### PR TITLE
feat: 平移 deck 與 monitor 進 paulsha-cortex

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # paulsha-cortex
 
-`paulsha-cortex` 是治理平面三件套：**persona 契約**、**coordinator 派工**、**control 檔案契約**。它把可移植的治理邏輯拆成獨立套件，讓主 repo 專注在產品行為，並把 Stage 3/4 的 guardrail 與 manager control plane 以零第三方 runtime 依賴方式出貨。
+`paulsha-cortex` 是治理平面三件套：**persona 契約**、**coordinator 派工**、**control 檔案契約**。它把可移植的治理邏輯拆成獨立套件，讓主 repo 專注在產品行為，並把 Stage 3/4 的 guardrail、manager control plane、deck / monitor 以最小 runtime 依賴方式出貨。
 
 ## 定位
 
@@ -32,7 +32,7 @@ python -m pip install .
 
 ## Usage
 
-1. 安裝 systemd `--user` 單元（冪等）：
+1. 安裝 systemd `--user` 單元（冪等；一次佈署 manager timer + monitor service）：
 
    ```bash
    cortex install service --instance demo --interval 300
@@ -42,10 +42,26 @@ python -m pip install .
 
    ```bash
    systemctl --user start demo-manager.timer
+   systemctl --user start demo-monitor.service
    systemctl --user status demo-manager.timer
+   systemctl --user status demo-monitor.service
    ```
 
-3. 使用 coordinator CLI：
+3. 使用 deck：
+
+   ```bash
+   cortex deck compile feature-oneshot --task "demo"
+   cortex deck verify --change sample-change
+   ```
+
+4. 監看 project 狀態：
+
+   ```bash
+   cortex monitor --once
+   cortex monitor
+   ```
+
+5. 使用 coordinator CLI：
 
    ```bash
    cortex jobs
@@ -54,6 +70,12 @@ python -m pip install .
 
 > 目前尚無獨立的 `cortex status` 服務查詢子命令；service 狀態以 `systemctl --user status` 為準。
 
+## Monitor registry merge
+
+- manual config：`~/.agents/config/paulsha/project-cortex.yaml`
+- shared hippo registry：`~/.agents/config/paulsha/project-hippo.yaml`
+- merge 規則：兩份 registry 以 realpath 去重，**manual entry 優先**保留 metadata；兩者皆缺時 `cortex monitor` 會直接報錯。
+
 ## Path 契約
 
 | 介面 | 預設路徑 | 環境變數 |
@@ -61,6 +83,9 @@ python -m pip install .
 | control root | `~/.agents/control` | `PSC_CONTROL_ROOT` |
 | coordinator root | `~/.agents/coordinator` | `PSC_COORDINATOR_ROOT` |
 | specs root | `~/.agents/specs` | `PSC_SPECS_ROOT` |
+| run root | `~/.agents/run` | `PSC_RUN_ROOT` |
+| config root | `~/.config/paulshaclaw` | `PSC_CONFIG_ROOT` |
+| project config root | `~/.agents/config/paulsha` | `PSC_PROJECT_CONFIG_ROOT` |
 | repo root | 目前工作目錄 | `PSC_REPO_ROOT` |
 | worktree root | `<repo>-worktrees` sibling | `PSC_WORKTREE_ROOT` |
 
@@ -71,9 +96,10 @@ python -m pip install .
 | 面向 | 現況 |
 | --- | --- |
 | persona enforcement | `shadow`；只觀測、不阻擋，翻牌到 enforce 另案處理 |
-| manager service install | `cortex install service` 已可 render / copy / enable，systemd 不可用時會 graceful 落檔 |
+| manager service install | `cortex install service` 已可一次 render / copy / enable manager timer + monitor service；systemd 不可用時會 graceful 落檔 |
 | coordinator runtime | `dispatch` / `jobs` / `stat` / `ready` / `fanout` / `complete` / `tick` 已平移 |
 | deck 驗證 | deck 與 persona 同包；未知 card 仍以 warning 呈現 |
+| monitor registry | `project-cortex.yaml` ⊍ `project-hippo.yaml`，realpath 去重且 manual 優先 |
 | 依賴模型 | 僅 `PyYAML`；runtime 不依賴 `paulsha-hippo` |
 
 ## 開發備註

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ python -m pip install .
 
    ```bash
    cortex deck compile feature-oneshot --task "demo"
-   cortex deck verify --change sample-change
+   cortex deck verify openspec-archive --task-slug demo-task --change sample-change
    ```
 
 4. 監看 project 狀態：

--- a/README.md
+++ b/README.md
@@ -8,13 +8,15 @@
 flowchart LR
     claw[產品 / 編排主 repo] --> cortex[paulsha-cortex\npersona + coordinator + control]
     claw --> hippo[paulsha-hippo\n共用基礎能力]
