### PR TITLE
feat(coordinator): band 判定與 CompletionRecord 記錄

### DIFF
--- a/changelog.d/222-sizing-band.md
+++ b/changelog.d/222-sizing-band.md
@@ -1,0 +1,3 @@
+### Added
+
+- **Issue #222：band 判定與 CompletionRecord 記錄**：`claim.py` 新增 `sizing_band()` 純函式，把 #221 `compute_sizing_score()` 的五維總分（0–10）依門檻（Green 0–3／Yellow 4–6／Red 7–10，沿用 `deck.schema.BAND_LEVELS`）換算成 band，供 `claim.py`／`registry.py`／`completion.py` 三處共用同一份門檻；`workflow.py` 的 `WorkflowRun` 新增可選欄位 `sizing_score`／`sizing_band` 作為 work item 快照（`registry.py` 的 `_manager_create_workflow_run`／`_manager_update_workflow_run` 同步支援，每次 repair／re-claim 都由呼叫端重新算過寫入，不沿用 claim 當時判定）；`completion.py` 的 `CompletionRecord` 同步新增可選欄位 `sizing_score`／`sizing_band`（比照 `reused_from` 的 provenance 模式，band 需與 score 門檻一致，排除於 semantic match 之外）與 `sizing_declaration_drift`（記錄宣告模組數 vs candidate 實際變更數，供 #210 後驗）。

--- a/paulsha_cortex/coordinator/claim.py
+++ b/paulsha_cortex/coordinator/claim.py
@@ -13,6 +13,7 @@ from pathlib import PurePosixPath
 from urllib.parse import quote
 
 from paulsha_cortex.config import paths
+from paulsha_cortex.deck.schema import BAND_LEVELS
 
 from . import verification
 
@@ -711,3 +712,27 @@ def build_label_argv(*, repo: str, issue: int, enabled: bool) -> list[str]:
         "DELETE",
         f"repos/{repo}/issues/{issue}/labels/{quote(AUTO_LABEL, safe='')}",
     ]
+
+
+# --- #222（design #208 H.2）：五維 sizing 總分 → band 判定 -------------------
+#
+# band 字串沿用 deck.schema.BAND_LEVELS（green/yellow/red），不得另立常數或大小
+# 寫變體。閾值 Green 0–3／Yellow 4–6／Red 7–10，對應 planning.SizingScore.total
+# （五維、每維 0–2、總分 0–10，見 #221）。claim.py／registry.py／completion.py
+# 三處共用這份純函式，避免各自硬編碼門檻造成漂移。band 本身只負責重算與記錄
+# （#222）；跨帶上升後的拆分「路由」屬 #223，不在本模組範圍。
+SIZING_BAND_GREEN_MAX = 3
+SIZING_BAND_YELLOW_MAX = 6
+
+
+def sizing_band(total: int) -> str:
+    """五維 sizing 總分（0–10）→ band。呼叫端每次 repair／re-claim 都須重新
+    傳入當下算出的 total，不得沿用 claim 當時判定的舊值（#222 驗收條件 3）。
+    """
+    if not isinstance(total, int) or isinstance(total, bool) or not (0 <= total <= 10):
+        raise ValueError("sizing total 必須為 0–10 的整數")
+    if total <= SIZING_BAND_GREEN_MAX:
+        return BAND_LEVELS[0]
+    if total <= SIZING_BAND_YELLOW_MAX:
+        return BAND_LEVELS[1]
+    return BAND_LEVELS[2]

--- a/paulsha_cortex/coordinator/completion.py
+++ b/paulsha_cortex/coordinator/completion.py
@@ -8,7 +8,9 @@ from typing import Any
 from uuid import uuid4
 
 from paulsha_cortex.config import paths
+from paulsha_cortex.deck.schema import BAND_LEVELS
 
+from . import claim
 from . import review as foreign_review
 from . import verification
 
