### PR TITLE
fix(monitor): legacy config 警告每 process 僅輸出一次

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 本專案遵循 hamanpaul project policy v1.0.15。
 
 ## [Unreleased]
+### Fixed
+- **Issue #254：legacy monitor config 警告去重**：在
+  `paulsha_cortex.monitor.config._resolve_config_source` 中加入單一 process 內 per-key
+  去重機制，保留既有 legacy 警告文案與設定解析順序，避免 legacy env 與 legacy
+  file fallback 在同一 process 重複輸出警告。
 
 ## [0.1.1] - 2026-07-28
 

--- a/changelog.d/dedupe-legacy-config-warnings.md
+++ b/changelog.d/dedupe-legacy-config-warnings.md
@@ -1,0 +1,3 @@
+### Fixed
+- **Issue #254：legacy monitor config 警告去重**：避免 `PAULSHACLAW_CONFIG` 與 `paulshaclaw.yaml`
+  在同一 process 重複發出警告；各 legacy 路徑維持逐字一致文案與既有解析順序。

--- a/docs/monitor-config.md
+++ b/docs/monitor-config.md
@@ -7,6 +7,7 @@
   - 不會合併任何 ambient 的 `project-hippo.yaml`（完全顯式）。
 - `config_path` 未傳入：
   - 依序使用 `PSC_MONITOR_CONFIG`、`PAULSHACLAW_CONFIG`、標準 `project-cortex.yaml` 或 legacy `paulshaclaw.yaml`。
+  - legacy config 的警告仍會提醒，但每個 process 每種 legacy 路徑僅會提示一次，且不影響既有訊息內容與設定解析順序。
   - 合併對應路徑下可見的 `project-hippo.yaml`，以提供 ambient projects。
 
 這個行為是為了讓「給定 explicit config」與「主機預設 ambient 設定」之間維持明確邊界：

--- a/openspec/changes/dedupe-legacy-config-warnings/design.md
+++ b/openspec/changes/dedupe-legacy-config-warnings/design.md
@@ -1,0 +1,60 @@
+---
+status: accepted
+work_item: dedupe-legacy-config-warnings-delivery
+---
+
+## Context
+
+`_resolve_config_source()` 依序處理 explicit path、`PSC_MONITOR_CONFIG`、
+`PAULSHACLAW_CONFIG`、新 manual file 與 legacy manual file。後兩個 legacy
+來源直接在 resolution path 呼叫 `warnings.warn(..., stacklevel=2)`；長駐 process
+反覆掃描時 caller location 與 warning filter 無法提供可靠的 process-level 去重。
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- legacy env 與 legacy file fallback 的 warning 各自每 process 最多一次。
+- 首次 warning message 與 stacklevel 保持不變。
+- config precedence、resolved path 與不存在時回傳 `None` 的行為不變。
+- regression 在 `simplefilter("always")` 下仍能證明 once contract。
+
+**Non-Goals:**
+
+- 不移除 legacy config 支援或自動搬移檔案。
+- 不改 warning category、文案或導入 logging subsystem。
+- 不跨 process 去重；每個 CLI process 仍可提醒一次。
+
+## Decisions
+
+### 1. 使用 module-local stable key set
+
+新增私有 set 與 helper `_warn_deprecated_once(key, message)`。每條 legacy path
+使用固定 key；helper 僅在 key 未出現時呼叫 `warnings.warn()`，成功後才記錄。
+這讓行為不受 stacklevel/caller location 或外部 `simplefilter("always")` 影響。
+
+### 2. 兩條 warning 各自保留一次
+
+legacy env 與 legacy file fallback 提供不同遷移資訊，因此不是全 module 共用一個
+boolean。每條路徑各自一次，兼顧降噪與遷移可見性。
+
+### 3. 測試直接隔離 module state
+
+Regression 以 monkeypatch 或 fixture 清空私有 set，避免測試執行順序污染；不新增
+production reset API。測試逐字比對首次訊息，並驗證重複 resolve 的 path 不變。
+
+## Risks / Trade-offs
+
+- [Risk] module state 讓同 process 後續 config 改變時不再重複提醒同一路徑。→
+  這正是 issue 要求的 process-level once contract；另一條 legacy path 仍有獨立 key。
+- [Risk] warning filter 設為 error 時 `warnings.warn()` 會拋出。→ 只有成功返回後才
+  記錄 key，保留既有 warning-as-error 行為。
+
+## Migration Plan
+
+無資料遷移。升級後每個新 process 第一次使用各 legacy source 時照常提醒，後續
+掃描不再重複；改用新 config 後完全不警告。
+
+## Open Questions
+
+無。

