### PR TITLE
fix(monitor): 限制 terminal GitHub 讀取範圍

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - **deck frontmatter emit 契約與 runtime parser keyset 對齊**：`EMITTED_FRONTMATTER_FIELDS`、deck compile frontmatter 與 `parse_spec_frontmatter()` 現在一致包含 `target_branch` / `verification` / `parse_error`；compile 產生 hold spec 時固定輸出 `null` 欄位，runtime 僅接受 `parse_error: null`（non-null fail-closed），避免 deck contract alignment 漂移。
 
 ### Fixed
+- **Terminal closure provider不再被GitHub暫時gateway故障或無關PR拖垮**：remote Todo改以default revision精確綁定的Contents API讀取，並逐筆重驗path/blob SHA/encoding；只有HTTP 502/503/504會依有限backoff重試，auth、rate-limit與malformed response仍立即fail-closed。Production ancestry compare只對canonical WorkflowRegistry已連結的PR執行，保留完整PR remote truth但不再為整個repo的歷史merged PR逐筆查詢。
 - **既有PR可由Manager推進至fresh exact Candidate**：post-archive修復等流程若WorkflowRun已綁PR但remote branch仍停在舊HEAD，ship adapter現在會先以PR context在乾淨checkout重跑preflight，再冪等push並重讀授權的`feature/*` ref；remote HEAD未精確對齊時維持fail-closed，不再必然卡在`ship HEAD differs from authenticated GitHub PR`。
 - **Official archive 後可安全修復 Candidate finding**：`cortex work retry-build` 現在可在唯一已通過的 ship authority 是 identity 精確的 Manager official archive 時，保留 archive step並重開最後builder與fresh verify/review；brainstorm authority會以同hash的唯一official archive artifact重證，任何其他已通過ship card仍拒絕rewind。新Candidate繼續要求單調延伸，讓archive後才暴露的stale path/test defect可經正式workflow修正。
 - **Terminal canary accepted planning authority 保持 immutable**：Todo bootstrap 與 delivery recovery 不再改寫已由 WorkflowRun hash-bound 的 OpenSpec proposal/design 與 accepted superpowers spec/design/plan；恢復 canonical bytes，讓同一 run 可由 Manager 重驗而不需直接修改 registry。

--- a/changelog.d/31-terminal-provider-read-retry.md
+++ b/changelog.d/31-terminal-provider-read-retry.md
@@ -1,0 +1,1 @@
+Fixed GitHub terminal closure scans by reading remote Todo files through exact-ref Contents identity checks, bounding retries to transient gateway failures, and limiting production merge ancestry comparisons to canonical workflow-linked PRs.

--- a/changelog.d/31-terminal-provider-read-retry.md
+++ b/changelog.d/31-terminal-provider-read-retry.md
@@ -1,1 +1,1 @@
-Fixed GitHub terminal closure scans by reading remote Todo files through exact-ref Contents identity checks, bounding retries to transient gateway failures, and limiting production merge ancestry comparisons to canonical workflow-linked PRs.
+fix(monitor): remote Todo改用exact-ref Contents identity，retry限於暫時gateway故障，production merge ancestry compare只查canonical workflow-linked PR。

--- a/docs/superpowers/specs/2026-07-17-unified-work-lifecycle.md
+++ b/docs/superpowers/specs/2026-07-17-unified-work-lifecycle.md
@@ -47,6 +47,7 @@ Override schema、negative exclusion與path safety以`CONTEXT.md`為canonical。
 - Provider成功才替換sources；failure保留last-good並更新degraded health。
 - Startup可先讀snapshot提供degraded state；invalid/unknown schema不覆寫合法檔。
 - GitHub default refresh 300秒；900秒沒有success時禁止auto claim與merge。
+- Terminal closure provider以default revision精確呼叫Contents API讀Todo，並驗response path、blob SHA與encoding；production只對WorkflowRegistry canonical linked PR做merge ancestry compare。HTTP 502/503/504可有限backoff重試，auth、rate-limit、其他HTTP錯誤與malformed/identity mismatch仍立即fail-closed並保留last-good。
 
 ### 2.4 CLI/API
 

