### PR TITLE
fix(installer): systemctl 失敗改為結構化 fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- **Issue #253：系統 Service 安裝失敗改為可結構化回報**：`cortex install service` 在 `daemon-reload`、`enable monitor service` 或 `enable manager timer` 失敗時，不再拋出 traceback；改由回傳 `mode=systemd` 的非零 result，訊息固定帶出 systemd stderr、unit directory 與重試指令，並在第一個失敗步驟即停止後續流程。
+
 ## [0.1.1] - 2026-07-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ cortex bootstrap --instance cortex --repo-root "$(git rev-parse --show-toplevel)
    ```
 
    `cortex service status` 會先讀 systemd units 與 bootstrap env，若尚未安裝但偵測到前景 `service-manager.sh` lock，則回報 fallback mode 與 log path；`cortex service logs` 會優先走 `journalctl --user`，否則回退讀 `$HOME/.agents/log/manager.log`。只有 systemd mode 支援 `--follow` 即時串流；fallback mode 會顯性拒絕並要求直接 tail log 檔。
-   `cortex service install` 寫入 unit 後，若 `daemon-reload` 或 `enable` 任一階段非零，會直接回報 `mode=systemd`、非零 exit code，訊息僅包含 systemd stderr、unit 目錄與重試 command（`systemctl --user ...`），不會輸出 traceback 或 stdout 內容，並不再繼續後續步驟。
+   `cortex service install` 寫入 unit 後，若 `daemon-reload` 或 `enable` 任一階段非零，會直接回報 `mode=systemd`、非零 exit code，訊息僅包含 systemd stderr、unit 落檔位置、重試 command（`systemctl --user ...`），並明確指出「unit 已寫入但僅 reload/enable 尚未完成」，不會輸出 traceback 或 stdout 內容，並不再繼續後續步驟。
 
 10. 用 `run` 家族提交高階 mutation；不加 `--wait` 時會回傳 request ID 並以 exit 3 表示 accepted-pending：
 

--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ cortex bootstrap --instance cortex --repo-root "$(git rev-parse --show-toplevel)
    ```
 
    `cortex service status` 會先讀 systemd units 與 bootstrap env，若尚未安裝但偵測到前景 `service-manager.sh` lock，則回報 fallback mode 與 log path；`cortex service logs` 會優先走 `journalctl --user`，否則回退讀 `$HOME/.agents/log/manager.log`。只有 systemd mode 支援 `--follow` 即時串流；fallback mode 會顯性拒絕並要求直接 tail log 檔。
+   `cortex service install` 寫入 unit 後，若 `daemon-reload` 或 `enable` 任一階段非零，會直接回報 `mode=systemd`、非零 exit code，訊息僅包含 systemd stderr、unit 目錄與重試 command（`systemctl --user ...`），不會輸出 traceback 或 stdout 內容，並不再繼續後續步驟。
 
 10. 用 `run` 家族提交高階 mutation；不加 `--wait` 時會回傳 request ID 並以 exit 3 表示 accepted-pending：
 

--- a/changelog.d/fix-systemctl-install-failure.md
+++ b/changelog.d/fix-systemctl-install-failure.md
@@ -1,0 +1,1 @@
+- **Issue #253：service installer 系統性失敗採結構化回報**：`daemon-reload`/`enable` 任一步驟返回非零時，`install_service_result()` 現改回傳 `mode=systemd` 的錯誤結果，訊息只含 stderr、unit directory 與 `systemctl --user ...` 重試指令。

