### PR TITLE
fix(cli): 修正 Usage 與 help 漂移

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,12 @@
 本專案所有重大變更都會記錄在此檔案。
 
 格式基於 [Keep a Changelog 1.1.0](https://keepachangelog.com/zh-TW/1.1.0/)，
-本專案遵循 hamanpaul project policy v1.0.7。
+本專案遵循 hamanpaul project policy v1.0.12。
 
 ## [Unreleased]
 
 ### Changed
+- **README Usage 與 CLI help 對齊實際 runtime**：頂層 `cortex --help` 現在列出 umbrella/coordinator 公開命令，coordinator/deck/monitor help 統一使用真實 `cortex` invocation，並明示低階 `dispatch` 停用、unsafe/model/control timeout 語意；README quickstart 同步區分 installer enable 與 service start、deprecated timer interval 與 daemon tick、monitor config 前置、Deck hold→auto、foreign review、preserving-commit merge 與 completion 流程。
 - **builder `exited` 不再直接走 completion shadow path**：coordinator 現在會先固定 Candidate、重新驗 pinned inputs，並以 deterministic ResultVerification 執行 required artifacts、persona scope、typed argv checks、task tests 與 base/candidate full-suite 比較；只有成功驗證才把 slice 推進 `verified` 或 `reviewing`，其餘一律 fail-closed 到 `needs_human`，不再讓 `exited` 單獨滿足 DAG。
 - **review-required slice 改為 exact-HEAD foreign review gate**：manager 現在會依 `PSC_PROJECT_CONFIG_ROOT/model-identities.yaml` 選擇不同 independence domain 的 reviewer，建立固定 Candidate 的 detached reviewer worktree，並把 `passed|rejected|absent` verdict 以 immutable GateEvaluation 落盤到 `evidence/review/`；缺 model / 同 domain / malformed verdict / stale HEAD / reviewer failure 一律 fail-closed，且只有 formal category enum 中的 blocking finding 會拒絕通過。
 - **dependency release 改為 CompletionRecord + target ancestry gate**：manager 在 `passed|verified` 後會先對 target ref 做 fetch/ancestor 檢查，寫入 immutable CompletionRecord 並把 slice 標記 `completed`；readiness 只接受 `slice_state=completed` 且 CompletionRecord/hash 對齊、Candidate 仍是當前 target ancestor 的 upstream，dispatch 下游 worktree 也改以 target ref SHA 當 base 並在發車前重驗 ancestry，避免未合併或 stale-head upstream 被提前釋放。

--- a/README.md
+++ b/README.md
@@ -20,8 +20,11 @@ persona 是 manager 與 guardrail 共同引用的**角色契約資料**（role p
 
 ## Install
 
+需求：Python 3.10+、Git，以及至少一個已安裝並登入的 headless executor CLI（`copilot`、`claude` 或 `codex`）。套件只安裝 Python runtime，不會代裝或登入 executor。
+
 ```bash
 pipx install git+https://github.com/hamanpaul/paulsha-cortex.git
+cortex --help
 ```
 
 也可在專案內直接安裝：
@@ -32,43 +35,78 @@ python -m pip install .
 
 ## Usage
 
-1. 安裝 systemd `--user` 單元（冪等；一次佈署 manager timer + monitor service）：
+1. 在被治理的目標 git repo 安裝 systemd `--user` 單元：
 
    ```bash
-   cortex install service --instance demo --interval 300
+   cd /path/to/target-repo
+   cortex install service \
+     --instance cortex \
+     --repo-root "$(git rev-parse --show-toplevel)"
    ```
 
-2. 啟動 / 查狀態：
+   Installer 會 render/copy units、執行 `daemon-reload`，並 enable manager timer 與 monitor service；**不會 start service**。`--interval` 只調整 deprecated timer 的 `OnUnitActiveSec`；長駐 daemon 的 tick 週期由 `PSC_MANAGER_INTERVAL_SECONDS` 控制。
+
+2. 啟動 manager 並分別檢查 service/runtime 狀態：
 
    ```bash
-   systemctl --user start demo-manager.timer
-   systemctl --user start demo-monitor.service
-   systemctl --user status demo-manager.timer
-   systemctl --user status demo-monitor.service
+   systemctl --user start cortex-manager.service cortex-manager.timer
+   systemctl --user status cortex-manager.service
+   cortex status | jq
    ```
 
-3. 使用 deck：
+   可在 `$HOME/.agents/core/runtime/cortex-manager.env` 加入 operator 設定；installer 重跑時會保留非 managed keys：
 
-   ```bash
-   cortex deck compile feature-oneshot --task "demo"
-   cortex deck verify openspec-archive --task-slug demo-task --change sample-change
+   ```dotenv
+   PSC_MANAGER_EXECUTOR=codex
+   PSC_MANAGER_INTERVAL_SECONDS=300
    ```
 
-4. 監看 project 狀態：
+3. 使用 Deck 先 dry-run，再 emit `dispatch: hold` specs：
 
    ```bash
-   cortex monitor --once
-   cortex monitor
+   cortex deck compile feature-oneshot --task "example feature" --change example-feature
+   cortex deck compile feature-oneshot --task "example feature" --change example-feature --emit
    ```
 
-5. 使用 coordinator CLI：
+4. 完成 interactive checklist，將 spec 的 glob plan 改為確切路徑，補齊 `target_branch` / `verification` 後才翻成 `dispatch: auto`，再執行一次完整 tick：
 
    ```bash
+   cortex ready --specs-dir "$HOME/.agents/specs" | jq
+   cortex tick \
+     --specs-dir "$HOME/.agents/specs" \
+     --executor codex \
+     --model "<builder-model-id>" \
+     --review-executor claude \
+     --review-model "<reviewer-model-id>"
+   ```
+
+5. Project Monitor 是選配功能。啟動前先建立 `$HOME/.agents/config/paulsha/project-cortex.yaml`；workspace path 應指向「包含各 repo 的父目錄」：
+
+   ```yaml
+   workspaces:
+     - name: projects
+       path: /path/to/workspace
+   monitor:
+     poll_interval_seconds: 60
+     rescan_interval_seconds: 300
+     legacy_policy: hide
+   ```
+
+   ```bash
+   cortex monitor --once | jq
+   systemctl --user start cortex-monitor.service
+   systemctl --user status cortex-monitor.service
+   ```
+
+6. 日常查詢：
+
+   ```bash
+   cortex status | jq
    cortex jobs
-   cortex ready --specs-dir ~/.agents/specs
+   cortex stat "$JOB_ID"
    ```
 
-> `cortex status` 查的是 manager 任務狀態；`systemctl --user status` 查的是 service 是否存活，兩者用途不同。
+> `cortex status` 查 manager 的工作與 gate 狀態；`systemctl --user status` 只查 service 是否存活，兩者不可互相替代。`fanout` / `tick` / `complete` / `slice-action` 的 CLI 最多等 control response 5 秒；timeout 後 daemon 可能仍在工作，應回到 `cortex status` 查證。
 
 ## 從使用者角度操作
 
@@ -113,7 +151,24 @@ Deck 產生的 spec 預設為 `dispatch: hold`，不會立即派工。翻成 `di
 
 Manager 只會派送「已翻 auto、有 plan、相依全部 completed」的 slice。不要使用低階 `cortex dispatch`；它因缺少 spec / verification metadata 已停用。
 
-### 2. 觀察任務狀態
+### 2. 派工與執行 gate
+
+先確認 ready set，再明確指定 builder 與 foreign reviewer：
+
+```bash
+cortex ready --specs-dir "$HOME/.agents/specs" | jq
+
+cortex tick \
+  --specs-dir "$HOME/.agents/specs" \
+  --executor codex \
+  --model "<builder-model-id>" \
+  --review-executor claude \
+  --review-model "<reviewer-model-id>"
+```
+
+`tick` 會依序處理 ready fanout、既有 Job 輪詢、deterministic verification、必要的 foreign review 與 completion 判斷。`--model` / `--review-model` 原樣傳給 executor，能否使用仍取決於該 CLI 與帳號權限。不要在一般操作加入 `--allow-unsafe`；它會旁路 executor approval/sandbox，且只允許單一 ready slice canary。
+
+### 3. 觀察任務狀態
 
 ```bash
 # Manager 綜合狀態：ready / held / in-flight / slices / attention
@@ -121,7 +176,7 @@ cortex status | jq
 
 # Job 執行歷史與單筆詳情
 cortex jobs | jq
-cortex stat <job-id> | jq
+cortex stat "$JOB_ID" | jq
 
 # 只列出目前可派送的 specs
 cortex ready --specs-dir ~/.agents/specs | jq
@@ -144,18 +199,31 @@ systemctl --user status cortex-manager.service cortex-monitor.service
 
 Job `exited` 只代表 Agent process 以 exit code 0 結束，**不代表任務交付完成**。只有 Slice 通過 deterministic verification、必要的 foreign review，且 Candidate 已進入 target branch 後，才會變成 `completed` 並釋放下游 dependency。
 
-### 3. 處理 `needs_human`
+### 4. 處理 `needs_human`
 
 先從 `cortex status` 的 `attention[].next_actions` 選擇當下允許的動作，不要手動改 `jobs.json`：
 
 ```bash
-cortex slice-action <slice-id> retry-build  --actor operator
-cortex slice-action <slice-id> retry-verify --actor operator
-cortex slice-action <slice-id> retry-review --actor operator
-cortex slice-action <slice-id> abandon      --actor operator
+cortex slice-action "$SLICE_ID" retry-build  --actor operator
+cortex slice-action "$SLICE_ID" retry-verify --actor operator
+cortex slice-action "$SLICE_ID" retry-review --actor operator
+cortex slice-action "$SLICE_ID" abandon      --actor operator
 ```
 
 `fanout`、`tick`、`complete` 與 `slice-action` 都會寫入 control request queue，再由 daemon / manager 這個單一 writer 改變狀態；daemon 未啟動時會明確拒絕，不會由 CLI 直接競寫 registry。
+
+### 5. Merge Candidate 並完成交付
+
+Cortex 不會替使用者 merge。verification / review 通過後，Slice 會停在 `verified` / `candidate-not-merged`；這個狀態不一定列入 `attention`，也要檢查 `status.slices`。將 `feature/<slice-id>` 透過保留原 Candidate commit 的 merge commit 合入並推送 target branch 後，再執行：
+
+```bash
+cortex complete \
+  --specs-dir "$HOME/.agents/specs" \
+  --review-executor claude \
+  --review-model "<reviewer-model-id>"
+```
+
+只有 Candidate 成為 `refs/remotes/<remote>/<target_branch>` 的 ancestor，Cortex 才會寫 CompletionRecord、標記 Slice `completed` 並釋放下游。squash / rebase merge / cherry-pick 會改變 Candidate identity，目前不受支援。
 
 ### 目前邊界
 
@@ -164,6 +232,9 @@ cortex slice-action <slice-id> abandon      --actor operator
 - verification 的 sanitized env 不等於 network / filesystem sandbox。
 - v1 自動 foreign review 限 `tier: shareable`。
 - preserving-commit merge 是目前受支援路徑；squash / cherry-pick 改變 Candidate identity 時會 fail-closed。
+- installer/service 尚無 periodic builder/reviewer model pin；需要固定 model 時，使用帶 `--model` / `--review-model` 的手動 `cortex tick`。
+
+尚未實作的 operator bootstrap、model pin、monitor init、instance/path isolation、state migration 與 async request UX 統一追蹤於 [issue #12](https://github.com/hamanpaul/paulsha-cortex/issues/12)，供後續 OpenSpec / implementation plan 使用。
 
 ## Coordinator dispatch discipline（v1）
 
@@ -216,12 +287,12 @@ verification:
 ```yaml
 schema_version: 1
 identities:
-  - executor: copilot
-    model_id: claude-haiku-4.5
-    independence_domain: anthropic
   - executor: codex
-    model_id: gpt-5.4
-    independence_domain: openai
+    model_id: "<builder-model-id>"
+    independence_domain: "<builder-domain>"
+  - executor: claude
+    model_id: "<reviewer-model-id>"
+    independence_domain: "<different-reviewer-domain>"
 ```
 
 - builder/reviewer 必須是 explicit `(executor, model_id)` 且可解析。
@@ -238,10 +309,10 @@ identities:
 ### Operator actions 與 status / attention
 
 ```bash
-cortex slice-action <slice-id> retry-build  --actor <text>
-cortex slice-action <slice-id> retry-verify --actor <text>
-cortex slice-action <slice-id> retry-review --actor <text>
-cortex slice-action <slice-id> abandon      --actor <text>
+cortex slice-action "$SLICE_ID" retry-build  --actor "$ACTOR"
+cortex slice-action "$SLICE_ID" retry-verify --actor "$ACTOR"
+cortex slice-action "$SLICE_ID" retry-review --actor "$ACTOR"
+cortex slice-action "$SLICE_ID" abandon      --actor "$ACTOR"
 ```
 
 - `slice-action` 一律透過 control request queue，由 daemon/manager 單一 writer 消費。
@@ -278,10 +349,10 @@ cortex slice-action <slice-id> abandon      --actor <text>
 
 | 面向 | 現況 |
 | --- | --- |
-| persona enforcement | `shadow`；只觀測、不阻擋，翻牌到 enforce 另案處理 |
-| manager service install | `cortex install service` 已可一次 render / copy / enable manager timer + monitor service；systemd 不可用時會 graceful 落檔 |
-| coordinator runtime | `dispatch` / `jobs` / `stat` / `ready` / `fanout` / `complete` / `tick` 已平移 |
-| deck 驗證 | deck 與 persona 同包；未知 card 仍以 warning 呈現 |
+| persona enforcement | standalone PR workflow 為 `shadow`；coordinator verification 的 `persona-scope` 為 fail-closed gate |
+| manager service install | `cortex install service` 會 render / copy / enable，但不會 start；systemd 不可用時只落檔 |
+| coordinator runtime | `jobs` / `stat` / `ready` / `status` 為讀取路徑；`fanout` / `complete` / `tick` / `slice-action` 走 control queue；舊低階 `dispatch` 已停用 |
+| deck 驗證 | compile 只產生 `dispatch: hold` 骨架；verify 只檢查 `produces` glob 存在性，不驗內容 |
 | monitor registry | `project-cortex.yaml` ⊍ `project-hippo.yaml`，realpath 去重且 manual 優先 |
 | 依賴模型 | 僅 `PyYAML`；runtime 不依賴 `paulsha-hippo` |
 

--- a/changelog.d/13.md
+++ b/changelog.d/13.md
@@ -1,0 +1,1 @@
+fix(cli): 對齊 README Usage、CLI help 與實際 manager、Deck、Monitor 操作流程，並新增 help alignment 回歸測試。

--- a/paulsha_cortex/cli.py
+++ b/paulsha_cortex/cli.py
@@ -7,7 +7,31 @@ from importlib import resources
 from pathlib import Path
 from typing import Sequence
 
-_USAGE = "usage: cortex {install service|relay-hook|deck|monitor|<coordinator subcommand>} <args...>\n"
+_USAGE = "usage: cortex [-h] <command> [<args>...]\n"
+_HELP = """\
+usage: cortex [-h] <command> [<args>...]
+
+paulsha-cortex 檔案驅動的 Agent 派工與交付治理 CLI
+
+setup and workflow commands:
+  install service  安裝 manager service/timer 與 monitor 的 systemd --user units
+  deck             預覽或產生 dispatch:hold 的 slice specs
+  monitor          掃描專案文件並輸出 Project Monitor 狀態
+  relay-hook       執行封裝內 relay hook（整合用途）
+
+coordinator commands:
+  status           讀取 manager daemon 綜合狀態
+  ready            列出符合派工條件的 specs
+  jobs, stat       查詢 Job 執行紀錄
+  fanout           派送目前 ready 的 slices
+  tick             執行 fanout + completion/review 流程
+  complete         輪詢既有 jobs 並執行 verification/review/completion
+  slice-action     對 needs_human slice 執行允許的 recovery action
+  reap-brokers     dry-run 或受限清理孤兒 Codex broker
+  dispatch         已停用的舊低階入口
+
+run 'cortex <command> --help' for command-specific help.
+"""
 
 
 def _relay_hook_script_path() -> Path:
@@ -19,6 +43,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     if not args:
         sys.stderr.write(_USAGE)
         return 2
+    if args[0] in {"-h", "--help"}:
+        sys.stdout.write(_HELP)
+        return 0
     if args[0] == "install":
         from paulsha_cortex.deploy.installer import main as install_main
 

--- a/paulsha_cortex/coordinator/cli.py
+++ b/paulsha_cortex/coordinator/cli.py
@@ -39,53 +39,71 @@ def _refuse_unsafe_fanout(metas, predicate, *, allow_unsafe, max_ready=1):
 
 
 def _build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(prog="python -m paulsha_cortex.coordinator")
+    parser = argparse.ArgumentParser(
+        prog="cortex",
+        description="讀取 manager 狀態，或透過 control queue 執行派工與交付 gate。",
+    )
     sub = parser.add_subparsers(dest="cmd", required=True)
 
-    p_dispatch = sub.add_parser("dispatch", help="派一個 job 進 pane+worktree")
+    p_dispatch = sub.add_parser(
+        "dispatch",
+        help="已停用的舊低階入口（請改用 fanout/tick）",
+        description="此入口缺少 spec/verification metadata，固定拒絕執行；請改用 fanout 或 tick。",
+    )
     p_dispatch.add_argument("--task", required=True)
     p_dispatch.add_argument("--persona", required=True)
     p_dispatch.add_argument("--pane", required=True)
     p_dispatch.add_argument("--command", required=True)
 
-    sub.add_parser("jobs", help="列出所有 job")
+    sub.add_parser("jobs", help="列出所有 Job 執行紀錄")
 
-    p_stat = sub.add_parser("stat", help="查單一 job")
+    p_stat = sub.add_parser("stat", help="查單一 Job 執行紀錄")
     p_stat.add_argument("job_id")
 
-    p_ready = sub.add_parser("ready", help="列出就緒（dispatch:auto∧有plan∧depends_on全滿足）的單位")
-    p_ready.add_argument("--specs-dir", required=True)
+    p_ready = sub.add_parser("ready", help="列出 dispatch:auto、plan 與 dependency 均就緒的 specs")
+    p_ready.add_argument("--specs-dir", required=True, help="要掃描的 spec 目錄")
 
-    p_fanout = sub.add_parser("fanout", help="對就緒集經 Dispatcher 並行派工")
-    p_fanout.add_argument("--specs-dir", required=True)
-    p_fanout.add_argument("--persona", default="builder")
+    p_fanout = sub.add_parser("fanout", help="透過 manager daemon 派送目前 ready 的 slices")
+    p_fanout.add_argument("--specs-dir", required=True, help="要掃描的 spec 目錄")
+    p_fanout.add_argument("--persona", default="builder", help="builder persona role（預設：builder）")
     p_fanout.add_argument(
         "--executor",
         choices=sorted(_ARGV_BUILDERS),
         default=None,
-        help="設定後走 headless launcher 路徑（copilot/claude/codex）；未設則沿用舊 tmux pane 路徑",
+        help="headless executor；未指定時使用 daemon 預設值",
     )
-    p_fanout.add_argument("--allow-unsafe", action="store_true")
-    p_fanout.add_argument("--model", default=None)
+    p_fanout.add_argument(
+        "--allow-unsafe",
+        action="store_true",
+        help="高風險：旁路 executor approval/sandbox；只允許單一 ready slice canary",
+    )
+    p_fanout.add_argument("--model", default=None, help="原樣傳給 builder executor 的 model ID")
 
     p_complete = sub.add_parser(
         "complete",
-        help="完成側 tick：輪詢 in-flight job → 寫 handoff manifest → 釋放下游",
+        help="輪詢既有 jobs，執行 verification/review/completion gate",
     )
-    p_complete.add_argument("--handoff-dir", default=autonomy.DEFAULT_HANDOFF_DIR)
+    p_complete.add_argument(
+        "--handoff-dir",
+        default=autonomy.DEFAULT_HANDOFF_DIR,
+        help=f"handoff 目錄（預設為相對路徑：{autonomy.DEFAULT_HANDOFF_DIR}）",
+    )
     p_complete.add_argument(
         "--specs-dir", default=None,
         help="設定後據 dependency graph 觀測算出本趟釋放的下游（released）",
     )
-    p_complete.add_argument("--review-executor", choices=sorted(_ARGV_BUILDERS), default=None)
-    p_complete.add_argument("--review-model", default=None)
+    p_complete.add_argument(
+        "--review-executor", choices=sorted(_ARGV_BUILDERS), default=None,
+        help="foreign reviewer executor",
+    )
+    p_complete.add_argument("--review-model", default=None, help="foreign reviewer model ID")
 
     p_slice_action = sub.add_parser("slice-action", help="對 needs_human slice 送出本機 recovery action")
     p_slice_action.add_argument("slice_id")
     p_slice_action.add_argument("action", choices=["retry-build", "retry-verify", "retry-review", "abandon"])
     p_slice_action.add_argument("--actor", required=True)
 
-    sub.add_parser("status", help="讀取 manager daemon 狀態快照")
+    sub.add_parser("status", help="讀取 manager daemon 的 ready/held/slices/attention 快照")
 
     p_reap = sub.add_parser("reap-brokers", help="操作員 dry-run/apply 孤兒 codex broker 回收")
     p_reap.add_argument("--apply", action="store_true")
@@ -93,18 +111,32 @@ def _build_parser() -> argparse.ArgumentParser:
 
     p_tick = sub.add_parser(
         "tick",
-        help="完整 manager tick：fanout→complete（idle-gated）",
+        help="執行完整 manager tick：fanout → verification/review/completion",
     )
-    p_tick.add_argument("--specs-dir", required=True)
-    p_tick.add_argument("--persona", default="builder")
-    p_tick.add_argument("--executor", choices=sorted(_ARGV_BUILDERS), default=None)
-    p_tick.add_argument("--handoff-dir", default=autonomy.DEFAULT_HANDOFF_DIR)
-    p_tick.add_argument("--require-idle", action="store_true")
-    p_tick.add_argument("--max-load", type=float, default=1.0)
-    p_tick.add_argument("--allow-unsafe", action="store_true")
-    p_tick.add_argument("--model", default=None)
-    p_tick.add_argument("--review-executor", choices=sorted(_ARGV_BUILDERS), default=None)
-    p_tick.add_argument("--review-model", default=None)
+    p_tick.add_argument("--specs-dir", required=True, help="要掃描的 spec 目錄")
+    p_tick.add_argument("--persona", default="builder", help="builder persona role（預設：builder）")
+    p_tick.add_argument(
+        "--executor", choices=sorted(_ARGV_BUILDERS), default=None,
+        help="headless builder executor；未指定時使用 daemon 預設值",
+    )
+    p_tick.add_argument(
+        "--handoff-dir",
+        default=autonomy.DEFAULT_HANDOFF_DIR,
+        help=f"handoff 目錄（預設為相對路徑：{autonomy.DEFAULT_HANDOFF_DIR}）",
+    )
+    p_tick.add_argument("--require-idle", action="store_true", help="系統負載高於 --max-load 時不派新工作")
+    p_tick.add_argument("--max-load", type=float, default=1.0, help="--require-idle 的 1-minute load threshold")
+    p_tick.add_argument(
+        "--allow-unsafe",
+        action="store_true",
+        help="高風險：旁路 executor approval/sandbox；只允許單一 ready slice canary",
+    )
+    p_tick.add_argument("--model", default=None, help="原樣傳給 builder executor 的 model ID")
+    p_tick.add_argument(
+        "--review-executor", choices=sorted(_ARGV_BUILDERS), default=None,
+        help="foreign reviewer executor",
+    )
+    p_tick.add_argument("--review-model", default=None, help="foreign reviewer model ID")
 
     return parser
 

--- a/paulsha_cortex/deck/cli.py
+++ b/paulsha_cortex/deck/cli.py
@@ -16,30 +16,33 @@ from .verify import DeckVerifyError
 
 
 def _build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(prog="psc deck")
+    parser = argparse.ArgumentParser(
+        prog="cortex deck",
+        description="將 Deck combo 編譯成預設 dispatch:hold 的 slice specs。",
+    )
     sub = parser.add_subparsers(dest="command", required=True)
 
     sub.add_parser("list", help="列出卡片與 combos")
 
     compile_parser = sub.add_parser("compile", help="combo+task → slice specs（預設 dry-run）")
-    compile_parser.add_argument("combo")
-    compile_parser.add_argument("--task", required=True)
-    compile_parser.add_argument("--change")
+    compile_parser.add_argument("combo", help="combo ID（例如 feature-oneshot）")
+    compile_parser.add_argument("--task", required=True, help="人類可讀的任務描述")
+    compile_parser.add_argument("--change", help="OpenSpec change ID；正式 emit 時依 combo 需求提供")
     compile_parser.add_argument("--with", dest="with_cards", action="append", default=[],
                                 metavar="CARD[:after=ID|:before=ID]")
     compile_parser.add_argument("--only", nargs="+", default=[])
-    compile_parser.add_argument("--allow-external", action="store_true")
-    compile_parser.add_argument("--plan", dest="plan_ref")
+    compile_parser.add_argument("--allow-external", action="store_true", help="允許 combo 宣告的外部前置輸入")
+    compile_parser.add_argument("--plan", dest="plan_ref", help="覆寫產生 spec 的 plan reference")
     out_group = compile_parser.add_mutually_exclusive_group()
-    out_group.add_argument("--out")
-    out_group.add_argument("--emit", action="store_true")
-    compile_parser.add_argument("--force", action="store_true")
+    out_group.add_argument("--out", help="寫入指定 spec 目錄；未設定時只 dry-run")
+    out_group.add_argument("--emit", action="store_true", help="寫入預設 specs 目錄；未設定時只 dry-run")
+    compile_parser.add_argument("--force", action="store_true", help="允許覆寫既有輸出檔")
 
     verify_parser = sub.add_parser("verify", help="卡片 produces 存在性驗收")
-    verify_parser.add_argument("card_id")
-    verify_parser.add_argument("--task-slug", required=True)
-    verify_parser.add_argument("--change")
-    verify_parser.add_argument("--root", default=".")
+    verify_parser.add_argument("card_id", help="要驗收 produces glob 的 card ID")
+    verify_parser.add_argument("--task-slug", required=True, help="compile 輸出的 task slug")
+    verify_parser.add_argument("--change", help="OpenSpec change ID")
+    verify_parser.add_argument("--root", default=".", help="glob 驗收根目錄（預設：目前目錄）")
     return parser
 
 

--- a/paulsha_cortex/deploy/installer.py
+++ b/paulsha_cortex/deploy/installer.py
@@ -116,12 +116,21 @@ def install_service(instance: str, interval: int, repo_root: Path) -> int:
 
 
 def main(argv: Sequence[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(prog="cortex install")
+    parser = argparse.ArgumentParser(
+        prog="cortex install",
+        description="安裝 paulsha-cortex systemd --user units；只落檔/enable，不會 start service。",
+    )
     sub = parser.add_subparsers(dest="target", required=True)
-    svc = sub.add_parser("service")
-    svc.add_argument("--instance", default="cortex")
-    svc.add_argument("--interval", type=int, default=300)
-    svc.add_argument("--repo-root", default=str(Path.cwd()))
+    svc = sub.add_parser("service", help="安裝 manager service/timer 與 monitor service")
+    svc.add_argument("--instance", default="cortex", help="systemd unit 前綴（預設：cortex）")
+    svc.add_argument(
+        "--interval", type=int, default=300,
+        help="deprecated manager timer 的 OnUnitActiveSec 秒數；daemon tick 請用 PSC_MANAGER_INTERVAL_SECONDS",
+    )
+    svc.add_argument(
+        "--repo-root", default=str(Path.cwd()),
+        help="被治理的目標 git repo（預設：目前目錄）",
+    )
     args = parser.parse_args(argv)
     try:
         instance = _validate_instance(args.instance)

--- a/paulsha_cortex/monitor/__main__.py
+++ b/paulsha_cortex/monitor/__main__.py
@@ -14,18 +14,18 @@ from .service import ProjectMonitorService
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
-        prog="paulsha_cortex.monitor",
-        description="Stage 9 Project Monitor",
+        prog="cortex monitor",
+        description="依 workspace 文件訊號推導專案狀態；不取代 coordinator delivery status。",
     )
     parser.add_argument(
         "--config",
-        help="path to project-cortex.yaml（或 legacy paulshaclaw.yaml）",
+        help="project-cortex.yaml 路徑（預設依環境變數與標準位置解析）",
         default=None,
     )
     parser.add_argument(
         "--once",
         action="store_true",
-        help="run a single scan, dump JSON snapshot to stdout, exit 0",
+        help="單次掃描後輸出 JSON 並結束；未指定則啟動長駐服務",
     )
     return parser
 

--- a/tests/test_cli_help_alignment.py
+++ b/tests/test_cli_help_alignment.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import pytest
+
+from paulsha_cortex import cli as umbrella_cli
+from paulsha_cortex.coordinator.cli import _build_parser as build_coordinator_parser
+from paulsha_cortex.deck.cli import _build_parser as build_deck_parser
+from paulsha_cortex.deploy import installer
+from paulsha_cortex.monitor.__main__ import build_parser as build_monitor_parser
+
+
+def test_umbrella_help_lists_public_command_families(capsys) -> None:
+    assert umbrella_cli.main(["--help"]) == 0
+    captured = capsys.readouterr()
+    assert captured.err == ""
+    assert "usage: cortex" in captured.out
+    assert "install service" in captured.out
+    assert "deck" in captured.out
+    assert "monitor" in captured.out
+    assert "tick" in captured.out
+    assert "dispatch         已停用" in captured.out
+
+
+def test_coordinator_help_uses_cortex_and_describes_disabled_dispatch(capsys) -> None:
+    parser = build_coordinator_parser()
+    assert parser.prog == "cortex"
+    assert "已停用的舊低階入口" in parser.format_help()
+
+    with pytest.raises(SystemExit) as exc:
+        parser.parse_args(["dispatch", "--help"])
+    assert exc.value.code == 0
+    assert "固定拒絕執行" in capsys.readouterr().out
+
+
+def test_fanout_help_uses_daemon_default_not_legacy_tmux(capsys) -> None:
+    parser = build_coordinator_parser()
+    with pytest.raises(SystemExit) as exc:
+        parser.parse_args(["fanout", "--help"])
+    assert exc.value.code == 0
+    output = capsys.readouterr().out
+    assert "daemon 預設值" in output
+    assert "舊 tmux pane" not in output
+    assert "旁路 executor approval/sandbox" in output
+
+
+def test_subcommand_help_uses_installed_cortex_invocations() -> None:
+    assert build_deck_parser().prog == "cortex deck"
+    assert build_monitor_parser().prog == "cortex monitor"
+
+
+def test_install_help_explains_enable_start_and_interval_semantics(capsys) -> None:
+    with pytest.raises(SystemExit) as exc:
+        installer.main(["service", "--help"])
+    assert exc.value.code == 0
+    output = capsys.readouterr().out
+    assert "usage: cortex install service" in output
+    assert "PSC_MANAGER_INTERVAL_SECONDS" in output
+    assert "被治理的目標 git repo" in output


### PR DESCRIPTION
## 摘要

- 將 README 的 Install / Usage 改成可實際操作的 manager、Deck、Monitor、verification、foreign review 與 completion 流程。
- 統一 `cortex`、`cortex deck`、`cortex monitor`、`cortex install service` 的 help invocation 與參數說明。
- 明示低階 `dispatch` 已停用、`--allow-unsafe` 風險、timer/daemon interval 差異，以及 installer enable 與 service start 的邊界。
- 新增 CLI help alignment 回歸測試，避免 README 與 runtime 再次漂移。

## 根因

CLI 功能持續演進後，README quickstart、argparse `prog/help` 與實際 control/manager 行為沒有同一個驗證面：使用者會看到舊 module 名稱、已停用的 dispatch 敘述，以及無法直接完成 clean-start 的 Usage。

## 使用者影響

- `cortex --help` 現在能看見 umbrella 與 coordinator 公開命令。
- Deck 產生 hold spec、人工補齊 contract、tick、觀察 status、preserving-commit merge、complete 的順序可直接依 README 操作。
- Monitor 設定與 systemd 啟動前置條件明確化。
- 尚未實作的 bootstrap/model pin/migration 等能力仍維持誠實邊界，另由 follow-up issue 規劃。

## 驗證

- [x] `python3 -m pytest -q` — 580 passed，20 subtests passed
- [x] `python3 -m policy_check --repo .` — 21 pass，0 fail，0 warn
- [x] CI-parity preflight — 25 pass，0 fail；R-22 僅 13 筆既有懸空引用 advisory
- [x] `openspec validate --all` — 3 passed，0 failed
- [x] `git diff --check`
- [x] `python3 -m paulsha_cortex.cli --help`
- [x] Deck / Monitor / Fanout / Installer help smoke

## Checklist

- [x] `CHANGELOG.md [Unreleased]` 已更新
- [x] `VERSION` 維持 `0.0.0`，符合非 release PR 意圖
- [x] README / Usage 與 CLI help 同步
- [x] 新增 help alignment 回歸測試
- [x] 未使用 policy exemption label
- [x] 未修改 agent convention symlink
