### PR TITLE
docs(porcelain): B1 porcelain-skeleton 規劃產物

### DIFF
--- a/.cortex/work-items.yaml
+++ b/.cortex/work-items.yaml
@@ -25,6 +25,15 @@ work_items:
         ref: hamanpaul/paulsha-cortex#27
       - kind: openspec
         ref: docs-only-lifecycle-canary-v2
+  porcelain-skeleton:
+    title: porcelain routing skeleton (B1)
+    links:
+      - kind: github_issue
+        ref: hamanpaul/paulsha-cortex#87
+      - kind: openspec
+        ref: porcelain-skeleton
+      - kind: path
+        ref: docs/superpowers/workstreams/porcelain-skeleton/todo.md
   add-cortex-version-flag:
     title: cortex --version flag (porcelain dogfood canary)
     links:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ## [Unreleased]
 
 ### Added
+- **B1 porcelain-skeleton 規劃產物**：路由骨架批次的 Work Item 綁定、規劃四件套與 OpenSpec change。
 - **cortex CLI 版本輸出**：新增頂層 `cortex --version`，輸出已安裝套件版本；若無 package metadata 則回退為 `0.0.0+unknown`。
 - **canary follow-ups workstream todo**：記錄 dogfood canary 實跑發現的後續事項，並作為 work authority 的新增 confirmed 來源。
 - **dogfood canary 規劃產物（add-cortex-version-flag）**：為 `cortex --version` canary 批次建立 confirmed Work Item 綁定、accepted 規劃四件套與 active OpenSpec change（`cli-version-reporting`），供 coordinator dogfood 派工消費。

--- a/changelog.d/87-porcelain-skeleton-planning.md
+++ b/changelog.d/87-porcelain-skeleton-planning.md
@@ -1,0 +1,3 @@
+### Added
+
+- **B1 porcelain-skeleton 規劃產物**：建立 porcelain 路由骨架批次的 confirmed Work Item 綁定、accepted 規劃四件套與 active OpenSpec change（`porcelain-command-registry` capability），供 coordinator dogfood 派工消費。

--- a/docs/superpowers/plans/porcelain-skeleton.md
+++ b/docs/superpowers/plans/porcelain-skeleton.md
@@ -1,0 +1,23 @@
+---
+status: accepted
+work_item: porcelain-skeleton
+---
+
+# porcelain-skeleton Plan
+
+## Tasks
+
+### 1. TDD RED
+
+- [ ] 新增 `tests/test_porcelain_registry.py` 與 `tests/test_cli_porcelain_routing.py`：註冊表契約（register/重名 raise/load_commands 冪等）、fake command 路由與退出碼、`--help` 含 `--version`、空註冊表不出現 porcelain 區段；先確認 RED。
+
+### 2. 實作
+
+- [ ] `paulsha_cortex/porcelain/__init__.py`：`PorcelainCommand` dataclass、`COMMANDS`、`register()`、`load_commands()`（`_FAMILY_MODULES` 空 tuple）。
+- [ ] `paulsha_cortex/cli.py`：`_USAGE`/`_HELP` 補 `--version` 行；`--help` 分支動態附加非空 porcelain 區段；coordinator 透傳前查 `COMMANDS` 分派。
+
+### 3. 同步與驗證
+
+- [ ] 新增 `changelog.d/porcelain-skeleton.md` fragment，並在 `CHANGELOG.md [Unreleased]` `### Added` 加入含 `porcelain-skeleton` 字樣的條目。
+- [ ] `python3 -m pytest tests/ -q` 全綠（含 `test_zero_dependency_runtime`）；`python3 -m policy_check --repo .` 0 fail；`git diff --check` 乾淨。
+- [ ] 完成後勾選 `openspec/changes/porcelain-skeleton/tasks.md` 的對應項並以 conventional commit 提交（不得改動本 plan 檔）。

--- a/docs/superpowers/specs/porcelain-skeleton-design.md
+++ b/docs/superpowers/specs/porcelain-skeleton-design.md
@@ -1,0 +1,28 @@
+---
+status: accepted
+work_item: porcelain-skeleton
+---
+
+# porcelain-skeleton Design
+
+## Goals
+
+讓 B2+ 七家族各自以獨立模組登記命令、互不修改共享路由檔，消除序列批次對 `cli.py` 的反覆衝突；同時把 `--version` 補進 usage/help（#120）。
+
+## Decisions
+
+### 註冊表形狀
+
+`paulsha_cortex/porcelain/__init__.py`：`PorcelainCommand`（frozen dataclass：`name`、`summary`、`run: Callable[[list[str]], int]`）、模組層 `COMMANDS: dict[str, PorcelainCommand]`、`register(command)`（重名 raise ValueError）、`load_commands()`（依 `_FAMILY_MODULES` tuple 匯入家族模組使其自行 register；B1 為空 tuple）。
+
+### 路由位置
+
+`cli.py` 的 `main()`：在 `doctor` 分派之後、coordinator 透傳之前呼叫 `porcelain.load_commands()` 並查 `COMMANDS`；命中則 `return command.run(args[1:])`。lazy import porcelain 模組以維持啟動成本。
+
+### Help 組裝
+
+`_USAGE` 與 `_HELP` 靜態字串補 `--version` 一行；`--help` 分支在輸出 `_HELP` 前，若 `COMMANDS` 非空則附加「porcelain commands:」區段（name + summary 對齊排版）。B1 註冊表為空 → 輸出與現行加 `--version` 行後完全一致。
+
+### 測試策略
+
+新檔 `tests/test_porcelain_registry.py`：register/重名 raise/`load_commands` 冪等；`tests/test_cli_porcelain_routing.py`：注入 fake command 後 `main(["fake", ...])` 分派與退出碼透傳、未註冊名稱透傳 coordinator 行為不變、`--help` 含 `--version` 且空註冊表無 porcelain 區段。

