### PR TITLE
docs(canary): 新增 follow-ups workstream todo 擴充 work authority

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ## [Unreleased]
 
 ### Added
+- **canary follow-ups workstream todo**：記錄 dogfood canary 實跑發現的後續事項，並作為 work authority 的新增 confirmed 來源。
 - **dogfood canary 規劃產物（add-cortex-version-flag）**：為 `cortex --version` canary 批次建立 confirmed Work Item 綁定、accepted 規劃四件套與 active OpenSpec change（`cli-version-reporting`），供 coordinator dogfood 派工消費。
 - **Porcelain CLI UX 規格與 v0.1.0 release plan**：凍結七家族（bootstrap/request/run/inspect/recover/service/init-sample）命令詞彙、exit code 契約、`--json` schema 穩定策略、request_id 顯性化 UX 與 TUI 邊界契約；並定義 v0.1.0 批次順序、release 程序（GitHub Release）、升級回滾與 KPI。
 

--- a/changelog.d/86-canary-followups.md
+++ b/changelog.d/86-canary-followups.md
@@ -1,0 +1,3 @@
+### Added
+
+- **canary follow-ups workstream todo**：記錄 dogfood canary 實跑發現的後續事項（builder commit 慣例、policy label 時序、claim key 設計債、runtime 殘留路徑），並作為 work authority 的新增 confirmed 來源。

--- a/docs/superpowers/workstreams/add-cortex-version-flag/followups.md
+++ b/docs/superpowers/workstreams/add-cortex-version-flag/followups.md
@@ -1,0 +1,15 @@
+---
+status: accepted
+work_item: add-cortex-version-flag
+---
+
+# add-cortex-version-flag Follow-ups
+
+canary 實跑期間發現、不阻斷本批次但需回饋 porcelain epic 的後續事項。
+
+## Tasks
+
+- [ ] dispatch prompt / plan 慣例明示「build 完成必須 git commit」（completion gate 要求 commit，但 prompt 未要求）。
+- [ ] policy-exempt label 需在 PR 事件觸發前就位（rerun 沿用舊 event payload，label 後掛不生效）；PR 建立時一併帶 label 或改寫 body 避免引用。
+- [ ] claim key 永久唯一 + superseded run 不可重宣告的設計債：評估 claim key attempt 版本化或 tombstone 機制（歷史以 -v2 識別繞過）。
+- [ ] daemon cwd=repo root 後 runtime 殘留（runtime/、.dogfood-specs/）落在 repo 內：已入 .gitignore，長期應改寫入 PSC_RUN_ROOT。


### PR DESCRIPTION
## 摘要
- 新增 canary follow-ups workstream todo（status: accepted，含 Tasks 章節），記錄實跑發現的後續事項
- 作為 work authority 的新增 confirmed 來源：authority digest 改變後，abandoned run 的 persisted claim key 失效，允許 fresh claim（body 不引用 issue 編號以維持 R-17 not-applicable）

## 驗證
- [x] `python3 -m policy_check --repo .`（0 fail）
- [x] `git diff --check`
- [x] fragment 與 `CHANGELOG.md [Unreleased]` 同步
- [x] `VERSION` 維持 0.0.0