### PR TITLE
fix(cli): mutation request 分級 timeout + pending 語意 (#152)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ## [Unreleased]
 
 ### Fixed
+- **Issue #152：mutation request 逾時改採分級 timeout + pending 回報**：`coordinator/cli.py` `_submit_mutation_request` 依 `req_type` 套用分級 timeout（`fanout`/`tick` 60 秒、`complete`/`work`/`work-action`/`run` 30 秒、其餘 5 秒），`poll` timeout 時保留 `req_id` 與追蹤指引並回傳 `EXIT_SUBMITTED_PENDING`（exit 3）避免成功派工被誤報為失敗。
 - **Issue #99：git runner 與 systemd 單元以 repo root 為基準**：`dispatcher._default_git_runner` 現在以 `git -C <repo_root>` 執行 git 呼叫；`cortex-manager.service` 與 `cortex-monitor.service` 渲染時皆加入 `WorkingDirectory=<repo_root>`，避免 daemon 於非預期目錄執行 git 或長駐服務命令。
 - **Issue #182：monitor workflow provider 跳過 superseded run 的 issue authority**：`WorkflowRegistryProvider` 建立 workflow_links 時不再對 `superseded` run 主張 issue/pr/openspec authority，避免廢棄 run 的 issue_refs 與其他 work item 衝突使 provider degraded；degraded 會凍結 `project_work_items` 於舊 snapshot，讓新以 work-items.yaml `github_issue` link 綁定的 source 永遠不進入 monitor read model。
 - **Issue #100：tick 的 dispatch 失敗回報與 manager daemon log 時間戳**：`DispatchReadyError` 現在輸出每 slice 的 `slice_id`、例外型別與訊息摘要；`tick` 在 fanout 失敗時保留已成功 dispatch 的 jobs 並回傳 per-slice 錯誤欄位；`manager_daemon` 的錯誤 log 改以可解析 ISO-8601 時間戳為行首。

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ cortex bootstrap --instance cortex --repo-root "$(git rev-parse --show-toplevel)
 
    `recover` 不提供 `--allow-unsafe` 等旁路旗標；需要專家級低階參數時仍使用既有 coordinator 命令。
 
-> `cortex status` 查 manager 的工作與 gate 狀態；`systemctl --user status` 只查 service 是否存活，兩者不可互相替代。`fanout` / `tick` / `complete` / `slice-action` 的 CLI 最多等 control response 5 秒；timeout 後 daemon 可能仍在工作，應回到 `cortex status` 查證。
+> `cortex status` 查 manager 的工作與 gate 狀態；`systemctl --user status` 只查 service 是否存活，兩者不可互相替代。mutation request 目前採分級 timeout：`fanout` / `tick` 為 60 秒，`complete` / `work-action` 為 30 秒，其餘為 5 秒；timeout 後 daemon 可能仍在工作，請回到 `cortex status` 或 `cortex request show <request-id>` 查證。
 
 ## 從使用者角度操作
 

--- a/changelog.d/fix-mutation-request-timeout.md
+++ b/changelog.d/fix-mutation-request-timeout.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **Issue #152：mutation request 分級 timeout 與 pending 回報**：`_submit_mutation_request` 依 request 類型套用分級 timeout（`fanout`/`tick` 60 秒、`complete`/`work`/`work-action`/`run` 30 秒、其他 5 秒），`poll` 超時時保留成功派工的可追蹤結果（含 `req_id`），回傳 `EXIT_SUBMITTED_PENDING`（3）避免將成功派工誤判為失敗。

--- a/openspec/changes/2026-07-25-fix-mutation-request-timeout/tasks.md
+++ b/openspec/changes/2026-07-25-fix-mutation-request-timeout/tasks.md
@@ -5,7 +5,7 @@ work_item: fix-mutation-request-timeout
 
 # Tasks
 
-- [ ] 1.1 RED：`tests/test_fix_mutation_request_timeout.py` 涵蓋分級 timeout 取用、逾時 pending 路徑含 req_id 與追蹤指引、exit code 區別。
+- [x] 1.1 RED：`tests/test_fix_mutation_request_timeout.py` 涵蓋分級 timeout 取用、逾時 pending 路徑含 req_id 與追蹤指引、exit code 區別。
 - [ ] 1.2 `coordinator/cli.py` `_REQUEST_TIMEOUTS` 表 + `_submit_mutation_request` 分級 timeout + pending 路徑 + `EXIT_SUBMITTED_PENDING`（#152）。
 - [ ] 1.3 `changelog.d/fix-mutation-request-timeout.md` 與 `CHANGELOG.md [Unreleased]` `### Fixed` 同步（#152）；README 對應段同步（R-18）。
 - [ ] 1.4 focused regression 全綠、`policy_check --repo .` 0 fail、`git diff --check` 乾淨。

--- a/openspec/changes/2026-07-25-fix-mutation-request-timeout/tasks.md
+++ b/openspec/changes/2026-07-25-fix-mutation-request-timeout/tasks.md
@@ -6,6 +6,6 @@ work_item: fix-mutation-request-timeout
 # Tasks
 
 - [x] 1.1 RED：`tests/test_fix_mutation_request_timeout.py` 涵蓋分級 timeout 取用、逾時 pending 路徑含 req_id 與追蹤指引、exit code 區別。
-- [ ] 1.2 `coordinator/cli.py` `_REQUEST_TIMEOUTS` 表 + `_submit_mutation_request` 分級 timeout + pending 路徑 + `EXIT_SUBMITTED_PENDING`（#152）。
-- [ ] 1.3 `changelog.d/fix-mutation-request-timeout.md` 與 `CHANGELOG.md [Unreleased]` `### Fixed` 同步（#152）；README 對應段同步（R-18）。
-- [ ] 1.4 focused regression 全綠、`policy_check --repo .` 0 fail、`git diff --check` 乾淨。
+- [x] 1.2 `coordinator/cli.py` `_REQUEST_TIMEOUTS` 表 + `_submit_mutation_request` 分級 timeout + pending 路徑 + `EXIT_SUBMITTED_PENDING`（#152）。
+- [x] 1.3 `changelog.d/fix-mutation-request-timeout.md` 與 `CHANGELOG.md [Unreleased]` `### Fixed` 同步（#152）；README 對應段同步（R-18）。
+- [x] 1.4 focused regression 全綠、`policy_check --repo .` 0 fail、`git diff --check` 乾淨。

--- a/paulsha_cortex/coordinator/cli.py
+++ b/paulsha_cortex/coordinator/cli.py
@@ -14,6 +14,17 @@ from .seams import PaneSender, ScriptWorktreeCreator, TmuxPaneSender, WorktreeCr
 DEFAULT_REQUEST_TIMEOUT_SECONDS = 5.0
 DEFAULT_REQUEST_POLL_INTERVAL_SECONDS = 0.1
 DEFAULT_REQUESTED_BY = "coordinator-cli"
+EXIT_SUBMITTED_PENDING = 3
+
+
+_REQUEST_TIMEOUTS: dict[str, float] = {
+    "fanout": 60.0,
+    "tick": 60.0,
+    "complete": 30.0,
+    "work": 30.0,
+    "work-action": 30.0,
+    "run": 30.0,
+}
 
 
 def _resolve_launcher(executor, injected, *, allow_unsafe, model):
@@ -382,14 +393,20 @@ def _submit_mutation_request(
             file=sys.stderr,
         )
         return 1
+
+    timeout_seconds = _REQUEST_TIMEOUTS.get(req_type, DEFAULT_REQUEST_TIMEOUT_SECONDS)
     req_id = submit_request_fn(req_type, dict(args), DEFAULT_REQUESTED_BY)
-    done = poll_done_fn(req_id, DEFAULT_REQUEST_TIMEOUT_SECONDS, DEFAULT_REQUEST_POLL_INTERVAL_SECONDS)
+    done = poll_done_fn(req_id, timeout_seconds, DEFAULT_REQUEST_POLL_INTERVAL_SECONDS)
     if not isinstance(done, dict):
         print(
-            f"錯誤: manager daemon 未在 {DEFAULT_REQUEST_TIMEOUT_SECONDS:.1f}s 內完成 {req_type} request: {req_id}",
+            f"錯誤: manager daemon 未在 {timeout_seconds:.1f}s 內完成 {req_type} request: {req_id}。",
             file=sys.stderr,
         )
-        return 1
+        print(
+            f"請使用 `cortex request show {req_id}` 或 `cortex request wait {req_id} --timeout {int(timeout_seconds)}` 追蹤狀態。",
+            file=sys.stderr,
+        )
+        return EXIT_SUBMITTED_PENDING
     if done.get("status") != "ok":
         print(f"錯誤: {done.get('error') or 'unknown request error'}", file=sys.stderr)
         return 1

--- a/paulsha_cortex/coordinator/cli.py
+++ b/paulsha_cortex/coordinator/cli.py
@@ -21,9 +21,7 @@ _REQUEST_TIMEOUTS: dict[str, float] = {
     "fanout": 60.0,
     "tick": 60.0,
     "complete": 30.0,
-    "work": 30.0,
     "work-action": 30.0,
-    "run": 30.0,
 }
 
 

--- a/reports/review/2026-07-26-fix-mutation-request-timeout-review.md
+++ b/reports/review/2026-07-26-fix-mutation-request-timeout-review.md
@@ -1,0 +1,44 @@
+---
+workflow_run_id: "workflow-3ccae4d22110c39e780b"
+workflow_card_id: "code-review"
+workflow_job_id: "wf-89388a5e2d-code-review-353"
+candidate: "3c0e92c6bf8bbae98966468c7ff0cc293f6b2646"
+---
+# Review: fix-mutation-request-timeout
+
+**Candidate:** `3c0e92c6bf8bbae98966468c7ff0cc293f6b2646`
+**Verdict:** Changes requested (blocking regression found)
+
+## What was checked
+
+- Diff of `580ed7e` (RED tests) and `3c0e92c` (implementation) against `openspec/changes/2026-07-25-fix-mutation-request-timeout/proposal.md` and `tasks.md`.
+- `paulsha_cortex/coordinator/cli.py`: new `_REQUEST_TIMEOUTS` table, tiered `_submit_mutation_request` timeout lookup, `EXIT_SUBMITTED_PENDING = 3` pending path with tracking guidance referencing `cortex request show`/`cortex request wait` (both real porcelain subcommands, confirmed present in `paulsha_cortex/porcelain/request.py`).
+- `tests/test_fix_mutation_request_timeout.py`: new focused regression suite — passes (3 passed, 6 subtests).
+- `policy_check --repo .`: 25 pass / 0 fail / 1 pre-existing advisory warn (R-22 dangling doc refs, unrelated).
+- `git diff --check HEAD~2 HEAD`: clean, no whitespace errors.
+- Full `pytest tests/` run: 31 failed / 1176 passed / 1 error.
+
+## Blocking finding: regression in existing coordinator CLI tests
+
+Task 1.4 asserts "focused regression 全綠、policy_check --repo . 0 fail、git diff --check 乾淨", but the full suite is not green because of this change:
+
+- `tests/test_coordinator_cli_complete.py::CliCompleteTests::test_complete_subcommand_routes_through_control_plane`
+- `tests/test_persona_phase2_coordinator_cli.py::CliTests::test_complete_submits_control_request_only`
+
+Both assert `polled == [(..., 5.0, 0.1)]` for the `complete` request type — the pre-existing fixed default timeout. The candidate's `_REQUEST_TIMEOUTS` maps `complete` to `30.0`, so these tests now fail with `[('req-...', 30.0, 0.1)] != [('req-...', 5.0, 0.1)]`.
+
+Verified this is caused by the candidate, not a pre-existing/environment issue: cloned the repo at parent commit `b443ad0` (pre-feature) into a scratch worktree and both tests pass cleanly there (`9 passed`), while they fail on candidate HEAD.
+
+The remaining 29 failures/1 error in the full run (`test_stage9_project_monitor_service.py`, `test_monitor_work_api.py`, `test_doctor.py::test_monitor_protocol_probe_rejects_transport_only_listener`, `test_persona_phase3_scope_ci.py::...test_subprocess_with_malformed_yaml_still_exits_zero`) are confirmed pre-existing/environmental and unrelated to this change:
+- The monitor/stage9/doctor failures are `PermissionError: [Errno 1] Operation not permitted` from `socket.socket(AF_UNIX, ...)` — a sandbox restriction on Unix domain sockets, reproduced identically on the unmodified parent commit in a separate writable clone.
+- The `test_persona_phase3_scope_ci` failure is `OSError: [Errno 30] Read-only file system` writing to `paulsha_cortex/persona/personas.yaml` in-place — an artifact of this review checkout being mounted read-only, not a code defect (the same test passes in a writable clone of the same commit).
+
+## Non-blocking notes
+
+- The tracking guidance text (`cortex request show <req_id>` / `cortex request wait <req_id> --timeout ...`) correctly references real porcelain subcommands (`paulsha_cortex/porcelain/request.py`), so the pending-path UX is sound.
+- README.md and CHANGELOG.md/changelog.d entries accurately describe the tiered timeouts and match the real `work-action` req_type (not the bare, nonexistent `work` type), which is good — but see the minor finding below about dead table entries.
+- Minor: `_REQUEST_TIMEOUTS` contains `'work': 30.0` and `'run': 30.0` entries that are unreachable — `paulsha_cortex/control/contract.py`'s `REQUEST_TYPES` frozenset has no `work` or `run` type, and no `cli.py` branch ever submits those strings (the `work` subcommand submits `work-action`, already separately keyed). Not blocking, but should be cleaned up to avoid confusion.
+
+## Recommendation
+
+Request changes: update the two broken tests to expect the new tiered timeout (or intentionally decide `complete` should keep 5.0s if that was unintended), rerun the **full** test suite (not just the new focused file) to confirm zero regressions, then resubmit.

--- a/reports/verify/2026-07-26-fix-mutation-request-timeout-verify.md
+++ b/reports/verify/2026-07-26-fix-mutation-request-timeout-verify.md
@@ -1,0 +1,43 @@
+---
+workflow_run_id: "workflow-3ccae4d22110c39e780b"
+workflow_card_id: "verification"
+workflow_job_id: "wf-89388a5e2d-verification-352"
+candidate: "3c0e92c6bf8bbae98966468c7ff0cc293f6b2646"
+---
+# Verification: fix-mutation-request-timeout
+
+**Candidate:** `3c0e92c6bf8bbae98966468c7ff0cc293f6b2646`
+
+## Scope reviewed
+
+- `paulsha_cortex/coordinator/cli.py`: new `_REQUEST_TIMEOUTS` table (`fanout`/`tick` 60s, `complete`/`work`/`work-action`/`run` 30s, else `DEFAULT_REQUEST_TIMEOUT_SECONDS` 5s) applied in `_submit_mutation_request`; on timeout, the code now prints the `req_id` plus tracking guidance (`cortex request show <req_id>` / `cortex request wait <req_id> --timeout <n>`) and returns the new `EXIT_SUBMITTED_PENDING` (3) instead of `1`, leaving the success/error-result paths unchanged. This matches proposal.md's goal and design.md's three decisions verbatim (tiered table, pending+req_id+guidance, exit-code differentiation, no `--json` envelope change).
+- Confirmed `cortex request show`/`cortex request wait` are real, wired porcelain subcommands reachable via the umbrella `cortex` entrypoint (`paulsha_cortex/cli.py` → `porcelain.request`), so the guidance text is not a dead reference.
+- Docs sync: `CHANGELOG.md [Unreleased] > Fixed`, `changelog.d/fix-mutation-request-timeout.md`, and `README.md`'s mutation-timeout callout all consistently describe the new tiered timeouts and Issue #152.
+- `openspec/changes/2026-07-25-fix-mutation-request-timeout/tasks.md`: all 4 checkboxes (RED test, implementation, changelog/README sync, regression/policy/diff-check) are checked; checkbox 1.1–1.3 are substantiated by the diff.
+
+## Commands executed (read-only, in `candidate/`)
+
+```
+git rev-parse HEAD
+git show 3c0e92c -- paulsha_cortex/coordinator/cli.py
+python3 -m pytest tests/test_fix_mutation_request_timeout.py -v
+python3 -m policy_check --repo .
+python3 -m pytest -q
+git diff --check HEAD~2..HEAD
+python3 -m pytest tests/test_coordinator_cli_complete.py tests/test_persona_phase2_coordinator_cli.py -v
+```
+
+## Results
+
+- Focused regression (`tests/test_fix_mutation_request_timeout.py`): **3/3 passed** (6 subtests) — covers tiered timeout selection, unchanged success path, and pending exit-code + tracking-guidance path.
+- `policy_check --repo .`: exit 0, `- fail: 0`.
+- `git diff --check HEAD~2..HEAD`: clean, no whitespace errors.
+- Full suite (`pytest -q`): **31 failed, 1176 passed, 1 error**. 29 of these failures are the same pre-existing `AF_UNIX` socket sandbox-permission failures previously documented in `reports/verify/2026-07-26-fix-dispatch-exception-detail-verify.md` (test_stage9_project_monitor_service.py, test_monitor_work_api.py, test_doctor.py, test_persona_phase3_scope_ci.py) and are unrelated to this diff.
+- **Regression introduced by this change (2 tests, confirmed by isolated re-run):**
+  - `tests/test_coordinator_cli_complete.py::CliCompleteTests::test_complete_subcommand_routes_through_control_plane`
+  - `tests/test_persona_phase2_coordinator_cli.py::CliTests::test_complete_submits_control_request_only`
+  Both assert `poll_done_fn` is called with the literal old default timeout `5.0` for `req_type="complete"`. The candidate's `_REQUEST_TIMEOUTS` table now maps `"complete"` to `30.0`, so these two pre-existing assertions fail with a clear diff (`30.0` vs expected `5.0`). These are not sandbox artifacts — they are direct, deterministic consequences of the timeout-table change and were not updated alongside it.
+
+## Conclusion
+
+The implementation is functionally correct and matches proposal.md/design.md intent, and the newly-added focused regression suite, policy_check, and diff-check all pass. However, the change has an unaddressed side effect: it breaks two pre-existing tests that still encode the old hardcoded 5.0s timeout for the `complete` request type. tasks.md's 1.4 claim of "focused regression 全綠" is accurate only for the new test file and does not reflect this full-suite regression. This should be fixed (update the two assertions to the new tiered timeout, or otherwise reconcile) before the work item is considered complete.

--- a/tests/test_coordinator_cli_complete.py
+++ b/tests/test_coordinator_cli_complete.py
@@ -38,7 +38,7 @@ class CliCompleteTests(unittest.TestCase):
             submitted,
             [("complete", {"handoff_dir": "runtime/handoff", "specs_dir": "specs"}, "coordinator-cli")],
         )
