### PR TITLE
feat(coordinator): stage 級 content-addressed execution key

### DIFF
--- a/changelog.d/stage-execution-key.md
+++ b/changelog.d/stage-execution-key.md
@@ -1,0 +1,3 @@
+### Added
+
+- **Issue #214：stage 級 content-addressed execution key**：新增 `registry.compute_stage_execution_key`（涵蓋 repo/work_id/card/phase/executor/model/base_sha/candidate_sha/frozen_input_hashes/action/test_policy）與 `JobRegistry.find_reusable_stage_evidence`（fail-closed reuse 查詢，建立在既有 phase 級 checkpoint 之上、與 `bind_workflow_evidence` 並存不改語意），`manager_daemon.py` 的 workflow-action/start 觸發處可消費此查詢在相同 key 已有可重用 evidence 時短路 dispatch、不增加 model invocation；`CompletionRecord` 新增 `reused_from`（run/job/evidence hash）provenance 欄位，並排除在 semantic match 之外避免良性 reuse 誤觸衝突 quarantine。

--- a/paulsha_cortex/coordinator/completion.py
+++ b/paulsha_cortex/coordinator/completion.py
@@ -20,6 +20,11 @@ VALID_REVIEW_POLICIES = frozenset({"required", "not-required"})
 VOLATILE_WORK_AUTHORITY_FIELDS = frozenset(
     {"snapshot_hash", "provider_revision", "source_revisions"}
 )
+# reused_from（#214 StageExecutionKey reuse）只是 provenance：記錄本次 stage
+# 是 reuse 既有 run/job/evidence 而非重新呼叫 model，不影響 completion 語意，
+# 故整個欄位排除在 semantic match 之外——避免良性 reuse 被誤判為衝突而觸發
+# quarantine（比照 VOLATILE_WORK_AUTHORITY_FIELDS 的做法）。
+REUSED_FROM_FIELDS = frozenset({"run_id", "job_id", "evidence_hash"})
 
 
 def classify_completion(*, exit_code: int, last_jsonl_line: str | None) -> str:
@@ -200,6 +205,18 @@ def _normalize_work_authority(value: object) -> dict[str, Any]:
     }
 
 
+def _normalize_reused_from(value: object) -> dict[str, str]:
+    if not isinstance(value, dict) or set(value) != REUSED_FROM_FIELDS:
+        raise ValueError("completion reused_from malformed")
+    return {
+        "run_id": _require_non_empty_string(value.get("run_id"), field="reused_from.run_id"),
+        "job_id": _require_non_empty_string(value.get("job_id"), field="reused_from.job_id"),
+        "evidence_hash": _normalize_digest_hash(
+            value.get("evidence_hash"), field="reused_from.evidence_hash"
+        ),
+    }
+
+
 def validate_completion_record(payload: object) -> dict[str, Any]:
     if not isinstance(payload, dict):
         raise ValueError("completion record must be an object")
@@ -228,7 +245,7 @@ def validate_completion_record(payload: object) -> dict[str, Any]:
     missing = sorted(required - set(payload))
     if missing:
         raise ValueError(f"completion record missing keys: {', '.join(missing)}")
-    extras = set(payload) - required - {"work_authority"}
+    extras = set(payload) - required - {"work_authority", "reused_from"}
     if extras:
         raise ValueError(f"completion record unexpected key: {sorted(extras)[0]}")
     if payload.get("schema_version") != COMPLETION_SCHEMA_VERSION:
@@ -274,6 +291,8 @@ def validate_completion_record(payload: object) -> dict[str, Any]:
     }
     if "work_authority" in payload:
         normalized["work_authority"] = _normalize_work_authority(payload["work_authority"])
+    if "reused_from" in payload:
+        normalized["reused_from"] = _normalize_reused_from(payload["reused_from"])
 
     reviewer_job_id = normalized["reviewer_job_id"]
     review_path = normalized["review_evaluation_path"]
@@ -326,6 +345,8 @@ def completion_records_semantically_match(existing: object, incoming: object) ->
         return False
     existing_authority = _semantic_work_authority(existing_normalized.pop("work_authority", None))
     incoming_authority = _semantic_work_authority(incoming_normalized.pop("work_authority", None))
+    existing_normalized.pop("reused_from", None)
+    incoming_normalized.pop("reused_from", None)
     return existing_normalized == incoming_normalized and existing_authority == incoming_authority
 
 

--- a/paulsha_cortex/coordinator/manager_daemon.py
+++ b/paulsha_cortex/coordinator/manager_daemon.py
@@ -273,6 +273,7 @@ def build_request_executor(
     workflow_runtime_factory=None,
     workflow_ship_validator=None,
     work_action_fn: Callable[..., dict[str, Any]] | None = None,
+    stage_evidence_validator: Callable[[dict[str, str]], bool] | None = None,
 ) -> Callable[[dict[str, Any]], dict[str, Any]]:
     def execute(request: dict[str, Any]) -> dict[str, Any]:
         args = request.get("args", {})
@@ -354,15 +355,31 @@ def build_request_executor(
             )
             if args.get("action") == "start":
                 run = registry.get_workflow_run(str(result["run_id"]))
