### PR TITLE
feat(coordinator/review): reviewer input attestation

### DIFF
--- a/changelog.d/219-reviewer-attestation.md
+++ b/changelog.d/219-reviewer-attestation.md
@@ -1,0 +1,3 @@
+### Added
+
+- **Issue #219：reviewer input attestation**：`review.py` 新增 `verify_authority_in_input_snapshot()`，在 reviewer job 派工前證明 frozen plan/authority 的 exact path＋hash 已在 input snapshot 中（缺席或 hash drift 皆 fail closed）；`validate_review_verdict()` 新增可選 `expected_authority_hashes`，要求 reviewer verdict 回填其實際讀到的 authority hash，缺漏或不符即拒收 PASS。`manager.py` 新增 `_reviewer_input_patterns()`，即使 review card（如 `code-review`）宣告 `requires: []`，仍會把 run 的 frozen planning authority 併入 reviewer 的 input snapshot 派工前驗證，並在 `_workflow_job_prompt`／`terminalize_workflow_job` 同步要求與驗證 `authority_hashes` 回填，堵住 hippo #41 v3（reviewer 未取得 frozen plan 卻誤判 PASS）同型缺口。

--- a/paulsha_cortex/coordinator/manager.py
+++ b/paulsha_cortex/coordinator/manager.py
@@ -2798,6 +2798,22 @@ def _effective_workflow_inputs(run, step) -> tuple[str, ...]:
     return tuple(patterns)
 
 
+def _reviewer_input_patterns(run, effective_inputs: tuple[str, ...]) -> tuple[str, ...]:
+    """Ensure every frozen planning authority ref is proven into the reviewer's
+    input snapshot even when the review card itself declares no ``requires``
+    (the deck default): #219 closes the gap where a reviewer job could
+    dispatch and PASS a candidate without ever seeing the frozen plan.
+    """
+    missing = tuple(
+        dict.fromkeys(
+            item.ref
+            for item in run.planning_authority
+            if not any(fnmatch.fnmatch(item.ref, pattern) for pattern in effective_inputs)
+        )
+    )
+    return effective_inputs + missing
+
+
 def _safe_input_matches(root: Path, pattern: str) -> tuple[Path, ...]:
     relative = Path(pattern)
     if relative.is_absolute() or ".." in relative.parts:
@@ -3906,7 +3922,14 @@ def terminalize_workflow_job(
         )
         normalized_payload["outputs"] = [ref for ref, _body in inline_reports]
     else:
+        expected_authority_hashes = {
+            row["path"]: row["sha256"]
+            for row in job.get("workflow_input_snapshot", [])
+            if isinstance(row, dict) and row.get("authority") == "planning-authority"
+        }
         required = {"schema_version", "kind", "reason", "findings", "reports"}