-        self.assertEqual(polled, [("req-complete-1", 5.0, 0.1)])
+        self.assertEqual(polled, [("req-complete-1", 30.0, 0.1)])
         self.assertEqual(
             json.loads(buf.getvalue()),
             {"completed": [{"slice_id": "slice-cli", "gate_status": "passed"}]},

--- a/tests/test_fix_mutation_request_timeout.py
+++ b/tests/test_fix_mutation_request_timeout.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import io
+import json
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+
+from paulsha_cortex.coordinator import cli
+
+
+class MutationRequestTimeoutTests(unittest.TestCase):
+    def test_submit_mutation_request_uses_tiered_timeouts(self) -> None:
+        def make_submit(req_type: str):
+            def submit(_req_type: str, args: dict, requested_by: str) -> str:
+                self.assertEqual(_req_type, req_type)
+                self.assertEqual(requested_by, "coordinator-cli")
+                self.assertEqual(args, {"foo": "bar"})
+                return f"req-{req_type}-1"
+
+            return submit
+
+        table = [
+            ("fanout", 60.0),
+            ("tick", 60.0),
+            ("complete", 30.0),
+            ("work-action", 30.0),
+            ("run", 30.0),
+            ("dispatch", 5.0),
+        ]
+
+        for req_type, expected_timeout in table:
+            with self.subTest(req_type=req_type):
+                polled: list[tuple[str, float, float]] = []
+
+                def fake_poll(req_id: str, timeout: float, poll_interval: float = 0.5) -> dict:
+                    polled.append((req_id, timeout, poll_interval))
+                    return {"status": "ok", "result": {"ok": True}}
+
+                rc = cli._submit_mutation_request(
+                    req_type,
+                    {"foo": "bar"},
+                    read_status_fn=lambda: {"degraded": False, "degraded_reason": None},
+                    submit_request_fn=make_submit(req_type),
+                    poll_done_fn=fake_poll,
+                )
+
+                self.assertEqual(rc, 0)
+                self.assertEqual(polled, [(f"req-{req_type}-1", expected_timeout, 0.1)])
+
+    def test_submit_mutation_request_keeps_success_path_unchanged(self) -> None:
+        submitted: list[tuple[str, dict, str]] = []
+        polled: list[tuple[str, float, float]] = []
+
+        def fake_submit(req_type: str, args: dict, requested_by: str) -> str:
+            submitted.append((req_type, dict(args), requested_by))
+            return "req-success-1"
+
+        def fake_poll(req_id: str, timeout: float, poll_interval: float = 0.5) -> dict:
+            polled.append((req_id, timeout, poll_interval))
+            return {"status": "ok", "result": {"completed": [{"slice_id": "slice-a"}]}}
+
+        out = io.StringIO()
+        with redirect_stdout(out):
+            rc = cli._submit_mutation_request(
+                "complete",
+                {"handoff_dir": "runtime/handoff"},
+                read_status_fn=lambda: {"degraded": False, "degraded_reason": None},
+                submit_request_fn=fake_submit,
+                poll_done_fn=fake_poll,
+            )
+
+        self.assertEqual(rc, 0)
+        self.assertEqual(
+            submitted,
+            [("complete", {"handoff_dir": "runtime/handoff"}, "coordinator-cli")],
+        )
+        self.assertEqual(polled, [("req-success-1", 30.0, 0.1)])
+        self.assertEqual(
+            json.loads(out.getvalue()),
+            {"completed": [{"slice_id": "slice-a"}]},
+        )
+
+    def test_submit_mutation_request_uses_pending_exit_code_when_timed_out(self) -> None:
+        req_id = "req-timeout-1"
+        self.assertTrue(hasattr(cli, "EXIT_SUBMITTED_PENDING"), "EXIT_SUBMITTED_PENDING must be introduced")
+        pending_code = getattr(cli, "EXIT_SUBMITTED_PENDING")
+
+        def fake_submit(_req_type: str, _args: dict, _requested_by: str) -> str:
+            return req_id
+
+        err = io.StringIO()
+        with redirect_stderr(err):
+            rc = cli._submit_mutation_request(
+                "fanout",
+                {"specs_dir": "specs"},
+                read_status_fn=lambda: {"degraded": False, "degraded_reason": None},
+                submit_request_fn=fake_submit,
+                poll_done_fn=lambda req_id, timeout, poll_interval=0.5: None,
+            )
+
+        self.assertEqual(rc, pending_code)
+        self.assertNotEqual(rc, 1)
+        message = err.getvalue()
+        self.assertIn(req_id, message)
+        self.assertTrue(
+            "追蹤" in message or "tracking" in message.lower() or "追蹤狀態" in message,
+            msg="pending path should include tracking guidance",
+        )
+
+        def fake_error_poll(req_id: str, timeout: float, poll_interval: float = 0.5) -> dict:
+            return {"status": "error", "error": "daemon rejected", "result": {}}
+
+        rc_error = cli._submit_mutation_request(
+            "fanout",
+            {"specs_dir": "specs"},
+            read_status_fn=lambda: {"degraded": False, "degraded_reason": None},
+            submit_request_fn=fake_submit,
+            poll_done_fn=fake_error_poll,
+        )
+
+        self.assertEqual(rc_error, 1)
+        self.assertNotEqual(rc_error, pending_code)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_fix_mutation_request_timeout.py
+++ b/tests/test_fix_mutation_request_timeout.py
@@ -24,7 +24,6 @@ class MutationRequestTimeoutTests(unittest.TestCase):
             ("tick", 60.0),
             ("complete", 30.0),
             ("work-action", 30.0),
-            ("run", 30.0),
             ("dispatch", 5.0),
         ]
 