@@ -44,6 +46,15 @@ RETRY_CLASSIFICATION_VALUES = frozenset(
 # 漏檢（plan_review_gate 判定通過，但 final 才發現問題其實出在 plan）。純
 # provenance，不影響既有 completion 語意，semantic match 排除比照 reused_from。
 VALID_FINAL_DEFECT_LOCI = frozenset({"plan", "candidate"})
+# #222（design #208 H.2）：五維 sizing 總分／band／宣告-實際模組數落差記錄。
+# sizing_score/sizing_band 是 work item 狀態（WorkflowRun，見 workflow.py）在
+# completion 當下的快照，band 門檻判定委派給 claim.sizing_band()（claim.py／
+# registry.py／completion.py 三處共用同一份純函式，避免各自硬編碼漂移）；
+# sizing_declaration_drift 記錄宣告模組數 vs candidate 實際變更數（供 #210
+# 後驗）。比照 #215 的 reused_from/retry_classification/final_defect_locus：
+# 可選欄位＋_normalize_*＋extras 白名單聯集；三者皆屬 work item 狀態快照／
+# provenance，不影響既有 completion 語意，semantic match 排除。
+SIZING_DECLARATION_DRIFT_FIELDS = frozenset({"declared_modules", "actual_modules"})
 
 
 def classify_completion(*, exit_code: int, last_jsonl_line: str | None) -> str:
@@ -248,6 +259,30 @@ def _normalize_final_defect_locus(value: object) -> str:
     return value
 
 
+def _normalize_sizing_score(value: object) -> int:
+    if not isinstance(value, int) or isinstance(value, bool) or not (0 <= value <= 10):
+        raise ValueError("completion sizing_score must be an int in [0, 10]")
+    return value
+
+
+def _normalize_sizing_band(value: object) -> str:
+    if value not in BAND_LEVELS:
+        raise ValueError(f"completion sizing_band must be one of {list(BAND_LEVELS)}")
+    return value
+
+
+def _normalize_sizing_declaration_drift(value: object) -> dict[str, int]:
+    if not isinstance(value, dict) or set(value) != SIZING_DECLARATION_DRIFT_FIELDS:
+        raise ValueError("completion sizing_declaration_drift malformed")
+    declared = value.get("declared_modules")
+    actual = value.get("actual_modules")
+    if not isinstance(declared, int) or isinstance(declared, bool) or declared < 0:
+        raise ValueError("completion sizing_declaration_drift.declared_modules invalid")
+    if not isinstance(actual, int) or isinstance(actual, bool) or actual < 0:
+        raise ValueError("completion sizing_declaration_drift.actual_modules invalid")
+    return {"declared_modules": declared, "actual_modules": actual}
+
+
 def validate_completion_record(payload: object) -> dict[str, Any]:
     if not isinstance(payload, dict):
         raise ValueError("completion record must be an object")
@@ -277,7 +312,8 @@ def validate_completion_record(payload: object) -> dict[str, Any]:
     if missing:
         raise ValueError(f"completion record missing keys: {', '.join(missing)}")
     extras = set(payload) - required - {
-        "work_authority", "reused_from", "retry_classification", "final_defect_locus"
+        "work_authority", "reused_from", "retry_classification", "final_defect_locus",
+        "sizing_score", "sizing_band", "sizing_declaration_drift",
     }
     if extras:
         raise ValueError(f"completion record unexpected key: {sorted(extras)[0]}")
@@ -332,6 +368,21 @@ def validate_completion_record(payload: object) -> dict[str, Any]:
         )
     if "final_defect_locus" in payload:
         normalized["final_defect_locus"] = _normalize_final_defect_locus(payload["final_defect_locus"])
+    if ("sizing_score" in payload) != ("sizing_band" in payload):
+        raise ValueError("completion sizing_score/sizing_band must be supplied together")
+    if "sizing_score" in payload:
+        normalized["sizing_score"] = _normalize_sizing_score(payload["sizing_score"])
+        normalized["sizing_band"] = _normalize_sizing_band(payload["sizing_band"])
+        expected_band = claim.sizing_band(normalized["sizing_score"])
+        if normalized["sizing_band"] != expected_band:
+            raise ValueError(
+                "completion sizing_band does not match sizing_score threshold "
+                f"(#222 H.2): expected {expected_band!r}, got {normalized['sizing_band']!r}"
+            )
+    if "sizing_declaration_drift" in payload:
+        normalized["sizing_declaration_drift"] = _normalize_sizing_declaration_drift(
+            payload["sizing_declaration_drift"]
+        )
 
     reviewer_job_id = normalized["reviewer_job_id"]
     review_path = normalized["review_evaluation_path"]
@@ -390,6 +441,12 @@ def completion_records_semantically_match(existing: object, incoming: object) ->
     incoming_normalized.pop("retry_classification", None)
     existing_normalized.pop("final_defect_locus", None)
     incoming_normalized.pop("final_defect_locus", None)
+    existing_normalized.pop("sizing_score", None)
+    incoming_normalized.pop("sizing_score", None)
+    existing_normalized.pop("sizing_band", None)
+    incoming_normalized.pop("sizing_band", None)
+    existing_normalized.pop("sizing_declaration_drift", None)
+    incoming_normalized.pop("sizing_declaration_drift", None)
     return existing_normalized == incoming_normalized and existing_authority == incoming_authority
 
 

