### PR TITLE
docs(canary): 建立 add-cortex-version-flag dogfood 規劃產物

### DIFF
--- a/.cortex/work-items.yaml
+++ b/.cortex/work-items.yaml
@@ -25,6 +25,15 @@ work_items:
         ref: hamanpaul/paulsha-cortex#27
       - kind: openspec
         ref: docs-only-lifecycle-canary-v2
+  add-cortex-version-flag:
+    title: cortex --version flag (porcelain dogfood canary)
+    links:
+      - kind: github_issue
+        ref: hamanpaul/paulsha-cortex#86
+      - kind: openspec
+        ref: add-cortex-version-flag
+      - kind: path
+        ref: docs/superpowers/workstreams/add-cortex-version-flag/todo.md
   terminal-lifecycle-canary:
     title: Unified lifecycle terminal live canary
     links:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ## [Unreleased]
 
 ### Added
+- **dogfood canary 規劃產物（add-cortex-version-flag）**：為 `cortex --version` canary 批次建立 confirmed Work Item 綁定、accepted 規劃四件套與 active OpenSpec change（`cli-version-reporting`），供 coordinator dogfood 派工消費。
 - **Porcelain CLI UX 規格與 v0.1.0 release plan**：凍結七家族（bootstrap/request/run/inspect/recover/service/init-sample）命令詞彙、exit code 契約、`--json` schema 穩定策略、request_id 顯性化 UX 與 TUI 邊界契約；並定義 v0.1.0 批次順序、release 程序（GitHub Release）、升級回滾與 KPI。
 
 ### Changed

--- a/changelog.d/86-canary-planning.md
+++ b/changelog.d/86-canary-planning.md
@@ -1,0 +1,3 @@
+### Added
+
+- **dogfood canary 規劃產物（add-cortex-version-flag）**：為 `cortex --version` canary 批次建立 confirmed Work Item 綁定（`.cortex/work-items.yaml`、workstream Todo）、accepted 規劃四件套（spec/design/plan）與 active OpenSpec change（`cli-version-reporting` capability），供 coordinator dogfood 派工消費。

--- a/docs/superpowers/plans/add-cortex-version-flag.md
+++ b/docs/superpowers/plans/add-cortex-version-flag.md
@@ -1,0 +1,22 @@
+---
+status: accepted
+work_item: add-cortex-version-flag
+---
+
+# add-cortex-version-flag Plan
+
+## Tasks
+
+### 1. TDD RED
+
+- [ ] 新增 `tests/test_cli_version.py`：斷言 `cortex --version`（`main(["--version"])`）輸出版本字串且 exit 0；先確認現況 RED。
+
+### 2. 實作
+
+- [ ] `paulsha_cortex/cli.py` 的 `main()` 在子命令路由前處理 `--version`：`importlib.metadata.version("paulsha-cortex")`，`PackageNotFoundError` fallback `0.0.0+unknown`；輸出 `cortex <version>`。
+
+### 3. 同步與驗證
+
+- [ ] `changelog.d/86-cortex-version-flag.md` fragment 與 `CHANGELOG.md [Unreleased]` 同步（Added）。
+- [ ] README 的 CLI 用法段落補 `--version` 一行。
+- [ ] `python3 -m pytest tests/ -q` 全綠；`python3 -m policy_check --repo .` 0 fail；`git diff --check` 乾淨。

