### PR TITLE
fix(workflow): malformed build 卡 terminal 改為可重試並明示 candidate 契約

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - **Porcelain CLI UX 規格與 v0.1.0 release plan**：凍結七家族（bootstrap/request/run/inspect/recover/service/init-sample）命令詞彙、exit code 契約、`--json` schema 穩定策略、request_id 顯性化 UX 與 TUI 邊界契約；並定義 v0.1.0 批次順序、release 程序（GitHub Release）、升級回滾與 KPI。
 
 ### Fixed
+- **malformed workflow build 卡改走可重試 recovery**：Manager 現在會把 malformed 的 passed terminal（含 build candidate 缺失）辨識為可重派卡片，避免 operator resume 永久卡死，並在 prompt 明示 build/plan candidate 的回報契約。
 - **canary 規劃產物補齊 completeness gate 要求**：openspec change 三件與 workstream Todo 補 `status: accepted` frontmatter 與各 kind 必要章節，`assess_planning_completeness` 全數通過。
 
 ### Changed

--- a/changelog.d/106-workflow-card-recovery.md
+++ b/changelog.d/106-workflow-card-recovery.md
@@ -1,0 +1,2 @@
+### Fixed
+- **malformed workflow build 卡改走可重試 recovery**：Manager 現在會把 malformed 的 passed terminal（含 build candidate 缺失）辨識為可重派卡片，避免 operator resume 永久卡死，並在 prompt 明示 build/plan candidate 的回報契約。

--- a/paulsha_cortex/coordinator/manager.py
+++ b/paulsha_cortex/coordinator/manager.py
@@ -2383,6 +2383,44 @@ def _retryable_nonpassing_workflow_terminal(job: Mapping[str, object]) -> bool:
     )
 
 
