### PR TITLE
fix(planning): 安全重建失敗的 planner sandbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - **deck frontmatter emit 契約與 runtime parser keyset 對齊**：`EMITTED_FRONTMATTER_FIELDS`、deck compile frontmatter 與 `parse_spec_frontmatter()` 現在一致包含 `target_branch` / `verification` / `parse_error`；compile 產生 hold spec 時固定輸出 `null` 欄位，runtime 僅接受 `parse_error: null`（non-null fail-closed），避免 deck contract alignment 漂移。
 
 ### Fixed
+- **失敗的 planner card 可安全重建 disposable sandbox**：retry 只會清理 canonical coordinator boundary 內、名稱精確綁定同一 run/card、且持久化狀態為 failed planner job 的 sandbox；symlink、identity mismatch 或清理不完整仍 fail-closed。
 - **唯讀 workflow planner 可在 disposable checkout 啟動 Codex**：Coordinator launcher 僅對 `read_only` card 加上 `--skip-git-repo-check`，保留 `--sandbox read-only`；builder 路徑仍維持原本的 git trust gate，避免放寬可寫入執行階段。
 - **Active workflow 不再被自己新增的 planning sources supersede**：auto claim 與 explicit resume 會先以穩定 repo/work/issue/OpenSpec identity 找出唯一 ongoing run；accepted superpowers spec/plan 加入 authority 時維持同一 run，由 active workflow 優先，不再建立新 claim。Codex planner 同時在無 `.git` 的 disposable read-only checkout 使用官方 `--skip-git-repo-check`，避免安全 sandbox 被 CLI trust check 誤擋。
 - **`work resume` 現在會真正重入既有 `needs_human` workflow**：claim router 不再把既有 `needs_human` 誤當成只讀結果直接回傳；operator resume 會以同一 claim key 呼叫 canonical starter，讓 define／brainstorm retry 可以在不新建 run 的前提下繼續。

--- a/changelog.d/14-planner-sandbox-retry.md
+++ b/changelog.d/14-planner-sandbox-retry.md
@@ -1,0 +1,2 @@
+### Fixed
+- Planner card 失敗重試時，Manager 會驗證 run/card identity 與 canonical boundary 後重建 disposable sandbox，不再要求人工清除安全的暫存 checkout。