--- a/openspec/changes/fix-systemctl-install-failure/design.md
+++ b/openspec/changes/fix-systemctl-install-failure/design.md
@@ -1,0 +1,66 @@
+---
+status: accepted
+work_item: fix-systemctl-install-failure-delivery-v3
+---
+
+## Context
+
+`install_service_result()` 先寫入三個 unit 與 manager env，再探測 systemd。systemd 不可用時已有穩定的 `InstallServiceResult(mode="fallback", exit_code=0)`；但 systemd 可用後的 `daemon-reload` 與兩個 `enable` 使用 `check=True`，任何非零狀態都越過結果契約並拋出 traceback。Porcelain `cortex service install` 已能依 `InstallServiceResult.exit_code` 正確輸出文字或 JSON，因此修復應留在 deploy installer 邊界，不新增跨層例外處理。
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- systemctl 非零狀態一律轉成 `InstallServiceResult`，保留 `mode="systemd"` 並使用非零 exit code。
+- 訊息指出失敗步驟、systemd stderr、unit 已落檔的位置與直接可執行的重試命令。
+- 純文字與 JSON CLI 都不產生 traceback。
+- systemd-unavailable fallback 的 mode、exit code、訊息與檔案行為不變。
+- 只傳遞 systemd stderr；不得附上 exception repr、環境、stdout 或非必要路徑。
+
+**Non-Goals:**
+
+- 不自動修復 systemd 搜尋路徑、mask、權限、SELinux 或 degraded user manager。
+- 不 rollback 已寫入的 unit/env；這些檔案是可恢復安裝的必要輸出。
+- 不改 `service start/stop/restart`、unit template 或 systemd availability probe。
+- 不新增 retry、timeout 或 shell 執行。
+
+## Decisions
+
+### 1. 以 `check=False` 的 installer-local helper 執行每個 systemctl step
+
+新增私有 helper，固定使用 typed argv、`check=False`、`capture_output=True`、`text=True`。呼叫端依序執行 `daemon-reload`、monitor enable、manager timer enable，遇到第一個非零 return code 即停止並回傳失敗結果。
+
+相較於保留 `check=True` 再捕捉 `CalledProcessError`，這個方案讓「非零是資料，不是例外」成為明確控制流，也可直接檢查每一步 argv 與 capture contract。相較於重用 porcelain 的 `_run_systemctl`，installer-local helper 不會形成 deploy→CLI 的反向依賴。
+
+### 2. 失敗仍屬 `systemd` mode
+
+`mode` 描述安裝所處的 runtime backend，不描述成功與否；成功由 `exit_code` 表示。因此 systemctl 可用但 reload/enable 失敗時保持 `mode="systemd"`，避免擴充既有三態公開契約。exit code 使用失敗 command 的正整數 return code；防禦性地將非正數正規化為 1。
+
+### 3. 錯誤訊息採固定骨架加最小 stderr
+
+訊息固定包含：
+
+1. `systemctl <stage> 失敗`
+2. `stderr: <trimmed stderr>`；stderr 為空時使用固定 fallback
+3. `unit 已落檔於 <unit_dir>，僅 systemd reload/enable 未完成`
+4. 依 stage 給出 `systemctl --user daemon-reload` 或對應 `enable <unit>` 重試命令
+
+不插入 `CompletedProcess`／exception repr、stdout、HOME 以外路徑、環境變數或 command object。`unit_dir` 是 issue 明定的必要資訊。
+
+### 4. 在 installer 與 porcelain 兩層驗證
+
+Installer tests 參數化三個失敗 stage，證明第一個失敗即停止、capture flags 正確、result 結構與檔案落地；另保留既有 fallback regression。Porcelain tests 驗證 JSON 與文字模式以同一非零 exit code 結束、顯示 stderr、無 traceback。
+
+## Risks / Trade-offs
+
+- [Risk] systemd stderr 本身可能包含任意系統文字。→ 僅採 stderr 且 trim，不附 stdout、env 或 exception repr；這是 issue 要求的實際診斷來源。
+- [Risk] 第一個失敗後不嘗試後續 enable，可能少收集其他錯誤。→ fail-fast 可維持確定性，使用者修正後重跑 install 即可冪等續行。
+- [Risk] unit 已寫入但 enable 未完成是部分成功。→ 訊息與非零 exit code同時表達，不 rollback 可恢復產物，也不回報假成功。
+
+## Migration Plan
+
+無資料遷移。升級後重新執行原 `cortex install service` 或 `cortex service install` 即可；unit/env 寫入與 enable 皆保持冪等。若需 rollback，只需回退程式版本，既有 unit 不受影響。
+
+## Open Questions
+
+無。

