### PR TITLE
docs(porcelain): 凍結 porcelain UX 規格與 v0.1.0 release plan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 
 ## [Unreleased]
 
+### Added
+- **Porcelain CLI UX 規格與 v0.1.0 release plan**：凍結七家族（bootstrap/request/run/inspect/recover/service/init-sample）命令詞彙、exit code 契約、`--json` schema 穩定策略、request_id 顯性化 UX 與 TUI 邊界契約；並定義 v0.1.0 批次順序、release 程序（GitHub Release）、升級回滾與 KPI。
+
 ### Changed
 - **Unified work lifecycle OpenSpec完成正式封存**：所有33項實作與canary工作已有可驗證證據，official CLI將change搬入日期archive，並把governed delivery、persona workflow與unified read model三份規格發佈為canonical specs。
 - **舊 lifecycle canary 以 abandoned 語意封存**：兩個未進入delivery的canary在Manager exact-run abandon後搬入日期archive，保留未勾選tasks並綁定immutable abandon evidence；不建立CompletionRecord，也不宣稱completed或done。

--- a/changelog.d/85-porcelain-ux-spec.md
+++ b/changelog.d/85-porcelain-ux-spec.md
@@ -1,0 +1,3 @@
+### Added
+
+- **Porcelain CLI UX 規格與 v0.1.0 release plan**：凍結七家族（bootstrap/request/run/inspect/recover/service/init-sample）命令詞彙、exit code 契約（0/1/2/3/4）、`--json` schema 穩定策略（`cortex-porcelain/<family>/v1`）、request_id 顯性化 UX 與 TUI 邊界契約；並定義 v0.1.0 批次順序、release 程序（GitHub Release）、升級回滾與 KPI。

