### PR TITLE
fix(manager): tick 失敗不推進排程時鐘，5 分鐘週期退化為 3 秒熱迴圈

### DIFF
--- a/changelog.d/249-tick-backoff.md
+++ b/changelog.d/249-tick-backoff.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **Issue #249：daemon tick 失敗不再退化為熱迴圈**：`manager_daemon.run_loop` 的 periodic tick 失敗時同樣推進排程時鐘並採指數退避（`tick_interval * 2^min(連續失敗數, 4)`，上限 16 倍），成功後即重置為正常間隔；連續失敗達門檻（`TICK_CIRCUIT_BREAKER_THRESHOLD = 6`）後熔斷暫停 periodic tick 一小時冷卻期（`TICK_CIRCUIT_BREAKER_COOLDOWN_SECONDS`），request 佇列（含人工 tick request，操作者的救援管道）處理完全不受影響，且人工 tick 成功會自動重置熔斷狀態。`status.json` 的 `daemon` 區塊新增 `consecutive_tick_failures`／`tick_circuit_open`／`last_tick_error`（已去識別化的型別＋原因摘要）觀測欄位。`_log_error` 對同一錯誤簽章的連續重複改為每 50 次輸出一則彙總，不再逐行全文重刷（第一次仍完整輸出）。

--- a/paulsha_cortex/coordinator/manager_daemon.py
+++ b/paulsha_cortex/coordinator/manager_daemon.py
@@ -4,6 +4,7 @@ import json
 import argparse
 import fcntl
 import os
+import re
 import signal
 import sys
 import tempfile
@@ -28,6 +29,23 @@ DEFAULT_EXECUTOR = "copilot"
 DEFAULT_MAX_LOAD = 1.0
 RECENT_DONE_LIMIT = 10
 MANAGER_CMD_MARKER = "paulsha_cortex.coordinator.manager_daemon"
+
+# Periodic-tick failure resilience (issue #249): a persistently failing tick
+# must never retry every poll cycle -- that turns a 5-minute schedule into a
+# hot loop. Consecutive failures back off the next attempt exponentially
+# (``tick_interval * BASE**min(failures, MAX_EXPONENT)``); once
+# TICK_CIRCUIT_BREAKER_THRESHOLD consecutive failures accrue, periodic ticks
+# pause entirely for TICK_CIRCUIT_BREAKER_COOLDOWN_SECONDS before one more
+# attempt is made. Request-queue processing (including a manual "tick"
+# request, the operator's rescue channel) is never gated by any of this.
+TICK_BACKOFF_MULTIPLIER_BASE = 2.0
+TICK_BACKOFF_MAX_EXPONENT = 4  # caps backoff at tick_interval * 2**4 = 16x
+TICK_CIRCUIT_BREAKER_THRESHOLD = 6  # consecutive failures before ticks pause
+TICK_CIRCUIT_BREAKER_COOLDOWN_SECONDS = 3600.0  # cool-down before one retry
+
+LOG_ERROR_SUMMARY_INTERVAL = 50  # suppressed-repeat summary cadence for _log_error
+_MULTI_SEGMENT_PATH_PATTERN = re.compile(r"\S*/\S*/\S+")
+TICK_ERROR_REASON_MAX_LENGTH = 200  # bounds status.json against a runaway message
 
 
 @dataclass
@@ -121,6 +139,35 @@ def default_tick_interval() -> float:
         return float(override)
     except ValueError:
         return DEFAULT_TICK_INTERVAL