--- a/docs/unified-work-lifecycle.md
+++ b/docs/unified-work-lifecycle.md
@@ -11,6 +11,8 @@ Monitor 對每個 repo/work item 只公開 `topic`、`todo`、`on-going`、`done
 
 Provider 失敗時會保留 last-good snapshot 並標 `degraded`。GitHub provider 超過 900 秒沒有成功 snapshot 時，auto claim 與 merge 都會 fail-closed。
 
+GitHub terminal closure scan 會以 authenticated default revision 的 Contents API 讀取 remote Todo，並重驗 path、blob SHA 與 base64 encoding；production 只對 canonical WorkflowRegistry 已連結的 PR 做 merge ancestry compare。只有 HTTP 502/503/504 會有限次 backoff retry，auth、rate-limit、其他 HTTP error、malformed JSON 或 identity mismatch 都立即保留 last-good 並標 degraded。
+
 ## Correlation authority
 
 可授權 mutation 的關聯只來自：

--- a/openspec/changes/unified-work-lifecycle/specs/unified-work-read-model/spec.md
+++ b/openspec/changes/unified-work-lifecycle/specs/unified-work-read-model/spec.md
@@ -21,6 +21,8 @@ Monitor MUST從authenticated GitHub、repo artifacts與Manager registry讀取ver
 ### Requirement: Provider失敗必須保留durable last-good
 Monitor MUST將provider snapshots與WorkItems原子保存於`$PSC_MONITOR_STATE_ROOT/work-items.snapshot.json`；未設定時root MUST為`$PSC_AGENTS_ROOT/monitor`，schema MUST為`work-items-snapshot/v1`且file mode MUST為`0600`。Provider只有成功完整scan後 MAY替換其sources/revision/last-success；auth、rate-limit、timeout、I/O、parse或ownership collision MUST保留last-good sources並標`degraded`。Unknown/invalid snapshot MUST NOT覆寫既有合法snapshot。
 
+GitHub terminal closure provider讀取remote Todo時 MUST以authenticated default revision呼叫Contents API，且 MUST逐筆驗證response為file、path與tree entry相同、blob SHA與tree revision相同、encoding為base64。Production ancestry compare MUST只對canonical WorkflowRegistry `workflow_links`已連結至該repo的PR執行；其他PR仍可提供remote state但 MUST NOT取得`merged_with_merge_commit=true`的closure authority。只有明確HTTP 502/503/504 MAY以finite bounded delay重試；auth、rate-limit、其他HTTP error、malformed JSON或identity mismatch MUST立即fail-closed並保留last-good。
+
 #### Scenario: GitHub暫時timeout
 - **WHEN** GitHub provider上次成功後本輪timeout
 - **THEN** snapshot保留上次GitHub sources與revision並更新degraded health
@@ -35,6 +37,11 @@ Monitor MUST將provider snapshots與WorkItems原子保存於`$PSC_MONITOR_STATE_
 - **WHEN** 距最後成功GitHub snapshot超過900秒
 - **THEN** read API仍可顯示last-good state與diagnostic
 - **THEN** Manager拒絕auto claim與merge
+
+#### Scenario: 無關merged PR不觸發terminal ancestry查詢
+- **WHEN** repo含多張歷史merged PR但WorkflowRegistry只把其中一張連結到active work item
+- **THEN** terminal provider只對該workflow-linked PR查詢merge revision是否已進default branch
+- **THEN** 無關PR不得取得closure authority，也不得因其compare API暫時失敗拖垮本輪scan
 
 ### Requirement: Correlation必須區分confirmed與inferred authority
 Confirmed association MUST只來自repo root `.cortex/work-items.yaml` version 1、markdown scalar frontmatter key `work_item`、GitHub closing reference或Manager workflow metadata。Override work ID MUST符合`[a-z0-9][a-z0-9-]*`；path MUST為repo-relative且不可escape。Title、slug、branch與issue token等heuristic MUST至少有兩個獨立訊號、無competing candidate，且只能建立`inferred` display group。單一source MUST NOT屬於兩個confirmed work item；collision MUST令provider degraded。`unlink` MUST保存exclusion。

