### PR TITLE
fix(work): fail closed on delivery findings

### DIFF
--- a/changelog.d/31-delivery-fix-required-needs-human.md
+++ b/changelog.d/31-delivery-fix-required-needs-human.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- 將 current-HEAD review finding 的 `fix-required` delivery 結果映射為 `needs_human`，恢復 exact-Candidate `retry-build` 修復閉環。

--- a/docs/unified-work-lifecycle.md
+++ b/docs/unified-work-lifecycle.md
@@ -99,6 +99,6 @@ Manager 是唯一 writer。每次 push 都會使上一個 delivery review epoch 
 - terminal-green checks/statuses、closing refs、archive diff 與 mergeability；
 - fresh GitHub provider snapshot。
 
-最多兩輪 builder fix/re-review，每個 HEAD 等待 15 分鐘；第三次仍有 finding 或逾時即 `needs_human`。合併只使用 `gh pr merge --merge --match-head-commit <HEAD>`，不使用 auto/squash/rebase。Merge 後會重新 fetch default branch，驗證雙親 merge commit ancestry、issue、archive、Todo 與 CompletionRecord，全部成立才投影 `done`。
+最多兩輪 builder fix/re-review，每個 HEAD 等待 15 分鐘；current-HEAD review 出現 finding 時，delivery adapter 會把 `fix-required` fail-closed 投影為 `needs_human`，只有 operator 的 exact-Candidate `retry-build` 才能重開 builder；第三次仍有 finding 或逾時也維持 `needs_human`。合併只使用 `gh pr merge --merge --match-head-commit <HEAD>`，不使用 auto/squash/rebase。Merge 後會重新 fetch default branch，驗證雙親 merge commit ancestry、issue、archive、Todo 與 CompletionRecord，全部成立才投影 `done`。
 
 V1 terminal delivery 僅支援 GitHub。其他 forge 仍可顯示 read model，但 ship 會停在 `needs_human`。

--- a/openspec/changes/unified-work-lifecycle/tasks.md
+++ b/openspec/changes/unified-work-lifecycle/tasks.md
@@ -45,6 +45,7 @@
 - [x] 3.13 RED-test並修正terminal closure provider：Todo以default revision精確綁定的Contents identity讀取，僅bounded retry HTTP 502/503/504，production ancestry compare只查canonical workflow-linked PR。
 - [x] 3.14 RED-test並修正existing-PR metadata transaction：title/body PATCH、labels PUT及identity reread僅對HTTP 502/503/504 bounded retry；create/push/merge side effect維持單次fail-closed。
 - [x] 3.15 RED-test並修正exact metadata冪等性：先authenticated reread title/body/labels，全部一致時不發PATCH/PUT；只有drift才write並再次完整reread。
+- [x] 3.16 RED-test並修正delivery finding閉環：`fix-required`由trusted adapter fail-closed映射為`needs_human`，使operator可用exact-Candidate `retry-build`重開builder。
 
 ## 4. PR D — Bootstrap, docs, deployment, canary
 

--- a/paulsha_cortex/coordinator/work_bridge.py
+++ b/paulsha_cortex/coordinator/work_bridge.py
@@ -1162,6 +1162,8 @@ def _completion_draft(
 
 
 def _delivery_adapter_status(action: object) -> str:
+    if not isinstance(action, str):
+        return "pending"
     if action == "done":
         return "passed"
     if action in {"fix-required", "needs_human"}:

--- a/paulsha_cortex/coordinator/work_bridge.py
+++ b/paulsha_cortex/coordinator/work_bridge.py
@@ -1161,6 +1161,14 @@ def _completion_draft(
     return target
 
 
+def _delivery_adapter_status(action: object) -> str:
+    if action == "done":
+        return "passed"
+    if action in {"fix-required", "needs_human"}:
+        return "needs_human"
+    return "pending"
+
+
 def build_production_ship_validator(
     *,
     registry,
@@ -1394,9 +1402,7 @@ def build_production_ship_validator(
                 old_head=candidate,
                 new_head=candidate,
             )
-        status = "passed" if action.get("action") == "done" else "pending"
-        if action.get("action") == "needs_human":
-            status = "needs_human"
+        status = _delivery_adapter_status(action.get("action"))
         evidence = _write_json_evidence(
             state_root,
             "delivery-adapter",

--- a/tests/test_work_bridge.py
+++ b/tests/test_work_bridge.py
@@ -116,6 +116,19 @@ def _steps() -> tuple[WorkflowStep, ...]:
     )
 
 
+@pytest.mark.parametrize(
+    ("action", "expected"),
+    [
+        ("done", "passed"),
+        ("fix-required", "needs_human"),
+        ("needs_human", "needs_human"),
+        ("awaiting-copilot", "pending"),
+    ],
+)
+def test_delivery_adapter_status(action: str, expected: str) -> None:
+    assert work_bridge._delivery_adapter_status(action) == expected
+
+
 def test_ship_adapter_creates_pr_after_metadata_preflight_and_binds_same_run(
     monkeypatch, tmp_path: Path
 ) -> None:

--- a/tests/test_work_bridge.py
+++ b/tests/test_work_bridge.py
@@ -119,13 +119,15 @@ def _steps() -> tuple[WorkflowStep, ...]:
 @pytest.mark.parametrize(
     ("action", "expected"),
     [
+        (None, "pending"),
+        ({}, "pending"),
         ("done", "passed"),
         ("fix-required", "needs_human"),
         ("needs_human", "needs_human"),
         ("awaiting-copilot", "pending"),
     ],
 )
-def test_delivery_adapter_status(action: str, expected: str) -> None:
+def test_delivery_adapter_status(action: object, expected: str) -> None:
     assert work_bridge._delivery_adapter_status(action) == expected
 
 


### PR DESCRIPTION
## 摘要

- 將 trusted delivery adapter 的 `fix-required` 結果映射為 `needs_human`
- 恢復 current-HEAD Copilot finding 到 exact-Candidate `retry-build` 的官方閉環
- 補 focused mapping test、文件、OpenSpec task 與 changelog fragment

## 驗證

- `python3 -m pytest -q`（1027 passed, 21 subtests passed）
- `openspec validate unified-work-lifecycle --strict`
- `PYTHONPATH=/tmp/psc-policy-Ar13QF python3 -m policy_check --repo .`（25 pass, 0 fail, 1 pre-existing WARN）

## Checklist

- [x] 本次變更已在 feature branch 完成
- [x] 已新增 changelog fragment
- [x] 已更新對應文件與 OpenSpec task
- [x] 已通過 full pytest、OpenSpec 與 policy gate
- [x] PR 內容使用 zh-TW