### PR TITLE
fix(work): 恢復既有 needs-human workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - **deck frontmatter emit 契約與 runtime parser keyset 對齊**：`EMITTED_FRONTMATTER_FIELDS`、deck compile frontmatter 與 `parse_spec_frontmatter()` 現在一致包含 `target_branch` / `verification` / `parse_error`；compile 產生 hold spec 時固定輸出 `null` 欄位，runtime 僅接受 `parse_error: null`（non-null fail-closed），避免 deck contract alignment 漂移。
 
 ### Fixed
+- **`work resume` 現在會真正重入既有 `needs_human` workflow**：claim router 不再把既有 `needs_human` 誤當成只讀結果直接回傳；operator resume 會以同一 claim key 呼叫 canonical starter，讓 define／brainstorm retry 可以在不新建 run 的前提下繼續。
 - **Headless 異質 brainstorm 不再因讀取 evidence 觸發互動 permission**：缺 accepted artifact 時，question pack 現在保留同 kind 的既有 repo refs；Manager 以 bounded、UTF-8、無 symlink 的 read-only方式把來源內容直接嵌入 secondary prompt，明確禁止 tool/command call，並提供 manifest-compatible planning destinations 與 exact JSON contract。`agy --mode plan --sandbox` 因此不需 unsafe bypass 或全域 command allow rule。
 - **`cortex work resume` 不再覆蓋 define retry 的真實結果**：canonical starter 已負責重跑 define／brainstorm 時，Manager daemon 不再緊接著呼叫只支援 card phase 的 resume；planning runtime 仍失敗時會保留原始 reason 與 `needs_human`，成功進入 plan 後才續跑 workflow card。
 - **Active workflow authority 可在 `start` action 消失後繼續 resume/closure**：canonical loader 現在把 confirmed `workflow_run` 視為持續 authority；display-only topic/orphan仍忽略，避免 `on-going` WorkItem 因 next actions 為空而變成 authority missing。

--- a/changelog.d/14-resume-needs-human.md
+++ b/changelog.d/14-resume-needs-human.md
@@ -1,0 +1,1 @@
+修正 `work resume` 對既有 `needs_human` run 只回傳狀態、未重入 canonical starter 的路由缺口。

--- a/paulsha_cortex/coordinator/work_actions.py
+++ b/paulsha_cortex/coordinator/work_actions.py
@@ -953,6 +953,12 @@ def _claim_action(
             if workflow_starter is None:
                 raise RuntimeError("canonical workflow starter unavailable")
             canonical_run = workflow_starter(authority, claim_key, decision.reason)
+        elif args.get("action") == "resume":
+            if workflow_starter is None:
+                raise RuntimeError("canonical workflow starter unavailable")
+            canonical_run = workflow_starter(
+                authority, canonical_run.claim_key, None
+            )
         active = canonical_run.to_dict()
         active["reason"] = decision.reason
     elif canonical_run is not None:

--- a/tests/test_work_actions.py
+++ b/tests/test_work_actions.py
@@ -169,6 +169,43 @@ def test_start_is_restart_idempotent_and_auto_uses_typed_label_command(tmp_path:
         )
 
 
+def test_resume_existing_needs_human_reenters_canonical_starter(tmp_path: Path) -> None:
+    snapshot = _snapshot(tmp_path / "snapshot.json")
+    authority = work_actions.load_work_authority(
+        repo="acme/demo", work_id="demo", snapshot_path=snapshot
+    )
+    registry = JobRegistry(state_path=tmp_path / "jobs.json")
+    claim_key = work_actions._expected_claim_key(authority)
+    initial = work_actions._fallback_workflow_starter(
+        registry, tmp_path / "runs.json"
+    )(authority, claim_key, "planning-failed")
+    calls: list[tuple[str, str | None]] = []
+
+    def starter(bound_authority, bound_claim_key, reason):
+        assert bound_authority == authority
+        calls.append((bound_claim_key, reason))
+        return registry._manager_update_workflow_run(
+            initial.run_id,
+            current_phase="plan",
+            facets=(),
+            attempts={"claim": 1, "define": 2, "plan": 1},
+        )
+
+    result = work_actions.execute_work_action(
+        args={"action": "resume", "repo": "acme/demo", "work_id": "demo"},
+        requested_by="operator",
+        snapshot_path=snapshot,
+        state_path=tmp_path / "runs.json",
+        now=lambda: 200,
+        workflow_registry=registry,
+        workflow_starter=starter,
+    )
+
+    assert calls == [(claim_key, None)]
+    assert result["result"]["run"]["current_phase"] == "plan"
+    assert result["result"]["run"]["facets"] == []
+
+
 def test_auto_without_issue_mutates_every_mapped_issue(tmp_path: Path) -> None:
     snapshot = _snapshot(tmp_path / "snapshot.json", issues=(12, 13))
     calls: list[list[str]] = []


### PR DESCRIPTION
## 摘要

- work resume 對既有 needs_human run 重入 canonical starter
- 保留同一 claim key 與 WorkflowRun
- 不放寬 planning/review/ship gate

## 驗證

- 949 tests passed
- 21 subtests passed
- OpenSpec 5/5
- policy check 零 failure
- exact-HEAD 自審完成