### PR TITLE
fix(launcher): copilot commit-required 卡補 scoped 檔案/工具權限

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - **Porcelain CLI UX 規格與 v0.1.0 release plan**：凍結七家族（bootstrap/request/run/inspect/recover/service/init-sample）命令詞彙、exit code 契約、`--json` schema 穩定策略、request_id 顯性化 UX 與 TUI 邊界契約；並定義 v0.1.0 批次順序、release 程序（GitHub Release）、升級回滾與 KPI。
 
 ### Fixed
+- **Copilot commit-required 卡補 scoped 檔案/工具權限**：workflow builder 派工現在會在 commit-required 模式只開 `--allow-all-tools` 與必要的 linked worktree Git 寫入目錄，避免 headless Copilot 因無法互動授權而卡在 commit。
 - **malformed workflow build 卡改走可重試 recovery**：Manager 現在會把 malformed 的 passed terminal（含 build candidate 缺失）辨識為可重派卡片，避免 operator resume 永久卡死，並在 prompt 明示 build/plan candidate 的回報契約。
 - **canary 規劃產物補齊 completeness gate 要求**：openspec change 三件與 workstream Todo 補 `status: accepted` frontmatter 與各 kind 必要章節，`assess_planning_completeness` 全數通過。
 

--- a/changelog.d/108-copilot-commit-permissions.md
+++ b/changelog.d/108-copilot-commit-permissions.md
@@ -1,0 +1,2 @@
+### Fixed
+- Copilot commit-required workflow builder 現在會補齊 scoped 工具與 linked worktree Git 寫入權限，避免 headless commit 卡在 permission denied。

--- a/paulsha_cortex/coordinator/launcher.py
+++ b/paulsha_cortex/coordinator/launcher.py
@@ -360,9 +360,16 @@ def build_copilot_argv(
     model: str | None = None,
     read_only: bool = False,
     review_only: bool = False,
+    commit_required: bool = False,
 ) -> list[str]:
+    if commit_required and (read_only or review_only or allow_unsafe):
+        raise ValueError("commit-required Copilot builder requires enforced workspace-write")
     if read_only or review_only:
         raise ValueError("copilot executor has no enforced read-only planning mode")
+    if commit_required:
+        if worktree is None:
+            raise ValueError("commit-required Copilot builder requires a worktree")
+        worktree = str(Path(worktree).resolve())
     # allow_unsafe（明確 opt-in）才放開 copilot 的全自動授權 --allow-all；
     # 預設關閉 → 由 executor 自身的互動授權把關（manager 自主派工請設 allow_unsafe=True）。
     argv = [
@@ -379,7 +386,12 @@ def build_copilot_argv(
     ]
     if model is not None:
         argv += ["--model", model]
-    if allow_unsafe:
+    if commit_required:
+        argv.append("--allow-all-tools")
+        argv += ["--add-dir", worktree]
+        for git_write_dir in _linked_worktree_git_write_dirs(worktree):
+            argv += ["--add-dir", git_write_dir]
+    elif allow_unsafe:
         argv.append("--allow-all")
     return argv
 
@@ -672,7 +684,7 @@ class SubprocessLauncher:
             "read_only": self._read_only,
             "review_only": self._review_only,
         }
-        if self._executor == "codex":
+        if self._executor in {"codex", "copilot"}:
             builder_kwargs["commit_required"] = self._commit_required
         if self._executor == "claude":
             builder_kwargs["review_terminal_kind"] = self._review_terminal_kind

--- a/tests/test_coordinator_launcher.py
+++ b/tests/test_coordinator_launcher.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+import shlex
 import subprocess
 import tempfile
 import unittest
@@ -28,6 +29,104 @@ class ArgvTests(unittest.TestCase):
         self.assertIn("slice-a", argv)
         self.assertIn("--output-format", argv)
         self.assertIn("json", argv)
