### PR TITLE
fix(workflow): 允許 maintainer review 接手 Copilot stop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - **deck frontmatter emit 契約與 runtime parser keyset 對齊**：`EMITTED_FRONTMATTER_FIELDS`、deck compile frontmatter 與 `parse_spec_frontmatter()` 現在一致包含 `target_branch` / `verification` / `parse_error`；compile 產生 hold spec 時固定輸出 `null` 欄位，runtime 僅接受 `parse_error: null`（non-null fail-closed），避免 deck contract alignment 漂移。
 
 ### Fixed
+- **Typed maintainer review可安全接手Copilot stop**：delivery journal停在`copilot-finding-budget-exhausted`、timeout或其他`copilot-*` needs-human reason時，只有WorkflowRun已綁定且path/hash完整的exact-HEAD maintainer evidence可重入；後續仍重驗immutable evidence，external merge與其他stop不會被旁路。
 - **Plan/build terminal output prompt對齊manifest ref契約**：structured prompt現在明示`outputs`只能是符合declared outputs的repo-relative artifact path字串；manifest未宣告outputs時固定要求`[]`，避免builder把adoption摘要放入outputs後被Manager正確拒絕而無法綁定tested descendant Candidate。
 - **Retry-build可採用已提交且已測試的descendant Candidate**：delivery preflight與post-archive review recovery prompt現在明示先檢查worktree既有repair commit，允許builder提交或採用tested descendant；Manager仍以exact舊Candidate CAS與單調ancestry獨立驗證，不接受caller evidence或倒退HEAD。
 - **Copilot workflow terminal evidence 可由 Manager 正式綁定**：terminal parser 現在只在 typed `assistant.message` event 讀取 `data.content` 的完整 workflow payload，保留既有 discriminator 驗證；不再把 Copilot 已成功產生的 exact-Candidate terminal 誤判為缺少 JSON evidence。

--- a/changelog.d/31-maintainer-review-recovery.md
+++ b/changelog.d/31-maintainer-review-recovery.md
@@ -1,0 +1,1 @@
+fix(workflow): 允許exact typed maintainer review安全重入既有`copilot-*` needs-human delivery stop。

--- a/docs/unified-work-lifecycle.md
+++ b/docs/unified-work-lifecycle.md
@@ -99,6 +99,6 @@ Manager 是唯一 writer。每次 push 都會使上一個 delivery review epoch 
 - terminal-green checks/statuses、closing refs、archive diff 與 mergeability；
 - fresh GitHub provider snapshot。
 
-最多兩輪 builder fix/re-review，每個 HEAD 等待 15 分鐘；current-HEAD review 出現 finding 時，delivery adapter 會把 `fix-required` fail-closed 投影為 `needs_human`，只有 operator 的 exact-Candidate `retry-build` 才能重開 builder；第三次仍有 finding 或逾時也維持 `needs_human`。合併只使用 `gh pr merge --merge --match-head-commit <HEAD>`，不使用 auto/squash/rebase。Merge 後會重新 fetch default branch，驗證雙親 merge commit ancestry、issue、archive、Todo 與 CompletionRecord，全部成立才投影 `done`。
+最多兩輪 builder fix/re-review，每個 HEAD 等待 15 分鐘；current-HEAD review 出現 finding 時，delivery adapter 會把 `fix-required` fail-closed 投影為 `needs_human`，只有 operator 的 exact-Candidate `retry-build` 才能重開 builder；第三次仍有 finding 或逾時也維持 `needs_human`。若後續已由Manager綁定exact-HEAD maintainer evidence，只有完整path/hash可重入這類`copilot-*` stop，其他stop reason仍fail-closed。合併只使用 `gh pr merge --merge --match-head-commit <HEAD>`，不使用 auto/squash/rebase。Merge 後會重新 fetch default branch，驗證雙親 merge commit ancestry、issue、archive、Todo 與 CompletionRecord，全部成立才投影 `done`。
 
 V1 terminal delivery 僅支援 GitHub。其他 forge 仍可顯示 read model，但 ship 會停在 `needs_human`。

--- a/openspec/changes/unified-work-lifecycle/design.md
+++ b/openspec/changes/unified-work-lifecycle/design.md
@@ -123,7 +123,7 @@ Dispatcher仍負責把dead PID/no sentinel fail-closed成failed job；Manager將
 
 ForeignReview仍是獨立必備gate。其後delivery review authority恰為`copilot`或`maintainer-review`之一。`review-attest`只經Manager queue建立：先重讀authenticated PR HEAD，再寫repo/work/run/authority digest/PR/candidate/actor/verdict綁定的immutable evidence。Ship重驗run gate ref/hash與current HEAD，GitHub checks/threads/mergeability/archive/closing refs完全沿用。
 
