### PR TITLE
feat(coordinator): 新增 pre-claim readiness 檢查與凍結集

### DIFF
--- a/changelog.d/pre-claim-readiness.md
+++ b/changelog.d/pre-claim-readiness.md
@@ -1,0 +1,3 @@
+### Added
+
+- **Issue #211：新增 pre-claim readiness 檢查與凍結集**：新增 `coordinator/claim_readiness.py`，依成本排序執行六項 pre-claim 檢查（heading/OpenSpec/changelog scope → base SHA → monitor snapshot → GitHub owner → capability → live probe，live probe 最後且帶 TTL 快取），輸出為可序列化的凍結集（frozen SHA/hash 組）而非布林值；失敗分終局（policy scope 契約互斥）與可重試兩類。`work_actions._claim_action` 新增可注入的 `readiness_checker`，任一檢查失敗即在建立 workflow job/worktree/model session 之前擋下。

--- a/paulsha_cortex/coordinator/claim_readiness.py
+++ b/paulsha_cortex/coordinator/claim_readiness.py
@@ -1,0 +1,464 @@
+"""Pre-claim readiness transaction (issue #211, design #208 A.2).
+
+This module is the six-gate readiness *transaction* that must pass, in full,
+before the Manager is allowed to create a workflow job, a builder worktree,
+or a model session for a claim. It is deliberately separate from
+``coordinator/preflight.py`` (a build-time CI-parity tool that runs the repo's
+own policy/test gates) and from ``claim.py`` (pure, I/O-free claim policy):
+several of the six checks require real I/O (git fetch, GitHub API, a live
+model probe), which ``claim.py``'s docstring explicitly disallows.
+
+Design (issue #208 A.2) — checks run in *cost order*, cheapest first, so an
+expensive check is never paid for when a cheap one would already have failed:
+
+1. ``local_scope``     — heading / OpenSpec strict / changelog-scope satisfiability (pure local string)
+2. ``base_sha``        — local base SHA vs. fetched remote main (one fetch)
+3. ``monitor_snapshot`` — monitor snapshot revision + single-owner invariant (local state)
+4. ``github_owner``    — GitHub issue owner/link consistency (network, rate-limited)
+5. ``capability``      — ``capable()`` predicate table lookup (config; #209 not yet landed,
+                          so an absent lookup is an observability *bypass*, not a failure)
+6. ``live_probe``      — an actual live probe session (e.g. ``agy-plan-sandbox``); always last,
+                          and TTL-cached so a burst of claim attempts does not repeatedly pay for it.
+
+The transaction's output is a **frozen set** of SHA/hash values (never a bare
+boolean): once ``evaluate_pre_claim_readiness`` returns ready, the returned
+``FrozenReadinessSet`` is what dispatch must carry forward — in particular the
+frozen ``base_sha``, which a builder worktree must be created from instead of
+whatever ``main`` happens to be at the moment the worktree is actually built.
+This directly closes the stale-base class of defect described in hippo #18
+(#2) and #41 (v2): readiness freezes the base once, and nothing downstream
+may silently re-derive a fresher (or staler) one.
+
+Failure classification is not uniform. Most failures are retryable (heading
+gap, stale base, an owner transfer still in flight); exactly one is terminal
+and must never be retried: a *policy scope contract conflict*, where the
+work item's own frozen scope forbids something the repo's policy requires
+(the literal cause of death in hippo #18 point 9 — PR-aware R-09 requires a
+changelog fragment while the frozen scope explicitly forbade one). Terminal
+failures resolve to ``needs_human``; retryable failures resolve to Manager's
+existing ``blocked`` vocabulary so no new action name has to be learned by
+downstream consumers (CLI, cockpit).
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable, Mapping
+
+from . import verification
+from .claim import WorkAuthority, work_authority_digest
+
+FROZEN_READINESS_SET_SCHEMA = "pre-claim-readiness-frozen-set/v1"
+LIVE_PROBE_DEFAULT_TTL_SECONDS = 300.0
+CHECK_ORDER = (
+    "local_scope",
+    "base_sha",
+    "monitor_snapshot",
+    "github_owner",
+    "capability",
+    "live_probe",
+)
+
+GitRunner = verification.GitRunner
+
+
+@dataclass(frozen=True)
+class ReadinessCheckResult:
+    """One check's verdict. ``terminal`` is only meaningful when ``passed`` is False."""
+
+    name: str
+    passed: bool
+    reason: str | None = None
+    terminal: bool = False
+    observation: Mapping[str, object] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if self.name not in CHECK_ORDER:
+            raise ValueError(f"unknown pre-claim readiness check: {self.name!r}")
+        if self.passed and (self.reason is not None or self.terminal):
+            raise ValueError("a passed readiness check must not carry reason/terminal")
+        if not self.passed and not self.reason:
+            raise ValueError("a failed readiness check requires a reason")
+
+
+def _passed(name: str, **observation: object) -> ReadinessCheckResult:
+    return ReadinessCheckResult(name=name, passed=True, observation=observation)
+
+
+def _failed(name: str, reason: str, *, terminal: bool = False) -> ReadinessCheckResult:
+    return ReadinessCheckResult(name=name, passed=False, reason=reason, terminal=terminal)
+
+
+@dataclass(frozen=True)
+class FrozenReadinessSet:
+    """The serializable freeze a dispatch must carry instead of re-deriving state.
+
+    ``base_sha`` is the exact value a builder worktree must be created from;
+    ``planning_authority_hashes`` pins the WorkAuthority digest(s) readiness
+    was evaluated against so a later authority change is detectable rather
+    than silently reused.
+    """
+
+    schema: str
+    repo: str
+    work_id: str
+    base_sha: str
+    planning_authority_hashes: tuple[str, ...]
+    monitor_snapshot_revision: str
+    issue_ref: str | None
+    executor_identity: str
+    frozen_at_epoch: float
+    live_probe_ttl_cached: bool
+
+    def __post_init__(self) -> None:
+        if self.schema != FROZEN_READINESS_SET_SCHEMA:
+            raise ValueError("frozen readiness set schema invalid")
+        if not isinstance(self.base_sha, str) or verification.SAFE_SHA_RE.fullmatch(self.base_sha) is None:
+            raise ValueError("frozen readiness set base_sha invalid")
+        if not self.planning_authority_hashes or any(
+            not isinstance(value, str) or not value for value in self.planning_authority_hashes
+        ):
+            raise ValueError("frozen readiness set planning_authority_hashes invalid")
+        if not isinstance(self.monitor_snapshot_revision, str) or not self.monitor_snapshot_revision:
+            raise ValueError("frozen readiness set monitor_snapshot_revision invalid")
+        if not isinstance(self.executor_identity, str) or not self.executor_identity:
+            raise ValueError("frozen readiness set executor_identity invalid")
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "schema": self.schema,
+            "repo": self.repo,
+            "work_id": self.work_id,
+            "base_sha": self.base_sha,
+            "planning_authority_hashes": list(self.planning_authority_hashes),
+            "monitor_snapshot_revision": self.monitor_snapshot_revision,
+            "issue_ref": self.issue_ref,
+            "executor_identity": self.executor_identity,
+            "frozen_at_epoch": self.frozen_at_epoch,
+            "live_probe_ttl_cached": self.live_probe_ttl_cached,
+        }
+
+    @classmethod
+    def from_dict(cls, payload: object) -> "FrozenReadinessSet":
+        if not isinstance(payload, Mapping) or payload.get("schema") != FROZEN_READINESS_SET_SCHEMA:
+            raise ValueError("frozen readiness set schema invalid")
+        hashes = payload.get("planning_authority_hashes")
+        if not isinstance(hashes, list):
+            raise ValueError("frozen readiness set planning_authority_hashes must be a list")
+        issue_ref = payload.get("issue_ref")
+        if issue_ref is not None and not isinstance(issue_ref, str):
+            raise ValueError("frozen readiness set issue_ref invalid")
+        frozen_at = payload.get("frozen_at_epoch")
+        if not isinstance(frozen_at, (int, float)) or isinstance(frozen_at, bool):
+            raise ValueError("frozen readiness set frozen_at_epoch invalid")
+        cached = payload.get("live_probe_ttl_cached")
+        if not isinstance(cached, bool):
+            raise ValueError("frozen readiness set live_probe_ttl_cached invalid")
+        return cls(
+            schema=payload.get("schema"),
+            repo=payload.get("repo"),
+            work_id=payload.get("work_id"),
+            base_sha=payload.get("base_sha"),
+            planning_authority_hashes=tuple(hashes),
+            monitor_snapshot_revision=payload.get("monitor_snapshot_revision"),
+            issue_ref=issue_ref,
+            executor_identity=payload.get("executor_identity"),
+            frozen_at_epoch=float(frozen_at),
+            live_probe_ttl_cached=cached,
+        )
+
+
+@dataclass(frozen=True)
+class ReadinessContext:
+    """The minimal per-claim identity every probe closure is evaluated against."""
+
+    authority: WorkAuthority
+    executor_identity: str
+    issue_ref: str | None = None
+
+
+@dataclass(frozen=True)
+class ReadinessOutcome:
+    """Result of running the full six-check transaction once."""
+
+    ready: bool
+    frozen: FrozenReadinessSet | None
+    failed_check: str | None
+    reason: str | None
+    terminal: bool
+    checks_run: tuple[str, ...]
+
+
+ReadinessProbe = Callable[[ReadinessContext], ReadinessCheckResult]
+
+
+@dataclass(frozen=True)
+class ReadinessProbes:
+    """The six #208 A.2 checks, bound to concrete callables, already cost-ordered."""
+
+    local_scope: ReadinessProbe
+    base_sha: ReadinessProbe
+    monitor_snapshot: ReadinessProbe
+    github_owner: ReadinessProbe
+    capability: ReadinessProbe
+    live_probe: ReadinessProbe
+
+    def ordered(self) -> tuple[tuple[str, ReadinessProbe], ...]:
+        return tuple((name, getattr(self, name)) for name in CHECK_ORDER)
+
+
+@dataclass
+class LiveProbeCache:
+    """TTL cache in front of the live probe — the one check that really starts a session."""
+
+    ttl_seconds: float = LIVE_PROBE_DEFAULT_TTL_SECONDS
+    _entries: dict[str, tuple[ReadinessCheckResult, float]] = field(default_factory=dict)
+
+    def peek(self, key: str, *, now: float) -> ReadinessCheckResult | None:
+        cached = self._entries.get(key)
+        if cached is None:
+            return None
+        result, expiry = cached
+        if now >= expiry:
+            del self._entries[key]
+            return None
+        return result
+
+    def store(self, key: str, result: ReadinessCheckResult, *, now: float) -> None:
+        self._entries[key] = (result, now + self.ttl_seconds)
+
+
+def evaluate_pre_claim_readiness(
+    context: ReadinessContext,
+    probes: ReadinessProbes,
+    *,
+    live_probe_cache: LiveProbeCache | None = None,
+    now: Callable[[], float] = time.time,
+) -> ReadinessOutcome:
+    """Run the six checks in cost order, short-circuiting on the first failure.
+
+    On success the return carries a :class:`FrozenReadinessSet`, never a bare
+    boolean. On failure the return carries which check failed, its reason,
+    and whether the failure is terminal (``needs_human``, never retried) or
+    retryable — the caller must not build a ``ClaimCandidate`` or start a
+    workflow either way.
+    """
+
+    cache = live_probe_cache if live_probe_cache is not None else LiveProbeCache()
+    checks_run: list[str] = []
+    observations: dict[str, Mapping[str, object]] = {}
+    live_probe_cached = False
+    for name, probe in probes.ordered():
+        checks_run.append(name)
+        if name == "live_probe":
+            now_epoch = now()
+            cache_key = f"{context.authority.repo}:{context.authority.work_id}:{context.executor_identity}"
+            cached_result = cache.peek(cache_key, now=now_epoch)
+            if cached_result is not None:
+                result = cached_result
+                live_probe_cached = True
+            else:
+                result = probe(context)
+                cache.store(cache_key, result, now=now_epoch)
+        else:
+            result = probe(context)
+        if not result.passed:
+            return ReadinessOutcome(
+                ready=False,
+                frozen=None,
+                failed_check=name,
+                reason=result.reason,
+                terminal=result.terminal,
+                checks_run=tuple(checks_run),
+            )
+        observations[name] = result.observation
+
+    frozen = FrozenReadinessSet(
+        schema=FROZEN_READINESS_SET_SCHEMA,
+        repo=context.authority.repo,
+        work_id=context.authority.work_id,
+        base_sha=str(observations["base_sha"]["base_sha"]),
+        planning_authority_hashes=(work_authority_digest(context.authority),),
+        monitor_snapshot_revision=str(observations["monitor_snapshot"]["snapshot_revision"]),
+        issue_ref=context.issue_ref,
+        executor_identity=context.executor_identity,
+        frozen_at_epoch=now(),
+        live_probe_ttl_cached=live_probe_cached,
+    )
+    return ReadinessOutcome(
+        ready=True,
+        frozen=frozen,
+        failed_check=None,
+        reason=None,
+        terminal=False,
+        checks_run=tuple(checks_run),
+    )
+
+
+# --------------------------------------------------------------------------
+# Default probe factories. Each returns a closure bound to its own concrete
+# dependencies (git runner, GitHub CLI runner, capability table, live
+# prober, ...), mirroring the ``workflow_starter``-style injectable-callable
+# convention already used throughout this package.
+# --------------------------------------------------------------------------
+
+
+def local_scope_probe(
+    *,
+    heading_ok: bool = True,
+    openspec_strict_ok: bool = True,
+    changelog_required: bool = True,
+    changelog_forbidden: bool = False,
+) -> ReadinessProbe:
+    """Pure local-string check: heading presence, OpenSpec strict validity, and
+    whether the work item's own frozen scope contradicts a policy requirement
+    (e.g. R-09 changelog vs. an explicit no-changelog scope — hippo #18 #9).
+    The contradiction case is the sole *terminal* failure in the whole
+    transaction; everything else here is a retryable gap.
+    """
+
+    def _probe(context: ReadinessContext) -> ReadinessCheckResult:
+        if not heading_ok:
+            return _failed("local_scope", "heading-gap")
+        if not openspec_strict_ok:
+            return _failed("local_scope", "openspec-strict-failed")
+        if changelog_required and changelog_forbidden:
+            return _failed("local_scope", "policy-scope-conflict", terminal=True)
+        return _passed("local_scope")
+
+    return _probe
+
+
+def base_sha_probe(
+    *,
+    repo_root: str | Path,
+    remote: str = "origin",
+    branch: str = "main",
+    local_known_base_sha: str | None = None,
+    git_runner: GitRunner | None = None,
+) -> ReadinessProbe:
+    """Fetch remote main once and freeze it as ``base_sha``.
+
+    If the caller already believed a different SHA was current (a base it
+    would otherwise have built a worktree from), that mismatch is the
+    stale-base defect from hippo #18 (#2) / #41 (v2): retryable, never
+    silently accepted.
+    """
+
+    def _probe(context: ReadinessContext) -> ReadinessCheckResult:
+        fetch = verification._run_git(
+            ["-C", str(repo_root), "fetch", "--no-tags", remote, branch],
+            git_runner,
+        )
+        if fetch["status"] != "ok":
+            return _failed("base_sha", "base-sha-fetch-failed")
+        ref = verification._run_git(
+            ["-C", str(repo_root), "rev-parse", f"refs/remotes/{remote}/{branch}"],
+            git_runner,
+        )
+        sha = ref["stdout"].strip().lower()
+        if ref["status"] != "ok" or verification.SAFE_SHA_RE.fullmatch(sha) is None:
+            return _failed("base_sha", "base-sha-unreadable")
+        if local_known_base_sha is not None and local_known_base_sha.strip().lower() != sha:
+            return _failed("base_sha", "stale-base")
+        return _passed("base_sha", base_sha=sha)
+
+    return _probe
+
+
+def monitor_snapshot_probe(*, owner_count: int = 1) -> ReadinessProbe:
+    """Freeze the already-loaded monitor snapshot revision and require a single owner.
+
+    ``authority.snapshot_hash`` was already computed when the durable Monitor
+    snapshot was loaded, so this check pays no extra I/O of its own — only
+    the owner-count invariant is caller-supplied (the caller already knows
+    how many active runs claim the same identity).
+    """
+
+    def _probe(context: ReadinessContext) -> ReadinessCheckResult:
+        if owner_count != 1:
+            return _failed("monitor_snapshot", "owner-transfer-incomplete")
+        return _passed("monitor_snapshot", snapshot_revision=context.authority.snapshot_hash)
+
+    return _probe
+
+
+def github_owner_probe(
+    *,
+    runner: Callable[..., object] = subprocess.run,
+    timeout_seconds: int = 20,
+) -> ReadinessProbe:
+    """Verify the confirmed GitHub issue is still open before claiming it."""
+
+    def _probe(context: ReadinessContext) -> ReadinessCheckResult:
+        if context.issue_ref is None:
+            return _passed("github_owner", checked=False)
+        completed = runner(
+            ["gh", "api", f"repos/{context.authority.repo}/issues/{context.issue_ref}"],
+            shell=False,
+            capture_output=True,
+            text=True,
+            timeout=timeout_seconds,
+        )
+        if getattr(completed, "returncode", None) != 0:
+            return _failed("github_owner", "github-owner-link-unreadable")
+        try:
+            payload = json.loads(getattr(completed, "stdout", ""))
+            state = payload["state"]
+        except (json.JSONDecodeError, KeyError, TypeError):
+            return _failed("github_owner", "github-owner-link-malformed")
+        if not isinstance(state, str) or state.lower() != "open":
+            return _failed("github_owner", "github-owner-link-mismatch")
+        return _passed("github_owner", issue_state=state)
+
+    return _probe
+
+
+def capability_probe(
+    *, capability_lookup: Callable[[str], bool | None] | None = None,
+) -> ReadinessProbe:
+    """``capable()`` predicate table lookup (#209).
+
+    #209's routing matrix has not landed, so an absent lookup table is a
+    pluggable, observability-flagged *bypass* rather than a hard failure —
+    per the #208 A.2 design note for this exact check.
+    """
+
+    def _probe(context: ReadinessContext) -> ReadinessCheckResult:
+        if capability_lookup is None:
+            return _passed("capability", bypass="envelope_unavailable")
+        state = capability_lookup(context.executor_identity)
+        if state is False:
+            return _failed("capability", "capability-insufficient")
+        return _passed("capability", bypass=None if state is True else "envelope_unavailable")
+
+    return _probe
+
+
+def live_probe_check(*, prober: Callable[[], object] | None = None) -> ReadinessProbe:
+    """The one check that really starts a session (default: ``agy-plan-sandbox``).
+
+    Must run last (enforced by :data:`CHECK_ORDER`) and is wrapped in a TTL
+    cache by :func:`evaluate_pre_claim_readiness`, not by this probe itself,
+    so the cache is visible to callers via ``ReadinessOutcome``/frozen-set
+    provenance instead of being a private implementation detail.
+    """
+
+    def _probe(context: ReadinessContext) -> ReadinessCheckResult:
+        run = prober
+        if run is None:
+            from .model_identities import probe_agy_capability
+
+            run = probe_agy_capability
+        outcome = run()
+        ready = bool(getattr(outcome, "ready", False))
+        if not ready:
+            reason = getattr(outcome, "reason", None) or "live-probe-failed"
+            return _failed("live_probe", str(reason))
+        return _passed("live_probe")
+
+    return _probe

