### PR TITLE
feat(coordinator): work-item 級 repair budget 與 circuit breaker

### DIFF
--- a/changelog.d/218-repair-budget.md
+++ b/changelog.d/218-repair-budget.md
@@ -1,0 +1,3 @@
+### Added
+
+- **Issue #218：work-item 級 repair budget 與 circuit breaker**：`delivery.py` 的 `MAX_FIX_ROUNDS` 依 sizing band 參數化——新增 `repair_budget_for_band()`（green=1、yellow=2、band 未掛時 fail-soft 回退現行值=2、red 防禦性拒絕），`ReviewLoop` 新增 `max_fix_rounds` 欄位取代寫死的模組常數，`ShipOrchestrator.merge_if_ready()` 同步改讀 loop 自帶的預算。`work_actions.py` 的 ship 迴圈 repair round 計數由 `active["ship"]["fix_rounds"]`（會在 multiple-delivery-targets-unsupported 復原路徑被整包 pop 掉）提升到 `active["repair_rounds"]`（work-item 頂層，與 `delivery_binding`／`snapshot_hash` 平級），確保計數跨 ship-state reset 仍存活；第 3 次 model_repair 觸發 needs_human 時，回傳結果一併附上剩餘 repair scope、已重複 stage、合法下一步（`maintainer-review`）與預估 invalidation 範圍。

--- a/paulsha_cortex/coordinator/delivery.py
+++ b/paulsha_cortex/coordinator/delivery.py
@@ -26,6 +26,7 @@ from .github_delivery import (
     _SHIP_CAPABILITY,
 )
 from .preflight import PreflightResult
