### PR TITLE
feat(coordinator/planning): 新增 plan review gate 三項判定

### DIFF
--- a/changelog.d/212-plan-review-gate.md
+++ b/changelog.d/212-plan-review-gate.md
@@ -1,0 +1,3 @@
+### Added
+
+- **Issue #212：新增 plan review gate 三項判定**：`planning.py` 新增 `plan_review_gate()`，依 cost order 跑完整性（每個 acceptance surface 有對應 task）／契約相容性（plan scope 與呼叫端算好的 R-09/R-16/R-19/R-22 相容，明確排除項目與規則衝突時是 hippo #18 第 9 條的 terminal case）／封套相符（plan 宣告的 `invariant_count`／`artifact_classes` 落在 #209 builder 封套內，封套資料缺席時記 `envelope_unavailable` 可觀測 bypass）三項判定，任一不過即 fail closed；`completion.py` 新增 `final_defect_locus` 訊號欄位，記錄 final 才發現問題出在 plan 而非 candidate 的訊號（供 #137 度量 plan review 漏檢），純 provenance 不影響 semantic match。

--- a/paulsha_cortex/coordinator/completion.py
+++ b/paulsha_cortex/coordinator/completion.py
@@ -25,6 +25,10 @@ VOLATILE_WORK_AUTHORITY_FIELDS = frozenset(
 # 故整個欄位排除在 semantic match 之外——避免良性 reuse 被誤判為衝突而觸發
 # quarantine（比照 VOLATILE_WORK_AUTHORITY_FIELDS 的做法）。
 REUSED_FROM_FIELDS = frozenset({"run_id", "job_id", "evidence_hash"})
+# #212：final 發現「plan 錯而非 candidate 錯」的訊號欄位，供 #137 度量 plan review
+# 漏檢（plan_review_gate 判定通過，但 final 才發現問題其實出在 plan）。純
+# provenance，不影響既有 completion 語意，semantic match 排除比照 reused_from。
+VALID_FINAL_DEFECT_LOCI = frozenset({"plan", "candidate"})
 
 
 def classify_completion(*, exit_code: int, last_jsonl_line: str | None) -> str:
@@ -217,6 +221,12 @@ def _normalize_reused_from(value: object) -> dict[str, str]:
     }
 
 
+def _normalize_final_defect_locus(value: object) -> str:
+    if value not in VALID_FINAL_DEFECT_LOCI:
+        raise ValueError(f"completion final_defect_locus must be one of {sorted(VALID_FINAL_DEFECT_LOCI)}")
+    return value
+
+
 def validate_completion_record(payload: object) -> dict[str, Any]:
     if not isinstance(payload, dict):
         raise ValueError("completion record must be an object")
@@ -245,7 +255,7 @@ def validate_completion_record(payload: object) -> dict[str, Any]:
     missing = sorted(required - set(payload))
     if missing:
         raise ValueError(f"completion record missing keys: {', '.join(missing)}")
-    extras = set(payload) - required - {"work_authority", "reused_from"}
+    extras = set(payload) - required - {"work_authority", "reused_from", "final_defect_locus"}
     if extras:
         raise ValueError(f"completion record unexpected key: {sorted(extras)[0]}")
     if payload.get("schema_version") != COMPLETION_SCHEMA_VERSION:
@@ -293,6 +303,8 @@ def validate_completion_record(payload: object) -> dict[str, Any]:
         normalized["work_authority"] = _normalize_work_authority(payload["work_authority"])
     if "reused_from" in payload:
         normalized["reused_from"] = _normalize_reused_from(payload["reused_from"])
+    if "final_defect_locus" in payload:
+        normalized["final_defect_locus"] = _normalize_final_defect_locus(payload["final_defect_locus"])
 
     reviewer_job_id = normalized["reviewer_job_id"]
     review_path = normalized["review_evaluation_path"]
@@ -347,6 +359,8 @@ def completion_records_semantically_match(existing: object, incoming: object) ->
     incoming_authority = _semantic_work_authority(incoming_normalized.pop("work_authority", None))
     existing_normalized.pop("reused_from", None)
     incoming_normalized.pop("reused_from", None)
+    existing_normalized.pop("final_defect_locus", None)
+    incoming_normalized.pop("final_defect_locus", None)
     return existing_normalized == incoming_normalized and existing_authority == incoming_authority
 
 

--- a/paulsha_cortex/coordinator/planning.py
+++ b/paulsha_cortex/coordinator/planning.py
@@ -4,7 +4,7 @@ import hashlib
 import json
 import os
 import re
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Callable, Iterable, Mapping
 
@@ -274,6 +274,291 @@ def assess_planning_completeness(artifacts: Iterable[PlanningArtifact]) -> Compl
     pack = _build_default_question_pack(assessments, missing_kinds)
     has_blockers = any(assessment.blocking_markers for assessment in assessments)
     return CompletenessReport(not missing_kinds and not has_blockers, assessments, missing_kinds, pack)
