### PR TITLE
fix(work): 保留 planning source 變更中的 active run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - **deck frontmatter emit 契約與 runtime parser keyset 對齊**：`EMITTED_FRONTMATTER_FIELDS`、deck compile frontmatter 與 `parse_spec_frontmatter()` 現在一致包含 `target_branch` / `verification` / `parse_error`；compile 產生 hold spec 時固定輸出 `null` 欄位，runtime 僅接受 `parse_error: null`（non-null fail-closed），避免 deck contract alignment 漂移。
 
 ### Fixed
+- **Active workflow 不再被自己新增的 planning sources supersede**：auto claim 與 explicit resume 會先以穩定 repo/work/issue/OpenSpec identity 找出唯一 ongoing run；accepted superpowers spec/plan 加入 authority 時維持同一 run，由 active workflow 優先，不再建立新 claim。Codex planner 同時在無 `.git` 的 disposable read-only checkout 使用官方 `--skip-git-repo-check`，避免安全 sandbox 被 CLI trust check 誤擋。
 - **`work resume` 現在會真正重入既有 `needs_human` workflow**：claim router 不再把既有 `needs_human` 誤當成只讀結果直接回傳；operator resume 會以同一 claim key 呼叫 canonical starter，讓 define／brainstorm retry 可以在不新建 run 的前提下繼續。
 - **Headless 異質 brainstorm 不再因讀取 evidence 觸發互動 permission**：缺 accepted artifact 時，question pack 現在保留同 kind 的既有 repo refs；Manager 以 bounded、UTF-8、無 symlink 的 read-only方式把來源內容直接嵌入 secondary prompt，明確禁止 tool/command call，並提供 manifest-compatible planning destinations 與 exact JSON contract。`agy --mode plan --sandbox` 因此不需 unsafe bypass 或全域 command allow rule。
 - **`cortex work resume` 不再覆蓋 define retry 的真實結果**：canonical starter 已負責重跑 define／brainstorm 時，Manager daemon 不再緊接著呼叫只支援 card phase 的 resume；planning runtime 仍失敗時會保留原始 reason 與 `needs_human`，成功進入 plan 後才續跑 workflow card。

--- a/changelog.d/14-active-auto-claim.md
+++ b/changelog.d/14-active-auto-claim.md
@@ -1,0 +1,1 @@
+避免 ongoing workflow 因自身發布 accepted planning sources 而被 auto claim supersede，並允許 Codex planner 在無 `.git` 的 disposable read-only checkout 啟動。