--- a/paulsha_cortex/coordinator/manager.py
+++ b/paulsha_cortex/coordinator/manager.py
@@ -2165,7 +2165,11 @@ def _planner_sandbox_path(job: Mapping[str, object], coordinator_root: str | Pat
     if not isinstance(raw, str) or not raw:
         raise ValueError("planner sandbox path missing")
     path = Path(raw)
-    if not path.is_absolute() or path.is_symlink():
+    if (
+        not path.is_absolute()
+        or path.is_symlink()
+        or path != path.resolve(strict=False)
+    ):
         raise ValueError("planner sandbox path invalid")
     root = Path(coordinator_root).resolve()
     allowed_parents = {
@@ -2175,6 +2179,27 @@ def _planner_sandbox_path(job: Mapping[str, object], coordinator_root: str | Pat
     if path.parent not in allowed_parents or re.fullmatch(r"[0-9a-f]{32}", path.name) is None:
         raise ValueError("planner sandbox path outside coordinator boundary")
     return path
+
+
+def _discard_failed_planner_sandbox(
+    job: Mapping[str, object],
+    *,
+    run_id: str,
+    card: str,
+    coordinator_root: str | Path,
+) -> None:
+    if job.get("persona") != "planner" or job.get("status") != "failed":
+        raise ValueError("planner sandbox retry requires failed planner job")
+    path = _planner_sandbox_path(job, coordinator_root)
+    expected_name = hashlib.sha256(f"{run_id}:{card}".encode()).hexdigest()[:32]
+    if path.name != expected_name:
+        raise ValueError("planner sandbox retry identity mismatch")
+    if path.exists():
+        if not path.is_dir():
+            raise ValueError("planner sandbox retry target is not a directory")
+        shutil.rmtree(path)
+    if path.exists() or path.is_symlink():
+        raise ValueError("planner sandbox retry cleanup incomplete")
 
 
 def terminalize_workflow_job(
@@ -3082,6 +3107,13 @@ def dispatch_workflow_card(
     ]
     if matching and not (retry_failed and matching[-1].get("status") == "failed"):
         return matching[-1]
+    if matching and step.persona == "planner":
+        _discard_failed_planner_sandbox(
+            matching[-1],
+            run_id=run.run_id,
+            card=step.card,
+            coordinator_root=coordinator_root,
+        )
     identity = _select_workflow_identity(run, step, identities)
     launcher = launcher_factory(identity)
     if launcher is None:

--- a/tests/test_workflow_production_wiring.py
+++ b/tests/test_workflow_production_wiring.py
@@ -769,6 +769,76 @@ def test_planner_terminalization_rejects_disposable_sandbox_pollution(tmp_path: 
     assert registry.get_job(job["job_id"])["workflow_evidence"] is None
 
 
+def test_failed_planner_retry_replaces_only_its_disposable_sandbox(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "source.md").write_text("source\n", encoding="utf-8")
+    coordinator_root = tmp_path / "coordinator"
+    registry = JobRegistry(state_path=coordinator_root / "registry.json")
+    run = registry._manager_create_workflow_run(
+        work_id="production-wiring",
+        repo="hamanpaul/paulsha-cortex",
+        claim_key="claim:v1:" + "1" * 64,
+        source_revision="2" * 64,
+        workspace_root=str(repo),
+        combo="feature-oneshot",
+        current_phase="plan",
+        steps=_manifest().steps,
+        issue_refs=("hamanpaul/paulsha-cortex#14",),
+        openspec_refs=("production-wiring",),
+        pr_refs=(),
+        attempts={"plan": 1},
+        gate_status="running",
+    )
+    identities = IdentityRegistry.from_rows(
+        [{
+            "executor": "codex",
+            "model_id": "gpt-primary",
+            "independence_domain": "openai",
+            "capabilities": ["planning"],
+        }]
+    )
+
+    class Launcher:
+        def as_read_only(self):
+            return self
+
+        def launch(self, *, slice_id, prompt, worktree, log_dir):
+            return LaunchHandle(
+                executor="codex",
+                model_id="gpt-primary",
+                session_name=slice_id,
+                pid=100,
+                log_path=str(Path(log_dir) / f"{slice_id}.jsonl"),
+            )
+
+    dispatcher = type("D", (), {"_registry": registry, "_git_runner": None})()
+    first = manager.dispatch_workflow_card(
+        dispatcher,
+        run=run,
+        identities=identities,
+        launcher_factory=lambda _: Launcher(),
+        coordinator_root=coordinator_root,
+    )
+    first_sandbox = Path(first["worktree"])
+    (first_sandbox / "failed-attempt-marker").write_text("stale\n", encoding="utf-8")
+    registry.update_headless_result(first["job_id"], status="failed", exit_code=1)
+
+    retried = manager.dispatch_workflow_card(
+        dispatcher,
+        run=run,
+        identities=identities,
+        launcher_factory=lambda _: Launcher(),
+        coordinator_root=coordinator_root,
+        retry_failed=True,
+    )
+
+    assert retried["job_id"] != first["job_id"]
+    assert Path(retried["worktree"]) == first_sandbox
+    assert not (first_sandbox / "failed-attempt-marker").exists()
+    assert (first_sandbox / "source.md").read_text(encoding="utf-8") == "source\n"
+
+
 def _run(
     *, phase: str, status: str, refs: tuple[GateEvidenceRef, ...],
     brainstorm_required: bool = True,


### PR DESCRIPTION
## 摘要

- failed planner card retry 前驗證 canonical coordinator boundary
- sandbox 名稱必須精確綁定同一 workflow run/card，symlink 與 identity mismatch fail-closed
- 清除後從 workspace baseline 重建 disposable checkout

## 驗證

- failed-attempt retry regression
- planner pollution regression
- 完整 pytest
- policy check
- OpenSpec validate
- PR-context preflight
