### PR TITLE
fix(coordinator): 保留 define resume 的真實結果

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - **deck frontmatter emit 契約與 runtime parser keyset 對齊**：`EMITTED_FRONTMATTER_FIELDS`、deck compile frontmatter 與 `parse_spec_frontmatter()` 現在一致包含 `target_branch` / `verification` / `parse_error`；compile 產生 hold spec 時固定輸出 `null` 欄位，runtime 僅接受 `parse_error: null`（non-null fail-closed），避免 deck contract alignment 漂移。
 
 ### Fixed
+- **`cortex work resume` 不再覆蓋 define retry 的真實結果**：canonical starter 已負責重跑 define／brainstorm 時，Manager daemon 不再緊接著呼叫只支援 card phase 的 resume；planning runtime 仍失敗時會保留原始 reason 與 `needs_human`，成功進入 plan 後才續跑 workflow card。
 - **Active workflow authority 可在 `start` action 消失後繼續 resume/closure**：canonical loader 現在把 confirmed `workflow_run` 視為持續 authority；display-only topic/orphan仍忽略，避免 `on-going` WorkItem 因 next actions 為空而變成 authority missing。
 - **Work authority loader 不再讓 display-only topic/orphan 阻塞 confirmed 工作**：canonical loader 會忽略沒有 `start` authority 或沒有 confirmed Todo 的 read-model rows；repo/work/source/action malformed 仍 fail-closed。Repo override 同步補上 unified lifecycle issue/OpenSpec/superpowers confirmed links，消除重複 display groups與錯誤 missing-issue workflow。
 - **Live GitHub provider 不再因 scan 前固定 clock 而被立即標 stale**：freshness reference 改為 provider scans 完成後再讀取，避免成功 snapshot 的 `last_success_at` 晚於 pre-scan clock 形成負 age、永久關閉 auto claim/merge；新增 deterministic clock regression 與 live projection probe。

--- a/changelog.d/14-define-resume.md
+++ b/changelog.d/14-define-resume.md
@@ -1,0 +1,1 @@
+修正 `cortex work resume` 在 define／brainstorm retry 後又執行 card-level resume，導致真實 planning failure 被覆蓋且錯誤清除 `needs_human` 的問題。

--- a/paulsha_cortex/coordinator/manager_daemon.py
+++ b/paulsha_cortex/coordinator/manager_daemon.py
@@ -401,7 +401,12 @@ def build_request_executor(
                         allow_unsafe=False,
                         model=identity.model_id,
                     )
-                    if args.get("action") == "resume":
+                    if args.get("action") == "resume" and run.current_phase in {
+                        "plan",
+                        "build",
+                        "verify",
+                        "review",
+                    }:
                         active_ship_validator = workflow_ship_validator
                         if (
                             active_ship_validator is None

--- a/tests/test_workflow_production_wiring.py
+++ b/tests/test_workflow_production_wiring.py
@@ -168,6 +168,63 @@ def test_public_work_resume_routes_through_phase_aware_poll_terminalize_advance(
     assert result["result"]["job_id"] == "new-build-job"
 
 
+def test_public_work_resume_preserves_define_retry_result(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    registry = JobRegistry(state_path=tmp_path / "registry.json")
+    run = registry._manager_create_workflow_run(
+        work_id="production-wiring",
+        repo="hamanpaul/paulsha-cortex",
+        claim_key="claim:v1:" + "1" * 64,
+        source_revision="2" * 64,
+        workspace_root=str(tmp_path),
+        combo="feature-oneshot",
+        current_phase="define",
+        steps=_manifest().steps,
+        issue_refs=("hamanpaul/paulsha-cortex#14",),
+        openspec_refs=("production-wiring",),
+        pr_refs=(),
+        attempts={"define": 1},
+        facets=("needs_human",),
+        brainstorm_required=True,
+        gate_status="running",
+    )
+    dispatcher = type("D", (), {"_registry": registry, "_git_runner": None})()
+    monkeypatch.setattr(
+        manager,
+        "resume_workflow_run",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("define retry is completed by the canonical work starter")
+        ),
+    )
+    executor = manager_daemon.build_request_executor(
+        dispatcher=dispatcher,
+        specs_dir=str(tmp_path / "specs"),
+        handoff_dir=str(tmp_path / "handoff"),
+        work_action_fn=lambda **_: {
+            "work_id": run.work_id,
+            "repo": run.repo,
+            "result": {
+                "action": "needs_human",
+                "reason": "planning-runtime-initialization-failed",
+                "run": run.to_dict(),
+            },
+        },
+    )
+
+    result = executor(
+        build_request(
+            req_type="work-action",
+            args={"action": "resume", "repo": run.repo, "work_id": run.work_id},
+            requested_by="operator",
+        )
+    )
+
+    assert result["result"]["reason"] == "planning-runtime-initialization-failed"
+    assert result["result"]["run"]["current_phase"] == "define"
+    assert result["result"]["run"]["facets"] == ["needs_human"]
+
+
 def test_control_queue_manager_executes_heterogeneous_brainstorm_before_plan(tmp_path: Path) -> None:
     registry = JobRegistry(state_path=tmp_path / "registry.json")
     candidate = "a" * 40


### PR DESCRIPTION
## 摘要

- 避免 canonical define retry 後再次執行 card-level resume
- 保留 planning runtime failure 與 needs_human
- plan/build/verify/review 仍使用 phase-aware resume

## 驗證

- 944 tests passed
- 21 subtests passed
- OpenSpec 4/4
- policy check 零 failure
- exact-HEAD 自審完成