### PR TITLE
docs(spec): 強化任務分派紀律 improve spec（依 hippo multi-agent 實戰）

### DIFF
--- a/docs/superpowers/plans/2026-07-12-dispatch-discipline-improve.md
+++ b/docs/superpowers/plans/2026-07-12-dispatch-discipline-improve.md
@@ -1,0 +1,613 @@
+# Dispatch Discipline Improve Implementation Plan
+
+> **執行要求：** 依 task 順序在獨立 `wt/dispatch-discipline/<task>` worktree 執行；每個 task 都先取得指定 RED，再做最小實作、跑局部測試並 commit。不得在同一 task 順手實作第 10 節 deferred workstreams。
+
+**Goal:** 沿用 cortex 現有 `JobRegistry → manager → handoff → DAG` 骨架，將 process exit 與可信 completion 分離，只有通過 deterministic verification、必要的異質 exact-HEAD review，且 Candidate 已進入 target branch 時才釋放 downstream。
+
+**Architecture:** `JobRegistry` 仍是 manager 單一 writer 的 atomic JSON state；在同一 state 新增 `slices`，Job 只表示 execution，Slice 表示交付生命週期。verification/review evidence 與 CompletionRecord 使用帶 `schema_version` 的 immutable JSON。manager tick 依序 poll Job、固定 Candidate、驗證、派 reviewer、驗 verdict、確認 target ancestry、先寫 CompletionRecord、最後標記 Slice completed。
+
+**Tech stack:** Python 3.10+、stdlib `subprocess/json/pathlib/tempfile`、既有 PyYAML wrapper、pytest/unittest、git CLI、Bash reaper fixture。
+
+**Source spec:** `docs/superpowers/specs/2026-07-12-dispatch-discipline-improve.md`
+
+**OpenSpec change:** `openspec/changes/dispatch-discipline-improve/`；`tasks.md`只追蹤apply進度，本文件是exact files、RED/PASS commands與commit boundaries的canonical execution plan。
+
+## Scope guardrails
+
+- v1 只支援 `tier: shareable`、preserving-commit merge、單一 configured remote、同一 dependency chain 共用 target branch。
+- v1 的 verification runner 只有 typed argv；不經 shell。sanitized env 不等於 network/filesystem sandbox，錯誤訊息與文件不得宣稱已隔離 untrusted code。
+- `informational`、`trivial` 可由 `review_policy=not-required` 直接從 verification 進 `verified`；`normative`、`code` 必須 ForeignReview。
+- 不做自動 retry/fix-loop、resume、batch integration、automatic rollback、remote override、attention digest、cost routing、journal platform或 cgroup ownership。
+- 每個 code task 都要更新 `CHANGELOG.md [Unreleased]`；同一系列可先在 Task 1 建一筆 umbrella entry，後續 task 只在行為實質改變時補充，不重複灌水。
+- 每個Task在focused/full gate通過後，必須勾選`openspec/changes/dispatch-discipline-improve/tasks.md`對應編號，並把該檔納入同一commit；未更新apply progress不得宣稱該Task完成。
+
+## Cross-task invariants
+
+1. `Job.exited` 只代表 exit code 0；永遠不能直接滿足 `depends_on`。
+2. `GateEvaluation` 每個 reviewer Job 一筆、terminal 後 immutable；stale evaluation 只留 audit。
+3. 任何 missing/invalid evidence、exception、unknown schema、identity absence、fetch failure 都 fail-closed 到 `needs_human` 或維持 `verified`，不得轉成 passed。
+4. Completion ordering 固定為：atomic CompletionRecord → atomic Slice `completed`。任一步失敗都不能 release downstream。
+5. `default_is_satisfied` 必須同時驗 Slice state、CompletionRecord、spec/plan hash 與 remote-tracking target ancestry。
+6. 所有 subprocess seam 都能注入；unit tests 不得啟真 agent、fetch 真 remote 或 signal 真 process。
+
+---
+
+### Task 1: 停止 periodic automatic reaper，建立 scoped operator command
+
+**Files:**
+
+- Modify: `paulsha_cortex/coordinator/broker_reaper.py`
+- Modify: `paulsha_cortex/coordinator/cli.py`
+- Modify: `paulsha_cortex/coordinator/manager_daemon.py`
+- Modify: `paulsha_cortex/scripts/reap-codex-brokers.sh`
+- Modify: `tests/test_coordinator_broker_reaper.py`
+- Modify: `tests/test_coordinator_cli_tick.py`
+- Modify: `tests/test_coordinator_manager_daemon.py`
+- Create: `tests/test_reap_codex_brokers_script.py`
+- Modify: `CHANGELOG.md`
+
+**Step 1: Write the failing Python wiring tests**
+
+新增測試鎖定：
+
+- `tick` 與 manager daemon 預設都不呼叫 reaper，移除 `--no-reap` 反向旗標。
+- 新增 `cortex reap-brokers`（top-level `cortex` 會直接透傳 coordinator CLI）且預設 `apply=False`。
+- `--apply` 未帶 `--cwd-root` 回 exit 2；帶入時 wrapper argv 同時包含 `--apply --cwd-root <canonical-realpath>`。
+
+Run:
+
+```bash
+python3 -m pytest -q \
+  tests/test_coordinator_broker_reaper.py \
+  tests/test_coordinator_cli_tick.py \
+  tests/test_coordinator_manager_daemon.py
+```
+
+Expected: FAIL，因 periodic tick 仍預設 apply，且 operator subcommand/cwd-root 尚不存在。
+
+**Step 2: Write the failing shell safety fixtures**
+
+以 `REAP_PROC_ROOT` fake `/proc` 與腳本既有 snapshot seam 建立 cases：同 project candidate、另一 project candidate、cwd 消失、cmdline/parent/start-time 在 apply 前改變。fake killer 只能收到同 root 且 recheck 完全一致的 PID；任何未知值都 skip。
+
+Run:
+
+```bash
+python3 -m pytest -q tests/test_reap_codex_brokers_script.py
+```
+
+Expected: FAIL，因目前腳本只用 cmdline + parent snapshot，且不要求 cwd root。
+
+**Step 3: Implement the minimum safe reaper path**
+
+- `reap_orphan_brokers()` 預設 `apply=False`；apply 時強制要求 resolved `cwd_root`。
+- 腳本解析 `--cwd-root`，以 path-component containment 判斷 cwd，不用字串 prefix。
+- signal 前即時重讀 PID/start-time/cmdline/parent/cwd；與候選 snapshot 不一致或讀取失敗就 skip。
+- 僅送 `SIGTERM`，不加入 wait/kill escalation。
+- 從 `cli.py`、`manager_daemon.py` 移除 periodic reaper wiring；`run_tick` 可暫留注入 seam 供相容測試，但 production path 不再傳入。
+
+**Step 4: Run focused tests and policy-sensitive help tests**
+
+```bash
+python3 -m pytest -q \
+  tests/test_coordinator_broker_reaper.py \
+  tests/test_reap_codex_brokers_script.py \
+  tests/test_coordinator_cli_tick.py \
+  tests/test_coordinator_manager_daemon.py \
+  tests/test_coordinator_cli_flags.py
+```
+
+Expected: PASS；negative fixture 沒有任何 signal。
+
+**Step 5: Commit**
+
+```bash
+git add paulsha_cortex/coordinator paulsha_cortex/scripts/reap-codex-brokers.sh tests CHANGELOG.md openspec/changes/dispatch-discipline-improve/tasks.md
+git commit -m "fix(coordinator): scope broker cleanup to operator command"
+```
+
+---
+
+### Task 2: 建立 versioned Job/Slice state foundation 與 clean-start gate
+
+**Files:**
+
+- Modify: `paulsha_cortex/coordinator/registry.py`
+- Modify: `paulsha_cortex/coordinator/completion.py`
+- Modify: `paulsha_cortex/coordinator/dispatcher.py`
+- Modify: `paulsha_cortex/coordinator/manager.py`
+- Modify: `paulsha_cortex/coordinator/manager_daemon.py`
+- Modify: `paulsha_cortex/coordinator/cli.py`
+- Modify: `paulsha_cortex/control/contract.py`
+- Modify: `paulsha_cortex/control/client.py`
+- Modify: `tests/test_persona_phase2_coordinator_cli.py`
+- Modify: `tests/test_coordinator_registry_headless.py`
+- Modify: `tests/test_coordinator_headless_completion.py`
+- Modify: `tests/test_coordinator_cli_complete.py`
+- Modify: `tests/test_coordinator_manager.py`
+- Modify: `tests/test_coordinator_manager_daemon.py`
+- Modify: `tests/test_control_contract.py`
+- Modify: `tests/test_control_client.py`
+
+**Step 1: Write RED state-schema tests**
+
+新增/修改測試要求：
+
+- state root 必須是 `{"schema_version": COORDINATOR_STATE_SCHEMA_VERSION, "seq": ..., "jobs": [...], "slices": [...]}`；測試引用production constant，不另寫magic number。
+- 無 state file 為合法 clean-start；缺/未知 `schema_version` 或含 legacy `done` 的 state 明確拒載，錯誤訊息包含檔案路徑與 archive/remove 指引，且不改寫原檔。
+- Job statuses 只接受 `dispatched/running/exited/failed`；headless exit code 0 產生 `exited`。
+- `SliceRecord` 至少保存 spec/plan path+hash、target branch、dispatch base、builder/reviewer IDs、candidate、state、gate state與 evidence refs。
+- state transition validator 拒絕表外轉移；Slice current evidence/evaluation refs與history containers必須可reload。GateEvaluation row/schema在Task 5才建立。
+- 移除無spec metadata的低階`cortex dispatch --task ...`；測試它明確拒絕且不寫state。
+- `fanout/tick/complete`等既有mutation CLI改成只提交control request，daemon未運行時明確失敗；read-only`jobs/stat/ready/status`可讀atomic snapshot但不得寫。
+
+Run:
+
+```bash
+python3 -m pytest -q \
+  tests/test_persona_phase2_coordinator_cli.py \
+  tests/test_coordinator_registry_headless.py \
+  tests/test_coordinator_headless_completion.py \
+  tests/test_coordinator_manager.py
+```
+
+Expected: FAIL，因 state 尚無 schema/slices 且仍使用 `done`。
+
+**Step 2: Implement one atomic state owner**
+
+- 將 registry persistence 擴充為 versioned root；沿用 temp file + `os.replace`。
+- 提供最小 `create_slice/get_slice/update_slice/record_action` API，不另建 TaskRun aggregate。此 task 先以完整 metadata fixture驗 API；production dispatch 到 Slice 的接線留在 Task 3，避免 parser尚未能提供 target/hash時寫出半套 SliceRecord。
+- 在 registry 內集中驗 Job/Slice/Gate 狀態與合法轉移；callers 不直接改 `_jobs/_slices`。
+- `classify_completion()` 回 `exited|failed`，dispatcher/poller/manager constants 同步改名。
+- 擴充既有control contract讓daemon消費`complete`；CLI永不自行建立第二個mutable JobRegistry writer。
+
+**Step 3: Pin crash/restart behavior**
+
+測試reload後`seq`、Slice current refs與history containers都保持；launch handle缺失只允許`failed`，不得猜測running。確認同一slice不會同時存在兩個active builder；legacy direct dispatch拒絕後state不變。
+
+**Step 4: Run focused state suite**
+
+```bash
+python3 -m pytest -q \
+  tests/test_coordinator_*.py \
+  tests/test_control_contract.py \
+  tests/test_control_client.py \
+  tests/test_persona_phase2_coordinator_cli.py \
+  tests/test_persona_phase4_fanout_autonomy.py
+```
+
+Expected: PASS。
+
+**Step 5: Commit**
+
+```bash
+git add paulsha_cortex/coordinator paulsha_cortex/control tests CHANGELOG.md openspec/changes/dispatch-discipline-improve/tasks.md
+git commit -m "feat(coordinator): separate execution and slice state"
+```
+
+---
+
+### Task 3: Parse and pin the v1 verification contract
+
+**Files:**
+
+- Modify: `paulsha_cortex/coordinator/autonomy.py`
+- Modify: `paulsha_cortex/coordinator/registry.py`
+- Modify: `paulsha_cortex/coordinator/dispatcher.py`
+- Modify: `paulsha_cortex/coordinator/manager.py`
+- Modify: `paulsha_cortex/coordinator/manager_daemon.py`
+- Modify: `paulsha_cortex/coordinator/cli.py`
+- Modify: `paulsha_cortex/control/contract.py`
+- Modify: `paulsha_cortex/control/client.py`
+- Create: `paulsha_cortex/coordinator/verification.py`
+- Create: `tests/test_coordinator_verification.py`
+- Modify: `tests/test_persona_phase4_fanout_autonomy.py`
+- Modify: `tests/test_coordinator_manager.py`
+- Modify: `tests/test_coordinator_manager_daemon.py`
+- Modify: `tests/test_control_contract.py`
+- Modify: `tests/test_control_client.py`
+
+**Step 1: Write RED frontmatter contract tests**
+
+覆蓋`target_branch`與`verification.docs_class|required_artifacts|checks|tests|full_suite`。`checks`只允許`persona-scope`與typed-argv `command`，且auto-dispatch必須恰有一個persona-scope與至少一個具名policy command。錯誤/未知型別一律讓該spec `dispatch=hold`並帶structured parse error，不可吞成空verification。文件class決定review policy：`normative/code=required`、`informational/trivial=not-required`。
+
+Run:
+
+```bash
+python3 -m pytest -q \
+  tests/test_persona_phase4_fanout_autonomy.py \
+  tests/test_coordinator_verification.py
+```
+
+Expected: FAIL，因 parser 尚不回 target/verification contract。
+
+**Step 2: Implement immutable dispatch inputs**
+
+- parser 只接受 spec 定義的 v1 keys；typed argv 必須是非空字串 list、timeout 為正數、cwd/path 經 normalize 後不可逃出 repo。
+- dispatch 前讀取 spec/plan bytes，保存 SHA-256；同時固定 target branch與 verification contract hash。
+- builder 後續修改 spec/plan不影響本輪；manager 比對 hash mismatch 時轉 `needs_human`。
+- v1 target remote 由 `PSC_TARGET_REMOTE` 取得，未設時用 `origin`；remote name只作為 git argv element，不進 shell。
+- production spec-driven `dispatch/fanout/tick`全部經control request交給同一manager writer，依序建立完整`pending` Slice、builder Job，再更新`building`；任一步失敗保留可診斷state且不得出現半套必填metadata。legacy低階direct dispatch維持Task 2的拒絕語意。
+
+**Step 3: Implement evidence schema and atomic writer**
+
+在 `verification.py` 定義 `VERIFICATION_SCHEMA_VERSION`、evidence validator與 atomic JSON write；evidence path 放在 coordinator root 下的 `evidence/verification/`，檔名包含 safe slice ID 與 Candidate SHA。已存在且內容 hash 完全一致可冪等重讀；不一致則隔離並 fail-closed。
+
+**Step 4: Run focused parser/schema tests**
+
+```bash
+python3 -m pytest -q \
+  tests/test_coordinator_*.py \
+  tests/test_persona_phase2_coordinator_cli.py \
+  tests/test_persona_phase4_fanout_autonomy.py
+```
+
+Expected: PASS。
+
+**Step 5: Commit**
+
+```bash
+git add paulsha_cortex/coordinator paulsha_cortex/control tests CHANGELOG.md openspec/changes/dispatch-discipline-improve/tasks.md
+git commit -m "feat(coordinator): pin verification contracts at dispatch"
+```
+
+---
+
+### Task 4: 固定 Candidate 並執行 deterministic ResultVerification
+
+**Files:**
+
+- Modify: `paulsha_cortex/coordinator/verification.py`
+- Modify: `paulsha_cortex/coordinator/manager.py`
+- Modify: `paulsha_cortex/coordinator/dispatcher.py`
+- Create: `tests/test_coordinator_candidate_verification.py`
+- Modify: `tests/test_coordinator_manager.py`
+
+**Step 1: Write RED Candidate fencing tests**
+
+builder Job`exited`後，manager讀branch HEAD並要求`dispatch_base`是Candidate ancestor且Candidate不等於base；v1沒有no-op/already-satisfied proof。無新commit、force-push到非descendant、branch ref在snapshot後偏離Candidate都轉`needs_human`，不得寫CompletionRecord。
+
+**Step 2: Write RED verification runner tests**
+
+以 injected subprocess/git runner 覆蓋：
+
+- required artifact missing、`must_change=true` 但未在 base..Candidate diff、scope violation。
+- command missing、non-zero、timeout、runner exception、cwd escape、evidence partial。
+- `persona-scope`使用dispatch base persona catalog bytes/hash、builder role與`base...Candidate`changed paths；Candidate修改catalog不影響本輪。
+- 每個typed-argv command check、task test與Candidate full suite都須exit 0。
+- full-suite在dispatch base與Candidate以相同argv/cwd/sanitized env各跑一次；Candidate non-zero、任一command missing/timeout/signal/runner error/evidence不完整都`needs_human`。base non-zero + Candidate zero可視為改善；兩者都non-zero不可比較且fail-closed。
+- informational/trivial 通過後直接 `verified`；normative/code 通過後進 `reviewing`。
+
+Run:
+
+```bash
+python3 -m pytest -q \
+  tests/test_coordinator_candidate_verification.py \
+  tests/test_coordinator_manager.py
+```
+
+Expected: FAIL，因 exit 0 現在仍走 completion shadow path。
+
+**Step 3: Implement deterministic checks**
+
+- 使用`subprocess.run(argv, shell=False, cwd=resolved_cwd, timeout=...)`；env只保留原環境中存在的`PATH/HOME/LANG/LC_ALL/TMPDIR/VIRTUAL_ENV`，contract不得自訂env，不帶token/credential env。
+- base full-suite 使用 manager 建立、finally 必清理的 detached temporary worktree；Candidate用已 pin 的 builder worktree/HEAD。
+- 先做 hash/Candidate/artifact/scope checks，再跑 task tests，最後 full suite；第一個拒絕仍寫完整 fail evidence。
+- manager 只依 validated evidence更新 Slice，不信任 agent log 的 done claim。
+
+**Step 4: Replace false-green regression tests**
+
+把現有「gate false/exception仍 passed」測試改成「verification reject/exception → needs_human、default_is_satisfied=false」。保留一個明確測試證明 Job `exited` 對 DAG 無效果。
+
+**Step 5: Run focused completion suite**
+
+```bash
+python3 -m pytest -q \
+  tests/test_coordinator_*.py \
+  tests/test_persona_phase2_coordinator_cli.py \
+  tests/test_persona_phase4_fanout_autonomy.py
+```
+
+Expected: PASS。
+
+**Step 6: Commit**
+
+```bash
+git add paulsha_cortex/coordinator tests CHANGELOG.md openspec/changes/dispatch-discipline-improve/tasks.md
+git commit -m "feat(coordinator): verify candidate results before completion"
+```
+
+---
+
+### Task 5: 派送 exact-HEAD ForeignReview 並驗證 immutable verdict
+
+**Files:**
+
+- Create: `paulsha_cortex/coordinator/review.py`
+- Modify: `paulsha_cortex/coordinator/registry.py`
+- Modify: `paulsha_cortex/coordinator/launcher.py`
+- Modify: `paulsha_cortex/coordinator/manager.py`
+- Modify: `paulsha_cortex/coordinator/manager_daemon.py`
+- Modify: `paulsha_cortex/coordinator/cli.py`
+- Create: `tests/test_coordinator_foreign_review.py`
+- Modify: `tests/test_coordinator_launcher.py`
+- Modify: `tests/test_coordinator_manager.py`
+
+**Step 1: Write RED identity and selection tests**
+
+定義 registry fixture：`(executor, model_id) -> independence_domain`。要求 builder與reviewer都具 explicit model ID；不同 CLI 但同 domain 仍為 absent，unknown identity亦 absent，只有不同 domain 才能建立 reviewer Job。v1 遇非 shareable tier直接 `needs_human`。
+
+**Step 2: Write RED exact checkout/verdict tests**
+
+要求manager建立detached reviewer worktree at exact Candidate、Job row保存kind/executor/model/domain/subject HEAD，並驗證verdict：schema version、reviewer/builder Job IDs、Candidate SHA、launch identity與findings schema。category enum固定為`correctness|acceptance|security|data-loss|race|scope-bypass|verification-bypass|style|pre-existing-out-of-scope`；severity為`critical|important|minor`，每筆必含summary/evidence list/recommendation。manager由canonical category+evidence location+summary算SHA-256 finding ID。verdict自稱的identity不能覆蓋launch metadata。
+
+覆蓋 stale HEAD、malformed JSON、missing provenance、reviewer process failure、blocking finding與只有 non-blocking style finding。
+
+Run:
+
+```bash
+python3 -m pytest -q \
+  tests/test_coordinator_foreign_review.py \
+  tests/test_coordinator_launcher.py \
+  tests/test_coordinator_manager.py
+```
+
+Expected: FAIL，因目前只有同步 shadow `GateRunner`。
+
+**Step 3: Implement the minimum model registry and reviewer Job**
+
+- 從 `PSC_PROJECT_CONFIG_ROOT/model-identities.yaml` 讀靜態映射；缺檔/重複 key/unknown fields fail-closed。
+- CLI/daemon增加 explicit builder `--model` 與 reviewer `--review-executor/--review-model` 接線；review-required slice缺任一值時 Gate=`absent`。
+- reviewer也是 registry Job，`persona=reviewer`、job kind明確；prompt以結構化區塊標示 repo/spec/diff/log皆為 untrusted data，要求只輸出 verdict schema。
+- manager啟動前移除detached reviewer worktree內固定的`.psc-review-verdict.json`，prompt要求reviewer只把結果寫到該路徑；process exited後manager讀取、驗schema/provenance，再atomic複製到coordinator root的`evidence/review/`。Candidate中預置檔、缺檔或多餘非JSON輸出都不能成為有效verdict。
+- policy在cortex端只使用正式category enum；`correctness/acceptance/security/data-loss/race/scope-bypass/verification-bypass`預設blocking，`style/pre-existing-out-of-scope`預設non-blocking。evidence item固定為`{path,line,detail}`，finding ID以category、summary與排序後evidence的sorted-key JSON取SHA-256；severity/recommendation不參與ID。
+
+**Step 4: Preserve immutable evaluations**
+
+GateEvaluation持久為Slice evaluation history所引用的versioned immutable evidence；每個reviewer Job建立新row，`passed/rejected/absent`後不可改。Candidate/spec/plan/verification hash變動時只清除Slice current ref並記`stale-input` reason，舊evaluation state/content完全不變，operator必須建立fresh reviewer Job。
+
+**Step 5: Run focused foreign-review suite**
+
+```bash
+python3 -m pytest -q \
+  tests/test_coordinator_*.py \
+  tests/test_persona_phase2_coordinator_cli.py \
+  tests/test_persona_phase4_fanout_autonomy.py
+```
+
+Expected: PASS。
+
+**Step 6: Commit**
+
+```bash
+git add paulsha_cortex/coordinator tests CHANGELOG.md openspec/changes/dispatch-discipline-improve/tasks.md
+git commit -m "feat(coordinator): require foreign exact-head review"
+```
+
+---
+
+### Task 6: 以 target ancestry 與 CompletionRecord 關閉 dependency release
+
+**Files:**
+
+- Modify: `paulsha_cortex/coordinator/completion.py`
+- Modify: `paulsha_cortex/coordinator/autonomy.py`
+- Modify: `paulsha_cortex/coordinator/manager.py`
+- Modify: `paulsha_cortex/coordinator/seams.py`
+- Modify: `paulsha_cortex/coordinator/dispatcher.py`
+- Create: `tests/test_coordinator_completion_record.py`
+- Create: `tests/test_coordinator_dependency_ancestry.py`
+- Modify: `tests/test_persona_phase4_fanout_autonomy.py`
+- Modify: `tests/test_coordinator_manager.py`
+- Modify: `tests/test_coordinator_manager_daemon.py`
+- Modify: `tests/test_coordinator_cli_tick.py`
+- Modify: `tests/test_persona_phase2_coordinator_cli.py`
+
+**Step 1: Write RED CompletionRecord tests**
+
+CompletionRecord必含schema、slice/spec/plan hashes、builder ID、dispatch base、Candidate、target branch、verification ref、review policy與completed_at。`required`shape必須有non-null reviewer ID/gate ref；`not-required`shape必須兩者為null並有docs class+contract hash導出的proof。混合shape、invalid schema/hash/evidence ref/symlink path均fail-closed。
+
+以injected atomic writer模擬：record write成功後、Slice update前crash。此時`default_is_satisfied=false`；restart須先重新fetch/recheck target ancestry，只有record、verified Slice與current ancestry都匹配才補第二步且不重跑reviewer。mismatch orphan移到quarantine並保持blocked；若remote已移除Candidate則不得補completed。
+
+**Step 2: Write RED git ancestry tests**
+
+以 temporary local bare remote + repo fixtures覆蓋：
+
+- fetch failure時 Slice維持 verified。
+- Candidate尚未進 `refs/remotes/<remote>/<target>` 時 blocked。
+- preserving merge後 completed；target新增無關 commit仍 satisfied。
+- squash/cherry-pick造成 Candidate非 ancestor時 needs_human。
+- dependency chain target branch不一致時 scan/dispatch fail-closed。
+- readiness後 target移動的 TOCTOU：downstream dispatch前必以 actual base SHA重驗所有 upstream Candidate。
+
+Run:
+
+```bash
+python3 -m pytest -q \
+  tests/test_coordinator_completion_record.py \
+  tests/test_coordinator_dependency_ancestry.py \
+  tests/test_persona_phase4_fanout_autonomy.py
+```
+
+Expected: FAIL，因現行 readiness只看 `gate_status=passed`，worktree base固定字串 `main`。
+
+**Step 3: Implement completion ordering and readiness**
+
+- `verified` tick先 fetch configured remote target，再以 `git merge-base --is-ancestor Candidate remote_tracking_ref`判定。
+- atomic寫 CompletionRecord後才 atomic更新 Slice completed。
+- 新增`DependencyResolver.resolve(meta) -> ResolvedDependencySet`，回satisfied、target branch、target ref SHA、upstream Candidate list與blocked reasons；`ready_units`回傳meta+同一proof，`dispatch_ready`不得以第二套global lookup重算。
+- `default_is_satisfied`若保留為compatibility wrapper，也只能委派resolver並回其`satisfied`；更新CLI、daemon、status provider callsites，不保留只看`gate_status`的旁路。
+
+**Step 4: Pin downstream base SHA**
+
+- `WorktreeCreator.create()`改為接受explicit `base_sha`；從`ResolvedDependencySet.target_ref_sha`取得，不另讀字串`main`。
+- 建 worktree/launch前重驗每個 upstream Candidate都是 `base_sha` ancestor；失敗則不建 worktree。
+- builder Job與Slice都保存 actual downstream dispatch base SHA，後續 verification沿用同一值。
+- 同步更新所有`WorktreeCreator` fake、CLI/daemon wiring與signature tests；Task 6 focused gate必須包含全部`tests/test_coordinator_*.py`，不得把callsite紅燈延後到Task 8。
+
+**Step 5: Run dependency suite**
+
+```bash
+python3 -m pytest -q \
+  tests/test_coordinator_*.py \
+  tests/test_persona_phase2_coordinator_cli.py \
+  tests/test_persona_phase4_fanout_autonomy.py
+```
+
+Expected: PASS。
+
+**Step 6: Commit**
+
+```bash
+git add paulsha_cortex/coordinator tests CHANGELOG.md openspec/changes/dispatch-discipline-improve/tasks.md
+git commit -m "feat(coordinator): gate dependencies on merged candidates"
+```
+
+---
+
+### Task 7: 提供 persisted local operator actions 與完整狀態說明
+
+**Files:**
+
+- Modify: `paulsha_cortex/coordinator/cli.py`
+- Modify: `paulsha_cortex/coordinator/manager_daemon.py`
+- Modify: `paulsha_cortex/coordinator/registry.py`
+- Modify: `paulsha_cortex/coordinator/manager.py`
+- Modify: `paulsha_cortex/control/contract.py`
+- Modify: `paulsha_cortex/control/client.py`
+- Create: `tests/test_coordinator_operator_actions.py`
+- Modify: `tests/test_coordinator_manager_daemon.py`
+- Modify: `tests/test_coordinator_cli_flags.py`
+- Modify: `tests/test_control_contract.py`
+- Modify: `tests/test_control_client.py`
+
+**Step 1: Write RED command tests**
+
+新增 local-only command contract：
+
+```text
+cortex slice-action <slice-id> retry-build  --actor <text>
+cortex slice-action <slice-id> retry-verify --actor <text>
+cortex slice-action <slice-id> retry-review --actor <text>
+cortex slice-action <slice-id> abandon      --actor <text>
+```
+
+CLI只能透過既有atomic control request queue送`slice-action`，不得直接開`JobRegistry`寫`jobs.json`。測試action/state不合法、缺actor、unknown slice皆由daemon/manager單一writer拒絕；合法action先持久化request，再由manager執行並寫done response。不得直接修改terminal evaluation或復活failed/completed Slice。
+
+**Step 2: Write RED status explanation tests**
+
+status output對每個 Slice顯示：目前 Slice/Job/Gate state、blocked/needs_human reason、Candidate/target ancestry摘要、current evidence refs、允許的下一個 operator actions。多筆 attention事項一次以清單回傳，不逐筆互動提問。
+
+Run:
+
+```bash
+python3 -m pytest -q \
+  tests/test_coordinator_operator_actions.py \
+  tests/test_coordinator_manager_daemon.py \
+  tests/test_coordinator_cli_flags.py
+```
+
+Expected: FAIL，因尚無 persisted action history/status detail。
+
+**Step 3: Implement explicit retry semantics**
+
+- `retry-build`建立新 builder Job並清除 current candidate/evidence refs，但保留舊 history。
+- `retry-verify`只允許可信 Candidate，建立新 verification evidence ref。
+- `retry-review`只允許 verification passed，建立新 reviewer Job/GateEvaluation。
+- `abandon`只將非 terminal Slice標 failed。
+- action record保存 action、actor、requested_at、consumed_at/result；v1只依本機檔案權限，不新增 remote API或 signed override。
+
+**Step 4: Run focused operator suite**
+
+```bash
+python3 -m pytest -q \
+  tests/test_coordinator_*.py \
+  tests/test_control_contract.py \
+  tests/test_control_client.py \
+  tests/test_persona_phase2_coordinator_cli.py \
+  tests/test_persona_phase4_fanout_autonomy.py
+```
+
+Expected: PASS。
+
+**Step 5: Commit**
+
+```bash
+git add paulsha_cortex/coordinator paulsha_cortex/control tests CHANGELOG.md openspec/changes/dispatch-discipline-improve/tasks.md
+git commit -m "feat(coordinator): add explicit slice recovery actions"
+```
+
+---
+
+### Task 8: Disposable canary、文件與完整 gates
+
+**Files:**
+
+- Create: `tests/test_coordinator_dispatch_discipline_e2e.py`
+- Modify: `README.md`
+- Modify: `docs/superpowers/specs/2026-07-12-dispatch-discipline-improve.md` only if implementation reveals a factual mismatch
+- Modify: `CHANGELOG.md`
+
+**Step 1: Add a disposable end-to-end fixture**
+
+在 temporary repo/bare remote、fake builder/reviewer launcher與injected command runner上跑完整 v1 flow，至少覆蓋：
+
+1. exit 0 + missing artifact → needs_human。
+2. verification passed + same-domain reviewer → absent。
+3. stale verdict HEAD → audit-only，不能 verified。
+4. review passed但 Candidate未 merge → verified/blocked。
+5. preserving merge + valid record → completed。
+6. downstream worktree actual base含 upstream Candidate才 dispatch。
+7. CompletionRecord/state crash window restart補完。
+8. reaper對另一 cwd root與changed process identity永不 signal。
+
+Run:
+
+```bash
+python3 -m pytest -q tests/test_coordinator_dispatch_discipline_e2e.py
+```
+
+Expected: PASS；本 task只整合既有行為，不新增 lifecycle state。
+
+**Step 2: Update operator documentation**
+
+README需說明：
+
+- Job/Slice/Gate三層狀態及 `exited != completed`。
+- verification frontmatter完整範例與 shareable-only信任邊界。
+- model identity config與 foreign判定。
+- preserving-commit/同 target branch限制。
+- CompletionRecord crash ordering、restart與 clean-start舊 state處理。
+- operator actions與「一次列出全部 needs_human事項」的 status用法。
+- broker reaper預設 dry-run、`--apply --cwd-root`及 best-effort PID race聲明。
+
+**Step 3: Run full verification**
+
+```bash
+python3 -m pytest -q
+python3 -m policy_check --repo .
+git diff --check
+```
+
+Expected: 全部 PASS、policy 0 failure。若 full suite有與本 feature 無關的既有 failure，保存 base/Candidate雙跑證據並停在 `needs_human`，不得自行豁免。
+
+**Step 4: Independent review gates**
+
+- 依 `superpowers:requesting-code-review` 對全 diff review。
+- 每次修 review finding後重新 review。
+- 最後由獨立 Codex adversarial review 嘗試推翻：false completion、stale evidence、identity spoof、TOCTOU、crash ordering、cross-project reaper safety。
+- Critical/Important 未清零前不得 archive/claim done。
+
+**Step 5: Commit**
+
+```bash
+git add tests/test_coordinator_dispatch_discipline_e2e.py README.md CHANGELOG.md docs/superpowers/specs openspec/changes/dispatch-discipline-improve/tasks.md
+git commit -m "test(coordinator): cover dispatch discipline canary"
+```
+
+## Implementation handoff
+
+1. 開始實作前先把本spec、plan與完整`openspec/changes/dispatch-discipline-improve/**`納入feature integration branch的commit；目前未commit的文件不會自動出現在新worktree，也無法於最後archive。再從該branch建`wt/dispatch-discipline/reaper`，只執行Task 1。
+2. 每個 task merge/串接到 feature integration branch後才開下一個 worktree，避免多個 agent同時改 `manager.py/registry.py`。
+3. Task 2–7 都是 code change，必須各自保有 RED output與 focused PASS output；Task 8才跑 full suite/policy。
+4. 完成後依 feature-delivery-pipeline 進 requesting-code-review → verification → archive `dispatch-discipline-improve` → conventional commit/finish branch → Codex adversarial review。
+5. 未經使用者明確要求，不 push、不開 PR、不 merge。

