### PR TITLE
fix(coordinator): re-claim 不繼承舊 PR 綁定 + terminal provider 跳過 closed-unmerged PR (#175)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ## [Unreleased]
 
 ### Fixed
+- **Issue #175：reclaim PR inheritance**：`start_canonical_workflow` needs_human 與 start 兩條路徑都不再帶入 `pr_refs`，`GitHubTerminalProvider` 不會將 `state=CLOSED`（未合併）PR 加入 `closing_links`，避免 closed PR 異常延續到 delivery authority。
 - **Issue #134：multi-issue build 支援最小 issue 為主 branch 且以 run repository 建立 worktree**：builder 會在 run 含多個 issue 時，使用編號最小的 `feature/<主issue>-<work_id>`，並由 run repo 作為 `ScriptWorktreeCreator` 的 git 工作目錄。
 - **Issue #152：mutation request 逾時改採分級 timeout + pending 回報**：`coordinator/cli.py` `_submit_mutation_request` 依 `req_type` 套用分級 timeout（`fanout`/`tick` 60 秒、`complete`/`work`/`work-action`/`run` 30 秒、其餘 5 秒），`poll` timeout 時保留 `req_id` 與追蹤指引並回傳 `EXIT_SUBMITTED_PENDING`（exit 3）避免成功派工被誤報為失敗。
 - **Issue #99：git runner 與 systemd 單元以 repo root 為基準**：`dispatcher._default_git_runner` 現在以 `git -C <repo_root>` 執行 git 呼叫；`cortex-manager.service` 與 `cortex-monitor.service` 渲染時皆加入 `WorkingDirectory=<repo_root>`，避免 daemon 於非預期目錄執行 git 或長駐服務命令。

--- a/changelog.d/reclaim-pr-inheritance.md
+++ b/changelog.d/reclaim-pr-inheritance.md
@@ -1,0 +1,2 @@
+### Fixed
+- **Issue #175：reclaim PR inheritance**：`coordinator` 在 needs_human 與 start phase 都不再帶入任何 `pr_refs`，並且 `GitHubTerminalProvider` 不會把 `state=CLOSED` 但未合併的 PR 轉為 `closing_links`，避免 closed PR 仍污染關聯主線閉環。

--- a/openspec/changes/2026-07-26-reclaim-pr-inheritance/tasks.md
+++ b/openspec/changes/2026-07-26-reclaim-pr-inheritance/tasks.md
@@ -6,6 +6,6 @@ work_item: reclaim-pr-inheritance
 # Tasks
 
 - [x] 1.1 RED：`tests/test_reclaim_pr_inheritance.py` 涵蓋新 claim run `pr_refs=()`、terminal provider 跳過 closed-unmerged closing_links、OPEN PR 回歸。
-- [ ] 1.2 `coordinator/work_bridge.py` `_claim_workflow_run`：新 run `pr_refs=()`（needs_human + start 兩路徑）（#175）。
-- [ ] 1.3 `monitor/providers.py` `GitHubTerminalProvider`：`state=="CLOSED"` PR 跳過 `closing_links`（#175）。
-- [ ] 1.4 `changelog.d/reclaim-pr-inheritance.md` 與 `CHANGELOG.md [Unreleased] ### Fixed`（#175）；README 同步（R-18）。
+- [x] 1.2 `coordinator/work_bridge.py` `_claim_workflow_run`：新 run `pr_refs=()`（needs_human + start 兩路徑）（#175）。
+- [x] 1.3 `monitor/providers.py` `GitHubTerminalProvider`：`state=="CLOSED"` PR 跳過 `closing_links`（#175）。
+- [x] 1.4 `changelog.d/reclaim-pr-inheritance.md` 與 `CHANGELOG.md [Unreleased] ### Fixed`（#175）；README 同步（R-18）。

--- a/openspec/changes/2026-07-26-reclaim-pr-inheritance/tasks.md
+++ b/openspec/changes/2026-07-26-reclaim-pr-inheritance/tasks.md
@@ -5,7 +5,7 @@ work_item: reclaim-pr-inheritance
 
 # Tasks
 
-- [ ] 1.1 RED：`tests/test_reclaim_pr_inheritance.py` 涵蓋新 claim run `pr_refs=()`、terminal provider 跳過 closed-unmerged closing_links、OPEN PR 回歸。
+- [x] 1.1 RED：`tests/test_reclaim_pr_inheritance.py` 涵蓋新 claim run `pr_refs=()`、terminal provider 跳過 closed-unmerged closing_links、OPEN PR 回歸。
 - [ ] 1.2 `coordinator/work_bridge.py` `_claim_workflow_run`：新 run `pr_refs=()`（needs_human + start 兩路徑）（#175）。
 - [ ] 1.3 `monitor/providers.py` `GitHubTerminalProvider`：`state=="CLOSED"` PR 跳過 `closing_links`（#175）。
 - [ ] 1.4 `changelog.d/reclaim-pr-inheritance.md` 與 `CHANGELOG.md [Unreleased] ### Fixed`（#175）；README 同步（R-18）。

--- a/paulsha_cortex/coordinator/work_bridge.py
+++ b/paulsha_cortex/coordinator/work_bridge.py
@@ -56,7 +56,7 @@ def resolve_trusted_repo_root(repo: str, *, explicit: object = None) -> Path:
     """Resolve owner/name only through installed repo/Monitor configuration."""
 
     candidates: list[Path] = []
-    if isinstance(explicit, str) and explicit:
+    if isinstance(explicit, (str, Path)) and explicit:
         raw = Path(explicit).expanduser()
         try:
             root = raw.resolve(strict=True)
@@ -209,7 +209,7 @@ def start_canonical_workflow(
             steps=manifest.steps,
             issue_refs=tuple(f"{authority.repo}#{number}" for number in authority.mapped_issues),
             openspec_refs=authority.mapped_openspec,
-            pr_refs=tuple(f"{authority.repo}#{number}" for number in authority.mapped_prs),
+            pr_refs=(),
             attempts={"claim": 1},
             facets=("needs_human",),
             gate_status="running",
@@ -243,7 +243,7 @@ def start_canonical_workflow(
             "primary_domain": primary.independence_domain,
             "issue_refs": [f"{authority.repo}#{number}" for number in authority.mapped_issues],
             "openspec_refs": list(authority.mapped_openspec),
-            "pr_refs": [f"{authority.repo}#{number}" for number in authority.mapped_prs],
+            "pr_refs": [],
         },
         identity_registry=identities,
         runtime_factory=runtime_factory,

--- a/paulsha_cortex/monitor/providers.py
+++ b/paulsha_cortex/monitor/providers.py
@@ -871,13 +871,14 @@ class GitHubTerminalProvider:
                 closing = pull["closingIssuesReferences"]
                 if closing["pageInfo"]["hasNextPage"]:
                     raise ValueError("closing issue pagination incomplete")
-                issues = closing["nodes"]
-                if issues:
-                    primary_issue_source = f"github_issue:{self.repo}#{issues[0]['number']}"
-                    links[pr_source_id] = primary_issue_source
-                    for issue in issues[1:]:
-                        issue_source = f"github_issue:{self.repo}#{issue['number']}"
-                        links[issue_source] = primary_issue_source
+                if pull.get("state") != "CLOSED":
+                    issues = closing["nodes"]
+                    if issues:
+                        primary_issue_source = f"github_issue:{self.repo}#{issues[0]['number']}"
+                        links[pr_source_id] = primary_issue_source
+                        for issue in issues[1:]:
+                            issue_source = f"github_issue:{self.repo}#{issue['number']}"
+                            links[issue_source] = primary_issue_source
                 merge = pull.get("mergeCommit") or {}
                 merge_revision = merge.get("oid")
                 parent_count = (merge.get("parents") or {}).get("totalCount")

--- a/tests/test_monitor_work_providers.py
+++ b/tests/test_monitor_work_providers.py
@@ -930,7 +930,6 @@ def test_github_terminal_provider_aggregates_pull_requests_across_pages():
     assert result.status == "ok"
     assert result.observations["closing_links"] == {
         "github_pr:example/acme#9": "github_issue:example/acme#7",
-        "github_pr:example/acme#10": "github_issue:example/acme#8",
     }
     assert result.observations["branches"] == [
         {"source_id": "github_pr:example/acme#9", "ref": "feature/9-work"},

--- a/tests/test_reclaim_pr_inheritance.py
+++ b/tests/test_reclaim_pr_inheritance.py
@@ -1,0 +1,269 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from paulsha_cortex.coordinator import work_bridge
+from paulsha_cortex.coordinator.claim import load_work_authority
+from paulsha_cortex.coordinator.model_identities import IdentityRegistry
+from paulsha_cortex.coordinator.registry import JobRegistry
+from paulsha_cortex.monitor.providers import GitHubTerminalProvider
+
+
+def _repo(root: Path) -> Path:
+    root.mkdir()
+    subprocess.run(["git", "init", "-q", str(root)], check=True)
+    subprocess.run(
+        ["git", "-C", str(root), "config", "user.email", "test@example.com"],
+        check=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(root), "config", "user.name", "Test"],
+        check=True,
+    )
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            str(root),
+            "remote",
+            "add",
+            "origin",
+            "git@github.com:acme/demo.git",
+        ],
+        check=True,
+    )
+    (root / "README.md").write_text("demo\n", encoding="utf-8")
+    subprocess.run(["git", "-C", str(root), "add", "README.md"], check=True)
+    subprocess.run(["git", "-C", str(root), "commit", "-qm", "init"], check=True)
+    return root
+
+
+def _snapshot(
+    path: Path,
+    *,
+    mapped_prs: tuple[int, ...] = (),
+    source_revisions: tuple[str, ...] = (
+        "github_issue:acme/demo#14@issue-open",
+        "openspec:acme/demo:work@spec-1",
+    ),
+) -> Path:
+    path.write_text(
+        json.dumps(
+            {
+                "schema": "work-items-snapshot/v1",
+                "providers": {
+                    "github": {
+                        "provider_id": "github",
+                        "revision": "gh-1",
+                        "last_success_epoch": 100,
+                        "degraded": False,
+                    }
+                },
+                "work_items": [
+                    {
+                        "repo": "acme/demo",
+                        "work_id": "work",
+                        "mapped_issues": [14],
+                        "mapped_prs": list(mapped_prs),
+                        "mapped_openspec": ["work"],
+                        "mapped_todo_paths": ["docs/todo.md"],
+                        "confirmed_todo": True,
+                        "auto_label": False,
+                        "source_revisions": list(source_revisions),
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _completed(payload, *, returncode=0, stderr=""):
+    return subprocess.CompletedProcess(
+        args=("gh",),
+        returncode=returncode,
+        stdout=json.dumps(payload),
+        stderr=stderr,
+    )
+
+
+class _FakeRunner:
+    def __init__(self, results):
+        self.results = iter(results)
+
+    def run(self, argv, *, timeout):
+        return next(self.results)
+
+
+def test_new_claim_run_starts_with_empty_pr_refs(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    workspace = _repo(tmp_path / "workspace")
+    snapshot = _snapshot(tmp_path / "snapshot.json", mapped_prs=(42,))
+    authority = load_work_authority(
+        repo="acme/demo", work_id="work", snapshot_path=snapshot
+    )
+    registry = JobRegistry(state_path=tmp_path / "jobs.json")
+
+    needs_human_run = work_bridge.start_canonical_workflow(
+        registry=registry,
+        authority=authority,
+        claim_key="claim:v1:" + "1" * 64,
+        coordinator_root=tmp_path / "coordinator",
+        explicit_repo_root=workspace,
+        needs_human_reason="missing-issue",
+    )
+    assert needs_human_run.pr_refs == ()
+
+    manifest = work_bridge.default_workflow_manifest("work", change="work")
+    captured: dict[str, object] = {}
+
+    def fake_apply_workflow_action(
+        _registry,
+        *,
+        args,
+        **_kwargs,
+    ):
+        captured["args"] = args
+        run = _registry._manager_create_workflow_run(
+            work_id=args["work_id"],
+            repo=args["repo"],
+            claim_key=args["claim_key"],
+            source_revision=args["source_revision"],
+            workspace_root=args["artifact_root"],
+            combo=manifest.combo,
+            current_phase="define",
+            steps=manifest.steps,
+            issue_refs=tuple(args["issue_refs"]),
+            openspec_refs=tuple(args["openspec_refs"]),
+            pr_refs=tuple(args["pr_refs"]),
+            attempts={"define": 1},
+        )
+        return {"run_id": run.run_id}
+
+    monkeypatch.setattr(
+        "paulsha_cortex.coordinator.manager.apply_workflow_action",
+        fake_apply_workflow_action,
+    )
+    identity_registry = IdentityRegistry.from_rows(
+        (
+            {
+                "executor": "codex",
+                "model_id": "gpt",
+                "independence_domain": "openai",
+                "capabilities": ["planning"],
+            },
+        )
+    )
+
+    start_run = work_bridge.start_canonical_workflow(
+        registry=registry,
+        authority=authority,
+        claim_key="claim:v1:" + "2" * 64,
+        coordinator_root=tmp_path / "coordinator",
+        explicit_repo_root=workspace,
+        identity_registry=identity_registry,
+    )
+    assert captured["args"]["pr_refs"] == []
+    assert start_run.pr_refs == ()
+
+
+def test_terminal_provider_skips_closed_unmerged_pr_closing_links():
+    graph = {
+        "data": {
+            "repository": {
+                "defaultBranchRef": {"name": "main", "target": {"oid": "d" * 40}},
+                "pullRequests": {
+                    "pageInfo": {"hasNextPage": False},
+                    "nodes": [
+                        {
+                            "number": 9,
+                            "body": "",
+                            "headRefOid": "e" * 40,
+                            "state": "OPEN",
+                            "mergedAt": None,
+                            "mergeCommit": None,
+                            "closingIssuesReferences": {
+                                "pageInfo": {"hasNextPage": False},
+                                "nodes": [{"number": 70, "state": "OPEN"}],
+                            },
+                        },
+                        {
+                            "number": 10,
+                            "body": "",
+                            "headRefOid": "f" * 40,
+                            "state": "CLOSED",
+                            "mergedAt": None,
+                            "mergeCommit": None,
+                            "closingIssuesReferences": {
+                                "pageInfo": {"hasNextPage": False},
+                                "nodes": [{"number": 71, "state": "CLOSED"}],
+                            },
+                        },
+                        {
+                            "number": 11,
+                            "body": "",
+                            "headRefOid": "g" * 40,
+                            "state": "MERGED",
+                            "mergedAt": "2026-07-17T10:00:00Z",
+                            "mergeCommit": {
+                                "oid": "a" * 40,
+                                "parents": {"totalCount": 2},
+                            },
+                            "closingIssuesReferences": {
+                                "pageInfo": {"hasNextPage": False},
+                                "nodes": [{"number": 72, "state": "MERGED"}],
+                            },
+                        },
+                    ],
+                },
+            }
+        }
+    }
+    tree = {"truncated": False, "tree": []}
+    runner = _FakeRunner([_completed(graph), _completed(tree), _completed({"status": "ahead"})])
+    result = GitHubTerminalProvider("example/acme", runner=runner).scan()
+
+    assert result.status == "ok"
+    assert result.observations["closing_links"] == {
+        "github_pr:example/acme#9": "github_issue:example/acme#70",
+        "github_pr:example/acme#11": "github_issue:example/acme#72",
+    }
+
+
+def test_terminal_provider_keeps_open_pr_closing_links():
+    graph = {
+        "data": {
+            "repository": {
+                "defaultBranchRef": {"name": "main", "target": {"oid": "d" * 40}},
+                "pullRequests": {
+                    "pageInfo": {"hasNextPage": False},
+                    "nodes": [
+                        {
+                            "number": 9,
+                            "body": "",
+                            "headRefOid": "e" * 40,
+                            "state": "OPEN",
+                            "mergedAt": None,
+                            "mergeCommit": None,
+                            "closingIssuesReferences": {
+                                "pageInfo": {"hasNextPage": False},
+                                "nodes": [{"number": 7, "state": "OPEN"}],
+                            },
+                        }
+                    ],
+                },
+            }
+        }
+    }
+    tree = {"truncated": False, "tree": []}
+    runner = _FakeRunner([_completed(graph), _completed(tree)])
+    result = GitHubTerminalProvider("example/acme", runner=runner).scan()
+
+    assert result.status == "ok"
+    assert result.observations["closing_links"] == {
+        "github_pr:example/acme#9": "github_issue:example/acme#7",
+    }


### PR DESCRIPTION
## 摘要

閉合 #175：re-claim 建立的新 WorkflowRun 不再繼承舊 run 的 PR 綁定（`pr_refs=()` 起始），且 terminal provider 不再以已關閉未合併 PR 的凍結 `closingIssuesReferences` 貢獻 `mapped_prs`。由 cortex dogfood 派工：codex（gpt-5.3-codex-spark）實作，claude/sonnet verification + code-review + adversarial-review，agy（gemini-3.6-flash）獨立對抗審查，operator 驗收。

## 變更

- `paulsha_cortex/coordinator/work_bridge.py` `start_canonical_workflow`：新 run `pr_refs=()`（needs_human）與 `pr_refs=[]`（start）兩路徑，不再取自 `authority.mapped_prs`。
- `paulsha_cortex/monitor/providers.py` `GitHubTerminalProvider`：`state=="CLOSED"` 的 PR 跳過 `closing_links`（OPEN/MERGED 不變）。
- `tests/test_reclaim_pr_inheritance.py`：新 run `pr_refs=()`、terminal provider closed-unmerged 過濾、OPEN 回歸。
- `CHANGELOG.md` / `changelog.d/reclaim-pr-inheritance.md`：`### Fixed` #175 條目。

## 驗收

- re-claim 後新 run `pr_refs=()` 不繼承舊 PR，delivery 時自行開新 PR。
- closed-unmerged PR 不再貢獻 `closing_links`/`mapped_prs`；OPEN/MERGED 不變。
- 既有 single-PR delivery lifecycle 與多 run/superseded 過濾測試不退化。
- `python3 -m pytest tests/ -q` 1214 passed；`policy_check --repo .` 0 fail。
- adversarial review（agy/gemini-3.6-flash）：no blocking findings，VERDICT: approve。

## 範圍外

`cortex work rebase-candidate` / `retry-build --rebase-onto` 與 delivery journal 時序強化屬 enhancement，留待後續 issue。

Closes #175

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>