### PR TITLE
chore(policy): 升級 paulsha-conventions 至 v1.0.15 並導入本地 runtime bundle 部署

### DIFF
--- a/.github/workflows/policy-check.yml
+++ b/.github/workflows/policy-check.yml
@@ -9,8 +9,8 @@ permissions:
 
 jobs:
   policy:
-    uses: hamanpaul/paulsha-conventions/.github/workflows/reusable-policy-check.yml@451c2680fb3a1f977fcbc8007baaa7dbe415cf03  # v1.0.14
+    uses: hamanpaul/paulsha-conventions/.github/workflows/reusable-policy-check.yml@a764806046c410eb4f254ac0b6a8aec8b7559dab  # v1.0.15
     with:
       policy_profile: flat
-      policy_version: "1.0.14"
-      policy_engine_ref: 451c2680fb3a1f977fcbc8007baaa7dbe415cf03
+      policy_version: "1.0.15"
+      policy_engine_ref: a764806046c410eb4f254ac0b6a8aec8b7559dab

--- a/.project-policy.yml
+++ b/.project-policy.yml
@@ -1,5 +1,5 @@
 policy_profile: flat
-policy_version: 1.0.14
+policy_version: 1.0.15
 tier: shareable
 code_paths:
   - ".project-policy.yml"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,16 @@
 本專案所有重大變更都會記錄在此檔案。
 
 格式基於 [Keep a Changelog 1.1.0](https://keepachangelog.com/zh-TW/1.1.0/)，
-本專案遵循 hamanpaul project policy v1.0.12。
+本專案遵循 hamanpaul project policy v1.0.15。
 
 ## [Unreleased]
 
 ### Added
 - **Issue #177：driving-cortex skill**：新增 `skills/driving-cortex/SKILL.md`，提供 agent 編排 coordinator 視角下的 cortex dogfood 批次驅動與交付操作指南（含 seven-section 實務骨架）。
+
+### Changed
+- **同步 policy 1.0.14 → 1.0.15**：`.project-policy.yml` 與 `CLAUDE.md`（`managed-by`／`policy_version`／profile 段）皆 bump 至 `1.0.15`；`Policy Check` workflow 的 `uses:` 與 `policy_engine_ref` 重新雙重釘選至 `hamanpaul/paulsha-conventions@a764806046c410eb4f254ac0b6a8aec8b7559dab`（= engine tag `v1.0.15`，尾註 `# v1.0.15` 供 R-23 對齊）；`README.md` 開發備註的引擎版號字樣同步更新。本次升版 1.0.14→1.0.15 未新增規則編號（僅新增 tag 觸發的 runtime bundle release workflow），故 `CLAUDE.md` 不需新增「新增規則」段落。
+- **本機部署 paulsha-conventions v1.0.15 runtime bundle**：依 release 說明下載 `paulsha-conventions-v1.0.15-cp312.tar.gz`、驗證 SHA-256 後執行 `install.sh`，`~/.agents/skills/preflight-ci` 改為指向新 runtime release 的受管 symlink；既有 skill 目錄已先備份（不影響本 repo 版控內容，屬本機環境變更）。
 
 ### Fixed
 - **Issue #98：修正 dispatch spec root 推斷**：`_infer_repo_root()` 在 `PSC_REPO_ROOT` 設定且 spec 位於 repo 外部時，改回傳 `paths.repo_root()`，避免沿 spec 路徑 `.git` 向上尋找導致誤判。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,15 +1,15 @@
-<!-- managed-by: hamanpaul/paulsha-conventions@v1.0.14 -->
+<!-- managed-by: hamanpaul/paulsha-conventions@v1.0.15 -->
 <!-- 此為 canonical 真檔；AGENTS.md / GEMINI.md / .github/copilot-instructions.md 為指向本檔的 symlink，只維護本檔 -->
-policy_version: 1.0.14
+policy_version: 1.0.15
 
 # Agent Policy Checklist
 
-本 repo 受 hamanpaul project policy v1.0.14 管轄。
+本 repo 受 hamanpaul project policy v1.0.15 管轄。
 所有 agent 進入 session 時，必須依下列 checklist 行動。
 
 ## 本 repo 的 profile
 - policy_profile: `flat` （見 `.project-policy.yml`）
-- policy_version: `1.0.14`
+- policy_version: `1.0.15`
 
 ## 本 repo 定位
 - `paulsha-cortex` 是治理平面拆包：persona 契約、coordinator 派工、control 檔案契約。

--- a/README.md
+++ b/README.md
@@ -500,7 +500,7 @@ Multi-issue workflow build 階段將以 `issue` 清單中最小號碼作為主 b
 ## 開發備註
 
 - repo 宣告 `tier: shareable`，所有範例與測試都必須維持去識別化。
-- repo policy 由 canonical `.project-policy.yml` 宣告，並 pin paulsha-conventions v1.0.14。
+- repo policy 由 canonical `.project-policy.yml` 宣告，並 pin paulsha-conventions v1.0.15。
 - agent 慣例檔採 symlink 模式：`AGENTS.md`、`GEMINI.md`、`.github/copilot-instructions.md` 都指向 `CLAUDE.md`。
 
 ## Version

--- a/changelog.d/policy-1-0-15.md
+++ b/changelog.d/policy-1-0-15.md
@@ -1,0 +1,3 @@
+### Changed
+
+- **同步 paulsha-conventions 1.0.14 → 1.0.15**：`.project-policy.yml` 與 `CLAUDE.md`（`managed-by`／`policy_version`／profile 段）皆 bump 至 `1.0.15`；`Policy Check` workflow 的 `uses:` 與 `policy_engine_ref` 重新雙重釘選至 `hamanpaul/paulsha-conventions@a764806046c410eb4f254ac0b6a8aec8b7559dab`（= engine tag `v1.0.15`，尾註供 R-23 對齊）；`README.md` 開發備註的引擎版號字樣同步更新。1.0.14→1.0.15 未新增規則編號，僅新增 tag 觸發的 runtime bundle release workflow，故 `CLAUDE.md` 不需新增規則段落。


### PR DESCRIPTION
## 摘要

將 `paulsha-conventions` 由 v1.0.14 升級至 **v1.0.15**，並完成本機 runtime bundle 部署。

v1.0.15 是**第一版導入本地部署流程**的 conventions 版本：新增 tag 觸發的 release workflow，依 Python minor version 建置 runtime bundle、驗證 archive digest 與離線安裝，並提供 `install.sh` 將 `preflight-ci` skill 部署為受管 artifact。

## 變更

| 檔案 | 變更 |
|---|---|
| `.project-policy.yml` | `policy_version` 1.0.14 → 1.0.15 |
| `CLAUDE.md`（canonical 真檔） | `managed-by` 註解、`policy_version`、管轄版本與 profile 段版號 |
| `.github/workflows/policy-check.yml` | 引擎 pin → `a764806046c410eb4f254ac0b6a8aec8b7559dab`（= tag v1.0.15 dereference 後的 commit SHA）；`policy_version` 與 `policy_engine_ref` 同步 |
| `README.md` | 開發備註的 pin 版號字樣 |
| `CHANGELOG.md` | `[Unreleased]` 新增 Changed 條目；header 版號字樣一併校正 |

`AGENTS.md` / `GEMINI.md` / `.github/copilot-instructions.md` 維持指向 `CLAUDE.md` 的 symlink，未還原為獨立複本。

## 規則差異

比對 v1.0.14 → v1.0.15 的 `policy_check/`：**未新增或變更任何編號規則**，故 `CLAUDE.md` 無需新增規則段落。

## 本機驗證（以目標引擎版本實跑）

- `policy_check --repo .`：**25 pass / 0 fail / 1 warn**（唯一 warning 為 R-22 的 24 個 pre-existing dangling doc references，非本次新破壞）
- `pytest tests/ -q`：**1241 passed, 3 skipped**
- `openspec validate --specs`：**16 passed, 0 failed**
- runtime bundle：`paulsha-conventions-v1.0.15-cp312.tar.gz`，SHA-256 驗證 OK，`install.sh` 回報 `INSTALLED 1.0.15`

## Checklist

- [x] `CHANGELOG.md [Unreleased]` 有對應 entry
- [x] `VERSION` 內容與意圖一致（本 PR 不動 VERSION）
- [x] 分支非 `main`，命名符合 `feature/<slug>`
- [x] `policy_check --repo .` 無 failure
- [x] 測試與 OpenSpec 驗證通過
- [x] agent symlink 未被還原為獨立複本（R-14）
- [x] 引擎 pin、`policy_engine_ref` 與 `policy_version` 三者對齊（R-20 / R-23）
