### PR TITLE
fix(workflow): repair 派工注入 bot review findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - **Porcelain CLI UX 規格與 v0.1.0 release plan**：凍結七家族（bootstrap/request/run/inspect/recover/service/init-sample）命令詞彙、exit code 契約、`--json` schema 穩定策略、request_id 顯性化 UX 與 TUI 邊界契約；並定義 v0.1.0 批次順序、release 程序（GitHub Release）、升級回滾與 KPI。
 
 ### Fixed
+- **repair 派工注入 bot review findings**：delivery journal 現在會保留 blocking review threads 的檔案/行號/摘錄，repair builder 的 commit-required prompt 會直接附上 needs-fix findings，避免 fix-round 在缺少 reviewer 上下文時盲修。
 - **builder workflow identity 先過濾 build capability**：`_select_workflow_identity()` 現在會先排除不具 `build` 能力的 builder 候選，再套用 `primary_domain` 偏好，避免 google primary domain 把 build 卡誤派給僅支援 planning 的身分而陷入 malformed 重派。
 - **plan-phase planner 卡可在產物完備時由 Manager 決定性通過**：`writing-plans` 等規劃卡若其 persisted planning authority 對應的 accepted spec/design/plan 已完整存在，manager 會直接把當前 planner step 標記為 `passed` 並推進到下一 phase，不再多派 planner executor。
 - **planner workflow identity 不再被 `primary_domain` 釘死**：`_select_workflow_identity()` 現在只對非 planner、非 reviewer persona 套用 domain 偏好，避免 primary domain 是 google 時規劃階段被 agy 單點綁死。

--- a/changelog.d/120-bot-findings-in-repair.md
+++ b/changelog.d/120-bot-findings-in-repair.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **repair 派工注入 bot review findings**：delivery journal 現在會保留 blocking review threads 的檔案/行號/摘錄，repair builder 的 commit-required prompt 會直接附上 needs-fix findings，避免 fix-round 在缺少 reviewer 上下文時盲修。

--- a/paulsha_cortex/coordinator/github_delivery.py
+++ b/paulsha_cortex/coordinator/github_delivery.py
@@ -61,6 +61,9 @@ class ReviewThread:
     thread_id: str
     resolved: bool
     outdated: bool
+    path: str | None = None
+    line: int | None = None
+    body_excerpt: str = ""
 
     @property
     def blocks_merge(self) -> bool:
@@ -243,7 +246,14 @@ query($owner:String!,$name:String!,$number:Int!,$issueCursor:String,$threadCurso
         pageInfo { hasNextPage endCursor }
       }
       reviewThreads(first:100,after:$threadCursor) {
-        nodes { id isResolved isOutdated }
+        nodes {
+          id
+          isResolved
+          isOutdated
+          comments(first:1) {
+            nodes { path line body }
+          }
+        }
         pageInfo { hasNextPage endCursor }
       }
     }
@@ -631,11 +641,42 @@ class GitHubDeliveryClient:
                     or not isinstance(node.get("isOutdated"), bool)
                 ):
                     raise TypeError("review thread node malformed")
+                path: str | None = None
+                line: int | None = None
+                body_excerpt = ""
+                comments = node.get("comments")
+                if comments is not None:
+                    if not isinstance(comments, dict):
+                        raise TypeError("review thread comments malformed")
+                    comment_nodes = comments.get("nodes")
+                    if not isinstance(comment_nodes, list):
+                        raise TypeError("review thread comments malformed")
+                    if comment_nodes:
+                        first_comment = comment_nodes[0]
+                        if not isinstance(first_comment, dict):
+                            raise TypeError("review thread comment malformed")
+                        path_value = first_comment.get("path")
+                        line_value = first_comment.get("line")
+                        body_value = first_comment.get("body")
+                        if path_value is not None and not isinstance(path_value, str):
+                            raise TypeError("review thread comment path malformed")
+                        if line_value is not None and (
+                            not isinstance(line_value, int) or isinstance(line_value, bool)
+                        ):
+                            raise TypeError("review thread comment line malformed")
+                        if body_value is not None and not isinstance(body_value, str):
+                            raise TypeError("review thread comment body malformed")
+                        path = path_value
+                        line = line_value
+                        body_excerpt = (body_value or "")[:240]
                 parsed_threads.append(
                     ReviewThread(
                         thread_id=node["id"],
                         resolved=node["isResolved"],
                         outdated=node["isOutdated"],
+                        path=path,
+                        line=line,
+                        body_excerpt=body_excerpt,
                     )
                 )
             threads = tuple(parsed_threads)

