### PR TITLE
fix(workflow): plan 卡於產物完備時決定性通過

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - **Porcelain CLI UX 規格與 v0.1.0 release plan**：凍結七家族（bootstrap/request/run/inspect/recover/service/init-sample）命令詞彙、exit code 契約、`--json` schema 穩定策略、request_id 顯性化 UX 與 TUI 邊界契約；並定義 v0.1.0 批次順序、release 程序（GitHub Release）、升級回滾與 KPI。
 
 ### Fixed
+- **plan-phase planner 卡可在產物完備時由 Manager 決定性通過**：`writing-plans` 等規劃卡若其 persisted planning authority 對應的 accepted spec/design/plan 已完整存在，manager 會直接把當前 planner step 標記為 `passed` 並推進到下一 phase，不再多派 planner executor。
 - **planner workflow identity 不再被 `primary_domain` 釘死**：`_select_workflow_identity()` 現在只對非 planner、非 reviewer persona 套用 domain 偏好，避免 primary domain 是 google 時規劃階段被 agy 單點綁死。
 - **model identities custom 優先 packaged 預設**：`load_model_identities()` 合併 packaged 與 custom registry 時改為先放 custom 條目，避免本機不可用的 agy 永遠搶先 operator 在 custom 設定的 planner 而卡在重派迴圈。
 - **builder archive gate 交付路徑與 tasks 勾選指示補齊**：builder persona 現在可寫 active OpenSpec、changelog、CHANGELOG 與 superpowers plan 路徑，commit-required workflow prompt 也會明示更新對應 `tasks.md` 勾選且不得改動 pinned input。

--- a/changelog.d/128-deterministic-plan-card.md
+++ b/changelog.d/128-deterministic-plan-card.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **plan-phase planner 卡可在產物完備時由 Manager 決定性通過**：`writing-plans` 等規劃卡若其 persisted planning authority 對應的 accepted spec/design/plan 已完整存在，manager 會直接把當前 planner step 標記為 `passed` 並推進到下一 phase，不再多派 planner executor。

--- a/paulsha_cortex/coordinator/manager.py
+++ b/paulsha_cortex/coordinator/manager.py
@@ -1785,6 +1785,22 @@ def _load_workflow_manifest(path_value: str) -> WorkflowManifest:
     return WorkflowManifest.from_dict(payload)
 
 
