### PR TITLE
fix(packaging): pyproject 補 readme 使 dist 通過 twine check --strict

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ build/
 # dogfood runtime 殘留（daemon cwd=repo root 時產生）
 /runtime/
 /.dogfood-specs/
+dist/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - **Porcelain CLI UX 規格與 v0.1.0 release plan**：凍結七家族（bootstrap/request/run/inspect/recover/service/init-sample）命令詞彙、exit code 契約、`--json` schema 穩定策略、request_id 顯性化 UX 與 TUI 邊界契約；並定義 v0.1.0 批次順序、release 程序（GitHub Release）、升級回滾與 KPI。
 
 ### Fixed
+- **pyproject 補 readme**：`[project]` 宣告 `readme = "README.md"`，使 build 產物通過 `twine check --strict`。
 - **ship source_revisions 漂移容忍**：`completion_records_semantically_match` 現在把 `work_authority.source_revisions` 視為揮發欄位，讓跨多次 main 前進的長期 in-flight run 在 ship 時不再因 source_revisions 合法漂移誤判 `completion record reread WorkAuthority mismatch`。
 - **CompletionRecord immutable 重用與 provider 缺檔韌性**：已完成/已合併 run 的 CompletionRecord 一旦已有可驗證舊檔，後續 reconciliation 會直接重用既有 record，不再因 `work_authority.source_revisions` 等合法漂移欄位重推導後隔離舊檔；`WorkflowRegistryProvider` 遇到缺失、symlink、越界或內容損毀的 completion 檔時，也只跳過該列並留下 diagnostic，不再讓整個 provider degraded。
 - **WorkflowRun completion record 冪等與 provider 韌性**：已完成 run 若因 snapshot/provider revision 漂移而重播 closure，現在會重用既有 CompletionRecord 的揮發 `work_authority` metadata，不再隔離合法舊檔；`WorkflowRegistryProvider` 遇到單筆 completion record 驗證失敗時也只跳過該列，其他 run 的 sources/links 與 validated completions 仍可正常輸出。

--- a/changelog.d/172-pyproject-readme.md
+++ b/changelog.d/172-pyproject-readme.md
@@ -1,0 +1,1 @@
+- **pyproject 補 readme**：`[project]` 宣告 `readme = "README.md"`，使 `python -m build` 產物帶 long_description、通過 `twine check --strict`（B9 release pipeline build gate 依賴此）。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ name = "paulsha-cortex"
 dynamic = ["version"]
 requires-python = ">=3.10"
 description = "agent 治理平面：manager 派工 + persona 護欄 + control 檔案契約"
+readme = "README.md"
 dependencies = ["PyYAML>=6"]
 
 [project.scripts]


### PR DESCRIPTION
Closes #172

## 摘要
- `pyproject.toml [project]` 補 `readme = "README.md"`，使 `python -m build` 產物帶 `long_description`/`long_description_content_type`，通過 `twine check --strict`
- B9 release pipeline 的 `build` CI job 依賴此（本機重現：修前 wheel/sdist 皆 FAILED due to warnings，修後皆 PASSED）
- 順帶把 `dist/`、`build/` 加入 `.gitignore`

## 驗證
- [x] 本機 `python -m build` + `twine check --strict dist/*` 全 PASSED
- [x] `python3 -m policy_check --repo .`（0 fail）
- [x] fragment + `CHANGELOG.md [Unreleased]` 同步