### PR TITLE
fix(openspec): 對齊 fix-systemctl-install-failure 的 work_item frontmatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 本專案遵循 hamanpaul project policy v1.0.15。
 
 ## [Unreleased]
+### Fixed
+- **Issue #273（實例修正）：openspec change 內 frontmatter `work_item` 不一致**：`openspec/changes/fix-systemctl-install-failure/tasks.md` 的 `work_item` 與同目錄 `proposal.md`／`design.md` 不同，使同一 openspec source 被兩個 work item 宣告擁有，觸發 confirmed source collision，導致 `hamanpaul/paulsha-cortex` 的 monitor work item projection 由 43 個降為 0、任何 work item 皆無法 claim。本次對齊 frontmatter 使 projection 恢復；靜默吞例外與 collision 影響範圍過大的根本問題見 #273。
+
 ### Added
 - **批次 B planning artifacts（#261／#256／#262／#205／#135）**：為五個 issue 各新增 spec／design／plan／workstream todo 與 openspec change（`2026-07-30-<work_item>`），並登錄 `.cortex/work-items.yaml`，作為 cortex work-item lifecycle 的 confirmed authority。五組皆通過 `assess_planning_completeness`（`status: accepted`、必要章節齊備、無 blocking marker）。本 PR 只提供 planning authority，實作由後續 cortex 派工的 build phase 完成。
 

--- a/changelog.d/fix-workitem-frontmatter-collision.md
+++ b/changelog.d/fix-workitem-frontmatter-collision.md
@@ -1,0 +1,7 @@
+### Fixed
+- **Issue #273（實例修正）：openspec change 內 frontmatter `work_item` 不一致**：
+  `openspec/changes/fix-systemctl-install-failure/tasks.md` 宣告的 `work_item` 與同目錄
+  `proposal.md`／`design.md` 不同，使同一個 openspec source 被兩個 work item 宣告擁有，
+  觸發 `correlate_work_sources` 的 confirmed source collision，導致 `hamanpaul/paulsha-cortex`
+  的 work item projection 由 43 個降為 0、任何 work item 都無法 claim。本次對齊 frontmatter；
+  collision 只影響單一 source 卻讓整個 repo 歸零、以及 refresh 例外被靜默吞掉的根本問題見 #273。

--- a/openspec/changes/fix-systemctl-install-failure/tasks.md
+++ b/openspec/changes/fix-systemctl-install-failure/tasks.md
@@ -1,6 +1,6 @@
 ---
 status: accepted
-work_item: fix-systemctl-install-failure
+work_item: fix-systemctl-install-failure-delivery-v3
 ---
 
 # Tasks


### PR DESCRIPTION
## 摘要

一行 frontmatter 修正，讓 monitor 的 cortex work item projection 從 **0 恢復為 43**。

`openspec/changes/fix-systemctl-install-failure/` 同一個目錄內：

| 檔案 | `work_item` |
|---|---|
| `proposal.md` | `fix-systemctl-install-failure-delivery-v3` |
| `design.md` | `fix-systemctl-install-failure-delivery-v3` |
| `tasks.md` | `fix-systemctl-install-failure` ← 不一致 |

同一個 openspec source 因而被兩個 work item 宣告擁有，`correlate_work_sources` 判定 confirmed source collision：

```
confirmed source collision: openspec:hamanpaul/paulsha-cortex:fix-systemctl-install-failure
  -> ['fix-systemctl-install-failure', 'fix-systemctl-install-failure-delivery-v3']
```

collision 使整個 `hamanpaul/paulsha-cortex` 的 work item projection 歸零，`cortex work start` 一律回 `confirmed work authority missing or ambiguous`，任何 work item 都無法 claim。

## 驗證

修正前後以相同流程實測：

| | 修正前 | 修正後 |
|---|---|---|
| `correlation.degraded` | `True` | **`False`** |
| diagnostics | 1 筆 collision | **空** |
| cortex work items | **0** | **43** |

## 範圍

本 PR 只修這一個實例。真正的根本問題另開 #273 追蹤，共三項：

1. `service.py:345-352` 把 refresh 的 `ValueError` 靜默吞掉，使 snapshot 從 2026-07-26 起永久停止更新，期間服務顯示 `active running` 且無任何 log。
2. 同一 git remote 的多個 checkout 會產生 duplicate work item ID 而使 monitor 整體失效（cortex 自己大量使用 sibling worktree，屬結構性問題）。
3. 單一 source collision 不應使整個 repo 的 projection 歸零。

Refs #273

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MBuP74pQJyBBcX17DDxBAo