### PR TITLE
docs: 8 issue 規劃產物與 work-item entries（平行派工準備）

### DIFF
--- a/.cortex/work-items.yaml
+++ b/.cortex/work-items.yaml
@@ -218,6 +218,110 @@ work_items:
         ref: docs/superpowers/specs/driving-cortex-skill-design.md
       - kind: path
         ref: docs/superpowers/plans/driving-cortex-skill.md
+  fix-dispatch-spec-path:
+    title: fix dispatch spec path resolution (#98)
+    links:
+      - kind: github_issue
+        ref: hamanpaul/paulsha-cortex#98
+      - kind: openspec
+        ref: 2026-07-26-fix-dispatch-spec-path
+      - kind: path
+        ref: docs/superpowers/specs/fix-dispatch-spec-path-spec.md
+      - kind: path
+        ref: docs/superpowers/specs/fix-dispatch-spec-path-design.md
+      - kind: path
+        ref: docs/superpowers/plans/fix-dispatch-spec-path.md
+  fix-deck-emit-frontmatter:
+    title: fix deck emit frontmatter for dispatch contract (#101)
+    links:
+      - kind: github_issue
+        ref: hamanpaul/paulsha-cortex#101
+      - kind: openspec
+        ref: 2026-07-26-fix-deck-emit-frontmatter
+      - kind: path
+        ref: docs/superpowers/specs/fix-deck-emit-frontmatter-spec.md
+      - kind: path
+        ref: docs/superpowers/specs/fix-deck-emit-frontmatter-design.md
+      - kind: path
+        ref: docs/superpowers/plans/fix-deck-emit-frontmatter.md
+  fix-builder-write-paths:
+    title: fix builder write_paths cross-repo (#118)
+    links:
+      - kind: github_issue
+        ref: hamanpaul/paulsha-cortex#118
+      - kind: openspec
+        ref: 2026-07-26-fix-builder-write-paths
+      - kind: path
+        ref: docs/superpowers/specs/fix-builder-write-paths-spec.md
+      - kind: path
+        ref: docs/superpowers/specs/fix-builder-write-paths-design.md
+      - kind: path
+        ref: docs/superpowers/plans/fix-builder-write-paths.md
+  docs-monitor-load-config:
+    title: docs monitor load_config explicit/ambient (#143)
+    links:
+      - kind: github_issue
+        ref: hamanpaul/paulsha-cortex#143
+      - kind: openspec
+        ref: 2026-07-26-docs-monitor-load-config
+      - kind: path
+        ref: docs/superpowers/specs/docs-monitor-load-config-spec.md
+      - kind: path
+        ref: docs/superpowers/specs/docs-monitor-load-config-design.md
+      - kind: path
+        ref: docs/superpowers/plans/docs-monitor-load-config.md
+  fix-service-install-overwrite:
+    title: fix service install overwrite guard (#148)
+    links:
+      - kind: github_issue
+        ref: hamanpaul/paulsha-cortex#148
+      - kind: openspec
+        ref: 2026-07-26-fix-service-install-overwrite
+      - kind: path
+        ref: docs/superpowers/specs/fix-service-install-overwrite-spec.md
+      - kind: path
+        ref: docs/superpowers/specs/fix-service-install-overwrite-design.md
+      - kind: path
+        ref: docs/superpowers/plans/fix-service-install-overwrite.md
+  fix-slice-failed-deadend:
+    title: fix slice failed state dead-end (#153)
+    links:
+      - kind: github_issue
+        ref: hamanpaul/paulsha-cortex#153
+      - kind: openspec
+        ref: 2026-07-26-fix-slice-failed-deadend
+      - kind: path
+        ref: docs/superpowers/specs/fix-slice-failed-deadend-spec.md
+      - kind: path
+        ref: docs/superpowers/specs/fix-slice-failed-deadend-design.md
+      - kind: path
+        ref: docs/superpowers/plans/fix-slice-failed-deadend.md
+  docs-archived-spec-purpose:
+    title: docs archived spec Purpose TBD (#158)
+    links:
+      - kind: github_issue
+        ref: hamanpaul/paulsha-cortex#158
+      - kind: openspec
+        ref: 2026-07-26-docs-archived-spec-purpose
+      - kind: path
+        ref: docs/superpowers/specs/docs-archived-spec-purpose-spec.md
+      - kind: path
+        ref: docs/superpowers/specs/docs-archived-spec-purpose-design.md
+      - kind: path
+        ref: docs/superpowers/plans/docs-archived-spec-purpose.md
+  test-r21-regex-resilience:
+    title: test R-21 regex resilience CRLF + Windows (#169)
+    links:
+      - kind: github_issue
+        ref: hamanpaul/paulsha-cortex#169
+      - kind: openspec
+        ref: 2026-07-26-test-r21-regex-resilience
+      - kind: path
+        ref: docs/superpowers/specs/test-r21-regex-resilience-spec.md
+      - kind: path
+        ref: docs/superpowers/specs/test-r21-regex-resilience-design.md
+      - kind: path
+        ref: docs/superpowers/plans/test-r21-regex-resilience.md
   dispatch-reliability-batch:
     title: dispatch reliability batch (abandoned, #134)
     links: []

--- a/docs/superpowers/plans/docs-archived-spec-purpose.md
+++ b/docs/superpowers/plans/docs-archived-spec-purpose.md
@@ -1,0 +1,26 @@
+---
+status: accepted
+work_item: docs-archived-spec-purpose
+---
+
+# docs-archived-spec-purpose Plan
+
+## Tasks
+
+### 1. TDD RED
+
+- [ ] `tests/test_openspec_archive_purpose.py`：
+  - `openspec archive` 產生的 spec.md 不含 `Purpose: TBD`。
+  - 含從 change proposal 推導的 Purpose 文字。
+  - 先確認 RED。
+
+### 2. 實作
+
+- [ ] `paulsha_cortex/cli/openspec*.py`：archive 時從 change proposal Goals 段推導 Purpose。
+- [ ] 批次更新 9 個既有 specs 的 `Purpose: TBD` 行。
+
+### 3. 同步與驗證
+
+- [ ] `changelog.d/docs-archived-spec-purpose.md` fragment；`CHANGELOG.md [Unreleased]` `### Fixed` 加入含 `#158` 條目。
+- [ ] `python3 -m pytest tests/ -q` 全綠；`python3 -m policy_check --repo .` 0 fail；`git diff --check` 乾淨。
+- [ ] 勾選 `openspec/changes/2026-07-26-docs-archived-spec-purpose/tasks.md` 對應項並以 conventional commit 提交。

--- a/docs/superpowers/plans/docs-monitor-load-config.md
+++ b/docs/superpowers/plans/docs-monitor-load-config.md
@@ -1,0 +1,25 @@
+---
+status: accepted
+work_item: docs-monitor-load-config
+---
+
+# docs-monitor-load-config Plan
+
+## Tasks
+
+### 1. TDD RED
+
+- [ ] `tests/test_monitor_config_explicit.py`：
+  - `load_config(config_path=<explicit>)` 不合併 ambient hippo projects。
+  - `load_config()` 不帶 config_path 時仍合併 ambient。
+  - 先確認 RED。
+
+### 2. 實作（docs-only）
+
+- [ ] `docs/`：新增或更新 monitor 文件，記錄 `load_config` 的 explicit/ambient 合併語意。
+
+### 3. 同步與驗證
+
+- [ ] `changelog.d/docs-monitor-load-config.md` fragment；`CHANGELOG.md [Unreleased]` `### Documentation` 加入含 `#143` 條目。
+- [ ] `python3 -m pytest tests/ -q` 全綠；`python3 -m policy_check --repo .` 0 fail；`git diff --check` 乾淨。
+- [ ] 勾選 `openspec/changes/2026-07-26-docs-monitor-load-config/tasks.md` 對應項並以 conventional commit 提交。

--- a/docs/superpowers/plans/fix-builder-write-paths.md
+++ b/docs/superpowers/plans/fix-builder-write-paths.md
@@ -1,0 +1,26 @@
+---
+status: accepted
+work_item: fix-builder-write-paths
+---
+
+# fix-builder-write-paths Plan
+
+## Tasks
+
+### 1. TDD RED
+
+- [ ] `tests/test_fix_builder_write_paths.py`：
+  - 跨 repo dispatch（target repo 非 `paulsha_cortex`）時 builder `write_paths` 涵蓋目標 repo 路徑，builder 不拒絕寫入。
+  - cortex repo 內 dispatch 時行為不變。
+  - 先確認 RED。
+
+### 2. 實作
+
+- [ ] `paulsha_cortex/persona/personas.yaml`：builder `write_paths` 改為 `["**"]` 或標記 dynamic。
+- [ ] `paulsha_cortex/persona/contract.py` 或 `render.py`：render 時動態推導 `write_paths`（若需更精確可從 `run.workspace_root`）。
+
+### 3. 同步與驗證
+
+- [ ] `changelog.d/fix-builder-write-paths.md` fragment；`CHANGELOG.md [Unreleased]` `### Fixed` 加入含 `#118` 條目。
+- [ ] `python3 -m pytest tests/ -q` 全綠；`python3 -m policy_check --repo .` 0 fail；`git diff --check` 乾淨。
+- [ ] 勾選 `openspec/changes/2026-07-26-fix-builder-write-paths/tasks.md` 對應項並以 conventional commit 提交。

--- a/docs/superpowers/plans/fix-deck-emit-frontmatter.md
+++ b/docs/superpowers/plans/fix-deck-emit-frontmatter.md
@@ -1,0 +1,28 @@
+---
+status: accepted
+work_item: fix-deck-emit-frontmatter
+---
+
+# fix-deck-emit-frontmatter Plan
+
+## Tasks
+
+### 1. TDD RED
+
+- [ ] `tests/test_fix_deck_emit_frontmatter.py`：
+  - `deck compile --emit` 產生 frontmatter `target_branch` 非空（從 context 推導）。
+  - `verification` 為完整物件含 `docs_class`、`checks`（persona-scope + policy command + tests + full_suite with baseline: no-regression）。
+  - 不再出現 `target_branch: null` 或 `verification: null`。
+  - 先確認 RED。
+
+### 2. 實作
+
+- [ ] `paulsha_cortex/deck/compile.py`：`--emit` render 時從 context 推導 `target_branch`，填入 verification skeleton。
+- [ ] `docs/`：新增 auto dispatch contract 文件（verification 物件結構、必填欄位、範例）。
+
+### 3. 同步與驗證
+
+- [ ] `changelog.d/fix-deck-emit-frontmatter.md` fragment；`CHANGELOG.md [Unreleased]` `### Fixed` 加入含 `#101` 條目。
+- [ ] README 對應段同步連結（R-18）。
+- [ ] `python3 -m pytest tests/ -q` 全綠；`python3 -m policy_check --repo .` 0 fail；`git diff --check` 乾淨。
+- [ ] 勾選 `openspec/changes/2026-07-26-fix-deck-emit-frontmatter/tasks.md` 對應項並以 conventional commit 提交。

--- a/docs/superpowers/plans/fix-dispatch-spec-path.md
+++ b/docs/superpowers/plans/fix-dispatch-spec-path.md
@@ -1,0 +1,26 @@
+---
+status: accepted
+work_item: fix-dispatch-spec-path
+---
+
+# fix-dispatch-spec-path Plan
+
+## Tasks
+
+### 1. TDD RED
+
+- [ ] `tests/test_fix_dispatch_spec_path.py`：
+  - spec 位於 repo 外（`tmp_path / "agents" / "specs" / "foo-spec.md"`）、`PSC_REPO_ROOT` 指向另一 `tmp_path` 時，`_infer_repo_root` 回傳 `paths.repo_root()`。
+  - spec 位於 repo 內時行為不變。
+  - `PSC_REPO_ROOT` 未設定 + spec 在 repo 外時維持既有 fallback。
+  - 先確認 RED。
+
+### 2. 實作
+
+- [ ] `paulsha_cortex/coordinator/autonomy.py`：`_infer_repo_root()` 新增子樹判斷——spec 不在 `paths.repo_root()` 子樹下時回傳 `paths.repo_root()`。
+
+### 3. 同步與驗證
+
+- [ ] `changelog.d/fix-dispatch-spec-path.md` fragment；`CHANGELOG.md [Unreleased]` `### Fixed` 加入含 `#98` 條目。
+- [ ] `python3 -m pytest tests/ -q` 全綠；`python3 -m policy_check --repo .` 0 fail；`git diff --check` 乾淨。
+- [ ] 勾選 `openspec/changes/2026-07-26-fix-dispatch-spec-path/tasks.md` 對應項並以 conventional commit 提交。

--- a/docs/superpowers/plans/fix-service-install-overwrite.md
+++ b/docs/superpowers/plans/fix-service-install-overwrite.md
@@ -1,0 +1,26 @@
+---
+status: accepted
+work_item: fix-service-install-overwrite
+---
+
+# fix-service-install-overwrite Plan
+
+## Tasks
+
+### 1. TDD RED
+
+- [ ] `tests/test_fix_service_install_overwrite.py`：
+  - 既有有效 config（venv A）+ 呼叫者 venv B → 不覆寫，raise 清晰錯誤。
+  - 既有 config 無效或同 venv → 正常安裝。
+  - 首次安裝（無既有 config）→ 正常安裝。
+  - 先確認 RED。
+
+### 2. 實作
+
+- [ ] `paulsha_cortex/deploy/installer.py`：新增 idempotent guard——偵測既有 config 指向不同有效 venv 時拒絕覆寫。
+
+### 3. 同步與驗證
+
+- [ ] `changelog.d/fix-service-install-overwrite.md` fragment；`CHANGELOG.md [Unreleased]` `### Fixed` 加入含 `#148` 條目。
+- [ ] `python3 -m pytest tests/ -q` 全綠；`python3 -m policy_check --repo .` 0 fail；`git diff --check` 乾淨。
+- [ ] 勾選 `openspec/changes/2026-07-26-fix-service-install-overwrite/tasks.md` 對應項並以 conventional commit 提交。

--- a/docs/superpowers/plans/fix-slice-failed-deadend.md
+++ b/docs/superpowers/plans/fix-slice-failed-deadend.md
@@ -1,0 +1,27 @@
+---
+status: accepted
+work_item: fix-slice-failed-deadend
+---
+
+# fix-slice-failed-deadend Plan
+
+## Tasks
+
+### 1. TDD RED
+
+- [ ] `tests/test_fix_slice_failed_deadend.py`：
+  - failed slice 可 transition 至 `needs_human`（不再 raise `ValueError`）。
+  - failed slice `actions` 非空。
+  - registry daemon 在 `jobs.json` 外部修改後可重載。
+  - 先確認 RED。
+
+### 2. 實作
+
+- [ ] `paulsha_cortex/coordinator/registry.py`：新增 `failed → needs_human` transition（或 `reset` action）。
+- [ ] `paulsha_cortex/coordinator/registry.py`：registry daemon 磁碟重載支援（mtime 比較或 reload 命令）。
+
+### 3. 同步與驗證
+
+- [ ] `changelog.d/fix-slice-failed-deadend.md` fragment；`CHANGELOG.md [Unreleased]` `### Fixed` 加入含 `#153` 條目。
+- [ ] `python3 -m pytest tests/ -q` 全綠；`python3 -m policy_check --repo .` 0 fail；`git diff --check` 乾淨。
+- [ ] 勾選 `openspec/changes/2026-07-26-fix-slice-failed-deadend/tasks.md` 對應項並以 conventional commit 提交。

--- a/docs/superpowers/plans/test-r21-regex-resilience.md
+++ b/docs/superpowers/plans/test-r21-regex-resilience.md
@@ -1,0 +1,28 @@
+---
+status: accepted
+work_item: test-r21-regex-resilience
+---
+
+# test-r21-regex-resilience Plan
+
+## Tasks
+
+### 1. TDD RED
+
+- [ ] `tests/test_onboarding_docs_contract.py`：新增測試案例：
+  - CRLF bash fence 被 `BASH_FENCE_RE` 捕獲。
+  - fence marker 後 trailing whitespace 的 code block 被捕獲。
+  - Windows `C:\Users\...` 被 `PERSONAL_ABSOLUTE_PATH_RE` 捕獲。
+  - 先確認 RED。
+
+### 2. 實作
+
+- [ ] `tests/test_onboarding_docs_contract.py`：
+  - `BASH_FENCE_RE` 改為容忍 `\r?\n` + `[ \t]*` + `re.DOTALL`。
+  - `PERSONAL_ABSOLUTE_PATH_RE` 新增 Windows drive-letter path。
+
+### 3. 同步與驗證
+
+- [ ] `changelog.d/test-r21-regex-resilience.md` fragment；`CHANGELOG.md [Unreleased]` `### Fixed` 加入含 `#169` 條目。
+- [ ] `python3 -m pytest tests/ -q` 全綠；`python3 -m policy_check --repo .` 0 fail；`git diff --check` 乾淨。
+- [ ] 勾選 `openspec/changes/2026-07-26-test-r21-regex-resilience/tasks.md` 對應項並以 conventional commit 提交。

--- a/docs/superpowers/specs/docs-archived-spec-purpose-design.md
+++ b/docs/superpowers/specs/docs-archived-spec-purpose-design.md
@@ -1,0 +1,21 @@
+---
+status: accepted
+work_item: docs-archived-spec-purpose
+---
+
+# docs-archived-spec-purpose Design
+
+## Decisions
+
+### D1 Purpose 推導來源
+
+從 change `proposal.md` 的 `## Goals` 段取首段文字。Goals 段通常是一句話描述目標，適合作為 Purpose。若 Goals 段不存在或為空，fallback 到 capability name 的 human-readable 形式（如 `porcelain-service-lifecycle` → `Porcelain service lifecycle`）。
+
+### D2 批次更新策略
+
+逐一讀取各 spec 的對應 change proposal（從 `openspec/changes/archive/` 找），推導 Purpose，替換 `Purpose: TBD ...` 行。不動 spec 其餘內容。
+
+### 風險與 mitigation
+
+- change proposal 可能已 archived 且路徑不明 → fallback 到 capability name human-readable。
+- 推導的 Purpose 需人類 review → 更新後可在後續 PR 微調。

--- a/docs/superpowers/specs/docs-archived-spec-purpose-spec.md
+++ b/docs/superpowers/specs/docs-archived-spec-purpose-spec.md
@@ -1,0 +1,32 @@
+---
+status: accepted
+work_item: docs-archived-spec-purpose
+---
+
+# docs-archived-spec-purpose Specification
+
+`#158`：修正 `openspec archive` 產生 `Purpose: TBD` stub，並批次更新既有 specs。
+
+## Requirements
+
+### R1 archive 不再產生 TBD
+
+`openspec archive` 產生的 `spec.md` MUST NOT 含 `Purpose: TBD`。MUST 從 change proposal 推導 Purpose 或 prompt 使用者輸入。
+
+### R2 既有 specs 批次更新
+
+以下 9 個 specs 的 `Purpose: TBD` 行 MUST 更新為適當文字：
+- persona-workflow-orchestration
+- porcelain-service-lifecycle
+- release-engineering-pipeline
+- porcelain-guided-bootstrap
+- porcelain-run-recover-verbs
+- porcelain-inspect-surface
+- unified-work-read-model
+- governed-delivery-closure
+- cli-version-reporting
+
+### R3 限制
+
+- TDD；archive 命令測試 + 既有 specs 更新。
+- `python3 -m policy_check --repo .` 0 fail。

--- a/docs/superpowers/specs/docs-monitor-load-config-design.md
+++ b/docs/superpowers/specs/docs-monitor-load-config-design.md
@@ -1,0 +1,24 @@
+---
+status: accepted
+work_item: docs-monitor-load-config
+---
+
+# docs-monitor-load-config Design
+
+## Decisions
+
+### D1 不改 code
+
+`load_config` 的 explicit/ambient 行為正確，僅缺文件與測試覆蓋。直接補文件與測試。
+
+### D2 文件結構
+
+在 monitor 文件中新增「Config Loading Semantics」段落：
+- **Ambient mode**（不帶 `config_path`）：自動偵測並合併 hippo projects。
+- **Explicit mode**（帶 `config_path`）：僅載入指定 config，不合併 ambient。
+
+附範例 YAML 與 CLI 用法。
+
+### D3 測試策略
+
+以 `tmp_path` 模擬 ambient hippo project 存在，分別測試帶/不帶 `config_path` 的合併行為差異。

--- a/docs/superpowers/specs/docs-monitor-load-config-spec.md
+++ b/docs/superpowers/specs/docs-monitor-load-config-spec.md
@@ -1,0 +1,27 @@
+---
+status: accepted
+work_item: docs-monitor-load-config
+---
+
+# docs-monitor-load-config Specification
+
+`#143`：文件化 `monitor/config.py:load_config` 的 explicit vs ambient 行為並補測試。
+
+## Requirements
+
+### R1 文件化 explicit/ambient 行為
+
+`docs/**` MUST 記錄 `load_config` 的行為：
+- 不帶 `config_path`：ambient mode，合併偵測到的 hippo projects。
+- 帶 `config_path`：explicit mode，僅載入指定 config，不合併 ambient hippo projects。
+
+### R2 測試覆蓋
+
+`tests/` MUST 含測試驗證：
+- 顯式 `config_path` 時不合併 ambient hippo projects。
+- 不帶 `config_path` 時仍合併 ambient。
+
+### R3 限制
+
+- docs-only + test-only；不改 code。
+- `python3 -m policy_check --repo .` 0 fail。

--- a/docs/superpowers/specs/fix-builder-write-paths-design.md
+++ b/docs/superpowers/specs/fix-builder-write-paths-design.md
@@ -1,0 +1,25 @@
+---
+status: accepted
+work_item: fix-builder-write-paths
+---
+
+# fix-builder-write-paths Design
+
+## Decisions
+
+### D1 採 `["**"]` + worktree boundary
+
+builder `write_paths` 改為 `["**"]`，由 worktree boundary 限制寫入範圍。理由：persona 在 worktree 內執行，`["**"]` 等價「worktree 內任意路徑」，不需列舉特定 repo 的子路徑。
+
+### D2 render 時動態推導（如需更精確）
+
+若 `run.workspace_root` 可用，render 時可推導更精確的 pattern（如目標 repo 的主要 code 目錄）。但 `["**"]` 作為通用 fallback 已足夠。
+
+### D3 personas.yaml 改動
+
+`personas.yaml` 中 builder 的 `write_paths` 欄位改為 `["**"]`（或標記為 dynamic）。`contract.py` / `render.py` render 時直接使用，不再硬編碼 repo 名。
+
+### 風險與 mitigation
+
+- `["**"]` 範圍廣 → worktree boundary 為硬限制，builder 無法越界寫入。
+- 既有測試斷言 `paulsha_cortex/**` → 需更新為 `**` 或動態推導結果。

--- a/docs/superpowers/specs/fix-builder-write-paths-spec.md
+++ b/docs/superpowers/specs/fix-builder-write-paths-spec.md
@@ -1,0 +1,28 @@
+---
+status: accepted
+work_item: fix-builder-write-paths
+---
+
+# fix-builder-write-paths Specification
+
+`#118`：修正 builder persona `write_paths` 硬編碼 `paulsha_cortex/**`，使跨 repo 派工時 builder 可寫入目標 repo 路徑。
+
+## Requirements
+
+### R1 write_paths 相對 worktree root
+
+builder persona 的 `write_paths` MUST 相對於 worktree root，非絕對於 cortex repo。跨 repo dispatch 時 MUST 涵蓋目標 repo 路徑。可採 `["**"]` 由 worktree boundary 限制，或從 `run.workspace_root` 動態推導。
+
+### R2 跨 repo dispatch 不拒絕寫入
+
+跨 repo dispatch（target repo 非 `paulsha_cortex`）時，builder MUST NOT 因 `write_paths` 不符而拒絕寫入。
+
+### R3 向後相容
+
+cortex repo 內 dispatch 時行為不變——`write_paths` 仍涵蓋 cortex 路徑。
+
+### R4 限制
+
+- stdlib-only；TDD。
+- 不得改變既有對外 CLI envelope schema。
+- `test_zero_dependency_runtime` 續綠；`python3 -m policy_check --repo .` 0 fail。

--- a/docs/superpowers/specs/fix-deck-emit-frontmatter-design.md
+++ b/docs/superpowers/specs/fix-deck-emit-frontmatter-design.md
@@ -1,0 +1,37 @@
+---
+status: accepted
+work_item: fix-deck-emit-frontmatter
+---
+
+# fix-deck-emit-frontmatter Design
+
+## Decisions
+
+### D1 target_branch 推導策略
+
+從 combo/work-item context 取 `target_branch`；若 combo 有 `branch` 欄位則直接用，否則 fallback `feature/<work-item-slug>` 並 emit warning 至 stderr。
+
+### D2 verification skeleton 結構
+
+```yaml
+verification:
+  docs_class: <class>
+  checks:
+    - persona: <reviewer-persona>
+      command: policy
+      name: policy
+    - tests: pytest tests/ -q
+    - full_suite:
+        baseline: no-regression
+```
+
+從現有 dispatch contract 測試碼推斷期望結構，填入 skeleton 值。
+
+### D3 文件位置
+
+在 `docs/` 新增 `dispatch-contract.md`（或併入既有文件），記錄 verification 物件結構、必填欄位、範例 frontmatter。README 對應段加連結。
+
+### 風險與 mitigation
+
+- verification skeleton 欄位需與實際 contract 同步 → 測試同時驗證 emit 結構與 contract 一致。
+- context 不足時 fallback 行為需明確 warning，避免 silent default。

--- a/docs/superpowers/specs/fix-deck-emit-frontmatter-spec.md
+++ b/docs/superpowers/specs/fix-deck-emit-frontmatter-spec.md
@@ -1,0 +1,32 @@
+---
+status: accepted
+work_item: fix-deck-emit-frontmatter
+---
+
+# fix-deck-emit-frontmatter Specification
+
+`#101`：修正 `deck compile --emit` 硬編碼 `target_branch: null` 與 `verification: null`，使 emit 產生的 frontmatter 符合 auto dispatch contract，並補文件。
+
+## Requirements
+
+### R1 target_branch 非空
+
+`deck compile --emit` 產生的 frontmatter `target_branch` MUST 非空，從 combo/work-item context 推導。MUST NOT 硬編碼 `null`。context 不足時 MUST 提供 fallback default 並 emit warning。
+
+### R2 verification 物件完整
+
+`verification` MUST 為含以下結構的物件：
+- `docs_class`：文件類別
+- `checks`：含 persona-scope、`name=policy` command、`tests`、`full_suite`（含 `baseline: no-regression`）
+
+MUST NOT 硬編碼 `null`。
+
+### R3 文件化 auto dispatch contract
+
+`docs/` 或 README MUST 記錄 auto dispatch contract 的 verification 物件結構、必填欄位、範例。使使用者不需讀測試碼即可理解。
+
+### R4 限制
+
+- stdlib-only；TDD。
+- 不得改變既有對外 CLI envelope schema 字串。
+- `test_zero_dependency_runtime` 續綠；`python3 -m policy_check --repo .` 0 fail。

--- a/docs/superpowers/specs/fix-dispatch-spec-path-design.md
+++ b/docs/superpowers/specs/fix-dispatch-spec-path-design.md
@@ -1,0 +1,21 @@
+---
+status: accepted
+work_item: fix-dispatch-spec-path
+---
+
+# fix-dispatch-spec-path Design
+
+## Decisions
+
+### D1 優先判斷 spec 是否在 repo 子樹
+
+`_infer_repo_root(spec_path)` 先 resolve `spec_path` 與 `paths.repo_root()`，判斷前者是否為後者子目錄。若是 → 既有 `.git` walk。若否 → 回傳 `paths.repo_root()`。理由：repo-relative contract path（如 `plan`）的解析基準應為設定 repo root，不是 spec 檔所在目錄。
+
+### D2 向後相容
+
+`PSC_REPO_ROOT` 未設定時 `paths.repo_root()` 回退到 cwd 解析，行為與既有一致。不改動 `paths.repo_root()` 本身。
+
+### 風險與 mitigation
+
+- 測試以 `tmp_path` 建構 repo 外 spec + monkeypatch `paths.repo_root` 回另一目錄，驗證回傳值為 monkeypatch 的 root。
+- 既有 repo 內 spec 路徑不受影響——新增分支判斷在「不在子樹」時才生效。

--- a/docs/superpowers/specs/fix-dispatch-spec-path-spec.md
+++ b/docs/superpowers/specs/fix-dispatch-spec-path-spec.md
@@ -1,0 +1,24 @@
+---
+status: accepted
+work_item: fix-dispatch-spec-path
+---
+
+# fix-dispatch-spec-path Specification
+
+`#98`：修正 `autonomy._infer_repo_root()` 在 spec 位於 repo 外時未回退至 `PSC_REPO_ROOT`，導致 repo-relative plan 路徑解析錯誤、dispatch pinning 失敗。
+
+## Requirements
+
+### R1 spec 在 repo 外時回傳 PSC_REPO_ROOT
+
+`paulsha_cortex/coordinator/autonomy.py::_infer_repo_root(spec_path)` 當 `spec_path` 不在 `paths.repo_root()` 子樹下時，MUST 回傳 `paths.repo_root()`，因為 repo-relative contract path 應以設定 repo root 為基準。MUST NOT 回傳 `spec_path.parent` 或沿 `.git` 搜尋結果。
+
+### R2 spec 在 repo 內行為不變
+
+spec 位於 `paths.repo_root()` 子樹下時，`_infer_repo_root` MUST 維持既有 `.git` parent walk 行為。
+
+### R3 限制
+
+- stdlib-only；TDD（mock/monkeypatch `paths.repo_root` 驗證回傳值）。
+- 不得改變既有對外 CLI envelope schema。
+- `test_zero_dependency_runtime` 續綠；`python3 -m policy_check --repo .` 0 fail。

--- a/docs/superpowers/specs/fix-service-install-overwrite-design.md
+++ b/docs/superpowers/specs/fix-service-install-overwrite-design.md
@@ -1,0 +1,26 @@
+---
+status: accepted
+work_item: fix-service-install-overwrite
+---
+
+# fix-service-install-overwrite Design
+
+## Decisions
+
+### D1 guard 邏輯
+
+安裝前：
+1. 讀取既有 `cortex-manager.env`（或 systemd unit `ExecStart`）中的 venv 路徑。
+2. 判斷該路徑是否有效（`os.path.isfile` 且 `os.access(x, os.X_OK)`）。
+3. 與 `sys.executable` 推導的 venv 比較。
+4. 有效且不同 → raise `RuntimeError` 含兩路徑與建議。
+5. 無效或相同 → 正常安裝。
+
+### D2 不依賴 sys.executable 為唯一來源
+
+guard 使 `sys.executable` 不再是無條件覆寫的來源。可考慮額外從已知路徑讀取（如 pipx 安裝路徑），但 guard 已足夠防止覆寫。
+
+### 風險與 mitigation
+
+- 既有 config 格式變異 → guard 僅在可解析有效路徑時生效。
+- 首次安裝無既有 config → 直接安裝。

--- a/docs/superpowers/specs/fix-service-install-overwrite-spec.md
+++ b/docs/superpowers/specs/fix-service-install-overwrite-spec.md
@@ -1,0 +1,28 @@
+---
+status: accepted
+work_item: fix-service-install-overwrite
+---
+
+# fix-service-install-overwrite Specification
+
+`#148`：修正 installer 以 `sys.executable` 推導路徑，使其他程式內嵌舊版 cortex 時覆寫正確 config。
+
+## Requirements
+
+### R1 idempotent guard
+
+`paulsha_cortex/deploy/installer.py` MUST 在安裝前偵測既有 config（`cortex-manager.env` / systemd unit）指向的 venv 路徑。若既有路徑有效（檔案存在且可執行）且指向不同 venv → MUST 拒絕覆寫並 raise 清晰錯誤。
+
+### R2 正常安裝路徑
+
+既有 config 無效、不存在、或指向同一 venv 時 → MUST 正常安裝/更新（idempotent）。
+
+### R3 錯誤訊息
+
+拒絕覆寫時錯誤訊息 MUST 含既有 venv 路徑、當前呼叫者 venv 路徑、建議操作。
+
+### R4 限制
+
+- stdlib-only；TDD。
+- 不得改變既有對外 CLI envelope schema。
+- `test_zero_dependency_runtime` 續綠；`python3 -m policy_check --repo .` 0 fail。

--- a/docs/superpowers/specs/fix-slice-failed-deadend-design.md
+++ b/docs/superpowers/specs/fix-slice-failed-deadend-design.md
@@ -1,0 +1,21 @@
+---
+status: accepted
+work_item: fix-slice-failed-deadend
+---
+
+# fix-slice-failed-deadend Design
+
+## Decisions
+
+### D1 failed → needs_human
+
+新增 `failed` 的 outgoing transition 至 `needs_human`。`needs_human` 已有 `retry-build`，形成完整恢復路徑：`failed → needs_human → (retry-build) → building`。安全：operator 先檢視再 retry。
+
+### D2 registry 磁碟重載
+
+daemon 在處理 action 前檢查 `jobs.json` mtime；若較記憶體載入時間新則重新讀取。或提供 `registry reload` 命令。採 mtime 比較為主動方式，不需 operator 手動 reload。
+
+### 風險與 mitigation
+
+- mtime 比較在快速連續修改時可能漏 → 加最小間隔或 atomic write（temp + rename）。
+- `failed → needs_human` 語意需清晰 → transition action 命名為 `ack-failure` 或 `request-review`。

--- a/docs/superpowers/specs/fix-slice-failed-deadend-spec.md
+++ b/docs/superpowers/specs/fix-slice-failed-deadend-spec.md
@@ -1,0 +1,28 @@
+---
+status: accepted
+work_item: fix-slice-failed-deadend
+---
+
+# fix-slice-failed-deadend Specification
+
+`#153`：修正 slice state machine `failed` 為終端 sink，使 failed slice 可恢復；registry daemon 可從磁碟重載。
+
+## Requirements
+
+### R1 failed state 有恢復路徑
+
+`paulsha_cortex/coordinator/registry.py` 的 slice state machine MUST 讓 `failed` state 有 outgoing transition（如 `failed → needs_human`）或新增 `reset` action 清除 failed state 允許 re-dispatch。MUST NOT 使 `failed` 為無出口的終端 sink。
+
+### R2 failed slice actions 非空
+
+failed slice 的 `actions` MUST 非空，含恢復 action（如 `retry-build` 或 `reset`）。
+
+### R3 registry 磁碟重載
+
+registry daemon MUST 支援從磁碟重載 jobs（偵測 `jobs.json` 修改或提供 reload 命令），使外部修改 `jobs.json` 後 daemon 狀態可同步。
+
+### R4 限制
+
+- stdlib-only；TDD。
+- 不得改變既有對外 CLI envelope schema。
+- `test_zero_dependency_runtime` 續綠；`python3 -m policy_check --repo .` 0 fail。

--- a/docs/superpowers/specs/test-r21-regex-resilience-design.md
+++ b/docs/superpowers/specs/test-r21-regex-resilience-design.md
@@ -1,0 +1,32 @@
+---
+status: accepted
+work_item: test-r21-regex-resilience
+---
+
+# test-r21-regex-resilience Design
+
+## Decisions
+
+### D1 BASH_FENCE_RE 新 pattern
+
+```python
+BASH_FENCE_RE = re.compile(r"```bash[ \t]*\r?\n(.*?)```", re.DOTALL)
+```
+
+- `[ \t]*`：fence marker 後可有空白/tab。
+- `\r?\n`：LF 或 CRLF。
+- `re.DOTALL`：多行內容完整捕獲。
+
+### D2 PERSONAL_ABSOLUTE_PATH_RE 新增 Windows
+
+在既有 pattern 旁新增：
+```python
+|[A-Za-z]:\\Users\\
+```
+
+限定 `\\Users\\` 子路徑以避免誤匹配其他 `C:\` 出現處。
+
+### 風險與 mitigation
+
+- 既有測試可能因 regex 改動而匹配數量變化 → 全綠確認無 regression。
+- Windows path pattern 需避免誤匹配 → 限定 `\\Users\\` 子路徑。

--- a/docs/superpowers/specs/test-r21-regex-resilience-spec.md
+++ b/docs/superpowers/specs/test-r21-regex-resilience-spec.md
@@ -1,0 +1,31 @@
+---
+status: accepted
+work_item: test-r21-regex-resilience
+---
+
+# test-r21-regex-resilience Specification
+
+`#169`：修正 `test_onboarding_docs_contract.py` 的 regex 漏洞——CRLF bash fence 與 Windows absolute path 未被涵蓋。
+
+## Requirements
+
+### R1 BASH_FENCE_RE 容忍 CRLF + whitespace
+
+`BASH_FENCE_RE` MUST 匹配：
+- LF（`\n`）分隔的 bash fence（既有行為）。
+- CRLF（`\r\n`）分隔的 bash fence。
+- fence marker 後有 trailing whitespace（如 ` ```bash `）的 code block。
+
+MUST NOT 靜默跳過上述任一情況。
+
+### R2 PERSONAL_ABSOLUTE_PATH_RE 涵蓋 Windows
+
+`PERSONAL_ABSOLUTE_PATH_RE` MUST 涵蓋：
+- `/home/...` 與 `/Users/...`（既有）。
+- Windows drive-letter path 如 `C:\Users\...`。
+
+### R3 限制
+
+- test-only；不改 production code。
+- 既有測試全綠（無 regression）。
+- `python3 -m policy_check --repo .` 0 fail。

--- a/docs/superpowers/workstreams/docs-archived-spec-purpose/todo.md
+++ b/docs/superpowers/workstreams/docs-archived-spec-purpose/todo.md
@@ -1,0 +1,13 @@
+---
+status: accepted
+work_item: docs-archived-spec-purpose
+---
+
+# docs-archived-spec-purpose Todo
+
+## Tasks
+
+- [ ] 將 issue #158、active OpenSpec change `2026-07-26-docs-archived-spec-purpose` 與本 Todo 綁定為同一 confirmed Work Item。
+- [ ] coordinator 派工 codex 完成 #158（TDD）：archive 命令推導 Purpose + 批次更新 9 個既有 specs。
+- [ ] ForeignReview 通過；operator 對抗 review 核可。
+- [ ] `openspec archive` 不再產生 `Purpose: TBD`；既有 specs 已更新（驗證）。

--- a/docs/superpowers/workstreams/docs-monitor-load-config/todo.md
+++ b/docs/superpowers/workstreams/docs-monitor-load-config/todo.md
@@ -1,0 +1,13 @@
+---
+status: accepted
+work_item: docs-monitor-load-config
+---
+
+# docs-monitor-load-config Todo
+
+## Tasks
+
+- [ ] 將 issue #143、active OpenSpec change `2026-07-26-docs-monitor-load-config` 與本 Todo 綁定為同一 confirmed Work Item。
+- [ ] coordinator 派工 codex 完成 #143（docs + test）：補 monitor config 文件 + 測試覆蓋 explicit/ambient 行為。
+- [ ] ForeignReview 通過；operator 對抗 review 核可。
+- [ ] 文件含 explicit/ambient 行為說明；測試全綠（驗證）。

--- a/docs/superpowers/workstreams/fix-builder-write-paths/todo.md
+++ b/docs/superpowers/workstreams/fix-builder-write-paths/todo.md
@@ -1,0 +1,13 @@
+---
+status: accepted
+work_item: fix-builder-write-paths
+---
+
+# fix-builder-write-paths Todo
+
+## Tasks
+
+- [ ] 將 issue #118、active OpenSpec change `2026-07-26-fix-builder-write-paths` 與本 Todo 綁定為同一 confirmed Work Item。
+- [ ] coordinator 派工 codex 完成 #118 修復（TDD）：builder `write_paths` 改為動態 `["**"]`，跨 repo dispatch 不拒絕寫入。
+- [ ] ForeignReview 通過；operator 對抗 review 核可。
+- [ ] 跨 repo dispatch（如 paulshaclaw）時 builder 可成功寫入目標 repo 路徑（驗證根因修復）。

--- a/docs/superpowers/workstreams/fix-deck-emit-frontmatter/todo.md
+++ b/docs/superpowers/workstreams/fix-deck-emit-frontmatter/todo.md
@@ -1,0 +1,14 @@
+---
+status: accepted
+work_item: fix-deck-emit-frontmatter
+---
+
+# fix-deck-emit-frontmatter Todo
+
+## Tasks
+
+- [ ] 將 issue #101、active OpenSpec change `2026-07-26-fix-deck-emit-frontmatter` 與本 Todo 綁定為同一 confirmed Work Item。
+- [ ] coordinator 派工 codex 完成 #101 修復（TDD）：`deck compile --emit` 產生符合 auto dispatch contract 的 frontmatter。
+- [ ] 補 auto dispatch contract 文件至 docs/。
+- [ ] ForeignReview 通過；operator 對抗 review 核可。
+- [ ] `deck compile --emit` 產生的 frontmatter 可被 dispatch_ready 接受（驗證根因修復）。

--- a/docs/superpowers/workstreams/fix-dispatch-spec-path/todo.md
+++ b/docs/superpowers/workstreams/fix-dispatch-spec-path/todo.md
@@ -1,0 +1,13 @@
+---
+status: accepted
+work_item: fix-dispatch-spec-path
+---
+
+# fix-dispatch-spec-path Todo
+
+## Tasks
+
+- [ ] 將 issue #98、active OpenSpec change `2026-07-26-fix-dispatch-spec-path` 與本 Todo 綁定為同一 confirmed Work Item。
+- [ ] coordinator 派工 codex 完成 #98 修復（TDD）：`_infer_repo_root` spec 在 repo 外時回傳 `paths.repo_root()`。
+- [ ] ForeignReview 通過；operator 對抗 review 核可。
+- [ ] spec 位於 repo 外 + `PSC_REPO_ROOT` 已設定時 dispatch pinning 不再失敗（驗證根因修復）。

--- a/docs/superpowers/workstreams/fix-service-install-overwrite/todo.md
+++ b/docs/superpowers/workstreams/fix-service-install-overwrite/todo.md
@@ -1,0 +1,13 @@
+---
+status: accepted
+work_item: fix-service-install-overwrite
+---
+
+# fix-service-install-overwrite Todo
+
+## Tasks
+
+- [ ] 將 issue #148、active OpenSpec change `2026-07-26-fix-service-install-overwrite` 與本 Todo 綁定為同一 confirmed Work Item。
+- [ ] coordinator 派工 codex 完成 #148 修復（TDD）：installer idempotent guard 防止不同 venv 覆寫。
+- [ ] ForeignReview 通過；operator 對抗 review 核可。
+- [ ] 既有有效 config + 不同 venv 呼叫 `install service` 不覆寫（驗證根因修復）。

--- a/docs/superpowers/workstreams/fix-slice-failed-deadend/todo.md
+++ b/docs/superpowers/workstreams/fix-slice-failed-deadend/todo.md
@@ -1,0 +1,13 @@
+---
+status: accepted
+work_item: fix-slice-failed-deadend
+---
+
+# fix-slice-failed-deadend Todo
+
+## Tasks
+
+- [ ] 將 issue #153、active OpenSpec change `2026-07-26-fix-slice-failed-deadend` 與本 Todo 綁定為同一 confirmed Work Item。
+- [ ] coordinator 派工 codex 完成 #153 修復（TDD）：failed slice 恢復路徑 + registry 磁碟重載。
+- [ ] ForeignReview 通過；operator 對抗 review 核可。
+- [ ] failed slice 可恢復（不再 dead-end）；registry 可從磁碟重載（驗證根因修復）。

--- a/docs/superpowers/workstreams/test-r21-regex-resilience/todo.md
+++ b/docs/superpowers/workstreams/test-r21-regex-resilience/todo.md
@@ -1,0 +1,13 @@
+---
+status: accepted
+work_item: test-r21-regex-resilience
+---
+
+# test-r21-regex-resilience Todo
+
+## Tasks
+
+- [ ] 將 issue #169、active OpenSpec change `2026-07-26-test-r21-regex-resilience` 與本 Todo 綁定為同一 confirmed Work Item。
+- [ ] coordinator 派工 codex 完成 #169 修復（TDD）：BASH_FENCE_RE 容忍 CRLF + whitespace、PERSONAL_ABSOLUTE_PATH_RE 涵蓋 Windows path。
+- [ ] ForeignReview 通過；operator 對抗 review 核可。
+- [ ] CRLF bash fence 與 Windows path 測試案例全綠（驗證 regex 修復）。

--- a/openspec/changes/2026-07-26-docs-archived-spec-purpose/design.md
+++ b/openspec/changes/2026-07-26-docs-archived-spec-purpose/design.md
@@ -1,0 +1,25 @@
+---
+status: accepted
+work_item: docs-archived-spec-purpose
+---
+
+# docs-archived-spec-purpose Design
+
+## Decisions
+
+### D1 從 change proposal 推導 Purpose
+
+archive 時從 change 的 `proposal.md` `## Goals` 段取首段作為 Purpose。若 Goals 為空或不足，fallback 到 change name 的 human-readable 形式。不再產生 `Purpose: TBD` stub。
+
+### D2 批次更新既有 specs
+
+逐一更新 9 個受影響 specs 的 `Purpose: TBD` 行，根據各 spec 的 change proposal 或 capability 名稱推導適當 Purpose 文字。
+
+### D3 向後相容
+
+既有已 archived specs 不需重新 archive，僅更新 Purpose 行。新 archive 命令不再產生 TBD。
+
+### 風險與 mitigation
+
+- 推導的 Purpose 可能不夠精確 → 以 change proposal 的 Goals 段為主來源，人類可後續微調。
+- 批次更新需確保不破壞 spec 其餘結構 → 僅替換 `Purpose: TBD ...` 行。

--- a/openspec/changes/2026-07-26-docs-archived-spec-purpose/proposal.md
+++ b/openspec/changes/2026-07-26-docs-archived-spec-purpose/proposal.md
@@ -1,0 +1,25 @@
+---
+status: accepted
+work_item: docs-archived-spec-purpose
+---
+
+## Goals
+
+修正 `openspec archive` 產生的 capability specs 含 `Purpose: TBD` stub，要麼在 archive 時要求填入 Purpose，要麼批次更新既有 specs。
+
+## Why
+
+`#158` 回報：`openspec archive` 產生的 capability specs 在 `openspec/specs/*/spec.md` 含 `Purpose: TBD - created by archiving change <name>. Update Purpose after archive.`。所有 archived specs 都有此 stub。需修正 archive 命令或批次更新既有 specs。
+
+受影響 specs：persona-workflow-orchestration、porcelain-service-lifecycle、release-engineering-pipeline、porcelain-guided-bootstrap、porcelain-run-recover-verbs、porcelain-inspect-surface、unified-work-read-model、governed-delivery-closure、cli-version-reporting。
+
+## What Changes
+
+- `paulsha_cortex/cli/openspec*.py`（若修正 archive 命令）：archive 時 prompt/require Purpose，或從 change proposal 推導 Purpose。
+- `openspec/specs/**`：批次更新既有 specs 的 `Purpose: TBD` 為適當文字。
+
+## Capabilities
+
+### Modified Capabilities
+
+- `openspec-archive`：archive 產生的 spec 不再含 `Purpose: TBD` stub；既有 specs 批次更新。

--- a/openspec/changes/2026-07-26-docs-archived-spec-purpose/tasks.md
+++ b/openspec/changes/2026-07-26-docs-archived-spec-purpose/tasks.md
@@ -1,0 +1,22 @@
+---
+status: accepted
+work_item: docs-archived-spec-purpose
+---
+
+# Tasks
+
+- [ ] [RED] `tests/test_openspec_archive_purpose.py`：`openspec archive` 產生的 spec.md 不含 `Purpose: TBD`（含從 change proposal 推導或 prompt 的 Purpose 文字）。
+- [ ] [實作] `paulsha_cortex/cli/openspec*.py`：archive 時從 change proposal 推導 Purpose（如取 `## Goals` 段首段），或 prompt 使用者輸入。
+- [ ] [實作] 批次更新既有 specs 的 `Purpose: TBD`：
+  - persona-workflow-orchestration
+  - porcelain-service-lifecycle
+  - release-engineering-pipeline
+  - porcelain-guided-bootstrap
+  - porcelain-run-recover-verbs
+  - porcelain-inspect-surface
+  - unified-work-read-model
+  - governed-delivery-closure
+  - cli-version-reporting
+- [ ] [同步與驗證] `changelog.d/docs-archived-spec-purpose.md` fragment；`CHANGELOG.md [Unreleased]` `### Fixed` 加入含 `#158` 條目。
+- [ ] [同步與驗證] `python3 -m pytest tests/ -q` 全綠；`python3 -m policy_check --repo .` 0 fail；`git diff --check` 乾淨。
+- [ ] [同步與驗證] 勾選本 tasks.md 對應項並以 conventional commit 提交。

--- a/openspec/changes/2026-07-26-docs-monitor-load-config/design.md
+++ b/openspec/changes/2026-07-26-docs-monitor-load-config/design.md
@@ -1,0 +1,22 @@
+---
+status: accepted
+work_item: docs-monitor-load-config
+---
+
+# docs-monitor-load-config Design
+
+## Decisions
+
+### D1 行為正確，僅缺文件與測試
+
+`load_config(config_path=...)` 顯式傳入時不合併 ambient hippo projects 是正確行為（explicit = fully explicit）。不需改 code，僅需補文件與測試。
+
+### D2 文件位置
+
+在 `docs/` 新增或在既有 monitor 文件中新增段落，記錄 `load_config` 的 explicit/ambient 合併語意：
+- 不帶 `config_path`：ambient mode，合併偵測到的 hippo projects。
+- 帶 `config_path`：explicit mode，僅載入指定 config，不合併 ambient。
+
+### D3 測試策略
+
+測試以 fixture 建立 ambient hippo project（`tmp_path` 模擬），驗證顯式 `config_path` 時不合併、不帶時合併。

--- a/openspec/changes/2026-07-26-docs-monitor-load-config/proposal.md
+++ b/openspec/changes/2026-07-26-docs-monitor-load-config/proposal.md
@@ -1,0 +1,23 @@
+---
+status: accepted
+work_item: docs-monitor-load-config
+---
+
+## Goals
+
+文件化 `monitor/config.py:183` 的行為變更：`load_config(config_path=...)` 顯式傳入 config_path 時不再合併 ambient hippo projects，並新增測試覆蓋此行為。
+
+## Why
+
+`#143` 回報：`paulsha_cortex/monitor/config.py:183` 變更行為——`load_config(config_path=...)` 顯式傳入 config_path 時不再合併 ambient hippo projects。這是正確行為（explicit = fully explicit），但未文件化。需要補文件並加測試。
+
+## What Changes
+
+- `docs/**`：記錄 `load_config` 的 explicit vs ambient 行為——顯式傳入 config_path 時 fully explicit，不合併 ambient hippo projects。
+- `tests/`：新增測試覆蓋顯式 config_path 不合併 ambient hippo projects 的行為。
+
+## Capabilities
+
+### Modified Capabilities
+
+- `monitor-config`：文件化 `load_config` 的 explicit/ambient 合併語意；測試覆蓋。

--- a/openspec/changes/2026-07-26-docs-monitor-load-config/tasks.md
+++ b/openspec/changes/2026-07-26-docs-monitor-load-config/tasks.md
@@ -1,0 +1,12 @@
+---
+status: accepted
+work_item: docs-monitor-load-config
+---
+
+# Tasks
+
+- [ ] [RED] `tests/test_monitor_config_explicit.py`：`load_config(config_path=<explicit>)` 不合併 ambient hippo projects（即使環境中有 hippo project 存在）；`load_config()` 不帶 config_path 時仍合併 ambient。
+- [ ] [實作] `docs/`（如 `docs/monitor-config.md` 或既有 monitor 文件）：記錄 `load_config` 的 explicit vs ambient 行為——顯式傳入 config_path 時 fully explicit。
+- [ ] [同步與驗證] `changelog.d/docs-monitor-load-config.md` fragment；`CHANGELOG.md [Unreleased]` `### Documentation` 加入含 `#143` 條目。
+- [ ] [同步與驗證] `python3 -m pytest tests/ -q` 全綠；`python3 -m policy_check --repo .` 0 fail；`git diff --check` 乾淨。
+- [ ] [同步與驗證] 勾選本 tasks.md 對應項並以 conventional commit 提交。

--- a/openspec/changes/2026-07-26-fix-builder-write-paths/design.md
+++ b/openspec/changes/2026-07-26-fix-builder-write-paths/design.md
@@ -1,0 +1,25 @@
+---
+status: accepted
+work_item: fix-builder-write-paths
+---
+
+# fix-builder-write-paths Design
+
+## Decisions
+
+### D1 write_paths 相對 worktree root
+
+builder `write_paths` 改為 `["**"]`（或從目標 repo 結構推導的 pattern），由 worktree boundary 限制寫入範圍。關鍵洞察：`write_paths` 應相對於 worktree root，非絕對於 cortex repo。
+
+### D2 render 時動態推導
+
+`persona/contract.py` 或 `render.py` render persona contract 時，從 `run.workspace_root` / 目標 repo 結構推導 `write_paths`。若 `run` 有 `workspace_root`，以該 root 為基準展開 glob pattern。
+
+### D3 向後相容
+
+cortex repo 內 dispatch 時行為不變——`["**"]` 涵蓋 cortex 路徑。既有測試若依賴特定 `write_paths` 值需同步更新。
+
+### 風險與 mitigation
+
+- `["**"]` 範圍可能過寬 → 由 worktree boundary 限制，builder 不可越界。
+- 既有測試斷言特定 `write_paths` 值 → 需更新斷言為動態推導結果或 `["**"]`。

--- a/openspec/changes/2026-07-26-fix-builder-write-paths/proposal.md
+++ b/openspec/changes/2026-07-26-fix-builder-write-paths/proposal.md
@@ -1,0 +1,23 @@
+---
+status: accepted
+work_item: fix-builder-write-paths
+---
+
+## Goals
+
+修正 builder persona 的 `write_paths` 硬編碼 `paulsha_cortex/**`，使跨 repo 派工時 builder 能寫入目標 repo 的路徑。
+
+## Why
+
+`#118` 回報：`paulsha_cortex/persona/personas.yaml` builder role 的 `write_paths: ["paulsha_cortex/**", ...]` 硬編碼。派工到不同 repo（如 paulshaclaw）時，builder 拒絕寫入因為目標 repo 路徑不符 `paulsha_cortex/**`。`write_paths` 烤進 persona catalog，非從目標 repo 動態推導。
+
+## What Changes
+
+- `paulsha_cortex/persona/personas.yaml`：builder `write_paths` 改為動態——從 `run.workspace_root` / 目標 repo 結構推導，或使用 `["**"]` 由 worktree boundary 限制，或 per-repo 可配置。
+- `paulsha_cortex/persona/contract.py` 或 `render.py`：render persona contract 時動態推導 `write_paths`。
+
+## Capabilities
+
+### Modified Capabilities
+
+- `persona-contract`：builder `write_paths` 相對於 worktree root，非絕對於 cortex repo。跨 repo 派工時 builder 可寫入目標 repo 路徑。

--- a/openspec/changes/2026-07-26-fix-builder-write-paths/tasks.md
+++ b/openspec/changes/2026-07-26-fix-builder-write-paths/tasks.md
@@ -1,0 +1,14 @@
+---
+status: accepted
+work_item: fix-builder-write-paths
+---
+
+# Tasks
+
+- [ ] [RED] `tests/test_fix_builder_write_paths.py`：跨 repo dispatch 時（target repo 非 `paulsha_cortex`），builder persona 的 `write_paths` 涵蓋目標 repo 路徑（如 `**` 或目標 repo 結構推導的路徑），builder 不拒絕寫入。
+- [ ] [RED] 既有 cortex repo 內 dispatch 行為不變（`write_paths` 仍涵蓋 cortex 路徑）。
+- [ ] [實作] `paulsha_cortex/persona/personas.yaml`：builder `write_paths` 改為動態 pattern（如 `["**"]` 由 worktree boundary 限制）。
+- [ ] [實作] `paulsha_cortex/persona/contract.py` 或 `render.py`：render 時動態推導 `write_paths`（從 `run.workspace_root` 或目標 repo 結構）。
+- [ ] [同步與驗證] `changelog.d/fix-builder-write-paths.md` fragment；`CHANGELOG.md [Unreleased]` `### Fixed` 加入含 `#118` 條目。
+- [ ] [同步與驗證] `python3 -m pytest tests/ -q` 全綠；`python3 -m policy_check --repo .` 0 fail；`git diff --check` 乾淨。
+- [ ] [同步與驗證] 勾選本 tasks.md 對應項並以 conventional commit 提交。

--- a/openspec/changes/2026-07-26-fix-deck-emit-frontmatter/design.md
+++ b/openspec/changes/2026-07-26-fix-deck-emit-frontmatter/design.md
@@ -1,0 +1,29 @@
+---
+status: accepted
+work_item: fix-deck-emit-frontmatter
+---
+
+# fix-deck-emit-frontmatter Design
+
+## Decisions
+
+### D1 target_branch 從 context 推導
+
+`deck compile --emit` render frontmatter 時，`target_branch` 從 combo/work-item context 推導（如 `feature/<slug>` 或 `wt/<feature>/<subtask>`），而非硬編碼 `null`。若 context 無分支資訊，emit 時 warning 並填入合理 default（如 `feature/<work-item-slug>`）。
+
+### D2 verification skeleton 符合 auto contract
+
+`verification` 物件包含：
+- `docs_class`：文件類別
+- `checks`：含 persona-scope（reviewer persona）、`name=policy` command（policy_check）、`tests`（pytest 指令）、`full_suite`（含 `baseline: no-regression`）
+
+skeleton 值可從現有 dispatch contract 測試碼推斷的期望結構填入。
+
+### D3 文件化 auto dispatch contract
+
+在 `docs/` 新增文件記錄 auto dispatch contract：verification 物件的必填欄位、結構、範例 frontmatter。使使用者不需讀測試碼即可理解契約。
+
+### 風險與 mitigation
+
+- 推導 `target_branch` 時 context 可能不完整 → fallback 到 `feature/<slug>` 並 warning。
+- verification skeleton 欄位需與實際 dispatch contract 保持同步 → 文件與測試同時維護。

--- a/openspec/changes/2026-07-26-fix-deck-emit-frontmatter/proposal.md
+++ b/openspec/changes/2026-07-26-fix-deck-emit-frontmatter/proposal.md
@@ -1,0 +1,24 @@
+---
+status: accepted
+work_item: fix-deck-emit-frontmatter
+---
+
+## Goals
+
+修正 `deck compile --emit` 產生的 frontmatter 硬編碼 `target_branch: null` 與 `verification: null`，使其符合 auto dispatch contract（非空 `target_branch` + 完整 `verification` 物件），並補文件記錄 auto dispatch contract 的 verification 物件結構。
+
+## Why
+
+`#101` 回報：`paulsha_cortex/deck/compile.py` 第 227–228 行硬編碼 `target_branch: null` 與 `verification: null`。auto dispatch contract 要求精確 plan path、非空 `target_branch`、完整 `verification` 物件（含 `docs_class` + `checks`（persona-scope + `name=policy` command + tests + full_suite with `baseline: no-regression`））。目前僅能從測試碼推斷契約，無使用者文件。
+
+## What Changes
+
+- `paulsha_cortex/deck/compile.py`：`--emit` 產生的 frontmatter 從 combo/work-item context 推導 `target_branch`，並填入 `verification` skeleton 符合 auto dispatch contract。
+- `docs/`：記錄 auto dispatch contract（verification 物件結構、必填欄位）。
+
+## Capabilities
+
+### Modified Capabilities
+
+- `deck-compile`：`--emit` 產生符合 auto dispatch contract 的 frontmatter（target_branch + verification skeleton）。
+- `dispatch-contract`：文件化 auto dispatch contract 的 verification 物件結構與必填欄位。

--- a/openspec/changes/2026-07-26-fix-deck-emit-frontmatter/tasks.md
+++ b/openspec/changes/2026-07-26-fix-deck-emit-frontmatter/tasks.md
@@ -1,0 +1,14 @@
+---
+status: accepted
+work_item: fix-deck-emit-frontmatter
+---
+
+# Tasks
+
+- [ ] [RED] `tests/test_fix_deck_emit_frontmatter.py`：`deck compile --emit` 產生的 frontmatter `target_branch` 非空（從 combo/work-item context 推導），`verification` 為含 `docs_class`、`checks`（含 persona-scope + `name=policy` command + `tests` + `full_suite` with `baseline: no-regression`）的完整物件。
+- [ ] [RED] 既有 `target_branch: null` 與 `verification: null` 的 emit 結果不再出現。
+- [ ] [實作] `paulsha_cortex/deck/compile.py`：`--emit` render frontmatter 時從 combo/work-item context 推導 `target_branch`，填入 verification skeleton。
+- [ ] [實作] docs/ 或 README：記錄 auto dispatch contract（verification 物件結構、必填欄位、範例）。
+- [ ] [同步與驗證] `changelog.d/fix-deck-emit-frontmatter.md` fragment；`CHANGELOG.md [Unreleased]` `### Fixed` 加入含 `#101` 條目。
+- [ ] [同步與驗證] `python3 -m pytest tests/ -q` 全綠；`python3 -m policy_check --repo .` 0 fail；`git diff --check` 乾淨。
+- [ ] [同步與驗證] 勾選本 tasks.md 對應項並以 conventional commit 提交。

--- a/openspec/changes/2026-07-26-fix-dispatch-spec-path/design.md
+++ b/openspec/changes/2026-07-26-fix-dispatch-spec-path/design.md
@@ -1,0 +1,21 @@
+---
+status: accepted
+work_item: fix-dispatch-spec-path
+---
+
+# fix-dispatch-spec-path Design
+
+## Decisions
+
+### D1 spec 在 repo 外 → 回傳 PSC_REPO_ROOT
+
+`_infer_repo_root(spec_path)` 新增邏輯：先判斷 `spec_path` 是否在 `paths.repo_root()` 子樹下（`Path.is_relative_to` 或 `resolve()` 比較）。若不在，直接回傳 `paths.repo_root()`，因為 repo-relative contract path（plan 等）應以設定的 repo root 為基準，而非 spec 所在目錄。
+
+### D2 spec 在 repo 內 → 維持既有行為
+
+spec 在 repo 子樹下時，沿用既有 `.git` parent walk 邏輯，不改變行為，確保向後相容。
+
+### 風險與 mitigation
+
+- `PSC_REPO_ROOT` 未設定時 `paths.repo_root()` 回退到 cwd 解析——此為既有行為，不受影響。
+- 測試以 `tmp_path` 模擬 repo 外 spec + monkeypatch `paths.repo_root` 回另一 `tmp_path` 驗證回傳值。

--- a/openspec/changes/2026-07-26-fix-dispatch-spec-path/proposal.md
+++ b/openspec/changes/2026-07-26-fix-dispatch-spec-path/proposal.md
@@ -1,0 +1,22 @@
+---
+status: accepted
+work_item: fix-dispatch-spec-path
+---
+
+## Goals
+
+修正 `autonomy._infer_repo_root()` 在 spec 位於 repo 外（如 `~/.agents/specs`）時未回退至 `PSC_REPO_ROOT`，導致 repo-relative plan 路徑解析到錯誤 root，造成 dispatch pinning 失敗。
+
+## Why
+
+`#98` 回報：當 spec 檔位於 repo 外（`~/.agents/specs/<slug>-spec.md`），`_infer_repo_root` 沿 parent 目錄尋找 `.git` 或直接回傳 `spec_path.parent`，而非使用已設定的 `PSC_REPO_ROOT`。結果：repo-relative `plan` 路徑被解析到錯誤 root → `plan file unreadable for dispatch pinning` → `dispatch_ready` 判定失敗 → 整個 dispatch 鏈中斷。這在 dogfood 派工流程中是高頻路徑。
+
+## What Changes
+
+- `paulsha_cortex/coordinator/autonomy.py`：`_infer_repo_root()` 當 spec 不在 repo root 子目錄下時，回傳 `paths.repo_root()`（即 `PSC_REPO_ROOT`），因為 repo-relative contract path 應以設定 repo root 為基準。
+
+## Capabilities
+
+### Modified Capabilities
+
+- `coordinator-autonomy`：spec 在 repo 外時 `_infer_repo_root` 回退至 `PSC_REPO_ROOT`，確保 repo-relative plan 路徑正確解析。

--- a/openspec/changes/2026-07-26-fix-dispatch-spec-path/tasks.md
+++ b/openspec/changes/2026-07-26-fix-dispatch-spec-path/tasks.md
@@ -1,0 +1,14 @@
+---
+status: accepted
+work_item: fix-dispatch-spec-path
+---
+
+# Tasks
+
+- [ ] [RED] `tests/test_fix_dispatch_spec_path.py`：spec 位於 `~/.agents/specs/`（repo 外）、`PSC_REPO_ROOT` 已設定時，`_infer_repo_root(spec_path)` 回傳 `paths.repo_root()` 而非 `spec_path.parent` 或沿 `.git` 搜尋結果。
+- [ ] [RED] spec 位於 repo 內時行為不變（回傳 repo root via `.git` walk）。
+- [ ] [RED] `_infer_repo_root` 在 `PSC_REPO_ROOT` 未設定且 spec 在 repo 外時仍維持既有 fallback 行為（向後相容）。
+- [ ] [實作] `paulsha_cortex/coordinator/autonomy.py`：`_infer_repo_root()` 優先檢查 spec 是否在 `paths.repo_root()` 子樹下；若不在，回傳 `paths.repo_root()`。
+- [ ] [同步與驗證] `changelog.d/fix-dispatch-spec-path.md` fragment；`CHANGELOG.md [Unreleased]` `### Fixed` 加入含 `#98` 條目。
+- [ ] [同步與驗證] `python3 -m pytest tests/ -q` 全綠；`python3 -m policy_check --repo .` 0 fail；`git diff --check` 乾淨。
+- [ ] [同步與驗證] 勾選本 tasks.md 對應項並以 conventional commit 提交。

--- a/openspec/changes/2026-07-26-fix-service-install-overwrite/design.md
+++ b/openspec/changes/2026-07-26-fix-service-install-overwrite/design.md
@@ -1,0 +1,28 @@
+---
+status: accepted
+work_item: fix-service-install-overwrite
+---
+
+# fix-service-install-overwrite Design
+
+## Decisions
+
+### D1 idempotent guard
+
+installer 安裝前讀取既有 `cortex-manager.env`（或 systemd unit）中記錄的 venv 路徑，與當前 `sys.executable` 推導的 venv 比較。若既有路徑有效（檔案存在且可執行）且指向不同 venv → 拒絕覆寫並 raise 清晰錯誤（含既有路徑、呼叫者路徑、建議操作）。若既有路徑無效或指向同一 venv → 正常安裝/更新。
+
+### D2 錯誤訊息清晰
+
+拒絕覆寫時錯誤訊息含：
+- 既有 config 指向的 venv 路徑
+- 當前呼叫者的 venv 路徑
+- 建議操作（如「使用既有 venv 的 cortex 執行 install」或「先移除既有 config」）
+
+### D3 不自動遷移
+
+不自動修正既有 config（避免誤判）。僅偵測+拒絕+建議。
+
+### 風險與 mitigation
+
+- 既有 config 格式可能不一致 → guard 僅在可解析出有效 venv 路徑時生效，否則視為無效→正常安裝。
+- 測試以 `tmp_path` 模擬兩個不同 venv 路徑與既有 config 檔。

--- a/openspec/changes/2026-07-26-fix-service-install-overwrite/proposal.md
+++ b/openspec/changes/2026-07-26-fix-service-install-overwrite/proposal.md
@@ -1,0 +1,25 @@
+---
+status: accepted
+work_item: fix-service-install-overwrite
+---
+
+## Goals
+
+修正 `deploy/installer.py` 以 `sys.executable` 推導路徑，使其他程式（如 paulshaclaw）內嵌舊版 cortex 時 `install service` 覆寫正確 config 為舊 venv 路徑。
+
+## Why
+
+`#148` 回報：`paulsha_cortex/deploy/installer.py` 用 `sys.executable` 推導路徑。當另一程式（paulshaclaw）內嵌舊版 cortex 在其 venv 並呼叫 `install service`，installer 用呼叫者的 `sys.executable` render `cortex-manager.env` 與 systemd unit，覆寫正確路徑為舊 venv 路徑。覆寫為潛伏（不重啟無感）直到下次 `systemctl restart`。
+
+## What Changes
+
+- `paulsha_cortex/deploy/installer.py`：
+  - 安裝前偵測既有 config 是否指向不同（有效）venv——idempotent guard，拒絕覆寫。
+  - 或鎖定/安裝到已知路徑，而非從呼叫者 `sys.executable` 推導。
+- `tests/`：回歸測試——既有有效 config + 不同呼叫者 venv → 不覆寫。
+
+## Capabilities
+
+### Modified Capabilities
+
+- `deploy-installer`：installer 含 idempotent guard，偵測既有有效 config 指向不同 venv 時拒絕覆寫。

--- a/openspec/changes/2026-07-26-fix-service-install-overwrite/tasks.md
+++ b/openspec/changes/2026-07-26-fix-service-install-overwrite/tasks.md
@@ -1,0 +1,14 @@
+---
+status: accepted
+work_item: fix-service-install-overwrite
+---
+
+# Tasks
+
+- [ ] [RED] `tests/test_fix_service_install_overwrite.py`：既有有效 config（指向 venv A）+ 不同呼叫者 venv（venv B）呼叫 `install service` → 不覆寫既有 config（或 raise 清晰錯誤）。
+- [ ] [RED] 既有 config 無效或指向同一 venv 時 → 正常安裝/更新（idempotent）。
+- [ ] [RED] 首次安裝（無既有 config）→ 正常安裝。
+- [ ] [實作] `paulsha_cortex/deploy/installer.py`：新增 idempotent guard——偵測既有 config 指向不同（有效）venv 時拒絕覆寫並 raise 清晰錯誤訊息。
+- [ ] [同步與驗證] `changelog.d/fix-service-install-overwrite.md` fragment；`CHANGELOG.md [Unreleased]` `### Fixed` 加入含 `#148` 條目。
+- [ ] [同步與驗證] `python3 -m pytest tests/ -q` 全綠；`python3 -m policy_check --repo .` 0 fail；`git diff --check` 乾淨。
+- [ ] [同步與驗證] 勾選本 tasks.md 對應項並以 conventional commit 提交。

--- a/openspec/changes/2026-07-26-fix-slice-failed-deadend/design.md
+++ b/openspec/changes/2026-07-26-fix-slice-failed-deadend/design.md
@@ -1,0 +1,25 @@
+---
+status: accepted
+work_item: fix-slice-failed-deadend
+---
+
+# fix-slice-failed-deadend Design
+
+## Decisions
+
+### D1 failed → needs_human transition
+
+新增 `failed → needs_human` transition，使 failed slice 可由 operator 手動介入後恢復。`needs_human` 已有 `retry-build`，形成 `failed → needs_human → (retry-build) → building` 恢復路徑。或者直接 `failed → building`（更激進但更直接）。
+
+### D2 選擇 needs_human 而非直接 building
+
+`failed → needs_human` 較安全——operator 先檢視 failed 原因再決定 retry，避免盲目重試。`needs_human` 的 `retry-build` action 已存在，重用即可。
+
+### D3 registry 磁碟重載
+
+registry daemon 定期（或在 action 處理前）檢查 `jobs.json` mtime，若較記憶體新則重載。或提供 explicit reload 命令。
+
+### 風險與 mitigation
+
+- `failed → needs_human` 可能讓 operator 誤以為需要人工 → action 名稱應清晰（如 `ack-failure` transition）。
+- 磁碟重載可能有 race condition → 重載時加 lock 或以 atomic read 處理。

--- a/openspec/changes/2026-07-26-fix-slice-failed-deadend/proposal.md
+++ b/openspec/changes/2026-07-26-fix-slice-failed-deadend/proposal.md
@@ -1,0 +1,25 @@
+---
+status: accepted
+work_item: fix-slice-failed-deadend
+---
+
+## Goals
+
+修正 slice state machine `failed` 為終端 sink 無退出路徑，使 failed slice 可恢復（retry-build / reset / re-dispatch），並確保 registry daemon 可從磁碟重載。
+
+## Why
+
+`#153` 回報：`paulsha_cortex/coordinator/registry.py` 的 slice state machine 有 `"failed": frozenset({"failed"})`——`failed` 無 outgoing transitions。failed slice `actions: []`、repin 被拒（`ValueError: 非法 slice state repin: 'failed'`）、`retry-build` 不允許（僅 `needs_human` 有）。且 registry daemon 將 jobs 保留在記憶體，刪除 `jobs.json` 無效。
+
+## What Changes
+
+- `paulsha_cortex/coordinator/registry.py`：
+  - 新增 `failed → needs_human` 或 `failed → building` transition，或新增 `reset` action 清除 failed state 允許 re-dispatch。
+  - 確保 registry daemon 可從磁碟重載（若 `jobs.json` 被修改）。
+- `tests/`：failed state recovery 路徑測試。
+
+## Capabilities
+
+### Modified Capabilities
+
+- `coordinator-registry`：`failed` slice state 不再是終端 sink；可恢復至 `needs_human` 或 re-dispatch。registry 可從磁碟重載。

--- a/openspec/changes/2026-07-26-fix-slice-failed-deadend/tasks.md
+++ b/openspec/changes/2026-07-26-fix-slice-failed-deadend/tasks.md
@@ -1,0 +1,15 @@
+---
+status: accepted
+work_item: fix-slice-failed-deadend
+---
+
+# Tasks
+
+- [ ] [RED] `tests/test_fix_slice_failed_deadend.py`：failed slice 可透過 `retry-build` 或 `reset` action 恢復（transition 至 `needs_human` 或 `building`），不再 raise `ValueError`。
+- [ ] [RED] failed slice 的 `actions` 不再為空（含恢復 action）。
+- [ ] [RED] registry daemon 在 `jobs.json` 被外部修改後可從磁碟重載（記憶體狀態與磁碟同步）。
+- [ ] [實作] `paulsha_cortex/coordinator/registry.py`：新增 `failed → needs_human` transition（或 `reset` action），使 failed slice 可恢復。
+- [ ] [實作] `paulsha_cortex/coordinator/registry.py`：registry daemon 支援從磁碟重載 jobs（偵測 `jobs.json` 修改時間或提供 reload 命令）。
+- [ ] [同步與驗證] `changelog.d/fix-slice-failed-deadend.md` fragment；`CHANGELOG.md [Unreleased]` `### Fixed` 加入含 `#153` 條目。
+- [ ] [同步與驗證] `python3 -m pytest tests/ -q` 全綠；`python3 -m policy_check --repo .` 0 fail；`git diff --check` 乾淨。
+- [ ] [同步與驗證] 勾選本 tasks.md 對應項並以 conventional commit 提交。

--- a/openspec/changes/2026-07-26-test-r21-regex-resilience/design.md
+++ b/openspec/changes/2026-07-26-test-r21-regex-resilience/design.md
@@ -1,0 +1,33 @@
+---
+status: accepted
+work_item: test-r21-regex-resilience
+---
+
+# test-r21-regex-resilience Design
+
+## Decisions
+
+### D1 BASH_FENCE_RE 容忍 CRLF + trailing whitespace
+
+改為 `re.compile(r"```bash[ \t]*\r?\n(.*?)```", re.DOTALL)`：
+- `[ \t]*` 容忍 fence marker 後的 trailing whitespace。
+- `\r?\n` 同時匹配 LF 與 CRLF。
+- `re.DOTALL` 確保多行 code block 被完整捕獲。
+
+### D2 PERSONAL_ABSOLUTE_PATH_RE 涵蓋 Windows
+
+在既有 `/home` 和 `/Users` pattern 旁新增 Windows drive-letter path：
+- `[A-Za-z]:\\Users\\`（如 `C:\Users\paul`）
+- 或更廣泛 `[A-Za-z]:\\` + 已知使用者目錄模式。
+
+### D3 測試案例
+
+新增 fixture/parametrize：
+- CRLF bash fence 的 markdown 內容。
+- fence marker 後有 trailing whitespace 的 markdown。
+- Windows `C:\Users\someone\...` 路徑在 docs 內容中。
+
+### 風險與 mitigation
+
+- regex 改動可能影響既有匹配 → 既有測試全綠確認無 regression。
+- Windows path pattern 需避免誤匹配 URL 中的 `C:\` → 限定 `\\Users\\` 子路徑。

--- a/openspec/changes/2026-07-26-test-r21-regex-resilience/proposal.md
+++ b/openspec/changes/2026-07-26-test-r21-regex-resilience/proposal.md
@@ -1,0 +1,27 @@
+---
+status: accepted
+work_item: test-r21-regex-resilience
+---
+
+## Goals
+
+修正 `tests/test_onboarding_docs_contract.py` 的兩個 regex 漏洞：`BASH_FENCE_RE` 僅匹配 LF 不匹配 CRLF、`PERSONAL_ABSOLUTE_PATH_RE` 不涵蓋 Windows 路徑。
+
+## Why
+
+`#169` 回報：
+1. `BASH_FENCE_RE = re.compile(r"```bash\n(.*?)```")` 僅匹配 `\n`（LF），不匹配 `\r\n`（CRLF）或 fence marker 後有 trailing whitespace → CRLF 的 bash code block 被靜默跳過（false assurance）。
+2. `PERSONAL_ABSOLUTE_PATH_RE` 僅涵蓋 `/home` 和 `/Users`，不涵蓋 Windows `C:\Users\...` 路徑。
+
+## What Changes
+
+- `tests/test_onboarding_docs_contract.py`：
+  - `BASH_FENCE_RE` 改為容忍 `\r?\n` 與 fence marker 後 trailing whitespace。
+  - `PERSONAL_ABSOLUTE_PATH_RE` 新增 Windows drive-letter path pattern。
+  - 新增 CRLF bash fence 與 Windows absolute path 測試案例。
+
+## Capabilities
+
+### Modified Capabilities
+
+- `onboarding-docs-contract`：R-21 regex 涵蓋 CRLF bash fence 與 Windows absolute path，消除 false assurance。

--- a/openspec/changes/2026-07-26-test-r21-regex-resilience/tasks.md
+++ b/openspec/changes/2026-07-26-test-r21-regex-resilience/tasks.md
@@ -1,0 +1,18 @@
+---
+status: accepted
+work_item: test-r21-regex-resilience
+---
+
+# Tasks
+
+- [ ] [RED] `tests/test_onboarding_docs_contract.py`：新增測試案例：
+  - CRLF bash fence（`\r\n`）的 code block 被 `BASH_FENCE_RE` 捕獲（非跳過）。
+  - fence marker 後有 trailing whitespace（如 ` ```bash `）的 code block 被捕獲。
+  - Windows `C:\Users\...` absolute path 被 `PERSONAL_ABSOLUTE_PATH_RE` 捕獲。
+  - 先確認 RED（既有 regex 在這些案例上失敗）。
+- [ ] [實作] `tests/test_onboarding_docs_contract.py`：
+  - `BASH_FENCE_RE` 改為 `re.compile(r"```bash[ \t]*\r?\n(.*?)```", re.DOTALL)`。
+  - `PERSONAL_ABSOLUTE_PATH_RE` 新增 Windows drive-letter pattern（如 `[A-Za-z]:\\Users\\`）。
+- [ ] [同步與驗證] `changelog.d/test-r21-regex-resilience.md` fragment；`CHANGELOG.md [Unreleased]` `### Fixed` 加入含 `#169` 條目。
+- [ ] [同步與驗證] `python3 -m pytest tests/ -q` 全綠；`python3 -m policy_check --repo .` 0 fail；`git diff --check` 乾淨。
+- [ ] [同步與驗證] 勾選本 tasks.md 對應項並以 conventional commit 提交。


### PR DESCRIPTION
## 摘要

為 8 個 OPEN issue 建立 accepted 規劃產物（openspec change + spec/design/plan + workstream todo），並加入 .cortex/work-items.yaml entry，準備透過 cortex 平行派工。

## 涵蓋 issue

| Issue | Slug | 鏈路 |
|-------|------|------|
| #98 | fix-dispatch-spec-path | A:coordinator-dispatch |
| #101 | fix-deck-emit-frontmatter | B:deck |
| #118 | fix-builder-write-paths | C:persona |
| #143 | docs-monitor-load-config | D:docs-batch |
| #148 | fix-service-install-overwrite | E:service |
| #153 | fix-slice-failed-deadend | F:coordinator-state |
| #158 | docs-archived-spec-purpose | D:docs-batch |
| #169 | test-r21-regex-resilience | G:test |

## 變更

- 56 個新規劃產物檔（8 x 7 files）
- .cortex/work-items.yaml 新增 8 個 work item entry
- 純 docs/planning 變更，不影響 runtime code

## 驗收

- [x] 所有 spec/plan/design 有 status: accepted frontmatter
- [x] work-items.yaml 合法 YAML（29 work items）
- [x] 各 issue 的 openspec change 目錄結構完整

skip-changelog: 純規劃產物（docs-only），不涉及 code 變動。

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>