--- a/docs/superpowers/plans/2026-07-12-dispatch-discipline-improve.md
+++ b/docs/superpowers/plans/2026-07-12-dispatch-discipline-improve.md
@@ -289,7 +289,7 @@ Expected: FAIL，因 exit 0 現在仍走 completion shadow path。
 
 **Step 3: Implement deterministic checks**
 
-- 使用`subprocess.run(argv, shell=False, cwd=resolved_cwd, timeout=...)`；env只保留原環境中存在的`PATH/HOME/LANG/LC_ALL/TMPDIR/VIRTUAL_ENV`，contract不得自訂env，不帶token/credential env。
+- 使用`subprocess.run(argv, shell=False, cwd=resolved_cwd, timeout=...)`；env只保留原環境中存在的`PATH`、`HOME`、`LANG`、`LC_ALL`、`TMPDIR`、`VIRTUAL_ENV`，contract不得自訂env，不帶token/credential env。
 - base full-suite 使用 manager 建立、finally 必清理的 detached temporary worktree；Candidate用已 pin 的 builder worktree/HEAD。
 - 先做 hash/Candidate/artifact/scope checks，再跑 task tests，最後 full suite；第一個拒絕仍寫完整 fail evidence。
 - manager 只依 validated evidence更新 Slice，不信任 agent log 的 done claim。

