### PR TITLE
fix(workflow): 修復 archive 後 closure reconciliation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - **deck frontmatter emit 契約與 runtime parser keyset 對齊**：`EMITTED_FRONTMATTER_FIELDS`、deck compile frontmatter 與 `parse_spec_frontmatter()` 現在一致包含 `target_branch` / `verification` / `parse_error`；compile 產生 hold spec 時固定輸出 `null` 欄位，runtime 僅接受 `parse_error: null`（non-null fail-closed），避免 deck contract alignment 漂移。
 
 ### Fixed
+- **Post-merge closure不再要求已archive的active planning path**：delivery journal完整綁定merged run/Candidate/merge commit/authorization時，operator resume會直接重驗CompletionRecord與remote closure；official archive移走active OpenSpec後不再誤報planning-authority reconciliation failure，malformed journal仍走原本fail-closed路徑。
 - **CompletionRecord接受typed maintainer review authority**：remote closure現在保留merge authorization實際使用的`copilot`或`maintainer-review` evidence kind/ref/hash，並要求兩者恰好一種；maintainer-authorized merge不再因舊的Copilot-only白名單卡住，缺失或雙重authority仍fail-closed。
 - **Typed maintainer review可安全接手Copilot stop**：delivery journal停在`copilot-finding-budget-exhausted`、timeout或其他`copilot-*` needs-human reason時，只有WorkflowRun已綁定且path/hash完整的exact-HEAD maintainer evidence可重入；後續仍重驗immutable evidence，external merge與其他stop不會被旁路。
 - **Plan/build terminal output prompt對齊manifest ref契約**：structured prompt現在明示`outputs`只能是符合declared outputs的repo-relative artifact path字串；manifest未宣告outputs時固定要求`[]`，避免builder把adoption摘要放入outputs後被Manager正確拒絕而無法綁定tested descendant Candidate。

--- a/changelog.d/31-post-merge-closure-reconciliation.md
+++ b/changelog.d/31-post-merge-closure-reconciliation.md
@@ -1,0 +1,1 @@
+fix(workflow): 讓merged delivery在official archive後直接重驗remote closure。

--- a/docs/unified-work-lifecycle.md
+++ b/docs/unified-work-lifecycle.md
@@ -104,7 +104,7 @@ Manager 是唯一 writer。每次 push 都會使上一個 delivery review epoch 
 - terminal-green checks/statuses、closing refs、archive diff 與 mergeability；
 - fresh GitHub provider snapshot。
 
-最多兩輪 builder fix/re-review，每個 HEAD 等待 15 分鐘；current-HEAD review 出現 finding 時，delivery adapter 會把 `fix-required` fail-closed 投影為 `needs_human`，只有 operator 的 exact-Candidate `retry-build` 才能重開 builder；第三次仍有 finding 或逾時也維持 `needs_human`。若後續已由Manager綁定exact-HEAD maintainer evidence，只有完整path/hash可重入這類`copilot-*` stop，其他stop reason仍fail-closed。合併只使用 `gh pr merge --merge --match-head-commit <HEAD>`，不使用 auto/squash/rebase。Merge 後會重新 fetch default branch，驗證雙親 merge commit ancestry、issue、archive、Todo 與 CompletionRecord；CompletionRecord會保留實際使用的`copilot`或`maintainer-review` kind/ref/hash，並要求恰好一種delivery review authority，全部成立才投影 `done`。
+最多兩輪 builder fix/re-review，每個 HEAD 等待 15 分鐘；current-HEAD review 出現 finding 時，delivery adapter 會把 `fix-required` fail-closed 投影為 `needs_human`，只有 operator 的 exact-Candidate `retry-build` 才能重開 builder；第三次仍有 finding 或逾時也維持 `needs_human`。若後續已由Manager綁定exact-HEAD maintainer evidence，只有完整path/hash可重入這類`copilot-*` stop，其他stop reason仍fail-closed。合併只使用 `gh pr merge --merge --match-head-commit <HEAD>`，不使用 auto/squash/rebase。Merge 後會重新 fetch default branch，驗證雙親 merge commit ancestry、issue、archive、Todo 與 CompletionRecord；CompletionRecord會保留實際使用的`copilot`或`maintainer-review` kind/ref/hash，並要求恰好一種delivery review authority。此時active OpenSpec planning path已由official archive移走屬預期狀態；完整綁定merged Candidate/merge commit/authorization的journal會直接進入ship validator closure，不回退要求active path，全部remote facts成立才投影 `done`。
 
 V1 terminal delivery 僅支援 GitHub。其他 forge 仍可顯示 read model，但 ship 會停在 `needs_human`。
 

