### PR TITLE
fix(workflow): 補齊 canary handoff 與 review authority 契約

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ cortex slice-action "$SLICE_ID" abandon      --actor operator
 
 `fanout`、`tick`、`complete`、`slice-action` 與 `work` 都會寫入 control request queue，再由 daemon / manager 這個單一 writer 改變狀態；daemon 未啟動時會明確拒絕，不會由 CLI 直接競寫 registry。
 
-Work lifecycle mutation 使用 `cortex work <link|unlink|start|resume|auto|ship> <work-id> --repo <owner/repo>`。`link` / `unlink` 以 `--kind <github_issue|github_pr|openspec|path> --ref <canonical-ref>` 指定來源，`--issue N` 僅保留一個 release 的相容入口，兩者不得混用；一般 link/start/resume 由 installer/Monitor registry 解析 trusted repo root，只有 `ship` 的 exact evidence refs 等進階欄位由 `--payload <json>` 傳入。CLI 只排隊，confirmed Todo/issue authority、GitHub label、official OpenSpec archive、preflight、current-HEAD review、merge 與 remote closure 都由 Manager 驗證及執行。
+Work lifecycle mutation 使用 `cortex work <link|unlink|start|resume|auto|review-attest|ship> <work-id> --repo <owner/repo>`。`link` / `unlink` 以 `--kind <github_issue|github_pr|openspec|path> --ref <canonical-ref>` 指定來源，`--issue N` 僅保留一個 release 的相容入口，兩者不得混用；一般 link/start/resume 由 installer/Monitor registry 解析 trusted repo root，只有 `review-attest` 的review摘要與 `ship` 的 exact evidence refs 等進階欄位由 `--payload <json>` 傳入。CLI 只排隊，confirmed Todo/issue authority、GitHub label、official OpenSpec archive、preflight、current-HEAD review、merge 與 remote closure 都由 Manager 驗證及執行。
 
 Manager periodic tick 會從 durable Monitor snapshot 執行 auto-claim scan；它會讀取 work item 的全部 mapped issues，任一張帶 `cortex:auto-on-going` 即符合 label 條件，但任一 GitHub API read 失敗會讓整個 claim fail-closed。`cortex work auto ... --enable|--disable` 未指定 legacy `--issue` 時會對全部 mapped issues 套用相同 label mutation；任一 mutation 失敗時整個 action 報錯。缺 issue 的 confirmed Todo 會持久化為 `needs_human: missing_issue`，待 operator link 且 Monitor snapshot 更新後才能 resume。Run 的 claim key 綁定該 work item 的 canonical semantic authority（provider/source revisions 與 confirmed refs），不綁 whole-fleet snapshot hash；只有 sequence、written-at 或其他 repo 噪音的 snapshot refresh 會原 run resume 並更新 provenance，語意來源變更才建立新 run。
 
@@ -235,14 +235,16 @@ Merge authorization 只雜湊 stable preflight 結果（argv、return code、HEA
 
 ### 5. 由 Manager 完成交付
 
-Work Item workflow 通過 build、deterministic verification 與 foreign review 後，由 Manager 依序 archive OpenSpec、跑 policy/pinned preflight、建立或更新 PR、要求 current-HEAD Copilot review，再重讀 checks、threads、closing refs 與 mergeability。只有全部 gate 對同一 HEAD 成立時才執行 merge commit；任何 stale provider、HEAD race、舊 review、partial closure 或第三輪 finding 都停在 `needs_human`。
+Work Item workflow 通過 build、deterministic verification 與 foreign review 後，由 Manager 依序 archive OpenSpec、跑 policy/pinned preflight、建立或更新 PR，再要求恰好一種current-HEAD delivery review：authenticated Copilot review，或透過`review-attest`建立的immutable maintainer evidence。Manager接著重讀checks、threads、closing refs與mergeability；只有全部gate對同一HEAD成立時才執行merge commit。Maintainer evidence保留`maintainer-review` kind，絕不偽裝成Copilot。
+
+Headless build card會在dispatch前解析declared inputs。Accepted planning artifact只接受WorkflowRun planning authority的ref/hash；獨立builder worktree缺檔時由Manager原子seed。Job、versioned bounded prompt與canonical evidence保存同一份input snapshot，terminalize再驗hash。Dead job轉`needs_human`後periodic runner不會自動重派，必須由operator明確執行`work resume`。
 
 Merge 後 Manager 會重新 fetch default branch，驗證雙親 merge commit ancestry、issue closed、active OpenSpec 消失、archive/Todo/CompletionRecord 成立。部分完成不會提早標 `done`。
 
 ### 目前邊界
 
 - 沒有 Web UI；任務意圖仍以 Markdown spec 維護。
-- Copilot finding 只允許兩輪 bounded fix/re-review；超過預算需由 operator recovery。
+- Copilot finding 只允許兩輪 bounded fix/re-review；超過預算需由 operator recovery。Maintainer路徑仍要求ForeignReview、terminal-green checks與resolved/outdated threads。
 - verification 的 sanitized env 不等於 network / filesystem sandbox。
 - v1 自動 foreign review 限 `tier: shareable`。
 - merge commit 是目前受支援路徑；auto/squash/rebase/cherry-pick 會 fail-closed。
@@ -325,8 +327,8 @@ identities:
 - v1 只支援 preserving-commit 路徑：Candidate 必須是 `refs/remotes/<remote>/<target_branch>` 的 ancestor；squash/cherry-pick 視為不支援（保持 blocked 或 needs_human）。
 - 同一 dependency chain 必須使用同一 target branch，否則 fail-closed。
 - completion ordering 固定為「先 atomic 寫 CompletionRecord，再 atomic 標 Slice `completed`」。
-- work delivery CompletionRecord 另綁定 repo/work/run ID、workflow step IDs、Monitor snapshot/provider/source revisions、mapped issues、PR/OpenSpec/Todo refs、merge commit，以及 trusted preflight/Copilot/ForeignReview/merge-authorization refs；cached done 每次仍會重新讀取 fresh authority 與 remote closure。
-- merge 前 Manager 會先以 atomic no-clobber+fsync 寫入唯讀 `merge-authorized` evidence file（authority digest、HEAD/tree、Copilot epoch/review ID、ForeignReview/preflight/checks hashes），再把 path/hash 綁回 run state。Crash replay 只接受 exact record；未經 Manager authorization 的 external merge 會進入 `needs_human`，不會直接閉合。
+- work delivery CompletionRecord 另綁定 repo/work/run ID、workflow step IDs、Monitor snapshot/provider/source revisions、mapped issues、PR/OpenSpec/Todo refs、merge commit，以及 trusted preflight/current-HEAD delivery review/ForeignReview/merge-authorization refs；cached done 每次仍會重新讀取 fresh authority 與 remote closure。
+- merge 前 Manager 會先以 atomic no-clobber+fsync 寫入唯讀 `merge-authorized` evidence file（authority digest、HEAD/tree、實際review kind/ref/hash、ForeignReview/preflight/checks hashes），再把 path/hash 綁回 run state。Crash replay 只接受 exact record；未經 Manager authorization 的 external merge 會進入 `needs_human`，不會直接閉合。
 - crash window（record 已寫、slice 尚未 completed）在 restart 後只會補完符合當前 target ancestry 的紀錄；不符合則維持 blocked。
 - 舊版無 `schema_version` / legacy `done` state 需先 clean-start（archive/remove 舊 `jobs.json`），不做 silent migration。
 
@@ -337,7 +339,13 @@ cortex slice-action "$SLICE_ID" retry-build  --actor "$ACTOR"
 cortex slice-action "$SLICE_ID" retry-verify --actor "$ACTOR"
 cortex slice-action "$SLICE_ID" retry-review --actor "$ACTOR"
 cortex slice-action "$SLICE_ID" abandon      --actor "$ACTOR"
+
+# PR已建立且foreign review綁定current HEAD後，建立typed maintainer evidence：
+cortex work review-attest "$WORK_ID" --repo "$REPO" --actor "$ACTOR" \
+  --payload review-attest.json
 ```
+
+`review-attest.json`只接受`{"verdict":"approved","summary":"...","findings":[]}`；path/hash由Manager生成，caller不得注入。Manager會重讀authenticated PR HEAD並將evidence綁定repo/work/run/authority/PR/candidate/actor。
 
 - `slice-action` 一律透過 control request queue，由 daemon/manager 單一 writer 消費。
 - status snapshot 會一次列出所有 `needs_human` 事項（`attention`），包含 reason、evidence refs、ancestry 摘要與 `next_actions`，不需逐筆互動追問。
@@ -361,14 +369,14 @@ cortex slice-action "$SLICE_ID" abandon      --actor "$ACTOR"
 | control root | `~/.agents/control` | `PSC_CONTROL_ROOT` |
 | coordinator root | `~/.agents/coordinator` | `PSC_COORDINATOR_ROOT` |
 | specs root | `~/.agents/specs` | `PSC_SPECS_ROOT` |
-| run root | CLI 預設 `~/.agents/run`；installed instance 為 `~/.agents/run/<instance>` | `PSC_RUN_ROOT` |
+| run root | 依 `PSC_INSTANCE`（預設`cortex`）讀installer env；未安裝時為`~/.agents/run/<instance>` | `PSC_RUN_ROOT`（最高優先） |
 | monitor state root | `~/.agents/monitor` | `PSC_MONITOR_STATE_ROOT` |
 | config root | `~/.config/paulshaclaw` | `PSC_CONFIG_ROOT` |
 | project config root | `~/.agents/config/paulsha` | `PSC_PROJECT_CONFIG_ROOT` |
 | repo root | 目前工作目錄 | `PSC_REPO_ROOT` |
 | worktree root | `<repo>-worktrees` sibling | `PSC_WORKTREE_ROOT` |
 
-共同前綴 `PSC_AGENTS_ROOT` 可一次覆寫 mutable/runtime roots。systemd unit 依宣告順序讀取 `~/.agents/core/runtime/<instance>.env` 與固定 bootstrap `~/.agents/core/runtime/<instance>-manager.env`；後者會持久化 `PSC_AGENTS_ROOT`，再將 runtime 導向 override。installer 重跑會更新自身管理的 Python/repo 值，但保留既有 operator `PSC_AGENTS_ROOT`、`PSC_RUN_ROOT`、`PSC_MONITOR_STATE_ROOT` 與 `PSC_PROJECT_CONFIG_ROOT`。Monitor socket 預設為 `$PSC_RUN_ROOT/project-monitor.sock`，也可由 `project-cortex.yaml` 的 `monitor.socket_path` 覆寫；live doctor 會透過 production `MonitorSocketClient` 執行 `list_work_items` 並驗證 `cortex-work/v1`，單純 Unix socket 可連線不算 ready。
+共同前綴 `PSC_AGENTS_ROOT` 可一次覆寫 mutable/runtime roots。systemd unit 依宣告順序讀取 `~/.agents/core/runtime/<instance>.env` 與固定 bootstrap `~/.agents/core/runtime/<instance>-manager.env`；installer在後者持久化`PSC_INSTANCE`與`PSC_AGENTS_ROOT`。Interactive CLI以同一`PSC_INSTANCE`選取bootstrap env，不掃描猜測其他instance；symlink、malformed或relative root會fail-closed。installer重跑會更新自身管理的Python/repo值，但保留既有operator roots。Monitor socket預設為`$PSC_RUN_ROOT/project-monitor.sock`，也可由`project-cortex.yaml`的`monitor.socket_path`覆寫；production `MonitorSocketClient`與service使用相同config解析。
 
 ## 誠實狀態表
 

--- a/changelog.d/14-handoff-contracts.md
+++ b/changelog.d/14-handoff-contracts.md
@@ -1,0 +1,4 @@
+- 修正 unified lifecycle handoff trust chain：declared workflow inputs 會在 dispatch 前解析、hash 綁定、必要時由 planning authority seed 到 builder worktree，並以版本化 bounded prompt 傳遞 card action、commit/test policy 與 terminal schema。
+- Dead headless job 進入 `needs_human` 後，periodic runner 不再自動清除 facet 或重派；只有 control queue 的明確 resume 可重試同一 run/card。
+- 新增 immutable exact-HEAD `cortex work review-attest` authority；delivery 保留實際 `maintainer-review` kind/ref/hash，與 Copilot 二選一且不弱化 ForeignReview、checks、threads、archive 或 closure gates。
+- Interactive runtime 依 `PSC_INSTANCE` 讀取 installer bootstrap env，與 systemd service 共用 instance-scoped `PSC_RUN_ROOT`；Monitor client也尊重production socket config。

--- a/changelog.d/14-handoff-contracts.md
+++ b/changelog.d/14-handoff-contracts.md
@@ -1,4 +1,4 @@
 - 修正 unified lifecycle handoff trust chain：declared workflow inputs 會在 dispatch 前解析、hash 綁定、必要時由 planning authority seed 到 builder worktree，並以版本化 bounded prompt 傳遞 card action、commit/test policy 與 terminal schema。
 - Dead headless job 進入 `needs_human` 後，periodic runner 不再自動清除 facet 或重派；只有 control queue 的明確 resume 可重試同一 run/card。
 - 新增 immutable exact-HEAD `cortex work review-attest` authority；delivery 保留實際 `maintainer-review` kind/ref/hash，與 Copilot 二選一且不弱化 ForeignReview、checks、threads、archive 或 closure gates。
-- Interactive runtime 依 `PSC_INSTANCE` 讀取 installer bootstrap env，與 systemd service 共用 instance-scoped `PSC_RUN_ROOT`；Monitor client也尊重production socket config。
+- Interactive runtime 依 `PSC_INSTANCE` 讀取 installer bootstrap env，與 systemd service 共用 control/coordinator/specs/run/monitor/project-config roots；Monitor client尊重production socket config，且symlink bootstrap fail-closed。

--- a/docs/adr/0001-unified-work-lifecycle-authority.md
+++ b/docs/adr/0001-unified-work-lifecycle-authority.md
@@ -61,9 +61,9 @@ Manager在launch前解析declared inputs，accepted planning artifact只接受Wo
 
 Dead job被reconcile成`needs_human`後，periodic runner不得自動重派；只有queued explicit resume可重試。ForeignReview之後的delivery review是`copilot | maintainer-review` typed union；maintainer attestation由Manager重讀PR HEAD後寫immutable exact-HEAD evidence，merge authorization v2保留實際kind/ref/hash，禁止偽裝Copilot。
 
-### 9. Runtime root依instance明確選擇
+### 9. Runtime roots依instance明確選擇
 
-Process `PSC_RUN_ROOT`最高優先；否則interactive CLI按`PSC_INSTANCE`讀installer bootstrap env，缺檔才使用`$PSC_AGENTS_ROOT/run/<instance>`。不掃描猜測多instance，malformed/symlink/relative env fail-closed；Monitor client使用production config socket path。
+Process specific `PSC_*_ROOT`最高優先，其次是可一次覆寫derived roots的process `PSC_AGENTS_ROOT`；兩者皆無時interactive CLI才按`PSC_INSTANCE`讀installer bootstrap env，讓control/coordinator/specs/run/monitor/project-config roots與service一致，缺檔則從`$HOME/.agents`推導。不掃描猜測多instance，malformed/symlink/relative env fail-closed，installer也拒絕覆寫symlink bootstrap；Monitor client使用production config socket path。
 
 ## Alternatives considered
 

--- a/docs/adr/0001-unified-work-lifecycle-authority.md
+++ b/docs/adr/0001-unified-work-lifecycle-authority.md
@@ -43,15 +43,27 @@ Completeness gate 在 accepted spec/design/plan 缺失、出現 TBD 或未決策
 
 ### 5. Delivery 是 bounded、current-HEAD、remote-verified closure
 
-Builder 使用 `feature/<issue>-<slug>` worktree；deterministic verification 與 foreign exact-HEAD review 沿用既有 Candidate/evidence gate。Brainstorm peer 與 foreign reviewer 是不同 gate，Copilot review也不能替代 foreign reviewer。
+Builder 使用 `feature/<issue>-<slug>` worktree；deterministic verification 與 foreign exact-HEAD review 沿用既有 Candidate/evidence gate。Brainstorm peer 與 foreign reviewer 是不同 gate；後續typed current-HEAD delivery review（Copilot或maintainer）也不能替代 foreign reviewer。
 
-Ship 由 Manager 執行：官方 `openspec archive -y`、tasks/spec/docs/changelog 檢查、zh-TW PR metadata、快速 policy、`PSC_PREFLIGHT_CMD` CI-parity preflight、GitHub checks、current-HEAD Copilot review、resolved/outdated threads、final HEAD race check、`gh pr merge --merge`。每次 push 重請 Copilot；最多兩輪 fix/re-review，每 HEAD 等 15 分鐘；逾限轉 needs_human。
+Ship 由 Manager 執行：官方 `openspec archive -y`、tasks/spec/docs/changelog 檢查、zh-TW PR metadata、快速 policy、`PSC_PREFLIGHT_CMD` CI-parity preflight、GitHub checks、typed current-HEAD delivery review、resolved/outdated threads、final HEAD race check、`gh pr merge --merge`。Copilot路徑每次push重請review且最多兩輪fix/re-review、每HEAD等15分鐘；maintainer路徑由Manager寫exact-HEAD immutable attestation。逾限或任一authority drift轉needs_human。
 
 Merge 後 fetch default branch，確認 merge ancestry、issues closed、active OpenSpec 消失、remote archive 存在、Todo tasks 完成，再寫 CompletionRecord。只有全部成立才投影 done。
 
 ### 6. 公開 contract versioned，舊 ProjectState 暫時相容
 
 CLI JSON schema URI 固定為 `cortex-work/v1`；WorkItem/WorkSource 欄位、排序、`on-going` spelling 與 explain trace 依 `CONTEXT.md` 定義。Monitor socket新增 `list_work_items`、`get_work_item`、`explain_work_item` 與 work subscription；既有 ProjectState request/response 保留一個 release cycle並標 deprecated。
+
+### 7. Planning artifact以hash-bound input snapshot交給builder
+
+Manager在launch前解析declared inputs，accepted planning artifact只接受WorkflowRun authority中的ref/hash。獨立builder worktree缺檔時由Manager原子seed；Job、prompt、terminal evidence保存相同input snapshot，terminalize再次驗hash。Prompt同時保存card skill/action/commit/test policy與exact terminal schema。Legacy pending card可繼承同phase inputs，但passed card不回填新gate。
+
+### 8. Human stop與delivery review都使用typed Manager authority
+
+Dead job被reconcile成`needs_human`後，periodic runner不得自動重派；只有queued explicit resume可重試。ForeignReview之後的delivery review是`copilot | maintainer-review` typed union；maintainer attestation由Manager重讀PR HEAD後寫immutable exact-HEAD evidence，merge authorization v2保留實際kind/ref/hash，禁止偽裝Copilot。
+
+### 9. Runtime root依instance明確選擇
+
+Process `PSC_RUN_ROOT`最高優先；否則interactive CLI按`PSC_INSTANCE`讀installer bootstrap env，缺檔才使用`$PSC_AGENTS_ROOT/run/<instance>`。不掃描猜測多instance，malformed/symlink/relative env fail-closed；Monitor client使用production config socket path。
 
 ## Alternatives considered
 

--- a/docs/handoffs/2026-07-18-unified-work-lifecycle.md
+++ b/docs/handoffs/2026-07-18-unified-work-lifecycle.md
@@ -1,0 +1,107 @@
+# Unified Work Lifecycle implementation handoff
+
+日期：2026-07-18（Asia/Taipei）
+
+## 停止邊界
+
+本輪已把 unified lifecycle 的主要 runtime、Monitor read model、persona workflow 與 delivery gate 分階段合併至 `main`，並以 issue #31 跑到 live canary 的 `build` phase。因後續設計可能調整，工作刻意停在 `worktree-isolation` 已通過、`tdd-red` 尚未完成的邊界；沒有建立 canary PR、沒有 archive canary OpenSpec、沒有 merge 或宣告 done。
+
+目前 `main` 為 `01431972a24aeb73f4e87967051787fd0c664b88`（PR #36 merge commit）。本 handoff 與 Manager 產生的三份 accepted planning artifacts 保存於 local branch `feature/14-unified-lifecycle-handoff`。
+
+## 已落地範圍
+
+- Monitor 已有跨 repo WorkItem source provider、durable last-good snapshot、confirmed/inferred correlation、四態 lifecycle reducer、degraded freeze、strict closure、list/get/explain socket 與 CLI read surface。
+- Manager 已是 work mutation 與 workflow registry 的單一 writer；支援 manual/label claim、active-run resume、persona-preserving manifest、heterogeneous planning、disposable read-only planner、builder/verify/review phase spine 與 delivery gates。
+- Registry 已升級 schema v2，保留 v1 legacy records；workflow step 保存 persona、executor/model/domain、inputs/outputs 與 evidence。
+- Delivery automation 已有 exact-tree preflight、ForeignReview、current-HEAD GitHub review/check/thread gate、merge-commit與 CompletionRecord/remote closure 驗證。
+- `agy`/Google 異質 brainstorm 已在 live run 成功，沒有使用 unsafe permission bypass 或全域 permission rule。
+- README、CLI help、doctor、migration、ADR、glossary、OpenSpec 與 superpowers plan 已同步到目前實作。
+
+主要已合併 PR：
+
+- #17 / #18：persona/delivery foundation 與 Monitor truth model。
+- #19：GitHub pagination 相容修正。
+- #21 / #28 / #32：三次隔離 canary bootstrap。
+- #22–#26、#29–#30：provider freshness、authority、resume、headless brainstorm 與 active-run continuity。
+- #33：唯讀 workflow planner 的 disposable checkout trust gate。
+- #34：failed planner sandbox 的 bounded retry reconciliation。
+- #35：真實 Codex JSONL terminal evidence parser。
+- #36：已合併 issue branch 的安全 builder worktree reuse。
+
+## Live canary exact state
+
+| 欄位 | 現值 |
+|---|---|
+| Issue | `hamanpaul/paulsha-cortex#31`，OPEN，已移除 `cortex:auto-on-going` |
+| Work ID | `terminal-lifecycle-canary` |
+| WorkflowRun | `workflow-ed15cd16ffa5e2c26306` |
+| Lifecycle | `ongoing` |
+| Current phase | `build` |
+| Passed cards | claim、brainstorming、openspec-propose、writing-plans、worktree-isolation |
+| Pending card | `tdd-red` |
+| Builder job | `wf-3fa5c69448-tdd-red-5`，registry 仍為 `dispatched`，process 已停止，沒有 exit sentinel/evidence |
+| Builder worktree | `$HOME/prj_pri/paulsha-cortex-worktrees/feature-31-terminal-lifecycle-canary` |
+| Builder worktree state | clean；HEAD `01431972...`；local branch 相對舊 remote branch ahead 9 |
+| Active OpenSpec | `terminal-lifecycle-canary`，0/3 tasks，未 archive |
+| PR / merge | 無 |
+
+`worktree-isolation` 的 canonical evidence 已綁定 candidate `01431972...`。停止 Manager 時，`tdd-red` 只建立了 Codex JSONL 開頭，沒有產生工作樹 diff、commit 或可接受 terminal evidence。
+
+## Pause controls
+
+為避免 active workflow 在沒有 auto label 時仍被 periodic resume：
+
+- `cortex:auto-on-going` 已從 issue #31 移除。
+- `cortex-manager.timer` 已 `disable --now`。
+- `cortex-manager.service` 為 inactive。
+- `cortex-monitor.service` 仍 active/enabled，read model 可繼續觀察。
+
+不要在完成下方設計討論與 orphan job reconciliation 前重新 enable/start Manager。移除 auto label 按既有契約不會取消 active workflow，所以單獨加回 timer 會繼續推進。
+
+## Durable planning 與 evidence
+
+Manager 已產生並驗證下列 accepted artifacts，本 branch 將它們納入版本控制：
+
+- `docs/superpowers/specs/terminal-lifecycle-canary-spec.md`
+- `docs/superpowers/specs/terminal-lifecycle-canary-design.md`
+- `docs/superpowers/plans/terminal-lifecycle-canary.md`
+
+Runtime evidence 位於 operator state（不進 git）：
+
+- Brainstorm：`$HOME/.agents/coordinator/evidence/planning/brainstorm-4ea700d6c243c60c603e1ae6a18d7c25.json`，SHA-256 `a859922a1ec8bf444473c27f61f158e558d7ee34f351d52165be2cdc272cc7ce`。
+- Plan card：`$HOME/.agents/coordinator/evidence/workflow/f9dc691031a1ecc607547932910b0e670b44bdb2cc861f8046c992f760281cdb.json`，SHA-256 `7420b537385ce055f2d971882b2caeb4d88ca1155950e3c52c3ef2f98689ee51`。
+- Worktree isolation：`$HOME/.agents/coordinator/evidence/workflow/15e13a900506bf59d355cb80ee80f8775dbf2a087a0df66fe370b814dcfeaece.json`，SHA-256 `cbd56d11eee097dcf1f0ee2a464dab4feeb7d04811b44ba21c3bd230e1c504ab`。
+- Canonical registry：`$HOME/.agents/coordinator/jobs.json`。
+
+## Canary history
+
+- Issue #20 / `docs-only-lifecycle-canary`：揭露 systemd PATH、test isolation、resume 與 runtime routing 問題；沒有 candidate/PR/merge，issue 仍 OPEN，active OpenSpec 仍在。
+- Issue #27 / `docs-only-lifecycle-canary-v2`：成功產生 brainstorm artifacts，之後揭露 planning source churn 與 Codex git trust 問題；沒有 candidate/PR/merge，issue 仍 OPEN，active OpenSpec 仍在。
+- Issue #31 / `terminal-lifecycle-canary`：確認異質 brainstorm、same-run resume、planner retry、真實 terminal parser 與 builder branch reuse；目前停在 build boundary。
+
+上述三個 canary 不得被宣稱完成；舊 active OpenSpec 與 issue 的清理方式要在設計討論後決定，不能直接偽造 archive/closure。
+
+## 尚未解決、需要重新討論的設計
+
+1. **Planning artifact handoff 到 builder**：brainstorm artifacts 原先發佈為 operator checkout 的 untracked files，builder worktree 由 committed `main` 建立，因此看不到 accepted plan。`worktree-isolation` agent 已觀察到 input glob 缺失但仍回 passed。應決定由 Manager 建立 planning commit、以 hash-bound copy seed worktree，或採其他 immutable handoff；目前只持久化 `workflow_inputs` 字串不足以證明 input 存在。
+2. **Card prompt 契約太薄**：builder prompt 只有 phase/card/inputs/outputs/candidate，沒有 bounded source material、task-specific action、commit/test要求或 exact output schema說明。真實 agent 會自行搜尋 repo/skills，成本高且可能越過 card intent。
+3. **Input gate**：terminalizer 驗 outputs/candidate，但 dispatch/terminalization 未機械驗證 declared input glob 已命中且 hash 與 planning authority一致。worktree-isolation 因此可在缺 plan 時 passed。
+4. **Interrupted job reconciliation**：`wf-3fa5c69448-tdd-red-5` 為 `dispatched`、PID 已死、無 sentinel。必須透過 Manager/operator action 正式轉為 failed/needs_human 或 retry；不要直接修改 `jobs.json`。
+5. **Self-review delivery seam**：使用者已明確要求由 maintainer exact-HEAD 自我審查以縮短迴圈，但 production ship validator 的 current-HEAD review authority仍以 Copilot gate 為主。若要支援 maintainer override，應是明確、可審計、repo/run scoped 的 evidence type，不能偽造 Copilot review或全域弱化 gate。
+6. **Service/run-root 一致性**：service 使用 `PSC_RUN_ROOT=$HOME/.agents/run/cortex`，interactive CLI 預設 socket/run root 曾落到 `$HOME/.agents/run`；需統一 discovery 或 installer contract。
+7. **Deployment observation scope**：`$HOME/.agents/config/paulsha/project-cortex.yaml` 目前為 canary 而只觀察 `paulsha-cortex`（大量 `ignore_dirs`）。何時恢復 fleet、是否先 read-only rollout，要重新確認。
+8. **Terminal cleanup**：`unified-work-lifecycle` 尚有 30/33 tasks；issue #14、#12、#20、#27、#31 都仍 OPEN。只有真正完成的 task 可勾選，issue #12 不得因本批工作被虛假關閉。
+
+## 建議的安全續作順序
+
+1. 保持 Manager timer disabled，先讀本 handoff、三份 accepted planning artifacts、run/job registry 與 builder worktree。
+2. 先決定 planning artifact handoff、input gate、prompt envelope 與 maintainer-review evidence 四個契約；必要時更新 ADR/OpenSpec/superpowers plan。
+3. 用測試重現「accepted plan 只在 operator overlay、builder worktree 缺 input」以及「dead dispatched job 無 sentinel」；實作 fail-closed reconciliation。
+4. 透過正式 Manager action處理 orphan `tdd-red` job，確認同一 run 繼續，不能另建 workflow 或直接編 registry。
+5. 重新跑 `python3 -m policy_check --repo .`、`openspec validate --all` 與 configured CI-parity preflight。
+6. 只有在 exact state 驗證後才重新 `systemctl --user enable --now cortex-manager.timer`；是否加回 issue #31 auto label另行決定，active run resume 本身不需要 label。
+7. 完成 canary 前不得 archive、merge、close issue 或投影 done；完成後再處理舊 canary與 fleet Monitor restoration。
+
+## 最近驗證基線
+
+PR #36 exact HEAD `07d0ef4b1bac20934eafe6bee46024be5f6ef28f` 已做 maintainer self-review，GitHub 3 checks terminal-green、0 review threads；PR-context preflight為：policy 0 fail、OpenSpec 6/6、pytest `955 passed, 21 subtests passed`。這是 code baseline，不是 canary terminal completion evidence。

