### PR TITLE
fix(coordinator): multi-issue Work Item + repo-scoped builder worktree (#134)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ## [Unreleased]
 
 ### Fixed
+- **Issue #134：multi-issue build 支援最小 issue 為主 branch 且以 run repository 建立 worktree**：builder 會在 run 含多個 issue 時，使用編號最小的 `feature/<主issue>-<work_id>`，並由 run repo 作為 `ScriptWorktreeCreator` 的 git 工作目錄。
 - **Issue #152：mutation request 逾時改採分級 timeout + pending 回報**：`coordinator/cli.py` `_submit_mutation_request` 依 `req_type` 套用分級 timeout（`fanout`/`tick` 60 秒、`complete`/`work`/`work-action`/`run` 30 秒、其餘 5 秒），`poll` timeout 時保留 `req_id` 與追蹤指引並回傳 `EXIT_SUBMITTED_PENDING`（exit 3）避免成功派工被誤報為失敗。
 - **Issue #99：git runner 與 systemd 單元以 repo root 為基準**：`dispatcher._default_git_runner` 現在以 `git -C <repo_root>` 執行 git 呼叫；`cortex-manager.service` 與 `cortex-monitor.service` 渲染時皆加入 `WorkingDirectory=<repo_root>`，避免 daemon 於非預期目錄執行 git 或長駐服務命令。
 - **Issue #182：monitor workflow provider 跳過 superseded run 的 issue authority**：`WorkflowRegistryProvider` 建立 workflow_links 時不再對 `superseded` run 主張 issue/pr/openspec authority，避免廢棄 run 的 issue_refs 與其他 work item 衝突使 provider degraded；degraded 會凍結 `project_work_items` 於舊 snapshot，讓新以 work-items.yaml `github_issue` link 綁定的 source 永遠不進入 monitor read model。

--- a/README.md
+++ b/README.md
@@ -480,6 +480,8 @@ cortex work review-attest "$WORK_ID" --repo "$REPO" --actor "$ACTOR" \
 | repo root | 指定 install 時的 git repo top-level（`--repo-root`） | `PSC_REPO_ROOT` |
 | worktree root | `<repo>-worktrees` sibling | `PSC_WORKTREE_ROOT` |
 
+Multi-issue workflow build 階段將以 `issue` 清單中最小號碼作為主 branch，並始終以 run repository 作為 `ScriptWorktreeCreator` 的 git來源，以確保 builder worktree 在對應 repo 池內建立。
+
 共同前綴 `PSC_AGENTS_ROOT` 可一次覆寫 mutable/runtime roots。systemd unit 依宣告順序讀取 `~/.agents/core/runtime/<instance>.env` 與固定 bootstrap `~/.agents/core/runtime/<instance>-manager.env`；installer在後者持久化`PSC_INSTANCE`與`PSC_AGENTS_ROOT`。Interactive CLI以同一`PSC_INSTANCE`選取bootstrap env，不掃描猜測其他instance；symlink、malformed或relative root會fail-closed。installer重跑會更新自身管理的Python/repo值，但保留既有operator roots。Monitor socket預設為`$PSC_RUN_ROOT/project-monitor.sock`，也可由`project-cortex.yaml`的`monitor.socket_path`覆寫；production `MonitorSocketClient`與service使用相同config解析。
 
 ## 誠實狀態表

--- a/changelog.d/multi-issue-worktree.md
+++ b/changelog.d/multi-issue-worktree.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **Issue #134：multi-issue build 不再限制只允許單一 issue**：Builder 在 build phase 會採用排序後最小的 issue 編號作為 `feature/<issue>-<work_id>` 的主 branch，並改用 run workspace repo 作為 worktree 建立來源。

--- a/openspec/changes/2026-07-26-multi-issue-worktree/tasks.md
+++ b/openspec/changes/2026-07-26-multi-issue-worktree/tasks.md
@@ -5,7 +5,7 @@ work_item: multi-issue-worktree
 
 # Tasks
 
-- [ ] 1.1 RED：`tests/test_multi_issue_worktree.py` 涵蓋 multi-issue build branch（primary=編號最小）、single-issue 回歸、build worktree 使用 `run.workspace_root`、`_pr_metadata` closes 全部 mapped issues。
+- [x] 1.1 RED：`tests/test_multi_issue_worktree.py` 涵蓋 multi-issue build branch（primary=編號最小）、single-issue 回歸、build worktree 使用 `run.workspace_root`、`_pr_metadata` closes 全部 mapped issues。
 - [ ] 1.2 `config/paths.py` `worktree_root_for(repo)` + `worktree_root()` delegate。
 - [ ] 1.3 `coordinator/manager.py` build phase：移除 `>1` raise、canonical primary branch、run-scoped `ScriptWorktreeCreator`（#134）。
 - [ ] 1.4 `changelog.d/multi-issue-worktree.md` 與 `CHANGELOG.md [Unreleased] ### Fixed`（#134）；README 同步（R-18）。

--- a/openspec/changes/2026-07-26-multi-issue-worktree/tasks.md
+++ b/openspec/changes/2026-07-26-multi-issue-worktree/tasks.md
@@ -6,6 +6,6 @@ work_item: multi-issue-worktree
 # Tasks
 
 - [x] 1.1 RED：`tests/test_multi_issue_worktree.py` 涵蓋 multi-issue build branch（primary=編號最小）、single-issue 回歸、build worktree 使用 `run.workspace_root`、`_pr_metadata` closes 全部 mapped issues。
-- [ ] 1.2 `config/paths.py` `worktree_root_for(repo)` + `worktree_root()` delegate。
-- [ ] 1.3 `coordinator/manager.py` build phase：移除 `>1` raise、canonical primary branch、run-scoped `ScriptWorktreeCreator`（#134）。
-- [ ] 1.4 `changelog.d/multi-issue-worktree.md` 與 `CHANGELOG.md [Unreleased] ### Fixed`（#134）；README 同步（R-18）。
+- [x] 1.2 `config/paths.py` `worktree_root_for(repo)` + `worktree_root()` delegate。
+- [x] 1.3 `coordinator/manager.py` build phase：移除 `>1` raise、canonical primary branch、run-scoped `ScriptWorktreeCreator`（#134）。
+- [x] 1.4 `changelog.d/multi-issue-worktree.md` 與 `CHANGELOG.md [Unreleased] ### Fixed`（#134）；README 同步（R-18）。

--- a/paulsha_cortex/config/paths.py
+++ b/paulsha_cortex/config/paths.py
@@ -69,10 +69,15 @@ def _canonical_repo_root(repo: Path) -> Path:
     return repo
 
 
-def worktree_root() -> Path:
-    """coordinator 派工 worktree 池預設為 sibling `<repo>-worktrees`。"""
+def worktree_root_for(repo: Path) -> Path:
+    """依給定 repo 計算 worktree pool，預設為 sibling `<repo>-worktrees`。"""
     override = _env_path("PSC_WORKTREE_ROOT")
     if override is not None:
         return override
-    repo = _canonical_repo_root(repo_root())
+    repo = _canonical_repo_root(repo)
     return repo.parent / f"{repo.name}-worktrees"
+
+
+def worktree_root() -> Path:
+    """coordinator 派工 worktree pool 的預設路徑。"""
+    return worktree_root_for(repo_root())

--- a/paulsha_cortex/coordinator/manager.py
+++ b/paulsha_cortex/coordinator/manager.py
@@ -5320,7 +5320,9 @@ def _dispatch_workflow_card(
                 )
             except BaseException as exc:
                 raise ValueError("workflow builder worktree creator unavailable") from exc
-        elif str(Path(getattr(creator, "repo_root", "")).resolve()) != str(workspace_root.resolve()):
+        elif isinstance(creator, seams.ScriptWorktreeCreator) and (
+            str(Path(creator.repo_root).resolve()) != str(workspace_root.resolve())
+        ):
             try:
                 creator = seams.ScriptWorktreeCreator(
                     repo=workspace_root,

--- a/paulsha_cortex/coordinator/manager.py
+++ b/paulsha_cortex/coordinator/manager.py
@@ -22,8 +22,10 @@ from ..persona import gate, handoff
 from . import autonomy
 from . import completion
 from . import planning_runtime
+from . import seams
 from . import review as foreign_review
 from . import verification
+from ..config.paths import worktree_root_for
 from .model_identities import (
     AGY_DOMAIN,
     AGY_LIVE_PROBE,
@@ -5308,18 +5310,34 @@ def _dispatch_workflow_card(
         worktree = str(builder_jobs[-1]["worktree"])
     elif step.phase == "build":
         creator = getattr(dispatcher, "_worktree_creator", None)
+        workspace_root = Path(run.workspace_root)
         if creator is None:
-            raise ValueError("workflow builder worktree creator unavailable")
+            try:
+                creator = seams.ScriptWorktreeCreator(
+                    repo=workspace_root,
+                    wt_root=worktree_root_for(workspace_root),
+                    base="main",
+                )
+            except BaseException as exc:
+                raise ValueError("workflow builder worktree creator unavailable") from exc
+        elif str(Path(getattr(creator, "repo_root", "")).resolve()) != str(workspace_root.resolve()):
+            try:
+                creator = seams.ScriptWorktreeCreator(
+                    repo=workspace_root,
+                    wt_root=worktree_root_for(workspace_root),
+                    base="main",
+                )
+            except BaseException as exc:
+                raise ValueError("workflow builder worktree creator unavailable") from exc
         issue_numbers = [
-            match.group(1)
+            int(match.group(1))
             for ref in run.issue_refs
             if (match := re.fullmatch(rf"{re.escape(run.repo)}#([1-9][0-9]*)", ref))
         ]
-        if len(issue_numbers) > 1:
-            raise ValueError("workflow builder requires exactly one confirmed issue")
+        primary_issue = min(issue_numbers) if issue_numbers else None
         builder_branch = (
-            f"feature/{issue_numbers[0]}-{run.work_id}"
-            if issue_numbers
+            f"feature/{primary_issue}-{run.work_id}"
+            if primary_issue is not None
             else f"feature/{run.work_id}"
         )
         worktree = str(creator.create(builder_branch))

--- a/paulsha_cortex/coordinator/seams.py
+++ b/paulsha_cortex/coordinator/seams.py
@@ -63,6 +63,10 @@ class ScriptWorktreeCreator:
         self._wt_root = Path(paths.worktree_root() if wt_root is None else wt_root)
         self._base = base
 
+    @property
+    def repo_root(self) -> Path:
+        return self._repo
+
     def create(self, branch: str, *, base_sha: str | None = None) -> str:
         slug = branch.replace("/", "-")
         target = self._wt_root / slug

--- a/reports/review/2026-07-26-multi-issue-worktree-review.md
+++ b/reports/review/2026-07-26-multi-issue-worktree-review.md
@@ -1,0 +1,69 @@
+---
+workflow_run_id: "workflow-e7117d7992303798057d"
+workflow_card_id: "code-review"
+workflow_job_id: "wf-7b67fee68a-code-review-358"
+candidate: "f88243085aa6e68f0af753245151a395b332536e"
+---
+# Review: multi-issue-worktree
+
+**Candidate:** `f88243085aa6e68f0af753245151a395b332536e`
+**Verdict:** Changes requested (blocking regression found)
+
+## What was checked
+
+- Diff of `ee18cbd` (RED tests) and `f882430` (implementation) against `openspec/changes/2026-07-26-multi-issue-worktree/{proposal,design,tasks}.md`.
+- `paulsha_cortex/config/paths.py`: `worktree_root_for(repo)` extraction with `worktree_root()` delegating to it — correct, matches D2, no behavior change for the no-arg case.
+- `paulsha_cortex/coordinator/manager.py` build phase: removed the `len(issue_numbers) > 1` raise, canonical `primary = min(issue_numbers)` branch naming, and an attempt at a run-scoped `ScriptWorktreeCreator`.
+- `tests/test_multi_issue_worktree.py`: new focused suite — passes (4 passed).
+- `work_bridge._pr_metadata`: unchanged, already iterated all `run.issue_refs`; the new test correctly locks in `Closes #34` / `Closes #39` ordering.
+- CHANGELOG.md / changelog.d / README.md / tasks.md updates: consistent with the shipped code and task checkboxes.
+- `git diff --check 399a515 f882430`: clean, no whitespace errors.
+- Full `pytest tests/` run, cross-checked against parent commit `399a515` in a writable scratch copy (`git archive` extraction, since both the sandbox checkout and `.git` are read-only) to separate real regressions from sandbox artifacts.
+
+## Blocking finding: build-phase silently discards injected WorktreeCreator seams
+
+The new build-phase logic (`manager.py:5310-5328`) is:
+
+```python
+creator = getattr(dispatcher, "_worktree_creator", None)
+workspace_root = Path(run.workspace_root)
+if creator is None:
+    creator = seams.ScriptWorktreeCreator(repo=workspace_root, wt_root=worktree_root_for(workspace_root), base="main")
+elif str(Path(getattr(creator, "repo_root", "")).resolve()) != str(workspace_root.resolve()):
+    creator = seams.ScriptWorktreeCreator(repo=workspace_root, wt_root=worktree_root_for(workspace_root), base="main")
+...
+worktree = str(creator.create(builder_branch))
+```
+
+The `elif` branch is meant to detect "dispatcher's creator already points at the run's repo, reuse it" vs. "different repo, build a scoped one" (design D2). But it keys this off a `.repo_root` attribute that **does not exist** on the real seam:
+
+- `seams.ScriptWorktreeCreator.__init__` only assigns `self._repo` (private) — it never sets `self.repo_root`.
+- The `WorktreeCreator` Protocol (`seams.py:18`) only requires `create(branch, *, base_sha=None)`, not `repo_root`.
+
+So `getattr(creator, "repo_root", "")` returns `""` for the real production creator *and* for essentially every existing test fake in the repo (they only implement `create`). `Path("").resolve()` resolves to the current process's cwd, which almost never equals `run.workspace_root`, so the `elif` branch is taken and the caller-supplied creator is **silently discarded and replaced** with a live `ScriptWorktreeCreator(base="main")` that shells out to real git against `run.workspace_root`.
+
+This breaks any existing dispatch path that relies on an injected `WorktreeCreator` test double returning a canned path without touching git — and it breaks real single-issue builds whenever the target repo's default branch isn't literally named `main` (e.g. freshly `git init`'d repos in tests, or any repo using `master`/another default).
+
+Confirmed as a genuine candidate-caused regression (not a sandbox/environment artifact) by running both commits from a writable scratch copy:
+
+- `tests/test_workflow_production_wiring.py::test_control_queue_manager_executes_heterogeneous_brainstorm_before_plan` — passes on parent `399a515`, fails on candidate `f882430` with `ValueError: git worktree base invalid: fatal: Needed a single revision`.
+- `tests/test_work_bridge.py::test_installed_defaults_start_to_ship_handoff_remains_monitor_ongoing` — same pass→fail transition, same error.
+
+Both failures happen because the tests inject a plain `WorktreeCreator`-shaped fake (no `repo_root` attribute) into a real `Dispatcher`, and the new code swaps it for a real `ScriptWorktreeCreator` that then fails to resolve `main^{commit}` in the test's freshly-initialized repo.
+
+The design doc (D2) actually specifies always constructing the run-scoped creator for the build phase, not conditionally reusing the dispatcher's — the conditional-reuse code path adds complexity that doesn't work as intended and is the direct cause of this regression. Recommend simplifying to unconditionally construct `seams.ScriptWorktreeCreator(repo=run.workspace_root, wt_root=worktree_root_for(run.workspace_root), base="main")` for the build phase, matching the design, rather than trying (and failing) to detect "same repo, reuse existing creator."
+
+## Full-suite run reconciliation (for completeness)
+
+Full `pytest tests/` in the read-only sandbox checkout: 31 failed / 1180 passed / 1 error. Reconciled against the same run on parent commit `399a515` (writable scratch copy): 28 failed / 1179 passed (0 errors). The 28 pre-existing failures are unchanged and confirmed environmental:
+
+- `test_doctor.py`, `test_monitor_work_api.py` (3), `test_stage9_project_monitor_service.py` (24): all `PermissionError: [Errno 1] Operation not permitted` from `socket.socket(AF_UNIX, ...)` — this sandbox forbids creating Unix domain sockets; reproduced identically on the parent commit.
+- `test_persona_phase3_scope_ci.py::CatalogErrorShadowTests::test_subprocess_with_malformed_yaml_still_exits_zero`: fails only in the read-only sandbox checkout (`OSError: Read-only file system` writing back `personas.yaml` in a `finally` cleanup); passes on the candidate commit when run from a writable scratch copy, so this is a checkout-mount artifact, not a candidate defect.
+
+The two genuinely new failures on top of that pre-existing baseline are exactly the `test_workflow_production_wiring.py` and `test_work_bridge.py` cases documented above.
+
+## Non-blocking notes
+
+- `config/paths.py` `worktree_root_for`/`worktree_root` refactor is clean and correctly preserves `PSC_WORKTREE_ROOT` override semantics.
+- `manager.py`'s canonical-primary-issue branch naming (`primary = min(issue_numbers)`) and the removal of the `>1` raise correctly implement D1 and are covered by `test_build_branch_uses_canonical_primary_issue_for_multi_issue_run` / `test_single_issue_build_branch_unchanged`.
+- Docs (CHANGELOG.md, changelog.d/multi-issue-worktree.md, README.md, tasks.md) accurately describe the intended behavior and are internally consistent with each other.

--- a/reports/verify/2026-07-26-multi-issue-worktree-verification.md
+++ b/reports/verify/2026-07-26-multi-issue-worktree-verification.md
@@ -1,0 +1,76 @@
+---
+workflow_run_id: "workflow-e7117d7992303798057d"
+workflow_card_id: "verification"
+workflow_job_id: "wf-7b67fee68a-verification-357"
+candidate: "f88243085aa6e68f0af753245151a395b332536e"
+---
+# Verification: 2026-07-26-multi-issue-worktree
+
+**Candidate:** `f88243085aa6e68f0af753245151a395b332536e`
+**Verdict: REJECT — regressions found, needs fix before merge.**
+
+## Scope reviewed
+
+- `openspec/changes/2026-07-26-multi-issue-worktree/{proposal,design,tasks}.md`
+- `paulsha_cortex/config/paths.py` (`worktree_root_for` / `worktree_root` delegate)
+- `paulsha_cortex/coordinator/manager.py` build-phase dispatch (`_dispatch_workflow_card`)
+- `tests/test_multi_issue_worktree.py` (new)
+- `CHANGELOG.md`, `README.md`, `changelog.d/multi-issue-worktree.md`
+
+## What works
+
+- `worktree_root_for(repo)` / `worktree_root()` refactor in `config/paths.py` is a clean, correct delegate extraction; no behavior change for existing callers.
+- Canonical primary-issue branch naming (`primary = min(issue_numbers)`, `feature/{primary}-{work_id}`) matches design D1 exactly; the `>1` raise is removed as intended.
+- `work_bridge._pr_metadata` already iterated all `run.issue_refs` before this change, so multi-issue `Closes #N` behavior is correct (confirmed by the new `test_pr_metadata_closes_all_mapped_issues` test).
+- The 4 new tests in `tests/test_multi_issue_worktree.py` all pass:
+  - `test_build_branch_uses_canonical_primary_issue_for_multi_issue_run`
+  - `test_single_issue_build_branch_unchanged`
+  - `test_build_worktree_uses_run_workspace_root_not_manager_repo`
+  - `test_pr_metadata_closes_all_mapped_issues`
+- Docs (`CHANGELOG.md`, `README.md`, `changelog.d/multi-issue-worktree.md`, `tasks.md`) are consistent with the shipped behavior.
+
+## Regression found
+
+Design D2 says the build phase should *unconditionally* construct a run-scoped `ScriptWorktreeCreator` instead of reusing `dispatcher._worktree_creator`. The actual implementation in `paulsha_cortex/coordinator/manager.py:5312-5330` instead **conditionally** reuses the dispatcher's creator, only reconstructing when it detects a repo mismatch:
+
+```python
+creator = getattr(dispatcher, "_worktree_creator", None)
+workspace_root = Path(run.workspace_root)
+if creator is None:
+    creator = seams.ScriptWorktreeCreator(repo=workspace_root, wt_root=worktree_root_for(workspace_root), base="main")
+elif str(Path(getattr(creator, "repo_root", "")).resolve()) != str(workspace_root.resolve()):
+    creator = seams.ScriptWorktreeCreator(repo=workspace_root, wt_root=worktree_root_for(workspace_root), base="main")
+```
+
+The `elif` uses `getattr(creator, "repo_root", "")`. Any injected worktree-creator object (test double, or a production creator) that doesn't expose a `repo_root` attribute equal to `run.workspace_root` is silently discarded and replaced by a brand-new real `seams.ScriptWorktreeCreator` hardcoded to `base="main"`. That real creator shells out to `git rev-parse --verify main^{commit}`, which fails whenever the target repo's default branch isn't literally named `main` (e.g. `master`) or hasn't been fully set up — raising `ValueError: git worktree base invalid: fatal: Needed a single revision`.
+
+This breaks two pre-existing tests that inject a lightweight worktree-creator fake without a `repo_root` attribute (the common pattern used throughout this test suite, e.g. `class WorktreeCreator: def create(self, branch, base_sha=None): ...`):
+
+- `tests/test_work_bridge.py::test_installed_defaults_start_to_ship_handoff_remains_monitor_ongoing`
+- `tests/test_workflow_production_wiring.py::test_control_queue_manager_executes_heterogeneous_brainstorm_before_plan`
+
+Both pass cleanly on the pre-fix commit `399a515` and fail on candidate `f882430` — verified by cloning the repo into a writable scratch directory (outside this read-only Candidate checkout) and running the exact same tests against both commits, which rules out this sandbox's own restrictions (see below) as the cause:
+
+```
+# at 399a515 (writable clone): 1 passed
+# at f882430 (writable clone): 1 failed — ValueError: git worktree base invalid: fatal: Needed a single revision
+#   raised from paulsha_cortex/coordinator/seams.py:80 via manager.py:5343 creator.create(builder_branch)
+```
+
+The new test suite (`tests/test_multi_issue_worktree.py`) does not catch this because its `_RecordingCreator` fake is constructed with `repo_root=workspace`, which happens to match `run.workspace_root`, so the buggy `elif` branch is never exercised for the "no-op / same-repo" case — leaving the discard-of-injected-creator defect unguarded.
+
+### Suggested fix direction
+Follow design D2 literally: always construct the run-scoped `ScriptWorktreeCreator` in the build phase and stop reading `dispatcher._worktree_creator` there at all (it's documented in D3 as intentionally out of scope for build phase). That removes both the `repo_root`-sniffing heuristic and the implicit dependency on test doubles exposing `repo_root`. Alternatively, if reuse-when-same-repo is intentionally desired, the comparison must not default-mismatch on missing `repo_root`, and `base` must not be hardcoded to `"main"` without a documented explicit contract for non-main-default repos.
+
+## Non-issues (sandbox artifacts, excluded from verdict)
+
+The full suite run in the read-only Candidate checkout also shows failures in `tests/test_stage9_project_monitor_service.py`, `tests/test_monitor_work_api.py`, and `tests/test_doctor.py::test_monitor_protocol_probe_rejects_transport_only_listener` — all `PermissionError: [Errno 1] Operation not permitted` on `socket.socket(socket.AF_UNIX, ...)`, unrelated to any file this change touches (monitor module is untouched). `tests/test_persona_phase3_scope_ci.py::test_subprocess_with_malformed_yaml_still_exits_zero` fails only because the Candidate checkout's `paulsha_cortex/persona/personas.yaml` is read-only in this sandbox (the test tries to temporarily overwrite it in place); it passes in a writable clone at the candidate commit. These are environment restrictions of this review sandbox, not defects introduced by the change.
+
+## Commands run
+
+```
+git rev-parse HEAD
+python -m pytest tests/test_multi_issue_worktree.py -q          # 4 passed
+python -m pytest tests/ -q                                       # 31 failed, 1180 passed (see triage above)
+# isolated repro in writable TMPDIR clone at 399a515 vs f882430
+```

--- a/tests/test_multi_issue_worktree.py
+++ b/tests/test_multi_issue_worktree.py
@@ -51,7 +51,7 @@ class _RecordingCreator:
 
 def _init_repo(root: Path) -> None:
     root.mkdir(parents=True, exist_ok=True)
-    subprocess.run(["git", "-C", str(root), "init", "-q"], check=True)
+    subprocess.run(["git", "-C", str(root), "init", "-q", "-b", "main"], check=True)
     subprocess.run(["git", "-C", str(root), "config", "user.email", "test@example.com"], check=True)
     subprocess.run(["git", "-C", str(root), "config", "user.name", "Test User"], check=True)
     (root / "README.md").write_text("test\n", encoding="utf-8")
@@ -161,6 +161,8 @@ def test_single_issue_build_branch_unchanged(tmp_path: Path) -> None:
 def test_build_worktree_uses_run_workspace_root_not_manager_repo(
     tmp_path: Path, monkeypatch: Any
 ) -> None:
+    from paulsha_cortex.config.paths import worktree_root_for
+
     manager_repo = tmp_path / "manager-repo"
     run_workspace = tmp_path / "run-repo"
     _init_repo(manager_repo)
@@ -171,22 +173,13 @@ def test_build_worktree_uses_run_workspace_root_not_manager_repo(
         workspace_root=run_workspace,
         issue_refs=(f"{_REPO}#34",),
     )
-    manager_creator = _RecordingCreator(manager_repo)
+    # Production daemon injects a real ScriptWorktreeCreator anchored at the
+    # Manager repo; build phase must re-anchor it to the run's workspace_root.
+    manager_pool = manager_repo.parent / f"{manager_repo.name}-worktrees"
+    manager_creator = manager.seams.ScriptWorktreeCreator(
+        repo=manager_repo, wt_root=manager_pool, base="main"
+    )
     launcher = _CommitLauncher()
-    script_calls: dict[str, object] = {}
-
-    class FakeScriptWorktreeCreator:
-        def __init__(self, repo: str | Path, wt_root: str | Path, base: str = "main") -> None:
-            script_calls["repo"] = str(repo)
-            script_calls["wt_root"] = str(wt_root)
-            script_calls["base"] = base
-            script_calls["branch"] = []
-
-        def create(self, branch: str, *, base_sha: str | None = None) -> str:
-            script_calls.setdefault("branch", []).append((branch, base_sha))
-            return str(run_workspace)
-
-    monkeypatch.setattr(manager.seams, "ScriptWorktreeCreator", FakeScriptWorktreeCreator)
     dispatcher = type(
         "D",
         (),
@@ -213,10 +206,12 @@ def test_build_worktree_uses_run_workspace_root_not_manager_repo(
     assert job is not None
     persisted = registry.get_job(job["job_id"])
 
-    assert script_calls["repo"] == str(run_workspace.resolve())
-    assert script_calls["branch"] == [("feature/34-multi-issue-worktree", None)]
-    assert persisted["worktree"] == str(run_workspace)
-    assert manager_creator.calls == []
+    expected_pool = worktree_root_for(run_workspace)
+    expected_worktree = expected_pool / "feature-34-multi-issue-worktree"
+    assert persisted["worktree"] == str(expected_worktree)
+    assert expected_worktree.is_dir()
+    # Manager-anchored pool must NOT receive the build worktree.
+    assert not (manager_pool / "feature-34-multi-issue-worktree").exists()
 
 
 def test_pr_metadata_closes_all_mapped_issues(tmp_path: Path) -> None:

--- a/tests/test_multi_issue_worktree.py
+++ b/tests/test_multi_issue_worktree.py
@@ -1,0 +1,234 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Any
+
+from paulsha_cortex.coordinator import manager, work_bridge
+from paulsha_cortex.coordinator.launcher import LaunchHandle
+from paulsha_cortex.coordinator.model_identities import IdentityRegistry
+from paulsha_cortex.coordinator.registry import JobRegistry
+from paulsha_cortex.coordinator.workflow import WorkflowStep
+
+
+_REPO = "hamanpaul/paulsha-cortex"
+
+
+class _CommitLauncher:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, str]] = []
+
+    def as_commit_required(self):
+        return self
+
+    def launch(self, *, slice_id: str, prompt: str, worktree: str, log_dir: str) -> LaunchHandle:
+        self.calls.append(
+            {
+                "slice_id": slice_id,
+                "worktree": worktree,
+                "prompt": prompt,
+                "log_dir": log_dir,
+            },
+        )
+        return LaunchHandle(
+            executor="copilot",
+            model_id="gpt",
+            session_name=slice_id,
+            pid=100,
+            log_path=f"{log_dir}/{slice_id}.jsonl",
+        )
+
+
+class _RecordingCreator:
+    def __init__(self, repo_root: Path) -> None:
+        self.repo_root = repo_root
+        self.calls: list[str] = []
+
+    def create(self, branch: str, *, base_sha: str | None = None) -> str:
+        self.calls.append(branch)
+        return str(self.repo_root)
+
+
+def _init_repo(root: Path) -> None:
+    root.mkdir(parents=True, exist_ok=True)
+    subprocess.run(["git", "-C", str(root), "init", "-q"], check=True)
+    subprocess.run(["git", "-C", str(root), "config", "user.email", "test@example.com"], check=True)
+    subprocess.run(["git", "-C", str(root), "config", "user.name", "Test User"], check=True)
+    (root / "README.md").write_text("test\n", encoding="utf-8")
+    subprocess.run(["git", "-C", str(root), "add", "README.md"], check=True)
+    subprocess.run(["git", "-C", str(root), "commit", "-qm", "init"], check=True)
+
+
+def _build_run(
+    registry: JobRegistry,
+    workspace_root: Path,
+    issue_refs: tuple[str, ...],
+) -> Any:
+    step = WorkflowStep(
+        phase="build",
+        persona="builder",
+        card="tdd-red",
+        executor="copilot",
+        model="gpt",
+        domain="openai",
+        inputs=(),
+        outputs=(),
+        commit_policy="required",
+        test_policy="red-required",
+        gate_result="pending",
+    )
+    return registry._manager_create_workflow_run(
+        work_id="multi-issue-worktree",
+        repo=_REPO,
+        claim_key="claim:v1:" + "1" * 64,
+        source_revision="2" * 64,
+        workspace_root=str(workspace_root),
+        combo="feature-oneshot",
+        current_phase="build",
+        steps=(step,),
+        issue_refs=issue_refs,
+        openspec_refs=("2026-07-26-multi-issue-worktree",),
+        pr_refs=(),
+        attempts={"build": 1},
+        gate_status="running",
+    )
+
+
+def _dispatch(
+    run,
+    registry: JobRegistry,
+    creator: _RecordingCreator,
+    tmp_path: Path,
+) -> tuple[dict[str, object], _CommitLauncher]:
+    launcher = _CommitLauncher()
+    dispatcher = type(
+        "D",
+        (),
+        {
+            "_registry": registry,
+            "_worktree_creator": creator,
+            "_git_runner": None,
+        },
+    )()
+    job = manager.dispatch_workflow_card(
+        dispatcher,
+        run=run,
+        identities=IdentityRegistry.from_rows(
+            [{
+                "executor": "copilot",
+                "model_id": "gpt",
+                "independence_domain": "openai",
+                "capabilities": ["build"],
+            }]
+        ),
+        launcher_factory=lambda _: launcher,
+        coordinator_root=tmp_path / "coordinator",
+    )
+    assert job is not None
+    return registry.get_job(job["job_id"]), launcher
+
+
+def test_build_branch_uses_canonical_primary_issue_for_multi_issue_run(tmp_path: Path) -> None:
+    workspace = tmp_path / "run-repo"
+    _init_repo(workspace)
+    registry = JobRegistry(state_path=tmp_path / "jobs.json")
+    run = _build_run(
+        registry,
+        workspace_root=workspace,
+        issue_refs=(f"{_REPO}#39", f"{_REPO}#34"),
+    )
+    creator = _RecordingCreator(workspace)
+    job, launcher = _dispatch(run, registry, creator, tmp_path)
+
+    assert creator.calls == ["feature/34-multi-issue-worktree"]
+    assert job["branch"] == "feature/34-multi-issue-worktree"
+    assert launcher.calls[0]["worktree"] == str(workspace)
+
+
+def test_single_issue_build_branch_unchanged(tmp_path: Path) -> None:
+    workspace = tmp_path / "run-repo"
+    _init_repo(workspace)
+    registry = JobRegistry(state_path=tmp_path / "jobs.json")
+    run = _build_run(registry, workspace_root=workspace, issue_refs=(f"{_REPO}#39",))
+    creator = _RecordingCreator(workspace)
+    job, launcher = _dispatch(run, registry, creator, tmp_path)
+
+    assert creator.calls == ["feature/39-multi-issue-worktree"]
+    assert job["branch"] == "feature/39-multi-issue-worktree"
+    assert launcher.calls[0]["worktree"] == str(workspace)
+
+
+def test_build_worktree_uses_run_workspace_root_not_manager_repo(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    manager_repo = tmp_path / "manager-repo"
+    run_workspace = tmp_path / "run-repo"
+    _init_repo(manager_repo)
+    _init_repo(run_workspace)
+    registry = JobRegistry(state_path=tmp_path / "jobs.json")
+    run = _build_run(
+        registry,
+        workspace_root=run_workspace,
+        issue_refs=(f"{_REPO}#34",),
+    )
+    manager_creator = _RecordingCreator(manager_repo)
+    launcher = _CommitLauncher()
+    script_calls: dict[str, object] = {}
+
+    class FakeScriptWorktreeCreator:
+        def __init__(self, repo: str | Path, wt_root: str | Path, base: str = "main") -> None:
+            script_calls["repo"] = str(repo)
+            script_calls["wt_root"] = str(wt_root)
+            script_calls["base"] = base
+            script_calls["branch"] = []
+
+        def create(self, branch: str, *, base_sha: str | None = None) -> str:
+            script_calls.setdefault("branch", []).append((branch, base_sha))
+            return str(run_workspace)
+
+    monkeypatch.setattr(manager.seams, "ScriptWorktreeCreator", FakeScriptWorktreeCreator)
+    dispatcher = type(
+        "D",
+        (),
+        {
+            "_registry": registry,
+            "_worktree_creator": manager_creator,
+            "_git_runner": None,
+        },
+    )()
+    job = manager.dispatch_workflow_card(
+        dispatcher,
+        run=run,
+        identities=IdentityRegistry.from_rows(
+            [{
+                "executor": "copilot",
+                "model_id": "gpt",
+                "independence_domain": "openai",
+                "capabilities": ["build"],
+            }]
+        ),
+        launcher_factory=lambda _: launcher,
+        coordinator_root=tmp_path / "coordinator",
+    )
+    assert job is not None
+    persisted = registry.get_job(job["job_id"])
+
+    assert script_calls["repo"] == str(run_workspace.resolve())
+    assert script_calls["branch"] == [("feature/34-multi-issue-worktree", None)]
+    assert persisted["worktree"] == str(run_workspace)
+    assert manager_creator.calls == []
+
+
+def test_pr_metadata_closes_all_mapped_issues(tmp_path: Path) -> None:
+    workspace = tmp_path / "run-repo"
+    _init_repo(workspace)
+    registry = JobRegistry(state_path=tmp_path / "jobs.json")
+    run = _build_run(
+        registry,
+        workspace_root=workspace,
+        issue_refs=(f"{_REPO}#39", f"{_REPO}#34"),
+    )
+    metadata = work_bridge._pr_metadata(run)
+    closes = [line for line in metadata["body"].splitlines() if line.startswith("Closes #")]
+
+    assert closes == ["Closes #34", "Closes #39"]


### PR DESCRIPTION
## 摘要

閉合 #134：unified workflow builder 支援 multi-issue Work Item（canonical primary issue branch naming）與 repo-scoped builder worktree（以 `run.workspace_root` 建立）。由 cortex dogfood 派工：codex（gpt-5.3-codex-spark）實作，claude/sonnet verification + code-review，operator 修正 code-review blocking finding。

## 變更

- `paulsha_cortex/coordinator/manager.py` build phase：移除 `>1` confirmed issue raise；canonical primary issue（編號最小）→ `feature/{primary}-{work_id}`；re-anchor 真實 `ScriptWorktreeCreator` 至 `run.workspace_root`（保留注入的 fake creator，不退化既有 lifecycle 測試）。
- `paulsha_cortex/coordinator/seams.py`：`ScriptWorktreeCreator` 新增 public `repo_root` property。
- `paulsha_cortex/config/paths.py`：新增 `worktree_root_for(repo)`；`worktree_root()` delegate。
- `tests/test_multi_issue_worktree.py`：multi-issue build branch（primary=編號最小）、single-issue 回歸、build worktree 使用 `run.workspace_root`（Manager repo ≠ run repo 時建於 run repo sibling pool）、`_pr_metadata` closes 全部 mapped issues。
- `CHANGELOG.md` / `changelog.d/multi-issue-worktree.md`：`### Fixed` #134 條目。

## 驗收

- 2-issue Work Item claim→build dispatch 成功（不再 raise `requires exactly one confirmed issue`）。
- Manager repo ≠ WorkflowRun repo 時 worktree 建於 run repo sibling pool。
- 單 issue 既有 lifecycle tests 不退化（`test_control_queue_manager_executes...` 等回歸綠）。
- delivery PR closing keywords 涵蓋全部 mapped issues（`_pr_metadata` 既有邏輯鎖定）。
- `python3 -m pytest tests/ -q` 1211 passed；`policy_check --repo .` 0 fail。

Closes #134

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>