### PR TITLE
fix(work): 隔離 display-only authority rows

### DIFF
--- a/.cortex/work-items.yaml
+++ b/.cortex/work-items.yaml
@@ -1,5 +1,16 @@
 version: 1
 work_items:
+  unified-work-lifecycle:
+    title: Unified work lifecycle
+    links:
+      - kind: github_issue
+        ref: hamanpaul/paulsha-cortex#14
+      - kind: openspec
+        ref: unified-work-lifecycle
+      - kind: path
+        ref: docs/superpowers/specs/2026-07-17-unified-work-lifecycle.md
+      - kind: path
+        ref: docs/superpowers/plans/2026-07-17-unified-work-lifecycle.md
   docs-only-lifecycle-canary:
     title: Unified lifecycle live canary
     links:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - **deck frontmatter emit 契約與 runtime parser keyset 對齊**：`EMITTED_FRONTMATTER_FIELDS`、deck compile frontmatter 與 `parse_spec_frontmatter()` 現在一致包含 `target_branch` / `verification` / `parse_error`；compile 產生 hold spec 時固定輸出 `null` 欄位，runtime 僅接受 `parse_error: null`（non-null fail-closed），避免 deck contract alignment 漂移。
 
 ### Fixed
+- **Work authority loader 不再讓 display-only topic/orphan 阻塞 confirmed 工作**：canonical loader 會忽略沒有 `start` authority 或沒有 confirmed Todo 的 read-model rows；repo/work/source/action malformed 仍 fail-closed。Repo override 同步補上 unified lifecycle issue/OpenSpec/superpowers confirmed links，消除重複 display groups與錯誤 missing-issue workflow。
 - **Live GitHub provider 不再因 scan 前固定 clock 而被立即標 stale**：freshness reference 改為 provider scans 完成後再讀取，避免成功 snapshot 的 `last_success_at` 晚於 pre-scan clock 形成負 age、永久關閉 auto claim/merge；新增 deterministic clock regression 與 live projection probe。
 - **GitHub Work provider 相容不支援 `gh api --slurp` 的 gh 版本**：pagination 改用 typed `--paginate --jq '.[]'` JSONL entity stream，保留 shell-free argv 與 malformed response fail-closed；避免 live Monitor 永久 degraded 並阻止 auto claim/merge。
 - **統一 `cortex work` umbrella routing**：`show` 仍由 Monitor read API 回應，`link`／`unlink`／`start`／`resume`／`auto`／`ship` 則正確進入 Manager control queue；共同 help 同步列出完整 command family。

--- a/changelog.d/14-authority-ignore-topic.md
+++ b/changelog.d/14-authority-ignore-topic.md
@@ -1,0 +1,1 @@
+fix(work): authority loader 忽略沒有 start authority／confirmed Todo 的 display-only rows，並補齊 unified lifecycle confirmed override。

