### PR TITLE
fix(install): 遷移 install service 未 reconcile 的 legacy Codex relay hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,11 @@
   的 `cortex relay-hook` 指令，改寫前自動備份原檔（`hooks.json.bak-<hex>`），
   只動 Cortex 自管的 entries，其餘 owner（例如 `paulsha-memory`、
   `psc-bro-return`）與已是 canonical 的設定維持不變，修補 Codex Stop hook
-  exit 127 的 install migration gap。
+  exit 127 的 install migration gap。全程 fail-open：套件內建 manifest
+  本身損壞/缺失時也不拋例外中斷 `cortex install service`，改回傳
+  `changed=False` 並附可辨識原因的 detail；`daemon-reload`／`enable` 等
+  systemctl 步驟失敗時，若 hook 遷移已先行發生，回報訊息會一併帶出遷移
+  結果，避免副作用（改檔＋備份）發生卻未讓 operator 知情。
 - **Issue #254：legacy monitor config 警告去重**：在
   `paulsha_cortex.monitor.config._resolve_config_source` 中加入單一 process 內 per-key
   去重機制，保留既有 legacy 警告文案與設定解析順序，避免 legacy env 與 legacy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@
 
 ## [Unreleased]
 ### Fixed
+- **Issue #155：修補 install/upgrade 未遷移 Codex 全域 relay hook**：新增
+  `paulsha_cortex.deploy.hooks.reconcile_codex_hooks()`，於 `cortex install
+  service` 流程中 idempotent 改寫 `$HOME/.codex/hooks.json` 內
+  `managedBy: psc-coordinator-relay` 的 legacy entry（指向已不存在的
+  `paulshaclaw/scripts/coordinator/psc-relay-hook.sh` 絕對路徑）為 canonical
+  的 `cortex relay-hook` 指令，改寫前自動備份原檔（`hooks.json.bak-<hex>`），
+  只動 Cortex 自管的 entries，其餘 owner（例如 `paulsha-memory`、
+  `psc-bro-return`）與已是 canonical 的設定維持不變，修補 Codex Stop hook
+  exit 127 的 install migration gap。
 - **Issue #254：legacy monitor config 警告去重**：在
   `paulsha_cortex.monitor.config._resolve_config_source` 中加入單一 process 內 per-key
   去重機制，保留既有 legacy 警告文案與設定解析順序，避免 legacy env 與 legacy

--- a/changelog.d/migrate-codex-relay-hook.md
+++ b/changelog.d/migrate-codex-relay-hook.md
@@ -1,0 +1,7 @@
+### Fixed
+- **Issue #155：install/upgrade 遷移 Codex 全域 relay hook**：新增
+  `paulsha_cortex.deploy.hooks.reconcile_codex_hooks()`，於 `cortex install service`
+  流程 idempotent 改寫 `$HOME/.codex/hooks.json` 內 `managedBy: psc-coordinator-relay`
+  的 legacy 絕對路徑 entry 為 canonical 的 `cortex relay-hook`，修補 Codex Stop hook
+  exit 127 的 migration gap；改寫前備份原檔、只動 Cortex 自管 entries、全程 fail-open
+  不中斷安裝，systemctl 步驟失敗時仍回報已發生的遷移結果。

