### PR TITLE
docs(canary): 建立乾淨 lifecycle authority

### DIFF
--- a/.cortex/work-items.yaml
+++ b/.cortex/work-items.yaml
@@ -18,3 +18,10 @@ work_items:
         ref: hamanpaul/paulsha-cortex#20
       - kind: openspec
         ref: docs-only-lifecycle-canary
+  docs-only-lifecycle-canary-v2:
+    title: Unified lifecycle clean live canary
+    links:
+      - kind: github_issue
+        ref: hamanpaul/paulsha-cortex#27
+      - kind: openspec
+        ref: docs-only-lifecycle-canary-v2

--- a/changelog.d/27-clean-live-canary-bootstrap.md
+++ b/changelog.d/27-clean-live-canary-bootstrap.md
@@ -1,0 +1,1 @@
+建立 issue #27 與全新 confirmed OpenSpec authority，讓修正 test isolation 後的 unified lifecycle 可執行乾淨 docs-only live canary。

--- a/openspec/changes/docs-only-lifecycle-canary-v2/.openspec.yaml
+++ b/openspec/changes/docs-only-lifecycle-canary-v2/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-18

--- a/openspec/changes/docs-only-lifecycle-canary-v2/design.md
+++ b/openspec/changes/docs-only-lifecycle-canary-v2/design.md
@@ -1,0 +1,23 @@
+---
+work_item: docs-only-lifecycle-canary-v2
+---
+
+## Context
+
+Canary 使用 repo-local override 將 issue #27 與新的 active OpenSpec confirmed mapping。Bootstrap merge 後才加入 `cortex:auto-on-going`，避免 artifacts 尚未在 default branch 時提前 claim。
+
+## Goals / Non-Goals
+
+- Goal：驗證 auto claim、`agy/google` 異質 brainstorm、docs-only build、ForeignReview、archive、preflight、current-HEAD maintainer review、merge commit 與 done projection。
+- Non-goal：修改 runtime code、直接修改 Manager registry，或對其他 repo 啟用 auto label。
+
+## Decisions
+
+- 使用全新 issue、work ID 與 OpenSpec，保留第一條 canary 的 fail-closed 診斷紀錄。
+- 初始 change 不建立 accepted superpowers plan；Manager 必須由 primary planner 與 `agy/google` secondary 補齊 planning authority。
+- 依 operator 指示，以 exact-HEAD maintainer adversarial review取代等待 Copilot；其餘 strict gates不變。
+
+## Risks / Trade-offs
+
+- Model output 若不符合 typed artifact contract，workflow 應 fail-closed 到 `needs_human`，不得繞過。
+- Canary 未通過前不對其他 repo 加 auto label。

--- a/openspec/changes/docs-only-lifecycle-canary-v2/proposal.md
+++ b/openspec/changes/docs-only-lifecycle-canary-v2/proposal.md
@@ -1,0 +1,28 @@
+---
+work_item: docs-only-lifecycle-canary-v2
+---
+
+## Why
+
+第一條 live canary 揭露並修正 production auto-claim 的 test isolation 缺口，但其 durable authority 已被污染，不能直接修改 registry 後冒充完整閉合。需要全新 confirmed authority 進行乾淨的 docs-only canary。
+
+## What Changes
+
+- 在 unified lifecycle 操作文件留下 clean live canary evidence。
+- 驗證 confirmed Todo + issue auto label 可進入異質 brainstorm、build、review 與 strict delivery closure。
+- 不修改 runtime code、public API 或既有治理語意。
+- 初始 change 刻意不提供 accepted superpowers plan，讓 completeness gate 必須執行異質 brainstorm。
+
+## Capabilities
+
+### New Capabilities
+
+- `lifecycle-clean-live-canary`: 定義乾淨 docs-only lifecycle canary 的 terminal evidence。
+
+### Modified Capabilities
+
+無。
+
+## Impact
+
+只影響 `docs/unified-work-lifecycle.md`、本 OpenSpec change 與 issue #27；不改 production code。

--- a/openspec/changes/docs-only-lifecycle-canary-v2/specs/lifecycle-clean-live-canary/spec.md
+++ b/openspec/changes/docs-only-lifecycle-canary-v2/specs/lifecycle-clean-live-canary/spec.md
@@ -1,0 +1,17 @@
+## ADDED Requirements
+
+### Requirement: Clean live canary 必須留下可審查的 terminal evidence
+
+Unified lifecycle 的 clean docs-only live canary MUST在操作文件記錄 mapped issue、planner/builder/reviewer independence domain、deterministic verification、archive、preflight、current-HEAD review、merge commit 與 done projection結果。任何未通過 gate MUST標示為未完成，不得宣稱 canary通過。
+
+#### Scenario: Canary 完整閉合
+
+- **WHEN** clean docs-only canary 的所有 strict gates與遠端 closure 均成立
+- **THEN** 操作文件記錄可追溯的 issue、PR、merge commit與CompletionRecord evidence
+- **THEN** Monitor 將 work item 投影為 `done`
+
+#### Scenario: 任一 gate 未完成
+
+- **WHEN** brainstorm、ForeignReview、archive、preflight、current-HEAD review或remote closure任一缺失
+- **THEN** 文件不得宣稱 canary通過
+- **THEN** workflow維持 `on-going`並帶 `needs_human`或`blocked` facet

--- a/openspec/changes/docs-only-lifecycle-canary-v2/tasks.md
+++ b/openspec/changes/docs-only-lifecycle-canary-v2/tasks.md
@@ -1,0 +1,9 @@
+---
+work_item: docs-only-lifecycle-canary-v2
+---
+
+## 1. Clean docs-only live canary
+
+- [ ] 1.1 在 `docs/unified-work-lifecycle.md` 新增 clean Live canary evidence 段落，記錄 issue、persona domain separation、驗證與 terminal closure。
+- [ ] 1.2 通過 docs diff、OpenSpec validation、policy、full preflight 與 ForeignReview。
+- [ ] 1.3 使用官方 OpenSpec CLI archive 本 change，並以 merge commit 關閉 issue #27。


### PR DESCRIPTION
## 摘要

- 建立全新 issue/OpenSpec confirmed authority
- 保留第一條 canary 的 fail-closed 診斷，不修改 registry
- 初始不提供 accepted superpowers plan，以觸發異質 brainstorm

## 驗證

- OpenSpec 5/5
- policy check 零 failure
- docs-only exact-HEAD 自審完成