--- a/docs/superpowers/specs/porcelain-skeleton-spec.md
+++ b/docs/superpowers/specs/porcelain-skeleton-spec.md
@@ -1,0 +1,26 @@
+---
+status: accepted
+work_item: porcelain-skeleton
+---
+
+# porcelain-skeleton Specification
+
+porcelain 計畫（epic #84）B1：為七家族建立可外掛的路由骨架，並承接 #120 的 help 可發現性缺口。範圍以 `docs/superpowers/specs/2026-07-21-porcelain-cli-ux-design.md` 為準。
+
+## Requirements
+
+### Porcelain 命令註冊表
+
+`paulsha_cortex/porcelain/` SHALL 提供命令註冊表：每個家族以（名稱、單行說明、`run(argv) -> int` 進入點）登記；名稱重複 MUST 立即失敗。B1 的正式註冊清單 SHALL 為空（家族由 B2+ 各自登記）。
+
+### 頂層路由整合
+
+`cortex <name>` 於 `paulsha_cortex/cli.py` SHALL 在既有命令之後、coordinator 透傳之前查詢註冊表並分派；未註冊名稱的行為 MUST 與現行完全一致（透傳 coordinator）。既有命令（install/deck/monitor/list/work/doctor/relay-hook 與 coordinator 面）行為 MUST 不變。
+
+### Help 可發現性（承接 #120）
+
+`cortex --help` 與 `_USAGE` SHALL 列出 `--version`；註冊表非空時 `cortex --help` SHALL 動態附加 porcelain commands 區段（B1 為空時不出現該區段）。
+
+### 限制
+
+stdlib-only；`test_zero_dependency_runtime` MUST 續綠；新增單元測試（先 RED 後 GREEN）覆蓋註冊表契約、路由分派與 help 文案。

--- a/docs/superpowers/workstreams/porcelain-skeleton/todo.md
+++ b/docs/superpowers/workstreams/porcelain-skeleton/todo.md
@@ -1,0 +1,13 @@
+---
+status: accepted
+work_item: porcelain-skeleton
+---
+
+# porcelain-skeleton Todo
+
+## Tasks
+
+- [ ] 將 issue #87、active OpenSpec change 與本 Todo 綁定為同一 confirmed Work Item。
+- [ ] coordinator 派工 copilot（gpt-5.4）完成註冊表 + 路由 + help 補列（TDD）。
+- [ ] ForeignReview（claude/sonnet）、自動 push/PR、bot review、merge 與 archive 閉合。
+- [ ] pipx 重裝後 `cortex --help` 顯示 `--version`、七家族骨架可供 B2+ 登記。

--- a/openspec/changes/porcelain-skeleton/.openspec.yaml
+++ b/openspec/changes/porcelain-skeleton/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-21

--- a/openspec/changes/porcelain-skeleton/design.md
+++ b/openspec/changes/porcelain-skeleton/design.md
@@ -1,0 +1,13 @@
+---
+status: accepted
+work_item: porcelain-skeleton
+---
+
+# Design
+
+## Decisions
+
+- **註冊表下放**：家族模組於 import 時 `register()`；`load_commands()` 依 `_FAMILY_MODULES` 清單匯入（B1 空 tuple），B2+ 每家族只改自己模組與清單一行。
+- **路由插點**：`main()` 在既有命令分派之後、coordinator 透傳之前查 `COMMANDS`——未註冊名稱行為與現行完全一致（fail-open 到 coordinator）。
+- **help 動態區段**：靜態 `_HELP` 保持可讀，porcelain 區段僅於非空時附加；`--version` 進靜態字串（#120）。
+- **重名 fail-fast**：`register()` 對重複名稱 raise，防兩家族搶同名。

