### PR TITLE
fix(manager): recent_done 補投影 gate_reason/job_id/branch 並加入 recency window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@
 
 ## [Unreleased]
 ### Fixed
+- **Issue #230／#265：`recent_done` 補投影欄位並加入 recency window**：`manager_daemon.py` 的
+  `recent_done_provider()`（`build_runtime_status_provider()` 內）除既有 `slice_id`／`gate_status`／
+  `at` 外，多投影 handoff manifest 既有的 `gate_reason`／`job_id`／`branch`（manifest 缺欄位時為
+  `null`，不拋錯），讓 `needs_human` 條目在 consumer 端（paulshaclaw cockpit）不再只顯示「待裁決 ·
+  原因未知」（#230）；範圍不含 `next_actions`——它是 `manager.slice_status_entry()` 算出來的衍生欄位，
+  不在 manifest 欄位集合裡，不屬本次修法範圍。同時新增可設定的 recency window（新常數
+  `RECENT_DONE_WINDOW_SECONDS`，預設 86400 秒／24 小時，可用 CLI `--recent-done-window-seconds`
+  或環境變數 `PSC_MANAGER_RECENT_DONE_WINDOW_SECONDS` 覆寫），過期 manifest 不再進入 `recent_done`；
+  window 內無資料時回空陣列，不回退撈更舊的紀錄（#265）。handoff manifest 檔案本身的
+  retention／prune 途徑不在本次範圍內，屬 #178 program teardown GC 負責。
 - **Issue #254：legacy monitor config 警告去重**：在
   `paulsha_cortex.monitor.config._resolve_config_source` 中加入單一 process 內 per-key
   去重機制，保留既有 legacy 警告文案與設定解析順序，避免 legacy env 與 legacy

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ cortex bootstrap --instance cortex --repo-root "$(git rev-parse --show-toplevel)
    ```dotenv
    PSC_MANAGER_EXECUTOR=codex
    PSC_MANAGER_INTERVAL_SECONDS=300
+   PSC_MANAGER_RECENT_DONE_WINDOW_SECONDS=86400
    ```
 
 3. 使用 Deck 先 dry-run，再 emit `dispatch: hold` specs：
@@ -310,7 +311,7 @@ systemctl --user status cortex-manager.service cortex-monitor.service
 - `in_flight`：正在執行的 Job。
 - `slices`：交付生命週期、gate、Candidate 與 evidence 摘要。
 - `attention`：全部 `needs_human` 項目，包含 reason 與當下合法的 `next_actions`。
-- `recent_done`：最近完成或進入 terminal gate 的 slice 摘要。
+- `recent_done`：最近完成或進入 terminal gate 的 slice 摘要，含 `slice_id`、`gate_status`、`at`、`gate_reason`、`job_id`、`branch`（manifest 缺該欄時為 `null`）。只回溯 `--recent-done-window-seconds`（預設 86400 秒／24 小時，可用 `PSC_MANAGER_RECENT_DONE_WINDOW_SECONDS` 覆寫）內完成的 handoff manifest；window 內沒有資料時回空陣列，不會回退撈更舊的紀錄，過期 manifest 檔案本身的清理屬於 #178 program teardown GC 的範圍，不在 `recent_done` provider 職責內。
 
 Job `exited` 只代表 Agent process 以 exit code 0 結束，**不代表任務交付完成**。只有 Slice 通過 deterministic verification、必要的 foreign review，且 Candidate 已進入 target branch 後，才會變成 `completed` 並釋放下游 dependency。
 

