### PR TITLE
fix(coordinator): 固定已完成 CompletionRecord 並強化 provider 缺檔韌性

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - **Porcelain CLI UX 規格與 v0.1.0 release plan**：凍結七家族（bootstrap/request/run/inspect/recover/service/init-sample）命令詞彙、exit code 契約、`--json` schema 穩定策略、request_id 顯性化 UX 與 TUI 邊界契約；並定義 v0.1.0 批次順序、release 程序（GitHub Release）、升級回滾與 KPI。
 
 ### Fixed
+- **CompletionRecord immutable 重用與 provider 缺檔韌性**：已完成/已合併 run 的 CompletionRecord 一旦已有可驗證舊檔，後續 reconciliation 會直接重用既有 record，不再因 `work_authority.source_revisions` 等合法漂移欄位重推導後隔離舊檔；`WorkflowRegistryProvider` 遇到缺失、symlink、越界或內容損毀的 completion 檔時，也只跳過該列並留下 diagnostic，不再讓整個 provider degraded。
 - **WorkflowRun completion record 冪等與 provider 韌性**：已完成 run 若因 snapshot/provider revision 漂移而重播 closure，現在會重用既有 CompletionRecord 的揮發 `work_authority` metadata，不再隔離合法舊檔；`WorkflowRegistryProvider` 遇到單筆 completion record 驗證失敗時也只跳過該列，其他 run 的 sources/links 與 validated completions 仍可正常輸出。
 - **porcelain-run-recover CLI JSON 邊界修正**：`cortex recover service restart` 不再暴露會誤導 schema 的 `--json` 旗標，`cortex run work --payload` help 也明確改成要求 JSON 檔案路徑。
 - **porcelain-bootstrap executor preflight**：`bootstrap` preflight 改為檢查實際 executor 登入態（`copilot` / `claude` / `codex`），移除未列入凍結設計的額外 `gh-auth` gate，且 `copilot` 探測不再要求 `--allow-all-tools`。

--- a/changelog.d/163-completion-immutable-provider-resilience.md
+++ b/changelog.d/163-completion-immutable-provider-resilience.md
@@ -1,0 +1,1 @@
+fix(workflow): 已完成 run 的 CompletionRecord 一旦落盤即固定重用既有有效紀錄，不再因 authority source revision 漂移被隔離；缺失或損毀的 completion 檔也只會跳過單列，不再讓整個 workflow provider degraded。

