### PR TITLE
fix: manager daemon 不再自停自己的 service（F1，issue #2）

### DIFF
--- a/paulsha_cortex/scripts/service-manager.sh
+++ b/paulsha_cortex/scripts/service-manager.sh
@@ -112,7 +112,10 @@ start_manager_service() {
 }
 
 start_manager_loop() {
-  stop_legacy_manager_timer
+  # F1（issue #2，Plan 3 真機實測到自停）：不得在此停 ${instance}-manager.*——
+  # 本函式即 cortex-manager.service 的 ExecStart，stop_legacy_manager_timer 會停掉「自己」
+  # （SIGTERM 自殺、Duration ~7ms）。cortex 為 timer+daemon 模型，舊 paulshaclaw 單元的
+  # cutover 已由 operator shell（start.sh）在 enable 前負責，此處不再自停。
   if [[ "${PSC_MANAGER_DAEMON_DISABLED:-0}" == "1" ]]; then
     echo "manager loop disabled (PSC_MANAGER_DAEMON_DISABLED=1)"
     return 0

--- a/tests/test_start_manager_service.py
+++ b/tests/test_start_manager_service.py
@@ -56,6 +56,39 @@ class StartManagerServiceTests(unittest.TestCase):
             self.assertIn("disabled", res.stdout)
             self.assertFalse((sd / "systemctl.log").exists())
 
+    def test_start_manager_loop_does_not_self_stop_current_service(self) -> None:
+        # F1 回歸（issue #2；Plan 3 真機實測到 cortex-manager.service 啟動 7ms 即被 SIGTERM 自停）：
+        # ExecStart 路徑（start_manager_loop）不得對 ${instance}-manager.service 下 systemctl stop。
+        with tempfile.TemporaryDirectory() as d:
+            root = Path(d)
+            sd = root / "stub"
+            sd.mkdir()
+            home = root / "home"
+            home.mkdir()
+            log = sd / "systemctl.log"
+            _systemctl_ok(sd, log)
+            script = (
+                "set -euo pipefail\n"
+                "PY=/bin/true\n"
+                "fn=\"$(sed -n '/^start_manager_loop()/,/^}/p' '" + str(START_SH) + "')\"\n"
+                "eval \"$fn\"\n"
+                "start_manager_loop\n"
+            )
+            env = {
+                **os.environ,
+                "PATH": f"{sd}:{os.environ['PATH']}",
+                "HOME": str(home),
+                "PSC_INSTANCE": "cortex",
+                "PSC_MANAGER_DAEMON_DISABLED": "1",
+            }
+            res = subprocess.run(["bash", "-c", script], capture_output=True, text=True, env=env)
+            self.assertEqual(res.returncode, 0, res.stderr)
+            calls = log.read_text(encoding="utf-8") if log.exists() else ""
+            self.assertNotIn(
+                "cortex-manager.service", calls,
+                f"start_manager_loop 對自己 instance 的 service 下了 systemctl（自停）：{calls!r}",
+            )
+
     def test_no_user_systemd_graceful_skip(self) -> None:
         with tempfile.TemporaryDirectory() as d:
             sd = Path(d)


### PR DESCRIPTION
Plan 3 真機 cutover 實測：cortex-manager.service 啟動 7ms 即被 SIGTERM 自停
——ExecStart 的 start_manager_loop 第一步 stop_legacy_manager_timer 停掉
${instance}-manager.service（= 自己）。cortex 為 timer+daemon 模型、舊
paulshaclaw 單元 cutover 已由 operator shell（start.sh，Plan 2 F2）負責，
移除 ExecStart 路徑的自停調用。加回歸測試（stub systemctl 驗不對自己 instance
的 service 下 systemctl）。Closes #2 的 F1（其餘 3 缺陷另計）。
