### PR TITLE
fix(planning): AGY_MODEL_ID 改用 agy 實際輸出的 kebab id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@
 
 ## [Unreleased]
 ### Fixed
+- **Issue #255：AGY_MODEL_ID 改用 agy 實際輸出的 kebab id**：`agy models` 現在輸出
+  kebab id（如 `gemini-3.1-pro-high`），但 `model_identities.AGY_MODEL_ID` 仍寫死
+  顯示名 `Gemini 3.1 Pro (High)`，導致 `probe_agy_capability` 字面比對必然
+  miss，套件預設下唯一的 planning identity 永遠 probe 失敗、work-item workflow
+  卡死在 `define/needs_human`。`AGY_MODEL_ID` 改為 `gemini-3.1-pro-high`；
+  `probe_agy_capability` 新增正規化容錯比對（`_normalize_model_token` /
+  `_resolve_agy_cli_token`），顯示名與 kebab id 之間的格式落差不再是硬性
+  依賴，且一律用 `agy models` 實際列出的字面值呼叫 `--model`；`model-not-listed`
+  失敗時 `diagnostic` 帶出實際可用清單方便除錯；v1 schema 設定檔沿用舊顯示名
+  的既有寫法仍會被正確識別為 canonical agy planning identity（向後相容）。同步
+  更新套件內建 `data/model-identities.yaml` 與 `README.md` / active openspec
+  spec 的範例值。
+
 - **Issue #254：legacy monitor config 警告去重**：在
   `paulsha_cortex.monitor.config._resolve_config_source` 中加入單一 process 內 per-key
   去重機制，保留既有 legacy 警告文案與設定解析順序，避免 legacy env 與 legacy

--- a/README.md
+++ b/README.md
@@ -406,7 +406,7 @@ verification:
 schema_version: 2
 identities:
   - executor: agy
-    model_id: Gemini 3.1 Pro (High)
+    model_id: gemini-3.1-pro-high
     independence_domain: google
     capabilities: [planning]
     live_probe: agy-plan-sandbox

--- a/changelog.d/agy-model-id-normalize.md
+++ b/changelog.d/agy-model-id-normalize.md
@@ -1,0 +1,6 @@
+### Fixed
+- **Issue #255：AGY_MODEL_ID 改用 agy 實際輸出的 kebab id**：`AGY_MODEL_ID` 由顯示名
+  `Gemini 3.1 Pro (High)` 改為 `gemini-3.1-pro-high`，並為 `probe_agy_capability` 加入
+  顯示名↔kebab id 的正規化容錯比對，修正套件預設下唯一 planning identity 永遠 probe
+  失敗、work-item workflow 卡死在 `define/needs_human` 的問題；`model-not-listed` 失敗
+  改帶出實際可用清單，v1 schema 沿用舊顯示名的設定維持向後相容。

--- a/openspec/specs/persona-workflow-orchestration/spec.md
+++ b/openspec/specs/persona-workflow-orchestration/spec.md
@@ -119,7 +119,7 @@ Verify/review identity MUST以schema v2明示`review` capability且其independen
 - **AND**forged、stale或unknown evidence state MUST保留`needs_human`且不得dispatch
 
 ### Requirement: Agy launcher必須使用safe plan sandbox
-`agy` launcher MUST使用headless print、plan mode與sandbox，MUST NOT加入unsafe permission bypass。Model identity registry MUST登錄`agy + Gemini 3.1 Pro (High)`為`google`並由`doctor --probe-live`驗capability；版本字串 alone MUST NOT視為可用。
+`agy` launcher MUST使用headless print、plan mode與sandbox，MUST NOT加入unsafe permission bypass。Model identity registry MUST登錄`agy + gemini-3.1-pro-high`（`agy models`實際輸出的kebab id，非顯示名）為`google`並由`doctor --probe-live`驗capability；版本字串 alone MUST NOT視為可用。
 
 #### Scenario: CLI介面漂移
 - **WHEN**agy存在但plan/sandbox smoke失敗或model identity不符

--- a/paulsha_cortex/coordinator/data/model-identities.yaml
+++ b/paulsha_cortex/coordinator/data/model-identities.yaml
@@ -1,7 +1,7 @@
 schema_version: 2
 identities:
   - executor: agy
-    model_id: Gemini 3.1 Pro (High)
+    model_id: gemini-3.1-pro-high
     independence_domain: google
     capabilities: [planning]
     live_probe: agy-plan-sandbox