+
+
+# --- #208 設計 A.1 第 3 點／#212：plan review gate（三項判定） ----------------
+#
+# 三份文件皆 accepted（assess_planning_completeness 通過）之後才跑的一層語意審查，
+# 是「唯一需要模型的前置閘」，但本函式落地的只是機械骨架與判定契約——三項判定中
+# 可機械判定的部分（契約相容性、封套查表）直接機械做；plan review 的 model
+# dispatch（effort=high、prompt cache）沿用既有 planning 流程身分，不在此模組。
+#
+# 三項判定（cost order，任一不過即 fail closed）：
+#   1. completeness            —— plan 為每個 acceptance surface 備有對應 task
+#   2. contract_compatibility  —— plan scope 與呼叫端算好的 R-09/R-16/R-19/R-22
+#                                  等 applicable_contract_rules 相容；plan
+#                                  frontmatter 明確排除的項目與規則要求衝突時，
+#                                  是 hippo #18 第 9 條要在此攔截的 terminal case
+#   3. envelope                —— plan 宣告的 invariant_count／artifact_classes
+#                                  落在 #209 builder 封套內；封套資料缺席
+#                                  （#209 未落地）時記 envelope_unavailable 並以
+#                                  可觀測 bypass 通過（對齊 #202 定案），有資料
+#                                  而超封套才 fail closed
+#
+# 失敗分類比照 claim_readiness.ReadinessOutcome：只有 policy-scope-conflict 是
+# terminal（回傳給呼叫端轉 needs_human），其餘（含 envelope 超界）都是可重試
+# 訊號（回派 planner）——這與 claim_readiness.capability_probe 對「capability
+# 不足」同樣視為可重試、而非 terminal 的既有先例一致。
+PLAN_REVIEW_CHECK_ORDER = ("completeness", "contract_compatibility", "envelope")
+
+# 契約相容性的規則→Tasks 關鍵字對照（啟發式子字串比對，大小寫不敏感）。
+# 只涵蓋 policy checklist 目前對「plan 尚未有程式碼變更」語意有意義的四條規則；
+# 是否適用（哪些規則命中）由呼叫端依 scope/code_paths 算好以 frozenset[str] 餵入，
+# 與 #221 compute_sizing_score 的 applicable_contract_rules 共用同一份計算結果。
+_CONTRACT_RULE_TASK_KEYWORDS: dict[str, frozenset[str]] = {
+    "R-09": frozenset({"changelog"}),
+    "R-16": frozenset({"cli"}),
+    "R-19": frozenset({"test", "測試"}),
+    "R-22": frozenset({"doc", "docs", "文件"}),
+}
+CONTRACT_COMPATIBILITY_RULES = frozenset(_CONTRACT_RULE_TASK_KEYWORDS)
+
+
+def _collect_task_items(body: str) -> tuple[str, ...]:
+    """收集 Tasks/Task heading 下的清單項目文字。
+
+    比照 _headings_and_markers() 對 Open Questions 的 heading-level 追蹤手法
+    （鎖定 heading、往下收集清單項目、遇到同級或更高層 heading 才停止），
+    抽出一個 Tasks 版本；152-156 行 _has_required_heading 已有的 task heading
+    判斷（"task"/"tasks" 或 "task " 前綴）在這裡重用同一組字面比對規則。
+    """
+    items: list[str] = []
+    in_fence = False
+    fence_token: str | None = None
+    task_level: int | None = None
+    for raw in body.splitlines():
+        stripped = raw.strip()
+        if stripped.startswith(("```", "~~~")):
+            token = stripped[:3]
+            if not in_fence:
+                in_fence = True
+                fence_token = token
+            elif token == fence_token:
+                in_fence = False
+                fence_token = None
+            continue
+        if in_fence:
+            continue
+        heading = _HEADING_RE.match(stripped)
+        if heading:
+            level = len(heading.group(1))
+            title = heading.group(2).strip().casefold()
+            title = re.sub(r"^\d+(?:\.\d+)*[.)]?\s+", "", title).rstrip(":：")
+            if title in {"task", "tasks"} or title.startswith("task "):
+                task_level = level
+            elif task_level is not None and level <= task_level:
+                task_level = None
+            continue
+        if task_level is None:
+            continue
+        item = _LIST_ITEM_RE.match(stripped)
+        if item:
+            items.append(item.group(1).strip())
+    return tuple(items)
+
+
+@dataclass(frozen=True)
+class PlanReviewCheckResult:
+    """一項 plan review 判定的結果。``terminal`` 只在 ``passed`` 為 False 時有意義。"""
+
+    name: str
+    passed: bool
+    reason: str | None = None
+    terminal: bool = False
+    observation: Mapping[str, object] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if self.name not in PLAN_REVIEW_CHECK_ORDER:
+            raise ValueError(f"unknown plan review check: {self.name!r}")
+        if self.passed and (self.reason is not None or self.terminal):
+            raise ValueError("a passed plan review check must not carry reason/terminal")
+        if not self.passed and not self.reason:
+            raise ValueError("a failed plan review check requires a reason")
+
+
+@dataclass(frozen=True)
+class PlanReviewOutcome:
+    """跑完（或短路於）三項判定後的結果，比照 ReadinessOutcome 的 ready/terminal 語意。"""
+
+    ready: bool
+    failed_check: str | None
+    reason: str | None
+    terminal: bool
+    checks_run: tuple[str, ...]
+    observations: Mapping[str, Mapping[str, object]]
+
+
+def _plan_review_completeness(
+    plan_artifact: PlanningArtifact, acceptance_surfaces: frozenset[str]
+) -> PlanReviewCheckResult:
+    _, body, _ = _frontmatter_and_body(plan_artifact.text)
+    haystack = "\n".join(_collect_task_items(body)).casefold()
+    missing = tuple(
+        sorted(surface for surface in acceptance_surfaces if surface.casefold() not in haystack)
+    )
+    if missing:
+        return PlanReviewCheckResult(
+            "completeness",
+            False,
+            reason=f"missing-task-for-surface: {', '.join(missing)}",
+            observation={"missing_surfaces": missing},
+        )
+    return PlanReviewCheckResult(
+        "completeness", True, observation={"acceptance_surfaces": tuple(sorted(acceptance_surfaces))}
+    )
+
+
+def _plan_review_contract_compatibility(
+    plan_artifact: PlanningArtifact, applicable_contract_rules: frozenset[str]
+) -> PlanReviewCheckResult:
+    unknown_rules = applicable_contract_rules - CONTRACT_COMPATIBILITY_RULES
+    if unknown_rules:
+        raise ValueError(f"applicable_contract_rules 含未知規則: {sorted(unknown_rules)}")
+    frontmatter, body, _ = _frontmatter_and_body(plan_artifact.text)
+    excludes_raw = frontmatter.get("scope_excludes", [])
+    if not isinstance(excludes_raw, list) or any(not isinstance(item, str) for item in excludes_raw):
+        raise ValueError("plan frontmatter scope_excludes 必須為字串列表")
+    excludes = frozenset(item.strip().casefold() for item in excludes_raw if item.strip())
+    haystack = "\n".join(_collect_task_items(body)).casefold()
+
+    conflicts: list[str] = []
+    missing: list[str] = []
+    for rule in sorted(applicable_contract_rules):
+        keywords = _CONTRACT_RULE_TASK_KEYWORDS[rule]
+        if keywords & excludes:
+            conflicts.append(rule)
+        elif not any(keyword in haystack for keyword in keywords):
+            missing.append(rule)
+
+    if conflicts:
+        # hippo #18 第 9 條：plan 自身宣告的 scope_excludes 與規則要求互斥，
+        # 是本判定唯一的 terminal case（回傳 needs_human，不回派 planner重試）。
+        return PlanReviewCheckResult(
+            "contract_compatibility",
+            False,
+            reason=f"policy-scope-conflict: {', '.join(conflicts)}",
+            terminal=True,
+            observation={"conflicts": tuple(conflicts)},
+        )
+    if missing:
+        return PlanReviewCheckResult(
+            "contract_compatibility",
+            False,
+            reason=f"missing-task-for-rule: {', '.join(missing)}",
+            observation={"missing_rules": tuple(missing)},
+        )
+    return PlanReviewCheckResult(
+        "contract_compatibility",
+        True,
+        observation={"applicable_contract_rules": tuple(sorted(applicable_contract_rules))},
+    )
+
+
+def _plan_review_envelope(
+    plan_artifact: PlanningArtifact,
+    envelope_lookup: Callable[[], Mapping[str, object] | None] | None,
+) -> PlanReviewCheckResult:
+    frontmatter, _, _ = _frontmatter_and_body(plan_artifact.text)
+    invariant_count = frontmatter.get("invariant_count")
+    if not isinstance(invariant_count, int) or isinstance(invariant_count, bool) or invariant_count < 0:
+        raise ValueError("plan frontmatter 缺少合法的 invariant_count（需為 >=0 整數宣告）")
+    artifact_classes_raw = frontmatter.get("artifact_classes")
+    if (
+        not isinstance(artifact_classes_raw, list)
+        or not artifact_classes_raw
+        or any(not isinstance(item, str) or not item.strip() for item in artifact_classes_raw)
+    ):
+        raise ValueError("plan frontmatter 缺少合法的 artifact_classes（需為非空字串列表宣告）")
+    artifact_classes = frozenset(item.strip() for item in artifact_classes_raw)
+
+    # #209（能力封套）未落地：可插拔 provider，缺席時可觀測 bypass 通過。
+    envelope = envelope_lookup() if envelope_lookup is not None else None
+    if envelope is None:
+        return PlanReviewCheckResult(
+            "envelope", True, observation={"bypass": "envelope_unavailable"}
+        )
+
+    envelope_invariant_count = envelope.get("invariant_count")
+    envelope_artifact_classes_raw = envelope.get("artifact_classes")
+    if (
+        not isinstance(envelope_invariant_count, int)
+        or isinstance(envelope_invariant_count, bool)
+        or envelope_invariant_count < 0
+        or not isinstance(envelope_artifact_classes_raw, list)
+        or any(not isinstance(item, str) for item in envelope_artifact_classes_raw)
+    ):
+        raise ValueError("builder envelope 格式錯誤")
+    envelope_artifact_classes = frozenset(str(item).strip() for item in envelope_artifact_classes_raw)
+    over_budget = artifact_classes - envelope_artifact_classes
+    if invariant_count > envelope_invariant_count or over_budget:
+        return PlanReviewCheckResult(
+            "envelope",
+            False,
+            reason="envelope-exceeded",
+            observation={
+                "invariant_count": invariant_count,
+                "envelope_invariant_count": envelope_invariant_count,
+                "over_budget_artifact_classes": tuple(sorted(over_budget)),
+            },
+        )
+    return PlanReviewCheckResult(
+        "envelope",
+        True,
+        observation={
+            "bypass": None,
+            "invariant_count": invariant_count,
+            "artifact_classes": tuple(sorted(artifact_classes)),
+        },
+    )
+
+
+def plan_review_gate(
+    *,
+    plan_artifact: PlanningArtifact,
+    acceptance_surfaces: frozenset[str],
+    applicable_contract_rules: frozenset[str],
+    envelope_lookup: Callable[[], Mapping[str, object] | None] | None = None,
+) -> PlanReviewOutcome:
+    """三項判定（完整性／契約相容性／封套相符），依 cost order 短路於首個失敗。
+
+    ``acceptance_surfaces``／``applicable_contract_rules`` 皆由呼叫端算好注入
+    （不在此模組反向推導 scope/code_paths），``envelope_lookup`` 是 #209 封套查表
+    的占位 provider（``None`` 或回傳 ``None`` 皆視為封套資料缺席）。
+    """
+    if plan_artifact.kind != "plan":
+        raise ValueError(f"plan_review_gate 需要 kind='plan' 的 artifact，實際 {plan_artifact.kind!r}")
+
+    checks: tuple[tuple[str, Callable[[], PlanReviewCheckResult]], ...] = (
+        ("completeness", lambda: _plan_review_completeness(plan_artifact, acceptance_surfaces)),
+        (
+            "contract_compatibility",
+            lambda: _plan_review_contract_compatibility(plan_artifact, applicable_contract_rules),
+        ),
+        ("envelope", lambda: _plan_review_envelope(plan_artifact, envelope_lookup)),
+    )
+    checks_run: list[str] = []
+    observations: dict[str, Mapping[str, object]] = {}
+    for name, probe in checks:
+        checks_run.append(name)
+        result = probe()
+        if not result.passed:
+            return PlanReviewOutcome(
+                ready=False,
+                failed_check=name,
+                reason=result.reason,
+                terminal=result.terminal,
+                checks_run=tuple(checks_run),
+                observations=observations,
+            )
+        observations[name] = result.observation
+    return PlanReviewOutcome(
+        ready=True,
+        failed_check=None,
+        reason=None,
+        terminal=False,
+        checks_run=tuple(checks_run),
+        observations=observations,
+    )
 
 
 # --- #208 設計 H.1／#221：五維 sizing 評分 -----------------------------------

