### PR TITLE
fix(coordinator): ship 容忍 work_authority.source_revisions 漂移

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - **Porcelain CLI UX 規格與 v0.1.0 release plan**：凍結七家族（bootstrap/request/run/inspect/recover/service/init-sample）命令詞彙、exit code 契約、`--json` schema 穩定策略、request_id 顯性化 UX 與 TUI 邊界契約；並定義 v0.1.0 批次順序、release 程序（GitHub Release）、升級回滾與 KPI。
 
 ### Fixed
+- **ship source_revisions 漂移容忍**：`completion_records_semantically_match` 現在把 `work_authority.source_revisions` 視為揮發欄位，讓跨多次 main 前進的長期 in-flight run 在 ship 時不再因 source_revisions 合法漂移誤判 `completion record reread WorkAuthority mismatch`。
 - **CompletionRecord immutable 重用與 provider 缺檔韌性**：已完成/已合併 run 的 CompletionRecord 一旦已有可驗證舊檔，後續 reconciliation 會直接重用既有 record，不再因 `work_authority.source_revisions` 等合法漂移欄位重推導後隔離舊檔；`WorkflowRegistryProvider` 遇到缺失、symlink、越界或內容損毀的 completion 檔時，也只跳過該列並留下 diagnostic，不再讓整個 provider degraded。
 - **WorkflowRun completion record 冪等與 provider 韌性**：已完成 run 若因 snapshot/provider revision 漂移而重播 closure，現在會重用既有 CompletionRecord 的揮發 `work_authority` metadata，不再隔離合法舊檔；`WorkflowRegistryProvider` 遇到單筆 completion record 驗證失敗時也只跳過該列，其他 run 的 sources/links 與 validated completions 仍可正常輸出。
 - **porcelain-run-recover CLI JSON 邊界修正**：`cortex recover service restart` 不再暴露會誤導 schema 的 `--json` 旗標，`cortex run work --payload` help 也明確改成要求 JSON 檔案路徑。

--- a/changelog.d/165-ship-source-revision-drift.md
+++ b/changelog.d/165-ship-source-revision-drift.md
@@ -1,0 +1,1 @@
+- **ship source_revisions 漂移容忍**：`completion_records_semantically_match` 現在把 `work_authority.source_revisions` 視為揮發欄位，讓跨多次 main 前進的長期 in-flight run 在 ship 時不再因 source_revisions 合法漂移誤判 `completion record reread WorkAuthority mismatch`；candidate/merge_commit/mapped refs 等仍精確比對。

--- a/paulsha_cortex/coordinator/completion.py
+++ b/paulsha_cortex/coordinator/completion.py
@@ -14,7 +14,12 @@ from . import verification
 
 COMPLETION_SCHEMA_VERSION = 1
 VALID_REVIEW_POLICIES = frozenset({"required", "not-required"})
-VOLATILE_WORK_AUTHORITY_FIELDS = frozenset({"snapshot_hash", "provider_revision"})
+# source_revisions（openspec/todo/spec 綁 default-branch tree SHA）隨 main 前進合法漂移，
+# 對 completion 語意（run/candidate/verdict/mapped refs/merge_commit）無影響，故納入揮發集，
+# 讓長期 in-flight run 的 ship work_authority 比對不因此漂移誤判 mismatch。
+VOLATILE_WORK_AUTHORITY_FIELDS = frozenset(
+    {"snapshot_hash", "provider_revision", "source_revisions"}
+)
 
 
 def classify_completion(*, exit_code: int, last_jsonl_line: str | None) -> str:

--- a/tests/test_coordinator_completion_record.py
+++ b/tests/test_coordinator_completion_record.py
@@ -433,6 +433,58 @@ class CompletionRecordReadAndSatisfactionTests(unittest.TestCase):
             quarantine_dir = root / "evidence" / "completion" / "quarantine"
             self.assertFalse(quarantine_dir.exists())
 
