### PR TITLE
fix(planning): 允許唯讀 planner 使用 disposable checkout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - **deck frontmatter emit 契約與 runtime parser keyset 對齊**：`EMITTED_FRONTMATTER_FIELDS`、deck compile frontmatter 與 `parse_spec_frontmatter()` 現在一致包含 `target_branch` / `verification` / `parse_error`；compile 產生 hold spec 時固定輸出 `null` 欄位，runtime 僅接受 `parse_error: null`（non-null fail-closed），避免 deck contract alignment 漂移。
 
 ### Fixed
+- **唯讀 workflow planner 可在 disposable checkout 啟動 Codex**：Coordinator launcher 僅對 `read_only` card 加上 `--skip-git-repo-check`，保留 `--sandbox read-only`；builder 路徑仍維持原本的 git trust gate，避免放寬可寫入執行階段。
 - **Active workflow 不再被自己新增的 planning sources supersede**：auto claim 與 explicit resume 會先以穩定 repo/work/issue/OpenSpec identity 找出唯一 ongoing run；accepted superpowers spec/plan 加入 authority 時維持同一 run，由 active workflow 優先，不再建立新 claim。Codex planner 同時在無 `.git` 的 disposable read-only checkout 使用官方 `--skip-git-repo-check`，避免安全 sandbox 被 CLI trust check 誤擋。
 - **`work resume` 現在會真正重入既有 `needs_human` workflow**：claim router 不再把既有 `needs_human` 誤當成只讀結果直接回傳；operator resume 會以同一 claim key 呼叫 canonical starter，讓 define／brainstorm retry 可以在不新建 run 的前提下繼續。
 - **Headless 異質 brainstorm 不再因讀取 evidence 觸發互動 permission**：缺 accepted artifact 時，question pack 現在保留同 kind 的既有 repo refs；Manager 以 bounded、UTF-8、無 symlink 的 read-only方式把來源內容直接嵌入 secondary prompt，明確禁止 tool/command call，並提供 manifest-compatible planning destinations 與 exact JSON contract。`agy --mode plan --sandbox` 因此不需 unsafe bypass 或全域 command allow rule。

--- a/changelog.d/14-planner-disposable-trust.md
+++ b/changelog.d/14-planner-disposable-trust.md
@@ -1,0 +1,2 @@
+### Fixed
+- 唯讀 workflow planner 的 Codex argv 現在在保留 read-only sandbox 的同時略過 disposable checkout 的 git repo trust check；可寫入 builder 不受影響。

--- a/paulsha_cortex/coordinator/launcher.py
+++ b/paulsha_cortex/coordinator/launcher.py
@@ -118,7 +118,7 @@ def build_codex_argv(
         # 信任閘等待輸入 → timeout。autonomous 派工須一併 bypass hook trust 才不會掛住。
         argv.append("--dangerously-bypass-hook-trust")
     elif read_only:
-        argv += ["--sandbox", "read-only"]
+        argv += ["--sandbox", "read-only", "--skip-git-repo-check"]
     if model is not None:
         argv += ["--model", model]
     argv.extend(["-o", str(Path(log_dir) / "last.json")])

--- a/tests/test_coordinator_launcher.py
+++ b/tests/test_coordinator_launcher.py
@@ -82,6 +82,14 @@ class ArgvTests(unittest.TestCase):
         self.assertNotIn("acceptEdits", claude)
         self.assertEqual(claude[claude.index("--tools") + 1], "")
         self.assertEqual(codex[codex.index("--sandbox") + 1], "read-only")
+        self.assertIn("--skip-git-repo-check", codex)
+
+    def test_codex_builder_keeps_git_trust_check(self) -> None:
+        argv = build_codex_argv(
+            prompt="P", slice_id="s", log_dir="/lg", read_only=False
+        )
+
+        self.assertNotIn("--skip-git-repo-check", argv)
 
     def test_codex_argv_allow_unsafe_adds_sandbox_bypass(self) -> None:
         # 明確 opt-in allow_unsafe=True 才加入 sandbox bypass flag


### PR DESCRIPTION
## 摘要

- 唯讀 Codex workflow card 保留 read-only sandbox 並略過 disposable checkout 的 git trust check
- builder 與其他可寫入路徑不加入例外
- 補上 launcher regression 與 changelog

## 驗證

- focused regression
- 完整 pytest
- policy check
- OpenSpec validate
- PR-context preflight
