### PR TITLE
test(workflow): 隔離 planning completion launcher

### DIFF
--- a/tests/test_workflow_production_wiring.py
+++ b/tests/test_workflow_production_wiring.py
@@ -3293,16 +3293,34 @@ def test_complete_plan_does_not_require_or_launch_brainstorm(tmp_path: Path) -> 
     args = _workflow_args(manifest_path, tmp_path)
     args["planning_artifacts"] = rows
     args["primary_domain"] = "openai"
+    launched: list[str] = []
+
+    class Launcher:
+        def as_read_only(self):
+            return self
+
+        def launch(self, *, slice_id, prompt, worktree, log_dir):
+            launched.append(slice_id)
+            return LaunchHandle(
+                executor="test",
+                model_id="test",
+                session_name=slice_id,
+                pid=100,
+                log_path=str(Path(log_dir) / f"{slice_id}.jsonl"),
+            )
+
     executor = manager_daemon.build_request_executor(
         dispatcher=dispatcher,
         specs_dir=str(tmp_path / "specs"),
         handoff_dir=str(tmp_path / "handoff"),
+        launcher=Launcher(),
         workflow_runtime_factory=lambda **_: (_ for _ in ()).throw(AssertionError("must not launch")),
     )
 
     result = executor(build_request(req_type="workflow-action", args=args, requested_by="operator"))
     run = registry.get_workflow_run(result["run_id"])
     assert result["reason"] == "planning-complete"
+    assert launched == [result["job_id"]]
     assert run.brainstorm_required is False
     assert run.gate_refs == ()
     assert {


### PR DESCRIPTION
## 摘要

- 讓 planning-complete production wiring test 明確注入 read-only fake launcher
- 保留正常 writing-plans job 派送驗證，但不再意外啟動真實 `agy`
- 避免 full preflight 的 disposable HOME 在外部 Antigravity 寫入期間發生 cleanup race

## 驗證

- disposable HOME + `agy` wrapper：54 passed；0 external launcher calls；無 `.gemini/antigravity-cli`
- `python3 -m pytest -q`（1029 passed, 21 subtests passed）
- `openspec validate --all --strict`（6 passed）
- pinned policy check（套用白名單 labels 後預期 0 fail）

## 豁免理由

- `skip-changelog`：本 PR 只隔離測試依賴，不改 runtime 或使用者可見行為。
- `policy-exempt:docs-sync`：canonical 行為與契約未變，沒有需要同步的產品文件。

## Checklist

- [x] 本次變更已在 feature branch 完成
- [x] 本次為 test-only，已用白名單 `skip-changelog` 並附理由
- [x] runtime、文件與 OpenSpec 契約未變更
- [x] 已通過 full pytest、OpenSpec 與 local policy reproduction
- [x] PR 內容使用 zh-TW