--- a/changelog.d/recent-done-surface.md
+++ b/changelog.d/recent-done-surface.md
@@ -1,0 +1,9 @@
+### Fixed
+- **Issue #230／#265：`recent_done` 補投影欄位並加入 recency window**：
+  `recent_done_provider()` 除既有 `slice_id`／`gate_status`／`at` 外，多投影 handoff
+  manifest 已有的 `gate_reason`／`job_id`／`branch`（缺欄位時為 `null`，不拋錯），讓
+  consumer 端的 `needs_human` 條目不再只顯示「待裁決 · 原因未知」（#230）；同時加入
+  可設定的 recency window（`RECENT_DONE_WINDOW_SECONDS`，預設 86400 秒，可經
+  `--recent-done-window-seconds` 或 `PSC_MANAGER_RECENT_DONE_WINDOW_SECONDS` 覆寫），
+  過期 manifest 不再進入 `recent_done`，window 內無資料時回空陣列而不回退撈更舊紀錄
+  （#265）。naive `completed_at` 一律視為 UTC，避免本地時區造成新鮮度誤判。

--- a/paulsha_cortex/coordinator/manager_daemon.py
+++ b/paulsha_cortex/coordinator/manager_daemon.py
@@ -10,6 +10,7 @@ import sys
 import tempfile
 import time
 from dataclasses import dataclass
+from datetime import datetime
 from pathlib import Path
 from typing import Any, Callable
 
@@ -29,6 +30,11 @@ DEFAULT_PERSONA = "builder"
 DEFAULT_EXECUTOR = "copilot"
 DEFAULT_MAX_LOAD = 1.0
 RECENT_DONE_LIMIT = 10
+# issue #265：`recent_done` 需要 recency window 才不會被過期 manifest 永久佔滿名額。
+# 24 小時是「一次 tick 週期 ~5 分鐘」與「operator 至少每天巡一次面板」之間的折衷值：
+# 夠短，不會讓數天前的死屍霸占僅 10 個名額；夠長，跨夜、跨個位數 tick 失敗重試仍在窗內。
+# 可用 PSC_MANAGER_RECENT_DONE_WINDOW_SECONDS 覆寫，見 README「觀察任務狀態」章節。
+RECENT_DONE_WINDOW_SECONDS = 86400.0
 MANAGER_CMD_MARKER = "paulsha_cortex.coordinator.manager_daemon"
 
 # Periodic-tick failure resilience (issue #249): a persistently failing tick
@@ -142,6 +148,30 @@ def default_tick_interval() -> float:
         return DEFAULT_TICK_INTERVAL
 
 