-                job = manager.dispatch_workflow_card(
-                    dispatcher,
-                    run=run,
-                    identities=identities,
-                    launcher_factory=launcher_factory,
-                    coordinator_root=coordinator_root,
-                )
-                if job is not None:
-                    result["job_id"] = job["job_id"]
+                # #214：呼叫端可預先算好本次 stage 的 content-addressed
+                # execution key；若既有 job 用同一把 key 留下完整且仍然有效
+                # 的 evidence（由 stage_evidence_validator 判定），就直接
+                # reuse，短路掉這個「唯一觸發處」，不重啟 model session。
+                # 沒帶 key、或找不到可 reuse 的 evidence 時，行為與過去完全
+                # 相同（fail-closed：預設照樣派新 job）。
+                stage_execution_key = args.get("stage_execution_key")
+                reused_from = None
+                if isinstance(stage_execution_key, str) and stage_execution_key:
+                    reused_from = registry.find_reusable_stage_evidence(
+                        stage_execution_key,
+                        is_evidence_still_valid=stage_evidence_validator,
+                    )
+                if reused_from is not None:
+                    result["reused_from"] = reused_from
+                else:
+                    job = manager.dispatch_workflow_card(
+                        dispatcher,
+                        run=run,
+                        identities=identities,
+                        launcher_factory=launcher_factory,
+                        coordinator_root=coordinator_root,
+                    )
+                    if job is not None:
+                        result["job_id"] = job["job_id"]
             return result
         if request["type"] == "work-action":
             registry = getattr(dispatcher, "_registry", None)

--- a/paulsha_cortex/coordinator/registry.py
+++ b/paulsha_cortex/coordinator/registry.py
@@ -861,10 +861,20 @@ class JobRegistry:
                 continue
             if not still_valid:
                 continue
+            evidence_hash = evidence.get("hash")
+            if (
+                not isinstance(evidence_hash, str)
+                or len(evidence_hash) != 64
+                or any(char not in "0123456789abcdef" for char in evidence_hash)
+            ):
+                continue
+            # evidence_hash 直接對齊 completion.py reused_from schema 的
+            # {run_id, job_id, evidence_hash}，消費端不需再自行拆 locator。
             return {
                 "run_id": job.get("workflow_run_id"),
                 "job_id": job.get("job_id"),
                 "evidence": dict(evidence),
+                "evidence_hash": evidence_hash,
             }
         return None
 

--- a/paulsha_cortex/coordinator/registry.py
+++ b/paulsha_cortex/coordinator/registry.py
@@ -7,9 +7,10 @@ import tempfile
 from dataclasses import replace
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 from paulsha_cortex.config import paths
+from . import verification
 from .workflow import (
     GateEvidenceRef,
     PlanningArtifactAuthority,
@@ -64,6 +65,69 @@ GATE_STATE_TRANSITIONS = {
     "failed": frozenset({"failed", "needs_human"}),
     "needs_human": frozenset({"needs_human", "pending", "passed", "failed"}),
 }
+
+# StageExecutionKey 涵蓋的內容定址欄位（#214）：repo/work_id/card/phase/executor/
+# model/base_sha/candidate_sha/frozen_input_hashes/action/test_policy 任一改變都必須
+# 產生不同 key，讓 authority／candidate／model 任一變更精準 invalidate reuse 判定。
+STAGE_EXECUTION_KEY_STRING_FIELDS = (
+    "repo",
+    "work_id",
+    "card",
+    "phase",
+    "executor",
+    "model",
+    "base_sha",
+    "candidate_sha",
+    "action",
+    "test_policy",
+)
+
+
+def compute_stage_execution_key(
+    *,
+    repo: str,
+    work_id: str,
+    card: str,
+    phase: str,
+    executor: str,
+    model: str,
+    base_sha: str,
+    candidate_sha: str,
+    frozen_input_hashes: tuple[str, ...] | list[str],
+    action: str,
+    test_policy: str,
+) -> str:
+    """把 stage 執行的內容定址欄位收斂成單一雜湊 key（建立在既有 phase 級
+    checkpoint／claim key 之上，只是把顆粒度從 phase 降到 stage）。
+
+    涵蓋 repo/work_id/card/phase/executor/model/base_sha/candidate_sha/
+    frozen_input_hashes/action/test_policy；任一欄位變更都會產生不同的
+    64-hex key，讓 authority／candidate／model 任一變更即精準 invalidate
+    既有 reuse 判定，不需要額外的比對邏輯。
+    """
+    values = {
+        "repo": repo,
+        "work_id": work_id,
+        "card": card,
+        "phase": phase,
+        "executor": executor,
+        "model": model,
+        "base_sha": base_sha,
+        "candidate_sha": candidate_sha,
+        "action": action,
+        "test_policy": test_policy,
+    }
+    for field_name in STAGE_EXECUTION_KEY_STRING_FIELDS:
+        value = values[field_name]
+        if not isinstance(value, str) or not value:
+            raise ValueError(f"stage execution key {field_name} 必須為非空字串")
+    if not isinstance(frozen_input_hashes, (list, tuple)) or any(
+        not isinstance(item, str) or not item for item in frozen_input_hashes
+    ):
+        raise ValueError("stage execution key frozen_input_hashes 必須為非空字串的 list/tuple")
+    payload = dict(values)
+    payload["frozen_input_hashes"] = sorted(frozen_input_hashes)
+    return verification.canonical_json_hash(payload)
 
 
 def _default_state_path() -> Path:
@@ -395,7 +459,7 @@ class JobRegistry:
             "executor", "session_name", "log_path", "model_id", "independence_domain",
             "workflow_run_id", "workflow_claim_key", "workflow_repo", "workflow_card",
             "workflow_phase", "workflow_repo_root", "workflow_input_root", "source_revision",
-            "workflow_sandbox_hash", "workflow_builder_job_id",
+            "workflow_sandbox_hash", "workflow_builder_job_id", "workflow_stage_execution_key",
         ):
             value = job.get(field)
             if value is not None and not isinstance(value, str):
