### PR TITLE
fix(coordinator): model identities 合併改 custom 優先

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - **Porcelain CLI UX 規格與 v0.1.0 release plan**：凍結七家族（bootstrap/request/run/inspect/recover/service/init-sample）命令詞彙、exit code 契約、`--json` schema 穩定策略、request_id 顯性化 UX 與 TUI 邊界契約；並定義 v0.1.0 批次順序、release 程序（GitHub Release）、升級回滾與 KPI。
 
 ### Fixed
+- **model identities custom 優先 packaged 預設**：`load_model_identities()` 合併 packaged 與 custom registry 時改為先放 custom 條目，避免本機不可用的 agy 永遠搶先 operator 在 custom 設定的 planner 而卡在重派迴圈。
 - **builder archive gate 交付路徑與 tasks 勾選指示補齊**：builder persona 現在可寫 active OpenSpec、changelog、CHANGELOG 與 superpowers plan 路徑，commit-required workflow prompt 也會明示更新對應 `tasks.md` 勾選且不得改動 pinned input。
 - **archive gate 不再把 R-22 advisory WARN 視為阻斷**：`policy_check` 的 doc reference gate 現在只以 return code 判定，避免既有 diff-aware R-22 advisory WARN 讓所有 archive change 永遠卡在 `doc-reference-invalid`。
 - **Copilot commit-required 卡補 scoped 檔案/工具權限**：workflow builder 派工現在會在 commit-required 模式只開 `--allow-all-tools` 與必要的 linked worktree Git 寫入目錄，避免 headless Copilot 因無法互動授權而卡在 commit。

--- a/changelog.d/123-custom-first-identities.md
+++ b/changelog.d/123-custom-first-identities.md
@@ -1,0 +1,2 @@
+### Fixed
+- model identities 合併改為 custom 條目優先於 packaged 預設，避免本機不可用的 agy 永遠搶先 custom planner 造成重派迴圈。

--- a/paulsha_cortex/coordinator/model_identities.py
+++ b/paulsha_cortex/coordinator/model_identities.py
@@ -252,7 +252,7 @@ def load_model_identities(
         additions.append(identity)
     return IdentityRegistry(
         schema_version=MODEL_IDENTITY_SCHEMA_VERSION,
-        identities=packaged.identities + tuple(additions),
+        identities=tuple(additions) + packaged.identities,
     )
 
 

--- a/tests/test_model_identities.py
+++ b/tests/test_model_identities.py
@@ -51,6 +51,44 @@ identities:
     assert registry.require("codex", "gpt-primary").independence_domain == "openai"
 
 
+def test_packaged_default_puts_custom_identities_before_packaged_defaults(tmp_path: Path) -> None:
+    (tmp_path / "model-identities.yaml").write_text(
+        """\
+schema_version: 2
+identities:
+  - executor: claude
+    model_id: planner
+    independence_domain: anthropic
+    capabilities: [planning, review]
+  - executor: copilot
+    model_id: build
+    independence_domain: github
+    capabilities: [build]
+""",
+        encoding="utf-8",
+    )
+
+    registry = load_model_identities(tmp_path, use_packaged_default=True)
+
+    assert [
+        (identity.executor, identity.model_id)
+        for identity in registry.identities
+    ] == [
+        ("claude", "planner"),
+        ("copilot", "build"),
+        ("agy", AGY_MODEL_ID),
+    ]
+
+
+def test_packaged_default_without_custom_file_returns_packaged_only(tmp_path: Path) -> None:
+    registry = load_model_identities(tmp_path, use_packaged_default=True)
+
+    assert [
+        (identity.executor, identity.model_id)
+        for identity in registry.identities
+    ] == [("agy", AGY_MODEL_ID)]
+
+
 def test_v2_registry_is_strict_and_rejects_unknown_or_duplicate_rows(tmp_path: Path) -> None:
     path = tmp_path / "model-identities.yaml"
     path.write_text(


### PR DESCRIPTION
## 摘要
- `load_model_identities` 合併順序改 custom 條目在前（operator 宣告優先於 packaged），重複衝突語意不變
- 解 planner 永遠選中不可用 packaged agy 的重派迴圈；custom claude[planning] 得以生效
- TDD：順序斷言（custom 前置、claude 先於 agy）、無 custom 時行為不變

實作：copilot CLI（gpt-5.4）直接編排；審查：Fable 5。

Closes #123

## 驗證
- [x] `python3 -m pytest tests/ -q`（1072 passed, 21 subtests passed）
- [x] `python3 -m policy_check --repo .`（0 fail）
- [x] `git diff --check`
- [x] fragment 與 `CHANGELOG.md [Unreleased]` 同步
- [x] `VERSION` 維持 0.0.0