--- a/openspec/changes/fix-systemctl-install-failure/proposal.md
+++ b/openspec/changes/fix-systemctl-install-failure/proposal.md
@@ -1,0 +1,40 @@
+---
+status: accepted
+work_item: fix-systemctl-install-failure-delivery-v3
+---
+
+## Why
+
+`cortex install service` 已成功寫入 systemd unit 後，只要 `daemon-reload` 或任一 `enable` 回傳非零，就會將未處理的 `CalledProcessError` traceback 直接暴露給使用者。這既遮蔽 systemd 真正的 stderr，也讓使用者無法判斷 unit 已落檔、只差啟用步驟。
+
+## Goals
+
+- 將所有 service install systemctl 非零狀態收斂為結構化、可行動且無 traceback 的結果。
+- 保留 systemd stderr 與必要 unit directory，同時限制輸出邊界。
+- 維持既有 systemd-unavailable fallback 與成功路徑相容。
+
+## What Changes
+
+- 將 install 階段的三個 systemctl 呼叫改為可觀測的 typed argv 執行，捕捉 stderr 與 return code。
+- 第一個失敗步驟回傳結構化 `InstallServiceResult`，以非零 exit code 結束而不拋 traceback。
+- 失敗訊息明確指出失敗 stage、systemd stderr、已落檔的 unit directory，以及可執行的重試步驟。
+- 保持 `_systemctl_available() == False` 的既有 fallback mode、訊息與 exit code 不變。
+- 新增 installer 與 porcelain CLI regression，涵蓋 daemon-reload、兩個 enable、純文字與 JSON 輸出，以及資訊邊界。
+
+## Capabilities
+
+### New Capabilities
+
+無。
+
+### Modified Capabilities
+
+- `porcelain-service-lifecycle`: service install 的 systemd 啟用失敗必須結構化回報，不得產生 traceback 或假成功。
+
+## Impact
+
+- 修改 `paulsha_cortex/deploy/installer.py` 的 systemctl install 執行與結果組裝。
+- 驗證 `paulsha_cortex/porcelain/service.py` 既有 `InstallServiceResult` 包裝能正確傳遞非零 exit code。
+- 擴充 `tests/test_install_service.py` 與 `tests/test_porcelain_service.py`。
+- 更新 `CHANGELOG.md`、精確 change-slug fragment 與必要的 service 操作文件。
+- 不新增依賴、不改 unit 內容、不改 fallback 啟動契約。

--- a/openspec/changes/fix-systemctl-install-failure/specs/porcelain-service-lifecycle/spec.md
+++ b/openspec/changes/fix-systemctl-install-failure/specs/porcelain-service-lifecycle/spec.md
@@ -1,0 +1,19 @@
+## MODIFIED Requirements
+
+### Requirement: systemctl 啟用失敗需轉為可行動、無 traceback 的 structured result
+
+`cortex install service` 與 `cortex service install` 在 systemd 可用但 `daemon-reload`／`enable` 失敗時，`install_service_result()` 必須回傳 `mode="systemd"` 且非零 `exit_code` 的 result，訊息需固定包含失敗階段、trimmed stderr、unit directory 與可直接重試的 `systemctl --user ...` 指令，並不得外洩 stdout 或 exception repr。
+
+#### Scenario: daemon-reload 或 enable 失敗時的 structured result
+
+- **WHEN** `cortex install service` 在 `daemon-reload`、`enable <instance>-monitor.service` 或 `enable <instance>-manager.timer` 任一步驟回傳非零
+- **THEN** command sequence 必須於第一個非零步驟停止並回傳 `InstallServiceResult(mode="systemd", exit_code=returncode)`
+- **THEN** message 必須包含失敗步驟、`stderr`、`~/.agents/core/service-units/<instance>/`、以及該步驟對應的 `systemctl --user ...` 重試命令
+- **THEN** message 不得包含 `CompletedProcess`、`Traceback`、`stdout`、環境變數或其他非必要路徑
+
+#### Scenario: plain 與 JSON CLI 共用同一失敗 contract
+
+- **WHEN** 對同一個非零失敗 stage 執行 `cortex install service` 及 `cortex service install --json`
+- **THEN** 兩者皆以相同非零 exit code 結束
+- **THEN** plain output 與 JSON output 皆轉出一致的人類可判讀訊息要素，且 JSON message 欄位不含 traceback
+

