### PR TITLE
fix(planning): 提供 headless brainstorm evidence context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - **deck frontmatter emit 契約與 runtime parser keyset 對齊**：`EMITTED_FRONTMATTER_FIELDS`、deck compile frontmatter 與 `parse_spec_frontmatter()` 現在一致包含 `target_branch` / `verification` / `parse_error`；compile 產生 hold spec 時固定輸出 `null` 欄位，runtime 僅接受 `parse_error: null`（non-null fail-closed），避免 deck contract alignment 漂移。
 
 ### Fixed
+- **Headless 異質 brainstorm 不再因讀取 evidence 觸發互動 permission**：缺 accepted artifact 時，question pack 現在保留同 kind 的既有 repo refs；Manager 以 bounded、UTF-8、無 symlink 的 read-only方式把來源內容直接嵌入 secondary prompt，明確禁止 tool/command call，並提供 manifest-compatible planning destinations 與 exact JSON contract。`agy --mode plan --sandbox` 因此不需 unsafe bypass 或全域 command allow rule。
 - **`cortex work resume` 不再覆蓋 define retry 的真實結果**：canonical starter 已負責重跑 define／brainstorm 時，Manager daemon 不再緊接著呼叫只支援 card phase 的 resume；planning runtime 仍失敗時會保留原始 reason 與 `needs_human`，成功進入 plan 後才續跑 workflow card。
 - **Active workflow authority 可在 `start` action 消失後繼續 resume/closure**：canonical loader 現在把 confirmed `workflow_run` 視為持續 authority；display-only topic/orphan仍忽略，避免 `on-going` WorkItem 因 next actions 為空而變成 authority missing。
 - **Work authority loader 不再讓 display-only topic/orphan 阻塞 confirmed 工作**：canonical loader 會忽略沒有 `start` authority 或沒有 confirmed Todo 的 read-model rows；repo/work/source/action malformed 仍 fail-closed。Repo override 同步補上 unified lifecycle issue/OpenSpec/superpowers confirmed links，消除重複 display groups與錯誤 missing-issue workflow。

--- a/changelog.d/14-planning-headless-evidence.md
+++ b/changelog.d/14-planning-headless-evidence.md
@@ -1,0 +1,1 @@
+讓 headless 異質 brainstorm 直接使用 Manager 提供的 bounded repo evidence 與 exact JSON schema，不需 Antigravity 互動 command permission 或 unsafe bypass。

--- a/paulsha_cortex/coordinator/planning.py
+++ b/paulsha_cortex/coordinator/planning.py
@@ -241,11 +241,16 @@ def _build_default_question_pack(
 ) -> QuestionPack:
     questions: list[PlanningQuestion] = []
     for kind in missing_kinds:
+        source_refs = tuple(
+            assessment.artifact.ref
+            for assessment in assessments
+            if assessment.artifact.kind == kind
+        )
         questions.append(
             _make_question(
                 f"missing-{kind}",
                 f"What authoritative content is required to create an accepted {kind}?",
-                (),
+                source_refs,
             )
         )
     for assessment in assessments:

--- a/paulsha_cortex/coordinator/planning_runtime.py
+++ b/paulsha_cortex/coordinator/planning_runtime.py
@@ -3,12 +3,14 @@ from __future__ import annotations
 import json
 import hashlib
 import os
+import re
 import shutil
 import stat
 import subprocess
 import tempfile
 from dataclasses import dataclass
 from pathlib import Path
+from pathlib import PurePosixPath
 from typing import Callable, Mapping
 
 from .launcher import build_agy_argv
@@ -169,8 +171,14 @@ def _extract_json(stdout: str, output_path: Path) -> object:
     candidates = [stdout.strip()]
     if output_path.is_file():
         candidates.insert(0, output_path.read_text(encoding="utf-8").strip())
-    candidates.extend(reversed([line.strip() for line in stdout.splitlines() if line.strip()]))
     for candidate in candidates:
+        fenced = re.fullmatch(
+            r"```(?:json)?\s*\n(?P<body>\{.*\})\s*\n```",
+            candidate,
+            flags=re.DOTALL | re.IGNORECASE,
+        )
+        if fenced is not None:
+            candidate = fenced.group("body")
         try:
             value = json.loads(candidate)
         except (json.JSONDecodeError, TypeError):
@@ -301,6 +309,72 @@ def _probe_identity(
     )
 
 
+def _planning_source_material(
+    pack: Mapping[str, object], *, root: Path, max_bytes: int = 262_144
+) -> dict[str, str]:
+    questions = pack.get("questions")
+    if not isinstance(questions, list):
+        raise ValueError("planning question pack has no questions")
+    refs = sorted(
+        {
+            ref
+            for question in questions
+            if isinstance(question, dict)
+            for ref in question.get("source_refs", [])
+            if isinstance(ref, str)
+        }
+    )
+    material: dict[str, str] = {}
+    total = 0
+    for ref in refs:
+        pure = PurePosixPath(ref)
+        if pure.is_absolute() or ".." in pure.parts or pure.as_posix() != ref:
+            raise ValueError("planning source ref is not canonical repo-relative")
+        current = root
+        for part in pure.parts:
+            current = current / part
+            if current.is_symlink():
+                raise ValueError("planning source ref traverses symlink")
+        try:
+            target = current.resolve(strict=True)
+            target.relative_to(root)
+        except (OSError, ValueError) as exc:
+            raise ValueError("planning source ref is unavailable") from exc
+        if not target.is_file():
+            raise ValueError("planning source ref is not a file")
+        try:
+            body = target.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError) as exc:
+            raise ValueError("planning source ref is unreadable") from exc
+        total += len(body.encode("utf-8"))
+        if total > max_bytes:
+            raise ValueError("planning source material exceeds bounded context")
+        material[ref] = body
+    return material
+
+
+def _planning_destinations(pack: Mapping[str, object]) -> dict[str, str]:
+    questions = pack.get("questions")
+    if not isinstance(questions, list):
+        return {}
+    slugs = {
+        parts[2]
+        for question in questions if isinstance(question, dict)
+        for ref in question.get("source_refs", [])
+        if isinstance(ref, str)
+        and (parts := PurePosixPath(ref).parts)[:2] == ("openspec", "changes")
+        and len(parts) >= 4
+    }
+    if len(slugs) != 1:
+        return {}
+    slug = next(iter(slugs))
+    return {
+        "spec": f"docs/superpowers/specs/{slug}-spec.md",
+        "design": f"docs/superpowers/specs/{slug}-design.md",
+        "plan": f"docs/superpowers/plans/{slug}.md",
+    }
+
+
 def build_production_planning_runtime(
     *,
     primary: tuple[str, str],
@@ -348,10 +422,19 @@ def build_production_planning_runtime(
         )
 
     def secondary(pack: Mapping[str, object], identity: ModelIdentity) -> object:
+        source_material = _planning_source_material(pack, root=root)
         return _invoke_json(
             identity,
-            "Return only evidence JSON; do not make decisions or edit files. Question pack: "
-            + json.dumps(pack, ensure_ascii=False, sort_keys=True),
+            "Do not call tools, run commands, make decisions, or edit files. Use only the supplied "
+            "source material. Return exactly one JSON object with keys schema_version=1, "
+            "question_pack_id, and evidence. Evidence must contain every question exactly once; "
+            "each row has only question_id, non-empty claims string list, and non-empty source_refs "
+            "string list naming supplied sources. Input: "
+            + json.dumps(
+                {"question_pack": pack, "source_material": source_material},
+                ensure_ascii=False,
+                sort_keys=True,
+            ),
             worktree=root,
             runner=runner,
             timeout_seconds=timeout_seconds,
@@ -359,9 +442,21 @@ def build_production_planning_runtime(
 
     def integrator(pack: Mapping[str, object], evidence: Mapping[str, object]) -> object:
         return invoke_primary(
-            "Integrate evidence without editing files. Return integration JSON with an artifacts list; "
-            "each artifact must contain kind, path, and complete UTF-8 content. "
-            + json.dumps({"question_pack": pack, "secondary_evidence": evidence}, ensure_ascii=False, sort_keys=True)
+            "Do not call tools or edit files. Integrate only the supplied evidence. Return exactly one "
+            "JSON object with schema_version=1, question_pack_id, secondary_evidence_hash, resolutions, "
+            "and artifacts. Each resolution has only question_id, decision, artifact_kind, artifact_refs. "
+            "Each artifact has only kind, path, content; content must be complete UTF-8 Markdown with "
+            "frontmatter status: accepted, the matching work_item, and required headings: Requirements "
+            "for spec, Decisions for design, Tasks for plan. Use the supplied destination paths. Input: "
+            + json.dumps(
+                {
+                    "question_pack": pack,
+                    "secondary_evidence": evidence,
+                    "destinations": _planning_destinations(pack),
+                },
+                ensure_ascii=False,
+                sort_keys=True,
+            )
         )
 
     return ProductionPlanningRuntime(registry, probes, questioner, secondary, integrator)

--- a/tests/test_planning_completeness.py
+++ b/tests/test_planning_completeness.py
@@ -159,6 +159,22 @@ def test_completeness_requires_accepted_spec_design_and_plan() -> None:
     assert [question.kind for question in report.default_question_pack.questions] == ["missing-plan"]
 
 
+def test_rejected_artifacts_remain_authoritative_sources_for_missing_kind_questions() -> None:
+    report = assess_planning_completeness(
+        [
+            _artifact("spec", "---\nstatus: draft\n---\n## Requirements\nDraft.\n", "openspec/changes/demo/proposal.md"),
+            _artifact("design", "---\nstatus: draft\n---\n## Decisions\nDraft.\n", "openspec/changes/demo/design.md"),
+            _artifact("plan", "---\nstatus: draft\n---\n## Tasks\n- [ ] Draft.\n", "openspec/changes/demo/tasks.md"),
+        ]
+    )
+
+    assert [question.source_refs for question in report.default_question_pack.questions] == [
+        ("openspec/changes/demo/proposal.md",),
+        ("openspec/changes/demo/design.md",),
+        ("openspec/changes/demo/tasks.md",),
+    ]
+
+
 def test_any_blocking_marker_triggers_brainstorm_even_when_an_alternate_artifact_is_accepted() -> None:
     report = assess_planning_completeness(
         [

--- a/tests/test_planning_runtime.py
+++ b/tests/test_planning_runtime.py
@@ -77,6 +77,108 @@ def test_production_runtime_loads_registry_and_probes_only_safe_launchers(
     assert claude_argv[claude_argv.index("--tools") + 1] == ""
 
 
+def test_secondary_prompt_embeds_bounded_repo_sources_without_tool_access(
+    monkeypatch, tmp_path: Path
+) -> None:
+    source = tmp_path / "openspec" / "changes" / "demo" / "proposal.md"
+    source.parent.mkdir(parents=True)
+    source.write_text("---\nstatus: draft\n---\n## Why\nEvidence.\n", encoding="utf-8")
+    registry = IdentityRegistry.from_rows(
+        [
+            {
+                "executor": "codex", "model_id": "primary", "independence_domain": "openai",
+                "capabilities": ["planning"],
+            },
+            {
+                "executor": "agy", "model_id": AGY_MODEL_ID, "independence_domain": "google",
+                "capabilities": ["planning"], "live_probe": "agy-plan-sandbox",
+            },
+        ]
+    )
+    monkeypatch.setattr(planning_runtime, "load_model_identities", lambda: registry)
+    prompts: list[str] = []
+
+    def runner(argv, **kwargs):
+        if argv == ["agy", "models"]:
+            return _completed(f"{AGY_MODEL_ID}\n")
+        prompt = argv[argv.index("--print") + 1] if "--print" in argv else argv[2]
+        prompts.append(prompt)
+        for marker in (
+            "Return only this compact JSON object and perform no tool calls: ",
+            "Return only this JSON object and do not call tools: ",
+        ):
+            if marker in prompt:
+                return _completed(prompt.split(marker, 1)[1] + "\n")
+        return _completed(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "question_pack_id": "qp-demo",
+                    "evidence": [
+                        {
+                            "question_id": "q-demo",
+                            "claims": ["The proposal records the intended evidence."],
+                            "source_refs": ["openspec/changes/demo/proposal.md"],
+                        }
+                    ],
+                }
+            )
+        )
+
+    runtime = planning_runtime.build_production_planning_runtime(
+        primary=("codex", "primary"), worktree=tmp_path, runner=runner
+    )
+    result = runtime.secondary_planner(
+        {
+            "schema_version": 1,
+            "pack_id": "qp-demo",
+            "questions": [
+                {
+                    "question_id": "q-demo",
+                    "kind": "missing-spec",
+                    "prompt": "What is required?",
+                    "source_refs": ["openspec/changes/demo/proposal.md"],
+                }
+            ],
+        },
+        registry.require("agy", AGY_MODEL_ID),
+    )
+
+    assert result["question_pack_id"] == "qp-demo"
+    assert "Do not call tools" in prompts[-1]
+    assert "Evidence." in prompts[-1]
+    assert planning_runtime._planning_destinations(
+        {
+            "questions": [
+                {"source_refs": ["openspec/changes/demo/proposal.md"]}
+            ]
+        }
+    )["plan"] == "docs/superpowers/plans/demo.md"
+
+
+def test_planning_json_parser_accepts_only_whole_fenced_object(tmp_path: Path) -> None:
+    output = tmp_path / "missing.json"
+    assert planning_runtime._extract_json(
+        '```json\n{"schema_version": 1}\n```\n', output
+    ) == {"schema_version": 1}
+    with pytest.raises(ValueError, match="no JSON object"):
+        planning_runtime._extract_json(
+            'Commentary.\n```json\n{"schema_version": 1}\n```\n', output
+        )
+
+
+def test_planning_source_material_rejects_symlink_traversal(tmp_path: Path) -> None:
+    outside = tmp_path / "outside.md"
+    outside.write_text("secret\n", encoding="utf-8")
+    link = tmp_path / "linked.md"
+    link.symlink_to(outside)
+
+    with pytest.raises(ValueError, match="symlink"):
+        planning_runtime._planning_source_material(
+            {"questions": [{"source_refs": ["linked.md"]}]}, root=tmp_path
+        )
+
+
 def test_planning_runtime_rejects_any_worktree_mutation(tmp_path: Path) -> None:
     identity = ModelIdentity("codex", "primary", "openai", ("planning",))
     baseline = tmp_path / "tracked.md"

--- a/tests/test_workflow_production_wiring.py
+++ b/tests/test_workflow_production_wiring.py
@@ -444,6 +444,7 @@ def test_control_queue_manager_executes_heterogeneous_brainstorm_before_plan(tmp
         workflow_identity_registry=identities,
         scan_specs_fn=lambda _: [],
         run_tick_fn=lambda *args, **kwargs: {"dispatch_skipped": False},
+        auto_claim_fn=lambda: [],
     )
     periodic()
     assert registry.get_workflow_run(run.run_id).current_phase == "build"


### PR DESCRIPTION
## 摘要

- 由 Manager bounded 讀取既有 planning artifacts 並嵌入 secondary prompt
- 禁止 headless secondary 呼叫工具或 command
- 支援完整 fenced JSON object 並提供 manifest-compatible destinations
- 隔離 periodic test，避免讀取 live authority

## 驗證

- 真實 agy plan/sandbox smoke：schema v1、3/3 evidence
- 948 tests passed
- 21 subtests passed
- OpenSpec 4/4
- policy check 零 failure
- exact-HEAD 自審完成