--- a/docs/superpowers/plans/terminal-lifecycle-canary.md
+++ b/docs/superpowers/plans/terminal-lifecycle-canary.md
@@ -1,0 +1,32 @@
+---
+status: accepted
+work_item: terminal-lifecycle-canary
+---
+
+# Terminal Lifecycle Canary Plan
+
+## Tasks
+
+### 1. Document the terminal lifecycle canary
+
+- [ ] Update `docs/unified-work-lifecycle.md` with issue #31 and the confirmed `terminal-lifecycle-canary` mapping.
+- [ ] Record persona-domain separation and the heterogeneous brainstorm requirement.
+- [ ] Record the docs-only build path, verification gates, and fail-closed `needs_human` behavior.
+- [ ] Record terminal closure through archive, merge-commit delivery, issue closure, and done projection.
+
+### 2. Validate the change
+
+- [ ] Verify that the resulting diff remains within the authorized documentation and OpenSpec scope.
+- [ ] Run OpenSpec validation successfully.
+- [ ] Run the repository policy checks successfully.
+- [ ] Run the full preflight successfully.
+- [ ] Complete ForeignReview successfully.
+- [ ] Obtain an adversarial maintainer review of the exact current HEAD.
+
+### 3. Deliver and close
+
+- [ ] Archive the `terminal-lifecycle-canary` OpenSpec change through the official archive flow.
+- [ ] Deliver the accepted change using a merge commit.
+- [ ] Close issue #31 through the delivered merge.
+- [ ] Verify that the completed work is projected as done.
+- [ ] If any required output or gate fails, retain `needs_human` and do not claim completion.

--- a/docs/superpowers/specs/terminal-lifecycle-canary-design.md
+++ b/docs/superpowers/specs/terminal-lifecycle-canary-design.md
@@ -1,0 +1,34 @@
+---
+status: accepted
+work_item: terminal-lifecycle-canary
+---
+
+# Terminal Lifecycle Canary Design
+
+## Decisions
+
+### Repo-local authority
+
+Use a repo-local override that maps issue #31 to a new active, confirmed OpenSpec work item named `terminal-lifecycle-canary`. Do not modify the Manager registry directly or extend automatic labeling to other repositories.
+
+### Isolated canary identity
+
+Use a new issue, work ID, and OpenSpec change so that the canary remains isolated from previous lifecycle runs and their test isolation, resume-routing, active-run source-churn, and disposable-planner activation concerns.
+
+### Planning authority
+
+The initial change intentionally has no accepted superpowers plan. The completeness gate must run a heterogeneous `agy`/Google brainstorm, after which the primary planner integrates the evidence and publishes the accepted specification, design, and plan.
+
+### Verification sequence
+
+The canary verifies automatic claim, heterogeneous brainstorming, docs-only build, ForeignReview, archive, preflight, exact-current-HEAD maintainer adversarial review, merge-commit delivery, and done projection.
+
+The maintainer review must target the exact HEAD being delivered. All other strict lifecycle gates remain unchanged.
+
+### Fail-closed completion
+
+Every required output and gate is authoritative. If any typed output is absent or any gate fails, the work remains `needs_human` and must not be projected as complete.
+
+### Change boundary
+
+Implementation is documentation-only and is confined to `docs/unified-work-lifecycle.md`, the current OpenSpec change, and issue #31. Runtime code is outside the change boundary.

--- a/docs/superpowers/specs/terminal-lifecycle-canary-spec.md
+++ b/docs/superpowers/specs/terminal-lifecycle-canary-spec.md
@@ -1,0 +1,32 @@
+---
+status: accepted
+work_item: terminal-lifecycle-canary
+---
+
+# Terminal Lifecycle Canary Specification
+
+## Requirements
+
+### Terminal lifecycle evidence
+
+The lifecycle-terminal-live-canary capability SHALL leave reviewable terminal live-canary evidence in `docs/unified-work-lifecycle.md`.
+
+The evidence SHALL cover confirmed Todo and issue auto-label behavior, heterogeneous brainstorming, docs-only build execution, review, and strict delivery closure.
+
+### Planning completeness
+
+The initial OpenSpec change SHALL omit an accepted superpowers plan so that the completeness gate is forced to execute a heterogeneous brainstorm before accepted planning artifacts are published.
+
+Accepted planning artifacts SHALL be produced only after the primary planner integrates the heterogeneous brainstorm evidence.
+
+### Terminal closure
+
+The canary SHALL verify terminal closure through archive, preflight, current-HEAD maintainer review, merge-commit delivery, issue closure, and done projection.
+
+A missing typed output or failed gate SHALL prevent completion and preserve a `needs_human` state.
+
+### Scope
+
+The change SHALL be limited to `docs/unified-work-lifecycle.md`, the `terminal-lifecycle-canary` OpenSpec change, and issue #31.
+
+The change SHALL NOT modify runtime code, directly alter the Manager registry, or enable automatic labels for other repositories.

--- a/docs/unified-work-lifecycle.md
+++ b/docs/unified-work-lifecycle.md
@@ -73,11 +73,11 @@ cortex doctor --probe-live --repo owner/repo --json
 
 ## Delivery gate
 
-Manager 是唯一 writer。每次 push 都會使上一個 Copilot epoch 失效，並重新要求 current-HEAD review。Merge 前必須同時具備：
+Manager 是唯一 writer。每次 push 都會使上一個 delivery review epoch 失效，並重新要求 current-HEAD review。Merge 前必須同時具備：
 
 - exact tree 的 policy + pinned preflight；
 - deterministic verification 與不同 independence domain 的 ForeignReview；
-- current-HEAD、非 error 的 Copilot review，且 threads resolved/outdated；
+- 恰好一種 current-HEAD typed delivery review：非 error 且 threads resolved/outdated 的 Copilot review，或 immutable exact-HEAD maintainer attestation；
 - terminal-green checks/statuses、closing refs、archive diff 與 mergeability；
 - fresh GitHub provider snapshot。
 

--- a/openspec/changes/unified-work-lifecycle/design.md
+++ b/openspec/changes/unified-work-lifecycle/design.md
@@ -87,7 +87,7 @@ Manager先以官方`openspec archive -y <change>`產生archive diff，確認task
 
 快速`python3 -m policy_check --repo .`後執行`PSC_PREFLIGHT_CMD`；初次帶draft metadata，既有PR修正帶`--pr N`。Preflight須涵蓋pytest、`openspec validate --all`與PR-context policy。`--skip-tests`只接受同tree hash、fresh、full-suite evidence。
 
-Push/PR後等待checks terminal-green，request `@copilot`並驗review `commit_id == HEAD`、非error、threads resolved/outdated。每次push建立新review epoch並重新request。Finding由Builder修正或Reviewer以證據判誤報；最多兩輪、每HEAD 15分鐘。超時或第三輪finding轉needs_human。
+Push/PR後等待checks terminal-green，並要求恰好一種typed current-HEAD delivery review。Copilot路徑request `@copilot`並驗review `commit_id == HEAD`、非error；maintainer路徑由Manager重讀PR HEAD後寫immutable attestation。兩者都要求threads resolved/outdated且不能替代ForeignReview。每次push使舊review authority失效；Copilot finding最多兩輪、每HEAD 15分鐘，超時或第三輪轉needs_human。
 
 Merge前重新讀HEAD、mergeability、checks、threads、closing issues與archive diff，若任一revision改變就重跑相應gate。只用`gh pr merge --merge`，不使用`--auto`。
 
@@ -96,6 +96,22 @@ Merge前重新讀HEAD、mergeability、checks、threads、closing issues與archi
 Merge後fetch default branch，驗merge commit ancestry、mapped issue closed、active OpenSpec消失、archive存在、Todo complete，再寫versioned CompletionRecord。Record綁定work ID、workflow/run/step IDs、source revisions、PR/head/merge SHA、issue states、archive tree、Todo revisions與gate evidence hashes。
 
 Monitor只在GitHub/provider fresh且Record驗證通過時投影done；record缺失、stale、source contradiction或provider degraded皆不升done。
+
+### 10. Planning handoff以input snapshot跨worktree
+
+WorkflowStep額外保存`skill_ref`與structured action/commit/test policy。Manager在dispatch前把目前card與同phase較早card的inputs合併，逐glob解析regular non-symlink檔案並保存pattern/path/hash/authority/content locator。若builder worktree缺accepted planning artifact，只能從WorkflowRun planning authority驗hash後原子seed；operator source drift、destination conflict、同glob未授權替代檔或128 KiB prompt bound超限皆停止在job建立前。
+
+Prompt固定為`workflow-card-prompt/v1`，包含resolved source content與terminal schema。Active v1 run可繼承同phase input contract以恢復pending cards，但既有passed card不回填新證據、不偽稱通過新gate。Terminalize再次驗snapshot hash，canonical job evidence保存相同snapshot。
+
+### 11. `needs_human`是operator resume boundary
+
+Dispatcher仍負責把dead PID/no sentinel fail-closed成failed job；Manager將run設`needs_human`後，periodic runner只回`operator-resume-required`，不得清facet或重派。只有control queue收到explicit work/workflow resume才清facet、保留舊failed job並重試相同run/card。
+
+### 12. Current-HEAD delivery review是typed union
+
+ForeignReview仍是獨立必備gate。其後delivery review authority恰為`copilot`或`maintainer-review`之一。`review-attest`只經Manager queue建立：先重讀authenticated PR HEAD，再寫repo/work/run/authority digest/PR/candidate/actor/verdict綁定的immutable evidence。Ship重驗run gate ref/hash與current HEAD，GitHub checks/threads/mergeability/archive/closing refs完全沿用。
+
+既有Copilot authorization維持v1 replay；maintainer路徑使用merge authorization v2，保存實際review kind/ref/hash。Manager不得把maintainer evidence寫成Copilot kind。Interactive runtime另以`PSC_INSTANCE`選取installer bootstrap env，讓CLI與service共享instance-scoped run root；invalid env fail-closed。
 
 ## Failure handling
 

--- a/openspec/changes/unified-work-lifecycle/specs/governed-delivery-closure/spec.md
+++ b/openspec/changes/unified-work-lifecycle/specs/governed-delivery-closure/spec.md
@@ -66,10 +66,10 @@ V1 WorkflowRun只支援唯一mapped PR、唯一OpenSpec change與唯一Todo path
 - **THEN**fleet auto rollout保持disabled
 - **THEN**Monitor read-only rollout仍可繼續並顯示diagnostics
 
-### Requirement: Interactive CLI與service必須解析相同instance run root
-`PSC_RUN_ROOT` process override MUST最高優先。未設定時interactive command MUST依`PSC_INSTANCE`（default `cortex`）讀取installer管理的`$HOME/.agents/core/runtime/<instance>-manager.env`；不存在安裝檔時預設為`$PSC_AGENTS_ROOT/run/<instance>`。Bootstrap env若為symlink、malformed或root非絕對路徑 MUST fail-closed。Installer MUST保存`PSC_INSTANCE`，Monitor socket client MUST使用production monitor config的socket path。
+### Requirement: Interactive CLI與service必須解析相同instance runtime roots
+各specific `PSC_*_ROOT` process override MUST最高優先；其次是可一次覆寫所有derived roots的process `PSC_AGENTS_ROOT`。兩者未設定時interactive command MUST依`PSC_INSTANCE`（default `cortex`）讀取installer管理的`$HOME/.agents/core/runtime/<instance>-manager.env`，並使用相同的agents/control/coordinator/specs/run/monitor/project-config roots；不存在安裝檔時才從`$HOME/.agents`推導。Bootstrap env若為symlink、malformed或root非絕對路徑 MUST fail-closed，installer也MUST拒絕覆寫symlink bootstrap。Installer MUST保存`PSC_INSTANCE`，Monitor socket client MUST使用production monitor config的socket path。
 
 #### Scenario: 安裝beta instance後由interactive CLI操作
-- **WHEN**operator設定`PSC_INSTANCE=beta`且未覆寫`PSC_RUN_ROOT`
-- **THEN**CLI與beta manager/monitor service使用相同run root與socket
-- **THEN**不得掃描猜測其他instance或fallback到generic run root
+- **WHEN**operator設定`PSC_INSTANCE=beta`且未覆寫specific runtime root
+- **THEN**CLI control queue與beta manager service使用相同control root，CLI與monitor service使用相同project config、run root與socket
+- **THEN**不得掃描猜測其他instance或fallback到generic runtime root

--- a/openspec/changes/unified-work-lifecycle/specs/governed-delivery-closure/spec.md
+++ b/openspec/changes/unified-work-lifecycle/specs/governed-delivery-closure/spec.md
@@ -15,8 +15,8 @@ Manager MUST先跑`python3 -m policy_check --repo .`，再執行configured `PSC_
 - **WHEN**current tree hash與evidence tree hash不同
 - **THEN**Manager拒絕`--skip-tests`並重跑full suite
 
-### Requirement: Copilot與GitHub gates必須綁定current HEAD
-開PR後 Manager MUST等待所有required checks terminal-green並request `@copilot`。有效Copilot review MUST非error且`commit_id`等於current HEAD；所有current findings threads MUST resolved或outdated。每次push MUST建立新review epoch並重新request，舊HEAD review MUST NOT沿用。Copilot MUST NOT取代ForeignReview。
+### Requirement: Delivery review與GitHub gates必須綁定current HEAD
+開PR後 Manager MUST等待所有required checks terminal-green，並要求恰好一種current-HEAD delivery review authority：request `@copilot`所得的authenticated review，或經control queue建立的typed `maintainer-review` evidence。有效Copilot review MUST非error且`commit_id`等於current HEAD；maintainer evidence MUST immutable且精確綁定repo/work/run/authority digest/PR/current HEAD/actor/verdict。所有current findings threads MUST resolved或outdated。每次push MUST使舊review evidence失效。兩種authority MUST保留實際kind/ref/hash，MUST NOT把maintainer evidence偽裝成Copilot。Delivery review MUST NOT取代ForeignReview。
 
 #### Scenario: Push後只有舊HEAD review
 - **WHEN**PR HEAD改變且最新Copilot review仍綁前一commit
@@ -25,6 +25,11 @@ Manager MUST先跑`python3 -m policy_check --repo .`，再執行configured `PSC_
 #### Scenario: Check cancelled或thread unresolved
 - **WHEN**任一required check failed/cancelled/pending，或current thread unresolved
 - **THEN**Manager不得merge
+
+#### Scenario: Maintainer attest綁定舊HEAD
+- **WHEN**PR HEAD已從A推進到B，但maintainer evidence綁定A
+- **THEN**Manager拒絕merge authorization並要求B的新attestation
+- **THEN**不得改寫evidence或把它記成Copilot review
 
 ### Requirement: Finding處理必須bounded且不得偷換reviewer
 真finding MUST由Builder修正並加regression test；誤報 MUST由Reviewer留下evidence後resolve。每個HEAD最長等待15分鐘，最多兩輪fix/re-review。Timeout或第三輪仍有finding MUST設`needs_human`，不得替換reviewer或繞過gate。
