### PR TITLE
fix(coordinator): authority 逐列隔離與結構化診斷

### DIFF
--- a/changelog.d/authority-isolation-diagnostics.md
+++ b/changelog.d/authority-isolation-diagnostics.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **Issue #206：durable GitHub provider authority invalid 仍復發且缺診斷**：`claim.load_work_authorities()` 改為逐 row 隔離解析——單一 row 的 provider/欄位驗證失敗不再中止整批載入，只把該 row 標記為不可用並繼續解析其餘 row；`load_work_authority(repo=, work_id=)` 因此不再被無關 repo 的壞 provider 誤阻斷，同時對「目標本身就是壞 row」的查詢改拋出帶 reason code 的精準錯誤，維持既有 fail-closed（壞 row 仍不出現在回傳結果中）。新增 `AuthorityValidationError(ValueError)`，攜帶不含機密的 `reason_code`／`repo`／`work_id`／`provider_id`／`field`，並讓 canonical（`provider-authority-*-canonical`）與 legacy（`provider-authority-*-legacy`）schema 的失敗 reason 各自可分辨；#217 的 identity 重複／雙 owner 完整性檢查維持原 raise 行為未動。

--- a/paulsha_cortex/coordinator/claim.py
+++ b/paulsha_cortex/coordinator/claim.py
@@ -23,6 +23,74 @@ GITHUB_PROVIDER_ID = "github"
 PROVIDER_MAX_AGE_SECONDS = 900
 DERIVED_AUTHORITY_KINDS = frozenset({"workflow_run", "completion_record"})
 