--- a/paulsha_cortex/coordinator/registry.py
+++ b/paulsha_cortex/coordinator/registry.py
@@ -1215,6 +1215,8 @@ class JobRegistry:
         facets: tuple[str, ...] = (),
         gate_status: str = "pending",
         planning_authority: tuple[PlanningArtifactAuthority, ...] = (),
+        sizing_score: int | None = None,
+        sizing_band: str | None = None,
     ) -> WorkflowRun:
         for existing in self._workflows:
             if existing.claim_key != claim_key:
@@ -1253,6 +1255,8 @@ class JobRegistry:
             updated_at=now,
             planning_authority=tuple(planning_authority),
             planning_source_revision=source_revision,
+            sizing_score=sizing_score,
+            sizing_band=sizing_band,
         )
         superseded_at = _now_iso()
         next_workflows = [
@@ -1300,6 +1304,8 @@ class JobRegistry:
         completion_source_revisions: dict[str, str] | None = None,
         pr_candidate: str | None = None,
         merge_revision: str | None = None,
+        sizing_score: int | None = None,
+        sizing_band: str | None = None,
     ) -> WorkflowRun:
         index = self._find_workflow_run_index(run_id)
         current = self._workflows[index]
@@ -1366,6 +1372,8 @@ class JobRegistry:
             ),
             pr_candidate=current.pr_candidate if pr_candidate is None else pr_candidate,
             merge_revision=current.merge_revision if merge_revision is None else merge_revision,
+            sizing_score=current.sizing_score if sizing_score is None else sizing_score,
+            sizing_band=current.sizing_band if sizing_band is None else sizing_band,
         )
         self._workflows[index] = updated
         self._persist()

--- a/paulsha_cortex/coordinator/workflow.py
+++ b/paulsha_cortex/coordinator/workflow.py
@@ -5,6 +5,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
+from .claim import sizing_band as compute_sizing_band
+
 
 DEFAULT_WORKFLOW_COMBO = "feature-oneshot"
 WORKFLOW_MANIFEST_VERSION = 1
@@ -306,6 +308,13 @@ class WorkflowRun:
     completion_source_revisions: dict[str, str] = field(default_factory=dict)
     pr_candidate: str | None = None
     merge_revision: str | None = None
+    # #222（design #208 H.2）：五維 sizing 總分／band 的 work item 快照，供中途
+    # 查詢。band 字串沿用 deck.schema.BAND_LEVELS，不得另立常數或大小寫變體；
+    # 門檻判定的純函式在 claim.sizing_band()（claim.py／registry.py／
+    # completion.py 三處共用）。每次 repair／re-claim 都須由呼叫端重新算過再
+    # 寫入，這裡只負責持有最新一次的快照，不做「沿用舊值」的隱含保證。
+    sizing_score: int | None = None
+    sizing_band: str | None = None
 
     def __post_init__(self) -> None:
         for field, value in (
@@ -399,6 +408,19 @@ class WorkflowRun:
             raise ValueError("workflow completion source revisions require completion fields")
         if self.status == "done" and not all(completion_values):
             raise ValueError("done workflow requires bound completion evidence")
+        if (self.sizing_score is None) != (self.sizing_band is None):
+            raise ValueError("workflow run sizing_score/sizing_band must be supplied together")
+        if self.sizing_score is not None:
+            # compute_sizing_band()（claim.sizing_band，#222 H.2）同時完成型別／
+            # 範圍檢查與門檻判定；sizing_band 若與門檻算出的預期值不符（含大小寫
+            # 變體、非法字串）在此一併 fail-closed，不必另外重複驗證 BAND_LEVELS
+            # 成員資格。
+            expected_band = compute_sizing_band(self.sizing_score)
+            if self.sizing_band != expected_band:
+                raise ValueError(
+                    "workflow run sizing_band 與 sizing_score 門檻不符"
+                    f"（預期 {expected_band!r}，實得 {self.sizing_band!r}）"
+                )
         if self.gate_status == "passed":
             required_kinds = ["foreign-review"]
             if self.brainstorm_required:
@@ -470,6 +492,8 @@ class WorkflowRun:
             "completion_source_revisions": dict(self.completion_source_revisions),
             "pr_candidate": self.pr_candidate,
             "merge_revision": self.merge_revision,
+            "sizing_score": self.sizing_score,
+            "sizing_band": self.sizing_band,
         }
 
     @classmethod