@@ -37,7 +42,7 @@ Manager MUST先跑`python3 -m policy_check --repo .`，再執行configured `PSC_
 ### Requirement: Merge前後必須重讀remote terminal facts
 Merge前 Manager MUST重新讀HEAD、mergeability、checks、threads、closing issues與archive diff，revision race MUST中止merge。Merge MUST使用`gh pr merge --merge`且 MUST NOT使用GitHub `--auto`。Merge後 MUST fetch default branch並驗merge ancestry、all mapped issues closed、active OpenSpec消失、remote archive存在、Todo tasks完成，才可寫versioned CompletionRecord並投影done。
 
-V1 WorkflowRun只支援唯一mapped PR、唯一OpenSpec change與唯一Todo path。任一類有多個confirmed refs時 Manager MUST設`needs_human:multiple-delivery-targets-unsupported`，MUST NOT只選其中一個完成、merge或寫CompletionRecord。Merge authorization MUST只雜湊stable semantic preflight result與immutable evidence hashes，MUST NOT納入stdout、stderr或duration；`merge-authorized` crash recovery MUST先依durable authorization與authenticated merge status reconcile，已merge時 MUST NOT重跑preflight。
+V1 WorkflowRun只支援唯一mapped PR、唯一OpenSpec change與唯一Todo path。任一類有多個confirmed refs時 Manager MUST設`needs_human:multiple-delivery-targets-unsupported`，MUST NOT只選其中一個完成、merge或寫CompletionRecord。Merge authorization MUST只雜湊stable semantic preflight result與immutable evidence hashes，MUST NOT納入stdout、stderr或duration；v2 authorization MUST保存實際current-HEAD review kind/ref/hash。`merge-authorized` crash recovery MUST先依durable authorization與authenticated merge status reconcile，已merge時 MUST NOT重跑preflight；既有v1 Copilot authorization只可按原schema重播，不得重新解釋成maintainer authority。
 
 #### Scenario: Work item有多個delivery targets
 - **WHEN**current WorkAuthority含多張PR、多個active OpenSpec或多個Todo path任一情形
@@ -54,9 +59,17 @@ V1 WorkflowRun只支援唯一mapped PR、唯一OpenSpec change與唯一Todo path
 - **THEN**Manager不得寫terminal CompletionRecord或投影done
 
 ### Requirement: Deployment前必須live doctor與單repo canary
-`cortex doctor --probe-live` MUST檢查gh auth/permissions、auto label、preflight executable、model identities、agy headless smoke與service paths。系統 MUST先在`paulsha-cortex`用低風險docs-only issue完成異質brainstorm→build→ForeignReview→archive→preflight→Copilot→merge commit→done canary；通過前 MUST NOT在其他repo啟用auto label。
+`cortex doctor --probe-live` MUST檢查gh auth/permissions、auto label、preflight executable、model identities、agy headless smoke與service paths。系統 MUST先在`paulsha-cortex`用低風險docs-only issue完成異質brainstorm→build→ForeignReview→archive→preflight→typed current-HEAD maintainer review→merge commit→done canary；通過前 MUST NOT在其他repo啟用auto label。
 
 #### Scenario: Canary任一gate失敗
 - **WHEN**canary未完成strict closure或doctor任一required probe失敗
 - **THEN**fleet auto rollout保持disabled
 - **THEN**Monitor read-only rollout仍可繼續並顯示diagnostics
+
+### Requirement: Interactive CLI與service必須解析相同instance run root
+`PSC_RUN_ROOT` process override MUST最高優先。未設定時interactive command MUST依`PSC_INSTANCE`（default `cortex`）讀取installer管理的`$HOME/.agents/core/runtime/<instance>-manager.env`；不存在安裝檔時預設為`$PSC_AGENTS_ROOT/run/<instance>`。Bootstrap env若為symlink、malformed或root非絕對路徑 MUST fail-closed。Installer MUST保存`PSC_INSTANCE`，Monitor socket client MUST使用production monitor config的socket path。
+
+#### Scenario: 安裝beta instance後由interactive CLI操作
+- **WHEN**operator設定`PSC_INSTANCE=beta`且未覆寫`PSC_RUN_ROOT`
+- **THEN**CLI與beta manager/monitor service使用相同run root與socket
+- **THEN**不得掃描猜測其他instance或fallback到generic run root

--- a/openspec/changes/unified-work-lifecycle/specs/persona-workflow-orchestration/spec.md
+++ b/openspec/changes/unified-work-lifecycle/specs/persona-workflow-orchestration/spec.md
@@ -32,8 +32,8 @@ Claim key MUST雜湊該work item的canonical semantic authority與provider/sourc
 - **THEN** Manager重用既有run/claim metadata並繼續
 - **THEN**不自動建立第二張issue
 
-### Requirement: Workflow manifest必須保留每步persona binding
-Deck compiler MUST把每張card的`persona_binding`寫入workflow manifest；Manager MUST依step使用planner、builder、reviewer或manager persona，不得以global builder覆蓋。Default combo MUST為`feature-oneshot`。每個WorkflowStep MUST保存phase、persona、card、executor/model/domain、inputs、outputs與gate result。
+### Requirement: Workflow manifest必須保留每步persona binding與execution contract
+Deck compiler MUST把每張card的`persona_binding`、`skill_ref`、task-specific action、commit policy與test policy寫入workflow manifest；Manager MUST依step使用planner、builder、reviewer或manager persona，不得以global builder覆蓋。Default combo MUST為`feature-oneshot`。每個WorkflowStep MUST保存phase、persona、card、executor/model/domain、inputs、outputs、execution contract與gate result。
 
 #### Scenario: Combo含不同persona cards
 - **WHEN** Deck compile feature-oneshot
@@ -71,9 +71,38 @@ Manager MUST在每張card dispatch時持久化output目錄baseline。Verify與re
 - **THEN**Manager不得選agy執行brainstorm
 
 ### Requirement: Brainstorm peer與Foreign Reviewer必須是獨立gate
-Builder MUST在`feature/<issue>-<slug>` worktree執行deterministic Candidate verification。Foreign Reviewer MUST使用不同於Builder的independence domain並在detached exact Candidate HEAD審查。Brainstorm peer、ForeignReview與Copilot review MUST保存不同gate/evidence refs，任一 MUST NOT取代另一個。
+Builder MUST在`feature/<issue>-<slug>` worktree執行deterministic Candidate verification。Foreign Reviewer MUST使用不同於Builder的independence domain並在detached exact Candidate HEAD審查。Brainstorm peer、ForeignReview與current-HEAD delivery review MUST保存不同gate/evidence refs，任一 MUST NOT取代另一個；delivery review MUST明確標為`copilot`或`maintainer-review`，不得互相偽裝。
 
 #### Scenario: Brainstorm peer也是可用reviewer
 - **WHEN**同一model曾產生planning evidence
 - **THEN**該evidence不能滿足ForeignReview
 - **THEN**Manager仍需按review gate選擇不同於Builder domain的reviewer step
+
+### Requirement: Declared inputs必須形成hash-bound handoff
+Manager MUST在launch前解析目前card與同phase既有card的declared input globs；每個glob MUST至少命中一個regular non-symlink UTF-8檔案。Planning artifact命中 MUST與WorkflowRun的planning authority ref/hash一致；builder worktree缺檔時 Manager MAY從該authority原子seed，但mutable operator artifact drift、destination conflict或未授權的同glob替代檔 MUST fail-closed。Manager MUST把pattern/path/hash/authority/content locator保存為Job input snapshot，terminalize時 MUST重驗檔案hash。
+
+#### Scenario: Builder worktree缺accepted plan
+- **WHEN**pending build card宣告accepted plan但獨立builder worktree尚無該檔
+- **THEN**Manager只從相同run的planning authority驗hash後原子seed
+- **THEN**Job、prompt與canonical evidence保存相同input snapshot
+
+#### Scenario: Operator artifact在accept後漂移
+- **WHEN**operator checkout中的planning artifact hash不再等於run authority
+- **THEN**Manager在建立Job或launch前拒絕dispatch
+- **THEN**不得以其他同glob檔案補位
+
+### Requirement: Headless card prompt必須是bounded execution envelope
+每張headless card prompt MUST為versioned structured envelope，至少包含run/work/source revision、phase/card/persona、skill ref、task action、commit/test policy、resolved source material、declared outputs、candidate semantics與exact terminal JSON schema。Source material總量 MUST有上限；超限 MUST fail-closed。Manager已provision worktree時，`worktree-isolation` MUST明示不得建立第二個worktree。
+
+#### Scenario: Legacy pending build card沒有直接inputs
+- **WHEN**active v1 manifest的`tdd-red`或`subagent-build`沒有直接inputs，但同phase較早card宣告accepted plan
+- **THEN**Manager繼承同phase input contract並建立snapshot
+- **THEN**不得把舊passed card靜默改寫成新gate已通過
+
+### Requirement: Interrupted headless job只能由operator恢復
+Dead PID且沒有exit sentinel的dispatched job MUST先由Dispatcher保存為failed並將WorkflowRun設為`needs_human`。Periodic runner MUST只reconcile，MUST NOT清除`needs_human`或自動重派；只有經control queue的explicit `work resume`或`workflow resume` MAY清除facet並重試同run/card，舊failed job MUST保留。
+
+#### Scenario: Periodic runner連跑兩輪
+- **WHEN**第一輪發現dead PID/no sentinel並將run設為needs_human
+- **THEN**第二輪回`operator-resume-required`
+- **THEN**不得建立新job

--- a/openspec/changes/unified-work-lifecycle/tasks.md
+++ b/openspec/changes/unified-work-lifecycle/tasks.md
@@ -43,7 +43,7 @@
 
 - [x] 4.1 實作`cortex doctor --probe-live`的gh auth/permissions、label、preflight executable、model identities、agy smoke與service path probes。
 - [x] 4.2 更新README、usage/help snapshots、service install與registry/snapshot migration docs。
-- [x] 4.2a 統一interactive/service instance runtime discovery；installer保存`PSC_INSTANCE`，CLI與Monitor client解析相同run root/socket。
+- [x] 4.2a 統一interactive/service instance runtime discovery；installer保存`PSC_INSTANCE`，CLI control queue與Monitor client解析相同runtime roots/socket。
 - [ ] 4.3 在`paulsha-cortex`以低風險docs-only issue跑auto-label canary，刻意缺accepted plan以觸發異質brainstorm。
 - [ ] 4.4 驗canary完整經brainstorm→build→ForeignReview→archive→preflight→typed maintainer current-HEAD review→merge commit→done；通過前不擴散auto label。
 - [ ] 4.5 使用official CLI archive `unified-work-lifecycle`；issue #12只勾實際涵蓋項目。

--- a/openspec/changes/unified-work-lifecycle/tasks.md
+++ b/openspec/changes/unified-work-lifecycle/tasks.md
@@ -25,6 +25,8 @@
 - [x] 2.5 驗planner/builder/reviewer domain separation及brainstorm/ForeignReview gate分離。
 - [x] 2.6 實作manifest per-card durable dispatch/resume、dispatch output baseline與run/card/Candidate-bound report gate、terminal canonical evidence、逐operation recoverable intent transaction、persisted planning authority CAS replacement，以及PermissionError仍可完整還原mode/xattrs/entries的planner sandbox rollback。
 - [x] 2.7 通過migration/focused/full tests、help、OpenSpec、policy與preflight。
+- [x] 2.8 RED-test並實作planning-authority seed、declared input snapshot/terminal hash重驗、versioned bounded card prompt與legacy same-phase input reconciliation。
+- [x] 2.9 RED-test並修正dead headless job的operator stop：periodic只reconcile，explicit queued resume才可重派同一run/card。
 
 ## 3. PR C — Delivery automation
 
@@ -35,13 +37,15 @@
 - [x] 3.5 實作每HEAD review epoch、兩輪/15分鐘bounded loop、exact-tree skip-tests與needs_human fallback。
 - [x] 3.6 實作`gh pr merge --merge`前final reread、stable-hash atomic durable `merge-authorized` record、免重跑preflight的crash reconciliation與merge後remote closure/authority-bound CompletionRecord；V1多delivery target轉needs_human。
 - [x] 3.7 通過GitHub seam/focused/full/integration tests、help、OpenSpec、policy與preflight；完成planner issue #5與ship-gate issue #16。Issue #8其餘task-type選牌、計分/成本與skill治理範圍保留，不由本change虛假關閉。
+- [x] 3.8 RED-test並實作immutable exact-HEAD `maintainer-review` attestation、Copilot/maintainer二選一gate與保留實際review kind/ref/hash的merge authorization v2。
 
 ## 4. PR D — Bootstrap, docs, deployment, canary
 
 - [x] 4.1 實作`cortex doctor --probe-live`的gh auth/permissions、label、preflight executable、model identities、agy smoke與service path probes。
 - [x] 4.2 更新README、usage/help snapshots、service install與registry/snapshot migration docs。
+- [x] 4.2a 統一interactive/service instance runtime discovery；installer保存`PSC_INSTANCE`，CLI與Monitor client解析相同run root/socket。
 - [ ] 4.3 在`paulsha-cortex`以低風險docs-only issue跑auto-label canary，刻意缺accepted plan以觸發異質brainstorm。
-- [ ] 4.4 驗canary完整經brainstorm→build→ForeignReview→archive→preflight→Copilot→merge commit→done；通過前不擴散auto label。
+- [ ] 4.4 驗canary完整經brainstorm→build→ForeignReview→archive→preflight→typed maintainer current-HEAD review→merge commit→done；通過前不擴散auto label。
 - [ ] 4.5 使用official CLI archive `unified-work-lifecycle`；issue #12只勾實際涵蓋項目。
 
 ## 5. Completion gates

--- a/paulsha_cortex/config/paths.py
+++ b/paulsha_cortex/config/paths.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 import os
 from pathlib import Path
 
+from .runtime import resolve_run_root
+
 
 def _env_path(name: str) -> Path | None:
     value = os.environ.get(name, "").strip()
@@ -33,7 +35,7 @@ def specs_root() -> Path:
 
 
 def run_root() -> Path:
-    return _resolve_root("PSC_RUN_ROOT", agents_root() / "run")
+    return resolve_run_root()
 
 
 def monitor_state_root() -> Path:

--- a/paulsha_cortex/config/paths.py
+++ b/paulsha_cortex/config/paths.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import os
 from pathlib import Path
 
-from .runtime import resolve_run_root
+from .runtime import resolve_project_config_root, resolve_run_root, resolve_runtime_root
 
 
 def _env_path(name: str) -> Path | None:
@@ -19,19 +19,19 @@ def _resolve_root(name: str, default: Path) -> Path:
 
 
 def agents_root() -> Path:
-    return _resolve_root("PSC_AGENTS_ROOT", Path.home() / ".agents")
+    return resolve_runtime_root("PSC_AGENTS_ROOT")
 
 
 def control_root() -> Path:
-    return _resolve_root("PSC_CONTROL_ROOT", agents_root() / "control")
+    return resolve_runtime_root("PSC_CONTROL_ROOT")
 
 
 def coordinator_root() -> Path:
-    return _resolve_root("PSC_COORDINATOR_ROOT", agents_root() / "coordinator")
+    return resolve_runtime_root("PSC_COORDINATOR_ROOT")
 
 
 def specs_root() -> Path:
-    return _resolve_root("PSC_SPECS_ROOT", agents_root() / "specs")
+    return resolve_runtime_root("PSC_SPECS_ROOT")
 
 
 def run_root() -> Path:
@@ -40,7 +40,7 @@ def run_root() -> Path:
 
 def monitor_state_root() -> Path:
     """Durable Monitor state; distinct from the runtime socket directory."""
-    return _resolve_root("PSC_MONITOR_STATE_ROOT", agents_root() / "monitor")
+    return resolve_runtime_root("PSC_MONITOR_STATE_ROOT")
 
 
 def work_items_snapshot_path() -> Path:
@@ -56,7 +56,7 @@ def config_path(*parts: str) -> Path:
 
 
 def project_config_root() -> Path:
-    return _resolve_root("PSC_PROJECT_CONFIG_ROOT", agents_root() / "config" / "paulsha")
+    return resolve_project_config_root()
 
 
 def repo_root() -> Path:

--- a/paulsha_cortex/config/runtime.py
+++ b/paulsha_cortex/config/runtime.py
@@ -1,0 +1,77 @@
+"""Installed runtime discovery shared by interactive commands and services."""
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+from typing import Mapping
+
+
+INSTANCE_RE = re.compile(r"[a-z0-9][a-z0-9-]*")
+ENV_KEY_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+
+
+def selected_instance(environment: Mapping[str, str] | None = None) -> str:
+    env = os.environ if environment is None else environment
+    instance = env.get("PSC_INSTANCE", "cortex").strip()
+    if INSTANCE_RE.fullmatch(instance) is None:
+        raise ValueError("PSC_INSTANCE 名稱不合法")
+    return instance
+
+
+def _parse_bootstrap_env(path: Path) -> dict[str, str]:
+    if path.is_symlink() or not path.is_file():
+        raise ValueError("runtime bootstrap env 必須是 regular non-symlink file")
+    values: dict[str, str] = {}
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        key, separator, value = line.partition("=")
+        if (
+            not separator
+            or ENV_KEY_RE.fullmatch(key) is None
+            or not value
+            or value != value.strip()
+            or value.startswith(("'", '"'))
+        ):
+            raise ValueError("runtime bootstrap env 格式錯誤")
+        values[key] = value
+    return values
+
+
+def resolve_run_root(
+    *,
+    environment: Mapping[str, str] | None = None,
+    home: Path | None = None,
+) -> Path:
+    """Resolve the interactive run root from the selected installed instance."""
+    env = os.environ if environment is None else environment
+    explicit = env.get("PSC_RUN_ROOT", "").strip()
+    if explicit:
+        root = Path(explicit).expanduser()
+        if not root.is_absolute():
+            raise ValueError("PSC_RUN_ROOT 必須為絕對路徑")
+        return root
+
+    instance = selected_instance(env)
+    selected_home = (Path.home() if home is None else Path(home)).expanduser()
+    if not selected_home.is_absolute():
+        raise ValueError("runtime home 必須為絕對路徑")
+    bootstrap = selected_home / ".agents" / "core" / "runtime" / f"{instance}-manager.env"
+    installed: dict[str, str] = {}
+    if bootstrap.exists() or bootstrap.is_symlink():
+        installed = _parse_bootstrap_env(bootstrap)
+
+    installed_run_root = installed.get("PSC_RUN_ROOT", "").strip()
+    if installed_run_root:
+        root = Path(installed_run_root).expanduser()
+        if not root.is_absolute():
+            raise ValueError("installed PSC_RUN_ROOT 必須為絕對路徑")
+        return root
+
+    agents_value = installed.get("PSC_AGENTS_ROOT", env.get("PSC_AGENTS_ROOT", "")).strip()
+    agents = Path(agents_value).expanduser() if agents_value else selected_home / ".agents"
+    if not agents.is_absolute():
+        raise ValueError("PSC_AGENTS_ROOT 必須為絕對路徑")
+    return agents / "run" / instance

--- a/paulsha_cortex/config/runtime.py
+++ b/paulsha_cortex/config/runtime.py
@@ -9,6 +9,13 @@ from typing import Mapping
 
 INSTANCE_RE = re.compile(r"[a-z0-9][a-z0-9-]*")
 ENV_KEY_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+RUNTIME_ROOT_DEFAULTS = {
+    "PSC_CONTROL_ROOT": ("control",),
+    "PSC_COORDINATOR_ROOT": ("coordinator",),
+    "PSC_SPECS_ROOT": ("specs",),
+    "PSC_MONITOR_STATE_ROOT": ("monitor",),
+    "PSC_PROJECT_CONFIG_ROOT": ("config", "paulsha"),
+}
 
 
 def selected_instance(environment: Mapping[str, str] | None = None) -> str:
@@ -40,6 +47,26 @@ def _parse_bootstrap_env(path: Path) -> dict[str, str]:
     return values
 
 
+def _installed_environment(
+    environment: Mapping[str, str],
+    *,
+    home: Path | None,
+) -> tuple[Path, dict[str, str]]:
+    selected_home = (Path.home() if home is None else Path(home)).expanduser()
+    if not selected_home.is_absolute():
+        raise ValueError("runtime home 必須為絕對路徑")
+    bootstrap = (
+        selected_home
+        / ".agents"
+        / "core"
+        / "runtime"
+        / f"{selected_instance(environment)}-manager.env"
+    )
+    if bootstrap.exists() or bootstrap.is_symlink():
+        return selected_home, _parse_bootstrap_env(bootstrap)
+    return selected_home, {}
+
+
 def resolve_run_root(
     *,
     environment: Mapping[str, str] | None = None,
@@ -47,31 +74,71 @@ def resolve_run_root(
 ) -> Path:
     """Resolve the interactive run root from the selected installed instance."""
     env = os.environ if environment is None else environment
-    explicit = env.get("PSC_RUN_ROOT", "").strip()
+    instance = selected_instance(env)
+    return resolve_runtime_root(
+        "PSC_RUN_ROOT",
+        default_parts=("run", instance),
+        environment=env,
+        home=home,
+    )
+
+
+def resolve_runtime_root(
+    name: str,
+    *,
+    default_parts: tuple[str, ...] | None = None,
+    environment: Mapping[str, str] | None = None,
+    home: Path | None = None,
+) -> Path:
+    """Resolve one root with process override, then selected installed instance authority."""
+    env = os.environ if environment is None else environment
+    explicit = env.get(name, "").strip()
     if explicit:
         root = Path(explicit).expanduser()
         if not root.is_absolute():
-            raise ValueError("PSC_RUN_ROOT 必須為絕對路徑")
+            raise ValueError(f"{name} 必須為絕對路徑")
         return root
 
-    instance = selected_instance(env)
-    selected_home = (Path.home() if home is None else Path(home)).expanduser()
-    if not selected_home.is_absolute():
-        raise ValueError("runtime home 必須為絕對路徑")
-    bootstrap = selected_home / ".agents" / "core" / "runtime" / f"{instance}-manager.env"
-    installed: dict[str, str] = {}
-    if bootstrap.exists() or bootstrap.is_symlink():
-        installed = _parse_bootstrap_env(bootstrap)
+    process_agents_value = env.get("PSC_AGENTS_ROOT", "").strip()
+    if process_agents_value:
+        process_agents = Path(process_agents_value).expanduser()
+        if not process_agents.is_absolute():
+            raise ValueError("PSC_AGENTS_ROOT 必須為絕對路徑")
+        if name == "PSC_AGENTS_ROOT":
+            return process_agents
+        relative = default_parts if default_parts is not None else RUNTIME_ROOT_DEFAULTS.get(name)
+        if relative is None:
+            raise ValueError(f"unsupported runtime root: {name}")
+        return process_agents.joinpath(*relative)
 
-    installed_run_root = installed.get("PSC_RUN_ROOT", "").strip()
-    if installed_run_root:
-        root = Path(installed_run_root).expanduser()
+    selected_home, installed = _installed_environment(env, home=home)
+    installed_value = installed.get(name, "").strip()
+    if installed_value:
+        root = Path(installed_value).expanduser()
         if not root.is_absolute():
-            raise ValueError("installed PSC_RUN_ROOT 必須為絕對路徑")
+            raise ValueError(f"installed {name} 必須為絕對路徑")
         return root
 
-    agents_value = installed.get("PSC_AGENTS_ROOT", env.get("PSC_AGENTS_ROOT", "")).strip()
+    agents_value = installed.get("PSC_AGENTS_ROOT", "").strip()
     agents = Path(agents_value).expanduser() if agents_value else selected_home / ".agents"
     if not agents.is_absolute():
         raise ValueError("PSC_AGENTS_ROOT 必須為絕對路徑")
-    return agents / "run" / instance
+    if name == "PSC_AGENTS_ROOT":
+        return agents
+    relative = default_parts if default_parts is not None else RUNTIME_ROOT_DEFAULTS.get(name)
+    if relative is None:
+        raise ValueError(f"unsupported runtime root: {name}")
+    return agents.joinpath(*relative)
+
+
+def resolve_project_config_root(
+    *,
+    environment: Mapping[str, str] | None = None,
+    home: Path | None = None,
+) -> Path:
+    """Resolve project config from the same selected installed instance as run root."""
+    return resolve_runtime_root(
+        "PSC_PROJECT_CONFIG_ROOT",
+        environment=environment,
+        home=home,
+    )

--- a/paulsha_cortex/control/contract.py
+++ b/paulsha_cortex/control/contract.py
@@ -12,7 +12,7 @@ from . import constants
 REQUEST_TYPES = frozenset(
     {"tick", "fanout", "dispatch", "complete", "slice-action", "workflow-action", "work-action"}
 )
-WORK_ACTIONS = frozenset({"link", "unlink", "start", "resume", "auto", "ship"})
+WORK_ACTIONS = frozenset({"link", "unlink", "start", "resume", "auto", "ship", "review-attest"})
 WORK_SOURCE_KINDS = frozenset({"github_issue", "github_pr", "openspec", "path"})
 
 

--- a/paulsha_cortex/coordinator/cli.py
+++ b/paulsha_cortex/coordinator/cli.py
@@ -104,12 +104,15 @@ def _build_parser() -> argparse.ArgumentParser:
     p_slice_action.add_argument("--actor", required=True)
 
     p_work = sub.add_parser("work", help="透過 manager daemon 執行 work lifecycle mutation")
-    p_work.add_argument("action", choices=["link", "unlink", "start", "resume", "auto", "ship"])
+    p_work.add_argument(
+        "action", choices=["link", "unlink", "start", "resume", "auto", "ship", "review-attest"]
+    )
     p_work.add_argument("work_id")
     p_work.add_argument("--repo", required=True)
     p_work.add_argument("--issue", type=int)
     p_work.add_argument("--kind", choices=["github_issue", "github_pr", "openspec", "path"])
     p_work.add_argument("--ref")
+    p_work.add_argument("--actor")
     toggle = p_work.add_mutually_exclusive_group()
     toggle.add_argument("--enable", action="store_true")
     toggle.add_argument("--disable", action="store_true")
@@ -246,6 +249,8 @@ def main(
             request_args["kind"] = args.kind
         if args.ref is not None:
             request_args["ref"] = args.ref
+        if args.actor is not None:
+            request_args["actor"] = args.actor
         if args.enable or args.disable:
             request_args["enabled"] = bool(args.enable)
         if args.payload:

--- a/paulsha_cortex/coordinator/delivery.py
+++ b/paulsha_cortex/coordinator/delivery.py
@@ -10,7 +10,12 @@ from pathlib import Path
 from typing import Callable, Mapping
 
 from . import completion, review as foreign_review, verification
-from .claim import GITHUB_PROVIDER_ID, PROVIDER_MAX_AGE_SECONDS, WorkAuthority
+from .claim import (
+    GITHUB_PROVIDER_ID,
+    PROVIDER_MAX_AGE_SECONDS,
+    WorkAuthority,
+    work_authority_digest,
+)
 from .github_delivery import (
     DeliveryFacts,
     DeliveryPolicy,
@@ -198,6 +203,42 @@ class ForeignReviewEvidence:
 
 
 @dataclass(frozen=True)
+class MaintainerReviewEvidence:
+    path: str
+    expected_hash: str
+
+
+def _validate_maintainer_review_evidence(
+    evidence: MaintainerReviewEvidence,
+    *,
+    authority: WorkAuthority,
+    pr_number: int,
+    expected_head: str,
+) -> dict[str, object]:
+    path = Path(evidence.path)
+    if not path.is_absolute() or path.is_symlink() or not path.is_file() or path.stat().st_mode & 0o222:
+        raise ValueError("maintainer review evidence must be immutable absolute file")
+    try:
+        body = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ValueError("maintainer review evidence unreadable") from exc
+    if (
+        not isinstance(body, dict)
+        or body.get("schema") != "cortex-maintainer-review/v1"
+        or body.get("repo") != authority.repo
+        or body.get("work_id") != authority.work_id
+        or body.get("authority_digest") != work_authority_digest(authority)
+        or body.get("pr_number") != pr_number
+        or body.get("candidate") != expected_head
+        or body.get("verdict") != "approved"
+        or body.get("findings") != []
+        or verification.canonical_json_hash(body) != evidence.expected_hash
+    ):
+        raise RuntimeError("maintainer review does not authorize exact HEAD")
+    return body
+
+
+@dataclass(frozen=True)
 class ShipResult:
     delivery_facts: DeliveryFacts
     expected_head: str
@@ -297,8 +338,9 @@ class ShipOrchestrator:
         expected_tree_hash: str,
         authority: WorkAuthority,
         preflight: PreflightResult,
-        copilot: ReviewDecision,
+        copilot: ReviewDecision | None,
         foreign_review: ForeignReviewEvidence,
+        maintainer_review: MaintainerReviewEvidence | None = None,
     ) -> ShipResult:
         _require_sha(expected_head)
         _require_sha(expected_tree_hash)
@@ -312,17 +354,29 @@ class ShipOrchestrator:
             or preflight.tree_hash.lower() != expected_tree_hash.lower()
         ):
             raise RuntimeError("preflight does not authorize exact HEAD/tree")
-        if (
-            copilot.action != "passed"
-            or copilot.head != expected_head
-            or copilot.review_id is None
-            or copilot.loop.head != expected_head
-            or copilot.loop.requested_at is None
-            or copilot.loop.fix_rounds > MAX_FIX_ROUNDS
-            or float(now_epoch) - copilot.loop.requested_at < 0
-            or float(now_epoch) - copilot.loop.requested_at > REVIEW_TIMEOUT_SECONDS
-        ):
-            raise RuntimeError("Copilot review epoch has not passed")
+        if (copilot is None) == (maintainer_review is None):
+            raise RuntimeError("exactly one current-HEAD delivery review is required")
+        if copilot is not None:
+            if (
+                copilot.action != "passed"
+                or copilot.head != expected_head
+                or copilot.review_id is None
+                or copilot.loop.head != expected_head
+                or copilot.loop.requested_at is None
+                or copilot.loop.fix_rounds > MAX_FIX_ROUNDS
+                or float(now_epoch) - copilot.loop.requested_at < 0
+                or float(now_epoch) - copilot.loop.requested_at > REVIEW_TIMEOUT_SECONDS
+            ):
+                raise RuntimeError("Copilot review epoch has not passed")
+            review_kind = "copilot"
+        else:
+            _validate_maintainer_review_evidence(
+                maintainer_review,
+                authority=authority,
+                pr_number=pr_number,
+                expected_head=expected_head,
+            )
+            review_kind = "maintainer-review"
         _validate_foreign_review(foreign_review, expected_head=expected_head)
         facts = self._github.merge_if_ready(
             repo=repo,
@@ -331,8 +385,9 @@ class ShipOrchestrator:
             policy=DeliveryPolicy(
                 expected_head=expected_head,
                 required_closing_issues=authority.mapped_issues,
-                copilot_review_id=copilot.review_id,
-                copilot_requested_at_epoch=copilot.loop.requested_at,
+                copilot_review_id=copilot.review_id if copilot is not None else None,
+                copilot_requested_at_epoch=(copilot.loop.requested_at if copilot is not None else None),
+                review_kind=review_kind,
             ),
             _capability=_SHIP_CAPABILITY,
         )

--- a/paulsha_cortex/coordinator/github_delivery.py
+++ b/paulsha_cortex/coordinator/github_delivery.py
@@ -82,8 +82,9 @@ class DeliveryFacts:
 class DeliveryPolicy:
     expected_head: str
     required_closing_issues: tuple[int, ...]
-    copilot_review_id: int
-    copilot_requested_at_epoch: float
+    copilot_review_id: int | None = None
+    copilot_requested_at_epoch: float | None = None
+    review_kind: str = "copilot"
 
 
 @dataclass(frozen=True)
@@ -107,20 +108,27 @@ def evaluate_delivery_gate(*, facts: DeliveryFacts, policy: DeliveryPolicy) -> G
     if not facts.checks or any(not check.terminal_green for check in facts.checks):
         reasons.append("checks-not-terminal-green")
 
-    current_reviews = tuple(
-        review
-        for review in facts.copilot_reviews
-        if review.commit_id == policy.expected_head
-        and review.review_id == policy.copilot_review_id
-        and review.author == COPILOT_REVIEWER_LOGIN
-        and review.submitted_at_epoch >= policy.copilot_requested_at_epoch
-    )
-    if not current_reviews:
-        reasons.append("copilot-current-head-review-missing")
-    elif any(review.is_error for review in current_reviews):
-        reasons.append("copilot-error-review")
-    elif any(review.state.upper() not in {"COMMENTED", "APPROVED"} for review in current_reviews):
-        reasons.append("copilot-review-state-invalid")
+    if policy.review_kind == "copilot":
+        if policy.copilot_review_id is None or policy.copilot_requested_at_epoch is None:
+            reasons.append("copilot-review-policy-invalid")
+            current_reviews = ()
+        else:
+            current_reviews = tuple(
+                review
+                for review in facts.copilot_reviews
+                if review.commit_id == policy.expected_head
+                and review.review_id == policy.copilot_review_id
+                and review.author == COPILOT_REVIEWER_LOGIN
+                and review.submitted_at_epoch >= policy.copilot_requested_at_epoch
+            )
+        if not current_reviews:
+            reasons.append("copilot-current-head-review-missing")
+        elif any(review.is_error for review in current_reviews):
+            reasons.append("copilot-error-review")
+        elif any(review.state.upper() not in {"COMMENTED", "APPROVED"} for review in current_reviews):
+            reasons.append("copilot-review-state-invalid")
+    elif policy.review_kind != "maintainer-review":
+        reasons.append("delivery-review-policy-invalid")
 
     if any(thread.blocks_merge for thread in facts.review_threads):
         reasons.append("review-thread-open")

--- a/paulsha_cortex/coordinator/manager.py
+++ b/paulsha_cortex/coordinator/manager.py
@@ -2135,6 +2135,185 @@ def _workflow_output_baseline(repo_root: Path, patterns: tuple[str, ...]) -> tup
     return tuple({"path": path, "sha256": rows[path]} for path in sorted(rows))
 
 
+def _effective_workflow_inputs(run, step) -> tuple[str, ...]:
+    """Include earlier same-phase inputs so legacy pending cards retain bounded context."""
+    patterns: list[str] = []
+    for item in run.steps:
+        if item.phase == step.phase:
+            for pattern in item.inputs:
+                if pattern not in patterns:
+                    patterns.append(pattern)
+        if item is step or item.card == step.card:
+            break
+    return tuple(patterns)
+
+
+def _safe_input_matches(root: Path, pattern: str) -> tuple[Path, ...]:
+    relative = Path(pattern)
+    if relative.is_absolute() or ".." in relative.parts:
+        raise ValueError("workflow manifest input pattern escapes repo")
+    matches: list[Path] = []
+    for unresolved in root.glob(pattern):
+        ref = unresolved.relative_to(root)
+        cursor = root
+        for part in ref.parts:
+            cursor = cursor / part
+            if cursor.is_symlink():
+                raise ValueError("workflow input symlink rejected")
+        resolved = unresolved.resolve()
+        resolved.relative_to(root)
+        if resolved.is_file():
+            matches.append(resolved)
+    return tuple(sorted(matches, key=lambda item: item.relative_to(root).as_posix()))
+
+
+def _write_workflow_input_content(
+    *,
+    coordinator_root: Path,
+    run,
+    ref: str,
+    digest: str,
+    content: str,
+) -> str:
+    envelope = {
+        "schema_version": 1,
+        "kind": "workflow-input-content",
+        "run_id": run.run_id,
+        "work_id": run.work_id,
+        "repo": run.repo,
+        "source_revision": run.source_revision,
+        "path": ref,
+        "sha256": digest,
+        "content": content,
+    }
+    encoded = (
+        json.dumps(envelope, ensure_ascii=False, sort_keys=True, separators=(",", ":")) + "\n"
+    ).encode("utf-8")
+    path = coordinator_root.resolve() / "evidence" / "workflow-inputs" / f"{digest}.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    except FileExistsError:
+        if path.is_symlink() or path.read_bytes() != encoded:
+            raise ValueError("workflow input content-address conflict")
+    else:
+        with os.fdopen(fd, "wb") as stream:
+            stream.write(encoded)
+            stream.flush()
+            os.fsync(stream.fileno())
+    return str(path)
+
+
+def _workflow_input_snapshot(
+    *,
+    run,
+    repo_root: Path,
+    patterns: tuple[str, ...],
+    coordinator_root: str | Path,
+) -> tuple[dict[str, str], ...]:
+    root = repo_root.resolve()
+    operator_root = Path(run.workspace_root).resolve()
+    authority = {item.ref: item for item in run.planning_authority}
+    seeds: dict[str, bytes] = {}
+
+    for pattern in patterns:
+        if _safe_input_matches(root, pattern):
+            continue
+        authority_refs = sorted(ref for ref in authority if fnmatch.fnmatch(ref, pattern))
+        if not authority_refs:
+            raise ValueError(f"workflow declared input missing: {pattern}")
+        for ref in authority_refs:
+            source = operator_root / ref
+            if source.is_symlink() or not source.is_file():
+                raise ValueError("workflow planning input missing")
+            data = source.read_bytes()
+            if hashlib.sha256(data).hexdigest() != authority[ref].baseline_sha256:
+                raise ValueError("workflow planning input drift")
+            seeds[ref] = data
+
+    for ref, data in seeds.items():
+        destination = root / ref
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        if destination.is_symlink():
+            raise ValueError("workflow input seed symlink rejected")
+        if destination.exists():
+            if not destination.is_file() or destination.read_bytes() != data:
+                raise ValueError("workflow input seed conflict")
+            continue
+        fd, temporary = tempfile.mkstemp(prefix=f".{destination.name}.", dir=destination.parent)
+        try:
+            with os.fdopen(fd, "wb") as stream:
+                stream.write(data)
+                stream.flush()
+                os.fsync(stream.fileno())
+            os.chmod(temporary, 0o600)
+            os.replace(temporary, destination)
+        finally:
+            if os.path.exists(temporary):
+                os.unlink(temporary)
+
+    rows: list[dict[str, str]] = []
+    total_bytes = 0
+    for pattern in patterns:
+        matches = _safe_input_matches(root, pattern)
+        if not matches:
+            raise ValueError(f"workflow declared input missing: {pattern}")
+        for resolved in matches:
+            ref = resolved.relative_to(root).as_posix()
+            data = resolved.read_bytes()
+            digest = hashlib.sha256(data).hexdigest()
+            bound = authority.get(ref)
+            if bound is not None and digest != bound.baseline_sha256:
+                raise ValueError("workflow planning input drift")
+            pattern_has_authority = any(
+                fnmatch.fnmatch(candidate_ref, pattern) for candidate_ref in authority
+            )
+            if pattern_has_authority and bound is None:
+                raise ValueError("workflow planning input lacks authority")
+            try:
+                content = data.decode("utf-8")
+            except UnicodeDecodeError as exc:
+                raise ValueError("workflow input must be UTF-8") from exc
+            total_bytes += len(data)
+            if total_bytes > 131072:
+                raise ValueError("workflow input envelope exceeds bound")
+            content_ref = _write_workflow_input_content(
+                coordinator_root=Path(coordinator_root),
+                run=run,
+                ref=ref,
+                digest=digest,
+                content=content,
+            )
+            rows.append(
+                {
+                    "pattern": pattern,
+                    "path": ref,
+                    "sha256": digest,
+                    "authority": "planning-authority" if bound is not None else "worktree",
+                    "content_ref": content_ref,
+                }
+            )
+    return tuple(rows)
+
+
+def _validate_workflow_input_snapshot(repo_root: Path, rows: object) -> None:
+    if not isinstance(rows, list):
+        raise ValueError("workflow input snapshot missing")
+    for row in rows:
+        if not isinstance(row, dict) or set(row) != {
+            "pattern", "path", "sha256", "authority", "content_ref"
+        }:
+            raise ValueError("workflow input snapshot invalid")
+        ref = Path(str(row["path"]))
+        if ref.is_absolute() or ".." in ref.parts:
+            raise ValueError("workflow input snapshot path invalid")
+        target = repo_root / ref
+        if target.is_symlink() or not target.is_file():
+            raise ValueError("workflow input snapshot file missing")
+        if hashlib.sha256(target.read_bytes()).hexdigest() != row["sha256"]:
+            raise ValueError("workflow input snapshot hash drift")
+
+
 def _report_binding(content: bytes) -> Mapping[str, object]:
     try:
         text = content.decode("utf-8")
@@ -2312,6 +2491,8 @@ def terminalize_workflow_job(
     if not isinstance(repo_root_value, str) or not repo_root_value:
         raise ValueError("workflow job repo root missing")
     repo_root = Path(repo_root_value).resolve()
+    input_snapshot = job.get("workflow_input_snapshot", [])
+    _validate_workflow_input_snapshot(repo_root, input_snapshot)
     baseline_rows = job.get("workflow_output_baseline")
     if not isinstance(baseline_rows, list):
         raise ValueError("workflow job output baseline missing")
@@ -2336,21 +2517,24 @@ def terminalize_workflow_job(
         repo_root=repo_root,
         baseline_by_ref=baseline_by_ref,
     )
+    job_binding = {
+        "job_id": job["job_id"],
+        "run_id": job["workflow_run_id"],
+        "claim_key": job["workflow_claim_key"],
+        "repo": job["workflow_repo"],
+        "source_revision": job["source_revision"],
+        "card_id": job["workflow_card"],
+        "phase": phase,
+        "inputs": job.get("workflow_inputs", []),
+        "outputs": declared_outputs,
+        "output_baseline": baseline_rows,
+    }
+    if "workflow_input_snapshot" in job:
+        job_binding["input_snapshot"] = input_snapshot
     envelope = {
         "schema_version": 1,
         "kind": str(phase),
-        "job": {
-            "job_id": job["job_id"],
-            "run_id": job["workflow_run_id"],
-            "claim_key": job["workflow_claim_key"],
-            "repo": job["workflow_repo"],
-            "source_revision": job["source_revision"],
-            "card_id": job["workflow_card"],
-            "phase": phase,
-            "inputs": job.get("workflow_inputs", []),
-            "outputs": declared_outputs,
-            "output_baseline": baseline_rows,
-        },
+        "job": job_binding,
         "payload": normalized_payload,
         "artifacts": artifacts,
     }
@@ -2436,6 +2620,11 @@ def _read_job_workflow_evidence(
         "outputs": job.get("workflow_outputs", []),
         "output_baseline": job.get("workflow_output_baseline", []),
     }
+    payload_job = payload.get("job") if isinstance(payload, dict) else None
+    if job.get("workflow_input_snapshot") or (
+        isinstance(payload_job, dict) and "input_snapshot" in payload_job
+    ):
+        expected_job["input_snapshot"] = job.get("workflow_input_snapshot", [])
     if (
         not isinstance(payload, dict)
         or payload.get("schema_version") != 1
@@ -3075,8 +3264,55 @@ def _select_workflow_identity(run, step, identities: IdentityRegistry):
     return candidates[0]
 
 
-def _workflow_job_prompt(run, step, *, builder_job_id: str | None) -> str:
+_LEGACY_CARD_EXECUTION = {
+    "worktree-isolation": (
+        "superpowers:using-git-worktrees",
+        "Confirm the Manager-provisioned worktree; do not create a second worktree.",
+        "forbidden",
+        "none",
+    ),
+    "tdd-red": (
+        "superpowers:test-driven-development",
+        "Use the accepted plan to add and commit a reproducible RED regression test.",
+        "required",
+        "red-required",
+    ),
+    "subagent-build": (
+        "superpowers:subagent-driven-development",
+        "Implement the accepted plan with the minimum diff and commit a tested candidate HEAD.",
+        "required",
+        "focused",
+    ),
+}
+
+
+def _workflow_job_prompt(
+    run,
+    step,
+    *,
+    builder_job_id: str | None,
+    input_snapshot: tuple[dict[str, str], ...] = (),
+) -> str:
+    fallback = _LEGACY_CARD_EXECUTION.get(step.card, (None, None, None, None))
+    source_material: list[dict[str, object]] = []
+    for row in input_snapshot:
+        content_path = Path(row["content_ref"])
+        if content_path.is_symlink() or not content_path.is_file():
+            raise ValueError("workflow input content reference missing")
+        envelope = json.loads(content_path.read_text(encoding="utf-8"))
+        if (
+            not isinstance(envelope, dict)
+            or envelope.get("kind") != "workflow-input-content"
+            or envelope.get("run_id") != run.run_id
+            or envelope.get("path") != row["path"]
+            or envelope.get("sha256") != row["sha256"]
+            or not isinstance(envelope.get("content"), str)
+        ):
+            raise ValueError("workflow input content reference drift")
+        source_material.append({**row, "content": envelope["content"]})
     contract: dict[str, object] = {
+        "schema_version": 1,
+        "kind": "workflow-card-prompt",
         "run_id": run.run_id,
         "work_id": run.work_id,
         "repo": run.repo,
@@ -3084,9 +3320,20 @@ def _workflow_job_prompt(run, step, *, builder_job_id: str | None) -> str:
         "phase": step.phase,
         "card_id": step.card,
         "persona": step.persona,
-        "inputs": list(step.inputs),
+        "inputs": list(dict.fromkeys(row["pattern"] for row in input_snapshot)),
+        "source_material": source_material,
         "declared_outputs": list(step.outputs),
         "candidate": run.candidate_head,
+        "skill_ref": step.skill_ref or fallback[0],
+        "action": step.action or fallback[1],
+        "commit_policy": step.commit_policy or fallback[2],
+        "test_policy": step.test_policy or fallback[3],
+        "terminal_schema": {
+            "kind": "workflow-card",
+            "schema_version": 1,
+            "required": ["schema_version", "kind", "status", "run_id", "card_id", "candidate", "outputs"],
+            "status": ["passed", "failed", "needs_human"],
+        },
     }
     if builder_job_id is not None:
         contract["builder_job_id"] = builder_job_id
@@ -3212,7 +3459,14 @@ def dispatch_workflow_card(
         worktree = str(creator.create(builder_branch))
     else:
         worktree = run.workspace_root
-    effective_repo_root = Path(repo_root if step.persona == "planner" else worktree).resolve()
+    effective_repo_root = Path(worktree).resolve()
+    effective_inputs = _effective_workflow_inputs(run, step)
+    input_snapshot = _workflow_input_snapshot(
+        run=run,
+        repo_root=effective_repo_root,
+        patterns=effective_inputs,
+        coordinator_root=coordinator_root,
+    )
     output_baseline = _workflow_output_baseline(effective_repo_root, step.outputs)
     dispatch_base: str | None = None
     if step.phase == "build":
@@ -3269,7 +3523,8 @@ def dispatch_workflow_card(
             workflow_card=step.card,
             workflow_phase=step.phase,
             workflow_repo_root=repo_root if step.persona == "planner" else worktree,
-            workflow_inputs=step.inputs,
+            workflow_inputs=effective_inputs,
+            workflow_input_snapshot=input_snapshot,
             workflow_outputs=step.outputs,
             source_revision=run.source_revision,
             workflow_sandbox_hash=sandbox_hash,
@@ -3282,7 +3537,12 @@ def dispatch_workflow_card(
     try:
         handle = launcher.launch(
             slice_id=str(job["job_id"]),
-            prompt=_workflow_job_prompt(run, step, builder_job_id=builder_job_id),
+            prompt=_workflow_job_prompt(
+                run,
+                step,
+                builder_job_id=builder_job_id,
+                input_snapshot=input_snapshot,
+            ),
             worktree=worktree,
             log_dir=str(Path(coordinator_root).resolve() / "logs" / "workflow"),
         )
@@ -3309,6 +3569,7 @@ def resume_workflow_run(
     launcher_factory: Callable[[object], object],
     coordinator_root: str | Path,
     ship_validator: Callable[..., object] | None = None,
+    operator_resume: bool = False,
 ) -> dict[str, object]:
     registry = getattr(dispatcher, "_registry", None)
     if registry is None:
@@ -3316,6 +3577,12 @@ def resume_workflow_run(
     run = registry.get_workflow_run(run_id)
     retry_failed = False
     if "needs_human" in run.facets and run.status == "ongoing":
+        if not operator_resume:
+            return {
+                "run_id": run.run_id,
+                "current_phase": run.current_phase,
+                "reason": "operator-resume-required",
+            }
         run = registry._manager_update_workflow_run(
             run.run_id,
             facets=tuple(facet for facet in run.facets if facet != "needs_human"),
@@ -3469,7 +3736,19 @@ def apply_workflow_action(
             or len(value["hash"]) != 64
         ):
             raise ValueError("ship validator current-HEAD result invalid")
-        completion = value.get("completion")
+        normalized = dict(value)
+        normalized.setdefault("review_kind", "copilot")
+        normalized.setdefault("review_ref", value.get("ref"))
+        normalized.setdefault("review_hash", value.get("hash"))
+        if (
+            normalized["review_kind"] not in {"copilot", "maintainer-review"}
+            or not isinstance(normalized["review_ref"], str)
+            or not normalized["review_ref"]
+            or not isinstance(normalized["review_hash"], str)
+            or len(normalized["review_hash"]) != 64
+        ):
+            raise ValueError("ship validator delivery review result invalid")
+        completion = normalized.get("completion")
         if status == "passed" and completion is not None:
             if (
                 not isinstance(completion, dict)
@@ -3494,7 +3773,7 @@ def apply_workflow_action(
                 is None
             ):
                 raise ValueError("ship validator completion binding invalid")
-        return str(status), value
+        return str(status), normalized
 
     if action == "advance":
         if not trusted_terminal:
@@ -3552,7 +3831,11 @@ def apply_workflow_action(
                         "reason": trusted.get("reason") or "delivery-needs-human",
                     }
                 refs = {item.kind: item for item in current.gate_refs}
-                refs["copilot"] = GateEvidenceRef("copilot", trusted["ref"], trusted["hash"])
+                review_kind = trusted["review_kind"]
+                refs.pop("maintainer-review" if review_kind == "copilot" else "copilot", None)
+                refs[review_kind] = GateEvidenceRef(
+                    review_kind, trusted["review_ref"], trusted["review_hash"]
+                )
                 ship_steps = current.steps
                 if trusted.get("completion") is not None:
                     if coordinator_root is None:
@@ -3568,7 +3851,9 @@ def apply_workflow_action(
                     current_phase="ship",
                     steps=ship_steps,
                     gate_refs=tuple(
-                        refs[kind] for kind in ("brainstorm", "foreign-review", "copilot") if kind in refs
+                        refs[kind]
+                        for kind in ("brainstorm", "foreign-review", "copilot", "maintainer-review")
+                        if kind in refs
                     ),
                     gate_status="passed",
                     facets=(),
@@ -3715,8 +4000,10 @@ def apply_workflow_action(
                     candidate=candidate,
                 )
                 if status == "passed":
-                    by_kind["copilot"] = GateEvidenceRef(
-                        "copilot", trusted["ref"], trusted["hash"]
+                    review_kind = trusted["review_kind"]
+                    by_kind.pop("maintainer-review" if review_kind == "copilot" else "copilot", None)
+                    by_kind[review_kind] = GateEvidenceRef(
+                        review_kind, trusted["review_ref"], trusted["review_hash"]
                     )
                     gate_status = "passed"
                     facets = ()
@@ -3744,7 +4031,11 @@ def apply_workflow_action(
                 and trusted.get("completion") is not None
                 else updated_steps
             ),
-            gate_refs=tuple(by_kind[kind] for kind in ("brainstorm", "foreign-review", "copilot") if kind in by_kind),
+            gate_refs=tuple(
+                by_kind[kind]
+                for kind in ("brainstorm", "foreign-review", "copilot", "maintainer-review")
+                if kind in by_kind
+            ),
             gate_status=gate_status,
             candidate_head=candidate,
             verified_head=verified,

--- a/paulsha_cortex/coordinator/manager.py
+++ b/paulsha_cortex/coordinator/manager.py
@@ -2189,18 +2189,25 @@ def _write_workflow_input_content(
     encoded = (
         json.dumps(envelope, ensure_ascii=False, sort_keys=True, separators=(",", ":")) + "\n"
     ).encode("utf-8")
-    path = coordinator_root.resolve() / "evidence" / "workflow-inputs" / f"{digest}.json"
+    locator_digest = hashlib.sha256(encoded).hexdigest()
+    path = coordinator_root.resolve() / "evidence" / "workflow-inputs" / f"{locator_digest}.json"
     path.parent.mkdir(parents=True, exist_ok=True)
     try:
         fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
     except FileExistsError:
-        if path.is_symlink() or path.read_bytes() != encoded:
+        if path.is_symlink() or path.read_bytes() != encoded or path.stat().st_mode & 0o222:
             raise ValueError("workflow input content-address conflict")
     else:
         with os.fdopen(fd, "wb") as stream:
             stream.write(encoded)
             stream.flush()
             os.fsync(stream.fileno())
+        os.chmod(path, 0o444)
+        directory_fd = os.open(path.parent, os.O_RDONLY | os.O_DIRECTORY)
+        try:
+            os.fsync(directory_fd)
+        finally:
+            os.close(directory_fd)
     return str(path)
 
 
@@ -2223,9 +2230,10 @@ def _workflow_input_snapshot(
         if not authority_refs:
             raise ValueError(f"workflow declared input missing: {pattern}")
         for ref in authority_refs:
-            source = operator_root / ref
-            if source.is_symlink() or not source.is_file():
+            source_matches = _safe_input_matches(operator_root, ref)
+            if len(source_matches) != 1:
                 raise ValueError("workflow planning input missing")
+            source = source_matches[0]
             data = source.read_bytes()
             if hashlib.sha256(data).hexdigest() != authority[ref].baseline_sha256:
                 raise ValueError("workflow planning input drift")
@@ -2233,14 +2241,23 @@ def _workflow_input_snapshot(
 
     for ref, data in seeds.items():
         destination = root / ref
-        destination.parent.mkdir(parents=True, exist_ok=True)
+        parent = root
+        for part in Path(ref).parent.parts:
+            child = parent / part
+            if child.is_symlink():
+                raise ValueError("workflow input seed parent symlink rejected")
+            child.mkdir(exist_ok=True)
+            if child.is_symlink() or not child.is_dir():
+                raise ValueError("workflow input seed parent invalid")
+            child.resolve().relative_to(root)
+            parent = child
         if destination.is_symlink():
             raise ValueError("workflow input seed symlink rejected")
         if destination.exists():
             if not destination.is_file() or destination.read_bytes() != data:
                 raise ValueError("workflow input seed conflict")
             continue
-        fd, temporary = tempfile.mkstemp(prefix=f".{destination.name}.", dir=destination.parent)
+        fd, temporary = tempfile.mkstemp(prefix=f".{destination.name}.", dir=parent)
         try:
             with os.fdopen(fd, "wb") as stream:
                 stream.write(data)
@@ -2296,7 +2313,63 @@ def _workflow_input_snapshot(
     return tuple(rows)
 
 
-def _validate_workflow_input_snapshot(repo_root: Path, rows: object) -> None:
+def _read_workflow_input_content(
+    row: Mapping[str, object],
+    *,
+    run=None,
+    coordinator_root: str | Path | None = None,
+) -> dict[str, object]:
+    raw_ref = row.get("content_ref")
+    if not isinstance(raw_ref, str):
+        raise ValueError("workflow input content reference invalid")
+    content_path = Path(raw_ref)
+    if not content_path.is_absolute() or content_path.is_symlink() or not content_path.is_file():
+        raise ValueError("workflow input content reference missing")
+    if content_path.stat().st_mode & 0o222:
+        raise ValueError("workflow input content reference mutable")
+    resolved = content_path.resolve()
+    if coordinator_root is not None:
+        expected_root = Path(coordinator_root).resolve() / "evidence" / "workflow-inputs"
+        if resolved.parent != expected_root:
+            raise ValueError("workflow input content reference outside evidence root")
+    encoded = resolved.read_bytes()
+    if resolved.suffix != ".json" or hashlib.sha256(encoded).hexdigest() != resolved.stem:
+        raise ValueError("workflow input content locator drift")
+    try:
+        envelope = json.loads(encoded.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ValueError("workflow input content reference invalid") from exc
+    required = {
+        "schema_version", "kind", "run_id", "work_id", "repo", "source_revision",
+        "path", "sha256", "content",
+    }
+    if (
+        not isinstance(envelope, dict)
+        or set(envelope) != required
+        or envelope.get("schema_version") != 1
+        or envelope.get("kind") != "workflow-input-content"
+        or envelope.get("path") != row.get("path")
+        or envelope.get("sha256") != row.get("sha256")
+        or not isinstance(envelope.get("content"), str)
+        or hashlib.sha256(envelope["content"].encode("utf-8")).hexdigest() != row.get("sha256")
+    ):
+        raise ValueError("workflow input content reference drift")
+    if run is not None and (
+        envelope.get("run_id") != run.run_id
+        or envelope.get("work_id") != run.work_id
+        or envelope.get("repo") != run.repo
+        or envelope.get("source_revision") != run.source_revision
+    ):
+        raise ValueError("workflow input content authority drift")
+    return envelope
+
+
+def _validate_workflow_input_snapshot(
+    repo_root: Path,
+    rows: object,
+    *,
+    coordinator_root: str | Path | None = None,
+) -> None:
     if not isinstance(rows, list):
         raise ValueError("workflow input snapshot missing")
     for row in rows:
@@ -2312,6 +2385,7 @@ def _validate_workflow_input_snapshot(repo_root: Path, rows: object) -> None:
             raise ValueError("workflow input snapshot file missing")
         if hashlib.sha256(target.read_bytes()).hexdigest() != row["sha256"]:
             raise ValueError("workflow input snapshot hash drift")
+        _read_workflow_input_content(row, coordinator_root=coordinator_root)
 
 
 def _report_binding(content: bytes) -> Mapping[str, object]:
@@ -2491,8 +2565,16 @@ def terminalize_workflow_job(
     if not isinstance(repo_root_value, str) or not repo_root_value:
         raise ValueError("workflow job repo root missing")
     repo_root = Path(repo_root_value).resolve()
+    input_root_value = job.get("workflow_input_root") or repo_root_value
+    if not isinstance(input_root_value, str) or not input_root_value:
+        raise ValueError("workflow job input root missing")
+    input_root = Path(input_root_value).resolve()
     input_snapshot = job.get("workflow_input_snapshot", [])
-    _validate_workflow_input_snapshot(repo_root, input_snapshot)
+    _validate_workflow_input_snapshot(
+        input_root,
+        input_snapshot,
+        coordinator_root=coordinator_root,
+    )
     baseline_rows = job.get("workflow_output_baseline")
     if not isinstance(baseline_rows, list):
         raise ValueError("workflow job output baseline missing")
@@ -3291,24 +3373,17 @@ def _workflow_job_prompt(
     step,
     *,
     builder_job_id: str | None,
+    coordinator_root: str | Path,
     input_snapshot: tuple[dict[str, str], ...] = (),
 ) -> str:
     fallback = _LEGACY_CARD_EXECUTION.get(step.card, (None, None, None, None))
     source_material: list[dict[str, object]] = []
     for row in input_snapshot:
-        content_path = Path(row["content_ref"])
-        if content_path.is_symlink() or not content_path.is_file():
-            raise ValueError("workflow input content reference missing")
-        envelope = json.loads(content_path.read_text(encoding="utf-8"))
-        if (
-            not isinstance(envelope, dict)
-            or envelope.get("kind") != "workflow-input-content"
-            or envelope.get("run_id") != run.run_id
-            or envelope.get("path") != row["path"]
-            or envelope.get("sha256") != row["sha256"]
-            or not isinstance(envelope.get("content"), str)
-        ):
-            raise ValueError("workflow input content reference drift")
+        envelope = _read_workflow_input_content(
+            row,
+            run=run,
+            coordinator_root=coordinator_root,
+        )
         source_material.append({**row, "content": envelope["content"]})
     contract: dict[str, object] = {
         "schema_version": 1,
@@ -3523,6 +3598,7 @@ def dispatch_workflow_card(
             workflow_card=step.card,
             workflow_phase=step.phase,
             workflow_repo_root=repo_root if step.persona == "planner" else worktree,
+            workflow_input_root=worktree,
             workflow_inputs=effective_inputs,
             workflow_input_snapshot=input_snapshot,
             workflow_outputs=step.outputs,
@@ -3541,6 +3617,7 @@ def dispatch_workflow_card(
                 run,
                 step,
                 builder_job_id=builder_job_id,
+                coordinator_root=coordinator_root,
                 input_snapshot=input_snapshot,
             ),
             worktree=worktree,

--- a/paulsha_cortex/coordinator/manager_daemon.py
+++ b/paulsha_cortex/coordinator/manager_daemon.py
@@ -337,6 +337,7 @@ def build_request_executor(
                     launcher_factory=launcher_factory,
                     coordinator_root=coordinator_root,
                     ship_validator=active_ship_validator,
+                    operator_resume=True,
                 )
             result = manager.apply_workflow_action(
                 registry,
@@ -426,6 +427,7 @@ def build_request_executor(
                             launcher_factory=launcher_factory,
                             coordinator_root=coordinator_root,
                             ship_validator=active_ship_validator,
+                            operator_resume=True,
                         )
                         result["result"].update(resumed)
                         result["result"]["run"] = registry.get_workflow_run(

--- a/paulsha_cortex/coordinator/registry.py
+++ b/paulsha_cortex/coordinator/registry.py
@@ -359,7 +359,7 @@ class JobRegistry:
         for field in (
             "executor", "session_name", "log_path", "model_id", "independence_domain",
             "workflow_run_id", "workflow_claim_key", "workflow_repo", "workflow_card",
-            "workflow_phase", "workflow_repo_root", "source_revision",
+            "workflow_phase", "workflow_repo_root", "workflow_input_root", "source_revision",
             "workflow_sandbox_hash",
         ):
             value = job.get(field)
@@ -597,6 +597,7 @@ class JobRegistry:
         workflow_card: str | None = None,
         workflow_phase: str | None = None,
         workflow_repo_root: str | None = None,
+        workflow_input_root: str | None = None,
         workflow_inputs: tuple[str, ...] = (),
         workflow_input_snapshot: tuple[dict[str, str], ...] = (),
         workflow_outputs: tuple[str, ...] = (),
@@ -641,6 +642,7 @@ class JobRegistry:
             "workflow_card": workflow_card,
             "workflow_phase": workflow_phase,
             "workflow_repo_root": workflow_repo_root,
+            "workflow_input_root": workflow_input_root,
             "workflow_inputs": list(workflow_inputs),
             "workflow_input_snapshot": [dict(row) for row in workflow_input_snapshot],
             "workflow_outputs": list(workflow_outputs),

--- a/paulsha_cortex/coordinator/registry.py
+++ b/paulsha_cortex/coordinator/registry.py
@@ -401,6 +401,30 @@ class JobRegistry:
                 raise ValueError(
                     f"coordinator 狀態檔 {field} 格式錯誤（fail-closed）: {self._state_path}"
                 )
+        input_snapshot = job.get("workflow_input_snapshot", [])
+        if not isinstance(input_snapshot, list):
+            raise ValueError(
+                f"coordinator 狀態檔 workflow_input_snapshot 格式錯誤（fail-closed）: {self._state_path}"
+            )
+        snapshot_keys: set[tuple[str, str]] = set()
+        for row in input_snapshot:
+            if (
+                not isinstance(row, dict)
+                or set(row) != {"pattern", "path", "sha256", "authority", "content_ref"}
+                or any(not isinstance(row.get(key), str) or not row[key] for key in row)
+                or Path(row["path"]).is_absolute()
+                or ".." in Path(row["path"]).parts
+                or Path(row["path"]).as_posix() != row["path"]
+                or len(row["sha256"]) != 64
+                or any(char not in "0123456789abcdef" for char in row["sha256"])
+                or row["authority"] not in {"planning-authority", "worktree"}
+                or not Path(row["content_ref"]).is_absolute()
+                or (row["pattern"], row["path"]) in snapshot_keys
+            ):
+                raise ValueError(
+                    f"coordinator 狀態檔 workflow_input_snapshot 格式錯誤（fail-closed）: {self._state_path}"
+                )
+            snapshot_keys.add((row["pattern"], row["path"]))
         output_baseline = job.get("workflow_output_baseline", [])
         if not isinstance(output_baseline, list):
             raise ValueError(
@@ -574,6 +598,7 @@ class JobRegistry:
         workflow_phase: str | None = None,
         workflow_repo_root: str | None = None,
         workflow_inputs: tuple[str, ...] = (),
+        workflow_input_snapshot: tuple[dict[str, str], ...] = (),
         workflow_outputs: tuple[str, ...] = (),
         source_revision: str | None = None,
         workflow_sandbox_hash: str | None = None,
@@ -617,6 +642,7 @@ class JobRegistry:
             "workflow_phase": workflow_phase,
             "workflow_repo_root": workflow_repo_root,
             "workflow_inputs": list(workflow_inputs),
+            "workflow_input_snapshot": [dict(row) for row in workflow_input_snapshot],
             "workflow_outputs": list(workflow_outputs),
             "source_revision": source_revision,
             "workflow_sandbox_hash": workflow_sandbox_hash,

--- a/paulsha_cortex/coordinator/work_actions.py
+++ b/paulsha_cortex/coordinator/work_actions.py
@@ -30,6 +30,7 @@ from .claim import (
 from .delivery import (
     ArchiveGateFacts,
     ForeignReviewEvidence,
+    MaintainerReviewEvidence,
     PullRequestMetadata,
     ReviewLoop,
     ShipOrchestrator,
@@ -47,6 +48,7 @@ from .github_delivery import (
 from . import verification
 from .preflight import PreflightRequest, load_preflight_command, run_preflight
 from .work_bridge import resolve_trusted_repo_root, workflow_status
+from .workflow import GateEvidenceRef
 
 
 Runner = Callable[..., object]
@@ -603,8 +605,9 @@ def _merge_authorization_body(
     binding: dict[str, Any],
     preflight: object,
     remote: object,
-    copilot: object,
+    copilot: object | None,
     foreign_review: ForeignReviewEvidence,
+    maintainer_review: MaintainerReviewEvidence | None = None,
 ) -> dict[str, Any]:
     normalized_foreign = _validate_foreign_review(
         foreign_review,
@@ -612,8 +615,7 @@ def _merge_authorization_body(
     )
     if verification.canonical_json_hash(normalized_foreign) != foreign_review.expected_hash.lower():
         raise RuntimeError("foreign review evidence hash changed during authorization")
-    return {
-        "schema": "cortex-merge-authorization/v1",
+    common = {
         "run_id": active["run_id"],
         "workflow_step_ids": list(active["workflow_step_ids"]),
         "repo": authority.repo,
@@ -624,6 +626,26 @@ def _merge_authorization_body(
         "todo_paths": list(binding["todo_paths"]),
         "head": preflight.head,
         "tree_hash": preflight.tree_hash,
+        "foreign_review_path": foreign_review.path,
+        "foreign_review_hash": foreign_review.expected_hash.lower(),
+        "preflight_hash": _preflight_hash(preflight),
+        "checks_hash": _checks_hash(remote),
+    }
+    if maintainer_review is not None:
+        if copilot is not None:
+            raise ValueError("merge authorization review authority is ambiguous")
+        return {
+            "schema": "cortex-merge-authorization/v2",
+            **common,
+            "review_kind": "maintainer-review",
+            "review_ref": maintainer_review.path,
+            "review_hash": maintainer_review.expected_hash.lower(),
+        }
+    if copilot is None:
+        raise ValueError("merge authorization review authority missing")
+    return {
+        "schema": "cortex-merge-authorization/v1",
+        **common,
         "copilot_requested_at_epoch": copilot.loop.requested_at,
         "copilot_review_id": copilot.review_id,
         "copilot_hash": verification.canonical_json_hash(
@@ -633,10 +655,6 @@ def _merge_authorization_body(
                 "requested_at_epoch": copilot.loop.requested_at,
             }
         ),
-        "foreign_review_path": foreign_review.path,
-        "foreign_review_hash": foreign_review.expected_hash.lower(),
-        "preflight_hash": _preflight_hash(preflight),
-        "checks_hash": _checks_hash(remote),
     }
 
 
@@ -727,7 +745,7 @@ def _authorization_identity_matches(
     body = value.get("payload")
     digest = value.get("hash")
     evidence_path = value.get("path")
-    required = {
+    common_required = {
         "schema",
         "run_id",
         "workflow_step_ids",
@@ -739,17 +757,23 @@ def _authorization_identity_matches(
         "todo_paths",
         "head",
         "tree_hash",
-        "copilot_requested_at_epoch",
-        "copilot_review_id",
-        "copilot_hash",
         "foreign_review_path",
         "foreign_review_hash",
         "preflight_hash",
         "checks_hash",
     }
+    schema = body.get("schema") if isinstance(body, dict) else None
+    review_required = (
+        {"copilot_requested_at_epoch", "copilot_review_id", "copilot_hash"}
+        if schema == "cortex-merge-authorization/v1"
+        else {"review_kind", "review_ref", "review_hash"}
+        if schema == "cortex-merge-authorization/v2"
+        else set()
+    )
     if (
         not isinstance(body, dict)
-        or set(body) != required
+        or not review_required
+        or set(body) != common_required | review_required
         or verification.canonical_json_hash(body) != digest
         or not isinstance(evidence_path, str)
         or not Path(evidence_path).is_absolute()
@@ -764,8 +788,8 @@ def _authorization_identity_matches(
         return False
     if evidence_wrapper != {"payload": body, "hash": digest}:
         return False
-    return (
-        body.get("schema") == "cortex-merge-authorization/v1"
+    common_valid = (
+        schema in {"cortex-merge-authorization/v1", "cortex-merge-authorization/v2"}
         and body.get("run_id") == active.get("run_id")
         and body.get("workflow_step_ids") == active.get("workflow_step_ids")
         and body.get("repo") == authority.repo
@@ -776,29 +800,59 @@ def _authorization_identity_matches(
         and body.get("todo_paths") == binding["todo_paths"]
         and body.get("head") == head
         and body.get("tree_hash") == tree_hash
-        and isinstance(body.get("copilot_review_id"), int)
-        and not isinstance(body.get("copilot_review_id"), bool)
-        and body["copilot_review_id"] > 0
-        and isinstance(body.get("copilot_requested_at_epoch"), (int, float))
-        and not isinstance(body.get("copilot_requested_at_epoch"), bool)
-        and math.isfinite(float(body["copilot_requested_at_epoch"]))
         and isinstance(body.get("foreign_review_path"), str)
         and Path(body["foreign_review_path"]).is_absolute()
         and all(
             isinstance(body.get(field), str)
             and re.fullmatch(r"[0-9a-f]{64}", body[field]) is not None
             for field in (
-                "copilot_hash",
                 "foreign_review_hash",
                 "preflight_hash",
                 "checks_hash",
             )
         )
     )
+    if not common_valid:
+        return False
+    if schema == "cortex-merge-authorization/v1":
+        return (
+            isinstance(body.get("copilot_review_id"), int)
+            and not isinstance(body.get("copilot_review_id"), bool)
+            and body["copilot_review_id"] > 0
+            and isinstance(body.get("copilot_requested_at_epoch"), (int, float))
+            and not isinstance(body.get("copilot_requested_at_epoch"), bool)
+            and math.isfinite(float(body["copilot_requested_at_epoch"]))
+            and isinstance(body.get("copilot_hash"), str)
+            and re.fullmatch(r"[0-9a-f]{64}", body["copilot_hash"]) is not None
+        )
+    review_ref = body.get("review_ref")
+    return (
+        body.get("review_kind") == "maintainer-review"
+        and isinstance(review_ref, str)
+        and Path(review_ref).is_absolute()
+        and not Path(review_ref).is_symlink()
+        and Path(review_ref).is_file()
+        and Path(review_ref).stat().st_mode & 0o222 == 0
+        and isinstance(body.get("review_hash"), str)
+        and re.fullmatch(r"[0-9a-f]{64}", body["review_hash"]) is not None
+    )
 
 
 def _trusted_evidence_refs(authorization: dict[str, Any]) -> tuple[dict[str, str], ...]:
     body = authorization["payload"]
+    current_review = (
+        {
+            "kind": "maintainer-review",
+            "ref": body["review_ref"],
+            "hash": body["review_hash"],
+        }
+        if body.get("schema") == "cortex-merge-authorization/v2"
+        else {
+            "kind": "copilot",
+            "ref": f"github-review:{body['copilot_review_id']}",
+            "hash": body["copilot_hash"],
+        }
+    )
     return (
         {
             "kind": "preflight",
@@ -810,17 +864,299 @@ def _trusted_evidence_refs(authorization: dict[str, Any]) -> tuple[dict[str, str
             "ref": body["foreign_review_path"],
             "hash": body["foreign_review_hash"],
         },
-        {
-            "kind": "copilot",
-            "ref": f"github-review:{body['copilot_review_id']}",
-            "hash": body["copilot_hash"],
-        },
+        current_review,
         {
             "kind": "merge_authorization",
             "ref": authorization["path"],
             "hash": authorization["hash"],
         },
     )
+
+
+def _maintainer_review_record(body: dict[str, Any], *, state_path: Path) -> dict[str, str]:
+    digest = verification.canonical_json_hash(body)
+    root = state_path.resolve().parent / "evidence" / "maintainer-review"
+    root.mkdir(parents=True, exist_ok=True)
+    target = root / f"{body['run_id']}-{body['candidate']}.json"
+    content = (json.dumps(body, ensure_ascii=False, indent=2, sort_keys=True) + "\n").encode("utf-8")
+    if target.exists():
+        if target.is_symlink() or target.read_bytes() != content or target.stat().st_mode & 0o222:
+            raise RuntimeError("maintainer review evidence conflict")
+    else:
+        temporary = root / f".{target.name}.{uuid4().hex}.tmp"
+        try:
+            fd = os.open(temporary, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+            with os.fdopen(fd, "wb") as handle:
+                handle.write(content)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.link(temporary, target)
+            os.chmod(target, 0o444)
+            directory_fd = os.open(root, os.O_RDONLY | os.O_DIRECTORY)
+            try:
+                os.fsync(directory_fd)
+            finally:
+                os.close(directory_fd)
+        except FileExistsError:
+            if target.is_symlink() or target.read_bytes() != content:
+                raise RuntimeError("maintainer review evidence conflict")
+        finally:
+            temporary.unlink(missing_ok=True)
+    return {"ref": str(target), "hash": digest}
+
+
+def _validate_maintainer_review(
+    *,
+    path: object,
+    expected_hash: object,
+    run,
+    authority,
+    pr_number: int,
+    candidate: str,
+) -> dict[str, Any]:
+    evidence_path = _absolute_file(path, field="maintainer_review_path")
+    if evidence_path.stat().st_mode & 0o222:
+        raise ValueError("maintainer review evidence must be immutable")
+    try:
+        body = json.loads(evidence_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ValueError("maintainer review evidence unreadable") from exc
+    bound_refs = [ref for ref in run.gate_refs if ref.kind == "maintainer-review"]
+    if (
+        run.current_phase != "review"
+        or run.candidate_head != candidate
+        or run.verified_head != candidate
+        or len(bound_refs) != 1
+        or bound_refs[0].ref != str(evidence_path)
+        or bound_refs[0].sha256 != expected_hash
+        or not isinstance(body, dict)
+        or body.get("schema") != "cortex-maintainer-review/v1"
+        or body.get("repo") != authority.repo
+        or body.get("work_id") != authority.work_id
+        or body.get("run_id") != run.run_id
+        or body.get("authority_digest") != work_authority_digest(authority)
+        or body.get("pr_number") != pr_number
+        or body.get("candidate") != candidate
+        or body.get("verdict") != "approved"
+        or body.get("findings") != []
+        or not isinstance(expected_hash, str)
+        or re.fullmatch(r"[0-9a-f]{64}", expected_hash) is None
+        or verification.canonical_json_hash(body) != expected_hash
+    ):
+        raise RuntimeError("maintainer review does not authorize exact HEAD")
+    return body
+
+
+def _review_attest_action(
+    *,
+    args: dict[str, Any],
+    requested_by: str,
+    authority,
+    runner: Runner,
+    now_epoch: float,
+    state_path: Path,
+    workflow_registry,
+) -> dict[str, Any]:
+    allowed = {"action", "repo", "work_id", "actor", "verdict", "summary", "findings"}
+    extras = set(args) - allowed
+    if extras:
+        raise ValueError(f"review-attest rejects caller evidence/input: {sorted(extras)[0]}")
+    actor = args.get("actor")
+    summary = args.get("summary")
+    findings = args.get("findings")
+    if (
+        not isinstance(actor, str) or not actor.strip() or len(actor) > 128 or "\n" in actor
+        or args.get("verdict") != "approved"
+        or not isinstance(summary, str) or not summary.strip() or len(summary) > 4000
+        or findings != []
+        or not isinstance(now_epoch, (int, float))
+        or isinstance(now_epoch, bool)
+        or not math.isfinite(float(now_epoch))
+    ):
+        raise ValueError("review-attest payload invalid")
+    _state, active, run = _load_work_run(
+        state_path=state_path,
+        workflow_registry=workflow_registry,
+        authority=authority,
+    )
+    _validate_current_run_authority(active, authority, run)
+    foreign = [ref for ref in run.gate_refs if ref.kind == "foreign-review"]
+    if (
+        run.current_phase != "review"
+        or run.status != "ongoing"
+        or not isinstance(run.candidate_head, str)
+        or run.verified_head != run.candidate_head
+        or len(foreign) != 1
+        or len(authority.mapped_prs) != 1
+        or run.pr_refs != (f"{run.repo}#{authority.mapped_prs[0]}",)
+    ):
+        raise RuntimeError("review-attest requires current exact-HEAD review run")
+    pr_number = authority.mapped_prs[0]
+    remote = GitHubDeliveryClient(runner=runner).fetch_delivery_facts(
+        repo=authority.repo,
+        pr_number=pr_number,
+        change=authority.mapped_openspec[0],
+    )
+    if remote.head != run.candidate_head:
+        raise RuntimeError("review-attest PR HEAD mismatch")
+    body = {
+        "schema": "cortex-maintainer-review/v1",
+        "repo": authority.repo,
+        "work_id": authority.work_id,
+        "run_id": run.run_id,
+        "authority_digest": work_authority_digest(authority),
+        "pr_number": pr_number,
+        "candidate": run.candidate_head,
+        "actor": actor.strip(),
+        "requested_by": requested_by,
+        "verdict": "approved",
+        "summary": summary.strip(),
+        "findings": [],
+        "reviewed_at_epoch": float(now_epoch),
+    }
+    record = _maintainer_review_record(body, state_path=state_path)
+    refs = {ref.kind: ref for ref in run.gate_refs if ref.kind != "copilot"}
+    refs["maintainer-review"] = GateEvidenceRef(
+        "maintainer-review", record["ref"], record["hash"]
+    )
+    workflow_registry._manager_update_workflow_run(
+        run.run_id,
+        gate_refs=tuple(
+            refs[kind]
+            for kind in ("brainstorm", "foreign-review", "maintainer-review")
+            if kind in refs
+        ),
+        facets=(),
+    )
+    return {"action": "review-attested", "head": run.candidate_head, **record}
+
+
+def _ship_with_maintainer_review(
+    *,
+    args: dict[str, Any],
+    active: dict[str, Any],
+    state: dict[str, Any],
+    state_path: Path,
+    authority,
+    canonical_run,
+    binding: dict[str, Any],
+    preflight: object,
+    remote: object,
+    orchestrator: ShipOrchestrator,
+    github: GitHubDeliveryClient,
+    ship: dict[str, Any] | None,
+    fix_rounds: int,
+) -> dict[str, Any]:
+    path = args.get("maintainer_review_path")
+    expected_hash = args.get("maintainer_review_hash")
+    _validate_maintainer_review(
+        path=path,
+        expected_hash=expected_hash,
+        run=canonical_run,
+        authority=authority,
+        pr_number=binding["pr_number"],
+        candidate=preflight.head,
+    )
+    maintainer = MaintainerReviewEvidence(path=str(path), expected_hash=str(expected_hash))
+    foreign_review = ForeignReviewEvidence(
+        path=str(_absolute_file(args.get("foreign_review_path"), field="foreign_review_path")),
+        expected_hash=args.get("foreign_review_hash"),
+    )
+    remote_gate = evaluate_delivery_gate(
+        facts=remote,
+        policy=DeliveryPolicy(
+            expected_head=preflight.head,
+            required_closing_issues=authority.mapped_issues,
+            review_kind="maintainer-review",
+        ),
+    )
+    if not remote_gate.allowed:
+        raise RuntimeError(f"merge authorization blocked: {', '.join(remote_gate.reasons)}")
+    authorization = _authorization_record(
+        _merge_authorization_body(
+            active=active,
+            authority=authority,
+            binding=binding,
+            preflight=preflight,
+            remote=remote,
+            copilot=None,
+            foreign_review=foreign_review,
+            maintainer_review=maintainer,
+        ),
+        state_path=state_path,
+    )
+    existing_authorization = ship.get("merge_authorization") if ship else None
+    if existing_authorization is not None and existing_authorization != authorization:
+        raise RuntimeError("persisted merge authorization differs from current gate evidence")
+    active["ship"] = {
+        **(ship or {}),
+        "phase": "merge-authorized",
+        "head": preflight.head,
+        "tree_hash": preflight.tree_hash,
+        "review_kind": "maintainer-review",
+        "review_ref": maintainer.path,
+        "fix_rounds": fix_rounds,
+        "pr_number": binding["pr_number"],
+        "change": binding["change"],
+        "todo_paths": list(binding["todo_paths"]),
+        "merge_authorization": authorization,
+    }
+    _save_runs(state_path, state)
+    try:
+        merged = orchestrator.merge_if_ready(
+            repo=authority.repo,
+            pr_number=binding["pr_number"],
+            change=binding["change"],
+            expected_head=preflight.head,
+            expected_tree_hash=preflight.tree_hash,
+            authority=authority,
+            preflight=preflight,
+            copilot=None,
+            foreign_review=foreign_review,
+            maintainer_review=maintainer,
+        )
+    except RuntimeError:
+        post_merge = github.fetch_merge_status(
+            repo=authority.repo, pr_number=binding["pr_number"]
+        )
+        if (
+            not post_merge.merged
+            or post_merge.pr_head != preflight.head
+            or not _authorization_matches(
+                authorization,
+                active=active,
+                authority=authority,
+                binding=binding,
+                preflight=preflight,
+                remote=remote,
+            )
+        ):
+            raise
+        merged = SimpleNamespace(
+            expected_head=preflight.head,
+            expected_tree_hash=preflight.tree_hash,
+        )
+    else:
+        post_merge = github.fetch_merge_status(
+            repo=authority.repo, pr_number=binding["pr_number"]
+        )
+        if not post_merge.merged or post_merge.pr_head != preflight.head:
+            raise RuntimeError("merge side effect is not visible on exact PR HEAD")
+    active["ship"] = {
+        **active["ship"],
+        "phase": "merged",
+        "head": merged.expected_head,
+        "tree_hash": merged.expected_tree_hash,
+        "merge_commit": post_merge.merge_commit,
+    }
+    _save_runs(state_path, state)
+    return {
+        "action": "merged-awaiting-closure",
+        "head": preflight.head,
+        "review_kind": "maintainer-review",
+        "review_ref": maintainer.path,
+        "review_hash": maintainer.expected_hash,
+    }
 
 
 def _fallback_workflow_starter(workflow_registry, state_path: Path):
@@ -1449,6 +1785,26 @@ def _ship_action(
     fix_rounds = ship.get("fix_rounds", 0) if ship else 0
     if not isinstance(fix_rounds, int) or isinstance(fix_rounds, bool) or fix_rounds < 0:
         raise ValueError("ship fix round state malformed")
+    has_maintainer_path = args.get("maintainer_review_path") is not None
+    has_maintainer_hash = args.get("maintainer_review_hash") is not None
+    if has_maintainer_path != has_maintainer_hash:
+        raise ValueError("maintainer review path/hash must be supplied together")
+    if has_maintainer_path:
+        return _ship_with_maintainer_review(
+            args=args,
+            active=active,
+            state=state,
+            state_path=state_path,
+            authority=authority,
+            canonical_run=canonical_run,
+            binding=binding,
+            preflight=preflight,
+            remote=remote,
+            orchestrator=orchestrator,
+            github=github,
+            ship=ship,
+            fix_rounds=fix_rounds,
+        )
     if ship and ship.get("phase") == "needs-fix" and previous_head == preflight.head:
         return {"action": "fix-required", "head": preflight.head, "fix_rounds": fix_rounds}
     if previous_head is not None and previous_head != preflight.head:
@@ -1654,7 +2010,7 @@ def execute_work_action(
     action = args.get("action")
     repo = args.get("repo")
     work_id = args.get("work_id")
-    if action not in {"link", "unlink", "start", "resume", "auto", "ship"}:
+    if action not in {"link", "unlink", "start", "resume", "auto", "ship", "review-attest"}:
         raise ValueError("unsupported work action")
     repo = _repo_identity(repo)
     if not isinstance(work_id, str) or re.fullmatch(r"[a-z0-9][a-z0-9-]*", work_id) is None:
@@ -1689,6 +2045,16 @@ def execute_work_action(
             state_path=resolved_state_path,
             workflow_registry=workflow_registry,
             workflow_starter=workflow_starter,
+        )
+    elif action == "review-attest":
+        result = _review_attest_action(
+            args=args,
+            requested_by=requested_by,
+            authority=authority,
+            runner=runner,
+            now_epoch=now_epoch,
+            state_path=resolved_state_path,
+            workflow_registry=workflow_registry,
         )
     elif action == "auto":
         enabled = args.get("enabled")

--- a/paulsha_cortex/coordinator/work_actions.py
+++ b/paulsha_cortex/coordinator/work_actions.py
@@ -826,7 +826,7 @@ def _authorization_identity_matches(
             and re.fullmatch(r"[0-9a-f]{64}", body["copilot_hash"]) is not None
         )
     review_ref = body.get("review_ref")
-    return (
+    if not (
         body.get("review_kind") == "maintainer-review"
         and isinstance(review_ref, str)
         and Path(review_ref).is_absolute()
@@ -835,7 +835,13 @@ def _authorization_identity_matches(
         and Path(review_ref).stat().st_mode & 0o222 == 0
         and isinstance(body.get("review_hash"), str)
         and re.fullmatch(r"[0-9a-f]{64}", body["review_hash"]) is not None
-    )
+    ):
+        return False
+    try:
+        review_payload = json.loads(Path(review_ref).read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return False
+    return verification.canonical_json_hash(review_payload) == body["review_hash"]
 
 
 def _trusted_evidence_refs(authorization: dict[str, Any]) -> tuple[dict[str, str], ...]:
@@ -898,7 +904,11 @@ def _maintainer_review_record(body: dict[str, Any], *, state_path: Path) -> dict
             finally:
                 os.close(directory_fd)
         except FileExistsError:
-            if target.is_symlink() or target.read_bytes() != content:
+            if (
+                target.is_symlink()
+                or target.read_bytes() != content
+                or target.stat().st_mode & 0o222
+            ):
                 raise RuntimeError("maintainer review evidence conflict")
         finally:
             temporary.unlink(missing_ok=True)
@@ -1026,7 +1036,7 @@ def _review_attest_action(
             for kind in ("brainstorm", "foreign-review", "maintainer-review")
             if kind in refs
         ),
-        facets=(),
+        facets=tuple(facet for facet in run.facets if facet != "needs_human"),
     )
     return {"action": "review-attested", "head": run.candidate_head, **record}
 

--- a/paulsha_cortex/coordinator/work_bridge.py
+++ b/paulsha_cortex/coordinator/work_bridge.py
@@ -772,6 +772,11 @@ def _workflow_evidence_payload(
         "outputs": job.get("workflow_outputs", []),
         "output_baseline": job.get("workflow_output_baseline", []),
     }
+    envelope_job = envelope.get("job") if isinstance(envelope, dict) else None
+    if job.get("workflow_input_snapshot") or (
+        isinstance(envelope_job, dict) and "input_snapshot" in envelope_job
+    ):
+        expected_job["input_snapshot"] = job.get("workflow_input_snapshot", [])
     payload = envelope.get("payload") if isinstance(envelope, dict) else None
     if (
         not isinstance(envelope, dict)
@@ -939,6 +944,9 @@ def build_production_ship_validator(
         foreign = [ref for ref in run.gate_refs if ref.kind == "foreign-review"]
         if len(foreign) != 1 or foreign[0].sha256 is None:
             raise ValueError("ship adapter requires canonical foreign-review evidence")
+        maintainer = [ref for ref in run.gate_refs if ref.kind == "maintainer-review"]
+        if len(maintainer) > 1 or (maintainer and maintainer[0].sha256 is None):
+            raise ValueError("ship adapter maintainer-review evidence is ambiguous")
         authority = load_work_authority(
             repo=run.repo,
             work_id=run.work_id,
@@ -1069,6 +1077,9 @@ def build_production_ship_validator(
             "pr_metadata_path": str(metadata_path),
             "skip_tests": False,
         }
+        if maintainer:
+            ship_args["maintainer_review_path"] = maintainer[0].ref
+            ship_args["maintainer_review_hash"] = maintainer[0].sha256
         if completion_draft is not None:
             ship_args["completion_record_path"] = str(completion_draft)
         action = work_actions._ship_action(
@@ -1128,6 +1139,14 @@ def build_production_ship_validator(
             "reason": action.get("reason"),
             **evidence,
         }
+        if maintainer:
+            result.update(
+                {
+                    "review_kind": "maintainer-review",
+                    "review_ref": maintainer[0].ref,
+                    "review_hash": maintainer[0].sha256,
+                }
+            )
         if status == "passed":
             record = action.get("completion_record")
             merge_revision = action.get("merge_commit")

--- a/paulsha_cortex/coordinator/workflow.py
+++ b/paulsha_cortex/coordinator/workflow.py
@@ -79,6 +79,10 @@ class WorkflowStep:
     inputs: tuple[str, ...]
     outputs: tuple[str, ...]
     gate_result: str = "pending"
+    skill_ref: str | None = None
+    action: str | None = None
+    commit_policy: str | None = None
+    test_policy: str | None = None
 
     def __post_init__(self) -> None:
         if self.phase not in WORKFLOW_PHASES:
@@ -94,6 +98,18 @@ class WorkflowStep:
                 raise ValueError(f"workflow step {field} 必須為字串tuple")
         if self.gate_result not in STEP_GATE_RESULTS:
             raise ValueError(f"workflow step gate_result 非法: {self.gate_result!r}")
+        for field, value in (
+            ("skill_ref", self.skill_ref),
+            ("action", self.action),
+            ("commit_policy", self.commit_policy),
+            ("test_policy", self.test_policy),
+        ):
+            if value is not None and (not isinstance(value, str) or not value):
+                raise ValueError(f"workflow step {field} 必須為null或非空字串")
+        if self.commit_policy not in {None, "forbidden", "optional", "required"}:
+            raise ValueError("workflow step commit_policy 非法")
+        if self.test_policy not in {None, "none", "red-required", "focused", "full"}:
+            raise ValueError("workflow step test_policy 非法")
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -106,6 +122,10 @@ class WorkflowStep:
             "inputs": list(self.inputs),
             "outputs": list(self.outputs),
             "gate_result": self.gate_result,
+            "skill_ref": self.skill_ref,
+            "action": self.action,
+            "commit_policy": self.commit_policy,
+            "test_policy": self.test_policy,
         }
 
     @classmethod
@@ -139,6 +159,10 @@ class WorkflowStep:
             inputs=tuple(inputs),
             outputs=tuple(outputs),
             gate_result=payload["gate_result"],
+            skill_ref=payload.get("skill_ref"),
+            action=payload.get("action"),
+            commit_policy=payload.get("commit_policy"),
+            test_policy=payload.get("test_policy"),
         )
 
 
@@ -151,7 +175,7 @@ class GateEvidenceRef:
     sha256: str | None = None
 
     def __post_init__(self) -> None:
-        if self.kind not in {"brainstorm", "foreign-review", "copilot"}:
+        if self.kind not in {"brainstorm", "foreign-review", "copilot", "maintainer-review"}:
             raise ValueError(f"workflow gate evidence kind 非法: {self.kind!r}")
         if not isinstance(self.ref, str) or not self.ref.strip():
             raise ValueError("workflow gate evidence ref 必須為非空字串")
@@ -379,9 +403,11 @@ class WorkflowRun:
         if self.current_phase == "ship":
             if self.gate_status != "passed":
                 raise ValueError("workflow ship gate_status 必須為passed")
-            for required_kind in ("foreign-review", "copilot"):
-                if required_kind not in gate_kinds:
-                    raise ValueError(f"workflow ship 缺少 {required_kind} gate evidence")
+            if "foreign-review" not in gate_kinds:
+                raise ValueError("workflow ship 缺少 foreign-review gate evidence")
+            delivery_reviews = {"copilot", "maintainer-review"} & set(gate_kinds)
+            if len(delivery_reviews) != 1:
+                raise ValueError("workflow ship 必須恰有一種 current-HEAD delivery review gate evidence")
             if self.candidate_head is None or self.verified_head != self.candidate_head:
                 raise ValueError("workflow ship 必須綁定已驗證的exact candidate HEAD")
             for required_phase in ("verify", "review", "ship"):

--- a/paulsha_cortex/deck/compile.py
+++ b/paulsha_cortex/deck/compile.py
@@ -302,6 +302,10 @@ def _compile_workflow_manifest(
                 domain=None,
                 inputs=tuple(_manifest_subst(item, slug, change) for item in card.requires),
                 outputs=tuple(_manifest_subst(item, slug, change) for item in card.produces),
+                skill_ref=card.skill_ref,
+                action=card.action,
+                commit_policy=card.commit_policy,
+                test_policy=card.test_policy,
             )
         )
     return WorkflowManifest(combo=combo.id, task_slug=slug, steps=tuple(steps))

--- a/paulsha_cortex/deck/data/cards.yaml
+++ b/paulsha_cortex/deck/data/cards.yaml
@@ -56,6 +56,10 @@ cards:
     requires: ["docs/superpowers/plans/*<task-slug>*.md"]
     produces: []          # worktree 由 coordinator 派工時自建（feature/<slice_id>）
     persona_binding: builder
+    execution:
+      action: "確認 Manager provision 的 builder worktree，並依 accepted plan 回報隔離狀態；不得另建第二個 worktree"
+      commit_policy: forbidden
+      test_policy: none
 
   - id: tdd-red
     kind: skill
@@ -64,9 +68,13 @@ cards:
     skill_ref: "superpowers:test-driven-development"
     phase: build
     slice_group: build
-    requires: []
+    requires: ["docs/superpowers/plans/*<task-slug>*.md"]
     produces: []          # RED 證據在 build session log／commits，Phase A 不機驗
     persona_binding: builder
+    execution:
+      action: "以 accepted plan 為唯一需求來源，新增可重現缺口的 RED regression test"
+      commit_policy: required
+      test_policy: red-required
 
   - id: subagent-build
     kind: skill
@@ -75,9 +83,13 @@ cards:
     skill_ref: "superpowers:subagent-driven-development"
     phase: build
     slice_group: build
-    requires: []
+    requires: ["docs/superpowers/plans/*<task-slug>*.md"]
     produces: []          # 完成偵測 = manager exit sentinel + branch commits
     persona_binding: builder
+    execution:
+      action: "依 accepted plan 以最小 diff 實作，讓 RED test 轉綠並提交候選 HEAD"
+      commit_policy: required
+      test_policy: focused
 
   - id: code-review
     kind: skill

--- a/paulsha_cortex/deck/schema.py
+++ b/paulsha_cortex/deck/schema.py
@@ -36,8 +36,10 @@ _CARD_KEYS = frozenset(
         "persona_binding",
         "provider_binding",
         "slice_group",
+        "execution",
     }
 )
+_EXECUTION_KEYS = frozenset({"action", "commit_policy", "test_policy"})
 _COMBO_FILE_KEYS = frozenset({"combo"})
 _COMBO_KEYS = frozenset({"id", "task_type", "cards", "gate_spine"})
 _COMBO_ENTRY_KEYS = frozenset({"ref", "depends_on"})
@@ -66,6 +68,9 @@ class Card:
     persona_binding: str | None = None
     provider_binding: str | None = None
     slice_group: str | None = None
+    action: str | None = None
+    commit_policy: str | None = None
+    test_policy: str | None = None
 
 
 @dataclass(frozen=True)
@@ -184,6 +189,24 @@ def load_cards(path: str | Path) -> dict[str, Card]:
         _check_placeholders(cid, requires + produces, rec_errors)
         persona_binding = _optional_str(rec.get("persona_binding"), cid, "persona_binding", rec_errors)
         provider_binding = _optional_str(rec.get("provider_binding"), cid, "provider_binding", rec_errors)
+        execution = rec.get("execution")
+        action = commit_policy = test_policy = None
+        if execution is not None:
+            if not isinstance(execution, Mapping):
+                rec_errors.append(f"{cid}: execution 必須為mapping")
+            else:
+                _check_unknown_keys(f"{cid}.execution", execution, _EXECUTION_KEYS, rec_errors)
+                action = _optional_str(execution.get("action"), cid, "execution.action", rec_errors)
+                commit_policy = _optional_str(
+                    execution.get("commit_policy"), cid, "execution.commit_policy", rec_errors
+                )
+                test_policy = _optional_str(
+                    execution.get("test_policy"), cid, "execution.test_policy", rec_errors
+                )
+                if commit_policy not in {None, "forbidden", "optional", "required"}:
+                    rec_errors.append(f"{cid}: execution.commit_policy 非法值 {commit_policy!r}")
+                if test_policy not in {None, "none", "red-required", "focused", "full"}:
+                    rec_errors.append(f"{cid}: execution.test_policy 非法值 {test_policy!r}")
         slice_group = rec.get("slice_group")
         if slice_group is not None and (not isinstance(slice_group, str) or not slice_group):
             rec_errors.append(f"{cid}: slice_group 必須為非空字串")
@@ -202,6 +225,9 @@ def load_cards(path: str | Path) -> dict[str, Card]:
             persona_binding=persona_binding,
             provider_binding=provider_binding,
             slice_group=slice_group,
+            action=action,
+            commit_policy=commit_policy,
+            test_policy=test_policy,
         )
     if errors:
         raise DeckSchemaError(f"cards 驗證失敗: {source}: " + "; ".join(errors))

--- a/paulsha_cortex/deploy/installer.py
+++ b/paulsha_cortex/deploy/installer.py
@@ -141,6 +141,7 @@ def install_service(instance: str, interval: int, repo_root: Path) -> int:
         env_file,
         {
             "PY": sys.executable,
+            "PSC_INSTANCE": instance,
             "PSC_REPO_ROOT": str(repo_root),
             "PSC_AGENTS_ROOT": str(agents_root),
             "PSC_RUN_ROOT": str(agents_root / "run" / instance),
@@ -149,6 +150,7 @@ def install_service(instance: str, interval: int, repo_root: Path) -> int:
         },
         preserve_existing=frozenset(
             {
+                "PSC_INSTANCE",
                 "PSC_AGENTS_ROOT",
                 "PSC_RUN_ROOT",
                 "PSC_MONITOR_STATE_ROOT",

--- a/paulsha_cortex/deploy/installer.py
+++ b/paulsha_cortex/deploy/installer.py
@@ -80,6 +80,8 @@ def _write_managed_env(
     每次 install 只覆寫本函式管理的鍵；既有的 PSC_MANAGER_SPECS_DIR、
     PSC_WORKTREE_ROOT、PSC_CONTROL_ROOT 等 operator 設定不得被清掉。
     """
+    if env_file.is_symlink():
+        raise ValueError("runtime bootstrap env 不可為 symlink")
     lines = env_file.read_text(encoding="utf-8").splitlines() if env_file.exists() else []
     remaining = dict(managed)
     out: list[str] = []
@@ -99,6 +101,8 @@ def _write_managed_env(
 
 
 def _read_plain_env(env_file: Path) -> dict[str, str]:
+    if env_file.is_symlink():
+        raise ValueError("runtime bootstrap env 不可為 symlink")
     if not env_file.is_file():
         return {}
     values: dict[str, str] = {}

--- a/paulsha_cortex/monitor/work_api.py
+++ b/paulsha_cortex/monitor/work_api.py
@@ -11,7 +11,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Callable, Mapping, Sequence
 
-from .config import default_socket_path
+from .config import load_config
 from .correlation import InferredSignal, correlate_work_sources
 from .lifecycle import ClosureEvidence, project_work_items
 from .models import ProjectState
@@ -277,7 +277,7 @@ class WorkReadModelStore:
 
 class MonitorSocketClient:
     def __init__(self, socket_path: str | Path | None = None, *, timeout: float = 5.0) -> None:
-        self.socket_path = Path(socket_path) if socket_path is not None else default_socket_path()
+        self.socket_path = Path(socket_path) if socket_path is not None else load_config().socket_path
         self.timeout = timeout
 
     def request(self, payload: Mapping) -> dict:

--- a/tests/test_control_client.py
+++ b/tests/test_control_client.py
@@ -117,6 +117,33 @@ def test_submit_work_action_writes_only_a_control_request(monkeypatch, tmp_path)
     }
 
 
+def test_submit_work_action_accepts_review_attest_through_control_contract(monkeypatch, tmp_path):
+    home = tmp_path / "home"
+    agents = tmp_path / "selected-agents"
+    runtime = home / ".agents" / "core" / "runtime"
+    runtime.mkdir(parents=True)
+    (runtime / "beta-manager.env").write_text(
+        f"PSC_AGENTS_ROOT={agents}\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("PSC_INSTANCE", "beta")
+    monkeypatch.delenv("PSC_AGENTS_ROOT", raising=False)
+    monkeypatch.delenv("PSC_CONTROL_ROOT", raising=False)
+
+    req_id = client.submit_work_action(
+        action="review-attest",
+        repo="acme/demo",
+        work_id="demo",
+        args={"actor": "maintainer", "verdict": "approved", "summary": "reviewed"},
+        requested_by="operator",
+    )
+
+    payload = contract.read_json(agents / "control" / "requests" / f"{req_id}.json")
+    assert payload is not None
+    assert payload["args"]["action"] == "review-attest"
+
+
 def test_read_status_degrades_on_missing_or_stale_file(monkeypatch, tmp_path):
     from paulsha_cortex.control import client
 

--- a/tests/test_coordinator_cli_flags.py
+++ b/tests/test_coordinator_cli_flags.py
@@ -2,10 +2,14 @@ from __future__ import annotations
 
 import io
 import json
+import os
 import tempfile
 import unittest
 from contextlib import redirect_stdout
+from pathlib import Path
+from unittest import mock
 
+from paulsha_cortex.control import client as control_client, contract as control_contract
 from paulsha_cortex.coordinator import cli
 from paulsha_cortex.coordinator.cli import _build_parser, _refuse_unsafe_fanout, _resolve_launcher
 from paulsha_cortex.coordinator.launcher import SubprocessLauncher
@@ -118,6 +122,47 @@ class WorkActionFlagTests(unittest.TestCase):
         self.assertEqual(submitted[0][0], "work-action")
         self.assertEqual(submitted[0][1]["action"], "ship")
         self.assertEqual(submitted[0][1]["pr_number"], 8)
+
+    def test_review_attest_parser_writes_valid_durable_control_request(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            payload_path = Path(root) / "review.json"
+            payload_path.write_text(
+                json.dumps(
+                    {
+                        "verdict": "approved",
+                        "summary": "Exact-HEAD review passed.",
+                        "findings": [],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            req_ids: list[str] = []
+
+            def done(req_id, *_args, **_kwargs):
+                req_ids.append(req_id)
+                return {"status": "ok", "result": {"action": "review-attested"}}
+
+            with mock.patch.dict(os.environ, {"PSC_CONTROL_ROOT": root}, clear=False):
+                with redirect_stdout(io.StringIO()):
+                    rc = cli.main(
+                        [
+                            "work", "review-attest", "demo", "--repo", "acme/demo",
+                            "--actor", "maintainer", "--payload", str(payload_path),
+                        ],
+                        control_read_status=lambda: {"degraded": False},
+                        control_submit_request=control_client.submit_request,
+                        control_poll_done=done,
+                    )
+
+            self.assertEqual(rc, 0)
+            request = control_contract.read_json(
+                Path(root) / "requests" / f"{req_ids[0]}.json"
+            )
+            self.assertIsNotNone(request)
+            self.assertEqual(request["args"]["action"], "review-attest")
+            self.assertEqual(request["args"]["actor"], "maintainer")
+            self.assertEqual(request["args"]["verdict"], "approved")
+            self.assertEqual(request["args"]["findings"], [])
 
     def test_work_link_parses_typed_kind_and_ref(self) -> None:
         args = _build_parser().parse_args(

--- a/tests/test_github_delivery.py
+++ b/tests/test_github_delivery.py
@@ -54,6 +54,23 @@ def test_delivery_gate_accepts_exact_current_head_terminal_green() -> None:
     assert result.reasons == ()
 
 
+def test_delivery_gate_accepts_typed_maintainer_review_without_copilot() -> None:
+    facts = replace(_facts(), copilot_reviews=())
+    policy = DeliveryPolicy(
+        expected_head=HEAD,
+        required_closing_issues=(14,),
+        review_kind="maintainer-review",
+    )
+
+    assert evaluate_delivery_gate(facts=facts, policy=policy).allowed
+    blocked = evaluate_delivery_gate(
+        facts=replace(facts, review_threads=(ReviewThread("open", False, False),)),
+        policy=policy,
+    )
+    assert not blocked.allowed
+    assert blocked.reasons == ("review-thread-open",)
+
+
 @pytest.mark.parametrize(
     ("facts", "reason"),
     (

--- a/tests/test_install_service.py
+++ b/tests/test_install_service.py
@@ -151,6 +151,23 @@ def test_install_existing_agents_root_drives_new_specific_defaults(tmp_path, mon
     assert f"PSC_MONITOR_STATE_ROOT={custom_agents / 'monitor'}" in env_lines
 
 
+def test_install_rejects_symlinked_bootstrap_without_overwriting_target(tmp_path, monkeypatch):
+    from paulsha_cortex.deploy import installer
+
+    home = tmp_path / "home"
+    env_file = home / ".agents" / "core" / "runtime" / "beta-manager.env"
+    env_file.parent.mkdir(parents=True)
+    outside = tmp_path / "outside.env"
+    outside.write_text("DO_NOT_OVERWRITE=1\n", encoding="utf-8")
+    env_file.symlink_to(outside)
+    monkeypatch.setenv("HOME", str(home))
+
+    with pytest.raises(ValueError, match="symlink"):
+        installer.install_service("beta", 300, tmp_path / "repo")
+
+    assert outside.read_text(encoding="utf-8") == "DO_NOT_OVERWRITE=1\n"
+
+
 def test_install_rejects_non_git_repo_root(tmp_path, monkeypatch, capsys):
     from paulsha_cortex.deploy import installer
 

--- a/tests/test_install_service.py
+++ b/tests/test_install_service.py
@@ -44,6 +44,7 @@ def test_install_writes_current_python_to_env_file(tmp_path, monkeypatch):
     env_file = tmp_path / ".agents" / "core" / "runtime" / "beta-manager.env"
     env_lines = env_file.read_text(encoding="utf-8").splitlines()
     assert f"PY={sys.executable}" in env_lines
+    assert "PSC_INSTANCE=beta" in env_lines
     assert f"PSC_RUN_ROOT={tmp_path / '.agents' / 'run' / 'beta'}" in env_lines
     assert f"PSC_MONITOR_STATE_ROOT={tmp_path / '.agents' / 'monitor'}" in env_lines
     assert f"PSC_PROJECT_CONFIG_ROOT={tmp_path / '.agents' / 'config' / 'paulsha'}" in env_lines

--- a/tests/test_monitor_config_resolution.py
+++ b/tests/test_monitor_config_resolution.py
@@ -3,6 +3,8 @@ from pathlib import Path
 import pytest
 
 from paulsha_cortex.monitor.config import _resolve_config_source, load_config
+from paulsha_cortex.monitor.work_api import MonitorSocketClient
+from paulsha_cortex.config import paths
 
 
 def _write(p: Path, text="workspaces:\n  - {name: a, path: /tmp/a}\n"):
@@ -37,6 +39,44 @@ def test_none_when_no_manual(monkeypatch, tmp_path):
     monkeypatch.setenv("PSC_PROJECT_CONFIG_ROOT", str(tmp_path / "agents"))
     monkeypatch.setenv("PSC_CONFIG_ROOT", str(tmp_path / "legacy"))
     assert _resolve_config_source(None) is None
+
+
+def test_socket_client_discovers_selected_instance_project_config(monkeypatch, tmp_path):
+    home = tmp_path / "home"
+    runtime = home / ".agents" / "core" / "runtime"
+    runtime.mkdir(parents=True)
+    project_config_root = tmp_path / "selected-config"
+    socket_path = tmp_path / "selected-run" / "monitor.sock"
+    (runtime / "beta-manager.env").write_text(
+        f"PSC_AGENTS_ROOT={tmp_path / 'selected-agents'}\n"
+        f"PSC_RUN_ROOT={tmp_path / 'selected-run'}\n"
+        f"PSC_PROJECT_CONFIG_ROOT={project_config_root}\n",
+        encoding="utf-8",
+    )
+    _write(
+        project_config_root / "project-cortex.yaml",
+        "workspaces:\n"
+        f"  - {{name: selected, path: {tmp_path / 'repo'}}}\n"
+        "monitor:\n"
+        f"  socket_path: {socket_path}\n",
+    )
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("PSC_INSTANCE", "beta")
+    for name in (
+        "PSC_AGENTS_ROOT",
+        "PSC_RUN_ROOT",
+        "PSC_PROJECT_CONFIG_ROOT",
+        "PSC_MONITOR_CONFIG",
+        "PAULSHACLAW_CONFIG",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+    assert paths.agents_root() == tmp_path / "selected-agents"
+    assert paths.control_root() == tmp_path / "selected-agents" / "control"
+    assert paths.coordinator_root() == tmp_path / "selected-agents" / "coordinator"
+    assert paths.specs_root() == tmp_path / "selected-agents" / "specs"
+    assert paths.project_config_root() == project_config_root
+    assert MonitorSocketClient().socket_path == socket_path
 
 
 def test_load_config_wraps_read_os_error(monkeypatch, tmp_path):

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+import pytest
+
 from paulsha_cortex.config import paths
 
 
@@ -32,9 +34,39 @@ def test_worktree_root_is_repo_sibling(monkeypatch, tmp_path):
 
 def test_run_root_default_and_env(monkeypatch, tmp_path):
     monkeypatch.delenv("PSC_RUN_ROOT", raising=False)
-    assert paths.run_root() == Path.home() / ".agents" / "run"
+    monkeypatch.delenv("PSC_INSTANCE", raising=False)
+    assert paths.run_root() == Path.home() / ".agents" / "run" / "cortex"
     monkeypatch.setenv("PSC_RUN_ROOT", str(tmp_path / "run"))
     assert paths.run_root() == tmp_path / "run"
+
+
+def test_run_root_discovers_selected_installed_instance(monkeypatch, tmp_path):
+    home = tmp_path / "home"
+    runtime = home / ".agents" / "core" / "runtime"
+    runtime.mkdir(parents=True)
+    (runtime / "beta-manager.env").write_text(
+        f"PSC_AGENTS_ROOT={tmp_path / 'agents'}\n"
+        f"PSC_RUN_ROOT={tmp_path / 'custom-run'}\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.delenv("PSC_RUN_ROOT", raising=False)
+    monkeypatch.setenv("PSC_INSTANCE", "beta")
+
+    assert paths.run_root() == tmp_path / "custom-run"
+
+
+def test_run_root_rejects_malformed_installed_environment(monkeypatch, tmp_path):
+    home = tmp_path / "home"
+    runtime = home / ".agents" / "core" / "runtime"
+    runtime.mkdir(parents=True)
+    (runtime / "cortex-manager.env").write_text("PSC_RUN_ROOT=relative/run\n", encoding="utf-8")
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.delenv("PSC_RUN_ROOT", raising=False)
+    monkeypatch.delenv("PSC_INSTANCE", raising=False)
+
+    with pytest.raises(ValueError, match="絕對路徑"):
+        paths.run_root()
 
 
 def test_config_path_default(monkeypatch):

--- a/tests/test_work_actions.py
+++ b/tests/test_work_actions.py
@@ -231,7 +231,7 @@ def test_review_attest_writes_immutable_exact_head_evidence(
         pr_refs=("acme/demo#8",),
         gate_refs=(GateEvidenceRef("foreign-review", "/evidence/foreign.json", "f" * 64),),
         gate_status="passed",
-        facets=(),
+        facets=("needs_human", "degraded"),
     )
 
     class GitHub:
@@ -269,6 +269,7 @@ def test_review_attest_writes_immutable_exact_head_evidence(
     review = next(ref for ref in persisted.gate_refs if ref.kind == "maintainer-review")
     assert review.ref == str(evidence)
     assert review.sha256 == first["result"]["hash"]
+    assert persisted.facets == ("degraded",)
 
 
 def test_auto_without_issue_mutates_every_mapped_issue(tmp_path: Path) -> None:
@@ -1613,6 +1614,60 @@ def test_crash_reconcile_uses_stable_authorization_without_rerunning_preflight(
         now=lambda: 220,
     )
     assert result["result"]["action"] == "merged-awaiting-closure"
+
+
+def test_v2_authorization_rejects_tampered_maintainer_review_on_replay(tmp_path: Path) -> None:
+    snapshot = _snapshot(tmp_path / "snapshot.json")
+    state = tmp_path / "runs.json"
+    authority = work_actions.load_work_authority(
+        repo="acme/demo", work_id="demo", snapshot_path=snapshot
+    )
+    active = {"run_id": "workflow-" + "a" * 20, "workflow_step_ids": ["review", "ship"]}
+    binding = {"pr_number": 8, "change": "demo", "todo_paths": ["docs/todo.md"]}
+    review = tmp_path / "maintainer-review.json"
+    review_payload = {"schema": "maintainer-review/v1", "candidate": HEAD, "verdict": "approved"}
+    review.write_text(json.dumps(review_payload), encoding="utf-8")
+    review.chmod(0o444)
+    body = {
+        "schema": "cortex-merge-authorization/v2",
+        "run_id": active["run_id"],
+        "workflow_step_ids": active["workflow_step_ids"],
+        "repo": "acme/demo",
+        "work_id": "demo",
+        "authority_digest": work_actions.work_authority_digest(authority),
+        **binding,
+        "head": HEAD,
+        "tree_hash": TREE,
+        "review_kind": "maintainer-review",
+        "review_ref": str(review),
+        "review_hash": work_actions.verification.canonical_json_hash(review_payload),
+        "foreign_review_path": str(tmp_path / "foreign.json"),
+        "foreign_review_hash": "2" * 64,
+        "preflight_hash": "3" * 64,
+        "checks_hash": "4" * 64,
+    }
+    authorization = work_actions._authorization_record(body, state_path=state)
+    assert work_actions._authorization_identity_matches(
+        authorization,
+        active=active,
+        authority=authority,
+        binding=binding,
+        head=HEAD,
+        tree_hash=TREE,
+    )
+
+    review.chmod(0o600)
+    review.write_text(json.dumps({**review_payload, "verdict": "rejected"}), encoding="utf-8")
+    review.chmod(0o444)
+
+    assert not work_actions._authorization_identity_matches(
+        authorization,
+        active=active,
+        authority=authority,
+        binding=binding,
+        head=HEAD,
+        tree_hash=TREE,
+    )
 
 
 def test_cached_done_replays_remote_closure_instead_of_trusting_local_state(

--- a/tests/test_work_actions.py
+++ b/tests/test_work_actions.py
@@ -18,6 +18,7 @@ from paulsha_cortex.coordinator.github_delivery import (
 )
 from paulsha_cortex.coordinator.preflight import CommandResult, PreflightResult
 from paulsha_cortex.coordinator.registry import JobRegistry
+from paulsha_cortex.coordinator.workflow import GateEvidenceRef
 
 
 HEAD = "a" * 40
@@ -204,6 +205,70 @@ def test_resume_existing_needs_human_reenters_canonical_starter(tmp_path: Path) 
     assert calls == [(claim_key, None)]
     assert result["result"]["run"]["current_phase"] == "plan"
     assert result["result"]["run"]["facets"] == []
+
+
+def test_review_attest_writes_immutable_exact_head_evidence(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    snapshot = _snapshot(tmp_path / "snapshot.json")
+    state = tmp_path / "runs.json"
+    registry = JobRegistry(state_path=tmp_path / "jobs.json")
+    started = work_actions.execute_work_action(
+        args={"action": "start", "repo": "acme/demo", "work_id": "demo"},
+        requested_by="operator",
+        snapshot_path=snapshot,
+        state_path=state,
+        now=lambda: 200,
+        workflow_registry=registry,
+    )
+    run_id = started["result"]["run"]["run_id"]
+    for phase in ("plan", "build", "verify", "review"):
+        registry._manager_update_workflow_run(run_id, current_phase=phase)
+    registry._manager_update_workflow_run(
+        run_id,
+        candidate_head=HEAD,
+        verified_head=HEAD,
+        pr_refs=("acme/demo#8",),
+        gate_refs=(GateEvidenceRef("foreign-review", "/evidence/foreign.json", "f" * 64),),
+        gate_status="passed",
+        facets=(),
+    )
+
+    class GitHub:
+        def __init__(self, *, runner):
+            pass
+
+        def fetch_delivery_facts(self, **kwargs):
+            return DeliveryFacts(
+                head=HEAD, mergeable=True, mergeable_state="clean",
+                checks=(GitHubCheck("pytest", "completed", "success"),),
+                copilot_reviews=(), review_threads=(), closing_issues=(12,),
+                active_openspec_absent=True, archive_present=True,
+            )
+
+    monkeypatch.setattr(work_actions, "GitHubDeliveryClient", GitHub)
+    args = {
+        "action": "review-attest", "repo": "acme/demo", "work_id": "demo",
+        "actor": "maintainer@example", "verdict": "approved",
+        "summary": "Exact-HEAD adversarial review passed.", "findings": [],
+    }
+    first = work_actions.execute_work_action(
+        args=args, requested_by="operator", snapshot_path=snapshot, state_path=state,
+        now=lambda: 210, workflow_registry=registry,
+    )
+    second = work_actions.execute_work_action(
+        args=args, requested_by="operator", snapshot_path=snapshot, state_path=state,
+        now=lambda: 210, workflow_registry=registry,
+    )
+
+    assert first == second
+    evidence = Path(first["result"]["ref"])
+    assert evidence.is_file()
+    assert evidence.stat().st_mode & 0o222 == 0
+    persisted = registry.get_workflow_run(run_id)
+    review = next(ref for ref in persisted.gate_refs if ref.kind == "maintainer-review")
+    assert review.ref == str(evidence)
+    assert review.sha256 == first["result"]["hash"]
 
 
 def test_auto_without_issue_mutates_every_mapped_issue(tmp_path: Path) -> None:

--- a/tests/test_workflow_manifest.py
+++ b/tests/test_workflow_manifest.py
@@ -44,6 +44,10 @@ def test_workflow_step_serializes_all_persisted_fields() -> None:
         "inputs": ("openspec/changes/demo/proposal.md",),
         "outputs": ("docs/superpowers/plans/demo.md",),
         "gate_result": "pending",
+        "skill_ref": None,
+        "action": None,
+        "commit_policy": None,
+        "test_policy": None,
     }
 
 
@@ -70,6 +74,21 @@ def test_feature_oneshot_emits_card_bound_personas_not_global_builder() -> None:
     ]
     assert {step.persona for step in steps} == {"planner", "builder", "reviewer", "manager"}
     assert all(step.gate_result == "pending" for step in steps)
+
+
+def test_manifest_roundtrips_card_execution_contract() -> None:
+    cards, combo = _feature_oneshot()
+    result = compile_combo(combo, cards, "manifest demo", change="demo")
+    manifest = WorkflowManifest.from_dict(result.workflow_manifest.to_dict())
+    red = next(step for step in manifest.steps if step.card == "tdd-red")
+    build = next(step for step in manifest.steps if step.card == "subagent-build")
+
+    assert red.skill_ref == "superpowers:test-driven-development"
+    assert red.commit_policy == "required"
+    assert red.test_policy == "red-required"
+    assert red.inputs == ("docs/superpowers/plans/*manifest-demo*.md",)
+    assert build.action and "accepted plan" in build.action
+    assert build.inputs == red.inputs
 
 
 def test_manifest_resolves_inputs_outputs_and_preserves_slice_frontmatter() -> None:

--- a/tests/test_workflow_production_wiring.py
+++ b/tests/test_workflow_production_wiring.py
@@ -307,6 +307,7 @@ def test_build_input_snapshot_seeds_hash_bound_plan_and_versions_prompt(tmp_path
             run,
             red,
             builder_job_id=None,
+            coordinator_root=tmp_path / "coordinator",
             input_snapshot=snapshot,
         ).split("Contract: ", 1)[1]
     )
@@ -327,6 +328,58 @@ def test_build_input_snapshot_seeds_hash_bound_plan_and_versions_prompt(tmp_path
     assert payload["skill_ref"] == "superpowers:test-driven-development"
     assert payload["source_material"][0]["content"] == plan_bytes.decode()
     assert payload["terminal_schema"]["required"]
+    assert Path(snapshot[0]["content_ref"]).stat().st_mode & 0o222 == 0
+
+
+def test_input_content_tamper_is_rejected_by_prompt_and_terminal_validation(tmp_path: Path) -> None:
+    operator_root = tmp_path / "operator"
+    builder_root = tmp_path / "builder"
+    plan_ref = "docs/superpowers/plans/production-wiring-plan.md"
+    plan = operator_root / plan_ref
+    plan.parent.mkdir(parents=True)
+    plan.write_text("# Accepted\n", encoding="utf-8")
+    builder_root.mkdir()
+    digest = hashlib.sha256(plan.read_bytes()).hexdigest()
+    registry = JobRegistry(state_path=tmp_path / "registry.json")
+    run = registry._manager_create_workflow_run(
+        work_id="production-wiring", repo="hamanpaul/paulsha-cortex",
+        claim_key="claim:v1:" + "1" * 64, source_revision="2" * 64,
+        workspace_root=str(operator_root), combo="feature-oneshot", current_phase="build",
+        steps=_manifest().steps, issue_refs=(), openspec_refs=("production-wiring",), pr_refs=(),
+        attempts={"build": 1}, gate_status="running",
+        planning_authority=(PlanningArtifactAuthority(
+            ref=plan_ref, kind="plan", work_id="production-wiring", baseline_sha256=digest,
+        ),),
+    )
+    red = next(step for step in run.steps if step.card == "tdd-red")
+    coordinator_root = tmp_path / "coordinator"
+    snapshot = manager._workflow_input_snapshot(
+        run=run,
+        repo_root=builder_root,
+        patterns=manager._effective_workflow_inputs(run, red),
+        coordinator_root=coordinator_root,
+    )
+    content_ref = Path(snapshot[0]["content_ref"])
+    envelope = json.loads(content_ref.read_text(encoding="utf-8"))
+    envelope["content"] = "# Tampered\n"
+    content_ref.chmod(0o600)
+    content_ref.write_text(json.dumps(envelope), encoding="utf-8")
+    content_ref.chmod(0o444)
+
+    with pytest.raises(ValueError, match="locator drift"):
+        manager._workflow_job_prompt(
+            run,
+            red,
+            builder_job_id=None,
+            coordinator_root=coordinator_root,
+            input_snapshot=snapshot,
+        )
+    with pytest.raises(ValueError, match="locator drift"):
+        manager._validate_workflow_input_snapshot(
+            builder_root,
+            list(snapshot),
+            coordinator_root=coordinator_root,
+        )
 
 
 def test_build_input_snapshot_rejects_mutable_operator_drift(tmp_path: Path) -> None:
@@ -358,6 +411,78 @@ def test_build_input_snapshot_rejects_mutable_operator_drift(tmp_path: Path) -> 
             coordinator_root=tmp_path / "coordinator",
         )
     assert list(builder_root.rglob("*")) == []
+
+
+def test_build_input_seed_rejects_symlinked_parent_without_outside_write(tmp_path: Path) -> None:
+    operator_root = tmp_path / "operator"
+    builder_root = tmp_path / "builder"
+    outside = tmp_path / "outside"
+    plan_ref = "docs/superpowers/plans/production-wiring-plan.md"
+    plan = operator_root / plan_ref
+    plan.parent.mkdir(parents=True)
+    plan.write_text("# Accepted\n", encoding="utf-8")
+    digest = hashlib.sha256(plan.read_bytes()).hexdigest()
+    builder_root.mkdir()
+    outside.mkdir()
+    (builder_root / "docs").symlink_to(outside, target_is_directory=True)
+    registry = JobRegistry(state_path=tmp_path / "registry.json")
+    run = registry._manager_create_workflow_run(
+        work_id="production-wiring", repo="hamanpaul/paulsha-cortex",
+        claim_key="claim:v1:" + "1" * 64, source_revision="2" * 64,
+        workspace_root=str(operator_root), combo="feature-oneshot", current_phase="build",
+        steps=_manifest().steps, issue_refs=(), openspec_refs=("production-wiring",), pr_refs=(),
+        attempts={"build": 1}, gate_status="running",
+        planning_authority=(PlanningArtifactAuthority(
+            ref=plan_ref, kind="plan", work_id="production-wiring", baseline_sha256=digest,
+        ),),
+    )
+    red = next(step for step in run.steps if step.card == "tdd-red")
+
+    with pytest.raises(ValueError, match="symlink"):
+        manager._workflow_input_snapshot(
+            run=run, repo_root=builder_root,
+            patterns=manager._effective_workflow_inputs(run, red),
+            coordinator_root=tmp_path / "coordinator",
+        )
+    assert not (outside / "superpowers/plans/production-wiring-plan.md").exists()
+
+
+def test_same_input_content_isolated_across_workflow_runs(tmp_path: Path) -> None:
+    refs: list[str] = []
+    for index in (1, 2):
+        operator_root = tmp_path / f"operator-{index}"
+        builder_root = tmp_path / f"builder-{index}"
+        plan_ref = f"docs/superpowers/plans/work-{index}-plan.md"
+        plan = operator_root / plan_ref
+        plan.parent.mkdir(parents=True)
+        plan.write_text("# Identical accepted content\n", encoding="utf-8")
+        builder_root.mkdir()
+        digest = hashlib.sha256(plan.read_bytes()).hexdigest()
+        registry = JobRegistry(state_path=tmp_path / f"registry-{index}.json")
+        manifest = compile_combo(
+            load_combo(DEFAULT_COMBOS_DIR / "feature-oneshot.yaml", load_cards(DEFAULT_CARDS_PATH)),
+            load_cards(DEFAULT_CARDS_PATH), f"work {index}", change=f"work-{index}",
+        ).workflow_manifest
+        run = registry._manager_create_workflow_run(
+            work_id=f"work-{index}", repo="hamanpaul/paulsha-cortex",
+            claim_key=f"claim:v1:{index}" + "1" * 63, source_revision=str(index) * 64,
+            workspace_root=str(operator_root), combo="feature-oneshot", current_phase="build",
+            steps=manifest.steps, issue_refs=(), openspec_refs=(f"work-{index}",), pr_refs=(),
+            attempts={"build": 1}, gate_status="running",
+            planning_authority=(PlanningArtifactAuthority(
+                ref=plan_ref, kind="plan", work_id=f"work-{index}", baseline_sha256=digest,
+            ),),
+        )
+        red = next(step for step in run.steps if step.card == "tdd-red")
+        snapshot = manager._workflow_input_snapshot(
+            run=run, repo_root=builder_root,
+            patterns=manager._effective_workflow_inputs(run, red),
+            coordinator_root=tmp_path / "coordinator",
+        )
+        refs.append(snapshot[0]["content_ref"])
+
+    assert refs[0] != refs[1]
+    assert all(Path(ref).is_file() for ref in refs)
 
 
 def test_control_queue_manager_executes_heterogeneous_brainstorm_before_plan(tmp_path: Path) -> None:
@@ -996,6 +1121,7 @@ def test_failed_planner_retry_replaces_only_its_disposable_sandbox(tmp_path: Pat
         launcher_factory=lambda _: Launcher(),
         coordinator_root=coordinator_root,
     )
+    assert first["workflow_input_root"] == first["worktree"]
     first_sandbox = Path(first["worktree"])
     (first_sandbox / "failed-attempt-marker").write_text("stale\n", encoding="utf-8")
     registry.update_headless_result(first["job_id"], status="failed", exit_code=1)

--- a/tests/test_workflow_production_wiring.py
+++ b/tests/test_workflow_production_wiring.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import hashlib
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -125,10 +126,10 @@ def test_public_work_resume_routes_through_phase_aware_poll_terminalize_advance(
         gate_status="running",
     )
     dispatcher = type("D", (), {"_registry": registry, "_git_runner": None})()
-    calls: list[str] = []
+    calls: list[tuple[str, bool]] = []
 
     def phase_aware_resume(*args, **kwargs):
-        calls.append(kwargs["run_id"])
+        calls.append((kwargs["run_id"], kwargs["operator_resume"]))
         return {
             "run_id": kwargs["run_id"],
             "current_phase": "build",
@@ -163,7 +164,7 @@ def test_public_work_resume_routes_through_phase_aware_poll_terminalize_advance(
         )
     )
 
-    assert calls == [run.run_id]
+    assert calls == [(run.run_id, True)]
     assert result["result"]["current_phase"] == "build"
     assert result["result"]["job_id"] == "new-build-job"
 
@@ -225,9 +226,146 @@ def test_public_work_resume_preserves_define_retry_result(
     assert result["result"]["run"]["facets"] == ["needs_human"]
 
 
+def test_periodic_resume_does_not_clear_needs_human_or_retry(tmp_path: Path) -> None:
+    registry = JobRegistry(state_path=tmp_path / "registry.json")
+    run = registry._manager_create_workflow_run(
+        work_id="production-wiring",
+        repo="hamanpaul/paulsha-cortex",
+        claim_key="claim:v1:" + "1" * 64,
+        source_revision="2" * 64,
+        workspace_root=str(tmp_path),
+        combo="feature-oneshot",
+        current_phase="build",
+        steps=_manifest().steps,
+        issue_refs=("hamanpaul/paulsha-cortex#14",),
+        openspec_refs=("production-wiring",),
+        pr_refs=(),
+        attempts={"build": 1},
+        facets=("needs_human",),
+        gate_status="running",
+    )
+    dispatcher = type("D", (), {"_registry": registry, "_git_runner": None})()
+
+    result = manager.resume_workflow_run(
+        dispatcher,
+        run_id=run.run_id,
+        identities=IdentityRegistry.from_rows([]),
+        launcher_factory=lambda _: (_ for _ in ()).throw(AssertionError("must not launch")),
+        coordinator_root=tmp_path,
+    )
+
+    assert result["reason"] == "operator-resume-required"
+    assert registry.get_workflow_run(run.run_id).facets == ("needs_human",)
+    assert registry.list_jobs() == []
+
+
+def test_build_input_snapshot_seeds_hash_bound_plan_and_versions_prompt(tmp_path: Path) -> None:
+    operator_root = tmp_path / "operator"
+    builder_root = tmp_path / "builder"
+    plan_ref = "docs/superpowers/plans/production-wiring-plan.md"
+    plan = operator_root / plan_ref
+    plan.parent.mkdir(parents=True)
+    plan_bytes = b"# Accepted plan\n\nBuild the contract.\n"
+    plan.write_bytes(plan_bytes)
+    builder_root.mkdir()
+    digest = hashlib.sha256(plan_bytes).hexdigest()
+    registry = JobRegistry(state_path=tmp_path / "registry.json")
+    run = registry._manager_create_workflow_run(
+        work_id="production-wiring",
+        repo="hamanpaul/paulsha-cortex",
+        claim_key="claim:v1:" + "1" * 64,
+        source_revision="2" * 64,
+        workspace_root=str(operator_root),
+        combo="feature-oneshot",
+        current_phase="build",
+        steps=_manifest().steps,
+        issue_refs=("hamanpaul/paulsha-cortex#14",),
+        openspec_refs=("production-wiring",),
+        pr_refs=(),
+        attempts={"build": 1},
+        gate_status="running",
+        planning_authority=(
+            PlanningArtifactAuthority(
+                ref=plan_ref,
+                kind="plan",
+                work_id="production-wiring",
+                baseline_sha256=digest,
+            ),
+        ),
+    )
+    red = next(step for step in run.steps if step.card == "tdd-red")
+
+    patterns = manager._effective_workflow_inputs(run, red)
+    snapshot = manager._workflow_input_snapshot(
+        run=run,
+        repo_root=builder_root,
+        patterns=patterns,
+        coordinator_root=tmp_path / "coordinator",
+    )
+    payload = json.loads(
+        manager._workflow_job_prompt(
+            run,
+            red,
+            builder_job_id=None,
+            input_snapshot=snapshot,
+        ).split("Contract: ", 1)[1]
+    )
+
+    assert patterns == ("docs/superpowers/plans/*production-wiring*.md",)
+    assert (builder_root / plan_ref).read_bytes() == plan_bytes
+    assert snapshot == (
+        {
+            "pattern": patterns[0],
+            "path": plan_ref,
+            "sha256": digest,
+            "authority": "planning-authority",
+            "content_ref": snapshot[0]["content_ref"],
+        },
+    )
+    assert payload["kind"] == "workflow-card-prompt"
+    assert payload["schema_version"] == 1
+    assert payload["skill_ref"] == "superpowers:test-driven-development"
+    assert payload["source_material"][0]["content"] == plan_bytes.decode()
+    assert payload["terminal_schema"]["required"]
+
+
+def test_build_input_snapshot_rejects_mutable_operator_drift(tmp_path: Path) -> None:
+    operator_root = tmp_path / "operator"
+    builder_root = tmp_path / "builder"
+    plan_ref = "docs/superpowers/plans/production-wiring-plan.md"
+    plan = operator_root / plan_ref
+    plan.parent.mkdir(parents=True)
+    plan.write_text("changed after acceptance\n", encoding="utf-8")
+    builder_root.mkdir()
+    registry = JobRegistry(state_path=tmp_path / "registry.json")
+    run = registry._manager_create_workflow_run(
+        work_id="production-wiring", repo="hamanpaul/paulsha-cortex",
+        claim_key="claim:v1:" + "1" * 64, source_revision="2" * 64,
+        workspace_root=str(operator_root), combo="feature-oneshot", current_phase="build",
+        steps=_manifest().steps, issue_refs=(), openspec_refs=("production-wiring",), pr_refs=(),
+        attempts={"build": 1}, gate_status="running",
+        planning_authority=(PlanningArtifactAuthority(
+            ref=plan_ref, kind="plan", work_id="production-wiring", baseline_sha256="0" * 64,
+        ),),
+    )
+    red = next(step for step in run.steps if step.card == "tdd-red")
+
+    with pytest.raises(ValueError, match="planning input drift"):
+        manager._workflow_input_snapshot(
+            run=run,
+            repo_root=builder_root,
+            patterns=manager._effective_workflow_inputs(run, red),
+            coordinator_root=tmp_path / "coordinator",
+        )
+    assert list(builder_root.rglob("*")) == []
+
+
 def test_control_queue_manager_executes_heterogeneous_brainstorm_before_plan(tmp_path: Path) -> None:
     registry = JobRegistry(state_path=tmp_path / "registry.json")
     candidate = "a" * 40
+    proposal = tmp_path / "openspec/changes/production-wiring/proposal.md"
+    proposal.parent.mkdir(parents=True)
+    proposal.write_text("# Proposal\n", encoding="utf-8")
 
     def git_runner(argv, **kwargs):
         if "cat-file" in argv:
@@ -808,6 +946,9 @@ def test_failed_planner_retry_replaces_only_its_disposable_sandbox(tmp_path: Pat
     repo = tmp_path / "repo"
     repo.mkdir()
     (repo / "source.md").write_text("source\n", encoding="utf-8")
+    proposal = repo / "openspec/changes/production-wiring/proposal.md"
+    proposal.parent.mkdir(parents=True)
+    proposal.write_text("# Proposal\n", encoding="utf-8")
     coordinator_root = tmp_path / "coordinator"
     registry = JobRegistry(state_path=coordinator_root / "registry.json")
     run = registry._manager_create_workflow_run(
@@ -933,12 +1074,14 @@ def test_workflow_gate_refs_are_typed_distinct_and_ship_requires_all_three() -> 
     brainstorm = GateEvidenceRef("brainstorm", "evidence/brainstorm.json")
     foreign = GateEvidenceRef("foreign-review", "evidence/foreign.json")
     copilot = GateEvidenceRef("copilot", "evidence/copilot.json")
+    maintainer = GateEvidenceRef("maintainer-review", "evidence/maintainer.json")
 
     assert _run(phase="review", status="passed", refs=(brainstorm, foreign)).gate_status == "passed"
     assert _run(phase="ship", status="passed", refs=(brainstorm, foreign, copilot)).current_phase == "ship"
+    assert _run(phase="ship", status="passed", refs=(brainstorm, foreign, maintainer)).current_phase == "ship"
     with pytest.raises(ValueError, match="foreign-review"):
         _run(phase="review", status="passed", refs=(brainstorm,))
-    with pytest.raises(ValueError, match="copilot"):
+    with pytest.raises(ValueError, match="delivery review"):
         _run(phase="ship", status="passed", refs=(brainstorm, foreign))
     with pytest.raises(ValueError, match="gate_status.*passed"):
         _run(phase="ship", status="running", refs=(brainstorm, foreign, copilot))
@@ -1159,6 +1302,9 @@ def test_complete_plan_does_not_require_or_launch_brainstorm(tmp_path: Path) -> 
     dispatcher = type("D", (), {"_registry": registry, "_git_runner": None})()
     manifest_path = tmp_path / "manifest.json"
     manifest_path.write_text(json.dumps(_manifest().to_dict()), encoding="utf-8")
+    proposal = tmp_path / "openspec/changes/production-wiring/proposal.md"
+    proposal.parent.mkdir(parents=True)
+    proposal.write_text("# Proposal\n", encoding="utf-8")
     bodies = {
         "spec": "---\nstatus: accepted\n---\n# Spec\n## Requirements\nFixed.\n",
         "design": "---\nstatus: accepted\n---\n# Design\n## Decisions\nFixed.\n",


### PR DESCRIPTION
## 摘要

- 以 planning authority 建立 hash-bound workflow input snapshot，將 accepted plan 安全交給獨立 builder worktree。
- 將 headless card prompt 升級為版本化 execution envelope，並阻止 periodic runner 自動重派 `needs_human` job。
- 新增 typed、immutable 的 maintainer exact-HEAD review authority，與 Copilot 二選一但保留 ForeignReview 及所有 GitHub gates。
- 統一 interactive CLI 與 installed service 的 instance-scoped runtime roots／socket discovery，並讓 bootstrap symlink fail-closed。

## 驗證

- [x] `PYTHONPATH=. python3 -m pytest -q`（971 passed、21 subtests）
- [x] `openspec validate --all --strict`（6 passed）
- [x] `git diff --check`
- [x] `python3 -m policy_check --repo .`

## 關聯

關聯 #14；umbrella 尚需完成 live terminal canary 與 archive，因此本 PR 不自動關閉 issue。