--- a/docs/superpowers/specs/2026-07-12-dispatch-discipline-improve.md
+++ b/docs/superpowers/specs/2026-07-12-dispatch-discipline-improve.md
@@ -1,107 +1,323 @@
-# Improve spec：強化 cortex 任務分派紀律（依 hippo multi-agent 實戰）（2026-07-12）
+# Improve spec：強化 cortex 任務分派紀律（依 multi-agent co-work 實戰）（2026-07-12）
 
-> Improvement 提案，非 greenfield。cortex 的 coordinator + persona 已經是一套多 vendor agent 分派系統；本 spec 把 paulsha-hippo 一次 9-issue 清零全程（多模型 co-work：copilot 實作／sonnet 驗收／Codex 異質 gate／frontier 硬修，跨多輪撞 limit、resume、洋蔥式剝 bug）**實測決定性的幾條紀律**落進 cortex 現有模組。方法論已固化於 `hamanpaul/paulsha-hippo` 的 `custom-skills/multi-model-orchestration`。
+> 狀態：v1 implementation spec。這是 improvement，不是 greenfield；以 cortex 現行 `slice_id → JobRegistry → completion → handoff → DAG release` 資料流為邊界，只修會造成假完成、同源審查與誤釋放下游的缺口。完整自治平台留待真實 TaskRun 證據再擴充。
 
-## 1. cortex 現況（實地盤點，非臆測）
+GitHub issue #10 是 umbrella backlog。本 spec 保留 `paulsha-hippo` 一次 9-issue 清零期間，Claude 與多家 agent/model co-work 得到的實戰心得；方法論是設計輸入，cortex 對 hippo 維持零 runtime 依賴。
 
-cortex 已具備分派骨架，且相似度極高：
+## 1. 實戰來源：哪些問題真的發生過
 
-- `persona/personas.yaml`：roles = `manager`（allowed_phases: research/define/plan/build/verify/review/ship）、`builder`（build）、`reviewer`（review）；`enforcement: shadow`。
-- `coordinator/launcher.py`：`build_claude_argv` / `build_codex_argv` / `build_copilot_argv` — **三家 vendor 都能 headless 起**。
-- `coordinator/autonomy.py`：`scan_specs` + `parse_spec_frontmatter` + `_build_graph` + `detect_cycles` — 讀 spec frontmatter、建**依賴圖 DAG**、偵測 cycle（= 拓撲分派）。
-- `coordinator/dispatcher.py`：`Dispatcher`、`_branch_for_task`（per-task 分支）、exit sentinel + `_pid_alive`（追蹤存活）。
-- `coordinator/manager.py`：`GateRunner` protocol、`_default_gate_runner`、handoff manifest 的 `_satisfied_pred`。
-- `coordinator/completion.py`：`classify_completion(exit_code, last_jsonl_line) -> 'done'/'failed'`。
-- `persona/gate.py`：`evaluate_diff` → `build_verdict`；`persona/shadow.py`：`run_shadow_validation`；`persona/handoff.py`：manifest 交棒；`persona/guardrail.py`：per-persona 路徑/工具 guardrail。
-- `coordinator/broker_reaper.py`：回收孤兒 codex broker（parent-based 偵測，委派 `scripts/reap-codex-brokers.sh`）。
+| 實戰心得 | 觀察到的失敗 | cortex 的最小落點 |
+| --- | --- | --- |
+| 完成必須看結果，不是 agent 自稱或 process exit | exit 0、末筆 log 說 done，實際仍是 placeholder、缺產物或測試紅 | P0-A：deterministic ResultVerification |
+| 同模型自審共享盲點 | 同源多 lens 與全綠測試仍放過 redaction、atomicity、race、rollback、crash-consistency 等真 bug | P0-B：不同 independence domain 的 ForeignReview |
+| gate 會逐輪剝出更深問題 | 修前輪 finding 後，複審才看到下一層；修復本身也可能引入新缺陷 | P0-C：保留 bounded fix-loop workstream，v1 先人工重派 |
+| 模型有比較優勢與成本差 | frontier 適合編排/硬修、cheaper agent 適合 bulk implementation、異質模型適合第二意見 | P1-A：保留 roster workstream，v1 只做最小 builder/reviewer mapping |
+| 長跑一定會遇到 session/rate limit | 沒有 checkpoint 時只能 restart，重做已完成工作 | P1-B：保留 resume workstream，等 canary 有真實中斷證據再做 |
+| process recovery 不能猜 ownership | name-pattern 很容易誤殺另一 project/worktree 的 live 工作 | P0-D：manager 不再自動跑 global reaper；operator apply 必須 scope 到 cwd root |
 
-**已經對得上的**：多 vendor launch、per-task 分支、DAG 拓撲、gate 概念、handoff、guardrail、reaper。這份 spec 不重造這些，只補「hippo 實戰證明缺了會出事」的紀律。
+這些心得不能因 YAGNI 被刪掉；YAGNI 只決定「現在實作多少」，不否定問題與後續方向。
 
-## 2. 五條實戰紀律 → cortex 的具體缺口
+## 2. 現行架構：已由 code/test trace 確認
 
