### PR TITLE
fix(coordinator): 穩定 CompletionRecord 重播與 workflow provider 韌性

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - **Porcelain CLI UX 規格與 v0.1.0 release plan**：凍結七家族（bootstrap/request/run/inspect/recover/service/init-sample）命令詞彙、exit code 契約、`--json` schema 穩定策略、request_id 顯性化 UX 與 TUI 邊界契約；並定義 v0.1.0 批次順序、release 程序（GitHub Release）、升級回滾與 KPI。
 
 ### Fixed
+- **WorkflowRun completion record 冪等與 provider 韌性**：已完成 run 若因 snapshot/provider revision 漂移而重播 closure，現在會重用既有 CompletionRecord 的揮發 `work_authority` metadata，不再隔離合法舊檔；`WorkflowRegistryProvider` 遇到單筆 completion record 驗證失敗時也只跳過該列，其他 run 的 sources/links 與 validated completions 仍可正常輸出。
 - **porcelain-run-recover CLI JSON 邊界修正**：`cortex recover service restart` 不再暴露會誤導 schema 的 `--json` 旗標，`cortex run work --payload` help 也明確改成要求 JSON 檔案路徑。
 - **porcelain-bootstrap executor preflight**：`bootstrap` preflight 改為檢查實際 executor 登入態（`copilot` / `claude` / `codex`），移除未列入凍結設計的額外 `gh-auth` gate，且 `copilot` 探測不再要求 `--allow-all-tools`。
 - **GitHub terminal PR 分頁**：`GitHubTerminalProvider` 現在會以 cursor 逐頁讀取最多 20 頁 pull requests，完整聚合超過 100 筆的 repo；若頁數仍未收斂則顯式失敗，避免第 101 個 PR 讓 terminal provider 永久 degraded。

--- a/changelog.d/159-completion-record-determinism.md
+++ b/changelog.d/159-completion-record-determinism.md
@@ -1,0 +1,1 @@
+fix(workflow): 已完成 run 的 CompletionRecord 會重用既有揮發 authority metadata，且單筆壞掉的 workflow completion 不再拖垮整個 provider。

--- a/paulsha_cortex/coordinator/completion.py
+++ b/paulsha_cortex/coordinator/completion.py
@@ -14,6 +14,7 @@ from . import verification
 
 COMPLETION_SCHEMA_VERSION = 1
 VALID_REVIEW_POLICIES = frozenset({"required", "not-required"})
+VOLATILE_WORK_AUTHORITY_FIELDS = frozenset({"snapshot_hash", "provider_revision"})
 
 
 def classify_completion(*, exit_code: int, last_jsonl_line: str | None) -> str:
@@ -301,6 +302,28 @@ def _load_json_file(path: str | Path) -> object:
     return json.loads(Path(path).read_text(encoding="utf-8"))
 
 
