### PR TITLE
fix(monitor): 修正 provider freshness clock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - **deck frontmatter emit 契約與 runtime parser keyset 對齊**：`EMITTED_FRONTMATTER_FIELDS`、deck compile frontmatter 與 `parse_spec_frontmatter()` 現在一致包含 `target_branch` / `verification` / `parse_error`；compile 產生 hold spec 時固定輸出 `null` 欄位，runtime 僅接受 `parse_error: null`（non-null fail-closed），避免 deck contract alignment 漂移。
 
 ### Fixed
+- **Live GitHub provider 不再因 scan 前固定 clock 而被立即標 stale**：freshness reference 改為 provider scans 完成後再讀取，避免成功 snapshot 的 `last_success_at` 晚於 pre-scan clock 形成負 age、永久關閉 auto claim/merge；新增 deterministic clock regression 與 live projection probe。
 - **GitHub Work provider 相容不支援 `gh api --slurp` 的 gh 版本**：pagination 改用 typed `--paginate --jq '.[]'` JSONL entity stream，保留 shell-free argv 與 malformed response fail-closed；避免 live Monitor 永久 degraded 並阻止 auto claim/merge。
 - **統一 `cortex work` umbrella routing**：`show` 仍由 Monitor read API 回應，`link`／`unlink`／`start`／`resume`／`auto`／`ship` 則正確進入 Manager control queue；共同 help 同步列出完整 command family。
 - **Project Monitor 不再把暫時掃描失敗發布成假移除**：workspace／project subtree 無法可靠讀取時保留 last-good `ProjectState` 並附加 `degraded` scan signal；只有成功掃描父層後才允許 removal。`poll_interval_seconds`、`rescan_interval_seconds` 與 `watch_debounce_ms` 也改為拒絕非正值，避免錯誤設定被 clamp 成緊迴圈。

--- a/changelog.d/14-provider-freshness-clock.md
+++ b/changelog.d/14-provider-freshness-clock.md
@@ -1,0 +1,1 @@
+fix(monitor): 以 provider scan 完成後的 clock 驗證 freshness，避免成功 GitHub snapshot 因負 age 被立即標 stale。

--- a/paulsha_cortex/monitor/work_api.py
+++ b/paulsha_cortex/monitor/work_api.py
@@ -381,6 +381,9 @@ class WorkModelRefresher:
                     relevant.append(providers[github_id])
                     if terminal_id in providers:
                         relevant.append(providers[terminal_id])
+                freshness_time = self.now()
+                if freshness_time.tzinfo is None:
+                    raise ValueError("now must include timezone")
                 freshness_snapshot = WorkSnapshot(
                     sequence=previous.sequence,
                     written_at=attempted_at,
@@ -393,7 +396,7 @@ class WorkModelRefresher:
                 for authority_id in (github_id, terminal_id):
                     fresh = freshness_snapshot.provider_is_fresh(
                         authority_id,
-                        now=current_time,
+                        now=freshness_time,
                         max_age=self.stale_after_seconds,
                     )
                     if authority_id not in relevant_ids or fresh:

--- a/tests/test_monitor_work_review_regressions.py
+++ b/tests/test_monitor_work_review_regressions.py
@@ -173,6 +173,71 @@ def _provider(provider_id: str, sources=(), *, observations=None, at=NOW):
     )
 
 
+def test_live_provider_freshness_uses_post_scan_clock(tmp_path):
+    repo = tmp_path / "repo"
+    proposal = repo / "openspec/changes/canary/proposal.md"
+    proposal.parent.mkdir(parents=True)
+    proposal.write_text("# Canary\n", encoding="utf-8")
+    override = repo / ".cortex/work-items.yaml"
+    override.parent.mkdir(parents=True)
+    override.write_text(
+        """version: 1
+work_items:
+  canary:
+    title: Canary
+    links:
+      - kind: github_issue
+        ref: example/acme#7
+      - kind: openspec
+        ref: canary
+""",
+        encoding="utf-8",
+    )
+    issue = WorkSource(
+        source_id="github_issue:example/acme#7",
+        kind="github_issue",
+        ref="example/acme#7",
+        revision="github:i7",
+        status="open",
+        confidence="confirmed",
+        provider="github:example/acme",
+    )
+    provider_time = "2026-07-17T10:00:01Z"
+    times = iter(
+        (
+            datetime(2026, 7, 17, 10, 0, 0, tzinfo=timezone.utc),
+            datetime(2026, 7, 17, 10, 0, 2, tzinfo=timezone.utc),
+        )
+    )
+    store = WorkReadModelStore.empty()
+    refresher = WorkModelRefresher(
+        durable_store=WorkSnapshotStore(tmp_path / "snapshot.json"),
+        read_store=store,
+        github_provider_factory=lambda _repo: _StaticProvider(
+            _provider("github:example/acme", (issue,), at=provider_time)
+        ),
+        github_terminal_provider_factory=lambda _repo: _StaticProvider(
+            _provider("github-terminal:example/acme", at=provider_time)
+        ),
+        workflow_provider_factory=lambda _repo: _StaticProvider(
+            _provider("workflow:example/acme")
+        ),
+        now=lambda: next(times),
+    )
+
+    refresher.refresh(
+        (ProjectState(project_id="example/acme", workspace="ws", path=str(repo)),),
+        include_github=True,
+    )
+
+    assert store.get_work_item("canary", repo="example/acme")["item"]["state"] == "todo"
+    assert store.list_work_items()["hard_gates"] == {
+        "auto_claim": True,
+        "merge": True,
+        "reasons": [],
+    }
+
+
 def test_production_wiring_passes_workflow_links_and_strict_closure(tmp_path):
     repo = tmp_path / "repo"
     repo.mkdir()


### PR DESCRIPTION
## 摘要

修正 live provider scan 前固定 clock，造成成功 snapshot 的 `last_success_at` 稍晚而被立即判定 stale，永久關閉 auto claim/merge。

## 驗證

- [x] deterministic pre-scan/post-scan clock regression
- [x] Monitor work API/snapshot/review regression suite
- [x] production provider + correlation live projection
- [x] full preflight

## 風險

只把 freshness reference 移到 provider scans 完成後；900 秒上限與負 age fail-closed 規則本身不變。