+
+    def test_copilot_builder_commit_required_scopes_tool_and_git_write_dirs(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            root = Path(d)
+            repo = root / "repo"
+            linked = root / "linked"
+            subprocess.run(["git", "init", "-q", str(repo)], check=True)
+            subprocess.run(
+                ["git", "-C", str(repo), "config", "user.name", "Launcher Test"],
+                check=True,
+            )
+            subprocess.run(
+                ["git", "-C", str(repo), "config", "user.email", "launcher@example.invalid"],
+                check=True,
+            )
+            (repo / "README.md").write_text("fixture\n", encoding="utf-8")
+            subprocess.run(["git", "-C", str(repo), "add", "README.md"], check=True)
+            subprocess.run(
+                ["git", "-C", str(repo), "commit", "-qm", "fixture"],
+                check=True,
+            )
+            subprocess.run(
+                [
+                    "git", "-C", str(repo), "worktree", "add", "-q",
+                    "-b", "feature/copilot-scope", str(linked), "HEAD",
+                ],
+                check=True,
+            )
+
+            argv = build_copilot_argv(
+                prompt="P",
+                slice_id="s",
+                log_dir=str(root / "logs"),
+                worktree=str(linked),
+                commit_required=True,
+            )
+
+            self.assertIn("--allow-all-tools", argv)
+            self.assertNotIn("--allow-all", argv)
+            add_dirs = [
+                argv[index + 1]
+                for index, value in enumerate(argv)
+                if value == "--add-dir"
+            ]
+            self.assertEqual(
+                add_dirs,
+                [
+                    str(linked.resolve()),
+                    str((repo / ".git" / "worktrees" / "linked").resolve()),
+                    str((repo / ".git" / "objects").resolve()),
+                    str((repo / ".git" / "refs" / "heads" / "feature").resolve()),
+                    str((repo / ".git" / "logs" / "refs" / "heads" / "feature").resolve()),
+                ],
+            )
+
+    def test_copilot_builder_commit_required_rejects_incompatible_modes(self) -> None:
+        for kwargs in (
+            {"read_only": True},
+            {"review_only": True},
+            {"allow_unsafe": True},
+        ):
+            with self.assertRaisesRegex(ValueError, "enforced workspace-write"):
+                build_copilot_argv(
+                    prompt="P",
+                    slice_id="s",
+                    log_dir="/lg",
+                    worktree="/wt/slice-a",
+                    commit_required=True,
+                    **kwargs,
+                )
+        with self.assertRaisesRegex(ValueError, "requires a worktree"):
+            build_copilot_argv(
+                prompt="P",
+                slice_id="s",
+                log_dir="/lg",
+                commit_required=True,
+            )
+
+    def test_copilot_builder_commit_required_false_preserves_existing_argv(self) -> None:
+        baseline = build_copilot_argv(
+            prompt="P",
+            slice_id="s",
+            log_dir="/lg",
+            worktree="/wt/slice-a",
+            model="claude-haiku-4.5",
+            allow_unsafe=True,
+        )
+        argv = build_copilot_argv(
+            prompt="P",
+            slice_id="s",
+            log_dir="/lg",
+            worktree="/wt/slice-a",
+            model="claude-haiku-4.5",
+            allow_unsafe=True,
+            commit_required=False,
+        )
+
+        self.assertEqual(argv, baseline)
 
     def test_claude_argv(self) -> None:
         argv = build_claude_argv(
@@ -582,6 +681,71 @@ class ArgvTests(unittest.TestCase):
             launcher_module.subprocess.Popen = original
         script = calls[0]["argv"][2]
         self.assertIn("--dangerously-bypass-approvals-and-sandbox", script)
+
+    def test_subprocess_launcher_copilot_commit_required_adds_scoped_permissions(self) -> None:
+        calls = []
+
+        class _FakeProc:
+            pid = 226
+
+        def _fake_popen(argv, *, cwd, env, stdout, stderr):
+            calls.append({"argv": argv})
+            return _FakeProc()
+
+        with tempfile.TemporaryDirectory() as d:
+            root = Path(d)
+            repo = root / "repo"
+            linked = root / "linked"
+            subprocess.run(["git", "init", "-q", str(repo)], check=True)
+            subprocess.run(
+                ["git", "-C", str(repo), "config", "user.name", "Launcher Test"],
+                check=True,
+            )
+            subprocess.run(
+                ["git", "-C", str(repo), "config", "user.email", "launcher@example.invalid"],
+                check=True,
+            )
+            (repo / "README.md").write_text("fixture\n", encoding="utf-8")
+            subprocess.run(["git", "-C", str(repo), "add", "README.md"], check=True)
+            subprocess.run(
+                ["git", "-C", str(repo), "commit", "-qm", "fixture"],
+                check=True,
+            )
+            subprocess.run(
+                [
+                    "git", "-C", str(repo), "worktree", "add", "-q",
+                    "-b", "feature/copilot-launch", str(linked), "HEAD",
+                ],
+                check=True,
+            )
+
+            git_write_dirs = launcher_module._linked_worktree_git_write_dirs(str(linked))
+            original = launcher_module.subprocess.Popen
+            launcher_module.subprocess.Popen = _fake_popen
+            try:
+                with mock.patch.object(
+                    launcher_module,
+                    "_linked_worktree_git_write_dirs",
+                    return_value=git_write_dirs,
+                ):
+                    SubprocessLauncher("copilot").as_commit_required().launch(
+                        slice_id="s",
+                        prompt="P",
+                        worktree=str(linked),
+                        log_dir=str(root / "lg"),
+                    )
+            finally:
+                launcher_module.subprocess.Popen = original
+
+            script = calls[0]["argv"][2]
+            inner_argv = shlex.split(script.split(";", 1)[0])
+            self.assertIn("--allow-all-tools", script)
+            self.assertIn(f"--add-dir {shlex.quote(str(linked.resolve()))}", script)
+            self.assertIn(
+                f"--add-dir {shlex.quote(git_write_dirs[0])}",
+                script,
+            )
+            self.assertNotIn("--allow-all", inner_argv)
 
     def test_prompt_is_single_element(self) -> None:
         # prompt 含換行也是單一 argv 元素（headless 的核心保證）


### PR DESCRIPTION
## 摘要
- `build_copilot_argv` 新增 `commit_required`：追加 `--allow-all-tools` + `--add-dir <worktree>` + linked worktree git write dirs（不用 `--allow-all`，寫入範圍限定）
- guard 比照 codex：與 read_only/review_only/allow_unsafe 互斥、必須有 worktree
- `SubprocessLauncher.launch` 對 codex 與 copilot 皆傳遞 `commit_required`
- TDD：argv 組合、互斥 guard、回歸保護、launch 傳遞層級測試

實作：copilot CLI（gpt-5.4）直接編排（dogfood commit-required 卡被本缺陷阻斷）；審查：Fable 5。

Closes #108

## 驗證
- [x] `python3 -m pytest tests/ -q`（1064 passed, 21 subtests passed）
- [x] `python3 -m policy_check --repo .`（0 fail）
- [x] `git diff --check`
- [x] fragment 與 `CHANGELOG.md [Unreleased]` 同步
- [x] `VERSION` 維持 0.0.0