### PR TITLE
fix(worktree): 安全續用已合併的 issue branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - **deck frontmatter emit 契約與 runtime parser keyset 對齊**：`EMITTED_FRONTMATTER_FIELDS`、deck compile frontmatter 與 `parse_spec_frontmatter()` 現在一致包含 `target_branch` / `verification` / `parse_error`；compile 產生 hold spec 時固定輸出 `null` 欄位，runtime 僅接受 `parse_error: null`（non-null fail-closed），避免 deck contract alignment 漂移。
 
 ### Fixed
+- **Builder worktree 可安全續用已合併的 issue branch**：若目標 local branch 已存在，只有在它是 requested base 的 ancestor 時才 fast-forward 後掛入 worktree；含未合併 commits、已被 checkout 或 ancestry 無法驗證皆 fail-closed，避免 canary bootstrap branch 阻斷正式 workflow build。
 - **Workflow terminal evidence 支援真實 Codex JSONL event stream**：Manager 會略過 `turn.completed` 與 tool envelopes，只從 final `item.completed/agent_message` 或帶明確 workflow discriminator 的 payload 解析 JSON；任意 command output 不再可能被誤當 canonical evidence。
 - **失敗的 planner card 可安全重建 disposable sandbox**：retry 只會清理 canonical coordinator boundary 內、名稱精確綁定同一 run/card、且持久化狀態為 failed planner job 的 sandbox；symlink、identity mismatch 或清理不完整仍 fail-closed。
 - **唯讀 workflow planner 可在 disposable checkout 啟動 Codex**：Coordinator launcher 僅對 `read_only` card 加上 `--skip-git-repo-check`，保留 `--sandbox read-only`；builder 路徑仍維持原本的 git trust gate，避免放寬可寫入執行階段。

--- a/changelog.d/14-worktree-branch-reuse.md
+++ b/changelog.d/14-worktree-branch-reuse.md
@@ -1,0 +1,2 @@
+### Fixed
+- Worktree creator 現在可重掛已完全合併至 base 的既有 issue branch；branch 有獨立 commits 時維持 fail-closed 且不移動 ref。