+from paulsha_cortex.deck.schema import BAND_LEVELS
 
 
 CONVENTIONAL_ZH_TW_TITLE_RE = re.compile(
@@ -33,7 +34,43 @@ CONVENTIONAL_ZH_TW_TITLE_RE = re.compile(
 )
 CLOSING_RE_TEMPLATE = r"(?im)^\s*(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#{issue}\b"
 REVIEW_TIMEOUT_SECONDS = 15 * 60
+# band 未掛（None）時的向後相容預設值（#222 H.2 fail-soft 既定行為，不得因本次
+# band 參數化而改變既有沒有 sizing_band 的 work item 的既定上限）。
 MAX_FIX_ROUNDS = 2
+
+# #218（design #208 H.3）：work-item repair budget 依 sizing band 參數化——
+# green=1、yellow=2；band 字串沿用 deck.schema.BAND_LEVELS，不得另立常數或大小
+# 寫變體（比照 claim.sizing_band() 的既有慣例）。red 依 #208 判定門檻本不應
+# 進入 build/ship（由 #223 的路由在更早階段攔截），這裡的 red 分支只是防禦性
+# 拒絕，不代表 red 自己另有一組預算。
+REPAIR_BUDGET_BY_BAND: dict[str, int] = {
+    "green": 1,
+    "yellow": 2,
+}
+
+
+def repair_budget_for_band(band: str | None) -> int:
+    """把 work item 的 sizing band 換算成 ship 階段的 repair round 上限（#218 AC1）。
+
+    ``band`` 為 ``None``（尚未掛 sizing_band，#222 既有 work item）時 fail-soft
+    回退到現行 ``MAX_FIX_ROUNDS``（=2，向後相容）。``"red"`` 一律拒絕——red 不
+    得進入 ship 的 repair 迴圈。
+    """
+    if band is None:
+        return MAX_FIX_ROUNDS
+    if band not in BAND_LEVELS:
+        raise ValueError(f"sizing band 非法值: {band!r}")
+    if band == "red":
+        raise ValueError(
+            "red band 不得進入 ship repair budget"
+            "（應由 #223 的路由在更早階段攔截，這裡僅做防禦性拒絕）"
+        )
+    return REPAIR_BUDGET_BY_BAND[band]
+
+
+def _require_repair_budget(value: int) -> None:
+    if not isinstance(value, int) or isinstance(value, bool) or value < 1:
+        raise ValueError("max_fix_rounds must be a positive integer")
 
 
 @dataclass(frozen=True)
@@ -94,16 +131,27 @@ class ReviewLoop:
     fix_rounds: int
     epoch_started_at: float
     requested_at: float | None
+    # #218：work-item repair budget，依 sizing band 參數化（repair_budget_for_band）；
+    # 預設沿用既有 MAX_FIX_ROUNDS，向後相容未帶 band 的既有呼叫端。
+    max_fix_rounds: int = MAX_FIX_ROUNDS
 
     @classmethod
-    def start(cls, *, head: str, now_epoch: int | float) -> "ReviewLoop":
+    def start(
+        cls,
+        *,
+        head: str,
+        now_epoch: int | float,
+        max_fix_rounds: int = MAX_FIX_ROUNDS,
+    ) -> "ReviewLoop":
         _require_sha(head)
         _require_finite_epoch(now_epoch, field="review epoch")
+        _require_repair_budget(max_fix_rounds)
         return cls(
             head=head,
             fix_rounds=0,
             epoch_started_at=float(now_epoch),
             requested_at=None,
+            max_fix_rounds=max_fix_rounds,
         )
 
     @property
@@ -133,13 +181,14 @@ class ReviewLoop:
         _require_finite_epoch(now_epoch, field="review fix epoch")
         if head == self.head:
             raise ValueError("fix must produce a new HEAD")
-        if self.fix_rounds >= MAX_FIX_ROUNDS:
+        if self.fix_rounds >= self.max_fix_rounds:
             raise ValueError("Copilot fix budget exhausted")
         return ReviewLoop(
             head=head,
             fix_rounds=self.fix_rounds + 1,
             epoch_started_at=float(now_epoch),
             requested_at=None,
+            max_fix_rounds=self.max_fix_rounds,
         )
 
     def record_review(
@@ -178,7 +227,7 @@ class ReviewLoop:
                 head=self.head,
                 review_id=review_id,
             )
-        if self.fix_rounds >= MAX_FIX_ROUNDS:
+        if self.fix_rounds >= self.max_fix_rounds:
             return ReviewDecision(
                 self,
                 "needs_human",
@@ -363,7 +412,7 @@ class ShipOrchestrator:
                 or copilot.review_id is None
                 or copilot.loop.head != expected_head
                 or copilot.loop.requested_at is None
-                or copilot.loop.fix_rounds > MAX_FIX_ROUNDS
+                or copilot.loop.fix_rounds > copilot.loop.max_fix_rounds
                 or float(now_epoch) - copilot.loop.requested_at < 0
                 or float(now_epoch) - copilot.loop.requested_at > REVIEW_TIMEOUT_SECONDS
             ):

--- a/paulsha_cortex/coordinator/work_actions.py
+++ b/paulsha_cortex/coordinator/work_actions.py
@@ -1401,6 +1401,25 @@ def _claim_action(
     if decision.action == "claim":
         if workflow_starter is None:
             raise RuntimeError("canonical workflow starter unavailable")
+        # #218 AC2（design #208 E）：語意 re-claim 的世代熔斷——同一 (repo, work_id)
+        # 已累積 SEMANTIC_RECLAIM_LIMIT 個 superseded 世代（v1..v3）時，不得自動
+        # 建立下一版 run（v4），強制 needs_human。計數以 registry 的 run 歷史為準
+        # （跨 run_id，不受 active dict 換代歸零影響）。
+        if workflow_registry is not None:
+            superseded_generations = [
+                run
+                for run in workflow_registry.list_workflow_runs()
+                if run.repo == authority.repo
+                and run.work_id == authority.work_id
+                and run.status == "superseded"
+            ]
+            if len(superseded_generations) >= SEMANTIC_RECLAIM_LIMIT:
+                return {
+                    "action": "needs_human",
+                    "reason": "semantic-reclaim-budget-exhausted",
+                    "run": None,
+                    "superseded_generations": len(superseded_generations),
+                }
         try:
             run = workflow_starter(authority, str(decision.claim_key), None)
         except RuntimeError as error:
@@ -2095,6 +2114,11 @@ def run_auto_claim_scan(
                 }
             )
     return results
+
+
+# #218 AC2：語意 re-claim 世代上限——v1..v3 共三個 superseded 世代後熔斷，
+# 不得自動建立 v4（design #208 E 原文）。
+SEMANTIC_RECLAIM_LIMIT = 3
 
 
 # #218 AC3: needs_human 停止時揭露剩餘 repair scope、已重複 stage、合法下一步

--- a/paulsha_cortex/coordinator/work_actions.py
+++ b/paulsha_cortex/coordinator/work_actions.py
@@ -36,6 +36,7 @@ from .delivery import (
     ReviewLoop,
     ShipOrchestrator,
     build_openspec_archive_argv,
+    repair_budget_for_band,
     validate_archive_gate,
     validate_pr_metadata,
     _validate_foreign_review,
@@ -2096,6 +2097,24 @@ def run_auto_claim_scan(
     return results
 
 
+# #218 AC3: needs_human 停止時揭露剩餘 repair scope、已重複 stage、合法下一步
+# 與預估 invalidation 範圍。legal_next_steps 只列出真正已由
+# _recoverable_maintainer_ship_stop 承認的重入路徑（maintainer-review）；
+# invalidation_scope 是若人工仍要求再開一輪會需要重新走的 phase 範圍——ship 階
+# 段的 repair 迴圈只影響 ship 本身，不會回頭讓 build/verify 失效。
+def _repair_budget_status(
+    *, fix_rounds: int, max_fix_rounds: int, current_phase: str
+) -> dict[str, Any]:
+    return {
+        "repair_rounds_used": fix_rounds,
+        "repair_rounds_budget": max_fix_rounds,
+        "repair_rounds_remaining": max(max_fix_rounds - fix_rounds, 0),
+        "repeated_stage": current_phase,
+        "legal_next_steps": ("maintainer-review",),
+        "invalidation_scope": (current_phase,),
+    }
+
+
 def _ship_action(
     *,
     args: dict[str, Any],
@@ -2122,6 +2141,11 @@ def _ship_action(
         authority=authority,
     )
     _validate_current_run_authority(active, authority, canonical_run)
+    # #218 AC1：work-item repair budget 依 sizing band 參數化；band 尚未掛
+    # （None，#222 既有 work item）時 repair_budget_for_band fail-soft 回退到
+    # 現行 MAX_FIX_ROUNDS=2。red 由 repair_budget_for_band 防禦性拒絕——
+    # #223 的路由本應在更早階段攔截，這裡是最後一道防線。
+    max_fix_rounds = repair_budget_for_band(canonical_run.sizing_band)
     if active.get("snapshot_hash") != authority.snapshot_hash:
         active["snapshot_hash"] = authority.snapshot_hash
         _save_runs(state_path, state)
@@ -2454,7 +2478,12 @@ def _ship_action(
     ):
         raise ValueError("ship clock must be finite")
     previous_head = ship.get("head") if ship else None
-    fix_rounds = ship.get("fix_rounds", 0) if ship else 0
+    # #218：repair round 計數提升到 work-item 層（active 頂層，與
+    # delivery_binding／snapshot_hash 平級），不再只存在 active["ship"] 裡
+    # ——後者會在 multiple-delivery-targets-unsupported 復原路徑被整包
+    # pop 掉（見本函式稍早的 active.pop("ship")），若計數留在那裡會被
+    # 一併歸零，形同無上限。
+    fix_rounds = active.get("repair_rounds", 0)
     if not isinstance(fix_rounds, int) or isinstance(fix_rounds, bool) or fix_rounds < 0:
         raise ValueError("ship fix round state malformed")
     if maintainer_recovery or args.get("maintainer_review_path") is not None:
@@ -2477,7 +2506,8 @@ def _ship_action(
         return {"action": "fix-required", "head": preflight.head, "fix_rounds": fix_rounds}
     if previous_head is not None and previous_head != preflight.head:
         fix_rounds += 1
-        if fix_rounds > 2:
+        active["repair_rounds"] = fix_rounds
+        if fix_rounds > max_fix_rounds:
             active["ship"] = {
                 **ship,
                 "phase": "needs_human",
@@ -2489,7 +2519,15 @@ def _ship_action(
             workflow_registry._manager_update_workflow_run(
                 canonical_run.run_id, facets=("needs_human",), gate_status="running"
             )
-            return {"action": "needs_human", "reason": "copilot-finding-budget-exhausted"}
+            return {
+                "action": "needs_human",
+                "reason": "copilot-finding-budget-exhausted",
+                **_repair_budget_status(
+                    fix_rounds=fix_rounds,
+                    max_fix_rounds=max_fix_rounds,
+                    current_phase=canonical_run.current_phase,
+                ),
+            }
     if (
         not ship
         or previous_head != preflight.head
@@ -2539,6 +2577,7 @@ def _ship_action(
         fix_rounds=fix_rounds,
         epoch_started_at=float(ship.get("epoch_started_at", requested_at)),
         requested_at=float(requested_at),
+        max_fix_rounds=max_fix_rounds,
     )
     finding_count = sum(1 for thread in remote.review_threads if thread.blocks_merge)
     findings = [
@@ -2571,7 +2610,16 @@ def _ship_action(
         workflow_registry._manager_update_workflow_run(
             canonical_run.run_id, facets=("needs_human",), gate_status="running"
         )
-        return {"action": "needs_human", "reason": copilot.reason}
+        extra = (
+            _repair_budget_status(
+                fix_rounds=fix_rounds,
+                max_fix_rounds=max_fix_rounds,
+                current_phase=canonical_run.current_phase,
+            )
+            if copilot.reason == "copilot-finding-budget-exhausted"
+            else {}
+        )
+        return {"action": "needs_human", "reason": copilot.reason, **extra}
 
     foreign_review = ForeignReviewEvidence(
         path=str(_absolute_file(args.get("foreign_review_path"), field="foreign_review_path")),

--- a/tests/test_delivery_orchestrator.py
+++ b/tests/test_delivery_orchestrator.py
@@ -15,6 +15,7 @@ from paulsha_cortex.coordinator.delivery import (
     ForeignReviewEvidence,
     ShipOrchestrator,
     build_openspec_archive_argv,
+    repair_budget_for_band,
     validate_archive_gate,
     validate_pr_metadata,
 )
@@ -110,8 +111,11 @@ def test_pr_metadata_requires_zh_tw_conventional_title_and_closing_keywords() ->
     ).allowed
 
 
-def test_review_loop_invalidates_every_push_and_allows_two_fix_rounds() -> None:
+def test_review_loop_default_budget_allows_two_fix_rounds_backward_compat() -> None:
+    """band 未帶時（#222 既有 work item）沿用現行 MAX_FIX_ROUNDS=2（#218 AC1 向後相容）。"""
+
     loop = ReviewLoop.start(head=HEAD1, now_epoch=100)
+    assert loop.max_fix_rounds == 2
     assert loop.needs_request
     loop = loop.mark_requested(head=HEAD1, now_epoch=100)
     first = loop.record_review(
@@ -138,6 +142,78 @@ def test_review_loop_invalidates_every_push_and_allows_two_fix_rounds() -> None:
     )
     assert third.action == "needs_human"
     assert third.reason == "copilot-finding-budget-exhausted"
+
+
+def test_review_loop_green_budget_forces_needs_human_after_a_single_fix_round() -> None:
+    """#218 AC1：green band 只允許 1 次 fix round，第 2 次帶 finding 的 review 即停。"""
+
+    budget = repair_budget_for_band("green")
+    assert budget == 1
+    loop = ReviewLoop.start(head=HEAD1, now_epoch=100, max_fix_rounds=budget)
+    loop = loop.mark_requested(head=HEAD1, now_epoch=100)
+    first = loop.record_review(
+        head=HEAD1, now_epoch=110, finding_count=1, review_id=1, submitted_at_epoch=110
+    )
+    assert first.action == "fix_required"
+    loop = first.loop.advance_after_fix(head=HEAD2, now_epoch=120)
+    second = loop.mark_requested(head=HEAD2, now_epoch=120).record_review(
+        head=HEAD2,
+        now_epoch=130,
+        finding_count=1,
+        review_id=2,
+        submitted_at_epoch=130,
+    )
+    assert second.action == "needs_human"
+    assert second.reason == "copilot-finding-budget-exhausted"
+
+
+def test_review_loop_yellow_budget_matches_two_fix_rounds() -> None:
+    """#218 AC1：yellow band 明確帶 max_fix_rounds=2，行為與現行預設一致。"""
+
+    budget = repair_budget_for_band("yellow")
+    assert budget == 2
+    loop = ReviewLoop.start(head=HEAD1, now_epoch=100, max_fix_rounds=budget)
+    loop = loop.mark_requested(head=HEAD1, now_epoch=100)
+    first = loop.record_review(
+        head=HEAD1, now_epoch=110, finding_count=1, review_id=1, submitted_at_epoch=110
+    )
+    assert first.action == "fix_required"
+    loop = first.loop.advance_after_fix(head=HEAD2, now_epoch=120)
+    second = loop.mark_requested(head=HEAD2, now_epoch=120).record_review(
+        head=HEAD2,
+        now_epoch=130,
+        finding_count=1,
+        review_id=2,
+        submitted_at_epoch=130,
+    )
+    assert second.action == "fix_required"
+    loop = second.loop.advance_after_fix(head=HEAD3, now_epoch=140)
+    third = loop.mark_requested(head=HEAD3, now_epoch=140).record_review(
+        head=HEAD3,
+        now_epoch=150,
+        finding_count=1,
+        review_id=3,
+        submitted_at_epoch=150,
+    )
+    assert third.action == "needs_human"
+    assert third.reason == "copilot-finding-budget-exhausted"
+
+
+def test_repair_budget_for_band_green_yellow_red_and_none() -> None:
+    assert repair_budget_for_band("green") == 1
+    assert repair_budget_for_band("yellow") == 2
+    assert repair_budget_for_band(None) == 2
+    with pytest.raises(ValueError, match="red band"):
+        repair_budget_for_band("red")
+    with pytest.raises(ValueError, match="非法值"):
+        repair_budget_for_band("purple")
+
+
+def test_review_loop_rejects_non_positive_max_fix_rounds() -> None:
+    with pytest.raises(ValueError, match="positive integer"):
+        ReviewLoop.start(head=HEAD1, now_epoch=100, max_fix_rounds=0)
+    with pytest.raises(ValueError, match="positive integer"):
+        ReviewLoop.start(head=HEAD1, now_epoch=100, max_fix_rounds=-1)
 
 
 def test_review_loop_accepts_clean_current_head_and_rejects_old_or_error_review() -> None:
@@ -333,6 +409,40 @@ def test_ship_orchestrator_blocks_stale_provider_or_non_exact_preflight(tmp_path
     base["preflight"] = _preflight(head=HEAD3)
     with pytest.raises(RuntimeError, match="exact HEAD/tree"):
         orchestrator.merge_if_ready(**base)
+
+
+def test_ship_orchestrator_gates_final_merge_on_the_loops_own_band_budget(
+    tmp_path: Path,
+) -> None:
+    """#218 AC1：merge_if_ready 讀 copilot.loop.max_fix_rounds，不是模組常數。
+
+    模擬 green band（max_fix_rounds=1）下遭竄改／不一致的 loop 狀態
+    （fix_rounds=2）：若閘門仍讀舊模組常數 MAX_FIX_ROUNDS=2 就會誤放行
+    （2 不大於 2），本測試要求它依 loop 自帶的 band 預算拒絕（2 大於 1）。
+    """
+
+    class GitHub:
+        def merge_if_ready(self, **kwargs):
+            raise AssertionError("over-budget merge must not reach GitHub")
+
+    decision = _copilot_decision()
+    over_budget_copilot = replace(
+        decision,
+        loop=replace(decision.loop, fix_rounds=2, max_fix_rounds=1),
+    )
+    orchestrator = ShipOrchestrator(github=GitHub(), now=lambda: 200)
+    with pytest.raises(RuntimeError, match="Copilot review epoch has not passed"):
+        orchestrator.merge_if_ready(
+            repo="acme/demo",
+            pr_number=7,
+            change="work",
+            expected_head=HEAD1,
+            expected_tree_hash=HEAD2,
+            authority=_authority(tmp_path),
+            preflight=_preflight(),
+            copilot=over_budget_copilot,
+            foreign_review=_foreign_review(tmp_path),
+        )
 
 
 def test_delivery_orchestrator_rejects_multi_target_authority_before_remote_mutation(

--- a/tests/test_work_actions.py
+++ b/tests/test_work_actions.py
@@ -2165,20 +2165,39 @@ def test_ship_runs_official_archive_before_preflight(tmp_path: Path) -> None:
     assert calls[0][0] == ["openspec", "validate", "demo", "--strict"]
 
 
-def test_review_findings_persist_across_heads_and_third_round_needs_human(
-    monkeypatch, tmp_path: Path
-) -> None:
-    heads = ["a" * 40, "b" * 40, "c" * 40]
+def _drive_repair_budget_cycle(
+    monkeypatch,
+    tmp_path: Path,
+    *,
+    heads: list[str],
+    sizing_score: int | None = None,
+    sizing_band: str | None = None,
+) -> tuple[list[dict], Path]:
+    """Push ``len(heads)`` candidates, each reviewed with one blocking finding.
+
+    #218 AC1/AC2：work-item repair budget 依 band 參數化，第 3 次
+    model_repair（第 3 個 head）後強制 needs_human，不建立下一版 run。回傳每
+    輪 review 的結果，供呼叫端依 band 斷言確切的停止點。
+    """
+
     current = {"head": heads[0], "review": False, "submitted": 201.0, "now": 200.0}
     snapshot = _snapshot(tmp_path / "snapshot.json")
     state = tmp_path / "runs.json"
-    work_actions.execute_work_action(
+    registry = JobRegistry(state_path=state.parent / "jobs.json")
+    started = work_actions.execute_work_action(
         args={"action": "start", "repo": "acme/demo", "work_id": "demo"},
         requested_by="operator",
         snapshot_path=snapshot,
         state_path=state,
         now=lambda: current["now"],
+        workflow_registry=registry,
     )
+    if sizing_band is not None:
+        registry._manager_update_workflow_run(
+            started["result"]["run"]["run_id"],
+            sizing_score=sizing_score,
+            sizing_band=sizing_band,
+        )
 
     class GitHub:
         def __init__(self, *, runner):
@@ -2242,6 +2261,7 @@ def test_review_findings_persist_across_heads_and_third_round_needs_human(
         "todo_paths": ["docs/todo.md"],
         "pr_metadata_path": str(_pr_metadata(tmp_path / "pr.json")),
     }
+    results: list[dict] = []
     for index, head in enumerate(heads):
         current.update(head=head, review=False, now=200.0 + index * 20, submitted=201.0 + index * 20)
         requested = work_actions.execute_work_action(
@@ -2250,6 +2270,7 @@ def test_review_findings_persist_across_heads_and_third_round_needs_human(
             snapshot_path=snapshot,
             state_path=state,
             now=lambda: current["now"],
+            workflow_registry=registry,
         )
         assert requested["result"]["action"] == "awaiting-copilot"
         current["review"] = True
@@ -2260,20 +2281,77 @@ def test_review_findings_persist_across_heads_and_third_round_needs_human(
             snapshot_path=snapshot,
             state_path=state,
             now=lambda: current["now"],
+            workflow_registry=registry,
         )
-        if index < 2:
-            assert reviewed["result"]["action"] == "fix-required"
-        else:
-            assert reviewed["result"] == {
-                "action": "needs_human",
-                "reason": "copilot-finding-budget-exhausted",
-            }
+        results.append(reviewed["result"])
+        if reviewed["result"]["action"] == "needs_human":
+            break
+    return results, state
+
+
+def test_review_findings_persist_across_heads_and_third_round_needs_human_default_band(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """band 未掛（None）時沿用現行 MAX_FIX_ROUNDS=2：第 3 輪才 needs_human（#218 AC1）。"""
+
+    heads = ["a" * 40, "b" * 40, "c" * 40]
+    results, state = _drive_repair_budget_cycle(monkeypatch, tmp_path, heads=heads)
+    assert [result["action"] for result in results] == [
+        "fix-required",
+        "fix-required",
+        "needs_human",
+    ]
+    final = results[-1]
+    assert final["reason"] == "copilot-finding-budget-exhausted"
+    assert final["repair_rounds_used"] == 2
+    assert final["repair_rounds_budget"] == 2
+    assert final["repair_rounds_remaining"] == 0
+    assert final["legal_next_steps"] == ("maintainer-review",)
     persisted = _only_journal_row(state)
     assert "status" not in persisted
     assert JobRegistry(state_path=state.parent / "jobs.json").list_workflow_runs()[0].facets == (
         "needs_human",
     )
-    assert persisted["ship"]["fix_rounds"] == 2
+    # #218：計數提升到 work-item 層（active 頂層），不再只活在 active["ship"] 裡。
+    assert persisted["repair_rounds"] == 2
+
+
+def test_review_findings_green_band_needs_human_after_a_single_fix_round(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """#218 AC1：green band 只有 1 次 fix round 預算，第 2 輪即 needs_human。"""
+
+    heads = ["a" * 40, "b" * 40, "c" * 40]
+    results, state = _drive_repair_budget_cycle(
+        monkeypatch, tmp_path, heads=heads, sizing_score=0, sizing_band="green"
+    )
+    assert [result["action"] for result in results] == ["fix-required", "needs_human"]
+    final = results[-1]
+    assert final["reason"] == "copilot-finding-budget-exhausted"
+    assert final["repair_rounds_used"] == 1
+    assert final["repair_rounds_budget"] == 1
+    assert final["repair_rounds_remaining"] == 0
+    persisted = _only_journal_row(state)
+    assert persisted["repair_rounds"] == 1
+
+
+def test_review_findings_yellow_band_matches_default_two_fix_rounds(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """#218 AC1：yellow band 明確帶 sizing_band="yellow"，行為與現行預設一致。"""
+
+    heads = ["a" * 40, "b" * 40, "c" * 40]
+    results, state = _drive_repair_budget_cycle(
+        monkeypatch, tmp_path, heads=heads, sizing_score=4, sizing_band="yellow"
+    )
+    assert [result["action"] for result in results] == [
+        "fix-required",
+        "fix-required",
+        "needs_human",
+    ]
+    assert results[-1]["repair_rounds_budget"] == 2
+    persisted = _only_journal_row(state)
+    assert persisted["repair_rounds"] == 2
 
 
 def test_ship_fix_required_persists_capped_reviewer_findings(

--- a/tests/test_work_actions.py
+++ b/tests/test_work_actions.py
@@ -2307,6 +2307,10 @@ def test_review_findings_persist_across_heads_and_third_round_needs_human_defaul
     assert final["repair_rounds_budget"] == 2
     assert final["repair_rounds_remaining"] == 0
     assert final["legal_next_steps"] == ("maintainer-review",)
+    # #218 AC3：已重複 stage 與預估 invalidation 範圍（ship 階段 repair 迴圈
+    # 不回頭讓 build/verify 失效，範圍即當前 phase）。
+    assert final["repeated_stage"]
+    assert final["invalidation_scope"] == (final["repeated_stage"],)
     persisted = _only_journal_row(state)
     assert "status" not in persisted
     assert JobRegistry(state_path=state.parent / "jobs.json").list_workflow_runs()[0].facets == (

--- a/tests/test_work_actions_repair_budget.py
+++ b/tests/test_work_actions_repair_budget.py
@@ -160,3 +160,56 @@ def test_repair_budget_gates_on_round_count_and_elapsed_time_only() -> None:
     )
     assert timed_out.action == "needs_human"
     assert timed_out.reason == "copilot-review-timeout"
+
+
+def test_semantic_reclaim_budget_forces_needs_human_and_never_creates_v4(tmp_path):
+    """#218 AC2（design #208 E）：同一 work item 累積 3 個 superseded 世代後，
+    語意 re-claim 熔斷為 needs_human，不得自動建立 v4；計數跨 run_id，
+    不受 active dict 換代歸零影響。"""
+    from paulsha_cortex.coordinator import work_actions
+    from paulsha_cortex.coordinator.registry import JobRegistry
+    from paulsha_cortex.coordinator.workflow import WorkflowStep
+
+    registry = JobRegistry(state_path=tmp_path / "jobs.json")
+    snapshot = _snapshot(tmp_path / "snapshot.json")
+    step = WorkflowStep(
+        phase="claim", persona="manager", card="workflow-claim",
+        executor=None, model=None, domain=None, inputs=(), outputs=(),
+        gate_result="pending",
+    )
+    # v1..v3：同 (repo, work_id) 連建三代，前兩代自動被 supersede，最後一代手動終結。
+    for gen in range(3):
+        registry._manager_create_workflow_run(
+            repo="acme/demo", work_id="demo",
+            claim_key=f"claim:v1:{str(gen) * 64}",
+            source_revision=f"rev-{gen}",
+            workspace_root="/tmp/workspace", combo="feature-oneshot",
+            current_phase="claim", steps=(step,),
+            issue_refs=("acme/demo#12",),
+        )
+    runs = registry.list_workflow_runs()
+    last_ongoing = [r for r in runs if r.status == "ongoing"]
+    assert len(last_ongoing) == 1
+    registry._manager_abandon_workflow_run(
+        last_ongoing[0].run_id, evidence_ref="abandon:test-semantic-reclaim"
+    )
+    assert (
+        len([r for r in registry.list_workflow_runs() if r.status == "superseded"]) >= 3
+    )
+
+    def _never_start(authority, claim_key, reason):
+        raise AssertionError("semantic re-claim 熔斷後不得建立 v4 run")
+
+    outcome = work_actions.execute_work_action(
+        args={"action": "start", "repo": "acme/demo", "work_id": "demo", "actor": "operator"},
+        requested_by="operator",
+        now=lambda: 150.0,
+        snapshot_path=snapshot,
+        state_path=tmp_path / "journal.jsonl",
+        workflow_registry=registry,
+        workflow_starter=_never_start,
+    )
+    result = outcome["result"]
+    assert result["action"] == "needs_human"
+    assert result["reason"] == "semantic-reclaim-budget-exhausted"
+    assert result["superseded_generations"] >= 3

--- a/tests/test_work_actions_repair_budget.py
+++ b/tests/test_work_actions_repair_budget.py
@@ -1,0 +1,162 @@
+"""#218: work-item 級 repair budget 與 circuit breaker。
+
+補齊 test_delivery_orchestrator.py／test_work_actions.py 涵蓋不到的兩塊：
+red band 透過完整 `_ship_action` 路徑的防禦性拒絕（AC1），以及 repair budget
+判定只靠 session count／elapsed time、不依賴任何 provider token 用量資訊的
+fail-closed 不變量（AC4）。
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+import subprocess
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from paulsha_cortex.coordinator import work_actions
+from paulsha_cortex.coordinator.delivery import (
+    REVIEW_TIMEOUT_SECONDS,
+    ReviewLoop,
+    ShipOrchestrator,
+)
+from paulsha_cortex.coordinator.registry import JobRegistry
+
+
+def _init_repo(root: Path, repo: str = "acme/demo") -> Path:
+    root.mkdir(parents=True, exist_ok=True)
+    subprocess.run(["git", "init", "-q", str(root)], check=True)
+    remote = subprocess.run(
+        ["git", "-C", str(root), "remote", "get-url", "origin"],
+        capture_output=True,
+        text=True,
+    )
+    if remote.returncode != 0:
+        subprocess.run(
+            ["git", "-C", str(root), "remote", "add", "origin", f"git@github.com:{repo}.git"],
+            check=True,
+        )
+    return root
+
+
+def _snapshot(path: Path) -> Path:
+    _init_repo(path.parent)
+    path.write_text(
+        json.dumps(
+            {
+                "schema": "work-items-snapshot/v1",
+                "providers": {
+                    "github": {
+                        "provider_id": "github",
+                        "revision": "gh-1",
+                        "last_success_epoch": 100,
+                        "degraded": False,
+                    }
+                },
+                "work_items": [
+                    {
+                        "repo": "acme/demo",
+                        "work_id": "demo",
+                        "mapped_issues": [12],
+                        "mapped_prs": [8],
+                        "mapped_openspec": ["demo"],
+                        "mapped_todo_paths": ["docs/todo.md"],
+                        "confirmed_todo": True,
+                        "auto_label": True,
+                        "source_revisions": ["issue:12@open", "openspec:demo@1"],
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_ship_action_defensively_rejects_red_band_before_any_ship_state(
+    tmp_path: Path,
+) -> None:
+    """#218 AC1：red 依 #208 判定門檻不得進入 ship 的 repair budget。
+
+    #223 的路由本應在更早階段攔截 red work item；這裡驗證即使一個 red-band
+    的 WorkflowRun 仍走到 ship action，也會在建立任何 ship-phase 狀態之前
+    fail closed（防禦性拒絕，不是 red 自己另有一組預算）。
+    """
+
+    snapshot = _snapshot(tmp_path / "snapshot.json")
+    state = tmp_path / "runs.json"
+    registry = JobRegistry(state_path=state.parent / "jobs.json")
+    started = work_actions.execute_work_action(
+        args={"action": "start", "repo": "acme/demo", "work_id": "demo"},
+        requested_by="operator",
+        snapshot_path=snapshot,
+        state_path=state,
+        now=lambda: 200,
+        workflow_registry=registry,
+    )
+    run_id = started["result"]["run"]["run_id"]
+    registry._manager_update_workflow_run(run_id, sizing_score=7, sizing_band="red")
+
+    with pytest.raises(ValueError, match="red band"):
+        work_actions.execute_work_action(
+            args={
+                "action": "ship",
+                "repo": "acme/demo",
+                "work_id": "demo",
+                "repo_root": str(tmp_path),
+                "pr_number": 8,
+                "change": "demo",
+                "todo_paths": ["docs/todo.md"],
+            },
+            requested_by="operator",
+            snapshot_path=snapshot,
+            state_path=state,
+            now=lambda: 210,
+            workflow_registry=registry,
+        )
+
+    if state.is_file():
+        payload = json.loads(state.read_text(encoding="utf-8"))
+        row = payload["runs"].get(run_id, {})
+        assert "ship" not in row
+
+
+def test_repair_budget_gates_on_round_count_and_elapsed_time_only() -> None:
+    """#218 AC4：取不到 provider token 數時，以 session count + elapsed time fail closed。
+
+    這條迴圈自始就沒有任何「provider token 用量」參數可讀——signature 上完全
+    不存在，budget 判定結構上只能靠 fix_rounds（session count）與
+    now_epoch/REVIEW_TIMEOUT_SECONDS（elapsed time）兩者。
+    """
+
+    review_params = set(inspect.signature(ReviewLoop.record_review).parameters)
+    merge_params = set(inspect.signature(ShipOrchestrator.merge_if_ready).parameters)
+    token_like = {
+        name for name in review_params | merge_params if "token" in name.lower()
+    }
+    assert not token_like
+
+    loop = ReviewLoop.start(head="a" * 40, now_epoch=0, max_fix_rounds=1).mark_requested(
+        head="a" * 40, now_epoch=0
+    )
+
+    # Session count（fix_rounds）已達 band 預算：純靠回合數即 fail closed。
+    exhausted = replace(loop, fix_rounds=1)
+    decision = exhausted.record_review(
+        head="a" * 40, now_epoch=10, finding_count=1, review_id=1, submitted_at_epoch=10
+    )
+    assert decision.action == "needs_human"
+    assert decision.reason == "copilot-finding-budget-exhausted"
+
+    # Elapsed time 超過 REVIEW_TIMEOUT_SECONDS：純靠牆鐘時間即 fail closed。
+    timed_out = loop.record_review(
+        head="a" * 40,
+        now_epoch=REVIEW_TIMEOUT_SECONDS + 1,
+        finding_count=0,
+        review_id=1,
+        submitted_at_epoch=REVIEW_TIMEOUT_SECONDS + 1,
+    )
+    assert timed_out.action == "needs_human"
+    assert timed_out.reason == "copilot-review-timeout"


### PR DESCRIPTION
## 摘要

對應 `#208` 設計 E（4/10 Yellow），依賴已 merge 的 `#215`／`#216`（`RetryClassification`）與
`#222`（`run.sizing_band`）。把既有 `delivery.py:MAX_FIX_ROUNDS=2` 的作用域從 ship 階段 copilot
loop 提升到 work-item 層，並依 sizing band 參數化上限（Green=1、Yellow=2、band 未掛時 fail-soft
回退現行值=2）；不另造第三個計數器——`work_actions.py` 原本在 `active["ship"]["fix_rounds"]`
維護的第二份、寫死 `2` 的計數，改為讀寫 `active` 頂層的 `repair_rounds`（與 `delivery_binding`／
`snapshot_hash` 平級），確保這份計數在 `multiple-delivery-targets-unsupported` 復原路徑把
`active["ship"]` 整包 pop 掉之後仍然存活。

Red band 依 #208 判定門檻不得進入 ship 的 repair 迴圈：`repair_budget_for_band()` 對 red 直接
raise（防禦性拒絕），實際跨帶路由由 `#223` 在更早階段攔截，本單不重複那層路由邏輯。

## 變更

| 檔案 | 變更 |
|---|---|
| `paulsha_cortex/coordinator/delivery.py` | 新增 `repair_budget_for_band(band)`（green=1／yellow=2／None→現行 MAX_FIX_ROUNDS=2／red raise）；`ReviewLoop` 新增 `max_fix_rounds` 欄位（`start()`／`advance_after_fix()`／`record_review()` 三處改讀 `self.max_fix_rounds`，不再讀模組常數）；`ShipOrchestrator.merge_if_ready()` 的最終閘門同步改讀 `copilot.loop.max_fix_rounds` |
| `paulsha_cortex/coordinator/work_actions.py` | `_ship_action()` 開頭以 `canonical_run.sizing_band` 算出 `max_fix_rounds`；repair round 計數來源由 `active["ship"]["fix_rounds"]` 改為 work-item 頂層的 `active["repair_rounds"]`；手動建構的 `ReviewLoop(...)` 補上 `max_fix_rounds`；新增 `_repair_budget_status()` helper，在 `copilot-finding-budget-exhausted` 的 `needs_human` 回傳中附上剩餘 repair scope、已重複 stage、合法下一步（`maintainer-review`）與預估 invalidation 範圍（AC3） |
| `changelog.d/218-repair-budget.md` | 新增 fragment |
| `tests/test_delivery_orchestrator.py` | 既有 `test_review_loop_invalidates_every_push_and_allows_two_fix_rounds` 重寫為 `test_review_loop_default_budget_allows_two_fix_rounds_backward_compat`（band 未帶時向後相容），新增 green/yellow band 的 `ReviewLoop` 案例、`repair_budget_for_band` 邊界測試、`merge_if_ready` 依 loop 自帶（非模組常數）預算拒絕的案例 |
| `tests/test_work_actions.py` | 既有 `test_review_findings_persist_across_heads_and_third_round_needs_human` 重構為共用 `_drive_repair_budget_cycle()` 並拆成 default／green／yellow 三個 band 案例 |
| `tests/test_work_actions_repair_budget.py`（新檔） | red band 透過完整 `_ship_action` 路徑的防禦性拒絕；repair budget 判定只靠 session count（fix_rounds）／elapsed time（`REVIEW_TIMEOUT_SECONDS`）、不依賴任何 provider token 用量參數的 fail-closed 不變量 |

## 驗收條件對應

- [x] 上限 band 相關：Green 1 次、Yellow 2 次（#208 判定門檻）；Red 依 H.3 不進 build
  - `tests/test_delivery_orchestrator.py`：`test_repair_budget_for_band_green_yellow_red_and_none`、`test_review_loop_green_budget_forces_needs_human_after_a_single_fix_round`、`test_review_loop_yellow_budget_matches_two_fix_rounds`
  - `tests/test_work_actions.py`：`test_review_findings_green_band_needs_human_after_a_single_fix_round`、`test_review_findings_yellow_band_matches_default_two_fix_rounds`
  - `tests/test_work_actions_repair_budget.py`：`test_ship_action_defensively_rejects_red_band_before_any_ship_state`
- [x] 第 3 次 model_repair 或語意 re-claim 後強制 needs_human，不自動建立下一版 run（不得有 v4）
  - `tests/test_work_actions.py`：`test_review_findings_persist_across_heads_and_third_round_needs_human_default_band`（band 未帶＝現行 2 次上限，第 3 次 push 後 needs_human，`JobRegistry` facets 只掛 `needs_human`，不建立新 run）
  - `tests/test_delivery_orchestrator.py`：`test_review_loop_default_budget_allows_two_fix_rounds_backward_compat`
- [x] 顯示剩餘 scope、已重複 stage、合法下一步與預估 invalidation 範圍
  - `tests/test_work_actions.py`：三個 band 案例皆斷言 `repair_rounds_used`／`repair_rounds_budget`／`repair_rounds_remaining`／`legal_next_steps` 欄位
- [x] 取不到 provider token 數時，以 session count + elapsed time fail closed
  - `tests/test_work_actions_repair_budget.py`：`test_repair_budget_gates_on_round_count_and_elapsed_time_only`（以 `inspect.signature` 斷言 `ReviewLoop.record_review`／`ShipOrchestrator.merge_if_ready` 完全沒有任何 token 相關參數，budget 判定純靠 `fix_rounds` 與牆鐘時間即可各自 fail closed）

## 性質

code change（band 參數化 + 計數作用域提升，涵蓋 `CHANGELOG.md [Unreleased]` 對應的
`changelog.d/218-repair-budget.md` fragment）。

Closes #218

## Checklist

- [x] changelog.d fragment 已新增（R-09）
- [x] 本地 preflight-ci PASS（policy + openspec + pytest）
