### PR TITLE
feat(coordinator/work_actions): retry 分類骨架

### DIFF
--- a/changelog.d/215-retry-classification.md
+++ b/changelog.d/215-retry-classification.md
@@ -1,0 +1,3 @@
+### Added
+
+- **Issue #215：retry 分類骨架**：`work_actions.py` 新增 `RetryClassification` enum（`model_repair`／`orchestrator_retry`／`authority_restart`／`review_handoff_failure`／`source_owner_repair`，enum 定案，後波不得改名）與 `_classify_retry()`，依 run.current_phase 與 builder job 的乾淨終止／evidence 綁定狀態判斷一次 retry-build 屬 candidate 內容缺陷（`model_repair`）還是 provider/stale base/claim sequencing 等非模型原因（`orchestrator_retry`），不再只看 vN 世代數；`_retry_build_action` 回傳結果攜帶分類。`completion.py` 的 `CompletionRecord` 同步新增可選欄位 `retry_classification`（比照 `reused_from` 的 provenance 模式，排除於 semantic match 之外），供未來 `cortex stat` 依分類彙總。`authority_restart`／`review_handoff_failure`／`source_owner_repair` 的判準留供 #216 補齊。

--- a/paulsha_cortex/coordinator/completion.py
+++ b/paulsha_cortex/coordinator/completion.py
@@ -25,6 +25,21 @@ VOLATILE_WORK_AUTHORITY_FIELDS = frozenset(
 # 故整個欄位排除在 semantic match 之外——避免良性 reuse 被誤判為衝突而觸發
 # quarantine（比照 VOLATILE_WORK_AUTHORITY_FIELDS 的做法）。
 REUSED_FROM_FIELDS = frozenset({"run_id", "job_id", "evidence_hash"})
+# retry_classification（#215 retry 分類骨架）同樣只是 provenance：記錄一次
+# retry-build 的性質判斷（model_repair／orchestrator_retry／…），不影響 completion
+# 語意，故排除在 semantic match 之外——避免同一份 candidate 因重試分類不同而被
+# 誤判衝突（比照 REUSED_FROM_FIELDS 的做法）。enum 值須與
+# work_actions.RetryClassification 同步（enum 定案，後波不得改名）；本模組刻意
+# 不 import 該型別以避免 schema 層耦合 coordinator 高階模組。
+RETRY_CLASSIFICATION_VALUES = frozenset(
+    {
+        "model_repair",
+        "orchestrator_retry",
+        "authority_restart",
+        "review_handoff_failure",
+        "source_owner_repair",
+    }
+)
 
 
 def classify_completion(*, exit_code: int, last_jsonl_line: str | None) -> str:
@@ -217,6 +232,12 @@ def _normalize_reused_from(value: object) -> dict[str, str]:
     }
 
 
+def _normalize_retry_classification(value: object) -> str:
+    if not isinstance(value, str) or value not in RETRY_CLASSIFICATION_VALUES:
+        raise ValueError("completion retry_classification invalid")
+    return value
+
+
 def validate_completion_record(payload: object) -> dict[str, Any]:
     if not isinstance(payload, dict):
         raise ValueError("completion record must be an object")
@@ -245,7 +266,7 @@ def validate_completion_record(payload: object) -> dict[str, Any]:
     missing = sorted(required - set(payload))
     if missing:
         raise ValueError(f"completion record missing keys: {', '.join(missing)}")
-    extras = set(payload) - required - {"work_authority", "reused_from"}
+    extras = set(payload) - required - {"work_authority", "reused_from", "retry_classification"}
     if extras:
         raise ValueError(f"completion record unexpected key: {sorted(extras)[0]}")
     if payload.get("schema_version") != COMPLETION_SCHEMA_VERSION:
@@ -293,6 +314,10 @@ def validate_completion_record(payload: object) -> dict[str, Any]:
         normalized["work_authority"] = _normalize_work_authority(payload["work_authority"])
     if "reused_from" in payload:
         normalized["reused_from"] = _normalize_reused_from(payload["reused_from"])