--- a/paulsha_cortex/coordinator/seams.py
+++ b/paulsha_cortex/coordinator/seams.py
@@ -48,8 +48,9 @@ class TmuxPaneSender:
 class ScriptWorktreeCreator:
     """真實作：鏡射 scripts/using-git-worktrees.sh 的新分支路徑。
 
-    `git -C <repo> worktree add -b <branch> <wt_root>/<slug> <base>`，
-    回傳 target 路徑。單元測試 MUST 注入 fake，不實體化此類。
+    新 branch 使用 `git worktree add -b`；既有 branch 僅在它完全位於 base
+    ancestry 時 fast-forward 後重掛。回傳 target 路徑。單元測試 MUST 注入
+    fake，不實體化此類。
     """
 
     def __init__(
@@ -66,12 +67,63 @@ class ScriptWorktreeCreator:
         slug = branch.replace("/", "-")
         target = self._wt_root / slug
         self._wt_root.mkdir(parents=True, exist_ok=True)
+        base = base_sha or self._base
         try:
-            subprocess.run(
-                ["git", "-C", str(self._repo), "worktree", "add", "-b", branch,
-                 str(target), base_sha or self._base],
-                check=True, capture_output=True,
+            if target.exists() or target.is_symlink():
+                raise ValueError("worktree target already exists")
+            base_probe = subprocess.run(
+                ["git", "-C", str(self._repo), "rev-parse", "--verify", f"{base}^{{commit}}"],
+                check=False,
+                capture_output=True,
             )
+            if base_probe.returncode != 0:
+                raise ValueError(
+                    f"git worktree base invalid: {base_probe.stderr.decode().strip()}"
+                )
+            exact_base = base_probe.stdout.decode().strip()
+            branch_probe = subprocess.run(
+                [
+                    "git", "-C", str(self._repo), "show-ref", "--verify", "--quiet",
+                    f"refs/heads/{branch}",
+                ],
+                check=False,
+                capture_output=True,
+            )
+            if branch_probe.returncode not in {0, 1}:
+                raise ValueError(
+                    f"git branch probe failed: {branch_probe.stderr.decode().strip()}"
+                )
+            if branch_probe.returncode == 0:
+                ancestor = subprocess.run(
+                    [
+                        "git", "-C", str(self._repo), "merge-base", "--is-ancestor",
+                        branch, exact_base,
+                    ],
+                    check=False,
+                    capture_output=True,
+                )
+                if ancestor.returncode == 1:
+                    raise ValueError("existing worktree branch has commits outside requested base")
+                if ancestor.returncode != 0:
+                    raise ValueError(
+                        f"git branch ancestry check failed: {ancestor.stderr.decode().strip()}"
+                    )
+                subprocess.run(
+                    ["git", "-C", str(self._repo), "branch", "-f", branch, exact_base],
+                    check=True,
+                    capture_output=True,
+                )
+                argv = [
+                    "git", "-C", str(self._repo), "worktree", "add", str(target), branch,
+                ]
+            else:
+                argv = [
+                    "git", "-C", str(self._repo), "worktree", "add", "-b", branch,
+                    str(target), exact_base,
+                ]
+            subprocess.run(argv, check=True, capture_output=True)
+        except ValueError:
+            raise
         except subprocess.CalledProcessError as exc:
             raise ValueError(f"git worktree add failed: {exc.stderr.decode().strip()}") from exc
         except FileNotFoundError as exc:

--- a/tests/test_coordinator_seams.py
+++ b/tests/test_coordinator_seams.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from paulsha_cortex.coordinator.seams import ScriptWorktreeCreator
+
+
+def _git(repo: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+def _repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(
+        ["git", "-C", str(repo), "init", "-b", "main"],
+        check=True,
+        capture_output=True,
+    )
+    _git(repo, "config", "user.email", "test@example.invalid")
+    _git(repo, "config", "user.name", "Test")
+    (repo / "tracked.txt").write_text("one\n", encoding="utf-8")
+    _git(repo, "add", "tracked.txt")
+    _git(repo, "commit", "-m", "initial")
+    return repo
+
+
+def test_worktree_creator_reuses_existing_branch_only_when_it_is_base_ancestor(
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+    branch = "feature/31-terminal-lifecycle-canary"
+    _git(repo, "branch", branch)
+    (repo / "tracked.txt").write_text("two\n", encoding="utf-8")
+    _git(repo, "commit", "-am", "main advances")
+    expected = _git(repo, "rev-parse", "main")
+
+    target = Path(
+        ScriptWorktreeCreator(repo=repo, wt_root=tmp_path / "worktrees").create(branch)
+    )
+
+    assert _git(repo, "rev-parse", branch) == expected
+    assert _git(target, "rev-parse", "HEAD") == expected
+    assert _git(target, "branch", "--show-current") == branch
+
+
+def test_worktree_creator_rejects_diverged_existing_branch_without_moving_it(
+    tmp_path: Path,
+) -> None:
+    repo = _repo(tmp_path)
+    branch = "feature/31-terminal-lifecycle-canary"
+    _git(repo, "switch", "-c", branch)
+    (repo / "feature.txt").write_text("feature\n", encoding="utf-8")
+    _git(repo, "add", "feature.txt")
+    _git(repo, "commit", "-m", "feature only")
+    branch_head = _git(repo, "rev-parse", "HEAD")
+    _git(repo, "switch", "main")
+    (repo / "main.txt").write_text("main\n", encoding="utf-8")
+    _git(repo, "add", "main.txt")
+    _git(repo, "commit", "-m", "main only")
+
+    with pytest.raises(ValueError, match="commits outside requested base"):
+        ScriptWorktreeCreator(repo=repo, wt_root=tmp_path / "worktrees").create(branch)
+
+    assert _git(repo, "rev-parse", branch) == branch_head
+    assert not (tmp_path / "worktrees" / "feature-31-terminal-lifecycle-canary").exists()


### PR DESCRIPTION
## 摘要

- 既有 local issue branch 必須是 requested base ancestor 才可重掛
- 驗證通過後 fast-forward 至 base，再建立 builder worktree
- diverged、checked-out 或 ancestry error 全部 fail-closed

## 驗證

- merged branch reuse integration test
- diverged branch negative regression
- 完整 pytest
- policy check
- OpenSpec validate
- PR-context preflight
