### PR TITLE
feat(coordinator): 五維 sizing 評分（三維機械算＋二維宣告）

### DIFF
--- a/changelog.d/221-sizing-score.md
+++ b/changelog.d/221-sizing-score.md
@@ -1,0 +1,3 @@
+### Added
+
+- **Issue #221：五維 sizing 評分（三維機械算＋二維宣告）**：`planning.py` 新增 `compute_sizing_score()`／`SizingScore`，純函式計算 acceptance_surfaces／spec_stability／orchestration，並讀取 plan frontmatter 宣告的 `domain_breadth`／`state_consistency`；`deck/schema.py`／`deck/compile.py` 同步落地 gate_spine 兩層制（`band_triggered` 加掛層，預設 Yellow 起掛，band 未知時保守全含），`feature-oneshot` combo 的 `adversarial-review` 移入加掛層。

--- a/paulsha_cortex/coordinator/planning.py
+++ b/paulsha_cortex/coordinator/planning.py
@@ -276,6 +276,131 @@ def assess_planning_completeness(artifacts: Iterable[PlanningArtifact]) -> Compl
     return CompletenessReport(not missing_kinds and not has_blockers, assessments, missing_kinds, pack)
 
 
+# --- #208 設計 H.1／#221：五維 sizing 評分 -----------------------------------
+#
+# 五維量表（每維 0-2 分，總分 0-10）：
+#   機械三維 —— acceptance_surfaces / spec_stability / orchestration，由
+#   compute_sizing_score() 依注入參數純函式計算；
+#   宣告二維 —— domain_breadth / state_consistency，由 planner 寫在 plan
+#   frontmatter（可證偽，供 #210/#137 後驗）。
+#
+# band 判定（Green/Yellow/Red 閾值套用）屬 #222，本模組只產生分數本身；
+# 全程不啟動任何 model session（純函式，不 import model_identities 的
+# CLI 呼叫路徑，也不對 planning_runtime.py 產生依賴）。
+SIZING_DIMENSIONS = (
+    "domain_breadth",
+    "state_consistency",
+    "acceptance_surfaces",
+    "spec_stability",
+    "orchestration",
+)
+# acceptance_surfaces 讀取的 contract 規則白名單（policy checklist R-09/R-16/R-19：
+# changelog fragment／CLI help 同步／CI 測試）；呼叫端算好「這個 work item 碰了哪些
+# 規則」後以 frozenset 注入，避免 planning.py 反向 import policy_check 或 deck。
+ACCEPTANCE_SURFACE_RULES = frozenset({"R-09", "R-16", "R-19"})
+# plan frontmatter 宣告欄位骨架（可擴充）：#212 會再掛 invariant_count／artifact_classes
+# 等自己的宣告欄位，沿用同一個「讀 frontmatter → 嚴格範圍檢查」helper 即可，不必
+# 各自重造一次驗證邏輯。
+_SIZING_DECLARED_FIELDS = ("domain_breadth", "state_consistency")
+
+
+def _declared_dimension(frontmatter: Mapping[str, object], field: str) -> int:
+    """讀取 plan frontmatter 宣告欄位，嚴格驗證為 0–2 整數（fail-closed，
+    比照 PlanningScope.__post_init__ 風格）。"""
+    value = frontmatter.get(field)
+    if not isinstance(value, int) or isinstance(value, bool) or not (0 <= value <= 2):
+        raise ValueError(f"plan frontmatter 缺少合法的 {field}（需為 0–2 整數宣告）")
+    return value
+
+
+@dataclass(frozen=True)
+class SizingScore:
+    domain_breadth: int
+    state_consistency: int
+    acceptance_surfaces: int
+    spec_stability: int
+    orchestration: int
+
+    def __post_init__(self) -> None:
+        for name in SIZING_DIMENSIONS:
+            value = getattr(self, name)
+            if not isinstance(value, int) or isinstance(value, bool) or not (0 <= value <= 2):
+                raise ValueError(f"sizing dimension {name} must be an int in [0, 2], got {value!r}")
+
+    @property
+    def total(self) -> int:
+        return sum(getattr(self, name) for name in SIZING_DIMENSIONS)
+
+    def to_dict(self) -> dict[str, object]:
+        payload: dict[str, object] = {name: getattr(self, name) for name in SIZING_DIMENSIONS}
+        payload["total"] = self.total
+        return payload
+
+
+def compute_sizing_score(
+    *,
+    plan_artifact: PlanningArtifact,
+    completeness_report: CompletenessReport,
+    gate_spine_count: int,
+    applicable_contract_rules: frozenset[str],
+    cards_count: int,
+    persona_binding_count: int,
+) -> SizingScore:
+    """五維 sizing 評分（#208 H.1）：三維機械算 + 二維宣告，純函式、不啟動 model session。
+
+    gate_spine_count／applicable_contract_rules／cards_count／persona_binding_count
+    皆由呼叫端算好注入（deck combo 的必要核心 gate_spine 計數、R-09/R-16/R-19 適用性、
+    combo.cards 數與其中填了 persona_binding 的卡片數）——planning.py 刻意不反向
+    import deck 模組，維持既有模組邊界。
+    """
+    if plan_artifact.kind != "plan":
+        raise ValueError(f"compute_sizing_score 需要 kind='plan' 的 artifact，實際 {plan_artifact.kind!r}")
+    frontmatter, _, _ = _frontmatter_and_body(plan_artifact.text)
+    domain_breadth = _declared_dimension(frontmatter, "domain_breadth")
+    state_consistency = _declared_dimension(frontmatter, "state_consistency")
+
+    if gate_spine_count < 0:
+        raise ValueError("gate_spine_count 不得為負")
+    unknown_rules = applicable_contract_rules - ACCEPTANCE_SURFACE_RULES
+    if unknown_rules:
+        raise ValueError(f"applicable_contract_rules 含未知規則: {sorted(unknown_rules)}")
+    if cards_count < 0 or persona_binding_count < 0 or persona_binding_count > cards_count:
+        raise ValueError("cards_count/persona_binding_count 不合法")
+
+    # acceptance_surfaces：核心 gate_spine 計數 + 適用規則數的組合訊號，門檻切三級。
+    acceptance_signal = gate_spine_count + len(applicable_contract_rules)
+    if acceptance_signal == 0:
+        acceptance_surfaces = 0
+    elif acceptance_signal <= 2:
+        acceptance_surfaces = 1
+    else:
+        acceptance_surfaces = 2
+
+    # spec_stability：deterministic completeness 結果——缺的 kind 數與是否有
+    # blocking markers 各扣一分，不只取 CompletenessReport.complete 的布林值。
+    missing_penalty = len(completeness_report.missing_kinds)
+    blocking_penalty = 1 if any(
+        assessment.blocking_markers for assessment in completeness_report.assessments
+    ) else 0
+    spec_stability = max(0, 2 - missing_penalty - blocking_penalty)
+
+    # orchestration：card 清單規模 + 有填 persona_binding 的卡片數。
+    if cards_count <= 1:
+        orchestration = 0
+    elif persona_binding_count <= 1:
+        orchestration = 1
+    else:
+        orchestration = 2
+
+    return SizingScore(
+        domain_breadth=domain_breadth,
+        state_consistency=state_consistency,
+        acceptance_surfaces=acceptance_surfaces,
+        spec_stability=spec_stability,
+        orchestration=orchestration,
+    )
+
+
 def _strict_string_list(value: object, field: str, *, allow_empty: bool = False) -> tuple[str, ...]:
     if not isinstance(value, list) or any(not isinstance(item, str) or not item.strip() for item in value):
         raise ValueError(f"{field} must be a string list")