@@ -542,6 +566,8 @@ class WorkflowRun:
             completion_source_revisions=dict(payload.get("completion_source_revisions", {})),
             pr_candidate=payload.get("pr_candidate"),
             merge_revision=payload.get("merge_revision"),
+            sizing_score=payload.get("sizing_score"),
+            sizing_band=payload.get("sizing_band"),
         )
 
 

--- a/paulsha_cortex/monitor/providers.py
+++ b/paulsha_cortex/monitor/providers.py
@@ -369,6 +369,8 @@ _WORKFLOW_V2_OPTIONAL_ROW_KEYS = frozenset(
         "brainstorm_required", "primary_domain", "candidate_head",
         "verified_head", "gate_status", "completion_source_revisions",
         "planning_authority", "planning_source_revision",
+        # #222（design #208 H.2）：五維 sizing 總分／band 的 work item 快照。
+        "sizing_score", "sizing_band",
     }
 )
 

--- a/tests/test_claim_sizing_band.py
+++ b/tests/test_claim_sizing_band.py
@@ -1,0 +1,49 @@
+"""#222（design #208 H.2）：五維 sizing 總分 → band 判定純函式。
+
+claim.sizing_band() 是 claim.py／registry.py／completion.py 三處共用的門檻判定，
+避免各自硬編碼 Green/Yellow/Red 門檻造成漂移。band 字串必須沿用
+deck.schema.BAND_LEVELS，不得另立常數或大小寫變體。
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from paulsha_cortex.coordinator import claim
+from paulsha_cortex.deck.schema import BAND_LEVELS
+
+
+class SizingBandThresholdTests(unittest.TestCase):
+    def test_green_band_covers_zero_to_three(self) -> None:
+        for total in (0, 1, 2, 3):
+            self.assertEqual(claim.sizing_band(total), "green")
+
+    def test_yellow_band_covers_four_to_six(self) -> None:
+        for total in (4, 5, 6):
+            self.assertEqual(claim.sizing_band(total), "yellow")
+
+    def test_red_band_covers_seven_to_ten(self) -> None:
+        for total in (7, 8, 9, 10):
+            self.assertEqual(claim.sizing_band(total), "red")
+
+    def test_returned_band_is_a_deck_schema_band_level(self) -> None:
+        for total in range(0, 11):
+            self.assertIn(claim.sizing_band(total), BAND_LEVELS)
+
+    def test_out_of_range_total_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            claim.sizing_band(-1)
+        with self.assertRaises(ValueError):
+            claim.sizing_band(11)
+
+    def test_non_integer_total_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            claim.sizing_band(3.0)
+        with self.assertRaises(ValueError):
+            claim.sizing_band("3")
+        with self.assertRaises(ValueError):
+            claim.sizing_band(True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_completion_sizing_band.py
+++ b/tests/test_completion_sizing_band.py
@@ -1,0 +1,188 @@
+"""#222（design #208 H.2）：CompletionRecord 新增 sizing_score/sizing_band/
+sizing_declaration_drift 三個可選 provenance 欄位。
+
+比照 #212 final_defect_locus 的模式（見 test_completion_final_defect_locus.py）：
+可選欄位＋_normalize_*＋extras 白名單聯集；band 屬 work item 狀態快照，
+semantic match 需忽略它（比照 reused_from）。sizing_band 必須與 sizing_score
+依 claim.sizing_band() 算出的門檻一致，否則 fail-closed。
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from paulsha_cortex.coordinator import claim, completion
+
+
+def _base_payload(**overrides: object) -> dict:
+    payload = {
+        "schema_version": completion.COMPLETION_SCHEMA_VERSION,
+        "slice_id": "sizing-band-gate",
+        "spec_hash": "1" * 64,
+        "plan_hash": "2" * 64,
+        "verification_hash": "3" * 64,
+        "builder_job_id": "builder-1",
+        "reviewer_job_id": None,
+        "dispatch_base": "a" * 40,
+        "candidate": "b" * 40,
+        "target_branch": "main",
+        "target_remote": "origin",
+        "target_ref": "refs/remotes/origin/main",
+        "target_ref_sha": "c" * 40,
+        "verification_evidence_path": "evidence/verification.json",
+        "verification_evidence_hash": "4" * 64,
+        "review_policy": "not-required",
+        "docs_class": "trivial",
+        "review_evaluation_path": None,
+        "review_evaluation_hash": None,
+        "completed_at": "2026-07-27T00:00:00+00:00",
+    }
+    payload.update(overrides)
+    return payload
+
+
+class SizingScoreBandValidationTests(unittest.TestCase):
+    def test_absent_sizing_fields_still_validate(self) -> None:
+        normalized = completion.validate_completion_record(_base_payload())
+        self.assertNotIn("sizing_score", normalized)
+        self.assertNotIn("sizing_band", normalized)
+
+    def test_consistent_score_and_band_round_trip(self) -> None:
+        normalized = completion.validate_completion_record(
+            _base_payload(sizing_score=2, sizing_band="green")
+        )
+        self.assertEqual(normalized["sizing_score"], 2)
+        self.assertEqual(normalized["sizing_band"], "green")
+
+    def test_all_three_bands_accept_their_matching_score_range(self) -> None:
+        for total, band in ((0, "green"), (3, "green"), (4, "yellow"), (6, "yellow"), (7, "red"), (10, "red")):
+            with self.subTest(total=total, band=band):
+                normalized = completion.validate_completion_record(
+                    _base_payload(sizing_score=total, sizing_band=band)
+                )
+                self.assertEqual(normalized["sizing_band"], band)
+                self.assertEqual(normalized["sizing_band"], claim.sizing_band(total))
+
+    def test_score_without_band_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            completion.validate_completion_record(_base_payload(sizing_score=2))
+
+    def test_band_without_score_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            completion.validate_completion_record(_base_payload(sizing_band="green"))
+
+    def test_band_not_matching_score_threshold_rejected(self) -> None:
+        # 8 落在 red 區間；宣稱 green 必須 fail-closed。
+        with self.assertRaises(ValueError):
+            completion.validate_completion_record(
+                _base_payload(sizing_score=8, sizing_band="green")
+            )
+
+    def test_case_variant_band_string_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            completion.validate_completion_record(
+                _base_payload(sizing_score=0, sizing_band="Green")
+            )
+
+    def test_score_out_of_range_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            completion.validate_completion_record(
+                _base_payload(sizing_score=11, sizing_band="red")
+            )
+
+    def test_non_integer_score_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            completion.validate_completion_record(
+                _base_payload(sizing_score=2.0, sizing_band="green")
+            )
+
+
+class SizingDeclarationDriftValidationTests(unittest.TestCase):
+    def test_absent_drift_still_validates(self) -> None:
+        normalized = completion.validate_completion_record(_base_payload())
+        self.assertNotIn("sizing_declaration_drift", normalized)
+
+    def test_drift_round_trips(self) -> None:
+        normalized = completion.validate_completion_record(
+            _base_payload(
+                sizing_declaration_drift={"declared_modules": 2, "actual_modules": 5}
+            )
+        )
+        self.assertEqual(
+            normalized["sizing_declaration_drift"],
+            {"declared_modules": 2, "actual_modules": 5},
+        )
+
+    def test_drift_independent_of_sizing_score_band(self) -> None:
+        # sizing_declaration_drift 可單獨出現，不強制與 sizing_score/sizing_band 成對。
+        normalized = completion.validate_completion_record(
+            _base_payload(
+                sizing_declaration_drift={"declared_modules": 1, "actual_modules": 1}
+            )
+        )
+        self.assertNotIn("sizing_score", normalized)
+        self.assertNotIn("sizing_band", normalized)
+
+    def test_missing_key_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            completion.validate_completion_record(
+                _base_payload(sizing_declaration_drift={"declared_modules": 1})
+            )
+
+    def test_extra_key_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            completion.validate_completion_record(
+                _base_payload(
+                    sizing_declaration_drift={
+                        "declared_modules": 1,
+                        "actual_modules": 1,
+                        "note": "extra",
+                    }
+                )
+            )
+
+    def test_negative_counts_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            completion.validate_completion_record(
+                _base_payload(
+                    sizing_declaration_drift={"declared_modules": -1, "actual_modules": 1}
+                )
+            )
+
+    def test_non_int_counts_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            completion.validate_completion_record(
+                _base_payload(
+                    sizing_declaration_drift={"declared_modules": "1", "actual_modules": 1}
+                )
+            )
+
+
+class SizingFieldsSemanticMatchTests(unittest.TestCase):
+    def test_sizing_score_and_band_excluded_from_semantic_match(self) -> None:
+        existing = _base_payload()
+        incoming = _base_payload(sizing_score=8, sizing_band="red")
+        self.assertTrue(completion.completion_records_semantically_match(existing, incoming))
+
+    def test_differing_sizing_score_and_band_still_matches(self) -> None:
+        existing = _base_payload(sizing_score=2, sizing_band="green")
+        incoming = _base_payload(sizing_score=8, sizing_band="red")
+        self.assertTrue(completion.completion_records_semantically_match(existing, incoming))
+
+    def test_sizing_declaration_drift_excluded_from_semantic_match(self) -> None:
+        existing = _base_payload()
+        incoming = _base_payload(
+            sizing_declaration_drift={"declared_modules": 1, "actual_modules": 9}
+        )
+        self.assertTrue(completion.completion_records_semantically_match(existing, incoming))
+
+    def test_real_conflict_still_detected_alongside_sizing_fields(self) -> None:
+        existing = _base_payload(sizing_score=2, sizing_band="green")
+        incoming = _base_payload(
+            sizing_score=2, sizing_band="green", candidate="d" * 40
+        )
+        self.assertFalse(completion.completion_records_semantically_match(existing, incoming))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_registry_sizing_band.py
+++ b/tests/test_registry_sizing_band.py
@@ -1,0 +1,117 @@
+"""#222（design #208 H.2）：sizing_score／sizing_band 寫入 work item（WorkflowRun）。
+
+驗收條件 3：每次 repair／re-claim 後重算 band，不得沿用 claim 當時判定——這裡
+驗證 registry 的 _manager_create_workflow_run／_manager_update_workflow_run
+機制本身支援每次覆寫成新算出的值（呼叫端每次都要重新傳入，不會被悄悄沿用舊
+band），而非把 claim 當時的判定當成永久快照。
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from paulsha_cortex.coordinator.registry import JobRegistry
+from paulsha_cortex.coordinator.workflow import WorkflowStep
+
+
+def _step(phase: str = "plan") -> WorkflowStep:
+    return WorkflowStep(
+        phase=phase,
+        persona="planner" if phase == "plan" else "builder",
+        card="writing-plans" if phase == "plan" else "test-driven-development",
+        executor="agy",
+        model="gemini-3.1-pro-high",
+        domain="google",
+        inputs=(),
+        outputs=(),
+        gate_result="pending",
+    )
+
+
+def _create_run(registry: JobRegistry, **overrides: object):
+    fields: dict[str, object] = {
+        "work_id": "sizing-band-work",
+        "repo": "hamanpaul/paulsha-cortex",
+        "claim_key": "claim:v1:" + "a" * 64,
+        "source_revision": "rev-a",
+        "workspace_root": "/tmp/paulsha-cortex",
+        "combo": "feature-oneshot",
+        "current_phase": "plan",
+        "steps": (_step(),),
+    }
+    fields.update(overrides)
+    return registry._manager_create_workflow_run(**fields)
+
+
+def test_create_workflow_run_persists_initial_sizing_snapshot(tmp_path: Path) -> None:
+    state = tmp_path / "jobs.json"
+    registry = JobRegistry(state_path=state)
+    created = _create_run(registry, sizing_score=8, sizing_band="red")
+
+    assert created.sizing_score == 8
+    assert created.sizing_band == "red"
+    reloaded = JobRegistry(state_path=state)
+    assert reloaded.get_workflow_run(created.run_id).sizing_score == 8
+    assert reloaded.get_workflow_run(created.run_id).sizing_band == "red"
+
+
+def test_update_after_repair_recomputes_band_and_does_not_keep_claim_time_value(
+    tmp_path: Path,
+) -> None:
+    state = tmp_path / "jobs.json"
+    registry = JobRegistry(state_path=state)
+    created = _create_run(registry, sizing_score=8, sizing_band="red")
+
+    # 模擬 repair 後重算：分數大幅下降，band 從 red 掉到 green。
+    repaired = registry._manager_update_workflow_run(
+        created.run_id,
+        current_phase="build",
+        sizing_score=2,
+        sizing_band="green",
+    )
+    assert repaired.sizing_score == 2
+    assert repaired.sizing_band == "green"
+    # 不得殘留 claim 當時的 red 判定。
+    assert repaired.sizing_score != created.sizing_score
+    assert repaired.sizing_band != created.sizing_band
+
+    persisted = JobRegistry(state_path=state).get_workflow_run(created.run_id)
+    assert persisted.sizing_score == 2
+    assert persisted.sizing_band == "green"
+
+
+def test_update_without_sizing_args_carries_forward_last_recorded_snapshot(
+    tmp_path: Path,
+) -> None:
+    state = tmp_path / "jobs.json"
+    registry = JobRegistry(state_path=state)
+    created = _create_run(registry, sizing_score=5, sizing_band="yellow")
+
+    unrelated_update = registry._manager_update_workflow_run(
+        created.run_id,
+        current_phase="build",
+    )
+    assert unrelated_update.sizing_score == 5
+    assert unrelated_update.sizing_band == "yellow"
+
+
+def test_mismatched_score_and_band_pair_rejected_on_create(tmp_path: Path) -> None:
+    state = tmp_path / "jobs.json"
+    registry = JobRegistry(state_path=state)
+    with pytest.raises(ValueError):
+        _create_run(registry, sizing_score=8, sizing_band="green")
+
+
+def test_mismatched_score_and_band_pair_rejected_on_update(tmp_path: Path) -> None:
+    state = tmp_path / "jobs.json"
+    registry = JobRegistry(state_path=state)
+    created = _create_run(registry, sizing_score=1, sizing_band="green")
+    with pytest.raises(ValueError):
+        registry._manager_update_workflow_run(
+            created.run_id,
+            current_phase="build",
+            sizing_score=9,
+            sizing_band="green",
+        )

--- a/tests/test_workflow_run_sizing_band.py
+++ b/tests/test_workflow_run_sizing_band.py
@@ -1,0 +1,105 @@
+"""#222（design #208 H.2）：WorkflowRun 新增 sizing_score／sizing_band 快照欄位。
+
+比照既有 pr_candidate/merge_revision 的 optional trailer 欄位模式：預設 None，
+成對出現（有一個就兩個都要），band 字串沿用 deck.schema.BAND_LEVELS。
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from paulsha_cortex.coordinator.workflow import WorkflowRun, WorkflowStep
+
+
+def _step() -> WorkflowStep:
+    return WorkflowStep(
+        phase="build",
+        persona="builder",
+        card="test-driven-development",
+        executor="agy",
+        model="gemini-3.1-pro-high",
+        domain="google",
+        inputs=(),
+        outputs=(),
+        gate_result="pending",
+    )
+
+
+def _run(**overrides: object) -> WorkflowRun:
+    fields: dict[str, object] = {
+        "run_id": "workflow-sizing-band",
+        "work_id": "sizing-band-work",
+        "repo": "hamanpaul/paulsha-cortex",
+        "claim_key": "claim:v1:" + "a" * 64,
+        "source_revision": "rev-a",
+        "workspace_root": "/tmp/paulsha-cortex",
+        "combo": "feature-oneshot",
+        "current_phase": "build",
+        "steps": (_step(),),
+        "issue_refs": (),
+        "openspec_refs": (),
+        "pr_refs": (),
+        "attempts": {},
+        "evidence_refs": (),
+        "gate_refs": (),
+        "brainstorm_required": False,
+        "primary_domain": None,
+        "candidate_head": None,
+        "verified_head": None,
+        "facets": (),
+        "gate_status": "pending",
+        "created_at": "2026-07-27T00:00:00+00:00",
+        "updated_at": "2026-07-27T00:00:00+00:00",
+    }
+    fields.update(overrides)
+    return WorkflowRun(**fields)
+
+
+class WorkflowRunSizingBandTests(unittest.TestCase):
+    def test_defaults_to_none(self) -> None:
+        run = _run()
+        self.assertIsNone(run.sizing_score)
+        self.assertIsNone(run.sizing_band)
+
+    def test_valid_pair_round_trips_through_to_dict_from_dict(self) -> None:
+        run = _run(sizing_score=8, sizing_band="red")
+        self.assertEqual(run.sizing_score, 8)
+        self.assertEqual(run.sizing_band, "red")
+        payload = run.to_dict()
+        self.assertEqual(payload["sizing_score"], 8)
+        self.assertEqual(payload["sizing_band"], "red")
+        restored = WorkflowRun.from_dict(payload)
+        self.assertEqual(restored.sizing_score, 8)
+        self.assertEqual(restored.sizing_band, "red")
+
+    def test_from_dict_without_sizing_fields_defaults_to_none(self) -> None:
+        payload = _run().to_dict()
+        payload.pop("sizing_score")
+        payload.pop("sizing_band")
+        restored = WorkflowRun.from_dict(payload)
+        self.assertIsNone(restored.sizing_score)
+        self.assertIsNone(restored.sizing_band)
+
+    def test_score_without_band_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            _run(sizing_score=2)
+
+    def test_band_without_score_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            _run(sizing_band="green")
+
+    def test_score_out_of_range_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            _run(sizing_score=11, sizing_band="red")
+        with self.assertRaises(ValueError):
+            _run(sizing_score=-1, sizing_band="green")
+
+    def test_unknown_band_string_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            _run(sizing_score=1, sizing_band="Green")  # 大小寫變體不合法
+        with self.assertRaises(ValueError):
+            _run(sizing_score=1, sizing_band="amber")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 摘要