-### P0-A｜完成 = 結果驗證，不是 exit code 分類
-
-**hippo 實證**：agent 會 **exit 0／宣稱「done」但根本沒做完**——copilot 在一個 task 回了 `placeholder-not-final`、多個 agent 宣稱成功但測試是紅的。單看 process 退出與末筆 log 會把「假完成」當「完成」。
-
-**cortex 缺口**：`completion.classify_completion(exit_code, last_jsonl_line)` 正是「exit code + 末筆 JSONL」判 done/failed——結構上無法分辨真做完與假做完。
-
-**提案**：在 `classify_completion` 回 `done` 與 manager 接受交棒**之間**插一個**結果驗證關**（比照 hippo 的 driver verify）：對該 task 的宣告產物做客觀斷言——分支有新 commit、該 task 的測試實跑為綠、diff 與 task 意圖相符（可用 persona contract 的 `allowed_phases`/scope 界定該驗什麼）。驗不過 → 不是 `done`，是 `needs-fix`（進 P0-C 的 fix-loop）。`done` 這個字只能由結果驗證授予，不是 agent 自稱、也不是 exit 0。
-
-### P0-B｜驗證 gate 異質 + fail-closed（整套架構的存在理由）
-
-**hippo 實證**：全綠測試 + **同模型** 3-lens 審查放過的 15+ 個真 bug（secret redaction 可被 override 繞過、DB 非原子發布、YAML 被標準 parser 靜默截斷、lost-update race、init rollback 誤刪、硬中止 crash-consistency…），**全部是異質 vendor（Codex）gate 抓到的**。同 vendor 自審共享盲點；不同 vendor 才是真的第二意見。
-
-**cortex 缺口**：兩個。(1) `personas.yaml` 沒有規定 `reviewer` 的 vendor 必須 **≠** `builder` 的 vendor——若兩者都派給同一家，gate 名存實亡。(2) `enforcement: shadow` = 目前 gate 是觀察模式，不擋。
-
-**提案**：
-- **異質綁定**：dispatcher 指派時強制 `reviewer.vendor ≠ builder.vendor`（cortex 三家都能起，天然可滿足）。builder 由誰做不限，但審它的 reviewer 必須跨 vendor。
-- **fail-closed**：`reviewer` 的 blocking verdict **不可被 builder 側（同 vendor/同角色）以「可能誤報」為由否決**——只能 (a) 修好後重審、或 (b) reviewer 自己在複審撤回。把此語意從 `shadow` 升為對 blocking verdict 生效的 enforce（其餘 severity 可維持 shadow/observe）。
-- **缺席顯性**：reviewer 起不來／逾時且復原失敗 → 標 `gate-absent`，不得靜默當通過；升級人工或明確記錄於交棒 manifest。
-
-### P0-C｜有界 fix-loop + 誠實升級（洋蔥收斂）
-
-**hippo 實證**：gate 每輪確認前輪已修、再剝出更深一個（且**修復可能引入新缺陷**，同 gate 再抓），跑到一輪 re-gate 乾淨為止；卡關就標 blocked、下游跳過，不硬推。
-
-**cortex 缺口**：manager/gate 目前沒有明確的「reject → fix → re-gate ≤N 輪 → 否則 needs-human」狀態機。
-
-**提案**：manager 的 job 狀態機加 `needs-fix → (builder 修) → re-gate`，上限（建議 2）；仍不過 → `blocked` / `needs-human`，DAG 下游依賴此 task 者標 `upstream-blocked`、不啟動。明文：一輪 re-gate 全綠才算 done；「已修得差不多」不是完成條件。
-
-### P1-A｜persona 依比較優勢分派（roster）
-
-**hippo 實證**：frontier 只做編排＋硬修（用量壓最低、最後才撞 limit）、bulk implement 丟 copilot/cheaper、異質 gate 丟不同 vendor、瑣事丟最便宜。角色錯配 = 又貴又容易撞牆。
-
-**cortex 缺口**：`personas.yaml` 的 role→phase 有了，但沒有 **role→vendor/model（依比較優勢）** 的宣告。
-
-**提案**：`personas.yaml` 每個 role 增 `vendor`/`model` 欄與「比較優勢」註記；dispatcher 依此起對應 CLI（`build_*_argv` 已備）。預設建議：manager=frontier、builder=cheaper/other-vendor、reviewer=**與 builder 不同 vendor**、瑣事=最便宜。與 P0-B 的異質綁定一致。
-
-### P1-B｜任務狀態持久 → resume 不 restart
-
-**hippo 實證**：長跑必撞 session/rate limit；靠 journal 把已完成步驟持久化、`resumeFromRunId` 續跑（已完成零成本跳過、已 merge 的批次硬標完成不重做），是活下來的關鍵。
-
-**cortex 缺口**：dispatcher 用 exit sentinel + pid 追活，broker_reaper 回收死掉的——但 task 被 reap／agent 撞 limit 死掉後，是**從持久狀態 resume 到上次 checkpoint**、還是從頭 restart？handoff manifest 已是持久交棒點，但缺「resume 語意」。
-
-**提案**：task 狀態（phase、已過的關、產物 ref）持久到 handoff manifest／journal；reaper 回收後，manager 重派時**從最後 checkpoint 續**，已完成的 phase/關不重跑；已 ship 的 task 標 terminal 不重啟。明文：resume 是常態路徑（天天走、被驗過），不是只有出事才踩的冷門分支。
-
-### P2｜reap／kill 前驗歸屬（guardrail 強化）
-
-**hippo 實證**：恢復序列差點誤殺兩個「孤兒狀」進程——實為別的專案 bot 與另一 agent 的 worktree job；照 name-pattern 殺會砸掉 live 工作。
-
-**cortex 現況**：`broker_reaper` 已用 parent-based（reaper 的 `app-server-broker.mjs`）而非純 name-pattern，方向正確。**提案**：把「SIGTERM 前必驗 cmdline/cwd 歸屬、絕不只憑 pattern」寫成 `guardrail.py` 的明文原則，涵蓋未來任何新增的 kill 路徑（不只 codex broker）。
-
-## 3. 非目標
-
-- 不重造 dispatcher/persona 骨架（已存在，只補紀律）。
-- 不強制所有 severity 都 fail-closed——只有 **blocking verdict** 升 enforce，其餘可維持 shadow/observe（漸進，不打斷現行 shadow 部署）。
-- 不 bump `VERSION`（release 時機另定）。
-- 不把某一家 vendor 寫死為唯一 reviewer——只綁「reviewer.vendor ≠ builder.vendor」的約束，不綁具體家。
-
-## 4. 驗收（怎麼知道成功）
-
-- **假完成擋得住**：構造一個 agent exit 0／末筆 JSONL 說 `done` 但分支無 commit／測試紅的 fixture → 結果驗證關必須判 `needs-fix`，不得放行為 `done`。
-- **異質綁定生效**：dispatcher 若被要求把 reviewer 派給與 builder 同 vendor → 顯性拒絕或重派；blocking verdict 下 builder 側無法 override merge。
-- **缺席不誤判**：reviewer 起不來 → `gate-absent`，deck/manifest 不顯示為健康通過。
-- **fix-loop 有界**：注入連續失敗 → ≤2 輪後 `needs-human`，下游 `upstream-blocked`，非無限重試。
-- **resume 不 restart**：reap 一個跑到一半的 task → 重派從 checkpoint 續，已過的關不重跑（以 manifest/journal 佐證）。
-- **roster 可宣告**：`personas.yaml` 能宣告 role→vendor 且 dispatcher 據此起對應 CLI。
-
-## 5. 相依與順序
-
-```
-P0-A 結果驗證完成關 ──┐
-P0-B 異質+fail-closed gate ──┼─（三者同屬「完成正確性」核心，先做）
-P0-C 有界 fix-loop ──┘
-P1-A roster（依比較優勢） ──（與 P0-B 異質綁定一致，接著做）
-P1-B resume 不 restart ──（獨立，長跑韌性）
-P2 reap 歸屬 guardrail ──（獨立小改，隨時）
+```mermaid
+flowchart TD
+    A[spec frontmatter] --> B[ready_units]
+    B --> C[dispatch_ready]
+    C --> D[JobRegistry jobs.json]
+    D --> E[exit sentinel or branch commit]
+    E --> F[Job done or failed]
+    F --> G[complete_tick]
+    G --> H[shadow persona gate recorded only]
+    H --> I[handoff gate_status]
+    I --> J[default_is_satisfied]
+    J --> K[DAG downstream release]
 ```
 
-## 6. 合規（cortex policy：flat / shareable / 1.0.12）
+現況事實：
 
-- 分支 `feature/<slug>`；禁 commit main；每 code PR 附 `changelog.d/` 碎片 + `CHANGELOG.md [Unreleased]` 鏡像；PR title conventional-commit、body zh-tw + `Closes #N`。
-- `tier: shareable`（R-21）：fixture／範例路徑中性佔位，無個人絕對路徑/機敏標記。
-- behavior 變更同步 README/docs（R-18）；新增測試進 CI（R-19）。
-- 本 spec 各項各自拆 issue + plan；建議 P0 三項作一個批次先走一輪完整 spec→plan→**異質 foreign-gate**→實作，順便當 cortex 自身採用該紀律的示範（吃自己的狗糧）。
+- `paulsha_cortex/coordinator/autonomy.py::parse_spec_frontmatter` 只解析 `dispatch`、`slice_id`、`plan`、`depends_on`。
+- `paulsha_cortex/coordinator/registry.py::JobRegistry` 以 atomic replace 持久化 `jobs.json`，Job status 只有 `dispatched/running/done/failed`。
+- `paulsha_cortex/coordinator/dispatcher.py` 的 branch polling 與 headless sentinel 都能直接把 Job 寫成 `done`。
+- `paulsha_cortex/coordinator/manager.py::complete_tick` 直接把 `done` 映射成 `gate_status=passed`；gate verdict 為 false 或 gate exception 都不阻擋。
+- `paulsha_cortex/coordinator/autonomy.py::default_is_satisfied` 只看 handoff `gate_status == passed`，沒有驗 upstream artifact 是否存在於 downstream base。
+- `paulsha_cortex/coordinator/manager_daemon.py` 預設每輪以 `apply=True` 執行 global broker reaper；shell script 只靠 cmdline pattern + parent 判斷候選。
 
-## 7. 一句話
+現有測試也明確鎖定 shadow 行為：false verdict 與 gate exception 仍寫 `passed`，隨後釋放 downstream。因此 v1 要改的是這條 load-bearing path，不是旁邊再蓋一套 Task orchestration engine。
 
