### PR TITLE
docs(driving-cortex-skill): #177 規劃產物與 work-item entry

### DIFF
--- a/.cortex/work-items.yaml
+++ b/.cortex/work-items.yaml
@@ -203,6 +203,21 @@ work_items:
         ref: docs/superpowers/specs/reclaim-pr-inheritance-design.md
       - kind: path
         ref: docs/superpowers/plans/reclaim-pr-inheritance.md
+  driving-cortex-skill:
+    title: driving-cortex skill (#177)
+    links:
+      - kind: github_issue
+        ref: hamanpaul/paulsha-cortex#177
+      - kind: openspec
+        ref: 2026-07-26-driving-cortex-skill
+      - kind: path
+        ref: docs/superpowers/workstreams/driving-cortex-skill/todo.md
+      - kind: path
+        ref: docs/superpowers/specs/driving-cortex-skill-spec.md
+      - kind: path
+        ref: docs/superpowers/specs/driving-cortex-skill-design.md
+      - kind: path
+        ref: docs/superpowers/plans/driving-cortex-skill.md
   dispatch-reliability-batch:
     title: dispatch reliability batch (abandoned, #134)
     links: []

--- a/docs/superpowers/plans/driving-cortex-skill.md
+++ b/docs/superpowers/plans/driving-cortex-skill.md
@@ -1,0 +1,31 @@
+---
+status: accepted
+work_item: driving-cortex-skill
+---
+
+# driving-cortex-skill Plan
+
+## Tasks
+
+### 1. TDD RED
+
+- [ ] `tests/test_driving_cortex_skill.py`：
+  - `test_skill_file_exists`：`skills/driving-cortex/SKILL.md` 存在。
+  - `test_skill_has_description_frontmatter`：frontmatter 含 `description` 且含觸發詞（dogfood cortex / 派工 cortex / cortex work）。
+  - `test_skill_covers_seven_sections`：七段關鍵標題皆出現（心智模型／開一個 dogfood 批次／驅動桿／執行器設定／每批 merge 後部署／生命週期特性／已知坑）。
+  - `test_skill_no_personal_paths`：全文無個人絕對路徑、使用者名、雇主／廠商識別（R-21）。
+  - `test_skill_no_unsafe_bypass_as_daily_guide`：`--dangerously-bypass-approvals-and-sandbox` 不作為日常指引（僅允許出現於明確標示的情境命令脈絡）。
+  - 先確認 RED（SKILL.md 不存在 → 失敗）。
+
+### 2. 撰寫 SKILL.md
+
+- [ ] `skills/driving-cortex/SKILL.md`：frontmatter `description` 觸發詞；頂部兩視角分工（引用 B8 `docs/onboarding/*`）。
+- [ ] 七段內容（issue #177 骨架）：心智模型、開一個 dogfood 批次、驅動桿、執行器設定、每批 merge 後部署、生命週期特性、已知坑。
+- [ ] 恢復桿與已知坑以 checklist 呈現（可逐項操作）；關聯 issue 以 `#N` 標注。
+
+### 3. 同步與驗證
+
+- [ ] README 補 skill 導覽一行（R-18）。
+- [ ] `changelog.d/driving-cortex-skill.md` fragment；`CHANGELOG.md [Unreleased]` `### Added` 加入含 `#177` 條目。
+- [ ] `python3 -m pytest tests/ -q` 全綠；`python3 -m policy_check --repo .` 0 fail（含 R-18/R-21/R-22）；`git diff --check` 乾淨。
+- [ ] 勾選 `openspec/changes/2026-07-26-driving-cortex-skill/tasks.md` 並以 conventional commit 提交（不得改動本 plan 檔）。

--- a/docs/superpowers/specs/driving-cortex-skill-design.md
+++ b/docs/superpowers/specs/driving-cortex-skill-design.md
@@ -1,0 +1,38 @@
+---
+status: accepted
+work_item: driving-cortex-skill
+---
+
+# driving-cortex-skill Design
+
+## Decisions
+
+### D1 Claude Code skill 格式優先（非 cortex 原生 deck skill 卡）
+
+選 **Claude Code skill**（`skills/driving-cortex/SKILL.md`，frontmatter `description` 觸發詞）為首要交付物。issue #177 明確訴求是「告訴 agent」，Claude Code skill 是 agent 在 session 內可被路由選用的形式；cortex 原生 deck skill 卡（`kind: skill`）可為後續選項，本批不交付，避免擴大爆炸半徑。
+
+不選「同步作 cortex deck skill 卡」：需動 deck schema 與 persona 載入路徑，超出 #177 訴求範圍。
+
+### D2 內容來源＝v0.1.0 實機驗收心得（issue #177）
+
+七段骨架直接採 issue #177 提供的心得（心智模型／開批次／驅動桿／執行器設定／部署／生命週期／已知坑）。所有命令、時序陷阱、恢復桿均回溯到該次 dogfood 實證與關聯 issue（#152/#100/#175/#158/#83/#99/#148/#142），不杜撰未落地行為。
+
+### D3 與 B8 onboarding docs 交叉引用
+
+SKILL.md 於頂部說明兩視角分工：B8 `docs/onboarding/*` 是人類 operator 的 install/bootstrap 旅程；本 skill 是 agent 編排 coordinator 視角。兩者交叉引用，避免重複維護兩份操作模型。
+
+### D4 契約測試鎖定結構與路徑衛生
+
+新增 `tests/test_driving_cortex_skill.py`，TDD RED 先行：斷言 SKILL.md 存在、frontmatter `description` 存在、七段關鍵標題（心智模型／開一個 dogfood 批次／驅動桿／執行器設定／每批 merge 後部署／生命週期特性／已知坑）皆出現、全文無個人絕對路徑與使用者名／雇主識別（R-21）、且不含 `--dangerously-bypass-approvals-and-sandbox` 作為「日常指引」（issue #177 提及直接派 codex 修 bug 時該 flag 為情境命令，非日常推薦；測試確保不被寫成常態操作）。
+
+### D5 不改動範圍
+
+- 不改 cortex runtime（coordinator/manager/monitor/dispatcher）。
+- 不改 model-identities.yaml schema。
+- 不改既有 planning-authority plan 檔。
+- README 僅補 skill 導覽一行（R-18 docs 對齊），不重寫 onboarding 段。
+
+## 風險
+
+- skill 內容若引用尚未落地的命令行為會誤導 agent：以契約測試鎖定關鍵標題存在性，並以 R-21 路徑衛生測試防止洩漏個人路徑。
+- 「直接派 codex 修 bug」段含 `--dangerously-bypass-approvals-and-sandbox`：D4 測試確保該 flag 僅出現於明確標示的情境命令區，不作為日常指引推薦。

--- a/docs/superpowers/specs/driving-cortex-skill-spec.md
+++ b/docs/superpowers/specs/driving-cortex-skill-spec.md
@@ -1,0 +1,50 @@
+---
+status: accepted
+work_item: driving-cortex-skill
+---
+
+# driving-cortex-skill Specification
+
+#177：新增 Claude Code skill `driving-cortex`，教 agent 如何驅動 cortex dogfood 派工與交付，結晶 v0.1.0 實機驗收心得。
+
+## 背景
+
+2026-07-24 完成 porcelain CLI 七家族 + docs + release pipeline（epic #84，v0.1.0 發佈）的全程 cortex dogfood 實機驗收——所有實作批次由 cortex coordinator 自己派工建構。過程證明 cortex 的派工/交付模型可用，但一個新 agent 面對 cortex 沒有「怎麼開這台車」的簡明指引；本次是靠跑完 9 批 + 修 17 個 runtime bug + 大量恢復操作才把操作模型摸透。這些 hard-won 知識應固化成 skill，讓後續 agent 幾分鐘上手，而不是重新踩一遍。
+
+與 B8 onboarding docs（`docs/onboarding/*`，人類 operator 的 install/bootstrap 旅程）互補——本 skill 是「agent 編排 coordinator」視角。
+
+## Requirements
+
+### R1 skill 產物與觸發
+
+SHALL 新增 `skills/driving-cortex/SKILL.md`，為 Claude Code skill 格式（frontmatter 含 `description` 觸發詞，如「dogfood cortex」「派工 cortex」「cortex work start/resume」）。`description` MUST 讓 skill 在 agent 欲驅動 cortex dogfood 派工與交付時被選用。
+
+### R2 七段內容骨架
+
+SKILL.md MUST 涵蓋以下七段（issue #177 心得骨架）：
+
+1. **心智模型**：manager daemon = 單一 writer（所有狀態變更走它、control queue、5s 等待逾時不代表失敗）；Monitor = 讀模型（`.cortex/work-items.yaml` + workstream `todo.md` → WorkAuthority）；deck skill 卡 + persona 交付鏈（claim→define→plan→build→verify→review→ship）。
+2. **開一個 dogfood 批次**：規劃產物契約（YAML frontmatter `status: accepted` + `work_item`、必要標題、不可有 TBD、`assess_planning_completeness` 離線驗證）；`.cortex/work-items.yaml` 加 entry + workstream `todo.md` + openspec change；`systemctl --user restart cortex-monitor.service` 並等 snapshot 含新 work_id。
+3. **驅動桿**：`cortex work start`、`cortex work resume --expected-run-id`、`cortex work retry-build --payload`、`cortex work review-attest --payload`、merge 卡 `review-thread-open` 的 GraphQL `resolveReviewThread` 後 resume。
+4. **執行器設定**：`~/.agents/config/paulsha/model-identities.yaml`（build executor 取自 identity.executor、`model_id` 須與 `--model` 逐字同、builder/reviewer `independence_domain` 不同）；直接派 codex 修 bug 必帶 `-c model_reasoning_effort="high"`。
+5. **每批 merge 後部署**：`pipx install --force <repo>` + 重啟 manager/monitor；部署時序陷阱（daemon 早於新檔案 mtime 起動→跑舊 code，驗證 lstart > deployed mtime）；F44 env/unit 可被別 venv 嵌入端覆寫（restart 前 grep env）。
+6. **生命週期特性**：run closure 輸送帶延遲一批（批次 N 的 run 收尾需其 todo 在 remote main 全勾，慣例在 N+1 規劃 PR 才勾 → N 停在 ongoing/review/needs_human 直到 N+1 merge 後 resume；非故障、不擋 N+1 claim；最後一批需獨立 PR 勾 todo）。
+7. **已知坑**：`#152` 5s timeout、`#100` manager.log 無時間戳、`#175` re-claim 後繼承已關閉 PR（別在已開 PR 後 re-claim）、`#158` archive spec Purpose 恆 TBD、`#83` worktree/branch 無 GC、`#99` daemon cwd 耦合；外部產物建後交叉驗證（`gh ... view` 確認）。
+
+恢復桿與坑清單 MUST 以 checklist 形式呈現，可直接逐項操作。
+
+### R3 內容治理
+
+SKILL.md 的技術宣稱 MUST 可回溯到 v0.1.0 實機驗收心得（issue #177）、既有 CLI 行為、service 行為或關聯 issue；MUST NOT 把尚未落地的行為描述為既成事實。MUST 與 B8 `docs/onboarding/*` 交叉引用（人類 operator vs agent orchestrator 兩視角）。
+
+### R4 路徑衛生（R-21）
+
+SKILL.md MUST 一律以 `~`、`$HOME`、環境變數或相對路徑表示路徑；MUST NOT 出現任何個人絕對路徑、使用者名或雇主／廠商識別（本 repo `tier: shareable`）。
+
+### R5 契約測試
+
+SHALL 新增 `tests/test_driving_cortex_skill.py`，鎖定：SKILL.md 存在、frontmatter 含 `description`、涵蓋 R2 七段關鍵標題、全文無個人絕對路徑／使用者名／雇主識別（R-21）、且不得出現 unsafe bypass flag 作為日常指引。
+
+### 驗收與限制
+
+一個沒跑過 cortex 的 agent，讀完 skill 後能獨立完成一個 dogfood 批次（claim→build→review→attest→merge）而不需重新摸索恢復桿。`python3 -m pytest tests/ -q` 全綠；`python3 -m policy_check --repo .` 0 fail（含 R-18/R-21/R-22）；`git diff --check` 乾淨；不新增 runtime 依賴；不改動既有 planning-authority plan。

--- a/docs/superpowers/workstreams/driving-cortex-skill/todo.md
+++ b/docs/superpowers/workstreams/driving-cortex-skill/todo.md
@@ -1,0 +1,13 @@
+---
+status: accepted
+work_item: driving-cortex-skill
+---
+
+# driving-cortex-skill Todo
+
+## Tasks
+
+- [ ] 將 issue #177、active OpenSpec change `2026-07-26-driving-cortex-skill` 與本 Todo 綁定為同一 confirmed Work Item。
+- [ ] coordinator 派工 codex（gpt-5.3-codex-spark）完成 #177 driving-cortex skill（TDD）：`skills/driving-cortex/SKILL.md` 七段骨架 + `tests/test_driving_cortex_skill.py` 契約測試。
+- [ ] ForeignReview（agy/gemini-3.6-flash-high）adversarial-review 通過；operator（Copilot CLI session）驗收核可。
+- [ ] 一個沒跑過 cortex 的 agent 讀完 skill 能獨立完成 dogfood 批次（claim→build→review→attest→merge）；全文無個人絕對路徑／使用者名／雇主識別（R-21）；pytest/policy_check 全綠。

--- a/openspec/changes/2026-07-26-driving-cortex-skill/design.md
+++ b/openspec/changes/2026-07-26-driving-cortex-skill/design.md
@@ -1,0 +1,29 @@
+---
+status: accepted
+work_item: driving-cortex-skill
+---
+
+# driving-cortex-skill Design
+
+## Decisions
+
+### D1 Claude Code skill 格式優先
+
+選 Claude Code skill（`skills/driving-cortex/SKILL.md`，frontmatter `description`）為首要交付物；cortex 原生 deck skill 卡為後續選項，本批不交付。issue #177 訴求是「告訴 agent」，Claude Code skill 是 session 內可被路由選用的形式。
+
+### D2 內容來源＝v0.1.0 實機驗收心得
+
+七段骨架直接採 issue #177 心得；命令、時序陷阱、恢復桿回溯到該次 dogfood 實證與關聯 issue（#152/#100/#175/#158/#83/#99/#148/#142），不杜撰未落地行為。
+
+### D3 與 B8 onboarding docs 交叉引用
+
+頂部說明兩視角分工：B8 `docs/onboarding/*`＝人類 operator install/bootstrap 旅程；本 skill＝agent 編排 coordinator 視角。交叉引用避免重複維護。
+
+### D4 契約測試鎖定結構與路徑衛生
+
+`tests/test_driving_cortex_skill.py` TDD RED 先行：SKILL.md 存在、frontmatter `description`、七段標題、R-21 無個人路徑、`--dangerously-bypass-approvals-and-sandbox` 不作日常指引。
+
+## 風險
+
+- skill 引用未落地行為會誤導 agent：契約測試鎖關鍵標題 + R-21 路徑衛生測試。
+- unsafe bypass flag 被寫成常態操作：D4 測試確保僅出現於情境命令脈絡。

--- a/openspec/changes/2026-07-26-driving-cortex-skill/proposal.md
+++ b/openspec/changes/2026-07-26-driving-cortex-skill/proposal.md
@@ -1,0 +1,23 @@
+---
+status: accepted
+work_item: driving-cortex-skill
+---
+
+## Goals
+
+新增 Claude Code skill `driving-cortex`，教 agent 如何驅動 cortex dogfood 派工與交付，結晶 v0.1.0 實機驗收心得，讓後續 agent 幾分鐘上手而非重新踩坑。
+
+## Why
+
+v0.1.0 全程 cortex dogfood 實機驗收證明派工/交付模型可用，但新 agent 面對 cortex 沒有「怎麼開這台車」的簡明指引——本次靠跑完 9 批 + 修 17 個 runtime bug + 大量恢復操作才摸透操作模型。這些 hard-won 知識應固化成 skill（#177）。與 B8 onboarding docs（人類 operator 視角）互補，本 skill 是 agent 編排 coordinator 視角。
+
+## What Changes
+
+- 新增 `skills/driving-cortex/SKILL.md`：Claude Code skill，frontmatter `description` 觸發詞；七段骨架（心智模型／開一個 dogfood 批次／驅動桿／執行器設定／每批 merge 後部署／生命週期特性／已知坑）；恢復桿與坑以 checklist 呈現。
+- 新增 `tests/test_driving_cortex_skill.py`：契約測試鎖定 SKILL.md 存在、七段標題、R-21 路徑衛生、unsafe bypass flag 不作日常指引。
+- README 補 skill 導覽一行；`changelog.d/driving-cortex-skill.md` 與 `CHANGELOG.md [Unreleased] ### Added`。
+
+## Capabilities
+
+### Modified Capabilities
+- 無 runtime capability 變更；本 change 為 agent 慣例檔（skill）與其契約測試。

--- a/openspec/changes/2026-07-26-driving-cortex-skill/tasks.md
+++ b/openspec/changes/2026-07-26-driving-cortex-skill/tasks.md
@@ -1,0 +1,11 @@
+---
+status: accepted
+work_item: driving-cortex-skill
+---
+
+# Tasks
+
+- [ ] 1.1 RED：`tests/test_driving_cortex_skill.py` 鎖定 SKILL.md 存在、frontmatter `description` 觸發詞、七段標題、R-21 無個人路徑、unsafe bypass flag 不作日常指引。
+- [ ] 1.2 `skills/driving-cortex/SKILL.md`：frontmatter `description` + 兩視角分工 + 七段骨架（心智模型／開一個 dogfood 批次／驅動桿／執行器設定／每批 merge 後部署／生命週期特性／已知坑）；恢復桿與坑以 checklist 呈現。
+- [ ] 1.3 README 補 skill 導覽一行（R-18）；`changelog.d/driving-cortex-skill.md` 與 `CHANGELOG.md [Unreleased] ### Added`（#177）。
+- [ ] 1.4 `python3 -m pytest tests/ -q` 全綠；`python3 -m policy_check --repo .` 0 fail；`git diff --check` 乾淨。


### PR DESCRIPTION
Planning authority spec/design/plan/todo + openspec change for #177 (driving-cortex skill).

- spec/design/plan/todo with `status: accepted` + `work_item: driving-cortex-skill`
- openspec change `2026-07-26-driving-cortex-skill`
- register `driving-cortex-skill` in `.cortex/work-items.yaml`

Planning PR (does not close #177; delivery PR by codex build will close #177). `assess_planning_completeness` = complete.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>