### PR TITLE
docs(canary): 建立 unified lifecycle live canary authority

### DIFF
--- a/.cortex/work-items.yaml
+++ b/.cortex/work-items.yaml
@@ -1,0 +1,9 @@
+version: 1
+work_items:
+  docs-only-lifecycle-canary:
+    title: Unified lifecycle live canary
+    links:
+      - kind: github_issue
+        ref: hamanpaul/paulsha-cortex#20
+      - kind: openspec
+        ref: docs-only-lifecycle-canary

--- a/changelog.d/20-live-canary-bootstrap.md
+++ b/changelog.d/20-live-canary-bootstrap.md
@@ -1,0 +1,1 @@
+docs(canary): 建立 unified lifecycle live canary 的 confirmed repo override 與 active OpenSpec bootstrap artifacts。

--- a/openspec/changes/docs-only-lifecycle-canary/.openspec.yaml
+++ b/openspec/changes/docs-only-lifecycle-canary/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-18

--- a/openspec/changes/docs-only-lifecycle-canary/design.md
+++ b/openspec/changes/docs-only-lifecycle-canary/design.md
@@ -1,0 +1,23 @@
+---
+work_item: docs-only-lifecycle-canary
+---
+
+## Context
+
+Canary 使用 repo-local override 將 issue #20 與 active OpenSpec confirmed mapping。Issue 在 bootstrap merge 後才加 `cortex:auto-on-going`，避免準備 artifacts 時提前 claim。
+
+## Goals / Non-Goals
+
+- Goal：驗證 auto claim、異質 brainstorm、docs-only build、ForeignReview、archive、preflight、current-HEAD maintainer review、merge commit 與 done projection。
+- Non-goal：修改 runtime code，或對其他 repo 啟用 auto label。
+
+## Decisions
+
+- 只新增一段 live canary evidence 文件，將 blast radius 限在 docs。
+- 初始 change 不建立 accepted superpowers plan；Manager 必須由 primary planner 與 `agy/google` secondary 補齊 planning authority。
+- 本次依 operator 指示，以 exact-HEAD maintainer adversarial review 取代等待 Copilot；其餘 strict gates不變。
+
+## Risks / Trade-offs
+
+- Model output 若不符合 typed artifact contract，workflow 應 fail-closed 到 `needs_human`，不得繞過。
+- Canary 未通過前不對其他 repo 加 auto label。

--- a/openspec/changes/docs-only-lifecycle-canary/proposal.md
+++ b/openspec/changes/docs-only-lifecycle-canary/proposal.md
@@ -1,0 +1,27 @@
+---
+work_item: docs-only-lifecycle-canary
+---
+
+## Why
+
+Unified lifecycle 已完成實作與部署，但仍需要一條低風險 docs-only live canary，證明 confirmed Todo + issue auto label 能進入異質 brainstorm、build、review 與 strict delivery closure。
+
+## What Changes
+
+- 在 unified lifecycle 操作文件留下 live canary evidence 記錄。
+- 不修改 runtime code、public API 或既有治理語意。
+- 初始 change 刻意不提供 accepted superpowers plan，讓 completeness gate 必須執行異質 brainstorm。
+
+## Capabilities
+
+### New Capabilities
+
+- `lifecycle-live-canary`: 定義 docs-only lifecycle canary 必須留下可審查的操作證據。
+
+### Modified Capabilities
+
+無。
+
+## Impact
+
+只影響 `docs/unified-work-lifecycle.md`、本 OpenSpec change 與 canary issue；不改 production code。

--- a/openspec/changes/docs-only-lifecycle-canary/specs/lifecycle-live-canary/spec.md
+++ b/openspec/changes/docs-only-lifecycle-canary/specs/lifecycle-live-canary/spec.md
@@ -1,0 +1,17 @@
+## ADDED Requirements
+
+### Requirement: Live canary 必須留下可審查的 terminal evidence
+
+Unified lifecycle 的 docs-only live canary MUST在操作文件記錄 mapped issue、planner/builder/reviewer independence domain、deterministic verification、archive、preflight、current-HEAD review、merge commit 與 done projection結果。任何未通過 gate MUST標示為未完成，不得宣稱 canary 通過。
+
+#### Scenario: Canary 完整閉合
+
+- **WHEN** docs-only canary 的所有 strict gates與遠端 closure 均成立
+- **THEN** 操作文件記錄可追溯的 issue、PR、merge commit與CompletionRecord evidence
+- **THEN** Monitor 將 work item 投影為 `done`
+
+#### Scenario: 任一 gate 未完成
+
+- **WHEN** brainstorm、ForeignReview、archive、preflight、current-HEAD review或remote closure任一缺失
+- **THEN** 文件不得宣稱 canary通過
+- **THEN** workflow維持 `on-going`並帶 `needs_human`或`blocked` facet

--- a/openspec/changes/docs-only-lifecycle-canary/tasks.md
+++ b/openspec/changes/docs-only-lifecycle-canary/tasks.md
@@ -1,0 +1,9 @@
+---
+work_item: docs-only-lifecycle-canary
+---
+
+## 1. Docs-only live canary
+
+- [ ] 1.1 在 `docs/unified-work-lifecycle.md` 新增 Live canary evidence 段落，記錄 issue、persona domain separation、驗證與 terminal closure。
+- [ ] 1.2 通過 docs diff、OpenSpec validation、policy、full preflight 與 ForeignReview。
+- [ ] 1.3 使用官方 OpenSpec CLI archive 本 change，並以 merge commit 關閉 issue #20。


### PR DESCRIPTION
## 摘要

建立低風險 docs-only live canary 的 confirmed repo override 與 active OpenSpec；bootstrap 階段不加 auto label，也不關閉 canary issue。

## 驗證

- [x] `openspec validate docs-only-lifecycle-canary --type change --strict`
- [x] `python3 -m policy_check --repo .`
- [x] full preflight

## 邊界

初始 artifacts 刻意不含 accepted superpowers plan，讓 bootstrap merge 後的 Manager completeness gate 必須觸發異質 brainstorm。