### PR TITLE
fix(manager): auto-claim 單一 work item 失敗中止整個 periodic tick

### DIFF
--- a/changelog.d/246-daemon-tick-isolation.md
+++ b/changelog.d/246-daemon-tick-isolation.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **Issue #246：auto-claim 單一 work item 失敗不再中止整個 periodic tick**：`work_actions.run_auto_claim_scan()` 的逐 authority 迴圈新增 try/except，任一 authority 的 claim 流程 raise（例如 `resolve_trusted_repo_root` 對不在信任清單的 repo fail-closed）改為 append 一筆帶 `repo-root-unresolved`／`claim-failed` reason 與不含機密的錯誤摘要的 blocked 結果並處理下一個 authority，不再讓整批掃描中止；`manager_daemon.build_periodic_tick_runner` 的 `execute()` 同步包住 auto-claim 呼叫，失敗時 `_log_error` 記錄安全脈絡（action／work_id／repo／source revision）並讓 `auto_claims` 降級為空 list，後面的 workflow resume 迴圈與 `run_tick` 照常執行，回傳 summary 新增 `auto_claim_failed`／`auto_claim_error` 供 operator 觀察降級（現場證據：17,013 次同一則 `ValueError` 每 4-5 秒重複，持續 22 小時）。

--- a/paulsha_cortex/coordinator/manager_daemon.py
+++ b/paulsha_cortex/coordinator/manager_daemon.py
@@ -667,14 +667,24 @@ def build_periodic_tick_runner(
 
     def execute() -> dict[str, Any]:
         registry = getattr(dispatcher, "_registry", None)
-        auto_claims = (
-            auto_claim_fn()
-            if auto_claim_fn is not None
-            else manager.run_auto_claim_scan(
-                registry=registry,
-                runtime_factory=planning_runtime.build_production_planning_runtime,
+        auto_claim_error: str | None = None
+        try:
+            auto_claims = (
+                auto_claim_fn()
+                if auto_claim_fn is not None
+                else manager.run_auto_claim_scan(
+                    registry=registry,
+                    runtime_factory=planning_runtime.build_production_planning_runtime,
+                )
             )
-        )
+        except (ValueError, RuntimeError, OSError) as exc:
+            # #216 daemon tick isolation：auto-claim 這個子系統整批失效（例如
+            # 快照載入本身壞掉）不得癱瘓本輪 tick——降級為空 auto_claims，
+            # 讓後面的 workflow resume 迴圈與 run_tick 照常執行；
+            # KeyboardInterrupt/SystemExit 不在攔截範圍，照常往外傳。
+            _log_error(exc, context={"action": "auto-claim-scan"})
+            auto_claims = []
+            auto_claim_error = f"{type(exc).__name__}: {exc}"
         if registry is not None and hasattr(registry, "list_workflow_runs"):
             state_path = getattr(registry, "_state_path", None)
             coordinator_root = (
@@ -716,7 +726,15 @@ def build_periodic_tick_runner(
                         ship_validator=active_ship_validator,
                     )
                 except Exception as exc:
-                    _log_error(exc)
+                    _log_error(
+                        exc,
+                        context={
+                            "action": "resume-workflow",
+                            "work_id": workflow.work_id,
+                            "repo": workflow.repo,
+                            "source_revision": workflow.source_revision,
+                        },
+                    )
                     registry._manager_update_workflow_run(
                         workflow.run_id,
                         facets=("needs_human",),
@@ -755,7 +773,13 @@ def build_periodic_tick_runner(
                 }
             )
         result = run_tick_fn(dispatcher, **run_tick_kwargs)
-        return {**result, "auto_claims": auto_claims}
+        summary = {**result, "auto_claims": auto_claims}
+        if auto_claim_error is not None:
+            # 讓 operator 能從 status/summary 看出 auto-claim 這輪降級了，
+            # 而不是靜默吞掉——不含絕對路徑／token，只有型別＋訊息摘要。
+            summary["auto_claim_failed"] = True
+            summary["auto_claim_error"] = auto_claim_error
+        return summary
 
     return execute
 
@@ -1027,8 +1051,15 @@ def _install_signal_handlers() -> None:
     signal.signal(signal.SIGINT, _handle_termination)
 
 
-def _log_error(exc: Exception) -> None:
-    print(f"{contract.utcnow()} manager_daemon error: {type(exc).__name__}: {exc}", file=sys.stderr)
+def _log_error(exc: Exception, *, context: dict[str, Any] | None = None) -> None:
+    message = f"{contract.utcnow()} manager_daemon error: {type(exc).__name__}: {exc}"
+    if context:
+        # 只收安全脈絡（action 種類／work_id／repo／snapshot 或 source
+        # revision）；呼叫端負責不要塞入 token、絕對路徑或 issue 內文。
+        details = " ".join(f"{key}={value}" for key, value in context.items() if value is not None)
+        if details:
+            message = f"{message} ({details})"
+    print(message, file=sys.stderr)
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/paulsha_cortex/coordinator/manager_daemon.py
+++ b/paulsha_cortex/coordinator/manager_daemon.py
@@ -20,6 +20,7 @@ from .dispatcher import Dispatcher
 from .model_identities import load_model_identities
 from .registry import JobRegistry
 from .seams import ScriptWorktreeCreator, TmuxPaneSender
+from .work_actions import safe_exception_summary
 
 DEFAULT_TICK_INTERVAL = 300.0
 DEFAULT_POLL_INTERVAL = 3.0
@@ -678,13 +679,13 @@ def build_periodic_tick_runner(
                 )
             )
         except (ValueError, RuntimeError, OSError) as exc:
-            # #216 daemon tick isolation：auto-claim 這個子系統整批失效（例如
+            # #246 daemon tick isolation：auto-claim 這個子系統整批失效（例如
             # 快照載入本身壞掉）不得癱瘓本輪 tick——降級為空 auto_claims，
             # 讓後面的 workflow resume 迴圈與 run_tick 照常執行；
             # KeyboardInterrupt/SystemExit 不在攔截範圍，照常往外傳。
             _log_error(exc, context={"action": "auto-claim-scan"})
             auto_claims = []
-            auto_claim_error = f"{type(exc).__name__}: {exc}"
+            auto_claim_error = safe_exception_summary(exc)
         if registry is not None and hasattr(registry, "list_workflow_runs"):
             state_path = getattr(registry, "_state_path", None)
             coordinator_root = (

--- a/paulsha_cortex/coordinator/work_actions.py
+++ b/paulsha_cortex/coordinator/work_actions.py
@@ -222,6 +222,18 @@ def _canonical_repo_root(value: object, *, repo: str) -> Path:
     return root
 
 
+# #246：例外摘要必須可安全外流——OSError 子類（FileNotFoundError／PermissionError
+# 等）的預設字串會內嵌絕對路徑，而 blocked 結果與 daemon summary 都會被寫進 durable
+# done record 與 log。這裡只保留型別名與清洗過的訊息：POSIX 絕對路徑與 ~ 展開路徑
+# 一律以 <path> 取代（R-21 tier: shareable，AI-SEC-001 禁止輸出個人絕對路徑）。
+_ABSOLUTE_PATH_RE = re.compile(r"(?:~|/)[^\s'\"]*/[^\s'\"]*")
+
+
+def safe_exception_summary(exc: BaseException) -> str:
+    """把例外轉成不含絕對路徑的簡短摘要，供 durable 記錄與日誌使用。"""
+    return f"{type(exc).__name__}: {_ABSOLUTE_PATH_RE.sub('<path>', str(exc))}"
+
+
 def _path_has_symlink(root: Path, relative: str) -> bool:
     current = root
     for part in PurePosixPath(relative).parts:
@@ -2164,7 +2176,7 @@ def run_auto_claim_scan(
                 readiness_checker=readiness_checker,
             )
         except (ValueError, RuntimeError, OSError) as exc:
-            # 單一 authority 的 claim 失敗（例如 #216 daemon tick isolation：
+            # 單一 authority 的 claim 失敗（例如 #246 daemon tick isolation：
             # start_canonical_workflow -> resolve_trusted_repo_root 對不在信任
             # 清單中的 repo fail-closed raise ValueError）不得讓整批 scan 中止；
             # KeyboardInterrupt/SystemExit 不在攔截範圍，照常往外傳。
@@ -2179,7 +2191,7 @@ def run_auto_claim_scan(
                     "work_id": authority.work_id,
                     "action": "blocked",
                     "reason": reason,
-                    "error": f"{type(exc).__name__}: {exc}",
+                    "error": safe_exception_summary(exc),
                 }
             )
             continue

--- a/paulsha_cortex/coordinator/work_actions.py
+++ b/paulsha_cortex/coordinator/work_actions.py
@@ -2151,17 +2151,38 @@ def run_auto_claim_scan(
                 live_auto_label = live_auto_label or "cortex:auto-on-going" in names
             if issue_reads_failed:
                 continue
-        result = _claim_action(
-            args={"action": "auto-scan"},
-            authority=authority,
-            now_epoch=now(),
-            state_path=resolved_state,
-            automatic=True,
-            auto_label=live_auto_label,
-            workflow_registry=workflow_registry,
-            workflow_starter=workflow_starter,
-            readiness_checker=readiness_checker,
-        )
+        try:
+            result = _claim_action(
+                args={"action": "auto-scan"},
+                authority=authority,
+                now_epoch=now(),
+                state_path=resolved_state,
+                automatic=True,
+                auto_label=live_auto_label,
+                workflow_registry=workflow_registry,
+                workflow_starter=workflow_starter,
+                readiness_checker=readiness_checker,
+            )
+        except (ValueError, RuntimeError, OSError) as exc:
+            # 單一 authority 的 claim 失敗（例如 #216 daemon tick isolation：
+            # start_canonical_workflow -> resolve_trusted_repo_root 對不在信任
+            # 清單中的 repo fail-closed raise ValueError）不得讓整批 scan 中止；
+            # KeyboardInterrupt/SystemExit 不在攔截範圍，照常往外傳。
+            reason = (
+                "repo-root-unresolved"
+                if isinstance(exc, ValueError) and "trusted repo registry" in str(exc)
+                else "claim-failed"
+            )
+            results.append(
+                {
+                    "repo": authority.repo,
+                    "work_id": authority.work_id,
+                    "action": "blocked",
+                    "reason": reason,
+                    "error": f"{type(exc).__name__}: {exc}",
+                }
+            )
+            continue
         if result["action"] not in {"ignore", "done"}:
             results.append(
                 {

--- a/tests/test_manager_daemon_tick_isolation.py
+++ b/tests/test_manager_daemon_tick_isolation.py
@@ -1,4 +1,4 @@
-"""#216 迴歸測試：periodic tick 的 execute() 不得被 auto-claim 單點失敗癱瘓。
+"""#246 迴歸測試：periodic tick 的 execute() 不得被 auto-claim 單點失敗癱瘓。
 
 背景：``build_periodic_tick_runner`` 的 ``execute()`` 呼叫
 ``manager.run_auto_claim_scan(...)``（或注入的 ``auto_claim_fn``）以前完全

--- a/tests/test_manager_daemon_tick_isolation.py
+++ b/tests/test_manager_daemon_tick_isolation.py
@@ -1,0 +1,145 @@
+"""#216 迴歸測試：periodic tick 的 execute() 不得被 auto-claim 單點失敗癱瘓。
+
+背景：``build_periodic_tick_runner`` 的 ``execute()`` 呼叫
+``manager.run_auto_claim_scan(...)``（或注入的 ``auto_claim_fn``）以前完全
+沒有 try/except；一旦它 raise，整個 tick 立刻結束——後面的 workflow resume
+迴圈與 ``run_tick`` 全部不會執行。本檔驗證 auto-claim 失敗後兩者仍會被
+呼叫，且回傳的 summary 帶有可觀測的降級標記。
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from paulsha_cortex.coordinator import manager_daemon
+
+
+def _resume_target_workflow() -> SimpleNamespace:
+    return SimpleNamespace(
+        run_id="run-1",
+        work_id="demo",
+        repo="acme/demo",
+        status="ongoing",
+        facets=(),
+        current_phase="build",
+        # 非 "claim:v1:" 前綴，短路掉 build_production_ship_validator 分支，
+        # 讓這個測試專心驗證隔離行為，不用另外準備 ship validator 依賴。
+        claim_key="claim:legacy:demo",
+        source_revision="",
+    )
+
+
+def _dispatcher_with_resumable_workflow(tmp_path: Path) -> SimpleNamespace:
+    workflow = _resume_target_workflow()
+    registry = SimpleNamespace(
+        _state_path=str(tmp_path / "jobs.json"),
+        list_workflow_runs=lambda: [workflow],
+    )
+    return SimpleNamespace(_registry=registry, _git_runner=lambda args: "")
+
+
+def test_periodic_tick_survives_auto_claim_failure_and_still_resumes_and_ticks(
+    monkeypatch, tmp_path: Path
+) -> None:
+    dispatcher = _dispatcher_with_resumable_workflow(tmp_path)
+
+    resume_calls: list[str] = []
+
+    def fake_resume_workflow_run(
+        dispatcher_arg,
+        *,
+        run_id,
+        identities,
+        launcher_factory,
+        coordinator_root,
+        ship_validator,
+    ):
+        resume_calls.append(run_id)
+
+    monkeypatch.setattr(manager_daemon.manager, "resume_workflow_run", fake_resume_workflow_run)
+
+    tick_calls: list[dict] = []
+
+    def fake_run_tick(dispatcher_arg, **kwargs):
+        tick_calls.append(kwargs)
+        return {
+            "dispatch_skipped": False,
+            "dispatched": [],
+            "completed": [],
+            "errors": [],
+            "reaped": None,
+        }
+
+    def failing_auto_claim() -> list[dict]:
+        raise ValueError(
+            "trusted repo registry did not resolve exactly one owner/name root"
+        )
+
+    runner = manager_daemon.build_periodic_tick_runner(
+        dispatcher=dispatcher,
+        specs_dir=str(tmp_path / "specs"),
+        handoff_dir=str(tmp_path / "handoff"),
+        launcher=object(),
+        run_tick_fn=fake_run_tick,
+        scan_specs_fn=lambda specs_dir: [],
+        auto_claim_fn=failing_auto_claim,
+        workflow_identity_registry=object(),
+    )
+
+    result = runner()
+
+    # 單一子系統（auto-claim）失效不得癱瘓整輪：resume 迴圈與 run_tick
+    # 仍然被呼叫。
+    assert resume_calls == ["run-1"]
+    assert len(tick_calls) == 1
+
+    # auto_claims 退化為空 list，而不是讓例外往外傳。
+    assert result["auto_claims"] == []
+    # summary 明確反映這輪 auto-claim 降級了，不是靜默吞掉。
+    assert result["auto_claim_failed"] is True
+    assert "ValueError" in result["auto_claim_error"]
+    assert "trusted repo registry" in result["auto_claim_error"]
+    assert str(tmp_path) not in result["auto_claim_error"]
+
+
+def test_periodic_tick_regression_no_failure_matches_existing_behavior(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """正常情況（auto-claim 不失敗）不得多出降級欄位，行為與現況完全相同。"""
+
+    dispatcher = _dispatcher_with_resumable_workflow(tmp_path)
+
+    resume_calls: list[str] = []
+
+    def fake_resume_workflow_run(dispatcher_arg, **kwargs):
+        resume_calls.append(kwargs["run_id"])
+
+    monkeypatch.setattr(manager_daemon.manager, "resume_workflow_run", fake_resume_workflow_run)
+
+    def fake_run_tick(dispatcher_arg, **kwargs):
+        return {
+            "dispatch_skipped": False,
+            "dispatched": [],
+            "completed": [],
+            "errors": [],
+            "reaped": None,
+        }
+
+    runner = manager_daemon.build_periodic_tick_runner(
+        dispatcher=dispatcher,
+        specs_dir=str(tmp_path / "specs"),
+        handoff_dir=str(tmp_path / "handoff"),
+        launcher=object(),
+        run_tick_fn=fake_run_tick,
+        scan_specs_fn=lambda specs_dir: [],
+        auto_claim_fn=lambda: [{"work_id": "demo", "action": "claim"}],
+        workflow_identity_registry=object(),
+    )
+
+    result = runner()
+
+    assert resume_calls == ["run-1"]
+    assert result["auto_claims"] == [{"work_id": "demo", "action": "claim"}]
+    assert "auto_claim_failed" not in result
+    assert "auto_claim_error" not in result

--- a/tests/test_work_actions_auto_claim_isolation.py
+++ b/tests/test_work_actions_auto_claim_isolation.py
@@ -1,0 +1,149 @@
+"""#216 迴歸測試：daemon tick 的 auto-claim 掃描逐 authority 隔離。
+
+背景（見 manager.log 現場證據）：`run_auto_claim_scan` 的
+``for authority in authorities:`` 迴圈以前完全沒有包住 ``_claim_action`` ->
+``workflow_starter`` -> ``resolve_trusted_repo_root`` 這條呼叫鏈；任一
+authority 對應的 repo 不在信任清單中，``resolve_trusted_repo_root`` 一
+``ValueError`` 就會讓整批 scan 中止，17,013 次同樣錯誤每 4-5 秒重複一次、
+持續 22 小時。本檔驗證單一 authority 的 claim 失敗只會產生一筆
+``blocked`` 結果，不影響其餘 authority 的處理。
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+from paulsha_cortex.coordinator import work_actions
+from paulsha_cortex.coordinator.registry import JobRegistry
+
+
+def _three_authority_snapshot(path: Path) -> Path:
+    path.write_text(
+        json.dumps(
+            {
+                "schema": "work-items-snapshot/v1",
+                "providers": {
+                    "github": {
+                        "provider_id": "github",
+                        "revision": "gh-1",
+                        "last_success_epoch": 100,
+                        "degraded": False,
+                    }
+                },
+                "work_items": [
+                    {
+                        "repo": "acme/demo",
+                        "work_id": f"demo-{index}",
+                        "mapped_issues": [issue],
+                        "mapped_prs": [],
+                        "mapped_openspec": [f"demo-{index}"],
+                        "mapped_todo_paths": [f"docs/todo-{index}.md"],
+                        "confirmed_todo": True,
+                        "auto_label": True,
+                        "source_revisions": [
+                            f"issue:{issue}@open",
+                            f"openspec:demo-{index}@1",
+                        ],
+                    }
+                    for index, issue in ((1, 11), (2, 12), (3, 13))
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _labeled_runner(argv, **kwargs):
+    return SimpleNamespace(
+        returncode=0,
+        stdout=json.dumps({"labels": [{"name": "cortex:auto-on-going"}]}),
+        stderr="",
+    )
+
+
+def _starter_failing_for(*, registry: JobRegistry, state_path: Path, fail_work_id: str):
+    base_starter = work_actions._fallback_workflow_starter(registry, state_path)
+
+    def starter(authority, claim_key, reason):
+        if authority.work_id == fail_work_id:
+            raise ValueError(
+                "trusted repo registry did not resolve exactly one owner/name root"
+            )
+        return base_starter(authority, claim_key, reason)
+
+    return starter
+
+
+def test_run_auto_claim_scan_isolates_single_authority_claim_failure(tmp_path: Path) -> None:
+    snapshot = _three_authority_snapshot(tmp_path / "snapshot.json")
+    state = tmp_path / "runs.json"
+    registry = JobRegistry(state_path=tmp_path / "jobs.json")
+    starter = _starter_failing_for(registry=registry, state_path=state, fail_work_id="demo-2")
+
+    result = work_actions.run_auto_claim_scan(
+        snapshot_path=snapshot,
+        state_path=state,
+        now=lambda: 200,
+        runner=_labeled_runner,
+        workflow_registry=registry,
+        workflow_starter=starter,
+    )
+
+    # 整體呼叫不 raise，三個 authority 都有對應結果。
+    assert [row["work_id"] for row in result] == ["demo-1", "demo-2", "demo-3"]
+
+    first, middle, last = result
+    assert first["action"] == "claim"
+    assert last["action"] == "claim"
+
+    # 中間那筆 starter raise ValueError，被轉成結構化 blocked 結果，
+    # 不得中止整批掃描。
+    assert middle["action"] == "blocked"
+    assert middle["reason"] == "repo-root-unresolved"
+    assert middle["repo"] == "acme/demo"
+    assert "ValueError" in middle["error"]
+    assert "trusted repo registry" in middle["error"]
+    # 錯誤摘要不得夾帶絕對路徑。
+    assert str(tmp_path) not in middle["error"]
+
+    # 另外兩個 authority 確實建立了 workflow run；失敗的那個沒有。
+    runs = registry.list_workflow_runs()
+    assert {run.work_id for run in runs} == {"demo-1", "demo-3"}
+    assert all(run.status == "ongoing" for run in runs)
+
+
+def test_run_auto_claim_scan_claim_failed_reason_for_generic_starter_error(
+    tmp_path: Path,
+) -> None:
+    """非 resolve_trusted_repo_root 型別的失敗，reason 落在通用的
+    ``claim-failed``，仍然是可預期的失敗類型（RuntimeError）而非裸吞。
+    """
+
+    snapshot = _three_authority_snapshot(tmp_path / "snapshot.json")
+    state = tmp_path / "runs.json"
+    registry = JobRegistry(state_path=tmp_path / "jobs.json")
+    base_starter = work_actions._fallback_workflow_starter(registry, state)
+
+    def starter(authority, claim_key, reason):
+        if authority.work_id == "demo-2":
+            raise RuntimeError("workspace lock unavailable")
+        return base_starter(authority, claim_key, reason)
+
+    result = work_actions.run_auto_claim_scan(
+        snapshot_path=snapshot,
+        state_path=state,
+        now=lambda: 200,
+        runner=_labeled_runner,
+        workflow_registry=registry,
+        workflow_starter=starter,
+    )
+
+    middle = result[1]
+    assert middle["work_id"] == "demo-2"
+    assert middle["action"] == "blocked"
+    assert middle["reason"] == "claim-failed"
+    assert "RuntimeError" in middle["error"]
+    assert [row["work_id"] for row in result] == ["demo-1", "demo-2", "demo-3"]

--- a/tests/test_work_actions_auto_claim_isolation.py
+++ b/tests/test_work_actions_auto_claim_isolation.py
@@ -1,4 +1,4 @@
-"""#216 迴歸測試：daemon tick 的 auto-claim 掃描逐 authority 隔離。
+"""#246 迴歸測試：daemon tick 的 auto-claim 掃描逐 authority 隔離。
 
 背景（見 manager.log 現場證據）：`run_auto_claim_scan` 的
 ``for authority in authorities:`` 迴圈以前完全沒有包住 ``_claim_action`` ->
@@ -147,3 +147,59 @@ def test_run_auto_claim_scan_claim_failed_reason_for_generic_starter_error(
     assert middle["reason"] == "claim-failed"
     assert "RuntimeError" in middle["error"]
     assert [row["work_id"] for row in result] == ["demo-1", "demo-2", "demo-3"]
+
+
+def test_safe_exception_summary_redacts_absolute_paths() -> None:
+    """#246（verifier finding）：OSError 子類的預設訊息內嵌絕對路徑，
+    而 blocked 結果／daemon summary／log 都會落到 durable done record；
+    摘要必須遮蔽路徑（R-21 tier: shareable）但保留可診斷的型別與語意。"""
+    summary = work_actions.safe_exception_summary(
+        FileNotFoundError(2, "No such file or directory", "/home/someone/.agents/jobs.json")
+    )
+    assert "FileNotFoundError" in summary
+    assert "/home/someone" not in summary
+    assert ".agents/jobs.json" not in summary
+    assert "<path>" in summary
+
+    home_relative = work_actions.safe_exception_summary(
+        PermissionError(13, "Permission denied", "~/.agents/coordinator/state.json")
+    )
+    assert "~/.agents" not in home_relative
+    assert "<path>" in home_relative
+
+    # 不含路徑的訊息必須原樣保留，才不會犧牲診斷力。
+    plain = work_actions.safe_exception_summary(
+        ValueError("trusted repo registry did not resolve exactly one owner/name root")
+    )
+    assert plain == (
+        "ValueError: trusted repo registry did not resolve exactly one owner/name root"
+    )
+
+
+def test_blocked_result_error_summary_is_path_free(tmp_path: Path) -> None:
+    """整條路徑驗證：starter 拋出帶絕對路徑的 OSError 時，
+    blocked 結果的 error 欄位不得洩漏該路徑。"""
+    leaked = tmp_path / "secret-state.json"
+    snapshot = _three_authority_snapshot(tmp_path / "snapshot.json")
+    state = tmp_path / "runs.json"
+    registry = JobRegistry(state_path=tmp_path / "jobs.json")
+    base_starter = work_actions._fallback_workflow_starter(registry, state)
+
+    def _starter(authority, claim_key, reason):
+        if authority.work_id == "demo-2":
+            raise FileNotFoundError(2, "No such file or directory", str(leaked))
+        return base_starter(authority, claim_key, reason)
+
+    results = work_actions.run_auto_claim_scan(
+        snapshot_path=snapshot,
+        state_path=state,
+        now=lambda: 200,
+        runner=_labeled_runner,
+        workflow_registry=registry,
+        workflow_starter=_starter,
+    )
+    blocked = [row for row in results if row.get("action") == "blocked"]
+    assert blocked, "預期 starter 失敗會產生 blocked 結果"
+    for row in blocked:
+        assert str(tmp_path) not in row.get("error", "")
+        assert "<path>" in row.get("error", "")

--- a/tests/test_work_actions_auto_claim_isolation.py
+++ b/tests/test_work_actions_auto_claim_isolation.py
@@ -149,22 +149,27 @@ def test_run_auto_claim_scan_claim_failed_reason_for_generic_starter_error(
     assert [row["work_id"] for row in result] == ["demo-1", "demo-2", "demo-3"]
 
 
-def test_safe_exception_summary_redacts_absolute_paths() -> None:
+def test_safe_exception_summary_redacts_absolute_paths(tmp_path: Path) -> None:
     """#246（verifier finding）：OSError 子類的預設訊息內嵌絕對路徑，
     而 blocked 結果／daemon summary／log 都會落到 durable done record；
-    摘要必須遮蔽路徑（R-21 tier: shareable）但保留可診斷的型別與語意。"""
+    摘要必須遮蔽路徑（R-21 tier: shareable）但保留可診斷的型別與語意。
+
+    路徑一律由 tmp_path 動態組出——測試檔本身不得出現個人絕對路徑字面值，
+    否則會反過來觸發 R-21。
+    """
+    leaked = tmp_path / ".agents" / "jobs.json"
     summary = work_actions.safe_exception_summary(
-        FileNotFoundError(2, "No such file or directory", "/home/someone/.agents/jobs.json")
+        FileNotFoundError(2, "No such file or directory", str(leaked))
     )
     assert "FileNotFoundError" in summary
-    assert "/home/someone" not in summary
-    assert ".agents/jobs.json" not in summary
+    assert str(tmp_path) not in summary
+    assert "jobs.json" not in summary
     assert "<path>" in summary
 
     home_relative = work_actions.safe_exception_summary(
-        PermissionError(13, "Permission denied", "~/.agents/coordinator/state.json")
+        PermissionError(13, "Permission denied", "~" + "/.agents/coordinator/state.json")
     )
-    assert "~/.agents" not in home_relative
+    assert "/.agents" not in home_relative
     assert "<path>" in home_relative
 
     # 不含路徑的訊息必須原樣保留，才不會犧牲診斷力。


### PR DESCRIPTION
## 摘要

修正 daemon periodic tick 的兩層錯誤隔離缺口。現場證據：`~/.agents/log/manager.log`
累計 17,013 次同一則 `ValueError: trusted repo registry did not resolve exactly
one owner/name root`，2026-07-27 起每 4-5 秒一次、持續 22 小時，觸發原因是
`jobs.json` 僅存的一筆 workflow 對應的 repo 不在信任清單中。根因是呼叫鏈全程
沒有任何隔離邊界：`work_actions.run_auto_claim_scan()` 逐 authority 迴圈沒有
per-authority try/except，`manager_daemon.build_periodic_tick_runner.execute()`
呼叫 auto-claim 也沒有 try/except，單一失敗一路往外炸穿整輪 tick，讓 workflow
resume 迴圈與 `run_tick` 全部不執行，daemon 因此陷入緊密重試迴圈。

`resolve_trusted_repo_root` fail-closed 的語意本身沒有問題，這次只修呼叫端缺
乏隔離；未修改 `resolve_trusted_repo_root`，也未動 `claim.py`（#206 平行修改中）。

## 變更

| 檔案 | 變更 |
| --- | --- |
| `paulsha_cortex/coordinator/work_actions.py` | `run_auto_claim_scan()` 的 `for authority in authorities:` 迴圈包住 `_claim_action(...)` 呼叫，只攔 `ValueError`／`RuntimeError`／`OSError`；失敗時 append 帶 `repo-root-unresolved`／`claim-failed` reason 與型別＋訊息錯誤摘要的 blocked 結果，`continue` 處理下一個 authority |
| `paulsha_cortex/coordinator/manager_daemon.py` | `build_periodic_tick_runner.execute()` 包住 `auto_claim_fn()`／`manager.run_auto_claim_scan(...)` 呼叫；失敗時 `_log_error` 記錄安全脈絡並讓 `auto_claims` 降級為空 list，繼續執行 workflow resume 迴圈與 `run_tick`；回傳 summary 新增 `auto_claim_failed`／`auto_claim_error`；resume 迴圈既有的 `_log_error(exc)` 呼叫點同步補上 `work_id`／`repo`／`source_revision` 脈絡；`_log_error` 新增選用 `context` 參數（不傳時行為與現況完全相同） |
| `changelog.d/246-daemon-tick-isolation.md` | 新增 fragment |
| `tests/test_work_actions_auto_claim_isolation.py` | 新增：三個 authority、中間一個 starter raise 的隔離行為測試（含 `resolve_trusted_repo_root` 型與通用 `RuntimeError` 型兩種 reason 分類） |
| `tests/test_manager_daemon_tick_isolation.py` | 新增：auto-claim raise 後 workflow resume 迴圈與 `run_tick` 仍被呼叫、summary 反映降級；另附 regression 測試確認無失敗時行為不變 |

## 驗收條件對應

- [x] AC1（`run_auto_claim_scan` 逐 authority 隔離）：
  `tests/test_work_actions_auto_claim_isolation.py::test_run_auto_claim_scan_isolates_single_authority_claim_failure`、
  `::test_run_auto_claim_scan_claim_failed_reason_for_generic_starter_error`
- [x] AC2（`execute()` 包住 auto-claim，resume 迴圈／`run_tick` 仍執行，summary 反映降級）：
  `tests/test_manager_daemon_tick_isolation.py::test_periodic_tick_survives_auto_claim_failure_and_still_resumes_and_ticks`
- [x] AC3（regression：無失敗行為不變）：
  `tests/test_manager_daemon_tick_isolation.py::test_periodic_tick_regression_no_failure_matches_existing_behavior`
- [x] AC4（診斷脈絡：action／work_id／repo／source revision，不含 token／絕對路徑）：
  同上兩個測試檔皆斷言 `error`／`auto_claim_error` 不含 `tmp_path` 絕對路徑；
  `manager_daemon._log_error` 新增 `context` 參數並於 auto-claim／resume 兩個
  呼叫點帶入安全脈絡

## 性質

fix（bug fix，行為修正 + 新增測試，無新功能）

Closes #246

## Checklist

- [x] changelog.d fragment 已新增（R-09）
- [x] 本地 preflight-ci PASS（policy + openspec + pytest）
