### PR TITLE
fix(coordinator): workflow phase job 收工不再誤走 slice lane gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ## [Unreleased]
 ### Fixed
+- **Issue #264：workflow phase job 收工不再誤走 slice lane gate**：`paulsha_cortex/coordinator/manager.py` 的 completion sweep 新增 `_is_workflow_lane_job()`（以 job 的 `workflow_run_id` 是否存在機械判定 lane 歸屬），completion sweep 對帶 `workflow_run_id` 的 job（workflow lane 的 phase job，本就不註冊進 `slices` 表）不再查 `slices` 表、不再產出 `needs_human`/`missing-slice-proof`，改寫入新的 `gate_status="workflow-tracked"`／`gate_reason="workflow-lane-job"`（job 失敗則 `gate_status="failed"`，`gate_reason` 仍為 `workflow-lane-job`，與 slice lane 的 `missing-slice-proof` 機械區分）；`missing-slice-proof` 保留給真正屬於 slice lane、但 slice 關聯缺失的情形，新增 regression test 釘死其 fail-closed 行為未被放寬。修正前受影響的 30 份誤判 manifest（`~/.agents/coordinator/handoff/*.json`，`gate_reason=missing-slice-proof` 且 `slice_id` 為 `wf-<hash>-<phase>` 形式）皆為歷史殘留、其對應 workflow 早已交付合併，建議標記為歷史誤判並保留供稽核（下次 completion sweep 對相同 job_id 為冪等 skip、不會自動覆寫；如需清理由使用者自行對 runtime state 執行 retention 操作，不在本次程式修改範圍內）。
 - **Issue #254：legacy monitor config 警告去重**：在
   `paulsha_cortex.monitor.config._resolve_config_source` 中加入單一 process 內 per-key
   去重機制，保留既有 legacy 警告文案與設定解析順序，避免 legacy env 與 legacy

--- a/changelog.d/workflow-lane-gate.md
+++ b/changelog.d/workflow-lane-gate.md
@@ -1,0 +1,7 @@
+### Fixed
+- **Issue #264：workflow phase job 收工不再誤走 slice lane gate**：completion sweep 新增
+  `_is_workflow_lane_job()`，以 `workflow_run_id` 機械判定 lane 歸屬；帶 `workflow_run_id`
+  的 phase job（本就不註冊進 `slices` 表）不再被查 `slices` 表、不再誤判為
+  `needs_human`/`missing-slice-proof`，改記 `gate_status="workflow-tracked"`／
+  `gate_reason="workflow-lane-job"`。`missing-slice-proof` 保留給真正屬於 slice lane 但
+  關聯缺失的情形，並以 regression test 釘死其 fail-closed 行為未被放寬。