@@ -407,6 +471,14 @@ class JobRegistry:
         ):
             raise ValueError(
                 f"coordinator 狀態檔 workflow_sandbox_hash 格式錯誤（fail-closed）: {self._state_path}"
+            )
+        stage_execution_key = job.get("workflow_stage_execution_key")
+        if stage_execution_key is not None and (
+            len(stage_execution_key) != 64
+            or any(char not in "0123456789abcdef" for char in stage_execution_key)
+        ):
+            raise ValueError(
+                f"coordinator 狀態檔 workflow_stage_execution_key 格式錯誤（fail-closed）: {self._state_path}"
             )
         for field in ("pid", "exit_code"):
             value = job.get(field)
@@ -642,6 +714,7 @@ class JobRegistry:
         workflow_sandbox_hash: str | None = None,
         workflow_output_baseline: tuple[dict[str, str], ...] = (),
         workflow_builder_job_id: str | None = None,
+        workflow_stage_execution_key: str | None = None,
     ) -> dict[str, Any]:
         if persona == "builder" and any(
             job.get("task") == task
@@ -689,6 +762,7 @@ class JobRegistry:
             "workflow_sandbox_hash": workflow_sandbox_hash,
             "workflow_output_baseline": [dict(row) for row in workflow_output_baseline],
             "workflow_builder_job_id": workflow_builder_job_id,
+            "workflow_stage_execution_key": workflow_stage_execution_key,
             "workflow_evidence": None,
             "created_at": _now_iso(),
         }
@@ -747,6 +821,52 @@ class JobRegistry:
             job["subject_head"] = subject_head
         self._persist()
         return _deepcopy_json(job)
+
+    def find_reusable_stage_evidence(
+        self,
+        stage_execution_key: str,
+        *,
+        is_evidence_still_valid: Callable[[dict[str, str]], bool] | None = None,
+    ) -> dict[str, Any] | None:
+        """依 StageExecutionKey 查找可重用的既有 workflow evidence（#214）。
+
+        只有『同一個 stage_execution_key』、成功結束（exited/exit_code==0）且
+        已綁定 canonical evidence 的既有 job 才是候選；`is_evidence_still_valid`
+        是呼叫端注入的驗證 callback（例如確認 evidence 完整、未撤銷、通過
+        ResultVerification），本方法不預設任何 evidence 語意。fail-closed：
+        key 格式錯誤、找不到候選、或未提供 callback（無法確認 evidence 仍然
+        有效）時一律回傳 None，交由呼叫端照原路徑重新派工，不會誤判可以
+        reuse。找到多筆候選時取最近一筆（列表尾端）。
+        """
+        if (
+            not isinstance(stage_execution_key, str)
+            or len(stage_execution_key) != 64
+            or any(char not in "0123456789abcdef" for char in stage_execution_key)
+        ):
+            return None
+        if is_evidence_still_valid is None:
+            return None
+        self._reload_if_changed()
+        for job in reversed(self._jobs):
+            if job.get("workflow_stage_execution_key") != stage_execution_key:
+                continue
+            if job.get("status") != "exited" or job.get("exit_code") != 0:
+                continue
+            evidence = job.get("workflow_evidence")
+            if not isinstance(evidence, dict):
+                continue
+            try:
+                still_valid = is_evidence_still_valid(dict(evidence))
+            except Exception:
+                continue
+            if not still_valid:
+                continue
+            return {
+                "run_id": job.get("workflow_run_id"),
+                "job_id": job.get("job_id"),
+                "evidence": dict(evidence),
+            }
+        return None
 
     def update_status(self, job_id: str, status: str) -> dict[str, Any]:
         if status not in VALID_JOB_STATUSES:

--- a/tests/test_completion_stage_execution_key.py
+++ b/tests/test_completion_stage_execution_key.py
@@ -1,0 +1,109 @@
+"""#214：CompletionRecord 的 reused-from provenance 欄位（stage 級 execution key reuse）。
+
+驗收條件對應：
+- 「CompletionRecord 記錄 reused-from run/job/evidence hash」
+- reused_from 只是 provenance，不應讓良性 reuse 被 semantic match 誤判為衝突。
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from paulsha_cortex.coordinator import completion
+
+
+def _base_payload(**overrides: object) -> dict:
+    payload = {
+        "schema_version": completion.COMPLETION_SCHEMA_VERSION,
+        "slice_id": "stage-execution-key",
+        "spec_hash": "1" * 64,
+        "plan_hash": "2" * 64,
+        "verification_hash": "3" * 64,
+        "builder_job_id": "builder-1",
+        "reviewer_job_id": None,
+        "dispatch_base": "a" * 40,
+        "candidate": "b" * 40,
+        "target_branch": "main",
+        "target_remote": "origin",
+        "target_ref": "refs/remotes/origin/main",
+        "target_ref_sha": "c" * 40,
+        "verification_evidence_path": "/evidence/verification.json",
+        "verification_evidence_hash": "4" * 64,
+        "review_policy": "not-required",
+        "docs_class": "trivial",
+        "review_evaluation_path": None,
+        "review_evaluation_hash": None,
+        "completed_at": "2026-07-27T00:00:00+00:00",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _reused_from(**overrides: object) -> dict:
+    reused_from = {
+        "run_id": "run-1",
+        "job_id": "job-1",
+        "evidence_hash": "5" * 64,
+    }
+    reused_from.update(overrides)
+    return reused_from
+
+
+class ReusedFromValidationTests(unittest.TestCase):
+    def test_absent_reused_from_still_validates(self) -> None:
+        normalized = completion.validate_completion_record(_base_payload())
+        self.assertNotIn("reused_from", normalized)
+
+    def test_reused_from_round_trips_normalized_and_lowercases_hash(self) -> None:
+        payload = _base_payload(reused_from=_reused_from(evidence_hash=("5" * 64).upper()))
+        normalized = completion.validate_completion_record(payload)
+        self.assertEqual(
+            normalized["reused_from"],
+            {"run_id": "run-1", "job_id": "job-1", "evidence_hash": "5" * 64},
+        )
+
+    def test_reused_from_rejects_missing_field(self) -> None:
+        broken = _reused_from()
+        del broken["job_id"]
+        with self.assertRaises(ValueError):
+            completion.validate_completion_record(_base_payload(reused_from=broken))
+
+    def test_reused_from_rejects_extra_field(self) -> None:
+        broken = _reused_from()
+        broken["extra"] = "nope"
+        with self.assertRaises(ValueError):
+            completion.validate_completion_record(_base_payload(reused_from=broken))
+
+    def test_reused_from_rejects_non_hex_evidence_hash(self) -> None:
+        broken = _reused_from(evidence_hash="z" * 64)
+        with self.assertRaises(ValueError):
+            completion.validate_completion_record(_base_payload(reused_from=broken))
+
+    def test_reused_from_rejects_empty_run_id(self) -> None:
+        broken = _reused_from(run_id="")
+        with self.assertRaises(ValueError):
+            completion.validate_completion_record(_base_payload(reused_from=broken))
+
+
+class ReusedFromSemanticMatchTests(unittest.TestCase):
+    def test_reused_from_excluded_from_semantic_match(self) -> None:
+        existing = _base_payload()
+        incoming = _base_payload(reused_from=_reused_from())
+        self.assertTrue(completion.completion_records_semantically_match(existing, incoming))
+
+    def test_differing_reused_from_still_matches(self) -> None:
+        existing = _base_payload(reused_from=_reused_from(job_id="job-1"))
+        incoming = _base_payload(reused_from=_reused_from(job_id="job-2", run_id="run-2"))
+        self.assertTrue(completion.completion_records_semantically_match(existing, incoming))
+
+    def test_real_conflict_still_detected_alongside_reused_from(self) -> None:
+        existing = _base_payload(reused_from=_reused_from())
+        incoming = _base_payload(
+            reused_from=_reused_from(),
+            verification_hash="9" * 64,
+        )
+        self.assertFalse(completion.completion_records_semantically_match(existing, incoming))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_coordinator_stage_execution_key.py
+++ b/tests/test_coordinator_stage_execution_key.py
@@ -204,9 +204,23 @@ class TestFindReusableStageEvidence:
             "run_id": "run-job-first",
             "job_id": first_job["job_id"],
             "evidence": {"kind": "gate", "path": "evidence/workflow/job-first.json", "hash": "f" * 64},
+            "evidence_hash": "f" * 64,
         }
         # 沒有因為「第二次執行」而多出任何 job（= 沒有多一次 model invocation）。
         assert jobs_after == jobs_before
+
+        # 形狀相容：registry 回傳可直接組出 completion reused_from payload，
+        # 不需任何欄位轉換（consumer 接線時不會在 _normalize_reused_from 掛掉）。
+        from paulsha_cortex.coordinator.completion import _normalize_reused_from
+
+        normalized = _normalize_reused_from(
+            {
+                "run_id": reused["run_id"],
+                "job_id": reused["job_id"],
+                "evidence_hash": reused["evidence_hash"],
+            }
+        )
+        assert normalized["evidence_hash"] == "f" * 64
 
     def test_authority_candidate_model_change_invalidates_reuse(self, tmp_path: Path) -> None:
         """AC4：authority／candidate／model 任一變更都必須精準 invalidate，