+    def test_semantic_match_tolerates_source_revisions_drift(self) -> None:
+        # ship 對長期 in-flight run 的 work_authority 比對必須容忍 source_revisions
+        # 隨 main 前進的合法漂移（只有它不同時仍視為語意相同），其餘語意欄位仍須一致。
+        def _payload(source_revisions: list[str]) -> dict:
+            return _completion_payload(
+                slice_id="slice-a",
+                candidate="b" * 40,
+                target_sha="c" * 40,
+                verification_ref={"path": "/verification.json", "hash": "3" * 64},
+                review_policy="required",
+                docs_class="code",
+                reviewer_job_id="reviewer-1",
+                review_eval_ref={"path": "/review-eval.json", "hash": "9" * 64},
+                work_authority={
+                    "repo": "acme/demo",
+                    "work_id": "work",
+                    "snapshot_hash": "0" * 64,
+                    "provider_id": "github",
+                    "provider_revision": "github-rev-1",
+                    "source_revisions": source_revisions,
+                    "mapped_issues": [14],
+                    "mapped_prs": [7],
+                    "mapped_openspec": ["work"],
+                    "mapped_todo_paths": ["docs/todo.md"],
+                    "pr_number": 7,
+                    "change": "work",
+                    "todo_paths": ["docs/todo.md"],
+                    "merge_commit": "a" * 40,
+                    "run_id": "run-1",
+                    "workflow_step_ids": ["step-ship"],
+                    "trusted_evidence_refs": [
+                        {"kind": "preflight", "ref": "tree:" + "b" * 40, "hash": "1" * 64},
+                        {"kind": "foreign_review", "ref": "/review.json", "hash": "2" * 64},
+                        {"kind": "copilot", "ref": "/delivery-review.json", "hash": "3" * 64},
+                        {"kind": "merge_authorization", "ref": "/authorization.json", "hash": "4" * 64},
+                    ],
+                },
+            )
+
+        existing = _payload(["openspec:work@tree-main-1"])
+        incoming = _payload(["openspec:work@tree-main-2"])
+        self.assertTrue(
+            completion.completion_records_semantically_match(existing, incoming)
+        )
+
+        # 真正的語意差異（mapped_prs）仍必須被判為不相符。
+        divergent = _payload(["openspec:work@tree-main-1"])
+        divergent["work_authority"]["mapped_prs"] = [8]
+        self.assertFalse(
+            completion.completion_records_semantically_match(existing, divergent)
+        )
+
     def test_load_completion_requires_completed_slice_state_and_matching_hashes(self) -> None:
         with tempfile.TemporaryDirectory() as d:
             root = Path(d)


### PR DESCRIPTION
Closes #165

## 摘要
- 把 `source_revisions` 加入 `completion.py::VOLATILE_WORK_AUTHORITY_FIELDS`
- 跨多次 main 前進的長期 in-flight run，其 completion_payload 的 `source_revisions`（openspec/todo/spec 綁 default-branch tree SHA）與 ship 時當前 authority 漂移，導致 `completion record reread WorkAuthority mismatch` 卡住交付
- F49b（#163）後 `completion_records_semantically_match` 僅由 `delivery.py` 兩處 ship 檢查呼叫，故 blast radius 僅限 ship 比對；candidate/merge_commit/mapped_prs/mapped_issues 等仍精確比對
- 實機驗收 F49c：B7 porcelain-init-sample 跨約 7 次 merge 後 ship 反覆卡此錯誤

## 驗證
- [x] 新增測試：僅 source_revisions 不同時 semantic match 通過；mapped_prs 差異仍判不符
- [x] `python3 -m pytest tests/test_delivery_orchestrator.py tests/test_coordinator_completion_record.py tests/test_work_bridge.py -q`（45 passed）
- [x] `python3 -m policy_check --repo .`（0 fail）
- [x] fragment + `CHANGELOG.md [Unreleased]` 同步