--- a/tests/test_completion_final_defect_locus.py
+++ b/tests/test_completion_final_defect_locus.py
@@ -1,0 +1,88 @@
+"""#212：CompletionRecord 新增「final 發現 plan 錯而非 candidate 錯」的訊號欄位。
+
+供 #137 度量 plan review 漏檢：plan_review_gate（#212 主體）在 plan 階段判定通過，
+但 final 才發現問題其實出在 plan 而非 candidate 實作時，於此記一筆 provenance 訊號。
+純 provenance，不影響既有 completion 語意，semantic match 需忽略它（比照 reused_from）。
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from paulsha_cortex.coordinator import completion
+
+
+def _base_payload(**overrides: object) -> dict:
+    payload = {
+        "schema_version": completion.COMPLETION_SCHEMA_VERSION,
+        "slice_id": "plan-review-gate",
+        "spec_hash": "1" * 64,
+        "plan_hash": "2" * 64,
+        "verification_hash": "3" * 64,
+        "builder_job_id": "builder-1",
+        "reviewer_job_id": None,
+        "dispatch_base": "a" * 40,
+        "candidate": "b" * 40,
+        "target_branch": "main",
+        "target_remote": "origin",
+        "target_ref": "refs/remotes/origin/main",
+        "target_ref_sha": "c" * 40,
+        "verification_evidence_path": "evidence/verification.json",
+        "verification_evidence_hash": "4" * 64,
+        "review_policy": "not-required",
+        "docs_class": "trivial",
+        "review_evaluation_path": None,
+        "review_evaluation_hash": None,
+        "completed_at": "2026-07-27T00:00:00+00:00",
+    }
+    payload.update(overrides)
+    return payload
+
+
+class FinalDefectLocusValidationTests(unittest.TestCase):
+    def test_absent_final_defect_locus_still_validates(self) -> None:
+        normalized = completion.validate_completion_record(_base_payload())
+        self.assertNotIn("final_defect_locus", normalized)
+
+    def test_plan_locus_round_trips(self) -> None:
+        normalized = completion.validate_completion_record(
+            _base_payload(final_defect_locus="plan")
+        )
+        self.assertEqual(normalized["final_defect_locus"], "plan")
+
+    def test_candidate_locus_round_trips(self) -> None:
+        normalized = completion.validate_completion_record(
+            _base_payload(final_defect_locus="candidate")
+        )
+        self.assertEqual(normalized["final_defect_locus"], "candidate")
+
+    def test_unknown_locus_value_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            completion.validate_completion_record(
+                _base_payload(final_defect_locus="builder")
+            )
+
+    def test_non_string_locus_value_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            completion.validate_completion_record(_base_payload(final_defect_locus=1))
+
+
+class FinalDefectLocusSemanticMatchTests(unittest.TestCase):
+    def test_final_defect_locus_excluded_from_semantic_match(self) -> None:
+        existing = _base_payload()
+        incoming = _base_payload(final_defect_locus="plan")
+        self.assertTrue(completion.completion_records_semantically_match(existing, incoming))
+
+    def test_differing_final_defect_locus_still_matches(self) -> None:
+        existing = _base_payload(final_defect_locus="plan")
+        incoming = _base_payload(final_defect_locus="candidate")
+        self.assertTrue(completion.completion_records_semantically_match(existing, incoming))
+
+    def test_real_conflict_still_detected_alongside_final_defect_locus(self) -> None:
+        existing = _base_payload(final_defect_locus="plan")
+        incoming = _base_payload(final_defect_locus="plan", candidate="d" * 40)
+        self.assertFalse(completion.completion_records_semantically_match(existing, incoming))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_planning_review_gate.py
+++ b/tests/test_planning_review_gate.py
@@ -1,0 +1,268 @@
+"""#212：plan_review_gate() 三項判定（#208 設計 A.1 第 3 點，不含 freeze 位移）。
+
+驗收條件對應：
+1. 完整性：plan 為每個 acceptance surface 備有對應 task
+2. 契約相容性：plan scope 與 R-09/R-16/R-19/R-22 相容（hippo #18 第 9 條在此攔截）
+3. 封套相符：plan 宣告的 invariant_count/artifact_classes 落在指定 builder 封套內；
+   builder 無封套資料時記 envelope_unavailable 並以可觀測 bypass 通過（對齊 #202 定案）
+4. 三項任一不過即 fail closed（ready=False），policy-scope-conflict 為 terminal，其餘可重試
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from paulsha_cortex.coordinator.planning import (
+    PlanningArtifact,
+    PlanReviewOutcome,
+    plan_review_gate,
+)
+
+
+def _plan_text(
+    *,
+    invariant_count: object = 1,
+    artifact_classes: str = "[code, test]",
+    scope_excludes: str | None = None,
+    tasks_body: str = (
+        "- 實作 code 變動\n"
+        "- 補 test 覆蓋\n"
+        "- 更新 changelog fragment\n"
+        "- 同步 CLI 說明\n"
+        "- 補 docs 段落\n"
+    ),
+    status: str = "accepted",
+) -> str:
+    excludes_line = f"scope_excludes: {scope_excludes}\n" if scope_excludes is not None else ""
+    return (
+        "---\n"
+        f"invariant_count: {invariant_count}\n"
+        f"artifact_classes: {artifact_classes}\n"
+        f"{excludes_line}"
+        f"status: {status}\n"
+        "---\n"
+        "## Tasks\n"
+        f"{tasks_body}"
+    )
+
+
+def _plan_artifact(**kwargs: object) -> PlanningArtifact:
+    return PlanningArtifact(kind="plan", ref="docs/superpowers/plans/demo.md", text=_plan_text(**kwargs))
+
+
+ALL_SURFACES = frozenset({"code", "test"})
+ALL_RULES = frozenset({"R-09", "R-16", "R-19", "R-22"})
+
+
+def test_gate_ready_when_all_three_checks_pass():
+    outcome = plan_review_gate(
+        plan_artifact=_plan_artifact(),
+        acceptance_surfaces=ALL_SURFACES,
+        applicable_contract_rules=ALL_RULES,
+    )
+    assert isinstance(outcome, PlanReviewOutcome)
+    assert outcome.ready is True
+    assert outcome.failed_check is None
+    assert outcome.terminal is False
+    assert outcome.checks_run == ("completeness", "contract_compatibility", "envelope")
+
+
+# --- 驗收條件 1：完整性 -------------------------------------------------
+
+
+def test_completeness_fails_when_acceptance_surface_has_no_task():
+    outcome = plan_review_gate(
+        plan_artifact=_plan_artifact(tasks_body="- 實作 code 變動\n"),
+        acceptance_surfaces=frozenset({"code", "docs"}),
+        applicable_contract_rules=frozenset(),
+    )
+    assert outcome.ready is False
+    assert outcome.failed_check == "completeness"
+    assert outcome.terminal is False
+    assert outcome.checks_run == ("completeness",)
+
+
+def test_completeness_passes_with_empty_acceptance_surfaces():
+    outcome = plan_review_gate(
+        plan_artifact=_plan_artifact(tasks_body="- 無關項目\n"),
+        acceptance_surfaces=frozenset(),
+        applicable_contract_rules=frozenset(),
+    )
+    assert outcome.ready is True
+
+
+def test_completeness_matches_task_text_case_insensitively():
+    outcome = plan_review_gate(
+        plan_artifact=_plan_artifact(tasks_body="- 補 CODE 變動與 TEST 覆蓋\n"),
+        acceptance_surfaces=frozenset({"code", "test"}),
+        applicable_contract_rules=frozenset(),
+    )
+    assert outcome.ready is True
+
+
+# --- 驗收條件 2：契約相容性 ----------------------------------------------
+
+
+def test_contract_compatibility_fails_when_required_task_missing():
+    outcome = plan_review_gate(
+        plan_artifact=_plan_artifact(tasks_body="- 只做 code 變動\n"),
+        acceptance_surfaces=frozenset(),
+        applicable_contract_rules=frozenset({"R-19"}),
+    )
+    assert outcome.ready is False
+    assert outcome.failed_check == "contract_compatibility"
+    assert outcome.terminal is False
+
+
+def test_contract_compatibility_passes_when_rule_keyword_present():
+    outcome = plan_review_gate(
+        plan_artifact=_plan_artifact(tasks_body="- 補測試（test）覆蓋新行為\n"),
+        acceptance_surfaces=frozenset(),
+        applicable_contract_rules=frozenset({"R-19"}),
+    )
+    assert outcome.ready is True
+
+
+def test_contract_compatibility_is_terminal_on_explicit_scope_conflict():
+    # hippo #18 第 9 條：plan 明確排除 changelog，但 R-09 要求 changelog fragment。
+    outcome = plan_review_gate(
+        plan_artifact=_plan_artifact(
+            scope_excludes="[changelog]",
+            tasks_body="- 只做 code 變動\n",
+        ),
+        acceptance_surfaces=frozenset(),
+        applicable_contract_rules=frozenset({"R-09"}),
+    )
+    assert outcome.ready is False
+    assert outcome.failed_check == "contract_compatibility"
+    assert outcome.terminal is True
+    assert outcome.reason is not None and "policy-scope-conflict" in outcome.reason
+
+
+def test_contract_compatibility_rejects_unknown_rule():
+    with pytest.raises(ValueError, match="R-99"):
+        plan_review_gate(
+            plan_artifact=_plan_artifact(),
+            acceptance_surfaces=frozenset(),
+            applicable_contract_rules=frozenset({"R-99"}),
+        )
+
+
+# --- 驗收條件 3：封套相符 ------------------------------------------------
+
+
+def test_envelope_bypasses_when_lookup_is_none():
+    outcome = plan_review_gate(
+        plan_artifact=_plan_artifact(invariant_count=99, artifact_classes="[code, test, exotic]"),
+        acceptance_surfaces=frozenset(),
+        applicable_contract_rules=frozenset(),
+        envelope_lookup=None,
+    )
+    assert outcome.ready is True
+    assert outcome.observations["envelope"]["bypass"] == "envelope_unavailable"
+
+
+def test_envelope_bypasses_when_lookup_returns_none():
+    outcome = plan_review_gate(
+        plan_artifact=_plan_artifact(),
+        acceptance_surfaces=frozenset(),
+        applicable_contract_rules=frozenset(),
+        envelope_lookup=lambda: None,
+    )
+    assert outcome.ready is True
+    assert outcome.observations["envelope"]["bypass"] == "envelope_unavailable"
+
+
+def test_envelope_fails_closed_when_invariant_count_exceeds_envelope():
+    outcome = plan_review_gate(
+        plan_artifact=_plan_artifact(invariant_count=5, artifact_classes="[code]"),
+        acceptance_surfaces=frozenset(),
+        applicable_contract_rules=frozenset(),
+        envelope_lookup=lambda: {"invariant_count": 2, "artifact_classes": ["code", "test"]},
+    )
+    assert outcome.ready is False
+    assert outcome.failed_check == "envelope"
+    assert outcome.terminal is False
+
+
+def test_envelope_fails_closed_when_artifact_class_exceeds_envelope():
+    outcome = plan_review_gate(
+        plan_artifact=_plan_artifact(invariant_count=1, artifact_classes="[code, exotic]"),
+        acceptance_surfaces=frozenset(),
+        applicable_contract_rules=frozenset(),
+        envelope_lookup=lambda: {"invariant_count": 2, "artifact_classes": ["code", "test"]},
+    )
+    assert outcome.ready is False
+    assert outcome.failed_check == "envelope"
+
+
+def test_envelope_passes_when_within_bounds():
+    outcome = plan_review_gate(
+        plan_artifact=_plan_artifact(invariant_count=2, artifact_classes="[code]"),
+        acceptance_surfaces=frozenset(),
+        applicable_contract_rules=frozenset(),
+        envelope_lookup=lambda: {"invariant_count": 2, "artifact_classes": ["code", "test"]},
+    )
+    assert outcome.ready is True
+
+
+def test_missing_invariant_count_declaration_rejected():
+    text = (
+        "---\n"
+        "artifact_classes: [code]\n"
+        "status: accepted\n"
+        "---\n"
+        "## Tasks\n"
+        "- a\n"
+    )
+    artifact = PlanningArtifact(kind="plan", ref="docs/superpowers/plans/demo.md", text=text)
+    with pytest.raises(ValueError, match="invariant_count"):
+        plan_review_gate(
+            plan_artifact=artifact,
+            acceptance_surfaces=frozenset(),
+            applicable_contract_rules=frozenset(),
+        )
+
+
+def test_missing_artifact_classes_declaration_rejected():
+    text = (
+        "---\n"
+        "invariant_count: 1\n"
+        "status: accepted\n"
+        "---\n"
+        "## Tasks\n"
+        "- a\n"
+    )
+    artifact = PlanningArtifact(kind="plan", ref="docs/superpowers/plans/demo.md", text=text)
+    with pytest.raises(ValueError, match="artifact_classes"):
+        plan_review_gate(
+            plan_artifact=artifact,
+            acceptance_surfaces=frozenset(),
+            applicable_contract_rules=frozenset(),
+        )
+
+
+# --- 檢查次序（cost order：completeness → contract_compatibility → envelope）----
+
+
+def test_checks_short_circuit_on_first_failure_completeness_then_contract():
+    outcome = plan_review_gate(
+        plan_artifact=_plan_artifact(tasks_body="- 無關項目\n"),
+        acceptance_surfaces=frozenset({"code"}),
+        applicable_contract_rules=frozenset({"R-19"}),
+    )
+    assert outcome.failed_check == "completeness"
+    assert outcome.checks_run == ("completeness",)
+
+
+# --- 非 plan artifact kind ------------------------------------------------
+
+
+def test_non_plan_artifact_kind_rejected():
+    artifact = PlanningArtifact(kind="design", ref="docs/superpowers/specs/demo-design.md", text="---\n---\n")
+    with pytest.raises(ValueError, match="plan"):
+        plan_review_gate(
+            plan_artifact=artifact,
+            acceptance_surfaces=frozenset(),
+            applicable_contract_rules=frozenset(),
+        )