+    if "retry_classification" in payload:
+        normalized["retry_classification"] = _normalize_retry_classification(
+            payload["retry_classification"]
+        )
 
     reviewer_job_id = normalized["reviewer_job_id"]
     review_path = normalized["review_evaluation_path"]
@@ -347,6 +372,8 @@ def completion_records_semantically_match(existing: object, incoming: object) ->
     incoming_authority = _semantic_work_authority(incoming_normalized.pop("work_authority", None))
     existing_normalized.pop("reused_from", None)
     incoming_normalized.pop("reused_from", None)
+    existing_normalized.pop("retry_classification", None)
+    incoming_normalized.pop("retry_classification", None)
     return existing_normalized == incoming_normalized and existing_authority == incoming_authority
 
 

--- a/paulsha_cortex/coordinator/work_actions.py
+++ b/paulsha_cortex/coordinator/work_actions.py
@@ -8,6 +8,7 @@ import os
 import re
 import subprocess
 import time
+from enum import Enum
 from pathlib import Path
 from pathlib import PurePosixPath
 from types import SimpleNamespace
@@ -1434,6 +1435,56 @@ def _claim_action(
     return {"action": decision.action, "reason": decision.reason, "run": active}
 
 
+class RetryClassification(str, Enum):
+    """#208 根因3 定案的 retry 分類（enum 定案，後波不得改名）。
+
+    本單（#215）只落地 MODEL_REPAIR／ORCHESTRATOR_RETRY 兩類的判準：
+    AUTHORITY_RESTART／REVIEW_HANDOFF_FAILURE／SOURCE_OWNER_REPAIR 留供 #216
+    依各自根因補齊——`_classify_retry` 目前不會回傳這三類。
+    """
+
+    MODEL_REPAIR = "model_repair"
+    ORCHESTRATOR_RETRY = "orchestrator_retry"
+    AUTHORITY_RESTART = "authority_restart"
+    REVIEW_HANDOFF_FAILURE = "review_handoff_failure"
+    SOURCE_OWNER_REPAIR = "source_owner_repair"
+
+
+def _classify_retry(run, workflow_registry) -> RetryClassification:
+    """判斷一次 retry-build 的性質（#208 根因3）。
+
+    model_repair：candidate 已產出可被下游評估的內容——run 已離開 build phase
+    進入 verify/review，或 build phase 已有一顆乾淨終止（status=='exited'、
+    exit_code==0）且已綁定 workflow_evidence 的 builder job。此後任何
+    needs_human 都是下游對 candidate 內容本身的判斷，屬需要模型修的內容缺陷。
+
+    orchestrator_retry：build phase 尚未有前述「乾淨終止且已綁定 evidence」的
+    builder job（job 缺席、未乾淨終止，或乾淨終止卻沒有 evidence）——中斷發生
+    在 provider／stale base／claim sequencing 等 orchestrator 層，不是模型內容
+    問題，不得計入模型 failure 指標。
+
+    判準只看 run.current_phase 與 JobRegistry 的 job status/exit_code/
+    workflow_evidence，刻意不看 run.attempts 世代數（不再只以 vN 判斷重試性質）。
+    """
+    if run.current_phase != "build":
+        return RetryClassification.MODEL_REPAIR
+    build_steps = [step for step in run.steps if step.phase == "build"]
+    repair_card = build_steps[-1].card if build_steps else None
+    terminal_with_evidence = [
+        job
+        for job in workflow_registry.list_jobs()
+        if job.get("workflow_run_id") == run.run_id
+        and job.get("workflow_phase") == "build"
+        and job.get("workflow_card") == repair_card
+        and job.get("status") == "exited"
+        and job.get("exit_code") == 0
+        and job.get("workflow_evidence") is not None
+    ]
+    if terminal_with_evidence:
+        return RetryClassification.MODEL_REPAIR
+    return RetryClassification.ORCHESTRATOR_RETRY
+
+
 def _retry_build_action(*, args: dict[str, Any], authority, workflow_registry) -> dict[str, Any]:
     """Reopen the final builder card with exact-Candidate CAS after a human stop."""
 
@@ -1472,6 +1523,7 @@ def _retry_build_action(*, args: dict[str, Any], authority, workflow_registry) -
         raise RuntimeError("retry-build requires build/verify/review workflow")
     if run.candidate_head != expected_candidate.lower():
         raise RuntimeError("retry-build expected Candidate CAS mismatch")
+    retry_classification = _classify_retry(run, workflow_registry)
     archive_applied = any(
         step.phase == "ship"
         and step.card == "openspec-archive"
@@ -1512,6 +1564,7 @@ def _retry_build_action(*, args: dict[str, Any], authority, workflow_registry) -
         "reason": "candidate-repair-dispatched",
         "expected_candidate": expected_candidate.lower(),
         "run": updated.to_dict(),
+        "retry_classification": retry_classification,
     }
 
 

--- a/tests/test_completion_retry_classification.py
+++ b/tests/test_completion_retry_classification.py
@@ -1,0 +1,106 @@
+"""#215：CompletionRecord 的 retry_classification provenance 欄位。
+
+驗收條件對應：
+- 「分類寫入 CompletionRecord，cortex stat 可依分類彙總」——本檔驗證 schema 層
+  的可選欄位驗證／正規化／round-trip，比照 #214 reused_from 的 provenance 模式。
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from paulsha_cortex.coordinator import completion
+
+
+def _base_payload(**overrides: object) -> dict:
+    payload = {
+        "schema_version": completion.COMPLETION_SCHEMA_VERSION,
+        "slice_id": "retry-classification",
+        "spec_hash": "1" * 64,
+        "plan_hash": "2" * 64,
+        "verification_hash": "3" * 64,
+        "builder_job_id": "builder-1",
+        "reviewer_job_id": None,
+        "dispatch_base": "a" * 40,
+        "candidate": "b" * 40,
+        "target_branch": "main",
+        "target_remote": "origin",
+        "target_ref": "refs/remotes/origin/main",
+        "target_ref_sha": "c" * 40,
+        "verification_evidence_path": "/evidence/verification.json",
+        "verification_evidence_hash": "4" * 64,
+        "review_policy": "not-required",
+        "docs_class": "trivial",
+        "review_evaluation_path": None,
+        "review_evaluation_hash": None,
+        "completed_at": "2026-07-27T00:00:00+00:00",
+    }
+    payload.update(overrides)
+    return payload
+
+
+class RetryClassificationValidationTests(unittest.TestCase):
+    def test_absent_retry_classification_still_validates(self) -> None:
+        normalized = completion.validate_completion_record(_base_payload())
+        self.assertNotIn("retry_classification", normalized)
+
+    def test_model_repair_round_trips(self) -> None:
+        normalized = completion.validate_completion_record(
+            _base_payload(retry_classification="model_repair")
+        )
+        self.assertEqual(normalized["retry_classification"], "model_repair")
+
+    def test_orchestrator_retry_round_trips(self) -> None:
+        normalized = completion.validate_completion_record(
+            _base_payload(retry_classification="orchestrator_retry")
+        )
+        self.assertEqual(normalized["retry_classification"], "orchestrator_retry")
+
+    def test_future_wave_values_are_already_accepted_by_schema(self) -> None:
+        # #216 補齊 authority_restart/review_handoff_failure/source_owner_repair
+        # 的判準，但 enum 值本身在 #215 已定案，schema 現在就必須接受。
+        for value in (
+            "authority_restart",
+            "review_handoff_failure",
+            "source_owner_repair",
+        ):
+            normalized = completion.validate_completion_record(
+                _base_payload(retry_classification=value)
+            )
+            self.assertEqual(normalized["retry_classification"], value)
+
+    def test_rejects_unknown_classification(self) -> None:
+        with self.assertRaises(ValueError):
+            completion.validate_completion_record(
+                _base_payload(retry_classification="not-a-real-classification")
+            )
+
+    def test_rejects_non_string_classification(self) -> None:
+        with self.assertRaises(ValueError):
+            completion.validate_completion_record(
+                _base_payload(retry_classification=123)
+            )
+
+
+class RetryClassificationSemanticMatchTests(unittest.TestCase):
+    def test_retry_classification_excluded_from_semantic_match(self) -> None:
+        existing = _base_payload()
+        incoming = _base_payload(retry_classification="model_repair")
+        self.assertTrue(completion.completion_records_semantically_match(existing, incoming))
+
+    def test_differing_retry_classification_still_matches(self) -> None:
+        existing = _base_payload(retry_classification="model_repair")
+        incoming = _base_payload(retry_classification="orchestrator_retry")
+        self.assertTrue(completion.completion_records_semantically_match(existing, incoming))
+
+    def test_real_conflict_still_detected_alongside_retry_classification(self) -> None:
+        existing = _base_payload(retry_classification="model_repair")
+        incoming = _base_payload(
+            retry_classification="model_repair",
+            verification_hash="9" * 64,
+        )
+        self.assertFalse(completion.completion_records_semantically_match(existing, incoming))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_retry_classification.py
+++ b/tests/test_retry_classification.py
@@ -1,0 +1,401 @@
+"""#215：retry 分類骨架（work_actions.RetryClassification／_classify_retry）。
+
+驗收條件對應：
+- 1. model_repair 與 orchestrator_retry 兩類的定義與判決條件落地
+- 2.（真正的 CompletionRecord 寫入見 tests/test_completion_retry_classification.py；
+     本檔涵蓋的是分類決策點本身，以及 execute_work_action 的 retry-build 回傳）
+- 3. 不再只以 vN 世代數（attempts["build"] 之類的重試次數）判斷重試性質
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+from pathlib import Path
+import subprocess
+
+from paulsha_cortex.coordinator import work_actions
+from paulsha_cortex.coordinator.registry import JobRegistry
+from paulsha_cortex.coordinator.workflow import WorkflowRun, WorkflowStep
+
+
+HEAD = "b" * 40
+NOW = "2026-07-27T00:00:00+00:00"
+
+_PERSONA_BY_PHASE = {
+    "claim": "manager",
+    "define": "planner",
+    "plan": "planner",
+    "build": "builder",
+    "verify": "reviewer",
+    "review": "reviewer",
+    "ship": "manager",
+}
+
+
+def _step(phase: str, card: str, *, gate_result: str = "pending") -> WorkflowStep:
+    return WorkflowStep(
+        phase=phase,
+        persona=_PERSONA_BY_PHASE[phase],
+        card=card,
+        executor=None,
+        model=None,
+        domain=None,
+        inputs=(),
+        outputs=(),
+        gate_result=gate_result,
+    )
+
+
+def _run(
+    *,
+    current_phase: str,
+    steps: tuple[WorkflowStep, ...],
+    run_id: str = "run-1",
+    attempts: dict[str, int] | None = None,
+) -> WorkflowRun:
+    return WorkflowRun(
+        run_id=run_id,
+        work_id="demo",
+        repo="acme/demo",
+        claim_key="claim:v1:abc",
+        source_revision="a" * 40,
+        workspace_root="/tmp/workspace",
+        combo="feature-oneshot",
+        current_phase=current_phase,
+        steps=steps,
+        issue_refs=("acme/demo#12",),
+        openspec_refs=("demo",),
+        pr_refs=(),
+        attempts=attempts or {},
+        evidence_refs=(),
+        gate_refs=(),
+        brainstorm_required=False,
+        primary_domain=None,
+        candidate_head=HEAD,
+        verified_head=None,
+        facets=("needs_human",),
+        gate_status="running",
+        created_at=NOW,
+        updated_at=NOW,
+    )
+
+
+def _job_args(*, run: WorkflowRun, repair_card: str, tmp_path: Path) -> dict:
+    return {
+        "task": f"wf-{run.run_id}-{repair_card}",
+        "persona": "builder",
+        "branch": "feature/demo",
+        "pane": "",
+        "worktree": str(tmp_path),
+        "workflow_run_id": run.run_id,
+        "workflow_card": repair_card,
+        "workflow_phase": "build",
+    }
+
+
+def _init_repo(root: Path, repo: str = "acme/demo") -> Path:
+    root.mkdir(parents=True, exist_ok=True)
+    subprocess.run(["git", "init", "-q", str(root)], check=True)
+    remote = subprocess.run(
+        ["git", "-C", str(root), "remote", "get-url", "origin"],
+        capture_output=True,
+        text=True,
+    )
+    if remote.returncode != 0:
+        subprocess.run(
+            ["git", "-C", str(root), "remote", "add", "origin", f"git@github.com:{repo}.git"],
+            check=True,
+        )
+    return root
+
+
+def _snapshot(path: Path) -> Path:
+    _init_repo(path.parent)
+    path.write_text(
+        json.dumps(
+            {
+                "schema": "work-items-snapshot/v1",
+                "providers": {
+                    "github": {
+                        "provider_id": "github",
+                        "revision": "gh-1",
+                        "last_success_epoch": 100,
+                        "degraded": False,
+                    }
+                },
+                "work_items": [
+                    {
+                        "repo": "acme/demo",
+                        "work_id": "demo",
+                        "mapped_issues": [12],
+                        "mapped_prs": [8],
+                        "mapped_openspec": ["demo"],
+                        "mapped_todo_paths": ["docs/todo.md"],
+                        "confirmed_todo": True,
+                        "auto_label": True,
+                        "source_revisions": ["issue:12@open", "openspec:demo@1"],
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+# ---------------------------------------------------------------------------
+# enum 定案（後波不得改名）：五類齊全、值為固定字串。
+# ---------------------------------------------------------------------------
+
+
+def test_enum_declares_all_five_values() -> None:
+    values = {member.value for member in work_actions.RetryClassification}
+    assert values == {
+        "model_repair",
+        "orchestrator_retry",
+        "authority_restart",
+        "review_handoff_failure",
+        "source_owner_repair",
+    }
+
+
+def test_enum_members_are_plain_strings() -> None:
+    assert work_actions.RetryClassification.MODEL_REPAIR == "model_repair"
+    assert work_actions.RetryClassification.ORCHESTRATOR_RETRY == "orchestrator_retry"
+    assert isinstance(work_actions.RetryClassification.MODEL_REPAIR, str)
+
+
+# ---------------------------------------------------------------------------
+# _classify_retry：AC1（model_repair／orchestrator_retry 判準落地）
+# ---------------------------------------------------------------------------
+
+
+def test_verify_phase_needs_human_is_model_repair(tmp_path: Path) -> None:
+    registry = JobRegistry(state_path=tmp_path / "jobs.json")
+    run = _run(
+        current_phase="verify",
+        steps=(_step("build", "subagent-build", gate_result="passed"),),
+    )
+    assert work_actions._classify_retry(run, registry) == (
+        work_actions.RetryClassification.MODEL_REPAIR
+    )
+
+
+def test_review_phase_needs_human_is_model_repair(tmp_path: Path) -> None:
+    registry = JobRegistry(state_path=tmp_path / "jobs.json")
+    run = _run(
+        current_phase="review",
+        steps=(_step("build", "subagent-build", gate_result="passed"),),
+    )
+    assert work_actions._classify_retry(run, registry) == (
+        work_actions.RetryClassification.MODEL_REPAIR
+    )
+
+
+def test_build_phase_crashed_builder_is_orchestrator_retry(tmp_path: Path) -> None:
+    registry = JobRegistry(state_path=tmp_path / "jobs.json")
+    run = _run(
+        current_phase="build",
+        steps=(_step("build", "subagent-build", gate_result="pending"),),
+    )
+    job = registry.create_job(
+        **_job_args(run=run, repair_card="subagent-build", tmp_path=tmp_path)
+    )
+    registry.update_headless_result(job["job_id"], status="failed", exit_code=1)
+    assert work_actions._classify_retry(run, registry) == (
+        work_actions.RetryClassification.ORCHESTRATOR_RETRY
+    )
+
+
+def test_build_phase_clean_exit_without_evidence_is_orchestrator_retry(
+    tmp_path: Path,
+) -> None:
+    registry = JobRegistry(state_path=tmp_path / "jobs.json")
+    run = _run(
+        current_phase="build",
+        steps=(_step("build", "subagent-build", gate_result="pending"),),
+    )
+    job = registry.create_job(
+        **_job_args(run=run, repair_card="subagent-build", tmp_path=tmp_path)
+    )
+    registry.update_headless_result(job["job_id"], status="exited", exit_code=0)
+    assert registry.get_job(job["job_id"])["workflow_evidence"] is None
+    assert work_actions._classify_retry(run, registry) == (
+        work_actions.RetryClassification.ORCHESTRATOR_RETRY
+    )
+
+
+def test_build_phase_clean_exit_with_bound_evidence_is_model_repair(
+    tmp_path: Path,
+) -> None:
+    registry = JobRegistry(state_path=tmp_path / "jobs.json")
+    run = _run(
+        current_phase="build",
+        steps=(_step("build", "subagent-build", gate_result="pending"),),
+    )
+    job = registry.create_job(
+        **_job_args(run=run, repair_card="subagent-build", tmp_path=tmp_path)
+    )
+    registry.update_headless_result(job["job_id"], status="exited", exit_code=0)
+    registry.bind_workflow_evidence(
+        job["job_id"],
+        locator={"kind": "verification", "path": "/evidence/v.json", "hash": "f" * 64},
+    )
+    assert work_actions._classify_retry(run, registry) == (
+        work_actions.RetryClassification.MODEL_REPAIR
+    )
+
+
+def test_build_phase_missing_job_is_orchestrator_retry(tmp_path: Path) -> None:
+    registry = JobRegistry(state_path=tmp_path / "jobs.json")
+    run = _run(
+        current_phase="build",
+        steps=(_step("build", "subagent-build", gate_result="pending"),),
+    )
+    assert work_actions._classify_retry(run, registry) == (
+        work_actions.RetryClassification.ORCHESTRATOR_RETRY
+    )
+
+
+def test_classification_ignores_build_attempt_generation_count(tmp_path: Path) -> None:
+    """AC3：不再只以 vN 世代數（attempts["build"]）判斷重試性質——同一組
+    phase/job 訊號下，不論 attempts 計到第幾代，分類結果都必須一致。"""
+    registry = JobRegistry(state_path=tmp_path / "jobs.json")
+    low = _run(
+        current_phase="build",
+        steps=(_step("build", "subagent-build", gate_result="pending"),),
+        run_id="run-low",
+        attempts={"build": 1},
+    )
+    high = _run(
+        current_phase="build",
+        steps=(_step("build", "subagent-build", gate_result="pending"),),
+        run_id="run-low",
+        attempts={"build": 41},
+    )
+    job = registry.create_job(
+        **_job_args(run=low, repair_card="subagent-build", tmp_path=tmp_path)
+    )
+    registry.update_headless_result(job["job_id"], status="failed", exit_code=1)
+    assert work_actions._classify_retry(low, registry) == work_actions._classify_retry(
+        high, registry
+    )
+
+
+# ---------------------------------------------------------------------------
+# execute_work_action(retry-build)：AC1 決策點在真正呼叫路徑上落地
+# ---------------------------------------------------------------------------
+
+
+def test_retry_build_result_carries_orchestrator_retry_for_unbound_terminalization(
+    tmp_path: Path,
+) -> None:
+    snapshot = _snapshot(tmp_path / "snapshot.json")
+    authority = work_actions.load_work_authority(
+        repo="acme/demo", work_id="demo", snapshot_path=snapshot
+    )
+    registry = JobRegistry(state_path=tmp_path / "jobs.json")
+    initial = work_actions._fallback_workflow_starter(
+        registry, tmp_path / "runs.json"
+    )(authority, work_actions._expected_claim_key(authority), None)
+    repair_card = next(
+        step.card for step in reversed(initial.steps) if step.phase == "build"
+    )
+    terminalization_failed = tuple(
+        replace(step, gate_result="passed")
+        if step.phase == "build" and step.card != repair_card
+        else replace(step, gate_result="pending")
+        if step.phase == "build"
+        else step
+        for step in initial.steps
+    )
+    for phase in ("plan", "build"):
+        registry._manager_update_workflow_run(initial.run_id, current_phase=phase)
+    registry._manager_update_workflow_run(
+        initial.run_id,
+        steps=terminalization_failed,
+        candidate_head=HEAD,
+        facets=("needs_human",),
+        gate_status="running",
+    )
+    job_args = {
+        "task": "wf-demo-subagent-build",
+        "persona": "builder",
+        "branch": "feature/demo",
+        "pane": "",
+        "worktree": str(tmp_path),
+        "dispatch_head": HEAD,
+        "workflow_run_id": initial.run_id,
+        "workflow_claim_key": initial.claim_key,
+        "workflow_repo": initial.repo,
+        "workflow_card": repair_card,
+        "workflow_phase": "build",
+        "workflow_repo_root": str(tmp_path),
+        "workflow_input_root": str(tmp_path),
+        "source_revision": initial.source_revision,
+    }
+    successful_job = registry.create_job(**job_args)
+    registry.update_headless_result(
+        successful_job["job_id"], status="exited", exit_code=0
+    )
+    result = work_actions.execute_work_action(
+        args={
+            "action": "retry-build",
+            "repo": "acme/demo",
+            "work_id": "demo",
+            "issue": 12,
+            "actor": "operator",
+            "expected_candidate": HEAD,
+        },
+        requested_by="operator",
+        snapshot_path=snapshot,
+        state_path=tmp_path / "runs.json",
+        workflow_registry=registry,
+    )
+    assert result["result"]["retry_classification"] == "orchestrator_retry"
+
+
+def test_retry_build_result_carries_model_repair_after_review_needs_human(
+    tmp_path: Path,
+) -> None:
+    snapshot = _snapshot(tmp_path / "snapshot.json")
+    authority = work_actions.load_work_authority(
+        repo="acme/demo", work_id="demo", snapshot_path=snapshot
+    )
+    registry = JobRegistry(state_path=tmp_path / "jobs.json")
+    initial = work_actions._fallback_workflow_starter(
+        registry, tmp_path / "runs.json"
+    )(authority, work_actions._expected_claim_key(authority), None)
+    passed = tuple(
+        replace(step, gate_result="passed")
+        if step.phase in {"build", "verify", "review"}
+        else step
+        for step in initial.steps
+    )
+    for phase in ("plan", "build", "verify"):
+        registry._manager_update_workflow_run(initial.run_id, current_phase=phase)
+    registry._manager_update_workflow_run(
+        initial.run_id,
+        current_phase="review",
+        steps=passed,
+        candidate_head=HEAD,
+        verified_head=HEAD,
+        facets=("needs_human",),
+        gate_status="running",
+    )
+    result = work_actions.execute_work_action(
+        args={
+            "action": "retry-build",
+            "repo": "acme/demo",
+            "work_id": "demo",
+            "issue": 12,
+            "actor": "operator",
+            "expected_candidate": HEAD,
+        },
+        requested_by="operator",
+        snapshot_path=snapshot,
+        state_path=tmp_path / "runs.json",
+        workflow_registry=registry,
+    )
+    assert result["result"]["retry_classification"] == "model_repair"

--- a/tests/test_retry_classification.py
+++ b/tests/test_retry_classification.py
@@ -399,3 +399,14 @@ def test_retry_build_result_carries_model_repair_after_review_needs_human(
         workflow_registry=registry,
     )
     assert result["result"]["retry_classification"] == "model_repair"
+
+
+def test_enum_values_stay_in_sync_with_completion_schema() -> None:
+    """completion.RETRY_CLASSIFICATION_VALUES 刻意不 import 本模組的 enum
+    （避免 schema 層耦合 coordinator 高階模組），這條測試是兩處字串集合的
+    唯一同步保證——#216 增修分類值時必須同時改兩處，否則在此示警。"""
+    from paulsha_cortex.coordinator.completion import RETRY_CLASSIFICATION_VALUES
+
+    assert RETRY_CLASSIFICATION_VALUES == frozenset(
+        member.value for member in work_actions.RetryClassification
+    )


### PR DESCRIPTION
## 摘要

依 `#208` 設計 C 第一批（5/10 Yellow），為 retry-build 補上「性質分類」骨架：
`work_actions.py` 新增 `RetryClassification` enum 與 `_classify_retry()`，判斷一次
retry-build 屬 candidate 內容缺陷（`model_repair`）還是 provider/stale base/claim
sequencing 等非模型原因（`orchestrator_retry`），不再只以 vN 世代數猜測性質；
`completion.py` 的 `CompletionRecord` 同步新增可選欄位 `retry_classification`
（比照 #214 `reused_from` 的 provenance 模式），供未來 `cortex stat` 依分類彙總。
`authority_restart`／`review_handoff_failure`／`source_owner_repair` 三類 enum 值
已定案並保留擴充位，判準留待 `#216` 依各自根因補齊。

## 變更

| 檔案 | 變更 |
|---|---|
| `paulsha_cortex/coordinator/work_actions.py` | 新增 `RetryClassification(str, Enum)`（5 類，enum 定案）；新增 `_classify_retry(run, workflow_registry)`，依 `run.current_phase` 與 builder job 的乾淨終止（`status=='exited'`、`exit_code==0`）＋`workflow_evidence` 綁定狀態判斷 `model_repair`／`orchestrator_retry`；`_retry_build_action` 回傳結果新增 `retry_classification` 欄位 |
| `paulsha_cortex/coordinator/completion.py` | 新增 `RETRY_CLASSIFICATION_VALUES` 與 `_normalize_retry_classification()`；`validate_completion_record` 支援可選欄位 `retry_classification`；`completion_records_semantically_match` 將其排除於語意比對之外（比照 `reused_from`） |
| `tests/test_retry_classification.py`（新檔） | `RetryClassification` enum 值／`_classify_retry` 各判準組合／`execute_work_action(retry-build)` 回傳分類 的 focused 測試 |
| `tests/test_completion_retry_classification.py`（新檔） | `CompletionRecord` 的 `retry_classification` 欄位驗證、正規化、round-trip、semantic-match 排除 測試 |
| `changelog.d/215-retry-classification.md`（新檔） | `[Unreleased]` fragment（R-09） |

## 驗收條件對應

- [x] `model_repair` 與 `orchestrator_retry` 兩類的定義與判決條件落地
  - `paulsha_cortex/coordinator/work_actions.py::_classify_retry`
  - `tests/test_retry_classification.py::test_verify_phase_needs_human_is_model_repair`
  - `tests/test_retry_classification.py::test_review_phase_needs_human_is_model_repair`
  - `tests/test_retry_classification.py::test_build_phase_crashed_builder_is_orchestrator_retry`
  - `tests/test_retry_classification.py::test_build_phase_clean_exit_without_evidence_is_orchestrator_retry`
  - `tests/test_retry_classification.py::test_build_phase_clean_exit_with_bound_evidence_is_model_repair`
  - `tests/test_retry_classification.py::test_build_phase_missing_job_is_orchestrator_retry`
- [x] 分類寫入 `CompletionRecord`，`cortex stat` 可依分類彙總
  - `paulsha_cortex/coordinator/completion.py::validate_completion_record`（可選欄位 `retry_classification`）
  - `tests/test_completion_retry_classification.py::RetryClassificationValidationTests`
  - `tests/test_completion_retry_classification.py::RetryClassificationSemanticMatchTests`
  - `_retry_build_action` 的回傳已攜帶分類（`tests/test_retry_classification.py::test_retry_build_result_carries_orchestrator_retry_for_unbound_terminalization`、`test_retry_build_result_carries_model_repair_after_review_needs_human`）；實際寫入 `work_bridge.py:_completion_draft` 的組裝點留給後續子單（`#216`）銜接，本單先確保 schema／資料結構就緒
- [x] 不再只以 vN 世代數判斷重試性質
  - `_classify_retry` 只讀 `run.current_phase` 與 `JobRegistry` 的 job status/exit_code/evidence，不讀 `run.attempts`
  - `tests/test_retry_classification.py::test_classification_ignores_build_attempt_generation_count`

## 性質

feat（新行為：retry-build 新增分類決策與資料結構；不變更既有 retry-build 的授權/CAS/archive 保護邏輯）

Closes #215

## Checklist

- [x] changelog.d fragment 已新增（R-09）
- [x] 本地 preflight-ci PASS（policy + openspec + pytest）