--- a/paulsha_cortex/coordinator/completion.py
+++ b/paulsha_cortex/coordinator/completion.py
@@ -412,9 +412,7 @@ def _existing_record_or_raise(
         existing = None
     if existing is not None:
         existing_hash = verification.canonical_json_hash(existing)
-        if existing_hash == content_hash or completion_records_semantically_match(existing, incoming):
-            return {"path": str(path), "hash": existing_hash, "payload": copy.deepcopy(existing)}
-        reason = "content mismatch"
+        return {"path": str(path), "hash": existing_hash, "payload": copy.deepcopy(existing)}
     quarantine_dir = path.parent / "quarantine"
     quarantine_dir.mkdir(parents=True, exist_ok=True)
     quarantine_path = quarantine_dir / f"{path.stem}-{uuid4().hex}.json"

--- a/paulsha_cortex/monitor/providers.py
+++ b/paulsha_cortex/monitor/providers.py
@@ -523,20 +523,20 @@ def _validated_workflow_completion(
     ):
         if not isinstance(value, str) or re.fullmatch(r"[0-9a-fA-F]{40}", value) is None:
             raise ValueError(f"{field} must be a 40-char commit SHA")
-    path = Path(record_path)
-    if path.is_symlink():
-        raise ValueError("completion_record_path must not be a symlink")
-    resolved = path.resolve(strict=True)
-    allowed_root = (state_path.parent / "evidence" / "completion").resolve()
     try:
-        resolved.relative_to(allowed_root)
-    except ValueError as error:
-        raise ValueError("completion_record_path escapes coordinator completion root") from error
-    from paulsha_cortex.coordinator.completion import read_completion_record
+        path = Path(record_path)
+        if path.is_symlink():
+            raise ValueError("completion_record_path must not be a symlink")
+        resolved = path.resolve(strict=True)
+        allowed_root = (state_path.parent / "evidence" / "completion").resolve()
+        try:
+            resolved.relative_to(allowed_root)
+        except ValueError as error:
+            raise ValueError("completion_record_path escapes coordinator completion root") from error
+        from paulsha_cortex.coordinator.completion import read_completion_record
 
-    try:
         record = read_completion_record(resolved, expected_hash=expected_hash.lower())
-    except ValueError as error:
+    except (OSError, ValueError) as error:
         raise _WorkflowCompletionValidationError(str(error)) from error
     normalized_sources = dict(source_revisions)
     authority_record = record.get("work_authority")

--- a/tests/test_coordinator_completion_record.py
+++ b/tests/test_coordinator_completion_record.py
@@ -65,8 +65,9 @@ def _completion_payload(
     docs_class: str,
     reviewer_job_id: str | None,
     review_eval_ref: dict | None,
+    work_authority: dict | None = None,
 ) -> dict:
-    return {
+    payload = {
         "schema_version": completion.COMPLETION_SCHEMA_VERSION,
         "slice_id": slice_id,
         "spec_hash": "1" * 64,
@@ -88,6 +89,9 @@ def _completion_payload(
         "review_evaluation_hash": None if review_eval_ref is None else review_eval_ref["hash"],
         "completed_at": "2026-07-12T00:00:00+00:00",
     }
+    if work_authority is not None:
+        payload["work_authority"] = work_authority
+    return payload
 
 
 def _write_manifest(
@@ -338,6 +342,96 @@ class CompletionRecordReadAndSatisfactionTests(unittest.TestCase):
             verification.atomic_write_json(record_path, normalized)
             with self.assertRaisesRegex(ValueError, "verification_evidence_path"):
                 completion.read_completion_record(record_path, expected_hash=record_hash)
+
+    def test_write_completion_record_reuses_existing_valid_record_despite_authority_drift(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            root = Path(d)
+            candidate = "b" * 40
+            verification_ref = _write_verification(
+                root, slice_id="slice-a", candidate=candidate, status="reviewing"
+            )
+            review_eval_ref = _write_review_eval(root, slice_id="slice-a", candidate=candidate)
+            first = completion.write_completion_record(
+                _completion_payload(
+                    slice_id="slice-a",
+                    candidate=candidate,
+                    target_sha="c" * 40,
+                    verification_ref=verification_ref,
+                    review_policy="required",
+                    docs_class="code",
+                    reviewer_job_id="reviewer-1",
+                    review_eval_ref=review_eval_ref,
+                    work_authority={
+                        "repo": "acme/demo",
+                        "work_id": "work",
+                        "snapshot_hash": "0" * 64,
+                        "provider_id": "github",
+                        "provider_revision": "github-rev-1",
+                        "source_revisions": ["issue:14@tree-main-1"],
+                        "mapped_issues": [14],
+                        "mapped_prs": [7],
+                        "mapped_openspec": ["work"],
+                        "mapped_todo_paths": ["docs/todo.md"],
+                        "pr_number": 7,
+                        "change": "work",
+                        "todo_paths": ["docs/todo.md"],
+                        "merge_commit": "a" * 40,
+                        "run_id": "run-1",
+                        "workflow_step_ids": ["step-ship"],
+                        "trusted_evidence_refs": [
+                            {"kind": "preflight", "ref": "tree:" + "b" * 40, "hash": "1" * 64},
+                            {"kind": "foreign_review", "ref": "/review.json", "hash": "2" * 64},
+                            {"kind": "copilot", "ref": "/delivery-review.json", "hash": "3" * 64},
+                            {"kind": "merge_authorization", "ref": "/authorization.json", "hash": "4" * 64},
+                        ],
+                    },
+                ),
+                coordinator_root=root,
+            )
+
+            second = completion.write_completion_record(
+                _completion_payload(
+                    slice_id="slice-a",
+                    candidate=candidate,
+                    target_sha="c" * 40,
+                    verification_ref=verification_ref,
+                    review_policy="required",
+                    docs_class="code",
+                    reviewer_job_id="reviewer-1",
+                    review_eval_ref=review_eval_ref,
+                    work_authority={
+                        "repo": "acme/demo",
+                        "work_id": "work",
+                        "snapshot_hash": "f" * 64,
+                        "provider_id": "github",
+                        "provider_revision": "github-rev-2",
+                        "source_revisions": ["issue:14@tree-main-2"],
+                        "mapped_issues": [14],
+                        "mapped_prs": [7],
+                        "mapped_openspec": ["work"],
+                        "mapped_todo_paths": ["docs/todo.md"],
+                        "pr_number": 7,
+                        "change": "work",
+                        "todo_paths": ["docs/todo.md"],
+                        "merge_commit": "a" * 40,
+                        "run_id": "run-1",
+                        "workflow_step_ids": ["step-ship"],
+                        "trusted_evidence_refs": [
+                            {"kind": "preflight", "ref": "tree:" + "b" * 40, "hash": "1" * 64},
+                            {"kind": "foreign_review", "ref": "/review.json", "hash": "2" * 64},
+                            {"kind": "copilot", "ref": "/delivery-review.json", "hash": "3" * 64},
+                            {"kind": "merge_authorization", "ref": "/authorization.json", "hash": "4" * 64},
+                        ],
+                    },
+                ),
+                coordinator_root=root,
+            )
+
+            self.assertEqual(second["path"], first["path"])
+            self.assertEqual(second["hash"], first["hash"])
+            self.assertEqual(second["payload"], first["payload"])
+            quarantine_dir = root / "evidence" / "completion" / "quarantine"
+            self.assertFalse(quarantine_dir.exists())
 
     def test_load_completion_requires_completed_slice_state_and_matching_hashes(self) -> None:
         with tempfile.TemporaryDirectory() as d:

--- a/tests/test_monitor_work_providers.py
+++ b/tests/test_monitor_work_providers.py
@@ -461,6 +461,93 @@ def test_workflow_registry_skips_broken_completion_row_and_keeps_other_sources(
     }
 
 
+def test_workflow_registry_missing_completion_file_skips_row_without_degrading(
+    monkeypatch, tmp_path
+):
+    state = tmp_path / "workflows.json"
+    missing = tmp_path / "evidence/completion/missing.json"
+    valid = tmp_path / "evidence/completion/valid.json"
+    valid.parent.mkdir(parents=True)
+    valid.write_text("{}", encoding="utf-8")
+
+    def read_record(path, *, expected_hash=None):
+        assert expected_hash == "c" * 64
+        assert Path(path) == valid
+        return {
+            "candidate": "b" * 40,
+            "work_id": "good-work",
+            "run_id": "run-good",
+            "source_revisions": {"github_pr:example/acme#10": "p" * 40},
+            "merge_revision": "d" * 40,
+        }
+
+    monkeypatch.setattr(
+        "paulsha_cortex.coordinator.completion.read_completion_record",
+        read_record,
+    )
+    state.write_text(
+        json.dumps(
+            {
+                "schema_version": 2,
+                "sequence": 8,
+                "legacy_records": {"jobs": [], "slices": []},
+                "workflow_runs": [
+                    {
+                        "run_id": "run-missing",
+                        "repo": "example/acme",
+                        "work_id": "missing-work",
+                        "status": "completed",
+                        "completion_record_path": str(missing),
+                        "completion_record_hash": "b" * 64,
+                        "completion_record_revision": "a" * 40,
+                        "source_revisions": {"github_pr:example/acme#9": "p" * 40},
+                        "pr_candidate": "a" * 40,
+                        "merge_revision": "d" * 40,
+                        "pr_refs": ["example/acme#9"],
+                    },
+                    {
+                        "run_id": "run-good",
+                        "repo": "example/acme",
+                        "work_id": "good-work",
+                        "status": "completed",
+                        "completion_record_path": str(valid),
+                        "completion_record_hash": "c" * 64,
+                        "completion_record_revision": "b" * 40,
+                        "source_revisions": {"github_pr:example/acme#10": "p" * 40},
+                        "pr_candidate": "b" * 40,
+                        "merge_revision": "d" * 40,
+                        "pr_refs": ["example/acme#10"],
+                    },
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = WorkflowRegistryProvider("example/acme", state_path=state).scan()
+
+    assert result.status == "ok"
+    assert [source.ref for source in result.sources] == ["run-good"]
+    assert any(
+        diagnostic.startswith("workflow completion skipped: run-missing:")
+        for diagnostic in result.diagnostics
+    )
+    assert result.observations["workflow_links"] == {
+        "workflow_run:example/acme:run-good": "good-work",
+        "github_pr:example/acme#10": "good-work",
+    }
+    assert result.observations["validated_completions"] == {
+        "good-work": [
+            {
+                "run_id": "run-good",
+                "pr_candidate": "b" * 40,
+                "merge_revision": "d" * 40,
+                "source_revisions": {"github_pr:example/acme#10": "p" * 40},
+            }
+        ]
+    }
+
+
 def test_workflow_registry_validates_refs_and_emits_canonical_authority_edges(tmp_path):
     state = tmp_path / "workflows.json"
     state.write_text(
@@ -663,7 +750,12 @@ def test_workflow_registry_rejects_completion_record_outside_safe_root(tmp_path)
 
     result = WorkflowRegistryProvider("example/acme", state_path=state).scan()
 
-    assert result.status == "degraded"
+    assert result.status == "ok"
+    assert result.sources == ()
+    assert result.observations["validated_completions"] == {}
+    assert result.diagnostics == (
+        "workflow completion skipped: run-1: completion_record_path escapes coordinator completion root",
+    )
 
 
 def test_github_terminal_provider_reads_closing_refs_and_remote_archive():


### PR DESCRIPTION
Closes #163

## 摘要（#159 殘留缺口的補完）
- **Gap A（根因）**：`_existing_record_or_raise` 現在把磁碟上已存在且可讀的 CompletionRecord 視為 immutable 錨點直接重用，不再對 `work_authority.source_revisions` 等隨 main 前進合法漂移的欄位做相等比對而隔離 done/merged run。僅真正損毀（不可讀）才隔離。
- **Gap B**：`_validated_workflow_completion` 的檔案存取段（symlink/`resolve(strict=True)`/越界/read）皆降為 row 級 `_WorkflowCompletionValidationError`，completion 檔缺失/損毀時 provider 跳過該 row 續跑、記 diagnostic，不再整體 degraded。結構性 registry 錯誤仍整體 degrade。
- 實機驗收 F49b：B6 completion 因 source_revisions 漂移反覆被隔離、檔案缺失致 workflow provider degraded，擋住 B7 交付關聯。

## 驗證
- [x] 新增回歸測試：immutable reuse（source_revisions 漂移不隔離）、provider 缺檔仍供其他 row sources/links
- [x] `python3 -m pytest tests/ -q` 全套 1187 passed
- [x] `python3 -m policy_check --repo .`（0 fail）
- [x] `changelog.d/163-*.md` + `CHANGELOG.md [Unreleased]` 同步