-cortex 已經有分派系統的**骨**；hippo 這趟用血換到的是它的**紀律**——完成要靠結果驗證不是 exit code、審查要靠異質 vendor 且擋得住、卡關要誠實升級不硬推、撞 limit 要 resume 不 restart。把這四條落進 coordinator + persona，cortex 才從「會派工」變成「派得出可信結果」。
+## 3. v1 domain model：沿用現有架構
+
+| 名詞 | v1 定義 | 持久位置 |
+| --- | --- | --- |
+| `SliceRecord` | 一個 `slice_id` 的最小協調狀態，串起 builder Job、verification、reviewer Job 與 completion | 擴充現有 coordinator atomic JSON state，新增 `slices`；不建立 TaskRevision/TaskRun 平台 |
+| `Job` | 一次 headless agent execution；builder/reviewer 都是 Job | 現有 `jobs` list |
+| `Candidate` | builder Job 產生、準備被驗證/審查的 exact commit | SliceRecord 的 `candidate_head` |
+| `ResultVerification` | commit/artifact/test/scope 的 deterministic checks | verification evidence JSON |
+| `ForeignReview` | 不同 independence domain 的 reviewer Job，對 exact Candidate 做語意審查 | review verdict JSON |
+| `GateEvaluation` | 一個 reviewer Job 對一個 exact Candidate 的 immutable gate結果 | SliceRecord保存current evaluation ref；舊evaluation只留audit |
+| `CompletionRecord` | Candidate 已 verified 且已合入 target branch的下游 readiness proof | `runtime/handoff/<slice_id>.json` |
+| `ModelIdentityEntry` | explicit `(executor, model_id)` 到 `independence_domain` 的靜態映射 | P0-B 的最小 coordinator config |
+
+SliceRecord 至少保存：`slice_id`、spec/plan path 與 hash、target branch、dispatch base、candidate head、builder/reviewer job IDs、slice state、gate state、verification/review evidence refs。所有 state write 仍由 manager 單一 writer透過現有 atomic JSON persistence 完成。
+
+coordinator state、verification evidence、review verdict與CompletionRecord都必須帶`schema_version`。完成寫入順序固定為：(1) atomic寫CompletionRecord；(2) atomic更新SliceRecord=`completed`。`default_is_satisfied`必須同時確認SliceRecord與CompletionRecord一致，所以兩步間crash仍保持blocked；restart看到verified Slice與完全匹配的orphan record時可完成第2步，不匹配的orphan record則隔離/移除。
+
+本repo尚無正式runtime state，因此採clean-start：新schema遇到舊/未知`jobs.json`時拒絕啟動並提供明確archive/remove指令，不做自動migration，也不得靜默清空。
+
+v1 不建立：TaskRevision lifecycle、TaskRun aggregate、journal/snapshot平台、remote authorization、standing authorization、integration queue或自動 rollback engine。
+
+## 4. 狀態 reference：圖看流程，表查語意
+
+### 4.1 Job states
+
+v1 將現行 `done` 改名為 `exited`，避免把 process completion 誤寫成 task completion。
+
+| State | 精確定義 | Writer / 合法進入 | 合法離開 | Terminal | 對 DAG 的效果 | Restart / late result |
+| --- | --- | --- | --- | --- | --- | --- |
+| `dispatched` | registry row 已持久化，launcher handle 尚未確認或 process 尚未觀測為 running | manager 在 launch 前建立 | `running`、`failed` | 否 | 無 | daemon restart 後依 PID/sentinel重建；無可信 handle則 failed |
+| `running` | process identity/handle 已持久化且仍存活 | launcher attach handle | `exited`、`failed` | 否 | 無 | restart 後以 sentinel/PID判斷；不得僅靠舊 PID宣稱 running |
+| `exited` | 有可信 exit evidence 且 exit code為 0；只代表本次 agent execution 結束 | dispatcher poller | 無 | 是 | 無；必須由 SliceRecord 進 verification/review | late duplicate evidence冪等忽略 |
+| `failed` | non-zero exit、process 消失且無可信 sentinel、launch failure | launcher/dispatcher | 無 | 是 | 無 | 新的人工 retry建立新 Job，不覆寫舊 Job |
+
+Job history 保留為獨立 rows；v1 不實作自動 fix/retry loop，因此不需要 Attempt lineage、superseded等額外 states。
+
+### 4.2 Slice states
+
+| State | 精確定義 | Writer / 進入條件 | 合法離開 | Terminal | 對 DAG 的效果 | Restart / human action |
+| --- | --- | --- | --- | --- | --- | --- |
+| `pending` | spec ready，但尚無 active builder Job | manager 掃描 ready slice | `building`、`failed` | 否 | 無 | 可安全重新 dispatch |
+| `building` | builder Job 已建立，等待 terminal Job result | manager dispatch | `verifying`、`needs_human` | 否 | 無 | 由 Job state重建；不得重派第二個 builder |
+| `verifying` | builder Job exited，正在跑 deterministic checks | manager | `reviewing`、`needs_human` | 否 | 無 | evidence完整可冪等重讀；缺/壞 evidence重跑 verification |
+| `reviewing` | verification passed，reviewer Job 已建立或 verdict待驗 | manager | `verified`、`needs_human` | 否 | 無 | verdict必須綁exact Candidate；stale evaluation留audit並建立fresh evaluation |
+| `verified` | deterministic checks passed，且依review policy取得passed GateEvaluation或明確`not-required` proof；尚未證明合入target branch | manager | `completed`、`needs_human` | 否 | 無 | 每tick重驗target ancestry；branch ref偏離pinned Candidate則needs_human |
+| `completed` | verified Candidate 是 target branch ancestor，CompletionRecord 已寫入 | manager | 無 | 是 | 唯一可滿足 `depends_on` | restart 後重驗 record schema與 ancestry；不符則 fail-closed |
+| `needs_human` | verification reject、review reject/absent、stale/invalid evidence或無法安全判斷 | manager | `building`、`verifying`、`reviewing`、`failed` | 否 | 無 | v1只在本機status集中呈現；本機operator顯式retry-build/retry-verify/retry-review或abandon |
+| `failed` | 人類明確 abandon，或 slice 無法再繼續 | manager/local operator | 無 | 是 | 無；downstream保持 blocked | 重新處理需建立新的 slice/spec，不復活舊 record |
+
+### 4.3 Gate states
+
+每個 reviewer Job 建立一個新的 GateEvaluation；evaluation terminal 後 immutable，不重設、不覆寫。Candidate/spec/plan/verification hash 改變時，舊evaluation的terminal state與內容完全不變；Slice清除current evaluation ref、記錄`stale-input` invalidation reason，再為fresh reviewer Job建立新的`pending` evaluation。`stale`不是GateEvaluation state。
+
+| State | 精確定義 | Writer / 進入條件 | 合法離開 | Terminal | 對 Slice 的效果 | Evidence |
+| --- | --- | --- | --- | --- | --- | --- |
+| `pending` | verification尚未取得有效 review verdict | manager | `passed`、`rejected`、`absent` | 否 | Slice維持 reviewing | reviewer selection、subject HEAD與input hashes |
+| `passed` | 有效 foreign verdict，policy分類後沒有 blocking findings | manager verdict validator | 無 | 是 | Slice可進 verified | reviewer Job/launch identity、detached HEAD、findings |
+| `rejected` | verdict含至少一個 policy-classified blocking finding | manager verdict validator | 無 | 是 | Slice進 needs_human | stable finding IDs、severity、evidence |
+| `absent` | 無可用異質 reviewer、provider/model身分不明、verdict schema/provenance不可信 | manager | 無 | 是 | Slice進 needs_human | 嘗試過的 reviewer與失敗原因 |
+
+v1 不支援 agent 自行 override gate。人類若不同意 finding，修正 task或由本機顯式重跑 review；remote signed override、digest與standing authorization延後。
+
+Foundation plan必須提供本機operator actions：`retry-build`建立新builder Job、`retry-verify`重跑deterministic checks、`retry-review`建立新reviewer Job、`abandon`把Slice標failed。CLI只能沿用現有atomic control request queue送`slice-action`，由daemon/manager這個state單一writer驗證並持久化requested action、actor字串與result；CLI不得直接競寫`jobs.json`。v1只信任本機檔案權限/CLI執行者，不開放remote override API。
+
+## 5. v1 完成資料流
+
+```mermaid
+stateDiagram-v2
+    [*] --> pending
+    pending --> building: dispatch builder Job
+    building --> verifying: builder Job exited
+    building --> needs_human: builder Job failed
+    verifying --> reviewing: checks pass and review required
+    verifying --> verified: checks pass and review not required
+    verifying --> needs_human: verification rejects/errors
+    reviewing --> verified: foreign verdict has no blocking finding
+    reviewing --> needs_human: rejected/absent/invalid verdict
+    verified --> completed: candidate is target branch ancestor
+    needs_human --> building: human requests new builder Job
+    needs_human --> verifying: human requests verification retry
+    needs_human --> reviewing: human requests fresh review
+    needs_human --> failed: human abandons
+    completed --> [*]
+    failed --> [*]
+```
+
+所有 completion entry points 必須收斂到同一條路：
+
+1. branch polling或headless sentinel只更新 Job `exited/failed`。
+2. builder `exited` 後，把當下branch HEAD snapshot成immutable Candidate；Candidate必須是dispatch base descendant，branch ref之後偏離該SHA則needs_human。
+3. verification通過後，review-required Slice才啟reviewer Job；review-not-required Slice以明確policy proof直接到verified。
+4. ForeignReview通過只到 `verified`；reviewer必須在detached worktree checkout exact Candidate，manager驗證launch/result metadata而非信任verdict自述。
+5. Candidate合入target branch且ancestry成立後，才寫 CompletionRecord並進 `completed`。
+6. `default_is_satisfied` 只接受合法 CompletionRecord + ancestry proof，才釋放 downstream。
+
+既有低階`cortex dispatch --task ...`沒有spec/plan/target/verification metadata，且尚無正式runtime caller，v1直接移除，不保留第二套execution-only mutation path。`dispatch/fanout/tick/complete/slice-action`等所有coordinator state mutation都必須經既有atomic control request queue，由daemon/manager單一writer執行；daemon未運行時明確拒絕。`jobs/stat/ready/status`可直接讀atomic snapshot但不得寫state。
+
+## 6. P0-A：ResultVerification
+
+### 6.1 最小 frontmatter contract
+
+擴充現有 parser，不另造 plan manifest平台：
+
+```yaml
+---
+dispatch: auto
+slice_id: example-slice
+plan: docs/superpowers/plans/example.md
+depends_on: [upstream-slice]
+target_branch: main
+verification:
+  docs_class: normative       # normative | informational | trivial | code
+  required_artifacts:
+    - path: paulsha_cortex/example.py
+      must_change: true
+  checks:
+    - kind: persona-scope
+    - kind: command
+      name: policy
+      argv: [python3, -m, policy_check, --repo, .]
+      cwd: .
+      timeout_seconds: 300
+  tests:
+    - argv: [python3, -m, pytest, -q, tests/test_example.py]
+      cwd: .
+      timeout_seconds: 300
+  full_suite:
+    argv: [python3, -m, pytest, -q]
+    baseline: no-regression
+---
+```
+
+規則：
+
+- v1只有一種implicit runner type：typed argv subprocess。所有command必須是非空argv list並以`shell=False`執行，不接受runner-type extension或`bash -c`。
+- `checks`只接受`persona-scope`與`command`。每份auto-dispatch contract必須恰有一個`persona-scope`與至少一個`name: policy`的command check；docs build/link/example/security檢查也以具名command check或`tests`明列，不存在隱藏plugin registry。
+- `persona-scope`使用dispatch base上的persona catalog bytes/hash與builder role，對`base...Candidate` changed paths呼叫既有`persona.gate` path-scope API；Candidate不得自行改變本輪catalog。
+- cwd realpath必須位於worktree；v1 subprocess env只保留`PATH`、`HOME`、`LANG`、`LC_ALL`、`TMPDIR`、`VIRTUAL_ENV`中原本存在的值，不接受contract自訂env，也不注入credential variables。完整network/filesystem sandbox延後，因此v1只允許trusted、shareable verification contract，不宣稱已隔離untrusted code。
+- `required_artifacts`、所有`checks`、task tests與Candidate full suite必須exit 0；任一non-zero即reject。
+- full suite以dispatch base SHA與Candidate在相同argv、sanitized env與相對cwd各跑一次。Candidate必須exit 0；base exit 0或non-zero皆可記錄（Candidate可修復既有red），但base/Candidate任一command missing、timeout、signal、runner error或evidence不完整一律`needs_human`。v1不解析test IDs，因此base與Candidate都non-zero不得宣稱no-regression。
+- Candidate必須與dispatch base不同；v1不建立already-satisfied/no-op proof。無新commit即使artifact已存在、tests全綠仍`needs_human`。
+- command不存在、runner exception或evidence不完整一律 fail-closed 到 `needs_human`。
+- verification contract以dispatch時spec/plan hash固定；builder修改它不影響本輪驗證，修改後需人工重新dispatch。
+- `diff是否完成task intent`不偽裝成deterministic check，由ForeignReview負責。
+
+### 6.2 Docs-specific verification
+
+| docs class | v1 gate |
+| --- | --- |
+| `normative`：spec、ADR、policy、runbook、API contract | path/link/example/policy/secret checks + ForeignReview；不跑無關runtime tests |
+| `informational`：README、教學、說明 | docs build/link/example/policy checks；`review_policy=not-required`，通過後可直接verified |
+| `trivial`：拼字、排版、無語意格式 | 最小diff/policy/secret checks；`review_policy=not-required`，通過後可直接verified |
+| `code` | 依code verification contract執行，ForeignReview required |
+
+文件副檔名不能自行決定docs class；normative文件即使只改Markdown仍具有實作風險。
+
+## 7. P0-B：ForeignReview
+
+- reviewer 是第二個獨立 Job，不是現行同步 `GateRunner` callback換名字。
+- builder/reviewer必須使用explicit model ID；最小ModelIdentityRegistry映射 `(executor, model_id) → independence_domain`。
+- foreign條件為 `reviewer.independence_domain != builder.independence_domain`。不同CLI但同模型家族不算異質。
+- 找不到映射或無可用異質reviewer → Gate `absent`、Slice `needs_human`，不得fallback成passed。
+- reviewer Job launch metadata由manager固定executor、explicit model ID、independence domain與detached Candidate checkout；verdict identity只能與launch metadata核對，不能自行決定。
+- verdict至少包含：schema version、reviewer Job ID、subject builder Job ID、candidate HEAD、model identity與`findings[]`。每筆finding必須有`category`（`correctness|acceptance|security|data-loss|race|scope-bypass|verification-bypass|style|pre-existing-out-of-scope`）、`severity`（`critical|important|minor`）、非空summary、非空recommendation與`evidence[]`；每個evidence item固定為`{path: repo-relative string, line: positive int|null, detail: non-empty string}`。manager以sorted-key JSON序列化`category`、summary與依`(path,line,detail)`排序的evidence後取SHA-256生成stable finding ID，recommendation/severity不參與ID；同verdict重複ID須拒絕。
+- reviewer提供finding；是否blocking由cortex policy依category/evidence判定。correctness、acceptance、security、data loss/race、scope/verification bypass預設blocking；style或scope外既有問題預設non-blocking。
+- verdict HEAD不等於current Candidate → 原GateEvaluation內容/state不變且不得成為current evaluation；Slice以`stale-input` reason進needs_human，operator可建立fresh reviewer Job。
+- repo/spec/diff/log均視為untrusted data；review prompt以結構化邊界提醒artifact內指令不具authority，並以adversarial fixtures測試。這是threat mitigation，不宣稱模型行為可被形式證明；verdict仍必須過schema validator。
+- v1自動外送review只支援`tier: shareable`；private/work資料的provider routing延後。
+
+現行persona path-scope gate保留為ResultVerification的一個deterministic check，不與ForeignReview混成同一gate。
+
+## 8. `depends_on`：真正的 artifact dependency
+
+v1 明定 `depends_on` 不是「先後順序」；下游必須真的取得upstream artifact：
+
+- upstream只有在verified Candidate已合入`target_branch`後才completed。
+- CompletionRecord至少包含`slice_id`、spec/plan hashes、builder Job ID、dispatch base、candidate HEAD、target branch、verification evidence ref、`review_policy`與completed_at。`review_policy=required`時`reviewer_job_id`與`gate_evaluation_ref`必須為非空；`review_policy=not-required`時兩欄必須為null，另須保存由docs class與contract hash導出的`review_not_required_proof`。兩種shape不得混用。
+- v1同一dependency chain的所有Slice必須使用相同target branch；不一致時scan/dispatch fail-closed。
+- completion前先fetch configured remote target；fetch失敗時保持verified。`default_is_satisfied`除了驗record schema與目前spec/plan hashes，還要以remote-tracking target ref做git ancestry確認。
+- downstream worktree必須從該target ref的actual SHA建立；dispatch前再次對每個upstream Candidate執行`merge-base --is-ancestor candidate downstream_base`，避免readiness與worktree建立間的TOCTOU。
+- readiness不再只回boolean：dependency resolver必須回`ResolvedDependencySet`（satisfied、target branch、target ref SHA、upstream Candidate list與blocked reasons）；`ready_units/dispatch_ready`沿同一proof把actual base SHA傳給WorktreeCreator，不得由不同callsite各自重讀隱藏global state。
+- v1只支援preserving-commit merge；squash/cherry-pick改變Candidate identity，視為unsupported並轉needs_human，content/tree identity留待integration workstream。
+- target branch加入無關commit不使completion失效；Candidate不再是ancestor、record損壞或spec改成新slice時fail-closed。
+
+v1不做batch integration branch與自動merge queue。代價是upstream PR必須先merge，下游才會ready；等真實DAG證明逐Task merge成為瓶頸，再啟動integration workstream。
+
+## 9. P0-D：先停止global reaper誤殺風險
+
+現行global broker janitor的process未必由cortex啟動，因此不能事後補一個假的cortex ownership lease。
+
+v1 最小修正：
+
+- manager daemon不再預設每tick以`apply=True`執行global reaper。
+- reaper保留operator command，預設永遠dry-run。
+- `--apply`必須明確帶`--cwd-root <realpath>`，只處理live cwd位於該root的candidate。
+- signal前立即重新讀live PID/start time、cmdline、parent與cwd；snapshot不一致、路徑不符或讀取失敗一律skip。Shell re-check只能best-effort降低PID reuse風險，不宣稱提供pidfd等級ownership proof。
+- 只送SIGTERM，不自動SIGKILL。
+- 另一project的orphan-like broker即使name/parent符合也不得被signal。
+
+Attempt-levelprocess group/cgroup、ownership lease與automatic cleanup等到cortex真的管理長跑process tree後再做，不放進v1。
+
+## 10. P0-C/P1：保留實戰方向，但按證據啟動
+
+| Deferred workstream | 為何不在v1 | 啟動條件 |
+| --- | --- | --- |
+| P0-C（deferred）bounded fix-loop | 尚無正式Task證明人工重派是瓶頸；自動loop會先增加狀態與成本 | canary/正式紀錄反覆出現相同reject→fix→re-review，且能定義可靠budget |
+| P1-A provider/model roster與cost routing | v1只需一組builder/reviewer explicit mapping | 多組model可用、usage/cost資料足以證明routing收益 |
+| P1-B checkpoint/resume | 尚無長跑Task或重複中斷資料 | 真實Task因session/rate limit重做已驗證工作 |
+| batch integration/impact/rollback engine | v1使用merged-to-target，無需另造branch authority | 逐Task merge顯著阻塞DAG throughput |
+| Human Attention digest/standing authorization | v1沒有足夠needs-human事件資料 | 本機status累積的人工事項確實頻繁打斷工作 |
+| workload tier engine/Tier 2 automation | v1先跑shareable Tier 1 canary | Tier 1穩定且有明確高風險自動化需求 |
+| journal/snapshot/hash-chain evidence平台 | 現有atomic JSON足以支援單機、零正式Task的v1 | state規模、audit或crash evidence證明JSON模型不足 |
+| flaky registry/token-cost accounting/cgroup | 尚無實測資料 | 對應failure/cost/process問題重複發生 |
+
+Deferred 不代表默認允許：v1遇到不支援的情境一律停止在 `needs_human`，不得偷偷降級成passed。
+
+## 11. v1 acceptance matrix
+
+### Completion correctness
+
+- exit 0、末筆log說done，但無新commit/required artifact → Job exited、Slice `needs_human`，不得CompletionRecord。
+- commit存在但task test紅 → `needs_human`。
+- test command不存在、timeout或runner exception → `needs_human`並保存failure evidence。
+- branch polling與headless sentinel都只能結束Job，不能繞過verification/review。
+- gate verdict false或gate exception → 不得寫`passed/completed`。
+
+### Foreign review
+
+- builder/reviewer不同executor但同independence domain → 拒絕選擇。
+- reviewer absent/identity unknown → Gate `absent`、Slice `needs_human`。
+- verdict審的是舊HEAD → stale evaluation不得成為current gate，要求fresh reviewer Job。
+- repo內容嘗試指示reviewer忽略問題 → 不得改變review contract，產生security evidence。
+
+### Artifact dependency
+
+- upstream verified但未合入target branch → downstream不ready。
+- upstream Candidate成為target branch ancestor → CompletionRecord合法，downstream才ready。
+- downstream worktree base不含upstream Candidate → dispatch fail-closed。
+- 損壞/stale CompletionRecord不得釋放下游。
+- CompletionRecord寫入後、Slice update前若remote target移除Candidate，restart不得補`completed`；須保持verified或進needs_human。
+- squash/cherry-pick後原Candidate不再是ancestor → v1不得宣稱completed。
+
+### Reaper safety
+
+- periodic manager tick不再自動送signal。
+- `--apply`未帶cwd root → 拒絕。
+- 另一project broker或live identity與snapshot不符 → skip，kill seam零呼叫。
+- dry-run與apply使用同一candidate/ownership判定。
+
+### Docs
+
+- normative spec即使Markdown-only，仍要通過docs checks與ForeignReview。
+- informational/trivial docs不應被迫跑無關runtime tests。
+
+## 12. 落地順序與 canary
+
+1. P0-D：先移除periodic manager的automatic global reap。
+2. Foundation：擴充atomic state的`slices`與上述詳細狀態語意；clean-start，不做legacy runtime migration。
+3. P0-A：統一兩條Job completion入口，加入最小verification frontmatter/evidence。
+4. P0-B：加入reviewer Job、ModelIdentityRegistry、verdict/blocking policy。
+5. Dependency truth：CompletionRecord + merged-to-target ancestry + downstream base驗證。
+6. Disposable canary：至少覆蓋假完成、異質review、stale verdict、target未merge、downstream base與reaper negative fixtures。
+
+Canary全綠前不宣稱v1完成，也不啟動P0-C/P1 deferred automation。
+
+## 13. 合規
+
+- 使用`feature/<slug>`或`feature/<issue>-<slug>`；禁止直接commit main。
+- code PR同步更新`CHANGELOG.md [Unreleased]`；docs-only spec沿用既有`skip-changelog`並附理由。本repo未採用`changelog.d/`。
+- `tier: shareable` fixtures使用中性temp paths，不含個人絕對路徑、使用者名或機敏標記。
+- behavior變更同步README/docs；新增tests進CI。
+- 每個code PR通過`python3 -m policy_check --repo .`、完整pytest與對應failure-mode fixtures。
+- #10保持umbrella；P0-D、Foundation、P0-A、P0-B、Dependency truth各自拆subissue/plan/code PR。
+
+## 14. 一句話
+
+cortex v1不另造一套agent workflow平台：它沿用現有Job/manager/handoff/DAG骨架，把「process結束」與「可信完成」分開，以客觀verification、異質exact-HEAD review與merged-to-target ancestry阻止假完成；其餘multi-agent實戰心得保留為有明確觸發條件的後續workstreams。