+def _read_planning_artifact_content(root: Path, ref: str) -> tuple[bytes, str]:
+    relative = Path(ref)
+    if relative.is_absolute() or ".." in relative.parts:
+        raise ValueError("planning artifact escapes artifact root")
+    unresolved = root / relative
+    cursor = root
+    for part in relative.parts:
+        cursor = cursor / part
+        if cursor.is_symlink():
+            raise ValueError("symlink planning artifact")
+    resolved = unresolved.resolve()
+    resolved.relative_to(root)
+    content = resolved.read_bytes()
+    return content, content.decode("utf-8")
+
+
 def _load_planning_artifacts(
     args: Mapping[str, object],
     *,
@@ -1814,20 +1830,8 @@ def _load_planning_artifacts(
     artifacts: list[PlanningArtifact] = []
     scanned: list[PlanningArtifactAuthority] = []
     for index, (kind, ref) in enumerate(requested):
-        relative = Path(ref)
-        if relative.is_absolute() or ".." in relative.parts:
-            raise ValueError(f"workflow-action planning_artifacts[{index}] escapes artifact_root")
         try:
-            unresolved = root / relative
-            cursor = root
-            for part in relative.parts:
-                cursor = cursor / part
-                if cursor.is_symlink():
-                    raise ValueError("symlink planning artifact")
-            resolved = unresolved.resolve()
-            resolved.relative_to(root)
-            content = resolved.read_bytes()
-            text = content.decode("utf-8")
+            content, text = _read_planning_artifact_content(root, ref)
         except (OSError, UnicodeDecodeError, ValueError) as exc:
             raise ValueError(f"workflow planning artifact unreadable: {ref}") from exc
         artifacts.append(PlanningArtifact(kind=kind, ref=ref, text=text))
@@ -1842,6 +1846,18 @@ def _load_planning_artifacts(
     if authority and tuple(scanned) != authority:
         raise ValueError("workflow planning artifact current authority drift")
     return tuple(artifacts), tuple(scanned)
+
+
+def _load_run_planning_artifacts(run) -> tuple[PlanningArtifact, ...] | None:
+    root = Path(run.workspace_root).resolve()
+    artifacts: list[PlanningArtifact] = []
+    for authority in run.planning_authority:
+        try:
+            _content, text = _read_planning_artifact_content(root, authority.ref)
+        except (OSError, UnicodeDecodeError, ValueError):
+            return None
+        artifacts.append(PlanningArtifact(kind=authority.kind, ref=authority.ref, text=text))
+    return tuple(artifacts)
 
 
 def _manager_archive_applied(run) -> bool:
@@ -5122,6 +5138,42 @@ def _dispatch_workflow_card(
             card=step.card,
             coordinator_root=coordinator_root,
         )
+    if step.persona == "planner" and step.phase == "plan":
+        artifacts = _load_run_planning_artifacts(run)
+        try:
+            planning_complete = artifacts is not None and assess_planning_completeness(artifacts).complete
+        except ValueError:
+            planning_complete = False
+        if planning_complete:
+            pending_phase_steps = [
+                item
+                for item in run.steps
+                if item.phase == run.current_phase and item.gate_result != "passed"
+            ]
+            is_last_pending = bool(pending_phase_steps) and step.card == pending_phase_steps[-1].card
+            next_phase = run.current_phase
+            attempts = run.attempts
+            if is_last_pending:
+                next_phase = WORKFLOW_PHASES[WORKFLOW_PHASES.index(run.current_phase) + 1]
+                attempts = {
+                    **run.attempts,
+                    next_phase: run.attempts.get(next_phase, 0) + 1,
+                }
+            registry._manager_update_workflow_run(
+                run.run_id,
+                current_phase=next_phase,
+                steps=_audit_phase_steps(
+                    run.steps,
+                    phase=run.current_phase,
+                    executor="cortex-manager",
+                    model="deterministic",
+                    domain="cortex",
+                    outputs=tuple(artifact.ref for artifact in artifacts),
+                    card_id=step.card,
+                ),
+                attempts=attempts,
+            )
+            return None
     identity = _select_workflow_identity(run, step, identities)
     launcher = launcher_factory(identity)
     if launcher is None:

--- a/tests/test_work_bridge.py
+++ b/tests/test_work_bridge.py
@@ -1059,8 +1059,11 @@ identities:
         )
     )
     run_id = started["result"]["run"]["run_id"]
-    first_job = registry.get_job(started["result"]["job_id"])
-    assert first_job["persona"] == "planner"
+    if "job_id" in started["result"]:
+        first_job = registry.get_job(started["result"]["job_id"])
+        assert first_job["persona"] == "planner"
+    else:
+        assert registry.get_workflow_run(run_id).current_phase == "build"
 
     result = None
     for _ in range(10):

--- a/tests/test_workflow_production_wiring.py
+++ b/tests/test_workflow_production_wiring.py
@@ -184,6 +184,37 @@ def _workflow_args(manifest_path: Path, artifact_root: Path) -> dict[str, object
     }
 
 
+def _write_planning_artifacts(root: Path, *, missing: set[str] | None = None) -> tuple[PlanningArtifactAuthority, ...]:
+    missing = missing or set()
+    proposal = root / "openspec/changes/production-wiring/proposal.md"
+    proposal.parent.mkdir(parents=True, exist_ok=True)
+    proposal.write_text("# Proposal\n", encoding="utf-8")
+    bodies = {
+        "spec": "---\nstatus: accepted\n---\n# Spec\n## Requirements\nFixed.\n",
+        "design": "---\nstatus: accepted\n---\n# Design\n## Decisions\nFixed.\n",
+        "plan": "---\nstatus: accepted\n---\n# Plan\n## Task 1\nBuild.\n",
+    }
+    authority: list[PlanningArtifactAuthority] = []
+    for kind, body in bodies.items():
+        ref = f"docs/{kind}.md"
+        path = root / ref
+        if kind not in missing:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(body, encoding="utf-8")
+            digest = hashlib.sha256(body.encode("utf-8")).hexdigest()
+        else:
+            digest = "0" * 64
+        authority.append(
+            PlanningArtifactAuthority(
+                ref=ref,
+                kind=kind,
+                work_id="production-wiring",
+                baseline_sha256=digest,
+            )
+        )
+    return tuple(authority)
+
+
 def test_control_queue_workflow_action_is_the_production_mutation_path(tmp_path: Path) -> None:
     registry = JobRegistry(state_path=tmp_path / "registry.json")
     dispatcher = type("D", (), {"_registry": registry, "_git_runner": None})()
@@ -381,6 +412,114 @@ def test_public_work_retry_build_forces_one_new_manager_dispatched_builder(
 
     assert calls == [True]
     assert result["result"]["job_id"] == "repair-builder"
+
+
+def test_plan_dispatch_passes_complete_planner_card_without_launch(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    registry = JobRegistry(state_path=tmp_path / "registry.json")
+    authority = _write_planning_artifacts(repo)
+    run = registry._manager_create_workflow_run(
+        work_id="production-wiring",
+        repo="hamanpaul/paulsha-cortex",
+        claim_key="claim:v1:" + "1" * 64,
+        source_revision="2" * 64,
+        workspace_root=str(repo),
+        combo="feature-oneshot",
+        current_phase="plan",
+        steps=_manifest().steps,
+        issue_refs=("hamanpaul/paulsha-cortex#14",),
+        openspec_refs=("production-wiring",),
+        pr_refs=(),
+        attempts={"plan": 1},
+        gate_status="running",
+        planning_authority=authority,
+    )
+
+    result = manager.dispatch_workflow_card(
+        type("D", (), {"_registry": registry, "_git_runner": None})(),
+        run=run,
+        identities=IdentityRegistry.from_rows([]),
+        launcher_factory=lambda _: (_ for _ in ()).throw(AssertionError("must not launch")),
+        coordinator_root=tmp_path / "coordinator",
+    )
+
+    persisted = registry.get_workflow_run(run.run_id)
+    planner = next(step for step in persisted.steps if step.card == "writing-plans")
+
+    assert result is None
+    assert persisted.current_phase == "build"
+    assert persisted.attempts == {"plan": 1, "build": 1}
+    assert planner.gate_result == "passed"
+    assert (planner.executor, planner.model, planner.domain) == (
+        "cortex-manager",
+        "deterministic",
+        "cortex",
+    )
+    assert planner.outputs == tuple(item.ref for item in authority)
+    assert registry.list_jobs() == []
+
+
+def test_plan_dispatch_launches_planner_when_artifacts_are_incomplete(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    registry = JobRegistry(state_path=tmp_path / "registry.json")
+    authority = _write_planning_artifacts(repo, missing={"plan"})
+    run = registry._manager_create_workflow_run(
+        work_id="production-wiring",
+        repo="hamanpaul/paulsha-cortex",
+        claim_key="claim:v1:" + "1" * 64,
+        source_revision="2" * 64,
+        workspace_root=str(repo),
+        combo="feature-oneshot",
+        current_phase="plan",
+        steps=_manifest().steps,
+        issue_refs=("hamanpaul/paulsha-cortex#14",),
+        openspec_refs=("production-wiring",),
+        pr_refs=(),
+        attempts={"plan": 1},
+        gate_status="running",
+        planning_authority=authority,
+    )
+    launched: list[str] = []
+
+    class Launcher:
+        def as_read_only(self):
+            return self
+
+        def launch(self, *, slice_id, prompt, worktree, log_dir):
+            launched.append(slice_id)
+            return LaunchHandle(
+                executor="codex",
+                model_id="gpt-primary",
+                session_name=slice_id,
+                pid=100,
+                log_path=str(Path(log_dir) / f"{slice_id}.jsonl"),
+            )
+
+    job = manager.dispatch_workflow_card(
+        type("D", (), {"_registry": registry, "_git_runner": None})(),
+        run=run,
+        identities=IdentityRegistry.from_rows(
+            [{
+                "executor": "codex",
+                "model_id": "gpt-primary",
+                "independence_domain": "openai",
+                "capabilities": ["planning"],
+            }]
+        ),
+        launcher_factory=lambda _: Launcher(),
+        coordinator_root=tmp_path / "coordinator",
+    )
+
+    persisted = registry.get_workflow_run(run.run_id)
+
+    assert job is not None
+    assert job["workflow_card"] == "writing-plans"
+    assert launched == [job["job_id"]]
+    assert persisted.current_phase == "plan"
+    assert next(step for step in persisted.steps if step.card == "writing-plans").gate_result == "pending"
+    assert len(registry.list_jobs()) == 1
 
 
 def test_forced_retry_build_dispatches_new_job_after_prior_success(
@@ -2376,8 +2515,8 @@ def test_control_queue_manager_executes_heterogeneous_brainstorm_before_plan(tmp
     assert calls == ["questioner", "secondary:anthropic", "integrator"]
     assert commit_capability_requests == []
     assert review_capability_requests == []
-    assert plan_launch_roots and all(path != tmp_path for path in plan_launch_roots)
-    assert run.current_phase == "plan"
+    assert plan_launch_roots == []
+    assert run.current_phase == "build"
     assert [ref.kind for ref in run.gate_refs] == ["brainstorm"]
     assert Path(run.gate_refs[0].ref).is_file()
 
@@ -2425,7 +2564,9 @@ def test_control_queue_manager_executes_heterogeneous_brainstorm_before_plan(tmp
             requested_by="operator",
         ))
         seen_phases.append(result["current_phase"])
-    assert seen_phases == ["build", "build", "build", "verify", "review", "review", "review"]
+        if result["reason"] == "blocking-findings":
+            break
+    assert seen_phases == ["build", "build", "verify", "review", "review", "review"]
     assert commit_capability_requests == ["required", "required"]
     assert review_capability_requests == [
         "workflow-verification-result",
@@ -2595,7 +2736,7 @@ def test_control_queue_manager_executes_heterogeneous_brainstorm_before_plan(tmp
         for step in shipped.steps if step.phase in {"claim", "define", "plan", "build", "verify", "review"}
     )
     workflow_jobs = [job for job in registry.list_jobs() if job.get("workflow_run_id") == run.run_id]
-    assert len(workflow_jobs) == 10
+    assert len(workflow_jobs) == 9
     assert {
         job.get("workflow_card")
         for job in workflow_jobs
@@ -4305,8 +4446,9 @@ def test_complete_plan_does_not_require_or_launch_brainstorm(tmp_path: Path) -> 
     result = executor(build_request(req_type="workflow-action", args=args, requested_by="operator"))
     run = registry.get_workflow_run(result["run_id"])
     assert result["reason"] == "planning-complete"
-    assert launched == [result["job_id"]]
+    assert launched == []
     assert run.brainstorm_required is False
+    assert run.current_phase == "build"
     assert run.gate_refs == ()
     assert {
         (authority.ref, authority.kind, authority.work_id, authority.baseline_sha256)


### PR DESCRIPTION
## 摘要
- `_dispatch_workflow_card` 對 planner 卡先以 `assess_planning_completeness`（以 run.planning_authority 於 workspace 讀檔）評估：完備 → step 直接標 passed（cortex-manager/deterministic，比照 define/archive 前例）、必要時推進 phase、不派 executor
- 不完備 → 維持既有派工（heterogeneous brainstorm 機制不變）；claim 路徑不動
- 解 planner executor 輪盤（agy headless 空輸出、claude plan-mode 契約漂移）造成的 malformed-retry 燒額度與 abandon 死鎖

實作：copilot CLI（gpt-5.4）直接編排；審查：Fable 5。

Closes #128

## 驗證
- [x] `python3 -m pytest tests/ -q`（1077 passed, 21 subtests passed）
- [x] `python3 -m policy_check --repo .`（0 fail）
- [x] `git diff --check`
- [x] fragment 與 `CHANGELOG.md [Unreleased]` 同步
- [x] `VERSION` 維持 0.0.0