### PR DESCRIPTION
## 摘要

實作 `#208` 設計 A.1 第 3 點（不含 freeze 位移，那是 `#213`）：`planning.py` 新增 `plan_review_gate()`，在 `assess_planning_completeness()` 之後、`PlanningGateRefs` 之前掛入三項判定（完整性／契約相容性／封套相符），任一不過即 fail closed。`plan_review_gate()` 是「唯一需要模型的前置閘」的機械骨架與判定契約——本單只落地三項判定中可機械判定的部分（契約相容性、封套查表）與完整性判定的輸入輸出契約；model dispatch（effort=high、prompt cache）沿用既有 planning 流程身分，接線留給後續子單。

同時 `completion.py` 新增 `final_defect_locus` 訊號欄位，記錄 final 才發現問題出在 plan 而非 candidate 的訊號，供 `#137` 度量 plan review 漏檢；純 provenance，不影響既有 completion 語意與 semantic match（比照既有 `reused_from` 的排除方式）。

失敗分類比照 `claim_readiness.ReadinessOutcome`：只有 plan 自身 `scope_excludes` 與規則要求互斥（hippo #18 第 9 條）是 terminal（回 `needs_human`），其餘（含 envelope 超界）皆可重試（回派 planner）——與 `claim_readiness.capability_probe` 把「capability 不足」視為可重試、而非 terminal 的既有先例一致。封套查表沿用 `#211` 的 `envelope_unavailable` 可觀測 bypass 命名與模式：`#209` 封套資料未落地時通過並記錄 bypass，有資料而超封套才 fail closed。