對應 `#208` 設計 H.2（4/10 Yellow），依賴已 merge 的 `#221`（`planning.compute_sizing_score()`）。
新增 band 判定純函式，把 #221 算出的五維總分換算成 Green/Yellow/Red，並把 `sizing_score`／
`sizing_band` 寫入 work item（`WorkflowRun`）與 `CompletionRecord`；每次 repair／re-claim 都由
呼叫端重新算過再寫入，不沿用 claim 當時的判定；`CompletionRecord` 同步新增
`sizing_declaration_drift`，記錄宣告模組數 vs candidate 實際變更數（供 `#210` 後驗）。

band 是 work item 屬性，非 issue 屬性；跨帶上升後的拆分「路由」屬 `#223`，本單只負責重算與記錄。

## 變更

| 檔案 | 變更 |
|---|---|
| `paulsha_cortex/coordinator/claim.py` | 新增 `sizing_band(total)` 純函式（Green 0–3／Yellow 4–6／Red 7–10，band 字串沿用 `deck.schema.BAND_LEVELS`），claim.py／registry.py／completion.py 三處共用同一份門檻 |
| `paulsha_cortex/coordinator/workflow.py` | `WorkflowRun` 新增可選欄位 `sizing_score`／`sizing_band`（成對出現，band 須與 score 門檻一致，委派 `claim.sizing_band()` 驗證），`to_dict`/`from_dict` 同步 |
| `paulsha_cortex/coordinator/registry.py` | `_manager_create_workflow_run`／`_manager_update_workflow_run` 新增 `sizing_score`／`sizing_band` 參數並持久化 |
| `paulsha_cortex/coordinator/completion.py` | `CompletionRecord` 新增可選欄位 `sizing_score`／`sizing_band`（band 需與 score 門檻一致）與 `sizing_declaration_drift`（`declared_modules`／`actual_modules`）；比照 `reused_from`／`retry_classification`／`final_defect_locus` 模式排除於 semantic match 之外 |
| `paulsha_cortex/monitor/providers.py` | `_WORKFLOW_V2_OPTIONAL_ROW_KEYS` 補上新欄位（monitor 對 `WorkflowRun` 欄位的 read-only allowlist，缺漏會讓 provider fail-closed 成 `degraded`） |
| `changelog.d/222-sizing-band.md` | 新增 fragment |
| `tests/test_claim_sizing_band.py` 等 4 個新測試檔 | 見下方驗收條件對應 |

