### PR TITLE
fix(workflow): 解析 Codex terminal evidence event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - **deck frontmatter emit 契約與 runtime parser keyset 對齊**：`EMITTED_FRONTMATTER_FIELDS`、deck compile frontmatter 與 `parse_spec_frontmatter()` 現在一致包含 `target_branch` / `verification` / `parse_error`；compile 產生 hold spec 時固定輸出 `null` 欄位，runtime 僅接受 `parse_error: null`（non-null fail-closed），避免 deck contract alignment 漂移。
 
 ### Fixed
+- **Workflow terminal evidence 支援真實 Codex JSONL event stream**：Manager 會略過 `turn.completed` 與 tool envelopes，只從 final `item.completed/agent_message` 或帶明確 workflow discriminator 的 payload 解析 JSON；任意 command output 不再可能被誤當 canonical evidence。
 - **失敗的 planner card 可安全重建 disposable sandbox**：retry 只會清理 canonical coordinator boundary 內、名稱精確綁定同一 run/card、且持久化狀態為 failed planner job 的 sandbox；symlink、identity mismatch 或清理不完整仍 fail-closed。
 - **唯讀 workflow planner 可在 disposable checkout 啟動 Codex**：Coordinator launcher 僅對 `read_only` card 加上 `--skip-git-repo-check`，保留 `--sandbox read-only`；builder 路徑仍維持原本的 git trust gate，避免放寬可寫入執行階段。
 - **Active workflow 不再被自己新增的 planning sources supersede**：auto claim 與 explicit resume 會先以穩定 repo/work/issue/OpenSpec identity 找出唯一 ongoing run；accepted superpowers spec/plan 加入 authority 時維持同一 run，由 active workflow 優先，不再建立新 claim。Codex planner 同時在無 `.git` 的 disposable read-only checkout 使用官方 `--skip-git-repo-check`，避免安全 sandbox 被 CLI trust check 誤擋。

--- a/changelog.d/14-workflow-jsonl-evidence.md
+++ b/changelog.d/14-workflow-jsonl-evidence.md
@@ -1,0 +1,2 @@
+### Fixed
+- Manager 現在從 Codex JSONL 的 final agent message 擷取 workflow evidence，並忽略 turn/tool envelopes 與缺少 evidence discriminator 的 JSON。

--- a/paulsha_cortex/coordinator/manager.py
+++ b/paulsha_cortex/coordinator/manager.py
@@ -2022,19 +2022,45 @@ def _extract_terminal_json(log_path: object) -> dict[str, object]:
         if not isinstance(value, dict):
             continue
         nested = value.get("workflow_evidence")
-        if isinstance(nested, dict):
+        if _is_workflow_terminal_payload(nested):
             return nested
+        item = value.get("item")
+        if (
+            value.get("type") == "item.completed"
+            and isinstance(item, dict)
+            and item.get("type") == "agent_message"
+        ):
+            parsed = _parse_terminal_json_text(item.get("text"))
+            if parsed is not None:
+                return parsed
         for key in ("result", "content", "message", "text"):
-            nested = value.get(key)
-            if isinstance(nested, str):
-                try:
-                    parsed = json.loads(nested)
-                except json.JSONDecodeError:
-                    continue
-                if isinstance(parsed, dict):
-                    return parsed
-        return value
+            parsed = _parse_terminal_json_text(value.get(key))
+            if parsed is not None:
+                return parsed
+        if _is_workflow_terminal_payload(value):
+            return value
     raise ValueError("workflow terminal log has no JSON evidence")
+
+
+def _parse_terminal_json_text(value: object) -> dict[str, object] | None:
+    if not isinstance(value, str):
+        return None
+    try:
+        parsed = json.loads(value)
+    except json.JSONDecodeError:
+        return None
+    return parsed if _is_workflow_terminal_payload(parsed) else None
+
+
+def _is_workflow_terminal_payload(value: object) -> bool:
+    return (
+        isinstance(value, dict)
+        and isinstance(value.get("schema_version"), int)
+        and ("status" in value or "state" in value)
+        and "candidate" in value
+        and "outputs" in value
+        and (value.get("kind") == "workflow-card" or "slice_id" in value)
+    )
 
 
 def _canonical_workflow_artifacts(

--- a/tests/test_workflow_production_wiring.py
+++ b/tests/test_workflow_production_wiring.py
@@ -769,6 +769,41 @@ def test_planner_terminalization_rejects_disposable_sandbox_pollution(tmp_path: 
     assert registry.get_job(job["job_id"])["workflow_evidence"] is None
 
 
+def test_terminal_json_uses_codex_final_agent_message_not_turn_envelope(tmp_path: Path) -> None:
+    evidence = {
+        "schema_version": 1,
+        "kind": "workflow-card",
+        "status": "passed",
+        "run_id": "run",
+        "card_id": "card",
+        "candidate": None,
+        "outputs": ["docs/superpowers/plans/work.md"],
+    }
+    log = tmp_path / "codex.jsonl"
+    log.write_text(
+        "\n".join(
+            (
+                json.dumps({
+                    "type": "item.completed",
+                    "item": {
+                        "type": "command_execution",
+                        "aggregated_output": json.dumps({"status": "fake"}),
+                    },
+                }),
+                json.dumps({
+                    "type": "item.completed",
+                    "item": {"type": "agent_message", "text": json.dumps(evidence)},
+                }),
+                json.dumps({"type": "turn.completed", "usage": {"output_tokens": 10}}),
+            )
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    assert manager._extract_terminal_json(str(log)) == evidence
+
+
 def test_failed_planner_retry_replaces_only_its_disposable_sandbox(tmp_path: Path) -> None:
     repo = tmp_path / "repo"
     repo.mkdir()


### PR DESCRIPTION
## 摘要

- 從 Codex JSONL final agent_message 解析 workflow evidence
- 忽略 turn.completed 與 command/tool envelopes
- 只有具 workflow-card、verification 或 review discriminator 的 payload 可進入 canonicalization

## 驗證

- 真實 Codex event ordering regression
- production workflow wiring 與 ship handoff regression
- 完整 pytest
- policy check
- OpenSpec validate
- PR-context preflight
