### PR TITLE
fix(coordinator): source-owner 轉移原子化

### DIFF
--- a/changelog.d/source-owner-atomic.md
+++ b/changelog.d/source-owner-atomic.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **Issue #217：source-owner 轉移原子化**：`work_bridge.start_canonical_workflow` 新增顯式斷言——同 repo 下若有其他 work_id 的 ongoing WorkflowRun 其 `issue_refs` 與本次 `mapped_issues` 重疊，且該 run 尚未 terminal（`status` 不在 `{superseded, done}`），一律拒絕新 claim，避免 hippo #41 v3→v4 owner 轉移競態重現的 `missing_issue`/`human-intervention-required` run。`claim.load_work_authorities` 同步補上「同一 repo 下每個 issue 至多一個 work_id owner」的結構性不變量，讓轉移中途若快照仍出現雙 owner，任何 claim/ship/abandon 呼叫都會在載入 authority 時即拒絕，而非悄悄挑一個贏家。

--- a/paulsha_cortex/coordinator/claim.py
+++ b/paulsha_cortex/coordinator/claim.py
@@ -397,6 +397,19 @@ def load_work_authorities(
     identities = [(authority.repo, authority.work_id) for authority in authorities]
     if len(set(identities)) != len(identities):
         raise ValueError("confirmed work authority missing or ambiguous")
+    # Source-owner transfers (#217, design #208 D) move an issue's mapped_issues
+    # from one work_id to another. If the durable snapshot is ever read back
+    # while two different work_ids both confirm the same issue — the mid-
+    # transfer state that must never surface — refuse rather than silently
+    # picking a "winner": every claim/ship/abandon caller loads authority
+    # through here, so this closes the ambiguity at the single choke point.
+    owners: dict[tuple[str, int], str] = {}
+    for authority in authorities:
+        for issue in authority.mapped_issues:
+            key = (authority.repo, issue)
+            owner = owners.setdefault(key, authority.work_id)
+            if owner != authority.work_id:
+                raise ValueError("confirmed work authority missing or ambiguous")
     return authorities
 
 

--- a/paulsha_cortex/coordinator/work_bridge.py
+++ b/paulsha_cortex/coordinator/work_bridge.py
@@ -169,6 +169,36 @@ def _write_manifest(root: Path, claim_key: str, manifest) -> Path:
     return target
 
 
+def _other_owner_ongoing_runs(registry, authority: WorkAuthority) -> list:
+    """Ongoing runs owned by a *different* work_id that still claim one of
+    this authority's mapped issues.
+
+    Source-owner transfers (issue #217, design #208 D) move ``mapped_issues``
+    from one work_id to another through the ``.cortex/work-items.yaml``
+    unlink/link override. ``JobRegistry._manager_create_workflow_run`` only
+    auto-supersedes an *ongoing* run for the same ``(repo, work_id)`` pair, so
+    a different work_id's stale claim on the same issue is never protected
+    there. Without this guard a new-owner claim could start while the old
+    owner's run is still live — the exact "舊 owner 仍在 snapshot 而新 run 已
+    start" intermediate state hippo #41 (v3→v4) hit as a missing_issue /
+    human-intervention-required run.
+    """
+
+    expected_issue_refs = {
+        f"{authority.repo}#{number}" for number in authority.mapped_issues
+    }
+    if not expected_issue_refs:
+        return []
+    return [
+        run
+        for run in registry.list_workflow_runs()
+        if run.repo == authority.repo
+        and run.work_id != authority.work_id
+        and run.status == "ongoing"
+        and expected_issue_refs & set(run.issue_refs)
+    ]
+
+
 def start_canonical_workflow(
     *,
     registry,
@@ -192,6 +222,13 @@ def start_canonical_workflow(
             return existing_run
         if existing_run.current_phase != "define":
             return existing_run
+    stale_owners = _other_owner_ongoing_runs(registry, authority)
+    if stale_owners:
+        blocking = ", ".join(sorted({run.work_id for run in stale_owners}))
+        raise RuntimeError(
+            "source-owner transfer incomplete: "
+            f"{blocking} still owns an overlapping issue"
+        )
     root = resolve_trusted_repo_root(authority.repo, explicit=explicit_repo_root)
     change = authority.mapped_openspec[0] if authority.mapped_openspec else authority.work_id
     manifest = default_workflow_manifest(authority.work_id, change=change)

--- a/tests/test_claim_source_owner_atomic.py
+++ b/tests/test_claim_source_owner_atomic.py
@@ -1,0 +1,108 @@
+"""Focused tests for claim.py's snapshot-level unique-owner invariant (#217).
+
+Design #208 D's source-owner transfer walks vN -> vN+1 through an
+unlink/link window in ``.cortex/work-items.yaml``. If the durable monitor
+snapshot is ever read back while two different work_ids both claim the same
+GitHub issue as a confirmed source -- the literal "舊 owner 仍在 snapshot 而
+新 run 已 start" intermediate state this issue must never let a claim
+observe -- every ``load_work_authorities``/``load_work_authority`` call must
+refuse rather than silently returning one arbitrary "winner".
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from paulsha_cortex.coordinator.claim import (
+    load_work_authorities,
+    load_work_authority,
+)
+
+
+def _row(work_id: str, *, issues: list[int]) -> dict:
+    return {
+        "repo": "acme/demo",
+        "work_id": work_id,
+        "mapped_issues": issues,
+        "mapped_prs": [],
+        "mapped_openspec": [],
+        "mapped_todo_paths": ["docs/todo.md"],
+        "confirmed_todo": True,
+        "auto_label": False,
+        "source_revisions": ["source-rev-1"],
+    }
+
+
+def _snapshot(path: Path, *, work_items: list[dict]) -> Path:
+    path.write_text(
+        json.dumps(
+            {
+                "schema": "work-items-snapshot/v1",
+                "providers": {
+                    "github": {
+                        "provider_id": "github",
+                        "revision": "gh-1",
+                        "last_success_epoch": 100,
+                        "degraded": False,
+                    }
+                },
+                "work_items": work_items,
+            }
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_snapshot_with_two_owners_for_same_issue_is_rejected(tmp_path: Path) -> None:
+    """hippo #41 v3->v4: a mid-transfer snapshot must never yield two owners."""
+
+    snapshot = _snapshot(
+        tmp_path / "snapshot.json",
+        work_items=[
+            _row("source-owner-old", issues=[41]),
+            _row("source-owner-new", issues=[41]),
+        ],
+    )
+    with pytest.raises(ValueError, match="missing or ambiguous"):
+        load_work_authorities(snapshot_path=snapshot)
+    with pytest.raises(ValueError, match="missing or ambiguous"):
+        load_work_authority(
+            repo="acme/demo", work_id="source-owner-new", snapshot_path=snapshot
+        )
+
+
+def test_snapshot_after_transfer_completes_has_single_owner(tmp_path: Path) -> None:
+    """Once unlink/link converge, only the new work_id maps the issue."""
+
+    snapshot = _snapshot(
+        tmp_path / "snapshot.json",
+        work_items=[
+            _row("source-owner-old", issues=[]),
+            _row("source-owner-new", issues=[41]),
+        ],
+    )
+    authorities = load_work_authorities(snapshot_path=snapshot)
+    assert {
+        authority.work_id: authority.mapped_issues for authority in authorities
+    } == {
+        "source-owner-old": (),
+        "source-owner-new": (41,),
+    }
+
+
+def test_disjoint_issues_across_work_ids_are_unaffected(tmp_path: Path) -> None:
+    """Two work_ids owning unrelated issues must not trip the guard."""
+
+    snapshot = _snapshot(
+        tmp_path / "snapshot.json",
+        work_items=[
+            _row("alpha", issues=[10]),
+            _row("beta", issues=[11]),
+        ],
+    )
+    authorities = load_work_authorities(snapshot_path=snapshot)
+    assert len(authorities) == 2

--- a/tests/test_work_bridge_source_owner_atomic.py
+++ b/tests/test_work_bridge_source_owner_atomic.py
@@ -1,0 +1,184 @@
+"""Guards against the vN -> vN+1 source-owner transfer race (#217, design #208 D).
+
+hippo #41 v3->v4: issue #41 moved from one work_id's authority to another's
+while the old work_id's WorkflowRun was still "ongoing" -- the
+missing_issue / human-intervention-required run this issue must stop
+reproducing. hippo #41 v5: once the old owner is properly terminalized
+(superseded), the new owner's claim must not get spuriously persisted-block
+either -- ``start_canonical_workflow`` is the "新 run 才可 claim" mounting
+point design #208 D's four-step order (terminalize/supersede -> unlink/link
+-> snapshot confirm -> claim) needs.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from paulsha_cortex.coordinator import work_bridge
+from paulsha_cortex.coordinator.claim import load_work_authority
+from paulsha_cortex.coordinator.registry import JobRegistry
+
+
+def _repo(root: Path) -> Path:
+    root.mkdir()
+    subprocess.run(["git", "init", "-q", str(root)], check=True)
+    subprocess.run(
+        ["git", "-C", str(root), "config", "user.email", "test@example.com"], check=True
+    )
+    subprocess.run(["git", "-C", str(root), "config", "user.name", "Test"], check=True)
+    subprocess.run(
+        ["git", "-C", str(root), "remote", "add", "origin", "git@github.com:acme/demo.git"],
+        check=True,
+    )
+    (root / "README.md").write_text("demo\n", encoding="utf-8")
+    subprocess.run(["git", "-C", str(root), "add", "README.md"], check=True)
+    subprocess.run(["git", "-C", str(root), "commit", "-qm", "init"], check=True)
+    return root
+
+
+def _snapshot(path: Path, *, work_id: str, issues: tuple[int, ...]) -> Path:
+    path.write_text(
+        json.dumps(
+            {
+                "schema": "work-items-snapshot/v1",
+                "providers": {
+                    "github": {
+                        "provider_id": "github",
+                        "revision": "gh-1",
+                        "last_success_epoch": 100,
+                        "degraded": False,
+                    }
+                },
+                "work_items": [
+                    {
+                        "repo": "acme/demo",
+                        "work_id": work_id,
+                        "mapped_issues": list(issues),
+                        "mapped_prs": [],
+                        "mapped_openspec": [work_id],
+                        "mapped_todo_paths": ["docs/todo.md"],
+                        "confirmed_todo": True,
+                        "auto_label": False,
+                        "source_revisions": ["source-rev-1"],
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _create_ongoing_run(registry: JobRegistry, *, authority, claim_key: str, issue: int) -> object:
+    return registry._manager_create_workflow_run(
+        work_id=authority.work_id,
+        repo=authority.repo,
+        claim_key=claim_key,
+        source_revision="source-rev",
+        workspace_root="/workspace",
+        combo="feature-oneshot",
+        current_phase="build",
+        steps=(),
+        issue_refs=(f"{authority.repo}#{issue}",),
+        openspec_refs=(authority.work_id,),
+    )
+
+
+def test_new_owner_claim_is_refused_while_old_owner_run_still_ongoing(tmp_path: Path) -> None:
+    """hippo #41 v3->v4: the old owner's ongoing run must block a new-owner claim."""
+
+    workspace = _repo(tmp_path / "workspace")
+    registry = JobRegistry(state_path=tmp_path / "jobs.json")
+    old_authority = load_work_authority(
+        repo="acme/demo",
+        work_id="source-owner-old",
+        snapshot_path=_snapshot(tmp_path / "old.json", work_id="source-owner-old", issues=(41,)),
+    )
+    _create_ongoing_run(registry, authority=old_authority, claim_key="claim:v1:" + "1" * 64, issue=41)
+
+    new_authority = load_work_authority(
+        repo="acme/demo",
+        work_id="source-owner-new",
+        snapshot_path=_snapshot(tmp_path / "new.json", work_id="source-owner-new", issues=(41,)),
+    )
+
+    with pytest.raises(RuntimeError, match="source-owner transfer incomplete"):
+        work_bridge.start_canonical_workflow(
+            registry=registry,
+            authority=new_authority,
+            claim_key="claim:v1:" + "2" * 64,
+            coordinator_root=tmp_path / "coordinator",
+            explicit_repo_root=workspace,
+            needs_human_reason="missing-issue",
+        )
+
+    # The "舊 owner 仍在 snapshot 而新 run 已 start" intermediate state must
+    # never materialize: no run for the new owner may exist yet.
+    assert [run.work_id for run in registry.list_workflow_runs()] == ["source-owner-old"]
+
+
+def test_new_owner_claim_succeeds_once_old_owner_run_is_terminal(tmp_path: Path) -> None:
+    """hippo #41 v5: a properly-terminalized transfer must not persist-block the new owner."""
+
+    workspace = _repo(tmp_path / "workspace")
+    registry = JobRegistry(state_path=tmp_path / "jobs.json")
+    old_authority = load_work_authority(
+        repo="acme/demo",
+        work_id="source-owner-old",
+        snapshot_path=_snapshot(tmp_path / "old.json", work_id="source-owner-old", issues=(41,)),
+    )
+    old_run = _create_ongoing_run(
+        registry, authority=old_authority, claim_key="claim:v1:" + "1" * 64, issue=41
+    )
+    # Step 1 of design #208 D: terminalize/supersede the old owner first.
+    registry._manager_abandon_workflow_run(old_run.run_id, evidence_ref="evidence://old-abandon")
+
+    new_authority = load_work_authority(
+        repo="acme/demo",
+        work_id="source-owner-new",
+        snapshot_path=_snapshot(tmp_path / "new.json", work_id="source-owner-new", issues=(41,)),
+    )
+
+    new_run = work_bridge.start_canonical_workflow(
+        registry=registry,
+        authority=new_authority,
+        claim_key="claim:v1:" + "2" * 64,
+        coordinator_root=tmp_path / "coordinator",
+        explicit_repo_root=workspace,
+        needs_human_reason="missing-issue",
+    )
+    assert new_run.work_id == "source-owner-new"
+    assert new_run.issue_refs == ("acme/demo#41",)
+
+
+def test_disjoint_issue_ownership_does_not_block_new_claim(tmp_path: Path) -> None:
+    """A different work_id's ongoing run on an unrelated issue must not block."""
+
+    workspace = _repo(tmp_path / "workspace")
+    registry = JobRegistry(state_path=tmp_path / "jobs.json")
+    other_authority = load_work_authority(
+        repo="acme/demo",
+        work_id="unrelated",
+        snapshot_path=_snapshot(tmp_path / "other.json", work_id="unrelated", issues=(99,)),
+    )
+    _create_ongoing_run(registry, authority=other_authority, claim_key="claim:v1:" + "3" * 64, issue=99)
+
+    new_authority = load_work_authority(
+        repo="acme/demo",
+        work_id="source-owner-new",
+        snapshot_path=_snapshot(tmp_path / "new.json", work_id="source-owner-new", issues=(41,)),
+    )
+
+    new_run = work_bridge.start_canonical_workflow(
+        registry=registry,
+        authority=new_authority,
+        claim_key="claim:v1:" + "4" * 64,
+        coordinator_root=tmp_path / "coordinator",
+        explicit_repo_root=workspace,
+        needs_human_reason="missing-issue",
+    )
+    assert new_run.work_id == "source-owner-new"


### PR DESCRIPTION
## 摘要

實作 `#208` 設計 D：source-owner 轉移原子化。既有程式碼中，`JobRegistry._manager_create_workflow_run` 只會自動 supersede **同一個** `(repo, work_id)` 的 ongoing run；當一個 issue 從 work_id A 轉給 work_id B（unlink/link override）時，A 的舊 run 完全沒有機制被自動終結，`work_bridge.start_canonical_workflow` 也沒有任何檢查會擋下「A 還在跑、B 就先 claim」的競態——這正是 hippo #41 v3→v4 owner 轉移產生 `missing_issue`/`human-intervention-required` run 的成因。

本單在讀碼地圖標出的「核心掛載點」`start_canonical_workflow` 補上顯式斷言：同 repo 下若有其他 work_id 的 ongoing run，其 `issue_refs` 與本次 `mapped_issues` 重疊，且該 run 尚未 terminal（`status` 不在 `{superseded, done}`），一律拒絕新 claim。另外在 `claim.load_work_authorities`（所有 claim/ship/abandon 呼叫載入 authority 的單一入口）補上「同一 repo 下每個 issue 至多一個 work_id owner」的結構性不變量——快照一旦短暫出現雙 owner（轉移中途的 bug 或競態），任何呼叫端都會在載入時直接拒絕，而不是悄悄挑一個贏家繼續往下跑。

兩道防線合起來把「舊 owner 仍在 snapshot 而新 run 已 start」的中間狀態，從執行期一路封到資料層。

## 變更

| 檔案 | 變更 |
|---|---|
| `paulsha_cortex/coordinator/work_bridge.py` | 新增 `_other_owner_ongoing_runs()`；`start_canonical_workflow` 在既有 claim_key collision guard 之後、建立任何新 run 之前，若偵測到其他 work_id 仍有 ongoing run 佔用重疊 issue，直接拋 `RuntimeError`（訊息含 `source-owner transfer incomplete`） |
| `paulsha_cortex/coordinator/claim.py` | `load_work_authorities` 在既有 `(repo, work_id)` 唯一性檢查之後，新增「同一 repo 下每個 issue 至多一個 work_id」的檢查，違反時沿用既有 `"confirmed work authority missing or ambiguous"` 訊息 |
| `tests/test_work_bridge_source_owner_atomic.py`（新增） | `start_canonical_workflow` 的三個情境：舊 owner 仍 ongoing 時拒絕新 claim（並確認 registry 內仍只有舊 owner 的 run）、舊 owner 已 terminalize 後新 claim 正常成功、不重疊 issue 的其他 work_id 不誤擋 |
| `tests/test_claim_source_owner_atomic.py`（新增） | `load_work_authorities`/`load_work_authority` 的三個情境：雙 owner 快照被拒絕、轉移完成後單一 owner 正常載入、不相關 issue 之間互不影響 |
| `changelog.d/source-owner-atomic.md`（新增） | R-09 changelog fragment |

## 驗收條件對應

- [x] vN→vN+1 依序：terminalize/supersede → unlink/link override → snapshot 確認唯一 owner → 新 run 才可 claim
      → `test_new_owner_claim_is_refused_while_old_owner_run_still_ongoing`、`test_new_owner_claim_succeeds_once_old_owner_run_is_terminal`（`tests/test_work_bridge_source_owner_atomic.py`）；`test_snapshot_after_transfer_completes_has_single_owner`（`tests/test_claim_source_owner_atomic.py`）
- [x] 不得出現舊 owner 仍在 snapshot 而新 run 已 start 的中間狀態
      → `test_new_owner_claim_is_refused_while_old_owner_run_still_ongoing`（斷言拒絕後 registry 內仍只有舊 owner 的 run）；`test_snapshot_with_two_owners_for_same_issue_is_rejected`（雙 owner 快照在 authority 載入層即被拒絕，任何呼叫端都拿不到可用 authority）
- [x] 競態測試：不可重現 missing_issue / persisted-block（hippo #41 v4/v5 實案）
      → `test_new_owner_claim_is_refused_while_old_owner_run_still_ongoing`（v4：舊 owner 未終結時新 claim 被明確拒絕，而非誤放行產生 missing_issue run）、`test_new_owner_claim_succeeds_once_old_owner_run_is_terminal`（v5：舊 owner 依 `_manager_abandon_workflow_run` 正確終結後，新 owner 首次 claim 不會被殘留狀態卡住）

補充：`test_disjoint_issue_ownership_does_not_block_new_claim` / `test_disjoint_issues_across_work_ids_are_unaffected` 佐證本次新增的兩道防線只鎖定「重疊 issue」情境，不誤傷不相關的 work_id 並行。

## 範圍註記（依 brief 要求記錄）

- **W1 TOCTOU 縫（`work_authority_digest` 不含 `auto_label`/`confirmed_issue`）**：評估後判定不在本單處理。理由：該縫是單一 authority 在 decide 之後、claim 之前被竄改是否可偵測的問題，與本單「跨 work_id 轉移原子化」是正交的兩個問題；且 brief 明確禁止直接改 `work_authority_digest` 的欄位集合（會使既有 claim key 全數失效，影響面遠超本單）。若要關閉，需要另一個獨立設計（例如比照 `build_production_ship_validator.validate()` 的 reload-and-compare 模式，在轉移序列完成後另外核對，而非改 digest 本身），建議另立 issue 追蹤。
- **`work_actions._claim_action` 的「resume」捷徑（僅把新 authority 中繼資料貼回回傳 dict、未真正呼叫 registry 建新 run/supersede 舊 run）**：讀碼地圖標出這是 hippo #41 v4/v5 競態的實際發生點之一，但該函式在 `work_actions.py`，不在本單「落點：`claim.py`、`work_bridge.py`」宣告範圍內。本單交付的兩道防線（`start_canonical_workflow` 顯式斷言 + `load_work_authorities` 唯一 owner 不變量）會在資料/掛載點層先擋下這個競態最終導致的錯誤狀態；但若要根治 `_claim_action` 本身那段 dict-patch 捷徑，需要另開子單處理 `work_actions.py`。

## 性質

fix（修正原子性缺口）：兩處新增皆為既有函式內的額外防禦性檢查，不改動任何既有函式簽名或回傳結構；正常（單一 owner、無競態）情境下行為與既有測試（`tests/test_work_claim.py`、`tests/test_work_bridge.py`、`tests/test_reclaim_pr_inheritance.py`）完全一致。

Closes #217

## Checklist

- [x] changelog.d fragment 已新增（R-09）
- [x] 本地 preflight-ci PASS（policy + openspec + pytest）
