### PR TITLE
fix(monitor): GitHubTerminalProvider PR 查詢改 cursor 分頁

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - **Porcelain CLI UX 規格與 v0.1.0 release plan**：凍結七家族（bootstrap/request/run/inspect/recover/service/init-sample）命令詞彙、exit code 契約、`--json` schema 穩定策略、request_id 顯性化 UX 與 TUI 邊界契約；並定義 v0.1.0 批次順序、release 程序（GitHub Release）、升級回滾與 KPI。
 
 ### Fixed
+- **GitHub terminal PR 分頁**：`GitHubTerminalProvider` 現在會以 cursor 逐頁讀取最多 20 頁 pull requests，完整聚合超過 100 筆的 repo；若頁數仍未收斂則顯式失敗，避免第 101 個 PR 讓 terminal provider 永久 degraded。
 - **porcelain-service lifecycle guardrails**：所有 `service` 子命令現在共用 instance 驗證，`logs --follow` 改為 systemd-only 串流且 fallback 明確拒絕，systemctl/journalctl 失敗時 `--json` 也會回傳一致的 `cortex-porcelain/service/v1` 錯誤 envelope。
 - **repair 派工注入 bot review findings**：delivery journal 現在會保留 blocking review threads 的檔案/行號/摘錄，repair builder 的 commit-required prompt 會直接附上 needs-fix findings，避免 fix-round 在缺少 reviewer 上下文時盲修。
 - **builder workflow identity 先過濾 build capability**：`_select_workflow_identity()` 現在會先排除不具 `build` 能力的 builder 候選，再套用 `primary_domain` 偏好，避免 google primary domain 把 build 卡誤派給僅支援 planning 的身分而陷入 malformed 重派。

--- a/changelog.d/150-terminal-pr-pagination.md
+++ b/changelog.d/150-terminal-pr-pagination.md
@@ -1,0 +1,1 @@
+fix(monitor): GitHubTerminalProvider 改為 cursor 分頁聚合 pull requests，並設 20 頁硬上限；超限時維持顯式失敗，避免第 101 個 PR 讓 terminal provider 永久 degraded。

--- a/paulsha_cortex/monitor/providers.py
+++ b/paulsha_cortex/monitor/providers.py
@@ -724,7 +724,8 @@ class GitHubWorkProvider:
 class GitHubTerminalProvider:
     """Read closing references and remote default-branch archive evidence."""
 
