### PR TITLE
fix(workflow): builder 可交付 archive gate 要件（write_paths + prompt 指示）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - **Porcelain CLI UX 規格與 v0.1.0 release plan**：凍結七家族（bootstrap/request/run/inspect/recover/service/init-sample）命令詞彙、exit code 契約、`--json` schema 穩定策略、request_id 顯性化 UX 與 TUI 邊界契約；並定義 v0.1.0 批次順序、release 程序（GitHub Release）、升級回滾與 KPI。
 
 ### Fixed
+- **builder archive gate 交付路徑與 tasks 勾選指示補齊**：builder persona 現在可寫 active OpenSpec、changelog、CHANGELOG 與 superpowers plan 路徑，commit-required workflow prompt 也會明示更新對應 `tasks.md` 勾選且不得改動 pinned input。
 - **archive gate 不再把 R-22 advisory WARN 視為阻斷**：`policy_check` 的 doc reference gate 現在只以 return code 判定，避免既有 diff-aware R-22 advisory WARN 讓所有 archive change 永遠卡在 `doc-reference-invalid`。
 - **Copilot commit-required 卡補 scoped 檔案/工具權限**：workflow builder 派工現在會在 commit-required 模式只開 `--allow-all-tools` 與必要的 linked worktree Git 寫入目錄，避免 headless Copilot 因無法互動授權而卡在 commit。
 - **malformed workflow build 卡改走可重試 recovery**：Manager 現在會把 malformed 的 passed terminal（含 build candidate 缺失）辨識為可重派卡片，避免 operator resume 永久卡死，並在 prompt 明示 build/plan candidate 的回報契約。

--- a/changelog.d/116-builder-deliverables.md
+++ b/changelog.d/116-builder-deliverables.md
@@ -1,0 +1,2 @@
+### Fixed
+- builder write_paths 補齊 archive gate 要件路徑，並讓 commit-required workflow prompt 明示勾選對應 `tasks.md`。

--- a/paulsha_cortex/coordinator/manager.py
+++ b/paulsha_cortex/coordinator/manager.py
@@ -4998,10 +4998,18 @@ def _workflow_job_prompt(
         "test_policy": step.test_policy or fallback[3],
         "terminal_schema": terminal_schema,
     }
+    if run.openspec_refs:
+        contract["openspec_ref"] = run.openspec_refs[0]
     if builder_job_id is not None:
         contract["builder_job_id"] = builder_job_id
     if candidate_checkout is not None:
         contract["candidate_checkout"] = candidate_checkout