--- a/docs/superpowers/specs/2026-07-12-dispatch-discipline-improve.md
+++ b/docs/superpowers/specs/2026-07-12-dispatch-discipline-improve.md
@@ -1,0 +1,107 @@
+# Improve spec：強化 cortex 任務分派紀律（依 hippo multi-agent 實戰）（2026-07-12）
+
+> Improvement 提案，非 greenfield。cortex 的 coordinator + persona 已經是一套多 vendor agent 分派系統；本 spec 把 paulsha-hippo 一次 9-issue 清零全程（多模型 co-work：copilot 實作／sonnet 驗收／Codex 異質 gate／frontier 硬修，跨多輪撞 limit、resume、洋蔥式剝 bug）**實測決定性的幾條紀律**落進 cortex 現有模組。方法論已固化於 `hamanpaul/paulsha-hippo` 的 `custom-skills/multi-model-orchestration`。
+
+## 1. cortex 現況（實地盤點，非臆測）
+
+cortex 已具備分派骨架，且相似度極高：
+
+- `persona/personas.yaml`：roles = `manager`（allowed_phases: research/define/plan/build/verify/review/ship）、`builder`（build）、`reviewer`（review）；`enforcement: shadow`。
+- `coordinator/launcher.py`：`build_claude_argv` / `build_codex_argv` / `build_copilot_argv` — **三家 vendor 都能 headless 起**。
+- `coordinator/autonomy.py`：`scan_specs` + `parse_spec_frontmatter` + `_build_graph` + `detect_cycles` — 讀 spec frontmatter、建**依賴圖 DAG**、偵測 cycle（= 拓撲分派）。
+- `coordinator/dispatcher.py`：`Dispatcher`、`_branch_for_task`（per-task 分支）、exit sentinel + `_pid_alive`（追蹤存活）。
+- `coordinator/manager.py`：`GateRunner` protocol、`_default_gate_runner`、handoff manifest 的 `_satisfied_pred`。
+- `coordinator/completion.py`：`classify_completion(exit_code, last_jsonl_line) -> 'done'/'failed'`。
+- `persona/gate.py`：`evaluate_diff` → `build_verdict`；`persona/shadow.py`：`run_shadow_validation`；`persona/handoff.py`：manifest 交棒；`persona/guardrail.py`：per-persona 路徑/工具 guardrail。
+- `coordinator/broker_reaper.py`：回收孤兒 codex broker（parent-based 偵測，委派 `scripts/reap-codex-brokers.sh`）。
+
+**已經對得上的**：多 vendor launch、per-task 分支、DAG 拓撲、gate 概念、handoff、guardrail、reaper。這份 spec 不重造這些，只補「hippo 實戰證明缺了會出事」的紀律。
+
+## 2. 五條實戰紀律 → cortex 的具體缺口
+
+### P0-A｜完成 = 結果驗證，不是 exit code 分類
+
+**hippo 實證**：agent 會 **exit 0／宣稱「done」但根本沒做完**——copilot 在一個 task 回了 `placeholder-not-final`、多個 agent 宣稱成功但測試是紅的。單看 process 退出與末筆 log 會把「假完成」當「完成」。
+
+**cortex 缺口**：`completion.classify_completion(exit_code, last_jsonl_line)` 正是「exit code + 末筆 JSONL」判 done/failed——結構上無法分辨真做完與假做完。
+
+**提案**：在 `classify_completion` 回 `done` 與 manager 接受交棒**之間**插一個**結果驗證關**（比照 hippo 的 driver verify）：對該 task 的宣告產物做客觀斷言——分支有新 commit、該 task 的測試實跑為綠、diff 與 task 意圖相符（可用 persona contract 的 `allowed_phases`/scope 界定該驗什麼）。驗不過 → 不是 `done`，是 `needs-fix`（進 P0-C 的 fix-loop）。`done` 這個字只能由結果驗證授予，不是 agent 自稱、也不是 exit 0。
+
+### P0-B｜驗證 gate 異質 + fail-closed（整套架構的存在理由）
+
+**hippo 實證**：全綠測試 + **同模型** 3-lens 審查放過的 15+ 個真 bug（secret redaction 可被 override 繞過、DB 非原子發布、YAML 被標準 parser 靜默截斷、lost-update race、init rollback 誤刪、硬中止 crash-consistency…），**全部是異質 vendor（Codex）gate 抓到的**。同 vendor 自審共享盲點；不同 vendor 才是真的第二意見。
+
+**cortex 缺口**：兩個。(1) `personas.yaml` 沒有規定 `reviewer` 的 vendor 必須 **≠** `builder` 的 vendor——若兩者都派給同一家，gate 名存實亡。(2) `enforcement: shadow` = 目前 gate 是觀察模式，不擋。
+
+**提案**：
+- **異質綁定**：dispatcher 指派時強制 `reviewer.vendor ≠ builder.vendor`（cortex 三家都能起，天然可滿足）。builder 由誰做不限，但審它的 reviewer 必須跨 vendor。
+- **fail-closed**：`reviewer` 的 blocking verdict **不可被 builder 側（同 vendor/同角色）以「可能誤報」為由否決**——只能 (a) 修好後重審、或 (b) reviewer 自己在複審撤回。把此語意從 `shadow` 升為對 blocking verdict 生效的 enforce（其餘 severity 可維持 shadow/observe）。
+- **缺席顯性**：reviewer 起不來／逾時且復原失敗 → 標 `gate-absent`，不得靜默當通過；升級人工或明確記錄於交棒 manifest。
+
+### P0-C｜有界 fix-loop + 誠實升級（洋蔥收斂）
+
+**hippo 實證**：gate 每輪確認前輪已修、再剝出更深一個（且**修復可能引入新缺陷**，同 gate 再抓），跑到一輪 re-gate 乾淨為止；卡關就標 blocked、下游跳過，不硬推。
+
+**cortex 缺口**：manager/gate 目前沒有明確的「reject → fix → re-gate ≤N 輪 → 否則 needs-human」狀態機。
+
+**提案**：manager 的 job 狀態機加 `needs-fix → (builder 修) → re-gate`，上限（建議 2）；仍不過 → `blocked` / `needs-human`，DAG 下游依賴此 task 者標 `upstream-blocked`、不啟動。明文：一輪 re-gate 全綠才算 done；「已修得差不多」不是完成條件。
+
+### P1-A｜persona 依比較優勢分派（roster）
+
+**hippo 實證**：frontier 只做編排＋硬修（用量壓最低、最後才撞 limit）、bulk implement 丟 copilot/cheaper、異質 gate 丟不同 vendor、瑣事丟最便宜。角色錯配 = 又貴又容易撞牆。
+
+**cortex 缺口**：`personas.yaml` 的 role→phase 有了，但沒有 **role→vendor/model（依比較優勢）** 的宣告。
+
+**提案**：`personas.yaml` 每個 role 增 `vendor`/`model` 欄與「比較優勢」註記；dispatcher 依此起對應 CLI（`build_*_argv` 已備）。預設建議：manager=frontier、builder=cheaper/other-vendor、reviewer=**與 builder 不同 vendor**、瑣事=最便宜。與 P0-B 的異質綁定一致。
+
+### P1-B｜任務狀態持久 → resume 不 restart
+
+**hippo 實證**：長跑必撞 session/rate limit；靠 journal 把已完成步驟持久化、`resumeFromRunId` 續跑（已完成零成本跳過、已 merge 的批次硬標完成不重做），是活下來的關鍵。
+
+**cortex 缺口**：dispatcher 用 exit sentinel + pid 追活，broker_reaper 回收死掉的——但 task 被 reap／agent 撞 limit 死掉後，是**從持久狀態 resume 到上次 checkpoint**、還是從頭 restart？handoff manifest 已是持久交棒點，但缺「resume 語意」。
+
+**提案**：task 狀態（phase、已過的關、產物 ref）持久到 handoff manifest／journal；reaper 回收後，manager 重派時**從最後 checkpoint 續**，已完成的 phase/關不重跑；已 ship 的 task 標 terminal 不重啟。明文：resume 是常態路徑（天天走、被驗過），不是只有出事才踩的冷門分支。
+
+### P2｜reap／kill 前驗歸屬（guardrail 強化）
+
+**hippo 實證**：恢復序列差點誤殺兩個「孤兒狀」進程——實為別的專案 bot 與另一 agent 的 worktree job；照 name-pattern 殺會砸掉 live 工作。
+
+**cortex 現況**：`broker_reaper` 已用 parent-based（reaper 的 `app-server-broker.mjs`）而非純 name-pattern，方向正確。**提案**：把「SIGTERM 前必驗 cmdline/cwd 歸屬、絕不只憑 pattern」寫成 `guardrail.py` 的明文原則，涵蓋未來任何新增的 kill 路徑（不只 codex broker）。
+
+## 3. 非目標
+
+- 不重造 dispatcher/persona 骨架（已存在，只補紀律）。
+- 不強制所有 severity 都 fail-closed——只有 **blocking verdict** 升 enforce，其餘可維持 shadow/observe（漸進，不打斷現行 shadow 部署）。
+- 不 bump `VERSION`（release 時機另定）。
+- 不把某一家 vendor 寫死為唯一 reviewer——只綁「reviewer.vendor ≠ builder.vendor」的約束，不綁具體家。
+
+## 4. 驗收（怎麼知道成功）
+
+- **假完成擋得住**：構造一個 agent exit 0／末筆 JSONL 說 `done` 但分支無 commit／測試紅的 fixture → 結果驗證關必須判 `needs-fix`，不得放行為 `done`。
+- **異質綁定生效**：dispatcher 若被要求把 reviewer 派給與 builder 同 vendor → 顯性拒絕或重派；blocking verdict 下 builder 側無法 override merge。
+- **缺席不誤判**：reviewer 起不來 → `gate-absent`，deck/manifest 不顯示為健康通過。
+- **fix-loop 有界**：注入連續失敗 → ≤2 輪後 `needs-human`，下游 `upstream-blocked`，非無限重試。
+- **resume 不 restart**：reap 一個跑到一半的 task → 重派從 checkpoint 續，已過的關不重跑（以 manifest/journal 佐證）。
+- **roster 可宣告**：`personas.yaml` 能宣告 role→vendor 且 dispatcher 據此起對應 CLI。
+
+## 5. 相依與順序
+
+```
+P0-A 結果驗證完成關 ──┐
+P0-B 異質+fail-closed gate ──┼─（三者同屬「完成正確性」核心，先做）
+P0-C 有界 fix-loop ──┘
+P1-A roster（依比較優勢） ──（與 P0-B 異質綁定一致，接著做）
+P1-B resume 不 restart ──（獨立，長跑韌性）
+P2 reap 歸屬 guardrail ──（獨立小改，隨時）
+```
+
+## 6. 合規（cortex policy：flat / shareable / 1.0.12）
+
+- 分支 `feature/<slug>`；禁 commit main；每 code PR 附 `changelog.d/` 碎片 + `CHANGELOG.md [Unreleased]` 鏡像；PR title conventional-commit、body zh-tw + `Closes #N`。
+- `tier: shareable`（R-21）：fixture／範例路徑中性佔位，無個人絕對路徑/機敏標記。
+- behavior 變更同步 README/docs（R-18）；新增測試進 CI（R-19）。
+- 本 spec 各項各自拆 issue + plan；建議 P0 三項作一個批次先走一輪完整 spec→plan→**異質 foreign-gate**→實作，順便當 cortex 自身採用該紀律的示範（吃自己的狗糧）。
+
+## 7. 一句話
+
+cortex 已經有分派系統的**骨**；hippo 這趟用血換到的是它的**紀律**——完成要靠結果驗證不是 exit code、審查要靠異質 vendor 且擋得住、卡關要誠實升級不硬推、撞 limit 要 resume 不 restart。把這四條落進 coordinator + persona，cortex 才從「會派工」變成「派得出可信結果」。

