### PR TITLE
fix(monitor): 支援舊版 gh pagination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - **deck frontmatter emit 契約與 runtime parser keyset 對齊**：`EMITTED_FRONTMATTER_FIELDS`、deck compile frontmatter 與 `parse_spec_frontmatter()` 現在一致包含 `target_branch` / `verification` / `parse_error`；compile 產生 hold spec 時固定輸出 `null` 欄位，runtime 僅接受 `parse_error: null`（non-null fail-closed），避免 deck contract alignment 漂移。
 
 ### Fixed
+- **GitHub Work provider 相容不支援 `gh api --slurp` 的 gh 版本**：pagination 改用 typed `--paginate --jq '.[]'` JSONL entity stream，保留 shell-free argv 與 malformed response fail-closed；避免 live Monitor 永久 degraded 並阻止 auto claim/merge。
 - **統一 `cortex work` umbrella routing**：`show` 仍由 Monitor read API 回應，`link`／`unlink`／`start`／`resume`／`auto`／`ship` 則正確進入 Manager control queue；共同 help 同步列出完整 command family。
 - **Project Monitor 不再把暫時掃描失敗發布成假移除**：workspace／project subtree 無法可靠讀取時保留 last-good `ProjectState` 並附加 `degraded` scan signal；只有成功掃描父層後才允許 removal。`poll_interval_seconds`、`rescan_interval_seconds` 與 `watch_debounce_ms` 也改為拒絕非正值，避免錯誤設定被 clamp 成緊迴圈。
 - **CompletionRecord 會重新驗證並綁定全部 evidence**：readiness 現在會嚴格驗證 GateEvaluation schema，並要求 verification/review evidence 的 Slice、Candidate、builder/reviewer job、狀態與 CompletionRecord 一致；target ref 也必須對應宣告的 remote/branch，避免以跨 Slice 或跨 Candidate 的合法 hash 證據繞過 dependency gate。

--- a/changelog.d/14-gh-api-pagination.md
+++ b/changelog.d/14-gh-api-pagination.md
@@ -1,0 +1,1 @@
+fix(monitor): 改用 `gh api --paginate --jq '.[]'` JSONL entity stream，相容不支援 `--slurp` 的 gh 版本，避免 GitHub provider 永久 degraded。

--- a/paulsha_cortex/monitor/providers.py
+++ b/paulsha_cortex/monitor/providers.py
@@ -632,7 +632,8 @@ class GitHubWorkProvider:
             "--method",
             "GET",
             "--paginate",
-            "--slurp",
+            "--jq",
+            ".[]",
             f"repos/{self.repo}/issues?state=all&per_page=100",
         )
         try:
@@ -655,8 +656,13 @@ class GitHubWorkProvider:
             return self._failure(attempted_at, diagnostic)
         stdout = completed.stdout.decode() if isinstance(completed.stdout, bytes) else completed.stdout
         try:
-            payload = json.loads(stdout)
-            entities = self._flatten_pages(payload)
+            entities = [
+                json.loads(line)
+                for line in stdout.splitlines()
+                if line.strip()
+            ]
+            if any(not isinstance(entity, dict) for entity in entities):
+                raise ValueError("GitHub entity is not an object")
             sources = tuple(self._entity_source(entity) for entity in entities)
         except (json.JSONDecodeError, TypeError, ValueError, KeyError):
             return self._failure(attempted_at, "github API returned malformed JSON")
@@ -687,21 +693,6 @@ class GitHubWorkProvider:
             diagnostics=(diagnostic,),
             sources=(),
         )
-
-    @staticmethod
-    def _flatten_pages(payload: object) -> list[dict]:
-        if not isinstance(payload, list):
-            raise ValueError("GitHub response is not an array")
-        pages = payload if not payload or isinstance(payload[0], list) else [payload]
-        entities: list[dict] = []
-        for page in pages:
-            if not isinstance(page, list):
-                raise ValueError("GitHub page is not an array")
-            for entity in page:
-                if not isinstance(entity, dict):
-                    raise ValueError("GitHub entity is not an object")
-                entities.append(entity)
-        return entities
 
     def _entity_source(self, entity: dict) -> WorkSource:
         number = entity["number"]

--- a/tests/test_monitor_work_providers.py
+++ b/tests/test_monitor_work_providers.py
@@ -125,26 +125,30 @@ def _completed(payload, *, returncode=0, stderr=""):
 
 
 def test_github_provider_uses_typed_argv_and_json():
+    rows = [
+        {
+            "number": 14,
+            "title": "umbrella",
+            "state": "open",
+            "node_id": "ISSUE_node",
+            "updated_at": "2026-07-17T10:00:00Z",
+            "labels": [{"name": "cortex:auto-on-going"}],
+        },
+        {
+            "number": 15,
+            "title": "delivery",
+            "state": "closed",
+            "node_id": "PR_node",
+            "updated_at": "2026-07-17T10:01:00Z",
+            "pull_request": {"url": "https://api.github.test/pr/15"},
+        },
+    ]
     runner = FakeRunner(
-        _completed(
-            [[
-                {
-                    "number": 14,
-                    "title": "umbrella",
-                    "state": "open",
-                    "node_id": "ISSUE_node",
-                    "updated_at": "2026-07-17T10:00:00Z",
-                    "labels": [{"name": "cortex:auto-on-going"}],
-                },
-                {
-                    "number": 15,
-                    "title": "delivery",
-                    "state": "closed",
-                    "node_id": "PR_node",
-                    "updated_at": "2026-07-17T10:01:00Z",
-                    "pull_request": {"url": "https://api.github.test/pr/15"},
-                },
-            ]]
+        subprocess.CompletedProcess(
+            args=("gh",),
+            returncode=0,
+            stdout="\n".join(json.dumps(row) for row in rows) + "\n",
+            stderr="",
         )
     )
 
@@ -163,7 +167,8 @@ def test_github_provider_uses_typed_argv_and_json():
         "--method",
         "GET",
         "--paginate",
-        "--slurp",
+        "--jq",
+        ".[]",
         "repos/example/acme/issues?state=all&per_page=100",
     )
     assert timeout == 12


### PR DESCRIPTION
## 摘要

修正 GitHub Work provider 在不支援 `gh api --slurp` 的環境永久 degraded，改用 typed JSONL pagination。

## 驗證

- [x] provider regression tests
- [x] live GitHub provider probe
- [x] full preflight

## 風險

保留 shell-free argv 與 malformed response fail-closed。