--- a/paulsha_cortex/deck/compile.py
+++ b/paulsha_cortex/deck/compile.py
@@ -12,7 +12,7 @@ from typing import Mapping, Sequence
 from paulsha_cortex.config import paths
 from paulsha_cortex.coordinator.workflow import WorkflowManifest, WorkflowStep
 
-from .schema import Card, Combo, ComboEntry
+from .schema import BAND_LEVELS, BandTriggeredSpine, Card, Combo, ComboEntry
 
 
 class DeckCompileError(ValueError):
@@ -134,6 +134,11 @@ class CompileResult:
     # Optional only for source compatibility with callers that construct a
     # CompileResult solely to exercise emit(); compile_combo always populates it.
     workflow_manifest: WorkflowManifest | None = None
+    # gate_spine 兩層制（#221）：verify_commands 為合併總覽（沿用既有行為），這兩個
+    # 欄位額外標示哪些 gate verify 指令屬於必要核心層、哪些屬於 band 觸發加掛層，
+    # 供下游（H.1 sizing/acceptance_surfaces）只讀核心層而不必重新解析 combo。
+    core_gate_verify_commands: tuple[str, ...] = ()
+    band_gate_verify_commands: tuple[str, ...] = ()
 
 
 _LEGACY_CARD_PHASES = {
@@ -432,14 +437,14 @@ def _verify_command(card: Card, slug: str, change: str | None) -> str:
 
 
 def _gate_verify_commands(
-    combo: Combo,
+    gate_spine: Sequence,
     cards: Mapping[str, Card],
     slug: str,
     change: str | None,
     selected_refs: frozenset[str],
 ) -> list[str]:
     commands: list[str] = []
-    for gate in combo.gate_spine:
+    for gate in gate_spine:
         if gate.after not in selected_refs:
             continue
         card = cards.get(gate.after)
@@ -453,6 +458,42 @@ def _gate_verify_commands(
     return commands
 
 
+def _band_meets_trigger(band: str, trigger: str) -> bool:
+    return BAND_LEVELS.index(band) >= BAND_LEVELS.index(trigger)
+
+
+def _apply_band_triggered(
+    hand: list[ComboEntry],
+    band_spine: BandTriggeredSpine | None,
+    band: str | None,
+) -> tuple[list[ComboEntry], bool]:
+    """band 兩層制（#221 maintainer 裁決）：band 未知（None）時保守地包含加掛層
+    （行為與今日一致）；band 已知時依 BAND_LEVELS 順序與 trigger 比較。加掛卡片
+    依其 depends_on 插入骨幹中最後一個依賴之後，未宣告 depends_on 則附加於尾端。
+    """
+    if band_spine is None:
+        return hand, False
+    if band is not None and band not in BAND_LEVELS:
+        raise DeckCompileError(f"band 非法值 {band!r}（允許 {list(BAND_LEVELS)}）")
+    if band is not None and not _band_meets_trigger(band, band_spine.trigger):
+        return hand, False
+
+    refs = {entry.ref for entry in hand}
+    result = list(hand)
+    for entry in band_spine.cards:
+        if entry.ref in refs:
+            raise DeckCompileError(f"band_triggered 卡片與骨幹重複: {entry.ref}")
+        current_refs = [e.ref for e in result]
+        if entry.depends_on:
+            positions = [current_refs.index(dep) for dep in entry.depends_on if dep in current_refs]
+            pos = max(positions) + 1 if positions else len(result)
+        else:
+            pos = len(result)
+        result.insert(pos, entry)
+        refs.add(entry.ref)
+    return result, True
+
+
 def compile_combo(
     combo: Combo,
     cards: Mapping[str, Card],
@@ -463,11 +504,16 @@ def compile_combo(
     only: Sequence[str] = (),
     allow_external: bool = False,
     plan_ref: str | None = None,
+    band: str | None = None,
 ) -> CompileResult:
     slug = slugify_task(task)
     if change is not None:
         change = _validate_change_name(change)
     entries = _resolve_hand(combo, cards, with_cards, only)
+    # --only 明確選卡時尊重使用者選擇，不再併入 band 加掛層（#221）。
+    band_applied = False
+    if not only:
+        entries, band_applied = _apply_band_triggered(entries, combo.band_triggered, band)
     external = _check_requires_coverage(entries, cards, allow_external)
     workflow_manifest = _compile_workflow_manifest(combo, entries, cards, slug, change)
 
@@ -488,7 +534,13 @@ def compile_combo(
     explicit_deps = {entry.ref: entry.depends_on for entry in entries}
     selected_refs = frozenset(entry.ref for entry in entries)
     slices: list[SliceDoc] = []
-    verify_commands = _gate_verify_commands(combo, cards, slug, change, selected_refs)
+    core_gate_commands = _gate_verify_commands(combo.gate_spine, cards, slug, change, selected_refs)
+    band_gate_commands: list[str] = (
+        _gate_verify_commands(combo.band_triggered.gate_spine, cards, slug, change, selected_refs)
+        if band_applied and combo.band_triggered is not None
+        else []
+    )
+    verify_commands = core_gate_commands + band_gate_commands
     previous_slice_id: str | None = None
 
     for slice_id, members in _group_slices(entries, cards, slug):
@@ -546,6 +598,8 @@ def compile_combo(
         verify_commands=tuple(dict.fromkeys(verify_commands)),
         external=external,
         workflow_manifest=workflow_manifest,
+        core_gate_verify_commands=tuple(dict.fromkeys(core_gate_commands)),
+        band_gate_verify_commands=tuple(dict.fromkeys(band_gate_commands)),
     )
 
 

--- a/paulsha_cortex/deck/data/combos/feature-oneshot.yaml
+++ b/paulsha_cortex/deck/data/combos/feature-oneshot.yaml
@@ -11,7 +11,6 @@ combo:
     - ref: subagent-build
     - ref: verification
     - ref: code-review
-    - ref: adversarial-review
     - ref: openspec-archive
     - ref: policy-commit
   gate_spine:
@@ -21,7 +20,16 @@ combo:
       exists: ["reports/verify/*<task-slug>*.md"]
     - after: code-review
       exists: ["reports/review/*<task-slug>*.md"]
-    - after: adversarial-review
-      exists: ["reports/review/*<task-slug>*-adversarial.md"]
     - after: openspec-archive
       exists: ["openspec/changes/archive/*<change>*"]
+  # gate_spine 兩層制（#208 H.1 / #221）：adversarial-review 為 band 觸發加掛層，
+  # 只有上面的 gate_spine（必要核心）計入 acceptance_surfaces；預設 Yellow 起掛，
+  # Green 不掛。band 未知（未傳入 compile_combo）時保守地視為已觸發（沿用現行行為）。
+  band_triggered:
+    trigger: yellow
+    cards:
+      - ref: adversarial-review
+        depends_on: [code-review]
+    gate_spine:
+      - after: adversarial-review
+        exists: ["reports/review/*<task-slug>*-adversarial.md"]

--- a/paulsha_cortex/deck/schema.py
+++ b/paulsha_cortex/deck/schema.py
@@ -41,9 +41,12 @@ _CARD_KEYS = frozenset(
 )
 _EXECUTION_KEYS = frozenset({"action", "commit_policy", "test_policy"})
 _COMBO_FILE_KEYS = frozenset({"combo"})
-_COMBO_KEYS = frozenset({"id", "task_type", "cards", "gate_spine"})
+_COMBO_KEYS = frozenset({"id", "task_type", "cards", "gate_spine", "band_triggered"})
 _COMBO_ENTRY_KEYS = frozenset({"ref", "depends_on"})
 _GATE_CHECK_KEYS = frozenset({"after", "exists"})
+_BAND_TRIGGERED_KEYS = frozenset({"trigger", "cards", "gate_spine"})
+# gate_spine 兩層制（#208 H.1 / #221）：band 依嚴重度單調遞增，band_triggered.trigger 必須是其中之一。
+BAND_LEVELS = ("green", "yellow", "red")
 _PLACEHOLDER_RE = re.compile(r"<([^<>]+)>")
 _DRIVE_RE = re.compile(r"^[A-Za-z]:")
 
@@ -86,11 +89,25 @@ class GateCheck:
 
 
 @dataclass(frozen=True)
+class BandTriggeredSpine:
+    """gate_spine 加掛層（band 觸發後才併入的 cards/gate_spine）。
+
+    只有 Combo.gate_spine（必要核心）計入 acceptance_surfaces；本層資料
+    刻意放在獨立欄位，讓下游（H.1 sizing）不會誤把加掛層算進去。
+    """
+
+    trigger: str
+    cards: tuple[ComboEntry, ...] = ()
+    gate_spine: tuple[GateCheck, ...] = ()
+
+
+@dataclass(frozen=True)
 class Combo:
     id: str
     task_type: str
     cards: tuple[ComboEntry, ...]
     gate_spine: tuple[GateCheck, ...] = ()
+    band_triggered: BandTriggeredSpine | None = None
 
 
 def _check_placeholders(card_id: str, globs: tuple[str, ...], errors: list[str]) -> None:
@@ -320,9 +337,78 @@ def load_combo(path: str | Path, cards: Mapping[str, Card]) -> Combo:
             errors.append(f"{g['after']}: gate_spine.exists 不得為空")
         spine.append(GateCheck(after=g["after"], exists=exists))
 
+    # band_triggered（gate_spine 兩層制加掛層，#221）：與上面 gate_spine 對稱解析，
+    # 但 ref／after 允許指向核心層（seen）或加掛層自身（band_seen），且加掛層卡片
+    # 不得與核心層重複（維持「必要核心 vs 加掛層」互斥，避免下游 acceptance_surfaces
+    # 誤重複計算）。
+    band_triggered: BandTriggeredSpine | None = None
+    raw_band = rec.get("band_triggered")
+    if raw_band is not None:
+        if not isinstance(raw_band, Mapping):
+            errors.append(f"combo: band_triggered 必須是 mapping，實際 {type(raw_band).__name__}")
+            raw_band = {}
+        _check_unknown_keys("combo.band_triggered", raw_band, _BAND_TRIGGERED_KEYS, errors)
+
+        trigger = raw_band.get("trigger")
+        if trigger not in BAND_LEVELS:
+            errors.append(f"combo.band_triggered: trigger 非法值 {trigger!r}（允許 {list(BAND_LEVELS)}）")
+            trigger = None
+
+        band_entries: list[ComboEntry] = []
+        raw_band_cards = raw_band.get("cards")
+        if raw_band_cards is not None and not isinstance(raw_band_cards, list):
+            errors.append(f"combo.band_triggered: cards 必須是清單，實際 {type(raw_band_cards).__name__}")
+            raw_band_cards = []
+        band_seen: set[str] = set()
+        for item in raw_band_cards or []:
+            if not isinstance(item, Mapping) or not isinstance(item.get("ref"), str):
+                errors.append("combo.band_triggered.cards 項目缺 ref")
+                continue
+            ref = item["ref"]
+            _check_unknown_keys(f"band_triggered.{ref}", item, _COMBO_ENTRY_KEYS, errors)
+            if ref not in cards:
+                errors.append(f"未知卡片引用: {ref}")
+            if ref in seen or ref in band_seen:
+                errors.append(f"band_triggered 卡片與骨幹重複: {ref}")
+            band_seen.add(ref)
+            band_deps = _str_tuple(item.get("depends_on"), ref, "depends_on", errors)
+            for d in band_deps:
+                if d not in seen and d not in band_seen:
+                    errors.append(f"{ref}: depends_on 指向 combo 外卡片 {d}")
+            band_entries.append(ComboEntry(ref=ref, depends_on=band_deps))
+
+        band_spine: list[GateCheck] = []
+        raw_band_spine = raw_band.get("gate_spine")
+        if raw_band_spine is not None and not isinstance(raw_band_spine, list):
+            errors.append(f"combo.band_triggered: gate_spine 必須是清單，實際 {type(raw_band_spine).__name__}")
+            raw_band_spine = []
+        for g in raw_band_spine or []:
+            if not isinstance(g, Mapping) or not isinstance(g.get("after"), str):
+                errors.append("band_triggered.gate_spine 項目缺 after")
+                continue
+            _check_unknown_keys(g["after"], g, _GATE_CHECK_KEYS, errors)
+            if g["after"] not in seen and g["after"] not in band_seen:
+                errors.append(f"band_triggered.gate_spine.after 指向不存在卡片: {g['after']}")
+            exists = _str_tuple(g.get("exists"), g["after"], "gate_spine.exists", errors)
+            _check_placeholders(g["after"], exists, errors)
+            if not exists:
+                errors.append(f"{g['after']}: gate_spine.exists 不得為空")
+            band_spine.append(GateCheck(after=g["after"], exists=exists))
+
+        if trigger is not None:
+            band_triggered = BandTriggeredSpine(
+                trigger=trigger, cards=tuple(band_entries), gate_spine=tuple(band_spine)
+            )
+
     if errors:
         raise DeckSchemaError(f"combo 驗證失敗: {source}: " + "; ".join(errors))
 
-    combo = Combo(id=combo_id, task_type=task_type, cards=tuple(entries), gate_spine=tuple(spine))
+    combo = Combo(
+        id=combo_id,
+        task_type=task_type,
+        cards=tuple(entries),
+        gate_spine=tuple(spine),
+        band_triggered=band_triggered,
+    )
     _detect_combo_cycles(combo.cards)
     return combo

--- a/tests/test_deck_compile_sizing_score.py
+++ b/tests/test_deck_compile_sizing_score.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+import pytest
+
+from paulsha_cortex.deck.compile import DeckCompileError, compile_combo
+from paulsha_cortex.deck.schema import load_cards, load_combo
+
+# #221：compile_combo 的 band 兩層制行為（core vs band_triggered 加掛層）。
+CARDS_YAML = """\
+version: 0
+cards:
+  - id: writing-plans
+    kind: skill
+    type: interactive
+    class: core
+    skill_ref: "superpowers:writing-plans"
+    requires: []
+    produces: ["docs/superpowers/plans/*<task-slug>*.md"]
+    persona_binding: planner
+  - id: code-review
+    kind: skill
+    type: headless
+    class: core
+    skill_ref: "superpowers:requesting-code-review"
+    requires: []
+    produces: ["reports/review/*<task-slug>*.md"]
+    persona_binding: reviewer
+  - id: ship
+    kind: skill
+    type: headless
+    class: core
+    skill_ref: "conventional-commit"
+    phase: ship
+    requires: []
+    produces: []
+    persona_binding: manager
+  - id: adversarial-review
+    kind: skill
+    type: headless
+    class: core
+    skill_ref: "codex:adversarial-review"
+    requires: ["reports/review/*<task-slug>*.md"]
+    produces: ["reports/review/*<task-slug>*-adversarial.md"]
+    persona_binding: reviewer
+"""
+
+COMBO_WITH_BAND = """\
+combo:
+  id: demo
+  task_type: feature
+  cards:
+    - ref: writing-plans
+    - ref: code-review
+    - ref: ship
+  gate_spine:
+    - after: writing-plans
+      exists: ["docs/superpowers/plans/*<task-slug>*.md"]
+  band_triggered:
+    trigger: yellow
+    cards:
+      - ref: adversarial-review
+        depends_on: [code-review]
+    gate_spine:
+      - after: adversarial-review
+        exists: ["reports/review/*<task-slug>*-adversarial.md"]
+"""
+
+COMBO_WITHOUT_BAND = """\
+combo:
+  id: demo
+  task_type: feature
+  cards:
+    - ref: writing-plans
+    - ref: code-review
+    - ref: ship
+  gate_spine:
+    - after: writing-plans
+      exists: ["docs/superpowers/plans/*<task-slug>*.md"]
+"""
+
+
+def _write(tmp_path, name, text):
+    p = tmp_path / name
+    p.write_text(text, encoding="utf-8")
+    return p
+
+
+def _load(tmp_path, combo_text):
+    cards = load_cards(_write(tmp_path, "cards.yaml", CARDS_YAML))
+    return cards, load_combo(_write(tmp_path, "demo.yaml", combo_text), cards)
+
+
+def test_band_default_none_conservatively_includes_band_layer(tmp_path):
+    cards, combo = _load(tmp_path, COMBO_WITH_BAND)
+    result = compile_combo(combo, cards, "demo task", change="demo")
+    slug = result.task_slug
+    assert [s.slice_id for s in result.slices] == [
+        f"{slug}-code-review",
+        f"{slug}-adversarial-review",
+        f"{slug}-ship",
+    ]
+    assert result.core_gate_verify_commands == (
+        f"cortex deck verify writing-plans --task-slug {slug}",
+    )
+    assert result.band_gate_verify_commands == (
+        f"cortex deck verify adversarial-review --task-slug {slug}",
+    )
+    assert f"cortex deck verify adversarial-review --task-slug {slug}" in result.verify_commands
+
+
+def test_band_below_trigger_excludes_band_layer(tmp_path):
+    cards, combo = _load(tmp_path, COMBO_WITH_BAND)
+    result = compile_combo(combo, cards, "demo task", change="demo", band="green")
+    slug = result.task_slug
+    assert [s.slice_id for s in result.slices] == [f"{slug}-code-review", f"{slug}-ship"]
+    assert result.band_gate_verify_commands == ()
+    assert not any("adversarial-review" in command for command in result.verify_commands)
+
+
+@pytest.mark.parametrize("band", ["yellow", "red"])
+def test_band_at_or_above_trigger_includes_band_layer(tmp_path, band):
+    cards, combo = _load(tmp_path, COMBO_WITH_BAND)
+    result = compile_combo(combo, cards, "demo task", change="demo", band=band)
+    slug = result.task_slug
+    assert f"{slug}-adversarial-review" in [s.slice_id for s in result.slices]
+    assert result.band_gate_verify_commands
+
+
+def test_band_invalid_value_rejected(tmp_path):
+    cards, combo = _load(tmp_path, COMBO_WITH_BAND)
+    with pytest.raises(DeckCompileError, match="band 非法值"):
+        compile_combo(combo, cards, "demo task", change="demo", band="purple")
+
+
+def test_only_mode_skips_band_layer_even_with_default_band(tmp_path):
+    cards, combo = _load(tmp_path, COMBO_WITH_BAND)
+    result = compile_combo(
+        combo, cards, "demo task", change="demo", only=("code-review",), allow_external=True
+    )
+    assert [s.slice_id for s in result.slices] == [f"{result.task_slug}-code-review"]
+    assert result.band_gate_verify_commands == ()
+
+
+def test_combo_without_band_triggered_is_noop_for_band_param(tmp_path):
+    cards, combo = _load(tmp_path, COMBO_WITHOUT_BAND)
+    result = compile_combo(combo, cards, "demo task", change="demo", band="red")
+    assert [s.slice_id for s in result.slices] == [f"{result.task_slug}-code-review", f"{result.task_slug}-ship"]
+    assert result.band_gate_verify_commands == ()
+
+
+def test_band_card_inserted_after_its_dependency_not_at_tail(tmp_path):
+    # 對抗回歸：加掛卡若只是無條件附加到 hand 尾端，會跑到 ship 之後，
+    # 破壞既有「review 先於 ship」語意——必須依 depends_on 插到正確位置。
+    cards, combo = _load(tmp_path, COMBO_WITH_BAND)
+    result = compile_combo(combo, cards, "demo task", change="demo", band="yellow")
+    slice_ids = [s.slice_id for s in result.slices]
+    assert slice_ids.index(f"{result.task_slug}-adversarial-review") < slice_ids.index(f"{result.task_slug}-ship")

--- a/tests/test_deck_data.py
+++ b/tests/test_deck_data.py
@@ -53,18 +53,29 @@ def test_interactive_headless_typing():
     assert cards["policy-commit"].slice_group == "ship"
 
 
+# gate_spine 兩層制（#221）：adversarial-review 搬到 band_triggered 加掛層，
+# 核心層（combo.cards / combo.gate_spine）不再含它。
+CORE_PHASE_CARDS = [cid for cid in PHASE_CARDS if cid != "adversarial-review"]
+
+
 def test_feature_oneshot_combo_loads():
     cards = load_cards(DEFAULT_CARDS_PATH)
     combo = load_combo(DEFAULT_COMBOS_DIR / "feature-oneshot.yaml", cards)
     assert combo.id == "feature-oneshot"
     assert combo.task_type == "feature"
-    assert [c.ref for c in combo.cards] == PHASE_CARDS
+    assert [c.ref for c in combo.cards] == CORE_PHASE_CARDS
     assert [(gate.after, gate.exists) for gate in combo.gate_spine] == [
         ("writing-plans", ("docs/superpowers/plans/*<task-slug>*.md",)),
         ("verification", ("reports/verify/*<task-slug>*.md",)),
         ("code-review", ("reports/review/*<task-slug>*.md",)),
-        ("adversarial-review", ("reports/review/*<task-slug>*-adversarial.md",)),
         ("openspec-archive", ("openspec/changes/archive/*<change>*",)),
+    ]
+    assert combo.band_triggered is not None
+    assert combo.band_triggered.trigger == "yellow"
+    assert [entry.ref for entry in combo.band_triggered.cards] == ["adversarial-review"]
+    assert combo.band_triggered.cards[0].depends_on == ("code-review",)
+    assert [(gate.after, gate.exists) for gate in combo.band_triggered.gate_spine] == [
+        ("adversarial-review", ("reports/review/*<task-slug>*-adversarial.md",)),
     ]
 
 
@@ -79,6 +90,7 @@ def test_mcu_feature_combo_loads():
     assert [(gate.after, gate.exists) for gate in combo.gate_spine] == [
         ("mcu-hw-evidence", ("docs/superpowers/specs/*<task-slug>*-hw-evidence.md",)),
     ]
+    assert combo.band_triggered is None
 
 
 def test_mcu_feature_real_data_compiles_to_hold_specs(tmp_path):

--- a/tests/test_deck_schema_sizing_score.py
+++ b/tests/test_deck_schema_sizing_score.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+import pytest
+
+from paulsha_cortex.deck.schema import (
+    BAND_LEVELS,
+    BandTriggeredSpine,
+    DeckSchemaError,
+    load_cards,
+    load_combo,
+)
+
+# #221：gate_spine 兩層制（必要核心 + band 觸發加掛層）schema 支援。
+CARDS_YAML = """\
+version: 0
+cards:
+  - id: writing-plans
+    kind: skill
+    type: interactive
+    class: core
+    skill_ref: "superpowers:writing-plans"
+    requires: []
+    produces: ["docs/superpowers/plans/*<task-slug>*.md"]
+    persona_binding: planner
+  - id: code-review
+    kind: skill
+    type: headless
+    class: core
+    skill_ref: "superpowers:requesting-code-review"
+    requires: []
+    produces: ["reports/review/*<task-slug>*.md"]
+    persona_binding: reviewer
+  - id: ship
+    kind: skill
+    type: headless
+    class: core
+    skill_ref: "conventional-commit"
+    requires: []
+    produces: []
+    persona_binding: manager
+  - id: adversarial-review
+    kind: skill
+    type: headless
+    class: core
+    skill_ref: "codex:adversarial-review"
+    requires: ["reports/review/*<task-slug>*.md"]
+    produces: ["reports/review/*<task-slug>*-adversarial.md"]
+    persona_binding: reviewer
+"""
+
+COMBO_WITH_BAND = """\
+combo:
+  id: demo
+  task_type: feature
+  cards:
+    - ref: writing-plans
+    - ref: code-review
+    - ref: ship
+  gate_spine:
+    - after: writing-plans
+      exists: ["docs/superpowers/plans/*<task-slug>*.md"]
+  band_triggered:
+    trigger: yellow
+    cards:
+      - ref: adversarial-review
+        depends_on: [code-review]
+    gate_spine:
+      - after: adversarial-review
+        exists: ["reports/review/*<task-slug>*-adversarial.md"]
+"""
+
+COMBO_WITHOUT_BAND = """\
+combo:
+  id: demo
+  task_type: feature
+  cards:
+    - ref: writing-plans
+    - ref: code-review
+    - ref: ship
+  gate_spine:
+    - after: writing-plans
+      exists: ["docs/superpowers/plans/*<task-slug>*.md"]
+"""
+
+
+def _write(tmp_path, name, text):
+    p = tmp_path / name
+    p.write_text(text, encoding="utf-8")
+    return p
+
+
+def _load(tmp_path, combo_text):
+    cards = load_cards(_write(tmp_path, "cards.yaml", CARDS_YAML))
+    return cards, load_combo(_write(tmp_path, "demo.yaml", combo_text), cards)
+
+
+def test_band_levels_order():
+    assert BAND_LEVELS == ("green", "yellow", "red")
+
+
+def test_load_combo_band_triggered_valid(tmp_path):
+    cards, combo = _load(tmp_path, COMBO_WITH_BAND)
+    # 核心層完全不含加掛卡：acceptance_surfaces 只讀這裡才不會誤把加掛層算進去
+    assert [c.ref for c in combo.cards] == ["writing-plans", "code-review", "ship"]
+    assert [gate.after for gate in combo.gate_spine] == ["writing-plans"]
+
+    assert isinstance(combo.band_triggered, BandTriggeredSpine)
+    assert combo.band_triggered.trigger == "yellow"
+    assert [c.ref for c in combo.band_triggered.cards] == ["adversarial-review"]
+    assert combo.band_triggered.cards[0].depends_on == ("code-review",)
+    assert [(g.after, g.exists) for g in combo.band_triggered.gate_spine] == [
+        ("adversarial-review", ("reports/review/*<task-slug>*-adversarial.md",)),
+    ]
+
+
+def test_load_combo_without_band_triggered_defaults_none(tmp_path):
+    _, combo = _load(tmp_path, COMBO_WITHOUT_BAND)
+    assert combo.band_triggered is None
+
+
+def test_load_combo_band_triggered_unknown_key_rejected(tmp_path):
+    bad = COMBO_WITH_BAND.replace("trigger: yellow", "trger: yellow")
+    cards = load_cards(_write(tmp_path, "cards.yaml", CARDS_YAML))
+    with pytest.raises(DeckSchemaError, match="trger"):
+        load_combo(_write(tmp_path, "demo.yaml", bad), cards)
+
+
+def test_load_combo_band_triggered_invalid_trigger_rejected(tmp_path):
+    bad = COMBO_WITH_BAND.replace("trigger: yellow", "trigger: purple")
+    cards = load_cards(_write(tmp_path, "cards.yaml", CARDS_YAML))
+    with pytest.raises(DeckSchemaError, match="trigger 非法值"):
+        load_combo(_write(tmp_path, "demo.yaml", bad), cards)
+
+
+def test_load_combo_band_triggered_unknown_card_ref_rejected(tmp_path):
+    bad = COMBO_WITH_BAND.replace("ref: adversarial-review", "ref: no-such-card")
+    cards = load_cards(_write(tmp_path, "cards.yaml", CARDS_YAML))
+    with pytest.raises(DeckSchemaError, match="no-such-card"):
+        load_combo(_write(tmp_path, "demo.yaml", bad), cards)
+
+
+def test_load_combo_band_triggered_duplicate_with_core_rejected(tmp_path):
+    bad = COMBO_WITH_BAND.replace(
+        "      - ref: adversarial-review\n        depends_on: [code-review]",
+        "      - ref: code-review",
+    )
+    cards = load_cards(_write(tmp_path, "cards.yaml", CARDS_YAML))
+    with pytest.raises(DeckSchemaError, match="band_triggered 卡片與骨幹重複"):
+        load_combo(_write(tmp_path, "demo.yaml", bad), cards)
+
+
+def test_load_combo_band_triggered_gate_after_unknown_rejected(tmp_path):
+    bad = COMBO_WITH_BAND.replace(
+        "      - after: adversarial-review\n        exists:",
+        "      - after: no-such-card\n        exists:",
+    )
+    cards = load_cards(_write(tmp_path, "cards.yaml", CARDS_YAML))
+    with pytest.raises(DeckSchemaError, match="不存在卡片"):
+        load_combo(_write(tmp_path, "demo.yaml", bad), cards)
+
+
+def test_load_combo_band_triggered_gate_empty_exists_rejected(tmp_path):
+    bad = COMBO_WITH_BAND.replace(
+        'exists: ["reports/review/*<task-slug>*-adversarial.md"]',
+        "exists: []",
+    )
+    cards = load_cards(_write(tmp_path, "cards.yaml", CARDS_YAML))
+    with pytest.raises(DeckSchemaError, match="exists"):
+        load_combo(_write(tmp_path, "demo.yaml", bad), cards)
+
+
+def test_load_combo_band_triggered_depends_on_outside_combo_rejected(tmp_path):
+    bad = COMBO_WITH_BAND.replace("depends_on: [code-review]", "depends_on: [no-such-dep]")
+    cards = load_cards(_write(tmp_path, "cards.yaml", CARDS_YAML))
+    with pytest.raises(DeckSchemaError, match="depends_on 指向 combo 外卡片"):
+        load_combo(_write(tmp_path, "demo.yaml", bad), cards)
+
+
+def test_load_combo_band_triggered_non_mapping_rejected(tmp_path):
+    bad = COMBO_WITHOUT_BAND + "  band_triggered: [oops]\n"
+    cards = load_cards(_write(tmp_path, "cards.yaml", CARDS_YAML))
+    with pytest.raises(DeckSchemaError, match="band_triggered 必須是 mapping"):
+        load_combo(_write(tmp_path, "demo.yaml", bad), cards)

--- a/tests/test_planning_sizing_score.py
+++ b/tests/test_planning_sizing_score.py
@@ -1,0 +1,247 @@
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+from paulsha_cortex.coordinator.planning import (
+    ArtifactAssessment,
+    BlockingMarker,
+    CompletenessReport,
+    PlanningArtifact,
+    QuestionPack,
+    SizingScore,
+    compute_sizing_score,
+)
+
+# #221：五維 sizing 評分（#208 設計 H.1）。三維（acceptance_surfaces/spec_stability/
+# orchestration）機械算，二維（domain_breadth/state_consistency）由 plan frontmatter 宣告。
+
+
+def _plan_artifact(domain_breadth: object = 2, state_consistency: object = 1, extra: str = "") -> PlanningArtifact:
+    text = (
+        "---\n"
+        f"domain_breadth: {domain_breadth}\n"
+        f"state_consistency: {state_consistency}\n"
+        "status: accepted\n"
+        "---\n"
+        "## Tasks\n"
+        f"{extra}"
+    )
+    return PlanningArtifact(kind="plan", ref="docs/superpowers/plans/demo.md", text=text)
+
+
+def _empty_question_pack() -> QuestionPack:
+    return QuestionPack(pack_id="qp-empty", questions=())
+
+
+def _completeness_report(*, missing_kinds=(), blocking=False) -> CompletenessReport:
+    artifact = PlanningArtifact(kind="plan", ref="docs/superpowers/plans/demo.md", text="---\nstatus: accepted\n---\n## Tasks\n- a")
+    markers = (BlockingMarker("standalone", 5, "TBD"),) if blocking else ()
+    assessment = ArtifactAssessment(artifact, not blocking, () if not blocking else ("blocking-decision",), markers)
+    return CompletenessReport(
+        complete=not missing_kinds and not blocking,
+        assessments=(assessment,),
+        missing_kinds=tuple(missing_kinds),
+        default_question_pack=_empty_question_pack(),
+    )
+
+
+def test_compute_sizing_score_full_example():
+    score = compute_sizing_score(
+        plan_artifact=_plan_artifact(domain_breadth=2, state_consistency=1),
+        completeness_report=_completeness_report(),
+        gate_spine_count=2,
+        applicable_contract_rules=frozenset({"R-09", "R-16", "R-19"}),
+        cards_count=5,
+        persona_binding_count=3,
+    )
+    assert isinstance(score, SizingScore)
+    assert score.domain_breadth == 2
+    assert score.state_consistency == 1
+    assert score.spec_stability == 2  # 全 accepted 無缺無阻塞
+    assert score.acceptance_surfaces == 2  # gate 2 + rule 3 = 5 → 上限 2
+    assert score.orchestration == 2  # cards>1 且 persona_binding>1
+    assert score.total == 9
+    assert score.to_dict()["total"] == 9
+
+
+@pytest.mark.parametrize(
+    "missing_kinds, blocking, expected",
+    [
+        ((), False, 2),
+        (("design",), False, 1),
+        ((), True, 1),
+        (("design",), True, 0),
+        (("design", "spec"), False, 0),
+    ],
+)
+def test_spec_stability_grading(missing_kinds, blocking, expected):
+    score = compute_sizing_score(
+        plan_artifact=_plan_artifact(),
+        completeness_report=_completeness_report(missing_kinds=missing_kinds, blocking=blocking),
+        gate_spine_count=0,
+        applicable_contract_rules=frozenset(),
+        cards_count=1,
+        persona_binding_count=0,
+    )
+    assert score.spec_stability == expected
+
+
+@pytest.mark.parametrize(
+    "gate_spine_count, rules, expected",
+    [
+        (0, frozenset(), 0),
+        (1, frozenset(), 1),
+        (0, frozenset({"R-09"}), 1),
+        (2, frozenset({"R-09"}), 2),
+        (1, frozenset({"R-09", "R-16", "R-19"}), 2),
+    ],
+)
+def test_acceptance_surfaces_grading(gate_spine_count, rules, expected):
+    score = compute_sizing_score(
+        plan_artifact=_plan_artifact(),
+        completeness_report=_completeness_report(),
+        gate_spine_count=gate_spine_count,
+        applicable_contract_rules=rules,
+        cards_count=1,
+        persona_binding_count=0,
+    )
+    assert score.acceptance_surfaces == expected
+
+
+@pytest.mark.parametrize(
+    "cards_count, persona_binding_count, expected",
+    [
+        (1, 0, 0),
+        (1, 1, 0),
+        (3, 1, 1),
+        (3, 2, 2),
+    ],
+)
+def test_orchestration_grading(cards_count, persona_binding_count, expected):
+    score = compute_sizing_score(
+        plan_artifact=_plan_artifact(),
+        completeness_report=_completeness_report(),
+        gate_spine_count=0,
+        applicable_contract_rules=frozenset(),
+        cards_count=cards_count,
+        persona_binding_count=persona_binding_count,
+    )
+    assert score.orchestration == expected
+
+
+def test_declared_dimension_missing_rejected():
+    text = "---\ndomain_breadth: 1\nstatus: accepted\n---\n## Tasks\n- a"
+    artifact = PlanningArtifact(kind="plan", ref="docs/superpowers/plans/demo.md", text=text)
+    with pytest.raises(ValueError, match="state_consistency"):
+        compute_sizing_score(
+            plan_artifact=artifact,
+            completeness_report=_completeness_report(),
+            gate_spine_count=0,
+            applicable_contract_rules=frozenset(),
+            cards_count=1,
+            persona_binding_count=0,
+        )
+
+
+@pytest.mark.parametrize("yaml_value", ["3", "-1", '"2"', "1.5"])
+def test_declared_dimension_out_of_range_or_wrong_type_rejected(yaml_value):
+    # 分別涵蓋：超出上界(3)、超出下界(-1)、字串型別("2")、浮點型別(1.5)。
+    text = (
+        "---\n"
+        f"domain_breadth: {yaml_value}\n"
+        "state_consistency: 1\n"
+        "status: accepted\n"
+        "---\n"
+        "## Tasks\n"
+    )
+    artifact = PlanningArtifact(kind="plan", ref="docs/superpowers/plans/demo.md", text=text)
+    with pytest.raises(ValueError):
+        compute_sizing_score(
+            plan_artifact=artifact,
+            completeness_report=_completeness_report(),
+            gate_spine_count=0,
+            applicable_contract_rules=frozenset(),
+            cards_count=1,
+            persona_binding_count=0,
+        )
+
+
+def test_declared_dimension_rejects_bool_even_though_bool_is_int_subclass():
+    with pytest.raises(ValueError, match="domain_breadth"):
+        compute_sizing_score(
+            plan_artifact=_plan_artifact(domain_breadth=True),
+            completeness_report=_completeness_report(),
+            gate_spine_count=0,
+            applicable_contract_rules=frozenset(),
+            cards_count=1,
+            persona_binding_count=0,
+        )
+
+
+def test_non_plan_artifact_kind_rejected():
+    artifact = PlanningArtifact(kind="design", ref="docs/superpowers/specs/demo-design.md", text="---\n---\n")
+    with pytest.raises(ValueError, match="plan"):
+        compute_sizing_score(
+            plan_artifact=artifact,
+            completeness_report=_completeness_report(),
+            gate_spine_count=0,
+            applicable_contract_rules=frozenset(),
+            cards_count=1,
+            persona_binding_count=0,
+        )
+
+
+def test_unknown_contract_rule_rejected():
+    with pytest.raises(ValueError, match="R-99"):
+        compute_sizing_score(
+            plan_artifact=_plan_artifact(),
+            completeness_report=_completeness_report(),
+            gate_spine_count=0,
+            applicable_contract_rules=frozenset({"R-99"}),
+            cards_count=1,
+            persona_binding_count=0,
+        )
+
+
+def test_sizing_score_rejects_out_of_range_dimension_directly():
+    with pytest.raises(ValueError):
+        SizingScore(
+            domain_breadth=3,
+            state_consistency=0,
+            acceptance_surfaces=0,
+            spec_stability=0,
+            orchestration=0,
+        )
+
+
+def test_compute_sizing_score_has_no_model_session_params():
+    # 驗收條件 3：全程不新增 model session——介面上就不該出現任何
+    # registry/probes/questioner 等會啟動 CLI 模型進程的參數。
+    sig = inspect.signature(compute_sizing_score)
+    forbidden = {
+        "registry",
+        "probes",
+        "primary",
+        "primary_questioner",
+        "secondary_planner",
+        "primary_integrator",
+        "artifact_writer",
+        "evidence_writer",
+    }
+    assert not (set(sig.parameters) & forbidden)
+
+
+def test_compute_sizing_score_is_pure_and_deterministic():
+    kwargs = dict(
+        plan_artifact=_plan_artifact(),
+        completeness_report=_completeness_report(),
+        gate_spine_count=1,
+        applicable_contract_rules=frozenset({"R-09"}),
+        cards_count=2,
+        persona_binding_count=1,
+    )
+    first = compute_sizing_score(**kwargs)
+    second = compute_sizing_score(**kwargs)
+    assert first == second

--- a/tests/test_workflow_manifest.py
+++ b/tests/test_workflow_manifest.py
@@ -57,7 +57,24 @@ def test_feature_oneshot_emits_card_bound_personas_not_global_builder() -> None:
 
     assert isinstance(result.workflow_manifest, WorkflowManifest)
     steps = result.workflow_manifest.steps
-    assert [step.card for step in steps] == [entry.ref for entry in combo.cards]
+    # gate_spine 兩層制（#221）：combo.cards 只含必要核心，adversarial-review 現在是
+    # band_triggered 加掛層——band 未傳入（None）時 compile_combo 保守地併入，行為
+    # 與改動前一致，故完整卡序仍含它，不能只比對 combo.cards（核心層）。
+    expected_card_order = [
+        "workflow-claim",
+        "brainstorming",
+        "openspec-propose",
+        "writing-plans",
+        "worktree-isolation",
+        "tdd-red",
+        "subagent-build",
+        "verification",
+        "code-review",
+        "adversarial-review",
+        "openspec-archive",
+        "policy-commit",
+    ]
+    assert [step.card for step in steps] == expected_card_order
     assert [(step.card, step.phase, step.persona) for step in steps] == [
         ("workflow-claim", "claim", "manager"),
         ("brainstorming", "define", "planner"),


### PR DESCRIPTION
## 摘要

依 `#208` 設計 H.1 落地五維 sizing 評分：`planning.py` 新增 `compute_sizing_score()`（三維機械算＋讀取二維宣告），並在 `deck/schema.py`／`deck/compile.py` 落地 gate_spine 兩層制（`band_triggered` 加掛層），把 `acceptance_surfaces` 需要的「必要核心」與「band 觸發加掛層」分離，打斷 gate_spine→acceptance_surfaces→sizing→band→gate_spine 的循環依賴。band 判定本身（Green/Yellow/Red 閾值套用）留給 `#222`；本單只產生分數與 schema 支撐。

## 變更

| 檔案 | 變更重點 |
|---|---|
| `paulsha_cortex/coordinator/planning.py` | 新增 `SizingScore`／`compute_sizing_score()`：純函式，機械算 `acceptance_surfaces`／`spec_stability`／`orchestration`，讀取 plan frontmatter 宣告的 `domain_breadth`／`state_consistency`；新增可擴充的 `_declared_dimension()` helper 供 `#212` 沿用同一驗證骨架。 |
| `paulsha_cortex/deck/schema.py` | `Combo` 新增 `band_triggered: BandTriggeredSpine \| None`；`_COMBO_KEYS` 新增鍵；`load_combo()` 對稱解析 band 層 cards/gate_spine，錯誤累積進同一 errors list、fail-closed。 |
| `paulsha_cortex/deck/compile.py` | `compile_combo()` 新增可選 `band` 參數；band 未知時保守併入加掛層（行為與今日一致），已知時依 `BAND_LEVELS` 順序比較 trigger；`--only` 明確選卡時不併入。`CompileResult` 新增 `core_gate_verify_commands`／`band_gate_verify_commands` 分離兩層 verify 指令。 |
| `paulsha_cortex/deck/data/combos/feature-oneshot.yaml` | `adversarial-review` 從核心 `cards`／`gate_spine` 移入 `band_triggered`（`trigger: yellow`），`depends_on: [code-review]` 保留原本插入位置語意。 |
| `tests/test_deck_schema_sizing_score.py`（新） | band_triggered schema 解析與 fail-closed 驗證（11 案）。 |
| `tests/test_deck_compile_sizing_score.py`（新） | compile 端 band 併入/排除、`--only` 排他、依 `depends_on` 定位插入（8 案）。 |
| `tests/test_planning_sizing_score.py`（新） | `compute_sizing_score()` 五維計算、邊界值、fail-closed、無 model session 介面驗證（26 案）。 |
| `tests/test_deck_data.py` | `test_feature_oneshot_combo_loads` 同步兩層制新結構；`mcu-feature` 補 `band_triggered is None` 斷言。 |
| `tests/test_workflow_manifest.py` | 卡序期望改用明確字面清單（`combo.cards` 現只含核心層，band 未傳入時仍保守併入 `adversarial-review`）。 |
| `changelog.d/221-sizing-score.md`（新） | R-09 fragment。 |

## 驗收條件對應

- [x] 機械三維：acceptance_surfaces（combo gate_spine 必要核心 + R-09/R-16/R-19 適用性）、spec_stability（deterministic completeness）、orchestration（card 清單 + persona_binding 數）
  → `tests/test_planning_sizing_score.py::test_acceptance_surfaces_grading`、`::test_spec_stability_grading`、`::test_orchestration_grading`、`::test_compute_sizing_score_full_example`
- [x] 宣告二維：plan 產出 `domain_breadth`、`state_consistency`
  → `tests/test_planning_sizing_score.py::test_declared_dimension_missing_rejected`、`::test_declared_dimension_out_of_range_or_wrong_type_rejected`、`::test_declared_dimension_rejects_bool_even_though_bool_is_int_subclass`
- [x] 全程不新增 model session
  → `tests/test_planning_sizing_score.py::test_compute_sizing_score_has_no_model_session_params`（介面上斷言不含 registry/probes/questioner 等參數）、`::test_compute_sizing_score_is_pure_and_deterministic`
- [x] 各維 0–2 分，總分 0–10
  → `tests/test_planning_sizing_score.py::test_sizing_score_rejects_out_of_range_dimension_directly`、`::test_compute_sizing_score_full_example`（`score.total == 9`）
- [x]（設計摘錄）gate_spine 兩層制：只有必要核心計入 acceptance_surfaces；band 未知時保守全含加掛層；`--only` 不併入
  → `tests/test_deck_schema_sizing_score.py` 全案、`tests/test_deck_compile_sizing_score.py` 全案

## 性質

feat（新增可機械消費的五維 sizing 分數與 gate_spine 兩層制 schema/compile 支撐；不含 band 判定與 claim 側路由，留給 `#222`／`#223`）。

Closes #221

## Checklist

- [x] changelog.d fragment 已新增（R-09）
- [x] 本地 preflight-ci PASS（policy + openspec + pytest）