--- a/openspec/changes/dispatch-discipline-improve/.openspec.yaml
+++ b/openspec/changes/dispatch-discipline-improve/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-12

--- a/openspec/changes/dispatch-discipline-improve/README.md
+++ b/openspec/changes/dispatch-discipline-improve/README.md
@@ -1,0 +1,3 @@
+# dispatch-discipline-improve
+
+強化 cortex 任務分派紀律：阻止假完成、要求必要的異質 exact-HEAD review、以 target ancestry 釋放相依，並移除 periodic automatic broker reaping。

--- a/openspec/changes/dispatch-discipline-improve/design.md
+++ b/openspec/changes/dispatch-discipline-improve/design.md
@@ -1,0 +1,93 @@
+## Context
+
+現行coordinator有可沿用的骨架：frontmatter scan、per-slice worktree、headless launcher、atomic `JobRegistry`、manager tick、handoff JSON與DAG readiness。缺口位於load-bearing completion path：poller可直接寫`done`，`complete_tick`將它映射為`gate_status=passed`，shadow gate的false/exception不阻擋，`default_is_satisfied`再僅憑該欄位釋放downstream。manager daemon另會periodic自動apply全域broker reaper。
+
+完整狀態與驗收語意見`docs/superpowers/specs/2026-07-12-dispatch-discipline-improve.md`；逐檔TDD步驟見`docs/superpowers/plans/2026-07-12-dispatch-discipline-improve.md`。
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- 在現有Job/manager/handoff/DAG骨架內阻止false completion。
+- 讓deterministic verification、必要的ForeignReview與target ancestry都產生可重讀證據。
+- 讓crash、stale evidence、unknown identity與fetch failure保持fail-closed。
+- 停止periodic automatic broker signaling，保留受cwd root縮限的manual best-effort cleanup。
+- 將所有`needs_human`狀態與可執行動作一次清楚列出，避免逐筆打斷operator。
+
+**Non-Goals:**
+
+- TaskRevision/TaskRun平台、journal/snapshot/hash-chain。
+- 自動fix-loop、resume、cost routing、batch integration、rollback engine。
+- remote/signed override、standing authorization或human attention digest service。
+- untrusted-code network/filesystem sandbox、pidfd/cgroup ownership證明。
+- squash/cherry-pick後的content identity。
+
+## Decisions
+
+### 1. 擴充現有atomic state，不建立平行workflow engine
+
+`jobs.json`加入`schema_version`與`slices`；Job只描述一次execution，Slice描述delivery lifecycle。這保留現有single-writer與atomic replace特性，也讓`exited`、`verified`、`completed`不再混為一談。
+
+替代方案是建立TaskRun aggregate與event journal；目前沒有正式runtime scale或resume需求證據，先不採用。
+
+### 2. Evidence immutable，current ref可替換
+
+verification、review verdict與CompletionRecord各有schema version與hash-bound identity。每個reviewer Job建立一筆terminal後不可改的GateEvaluation；Candidate或input hash改變時建立fresh evaluation，舊資料只留audit。
+
+這比重設單一gate state更容易驗restart與stale-result fencing，且不需要完整attempt平台。
+
+### 3. Typed argv deterministic verification先於semantic review
+
+runner只有implicit typed-argv subprocess，接受worktree內cwd。contract明列`persona-scope`與command checks；auto-dispatch必須有policy command。env只保留`PATH/HOME/LANG/LC_ALL/TMPDIR/VIRTUAL_ENV`中既有值。required artifacts、Candidate commands與Candidate full suite必須通過；base full suite可red而Candidate必須green，任一runner error/timeout則`needs_human`。Candidate等於dispatch base一律拒絕，v1不建立no-op proof。
+
+v1只允許trusted、shareable contract。清env不是sandbox，因此不接受untrusted verification，也不宣稱network isolation。
+
+### 4. ForeignReview以manager launch metadata證明身分與subject
+
+靜態ModelIdentityRegistry將`(executor, model_id)`映射到`independence_domain`；manager固定builder/reviewer launch metadata與detached Candidate checkout。reviewer自述不能覆蓋launch authority；不同CLI但同domain不算foreign。
+
+informational/trivial以明確`review_policy=not-required` proof跳過review；normative/code找不到foreign reviewer時Gate=`absent`並停在`needs_human`。
+
+CompletionRecord採discriminated shape：required review保存reviewer Job/Gate refs；not-required時兩欄必為null並保存docs class+contract hash proof。GateEvaluation row永不改；stale只清除Slice current ref並記invalidation reason。
+
+### 5. Artifact dependency以remote target ancestry閉合
+
+Slice只在Candidate已verified且為remote-tracking target ancestor時完成。同一dependency chain使用同target branch，且只支援保留Candidate commit identity的merge。readiness後、worktree建立前，再以actual downstream base SHA重驗每個upstream Candidate，關閉TOCTOU。
+
+逐task merge的throughput代價先接受；只有真實瓶頸出現才考慮integration branch/queue。
+
+### 6. CompletionRecord先寫，Slice completed後寫
+
+先atomic寫CompletionRecord，再atomic更新Slice。`default_is_satisfied`同時要求兩者一致，所以兩步間crash保持blocked；restart只補完完全匹配的orphan record，不匹配者隔離。
+
+restart補第二步前仍須重新fetch並確認current target ancestry；remote已移除Candidate時不得把Slice標completed。
+
+跨兩個檔案做transaction/journal可提供更強原子性，但對目前單機JSON規模是不必要平台化。
+
+### 7. Broker cleanup只由operator觸發
+
+manager periodic path完全不接reaper。manual command預設dry-run；apply需resolved cwd root，signal前重讀start-time/cmdline/parent/cwd且只送SIGTERM。這是best-effort降低誤殺，不宣稱等同pidfd ownership。
+
+### 8. Human action沿用control request queue
+
+CLI的`dispatch/fanout/tick/complete/slice-action`只送control request；daemon/manager是`jobs.json`唯一writer。無spec metadata的舊低階direct dispatch移除；daemon未運行時mutation明確失敗。`jobs/stat/ready/status`只讀atomic snapshot。這沿用既有request/done contract，避免CLI與daemon競寫state。dependency resolution同樣回傳含target ref SHA與upstream Candidates的`ResolvedDependencySet`，讓readiness proof一路傳到worktree creation。
+
+## Risks / Trade-offs
+
+- [逐task preserving merge降低DAG throughput] → 先以canary觀測；有重複瓶頸證據才啟動integration workstream。
+- [sanitized env仍可執行具網路能力的trusted command] → v1限shareable/trusted contract並明文揭露邊界。
+- [靜態model identity不是provider cryptographic attestation] → manager launch metadata為本機authority；unknown/mismatch一律absent。
+- [JSON state與evidence數量成長] → 先沿用atomic files；只有scale/audit證據顯示不足才導入journal。
+- [cwd/process reread仍有check-to-signal race] → periodic path不signal、apply需operator明確scope、任何未知值skip、只SIGTERM。
+
+## Migration Plan
+
+1. 先移除periodic automatic reaper，這項可獨立安全落地。
+2. 引入versioned state與`done → exited`；因尚無正式task runtime，遇legacy/unknown state直接拒載並提示operator archive/remove。
+3. 依序接上verification、ForeignReview、CompletionRecord與ancestry readiness；每階段以RED regression證明舊false-green被關閉。
+4. 以temporary repo/bare remote/fake agents跑disposable canary後再啟用真實spec。
+5. rollback只回退code並使用deployment前保存的state archive；不得用新版程式自動重寫未知舊state。
+
+## Open Questions
+
+無blocking open question。Deferred workstreams及其證據觸發條件由source spec第10節管理，不在本change預先決定。

--- a/openspec/changes/dispatch-discipline-improve/design.md
+++ b/openspec/changes/dispatch-discipline-improve/design.md
@@ -38,7 +38,7 @@ verification、review verdict與CompletionRecord各有schema version與hash-boun
 
 ### 3. Typed argv deterministic verification先於semantic review
 
-runner只有implicit typed-argv subprocess，接受worktree內cwd。contract明列`persona-scope`與command checks；auto-dispatch必須有policy command。env只保留`PATH/HOME/LANG/LC_ALL/TMPDIR/VIRTUAL_ENV`中既有值。required artifacts、Candidate commands與Candidate full suite必須通過；base full suite可red而Candidate必須green，任一runner error/timeout則`needs_human`。Candidate等於dispatch base一律拒絕，v1不建立no-op proof。
+runner只有implicit typed-argv subprocess，接受worktree內cwd。contract明列`persona-scope`與command checks；auto-dispatch必須有policy command。env只保留`PATH`、`HOME`、`LANG`、`LC_ALL`、`TMPDIR`、`VIRTUAL_ENV`中既有值。required artifacts、Candidate commands與Candidate full suite必須通過；base full suite可red而Candidate必須green，任一runner error/timeout則`needs_human`。Candidate等於dispatch base一律拒絕，v1不建立no-op proof。
 
 v1只允許trusted、shareable contract。清env不是sandbox，因此不接受untrusted verification，也不宣稱network isolation。
 

--- a/openspec/changes/dispatch-discipline-improve/proposal.md
+++ b/openspec/changes/dispatch-discipline-improve/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+cortex目前把agent process成功退出直接視為task完成，即使verification/review失敗，downstream仍可能被釋放；periodic manager同時會自動套用global broker reaper，存在跨project誤殺風險。這些缺口已在Claude與multi-agent co-work中實際造成false-green、共享盲點與人工恢復負擔，應先以現有coordinator骨架補上最小可信完成鏈。
+
+## What Changes
+
+- **BREAKING**：Job terminal `done`改為`exited`，只代表execution成功結束；舊/未知`jobs.json`採clean-start拒載，不提供自動migration。
+- 在既有atomic coordinator state新增Slice lifecycle、immutable verification/review evidence與versioned CompletionRecord。
+- 以typed-argv deterministic verification驗Candidate、必要產物、task tests、scope與no-regression full suite。
+- normative/code task必須由不同independence domain的reviewer Job審查exact Candidate HEAD；informational/trivial可由明確`not-required` policy直接進verified。
+- `depends_on`只在verified Candidate已成為configured remote target branch ancestor、CompletionRecord與Slice state一致時滿足；downstream worktree建立前再次驗actual base。
+- periodic manager不再自動執行global broker cleanup；operator command預設dry-run，apply須以cwd root縮限並在signal前重新驗process identity。
+- bounded fix-loop、resume、batch integration、automatic rollback、remote override、cost routing與journal platform維持deferred。
+
+## Capabilities
+
+### New Capabilities
+
+- `trusted-dispatch-completion`: 將Job execution、Slice delivery、deterministic verification、ForeignReview、CompletionRecord與artifact-aware dependency release串成fail-closed完成鏈。
+- `scoped-broker-cleanup`: 將broker cleanup改成operator-driven、cwd-scoped、signal前重新驗證的best-effort安全操作。
+
+### Modified Capabilities
+
+無；本repo尚無既有OpenSpec capability。
+
+## Impact
+
+- Affected code：`paulsha_cortex/coordinator/{registry,dispatcher,autonomy,manager,manager_daemon,launcher,completion,broker_reaper,seams}.py`、broker reaper shell script與coordinator CLI。
+- Affected state/API：`jobs.json` schema、Job status vocabulary、spec frontmatter、handoff CompletionRecord、manager status與local operator actions。
+- Affected tests/docs：coordinator unit/integration tests、disposable git remote canary、README與`CHANGELOG.md [Unreleased]`。
+- Runtime boundary：維持對`paulsha-hippo`零runtime依賴；只支援shareable tier、preserving-commit merge與同target-branch dependency chain。

--- a/openspec/changes/dispatch-discipline-improve/specs/scoped-broker-cleanup/spec.md
+++ b/openspec/changes/dispatch-discipline-improve/specs/scoped-broker-cleanup/spec.md
@@ -1,0 +1,35 @@
+## ADDED Requirements
+
+### Requirement: Periodic manager不得自動signal broker
+manager daemon與periodic/oneshot tick MUST NOT自動apply global broker reaper。broker cleanup MUST只能由local operator command觸發。
+
+#### Scenario: Normal manager tick
+- **WHEN** manager執行periodic或manual tick且operator未呼叫cleanup command
+- **THEN** manager不執行broker reaper
+- **THEN** manager不對任何broker送signal
+
+### Requirement: Cleanup apply必須由cwd root縮限
+broker cleanup command MUST預設dry-run。operator要求apply時MUST提供resolved cwd root；候選live cwd不在該root、無法解析或僅有字串prefix相似時MUST skip。
+
+#### Scenario: Dry-run列出候選
+- **WHEN** operator未提供`--apply`
+- **THEN** command可回報符合條件的候選
+- **THEN** command不送任何signal
+
+#### Scenario: 另一project的orphan-like broker
+- **WHEN** broker cmdline與parent符合pattern但live cwd不在operator指定root
+- **THEN** command skip該PID
+- **THEN** fake或real signal seam不被呼叫
+
+### Requirement: Signal前必須重新驗process identity
+apply path MUST在送signal前立即重新讀PID start-time、cmdline、parent與cwd，並與候選snapshot比較；任何改變、消失或讀取失敗 MUST skip。系統MUST只送SIGTERM且MUST NOT自動升級SIGKILL。
+
+#### Scenario: PID在scan與apply之間被reuse
+- **WHEN** live start-time、cmdline、parent或cwd任一值與候選snapshot不同
+- **THEN** command skip該PID
+- **THEN** 不送SIGTERM或SIGKILL
+
+#### Scenario: Identity完全一致
+- **WHEN** operator明確apply、cwd在root內且所有live identity欄位與snapshot一致
+- **THEN** command只對該PID送一次SIGTERM
+- **THEN** command不等待後自動送SIGKILL

