### PR TITLE
docs(agent-policy): changelog 要求對齊 engine R-09 的 changelog.d fragment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@
 
 ## [Unreleased]
 ### Fixed
+- **Issue #270：CLAUDE.md 的 changelog 要求對齊 engine R-09**：agent 指引原先三處（改 code 時、
+  claim done 前）都只要求 `CHANGELOG.md [Unreleased]`，與 R-09 實際檢查的 `changelog.d/*.md`
+  fragment 不一致，導致照指引交付的 PR 必然掛在 `policy / check`（#266／#267／#268／#269
+  四個 PR 同時實證）。改以 fragment 為硬性 gate、寫明檔名 slug 慣例與「fragment 須 commit
+  才進 diff」；claim-done checklist 的 policy_check 一項補上帶 `--pr-title`／`--pr-body`／
+  `--pr-labels`／`--pr-base-ref`／`--pr-head-ref` 的完整命令形式（裸跑會給出假的 `fail: 0`，
+  因為 CI 會傳這五個參數並啟用一批 PR／diff-aware 規則）；並移除指向不存在檔案的
+  `.github/pull_request_template.md` checklist 項目。`CLAUDE.md` 為 canonical 真檔，
+  `AGENTS.md`／`GEMINI.md`／`.github/copilot-instructions.md` 的 symlink 自動同步。
+
+### Fixed
 - **Issue #254：legacy monitor config 警告去重**：在
   `paulsha_cortex.monitor.config._resolve_config_source` 中加入單一 process 內 per-key
   去重機制，保留既有 legacy 警告文案與設定解析順序，避免 legacy env 與 legacy

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,9 +23,16 @@ policy_version: 1.0.15
 - [ ] 若本任務跨多個子項，先建議用 `git worktree` 拆開
 
 ## 改 code 時
-- [ ] 同一 PR 必須同步更新 `CHANGELOG.md [Unreleased]`
-- [ ] 除非可明確標示為 docs-only / test-only / chore，否則不得省略 CHANGELOG
+- [ ] **同一 PR 必須新增 `changelog.d/<slug>.md` fragment**（R-09 實際檢查的就是這個；
+      只寫 `CHANGELOG.md [Unreleased]` 會 FAIL）
+  - 檔名 slug＝分支名去掉 issue number，例：`feature/155-migrate-codex-relay-hook`
+    → `changelog.d/migrate-codex-relay-hook.md`
+  - fragment 必須 **commit** 才算（只 `git add` 不進 diff，R-09 仍 FAIL）
+  - 發版時由 fragment 收攏進 `CHANGELOG.md`，因此並行 PR 不會在同一段互相衝突
+- [ ] 另同步補 `CHANGELOG.md [Unreleased]` entry（repo 慣例，與 fragment 併存）
+- [ ] 除非可明確標示為 docs-only / test-only / chore，否則不得省略 changelog
 - [ ] code_paths 涵蓋的檔案變動皆視為 code change
+      （本 repo 的 code_paths 含 `**/*.md`，故連改 `CLAUDE.md`／docs 也算）
 
 ## 改版號時（release 觸發時）
 - [ ] 嚴格遵循 `<MAJOR>.<MINOR>.<PATCH>[-fix.N]`
@@ -36,10 +43,20 @@ policy_version: 1.0.15
 - [ ] MAJOR bump 需使用者明確核可
 
 ## 完成任務（claim done）前
-- [ ] `CHANGELOG.md [Unreleased]` 有對應 entry（或 PR 標 `skip-changelog` + 理由）
+- [ ] `changelog.d/<slug>.md` fragment 已新增且已 commit（或 PR 標 `skip-changelog` + 理由）
+- [ ] `CHANGELOG.md [Unreleased]` 有對應 entry
 - [ ] `VERSION` 內容與意圖一致（release label PR 才可偏離 latest tag）
-- [ ] `.github/pull_request_template.md` checklist 全勾
-- [ ] `python3 -m policy_check --repo .` 無任何 failure
+- [ ] PR body checklist 全勾（R-11；本 repo 目前無 PR template 檔案，
+      checklist 由 PR body 自行帶出）
+- [ ] **policy_check 必須帶 PR 上下文跑**，裸跑會給出假的 `fail: 0`：
+      ```bash
+      python3 -m policy_check --repo . \
+        --pr-title "<PR 標題>" --pr-body "<PR body>" --pr-labels "<labels>" \
+        --pr-base-ref main --pr-head-ref "feature/<slug>"
+      ```
+      CI 走 `.github/workflows/policy-check.yml` → conventions 的
+      `reusable-policy-check.yml`，會傳這五個參數並啟用一批 PR／diff-aware 規則
+      （含 R-09 的 diff 判定）；少了它們本機看不到那些 rule 的真實結果
 - [ ] 若本 repo 有額外測試 / lint / build 指令，需一併通過
 - [ ] 若跳過任何檢查，PR 必須帶對應豁免 label + 理由
 