--- a/paulsha_cortex/coordinator/work_actions.py
+++ b/paulsha_cortex/coordinator/work_actions.py
@@ -1253,7 +1253,20 @@ def _claim_action(
     auto_label: bool | None = None,
     workflow_registry=None,
     workflow_starter=None,
+    readiness_checker=None,
 ) -> dict[str, Any]:
+    """Claim decision for one authority.
+
+    ``readiness_checker``, when supplied, is the #211 pre-claim readiness
+    transaction (see ``claim_readiness.py``): a callable of
+    ``(authority, issue_ref) -> ReadinessOutcome`` run before a
+    ``ClaimCandidate`` is even assembled. Any readiness failure returns here
+    without ever calling ``workflow_starter`` — no workflow job, worktree, or
+    model session may be created until all six checks pass. ``None`` (the
+    default) preserves prior behaviour exactly, so existing callers that do
+    not yet wire a checker are unaffected.
+    """
+
     canonical_run = None
     if workflow_registry is not None:
         all_runs = workflow_registry.list_workflow_runs()
@@ -1300,6 +1313,16 @@ def _claim_action(
     issue = args.get("issue") if args.get("issue") is not None else (
         authority.mapped_issues[0] if authority.mapped_issues else None
     )
+    if readiness_checker is not None:
+        issue_ref = f"{authority.repo}#{issue}" if issue is not None else None
+        readiness = readiness_checker(authority, issue_ref)
+        if not readiness.ready:
+            return {
+                "action": "needs_human" if readiness.terminal else "blocked",
+                "reason": readiness.reason,
+                "run": None,
+                "readiness_failed_check": readiness.failed_check,
+            }
     candidate = ClaimCandidate(
         authority=authority,
         repo=authority.repo,
@@ -1406,6 +1429,8 @@ def _claim_action(
                 ),
             }
         )