--- a/openspec/changes/dispatch-discipline-improve/specs/trusted-dispatch-completion/spec.md
+++ b/openspec/changes/dispatch-discipline-improve/specs/trusted-dispatch-completion/spec.md
@@ -1,0 +1,100 @@
+## ADDED Requirements
+
+### Requirement: Execution與delivery狀態必須分離
+系統MUST以versioned atomic coordinator state分別保存Job execution與Slice delivery。exit code 0只能令Job進入`exited`，不得直接產生CompletionRecord、`completed` Slice或滿足`depends_on`。系統MUST拒載legacy或未知schema且不得自動清空或migration。
+
+#### Scenario: Agent成功退出但尚未驗證
+- **WHEN** builder Job以exit code 0結束
+- **THEN** Job成為`exited`且Slice進入verification path
+- **THEN** downstream維持blocked
+
+#### Scenario: 啟動遇到legacy state
+- **WHEN** coordinator讀到缺少支援schema version或含legacy `done`的`jobs.json`
+- **THEN** coordinator拒絕啟動並顯示state路徑與archive/remove指引
+- **THEN** 原state檔保持不變
+
+#### Scenario: 使用舊低階direct dispatch
+- **WHEN** operator嘗試使用沒有spec/plan/verification metadata的legacy direct dispatch介面
+- **THEN** CLI明確拒絕並指示使用spec-driven control request
+- **THEN** 系統不寫Job、Slice或CompletionRecord
+
+#### Scenario: Daemon未運行時要求mutation
+- **WHEN** operator呼叫`dispatch/fanout/tick/complete/slice-action`且沒有manager daemon可消費control request
+- **THEN** CLI以明確錯誤結束且不直接寫`jobs.json`
+
+### Requirement: Candidate必須接受deterministic ResultVerification
+系統MUST在builder exit後固定exact Candidate SHA，確認dispatch base為其ancestor且兩者不同，並依dispatch時pin住的contract驗required artifacts、`must_change`、persona scope、明列的policy/docs/security commands、task commands與full suite。command MUST使用typed argv且不得經shell；env只保留`PATH/HOME/LANG/LC_ALL/TMPDIR/VIRTUAL_ENV`中既有值。Candidate command/full suite MUST exit 0；base full suite可non-zero但runner本身必須可信完成。缺失、timeout、signal、exception、兩邊皆non-zero、未知或不完整evidence MUST fail-closed。
+
+#### Scenario: Exit 0但必要產物缺失
+- **WHEN** Candidate的builder Job exited但verification找不到required artifact
+- **THEN** Slice進入`needs_human`
+- **THEN** 系統不建立CompletionRecord
+
+#### Scenario: Candidate ref被force-update
+- **WHEN** manager固定Candidate後branch ref偏離該SHA或Candidate不再是dispatch base descendant
+- **THEN** 原verification/review不能沿用
+- **THEN** Slice進入`needs_human`
+
+#### Scenario: Builder沒有產生新commit
+- **WHEN** builder Job exited且branch HEAD等於dispatch base
+- **THEN** Slice進入`needs_human`，即使既有artifact存在且tests全綠
+- **THEN** 系統不建立no-op proof或CompletionRecord
+
+#### Scenario: Informational文件不需要semantic review
+- **WHEN** `docs_class=informational`或`trivial`且deterministic checks全部通過
+- **THEN** 系統以明確`review_policy=not-required` proof令Slice進入`verified`
+- **THEN** reviewer Job與GateEvaluation可為空
+
+### Requirement: Normative與code task必須取得ForeignReview
+系統MUST為`normative`與`code` Candidate建立獨立reviewer Job。reviewer的`independence_domain` MUST不同於builder，且manager MUST以launch metadata固定explicit executor/model identity與detached exact Candidate checkout。每個reviewer Job的GateEvaluation MUST terminal後immutable；stale input只能清除Slice current ref並記reason，不得修改舊evaluation。finding category MUST限定為`correctness|acceptance|security|data-loss|race|scope-bypass|verification-bypass|style|pre-existing-out-of-scope`，severity MUST為`critical|important|minor`，且每筆MUST含非空summary、recommendation與`evidence[]`。evidence item MUST為repo-relative path、positive line或null、non-empty detail。manager MUST以category、summary與排序後evidence的sorted-key JSON SHA-256產生finding ID。
+
+#### Scenario: 不同CLI但同一independence domain
+- **WHEN** reviewer executor與builder不同但兩者model identity映射到相同domain
+- **THEN** GateEvaluation成為`absent`
+- **THEN** Slice進入`needs_human`
+
+#### Scenario: Verdict綁定stale Candidate
+- **WHEN** verdict的subject HEAD或input hashes與current Candidate不一致
+- **THEN** verdict只保留為audit evidence且不能成為current evaluation
+- **THEN** 系統需要新的reviewer Job才能繼續
+
+#### Scenario: Reviewer回報blocking finding
+- **WHEN** validated verdict包含cortex policy分類為blocking的finding
+- **THEN** GateEvaluation成為`rejected`
+- **THEN** Slice進入`needs_human`且不釋放downstream
+
+### Requirement: Completion必須由target ancestry與一致證據證明
+系統MUST只在verified Candidate為configured remote-tracking target branch ancestor時完成Slice。CompletionRecord MUST帶schema version、input hashes、builder Job ID、Candidate、target、verification ref與review policy。required review MUST保存non-null reviewer Job/Gate refs；not-required MUST保存null refs與docs class+contract hash proof。系統MUST先atomic寫CompletionRecord，再atomic標記Slice`completed`；readiness MUST同時驗兩者與current ancestry。
+
+#### Scenario: Review通過但Candidate尚未merge
+- **WHEN** Slice已verified但Candidate不是remote target ancestor
+- **THEN** Slice維持`verified`
+- **THEN** `depends_on`維持不滿足
+
+#### Scenario: Record寫入後state更新前crash
+- **WHEN** CompletionRecord已atomic寫入但Slice仍為`verified`
+- **THEN** readiness回false
+- **THEN** restart重新fetch target，只在record、Slice與current ancestry完全匹配時補完`completed`
+
+#### Scenario: Crash window期間target移除Candidate
+- **WHEN** CompletionRecord已寫但restart時Candidate已不是remote target ancestor
+- **THEN** 系統不得把Slice補成`completed`
+- **THEN** Slice維持blocked並呈現可診斷reason
+
+#### Scenario: Downstream dispatch重新驗actual base
+- **WHEN** downstream在readiness判斷後準備建立worktree
+- **THEN** 系統解析remote target的actual base SHA並重新驗每個upstream Candidate為其ancestor
+- **THEN** 任一驗證失敗時不得建立或launch downstream worktree
+
+### Requirement: Human recovery必須明確且可追蹤
+系統MUST提供local `retry-build`、`retry-verify`、`retry-review`與`abandon` actions。CLI MUST透過既有atomic control request queue送出action；daemon/manager作為state單一writer保存action、actor與結果。status MUST一次列出所有Slice狀態、阻擋理由、evidence摘要與合法下一步，不得將remote或agent自述視為human override。
+
+#### Scenario: Operator重跑review
+- **WHEN** `needs_human` Slice有可信verification evidence且operator提交`retry-review`與actor
+- **THEN** 系統保存action history並建立新的reviewer Job與GateEvaluation
+- **THEN** 舊evaluation維持immutable audit record
+
+#### Scenario: Status呈現多筆人工事項
+- **WHEN** 多個Slice同時處於`needs_human`
+- **THEN** 單次status response列出全部Slice、原因與允許action
+- **THEN** 系統不要求operator逐筆互動確認

--- a/openspec/changes/dispatch-discipline-improve/specs/trusted-dispatch-completion/spec.md
+++ b/openspec/changes/dispatch-discipline-improve/specs/trusted-dispatch-completion/spec.md
@@ -23,7 +23,7 @@
 - **THEN** CLI以明確錯誤結束且不直接寫`jobs.json`
 
 ### Requirement: Candidate必須接受deterministic ResultVerification
-系統MUST在builder exit後固定exact Candidate SHA，確認dispatch base為其ancestor且兩者不同，並依dispatch時pin住的contract驗required artifacts、`must_change`、persona scope、明列的policy/docs/security commands、task commands與full suite。command MUST使用typed argv且不得經shell；env只保留`PATH/HOME/LANG/LC_ALL/TMPDIR/VIRTUAL_ENV`中既有值。Candidate command/full suite MUST exit 0；base full suite可non-zero但runner本身必須可信完成。缺失、timeout、signal、exception、兩邊皆non-zero、未知或不完整evidence MUST fail-closed。
+系統MUST在builder exit後固定exact Candidate SHA，確認dispatch base為其ancestor且兩者不同，並依dispatch時pin住的contract驗required artifacts、`must_change`、persona scope、明列的policy/docs/security commands、task commands與full suite。command MUST使用typed argv且不得經shell；env只保留`PATH`、`HOME`、`LANG`、`LC_ALL`、`TMPDIR`、`VIRTUAL_ENV`中既有值。Candidate command/full suite MUST exit 0；base full suite可non-zero但runner本身必須可信完成。缺失、timeout、signal、exception、兩邊皆non-zero、未知或不完整evidence MUST fail-closed。
 
 #### Scenario: Exit 0但必要產物缺失
 - **WHEN** Candidate的builder Job exited但verification找不到required artifact

--- a/openspec/changes/dispatch-discipline-improve/tasks.md
+++ b/openspec/changes/dispatch-discipline-improve/tasks.md
@@ -1,0 +1,48 @@
+> Detailed RED/PASS commands, exact files and commit boundaries are canonical in `docs/superpowers/plans/2026-07-12-dispatch-discipline-improve.md`. This checklist tracks OpenSpec apply progress without duplicating that execution plan.
+
+## 1. Scoped broker cleanup
+
+- [ ] 1.1 RED-test that periodic CLI/daemon ticks never call the reaper and manual cleanup defaults to dry-run.
+- [ ] 1.2 Implement `cortex reap-brokers`, require `--cwd-root` for apply, recheck live process identity and send SIGTERM only.
+- [ ] 1.3 Pass Python wiring and fake `/proc` negative fixtures, including cross-project and PID-reuse cases.
+
+## 2. Versioned coordinator state
+
+- [ ] 2.1 RED-test versioned `jobs+slices` state, `done → exited`, legal transitions, reloadable current/history containers and clean-start rejection.
+- [ ] 2.2 Implement atomic SliceRecord CRUD/action history while retaining Job history and single-writer persistence.
+- [ ] 2.3 Pass registry, dispatcher, completion, manager and restart focused tests.
+
+## 3. Deterministic verification
+
+- [ ] 3.1 RED-test strict `target_branch` and verification frontmatter parsing plus dispatch-time spec/plan/contract hashes.
+- [ ] 3.2 Implement versioned verification evidence, Candidate fencing, required artifact/scope/task checks and base-vs-Candidate no-regression suite.
+- [ ] 3.3 Replace false-green regressions so exit, rejection, timeout, exception and incomplete evidence cannot release downstream.
+
+## 4. Foreign exact-HEAD review
+
+- [ ] 4.1 RED-test explicit model identity mapping, different-domain selection, detached exact Candidate checkout and verdict provenance.
+- [ ] 4.2 Implement reviewer Jobs, immutable GateEvaluations and cortex-owned blocking-category classification.
+- [ ] 4.3 Pass same-domain, unknown identity, stale HEAD, malformed verdict, blocking and non-blocking review cases.
+
+## 5. Artifact-aware dependency release
+
+- [ ] 5.1 RED-test versioned CompletionRecord validation, record-first crash ordering and orphan-record restart handling.
+- [ ] 5.2 Implement remote target fetch/ancestry completion and readiness checks that require matching Slice state and evidence hashes.
+- [ ] 5.3 Pin downstream worktree actual base SHA and recheck every upstream Candidate before creation/launch.
+- [ ] 5.4 Pass unmerged, preserving-merge, squash/cherry-pick unsupported, target mismatch and TOCTOU git fixtures.
+
+## 6. Local recovery and status
+
+- [ ] 6.1 RED-test persisted `retry-build`, `retry-verify`, `retry-review` and `abandon` actions with required actor.
+- [ ] 6.2 Route `slice-action` through the existing control request queue so daemon/manager remains the only state writer.
+- [ ] 6.3 Implement action consumption and a single status response listing all needs-human reasons, evidence and legal next actions.
+
+## 7. Canary and documentation
+
+- [ ] 7.1 Pass a disposable end-to-end temporary repo/remote/fake-agent canary covering false completion, foreign review, stale verdict, merge ancestry, crash recovery and reaper negatives.
+- [ ] 7.2 Update README and `CHANGELOG.md [Unreleased]` with state semantics, contracts, limits, operator actions and best-effort cleanup warning.
+
+## 8. Completion gates
+
+- [ ] 8.1 Pass the full pytest suite, `python3 -m policy_check --repo .` and `git diff --check`.
+- [ ] 8.2 Complete independent code review, re-review every fix and resolve all Critical/Important adversarial findings.


### PR DESCRIPTION
## 摘要
依 paulsha-hippo 一次 9-issue 清零的多 agent co-work 實戰，替 cortex 的 **coordinator + persona 任務分派層**寫 improve spec。cortex 已有分派骨架（`launcher` 三家 vendor、`autonomy` DAG、`dispatcher` per-task 分支、`persona/gate`、`handoff`、`broker_reaper`），本 spec 只補實戰證明缺了會出事的紀律。

## 五條紀律 → cortex 具體缺口
- **P0-A 完成=結果驗證**：`completion.classify_completion(exit_code, last_jsonl_line)` 用 process 退出判 done——擋不住 agent exit 0 卻沒做完（hippo 實例：copilot 回 `placeholder-not-final`、宣稱成功但測試紅）。插結果驗證關（commit/測試/diff 對意圖）。
- **P0-B 異質 fail-closed gate**：`personas.yaml` 未綁 `reviewer.vendor ≠ builder.vendor`、`enforcement: shadow`。同 vendor 自審共享盲點——hippo 15+ 個真 bug 全綠測試+同模型 3-lens 都放過、異質 Codex 才抓到。綁異質 + blocking verdict 升 fail-closed + 缺席顯性。
- **P0-C 有界 fix-loop**：reject→fix→re-gate ≤2 輪→needs-human，下游 upstream-blocked。
- **P1-A roster**：role→vendor 依比較優勢（frontier 編排、builder cheaper、reviewer 異質、瑣事最便宜）。
- **P1-B resume 不 restart**：task 狀態持久到 manifest/journal，reap 後從 checkpoint 續。
- **P2 reap 前驗歸屬**：SIGTERM 前驗 cmdline/cwd，不憑 pattern（hippo 差點誤殺別專案進程）。

## 驗收定義性測試
假完成 fixture（exit 0 + 末筆 log 說 done，但無 commit/測試紅）→ 結果驗證關必須判 needs-fix。

## 合規
R-21 無個人路徑 ✓；policy_check 零 failure ✓；changelog 免（docs-only spec）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)