--- a/docs/superpowers/plans/2026-07-21-v0.1.0-release-plan.md
+++ b/docs/superpowers/plans/2026-07-21-v0.1.0-release-plan.md
@@ -1,0 +1,73 @@
+# v0.1.0 首發 release plan
+
+- status: accepted
+- 日期：2026-07-21
+- 對應 issue：#85（epic #84）
+- 規格依據：`docs/superpowers/specs/2026-07-21-porcelain-cli-ux-design.md`
+
+## 1. 目標
+
+1. v0.1.0 = porcelain CLI 七家族 + onboarding docs + release pipeline，全數 merged。
+2. 發佈深度：**GitHub Release**（tag `v0.1.0` + wheel/sdist artifacts）。不上 PyPI/TestPyPI（留待後續版本）。
+3. 全部實作批次經 cortex coordinator dogfood 派工（builder：copilot CLI / gpt-5.4；ForeignReview：claude / sonnet），同時完成治理流程與 runtime 的第一次實機執行驗收。
+
+## 2. 批次順序與依賴
+
+| 批次 | issue | 內容 | 依賴 |
+|---|---|---|---|
+| B0 | #85 | UX 規格凍結 + 本 release plan（docs PR，不走 dogfood） | — |
+| Canary | #86 | `cortex --version`（dogfood 全管線驗證） | B0 |
+| B1 | #87 | porcelain 路由骨架 | Canary |
+| B2 | #88 | request 家族 | B1 |
+| B3 | #89 | inspect 家族 | B1 |
+| B4 | #90 | service 家族 | B1 |
+| B5 | #91 | bootstrap | B4 |
+| B6 | #92 | run + recover 家族 | B2 |
+| B7 | #93 | init-sample | B1 |
+| B8 | #94 | onboarding docs 七件 | 可與 B5–B7 平行 |
+| B9 | #95 | CI/release pipeline | 建議最後（檢查清單需引用已存在命令） |
+
+B1–B7 皆動頂層路由面，序列合併；B8 檔案不相交可平行。每批次 = 子 issue + openspec change + feature branch + PR，依 epic #84 的 dogfood runbook 執行。
+
+## 3. 每批次驗收點（merge 後）
+
+1. PR merged（merge commit + `--match-head-commit`）、Copilot review bot 有紀錄、CI 三 workflow 綠。
+2. 子 issue 因 closing keyword 自動關閉。
+3. `changelog.d/` fragment + `CHANGELOG.md [Unreleased]` 同步；openspec change 已 archive。
+4. `pipx install --force <repo>` 重裝後實跑新命令 smoke；`python3 -m policy_check --repo .` 0 fail；pytest 全綠。
+
+## 4. Release 程序（一次性，非 dogfood 批次）
+
+1. **前置**：B0–B9 全 landed，且最後一個 feature merge 後 **7 天無 hotfix**（policy flat profile 的 MINOR bump 條件；0.0.0 → 0.1.0 屬 MINOR）。
+2. 建 label：`release:0.1.0`（policy R-07 以 `release:` 前綴識別 release PR）。
+3. Release PR（`feature/<N>-release-0.1.0`）：
+   - `VERSION`：`0.0.0` → `0.1.0`。
+   - collate `changelog.d/` 全部 fragments → `CHANGELOG.md` 新增 `## [0.1.0] - <日期>` 段，清空 `[Unreleased]` 與 `changelog.d/`。
+   - PR 貼 `release:0.1.0` label（tag 尚未存在時 R-07 因此放行）。
+4. Merge 後：`git tag v0.1.0 <merge-commit>` + push tag → B9 的 release workflow 自動 build（`python -m build`）、`twine check`、產 GitHub Release 並附 wheel/sdist。
+5. **發佈驗證**：
+   - `gh release view v0.1.0`：release 存在、附件完整。
+   - clean venv：`pip install <wheel>` → `cortex --version` 輸出 `0.1.0`；`cortex bootstrap --dry-run` 可執行。
+   - `pipx install git+<repo-url>@v0.1.0` 安裝路徑可用。
+
+## 5. 升級與回滾
+
+- 升級：`pipx install --force git+<repo-url>@v0.1.0`；若 service unit 模板有變，`cortex service install` 重新 render 後 `cortex service restart`。
+- 回滾：`pipx install --force git+<repo-url>@<前一 ref>`；`cortex service restart`。發佈後發現重大缺陷 → `-fix.N` hotfix 流程（policy PATCH/fix 規則），不撤 tag。
+
+## 6. KPI（承研究報告，release 後量測）
+
+| KPI | 目標 |
+|---|---|
+| 首次上手（安裝 → bootstrap 完成且 status 綠） | < 10 分鐘 |
+| clean-install smoke 成功率（CI） | > 95% |
+| request 可追蹤率（timeout/pending 後 show/wait 可追到 terminal） | > 95% |
+| porcelain 對常用低階操作的覆蓋率 | > 80% |
+| onboarding docs 完成度（Quickstart/Upgrade/Rollback/Troubleshooting/Concepts/Admin/Runbook） | 100% |
+
+## 7. 風險摘要
+
+- copilot headless 授權行為（canary 先驗證；tick 帶 `--allow-unsafe`，天生 ≤1 ready slice）。
+- dogfood 自動開的 PR body 可能缺 `Closes #N` / 驗證 checklist → 驗收介入點：merge 前補 body。
+- worktree/branch 孤兒需人工清理（對照 issue #83）。
+- daemon 與 CLI 的 executor/model 雙軌設定漂移 → 已以 env 對齊 + 每批次重裝驗證緩解。

