### PR TITLE
chore(canary): work-items 補 spec/plan path links 使 authority 完整

### DIFF
--- a/.cortex/work-items.yaml
+++ b/.cortex/work-items.yaml
@@ -34,6 +34,10 @@ work_items:
         ref: add-cortex-version-flag
       - kind: path
         ref: docs/superpowers/workstreams/add-cortex-version-flag/todo.md
+      - kind: path
+        ref: docs/superpowers/specs/add-cortex-version-flag-spec.md
+      - kind: path
+        ref: docs/superpowers/plans/add-cortex-version-flag.md
   terminal-lifecycle-canary:
     title: Unified lifecycle terminal live canary
     links:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - **canary 規劃產物補齊 completeness gate 要求**：openspec change 三件與 workstream Todo 補 `status: accepted` frontmatter 與各 kind 必要章節，`assess_planning_completeness` 全數通過。
 
 ### Changed
+- **canary Work Item 補齊 spec/plan path links**：`.cortex/work-items.yaml` 的 canary 條目補 superpowers spec/plan path links，work authority 完整涵蓋規劃產物。
 - **Unified work lifecycle OpenSpec完成正式封存**：所有33項實作與canary工作已有可驗證證據，official CLI將change搬入日期archive，並把governed delivery、persona workflow與unified read model三份規格發佈為canonical specs。
 - **舊 lifecycle canary 以 abandoned 語意封存**：兩個未進入delivery的canary在Manager exact-run abandon後搬入日期archive，保留未勾選tasks並綁定immutable abandon evidence；不建立CompletionRecord，也不宣稱completed或done。
 - **Canonical ship audit保留Job發證時source revision**：evidence reader改以Job自身persisted dispatch revision驗envelope，不再因WorkflowRun current source於PR/provider refresh後前進而誤報binding invalid；run/claim/repo/card/phase與locator/hash仍完整fail-closed重驗。

--- a/changelog.d/86-workitem-links.md
+++ b/changelog.d/86-workitem-links.md
@@ -1,0 +1,3 @@
+### Changed
+
+- **canary Work Item 補齊 spec/plan path links**：`.cortex/work-items.yaml` 的 `add-cortex-version-flag` 條目比照 `unified-work-lifecycle` 前例補上 superpowers spec 與 plan 的 path links，使 work authority 完整涵蓋規劃產物（並使 abandoned run 的 claim key 失效，允許 fresh claim）。


### PR DESCRIPTION
## 摘要
- `.cortex/work-items.yaml` 的 add-cortex-version-flag 條目比照 unified-work-lifecycle 前例，補 superpowers spec 與 plan 的 path links
- work authority 完整涵蓋規劃產物；同時使 abandoned run 的 persisted claim key 失效，允許 fresh claim（對應 canary 坑清單 F16）
- 關聯脈絡見 dogfood canary issue 與 porcelain epic（編號見 branch 名，body 刻意不引用以維持 R-17 not-applicable）

## 驗證
- [x] `python3 -m policy_check --repo .`（0 fail）
- [x] `git diff --check`
- [x] fragment 與 `CHANGELOG.md [Unreleased]` 同步
- [x] `VERSION` 維持 0.0.0