-    _QUERY = """query($owner:String!,$name:String!){repository(owner:$owner,name:$name){defaultBranchRef{name target{... on Commit{oid}}} pullRequests(first:100,states:[OPEN,CLOSED,MERGED]){pageInfo{hasNextPage} nodes{number body headRefName headRefOid state mergedAt mergeCommit{oid parents(first:3){totalCount}} closingIssuesReferences(first:100){pageInfo{hasNextPage} nodes{number state}}}}}}"""
+    _QUERY = """query($owner:String!,$name:String!,$cursor:String){repository(owner:$owner,name:$name){defaultBranchRef{name target{... on Commit{oid}}} pullRequests(first:100,after:$cursor,states:[OPEN,CLOSED,MERGED]){pageInfo{hasNextPage endCursor} nodes{number body headRefName headRefOid state mergedAt mergeCommit{oid parents(first:3){totalCount}} closingIssuesReferences(first:100){pageInfo{hasNextPage} nodes{number state}}}}}}"""
+    _PULL_REQUEST_PAGE_LIMIT = 20
 
     def __init__(
         self,
@@ -768,20 +769,27 @@ class GitHubTerminalProvider:
         attempted_at = _utcnow()
         owner, name = self.repo.split("/", 1)
         try:
-            graph = self._json(
-                (
-                    "gh", "api", "graphql",
-                    "-f", f"query={self._QUERY}",
-                    "-F", f"owner={owner}",
-                    "-F", f"name={name}",
-                )
-            )
+            graph = self._json(self._pull_request_argv(owner=owner, name=name))
             repository = graph["data"]["repository"]
+            default_branch_ref = repository["defaultBranchRef"]
             pulls = repository["pullRequests"]
-            if pulls["pageInfo"]["hasNextPage"]:
-                raise ValueError("pull request pagination incomplete")
-            default_branch = repository["defaultBranchRef"]["name"]
-            default_revision = repository["defaultBranchRef"]["target"]["oid"]
+            pull_nodes = list(pulls["nodes"])
+            page_count = 1
+            while pulls["pageInfo"]["hasNextPage"]:
+                if page_count >= self._PULL_REQUEST_PAGE_LIMIT:
+                    raise ValueError("pull request pagination incomplete")
+                cursor = pulls["pageInfo"]["endCursor"]
+                if not isinstance(cursor, str) or not cursor:
+                    raise ValueError("pull request pagination incomplete")
+                graph = self._json(
+                    self._pull_request_argv(owner=owner, name=name, cursor=cursor)
+                )
+                repository = graph["data"]["repository"]
+                pulls = repository["pullRequests"]
+                pull_nodes.extend(pulls["nodes"])
+                page_count += 1
+            default_branch = default_branch_ref["name"]
+            default_revision = default_branch_ref["target"]["oid"]
             if re.fullmatch(r"[0-9a-fA-F]{40}", default_revision) is None:
                 raise ValueError("default branch revision is invalid")
             tree = self._json(
@@ -839,7 +847,7 @@ class GitHubTerminalProvider:
             links: dict[str, str] = {}
             remote_prs: list[dict[str, object]] = []
             branches: list[dict[str, str]] = []
-            for pull in pulls["nodes"]:
+            for pull in pull_nodes:
                 number = pull["number"]
                 pr_source_id = f"github_pr:{self.repo}#{number}"
                 head_ref = pull.get("headRefName")
@@ -927,6 +935,23 @@ class GitHubTerminalProvider:
             sources=sources,
             observations=observations,
         )
+
+    def _pull_request_argv(
+        self,
+        *,
+        owner: str,
+        name: str,
+        cursor: str | None = None,
+    ) -> tuple[str, ...]:
+        argv = [
+            "gh", "api", "graphql",
+            "-f", f"query={self._QUERY}",
+            "-F", f"owner={owner}",
+            "-F", f"name={name}",
+        ]
+        if cursor is not None:
+            argv.extend(("-F", f"cursor={cursor}"))
+        return tuple(argv)
 
     def _json(self, argv: Sequence[str]) -> Mapping:
         completed = None

--- a/tests/test_monitor_work_providers.py
+++ b/tests/test_monitor_work_providers.py
@@ -643,6 +643,154 @@ def test_github_terminal_provider_reads_closing_refs_and_remote_archive():
     }
 
 