--- a/changelog.d/align-changelog-guidance.md
+++ b/changelog.d/align-changelog-guidance.md
@@ -1,0 +1,7 @@
+### Fixed
+- **Issue #270：CLAUDE.md 的 changelog 要求對齊 engine R-09**：agent 指引原先只要求
+  `CHANGELOG.md [Unreleased]`，與 R-09 實際檢查的 `changelog.d/*.md` fragment 不一致，
+  照做必掛 `policy / check`（#266／#267／#268／#269 四個 PR 實證）。改以 fragment 為硬性
+  gate 並寫明檔名 slug 慣例與「須 commit 才進 diff」；claim-done checklist 的 policy_check
+  補上帶 PR 上下文的完整命令（裸跑會給出假的 `fail: 0`）；移除指向不存在的
+  `.github/pull_request_template.md` 的懸空引用。


### PR DESCRIPTION
## 摘要

`CLAUDE.md` 原先三處（「改 code 時」×2、「完成任務前」×1）都只要求 `CHANGELOG.md [Unreleased]`，但 engine R-09 實際檢查的是 `changelog.d/*.md` fragment。照指引交付必然掛 `policy / check` —— #266／#267／#268／#269 四個 PR 同時實證（其餘 7 項 check 全綠，只有 policy 紅）。

因為 `AGENTS.md`／`GEMINI.md`／`.github/copilot-instructions.md` 都是 `CLAUDE.md` 的 symlink，且 cortex 自主派工也讀同一份，這個指引缺陷會讓每一條 lane 都踩。

## 改動

1. **changelog 要求改以 fragment 為硬性 gate**，並寫明：
   - 檔名 slug＝分支去掉 issue number（`feature/155-migrate-codex-relay-hook` → `changelog.d/migrate-codex-relay-hook.md`）
   - fragment 必須 **commit** 才進 diff（只 `git add` 的話 R-09 仍 FAIL）
   - 發版時由 fragment 收攏進 `CHANGELOG.md`，因此並行 PR 不會在同一段互相衝突
   - `CHANGELOG.md [Unreleased]` entry 仍補（repo 慣例，與 fragment 併存）
2. **註明 code_paths 含 `**/*.md`**，所以連改 `CLAUDE.md`／docs 也算 code change（本 PR 自身即為例證，已附 fragment）。
3. **policy_check 改為帶 PR 上下文的完整命令**：裸跑 `python3 -m policy_check --repo .` 會給出假的 `fail: 0`。CI 走 conventions 的 `reusable-policy-check.yml`，其 `run.sh` 會傳 `--pr-title`／`--pr-body`／`--pr-labels`／`--pr-base-ref`／`--pr-head-ref`，啟用一批本機看不到的 PR／diff-aware 規則。實測同一 commit：裸跑 `fail: 0`，補參數後 `fail: 1`（R-09）。
4. **移除懸空引用**：claim-done checklist 原有一項「`.github/pull_request_template.md` checklist 全勾」，但該檔案不存在（`.github/` 下只有 `copilot-instructions.md` 與 `workflows/`）。改為「PR body checklist 全勾（R-11）」並註明本 repo 目前無 template 檔案。

## 非目標

不改 engine 端的 R-09 判定。fragment-based 設計是刻意的（發版收攏、避免 `CHANGELOG.md` 在並行 PR 間反覆衝突），本 PR 只讓 repo 指引與它對齊。

## 測試計畫

- [x] 帶 PR 上下文的 policy_check：`pass: 24, fail: 0, warn: 2`（R-18 docs-sync、R-22 皆 advisory）
- [x] R-22 懸空引用仍為 **24 筆**（與基準 HEAD 相同，未新增；移除 PR template 引用後未產生新懸空）
- [x] `AGENTS.md`／`GEMINI.md`／`.github/copilot-instructions.md` 仍為指向 `CLAUDE.md` 的 symlink（R-14 無豁免）
- [x] 本 PR 自身附 `changelog.d/align-changelog-guidance.md` fragment —— 修法的自我驗證

Closes #270

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MBuP74pQJyBBcX17DDxBAo
