### PR TITLE
fix(workflow): planner 選擇不再被 primary_domain 釘死

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - **Porcelain CLI UX 規格與 v0.1.0 release plan**：凍結七家族（bootstrap/request/run/inspect/recover/service/init-sample）命令詞彙、exit code 契約、`--json` schema 穩定策略、request_id 顯性化 UX 與 TUI 邊界契約；並定義 v0.1.0 批次順序、release 程序（GitHub Release）、升級回滾與 KPI。
 
 ### Fixed
+- **planner workflow identity 不再被 `primary_domain` 釘死**：`_select_workflow_identity()` 現在只對非 planner、非 reviewer persona 套用 domain 偏好，避免 primary domain 是 google 時規劃階段被 agy 單點綁死。
 - **model identities custom 優先 packaged 預設**：`load_model_identities()` 合併 packaged 與 custom registry 時改為先放 custom 條目，避免本機不可用的 agy 永遠搶先 operator 在 custom 設定的 planner 而卡在重派迴圈。
 - **builder archive gate 交付路徑與 tasks 勾選指示補齊**：builder persona 現在可寫 active OpenSpec、changelog、CHANGELOG 與 superpowers plan 路徑，commit-required workflow prompt 也會明示更新對應 `tasks.md` 勾選且不得改動 pinned input。
 - **archive gate 不再把 R-22 advisory WARN 視為阻斷**：`policy_check` 的 doc reference gate 現在只以 return code 判定，避免既有 diff-aware R-22 advisory WARN 讓所有 archive change 永遠卡在 `doc-reference-invalid`。

--- a/changelog.d/126-planner-domain-unpin.md
+++ b/changelog.d/126-planner-domain-unpin.md
@@ -1,0 +1,2 @@
+### Fixed
+- planner workflow identity 選擇不再被 `primary_domain` 釘死，避免 google 為 primary domain 時因 agy 不可用而卡住規劃階段。

--- a/paulsha_cortex/coordinator/manager.py
+++ b/paulsha_cortex/coordinator/manager.py
@@ -4870,7 +4870,7 @@ def _select_workflow_identity(run, step, identities: IdentityRegistry):
     candidates = list(identities.identities)
     if step.persona == "planner":
         candidates = [item for item in candidates if "planning" in item.capabilities]
-    if step.persona == "reviewer":
+    elif step.persona == "reviewer":
         candidates = [
             item
             for item in candidates

--- a/tests/test_workflow_production_wiring.py
+++ b/tests/test_workflow_production_wiring.py
@@ -2816,6 +2816,95 @@ def test_manager_rejects_same_domain_reviewer_before_dispatch(tmp_path: Path) ->
         manager._select_workflow_identity(run, review_step, identities)
 
 
+def _workflow_identity_run(*, primary_domain: str | None, build_domain: str | None = None) -> SimpleNamespace:
+    steps = []
+    if build_domain is not None:
+        steps.append(SimpleNamespace(phase="build", gate_result="passed", domain=build_domain))
+    return SimpleNamespace(primary_domain=primary_domain, steps=steps)
+
+
+def test_planner_identity_selection_ignores_primary_domain_preference() -> None:
+    identities = IdentityRegistry.from_rows(
+        [
+            {
+                "executor": "claude",
+                "model_id": "planner-claude",
+                "independence_domain": "anthropic",
+                "capabilities": ["planning", "review"],
+            },
+            {
+                "executor": "agy",
+                "model_id": AGY_MODEL_ID,
+                "independence_domain": "google",
+                "capabilities": ["planning"],
+                "live_probe": AGY_LIVE_PROBE,
+            },
+        ]
+    )
+
+    selected = manager._select_workflow_identity(
+        _workflow_identity_run(primary_domain="google"),
+        SimpleNamespace(persona="planner"),
+        identities,
+    )
+
+    assert (selected.executor, selected.model_id) == ("claude", "planner-claude")
+
+
+def test_builder_identity_selection_still_prefers_primary_domain() -> None:
+    identities = IdentityRegistry.from_rows(
+        [
+            {
+                "executor": "codex",
+                "model_id": "builder-openai",
+                "independence_domain": "openai",
+                "capabilities": [],
+            },
+            {
+                "executor": "gemini",
+                "model_id": "builder-google",
+                "independence_domain": "google",
+                "capabilities": [],
+            },
+        ]
+    )
+
+    selected = manager._select_workflow_identity(
+        _workflow_identity_run(primary_domain="google"),
+        SimpleNamespace(persona="builder"),
+        identities,
+    )
+
+    assert (selected.executor, selected.model_id) == ("gemini", "builder-google")
+
+
+def test_reviewer_identity_selection_excludes_builder_domains() -> None:
+    identities = IdentityRegistry.from_rows(
+        [
+            {
+                "executor": "claude",
+                "model_id": "review-google",
+                "independence_domain": "google",
+                "capabilities": ["review"],
+            },
+            {
+                "executor": "claude",
+                "model_id": "review-anthropic",
+                "independence_domain": "anthropic",
+                "capabilities": ["review"],
+            },
+        ]
+    )
+
+    selected = manager._select_workflow_identity(
+        _workflow_identity_run(primary_domain="google", build_domain="google"),
+        SimpleNamespace(persona="reviewer"),
+        identities,
+    )
+
+    assert (selected.executor, selected.model_id) == ("claude", "review-anthropic")
+
+
 def test_manager_rejects_planner_artifacts_outside_governed_roots(tmp_path: Path) -> None:
     with pytest.raises(ValueError, match="outside governed roots"):
         manager._publish_planning_artifacts(


### PR DESCRIPTION
## 摘要
- `_select_workflow_identity` 的 primary_domain 偏好改為僅適用 builder/manager 等 persona；planner 以 planning 過濾後順序直選（配合 #124 custom-first 由 operator 控制）
- 解 planner 被鎖到不可用身分（agy headless 故障）造成的 malformed-retry 無限迴圈與 abandon 三不死鎖
- TDD：primary_domain=google 下 planner 選 claude；builder domain 偏好與 reviewer 過濾不變

實作：copilot CLI（gpt-5.4）直接編排；審查：Fable 5。

Closes #126

## 驗證
- [x] `python3 -m pytest tests/ -q` 全綠
- [x] `python3 -m policy_check --repo .`（0 fail）
- [x] `git diff --check`
- [x] fragment 與 `CHANGELOG.md [Unreleased]` 同步
- [x] `VERSION` 維持 0.0.0