### PR TITLE
fix(workflow): builder 選擇先過濾 build capability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - **Porcelain CLI UX 規格與 v0.1.0 release plan**：凍結七家族（bootstrap/request/run/inspect/recover/service/init-sample）命令詞彙、exit code 契約、`--json` schema 穩定策略、request_id 顯性化 UX 與 TUI 邊界契約；並定義 v0.1.0 批次順序、release 程序（GitHub Release）、升級回滾與 KPI。
 
 ### Fixed
+- **builder workflow identity 先過濾 build capability**：`_select_workflow_identity()` 現在會先排除不具 `build` 能力的 builder 候選，再套用 `primary_domain` 偏好，避免 google primary domain 把 build 卡誤派給僅支援 planning 的身分而陷入 malformed 重派。
 - **plan-phase planner 卡可在產物完備時由 Manager 決定性通過**：`writing-plans` 等規劃卡若其 persisted planning authority 對應的 accepted spec/design/plan 已完整存在，manager 會直接把當前 planner step 標記為 `passed` 並推進到下一 phase，不再多派 planner executor。
 - **planner workflow identity 不再被 `primary_domain` 釘死**：`_select_workflow_identity()` 現在只對非 planner、非 reviewer persona 套用 domain 偏好，避免 primary domain 是 google 時規劃階段被 agy 單點綁死。
 - **model identities custom 優先 packaged 預設**：`load_model_identities()` 合併 packaged 與 custom registry 時改為先放 custom 條目，避免本機不可用的 agy 永遠搶先 operator 在 custom 設定的 planner 而卡在重派迴圈。

--- a/changelog.d/130-builder-capability-filter.md
+++ b/changelog.d/130-builder-capability-filter.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **builder workflow identity 先過濾 build capability**：`_select_workflow_identity()` 現在會先排除不具 `build` 能力的 builder 候選，再套用 `primary_domain` 偏好，避免 google primary domain 把 build 卡誤派給僅支援 planning 的身分而陷入 malformed 重派。

--- a/paulsha_cortex/coordinator/manager.py
+++ b/paulsha_cortex/coordinator/manager.py
@@ -4893,10 +4893,12 @@ def _select_workflow_identity(run, step, identities: IdentityRegistry):
             if "review" in item.capabilities
             and item.independence_domain not in builder_domains
         ]
-    elif run.primary_domain is not None:
-        preferred = [item for item in candidates if item.independence_domain == run.primary_domain]
-        if preferred:
-            candidates = preferred
+    else:
+        candidates = [item for item in candidates if "build" in item.capabilities]
+        if run.primary_domain is not None:
+            preferred = [item for item in candidates if item.independence_domain == run.primary_domain]
+            if preferred:
+                candidates = preferred
     if not candidates:
         raise ValueError(f"no configured identity for workflow persona: {step.persona}")
     return candidates[0]

--- a/tests/test_work_bridge.py
+++ b/tests/test_work_bridge.py
@@ -887,7 +887,7 @@ identities:
   - executor: codex
     model_id: gpt-primary
     independence_domain: openai
-    capabilities: [planning]
+    capabilities: [planning, build]
   - executor: claude
     model_id: claude-reviewer
     independence_domain: anthropic

--- a/tests/test_workflow_production_wiring.py
+++ b/tests/test_workflow_production_wiring.py
@@ -606,7 +606,7 @@ def test_forced_retry_build_dispatches_new_job_after_prior_success(
                 "executor": "codex",
                 "model_id": "gpt-primary",
                 "independence_domain": "openai",
-                "capabilities": ["planning"],
+                "capabilities": ["build"],
             }]
         ),
         launcher_factory=lambda _: Launcher(),
@@ -1154,7 +1154,7 @@ def test_operator_resume_retries_bound_needs_human_terminal_without_rewriting_ol
         "executor": "codex",
         "model_id": "gpt-primary",
         "independence_domain": "openai",