+    effective_commit_policy = step.commit_policy or fallback[2]
+    tasks_path = (
+        f"openspec/changes/{contract['openspec_ref']}/tasks.md"
+        if isinstance(contract.get("openspec_ref"), str)
+        else "openspec/changes/<change>/tasks.md"
+    )
     planner_contract = (
         " This planner card is read-only: use the disposable checkout only, do not edit files, and "
         "return only existing manifest-declared artifacts."
@@ -5017,6 +5025,12 @@ def _workflow_job_prompt(
         if step.persona == "reviewer"
         else ""
     )
+    commit_required_contract = (
+        f" Before the final commit, update {tasks_path} checkboxes for work completed by this card, "
+        "and never modify pinned input files such as the plan document."
+        if effective_commit_policy == "required"
+        else ""
+    )
     return (
         "Execute exactly one workflow card. End with one JSON object only; do not supply an evidence "
         "path or hash because Manager will canonicalize it. For workflow-card outputs, return only "
@@ -5028,6 +5042,7 @@ def _workflow_job_prompt(
         "null."
         + planner_contract
         + reviewer_contract
+        + commit_required_contract
         + " Contract: "
         + json.dumps(contract, ensure_ascii=False, sort_keys=True)
     )

--- a/paulsha_cortex/persona/personas.yaml
+++ b/paulsha_cortex/persona/personas.yaml
@@ -22,7 +22,7 @@ roles:
     version: "2.0.0"
     summary: implements approved build slices within bounded scope (copilot first, fixers after)
     allowed_phases: [build]
-    write_paths: ["paulsha_cortex/**", "tests/**", "openspec/changes/archive/**"]
+    write_paths: ["paulsha_cortex/**", "tests/**", "openspec/changes/archive/**", "openspec/changes/**", "changelog.d/**", "CHANGELOG.md", "docs/superpowers/plans/**"]
     allowed_tools: ["python -m unittest", "rg", "edit", "git add", "git commit"]
     skills: [worktree-isolation, tdd-red, subagent-build]
   reviewer:

--- a/tests/test_coordinator_manager.py
+++ b/tests/test_coordinator_manager.py
@@ -13,6 +13,7 @@ from unittest import mock
 from paulsha_cortex.coordinator import manager
 from paulsha_cortex.coordinator.autonomy import dispatch_ready
 from paulsha_cortex.coordinator.registry import JobRegistry
+from paulsha_cortex.coordinator.workflow import WorkflowStep
 
 
 class FakeDispatcher:
@@ -225,6 +226,103 @@ class CompleteTickDoneTests(unittest.TestCase):
             self.assertEqual(summary["completed"], [{"slice_id": "slice-a", "gate_status": "needs_human"}])
             self.assertFalse(manager.autonomy.default_is_satisfied("slice-a", handoff_dir=str(hdir)))
             self.assertEqual(summary["errors"], [])
+
+
+class WorkflowJobPromptTests(unittest.TestCase):
+    def _run(self, *, openspec_refs: tuple[str, ...] = ("issue-116",)) -> SimpleNamespace:
+        return SimpleNamespace(
+            run_id="run-1",
+            work_id="work-1",
+            repo="owner/repo",
+            source_revision="a" * 40,
+            candidate_head=None,
+            openspec_refs=openspec_refs,
+        )
+
+    def test_commit_required_build_card_prompt_includes_tasks_guidance(self) -> None:
+        step = WorkflowStep(
+            phase="build",
+            persona="builder",
+            card="subagent-build",
+            executor=None,
+            model=None,
+            domain=None,
+            inputs=(),
+            outputs=(),
+        )
+
+        prompt = manager._workflow_job_prompt(
+            self._run(),
+            step,
+            builder_job_id="job-1",
+            coordinator_root="/tmp/coordinator",
+        )
+
+        self.assertIn("openspec/changes/issue-116/tasks.md checkboxes", prompt)
+        self.assertIn("never modify pinned input files such as the plan document", prompt)
+
+    def test_commit_required_build_card_without_openspec_ref_uses_generic_tasks_path(self) -> None:
+        step = WorkflowStep(
+            phase="build",
+            persona="builder",
+            card="tdd-red",
+            executor=None,
+            model=None,
+            domain=None,
+            inputs=(),
+            outputs=(),
+        )
+
+        prompt = manager._workflow_job_prompt(
+            self._run(openspec_refs=()),
+            step,
+            builder_job_id="job-1",
+            coordinator_root="/tmp/coordinator",
+        )
+
+        self.assertIn("openspec/changes/<change>/tasks.md checkboxes", prompt)
+        self.assertIn("never modify pinned input files such as the plan document", prompt)
+
+    def test_non_commit_required_cards_do_not_include_tasks_guidance(self) -> None:
+        worktree_step = WorkflowStep(
+            phase="build",
+            persona="builder",
+            card="worktree-isolation",
+            executor=None,
+            model=None,
+            domain=None,
+            inputs=(),
+            outputs=(),
+        )
+        verification_step = WorkflowStep(
+            phase="verify",
+            persona="reviewer",
+            card="verification",
+            executor=None,
+            model=None,
+            domain=None,
+            inputs=(),
+            outputs=("reports/verify/work-1.md",),
+        )
+
+        worktree_prompt = manager._workflow_job_prompt(
+            self._run(),
+            worktree_step,
+            builder_job_id=None,
+            coordinator_root="/tmp/coordinator",
+        )
+        verification_prompt = manager._workflow_job_prompt(
+            self._run(),
+            verification_step,
+            builder_job_id="job-1",
+            coordinator_root="/tmp/coordinator",
+            candidate_checkout="candidate",
+        )
+
+        self.assertNotIn("tasks.md checkboxes", worktree_prompt)
+        self.assertNotIn("never modify pinned input files", worktree_prompt)
+        self.assertNotIn("tasks.md checkboxes", verification_prompt)
+        self.assertNotIn("never modify pinned input files", verification_prompt)
 
 
 class CompleteTickFailedAndInFlightTests(unittest.TestCase):

--- a/tests/test_persona_config_loader.py
+++ b/tests/test_persona_config_loader.py
@@ -55,8 +55,16 @@ class LoadCatalogTests(unittest.TestCase):
 
     def test_contract_catalog_sourced_from_yaml(self) -> None:
         self.assertEqual(
-            set(contract.PERSONA_CATALOG["builder"].write_paths),
-            {"paulsha_cortex/**", "tests/**", "openspec/changes/archive/**"},
+            list(contract.PERSONA_CATALOG["builder"].write_paths),
+            [
+                "paulsha_cortex/**",
+                "tests/**",
+                "openspec/changes/archive/**",
+                "openspec/changes/**",
+                "changelog.d/**",
+                "CHANGELOG.md",
+                "docs/superpowers/plans/**",
+            ],
         )
 
     def test_malformed_yaml_fails_closed(self) -> None:
@@ -86,6 +94,12 @@ class RoleV2ScopeTests(unittest.TestCase):
     def test_builder_archive_yes_push_no_commit_yes(self) -> None:
         self.assertTrue(
             self.rail.evaluate_filesystem(role="builder", path="openspec/changes/archive/x/spec.md").allowed
+        )
+        self.assertTrue(
+            self.rail.evaluate_filesystem(role="builder", path="openspec/changes/x/tasks.md").allowed
+        )
+        self.assertTrue(
+            self.rail.evaluate_filesystem(role="builder", path="changelog.d/116-builder-deliverables.md").allowed
         )
         self.assertFalse(self.rail.evaluate_tool(role="builder", tool="git push").allowed)
         self.assertTrue(self.rail.evaluate_tool(role="builder", tool="git commit").allowed)


### PR DESCRIPTION
## 摘要
- `personas.yaml` builder write_paths 補 `openspec/changes/**`、`changelog.d/**`、`CHANGELOG.md`、`docs/superpowers/plans/**`（把 shadow 實態入約）
- `_workflow_job_prompt`：commit-required 卡尾句指示「final commit 前勾選 openspec/changes/<change>/tasks.md、勿改 pinned input（plan）」，路徑以 run.openspec_refs 具體化
- 解 F26–F28 設計矛盾三角：archive gate 讀候選樹的要件（tasks 全勾/fragment）從此可由 builder 合約內交付

實作：copilot CLI（gpt-5.4）直接編排；審查：Fable 5。

Closes #116

## 驗證
- [x] `python3 -m pytest tests/ -q`（1068 passed, 21 subtests passed）
- [x] `python3 -m policy_check --repo .`（0 fail）
- [x] `git diff --check`
- [x] fragment 與 `CHANGELOG.md [Unreleased]` 同步
- [x] `VERSION` 維持 0.0.0