+def _malformed_workflow_card_terminal(job: Mapping[str, object]) -> bool:
+    """Recognize plan/build terminals that cannot be bound as a passed workflow-card."""
+
+    if _retryable_nonpassing_workflow_terminal(job):
+        return False
+    if (
+        job.get("workflow_evidence") is not None
+        or job.get("status") != "exited"
+        or type(job.get("exit_code")) is not int
+        or job.get("exit_code") != 0
+        or job.get("workflow_phase") not in {"plan", "build"}
+    ):
+        return False
+    try:
+        raw = _extract_terminal_json(job.get("log_path"))
+    except ValueError:
+        return True
+    required = {
+        "schema_version", "kind", "status", "run_id", "card_id", "candidate", "outputs",
+    }
+    if (
+        set(raw) != required
+        or type(raw.get("schema_version")) is not int
+        or raw.get("schema_version") != 1
+        or raw.get("kind") != "workflow-card"
+    ):
+        return True
+    if raw.get("status") != "passed":
+        return True
+    candidate = raw.get("candidate")
+    if job.get("workflow_phase") == "build":
+        return (
+            not isinstance(candidate, str)
+            or verification.SAFE_SHA_RE.fullmatch(candidate) is None
+        )
+    return candidate is not None
+
+
 def _workflow_review_evidence_state(
     job: Mapping[str, object],
     *,
@@ -3493,6 +3531,7 @@ def _discard_failed_planner_sandbox(
     if job.get("persona") != "planner" or (
         job.get("status") != "failed"
         and not _retryable_nonpassing_workflow_terminal(job)
+        and not _malformed_workflow_card_terminal(job)
     ):
         raise ValueError("planner sandbox retry requires failed planner job")
     path = _planner_sandbox_path(job, coordinator_root)
@@ -4983,7 +5022,10 @@ def _workflow_job_prompt(
         "path or hash because Manager will canonicalize it. For workflow-card outputs, return only "
         "repo-relative artifact path strings matching declared_outputs; when declared_outputs is "
         "empty, outputs must be exactly []. Never put action, summary, or other descriptive objects "
-        "in outputs."
+        "in outputs. For build cards, candidate must be the full 40-hex commit SHA of the worktree "
+        "HEAD after the card completes (use `git rev-parse HEAD`); commit-forbidden cards must "
+        "report the current HEAD, build candidates must never be null, and plan candidates must be "
+        "null."
         + planner_contract
         + reviewer_contract
         + " Contract: "
@@ -5029,6 +5071,7 @@ def _dispatch_workflow_card(
                 and (
                     matching[-1].get("status") == "failed"
                     or _retryable_nonpassing_workflow_terminal(matching[-1])
+                    or _malformed_workflow_card_terminal(matching[-1])
                     or _is_rejected_workflow_review_evidence(
                         matching[-1],
                         run=run,
@@ -5649,6 +5692,23 @@ def resume_workflow_run(
             "current_phase": updated.current_phase,
             "job_id": job["job_id"],
             "reason": failure_reason,
+        }
+    if _malformed_workflow_card_terminal(job):
+        replacement = dispatch_workflow_card(
+            dispatcher,
+            run=run,
+            identities=identities,
+            launcher_factory=launcher_factory,
+            coordinator_root=coordinator_root,
+            retry_failed=True,
+        )
+        if replacement is None:
+            return {"run_id": run.run_id, "current_phase": run.current_phase, "reason": "not-dispatchable"}
+        return {
+            "run_id": run.run_id,
+            "current_phase": run.current_phase,
+            "job_id": replacement["job_id"],
+            "reason": "card-terminal-malformed-retry",
         }
     try:
         job = terminalize_workflow_job(

--- a/tests/test_workflow_production_wiring.py
+++ b/tests/test_workflow_production_wiring.py
@@ -1036,18 +1036,23 @@ def test_operator_resume_retries_bound_needs_human_terminal_without_rewriting_ol
         "candidate": "a" * 40,
         "outputs": [],
     }) + "\n", encoding="utf-8")
-    with pytest.raises(ValueError, match="did not pass"):
-        manager.resume_workflow_run(
-            ResumeDispatcher(),
-            run_id=run.run_id,
-            identities=identities,
-            launcher_factory=lambda _: Launcher(),
-            coordinator_root=tmp_path / "coordinator",
-            operator_resume=True,
-        )
-    assert registry.get_workflow_run(run.run_id).facets == ("needs_human",)
-    assert len(registry.list_jobs()) == 1
-    log.write_text(json.dumps({
+    malformed = manager.resume_workflow_run(
+        ResumeDispatcher(),
+        run_id=run.run_id,
+        identities=identities,
+        launcher_factory=lambda _: Launcher(),
+        coordinator_root=tmp_path / "coordinator",
+        operator_resume=True,
+    )
+    assert malformed["reason"] == "card-terminal-malformed-retry"
+    assert malformed["job_id"] != old_job["job_id"]
+    assert registry.get_workflow_run(run.run_id).facets == ()
+    assert len(registry.list_jobs()) == 2
+    assert registry.get_job(old_job["job_id"])["workflow_evidence"] is None
+    retry_job = registry.get_job(malformed["job_id"])
+    retry_log = Path(retry_job["log_path"])
+    retry_log.parent.mkdir(parents=True, exist_ok=True)
+    retry_log.write_text(json.dumps({
         "schema_version": 1,
         "kind": "workflow-card",
         "status": "needs_human",
@@ -1056,6 +1061,12 @@ def test_operator_resume_retries_bound_needs_human_terminal_without_rewriting_ol
         "candidate": "a" * 40,
         "outputs": [],
     }) + "\n", encoding="utf-8")
+    registry.update_headless_result(retry_job["job_id"], status="exited", exit_code=0)
+    registry._manager_update_workflow_run(
+        run.run_id,
+        facets=("needs_human",),
+        gate_status="running",
+    )
 
     result = manager.resume_workflow_run(
         ResumeDispatcher(),
@@ -1115,6 +1126,180 @@ def test_nonpassing_terminal_retry_authority_requires_exact_schema_and_binding(
 
     log.write_text(json.dumps(payload) + "\n", encoding="utf-8")
     assert manager._retryable_nonpassing_workflow_terminal({**job, "exit_code": False}) is False
+
+
+def test_malformed_workflow_card_terminal_detects_unterminalizable_card_results(
+    tmp_path: Path,
+) -> None:
+    log = tmp_path / "terminal.jsonl"
+    job = {
+        "workflow_evidence": None,
+        "status": "exited",
+        "exit_code": 0,
+        "workflow_phase": "build",
+        "workflow_run_id": "run",
+        "workflow_card": "card",
+        "log_path": str(log),
+    }
+    good = {
+        "schema_version": 1,
+        "kind": "workflow-card",
+        "status": "passed",
+        "run_id": "run",
+        "card_id": "card",
+        "candidate": "a" * 40,
+        "outputs": [],
+    }
+
+    log.write_text(json.dumps({**good, "candidate": None}) + "\n", encoding="utf-8")
+    assert manager._malformed_workflow_card_terminal(job) is True
+
+    for status in ("failed", "needs_human"):
+        log.write_text(json.dumps({**good, "status": status}) + "\n", encoding="utf-8")
+        assert manager._malformed_workflow_card_terminal(job) is False
+
+    for status in ("failed", "needs_human"):
+        log.write_text(
+            json.dumps({**good, "status": status, "candidate": None}) + "\n",
+            encoding="utf-8",
+        )
+        assert manager._malformed_workflow_card_terminal(job) is True
+
+    log.write_text(json.dumps({**good, "status": "done"}) + "\n", encoding="utf-8")
+    assert manager._malformed_workflow_card_terminal(job) is True
+
+    log.write_text(json.dumps(good) + "\n", encoding="utf-8")
+    assert manager._malformed_workflow_card_terminal(job) is False
+
+
+def test_operator_resume_retries_malformed_build_terminal_without_advancing(
+    tmp_path: Path,
+) -> None:
+    operator_root = tmp_path / "operator"
+    builder_root = tmp_path / "builder"
+    coordinator_root = tmp_path / "coordinator"
+    operator_root.mkdir()
+    builder_root.mkdir()
+    plan_ref = "docs/superpowers/plans/production-wiring-plan.md"
+    plan = operator_root / plan_ref
+    plan.parent.mkdir(parents=True)
+    plan.write_text("---\nstatus: accepted\n---\n# Plan\n## Steps\n- Reproduce\n", encoding="utf-8")
+    registry = JobRegistry(state_path=coordinator_root / "registry.json")
+    run = registry._manager_create_workflow_run(
+        work_id="production-wiring",
+        repo="hamanpaul/paulsha-cortex",
+        claim_key="claim:v1:" + "1" * 64,
+        source_revision="2" * 64,
+        workspace_root=str(operator_root),
+        combo="feature-oneshot",
+        current_phase="build",
+        steps=_manifest().steps,
+        issue_refs=("hamanpaul/paulsha-cortex#14",),
+        openspec_refs=("production-wiring",),
+        pr_refs=(),
+        attempts={"build": 1},
+        gate_status="running",
+        planning_authority=(
+            PlanningArtifactAuthority(
+                ref=plan_ref,
+                kind="plan",
+                work_id="production-wiring",
+                baseline_sha256=hashlib.sha256(plan.read_bytes()).hexdigest(),
+            ),
+        ),
+    )
+    step = manager._current_workflow_step(run)
+    assert step is not None
+    assert step.phase == "build"
+    log = tmp_path / "malformed-build.jsonl"
+    log.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "kind": "workflow-card",
+                "status": "passed",
+                "run_id": run.run_id,
+                "card_id": step.card,
+                "candidate": None,
+                "outputs": [],
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    legacy = registry.create_job(
+        task="wf-malformed-build",
+        persona="builder",
+        kind="build",
+        branch="feature/14-production-wiring",
+        pane="",
+        worktree=str(builder_root),
+        dispatch_head="a" * 40,
+        executor="codex",
+        model_id="gpt-primary",
+        independence_domain="openai",
+        workflow_run_id=run.run_id,
+        workflow_claim_key=run.claim_key,
+        workflow_repo=run.repo,
+        workflow_card=step.card,
+        workflow_phase=step.phase,
+        workflow_repo_root=str(builder_root),
+        workflow_input_root=str(builder_root),
+        workflow_inputs=manager._effective_workflow_inputs(run, step),
+        workflow_outputs=step.outputs,
+        source_revision=run.source_revision,
+    )
+    registry.attach_launch_handle(
+        legacy["job_id"],
+        executor="codex",
+        model_id="gpt-primary",
+        session_name="wf-malformed-build",
+        log_path=str(log),
+    )
+    registry.update_headless_result(legacy["job_id"], status="exited", exit_code=0)
+    identities = IdentityRegistry.from_rows(
+        [{
+            "executor": "codex",
+            "model_id": "gpt-primary",
+            "independence_domain": "openai",
+            "capabilities": [],
+        }]
+    )
+
+    class Launcher:
+        def as_commit_required(self):
+            return self
+
+        def launch(self, *, slice_id, prompt, worktree, log_dir):
+            return LaunchHandle(
+                executor="codex",
+                model_id="gpt-primary",
+                session_name=slice_id,
+                pid=100,
+                log_path=str(Path(log_dir) / f"{slice_id}.jsonl"),
+            )
+
+    class ResumeDispatcher:
+        _registry = registry
+        _git_runner = None
+
+        def poll_headless_done(self, job_id):
+            return registry.get_job(job_id)
+
+    result = manager.resume_workflow_run(
+        ResumeDispatcher(),
+        run_id=run.run_id,
+        identities=identities,
+        launcher_factory=lambda _identity: Launcher(),
+        coordinator_root=coordinator_root,
+        operator_resume=True,
+    )
+
+    assert result["reason"] == "card-terminal-malformed-retry"
+    assert result["current_phase"] == "build"
+    assert result["job_id"] != legacy["job_id"]
+    assert registry.get_job(legacy["job_id"])["workflow_evidence"] is None
+    assert registry.get_workflow_run(run.run_id).current_phase == "build"
 
 
 def test_operator_resume_recovers_only_exact_legacy_agy_reviewer_terminal(
@@ -1816,6 +2001,17 @@ def test_build_input_snapshot_seeds_hash_bound_plan_and_versions_prompt(tmp_path
     assert payload["terminal_schema"]["fixed"]["outputs"] == []
     assert payload["terminal_schema"]["outputs"]["descriptive_objects_forbidden"] is True
     assert Path(snapshot[0]["content_ref"]).stat().st_mode & 0o222 == 0
+    prompt = manager._workflow_job_prompt(
+        run,
+        red,
+        builder_job_id=None,
+        coordinator_root=tmp_path / "coordinator",
+        input_snapshot=snapshot,
+    )
+    assert "40-hex" in prompt
+    assert "rev-parse HEAD" in prompt
+    assert "must never be null" in prompt
+    assert "must be null" in prompt
 
 
 def test_input_content_tamper_is_rejected_by_prompt_and_terminal_validation(tmp_path: Path) -> None:
@@ -2944,6 +3140,98 @@ def test_failed_planner_retry_replaces_only_its_disposable_sandbox(tmp_path: Pat
     first_sandbox = Path(first["worktree"])
     (first_sandbox / "failed-attempt-marker").write_text("stale\n", encoding="utf-8")
     registry.update_headless_result(first["job_id"], status="failed", exit_code=1)
+
+    retried = manager.dispatch_workflow_card(
+        dispatcher,
+        run=run,
+        identities=identities,
+        launcher_factory=lambda _: Launcher(),
+        coordinator_root=coordinator_root,
+        retry_failed=True,
+    )
+
+    assert retried["job_id"] != first["job_id"]
+    assert Path(retried["worktree"]) == first_sandbox
+    assert not (first_sandbox / "failed-attempt-marker").exists()
+    assert (first_sandbox / "source.md").read_text(encoding="utf-8") == "source\n"
+
+
+def test_malformed_planner_terminal_retry_reuses_cleaned_disposable_sandbox(
+    tmp_path: Path,
+) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "source.md").write_text("source\n", encoding="utf-8")
+    proposal = repo / "openspec/changes/production-wiring/proposal.md"
+    proposal.parent.mkdir(parents=True)
+    proposal.write_text("# Proposal\n", encoding="utf-8")
+    coordinator_root = tmp_path / "coordinator"
+    registry = JobRegistry(state_path=coordinator_root / "registry.json")
+    run = registry._manager_create_workflow_run(
+        work_id="production-wiring",
+        repo="hamanpaul/paulsha-cortex",
+        claim_key="claim:v1:" + "1" * 64,
+        source_revision="2" * 64,
+        workspace_root=str(repo),
+        combo="feature-oneshot",
+        current_phase="plan",
+        steps=_manifest().steps,
+        issue_refs=("hamanpaul/paulsha-cortex#14",),
+        openspec_refs=("production-wiring",),
+        pr_refs=(),
+        attempts={"plan": 1},
+        gate_status="running",
+    )
+    identities = IdentityRegistry.from_rows(
+        [{
+            "executor": "codex",
+            "model_id": "gpt-primary",
+            "independence_domain": "openai",
+            "capabilities": ["planning"],
+        }]
+    )
+
+    class Launcher:
+        def as_read_only(self):
+            return self
+
+        def launch(self, *, slice_id, prompt, worktree, log_dir):
+            return LaunchHandle(
+                executor="codex",
+                model_id="gpt-primary",
+                session_name=slice_id,
+                pid=100,
+                log_path=str(Path(log_dir) / f"{slice_id}.jsonl"),
+            )
+
+    dispatcher = type("D", (), {"_registry": registry, "_git_runner": None})()
+    first = manager.dispatch_workflow_card(
+        dispatcher,
+        run=run,
+        identities=identities,
+        launcher_factory=lambda _: Launcher(),
+        coordinator_root=coordinator_root,
+    )
+    first_sandbox = Path(first["worktree"])
+    (first_sandbox / "failed-attempt-marker").write_text("stale\n", encoding="utf-8")
+    first_log = Path(first["log_path"])
+    first_log.parent.mkdir(parents=True, exist_ok=True)
+    first_log.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "kind": "workflow-card",
+                "status": "done",
+                "run_id": run.run_id,
+                "card_id": first["workflow_card"],
+                "candidate": None,
+                "outputs": [],
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    registry.update_headless_result(first["job_id"], status="exited", exit_code=0)
 
     retried = manager.dispatch_workflow_card(
         dispatcher,


### PR DESCRIPTION
## 摘要
- 新增 `_malformed_workflow_card_terminal`：exited/exit0 但 terminal evidence 無法作為 passed 綁定（schema 破損、candidate 非法、status 非法）的 plan/build 卡辨識為可重派，不再永久 wedge
- `resume_workflow_run` 遇 malformed terminal 改走重派（reason=card-terminal-malformed-retry），不再 raise 卡死 operator resume
- `_discard_failed_planner_sandbox` 前置條件接受 malformed planner job（retry 路徑不再 raise）
- `_workflow_job_prompt` 明示 candidate 契約：build 卡必為 worktree HEAD 40-hex SHA（禁 commit 卡＝現有 HEAD）、plan 卡必為 null
- TDD：新增 malformed helper / operator resume 重派 / prompt 文案測試

實作：copilot CLI（gpt-5.4）直接編排（dogfood 管線被本缺陷阻斷）；審查：Fable 5 兩輪（第二輪補 status 非 passed 的 wedge 缺口與 planner sandbox 前置條件）。

Closes #106

## 驗證
- [x] `python3 -m pytest tests/ -q`（1060 passed, 21 subtests passed）
- [x] `python3 -m policy_check --repo .`（0 fail）
- [x] `git diff --check`
- [x] fragment 與 `CHANGELOG.md [Unreleased]` 同步
- [x] `VERSION` 維持 0.0.0