+
+
+def _tick_backoff_seconds(base_interval: float, consecutive_failures: int) -> float:
+    """Exponential backoff interval for the next periodic-tick retry.
+
+    Doubles per consecutive failure, capped at ``TICK_BACKOFF_MAX_EXPONENT``
+    doublings, so a persistently failing tick backs off instead of retrying
+    on every poll cycle. ``consecutive_failures <= 0`` (no prior failure)
+    returns the unmodified ``base_interval``, preserving today's cadence.
+    """
+    if consecutive_failures <= 0:
+        return base_interval
+    exponent = min(consecutive_failures, TICK_BACKOFF_MAX_EXPONENT)
+    return base_interval * (TICK_BACKOFF_MULTIPLIER_BASE**exponent)
+
+
+def _safe_tick_error_summary(exc: Exception) -> dict[str, str]:
+    """Build a redacted, length-capped last-failure summary for ``status.json``.
+
+    Unlike the stderr log (operator-only, ephemeral), ``status.json`` is a
+    persisted, always-on-disk artifact, so multi-segment filesystem paths
+    (which could leak a machine's or user's directory layout) are replaced
+    with a placeholder and the reason is capped to a bounded length.
+    """
+    reason = " ".join(str(exc).split())
+    reason = _MULTI_SEGMENT_PATH_PATTERN.sub("<path>", reason)
+    if len(reason) > TICK_ERROR_REASON_MAX_LENGTH:
+        reason = reason[:TICK_ERROR_REASON_MAX_LENGTH].rstrip() + "…"
+    return {"type": type(exc).__name__, "reason": reason}
 
 
 def _in_flight_status(registry) -> list[dict[str, Any]]:
@@ -865,6 +912,10 @@ def run_loop(
     daemon_idle = True
     last_tick_monotonic = monotonic_fn()
     rounds = 0
+    consecutive_tick_failures = 0
+    tick_circuit_open = False
+    last_tick_error: dict[str, str] | None = None
+    _reset_log_error_dedup_state()
 
     try:
         while max_rounds is None or rounds < max_rounds:
@@ -904,6 +955,13 @@ def run_loop(
                         last_tick_at = now_fn()
                         last_tick_monotonic = monotonic_fn()
                         tick_ran_this_round = True
+                        # A successful manual tick is the operator's rescue
+                        # channel for a tripped circuit breaker: clear the
+                        # periodic path's failure bookkeeping so it gets a
+                        # fresh normal-cadence attempt next round.
+                        consecutive_tick_failures = 0
+                        tick_circuit_open = False
+                        last_tick_error = None
                 except Exception as exc:  # noqa: BLE001
                     done_payload = contract.build_done(
                         req_id=request_id,
@@ -920,10 +978,15 @@ def run_loop(
                     request_drain_interrupted = True
                     break
 
+            if tick_circuit_open:
+                effective_tick_interval = TICK_CIRCUIT_BREAKER_COOLDOWN_SECONDS
+            else:
+                effective_tick_interval = _tick_backoff_seconds(tick_interval, consecutive_tick_failures)
+
             if (
                 not request_drain_interrupted
                 and not tick_ran_this_round
-                and monotonic_fn() - last_tick_monotonic >= tick_interval
+                and monotonic_fn() - last_tick_monotonic >= effective_tick_interval
             ):
                 try:
                     summary = periodic_runner()
@@ -932,8 +995,22 @@ def run_loop(
                     if not skipped:
                         last_tick_at = now_fn()
                         last_tick_monotonic = monotonic_fn()
+                        consecutive_tick_failures = 0
+                        tick_circuit_open = False
+                        last_tick_error = None
                 except Exception as exc:  # noqa: BLE001
                     _log_error(exc)
+                    # Failure must still advance the clock -- this is the
+                    # core fix for #249: the pre-fix code left
+                    # last_tick_monotonic untouched on failure, so the next
+                    # poll cycle (3s later) immediately re-triggered the
+                    # same failing tick forever instead of waiting out
+                    # tick_interval (or the backed-off interval below).
+                    consecutive_tick_failures += 1
+                    last_tick_error = _safe_tick_error_summary(exc)
+                    last_tick_monotonic = monotonic_fn()
+                    if consecutive_tick_failures >= TICK_CIRCUIT_BREAKER_THRESHOLD:
+                        tick_circuit_open = True
 
             try:
                 snapshot = provider()
@@ -945,6 +1022,9 @@ def run_loop(
                         "pid": runtime_pid,
                         "last_tick_at": last_tick_at,
                         "idle": daemon_idle,
+                        "consecutive_tick_failures": consecutive_tick_failures,
+                        "tick_circuit_open": tick_circuit_open,
+                        "last_tick_error": last_tick_error,
                     },
                     updated_at=now_fn(),
                 )
@@ -1027,8 +1107,46 @@ def _install_signal_handlers() -> None:
     signal.signal(signal.SIGINT, _handle_termination)
 
 
+# Module-level state for _log_error's repeat suppression (issue #249: the
+# same ValueError printed 17,013 times over 22 hours because _log_error had
+# zero de-duplication). Reset once per daemon run via
+# _reset_log_error_dedup_state() -- called at the top of run_loop -- so a
+# fresh daemon process (or a fresh test invocation of run_loop) never
+# inherits suppression counters from a previous run.
+_LOG_ERROR_DEDUP_STATE: dict[str, Any] = {"signature": None, "repeat_count": 0}
+
+
+def _reset_log_error_dedup_state() -> None:
+    _LOG_ERROR_DEDUP_STATE["signature"] = None
+    _LOG_ERROR_DEDUP_STATE["repeat_count"] = 0
+
+
 def _log_error(exc: Exception) -> None:
-    print(f"{contract.utcnow()} manager_daemon error: {type(exc).__name__}: {exc}", file=sys.stderr)
+    """Print a manager_daemon error to stderr, with repeat suppression.
+
+    The first occurrence of an error signature (exception type + message)
+    is always printed in full. Consecutive repeats of the exact same
+    signature are suppressed and replaced by a periodic "still repeating"
+    summary every LOG_ERROR_SUMMARY_INTERVAL occurrences, so a persistently
+    failing tick can no longer flood the log the way it did in #249 --
+    while still leaving evidence (via the summary lines) that the failure
+    is ongoing.
+    """
+    timestamp = contract.utcnow()
+    signature = f"{type(exc).__name__}: {exc}"
+    state = _LOG_ERROR_DEDUP_STATE
+    if state["signature"] != signature:
+        state["signature"] = signature
+        state["repeat_count"] = 0
+        print(f"{timestamp} manager_daemon error: {signature}", file=sys.stderr)
+        return
+    state["repeat_count"] += 1
+    if state["repeat_count"] % LOG_ERROR_SUMMARY_INTERVAL == 0:
+        print(
+            f"{timestamp} manager_daemon error (repeated {state['repeat_count']}x since "
+            f"first occurrence, most recent at {timestamp}): {signature}",
+            file=sys.stderr,
+        )
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/tests/test_manager_daemon_tick_backoff.py
+++ b/tests/test_manager_daemon_tick_backoff.py
@@ -1,0 +1,270 @@
+"""Tick-failure resilience for the manager daemon's periodic scheduler.
+
+Covers issue #249: a periodic tick that raises must not turn the
+``tick_interval`` schedule into a hot loop. These tests exercise
+``run_loop``'s failure-backoff, circuit-breaker, health-signal, and
+error-log de-duplication behaviour using fully injected fake clocks/sleeps
+(never a real ``time.sleep``).
+"""
+
+from __future__ import annotations
+
+from paulsha_cortex.control import constants, contract
+from paulsha_cortex.coordinator import manager_daemon
+
+
+class _FakeClock:
+    """Deterministic monotonic clock: value only advances via ``sleep``.
+
+    Mirrors real ``time.monotonic()``/``time.sleep()`` semantics: multiple
+    reads within the same "instant" (before any sleep) return the same
+    value, and only the loop's end-of-round ``sleep_fn`` call moves time
+    forward. This lets tests reason about elapsed wall-clock time across
+    many rounds without ever performing a real sleep.
+    """
+
+    def __init__(self, start: float = 0.0) -> None:
+        self.value = start
+
+    def monotonic(self) -> float:
+        return self.value
+
+    def sleep(self, seconds: float) -> None:
+        self.value += seconds
+
+
+def _write_request(req_id: str, **overrides) -> dict:
+    request = {
+        "schema_version": constants.SCHEMA_VERSION,
+        "req_id": req_id,
+        "type": "tick",
+        "args": {"executor": "copilot"},
+        "requested_by": "cockpit",
+        "created_at": "2026-07-03T09:00:00+00:00",
+    }
+    request.update(overrides)
+    contract.atomic_write_json(constants.requests_dir() / f"{req_id}.json", request)
+    return request
+
+
+def _expected_backoff_attempt_clocks(tick_interval: float, count: int) -> list[float]:
+    """Replicate the production backoff formula to compute expected attempt times."""
+    clocks: list[float] = []
+    elapsed = 0.0
+    consecutive_failures = 0
+    for _ in range(count):
+        elapsed += manager_daemon._tick_backoff_seconds(tick_interval, consecutive_failures)
+        clocks.append(elapsed)
+        consecutive_failures += 1
+    return clocks
+
+
+def test_periodic_tick_backoff_prevents_hot_retry_and_resets_after_success(monkeypatch, tmp_path):
+    monkeypatch.setenv("PSC_CONTROL_ROOT", str(tmp_path))
+    clock = _FakeClock()
+    call_clocks: list[float] = []
+
+    def periodic_tick_runner() -> dict:
+        call_clocks.append(clock.value)
+        if len(call_clocks) <= 2:
+            raise ValueError("boom")
+        return {"dispatch_skipped": False}
+
+    started = manager_daemon.run_loop(
+        request_executor=lambda req: {"dispatched": []},
+        status_provider=lambda: {"ready": [], "in_flight": [], "recent_done": []},
+        periodic_tick_runner=periodic_tick_runner,
+        poll_interval=1.0,
+        tick_interval=10.0,
+        now_fn=lambda: "2026-07-03T09:05:00+00:00",
+        monotonic_fn=clock.monotonic,
+        sleep_fn=clock.sleep,
+        pid=1,
+        max_rounds=85,
+    )
+
+    assert started is True
+    # 1st attempt at t=10 (base tick_interval) fails; backoff to +20 -> 2nd
+    # attempt at t=30 fails; backoff to +40 -> 3rd attempt at t=70 succeeds;
+    # normal cadence resumes -> 4th attempt at t=80 (just +10, not +80).
+    assert call_clocks == [10.0, 30.0, 70.0, 80.0]
+    # 85 rounds at a 1s poll would be ~85 calls under the old hot-loop bug;
+    # backoff keeps the call count nowhere near that.
+    assert len(call_clocks) < 10
+
+    status = contract.read_json(constants.status_path())
+    assert status["daemon"]["consecutive_tick_failures"] == 0
+    assert status["daemon"]["tick_circuit_open"] is False
+    assert status["daemon"]["last_tick_error"] is None
+
+
+def test_periodic_tick_circuit_breaker_stops_calls_but_keeps_draining_requests(monkeypatch, tmp_path):
+    monkeypatch.setenv("PSC_CONTROL_ROOT", str(tmp_path))
+    clock = _FakeClock()
+    tick_interval = 1.0
+    poll_interval = 1.0
+
+    periodic_calls: list[float] = []
+
+    def periodic_tick_runner() -> dict:
+        periodic_calls.append(clock.value)
+        raise ValueError("periodic tick always fails")
+
+    processed_req_ids: list[str] = []
+    seed_counter = {"n": 0}
+
+    def request_executor(req: dict) -> dict:
+        processed_req_ids.append(req["req_id"])
+        seed_counter["n"] += 1
+        _write_request(f"20260703T090000Z-seed{seed_counter['n']:05d}", type="dispatch")
+        return {"dispatched": []}
+
+    _write_request("20260703T090000Z-seed00000", type="dispatch")
+
+    attempt_clocks = _expected_backoff_attempt_clocks(
+        tick_interval, manager_daemon.TICK_CIRCUIT_BREAKER_THRESHOLD
+    )
+    max_rounds = int(attempt_clocks[-1]) + 10  # buffer, still far short of the cooldown
+
+    started = manager_daemon.run_loop(
+        request_executor=request_executor,
+        status_provider=lambda: {"ready": [], "in_flight": [], "recent_done": []},
+        periodic_tick_runner=periodic_tick_runner,
+        poll_interval=poll_interval,
+        tick_interval=tick_interval,
+        now_fn=lambda: "2026-07-03T09:05:00+00:00",
+        monotonic_fn=clock.monotonic,
+        sleep_fn=clock.sleep,
+        pid=1,
+        max_rounds=max_rounds,
+    )
+
+    assert started is True
+    # Circuit opens exactly at the threshold-th consecutive failure and stays
+    # open for the (much longer) cooldown window, so no further periodic
+    # attempts happen within this test's round budget.
+    assert len(periodic_calls) == manager_daemon.TICK_CIRCUIT_BREAKER_THRESHOLD
+    # The request queue (the operator rescue channel) drains one request per
+    # round throughout -- entirely unaffected by the periodic circuit breaker.
+    assert len(processed_req_ids) == max_rounds
+
+    status = contract.read_json(constants.status_path())
+    daemon = status["daemon"]
+    assert daemon["tick_circuit_open"] is True
+    assert daemon["consecutive_tick_failures"] == manager_daemon.TICK_CIRCUIT_BREAKER_THRESHOLD
+    assert daemon["last_tick_error"]["type"] == "ValueError"
+
+
+def test_status_reflects_tick_failure_and_resets_after_success(monkeypatch, tmp_path):
+    monkeypatch.setenv("PSC_CONTROL_ROOT", str(tmp_path))
+
+    def failing_runner() -> dict:
+        raise ValueError("boom: sentinel reason")
+
+    failure_points = iter([0.0, 5.0, 5.0])
+    manager_daemon.run_loop(
+        request_executor=lambda req: {"dispatched": []},
+        status_provider=lambda: {"ready": [], "in_flight": [], "recent_done": []},
+        periodic_tick_runner=failing_runner,
+        poll_interval=0.0,
+        tick_interval=5.0,
+        now_fn=lambda: "2026-07-03T09:05:00+00:00",
+        monotonic_fn=lambda: next(failure_points),
+        sleep_fn=lambda _: None,
+        pid=1,
+        max_rounds=1,
+    )
+
+    status_after_failure = contract.read_json(constants.status_path())
+    daemon_after_failure = status_after_failure["daemon"]
+    assert daemon_after_failure["consecutive_tick_failures"] == 1
+    assert daemon_after_failure["tick_circuit_open"] is False
+    assert daemon_after_failure["last_tick_error"]["type"] == "ValueError"
+    assert "sentinel reason" in daemon_after_failure["last_tick_error"]["reason"]
+    assert daemon_after_failure["last_tick_at"] is None  # never succeeded yet
+
+    success_points = iter([0.0, 5.0, 5.0])
+    manager_daemon.run_loop(
+        request_executor=lambda req: {"dispatched": []},
+        status_provider=lambda: {"ready": [], "in_flight": [], "recent_done": []},
+        periodic_tick_runner=lambda: {"dispatch_skipped": False},
+        poll_interval=0.0,
+        tick_interval=5.0,
+        now_fn=lambda: "2026-07-03T09:06:00+00:00",
+        monotonic_fn=lambda: next(success_points),
+        sleep_fn=lambda _: None,
+        pid=1,
+        max_rounds=1,
+    )
+
+    status_after_success = contract.read_json(constants.status_path())
+    daemon_after_success = status_after_success["daemon"]
+    assert daemon_after_success["consecutive_tick_failures"] == 0
+    assert daemon_after_success["tick_circuit_open"] is False
+    assert daemon_after_success["last_tick_error"] is None
+    assert daemon_after_success["last_tick_at"] == "2026-07-03T09:06:00+00:00"
+
+
+def test_periodic_tick_cadence_unaffected_when_no_failures_occur(monkeypatch, tmp_path):
+    monkeypatch.setenv("PSC_CONTROL_ROOT", str(tmp_path))
+    clock = _FakeClock()
+    call_clocks: list[float] = []
+
+    def periodic_tick_runner() -> dict:
+        call_clocks.append(clock.value)
+        return {"dispatch_skipped": False}
+
+    manager_daemon.run_loop(
+        request_executor=lambda req: {"dispatched": []},
+        status_provider=lambda: {"ready": [], "in_flight": [], "recent_done": []},
+        periodic_tick_runner=periodic_tick_runner,
+        poll_interval=1.0,
+        tick_interval=10.0,
+        now_fn=lambda: "2026-07-03T09:05:00+00:00",
+        monotonic_fn=clock.monotonic,
+        sleep_fn=clock.sleep,
+        pid=1,
+        max_rounds=35,
+    )
+
+    # Untouched regression: three ticks land exactly on tick_interval
+    # multiples, with zero drift from the new backoff/circuit machinery.
+    assert call_clocks == [10.0, 20.0, 30.0]
+
+
+def test_log_error_deduplicates_repeated_signature_with_periodic_summary(capsys):
+    manager_daemon._reset_log_error_dedup_state()
+    exc = ValueError("same failure every time")
+    total_calls = 220
+
+    for _ in range(total_calls):
+        manager_daemon._log_error(exc)
+
+    output_lines = [line for line in capsys.readouterr().err.splitlines() if line.strip()]
+
+    interval = manager_daemon.LOG_ERROR_SUMMARY_INTERVAL
+    expected_lines = 1 + (total_calls - 1) // interval
+    assert len(output_lines) == expected_lines
+    assert len(output_lines) < total_calls
+    # First occurrence is always printed in full, never suppressed.
+    assert "same failure every time" in output_lines[0]
+    # At least one summary line proves the error is still recurring.
+    assert any("repeated" in line and "same failure every time" in line for line in output_lines[1:])
+
+    manager_daemon._log_error(RuntimeError("a totally different problem"))
+    stderr_tail = capsys.readouterr().err
+    assert "a totally different problem" in stderr_tail
+
+
+def test_safe_tick_error_summary_redacts_paths_and_caps_length():
+    exc = ValueError("failed reading /home/example-user/.agents/core/registry/db.sqlite during scan")
+
+    summary = manager_daemon._safe_tick_error_summary(exc)
+
+    assert summary["type"] == "ValueError"
+    assert "/home" not in summary["reason"]
+    assert "<path>" in summary["reason"]
+
+    long_exc = RuntimeError("x" * 500)
+    long_summary = manager_daemon._safe_tick_error_summary(long_exc)
+    assert len(long_summary["reason"]) <= manager_daemon.TICK_ERROR_REASON_MAX_LENGTH + 1


### PR DESCRIPTION
## 摘要

`manager_daemon.run_loop` 的 periodic tick 排程時鐘過去只在**成功**時推進；tick 失敗時
`last_tick_monotonic` 原封不動，下一輪迴圈（3 秒後）判斷式立刻又成立，永遠全速重試、永不退避——
5 分鐘的 tick 週期因此在持續失敗時退化為 3 秒熱迴圈（現場證據：`manager.log` 22 小時內同一
`ValueError` 重複 17,013 次，見 #249）。本 PR 讓失敗路徑同樣推進排程時鐘並採指數退避，連續失敗
達門檻後熔斷暫停 periodic tick（request 佇列與人工 tick request 不受影響），`status.json` 新增
觀測欄位讓 operator 能看出 daemon 名存實亡，並讓 `_log_error` 對同一錯誤簽章去重，不再逐行洗版。

## 變更

| 檔案 | 變更 |
|---|---|
| `paulsha_cortex/coordinator/manager_daemon.py` | `run_loop`：periodic tick 失敗時推進 `last_tick_monotonic` 並指數退避（新函式 `_tick_backoff_seconds`）；連續失敗達 `TICK_CIRCUIT_BREAKER_THRESHOLD` 後熔斷（`tick_circuit_open`），冷卻 `TICK_CIRCUIT_BREAKER_COOLDOWN_SECONDS` 後自動重試一次；成功的人工 tick request 會重置熔斷狀態。`status.json` 的 `daemon` 區塊新增 `consecutive_tick_failures`／`tick_circuit_open`／`last_tick_error`（新函式 `_safe_tick_error_summary` 去識別化）。`_log_error` 對相同錯誤簽章加入去重（新狀態 `_LOG_ERROR_DEDUP_STATE` + `_reset_log_error_dedup_state`），每 `LOG_ERROR_SUMMARY_INTERVAL`(50) 次重複才輸出一則彙總。 |
| `tests/test_manager_daemon_tick_backoff.py`（新檔） | 6 個行為測試，覆蓋退避／熔斷／健康訊號／regression／日誌去重／安全摘要，全部使用假時鐘（無真實 `time.sleep`）。 |
| `changelog.d/249-tick-backoff.md`（新檔） | R-09 fragment。 |

## 驗收條件對應

- [x] **A. 失敗也要推進排程時鐘（指數退避）**：`test_periodic_tick_backoff_prevents_hot_retry_and_resets_after_success`（`tests/test_manager_daemon_tick_backoff.py`）——連續 2 次失敗分別以 +20s／+40s 退避，第 3 次成功後立即恢復正常 +10s 間隔；`test_periodic_tick_cadence_unaffected_when_no_failures_occur` 額外證明無失敗時退避完全不介入。
- [x] **B. 連續失敗熔斷（含救援管道不受影響、可自我恢復）**：`test_periodic_tick_circuit_breaker_stops_calls_but_keeps_draining_requests`——連續失敗達 `TICK_CIRCUIT_BREAKER_THRESHOLD` 後 periodic tick 不再被呼叫，但 request 佇列每輪仍持續被處理（spy 佐證）。自我恢復的兩條路徑：人工 tick request 成功即重置熔斷狀態（`run_loop` 內對應程式碼區塊，見變更表；此路徑復用既有「manual tick resets deadline」語意，未新增獨立測試，理由見下方設計決策）；冷卻期滿後自動重試一次（`tick_circuit_open` 時改用 `TICK_CIRCUIT_BREAKER_COOLDOWN_SECONDS` 作為下一次判斷門檻，同一段程式碼路徑）。
- [x] **C. 真實健康訊號**：`test_status_reflects_tick_failure_and_resets_after_success`——失敗期間 `status.json.daemon.consecutive_tick_failures`／`last_tick_error` 反映實況，成功後歸零／清空。已 grep 確認本 repo 目前無「cortex doctor 反映 daemon tick 健康」的既有介面（`doctor.py` 只檢查 systemd unit 檔案設定，不讀 `status.json`），故未新增無中生有的整合；`status.json` 本身已透過既有 `cortex manager status` 命令（`json.dumps(read_status_fn())`）逐欄位透傳，無需額外改動即可被 operator／`cortex stat` 生態讀到。
- [x] **D. 錯誤日誌去重**：`test_log_error_deduplicates_repeated_signature_with_periodic_summary`——220 次相同錯誤只輸出 5 行（1 次完整首發 + 4 次彙總），且第一次完整、彙總行含重複次數與最近時間；並驗證不同錯誤簽章不受抑制影響。
- [x] **regression**：`test_periodic_tick_cadence_unaffected_when_no_failures_occur` 明確斷言無失敗情況下 tick 恰好落在 `tick_interval` 整數倍、零漂移；既有 `tests/test_coordinator_manager_daemon.py`、`tests/test_fix_dispatch_exception_detail.py`、`tests/test_manager_daemon_stage_execution_key.py`、`tests/test_start_manager_service.py` 全綠（68 tests）。

## 設計決策

- **退避參數**：`TICK_BACKOFF_MULTIPLIER_BASE=2.0`、`TICK_BACKOFF_MAX_EXPONENT=4`（上限 16 倍間隔）、
  `TICK_CIRCUIT_BREAKER_THRESHOLD=6`、`TICK_CIRCUIT_BREAKER_COOLDOWN_SECONDS=3600`（1 小時）。以預設
  `tick_interval=300s` 推算：連續失敗會在約 3.9 小時後觸發熔斷（而非現況的 22 小時熱迴圈瞬間洗版），
  熔斷後每小時自動探測一次是否恢復；數字均為具名常數，之後若要調整無需改動邏輯。
- **`last_tick_at` 不重複新增欄位**：其語意本來就只在成功時更新（等同「最後一次成功時間」），故未
  另加同義欄位，只新增 `consecutive_tick_failures`／`tick_circuit_open`／`last_tick_error` 三個真正
  新增的觀測面向，維持 diff 最小。
- **熔斷不影響 request 佇列**：完全沒有觸碰 request-draining 迴圈（含人工 `tick` request 的既有處理
  路徑）——`tick_circuit_open` 只改變 periodic tick 那個判斷式使用的門檻值，request 迴圈本身在其之前
  無條件執行，天然滿足「救援管道不受熔斷影響」。
- **`_log_error` 簽章保持不變（未加參數）**：既有 3 個測試以 `monkeypatch.setattr(manager_daemon,
  "_log_error", lambda exc: ...)` 整函式替換，若改成需要額外關鍵字參數會直接打壞這些既有測試；改用
  模組層級去重狀態＋在 `run_loop` 起點呼叫 `_reset_log_error_dedup_state()`，讓每次 daemon run（含每個
  測試各自呼叫 `run_loop`）都從乾淨狀態開始，不會跨 run 誤判「同一錯誤」。
- **`status.json` 的 `last_tick_error.reason`**：用正則移除任何含 2 個以上路徑分隔符的 token（保守
  策略，寧可誤判也不漏放路徑），並截斷至 200 字元，避免異常訊息把 `status.json` 撐爆或洩漏路徑。

## 性質

Fixed（bugfix，含新測試檔）。

Closes #249

## Checklist

- [x] changelog.d fragment 已新增（R-09）
- [x] 本地 preflight-ci PASS（policy + openspec + pytest）
