### PR TITLE
docs(canary): changelog 交付權還給候選批次

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@
 ## [Unreleased]
 
 ### Added
-- **`cortex --version` 頂層旗標（add-cortex-version-flag）**：輸出安裝套件版本（importlib.metadata + fallback），exit 0；dogfood canary 首個實機交付批次。
 - **canary follow-ups workstream todo**：記錄 dogfood canary 實跑發現的後續事項，並作為 work authority 的新增 confirmed 來源。
 - **dogfood canary 規劃產物（add-cortex-version-flag）**：為 `cortex --version` canary 批次建立 confirmed Work Item 綁定、accepted 規劃四件套與 active OpenSpec change（`cli-version-reporting`），供 coordinator dogfood 派工消費。
 - **Porcelain CLI UX 規格與 v0.1.0 release plan**：凍結七家族（bootstrap/request/run/inspect/recover/service/init-sample）命令詞彙、exit code 契約、`--json` schema 穩定策略、request_id 顯性化 UX 與 TUI 邊界契約；並定義 v0.1.0 批次順序、release 程序（GitHub Release）、升級回滾與 KPI。

--- a/changelog.d/add-cortex-version-flag.md
+++ b/changelog.d/add-cortex-version-flag.md
@@ -1,3 +1,0 @@
-### Added
-
-- **`cortex --version` 頂層旗標**：輸出安裝套件版本（importlib.metadata，PackageNotFoundError fallback `0.0.0+unknown`），exit 0；含單元測試。dogfood canary（deck→tick→copilot build→claude review→自動交付）首個實機交付批次。


### PR DESCRIPTION
## 摘要
- 撤回 main 上預放的 change-named fragment 與 CHANGELOG [Unreleased] 條目
- production ship 的 archive gate 在 pristine 候選樹評估：候選將由 retry-build（builder 依 plan 1.3）補齊自己的 fragment/CHANGELOG/tasks，避免與 main 重複造成 merge 衝突；R-09 本意即 fragment 隨 feature PR（body 不引用 issue 編號以維持 R-17 not-applicable）
- tasks.md 勾選與 README 保留於 main（候選側同內容變更可 clean merge）

## 驗證
- [x] `python3 -m policy_check --repo .`（0 fail）
- [x] `git diff --check`
- [x] 本 PR 為 canary 交付編排的 docs 調整（`skip-changelog` 不適用：仍動 code_paths，惟內容即 changelog 本身的撤回）
- [x] `VERSION` 維持 0.0.0