--- a/paulsha_cortex/coordinator/claim.py
+++ b/paulsha_cortex/coordinator/claim.py
@@ -243,11 +243,14 @@ def _authority_from_canonical_row(
     sources = row.get("sources")
     if not isinstance(repo, str) or not isinstance(work_id, str) or not isinstance(sources, list):
         raise ValueError("canonical work authority row malformed")
-    if (
-        re.fullmatch(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", repo) is None
-        or re.fullmatch(r"[a-z0-9][a-z0-9-]*", work_id) is None
-    ):
+    if re.fullmatch(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", repo) is None:
         raise ValueError("canonical work authority identity invalid")
+    next_actions = row.get("next_actions")
+    if next_actions is not None and (
+        not isinstance(next_actions, list)
+        or any(not isinstance(action, str) or not action for action in next_actions)
+    ):
+        raise ValueError("canonical work authority actions malformed")
     if any(
         not isinstance(source, dict)
         or source.get("confidence") not in {"confirmed", "inferred"}
@@ -256,6 +259,18 @@ def _authority_from_canonical_row(
         raise ValueError("canonical work authority sources malformed")
     if sources and all(source["confidence"] == "inferred" for source in sources):
         return None
+    if next_actions is not None and "start" not in next_actions:
+        return None
+    confirmed = [
+        source
+        for source in sources
+        if isinstance(source, dict) and source.get("confidence") == "confirmed"
+    ]
+    todo_kinds = {"todo", "superpowers_spec", "superpowers_plan", "openspec"}
+    if not any(source.get("kind") in todo_kinds for source in confirmed):
+        return None
+    if re.fullmatch(r"[a-z0-9][a-z0-9-]*", work_id) is None:
+        raise ValueError("canonical work authority identity invalid")
     provider_id = f"github:{repo}"
     github = providers.get(provider_id)
     if not isinstance(github, dict):
@@ -273,11 +288,6 @@ def _authority_from_canonical_row(
         last_success = datetime.fromisoformat(last_success_at.replace("Z", "+00:00")).timestamp()
     except ValueError as exc:
         raise ValueError("durable GitHub provider timestamp invalid") from exc
-    confirmed = [
-        source
-        for source in sources
-        if isinstance(source, dict) and source.get("confidence") == "confirmed"
-    ]
     issues: list[int] = []
     prs: list[int] = []
     changes: list[str] = []
@@ -299,7 +309,6 @@ def _authority_from_canonical_row(
             if not _safe_todo_path(ref):
                 raise ValueError("canonical Todo work source ref invalid")
             todo_paths.append(ref)
-    todo_kinds = {"todo", "superpowers_spec", "superpowers_plan", "openspec"}
     confirmed_todo = any(source.get("kind") in todo_kinds for source in confirmed)
     semantic_sources: dict[str, str] = {}
     for source in confirmed:

--- a/tests/test_coordinator_manager_daemon.py
+++ b/tests/test_coordinator_manager_daemon.py
@@ -1464,6 +1464,7 @@ def test_periodic_tick_runner_passes_default_builder_model(monkeypatch, tmp_path
         default_model="claude-haiku-4.5",
         run_tick_fn=fake_run_tick,
         scan_specs_fn=lambda specs_dir: [],
+        auto_claim_fn=lambda: [],
     )
 
     runner()

--- a/tests/test_work_actions.py
+++ b/tests/test_work_actions.py
@@ -446,6 +446,66 @@ def test_canonical_claim_excludes_derived_sources_and_volatile_github_revisions(
     assert decision.reason is None
 
 
+def test_canonical_authority_loader_ignores_issue_only_topic_rows(tmp_path: Path) -> None:
+    snapshot = tmp_path / "canonical.json"
+    provider = {
+        "provider_id": "github:acme/demo",
+        "status": "ok",
+        "last_attempt_at": "2026-07-17T00:00:00Z",
+        "last_success_at": "2026-07-17T00:00:00Z",
+        "revision": "gh-1",
+        "diagnostics": [],
+        "sources": [],
+        "observations": {},
+    }
+    issue = {
+        "source_id": "github_issue:acme/demo#12",
+        "kind": "github_issue",
+        "ref": "acme/demo#12",
+        "revision": "issue-open",
+        "status": "open",
+        "confidence": "confirmed",
+        "provider": "github:acme/demo",
+    }
+    openspec = {
+        "source_id": "openspec:acme/demo:demo",
+        "kind": "openspec",
+        "ref": "demo",
+        "revision": "spec-content",
+        "status": "active",
+        "confidence": "confirmed",
+        "provider": "repo:acme/demo",
+    }
+    snapshot.write_text(
+        json.dumps(
+            {
+                "schema": "work-items-snapshot/v1",
+                "providers": {"github:acme/demo": provider},
+                "work_items": [
+                    {
+                        "repo": "acme/demo",
+                        "work_id": "issue:acme/demo#99",
+                        "sources": [{**issue, "ref": "acme/demo#99", "source_id": "github_issue:acme/demo#99"}],
+                    },
+                    {
+                        "repo": "acme/demo",
+                        "work_id": "demo",
+                        "sources": [issue, openspec],
+                    },
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    authority = work_actions.load_work_authority(
+        repo="acme/demo", work_id="demo", snapshot_path=snapshot
+    )
+
+    assert authority.mapped_issues == (12,)
+    assert authority.mapped_openspec == ("demo",)
+
+
 def test_snapshot_refresh_noise_keeps_same_semantic_run(tmp_path: Path) -> None:
     snapshot = _snapshot(tmp_path / "snapshot.json")
     state = tmp_path / "runs.json"


### PR DESCRIPTION
## 摘要

修正 canonical authority loader 因合法 issue-only topic stable ID 不是 work slug，而阻塞同 repo 所有 confirmed Todo mutation。沒有 start authority／confirmed Todo 的 rows 現在只供顯示；malformed actionable authority 仍 fail-closed。

同時補齊 unified lifecycle 的 repo-local confirmed override，避免 active artifacts 分裂成 orphan groups或產生錯誤 missing-issue workflow。

## 驗證

- [x] issue-only topic + confirmed Todo isolation regression
- [x] work actions／bridge／manager focused suite 94 passed
- [x] production provider projection 僅產生兩筆合法 WorkAuthority（canary 與 umbrella）
- [x] full preflight

## 風險

只有具 `start` authority 且含 confirmed Todo 的 canonical row 會進 mutation loader；repo、source、action 格式錯誤仍拒絕整批 authority。