### PR TITLE
docs(canary): 補齊 planning artifacts 的 completeness gate 要求

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@ __pycache__/
 .pytest_cache/
 build/
 *.egg-info/
+
+# dogfood runtime 殘留（daemon cwd=repo root 時產生）
+/runtime/
+/.dogfood-specs/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 - **dogfood canary 規劃產物（add-cortex-version-flag）**：為 `cortex --version` canary 批次建立 confirmed Work Item 綁定、accepted 規劃四件套與 active OpenSpec change（`cli-version-reporting`），供 coordinator dogfood 派工消費。
 - **Porcelain CLI UX 規格與 v0.1.0 release plan**：凍結七家族（bootstrap/request/run/inspect/recover/service/init-sample）命令詞彙、exit code 契約、`--json` schema 穩定策略、request_id 顯性化 UX 與 TUI 邊界契約；並定義 v0.1.0 批次順序、release 程序（GitHub Release）、升級回滾與 KPI。
 
+### Fixed
+- **canary 規劃產物補齊 completeness gate 要求**：openspec change 三件與 workstream Todo 補 `status: accepted` frontmatter 與各 kind 必要章節，`assess_planning_completeness` 全數通過。
+
 ### Changed
 - **Unified work lifecycle OpenSpec完成正式封存**：所有33項實作與canary工作已有可驗證證據，official CLI將change搬入日期archive，並把governed delivery、persona workflow與unified read model三份規格發佈為canonical specs。
 - **舊 lifecycle canary 以 abandoned 語意封存**：兩個未進入delivery的canary在Manager exact-run abandon後搬入日期archive，保留未勾選tasks並綁定immutable abandon evidence；不建立CompletionRecord，也不宣稱completed或done。

--- a/changelog.d/86-planning-completeness.md
+++ b/changelog.d/86-planning-completeness.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **canary 規劃產物補齊 completeness gate 要求**：為 openspec change 三件（proposal/design/tasks）與 workstream Todo 補上 `status: accepted` frontmatter，並補齊各 kind 必要章節（spec 類需 Goals/Requirements、plan 類需 Tasks），使 `assess_planning_completeness` 全數通過、workflow define 階段不再誤觸異質 brainstorm。

--- a/docs/superpowers/specs/add-cortex-version-flag-design.md
+++ b/docs/superpowers/specs/add-cortex-version-flag-design.md
@@ -5,6 +5,10 @@ work_item: add-cortex-version-flag
 
 # add-cortex-version-flag Design
 
+## Goals
+
+以最小、可驗證的變更補上 cortex 版本可見性，同時作為 dogfood 管線的 canary 標的；設計上優先「不動既有行為」與「零新增依賴」。
+
 ## Decisions
 
 ### 實作位置

--- a/docs/superpowers/workstreams/add-cortex-version-flag/todo.md
+++ b/docs/superpowers/workstreams/add-cortex-version-flag/todo.md
@@ -1,8 +1,11 @@
 ---
+status: accepted
 work_item: add-cortex-version-flag
 ---
 
 # add-cortex-version-flag Todo
+
+## Tasks
 
 - [ ] 將 issue #86、active OpenSpec change 與本 Todo 綁定為同一 confirmed Work Item。
 - [ ] 由 coordinator 派工 copilot（gpt-5.4）在 worktree 完成 `cortex --version` build（TDD）。

--- a/openspec/changes/add-cortex-version-flag/design.md
+++ b/openspec/changes/add-cortex-version-flag/design.md
@@ -1,3 +1,8 @@
+---
+status: accepted
+work_item: add-cortex-version-flag
+---
+
 # Design
 
 ## Decisions

--- a/openspec/changes/add-cortex-version-flag/proposal.md
+++ b/openspec/changes/add-cortex-version-flag/proposal.md
@@ -1,6 +1,11 @@
 ---
+status: accepted
 work_item: add-cortex-version-flag
 ---
+
+## Goals
+
+驗證 coordinator 全自動交付鏈（dogfood canary），並補上 release 工程需要的版本可見性。
 
 ## Why
 

--- a/openspec/changes/add-cortex-version-flag/tasks.md
+++ b/openspec/changes/add-cortex-version-flag/tasks.md
@@ -1,3 +1,8 @@
+---
+status: accepted
+work_item: add-cortex-version-flag
+---
+
 # Tasks
 
 - [ ] 1.1 新增 `tests/test_cli_version.py`，確認現況 RED。


### PR DESCRIPTION
## 摘要
- openspec change（proposal/design/tasks）與 workstream Todo 補 `status: accepted` frontmatter
- 補齊各 kind 必要章節：spec 類補 `## Goals`、todo 補 `## Tasks`
- `assess_planning_completeness` 離線驗證 7/7 PASS、complete=True（原 5 份 FAIL 導致 workflow define 卡 needs_human + 誤觸異質 brainstorm）

Refs #86（不關閉；實作 PR 才關）

## 驗證
- [x] `assess_planning_completeness` 離線 7/7 PASS、complete=True
- [x] `openspec validate --all --strict`（7 passed）
- [x] `python3 -m policy_check --repo .`（0 fail）
- [x] `git diff --check`
- [x] fragment 與 `CHANGELOG.md [Unreleased]` 同步
- [x] `VERSION` 維持 0.0.0