### PR TITLE
fix(monitor): workflow provider 跳過 superseded run 的 issue authority (#182)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixed
 - **Issue #99：git runner 與 systemd 單元以 repo root 為基準**：`dispatcher._default_git_runner` 現在以 `git -C <repo_root>` 執行 git 呼叫；`cortex-manager.service` 與 `cortex-monitor.service` 渲染時皆加入 `WorkingDirectory=<repo_root>`，避免 daemon 於非預期目錄執行 git 或長駐服務命令。
+- **Issue #182：monitor workflow provider 跳過 superseded run 的 issue authority**：`WorkflowRegistryProvider` 建立 workflow_links 時不再對 `superseded` run 主張 issue/pr/openspec authority，避免廢棄 run 的 issue_refs 與其他 work item 衝突使 provider degraded；degraded 會凍結 `project_work_items` 於舊 snapshot，讓新以 work-items.yaml `github_issue` link 綁定的 source 永遠不進入 monitor read model。
 
 ## [0.1.0] - 2026-07-24
 

--- a/changelog.d/fix-workflow-authority-superseded.md
+++ b/changelog.d/fix-workflow-authority-superseded.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **Issue #182：monitor workflow provider 不再對 superseded run 主張 issue authority**：`WorkflowRegistryProvider` 建立 workflow_links（issue/pr/openspec authority）時跳過 `superseded` run，避免廢棄 run 的 issue_refs 與其他 work item 的 run 衝突導致 provider degraded；degraded 會使 `project_work_items` 凍結於舊 snapshot，讓新以 work-items.yaml `github_issue` link 綁定的 source（如 #100）永遠不進入 monitor read model。superseded run 仍作為來源顯示，只是不再主張 issue authority。

--- a/paulsha_cortex/monitor/providers.py
+++ b/paulsha_cortex/monitor/providers.py
@@ -306,17 +306,18 @@ class WorkflowRegistryProvider:
                     )
                 )
                 _add_workflow_link(links, source_id, work_id)
-                for ref in row.get("issue_refs", []):
-                    _add_workflow_link(links, f"github_issue:{ref}", work_id)
-                for ref in row.get("pr_refs", []):
-                    _add_workflow_link(links, f"github_pr:{ref}", work_id)
-                for ref in row.get("openspec_refs", []):
-                    for canonical_id in (
-                        f"openspec:{self.repo}:{ref}",
-                        f"github_openspec:{self.repo}:{ref}:active",
-                        f"github_openspec:{self.repo}:{ref}:archived",
-                    ):
-                        _add_workflow_link(links, canonical_id, work_id)
+                if status != "superseded":
+                    for ref in row.get("issue_refs", []):
+                        _add_workflow_link(links, f"github_issue:{ref}", work_id)
+                    for ref in row.get("pr_refs", []):
+                        _add_workflow_link(links, f"github_pr:{ref}", work_id)
+                    for ref in row.get("openspec_refs", []):
+                        for canonical_id in (
+                            f"openspec:{self.repo}:{ref}",
+                            f"github_openspec:{self.repo}:{ref}:active",
+                            f"github_openspec:{self.repo}:{ref}:archived",
+                        ):
+                            _add_workflow_link(links, canonical_id, work_id)
                 if completion is not None:
                     validated_completions.setdefault(work_id, []).append(completion)
         except (OSError, UnicodeError, json.JSONDecodeError, ValueError) as error:

--- a/tests/test_monitor_work_providers.py
+++ b/tests/test_monitor_work_providers.py
@@ -654,6 +654,53 @@ def test_workflow_registry_rejects_cross_work_authority_collision(tmp_path):
     assert any("authority collision" in note for note in result.diagnostics)
 
 
+def test_workflow_registry_superseded_run_does_not_claim_issue_authority(tmp_path):
+    # A superseded (abandoned) run must not claim issue/pr/openspec authority,
+    # so it cannot collide with another work item's run on a shared issue ref
+    # (regression for #182: workflow provider degraded froze projection and
+    # hid newly override-bound sources like #100).
+    state = tmp_path / "workflows.json"
+    state.write_text(
+        json.dumps(
+            {
+                "schema_version": 2,
+                "sequence": 9,
+                "legacy_records": {"jobs": [], "slices": []},
+                "workflow_runs": [
+                    {
+                        "run_id": "run-abandoned",
+                        "repo": "example/acme",
+                        "work_id": "abandoned-batch",
+                        "status": "superseded",
+                        "issue_refs": ["example/acme#7"],
+                        "pr_refs": ["example/acme#9"],
+                        "openspec_refs": ["canary"],
+                    },
+                    {
+                        "run_id": "run-active",
+                        "repo": "example/acme",
+                        "work_id": "real-work",
+                        "status": "completed",
+                        "issue_refs": ["example/acme#7"],
+                    },
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = WorkflowRegistryProvider("example/acme", state_path=state).scan()
+
+    assert result.status == "ok"
+    links = result.observations["workflow_links"]
+    # superseded run still maps its own workflow_run source (unique, no collision)
+    assert links["workflow_run:example/acme:run-abandoned"] == "abandoned-batch"
+    # but it does NOT claim issue/pr/openspec authority (only the active run does)
+    assert links["github_issue:example/acme#7"] == "real-work"
+    assert "github_pr:example/acme#9" not in links
+    assert "openspec:example/acme:canary" not in links
+
+
 def test_workflow_registry_unknown_schema_and_root_keys_are_degraded(tmp_path):
     state = tmp_path / "workflows.json"
     for payload in (


### PR DESCRIPTION
## 背景
#182：廢棄（superseded）的 `dispatch-reliability-batch` run 仍帶 issue_refs #99/#100/#152，與其他 work item 的 run 在 #99 上發生 workflow authority collision → `workflow` provider degraded → `project_work_items` 走 degraded 分支凍結於舊 snapshot → 新以 work-items.yaml `github_issue` link 綁定的 #100 永遠不進 monitor read model（claim 失敗 `issue_refs: []`）。

## 修改
`paulsha_cortex/monitor/providers.py`：`WorkflowRegistryProvider` 建立 workflow_links（issue/pr/openspec authority）時跳過 `superseded` run。superseded run 仍作為來源（workflow_run source）顯示，只是不再主張 issue/pr/openspec authority，故不與其他 run 衝突。

## 測試
- 新增 `test_workflow_registry_superseded_run_does_not_claim_issue_authority`：superseded run 不發 issue/pr/openspec authority 邊、不與 active run 在共用 issue 碰撞。
- `python3 -m pytest tests/ -q` 1201 passed。
- `python3 -m policy_check --repo .` 0 fail。

## 驗證計畫
merge + pipx 重裝 + restart monitor 後：`workflow:hamanpaul/paulsha-cortex` provider 回 `ok`、不再有 #99 authority collision；`fix-dispatch-exception-detail` 的 #100 issue 進入 read model，`cortex work start fix-dispatch-exception-detail` 可成功 claim。

Closes #182

- [x] `python3 -m pytest tests/ -q` 全綠
- [x] `python3 -m policy_check --repo .` 0 fail
- [x] `git diff --check` 乾淨