--- a/docs/superpowers/specs/add-cortex-version-flag-design.md
+++ b/docs/superpowers/specs/add-cortex-version-flag-design.md
@@ -1,0 +1,24 @@
+---
+status: accepted
+work_item: add-cortex-version-flag
+---
+
+# add-cortex-version-flag Design
+
+## Decisions
+
+### 實作位置
+
+在 `paulsha_cortex/cli.py` 的 `main()` 子命令路由之前處理 `--version`（比照既有 `-h/--help` 的頂層特殊處理），避免落入 coordinator 透傳路徑的必填 `cmd` 檢查。
+
+### 版本解析
+
+以 `importlib.metadata.version("paulsha-cortex")` 為權威來源；`PackageNotFoundError` 時 fallback 輸出 `0.0.0+unknown`。不直接讀 repo `VERSION` 檔（安裝環境不存在該檔）。
+
+### 輸出格式
+
+單行 `cortex <version>`，stdout，exit 0。不加多餘裝飾，便於腳本解析。
+
+### 測試策略
+
+`tests/test_cli_version.py`：以 subprocess 或直接呼叫 `main(["--version"])` 斷言輸出含套件版本且 exit 0；先 RED（現況會落入 argparse 必填 `cmd` 錯誤）後實作轉 GREEN。

--- a/docs/superpowers/specs/add-cortex-version-flag-spec.md
+++ b/docs/superpowers/specs/add-cortex-version-flag-spec.md
@@ -1,0 +1,26 @@
+---
+status: accepted
+work_item: add-cortex-version-flag
+---
+
+# add-cortex-version-flag Specification
+
+porcelain 計畫（epic #84）的 dogfood canary：以最小真實變更驗證 coordinator 全自動交付鏈，同時補上 release 工程需要的版本可見性。
+
+## Requirements
+
+### 頂層 --version 旗標
+
+`cortex --version` SHALL 輸出目前安裝的套件版本字串並以 exit code 0 結束，不得要求任何子命令。
+
+版本 SHALL 優先取自已安裝套件 metadata（`importlib.metadata`）；metadata 不可得時 SHALL fallback 至可辨識的開發版本字串。
+
+### 範圍限制
+
+本變更 SHALL 僅新增頂層旗標，不得改動任何既有子命令的行為、參數或輸出。
+
+本變更 SHALL 維持 stdlib-only，不新增 runtime 依賴。
+
+### 驗證
+
+變更 SHALL 附帶單元測試（先 RED 後 GREEN），並保持既有測試全綠。

--- a/docs/superpowers/workstreams/add-cortex-version-flag/todo.md
+++ b/docs/superpowers/workstreams/add-cortex-version-flag/todo.md
@@ -1,0 +1,10 @@
+---
+work_item: add-cortex-version-flag
+---
+
+# add-cortex-version-flag Todo
+
+- [ ] 將 issue #86、active OpenSpec change 與本 Todo 綁定為同一 confirmed Work Item。
+- [ ] 由 coordinator 派工 copilot（gpt-5.4）在 worktree 完成 `cortex --version` build（TDD）。
+- [ ] ForeignReview（claude/sonnet）、自動 push、自動開 PR、Copilot bot review、merge 與 archive 全自動閉合。
+- [ ] pipx 重裝後 `cortex --version` 輸出正確版本字串，坑清單記錄至 porcelain epic #84。

--- a/openspec/changes/add-cortex-version-flag/.openspec.yaml
+++ b/openspec/changes/add-cortex-version-flag/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-21

--- a/openspec/changes/add-cortex-version-flag/design.md
+++ b/openspec/changes/add-cortex-version-flag/design.md
@@ -1,0 +1,8 @@
+# Design
+
+## Decisions
+
+- **路由前處理**：`--version` 在 `main()` 子命令路由之前攔截，比照 `-h/--help` 頂層特殊處理，不落入 coordinator 透傳的必填 `cmd` 檢查。
+- **版本來源**：`importlib.metadata.version("paulsha-cortex")` 為權威；`PackageNotFoundError` fallback `0.0.0+unknown`。不讀 repo `VERSION` 檔（安裝環境不存在）。
+- **輸出契約**：單行 `cortex <version>`，stdout，exit 0。
+- **最小範圍**：canary 紀律——只加一個旗標，其他一律不動。

