### PR TITLE
fix(delivery): archive gate 不再把 R-22 advisory WARN 視為阻斷

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - **Porcelain CLI UX 規格與 v0.1.0 release plan**：凍結七家族（bootstrap/request/run/inspect/recover/service/init-sample）命令詞彙、exit code 契約、`--json` schema 穩定策略、request_id 顯性化 UX 與 TUI 邊界契約；並定義 v0.1.0 批次順序、release 程序（GitHub Release）、升級回滾與 KPI。
 
 ### Fixed
+- **archive gate 不再把 R-22 advisory WARN 視為阻斷**：`policy_check` 的 doc reference gate 現在只以 return code 判定，避免既有 diff-aware R-22 advisory WARN 讓所有 archive change 永遠卡在 `doc-reference-invalid`。
 - **Copilot commit-required 卡補 scoped 檔案/工具權限**：workflow builder 派工現在會在 commit-required 模式只開 `--allow-all-tools` 與必要的 linked worktree Git 寫入目錄，避免 headless Copilot 因無法互動授權而卡在 commit。
 - **malformed workflow build 卡改走可重試 recovery**：Manager 現在會把 malformed 的 passed terminal（含 build candidate 缺失）辨識為可重派卡片，避免 operator resume 永久卡死，並在 prompt 明示 build/plan candidate 的回報契約。
 - **canary 規劃產物補齊 completeness gate 要求**：openspec change 三件與 workstream Todo 補 `status: accepted` frontmatter 與各 kind 必要章節，`assess_planning_completeness` 全數通過。

--- a/changelog.d/112-archive-gate-warn.md
+++ b/changelog.d/112-archive-gate-warn.md
@@ -1,0 +1,2 @@
+### Fixed
+- **archive gate 不再把 R-22 advisory WARN 視為阻斷**：`policy_check` 的 doc reference gate 現在只以 return code 判定，避免既有 diff-aware R-22 advisory WARN 讓所有 archive change 永遠卡在 `doc-reference-invalid`。

--- a/paulsha_cortex/coordinator/work_actions.py
+++ b/paulsha_cortex/coordinator/work_actions.py
@@ -144,18 +144,10 @@ def _validate_local_archive_inputs(
         path.is_file() and not path.is_symlink() and path.read_text(encoding="utf-8").strip()
         for path in fragments
     )
