### PR TITLE
fix(work): 保留 active workflow authority

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - **deck frontmatter emit 契約與 runtime parser keyset 對齊**：`EMITTED_FRONTMATTER_FIELDS`、deck compile frontmatter 與 `parse_spec_frontmatter()` 現在一致包含 `target_branch` / `verification` / `parse_error`；compile 產生 hold spec 時固定輸出 `null` 欄位，runtime 僅接受 `parse_error: null`（non-null fail-closed），避免 deck contract alignment 漂移。
 
 ### Fixed
+- **Active workflow authority 可在 `start` action 消失後繼續 resume/closure**：canonical loader 現在把 confirmed `workflow_run` 視為持續 authority；display-only topic/orphan仍忽略，避免 `on-going` WorkItem 因 next actions 為空而變成 authority missing。
 - **Work authority loader 不再讓 display-only topic/orphan 阻塞 confirmed 工作**：canonical loader 會忽略沒有 `start` authority 或沒有 confirmed Todo 的 read-model rows；repo/work/source/action malformed 仍 fail-closed。Repo override 同步補上 unified lifecycle issue/OpenSpec/superpowers confirmed links，消除重複 display groups與錯誤 missing-issue workflow。
 - **Live GitHub provider 不再因 scan 前固定 clock 而被立即標 stale**：freshness reference 改為 provider scans 完成後再讀取，避免成功 snapshot 的 `last_success_at` 晚於 pre-scan clock 形成負 age、永久關閉 auto claim/merge；新增 deterministic clock regression 與 live projection probe。
 - **GitHub Work provider 相容不支援 `gh api --slurp` 的 gh 版本**：pagination 改用 typed `--paginate --jq '.[]'` JSONL entity stream，保留 shell-free argv 與 malformed response fail-closed；避免 live Monitor 永久 degraded 並阻止 auto claim/merge。

--- a/changelog.d/14-authority-active-resume.md
+++ b/changelog.d/14-authority-active-resume.md
@@ -1,0 +1,1 @@
+fix(work): 保留含 confirmed workflow run 的 active WorkAuthority，讓 on-going item 可 resume 與完成 closure。

--- a/paulsha_cortex/coordinator/claim.py
+++ b/paulsha_cortex/coordinator/claim.py
@@ -259,13 +259,14 @@ def _authority_from_canonical_row(
         raise ValueError("canonical work authority sources malformed")
     if sources and all(source["confidence"] == "inferred" for source in sources):
         return None
-    if next_actions is not None and "start" not in next_actions:
-        return None
     confirmed = [
         source
         for source in sources
         if isinstance(source, dict) and source.get("confidence") == "confirmed"
     ]
+    has_workflow = any(source.get("kind") == "workflow_run" for source in confirmed)
+    if next_actions is not None and "start" not in next_actions and not has_workflow:
+        return None
     todo_kinds = {"todo", "superpowers_spec", "superpowers_plan", "openspec"}
     if not any(source.get("kind") in todo_kinds for source in confirmed):
         return None

--- a/tests/test_work_actions.py
+++ b/tests/test_work_actions.py
@@ -476,6 +476,15 @@ def test_canonical_authority_loader_ignores_issue_only_topic_rows(tmp_path: Path
         "confidence": "confirmed",
         "provider": "repo:acme/demo",
     }
+    workflow = {
+        "source_id": "workflow_run:acme/demo:run-1",
+        "kind": "workflow_run",
+        "ref": "run-1",
+        "revision": "registry:1",
+        "status": "ongoing",
+        "confidence": "confirmed",
+        "provider": "workflow:acme/demo",
+    }
     snapshot.write_text(
         json.dumps(
             {
@@ -485,12 +494,14 @@ def test_canonical_authority_loader_ignores_issue_only_topic_rows(tmp_path: Path
                     {
                         "repo": "acme/demo",
                         "work_id": "issue:acme/demo#99",
+                        "next_actions": [],
                         "sources": [{**issue, "ref": "acme/demo#99", "source_id": "github_issue:acme/demo#99"}],
                     },
                     {
                         "repo": "acme/demo",
                         "work_id": "demo",
-                        "sources": [issue, openspec],
+                        "next_actions": [],
+                        "sources": [issue, openspec, workflow],
                     },
                 ],
             }


### PR DESCRIPTION
## 摘要

修正 WorkItem 進入 on-going 後 `start` next action 消失，canonical loader 因而把同一 active authority 排除，造成 `resume` 回 authority missing。

含 confirmed `workflow_run` 的 row 現在持續可供 resume/closure；issue-only topic、orphan no-start row仍只供顯示。

## 驗證

- [x] active row + empty next actions regression
- [x] current live snapshot 可載入 canary 與 umbrella 兩筆 authority
- [x] full preflight

## 風險

workflow_run 只延續已由 Manager 建立的 authority，不會讓沒有 confirmed Todo 的 topic獲得 mutation 權限。