### PR TITLE
fix(delivery): 既有 PR 推送 fresh Candidate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - **deck frontmatter emit 契約與 runtime parser keyset 對齊**：`EMITTED_FRONTMATTER_FIELDS`、deck compile frontmatter 與 `parse_spec_frontmatter()` 現在一致包含 `target_branch` / `verification` / `parse_error`；compile 產生 hold spec 時固定輸出 `null` 欄位，runtime 僅接受 `parse_error: null`（non-null fail-closed），避免 deck contract alignment 漂移。
 
 ### Fixed
+- **既有PR可由Manager推進至fresh exact Candidate**：post-archive修復等流程若WorkflowRun已綁PR但remote branch仍停在舊HEAD，ship adapter現在會先以PR context在乾淨checkout重跑preflight，再冪等push並重讀授權的`feature/*` ref；remote HEAD未精確對齊時維持fail-closed，不再必然卡在`ship HEAD differs from authenticated GitHub PR`。
 - **Official archive 後可安全修復 Candidate finding**：`cortex work retry-build` 現在可在唯一已通過的 ship authority 是 identity 精確的 Manager official archive 時，保留 archive step並重開最後builder與fresh verify/review；brainstorm authority會以同hash的唯一official archive artifact重證，任何其他已通過ship card仍拒絕rewind。新Candidate繼續要求單調延伸，讓archive後才暴露的stale path/test defect可經正式workflow修正。
 - **Terminal canary accepted planning authority 保持 immutable**：Todo bootstrap 與 delivery recovery 不再改寫已由 WorkflowRun hash-bound 的 OpenSpec proposal/design 與 accepted superpowers spec/design/plan；恢復 canonical bytes，讓同一 run 可由 Manager 重驗而不需直接修改 registry。
 - **Delivery target-cardinality stop 可在 authority 收斂後安全續作**：terminal canary 補齊唯一 confirmed Todo 與 repo-local mapping；若 delivery 尚未建立 immutable binding，只因 PR／OpenSpec／Todo target 數量不符而進入 `needs_human`，operator 修正 authority 後可 explicit resume 同一 WorkflowRun。Manager 會先重綁既有 PR run 的 delivery journal authority，再只清除此特定 stop；其他 `needs_human` 與已建立 binding 的 delivery 仍維持 fail-closed。

--- a/changelog.d/31-existing-pr-candidate-push.md
+++ b/changelog.d/31-existing-pr-candidate-push.md
@@ -1,0 +1,1 @@
+fix(delivery): 既有 PR 的 remote HEAD 落後 fresh exact Candidate 時，先以 PR context 完成乾淨 preflight，再由 Manager 冪等 push 並重讀授權 feature ref。

--- a/docs/superpowers/specs/2026-07-17-unified-work-lifecycle.md
+++ b/docs/superpowers/specs/2026-07-17-unified-work-lifecycle.md
@@ -108,7 +108,7 @@ Manager依序：
 1. `openspec archive -y <change>`，驗tasks/canonical specs/doc refs/changelog。
 2. 擬定zh-TW conventional PR title/body/labels，body用`Closes #N`。
 3. 跑快速policy，再跑`PSC_PREFLIGHT_CMD`；preflight含pytest/OpenSpec/PR-context policy。
-4. 開/更新PR，等待checks terminal-green，每次push重請current-HEAD Copilot。
+4. 開/更新PR；若既有PR仍停在修復前HEAD，先以PR context對乾淨exact Candidate重跑preflight，再由Manager冪等push並重讀授權feature ref。等待checks terminal-green，每次push重請current-HEAD Copilot。
 5. 驗Copilot非error、`commit_id == HEAD`、threads resolved/outdated。
 6. Finding最多兩輪builder fix/re-review，每HEAD 15分鐘；逾限needs_human。
 7. Merge前重讀HEAD/mergeability/checks/threads/issues/archive；只用`gh pr merge --merge`。