--- a/paulsha_cortex/coordinator/planning_runtime.py
+++ b/paulsha_cortex/coordinator/planning_runtime.py
@@ -47,7 +47,7 @@ def _planning_argv(identity: ModelIdentity, prompt: str, temp_dir: str, worktree
         return [
             "codex", "exec", prompt, "--json", "--sandbox", "read-only",
             "--model", identity.model_id, "-o", str(Path(temp_dir) / "last.json"),
-            "-C", str(worktree),
+            "-C", str(worktree), "--skip-git-repo-check",
         ]
     if identity.executor == "claude":
         return [

--- a/paulsha_cortex/coordinator/work_actions.py
+++ b/paulsha_cortex/coordinator/work_actions.py
@@ -889,10 +889,11 @@ def _claim_action(
 ) -> dict[str, Any]:
     canonical_run = None
     if workflow_registry is not None:
+        all_runs = workflow_registry.list_workflow_runs()
         expected_key = _expected_claim_key(authority)
         matching = [
             run
-            for run in workflow_registry.list_workflow_runs()
+            for run in all_runs
             if run.repo == authority.repo
             and run.work_id == authority.work_id
             and run.claim_key == expected_key
@@ -900,6 +901,23 @@ def _claim_action(
         if len(matching) > 1:
             raise RuntimeError("canonical workflow claim is ambiguous")
         canonical_run = matching[0] if matching else None
+        if canonical_run is None and (automatic or args.get("action") == "resume"):
+            active = [
+                run
+                for run in all_runs
+                if run.repo == authority.repo
+                and run.work_id == authority.work_id
+                and run.status == "ongoing"
+                and run.issue_refs
+                == tuple(
+                    f"{authority.repo}#{number}"
+                    for number in authority.mapped_issues
+                )
+                and run.openspec_refs == authority.mapped_openspec
+            ]
+            if len(active) > 1:
+                raise RuntimeError("active workflow identity is ambiguous")
+            canonical_run = active[0] if active else None
     issue = args.get("issue") if args.get("issue") is not None else (
         authority.mapped_issues[0] if authority.mapped_issues else None
     )
@@ -925,6 +943,26 @@ def _claim_action(
             work_authority_digest(authority) if canonical_run is not None else None
         ),
     )
+    if (
+        canonical_run is not None
+        and canonical_run.claim_key != _expected_claim_key(authority)
+        and (automatic or args.get("action") == "resume")
+    ):
+        active = canonical_run.to_dict()
+        active.update(
+            {
+                "snapshot_hash": authority.snapshot_hash,
+                "source_revisions": list(authority.source_revisions),
+                "provider_revision": authority.github_provider_revision,
+                "authority_digest": work_authority_digest(authority),
+                "status": workflow_status(canonical_run),
+            }
+        )
+        return {
+            "action": "resume",
+            "reason": "active-workflow",
+            "run": active,
+        }
     decision = (
         decide_auto_claim(candidate, now_epoch=now_epoch)
         if automatic

--- a/tests/test_planning_runtime.py
+++ b/tests/test_planning_runtime.py
@@ -60,6 +60,7 @@ def test_production_runtime_loads_registry_and_probes_only_safe_launchers(
     assert codex_calls and all(
         argv[argv.index("--sandbox") + 1] == "read-only" for argv in codex_calls
     )
+    assert all("--skip-git-repo-check" in argv for argv in codex_calls)
     agy_calls = [
         argv for argv in calls if argv and argv[0] == "agy" and argv != ["agy", "models"]
     ]

--- a/tests/test_work_actions.py
+++ b/tests/test_work_actions.py
@@ -309,6 +309,48 @@ def test_source_change_starts_new_canonical_run(tmp_path: Path) -> None:
     assert "blocked" in old.facets
 
 
+def test_auto_scan_does_not_supersede_active_run_when_planning_adds_sources(
+    tmp_path: Path,
+) -> None:
+    snapshot = _snapshot(tmp_path / "snapshot.json")
+    state = tmp_path / "runs.json"
+    registry = JobRegistry(state_path=tmp_path / "jobs.json")
+    first = work_actions.execute_work_action(
+        args={"action": "start", "repo": "acme/demo", "work_id": "demo"},
+        requested_by="operator",
+        snapshot_path=snapshot,
+        state_path=state,
+        now=lambda: 200,
+        workflow_registry=registry,
+    )
+    _snapshot(
+        snapshot,
+        source_revisions=(
+            "issue:12@open",
+            "openspec:demo@1",
+            "superpowers_plan:docs/demo.md@active",
+        ),
+        provider_revision="gh-2",
+    )
+
+    result = work_actions.run_auto_claim_scan(
+        snapshot_path=snapshot,
+        state_path=state,
+        now=lambda: 200,
+        runner=lambda *args, **kwargs: SimpleNamespace(
+            returncode=0,
+            stdout=json.dumps({"labels": [{"name": "cortex:auto-on-going"}]}),
+            stderr="",
+        ),
+        workflow_registry=registry,
+    )
+
+    assert result[0]["action"] == "resume"
+    assert result[0]["run"]["run_id"] == first["result"]["run"]["run_id"]
+    assert len(registry.list_workflow_runs()) == 1
+    assert registry.list_workflow_runs()[0].status == "ongoing"
+
+
 def test_canonical_claim_excludes_derived_sources_and_volatile_github_revisions(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## 摘要

- auto claim 與 resume 優先使用穩定 identity 的唯一 ongoing run
- accepted planning sources 不再 supersede 自己的 workflow
- Codex disposable planner 加入 skip-git-repo-check 且維持 read-only sandbox

## 驗證

- 950 tests passed
- 21 subtests passed
- OpenSpec 5/5
- policy check 零 failure
- exact-HEAD 自審完成