+def default_recent_done_window_seconds() -> float:
+    override = os.environ.get("PSC_MANAGER_RECENT_DONE_WINDOW_SECONDS")
+    if not override:
+        return RECENT_DONE_WINDOW_SECONDS
+    try:
+        return float(override)
+    except ValueError:
+        return RECENT_DONE_WINDOW_SECONDS
+
+
+def _parse_iso8601(value: Any) -> datetime | None:
+    """寬容解析 ISO-8601 時間字串；解析失敗或非字串一律回傳 ``None``。
+
+    ``recent_done`` 的新鮮度判斷必須保守：解析不出時間就無法證明「新鮮」，
+    因此呼叫端會把 ``None`` 當成「排除在 window 之外」處理，而不是預設放行。
+    """
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        return datetime.fromisoformat(value)
+    except ValueError:
+        return None
+
+
 def _tick_backoff_seconds(base_interval: float, consecutive_failures: int) -> float:
     """Exponential backoff interval for the next periodic-tick retry.
 
@@ -225,6 +255,8 @@ def build_runtime_status_provider(
     scan_specs_fn: Callable[[str], list[dict[str, Any]]] = autonomy.scan_specs,
     ready_units_fn: Callable[[list[dict[str, Any]], Callable[[str], bool]], list[dict[str, Any]]] = autonomy.ready_units,
     recent_done_limit: int = RECENT_DONE_LIMIT,
+    recent_done_window_seconds: float | None = RECENT_DONE_WINDOW_SECONDS,
+    now_fn: Callable[[], str] = contract.utcnow,
     git_runner=None,
 ) -> Callable[[], dict[str, Any]]:
     def recent_done_provider() -> list[dict[str, Any]]:
@@ -232,17 +264,33 @@ def build_runtime_status_provider(
         handoff_path = Path(handoff_dir)
         if not handoff_path.is_dir():
             return []
+        cutoff_ts: float | None = None
+        if recent_done_window_seconds is not None:
+            now_dt = _parse_iso8601(now_fn())
+            if now_dt is not None:
+                cutoff_ts = now_dt.timestamp() - recent_done_window_seconds
         for path in handoff_path.glob("*.json"):
             payload = contract.read_json(path)
             if not isinstance(payload, dict):
                 continue
+            completed_at = payload.get("completed_at")
+            if cutoff_ts is not None:
+                # window 內 0 筆時 recent_done 必須是空陣列，不得回退撈更舊的 manifest
+                # （issue #265 驗收條件）；完全解析不出時間的 manifest 一律視為過期排除，
+                # 不能因為「看不出新鮮度」就預設放行。
+                completed_dt = _parse_iso8601(completed_at)
+                if completed_dt is None or completed_dt.timestamp() < cutoff_ts:
+                    continue
             manifests.append(
                 (
-                    str(payload.get("completed_at") or ""),
+                    str(completed_at or ""),
                     {
                         "slice_id": payload.get("slice_id"),
                         "gate_status": payload.get("gate_status"),
-                        "at": payload.get("completed_at"),
+                        "at": completed_at,
+                        "gate_reason": payload.get("gate_reason"),
+                        "job_id": payload.get("job_id"),
+                        "branch": payload.get("branch"),
                     },
                 )
             )
@@ -856,6 +904,7 @@ def run_loop(
     default_review_executor: str | None = None,
     default_review_model: str | None = None,
     reaper: Callable[[], dict[str, Any]] | None = None,
+    recent_done_window_seconds: float | None = RECENT_DONE_WINDOW_SECONDS,
 ) -> bool:
     runtime_pid = os.getpid() if pid is None else pid
     held_lock = acquire_lock(pid=runtime_pid, pid_alive=pid_alive, now_fn=now_fn)
@@ -906,6 +955,8 @@ def run_loop(
         specs_dir=resolved_specs_dir,
         handoff_dir=handoff_dir,
         git_runner=getattr(ensure_dispatcher(), "_git_runner", None),
+        recent_done_window_seconds=recent_done_window_seconds,
+        now_fn=now_fn,
     )
     if periodic_tick_runner is not None:
         periodic_runner = periodic_tick_runner
@@ -1194,6 +1245,15 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--handoff-dir", default=autonomy.DEFAULT_HANDOFF_DIR)
     parser.add_argument("--max-rounds", type=int)
     parser.add_argument("--no-require-idle", action="store_true")
+    parser.add_argument(
+        "--recent-done-window-seconds",
+        type=float,
+        default=default_recent_done_window_seconds(),
+        help=(
+            "status.json 的 recent_done 只回溯這麼多秒內完成的 manifest（issue #265）；"
+            "預設 86400（24 小時），亦可用 PSC_MANAGER_RECENT_DONE_WINDOW_SECONDS 覆寫。"
+        ),
+    )
     args = parser.parse_args(argv)
     _install_signal_handlers()
 
@@ -1208,6 +1268,7 @@ def main(argv: list[str] | None = None) -> int:
         default_model=args.model,
         default_review_executor=args.review_executor,
         default_review_model=args.review_model,
+        recent_done_window_seconds=args.recent_done_window_seconds,
     )
     return 0 if started else 1
 

--- a/paulsha_cortex/coordinator/manager_daemon.py
+++ b/paulsha_cortex/coordinator/manager_daemon.py
@@ -10,7 +10,7 @@ import sys
 import tempfile
 import time
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable
 
@@ -163,13 +163,25 @@ def _parse_iso8601(value: Any) -> datetime | None:
 
     ``recent_done`` 的新鮮度判斷必須保守：解析不出時間就無法證明「新鮮」，
     因此呼叫端會把 ``None`` 當成「排除在 window 之外」處理，而不是預設放行。
+
+    ``recent_done`` 讀的是磁碟上任意來源的 JSON manifest（歷史檔、其他版本
+    寫入的檔、手動放的檔），不能假設一定帶時區。``datetime.fromisoformat``
+    對不帶時區的字串會回傳 naive datetime，而 naive datetime 的
+    ``.timestamp()`` 是用**本機系統時區**解讀、不是 UTC——同一份 manifest
+    在 UTC 與 UTC+8 主機上算出的 timestamp 會差到 8 小時，足以讓一份仍在
+    window 內的 manifest 被誤判過期而剔除（#265 修法後續發現的邊界缺陷）。
+    因此 naive datetime 一律視為 UTC 補上 tzinfo，避免新鮮度判定被執行主機
+    的本地時區污染。
     """
     if not isinstance(value, str) or not value:
         return None
     try:
-        return datetime.fromisoformat(value)
+        parsed = datetime.fromisoformat(value)
     except ValueError:
         return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed
 
 
 def _tick_backoff_seconds(base_interval: float, consecutive_failures: int) -> float:

--- a/tests/test_coordinator_manager_daemon.py
+++ b/tests/test_coordinator_manager_daemon.py
@@ -1268,6 +1268,70 @@ def test_recent_done_provider_window_disabled_when_none(monkeypatch, tmp_path):
     assert [entry["slice_id"] for entry in status["recent_done"]] == ["ancient"]
 
 
+def test_recent_done_provider_treats_naive_completed_at_as_utc(monkeypatch, tmp_path):
+    """naive（無時區）completed_at 必須視為 UTC，不能被執行主機的本地時區污染。
+
+    ``datetime.fromisoformat`` 對 naive 字串回傳 naive datetime，naive
+    datetime 的 ``.timestamp()`` 用本機系統時區解讀。在 UTC+8 主機上，若
+    provider 沒有把 naive 字串正規化成 UTC，一份實際只有 16.5 小時前完成、
+    理應落在 24 小時 window 內的 manifest，會被誤判成 24.5 小時前而剔除
+    ——方向正好與 #265 要修的「過期不留」相反，變成「新鮮的被丟掉」。
+
+    本測試把行程的 TZ 切到 Asia/Taipei（UTC+8）模擬這個環境差異，並比較
+    naive／aware 兩種寫法的同一時刻是否得到一致的新鮮度判定。
+    """
+    monkeypatch.setenv("PSC_CONTROL_ROOT", str(tmp_path))
+    handoff_dir = tmp_path / "handoff"
+    handoff_dir.mkdir()
+    # now = 2026-07-30T02:00:00Z，window = 24h -> cutoff = 2026-07-29T02:00:00Z
+    (handoff_dir / "naive-fresh.json").write_text(
+        json.dumps(
+            {
+                "slice_id": "naive-fresh",
+                "gate_status": "passed",
+                # 無時區字串；正確判定應視為 UTC，距 cutoff 尚有 16.5 小時，應保留
+                "completed_at": "2026-07-29T09:30:00",
+            }
+        ),
+        encoding="utf-8",
+    )
+    (handoff_dir / "aware-fresh.json").write_text(
+        json.dumps(
+            {
+                "slice_id": "aware-fresh",
+                "gate_status": "passed",
+                # 與上者代表同一個 UTC 時刻，帶明確時區
+                "completed_at": "2026-07-29T09:30:00+00:00",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    original_tz = os.environ.get("TZ")
+    monkeypatch.setenv("TZ", "Asia/Taipei")
+    time.tzset()
+    try:
+        provider = manager_daemon.build_runtime_status_provider(
+            registry=FakeRegistry(),
+            specs_dir=str(tmp_path / "specs"),
+            handoff_dir=str(handoff_dir),
+            scan_specs_fn=lambda specs_dir: [],
+            recent_done_window_seconds=86400.0,
+            now_fn=lambda: "2026-07-30T02:00:00+00:00",
+        )
+
+        status = provider()
+    finally:
+        if original_tz is None:
+            os.environ.pop("TZ", None)
+        else:
+            os.environ["TZ"] = original_tz
+        time.tzset()
+
+    slice_ids = {entry["slice_id"] for entry in status["recent_done"]}
+    assert slice_ids == {"naive-fresh", "aware-fresh"}
+
+
 def test_runtime_status_provider_classifies_held_units(monkeypatch, tmp_path):
     monkeypatch.setenv("PSC_CONTROL_ROOT", str(tmp_path))
     handoff_dir = tmp_path / "handoff"

--- a/tests/test_coordinator_manager_daemon.py
+++ b/tests/test_coordinator_manager_daemon.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import inspect
+import json
 import os
 import signal
 import subprocess
@@ -1112,6 +1113,7 @@ def test_runtime_status_provider_lists_recent_done_by_completion_time(monkeypatc
         handoff_dir=str(handoff_dir),
         scan_specs_fn=lambda specs_dir: [{"slice_id": "slice-ready", "dispatch": "auto", "plan": "p.md", "depends_on": []}],
         ready_units_fn=lambda metas, predicate: metas,
+        now_fn=lambda: "2026-07-03T09:10:00+00:00",
     )
 
     status = provider()
@@ -1119,6 +1121,151 @@ def test_runtime_status_provider_lists_recent_done_by_completion_time(monkeypatc
     assert status["ready"] == ["slice-ready"]
     assert status["in_flight"] == [{"job_id": "job-1", "slice_id": "slice-x", "state": "running"}]
     assert [entry["slice_id"] for entry in status["recent_done"]] == ["slice-b", "slice-a"]
+
+
+def test_recent_done_provider_projects_gate_reason_job_id_branch(monkeypatch, tmp_path):
+    """#230：provider 需多投影 gate_reason／job_id／branch，manifest 缺欄位時為 null 不拋錯。"""
+    monkeypatch.setenv("PSC_CONTROL_ROOT", str(tmp_path))
+    handoff_dir = tmp_path / "handoff"
+    handoff_dir.mkdir()
+    (handoff_dir / "slice-full.json").write_text(
+        json.dumps(
+            {
+                "slice_id": "slice-full",
+                "gate_status": "needs_human",
+                "completed_at": "2026-07-03T09:03:00+00:00",
+                "gate_reason": "missing-slice-proof",
+                "job_id": "wf-abc-code-review-1",
+                "branch": "feature/xyz",
+            }
+        ),
+        encoding="utf-8",
+    )
+    (handoff_dir / "slice-sparse.json").write_text(
+        json.dumps(
+            {
+                "slice_id": "slice-sparse",
+                "gate_status": "passed",
+                "completed_at": "2026-07-03T09:01:00+00:00",
+            }
+        ),
+        encoding="utf-8",
+    )
+    provider = manager_daemon.build_runtime_status_provider(
+        registry=FakeRegistry(),
+        specs_dir=str(tmp_path / "specs"),
+        handoff_dir=str(handoff_dir),
+        scan_specs_fn=lambda specs_dir: [],
+        now_fn=lambda: "2026-07-03T09:10:00+00:00",
+    )
+
+    status = provider()
+    entries = {entry["slice_id"]: entry for entry in status["recent_done"]}
+
+    assert entries["slice-full"]["gate_reason"] == "missing-slice-proof"
+    assert entries["slice-full"]["job_id"] == "wf-abc-code-review-1"
+    assert entries["slice-full"]["branch"] == "feature/xyz"
+    assert entries["slice-sparse"]["gate_reason"] is None
+    assert entries["slice-sparse"]["job_id"] is None
+    assert entries["slice-sparse"]["branch"] is None
+
+
+def test_recent_done_provider_applies_recency_window(monkeypatch, tmp_path):
+    """#265：超出 window 的 manifest 不進 recent_done，window 內無資料時回空陣列。"""
+    monkeypatch.setenv("PSC_CONTROL_ROOT", str(tmp_path))
+    handoff_dir = tmp_path / "handoff"
+    handoff_dir.mkdir()
+    (handoff_dir / "stale.json").write_text(
+        json.dumps(
+            {
+                "slice_id": "stale",
+                "gate_status": "needs_human",
+                "completed_at": "2026-07-22T03:46:54+00:00",
+            }
+        ),
+        encoding="utf-8",
+    )
+    provider = manager_daemon.build_runtime_status_provider(
+        registry=FakeRegistry(),
+        specs_dir=str(tmp_path / "specs"),
+        handoff_dir=str(handoff_dir),
+        scan_specs_fn=lambda specs_dir: [],
+        recent_done_window_seconds=86400.0,
+        now_fn=lambda: "2026-07-30T02:05:31+00:00",
+    )
+
+    status = provider()
+
+    assert status["recent_done"] == []
+
+
+def test_recent_done_provider_window_boundary_included_and_excluded(monkeypatch, tmp_path):
+    """window 邊界：剛好在窗內（含 cutoff 當下）納入，剛好過期（早於 cutoff 一秒）排除。"""
+    monkeypatch.setenv("PSC_CONTROL_ROOT", str(tmp_path))
+    handoff_dir = tmp_path / "handoff"
+    handoff_dir.mkdir()
+    # now = 2026-07-04T00:00:00+00:00, window = 86400s -> cutoff = 2026-07-03T00:00:00+00:00
+    (handoff_dir / "in-window.json").write_text(
+        json.dumps(
+            {
+                "slice_id": "in-window",
+                "gate_status": "passed",
+                "completed_at": "2026-07-03T00:00:00+00:00",
+            }
+        ),
+        encoding="utf-8",
+    )
+    (handoff_dir / "expired.json").write_text(
+        json.dumps(
+            {
+                "slice_id": "expired",
+                "gate_status": "passed",
+                "completed_at": "2026-07-02T23:59:59+00:00",
+            }
+        ),
+        encoding="utf-8",
+    )
+    provider = manager_daemon.build_runtime_status_provider(
+        registry=FakeRegistry(),
+        specs_dir=str(tmp_path / "specs"),
+        handoff_dir=str(handoff_dir),
+        scan_specs_fn=lambda specs_dir: [],
+        recent_done_window_seconds=86400.0,
+        now_fn=lambda: "2026-07-04T00:00:00+00:00",
+    )
+
+    status = provider()
+
+    assert [entry["slice_id"] for entry in status["recent_done"]] == ["in-window"]
+
+
+def test_recent_done_provider_window_disabled_when_none(monkeypatch, tmp_path):
+    """recent_done_window_seconds=None 明確關閉 window（保留舊行為的逃生艙口，供未來調校用）。"""
+    monkeypatch.setenv("PSC_CONTROL_ROOT", str(tmp_path))
+    handoff_dir = tmp_path / "handoff"
+    handoff_dir.mkdir()
+    (handoff_dir / "ancient.json").write_text(
+        json.dumps(
+            {
+                "slice_id": "ancient",
+                "gate_status": "passed",
+                "completed_at": "2020-01-01T00:00:00+00:00",
+            }
+        ),
+        encoding="utf-8",
+    )
+    provider = manager_daemon.build_runtime_status_provider(
+        registry=FakeRegistry(),
+        specs_dir=str(tmp_path / "specs"),
+        handoff_dir=str(handoff_dir),
+        scan_specs_fn=lambda specs_dir: [],
+        recent_done_window_seconds=None,
+        now_fn=lambda: "2026-07-30T00:00:00+00:00",
+    )
+
+    status = provider()
+
+    assert [entry["slice_id"] for entry in status["recent_done"]] == ["ancient"]
 
 
 def test_runtime_status_provider_classifies_held_units(monkeypatch, tmp_path):
@@ -1988,11 +2135,15 @@ def test_run_loop_default_builders_receive_injected_dispatcher_and_registry(monk
         seen["workflow_runtime_factory"] = workflow_runtime_factory
         return lambda req: {"dispatched": [req["req_id"]], "completed": [], "errors": [], "reaped": None}
 
-    def fake_build_runtime_status_provider(*, registry, specs_dir, handoff_dir, git_runner=None):
+    def fake_build_runtime_status_provider(
+        *, registry, specs_dir, handoff_dir, git_runner=None, recent_done_window_seconds=None, now_fn=None
+    ):
         seen["status_registry"] = registry
         seen["status_specs_dir"] = specs_dir
         seen["status_handoff_dir"] = handoff_dir
         seen["status_git_runner"] = git_runner
+        seen["status_recent_done_window_seconds"] = recent_done_window_seconds
+        seen["status_now_fn"] = now_fn
         return lambda: {"ready": [], "in_flight": [], "recent_done": []}
 
     def fake_build_periodic_tick_runner(*, dispatcher, specs_dir, handoff_dir, launcher, require_idle, default_executor, reaper):


### PR DESCRIPTION
## 背景

`paulshaclaw` cockpit JOBS 面板改為「要人動手的先講」後，`recent_done` 條目暴露出兩個獨立缺口，兩者都在同一個函式 `paulsha_cortex/coordinator/manager_daemon.py` 的 `recent_done_provider()`（`build_runtime_status_provider()` 內），故合成一個 PR 一起修。

## #230：欄位投影缺口

`recent_done_provider()` 讀 handoff manifest 後只投影 `slice_id`／`gate_status`／`at` 三欄，manifest 已有的 `gate_reason`、`job_id`、`branch` 被丟掉，導致下游 consumer（paulshaclaw cockpit）只能顯示「待裁決 · 原因未知」。

修法：多投影這三欄；manifest 缺該欄時為 `null`，不拋錯。

**範圍邊界（依 issue 最新 comment 釐清）**：`next_actions` **不**在本次修法範圍內。它不是 manifest 欄位，而是 `manager.slice_status_entry()`（`attention` section）算出來的衍生欄位；33 份現場 manifest 的欄位集合裡沒有 `next_actions`。本 PR 只做欄位投影，不做 action 推導。

## #265：新鮮度缺口

`recent_done_provider()` 只做排序 + 取前 N（`RECENT_DONE_LIMIT = 10`），沒有 recency window，也沒有 prune，導致 8 天前的一批 terminal manifest 永久佔滿全部 10 個名額，擠掉真正需要裁決的新資料。

修法：加入可設定的 recency window。

- 新常數 `RECENT_DONE_WINDOW_SECONDS`，預設 `86400` 秒（24 小時）。
- 可用 CLI `--recent-done-window-seconds` 或環境變數 `PSC_MANAGER_RECENT_DONE_WINDOW_SECONDS` 覆寫，`README.md` 同步說明預設值與設定方式。
- 過期 manifest（含解析不出 `completed_at` 的 manifest，視為無法證明新鮮而保守排除）不進 `recent_done`。
- window 內 0 筆時回空陣列，**不回退撈更舊的資料**。
- window 邊界行為明確：剛好等於 cutoff（窗內）納入，早於 cutoff 一秒（過期）排除。

**範圍邊界**：handoff manifest 檔案本身的 retention／prune 途徑（例如 `cortex handoff prune`）不在本次範圍內，明確記錄由 **#178** program teardown GC 負責。本 PR 未刪除、未修改任何 manifest 檔案，也未動 `~/.agents/coordinator/handoff/` 下的 runtime state。

## 明確不在本 PR 範圍

- `paulsha_cortex/coordinator/manager.py` 的 completion sweep（`#264`，另一個 agent 正在處理）。
- `repo`（project 歸屬）欄位（#230 後續 comment 追加，但未在本次任務範圍內，留待後續 PR）。
- handoff manifest 的刪檔／GC 功能（`#178`）。

## 測試

TDD：先寫會失敗的測試（5 個新／改測試涵蓋三個新欄位透出、缺欄位為 null、window 內無資料回空陣列、window 邊界含/排除、window 關閉逃生艙口），確認 RED，再實作到 GREEN。

```
python3 -m pytest tests/ -x -q
# 1613 passed, 32 subtests passed
```

```
python3 -m policy_check --repo .
# pass: 25, fail: 0, warn: 1（R-22 陳年 pre-existing warning，未新增）
```

Closes #230
Closes #265

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MBuP74pQJyBBcX17DDxBAo