--- a/paulsha_cortex/deploy/hooks.py
+++ b/paulsha_cortex/deploy/hooks.py
@@ -1,0 +1,132 @@
+"""reconcile 全域 agent hook 設定——只改寫 Cortex 自管的 managedBy entries。
+
+issue #155：升級後 `$HOME/.codex/hooks.json` 仍保留舊版 psc-relay-hook.sh
+絕對路徑（該檔案已隨舊 repo 佈局消失），造成 Codex Stop hook exit 127。
+fresh install 的 template（`paulsha_cortex/scripts/hooks/codex.json`）已改用
+`cortex relay-hook`，但 install/upgrade flow 從未 reconcile 既存的 live 設定。
+
+本模組提供 idempotent 的 reconcile：只改寫 `managedBy` 標記為
+`psc-coordinator-relay` 的 entries，其餘 owner（例如 `paulsha-memory`、
+`psc-bro-return`）與未知 event 一律原樣保留。
+"""
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass, field
+from importlib import resources
+from pathlib import Path
+from uuid import uuid4
+
+MANAGED_BY = "psc-coordinator-relay"
+
+
+@dataclass(frozen=True)
+class HookReconcileResult:
+    path: Path
+    changed: bool
+    migrated_events: tuple[str, ...] = field(default_factory=tuple)
+    detail: str = ""
+
+
+def _codex_hooks_manifest_path() -> Path:
+    return Path(str(resources.files("paulsha_cortex") / "scripts" / "hooks" / "codex.json"))
+
+
+def _load_canonical_commands(manifest_path: Path) -> dict[str, str]:
+    """回傳 {event: canonical command}，例如 {"Stop": "PSC_RELAY_EVENT=stop cortex relay-hook"}。"""
+    doc = json.loads(manifest_path.read_text(encoding="utf-8"))
+    commands: dict[str, str] = {}
+    for event, groups in doc.get("hooks", {}).items():
+        for group in groups:
+            for hook in group.get("hooks", []):
+                if hook.get("managedBy") == MANAGED_BY and "command" in hook:
+                    commands[event] = hook["command"]
+    return commands
+
+
+def default_codex_hooks_path(home: Path | None = None) -> Path:
+    base = home if home is not None else Path.home()
+    return base / ".codex" / "hooks.json"
+
+
+def _atomic_write_text(target: Path, text: str) -> None:
+    target.parent.mkdir(parents=True, exist_ok=True)
+    temp_path = target.parent / f".{target.name}.{uuid4().hex}.tmp"
+    try:
+        temp_path.write_text(text, encoding="utf-8")
+        os.replace(temp_path, target)
+    finally:
+        temp_path.unlink(missing_ok=True)
+
+
+def reconcile_codex_hooks(
+    hooks_path: Path | None = None,
+    *,
+    manifest_path: Path | None = None,
+) -> HookReconcileResult:
+    """就地改寫 `hooks_path` 中屬於 `psc-coordinator-relay` 的 legacy entries。
+
+    - 檔案不存在：no-op（fresh install 走既有 template 佈署路徑，不在此函式範圍）。
+    - 非 managedBy=psc-coordinator-relay 的 entries：不動。
+    - 已是 canonical command 的 entries：不動（idempotent，changed=False）。
+    - 寫回前先備份原檔到 `<path>.bak-<hex>`，並以 atomic replace 落檔。
+    """
+    target = hooks_path if hooks_path is not None else default_codex_hooks_path()
+    manifest = manifest_path if manifest_path is not None else _codex_hooks_manifest_path()
+
+    if not target.is_file():
+        return HookReconcileResult(path=target, changed=False, detail="hooks 設定不存在，略過")
+
+    try:
+        raw_text = target.read_text(encoding="utf-8")
+        doc = json.loads(raw_text)
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        return HookReconcileResult(
+            path=target, changed=False, detail=f"hooks 設定無法解析，略過：{exc}"
+        )
+
+    if not isinstance(doc, dict) or not isinstance(doc.get("hooks"), dict):
+        return HookReconcileResult(
+            path=target, changed=False, detail="hooks 設定結構不符預期，略過"
+        )
+
+    canonical_commands = _load_canonical_commands(manifest)
+
+    migrated_events: list[str] = []
+    for event, canonical_command in canonical_commands.items():
+        groups = doc["hooks"].get(event)
+        if not isinstance(groups, list):
+            continue
+        for group in groups:
+            if not isinstance(group, dict):
+                continue
+            hooks = group.get("hooks")
+            if not isinstance(hooks, list):
+                continue
+            for hook in hooks:
+                if not isinstance(hook, dict):
+                    continue
+                if hook.get("managedBy") != MANAGED_BY:
+                    continue
+                if hook.get("command") == canonical_command:
+                    continue
+                hook["command"] = canonical_command
+                if event not in migrated_events:
+                    migrated_events.append(event)
+
+    if not migrated_events:
+        return HookReconcileResult(path=target, changed=False, detail="已是 canonical，無需遷移")
+
+    backup_path = target.parent / f"{target.name}.bak-{uuid4().hex}"
+    backup_path.write_text(raw_text, encoding="utf-8")
+
+    new_text = json.dumps(doc, ensure_ascii=False, indent=2) + "\n"
+    _atomic_write_text(target, new_text)
+
+    return HookReconcileResult(
+        path=target,
+        changed=True,
+        migrated_events=tuple(migrated_events),
+        detail=f"遷移 {', '.join(migrated_events)} 至 cortex relay-hook；備份於 {backup_path}",
+    )