--- a/openspec/changes/unified-work-lifecycle/design.md
+++ b/openspec/changes/unified-work-lifecycle/design.md
@@ -125,7 +125,7 @@ Dispatcher仍負責把dead PID/no sentinel fail-closed成failed job；Manager將
 
 ForeignReview仍是獨立必備gate。其後delivery review authority恰為`copilot`或`maintainer-review`之一。`review-attest`只經Manager queue建立：先重讀authenticated PR HEAD，再寫repo/work/run/authority digest/PR/candidate/actor/verdict綁定的immutable evidence。Ship重驗run gate ref/hash與current HEAD，GitHub checks/threads/mergeability/archive/closing refs完全沿用。
 
-既有Copilot authorization維持v1 replay；maintainer路徑使用merge authorization v2，保存實際review kind/ref/hash。WorkflowRun已綁定且path/hash完整的exact-HEAD maintainer evidence只可重入既有`copilot-*` needs-human stop；external merge、target cardinality或其他stop仍fail-closed。Manager不得把maintainer evidence寫成Copilot kind，CompletionRecord的trusted evidence也保留同一typed union，並要求Copilot／maintainer恰好一種。Interactive runtime另以`PSC_INSTANCE`選取installer bootstrap env，讓CLI與service共享instance-scoped run root；invalid env fail-closed。
+既有Copilot authorization維持v1 replay；maintainer路徑使用merge authorization v2，保存實際review kind/ref/hash。WorkflowRun已綁定且path/hash完整的exact-HEAD maintainer evidence只可重入既有`copilot-*` needs-human stop；external merge、target cardinality或其他stop仍fail-closed。Manager不得把maintainer evidence寫成Copilot kind，CompletionRecord的trusted evidence也保留同一typed union，並要求Copilot／maintainer恰好一種。Delivery journal已精確記錄`merged`後，resume只把完整repo/work/run/Candidate/merge commit/authorization binding視為post-merge routing hint，略過已被official archive移走的active planning path重驗；它不授予authority，CompletionRecord與remote closure仍由ship validator完整fail-closed重驗。Interactive runtime另以`PSC_INSTANCE`選取installer bootstrap env，讓CLI與service共享instance-scoped run root；invalid env fail-closed。
 
 ## Failure handling
 