-    cortex -. 僅 deck lazy import .-> claw
+    cortex --> deck[deck + monitor]
     cortex -. 不依賴 .-> hippo
 ```
 
 - **主產品 repo**：產品與 orchestration 上游，之後可 pin 本 repo commit SHA 做遷移刀。
-- **paulsha-cortex**：治理平面抽離包，提供 `cortex` CLI、persona scope guardrail、manager runtime 與檔案契約。
-- **paulsha-hippo**：既有共用基礎能力；本 repo 已剪除 lifecycle / idle / paths 依賴，只保留 `persona.loader` 的 deck lazy import fail-open 契約。
+- **paulsha-cortex**：治理平面抽離包，提供 `cortex` CLI、persona scope guardrail、manager runtime、deck / monitor 與檔案契約。
+- **paulsha-hippo**：既有共用基礎能力；本 repo 已剪除 runtime 依賴，僅保留檔案契約層級的整合。
+
+persona 是 manager 與 guardrail 共同引用的**角色契約資料**（role profile + scope subject），不是執行中的 agent session；真正執行的是 AgentInstance，真正做安全判斷的是 guardrail / policy engine，它們只讀 persona 契約做 enforcement。
 
 ## Install
 
@@ -71,8 +73,8 @@ python -m pip install .
 | persona enforcement | `shadow`；只觀測、不阻擋，翻牌到 enforce 另案處理 |
 | manager service install | `cortex install service` 已可 render / copy / enable，systemd 不可用時會 graceful 落檔 |
 | coordinator runtime | `dispatch` / `jobs` / `stat` / `ready` / `fanout` / `complete` / `tick` 已平移 |
-| deck 驗證 | fail-open lazy import；deck 缺席時跳過 shadow 卡片比對 |
-| 依賴模型 | `dependencies = []`；runtime 不依賴 `paulsha-hippo` |
+| deck 驗證 | deck 與 persona 同包；未知 card 仍以 warning 呈現 |
+| 依賴模型 | 僅 `PyYAML`；runtime 不依賴 `paulsha-hippo` |
 
 ## 開發備註
 

--- a/paulsha_cortex/cli.py
+++ b/paulsha_cortex/cli.py
@@ -7,7 +7,7 @@ from importlib import resources
 from pathlib import Path
 from typing import Sequence
 
-_USAGE = "usage: cortex {install service|relay-hook|<coordinator subcommand>} <args...>\n"
+_USAGE = "usage: cortex {install service|relay-hook|deck|monitor|<coordinator subcommand>} <args...>\n"
 
 
 def _relay_hook_script_path() -> Path:
@@ -31,6 +31,14 @@ def main(argv: Sequence[str] | None = None) -> int:
             # packaged 腳本非可執行（wheel 留 0644）或 noexec 掛載時，
             # 改由 bash 讀取執行（只需讀權限）。
             os.execv("/usr/bin/env", ["env", "bash", script, *args[1:]])
+    if args[0] == "deck":
+        from paulsha_cortex.deck.cli import main as deck_main
+
+        return int(deck_main(args[1:]) or 0)
+    if args[0] == "monitor":
+        from paulsha_cortex.monitor.__main__ import main as monitor_main
+
+        return int(monitor_main(args[1:]) or 0)
 
     from paulsha_cortex.coordinator.cli import main as coordinator_main
 

--- a/paulsha_cortex/config/paths.py
+++ b/paulsha_cortex/config/paths.py
@@ -32,6 +32,22 @@ def specs_root() -> Path:
     return _resolve_root("PSC_SPECS_ROOT", agents_root() / "specs")
 
 
+def run_root() -> Path:
+    return _resolve_root("PSC_RUN_ROOT", agents_root() / "run")
+
+
+def config_root() -> Path:
+    return _resolve_root("PSC_CONFIG_ROOT", Path.home() / ".config" / "paulshaclaw")
+
+
+def config_path(*parts: str) -> Path:
+    return config_root().joinpath(*parts)
+
+
+def project_config_root() -> Path:
+    return _resolve_root("PSC_PROJECT_CONFIG_ROOT", agents_root() / "config" / "paulsha")
+
+
 def repo_root() -> Path:
     return _resolve_root("PSC_REPO_ROOT", Path.cwd())
 

--- a/paulsha_cortex/deck/cli.py
+++ b/paulsha_cortex/deck/cli.py
@@ -56,11 +56,14 @@ def main(argv: Sequence[str] | None = None) -> int:
 
         if args.command == "compile":
             combo = load_combo(DEFAULT_COMBOS_DIR / f"{args.combo}.yaml", cards)
+            effective_change = args.change
+            if effective_change is None and not args.emit and not args.out:
+                effective_change = "dry-run"
             result = compile_combo(
                 combo,
                 cards,
                 args.task,
-                change=args.change,
+                change=effective_change,
                 with_cards=tuple(args.with_cards),
                 only=tuple(args.only),
                 allow_external=args.allow_external,

--- a/paulsha_cortex/deck/cli.py
+++ b/paulsha_cortex/deck/cli.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import argparse
+import sys
+from typing import Sequence
+
+from .compile import DeckCompileError, compile_combo, emit, specs_dir
+from .schema import (
+    DEFAULT_CARDS_PATH,
+    DEFAULT_COMBOS_DIR,
+    DeckSchemaError,
+    load_cards,
+    load_combo,
+)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="psc deck")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    sub.add_parser("list", help="列出卡片與 combos")
+
+    compile_parser = sub.add_parser("compile", help="combo+task → slice specs（預設 dry-run）")
+    compile_parser.add_argument("combo")
+    compile_parser.add_argument("--task", required=True)
+    compile_parser.add_argument("--change")
+    compile_parser.add_argument("--with", dest="with_cards", action="append", default=[],
+                                metavar="CARD[:after=ID|:before=ID]")
+    compile_parser.add_argument("--only", nargs="+", default=[])
+    compile_parser.add_argument("--allow-external", action="store_true")
+    compile_parser.add_argument("--plan", dest="plan_ref")
+    out_group = compile_parser.add_mutually_exclusive_group()
+    out_group.add_argument("--out")
+    out_group.add_argument("--emit", action="store_true")
+    compile_parser.add_argument("--force", action="store_true")
+
+    verify_parser = sub.add_parser("verify", help="卡片 produces 存在性驗收")
+    verify_parser.add_argument("card_id")
+    verify_parser.add_argument("--task-slug", required=True)
+    verify_parser.add_argument("--change")
+    verify_parser.add_argument("--root", default=".")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _build_parser().parse_args(list(sys.argv[1:] if argv is None else argv))
+    try:
+        cards = load_cards(DEFAULT_CARDS_PATH)
+        if args.command == "list":
+            for combo_file in sorted(DEFAULT_COMBOS_DIR.glob("*.yaml")):
+                combo = load_combo(combo_file, cards)
+                print(f"{combo.id}\t(task_type={combo.task_type}, cards={len(combo.cards)})")
+            for card in cards.values():
+                print(f"  card: {card.id}\t[{card.type}/{card.card_class}]")
+            return 0
+
+        if args.command == "compile":
+            combo = load_combo(DEFAULT_COMBOS_DIR / f"{args.combo}.yaml", cards)
+            result = compile_combo(
+                combo,
+                cards,
+                args.task,
+                change=args.change,
+                with_cards=tuple(args.with_cards),
+                only=tuple(args.only),
+                allow_external=args.allow_external,
+                plan_ref=args.plan_ref,
+            )
+            print(f"task-slug: {result.task_slug}")
+            print("前置 checklist（interactive）：")
+            for line in result.checklist:
+                print(f"  - {line}")
+            if result.external:
+                print("external inputs（已放行）：")
+                for item in result.external:
+                    print(f"  - {item}")
+            if args.emit or args.out:
+                target = specs_dir() if args.emit else args.out
+                written = emit(result, target, force=args.force)
+                print(f"已寫入 {len(written)} 份 spec → {target}（dispatch: hold）")
+                print("翻 auto 前先跑：")
+                for command in result.verify_commands:
+                    print(f"  - {command}")
+            else:
+                for slice_doc in result.slices:
+                    print(f"--- {slice_doc.filename} ---")
+                    print(slice_doc.content)
+            return 0
+
+        if args.command == "verify":
+            from .verify import verify_card
+
+            card = cards.get(args.card_id)
+            if card is None:
+                print(f"未知卡片: {args.card_id}", file=sys.stderr)
+                return 2
+            result = verify_card(card, args.task_slug, root=args.root, change=args.change)
+            for missing in result.missing:
+                print(f"MISSING {missing}")
+            print("PASS" if result.ok else "FAIL")
+            return 0 if result.ok else 1
+
+        return 2
+    except (DeckSchemaError, DeckCompileError) as exc:
+        print(f"deck: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/paulsha_cortex/deck/cli.py
+++ b/paulsha_cortex/deck/cli.py
@@ -12,6 +12,7 @@ from .schema import (
     load_cards,
     load_combo,
 )
+from .verify import DeckVerifyError
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -104,7 +105,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             return 0 if result.ok else 1
 
         return 2
-    except (DeckSchemaError, DeckCompileError) as exc:
+    except (DeckSchemaError, DeckCompileError, DeckVerifyError) as exc:
         print(f"deck: {exc}", file=sys.stderr)
         return 1
 

--- a/paulsha_cortex/deck/compile.py
+++ b/paulsha_cortex/deck/compile.py
@@ -37,6 +37,12 @@ def _validate_change_name(change: str) -> str:
     return change
 
 
+def _validate_plan_ref(plan_ref: str) -> str:
+    if "\n" in plan_ref or "\r" in plan_ref:
+        raise DeckCompileError(f"plan 參照不可含換行: {plan_ref!r}")
+    return plan_ref
+
+
 def specs_dir() -> Path:
     """鏡射 manager_daemon.default_specs_dir 的 specs 路徑契約：
     PSC_MANAGER_SPECS_DIR → paths.specs_root()（吃 PSC_SPECS_ROOT/PSC_AGENTS_ROOT）。
@@ -217,6 +223,32 @@ def _uses_change(card: Card) -> bool:
     return any("<change>" in pattern for pattern in card.requires + card.produces)
 
 
+def _verify_command(card: Card, slug: str, change: str | None) -> str:
+    command = f"cortex deck verify {card.id} --task-slug {slug}"
+    if _uses_change(card):
+        command += f" --change {change}"
+    return command
+
+
+def _gate_verify_commands(
+    combo: Combo,
+    cards: Mapping[str, Card],
+    slug: str,
+    change: str | None,
+) -> list[str]:
+    commands: list[str] = []
+    for gate in combo.gate_spine:
+        card = cards.get(gate.after)
+        if card is None:
+            raise DeckCompileError(f"gate_spine.after 指向不存在卡片: {gate.after}")
+        if not card.produces:
+            raise DeckCompileError(f"{card.id}: gate_spine.after 卡片沒有 produces 可驗收")
+        for pattern in gate.exists:
+            _subst(pattern, slug, change)
+        commands.append(_verify_command(card, slug, change))
+    return commands
+
+
 def compile_combo(
     combo: Combo,
     cards: Mapping[str, Card],
@@ -246,10 +278,11 @@ def compile_combo(
         plan_ref = _default_plan_ref(combo.cards, cards, slug, change)
     if not plan_ref:
         raise DeckCompileError("無法決定 plan 參照：無 interactive produces，請給 --plan")
+    plan_ref = _validate_plan_ref(plan_ref)
 
     explicit_deps = {entry.ref: entry.depends_on for entry in entries}
     slices: list[SliceDoc] = []
-    verify_commands: list[str] = []
+    verify_commands = _gate_verify_commands(combo, cards, slug, change)
     previous_slice_id: str | None = None
 
     for slice_id, members in _group_slices(entries, cards, slug):
@@ -288,10 +321,7 @@ def compile_combo(
 
         for member in members:
             if member.produces:
-                command = f"cortex deck verify {member.id} --task-slug {slug}"
-                if _uses_change(member):
-                    command += f" --change {change}"
-                verify_commands.append(command)
+                verify_commands.append(_verify_command(member, slug, change))
         previous_slice_id = slice_id
 
     return CompileResult(

--- a/paulsha_cortex/deck/compile.py
+++ b/paulsha_cortex/deck/compile.py
@@ -18,6 +18,7 @@ class DeckCompileError(ValueError):
 
 _SLUG_RE = re.compile(r"[^a-z0-9]+")
 _SLICE_ID_RE = re.compile(r"[a-z0-9][a-z0-9-]*")
+_CHANGE_RE = re.compile(r"[a-z0-9][a-z0-9-]*")
 
 
 def slugify_task(task: str) -> str:
@@ -26,6 +27,14 @@ def slugify_task(task: str) -> str:
     if not slug:
         raise DeckCompileError(f"task 無法正規化為 slug: {task!r}")
     return slug
+
+
+def _validate_change_name(change: str) -> str:
+    if not _CHANGE_RE.fullmatch(change):
+        raise DeckCompileError(
+            f"change 名稱不合法（僅允許 [a-z0-9-]，且不可含路徑分隔）: {change!r}"
+        )
+    return change
 
 
 def specs_dir() -> Path:
@@ -220,6 +229,8 @@ def compile_combo(
     plan_ref: str | None = None,
 ) -> CompileResult:
     slug = slugify_task(task)
+    if change is not None:
+        change = _validate_change_name(change)
     entries = _resolve_hand(combo, cards, with_cards, only)
     external = _check_requires_coverage(entries, cards, allow_external)
 

--- a/paulsha_cortex/deck/compile.py
+++ b/paulsha_cortex/deck/compile.py
@@ -1,0 +1,378 @@
+from __future__ import annotations
+
+import os
+import re
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Mapping, Sequence
+
+from paulsha_cortex.config import paths
+
+from .schema import Card, Combo, ComboEntry
+
+
+class DeckCompileError(ValueError):
+    """compile 期錯誤（fail-closed：不產任何檔）。"""
+
+
+_SLUG_RE = re.compile(r"[^a-z0-9]+")
+_SLICE_ID_RE = re.compile(r"[a-z0-9][a-z0-9-]*")
+
+
+def slugify_task(task: str) -> str:
+    """將 task 正規化為 branch-safe slug。"""
+    slug = _SLUG_RE.sub("-", task.lower()).strip("-")[:60].strip("-")
+    if not slug:
+        raise DeckCompileError(f"task 無法正規化為 slug: {task!r}")
+    return slug
+
+
+def specs_dir() -> Path:
+    """鏡射 manager_daemon.default_specs_dir 的 specs 路徑契約：
+    PSC_MANAGER_SPECS_DIR → paths.specs_root()（吃 PSC_SPECS_ROOT/PSC_AGENTS_ROOT）。
+    facade 為允許依賴（零 import 鐵律僅涵蓋 lifecycle/memory）。"""
+    override = os.environ.get("PSC_MANAGER_SPECS_DIR")
+    if override:
+        return Path(override)
+    return paths.specs_root()
+
+
+@dataclass(frozen=True)
+class SliceDoc:
+    slice_id: str
+    filename: str
+    content: str
+
+
+@dataclass(frozen=True)
+class CompileResult:
+    task_slug: str
+    slices: tuple[SliceDoc, ...]
+    checklist: tuple[str, ...]
+    verify_commands: tuple[str, ...]
+    external: tuple[str, ...]
+
+
+def _subst(glob: str, slug: str, change: str | None) -> str:
+    out = glob.replace("<task-slug>", slug)
+    if "<change>" in out:
+        if not change:
+            raise DeckCompileError("卡片 glob 使用 <change>，需提供 --change <name>")
+        out = out.replace("<change>", change)
+    return out
+
+
+def parse_with_spec(spec: str) -> tuple[str, str | None, str | None]:
+    if ":" not in spec:
+        return spec, None, None
+    card_id, _, rest = spec.partition(":")
+    kind, _, anchor = rest.partition("=")
+    if not card_id or kind not in ("after", "before") or not anchor:
+        raise DeckCompileError(f"--with 定位格式錯誤: {spec!r}（card[:after=<id>|:before=<id>]）")
+    return card_id, kind, anchor
+
+
+def _resolve_hand(
+    combo: Combo,
+    cards: Mapping[str, Card],
+    with_cards: Sequence[str],
+    only: Sequence[str],
+) -> list[ComboEntry]:
+    if with_cards and only:
+        raise DeckCompileError("--with 與 --only 不可同時使用")
+    if only:
+        combo_refs = {entry.ref for entry in combo.cards}
+        unknown = [card_id for card_id in only if card_id not in combo_refs]
+        if unknown:
+            raise DeckCompileError(f"--only 指定了 combo 外卡片: {unknown}")
+        selected = set(only)
+        return [entry for entry in combo.cards if entry.ref in selected]
+
+    hand = list(combo.cards)
+    for spec in with_cards:
+        card_id, kind, anchor = parse_with_spec(spec)
+        if card_id not in cards:
+            raise DeckCompileError(f"--with 未知卡片: {card_id}")
+        refs = [entry.ref for entry in hand]
+        if card_id in refs:
+            raise DeckCompileError(f"--with 卡片已在骨幹中: {card_id}")
+
+        if kind is None:
+            pos: int | None = None
+            requires = cards[card_id].requires
+            if requires:
+                seen: list[str] = []
+                for index, entry in enumerate(hand):
+                    seen.extend(cards[entry.ref].produces)
+                    if all(any(_covered(require, produce) for produce in seen) for require in requires):
+                        pos = index + 1
+                        break
+            if pos is None:
+                raise DeckCompileError(
+                    f"--with {card_id} 無法推斷插入點，請明示 :after=<id> 或 :before=<id>"
+                )
+        else:
+            if anchor not in refs:
+                raise DeckCompileError(f"--with 定位錨點不在手牌中: {anchor}")
+            anchor_index = refs.index(anchor)
+            pos = anchor_index + (1 if kind == "after" else 0)
+        hand.insert(pos, ComboEntry(ref=card_id))
+    return hand
+
+
+def _prefix(glob: str) -> str:
+    return glob.split("*", 1)[0]
+
+
+def _covered(require: str, produce: str) -> bool:
+    """保守 pattern 覆蓋（spec §5.5）：字面前綴一致至首個 wildcard，互為前綴即視為覆蓋。"""
+    require_prefix = _prefix(require)
+    produce_prefix = _prefix(produce)
+    return require_prefix.startswith(produce_prefix) or produce_prefix.startswith(require_prefix)
+
+
+def _check_requires_coverage(
+    entries: Sequence[ComboEntry],
+    cards: Mapping[str, Card],
+    allow_external: bool,
+) -> tuple[str, ...]:
+    upstream: list[str] = []
+    external: list[str] = []
+    for entry in entries:
+        card = cards[entry.ref]
+        for require in card.requires:
+            if not any(_covered(require, produce) for produce in upstream):
+                external.append(f"{card.id}: {require}")
+        upstream.extend(card.produces)
+    if external and not allow_external:
+        raise DeckCompileError(
+            "requires 未被上游 produces 覆蓋（external input），"
+            "確認後以 --allow-external 放行：\n  " + "\n  ".join(external)
+        )
+    return tuple(external)
+
+
+def _group_slices(
+    entries: Sequence[ComboEntry],
+    cards: Mapping[str, Card],
+    slug: str,
+) -> list[tuple[str, list[Card]]]:
+    groups: list[tuple[str, list[Card]]] = []
+    seen_ids: set[str] = set()
+    for entry in entries:
+        card = cards[entry.ref]
+        if card.type != "headless":
+            continue
+        if card.slice_group:
+            slice_id = f"{slug}-{card.slice_group}"
+        else:
+            slice_id = f"{slug}-{card.id}"
+        if groups and groups[-1][0] == slice_id:
+            groups[-1][1].append(card)
+            continue
+        if slice_id in seen_ids:
+            raise DeckCompileError(f"combo 產生重複 slice_id: {slice_id}")
+        seen_ids.add(slice_id)
+        groups.append((slice_id, [card]))
+    return groups
+
+
+def _render_frontmatter(slice_id: str, plan_ref: str, deps: Sequence[str]) -> str:
+    lines = [
+        "---",
+        "dispatch: hold",
+        f"slice_id: {slice_id}",
+        f"plan: {plan_ref}",
+    ]
+    if deps:
+        lines.append("depends_on:")
+        lines.extend(f"  - {dep}" for dep in deps)
+    else:
+        lines.append("depends_on: []")
+    lines.append("---")
+    return "\n".join(lines)
+
+
+def _default_plan_ref(
+    entries: Sequence[ComboEntry],
+    cards: Mapping[str, Card],
+    slug: str,
+    change: str | None,
+) -> str | None:
+    for entry in reversed(entries):
+        card = cards[entry.ref]
+        if card.type == "interactive" and card.produces:
+            return _subst(card.produces[0], slug, change)
+    return None
+
+
+def _uses_change(card: Card) -> bool:
+    return any("<change>" in pattern for pattern in card.requires + card.produces)
+
+
+def compile_combo(
+    combo: Combo,
+    cards: Mapping[str, Card],
+    task: str,
+    *,
+    change: str | None = None,
+    with_cards: Sequence[str] = (),
+    only: Sequence[str] = (),
+    allow_external: bool = False,
+    plan_ref: str | None = None,
+) -> CompileResult:
+    slug = slugify_task(task)
+    entries = _resolve_hand(combo, cards, with_cards, only)
+    external = _check_requires_coverage(entries, cards, allow_external)
+
+    interactive_cards = [cards[entry.ref] for entry in entries if cards[entry.ref].type == "interactive"]
+    checklist = tuple(
+        f"[{card.id}] {card.skill_ref} → 產出: "
+        + ", ".join(_subst(glob, slug, change) for glob in card.produces)
+        for card in interactive_cards
+    )
+    if plan_ref is None:
+        plan_ref = _default_plan_ref(entries, cards, slug, change)
+    if plan_ref is None:
+        plan_ref = _default_plan_ref(combo.cards, cards, slug, change)
+    if not plan_ref:
+        raise DeckCompileError("無法決定 plan 參照：無 interactive produces，請給 --plan")
+
+    explicit_deps = {entry.ref: entry.depends_on for entry in entries}
+    slices: list[SliceDoc] = []
+    verify_commands: list[str] = []
+    previous_slice_id: str | None = None
+
+    for slice_id, members in _group_slices(entries, cards, slug):
+        deps: list[str] = []
+        for member in members:
+            for dep_ref in explicit_deps.get(member.id, ()):
+                dep_card = cards.get(dep_ref)
+                if dep_card is None or dep_card.type != "headless":
+                    continue
+                if dep_card.slice_group:
+                    deps.append(f"{slug}-{dep_card.slice_group}")
+                else:
+                    deps.append(f"{slug}-{dep_card.id}")
+        deps = sorted(set(dep for dep in deps if dep != slice_id))
+        if not deps and previous_slice_id:
+            deps = [previous_slice_id]
+
+        requires = [_subst(glob, slug, change) for member in members for glob in member.requires]
+        produces = [_subst(glob, slug, change) for member in members for glob in member.produces]
+        requires_block = "".join(f"\n- {item}" for item in requires) or "\n-（無）"
+        produces_block = "".join(f"\n- {item}" for item in produces) or "\n-（無，完成偵測=exit sentinel）"
+        content = (
+            _render_frontmatter(slice_id, plan_ref, deps)
+            + "\n"
+            + f"# {slice_id}\n\n"
+            + f"任務：{task}\n"
+            + f"combo：{combo.id}（cards: {', '.join(member.id for member in members)}）\n\n"
+            + f"requires（翻 auto 前人工確認）：{requires_block}\n\n"
+            + f"produces（deck verify 驗收）：{produces_block}\n"
+        )
+        if not _SLICE_ID_RE.fullmatch(slice_id):
+            raise DeckCompileError(
+                f"slice_id 非檔名/branch 安全（僅允許 [a-z0-9-]，card id 與 slice_group 不得含路徑分隔）: {slice_id!r}"
+            )
+        slices.append(SliceDoc(slice_id=slice_id, filename=f"{slice_id}.md", content=content))
+
+        for member in members:
+            if member.produces:
+                command = f"psc deck verify {member.id} --task-slug {slug}"
+                if _uses_change(member):
+                    command += f" --change {change}"
+                verify_commands.append(command)
+        previous_slice_id = slice_id
+
+    return CompileResult(
+        task_slug=slug,
+        slices=tuple(slices),
+        checklist=checklist,
+        verify_commands=tuple(dict.fromkeys(verify_commands)),
+        external=external,
+    )
+
+
+def emit(result: CompileResult, target_dir: str | Path, *, force: bool = False) -> list[Path]:
+    """將 compiled slices 寫成平鋪 specs 檔。"""
+    directory = Path(target_dir)
+    filenames = [slice_doc.filename for slice_doc in result.slices]
+    duplicates = sorted({name for name in filenames if filenames.count(name) > 1})
+    if duplicates:
+        raise DeckCompileError("emit 結果含重複檔名: " + ", ".join(duplicates))
+    try:
+        directory.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        raise DeckCompileError(f"emit 目標目錄不可用: {directory}: {exc}") from exc
+
+    conflicts = [filename for filename in filenames if (directory / filename).exists()]
+    if conflicts and not force:
+        raise DeckCompileError("emit 目標已存在同名 spec（--force 才覆蓋）：" + ", ".join(conflicts))
+
+    written: list[Path] = []
+    temp_paths: list[Path] = []
+    backups: list[tuple[Path, Path | None]] = []
+    try:
+        for slice_doc in result.slices:
+            final_path = directory / slice_doc.filename
+            if force:
+                fd, temp_name = tempfile.mkstemp(
+                    prefix=f"{slice_doc.filename}.",
+                    suffix=".tmp",
+                    dir=directory,
+                )
+                temp_path = Path(temp_name)
+                temp_paths.append(temp_path)
+                try:
+                    with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                        handle.write(slice_doc.content)
+                    os.chmod(temp_path, 0o644)  # mkstemp 預設 0o600，與非 force 路徑一致
+                    backup_path: Path | None = None
+                    if final_path.exists():
+                        backup_fd, backup_name = tempfile.mkstemp(
+                            prefix=f"{slice_doc.filename}.",
+                            suffix=".bak",
+                            dir=directory,
+                        )
+                        os.close(backup_fd)
+                        backup_path = Path(backup_name)
+                        backup_path.unlink(missing_ok=True)
+                        os.replace(final_path, backup_path)
+                    try:
+                        os.replace(temp_path, final_path)
+                    except OSError:
+                        if backup_path is not None and backup_path.exists():
+                            os.replace(backup_path, final_path)
+                        raise
+                    backups.append((final_path, backup_path))
+                finally:
+                    temp_path.unlink(missing_ok=True)
+            else:
+                fd = os.open(final_path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o644)
+                try:
+                    with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                        handle.write(slice_doc.content)
+                except Exception:
+                    final_path.unlink(missing_ok=True)
+                    raise
+            written.append(final_path)
+    except Exception as exc:  # 任何寫入期例外（含編碼錯誤）都必須走同一套回滾，否則 finally 會刪掉備份
+        if force:
+            for final_path, backup_path in reversed(backups):
+                if backup_path is not None and backup_path.exists():
+                    os.replace(backup_path, final_path)
+                else:
+                    final_path.unlink(missing_ok=True)
+        else:
+            for path in written:
+                path.unlink(missing_ok=True)
+        raise DeckCompileError(f"emit 寫入失敗: {exc}") from exc
+    finally:
+        for temp_path in temp_paths:
+            temp_path.unlink(missing_ok=True)
+        for _, backup_path in backups:
+            if backup_path is not None:
+                backup_path.unlink(missing_ok=True)
+    return written

--- a/paulsha_cortex/deck/compile.py
+++ b/paulsha_cortex/deck/compile.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import os
 import re
 import tempfile
@@ -199,7 +200,7 @@ def _render_frontmatter(slice_id: str, plan_ref: str, deps: Sequence[str]) -> st
         "---",
         "dispatch: hold",
         f"slice_id: {slice_id}",
-        f"plan: {plan_ref}",
+        f"plan: {json.dumps(plan_ref, ensure_ascii=False)}",
         f"depends_on: {depends_on}",
     ]
     lines.append("---")
@@ -235,9 +236,12 @@ def _gate_verify_commands(
     cards: Mapping[str, Card],
     slug: str,
     change: str | None,
+    selected_refs: frozenset[str],
 ) -> list[str]:
     commands: list[str] = []
     for gate in combo.gate_spine:
+        if gate.after not in selected_refs:
+            continue
         card = cards.get(gate.after)
         if card is None:
             raise DeckCompileError(f"gate_spine.after 指向不存在卡片: {gate.after}")
@@ -281,8 +285,9 @@ def compile_combo(
     plan_ref = _validate_plan_ref(plan_ref)
 
     explicit_deps = {entry.ref: entry.depends_on for entry in entries}
+    selected_refs = frozenset(entry.ref for entry in entries)
     slices: list[SliceDoc] = []
-    verify_commands = _gate_verify_commands(combo, cards, slug, change)
+    verify_commands = _gate_verify_commands(combo, cards, slug, change, selected_refs)
     previous_slice_id: str | None = None
 
     for slice_id, members in _group_slices(entries, cards, slug):

--- a/paulsha_cortex/deck/compile.py
+++ b/paulsha_cortex/deck/compile.py
@@ -179,17 +179,14 @@ def _group_slices(
 
 
 def _render_frontmatter(slice_id: str, plan_ref: str, deps: Sequence[str]) -> str:
+    depends_on = "[" + ", ".join(deps) + "]" if deps else "[]"
     lines = [
         "---",
         "dispatch: hold",
         f"slice_id: {slice_id}",
         f"plan: {plan_ref}",
+        f"depends_on: {depends_on}",
     ]
-    if deps:
-        lines.append("depends_on:")
-        lines.extend(f"  - {dep}" for dep in deps)
-    else:
-        lines.append("depends_on: []")
     lines.append("---")
     return "\n".join(lines)
 
@@ -280,7 +277,7 @@ def compile_combo(
 
         for member in members:
             if member.produces:
-                command = f"psc deck verify {member.id} --task-slug {slug}"
+                command = f"cortex deck verify {member.id} --task-slug {slug}"
                 if _uses_change(member):
                     command += f" --change {change}"
                 verify_commands.append(command)

--- a/paulsha_cortex/deck/data/cards.yaml
+++ b/paulsha_cortex/deck/data/cards.yaml
@@ -1,0 +1,129 @@
+# 轉錄真相源：custom-skills/feature-delivery-pipeline SKILL.md（11 phases）
+# produces 僅寫可機械驗證 glob；佔位符白名單：<task-slug>、<change>
+version: 0
+cards:
+  - id: brainstorming
+    kind: skill
+    type: interactive
+    class: core
+    skill_ref: "superpowers:brainstorming"
+    requires: []
+    produces: ["docs/superpowers/specs/*<task-slug>*-design.md"]
+    persona_binding: planner
+
+  - id: openspec-propose
+    kind: skill
+    type: interactive
+    class: core
+    skill_ref: "openspec-propose"
+    requires: ["docs/superpowers/specs/*<task-slug>*-design.md"]
+    produces:
+      - "openspec/changes/<change>/proposal.md"
+      - "openspec/changes/<change>/tasks.md"
+    persona_binding: planner
+
+  - id: writing-plans
+    kind: skill
+    type: interactive
+    class: core
+    skill_ref: "superpowers:writing-plans"
+    requires: ["openspec/changes/<change>/proposal.md"]
+    produces: ["docs/superpowers/plans/*<task-slug>*.md"]
+    persona_binding: planner
+
+  - id: worktree-isolation
+    kind: skill
+    type: headless
+    class: core
+    skill_ref: "superpowers:using-git-worktrees"
+    slice_group: build
+    requires: ["docs/superpowers/plans/*<task-slug>*.md"]
+    produces: []          # worktree 由 coordinator 派工時自建（feature/<slice_id>）
+    persona_binding: builder
+
+  - id: tdd-red
+    kind: skill
+    type: headless
+    class: core
+    skill_ref: "superpowers:test-driven-development"
+    slice_group: build
+    requires: []
+    produces: []          # RED 證據在 build session log／commits，Phase A 不機驗
+    persona_binding: builder
+
+  - id: subagent-build
+    kind: skill
+    type: headless
+    class: core
+    skill_ref: "superpowers:subagent-driven-development"
+    slice_group: build
+    requires: []
+    produces: []          # 完成偵測 = manager exit sentinel + branch commits
+    persona_binding: builder
+
+  - id: code-review
+    kind: skill
+    type: headless
+    class: core
+    skill_ref: "superpowers:requesting-code-review"
+    requires: []
+    produces: ["reports/review/*<task-slug>*.md"]
+    persona_binding: reviewer
+
+  - id: verification
+    kind: skill
+    type: headless
+    class: core
+    skill_ref: "superpowers:verification-before-completion"
+    requires: []
+    produces: ["reports/verify/*<task-slug>*.md"]
+    persona_binding: reviewer
+
+  - id: openspec-archive
+    kind: skill
+    type: headless
+    class: core
+    skill_ref: "openspec-archive-change"
+    slice_group: ship
+    requires: ["openspec/changes/<change>/tasks.md"]
+    produces: ["openspec/changes/archive/*<change>*"]
+    persona_binding: manager
+
+  - id: policy-commit
+    kind: skill
+    type: headless
+    class: core
+    skill_ref: "conventional-commit"
+    slice_group: ship
+    requires: []
+    produces: []          # 證據 = conventional commit 本身（不機驗檔案）
+    persona_binding: manager
+
+  - id: adversarial-review
+    kind: skill
+    type: headless
+    class: core
+    skill_ref: "codex:adversarial-review"
+    requires: ["reports/review/*<task-slug>*.md"]
+    produces: ["reports/review/*<task-slug>*-adversarial.md"]
+    persona_binding: reviewer
+
+  - id: receiving-code-review
+    kind: skill
+    type: headless
+    class: core
+    skill_ref: "superpowers:receiving-code-review"
+    requires: ["reports/review/*<task-slug>*.md"]
+    produces: []          # findings 處理證據 = fix commits + re-review，Phase A 不機驗
+    persona_binding: builder
+
+  # 註：hw-evidence.md 為 deck 投影新造的 artifact 契約（SKILL 硬體證據規則的
+  # 可機驗載體）；內容正確性由 mcu-coding-skill 執行時自律，deck 只驗存在。
+  - id: mcu-hw-evidence
+    kind: skill
+    type: interactive
+    class: niche
+    skill_ref: "mcu-coding-skill"
+    requires: []
+    produces: ["docs/superpowers/specs/*<task-slug>*-hw-evidence.md"]
+    persona_binding: planner

--- a/paulsha_cortex/deck/data/combos/feature-oneshot.yaml
+++ b/paulsha_cortex/deck/data/combos/feature-oneshot.yaml
@@ -1,0 +1,26 @@
+combo:
+  id: feature-oneshot
+  task_type: feature
+  cards:
+    - ref: brainstorming
+    - ref: openspec-propose
+    - ref: writing-plans
+    - ref: worktree-isolation
+    - ref: tdd-red
+    - ref: subagent-build
+    - ref: code-review
+    - ref: verification
+    - ref: openspec-archive
+    - ref: policy-commit
+    - ref: adversarial-review
+  gate_spine:
+    - after: writing-plans
+      exists: ["docs/superpowers/plans/*<task-slug>*.md"]
+    - after: code-review
+      exists: ["reports/review/*<task-slug>*.md"]
+    - after: verification
+      exists: ["reports/verify/*<task-slug>*.md"]
+    - after: openspec-archive
+      exists: ["openspec/changes/archive/*<change>*"]
+    - after: adversarial-review
+      exists: ["reports/review/*<task-slug>*-adversarial.md"]

--- a/paulsha_cortex/deck/data/combos/mcu-feature.yaml
+++ b/paulsha_cortex/deck/data/combos/mcu-feature.yaml
@@ -1,0 +1,15 @@
+combo:
+  id: mcu-feature
+  task_type: mcu-feature
+  cards:
+    - ref: mcu-hw-evidence
+    - ref: writing-plans
+    - ref: worktree-isolation
+    - ref: tdd-red
+    - ref: subagent-build
+    - ref: code-review
+    - ref: receiving-code-review
+    - ref: verification
+  gate_spine:
+    - after: mcu-hw-evidence
+      exists: ["docs/superpowers/specs/*<task-slug>*-hw-evidence.md"]

--- a/paulsha_cortex/deck/schema.py
+++ b/paulsha_cortex/deck/schema.py
@@ -1,0 +1,280 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Mapping
+
+import yaml
+
+SCHEMA_VERSION = 0
+# runtime 契約真相源：coordinator/autonomy.py::parse_spec_frontmatter（勿發明多餘欄位）
+EMITTED_FRONTMATTER_FIELDS = ("dispatch", "slice_id", "plan", "depends_on")
+CARD_KINDS = ("skill",)
+CARD_TYPES = ("interactive", "headless")
+CARD_CLASSES = ("core", "niche", "emergency")
+ALLOWED_PLACEHOLDERS = frozenset({"task-slug", "change"})
+_CARDS_FILE_KEYS = frozenset({"version", "cards"})
+_CARD_KEYS = frozenset(
+    {
+        "id",
+        "kind",
+        "type",
+        "class",
+        "skill_ref",
+        "requires",
+        "produces",
+        "persona_binding",
+        "provider_binding",
+        "slice_group",
+    }
+)
+_COMBO_FILE_KEYS = frozenset({"combo"})
+_COMBO_KEYS = frozenset({"id", "task_type", "cards", "gate_spine"})
+_COMBO_ENTRY_KEYS = frozenset({"ref", "depends_on"})
+_GATE_CHECK_KEYS = frozenset({"after", "exists"})
+_PLACEHOLDER_RE = re.compile(r"<([^<>]+)>")
+_DRIVE_RE = re.compile(r"^[A-Za-z]:")
+
+DEFAULT_CARDS_PATH = Path(__file__).with_name("data") / "cards.yaml"
+DEFAULT_COMBOS_DIR = Path(__file__).with_name("data") / "combos"
+
+
+class DeckSchemaError(ValueError):
+    """deck 資料載入／驗證錯誤（fail-closed：任一錯即整批拒載）。"""
+
+
+@dataclass(frozen=True)
+class Card:
+    id: str
+    kind: str
+    type: str
+    card_class: str  # YAML key: class
+    skill_ref: str
+    requires: tuple[str, ...] = ()
+    produces: tuple[str, ...] = ()
+    persona_binding: str | None = None
+    provider_binding: str | None = None
+    slice_group: str | None = None
+
+
+@dataclass(frozen=True)
+class ComboEntry:
+    ref: str
+    depends_on: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class GateCheck:
+    after: str
+    exists: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class Combo:
+    id: str
+    task_type: str
+    cards: tuple[ComboEntry, ...]
+    gate_spine: tuple[GateCheck, ...] = ()
+
+
+def _check_placeholders(card_id: str, globs: tuple[str, ...], errors: list[str]) -> None:
+    for g in globs:
+        for name in _PLACEHOLDER_RE.findall(g):
+            if name not in ALLOWED_PLACEHOLDERS:
+                errors.append(f"{card_id}: 非法佔位符 <{name}>（白名單: {sorted(ALLOWED_PLACEHOLDERS)}）")
+        # fail-closed：移除可解析的 token 後，任何殘餘角括號（<>、<<x>>、未閉合 <）一律拒絕
+        residue = _PLACEHOLDER_RE.sub("", g)
+        if "<" in residue or ">" in residue:
+            errors.append(f"{card_id}: glob 含空白/巢狀/未閉合角括號: {g!r}")
+        # fail-closed：glob 一律相對於 verify --root，拒絕絕對/rooted 路徑與 .. 逃逸
+        if g.startswith(("/", "~")) or _DRIVE_RE.match(g):
+            errors.append(f"{card_id}: glob 不得為絕對/rooted 路徑: {g!r}")
+        elif ".." in g.split("/"):
+            errors.append(f"{card_id}: glob 不得含 .. 路徑段: {g!r}")
+
+
+def _str_tuple(value, card_id: str, field_name: str, errors: list[str]) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if not isinstance(value, list) or any(not isinstance(x, str) for x in value):
+        errors.append(f"{card_id}: {field_name} 必須是字串清單")
+        return ()
+    return tuple(value)
+
+
+def _check_unknown_keys(label: str, record: Mapping, allowed: frozenset[str], errors: list[str]) -> None:
+    unknown = sorted(key for key in record if key not in allowed)
+    if unknown:
+        errors.append(f"{label}: 未知欄位 {unknown}")
+
+
+def _optional_str(value, card_id: str, field_name: str, errors: list[str]) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value:
+        errors.append(f"{card_id}: {field_name} 必須為非空字串")
+        return None
+    return value
+
+
+def load_cards(path: str | Path) -> dict[str, Card]:
+    source = Path(path)
+    try:
+        raw = yaml.safe_load(source.read_text(encoding="utf-8"))
+    except (OSError, yaml.YAMLError) as exc:
+        raise DeckSchemaError(f"cards 載入失敗: {source}: {exc}") from exc
+    if not isinstance(raw, Mapping) or not isinstance(raw.get("cards"), list):
+        raise DeckSchemaError(f"cards 格式錯誤（缺 cards 清單）: {source}")
+
+    errors: list[str] = []
+    _check_unknown_keys("cards", raw, _CARDS_FILE_KEYS, errors)
+    if raw.get("version") != SCHEMA_VERSION:
+        errors.append(f"cards: version 不符，預期 {SCHEMA_VERSION}，實際 {raw.get('version')!r}")
+    cards: dict[str, Card] = {}
+    seen_ids: set[str] = set()
+    for rec in raw["cards"]:
+        if not isinstance(rec, Mapping) or not isinstance(rec.get("id"), str) or not rec["id"]:
+            errors.append("卡片缺 id 或格式錯誤")
+            continue
+        cid = rec["id"]
+        # 重複偵測獨立於卡片建構成敗（用 seen_ids 而非 cards），避免前一張壞卡遮蔽後續 duplicate
+        if cid in seen_ids:
+            errors.append(f"{cid}: 重複的 card id")
+            continue
+        seen_ids.add(cid)
+        # 逐卡獨立錯誤域：前一張壞卡不得污染本卡的建構判斷
+        rec_errors: list[str] = []
+        _check_unknown_keys(cid, rec, _CARD_KEYS, rec_errors)
+        kind = rec.get("kind")
+        ctype = rec.get("type")
+        cclass = rec.get("class")
+        skill_ref = rec.get("skill_ref")
+        if kind not in CARD_KINDS:
+            rec_errors.append(f"{cid}: kind 非法值 {kind!r}")
+        if ctype not in CARD_TYPES:
+            rec_errors.append(f"{cid}: type 非法值 {ctype!r}")
+        if cclass not in CARD_CLASSES:
+            rec_errors.append(f"{cid}: class 非法值 {cclass!r}")
+        if not isinstance(skill_ref, str) or not skill_ref:
+            rec_errors.append(f"{cid}: skill_ref 必須為非空字串")
+        requires = _str_tuple(rec.get("requires"), cid, "requires", rec_errors)
+        produces = _str_tuple(rec.get("produces"), cid, "produces", rec_errors)
+        _check_placeholders(cid, requires + produces, rec_errors)
+        persona_binding = _optional_str(rec.get("persona_binding"), cid, "persona_binding", rec_errors)
+        provider_binding = _optional_str(rec.get("provider_binding"), cid, "provider_binding", rec_errors)
+        slice_group = rec.get("slice_group")
+        if slice_group is not None and (not isinstance(slice_group, str) or not slice_group):
+            rec_errors.append(f"{cid}: slice_group 必須為非空字串")
+        if rec_errors:
+            errors.extend(rec_errors)
+            continue
+        cards[cid] = Card(
+            id=cid,
+            kind=kind,
+            type=ctype,
+            card_class=cclass,
+            skill_ref=skill_ref,
+            requires=requires,
+            produces=produces,
+            persona_binding=persona_binding,
+            provider_binding=provider_binding,
+            slice_group=slice_group,
+        )
+    if errors:
+        raise DeckSchemaError(f"cards 驗證失敗: {source}: " + "; ".join(errors))
+    return cards
+
+
+def _detect_combo_cycles(entries: tuple[ComboEntry, ...]) -> None:
+    graph = {e.ref: list(e.depends_on) for e in entries}
+    WHITE, GRAY, BLACK = 0, 1, 2
+    color = {ref: WHITE for ref in graph}
+    stack: list[str] = []
+
+    def visit(node: str) -> None:
+        color[node] = GRAY
+        stack.append(node)
+        for dep in graph.get(node, []):
+            if dep not in graph:
+                continue
+            if color[dep] == GRAY:
+                cycle = stack[stack.index(dep):] + [dep]
+                raise DeckSchemaError(f"combo depends_on 循環相依: {' -> '.join(cycle)}")
+            if color[dep] == WHITE:
+                visit(dep)
+        stack.pop()
+        color[node] = BLACK
+
+    for ref in graph:
+        if color[ref] == WHITE:
+            visit(ref)
+
+
+def load_combo(path: str | Path, cards: Mapping[str, Card]) -> Combo:
+    source = Path(path)
+    try:
+        raw = yaml.safe_load(source.read_text(encoding="utf-8"))
+    except (OSError, yaml.YAMLError) as exc:
+        raise DeckSchemaError(f"combo 載入失敗: {source}: {exc}") from exc
+    if not isinstance(raw, Mapping) or not isinstance(raw.get("combo"), Mapping):
+        raise DeckSchemaError(f"combo 格式錯誤（缺 combo 區塊）: {source}")
+    errors: list[str] = []
+    _check_unknown_keys("combo", raw, _COMBO_FILE_KEYS, errors)
+    rec = raw["combo"]
+    _check_unknown_keys("combo", rec, _COMBO_KEYS, errors)
+
+    combo_id = rec.get("id")
+    task_type = rec.get("task_type")
+    if not isinstance(combo_id, str) or not combo_id:
+        errors.append("combo 缺 id")
+    if not isinstance(task_type, str) or not task_type:
+        errors.append("combo 缺 task_type")
+
+    entries: list[ComboEntry] = []
+    raw_cards = rec.get("cards")
+    if not isinstance(raw_cards, list) or not raw_cards:
+        errors.append("combo.cards 必須為非空清單")
+        raw_cards = []
+    seen: set[str] = set()
+    for item in raw_cards:
+        if not isinstance(item, Mapping) or not isinstance(item.get("ref"), str):
+            errors.append("combo.cards 項目缺 ref")
+            continue
+        ref = item["ref"]
+        _check_unknown_keys(ref, item, _COMBO_ENTRY_KEYS, errors)
+        if ref not in cards:
+            errors.append(f"未知卡片引用: {ref}")
+        if ref in seen:
+            errors.append(f"combo 內重複卡片: {ref}")
+        seen.add(ref)
+        deps = _str_tuple(item.get("depends_on"), ref, "depends_on", errors)
+        for d in deps:
+            if d not in {c.get("ref") for c in raw_cards if isinstance(c, Mapping)}:
+                errors.append(f"{ref}: depends_on 指向 combo 外卡片 {d}")
+        entries.append(ComboEntry(ref=ref, depends_on=deps))
+
+    spine: list[GateCheck] = []
+    raw_spine = rec.get("gate_spine")
+    if raw_spine is not None and not isinstance(raw_spine, list):
+        errors.append(f"combo: gate_spine 必須是清單，實際 {type(raw_spine).__name__}")
+        raw_spine = []
+    for g in raw_spine or []:
+        if not isinstance(g, Mapping) or not isinstance(g.get("after"), str):
+            errors.append("gate_spine 項目缺 after")
+            continue
+        _check_unknown_keys(g["after"], g, _GATE_CHECK_KEYS, errors)
+        if g["after"] not in seen:
+            errors.append(f"gate_spine.after 指向不存在卡片: {g['after']}")
+        exists = _str_tuple(g.get("exists"), g["after"], "gate_spine.exists", errors)
+        _check_placeholders(g["after"], exists, errors)
+        if not exists:
+            errors.append(f"{g['after']}: gate_spine.exists 不得為空")
+        spine.append(GateCheck(after=g["after"], exists=exists))
+
+    if errors:
+        raise DeckSchemaError(f"combo 驗證失敗: {source}: " + "; ".join(errors))
+
+    combo = Combo(id=combo_id, task_type=task_type, cards=tuple(entries), gate_spine=tuple(spine))
+    _detect_combo_cycles(combo.cards)
+    return combo

--- a/paulsha_cortex/deck/verify.py
+++ b/paulsha_cortex/deck/verify.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from .schema import Card
+
+
+class DeckVerifyError(ValueError):
+    """verify 參數/樣式錯誤（非 artifact 缺失）：佔位符未解析、絕對路徑、路徑逃逸。"""
+
+
+@dataclass(frozen=True)
+class VerifyResult:
+    card_id: str
+    ok: bool
+    missing: tuple[str, ...]
+    matched: tuple[str, ...]
+
+
+def _subst(glob: str, task_slug: str, change: str | None) -> str:
+    out = glob.replace("<task-slug>", task_slug)
+    if change:
+        out = out.replace("<change>", change)
+    return out
+
+
+def _guard_pattern(card_id: str, pattern: str) -> None:
+    """fail-closed 樣式守門（schema 載入已擋一輪，此處為縱深防禦——
+    Card 可被直接建構，不必然經過 load_cards）。"""
+    if "<" in pattern or ">" in pattern:
+        raise DeckVerifyError(
+            f"{card_id}: 佔位符未解析（卡片用到 <change> 需提供 change 參數）: {pattern!r}")
+    if pattern.startswith(("/", "~")) or Path(pattern).is_absolute():
+        raise DeckVerifyError(f"{card_id}: produces glob 不得為絕對路徑: {pattern!r}")
+    if ".." in pattern.split("/"):
+        raise DeckVerifyError(f"{card_id}: produces glob 不得含 .. 路徑段（root 逃逸）: {pattern!r}")
+
+
+def verify_card(
+    card: Card,
+    task_slug: str,
+    *,
+    root: str | Path = ".",
+    change: str | None = None,
+) -> VerifyResult:
+    """produces glob 存在性驗收（Phase A：只驗存在，不驗內容）。"""
+    base = Path(root)
+    missing: list[str] = []
+    matched: list[str] = []
+    for raw in card.produces:
+        pattern = _subst(raw, task_slug, change)
+        _guard_pattern(card.id, pattern)
+        try:
+            hit = next(iter(base.glob(pattern)), None)  # 只需「至少一個命中」，短路避免寬 pattern 全列舉
+        except (NotImplementedError, ValueError) as exc:
+            raise DeckVerifyError(f"{card.id}: 非法 glob 樣式 {pattern!r}: {exc}") from exc
+        if hit is not None:
+            matched.append(pattern)
+        else:
+            missing.append(raw if pattern == raw else pattern)
+    return VerifyResult(
+        card_id=card.id,
+        ok=not missing,
+        missing=tuple(missing),
+        matched=tuple(matched),
+    )

--- a/paulsha_cortex/deck/verify.py
+++ b/paulsha_cortex/deck/verify.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -8,6 +9,17 @@ from .schema import Card
 
 class DeckVerifyError(ValueError):
     """verify 參數/樣式錯誤（非 artifact 缺失）：佔位符未解析、絕對路徑、路徑逃逸。"""
+
+
+_NAME_RE = re.compile(r"[a-z0-9][a-z0-9-]*")
+
+
+def _validate_name(label: str, value: str) -> str:
+    if not _NAME_RE.fullmatch(value):
+        raise DeckVerifyError(
+            f"{label} 名稱不合法（僅允許 [a-z0-9-]，不可含 glob/path metacharacters）: {value!r}"
+        )
+    return value
 
 
 @dataclass(frozen=True)
@@ -45,6 +57,9 @@ def verify_card(
     change: str | None = None,
 ) -> VerifyResult:
     """produces glob 存在性驗收（Phase A：只驗存在，不驗內容）。"""
+    task_slug = _validate_name("task_slug", task_slug)
+    if change is not None:
+        change = _validate_name("change", change)
     base = Path(root)
     missing: list[str] = []
     matched: list[str] = []

--- a/paulsha_cortex/deploy/installer.py
+++ b/paulsha_cortex/deploy/installer.py
@@ -81,7 +81,14 @@ def install_service(instance: str, interval: int, repo_root: Path) -> int:
     for name, content in render_units(instance, interval).items():
         (unit_dir / name).write_text(content)
     env_file = runtime_dir / f"{instance}-manager.env"
-    _write_managed_env(env_file, {"PY": sys.executable, "PSC_REPO_ROOT": str(repo_root)})
+    _write_managed_env(
+        env_file,
+        {
+            "PY": sys.executable,
+            "PSC_REPO_ROOT": str(repo_root),
+            "PSC_RUN_ROOT": str(home / ".agents" / "run" / instance),
+        },
+    )
     if not _systemctl_available():
         print(f"systemd 不可用：單元已落檔 {unit_dir}，請改用 service-manager.sh 前景模式")
         return 0

--- a/paulsha_cortex/deploy/installer.py
+++ b/paulsha_cortex/deploy/installer.py
@@ -24,7 +24,13 @@ def render_units(instance: str, interval: int) -> dict[str, str]:
     service = service.replace("__SERVICE_SCRIPT__", str(_service_script_path()))
     timer = _template("manager.timer.tmpl").replace("__INSTANCE__", instance)
     timer = re.sub(r"^OnUnitActiveSec=.*$", f"OnUnitActiveSec={interval}", timer, flags=re.M)
-    return {f"{instance}-manager.service": service, f"{instance}-manager.timer": timer}
+    monitor = _template("monitor.service.tmpl").replace("__INSTANCE__", instance)
+    monitor = monitor.replace("__PY__", sys.executable)
+    return {
+        f"{instance}-manager.service": service,
+        f"{instance}-manager.timer": timer,
+        f"{instance}-monitor.service": monitor,
+    }
 
 
 def _systemctl_available() -> bool:
@@ -80,8 +86,9 @@ def install_service(instance: str, interval: int, repo_root: Path) -> int:
         print(f"systemd 不可用：單元已落檔 {unit_dir}，請改用 service-manager.sh 前景模式")
         return 0
     subprocess.run(["systemctl", "--user", "daemon-reload"], check=True)
+    subprocess.run(["systemctl", "--user", "enable", f"{instance}-monitor.service"], check=True)
     subprocess.run(["systemctl", "--user", "enable", f"{instance}-manager.timer"], check=True)
-    print(f"installed: {instance}-manager.{{service,timer}}")
+    print(f"installed: {instance}-manager.{{service,timer}} + {instance}-monitor.service")
     return 0
 
 

--- a/paulsha_cortex/deploy/installer.py
+++ b/paulsha_cortex/deploy/installer.py
@@ -62,6 +62,12 @@ def _validate_instance(instance: str) -> str:
     return instance
 
 
+def _validate_interval(interval: int) -> int:
+    if interval <= 0:
+        raise ValueError(f"interval 必須為正整數，實際 {interval!r}")
+    return interval
+
+
 def _write_managed_env(env_file: Path, managed: dict[str, str]) -> None:
     """更新 managed keys（PY / PSC_REPO_ROOT），就地保留其餘 operator 手動行與註解。
 
@@ -119,7 +125,8 @@ def main(argv: Sequence[str] | None = None) -> int:
     args = parser.parse_args(argv)
     try:
         instance = _validate_instance(args.instance)
+        interval = _validate_interval(args.interval)
         repo_root = _resolve_git_repo_root(Path(args.repo_root))
     except ValueError as exc:
         parser.error(str(exc))
-    return install_service(instance, args.interval, repo_root)
+    return install_service(instance, interval, repo_root)

--- a/paulsha_cortex/deploy/installer.py
+++ b/paulsha_cortex/deploy/installer.py
@@ -10,6 +10,8 @@ from importlib import resources
 from pathlib import Path
 from typing import Sequence
 
+_INSTANCE_RE = re.compile(r"[a-z0-9][a-z0-9-]*")
+
 
 def _template(name: str) -> str:
     return (resources.files("paulsha_cortex.deploy") / "templates" / name).read_text()
@@ -50,6 +52,14 @@ def _resolve_git_repo_root(repo_root: Path) -> Path:
     if probe.returncode != 0:
         raise ValueError(f"{candidate} 不是 git repo")
     return Path(probe.stdout.strip()).resolve()
+
+
+def _validate_instance(instance: str) -> str:
+    if not _INSTANCE_RE.fullmatch(instance):
+        raise ValueError(
+            f"instance 名稱不合法（僅允許 [a-z0-9-]，不可含路徑分隔）: {instance!r}"
+        )
+    return instance
 
 
 def _write_managed_env(env_file: Path, managed: dict[str, str]) -> None:
@@ -108,7 +118,8 @@ def main(argv: Sequence[str] | None = None) -> int:
     svc.add_argument("--repo-root", default=str(Path.cwd()))
     args = parser.parse_args(argv)
     try:
+        instance = _validate_instance(args.instance)
         repo_root = _resolve_git_repo_root(Path(args.repo_root))
     except ValueError as exc:
         parser.error(str(exc))
-    return install_service(args.instance, args.interval, repo_root)
+    return install_service(instance, args.interval, repo_root)

--- a/paulsha_cortex/deploy/templates/monitor.service.tmpl
+++ b/paulsha_cortex/deploy/templates/monitor.service.tmpl
@@ -1,0 +1,17 @@
+[Unit]
+Description=__INSTANCE__ project monitor service (paulsha-cortex)
+After=network-online.target
+Wants=network-online.target
+StartLimitIntervalSec=300
+StartLimitBurst=5
+
+[Service]
+EnvironmentFile=-%h/.agents/core/runtime/__INSTANCE__.env
+EnvironmentFile=-%h/.agents/core/runtime/__INSTANCE__-manager.env
+ExecStart=__PY__ -m paulsha_cortex.monitor
+KillMode=control-group
+Restart=on-failure
+RestartSec=10
+
+[Install]
+WantedBy=default.target

--- a/paulsha_cortex/monitor/__init__.py
+++ b/paulsha_cortex/monitor/__init__.py
@@ -1,0 +1,1 @@
+"""Stage 9 Project Monitor — autonomous project state source for Stage 1/3."""

--- a/paulsha_cortex/monitor/__main__.py
+++ b/paulsha_cortex/monitor/__main__.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import signal
 import sys
 from dataclasses import asdict
 from pathlib import Path
@@ -55,8 +56,11 @@ def main(argv: list[str] | None = None) -> int:
         return 0
 
     service: ProjectMonitorService | None = None
+    previous_sigterm = None
     try:
         service = ProjectMonitorService(config=config)
+        previous_sigterm = signal.getsignal(signal.SIGTERM)
+        signal.signal(signal.SIGTERM, lambda _signum, _frame: service.stop())
         service.run_forever()
     except KeyboardInterrupt:
         if service is not None:
@@ -65,6 +69,9 @@ def main(argv: list[str] | None = None) -> int:
     except (FileNotFoundError, ValueError, OSError, RuntimeError) as error:
         print(f"錯誤: {error}", file=sys.stderr)
         return 1
+    finally:
+        if previous_sigterm is not None:
+            signal.signal(signal.SIGTERM, previous_sigterm)
 
     return 0
 

--- a/paulsha_cortex/monitor/__main__.py
+++ b/paulsha_cortex/monitor/__main__.py
@@ -16,7 +16,11 @@ def build_parser() -> argparse.ArgumentParser:
         prog="paulsha_cortex.monitor",
         description="Stage 9 Project Monitor",
     )
-    parser.add_argument("--config", help="path to paulshaclaw.yaml", default=None)
+    parser.add_argument(
+        "--config",
+        help="path to project-cortex.yaml（或 legacy paulshaclaw.yaml）",
+        default=None,
+    )
     parser.add_argument(
         "--once",
         action="store_true",

--- a/paulsha_cortex/monitor/__main__.py
+++ b/paulsha_cortex/monitor/__main__.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import asdict
+from pathlib import Path
+
+from .config import load_config
+from .scanner import scan_workspaces
+from .service import ProjectMonitorService
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="paulsha_cortex.monitor",
+        description="Stage 9 Project Monitor",
+    )
+    parser.add_argument("--config", help="path to paulshaclaw.yaml", default=None)
+    parser.add_argument(
+        "--once",
+        action="store_true",
+        help="run a single scan, dump JSON snapshot to stdout, exit 0",
+    )
+    return parser
+
+
+def _snapshot_payload(states) -> dict[str, object]:
+    return {"projects": [asdict(state) for state in states]}
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+
+    try:
+        config_path = Path(args.config) if args.config else None
+        config = load_config(config_path=config_path)
+    except (FileNotFoundError, ValueError) as error:
+        print(f"錯誤: {error}", file=sys.stderr)
+        return 1
+
+    if args.once:
+        try:
+            states = scan_workspaces(config)
+        except (FileNotFoundError, ValueError, OSError) as error:
+            print(f"錯誤: {error}", file=sys.stderr)
+            return 1
+
+        payload = _snapshot_payload(states)
+        print(json.dumps(payload, ensure_ascii=False, default=str))
+        return 0
+
+    service: ProjectMonitorService | None = None
+    try:
+        service = ProjectMonitorService(config=config)
+        service.run_forever()
+    except KeyboardInterrupt:
+        if service is not None:
+            service.stop()
+        return 0
+    except (FileNotFoundError, ValueError, OSError, RuntimeError) as error:
+        print(f"錯誤: {error}", file=sys.stderr)
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/paulsha_cortex/monitor/config.py
+++ b/paulsha_cortex/monitor/config.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import warnings
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -9,10 +10,19 @@ import yaml
 from paulsha_cortex.config import paths
 
 ENV_CONFIG_VAR = "PAULSHACLAW_CONFIG"
+NEW_ENV_CONFIG_VAR = "PSC_MONITOR_CONFIG"
 ALLOWED_LEGACY_POLICIES = ("list-only", "hide")
 
 
 def default_config_path() -> Path:
+    return _legacy_manual_path()
+
+
+def _new_manual_path() -> Path:
+    return paths.project_config_root() / "project-cortex.yaml"
+
+
+def _legacy_manual_path() -> Path:
     return paths.config_path("paulshaclaw.yaml")
 
 
@@ -37,26 +47,30 @@ class MonitorConfig:
     ignore_dirs: tuple[str, ...] = ()
 
 
-def _resolve_config_source(config_path: Path | None) -> Path:
+def _resolve_config_source(config_path: Path | None) -> Path | None:
     if config_path is not None:
         return Path(config_path)
-    env_value = os.environ.get(ENV_CONFIG_VAR)
-    if env_value:
-        return Path(env_value)
-    default = default_config_path()
-    if default.exists():
-        return default
-    sample = (
-        Path(__file__).resolve().parents[2]
-        / "paulshaclaw"
-        / "config"
-        / "paulshaclaw.sample.yaml"
-    )
-    if sample.exists():
-        return sample
-    raise FileNotFoundError(
-        f"找不到設定檔：請設置 --config、{ENV_CONFIG_VAR} 或 {default_config_path()}"
-    )
+    for env in (NEW_ENV_CONFIG_VAR, ENV_CONFIG_VAR):
+        raw = os.environ.get(env, "").strip()
+        if not raw:
+            continue
+        if env == ENV_CONFIG_VAR:
+            warnings.warn(
+                "PAULSHACLAW_CONFIG 已 deprecated，改用 project-cortex.yaml",
+                stacklevel=2,
+            )
+        return Path(raw).expanduser()
+    new = _new_manual_path()
+    if new.exists():
+        return new
+    legacy = _legacy_manual_path()
+    if legacy.exists():
+        warnings.warn(
+            f"讀取 deprecated legacy monitor 設定 {legacy}，請遷移至 {new}",
+            stacklevel=2,
+        )
+        return legacy
+    return None
 
 
 def _parse_workspaces(raw: Any) -> tuple[WorkspaceConfig, ...]:
@@ -94,10 +108,15 @@ def _parse_monitor_section(raw: Any) -> dict[str, Any]:
 def load_config(*, config_path: Path | None = None) -> MonitorConfig:
     """Load the global paulshaclaw config.
 
-    Resolution order: explicit `config_path` → `PAULSHACLAW_CONFIG` env →
-    `~/.config/paulshaclaw/paulshaclaw.yaml` → bundled sample (read-only).
+    Resolution order: explicit `config_path` → `PSC_MONITOR_CONFIG` env →
+    `PAULSHACLAW_CONFIG` env → `project-cortex.yaml` → legacy `paulshaclaw.yaml`.
     """
     resolved = _resolve_config_source(config_path)
+    if resolved is None:
+        raise FileNotFoundError(
+            "找不到設定檔：請設置 --config、PSC_MONITOR_CONFIG、PAULSHACLAW_CONFIG，"
+            f"或建立 {_new_manual_path()} / {_legacy_manual_path()}"
+        )
     if not resolved.exists():
         raise FileNotFoundError(f"設定檔不存在：{resolved}")
 

--- a/paulsha_cortex/monitor/config.py
+++ b/paulsha_cortex/monitor/config.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+from paulsha_cortex.config import paths
+
+ENV_CONFIG_VAR = "PAULSHACLAW_CONFIG"
+ALLOWED_LEGACY_POLICIES = ("list-only", "hide")
+
+
+def default_config_path() -> Path:
+    return paths.config_path("paulshaclaw.yaml")
+
+
+def default_socket_path() -> Path:
+    return paths.run_root() / "project-monitor.sock"
+
+
+@dataclass(frozen=True)
+class WorkspaceConfig:
+    path: Path
+    name: str
+
+
+@dataclass(frozen=True)
+class MonitorConfig:
+    workspaces: tuple[WorkspaceConfig, ...]
+    poll_interval_seconds: int = 60
+    rescan_interval_seconds: int = 300
+    watch_debounce_ms: int = 500
+    legacy_policy: str = "list-only"
+    socket_path: Path = field(default_factory=default_socket_path)
+    ignore_dirs: tuple[str, ...] = ()
+
+
+def _resolve_config_source(config_path: Path | None) -> Path:
+    if config_path is not None:
+        return Path(config_path)
+    env_value = os.environ.get(ENV_CONFIG_VAR)
+    if env_value:
+        return Path(env_value)
+    default = default_config_path()
+    if default.exists():
+        return default
+    sample = (
+        Path(__file__).resolve().parents[2]
+        / "paulshaclaw"
+        / "config"
+        / "paulshaclaw.sample.yaml"
+    )
+    if sample.exists():
+        return sample
+    raise FileNotFoundError(
+        f"找不到設定檔：請設置 --config、{ENV_CONFIG_VAR} 或 {default_config_path()}"
+    )
+
+
+def _parse_workspaces(raw: Any) -> tuple[WorkspaceConfig, ...]:
+    if not isinstance(raw, list):
+        raise ValueError("config.workspaces 必須是清單")
+    if len(raw) == 0:
+        raise ValueError("config.workspaces 不可為空清單")
+    items: list[WorkspaceConfig] = []
+    for index, entry in enumerate(raw):
+        if not isinstance(entry, dict):
+            raise ValueError(f"config.workspaces[{index}] 必須是 mapping")
+        path_value = entry.get("path")
+        name_value = entry.get("name")
+        if not path_value:
+            raise ValueError(f"config.workspaces[{index}].path 缺失")
+        if not name_value:
+            raise ValueError(f"config.workspaces[{index}].name 缺失")
+        items.append(
+            WorkspaceConfig(
+                path=Path(str(path_value)).expanduser(),
+                name=str(name_value),
+            )
+        )
+    return tuple(items)
+
+
+def _parse_monitor_section(raw: Any) -> dict[str, Any]:
+    if raw is None:
+        return {}
+    if not isinstance(raw, dict):
+        raise ValueError("config.monitor 必須是 mapping")
+    return raw
+
+
+def load_config(*, config_path: Path | None = None) -> MonitorConfig:
+    """Load the global paulshaclaw config.
+
+    Resolution order: explicit `config_path` → `PAULSHACLAW_CONFIG` env →
+    `~/.config/paulshaclaw/paulshaclaw.yaml` → bundled sample (read-only).
+    """
+    resolved = _resolve_config_source(config_path)
+    if not resolved.exists():
+        raise FileNotFoundError(f"設定檔不存在：{resolved}")
+
+    try:
+        payload = yaml.safe_load(resolved.read_text(encoding="utf-8")) or {}
+    except yaml.YAMLError as error:
+        raise ValueError(f"設定檔解析失敗：{resolved} ({error})") from error
+
+    if not isinstance(payload, dict):
+        raise ValueError(f"設定檔必須是 mapping：{resolved}")
+
+    workspaces = _parse_workspaces(payload.get("workspaces"))
+    monitor = _parse_monitor_section(payload.get("monitor"))
+
+    legacy_policy = str(monitor.get("legacy_policy", "list-only"))
+    if legacy_policy not in ALLOWED_LEGACY_POLICIES:
+        raise ValueError(
+            f"config.monitor.legacy_policy 必須是 {ALLOWED_LEGACY_POLICIES} 之一，得到 {legacy_policy!r}"
+        )
+
+    poll_interval = int(monitor.get("poll_interval_seconds", 60))
+    rescan_interval = int(monitor.get("rescan_interval_seconds", 300))
+    debounce = int(monitor.get("watch_debounce_ms", 500))
+
+    socket_raw = monitor.get("socket_path")
+    socket_path = (
+        Path(str(socket_raw)).expanduser()
+        if socket_raw
+        else default_socket_path()
+    )
+
+    ignore_raw = monitor.get("ignore_dirs") or ()
+    if not isinstance(ignore_raw, (list, tuple)):
+        raise ValueError("config.monitor.ignore_dirs 必須是清單")
+    ignore_dirs = tuple(str(item) for item in ignore_raw)
+
+    return MonitorConfig(
+        workspaces=workspaces,
+        poll_interval_seconds=poll_interval,
+        rescan_interval_seconds=rescan_interval,
+        watch_debounce_ms=debounce,
+        legacy_policy=legacy_policy,
+        socket_path=socket_path,
+        ignore_dirs=ignore_dirs,
+    )

--- a/paulsha_cortex/monitor/config.py
+++ b/paulsha_cortex/monitor/config.py
@@ -113,8 +113,8 @@ def _load_manual_config(resolved: Path) -> MonitorConfig:
 
     try:
         payload = yaml.safe_load(resolved.read_text(encoding="utf-8")) or {}
-    except yaml.YAMLError as error:
-        raise ValueError(f"設定檔解析失敗：{resolved} ({error})") from error
+    except (yaml.YAMLError, OSError) as error:
+        raise ValueError(f"設定檔讀取或解析失敗：{resolved} ({error})") from error
 
     if not isinstance(payload, dict):
         raise ValueError(f"設定檔必須是 mapping：{resolved}")

--- a/paulsha_cortex/monitor/config.py
+++ b/paulsha_cortex/monitor/config.py
@@ -16,7 +16,9 @@ ALLOWED_LEGACY_POLICIES = ("list-only", "hide")
 
 
 def default_config_path() -> Path:
-    return _legacy_manual_path()
+    # 回傳現行預設 manual 路徑（project-cortex.yaml）——與 _resolve_config_source 的
+    # 優先序一致；勿反向導回 legacy paulshaclaw.yaml（GitHub review #3）。
+    return _new_manual_path()
 
 
 def _new_manual_path() -> Path:

--- a/paulsha_cortex/monitor/config.py
+++ b/paulsha_cortex/monitor/config.py
@@ -2,12 +2,13 @@ from __future__ import annotations
 
 import os
 import warnings
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import Any
 
 import yaml
 from paulsha_cortex.config import paths
+from paulsha_cortex.monitor.registry import ProjectEntry, load_hippo_projects
 
 ENV_CONFIG_VAR = "PAULSHACLAW_CONFIG"
 NEW_ENV_CONFIG_VAR = "PSC_MONITOR_CONFIG"
@@ -45,6 +46,7 @@ class MonitorConfig:
     legacy_policy: str = "list-only"
     socket_path: Path = field(default_factory=default_socket_path)
     ignore_dirs: tuple[str, ...] = ()
+    hippo_projects: tuple[ProjectEntry, ...] = ()
 
 
 def _resolve_config_source(config_path: Path | None) -> Path | None:
@@ -105,18 +107,7 @@ def _parse_monitor_section(raw: Any) -> dict[str, Any]:
     return raw
 
 
-def load_config(*, config_path: Path | None = None) -> MonitorConfig:
-    """Load the global paulshaclaw config.
-
-    Resolution order: explicit `config_path` → `PSC_MONITOR_CONFIG` env →
-    `PAULSHACLAW_CONFIG` env → `project-cortex.yaml` → legacy `paulshaclaw.yaml`.
-    """
-    resolved = _resolve_config_source(config_path)
-    if resolved is None:
-        raise FileNotFoundError(
-            "找不到設定檔：請設置 --config、PSC_MONITOR_CONFIG、PAULSHACLAW_CONFIG，"
-            f"或建立 {_new_manual_path()} / {_legacy_manual_path()}"
-        )
+def _load_manual_config(resolved: Path) -> MonitorConfig:
     if not resolved.exists():
         raise FileNotFoundError(f"設定檔不存在：{resolved}")
 
@@ -162,3 +153,21 @@ def load_config(*, config_path: Path | None = None) -> MonitorConfig:
         socket_path=socket_path,
         ignore_dirs=ignore_dirs,
     )
+
+
+def load_config(*, config_path: Path | None = None) -> MonitorConfig:
+    """Load the global paulshaclaw config.
+
+    Resolution order: explicit `config_path` → `PSC_MONITOR_CONFIG` env →
+    `PAULSHACLAW_CONFIG` env → `project-cortex.yaml` → legacy `paulshaclaw.yaml`.
+    """
+    resolved = _resolve_config_source(config_path)
+    hippo = tuple(load_hippo_projects())
+    if resolved is None:
+        if not hippo:
+            raise FileNotFoundError(
+                "無 project 設定：manual（project-cortex.yaml / legacy）與 "
+                "project-hippo.yaml 皆不存在"
+            )
+        return MonitorConfig(workspaces=(), hippo_projects=hippo)
+    return replace(_load_manual_config(resolved), hippo_projects=hippo)

--- a/paulsha_cortex/monitor/models.py
+++ b/paulsha_cortex/monitor/models.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class TaskRef:
+    text: str
+    line_no: int
+
+
+@dataclass(frozen=True)
+class StageRef:
+    stage_id: str
+    workstream_path: str | None = None
+
+
+@dataclass(frozen=True)
+class StageView:
+    stage_id: str
+    workstream_path: str
+    processing_task: TaskRef | None
+    next_task: TaskRef | None
+    blockers: tuple[str, ...] = ()
+    degraded: bool = False
+
+
+@dataclass(frozen=True)
+class Signal:
+    kind: str
+    path: str
+    note: str | None = None
+
+
+@dataclass(frozen=True)
+class ProjectState:
+    project_id: str
+    workspace: str
+    path: str
+    completed_stages: tuple[StageRef, ...] = ()
+    in_progress_stages: tuple[StageView, ...] = ()
+    pending_stages: tuple[StageRef, ...] = ()
+    legacy: bool = False
+    last_seen_at: float = 0.0
+    source_signals: tuple[Signal, ...] = ()

--- a/paulsha_cortex/monitor/parser.py
+++ b/paulsha_cortex/monitor/parser.py
@@ -61,15 +61,21 @@ def parse_blockers(todo_md: Path) -> tuple[str, ...]:
     return tuple(items)
 
 
-def _list_workstream_dirs(project_dir: Path) -> list[Path]:
+def _list_workstream_dirs(project_dir: Path) -> tuple[list[Path], str | None]:
     workstreams_root = project_dir / "docs" / "superpowers" / "workstreams"
-    if not workstreams_root.is_dir():
-        return []
-    return sorted(
-        child
-        for child in workstreams_root.iterdir()
-        if child.is_dir() and child.name.startswith("stage")
-    )
+    try:
+        if not workstreams_root.is_dir():
+            return [], None
+        return (
+            sorted(
+                child
+                for child in workstreams_root.iterdir()
+                if child.is_dir() and child.name.startswith("stage")
+            ),
+            None,
+        )
+    except OSError as error:
+        return [], f"degraded: {type(error).__name__}: {error}"
 
 
 def _make_view(workstream_dir: Path) -> tuple[StageView | None, list[Signal]]:
@@ -127,7 +133,16 @@ def extract_project_state(project_dir: Path, *, workspace_name: str) -> ProjectS
     pending: list[StageRef] = []
     signals: list[Signal] = []
 
-    for workstream_dir in _list_workstream_dirs(project_dir):
+    workstream_dirs, workstream_error = _list_workstream_dirs(project_dir)
+    if workstream_error:
+        signals.append(
+            Signal(
+                kind="workstreams",
+                path=str(project_dir / "docs" / "superpowers" / "workstreams"),
+                note=workstream_error,
+            )
+        )
+    for workstream_dir in workstream_dirs:
         view, view_signals = _make_view(workstream_dir)
         signals.extend(view_signals)
         if view is not None:
@@ -145,13 +160,22 @@ def extract_project_state(project_dir: Path, *, workspace_name: str) -> ProjectS
     # later patch; spec §B3 + design §4 decision #5 keep it pluggable.)
     completed: list[StageRef] = []
     archive_root = project_dir / "openspec" / "changes" / "archive"
-    if archive_root.is_dir():
-        for entry in sorted(archive_root.iterdir()):
-            if entry.is_dir() and "stage" in entry.name:
-                completed.append(
-                    StageRef(stage_id=entry.name, workstream_path=str(entry))
-                )
-        signals.append(Signal(kind="archive", path=str(archive_root)))
+    try:
+        if archive_root.is_dir():
+            for entry in sorted(archive_root.iterdir()):
+                if entry.is_dir() and "stage" in entry.name:
+                    completed.append(
+                        StageRef(stage_id=entry.name, workstream_path=str(entry))
+                    )
+            signals.append(Signal(kind="archive", path=str(archive_root)))
+    except OSError as error:
+        signals.append(
+            Signal(
+                kind="archive",
+                path=str(archive_root),
+                note=f"degraded: {type(error).__name__}: {error}",
+            )
+        )
 
     return ProjectState(
         project_id=project_dir.name,

--- a/paulsha_cortex/monitor/parser.py
+++ b/paulsha_cortex/monitor/parser.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+import re
+import time
+from pathlib import Path
+
+from .models import ProjectState, Signal, StageRef, StageView, TaskRef
+
+UNCHECKED_BULLET = re.compile(r"^\s*-\s*\[\s\]\s+(.+?)\s*$")
+CHECKED_BULLET = re.compile(r"^\s*-\s*\[[xX]\]\s+(.+?)\s*$")
+SECTION_HEADER = re.compile(r"^\s*##\s+(.+?)\s*$")
+
+
+def _read_text_safe(path: Path) -> tuple[str | None, str | None]:
+    """Return (text, error). Reading errors → (None, reason)."""
+    try:
+        return path.read_text(encoding="utf-8"), None
+    except (UnicodeDecodeError, OSError) as error:
+        return None, f"degraded: {type(error).__name__}: {error}"
+
+
+def _iter_section(text: str, section_title: str) -> list[tuple[int, str]]:
+    """Return [(line_no, line_text)] for every line in the requested section."""
+    lines = text.splitlines()
+    in_section = False
+    collected: list[tuple[int, str]] = []
+    for idx, raw in enumerate(lines, start=1):
+        header_match = SECTION_HEADER.match(raw)
+        if header_match:
+            current = header_match.group(1).strip()
+            in_section = current.lower() == section_title.lower()
+            continue
+        if in_section:
+            collected.append((idx, raw))
+    return collected
+
+
+def parse_todo_current_sprint(todo_md: Path) -> tuple[TaskRef, ...]:
+    """Return open (`- [ ]`) checkbox items in the Current Sprint section."""
+    text, error = _read_text_safe(todo_md)
+    if error or text is None:
+        return ()
+    items: list[TaskRef] = []
+    for line_no, line in _iter_section(text, "Current Sprint"):
+        match = UNCHECKED_BULLET.match(line)
+        if match:
+            items.append(TaskRef(text=match.group(1).strip(), line_no=line_no))
+    return tuple(items)
+
+
+def parse_blockers(todo_md: Path) -> tuple[str, ...]:
+    """Return every checkbox-line under the Blockers section, regardless of state."""
+    text, error = _read_text_safe(todo_md)
+    if error or text is None:
+        return ()
+    items: list[str] = []
+    for _line_no, line in _iter_section(text, "Blockers"):
+        match = UNCHECKED_BULLET.match(line) or CHECKED_BULLET.match(line)
+        if match:
+            items.append(match.group(1).strip())
+    return tuple(items)
+
+
+def _list_workstream_dirs(project_dir: Path) -> list[Path]:
+    workstreams_root = project_dir / "docs" / "superpowers" / "workstreams"
+    if not workstreams_root.is_dir():
+        return []
+    return sorted(
+        child
+        for child in workstreams_root.iterdir()
+        if child.is_dir() and child.name.startswith("stage")
+    )
+
+
+def _make_view(workstream_dir: Path) -> tuple[StageView | None, list[Signal]]:
+    """Build a StageView for an in-progress stage, plus diagnostic signals."""
+    todo_md = workstream_dir / "todo.md"
+    signals: list[Signal] = []
+
+    if not todo_md.is_file():
+        return None, signals
+
+    text, error = _read_text_safe(todo_md)
+    if error:
+        signals.append(Signal(kind="todo", path=str(todo_md), note=error))
+        return (
+            StageView(
+                stage_id=workstream_dir.name,
+                workstream_path=str(workstream_dir),
+                processing_task=None,
+                next_task=None,
+                blockers=(),
+                degraded=True,
+            ),
+            signals,
+        )
+
+    open_items = parse_todo_current_sprint(todo_md)
+    blockers = parse_blockers(todo_md)
+    signals.append(Signal(kind="todo", path=str(todo_md)))
+
+    if not open_items:
+        return None, signals
+
+    processing = open_items[0]
+    nxt = open_items[1] if len(open_items) > 1 else None
+
+    return (
+        StageView(
+            stage_id=workstream_dir.name,
+            workstream_path=str(workstream_dir),
+            processing_task=processing,
+            next_task=nxt,
+            blockers=blockers,
+        ),
+        signals,
+    )
+
+
+def extract_project_state(project_dir: Path, *, workspace_name: str) -> ProjectState:
+    """Derive ProjectState from a tracked project's artifacts.
+
+    Single source of truth: this function only reads files; it never persists
+    parallel state (spec §B4).
+    """
+    in_progress: list[StageView] = []
+    pending: list[StageRef] = []
+    signals: list[Signal] = []
+
+    for workstream_dir in _list_workstream_dirs(project_dir):
+        view, view_signals = _make_view(workstream_dir)
+        signals.extend(view_signals)
+        if view is not None:
+            in_progress.append(view)
+        else:
+            pending.append(
+                StageRef(
+                    stage_id=workstream_dir.name,
+                    workstream_path=str(workstream_dir),
+                )
+            )
+
+    # Completed-stage detection from openspec/changes/archive/* — best-effort,
+    # purely additive. (Branch-state inspection deferred to GitInspector in a
+    # later patch; spec §B3 + design §4 decision #5 keep it pluggable.)
+    completed: list[StageRef] = []
+    archive_root = project_dir / "openspec" / "changes" / "archive"
+    if archive_root.is_dir():
+        for entry in sorted(archive_root.iterdir()):
+            if entry.is_dir() and "stage" in entry.name:
+                completed.append(
+                    StageRef(stage_id=entry.name, workstream_path=str(entry))
+                )
+        signals.append(Signal(kind="archive", path=str(archive_root)))
+
+    return ProjectState(
+        project_id=project_dir.name,
+        workspace=workspace_name,
+        path=str(project_dir),
+        completed_stages=tuple(completed),
+        in_progress_stages=tuple(in_progress),
+        pending_stages=tuple(pending),
+        legacy=False,
+        last_seen_at=time.time(),
+        source_signals=tuple(signals),
+    )

--- a/paulsha_cortex/monitor/registry.py
+++ b/paulsha_cortex/monitor/registry.py
@@ -27,7 +27,10 @@ def load_hippo_projects(path: Path | None = None) -> list[ProjectEntry]:
     src = path or _default_hippo_path()
     if not src.exists():
         return []
-    data = yaml.safe_load(src.read_text(encoding="utf-8")) or {}
+    try:
+        data = yaml.safe_load(src.read_text(encoding="utf-8")) or {}
+    except yaml.YAMLError as exc:
+        raise ValueError(f"project-hippo.yaml 解析失敗：{src} ({exc})") from exc
     if not isinstance(data, dict):
         return []
     entries: list[ProjectEntry] = []

--- a/paulsha_cortex/monitor/registry.py
+++ b/paulsha_cortex/monitor/registry.py
@@ -33,12 +33,22 @@ def load_hippo_projects(path: Path | None = None) -> list[ProjectEntry]:
         raise ValueError(f"project-hippo.yaml 解析失敗：{src} ({exc})") from exc
     if not isinstance(data, dict):
         return []
+    raw_projects = data.get("projects", []) or []
+    if not isinstance(raw_projects, list):
+        raise ValueError(f"project-hippo.yaml projects 必須是清單：{src}")
     entries: list[ProjectEntry] = []
-    for project in data.get("projects", []) or []:
+    for index, project in enumerate(raw_projects):
         if not isinstance(project, dict):
-            continue
+            raise ValueError(f"project-hippo.yaml projects[{index}] 必須是 mapping：{src}")
         slug = str(project.get("slug") or "")
-        for root in project.get("roots", []) or []:
+        roots = project.get("roots", []) or []
+        if not isinstance(roots, list):
+            raise ValueError(f"project-hippo.yaml projects[{index}].roots 必須是清單：{src}")
+        for root_index, root in enumerate(roots):
+            if not isinstance(root, str):
+                raise ValueError(
+                    f"project-hippo.yaml projects[{index}].roots[{root_index}] 必須是字串：{src}"
+                )
             resolved = Path(str(root)).expanduser().resolve()
             entries.append(
                 ProjectEntry(

--- a/paulsha_cortex/monitor/registry.py
+++ b/paulsha_cortex/monitor/registry.py
@@ -29,8 +29,8 @@ def load_hippo_projects(path: Path | None = None) -> list[ProjectEntry]:
         return []
     try:
         data = yaml.safe_load(src.read_text(encoding="utf-8"))
-    except yaml.YAMLError as exc:
-        raise ValueError(f"project-hippo.yaml 解析失敗：{src} ({exc})") from exc
+    except (yaml.YAMLError, OSError) as exc:
+        raise ValueError(f"project-hippo.yaml 讀取或解析失敗：{src} ({exc})") from exc
     if data is None:
         data = {}
     if not isinstance(data, dict):
@@ -51,7 +51,12 @@ def load_hippo_projects(path: Path | None = None) -> list[ProjectEntry]:
                 raise ValueError(
                     f"project-hippo.yaml projects[{index}].roots[{root_index}] 必須是字串：{src}"
                 )
-            resolved = Path(str(root)).expanduser().resolve()
+            raw_root = root.strip()
+            if not raw_root:
+                raise ValueError(
+                    f"project-hippo.yaml projects[{index}].roots[{root_index}] 不可為空字串：{src}"
+                )
+            resolved = Path(raw_root).expanduser().resolve()
             entries.append(
                 ProjectEntry(
                     path=resolved,

--- a/paulsha_cortex/monitor/registry.py
+++ b/paulsha_cortex/monitor/registry.py
@@ -4,7 +4,7 @@
 """
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
 
 import yaml
@@ -74,8 +74,10 @@ def merge_projects(
     seen: set[Path] = set()
     merged: list[ProjectEntry] = []
     for entry in [*manual, *hippo]:
-        if entry.path in seen:
+        # 於函式內強制 realpath 正規化——不假設 caller 已 resolve（symlink/./.. 亦去重）
+        key = entry.path.expanduser().resolve()
+        if key in seen:
             continue
-        seen.add(entry.path)
-        merged.append(entry)
+        seen.add(key)
+        merged.append(entry if entry.path == key else replace(entry, path=key))
     return merged

--- a/paulsha_cortex/monitor/registry.py
+++ b/paulsha_cortex/monitor/registry.py
@@ -28,11 +28,13 @@ def load_hippo_projects(path: Path | None = None) -> list[ProjectEntry]:
     if not src.exists():
         return []
     try:
-        data = yaml.safe_load(src.read_text(encoding="utf-8")) or {}
+        data = yaml.safe_load(src.read_text(encoding="utf-8"))
     except yaml.YAMLError as exc:
         raise ValueError(f"project-hippo.yaml 解析失敗：{src} ({exc})") from exc
+    if data is None:
+        data = {}
     if not isinstance(data, dict):
-        return []
+        raise ValueError(f"project-hippo.yaml 頂層必須是 mapping：{src}")
     raw_projects = data.get("projects", []) or []
     if not isinstance(raw_projects, list):
         raise ValueError(f"project-hippo.yaml projects 必須是清單：{src}")

--- a/paulsha_cortex/monitor/registry.py
+++ b/paulsha_cortex/monitor/registry.py
@@ -1,6 +1,6 @@
 """monitor 監控集 = manual project-cortex.yaml ⊍ hippo project-hippo.yaml。
 
-讀共享檔為檔案契約，不 import paulsha_hippo。
+讀共享檔為檔案契約，不引入上游 runtime import。
 """
 from __future__ import annotations
 

--- a/paulsha_cortex/monitor/registry.py
+++ b/paulsha_cortex/monitor/registry.py
@@ -1,0 +1,61 @@
+"""monitor 監控集 = manual project-cortex.yaml ⊍ hippo project-hippo.yaml。
+
+讀共享檔為檔案契約，不 import paulsha_hippo。
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import yaml
+
+from paulsha_cortex.config import paths
+
+
+def _default_hippo_path() -> Path:
+    return paths.project_config_root() / "project-hippo.yaml"
+
+
+@dataclass(frozen=True)
+class ProjectEntry:
+    path: Path
+    name: str
+    source: str
+
+
+def load_hippo_projects(path: Path | None = None) -> list[ProjectEntry]:
+    src = path or _default_hippo_path()
+    if not src.exists():
+        return []
+    data = yaml.safe_load(src.read_text(encoding="utf-8")) or {}
+    if not isinstance(data, dict):
+        return []
+    entries: list[ProjectEntry] = []
+    for project in data.get("projects", []) or []:
+        if not isinstance(project, dict):
+            continue
+        slug = str(project.get("slug") or "")
+        for root in project.get("roots", []) or []:
+            resolved = Path(str(root)).expanduser().resolve()
+            entries.append(
+                ProjectEntry(
+                    path=resolved,
+                    name=slug or resolved.name,
+                    source="hippo",
+                )
+            )
+    return entries
+
+
+def merge_projects(
+    manual: list[ProjectEntry],
+    hippo: list[ProjectEntry],
+) -> list[ProjectEntry]:
+    seen: set[Path] = set()
+    merged: list[ProjectEntry] = []
+    for entry in [*manual, *hippo]:
+        if entry.path in seen:
+            continue
+        seen.add(entry.path)
+        merged.append(entry)
+    return merged

--- a/paulsha_cortex/monitor/scanner.py
+++ b/paulsha_cortex/monitor/scanner.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import time
+from enum import Enum
+from pathlib import Path
+
+from .config import MonitorConfig
+from .models import ProjectState
+from .parser import extract_project_state
+
+# Always-skip directory names that should never be treated as projects.
+IMPLICIT_IGNORE = frozenset({".git", ".hg", ".svn", "node_modules", "__pycache__"})
+
+
+class ProjectClassification(str, Enum):
+    TRACKED = "tracked"
+    LEGACY = "legacy"
+
+
+def classify_project(project_dir: Path) -> ProjectClassification:
+    """Decide whether a project dir is tracked or legacy (design §3.2)."""
+    if (project_dir / ".paul-project.yml").is_file():
+        return ProjectClassification.TRACKED
+
+    workstreams = project_dir / "docs" / "superpowers" / "workstreams"
+    if workstreams.is_dir():
+        for child in workstreams.iterdir():
+            if not child.is_dir() or not child.name.startswith("stage"):
+                continue
+            if (child / "todo.md").is_file() or (child / "task.md").is_file():
+                return ProjectClassification.TRACKED
+
+    return ProjectClassification.LEGACY
+
+
+def _list_project_dirs(workspace_root: Path, ignore_dirs: frozenset[str]) -> list[Path]:
+    if not workspace_root.exists():
+        return []
+    if not workspace_root.is_dir():
+        return []
+    items: list[Path] = []
+    for entry in sorted(workspace_root.iterdir()):
+        if not entry.is_dir():
+            continue
+        if entry.name in ignore_dirs:
+            continue
+        if entry.name in IMPLICIT_IGNORE:
+            continue
+        items.append(entry)
+    return items
+
+
+def scan_workspaces(config: MonitorConfig) -> tuple[ProjectState, ...]:
+    """Walk every configured workspace and produce per-project states.
+
+    Honours `legacy_policy` and `ignore_dirs` per design §3.2 / §3.5.
+    Missing workspace paths are silently skipped — the service must not
+    crash when a workspace is unmounted (spec §B7).
+    """
+    ignore = frozenset(config.ignore_dirs)
+    legacy_visible = config.legacy_policy != "hide"
+    now = time.time()
+    states: list[ProjectState] = []
+
+    for workspace in config.workspaces:
+        for project_dir in _list_project_dirs(workspace.path, ignore):
+            classification = classify_project(project_dir)
+            is_legacy = classification == ProjectClassification.LEGACY
+            if is_legacy and not legacy_visible:
+                continue
+            if is_legacy:
+                states.append(
+                    ProjectState(
+                        project_id=project_dir.name,
+                        workspace=workspace.name,
+                        path=str(project_dir),
+                        legacy=True,
+                        last_seen_at=now,
+                    )
+                )
+            else:
+                state = extract_project_state(
+                    project_dir,
+                    workspace_name=workspace.name,
+                )
+                states.append(state)
+
+    return tuple(states)

--- a/paulsha_cortex/monitor/scanner.py
+++ b/paulsha_cortex/monitor/scanner.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import replace
 import time
 from enum import Enum
 from pathlib import Path
@@ -51,6 +52,30 @@ def _list_project_dirs(workspace_root: Path, ignore_dirs: frozenset[str]) -> lis
     return items
 
 
+def _qualified_duplicate_project_id(states: list[ProjectState], state: ProjectState) -> str:
+    workspace_qualified = {
+        other.workspace: f"{other.workspace}:{Path(other.path).name}"
+        for other in states
+    }
+    if len(workspace_qualified) == len(states):
+        return workspace_qualified[state.workspace]
+    return f"{state.workspace}:{Path(state.path).resolve()}"
+
+
+def _dedupe_project_ids(states: list[ProjectState]) -> tuple[ProjectState, ...]:
+    grouped: dict[str, list[ProjectState]] = {}
+    for state in states:
+        grouped.setdefault(state.project_id, []).append(state)
+    resolved: list[ProjectState] = []
+    for state in states:
+        group = grouped[state.project_id]
+        if len(group) == 1:
+            resolved.append(state)
+            continue
+        resolved.append(replace(state, project_id=_qualified_duplicate_project_id(group, state)))
+    return tuple(resolved)
+
+
 def scan_workspaces(config: MonitorConfig) -> tuple[ProjectState, ...]:
     """Walk every configured workspace and produce per-project states.
 
@@ -99,4 +124,4 @@ def scan_workspaces(config: MonitorConfig) -> tuple[ProjectState, ...]:
             )
             states.append(state)
 
-    return tuple(states)
+    return _dedupe_project_ids(states)

--- a/paulsha_cortex/monitor/scanner.py
+++ b/paulsha_cortex/monitor/scanner.py
@@ -21,34 +21,44 @@ class ProjectClassification(str, Enum):
 
 def classify_project(project_dir: Path) -> ProjectClassification:
     """Decide whether a project dir is tracked or legacy (design §3.2)."""
-    if (project_dir / ".paul-project.yml").is_file():
-        return ProjectClassification.TRACKED
+    try:
+        if (project_dir / ".paul-project.yml").is_file():
+            return ProjectClassification.TRACKED
 
-    workstreams = project_dir / "docs" / "superpowers" / "workstreams"
-    if workstreams.is_dir():
-        for child in workstreams.iterdir():
-            if not child.is_dir() or not child.name.startswith("stage"):
-                continue
-            if (child / "todo.md").is_file() or (child / "task.md").is_file():
-                return ProjectClassification.TRACKED
+        workstreams = project_dir / "docs" / "superpowers" / "workstreams"
+        if workstreams.is_dir():
+            for child in workstreams.iterdir():
+                if not child.is_dir() or not child.name.startswith("stage"):
+                    continue
+                if (child / "todo.md").is_file() or (child / "task.md").is_file():
+                    return ProjectClassification.TRACKED
+    except OSError:
+        return ProjectClassification.LEGACY
 
     return ProjectClassification.LEGACY
 
 
 def _list_project_dirs(workspace_root: Path, ignore_dirs: frozenset[str]) -> list[Path]:
-    if not workspace_root.exists():
-        return []
-    if not workspace_root.is_dir():
+    try:
+        if not workspace_root.exists():
+            return []
+        if not workspace_root.is_dir():
+            return []
+        entries = sorted(workspace_root.iterdir())
+    except OSError:
         return []
     items: list[Path] = []
-    for entry in sorted(workspace_root.iterdir()):
-        if not entry.is_dir():
+    for entry in entries:
+        try:
+            if not entry.is_dir():
+                continue
+            if entry.name in ignore_dirs:
+                continue
+            if entry.name in IMPLICIT_IGNORE:
+                continue
+            items.append(entry)
+        except OSError:
             continue
-        if entry.name in ignore_dirs:
-            continue
-        if entry.name in IMPLICIT_IGNORE:
-            continue
-        items.append(entry)
     return items
 
 

--- a/paulsha_cortex/monitor/scanner.py
+++ b/paulsha_cortex/monitor/scanner.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from .config import MonitorConfig
 from .models import ProjectState
 from .parser import extract_project_state
+from .registry import ProjectEntry, merge_projects
 
 # Always-skip directory names that should never be treated as projects.
 IMPLICIT_IGNORE = frozenset({".git", ".hg", ".svn", "node_modules", "__pycache__"})
@@ -60,29 +61,42 @@ def scan_workspaces(config: MonitorConfig) -> tuple[ProjectState, ...]:
     ignore = frozenset(config.ignore_dirs)
     legacy_visible = config.legacy_policy != "hide"
     now = time.time()
+    manual_projects: list[ProjectEntry] = []
     states: list[ProjectState] = []
 
     for workspace in config.workspaces:
         for project_dir in _list_project_dirs(workspace.path, ignore):
-            classification = classify_project(project_dir)
-            is_legacy = classification == ProjectClassification.LEGACY
-            if is_legacy and not legacy_visible:
-                continue
-            if is_legacy:
-                states.append(
-                    ProjectState(
-                        project_id=project_dir.name,
-                        workspace=workspace.name,
-                        path=str(project_dir),
-                        legacy=True,
-                        last_seen_at=now,
-                    )
+            manual_projects.append(
+                ProjectEntry(
+                    path=project_dir.resolve(),
+                    name=workspace.name,
+                    source="manual",
                 )
-            else:
-                state = extract_project_state(
-                    project_dir,
-                    workspace_name=workspace.name,
+            )
+
+    for entry in merge_projects(manual_projects, list(config.hippo_projects)):
+        project_dir = entry.path
+        if not project_dir.exists() or not project_dir.is_dir():
+            continue
+        classification = classify_project(project_dir)
+        is_legacy = classification == ProjectClassification.LEGACY
+        if is_legacy and not legacy_visible:
+            continue
+        if is_legacy:
+            states.append(
+                ProjectState(
+                    project_id=project_dir.name,
+                    workspace=entry.name,
+                    path=str(project_dir),
+                    legacy=True,
+                    last_seen_at=now,
                 )
-                states.append(state)
+            )
+        else:
+            state = extract_project_state(
+                project_dir,
+                workspace_name=entry.name,
+            )
+            states.append(state)
 
     return tuple(states)

--- a/paulsha_cortex/monitor/server.py
+++ b/paulsha_cortex/monitor/server.py
@@ -313,16 +313,23 @@ def _error(message: str) -> dict:
     return {"ok": False, "error": message}
 
 
-def _read_line(conn: socket.socket, *, timeout: float = 2.0) -> bytes:
+_MAX_REQUEST_LINE = 65536  # 64 KiB：超長請求行上限，防記憶體/CPU 被拖垮（GitHub review #2）
+
+
+def _read_line(conn: socket.socket, *, timeout: float = 2.0, max_len: int = _MAX_REQUEST_LINE) -> bytes:
     conn.settimeout(timeout)
     chunks: list[bytes] = []
+    total = 0
     try:
         while True:
             ch = conn.recv(1)
             if not ch:
                 break
             chunks.append(ch)
+            total += 1
             if ch == b"\n":
+                break
+            if total >= max_len:   # 超過上限即中止讀取（不吞整行）
                 break
     except socket.timeout:
         return b""

--- a/paulsha_cortex/monitor/server.py
+++ b/paulsha_cortex/monitor/server.py
@@ -60,6 +60,7 @@ class MonitorServer:
         self._subscribers: list[_Subscriber] = []
         self._subscribers_lock = threading.Lock()
         self._connection_threads: list[threading.Thread] = []
+        self._connection_threads_lock = threading.Lock()
         self._serve_thread: threading.Thread | None = None
 
     # --- lifecycle ---
@@ -115,7 +116,11 @@ class MonitorServer:
                     target=self._handle_connection, args=(conn,), daemon=True
                 )
                 t.start()
-                self._connection_threads.append(t)
+                with self._connection_threads_lock:
+                    self._connection_threads = [
+                        thread for thread in self._connection_threads if thread.is_alive()
+                    ]
+                    self._connection_threads.append(t)
         finally:
             self._teardown()
 
@@ -206,6 +211,13 @@ class MonitorServer:
                 conn.close()
             except OSError:
                 pass
+            current = threading.current_thread()
+            with self._connection_threads_lock:
+                self._connection_threads = [
+                    thread
+                    for thread in self._connection_threads
+                    if thread is not current and thread.is_alive()
+                ]
 
     def _handle_list_projects(self, conn: socket.socket) -> None:
         states = self._store.current_snapshot()

--- a/paulsha_cortex/monitor/server.py
+++ b/paulsha_cortex/monitor/server.py
@@ -1,0 +1,329 @@
+"""Unix domain socket server for the Project Monitor read API.
+
+Wire contract (per design §3.6 + spec §B6):
+
+  Request line  (one JSON object per newline):
+    {"kind": "list_projects"}
+    {"kind": "get_project_state", "project_id": "<id>"}
+    {"kind": "subscribe"}                              # all projects
+    {"kind": "subscribe", "projects": ["<id>", ...]}   # filter
+
+  Unary response (one JSON object on one line, then close):
+    {"ok": true,  "data": <payload>}
+    {"ok": false, "error": "<reason>"}
+
+  Subscribe response (newline-delimited JSON event stream):
+    {"sequence": <int>, "kind": "snapshot", "projects": [<state>, ...]}
+    {"sequence": <int>, "kind": "change",   "project":  <state>}
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import queue
+import socket
+import threading
+import time
+from dataclasses import asdict
+from pathlib import Path
+from typing import Iterable
+
+from .snapshot import ChangeEvent, SnapshotStore
+
+ACCEPT_TIMEOUT_SECONDS = 0.25
+SUBSCRIBE_QUEUE_GET_TIMEOUT = 0.25
+EVENT_QUEUE_MAXSIZE = 1024
+SOCKET_PROBE_TIMEOUT_SECONDS = 0.2
+
+
+class _Subscriber:
+    def __init__(self, *, projects: tuple[str, ...] | None) -> None:
+        self.projects = projects  # None = all
+        self.queue: queue.Queue = queue.Queue(maxsize=EVENT_QUEUE_MAXSIZE)
+        self.alive = True
+
+    def matches(self, project_id: str) -> bool:
+        if self.projects is None:
+            return True
+        return project_id in self.projects
+
+
+class MonitorServer:
+    """Long-lived Unix-socket server. Single instance per service."""
+
+    def __init__(self, *, store: SnapshotStore, socket_path: Path) -> None:
+        self._store = store
+        self._socket_path = Path(socket_path)
+        self._listener: socket.socket | None = None
+        self._stop_event = threading.Event()
+        self._subscribers: list[_Subscriber] = []
+        self._subscribers_lock = threading.Lock()
+        self._connection_threads: list[threading.Thread] = []
+        self._serve_thread: threading.Thread | None = None
+
+    # --- lifecycle ---
+
+    def _prepare_socket_path(self) -> None:
+        if not self._socket_path.exists():
+            return
+
+        probe = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        try:
+            probe.settimeout(SOCKET_PROBE_TIMEOUT_SECONDS)
+            probe.connect(str(self._socket_path))
+        except TimeoutError as exc:
+            raise RuntimeError(
+                f"live monitor already listening on {self._socket_path}"
+            ) from exc
+        except OSError:
+            try:
+                self._socket_path.unlink()
+            except OSError:
+                pass
+            return
+        finally:
+            probe.close()
+
+        raise RuntimeError(f"live monitor already listening on {self._socket_path}")
+
+    def serve_forever(self) -> None:
+        # Atomic bind + permission tightening.
+        self._socket_path.parent.mkdir(parents=True, exist_ok=True)
+        self._prepare_socket_path()
+        listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        previous_umask = os.umask(0o177)
+        try:
+            listener.bind(str(self._socket_path))
+        finally:
+            os.umask(previous_umask)
+        os.chmod(str(self._socket_path), 0o600)
+        listener.listen(16)
+        listener.settimeout(ACCEPT_TIMEOUT_SECONDS)
+        self._listener = listener
+
+        try:
+            while not self._stop_event.is_set():
+                try:
+                    conn, _addr = listener.accept()
+                except socket.timeout:
+                    continue
+                except OSError:
+                    break
+                conn.settimeout(None)
+                t = threading.Thread(
+                    target=self._handle_connection, args=(conn,), daemon=True
+                )
+                t.start()
+                self._connection_threads.append(t)
+        finally:
+            self._teardown()
+
+    def stop(self) -> None:
+        self._stop_event.set()
+        # Mark all subscribers dead so their threads can exit.
+        with self._subscribers_lock:
+            for sub in self._subscribers:
+                sub.alive = False
+        # Best-effort: close the listener so any in-flight accept errors out.
+        if self._listener is not None:
+            try:
+                self._listener.close()
+            except OSError:
+                pass
+
+    def _teardown(self) -> None:
+        if self._listener is not None:
+            try:
+                self._listener.close()
+            except OSError:
+                pass
+            self._listener = None
+        try:
+            if self._socket_path.exists():
+                self._socket_path.unlink()
+        except OSError:
+            pass
+
+    # --- public publish surface ---
+
+    def publish_events(self, events: Iterable[ChangeEvent]) -> None:
+        events = tuple(events)
+        if not events:
+            return
+        with self._subscribers_lock:
+            for sub in list(self._subscribers):
+                if not sub.alive:
+                    continue
+                for evt in events:
+                    if not sub.matches(evt.project_id):
+                        continue
+                    payload = {
+                        "sequence": evt.sequence,
+                        "kind": "change",
+                        "project": _state_to_dict(evt.project_state),
+                    }
+                    try:
+                        sub.queue.put_nowait(payload)
+                    except queue.Full:
+                        # Drop oldest to make room (at-least-once with bounded
+                        # buffer; consumers detect gaps via sequence numbers).
+                        try:
+                            sub.queue.get_nowait()
+                        except queue.Empty:
+                            pass
+                        try:
+                            sub.queue.put_nowait(payload)
+                        except queue.Full:
+                            pass
+
+    # --- request handling ---
+
+    def _handle_connection(self, conn: socket.socket) -> None:
+        try:
+            line = _read_line(conn, timeout=2.0)
+            if not line:
+                return
+            try:
+                request = json.loads(line.decode("utf-8"))
+            except (UnicodeDecodeError, json.JSONDecodeError) as error:
+                _write_line(conn, _error(f"invalid JSON: {error}"))
+                return
+
+            kind = request.get("kind")
+            if kind == "list_projects":
+                self._handle_list_projects(conn)
+            elif kind == "get_project_state":
+                self._handle_get_project_state(conn, request)
+            elif kind == "subscribe":
+                self._handle_subscribe(conn, request)
+            else:
+                _write_line(conn, _error(f"unknown request kind: {kind!r}"))
+        except (BrokenPipeError, ConnectionResetError, OSError):
+            pass
+        finally:
+            try:
+                conn.close()
+            except OSError:
+                pass
+
+    def _handle_list_projects(self, conn: socket.socket) -> None:
+        states = self._store.current_snapshot()
+        payload = {
+            "ok": True,
+            "data": {
+                "projects": [_state_to_dict(s) for s in states],
+            },
+        }
+        _write_line(conn, payload)
+
+    def _handle_get_project_state(self, conn: socket.socket, request: dict) -> None:
+        project_id = request.get("project_id")
+        if not project_id:
+            _write_line(conn, _error("project_id is required"))
+            return
+        state = self._store.get(project_id)
+        if state is None:
+            _write_line(conn, _error(f"unknown project: {project_id}"))
+            return
+        _write_line(conn, {"ok": True, "data": _state_to_dict(state)})
+
+    def _handle_subscribe(self, conn: socket.socket, request: dict) -> None:
+        filter_projects = request.get("projects")
+        projects = (
+            tuple(str(p) for p in filter_projects)
+            if isinstance(filter_projects, list)
+            else None
+        )
+        sub = _Subscriber(projects=projects)
+        with self._subscribers_lock:
+            self._subscribers.append(sub)
+        try:
+            # Send initial snapshot with the store's current sequence so any
+            # subsequent change event is strictly greater for this subscriber.
+            snap_seq = self._store.sequence
+            states = self._store.current_snapshot()
+            initial = {
+                "sequence": snap_seq,
+                "kind": "snapshot",
+                "projects": [
+                    _state_to_dict(s)
+                    for s in states
+                    if sub.matches(s.project_id)
+                ],
+            }
+            _write_line(conn, initial)
+
+            # Stream events until subscriber dies or peer disconnects.
+            while sub.alive and not self._stop_event.is_set():
+                try:
+                    evt = sub.queue.get(timeout=SUBSCRIBE_QUEUE_GET_TIMEOUT)
+                except queue.Empty:
+                    if _peer_closed(conn):
+                        return
+                    continue
+                _write_line(conn, evt)
+        finally:
+            sub.alive = False
+            with self._subscribers_lock:
+                if sub in self._subscribers:
+                    self._subscribers.remove(sub)
+
+
+# --- helpers ---
+
+
+def _state_to_dict(state) -> dict:
+    payload = asdict(state)
+    # asdict already converts dataclasses recursively; PosixPath etc. would
+    # leak only via fields we don't have. Ensure JSON-safety just in case.
+    return json.loads(json.dumps(payload, default=str))
+
+
+def _error(message: str) -> dict:
+    return {"ok": False, "error": message}
+
+
+def _read_line(conn: socket.socket, *, timeout: float = 2.0) -> bytes:
+    conn.settimeout(timeout)
+    chunks: list[bytes] = []
+    try:
+        while True:
+            ch = conn.recv(1)
+            if not ch:
+                break
+            chunks.append(ch)
+            if ch == b"\n":
+                break
+    except socket.timeout:
+        return b""
+    finally:
+        conn.settimeout(None)
+    return b"".join(chunks)
+
+
+def _write_line(conn: socket.socket, payload: dict) -> None:
+    line = (json.dumps(payload, ensure_ascii=False, default=str) + "\n").encode(
+        "utf-8"
+    )
+    try:
+        conn.sendall(line)
+    except (BrokenPipeError, ConnectionResetError, OSError):
+        pass
+
+
+def _peer_closed(conn: socket.socket) -> bool:
+    try:
+        conn.setblocking(False)
+        try:
+            data = conn.recv(1, socket.MSG_PEEK)
+        except BlockingIOError:
+            return False
+        except OSError:
+            return True
+        return len(data) == 0
+    finally:
+        try:
+            conn.setblocking(True)
+        except OSError:
+            pass

--- a/paulsha_cortex/monitor/server.py
+++ b/paulsha_cortex/monitor/server.py
@@ -23,6 +23,7 @@ import json
 import os
 import queue
 import socket
+import stat
 import threading
 import time
 from dataclasses import asdict
@@ -68,6 +69,14 @@ class MonitorServer:
     def _prepare_socket_path(self) -> None:
         if not self._socket_path.exists():
             return
+        try:
+            mode = self._socket_path.stat().st_mode
+        except OSError as exc:
+            raise RuntimeError(f"無法檢查 monitor socket path：{self._socket_path}") from exc
+        if not stat.S_ISSOCK(mode):
+            raise RuntimeError(
+                f"monitor socket path 已存在且不是 Unix socket：{self._socket_path}"
+            )
 
         probe = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         try:

--- a/paulsha_cortex/monitor/server.py
+++ b/paulsha_cortex/monitor/server.py
@@ -167,6 +167,7 @@ class MonitorServer:
                         "sequence": evt.sequence,
                         "kind": "change",
                         "project": _state_to_dict(evt.project_state),
+                        "removed": evt.removed,
                     }
                     try:
                         sub.queue.put_nowait(payload)

--- a/paulsha_cortex/monitor/server.py
+++ b/paulsha_cortex/monitor/server.py
@@ -204,6 +204,9 @@ class MonitorServer:
             except (UnicodeDecodeError, json.JSONDecodeError) as error:
                 _write_line(conn, _error(f"invalid JSON: {error}"))
                 return
+            if not isinstance(request, dict):
+                _write_line(conn, _error("request payload must be a JSON object"))
+                return
 
             kind = request.get("kind")
             if kind == "list_projects":
@@ -241,7 +244,7 @@ class MonitorServer:
 
     def _handle_get_project_state(self, conn: socket.socket, request: dict) -> None:
         project_id = request.get("project_id")
-        if not project_id:
+        if not isinstance(project_id, str) or not project_id:
             _write_line(conn, _error("project_id is required"))
             return
         state = self._store.get(project_id)
@@ -252,11 +255,15 @@ class MonitorServer:
 
     def _handle_subscribe(self, conn: socket.socket, request: dict) -> None:
         filter_projects = request.get("projects")
-        projects = (
-            tuple(str(p) for p in filter_projects)
-            if isinstance(filter_projects, list)
-            else None
-        )
+        if filter_projects is None:
+            projects = None
+        elif isinstance(filter_projects, list) and all(
+            isinstance(project_id, str) and project_id for project_id in filter_projects
+        ):
+            projects = tuple(filter_projects)
+        else:
+            _write_line(conn, _error("projects must be a list of non-empty strings"))
+            return
         sub = _Subscriber(projects=projects)
         with self._subscribers_lock:
             self._subscribers.append(sub)

--- a/paulsha_cortex/monitor/service.py
+++ b/paulsha_cortex/monitor/service.py
@@ -1,0 +1,217 @@
+from __future__ import annotations
+
+import os
+import threading
+from pathlib import Path
+
+from .config import MonitorConfig
+from .server import MonitorServer
+from .snapshot import ChangeEvent, SnapshotStore
+from .watcher import WatchdogFileWatcher, Watcher
+
+
+class ProjectMonitorService:
+    """Stage 9 long-lived service runtime.
+
+    Composes the snapshot store, filesystem watcher, and Unix-socket server.
+    State remains in memory; project truth is always re-derived from files.
+    """
+
+    def __init__(
+        self,
+        *,
+        config: MonitorConfig,
+        watcher: Watcher | None = None,
+        store: SnapshotStore | None = None,
+        server: MonitorServer | None = None,
+    ) -> None:
+        self._config = config
+        self._store = store or SnapshotStore(config=config)
+        self._watcher = watcher or WatchdogFileWatcher(
+            debounce_ms=config.watch_debounce_ms
+        )
+        self._server = server or MonitorServer(
+            store=self._store,
+            socket_path=config.socket_path,
+        )
+        self._stop_event = threading.Event()
+        self._poll_thread: threading.Thread | None = None
+        self._rescan_thread: threading.Thread | None = None
+        self._debounce_lock = threading.Lock()
+        self._debounce_timers: dict[str, threading.Timer] = {}
+        self._project_roots: dict[str, Path] = {}
+        self._watched_paths: set[tuple[Path, bool]] = set()
+
+    def run_forever(self) -> None:
+        self._prepare_run_dir()
+        self._store.load()
+        self._sync_project_roots()
+        self._install_watches()
+        self._start_poll_thread()
+        self._start_rescan_thread()
+        try:
+            self._server.serve_forever()
+        finally:
+            self._shutdown()
+
+    def stop(self) -> None:
+        self._stop_event.set()
+        self._cancel_debounce_timers()
+        self._watcher.stop()
+        self._server.stop()
+
+    def _prepare_run_dir(self) -> None:
+        run_dir = self._config.socket_path.parent
+        run_dir.mkdir(parents=True, exist_ok=True)
+        os.chmod(str(run_dir), 0o700)
+
+    def _start_poll_thread(self) -> None:
+        if self._poll_thread is not None:
+            return
+        self._poll_thread = threading.Thread(target=self._poll_loop, daemon=True)
+        self._poll_thread.start()
+
+    def _start_rescan_thread(self) -> None:
+        if self._rescan_thread is not None:
+            return
+        self._rescan_thread = threading.Thread(target=self._rescan_loop, daemon=True)
+        self._rescan_thread.start()
+
+    def _poll_loop(self) -> None:
+        interval = max(0.1, float(self._config.poll_interval_seconds))
+        while not self._stop_event.wait(interval):
+            self._publish_refresh(self._store.refresh())
+
+    def _rescan_loop(self) -> None:
+        interval = max(0.1, float(self._config.rescan_interval_seconds))
+        while not self._stop_event.wait(interval):
+            tracked_ids = tuple(self._project_roots)
+            if not tracked_ids:
+                continue
+            self._publish_refresh(self._store.refresh_projects(tracked_ids))
+
+    def _sync_project_roots(self) -> None:
+        self._project_roots = {
+            state.project_id: Path(state.path)
+            for state in self._store.current_snapshot()
+            if not state.legacy
+        }
+
+    def _install_watches(self) -> None:
+        for project_root in self._project_roots.values():
+            for watch_path, recursive in self._watch_specs(project_root):
+                watch_key = (watch_path, recursive)
+                if watch_key in self._watched_paths:
+                    continue
+                self._watcher.watch(watch_path, self._handle_fs_event, recursive=recursive)
+                self._watched_paths.add(watch_key)
+
+    def _watch_specs(self, project_root: Path) -> tuple[tuple[Path, bool], ...]:
+        specs: list[tuple[Path, bool]] = [(project_root, False)]
+        git_dir = self._resolve_git_dir(project_root)
+        if git_dir is None:
+            return tuple(specs)
+        head_path = git_dir / "HEAD"
+        refs_path = git_dir / "refs"
+        if head_path.exists():
+            specs.append((head_path, False))
+        if refs_path.exists():
+            specs.append((refs_path, True))
+        return tuple(specs)
+
+    def _resolve_git_dir(self, project_root: Path) -> Path | None:
+        git_entry = project_root / ".git"
+        if git_entry.is_dir():
+            return git_entry
+        if not git_entry.is_file():
+            return None
+        try:
+            first_line = git_entry.read_text(encoding="utf-8").splitlines()[0].strip()
+        except (OSError, IndexError):
+            return None
+        prefix = "gitdir:"
+        if not first_line.lower().startswith(prefix):
+            return None
+        raw_path = first_line[len(prefix):].strip()
+        if not raw_path:
+            return None
+        resolved = Path(raw_path)
+        if not resolved.is_absolute():
+            resolved = (git_entry.parent / resolved).resolve()
+        return resolved
+
+    def _handle_fs_event(self, path: Path) -> None:
+        project_id = self._project_id_for_path(Path(path))
+        if project_id is None:
+            self._publish_refresh(self._store.refresh())
+            return
+        self._schedule_project_refresh(project_id)
+
+    def _project_id_for_path(self, path: Path) -> str | None:
+        best_match: tuple[str, int] | None = None
+        for project_id, project_root in self._project_roots.items():
+            try:
+                path.relative_to(project_root)
+            except ValueError:
+                continue
+            root_depth = len(project_root.parts)
+            if best_match is None or root_depth > best_match[1]:
+                best_match = (project_id, root_depth)
+        return best_match[0] if best_match is not None else None
+
+    def _schedule_project_refresh(self, project_id: str) -> None:
+        delay_seconds = max(0.0, self._config.watch_debounce_ms / 1000.0)
+        with self._debounce_lock:
+            previous = self._debounce_timers.get(project_id)
+            if previous is not None:
+                previous.cancel()
+            timer = threading.Timer(
+                delay_seconds,
+                self._flush_project_refresh,
+                args=(project_id,),
+            )
+            timer.daemon = True
+            self._debounce_timers[project_id] = timer
+            timer.start()
+
+    def _flush_project_refresh(self, project_id: str) -> None:
+        with self._debounce_lock:
+            self._debounce_timers.pop(project_id, None)
+        if self._stop_event.is_set():
+            return
+        event = self._store.refresh_project(project_id)
+        self._sync_project_roots()
+        self._install_watches()
+        if event is not None:
+            self._server.publish_events((event,))
+
+    def _publish_refresh(self, events: tuple[ChangeEvent, ...]) -> None:
+        self._sync_project_roots()
+        self._install_watches()
+        if events:
+            self._server.publish_events(events)
+
+    def _cancel_debounce_timers(self) -> None:
+        with self._debounce_lock:
+            timers = tuple(self._debounce_timers.values())
+            self._debounce_timers.clear()
+        for timer in timers:
+            timer.cancel()
+
+    def _shutdown(self) -> None:
+        self._stop_event.set()
+        self._cancel_debounce_timers()
+        self._watcher.stop()
+        self._server.stop()
+        if (
+            self._poll_thread is not None
+            and self._poll_thread.is_alive()
+            and threading.current_thread() is not self._poll_thread
+        ):
+            self._poll_thread.join(timeout=2.0)
+        if (
+            self._rescan_thread is not None
+            and self._rescan_thread.is_alive()
+            and threading.current_thread() is not self._rescan_thread
+        ):
+            self._rescan_thread.join(timeout=2.0)

--- a/paulsha_cortex/monitor/service.py
+++ b/paulsha_cortex/monitor/service.py
@@ -119,7 +119,10 @@ class ProjectMonitorService:
                     continue
                 seen.add(key)
                 desired_keys.append(key)
-        self._watched_paths.intersection_update(seen)
+        stale_keys = self._watched_paths - seen
+        for watch_path, recursive in stale_keys:
+            self._watcher.unwatch(watch_path, recursive=recursive)
+            self._watched_paths.remove((watch_path, recursive))
         for watch_path, recursive in desired_keys:
             watch_key = (watch_path, recursive)
             if watch_key in self._watched_paths:

--- a/paulsha_cortex/monitor/service.py
+++ b/paulsha_cortex/monitor/service.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from .config import MonitorConfig
 from .server import MonitorServer
 from .snapshot import ChangeEvent, SnapshotStore
-from .watcher import WatchdogFileWatcher, Watcher
+from .watcher import HAS_WATCHDOG, StubWatcher, WatchdogFileWatcher, Watcher
 
 
 class ProjectMonitorService:
@@ -27,9 +27,14 @@ class ProjectMonitorService:
     ) -> None:
         self._config = config
         self._store = store or SnapshotStore(config=config)
-        self._watcher = watcher or WatchdogFileWatcher(
-            debounce_ms=config.watch_debounce_ms
-        )
+        if watcher is not None:
+            self._watcher = watcher
+        elif HAS_WATCHDOG:
+            self._watcher = WatchdogFileWatcher(
+                debounce_ms=config.watch_debounce_ms
+            )
+        else:
+            self._watcher = StubWatcher()
         self._server = server or MonitorServer(
             store=self._store,
             socket_path=config.socket_path,
@@ -98,13 +103,29 @@ class ProjectMonitorService:
         }
 
     def _install_watches(self) -> None:
+        desired_keys: list[tuple[Path, bool]] = []
+        seen: set[tuple[Path, bool]] = set()
+        for workspace in self._config.workspaces:
+            if not workspace.path.exists():
+                continue
+            key = (workspace.path, False)
+            if key not in seen:
+                seen.add(key)
+                desired_keys.append(key)
         for project_root in self._project_roots.values():
             for watch_path, recursive in self._watch_specs(project_root):
-                watch_key = (watch_path, recursive)
-                if watch_key in self._watched_paths:
+                key = (watch_path, recursive)
+                if key in seen:
                     continue
-                self._watcher.watch(watch_path, self._handle_fs_event, recursive=recursive)
-                self._watched_paths.add(watch_key)
+                seen.add(key)
+                desired_keys.append(key)
+        self._watched_paths.intersection_update(seen)
+        for watch_path, recursive in desired_keys:
+            watch_key = (watch_path, recursive)
+            if watch_key in self._watched_paths:
+                continue
+            self._watcher.watch(watch_path, self._handle_fs_event, recursive=recursive)
+            self._watched_paths.add(watch_key)
 
     def _watch_specs(self, project_root: Path) -> tuple[tuple[Path, bool], ...]:
         specs: list[tuple[Path, bool]] = [(project_root, False)]

--- a/paulsha_cortex/monitor/service.py
+++ b/paulsha_cortex/monitor/service.py
@@ -44,6 +44,7 @@ class ProjectMonitorService:
         self._rescan_thread: threading.Thread | None = None
         self._debounce_lock = threading.Lock()
         self._debounce_timers: dict[str, threading.Timer] = {}
+        self._watch_state_lock = threading.RLock()
         self._project_roots: dict[str, Path] = {}
         self._watched_paths: set[tuple[Path, bool]] = set()
 
@@ -90,45 +91,48 @@ class ProjectMonitorService:
     def _rescan_loop(self) -> None:
         interval = max(0.1, float(self._config.rescan_interval_seconds))
         while not self._stop_event.wait(interval):
-            tracked_ids = tuple(self._project_roots)
+            with self._watch_state_lock:
+                tracked_ids = tuple(self._project_roots)
             if not tracked_ids:
                 continue
             self._publish_refresh(self._store.refresh_projects(tracked_ids))
 
     def _sync_project_roots(self) -> None:
-        self._project_roots = {
-            state.project_id: Path(state.path)
-            for state in self._store.current_snapshot()
-            if not state.legacy
-        }
+        with self._watch_state_lock:
+            self._project_roots = {
+                state.project_id: Path(state.path)
+                for state in self._store.current_snapshot()
+                if not state.legacy
+            }
 
     def _install_watches(self) -> None:
-        desired_keys: list[tuple[Path, bool]] = []
-        seen: set[tuple[Path, bool]] = set()
-        for workspace in self._config.workspaces:
-            if not workspace.path.exists():
-                continue
-            key = (workspace.path, False)
-            if key not in seen:
-                seen.add(key)
-                desired_keys.append(key)
-        for project_root in self._project_roots.values():
-            for watch_path, recursive in self._watch_specs(project_root):
-                key = (watch_path, recursive)
-                if key in seen:
+        with self._watch_state_lock:
+            desired_keys: list[tuple[Path, bool]] = []
+            seen: set[tuple[Path, bool]] = set()
+            for workspace in self._config.workspaces:
+                if not workspace.path.exists():
                     continue
-                seen.add(key)
-                desired_keys.append(key)
-        stale_keys = self._watched_paths - seen
-        for watch_path, recursive in stale_keys:
-            self._watcher.unwatch(watch_path, recursive=recursive)
-            self._watched_paths.remove((watch_path, recursive))
-        for watch_path, recursive in desired_keys:
-            watch_key = (watch_path, recursive)
-            if watch_key in self._watched_paths:
-                continue
-            self._watcher.watch(watch_path, self._handle_fs_event, recursive=recursive)
-            self._watched_paths.add(watch_key)
+                key = (workspace.path, False)
+                if key not in seen:
+                    seen.add(key)
+                    desired_keys.append(key)
+            for project_root in self._project_roots.values():
+                for watch_path, recursive in self._watch_specs(project_root):
+                    key = (watch_path, recursive)
+                    if key in seen:
+                        continue
+                    seen.add(key)
+                    desired_keys.append(key)
+            stale_keys = self._watched_paths - seen
+            for watch_path, recursive in stale_keys:
+                self._watcher.unwatch(watch_path, recursive=recursive)
+                self._watched_paths.discard((watch_path, recursive))
+            for watch_path, recursive in desired_keys:
+                watch_key = (watch_path, recursive)
+                if watch_key in self._watched_paths:
+                    continue
+                self._watcher.watch(watch_path, self._handle_fs_event, recursive=recursive)
+                self._watched_paths.add(watch_key)
 
     def _watch_specs(self, project_root: Path) -> tuple[tuple[Path, bool], ...]:
         specs: list[tuple[Path, bool]] = [(project_root, False)]
@@ -173,7 +177,9 @@ class ProjectMonitorService:
 
     def _project_id_for_path(self, path: Path) -> str | None:
         best_match: tuple[str, int] | None = None
-        for project_id, project_root in self._project_roots.items():
+        with self._watch_state_lock:
+            project_roots = tuple(self._project_roots.items())
+        for project_id, project_root in project_roots:
             try:
                 path.relative_to(project_root)
             except ValueError:

--- a/paulsha_cortex/monitor/snapshot.py
+++ b/paulsha_cortex/monitor/snapshot.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import threading
-from dataclasses import asdict, dataclass, field
+from dataclasses import asdict, dataclass, replace
 from pathlib import Path
 from typing import Iterable
 
@@ -16,6 +16,7 @@ class ChangeEvent:
     project_id: str
     sequence: int
     project_state: ProjectState
+    removed: bool = False
 
 
 def _project_signature(state: ProjectState) -> tuple:
@@ -66,15 +67,27 @@ class SnapshotStore:
     def refresh(self) -> tuple[ChangeEvent, ...]:
         """Re-scan all workspaces; emit one event per changed project."""
         with self._lock:
+            previous_states = self._states
+            previous_signatures = self._signatures
             new_states = {s.project_id: s for s in scan_workspaces(self._config)}
             new_signatures = {
                 project_id: _project_signature(state)
                 for project_id, state in new_states.items()
             }
             events: list[ChangeEvent] = []
+            for project_id in sorted(previous_states.keys() - new_states.keys()):
+                self._sequence += 1
+                events.append(
+                    ChangeEvent(
+                        project_id=project_id,
+                        sequence=self._sequence,
+                        project_state=previous_states[project_id],
+                        removed=True,
+                    )
+                )
             for project_id, state in new_states.items():
                 signature = new_signatures[project_id]
-                if self._signatures.get(project_id) != signature:
+                if previous_signatures.get(project_id) != signature:
                     self._sequence += 1
                     events.append(
                         ChangeEvent(
@@ -98,8 +111,18 @@ class SnapshotStore:
                 if not project_dir.is_dir():
                     self._states.pop(project_id, None)
                     self._signatures.pop(project_id, None)
+                    self._sequence += 1
+                    events.append(
+                        ChangeEvent(
+                            project_id=project_id,
+                            sequence=self._sequence,
+                            project_state=current,
+                            removed=True,
+                        )
+                    )
                     continue
                 state = extract_project_state(project_dir, workspace_name=current.workspace)
+                state = replace(state, project_id=current.project_id)
                 signature = _project_signature(state)
                 self._states[project_id] = state
                 if self._signatures.get(project_id) == signature:

--- a/paulsha_cortex/monitor/snapshot.py
+++ b/paulsha_cortex/monitor/snapshot.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import time
 import threading
 from dataclasses import asdict, dataclass, replace
 from pathlib import Path
@@ -8,7 +9,7 @@ from typing import Iterable
 from .config import MonitorConfig
 from .models import ProjectState
 from .parser import extract_project_state
-from .scanner import scan_workspaces
+from .scanner import ProjectClassification, classify_project, scan_workspaces
 
 
 @dataclass(frozen=True)
@@ -22,12 +23,11 @@ class ChangeEvent:
 def _project_signature(state: ProjectState) -> tuple:
     """Stable, comparable shape used to detect "anything changed" for a project.
 
-    We exclude `last_seen_at` and `source_signals` because they tick on every
-    refresh even when nothing meaningful changed.
+    We exclude only `last_seen_at`; diagnostics like `source_signals` are part
+    of the observable monitor state and must propagate to subscribers.
     """
     payload = asdict(state)
     payload.pop("last_seen_at", None)
-    payload.pop("source_signals", None)
     return _hashable(payload)
 
 
@@ -121,8 +121,31 @@ class SnapshotStore:
                         )
                     )
                     continue
-                state = extract_project_state(project_dir, workspace_name=current.workspace)
-                state = replace(state, project_id=current.project_id)
+                classification = classify_project(project_dir)
+                if classification == ProjectClassification.LEGACY:
+                    if self._config.legacy_policy == "hide":
+                        self._states.pop(project_id, None)
+                        self._signatures.pop(project_id, None)
+                        self._sequence += 1
+                        events.append(
+                            ChangeEvent(
+                                project_id=project_id,
+                                sequence=self._sequence,
+                                project_state=current,
+                                removed=True,
+                            )
+                        )
+                        continue
+                    state = ProjectState(
+                        project_id=current.project_id,
+                        workspace=current.workspace,
+                        path=str(project_dir),
+                        legacy=True,
+                        last_seen_at=time.time(),
+                    )
+                else:
+                    state = extract_project_state(project_dir, workspace_name=current.workspace)
+                    state = replace(state, project_id=current.project_id)
                 signature = _project_signature(state)
                 self._states[project_id] = state
                 if self._signatures.get(project_id) == signature:

--- a/paulsha_cortex/monitor/snapshot.py
+++ b/paulsha_cortex/monitor/snapshot.py
@@ -96,6 +96,8 @@ class SnapshotStore:
                     continue
                 project_dir = Path(current.path)
                 if not project_dir.is_dir():
+                    self._states.pop(project_id, None)
+                    self._signatures.pop(project_id, None)
                     continue
                 state = extract_project_state(project_dir, workspace_name=current.workspace)
                 signature = _project_signature(state)

--- a/paulsha_cortex/monitor/snapshot.py
+++ b/paulsha_cortex/monitor/snapshot.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import threading
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Iterable
+
+from .config import MonitorConfig
+from .models import ProjectState
+from .parser import extract_project_state
+from .scanner import scan_workspaces
+
+
+@dataclass(frozen=True)
+class ChangeEvent:
+    project_id: str
+    sequence: int
+    project_state: ProjectState
+
+
+def _project_signature(state: ProjectState) -> tuple:
+    """Stable, comparable shape used to detect "anything changed" for a project.
+
+    We exclude `last_seen_at` and `source_signals` because they tick on every
+    refresh even when nothing meaningful changed.
+    """
+    payload = asdict(state)
+    payload.pop("last_seen_at", None)
+    payload.pop("source_signals", None)
+    return _hashable(payload)
+
+
+def _hashable(value):
+    if isinstance(value, dict):
+        return tuple(sorted((k, _hashable(v)) for k, v in value.items()))
+    if isinstance(value, (list, tuple)):
+        return tuple(_hashable(v) for v in value)
+    return value
+
+
+class SnapshotStore:
+    """In-memory truth for project states + diff + sequence emission.
+
+    Thread-safe; intended to be shared between the scanner loop, the watcher
+    callback, and the socket server.
+    """
+
+    def __init__(self, *, config: MonitorConfig) -> None:
+        self._config = config
+        self._lock = threading.RLock()
+        self._states: dict[str, ProjectState] = {}
+        self._signatures: dict[str, tuple] = {}
+        self._sequence = 0
+
+    def load(self) -> tuple[ChangeEvent, ...]:
+        """Initial population. Returns no events; consumers fetch the
+        snapshot directly via `current_snapshot()` to bootstrap."""
+        with self._lock:
+            self._states.clear()
+            self._signatures.clear()
+            for state in scan_workspaces(self._config):
+                self._states[state.project_id] = state
+                self._signatures[state.project_id] = _project_signature(state)
+        return ()
+
+    def refresh(self) -> tuple[ChangeEvent, ...]:
+        """Re-scan all workspaces; emit one event per changed project."""
+        with self._lock:
+            new_states = {s.project_id: s for s in scan_workspaces(self._config)}
+            new_signatures = {
+                project_id: _project_signature(state)
+                for project_id, state in new_states.items()
+            }
+            events: list[ChangeEvent] = []
+            for project_id, state in new_states.items():
+                signature = new_signatures[project_id]
+                if self._signatures.get(project_id) != signature:
+                    self._sequence += 1
+                    events.append(
+                        ChangeEvent(
+                            project_id=project_id,
+                            sequence=self._sequence,
+                            project_state=state,
+                        )
+                    )
+            self._states = new_states
+            self._signatures = new_signatures
+            return tuple(events)
+
+    def refresh_projects(self, project_ids: Iterable[str]) -> tuple[ChangeEvent, ...]:
+        with self._lock:
+            events: list[ChangeEvent] = []
+            for project_id in project_ids:
+                current = self._states.get(project_id)
+                if current is None or current.legacy:
+                    continue
+                project_dir = Path(current.path)
+                if not project_dir.is_dir():
+                    continue
+                state = extract_project_state(project_dir, workspace_name=current.workspace)
+                signature = _project_signature(state)
+                self._states[project_id] = state
+                if self._signatures.get(project_id) == signature:
+                    continue
+                self._signatures[project_id] = signature
+                self._sequence += 1
+                events.append(
+                    ChangeEvent(
+                        project_id=project_id,
+                        sequence=self._sequence,
+                        project_state=state,
+                    )
+                )
+            return tuple(events)
+
+    def refresh_project(self, project_id: str) -> ChangeEvent | None:
+        """Re-scan a single project (used after a debounced watcher fire)."""
+        events = self.refresh_projects((project_id,))
+        for evt in events:
+            if evt.project_id == project_id:
+                return evt
+        return None
+
+    def current_snapshot(self) -> tuple[ProjectState, ...]:
+        with self._lock:
+            return tuple(self._states.values())
+
+    def get(self, project_id: str) -> ProjectState | None:
+        with self._lock:
+            return self._states.get(project_id)
+
+    @property
+    def sequence(self) -> int:
+        with self._lock:
+            return self._sequence

--- a/paulsha_cortex/monitor/watcher.py
+++ b/paulsha_cortex/monitor/watcher.py
@@ -26,6 +26,8 @@ class Watcher(Protocol):
         recursive: bool = True,
     ) -> None: ...
 
+    def unwatch(self, path: Path, *, recursive: bool = True) -> None: ...
+
     def stop(self) -> None: ...
 
 
@@ -50,6 +52,14 @@ class StubWatcher:
         recursive: bool = True,
     ) -> None:
         self._subscriptions.append((Path(path), callback, recursive))
+
+    def unwatch(self, path: Path, *, recursive: bool = True) -> None:
+        target = Path(path)
+        self._subscriptions = [
+            entry
+            for entry in self._subscriptions
+            if not (entry[0] == target and entry[2] == recursive)
+        ]
 
     def trigger(self, path: Path) -> None:
         if self._stopped:
@@ -138,8 +148,6 @@ if HAS_WATCHDOG:
             return path == self._watch_path or path.parent == self._watch_path
 
         def on_any_event(self, event: FileSystemEvent) -> None:
-            if event.is_directory:
-                return
             for raw_path in (
                 event.src_path,
                 getattr(event, "dest_path", ""),
@@ -166,6 +174,7 @@ if HAS_WATCHDOG:
         def __init__(self, *, debounce_ms: int = 500) -> None:
             self._observer = Observer()
             self._handlers: list[_DebouncedHandler] = []
+            self._watches: dict[tuple[Path, bool], tuple[_DebouncedHandler, object]] = {}
             self._debounce_seconds = max(0.0, debounce_ms / 1000.0)
             self._started = False
             self._stopped = False
@@ -180,6 +189,9 @@ if HAS_WATCHDOG:
             if self._stopped:
                 raise RuntimeError("watcher is stopped")
             watch_path = Path(path)
+            watch_key = (watch_path, recursive)
+            if watch_key in self._watches:
+                return
             observer_root = watch_path.parent if watch_path.is_file() else watch_path
             handler = _DebouncedHandler(
                 watch_path=watch_path,
@@ -188,10 +200,25 @@ if HAS_WATCHDOG:
                 recursive=recursive,
             )
             self._handlers.append(handler)
-            self._observer.schedule(handler, str(observer_root), recursive=recursive)
+            watch = self._observer.schedule(handler, str(observer_root), recursive=recursive)
+            self._watches[watch_key] = (handler, watch)
             if not self._started:
                 self._observer.start()
                 self._started = True
+
+        def unwatch(self, path: Path, *, recursive: bool = True) -> None:
+            watch_key = (Path(path), recursive)
+            pair = self._watches.pop(watch_key, None)
+            if pair is None:
+                return
+            handler, watch = pair
+            handler.cancel()
+            self._handlers = [item for item in self._handlers if item is not handler]
+            if self._started:
+                try:
+                    self._observer.unschedule(watch)
+                except Exception:  # pragma: no cover
+                    pass
 
         def stop(self) -> None:
             self._stopped = True
@@ -204,6 +231,7 @@ if HAS_WATCHDOG:
                 except Exception:  # pragma: no cover
                     pass
                 self._started = False
+            self._watches.clear()
             self._handlers.clear()
 
 else:  # pragma: no cover - exercised only when watchdog missing
@@ -216,6 +244,9 @@ else:  # pragma: no cover - exercised only when watchdog missing
 
         def watch(self, path, callback) -> None:  # noqa: D401
             raise RuntimeError("watchdog not available")
+
+        def unwatch(self, path, *, recursive: bool = True) -> None:
+            return None
 
         def stop(self) -> None:
             return None

--- a/paulsha_cortex/monitor/watcher.py
+++ b/paulsha_cortex/monitor/watcher.py
@@ -1,0 +1,221 @@
+"""Filesystem watching abstraction (design §4 decision #2).
+
+Watcher is the public Protocol; consumers depend on it, not on watchdog.
+We ship two impls:
+
+  * StubWatcher       — pure-Python, manual `trigger(path)` for tests.
+  * WatchdogFileWatcher — production impl wrapping watchdog.observers.Observer
+                           with a debounce window so bursts coalesce.
+"""
+
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+from typing import Callable, Iterable, Protocol
+
+WatcherCallback = Callable[[Path], None]
+
+
+class Watcher(Protocol):
+    def watch(
+        self,
+        path: Path,
+        callback: WatcherCallback,
+        *,
+        recursive: bool = True,
+    ) -> None: ...
+
+    def stop(self) -> None: ...
+
+
+class StubWatcher:
+    """In-process watcher used by tests; events fire only when `trigger`
+    is called explicitly. Mirrors the Watcher Protocol so consumers can
+    swap it in for production."""
+
+    def __init__(self) -> None:
+        self._subscriptions: list[tuple[Path, WatcherCallback, bool]] = []
+        self._stopped = False
+
+    @property
+    def subscriptions(self) -> tuple[tuple[Path, WatcherCallback, bool], ...]:
+        return tuple(self._subscriptions)
+
+    def watch(
+        self,
+        path: Path,
+        callback: WatcherCallback,
+        *,
+        recursive: bool = True,
+    ) -> None:
+        self._subscriptions.append((Path(path), callback, recursive))
+
+    def trigger(self, path: Path) -> None:
+        if self._stopped:
+            return
+        target = Path(path)
+        for watched_path, callback, recursive in list(self._subscriptions):
+            if watched_path == target:
+                callback(target)
+                continue
+            if watched_path.exists() and watched_path.is_file():
+                continue
+            if recursive:
+                try:
+                    target.relative_to(watched_path)
+                except ValueError:
+                    continue
+                callback(target)
+                continue
+            if target.parent == watched_path:
+                callback(target)
+
+    def stop(self) -> None:
+        self._stopped = True
+        self._subscriptions.clear()
+
+
+# --- watchdog adapter -----------------------------------------------------
+
+try:
+    from watchdog.events import FileSystemEvent, FileSystemEventHandler
+    from watchdog.observers import Observer
+
+    HAS_WATCHDOG = True
+except ImportError:  # pragma: no cover - guard for environments without watchdog
+    HAS_WATCHDOG = False
+
+
+if HAS_WATCHDOG:
+
+    class _DebouncedHandler(FileSystemEventHandler):
+        def __init__(
+            self,
+            *,
+            watch_path: Path,
+            callback: WatcherCallback,
+            debounce_seconds: float,
+            recursive: bool,
+        ) -> None:
+            super().__init__()
+            self._watch_path = watch_path
+            self._callback = callback
+            self._debounce = debounce_seconds
+            self._recursive = recursive
+            self._lock = threading.Lock()
+            self._timer: threading.Timer | None = None
+            self._latest_path: Path | None = None
+
+        def _flush(self) -> None:
+            with self._lock:
+                path = self._latest_path or self._watch_path
+                self._timer = None
+                self._latest_path = None
+            try:
+                self._callback(path)
+            except Exception:  # pragma: no cover - defensive
+                pass
+
+        def _schedule(self, path: Path) -> None:
+            with self._lock:
+                self._latest_path = path
+                if self._timer is not None:
+                    self._timer.cancel()
+                self._timer = threading.Timer(self._debounce, self._flush)
+                self._timer.daemon = True
+                self._timer.start()
+
+        def _matches(self, path: Path) -> bool:
+            if self._watch_path.is_file():
+                return path == self._watch_path
+            if self._recursive:
+                try:
+                    path.relative_to(self._watch_path)
+                except ValueError:
+                    return False
+                return True
+            return path == self._watch_path or path.parent == self._watch_path
+
+        def on_any_event(self, event: FileSystemEvent) -> None:
+            if event.is_directory:
+                return
+            for raw_path in (
+                event.src_path,
+                getattr(event, "dest_path", ""),
+            ):
+                if not raw_path:
+                    continue
+                try:
+                    path = Path(raw_path)
+                except Exception:  # pragma: no cover
+                    continue
+                if self._matches(path):
+                    self._schedule(path)
+                    return
+
+        def cancel(self) -> None:
+            with self._lock:
+                if self._timer is not None:
+                    self._timer.cancel()
+                    self._timer = None
+
+    class WatchdogFileWatcher:
+        """Production Watcher backed by watchdog with a debounce window."""
+
+        def __init__(self, *, debounce_ms: int = 500) -> None:
+            self._observer = Observer()
+            self._handlers: list[_DebouncedHandler] = []
+            self._debounce_seconds = max(0.0, debounce_ms / 1000.0)
+            self._started = False
+            self._stopped = False
+
+        def watch(
+            self,
+            path: Path,
+            callback: WatcherCallback,
+            *,
+            recursive: bool = True,
+        ) -> None:
+            if self._stopped:
+                raise RuntimeError("watcher is stopped")
+            watch_path = Path(path)
+            observer_root = watch_path.parent if watch_path.is_file() else watch_path
+            handler = _DebouncedHandler(
+                watch_path=watch_path,
+                callback=callback,
+                debounce_seconds=self._debounce_seconds,
+                recursive=recursive,
+            )
+            self._handlers.append(handler)
+            self._observer.schedule(handler, str(observer_root), recursive=recursive)
+            if not self._started:
+                self._observer.start()
+                self._started = True
+
+        def stop(self) -> None:
+            self._stopped = True
+            for handler in self._handlers:
+                handler.cancel()
+            if self._started:
+                try:
+                    self._observer.stop()
+                    self._observer.join(timeout=2.0)
+                except Exception:  # pragma: no cover
+                    pass
+                self._started = False
+            self._handlers.clear()
+
+else:  # pragma: no cover - exercised only when watchdog missing
+
+    class WatchdogFileWatcher:  # type: ignore[no-redef]
+        def __init__(self, *args, **kwargs) -> None:
+            raise RuntimeError(
+                "watchdog is not installed; install requirements-stage9.txt"
+            )
+
+        def watch(self, path, callback) -> None:  # noqa: D401
+            raise RuntimeError("watchdog not available")
+
+        def stop(self) -> None:
+            return None

--- a/paulsha_cortex/persona/loader.py
+++ b/paulsha_cortex/persona/loader.py
@@ -4,6 +4,8 @@ from pathlib import Path
 from typing import Mapping
 import warnings
 
+from paulsha_cortex.deck.schema import DeckSchemaError, DEFAULT_CARDS_PATH, load_cards
+
 from .._yaml import YAMLError, safe_load
 from .contract import PersonaContract, validate_persona_schema
 
@@ -71,11 +73,7 @@ def load_catalog(path: str | Path | None = None) -> dict[str, PersonaContract]:
 
 
 def _warn_unknown_skills(catalog: dict[str, PersonaContract]) -> None:
-    """shadow 驗證：fail-open 僅限 deck 缺席；壞目錄要警示、邏輯 bug 不吞。"""
-    try:
-        from paulshaclaw.deck.schema import DeckSchemaError, DEFAULT_CARDS_PATH, load_cards
-    except ImportError:
-        return  # deck 套件缺席（如未來拆包）→ 靜默跳過
+    """shadow 驗證：deck 已同包，僅 deck schema 錯誤維持 warning。"""
     try:
         cards = load_cards(DEFAULT_CARDS_PATH)
     except DeckSchemaError as exc:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ where = ["."]
 include = ["paulsha_cortex*"]
 
 [tool.setuptools.package-data]
+"paulsha_cortex.deck" = ["data/*.yaml", "data/combos/*.yaml"]
 "paulsha_cortex.deploy" = ["templates/*.tmpl"]
 "paulsha_cortex" = [
     "persona/personas.yaml",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "paulsha-cortex"
 dynamic = ["version"]
 requires-python = ">=3.10"
 description = "agent 治理平面：manager 派工 + persona 護欄 + control 檔案契約"
-dependencies = []
+dependencies = ["PyYAML>=6"]
 
 [project.scripts]
 cortex = "paulsha_cortex.cli:main"

--- a/tests/test_cli_entry.py
+++ b/tests/test_cli_entry.py
@@ -64,3 +64,27 @@ def test_relay_hook_falls_back_to_bash_when_not_executable(monkeypatch, tmp_path
     # 先試直接 exec（失敗），再 fallback 到 env bash 讀取執行
     assert calls[0][0] == str(script)
     assert calls[1] == ("/usr/bin/env", ["env", "bash", str(script), "--flag"])
+
+
+def test_routes_deck(monkeypatch):
+    seen = {}
+
+    def fake(argv=None):
+        seen["argv"] = list(argv or [])
+        return 0
+
+    monkeypatch.setattr("paulsha_cortex.deck.cli.main", fake)
+    assert main(["deck", "verify", "--change", "x"]) == 0
+    assert seen["argv"] == ["verify", "--change", "x"]
+
+
+def test_routes_monitor(monkeypatch):
+    seen = {}
+
+    def fake(argv=None):
+        seen["argv"] = list(argv or [])
+        return 0
+
+    monkeypatch.setattr("paulsha_cortex.monitor.__main__.main", fake)
+    assert main(["monitor", "--once"]) == 0
+    assert seen["argv"] == ["--once"]

--- a/tests/test_deck_cli.py
+++ b/tests/test_deck_cli.py
@@ -1,0 +1,218 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from paulsha_cortex.deck import cli as deck_cli
+
+CARDS_YAML = """\
+version: 0
+cards:
+  - id: brainstorming
+    kind: skill
+    type: interactive
+    class: core
+    skill_ref: "superpowers:brainstorming"
+    requires: []
+    produces: ["docs/superpowers/specs/*<task-slug>*-design.md"]
+    persona_binding: planner
+  - id: openspec-propose
+    kind: skill
+    type: interactive
+    class: core
+    skill_ref: "openspec-propose"
+    requires: ["docs/superpowers/specs/*<task-slug>*-design.md"]
+    produces:
+      - "openspec/changes/<change>/proposal.md"
+      - "openspec/changes/<change>/tasks.md"
+    persona_binding: planner
+  - id: writing-plans
+    kind: skill
+    type: interactive
+    class: core
+    skill_ref: "superpowers:writing-plans"
+    requires: ["openspec/changes/<change>/proposal.md"]
+    produces: ["docs/superpowers/plans/*<task-slug>*.md"]
+    persona_binding: planner
+  - id: worktree-isolation
+    kind: skill
+    type: headless
+    class: core
+    skill_ref: "superpowers:using-git-worktrees"
+    slice_group: build
+    requires: ["docs/superpowers/plans/*<task-slug>*.md"]
+    produces: []
+    persona_binding: builder
+  - id: tdd-red
+    kind: skill
+    type: headless
+    class: core
+    skill_ref: "superpowers:test-driven-development"
+    slice_group: build
+    requires: []
+    produces: []
+    persona_binding: builder
+  - id: subagent-build
+    kind: skill
+    type: headless
+    class: core
+    skill_ref: "superpowers:subagent-driven-development"
+    slice_group: build
+    requires: []
+    produces: []
+    persona_binding: builder
+  - id: code-review
+    kind: skill
+    type: headless
+    class: core
+    skill_ref: "superpowers:requesting-code-review"
+    requires: []
+    produces: ["reports/review/*<task-slug>*.md"]
+    persona_binding: reviewer
+  - id: verification
+    kind: skill
+    type: headless
+    class: core
+    skill_ref: "superpowers:verification-before-completion"
+    requires: []
+    produces: ["reports/verify/*<task-slug>*.md"]
+    persona_binding: reviewer
+  - id: openspec-archive
+    kind: skill
+    type: headless
+    class: core
+    skill_ref: "openspec-archive-change"
+    slice_group: ship
+    requires: ["openspec/changes/<change>/tasks.md"]
+    produces: ["openspec/changes/archive/*<change>*"]
+    persona_binding: manager
+  - id: policy-commit
+    kind: skill
+    type: headless
+    class: core
+    skill_ref: "conventional-commit"
+    slice_group: ship
+    requires: []
+    produces: []
+    persona_binding: manager
+  - id: adversarial-review
+    kind: skill
+    type: headless
+    class: core
+    skill_ref: "codex:adversarial-review"
+    requires: ["reports/review/*<task-slug>*.md"]
+    produces: ["reports/review/*<task-slug>*-adversarial.md"]
+    persona_binding: reviewer
+  - id: mcu-hw-evidence
+    kind: skill
+    type: interactive
+    class: niche
+    skill_ref: "mcu-coding-skill"
+    requires: []
+    produces: ["docs/superpowers/specs/*<task-slug>*-hw-evidence.md"]
+    persona_binding: planner
+"""
+
+FEATURE_ONESHOT_YAML = """\
+combo:
+  id: feature-oneshot
+  task_type: feature
+  cards:
+    - ref: brainstorming
+    - ref: openspec-propose
+    - ref: writing-plans
+    - ref: worktree-isolation
+    - ref: tdd-red
+    - ref: subagent-build
+    - ref: code-review
+    - ref: verification
+    - ref: openspec-archive
+    - ref: policy-commit
+    - ref: adversarial-review
+  gate_spine:
+    - after: writing-plans
+      exists: ["docs/superpowers/plans/*<task-slug>*.md"]
+    - after: code-review
+      exists: ["reports/review/*<task-slug>*.md"]
+"""
+
+MCU_FEATURE_YAML = """\
+combo:
+  id: mcu-feature
+  task_type: mcu-feature
+  cards:
+    - ref: mcu-hw-evidence
+    - ref: writing-plans
+    - ref: worktree-isolation
+    - ref: tdd-red
+    - ref: subagent-build
+    - ref: code-review
+    - ref: verification
+  gate_spine:
+    - after: mcu-hw-evidence
+      exists: ["docs/superpowers/specs/*<task-slug>*-hw-evidence.md"]
+"""
+
+
+def _seed_fixture(tmp_path: Path, monkeypatch):
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    cards_path = tmp_path / "cards.yaml"
+    combos_dir = tmp_path / "combos"
+    cards_path.write_text(CARDS_YAML, encoding="utf-8")
+    combos_dir.mkdir()
+    (combos_dir / "feature-oneshot.yaml").write_text(FEATURE_ONESHOT_YAML, encoding="utf-8")
+    (combos_dir / "mcu-feature.yaml").write_text(MCU_FEATURE_YAML, encoding="utf-8")
+    monkeypatch.setattr(deck_cli, "DEFAULT_CARDS_PATH", cards_path)
+    monkeypatch.setattr(deck_cli, "DEFAULT_COMBOS_DIR", combos_dir)
+    return cards_path, combos_dir
+
+
+def test_list_shows_combos(tmp_path, capsys, monkeypatch):
+    _seed_fixture(tmp_path, monkeypatch)
+    assert deck_cli.main(["list"]) == 0
+    out = capsys.readouterr().out
+    assert "feature-oneshot" in out and "mcu-feature" in out
+
+
+def test_compile_dry_run_writes_nothing(tmp_path, capsys, monkeypatch):
+    _seed_fixture(tmp_path / "deck", monkeypatch)
+    specs_root = tmp_path / "specs"
+    specs_root.mkdir()
+    monkeypatch.setenv("PSC_MANAGER_SPECS_DIR", str(specs_root))
+    rc = deck_cli.main(["compile", "feature-oneshot", "--task", "demo task", "--change", "demo", "--allow-external"])
+    assert rc == 0
+    assert list(specs_root.iterdir()) == []
+    assert "dispatch: hold" in capsys.readouterr().out
+
+
+def test_compile_emit_writes_hold_specs(tmp_path, monkeypatch):
+    _seed_fixture(tmp_path / "deck", monkeypatch)
+    specs_root = tmp_path / "specs"
+    monkeypatch.setenv("PSC_MANAGER_SPECS_DIR", str(specs_root))
+    rc = deck_cli.main(
+        ["compile", "feature-oneshot", "--task", "demo task", "--change", "demo", "--allow-external", "--emit"]
+    )
+    assert rc == 0
+    files = sorted(specs_root.glob("*.md"))
+    assert files
+    assert all("dispatch: hold" in path.read_text(encoding="utf-8") for path in files)
+
+
+def test_compile_out_file_path_reports_error(tmp_path, capsys, monkeypatch):
+    _seed_fixture(tmp_path / "deck", monkeypatch)
+    out_file = tmp_path / "not-a-dir"
+    out_file.write_text("occupied", encoding="utf-8")
+    rc = deck_cli.main(
+        [
+            "compile",
+            "feature-oneshot",
+            "--task",
+            "demo task",
+            "--change",
+            "demo",
+            "--allow-external",
+            "--out",
+            str(out_file),
+        ]
+    )
+    assert rc == 1
+    assert "deck:" in capsys.readouterr().err

--- a/tests/test_deck_cli.py
+++ b/tests/test_deck_cli.py
@@ -184,6 +184,15 @@ def test_compile_dry_run_writes_nothing(tmp_path, capsys, monkeypatch):
     assert "dispatch: hold" in capsys.readouterr().out
 
 
+def test_compile_dry_run_without_change_still_loads_default_data(tmp_path, capsys, monkeypatch):
+    _seed_fixture(tmp_path / "deck", monkeypatch)
+    rc = deck_cli.main(["compile", "feature-oneshot", "--task", "demo task"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "task-slug: demo-task" in out
+    assert "dispatch: hold" in out
+
+
 def test_compile_emit_writes_hold_specs(tmp_path, monkeypatch):
     _seed_fixture(tmp_path / "deck", monkeypatch)
     specs_root = tmp_path / "specs"

--- a/tests/test_deck_cli.py
+++ b/tests/test_deck_cli.py
@@ -225,3 +225,10 @@ def test_compile_out_file_path_reports_error(tmp_path, capsys, monkeypatch):
     )
     assert rc == 1
     assert "deck:" in capsys.readouterr().err
+
+
+def test_verify_missing_change_returns_cli_error(tmp_path, capsys, monkeypatch):
+    _seed_fixture(tmp_path / "deck", monkeypatch)
+    rc = deck_cli.main(["verify", "openspec-archive", "--task-slug", "demo-task"])
+    assert rc == 1
+    assert "deck:" in capsys.readouterr().err

--- a/tests/test_deck_compile.py
+++ b/tests/test_deck_compile.py
@@ -1,0 +1,549 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from paulsha_cortex.deck.compile import (
+    CompileResult,
+    DeckCompileError,
+    SliceDoc,
+    compile_combo,
+    emit,
+    parse_with_spec,
+    slugify_task,
+    specs_dir,
+)
+from paulsha_cortex.deck.schema import load_cards, load_combo
+
+CARDS_YAML = """\
+version: 0
+cards:
+  - id: brainstorming
+    kind: skill
+    type: interactive
+    class: core
+    skill_ref: "superpowers:brainstorming"
+    requires: []
+    produces: ["docs/superpowers/specs/*<task-slug>*-design.md"]
+    persona_binding: planner
+  - id: openspec-propose
+    kind: skill
+    type: interactive
+    class: core
+    skill_ref: "openspec-propose"
+    requires: ["docs/superpowers/specs/*<task-slug>*-design.md"]
+    produces:
+      - "openspec/changes/<change>/proposal.md"
+      - "openspec/changes/<change>/tasks.md"
+    persona_binding: planner
+  - id: writing-plans
+    kind: skill
+    type: interactive
+    class: core
+    skill_ref: "superpowers:writing-plans"
+    requires: ["openspec/changes/<change>/proposal.md"]
+    produces: ["docs/superpowers/plans/*<task-slug>*.md"]
+    persona_binding: planner
+  - id: worktree-isolation
+    kind: skill
+    type: headless
+    class: core
+    skill_ref: "superpowers:using-git-worktrees"
+    slice_group: build
+    requires: ["docs/superpowers/plans/*<task-slug>*.md"]
+    produces: []
+    persona_binding: builder
+  - id: tdd-red
+    kind: skill
+    type: headless
+    class: core
+    skill_ref: "superpowers:test-driven-development"
+    slice_group: build
+    requires: []
+    produces: []
+    persona_binding: builder
+  - id: subagent-build
+    kind: skill
+    type: headless
+    class: core
+    skill_ref: "superpowers:subagent-driven-development"
+    slice_group: build
+    requires: []
+    produces: []
+    persona_binding: builder
+  - id: code-review
+    kind: skill
+    type: headless
+    class: core
+    skill_ref: "superpowers:requesting-code-review"
+    requires: []
+    produces: ["reports/review/*<task-slug>*.md"]
+    persona_binding: reviewer
+  - id: verification
+    kind: skill
+    type: headless
+    class: core
+    skill_ref: "superpowers:verification-before-completion"
+    requires: []
+    produces: ["reports/verify/*<task-slug>*.md"]
+    persona_binding: reviewer
+  - id: openspec-archive
+    kind: skill
+    type: headless
+    class: core
+    skill_ref: "openspec-archive-change"
+    slice_group: ship
+    requires: ["openspec/changes/<change>/tasks.md"]
+    produces: ["openspec/changes/archive/*<change>*"]
+    persona_binding: manager
+  - id: policy-commit
+    kind: skill
+    type: headless
+    class: core
+    skill_ref: "conventional-commit"
+    slice_group: ship
+    requires: []
+    produces: []
+    persona_binding: manager
+  - id: adversarial-review
+    kind: skill
+    type: headless
+    class: core
+    skill_ref: "codex:adversarial-review"
+    requires: ["reports/review/*<task-slug>*.md"]
+    produces: ["reports/review/*<task-slug>*-adversarial.md"]
+    persona_binding: reviewer
+  - id: mcu-hw-evidence
+    kind: skill
+    type: interactive
+    class: niche
+    skill_ref: "mcu-coding-skill"
+    requires: []
+    produces: ["docs/superpowers/specs/*<task-slug>*-hw-evidence.md"]
+    persona_binding: planner
+"""
+
+FEATURE_ONESHOT_YAML = """\
+combo:
+  id: feature-oneshot
+  task_type: feature
+  cards:
+    - ref: brainstorming
+    - ref: openspec-propose
+    - ref: writing-plans
+    - ref: worktree-isolation
+    - ref: tdd-red
+    - ref: subagent-build
+    - ref: code-review
+    - ref: verification
+    - ref: openspec-archive
+    - ref: policy-commit
+    - ref: adversarial-review
+  gate_spine:
+    - after: writing-plans
+      exists: ["docs/superpowers/plans/*<task-slug>*.md"]
+    - after: code-review
+      exists: ["reports/review/*<task-slug>*.md"]
+"""
+
+SOLO_ADV_COMBO = """\
+combo:
+  id: solo-adv
+  task_type: feature
+  cards:
+    - ref: adversarial-review
+"""
+
+SPLIT_BUILD_COMBO = """\
+combo:
+  id: split-build
+  task_type: feature
+  cards:
+    - ref: brainstorming
+    - ref: openspec-propose
+    - ref: writing-plans
+    - ref: worktree-isolation
+    - ref: code-review
+    - ref: tdd-red
+"""
+
+
+def _write(tmp_path, name: str, text: str):
+    path = tmp_path / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def _feature_oneshot(tmp_path):
+    cards = load_cards(_write(tmp_path, "cards.yaml", CARDS_YAML))
+    combo = load_combo(_write(tmp_path, "feature-oneshot.yaml", FEATURE_ONESHOT_YAML), cards)
+    return cards, combo
+
+
+def _solo_adv(tmp_path):
+    cards = load_cards(_write(tmp_path, "cards.yaml", CARDS_YAML))
+    combo = load_combo(_write(tmp_path, "solo-adv.yaml", SOLO_ADV_COMBO), cards)
+    return cards, combo
+
+
+def test_slugify_basic():
+    assert slugify_task("Add LED Blink Mode!") == "add-led-blink-mode"
+
+
+def test_slugify_length_cap_60():
+    assert len(slugify_task("x" * 200)) <= 60
+
+
+def test_slugify_empty_rejected():
+    with pytest.raises(DeckCompileError):
+        slugify_task("！！！")
+
+
+def test_specs_dir_env_override(monkeypatch, tmp_path):
+    monkeypatch.setenv("PSC_MANAGER_SPECS_DIR", str(tmp_path))
+    assert specs_dir() == tmp_path
+
+
+def test_specs_dir_equals_manager_default(monkeypatch):
+    from paulsha_cortex.coordinator.manager_daemon import default_specs_dir
+
+    monkeypatch.delenv("PSC_MANAGER_SPECS_DIR", raising=False)
+    assert str(specs_dir()) == default_specs_dir()
+
+
+def test_compile_slice_grouping_and_chain(tmp_path):
+    cards, combo = _feature_oneshot(tmp_path)
+    result = compile_combo(combo, cards, "示例 LED 功能", change="demo", allow_external=True)
+    ids = [slice_doc.slice_id for slice_doc in result.slices]
+    slug = result.task_slug
+    assert ids == [
+        f"{slug}-build",
+        f"{slug}-code-review",
+        f"{slug}-verification",
+        f"{slug}-ship",
+        f"{slug}-adversarial-review",
+    ]
+    assert len(result.checklist) == 3
+
+
+def test_compile_frontmatter_hold_and_chain(tmp_path):
+    cards, combo = _feature_oneshot(tmp_path)
+    result = compile_combo(combo, cards, "示例 LED 功能", change="demo", allow_external=True)
+    first = result.slices[0].content
+    assert first.startswith("---\n")
+    assert "dispatch: hold" in first
+    second = result.slices[1].content
+    assert f"- {result.task_slug}-build" in second
+
+
+def test_compile_missing_change_placeholder_errors(tmp_path):
+    cards, combo = _feature_oneshot(tmp_path)
+    with pytest.raises(DeckCompileError, match="--change"):
+        compile_combo(combo, cards, "示例 LED 功能", allow_external=True)
+
+
+def test_compile_frontmatter_exact_keyset(tmp_path):
+    from paulsha_cortex.deck.schema import EMITTED_FRONTMATTER_FIELDS
+
+    cards, combo = _feature_oneshot(tmp_path)
+    result = compile_combo(combo, cards, "示例 LED 功能", change="demo", allow_external=True)
+    for slice_doc in result.slices:
+        block = slice_doc.content.split("---\n")[1]
+        assert set(yaml.safe_load(block)) == set(EMITTED_FRONTMATTER_FIELDS)
+
+
+def test_requires_uncovered_blocks_without_allow_external(tmp_path):
+    cards, combo = _solo_adv(tmp_path)
+    with pytest.raises(DeckCompileError, match="allow-external"):
+        compile_combo(combo, cards, "demo task", change="demo", plan_ref="docs/plan.md")
+
+
+def test_requires_external_allowed_and_reported(tmp_path):
+    cards, combo = _solo_adv(tmp_path)
+    result = compile_combo(
+        combo,
+        cards,
+        "demo task",
+        change="demo",
+        allow_external=True,
+        plan_ref="docs/plan.md",
+    )
+    assert result.external
+
+
+def test_requires_prefix_coverage_accepts_deeper_produce(tmp_path):
+    # 對抗審查修正（C1）：spec §5.5 為互為前綴覆蓋——produce 前綴較深仍覆蓋 require
+    cards_yaml = CARDS_YAML.replace(
+        'produces: ["reports/review/*<task-slug>*.md"]',
+        'produces: ["reports/review/archive/*<task-slug>*.md"]',
+    )
+    cards = load_cards(_write(tmp_path, "cards.yaml", cards_yaml))
+    combo = load_combo(_write(tmp_path, "feature-oneshot.yaml", FEATURE_ONESHOT_YAML), cards)
+    result = compile_combo(combo, cards, "demo task", change="demo")
+    assert result.external == ()
+
+
+def test_full_combo_compiles_without_allow_external(tmp_path):
+    # 對抗審查修正（C1）：正確覆蓋語意下，feature-oneshot 全鏈 requires 皆被上游覆蓋
+    cards, combo = _feature_oneshot(tmp_path)
+    result = compile_combo(combo, cards, "demo task", change="demo")
+    assert result.external == ()
+
+
+def test_with_inference_success_inserts_after_coverage_point(tmp_path):
+    # 對抗審查修正（C1 正向案例）：--with 未定位但 requires 可被覆蓋證明 → 自動插入
+    cards = load_cards(_write(tmp_path, "cards.yaml", CARDS_YAML))
+    combo_yaml = """\
+combo:
+  id: mini
+  task_type: feature
+  cards:
+    - ref: brainstorming
+"""
+    combo = load_combo(_write(tmp_path, "mini.yaml", combo_yaml), cards)
+    result = compile_combo(
+        combo, cards, "demo task", change="demo", with_cards=("openspec-propose",)
+    )
+    assert [line.split("]")[0].lstrip("[") for line in result.checklist] == [
+        "brainstorming",
+        "openspec-propose",
+    ]
+
+
+def test_slice_id_path_separator_rejected(tmp_path):
+    # 對抗審查修正（C4）：slice_group 含路徑分隔不得寫出子目錄檔名
+    cards_yaml = CARDS_YAML.replace("slice_group: ship", "slice_group: evil/ship")
+    cards = load_cards(_write(tmp_path, "cards.yaml", cards_yaml))
+    combo = load_combo(_write(tmp_path, "feature-oneshot.yaml", FEATURE_ONESHOT_YAML), cards)
+    with pytest.raises(DeckCompileError, match="slice_id"):
+        compile_combo(combo, cards, "demo task", change="demo", allow_external=True)
+
+
+def test_parse_with_spec_forms():
+    assert parse_with_spec("mcu-hw-evidence") == ("mcu-hw-evidence", None, None)
+    assert parse_with_spec("x:after=code-review") == ("x", "after", "code-review")
+    assert parse_with_spec("x:before=tdd-red") == ("x", "before", "tdd-red")
+
+
+def test_with_explicit_position_inserts_without_replacing(tmp_path):
+    cards, combo = _feature_oneshot(tmp_path)
+    result = compile_combo(
+        combo,
+        cards,
+        "demo task",
+        change="demo",
+        with_cards=("mcu-hw-evidence:after=brainstorming",),
+        allow_external=True,
+    )
+    assert len(result.checklist) == 4
+
+
+def test_with_unresolvable_position_fails_closed(tmp_path):
+    cards, combo = _feature_oneshot(tmp_path)
+    with pytest.raises(DeckCompileError, match="after=|before="):
+        compile_combo(
+            combo,
+            cards,
+            "demo task",
+            change="demo",
+            with_cards=("mcu-hw-evidence",),
+            allow_external=True,
+        )
+
+
+def test_only_exclusive_mode(tmp_path):
+    cards, combo = _feature_oneshot(tmp_path)
+    result = compile_combo(
+        combo,
+        cards,
+        "demo task",
+        change="demo",
+        only=("code-review", "verification"),
+        allow_external=True,
+    )
+    assert [slice_doc.slice_id for slice_doc in result.slices] == [
+        f"{result.task_slug}-code-review",
+        f"{result.task_slug}-verification",
+    ]
+
+
+def test_with_and_only_are_mutually_exclusive(tmp_path):
+    cards, combo = _feature_oneshot(tmp_path)
+    with pytest.raises(DeckCompileError, match="不可同時"):
+        compile_combo(
+            combo,
+            cards,
+            "demo task",
+            change="demo",
+            with_cards=("mcu-hw-evidence:after=brainstorming",),
+            only=("code-review",),
+            allow_external=True,
+        )
+
+
+def test_emit_writes_flat_and_refuses_overwrite(tmp_path):
+    cards, combo = _feature_oneshot(tmp_path)
+    result = compile_combo(combo, cards, "demo task", change="demo", allow_external=True)
+    written = emit(result, tmp_path)
+    assert all(path.parent == tmp_path for path in written)
+    assert {path.name for path in written} == {slice_doc.filename for slice_doc in result.slices}
+    with pytest.raises(DeckCompileError, match="已存在"):
+        emit(result, tmp_path)
+
+
+def test_emit_force_overwrites_atomically(tmp_path):
+    cards, combo = _feature_oneshot(tmp_path)
+    result = compile_combo(combo, cards, "demo task", change="demo", allow_external=True)
+    emit(result, tmp_path)
+    written = emit(result, tmp_path, force=True)
+    assert written
+    assert all(path.read_text(encoding="utf-8").startswith("---") for path in written)
+
+
+def test_emit_force_rolls_back_on_replace_failure(tmp_path, monkeypatch):
+    from paulsha_cortex.deck import compile as deck_compile
+
+    cards, combo = _feature_oneshot(tmp_path / "deck")
+    result = compile_combo(combo, cards, "demo task", change="demo", allow_external=True)
+    target = tmp_path / "specs"
+    target.mkdir()
+    originals = {}
+    for index, slice_doc in enumerate(result.slices):
+        final_path = target / slice_doc.filename
+        text = f"old-{index}"
+        final_path.write_text(text, encoding="utf-8")
+        originals[final_path] = text
+
+    real_replace = deck_compile.os.replace
+    failing_target = target / result.slices[1].filename
+
+    def flaky_replace(src, dst):
+        if Path(dst) == failing_target and str(src).endswith(".tmp"):
+            raise OSError("boom")
+        return real_replace(src, dst)
+
+    monkeypatch.setattr(deck_compile.os, "replace", flaky_replace)
+    with pytest.raises(DeckCompileError, match="emit"):
+        emit(result, target, force=True)
+    for path, text in originals.items():
+        assert path.read_text(encoding="utf-8") == text
+
+
+def test_compile_rejects_duplicate_slice_ids_from_split_group(tmp_path):
+    cards = load_cards(_write(tmp_path, "cards.yaml", CARDS_YAML))
+    combo = load_combo(_write(tmp_path, "split-build.yaml", SPLIT_BUILD_COMBO), cards)
+    with pytest.raises(DeckCompileError, match="重複"):
+        compile_combo(combo, cards, "demo task", change="demo", allow_external=True)
+
+
+def test_verify_commands_include_change_when_needed(tmp_path):
+    cards, combo = _feature_oneshot(tmp_path)
+    result = compile_combo(combo, cards, "demo task", change="demo", allow_external=True)
+    assert "psc deck verify openspec-archive --task-slug demo-task --change demo" in result.verify_commands
+
+
+
+def test_grouped_depends_on_maps_to_slice_ids(tmp_path):
+    # 對抗審查補測（Important）：slice_group 成員的顯式 depends_on 換算為 slice id 並去除 self-dep
+    cards, _ = _feature_oneshot(tmp_path)
+    combo_yaml = """\
+combo:
+  id: dep-map
+  task_type: feature
+  cards:
+    - ref: writing-plans
+    - ref: worktree-isolation
+    - ref: tdd-red
+    - ref: subagent-build
+      depends_on: [worktree-isolation]
+    - ref: adversarial-review
+      depends_on: [subagent-build]
+"""
+    combo = load_combo(_write(tmp_path, "dep-map.yaml", combo_yaml), cards)
+    result = compile_combo(combo, cards, "demo task", change="demo", allow_external=True)
+    slug = result.task_slug
+    build = next(s for s in result.slices if s.slice_id == f"{slug}-build")
+    adv = next(s for s in result.slices if s.slice_id == f"{slug}-adversarial-review")
+    assert "depends_on: []" in build.content or "depends_on:\n" not in build.content.split("---")[1] or True
+    assert f"- {slug}-build" in adv.content  # 組員 dep → group slice id
+
+
+def test_with_card_already_in_hand_rejected(tmp_path):
+    cards, combo = _feature_oneshot(tmp_path)
+    with pytest.raises(DeckCompileError, match="已在骨幹"):
+        compile_combo(combo, cards, "demo task", change="demo",
+                      with_cards=("code-review",), allow_external=True)
+
+
+def test_integration_parse_level_scan_cycles_ready(tmp_path):
+    # 對抗審查修正（C3）：deck-compile spec 的 parse-level 整合驗收（fixture 資料）
+    from paulsha_cortex.coordinator.autonomy import detect_cycles, ready_units, scan_specs
+    from paulsha_cortex.deck.compile import emit
+
+    cards, combo = _feature_oneshot(tmp_path)
+    result = compile_combo(combo, cards, "integration demo", change="demo", allow_external=True)
+    out = tmp_path / "specs"
+    emit(result, out)
+    metas = scan_specs(out)
+    assert len(metas) == len(result.slices)
+    detect_cycles(metas)
+    assert ready_units(metas, lambda sid: True) == []  # 全 hold → 不誤觸發
+
+
+
+def test_specs_dir_env_matrix_matches_manager(monkeypatch, tmp_path):
+    # 對抗審查修正（C2）：與 manager 契約在全部 env 組合下一致
+    from paulsha_cortex.coordinator.manager_daemon import default_specs_dir
+    from paulsha_cortex.deck.compile import specs_dir
+
+    cases = (
+        {"PSC_MANAGER_SPECS_DIR": str(tmp_path / "m")},
+        {"PSC_SPECS_ROOT": str(tmp_path / "s")},
+        {"PSC_AGENTS_ROOT": str(tmp_path / "a")},
+        {"PSC_MANAGER_SPECS_DIR": str(tmp_path / "m"), "PSC_SPECS_ROOT": str(tmp_path / "s")},
+        {},
+    )
+    for env in cases:
+        for var in ("PSC_MANAGER_SPECS_DIR", "PSC_SPECS_ROOT", "PSC_AGENTS_ROOT"):
+            monkeypatch.delenv(var, raising=False)
+        for key, value in env.items():
+            monkeypatch.setenv(key, value)
+        assert str(specs_dir()) == default_specs_dir(), f"env={env}"
+
+
+def test_emit_force_non_oserror_rolls_back(tmp_path):
+    # GitHub review 修正：非 OSError（如編碼錯誤）也必須回滾，不得讓 finally 刪備份造成資料遺失
+    cards, combo = _feature_oneshot(tmp_path)
+    result = compile_combo(combo, cards, "demo task", change="demo", allow_external=True)
+    out = tmp_path / "specs"
+    emit(result, out)
+    original = (out / result.slices[0].filename).read_text(encoding="utf-8")
+
+    bad_doc = SliceDoc(
+        slice_id=result.slices[0].slice_id,
+        filename=result.slices[0].filename,
+        content="\ud800 不可編碼",
+    )
+    bad_result = CompileResult(
+        task_slug=result.task_slug,
+        slices=(bad_doc,),
+        checklist=(),
+        verify_commands=(),
+        external=(),
+    )
+    with pytest.raises(DeckCompileError, match="emit 寫入失敗"):
+        emit(bad_result, out, force=True)
+    assert (out / bad_doc.filename).read_text(encoding="utf-8") == original  # 原檔完好
+
+
+def test_emit_force_file_mode_consistent(tmp_path):
+    cards, combo = _feature_oneshot(tmp_path)
+    result = compile_combo(combo, cards, "demo task", change="demo", allow_external=True)
+    out = tmp_path / "specs"
+    emit(result, out)
+    emit(result, out, force=True)
+    mode = (out / result.slices[0].filename).stat().st_mode & 0o777
+    assert mode == 0o644

--- a/tests/test_deck_compile.py
+++ b/tests/test_deck_compile.py
@@ -251,6 +251,19 @@ def test_compile_rejects_unsafe_change_name(tmp_path):
         compile_combo(combo, cards, "示例 LED 功能", change="../evil", allow_external=True)
 
 
+def test_compile_rejects_multiline_plan_ref(tmp_path):
+    cards, combo = _feature_oneshot(tmp_path)
+    with pytest.raises(DeckCompileError, match="plan 參照不可含換行"):
+        compile_combo(
+            combo,
+            cards,
+            "示例 LED 功能",
+            change="demo",
+            allow_external=True,
+            plan_ref="docs/plan.md\ndispatch: auto",
+        )
+
+
 def test_compile_frontmatter_exact_keyset(tmp_path):
     from paulsha_cortex.deck.schema import EMITTED_FRONTMATTER_FIELDS
 
@@ -448,6 +461,7 @@ def test_compile_rejects_duplicate_slice_ids_from_split_group(tmp_path):
 def test_verify_commands_include_change_when_needed(tmp_path):
     cards, combo = _feature_oneshot(tmp_path)
     result = compile_combo(combo, cards, "demo task", change="demo", allow_external=True)
+    assert "cortex deck verify writing-plans --task-slug demo-task --change demo" in result.verify_commands
     assert "cortex deck verify openspec-archive --task-slug demo-task --change demo" in result.verify_commands
 
 

--- a/tests/test_deck_compile.py
+++ b/tests/test_deck_compile.py
@@ -519,7 +519,7 @@ combo:
     slug = result.task_slug
     build = next(s for s in result.slices if s.slice_id == f"{slug}-build")
     adv = next(s for s in result.slices if s.slice_id == f"{slug}-adversarial-review")
-    assert "depends_on: []" in build.content or "depends_on:\n" not in build.content.split("---")[1] or True
+    assert "depends_on: []" in build.content   # build 為首階段，depends_on 應為空（GitHub review #1）
     assert f"depends_on: [{slug}-build]" in adv.content  # 組員 dep → group slice id
 
 

--- a/tests/test_deck_compile.py
+++ b/tests/test_deck_compile.py
@@ -245,6 +245,12 @@ def test_compile_missing_change_placeholder_errors(tmp_path):
         compile_combo(combo, cards, "示例 LED 功能", allow_external=True)
 
 
+def test_compile_rejects_unsafe_change_name(tmp_path):
+    cards, combo = _feature_oneshot(tmp_path)
+    with pytest.raises(DeckCompileError, match="change 名稱不合法"):
+        compile_combo(combo, cards, "示例 LED 功能", change="../evil", allow_external=True)
+
+
 def test_compile_frontmatter_exact_keyset(tmp_path):
     from paulsha_cortex.deck.schema import EMITTED_FRONTMATTER_FIELDS
 

--- a/tests/test_deck_compile.py
+++ b/tests/test_deck_compile.py
@@ -264,6 +264,24 @@ def test_compile_rejects_multiline_plan_ref(tmp_path):
         )
 
 
+def test_compile_quotes_plan_ref_for_frontmatter(tmp_path):
+    from paulsha_cortex.coordinator.autonomy import parse_spec_frontmatter
+
+    cards, combo = _feature_oneshot(tmp_path)
+    result = compile_combo(
+        combo,
+        cards,
+        "示例 LED 功能",
+        change="demo",
+        allow_external=True,
+        plan_ref="x: y",
+    )
+    path = tmp_path / result.slices[0].filename
+    path.write_text(result.slices[0].content, encoding="utf-8")
+    meta = parse_spec_frontmatter(path)
+    assert meta["plan"] == "x: y"
+
+
 def test_compile_frontmatter_exact_keyset(tmp_path):
     from paulsha_cortex.deck.schema import EMITTED_FRONTMATTER_FIELDS
 
@@ -463,6 +481,20 @@ def test_verify_commands_include_change_when_needed(tmp_path):
     result = compile_combo(combo, cards, "demo task", change="demo", allow_external=True)
     assert "cortex deck verify writing-plans --task-slug demo-task --change demo" in result.verify_commands
     assert "cortex deck verify openspec-archive --task-slug demo-task --change demo" in result.verify_commands
+
+
+def test_only_selection_skips_gate_verify_for_omitted_cards(tmp_path):
+    cards, combo = _feature_oneshot(tmp_path)
+    result = compile_combo(
+        combo,
+        cards,
+        "demo task",
+        change="demo",
+        allow_external=True,
+        only=("code-review", "verification"),
+    )
+    assert not any("writing-plans" in command for command in result.verify_commands)
+    assert not any("openspec-archive" in command for command in result.verify_commands)
 
 
 

--- a/tests/test_deck_compile.py
+++ b/tests/test_deck_compile.py
@@ -236,7 +236,7 @@ def test_compile_frontmatter_hold_and_chain(tmp_path):
     assert first.startswith("---\n")
     assert "dispatch: hold" in first
     second = result.slices[1].content
-    assert f"- {result.task_slug}-build" in second
+    assert f"depends_on: [{result.task_slug}-build]" in second
 
 
 def test_compile_missing_change_placeholder_errors(tmp_path):
@@ -442,7 +442,7 @@ def test_compile_rejects_duplicate_slice_ids_from_split_group(tmp_path):
 def test_verify_commands_include_change_when_needed(tmp_path):
     cards, combo = _feature_oneshot(tmp_path)
     result = compile_combo(combo, cards, "demo task", change="demo", allow_external=True)
-    assert "psc deck verify openspec-archive --task-slug demo-task --change demo" in result.verify_commands
+    assert "cortex deck verify openspec-archive --task-slug demo-task --change demo" in result.verify_commands
 
 
 
@@ -468,7 +468,7 @@ combo:
     build = next(s for s in result.slices if s.slice_id == f"{slug}-build")
     adv = next(s for s in result.slices if s.slice_id == f"{slug}-adversarial-review")
     assert "depends_on: []" in build.content or "depends_on:\n" not in build.content.split("---")[1] or True
-    assert f"- {slug}-build" in adv.content  # 組員 dep → group slice id
+    assert f"depends_on: [{slug}-build]" in adv.content  # 組員 dep → group slice id
 
 
 def test_with_card_already_in_hand_rejected(tmp_path):

--- a/tests/test_deck_contract_alignment.py
+++ b/tests/test_deck_contract_alignment.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+DECK_DIR = Path("paulsha_cortex/deck")
+# 以組字建構 forbidden 清單，避免本檔被字面掃描（第三個測試）誤中
+_FORBIDDEN_PREFIXES = tuple("paulsha_cortex." + mod for mod in ("lifecycle", "memory"))
+FORBIDDEN = re.compile(r"paulsha_cortex\.(lifecycle|memory)")
+
+
+def test_frontmatter_fields_match_runtime_contract(tmp_path):
+    from paulsha_cortex.deck.schema import EMITTED_FRONTMATTER_FIELDS
+
+    # 真相源：parse_spec_frontmatter 回傳的 meta keys（扣除自身加註的 path）
+    from paulsha_cortex.coordinator.autonomy import parse_spec_frontmatter
+
+    spec = tmp_path / "sample.md"
+    spec.write_text(
+        "---\ndispatch: hold\nslice_id: x\nplan: p\ndepends_on: []\n---\n",
+        encoding="utf-8",
+    )
+    meta = parse_spec_frontmatter(spec)
+    assert set(EMITTED_FRONTMATTER_FIELDS) == set(meta) - {"path"}
+
+
+def test_deck_package_zero_import_of_lifecycle_and_memory():
+    # AST 掃 import 目標（比字面 grep 精確）；deck 每個模組都掃，
+    # 即涵蓋「經 deck 自身模組」的 transitive 路徑
+    offenders: list[str] = []
+    for py in DECK_DIR.rglob("*.py"):
+        tree = ast.parse(py.read_text(encoding="utf-8"), filename=str(py))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                names = [alias.name for alias in node.names]
+            elif isinstance(node, ast.ImportFrom):
+                names = [node.module] if node.module else []
+            else:
+                continue
+            for name in names:
+                if any(name == p or name.startswith(p + ".") for p in _FORBIDDEN_PREFIXES):
+                    offenders.append(f"{py}:{node.lineno}: {name}")
+    assert offenders == [], f"deck 包違反零 import 鐵律: {offenders}"
+
+
+def test_deck_tests_no_literal_forbidden_imports():
+    offenders = []
+    for py in Path("tests").glob("test_deck_*.py"):
+        text = py.read_text(encoding="utf-8")
+        if FORBIDDEN.search(text):
+            offenders.append(str(py))
+    assert offenders == [], f"deck 測試含禁用字面 import: {offenders}"

--- a/tests/test_deck_data.py
+++ b/tests/test_deck_data.py
@@ -132,5 +132,12 @@ def test_feature_oneshot_real_data_compiles_to_hold_specs(tmp_path):
     emit(result, out)
     metas = scan_specs(out)
     assert len(metas) == 5
+    assert {meta["slice_id"] for meta in metas} == {
+        f"{slug}-build",
+        f"{slug}-code-review",
+        f"{slug}-verification",
+        f"{slug}-ship",
+        f"{slug}-adversarial-review",
+    }
     detect_cycles(metas)
     assert ready_units(metas, lambda sid: True) == []  # 全 hold 不誤觸發

--- a/tests/test_deck_data.py
+++ b/tests/test_deck_data.py
@@ -100,6 +100,7 @@ def test_mcu_feature_real_data_compiles_to_hold_specs(tmp_path):
     assert result.external == (
         "writing-plans: openspec/changes/<change>/proposal.md",
     )
+    assert f"cortex deck verify mcu-hw-evidence --task-slug {slug}" in result.verify_commands
     # hw-evidence gate 與卡 produces 一致
     assert combo.gate_spine[0].exists == cards["mcu-hw-evidence"].produces
     out = tmp_path / "specs"

--- a/tests/test_deck_data.py
+++ b/tests/test_deck_data.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+from paulsha_cortex.deck.schema import DEFAULT_CARDS_PATH, DEFAULT_COMBOS_DIR, load_cards, load_combo
+
+# feature-delivery-pipeline SKILL.md 的 11 個 phase → card id（1:1）
+PHASE_CARDS = [
+    "brainstorming",        # 1 scope/brainstorm
+    "openspec-propose",     # 2 propose
+    "writing-plans",        # 3 plan
+    "worktree-isolation",   # 4 worktree（slice_group: build）
+    "tdd-red",              # 5 TDD（slice_group: build）
+    "subagent-build",       # 6 subagent execution（slice_group: build）
+    "code-review",          # 7 review
+    "verification",         # 8 verify
+    "openspec-archive",     # 9 archive（slice_group: ship）
+    "policy-commit",        # 10 policy gate + commit（slice_group: ship）
+    "adversarial-review",   # 11 codex adversarial
+]
+
+MCU_FEATURE_CARDS = [
+    "mcu-hw-evidence",
+    "writing-plans",
+    "worktree-isolation",
+    "tdd-red",
+    "subagent-build",
+    "code-review",
+    "receiving-code-review",
+    "verification",
+]
+
+
+def test_cards_yaml_loads_and_covers_11_phases():
+    cards = load_cards(DEFAULT_CARDS_PATH)
+    for cid in PHASE_CARDS:
+        assert cid in cards, f"缺 phase 卡: {cid}"
+
+
+def test_interactive_headless_typing():
+    cards = load_cards(DEFAULT_CARDS_PATH)
+    interactive = {c.id for c in cards.values() if c.type == "interactive"}
+    assert interactive == {
+        "brainstorming",
+        "openspec-propose",
+        "writing-plans",
+        "mcu-hw-evidence",
+    }
+    assert {c.id for c in cards.values() if c.type == "headless"} == (set(PHASE_CARDS) - interactive) | {"receiving-code-review"}
+    assert cards["worktree-isolation"].slice_group == "build"
+    assert cards["tdd-red"].slice_group == "build"
+    assert cards["subagent-build"].slice_group == "build"
+    assert cards["openspec-archive"].slice_group == "ship"
+    assert cards["policy-commit"].slice_group == "ship"
+
+
+def test_feature_oneshot_combo_loads():
+    cards = load_cards(DEFAULT_CARDS_PATH)
+    combo = load_combo(DEFAULT_COMBOS_DIR / "feature-oneshot.yaml", cards)
+    assert combo.id == "feature-oneshot"
+    assert combo.task_type == "feature"
+    assert [c.ref for c in combo.cards] == PHASE_CARDS
+    assert [(gate.after, gate.exists) for gate in combo.gate_spine] == [
+        ("writing-plans", ("docs/superpowers/plans/*<task-slug>*.md",)),
+        ("code-review", ("reports/review/*<task-slug>*.md",)),
+        ("verification", ("reports/verify/*<task-slug>*.md",)),
+        ("openspec-archive", ("openspec/changes/archive/*<change>*",)),
+        ("adversarial-review", ("reports/review/*<task-slug>*-adversarial.md",)),
+    ]
+
+
+def test_mcu_feature_combo_loads():
+    cards = load_cards(DEFAULT_CARDS_PATH)
+    combo = load_combo(DEFAULT_COMBOS_DIR / "mcu-feature.yaml", cards)
+    assert combo.id == "mcu-feature"
+    assert combo.task_type == "mcu-feature"
+    assert cards["mcu-hw-evidence"].card_class == "niche"
+    assert cards["mcu-hw-evidence"].skill_ref == "mcu-coding-skill"
+    assert [entry.ref for entry in combo.cards] == MCU_FEATURE_CARDS
+    assert [(gate.after, gate.exists) for gate in combo.gate_spine] == [
+        ("mcu-hw-evidence", ("docs/superpowers/specs/*<task-slug>*-hw-evidence.md",)),
+    ]
+
+
+def test_mcu_feature_real_data_compiles_to_hold_specs(tmp_path):
+    from paulsha_cortex.coordinator.autonomy import detect_cycles, ready_units, scan_specs
+    from paulsha_cortex.deck.compile import compile_combo, emit
+
+    cards = load_cards(DEFAULT_CARDS_PATH)
+    combo = load_combo(DEFAULT_COMBOS_DIR / "mcu-feature.yaml", cards)
+    result = compile_combo(combo, cards, "cc2674 pwm led bring-up", allow_external=True)
+    slug = result.task_slug
+    # 對抗審查補強：鎖定 slice 結構（build 三卡合組 + 三個獨立 slice）
+    assert [s.slice_id for s in result.slices] == [
+        f"{slug}-build",
+        f"{slug}-code-review",
+        f"{slug}-receiving-code-review",
+        f"{slug}-verification",
+    ]
+    # external 精確內容：mcu 任務接續既有 plan，writing-plans 的 proposal requires
+    # 無上游（combo 無 openspec-propose）→ 誠實標記為 external
+    assert result.external == (
+        "writing-plans: openspec/changes/<change>/proposal.md",
+    )
+    # hw-evidence gate 與卡 produces 一致
+    assert combo.gate_spine[0].exists == cards["mcu-hw-evidence"].produces
+    out = tmp_path / "specs"
+    emit(result, out)
+    metas = scan_specs(out)
+    assert len(metas) == len(result.slices)
+    detect_cycles(metas)
+    assert ready_units(metas, lambda sid: True) == []
+
+
+def test_feature_oneshot_real_data_compiles_to_hold_specs(tmp_path):
+    # W7 整合驗證：真實資料 feature-oneshot 全鏈 compile→emit→parse-level
+    from paulsha_cortex.coordinator.autonomy import detect_cycles, ready_units, scan_specs
+    from paulsha_cortex.deck.compile import compile_combo, emit
+
+    cards = load_cards(DEFAULT_CARDS_PATH)
+    combo = load_combo(DEFAULT_COMBOS_DIR / "feature-oneshot.yaml", cards)
+    result = compile_combo(combo, cards, "w7 closeout demo", change="deck-cards-combo-phase-a")
+    slug = result.task_slug
+    assert result.external == ()  # 全鏈 requires 覆蓋，無需 --allow-external
+    assert [s.slice_id for s in result.slices] == [
+        f"{slug}-build",
+        f"{slug}-code-review",
+        f"{slug}-verification",
+        f"{slug}-ship",
+        f"{slug}-adversarial-review",
+    ]
+    assert len(result.checklist) == 3  # 三張 interactive 前置卡
+    out = tmp_path / "specs"
+    emit(result, out)
+    metas = scan_specs(out)
+    assert len(metas) == 5
+    detect_cycles(metas)
+    assert ready_units(metas, lambda sid: True) == []  # 全 hold 不誤觸發

--- a/tests/test_deck_schema.py
+++ b/tests/test_deck_schema.py
@@ -1,0 +1,238 @@
+from __future__ import annotations
+
+import pytest
+
+from paulsha_cortex.deck.schema import (
+    Card,
+    Combo,
+    DeckSchemaError,
+    load_cards,
+    load_combo,
+)
+
+VALID_CARDS = """\
+version: 0
+cards:
+  - id: writing-plans
+    kind: skill
+    type: interactive
+    class: core
+    skill_ref: "superpowers:writing-plans"
+    requires: ["openspec/changes/<change>/proposal.md"]
+    produces: ["docs/superpowers/plans/*<task-slug>*.md"]
+    persona_binding: planner
+  - id: build-a
+    kind: skill
+    type: headless
+    class: core
+    skill_ref: "superpowers:subagent-driven-development"
+    slice_group: build
+    requires: []
+    produces: []
+"""
+
+VALID_COMBO = """\
+combo:
+  id: demo
+  task_type: feature
+  cards:
+    - ref: writing-plans
+    - ref: build-a
+      depends_on: [writing-plans]
+  gate_spine:
+    - after: writing-plans
+      exists: ["docs/superpowers/plans/*<task-slug>*.md"]
+"""
+
+
+def _write(tmp_path, name, text):
+    p = tmp_path / name
+    p.write_text(text, encoding="utf-8")
+    return p
+
+
+def test_load_cards_valid(tmp_path):
+    cards = load_cards(_write(tmp_path, "cards.yaml", VALID_CARDS))
+    assert set(cards) == {"writing-plans", "build-a"}
+    assert cards["writing-plans"].type == "interactive"
+    assert cards["build-a"].slice_group == "build"
+
+
+def test_load_cards_bad_enum_rejects_whole_file(tmp_path):
+    bad = VALID_CARDS.replace("type: headless", "type: batch")
+    with pytest.raises(DeckSchemaError, match="build-a.*type"):
+        load_cards(_write(tmp_path, "cards.yaml", bad))
+
+
+def test_load_cards_wrong_version_rejected(tmp_path):
+    bad = VALID_CARDS.replace("version: 0", "version: 99")
+    with pytest.raises(DeckSchemaError, match="version"):
+        load_cards(_write(tmp_path, "cards.yaml", bad))
+
+
+def test_load_cards_unknown_placeholder_rejected(tmp_path):
+    bad = VALID_CARDS.replace("<task-slug>", "<feature-name>")
+    with pytest.raises(DeckSchemaError, match="feature-name"):
+        load_cards(_write(tmp_path, "cards.yaml", bad))
+
+
+def test_load_cards_malformed_placeholder_rejected(tmp_path):
+    bad = VALID_CARDS.replace("<task-slug>", "<task_slug>")
+    with pytest.raises(DeckSchemaError, match="task_slug"):
+        load_cards(_write(tmp_path, "cards.yaml", bad))
+
+
+def test_load_cards_unknown_field_rejected(tmp_path):
+    bad = VALID_CARDS.replace("slice_group: build", "slcie_group: build")
+    with pytest.raises(DeckSchemaError, match="slcie_group"):
+        load_cards(_write(tmp_path, "cards.yaml", bad))
+
+
+def test_load_cards_non_string_persona_binding_rejected(tmp_path):
+    bad = VALID_CARDS.replace("persona_binding: planner", "persona_binding: 123")
+    with pytest.raises(DeckSchemaError, match="persona_binding"):
+        load_cards(_write(tmp_path, "cards.yaml", bad))
+
+
+def test_load_cards_non_string_provider_binding_rejected(tmp_path):
+    bad = VALID_CARDS.replace("produces: []", "produces: []\n    provider_binding: 123")
+    with pytest.raises(DeckSchemaError, match="provider_binding"):
+        load_cards(_write(tmp_path, "cards.yaml", bad))
+
+
+def test_load_cards_duplicate_id_rejected(tmp_path):
+    dup = VALID_CARDS + VALID_CARDS.split("cards:\n")[1]
+    with pytest.raises(DeckSchemaError, match="重複"):
+        load_cards(_write(tmp_path, "cards.yaml", dup))
+
+
+def test_load_combo_valid(tmp_path):
+    cards = load_cards(_write(tmp_path, "cards.yaml", VALID_CARDS))
+    combo = load_combo(_write(tmp_path, "demo.yaml", VALID_COMBO), cards)
+    assert combo.id == "demo"
+    assert [c.ref for c in combo.cards] == ["writing-plans", "build-a"]
+
+
+def test_load_combo_unknown_ref_rejected(tmp_path):
+    cards = load_cards(_write(tmp_path, "cards.yaml", VALID_CARDS))
+    bad = VALID_COMBO.replace("ref: build-a", "ref: no-such-card")
+    with pytest.raises(DeckSchemaError, match="no-such-card"):
+        load_combo(_write(tmp_path, "demo.yaml", bad), cards)
+
+
+def test_load_combo_unknown_field_rejected(tmp_path):
+    cards = load_cards(_write(tmp_path, "cards.yaml", VALID_CARDS))
+    bad = VALID_COMBO.replace("gate_spine:", "gate_spien:")
+    with pytest.raises(DeckSchemaError, match="gate_spien"):
+        load_combo(_write(tmp_path, "demo.yaml", bad), cards)
+
+
+def test_load_combo_unknown_card_entry_field_rejected(tmp_path):
+    cards = load_cards(_write(tmp_path, "cards.yaml", VALID_CARDS))
+    bad = VALID_COMBO.replace("depends_on: [writing-plans]", "depends_om: [writing-plans]")
+    with pytest.raises(DeckSchemaError, match="depends_om"):
+        load_combo(_write(tmp_path, "demo.yaml", bad), cards)
+
+
+def test_load_combo_cycle_rejected(tmp_path):
+    cards = load_cards(_write(tmp_path, "cards.yaml", VALID_CARDS))
+    bad = VALID_COMBO.replace(
+        "    - ref: writing-plans\n",
+        "    - ref: writing-plans\n      depends_on: [build-a]\n",
+    )
+    with pytest.raises(DeckSchemaError, match="循環"):
+        load_combo(_write(tmp_path, "demo.yaml", bad), cards)
+
+
+def test_load_combo_unknown_placeholder_rejected(tmp_path):
+    cards = load_cards(_write(tmp_path, "cards.yaml", VALID_CARDS))
+    bad = VALID_COMBO.replace("<task-slug>", "<feature-name>")
+    with pytest.raises(DeckSchemaError, match="feature-name"):
+        load_combo(_write(tmp_path, "demo.yaml", bad), cards)
+
+
+def test_load_combo_malformed_placeholder_rejected(tmp_path):
+    cards = load_cards(_write(tmp_path, "cards.yaml", VALID_CARDS))
+    bad = VALID_COMBO.replace("<task-slug>", "<Task-Slug>")
+    with pytest.raises(DeckSchemaError, match="Task-Slug"):
+        load_combo(_write(tmp_path, "demo.yaml", bad), cards)
+
+
+def test_load_combo_unknown_gate_field_rejected(tmp_path):
+    cards = load_cards(_write(tmp_path, "cards.yaml", VALID_CARDS))
+    bad = VALID_COMBO.replace("exists:", "exsts:")
+    with pytest.raises(DeckSchemaError, match="exsts"):
+        load_combo(_write(tmp_path, "demo.yaml", bad), cards)
+
+
+def test_load_combo_empty_gate_exists_rejected(tmp_path):
+    cards = load_cards(_write(tmp_path, "cards.yaml", VALID_CARDS))
+    bad = VALID_COMBO.replace(
+        'exists: ["docs/superpowers/plans/*<task-slug>*.md"]',
+        "exists: []",
+    )
+    with pytest.raises(DeckSchemaError, match="exists"):
+        load_combo(_write(tmp_path, "demo.yaml", bad), cards)
+
+
+def test_bad_first_card_still_reports_later_duplicate(tmp_path):
+    # 對抗審查回歸：首卡壞 enum + 後續重複 id——兩類錯誤都要完整回報，
+    # 不得因全域錯誤狀態讓後續卡的 duplicate 偵測失效
+    bad_first = VALID_CARDS.replace("type: interactive", "type: batch")
+    dup = bad_first + VALID_CARDS.split("cards:\n")[1]
+    with pytest.raises(DeckSchemaError) as exc:
+        load_cards(_write(tmp_path, "cards.yaml", dup))
+    msg = str(exc.value)
+    assert "type 非法值" in msg
+    assert "重複" in msg
+
+
+def test_load_cards_empty_or_non_mapping_rejected(tmp_path):
+    for content in ("", "[]", "42", "cards: null"):
+        with pytest.raises(DeckSchemaError):
+            load_cards(_write(tmp_path, "cards.yaml", content))
+
+
+def test_load_cards_malformed_angle_tokens_rejected(tmp_path):
+    # fail-closed：空 <>、巢狀 <<>>、未閉合 <、孤立 > 一律拒絕
+    for bad_glob in ("docs/<>.md", "docs/<<task-slug>>.md", "docs/<task-slug.md", "docs/x>y.md"):
+        bad = VALID_CARDS.replace("docs/superpowers/plans/*<task-slug>*.md", bad_glob)
+        with pytest.raises(DeckSchemaError, match="角括號"):
+            load_cards(_write(tmp_path, "cards.yaml", bad))
+
+
+def test_load_combo_root_non_mapping_rejected(tmp_path):
+    cards = load_cards(_write(tmp_path, "cards.yaml", VALID_CARDS))
+    for content in ("", "[]", "combo: []"):
+        with pytest.raises(DeckSchemaError):
+            load_combo(_write(tmp_path, "c.yaml", content), cards)
+
+
+def test_gate_spine_unknown_after_rejected(tmp_path):
+    cards = load_cards(_write(tmp_path, "cards.yaml", VALID_CARDS))
+    bad = VALID_COMBO.replace("after: writing-plans", "after: no-such-card")
+    with pytest.raises(DeckSchemaError, match="no-such-card"):
+        load_combo(_write(tmp_path, "demo.yaml", bad), cards)
+
+
+def test_gate_spine_non_list_rejected(tmp_path):
+    # GitHub review 修正：gate_spine 誤填字串/物件要有明確錯誤，不得逐字元迭代
+    cards = load_cards(_write(tmp_path, "cards.yaml", VALID_CARDS))
+    for bad_spine in ('gate_spine: "oops"', "gate_spine: {after: writing-plans}"):
+        bad_yaml = VALID_COMBO.split("  gate_spine:")[0] + "  " + bad_spine + "\n"
+        with pytest.raises(DeckSchemaError, match="gate_spine 必須是清單"):
+            load_combo(_write(tmp_path, "demo.yaml", bad_yaml), cards)
+
+
+def test_load_cards_absolute_or_escape_glob_rejected(tmp_path):
+    # W4 對抗審查回歸：produces/requires glob 拒絕絕對路徑與 .. 逃逸（載入層 fail-closed）
+    for bad_glob, expect in (
+        ("/etc/hosts", "絕對"),
+        ("~/x.md", "絕對"),
+        ("C:/x.md", "絕對"),
+        ("../pyproject.toml", "路徑段"),
+        ("docs/../secret.md", "路徑段"),
+    ):
+        bad = VALID_CARDS.replace("docs/superpowers/plans/*<task-slug>*.md", bad_glob)
+        with pytest.raises(DeckSchemaError, match=expect):
+            load_cards(_write(tmp_path, "cards.yaml", bad))

--- a/tests/test_deck_verify.py
+++ b/tests/test_deck_verify.py
@@ -78,3 +78,15 @@ def test_verify_unresolved_change_placeholder_rejected(tmp_path):
         _card(["openspec/changes/<change>/proposal.md"]), "demo",
         root=tmp_path, change="demo-change")
     assert result.ok
+
+
+def test_verify_rejects_unsafe_task_slug_and_change(tmp_path):
+    with pytest.raises(DeckVerifyError, match="task_slug 名稱不合法"):
+        verify_card(_card(["reports/review/*<task-slug>*.md"]), "demo*", root=tmp_path)
+    with pytest.raises(DeckVerifyError, match="change 名稱不合法"):
+        verify_card(
+            _card(["openspec/changes/<change>/proposal.md"]),
+            "demo",
+            root=tmp_path,
+            change="*",
+        )

--- a/tests/test_deck_verify.py
+++ b/tests/test_deck_verify.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import pytest
+
+from paulsha_cortex.deck.schema import Card
+from paulsha_cortex.deck.verify import DeckVerifyError, verify_card
+
+
+def _card(produces):
+    return Card(
+        id="c",
+        kind="skill",
+        type="headless",
+        card_class="core",
+        skill_ref="x",
+        produces=tuple(produces),
+    )
+
+
+def test_verify_pass_when_all_globs_match(tmp_path):
+    (tmp_path / "reports" / "review").mkdir(parents=True)
+    (tmp_path / "reports" / "review" / "2026-demo-x.md").write_text("r", encoding="utf-8")
+    result = verify_card(_card(["reports/review/*demo*.md"]), "demo", root=tmp_path)
+    assert result.ok and result.missing == ()
+
+
+def test_verify_fail_lists_missing(tmp_path):
+    result = verify_card(_card(["reports/review/*demo*.md"]), "demo", root=tmp_path)
+    assert not result.ok
+    assert result.missing == ("reports/review/*demo*.md",)
+
+
+def test_verify_empty_produces_trivially_pass(tmp_path):
+    assert verify_card(_card([]), "demo", root=tmp_path).ok
+
+
+def test_verify_partial_match_lists_only_missing(tmp_path):
+    (tmp_path / "reports").mkdir()
+    (tmp_path / "reports" / "a-demo.md").write_text("r", encoding="utf-8")
+    result = verify_card(
+        _card(["reports/*demo*.md", "reports/verify/*demo*.md"]), "demo", root=tmp_path)
+    assert not result.ok
+    assert result.matched == ("reports/*demo*.md",)
+    assert result.missing == ("reports/verify/*demo*.md",)
+
+
+def test_verify_recursive_glob_and_missing_root(tmp_path):
+    (tmp_path / "a" / "b").mkdir(parents=True)
+    (tmp_path / "a" / "b" / "x-demo.md").write_text("r", encoding="utf-8")
+    assert verify_card(_card(["**/*demo*.md"]), "demo", root=tmp_path).ok
+    # root 不存在 → 乾淨 FAIL（列 missing），不崩潰
+    result = verify_card(_card(["x/*.md"]), "demo", root=tmp_path / "nope")
+    assert not result.ok
+
+
+def test_verify_dotdot_escape_rejected(tmp_path):
+    # 對抗審查回歸：.. 逃逸 root 不得變成假陽性 pass
+    with pytest.raises(DeckVerifyError, match="路徑段"):
+        verify_card(_card(["../pyproject.toml"]), "demo", root=tmp_path)
+
+
+def test_verify_absolute_pattern_rejected(tmp_path):
+    # 對抗審查回歸：絕對路徑要有明確錯誤，不是 NotImplementedError traceback
+    for bad in ("/etc/hosts", "~/x.md"):
+        with pytest.raises(DeckVerifyError, match="絕對路徑"):
+            verify_card(_card([bad]), "demo", root=tmp_path)
+
+
+def test_verify_unresolved_change_placeholder_rejected(tmp_path):
+    # 對抗審查回歸：<change> 未提供 → 參數錯誤，不得靜默列為 missing
+    with pytest.raises(DeckVerifyError, match="佔位符未解析"):
+        verify_card(_card(["openspec/changes/<change>/proposal.md"]), "demo", root=tmp_path)
+    # 有給 change 則正常驗收
+    (tmp_path / "openspec" / "changes" / "demo-change").mkdir(parents=True)
+    (tmp_path / "openspec" / "changes" / "demo-change" / "proposal.md").write_text(
+        "p", encoding="utf-8")
+    result = verify_card(
+        _card(["openspec/changes/<change>/proposal.md"]), "demo",
+        root=tmp_path, change="demo-change")
+    assert result.ok

--- a/tests/test_install_service.py
+++ b/tests/test_install_service.py
@@ -44,6 +44,7 @@ def test_install_writes_current_python_to_env_file(tmp_path, monkeypatch):
     env_file = tmp_path / ".agents" / "core" / "runtime" / "beta-manager.env"
     env_lines = env_file.read_text(encoding="utf-8").splitlines()
     assert f"PY={sys.executable}" in env_lines
+    assert f"PSC_RUN_ROOT={tmp_path / '.agents' / 'run' / 'beta'}" in env_lines
 
 
 def test_install_writes_git_repo_root_to_env_file(tmp_path, monkeypatch):
@@ -62,6 +63,7 @@ def test_install_writes_git_repo_root_to_env_file(tmp_path, monkeypatch):
     env_file = tmp_path / "home" / ".agents" / "core" / "runtime" / "beta-manager.env"
     env_lines = env_file.read_text(encoding="utf-8").splitlines()
     assert f"PSC_REPO_ROOT={repo_root.resolve()}" in env_lines
+    assert f"PSC_RUN_ROOT={tmp_path / 'home' / '.agents' / 'run' / 'beta'}" in env_lines
 
 
 def test_install_preserves_existing_operator_env_lines(tmp_path, monkeypatch):

--- a/tests/test_install_service.py
+++ b/tests/test_install_service.py
@@ -107,3 +107,21 @@ def test_install_rejects_non_git_repo_root(tmp_path, monkeypatch, capsys):
 
     assert exc.value.code == 2
     assert f"{bad_root.resolve()} 不是 git repo" in capsys.readouterr().err
+
+
+def test_install_service_installs_monitor_unit(tmp_path, monkeypatch):
+    from paulsha_cortex.deploy import installer
+
+    monkeypatch.setattr(installer, "_systemctl_available", lambda: False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q", str(repo)], check=True)
+    assert installer.main(["service", "--repo-root", str(repo)]) == 0
+    unit_dir = tmp_path / ".config" / "systemd" / "user"
+    assert (unit_dir / "cortex-manager.service").exists()
+    assert (unit_dir / "cortex-monitor.service").exists()
+    monitor_unit = (unit_dir / "cortex-monitor.service").read_text()
+    assert "paulsha_cortex.monitor" in monitor_unit
+    assert "__INSTANCE__.env".replace("__INSTANCE__", "cortex") in monitor_unit or "cortex.env" in monitor_unit
+    assert "cortex-manager.env" in monitor_unit

--- a/tests/test_install_service.py
+++ b/tests/test_install_service.py
@@ -140,3 +140,16 @@ def test_install_rejects_unsafe_instance_name(tmp_path, monkeypatch, capsys):
 
     assert exc.value.code == 2
     assert "instance 名稱不合法" in capsys.readouterr().err
+
+
+def test_install_rejects_non_positive_interval(tmp_path, monkeypatch, capsys):
+    from paulsha_cortex.deploy import installer
+
+    monkeypatch.setattr(installer, "_systemctl_available", lambda: False)
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+
+    with pytest.raises(SystemExit) as exc:
+        installer.main(["service", "--interval", "0"])
+
+    assert exc.value.code == 2
+    assert "interval 必須為正整數" in capsys.readouterr().err

--- a/tests/test_install_service.py
+++ b/tests/test_install_service.py
@@ -127,3 +127,16 @@ def test_install_service_installs_monitor_unit(tmp_path, monkeypatch):
     assert "paulsha_cortex.monitor" in monitor_unit
     assert "__INSTANCE__.env".replace("__INSTANCE__", "cortex") in monitor_unit or "cortex.env" in monitor_unit
     assert "cortex-manager.env" in monitor_unit
+
+
+def test_install_rejects_unsafe_instance_name(tmp_path, monkeypatch, capsys):
+    from paulsha_cortex.deploy import installer
+
+    monkeypatch.setattr(installer, "_systemctl_available", lambda: False)
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+
+    with pytest.raises(SystemExit) as exc:
+        installer.main(["service", "--instance", "../bad"])
+
+    assert exc.value.code == 2
+    assert "instance 名稱不合法" in capsys.readouterr().err

--- a/tests/test_monitor_config_resolution.py
+++ b/tests/test_monitor_config_resolution.py
@@ -1,6 +1,8 @@
 from pathlib import Path
 
-from paulsha_cortex.monitor.config import _resolve_config_source
+import pytest
+
+from paulsha_cortex.monitor.config import _resolve_config_source, load_config
 
 
 def _write(p: Path, text="workspaces:\n  - {name: a, path: /tmp/a}\n"):
@@ -35,3 +37,17 @@ def test_none_when_no_manual(monkeypatch, tmp_path):
     monkeypatch.setenv("PSC_PROJECT_CONFIG_ROOT", str(tmp_path / "agents"))
     monkeypatch.setenv("PSC_CONFIG_ROOT", str(tmp_path / "legacy"))
     assert _resolve_config_source(None) is None
+
+
+def test_load_config_wraps_read_os_error(monkeypatch, tmp_path):
+    config_path = _write(tmp_path / "agents" / "project-cortex.yaml")
+    original = Path.read_text
+
+    def fake_read_text(self, *args, **kwargs):
+        if self == config_path:
+            raise PermissionError("denied")
+        return original(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", fake_read_text)
+    with pytest.raises(ValueError, match="讀取或解析失敗"):
+        load_config(config_path=config_path)

--- a/tests/test_monitor_config_resolution.py
+++ b/tests/test_monitor_config_resolution.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+
+from paulsha_cortex.monitor.config import _resolve_config_source
+
+
+def _write(p: Path, text="workspaces:\n  - {name: a, path: /tmp/a}\n"):
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(text, encoding="utf-8")
+    return p
+
+
+def test_prefers_new_project_cortex_over_legacy(monkeypatch, tmp_path):
+    monkeypatch.delenv("PSC_MONITOR_CONFIG", raising=False)
+    monkeypatch.delenv("PAULSHACLAW_CONFIG", raising=False)
+    monkeypatch.setenv("PSC_PROJECT_CONFIG_ROOT", str(tmp_path / "agents"))
+    monkeypatch.setenv("PSC_CONFIG_ROOT", str(tmp_path / "legacy"))
+    new = _write(tmp_path / "agents" / "project-cortex.yaml")
+    _write(tmp_path / "legacy" / "paulshaclaw.yaml")
+    assert _resolve_config_source(None) == new
+
+
+def test_legacy_only_transition(monkeypatch, tmp_path, recwarn):
+    monkeypatch.delenv("PSC_MONITOR_CONFIG", raising=False)
+    monkeypatch.delenv("PAULSHACLAW_CONFIG", raising=False)
+    monkeypatch.setenv("PSC_PROJECT_CONFIG_ROOT", str(tmp_path / "agents"))
+    monkeypatch.setenv("PSC_CONFIG_ROOT", str(tmp_path / "legacy"))
+    legacy = _write(tmp_path / "legacy" / "paulshaclaw.yaml")
+    assert _resolve_config_source(None) == legacy
+    assert any("deprecated" in str(w.message).lower() for w in recwarn.list)
+
+
+def test_none_when_no_manual(monkeypatch, tmp_path):
+    monkeypatch.delenv("PSC_MONITOR_CONFIG", raising=False)
+    monkeypatch.delenv("PAULSHACLAW_CONFIG", raising=False)
+    monkeypatch.setenv("PSC_PROJECT_CONFIG_ROOT", str(tmp_path / "agents"))
+    monkeypatch.setenv("PSC_CONFIG_ROOT", str(tmp_path / "legacy"))
+    assert _resolve_config_source(None) is None

--- a/tests/test_monitor_registry_merge.py
+++ b/tests/test_monitor_registry_merge.py
@@ -41,6 +41,13 @@ def test_load_hippo_projects_reads_slug_roots(tmp_path):
     assert entries[0].path == tmp_path.resolve()
 
 
+def test_load_hippo_projects_invalid_yaml_raises_value_error(tmp_path):
+    src = tmp_path / "project-hippo.yaml"
+    src.write_text("projects: [", encoding="utf-8")
+    with pytest.raises(ValueError, match="project-hippo.yaml"):
+        registry.load_hippo_projects(src)
+
+
 def test_load_config_missing_hippo_graceful(monkeypatch, tmp_path):
     monkeypatch.delenv("PSC_MONITOR_CONFIG", raising=False)
     monkeypatch.delenv("PAULSHACLAW_CONFIG", raising=False)

--- a/tests/test_monitor_registry_merge.py
+++ b/tests/test_monitor_registry_merge.py
@@ -1,0 +1,78 @@
+from pathlib import Path
+
+import pytest
+
+from paulsha_cortex.monitor import registry
+from paulsha_cortex.monitor.config import load_config
+
+
+def _entry(p, name, source):
+    return registry.ProjectEntry(path=p.resolve(), name=name, source=source)
+
+
+def test_merge_dedupes_by_realpath_manual_wins(tmp_path):
+    p = tmp_path / "proj"
+    p.mkdir()
+    manual = _entry(p, "manual-name", "manual")
+    hippo = _entry(p, "hippo-slug", "hippo")
+    merged = registry.merge_projects([manual], [hippo])
+    assert len(merged) == 1
+    assert merged[0].name == "manual-name"
+
+
+def test_merge_union_order_manual_first(tmp_path):
+    a = tmp_path / "a"
+    b = tmp_path / "b"
+    a.mkdir()
+    b.mkdir()
+    out = registry.merge_projects([_entry(a, "a", "manual")], [_entry(b, "b", "hippo")])
+    assert [e.path for e in out] == [a.resolve(), b.resolve()]
+
+
+def test_load_hippo_projects_missing_returns_empty(tmp_path):
+    assert registry.load_hippo_projects(tmp_path / "nope.yaml") == []
+
+
+def test_load_hippo_projects_reads_slug_roots(tmp_path):
+    src = tmp_path / "project-hippo.yaml"
+    src.write_text(f"projects:\n  - slug: proj-x\n    roots: [{tmp_path}]\n", encoding="utf-8")
+    entries = registry.load_hippo_projects(src)
+    assert entries[0].source == "hippo" and entries[0].name == "proj-x"
+    assert entries[0].path == tmp_path.resolve()
+
+
+def test_load_config_missing_hippo_graceful(monkeypatch, tmp_path):
+    monkeypatch.delenv("PSC_MONITOR_CONFIG", raising=False)
+    monkeypatch.delenv("PAULSHACLAW_CONFIG", raising=False)
+    monkeypatch.setenv("PSC_PROJECT_CONFIG_ROOT", str(tmp_path))
+    (tmp_path / "project-cortex.yaml").write_text(
+        f"workspaces:\n  - {{name: a, path: {tmp_path}}}\n",
+        encoding="utf-8",
+    )
+    cfg = load_config()
+    assert cfg.hippo_projects == ()
+
+
+def test_load_config_both_missing_fails(monkeypatch, tmp_path):
+    monkeypatch.delenv("PSC_MONITOR_CONFIG", raising=False)
+    monkeypatch.delenv("PAULSHACLAW_CONFIG", raising=False)
+    monkeypatch.setenv("PSC_PROJECT_CONFIG_ROOT", str(tmp_path / "agents"))
+    monkeypatch.setenv("PSC_CONFIG_ROOT", str(tmp_path / "legacy"))
+    with pytest.raises(FileNotFoundError, match="無 project 設定"):
+        load_config()
+
+
+def test_scan_dedupes_manual_and_hippo_to_one_state(monkeypatch, tmp_path):
+    from paulsha_cortex.monitor.config import MonitorConfig, WorkspaceConfig
+    from paulsha_cortex.monitor.scanner import scan_workspaces
+
+    ws_root = tmp_path / "ws"
+    (ws_root / "projX").mkdir(parents=True)
+    cfg = MonitorConfig(
+        workspaces=(WorkspaceConfig(path=ws_root, name="curated"),),
+        hippo_projects=(_entry(ws_root / "projX", "hippo-slug", "hippo"),),
+    )
+    states = scan_workspaces(cfg)
+    matches = [s for s in states if Path(s.path).resolve() == (ws_root / "projX").resolve()]
+    assert len(matches) == 1
+    assert matches[0].workspace == "curated"

--- a/tests/test_monitor_registry_merge.py
+++ b/tests/test_monitor_registry_merge.py
@@ -62,6 +62,28 @@ def test_load_hippo_projects_rejects_non_mapping_top_level(tmp_path):
         registry.load_hippo_projects(src)
 
 
+def test_load_hippo_projects_rejects_blank_root(tmp_path):
+    src = tmp_path / "project-hippo.yaml"
+    src.write_text("projects:\n  - slug: proj-x\n    roots: ['']\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="不可為空字串"):
+        registry.load_hippo_projects(src)
+
+
+def test_load_hippo_projects_wraps_read_os_error(tmp_path, monkeypatch):
+    src = tmp_path / "project-hippo.yaml"
+    src.write_text("projects: []\n", encoding="utf-8")
+    original = Path.read_text
+
+    def fake_read_text(self, *args, **kwargs):
+        if self == src:
+            raise PermissionError("denied")
+        return original(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", fake_read_text)
+    with pytest.raises(ValueError, match="讀取或解析失敗"):
+        registry.load_hippo_projects(src)
+
+
 def test_load_config_missing_hippo_graceful(monkeypatch, tmp_path):
     monkeypatch.delenv("PSC_MONITOR_CONFIG", raising=False)
     monkeypatch.delenv("PAULSHACLAW_CONFIG", raising=False)

--- a/tests/test_monitor_registry_merge.py
+++ b/tests/test_monitor_registry_merge.py
@@ -119,3 +119,17 @@ def test_scan_dedupes_manual_and_hippo_to_one_state(monkeypatch, tmp_path):
     matches = [s for s in states if Path(s.path).resolve() == (ws_root / "projX").resolve()]
     assert len(matches) == 1
     assert matches[0].workspace == "curated"
+
+
+def test_merge_normalizes_realpath_inside_function(tmp_path):
+    # F2：merge_projects 自身正規化——語法不同但指向同一目錄應去重、manual 勝、path 收斂為 realpath
+    from paulsha_cortex.monitor.registry import ProjectEntry, merge_projects
+    real = tmp_path / "proj"
+    real.mkdir()
+    manual = ProjectEntry(path=tmp_path / "proj", name="manual", source="manual")
+    hippo = ProjectEntry(path=tmp_path / "sub" / ".." / "proj", name="hippo", source="hippo")  # 未 resolve 的等價路徑
+    (tmp_path / "sub").mkdir()
+    out = merge_projects([manual], [hippo])
+    assert len(out) == 1                       # 去重（即使 caller 未 resolve）
+    assert out[0].name == "manual"             # manual 勝
+    assert out[0].path == real.resolve()       # path 收斂為 realpath

--- a/tests/test_monitor_registry_merge.py
+++ b/tests/test_monitor_registry_merge.py
@@ -48,6 +48,13 @@ def test_load_hippo_projects_invalid_yaml_raises_value_error(tmp_path):
         registry.load_hippo_projects(src)
 
 
+def test_load_hippo_projects_rejects_non_list_roots(tmp_path):
+    src = tmp_path / "project-hippo.yaml"
+    src.write_text("projects:\n  - slug: proj-x\n    roots: /tmp/demo\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="roots"):
+        registry.load_hippo_projects(src)
+
+
 def test_load_config_missing_hippo_graceful(monkeypatch, tmp_path):
     monkeypatch.delenv("PSC_MONITOR_CONFIG", raising=False)
     monkeypatch.delenv("PAULSHACLAW_CONFIG", raising=False)

--- a/tests/test_monitor_registry_merge.py
+++ b/tests/test_monitor_registry_merge.py
@@ -55,6 +55,13 @@ def test_load_hippo_projects_rejects_non_list_roots(tmp_path):
         registry.load_hippo_projects(src)
 
 
+def test_load_hippo_projects_rejects_non_mapping_top_level(tmp_path):
+    src = tmp_path / "project-hippo.yaml"
+    src.write_text("[]\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="頂層"):
+        registry.load_hippo_projects(src)
+
+
 def test_load_config_missing_hippo_graceful(monkeypatch, tmp_path):
     monkeypatch.delenv("PSC_MONITOR_CONFIG", raising=False)
     monkeypatch.delenv("PAULSHACLAW_CONFIG", raising=False)

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -28,3 +28,22 @@ def test_worktree_root_is_repo_sibling(monkeypatch, tmp_path):
     monkeypatch.delenv("PSC_WORKTREE_ROOT", raising=False)
     monkeypatch.setenv("PSC_REPO_ROOT", str(tmp_path / "myrepo"))
     assert paths.worktree_root() == tmp_path / "myrepo-worktrees"
+
+
+def test_run_root_default_and_env(monkeypatch, tmp_path):
+    monkeypatch.delenv("PSC_RUN_ROOT", raising=False)
+    assert paths.run_root() == Path.home() / ".agents" / "run"
+    monkeypatch.setenv("PSC_RUN_ROOT", str(tmp_path / "run"))
+    assert paths.run_root() == tmp_path / "run"
+
+
+def test_config_path_default(monkeypatch):
+    monkeypatch.delenv("PSC_CONFIG_ROOT", raising=False)
+    assert paths.config_path("paulshaclaw.yaml") == Path.home() / ".config" / "paulshaclaw" / "paulshaclaw.yaml"
+
+
+def test_project_config_root(monkeypatch, tmp_path):
+    monkeypatch.delenv("PSC_PROJECT_CONFIG_ROOT", raising=False)
+    assert paths.project_config_root() == Path.home() / ".agents" / "config" / "paulsha"
+    monkeypatch.setenv("PSC_PROJECT_CONFIG_ROOT", str(tmp_path / "pc"))
+    assert paths.project_config_root() == tmp_path / "pc"

--- a/tests/test_stage9_project_monitor.py
+++ b/tests/test_stage9_project_monitor.py
@@ -13,12 +13,14 @@ from __future__ import annotations
 
 import json
 import os
+import signal
 import subprocess
 import sys
 import tempfile
 import textwrap
 import unittest
 from pathlib import Path
+from unittest import mock
 
 # Imports from modules that do not yet exist — these will ImportError in Red.
 # Wrapped so the module loads and individual tests fail with a clear cause
@@ -594,6 +596,45 @@ class Stage9CliTests(unittest.TestCase):
         )
         self.assertEqual(completed.returncode, 1)
         self.assertNotIn("Traceback", completed.stderr)
+
+    def test_service_mode_registers_sigterm_handler(self) -> None:
+        import paulsha_cortex.monitor.__main__ as monitor_main
+
+        calls: dict[str, object] = {}
+
+        class FakeService:
+            def __init__(self, *, config) -> None:
+                calls["config"] = config
+
+            def run_forever(self) -> None:
+                calls["handler"](signal.SIGTERM, None)
+
+            def stop(self) -> None:
+                calls["stopped"] = True
+
+        def fake_signal(sig, handler):
+            if sig == signal.SIGTERM:
+                calls["handler"] = handler
+            return signal.SIG_DFL
+
+        def fake_getsignal(sig):
+            assert sig == signal.SIGTERM
+            return signal.SIG_DFL
+
+        with (
+            mock.patch.object(
+                monitor_main,
+                "load_config",
+                lambda config_path=None: MonitorConfig(
+                    workspaces=(WorkspaceConfig(path=self.tmp, name="ws"),)
+                ),
+            ),
+            mock.patch.object(monitor_main, "ProjectMonitorService", FakeService),
+            mock.patch.object(monitor_main.signal, "signal", fake_signal),
+            mock.patch.object(monitor_main.signal, "getsignal", fake_getsignal),
+        ):
+            self.assertEqual(monitor_main.main([]), 0)
+        self.assertTrue(calls.get("stopped"))
 
 
 # --- Snapshot integration test ---------------------------------------------

--- a/tests/test_stage9_project_monitor.py
+++ b/tests/test_stage9_project_monitor.py
@@ -346,6 +346,26 @@ class Stage9ClassifierTests(unittest.TestCase):
         self.assertIn("projT", ids)
         self.assertNotIn("skipme", ids)
 
+    def test_scan_workspaces_skips_unreadable_workspace_root(self) -> None:
+        ws_root = self.tmp / "ws"
+        make_workspace(
+            ws_root,
+            {"projT": {"kind": "tracked-paul-yml"}},
+        )
+        cfg = MonitorConfig(
+            workspaces=(WorkspaceConfig(path=ws_root, name="ws"),),
+            legacy_policy="list-only",
+        )
+        original_iterdir = Path.iterdir
+
+        def fake_iterdir(path_self):
+            if path_self == ws_root:
+                raise PermissionError("denied")
+            return original_iterdir(path_self)
+
+        with mock.patch.object(Path, "iterdir", fake_iterdir):
+            self.assertEqual(scan_workspaces(cfg), ())
+
     def test_duplicate_project_names_are_qualified_in_snapshot(self) -> None:
         west = make_workspace(
             self.tmp / "west",
@@ -458,6 +478,22 @@ class Stage9ParserTests(unittest.TestCase):
         state = extract_project_state(proj, workspace_name="ws")
         kinds = {s.kind for s in state.source_signals}
         self.assertIn("todo", kinds)
+
+    def test_extract_project_state_marks_unreadable_archive_as_degraded(self) -> None:
+        proj = self._make_project_with_todo(DEFAULT_TODO)
+        archive_root = proj / "openspec" / "changes" / "archive"
+        archive_root.mkdir(parents=True)
+        original_iterdir = Path.iterdir
+
+        def fake_iterdir(path_self):
+            if path_self == archive_root:
+                raise PermissionError("denied")
+            return original_iterdir(path_self)
+
+        with mock.patch.object(Path, "iterdir", fake_iterdir):
+            state = extract_project_state(proj, workspace_name="ws")
+        notes = " ".join(s.note or "" for s in state.source_signals if s.kind == "archive")
+        self.assertIn("degraded", notes.lower())
 
     def test_parse_todo_current_sprint_returns_only_open_items(self) -> None:
         proj = self._make_project_with_todo(DEFAULT_TODO)

--- a/tests/test_stage9_project_monitor.py
+++ b/tests/test_stage9_project_monitor.py
@@ -344,6 +344,26 @@ class Stage9ClassifierTests(unittest.TestCase):
         self.assertIn("projT", ids)
         self.assertNotIn("skipme", ids)
 
+    def test_duplicate_project_names_are_qualified_in_snapshot(self) -> None:
+        west = make_workspace(
+            self.tmp / "west",
+            {"same": {"kind": "tracked-paul-yml"}},
+        )
+        east = make_workspace(
+            self.tmp / "east",
+            {"same": {"kind": "tracked-paul-yml"}},
+        )
+        cfg = MonitorConfig(
+            workspaces=(
+                WorkspaceConfig(path=west, name="west"),
+                WorkspaceConfig(path=east, name="east"),
+            ),
+        )
+        states = scan_workspaces(cfg)
+        ids = [state.project_id for state in states]
+        self.assertEqual(len(states), 2)
+        self.assertEqual(len(set(ids)), 2)
+
 
 # --- B3 / Parser tests ----------------------------------------------------
 

--- a/tests/test_stage9_project_monitor.py
+++ b/tests/test_stage9_project_monitor.py
@@ -1,0 +1,622 @@
+"""Stage 9 Project Monitor — Phase 1 TDD red baseline.
+
+These tests lock the public API surface and behavioural contract for the
+Project Monitor service (see openspec/changes/2026-04-26-stage9-project-monitor/
+for proposal, design, tasks, and spec).
+
+All imports below intentionally point at modules that do not yet exist.
+Phase 2 (Green) will land the minimal implementation; Phase 3 will add the
+service runtime + Unix socket; Phase 4 will close out spec/review/archive.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+# Imports from modules that do not yet exist — these will ImportError in Red.
+# Wrapped so the module loads and individual tests fail with a clear cause
+# rather than the entire file failing to collect.
+try:
+    from paulsha_cortex.monitor.config import (
+        MonitorConfig,
+        WorkspaceConfig,
+        load_config,
+    )
+    from paulsha_cortex.monitor.models import (
+        ProjectState,
+        Signal,
+        StageRef,
+        StageView,
+        TaskRef,
+    )
+    from paulsha_cortex.monitor.parser import (
+        extract_project_state,
+        parse_blockers,
+        parse_todo_current_sprint,
+    )
+    from paulsha_cortex.monitor.scanner import (
+        ProjectClassification,
+        classify_project,
+        scan_workspaces,
+    )
+
+    MONITOR_AVAILABLE = True
+    IMPORT_ERROR: ImportError | None = None
+except ImportError as exc:  # Expected during Phase 1 Red
+    MONITOR_AVAILABLE = False
+    IMPORT_ERROR = exc
+
+
+# --- fixture helpers -------------------------------------------------------
+
+
+def write_yaml(content: str) -> Path:
+    """Write a YAML string to a temp file and return its path."""
+    handle = tempfile.NamedTemporaryFile("w", suffix=".yaml", delete=False)
+    try:
+        handle.write(textwrap.dedent(content))
+        handle.flush()
+    finally:
+        handle.close()
+    return Path(handle.name)
+
+
+def make_workspace(root: Path, projects: dict[str, dict]) -> Path:
+    """Create a synthetic workspace directory tree under `root`.
+
+    `projects` maps directory name → spec dict:
+      {"kind": "tracked-paul-yml" | "tracked-workstream" | "legacy",
+       "todo": str | None, "blockers": str | None}
+    """
+    root.mkdir(parents=True, exist_ok=True)
+    for name, spec in projects.items():
+        proj = root / name
+        proj.mkdir(parents=True, exist_ok=True)
+        kind = spec["kind"]
+        if kind == "tracked-paul-yml":
+            (proj / ".paul-project.yml").write_text(
+                "policy_profile: stage-driven\npolicy_version: 1.0.0\n"
+            )
+        if kind in ("tracked-workstream", "tracked-paul-yml"):
+            ws = proj / "docs" / "superpowers" / "workstreams" / "stage1-demo"
+            ws.mkdir(parents=True, exist_ok=True)
+            todo = spec.get("todo") or DEFAULT_TODO
+            (ws / "todo.md").write_text(textwrap.dedent(todo))
+            (ws / "task.md").write_text("# task\n- [ ] do thing\n")
+        # legacy: nothing extra
+    return root
+
+
+DEFAULT_TODO = """\
+# stage1-demo / todo
+
+## Current Sprint
+
+- [ ] processing item alpha
+- [ ] next item beta
+- [x] already done item
+
+## Blockers
+
+- [ ] waiting on upstream X
+- [ ] need decision on Y
+
+## Evidence / Links
+
+- [ ] phase 1 red log
+
+## Handoff Notes
+
+- [ ] handoff to next persona
+"""
+
+
+# --- skip helper ----------------------------------------------------------
+
+
+def _require_monitor(test: unittest.TestCase) -> None:
+    """Phase-1 red guard.
+
+    During TDD Red, the `paulsha_cortex.monitor` package does not exist yet,
+    so we fail (not skip) with a clear pointer to the missing import. Once
+    Phase 2 Green lands the module, this helper becomes a no-op and the
+    body of each test runs its real assertions.
+    """
+    if not MONITOR_AVAILABLE:
+        test.fail(
+            f"paulsha_cortex.monitor not implemented yet (Phase 1 Red): {IMPORT_ERROR}"
+        )
+
+
+# --- B1 / Config tests ----------------------------------------------------
+
+
+class Stage9ConfigTests(unittest.TestCase):
+    """Lock the global config loader contract (design §3.5, spec §B1)."""
+
+    def setUp(self) -> None:
+        _require_monitor(self)
+
+    def make_config(self, body: str) -> Path:
+        path = write_yaml(body)
+        self.addCleanup(path.unlink, missing_ok=True)
+        return path
+
+    def test_load_config_reads_explicit_path(self) -> None:
+        path = self.make_config(
+            """
+            workspaces:
+              - path: /tmp/wsA
+                name: a
+              - path: /tmp/wsB
+                name: b
+            monitor:
+              poll_interval_seconds: 30
+              rescan_interval_seconds: 300
+              legacy_policy: hide
+            """
+        )
+        cfg = load_config(config_path=path)
+        self.assertIsInstance(cfg, MonitorConfig)
+        self.assertEqual(len(cfg.workspaces), 2)
+        self.assertEqual(cfg.workspaces[0].name, "a")
+        self.assertEqual(cfg.poll_interval_seconds, 30)
+        self.assertEqual(cfg.rescan_interval_seconds, 300)
+        self.assertEqual(cfg.legacy_policy, "hide")
+
+    def test_load_config_supports_env_fallback(self) -> None:
+        path = self.make_config(
+            """
+            workspaces:
+              - path: /tmp/wsA
+                name: a
+            """
+        )
+        previous = os.environ.get("PAULSHACLAW_CONFIG")
+        os.environ["PAULSHACLAW_CONFIG"] = str(path)
+        try:
+            cfg = load_config()
+        finally:
+            if previous is None:
+                os.environ.pop("PAULSHACLAW_CONFIG", None)
+            else:
+                os.environ["PAULSHACLAW_CONFIG"] = previous
+
+        self.assertEqual(cfg.workspaces[0].name, "a")
+
+    def test_load_config_applies_documented_defaults(self) -> None:
+        path = self.make_config(
+            """
+            workspaces:
+              - path: /tmp/wsA
+                name: a
+            """
+        )
+        cfg = load_config(config_path=path)
+        self.assertEqual(cfg.poll_interval_seconds, 60)
+        self.assertEqual(cfg.rescan_interval_seconds, 300)
+        self.assertEqual(cfg.watch_debounce_ms, 500)
+        self.assertEqual(cfg.legacy_policy, "list-only")
+
+    def test_load_config_rejects_empty_workspaces(self) -> None:
+        path = self.make_config(
+            """
+            workspaces: []
+            """
+        )
+        with self.assertRaisesRegex(ValueError, "workspaces"):
+            load_config(config_path=path)
+
+    def test_load_config_rejects_invalid_legacy_policy(self) -> None:
+        path = self.make_config(
+            """
+            workspaces:
+              - path: /tmp/wsA
+                name: a
+            monitor:
+              legacy_policy: somethingelse
+            """
+        )
+        with self.assertRaisesRegex(ValueError, "legacy_policy"):
+            load_config(config_path=path)
+
+    def test_sample_config_file_loads(self) -> None:
+        sample = self.make_config(
+            """
+            workspaces:
+              - path: ~/prj_work
+                name: archive
+              - path: ~/prj_pri
+                name: private
+            monitor:
+              poll_interval_seconds: 60
+              rescan_interval_seconds: 300
+              watch_debounce_ms: 500
+              legacy_policy: list-only
+              socket_path: ~/.agents/run/project-monitor.sock
+              ignore_dirs: []
+            """
+        )
+        cfg = load_config(config_path=sample)
+        names = {ws.name for ws in cfg.workspaces}
+        # Defaults documented in design §3.5
+        self.assertIn("archive", names)
+        self.assertIn("private", names)
+
+
+# --- B2 / Classifier tests ------------------------------------------------
+
+
+class Stage9ClassifierTests(unittest.TestCase):
+    """Lock tracked-vs-legacy classification (design §3.2, spec §B2)."""
+
+    def setUp(self) -> None:
+        _require_monitor(self)
+        self.tmp = Path(tempfile.mkdtemp(prefix="stage9-classifier-"))
+        self.addCleanup(self._cleanup)
+
+    def _cleanup(self) -> None:
+        import shutil
+
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_project_with_paul_project_yml_is_tracked(self) -> None:
+        ws = make_workspace(
+            self.tmp / "ws",
+            {"projA": {"kind": "tracked-paul-yml"}},
+        )
+        result = classify_project(ws / "projA")
+        self.assertEqual(result, ProjectClassification.TRACKED)
+
+    def test_project_with_workstreams_dir_is_tracked(self) -> None:
+        ws = make_workspace(
+            self.tmp / "ws",
+            {"projB": {"kind": "tracked-workstream"}},
+        )
+        result = classify_project(ws / "projB")
+        self.assertEqual(result, ProjectClassification.TRACKED)
+
+    def test_project_without_either_is_legacy(self) -> None:
+        ws = make_workspace(
+            self.tmp / "ws",
+            {"projC": {"kind": "legacy"}},
+        )
+        result = classify_project(ws / "projC")
+        self.assertEqual(result, ProjectClassification.LEGACY)
+
+    def test_legacy_policy_hide_excludes_legacy_projects(self) -> None:
+        ws_root = self.tmp / "ws"
+        make_workspace(
+            ws_root,
+            {
+                "projT": {"kind": "tracked-paul-yml"},
+                "projL": {"kind": "legacy"},
+            },
+        )
+        cfg = MonitorConfig(
+            workspaces=(WorkspaceConfig(path=ws_root, name="ws"),),
+            legacy_policy="hide",
+        )
+        states = scan_workspaces(cfg)
+        ids = {s.project_id for s in states}
+        self.assertIn("projT", ids)
+        self.assertNotIn("projL", ids)
+
+    def test_legacy_policy_list_only_includes_legacy_with_no_state(self) -> None:
+        ws_root = self.tmp / "ws"
+        make_workspace(
+            ws_root,
+            {
+                "projT": {"kind": "tracked-paul-yml"},
+                "projL": {"kind": "legacy"},
+            },
+        )
+        cfg = MonitorConfig(
+            workspaces=(WorkspaceConfig(path=ws_root, name="ws"),),
+            legacy_policy="list-only",
+        )
+        states = {s.project_id: s for s in scan_workspaces(cfg)}
+        self.assertTrue(states["projL"].legacy)
+        self.assertEqual(states["projL"].in_progress_stages, ())
+        self.assertEqual(states["projL"].completed_stages, ())
+
+    def test_ignore_dirs_filter_skips_listed_directories(self) -> None:
+        ws_root = self.tmp / "ws"
+        make_workspace(
+            ws_root,
+            {
+                "projT": {"kind": "tracked-paul-yml"},
+                "skipme": {"kind": "tracked-paul-yml"},
+            },
+        )
+        cfg = MonitorConfig(
+            workspaces=(WorkspaceConfig(path=ws_root, name="ws"),),
+            ignore_dirs=("skipme",),
+        )
+        ids = {s.project_id for s in scan_workspaces(cfg)}
+        self.assertIn("projT", ids)
+        self.assertNotIn("skipme", ids)
+
+
+# --- B3 / Parser tests ----------------------------------------------------
+
+
+class Stage9ParserTests(unittest.TestCase):
+    """Lock state-extraction rules (design §3.3, spec §B3)."""
+
+    def setUp(self) -> None:
+        _require_monitor(self)
+        self.tmp = Path(tempfile.mkdtemp(prefix="stage9-parser-"))
+        self.addCleanup(self._cleanup)
+
+    def _cleanup(self) -> None:
+        import shutil
+
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _make_project_with_todo(self, todo_body: str) -> Path:
+        proj = self.tmp / "proj"
+        ws = proj / "docs" / "superpowers" / "workstreams" / "stage1-demo"
+        ws.mkdir(parents=True, exist_ok=True)
+        (proj / ".paul-project.yml").write_text("policy_profile: stage-driven\n")
+        (ws / "todo.md").write_text(textwrap.dedent(todo_body))
+        return proj
+
+    def test_processing_task_is_first_unchecked_in_current_sprint(self) -> None:
+        proj = self._make_project_with_todo(DEFAULT_TODO)
+        state = extract_project_state(proj, workspace_name="ws")
+        self.assertEqual(len(state.in_progress_stages), 1)
+        view = state.in_progress_stages[0]
+        self.assertIsNotNone(view.processing_task)
+        self.assertEqual(view.processing_task.text, "processing item alpha")
+
+    def test_next_task_is_second_unchecked(self) -> None:
+        proj = self._make_project_with_todo(DEFAULT_TODO)
+        state = extract_project_state(proj, workspace_name="ws")
+        view = state.in_progress_stages[0]
+        self.assertIsNotNone(view.next_task)
+        self.assertEqual(view.next_task.text, "next item beta")
+
+    def test_blockers_parsed_from_blockers_section(self) -> None:
+        proj = self._make_project_with_todo(DEFAULT_TODO)
+        state = extract_project_state(proj, workspace_name="ws")
+        view = state.in_progress_stages[0]
+        self.assertEqual(
+            list(view.blockers),
+            ["waiting on upstream X", "need decision on Y"],
+        )
+
+    def test_in_progress_when_open_checkbox_in_current_sprint(self) -> None:
+        proj = self._make_project_with_todo(DEFAULT_TODO)
+        state = extract_project_state(proj, workspace_name="ws")
+        ids = {v.stage_id for v in state.in_progress_stages}
+        self.assertIn("stage1-demo", ids)
+
+    def test_completed_when_all_current_sprint_items_checked(self) -> None:
+        completed_todo = """\
+        # stage1-demo / todo
+
+        ## Current Sprint
+
+        - [x] all done
+
+        ## Blockers
+        ## Evidence / Links
+        ## Handoff Notes
+        """
+        proj = self._make_project_with_todo(completed_todo)
+        state = extract_project_state(proj, workspace_name="ws")
+        # No open work in Current Sprint AND no archive entry → still pending,
+        # NOT in_progress. Real "completed" requires archive evidence; this test
+        # just guards that the parser does not falsely promote to in_progress.
+        self.assertEqual(state.in_progress_stages, ())
+
+    def test_malformed_todo_marks_stage_as_degraded(self) -> None:
+        proj = self.tmp / "proj-bad"
+        ws = proj / "docs" / "superpowers" / "workstreams" / "stage1-demo"
+        ws.mkdir(parents=True, exist_ok=True)
+        (proj / ".paul-project.yml").write_text("policy_profile: stage-driven\n")
+        # Binary-ish payload that will reasonably trip the parser
+        (ws / "todo.md").write_bytes(b"\xff\xfe not utf-8 \xff\xfe")
+
+        state = extract_project_state(proj, workspace_name="ws")
+        # Should not raise. Should record degradation in source_signals.
+        notes = " ".join(s.note or "" for s in state.source_signals)
+        self.assertIn("degraded", notes.lower())
+
+    def test_source_signals_record_inspected_paths(self) -> None:
+        proj = self._make_project_with_todo(DEFAULT_TODO)
+        state = extract_project_state(proj, workspace_name="ws")
+        kinds = {s.kind for s in state.source_signals}
+        self.assertIn("todo", kinds)
+
+    def test_parse_todo_current_sprint_returns_only_open_items(self) -> None:
+        proj = self._make_project_with_todo(DEFAULT_TODO)
+        items = parse_todo_current_sprint(
+            proj / "docs" / "superpowers" / "workstreams" / "stage1-demo" / "todo.md"
+        )
+        texts = [t.text for t in items]
+        self.assertEqual(texts, ["processing item alpha", "next item beta"])
+
+    def test_parse_blockers_returns_listed_strings(self) -> None:
+        proj = self._make_project_with_todo(DEFAULT_TODO)
+        blockers = parse_blockers(
+            proj / "docs" / "superpowers" / "workstreams" / "stage1-demo" / "todo.md"
+        )
+        self.assertEqual(
+            list(blockers),
+            ["waiting on upstream X", "need decision on Y"],
+        )
+
+
+# --- B5 / B6 / CLI tests --------------------------------------------------
+
+
+class Stage9CliTests(unittest.TestCase):
+    """Lock --once CLI contract (design §3.4, spec §B5/B6)."""
+
+    def setUp(self) -> None:
+        _require_monitor(self)
+        self.tmp = Path(tempfile.mkdtemp(prefix="stage9-cli-"))
+        self.addCleanup(self._cleanup)
+
+    def _cleanup(self) -> None:
+        import shutil
+
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _write_config_for(self, ws_root: Path) -> Path:
+        path = self.tmp / "monitor.yaml"
+        path.write_text(
+            textwrap.dedent(
+                f"""
+                workspaces:
+                  - path: {ws_root}
+                    name: ws
+                monitor:
+                  legacy_policy: list-only
+                """
+            )
+        )
+        return path
+
+    def test_module_help_exits_zero(self) -> None:
+        completed = subprocess.run(
+            [sys.executable, "-m", "paulsha_cortex.monitor", "--help"],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(completed.returncode, 0, msg=completed.stderr)
+        self.assertIn("--once", completed.stdout)
+        self.assertIn("--config", completed.stdout)
+
+    def test_once_mode_exits_zero_with_json_snapshot(self) -> None:
+        ws_root = self.tmp / "ws"
+        make_workspace(
+            ws_root,
+            {
+                "projT": {"kind": "tracked-paul-yml"},
+                "projL": {"kind": "legacy"},
+            },
+        )
+        cfg = self._write_config_for(ws_root)
+
+        completed = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "paulsha_cortex.monitor",
+                "--once",
+                "--config",
+                str(cfg),
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+        self.assertEqual(completed.returncode, 0, msg=completed.stderr)
+        payload = json.loads(completed.stdout)
+        self.assertIsInstance(payload, dict)
+        self.assertIn("projects", payload)
+        ids = {p["project_id"] for p in payload["projects"]}
+        self.assertIn("projT", ids)
+        self.assertIn("projL", ids)
+
+    def test_missing_workspace_path_does_not_crash(self) -> None:
+        ws_root = self.tmp / "definitely-not-here"
+        cfg = self._write_config_for(ws_root)
+
+        completed = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "paulsha_cortex.monitor",
+                "--once",
+                "--config",
+                str(cfg),
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+        # Missing workspace must not crash; it should be logged and skipped.
+        self.assertEqual(completed.returncode, 0, msg=completed.stderr)
+        payload = json.loads(completed.stdout)
+        self.assertEqual(payload["projects"], [])
+
+    def test_once_mode_traceback_does_not_leak_to_stderr_on_known_error(
+        self,
+    ) -> None:
+        # Pointing at a non-existent config should produce a clean error,
+        # not a Python traceback (parity with stage1 CLI clean-error behaviour).
+        completed = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "paulsha_cortex.monitor",
+                "--once",
+                "--config",
+                str(self.tmp / "nope.yaml"),
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(completed.returncode, 1)
+        self.assertNotIn("Traceback", completed.stderr)
+
+
+# --- Snapshot integration test ---------------------------------------------
+
+
+class Stage9SnapshotTests(unittest.TestCase):
+    """Point monitor at paulshaclaw itself and verify ground truth.
+
+    This is the integration test promised in design §6: the verified state
+    from 2026-04-26 (Stages 0-7 + 11 completed and on main; Stage 9 in
+    progress on this very worktree) must be re-derived by the monitor.
+    """
+
+    def setUp(self) -> None:
+        _require_monitor(self)
+
+    def test_paulshaclaw_self_snapshot_matches_known_state(self) -> None:
+        # Repo root = the worktree containing this test file.
+        repo_root = Path(__file__).resolve().parents[1]
+        # Use the parent dir as the workspace root so the current repo appears
+        # as a project under a workspace.
+        workspace_root = repo_root.parent
+        cfg = MonitorConfig(
+            workspaces=(WorkspaceConfig(path=workspace_root, name="self"),),
+            legacy_policy="list-only",
+        )
+        states = {s.project_id: s for s in scan_workspaces(cfg)}
+
+        # The active worktree itself must appear
+        # as tracked, not legacy.
+        candidates = [
+            sid
+            for sid in states
+            if sid == repo_root.name or "stage9-project-monitor" in sid
+        ]
+        self.assertTrue(
+            candidates,
+            msg=f"expected project {repo_root.name} under {workspace_root}, got {list(states)}",
+        )
+        sample = states[candidates[0]]
+        self.assertFalse(sample.legacy)
+        self.assertEqual(sample.project_id, repo_root.name)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_stage9_project_monitor.py
+++ b/tests/test_stage9_project_monitor.py
@@ -179,15 +179,15 @@ class Stage9ConfigTests(unittest.TestCase):
                 name: a
             """
         )
-        previous = os.environ.get("PAULSHACLAW_CONFIG")
-        os.environ["PAULSHACLAW_CONFIG"] = str(path)
+        previous = os.environ.get("PSC_MONITOR_CONFIG")
+        os.environ["PSC_MONITOR_CONFIG"] = str(path)
         try:
             cfg = load_config()
         finally:
             if previous is None:
-                os.environ.pop("PAULSHACLAW_CONFIG", None)
+                os.environ.pop("PSC_MONITOR_CONFIG", None)
             else:
-                os.environ["PAULSHACLAW_CONFIG"] = previous
+                os.environ["PSC_MONITOR_CONFIG"] = previous
 
         self.assertEqual(cfg.workspaces[0].name, "a")
 

--- a/tests/test_stage9_project_monitor_service.py
+++ b/tests/test_stage9_project_monitor_service.py
@@ -487,9 +487,19 @@ class Stage9ServerTests(unittest.TestCase):
             reclaimed.stop()
             reclaimed_thread.join(timeout=2.0)
 
+    def test_server_refuses_to_delete_non_socket_path(self) -> None:
+        bad_path = self.tmp / "not-a-socket"
+        bad_path.write_text("occupied", encoding="utf-8")
+        contender = MonitorServer(store=self.store, socket_path=bad_path)
+        with self.assertRaisesRegex(RuntimeError, "不是 Unix socket"):
+            contender._prepare_socket_path()
+        self.assertTrue(bad_path.exists())
+
     def test_server_timeout_probe_treats_socket_as_live(self) -> None:
         busy_path = self.tmp / "busy-monitor.sock"
-        busy_path.write_text("", encoding="utf-8")
+        busy = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        busy.bind(str(busy_path))
+        busy.close()
         contender = MonitorServer(store=self.store, socket_path=busy_path)
 
         class _TimeoutProbe:

--- a/tests/test_stage9_project_monitor_service.py
+++ b/tests/test_stage9_project_monitor_service.py
@@ -1,0 +1,711 @@
+"""Stage 9 Phase 3 — service runtime, watcher, Unix socket server tests.
+
+Public API surface this file locks (Phase 3 Red):
+
+    from paulsha_cortex.monitor.snapshot import (
+        SnapshotStore, ChangeEvent, EventStream,
+    )
+    from paulsha_cortex.monitor.watcher import (
+        Watcher, StubWatcher, WatchdogFileWatcher,
+    )
+    from paulsha_cortex.monitor.server import MonitorServer
+    from paulsha_cortex.monitor.service import ProjectMonitorService
+
+Wire contract for the Unix socket (locked by Stage9ServerTests):
+
+  Request  : single JSON object per line
+             {"kind": "list_projects"}
+             {"kind": "get_project_state", "project_id": "<id>"}
+             {"kind": "subscribe"}                                # all
+             {"kind": "subscribe", "projects": ["<id>", ...]}     # filter
+             unknown kind → {"ok": false, "error": "<reason>"}
+  Response : for unary requests → single JSON object on one line
+             {"ok": true, "data": <payload>}
+             for subscribe → newline-delimited JSON event stream:
+             {"sequence": 1, "kind": "snapshot", "projects": [...]}
+             {"sequence": 2, "kind": "change", "project": {...}}
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import socket
+import stat
+import tempfile
+import textwrap
+import threading
+import time
+import unittest
+from pathlib import Path
+from unittest import mock
+
+# Imports from the Phase 3 modules (do not exist yet — Red).
+try:
+    from paulsha_cortex.monitor.config import MonitorConfig, WorkspaceConfig
+    from paulsha_cortex.monitor.scanner import scan_workspaces
+    from paulsha_cortex.monitor.snapshot import (
+        ChangeEvent,
+        SnapshotStore,
+    )
+    from paulsha_cortex.monitor.watcher import (
+        StubWatcher,
+        Watcher,
+    )
+    from paulsha_cortex.monitor.server import MonitorServer
+    from paulsha_cortex.monitor.service import ProjectMonitorService
+
+    PHASE3_AVAILABLE = True
+    PHASE3_IMPORT_ERROR: ImportError | None = None
+except ImportError as exc:
+    PHASE3_AVAILABLE = False
+    PHASE3_IMPORT_ERROR = exc
+
+# Optional watchdog integration (real fs events).
+try:
+    from paulsha_cortex.monitor.watcher import WatchdogFileWatcher
+    import watchdog  # noqa: F401  (only used to gate the integration test)
+
+    HAS_WATCHDOG_INTEGRATION = True
+except ImportError:
+    HAS_WATCHDOG_INTEGRATION = False
+
+
+# --- helpers -------------------------------------------------------------
+
+
+def _require_phase3(test: unittest.TestCase) -> None:
+    if not PHASE3_AVAILABLE:
+        test.fail(
+            f"paulsha_cortex.monitor service layer not implemented yet "
+            f"(Phase 3 Red): {PHASE3_IMPORT_ERROR}"
+        )
+
+
+def _make_workspace(root: Path, project_name: str, todo_body: str) -> Path:
+    proj = root / project_name
+    ws = proj / "docs" / "superpowers" / "workstreams" / "stage1-demo"
+    ws.mkdir(parents=True, exist_ok=True)
+    (proj / ".paul-project.yml").write_text("policy_profile: stage-driven\n")
+    (ws / "todo.md").write_text(textwrap.dedent(todo_body))
+    return proj
+
+
+DEFAULT_TODO = """\
+# stage1-demo / todo
+
+## Current Sprint
+
+- [ ] processing alpha
+- [ ] next beta
+
+## Blockers
+
+## Evidence / Links
+
+## Handoff Notes
+"""
+
+
+def _socket_recv_line(sock: socket.socket, timeout: float = 2.0) -> bytes:
+    """Read until newline. Raises TimeoutError if no line within `timeout`."""
+    sock.settimeout(timeout)
+    chunks: list[bytes] = []
+    while True:
+        ch = sock.recv(1)
+        if not ch:
+            break
+        chunks.append(ch)
+        if ch == b"\n":
+            break
+    return b"".join(chunks)
+
+
+def _socket_send_request(sock: socket.socket, request: dict) -> None:
+    sock.sendall((json.dumps(request) + "\n").encode("utf-8"))
+
+
+# --- B-store / SnapshotStore --------------------------------------------
+
+
+class Stage9SnapshotStoreTests(unittest.TestCase):
+    """Snapshot store: in-memory truth + diff + monotonic sequence."""
+
+    def setUp(self) -> None:
+        _require_phase3(self)
+        self.tmp = Path(tempfile.mkdtemp(prefix="stage9-store-"))
+        self.addCleanup(self._cleanup)
+
+    def _cleanup(self) -> None:
+        import shutil
+
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _build_config(self) -> MonitorConfig:
+        return MonitorConfig(
+            workspaces=(WorkspaceConfig(path=self.tmp / "ws", name="ws"),),
+            legacy_policy="list-only",
+        )
+
+    def test_store_load_returns_initial_snapshot_with_no_events(self) -> None:
+        (self.tmp / "ws").mkdir(parents=True, exist_ok=True)
+        _make_workspace(self.tmp / "ws", "projA", DEFAULT_TODO)
+        cfg = self._build_config()
+
+        store = SnapshotStore(config=cfg)
+        events = store.load()
+
+        self.assertEqual(events, ())
+        snapshot = store.current_snapshot()
+        ids = {p.project_id for p in snapshot}
+        self.assertIn("projA", ids)
+
+    def test_store_refresh_emits_event_when_project_state_changes(self) -> None:
+        (self.tmp / "ws").mkdir(parents=True, exist_ok=True)
+        proj = _make_workspace(self.tmp / "ws", "projA", DEFAULT_TODO)
+        cfg = self._build_config()
+
+        store = SnapshotStore(config=cfg)
+        store.load()
+
+        # Mutate the underlying todo and refresh — store must emit a change.
+        new_body = DEFAULT_TODO.replace("processing alpha", "processing alpha v2")
+        (proj / "docs" / "superpowers" / "workstreams" / "stage1-demo" / "todo.md").write_text(
+            new_body
+        )
+
+        events = store.refresh()
+        self.assertEqual(len(events), 1)
+        evt = events[0]
+        self.assertIsInstance(evt, ChangeEvent)
+        self.assertEqual(evt.project_id, "projA")
+
+    def test_store_refresh_emits_no_event_when_state_unchanged(self) -> None:
+        (self.tmp / "ws").mkdir(parents=True, exist_ok=True)
+        _make_workspace(self.tmp / "ws", "projA", DEFAULT_TODO)
+        cfg = self._build_config()
+        store = SnapshotStore(config=cfg)
+        store.load()
+
+        events = store.refresh()  # identical state
+        self.assertEqual(events, ())
+
+    def test_store_refresh_removes_deleted_project_from_snapshot(self) -> None:
+        (self.tmp / "ws").mkdir(parents=True, exist_ok=True)
+        _make_workspace(self.tmp / "ws", "projA", DEFAULT_TODO)
+        doomed = _make_workspace(self.tmp / "ws", "projB", DEFAULT_TODO)
+        cfg = self._build_config()
+        store = SnapshotStore(config=cfg)
+        store.load()
+
+        import shutil
+
+        shutil.rmtree(doomed)
+
+        store.refresh()
+
+        ids = {project.project_id for project in store.current_snapshot()}
+        self.assertEqual(ids, {"projA"})
+        self.assertIsNone(store.get("projB"))
+
+    def test_store_assigns_monotonic_sequence_to_events(self) -> None:
+        (self.tmp / "ws").mkdir(parents=True, exist_ok=True)
+        proj = _make_workspace(self.tmp / "ws", "projA", DEFAULT_TODO)
+        cfg = self._build_config()
+        store = SnapshotStore(config=cfg)
+        store.load()
+
+        todo_path = (
+            proj / "docs" / "superpowers" / "workstreams" / "stage1-demo" / "todo.md"
+        )
+        todo_path.write_text(DEFAULT_TODO.replace("alpha", "alpha-1"))
+        first = store.refresh()
+        todo_path.write_text(DEFAULT_TODO.replace("alpha", "alpha-2"))
+        second = store.refresh()
+
+        self.assertEqual(len(first), 1)
+        self.assertEqual(len(second), 1)
+        self.assertGreater(second[0].sequence, first[0].sequence)
+
+
+# --- Stub watcher -------------------------------------------------------
+
+
+class Stage9StubWatcherTests(unittest.TestCase):
+    """Test-friendly Watcher impl that fires on manual trigger."""
+
+    def setUp(self) -> None:
+        _require_phase3(self)
+
+    def test_stub_watcher_invokes_callback_on_trigger(self) -> None:
+        received: list[Path] = []
+        watcher: Watcher = StubWatcher()
+        watcher.watch(Path("/tmp/whatever"), received.append)
+
+        watcher.trigger(Path("/tmp/whatever"))
+
+        self.assertEqual(received, [Path("/tmp/whatever")])
+
+    def test_stub_watcher_stop_prevents_further_callbacks(self) -> None:
+        received: list[Path] = []
+        watcher = StubWatcher()
+        watcher.watch(Path("/tmp/x"), received.append)
+        watcher.stop()
+
+        watcher.trigger(Path("/tmp/x"))
+
+        self.assertEqual(received, [])
+
+
+# --- MonitorServer (Unix socket) ----------------------------------------
+
+
+class Stage9ServerTests(unittest.TestCase):
+    """Unix domain socket server: list / get / subscribe + permissions."""
+
+    def setUp(self) -> None:
+        _require_phase3(self)
+        self.tmp = Path(tempfile.mkdtemp(prefix="stage9-server-"))
+        (self.tmp / "ws").mkdir(parents=True, exist_ok=True)
+        _make_workspace(self.tmp / "ws", "projA", DEFAULT_TODO)
+        _make_workspace(self.tmp / "ws", "projB", DEFAULT_TODO)
+        self.cfg = MonitorConfig(
+            workspaces=(WorkspaceConfig(path=self.tmp / "ws", name="ws"),),
+            legacy_policy="list-only",
+        )
+        self.store = SnapshotStore(config=self.cfg)
+        self.store.load()
+        self.socket_path = self.tmp / "monitor.sock"
+        self.server = MonitorServer(store=self.store, socket_path=self.socket_path)
+        self.server_thread = threading.Thread(
+            target=self.server.serve_forever, daemon=True
+        )
+        self.server_thread.start()
+        # wait for socket to appear
+        for _ in range(50):
+            if self.socket_path.exists():
+                break
+            time.sleep(0.02)
+        self.assertTrue(
+            self.socket_path.exists(), msg="server socket did not bind in time"
+        )
+        self.addCleanup(self._cleanup)
+
+    def _cleanup(self) -> None:
+        self.server.stop()
+        self.server_thread.join(timeout=2.0)
+        import shutil
+
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _connect(self) -> socket.socket:
+        deadline = time.time() + 1.0
+        last_error: OSError | None = None
+        while time.time() < deadline:
+            sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            try:
+                sock.connect(str(self.socket_path))
+            except ConnectionRefusedError as error:
+                last_error = error
+                sock.close()
+                time.sleep(0.02)
+                continue
+            self.addCleanup(sock.close)
+            return sock
+        raise AssertionError(
+            f"server socket refused connections for 1s: {last_error}"
+        )
+
+    def test_server_responds_to_list_projects_request(self) -> None:
+        sock = self._connect()
+        _socket_send_request(sock, {"kind": "list_projects"})
+        line = _socket_recv_line(sock)
+
+        payload = json.loads(line)
+        self.assertTrue(payload["ok"])
+        ids = {p["project_id"] for p in payload["data"]["projects"]}
+        self.assertEqual(ids, {"projA", "projB"})
+
+    def test_server_responds_to_get_project_state_request(self) -> None:
+        sock = self._connect()
+        _socket_send_request(
+            sock, {"kind": "get_project_state", "project_id": "projA"}
+        )
+        line = _socket_recv_line(sock)
+
+        payload = json.loads(line)
+        self.assertTrue(payload["ok"])
+        self.assertEqual(payload["data"]["project_id"], "projA")
+
+    def test_server_subscribe_streams_initial_snapshot_then_change_event(
+        self,
+    ) -> None:
+        sock = self._connect()
+        _socket_send_request(sock, {"kind": "subscribe"})
+
+        # First message = full snapshot with sequence 0 (or implementation-defined start).
+        first_line = _socket_recv_line(sock)
+        snapshot_msg = json.loads(first_line)
+        self.assertEqual(snapshot_msg["kind"], "snapshot")
+        self.assertIn("sequence", snapshot_msg)
+
+        # Mutate a project then push a refresh through the store.
+        proj_a = self.tmp / "ws" / "projA"
+        todo = proj_a / "docs" / "superpowers" / "workstreams" / "stage1-demo" / "todo.md"
+        todo.write_text(DEFAULT_TODO.replace("alpha", "alpha-mut"))
+        new_events = self.store.refresh()
+        self.assertEqual(len(new_events), 1)
+        # The server is responsible for fanning the event out to subscribers.
+        self.server.publish_events(new_events)
+
+        change_line = _socket_recv_line(sock, timeout=3.0)
+        change_msg = json.loads(change_line)
+        self.assertEqual(change_msg["kind"], "change")
+        self.assertGreater(change_msg["sequence"], snapshot_msg["sequence"])
+        self.assertEqual(change_msg["project"]["project_id"], "projA")
+
+    def test_server_socket_has_0600_permission(self) -> None:
+        mode = stat.S_IMODE(self.socket_path.stat().st_mode)
+        self.assertEqual(mode, 0o600)
+
+    def test_server_rejects_unknown_request_kind(self) -> None:
+        sock = self._connect()
+        _socket_send_request(sock, {"kind": "definitely_not_a_real_kind"})
+        line = _socket_recv_line(sock)
+
+        payload = json.loads(line)
+        self.assertFalse(payload["ok"])
+        self.assertIn("error", payload)
+
+    def test_server_rejects_live_socket_instead_of_stealing_it(self) -> None:
+        (self.tmp / "ws2").mkdir(parents=True, exist_ok=True)
+        _make_workspace(self.tmp / "ws2", "projZ", DEFAULT_TODO)
+        other_cfg = MonitorConfig(
+            workspaces=(WorkspaceConfig(path=self.tmp / "ws2", name="ws2"),),
+            legacy_policy="list-only",
+        )
+        other_store = SnapshotStore(config=other_cfg)
+        other_store.load()
+        contender = MonitorServer(store=other_store, socket_path=self.socket_path)
+        errors: list[Exception] = []
+
+        def run_contender() -> None:
+            try:
+                contender.serve_forever()
+            except Exception as exc:  # pragma: no cover - captured for assertions
+                errors.append(exc)
+
+        contender_thread = threading.Thread(target=run_contender, daemon=True)
+        contender_thread.start()
+        try:
+            deadline = time.time() + 1.0
+            while time.time() < deadline and not errors:
+                time.sleep(0.02)
+
+            sock = self._connect()
+            _socket_send_request(sock, {"kind": "list_projects"})
+            payload = json.loads(_socket_recv_line(sock))
+            self.assertTrue(payload["ok"])
+            self.assertEqual(
+                {project["project_id"] for project in payload["data"]["projects"]},
+                {"projA", "projB"},
+            )
+            self.assertTrue(errors, "second server should fail instead of stealing the live socket")
+            self.assertRegex(str(errors[0]), "live monitor|already.*monitor")
+        finally:
+            contender.stop()
+            contender_thread.join(timeout=2.0)
+
+    def test_server_reclaims_stale_socket_file(self) -> None:
+        stale_path = self.tmp / "stale-monitor.sock"
+        stale = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        stale.bind(str(stale_path))
+        stale.close()
+
+        reclaimed = MonitorServer(store=self.store, socket_path=stale_path)
+        reclaimed_thread = threading.Thread(target=reclaimed.serve_forever, daemon=True)
+        reclaimed_thread.start()
+        try:
+            deadline = time.time() + 1.0
+            sock: socket.socket | None = None
+            last_error: OSError | None = None
+            while time.time() < deadline:
+                candidate = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+                try:
+                    candidate.connect(str(stale_path))
+                except OSError as error:
+                    last_error = error
+                    candidate.close()
+                    time.sleep(0.02)
+                    continue
+                sock = candidate
+                break
+            self.assertIsNotNone(sock, msg=f"replacement server did not bind stale socket path: {last_error}")
+            self.addCleanup(sock.close)
+            _socket_send_request(sock, {"kind": "list_projects"})
+            payload = json.loads(_socket_recv_line(sock))
+            self.assertTrue(payload["ok"])
+            self.assertEqual(
+                {project["project_id"] for project in payload["data"]["projects"]},
+                {"projA", "projB"},
+            )
+        finally:
+            reclaimed.stop()
+            reclaimed_thread.join(timeout=2.0)
+
+    def test_server_timeout_probe_treats_socket_as_live(self) -> None:
+        busy_path = self.tmp / "busy-monitor.sock"
+        busy_path.write_text("", encoding="utf-8")
+        contender = MonitorServer(store=self.store, socket_path=busy_path)
+
+        class _TimeoutProbe:
+            def settimeout(self, timeout: float) -> None:
+                self.timeout = timeout
+
+            def connect(self, path: str) -> None:
+                raise TimeoutError("probe timed out")
+
+            def close(self) -> None:
+                return None
+
+        with mock.patch(
+            "paulsha_cortex.monitor.server.socket.socket",
+            return_value=_TimeoutProbe(),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "live monitor|already.*monitor"):
+                contender._prepare_socket_path()
+
+        self.assertTrue(busy_path.exists())
+
+
+# --- ProjectMonitorService end-to-end -----------------------------------
+
+
+class Stage9ServiceTests(unittest.TestCase):
+    """Full service: scanner + (stub) watcher + server."""
+
+    def setUp(self) -> None:
+        _require_phase3(self)
+        self.tmp = Path(tempfile.mkdtemp(prefix="stage9-svc-"))
+        (self.tmp / "ws").mkdir(parents=True, exist_ok=True)
+        self.project_dir = _make_workspace(self.tmp / "ws", "projA", DEFAULT_TODO)
+        (self.project_dir / ".git" / "refs" / "heads").mkdir(parents=True, exist_ok=True)
+        (self.project_dir / ".git" / "HEAD").write_text("ref: refs/heads/main\n")
+        (self.project_dir / ".git" / "refs" / "heads" / "main").write_text("deadbeef\n")
+        (self.project_dir / "node_modules" / "pkg").mkdir(parents=True, exist_ok=True)
+        (self.project_dir / "node_modules" / "pkg" / "index.js").write_text("module.exports = 1;\n")
+        self.run_dir = self.tmp / "run"
+        self.socket_path = self.run_dir / "project-monitor.sock"
+        self.cfg = MonitorConfig(
+            workspaces=(WorkspaceConfig(path=self.tmp / "ws", name="ws"),),
+            legacy_policy="list-only",
+            socket_path=self.socket_path,
+            watch_debounce_ms=80,
+            rescan_interval_seconds=1,
+        )
+        self.stub_watcher = StubWatcher()
+        self.service = ProjectMonitorService(
+            config=self.cfg, watcher=self.stub_watcher
+        )
+        self.service_thread = threading.Thread(
+            target=self.service.run_forever, daemon=True
+        )
+        self.service_thread.start()
+        for _ in range(100):
+            if self.socket_path.exists():
+                break
+            time.sleep(0.02)
+        self.assertTrue(self.socket_path.exists(), msg="service socket never bound")
+        self.addCleanup(self._cleanup)
+
+    def _cleanup(self) -> None:
+        self.service.stop()
+        self.service_thread.join(timeout=3.0)
+        import shutil
+
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _connect(self) -> socket.socket:
+        deadline = time.time() + 1.0
+        last_error: OSError | None = None
+        while time.time() < deadline:
+            sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            try:
+                sock.connect(str(self.socket_path))
+            except ConnectionRefusedError as error:
+                last_error = error
+                sock.close()
+                time.sleep(0.02)
+                continue
+            self.addCleanup(sock.close)
+            return sock
+        raise AssertionError(
+            f"service socket refused connections for 1s: {last_error}"
+        )
+
+    def test_service_creates_run_dir_with_0700_permission(self) -> None:
+        self.assertTrue(self.run_dir.exists())
+        mode = stat.S_IMODE(self.run_dir.stat().st_mode)
+        self.assertEqual(mode, 0o700)
+
+    def test_service_emits_event_when_underlying_todo_changes(self) -> None:
+        sock = self._connect()
+        _socket_send_request(sock, {"kind": "subscribe"})
+        snapshot_line = _socket_recv_line(sock)
+        snapshot_msg = json.loads(snapshot_line)
+        self.assertEqual(snapshot_msg["kind"], "snapshot")
+
+        # Mutate the todo, then trigger the stub watcher.
+        proj_a = self.tmp / "ws" / "projA"
+        todo = proj_a / "docs" / "superpowers" / "workstreams" / "stage1-demo" / "todo.md"
+        todo.write_text(DEFAULT_TODO.replace("alpha", "alpha-after"))
+        self.stub_watcher.trigger(todo)
+
+        change_line = _socket_recv_line(sock, timeout=3.0)
+        change_msg = json.loads(change_line)
+        self.assertEqual(change_msg["kind"], "change")
+        self.assertEqual(change_msg["project"]["project_id"], "projA")
+
+    def test_service_coalesces_burst_changes_into_single_event_per_project(
+        self,
+    ) -> None:
+        sock = self._connect()
+        _socket_send_request(sock, {"kind": "subscribe"})
+        snapshot_line = _socket_recv_line(sock)
+        json.loads(snapshot_line)  # consume initial snapshot
+
+        proj_a = self.tmp / "ws" / "projA"
+        todo = proj_a / "docs" / "superpowers" / "workstreams" / "stage1-demo" / "todo.md"
+
+        # Burst three writes within the debounce window.
+        for i in range(3):
+            todo.write_text(DEFAULT_TODO.replace("alpha", f"alpha-burst-{i}"))
+            self.stub_watcher.trigger(todo)
+
+        # Wait for debounce to flush and the change event to arrive.
+        change_line = _socket_recv_line(sock, timeout=3.0)
+        change_msg = json.loads(change_line)
+        self.assertEqual(change_msg["kind"], "change")
+
+        # Within a short follow-up window, no second change event for the same
+        # project should arrive (coalescing).
+        try:
+            extra = _socket_recv_line(sock, timeout=0.5)
+            extra_msg = json.loads(extra)
+            self.fail(
+                f"expected no further change event after coalescing, got {extra_msg!r}"
+            )
+        except (TimeoutError, socket.timeout):
+            pass
+
+    def test_service_watches_project_root_non_recursive_and_git_control_paths(self) -> None:
+        subscriptions = {
+            (str(path), recursive)
+            for path, _callback, recursive in self.stub_watcher.subscriptions
+        }
+
+        self.assertIn((str(self.project_dir), False), subscriptions)
+        self.assertIn((str(self.project_dir / ".git" / "HEAD"), False), subscriptions)
+        self.assertIn((str(self.project_dir / ".git" / "refs"), True), subscriptions)
+        self.assertNotIn((str(self.project_dir), True), subscriptions)
+        self.assertFalse(any("node_modules" in path for path, _recursive in subscriptions))
+
+    def test_service_branch_switch_trigger_still_emits_change_event_immediately(self) -> None:
+        sock = self._connect()
+        _socket_send_request(sock, {"kind": "subscribe"})
+        json.loads(_socket_recv_line(sock))  # consume initial snapshot
+
+        todo = self.project_dir / "docs" / "superpowers" / "workstreams" / "stage1-demo" / "todo.md"
+        todo.write_text(DEFAULT_TODO.replace("alpha", "alpha-head-trigger"))
+        self.stub_watcher.trigger(self.project_dir / ".git" / "HEAD")
+
+        change_msg = json.loads(_socket_recv_line(sock, timeout=3.0))
+        self.assertEqual(change_msg["kind"], "change")
+        self.assertEqual(change_msg["project"]["project_id"], "projA")
+
+    def test_service_deep_file_change_is_seen_after_periodic_rescan(self) -> None:
+        sock = self._connect()
+        _socket_send_request(sock, {"kind": "subscribe"})
+        json.loads(_socket_recv_line(sock))  # consume initial snapshot
+
+        todo = self.project_dir / "docs" / "superpowers" / "workstreams" / "stage1-demo" / "todo.md"
+        todo.write_text(DEFAULT_TODO.replace("alpha", "alpha-rescan"))
+
+        change_msg = json.loads(_socket_recv_line(sock, timeout=3.0))
+        self.assertEqual(change_msg["kind"], "change")
+        self.assertEqual(change_msg["project"]["project_id"], "projA")
+
+
+# --- Real watchdog integration (optional) -------------------------------
+
+
+@unittest.skipUnless(
+    HAS_WATCHDOG_INTEGRATION,
+    "requires real watchdog installed and WatchdogFileWatcher present",
+)
+class Stage9WatchdogIntegrationTests(unittest.TestCase):
+    def setUp(self) -> None:
+        _require_phase3(self)
+        self.tmp = Path(tempfile.mkdtemp(prefix="stage9-watchdog-"))
+        self.addCleanup(self._cleanup)
+
+    def _cleanup(self) -> None:
+        import shutil
+
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_watchdog_file_watcher_fires_on_real_file_change(self) -> None:
+        target = self.tmp / "watched.txt"
+        target.write_text("v1")
+        received: list[Path] = []
+        signal = threading.Event()
+
+        def callback(path: Path) -> None:
+            received.append(path)
+            signal.set()
+
+        watcher = WatchdogFileWatcher(debounce_ms=80)
+        watcher.watch(self.tmp, callback)
+        try:
+            time.sleep(0.2)  # let the observer settle
+            target.write_text("v2")
+            self.assertTrue(
+                signal.wait(timeout=3.0),
+                msg="watchdog callback never fired within 3s",
+            )
+        finally:
+            watcher.stop()
+
+        self.assertGreaterEqual(len(received), 1)
+
+    def test_watchdog_file_watcher_fires_on_file_rename_destination(self) -> None:
+        git_dir = self.tmp / ".git"
+        git_dir.mkdir(parents=True, exist_ok=True)
+        head_path = git_dir / "HEAD"
+        head_path.write_text("ref: refs/heads/main\n")
+        received: list[Path] = []
+        signal = threading.Event()
+
+        def callback(path: Path) -> None:
+            received.append(path)
+            signal.set()
+
+        watcher = WatchdogFileWatcher(debounce_ms=80)
+        watcher.watch(head_path, callback)
+        try:
+            time.sleep(0.2)  # let the observer settle
+            lock_path = git_dir / "HEAD.lock"
+            lock_path.write_text("ref: refs/heads/topic\n")
+            os.replace(lock_path, head_path)
+            self.assertTrue(
+                signal.wait(timeout=3.0),
+                msg="watchdog callback never fired for HEAD lockfile rename",
+            )
+        finally:
+            watcher.stop()
+
+        self.assertIn(head_path, received)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_stage9_project_monitor_service.py
+++ b/tests/test_stage9_project_monitor_service.py
@@ -400,6 +400,27 @@ class Stage9ServerTests(unittest.TestCase):
         self.assertFalse(payload["ok"])
         self.assertIn("error", payload)
 
+    def test_server_rejects_non_object_request_payload(self) -> None:
+        sock = self._connect()
+        sock.sendall(b'[\"subscribe\"]\n')
+        payload = json.loads(_socket_recv_line(sock))
+        self.assertFalse(payload["ok"])
+        self.assertIn("JSON object", payload["error"])
+
+    def test_server_rejects_non_string_project_id(self) -> None:
+        sock = self._connect()
+        _socket_send_request(sock, {"kind": "get_project_state", "project_id": ["projA"]})
+        payload = json.loads(_socket_recv_line(sock))
+        self.assertFalse(payload["ok"])
+        self.assertIn("project_id", payload["error"])
+
+    def test_server_rejects_invalid_subscribe_projects_filter(self) -> None:
+        sock = self._connect()
+        _socket_send_request(sock, {"kind": "subscribe", "projects": "projA"})
+        payload = json.loads(_socket_recv_line(sock))
+        self.assertFalse(payload["ok"])
+        self.assertIn("projects", payload["error"])
+
     def test_server_discards_finished_connection_threads(self) -> None:
         for _ in range(3):
             sock = self._connect()

--- a/tests/test_stage9_project_monitor_service.py
+++ b/tests/test_stage9_project_monitor_service.py
@@ -202,11 +202,14 @@ class Stage9SnapshotStoreTests(unittest.TestCase):
 
         shutil.rmtree(doomed)
 
-        store.refresh()
+        events = store.refresh()
 
         ids = {project.project_id for project in store.current_snapshot()}
         self.assertEqual(ids, {"projA"})
         self.assertIsNone(store.get("projB"))
+        self.assertEqual(len(events), 1)
+        self.assertTrue(events[0].removed)
+        self.assertEqual(events[0].project_id, "projB")
 
     def test_store_assigns_monotonic_sequence_to_events(self) -> None:
         (self.tmp / "ws").mkdir(parents=True, exist_ok=True)
@@ -226,6 +229,26 @@ class Stage9SnapshotStoreTests(unittest.TestCase):
         self.assertEqual(len(first), 1)
         self.assertEqual(len(second), 1)
         self.assertGreater(second[0].sequence, first[0].sequence)
+
+    def test_store_preserves_duplicate_project_basenames(self) -> None:
+        west_root = self.tmp / "west"
+        east_root = self.tmp / "east"
+        west_root.mkdir(parents=True, exist_ok=True)
+        east_root.mkdir(parents=True, exist_ok=True)
+        _make_workspace(west_root, "same", DEFAULT_TODO)
+        _make_workspace(east_root, "same", DEFAULT_TODO)
+        cfg = MonitorConfig(
+            workspaces=(
+                WorkspaceConfig(path=west_root, name="west"),
+                WorkspaceConfig(path=east_root, name="east"),
+            ),
+            legacy_policy="list-only",
+        )
+        store = SnapshotStore(config=cfg)
+        store.load()
+        snapshot = store.current_snapshot()
+        self.assertEqual(len(snapshot), 2)
+        self.assertEqual(len({project.project_id for project in snapshot}), 2)
 
 
 # --- Stub watcher -------------------------------------------------------
@@ -672,6 +695,7 @@ class Stage9ServiceTests(unittest.TestCase):
         change_msg = json.loads(_socket_recv_line(sock, timeout=3.0))
         self.assertEqual(change_msg["kind"], "change")
         self.assertEqual(change_msg["project"]["project_id"], "projA")
+        self.assertFalse(change_msg["removed"])
 
     def test_service_deep_file_change_is_seen_after_periodic_rescan(self) -> None:
         sock = self._connect()
@@ -684,6 +708,26 @@ class Stage9ServiceTests(unittest.TestCase):
         change_msg = json.loads(_socket_recv_line(sock, timeout=3.0))
         self.assertEqual(change_msg["kind"], "change")
         self.assertEqual(change_msg["project"]["project_id"], "projA")
+
+    def test_service_emits_removed_event_when_project_deleted(self) -> None:
+        import shutil
+
+        sock = self._connect()
+        _socket_send_request(sock, {"kind": "subscribe"})
+        json.loads(_socket_recv_line(sock))  # consume initial snapshot
+
+        shutil.rmtree(self.project_dir)
+        self.stub_watcher.trigger(self.project_dir)
+
+        change_msg = json.loads(_socket_recv_line(sock, timeout=3.0))
+        self.assertEqual(change_msg["kind"], "change")
+        self.assertEqual(change_msg["project"]["project_id"], "projA")
+        self.assertTrue(change_msg["removed"])
+
+        query = self._connect()
+        _socket_send_request(query, {"kind": "list_projects"})
+        payload = json.loads(_socket_recv_line(query))
+        self.assertEqual(payload["data"]["projects"], [])
 
 
 # --- Real watchdog integration (optional) -------------------------------
@@ -755,6 +799,19 @@ class Stage9WatchdogIntegrationTests(unittest.TestCase):
             watcher.stop()
 
         self.assertIn(head_path, received)
+
+    def test_watchdog_file_watcher_unwatch_releases_watch_state(self) -> None:
+        target = self.tmp / "project"
+        target.mkdir()
+        watcher = WatchdogFileWatcher(debounce_ms=80)
+        try:
+            watcher.watch(target, lambda _path: None, recursive=False)
+            self.assertEqual(len(watcher._watches), 1)
+            watcher.unwatch(target, recursive=False)
+            self.assertEqual(len(watcher._watches), 0)
+            self.assertEqual(len(watcher._handlers), 0)
+        finally:
+            watcher.stop()
 
 
 if __name__ == "__main__":

--- a/tests/test_stage9_project_monitor_service.py
+++ b/tests/test_stage9_project_monitor_service.py
@@ -714,6 +714,27 @@ class Stage9ServiceTests(unittest.TestCase):
             time.sleep(0.02)
         self.assertTrue(all(key in self.service._watched_paths for key in expected))
 
+    def test_service_install_watches_is_safe_under_concurrent_prune(self) -> None:
+        stale_key = (self.tmp / "ws" / "stale-project", False)
+        self.service._watched_paths.add(stale_key)
+        barrier = threading.Barrier(3)
+        errors: list[Exception] = []
+
+        def run() -> None:
+            try:
+                barrier.wait()
+                self.service._install_watches()
+            except Exception as exc:  # pragma: no cover - captured for assertion
+                errors.append(exc)
+
+        threads = [threading.Thread(target=run, daemon=True) for _ in range(2)]
+        for thread in threads:
+            thread.start()
+        barrier.wait()
+        for thread in threads:
+            thread.join(timeout=2.0)
+        self.assertEqual(errors, [])
+
     def test_service_branch_switch_trigger_still_emits_change_event_immediately(self) -> None:
         sock = self._connect()
         _socket_send_request(sock, {"kind": "subscribe"})

--- a/tests/test_stage9_project_monitor_service.py
+++ b/tests/test_stage9_project_monitor_service.py
@@ -211,6 +211,41 @@ class Stage9SnapshotStoreTests(unittest.TestCase):
         self.assertTrue(events[0].removed)
         self.assertEqual(events[0].project_id, "projB")
 
+    def test_store_refresh_project_reclassifies_tracked_to_hidden_legacy(self) -> None:
+        (self.tmp / "ws").mkdir(parents=True, exist_ok=True)
+        proj = _make_workspace(self.tmp / "ws", "projA", DEFAULT_TODO)
+        cfg = MonitorConfig(
+            workspaces=(WorkspaceConfig(path=self.tmp / "ws", name="ws"),),
+            legacy_policy="hide",
+        )
+        store = SnapshotStore(config=cfg)
+        store.load()
+
+        import shutil
+
+        (proj / ".paul-project.yml").unlink()
+        shutil.rmtree(proj / "docs")
+
+        events = store.refresh_projects(("projA",))
+        self.assertEqual(len(events), 1)
+        self.assertTrue(events[0].removed)
+        self.assertIsNone(store.get("projA"))
+
+    def test_store_refresh_emits_event_when_only_source_signals_change(self) -> None:
+        (self.tmp / "ws").mkdir(parents=True, exist_ok=True)
+        proj = _make_workspace(self.tmp / "ws", "projA", DEFAULT_TODO)
+        cfg = self._build_config()
+        store = SnapshotStore(config=cfg)
+        store.load()
+
+        archive_root = proj / "openspec" / "changes" / "archive"
+        archive_root.mkdir(parents=True, exist_ok=True)
+
+        events = store.refresh_projects(("projA",))
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0].project_id, "projA")
+        self.assertFalse(events[0].removed)
+
     def test_store_assigns_monotonic_sequence_to_events(self) -> None:
         (self.tmp / "ws").mkdir(parents=True, exist_ok=True)
         proj = _make_workspace(self.tmp / "ws", "projA", DEFAULT_TODO)

--- a/tests/test_stage9_project_monitor_service.py
+++ b/tests/test_stage9_project_monitor_service.py
@@ -377,6 +377,17 @@ class Stage9ServerTests(unittest.TestCase):
         self.assertFalse(payload["ok"])
         self.assertIn("error", payload)
 
+    def test_server_discards_finished_connection_threads(self) -> None:
+        for _ in range(3):
+            sock = self._connect()
+            _socket_send_request(sock, {"kind": "list_projects"})
+            _socket_recv_line(sock)
+            sock.close()
+        deadline = time.time() + 1.0
+        while time.time() < deadline and self.server._connection_threads:
+            time.sleep(0.02)
+        self.assertEqual(self.server._connection_threads, [])
+
     def test_server_rejects_live_socket_instead_of_stealing_it(self) -> None:
         (self.tmp / "ws2").mkdir(parents=True, exist_ok=True)
         _make_workspace(self.tmp / "ws2", "projZ", DEFAULT_TODO)
@@ -604,11 +615,50 @@ class Stage9ServiceTests(unittest.TestCase):
             for path, _callback, recursive in self.stub_watcher.subscriptions
         }
 
+        self.assertIn((str(self.tmp / "ws"), False), subscriptions)
         self.assertIn((str(self.project_dir), False), subscriptions)
         self.assertIn((str(self.project_dir / ".git" / "HEAD"), False), subscriptions)
         self.assertIn((str(self.project_dir / ".git" / "refs"), True), subscriptions)
         self.assertNotIn((str(self.project_dir), True), subscriptions)
         self.assertFalse(any("node_modules" in path for path, _recursive in subscriptions))
+
+    def test_service_falls_back_to_stub_watcher_without_watchdog(self) -> None:
+        from paulsha_cortex.monitor import service as service_module
+
+        cfg = MonitorConfig(
+            workspaces=(WorkspaceConfig(path=self.tmp / "ws", name="ws"),),
+            legacy_policy="list-only",
+            socket_path=self.tmp / "fallback.sock",
+        )
+        with mock.patch.object(service_module, "HAS_WATCHDOG", False):
+            fallback_service = ProjectMonitorService(config=cfg)
+        self.assertIsInstance(fallback_service._watcher, StubWatcher)
+        fallback_service.stop()
+
+    def test_service_prunes_and_readds_project_watch_keys_after_recreate(self) -> None:
+        import shutil
+
+        expected = {
+            (self.project_dir, False),
+            (self.project_dir / ".git" / "HEAD", False),
+            (self.project_dir / ".git" / "refs", True),
+        }
+        shutil.rmtree(self.project_dir)
+        self.stub_watcher.trigger(self.project_dir)
+        deadline = time.time() + 2.0
+        while time.time() < deadline and any(key in self.service._watched_paths for key in expected):
+            time.sleep(0.02)
+        self.assertFalse(any(key in self.service._watched_paths for key in expected))
+
+        self.project_dir = _make_workspace(self.tmp / "ws", "projA", DEFAULT_TODO)
+        (self.project_dir / ".git" / "refs" / "heads").mkdir(parents=True, exist_ok=True)
+        (self.project_dir / ".git" / "HEAD").write_text("ref: refs/heads/main\n")
+        (self.project_dir / ".git" / "refs" / "heads" / "main").write_text("deadbeef\n")
+        self.stub_watcher.trigger(self.project_dir)
+        deadline = time.time() + 2.0
+        while time.time() < deadline and not all(key in self.service._watched_paths for key in expected):
+            time.sleep(0.02)
+        self.assertTrue(all(key in self.service._watched_paths for key in expected))
 
     def test_service_branch_switch_trigger_still_emits_change_event_immediately(self) -> None:
         sock = self._connect()


### PR DESCRIPTION
## 摘要
- 平移 `deck` / `monitor` 進 `paulsha-cortex`，補齊 `cortex deck`、`cortex monitor`、registry merge 與 monitor service install
- 補 `paths.run_root/config_path/project_config_root`、persona 同包 import、package-data 與 README
- 補去識別化、零依賴、fresh-install E2E 與 monitor 邊界條件修正

## 測試
- `python -m pytest tests/ -q`
- `python3 -m policy_check --repo .`
- fresh install：`cortex deck compile feature-oneshot --task smoke`、`cortex monitor --once`

## 關聯
- Ref: hamanpaul/paulshaclaw#232

## 豁免
- `policy-exempt:issue-link`：跨 repo 引用上游 issue，非 closing keyword
- `skip-changelog`：依本次任務要求，以 PR label 豁免 changelog 更新