+def _semantic_work_authority(authority: object) -> dict[str, Any] | None:
+    if authority is None:
+        return None
+    normalized = _normalize_work_authority(authority)
+    return {
+        key: copy.deepcopy(value)
+        for key, value in normalized.items()
+        if key not in VOLATILE_WORK_AUTHORITY_FIELDS
+    }
+
+
+def completion_records_semantically_match(existing: object, incoming: object) -> bool:
+    try:
+        existing_normalized = validate_completion_record(existing)
+        incoming_normalized = validate_completion_record(incoming)
+    except ValueError:
+        return False
+    existing_authority = _semantic_work_authority(existing_normalized.pop("work_authority", None))
+    incoming_authority = _semantic_work_authority(incoming_normalized.pop("work_authority", None))
+    return existing_normalized == incoming_normalized and existing_authority == incoming_authority
+
+
 def _validate_reference(
     *,
     path: object,
@@ -377,15 +400,20 @@ def read_completion_record(
     return normalized
 
 
-def _existing_record_or_raise(path: Path, content_hash: str) -> dict[str, Any]:
+def _existing_record_or_raise(
+    path: Path,
+    content_hash: str,
+    incoming: dict[str, Any],
+) -> dict[str, Any]:
     reason = "existing completion record unreadable"
     try:
         existing = read_completion_record(path)
     except ValueError:
         existing = None
     if existing is not None:
-        if verification.canonical_json_hash(existing) == content_hash:
-            return {"path": str(path), "hash": content_hash, "payload": copy.deepcopy(existing)}
+        existing_hash = verification.canonical_json_hash(existing)
+        if existing_hash == content_hash or completion_records_semantically_match(existing, incoming):
+            return {"path": str(path), "hash": existing_hash, "payload": copy.deepcopy(existing)}
         reason = "content mismatch"
     quarantine_dir = path.parent / "quarantine"
     quarantine_dir.mkdir(parents=True, exist_ok=True)
@@ -407,11 +435,11 @@ def write_completion_record(
     )
     content_hash = verification.canonical_json_hash(normalized)
     if path.exists():
-        return _existing_record_or_raise(path, content_hash)
+        return _existing_record_or_raise(path, content_hash, normalized)
     try:
         verification.atomic_write_json(path, normalized)
     except verification.AtomicWriteConflictError:
-        return _existing_record_or_raise(path, content_hash)
+        return _existing_record_or_raise(path, content_hash, normalized)
     return {"path": str(path), "hash": content_hash, "payload": copy.deepcopy(normalized)}
 
 

--- a/paulsha_cortex/coordinator/delivery.py
+++ b/paulsha_cortex/coordinator/delivery.py
@@ -458,7 +458,12 @@ class ShipOrchestrator:
                 key=lambda item: item["kind"],
             ),
         }
-        if normalized.get("work_authority") != expected_work_authority:
+        expected_record = dict(normalized)
+        expected_record["work_authority"] = expected_work_authority
+        if not completion.completion_records_semantically_match(
+            normalized,
+            expected_record,
+        ):
             raise RuntimeError("completion record WorkAuthority does not match remote delivery")
         record = completion.write_completion_record(
             normalized,
@@ -470,7 +475,10 @@ class ShipOrchestrator:
         )
         if reread["candidate"] != expected_head.lower():
             raise RuntimeError("completion record reread does not match delivered HEAD")