--- a/openspec/changes/unified-work-lifecycle/specs/governed-delivery-closure/spec.md
+++ b/openspec/changes/unified-work-lifecycle/specs/governed-delivery-closure/spec.md
@@ -62,6 +62,13 @@ Manager MUST先跑`python3 -m policy_check --repo .`，再執行configured `PSC_
 ### Requirement: Merge前後必須重讀remote terminal facts
 Merge前 Manager MUST重新讀HEAD、mergeability、checks、threads、closing issues與archive diff，revision race MUST中止merge。Merge MUST使用`gh pr merge --merge`且 MUST NOT使用GitHub `--auto`。Merge後 MUST fetch default branch並驗merge ancestry、all mapped issues closed、active OpenSpec消失、remote archive存在、Todo tasks完成，才可寫versioned CompletionRecord並投影done。
 
+#### Scenario: Merge後active planning path已移入official archive
+- **GIVEN**Manager delivery journal已以exact Candidate與merge authorization記錄`merged`
+- **AND**accepted OpenSpec planning paths已由同一workflow的official archive移出active change目錄
+- **WHEN**operator resume觸發remote closure reconciliation
+- **THEN**Manager MUST直接重驗merged journal與remote closure，不得因active planning path已不存在而回退到planning-authority reconciliation
+- **AND**journal identity、Candidate、merge commit或authorization不完整時 MUST維持原本的fail-closed planning reconciliation與ship validator檢查
+
 Existing PR metadata transaction的title/body PATCH、labels PUT與後續PR/issue identity reread MAY只在明確HTTP 502/503/504時以finite bounded delay重試；這些操作 MUST保持冪等且每次成功後仍完整reread。PR create、Candidate push、review request、merge與其他delivery side effect MUST NOT取得此retry authority。Auth、rate-limit、其他HTTP error或malformed response MUST立即fail-closed。
 
 Manager MUST在existing PR metadata write前先authenticated reread PR title/body與issue labels；三者與canonical metadata全部精確一致時 MUST NOT發出PATCH或PUT。任一欄drift時才 MAY執行冪等PATCH/PUT，且成功後 MUST再次完整reread並驗exact identity。Initial reread、post-write reread或shape validation任一失敗 MUST fail-closed，MUST NOT把write omission解釋為未驗證的skip。

--- a/openspec/changes/unified-work-lifecycle/tasks.md
+++ b/openspec/changes/unified-work-lifecycle/tasks.md
@@ -51,6 +51,7 @@
 - [x] 3.19 RED-test並修正typed maintainer review recovery：只有完整path/hash且已由WorkflowRun綁定的exact-HEAD maintainer evidence可重入`copilot-*` needs-human stop；其他stop與錯誤binding維持fail-closed。
 - [x] 3.20 RED-test並修正CompletionRecord typed delivery evidence：保留merge authorization實際使用的`copilot`或`maintainer-review` kind/ref/hash，要求兩者恰好一種，避免maintainer-authorized merge卡在remote closure。
 - [x] 3.21 RED-test並新增`work abandon`：exact run ID CAS、current authority、actor/reason、active Job與pre-delivery side-effect gate全部fail-closed；成功只寫immutable evidence並將run設為superseded，不建立CompletionRecord。
+- [x] 3.22 RED-test並修正post-merge closure routing：delivery journal完整綁定merged Candidate/merge commit/authorization時，resume略過已被official archive移走的active planning path重驗，仍由ship validator完整驗證CompletionRecord與remote closure。
 
 ## 4. PR D — Bootstrap, docs, deployment, canary
 

--- a/paulsha_cortex/coordinator/manager.py
+++ b/paulsha_cortex/coordinator/manager.py
@@ -5310,6 +5310,49 @@ def dispatch_workflow_card(
     )
 
 
+def _merged_delivery_reconciliation_pending(run, *, coordinator_root: str | Path) -> bool:
+    """Detect the narrow post-merge closure path without granting ship authority."""
+    if run.current_phase != "review" or not isinstance(run.candidate_head, str):
+        return False
+    journal_path = Path(coordinator_root) / "delivery-journal.json"
+    if journal_path.is_symlink() or not journal_path.is_file():
+        return False
+    try:
+        journal = json.loads(journal_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return False
+    rows = journal.get("runs") if isinstance(journal, dict) else None
+    row = rows.get(run.run_id) if isinstance(rows, dict) else None
+    ship = row.get("ship") if isinstance(row, dict) else None
+    authorization = ship.get("merge_authorization") if isinstance(ship, dict) else None
+    authorization_body = (
+        authorization.get("payload") if isinstance(authorization, dict) else None
+    )
+    return bool(
+        isinstance(journal, dict)
+        and journal.get("schema") == "cortex-delivery-journal/v1"
+        and isinstance(row, dict)
+        and row.get("run_id") == run.run_id
+        and row.get("repo") == run.repo
+        and row.get("work_id") == run.work_id
+        and isinstance(ship, dict)
+        and ship.get("phase") == "merged"
+        and ship.get("head") == run.candidate_head
+        and isinstance(ship.get("merge_commit"), str)
+        and verification.SAFE_SHA_RE.fullmatch(ship["merge_commit"]) is not None
+        and isinstance(authorization, dict)
+        and isinstance(authorization.get("path"), str)
+        and Path(authorization["path"]).is_absolute()
+        and isinstance(authorization.get("hash"), str)
+        and re.fullmatch(r"[0-9a-f]{64}", authorization["hash"]) is not None
+        and isinstance(authorization_body, dict)
+        and authorization_body.get("run_id") == run.run_id
+        and authorization_body.get("repo") == run.repo
+        and authorization_body.get("work_id") == run.work_id
+        and authorization_body.get("head") == run.candidate_head
+    )
+
+
 def resume_workflow_run(
     dispatcher,
     *,
@@ -5409,32 +5452,38 @@ def resume_workflow_run(
             "current_phase": updated.current_phase,
             "reason": "planning-publication-drift",
         }
-    try:
-        planning_authority, planning_source_revision = _validated_brainstorm_planning_authority(
-            run,
-            coordinator_root=coordinator_root,
-        )
-    except ValueError:
-        current = registry.get_workflow_run(run.run_id)
-        updated = registry._manager_update_workflow_run(
-            run.run_id,
-            facets=tuple(dict.fromkeys((*current.facets, "needs_human"))),
-            gate_status=pre_resume_gate_status,
-        )
-        return {
-            "run_id": updated.run_id,
-            "current_phase": updated.current_phase,
-            "reason": "planning-authority-reconciliation-failed",
-        }
-    if (
-        planning_authority != run.planning_authority
-        or planning_source_revision != run.planning_source_revision
-    ):
-        run = registry._manager_update_workflow_run(
-            run.run_id,
-            planning_authority=planning_authority,
-            planning_source_revision=planning_source_revision,
-        )
+    post_merge_closure = ship_validator is not None and _merged_delivery_reconciliation_pending(
+        run, coordinator_root=coordinator_root
+    )
+    if not post_merge_closure:
+        try:
+            planning_authority, planning_source_revision = (
+                _validated_brainstorm_planning_authority(
+                    run,
+                    coordinator_root=coordinator_root,
+                )
+            )
+        except ValueError:
+            current = registry.get_workflow_run(run.run_id)
+            updated = registry._manager_update_workflow_run(
+                run.run_id,
+                facets=tuple(dict.fromkeys((*current.facets, "needs_human"))),
+                gate_status=pre_resume_gate_status,
+            )
+            return {
+                "run_id": updated.run_id,
+                "current_phase": updated.current_phase,
+                "reason": "planning-authority-reconciliation-failed",
+            }
+        if (
+            planning_authority != run.planning_authority
+            or planning_source_revision != run.planning_source_revision
+        ):
+            run = registry._manager_update_workflow_run(
+                run.run_id,
+                planning_authority=planning_authority,
+                planning_source_revision=planning_source_revision,
+            )
 
     def dispatch_or_stop(
         bound_run,

--- a/tests/test_workflow_production_wiring.py
+++ b/tests/test_workflow_production_wiring.py
@@ -523,6 +523,143 @@ def test_ship_validator_failure_persists_needs_human_on_review_complete_run(
     assert stopped.gate_status == "failed"
 
 
+def test_post_merge_closure_skips_active_planning_path_reconciliation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    steps = tuple(
+        WorkflowStep.from_dict({**step.to_dict(), "gate_result": "passed"})
+        if step.phase != "ship"
+        else step
+        for step in _manifest().steps
+    )
+    registry = JobRegistry(state_path=tmp_path / "registry.json")
+    candidate = "a" * 40
+    run = registry._manager_create_workflow_run(
+        work_id="production-wiring",
+        repo="hamanpaul/paulsha-cortex",
+        claim_key="claim:v1:" + "1" * 64,
+        source_revision="2" * 64,
+        workspace_root=str(tmp_path),
+        combo="feature-oneshot",
+        current_phase="review",
+        steps=steps,
+        issue_refs=("hamanpaul/paulsha-cortex#14",),
+        openspec_refs=("production-wiring",),
+        pr_refs=("hamanpaul/paulsha-cortex#17",),
+        attempts={"review": 1},
+        candidate_head=candidate,
+        verified_head=candidate,
+        facets=("needs_human",),
+        gate_status="failed",
+        brainstorm_required=True,
+    )
+    (tmp_path / "delivery-journal.json").write_text(
+        json.dumps(
+            {
+                "schema": "cortex-delivery-journal/v1",
+                "runs": {
+                    run.run_id: {
+                        "run_id": run.run_id,
+                        "repo": run.repo,
+                        "work_id": run.work_id,
+                        "ship": {
+                            "phase": "merged",
+                            "head": candidate,
+                            "merge_commit": "b" * 40,
+                            "merge_authorization": {
+                                "path": "/evidence/authorization.json",
+                                "hash": "d" * 64,
+                                "payload": {
+                                    "run_id": run.run_id,
+                                    "repo": run.repo,
+                                    "work_id": run.work_id,
+                                    "head": candidate,
+                                },
+                            },
+                        },
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        manager,
+        "_validated_brainstorm_planning_authority",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("post-merge closure must not require active planning paths")
+        ),
+    )
+    calls: list[str] = []
+    dispatcher = type("D", (), {"_registry": registry, "_git_runner": None})()
+
+    result = manager.resume_workflow_run(
+        dispatcher,
+        run_id=run.run_id,
+        identities=IdentityRegistry.from_rows([]),
+        launcher_factory=lambda _: None,
+        coordinator_root=tmp_path,
+        operator_resume=True,
+        ship_validator=lambda **_: calls.append("ship")
+        or {
+            "trusted": True,
+            "status": "pending",
+            "head": candidate,
+            "commit_id": candidate,
+            "ref": "delivery:merged",
+            "hash": "c" * 64,
+        },
+    )
+
+    assert result["reason"] == "delivery-in-progress"
+    assert calls == ["ship"]
+    assert registry.get_workflow_run(run.run_id).facets == ()
+
+
+def test_post_merge_closure_routing_rejects_incomplete_authorization(tmp_path: Path) -> None:
+    run = SimpleNamespace(
+        run_id="workflow-" + "1" * 20,
+        repo="hamanpaul/paulsha-cortex",
+        work_id="production-wiring",
+        current_phase="review",
+        candidate_head="a" * 40,
+    )
+    (tmp_path / "delivery-journal.json").write_text(
+        json.dumps(
+            {
+                "schema": "cortex-delivery-journal/v1",
+                "runs": {
+                    run.run_id: {
+                        "run_id": run.run_id,
+                        "repo": run.repo,
+                        "work_id": run.work_id,
+                        "ship": {
+                            "phase": "merged",
+                            "head": run.candidate_head,
+                            "merge_commit": "b" * 40,
+                            "merge_authorization": {
+                                "path": "/evidence/authorization.json",
+                                "hash": "c" * 64,
+                                "payload": {
+                                    "run_id": run.run_id,
+                                    "repo": run.repo,
+                                    "work_id": run.work_id,
+                                },
+                            },
+                        },
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert not manager._merged_delivery_reconciliation_pending(
+        run, coordinator_root=tmp_path
+    )
+
+
 def test_operator_resume_retries_bound_needs_human_terminal_without_rewriting_old_job(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## 摘要

- delivery journal完整綁定merged run/Candidate/merge commit/authorization時，resume直接進入ship validator closure
- official archive移走active OpenSpec planning paths後，不再回退到planning-authority reconciliation failure
- journal identity或authorization binding不完整時仍走原本fail-closed路徑
- 補齊正負向production wiring測試、OpenSpec、操作文件與 changelog

## 驗證

- [x] `python3 -m pytest tests/ -q`（1045 passed, 21 subtests passed）
- [x] `openspec validate --all --strict`（6 passed, 0 failed）
- [x] pinned `python3 -m policy_check --repo .`（25 pass, 0 fail；1 個既有 R-22 warn）
- [x] `git diff --check`
- [x] live merged journal routing helper 回傳 `True`
- [x] `CHANGELOG.md [Unreleased]` 與 fragment 已更新
- [x] `VERSION` 維持 0.0.0，符合非 release PR 意圖
- [x] docs / OpenSpec 已同步