--- a/openspec/changes/dedupe-legacy-config-warnings/proposal.md
+++ b/openspec/changes/dedupe-legacy-config-warnings/proposal.md
@@ -1,0 +1,41 @@
+---
+status: accepted
+work_item: dedupe-legacy-config-warnings-delivery
+---
+
+## Why
+
+長駐 manager process 每次 monitor config resolution 選到 legacy
+`PAULSHACLAW_CONFIG` 或 legacy `paulshaclaw.yaml` fallback 時都輸出相同
+deprecation warning。警告不會自行停止，會持續污染 daemon log 並淹沒真正的
+runtime 訊號。
+
+## Goals
+
+- 兩條 legacy config 遷移警告在同一 process 內各自最多輸出一次。
+- 保留首次完整警告文字、resolved path 與 config precedence。
+- 新 config env/file 路徑維持零 legacy warning。
+
+## What Changes
+
+- 在 monitor config module 建立穩定 deprecation key 與 per-process warning
+  deduplication helper。
+- legacy env 與 legacy file fallback 使用不同 key，但共享相同 once contract。
+- 新增強制 warning filter 的 regression，證明去重不依賴 caller location。
+
+## Capabilities
+
+### New Capabilities
+
+- `monitor-config-resolution`: monitor config source selection 必須保持 precedence，
+  並限制 legacy migration warning 為每 process 每路徑一次。
+
+### Modified Capabilities
+
+無。
+
+## Impact
+
+- 修改 `paulsha_cortex/monitor/config.py` 與直接相關 config resolution tests。
+- 更新 changelog 與必要 config migration 文件。
+- 不新增依賴、不改 warning message、不改 config path precedence。

--- a/openspec/changes/dedupe-legacy-config-warnings/specs/monitor-warning-dedupe/spec.md
+++ b/openspec/changes/dedupe-legacy-config-warnings/specs/monitor-warning-dedupe/spec.md
@@ -1,0 +1,38 @@
+## ADDED Requirements
+
+### Requirement: legacy env deprecation warning is emitted at most once per process
+
+`paulsha_cortex.monitor.config._resolve_config_source()` MUST emit the `PAULSHACLAW_CONFIG` deprecation warning at most once per process lifetime, and that warning MUST use the legacy key `legacy-monitor-env`.
+
+#### Scenario: legacy env deprecation warning dedupe
+
+- **GIVEN** the process has `PAULSHACLAW_CONFIG` set and no `PSC_MONITOR_CONFIG`
+- **WHEN** `_resolve_config_source(None)` is called three times
+- **THEN** exactly one warning MUST be emitted
+- **AND** the warning message MUST exactly match `PAULSHACLAW_CONFIG 已 deprecated，改用 project-cortex.yaml`
+- **AND** `_resolve_config_source(None)` MUST return the same path all three times
+
+### Requirement: legacy file deprecation warning is emitted at most once per process
+
+`paulsha_cortex.monitor.config._resolve_config_source()` MUST emit the legacy file deprecation warning at most once per process lifetime, and that warning MUST use the legacy key `legacy-monitor-file`.
+
+#### Scenario: legacy file deprecation warning dedupe
+
+- **GIVEN** no `PSC_MONITOR_CONFIG` and no `PAULSHACLAW_CONFIG`
+- **AND** `project-cortex.yaml` does not exist while `paulshaclaw.yaml` exists
+- **WHEN** `_resolve_config_source(None)` is called three times
+- **THEN** exactly one warning MUST be emitted
+- **AND** the warning message MUST match the existing phrasing
+- **AND** `_resolve_config_source(None)` MUST return the same legacy path all three times
+
+### Requirement: legacy warning behavior does not change message, precedence, or stacklevel contract
+
+For non-deprecated paths, including when `project-cortex.yaml` exists, `_resolve_config_source()` MUST preserve existing precedence and message content, and deprecated warning stacklevel behavior MUST remain equivalent to the prior contract.
+
+#### Scenario: new config path and warning attribution
+
+- **GIVEN** `project-cortex.yaml` exists and legacy env/file are absent
+- **WHEN** `_resolve_config_source(None)` is called three times
+- **THEN** no deprecated warning MUST be emitted
+- **AND** precedence and resolved path MUST remain unchanged
+- **AND** deprecated warning attribution MUST remain equivalent to the pre-refactor contract.