-    policy_text = "\n".join(
-        str(getattr(policy, field, "")) for field in ("stdout", "stderr")
-    )
-    doc_reference_warning = bool(
-        re.search(r"(?i)(?:R-22.*WARN|WARN.*R-22|doc-reference.*WARN|WARN.*doc-reference)", policy_text)
-    )
     facts = ArchiveGateFacts(
         tasks_complete=bool(task_states) and all(state.lower() == "x" for state in task_states),
         canonical_specs_valid=getattr(canonical, "returncode", None) == 0,
-        doc_references_valid=(
-            getattr(policy, "returncode", None) == 0 and not doc_reference_warning
-        ),
+        doc_references_valid=getattr(policy, "returncode", None) == 0,
         changelog_present=(
             re.search(
                 rf"(?im)^\s*[-*]\s+.*(?<![a-z0-9-]){re.escape(change)}(?![a-z0-9-]).*$",

--- a/tests/test_work_actions.py
+++ b/tests/test_work_actions.py
@@ -2726,19 +2726,98 @@ def test_archive_and_pr_metadata_fail_closed_before_mutation(
     assert ["openspec", "archive", "-y", "demo"] not in calls
 
 
-@pytest.mark.parametrize(
-    ("changelog", "policy_stdout", "reason"),
-    [
-        ("## [Unreleased]\n- **other**: done\n", "", "changelog-missing"),
-        (
-            "## [Unreleased]\n- **demo**: done\n",
-            "WARN R-22 doc-reference stale link",
-            "doc-reference-invalid",
-        ),
-    ],
-)
-def test_archive_requires_change_specific_changelog_and_no_doc_reference_warning(
-    tmp_path: Path, changelog: str, policy_stdout: str, reason: str
+def test_archive_requires_change_specific_changelog(tmp_path: Path) -> None:
+    snapshot = _snapshot(tmp_path / "snapshot.json")
+    state = tmp_path / "runs.json"
+    work_actions.execute_work_action(
+        args={"action": "start", "repo": "acme/demo", "work_id": "demo"},
+        requested_by="operator",
+        snapshot_path=snapshot,
+        state_path=state,
+        now=lambda: 200,
+    )
+    change_dir = tmp_path / "openspec" / "changes" / "demo"
+    change_dir.mkdir(parents=True)
+    (change_dir / "tasks.md").write_text("- [x] complete\n", encoding="utf-8")
+    (tmp_path / "CHANGELOG.md").write_text(
+        "## [Unreleased]\n- **other**: done\n", encoding="utf-8"
+    )
+
+    def runner(argv, **kwargs):
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    with pytest.raises(RuntimeError, match="changelog-missing"):
+        work_actions.execute_work_action(
+            args={
+                "action": "ship",
+                "repo": "acme/demo",
+                "work_id": "demo",
+                "repo_root": str(tmp_path),
+                "pr_number": 8,
+                "change": "demo",
+                "todo_paths": ["docs/todo.md"],
+                "pr_metadata_path": str(_pr_metadata(tmp_path / "pr.json")),
+            },
+            requested_by="operator",
+            snapshot_path=snapshot,
+            state_path=state,
+            now=lambda: 200,
+            runner=runner,
+        )
+
+
+def test_archive_allows_advisory_r22_doc_reference_warning(tmp_path: Path) -> None:
+    snapshot = _snapshot(tmp_path / "snapshot.json")
+    state = tmp_path / "runs.json"
+    work_actions.execute_work_action(
+        args={"action": "start", "repo": "acme/demo", "work_id": "demo"},
+        requested_by="operator",
+        snapshot_path=snapshot,
+        state_path=state,
+        now=lambda: 200,
+    )
+    change_dir = tmp_path / "openspec" / "changes" / "demo"
+    change_dir.mkdir(parents=True)
+    (change_dir / "tasks.md").write_text("- [x] complete\n", encoding="utf-8")
+    (tmp_path / "CHANGELOG.md").write_text(
+        "## [Unreleased]\n- **demo**: done\n", encoding="utf-8"
+    )
+    calls = []
+
+    def runner(argv, **kwargs):
+        calls.append(argv)
+        if argv[:3] == ["python3", "-m", "policy_check"]:
+            return SimpleNamespace(
+                returncode=0,
+                stdout="WARN R-22 doc-reference stale link",
+                stderr="",
+            )
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    result = work_actions.execute_work_action(
+        args={
+            "action": "ship",
+            "repo": "acme/demo",
+            "work_id": "demo",
+            "repo_root": str(tmp_path),
+            "pr_number": 8,
+            "change": "demo",
+            "todo_paths": ["docs/todo.md"],
+            "pr_metadata_path": str(_pr_metadata(tmp_path / "pr.json")),
+        },
+        requested_by="operator",
+        snapshot_path=snapshot,
+        state_path=state,
+        now=lambda: 200,
+        runner=runner,
+    )
+
+    assert result["result"]["action"] == "archive-applied-needs-commit"
+    assert calls[-1] == ["openspec", "archive", "-y", "demo"]
+
+
+def test_archive_blocks_nonzero_policy_check_with_doc_reference_invalid(
+    tmp_path: Path,
 ) -> None:
     snapshot = _snapshot(tmp_path / "snapshot.json")
     state = tmp_path / "runs.json"
@@ -2752,13 +2831,20 @@ def test_archive_requires_change_specific_changelog_and_no_doc_reference_warning
     change_dir = tmp_path / "openspec" / "changes" / "demo"
     change_dir.mkdir(parents=True)
     (change_dir / "tasks.md").write_text("- [x] complete\n", encoding="utf-8")
-    (tmp_path / "CHANGELOG.md").write_text(changelog, encoding="utf-8")
+    (tmp_path / "CHANGELOG.md").write_text(
+        "## [Unreleased]\n- **demo**: done\n", encoding="utf-8"
+    )
 
     def runner(argv, **kwargs):
-        stdout = policy_stdout if argv[:3] == ["python3", "-m", "policy_check"] else ""
-        return SimpleNamespace(returncode=0, stdout=stdout, stderr="")
+        if argv[:3] == ["python3", "-m", "policy_check"]:
+            return SimpleNamespace(
+                returncode=1,
+                stdout="WARN R-22 doc-reference stale link",
+                stderr="",
+            )
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
 
-    with pytest.raises(RuntimeError, match=reason):
+    with pytest.raises(RuntimeError, match="doc-reference-invalid"):
         work_actions.execute_work_action(
             args={
                 "action": "ship",


### PR DESCRIPTION
## 摘要
- `_validate_local_archive_inputs` 移除 R-22 WARN regex 分支，`doc_references_valid` 僅以 `policy_check` returncode 判定
- policy 1.0.12 的 R-22 為 diff-aware：新懸空 FAIL（已反映於 returncode）、陳年懸空 advisory WARN 明文不擋；gate 原行為使含任何陳年 WARN 的 repo 之 archive 閉環永遠 blocked
- 測試：WARN 字樣 + returncode 0 不得回 doc-reference-invalid；returncode 非 0 仍阻斷

實作：copilot CLI（gpt-5.4）直接編排；審查：Fable 5。

Closes #112

## 驗證
- [x] `python3 -m pytest tests/ -q`（1065 passed, 21 subtests passed）
- [x] `python3 -m policy_check --repo .`（0 fail）
- [x] `git diff --check`
- [x] fragment 與 `CHANGELOG.md [Unreleased]` 同步
- [x] `VERSION` 維持 0.0.0