## 驗收條件對應

- [x] band 判定閾值：Green 0–3、Yellow 4–6、Red 7–10
  - `tests/test_claim_sizing_band.py`：`SizingBandThresholdTests`（三段邊界值、範圍外/非 int 拒收、回傳值必為 `deck.schema.BAND_LEVELS` 成員）
- [x] `sizing_score`／`sizing_band` 寫入 work item 與 CompletionRecord
  - `tests/test_workflow_run_sizing_band.py`：`WorkflowRunSizingBandTests`（`WorkflowRun` 欄位驗證、`to_dict`/`from_dict` round-trip、成對規則、門檻不符拒收）
  - `tests/test_registry_sizing_band.py`：`test_create_workflow_run_persists_initial_sizing_snapshot` 等（`_manager_create_workflow_run` 落地並跨重啟持久化）
  - `tests/test_completion_sizing_band.py`：`SizingScoreBandValidationTests`（`CompletionRecord` schema 驗證、三段門檻對應、score/band 成對、門檻不符拒收）
- [x] 每次 repair／re-claim 後重算 band，不得沿用 claim 當時判定
  - `tests/test_registry_sizing_band.py`：`test_update_after_repair_recomputes_band_and_does_not_keep_claim_time_value`（模擬 repair 後 red→green 重算，斷言不殘留 claim 當時的舊值）／`test_mismatched_score_and_band_pair_rejected_on_update`
- [x] 記錄 `sizing_declaration_drift`（宣告模組數 vs candidate 實際變更數，供 #210）
  - `tests/test_completion_sizing_band.py`：`SizingDeclarationDriftValidationTests`（round-trip、缺鍵/多鍵/負數/非 int 拒收、獨立於 sizing_score/band 出現）、`SizingFieldsSemanticMatchTests`（band 屬 work item 狀態快照，semantic match 排除三個新欄位；真衝突仍可被偵測）

## 性質

code change（新增 pure function + dataclass 欄位 + schema 驗證），涵蓋 `CHANGELOG.md [Unreleased]` 對應的 `changelog.d/222-sizing-band.md` fragment。

Closes #222

## Checklist

- [x] changelog.d fragment 已新增（R-09）
- [x] 本地 preflight-ci PASS（policy + openspec + pytest）