--- a/openspec/changes/add-cortex-version-flag/proposal.md
+++ b/openspec/changes/add-cortex-version-flag/proposal.md
@@ -1,0 +1,20 @@
+---
+work_item: add-cortex-version-flag
+---
+
+## Why
+
+porcelain 計畫（epic #84、issue #86）需要一個最小真實批次做 dogfood canary，在賭上七家族之前驗證 deck → tick → copilot build → ForeignReview → 自動 push/PR/bot review/merge → archive 的全自動交付鏈。同時，deep research 指出 cortex 缺乏版本可見性（對照 `--version` 慣例），是 release 工程的前置需求。
+
+## What Changes
+
+- `paulsha_cortex/cli.py` 新增頂層 `--version` 旗標：輸出安裝套件版本（`importlib.metadata`，fallback `0.0.0+unknown`），exit 0。
+- 新增 `tests/test_cli_version.py`（TDD：先 RED 後 GREEN）。
+- README CLI 段落與 changelog fragment 同步。
+- 不改動任何既有子命令行為；不新增 runtime 依賴。
+
+## Capabilities
+
+### New Capabilities
+
+- `cli-version-reporting`: cortex CLI 的版本可見性——頂層 `--version` 輸出安裝版本，供人類與腳本辨識運行中版本。

--- a/openspec/changes/add-cortex-version-flag/specs/cli-version-reporting/spec.md
+++ b/openspec/changes/add-cortex-version-flag/specs/cli-version-reporting/spec.md
@@ -1,0 +1,17 @@
+## ADDED Requirements
+
+### Requirement: cortex CLI 必須提供頂層 --version
+
+`cortex --version` MUST 輸出目前安裝的套件版本並以 exit 0 結束，不得要求子命令，且不得改變任何既有子命令行為。
+
+#### Scenario: 已安裝環境查詢版本
+
+- **WHEN** 使用者在已安裝 paulsha-cortex 的環境執行 `cortex --version`
+- **THEN** stdout 輸出單行 `cortex <version>`（version 來自套件 metadata）
+- **THEN** exit code 為 0
+
+#### Scenario: 套件 metadata 不可得
+
+- **WHEN** 於未安裝套件 metadata 的開發環境執行 `cortex --version`
+- **THEN** stdout 輸出 fallback 版本字串 `cortex 0.0.0+unknown`
+- **THEN** exit code 為 0

--- a/openspec/changes/add-cortex-version-flag/tasks.md
+++ b/openspec/changes/add-cortex-version-flag/tasks.md
@@ -1,0 +1,6 @@
+# Tasks
+
+- [ ] 1.1 新增 `tests/test_cli_version.py`，確認現況 RED。
+- [ ] 1.2 `paulsha_cortex/cli.py` 頂層 `--version` 實作（importlib.metadata + fallback），測試轉 GREEN。
+- [ ] 1.3 README CLI 段落補 `--version`；`changelog.d/86-cortex-version-flag.md` 與 `CHANGELOG.md [Unreleased]` 同步。
+- [ ] 1.4 `pytest` 全綠、`policy_check` 0 fail、`git diff --check` 乾淨。


### PR DESCRIPTION
## 摘要
- 建立 canary 批次的 confirmed Work Item 綁定：`.cortex/work-items.yaml` + `docs/superpowers/workstreams/add-cortex-version-flag/todo.md`
- accepted 規劃四件套：spec / design / plan（frontmatter `status: accepted` + `work_item`）
- active OpenSpec change `add-cortex-version-flag`（`cli-version-reporting` capability）
- fragment 與 `CHANGELOG.md [Unreleased]` 同步

本 PR 只含規劃產物；`cortex --version` 實作將由 coordinator dogfood 派工 copilot（gpt-5.4）完成並自動開 PR（屆時才 `Closes #86`）。

Refs #86（不關閉；實作 PR 才關）

## 驗證
- [x] `openspec validate --all --strict`（7 passed, 0 failed）
- [x] `python3 -m policy_check --repo .`（0 fail）
- [x] `python3 -m pytest tests/ -q`（1057 passed）
- [x] `git diff --check`
- [x] `CHANGELOG.md [Unreleased]` 與 fragment 同步
- [x] `VERSION` 維持 0.0.0，符合非 release PR 意圖