--- a/openspec/changes/unified-work-lifecycle/tasks.md
+++ b/openspec/changes/unified-work-lifecycle/tasks.md
@@ -42,6 +42,7 @@
 - [x] 3.10 RED-test並實作post-archive retry-build：只保留Manager-owned official archive authority，重開最後builder並讓新Candidate單調延伸；其他已通過ship card拒絕retry。
 - [x] 3.11 RED-test並修正delivery GitHub pagination：不依賴本機gh不支援的`--slurp`，以typed JSONL page stream完整重讀checks/statuses/reviews，malformed page維持fail-closed。
 - [x] 3.12 RED-test並修正既有PR的Candidate推送：fresh verify/review後先以PR context重跑乾淨exact-Candidate preflight，再由Manager冪等push並重讀授權feature ref，remote HEAD不符時不得進入delivery gate。
+- [x] 3.13 RED-test並修正terminal closure provider：Todo以default revision精確綁定的Contents identity讀取，僅bounded retry HTTP 502/503/504，production ancestry compare只查canonical workflow-linked PR。
 
 ## 4. PR D — Bootstrap, docs, deployment, canary
 

--- a/paulsha_cortex/monitor/providers.py
+++ b/paulsha_cortex/monitor/providers.py
@@ -5,11 +5,14 @@ import hashlib
 import base64
 import binascii
 import json
+import math
 import re
 import subprocess
+import time
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Mapping, Protocol, Sequence
+from typing import Any, Callable, Mapping, Protocol, Sequence
+from urllib.parse import quote
 
 import yaml
 
@@ -729,11 +732,37 @@ class GitHubTerminalProvider:
         *,
         runner: CommandRunner | None = None,
         timeout_seconds: float = 30,
+        retry_delays: tuple[float, ...] = (2.0, 5.0, 10.0),
+        sleeper: Callable[[float], None] = time.sleep,
+        relevant_pr_numbers: tuple[int, ...] | None = None,
     ) -> None:
         self.repo = repo
         self.provider_id = f"github-terminal:{repo}"
         self.runner = runner or SubprocessCommandRunner()
         self.timeout_seconds = timeout_seconds
+        if any(
+            not isinstance(delay, (int, float))
+            or isinstance(delay, bool)
+            or not math.isfinite(float(delay))
+            or delay < 0
+            for delay in retry_delays
+        ):
+            raise ValueError("GitHub terminal retry delays must be finite non-negative numbers")
+        self.retry_delays = tuple(float(delay) for delay in retry_delays)
+        self.sleeper = sleeper
+        if relevant_pr_numbers is not None and (
+            len(relevant_pr_numbers) != len(set(relevant_pr_numbers))
+            or any(
+                not isinstance(number, int)
+                or isinstance(number, bool)
+                or number <= 0
+                for number in relevant_pr_numbers
+            )
+        ):
+            raise ValueError("relevant PR numbers must be unique positive integers")
+        self.relevant_pr_numbers = (
+            None if relevant_pr_numbers is None else frozenset(relevant_pr_numbers)
+        )
 
     def scan(self) -> ProviderSnapshot:
         attempted_at = _utcnow()
@@ -765,7 +794,10 @@ class GitHubTerminalProvider:
                 raise ValueError("default branch tree is truncated")
             if not isinstance(tree.get("tree"), list):
                 raise ValueError("default branch tree entries are invalid")
-            remote_todos = self._remote_todos(tree)
+            remote_todos = self._remote_todos(
+                tree,
+                default_revision=default_revision.lower(),
+            )
             paths = {
                 row["path"]
                 for row in tree["tree"]
@@ -834,6 +866,10 @@ class GitHubTerminalProvider:
                     and isinstance(parent_count, int)
                     and not isinstance(parent_count, bool)
                     and parent_count >= 2
+                    and (
+                        self.relevant_pr_numbers is None
+                        or number in self.relevant_pr_numbers
+                    )
                 )
                 if merge_commit:
                     comparison = self._json(
@@ -893,8 +929,19 @@ class GitHubTerminalProvider:
         )
 
     def _json(self, argv: Sequence[str]) -> Mapping:
-        completed = self.runner.run(argv, timeout=self.timeout_seconds)
-        if completed.returncode != 0:
+        completed = None
+        for attempt in range(len(self.retry_delays) + 1):
+            completed = self.runner.run(argv, timeout=self.timeout_seconds)
+            if completed.returncode == 0:
+                break
+            error = f"{completed.stderr}\n{completed.stdout}"
+            if (
+                attempt >= len(self.retry_delays)
+                or re.search(r"\bHTTP (?:502|503|504)\b", error) is None
+            ):
+                raise OSError("gh api failed")
+            self.sleeper(self.retry_delays[attempt])
+        if completed is None or completed.returncode != 0:
             raise OSError("gh api failed")
         payload = json.loads(completed.stdout)
         if not isinstance(payload, Mapping):
@@ -913,7 +960,12 @@ class GitHubTerminalProvider:
             observations={},
         )
 
-    def _remote_todos(self, tree: Mapping) -> list[dict[str, object]]:
+    def _remote_todos(
+        self,
+        tree: Mapping,
+        *,
+        default_revision: str,
+    ) -> list[dict[str, object]]:
         rows: list[dict[str, object]] = []
         for entry in tree.get("tree", []):
             if not isinstance(entry, Mapping):
@@ -935,23 +987,32 @@ class GitHubTerminalProvider:
                 r"[0-9a-fA-F]{40}", revision
             ) is None:
                 raise ValueError("remote Todo tree entry is invalid")