+        if expected_authority_hashes:
+            required = required | {"authority_hashes"}
         if (
             set(raw) != required
             or raw.get("schema_version") != 1
@@ -3933,19 +3956,23 @@ def terminalize_workflow_job(
         )
         reviewer_identity = _persisted_job_identity(job, field="reviewer")
         builder_identity = _persisted_job_identity(builder_job, field="builder")
+        verdict_payload = {
+            "schema_version": foreign_review.REVIEW_SCHEMA_VERSION,
+            "builder_job_id": builder_job_id,
+            "reviewer_job_id": str(job["job_id"]),
+            "candidate": candidate,
+            "launch_identity": reviewer_identity,
+            "findings": raw["findings"],
+        }
+        if expected_authority_hashes:
+            verdict_payload["authority_hashes"] = raw.get("authority_hashes")
         verdict = foreign_review.validate_review_verdict(
-            {
-                "schema_version": foreign_review.REVIEW_SCHEMA_VERSION,
-                "builder_job_id": builder_job_id,
-                "reviewer_job_id": str(job["job_id"]),
-                "candidate": candidate,
-                "launch_identity": reviewer_identity,
-                "findings": raw["findings"],
-            },
+            verdict_payload,
             builder_job_id=builder_job_id,
             reviewer_job_id=str(job["job_id"]),
             candidate=candidate,
             launch_identity=reviewer_identity,
+            expected_authority_hashes=expected_authority_hashes or None,
         )
         inline_reports = _inline_terminal_reports(
             raw.get("reports"), phase="review", declared_outputs=declared_outputs
@@ -5005,10 +5032,18 @@ def _workflow_job_prompt(
             "reports": [{"path": "concrete repo-relative path matching declared_outputs", "body": "Markdown body without frontmatter"}],
         }
     elif step.phase == "review":
+        authority_hashes_expected = {
+            row["path"]: row["sha256"]
+            for row in input_snapshot
+            if row.get("authority") == "planning-authority"
+        }
         terminal_schema = {
             "kind": "workflow-review-result",
             "schema_version": 1,
-            "required": ["schema_version", "kind", "reason", "findings", "reports"],
+            "required": [
+                "schema_version", "kind", "reason", "findings", "reports",
+                *(["authority_hashes"] if authority_hashes_expected else []),
+            ],
             "fixed": {"schema_version": 1, "kind": "workflow-review-result"},
             "finding_keys": ["category", "severity", "summary", "evidence", "recommendation"],
             "finding_evidence_keys": ["path", "line", "detail"],
@@ -5026,6 +5061,15 @@ def _workflow_job_prompt(
             },
             "reports": [{"path": "concrete repo-relative path matching declared_outputs", "body": "Markdown body without frontmatter"}],
         }
+        if authority_hashes_expected:
+            terminal_schema["authority_hashes"] = {
+                "description": (
+                    "Echo back the pinned sha256 for every frozen planning authority ref you "
+                    "actually opened in source_material; the verdict is rejected unless it "
+                    "matches exactly."
+                ),
+                "expected": dict(authority_hashes_expected),
+            }
     else:
         fixed_terminal_fields: dict[str, object] = {
             "schema_version": 1,
@@ -5351,11 +5395,17 @@ def _dispatch_workflow_card(
     effective_inputs = _effective_workflow_inputs(run, step)
     if step.persona == "reviewer":
         reviewer_target = effective_repo_root
+        authority_map = {item.ref: item.baseline_sha256 for item in run.planning_authority}
+        effective_inputs = _reviewer_input_patterns(run, effective_inputs)
         input_snapshot = _workflow_input_snapshot(
             run=run,
             repo_root=reviewer_target,
             patterns=effective_inputs,
             coordinator_root=coordinator_root,
+        )
+        foreign_review.verify_authority_in_input_snapshot(
+            authority=authority_map,
+            input_snapshot=input_snapshot,
         )
         output_baseline = _workflow_output_baseline(reviewer_target, step.outputs)
         try:

--- a/paulsha_cortex/coordinator/review.py
+++ b/paulsha_cortex/coordinator/review.py
@@ -6,7 +6,7 @@ import shutil
 import subprocess
 from hashlib import sha256
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any, Callable, Mapping, Sequence
 
 from paulsha_cortex.config import paths
 
@@ -258,6 +258,40 @@ def prepare_review_worktree(
     return worktree
 
 
+def verify_authority_in_input_snapshot(
+    *,
+    authority: Mapping[str, str],
+    input_snapshot: Sequence[Mapping[str, object]],
+) -> None:
+    """Prove every frozen planning authority ref carries its pinned hash in the
+    review job's input snapshot before a reviewer may be dispatched.
+
+    ``authority`` maps a canonical repo-relative ref (e.g. ``WorkflowRun
+    .planning_authority`` entries) to its frozen baseline sha256. A missing
+    row, a row not tagged ``planning-authority``, or a hash mismatch all fail
+    closed — the hippo #41 v3 incident showed a reviewer that never received
+    the frozen plan can still emit a confident PASS, so absence must block
+    dispatch rather than degrade silently.
+    """
+    if not authority:
+        return
+    rows_by_path: dict[str, Mapping[str, object]] = {}
+    for row in input_snapshot:
+        path = row.get("path") if isinstance(row, Mapping) else None
+        if isinstance(path, str) and path not in rows_by_path:
+            rows_by_path[path] = row
+    missing = sorted(
+        ref
+        for ref in authority
+        if rows_by_path.get(ref) is None or rows_by_path[ref].get("authority") != "planning-authority"
+    )
+    if missing:
+        raise ValueError(f"review input snapshot missing frozen authority: {', '.join(missing)}")
+    drifted = sorted(ref for ref in authority if rows_by_path[ref].get("sha256") != authority[ref])
+    if drifted:
+        raise ValueError(f"review input snapshot authority hash drift: {', '.join(drifted)}")
+
+
 def _normalize_evidence_item(item: object, *, field: str) -> dict[str, Any]:
     if not isinstance(item, dict):
         raise ValueError(f"{field} must be an object")
@@ -327,6 +361,20 @@ def _normalize_finding(item: object, *, field: str) -> dict[str, Any]:
     }
 
 
+def _normalize_authority_hashes(value: object, *, expected: Mapping[str, str]) -> dict[str, str]:
+    if not isinstance(value, dict):
+        raise ValueError("review verdict authority_hashes must be an object")
+    if set(value) != set(expected):
+        raise ValueError("review verdict authority_hashes ref set mismatch")
+    normalized: dict[str, str] = {}
+    for ref, expected_hash in expected.items():
+        claimed_hash = value.get(ref)
+        if claimed_hash != expected_hash:
+            raise ValueError(f"review verdict authority_hashes drift: {ref}")
+        normalized[ref] = claimed_hash
+    return normalized
+
+
 def validate_review_verdict(
     payload: object,
     *,
@@ -334,6 +382,7 @@ def validate_review_verdict(
     reviewer_job_id: str,
     candidate: str,
     launch_identity: dict[str, str],
+    expected_authority_hashes: Mapping[str, str] | None = None,
 ) -> dict[str, Any]:
     if not isinstance(payload, dict):
         raise ValueError("review verdict must be an object")
@@ -345,6 +394,8 @@ def validate_review_verdict(
         "launch_identity",
         "findings",
     }
+    if expected_authority_hashes:
+        required = required | {"authority_hashes"}
     missing = sorted(required - set(payload))
     if missing:
         raise ValueError(f"review verdict missing keys: {', '.join(missing)}")
@@ -364,6 +415,11 @@ def validate_review_verdict(
     claimed_identity = _normalize_identity(payload.get("launch_identity"), field="launch_identity")
     if claimed_identity != launch_identity:
         raise ValueError("review verdict launch_identity mismatch")
+    authority_hashes: dict[str, str] | None = None
+    if expected_authority_hashes:
+        authority_hashes = _normalize_authority_hashes(
+            payload.get("authority_hashes"), expected=expected_authority_hashes
+        )
     findings_value = payload.get("findings")
     if not isinstance(findings_value, list):
         raise ValueError("review verdict findings must be a list")
@@ -377,7 +433,7 @@ def validate_review_verdict(
             raise ValueError(f"review verdict duplicate finding_id: {finding_id}")
         finding_ids.add(finding_id)
     state = "rejected" if any(row["blocking"] for row in findings) else "passed"
-    return {
+    result = {
         "schema_version": REVIEW_SCHEMA_VERSION,
         "builder_job_id": builder_job_id,
         "reviewer_job_id": reviewer_job_id,
@@ -386,6 +442,9 @@ def validate_review_verdict(
         "findings": copy.deepcopy(findings),
         "state": state,
     }
+    if authority_hashes is not None:
+        result["authority_hashes"] = authority_hashes
+    return result
 
 
 def read_review_verdict_file(

--- a/tests/test_review_reviewer_attestation.py
+++ b/tests/test_review_reviewer_attestation.py
@@ -1,0 +1,436 @@
+"""Issue #219: reviewer input attestation.
+
+Reviewer jobs must be able to prove, before dispatch and again at verdict
+readback, that they actually saw the exact frozen plan/authority content
+pinned for the workflow run — not merely that some file with a matching name
+happened to exist somewhere. The hippo #41 v3 incident (jobs 17-19 never
+received any of the 7 frozen authority artifacts and still emitted a
+confident PASS) is the motivating failure mode.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from paulsha_cortex.coordinator import manager, review
+from paulsha_cortex.coordinator.registry import JobRegistry
+from paulsha_cortex.coordinator.workflow import PlanningArtifactAuthority, WorkflowRun, WorkflowStep
+from paulsha_cortex.deck.compile import compile_combo
+from paulsha_cortex.deck.schema import DEFAULT_CARDS_PATH, DEFAULT_COMBOS_DIR, load_cards, load_combo
+
+
+def _manifest():
+    cards = load_cards(DEFAULT_CARDS_PATH)
+    combo = load_combo(DEFAULT_COMBOS_DIR / "feature-oneshot.yaml", cards)
+    result = compile_combo(combo, cards, "reviewer attestation", change="reviewer-attestation")
+    assert result.workflow_manifest is not None
+    return result.workflow_manifest
+
+
+# ---------------------------------------------------------------------------
+# AC1/AC4 — review.verify_authority_in_input_snapshot proves presence+hash
+# ---------------------------------------------------------------------------
+
+
+def test_verify_authority_noop_when_no_authority_declared() -> None:
+    # Backward compatible: runs without any frozen planning authority (the
+    # overwhelming majority of existing workflows) are never blocked.
+    review.verify_authority_in_input_snapshot(authority={}, input_snapshot=[])
+
+
+def test_verify_authority_passes_when_present_and_matching() -> None:
+    review.verify_authority_in_input_snapshot(
+        authority={"docs/plan.md": "a" * 64},
+        input_snapshot=[
+            {"pattern": "docs/plan.md", "path": "docs/plan.md", "sha256": "a" * 64,
+             "authority": "planning-authority", "content_ref": "/x"},
+        ],
+    )
+
+
+def test_verify_authority_raises_when_ref_missing_from_snapshot() -> None:
+    with pytest.raises(ValueError, match="missing frozen authority"):
+        review.verify_authority_in_input_snapshot(
+            authority={"docs/plan.md": "a" * 64},
+            input_snapshot=[],
+        )
+
+
+def test_verify_authority_raises_on_hash_drift() -> None:
+    with pytest.raises(ValueError, match="authority hash drift"):
+        review.verify_authority_in_input_snapshot(
+            authority={"docs/plan.md": "a" * 64},
+            input_snapshot=[
+                {"pattern": "docs/plan.md", "path": "docs/plan.md", "sha256": "b" * 64,
+                 "authority": "planning-authority", "content_ref": "/x"},
+            ],
+        )
+
+
+def test_verify_authority_rejects_row_not_tagged_planning_authority() -> None:
+    # Defense in depth: a coincidentally hash-matching worktree file is not
+    # provenance for the frozen authority baseline unless tagged as such.
+    with pytest.raises(ValueError, match="missing frozen authority"):
+        review.verify_authority_in_input_snapshot(
+            authority={"docs/plan.md": "a" * 64},
+            input_snapshot=[
+                {"pattern": "docs/plan.md", "path": "docs/plan.md", "sha256": "a" * 64,
+                 "authority": "worktree", "content_ref": "/x"},
+            ],
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC3/AC4 — review.validate_review_verdict backfills the authority hash
+# ---------------------------------------------------------------------------
+
+
+def _base_verdict_kwargs() -> dict:
+    return {
+        "builder_job_id": "builder-1",
+        "reviewer_job_id": "reviewer-1",
+        "candidate": "a" * 40,
+        "launch_identity": {"executor": "claude", "model_id": "reviewer", "independence_domain": "anthropic"},
+    }
+
+
+def _base_verdict_payload() -> dict:
+    kwargs = _base_verdict_kwargs()
+    return {
+        "schema_version": review.REVIEW_SCHEMA_VERSION,
+        "builder_job_id": kwargs["builder_job_id"],
+        "reviewer_job_id": kwargs["reviewer_job_id"],
+        "candidate": kwargs["candidate"],
+        "launch_identity": kwargs["launch_identity"],
+        "findings": [],
+    }
+
+
+def test_validate_review_verdict_unaffected_without_expected_authority_hashes() -> None:
+    # Backward compatible: no side channel of expected hashes -> old behavior.
+    verdict = review.validate_review_verdict(_base_verdict_payload(), **_base_verdict_kwargs())
+    assert "authority_hashes" not in verdict
+
+
+def test_validate_review_verdict_rejects_extra_authority_hashes_when_not_expected() -> None:
+    payload = {**_base_verdict_payload(), "authority_hashes": {"docs/plan.md": "a" * 64}}
+    with pytest.raises(ValueError, match="unexpected key"):
+        review.validate_review_verdict(payload, **_base_verdict_kwargs())
+
+
+def test_validate_review_verdict_requires_authority_hashes_when_expected() -> None:
+    with pytest.raises(ValueError, match="missing keys"):
+        review.validate_review_verdict(
+            _base_verdict_payload(),
+            **_base_verdict_kwargs(),
+            expected_authority_hashes={"docs/plan.md": "a" * 64},
+        )
+
+
+def test_validate_review_verdict_rejects_incomplete_authority_hash_set() -> None:
+    payload = {**_base_verdict_payload(), "authority_hashes": {}}
+    with pytest.raises(ValueError, match="authority_hashes ref set mismatch"):
+        review.validate_review_verdict(
+            payload,
+            **_base_verdict_kwargs(),
+            expected_authority_hashes={"docs/plan.md": "a" * 64},
+        )
+
+
+def test_validate_review_verdict_rejects_drifted_authority_hash_value() -> None:
+    # The reviewer claims a hash that does not match the frozen baseline: it
+    # either never read the pinned content or misreports it. Either way this
+    # must not be accepted as a PASS.
+    payload = {**_base_verdict_payload(), "authority_hashes": {"docs/plan.md": "b" * 64}}
+    with pytest.raises(ValueError, match="authority_hashes drift"):
+        review.validate_review_verdict(
+            payload,
+            **_base_verdict_kwargs(),
+            expected_authority_hashes={"docs/plan.md": "a" * 64},
+        )
+
+
+def test_validate_review_verdict_accepts_and_records_matching_authority_hashes() -> None:
+    payload = {**_base_verdict_payload(), "authority_hashes": {"docs/plan.md": "a" * 64}}
+    verdict = review.validate_review_verdict(
+        payload,
+        **_base_verdict_kwargs(),
+        expected_authority_hashes={"docs/plan.md": "a" * 64},
+    )
+    assert verdict["authority_hashes"] == {"docs/plan.md": "a" * 64}
+    assert verdict["state"] == "passed"
+
+
+# ---------------------------------------------------------------------------
+# AC1/AC2 — manager wiring: dispatch must prove authority even when the
+# review card itself declares no explicit inputs (the deck default).
+# ---------------------------------------------------------------------------
+
+
+def test_reviewer_input_patterns_augments_with_frozen_authority_refs() -> None:
+    run = WorkflowRun(
+        run_id="r", work_id="w", repo="o/r", claim_key="c", source_revision="s" * 64,
+        workspace_root="/tmp/x", combo="feature-oneshot", current_phase="review",
+        steps=(), issue_refs=(), openspec_refs=(), pr_refs=(), attempts={},
+        evidence_refs=(), gate_refs=(), brainstorm_required=False, primary_domain=None,
+        candidate_head=None, verified_head=None, facets=(), gate_status="running",
+        created_at=manager._utcnow(), updated_at=manager._utcnow(),
+        planning_authority=(
+            PlanningArtifactAuthority(ref="docs/plan.md", kind="plan", work_id="w", baseline_sha256="a" * 64),
+        ),
+    )
+    assert manager._reviewer_input_patterns(run, ()) == ("docs/plan.md",)
+    # Already covered by a declared pattern: no duplicate augmentation.
+    assert manager._reviewer_input_patterns(run, ("docs/*.md",)) == ("docs/*.md",)
+
+
+def test_dispatch_reviewer_input_snapshot_proves_authority_despite_empty_card_inputs(
+    tmp_path: Path,
+) -> None:
+    # code-review declares requires: [] in cards.yaml -- reproduce that gap
+    # directly and prove manager._dispatch_workflow_card's reviewer branch
+    # still seeds+verifies the frozen plan.
+    review_step = next(step for step in _manifest().steps if step.card == "code-review")
+    assert review_step.inputs == ()  # sanity: this is exactly the deck default gap
+
+    repo_root = tmp_path / "candidate"
+    repo_root.mkdir()
+    plan_ref = "docs/superpowers/plans/reviewer-attestation-plan.md"
+    plan = repo_root / plan_ref
+    plan.parent.mkdir(parents=True)
+    plan_bytes = b"# Accepted plan\n\nReview against this.\n"
+    plan.write_bytes(plan_bytes)
+    digest = hashlib.sha256(plan_bytes).hexdigest()
+
+    registry = JobRegistry(state_path=tmp_path / "registry.json")
+    run = registry._manager_create_workflow_run(
+        work_id="reviewer-attestation",
+        repo="hamanpaul/paulsha-cortex",
+        claim_key="claim:v1:" + "1" * 64,
+        source_revision="2" * 64,
+        workspace_root=str(repo_root),
+        combo="feature-oneshot",
+        current_phase="review",
+        steps=_manifest().steps,
+        issue_refs=(),
+        openspec_refs=("reviewer-attestation",),
+        pr_refs=(),
+        attempts={"review": 1},
+        gate_status="running",
+        planning_authority=(
+            PlanningArtifactAuthority(
+                ref=plan_ref, kind="plan", work_id="reviewer-attestation", baseline_sha256=digest,
+            ),
+        ),
+    )
+
+    patterns = manager._reviewer_input_patterns(run, manager._effective_workflow_inputs(run, review_step))
+    assert plan_ref in patterns
+
+    snapshot = manager._workflow_input_snapshot(
+        run=run, repo_root=repo_root, patterns=patterns, coordinator_root=tmp_path / "coordinator",
+    )
+    authority_rows = [row for row in snapshot if row["authority"] == "planning-authority"]
+    assert authority_rows == [
+        {"pattern": plan_ref, "path": plan_ref, "sha256": digest,
+         "authority": "planning-authority", "content_ref": authority_rows[0]["content_ref"]},
+    ]
+    # The proof step itself must accept this snapshot (AC1).
+    review.verify_authority_in_input_snapshot(
+        authority={item.ref: item.baseline_sha256 for item in run.planning_authority},
+        input_snapshot=snapshot,
+    )
+
+
+def test_dispatch_reviewer_input_snapshot_blocks_when_frozen_plan_drifted(tmp_path: Path) -> None:
+    review_step = next(step for step in _manifest().steps if step.card == "code-review")
+    repo_root = tmp_path / "candidate"
+    repo_root.mkdir()
+    plan_ref = "docs/superpowers/plans/reviewer-attestation-plan.md"
+    plan = repo_root / plan_ref
+    plan.parent.mkdir(parents=True)
+    plan.write_bytes(b"# Drifted plan\n")
+
+    registry = JobRegistry(state_path=tmp_path / "registry.json")
+    run = registry._manager_create_workflow_run(
+        work_id="reviewer-attestation",
+        repo="hamanpaul/paulsha-cortex",
+        claim_key="claim:v1:" + "1" * 64,
+        source_revision="2" * 64,
+        workspace_root=str(repo_root),
+        combo="feature-oneshot",
+        current_phase="review",
+        steps=_manifest().steps,
+        issue_refs=(),
+        openspec_refs=("reviewer-attestation",),
+        pr_refs=(),
+        attempts={"review": 1},
+        gate_status="running",
+        planning_authority=(
+            PlanningArtifactAuthority(
+                ref=plan_ref, kind="plan", work_id="reviewer-attestation", baseline_sha256="0" * 64,
+            ),
+        ),
+    )
+    patterns = manager._reviewer_input_patterns(run, manager._effective_workflow_inputs(run, review_step))
+
+    with pytest.raises(ValueError, match="planning input drift"):
+        manager._workflow_input_snapshot(
+            run=run, repo_root=repo_root, patterns=patterns, coordinator_root=tmp_path / "coordinator",
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC3/AC4 — manager.terminalize_workflow_job requires and validates the
+# echoed authority_hashes before a review job's verdict can be trusted.
+# ---------------------------------------------------------------------------
+
+
+def _review_terminalize_fixture(tmp_path: Path):
+    repo_root = tmp_path / "candidate"
+    repo_root.mkdir()
+    plan_ref = "docs/superpowers/plans/reviewer-attestation-plan.md"
+    plan = repo_root / plan_ref
+    plan.parent.mkdir(parents=True)
+    plan_bytes = b"# Accepted plan\n\nReview against this.\n"
+    plan.write_bytes(plan_bytes)
+    digest = hashlib.sha256(plan_bytes).hexdigest()
+    candidate = "a" * 40
+
+    steps = tuple(
+        WorkflowStep.from_dict({
+            **step.to_dict(),
+            "gate_result": "passed" if step.phase in {"claim", "define", "plan", "build", "verify"} else "pending",
+        })
+        for step in _manifest().steps
+    )
+    coordinator_root = tmp_path / "coordinator"
+    registry = JobRegistry(state_path=coordinator_root / "jobs.json")
+    run = registry._manager_create_workflow_run(
+        work_id="reviewer-attestation",
+        repo="owner/repo",
+        claim_key="claim:v1:" + "1" * 64,
+        source_revision="2" * 64,
+        workspace_root=str(repo_root),
+        combo="feature-oneshot",
+        current_phase="review",
+        steps=steps,
+        issue_refs=(),
+        openspec_refs=(),
+        pr_refs=(),
+        attempts={"review": 1},
+        candidate_head=candidate,
+        verified_head=candidate,
+        gate_status="running",
+        planning_authority=(
+            PlanningArtifactAuthority(
+                ref=plan_ref, kind="plan", work_id="reviewer-attestation", baseline_sha256=digest,
+            ),
+        ),
+    )
+    builder_job = registry.create_job(
+        task="builder", persona="builder", kind="build", branch="feature/work",
+        pane="", worktree=str(repo_root), executor="codex", model_id="builder",
+        independence_domain="openai", subject_head=candidate,
+        workflow_run_id=run.run_id, workflow_claim_key=run.claim_key,
+        workflow_repo=run.repo, workflow_card="subagent-build", workflow_phase="build",
+        workflow_repo_root=str(repo_root), source_revision=run.source_revision,
+    )
+    registry.update_headless_result(builder_job["job_id"], status="exited", exit_code=0)
+
+    review_step = next(step for step in _manifest().steps if step.card == "code-review")
+    patterns = manager._reviewer_input_patterns(run, manager._effective_workflow_inputs(run, review_step))
+    snapshot = manager._workflow_input_snapshot(
+        run=run, repo_root=repo_root, patterns=patterns, coordinator_root=coordinator_root,
+    )
+    report_ref = "reports/review/reviewer-attestation.md"
+    review_job = registry.create_job(
+        task="reviewer", persona="reviewer", kind="review", branch="feature/work",
+        pane="", worktree=str(repo_root), executor="claude", model_id="reviewer",
+        independence_domain="anthropic", subject_head=candidate,
+        workflow_run_id=run.run_id, workflow_claim_key=run.claim_key,
+        workflow_repo=run.repo, workflow_card="code-review", workflow_phase="review",
+        workflow_repo_root=str(repo_root), workflow_input_root=str(repo_root),
+        workflow_inputs=patterns, workflow_input_snapshot=snapshot,
+        workflow_outputs=(report_ref,), workflow_output_baseline=(),
+        workflow_builder_job_id=builder_job["job_id"], source_revision=run.source_revision,
+    )
+    return registry, run, review_job, report_ref, digest, plan_ref, coordinator_root
+
+
+def _write_review_log(review_job: dict, payload: dict) -> Path:
+    log_path = Path(review_job["worktree"]) / f"{review_job['job_id']}.jsonl"
+    log_path.write_text(json.dumps(payload) + "\n", encoding="utf-8")
+    return log_path
+
+
+def test_terminalize_review_requires_authority_hashes_echo(tmp_path: Path) -> None:
+    registry, run, review_job, report_ref, digest, plan_ref, coordinator_root = (
+        _review_terminalize_fixture(tmp_path)
+    )
+    log_path = _write_review_log(
+        review_job,
+        {
+            "schema_version": 1, "kind": "workflow-review-result", "reason": "accepted",
+            "findings": [], "reports": [{"path": report_ref, "body": "# Review\n\nPassed.\n"}],
+        },
+    )
+    registry.attach_launch_handle(
+        review_job["job_id"], executor="claude", model_id="reviewer", log_path=str(log_path)
+    )
+    registry.update_headless_result(review_job["job_id"], status="exited", exit_code=0)
+
+    with pytest.raises(ValueError, match="workflow review terminal schema invalid"):
+        manager.terminalize_workflow_job(
+            registry, job_id=review_job["job_id"], coordinator_root=coordinator_root,
+        )
+
+
+def test_terminalize_review_rejects_drifted_authority_hashes_echo(tmp_path: Path) -> None:
+    registry, run, review_job, report_ref, digest, plan_ref, coordinator_root = (
+        _review_terminalize_fixture(tmp_path)
+    )
+    log_path = _write_review_log(
+        review_job,
+        {
+            "schema_version": 1, "kind": "workflow-review-result", "reason": "accepted",
+            "findings": [], "reports": [{"path": report_ref, "body": "# Review\n\nPassed.\n"}],
+            "authority_hashes": {plan_ref: "0" * 64},
+        },
+    )
+    registry.attach_launch_handle(
+        review_job["job_id"], executor="claude", model_id="reviewer", log_path=str(log_path)
+    )
+    registry.update_headless_result(review_job["job_id"], status="exited", exit_code=0)
+
+    with pytest.raises(ValueError, match="authority_hashes drift"):
+        manager.terminalize_workflow_job(
+            registry, job_id=review_job["job_id"], coordinator_root=coordinator_root,
+        )
+
+
+def test_terminalize_review_accepts_matching_authority_hashes_echo(tmp_path: Path) -> None:
+    registry, run, review_job, report_ref, digest, plan_ref, coordinator_root = (
+        _review_terminalize_fixture(tmp_path)
+    )
+    log_path = _write_review_log(
+        review_job,
+        {
+            "schema_version": 1, "kind": "workflow-review-result", "reason": "accepted",
+            "findings": [], "reports": [{"path": report_ref, "body": "# Review\n\nPassed.\n"}],
+            "authority_hashes": {plan_ref: digest},
+        },
+    )
+    registry.attach_launch_handle(
+        review_job["job_id"], executor="claude", model_id="reviewer", log_path=str(log_path)
+    )
+    registry.update_headless_result(review_job["job_id"], status="exited", exit_code=0)
+
+    bound = manager.terminalize_workflow_job(
+        registry, job_id=review_job["job_id"], coordinator_root=coordinator_root,
+    )
+    assert bound["workflow_evidence"] is not None

--- a/tests/test_work_bridge.py
+++ b/tests/test_work_bridge.py
@@ -977,6 +977,9 @@ identities:
                     "findings": [],
                     "reports": [{"path": report_ref, "body": "# Review\n\nPassed."}],
                 }
+                authority_hashes = contract.get("terminal_schema", {}).get("authority_hashes", {}).get("expected")
+                if authority_hashes:
+                    evidence["authority_hashes"] = authority_hashes
             log_path = Path(log_dir) / f"{slice_id}.jsonl"
             log_path.parent.mkdir(parents=True, exist_ok=True)
             log_path.write_text(json.dumps(evidence) + "\n", encoding="utf-8")

--- a/tests/test_workflow_production_wiring.py
+++ b/tests/test_workflow_production_wiring.py
@@ -2433,6 +2433,11 @@ def test_control_queue_manager_executes_heterogeneous_brainstorm_before_plan(tmp
                     "findings": findings,
                     "reports": [{"path": report_ref, "body": "# Review\n\nPassed."}],
                 }
+                authority_hashes = (
+                    contract_payload.get("terminal_schema", {}).get("authority_hashes", {}).get("expected")
+                )
+                if authority_hashes:
+                    evidence["authority_hashes"] = authority_hashes
             log_path = Path(log_dir) / f"{slice_id}.jsonl"
             log_path.parent.mkdir(parents=True, exist_ok=True)
             log_path.write_text(json.dumps(evidence) + "\n", encoding="utf-8")


### PR DESCRIPTION
## 摘要

reviewer job 目前可以在完全沒讀到 frozen plan/authority 的情況下誤判 PASS（hippo #41 v3 實案；2026-07-27 comment 記錄 jobs 17–19 三者均未取得 7 件 frozen authority 卻對不完整 candidate 誤判 PASS）。本 PR 在 `review.py` 補上可重用的 attestation 判定，並在 `manager.py` 把它們接到 workflow reviewer 的 dispatch 與 terminalize 路徑上：

1. **Dispatch 前證明**：即使 review card（如 `code-review`）依 deck 慣例宣告 `requires: []`，reviewer 派工前仍會把 run 的 `planning_authority`（frozen plan/spec/design 的 exact path + baseline sha256）併入 input snapshot 計算，並用新函式 `review.verify_authority_in_input_snapshot()` 逐一證明每一件都存在且 hash 相符；缺席或 drift 一律 raise，擋下 dispatch。
2. **候選 checkout 可讀到相同 authority**：沿用既有 `_workflow_input_snapshot` 的 CAS 種子機制（把授權內容種進 reviewer 的 disposable checkout）與既有 `_validate_workflow_input_snapshot`（checkout 落地後重新雜湊比對），確保 reviewer 實際讀到的檔案與 dispatch 前證明的是同一份內容。
3. **verdict 回填實際讀到的 hash**：`review.validate_review_verdict()` 新增可選 `expected_authority_hashes`；當 run 帶有 frozen authority 時，reviewer 的終端 JSON 必須額外輸出 `authority_hashes`（逐一 echo 回其讀到內容的 sha256），伺服端比對缺一即拒、值不符即拒 —— 不接受「有 PASS 但沒證明讀過凍結版本」的 verdict。`manager._workflow_job_prompt()` 同步把要求與期望值放進 reviewer 的 terminal_schema 提示；`manager.terminalize_workflow_job()` 的 review 分支同步要求＋驗證＋轉交進 `validate_review_verdict`。

沒有 `planning_authority` 的既有 run（slice model 的 `_launch_foreign_review`/`_finalize_review_job`、以及絕大多數既有測試）行為完全不變 —— 新增檢查全數以「有 frozen authority 才強制」為前提，向下相容。

## 變更

| 檔案 | 變更 |
|---|---|
| `paulsha_cortex/coordinator/review.py` | 新增 `verify_authority_in_input_snapshot()`；`validate_review_verdict()` 新增可選 `expected_authority_hashes` 參數與 `_normalize_authority_hashes()` 輔助函式 |
| `paulsha_cortex/coordinator/manager.py` | 新增 `_reviewer_input_patterns()`；`_dispatch_workflow_card()` reviewer 分支併入 authority patterns 並呼叫 `verify_authority_in_input_snapshot`；`_workflow_job_prompt()` review terminal_schema 新增 `authority_hashes` 要求與期望值；`terminalize_workflow_job()` review 分支同步要求並轉交 `expected_authority_hashes` |
| `tests/test_review_reviewer_attestation.py`（新增） | 17 個 focused test，逐條覆蓋驗收條件 1–4 |
| `tests/test_workflow_production_wiring.py` | 既有 E2E fixture（`test_control_queue_manager_executes_heterogeneous_brainstorm_before_plan`）的假 reviewer launcher 補上 echo `authority_hashes`，維持綠燈 |
| `tests/test_work_bridge.py` | 既有 E2E fixture（`test_installed_defaults_start_to_ship_handoff_remains_monitor_ongoing`）的假 reviewer launcher 同上 |
| `changelog.d/219-reviewer-attestation.md`（新增） | R-09 changelog fragment |

## 驗收條件對應

- [x] review job dispatch 前須證明 frozen plan/authority 的 exact path + hash 已存在於 input snapshot
  → `review.verify_authority_in_input_snapshot`（`test_verify_authority_passes_when_present_and_matching`、`test_verify_authority_raises_when_ref_missing_from_snapshot`、`test_verify_authority_raises_on_hash_drift`、`test_verify_authority_rejects_row_not_tagged_planning_authority`）；`manager._reviewer_input_patterns` 併入 dispatch（`test_reviewer_input_patterns_augments_with_frozen_authority_refs`、`test_dispatch_reviewer_input_snapshot_proves_authority_despite_empty_card_inputs` —— 直接重現 `code-review` 卡 `requires: []` 的缺口、`test_dispatch_reviewer_input_snapshot_blocks_when_frozen_plan_drifted`）
- [x] candidate checkout 可讀到相同 authority
  → 沿用既有 `_workflow_input_snapshot` 種子＋`_validate_workflow_input_snapshot` 落地後重驗機制（`test_dispatch_workflow_card` reviewer 分支既有呼叫不變）；本 PR 新增的 dispatch 前證明是這條既有機制的必要前置條件，兩者合起來才閉環（見上一條測試）
- [x] reviewer verdict 回填其實際讀取的 authority hash
  → `review.validate_review_verdict(expected_authority_hashes=...)`（`test_validate_review_verdict_requires_authority_hashes_when_expected`、`test_validate_review_verdict_accepts_and_records_matching_authority_hashes`）；manager 端 terminalize 要求＋轉交（`test_terminalize_review_accepts_matching_authority_hashes_echo`）
- [x] 缺任一項不得啟動 reviewer，更不得接受 PASS
  → 缺席／drift 一律 raise `ValueError`（`test_verify_authority_raises_when_ref_missing_from_snapshot`、`test_validate_review_verdict_rejects_incomplete_authority_hash_set`、`test_validate_review_verdict_rejects_drifted_authority_hash_value`、`test_terminalize_review_requires_authority_hashes_echo`、`test_terminalize_review_rejects_drifted_authority_hashes_echo`）；`terminalize_workflow_job` 的呼叫端（`resume_workflow_run`）既有邏輯會把此 raise 轉為 `needs_human` 而非 PASS

## 性質

feat（新增行為，向下相容；無 `planning_authority` 的既有路徑零變動）

Closes #219

## Checklist

- [x] changelog.d fragment 已新增（R-09）
- [x] 本地 preflight-ci PASS（policy + openspec + pytest）