--- a/paulsha_cortex/deploy/hooks.py
+++ b/paulsha_cortex/deploy/hooks.py
@@ -71,6 +71,10 @@ def reconcile_codex_hooks(
     - 非 managedBy=psc-coordinator-relay 的 entries：不動。
     - 已是 canonical command 的 entries：不動（idempotent，changed=False）。
     - 寫回前先備份原檔到 `<path>.bak-<hex>`，並以 atomic replace 落檔。
+    - 全程 fail-open：live hooks.json 無法解析/結構不符，或套件內建 manifest
+      本身損壞讀不出來，一律回傳 `changed=False` 並附上可辨識原因的 detail，
+      不拋例外——這是 `cortex install service` 的附帶步驟，不該讓主要安裝
+      流程整體失敗。
     """
     target = hooks_path if hooks_path is not None else default_codex_hooks_path()
     manifest = manifest_path if manifest_path is not None else _codex_hooks_manifest_path()
@@ -91,7 +95,17 @@ def reconcile_codex_hooks(
             path=target, changed=False, detail="hooks 設定結構不符預期，略過"
         )
 
-    canonical_commands = _load_canonical_commands(manifest)
+    try:
+        canonical_commands = _load_canonical_commands(manifest)
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError, AttributeError, TypeError) as exc:
+        return HookReconcileResult(
+            path=target,
+            changed=False,
+            detail=(
+                f"套件內建 hooks manifest（{manifest}）無法讀取或解析，略過遷移；"
+                f"這通常代表套件安裝損壞而非 hooks 設定本身的問題：{exc}"
+            ),
+        )
 
     migrated_events: list[str] = []
     for event, canonical_command in canonical_commands.items():

--- a/paulsha_cortex/deploy/installer.py
+++ b/paulsha_cortex/deploy/installer.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from typing import Sequence
 
 from paulsha_cortex.config import paths
+from paulsha_cortex.deploy import hooks as hook_reconcile
 
 _INSTANCE_RE = re.compile(r"[a-z0-9][a-z0-9-]*")
 _SUPPORTED_EXECUTORS = frozenset({"copilot", "claude", "codex"})
@@ -259,13 +260,18 @@ def install_service_result(instance: str, interval: int, repo_root: Path) -> Ins
             }
         ),
     )
+    hook_reconcile_result = hook_reconcile.reconcile_codex_hooks(
+        hook_reconcile.default_codex_hooks_path(home)
+    )
+    hook_note = f"codex hooks reconcile: {hook_reconcile_result.detail}"
     if not _systemctl_available():
         return InstallServiceResult(
             exit_code=0,
             mode="fallback",
             message=(
                 f"systemd 不可用：單元已落檔 {unit_dir}，請改用 service-manager.sh 前景模式；"
-                "fallback 缺少 `cortex service logs --follow` 即時串流。"
+                "fallback 缺少 `cortex service logs --follow` 即時串流。\n"
+                f"{hook_note}"
             ),
         )
     for stage, args in (
@@ -284,7 +290,10 @@ def install_service_result(instance: str, interval: int, repo_root: Path) -> Ins
     return InstallServiceResult(
         exit_code=0,
         mode="systemd",
-        message=f"installed: {instance}-manager.{{service,timer}} + {instance}-monitor.service",
+        message=(
+            f"installed: {instance}-manager.{{service,timer}} + {instance}-monitor.service\n"
+            f"{hook_note}"
+        ),
     )
 
 

--- a/paulsha_cortex/deploy/installer.py
+++ b/paulsha_cortex/deploy/installer.py
@@ -73,21 +73,27 @@ def _systemctl_install_failure(
     result: subprocess.CompletedProcess[str],
     unit_dir: Path,
     retry_argv: Sequence[str],
+    hook_note: str | None = None,
 ) -> InstallServiceResult:
     stderr_message = (result.stderr or "systemctl 指令失敗").strip()
     if not stderr_message:
         stderr_message = "未回報錯誤訊息"
     retry_command = " ".join(("systemctl", "--user", *retry_argv))
     exit_code = result.returncode if result.returncode > 0 else 1
+    message = (
+        f"systemctl {stage} 失敗：{stderr_message}\n"
+        f"unit 已落檔於 {unit_dir}，僅 systemd reload/enable 未完成。\n"
+        f"unit dir: {unit_dir}\n"
+        f"retry: {retry_command}"
+    )
+    if hook_note:
+        # reconcile 發生在本 for loop 之前；即使 systemctl 這一步失敗，
+        # hook 檔案／備份的副作用已經產生，必須一併回報給 operator。
+        message = f"{message}\n{hook_note}"
     return InstallServiceResult(
         exit_code=exit_code,
         mode="systemd",
-        message=(
-            f"systemctl {stage} 失敗：{stderr_message}\n"
-            f"unit 已落檔於 {unit_dir}，僅 systemd reload/enable 未完成。\n"
-            f"unit dir: {unit_dir}\n"
-            f"retry: {retry_command}"
-        ),
+        message=message,
     )
 
 
@@ -286,6 +292,7 @@ def install_service_result(instance: str, interval: int, repo_root: Path) -> Ins
                 result=result,
                 unit_dir=unit_dir,
                 retry_argv=list(args),
+                hook_note=hook_note,
             )
     return InstallServiceResult(
         exit_code=0,

--- a/tests/test_hook_reconcile.py
+++ b/tests/test_hook_reconcile.py
@@ -142,6 +142,37 @@ class HookReconcileTests(unittest.TestCase):
         home = Path("/tmp/fake-home")
         self.assertEqual(hooks_mod.default_codex_hooks_path(home), home / ".codex" / "hooks.json")
 
+    def test_missing_packaged_manifest_is_fail_open_noop(self) -> None:
+        """套件內建 manifest 損壞/缺失，不得讓 reconcile 拋例外炸穿 install。"""
+        with tempfile.TemporaryDirectory() as d:
+            target = Path(d) / "hooks.json"
+            target.write_text(json.dumps(_legacy_doc()), encoding="utf-8")
+            missing_manifest = Path(d) / "does-not-exist.json"
+
+            result = hooks_mod.reconcile_codex_hooks(target, manifest_path=missing_manifest)
+
+            self.assertFalse(result.changed)
+            self.assertIn("manifest", result.detail)
+            # live hooks.json 完全未被觸碰
+            doc = json.loads(target.read_text(encoding="utf-8"))
+            managed_stop = next(
+                h for h in doc["hooks"]["Stop"][0]["hooks"]
+                if h["managedBy"] == "psc-coordinator-relay"
+            )
+            self.assertEqual(managed_stop["command"], LEGACY_STOP_COMMAND)
+
+    def test_corrupt_packaged_manifest_is_fail_open_noop(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            target = Path(d) / "hooks.json"
+            target.write_text(json.dumps(_legacy_doc()), encoding="utf-8")
+            corrupt_manifest = Path(d) / "codex.json"
+            corrupt_manifest.write_text("{not valid json", encoding="utf-8")
+
+            result = hooks_mod.reconcile_codex_hooks(target, manifest_path=corrupt_manifest)
+
+            self.assertFalse(result.changed)
+            self.assertIn("manifest", result.detail)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_hook_reconcile.py
+++ b/tests/test_hook_reconcile.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from paulsha_cortex.deploy import hooks as hooks_mod
+
+LEGACY_STOP_COMMAND = (
+    "PSC_RELAY_EVENT=stop $HOME/prj_pri/paulshaclaw/scripts/coordinator/psc-relay-hook.sh"
+)
+LEGACY_SESSION_START_COMMAND = (
+    "PSC_RELAY_EVENT=session_start "
+    "$HOME/prj_pri/paulshaclaw/scripts/coordinator/psc-relay-hook.sh"
+)
+CANONICAL_STOP_COMMAND = "PSC_RELAY_EVENT=stop cortex relay-hook"
+CANONICAL_SESSION_START_COMMAND = "PSC_RELAY_EVENT=session_start cortex relay-hook"
+
+
+def _legacy_doc() -> dict:
+    return {
+        "hooks": {
+            "SessionStart": [
+                {
+                    "matcher": "startup|clear|compact",
+                    "hooks": [
+                        {
+                            "command": LEGACY_SESSION_START_COMMAND,
+                            "type": "command",
+                            "managedBy": "psc-coordinator-relay",
+                        }
+                    ],
+                }
+            ],
+            "Stop": [
+                {
+                    "matcher": ".*",
+                    "hooks": [
+                        {
+                            "command": "PSC_RELAY_EVENT=stop /some/other/psc-bro-return.sh",
+                            "type": "command",
+                            "managedBy": "psc-bro-return",
+                        },
+                        {
+                            "command": LEGACY_STOP_COMMAND,
+                            "type": "command",
+                            "managedBy": "psc-coordinator-relay",
+                        },
+                    ],
+                }
+            ],
+        }
+    }
+
+
+class HookReconcileTests(unittest.TestCase):
+    def test_migrates_legacy_managed_entries_to_canonical_command(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            target = Path(d) / "hooks.json"
+            target.write_text(json.dumps(_legacy_doc()), encoding="utf-8")
+
+            result = hooks_mod.reconcile_codex_hooks(target)
+
+            self.assertTrue(result.changed)
+            self.assertEqual(set(result.migrated_events), {"SessionStart", "Stop"})
+
+            doc = json.loads(target.read_text(encoding="utf-8"))
+            stop_hooks = doc["hooks"]["Stop"][0]["hooks"]
+            session_hooks = doc["hooks"]["SessionStart"][0]["hooks"]
+            self.assertEqual(session_hooks[0]["command"], CANONICAL_SESSION_START_COMMAND)
+            managed_stop = next(h for h in stop_hooks if h["managedBy"] == "psc-coordinator-relay")
+            self.assertEqual(managed_stop["command"], CANONICAL_STOP_COMMAND)
+
+    def test_preserves_unrelated_owner_hooks(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            target = Path(d) / "hooks.json"
+            target.write_text(json.dumps(_legacy_doc()), encoding="utf-8")
+
+            hooks_mod.reconcile_codex_hooks(target)
+
+            doc = json.loads(target.read_text(encoding="utf-8"))
+            stop_hooks = doc["hooks"]["Stop"][0]["hooks"]
+            other = next(h for h in stop_hooks if h["managedBy"] == "psc-bro-return")
+            self.assertEqual(other["command"], "PSC_RELAY_EVENT=stop /some/other/psc-bro-return.sh")
+
+    def test_no_legacy_path_remains_after_reconcile(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            target = Path(d) / "hooks.json"
+            target.write_text(json.dumps(_legacy_doc()), encoding="utf-8")
+
+            hooks_mod.reconcile_codex_hooks(target)
+
+            text = target.read_text(encoding="utf-8")
+            self.assertNotIn("psc-relay-hook.sh", text.replace("cortex relay-hook", ""))
+            # 更直接：確認舊絕對路徑片段完全消失
+            self.assertNotIn("paulshaclaw/scripts/coordinator/psc-relay-hook.sh", text)
+
+    def test_idempotent_second_run_is_noop(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            target = Path(d) / "hooks.json"
+            target.write_text(json.dumps(_legacy_doc()), encoding="utf-8")
+
+            first = hooks_mod.reconcile_codex_hooks(target)
+            self.assertTrue(first.changed)
+            second = hooks_mod.reconcile_codex_hooks(target)
+            self.assertFalse(second.changed)
+
+    def test_missing_hooks_file_is_noop(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            target = Path(d) / "hooks.json"
+            result = hooks_mod.reconcile_codex_hooks(target)
+            self.assertFalse(result.changed)
+            self.assertFalse(target.exists())
+
+    def test_backup_written_when_migration_happens(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            target = Path(d) / "hooks.json"
+            target.write_text(json.dumps(_legacy_doc()), encoding="utf-8")
+
+            hooks_mod.reconcile_codex_hooks(target)
+
+            backups = list(Path(d).glob("hooks.json.bak-*"))
+            self.assertEqual(len(backups), 1)
+            backup_doc = json.loads(backups[0].read_text(encoding="utf-8"))
+            self.assertEqual(
+                backup_doc["hooks"]["Stop"][0]["hooks"][1]["command"], LEGACY_STOP_COMMAND
+            )
+
+    def test_already_canonical_is_untouched(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            target = Path(d) / "hooks.json"
+            doc = _legacy_doc()
+            doc["hooks"]["Stop"][0]["hooks"][1]["command"] = CANONICAL_STOP_COMMAND
+            doc["hooks"]["SessionStart"][0]["hooks"][0]["command"] = CANONICAL_SESSION_START_COMMAND
+            target.write_text(json.dumps(doc), encoding="utf-8")
+
+            result = hooks_mod.reconcile_codex_hooks(target)
+            self.assertFalse(result.changed)
+
+    def test_default_codex_hooks_path_uses_home(self) -> None:
+        home = Path("/tmp/fake-home")
+        self.assertEqual(hooks_mod.default_codex_hooks_path(home), home / ".codex" / "hooks.json")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_install_service.py
+++ b/tests/test_install_service.py
@@ -1,3 +1,4 @@
+import json
 import subprocess
 import sys
 
@@ -105,6 +106,78 @@ def test_install_preserves_existing_operator_env_lines(tmp_path, monkeypatch):
     assert f"PY={sys.executable}" in env_lines
     assert sum(line.startswith("PY=") for line in env_lines) == 1
     assert f"PSC_REPO_ROOT={repo_root.resolve()}" in env_lines
+
+
+def test_install_reconciles_legacy_codex_relay_hook(tmp_path, monkeypatch):
+    """issue #155：install service 應 reconcile 既存的 legacy Codex hooks.json。"""
+    from paulsha_cortex.deploy import installer
+
+    repo_root = _init_git_repo(tmp_path / "repo")
+    home = tmp_path / "home"
+    codex_hooks = home / ".codex" / "hooks.json"
+    codex_hooks.parent.mkdir(parents=True)
+    codex_hooks.write_text(
+        json.dumps(
+            {
+                "hooks": {
+                    "SessionStart": [
+                        {
+                            "matcher": "startup|clear|compact",
+                            "hooks": [
+                                {
+                                    "command": (
+                                        "PSC_RELAY_EVENT=session_start "
+                                        "$HOME/prj_pri/paulshaclaw/scripts/coordinator/"
+                                        "psc-relay-hook.sh"
+                                    ),
+                                    "type": "command",
+                                    "managedBy": "psc-coordinator-relay",
+                                }
+                            ],
+                        }
+                    ],
+                    "Stop": [
+                        {
+                            "matcher": ".*",
+                            "hooks": [
+                                {
+                                    "command": "PSC_RELAY_EVENT=stop /opt/psc-bro-return.sh",
+                                    "type": "command",
+                                    "managedBy": "psc-bro-return",
+                                },
+                                {
+                                    "command": (
+                                        "PSC_RELAY_EVENT=stop "
+                                        "$HOME/prj_pri/paulshaclaw/scripts/coordinator/"
+                                        "psc-relay-hook.sh"
+                                    ),
+                                    "type": "command",
+                                    "managedBy": "psc-coordinator-relay",
+                                },
+                            ],
+                        }
+                    ],
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(installer, "_systemctl_available", lambda: False)
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.chdir(repo_root)
+
+    assert installer.main(["service", "--instance", "beta"]) == 0
+
+    doc = json.loads(codex_hooks.read_text(encoding="utf-8"))
+    stop_hooks = doc["hooks"]["Stop"][0]["hooks"]
+    session_hooks = doc["hooks"]["SessionStart"][0]["hooks"]
+    assert session_hooks[0]["command"] == "PSC_RELAY_EVENT=session_start cortex relay-hook"
+    managed_stop = next(h for h in stop_hooks if h["managedBy"] == "psc-coordinator-relay")
+    assert managed_stop["command"] == "PSC_RELAY_EVENT=stop cortex relay-hook"
+    other_stop = next(h for h in stop_hooks if h["managedBy"] == "psc-bro-return")
+    assert other_stop["command"] == "PSC_RELAY_EVENT=stop /opt/psc-bro-return.sh"
+    assert list(codex_hooks.parent.glob("hooks.json.bak-*"))
 
 
 def test_install_derives_runtime_defaults_from_agents_root_but_keeps_bootstrap_env_location(

--- a/tests/test_install_service.py
+++ b/tests/test_install_service.py
@@ -369,3 +369,62 @@ def test_install_service_and_install_reports_systemctl_step_error(
     assert "CompletedProcess" not in fake_result.message
     assert "Traceback" not in fake_result.message
     assert calls == expected_commands[: failure_index + 1]
+
+
+def test_systemctl_failure_still_reports_hook_migration_that_already_happened(
+    tmp_path, monkeypatch
+):
+    """reconcile 跑在 systemctl for loop 之前；就算 systemctl 失敗，已發生的
+    hook 遷移／備份副作用也必須出現在回報訊息中，不能悄悄消失。"""
+    from paulsha_cortex.deploy import installer
+
+    home = tmp_path / "home"
+    codex_hooks = home / ".codex" / "hooks.json"
+    codex_hooks.parent.mkdir(parents=True)
+    codex_hooks.write_text(
+        json.dumps(
+            {
+                "hooks": {
+                    "Stop": [
+                        {
+                            "matcher": ".*",
+                            "hooks": [
+                                {
+                                    "command": (
+                                        "PSC_RELAY_EVENT=stop "
+                                        "$HOME/prj_pri/paulshaclaw/scripts/coordinator/"
+                                        "psc-relay-hook.sh"
+                                    ),
+                                    "type": "command",
+                                    "managedBy": "psc-coordinator-relay",
+                                }
+                            ],
+                        }
+                    ]
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    def fake_run(argv, *args, **kwargs):
+        if argv == ["systemctl", "--user", "daemon-reload"]:
+            return subprocess.CompletedProcess(argv, 7, stdout="", stderr="boom")
+        return subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(installer.subprocess, "run", fake_run)
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setattr(installer, "_systemctl_available", lambda: True)
+
+    result = installer.install_service_result("beta", 120, tmp_path / "repo")
+
+    assert result.mode == "systemd"
+    assert result.exit_code == 7
+    assert "codex hooks reconcile" in result.message
+    assert "cortex relay-hook" in result.message
+
+    # 副作用確實已發生：live 檔案被改寫、備份確實落檔。
+    doc = json.loads(codex_hooks.read_text(encoding="utf-8"))
+    managed = doc["hooks"]["Stop"][0]["hooks"][0]
+    assert managed["command"] == "PSC_RELAY_EVENT=stop cortex relay-hook"
+    assert list(codex_hooks.parent.glob("hooks.json.bak-*"))


### PR DESCRIPTION
## 摘要

- 升級後 `$HOME/.codex/hooks.json` 仍保留舊版 `psc-relay-hook.sh` 絕對路徑（該檔案已隨舊 repo 佈局消失），導致 Codex Stop hook 回報 `exit 127`。
- 新增 `paulsha_cortex.deploy.hooks.reconcile_codex_hooks()`，在 `cortex install service` 流程中 idempotent 改寫 `managedBy: psc-coordinator-relay` 的 legacy entry 為 canonical 的 `PSC_RELAY_EVENT=<event> cortex relay-hook`。
- 改寫前自動備份原檔（`hooks.json.bak-<hex>`），只動 Cortex 自管的 entries，其餘 owner（`paulsha-memory`、`psc-bro-return` 等）與已是 canonical 的設定維持不變；`hooks.json` 不存在或內容非預期結構時 no-op（fail-open，不阻斷 install）。

## 測試計畫

- [x] `tests/test_hook_reconcile.py`（新增，8 case：遷移、保留其他 owner、legacy path 完全消失、idempotent 二次執行、檔案不存在 no-op、備份落檔、已是 canonical 不動、預設路徑推導）
- [x] `tests/test_install_service.py`（新增 `test_install_reconciles_legacy_codex_relay_hook`，驗證 `cortex install service` 端到端 reconcile 一份含多 owner 的 legacy hooks.json）
- [x] `python3 -m pytest tests/ -x -q` — 1618 passed, 32 subtests passed
- [x] `python3 -m policy_check --repo .` — fail: 0（R-22 為既有 24 筆陳年 warn，本次未新增）

Closes #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MBuP74pQJyBBcX17DDxBAo