### PR TITLE
docs(reclaim-pr-inheritance): #175 規劃產物與 work-item entry

### DIFF
--- a/.cortex/work-items.yaml
+++ b/.cortex/work-items.yaml
@@ -188,6 +188,21 @@ work_items:
         ref: docs/superpowers/specs/multi-issue-worktree-design.md
       - kind: path
         ref: docs/superpowers/plans/multi-issue-worktree.md
+  reclaim-pr-inheritance:
+    title: re-claim PR inheritance + closed-unmapped terminal correlation (#175)
+    links:
+      - kind: github_issue
+        ref: hamanpaul/paulsha-cortex#175
+      - kind: openspec
+        ref: 2026-07-26-reclaim-pr-inheritance
+      - kind: path
+        ref: docs/superpowers/workstreams/reclaim-pr-inheritance/todo.md
+      - kind: path
+        ref: docs/superpowers/specs/reclaim-pr-inheritance-spec.md
+      - kind: path
+        ref: docs/superpowers/specs/reclaim-pr-inheritance-design.md
+      - kind: path
+        ref: docs/superpowers/plans/reclaim-pr-inheritance.md
   dispatch-reliability-batch:
     title: dispatch reliability batch (abandoned, #134)
     links: []

--- a/docs/superpowers/plans/reclaim-pr-inheritance.md
+++ b/docs/superpowers/plans/reclaim-pr-inheritance.md
@@ -1,0 +1,28 @@
+---
+status: accepted
+work_item: reclaim-pr-inheritance
+---
+
+# reclaim-pr-inheritance Plan
+
+## Tasks
+
+### 1. TDD RED
+
+- [ ] `tests/test_reclaim_pr_inheritance.py`：
+  - `test_new_claim_run_starts_with_empty_pr_refs`：`authority.mapped_prs=(42,)` 時，`_claim_workflow_run` 建立的 run `pr_refs == ()`（needs_human 路徑與 start 路徑皆驗）。
+  - `test_terminal_provider_skips_closed_unmerged_pr_closing_links`：餵入含 OPEN / CLOSED-unmerged / MERGED PR 的 terminal 觀測，斷言 `closing_links` 只含 OPEN 與 MERGED 的 PR→issue 連結，不含 closed-unmerged。
+  - `test_terminal_provider_keeps_open_pr_closing_links`：OPEN PR 仍產 link（回歸）。
+  - 先確認 RED。
+
+### 2. 實作
+
+- [ ] `paulsha_cortex/coordinator/work_bridge.py`：`_claim_workflow_run` needs_human 建立路徑（`pr_refs=tuple(...)`）改 `pr_refs=()`；start 路徑 args `pr_refs` 改 `[]`。
+- [ ] `paulsha_cortex/monitor/providers.py` `GitHubTerminalProvider._scan`：遍歷 `pull_nodes` 時，`state == "CLOSED"` 的 PR 跳過 `closing_links`（OPEN/MERGED 不變）。
+
+### 3. 同步與驗證
+
+- [ ] `changelog.d/reclaim-pr-inheritance.md`；`CHANGELOG.md [Unreleased] ### Fixed` 加入含 `#175` 條目。
+- [ ] README 對應段同步（R-18）若有 re-claim/delivery 說明段。
+- [ ] `python3 -m pytest tests/ -q` 全綠；`policy_check --repo .` 0 fail；`git diff --check` 乾淨。
+- [ ] 勾選 `openspec/changes/2026-07-26-reclaim-pr-inheritance/tasks.md`。

--- a/docs/superpowers/specs/reclaim-pr-inheritance-design.md
+++ b/docs/superpowers/specs/reclaim-pr-inheritance-design.md
@@ -1,0 +1,37 @@
+---
+status: accepted
+work_item: reclaim-pr-inheritance
+---
+
+# reclaim-pr-inheritance Design
+
+## Decisions
+
+### D1 新 run `pr_refs=()`（不繼承 mapped_prs）
+
+`work_bridge._claim_workflow_run` 兩處建立新 run 的 `pr_refs`：
+- needs_human 路徑（`registry._manager_create_workflow_run(..., pr_refs=tuple(f"{repo}#{n}" for n in authority.mapped_prs))`）。
+- start 路徑（`apply_workflow_action` args `pr_refs=[...]`）。
+
+兩處皆改為 `pr_refs=()`（或空 list）。理由：`pr_refs` 表「本 run 的 delivery PR」；新 run 尚未 delivery，不應有 PR。舊 run 的 PR 由該 run 自己的 `pr_refs` 表達，superseded run 的 monitor 連結已被 `status != "superseded"` 過濾（`providers.py:309`）。
+
+不選「保留繼承但於 delivery 時覆寫」：delivery 路徑已假設 `pr_refs` 為空時開新 PR、非空時用既有 PR（`work_bridge.py:1255-1318`）；繼承舊 PR 會走「既有 PR」分支並卡死（舊 PR 已關閉無法 reopen）。從源頭 `pr_refs=()` 讓新 run 走「開新 PR」分支。
+
+### D2 terminal provider 過濾 closed-unmerged
+
+`GitHubTerminalProvider._scan`（`providers.py:865-880`）遍歷 `pull_nodes` 建 `closing_links`。對 `pull["state"] == "CLOSED"` 且 `pull.get("mergeCommit")` 為空（未 merge）的 PR，跳過 `closing_links` 建立。OPEN 與 MERGED（有 mergeCommit）保留。
+
+判定：`closed_unmerged = state == "CLOSED" and not (merge_commit_oid)`。MERGED PR 的 `state == "MERGED"`（非 CLOSED），不受影響；CLOSED 且有 mergeCommit 不存在於 GitHub 語意（merged PR state=MERGED），故 `state=="CLOSED"` 即未合併。
+
+不選「過濾所有 CLOSED」：未來若有「關閉又 reopen」語意變化，保留 CLOSED 但 merged 的判斷較保守；但 GitHub 已關閉未合併即廢棄，本設計直接以 `state=="CLOSED"` 判定廢棄（merged 永為 MERGED state）。
+
+### D3 不動範圍
+
+- `claim.py` `mapped_prs` 仍如實反映 confirmed github_pr sources（含舊 open PR）；但新 run 不再以它為 `pr_refs`（D1）。`mapped_prs` 仍用於 `_canonical_workflow_run` 的既有 run 比對（既有 delivery run 的 `pr_refs` 比對 `mapped_prs`）——既有 run 的 `pr_refs` 在 delivery 時設為 `(pr,)`，與 `mapped_prs` 一致，不退化。
+- delivery journal row 建立時序（`_load_work_run` 已 create-on-missing）不動；R1 消除繼承後新 run 不會誤入既有 PR 的 journal 路徑。
+- `rebase-candidate` / `retry-build --rebase-onto` 不實作（enhancement，後續 issue）。
+
+## 風險
+
+- D1 改 `pr_refs` 起始：須確認 monitor 對「ongoing run 無 pr_refs」的處理不退化（ongoing run 在 delivery 前本就可能 `pr_refs=()`，既有測試已涵蓋）。
+- D2 改 terminal provider：須確認 `closing_links` 移除 closed-unmerged 後，`mapped_prs` 對「曾關閉又 reopen 的 PR」仍能在 reopen 後重新關聯（reopen → state OPEN → 重新產 link）。以測試鎖定。

--- a/docs/superpowers/specs/reclaim-pr-inheritance-spec.md
+++ b/docs/superpowers/specs/reclaim-pr-inheritance-spec.md
@@ -1,0 +1,45 @@
+---
+status: accepted
+work_item: reclaim-pr-inheritance
+---
+
+# reclaim-pr-inheritance Specification
+
+#175：re-claim 後新 run 繼承舊 run 的 PR 綁定，使 delivery 進入不可恢復的糾纏（delivery journal 孤兒、無法開新 PR）。
+
+## 背景
+
+當一個 run 已進到 delivery（已開 PR）後需重建（例：dispatch_base 變動需 rebase），operator `cortex work start` 重 claim：
+- 舊 run 標 `superseded`（正確），但**新 run 繼承舊 run 的 PR 綁定**（`pr_refs=(舊PR,)`），因 `work_bridge` 以 `authority.mapped_prs` 建立新 run 的 `pr_refs`。
+- operator 關閉舊 PR 想讓新 run 開新 PR：GitHub 對已關閉 PR 凍結 `closingIssuesReferences`，terminal provider 重掃後 `mapped_prs` 仍頑固含該已關閉 PR。
+- 已關閉且分支已刪的 PR 無法 reopen，新 run 綁死舊 PR、無法交付。
+
+## Requirements
+
+### R1 新 run 不繼承舊 PR 綁定
+
+新 claim 建立的 WorkflowRun MUST 以 `pr_refs=()` 起始，不得繼承 `authority.mapped_prs`。新 run 在 delivery 階段自行建立自己的 PR（既有 `_push_exact_candidate`→`create_or_get_pull_request`→`pr_refs=(new,)` 路徑不變）。
+
+- `work_bridge._claim_workflow_run`：needs_human 建立路徑與 `apply_workflow_action("start")` 的 `pr_refs` 皆改為 `()`（不再取自 `authority.mapped_prs`）。
+- 舊 run（superseded）的 PR 連結由 monitor 既有的 `status != "superseded"` 過濾維持，不污染新 run。
+
+### R2 terminal provider 不再關聯已關閉未合併 PR
+
+`GitHubTerminalProvider` 對 `state == CLOSED` 且未 merge 的 PR（closed-unmerged，即廢棄 PR）MUST NOT 產出 `closing_links`。OPEN 與 MERGED PR 的 closing 關聯不變。
+
+- 關閉未合併 PR 的 `closingIssuesReferences` 是 GitHub 凍結的過時證據，不應再貢獻 `mapped_prs`。
+- MERGED PR 的 closing 關聯保留（完成證據）。
+
+### R3 限制
+
+- stdlib-only；TDD（先 RED）。
+- 不實作 `cortex work rebase-candidate` / `retry-build --rebase-onto`（#175 建議的 in-flight rebase 強化）——屬獨立 enhancement，留待後續 issue；本批只修繼承根因。
+- 不改 delivery journal schema；既有單 PR delivery lifecycle 不退化（run 在 delivery 建立自己的 PR 並寫 `pr_refs`）。
+- `python3 -m pytest tests/ -q` 全綠；`policy_check --repo .` 0 fail。
+
+## 驗收
+
+- 新增測試：authority.mapped_prs 非空時，新 claim 建立的 run `pr_refs == ()`。
+- 新增測試：terminal provider 對 closed-unmerged PR 不產 closing_links；OPEN/MERGED PR 仍產。
+- 既有 single-PR delivery lifecycle 測試不退化（run delivery 時建立 PR 並設 `pr_refs`）。
+- 既有多 run / superseded 過濾測試不退化。

--- a/docs/superpowers/workstreams/reclaim-pr-inheritance/todo.md
+++ b/docs/superpowers/workstreams/reclaim-pr-inheritance/todo.md
@@ -1,0 +1,13 @@
+---
+status: accepted
+work_item: reclaim-pr-inheritance
+---
+
+# reclaim-pr-inheritance Todo
+
+## Tasks
+
+- [ ] 將 issue #175、active OpenSpec change `2026-07-26-reclaim-pr-inheritance` 與本 Todo 綁定為同一 confirmed Work Item。
+- [ ] coordinator 派工 codex（gpt-5.3-codex-spark）完成 #175 修復（TDD）：新 claim run `pr_refs=()`（不繼承 mapped_prs）+ terminal provider 跳過 closed-unmerged PR 的 closing 關聯。
+- [ ] ForeignReview（agy/gemini-3.6-flash）adversarial-review 通過；operator（Copilot CLI session）驗收核可。
+- [ ] re-claim 後新 run 不繼承舊 PR、自行開新 PR 交付；closed-unmerged PR 不再貢獻 mapped_prs（驗證 #175）。

--- a/openspec/changes/2026-07-26-reclaim-pr-inheritance/design.md
+++ b/openspec/changes/2026-07-26-reclaim-pr-inheritance/design.md
@@ -1,0 +1,22 @@
+---
+status: accepted
+work_item: reclaim-pr-inheritance
+---
+
+# reclaim-pr-inheritance Design
+
+## Decisions
+
+### D1 新 run `pr_refs=()`（不繼承 mapped_prs）
+
+`work_bridge._claim_workflow_run` 兩處建立新 run 的 `pr_refs` 改為 `()`。`pr_refs` 表「本 run 的 delivery PR」；新 run 尚未 delivery，不應有 PR。舊 run 的 PR 由該 run 自己的 `pr_refs` 表達，superseded run 的 monitor 連結已被 `status != "superseded"` 過濾。
+
+delivery 路徑已假設 `pr_refs` 為空時開新 PR、非空時用既有 PR；繼承舊 PR 會走「既有 PR」分支並卡死（舊 PR 已關閉無法 reopen）。從源頭 `pr_refs=()` 讓新 run 走「開新 PR」分支。
+
+### D2 terminal provider 過濾 closed-unmerged
+
+`GitHubTerminalProvider._scan` 對 `state == "CLOSED"` 的 PR 跳過 `closing_links`；OPEN 與 MERGED 保留。GitHub merged PR 的 state 為 `MERGED`（非 CLOSED），故 `state=="CLOSED"` 即未合併廢棄 PR。
+
+### D3 不動範圍
+
+`mapped_prs` 仍如實反映 confirmed github_pr sources；`_canonical_workflow_run` 對既有 delivery run 的 `pr_refs` 比對 `mapped_prs` 不變。`rebase-candidate` / `retry-build --rebase-onto` 不實作（enhancement，後續 issue）。

--- a/openspec/changes/2026-07-26-reclaim-pr-inheritance/proposal.md
+++ b/openspec/changes/2026-07-26-reclaim-pr-inheritance/proposal.md
@@ -1,0 +1,24 @@
+---
+status: accepted
+work_item: reclaim-pr-inheritance
+---
+
+## Goals
+
+讓 re-claim 建立的新 WorkflowRun 不繼承舊 run 的 PR 綁定（`pr_refs=()` 起始），並讓 terminal provider 不再以已關閉未合併 PR 的凍結 `closingIssuesReferences` 貢獻 `mapped_prs`，消除 #175 的 delivery 糾纏根因。
+
+## Why
+
+re-claim 後新 run 以 `authority.mapped_prs` 建立 `pr_refs`，繼承舊 run 的 PR；舊 PR 關閉後 GitHub 凍結其 closing refs，terminal provider 仍頑固關聯，新 run 綁死已關閉 PR 無法開新 PR 交付。
+
+## What Changes
+
+- `coordinator/work_bridge.py`：新 run claim 的 `pr_refs` 改 `()`（needs_human 與 start 兩路徑）。
+- `monitor/providers.py` `GitHubTerminalProvider`：`state=="CLOSED"` 的 PR 跳過 `closing_links`。
+- `tests/test_reclaim_pr_inheritance.py`：新 run `pr_refs=()`、terminal provider closed-unmerged 過濾、OPEN 回歸。
+
+## Capabilities
+
+### Modified Capabilities
+- `coordinator/work-claim`：新 run 不繼承舊 PR。
+- `monitor/terminal-provider`：closed-unmerged PR 不貢獻 closing 關聯。

--- a/openspec/changes/2026-07-26-reclaim-pr-inheritance/tasks.md
+++ b/openspec/changes/2026-07-26-reclaim-pr-inheritance/tasks.md
@@ -1,0 +1,11 @@
+---
+status: accepted
+work_item: reclaim-pr-inheritance
+---
+
+# Tasks
+
+- [ ] 1.1 RED：`tests/test_reclaim_pr_inheritance.py` 涵蓋新 claim run `pr_refs=()`、terminal provider 跳過 closed-unmerged closing_links、OPEN PR 回歸。
+- [ ] 1.2 `coordinator/work_bridge.py` `_claim_workflow_run`：新 run `pr_refs=()`（needs_human + start 兩路徑）（#175）。
+- [ ] 1.3 `monitor/providers.py` `GitHubTerminalProvider`：`state=="CLOSED"` PR 跳過 `closing_links`（#175）。
+- [ ] 1.4 `changelog.d/reclaim-pr-inheritance.md` 與 `CHANGELOG.md [Unreleased] ### Fixed`（#175）；README 同步（R-18）。


### PR DESCRIPTION
## 摘要

為 #175（re-claim 後繼承已關閉 PR 綁定 → delivery journal 孤兒、無法交付）建立規劃三件套（spec/design/plan）、workstream todo、OpenSpec change（`2026-07-26-reclaim-pr-inheritance`，含 `design.md`）與 `.cortex/work-items.yaml` entry。本 PR 僅含規劃產物（docs-only）；實作由後續 cortex 派工 codex（gpt-5.3-codex-spark）以 TDD 落地，adversarial review 由 agy（gemini-3.6-flash）執行，operator 驗收。

## 設計要點

- **R1 新 run 不繼承舊 PR**：新 claim 的 WorkflowRun `pr_refs=()` 起始（不取自 `authority.mapped_prs`），delivery 時自行開新 PR。
- **R2 terminal provider 過濾 closed-unmerged**：`state=="CLOSED"` 的 PR 跳過 `closing_links`（OPEN/MERGED 不變），消除 `mapped_prs` 頑固繼承。
- **範圍外**：`cortex work rebase-candidate` / `retry-build --rebase-onto` 與 delivery journal 時序強化屬 enhancement，留待後續 issue。

## Checklist
- [x] 規劃三件套 frontmatter `status: accepted` + `work_item`，必要標題齊備，無 TBD
- [x] openspec change 含 `design.md`（design kind 來源）
- [x] `.cortex/work-items.yaml` entry 與 issue/openspec/path links 綁定
- [x] `python3 -m policy_check --repo .` 0 fail
- [x] docs-only；CHANGELOG entry 隨實作 PR（#175）

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>