### PR TITLE
chore(work-items): 加入 #100/#152 work-item entry

### DIFF
--- a/.cortex/work-items.yaml
+++ b/.cortex/work-items.yaml
@@ -143,6 +143,36 @@ work_items:
         ref: docs/superpowers/specs/fix-git-runner-cwd-design.md
       - kind: path
         ref: docs/superpowers/plans/fix-git-runner-cwd.md
+  fix-dispatch-exception-detail:
+    title: fix DispatchReadyError detail + manager.log timestamp (#100)
+    links:
+      - kind: github_issue
+        ref: hamanpaul/paulsha-cortex#100
+      - kind: openspec
+        ref: 2026-07-25-fix-dispatch-exception-detail
+      - kind: path
+        ref: docs/superpowers/workstreams/fix-dispatch-exception-detail/todo.md
+      - kind: path
+        ref: docs/superpowers/specs/fix-dispatch-exception-detail-spec.md
+      - kind: path
+        ref: docs/superpowers/specs/fix-dispatch-exception-detail-design.md
+      - kind: path
+        ref: docs/superpowers/plans/fix-dispatch-exception-detail.md
+  fix-mutation-request-timeout:
+    title: fix mutation request 5s timeout (#152)
+    links:
+      - kind: github_issue
+        ref: hamanpaul/paulsha-cortex#152
+      - kind: openspec
+        ref: 2026-07-25-fix-mutation-request-timeout
+      - kind: path
+        ref: docs/superpowers/workstreams/fix-mutation-request-timeout/todo.md
+      - kind: path
+        ref: docs/superpowers/specs/fix-mutation-request-timeout-spec.md
+      - kind: path
+        ref: docs/superpowers/specs/fix-mutation-request-timeout-design.md
+      - kind: path
+        ref: docs/superpowers/plans/fix-mutation-request-timeout.md
   dispatch-reliability-batch:
     title: dispatch reliability batch (abandoned, #134)
     links: []


### PR DESCRIPTION
## 內容
- `.cortex/work-items.yaml` 加入 `fix-dispatch-exception-detail`(#100) 與 `fix-mutation-request-timeout`(#152) 的 work-item entry。
- 規劃產物（spec/design/plan/todo/openspec）已在 #179 併入 main；本 PR 僅補 work-items.yaml 的 entry，讓 monitor 的 github provider 能將 #100/#152 issue 关聯為 confirmed source，供 `cortex work start` claim。

## 為何需要
實測：work-items.yaml entry 必須在 main 上，github provider 才會把 issue 為 confirmed source（local feature branch 上的 entry 不夠）。

- [x] docs/chore-only，未改 code（`skip-changelog`：純 work-items 設定）