### PR TITLE
feat(coordinator): 凍結點移至 plan review 通過之後

### DIFF
--- a/changelog.d/freeze-after-plan-review.md
+++ b/changelog.d/freeze-after-plan-review.md
@@ -1,0 +1,3 @@
+### Added
+
+- **Issue #213：凍結點移至 plan review 通過之後**：`claim.py` 新增 `claim_identity_digest()`（不含 `mapped_openspec`／`mapped_todo_paths`／`source_revisions` 的穩定 identity）與 `ClaimCandidate.active_plan_review_passed`／`active_claim_identity_digest`；`_existing()` 在 `active_plan_review_passed=False`（plan review 尚未通過）時改用穩定 identity 比對，plan 修訂造成的產物欄位飄移不再被誤判為 authority 變更、不再觸發 supersede（hippo #18 第 3、7 條 v3→v4→… 世代增長 regression）。`planning.py` 新增 `plan_review_freezes_authority()`，把 `plan_review_gate()`（#212）的判定結果對應到「是否可以 freeze」，供呼叫端串接。

--- a/paulsha_cortex/coordinator/claim.py
+++ b/paulsha_cortex/coordinator/claim.py
@@ -384,6 +384,35 @@ def work_authority_digest(authority: WorkAuthority) -> str:
     return verification.canonical_json_hash(payload)
 
 
+def claim_identity_digest(authority: WorkAuthority) -> str:
+    """Stable claim identity, excluding the planning-artifact-driven fields
+    (#213, design #208 A.1: freeze point moves to *after* plan review passes).
+
+    ``work_authority_digest`` folds in ``mapped_openspec``/``mapped_todo_paths``/
+    ``source_revisions`` — exactly the fields a plan -> plan review -> revision
+    loop touches as planning artifacts are drafted and rewritten. Comparing
+    against the *full* digest while ``planning.plan_review_gate`` has not yet
+    returned ``ready=True`` makes every plan revision look like a changed
+    authority, so ``_existing()`` treats an active workflow as unmatched and
+    the caller mints a fresh claim — the mechanism behind hippo #18's #3/#7
+    v3->v4->... authority generation growth. This digest is the light,
+    GitHub-anchored identity (``mapped_issues``/``mapped_prs``/``confirmed_todo``)
+    a plan revision alone cannot change, used by ``_existing()`` while an
+    active run's plan review has not passed yet.
+    """
+    if not isinstance(authority, WorkAuthority):
+        raise ValueError("confirmed WorkAuthority is required")
+    payload = {
+        "repo": authority.repo,
+        "work_id": authority.work_id,
+        "provider_id": authority.github_provider_id,
+        "mapped_issues": list(authority.mapped_issues),
+        "mapped_prs": list(authority.mapped_prs),
+        "confirmed_todo": authority.confirmed_todo,
+    }
+    return verification.canonical_json_hash(payload)
+
+
 def load_work_authorities(
     *, snapshot_path: str | Path | None = None
 ) -> tuple[WorkAuthority, ...]:
@@ -445,6 +474,8 @@ class ClaimCandidate:
     active_source_revisions: tuple[str, ...] | None = None
     active_provider_revision: str | None = None
     active_authority_digest: str | None = None
+    active_plan_review_passed: bool = True
+    active_claim_identity_digest: str | None = None
 
 
 @dataclass(frozen=True)
@@ -467,6 +498,7 @@ def _validate_candidate(candidate: ClaimCandidate) -> None:
     for field, value in (
         ("confirmed_todo", candidate.confirmed_todo),
         ("auto_label", candidate.auto_label),
+        ("active_plan_review_passed", candidate.active_plan_review_passed),
     ):
         if not isinstance(value, bool):
             raise ValueError(f"{field} must be boolean")
@@ -518,6 +550,13 @@ def _validate_candidate(candidate: ClaimCandidate) -> None:
             or re.fullmatch(r"[0-9a-f]{64}", candidate.active_authority_digest) is None
         ):
             raise ValueError("active workflow authority metadata missing")