-        "capabilities": [],
+        "capabilities": ["build"],
     }])
     stopped = manager.resume_workflow_run(
         ResumeDispatcher(),
@@ -1401,7 +1401,7 @@ def test_operator_resume_retries_malformed_build_terminal_without_advancing(
             "executor": "codex",
             "model_id": "gpt-primary",
             "independence_domain": "openai",
-            "capabilities": [],
+            "capabilities": ["build"],
         }]
     )
 
@@ -2351,7 +2351,7 @@ def test_control_queue_manager_executes_heterogeneous_brainstorm_before_plan(tmp
                 "executor": "codex",
                 "model_id": "gpt-primary",
                 "independence_domain": "openai",
-                "capabilities": ["planning"],
+                "capabilities": ["planning", "build"],
             },
             {
                 "executor": "claude",
@@ -2968,6 +2968,12 @@ def test_planner_identity_selection_ignores_primary_domain_preference() -> None:
     identities = IdentityRegistry.from_rows(
         [
             {
+                "executor": "copilot",
+                "model_id": "builder-openai",
+                "independence_domain": "openai",
+                "capabilities": ["build"],
+            },
+            {
                 "executor": "claude",
                 "model_id": "planner-claude",
                 "independence_domain": "anthropic",
@@ -2992,20 +2998,67 @@ def test_planner_identity_selection_ignores_primary_domain_preference() -> None:
     assert (selected.executor, selected.model_id) == ("claude", "planner-claude")
 
 
-def test_builder_identity_selection_still_prefers_primary_domain() -> None:
+def test_builder_identity_selection_requires_build_capability_before_domain_preference() -> None:
     identities = IdentityRegistry.from_rows(
         [
             {
-                "executor": "codex",
+                "executor": "copilot",
                 "model_id": "builder-openai",
                 "independence_domain": "openai",
-                "capabilities": [],
+                "capabilities": ["build"],
+            },
+            {
+                "executor": "claude",
+                "model_id": "planner-claude",
+                "independence_domain": "anthropic",
+                "capabilities": ["planning", "review"],
+            },
+            {
+                "executor": "agy",
+                "model_id": AGY_MODEL_ID,
+                "independence_domain": "google",
+                "capabilities": ["planning"],
+                "live_probe": AGY_LIVE_PROBE,
+            },
+        ]
+    )
+
+    selected = manager._select_workflow_identity(
+        _workflow_identity_run(primary_domain="google"),
+        SimpleNamespace(persona="builder"),
+        identities,
+    )
+
+    assert (selected.executor, selected.model_id) == ("copilot", "builder-openai")
+
+
+def test_builder_identity_selection_still_prefers_primary_domain_after_build_filter() -> None:
+    identities = IdentityRegistry.from_rows(
+        [
+            {
+                "executor": "copilot",
+                "model_id": "builder-openai",
+                "independence_domain": "openai",
+                "capabilities": ["build"],
+            },
+            {
+                "executor": "claude",
+                "model_id": "planner-claude",
+                "independence_domain": "anthropic",
+                "capabilities": ["planning", "review"],
+            },
+            {
+                "executor": "agy",
+                "model_id": AGY_MODEL_ID,
+                "independence_domain": "google",
+                "capabilities": ["planning"],
+                "live_probe": AGY_LIVE_PROBE,
             },
             {
                 "executor": "gemini",
                 "model_id": "builder-google",
                 "independence_domain": "google",
-                "capabilities": [],
+                "capabilities": ["build"],
             },
         ]
     )


### PR DESCRIPTION
## 摘要
- `_select_workflow_identity` builder 路徑先過濾 `build` capability 再套 primary_domain 偏好（與 planner/reviewer 過濾對稱）
- 解 domain-pin 將 build 卡鎖到僅 planning 身分（agy）造成的 malformed 迴圈

實作：copilot CLI（gpt-5.4）直接編排；審查：Fable 5。

Closes #130

## 驗證
- [x] `python3 -m pytest tests/ -q` 全綠
- [x] `python3 -m policy_check --repo .`（0 fail）
- [x] `git diff --check`
- [x] fragment 與 `CHANGELOG.md [Unreleased]` 同步
- [x] `VERSION` 維持 0.0.0