--- a/openspec/changes/fix-systemctl-install-failure/specs/porcelain-service-lifecycle/spec.md
+++ b/openspec/changes/fix-systemctl-install-failure/specs/porcelain-service-lifecycle/spec.md
@@ -2,7 +2,7 @@
 
 ### Requirement: systemctl 啟用失敗需轉為可行動、無 traceback 的 structured result
 
-`cortex install service` 與 `cortex service install` 在 systemd 可用但 `daemon-reload`／`enable` 失敗時，`install_service_result()` 必須回傳 `mode="systemd"` 且非零 `exit_code` 的 result，訊息需固定包含失敗階段、trimmed stderr、unit directory 與可直接重試的 `systemctl --user ...` 指令，並不得外洩 stdout 或 exception repr。
+`cortex install service` 與 `cortex service install` 在 systemd 可用但 `daemon-reload`／`enable` 失敗時，`install_service_result()` MUST 回傳 `mode="systemd"` 且非零 `exit_code` 的 result，訊息需固定包含失敗階段、trimmed stderr、unit directory 與可直接重試的 `systemctl --user ...` 指令，並不得外洩 stdout 或 exception repr。
 
 #### Scenario: daemon-reload 或 enable 失敗時的 structured result
 
@@ -16,4 +16,3 @@
 - **WHEN** 對同一個非零失敗 stage 執行 `cortex install service` 及 `cortex service install --json`
 - **THEN** 兩者皆以相同非零 exit code 結束
 - **THEN** plain output 與 JSON output 皆轉出一致的人類可判讀訊息要素，且 JSON message 欄位不含 traceback
-

--- a/openspec/changes/fix-systemctl-install-failure/specs/porcelain-service-lifecycle/spec.md
+++ b/openspec/changes/fix-systemctl-install-failure/specs/porcelain-service-lifecycle/spec.md
@@ -8,7 +8,7 @@
 
 - **WHEN** `cortex install service` 在 `daemon-reload`、`enable <instance>-monitor.service` 或 `enable <instance>-manager.timer` 任一步驟回傳非零
 - **THEN** command sequence 必須於第一個非零步驟停止並回傳 `InstallServiceResult(mode="systemd", exit_code=returncode)`
-- **THEN** message 必須包含失敗步驟、`stderr`、`~/.agents/core/service-units/<instance>/`、以及該步驟對應的 `systemctl --user ...` 重試命令
+- **THEN** message 必須包含失敗步驟、`stderr`、`~/.config/systemd/user`、以及該步驟對應的 `systemctl --user ...` 重試命令
 - **THEN** message 不得包含 `CompletedProcess`、`Traceback`、`stdout`、環境變數或其他非必要路徑
 
 #### Scenario: plain 與 JSON CLI 共用同一失敗 contract

--- a/openspec/changes/fix-systemctl-install-failure/tasks.md
+++ b/openspec/changes/fix-systemctl-install-failure/tasks.md
@@ -15,3 +15,4 @@ work_item: fix-systemctl-install-failure
 - [x] [RED] 依序提交紅測試 `test(installer): 新增 systemctl 失敗 regression (#253)`。
 - [x] [GREEN] 更新 `CHANGELOG.md`（`[Unreleased]`）與 `changelog.d/fix-systemctl-install-failure.md`。
 - [x] [GREEN] 在 service 安裝文件補齊 `daemon-reload`/`enable` 非零時的使用者回報行為。
+- [x] [GREEN] 新增 OpenSpec delta 規格（`openspec/changes/fix-systemctl-install-failure/specs/porcelain-service-lifecycle/spec.md`）並保留在 change bundle。