-既有Copilot authorization維持v1 replay；maintainer路徑使用merge authorization v2，保存實際review kind/ref/hash。Manager不得把maintainer evidence寫成Copilot kind。Interactive runtime另以`PSC_INSTANCE`選取installer bootstrap env，讓CLI與service共享instance-scoped run root；invalid env fail-closed。
+既有Copilot authorization維持v1 replay；maintainer路徑使用merge authorization v2，保存實際review kind/ref/hash。WorkflowRun已綁定且path/hash完整的exact-HEAD maintainer evidence只可重入既有`copilot-*` needs-human stop；external merge、target cardinality或其他stop仍fail-closed。Manager不得把maintainer evidence寫成Copilot kind。Interactive runtime另以`PSC_INSTANCE`選取installer bootstrap env，讓CLI與service共享instance-scoped run root；invalid env fail-closed。
 
 ## Failure handling
 

--- a/openspec/changes/unified-work-lifecycle/specs/governed-delivery-closure/spec.md
+++ b/openspec/changes/unified-work-lifecycle/specs/governed-delivery-closure/spec.md
@@ -40,6 +40,12 @@ Manager MUST先跑`python3 -m policy_check --repo .`，再執行configured `PSC_
 - **THEN**Manager拒絕merge authorization並要求B的新attestation
 - **THEN**不得改寫evidence或把它記成Copilot review
 
+#### Scenario: Copilot stop切換為typed maintainer authority
+- **GIVEN**delivery journal停在`copilot-*` needs-human reason，且WorkflowRun綁定一份exact-HEAD maintainer-review evidence
+- **WHEN**ship validator提供該evidence完整的path/hash pair
+- **THEN**Manager MAY重入同一delivery transaction，並在merge authorization前重驗immutable evidence
+- **AND**external merge、target cardinality、未知stop reason、不完整path/hash、stale Candidate或binding mismatch MUST維持fail-closed
+
 ### Requirement: Finding處理必須bounded且不得偷換reviewer
 真finding MUST由Builder修正並加regression test；誤報 MUST由Reviewer留下evidence後resolve。每個HEAD最長等待15分鐘，最多兩輪fix/re-review。Timeout或第三輪仍有finding MUST設`needs_human`，不得替換reviewer或繞過gate。
 

--- a/openspec/changes/unified-work-lifecycle/tasks.md
+++ b/openspec/changes/unified-work-lifecycle/tasks.md
@@ -48,6 +48,7 @@
 - [x] 3.16 RED-test並修正delivery finding閉環：`fix-required`由trusted adapter fail-closed映射為`needs_human`，使operator可用exact-Candidate `retry-build`重開builder。
 - [x] 3.17 RED-test並修正builder terminalization recovery：final builder job已成功退出（`exited/0`）但immutable evidence未綁定時，允許exact-Candidate `retry-build`在窄化build phase重派；真正failed job、前置build、job狀態與input snapshot維持fail-closed。
 - [x] 3.18 RED-test並收緊plan/build terminal output prompt：`outputs`只允許符合manifest的repo-relative artifact path字串；manifest無outputs時明示固定為空陣列，禁止描述性物件造成合法repair Candidate無法綁定。
+- [x] 3.19 RED-test並修正typed maintainer review recovery：只有完整path/hash且已由WorkflowRun綁定的exact-HEAD maintainer evidence可重入`copilot-*` needs-human stop；其他stop與錯誤binding維持fail-closed。
 
 ## 4. PR D — Bootstrap, docs, deployment, canary
 

--- a/paulsha_cortex/coordinator/work_actions.py
+++ b/paulsha_cortex/coordinator/work_actions.py
@@ -1169,6 +1169,26 @@ def _ship_with_maintainer_review(
     }
 
 
+def _recoverable_maintainer_ship_stop(
+    *,
+    ship: dict[str, Any] | None,
+    args: dict[str, Any],
+) -> bool:
+    """Detect a complete maintainer locator on a recoverable Copilot stop."""
+
+    has_path = args.get("maintainer_review_path") is not None
+    has_hash = args.get("maintainer_review_hash") is not None
+    if has_path != has_hash:
+        raise ValueError("maintainer review path/hash must be supplied together")
+    return bool(
+        has_path
+        and ship is not None
+        and ship.get("phase") == "needs_human"
+        and isinstance(ship.get("reason"), str)
+        and str(ship["reason"]).startswith("copilot-")
+    )
+
+
 def _fallback_workflow_starter(workflow_registry, state_path: Path):
     """Test/embedding fallback; installed daemon supplies the production starter."""
 
@@ -1638,7 +1658,8 @@ def _ship_action(
     github = GitHubDeliveryClient(runner=runner)
     orchestrator = ShipOrchestrator(github=github, now=now)
 
-    if ship and ship.get("phase") == "needs_human":
+    maintainer_recovery = _recoverable_maintainer_ship_stop(ship=ship, args=args)
+    if ship and ship.get("phase") == "needs_human" and not maintainer_recovery:
         return {"action": "needs_human", "reason": ship.get("reason")}
 
     if ship and ship.get("phase") == "merged":
@@ -1896,11 +1917,7 @@ def _ship_action(
     fix_rounds = ship.get("fix_rounds", 0) if ship else 0
     if not isinstance(fix_rounds, int) or isinstance(fix_rounds, bool) or fix_rounds < 0:
         raise ValueError("ship fix round state malformed")
-    has_maintainer_path = args.get("maintainer_review_path") is not None
-    has_maintainer_hash = args.get("maintainer_review_hash") is not None
-    if has_maintainer_path != has_maintainer_hash:
-        raise ValueError("maintainer review path/hash must be supplied together")
-    if has_maintainer_path:
+    if maintainer_recovery or args.get("maintainer_review_path") is not None:
         return _ship_with_maintainer_review(
             args=args,
             active=active,

--- a/tests/test_work_actions.py
+++ b/tests/test_work_actions.py
@@ -555,6 +555,185 @@ def test_review_attest_writes_immutable_exact_head_evidence(
     assert persisted.facets == ("degraded",)
 
 
+def test_typed_maintainer_review_can_reenter_only_copilot_needs_human_stop() -> None:
+    evidence = {
+        "maintainer_review_path": "/evidence/maintainer.json",
+        "maintainer_review_hash": "a" * 64,
+    }
+
+    assert work_actions._recoverable_maintainer_ship_stop(
+        ship={"phase": "needs_human", "reason": "copilot-finding-budget-exhausted"},
+        args=evidence,
+    )
+    assert work_actions._recoverable_maintainer_ship_stop(
+        ship={"phase": "needs_human", "reason": "copilot-review-timeout"},
+        args=evidence,
+    )
+    assert not work_actions._recoverable_maintainer_ship_stop(
+        ship={"phase": "needs_human", "reason": "external-merge-without-authorization"},
+        args=evidence,
+    )
+    with pytest.raises(ValueError, match="path/hash must be supplied together"):
+        work_actions._recoverable_maintainer_ship_stop(
+            ship={"phase": "needs_human", "reason": "copilot-review-timeout"},
+            args={"maintainer_review_path": "/evidence/maintainer.json"},
+        )
+
+
+def test_ship_reenters_copilot_stop_through_bound_maintainer_review(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    snapshot = _snapshot(tmp_path / "snapshot.json")
+    state = tmp_path / "runs.json"
+    started = work_actions.execute_work_action(
+        args={"action": "start", "repo": "acme/demo", "work_id": "demo"},
+        requested_by="operator",
+        snapshot_path=snapshot,
+        state_path=state,
+        now=lambda: 200,
+    )
+    registry = JobRegistry(state_path=tmp_path / "jobs.json")
+    run_id = started["result"]["run"]["run_id"]
+    authority = work_actions.load_work_authority(
+        repo="acme/demo", work_id="demo", snapshot_path=snapshot
+    )
+    maintainer_body = {
+        "schema": "cortex-maintainer-review/v1",
+        "repo": "acme/demo",
+        "work_id": "demo",
+        "run_id": run_id,
+        "authority_digest": work_actions.work_authority_digest(authority),
+        "pr_number": 8,
+        "candidate": HEAD,
+        "actor": "maintainer",
+        "requested_by": "operator",
+        "verdict": "approved",
+        "summary": "Exact-HEAD review passed.",
+        "findings": [],
+        "reviewed_at_epoch": 205.0,
+    }
+    maintainer = work_actions._maintainer_review_record(
+        maintainer_body, state_path=state
+    )
+    foreign_payload = {"state": "passed", "candidate": HEAD}
+    foreign = tmp_path / "foreign.json"
+    foreign.write_text(json.dumps(foreign_payload), encoding="utf-8")
+    foreign_hash = work_actions.verification.canonical_json_hash(foreign_payload)
+    for phase in ("plan", "build", "verify", "review"):
+        registry._manager_update_workflow_run(run_id, current_phase=phase)
+    registry._manager_update_workflow_run(
+        run_id,
+        candidate_head=HEAD,
+        verified_head=HEAD,
+        pr_refs=("acme/demo#8",),
+        gate_refs=(
+            GateEvidenceRef("foreign-review", str(foreign), foreign_hash),
+            GateEvidenceRef("maintainer-review", maintainer["ref"], maintainer["hash"]),
+        ),
+        gate_status="passed",
+        facets=("needs_human",),
+    )
+    _initialize_delivery_journal(snapshot=snapshot, state=state)
+    persisted = json.loads(state.read_text(encoding="utf-8"))
+    row = persisted["runs"][run_id]
+    row["ship"] = {
+        "phase": "needs_human",
+        "reason": "copilot-finding-budget-exhausted",
+        "head": HEAD,
+        "tree_hash": TREE,
+        "fix_rounds": 3,
+        "pr_number": 8,
+        "change": "demo",
+        "todo_paths": ["docs/todo.md"],
+    }
+    state.write_text(json.dumps(persisted), encoding="utf-8")
+    merged = {"value": False}
+
+    class GitHub:
+        def __init__(self, *, runner):
+            pass
+
+        def ensure_pr_metadata(self, **kwargs):
+            pass
+
+        def fetch_delivery_facts(self, **kwargs):
+            return DeliveryFacts(
+                head=HEAD,
+                mergeable=True,
+                mergeable_state="clean",
+                checks=(GitHubCheck("pytest", "completed", "success"),),
+                copilot_reviews=(),
+                review_threads=(),
+                closing_issues=(12,),
+                active_openspec_absent=True,
+                archive_present=True,
+            )
+
+        def fetch_merge_status(self, **kwargs):
+            return MergeStatus(
+                merged=merged["value"],
+                pr_head=HEAD,
+                merge_commit="c" * 40 if merged["value"] else None,
+            )
+
+    class Orchestrator:
+        def __init__(self, *, github, now):
+            pass
+
+        def merge_if_ready(self, **kwargs):
+            assert kwargs["copilot"] is None
+            assert kwargs["maintainer_review"].path == maintainer["ref"]
+            merged["value"] = True
+            return SimpleNamespace(expected_head=HEAD, expected_tree_hash=TREE)
+
+    monkeypatch.setattr(work_actions, "GitHubDeliveryClient", GitHub)
+    monkeypatch.setattr(work_actions, "ShipOrchestrator", Orchestrator)
+    monkeypatch.setattr(
+        work_actions,
+        "_validate_foreign_review",
+        lambda *args, **kwargs: foreign_payload,
+    )
+    monkeypatch.setattr(work_actions, "load_preflight_command", lambda: ("preflight",))
+    monkeypatch.setattr(
+        work_actions,
+        "run_preflight",
+        lambda **kwargs: PreflightResult(
+            passed=True,
+            failed_stage=None,
+            policy=CommandResult(("policy",), 0, "", ""),
+            ci_parity=CommandResult(("preflight",), 0, "", ""),
+            head=HEAD,
+            tree_hash=TREE,
+        ),
+    )
+    result = work_actions.execute_work_action(
+        args={
+            "action": "ship",
+            "repo": "acme/demo",
+            "work_id": "demo",
+            "repo_root": str(tmp_path),
+            "pr_number": 8,
+            "change": "demo",
+            "todo_paths": ["docs/todo.md"],
+            "foreign_review_path": str(foreign),
+            "foreign_review_hash": foreign_hash,
+            "maintainer_review_path": maintainer["ref"],
+            "maintainer_review_hash": maintainer["hash"],
+            "pr_metadata_path": str(_pr_metadata(tmp_path / "pr.json")),
+        },
+        requested_by="operator",
+        snapshot_path=snapshot,
+        state_path=state,
+        now=lambda: 210,
+        workflow_registry=registry,
+    )
+
+    assert result["result"]["action"] == "merged-awaiting-closure"
+    assert result["result"]["review_kind"] == "maintainer-review"
+    assert _only_journal_row(state)["ship"]["phase"] == "merged"
+
+
 def test_auto_without_issue_mutates_every_mapped_issue(tmp_path: Path) -> None:
     snapshot = _snapshot(tmp_path / "snapshot.json", issues=(12, 13))
     calls: list[list[str]] = []


### PR DESCRIPTION
## 摘要

- 允許完整 typed maintainer path/hash 重入既有 `copilot-*` needs-human delivery stop
- external merge、target cardinality、未知 stop 與不完整 evidence 維持 fail-closed
- 補齊回歸測試、OpenSpec、操作文件與 changelog

## 驗證

- [x] `python3 -m pytest -q`（1033 passed, 21 subtests passed）
- [x] `openspec validate --all`（6 passed, 0 failed）
- [x] pinned `python3 -m policy_check --repo .`（25 pass, 0 fail；1 個既有 R-22 warn）
- [x] `CHANGELOG.md [Unreleased]` 與 fragment 已更新
- [x] `VERSION` 維持 0.0.0，符合非 release PR 意圖
- [x] docs / OpenSpec 已同步