-        if reread.get("work_authority") != expected_work_authority:
+        if not completion.completion_records_semantically_match(
+            reread,
+            expected_record,
+        ):
             raise RuntimeError("completion record reread WorkAuthority mismatch")
         final_facts = replace(facts, completion_record_valid=True)
         final_gate = evaluate_remote_closure(

--- a/paulsha_cortex/monitor/providers.py
+++ b/paulsha_cortex/monitor/providers.py
@@ -275,6 +275,7 @@ class WorkflowRegistryProvider:
                 rows = payload["workflow_runs"]
             sources: list[WorkSource] = []
             links: dict[str, str] = {}
+            diagnostics: list[str] = []
             validated_completions: dict[str, list[dict[str, object]]] = {}
             for row in rows:
                 _validate_workflow_v2_row(row)
@@ -282,6 +283,15 @@ class WorkflowRegistryProvider:
                     continue
                 run_id = _nonempty(row.get("run_id"), "run_id")
                 work_id = _nonempty(row.get("work_id"), "work_id")
+                try:
+                    completion = _validated_workflow_completion(
+                        row, state_path=self.state_path
+                    )
+                except _WorkflowCompletionValidationError as error:
+                    diagnostics.append(
+                        f"workflow completion skipped: {run_id}: {error}"
+                    )
+                    continue
                 status = _nonempty(row.get("status", row.get("current_phase")), "status")
                 source_id = f"workflow_run:{self.repo}:{run_id}"
                 sources.append(
@@ -307,9 +317,6 @@ class WorkflowRegistryProvider:
                         f"github_openspec:{self.repo}:{ref}:archived",
                     ):
                         _add_workflow_link(links, canonical_id, work_id)
-                completion = _validated_workflow_completion(
-                    row, state_path=self.state_path
-                )
                 if completion is not None:
                     validated_completions.setdefault(work_id, []).append(completion)
         except (OSError, UnicodeError, json.JSONDecodeError, ValueError) as error:
@@ -329,7 +336,7 @@ class WorkflowRegistryProvider:
             last_attempt_at=attempted_at,
             last_success_at=attempted_at,
             revision=f"registry-sha256:{_digest((raw,))}",
-            diagnostics=(),
+            diagnostics=tuple(diagnostics),
             sources=tuple(sources),
             observations={
                 "workflow_links": links,
@@ -363,6 +370,10 @@ _WORKFLOW_V2_OPTIONAL_ROW_KEYS = frozenset(
         "planning_authority", "planning_source_revision",
     }
 )
+
+
+class _WorkflowCompletionValidationError(ValueError):
+    """Bad completion contents for one row; provider may skip that row only."""
 
 
 def _validate_workflow_v1_root(payload: Mapping) -> None:
@@ -523,7 +534,10 @@ def _validated_workflow_completion(
         raise ValueError("completion_record_path escapes coordinator completion root") from error
     from paulsha_cortex.coordinator.completion import read_completion_record
 
-    record = read_completion_record(resolved, expected_hash=expected_hash.lower())
+    try:
+        record = read_completion_record(resolved, expected_hash=expected_hash.lower())
+    except ValueError as error:
+        raise _WorkflowCompletionValidationError(str(error)) from error
     normalized_sources = dict(source_revisions)
     authority_record = record.get("work_authority")
     if isinstance(authority_record, Mapping):

--- a/tests/test_delivery_orchestrator.py
+++ b/tests/test_delivery_orchestrator.py
@@ -460,6 +460,139 @@ def test_remote_closure_reads_and_validates_completion_record(
     )["candidate"] == HEAD1
 
 
+def test_remote_closure_reuses_existing_completion_record_when_authority_metadata_drifts(
+    tmp_path: Path,
+) -> None:
+    authority = _authority(tmp_path, last_success=0)
+    verification_ref = verification.write_verification_evidence(
+        {
+            "schema_version": verification.VERIFICATION_SCHEMA_VERSION,
+            "slice_id": "ship-review",
+            "candidate": HEAD1,
+            "status": "reviewing",
+            "summary": "ok",
+            "details": {"ok": True},
+        },
+        coordinator_root=tmp_path,
+    )
+    foreign_payload = json.loads(Path(_foreign_review(tmp_path).path).read_text())
+    review_ref = review.write_gate_evaluation(foreign_payload, coordinator_root=tmp_path)
+    trusted_evidence_refs = [
+        {"kind": "preflight", "ref": "tree:" + HEAD2, "hash": "5" * 64},
+        {"kind": "foreign_review", "ref": review_ref["path"], "hash": review_ref["hash"]},
+        {"kind": "copilot", "ref": "github-review:9", "hash": "6" * 64},
+        {"kind": "merge_authorization", "ref": "run:run-1", "hash": "7" * 64},
+    ]
+    completion_payload = {
+        "schema_version": completion.COMPLETION_SCHEMA_VERSION,
+        "slice_id": "ship-review",
+        "spec_hash": "1" * 64,
+        "plan_hash": "2" * 64,
+        "verification_hash": "3" * 64,
+        "builder_job_id": "builder-1",
+        "reviewer_job_id": "reviewer-1",
+        "dispatch_base": HEAD3,
+        "candidate": HEAD1,
+        "target_branch": "main",
+        "target_remote": "origin",
+        "target_ref": "refs/remotes/origin/main",
+        "target_ref_sha": HEAD2,
+        "verification_evidence_path": verification_ref["path"],
+        "verification_evidence_hash": verification_ref["hash"],
+        "review_policy": "required",
+        "docs_class": "code",
+        "review_evaluation_path": review_ref["path"],
+        "review_evaluation_hash": review_ref["hash"],
+        "completed_at": "2026-07-17T00:00:00+00:00",
+        "work_authority": {
+            "repo": authority.repo,
+            "work_id": authority.work_id,
+            "snapshot_hash": authority.snapshot_hash,
+            "provider_id": authority.github_provider_id,
+            "provider_revision": authority.github_provider_revision,
+            "source_revisions": list(authority.source_revisions),
+            "mapped_issues": list(authority.mapped_issues),
+            "mapped_prs": list(authority.mapped_prs),
+            "mapped_openspec": list(authority.mapped_openspec),
+            "mapped_todo_paths": list(authority.mapped_todo_paths),
+            "pr_number": 7,
+            "change": "work",
+            "todo_paths": ["docs/todo.md"],
+            "merge_commit": HEAD2,
+            "run_id": "run-1",
+            "workflow_step_ids": ["step-build", "step-review", "step-ship"],
+            "trusted_evidence_refs": trusted_evidence_refs,
+        },
+    }
+
+    class GitHub:
+        def fetch_remote_closure(self, **kwargs):
+            return RemoteClosureFacts(
+                merge_commit=HEAD2,
+                pr_head=HEAD1,
+                merge_parents=(HEAD3, HEAD1),
+                default_head=HEAD2,
+                merge_is_ancestor=True,
+                merge_is_merge_commit=True,
+                issue_states={14: "closed"},
+                active_openspec_absent=True,
+                archive_present=True,
+                todo_complete=True,
+                todo_revisions={"docs/todo.md": HEAD3},
+                completion_record_valid=False,
+            )
+
+    orchestrator = ShipOrchestrator(github=GitHub(), now=lambda: 0)
+    first = orchestrator.verify_remote_closure(
+        repo="acme/demo",
+        pr_number=7,
+        change="work",
+        authority=authority,
+        todo_paths=("docs/todo.md",),
+        expected_head=HEAD1,
+        completion_payload=completion_payload,
+        run_id="run-1",
+        workflow_step_ids=("step-build", "step-review", "step-ship"),
+        trusted_evidence_refs=tuple(trusted_evidence_refs),
+        coordinator_root=tmp_path,
+    )
+    replay_authority = authority.__class__._verified(
+        repo=authority.repo,
+        work_id=authority.work_id,
+        mapped_issues=authority.mapped_issues,
+        mapped_prs=authority.mapped_prs,
+        mapped_openspec=authority.mapped_openspec,
+        mapped_todo_paths=authority.mapped_todo_paths,
+        confirmed_todo=authority.confirmed_todo,
+        auto_label=authority.auto_label,
+        source_revisions=authority.source_revisions,
+        provider_id=authority.github_provider_id,
+        provider_revision="github-rev-2",
+        last_success_epoch=authority.github_last_success_epoch,
+        snapshot_hash="9" * 64,
+    )
+
+    second = orchestrator.verify_remote_closure(
+        repo="acme/demo",
+        pr_number=7,
+        change="work",
+        authority=replay_authority,
+        todo_paths=("docs/todo.md",),
+        expected_head=HEAD1,
+        completion_payload=completion.read_completion_record(
+            first.completion_record["path"],
+            expected_hash=first.completion_record["hash"],
+        ),
+        run_id="run-1",
+        workflow_step_ids=("step-build", "step-review", "step-ship"),
+        trusted_evidence_refs=tuple(trusted_evidence_refs),
+        coordinator_root=tmp_path,
+    )
+
+    assert second.completion_record == first.completion_record
+    assert not list((tmp_path / "evidence" / "completion" / "quarantine").glob("*.json"))
+
+
 def test_remote_closure_rejects_completion_bound_to_another_work(tmp_path: Path) -> None:
     authority = _authority(tmp_path, last_success=0)
 

--- a/tests/test_monitor_work_providers.py
+++ b/tests/test_monitor_work_providers.py
@@ -377,6 +377,90 @@ def test_workflow_registry_rejects_cross_work_completion_replay(monkeypatch, tmp
     assert result.observations["validated_completions"] == {}
 
 
+def test_workflow_registry_skips_broken_completion_row_and_keeps_other_sources(
+    monkeypatch, tmp_path
+):
+    state = tmp_path / "workflows.json"
+    broken = tmp_path / "evidence/completion/broken.json"
+    valid = tmp_path / "evidence/completion/valid.json"
+    broken.parent.mkdir(parents=True)
+    broken.write_text("{}", encoding="utf-8")
+    valid.write_text("{}", encoding="utf-8")
+
+    def read_record(path, *, expected_hash=None):
+        if Path(path) == broken:
+            raise ValueError("completion record unreadable")
+        return {
+            "candidate": "b" * 40,
+            "work_id": "good-work",
+            "run_id": "run-good",
+            "source_revisions": {"github_pr:example/acme#10": "p" * 40},
+            "merge_revision": "d" * 40,
+        }
+
+    monkeypatch.setattr(
+        "paulsha_cortex.coordinator.completion.read_completion_record",
+        read_record,
+    )
+    state.write_text(
+        json.dumps(
+            {
+                "schema_version": 2,
+                "sequence": 8,
+                "legacy_records": {"jobs": [], "slices": []},
+                "workflow_runs": [
+                    {
+                        "run_id": "run-bad",
+                        "repo": "example/acme",
+                        "work_id": "bad-work",
+                        "status": "completed",
+                        "completion_record_path": str(broken),
+                        "completion_record_hash": "b" * 64,
+                        "completion_record_revision": "a" * 40,
+                        "source_revisions": {"github_pr:example/acme#9": "p" * 40},
+                        "pr_candidate": "a" * 40,
+                        "merge_revision": "d" * 40,
+                        "pr_refs": ["example/acme#9"],
+                    },
+                    {
+                        "run_id": "run-good",
+                        "repo": "example/acme",
+                        "work_id": "good-work",
+                        "status": "completed",
+                        "completion_record_path": str(valid),
+                        "completion_record_hash": "c" * 64,
+                        "completion_record_revision": "b" * 40,
+                        "source_revisions": {"github_pr:example/acme#10": "p" * 40},
+                        "pr_candidate": "b" * 40,
+                        "merge_revision": "d" * 40,
+                        "pr_refs": ["example/acme#10"],
+                    },
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = WorkflowRegistryProvider("example/acme", state_path=state).scan()
+
+    assert result.status == "ok"
+    assert [source.ref for source in result.sources] == ["run-good"]
+    assert result.observations["workflow_links"] == {
+        "workflow_run:example/acme:run-good": "good-work",
+        "github_pr:example/acme#10": "good-work",
+    }
+    assert result.observations["validated_completions"] == {
+        "good-work": [
+            {
+                "run_id": "run-good",
+                "pr_candidate": "b" * 40,
+                "merge_revision": "d" * 40,
+                "source_revisions": {"github_pr:example/acme#10": "p" * 40},
+            }
+        ]
+    }
+
+
 def test_workflow_registry_validates_refs_and_emits_canonical_authority_edges(tmp_path):
     state = tmp_path / "workflows.json"
     state.write_text(


### PR DESCRIPTION
Closes #159

## 摘要
- done run 的 CompletionRecord 在 `work_authority.snapshot_hash`/`provider_revision` 漂移時，以語意一致為準重用既有 record（新增 `completion_records_semantically_match`），不再因揮發 metadata 產生 conflict/quarantine
- `WorkflowRegistryProvider.scan` 對單筆 completion record 讀取失敗改為跳過該 row（記 diagnostic），其他 run 的 sources/links/validated completions 照常輸出，不再整體 degraded
- `ShipOrchestrator` 的 WorkAuthority 比對同步改用語意比對
- 實機驗收 finding F49：B6 交付因 B5 completion 揮發 metadata 漂移被隔離、workflow provider 全域 degraded 而卡死

## 驗證
- [x] 新增回歸測試：done run completion 在 metadata 漂移後重播不衝突；單筆 completion 損毀時 provider 仍供其他 run 的 sources/links
- [x] `python3 -m pytest tests/ -q` 全套 1185 passed
- [x] `python3 -m policy_check --repo .`（0 fail，僅既有 R-22 advisory）
- [x] `changelog.d/159-completion-record-determinism.md` + `CHANGELOG.md [Unreleased]` 同步