--- a/paulsha_cortex/coordinator/model_identities.py
+++ b/paulsha_cortex/coordinator/model_identities.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import re
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
@@ -13,7 +14,12 @@ from .launcher import build_agy_argv
 
 MODEL_IDENTITY_SCHEMA_VERSION = 2
 SUPPORTED_MODEL_IDENTITY_SCHEMAS = frozenset({1, 2})
-AGY_MODEL_ID = "Gemini 3.1 Pro (High)"
+# `agy models` 現在輸出 kebab id（例如 `gemini-3.1-pro-high`），不是顯示名。
+# 這裡的常數就是 registry 用來比對／查找的 canonical model_id，必須跟 CLI
+# 實際輸出一致，否則 probe_agy_capability 會字面比對失敗（issue #255）。
+AGY_MODEL_ID = "gemini-3.1-pro-high"
+# 舊版顯示名，僅為相容 v1 schema 的既有設定檔（見 `_is_canonical_agy_model_id`）。
+_AGY_MODEL_ID_LEGACY_DISPLAY_NAME = "Gemini 3.1 Pro (High)"
 AGY_DOMAIN = "google"
 AGY_LIVE_PROBE = "agy-plan-sandbox"
 PLANNER_PRIORITY = (
@@ -55,6 +61,11 @@ def _assert_no_duplicate_yaml_keys(text: str) -> None:
         if key in contexts[-1][1]:
             raise ValueError(f"duplicate key '{key}' at line {lineno}")
         contexts[-1][1].add(key)
+
+
+def _is_canonical_agy_model_id(model_id: str) -> bool:
+    """v1 設定檔可能仍寫著舊顯示名；兩種拼法都視為 canonical agy 身分。"""
+    return model_id in (AGY_MODEL_ID, _AGY_MODEL_ID_LEGACY_DISPLAY_NAME)
 
 
 def _nonempty(value: object, field: str) -> str:
@@ -213,9 +224,13 @@ def _load_model_identity_file(path: Path) -> IdentityRegistry:
             # v1 had no capability field. Preserve its identities as planning
             # fallback candidates; selection still requires a matching live
             # probe and a foreign independence domain.
-            if executor != "agy" or model_id == AGY_MODEL_ID:
+            if executor != "agy" or (
+                isinstance(model_id, str) and _is_canonical_agy_model_id(model_id)
+            ):
                 normalized["capabilities"] = ["planning"]
-            if executor == "agy" and model_id == AGY_MODEL_ID:
+            if executor == "agy" and isinstance(model_id, str) and _is_canonical_agy_model_id(
+                model_id
+            ):
                 normalized["live_probe"] = AGY_LIVE_PROBE
             normalized_rows.append(normalized)
         rows = normalized_rows
@@ -290,6 +305,29 @@ def _failed_agy(reason: str, diagnostic: str | None = None) -> CapabilityProbe:
     return CapabilityProbe(False, "agy", AGY_MODEL_ID, AGY_DOMAIN, reason, diagnostic)
 
 
+def _normalize_model_token(value: str) -> str:
+    """正規化 model id／顯示名，容忍 `agy models` 輸出格式（顯示名 vs kebab id、
+    大小寫、空白/括號等標點差異）未來再次改版。"""
+    return re.sub(r"[^a-z0-9]+", "-", value.strip().lower()).strip("-")
+
+
+def _resolve_agy_cli_token(expected: str, listed: Iterable[str]) -> str | None:
+    """在 `agy models` 的輸出行中找出與 expected 語意相符的實際 CLI token。
+
+    優先字面完全比對；找不到時退而用正規化比對，讓顯示名／kebab id 之間的
+    命名落差不必等到常數再次寫死才修（issue #255）。回傳的是 `agy models`
+    實際印出的那一行，因為 `--model` 必須用 CLI 認得的字面值呼叫。
+    """
+    listed_set = {line for line in listed if line}
+    if expected in listed_set:
+        return expected
+    target = _normalize_model_token(expected)
+    for line in listed_set:
+        if _normalize_model_token(line) == target:
+            return line
+    return None
+
+
 def probe_agy_capability(
     *,
     runner: ProcessRunner | None = None,
@@ -310,8 +348,14 @@ def probe_agy_capability(
         return _failed_agy("models-probe-failed", type(exc).__name__)
     if listed_rc != 0:
         return _failed_agy("models-probe-failed", f"exit-code:{listed_rc}")
-    if AGY_MODEL_ID not in {line.strip() for line in listed_stdout.splitlines()}:
-        return _failed_agy("model-not-listed")
+    listed_lines = {line.strip() for line in listed_stdout.splitlines() if line.strip()}
+    cli_model_token = _resolve_agy_cli_token(AGY_MODEL_ID, listed_lines)
+    if cli_model_token is None:
+        available = ", ".join(sorted(listed_lines)[:20])
+        return _failed_agy(
+            "model-not-listed",
+            f"expected={AGY_MODEL_ID!r} available=[{available}]",
+        )
 
     expected = {"capability": "cortex-plan-sandbox", "model": AGY_MODEL_ID}
     prompt = (
@@ -322,7 +366,7 @@ def probe_agy_capability(
         prompt=prompt,
         slice_id="cortex-capability-probe",
         log_dir=".",
-        model=AGY_MODEL_ID,
+        model=cli_model_token,
     )
     try:
         smoke_raw = process_runner(argv, **common)

--- a/tests/test_model_identities.py
+++ b/tests/test_model_identities.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import pytest
 
 from paulsha_cortex.coordinator.model_identities import (
+    AGY_LIVE_PROBE,
     AGY_MODEL_ID,
     CapabilityProbe,
     IdentityRegistry,
@@ -150,11 +151,11 @@ def test_foreign_review_uses_v2_registry_without_leaking_planner_metadata(tmp_pa
     from paulsha_cortex.coordinator import review
 
     (tmp_path / "model-identities.yaml").write_text(
-        """\
+        f"""\
 schema_version: 2
 identities:
   - executor: agy
-    model_id: Gemini 3.1 Pro (High)
+    model_id: {AGY_MODEL_ID}
     independence_domain: google
     capabilities: [planning]
     live_probe: agy-plan-sandbox
@@ -177,9 +178,9 @@ def test_agy_probe_requires_model_listing_and_safe_headless_smoke() -> None:
     def runner(argv, **kwargs):
         calls.append({"argv": argv, **kwargs})
         if argv == ["agy", "models"]:
-            return _completed(stdout=f"Gemini 3.1 Pro (Low)\n{AGY_MODEL_ID}\n")
+            return _completed(stdout=f"gemini-3.1-pro-low\n{AGY_MODEL_ID}\n")
         return _completed(
-            stdout='{"capability":"cortex-plan-sandbox","model":"Gemini 3.1 Pro (High)"}\n'
+            stdout=f'{{"capability":"cortex-plan-sandbox","model":"{AGY_MODEL_ID}"}}\n'
         )
 
     probe = probe_agy_capability(runner=runner, timeout_seconds=11)
@@ -315,6 +316,86 @@ def test_secondary_selection_fails_closed_for_unknown_or_same_domain_only() -> N
         probes=probes,
     )
     assert (same.state, same.reason) == ("needs_human", "no-heterogeneous-planner")
+
+
+def test_agy_model_id_matches_agy_cli_kebab_id() -> None:
+    """`agy models` 現在輸出 kebab id，而不是顯示名（issue #255 根因）。
+
+    這條測試釘住 canonical 值本身，避免未來又悄悄退回顯示名或其他跟
+    `agy models` 實際輸出脫節的拼法。
+    """
+    assert AGY_MODEL_ID == "gemini-3.1-pro-high"
+    assert AGY_MODEL_ID.islower()
+    assert " " not in AGY_MODEL_ID
+
+
+def test_agy_probe_tolerates_display_name_vs_kebab_id_drift(monkeypatch) -> None:
+    """即使 `agy models` 的輸出格式再跟 canonical 常數脫節一次，probe 也不該
+    一字不差比對失敗——這條測試刻意跟目前的 AGY_MODEL_ID 拼法無關，用
+    monkeypatch 固定一個 canonical 值，驗證「正規化後語意相同即可」這條規則
+    本身，而不是巧合碰上兩者剛好相等。
+
+    容錯比對用正規化（大小寫／標點）判斷語意相同的那一行，並且用
+    `agy models` 實際印出的字面值去呼叫 `--model`，而不是硬塞 canonical
+    id（CLI 不一定認得 canonical 拼法）。
+    """
+    monkeypatch.setattr(
+        "paulsha_cortex.coordinator.model_identities.AGY_MODEL_ID", "sample-model-x"
+    )
+    calls: list[dict] = []
+    drifted_line = "Sample Model X"  # 與 canonical 值語意相同、格式不同
+
+    def runner(argv, **kwargs):
+        calls.append({"argv": argv, **kwargs})
+        if argv == ["agy", "models"]:
+            return _completed(stdout=f"other-model\n{drifted_line}\n")
+        return _completed(
+            stdout='{"capability":"cortex-plan-sandbox","model":"sample-model-x"}\n'
+        )
+
+    probe = probe_agy_capability(runner=runner)
+
+    assert probe.ready is True
+    assert probe.identity == ("agy", "sample-model-x", "google")
+    model_index = calls[1]["argv"].index("--model") + 1
+    assert calls[1]["argv"][model_index] == drifted_line
+
+
+def test_agy_probe_model_not_listed_diagnostic_surfaces_available_models() -> None:
+    """失敗時 diagnostic 要帶出實際清單，不能只留下一個空的 reason 讓人猜。"""
+    probe = probe_agy_capability(
+        runner=lambda *a, **k: _completed(
+            stdout="gemini-3.6-flash-high\ngemini-3.6-flash-medium\n"
+        )
+    )
+
+    assert probe.ready is False
+    assert probe.reason == "model-not-listed"
+    assert probe.diagnostic is not None
+    assert AGY_MODEL_ID in probe.diagnostic
+    assert "gemini-3.6-flash-high" in probe.diagnostic
+
+
+def test_v1_legacy_display_name_still_promotes_to_canonical_agy_planning_identity(
+    tmp_path: Path,
+) -> None:
+    """既有 v1 設定檔若還寫著舊顯示名，也要繼續被視為 canonical agy 身分。"""
+    (tmp_path / "model-identities.yaml").write_text(
+        """\
+schema_version: 1
+identities:
+  - executor: agy
+    model_id: Gemini 3.1 Pro (High)
+    independence_domain: google
+""",
+        encoding="utf-8",
+    )
+
+    registry = load_model_identities(tmp_path, use_packaged_default=False)
+
+    legacy = registry.require("agy", "Gemini 3.1 Pro (High)")
+    assert legacy.capabilities == ("planning",)
+    assert legacy.live_probe == AGY_LIVE_PROBE
 
 
 def test_v1_identity_is_a_probe_bound_planning_fallback(tmp_path: Path) -> None:


### PR DESCRIPTION
## 摘要

`agy models` 現在輸出 kebab id（如 `gemini-3.1-pro-high`），但
`model_identities.AGY_MODEL_ID` 仍寫死顯示名 `"Gemini 3.1 Pro (High)"`。
`probe_agy_capability` 以字面比對輸出行，必然 miss → 套件預設下唯一的
planning identity 永遠 probe 失敗 → work-item workflow 永遠卡在
`define/needs_human`（實測見 issue #255）。

## 修法

- `AGY_MODEL_ID` 改為 `gemini-3.1-pro-high`（agy 實際輸出的 canonical id）。
- `probe_agy_capability` 新增正規化容錯比對（`_normalize_model_token` /
  `_resolve_agy_cli_token`）：先字面比對，找不到再用正規化（大小寫/標點）
  比對，避免未來顯示名/kebab id 格式又一次脫節；並改用 `agy models`
  實際列出的字面值去呼叫 `--model`，而不是硬塞 canonical id（CLI 不一定
  認得 canonical 拼法）。
- `model-not-listed` 失敗時 `diagnostic` 帶出實際可用清單，方便下次脫節
  時一眼看出（issue 建議 2）。
- v1 schema 設定檔若沿用舊顯示名寫法，仍會被正確識別為 canonical agy
  planning identity（向後相容，`_is_canonical_agy_model_id`）。
- 同步更新套件內建 `paulsha_cortex/coordinator/data/model-identities.yaml`、
  `README.md` 範例、active openspec spec 的敘述值。

## 範圍說明

- `select_secondary_planner` 本身邏輯未改動；但因 primary probe 現在能
  正確 ready，其「跳過 probe 不 ready 的 identity」這條連鎖規則不會再
  誤傷 canonical agy 身分。
- `cortex doctor` 的 `agy_probe` callback 契約（`_default_agy_probe`）刻意
  維持不外洩 raw diagnostic 到報表（既有的 secret-safety 測試
  `test_doctor_does_not_echo_credentials_from_failed_command` 保護這條
  契約），因此本 PR 沒有把 diagnostic 接進 `cortex doctor` 的輸出——issue
  建議 3（doctor 訊息誤導性）留待日後若要處理，需另外設計「reason 安全但
  diagnostic 不安全」的分層揭露方式，避免這次順手改動撞上既有的安全契約。
- 不動 issue #256（planning claim 卡死的復原路徑），那是獨立一票。

## 測試

- 新增/更新 `tests/test_model_identities.py`：kebab id 常數本身、正規化
  容錯比對（含用 monkeypatch 固定 canonical 值，避免測試巧合通過）、
  `model-not-listed` diagnostic 內容、v1 舊顯示名向後相容。
- `python3 -m pytest tests/ -q` → 1613 passed, 32 subtests passed。
- `python3 -m policy_check --repo .` → fail: 0, warn: 1（R-22 為既有陳年
  warning，未新增）。

Closes #255

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MBuP74pQJyBBcX17DDxBAo