### PR TITLE
fix(coordinator): dispatch contract path 對 repo 外 specs 目錄失效 (#98)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - **Issue #177：driving-cortex skill**：新增 `skills/driving-cortex/SKILL.md`，提供 agent 編排 coordinator 視角下的 cortex dogfood 批次驅動與交付操作指南（含 seven-section 實務骨架）。
 
 ### Fixed
+- **Issue #98：修正 dispatch spec root 推斷**：`_infer_repo_root()` 在 `PSC_REPO_ROOT` 設定且 spec 位於 repo 外部時，改回傳 `paths.repo_root()`，避免沿 spec 路徑 `.git` 向上尋找導致誤判。
 - **Issue #175：reclaim PR inheritance**：`start_canonical_workflow` needs_human 與 start 兩條路徑都不再帶入 `pr_refs`，`GitHubTerminalProvider` 不會將 `state=CLOSED`（未合併）PR 加入 `closing_links`，避免 closed PR 異常延續到 delivery authority。
 - **Issue #134：multi-issue build 支援最小 issue 為主 branch 且以 run repository 建立 worktree**：builder 會在 run 含多個 issue 時，使用編號最小的 `feature/<主issue>-<work_id>`，並由 run repo 作為 `ScriptWorktreeCreator` 的 git 工作目錄。
 - **Issue #152：mutation request 逾時改採分級 timeout + pending 回報**：`coordinator/cli.py` `_submit_mutation_request` 依 `req_type` 套用分級 timeout（`fanout`/`tick` 60 秒、`complete`/`work`/`work-action`/`run` 30 秒、其餘 5 秒），`poll` timeout 時保留 `req_id` 與追蹤指引並回傳 `EXIT_SUBMITTED_PENDING`（exit 3）避免成功派工被誤報為失敗。

--- a/changelog.d/fix-dispatch-spec-path.md
+++ b/changelog.d/fix-dispatch-spec-path.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **Issue #98：修正 dispatch spec root 推斷**：`_infer_repo_root()` 在 `PSC_REPO_ROOT` 設定且 spec 路徑位於 `paths.repo_root()` 之外時，改回傳 configured repo root，避免沿外部路徑 `.git` 向上掃描導致錯誤的 repo 判斷。

--- a/openspec/changes/2026-07-26-fix-dispatch-spec-path/tasks.md
+++ b/openspec/changes/2026-07-26-fix-dispatch-spec-path/tasks.md
@@ -8,7 +8,7 @@ work_item: fix-dispatch-spec-path
 - [x] [RED] `tests/test_fix_dispatch_spec_path.py`：spec 位於 `~/.agents/specs/`（repo 外）、`PSC_REPO_ROOT` 已設定時，`_infer_repo_root(spec_path)` 回傳 `paths.repo_root()` 而非 `spec_path.parent` 或沿 `.git` 搜尋結果。
 - [x] [RED] spec 位於 repo 內時行為不變（回傳 repo root via `.git` walk）。
 - [x] [RED] `_infer_repo_root` 在 `PSC_REPO_ROOT` 未設定且 spec 在 repo 外時仍維持既有 fallback 行為（向後相容）。
-- [ ] [實作] `paulsha_cortex/coordinator/autonomy.py`：`_infer_repo_root()` 優先檢查 spec 是否在 `paths.repo_root()` 子樹下；若不在，回傳 `paths.repo_root()`。
-- [ ] [同步與驗證] `changelog.d/fix-dispatch-spec-path.md` fragment；`CHANGELOG.md [Unreleased]` `### Fixed` 加入含 `#98` 條目。
-- [ ] [同步與驗證] `python3 -m pytest tests/ -q` 全綠；`python3 -m policy_check --repo .` 0 fail；`git diff --check` 乾淨。
-- [ ] [同步與驗證] 勾選本 tasks.md 對應項並以 conventional commit 提交。
+- [x] [實作] `paulsha_cortex/coordinator/autonomy.py`：`_infer_repo_root()` 優先檢查 spec 是否在 `paths.repo_root()` 子樹下；若不在，回傳 `paths.repo_root()`。
+- [x] [同步與驗證] `changelog.d/fix-dispatch-spec-path.md` fragment；`CHANGELOG.md [Unreleased]` `### Fixed` 加入含 `#98` 條目。
+- [x] [同步與驗證] `python3 -m pytest tests/ -q` 全綠；`python3 -m policy_check --repo .` 0 fail；`git diff --check` 乾淨。
+- [x] [同步與驗證] 勾選本 tasks.md 對應項並以 conventional commit 提交。

--- a/openspec/changes/2026-07-26-fix-dispatch-spec-path/tasks.md
+++ b/openspec/changes/2026-07-26-fix-dispatch-spec-path/tasks.md
@@ -5,9 +5,9 @@ work_item: fix-dispatch-spec-path
 
 # Tasks
 
-- [ ] [RED] `tests/test_fix_dispatch_spec_path.py`：spec 位於 `~/.agents/specs/`（repo 外）、`PSC_REPO_ROOT` 已設定時，`_infer_repo_root(spec_path)` 回傳 `paths.repo_root()` 而非 `spec_path.parent` 或沿 `.git` 搜尋結果。
-- [ ] [RED] spec 位於 repo 內時行為不變（回傳 repo root via `.git` walk）。
-- [ ] [RED] `_infer_repo_root` 在 `PSC_REPO_ROOT` 未設定且 spec 在 repo 外時仍維持既有 fallback 行為（向後相容）。
+- [x] [RED] `tests/test_fix_dispatch_spec_path.py`：spec 位於 `~/.agents/specs/`（repo 外）、`PSC_REPO_ROOT` 已設定時，`_infer_repo_root(spec_path)` 回傳 `paths.repo_root()` 而非 `spec_path.parent` 或沿 `.git` 搜尋結果。
+- [x] [RED] spec 位於 repo 內時行為不變（回傳 repo root via `.git` walk）。
+- [x] [RED] `_infer_repo_root` 在 `PSC_REPO_ROOT` 未設定且 spec 在 repo 外時仍維持既有 fallback 行為（向後相容）。
 - [ ] [實作] `paulsha_cortex/coordinator/autonomy.py`：`_infer_repo_root()` 優先檢查 spec 是否在 `paths.repo_root()` 子樹下；若不在，回傳 `paths.repo_root()`。
 - [ ] [同步與驗證] `changelog.d/fix-dispatch-spec-path.md` fragment；`CHANGELOG.md [Unreleased]` `### Fixed` 加入含 `#98` 條目。
 - [ ] [同步與驗證] `python3 -m pytest tests/ -q` 全綠；`python3 -m policy_check --repo .` 0 fail；`git diff --check` 乾淨。

--- a/paulsha_cortex/coordinator/autonomy.py
+++ b/paulsha_cortex/coordinator/autonomy.py
@@ -188,12 +188,21 @@ def _normalize_depends_on(value: object) -> list[str]:
 
 def _infer_repo_root(spec_path: Path) -> Path:
     configured = paths.repo_root().resolve()
+    if os.getenv("PSC_REPO_ROOT"):
+        try:
+            spec_path.resolve().relative_to(configured)
+        except ValueError:
+            return configured
+        else:
+            return configured
     try:
         spec_path.resolve().relative_to(configured)
         return configured
     except ValueError:
         pass
     for parent in [spec_path.resolve(), *spec_path.resolve().parents]:
+        if parent == configured.parent:
+            break
         if (parent / ".git").exists():
             return parent
     return spec_path.resolve().parent

--- a/tests/test_fix_dispatch_spec_path.py
+++ b/tests/test_fix_dispatch_spec_path.py
@@ -19,6 +19,7 @@ def test_infer_repo_root_prefers_configured_repo_root_for_external_spec(monkeypa
 
 def test_infer_repo_root_keeps_in_repo_path_for_repo_relative_spec(monkeypatch, tmp_path):
     repo_root = tmp_path / "repo"
+    repo_root.mkdir()
     (repo_root / ".git").mkdir()
     spec_path = repo_root / "specs" / "foo-spec.md"
     spec_path.parent.mkdir(parents=True)
@@ -31,6 +32,7 @@ def test_infer_repo_root_keeps_in_repo_path_for_repo_relative_spec(monkeypatch, 
 
 def test_infer_repo_root_fallback_unchanged_without_configured_repo_root(monkeypatch, tmp_path):
     repo_root = tmp_path / "repo"
+    repo_root.mkdir()
     spec_path = tmp_path / "outside" / "specs" / "foo-spec.md"
     spec_path.parent.mkdir(parents=True)
     spec_path.write_text("# foo\n", encoding="utf-8")

--- a/tests/test_fix_dispatch_spec_path.py
+++ b/tests/test_fix_dispatch_spec_path.py
@@ -1,0 +1,41 @@
+from pathlib import Path
+
+from paulsha_cortex.coordinator.autonomy import _infer_repo_root
+
+
+def test_infer_repo_root_prefers_configured_repo_root_for_external_spec(monkeypatch, tmp_path):
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    spec_dir = tmp_path / "agents" / "specs"
+    spec_path = spec_dir / "foo-spec.md"
+    spec_dir.mkdir(parents=True)
+    spec_path.write_text("# foo\n", encoding="utf-8")
+    (tmp_path / "agents" / ".git").mkdir()
+
+    monkeypatch.setenv("PSC_REPO_ROOT", str(repo_root))
+
+    assert _infer_repo_root(spec_path) == repo_root
+
+
+def test_infer_repo_root_keeps_in_repo_path_for_repo_relative_spec(monkeypatch, tmp_path):
+    repo_root = tmp_path / "repo"
+    (repo_root / ".git").mkdir()
+    spec_path = repo_root / "specs" / "foo-spec.md"
+    spec_path.parent.mkdir(parents=True)
+    spec_path.write_text("# foo\n", encoding="utf-8")
+
+    monkeypatch.setenv("PSC_REPO_ROOT", str(repo_root))
+
+    assert _infer_repo_root(spec_path) == repo_root
+
+
+def test_infer_repo_root_fallback_unchanged_without_configured_repo_root(monkeypatch, tmp_path):
+    repo_root = tmp_path / "repo"
+    spec_path = tmp_path / "outside" / "specs" / "foo-spec.md"
+    spec_path.parent.mkdir(parents=True)
+    spec_path.write_text("# foo\n", encoding="utf-8")
+
+    monkeypatch.delenv("PSC_REPO_ROOT", raising=False)
+    monkeypatch.chdir(repo_root)
+
+    assert _infer_repo_root(spec_path) == spec_path.parent


### PR DESCRIPTION
Closes #98

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
