### PR TITLE
docs(multi-issue-worktree): #134 規劃產物與 work-item entry

### DIFF
--- a/.cortex/work-items.yaml
+++ b/.cortex/work-items.yaml
@@ -173,6 +173,21 @@ work_items:
         ref: docs/superpowers/specs/fix-mutation-request-timeout-design.md
       - kind: path
         ref: docs/superpowers/plans/fix-mutation-request-timeout.md
+  multi-issue-worktree:
+    title: multi-issue Work Item + repo-scoped builder worktree (#134)
+    links:
+      - kind: github_issue
+        ref: hamanpaul/paulsha-cortex#134
+      - kind: openspec
+        ref: 2026-07-26-multi-issue-worktree
+      - kind: path
+        ref: docs/superpowers/workstreams/multi-issue-worktree/todo.md
+      - kind: path
+        ref: docs/superpowers/specs/multi-issue-worktree-spec.md
+      - kind: path
+        ref: docs/superpowers/specs/multi-issue-worktree-design.md
+      - kind: path
+        ref: docs/superpowers/plans/multi-issue-worktree.md
   dispatch-reliability-batch:
     title: dispatch reliability batch (abandoned, #134)
     links: []

--- a/docs/superpowers/plans/multi-issue-worktree.md
+++ b/docs/superpowers/plans/multi-issue-worktree.md
@@ -1,0 +1,30 @@
+---
+status: accepted
+work_item: multi-issue-worktree
+---
+
+# multi-issue-worktree Plan
+
+## Tasks
+
+### 1. TDD RED
+
+- [ ] `tests/test_multi_issue_worktree.py`：
+  - `test_build_branch_uses_canonical_primary_issue_for_multi_issue_run`：2-issue run（如 `repo#34`、`repo#39`）進 build phase 不 raise；注入 fake `WorktreeCreator`（記錄 `create(branch)` 的 branch），斷言 branch == `feature/34-{work_id}`（編號最小為 primary）。
+  - `test_single_issue_build_branch_unchanged`：1-issue run branch == `feature/{issue}-{work_id}`（回歸鎖定）。
+  - `test_build_worktree_uses_run_workspace_root_not_manager_repo`：run.workspace_root 指向 run repo，Manager repo 不同；斷言 build 構造的 `ScriptWorktreeCreator` 以 run.workspace_root 為 repo（用真實 git repo fixture，驗 `git -C` 作用對象 / worktree pool 為 run repo sibling）。
+  - `test_pr_metadata_closes_all_mapped_issues`：multi-issue run 的 `_pr_metadata` body 含 `Closes #34` 與 `Closes #39`（既有邏輯鎖定）。
+  - 先確認 RED（多 issue 在現行 `>1` raise 下失敗；worktree repo 測試在現行共用 creator 下指向 Manager repo 失敗）。
+
+### 2. 實作
+
+- [ ] `paulsha_cortex/config/paths.py`：新增 `worktree_root_for(repo: Path) -> Path`（sibling pool，尊重 `PSC_WORKTREE_ROOT`）；`worktree_root()` 改 `return worktree_root_for(repo_root())`，消除重複。
+- [ ] `paulsha_cortex/coordinator/manager.py` build phase（~5309-5325）：移除 `len(issue_numbers) > 1` raise；`primary = min(int(n) for n in issue_numbers)`；`builder_branch = f"feature/{primary}-{run.work_id}" if issue_numbers else f"feature/{run.work_id}"`；以 `ScriptWorktreeCreator(repo=run.workspace_root, wt_root=worktree_root_for(Path(run.workspace_root)), base="main")` 取代 `dispatcher._worktree_creator`（僅 build phase、`creator is None` 之分管；保留 `creator is None` raise 的語意改為 run-scoped 構造失敗時 raise）。
+- [ ] 匯入：`from ..config.paths import worktree_root_for`（或既有 paths alias）；`from .seams import ScriptWorktreeCreator`（manager.py 已否則補）。
+
+### 3. 同步與驗證
+
+- [ ] `changelog.d/multi-issue-worktree.md`；`CHANGELOG.md [Unreleased]` `### Fixed` 加入含 `#134` 條目（multi-issue Work Item + repo-scoped builder worktree）。
+- [ ] README 對應段同步（R-18：multi-issue Work Item 與 repo-scoped worktree）若 README 有 builder/worktree 相關段；無則補一行概念說明。
+- [ ] `python3 -m pytest tests/ -q` 全綠；`policy_check --repo .` 0 fail；`git diff --check` 乾淨。
+- [ ] 勾選 `openspec/changes/2026-07-26-multi-issue-worktree/tasks.md` 並以 conventional commit 提交。

--- a/docs/superpowers/specs/multi-issue-worktree-design.md
+++ b/docs/superpowers/specs/multi-issue-worktree-design.md
@@ -1,0 +1,43 @@
+---
+status: accepted
+work_item: multi-issue-worktree
+---
+
+# multi-issue-worktree Design
+
+## Decisions
+
+### D1 canonical primary issue branch naming（非 `feature/<work_id>` 新形狀）
+
+選 **編號最小 issue 為 primary**，branch = `feature/{primary}-{work_id}`，逐字沿用既有單 issue 格式。
+
+不選 `feature/<work_id>`（issue 提到的另一選項）：雖語意合理，但 monitor 的 PR↔issue correlation 有 branch-name heuristic（`feature/{number}-*`，見 `test_monitor_work_providers.py`）；引入無 issue 編號的新形狀會破壞該 heuristic，需連動改 monitor，擴大爆炸半徑。canonical primary 保留既有形狀，monitor 與 delivery 既有邏輯零改動，closing keywords 仍涵蓋全部 issue。
+
+`manager.py:5313-5325` 現行：
+```
+issue_numbers = [m.group(1) for ref in run.issue_refs if (match := re.fullmatch(rf"{re.escape(run.repo)}#([1-9][0-9]*)", ref))]
+if len(issue_numbers) > 1:
+    raise ValueError("workflow builder requires exactly one confirmed issue")
+builder_branch = f"feature/{issue_numbers[0]}-{run.work_id}" if issue_numbers else f"feature/{run.work_id}"
+```
+改為：移除 `>1` raise；`primary = min(int(n) for n in issue_numbers)`；`builder_branch = f"feature/{primary}-{run.work_id}"`（issue 為空時 fallback `feature/{run.work_id}` 不變）。單 issue：primary 即唯一 → 行為不變。
+
+### D2 run-scoped worktree creator（build phase 專用）
+
+在 build phase 分支（`manager.py:5309-5325`）不再取 `dispatcher._worktree_creator`，改構造 `ScriptWorktreeCreator(repo=run.workspace_root, wt_root=worktree_pool_for(run.workspace_root), base=DEFAULT_BRANCH)`。保留 `creator.create(builder_branch)` 呼叫介面不變。
+
+- `worktree_pool_for(repo)`：新增 `paths.worktree_root_for(repo: Path) -> Path`，鏡射 `worktree_root()` 的 sibling 邏輯但以傳入 repo 為錨點（`_canonical_repo_root(repo).parent / f"{name}-worktrees"`），尊重 `PSC_WORKTREE_ROOT` env（與既有 `worktree_root()` 同一支函式重用：將 `worktree_root()` 改為 `return worktree_root_for(repo_root())`，避免重複邏輯）。
+- `DEFAULT_BRANCH`：run 的 default branch。現行 `ScriptWorktreeCreator(base="main")` 預設 main；本批保留 `main` 為 build base（與既有單 issue 行為一致）。不引入 dispatch_base 客製化（那是 #175 範疇）。
+
+不選「擴充 `WorktreeCreator.create` 加 repo 參數」：會破壞 `WorktreeCreator` Protocol 與所有 fake/real 實作（`autonomy.py`、測試 `FakeWorktreeCreator`），爆炸半徑大。run-scoped 實例化為 build phase 區域行為，零 Protocol 改動。
+
+### D3 不改動範圍
+
+- `autonomy.py:551` 非 workflow 派工路徑：仍用 dispatcher 共用 creator（Manager repo 為正確 repo）。
+- `work_bridge._pr_metadata`：已 iter 全部 `run.issue_refs` 產 `Closes #N`，不改正式邏輯，僅補測試鎖定 multi-issue。
+- `dispatcher.py` / `manager_daemon.py:790` 共用 creator 構造：不動（仍供非 workflow 路徑用）。
+
+## 風險
+
+- monitor branch-name correlation 對 multi-issue 仍命中 primary issue 編號（因 branch 含 primary）；其餘 issue 經 closingIssuesReferences 收斂——以測試鎖定。
+- 跨 repo build：`run.workspace_root` 必須是可信 repo（`resolve_trusted_repo_root` 已在 claim 時驗證）；build phase 僅取用既有 `run.workspace_root`，不新增信任邊界。

--- a/docs/superpowers/specs/multi-issue-worktree-spec.md
+++ b/docs/superpowers/specs/multi-issue-worktree-spec.md
@@ -1,0 +1,50 @@
+---
+status: accepted
+work_item: multi-issue-worktree
+---
+
+# multi-issue-worktree Specification
+
+#134：Unified workflow builder 對 multi-issue Work Item 與跨 repo run 的兩個 fail-closed 缺口。
+
+## 背景
+
+`_dispatch_workflow_card`（`coordinator/manager.py`）在 build phase 蒐集 `run.issue_refs`，只要 confirmed issue 數量大於 1 就拋 `workflow builder requires exactly one confirmed issue`。Monitor/WorkAuthority 已允許多張 issue 收斂成同一 Work Item（`work_bridge.py` 以 `authority.mapped_issues` 建立含多個 issue_refs 的 run），但 builder 契約不允許同一 run 實作與閉合它們。實證：#179 前置批因本限制被迫將 3-issue `dispatch-reliability-batch` 拆成單 issue work item。
+
+第二缺口：builder worktree 透過 dispatcher 共用的 `ScriptWorktreeCreator`（`coordinator/seams.py`），其 `repo` 預設為 Manager process 的 `paths.repo_root()`（`PSC_REPO_ROOT`）。當全域 Manager 安裝於 paulsha-cortex、run 實際屬於 paulsha-hippo 時，target SHA 與 worktree repo 不一致，跨 repo build 會在 `git -C <manager_repo>` 上下文操作錯誤 repo 而 fail。
+
+## Requirements
+
+### R1 multi-issue run 進入 build
+
+一個 Work Item 可合法綁定一或多張 confirmed GitHub issues。build phase 不得因 confirmed issue 數量大於 1 停止；MUST 改用 deterministic branch naming：
+
+- canonical primary issue = `run.issue_refs` 中編號最小者。
+- builder branch = `feature/{primary_issue_number}-{run.work_id}`（與既有單 issue 格式 `feature/{issue}-{work_id}` 逐字一致）。
+- 單 issue run：primary 即唯一 issue，branch 與既有行為完全相同（不回歸）。
+
+不再拋 `workflow builder requires exactly one confirmed issue`。
+
+### R2 repo-scoped builder worktree
+
+build phase 的 worktree MUST 以 `run.workspace_root` 對應的 canonical git repo 建立，不得依賴 Manager instance 的固定 `PSC_REPO_ROOT`：
+
+- 為 build phase 構造 run-scoped `ScriptWorktreeCreator`，`repo=run.workspace_root`、`wt_root` 為 run repo 的 sibling worktree pool、`base` 為該 repo 的 default branch。
+- 不改動 dispatcher 共用 creator 與 `autonomy.py` 的非 workflow 派工路徑（那裡仍以 Manager repo 為正確 repo）。
+- `ScriptWorktreeCreator` 既有 fail-closed 驗證（base `rev-parse --verify`、既有 branch ancestry `merge-base --is-ancestor`、target exists、branch probe）MUST 保留並對 run repo 生效。
+
+### R3 限制
+
+- stdlib-only；TDD（先 RED）。
+- 不改對外 CLI `--json` envelope schema 字串。
+- delivery PR body 的 closing keywords 涵蓋該 Work Item 全部 mapped issues（`work_bridge._pr_metadata` 已 iter `run.issue_refs`；本批僅以測試鎖定既有行為，不改正式邏輯）。
+- `python3 -m pytest tests/ -q` 全綠；`policy_check --repo .` 0 fail；`git diff --check` 乾淨。
+- 不處理 #175（re-claim PR 繼承）與 #177（driving-cortex skill）。
+
+## 驗收
+
+- 新增 2-issue Work Item 的 workflow 整合測試：claim → accepted planning → build dispatch 成功（不再 raise `requires exactly one confirmed issue`），且 builder branch = `feature/{min_issue}-{work_id}`。
+- 新增「Manager repo ≠ WorkflowRun repo」整合測試：build worktree 建於 run repo 的 sibling pool，`git -C` 指向 run workspace_root 而非 Manager repo。
+- 單 issue 既有 branch naming 與 lifecycle tests 不退化。
+- multi-issue run 的 `_pr_metadata` 產出含全部 issue 的 `Closes #N`（鎖定測試）。
+- CompletionRecord / delivery binding 保留全部 issue source revisions（既有路徑，以測試鎖定）。

--- a/docs/superpowers/workstreams/multi-issue-worktree/todo.md
+++ b/docs/superpowers/workstreams/multi-issue-worktree/todo.md
@@ -1,0 +1,13 @@
+---
+status: accepted
+work_item: multi-issue-worktree
+---
+
+# multi-issue-worktree Todo
+
+## Tasks
+
+- [ ] 將 issue #134、active OpenSpec change `2026-07-26-multi-issue-worktree` 與本 Todo 綁定為同一 confirmed Work Item。
+- [ ] coordinator 派工 codex（gpt-5.3-codex-spark）完成 #134 修復（TDD）：multi-issue Work Item 進 build（canonical primary issue branch naming）+ repo-scoped builder worktree（`run.workspace_root`）。
+- [ ] ForeignReview（agy/gemini-3.6-flash）adversarial-review 通過；operator（Copilot CLI session）驗收核可。
+- [ ] 2-issue Work Item claim→build dispatch 成功；Manager repo ≠ WorkflowRun repo 時 worktree 建於 run repo sibling pool；單 issue 既有 lifecycle 不退化；delivery PR closing keywords 涵蓋全部 mapped issues（驗證 #134）。

--- a/openspec/changes/2026-07-26-multi-issue-worktree/proposal.md
+++ b/openspec/changes/2026-07-26-multi-issue-worktree/proposal.md
@@ -1,0 +1,23 @@
+---
+status: accepted
+work_item: multi-issue-worktree
+---
+
+## Goals
+
+讓 unified workflow builder 支援 multi-issue Work Item（deterministic canonical primary issue branch naming）與 repo-scoped builder worktree（以 `run.workspace_root` 建立，不依賴 Manager 的 `PSC_REPO_ROOT`），消除 #134 的兩個 fail-closed 缺口。
+
+## Why
+
+Monitor/WorkAuthority 已允許多張 issue 收斂成同一 Work Item，但 `manager._dispatch_workflow_card` 在 build phase 對 confirmed issue > 1 拋 `workflow builder requires exactly one confirmed issue`，使 multi-issue run 無法實作與閉合（#179 前置批因此被迫拆成單 issue work item）。同時 builder worktree 透過 dispatcher 共用的 `ScriptWorktreeCreator`（預設 `paths.repo_root()`＝Manager repo），跨 repo run（Manager 在 paulsha-cortex、run 屬 paulsha-hippo）會在錯誤 repo 操作 git 而 fail。
+
+## What Changes
+
+- `coordinator/manager.py` build phase：移除 multi-issue raise；以編號最小 issue 為 primary 構造 `feature/{primary}-{work_id}` branch；構造 run-scoped `ScriptWorktreeCreator(repo=run.workspace_root, wt_root=worktree_root_for(run.workspace_root), base="main")` 取代 dispatcher 共用 creator。
+- `config/paths.py`：新增 `worktree_root_for(repo)`；`worktree_root()` 改為其 delegate，消除重複。
+- `tests/test_multi_issue_worktree.py`：2-issue claim→build、Manager repo≠run repo worktree、single-issue 回歸、`_pr_metadata` closes all mapped issues。
+
+## Capabilities
+
+### Modified Capabilities
+- `coordinator/workflow-build`：multi-issue Work Item 進 build；builder worktree 以 run repo 為錨點。

--- a/openspec/changes/2026-07-26-multi-issue-worktree/tasks.md
+++ b/openspec/changes/2026-07-26-multi-issue-worktree/tasks.md
@@ -1,0 +1,11 @@
+---
+status: accepted
+work_item: multi-issue-worktree
+---
+
+# Tasks
+
+- [ ] 1.1 RED：`tests/test_multi_issue_worktree.py` 涵蓋 multi-issue build branch（primary=編號最小）、single-issue 回歸、build worktree 使用 `run.workspace_root`、`_pr_metadata` closes 全部 mapped issues。
+- [ ] 1.2 `config/paths.py` `worktree_root_for(repo)` + `worktree_root()` delegate。
+- [ ] 1.3 `coordinator/manager.py` build phase：移除 `>1` raise、canonical primary branch、run-scoped `ScriptWorktreeCreator`（#134）。
+- [ ] 1.4 `changelog.d/multi-issue-worktree.md` 與 `CHANGELOG.md [Unreleased] ### Fixed`（#134）；README 同步（R-18）。


### PR DESCRIPTION
## 摘要

為 #134（multi-issue Work Item + repo-scoped builder worktree）建立規劃三件套（spec/design/plan）、workstream todo、OpenSpec change（`2026-07-26-multi-issue-worktree`）與 `.cortex/work-items.yaml` entry。本 PR 僅含規劃產物（docs-only）；實作由後續 cortex 派工 codex（gpt-5.3-codex-spark）以 TDD 落地，adversarial review 由 agy（gemini-3.6-flash）執行，operator 驗收。

## 變更

- `docs/superpowers/specs/multi-issue-worktree-{spec,design}.md`、`docs/superpowers/plans/multi-issue-worktree.md`
- `docs/superpowers/workstreams/multi-issue-worktree/todo.md`
- `openspec/changes/2026-07-26-multi-issue-worktree/{proposal,tasks}.md`
- `.cortex/work-items.yaml`：新增 `multi-issue-worktree` entry

## 設計要點

- **R1 multi-issue 進 build**：canonical primary issue（編號最小）→ `feature/{primary}-{work_id}`，逐字沿用既有單 issue 格式（monitor branch correlation 零改動），移除 `>1` raise。
- **R2 repo-scoped worktree**：build phase 構造 run-scoped `ScriptWorktreeCreator(repo=run.workspace_root)`；新增 `paths.worktree_root_for(repo)`；不動 `autonomy.py` 非 workflow 路徑。

## 關聯

參考 #134（本 PR 不關閉該 issue，實作 PR 將以 `Closes #134` 閉合）。

## Checklist

- [x] 規劃三件套 frontmatter `status: accepted` + `work_item`，必要標題齊備，無 TBD
- [x] `.cortex/work-items.yaml` entry 與 issue/openspec/path links 綁定
- [x] `python3 -m policy_check --repo .` 0 fail
- [x] docs-only；CHANGELOG entry 隨實作 PR 落地（R-09 pass）

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>