--- a/tests/test_coordinator_stage_execution_key.py
+++ b/tests/test_coordinator_stage_execution_key.py
@@ -1,0 +1,258 @@
+"""#214：stage 級 content-addressed StageExecutionKey（建立在既有 phase 級
+
+checkpoint 之上，把顆粒度從 phase 降到 stage）。
+
+驗收條件對應：
+- StageExecutionKey 涵蓋 repo/work_id/card/phase/executor/model/base_sha/
+  candidate_sha/frozen_input_hashes/action/test_policy
+- 相同 key 第二次執行 reuse evidence，model invocation count 不增加
+- authority／candidate／model 任一變更才精準 invalidate
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from paulsha_cortex.coordinator.registry import JobRegistry, compute_stage_execution_key
+
+
+def _key_kwargs(**overrides: object) -> dict:
+    base = {
+        "repo": "hamanpaul/paulsha-cortex",
+        "work_id": "214-stage-execution-key",
+        "card": "build",
+        "phase": "build",
+        "executor": "codex",
+        "model": "gpt-5",
+        "base_sha": "a" * 40,
+        "candidate_sha": "b" * 40,
+        "frozen_input_hashes": ("1" * 64, "2" * 64),
+        "action": "propose-diff",
+        "test_policy": "focused",
+    }
+    base.update(overrides)
+    return base
+
+
+class TestComputeStageExecutionKey:
+    def test_deterministic_for_identical_inputs(self) -> None:
+        first = compute_stage_execution_key(**_key_kwargs())
+        second = compute_stage_execution_key(**_key_kwargs())
+        assert first == second
+        assert len(first) == 64
+        assert all(char in "0123456789abcdef" for char in first)
+
+    def test_frozen_input_hashes_order_independent(self) -> None:
+        forward = compute_stage_execution_key(
+            **_key_kwargs(frozen_input_hashes=("1" * 64, "2" * 64))
+        )
+        backward = compute_stage_execution_key(
+            **_key_kwargs(frozen_input_hashes=("2" * 64, "1" * 64))
+        )
+        assert forward == backward
+
+    @pytest.mark.parametrize(
+        "field,changed",
+        [
+            ("repo", "other/repo"),
+            ("work_id", "different-work"),
+            ("card", "review"),
+            ("phase", "verify"),
+            ("executor", "claude"),
+            ("model", "different-model"),
+            ("base_sha", "c" * 40),
+            ("candidate_sha", "d" * 40),
+            ("action", "commit-diff"),
+            ("test_policy", "full"),
+        ],
+    )
+    def test_any_covered_field_change_invalidates_key(self, field: str, changed: str) -> None:
+        baseline = compute_stage_execution_key(**_key_kwargs())
+        mutated = compute_stage_execution_key(**_key_kwargs(**{field: changed}))
+        assert baseline != mutated
+
+    def test_frozen_input_hashes_change_invalidates_key(self) -> None:
+        baseline = compute_stage_execution_key(**_key_kwargs())
+        mutated = compute_stage_execution_key(
+            **_key_kwargs(frozen_input_hashes=("1" * 64, "3" * 64))
+        )
+        assert baseline != mutated
+
+    @pytest.mark.parametrize(
+        "field",
+        [
+            "repo", "work_id", "card", "phase", "executor", "model",
+            "base_sha", "candidate_sha", "action", "test_policy",
+        ],
+    )
+    def test_rejects_empty_string_field(self, field: str) -> None:
+        with pytest.raises(ValueError):
+            compute_stage_execution_key(**_key_kwargs(**{field: ""}))
+
+    def test_rejects_empty_frozen_input_hash_entry(self) -> None:
+        with pytest.raises(ValueError):
+            compute_stage_execution_key(**_key_kwargs(frozen_input_hashes=("1" * 64, "")))
+
+
+def _make_registry(tmp_path: Path) -> JobRegistry:
+    return JobRegistry(state_path=tmp_path / "registry.json")
+
+
+def _create_terminal_job_with_evidence(
+    registry: JobRegistry,
+    *,
+    task: str,
+    stage_execution_key: str,
+    evidence_hash: str = "e" * 64,
+) -> dict:
+    job = registry.create_job(
+        task=task,
+        persona="review",
+        branch=f"feature/{task}",
+        pane="pane-1",
+        worktree=f"/tmp/{task}",
+        workflow_run_id=f"run-{task}",
+        workflow_stage_execution_key=stage_execution_key,
+    )
+    registry.update_headless_result(job["job_id"], status="exited", exit_code=0)
+    bound = registry.bind_workflow_evidence(
+        job["job_id"],
+        locator={"kind": "gate", "path": f"evidence/workflow/{task}.json", "hash": evidence_hash},
+    )
+    return bound
+
+
+class TestFindReusableStageEvidence:
+    def test_returns_none_for_malformed_key(self, tmp_path: Path) -> None:
+        registry = _make_registry(tmp_path)
+        assert registry.find_reusable_stage_evidence("not-a-hex-key") is None
+
+    def test_fail_closed_without_validator_even_with_matching_job(self, tmp_path: Path) -> None:
+        registry = _make_registry(tmp_path)
+        key = compute_stage_execution_key(**_key_kwargs())
+        _create_terminal_job_with_evidence(registry, task="job-a", stage_execution_key=key)
+        # 沒帶 is_evidence_still_valid callback：無法確認 evidence 是否仍然
+        # 有效，fail-closed 必須回 None，不能自作主張判定可以 reuse。
+        assert registry.find_reusable_stage_evidence(key) is None
+
+    def test_returns_none_when_no_job_matches_key(self, tmp_path: Path) -> None:
+        registry = _make_registry(tmp_path)
+        key = compute_stage_execution_key(**_key_kwargs())
+        other_key = compute_stage_execution_key(**_key_kwargs(model="other-model"))
+        _create_terminal_job_with_evidence(registry, task="job-a", stage_execution_key=other_key)
+        assert registry.find_reusable_stage_evidence(key, is_evidence_still_valid=lambda _e: True) is None
+
+    def test_returns_none_when_job_did_not_exit_successfully(self, tmp_path: Path) -> None:
+        registry = _make_registry(tmp_path)
+        key = compute_stage_execution_key(**_key_kwargs())
+        job = registry.create_job(
+            task="job-failed",
+            persona="review",
+            branch="feature/job-failed",
+            pane="pane-1",
+            worktree="/tmp/job-failed",
+            workflow_stage_execution_key=key,
+        )
+        registry.update_headless_result(job["job_id"], status="failed", exit_code=1)
+        assert registry.find_reusable_stage_evidence(key, is_evidence_still_valid=lambda _e: True) is None
+
+    def test_returns_none_when_evidence_not_bound(self, tmp_path: Path) -> None:
+        registry = _make_registry(tmp_path)
+        key = compute_stage_execution_key(**_key_kwargs())
+        job = registry.create_job(
+            task="job-no-evidence",
+            persona="review",
+            branch="feature/job-no-evidence",
+            pane="pane-1",
+            worktree="/tmp/job-no-evidence",
+            workflow_stage_execution_key=key,
+        )
+        registry.update_headless_result(job["job_id"], status="exited", exit_code=0)
+        assert registry.find_reusable_stage_evidence(key, is_evidence_still_valid=lambda _e: True) is None
+
+    def test_returns_none_when_validator_rejects_evidence(self, tmp_path: Path) -> None:
+        registry = _make_registry(tmp_path)
+        key = compute_stage_execution_key(**_key_kwargs())
+        _create_terminal_job_with_evidence(registry, task="job-a", stage_execution_key=key)
+        assert registry.find_reusable_stage_evidence(key, is_evidence_still_valid=lambda _e: False) is None
+
+    def test_returns_none_when_validator_raises(self, tmp_path: Path) -> None:
+        registry = _make_registry(tmp_path)
+        key = compute_stage_execution_key(**_key_kwargs())
+        _create_terminal_job_with_evidence(registry, task="job-a", stage_execution_key=key)
+
+        def _boom(_evidence: dict) -> bool:
+            raise RuntimeError("evidence store unavailable")
+
+        assert registry.find_reusable_stage_evidence(key, is_evidence_still_valid=_boom) is None
+
+    def test_reuses_evidence_for_identical_key_second_execution(self, tmp_path: Path) -> None:
+        """AC2：相同 key 第二次執行時，不需要建立第二個 job（不增加 model
+        invocation count）就能取得可重用的 evidence locator。"""
+        registry = _make_registry(tmp_path)
+        key = compute_stage_execution_key(**_key_kwargs())
+        first_job = _create_terminal_job_with_evidence(
+            registry, task="job-first", stage_execution_key=key, evidence_hash="f" * 64
+        )
+        jobs_before = registry.list_jobs()
+        reused = registry.find_reusable_stage_evidence(key, is_evidence_still_valid=lambda _e: True)
+        jobs_after = registry.list_jobs()
+
+        assert reused == {
+            "run_id": "run-job-first",
+            "job_id": first_job["job_id"],
+            "evidence": {"kind": "gate", "path": "evidence/workflow/job-first.json", "hash": "f" * 64},
+        }
+        # 沒有因為「第二次執行」而多出任何 job（= 沒有多一次 model invocation）。
+        assert jobs_after == jobs_before
+
+    def test_authority_candidate_model_change_invalidates_reuse(self, tmp_path: Path) -> None:
+        """AC4：authority／candidate／model 任一變更都必須精準 invalidate，
+        不能沿用舊 key 的 evidence。"""
+        registry = _make_registry(tmp_path)
+        key = compute_stage_execution_key(**_key_kwargs())
+        _create_terminal_job_with_evidence(registry, task="job-a", stage_execution_key=key)
+
+        changed_model_key = compute_stage_execution_key(**_key_kwargs(model="a-new-model"))
+        changed_candidate_key = compute_stage_execution_key(**_key_kwargs(candidate_sha="f" * 40))
+        changed_repo_key = compute_stage_execution_key(**_key_kwargs(repo="other/repo"))
+
+        for invalidated_key in (changed_model_key, changed_candidate_key, changed_repo_key):
+            assert (
+                registry.find_reusable_stage_evidence(
+                    invalidated_key, is_evidence_still_valid=lambda _e: True
+                )
+                is None
+            )
+
+
+def test_create_job_rejects_malformed_stage_execution_key(tmp_path: Path) -> None:
+    registry = _make_registry(tmp_path)
+    with pytest.raises(ValueError):
+        registry.create_job(
+            task="job-bad-key",
+            persona="review",
+            branch="feature/job-bad-key",
+            pane="pane-1",
+            worktree="/tmp/job-bad-key",
+            workflow_stage_execution_key="too-short",
+        )
+
+
+def test_create_job_persists_stage_execution_key(tmp_path: Path) -> None:
+    registry = _make_registry(tmp_path)
+    key = compute_stage_execution_key(**_key_kwargs())
+    job = registry.create_job(
+        task="job-persisted",
+        persona="review",
+        branch="feature/job-persisted",
+        pane="pane-1",
+        worktree="/tmp/job-persisted",
+        workflow_stage_execution_key=key,
+    )
+    assert registry.get_job(job["job_id"])["workflow_stage_execution_key"] == key
+
+    reloaded = JobRegistry(state_path=registry._state_path)
+    assert reloaded.get_job(job["job_id"])["workflow_stage_execution_key"] == key

--- a/tests/test_manager_daemon_stage_execution_key.py
+++ b/tests/test_manager_daemon_stage_execution_key.py
@@ -1,0 +1,216 @@
+"""#214：manager_daemon.py 的 workflow-action/start 觸發處消費 StageExecutionKey
+
+reuse 判定——相同 key 第二次執行時短路掉 dispatch_workflow_card（不增加 model
+invocation count），沒帶 key 或找不到可 reuse 的 evidence時行為與過去完全相同。
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from paulsha_cortex.control.contract import build_request
+from paulsha_cortex.coordinator import manager, manager_daemon
+from paulsha_cortex.coordinator.model_identities import IdentityRegistry
+from paulsha_cortex.coordinator.registry import JobRegistry, compute_stage_execution_key
+from paulsha_cortex.coordinator.workflow import WorkflowStep
+
+
+def _build_step() -> WorkflowStep:
+    return WorkflowStep(
+        phase="build",
+        persona="builder",
+        card="build",
+        executor="codex",
+        model="gpt-5",
+        domain="openai",
+        inputs=(),
+        outputs=(),
+    )
+
+
+def _make_run(registry: JobRegistry, tmp_path: Path):
+    return registry._manager_create_workflow_run(
+        work_id="214-stage-execution-key",
+        repo="hamanpaul/paulsha-cortex",
+        claim_key="claim:v1:" + "1" * 64,
+        source_revision="2" * 64,
+        workspace_root=str(tmp_path),
+        combo="feature-oneshot",
+        current_phase="build",
+        steps=(_build_step(),),
+        issue_refs=("hamanpaul/paulsha-cortex#214",),
+        openspec_refs=("214-stage-execution-key",),
+        pr_refs=(),
+        attempts={"build": 1},
+        gate_status="running",
+    )
+
+
+def _executor(
+    *,
+    dispatcher,
+    tmp_path: Path,
+    stage_evidence_validator=None,
+):
+    return manager_daemon.build_request_executor(
+        dispatcher=dispatcher,
+        specs_dir=str(tmp_path / "specs"),
+        handoff_dir=str(tmp_path / "handoff"),
+        workflow_identity_registry=IdentityRegistry.from_rows([]),
+        stage_evidence_validator=stage_evidence_validator,
+    )
+
+
+def test_start_reuses_stage_evidence_and_does_not_dispatch_a_new_job(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    registry = JobRegistry(state_path=tmp_path / "registry.json")
+    run = _make_run(registry, tmp_path)
+    dispatcher = type("D", (), {"_registry": registry, "_git_runner": None})()
+
+    stage_execution_key = compute_stage_execution_key(
+        repo="hamanpaul/paulsha-cortex",
+        work_id="214-stage-execution-key",
+        card="build",
+        phase="build",
+        executor="codex",
+        model="gpt-5",
+        base_sha="a" * 40,
+        candidate_sha="b" * 40,
+        frozen_input_hashes=("1" * 64,),
+        action="propose-diff",
+        test_policy="focused",
+    )
+    prior_job = registry.create_job(
+        task="prior-build",
+        persona="review",
+        branch="feature/prior-build",
+        pane="pane-1",
+        worktree=str(tmp_path / "prior-build"),
+        workflow_run_id="prior-run",
+        workflow_stage_execution_key=stage_execution_key,
+    )
+    registry.update_headless_result(prior_job["job_id"], status="exited", exit_code=0)
+    registry.bind_workflow_evidence(
+        prior_job["job_id"],
+        locator={"kind": "gate", "path": "evidence/workflow/prior-build.json", "hash": "e" * 64},
+    )
+    jobs_before = registry.list_jobs()
+
+    monkeypatch.setattr(
+        manager,
+        "apply_workflow_action",
+        lambda *a, **k: {"run_id": run.run_id, "current_phase": "build"},
+    )
+
+    def _must_not_dispatch(*args, **kwargs):
+        raise AssertionError("相同 stage_execution_key 找到可重用 evidence 時不應再派新 job")
+
+    monkeypatch.setattr(manager, "dispatch_workflow_card", _must_not_dispatch)
+
+    executor = _executor(
+        dispatcher=dispatcher,
+        tmp_path=tmp_path,
+        stage_evidence_validator=lambda _evidence: True,
+    )
+    result = executor(
+        build_request(
+            req_type="workflow-action",
+            args={"action": "start", "stage_execution_key": stage_execution_key},
+            requested_by="operator",
+        )
+    )
+
+    assert result["reused_from"] == {
+        "run_id": "prior-run",
+        "job_id": prior_job["job_id"],
+        "evidence": {"kind": "gate", "path": "evidence/workflow/prior-build.json", "hash": "e" * 64},
+    }
+    assert "job_id" not in result
+    # model invocation count 不增加：沒有因為這次「reuse」而多出任何 job。
+    assert registry.list_jobs() == jobs_before
+
+
+def test_start_dispatches_normally_when_no_reusable_stage_evidence(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    registry = JobRegistry(state_path=tmp_path / "registry.json")
+    run = _make_run(registry, tmp_path)
+    dispatcher = type("D", (), {"_registry": registry, "_git_runner": None})()
+
+    monkeypatch.setattr(
+        manager,
+        "apply_workflow_action",
+        lambda *a, **k: {"run_id": run.run_id, "current_phase": "build"},
+    )
+    dispatch_calls = []
+
+    def _fake_dispatch(*args, **kwargs):
+        dispatch_calls.append(kwargs)
+        return {"job_id": "new-build-job"}
+
+    monkeypatch.setattr(manager, "dispatch_workflow_card", _fake_dispatch)
+
+    executor = _executor(
+        dispatcher=dispatcher,
+        tmp_path=tmp_path,
+        stage_evidence_validator=lambda _evidence: True,
+    )
+    unmatched_key = compute_stage_execution_key(
+        repo="hamanpaul/paulsha-cortex",
+        work_id="214-stage-execution-key",
+        card="build",
+        phase="build",
+        executor="codex",
+        model="a-different-model",
+        base_sha="a" * 40,
+        candidate_sha="b" * 40,
+        frozen_input_hashes=("1" * 64,),
+        action="propose-diff",
+        test_policy="focused",
+    )
+    result = executor(
+        build_request(
+            req_type="workflow-action",
+            args={"action": "start", "stage_execution_key": unmatched_key},
+            requested_by="operator",
+        )
+    )
+
+    assert len(dispatch_calls) == 1
+    assert result["job_id"] == "new-build-job"
+    assert "reused_from" not in result
+
+
+def test_start_without_stage_execution_key_keeps_previous_behavior(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    registry = JobRegistry(state_path=tmp_path / "registry.json")
+    run = _make_run(registry, tmp_path)
+    dispatcher = type("D", (), {"_registry": registry, "_git_runner": None})()
+
+    monkeypatch.setattr(
+        manager,
+        "apply_workflow_action",
+        lambda *a, **k: {"run_id": run.run_id, "current_phase": "build"},
+    )
+    dispatch_calls = []
+
+    def _fake_dispatch(*args, **kwargs):
+        dispatch_calls.append(kwargs)
+        return {"job_id": "new-build-job"}
+
+    monkeypatch.setattr(manager, "dispatch_workflow_card", _fake_dispatch)
+
+    # 沒帶 stage_evidence_validator、也沒帶 stage_execution_key：backward
+    # compatible，行為必須與 #214 之前完全相同。
+    executor = _executor(dispatcher=dispatcher, tmp_path=tmp_path)
+    result = executor(
+        build_request(req_type="workflow-action", args={"action": "start"}, requested_by="operator")
+    )
+
+    assert len(dispatch_calls) == 1
+    assert result["job_id"] == "new-build-job"
+    assert "reused_from" not in result

--- a/tests/test_manager_daemon_stage_execution_key.py
+++ b/tests/test_manager_daemon_stage_execution_key.py
@@ -127,6 +127,7 @@ def test_start_reuses_stage_evidence_and_does_not_dispatch_a_new_job(
         "run_id": "prior-run",
         "job_id": prior_job["job_id"],
         "evidence": {"kind": "gate", "path": "evidence/workflow/prior-build.json", "hash": "e" * 64},
+        "evidence_hash": "e" * 64,
     }
     assert "job_id" not in result
     # model invocation count 不增加：沒有因為這次「reuse」而多出任何 job。


### PR DESCRIPTION
## 摘要

對應 `#208` 設計 B。建立在既有 phase 級 checkpoint（`manager_daemon.py` 的
workflow-action/start 觸發處、`claim.py` 的 claim key）之上，把顆粒度從 phase
降到 stage：新增 `StageExecutionKey`（content-addressed），在相同 key 已有完整
且通過驗證的 evidence 時可直接 reuse、不重啟 model session；`CompletionRecord`
記錄 reused-from provenance；authority／candidate／model 任一變更都會產生不同
key，精準 invalidate。不做 retry 分類（`#215`/`#216`）、不做 band（`#222`）；
reuse 判定全程 fail-closed。

## 變更

| 檔案 | 變更內容 |
|---|---|
| `paulsha_cortex/coordinator/registry.py` | 新增 `compute_stage_execution_key`（11 個內容定址欄位收斂成 64-hex key）；`create_job`/`_validate_loaded_job` 新增 `workflow_stage_execution_key` 欄位與格式驗證；新增 `JobRegistry.find_reusable_stage_evidence`（fail-closed reuse 查詢，與既有 `bind_workflow_evidence` 並存、不改其語意） |
| `paulsha_cortex/coordinator/completion.py` | `CompletionRecord` 新增可選 `reused_from`（run_id/job_id/evidence_hash）provenance 欄位；`completion_records_semantically_match` 排除 `reused_from`，避免良性 reuse 被誤判為衝突觸發 quarantine |
| `paulsha_cortex/coordinator/manager_daemon.py` | `build_request_executor` 新增可選 `stage_evidence_validator` 參數；workflow-action/start 觸發處消費 `find_reusable_stage_evidence`：帶 `stage_execution_key` 且找到可重用 evidence 時短路 `dispatch_workflow_card`（不增加 model invocation），否則行為與過去完全相同（backward compatible） |
| `changelog.d/stage-execution-key.md` | 新增 changelog fragment |
| `tests/test_coordinator_stage_execution_key.py` | 新測試：`compute_stage_execution_key` 涵蓋欄位／確定性／任一欄位變更即 invalidate；`find_reusable_stage_evidence` 的 fail-closed 各分支與 reuse 成功路徑 |
| `tests/test_completion_stage_execution_key.py` | 新測試：`reused_from` schema 驗證與 semantic match 排除 |
| `tests/test_manager_daemon_stage_execution_key.py` | 新測試：daemon 觸發處的短路／正常派工／向下相容三種路徑 |

## 驗收條件對應

- [x] StageExecutionKey 涵蓋 repo/work_id/card/phase/executor/model/base_sha/candidate_sha/frozen_input_hashes/action/test_policy
  → `tests/test_coordinator_stage_execution_key.py::TestComputeStageExecutionKey`（`test_any_covered_field_change_invalidates_key`、`test_frozen_input_hashes_change_invalidates_key`）
- [x] 相同 key 第二次執行 reuse evidence，model invocation count 不增加
  → `tests/test_coordinator_stage_execution_key.py::TestFindReusableStageEvidence::test_reuses_evidence_for_identical_key_second_execution`；
    `tests/test_manager_daemon_stage_execution_key.py::test_start_reuses_stage_evidence_and_does_not_dispatch_a_new_job`
- [x] CompletionRecord 記錄 reused-from run/job/evidence hash
  → `tests/test_completion_stage_execution_key.py::ReusedFromValidationTests`（`test_reused_from_round_trips_normalized_and_lowercases_hash` 等）
- [x] authority／candidate／model 任一變更才精準 invalidate
  → `tests/test_coordinator_stage_execution_key.py::TestFindReusableStageEvidence::test_authority_candidate_model_change_invalidates_reuse`；
    `tests/test_manager_daemon_stage_execution_key.py::test_start_dispatches_normally_when_no_reusable_stage_evidence`

## 性質

feat（新能力，非 bugfix）；reuse 判定 fail-closed（沒有驗證 callback、key 格式錯、
evidence 未綁定或驗證不過一律不 reuse），對既有呼叫端 100% 向下相容（未帶
`stage_execution_key`／`stage_evidence_validator` 時行為與改動前完全相同）。

Closes #214

## Checklist

- [x] changelog.d fragment 已新增（R-09）
- [x] 本地 preflight-ci PASS（policy + openspec + pytest）