--- a/paulsha_cortex/coordinator/manager.py
+++ b/paulsha_cortex/coordinator/manager.py
@@ -4926,6 +4926,47 @@ _LEGACY_CARD_EXECUTION = {
 }
 
 
+def _repair_findings_prompt_suffix(run, *, coordinator_root: str | Path) -> str:
+    journal_path = Path(coordinator_root) / "delivery-journal.json"
+    if journal_path.is_symlink() or not journal_path.is_file():
+        return ""
+    try:
+        journal = json.loads(journal_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return ""
+    runs = journal.get("runs") if isinstance(journal, dict) else None
+    row = runs.get(run.run_id) if isinstance(runs, dict) else None
+    ship = row.get("ship") if isinstance(row, dict) else None
+    findings = ship.get("findings") if isinstance(ship, dict) else None
+    if not (
+        isinstance(ship, dict)
+        and ship.get("phase") == "needs-fix"
+        and isinstance(findings, list)
+        and findings
+    ):
+        return ""
+    compact: list[str] = []
+    for finding in findings:
+        if not isinstance(finding, dict):
+            continue
+        path = finding.get("path")
+        line = finding.get("line")
+        body = finding.get("body")
+        if path is not None and not isinstance(path, str):
+            continue
+        if line is not None and (not isinstance(line, int) or isinstance(line, bool)):
+            continue
+        if not isinstance(body, str) or not body:
+            continue
+        compact.append(f"[{path or '?'}:{line if line is not None else '?'}] {body}")
+    if not compact:
+        return ""
+    suffix = " Reviewer findings to fix in this repair (address each, then commit): " + "; ".join(
+        compact
+    )
+    return suffix[:2000]
+
+
 def _workflow_job_prompt(
     run,
     step,
@@ -5049,6 +5090,11 @@ def _workflow_job_prompt(
         if effective_commit_policy == "required"
         else ""
     )
+    repair_findings_contract = (
+        _repair_findings_prompt_suffix(run, coordinator_root=coordinator_root)
+        if effective_commit_policy == "required"
+        else ""
+    )
     return (
         "Execute exactly one workflow card. End with one JSON object only; do not supply an evidence "
         "path or hash because Manager will canonicalize it. For workflow-card outputs, return only "
@@ -5061,6 +5107,7 @@ def _workflow_job_prompt(
         + planner_contract
         + reviewer_contract
         + commit_required_contract
+        + repair_findings_contract
         + " Contract: "
         + json.dumps(contract, ensure_ascii=False, sort_keys=True)
     )

--- a/paulsha_cortex/coordinator/work_actions.py
+++ b/paulsha_cortex/coordinator/work_actions.py
@@ -2264,6 +2264,11 @@ def _ship_action(
         requested_at=float(requested_at),
     )
     finding_count = sum(1 for thread in remote.review_threads if thread.blocks_merge)
+    findings = [
+        {"path": thread.path, "line": thread.line, "body": thread.body_excerpt}
+        for thread in remote.review_threads
+        if thread.blocks_merge
+    ][:10]
     copilot = loop.record_review(
         head=review.commit_id,
         now_epoch=now_epoch,
@@ -2278,6 +2283,7 @@ def _ship_action(
             "phase": "needs-fix",
             "review_id": review.review_id,
             "finding_count": finding_count,
+            "findings": findings,
             "fix_rounds": fix_rounds,
         }
         _save_runs(state_path, state)

--- a/tests/test_coordinator_manager.py
+++ b/tests/test_coordinator_manager.py
@@ -324,6 +324,115 @@ class WorkflowJobPromptTests(unittest.TestCase):
         self.assertNotIn("tasks.md checkboxes", verification_prompt)
         self.assertNotIn("never modify pinned input files", verification_prompt)
 
+    def test_commit_required_prompt_includes_needs_fix_reviewer_findings(self) -> None:
+        step = WorkflowStep(
+            phase="build",
+            persona="builder",
+            card="subagent-build",
+            executor=None,
+            model=None,
+            domain=None,
+            inputs=(),
+            outputs=(),
+        )
+        with tempfile.TemporaryDirectory() as coordinator_root:
+            (Path(coordinator_root) / "delivery-journal.json").write_text(
+                json.dumps(
+                    {
+                        "schema": "cortex-delivery-journal/v1",
+                        "runs": {
+                            "run-1": {
+                                "run_id": "run-1",
+                                "repo": "owner/repo",
+                                "work_id": "work-1",
+                                "ship": {
+                                    "phase": "needs-fix",
+                                    "findings": [
+                                        {
+                                            "path": "paulsha_cortex/porcelain/request.py",
+                                            "line": 193,
+                                            "body": "Repair the missing request binding.",
+                                        }
+                                    ],
+                                },
+                            }
+                        },
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            prompt = manager._workflow_job_prompt(
+                self._run(),
+                step,
+                builder_job_id="job-1",
+                coordinator_root=coordinator_root,
+            )
+
+        self.assertIn("Reviewer findings to fix in this repair", prompt)
+        self.assertIn(
+            "[paulsha_cortex/porcelain/request.py:193] Repair the missing request binding.",
+            prompt,
+        )
+
+    def test_missing_delivery_journal_keeps_commit_required_prompt_unchanged(self) -> None:
+        step = WorkflowStep(
+            phase="build",
+            persona="builder",
+            card="subagent-build",
+            executor=None,
+            model=None,
+            domain=None,
+            inputs=(),
+            outputs=(),
+        )
+        with tempfile.TemporaryDirectory() as coordinator_root:
+            prompt = manager._workflow_job_prompt(
+                self._run(),
+                step,
+                builder_job_id="job-1",
+                coordinator_root=coordinator_root,
+            )
+
+        self.assertNotIn("Reviewer findings to fix in this repair", prompt)
+
+    def test_needs_fix_prompt_without_findings_remains_unchanged(self) -> None:
+        step = WorkflowStep(
+            phase="build",
+            persona="builder",
+            card="subagent-build",
+            executor=None,
+            model=None,
+            domain=None,
+            inputs=(),
+            outputs=(),
+        )
+        with tempfile.TemporaryDirectory() as coordinator_root:
+            (Path(coordinator_root) / "delivery-journal.json").write_text(
+                json.dumps(
+                    {
+                        "schema": "cortex-delivery-journal/v1",
+                        "runs": {
+                            "run-1": {
+                                "run_id": "run-1",
+                                "repo": "owner/repo",
+                                "work_id": "work-1",
+                                "ship": {"phase": "needs-fix"},
+                            }
+                        },
+                    }
+                ),
+                encoding="utf-8",
+            )
+            prompt = manager._workflow_job_prompt(
+                self._run(),
+                step,
+                builder_job_id="job-1",
+                coordinator_root=coordinator_root,
+            )
+
+        self.assertNotIn("Reviewer findings to fix in this repair", prompt)
+
 
 class CompleteTickFailedAndInFlightTests(unittest.TestCase):
     def test_failed_job_writes_failed_manifest(self) -> None:

--- a/tests/test_github_delivery.py
+++ b/tests/test_github_delivery.py
@@ -173,6 +173,31 @@ def test_outdated_unresolved_thread_is_non_blocking() -> None:
     ).allowed
 
 
+def test_review_thread_carries_finding_context_without_changing_blocking_logic() -> None:
+    blocked = ReviewThread(
+        thread_id="t-find",
+        resolved=False,
+        outdated=False,
+        path="paulsha_cortex/porcelain/request.py",
+        line=193,
+        body_excerpt="Please guard the missing request mapping.",
+    )
+    outdated = ReviewThread(
+        thread_id="t-old",
+        resolved=False,
+        outdated=True,
+        path="paulsha_cortex/porcelain/request.py",
+        line=193,
+        body_excerpt="Old finding.",
+    )
+
+    assert blocked.blocks_merge is True
+    assert blocked.path == "paulsha_cortex/porcelain/request.py"
+    assert blocked.line == 193
+    assert blocked.body_excerpt == "Please guard the missing request mapping."
+    assert outdated.blocks_merge is False
+
+
 def test_typed_github_commands_request_copilot_and_merge_commit_only() -> None:
     assert build_copilot_request_argv(repo="hamanpaul/paulsha-cortex", pr_number=15) == [
         "gh",

--- a/tests/test_github_delivery_client.py
+++ b/tests/test_github_delivery_client.py
@@ -94,7 +94,20 @@ class FakeRunner:
                                 },
                                 "reviewThreads": {
                                     "nodes": [
-                                        {"id": "T1", "isResolved": False, "isOutdated": True}
+                                        {
+                                            "id": "T1",
+                                            "isResolved": False,
+                                            "isOutdated": True,
+                                            "comments": {
+                                                "nodes": [
+                                                    {
+                                                        "path": "paulsha_cortex/porcelain/request.py",
+                                                        "line": 193,
+                                                        "body": "A" * 300,
+                                                    }
+                                                ]
+                                            },
+                                        }
                                     ],
                                     "pageInfo": {
                                         "hasNextPage": False,
@@ -157,6 +170,9 @@ def test_fetch_delivery_facts_uses_authenticated_typed_gh_api() -> None:
     assert facts.active_openspec_absent
     assert facts.archive_present
     assert facts.review_threads[0].outdated
+    assert facts.review_threads[0].path == "paulsha_cortex/porcelain/request.py"
+    assert facts.review_threads[0].line == 193
+    assert facts.review_threads[0].body_excerpt == "A" * 240
     assert any(
         f"commits/{HEAD}/statuses" in " ".join(call[0]) for call in runner.calls
     )
@@ -649,6 +665,15 @@ def test_graphql_connections_are_fully_paginated_and_booleans_are_strict() -> No
                                             "id": thread,
                                             "isResolved": resolved,
                                             "isOutdated": False,
+                                            "comments": {
+                                                "nodes": [
+                                                    {
+                                                        "path": f"src/{thread.lower()}.py",
+                                                        "line": issue,
+                                                        "body": f"finding-{thread}",
+                                                    }
+                                                ]
+                                            },
                                         }
                                     ],
                                     "pageInfo": {
@@ -669,6 +694,12 @@ def test_graphql_connections_are_fully_paginated_and_booleans_are_strict() -> No
     )
     assert facts.closing_issues == (14, 15)
     assert tuple(thread.thread_id for thread in facts.review_threads) == ("T1", "T2")
+    assert tuple(thread.path for thread in facts.review_threads) == ("src/t1.py", "src/t2.py")
+    assert tuple(thread.line for thread in facts.review_threads) == (14, 15)
+    assert tuple(thread.body_excerpt for thread in facts.review_threads) == (
+        "finding-T1",
+        "finding-T2",
+    )
     with pytest.raises(RuntimeError, match="association facts malformed"):
         GitHubDeliveryClient(runner=Paged(malformed=True)).fetch_delivery_facts(
             repo="acme/demo",

--- a/tests/test_work_actions.py
+++ b/tests/test_work_actions.py
@@ -2276,6 +2276,126 @@ def test_review_findings_persist_across_heads_and_third_round_needs_human(
     assert persisted["ship"]["fix_rounds"] == 2
 
 
+def test_ship_fix_required_persists_capped_reviewer_findings(
+    monkeypatch, tmp_path: Path
+) -> None:
+    snapshot = _snapshot(tmp_path / "snapshot.json")
+    state = tmp_path / "runs.json"
+    work_actions.execute_work_action(
+        args={"action": "start", "repo": "acme/demo", "work_id": "demo"},
+        requested_by="operator",
+        snapshot_path=snapshot,
+        state_path=state,
+        now=lambda: 200,
+    )
+
+    threads = tuple(
+        ReviewThread(
+            thread_id=f"thread-{index}",
+            resolved=False,
+            outdated=False,
+            path=f"src/file_{index}.py",
+            line=100 + index,
+            body_excerpt=f"finding {index}",
+        )
+        for index in range(12)
+    )
+    current = {"review_ready": False}
+
+    class GitHub:
+        def __init__(self, *, runner):
+            pass
+
+        def ensure_pr_metadata(self, **kwargs):
+            pass
+
+        def fetch_delivery_facts(self, **kwargs):
+            reviews = ()
+            if current["review_ready"]:
+                reviews = (
+                    CopilotReview(
+                        review_id=9,
+                        commit_id=HEAD,
+                        state="COMMENTED",
+                        body="findings",
+                        author=COPILOT_REVIEWER_LOGIN,
+                        submitted_at_epoch=205.0,
+                    ),
+                )
+            return DeliveryFacts(
+                head=HEAD,
+                mergeable=True,
+                mergeable_state="clean",
+                checks=(),
+                copilot_reviews=reviews,
+                review_threads=threads,
+                closing_issues=(12,),
+                active_openspec_absent=True,
+                archive_present=True,
+            )
+
+        def fetch_merge_status(self, **kwargs):
+            return MergeStatus(False, HEAD, None)
+
+        def request_copilot(self, **kwargs):
+            pass
+
+    monkeypatch.setattr(work_actions, "GitHubDeliveryClient", GitHub)
+    monkeypatch.setattr(work_actions, "load_preflight_command", lambda: ("preflight",))
+    monkeypatch.setattr(
+        work_actions,
+        "run_preflight",
+        lambda **kwargs: PreflightResult(
+            True,
+            None,
+            CommandResult(("policy",), 0, "", ""),
+            CommandResult(("preflight",), 0, "", ""),
+            HEAD,
+            TREE,
+        ),
+    )
+    args = {
+        "action": "ship",
+        "repo": "acme/demo",
+        "work_id": "demo",
+        "repo_root": str(tmp_path),
+        "pr_number": 8,
+        "change": "demo",
+        "todo_paths": ["docs/todo.md"],
+        "pr_metadata_path": str(_pr_metadata(tmp_path / "pr.json")),
+    }
+
+    requested = work_actions.execute_work_action(
+        args=args,
+        requested_by="operator",
+        snapshot_path=snapshot,
+        state_path=state,
+        now=lambda: 200,
+    )
+    assert requested["result"]["action"] == "awaiting-copilot"
+
+    current["review_ready"] = True
+    reviewed = work_actions.execute_work_action(
+        args=args,
+        requested_by="operator",
+        snapshot_path=snapshot,
+        state_path=state,
+        now=lambda: 207,
+    )
+
+    assert reviewed["result"] == {
+        "action": "fix-required",
+        "reason": "copilot-findings",
+        "findings": 12,
+    }
+    persisted = _only_journal_row(state)
+    assert persisted["ship"]["phase"] == "needs-fix"
+    assert persisted["ship"]["findings"] == [
+        {"path": f"src/file_{index}.py", "line": 100 + index, "body": f"finding {index}"}
+        for index in range(10)
+    ]
+
+
 def test_external_merge_without_durable_authorization_needs_human(monkeypatch, tmp_path: Path) -> None:
     snapshot = _snapshot(tmp_path / "snapshot.json")
     state = tmp_path / "runs.json"


### PR DESCRIPTION
## 摘要
- `ReviewThread` 擴充 path/line/body_excerpt（GraphQL 同步取首則 comment）
- needs-fix 的 ship record 存 blocking findings（cap 10）
- `_workflow_job_prompt` 對 commit-required repair 卡注入「Reviewer findings to fix」列表（journal 容錯）
- 解 F32：fix-round 不再盲修，bot findings 自癒閉環（issue #120 第二部分）

實作：copilot CLI（gpt-5.4）直接編排；審查：Fable 5。
註：`test_stage9_project_monitor` 的 workspace 測試為既有環境敏感紅（實機 leak 真實 workspace；CI 淨環境通過），與本修無關。

Closes #120

## 驗證
- [x] `python3 -m pytest tests/ -q`（1087 passed；1 既有環境敏感紅與本修無關）
- [x] `python3 -m policy_check --repo .`（0 fail）
- [x] `git diff --check`
- [x] fragment 與 `CHANGELOG.md [Unreleased]` 同步
- [x] `VERSION` 維持 0.0.0