+        if not candidate.active_plan_review_passed and (
+            not isinstance(candidate.active_claim_identity_digest, str)
+            or re.fullmatch(r"[0-9a-f]{64}", candidate.active_claim_identity_digest) is None
+        ):
+            # #213：plan review 尚未通過（freeze 未發生）時，_existing() 改用
+            # claim_identity_digest 比對，這個欄位就是它比對的持久化基準。
+            raise ValueError("active workflow pre-freeze identity digest missing")
 
 
 def build_claim_key(candidate: ClaimCandidate) -> str:
@@ -536,6 +575,17 @@ def build_claim_key(candidate: ClaimCandidate) -> str:
 def _existing(candidate: ClaimCandidate) -> ClaimDecision | None:
     if candidate.active_run_id is None:
         return None
+    if not candidate.active_plan_review_passed:
+        # #213（design #208 A.1）：freeze point 位於 plan review 通過之後。
+        # 這個 run 的 plan 仍在 plan -> revision 迴圈裡（尚未 freeze），只比對
+        # 穩定 identity（claim_identity_digest，不含 mapped_openspec/
+        # mapped_todo_paths/source_revisions）——plan 修訂造成這些欄位飄移不算
+        # authority 變更，不觸發 supersede、不生出新世代（hippo #18 #3/#7）。
+        # 持久化的 claim_key 是在 plan 存在之前鎖定的，此時不得拿（帶有目前飄移
+        # 欄位的）完整 digest 反向驗證它，所以不做 expected_key 比對。
+        if candidate.active_claim_identity_digest != claim_identity_digest(candidate.authority):
+            return None
+        return _resume_decision(candidate)
     authority_changed = (
         candidate.active_authority_digest != work_authority_digest(candidate.authority)
         or tuple(sorted(candidate.active_source_revisions or ()))
@@ -557,6 +607,10 @@ def _existing(candidate: ClaimCandidate) -> ClaimDecision | None:
     )
     if candidate.active_claim_key != expected_key:
         raise ValueError("persisted claim key does not match authority")
