### PR TITLE
docs(porcelain): B1 rollout 補充規格（authority 擴充）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ## [Unreleased]
 
 ### Added
+- **porcelain-skeleton rollout 補充規格**：B1 驗收要求與 B2+ 接軌契約。
 - **B1 porcelain-skeleton 規劃產物**：路由骨架批次的 Work Item 綁定、規劃四件套與 OpenSpec change。
 - **cortex CLI 版本輸出**：新增頂層 `cortex --version`，輸出已安裝套件版本；若無 package metadata 則回退為 `0.0.0+unknown`。
 - **canary follow-ups workstream todo**：記錄 dogfood canary 實跑發現的後續事項，並作為 work authority 的新增 confirmed 來源。

--- a/changelog.d/87-skeleton-rollout-spec.md
+++ b/changelog.d/87-skeleton-rollout-spec.md
@@ -1,0 +1,3 @@
+### Added
+
+- **porcelain-skeleton rollout 補充規格**：B1 落地驗收要求與 B2+ 接軌契約（僅經 _FAMILY_MODULES 登記）。

--- a/docs/superpowers/specs/porcelain-skeleton-rollout-spec.md
+++ b/docs/superpowers/specs/porcelain-skeleton-rollout-spec.md
@@ -1,0 +1,18 @@
+---
+status: accepted
+work_item: porcelain-skeleton
+---
+
+# porcelain-skeleton Rollout Specification
+
+B1 落地後的驗收與後續批次接軌注意事項（補充規格；主規格見 porcelain-skeleton-spec.md）。
+
+## Requirements
+
+### 落地驗收
+
+B1 merge 後 SHALL 以 `pipx install --force` 重裝並實測：`cortex --help` 顯示 `--version` 且（空註冊表下）無 porcelain 區段；既有命令行為不變（抽測 `status`/`list`/`doctor --json`）。
+
+### 後續批次接軌
+
+B2+ 各家族 SHALL 只透過 `_FAMILY_MODULES` 清單與自身模組登記，MUST NOT 直接修改 `cli.py` 的路由 if-chain 或靜態 help 主體。


### PR DESCRIPTION
## 摘要
- 新增 `porcelain-skeleton-rollout-spec.md`（accepted、含 Requirements）：B1 落地驗收要求與 B2+ 接軌契約
- 兼作 work authority 的新 confirmed 來源：abandoned run 的 claim key 失效、允許 fresh claim（不增 todo 數量，避開 ship single-todo 限制；body 不引用 issue 編號以維持 R-17 not-applicable）

## 驗證
- [x] `python3 -m policy_check --repo .`（0 fail）
- [x] `git diff --check`
- [x] fragment 與 `CHANGELOG.md [Unreleased]` 同步
- [x] `VERSION` 維持 0.0.0