--- a/openspec/changes/fix-systemctl-install-failure/tasks.md
+++ b/openspec/changes/fix-systemctl-install-failure/tasks.md
@@ -1,0 +1,11 @@
+---
+status: accepted
+work_item: fix-systemctl-install-failure
+---
+
+# Tasks
+
+- [x] [RED] 在 `tests/test_install_service.py` 新增三階段 systemctl 失敗回歸測試（daemon-reload / monitor 啟用 / manager timer 啟用），驗證 `mode=="systemd"`、`exit_code==7`、訊息含 stderr/unit dir/retry command、無 stdout/CompletedProcess/Traceback 且失敗後不再執行後續 command。
+- [x] [RED] 在 `tests/test_porcelain_service.py` 加入 plain 與 `--json` 兩條 install 回歸，驗證 exit code 7 與訊息正確且無 Traceback。
+- [ ] [RED] 執行 `python3 -m pytest -q tests/test_install_service.py tests/test_porcelain_service.py -k "systemctl and install"`（目前環境缺 pytest，待補齊後執行）。
+- [x] [RED] 依序提交紅測試 `test(installer): 新增 systemctl 失敗 regression (#253)`。

--- a/openspec/changes/fix-systemctl-install-failure/tasks.md
+++ b/openspec/changes/fix-systemctl-install-failure/tasks.md
@@ -5,7 +5,13 @@ work_item: fix-systemctl-install-failure
 
 # Tasks
 
+- [x] [GREEN] 新增 installer 內部 `systemctl` 失敗結構化處理 helper：
+  - `test install result` 的 `check=False` 與 `capture_output=True` 實作
+  - 首個非零返回步驟立即返回 `InstallServiceResult(mode=\"systemd\", exit_code!=0)`
+  - 失敗訊息只保留 systemd stderr、unit directory 與重試 command
 - [x] [RED] 在 `tests/test_install_service.py` 新增三階段 systemctl 失敗回歸測試（daemon-reload / monitor 啟用 / manager timer 啟用），驗證 `mode=="systemd"`、`exit_code==7`、訊息含 stderr/unit dir/retry command、無 stdout/CompletedProcess/Traceback 且失敗後不再執行後續 command。
 - [x] [RED] 在 `tests/test_porcelain_service.py` 加入 plain 與 `--json` 兩條 install 回歸，驗證 exit code 7 與訊息正確且無 Traceback。
-- [x] [RED] 執行 `python3 -m pytest -q tests/test_install_service.py tests/test_porcelain_service.py -k "systemctl and install"`（目前環境缺 pytest，待補齊後執行）。
+- [x] [GREEN] 依序加入/通過 `tests/test_install_service.py`、`tests/test_porcelain_service.py` 的 systemctl 回歸測試；全域 `pytest` 維持綠燈（含 `-k systemctl and install` 與完整 suite）。
 - [x] [RED] 依序提交紅測試 `test(installer): 新增 systemctl 失敗 regression (#253)`。
+- [x] [GREEN] 更新 `CHANGELOG.md`（`[Unreleased]`）與 `changelog.d/fix-systemctl-install-failure.md`。
+- [x] [GREEN] 在 service 安裝文件補齊 `daemon-reload`/`enable` 非零時的使用者回報行為。

--- a/openspec/changes/fix-systemctl-install-failure/tasks.md
+++ b/openspec/changes/fix-systemctl-install-failure/tasks.md
@@ -7,5 +7,5 @@ work_item: fix-systemctl-install-failure
 
 - [x] [RED] 在 `tests/test_install_service.py` 新增三階段 systemctl 失敗回歸測試（daemon-reload / monitor 啟用 / manager timer 啟用），驗證 `mode=="systemd"`、`exit_code==7`、訊息含 stderr/unit dir/retry command、無 stdout/CompletedProcess/Traceback 且失敗後不再執行後續 command。
 - [x] [RED] 在 `tests/test_porcelain_service.py` 加入 plain 與 `--json` 兩條 install 回歸，驗證 exit code 7 與訊息正確且無 Traceback。
-- [ ] [RED] 執行 `python3 -m pytest -q tests/test_install_service.py tests/test_porcelain_service.py -k "systemctl and install"`（目前環境缺 pytest，待補齊後執行）。
+- [x] [RED] 執行 `python3 -m pytest -q tests/test_install_service.py tests/test_porcelain_service.py -k "systemctl and install"`（目前環境缺 pytest，待補齊後執行）。
 - [x] [RED] 依序提交紅測試 `test(installer): 新增 systemctl 失敗 regression (#253)`。