+    return _resume_decision(candidate)
+
+
+def _resume_decision(candidate: ClaimCandidate) -> ClaimDecision:
     if candidate.active_status == "done":
         return ClaimDecision(
             action="done",

--- a/paulsha_cortex/coordinator/planning.py
+++ b/paulsha_cortex/coordinator/planning.py
@@ -561,6 +561,19 @@ def plan_review_gate(
     )
 
 
+def plan_review_freezes_authority(outcome: PlanReviewOutcome) -> bool:
+    """#213（design #208 A.1）：freeze point 移至 plan review 通過之後。
+
+    把 :func:`plan_review_gate` 的判定結果對應到「呼叫端現在可以 freeze 了嗎」——
+    只有 ``ready=True`` 才可以，不論不通過的原因是可重試（回派 planner 修訂）還是
+    terminal（policy-scope-conflict，轉 needs_human）：兩者都代表 plan 尚未定案，
+    freeze 都不該發生。這是 ``claim.ClaimCandidate.active_plan_review_passed``
+    該填入的值，讓 plan review 前的 plan 修訂不會被 claim.py 誤判成 authority
+    變更（避免觸發 supersede、產生新世代，hippo #18 第 3、7 條）。
+    """
+    return outcome.ready
+
+
 # --- #208 設計 H.1／#221：五維 sizing 評分 -----------------------------------
 #
 # 五維量表（每維 0-2 分，總分 0-10）：

--- a/tests/test_freeze_after_plan_review.py
+++ b/tests/test_freeze_after_plan_review.py
@@ -1,0 +1,341 @@
+"""#213（design #208 A.1）：freeze point 移至 plan review 通過之後。
+
+lifecycle 改為 plan -> plan review -> 修訂 -> freeze -> build：在 planning.plan_review_gate()
+（#212）尚未回傳 ready=True 之前，plan 修訂造成的 mapped_openspec/mapped_todo_paths/
+source_revisions 飄移，不得被 claim.py 當成 authority 變更（觸發 supersede、生出新世代）。
+
+驗收條件對應：
+1. freeze point 位於 plan review 通過之後 —— planning.plan_review_freezes_authority()
+   把 plan_review_gate() 的 outcome 對應到「是否可以 freeze」。
+2. plan review 前的 plan 修訂不產生 supersede、不變更 authority hash —— claim.py
+   _existing() 在 active_plan_review_passed=False 時改用 claim_identity_digest()
+   （不含 mapped_openspec/mapped_todo_paths/source_revisions）判斷是否比對得上。
+3. regression：plan 修訂不再導致 v3->v4 的 authority 世代增長（hippo #18 第 3、7 條）。
+4. 既有合法 plan（plan review 已通過）仍可通過新順序（沿用完整 digest 比對，行為不變）。
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+import json
+from pathlib import Path
+
+import pytest
+
+from paulsha_cortex.coordinator.claim import (
+    ClaimCandidate,
+    WorkAuthority,
+    build_claim_key,
+    claim_identity_digest,
+    decide_auto_claim,
+    decide_manual_start,
+    load_work_authority,
+    work_authority_digest,
+)
+from paulsha_cortex.coordinator.planning import (
+    PlanningArtifact,
+    PlanReviewOutcome,
+    plan_review_freezes_authority,
+    plan_review_gate,
+)
+
+
+# --- fixtures --------------------------------------------------------------
+
+
+def _authority(
+    tmp_path: Path,
+    *,
+    label: str,
+    mapped_openspec: tuple[str, ...] = ("lifecycle",),
+    mapped_todo_paths: tuple[str, ...] = ("docs/todo.md",),
+    source_revisions: tuple[str, ...] = ("issue:14@open", "openspec:lifecycle@abc"),
+    issues: tuple[int, ...] = (14,),
+) -> WorkAuthority:
+    payload = {
+        "schema": "work-items-snapshot/v1",
+        "providers": {
+            "github": {
+                "provider_id": "github",
+                "revision": "github-rev-1",
+                "last_success_epoch": 950,
+                "degraded": False,
+            }
+        },
+        "work_items": [
+            {
+                "repo": "acme/demo",
+                "work_id": "lifecycle",
+                "mapped_issues": list(issues),
+                "mapped_prs": [8],
+                "mapped_openspec": list(mapped_openspec),
+                "mapped_todo_paths": list(mapped_todo_paths),
+                "confirmed_todo": True,
+                "auto_label": True,
+                "source_revisions": list(source_revisions),
+            }
+        ],
+    }
+    path = tmp_path / f"snapshot-{label}.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return load_work_authority(repo="acme/demo", work_id="lifecycle", snapshot_path=path)
+
+
+def _fresh_candidate(authority: WorkAuthority) -> ClaimCandidate:
+    return ClaimCandidate(
+        authority=authority,
+        repo="acme/demo",
+        work_id="lifecycle",
+        source_revisions=authority.source_revisions,
+        confirmed_todo=True,
+        confirmed_issue=14,
+        auto_label=True,
+        active_run_id=None,
+        active_claim_key=None,
+    )
+
+
+def _active_candidate(
+    *,
+    original: WorkAuthority,
+    current: WorkAuthority,
+    active_plan_review_passed: bool,
+) -> ClaimCandidate:
+    original_claim_key = build_claim_key(_fresh_candidate(original))
+    return replace(
+        _fresh_candidate(current),
+        active_run_id="run-1",
+        active_claim_key=original_claim_key,
+        active_status="ongoing",
+        active_snapshot_hash=original.snapshot_hash,
+        active_source_revisions=original.source_revisions,
+        active_provider_revision=original.github_provider_revision,
+        active_authority_digest=work_authority_digest(original),
+        active_plan_review_passed=active_plan_review_passed,
+        active_claim_identity_digest=claim_identity_digest(original),
+    )
+
+
+# --- AC1: freeze point 位於 plan review 通過之後 ----------------------------
+
+
+def _plan_text(*, tasks_body: str) -> str:
+    return (
+        "---\n"
+        "invariant_count: 1\n"
+        "artifact_classes: [code]\n"
+        "status: accepted\n"
+        "---\n"
+        "## Tasks\n"
+        f"{tasks_body}"
+    )
+
+
+def test_plan_review_freezes_authority_only_when_gate_ready() -> None:
+    ready_plan = PlanningArtifact(
+        kind="plan",
+        ref="docs/superpowers/plans/demo.md",
+        text=_plan_text(tasks_body="- 實作 code 變動\n"),
+    )
+    ready_outcome = plan_review_gate(
+        plan_artifact=ready_plan,
+        acceptance_surfaces=frozenset({"code"}),
+        applicable_contract_rules=frozenset(),
+    )
+    assert isinstance(ready_outcome, PlanReviewOutcome)
+    assert ready_outcome.ready is True
+    assert plan_review_freezes_authority(ready_outcome) is True
+
+    unready_plan = PlanningArtifact(
+        kind="plan",
+        ref="docs/superpowers/plans/demo.md",
+        text=_plan_text(tasks_body="- 其他工作\n"),
+    )
+    unready_outcome = plan_review_gate(
+        plan_artifact=unready_plan,
+        acceptance_surfaces=frozenset({"code"}),
+        applicable_contract_rules=frozenset(),
+    )
+    assert unready_outcome.ready is False
+    assert plan_review_freezes_authority(unready_outcome) is False
+
+
+def test_plan_review_freezes_authority_rejects_terminal_outcome_too() -> None:
+    terminal_outcome = PlanReviewOutcome(
+        ready=False,
+        failed_check="contract_compatibility",
+        reason="policy-scope-conflict: R-09",
+        terminal=True,
+        checks_run=("completeness", "contract_compatibility"),
+        observations={},
+    )
+    assert plan_review_freezes_authority(terminal_outcome) is False
+
+
+# --- claim_identity_digest：穩定 identity（不含 plan 產物欄位）-------------
+
+
+def test_claim_identity_digest_requires_work_authority() -> None:
+    with pytest.raises(ValueError, match="WorkAuthority is required"):
+        claim_identity_digest(object())  # type: ignore[arg-type]
+
+
+def test_claim_identity_digest_ignores_plan_artifact_fields(tmp_path: Path) -> None:
+    original = _authority(tmp_path, label="v1")
+    revised = _authority(
+        tmp_path,
+        label="v2",
+        mapped_openspec=("lifecycle", "lifecycle-appendix"),
+        mapped_todo_paths=("docs/todo.md", "docs/todo-2.md"),
+        source_revisions=("issue:14@open", "openspec:lifecycle@zzz"),
+    )
+    # 完整 digest 會因為 plan 產物欄位飄移而不同——這正是要繞過的部分。
+    assert work_authority_digest(original) != work_authority_digest(revised)
+    # 穩定 identity 不受影響。
+    assert claim_identity_digest(original) == claim_identity_digest(revised)
+
+
+def test_claim_identity_digest_still_reacts_to_genuine_identity_change(tmp_path: Path) -> None:
+    original = _authority(tmp_path, label="v1")
+    different_issue = _authority(tmp_path, label="other-issue", issues=(99,))
+    assert claim_identity_digest(original) != claim_identity_digest(different_issue)
+
+
+# --- AC2/AC3：plan review 前的修訂不觸發 supersede / 不變更 authority hash --
+
+
+def test_plan_revision_before_review_does_not_supersede_or_change_claim_key(
+    tmp_path: Path,
+) -> None:
+    original = _authority(tmp_path, label="v1")
+    revised = _authority(
+        tmp_path,
+        label="v2",
+        mapped_openspec=("lifecycle", "lifecycle-appendix"),
+        mapped_todo_paths=("docs/todo.md", "docs/todo-2.md"),
+        source_revisions=("issue:14@open", "openspec:lifecycle@zzz"),
+    )
+    candidate = _active_candidate(
+        original=original, current=revised, active_plan_review_passed=False
+    )
+    original_key = candidate.active_claim_key
+
+    manual = decide_manual_start(candidate, now_epoch=1_000)
+    auto = decide_auto_claim(candidate, now_epoch=1_000)
+
+    assert manual.action == "resume"
+    assert manual.claim_key == original_key
+    assert auto.action == "resume"
+    assert auto.claim_key == original_key
+
+
+def test_plan_revision_loop_v1_through_v4_never_grows_a_new_generation(
+    tmp_path: Path,
+) -> None:
+    """hippo #18 第 3、7 條 regression：plan review 前反覆修訂不得產生 v3->v4 世代增長。"""
+
+    original = _authority(tmp_path, label="v1")
+    original_key = build_claim_key(_fresh_candidate(original))
+
+    revisions = [
+        _authority(
+            tmp_path,
+            label=f"v{n}",
+            mapped_todo_paths=("docs/todo.md",) + tuple(f"docs/rev-{i}.md" for i in range(n)),
+            source_revisions=("issue:14@open", f"openspec:lifecycle@rev-{n}"),
+        )
+        for n in range(2, 5)
+    ]
+    for revision in revisions:
+        candidate = _active_candidate(
+            original=original, current=revision, active_plan_review_passed=False
+        )
+        decision = decide_auto_claim(candidate, now_epoch=1_000)
+        assert decision.action == "resume", "plan 修訂在 plan review 前不得脫離 resume"
+        assert decision.claim_key == original_key, "authority 世代不得因 plan 修訂增長"
+
+
+def test_without_the_guard_the_same_revision_would_have_superseded(tmp_path: Path) -> None:
+    """對照組：若呼叫端誤把 active_plan_review_passed 設為 True（等同 pre-#213 行為），
+    同一次 plan 修訂會被判定成 authority 變了，逼流程重新決策、生出新 claim_key
+    ——這正是 hippo #18 v3->v4->... 世代增長的成因，用來證明本次 guard 確實生效。
+    """
+
+    original = _authority(tmp_path, label="v1")
+    revised = _authority(
+        tmp_path,
+        label="v2",
+        mapped_openspec=("lifecycle", "lifecycle-appendix"),
+        mapped_todo_paths=("docs/todo.md", "docs/todo-2.md"),
+        source_revisions=("issue:14@open", "openspec:lifecycle@zzz"),
+    )
+    candidate = _active_candidate(
+        original=original, current=revised, active_plan_review_passed=True
+    )
+    decision = decide_auto_claim(candidate, now_epoch=1_000)
+    assert decision.action == "claim"
+    assert decision.claim_key != candidate.active_claim_key
+
+
+# --- AC4：plan review 已通過（既有行為）不受影響 ----------------------------
+
+
+def test_after_plan_review_passes_a_genuine_authority_change_still_forces_redecision(
+    tmp_path: Path,
+) -> None:
+    original = _authority(tmp_path, label="v1")
+    genuinely_different = _authority(tmp_path, label="other-issue", issues=(99,))
+    candidate = replace(
+        _active_candidate(
+            original=original,
+            current=genuinely_different,
+            active_plan_review_passed=True,
+        ),
+        confirmed_issue=99,
+    )
+    decision = decide_auto_claim(candidate, now_epoch=1_000)
+    assert decision.action in {"claim", "needs_human"}
+    if decision.action == "claim":
+        assert decision.claim_key != candidate.active_claim_key
+
+
+def test_active_plan_review_passed_defaults_true_and_preserves_existing_behaviour(
+    tmp_path: Path,
+) -> None:
+    authority = _authority(tmp_path, label="v1")
+    candidate = _fresh_candidate(authority)
+    assert candidate.active_plan_review_passed is True
+    assert candidate.active_claim_identity_digest is None
+    assert decide_manual_start(candidate, now_epoch=1_000).action == "claim"
+
+
+# --- 驗證：欄位型別與必要性 --------------------------------------------------
+
+
+def test_active_plan_review_passed_must_be_boolean(tmp_path: Path) -> None:
+    authority = _authority(tmp_path, label="v1")
+    candidate = _active_candidate(
+        original=authority, current=authority, active_plan_review_passed=True
+    )
+    with pytest.raises(ValueError, match="must be boolean"):
+        decide_auto_claim(
+            replace(candidate, active_plan_review_passed="yes"),  # type: ignore[arg-type]
+            now_epoch=1_000,
+        )
+
+
+def test_pre_freeze_active_claim_identity_digest_is_required(tmp_path: Path) -> None:
+    authority = _authority(tmp_path, label="v1")
+    candidate = _active_candidate(
+        original=authority, current=authority, active_plan_review_passed=False
+    )
+    with pytest.raises(ValueError, match="pre-freeze identity digest"):
+        decide_auto_claim(
+            replace(candidate, active_claim_identity_digest=None),
+            now_epoch=1_000,
+        )
+    with pytest.raises(ValueError, match="pre-freeze identity digest"):
+        decide_auto_claim(
+            replace(candidate, active_claim_identity_digest="not-a-hash"),
+            now_epoch=1_000,
+        )


### PR DESCRIPTION
## 摘要

對應 #208 設計 A.1「凍結點位移」：lifecycle 由 `plan → freeze → build` 改為
`plan → plan review → 修訂 → freeze → build`。plan review（#212 `plan_review_gate()`）
通過之前，plan 修訂造成的 `mapped_openspec`／`mapped_todo_paths`／`source_revisions`
飄移不再被 `claim.py` 誤判為 authority 變更，避免觸發 supersede、生出新世代
（hippo #18 第 3、7 條 v3→v4→… 世代增長）。`final(exact-head)` 不受影響，仍是
candidate 對 frozen plan 的符合度檢查。

## 變更

| 檔案 | 變更 |
| --- | --- |
| `paulsha_cortex/coordinator/claim.py` | 新增 `claim_identity_digest()`（不含 plan 產物欄位的穩定 identity）；`ClaimCandidate` 新增 `active_plan_review_passed`（預設 `True`，向後相容）／`active_claim_identity_digest`；`_existing()` 在 `active_plan_review_passed=False` 時改用穩定 identity 比對，略過完整 digest 的 `expected_key` 驗證；抽出共用的 `_resume_decision()` |
| `paulsha_cortex/coordinator/planning.py` | 新增 `plan_review_freezes_authority()`，把 `plan_review_gate()`（#212，既有介面，未改名）的判定結果對應到「是否可以 freeze」 |
| `tests/test_freeze_after_plan_review.py` | 新檔，覆蓋全部驗收條件（見下） |
| `changelog.d/freeze-after-plan-review.md` | 新增 fragment |

## 驗收條件對應

1. **freeze point 位於 plan review 通過之後**
   - `test_plan_review_freezes_authority_only_when_gate_ready`
   - `test_plan_review_freezes_authority_rejects_terminal_outcome_too`
2. **plan review 前的 plan 修訂不產生 supersede、不變更 authority hash**
   - `test_claim_identity_digest_ignores_plan_artifact_fields`
   - `test_plan_revision_before_review_does_not_supersede_or_change_claim_key`
3. **regression：plan 修訂不再導致 v3→v4 的 authority 世代增長（hippo #18 #3/#7）**
   - `test_plan_revision_loop_v1_through_v4_never_grows_a_new_generation`
   - `test_without_the_guard_the_same_revision_would_have_superseded`（對照組，證明
     guard 若不生效會重現 hippo #18 的世代增長）
4. **既有合法 plan 仍可通過新順序**
   - `test_active_plan_review_passed_defaults_true_and_preserves_existing_behaviour`
   - `test_after_plan_review_passes_a_genuine_authority_change_still_forces_redecision`
   - 既有 `tests/test_work_claim.py`／`tests/test_planning_review_gate.py` 等全數維持綠燈（見 preflight 全量 pytest）

另補：`claim_identity_digest()` 型別防呆、`active_plan_review_passed` 嚴格布林、
`active_claim_identity_digest` 於 pre-freeze 必要性驗證。

## 性質

feat（新增 claim.py／planning.py 純函式與 `ClaimCandidate` 新欄位，皆向後相容、
不改動任何既有呼叫端的預設行為）。

Closes #213

## Checklist

- [x] changelog.d fragment 已新增（R-09）
- [x] 本地 preflight-ci PASS（policy + openspec + pytest）