--- a/docs/superpowers/specs/2026-07-21-porcelain-cli-ux-design.md
+++ b/docs/superpowers/specs/2026-07-21-porcelain-cli-ux-design.md
@@ -1,0 +1,163 @@
+# Porcelain CLI UX 設計規格
+
+- status: accepted
+- 日期：2026-07-21
+- 對應 issue：#85（epic #84）
+- 來源研究：《強化 paulsha-cortex 的 CLI 最後一哩路研究計劃》（cortex deep research）
+
+本規格凍結 porcelain CLI 七家族的命令詞彙、exit code 契約、`--json` schema 穩定策略與 request_id UX。B1–B9 各批次的實作範圍以本文件為準；與本文件衝突的實作視為規格違反，需先回到本文件修訂。
+
+## 1. 目的與範圍
+
+cortex 既有命令面（`fanout/tick/complete/slice-action/work/status/jobs/stat/…`）對內部模型準確，但對一般 CLI 使用者暴露了過多必須先理解的概念（systemd、specs、dispatch hold/auto、slice lifecycle）。本規格依 Git plumbing/porcelain 分層慣例，在**不動核心**的前提下新增高階任務導向命令面。
+
+**不可動假設（non-goals）**：
+
+1. 不改 control 檔案契約與 manager control plane。
+2. 不改 spec/job/slice/work 資料模型與權責邊界。
+3. 不改 daemon single-writer：porcelain 只能發 request 或呼叫既有 CLI/client，禁止直接寫 workflow 狀態檔。
+4. 不新增 runtime 依賴（stdlib-only；`PyYAML` 為既有唯一例外）。
+5. 既有低階命令全部保留，行為不變（porcelain 是新增層，不是替換）。
+
+## 2. 設計原則
+
+1. **任務導向動詞**：使用者說得出口的操作（bootstrap、run、recover），而不是內部模型名。
+2. **雙軌輸出**：預設人類可讀摘要；所有命令支援 `--json`。腳本只准解析 `--json`，人類輸出不承諾穩定。
+3. **可追溯**：所有高階輸出必須能回溯到底層 request/status/log 來源；porcelain 不得產生底層查不到的「合成狀態」。
+4. **危險旗標不外露**：`--allow-unsafe` 等旁路旗標僅存在於低階命令；porcelain 不提供。專家永遠可以退回低階命令。
+5. **失敗訊息帶下一步**：每個錯誤訊息附至少一個可執行的建議命令。
+
+## 3. Exit code 契約
+
+| code | 語意 | 適用 |
+|---|---|---|
+| 0 | 成功（terminal success） | 全家族 |
+| 1 | terminal failure（操作完成但結果為失敗；或執行錯誤） | 全家族 |
+| 2 | 用法錯誤（argparse 層） | 全家族 |
+| 3 | accepted / pending（request 已受理但尚未 terminal；含 wait timeout） | request、run、recover |
+| 4 | 環境不滿足（preflight 未過：缺 executor、systemd 不可用且無 fallback、路徑不合法…） | bootstrap、service、doctor 類 |
+
+規則：exit 3 一律伴隨 `request_id` 輸出與追蹤提示；exit 4 一律列出「缺什麼、怎麼補」。
+
+## 4. `--json` schema 穩定策略
+
+沿用 repo 既有版本化慣例（`cortex-work/v1`、`cortex-doctor/v1`）：
+
+1. 每個 `--json` 輸出頂層必含 `"schema": "cortex-porcelain/<family>/v1"`。
+2. 演進只允許 additive（新增欄位）；語意變更或欄位移除必須 bump `/v2` 並保留 `/v1` 至少一個 MINOR 週期。
+3. `--json` 時 stdout 僅含單一 JSON 文件；診斷訊息走 stderr。
+4. 欄位命名 snake_case；時間一律 UTC ISO-8601。
+
+## 5. request_id UX
+
+現況：mutation request 由 CLI 寫入 control queue 後最多等 5 秒，逾時僅報錯，req_id 不外露。本規格將 request 顯性化：
+
+1. 所有 mutation 提交（run/recover 家族）成功寫入 queue 後，**立即**輸出：
+
+   ```
+   request_id: req_<...>
+   action: tick
+   accepted: true
+   status: pending
+   hint: cortex request wait req_<...>   # 或 cortex request show req_<...>
+   ```
+
+2. 未帶 `--wait`：以 exit 3 結束（accepted-pending）。帶 `--wait [--timeout N]`（預設 120s）：輪詢 done 檔，成功 exit 0、terminal failure exit 1、timeout exit 3（並再次印出追蹤提示）。
+3. `request` 家族為純唯讀（讀 `requests/`、`done/`、`status.json`、job registry），不經 control queue，daemon degraded 時仍可用。
+
+## 6. 命令詞彙表（七家族）
+
+### 6.1 `cortex request` — request 追蹤
+
+| 命令 | 語意 | 資料來源 |
+|---|---|---|
+| `request list [--recent N]` | 最近 requests（pending + done） | `requests/`、`done/` |
+| `request show <request_id>` | 型別、參數摘要、建立/完成時間、result/error、關聯 job/slice/work | done payload + job registry |
+| `request wait <request_id> [--timeout N]` | 等待 terminal（exit 0/1/3） | done 檔輪詢 |
+| `request logs <request_id>` | best-effort 聚合該 request 相關的 manager log / job log 片段 | manager.log、job logs |
+
+設計決策：**不提供 `request submit`**。提交一律走語意化的 `run`/`recover` 命令；request 家族只負責追蹤。理由：generic submit 會繞過語意層驗證，且與 run 家族重複。
+
+### 6.2 `cortex run` — 高階工作語意（映射既有 request types）
+
+| 命令 | 映射 |
+|---|---|
+| `run tick [--specs-dir D] [--executor E --model M] [--review-executor E --review-model M] [--wait]` | `tick` request |
+| `run fanout [...]`（參數同上，無 review） | `fanout` request |
+| `run complete [--review-executor E --review-model M] [--wait]` | `complete` request |
+| `run work <start\|resume\|auto\|ship\|…> <work_id> --repo R [...] [--wait]` | `work-action` request |
+
+輸出一律含 request_id（第 5 節格式）。executor/model 省略時採 daemon 部署設定，並於輸出中回顯實際生效值。
+
+### 6.3 `cortex inspect` — 統一唯讀檢視
+
+| 命令 | 包裝 |
+|---|---|
+| `inspect status` | control `status.json`（含 daemon pid/idle/last_tick、ready/held/in_flight/recent_done） |
+| `inspect job <job_id>` | `stat` |
+| `inspect ready` | `ready` |
+| `inspect work <work_id> [--repo R] [--explain]` | Monitor socket `work show` |
+| `inspect doctor [--repo R]` | `doctor` |
+| `inspect service` | service 模式（systemd/fallback/none）、unit 狀態、**運行中版本** |
+
+全部唯讀、不經 control queue（`status.json` 直讀）。`inspect service` 必須顯示運行中程式版本與安裝來源，避免「daemon 跑過期快照無人察覺」。
+
+### 6.4 `cortex service` — 服務生命週期
+
+| 命令 | 行為 |
+|---|---|
+| `service install [--instance I] [--repo-root P] [--interval N]` | 包裝既有 installer（render/copy units、daemon-reload、enable） |
+| `service start / stop / restart` | systemd：**service + timer 成對操作**；fallback：管理 daemon 行程 |
+| `service status` | 模式、unit 狀態、pid、運行版本、env 摘要（executor/interval/specs-dir） |
+| `service logs [--follow] [-n N]` | systemd：journalctl；fallback：log 檔 tail |
+| `service uninstall [--purge]` | 停用並移除 units（`--purge` 才清 runtime env） |
+
+契約：明確區分三種模式（systemd / fallback / 未安裝），禁止假成功——systemd 不可用時必須說明並指出 fallback 路徑。stop/start 必含 timer，避免「只停 service 被 timer 拉回」。
+
+### 6.5 `cortex bootstrap` — 從乾淨機器到第一次成功
+
+流程（每步失敗訊息附修法；`--dry-run` 只檢查不動作）：
+
+1. 環境檢查：Python/Git/repo-root/executor CLI 在 PATH 且已登入（只報狀態，不代登入）→ 不滿足 exit 4。
+2. `service install`（透傳 `--instance/--interval`）。
+3. `--start`（預設開）：啟動 service+timer；systemd 不可用 → 說明 fallback。
+4. 健檢：`inspect status` + `inspect doctor` 摘要。
+5. 選配 `--sample <combo> --task "..."`：呼叫 init-sample（sample 失敗不影響 bootstrap 本身的成功判定，但明確標示）。
+6. 輸出下一步指引（人類可讀；`--json` 為機器格式）。
+
+### 6.6 `cortex recover` — 操作員恢復語彙
+
+| 命令 | 映射 |
+|---|---|
+| `recover slice <slice_id> <retry-build\|retry-verify\|retry-review\|abandon> --actor A [--wait]` | `slice-action` |
+| `recover work <work_id> <retry-build\|resume\|abandon> --repo R [--wait]` | `work-action` |
+| `recover brokers reap [--apply]` | `reap-brokers` |
+| `recover service restart` | `service restart` 別名 |
+
+mutation 類輸出一律含 request_id。`--actor` 為必填（審計要求），不提供預設值。
+
+### 6.7 `cortex init-sample` — 第一個 sample workflow
+
+```
+cortex init-sample --task "<描述>" [--combo feature-oneshot] [--change NAME]
+```
+
+包裝 `deck compile --emit`：產出 spec 一律 `dispatch: hold`，輸出 spec 路徑、必要的人工欄位清單、`deck verify` 檢核命令、與翻 auto 的說明。**絕不**自動翻 auto。
+
+## 7. TUI 邊界契約
+
+1. paulshaclaw（cockpit/TUI）只透過兩個穩定介面消費 cortex：porcelain `--json` 輸出、Monitor Unix socket read API。
+2. TUI 的任何 mutation 一律經 porcelain 命令（或既有 control client request），**禁止**直接讀寫 cortex 內部狀態檔（jobs registry、delivery journal、spec frontmatter…）。
+3. 相容性以 `--json` 的 schema 版本為準；TUI pin 最低 cortex 版本。
+4. TUI 的實作與發佈不在本 repo 與 v0.1.0 範圍。
+
+## 8. 實作限制
+
+1. `paulsha_cortex/porcelain/` 子模組承載七家族；頂層 `cli.py` 路由表外掛化（B1），各家族自行登記。
+2. stdlib-only；`test_zero_dependency_runtime` 必須續綠。
+3. 每個家族附 unit tests（mock control client / 檔案 fixture），CI（`tests.yml`）自動涵蓋。
+4. 新命令落地的同一 PR 必須同步 README 命令面章節與 CLI help（policy R-16）。
+
+## 9. 名詞速查（供 B8 Concepts 文件展開）
+
+`spec`（deck 產出的派工單，frontmatter 控制 hold/auto）→ `job`（一次 executor 執行）→ `slice`（工作切片，含 verify/review gate）→ `work`（跨 PR/issue 的統一生命週期 read model）。Manager daemon 是唯一 writer；Monitor 把多來源事實投影成 work read model。


### PR DESCRIPTION
## 摘要
- 凍結 porcelain CLI 七家族 UX 規格：命令詞彙表、exit code 契約（0/1/2/3/4）、`--json` schema 穩定策略（`cortex-porcelain/<family>/v1`）、request_id 顯性化 UX、TUI 邊界契約
- 定義 v0.1.0 release plan：批次順序（#86–#95）、GitHub Release 程序、升級回滾、KPI
- 同步 `changelog.d/85-porcelain-ux-spec.md` 與 `CHANGELOG.md [Unreleased]`

Closes #85

## 驗證
- [x] `python3 -m policy_check --repo .`（0 fail；R-22 為既有 advisory warn）
- [x] `python3 -m pytest tests/ -q`（1057 passed, 21 subtests passed）
- [x] `git diff --check`
- [x] `CHANGELOG.md [Unreleased]` 與 fragment 同步
- [x] `VERSION` 維持 0.0.0，符合非 release PR 意圖