### PR TITLE
fix(coordinator): git runner 與 service 綁定 repo root 消除 cwd 耦合 (#99)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- **Issue #99：git runner 與 systemd 單元以 repo root 為基準**：`dispatcher._default_git_runner` 現在以 `git -C <repo_root>` 執行 git 呼叫；`cortex-manager.service` 與 `cortex-monitor.service` 渲染時皆加入 `WorkingDirectory=<repo_root>`，避免 daemon 於非預期目錄執行 git 或長駐服務命令。
+
 ## [0.1.0] - 2026-07-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ cortex bootstrap --instance cortex --repo-root "$(git rev-parse --show-toplevel)
      --repo-root "$(git rev-parse --show-toplevel)"
    ```
 
-   Installer 會 render/copy units、執行 `daemon-reload`，並 enable manager timer 與 monitor service；**不會 start service**。`--interval` 只調整 deprecated timer 的 `OnUnitActiveSec`；長駐 daemon 的 tick 週期由 `PSC_MANAGER_INTERVAL_SECONDS` 控制。
+   Installer 會 render/copy units、執行 `daemon-reload`，並 enable manager timer 與 monitor service；**不會 start service**。`--interval` 只調整 deprecated timer 的 `OnUnitActiveSec`；長駐 daemon 的 tick 週期由 `PSC_MANAGER_INTERVAL_SECONDS` 控制。兩個 service 都會設定 `WorkingDirectory=<PSC_REPO_ROOT>`，因此服務執行時不受 `cwd` 影響。
 
 2. 啟動 manager 並分別檢查 service/runtime 狀態：
 
@@ -473,7 +473,7 @@ cortex work review-attest "$WORK_ID" --repo "$REPO" --actor "$ACTOR" \
 | monitor state root | `~/.agents/monitor` | `PSC_MONITOR_STATE_ROOT` |
 | config root | `~/.config/paulshaclaw` | `PSC_CONFIG_ROOT` |
 | project config root | `~/.agents/config/paulsha` | `PSC_PROJECT_CONFIG_ROOT` |
-| repo root | 目前工作目錄 | `PSC_REPO_ROOT` |
+| repo root | 指定 install 時的 git repo top-level（`--repo-root`） | `PSC_REPO_ROOT` |
 | worktree root | `<repo>-worktrees` sibling | `PSC_WORKTREE_ROOT` |
 
 共同前綴 `PSC_AGENTS_ROOT` 可一次覆寫 mutable/runtime roots。systemd unit 依宣告順序讀取 `~/.agents/core/runtime/<instance>.env` 與固定 bootstrap `~/.agents/core/runtime/<instance>-manager.env`；installer在後者持久化`PSC_INSTANCE`與`PSC_AGENTS_ROOT`。Interactive CLI以同一`PSC_INSTANCE`選取bootstrap env，不掃描猜測其他instance；symlink、malformed或relative root會fail-closed。installer重跑會更新自身管理的Python/repo值，但保留既有operator roots。Monitor socket預設為`$PSC_RUN_ROOT/project-monitor.sock`，也可由`project-cortex.yaml`的`monitor.socket_path`覆寫；production `MonitorSocketClient`與service使用相同config解析。

--- a/changelog.d/fix-git-runner-cwd.md
+++ b/changelog.d/fix-git-runner-cwd.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **Issue #99：git runner 與 service units 使用 repo root 定位**：`_default_git_runner` 改為以 `paths.repo_root()` 呼叫 `git -C <repo_root>`，並將 `cortex-manager.service` 與 `cortex-monitor.service` 渲染加入 `WorkingDirectory=<repo_root>`，避免系統d 啟動目錄漂移。

--- a/openspec/changes/2026-07-25-fix-git-runner-cwd/tasks.md
+++ b/openspec/changes/2026-07-25-fix-git-runner-cwd/tasks.md
@@ -1,0 +1,16 @@
+---
+status: accepted
+work_item: fix-git-runner-cwd
+---
+
+# Tasks
+
+- [x] [RED] `tests/test_fix_git_runner_cwd.py`：`_default_git_runner(["rev-parse","--show-toplevel"])` 以 `subprocess.run` 被呼叫，斷言 argv 前段為 `["git","-C",<repo_root>]`（mock `subprocess.run`；monkeypatch `paulsha_cortex.config.paths.repo_root` 回 `tmp_path`）。
+- [x] [RED] git 失敗時 raise `RuntimeError` 含 `-C` 與 stderr。
+- [x] [RED] installer render 的 `cortex-manager.service` 內容含 `WorkingDirectory=`（含 monitor unit）。
+- [ ] [實作] `paulsha_cortex/coordinator/dispatcher.py`：`_default_git_runner` 改 `git -C paths.repo_root()`，失敗訊息含 `-C`。
+- [ ] [實作] installer 模板：`cortex-manager.service` 與 `cortex-monitor.service` render 加 `WorkingDirectory=<repo_root>`。
+- [ ] [同步與驗證] `changelog.d/fix-git-runner-cwd.md` fragment；`CHANGELOG.md [Unreleased]` `### Fixed` 加入含 `#99` 字樣條目（git runner cwd 耦合）。
+- [ ] [同步與驗證] README 對應段同步（R-18：git runner cwd 無關、installer WorkingDirectory）。
+- [ ] [同步與驗證] `python3 -m pytest tests/ -q` 全綠；`python3 -m policy_check --repo .` 0 fail；`git diff --check` 乾淨。
+- [ ] [同步與驗證] 勾選 `openspec/changes/2026-07-25-fix-git-runner-cwd/tasks.md` 對應項並以 conventional commit 提交（不得改動本 plan 檔）。

--- a/openspec/changes/2026-07-25-fix-git-runner-cwd/tasks.md
+++ b/openspec/changes/2026-07-25-fix-git-runner-cwd/tasks.md
@@ -8,9 +8,9 @@ work_item: fix-git-runner-cwd
 - [x] [RED] `tests/test_fix_git_runner_cwd.py`：`_default_git_runner(["rev-parse","--show-toplevel"])` 以 `subprocess.run` 被呼叫，斷言 argv 前段為 `["git","-C",<repo_root>]`（mock `subprocess.run`；monkeypatch `paulsha_cortex.config.paths.repo_root` 回 `tmp_path`）。
 - [x] [RED] git 失敗時 raise `RuntimeError` 含 `-C` 與 stderr。
 - [x] [RED] installer render 的 `cortex-manager.service` 內容含 `WorkingDirectory=`（含 monitor unit）。
-- [ ] [實作] `paulsha_cortex/coordinator/dispatcher.py`：`_default_git_runner` 改 `git -C paths.repo_root()`，失敗訊息含 `-C`。
-- [ ] [實作] installer 模板：`cortex-manager.service` 與 `cortex-monitor.service` render 加 `WorkingDirectory=<repo_root>`。
-- [ ] [同步與驗證] `changelog.d/fix-git-runner-cwd.md` fragment；`CHANGELOG.md [Unreleased]` `### Fixed` 加入含 `#99` 字樣條目（git runner cwd 耦合）。
-- [ ] [同步與驗證] README 對應段同步（R-18：git runner cwd 無關、installer WorkingDirectory）。
-- [ ] [同步與驗證] `python3 -m pytest tests/ -q` 全綠；`python3 -m policy_check --repo .` 0 fail；`git diff --check` 乾淨。
-- [ ] [同步與驗證] 勾選 `openspec/changes/2026-07-25-fix-git-runner-cwd/tasks.md` 對應項並以 conventional commit 提交（不得改動本 plan 檔）。
+- [x] [實作] `paulsha_cortex/coordinator/dispatcher.py`：`_default_git_runner` 改 `git -C paths.repo_root()`，失敗訊息含 `-C`。
+- [x] [實作] installer 模板：`cortex-manager.service` 與 `cortex-monitor.service` render 加 `WorkingDirectory=<repo_root>`。
+- [x] [同步與驗證] `changelog.d/fix-git-runner-cwd.md` fragment；`CHANGELOG.md [Unreleased]` `### Fixed` 加入含 `#99` 字樣條目（git runner cwd 耦合）。
+- [x] [同步與驗證] README 對應段同步（R-18：git runner cwd 無關、installer WorkingDirectory）。
+- [x] [同步與驗證] `python3 -m pytest tests/ -q` 全綠；`python3 -m policy_check --repo .` 0 fail；`git diff --check` 乾淨。
+- [x] [同步與驗證] 勾選 `openspec/changes/2026-07-25-fix-git-runner-cwd/tasks.md` 對應項並以 conventional commit 提交（不得改動本 plan 檔）。

--- a/paulsha_cortex/coordinator/dispatcher.py
+++ b/paulsha_cortex/coordinator/dispatcher.py
@@ -5,6 +5,8 @@ import subprocess
 from pathlib import Path
 from typing import Callable
 
+from paulsha_cortex.config import paths
+
 from .completion import classify_completion
 from .registry import JobRegistry
 from .seams import PaneSender, WorktreeCreator
@@ -20,9 +22,16 @@ PidAlive = Callable[[int], bool]
 
 
 def _default_git_runner(args: list[str]) -> str:
-    proc = subprocess.run(["git", *args], capture_output=True, text=True)
+    repo_root = paths.repo_root()
+    proc = subprocess.run(
+        ["git", "-C", str(repo_root), *args],
+        capture_output=True,
+        text=True,
+    )
     if proc.returncode != 0:
-        raise RuntimeError(f"git {' '.join(args)} 失敗: {proc.stderr.strip()}")
+        raise RuntimeError(
+            f"git -C {repo_root} {' '.join(args)} 失敗: {proc.stderr.strip()}"
+        )
     return proc.stdout.strip()
 
 

--- a/paulsha_cortex/deploy/installer.py
+++ b/paulsha_cortex/deploy/installer.py
@@ -12,6 +12,8 @@ from importlib import resources
 from pathlib import Path
 from typing import Sequence
 
+from paulsha_cortex.config import paths
+
 _INSTANCE_RE = re.compile(r"[a-z0-9][a-z0-9-]*")
 _SUPPORTED_EXECUTORS = frozenset({"copilot", "claude", "codex"})
 
@@ -31,13 +33,16 @@ def _service_script_path() -> Path:
     return Path(str(resources.files("paulsha_cortex") / "scripts" / "service-manager.sh"))
 
 
-def render_units(instance: str, interval: int) -> dict[str, str]:
+def render_units(instance: str, interval: int, repo_root: Path | str | None = None) -> dict[str, str]:
     service = _template("manager.service.tmpl").replace("__INSTANCE__", instance)
     service = service.replace("__SERVICE_SCRIPT__", str(_service_script_path()))
     timer = _template("manager.timer.tmpl").replace("__INSTANCE__", instance)
     timer = re.sub(r"^OnUnitActiveSec=.*$", f"OnUnitActiveSec={interval}", timer, flags=re.M)
     monitor = _template("monitor.service.tmpl").replace("__INSTANCE__", instance)
     monitor = monitor.replace("__PY__", sys.executable)
+    service_root = Path(repo_root).resolve() if repo_root is not None else paths.repo_root().resolve()
+    service = service.replace("__REPO_ROOT__", str(service_root))
+    monitor = monitor.replace("__REPO_ROOT__", str(service_root))
     return {
         f"{instance}-manager.service": service,
         f"{instance}-manager.timer": timer,
@@ -167,7 +172,7 @@ def install_service_result(instance: str, interval: int, repo_root: Path) -> Ins
         agents_root / "config" / "paulsha",
     ):
         directory.mkdir(parents=True, exist_ok=True)
-    for name, content in render_units(instance, interval).items():
+    for name, content in render_units(instance, interval, repo_root=repo_root).items():
         (unit_dir / name).write_text(content)
     managed_env = {
         "PY": sys.executable,

--- a/paulsha_cortex/deploy/templates/manager.service.tmpl
+++ b/paulsha_cortex/deploy/templates/manager.service.tmpl
@@ -9,6 +9,7 @@ StartLimitBurst=5
 EnvironmentFile=-%h/.agents/core/runtime/__INSTANCE__.env
 EnvironmentFile=-%h/.agents/core/runtime/__INSTANCE__-manager.env
 ExecStart=/usr/bin/env bash __SERVICE_SCRIPT__
+WorkingDirectory=__REPO_ROOT__
 KillMode=control-group
 UMask=0022
 Restart=on-failure

--- a/paulsha_cortex/deploy/templates/monitor.service.tmpl
+++ b/paulsha_cortex/deploy/templates/monitor.service.tmpl
@@ -9,6 +9,7 @@ StartLimitBurst=5
 EnvironmentFile=-%h/.agents/core/runtime/__INSTANCE__.env
 EnvironmentFile=-%h/.agents/core/runtime/__INSTANCE__-manager.env
 ExecStart=__PY__ -m paulsha_cortex.monitor
+WorkingDirectory=__REPO_ROOT__
 KillMode=control-group
 Restart=on-failure
 RestartSec=10

--- a/tests/test_fix_git_runner_cwd.py
+++ b/tests/test_fix_git_runner_cwd.py
@@ -1,0 +1,43 @@
+import re
+from types import SimpleNamespace
+
+import pytest
+
+from paulsha_cortex.coordinator import dispatcher
+from paulsha_cortex.config import paths
+from paulsha_cortex.deploy.installer import render_units
+
+
+def test_default_git_runner_prefixes_arguments_with_repo_root(monkeypatch, tmp_path):
+    calls: list[tuple] = []
+
+    def fake_run(argv, capture_output=True, text=True):
+        calls.append((argv, capture_output, text))
+        return SimpleNamespace(returncode=0, stdout="abc\n", stderr="")
+
+    monkeypatch.setattr(paths, "repo_root", lambda: tmp_path)
+    monkeypatch.setattr(dispatcher.subprocess, "run", fake_run)
+
+    out = dispatcher._default_git_runner(["rev-parse", "--show-toplevel"])
+    assert out == "abc"
+    assert calls == [(["git", "-C", str(tmp_path), "rev-parse", "--show-toplevel"], True, True)]
+
+
+def test_default_git_runner_failure_includes_repo_root_and_stderr(monkeypatch, tmp_path):
+    def fake_run(argv, capture_output=True, text=True):
+        return SimpleNamespace(returncode=128, stdout="", stderr="fatal: not a git repository")
+
+    monkeypatch.setattr(paths, "repo_root", lambda: tmp_path)
+    monkeypatch.setattr(dispatcher.subprocess, "run", fake_run)
+
+    with pytest.raises(RuntimeError, match=re.escape("-C")) as exc:
+        dispatcher._default_git_runner(["rev-parse", "--show-toplevel"])
+    message = str(exc.value)
+    assert str(tmp_path) in message
+    assert "fatal: not a git repository" in message
+
+
+def test_render_units_includes_working_directory_for_manager_and_monitor_service():
+    units = render_units("cortex", 300)
+    assert "WorkingDirectory=" in units["cortex-manager.service"]
+    assert "WorkingDirectory=" in units["cortex-monitor.service"]


### PR DESCRIPTION
## 背景
#99：`dispatcher._default_git_runner` 依賴行程 cwd，systemd 啟動的 manager daemon（cwd 非 repo root）派工鏈上所有 git 呼叫失敗；`cortex install service` render 的 unit 無 `WorkingDirectory`。

## 修改
- `coordinator/dispatcher.py`：`_default_git_runner` 改 `git -C <repo_root>`（`paths.repo_root()`），失敗訊息含 `-C`。
- `deploy/installer.py` + `templates/{manager,monitor}.service.tmpl`：render 加 `WorkingDirectory=<repo_root>`（defense in depth，與 `-C` 並行）。
- `tests/test_fix_git_runner_cwd.py`：3 個 regression（`-C` argv、失敗訊息、`WorkingDirectory=`）。
- CHANGELOG / README / openspec tasks 同步。

## 派工與審查
- builder：cortex 派工 codex（`gpt-5.3-codex-spark`），feature-oneshot combo。
- 對抗審查：operator（Copilot CLI）審過候選 `a57c5a9` → 判定 **APPROVED**（修復正確完整、符合 spec/design、無未處置缺陷）。
- 規劃產物已先以 docs PR #179 併入 main，本 PR 為程式碼交付。

Closes #99

- [x] `python3 -m pytest tests/ -q` 全綠
- [x] `python3 -m policy_check --repo .` 0 fail
- [x] `git diff --check` 乾淨