--- a/openspec/changes/porcelain-skeleton/proposal.md
+++ b/openspec/changes/porcelain-skeleton/proposal.md
@@ -1,0 +1,25 @@
+---
+status: accepted
+work_item: porcelain-skeleton
+---
+
+## Goals
+
+建立 porcelain 七家族的可外掛路由骨架（B1），消除後續批次對共享路由檔的衝突，並承接 #120 的 `--version` help 可發現性。
+
+## Why
+
+porcelain 計畫（epic #84）B2–B7 六個家族批次都要在 `cortex` CLI 掛新命令；若各批次直接改 `cli.py` 的 if-chain 與靜態 help，序列衝突與 R-16 同步負擔會隨批次數放大。B1 以註冊表把「登記」下放給家族模組，路由與 help 一次外掛化。
+
+## What Changes
+
+- 新增 `paulsha_cortex/porcelain/`（`PorcelainCommand`、`COMMANDS`、`register`、`load_commands`；B1 家族清單為空）。
+- `paulsha_cortex/cli.py`：coordinator 透傳前查註冊表分派；`_USAGE`/`_HELP` 補 `--version`；`--help` 動態附加非空 porcelain 區段。
+- 新增註冊表與路由單元測試（TDD）。
+- 不改任何既有命令行為；stdlib-only。
+
+## Capabilities
+
+### New Capabilities
+
+- `porcelain-command-registry`: porcelain 命令的登記與頂層路由契約——家族模組自行 register，`cli.py` 統一分派與 help 呈現。

--- a/openspec/changes/porcelain-skeleton/specs/porcelain-command-registry/spec.md
+++ b/openspec/changes/porcelain-skeleton/specs/porcelain-command-registry/spec.md
@@ -1,0 +1,24 @@
+## ADDED Requirements
+
+### Requirement: porcelain 命令必須經註冊表登記與分派
+
+porcelain 家族命令 MUST 以（名稱、單行說明、`run(argv) -> int`）登記於 `paulsha_cortex/porcelain` 註冊表；`cortex <name>` MUST 由頂層路由查表分派並透傳退出碼；重複名稱 MUST 於登記時立即失敗。
+
+#### Scenario: 已登記命令分派
+
+- **WHEN** 家族模組已 register `fake` 且使用者執行 `cortex fake --x`
+- **THEN** 註冊表的 `run(["--x"])` 被呼叫且其回傳值成為行程退出碼
+
+#### Scenario: 未登記名稱維持現行為
+
+- **WHEN** 使用者執行未登記的 `cortex status`
+- **THEN** 行為與導入註冊表前完全一致（透傳 coordinator）
+
+### Requirement: help 必須呈現 --version 與非空 porcelain 區段
+
+`cortex --help` 與 usage MUST 列出 `--version`；註冊表非空時 MUST 動態附加 porcelain commands 區段，為空時 MUST 不出現該區段。
+
+#### Scenario: 空註冊表
+
+- **WHEN** B1 狀態（無家族登記）下執行 `cortex --help`
+- **THEN** 輸出含 `--version` 行且不含 porcelain 區段

--- a/openspec/changes/porcelain-skeleton/tasks.md
+++ b/openspec/changes/porcelain-skeleton/tasks.md
@@ -1,0 +1,12 @@
+---
+status: accepted
+work_item: porcelain-skeleton
+---
+
+# Tasks
+
+- [ ] 1.1 RED：註冊表契約與路由/help 測試（`tests/test_porcelain_registry.py`、`tests/test_cli_porcelain_routing.py`）。
+- [ ] 1.2 `paulsha_cortex/porcelain/__init__.py` 註冊表實作。
+- [ ] 1.3 `cli.py` 路由整合 + `_USAGE`/`_HELP` 補 `--version` + 動態 porcelain 區段。
+- [ ] 1.4 `changelog.d/porcelain-skeleton.md` 與 `CHANGELOG.md [Unreleased]` 同步（條目含 porcelain-skeleton 字樣）。
+- [ ] 1.5 pytest 全綠、policy_check 0 fail、`git diff --check` 乾淨。


### PR DESCRIPTION
## 摘要
- B1（路由骨架）dogfood 批次的規劃六件套：Work Item 綁定（work-items.yaml + workstream todo）、accepted spec/design/plan、OpenSpec change `porcelain-skeleton`（`porcelain-command-registry` capability）
- 範圍依 B0 UX 規格 §8：`paulsha_cortex/porcelain/` 註冊表 + cli.py 路由外掛化 + help 補 `--version`（承接既開的 help 可發現性 issue，實作 PR 才關）
- `assess_planning_completeness` 離線 7/7 PASS；planning PR 不動 runtime code（body 不引用 issue 編號以維持 R-17 not-applicable）

## 驗證
- [x] `assess_planning_completeness` 7/7 PASS、complete=True
- [x] `openspec validate --all --strict`（8 passed）
- [x] `python3 -m policy_check --repo .`（0 fail）
- [x] `git diff --check`
- [x] fragment 與 `CHANGELOG.md [Unreleased]` 同步
- [x] `VERSION` 維持 0.0.0