+# #206：穩定 reason code，供 upstream（durable done record／manager log）在不
+# 重新解析訊息文字的情況下辨識是哪一種 authority 驗證失敗。canonical 與 legacy
+# schema 各自的 provider 失敗一律區分 -canonical / -legacy 後綴（AC3）。
+REASON_ROW_MALFORMED = "row-malformed"
+REASON_IDENTITY_INVALID = "identity-invalid"
+REASON_PROVIDER_MISSING_CANONICAL = "provider-authority-missing-canonical"
+REASON_PROVIDER_INVALID_CANONICAL = "provider-authority-invalid-canonical"
+REASON_PROVIDER_MISSING_LEGACY = "provider-authority-missing-legacy"
+REASON_PROVIDER_INVALID_LEGACY = "provider-authority-invalid-legacy"
+
+_UNSAFE_LABEL_PREFIXES = ("/", "~")
+
+
+def _diagnostic_label(value: object, *, max_len: int = 200) -> str | None:
+    """Best-effort, secret-free label for a snapshot row's identity field.
+
+    Only ever attached to :class:`AuthorityValidationError` for diagnostics
+    — never used for authorization decisions. Rejects values that look like
+    filesystem paths so a malformed row can never smuggle an absolute path
+    into a durable error message (tier: shareable — AI-SEC-001 契約）.
+    """
+    if not isinstance(value, str):
+        return None
+    text = value.strip()
+    if not text or text.startswith(_UNSAFE_LABEL_PREFIXES) or "\\" in text:
+        return None
+    if len(text) > max_len:
+        text = text[:max_len] + "…"
+    return text
+
+
+class AuthorityValidationError(ValueError):
+    """Row-scoped authority validation failure with secret-free diagnostics.
+
+    Carries a stable ``reason_code`` plus ``repo``/``work_id``/
+    ``provider_id``/``field`` (#206 AC1/AC3) so upstream durable done
+    records and Manager logs can record *which* mutation failed without
+    re-parsing message text. Remains a ``ValueError`` subclass so existing
+    ``except ValueError`` call sites keep working unchanged.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        reason_code: str,
+        repo: str | None = None,
+        work_id: str | None = None,
+        provider_id: str | None = None,
+        field: str | None = None,
+    ) -> None:
+        self.reason_code = reason_code
+        self.repo = repo
+        self.work_id = work_id
+        self.provider_id = provider_id
+        self.field = field
+        self.base_message = message
+        details = [f"reason={reason_code}"]
+        for label, value in (
+            ("repo", repo),
+            ("work_id", work_id),
+            ("provider_id", provider_id),
+            ("field", field),
+        ):
+            if value is not None:
+                details.append(f"{label}={value}")
+        super().__init__(f"{message} ({', '.join(details)})")
+
 
 def semantic_source_revision(
     *,
@@ -56,14 +124,24 @@ def semantic_source_revision(
             else {"open", "closed", "merged"}
         )
         if state not in allowed:
-            raise ValueError(f"canonical {kind} lifecycle status invalid")
+            raise AuthorityValidationError(
+                f"canonical {kind} lifecycle status invalid",
+                reason_code=REASON_ROW_MALFORMED,
+                repo=_diagnostic_label(repo),
+                field="status",
+            )
         return source_id, f"identity:{ref};state:{state}"
     if kind in {"todo", "superpowers_spec", "superpowers_plan"}:
         return source_id, f"identity:{ref}"
     if kind == "openspec":
         state = str(status or "").lower()
         if state not in {"active", "archived"}:
-            raise ValueError("canonical openspec lifecycle status invalid")
+            raise AuthorityValidationError(
+                "canonical openspec lifecycle status invalid",
+                reason_code=REASON_ROW_MALFORMED,
+                repo=_diagnostic_label(repo),
+                field="status",
+            )
         return f"openspec:{repo}:{ref}", f"identity:{ref};state:{state}"
     return source_id, revision
 
@@ -144,7 +222,12 @@ def _load_snapshot(snapshot_path: str | Path | None = None) -> tuple[dict, str]:
         # PR A canonical schema keys GitHub providers by repo.
         return payload, verification.canonical_json_hash(payload)
     if not isinstance(github, dict) or github.get("provider_id") != GITHUB_PROVIDER_ID:
-        raise ValueError("durable GitHub provider authority missing")
+        raise AuthorityValidationError(
+            "durable GitHub provider authority missing",
+            reason_code=REASON_PROVIDER_MISSING_LEGACY,
+            provider_id=GITHUB_PROVIDER_ID,
+            field="provider_id",
+        )
     revision = github.get("revision")
     last_success = github.get("last_success_epoch")
     degraded = github.get("degraded")
@@ -157,7 +240,22 @@ def _load_snapshot(snapshot_path: str | Path | None = None) -> tuple[dict, str]:
         or not isinstance(degraded, bool)
         or degraded
     ):
-        raise ValueError("durable GitHub provider authority invalid")
+        if not isinstance(revision, str) or not revision.strip():
+            field = "revision"
+        elif (
+            not isinstance(last_success, (int, float))
+            or isinstance(last_success, bool)
+            or not math.isfinite(float(last_success))
+        ):
+            field = "last_success_epoch"
+        else:
+            field = "degraded"
+        raise AuthorityValidationError(
+            "durable GitHub provider authority invalid",
+            reason_code=REASON_PROVIDER_INVALID_LEGACY,
+            provider_id=GITHUB_PROVIDER_ID,
+            field=field,
+        )
     return payload, verification.canonical_json_hash(payload)
 
 
@@ -165,9 +263,14 @@ def _authority_from_row(
     *, row: object, providers: dict, snapshot_hash: str
 ) -> WorkAuthority | None:
     if not isinstance(row, dict):
-        raise ValueError("confirmed work authority row malformed")
+        raise AuthorityValidationError(
+            "confirmed work authority row malformed",
+            reason_code=REASON_ROW_MALFORMED,
+        )
     repo = row.get("repo")
     work_id = row.get("work_id")
+    repo_label = _diagnostic_label(repo)
+    work_id_label = _diagnostic_label(work_id)
     if "mapped_issues" not in row:
         return _authority_from_canonical_row(
             row=row,
@@ -176,7 +279,14 @@ def _authority_from_row(
         )
     github = providers.get(GITHUB_PROVIDER_ID)
     if not isinstance(github, dict):
-        raise ValueError("durable GitHub provider authority missing")
+        raise AuthorityValidationError(
+            "durable GitHub provider authority missing",
+            reason_code=REASON_PROVIDER_MISSING_LEGACY,
+            repo=repo_label,
+            work_id=work_id_label,
+            provider_id=GITHUB_PROVIDER_ID,
+            field="providers.github",
+        )
     issues = row.get("mapped_issues")
     prs = row.get("mapped_prs", [])
     changes = row.get("mapped_openspec", [])
@@ -202,24 +312,51 @@ def _authority_from_row(
         or any(not _safe_todo_path(path) for path in todo_paths)
         or len(set(todo_paths)) != len(todo_paths)
     ):
-        raise ValueError("confirmed work authority mapped issues invalid")
-    if (
-        not isinstance(repo, str)
-        or re.fullmatch(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", repo) is None
-        or not isinstance(work_id, str)
-        or re.fullmatch(r"[a-z0-9][a-z0-9-]*", work_id) is None
-    ):
-        raise ValueError("confirmed work authority identity invalid")
+        raise AuthorityValidationError(
+            "confirmed work authority mapped issues invalid",
+            reason_code=REASON_ROW_MALFORMED,
+            repo=repo_label,
+            work_id=work_id_label,
+            field="mapped_issues",
+        )
+    repo_valid = isinstance(repo, str) and re.fullmatch(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", repo) is not None
+    work_id_valid = isinstance(work_id, str) and re.fullmatch(r"[a-z0-9][a-z0-9-]*", work_id) is not None
+    if not repo_valid or not work_id_valid:
+        raise AuthorityValidationError(
+            "confirmed work authority identity invalid",
+            reason_code=REASON_IDENTITY_INVALID,
+            repo=repo_label,
+            work_id=work_id_label,
+            field="repo" if not repo_valid else "work_id",
+        )
     if not isinstance(confirmed_todo, bool):
-        raise ValueError("confirmed work authority Todo flag invalid")
+        raise AuthorityValidationError(
+            "confirmed work authority Todo flag invalid",
+            reason_code=REASON_ROW_MALFORMED,
+            repo=repo_label,
+            work_id=work_id_label,
+            field="confirmed_todo",
+        )
     if not isinstance(auto_label, bool):
-        raise ValueError("confirmed work authority auto label invalid")
+        raise AuthorityValidationError(
+            "confirmed work authority auto label invalid",
+            reason_code=REASON_ROW_MALFORMED,
+            repo=repo_label,
+            work_id=work_id_label,
+            field="auto_label",
+        )
     if (
         not isinstance(source_revisions, list)
         or not source_revisions
         or any(not isinstance(value, str) or not value.strip() for value in source_revisions)
     ):
-        raise ValueError("confirmed work authority revisions invalid")
+        raise AuthorityValidationError(
+            "confirmed work authority revisions invalid",
+            reason_code=REASON_ROW_MALFORMED,
+            repo=repo_label,
+            work_id=work_id_label,
+            field="source_revisions",
+        )
     return WorkAuthority._verified(
         repo=repo,
         work_id=work_id,
@@ -242,22 +379,47 @@ def _authority_from_canonical_row(
     repo = row.get("repo")
     work_id = row.get("work_id")
     sources = row.get("sources")
+    repo_label = _diagnostic_label(repo)
+    work_id_label = _diagnostic_label(work_id)
     if not isinstance(repo, str) or not isinstance(work_id, str) or not isinstance(sources, list):
-        raise ValueError("canonical work authority row malformed")
+        raise AuthorityValidationError(
+            "canonical work authority row malformed",
+            reason_code=REASON_ROW_MALFORMED,
+            repo=repo_label,
+            work_id=work_id_label,
+        )
     if re.fullmatch(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", repo) is None:
-        raise ValueError("canonical work authority identity invalid")
+        raise AuthorityValidationError(
+            "canonical work authority identity invalid",
+            reason_code=REASON_IDENTITY_INVALID,
+            repo=repo_label,
+            work_id=work_id_label,
+            field="repo",
+        )
     next_actions = row.get("next_actions")
     if next_actions is not None and (
         not isinstance(next_actions, list)
         or any(not isinstance(action, str) or not action for action in next_actions)
     ):
-        raise ValueError("canonical work authority actions malformed")
+        raise AuthorityValidationError(
+            "canonical work authority actions malformed",
+            reason_code=REASON_ROW_MALFORMED,
+            repo=repo_label,
+            work_id=work_id_label,
+            field="next_actions",
+        )
     if any(
         not isinstance(source, dict)
         or source.get("confidence") not in {"confirmed", "inferred"}
         for source in sources
     ):
-        raise ValueError("canonical work authority sources malformed")
+        raise AuthorityValidationError(
+            "canonical work authority sources malformed",
+            reason_code=REASON_ROW_MALFORMED,
+            repo=repo_label,
+            work_id=work_id_label,
+            field="sources",
+        )
     if sources and all(source["confidence"] == "inferred" for source in sources):
         return None
     confirmed = [
@@ -272,11 +434,24 @@ def _authority_from_canonical_row(
     if not any(source.get("kind") in todo_kinds for source in confirmed):
         return None
     if re.fullmatch(r"[a-z0-9][a-z0-9-]*", work_id) is None:
-        raise ValueError("canonical work authority identity invalid")
+        raise AuthorityValidationError(
+            "canonical work authority identity invalid",
+            reason_code=REASON_IDENTITY_INVALID,
+            repo=repo_label,
+            work_id=work_id_label,
+            field="work_id",
+        )
     provider_id = f"github:{repo}"
     github = providers.get(provider_id)
     if not isinstance(github, dict):
-        raise ValueError("durable GitHub provider authority missing")
+        raise AuthorityValidationError(
+            "durable GitHub provider authority missing",
+            reason_code=REASON_PROVIDER_MISSING_CANONICAL,
+            repo=repo_label,
+            work_id=work_id_label,
+            provider_id=provider_id,
+            field="providers",
+        )
     revision = github.get("revision")
     last_success_at = github.get("last_success_at")
     if (
@@ -285,11 +460,31 @@ def _authority_from_canonical_row(
         or not revision
         or not isinstance(last_success_at, str)
     ):
-        raise ValueError("durable GitHub provider authority invalid")
+        if github.get("status") != "ok":
+            field = "status"
+        elif not isinstance(revision, str) or not revision:
+            field = "revision"
+        else:
+            field = "last_success_at"
+        raise AuthorityValidationError(
+            "durable GitHub provider authority invalid",
+            reason_code=REASON_PROVIDER_INVALID_CANONICAL,
+            repo=repo_label,
+            work_id=work_id_label,
+            provider_id=provider_id,
+            field=field,
+        )
     try:
         last_success = datetime.fromisoformat(last_success_at.replace("Z", "+00:00")).timestamp()
     except ValueError as exc:
-        raise ValueError("durable GitHub provider timestamp invalid") from exc
+        raise AuthorityValidationError(
+            "durable GitHub provider timestamp invalid",
+            reason_code=REASON_PROVIDER_INVALID_CANONICAL,
+            repo=repo_label,
+            work_id=work_id_label,
+            provider_id=provider_id,
+            field="last_success_at",
+        ) from exc
     issues: list[int] = []
     prs: list[int] = []
     changes: list[str] = []
@@ -300,16 +495,34 @@ def _authority_from_canonical_row(
         if kind in {"github_issue", "github_pr"}:
             match = re.fullmatch(rf"{re.escape(repo)}#([1-9][0-9]*)", str(ref or ""))
             if match is None:
-                raise ValueError("canonical GitHub work source ref invalid")
+                raise AuthorityValidationError(
+                    "canonical GitHub work source ref invalid",
+                    reason_code=REASON_ROW_MALFORMED,
+                    repo=repo_label,
+                    work_id=work_id_label,
+                    field="sources.ref",
+                )
             target = issues if kind == "github_issue" else prs
             target.append(int(match.group(1)))
         elif kind == "openspec":
             if not isinstance(ref, str) or re.fullmatch(r"[a-z0-9]+(?:-[a-z0-9]+)*", ref) is None:
-                raise ValueError("canonical OpenSpec work source ref invalid")
+                raise AuthorityValidationError(
+                    "canonical OpenSpec work source ref invalid",
+                    reason_code=REASON_ROW_MALFORMED,
+                    repo=repo_label,
+                    work_id=work_id_label,
+                    field="sources.ref",
+                )
             changes.append(ref)
         elif kind == "todo":
             if not _safe_todo_path(ref):
-                raise ValueError("canonical Todo work source ref invalid")
+                raise AuthorityValidationError(
+                    "canonical Todo work source ref invalid",
+                    reason_code=REASON_ROW_MALFORMED,
+                    repo=repo_label,
+                    work_id=work_id_label,
+                    field="sources.ref",
+                )
             todo_paths.append(ref)
     confirmed_todo = any(source.get("kind") in todo_kinds for source in confirmed)
     semantic_sources: dict[str, str] = {}
@@ -333,12 +546,24 @@ def _authority_from_canonical_row(
         key, value = semantic
         previous = semantic_sources.setdefault(key, value)
         if previous != value:
-            raise ValueError("confirmed semantic work authority revisions conflict")
+            raise AuthorityValidationError(
+                "confirmed semantic work authority revisions conflict",
+                reason_code=REASON_ROW_MALFORMED,
+                repo=repo_label,
+                work_id=work_id_label,
+                field="source_revisions",
+            )
     source_revisions = tuple(
         f"{source_id}@{semantic_sources[source_id]}" for source_id in sorted(semantic_sources)
     )
     if not source_revisions:
-        raise ValueError("confirmed work authority revisions invalid")
+        raise AuthorityValidationError(
+            "confirmed work authority revisions invalid",
+            reason_code=REASON_ROW_MALFORMED,
+            repo=repo_label,
+            work_id=work_id_label,
+            field="source_revisions",
+        )
     return WorkAuthority._verified(
         repo=repo,
         work_id=work_id,
@@ -414,16 +639,33 @@ def claim_identity_digest(authority: WorkAuthority) -> str:
     return verification.canonical_json_hash(payload)
 
 
-def load_work_authorities(
+def _load_work_authorities_with_diagnostics(
     *, snapshot_path: str | Path | None = None
-) -> tuple[WorkAuthority, ...]:
+) -> tuple[tuple[WorkAuthority, ...], tuple[AuthorityValidationError, ...]]:
+    """Parse every row independently (#206 AC4): one row's validation failure
+    is recorded as ``AuthorityValidationError`` diagnostics and the row is
+    dropped from the result, but parsing continues for the remaining rows —
+    an unrelated repo's degraded/malformed provider must never blast-radius
+    a healthy repo's work-action (durable "authority invalid" recurrence).
+
+    Fail-closed is preserved: a skipped row's work item simply never appears
+    in the returned authorities, so any lookup for it still fails — just
+    with the specific skip reason (see ``load_work_authority``) instead of
+    aborting the whole snapshot load.
+    """
     payload, digest = _load_snapshot(snapshot_path)
     providers = payload["providers"]
-    parsed = (
-        _authority_from_row(row=row, providers=providers, snapshot_hash=digest)
-        for row in payload["work_items"]
-    )
-    authorities = tuple(authority for authority in parsed if authority is not None)
+    parsed: list[WorkAuthority] = []
+    skipped: list[AuthorityValidationError] = []
+    for row in payload["work_items"]:
+        try:
+            authority = _authority_from_row(row=row, providers=providers, snapshot_hash=digest)
+        except AuthorityValidationError as exc:
+            skipped.append(exc)
+            continue
+        if authority is not None:
+            parsed.append(authority)
+    authorities = tuple(parsed)
     identities = [(authority.repo, authority.work_id) for authority in authorities]
     if len(set(identities)) != len(identities):
         raise ValueError("confirmed work authority missing or ambiguous")
@@ -433,6 +675,9 @@ def load_work_authorities(
     # transfer state that must never surface — refuse rather than silently
     # picking a "winner": every claim/ship/abandon caller loads authority
     # through here, so this closes the ambiguity at the single choke point.
+    # These two integrity checks are snapshot-wide invariants, not per-row
+    # parsing failures, so they intentionally keep the pre-#206 raise
+    # behaviour rather than joining the per-row isolation above.
     owners: dict[tuple[str, int], str] = {}
     for authority in authorities:
         for issue in authority.mapped_issues:
@@ -440,6 +685,13 @@ def load_work_authorities(
             owner = owners.setdefault(key, authority.work_id)
             if owner != authority.work_id:
                 raise ValueError("confirmed work authority missing or ambiguous")
+    return authorities, tuple(skipped)
+
+
+def load_work_authorities(
+    *, snapshot_path: str | Path | None = None
+) -> tuple[WorkAuthority, ...]:
+    authorities, _skipped = _load_work_authorities_with_diagnostics(snapshot_path=snapshot_path)
     return authorities
 
 
@@ -449,14 +701,20 @@ def load_work_authority(
     work_id: str,
     snapshot_path: str | Path | None = None,
 ) -> WorkAuthority:
+    authorities, skipped = _load_work_authorities_with_diagnostics(snapshot_path=snapshot_path)
     matches = [
         authority
-        for authority in load_work_authorities(snapshot_path=snapshot_path)
+        for authority in authorities
         if authority.repo == repo and authority.work_id == work_id
     ]
-    if len(matches) != 1:
-        raise ValueError("confirmed work authority missing or ambiguous")
-    return matches[0]
+    if len(matches) == 1:
+        return matches[0]
+    # #206 AC1/C：目標本身就是被跳過的壞 row → 拋出帶該 row reason code 的錯誤，
+    # 而不是泛化的 missing/ambiguous，讓呼叫端能診斷「因為它的 authority 無效」。
+    for exc in skipped:
+        if exc.repo == repo and exc.work_id in (None, work_id):
+            raise exc
+    raise ValueError("confirmed work authority missing or ambiguous")
 
 
 @dataclass(frozen=True)

--- a/tests/test_claim_authority_isolation_206.py
+++ b/tests/test_claim_authority_isolation_206.py
@@ -1,0 +1,259 @@
+"""Focused tests for issue #206: per-row authority isolation + structured
+diagnostics in ``claim.load_work_authorities``/``load_work_authority``.
+
+Reproduces the durable "GitHub provider authority invalid" recurrence: one
+repo's canonical GitHub provider entry is missing/invalid while an unrelated
+repo in the same snapshot is healthy. Before this fix, a single bad row
+aborted the *entire* ``load_work_authorities()`` load, so a target repo's
+work-action was blocked by fleet noise from a repo it has nothing to do
+with. The fix must keep fail-closed for the bad row's own work item while
+no longer letting it blast-radius other repos.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from paulsha_cortex.coordinator.claim import (
+    AuthorityValidationError,
+    load_work_authorities,
+    load_work_authority,
+)
+
+
+def _canonical_row(
+    *,
+    repo: str,
+    work_id: str,
+    todo_ref: str = "docs/todo.md",
+) -> dict:
+    return {
+        "repo": repo,
+        "work_id": work_id,
+        "sources": [
+            {
+                "confidence": "confirmed",
+                "kind": "todo",
+                "ref": todo_ref,
+                "source_id": f"todo:{work_id}",
+                "revision": "todo-rev-1",
+            }
+        ],
+    }
+
+
+def _healthy_provider(*, revision: str = "gh-rev-1", last_success_at: str = "2026-07-20T00:00:00Z") -> dict:
+    return {"status": "ok", "revision": revision, "last_success_at": last_success_at}
+
+
+def _write_snapshot(path: Path, *, providers: dict, work_items: list[dict]) -> Path:
+    path.write_text(
+        json.dumps(
+            {
+                "schema": "work-items-snapshot/v1",
+                "providers": providers,
+                "work_items": work_items,
+            }
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _two_repo_snapshot(tmp_path: Path, *, broken_provider: dict | None) -> Path:
+    """repo A (``acme/broken``) has an invalid/missing provider; repo B
+    (``acme/healthy``) is fully healthy. ``broken_provider=None`` omits the
+    provider entry entirely (missing); a dict with a bad ``status`` field
+    exercises the invalid-but-present case.
+    """
+
+    providers = {"github:acme/healthy": _healthy_provider()}
+    if broken_provider is not None:
+        providers["github:acme/broken"] = broken_provider
+    return _write_snapshot(
+        tmp_path / "snapshot.json",
+        providers=providers,
+        work_items=[
+            _canonical_row(repo="acme/broken", work_id="broken-work"),
+            _canonical_row(repo="acme/healthy", work_id="healthy-work"),
+        ],
+    )
+
+
+# --- AC4 / 測試要求 1：跨 repo 不誤阻斷 -------------------------------------
+
+
+def test_unrelated_repo_bad_provider_does_not_block_healthy_repo(tmp_path: Path) -> None:
+    snapshot = _two_repo_snapshot(tmp_path, broken_provider=None)
+
+    healthy = load_work_authority(repo="acme/healthy", work_id="healthy-work", snapshot_path=snapshot)
+    assert healthy.repo == "acme/healthy"
+    assert healthy.work_id == "healthy-work"
+
+    with pytest.raises(AuthorityValidationError) as excinfo:
+        load_work_authority(repo="acme/broken", work_id="broken-work", snapshot_path=snapshot)
+    assert excinfo.value.repo == "acme/broken"
+    assert excinfo.value.reason_code.startswith("provider-authority-")
+
+
+def test_invalid_but_present_provider_also_isolated_per_repo(tmp_path: Path) -> None:
+    snapshot = _two_repo_snapshot(
+        tmp_path,
+        broken_provider={"status": "degraded", "revision": "gh-rev-x", "last_success_at": "2026-07-20T00:00:00Z"},
+    )
+
+    healthy = load_work_authority(repo="acme/healthy", work_id="healthy-work", snapshot_path=snapshot)
+    assert healthy.work_id == "healthy-work"
+
+    with pytest.raises(AuthorityValidationError) as excinfo:
+        load_work_authority(repo="acme/broken", work_id="broken-work", snapshot_path=snapshot)
+    assert excinfo.value.reason_code == "provider-authority-invalid-canonical"
+    assert excinfo.value.field == "status"
+
+
+# --- 測試要求 2：fail-closed 未鬆動 -----------------------------------------
+
+
+def test_bad_row_work_item_absent_from_load_work_authorities(tmp_path: Path) -> None:
+    snapshot = _two_repo_snapshot(tmp_path, broken_provider=None)
+    authorities = load_work_authorities(snapshot_path=snapshot)
+    identities = {(authority.repo, authority.work_id) for authority in authorities}
+    assert identities == {("acme/healthy", "healthy-work")}
+    assert ("acme/broken", "broken-work") not in identities
+
+
+# --- 測試要求 3：canonical 與 legacy reason 分離 ----------------------------
+
+
+def test_canonical_and_legacy_provider_failures_use_distinct_reason_codes(tmp_path: Path) -> None:
+    canonical_snapshot = _two_repo_snapshot(tmp_path, broken_provider=None)
+    with pytest.raises(AuthorityValidationError) as canonical_excinfo:
+        load_work_authority(repo="acme/broken", work_id="broken-work", snapshot_path=canonical_snapshot)
+
+    legacy_snapshot = _write_snapshot(
+        tmp_path / "legacy-snapshot.json",
+        providers={
+            "github": {
+                "provider_id": "github",
+                "revision": "gh-1",
+                "last_success_epoch": 100,
+                "degraded": True,
+            }
+        },
+        work_items=[
+            {
+                "repo": "acme/demo",
+                "work_id": "legacy-work",
+                "mapped_issues": [1],
+                "mapped_prs": [],
+                "mapped_openspec": [],
+                "mapped_todo_paths": ["docs/todo.md"],
+                "confirmed_todo": True,
+                "auto_label": False,
+                "source_revisions": ["source-rev-1"],
+            }
+        ],
+    )
+    with pytest.raises(AuthorityValidationError) as legacy_excinfo:
+        load_work_authority(repo="acme/demo", work_id="legacy-work", snapshot_path=legacy_snapshot)
+
+    assert canonical_excinfo.value.reason_code != legacy_excinfo.value.reason_code
+    assert "canonical" in canonical_excinfo.value.reason_code
+    assert "legacy" in legacy_excinfo.value.reason_code
+
+
+def test_legacy_row_level_provider_missing_uses_legacy_reason_code(tmp_path: Path) -> None:
+    # No "github" key at all in providers -> legacy row's own provider lookup
+    # (not the snapshot-level degraded gate) is what fails.
+    snapshot = _write_snapshot(
+        tmp_path / "legacy-missing.json",
+        providers={},
+        work_items=[
+            {
+                "repo": "acme/demo",
+                "work_id": "legacy-work",
+                "mapped_issues": [1],
+                "mapped_prs": [],
+                "mapped_openspec": [],
+                "mapped_todo_paths": ["docs/todo.md"],
+                "confirmed_todo": True,
+                "auto_label": False,
+                "source_revisions": ["source-rev-1"],
+            }
+        ],
+    )
+    with pytest.raises(AuthorityValidationError) as excinfo:
+        load_work_authority(repo="acme/demo", work_id="legacy-work", snapshot_path=snapshot)
+    assert excinfo.value.reason_code == "provider-authority-missing-legacy"
+
+
+# --- 測試要求 4：診斷內容含必要欄位、不含機密 -------------------------------
+
+
+def test_diagnostics_contain_repo_provider_field_and_no_secrets(tmp_path: Path) -> None:
+    snapshot = _two_repo_snapshot(tmp_path, broken_provider=None)
+    with pytest.raises(AuthorityValidationError) as excinfo:
+        load_work_authority(repo="acme/broken", work_id="broken-work", snapshot_path=snapshot)
+    exc = excinfo.value
+    assert exc.repo == "acme/broken"
+    assert exc.provider_id == "github:acme/broken"
+    assert exc.field is not None
+    assert exc.reason_code
+
+    rendered = str(exc)
+    assert "acme/broken" in rendered
+    assert str(tmp_path) not in rendered
+    assert "/home/" not in rendered
+    assert not rendered.startswith("/")
+
+
+# --- 測試要求 5：既有 regression（#217 雙 owner／identity 重複）維持 raise -----
+
+
+def test_duplicate_identity_rows_still_raise(tmp_path: Path) -> None:
+    snapshot = _write_snapshot(
+        tmp_path / "dup-identity.json",
+        providers={"github:acme/demo": _healthy_provider()},
+        work_items=[
+            _canonical_row(repo="acme/demo", work_id="dup-work"),
+            _canonical_row(repo="acme/demo", work_id="dup-work"),
+        ],
+    )
+    with pytest.raises(ValueError, match="missing or ambiguous"):
+        load_work_authorities(snapshot_path=snapshot)
+
+
+def test_dual_owner_same_issue_still_raises_217_regression(tmp_path: Path) -> None:
+    providers = {"github:acme/demo": _healthy_provider()}
+    row_old = _canonical_row(repo="acme/demo", work_id="owner-old")
+    row_old["sources"].append(
+        {
+            "confidence": "confirmed",
+            "kind": "github_issue",
+            "ref": "acme/demo#41",
+            "source_id": "issue:41",
+            "revision": "issue-rev-1",
+            "status": "open",
+        }
+    )
+    row_new = _canonical_row(repo="acme/demo", work_id="owner-new")
+    row_new["sources"].append(
+        {
+            "confidence": "confirmed",
+            "kind": "github_issue",
+            "ref": "acme/demo#41",
+            "source_id": "issue:41",
+            "revision": "issue-rev-1",
+            "status": "open",
+        }
+    )
+    snapshot = _write_snapshot(
+        tmp_path / "dual-owner.json",
+        providers=providers,
+        work_items=[row_old, row_new],
+    )
+    with pytest.raises(ValueError, match="missing or ambiguous"):
+        load_work_authorities(snapshot_path=snapshot)


### PR DESCRIPTION
## 摘要

`claim.load_work_authorities()`（`load_work_authority()` 的共用實作）過去以「generator + 一次性 `tuple(...)`」materialize 所有 work rows：任一 row 的 provider authority 解析失敗即 raise，中止整批載入。canonical schema 的 provider 是 repo-scoped（`github:<repo>`），因此無關 repo 的壞/degraded provider 會讓健康 repo 的 `ship`／`start`／`resume`／`retry-*` 全數落入泛化的 `"durable GitHub provider authority invalid"`，且訊息本身無法指出是哪個 repo、哪個欄位、canonical 還是 legacy schema——這正是 #150 修完 pagination 根因後同一錯誤仍持續復發的原因。

本 PR 把 `load_work_authorities()` 改為**逐 row 隔離解析**：單一 row 驗證失敗只把該 row 記為不可用（連同 reason code）並繼續解析其餘 row；`load_work_authority()` 對「查詢目標本身就是壞 row」的情境改拋出帶結構化診斷的 `AuthorityValidationError`，而不是泛化訊息。fail-closed 維持不變——壞 row 對應的 work item 依然不會出現在回傳的 authorities 中。#217 加的 identity 重複／雙 owner snapshot 級完整性檢查（快照層級不變量，非單 row 解析失敗）維持原 raise 行為，未動。

daemon tick（`manager_daemon.py`）與 `work_actions.run_auto_claim_scan` 的迴圈隔離屬另一張平行單負責，本 PR 未觸碰。

## 變更

| 檔案 | 變更 |
| --- | --- |
| `paulsha_cortex/coordinator/claim.py` | 新增 `AuthorityValidationError(ValueError)`（`reason_code`／`repo`／`work_id`／`provider_id`／`field`，訊息不含機密樣式）；`_load_snapshot`、`_authority_from_row`、`_authority_from_canonical_row`、`semantic_source_revision` 的 row/provider 驗證改拋 `AuthorityValidationError`（訊息文字不變，向後相容既有 `except ValueError`／`match=` 斷言）；`load_work_authorities` 拆出 `_load_work_authorities_with_diagnostics`，逐 row try/except 隔離解析，snapshot 級完整性檢查（identity 重複、#217 雙 owner）維持原位置與原 raise 行為；`load_work_authority` 在查無目標時，若目標對應到被跳過的 row，改拋出該 row 的 `AuthorityValidationError`。 |
| `tests/test_claim_authority_isolation_206.py` | 新增：跨 repo 隔離、fail-closed、canonical/legacy reason 分離、診斷內容與機密掃描、#217 regression。 |
| `changelog.d/authority-isolation-diagnostics.md` | 新增 changelog fragment（R-09）。 |

## 驗收條件對應

1. [x] authority 驗證錯誤含不含機密的 `provider_id`／target repo／失敗欄位／reason code
   → `test_diagnostics_contain_repo_provider_field_and_no_secrets`
2. [x] daemon 側 done／manager log 的持久化診斷 → **本單不涉，見 PR body「非目標」**；本單確保 `claim.py` 拋出的錯誤本身攜帶足夠結構化資訊（`AuthorityValidationError` 的 `reason_code`／`repo`／`work_id`／`provider_id`／`field`）供上游記錄
3. [x] canonical 與 legacy schema 的錯誤 reason 分離
   → `test_canonical_and_legacy_provider_failures_use_distinct_reason_codes`、`test_legacy_row_level_provider_missing_uses_legacy_reason_code`
4. [x] target repo work-action 只由其必要 authority gating；其他 repo provider degraded 不誤阻斷
   → `test_unrelated_repo_bad_provider_does_not_block_healthy_repo`、`test_invalid_but_present_provider_also_isolated_per_repo`、`test_bad_row_work_item_absent_from_load_work_authorities`

其餘測試要求：
- fail-closed 未鬆動 → `test_bad_row_work_item_absent_from_load_work_authorities`
- regression（#217 雙 owner／identity 重複仍 raise；既有 claim 相關測試全綠）
  → `test_duplicate_identity_rows_still_raise`、`test_dual_owner_same_issue_still_raises_217_regression`，並全量跑過 `tests/test_work_claim.py`、`tests/test_claim_source_owner_atomic.py`、`tests/test_work_actions.py`、`tests/test_work_bridge.py` 等既有套件（見下方 Checklist）

## 非目標 / 留給整合

- **daemon tick fault isolation**（`manager_daemon.py`）與 **`work_actions.run_auto_claim_scan` 的迴圈結構**：issue #206 AC2（durable done／manager log 保留診斷）由另一位 builder 平行處理該兩處，本 PR 依 maintainer 裁決不觸碰，只確保 `claim.py` 拋出的例外攜帶足夠欄位供其記錄。
- 未新增「保存最小 failure snapshot metadata」的持久化落地（issue 原文驗收條件之一）——此為 daemon/log 側工作，隨上述平行單一併收斂。

## 性質

fix（行為修正 + 新測試），無 breaking change：`AuthorityValidationError` 為 `ValueError` 子類別，既有 `except ValueError`／訊息子字串比對（`work_actions.run_auto_claim_scan` 的 `"snapshot unavailable"`、`work_bridge` 的 `_SOURCE_OWNER_CONFLICT_PREFIX`）均未受影響（已 grep 確認兩者的訊息來源不在本次改動範圍內）。

Closes #206

## Checklist

- [x] changelog.d fragment 已新增（R-09）
- [x] 本地 preflight-ci PASS（policy + openspec + pytest）