--- a/openspec/changes/dedupe-legacy-config-warnings/tasks.md
+++ b/openspec/changes/dedupe-legacy-config-warnings/tasks.md
@@ -1,5 +1,5 @@
 ---
-status: in_progress
+status: done
 work_item: dedupe-legacy-config-warnings-delivery
 ---
 

--- a/openspec/changes/dedupe-legacy-config-warnings/tasks.md
+++ b/openspec/changes/dedupe-legacy-config-warnings/tasks.md
@@ -1,0 +1,16 @@
+---
+status: in_progress
+work_item: dedupe-legacy-config-warnings-delivery
+---
+
+# Tasks
+
+- [x] [RED] Add isolated warning-state fixture for per-process warning dedupe tests
+- [x] [RED] Add legacy file fallback once-only regression test
+- [x] [RED] Add legacy env fallback once-only regression test
+- [x] [RED] Add new config no-warning regression test
+- [x] [RED] Run failing regression test suite and commit
+- [ ] [GREEN] Implement one-shot warning dedupe helper in production code
+- [ ] [GREEN] Route both legacy paths through helper with distinct keys
+- [ ] [GREEN] Verify focused tests pass and commit implementation
+- [ ] [DOC] Update changelog and docs, then complete governance checks

--- a/openspec/changes/dedupe-legacy-config-warnings/tasks.md
+++ b/openspec/changes/dedupe-legacy-config-warnings/tasks.md
@@ -10,7 +10,7 @@ work_item: dedupe-legacy-config-warnings-delivery
 - [x] [RED] Add legacy env fallback once-only regression test
 - [x] [RED] Add new config no-warning regression test
 - [x] [RED] Run failing regression test suite and commit
-- [ ] [GREEN] Implement one-shot warning dedupe helper in production code
-- [ ] [GREEN] Route both legacy paths through helper with distinct keys
-- [ ] [GREEN] Verify focused tests pass and commit implementation
-- [ ] [DOC] Update changelog and docs, then complete governance checks
+- [x] [GREEN] Implement one-shot warning dedupe helper in production code
+- [x] [GREEN] Route both legacy paths through helper with distinct keys
+- [x] [GREEN] Verify focused tests pass and commit implementation
+- [x] [DOC] Update changelog and docs, then complete governance checks

--- a/openspec/changes/dedupe-legacy-config-warnings/tasks.md
+++ b/openspec/changes/dedupe-legacy-config-warnings/tasks.md
@@ -14,3 +14,5 @@ work_item: dedupe-legacy-config-warnings-delivery
 - [x] [GREEN] Route both legacy paths through helper with distinct keys
 - [x] [GREEN] Verify focused tests pass and commit implementation
 - [x] [DOC] Update changelog and docs, then complete governance checks
+- [x] [REPAIR] Preserve legacy warning attribution by keeping `stacklevel=2`
+- [x] [REPAIR] Add regression test to lock warning caller attribution

--- a/paulsha_cortex/monitor/config.py
+++ b/paulsha_cortex/monitor/config.py
@@ -16,11 +16,10 @@ ALLOWED_LEGACY_POLICIES = ("list-only", "hide")
 _WARNED_DEPRECATIONS: set[str] = set()
 
 
-def _warn_deprecated_once(key: str, message: str) -> None:
+def _warn_deprecated_once(key: str, _message: str) -> bool:
     if key in _WARNED_DEPRECATIONS:
-        return
-    warnings.warn(message, stacklevel=3)
-    _WARNED_DEPRECATIONS.add(key)
+        return False
+    return True
 
 
 def default_config_path() -> Path:
@@ -69,20 +68,30 @@ def _resolve_config_source(config_path: Path | None) -> Path | None:
         if not raw:
             continue
         if env == ENV_CONFIG_VAR:
-            _warn_deprecated_once(
+            if _warn_deprecated_once(
                 "legacy-monitor-env",
                 "PAULSHACLAW_CONFIG 已 deprecated，改用 project-cortex.yaml",
-            )
+            ):
+                warnings.warn(
+                    "PAULSHACLAW_CONFIG 已 deprecated，改用 project-cortex.yaml",
+                    stacklevel=2,
+                )
+                _WARNED_DEPRECATIONS.add("legacy-monitor-env")
         return Path(raw).expanduser()
     new = _new_manual_path()
     if new.exists():
         return new
     legacy = _legacy_manual_path()
     if legacy.exists():
-        _warn_deprecated_once(
+        if _warn_deprecated_once(
             "legacy-monitor-file",
             f"讀取 deprecated legacy monitor 設定 {legacy}，請遷移至 {new}",
-        )
+        ):
+            warnings.warn(
+                f"讀取 deprecated legacy monitor 設定 {legacy}，請遷移至 {new}",
+                stacklevel=2,
+            )
+            _WARNED_DEPRECATIONS.add("legacy-monitor-file")
         return legacy
     return None
 

--- a/paulsha_cortex/monitor/config.py
+++ b/paulsha_cortex/monitor/config.py
@@ -19,7 +19,7 @@ _WARNED_DEPRECATIONS: set[str] = set()
 def _warn_deprecated_once(key: str, message: str) -> None:
     if key in _WARNED_DEPRECATIONS:
         return
-    warnings.warn(message, stacklevel=2)
+    warnings.warn(message, stacklevel=3)
     _WARNED_DEPRECATIONS.add(key)
 
 

--- a/paulsha_cortex/monitor/config.py
+++ b/paulsha_cortex/monitor/config.py
@@ -13,6 +13,14 @@ from paulsha_cortex.monitor.registry import ProjectEntry, load_hippo_projects
 ENV_CONFIG_VAR = "PAULSHACLAW_CONFIG"
 NEW_ENV_CONFIG_VAR = "PSC_MONITOR_CONFIG"
 ALLOWED_LEGACY_POLICIES = ("list-only", "hide")
+_WARNED_DEPRECATIONS: set[str] = set()
+
+
+def _warn_deprecated_once(key: str, message: str) -> None:
+    if key in _WARNED_DEPRECATIONS:
+        return
+    warnings.warn(message, stacklevel=2)
+    _WARNED_DEPRECATIONS.add(key)
 
 
 def default_config_path() -> Path:
@@ -61,9 +69,9 @@ def _resolve_config_source(config_path: Path | None) -> Path | None:
         if not raw:
             continue
         if env == ENV_CONFIG_VAR:
-            warnings.warn(
+            _warn_deprecated_once(
+                "legacy-monitor-env",
                 "PAULSHACLAW_CONFIG 已 deprecated，改用 project-cortex.yaml",
-                stacklevel=2,
             )
         return Path(raw).expanduser()
     new = _new_manual_path()
@@ -71,9 +79,9 @@ def _resolve_config_source(config_path: Path | None) -> Path | None:
         return new
     legacy = _legacy_manual_path()
     if legacy.exists():
-        warnings.warn(
+        _warn_deprecated_once(
+            "legacy-monitor-file",
             f"讀取 deprecated legacy monitor 設定 {legacy}，請遷移至 {new}",
-            stacklevel=2,
         )
         return legacy
     return None

--- a/tests/test_monitor_config_resolution.py
+++ b/tests/test_monitor_config_resolution.py
@@ -18,10 +18,7 @@ def _write(p: Path, text="workspaces:\n  - {name: a, path: /tmp/a}\n"):
 @pytest.fixture
 def isolate_warning_state(monkeypatch):
     original = getattr(monitor_config, "_WARNED_DEPRECATIONS", None)
-    if original is None:
-        monkeypatch.setattr(monitor_config, "_WARNED_DEPRECATIONS", set(), raising=False)
-    else:
-        monkeypatch.setattr(monitor_config, "_WARNED_DEPRECATIONS", set(original))
+    monkeypatch.setattr(monitor_config, "_WARNED_DEPRECATIONS", set(), raising=False)
     yield
     if original is None:
         monkeypatch.delattr(monitor_config, "_WARNED_DEPRECATIONS", raising=False)

--- a/tests/test_monitor_config_resolution.py
+++ b/tests/test_monitor_config_resolution.py
@@ -1,8 +1,10 @@
 from pathlib import Path
+import warnings
 
 import pytest
 
 from paulsha_cortex.monitor.config import _resolve_config_source, load_config
+import paulsha_cortex.monitor.config as monitor_config
 from paulsha_cortex.monitor.work_api import MonitorSocketClient
 from paulsha_cortex.config import paths
 
@@ -11,6 +13,20 @@ def _write(p: Path, text="workspaces:\n  - {name: a, path: /tmp/a}\n"):
     p.parent.mkdir(parents=True, exist_ok=True)
     p.write_text(text, encoding="utf-8")
     return p
+
+
+@pytest.fixture
+def isolate_warning_state(monkeypatch):
+    original = getattr(monitor_config, "_WARNED_DEPRECATIONS", None)
+    if original is None:
+        monkeypatch.setattr(monitor_config, "_WARNED_DEPRECATIONS", set(), raising=False)
+    else:
+        monkeypatch.setattr(monitor_config, "_WARNED_DEPRECATIONS", set(original))
+    yield
+    if original is None:
+        monkeypatch.delattr(monitor_config, "_WARNED_DEPRECATIONS", raising=False)
+    else:
+        monkeypatch.setattr(monitor_config, "_WARNED_DEPRECATIONS", original)
 
 
 def test_prefers_new_project_cortex_over_legacy(monkeypatch, tmp_path):
@@ -31,6 +47,57 @@ def test_legacy_only_transition(monkeypatch, tmp_path, recwarn):
     legacy = _write(tmp_path / "legacy" / "paulshaclaw.yaml")
     assert _resolve_config_source(None) == legacy
     assert any("deprecated" in str(w.message).lower() for w in recwarn.list)
+
+
+def test_legacy_file_warning_once_per_process(monkeypatch, tmp_path, isolate_warning_state):
+    monkeypatch.delenv("PSC_MONITOR_CONFIG", raising=False)
+    monkeypatch.delenv("PAULSHACLAW_CONFIG", raising=False)
+    monkeypatch.setenv("PSC_PROJECT_CONFIG_ROOT", str(tmp_path / "agents"))
+    monkeypatch.setenv("PSC_CONFIG_ROOT", str(tmp_path / "legacy"))
+    legacy = _write(tmp_path / "legacy" / "paulshaclaw.yaml")
+    expected_message = (
+        f"讀取 deprecated legacy monitor 設定 {legacy}，請遷移至 {tmp_path / 'agents' / 'project-cortex.yaml'}"
+    )
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        resolved = [_resolve_config_source(None) for _ in range(3)]
+
+    assert resolved == [legacy, legacy, legacy]
+    assert len(caught) == 1
+    assert str(caught[0].message) == expected_message
+
+
+def test_legacy_env_warning_once_per_process(monkeypatch, tmp_path, isolate_warning_state):
+    legacy_env = tmp_path / "legacy-env-config.yaml"
+    legacy = _write(legacy_env)
+    monkeypatch.setenv("PAULSHACLAW_CONFIG", str(legacy))
+    monkeypatch.delenv("PSC_MONITOR_CONFIG", raising=False)
+    monkeypatch.setenv("PSC_PROJECT_CONFIG_ROOT", str(tmp_path / "agents"))
+    monkeypatch.setenv("PSC_CONFIG_ROOT", str(tmp_path / "legacy"))
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        resolved = [_resolve_config_source(None) for _ in range(3)]
+
+    assert resolved == [legacy, legacy, legacy]
+    assert len(caught) == 1
+    assert str(caught[0].message) == "PAULSHACLAW_CONFIG 已 deprecated，改用 project-cortex.yaml"
+
+
+def test_new_config_has_no_deprecation_warning(monkeypatch, tmp_path, isolate_warning_state):
+    monkeypatch.delenv("PSC_MONITOR_CONFIG", raising=False)
+    monkeypatch.delenv("PAULSHACLAW_CONFIG", raising=False)
+    monkeypatch.setenv("PSC_PROJECT_CONFIG_ROOT", str(tmp_path / "agents"))
+    monkeypatch.setenv("PSC_CONFIG_ROOT", str(tmp_path / "legacy"))
+    new = _write(tmp_path / "agents" / "project-cortex.yaml")
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        resolved = [_resolve_config_source(None) for _ in range(3)]
+
+    assert resolved == [new, new, new]
+    assert caught == []
 
 
 def test_none_when_no_manual(monkeypatch, tmp_path):

--- a/tests/test_monitor_config_resolution.py
+++ b/tests/test_monitor_config_resolution.py
@@ -82,6 +82,24 @@ def test_legacy_env_warning_once_per_process(monkeypatch, tmp_path, isolate_warn
     assert str(caught[0].message) == "PAULSHACLAW_CONFIG 已 deprecated，改用 project-cortex.yaml"
 
 
+def test_legacy_env_warning_stacklevel_points_to_caller(monkeypatch, tmp_path, isolate_warning_state):
+    legacy = _write(tmp_path / "legacy-env-config.yaml")
+    monkeypatch.setenv("PAULSHACLAW_CONFIG", str(legacy))
+    monkeypatch.delenv("PSC_MONITOR_CONFIG", raising=False)
+    monkeypatch.setenv("PSC_PROJECT_CONFIG_ROOT", str(tmp_path / "agents"))
+    monkeypatch.setenv("PSC_CONFIG_ROOT", str(tmp_path / "legacy"))
+
+    def resolve_once():
+        return _resolve_config_source(None)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        resolve_once()
+
+    assert len(caught) == 1
+    assert Path(caught[0].filename).name == Path(__file__).name
+
+
 def test_new_config_has_no_deprecation_warning(monkeypatch, tmp_path, isolate_warning_state):
     monkeypatch.delenv("PSC_MONITOR_CONFIG", raising=False)
     monkeypatch.delenv("PAULSHACLAW_CONFIG", raising=False)


### PR DESCRIPTION
## 摘要

- 以兩個穩定 key 分別追蹤 legacy file fallback 與 `PAULSHACLAW_CONFIG` warning。
- 同一 process 內每條 legacy path 最多發出一次完整警告。
- 保留 warning 文案、config precedence、resolved path 與新設定零 warning 行為。
- 補上強制 `simplefilter("always")` 的去重 regression，以及 warning caller attribution regression。

## 根因

`_resolve_config_source()` 每次選到 legacy source 都直接呼叫 `warnings.warn()`；長駐 manager 反覆掃描時會持續污染日誌，Python caller-location filter 也不是可靠的 process-level contract。

## 驗證

- [x] 全套 pytest：1591 passed, 3 skipped, 32 subtests
- [x] monitor config focused tests：10 passed
- [x] OpenSpec strict validation 通過
- [x] `python3 -m policy_check --repo .`：0 failures（僅既有 R-22 advisory）
- [x] `git diff --check` 通過
- [x] CHANGELOG 與 exact-slug fragment 已更新

## Review 注意事項

對抗審查曾發現 helper 抽取後若直接沿用 `stacklevel=2`，warning attribution 會多偏移一層。Candidate 已把 `warnings.warn(..., stacklevel=2)` 保留在 `_resolve_config_source()`，並新增 caller-attribution regression；請特別檢查此 once helper／inline warning 分工是否清楚。

## 使用者影響

長駐 daemon 不再反覆刷同一 legacy migration warning；每個新 process 仍會保留一次完整遷移提醒。

Closes #254