+        if readiness_checker is not None:
+            active["frozen_readiness"] = readiness.frozen.to_dict()
     return {"action": decision.action, "reason": decision.reason, "run": active}
 
 
@@ -1734,6 +1759,7 @@ def run_auto_claim_scan(
     runner: Runner = subprocess.run,
     workflow_registry=None,
     workflow_starter=None,
+    readiness_checker=None,
 ) -> list[dict[str, Any]]:
     """Project the durable Monitor snapshot into Manager-owned auto claims."""
 
@@ -1807,6 +1833,7 @@ def run_auto_claim_scan(
             auto_label=live_auto_label,
             workflow_registry=workflow_registry,
             workflow_starter=workflow_starter,
+            readiness_checker=readiness_checker,
         )
         if result["action"] not in {"ignore", "done"}:
             results.append(
@@ -2403,6 +2430,7 @@ def execute_work_action(
     state_path: str | Path | None = None,
     workflow_registry=None,
     workflow_starter=None,
+    readiness_checker=None,
 ) -> dict[str, Any]:
     action = args.get("action")
     repo = args.get("repo")
@@ -2445,6 +2473,7 @@ def execute_work_action(
             state_path=resolved_state_path,
             workflow_registry=workflow_registry,
             workflow_starter=workflow_starter,
+            readiness_checker=readiness_checker,
         )
     elif action == "retry-build":
         result = _retry_build_action(

--- a/tests/test_claim_readiness.py
+++ b/tests/test_claim_readiness.py
@@ -1,0 +1,356 @@
+"""Focused tests for the #211 pre-claim readiness transaction (issue #208 A.2)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from paulsha_cortex.coordinator import claim_readiness as cr
+from paulsha_cortex.coordinator.claim import WorkAuthority, load_work_authority
+
+
+def _authority(tmp_path: Path, *, name: str = "snapshot.json") -> WorkAuthority:
+    payload = {
+        "schema": "work-items-snapshot/v1",
+        "providers": {
+            "github": {
+                "provider_id": "github",
+                "revision": "github-rev-1",
+                "last_success_epoch": 950,
+                "degraded": False,
+            }
+        },
+        "work_items": [
+            {
+                "repo": "acme/demo",
+                "work_id": "readiness",
+                "mapped_issues": [211],
+                "mapped_prs": [],
+                "mapped_openspec": ["readiness"],
+                "mapped_todo_paths": ["docs/todo.md"],
+                "confirmed_todo": True,
+                "auto_label": True,
+                "source_revisions": ["issue:211@open", "openspec:readiness@abc"],
+            }
+        ],
+    }
+    path = tmp_path / name
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return load_work_authority(repo="acme/demo", work_id="readiness", snapshot_path=path)
+
+
+def _passing_probes(**overrides) -> cr.ReadinessProbes:
+    base = dict(
+        local_scope=cr.local_scope_probe(),
+        base_sha=cr.base_sha_probe(repo_root="/unused", git_runner=_fixed_git_runner("a" * 40)),
+        monitor_snapshot=cr.monitor_snapshot_probe(),
+        github_owner=cr.github_owner_probe(
+            runner=lambda *a, **k: SimpleNamespace(
+                returncode=0, stdout=json.dumps({"state": "open"}), stderr=""
+            )
+        ),
+        capability=cr.capability_probe(),
+        live_probe=cr.live_probe_check(prober=lambda: SimpleNamespace(ready=True)),
+    )
+    base.update(overrides)
+    return cr.ReadinessProbes(**base)
+
+
+def _fixed_git_runner(remote_sha: str):
+    def _run(args: list[str]):
+        if "fetch" in args:
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        if "rev-parse" in args:
+            return SimpleNamespace(returncode=0, stdout=f"{remote_sha}\n", stderr="")
+        raise AssertionError(f"unexpected git invocation: {args}")
+
+    return _run
+
+
+# ---------------------------------------------------------------------------
+# AC1: cost-ordered execution, live probe last + TTL cached
+# ---------------------------------------------------------------------------
+
+
+def test_checks_run_in_declared_cost_order_and_live_probe_is_last(tmp_path: Path) -> None:
+    authority = _authority(tmp_path)
+    context = cr.ReadinessContext(authority=authority, executor_identity="agy:gemini")
+    probes = _passing_probes(
+        base_sha=cr.base_sha_probe(repo_root="/unused", git_runner=_fixed_git_runner("a" * 40)),
+    )
+    outcome = cr.evaluate_pre_claim_readiness(context, probes, now=lambda: 1000.0)
+    assert outcome.checks_run == cr.CHECK_ORDER
+    assert outcome.checks_run[-1] == "live_probe"
+    assert outcome.ready is True
+
+
+def test_short_circuits_before_paying_for_more_expensive_checks(tmp_path: Path) -> None:
+    """A cheap check failing must never invoke the expensive checks after it."""
+
+    authority = _authority(tmp_path)
+    context = cr.ReadinessContext(authority=authority, executor_identity="agy:gemini")
+    called = []
+
+    def _spy(name):
+        def _probe(_context):
+            called.append(name)
+            return cr._passed(name)
+
+        return _probe
+
+    probes = cr.ReadinessProbes(
+        local_scope=lambda _ctx: cr._failed("local_scope", "heading-gap"),
+        base_sha=_spy("base_sha"),
+        monitor_snapshot=_spy("monitor_snapshot"),
+        github_owner=_spy("github_owner"),
+        capability=_spy("capability"),
+        live_probe=_spy("live_probe"),
+    )
+    outcome = cr.evaluate_pre_claim_readiness(context, probes, now=lambda: 1000.0)
+    assert outcome.ready is False
+    assert outcome.failed_check == "local_scope"
+    assert called == []
+    assert outcome.checks_run == ("local_scope",)
+
+
+def test_live_probe_ttl_cache_avoids_repeated_real_probes(tmp_path: Path) -> None:
+    authority = _authority(tmp_path)
+    context = cr.ReadinessContext(authority=authority, executor_identity="agy:gemini")
+    probe_calls = []
+
+    def _prober():
+        probe_calls.append(1)
+        return SimpleNamespace(ready=True)
+
+    probes = _passing_probes(
+        base_sha=cr.base_sha_probe(repo_root="/unused", git_runner=_fixed_git_runner("a" * 40)),
+        live_probe=cr.live_probe_check(prober=_prober),
+    )
+    cache = cr.LiveProbeCache(ttl_seconds=100.0)
+    first = cr.evaluate_pre_claim_readiness(context, probes, live_probe_cache=cache, now=lambda: 1000.0)
+    second = cr.evaluate_pre_claim_readiness(context, probes, live_probe_cache=cache, now=lambda: 1010.0)
+    assert first.ready and second.ready
+    assert len(probe_calls) == 1
+    assert first.frozen.live_probe_ttl_cached is False
+    assert second.frozen.live_probe_ttl_cached is True
+
+
+def test_live_probe_ttl_cache_expires_and_reprobes(tmp_path: Path) -> None:
+    authority = _authority(tmp_path)
+    context = cr.ReadinessContext(authority=authority, executor_identity="agy:gemini")
+    probe_calls = []
+
+    def _prober():
+        probe_calls.append(1)
+        return SimpleNamespace(ready=True)
+
+    probes = _passing_probes(
+        base_sha=cr.base_sha_probe(repo_root="/unused", git_runner=_fixed_git_runner("a" * 40)),
+        live_probe=cr.live_probe_check(prober=_prober),
+    )
+    cache = cr.LiveProbeCache(ttl_seconds=5.0)
+    cr.evaluate_pre_claim_readiness(context, probes, live_probe_cache=cache, now=lambda: 1000.0)
+    cr.evaluate_pre_claim_readiness(context, probes, live_probe_cache=cache, now=lambda: 1010.0)
+    assert len(probe_calls) == 2
+
+
+# ---------------------------------------------------------------------------
+# AC2: output is a frozen set carrying SHA/hash values, not a boolean
+# ---------------------------------------------------------------------------
+
+
+def test_success_returns_frozen_set_not_a_boolean(tmp_path: Path) -> None:
+    authority = _authority(tmp_path)
+    context = cr.ReadinessContext(
+        authority=authority, executor_identity="agy:gemini", issue_ref="acme/demo#211"
+    )
+    remote_sha = "c" * 40
+    probes = _passing_probes(base_sha=cr.base_sha_probe(repo_root="/unused", git_runner=_fixed_git_runner(remote_sha)))
+    outcome = cr.evaluate_pre_claim_readiness(context, probes, now=lambda: 1234.5)
+    assert isinstance(outcome, cr.ReadinessOutcome)
+    assert isinstance(outcome.frozen, cr.FrozenReadinessSet)
+    assert outcome.frozen.base_sha == remote_sha
+    assert outcome.frozen.planning_authority_hashes
+    assert outcome.frozen.monitor_snapshot_revision == authority.snapshot_hash
+    assert outcome.frozen.issue_ref == "acme/demo#211"
+    assert outcome.frozen.frozen_at_epoch == 1234.5
+
+
+def test_frozen_set_round_trips_through_dict(tmp_path: Path) -> None:
+    authority = _authority(tmp_path)
+    context = cr.ReadinessContext(authority=authority, executor_identity="agy:gemini")
+    probes = _passing_probes(base_sha=cr.base_sha_probe(repo_root="/unused", git_runner=_fixed_git_runner("d" * 40)))
+    outcome = cr.evaluate_pre_claim_readiness(context, probes, now=lambda: 42.0)
+    payload = outcome.frozen.to_dict()
+    restored = cr.FrozenReadinessSet.from_dict(payload)
+    assert restored == outcome.frozen
+
+
+def test_frozen_set_rejects_malformed_payload() -> None:
+    with pytest.raises(ValueError, match="schema invalid"):
+        cr.FrozenReadinessSet.from_dict({"schema": "wrong"})
+
+
+# ---------------------------------------------------------------------------
+# AC3: builder worktree must use the frozen base SHA — stale base is caught,
+# and a later drift in "current remote main" cannot silently reappear once frozen.
+# ---------------------------------------------------------------------------
+
+
+def test_stale_local_base_is_rejected_before_freeze(tmp_path: Path) -> None:
+    authority = _authority(tmp_path)
+    context = cr.ReadinessContext(authority=authority, executor_identity="agy:gemini")
+    probes = _passing_probes(
+        base_sha=cr.base_sha_probe(
+            repo_root="/unused",
+            git_runner=_fixed_git_runner("e" * 40),
+            local_known_base_sha="f" * 40,
+        ),
+    )
+    outcome = cr.evaluate_pre_claim_readiness(context, probes, now=lambda: 1000.0)
+    assert outcome.ready is False
+    assert outcome.failed_check == "base_sha"
+    assert outcome.reason == "stale-base"
+    assert outcome.frozen is None
+    assert outcome.terminal is False
+
+
+def test_frozen_base_sha_is_immutable_once_captured(tmp_path: Path) -> None:
+    """Once frozen, a later drift in what remote main *now* points to must not
+    silently change the already-returned frozen value: it is a value object,
+    not a live pointer back at the repo."""
+
+    authority = _authority(tmp_path)
+    context = cr.ReadinessContext(authority=authority, executor_identity="agy:gemini")
+    first_sha = "1" * 40
+    probes = _passing_probes(base_sha=cr.base_sha_probe(repo_root="/unused", git_runner=_fixed_git_runner(first_sha)))
+    outcome = cr.evaluate_pre_claim_readiness(context, probes, now=lambda: 1000.0)
+    frozen = outcome.frozen
+    assert frozen.base_sha == first_sha
+
+    # Remote main has since moved; the frozen value from the earlier
+    # transaction must be unaffected (dataclass is frozen too).
+    with pytest.raises(Exception):
+        frozen.base_sha = "2" * 40  # type: ignore[misc]
+    assert frozen.base_sha == first_sha
+
+
+# ---------------------------------------------------------------------------
+# AC4: terminal vs. retryable classification; policy-scope conflict is terminal
+# ---------------------------------------------------------------------------
+
+
+def test_heading_gap_is_retryable_not_terminal(tmp_path: Path) -> None:
+    authority = _authority(tmp_path)
+    context = cr.ReadinessContext(authority=authority, executor_identity="agy:gemini")
+    probes = _passing_probes(local_scope=cr.local_scope_probe(heading_ok=False))
+    outcome = cr.evaluate_pre_claim_readiness(context, probes, now=lambda: 1000.0)
+    assert outcome.ready is False
+    assert outcome.reason == "heading-gap"
+    assert outcome.terminal is False
+
+
+def test_policy_scope_conflict_is_terminal_and_never_retried(tmp_path: Path) -> None:
+    """hippo #18 point 9: R-09 requires a changelog fragment while the frozen
+    scope explicitly forbids one — an unsatisfiable contract that must resolve
+    straight to needs_human, never loop back into a retry."""
+
+    authority = _authority(tmp_path)
+    context = cr.ReadinessContext(authority=authority, executor_identity="agy:gemini")
+    probes = _passing_probes(
+        local_scope=cr.local_scope_probe(changelog_required=True, changelog_forbidden=True),
+    )
+    outcome = cr.evaluate_pre_claim_readiness(context, probes, now=lambda: 1000.0)
+    assert outcome.ready is False
+    assert outcome.failed_check == "local_scope"
+    assert outcome.reason == "policy-scope-conflict"
+    assert outcome.terminal is True
+
+
+def test_owner_transfer_incomplete_is_retryable(tmp_path: Path) -> None:
+    authority = _authority(tmp_path)
+    context = cr.ReadinessContext(authority=authority, executor_identity="agy:gemini")
+    probes = _passing_probes(
+        base_sha=cr.base_sha_probe(repo_root="/unused", git_runner=_fixed_git_runner("a" * 40)),
+        monitor_snapshot=cr.monitor_snapshot_probe(owner_count=2),
+    )
+    outcome = cr.evaluate_pre_claim_readiness(context, probes, now=lambda: 1000.0)
+    assert outcome.ready is False
+    assert outcome.reason == "owner-transfer-incomplete"
+    assert outcome.terminal is False
+
+
+def test_capability_unavailable_is_an_observable_bypass_not_a_failure(tmp_path: Path) -> None:
+    """#209's capability table has not landed; absent lookup must pass through
+    (with an observability marker), not fail closed."""
+
+    authority = _authority(tmp_path)
+    context = cr.ReadinessContext(authority=authority, executor_identity="agy:gemini")
+    probes = _passing_probes(
+        base_sha=cr.base_sha_probe(repo_root="/unused", git_runner=_fixed_git_runner("a" * 40)),
+        capability=cr.capability_probe(capability_lookup=None),
+    )
+    outcome = cr.evaluate_pre_claim_readiness(context, probes, now=lambda: 1000.0)
+    assert outcome.ready is True
+
+
+def test_capability_insufficient_fails_closed(tmp_path: Path) -> None:
+    authority = _authority(tmp_path)
+    context = cr.ReadinessContext(authority=authority, executor_identity="agy:gemini")
+    probes = _passing_probes(
+        base_sha=cr.base_sha_probe(repo_root="/unused", git_runner=_fixed_git_runner("a" * 40)),
+        capability=cr.capability_probe(capability_lookup=lambda _identity: False),
+    )
+    outcome = cr.evaluate_pre_claim_readiness(context, probes, now=lambda: 1000.0)
+    assert outcome.ready is False
+    assert outcome.reason == "capability-insufficient"
+    assert outcome.terminal is False
+
+
+def test_live_probe_failure_is_retryable(tmp_path: Path) -> None:
+    authority = _authority(tmp_path)
+    context = cr.ReadinessContext(authority=authority, executor_identity="agy:gemini")
+    probes = _passing_probes(
+        base_sha=cr.base_sha_probe(repo_root="/unused", git_runner=_fixed_git_runner("a" * 40)),
+        live_probe=cr.live_probe_check(prober=lambda: SimpleNamespace(ready=False, reason="models-probe-failed")),
+    )
+    outcome = cr.evaluate_pre_claim_readiness(context, probes, now=lambda: 1000.0)
+    assert outcome.ready is False
+    assert outcome.failed_check == "live_probe"
+    assert outcome.reason == "models-probe-failed"
+    assert outcome.terminal is False
+
+
+def test_github_owner_link_mismatch_blocks_before_capability_and_live_probe(tmp_path: Path) -> None:
+    authority = _authority(tmp_path)
+    context = cr.ReadinessContext(
+        authority=authority, executor_identity="agy:gemini", issue_ref="acme/demo#211"
+    )
+    probes = _passing_probes(
+        base_sha=cr.base_sha_probe(repo_root="/unused", git_runner=_fixed_git_runner("a" * 40)),
+        github_owner=cr.github_owner_probe(
+            runner=lambda *a, **k: SimpleNamespace(returncode=0, stdout=json.dumps({"state": "closed"}), stderr="")
+        ),
+    )
+    outcome = cr.evaluate_pre_claim_readiness(context, probes, now=lambda: 1000.0)
+    assert outcome.ready is False
+    assert outcome.failed_check == "github_owner"
+    assert outcome.reason == "github-owner-link-mismatch"
+
+
+# ---------------------------------------------------------------------------
+# ReadinessCheckResult invariants
+# ---------------------------------------------------------------------------
+
+
+def test_check_result_rejects_passed_with_reason() -> None:
+    with pytest.raises(ValueError, match="must not carry reason"):
+        cr.ReadinessCheckResult(name="local_scope", passed=True, reason="oops")
+
+
+def test_check_result_rejects_failed_without_reason() -> None:
+    with pytest.raises(ValueError, match="requires a reason"):
+        cr.ReadinessCheckResult(name="local_scope", passed=False)

--- a/tests/test_pre_claim_readiness_gate.py
+++ b/tests/test_pre_claim_readiness_gate.py
@@ -1,0 +1,274 @@
+"""Focused tests for the #211 readiness gate mounted on work_actions._claim_action.
+
+AC5 (issue #211): any pre-claim readiness check failure must not create a
+workflow job, worktree, or model session. These tests assert the gate blocks
+*before* ``workflow_starter`` is ever invoked, for both the manual claim path
+(``_claim_action`` / ``execute_work_action``) and the automatic scan path
+(``run_auto_claim_scan``).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from paulsha_cortex.coordinator import claim_readiness as cr
+from paulsha_cortex.coordinator import work_actions
+from paulsha_cortex.coordinator.claim import WorkAuthority
+
+
+def _never_start(*_args, **_kwargs):
+    raise AssertionError("readiness failure must not create a workflow job/worktree/model session")
+
+
+def _snapshot(path: Path, *, issues=(211,), auto_label: bool = True) -> Path:
+    path.write_text(
+        json.dumps(
+            {
+                "schema": "work-items-snapshot/v1",
+                "providers": {
+                    "github": {
+                        "provider_id": "github",
+                        "revision": "gh-1",
+                        "last_success_epoch": 100,
+                        "degraded": False,
+                    }
+                },
+                "work_items": [
+                    {
+                        "repo": "acme/demo",
+                        "work_id": "demo",
+                        "mapped_issues": list(issues),
+                        "mapped_prs": [],
+                        "mapped_openspec": ["demo"],
+                        "mapped_todo_paths": ["docs/todo.md"],
+                        "confirmed_todo": True,
+                        "auto_label": auto_label,
+                        "source_revisions": ["issue:211@open", "openspec:demo@1"],
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _authority(tmp_path: Path) -> WorkAuthority:
+    snapshot = _snapshot(tmp_path / "snapshot.json")
+    return work_actions.load_work_authority(repo="acme/demo", work_id="demo", snapshot_path=snapshot)
+
+
+def _retryable_outcome(reason: str = "stale-base", failed_check: str = "base_sha") -> cr.ReadinessOutcome:
+    return cr.ReadinessOutcome(
+        ready=False,
+        frozen=None,
+        failed_check=failed_check,
+        reason=reason,
+        terminal=False,
+        checks_run=("local_scope", failed_check),
+    )
+
+
+def _terminal_outcome() -> cr.ReadinessOutcome:
+    return cr.ReadinessOutcome(
+        ready=False,
+        frozen=None,
+        failed_check="local_scope",
+        reason="policy-scope-conflict",
+        terminal=True,
+        checks_run=("local_scope",),
+    )
+
+
+def _passing_outcome(authority: WorkAuthority) -> cr.ReadinessOutcome:
+    from paulsha_cortex.coordinator.claim import work_authority_digest
+
+    frozen = cr.FrozenReadinessSet(
+        schema=cr.FROZEN_READINESS_SET_SCHEMA,
+        repo=authority.repo,
+        work_id=authority.work_id,
+        base_sha="a" * 40,
+        planning_authority_hashes=(work_authority_digest(authority),),
+        monitor_snapshot_revision=authority.snapshot_hash,
+        issue_ref="acme/demo#211",
+        executor_identity="agy:gemini",
+        frozen_at_epoch=1000.0,
+        live_probe_ttl_cached=False,
+    )
+    return cr.ReadinessOutcome(
+        ready=True,
+        frozen=frozen,
+        failed_check=None,
+        reason=None,
+        terminal=False,
+        checks_run=cr.CHECK_ORDER,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Backward compatibility: no readiness_checker supplied changes nothing.
+# ---------------------------------------------------------------------------
+
+
+def test_claim_action_without_readiness_checker_behaves_as_before(tmp_path: Path) -> None:
+    authority = _authority(tmp_path)
+    started = []
+
+    def starter(authority_arg, claim_key, reason):
+        started.append((authority_arg.work_id, claim_key, reason))
+        return _FakeRun(claim_key)
+
+    result = work_actions._claim_action(
+        args={"action": "start", "issue": 211},
+        authority=authority,
+        now_epoch=200,
+        state_path=tmp_path / "runs.json",
+        workflow_starter=starter,
+    )
+    assert result["action"] == "claim"
+    assert len(started) == 1
+
+
+class _FakeRun:
+    def __init__(self, claim_key: str) -> None:
+        self.claim_key = claim_key
+        self.run_id = "workflow-" + "a" * 20
+        self.repo = "acme/demo"
+        self.work_id = "demo"
+        self.status = "ongoing"
+        self.current_phase = "define"
+        self.facets = ()
+        self.issue_refs = ("acme/demo#211",)
+        self.openspec_refs = ("demo",)
+
+    def to_dict(self) -> dict:
+        return {
+            "run_id": self.run_id,
+            "repo": self.repo,
+            "work_id": self.work_id,
+            "claim_key": self.claim_key,
+            "status": self.status,
+        }
+
+
+# ---------------------------------------------------------------------------
+# AC5: any readiness failure blocks before workflow_starter is ever called.
+# ---------------------------------------------------------------------------
+
+
+def test_retryable_readiness_failure_blocks_without_creating_a_run(tmp_path: Path) -> None:
+    authority = _authority(tmp_path)
+    result = work_actions._claim_action(
+        args={"action": "start", "issue": 211},
+        authority=authority,
+        now_epoch=200,
+        state_path=tmp_path / "runs.json",
+        workflow_starter=_never_start,
+        readiness_checker=lambda _authority, _issue_ref: _retryable_outcome(),
+    )
+    assert result == {
+        "action": "blocked",
+        "reason": "stale-base",
+        "run": None,
+        "readiness_failed_check": "base_sha",
+    }
+
+
+def test_terminal_readiness_failure_routes_to_needs_human_without_a_run(tmp_path: Path) -> None:
+    authority = _authority(tmp_path)
+    result = work_actions._claim_action(
+        args={"action": "start", "issue": 211},
+        authority=authority,
+        now_epoch=200,
+        state_path=tmp_path / "runs.json",
+        workflow_starter=_never_start,
+        readiness_checker=lambda _authority, _issue_ref: _terminal_outcome(),
+    )
+    assert result["action"] == "needs_human"
+    assert result["reason"] == "policy-scope-conflict"
+    assert result["run"] is None
+    # Not routed through the normal needs_human tracking run: no run_id at
+    # all means there is nothing to feed back into a retry loop.
+    assert "run_id" not in result
+
+
+def test_readiness_checker_receives_confirmed_issue_ref(tmp_path: Path) -> None:
+    authority = _authority(tmp_path)
+    seen = []
+
+    def checker(_authority, issue_ref):
+        seen.append(issue_ref)
+        return _retryable_outcome()
+
+    work_actions._claim_action(
+        args={"action": "start", "issue": 211},
+        authority=authority,
+        now_epoch=200,
+        state_path=tmp_path / "runs.json",
+        workflow_starter=_never_start,
+        readiness_checker=checker,
+    )
+    assert seen == ["acme/demo#211"]
+
+
+def test_automatic_scan_readiness_failure_never_reads_workflow_starter(tmp_path: Path) -> None:
+    """The automatic (cron) claim path must honour the same gate."""
+
+    snapshot = _snapshot(tmp_path / "snapshot.json")
+    state = tmp_path / "runs.json"
+
+    def runner(argv, **kwargs):
+        from types import SimpleNamespace
+
+        return SimpleNamespace(
+            returncode=0,
+            stdout=json.dumps({"labels": [{"name": "cortex:auto-on-going"}]}),
+            stderr="",
+        )
+
+    from paulsha_cortex.coordinator.registry import JobRegistry
+
+    registry = JobRegistry(state_path=state.parent / "jobs.json")
+    results = work_actions.run_auto_claim_scan(
+        snapshot_path=snapshot,
+        state_path=state,
+        now=lambda: 200,
+        runner=runner,
+        workflow_registry=registry,
+        workflow_starter=_never_start,
+        readiness_checker=lambda _authority, _issue_ref: _terminal_outcome(),
+    )
+    assert len(results) == 1
+    assert results[0]["action"] == "needs_human"
+    assert results[0]["reason"] == "policy-scope-conflict"
+
+
+# ---------------------------------------------------------------------------
+# AC2 (frozen set, not a boolean) round-trips through the claim result.
+# ---------------------------------------------------------------------------
+
+
+def test_passing_readiness_attaches_frozen_set_to_the_claimed_run(tmp_path: Path) -> None:
+    authority = _authority(tmp_path)
+    outcome = _passing_outcome(authority)
+    started = []
+
+    def starter(authority_arg, claim_key, reason):
+        started.append(claim_key)
+        return _FakeRun(claim_key)
+
+    result = work_actions._claim_action(
+        args={"action": "start", "issue": 211},
+        authority=authority,
+        now_epoch=200,
+        state_path=tmp_path / "runs.json",
+        workflow_starter=starter,
+        readiness_checker=lambda _authority, _issue_ref: outcome,
+    )
+    assert result["action"] == "claim"
+    assert len(started) == 1
+    assert result["run"]["frozen_readiness"] == outcome.frozen.to_dict()
+    assert result["run"]["frozen_readiness"]["base_sha"] == "a" * 40


### PR DESCRIPTION
## 摘要

實作 `#208` 設計 A.2：新增 pre-claim readiness 六項檢查與凍結集，並在 `work_actions._claim_action` 掛載檢查點。任一檢查失敗即在建立 workflow job／worktree／model session **之前**擋下；輸出為可序列化的凍結集（frozen SHA/hash 組），而非布林值。失敗分「終局」（policy scope 契約互斥）與「可重試」兩類，不一律回 `needs_human`。

新模組刻意不沿用既有 `coordinator/preflight.py`（build 期跑 repo test/policy 的工具，語意不同）；也不放進 `claim.py` 本體（`claim.py` docstring 明講是 pure policy，六項檢查有一半需要 I/O）。

## 變更

| 檔案 | 變更 |
|---|---|
| `paulsha_cortex/coordinator/claim_readiness.py`（新增） | 六項 cost-ordered 檢查（`local_scope`／`base_sha`／`monitor_snapshot`／`github_owner`／`capability`／`live_probe`）、`ReadinessCheckResult`／`FrozenReadinessSet`（含 `to_dict`/`from_dict`）／`ReadinessOutcome`／`LiveProbeCache`（TTL）、`evaluate_pre_claim_readiness` 執行器，以及六個 default probe factory |
| `paulsha_cortex/coordinator/work_actions.py` | `_claim_action`／`run_auto_claim_scan`／`execute_work_action` 新增可注入的 `readiness_checker`（預設 `None`，維持既有行為不變）；不通過時在組出 `ClaimCandidate` 前直接回傳 `blocked`／`needs_human`，不呼叫 `workflow_starter`；通過時把凍結集掛進回傳的 `run["frozen_readiness"]` |
| `tests/test_claim_readiness.py`（新增） | 純模組測試：cost-order 執行＋短路、live probe 最後＋TTL 快取（含過期重探）、凍結集非布林／可序列化／base_sha 不可變、終局／可重試分類（含 policy-scope-conflict 終局） |
| `tests/test_pre_claim_readiness_gate.py`（新增） | 掛載點測試：預設不注入時行為不變、可重試／終局失敗皆不建立 workflow_starter 呼叫（含 auto-scan 路徑）、通過時凍結集正確附掛 |
| `changelog.d/pre-claim-readiness.md`（新增） | R-09 changelog fragment |

## 驗收條件對應

- [x] 依成本排序執行六項檢查，live probe 為最後一項且帶 TTL 快取
      → `test_checks_run_in_declared_cost_order_and_live_probe_is_last`、`test_short_circuits_before_paying_for_more_expensive_checks`、`test_live_probe_ttl_cache_avoids_repeated_real_probes`、`test_live_probe_ttl_cache_expires_and_reprobes`（`tests/test_claim_readiness.py`）
- [x] 輸出為凍結集而非布林值；dispatch 攜帶凍結的 SHA/hash 組
      → `test_success_returns_frozen_set_not_a_boolean`、`test_frozen_set_round_trips_through_dict`（`tests/test_claim_readiness.py`）；`test_passing_readiness_attaches_frozen_set_to_the_claimed_run`（`tests/test_pre_claim_readiness_gate.py`）
- [x] builder worktree 以凍結 base SHA 建立，stale base 不可重現
      → `test_stale_local_base_is_rejected_before_freeze`、`test_frozen_base_sha_is_immutable_once_captured`（`tests/test_claim_readiness.py`）。本單交付凍結集資料結構本身（含 `base_sha` 欄位）；實際 builder worktree 建立邏輯依 `docs/superpowers/workstreams/cost-governance-cluster/todo.md` 的檔案衝突序列屬 `#213`（freeze point 位移）之後續工作，不在本單範圍
- [x] 失敗分終局／可重試；policy scope 契約互斥判為終局，不進重試迴路
      → `test_policy_scope_conflict_is_terminal_and_never_retried`、`test_heading_gap_is_retryable_not_terminal`、`test_owner_transfer_incomplete_is_retryable`、`test_capability_insufficient_fails_closed`、`test_live_probe_failure_is_retryable`（`tests/test_claim_readiness.py`）；`test_terminal_readiness_failure_routes_to_needs_human_without_a_run`（`tests/test_pre_claim_readiness_gate.py`）
- [x] 任一檢查失敗不得建立 workflow job／worktree／model session
      → `test_retryable_readiness_failure_blocks_without_creating_a_run`、`test_terminal_readiness_failure_routes_to_needs_human_without_a_run`、`test_automatic_scan_readiness_failure_never_reads_workflow_starter`（`tests/test_pre_claim_readiness_gate.py`，皆以會 raise `AssertionError` 的 `workflow_starter` 佐證從未被呼叫）

## 性質

feat（新功能）：新增模組 + 既有函式新增可選注入參數，預設值維持既有行為（`test_claim_action_without_readiness_checker_behaves_as_before` 佐證），不影響任何既有呼叫端。

Closes #211

## Checklist

- [x] changelog.d fragment 已新增（R-09）
- [x] 本地 preflight-ci PASS（policy + openspec + pytest）