+def test_github_terminal_provider_aggregates_pull_requests_across_pages():
+    first_page = {
+        "data": {
+            "repository": {
+                "defaultBranchRef": {"name": "main", "target": {"oid": "d" * 40}},
+                "pullRequests": {
+                    "pageInfo": {"hasNextPage": True, "endCursor": "cursor-1"},
+                    "nodes": [
+                        {
+                            "number": 9,
+                            "body": "",
+                            "headRefName": "feature/9-work",
+                            "headRefOid": "e" * 40,
+                            "state": "OPEN",
+                            "mergedAt": None,
+                            "mergeCommit": None,
+                            "closingIssuesReferences": {
+                                "pageInfo": {"hasNextPage": False},
+                                "nodes": [{"number": 7, "state": "OPEN"}],
+                            },
+                        }
+                    ],
+                },
+            }
+        }
+    }
+    second_page = {
+        "data": {
+            "repository": {
+                "defaultBranchRef": {"name": "ignored", "target": {"oid": "f" * 40}},
+                "pullRequests": {
+                    "pageInfo": {"hasNextPage": False, "endCursor": None},
+                    "nodes": [
+                        {
+                            "number": 10,
+                            "body": "",
+                            "headRefName": "feature/10-work",
+                            "headRefOid": "a" * 40,
+                            "state": "CLOSED",
+                            "mergedAt": None,
+                            "mergeCommit": None,
+                            "closingIssuesReferences": {
+                                "pageInfo": {"hasNextPage": False},
+                                "nodes": [{"number": 8, "state": "CLOSED"}],
+                            },
+                        }
+                    ],
+                },
+            }
+        }
+    }
+    runner = SequenceRunner(
+        [
+            _completed(first_page),
+            _completed(second_page),
+            _completed({"truncated": False, "tree": []}),
+        ]
+    )
+
+    result = GitHubTerminalProvider("example/acme", runner=runner).scan()
+
+    assert result.status == "ok"
+    assert result.observations["closing_links"] == {
+        "github_pr:example/acme#9": "github_issue:example/acme#7",
+        "github_pr:example/acme#10": "github_issue:example/acme#8",
+    }
+    assert result.observations["branches"] == [
+        {"source_id": "github_pr:example/acme#9", "ref": "feature/9-work"},
+        {"source_id": "github_pr:example/acme#10", "ref": "feature/10-work"},
+    ]
+    assert result.observations["remote_prs"] == [
+        {
+            "source_id": "github_pr:example/acme#10",
+            "candidate": "a" * 40,
+            "merge_revision": None,
+            "merged_with_merge_commit": False,
+        },
+        {
+            "source_id": "github_pr:example/acme#9",
+            "candidate": "e" * 40,
+            "merge_revision": None,
+            "merged_with_merge_commit": False,
+        },
+    ]
+    assert result.observations["default_branch"] == "main"
+    assert result.observations["default_revision"] == "d" * 40
+    assert runner.calls[0] == (
+        "gh",
+        "api",
+        "graphql",
+        "-f",
+        f"query={GitHubTerminalProvider._QUERY}",
+        "-F",
+        "owner=example",
+        "-F",
+        "name=acme",
+    )
+    assert runner.calls[1] == (
+        "gh",
+        "api",
+        "graphql",
+        "-f",
+        f"query={GitHubTerminalProvider._QUERY}",
+        "-F",
+        "owner=example",
+        "-F",
+        "name=acme",
+        "-F",
+        "cursor=cursor-1",
+    )
+
+
+def test_github_terminal_provider_pull_request_page_limit_is_explicit_failure():
+    runner = SequenceRunner(
+        [
+            _completed(
+                {
+                    "data": {
+                        "repository": {
+                            "defaultBranchRef": {
+                                "name": "main",
+                                "target": {"oid": "d" * 40},
+                            },
+                            "pullRequests": {
+                                "pageInfo": {
+                                    "hasNextPage": True,
+                                    "endCursor": f"cursor-{index}",
+                                },
+                                "nodes": [],
+                            },
+                        }
+                    }
+                }
+            )
+            for index in range(20)
+        ]
+    )
+
+    result = GitHubTerminalProvider("example/acme", runner=runner).scan()
+
+    assert result.status == "degraded"
+    assert result.sources == ()
+    assert result.observations == {}
+    assert result.diagnostics == ("github terminal evidence unavailable",)
+    assert len(runner.calls) == 20
+    assert all(call[:3] == ("gh", "api", "graphql") for call in runner.calls)
+
+
 def test_github_terminal_squash_merge_is_not_a_merge_commit():
     graph = {
         "data": {


### PR DESCRIPTION
Closes #150

## 摘要
- `_QUERY` 增加 `$cursor:String`，`pullRequests(first:100,after:$cursor,...)` 以 while 迴圈聚合全部 nodes；`defaultBranchRef` 取第一頁值
- 20 頁硬上限，超限或 endCursor 異常維持 `pull request pagination incomplete` 顯式失敗，不靜默截斷
- 實機驗收 finding F45：PR #149 為本 repo 第 101 個 PR，觸發 provider 永久 degraded、凍結新 work-item correlation

## 驗證
- [x] 新增兩測試：跨頁聚合成功、頁數超限顯式失敗
- [x] `python3 -m pytest tests/ -q` 全套 1134 passed
- [x] `python3 -m policy_check --repo .`（0 fail）
- [x] `changelog.d/150-terminal-pr-pagination.md` + `CHANGELOG.md [Unreleased]` 同步