### PR TITLE
feat(skill): driving-cortex skill 教 agent 驅動 cortex dogfood 派工與交付 (#177)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 
 ## [Unreleased]
 
+### Added
+- **Issue #177：driving-cortex skill**：新增 `skills/driving-cortex/SKILL.md`，提供 agent 編排 coordinator 視角下的 cortex dogfood 批次驅動與交付操作指南（含 seven-section 實務骨架）。
+
 ### Fixed
 - **Issue #175：reclaim PR inheritance**：`start_canonical_workflow` needs_human 與 start 兩條路徑都不再帶入 `pr_refs`，`GitHubTerminalProvider` 不會將 `state=CLOSED`（未合併）PR 加入 `closing_links`，避免 closed PR 異常延續到 delivery authority。
 - **Issue #134：multi-issue build 支援最小 issue 為主 branch 且以 run repository 建立 worktree**：builder 會在 run 含多個 issue 時，使用編號最小的 `feature/<主issue>-<work_id>`，並由 run repo 作為 `ScriptWorktreeCreator` 的 git 工作目錄。

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ python -m pip install .
 - [Concepts](docs/onboarding/concepts.md)：`spec`、`job`、`slice`、`work` 名詞速查。
 - [Admin](docs/onboarding/admin.md)：`cortex service`、`cortex inspect`、`cortex request` 的日常維運操作。
 - [Runbook](docs/onboarding/runbook.md)：把常見事故整理成可執行 SOP。
+- [driving-cortex skill](skills/driving-cortex/SKILL.md)：agent 編排 coordinator 視角，對應 issue #177 的 dogfood 派工實務。
 
 ## Usage
 

--- a/changelog.d/driving-cortex-skill.md
+++ b/changelog.d/driving-cortex-skill.md
@@ -1,0 +1,3 @@
+### Added
+
+- **Issue #177：driving-cortex skill**：新增 `skills/driving-cortex/SKILL.md`，提供 agent 驅動 cortex dogfood 派工與交付的操作指南（含心智模型、批次啟動、驅動桿、每批部署與已知坑）。

--- a/openspec/changes/2026-07-26-driving-cortex-skill/tasks.md
+++ b/openspec/changes/2026-07-26-driving-cortex-skill/tasks.md
@@ -5,7 +5,7 @@ work_item: driving-cortex-skill
 
 # Tasks
 
-- [ ] 1.1 RED：`tests/test_driving_cortex_skill.py` 鎖定 SKILL.md 存在、frontmatter `description` 觸發詞、七段標題、R-21 無個人路徑、unsafe bypass flag 不作日常指引。
+- [x] 1.1 RED：`tests/test_driving_cortex_skill.py` 鎖定 SKILL.md 存在、frontmatter `description` 觸發詞、七段標題、R-21 無個人路徑、unsafe bypass flag 不作日常指引。
 - [ ] 1.2 `skills/driving-cortex/SKILL.md`：frontmatter `description` + 兩視角分工 + 七段骨架（心智模型／開一個 dogfood 批次／驅動桿／執行器設定／每批 merge 後部署／生命週期特性／已知坑）；恢復桿與坑以 checklist 呈現。
 - [ ] 1.3 README 補 skill 導覽一行（R-18）；`changelog.d/driving-cortex-skill.md` 與 `CHANGELOG.md [Unreleased] ### Added`（#177）。
 - [ ] 1.4 `python3 -m pytest tests/ -q` 全綠；`python3 -m policy_check --repo .` 0 fail；`git diff --check` 乾淨。

--- a/openspec/changes/2026-07-26-driving-cortex-skill/tasks.md
+++ b/openspec/changes/2026-07-26-driving-cortex-skill/tasks.md
@@ -6,6 +6,6 @@ work_item: driving-cortex-skill
 # Tasks
 
 - [x] 1.1 RED：`tests/test_driving_cortex_skill.py` 鎖定 SKILL.md 存在、frontmatter `description` 觸發詞、七段標題、R-21 無個人路徑、unsafe bypass flag 不作日常指引。
-- [ ] 1.2 `skills/driving-cortex/SKILL.md`：frontmatter `description` + 兩視角分工 + 七段骨架（心智模型／開一個 dogfood 批次／驅動桿／執行器設定／每批 merge 後部署／生命週期特性／已知坑）；恢復桿與坑以 checklist 呈現。
-- [ ] 1.3 README 補 skill 導覽一行（R-18）；`changelog.d/driving-cortex-skill.md` 與 `CHANGELOG.md [Unreleased] ### Added`（#177）。
+- [x] 1.2 `skills/driving-cortex/SKILL.md`：frontmatter `description` + 兩視角分工 + 七段骨架（心智模型／開一個 dogfood 批次／驅動桿／執行器設定／每批 merge 後部署／生命週期特性／已知坑）；恢復桿與坑以 checklist 呈現。
+- [x] 1.3 README 補 skill 導覽一行（R-18）；`changelog.d/driving-cortex-skill.md` 與 `CHANGELOG.md [Unreleased] ### Added`（#177）。
 - [ ] 1.4 `python3 -m pytest tests/ -q` 全綠；`python3 -m policy_check --repo .` 0 fail；`git diff --check` 乾淨。

--- a/skills/driving-cortex/SKILL.md
+++ b/skills/driving-cortex/SKILL.md
@@ -61,7 +61,7 @@ description: "driving cortex、派工 cortex、cortex work 導向的協作 skill
 ## 已知坑
 
 - [ ] `#152`：`5s` 這類短超時是預期回報節奏，不代表實際失敗，先確認 `--wait` 與 retry 方案。
-- [ ] `#175`：`re-claim` 後會繼承舊上下文，避免在已開 PR 後直接 re-claim。
+- [ ] `#175`：re-claim 繼承舊 PR 綁定已於 #190 修復；仍建議避免在已開 PR 後直接 re-claim，以防邊界情境殘留。
 - [ ] `#158`：archive/sources 的 Purpose 若仍留 `TBD`，會阻礙 close gate，需補齊。
 - [ ] `#83`：缺少 worktree/branch GC 的情境下，偶有殘留資源；交接前回收可疑 workspace。
 - [ ] `#99`：daemon 若假設目前 cwd 作為 repo root，可能讀錯目錄，務必驗證 manager/monitor 是否以 `PSC_REPO_ROOT` 類正確根路徑執行。

--- a/skills/driving-cortex/SKILL.md
+++ b/skills/driving-cortex/SKILL.md
@@ -1,0 +1,67 @@
+---
+description: "driving cortex、派工 cortex、cortex work 導向的協作 skill（issue #177）"
+---
+
+# driving-cortex skill
+
+## 兩視角分工（對應 B8 `docs/onboarding/*`）
+
+- B8 onboarding docs 聚焦「人類 operator」安裝、bootstrap、日常維運；本 skill 是 agent 在 session 內的編排視角。
+- 你是 agent 時，主要目標是**讓 coordinator 正確拿到可執行的 spec / plan / authority，並持續把 run 從 claim 走到 ship**；不是代替 operator 做環境安裝。
+
+## 心智模型
+
+- Manager 是唯一 writer：所有狀態變更、派工、run 推進都由 manager daemon 維護（透過 control queue）。
+- Monitor 是唯讀投影：讀取 `.cortex/work-items.yaml`、workstream `todo.md` 以及其他 confirmed authority。
+- deck 是上游契約入口：先形成 accepted planning artifact 後，依 `claim → define → plan → build → verify → review → ship` 進入生產化 workflow。
+- `cortex work start`、`resume`、`retry-build`、`review-attest` 是 build 之後的人機協作邊界；`5s` 類 timeout 本身通常只是「未達結果」，不代表系統已失敗。
+
+## 開一個 dogfood 批次
+
+1. 從 accepted planning artifact 開始：spec/plan/frontmatter 必須有 `status: accepted`、`work_item`、必要章節與 `target_branch`。
+2. 在 `.cortex/work-items.yaml` 加入對應 work item 並對齊 `issue`。
+3. 把 `docs/superpowers/plans/driving-cortex-skill.md` 參考為本批次來源之一，並補齊對應 `openspec/changes/2026-07-26-driving-cortex-skill/tasks.md`。
+4. 啟動或重啟 monitor snapshot，確認 work item 在 remote view 出現後再開始調度。
+5. 透過 `cortex ready --specs-dir ...` 檢查已滿足條件，再進入 `cortex tick`。
+
+## 驅動桿
+
+- 每次 run 啟動順序：
+  - `cortex work start --workflow-action`（依 manager 指示）
+  - `cortex work resume --expected-run-id`（run 卡住時）
+  - `cortex work retry-build --payload ...`（build 後重試）
+  - `cortex work review-attest --payload ...`（有 `review-attest` evidence 時）
+- 恢復桿（依序操作）：
+  - [ ] run 停留在 `needs_human` 時，先看 run/facet 的 blocking reason，補齊對應 artifact 再 resume。
+  - [ ] 驗證卡片 evidence 的 binding 是否可重讀，必要時用 `cortex work retry-build`。
+  - [ ] review-thread 未關閉但 merge-ready 前先在 remote 解決 thread，再以 `cortex work resume` 重繼。
+  - [ ] merge 後發現 run 尚未前進時，等待下一 run 合併後再 resume（避免手動強推）。
+
+## 執行器設定
+
+- 編輯 `~/.agents/config/paulsha/model-identities.yaml`。
+- `build` 的 executor 需對齊 `identity.executor`，`model_id` 要和 CLI `--model` 完整一致。
+- builder 與 reviewer `independence_domain` 不可相同，避免同域風險互相依賴。
+- 直接派 `codex` 修 bug 時，請使用 `-c model_reasoning_effort="high"`（對齊 issue #148 所需效能策略）。
+
+## 每批 merge 後部署
+
+1. 在 target repo 以 `pipx install --force <repo>` 重新安裝，讓新 code 可被服務載入。
+2. 依序 restart manager/monitor，確保新 manifest、workflow 入口與身份配置同步。
+3. 開始下一批前先清點 `systemctl --user status`、`cortex status` 與 monitor snapshot。
+4. 注意順序：daemon 啟動若過快，可能先看到舊 mtime；可在重啟前後比較部署時間與檔案 mtime 判斷是否已切到新版本。
+5. 複核 env/unit：有些 venv 或外部注入會覆寫 `F44` 相關變數，重啟前以 `grep` 將其列出。
+
+## 生命週期特性
+
+- run closure 常有一批延遲：批次 N 在 N+1 合併前，可能維持在 `ongoing / review / needs_human`。
+- 非故障情境下，不建議卡住 N，以免阻斷 N+1 先行 claim；優先先完成 N+1 的規劃與 merge，待前序條件滿足後再 resume N。
+- 最後一批必須有獨立 PR 確認 todo 勾選完成，避免 done record 先行封裝。
+
+## 已知坑
+
+- [ ] `#152`：`5s` 這類短超時是預期回報節奏，不代表實際失敗，先確認 `--wait` 與 retry 方案。
+- [ ] `#175`：`re-claim` 後會繼承舊上下文，避免在已開 PR 後直接 re-claim。
+- [ ] `#158`：archive/sources 的 Purpose 若仍留 `TBD`，會阻礙 close gate，需補齊。
+- [ ] `#83`：缺少 worktree/branch GC 的情境下，偶有殘留資源；交接前回收可疑 workspace。
+- [ ] `#99`：daemon 若假設目前 cwd 作為 repo root，可能讀錯目錄，務必驗證 manager/monitor 是否以 `PSC_REPO_ROOT` 類正確根路徑執行。

--- a/tests/test_driving_cortex_skill.py
+++ b/tests/test_driving_cortex_skill.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SKILL_PATH = REPO_ROOT / "skills" / "driving-cortex" / "SKILL.md"
+
+HOME = Path.home()
+
+ABSOLUTE_PATH_RE = re.compile(
+    r"(?<![A-Za-z0-9._-])/(?:home|Users)/[A-Za-z0-9._-]+(?:/[A-Za-z0-9._~%+\\-]*)+"
+)
+DANGEROUS_FLAG = "--dangerously-bypass-approvals-and-sandbox"
+TRIGGER_PHRASES = ("dogfood cortex", "派工 cortex", "cortex work")
+SECTION_HEADINGS = (
+    "## 心智模型",
+    "## 開一個 dogfood 批次",
+    "## 驅動桿",
+    "## 執行器設定",
+    "## 每批 merge 後部署",
+    "## 生命週期特性",
+    "## 已知坑",
+)
+FORBIDDEN_CONTEXT = (r"僅限", r"僅作", r"例外", r"除外", r"僅在", r"必要情境", r"緊急")
+BUSINESS_IDENTIFIERS = ("hamanpaul", "arcadyan")
+
+
+def _read_skill_text() -> str:
+    assert SKILL_PATH.is_file(), f"missing skill file: {SKILL_PATH}"
+    return SKILL_PATH.read_text(encoding="utf-8")
+
+
+def _read_frontmatter(text: str) -> dict[str, object]:
+    match = re.search(r"^---\n(?P<body>.*?)\n---\n", text, flags=re.DOTALL)
+    assert match, "SKILL.md must include YAML frontmatter"
+    data = yaml.safe_load(match.group("body")) or {}
+    assert isinstance(data, dict), "SKILL.md frontmatter must be mapping"
+    return data
+
+
+def _assert_no_personal_or_vendor_tokens(text: str) -> None:
+    normalized = text.lower()
+    assert not ABSOLUTE_PATH_RE.search(text), "SKILL.md must not contain personal absolute paths"
+    assert str(HOME) not in text, "SKILL.md must not contain current-user absolute path"
+    assert str(REPO_ROOT) not in text, "SKILL.md should avoid hardcoded repo absolute paths"
+    for token in (os.getenv("USER"), os.getenv("USERNAME")):
+        if token:
+            assert token not in text, f"SKILL.md must not embed username token: {token}"
+    for marker in BUSINESS_IDENTIFIERS:
+        assert marker not in normalized, f"SKILL.md must not embed vendor/organizational identifier: {marker}"
+
+
+def _assert_unsafe_flag_context(text: str) -> None:
+    if DANGEROUS_FLAG not in text:
+        return
+    lines = text.splitlines()
+    for idx, line in enumerate(lines):
+        if DANGEROUS_FLAG not in line:
+            continue
+        neighborhood = "\n".join(lines[max(0, idx - 1) : min(len(lines), idx + 2)])
+        if not any(re.search(token, neighborhood) for token in FORBIDDEN_CONTEXT):
+            assert False, (
+                "Unsafe bypass flag is used as daily guide; keep it under explicit exception context"
+            )
+
+
+def test_skill_file_exists() -> None:
+    assert SKILL_PATH.is_file(), f"missing skill file: {SKILL_PATH}"
+
+
+def test_skill_has_description_frontmatter() -> None:
+    text = _read_skill_text()
+    meta = _read_frontmatter(text)
+    description = meta.get("description")
+    assert isinstance(description, str), "description missing from frontmatter"
+    lower_description = description.lower()
+    assert any(token in lower_description for token in TRIGGER_PHRASES), (
+        "frontmatter description must include one trigger phrase"
+    )
+
+
+def test_skill_covers_seven_sections() -> None:
+    text = _read_skill_text()
+    for heading in SECTION_HEADINGS:
+        assert heading in text, f"missing required heading: {heading}"
+
+
+def test_skill_no_personal_paths() -> None:
+    text = _read_skill_text()
+    _assert_no_personal_or_vendor_tokens(text)
+
+
+def test_skill_no_unsafe_bypass_as_daily_guide() -> None:
+    text = _read_skill_text()
+    _assert_unsafe_flag_context(text)


### PR DESCRIPTION
Closes #177

新增 Claude Code skill `skills/driving-cortex/SKILL.md`，結晶 v0.1.0 實機驗收心得，教 agent 驅動 cortex dogfood 派工與交付（claim→build→review→attest→ship）。

## 內容
- `skills/driving-cortex/SKILL.md`：七段骨架（心智模型／開一個 dogfood 批次／驅動桿／執行器設定／每批 merge 後部署／生命週期特性／已知坑），恢復桿與坑以 checklist 呈現；與 B8 `docs/onboarding/*` 交叉引用。
- `tests/test_driving_cortex_skill.py`：契約測試鎖定 SKILL.md 存在、frontmatter 觸發詞、七段標題、R-21 無個人路徑/廠商識別、unsafe bypass flag 不作日常指引。
- README 補 skill 導覽一行；`changelog.d/driving-cortex-skill.md` 與 `CHANGELOG.md [Unreleased] ### Added`。

## 流程
- 規劃：planning PR #191（spec/design/plan/todo + openspec change + work-item entry）已 merge。
- 實作：cortex coordinator 派工 codex（gpt-5.3-codex-spark）於 feature-oneshot workflow run `workflow-c0fee5963cb3da0f2d58` 完成；候選 commit 576881ff。
- 對抗審查：agy（gemini-3.6-flash-high）adversarial review。
- 驗收：operator（Copilot CLI）核可 — pytest 1219 pass、policy_check 0 fail、git diff --check 乾淨、agy 對抗通過。

## 注意
build 卡片在 codex `workspace-write` sandbox 下跑全套 pytest 時，28 個 AF_UNIX socket 測試因沙箱限制失敗（環境因素，非本變更缺陷），codex 據實回報 status=failed；候選已由 operator 在非沙箱環境驗證全綠（1219 pass）後採 operator-attest 路徑交付。

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>