## 變更

| 檔案 | 變更 |
|---|---|
| `paulsha_cortex/coordinator/planning.py` | 新增 `plan_review_gate()`／`PlanReviewOutcome`／`PlanReviewCheckResult`／`PLAN_REVIEW_CHECK_ORDER`／`CONTRACT_COMPATIBILITY_RULES`；新增 `_collect_task_items()`（比照 `_headings_and_markers()` 對 Open Questions 的 heading-level 追蹤手法，抽出 Tasks 版本）與三個判定 helper（`_plan_review_completeness`／`_plan_review_contract_compatibility`／`_plan_review_envelope`） |
| `paulsha_cortex/coordinator/completion.py` | `validate_completion_record` 新增可選欄位 `final_defect_locus`（`plan`／`candidate`），`completion_records_semantically_match` 排除該欄位 |
| `tests/test_planning_review_gate.py`（新增） | `plan_review_gate()` 三項判定：ready 路徑、完整性缺 task、契約相容性缺 task／terminal scope 衝突／未知規則拒絕、封套 bypass／超界／通過、cost-order 短路、非 plan kind 拒絕 |
| `tests/test_completion_final_defect_locus.py`（新增） | `final_defect_locus` 欄位驗證（缺省／`plan`／`candidate`／非法值拒絕）與 semantic match 排除行為 |
| `changelog.d/212-plan-review-gate.md`（新增） | R-09 changelog fragment |

