### PR TITLE
docs(canary): main 側交付閉環要件

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ## [Unreleased]
 
 ### Added
+- **`cortex --version` 頂層旗標（add-cortex-version-flag）**：輸出安裝套件版本（importlib.metadata + fallback），exit 0；dogfood canary 首個實機交付批次。
 - **canary follow-ups workstream todo**：記錄 dogfood canary 實跑發現的後續事項，並作為 work authority 的新增 confirmed 來源。
 - **dogfood canary 規劃產物（add-cortex-version-flag）**：為 `cortex --version` canary 批次建立 confirmed Work Item 綁定、accepted 規劃四件套與 active OpenSpec change（`cli-version-reporting`），供 coordinator dogfood 派工消費。
 - **Porcelain CLI UX 規格與 v0.1.0 release plan**：凍結七家族（bootstrap/request/run/inspect/recover/service/init-sample）命令詞彙、exit code 契約、`--json` schema 穩定策略、request_id 顯性化 UX 與 TUI 邊界契約；並定義 v0.1.0 批次順序、release 程序（GitHub Release）、升級回滾與 KPI。

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ python -m pip install .
 6. 日常查詢：
 
    ```bash
+   cortex --version
    cortex status | jq
    cortex jobs
    cortex stat "$JOB_ID"

--- a/changelog.d/add-cortex-version-flag.md
+++ b/changelog.d/add-cortex-version-flag.md
@@ -1,0 +1,3 @@
+### Added
+
+- **`cortex --version` 頂層旗標**：輸出安裝套件版本（importlib.metadata，PackageNotFoundError fallback `0.0.0+unknown`），exit 0；含單元測試。dogfood canary（deck→tick→copilot build→claude review→自動交付）首個實機交付批次。

--- a/openspec/changes/add-cortex-version-flag/tasks.md
+++ b/openspec/changes/add-cortex-version-flag/tasks.md
@@ -5,7 +5,7 @@ work_item: add-cortex-version-flag
 
 # Tasks
 
-- [ ] 1.1 新增 `tests/test_cli_version.py`，確認現況 RED。
-- [ ] 1.2 `paulsha_cortex/cli.py` 頂層 `--version` 實作（importlib.metadata + fallback），測試轉 GREEN。
-- [ ] 1.3 README CLI 段落補 `--version`；`changelog.d/86-cortex-version-flag.md` 與 `CHANGELOG.md [Unreleased]` 同步。
-- [ ] 1.4 `pytest` 全綠、`policy_check` 0 fail、`git diff --check` 乾淨。
+- [x] 1.1 新增 `tests/test_cli_version.py`，確認現況 RED。
+- [x] 1.2 `paulsha_cortex/cli.py` 頂層 `--version` 實作（importlib.metadata + fallback），測試轉 GREEN。
+- [x] 1.3 README CLI 段落補 `--version`；`changelog.d/86-cortex-version-flag.md` 與 `CHANGELOG.md [Unreleased]` 同步。
+- [x] 1.4 `pytest` 全綠、`policy_check` 0 fail、`git diff --check` 乾淨。


### PR DESCRIPTION
## 摘要
- archive gate 以 main checkout 為準：tasks.md 全勾、change-named fragment（`changelog.d/add-cortex-version-flag.md`）、CHANGELOG [Unreleased] 條目、README 日常查詢補 `--version`（R-16）
- 候選分支已退回 builder exact HEAD（exact-candidate push 授權要求候選純度；完成件依 gate 設計放 main — body 不引用 issue 編號以維持 R-17 not-applicable）

## 驗證
- [x] `python3 -m policy_check --repo .`（0 fail）
- [x] `git diff --check`
- [x] fragment 與 `CHANGELOG.md [Unreleased]` 同步
- [x] `VERSION` 維持 0.0.0