--- a/paulsha_cortex/coordinator/manager.py
+++ b/paulsha_cortex/coordinator/manager.py
@@ -55,6 +55,15 @@ from .workflow import (
 
 IN_FLIGHT_STATUSES = frozenset({"dispatched", "running"})
 TERMINAL_STATUSES = frozenset({"exited", "failed"})
+
+# workflow lane 的 phase job（issue #264）terminal manifest 語意：不查 slices
+# 表，gate 依據就是 job 自身的 exit 結果——phase 的實際推進/gate 判定由
+# workflow registry（_dispatch_workflow_card 重掃 list_jobs()）負責，跟這裡
+# 寫的 handoff manifest 無關（manifest 只供 operator 視野／cockpit 展示用）。
+# 用獨立的 gate_status/gate_reason，機械區分於 slice lane 的
+# needs_human/missing-slice-proof，不得誤觸 needs_human 佇列。
+WORKFLOW_LANE_GATE_STATUS = "workflow-tracked"
+WORKFLOW_LANE_GATE_REASON = "workflow-lane-job"
 VERIFICATION_RESULT_STATES = frozenset({"needs_human", "reviewing", "verified"})
 SLICE_ACTIONS = frozenset({"retry-build", "retry-verify", "retry-review", "abandon"})
 WORKFLOW_REPORT_MAX_BYTES = 128 * 1024
@@ -132,6 +141,17 @@ def _existing_manifest_job_id(path: Path) -> str | None:
         return None
     job_id = payload.get("job_id")
     return job_id if isinstance(job_id, str) else None
+
+
+def _is_workflow_lane_job(job: dict) -> bool:
+    """job 屬於 workflow lane 的判定（issue #264）。
+
+    registry.create_job() 只有透過 workflow 派工路徑（_job_for_workflow_card /
+    dispatch_workflow_card）才會帶 workflow_run_id；slice lane 的 job（經
+    autonomy.dispatch_ready 派工）恆為 None。以此欄位機械區分兩條 lane，
+    而不是靠查不到 slices 表就一律當成 slice lane 缺 proof。
+    """
+    return job.get("workflow_run_id") is not None
 
 
 def _slice_for_job(registry, slice_id: str, job_id: str) -> dict | None:
@@ -1457,8 +1477,12 @@ def complete_tick(
                 except Exception:
                     identity_registry = None
                 if slice_row is None:
-                    gate_status = "needs_human"
-                    gate_reason = "missing-slice-proof"
+                    if _is_workflow_lane_job(job):
+                        gate_status = "failed" if status == "failed" else WORKFLOW_LANE_GATE_STATUS
+                        gate_reason = WORKFLOW_LANE_GATE_REASON
+                    else:
+                        gate_status = "needs_human"
+                        gate_reason = "missing-slice-proof"
                 elif slice_row.get("state") in {"verified", "completed"} and slice_row.get("gate_state") == "passed":
                     review_path, review_hash, review_payload = _current_review_ref(slice_row)
                     if review_payload is not None:
@@ -1509,6 +1533,12 @@ def complete_tick(
                             registry.update_slice(slice_id, state="failed", gate_state="failed")
                         except Exception:
                             pass
+                elif slice_row is None and _is_workflow_lane_job(job):
+                    # workflow lane 的 build phase job 到這裡必為 status == "exited"
+                    # （failed 已在上面 `elif status == "failed":` 分支處理掉），不查
+                    # slices 表、不當成缺 slice proof。
+                    gate_status = WORKFLOW_LANE_GATE_STATUS
+                    gate_reason = WORKFLOW_LANE_GATE_REASON
                 elif slice_row is None:
                     evidence = _write_status_evidence(
                         slice_row=None,

--- a/tests/test_coordinator_manager.py
+++ b/tests/test_coordinator_manager.py
@@ -726,6 +726,114 @@ class CompleteTickReconcileTests(unittest.TestCase):
             self.assertEqual(summary["errors"], [])
 
 
+def _make_workflow_job(
+    reg: JobRegistry,
+    slice_id: str,
+    *,
+    kind: str = "build",
+    run_id: str = "wf-abc123",
+    phase: str = "build",
+    card: str = "card-1",
+) -> dict:
+    """workflow lane 的 phase job：帶 workflow_run_id，不註冊進 slices 表（issue #264）。"""
+    return reg.create_job(
+        task=slice_id, persona="builder", branch=f"feature/{slice_id}",
+        pane="", worktree=f"/wt/{slice_id}",
+        executor="copilot", session_name=slice_id, pid=4242,
+        log_path=f"/logs/{slice_id}.jsonl",
+        kind=kind,
+        workflow_run_id=run_id,
+        workflow_claim_key="claim-1",
+        workflow_repo="owner/repo",
+        workflow_card=card,
+        workflow_phase=phase,
+    )
+
+
+class CompleteTickWorkflowLaneGateTests(unittest.TestCase):
+    """issue #264：workflow phase job 收工不得誤走 slice lane 的 missing-slice-proof gate。"""
+
+    def test_workflow_build_phase_job_terminal_is_not_missing_slice_proof(self) -> None:
+        # slices 表無對應列（workflow lane 本就不註冊進 slices）；job 帶 workflow_run_id。
+        with tempfile.TemporaryDirectory() as d:
+            reg = _reg(d)
+            job = _make_workflow_job(reg, "wf-c81b4d82a7-build-1", kind="build")
+            disp = FakeDispatcher(reg, poll_map={job["job_id"]: "exited"})
+            hdir = Path(d) / "handoff"
+
+            summary = manager.complete_tick(disp, handoff_dir=str(hdir), clock=lambda: "T0")
+
+            manifest = json.loads((hdir / "wf-c81b4d82a7-build-1.json").read_text(encoding="utf-8"))
+            self.assertNotEqual(manifest["gate_status"], "needs_human")
+            self.assertNotEqual(manifest["gate_reason"], "missing-slice-proof")
+            self.assertEqual(manifest["gate_status"], manager.WORKFLOW_LANE_GATE_STATUS)
+            self.assertEqual(manifest["gate_reason"], manager.WORKFLOW_LANE_GATE_REASON)
+            self.assertEqual(
+                summary["completed"],
+                [{"slice_id": "wf-c81b4d82a7-build-1", "gate_status": manager.WORKFLOW_LANE_GATE_STATUS}],
+            )
+            self.assertEqual(summary["errors"], [])
+
+    def test_workflow_review_phase_job_terminal_is_not_missing_slice_proof(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            reg = _reg(d)
+            job = _make_workflow_job(
+                reg, "wf-c81b4d82a7-adversarial-review-1", kind="review", phase="adversarial-review",
+            )
+            disp = FakeDispatcher(reg, poll_map={job["job_id"]: "exited"})
+            hdir = Path(d) / "handoff"
+
+            manager.complete_tick(disp, handoff_dir=str(hdir), clock=lambda: "T0")
+
+            manifest = json.loads(
+                (hdir / "wf-c81b4d82a7-adversarial-review-1.json").read_text(encoding="utf-8")
+            )
+            self.assertNotEqual(manifest["gate_status"], "needs_human")
+            self.assertNotEqual(manifest["gate_reason"], "missing-slice-proof")
+            self.assertEqual(manifest["gate_status"], manager.WORKFLOW_LANE_GATE_STATUS)
+            self.assertEqual(manifest["gate_reason"], manager.WORKFLOW_LANE_GATE_REASON)
+
+    def test_workflow_review_phase_job_failed_is_failed_not_missing_slice_proof(self) -> None:
+        # workflow lane 的 review kind job 失敗時：fail closed 為 failed，不是 needs_human/
+        # missing-slice-proof（那是 slice lane 的語意，這裡是模型錯配就不該套用）。
+        with tempfile.TemporaryDirectory() as d:
+            reg = _reg(d)
+            job = _make_workflow_job(
+                reg, "wf-c81b4d82a7-adversarial-review-2", kind="review", phase="adversarial-review",
+            )
+            disp = FakeDispatcher(reg, poll_map={job["job_id"]: "failed"})
+            hdir = Path(d) / "handoff"
+
+            manager.complete_tick(disp, handoff_dir=str(hdir), clock=lambda: "T0")
+
+            manifest = json.loads(
+                (hdir / "wf-c81b4d82a7-adversarial-review-2.json").read_text(encoding="utf-8")
+            )
+            self.assertEqual(manifest["gate_status"], "failed")
+            self.assertNotEqual(manifest["gate_reason"], "missing-slice-proof")
+            self.assertEqual(manifest["gate_reason"], manager.WORKFLOW_LANE_GATE_REASON)
+
+    def test_slice_lane_job_missing_pinned_verification_contract_still_fails_closed(self) -> None:
+        # regression pin：不得因本次修改而放寬 slice lane 的 fail-closed 行為——
+        # 沒有 workflow_run_id、也沒有註冊進 slices 表的 job，仍必須是
+        # needs_human/missing-slice-proof（issue #264 驗收條件：不可放寬既有語意）。
+        with tempfile.TemporaryDirectory() as d:
+            reg = _reg(d)
+            job = _make_job(reg, "slice-missing-proof")
+            disp = FakeDispatcher(reg, poll_map={job["job_id"]: "exited"})
+            hdir = Path(d) / "handoff"
+
+            summary = manager.complete_tick(disp, handoff_dir=str(hdir), clock=lambda: "T0")
+
+            manifest = json.loads((hdir / "slice-missing-proof.json").read_text(encoding="utf-8"))
+            self.assertEqual(manifest["gate_status"], "needs_human")
+            self.assertEqual(manifest["gate_reason"], "missing-slice-proof")
+            self.assertEqual(
+                summary["completed"],
+                [{"slice_id": "slice-missing-proof", "gate_status": "needs_human"}],
+            )
+
+
 class CompleteTickVerificationTests(unittest.TestCase):
     def test_verification_runner_exception_marks_needs_human(self) -> None:
         with tempfile.TemporaryDirectory() as d:


### PR DESCRIPTION
## 背景

`paulsha_cortex/coordinator/manager.py` 的 completion sweep 對 `slice_row is None` 一律打 `gate_status=needs_human` / `gate_reason=missing-slice-proof`。但 workflow lane 的 phase job（識別欄位為 `workflow_run_id` / `workflow_phase` / `workflow_card`）本就不會註冊進 registry 的 `slices` 表，導致 `_slice_for_job()` / `_slice_for_reviewer_job()` 必然 miss，把已交付成功（`exit_code=0`）的 workflow phase job 一律誤判為待人工裁決。實測環境下 33 份 terminal manifest 中有 30 份因此被錯誤標成 `needs_human`。

## 修法

- 新增 `_is_workflow_lane_job(job)`：以 job 是否帶 `workflow_run_id`（只有透過 workflow 派工路徑才會設定）機械判定 lane 歸屬，不靠「查不到 slices 表」這個間接訊號。
- completion sweep 的 build kind 與 review kind 兩處 `slice_row is None` 分支都新增 workflow lane 判斷：
  - workflow lane 的 job 成功（`exited`）→ `gate_status="workflow-tracked"`、`gate_reason="workflow-lane-job"`。
  - workflow lane 的 review kind job 失敗（`failed`）→ `gate_status="failed"`、`gate_reason="workflow-lane-job"`（build kind 失敗已由既有 `builder-failed` 分支處理，不受影響）。
  - 非 workflow lane（即 slice lane）維持原行為：`needs_human` / `missing-slice-proof`。
- workflow phase job 的實際 phase 推進/gate 判定本就由 `_dispatch_workflow_card` 重新掃描 `registry.list_jobs()` 決定，不依賴這裡寫的 handoff manifest；這裡新增的 `gate_status`/`gate_reason` 純粹是 operator 視野（cockpit JOBS 面板等下游消費者）用的誠實標記，不影響既有 workflow 推進邏輯。

## 測試（TDD：RED → GREEN）

新增 `CompleteTickWorkflowLaneGateTests`（`tests/test_coordinator_manager.py`）：
- `test_workflow_build_phase_job_terminal_is_not_missing_slice_proof`：workflow build phase job（slices 表無列）terminal 收工，驗證不是 `needs_human`/`missing-slice-proof`。
- `test_workflow_review_phase_job_terminal_is_not_missing_slice_proof`：同上，review kind。
- `test_workflow_review_phase_job_failed_is_failed_not_missing_slice_proof`：workflow review phase job 失敗時是 `failed`，不是 `needs_human`/`missing-slice-proof`。
- `test_slice_lane_job_missing_pinned_verification_contract_still_fails_closed`：**regression pin**——沒有 `workflow_run_id` 的 job 仍必須 fail closed 為 `needs_human`/`missing-slice-proof`，不因本次修改而放寬 slice lane 的既有行為。

修改前（`git stash push -- paulsha_cortex/coordinator/manager.py` 驗證）：新增的 3 個正向測試皆為 RED（斷言 `needs_human`/`missing-slice-proof` 出現，如預期失敗）；修改後全部 GREEN。

## 驗證結果

- `python3 -m pytest tests/test_coordinator_manager.py -q` → **60 passed**
- `python3 -m pytest tests/ -q`（全套）→ **1613 passed, 32 subtests passed**
- `python3 -m policy_check --repo .` → **fail: 0**（R-22 為既有 24 筆陳年 dangling reference warn，本次未新增）

## 既有 30 份誤判 manifest 的處置建議

`~/.agents/coordinator/handoff/*.json` 中 `gate_reason=missing-slice-proof` 且 `slice_id` 為 `wf-<hash>-<phase>` 形式、`branch` 指向早已合併分支的 30 份，是修法前留下的歷史殘留：

- **不建議自動刪除**：那是使用者 runtime state，不是本次程式修改的一部分，也不在本 PR 範圍內處理。
- **建議標記為歷史誤判、保留供稽核**：這批 manifest 的 `exit_code=0` 已誠實記錄工作本身成功，只有 `gate_status`/`gate_reason` 是錯的診斷結論；直接刪除會抹除稽核軌跡。
- **不會自動被本次修法覆寫**：completion sweep 的冪等檢查（`_existing_manifest_job_id`）是以 `job_id` 是否相同判斷是否 skip，同一批舊 job 若未被重新派工，manifest 會原樣留在磁碟——需要使用者對照 `jobs.json` 的 `workflow_run_id`/`branch` 手動核對後決定是否用 handoff retention 工具（#265 範圍）批次歸檔或標記。
- 未來新產生的 workflow phase job 收工不會再誤走此 gate，問題不會再擴大。

Closes #264

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MBuP74pQJyBBcX17DDxBAo