### PR TITLE
docs(canary): 建立 terminal lifecycle authority

### DIFF
--- a/.cortex/work-items.yaml
+++ b/.cortex/work-items.yaml
@@ -25,3 +25,10 @@ work_items:
         ref: hamanpaul/paulsha-cortex#27
       - kind: openspec
         ref: docs-only-lifecycle-canary-v2
+  terminal-lifecycle-canary:
+    title: Unified lifecycle terminal live canary
+    links:
+      - kind: github_issue
+        ref: hamanpaul/paulsha-cortex#31
+      - kind: openspec
+        ref: terminal-lifecycle-canary

--- a/changelog.d/31-terminal-live-canary-bootstrap.md
+++ b/changelog.d/31-terminal-live-canary-bootstrap.md
@@ -1,0 +1,1 @@
+建立全新 issue #31 與 terminal lifecycle OpenSpec authority，驗證先前 canary 揭露缺口修正後的完整閉合。

--- a/openspec/changes/terminal-lifecycle-canary/.openspec.yaml
+++ b/openspec/changes/terminal-lifecycle-canary/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-18

--- a/openspec/changes/terminal-lifecycle-canary/design.md
+++ b/openspec/changes/terminal-lifecycle-canary/design.md
@@ -1,0 +1,22 @@
+---
+work_item: terminal-lifecycle-canary
+---
+
+## Context
+
+Repo-local override 將 issue #31 與新的 active OpenSpec confirmed mapping。Bootstrap merge 後才加入 auto label。
+
+## Goals / Non-Goals
+
+- Goal：驗證 auto claim、`agy/google` brainstorm、docs-only build、ForeignReview、archive、preflight、current-HEAD maintainer review、merge commit 與 done projection。
+- Non-goal：修改 runtime code、直接修改 Manager registry，或對其他 repo 啟用 auto label。
+
+## Decisions
+
+- 使用全新 issue/work ID/OpenSpec；前兩條 canary 保留 fail-closed 診斷紀錄。
+- accepted planning artifacts 必須由 primary planner 整合 `agy/google` evidence 後發布。
+- 依 operator 指示使用 exact-HEAD maintainer adversarial review；其餘 strict gates不變。
+
+## Risks / Trade-offs
+
+- 任一 typed output 或 gate 不通過即維持 `needs_human`，不得宣稱完成。

--- a/openspec/changes/terminal-lifecycle-canary/proposal.md
+++ b/openspec/changes/terminal-lifecycle-canary/proposal.md
@@ -1,0 +1,28 @@
+---
+work_item: terminal-lifecycle-canary
+---
+
+## Why
+
+前兩條 canary 以 fail-closed 方式揭露 test isolation、resume routing、active-run source churn 與 disposable planner 啟動缺口；修正合併後需要全新 authority 驗證 terminal closure。
+
+## What Changes
+
+- 在 unified lifecycle 操作文件留下 terminal live canary evidence。
+- 驗證 confirmed Todo + issue auto label、異質 brainstorm、docs-only build、review 與 strict delivery closure。
+- 初始 change 不提供 accepted superpowers plan，強制 completeness gate 執行異質 brainstorm。
+- 不修改 runtime code或既有治理語意。
+
+## Capabilities
+
+### New Capabilities
+
+- `lifecycle-terminal-live-canary`: 定義 terminal docs-only canary 的可審查 evidence。
+
+### Modified Capabilities
+
+無。
+
+## Impact
+
+只影響 `docs/unified-work-lifecycle.md`、本 OpenSpec change 與 issue #31。

--- a/openspec/changes/terminal-lifecycle-canary/specs/lifecycle-terminal-live-canary/spec.md
+++ b/openspec/changes/terminal-lifecycle-canary/specs/lifecycle-terminal-live-canary/spec.md
@@ -1,0 +1,16 @@
+## ADDED Requirements
+
+### Requirement: Terminal live canary 必須留下可審查 evidence
+
+Terminal docs-only canary MUST記錄 mapped issue、planner/builder/reviewer independence domain、verification、archive、preflight、current-HEAD review、merge commit與done projection。任一 gate 未通過時 MUST維持未完成。
+
+#### Scenario: Canary 完整閉合
+
+- **WHEN** 全部 strict gates與remote closure成立
+- **THEN** 操作文件記錄 issue、PR、merge commit與CompletionRecord evidence
+- **THEN** Monitor投影 work item為 `done`
+
+#### Scenario: 任一 gate 未完成
+
+- **WHEN** brainstorm、ForeignReview、archive、preflight、review或remote closure任一缺失
+- **THEN** workflow維持 `on-going`並帶 attention facet

--- a/openspec/changes/terminal-lifecycle-canary/tasks.md
+++ b/openspec/changes/terminal-lifecycle-canary/tasks.md
@@ -1,0 +1,9 @@
+---
+work_item: terminal-lifecycle-canary
+---
+
+## 1. Terminal docs-only live canary
+
+- [ ] 1.1 在 `docs/unified-work-lifecycle.md` 記錄 issue、persona domain separation、驗證與 terminal closure。
+- [ ] 1.2 通過 docs diff、OpenSpec validation、policy、full preflight 與 ForeignReview。
+- [ ] 1.3 官方 archive 本 change，以 merge commit 關閉 issue #31並驗證 done projection。


### PR DESCRIPTION
## 摘要

- 建立全新 terminal canary confirmed authority
- 初始不提供 accepted superpowers plan
- 保留前兩條 canary 的 fail-closed 診斷

## 驗證

- OpenSpec validate all
- policy check 零 failure
- exact-HEAD 自審完成