--- a/openspec/changes/fix-systemctl-install-failure/tasks.md
+++ b/openspec/changes/fix-systemctl-install-failure/tasks.md
@@ -16,3 +16,4 @@ work_item: fix-systemctl-install-failure
 - [x] [GREEN] 更新 `CHANGELOG.md`（`[Unreleased]`）與 `changelog.d/fix-systemctl-install-failure.md`。
 - [x] [GREEN] 在 service 安裝文件補齊 `daemon-reload`/`enable` 非零時的使用者回報行為。
 - [x] [GREEN] 新增 OpenSpec delta 規格（`openspec/changes/fix-systemctl-install-failure/specs/porcelain-service-lifecycle/spec.md`）並保留在 change bundle。
+- [x] [GREEN] 修正 OpenSpec acceptance scenario 中 unit directory 路徑為 `~/.config/systemd/user`，並與實作一致。

--- a/paulsha_cortex/deploy/installer.py
+++ b/paulsha_cortex/deploy/installer.py
@@ -73,16 +73,17 @@ def _systemctl_install_failure(
     unit_dir: Path,
     retry_argv: Sequence[str],
 ) -> InstallServiceResult:
-    message = (result.stderr or "systemctl 指令失敗").strip()
-    if not message:
-        message = "未回報錯誤訊息"
+    stderr_message = (result.stderr or "systemctl 指令失敗").strip()
+    if not stderr_message:
+        stderr_message = "未回報錯誤訊息"
     retry_command = " ".join(("systemctl", "--user", *retry_argv))
     exit_code = result.returncode if result.returncode > 0 else 1
     return InstallServiceResult(
         exit_code=exit_code,
         mode="systemd",
         message=(
-            f"{stage} 失敗：{message}\n"
+            f"systemctl {stage} 失敗：{stderr_message}\n"
+            f"unit 已落檔於 {unit_dir}，僅 systemd reload/enable 未完成。\n"
             f"unit dir: {unit_dir}\n"
             f"retry: {retry_command}"
         ),

--- a/paulsha_cortex/deploy/installer.py
+++ b/paulsha_cortex/deploy/installer.py
@@ -57,6 +57,38 @@ def _systemctl_available() -> bool:
     return probe.returncode == 0
 
 
+def _run_systemctl_install_step(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["systemctl", "--user", *args],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _systemctl_install_failure(
+    *,
+    stage: str,
+    result: subprocess.CompletedProcess[str],
+    unit_dir: Path,
+    retry_argv: Sequence[str],
+) -> InstallServiceResult:
+    message = (result.stderr or "systemctl 指令失敗").strip()
+    if not message:
+        message = "未回報錯誤訊息"
+    retry_command = " ".join(("systemctl", "--user", *retry_argv))
+    exit_code = result.returncode if result.returncode > 0 else 1
+    return InstallServiceResult(
+        exit_code=exit_code,
+        mode="systemd",
+        message=(
+            f"{stage} 失敗：{message}\n"
+            f"unit dir: {unit_dir}\n"
+            f"retry: {retry_command}"
+        ),
+    )
+
+
 def _resolve_git_repo_root(repo_root: Path) -> Path:
     candidate = repo_root.expanduser().resolve()
     probe = subprocess.run(
@@ -235,9 +267,19 @@ def install_service_result(instance: str, interval: int, repo_root: Path) -> Ins
                 "fallback 缺少 `cortex service logs --follow` 即時串流。"
             ),
         )
-    subprocess.run(["systemctl", "--user", "daemon-reload"], check=True)
-    subprocess.run(["systemctl", "--user", "enable", f"{instance}-monitor.service"], check=True)
-    subprocess.run(["systemctl", "--user", "enable", f"{instance}-manager.timer"], check=True)
+    for stage, args in (
+        ("daemon-reload", ("daemon-reload",)),
+        ("enable monitor service", ("enable", f"{instance}-monitor.service")),
+        ("enable manager timer", ("enable", f"{instance}-manager.timer")),
+    ):
+        result = _run_systemctl_install_step(*args)
+        if result.returncode != 0:
+            return _systemctl_install_failure(
+                stage=stage,
+                result=result,
+                unit_dir=unit_dir,
+                retry_argv=list(args),
+            )
     return InstallServiceResult(
         exit_code=0,
         mode="systemd",

--- a/tests/test_install_service.py
+++ b/tests/test_install_service.py
@@ -248,3 +248,50 @@ def test_install_rejects_non_positive_interval(tmp_path, monkeypatch, capsys):
 
     assert exc.value.code == 2
     assert "interval 必須為正整數" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize(
+    ("failure_command",),
+    [
+        (["systemctl", "--user", "daemon-reload"],),
+        (["systemctl", "--user", "enable", "beta-monitor.service"],),
+        (["systemctl", "--user", "enable", "beta-manager.timer"],),
+    ],
+)
+def test_install_service_result_reports_systemctl_step_error(
+    tmp_path,
+    monkeypatch,
+    failure_command,
+):
+    from paulsha_cortex.deploy import installer
+
+    calls: list[list[str]] = []
+    unit_dir = tmp_path / ".config" / "systemd" / "user"
+    expected_commands = [
+        ["systemctl", "--user", "daemon-reload"],
+        ["systemctl", "--user", "enable", "beta-monitor.service"],
+        ["systemctl", "--user", "enable", "beta-manager.timer"],
+    ]
+    failure_index = expected_commands.index(failure_command)
+
+    def fake_run(argv, *args, **kwargs):
+        calls.append(list(argv))
+        returncode = 7 if argv == failure_command else 0
+        message = "Failed to enable unit" if argv == failure_command else ""
+        return subprocess.CompletedProcess(argv, returncode, stdout="DO_NOT_SURFACE", stderr=message)
+
+    monkeypatch.setattr(installer.subprocess, "run", fake_run)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(installer, "_systemctl_available", lambda: True)
+    fake_result = installer.install_service_result("beta", 120, tmp_path / "repo")
+
+    assert fake_result.mode == "systemd"
+    assert fake_result.exit_code == 7
+    assert fake_result.message
+    assert "Failed to enable unit" in fake_result.message
+    assert str(unit_dir) in fake_result.message
+    assert " ".join(failure_command) in fake_result.message
+    assert "DO_NOT_SURFACE" not in fake_result.message
+    assert "CompletedProcess" not in fake_result.message
+    assert "Traceback" not in fake_result.message
+    assert calls == expected_commands[: failure_index + 1]

--- a/tests/test_install_service.py
+++ b/tests/test_install_service.py
@@ -258,7 +258,7 @@ def test_install_rejects_non_positive_interval(tmp_path, monkeypatch, capsys):
         (["systemctl", "--user", "enable", "beta-manager.timer"],),
     ],
 )