## 驗收條件對應

- [x] 完整性：plan 為每個 acceptance surface 備有對應 task
      → `test_completeness_fails_when_acceptance_surface_has_no_task`、`test_completeness_passes_with_empty_acceptance_surfaces`、`test_completeness_matches_task_text_case_insensitively`（`tests/test_planning_review_gate.py`）
- [x] 契約相容性：plan scope 與 R-09／R-16／R-19／R-22 相容（hippo #18 第 9 條在此攔截）
      → `test_contract_compatibility_fails_when_required_task_missing`、`test_contract_compatibility_passes_when_rule_keyword_present`、`test_contract_compatibility_is_terminal_on_explicit_scope_conflict`、`test_contract_compatibility_rejects_unknown_rule`（`tests/test_planning_review_gate.py`）
- [x] 封套相符：plan 宣告的 `invariant_count`／`artifact_classes` 落在指定 builder 封套內
      → `test_envelope_bypasses_when_lookup_is_none`、`test_envelope_bypasses_when_lookup_returns_none`、`test_envelope_fails_closed_when_invariant_count_exceeds_envelope`、`test_envelope_fails_closed_when_artifact_class_exceeds_envelope`、`test_envelope_passes_when_within_bounds`、`test_missing_invariant_count_declaration_rejected`、`test_missing_artifact_classes_declaration_rejected`（`tests/test_planning_review_gate.py`）