--- a/openspec/changes/unified-work-lifecycle/specs/governed-delivery-closure/spec.md
+++ b/openspec/changes/unified-work-lifecycle/specs/governed-delivery-closure/spec.md
@@ -15,6 +15,11 @@ Manager MUST先跑`python3 -m policy_check --repo .`，再執行configured `PSC_
 - **WHEN**current tree hash與evidence tree hash不同
 - **THEN**Manager拒絕`--skip-tests`並重跑full suite
 
+#### Scenario: 既有PR仍停在修復前HEAD
+- **WHEN**WorkflowRun已綁定既有PR，但fresh verify/review通過的exact Candidate尚未出現在該PR branch
+- **THEN**Manager先以`--pr N`對乾淨exact-Candidate checkout完成preflight，再冪等push授權的`feature/*` ref並重讀remote HEAD
+- **THEN**remote HEAD未精確等於Candidate時不得進入current-HEAD delivery gate
+
 ### Requirement: Delivery review與GitHub gates必須綁定current HEAD
 開PR後 Manager MUST等待所有required checks terminal-green，並要求恰好一種current-HEAD delivery review authority：request `@copilot`所得的authenticated review，或經control queue建立的typed `maintainer-review` evidence。有效Copilot review MUST非error且`commit_id`等於current HEAD；maintainer evidence MUST immutable且精確綁定repo/work/run/authority digest/PR/current HEAD/actor/verdict。所有current findings threads MUST resolved或outdated。每次push MUST使舊review evidence失效。兩種authority MUST保留實際kind/ref/hash，MUST NOT把maintainer evidence偽裝成Copilot。Delivery review MUST NOT取代ForeignReview。Manager讀取checks、statuses與reviews的REST pagination MUST使用目前支援的typed shell-free gh argv，MUST NOT要求本機gh未提供的`--slurp`；空輸出或任一malformed page MUST fail-closed。
 

--- a/openspec/changes/unified-work-lifecycle/tasks.md
+++ b/openspec/changes/unified-work-lifecycle/tasks.md
@@ -41,6 +41,7 @@
 - [x] 3.9 RED-test並實作pre-binding target-cardinality stop恢復：operator補齊唯一PR/OpenSpec/Todo authority後explicit resume可重綁同一run journal；既有binding與其他needs_human仍fail-closed。
 - [x] 3.10 RED-test並實作post-archive retry-build：只保留Manager-owned official archive authority，重開最後builder並讓新Candidate單調延伸；其他已通過ship card拒絕retry。
 - [x] 3.11 RED-test並修正delivery GitHub pagination：不依賴本機gh不支援的`--slurp`，以typed JSONL page stream完整重讀checks/statuses/reviews，malformed page維持fail-closed。
+- [x] 3.12 RED-test並修正既有PR的Candidate推送：fresh verify/review後先以PR context重跑乾淨exact-Candidate preflight，再由Manager冪等push並重讀授權feature ref，remote HEAD不符時不得進入delivery gate。
 
 ## 4. PR D — Bootstrap, docs, deployment, canary
 

--- a/paulsha_cortex/coordinator/work_bridge.py
+++ b/paulsha_cortex/coordinator/work_bridge.py
@@ -411,6 +411,7 @@ def _push_exact_candidate(
     branch: str,
     candidate: str,
     runner,
+    pre_push: Callable[[], None] | None = None,
 ) -> None:
     if re.fullmatch(r"feature/[a-z0-9][a-z0-9._/-]*", branch) is None:
         raise ValueError("workflow delivery branch is not an authorized feature ref")
@@ -468,6 +469,8 @@ def _push_exact_candidate(
     if persisted is not None and persisted != expected:
         raise RuntimeError("delivery push journal conflicts with Candidate")
     if remote_head != candidate:
+        if pre_push is not None:
+            pre_push()
         pushed = runner(
             ["git", "-C", str(worktree), "push", "origin", f"HEAD:{ref}"],
             shell=False,
@@ -1289,6 +1292,30 @@ def build_production_ship_validator(
             state_root=state_root,
             run=run,
             authority=authority,
+        )
+        def authorize_existing_pr_push() -> None:
+            existing = _run_exact_candidate_preflight(
+                worktree=worktree,
+                branch=branch,
+                candidate=candidate,
+                command=load_preflight_command(),
+                request=PreflightRequest(pr_number=number),
+                runner=runner,
+                now=now,
+            )
+            if not existing.passed or existing.head != candidate:
+                raise RuntimeError("existing PR exact-Candidate preflight failed")
+
+        _push_exact_candidate(
+            registry=registry,
+            run=run,
+            authority=authority,
+            state_root=state_root,
+            worktree=worktree,
+            branch=branch,
+            candidate=candidate,
+            runner=runner,
+            pre_push=authorize_existing_pr_push,
         )
         from . import work_actions
         from . import review as review_evidence

--- a/tests/test_work_bridge.py
+++ b/tests/test_work_bridge.py
@@ -312,19 +312,27 @@ def test_ship_adapter_creates_pr_after_metadata_preflight_and_binds_same_run(
             return "main"
 
     monkeypatch.setattr(work_bridge, "GitHubDeliveryClient", GitHub)
-    pushed = False
+    remote_head = None
+    push_count = 0
 
     def delivery_runner(argv, **kwargs):
-        nonlocal pushed
+        nonlocal push_count, remote_head
         if "ls-remote" in argv:
             return SimpleNamespace(
-                returncode=0 if pushed else 2,
-                stdout=(f"{candidate}\trefs/heads/feature/14-work\n" if pushed else ""),
+                returncode=0 if remote_head is not None else 2,
+                stdout=(
+                    f"{remote_head}\trefs/heads/feature/14-work\n"
+                    if remote_head is not None
+                    else ""
+                ),
                 stderr="",
             )
         if "push" in argv:
             assert argv[-3:] == ["push", "origin", "HEAD:refs/heads/feature/14-work"]
-            pushed = True
+            if push_count == 1:
+                assert preflight_requests[-1].pr_number == 17
+            push_count += 1
+            remote_head = candidate
             return SimpleNamespace(returncode=0, stdout="", stderr="")
         raise AssertionError(argv)
 
@@ -380,6 +388,25 @@ def test_ship_adapter_creates_pr_after_metadata_preflight_and_binds_same_run(
     assert "openspec:acme/demo:work@spec-2" in journal["runs"][run.run_id][
         "source_revisions"
     ]
+
+    # A repaired exact Candidate on an already-bound PR must be preflighted,
+    # pushed, and read back before the ordinary ship state machine compares
+    # authenticated remote facts with the local tree.
+    remote_head = "a" * 40
+    monkeypatch.setattr(
+        work_actions,
+        "_ship_action",
+        lambda **kwargs: {"action": "awaiting-copilot"},
+    )
+    resumed = validator(
+        run=registry.get_workflow_run(run.run_id),
+        candidate=candidate,
+    )
+
+    assert resumed["status"] == "pending"
+    assert remote_head == candidate
+    assert push_count == 2
+    assert preflight_requests[-1].pr_number == 17
 
 
 def test_delivery_report_cleanup_rejects_hash_drift_without_deleting(


### PR DESCRIPTION
## 摘要

- 既有 PR 的遠端 HEAD 落後 fresh verified Candidate 時，先在乾淨 exact-Candidate checkout 以 PR context 執行 preflight。
- preflight 通過後才由 Manager 冪等 push 授權的 feature ref，並重讀 remote HEAD。
- remote 已對齊時不重複執行額外 pre-push preflight。

## 驗證

- [x] `python3 -m pytest -q`（1013 passed，21 subtests）
- [x] `openspec validate --all`（6 passed）
- [x] `python3 -m policy_check --repo .`（21 pass）
- [x] pinned v1.0.12 policy（25 pass，0 fail，1 pre-existing R-22 warn）
- [x] CHANGELOG 與 OpenSpec spec/tasks 已同步
- [x] VERSION 無 release 意圖，維持不變