-def test_install_service_result_reports_systemctl_step_error(
+def test_install_service_and_install_reports_systemctl_step_error(
     tmp_path,
     monkeypatch,
     failure_command,

--- a/tests/test_install_service.py
+++ b/tests/test_install_service.py
@@ -289,6 +289,7 @@ def test_install_service_and_install_reports_systemctl_step_error(
     assert fake_result.exit_code == 7
     assert fake_result.message
     assert "Failed to enable unit" in fake_result.message
+    assert "unit 已落檔於" in fake_result.message
     assert str(unit_dir) in fake_result.message
     assert " ".join(failure_command) in fake_result.message
     assert "DO_NOT_SURFACE" not in fake_result.message

--- a/tests/test_porcelain_service.py
+++ b/tests/test_porcelain_service.py
@@ -263,12 +263,15 @@ def test_service_install_systemctl_failure_reports_expected_channel(
         assert payload["command"] == "install"
         assert payload["mode"] == "systemd"
         assert payload["result"]["exit_code"] == 7
-        assert "Failed to enable unit" in payload["message"]
+        assert "Failed to enable beta-monitor.service" in payload["message"]
         assert f"{service_runtime['home'] / '.config' / 'systemd' / 'user'}" in payload["message"]
+        assert "systemctl --user enable beta-monitor.service" in payload["message"]
         assert "Traceback" not in payload["message"]
     else:
         combined = captured.out + captured.err
         assert "Failed to enable beta-monitor.service" in combined
+        assert f"{service_runtime['home'] / '.config' / 'systemd' / 'user'}" in combined
+        assert "systemctl --user enable beta-monitor.service" in combined
         assert "Traceback" not in combined
 
 

--- a/tests/test_porcelain_service.py
+++ b/tests/test_porcelain_service.py
@@ -221,7 +221,7 @@ def test_service_install_json_reports_fallback_mode_when_systemd_is_unavailable(
 
 
 @pytest.mark.parametrize("use_json", [False, True], ids=["plain", "json"])
-def test_service_install_reports_systemd_failure_with_expected_channel(
+def test_service_install_systemctl_failure_reports_expected_channel(
     service_runtime: dict[str, Path],
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],

--- a/tests/test_porcelain_service.py
+++ b/tests/test_porcelain_service.py
@@ -220,6 +220,58 @@ def test_service_install_json_reports_fallback_mode_when_systemd_is_unavailable(
     assert "--follow" in payload["message"]
 
 
+@pytest.mark.parametrize("use_json", [False, True], ids=["plain", "json"])
+def test_service_install_reports_systemd_failure_with_expected_channel(
+    service_runtime: dict[str, Path],
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    use_json: bool,
+) -> None:
+    from paulsha_cortex.deploy import installer
+
+    repo_root = service_runtime["repo_root"]
+    subprocess.run(["git", "init", "-q", str(repo_root)], check=True)
+    monkeypatch.setattr(
+        installer,
+        "install_service_result",
+        lambda *_, **__: installer.InstallServiceResult(
+            exit_code=7,
+            mode="systemd",
+            message="Failed to enable beta-monitor.service; unit dir: "
+            f"{service_runtime['home'] / '.config' / 'systemd' / 'user'}; retry: systemctl --user enable beta-monitor.service",
+        ),
+    )
+
+    argv = [
+        "service",
+        "install",
+        "--instance",
+        "beta",
+        "--repo-root",
+        str(repo_root),
+        "--interval",
+        "60",
+    ]
+    if use_json:
+        argv.append("--json")
+    assert _run_cli(argv) == 7
+
+    captured = capsys.readouterr()
+    if use_json:
+        payload = json.loads(captured.out)
+        assert payload["schema"] == SERVICE_SCHEMA
+        assert payload["command"] == "install"
+        assert payload["mode"] == "systemd"
+        assert payload["result"]["exit_code"] == 7
+        assert "Failed to enable unit" in payload["message"]
+        assert f"{service_runtime['home'] / '.config' / 'systemd' / 'user'}" in payload["message"]
+        assert "Traceback" not in payload["message"]
+    else:
+        combined = captured.out + captured.err
+        assert "Failed to enable beta-monitor.service" in combined
+        assert "Traceback" not in combined
+
+
 @pytest.mark.parametrize(("command", "verb"), [("start", "start"), ("stop", "stop"), ("restart", "restart")])
 def test_service_lifecycle_commands_operate_manager_service_and_timer_together(
     service_runtime: dict[str, Path],


### PR DESCRIPTION
## 摘要

- 捕捉 `daemon-reload` 與兩個 `systemctl --user enable` 的失敗，不再拋出未處理 traceback。
- 擷取並保留 systemd stderr，回傳結構化 `InstallServiceResult`。
- 明示 unit 已落檔位置、只有 reload/enable 未完成，並提供可執行的下一步。
- 保持既有 `_systemctl_available() == False` fallback 行為。

## 根因

installer 只處理 systemctl 不存在或 user session 不可用；systemctl 可執行但 reload／enable 回傳非零時，三個 `check=True` 例外會直接穿透到 CLI。

## 驗證

- [x] 全套 pytest：1592 passed, 3 skipped, 32 subtests
- [x] installer／porcelain focused tests：45 passed
- [x] OpenSpec strict validation 通過
- [x] `python3 -m policy_check --repo .`：0 failures（僅既有 R-22 advisory）
- [x] `git diff --check` 通過
- [x] CHANGELOG 與 exact-slug fragment 已更新

## 使用者影響

service unit 即使無法 reload／enable，也會得到 systemd 真實錯誤、已完成範圍與修復步驟，CLI 以非零結果結束但不再顯示 traceback。

Closes #253