--- a/tests/test_persona_phase2_coordinator_cli.py
+++ b/tests/test_persona_phase2_coordinator_cli.py
@@ -211,7 +211,7 @@ class CliTests(unittest.TestCase):
                 submitted,
                 [("complete", {"handoff_dir": str(Path(d) / "handoff")}, "coordinator-cli")],
             )
-            self.assertEqual(polled, [("req-1", 5.0, 0.1)])
+            self.assertEqual(polled, [("req-1", 30.0, 0.1)])
             self.assertEqual(json.loads(buf.getvalue()), {"completed": [{"slice_id": "slice-a", "gate_status": "passed"}]})
             self.assertEqual(reg.list_jobs(), [])
 


### PR DESCRIPTION
## 背景
#152：`_submit_mutation_request` 的 5s timeout 小於 fanout/work 真實耗時，daemon 背後成功卻回報失敗，operator 重試撞 `worktree already exists` 進入 slice failed 死路。

## 修改
- `coordinator/cli.py`：`_REQUEST_TIMEOUTS`（fanout/tick=60、complete/work-action=30、其他 5）；逾時改回傳 pending 訊息（含 req_id 與 `cortex request show/wait` 追蹤指引）+ `EXIT_SUBMITTED_PENDING=3` 區別失敗。
- CHANGELOG / README / changelog.d / openspec tasks 同步。
- `tests/test_fix_mutation_request_timeout.py`：分級 timeout、pending exit code、成功路徑不變。

## review 修訂
code-review（claude/sonnet，ForeignReview）指出 blocking regression：`complete` 5→30 打破兩個既有測試（assert 5.0）；`_REQUEST_TIMEOUTS` 的 `work`/`run` 為死表項（contract.REQUEST_TYPES 無 work/run）。已修正：兩既有測試更新 30.0（符合 spec）、移除死表項。全測 1207 passed。

## 派工與審查
- builder：cortex 派工 codex（`gpt-5.3-codex-spark`），feature-oneshot（worktree-isolation/tdd-red/subagent-build + verification passed）。
- ForeignReview（claude/sonnet）code-review：blocking finding 已由 operator 修正。
- operator（Copilot CLI）對抗 review：APPROVED（修復正確、finding 已解、全測綠）。

Closes #152

- [x] `python3 -m pytest tests/ -q` 1207 passed
- [x] `python3 -m policy_check --repo .` 0 fail
- [x] `git diff --check` 乾淨