- [x] 三項任一不過即 fail closed，回派 planner 或轉 `needs_human`
      → `test_gate_ready_when_all_three_checks_pass`（`ready`/`terminal` 欄位）、`test_contract_compatibility_is_terminal_on_explicit_scope_conflict`（唯一 terminal case）、其餘失敗測試皆斷言 `terminal is False`（可重試）、`test_checks_short_circuit_on_first_failure_completeness_then_contract`（cost-order 短路，`checks_run` 只含已跑的檢查）
- [x] plan review 使用 `high` effort 即可，plan 為穩定 prefix 應命中 prompt cache
      → 本單落地的是判定的機械骨架與契約（`plan_review_gate()` 全程不 import/呼叫任何 model session API，`compute_sizing_score` 的既有 `test_compute_sizing_score_has_no_model_session_params` 先例已驗證同一模組邊界）；effort/cache 屬既有 planning 流程身分的 dispatch 參數，接線非本單範圍
- [x]（`completion.py` 訊號欄位，非驗收條件但屬落點檔案要求）final 發現「plan 錯而非 candidate 錯」訊號
      → `test_plan_locus_round_trips`、`test_candidate_locus_round_trips`、`test_unknown_locus_value_rejected`、`test_final_defect_locus_excluded_from_semantic_match`（`tests/test_completion_final_defect_locus.py`）

## 性質

feat（新功能）：`planning.py`／`completion.py` 新增函式與可選欄位，皆為新增純函式與可選欄位，不改動既有函式簽章或既有呼叫端行為；`#211` 已落地的凍結集/readiness 介面未變動，`#221` 的 `compute_sizing_score`／`_declared_dimension` 也未變動。

Closes #212

## Checklist

- [x] changelog.d fragment 已新增（R-09）
- [x] 本地 preflight-ci PASS（policy + openspec + pytest）
