### PR TITLE
fix(workflow): 解析 Copilot terminal evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - **deck frontmatter emit 契約與 runtime parser keyset 對齊**：`EMITTED_FRONTMATTER_FIELDS`、deck compile frontmatter 與 `parse_spec_frontmatter()` 現在一致包含 `target_branch` / `verification` / `parse_error`；compile 產生 hold spec 時固定輸出 `null` 欄位，runtime 僅接受 `parse_error: null`（non-null fail-closed），避免 deck contract alignment 漂移。
 
 ### Fixed
+- **Copilot workflow terminal evidence 可由 Manager 正式綁定**：terminal parser 現在只在 typed `assistant.message` event 讀取 `data.content` 的完整 workflow payload，保留既有 discriminator 驗證；不再把 Copilot 已成功產生的 exact-Candidate terminal 誤判為缺少 JSON evidence。
 - **Exact PR metadata不再無條件重寫**：`ensure_pr_metadata`先以authenticated PR/issue reread驗title、body與完整labels；全部精確一致時直接保留remote state，不發PATCH/PUT。任一欄drift才執行冪等metadata writes並再次完整reread，降低GitHub write degradation期間的無效side effect且不放寬identity gate。
 - **Delivery PR metadata可承受暫時gateway故障**：既有PR的title/body PATCH、labels PUT與兩筆identity reread只在HTTP 502/503/504時做finite bounded retry；這些操作皆為冪等metadata transaction。PR create、push、merge與其他delivery side effect不共用此retry路徑，auth、rate-limit及malformed response仍立即fail-closed。
 - **Terminal closure provider不再被GitHub暫時gateway故障或無關PR拖垮**：remote Todo改以default revision精確綁定的Contents API讀取，並逐筆重驗path/blob SHA/encoding；只有HTTP 502/503/504會依有限backoff重試，auth、rate-limit與malformed response仍立即fail-closed。Production ancestry compare只對canonical WorkflowRegistry已連結的PR執行，保留完整PR remote truth但不再為整個repo的歷史merged PR逐筆查詢。

--- a/changelog.d/31-copilot-terminal-evidence.md
+++ b/changelog.d/31-copilot-terminal-evidence.md
@@ -1,0 +1,1 @@
+fix(workflow): 解析 Copilot typed assistant message 的 exact-Candidate terminal evidence，並拒絕 non-message event 偽造綁定。

--- a/paulsha_cortex/coordinator/manager.py
+++ b/paulsha_cortex/coordinator/manager.py
@@ -2293,6 +2293,11 @@ def _extract_terminal_json(log_path: object) -> dict[str, object]:
             parsed = _parse_terminal_json_text(item.get("text"))
             if parsed is not None:
                 return parsed
+        data = value.get("data")
+        if value.get("type") == "assistant.message" and isinstance(data, dict):
+            parsed = _parse_terminal_json_text(data.get("content"))
+            if parsed is not None:
+                return parsed
         for key in ("result", "content", "message", "text"):
             parsed = _parse_terminal_json_text(value.get(key))
             if parsed is not None:

--- a/tests/test_workflow_production_wiring.py
+++ b/tests/test_workflow_production_wiring.py
@@ -2278,6 +2278,58 @@ def test_terminal_json_uses_codex_final_agent_message_not_turn_envelope(tmp_path
     assert manager._extract_terminal_json(str(log)) == evidence
 
 
+def test_terminal_json_reads_copilot_assistant_message_data_content(tmp_path: Path) -> None:
+    evidence = {
+        "schema_version": 1,
+        "kind": "workflow-card",
+        "status": "passed",
+        "run_id": "run",
+        "card_id": "card",
+        "candidate": "a" * 40,
+        "outputs": [],
+    }
+    log = tmp_path / "copilot.jsonl"
+    log.write_text(
+        "\n".join(
+            (
+                json.dumps({
+                    "type": "assistant.message",
+                    "data": {"content": json.dumps(evidence)},
+                }),
+                json.dumps({"type": "result", "exitCode": 0}),
+            )
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    assert manager._extract_terminal_json(str(log)) == evidence
+
+
+def test_terminal_json_rejects_copilot_non_message_data_content(tmp_path: Path) -> None:
+    fake = {
+        "schema_version": 1,
+        "kind": "workflow-card",
+        "status": "passed",
+        "run_id": "run",
+        "card_id": "card",
+        "candidate": "a" * 40,
+        "outputs": [],
+    }
+    log = tmp_path / "copilot-tool.jsonl"
+    log.write_text(
+        json.dumps({
+            "type": "tool.execution_complete",
+            "data": {"content": json.dumps(fake)},
+        })
+        + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="no JSON evidence"):
+        manager._extract_terminal_json(str(log))
+
+
 def test_failed_planner_retry_replaces_only_its_disposable_sandbox(tmp_path: Path) -> None:
     repo = tmp_path / "repo"
     repo.mkdir()


### PR DESCRIPTION
## 摘要

- 支援 Copilot JSONL typed `assistant.message` event 的 `data.content` workflow payload
- 僅在 assistant message 解析 nested content，拒絕 tool event 偽造 terminal evidence
- 保留既有完整 discriminator 與 exact-Candidate 驗證
- 同步 changelog

## 驗證

- TDD red：新增 Copilot event regression 後舊 parser 如預期失敗
- focused terminal parser tests（4 passed）
- `python3 -m pytest -q`（1032 passed, 21 subtests passed）
- `openspec validate --all --strict`（6 passed）
- pinned policy check（25 pass, 0 fail, 1 pre-existing WARN）

## Checklist

- [x] 本次變更已在 feature branch 完成
- [x] 已更新 CHANGELOG.md [Unreleased]
- [x] 已新增正向與 fail-closed 負向 regression
- [x] 已通過 full pytest、OpenSpec 與 policy gate
- [x] PR 內容使用 zh-TW