-            blob = self._json(
+            content_file = self._json(
                 (
                     "gh", "api", "--method", "GET",
-                    f"repos/{self.repo}/git/blobs/{revision}",
+                    (
+                        f"repos/{self.repo}/contents/{quote(path, safe='/')}"
+                        f"?ref={default_revision}"
+                    ),
                 )
             )
-            if blob.get("encoding") != "base64" or blob.get("sha") != revision:
-                raise ValueError("remote Todo blob revision mismatch")
-            content = blob.get("content")
+            if (
+                content_file.get("type") != "file"
+                or content_file.get("path") != path
+                or not isinstance(content_file.get("sha"), str)
+                or content_file["sha"].lower() != revision.lower()
+                or content_file.get("encoding") != "base64"
+            ):
+                raise ValueError("remote Todo content identity mismatch")
+            content = content_file.get("content")
             if not isinstance(content, str):
-                raise ValueError("remote Todo blob content is invalid")
+                raise ValueError("remote Todo content is invalid")
             try:
                 text = base64.b64decode(
                     re.sub(r"\s+", "", content), validate=True
                 ).decode("utf-8")
             except (binascii.Error, UnicodeDecodeError) as error:
-                raise ValueError("remote Todo blob content is invalid") from error
+                raise ValueError("remote Todo content is invalid") from error
             row: dict[str, object] = {
                 "path": path,
                 "revision": revision.lower(),

--- a/paulsha_cortex/monitor/work_api.py
+++ b/paulsha_cortex/monitor/work_api.py
@@ -29,6 +29,26 @@ from .work_snapshot import WorkSnapshot, WorkSnapshotStore, work_key
 WORK_API_SCHEMA = "cortex-work/v1"
 
 
+def _workflow_linked_pr_numbers(
+    provider: ProviderSnapshot,
+    *,
+    repo: str,
+) -> tuple[int, ...]:
+    links = provider.observations.get("workflow_links", {})
+    if not isinstance(links, Mapping):
+        return ()
+    prefix = f"github_pr:{repo}#"
+    numbers = {
+        int(source_id[len(prefix) :])
+        for source_id in links
+        if isinstance(source_id, str)
+        and source_id.startswith(prefix)
+        and source_id[len(prefix) :].isdigit()
+        and int(source_id[len(prefix) :]) > 0
+    }
+    return tuple(sorted(numbers))
+
+
 def _utcnow() -> str:
     return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
 
@@ -325,6 +345,9 @@ class WorkModelRefresher:
         self.github_terminal_provider_factory = (
             github_terminal_provider_factory or GitHubTerminalProvider
         )
+        self._uses_default_github_terminal_provider = (
+            github_terminal_provider_factory is None
+        )
         self.workflow_provider_factory = workflow_provider_factory or WorkflowRegistryProvider
         self.stale_after_seconds = stale_after_seconds
         self.now = now or (lambda: datetime.now(timezone.utc))
@@ -371,7 +394,18 @@ class WorkModelRefresher:
                     github = _retain_last_good(providers.get(github_id), github_result)
                     providers[github_id] = github
                     relevant.append(github)
-                    terminal_result = self.github_terminal_provider_factory(repo).scan()
+                    terminal_provider = (
+                        GitHubTerminalProvider(
+                            repo,
+                            relevant_pr_numbers=_workflow_linked_pr_numbers(
+                                workflow,
+                                repo=repo,
+                            ),
+                        )
+                        if self._uses_default_github_terminal_provider
+                        else self.github_terminal_provider_factory(repo)
+                    )
+                    terminal_result = terminal_provider.scan()
                     terminal = _retain_last_good(
                         providers.get(terminal_result.provider_id), terminal_result
                     )

--- a/tests/test_monitor_work_api.py
+++ b/tests/test_monitor_work_api.py
@@ -16,6 +16,7 @@ from paulsha_cortex.monitor.work_api import (
     WorkChangeEvent,
     WorkModelRefresher,
     WorkReadModelStore,
+    _workflow_linked_pr_numbers,
 )
 from paulsha_cortex.monitor.work_models import ProviderSnapshot, WorkItem
 from paulsha_cortex.monitor.work_snapshot import WorkSnapshot
@@ -62,6 +63,28 @@ def test_read_model_list_defaults_hide_done_and_sorts():
     assert envelope["sequence"] == 7
     assert [item["work_id"] for item in envelope["items"]] == ["a-topic", "b-todo"]
     assert envelope["degraded"] is False
+
+
+def test_terminal_pr_filter_comes_only_from_canonical_workflow_links():
+    provider = ProviderSnapshot(
+        provider_id="workflow:example/acme",
+        status="ok",
+        last_attempt_at=NOW,
+        last_success_at=NOW,
+        revision="workflow-1",
+        diagnostics=(),
+        sources=(),
+        observations={
+            "workflow_links": {
+                "github_pr:example/acme#54": "terminal-canary",
+                "github_pr:example/acme#7": "older-work",
+                "github_pr:example/other#99": "other-repo",
+                "github_issue:example/acme#31": "terminal-canary",
+            }
+        },
+    )
+
+    assert _workflow_linked_pr_numbers(provider, repo="example/acme") == (7, 54)
 
 
 def test_read_model_filters_repo_and_normalizes_on_going():

--- a/tests/test_monitor_work_providers.py
+++ b/tests/test_monitor_work_providers.py
@@ -715,6 +715,58 @@ def test_github_terminal_merge_not_on_default_branch_is_not_terminal():
     assert not result.observations["remote_prs"][0]["merged_with_merge_commit"]
 
 
+def test_github_terminal_compares_only_workflow_linked_prs():
+    def merged(number: int, merge: str) -> dict:
+        return {
+            "number": number,
+            "body": "",
+            "headRefName": f"feature/{number}-work",
+            "headRefOid": str(number % 10) * 40,
+            "state": "MERGED",
+            "mergedAt": "2026-07-17T10:00:00Z",
+            "mergeCommit": {"oid": merge, "parents": {"totalCount": 2}},
+            "closingIssuesReferences": {
+                "pageInfo": {"hasNextPage": False},
+                "nodes": [{"number": number, "state": "CLOSED"}],
+            },
+        }
+
+    graph = {
+        "data": {
+            "repository": {
+                "defaultBranchRef": {"name": "main", "target": {"oid": "d" * 40}},
+                "pullRequests": {
+                    "pageInfo": {"hasNextPage": False},
+                    "nodes": [merged(8, "a" * 40), merged(9, "b" * 40)],
+                },
+            }
+        }
+    }
+    runner = SequenceRunner(
+        [
+            _completed(graph),
+            _completed({"truncated": False, "tree": []}),
+            _completed({"status": "ahead"}),
+        ]
+    )
+
+    result = GitHubTerminalProvider(
+        "example/acme",
+        runner=runner,
+        relevant_pr_numbers=(9,),
+    ).scan()
+
+    assert result.status == "ok"
+    assert len(runner.calls) == 3
+    assert "compare/" + "b" * 40 in runner.calls[2][-1]
+    by_number = {
+        int(row["source_id"].rsplit("#", 1)[1]): row
+        for row in result.observations["remote_prs"]
+    }
+    assert by_number[8]["merged_with_merge_commit"] is False
+    assert by_number[9]["merged_with_merge_commit"] is True
+
+
 def test_github_terminal_truncated_tree_is_degraded():
     graph = {
         "data": {
@@ -731,6 +783,61 @@ def test_github_terminal_truncated_tree_is_degraded():
     result = GitHubTerminalProvider("example/acme", runner=runner).scan()
 
     assert result.status == "degraded"
+
+
+def test_github_terminal_retries_only_transient_gateway_failures():
+    graph = {
+        "data": {
+            "repository": {
+                "defaultBranchRef": {"name": "main", "target": {"oid": "d" * 40}},
+                "pullRequests": {"pageInfo": {"hasNextPage": False}, "nodes": []},
+            }
+        }
+    }
+    transient = _completed(
+        {"message": "temporarily unavailable"},
+        returncode=1,
+        stderr="gh: temporarily unavailable (HTTP 503)",
+    )
+    runner = SequenceRunner(
+        [transient, _completed(graph), _completed({"truncated": False, "tree": []})]
+    )
+    sleeps = []
+
+    result = GitHubTerminalProvider(
+        "example/acme",
+        runner=runner,
+        retry_delays=(0.25,),
+        sleeper=sleeps.append,
+    ).scan()
+
+    assert result.status == "ok"
+    assert sleeps == [0.25]
+    assert runner.calls[0] == runner.calls[1]
+
+
+def test_github_terminal_does_not_retry_non_transient_api_failure():
+    runner = SequenceRunner(
+        [
+            _completed(
+                {"message": "bad credentials"},
+                returncode=1,
+                stderr="gh: bad credentials (HTTP 401)",
+            )
+        ]
+    )
+    sleeps = []
+
+    result = GitHubTerminalProvider(
+        "example/acme",
+        runner=runner,
+        retry_delays=(0.25, 0.5),
+        sleeper=sleeps.append,
+    ).scan()
+
+    assert result.status == "degraded"
+    assert sleeps == []
+    assert len(runner.calls) == 1
 
 
 def test_remote_default_branch_todo_blob_is_only_completion_authority(tmp_path):
@@ -760,6 +867,8 @@ def test_remote_default_branch_todo_blob_is_only_completion_authority(tmp_path):
     }
     remote_body = "---\nwork_item: work\n---\n- [x] remote task\n"
     blob = {
+        "type": "file",
+        "path": "docs/superpowers/workstreams/work/todo.md",
         "encoding": "base64",
         "content": base64.b64encode(remote_body.encode()).decode(),
         "sha": "c" * 40,
@@ -777,6 +886,14 @@ def test_remote_default_branch_todo_blob_is_only_completion_authority(tmp_path):
             "complete": True,
         }
     ]
+    assert runner.calls[2] == (
+        "gh",
+        "api",
+        "--method",
+        "GET",
+        "repos/example/acme/contents/docs/superpowers/workstreams/work/todo.md?ref="
+        + "d" * 40,
+    )
 
 
 def test_remote_archived_openspec_tasks_are_todo_completion_evidence():
@@ -794,6 +911,8 @@ def test_remote_archived_openspec_tasks_are_todo_completion_evidence():
         "tree": [{"path": task_path, "type": "blob", "sha": "c" * 40}],
     }
     blob = {
+        "type": "file",
+        "path": task_path,
         "encoding": "base64",
         "content": base64.b64encode(b"- [x] task one\n- [x] task two\n").decode(),
         "sha": "c" * 40,
@@ -814,6 +933,35 @@ def test_remote_archived_openspec_tasks_are_todo_completion_evidence():
     assert [(source.ref, source.status) for source in result.sources] == [
         ("canary", "archived")
     ]
+
+
+def test_remote_todo_contents_identity_mismatch_is_degraded():
+    graph = {
+        "data": {
+            "repository": {
+                "defaultBranchRef": {"name": "main", "target": {"oid": "d" * 40}},
+                "pullRequests": {"pageInfo": {"hasNextPage": False}, "nodes": []},
+            }
+        }
+    }
+    path = "docs/superpowers/workstreams/work/todo.md"
+    tree = {
+        "truncated": False,
+        "tree": [{"path": path, "type": "blob", "sha": "c" * 40}],
+    }
+    contents = {
+        "type": "file",
+        "path": path,
+        "encoding": "base64",
+        "content": base64.b64encode(b"- [x] task\n").decode(),
+        "sha": "e" * 40,
+    }
+    runner = SequenceRunner([_completed(graph), _completed(tree), _completed(contents)])
+
+    result = GitHubTerminalProvider("example/acme", runner=runner).scan()
+
+    assert result.status == "degraded"
+    assert result.observations == {}
 
 
 def test_pr_body_work_item_is_not_confirmed_authority():

--- a/tests/test_monitor_work_review_regressions.py
+++ b/tests/test_monitor_work_review_regressions.py
@@ -173,6 +173,57 @@ def _provider(provider_id: str, sources=(), *, observations=None, at=NOW):
     )
 
 
+def test_default_terminal_provider_receives_only_registry_linked_prs(
+    tmp_path, monkeypatch
+):
+    captured: list[tuple[str, tuple[int, ...] | None]] = []
+
+    class CapturingTerminalProvider:
+        def __init__(self, repo: str, *, relevant_pr_numbers=None):
+            captured.append((repo, relevant_pr_numbers))
+            self.repo = repo
+
+        def scan(self) -> ProviderSnapshot:
+            return _provider(f"github-terminal:{self.repo}")
+
+    monkeypatch.setattr(
+        "paulsha_cortex.monitor.work_api.GitHubTerminalProvider",
+        CapturingTerminalProvider,
+    )
+    workflow = _provider(
+        "workflow:example/acme",
+        observations={
+            "workflow_links": {
+                "github_pr:example/acme#9": "work",
+                "github_issue:example/acme#7": "work",
+                "github_pr:example/other#11": "other",
+            }
+        },
+    )
+    refresher = WorkModelRefresher(
+        durable_store=WorkSnapshotStore(tmp_path / "snapshot.json"),
+        read_store=WorkReadModelStore.empty(),
+        github_provider_factory=lambda _repo: _StaticProvider(
+            _provider("github:example/acme")
+        ),
+        workflow_provider_factory=lambda _repo: _StaticProvider(workflow),
+        now=lambda: datetime(2026, 7, 17, 10, 0, tzinfo=timezone.utc),
+    )
+
+    refresher.refresh(
+        (
+            ProjectState(
+                project_id="example/acme",
+                workspace="ws",
+                path=str(tmp_path),
+            ),
+        ),
+        include_github=True,
+    )
+
+    assert captured == [("example/acme", (9,))]
+
+
 def test_live_provider_freshness_uses_post_scan_clock(tmp_path):
     repo = tmp_path / "repo"
     proposal = repo / "openspec/changes/canary/proposal.md"


### PR DESCRIPTION
## 摘要

- remote Todo 改用 exact default revision 的 Contents API，重驗 response path、blob SHA 與 encoding。
- 只有 HTTP 502/503/504 會做有限 backoff retry；auth、rate-limit、其他錯誤與 malformed response 仍立即 fail-closed。
- production merge ancestry compare 只針對 canonical WorkflowRegistry 已連結的 PR，避免無關歷史 PR 拖垮整輪 terminal scan。
- 保留所有 PR remote truth；未被 workflow 連結的 PR 不取得 terminal closure authority。

## 驗證

- [x] `python3 -m pytest -q`（1019 passed，21 subtests）
- [x] Monitor regression（72 passed）
- [x] live source smoke（provider status `ok`，49 PR、2 remote Todo）
- [x] `openspec validate --all --strict`（6 passed）
- [x] repo policy（25 pass，0 fail，1 pre-existing R-22 warn）
- [x] pinned v1.0.12 policy（25 pass，0 fail，1 pre-existing R-22 warn）
- [x] docs、OpenSpec spec/tasks、CHANGELOG 與 fragment 已同步
- [x] VERSION 無 release 意圖，維持不變
