### PR TITLE
fix(coordinator): dispatch 前驗證 runtime capability 與 provider 新鮮度

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@
 本專案遵循 hamanpaul project policy v1.0.15。
 
 ## [Unreleased]
+### Added
+- **Issue #262：dispatch 前驗證 runtime capability 與 provider snapshot 新鮮度**：新增
+  `coordinator/runtime_preflight.py`，在建立 worktree／sandbox／job row／model session 之前，
+  於「即將實際被使用的 executor 環境」執行低成本 preflight。card 契約新增 `runtime_capabilities`
+  資料宣告（`module:` / `executable:` / `bridge:` / `provider:`），preflight 為通用執行器，新增
+  card 不需修改實作；非法宣告在 deck 載入時 fail-closed。module 檢查透過 executor 的 interpreter
+  以子行程 import、executable 只查 executor PATH，皆不使用 manager 這側的 import 或 host PATH；
+  `SubprocessLauncher.executor_environment()` 沿用與 `launch()` 相同的 `_git_scope_env()`／
+  `_review_scope_env()`，確保 preflight 與正式 job 的 interpreter／PATH／HOME／sandbox policy 一致。
+  provider 健康改採「快照 + TTL + 有界 probe」三層，snapshot 帶 `observed_at`／TTL／source／reason，
+  超過 TTL 的 degraded 判斷不再被當成當前事實；`capability missing`／`provider unavailable`／
+  `stale snapshot`／`probe inconclusive` 四種結果各自獨立表達，只有前兩者是 hard block。live probe
+  以 provider identity 為鍵共用 TTL 快取與 rate-limit 額度，同批次同 provider 不重複探測。preflight
+  失敗時優先在既有 identity 順序與 independence domain 規則內 re-route，無合法替代才進入帶具體
+  reason 的 `needs_human`，全程 model invocation 維持 0；`cortex inspect status` 顯示缺少的
+  capability、使用中的 executor environment 與 snapshot 新鮮度。
+
 ### Fixed
 - **Issue #256：planning claim 前向恢復與放行語意修正**：`recover-planning` 新增環境/內容分類判定與 CAS 重入保護，`abandon` 加入 `planning_released` 釋放標記讓 `needs_human` 的同識別 work item 可重 claim，並讓 `resume` 對 `needs_human` 回傳合法 `next_actions`（停在 `define` 的環境類 planning 失敗才含 `recover-planning`，內容類仍只給 `abandon`）與具體 `blocking_reason`，恢復稽核紀錄亦保存前後 run 狀態；`work_actions`、`control/contract`、`coordinator/cli`、`porcelain/run`、`work bridge/registry` 均同步放行與解讀新動作。
 

--- a/README.md
+++ b/README.md
@@ -399,6 +399,57 @@ verification:
 - v1 只支援 `tier: shareable`；非 shareable 會 fail-closed 到 `needs_human`。
 - verification command 只接受 typed argv（`shell=False`）；採 sanitized env，但這不是 sandbox，不保證隔離 untrusted code。
 
+### Runtime preflight（dispatch 前的 capability 與 provider 新鮮度，#262）
+
+Manager 在建立 worktree／sandbox／job row／model session **之前**，會依 card 宣告在
+「即將實際被使用的 executor 環境」執行低成本 preflight。card 未宣告任何 capability
+時 preflight 是 no-op，行為與先前相同。
+
+`paulsha_cortex/deck/data/cards.yaml` 的 card 可宣告 `runtime_capabilities`，形式為
+`<kind>:<name>`，kind 為 `module`／`executable`／`bridge`／`provider`：
+
+```yaml
+  - id: tdd-red
+    # ...
+    runtime_capabilities: ["module:pytest"]
+```
+
+宣告是資料而非程式碼分支——新增 card 只要寫這份宣告，不需修改 preflight 實作；
+非法 kind 或空 name 會在 deck 載入時 fail-closed（`DeckSchemaError`），避免無聲漏檢。
+
+檢查一律走 executor 環境，不看 host：
+
+- `module:` 以 executor 的 interpreter 開子行程 import；
+- `executable:` 只解析 executor 的 `PATH`；
+- `bridge:` 依內建對照表落到 module 或 executable 探測；
+- `provider:` 讀 provider snapshot 的新鮮度。
+
+`SubprocessLauncher.executor_environment()` 用與 `launch()` 相同的
+`_git_scope_env()`／`_review_scope_env()` 產生 env，因此 preflight 與正式 job 的
+interpreter、`PATH`、`HOME`／sandbox policy 一致（reviewer 會走最小 env）。
+
+Provider 健康採「快照 + TTL + 有界 probe」三層。snapshot 帶 `observed_at`、TTL、
+source 與 reason；TTL 內直接採信，逾期的 degraded **不會**被當成當前事實，而是對
+必要 provider 執行有界 live probe。四種結果各自獨立，不折疊成布林：
+
+| 結果 | 意義 | 是否 hard block |
+| --- | --- | --- |
+| `capability_missing` | executor 環境缺 module／executable／bridge | 是 |
+| `provider_unavailable` | 新鮮快照或 live probe 判定 provider 不可用 | 是 |
+| `stale_snapshot` | 快照逾期且無法探測，需刷新 | 否 |
+| `probe_inconclusive` | 探測 timeout／額度耗盡／無定論 | 否 |
+
+live probe 以 provider identity 為鍵共用 TTL 快取與 rate-limit 額度（沿用
+`claim_readiness` 的 `LiveProbeCache` 模式），同批次多張 card 對同一 provider 只探測
+一次。preflight 失敗時，Manager 會在既有 identity 順序與 independence domain 規則內
+自動 re-route 至下一個合法 identity；沒有合法替代才進入帶具體 reason 的
+`needs_human`（`reason` 形如 `runtime-preflight-capability_missing`）。整個 gate 位於
+model session 建立之前，被擋下時 model invocation 維持 0。
+
+`cortex inspect status` 會顯示缺少的 capability、使用中的 executor environment
+（名稱／interpreter／`PATH`／`HOME`）與每個 provider 的 snapshot 新鮮度
+（status、source、age、TTL、是否 fresh）。
+
 ### Foreign reviewer identity（不同 independence domain）
 
 `PSC_PROJECT_CONFIG_ROOT/model-identities.yaml`：

--- a/changelog.d/dispatch-runtime-preflight.md
+++ b/changelog.d/dispatch-runtime-preflight.md
@@ -1,0 +1,21 @@
+### Added
+- **Issue #262：dispatch 前驗證 runtime capability 與 provider snapshot 新鮮度**：新增
+  `coordinator/runtime_preflight.py`，在建立 worktree／sandbox／job row／model session
+  之前，於「即將實際被使用的 executor 環境」執行低成本 preflight。card 契約新增
+  `runtime_capabilities` 資料宣告（`module:` / `executable:` / `bridge:` / `provider:`），
+  preflight 是通用執行器，新增 card 不需改實作；非法宣告在 deck 載入時 fail-closed。
+  module 檢查透過 executor 的 interpreter 以子行程 import、executable 只查 executor
+  PATH，皆不使用 manager 這側的 import 或 host PATH——`SubprocessLauncher` 新增
+  `executor_environment()`，沿用與 `launch()` 相同的 `_git_scope_env()`／
+  `_review_scope_env()`，確保 preflight 與正式 job 的 interpreter／PATH／HOME／sandbox
+  policy 一致。provider 健康改採「快照 + TTL + 有界 probe」三層，snapshot 帶
+  `observed_at`／TTL／source／reason；超過 TTL 的 degraded 判斷不再被當成當前事實
+  （這正是 2026-07-30 dogfood 中三個 work item 因過時 `github rate limit exceeded`
+  診斷而無法 claim 的成因）。`capability missing`／`provider unavailable`／
+  `stale snapshot`／`probe inconclusive` 四種結果各自獨立表達、不折疊成布林，前兩者
+  才是 hard block。live probe 以 provider identity 為鍵共用 TTL 快取與 rate-limit 額度
+  （沿用 `claim_readiness` 的 `LiveProbeCache` 模式），同批次同 provider 不重複探測。
+  preflight 失敗時優先在既有 identity 順序與 independence domain 規則內 re-route，
+  無合法替代才進入帶具體 reason 的 `needs_human`，全程 model invocation 維持 0；
+  `cortex inspect status` 顯示缺少的 capability、使用中的 executor environment 與
+  snapshot 新鮮度。

--- a/paulsha_cortex/coordinator/launcher.py
+++ b/paulsha_cortex/coordinator/launcher.py
@@ -6,6 +6,7 @@ import re
 import shlex
 import shutil
 import subprocess
+import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Protocol, runtime_checkable
@@ -661,6 +662,45 @@ class SubprocessLauncher:
             read_only=False,
             review_only=False,
             commit_required=True,
+        )
+
+    def executor_environment(self, *, slice_id: str = "preflight"):
+        """#262 D2：回報正式 job 會實際看到的 executor 環境。
+
+        env 由與 `launch()` 相同的 `_review_scope_env()`／`_git_scope_env()` 產生，
+        因此 preflight 檢查的 PATH／HOME／sandbox policy 與正式 job 一致；
+        若在此另建一份 env，preflight 就只是安慰劑（見 design D2）。
+        """
+
+        from .runtime_preflight import ExecutorEnvironment
+
+        if self._review_only:
+            env = _review_scope_env()
+        else:
+            env = {
+                **_git_scope_env(),
+                "PSC_SLICE_ID": slice_id,
+                "PSC_REPO_ROOT": str(Path(__file__).resolve().parents[2]),
+            }
+            if self._relay_target is not None:
+                env["PSC_RELAY_TARGET"] = self._relay_target
+        # interpreter：job 以 `bash -lc` 啟動，其 python 由 env 的 PATH 決定，
+        # 因此以同一份 env 解析，而非用 manager 自己的 sys.executable。
+        interpreter = shutil.which("python3", path=env.get("PATH", "")) or shutil.which(
+            "python", path=env.get("PATH", "")
+        )
+        if self._review_only:
+            mode = "review-only"
+        elif self._read_only:
+            mode = "read-only"
+        else:
+            mode = "workspace-write"
+        return ExecutorEnvironment(
+            name=f"{self._executor}:{mode}",
+            interpreter=(interpreter,) if interpreter else (sys.executable,),
+            path=env.get("PATH", ""),
+            home=env.get("HOME", ""),
+            provider_identity=f"{self._executor}/{self._model}" if self._model else self._executor,
         )
 
     def launch(self, *, slice_id: str, prompt: str, worktree: str, log_dir: str) -> LaunchHandle:

--- a/paulsha_cortex/coordinator/manager.py
+++ b/paulsha_cortex/coordinator/manager.py
@@ -4948,7 +4948,14 @@ def _current_workflow_step(run):
     return pending[0] if pending else None
 
 
-def _select_workflow_identity(run, step, identities: IdentityRegistry):
+def _workflow_identity_candidates(run, step, identities: IdentityRegistry) -> list:
+    """依既有規則產生合格 identity 清單，順序即優先序。
+
+    #262：re-route 需要「次佳但合法」的候選，因此把原本只回傳 candidates[0]
+    的邏輯抽成清單。過濾條件（persona capability、independence domain）完全
+    不變——spec 明列「不改 identity 選擇順序與 independence domain 規則」。
+    """
+
     builder_domains = {
         item.domain
         for item in run.steps
@@ -4972,7 +4979,98 @@ def _select_workflow_identity(run, step, identities: IdentityRegistry):
                 candidates = preferred
     if not candidates:
         raise ValueError(f"no configured identity for workflow persona: {step.persona}")
-    return candidates[0]
+    return candidates
+
+
+def _select_workflow_identity(run, step, identities: IdentityRegistry):
+    return _workflow_identity_candidates(run, step, identities)[0]
+
+
+def _specialize_workflow_launcher(launcher, step):
+    """依 persona／commit policy 套用 launcher 的執行契約。
+
+    抽成函式是為了讓 #262 的 preflight 能取得「與正式 job 完全相同」的
+    launcher（進而是相同的 PATH／HOME／sandbox policy）。若 preflight 用未
+    specialize 的 launcher，reviewer 的最小 env 就不會被檢查到——那正是
+    design D2 說的安慰劑。
+    """
+
+    if step.persona == "planner":
+        read_only_factory = getattr(launcher, "as_read_only", None)
+        if not callable(read_only_factory):
+            raise ValueError("planner launcher lacks enforced read-only contract")
+        launcher = read_only_factory()
+    elif step.persona == "reviewer":
+        review_only_factory = getattr(launcher, "as_review_only", None)
+        if not callable(review_only_factory):
+            raise ValueError("reviewer launcher lacks enforced read-only contract")
+        terminal_kind = (
+            "workflow-verification-result"
+            if step.phase == "verify"
+            else "workflow-review-result"
+        )
+        launcher = review_only_factory(terminal_kind=terminal_kind)
+    effective_commit_policy = step.commit_policy or _LEGACY_CARD_EXECUTION.get(
+        step.card, (None, None, None, None)
+    )[2]
+    if effective_commit_policy == "required":
+        if step.persona != "builder":
+            raise ValueError("commit-required workflow card must use builder persona")
+        commit_required_factory = getattr(launcher, "as_commit_required", None)
+        if not callable(commit_required_factory):
+            raise ValueError("builder launcher lacks explicit commit-required capability")
+        launcher = commit_required_factory()
+    return launcher
+
+
+def _runtime_preflight_gate(run, step, *, identities: IdentityRegistry, launcher_factory):
+    """#262：dispatch 前的 runtime capability／provider 新鮮度 gate。
+
+    回傳 None 代表這張 card 未宣告任何 capability，呼叫端照原路徑走；否則回傳
+    `DispatchGateDecision`，其中 `launcher` 只在通過 preflight 的 identity 上建立
+    ——被擋下的 identity 不會產生任何 model session。
+    """
+
+    from .runtime_preflight import card_runtime_requirements, evaluate_dispatch_gate
+
+    try:
+        requirements = card_runtime_requirements(step.card)
+    except Exception:  # noqa: BLE001 - deck 載入問題不得把 dispatch 一起拖垮
+        return None
+    if not requirements:
+        return None
+
+    candidates = _workflow_identity_candidates(run, step, identities)
+
+    # 每個 identity 只 specialize 一次並記憶：preflight 與最終 dispatch 共用同一
+    # 個 launcher 實例，因此（a）檢查的環境就是 job 的環境，（b）通過的 identity
+    # 不會被重複套用 as_commit_required／as_review_only 等契約工廠。
+    specialized: dict[int, object] = {}
+
+    def _launcher_for(identity):
+        key = id(identity)
+        if key not in specialized:
+            specialized[key] = _specialize_workflow_launcher(launcher_factory(identity), step)
+        return specialized[key]
+
+    def _environment_for(identity):
+        launcher = _launcher_for(identity)
+        describe = getattr(launcher, "executor_environment", None)
+        if callable(describe):
+            return describe()
+        # launcher 未描述自身環境時退回 host 描述：仍會檢查，只是無法保證與正式
+        # job 完全一致；這是 fail-soft，不比 #262 之前更差。
+        from .runtime_preflight import host_environment
+
+        return host_environment()
+
+    return evaluate_dispatch_gate(
+        card=step.card,
+        requirements=requirements,
+        candidates=candidates,
+        environment_for=_environment_for,
+        launcher_factory=_launcher_for,
+    )
 
 
 _LEGACY_CARD_EXECUTION = {
@@ -5427,35 +5525,38 @@ def _dispatch_workflow_card(
                 **({"plan_review_passed": True} if plan_review_passed_now else {}),
             )
             return None
-    identity = _select_workflow_identity(run, step, identities)
-    launcher = launcher_factory(identity)
-    if launcher is None:
-        raise ValueError("workflow launcher unavailable")
-    if step.persona == "planner":
-        read_only_factory = getattr(launcher, "as_read_only", None)
-        if not callable(read_only_factory):
-            raise ValueError("planner launcher lacks enforced read-only contract")
-        launcher = read_only_factory()
-    elif step.persona == "reviewer":
-        review_only_factory = getattr(launcher, "as_review_only", None)
-        if not callable(review_only_factory):
-            raise ValueError("reviewer launcher lacks enforced read-only contract")
-        terminal_kind = (
-            "workflow-verification-result"
-            if step.phase == "verify"
-            else "workflow-review-result"
+    # #262 runtime preflight gate：在建立 worktree／sandbox／job row／model session
+    # 之前，於實際將被使用的 executor 環境驗證 card 宣告的 capability 與 provider
+    # 新鮮度。未宣告 capability 的 card 完全走原路徑（gate 為 no-op）。
+    gate = _runtime_preflight_gate(
+        run,
+        step,
+        identities=identities,
+        launcher_factory=launcher_factory,
+    )
+    if gate is not None and gate.action == "needs_human":
+        updated = registry._manager_update_workflow_run(
+            run.run_id,
+            facets=tuple(dict.fromkeys((*run.facets, "needs_human"))),
         )
-        launcher = review_only_factory(terminal_kind=terminal_kind)
-    effective_commit_policy = step.commit_policy or _LEGACY_CARD_EXECUTION.get(
-        step.card, (None, None, None, None)
-    )[2]
-    if effective_commit_policy == "required":
-        if step.persona != "builder":
-            raise ValueError("commit-required workflow card must use builder persona")
-        commit_required_factory = getattr(launcher, "as_commit_required", None)
-        if not callable(commit_required_factory):
-            raise ValueError("builder launcher lacks explicit commit-required capability")
-        launcher = commit_required_factory()
+        return {
+            "run_id": updated.run_id,
+            "current_phase": updated.current_phase,
+            "reason": f"runtime-preflight-{gate.result.outcome.value}",
+            "runtime_preflight": gate.to_dict(),
+        }
+    if gate is not None:
+        # gate.launcher 已由 _runtime_preflight_gate 套過執行契約，不再 specialize。
+        identity = gate.identity
+        launcher = gate.launcher
+        if launcher is None:
+            raise ValueError("workflow launcher unavailable")
+    else:
+        identity = _select_workflow_identity(run, step, identities)
+        launcher = launcher_factory(identity)
+        if launcher is None:
+            raise ValueError("workflow launcher unavailable")
+        launcher = _specialize_workflow_launcher(launcher, step)
     builder_jobs = [
         job
         for job in registry.list_jobs()

--- a/paulsha_cortex/coordinator/runtime_preflight.py
+++ b/paulsha_cortex/coordinator/runtime_preflight.py
@@ -1,0 +1,711 @@
+"""#262 dispatch 前的 runtime capability 與 provider 新鮮度驗證。
+
+設計依據 docs/superpowers/specs/dispatch-runtime-preflight-design.md：
+
+- D1 capability 以資料宣告，本模組是通用執行器，不為個別 card 寫分支。
+- D2 探測一律在「即將實際被使用的 executor environment」內進行；module 檢查
+  透過該環境的 interpreter 以子行程執行，executable 檢查只看該環境的 PATH。
+  絕不使用 manager 這側的 import 或 host PATH，否則會產生假通過（#262 的
+  pytest 在 host 有、在 Spark 隔離環境沒有，正是這個缺口）。
+- D3 provider 健康採「快照 + TTL + 有界 probe」三層。
+- D4 四種結果分開表達，不折疊為布林。
+- D5 preflight 失敗優先 re-route，其次 needs_human。
+- D6 probe 預算以 provider identity 為鍵，沿用 claim_readiness 的 TTL 快取模式。
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import time
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass, field
+from enum import Enum
+
+__all__ = [
+    "CAPABILITY_KINDS",
+    "DEFAULT_PROBE_TIMEOUT_SECONDS",
+    "DEFAULT_PROVIDER_TTL_SECONDS",
+    "CapabilityFinding",
+    "DispatchGateDecision",
+    "card_runtime_requirements",
+    "ExecutorEnvironment",
+    "PreflightOutcome",
+    "ProbeBudget",
+    "ProviderFreshness",
+    "RuntimeCapability",
+    "RuntimePreflightResult",
+    "evaluate_dispatch_gate",
+    "render_preflight_status",
+    "run_runtime_preflight",
+]
+
+
+# capability 宣告的 kind 白名單，對應 spec R1 列舉的四類。
+CAPABILITY_KINDS: tuple[str, ...] = ("module", "executable", "bridge", "provider")
+
+# provider snapshot 的預設 TTL；與 claim.PROVIDER_MAX_AGE_SECONDS 的 900 秒對齊。
+DEFAULT_PROVIDER_TTL_SECONDS = 900.0
+
+# 單次 capability 探測的 timeout（R4：探測必須有界）。
+DEFAULT_PROBE_TIMEOUT_SECONDS = 10.0
+
+# bridge 宣告名稱到「可用性如何判定」的資料表。bridge 依賴可能是一個
+# executable（socat／script），也可能是 interpreter 內的 module（pty／fcntl）。
+# 這仍是資料而非分支：新增 bridge 只需在此加一列。
+_BRIDGE_PROBES: Mapping[str, tuple[str, str]] = {
+    "pty": ("module", "pty"),
+    "fcntl": ("module", "fcntl"),
+    "termios": ("module", "termios"),
+    "socat": ("executable", "socat"),
+    "script": ("executable", "script"),
+    "tmux": ("executable", "tmux"),
+}
+
+
+class PreflightOutcome(str, Enum):
+    """D4：四種結果各自獨立，不折疊成「可用／不可用」布林。
+
+    四者的正確處置不同——capability missing 要修環境或 re-route；provider
+    unavailable 可等待或換 identity；stale snapshot 要刷新；probe inconclusive
+    不應被當成失敗。
+    """
+
+    OK = "ok"
+    CAPABILITY_MISSING = "capability_missing"
+    PROVIDER_UNAVAILABLE = "provider_unavailable"
+    STALE_SNAPSHOT = "stale_snapshot"
+    PROBE_INCONCLUSIVE = "probe_inconclusive"
+
+
+# 只有這兩種是 hard block；stale snapshot 要刷新、probe inconclusive 無定論，
+# 皆不得擋住 dispatch（見 spec R3 與 design D4）。
+_BLOCKING_OUTCOMES = frozenset(
+    {PreflightOutcome.CAPABILITY_MISSING, PreflightOutcome.PROVIDER_UNAVAILABLE}
+)
+
+# 彙總多筆 finding 時的嚴重度排序：越前面越優先成為整體 outcome。
+_OUTCOME_SEVERITY: tuple[PreflightOutcome, ...] = (
+    PreflightOutcome.CAPABILITY_MISSING,
+    PreflightOutcome.PROVIDER_UNAVAILABLE,
+    PreflightOutcome.STALE_SNAPSHOT,
+    PreflightOutcome.PROBE_INCONCLUSIVE,
+    PreflightOutcome.OK,
+)
+
+
+@dataclass(frozen=True)
+class RuntimeCapability:
+    """一項 capability 宣告（R1）。純資料，preflight 依 kind 逐項檢查。"""
+
+    kind: str
+    name: str
+    detail: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.kind not in CAPABILITY_KINDS:
+            raise ValueError(
+                f"unknown runtime capability kind: {self.kind!r} "
+                f"(expected one of {', '.join(CAPABILITY_KINDS)})"
+            )
+        if not isinstance(self.name, str) or not self.name.strip():
+            raise ValueError("runtime capability name must be a non-empty string")
+
+    @property
+    def token(self) -> str:
+        """穩定的機械可比對識別字串，例如 `module:pytest`。"""
+
+        return f"{self.kind}:{self.name}"
+
+    @classmethod
+    def parse(cls, spec: str) -> "RuntimeCapability":
+        """由 `<kind>:<name>` 字串解析宣告；card YAML 直接寫這個形式。"""
+
+        if not isinstance(spec, str) or ":" not in spec:
+            raise ValueError(f"runtime capability must look like '<kind>:<name>': {spec!r}")
+        kind, _, name = spec.partition(":")
+        return cls(kind.strip(), name.strip())
+
+    def to_dict(self) -> dict[str, object]:
+        payload: dict[str, object] = {"kind": self.kind, "name": self.name, "token": self.token}
+        if self.detail is not None:
+            payload["detail"] = self.detail
+        return payload
+
+
+@dataclass(frozen=True)
+class ExecutorEnvironment:
+    """D2：即將實際被使用的 executor 環境。
+
+    preflight 的探測必須經由這裡描述的 interpreter／PATH／HOME 進行，才能與
+    正式 job 一致；只檢查 host PATH 會產生假通過。
+    """
+
+    name: str
+    interpreter: tuple[str, ...]
+    path: str
+    home: str
+    provider_identity: str | None = None
+    extra_env: Mapping[str, str] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not self.interpreter:
+            raise ValueError("executor environment requires a non-empty interpreter argv")
+
+    def environ(self) -> dict[str, str]:
+        """正式 job 會看到的環境變數（sandbox policy 的具體展現）。"""
+
+        env = {"PATH": self.path, "HOME": self.home}
+        env.update(self.extra_env)
+        return env
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "name": self.name,
+            "interpreter": list(self.interpreter),
+            "path": self.path,
+            "home": self.home,
+            "provider_identity": self.provider_identity,
+        }
+
+
+@dataclass(frozen=True)
+class ProviderFreshness:
+    """R3：provider snapshot 的新鮮度語意（observed_at／TTL／source／reason）。"""
+
+    provider_id: str
+    status: str
+    observed_at: float
+    ttl_seconds: float = DEFAULT_PROVIDER_TTL_SECONDS
+    source: str = "snapshot"
+    reason: str | None = None
+
+    def age_seconds(self, *, now: float) -> float:
+        return float(now) - float(self.observed_at)
+
+    def is_fresh(self, *, now: float) -> bool:
+        age = self.age_seconds(now=now)
+        return 0.0 <= age <= float(self.ttl_seconds)
+
+    def to_dict(self, *, now: float | None = None) -> dict[str, object]:
+        payload: dict[str, object] = {
+            "provider_id": self.provider_id,
+            "status": self.status,
+            "observed_at": self.observed_at,
+            "ttl_seconds": self.ttl_seconds,
+            "source": self.source,
+            "reason": self.reason,
+        }
+        if now is not None:
+            payload["age_seconds"] = self.age_seconds(now=now)
+            payload["fresh"] = self.is_fresh(now=now)
+        return payload
+
+
+@dataclass
+class ProbeBudget:
+    """R4／D6：live probe 的 timeout／快取／rate-limit 預算，以 provider identity 為鍵。
+
+    沿用 `claim_readiness.LiveProbeCache` 的 TTL 快取模式，不另立一套：同一批次
+    內多張 card 需要同一 provider 時只探測一次，避免形成另一個昂貴 retry loop。
+    """
+
+    ttl_seconds: float = 300.0
+    timeout_seconds: float = DEFAULT_PROBE_TIMEOUT_SECONDS
+    max_probes: int = 4
+    now: Callable[[], float] = time.monotonic
+    _entries: dict[str, tuple[float, ProviderFreshness]] = field(default_factory=dict, repr=False)
+    _consumed: int = field(default=0, repr=False)
+
+    @property
+    def consumed(self) -> int:
+        return self._consumed
+
+    @property
+    def remaining(self) -> int:
+        return max(0, self.max_probes - self._consumed)
+
+    def peek(self, provider_id: str) -> ProviderFreshness | None:
+        entry = self._entries.get(provider_id)
+        if entry is None:
+            return None
+        stored_at, value = entry
+        if self.now() - stored_at > self.ttl_seconds:
+            self._entries.pop(provider_id, None)
+            return None
+        return value
+
+    def store(self, provider_id: str, value: ProviderFreshness) -> None:
+        self._entries[provider_id] = (self.now(), value)
+
+    def consume(self) -> bool:
+        """扣一次 rate-limit 額度；額度耗盡時回傳 False（不再探測）。"""
+
+        if self._consumed >= self.max_probes:
+            return False
+        self._consumed += 1
+        return True
+
+
+@dataclass(frozen=True)
+class CapabilityFinding:
+    """單一 capability 宣告的檢查結果。"""
+
+    capability: RuntimeCapability
+    outcome: PreflightOutcome
+    reason: str
+    freshness: ProviderFreshness | None = None
+
+    @property
+    def satisfied(self) -> bool:
+        return self.outcome is PreflightOutcome.OK
+
+    def to_dict(self, *, now: float | None = None) -> dict[str, object]:
+        return {
+            "capability": self.capability.to_dict(),
+            "token": self.capability.token,
+            "outcome": self.outcome.value,
+            "reason": self.reason,
+            "freshness": None if self.freshness is None else self.freshness.to_dict(now=now),
+        }
+
+
+@dataclass(frozen=True)
+class RuntimePreflightResult:
+    """一個 (card, identity, environment) 組合的 preflight 結果。"""
+
+    card: str
+    identity_token: str
+    environment: ExecutorEnvironment
+    findings: tuple[CapabilityFinding, ...]
+    checked_at: float
+
+    @property
+    def outcome(self) -> PreflightOutcome:
+        """彙總為單一 outcome，但四種結果仍各自可辨識（D4）。"""
+
+        present = {finding.outcome for finding in self.findings}
+        for candidate in _OUTCOME_SEVERITY:
+            if candidate in present:
+                return candidate
+        return PreflightOutcome.OK
+
+    @property
+    def outcomes(self) -> tuple[PreflightOutcome, ...]:
+        return tuple(dict.fromkeys(finding.outcome for finding in self.findings))
+
+    @property
+    def blocking(self) -> bool:
+        return any(finding.outcome in _BLOCKING_OUTCOMES for finding in self.findings)
+
+    @property
+    def missing_capabilities(self) -> tuple[str, ...]:
+        return tuple(
+            finding.capability.token
+            for finding in self.findings
+            if finding.outcome is PreflightOutcome.CAPABILITY_MISSING
+        )
+
+    @property
+    def unavailable_providers(self) -> tuple[str, ...]:
+        return tuple(
+            finding.capability.name
+            for finding in self.findings
+            if finding.outcome is PreflightOutcome.PROVIDER_UNAVAILABLE
+        )
+
+    @property
+    def provider_freshness(self) -> tuple[ProviderFreshness, ...]:
+        return tuple(f.freshness for f in self.findings if f.freshness is not None)
+
+    def blocking_reason(self) -> str | None:
+        """R2：可操作的具體原因，指出缺哪些 capability／哪個 provider 不可用。"""
+
+        if not self.blocking:
+            return None
+        parts: list[str] = []
+        if self.missing_capabilities:
+            parts.append("missing capabilities: " + ", ".join(self.missing_capabilities))
+        if self.unavailable_providers:
+            parts.append("providers unavailable: " + ", ".join(self.unavailable_providers))
+        return f"[{self.identity_token} @ {self.environment.name}] " + "; ".join(parts)
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "card": self.card,
+            "identity": self.identity_token,
+            "outcome": self.outcome.value,
+            "outcomes": [item.value for item in self.outcomes],
+            "blocking": self.blocking,
+            "checked_at": self.checked_at,
+            "executor_environment": self.environment.to_dict(),
+            "missing_capabilities": list(self.missing_capabilities),
+            "unavailable_providers": list(self.unavailable_providers),
+            "findings": [f.to_dict(now=self.checked_at) for f in self.findings],
+            "provider_freshness": [
+                item.to_dict(now=self.checked_at) for item in self.provider_freshness
+            ],
+        }
+
+
+# --------------------------------------------------------------- 探測基本動作
+
+
+def _probe_module(
+    environment: ExecutorEnvironment, module: str, *, timeout_seconds: float
+) -> tuple[bool, str]:
+    """在 executor 的 interpreter 內以子行程 import；不得用 manager 這側的 import。"""
+
+    argv = [*environment.interpreter, "-c", f"import importlib; importlib.import_module({module!r})"]
+    try:
+        completed = subprocess.run(  # noqa: S603 - argv 為內部組裝，非 shell
+            argv,
+            env=environment.environ(),
+            capture_output=True,
+            text=True,
+            timeout=timeout_seconds,
+            check=False,
+        )
+    except FileNotFoundError:
+        return False, f"executor interpreter not found: {environment.interpreter[0]}"
+    except subprocess.TimeoutExpired:
+        return False, f"module probe timed out after {timeout_seconds}s"
+    if completed.returncode == 0:
+        return True, "importable in executor interpreter"
+    detail = (completed.stderr or "").strip().splitlines()
+    tail = detail[-1] if detail else f"exit {completed.returncode}"
+    return False, f"not importable in executor interpreter: {tail}"
+
+
+def _probe_executable(environment: ExecutorEnvironment, name: str) -> tuple[bool, str]:
+    """只查 executor 環境的 PATH；host PATH 不參與判定（spec R2）。"""
+
+    resolved = shutil.which(name, path=environment.path)
+    if resolved:
+        return True, f"resolved on executor PATH: {resolved}"
+    return False, f"not on executor PATH ({environment.path or '<empty>'})"
+
+
+def _probe_bridge(
+    environment: ExecutorEnvironment, name: str, *, timeout_seconds: float
+) -> tuple[bool, str]:
+    kind, target = _BRIDGE_PROBES.get(name, ("executable", name))
+    if kind == "module":
+        return _probe_module(environment, target, timeout_seconds=timeout_seconds)
+    return _probe_executable(environment, target)
+
+
+def _resolve_provider_freshness(
+    provider_id: str,
+    *,
+    snapshot_lookup: Callable[[str], ProviderFreshness | None] | None,
+    provider_prober: Callable[[str], ProviderFreshness | None] | None,
+    budget: ProbeBudget | None,
+    now: float,
+) -> tuple[PreflightOutcome, str, ProviderFreshness | None]:
+    """D3：快照 + TTL + 有界 probe 三層。"""
+
+    snapshot = snapshot_lookup(provider_id) if snapshot_lookup is not None else None
+    if snapshot is None:
+        return (
+            PreflightOutcome.STALE_SNAPSHOT,
+            "no provider snapshot available",
+            None,
+        )
+
+    if snapshot.is_fresh(now=now):
+        # TTL 內的快照即當前事實，直接採信，不付出探測成本。
+        if snapshot.status == "ok":
+            return PreflightOutcome.OK, "provider snapshot fresh and ok", snapshot
+        return (
+            PreflightOutcome.PROVIDER_UNAVAILABLE,
+            f"provider {snapshot.status}: {snapshot.reason or 'no reason recorded'}",
+            snapshot,
+        )
+
+    # 逾期。#262 的教訓：stale 的 degraded 判斷不得被當成當前事實。
+    age = snapshot.age_seconds(now=now)
+    stale_reason = (
+        f"snapshot stale ({age:.0f}s > ttl {snapshot.ttl_seconds:.0f}s); "
+        f"last recorded status={snapshot.status} reason={snapshot.reason or 'none'}"
+    )
+    if provider_prober is None:
+        return PreflightOutcome.STALE_SNAPSHOT, stale_reason, snapshot
+
+    active_budget = budget if budget is not None else ProbeBudget()
+    cached = active_budget.peek(provider_id)
+    if cached is not None:
+        # 同批次同 provider：走快取，不重複探測（D6）。
+        if cached.status == "ok":
+            return PreflightOutcome.OK, "provider live probe ok (cached)", cached
+        return (
+            PreflightOutcome.PROVIDER_UNAVAILABLE,
+            f"provider live probe {cached.status} (cached): {cached.reason or 'no reason'}",
+            cached,
+        )
+
+    if not active_budget.consume():
+        return (
+            PreflightOutcome.PROBE_INCONCLUSIVE,
+            f"live probe budget exhausted ({active_budget.max_probes} probes); {stale_reason}",
+            snapshot,
+        )
+
+    try:
+        probed = provider_prober(provider_id)
+    except Exception as exc:  # noqa: BLE001 - 探測失敗一律歸為無定論，不當成失敗
+        return (
+            PreflightOutcome.PROBE_INCONCLUSIVE,
+            f"live probe inconclusive: {type(exc).__name__}: {exc}",
+            snapshot,
+        )
+    if probed is None:
+        return (
+            PreflightOutcome.PROBE_INCONCLUSIVE,
+            f"live probe returned no verdict; {stale_reason}",
+            snapshot,
+        )
+
+    active_budget.store(provider_id, probed)
+    if probed.status == "ok":
+        return PreflightOutcome.OK, "provider live probe ok", probed
+    return (
+        PreflightOutcome.PROVIDER_UNAVAILABLE,
+        f"provider live probe {probed.status}: {probed.reason or 'no reason'}",
+        probed,
+    )
+
+
+# ---------------------------------------------------------------- card 宣告讀取
+
+
+def card_runtime_requirements(
+    card_id: str, *, cards: Mapping[str, object] | None = None
+) -> tuple[RuntimeCapability, ...]:
+    """讀出某張 card 的 capability 宣告（R1：資料驅動）。
+
+    未宣告或查無此 card 時回傳空 tuple——preflight 對它是 no-op，行為與
+    #262 之前完全相同，因此加宣告是純增量、不會回頭影響既有 card。
+    """
+
+    if cards is None:
+        from paulsha_cortex.deck.schema import DEFAULT_CARDS_PATH, load_cards
+
+        cards = load_cards(DEFAULT_CARDS_PATH)
+    card = cards.get(card_id)
+    if card is None:
+        return ()
+    declared = getattr(card, "runtime_capabilities", ())
+    return tuple(RuntimeCapability.parse(token) for token in declared)
+
+
+# ------------------------------------------------------------------ 通用執行器
+
+
+def run_runtime_preflight(
+    *,
+    card: str,
+    requirements: Sequence[RuntimeCapability],
+    identity: object,
+    environment: ExecutorEnvironment,
+    snapshot_lookup: Callable[[str], ProviderFreshness | None] | None = None,
+    provider_prober: Callable[[str], ProviderFreshness | None] | None = None,
+    budget: ProbeBudget | None = None,
+    now: float | None = None,
+) -> RuntimePreflightResult:
+    """依 card 的 capability 宣告逐項檢查（R1 資料驅動，R2 在 executor 環境內）。"""
+
+    checked_at = time.time() if now is None else float(now)
+    timeout_seconds = budget.timeout_seconds if budget is not None else DEFAULT_PROBE_TIMEOUT_SECONDS
+    findings: list[CapabilityFinding] = []
+
+    for capability in requirements:
+        if capability.kind == "module":
+            ok, reason = _probe_module(environment, capability.name, timeout_seconds=timeout_seconds)
+            outcome = PreflightOutcome.OK if ok else PreflightOutcome.CAPABILITY_MISSING
+            findings.append(CapabilityFinding(capability, outcome, reason))
+        elif capability.kind == "executable":
+            ok, reason = _probe_executable(environment, capability.name)
+            outcome = PreflightOutcome.OK if ok else PreflightOutcome.CAPABILITY_MISSING
+            findings.append(CapabilityFinding(capability, outcome, reason))
+        elif capability.kind == "bridge":
+            ok, reason = _probe_bridge(environment, capability.name, timeout_seconds=timeout_seconds)
+            outcome = PreflightOutcome.OK if ok else PreflightOutcome.CAPABILITY_MISSING
+            findings.append(CapabilityFinding(capability, outcome, reason))
+        else:  # provider —— kind 白名單已由 RuntimeCapability 保證
+            outcome, reason, freshness = _resolve_provider_freshness(
+                capability.name,
+                snapshot_lookup=snapshot_lookup,
+                provider_prober=provider_prober,
+                budget=budget,
+                now=checked_at,
+            )
+            findings.append(CapabilityFinding(capability, outcome, reason, freshness))
+
+    return RuntimePreflightResult(
+        card=card,
+        identity_token=_identity_token(identity),
+        environment=environment,
+        findings=tuple(findings),
+        checked_at=checked_at,
+    )
+
+
+def _identity_token(identity: object) -> str:
+    executor = getattr(identity, "executor", None)
+    model_id = getattr(identity, "model_id", None)
+    if executor and model_id:
+        return f"{executor}/{model_id}"
+    return str(identity)
+
+
+# ------------------------------------------------------------------ dispatch gate
+
+
+@dataclass(frozen=True)
+class DispatchGateDecision:
+    """D5：preflight 失敗優先 re-route，其次 needs_human。
+
+    `model_invocations` 恆為 0——這個 gate 位於 model session 建立之前，
+    本身永遠不會啟動任何模型。
+    """
+
+    action: str
+    identity: object | None
+    reason: str | None
+    result: RuntimePreflightResult
+    attempts: tuple[RuntimePreflightResult, ...]
+    launcher: object | None = None
+    model_invocations: int = 0
+
+    @property
+    def blocked(self) -> bool:
+        return self.action == "needs_human"
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "action": self.action,
+            "identity": None if self.identity is None else _identity_token(self.identity),
+            "reason": self.reason,
+            "model_invocations": self.model_invocations,
+            "missing_capabilities": list(
+                dict.fromkeys(
+                    token for attempt in self.attempts for token in attempt.missing_capabilities
+                )
+            ),
+            "result": self.result.to_dict(),
+            "attempts": [attempt.to_dict() for attempt in self.attempts],
+        }
+
+
+def evaluate_dispatch_gate(
+    *,
+    card: str,
+    requirements: Sequence[RuntimeCapability],
+    candidates: Sequence[object],
+    environment_for: Callable[[object], ExecutorEnvironment],
+    launcher_factory: Callable[[object], object] | None = None,
+    snapshot_lookup: Callable[[str], ProviderFreshness | None] | None = None,
+    provider_prober: Callable[[str], ProviderFreshness | None] | None = None,
+    budget: ProbeBudget | None = None,
+    now: float | None = None,
+) -> DispatchGateDecision:
+    """在建立 model session 之前決定 dispatch／re-route／needs_human。
+
+    `candidates` 由呼叫端以既有的 identity 選擇規則產生並保持原順序——本 gate
+    不改選擇順序，也不放寬 independence domain 規則（spec 非目標），只是在
+    既有順序上略過 preflight 失敗者。
+    """
+
+    if not candidates:
+        raise ValueError("dispatch gate requires at least one identity candidate")
+
+    attempts: list[RuntimePreflightResult] = []
+    active_budget = budget if budget is not None else ProbeBudget()
+
+    for index, identity in enumerate(candidates):
+        result = run_runtime_preflight(
+            card=card,
+            requirements=requirements,
+            identity=identity,
+            environment=environment_for(identity),
+            snapshot_lookup=snapshot_lookup,
+            provider_prober=provider_prober,
+            budget=active_budget,
+            now=now,
+        )
+        attempts.append(result)
+        if result.blocking:
+            continue
+        # 通過：到這裡才允許建立 launcher／model session。
+        launcher = None if launcher_factory is None else launcher_factory(identity)
+        return DispatchGateDecision(
+            action="dispatch" if index == 0 else "reroute",
+            identity=identity,
+            reason=None if index == 0 else "capability-missing-rerouted",
+            result=result,
+            attempts=tuple(attempts),
+            launcher=launcher,
+        )
+
+    # 全部 candidate 都被擋下 → needs_human，reason 必須具體可操作。
+    reasons = [attempt.blocking_reason() for attempt in attempts]
+    reason = "runtime preflight blocked all candidates -- " + " | ".join(
+        item for item in reasons if item
+    )
+    return DispatchGateDecision(
+        action="needs_human",
+        identity=None,
+        reason=reason,
+        result=attempts[-1],
+        attempts=tuple(attempts),
+    )
+
+
+# ------------------------------------------------------------------ R5 可觀測
+
+
+def render_preflight_status(payload: Mapping[str, object]) -> list[str]:
+    """把 gate decision 的 payload 轉成 status／inspect 可印的文字行。
+
+    顯示缺少的 capability、使用中的 executor environment 與 snapshot 新鮮度。
+    """
+
+    lines = [f"runtime-preflight: {payload.get('action', 'unknown')}"]
+    reason = payload.get("reason")
+    if reason:
+        lines.append(f"  reason: {reason}")
+    missing = payload.get("missing_capabilities") or []
+    if missing:
+        lines.append(f"  missing capabilities: {', '.join(str(item) for item in missing)}")
+    attempts = payload.get("attempts") or []
+    for attempt in attempts:  # type: ignore[union-attr]
+        env = attempt.get("executor_environment", {})
+        lines.append(
+            f"  [{attempt.get('identity')}] env={env.get('name')} "
+            f"interpreter={' '.join(env.get('interpreter', []))} "
+            f"PATH={env.get('path')} HOME={env.get('home')} -> {attempt.get('outcome')}"
+        )
+        for freshness in attempt.get("provider_freshness", []) or []:
+            lines.append(
+                f"    provider {freshness.get('provider_id')}: status={freshness.get('status')} "
+                f"source={freshness.get('source')} age={freshness.get('age_seconds')}s "
+                f"ttl={freshness.get('ttl_seconds')}s fresh={freshness.get('fresh')} "
+                f"reason={freshness.get('reason')}"
+            )
+    return lines
+
+
+def host_environment(*, name: str = "host", provider_identity: str | None = None) -> ExecutorEnvironment:
+    """僅供 fallback：當 card 未宣告專屬 executor 環境時的 host 描述。"""
+
+    import sys
+
+    return ExecutorEnvironment(
+        name=name,
+        interpreter=(sys.executable,),
+        path=os.environ.get("PATH", ""),
+        home=os.path.expanduser("~"),
+        provider_identity=provider_identity,
+    )

--- a/paulsha_cortex/deck/data/cards.yaml
+++ b/paulsha_cortex/deck/data/cards.yaml
@@ -75,6 +75,8 @@ cards:
       action: "以 accepted plan 為唯一需求來源，新增可重現缺口的 RED regression test"
       commit_policy: required
       test_policy: red-required
+    # #262：RED 證據需要在 executor 環境內實際跑 pytest。
+    runtime_capabilities: ["module:pytest"]
 
   - id: subagent-build
     kind: skill
@@ -90,6 +92,8 @@ cards:
       action: "依 accepted plan 以最小 diff 實作，讓 RED test 轉綠並提交候選 HEAD"
       commit_policy: required
       test_policy: focused
+    # #262：轉綠判定需要在 executor 環境內實際跑 pytest。
+    runtime_capabilities: ["module:pytest"]
 
   - id: code-review
     kind: skill
@@ -110,6 +114,8 @@ cards:
     requires: []
     produces: ["reports/verify/*<task-slug>*.md"]
     persona_binding: reviewer
+    # #262：verification 要在 executor 環境內跑完整套件。
+    runtime_capabilities: ["module:pytest"]
 
   - id: openspec-archive
     kind: skill

--- a/paulsha_cortex/deck/schema.py
+++ b/paulsha_cortex/deck/schema.py
@@ -37,8 +37,14 @@ _CARD_KEYS = frozenset(
         "provider_binding",
         "slice_group",
         "execution",
+        "runtime_capabilities",
     }
 )
+# #262 R1：card 以資料宣告執行所需 runtime capability，形式為 `<kind>:<name>`
+# （例：`module:pytest`、`executable:socat`）。新增 card 只需寫這份宣告，
+# 不必修改 preflight 實作。kind 白名單與
+# coordinator.runtime_preflight.CAPABILITY_KINDS 為同一組值。
+RUNTIME_CAPABILITY_KINDS = ("module", "executable", "bridge", "provider")
 _EXECUTION_KEYS = frozenset({"action", "commit_policy", "test_policy"})
 _COMBO_FILE_KEYS = frozenset({"combo"})
 _COMBO_KEYS = frozenset({"id", "task_type", "cards", "gate_spine", "band_triggered"})
@@ -74,6 +80,8 @@ class Card:
     action: str | None = None
     commit_policy: str | None = None
     test_policy: str | None = None
+    # #262 R1：dispatch 前 preflight 依這份宣告逐項檢查。
+    runtime_capabilities: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -227,6 +235,20 @@ def load_cards(path: str | Path) -> dict[str, Card]:
         slice_group = rec.get("slice_group")
         if slice_group is not None and (not isinstance(slice_group, str) or not slice_group):
             rec_errors.append(f"{cid}: slice_group 必須為非空字串")
+        runtime_capabilities = _str_tuple(
+            rec.get("runtime_capabilities"), cid, "runtime_capabilities", rec_errors
+        )
+        # fail-closed：宣告格式錯誤（未知 kind／空 name）在載入時就擋下，
+        # 避免無聲漏檢——漏掉一項宣告等於退回 #262 的現狀。
+        for token in runtime_capabilities:
+            kind_part, sep, name_part = token.partition(":")
+            if not sep or kind_part not in RUNTIME_CAPABILITY_KINDS or not name_part.strip():
+                rec_errors.append(
+                    f"{cid}: runtime_capabilities 非法值 {token!r}"
+                    f"（須為 <kind>:<name>，kind ∈ {'/'.join(RUNTIME_CAPABILITY_KINDS)}）"
+                )
+        if len(set(runtime_capabilities)) != len(runtime_capabilities):
+            rec_errors.append(f"{cid}: runtime_capabilities 有重複宣告")
         if rec_errors:
             errors.extend(rec_errors)
             continue
@@ -245,6 +267,7 @@ def load_cards(path: str | Path) -> dict[str, Card]:
             action=action,
             commit_policy=commit_policy,
             test_policy=test_policy,
+            runtime_capabilities=runtime_capabilities,
         )
     if errors:
         raise DeckSchemaError(f"cards 驗證失敗: {source}: " + "; ".join(errors))

--- a/paulsha_cortex/porcelain/inspect.py
+++ b/paulsha_cortex/porcelain/inspect.py
@@ -90,6 +90,13 @@ def _print_status(status: dict[str, Any]) -> None:
     sys.stdout.write(
         "recent_done: " + json.dumps(status.get("recent_done", []), ensure_ascii=False, sort_keys=True) + "\n"
     )
+    # #262 R5：顯示缺少的 capability、使用中的 executor environment 與 snapshot 新鮮度。
+    preflight = status.get("runtime_preflight")
+    if preflight:
+        from paulsha_cortex.coordinator.runtime_preflight import render_preflight_status
+
+        for line in render_preflight_status(preflight):
+            sys.stdout.write(line + "\n")
 
 
 def _print_job(job: dict[str, Any]) -> None:

--- a/tests/test_dispatch_runtime_preflight.py
+++ b/tests/test_dispatch_runtime_preflight.py
@@ -1,0 +1,773 @@
+"""#262 dispatch runtime preflight 的行為測試。
+
+每個測試對應 docs/superpowers/specs/dispatch-runtime-preflight-spec.md 的
+Requirement（R1~R5），斷言 Requirement 的語意而非欄位存在性。
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import shutil
+import stat
+import sys
+
+import pytest
+
+from paulsha_cortex.coordinator.model_identities import ModelIdentity
+from paulsha_cortex.coordinator.runtime_preflight import (
+    CAPABILITY_KINDS,
+    DispatchGateDecision,
+    ExecutorEnvironment,
+    PreflightOutcome,
+    ProbeBudget,
+    ProviderFreshness,
+    RuntimeCapability,
+    evaluate_dispatch_gate,
+    run_runtime_preflight,
+)
+
+
+# ---------------------------------------------------------------- 共用 fixture
+
+
+def _executable(directory, name: str) -> str:
+    """在 directory 內造一個可執行的 stub，回傳其路徑。"""
+
+    target = directory / name
+    target.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    target.chmod(target.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    return str(target)
+
+
+def _host_env(tmp_path, **overrides) -> ExecutorEnvironment:
+    """與 host 一致的 executor 環境（模組確實可 import、PATH 為 host PATH）。"""
+
+    params = {
+        "name": "host-parity",
+        "interpreter": (sys.executable,),
+        "path": os.environ.get("PATH", ""),
+        # 必須沿用真實 HOME：pytest 裝在 user-site（$HOME/.local），換掉 HOME
+        # 就等於換了一個 executor 環境，那是 _isolated_env 的工作。
+        "home": os.path.expanduser("~"),
+        "provider_identity": None,
+    }
+    params.update(overrides)
+    return ExecutorEnvironment(**params)
+
+
+def _isolated_env(tmp_path, **overrides) -> ExecutorEnvironment:
+    """模擬 Spark 隔離環境：真實 interpreter 但看不到 host site-packages。
+
+    `python3 -I -S` 會停用 site 模組，因此 host site-packages 內的套件
+    （例如 pytest）在此 interpreter 下無法 import——這正是 #262 的情境。
+    """
+
+    params = {
+        "name": "isolated-executor",
+        "interpreter": (sys.executable, "-I", "-S"),
+        "path": str(tmp_path / "empty-bin"),
+        "home": str(tmp_path / "sandbox-home"),
+        "provider_identity": None,
+    }
+    params.update(overrides)
+    (tmp_path / "empty-bin").mkdir(exist_ok=True)
+    return ExecutorEnvironment(**params)
+
+
+class _CountingLauncherFactory:
+    """記錄 model session 建立次數；preflight 攔截時必須維持 0。"""
+
+    def __init__(self) -> None:
+        self.model_invocations = 0
+
+    def __call__(self, identity):  # pragma: no cover - 被呼叫即代表測試失敗
+        self.model_invocations += 1
+        return object()
+
+
+_BUILDER = ModelIdentity(
+    executor="claude",
+    model_id="opus-5",
+    independence_domain="anthropic",
+    capabilities=("build",),
+)
+_ALT_BUILDER = ModelIdentity(
+    executor="codex",
+    model_id="gpt-5.4",
+    independence_domain="openai",
+    capabilities=("build",),
+)
+
+
+# ------------------------------------------------------------------ R1 / R2
+
+
+def test_missing_module_blocks_dispatch_with_zero_model_calls(tmp_path):
+    """R2：executor 環境缺 module 時在 dispatch 前攔截，model invocation 維持 0。"""
+
+    factory = _CountingLauncherFactory()
+    decision = evaluate_dispatch_gate(
+        card="tdd-red",
+        requirements=(RuntimeCapability("module", "pytest"),),
+        candidates=(_BUILDER,),
+        environment_for=lambda identity: _isolated_env(tmp_path),
+        launcher_factory=factory,
+    )
+
+    assert isinstance(decision, DispatchGateDecision)
+    assert decision.action == "needs_human"
+    assert decision.identity is None
+    # 語意斷言：確實判為 capability missing，而非泛用失敗。
+    assert decision.result.outcome is PreflightOutcome.CAPABILITY_MISSING
+    assert "module:pytest" in decision.result.missing_capabilities
+    # 核心驗收：完全沒有建立 model session。
+    assert factory.model_invocations == 0
+    assert decision.model_invocations == 0
+
+
+def test_missing_executable_blocks_dispatch(tmp_path):
+    """R2：reviewer sandbox 缺 socat 時同樣在 dispatch 前攔截。"""
+
+    assert shutil.which("sh") is not None, "host 必須有 sh 才能驗證 PATH 隔離語意"
+
+    factory = _CountingLauncherFactory()
+    decision = evaluate_dispatch_gate(
+        card="requesting-code-review",
+        requirements=(RuntimeCapability("executable", "socat"),),
+        candidates=(_BUILDER,),
+        environment_for=lambda identity: _isolated_env(tmp_path),
+        launcher_factory=factory,
+    )
+
+    assert decision.action == "needs_human"
+    assert decision.result.outcome is PreflightOutcome.CAPABILITY_MISSING
+    assert "executable:socat" in decision.result.missing_capabilities
+    assert factory.model_invocations == 0
+
+    # 對照組：把 socat stub 放進 executor 環境的 PATH 後必須放行，
+    # 證明判定依據是 executor PATH 而非「一律失敗」。
+    bindir = tmp_path / "with-socat"
+    bindir.mkdir()
+    _executable(bindir, "socat")
+    ok_factory = _CountingLauncherFactory()
+    ok_decision = evaluate_dispatch_gate(
+        card="requesting-code-review",
+        requirements=(RuntimeCapability("executable", "socat"),),
+        candidates=(_BUILDER,),
+        environment_for=lambda identity: _isolated_env(tmp_path, path=str(bindir)),
+        launcher_factory=ok_factory,
+    )
+    assert ok_decision.action == "dispatch"
+    assert ok_decision.result.outcome is PreflightOutcome.OK
+    assert ok_factory.model_invocations == 1
+
+
+def test_preflight_uses_executor_environment_not_host(tmp_path):
+    """R2：host 有而 executor 環境沒有的 module，必須判為缺失。
+
+    這是 #262 的核心——不得因為 manager 這側 import 得到就放行。
+    """
+
+    # 前提：host（跑測試的這個 interpreter）確實有 pytest。
+    assert importlib.util.find_spec("pytest") is not None
+
+    host_result = run_runtime_preflight(
+        card="tdd-red",
+        requirements=(RuntimeCapability("module", "pytest"),),
+        identity=_BUILDER,
+        environment=_host_env(tmp_path),
+    )
+    assert host_result.outcome is PreflightOutcome.OK, "host 環境應該通過"
+
+    # 同一個宣告，改在隔離 executor 環境檢查 → 必須判為缺失。
+    isolated_result = run_runtime_preflight(
+        card="tdd-red",
+        requirements=(RuntimeCapability("module", "pytest"),),
+        identity=_BUILDER,
+        environment=_isolated_env(tmp_path),
+    )
+    assert isolated_result.outcome is PreflightOutcome.CAPABILITY_MISSING
+    assert isolated_result.missing_capabilities == ("module:pytest",)
+
+    # 進一步隔離變因：只改 interpreter（HOME／PATH 與 host 相同）也必須判為缺失，
+    # 證明判定確實經由 executor 的 interpreter，而非 manager 這側的 import。
+    interpreter_only = run_runtime_preflight(
+        card="tdd-red",
+        requirements=(RuntimeCapability("module", "pytest"),),
+        identity=_BUILDER,
+        environment=_host_env(
+            tmp_path, name="interpreter-only", interpreter=(sys.executable, "-I", "-S")
+        ),
+    )
+    assert interpreter_only.outcome is PreflightOutcome.CAPABILITY_MISSING
+
+    # R5：結果必須指出實際使用的 executor environment，而非 host。
+    described = isolated_result.to_dict()["executor_environment"]
+    assert described["name"] == "isolated-executor"
+    assert described["interpreter"] == [sys.executable, "-I", "-S"]
+    assert described["path"] == str(tmp_path / "empty-bin")
+    assert described["home"] == str(tmp_path / "sandbox-home")
+
+
+def test_card_capability_declaration_is_data_driven(tmp_path):
+    """R1：新增 card 的宣告只是資料，不需修改 preflight 實作。"""
+
+    # 四種 kind 都必須被通用執行器涵蓋。
+    assert set(CAPABILITY_KINDS) == {"module", "executable", "bridge", "provider"}
+
+    # 一張「新 card」用資料宣告兩項需求，preflight 逐項檢查。
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    _executable(bindir, "socat")
+    requirements = tuple(
+        RuntimeCapability.parse(token)
+        for token in ("module:json", "executable:socat")
+    )
+    result = run_runtime_preflight(
+        card="a-brand-new-card",
+        requirements=requirements,
+        identity=_BUILDER,
+        environment=_host_env(tmp_path, path=str(bindir)),
+    )
+    assert result.outcome is PreflightOutcome.OK
+    # 逐項檢查：兩項宣告各自產生一筆 finding。
+    assert tuple(f.capability.token for f in result.findings) == (
+        "module:json",
+        "executable:socat",
+    )
+
+    # 換一個 kind 也不需改實作：bridge 宣告同樣被通用執行器涵蓋。
+    empty = tmp_path / "nothing"
+    empty.mkdir()
+    bridge_missing = run_runtime_preflight(
+        card="a-brand-new-card",
+        requirements=(RuntimeCapability("bridge", "socat"),),
+        identity=_BUILDER,
+        environment=_host_env(tmp_path, path=str(empty)),
+    )
+    assert bridge_missing.outcome is PreflightOutcome.CAPABILITY_MISSING
+    assert bridge_missing.missing_capabilities == ("bridge:socat",)
+
+    # bridge 也可以由 interpreter 內的 module 支撐（pty 是 stdlib）。
+    bridge_ok = run_runtime_preflight(
+        card="a-brand-new-card",
+        requirements=(RuntimeCapability("bridge", "pty"),),
+        identity=_BUILDER,
+        environment=_host_env(tmp_path, path=str(empty)),
+    )
+    assert bridge_ok.outcome is PreflightOutcome.OK
+
+
+# ------------------------------------------------------------------------ R3
+
+
+def test_stale_degraded_snapshot_is_not_hard_block(tmp_path):
+    """R3：超過 TTL 的 degraded 快照不得被當成當前事實。"""
+
+    stale = ProviderFreshness(
+        provider_id="github:hamanpaul/paulsha-cortex",
+        status="degraded",
+        observed_at=1000.0,
+        ttl_seconds=900.0,
+        source="snapshot",
+        reason="github rate limit exceeded",
+    )
+    now = 1000.0 + 5000.0  # 遠超 TTL
+    assert stale.is_fresh(now=now) is False
+
+    probe_calls: list[str] = []
+
+    def _probe(provider_id: str) -> ProviderFreshness:
+        probe_calls.append(provider_id)
+        return ProviderFreshness(
+            provider_id=provider_id,
+            status="ok",
+            observed_at=now,
+            ttl_seconds=900.0,
+            source="live-probe",
+            reason=None,
+        )
+
+    result = run_runtime_preflight(
+        card="workflow-claim",
+        requirements=(RuntimeCapability("provider", "github:hamanpaul/paulsha-cortex"),),
+        identity=_BUILDER,
+        environment=_host_env(tmp_path),
+        snapshot_lookup=lambda pid: stale,
+        provider_prober=_probe,
+        budget=ProbeBudget(now=lambda: now),
+        now=now,
+    )
+
+    # 語意：stale 的 degraded 被 live probe 覆蓋，最終判定為可用。
+    assert result.outcome is PreflightOutcome.OK
+    assert probe_calls == ["github:hamanpaul/paulsha-cortex"]
+    # 且必須留下新鮮度證據，來源是 live probe 而非 stale snapshot。
+    freshness = result.to_dict()["provider_freshness"]
+    assert freshness[0]["source"] == "live-probe"
+    assert freshness[0]["status"] == "ok"
+
+    # 對照：同樣是 degraded 但仍在 TTL 內 → 才是當前事實，硬擋且不 probe。
+    fresh_calls: list[str] = []
+    fresh = ProviderFreshness(
+        provider_id="github:hamanpaul/paulsha-cortex",
+        status="degraded",
+        observed_at=now - 10.0,
+        ttl_seconds=900.0,
+        source="snapshot",
+        reason="github rate limit exceeded",
+    )
+    fresh_result = run_runtime_preflight(
+        card="workflow-claim",
+        requirements=(RuntimeCapability("provider", "github:hamanpaul/paulsha-cortex"),),
+        identity=_BUILDER,
+        environment=_host_env(tmp_path),
+        snapshot_lookup=lambda pid: fresh,
+        provider_prober=lambda pid: fresh_calls.append(pid),
+        budget=ProbeBudget(now=lambda: now),
+        now=now,
+    )
+    assert fresh_result.outcome is PreflightOutcome.PROVIDER_UNAVAILABLE
+    assert fresh_calls == [], "TTL 內的快照應直接採信，不付出探測成本"
+
+
+def test_four_outcomes_are_distinguishable(tmp_path):
+    """R3/D4：四種結果各自獨立表達，不折疊成布林。"""
+
+    now = 5000.0
+    provider = RuntimeCapability("provider", "github:acme/repo")
+
+    def _snapshot(status: str, age: float) -> ProviderFreshness:
+        return ProviderFreshness(
+            provider_id="github:acme/repo",
+            status=status,
+            observed_at=now - age,
+            ttl_seconds=900.0,
+            source="snapshot",
+            reason="stale diagnostics" if status == "degraded" else None,
+        )
+
+    # 1. capability missing
+    missing = run_runtime_preflight(
+        card="c",
+        requirements=(RuntimeCapability("module", "pytest"),),
+        identity=_BUILDER,
+        environment=_isolated_env(tmp_path),
+        now=now,
+    )
+
+    # 2. provider unavailable（fresh degraded）
+    unavailable = run_runtime_preflight(
+        card="c",
+        requirements=(provider,),
+        identity=_BUILDER,
+        environment=_host_env(tmp_path),
+        snapshot_lookup=lambda pid: _snapshot("degraded", 10.0),
+        now=now,
+    )
+
+    # 3. stale snapshot（逾期且無 prober 可用）
+    stale = run_runtime_preflight(
+        card="c",
+        requirements=(provider,),
+        identity=_BUILDER,
+        environment=_host_env(tmp_path),
+        snapshot_lookup=lambda pid: _snapshot("degraded", 5000.0),
+        provider_prober=None,
+        now=now,
+    )
+
+    # 4. probe inconclusive（逾期、有 prober 但探測無定論）
+    def _inconclusive(pid: str):
+        raise TimeoutError("probe timed out")
+
+    inconclusive = run_runtime_preflight(
+        card="c",
+        requirements=(provider,),
+        identity=_BUILDER,
+        environment=_host_env(tmp_path),
+        snapshot_lookup=lambda pid: _snapshot("degraded", 5000.0),
+        provider_prober=_inconclusive,
+        budget=ProbeBudget(now=lambda: now),
+        now=now,
+    )
+
+    outcomes = [
+        missing.outcome,
+        unavailable.outcome,
+        stale.outcome,
+        inconclusive.outcome,
+    ]
+    assert outcomes == [
+        PreflightOutcome.CAPABILITY_MISSING,
+        PreflightOutcome.PROVIDER_UNAVAILABLE,
+        PreflightOutcome.STALE_SNAPSHOT,
+        PreflightOutcome.PROBE_INCONCLUSIVE,
+    ]
+    # 四者互異，且沒有被折疊成同一個布林。
+    assert len(set(outcomes)) == 4
+
+    # 處置也必須不同：只有前兩者是 hard block。
+    assert missing.blocking is True
+    assert unavailable.blocking is True
+    assert stale.blocking is False, "stale 需要刷新，不是硬擋"
+    assert inconclusive.blocking is False, "probe inconclusive 不應被當成失敗"
+
+
+def test_live_probe_respects_budget(tmp_path):
+    """R4/D6：live probe 有 timeout／快取／rate-limit 預算，同批次不重複探測。"""
+
+    now = 7000.0
+    provider = RuntimeCapability("provider", "github:acme/repo")
+    stale = ProviderFreshness(
+        provider_id="github:acme/repo",
+        status="degraded",
+        observed_at=now - 5000.0,
+        ttl_seconds=900.0,
+        source="snapshot",
+        reason="stale",
+    )
+
+    calls: list[str] = []
+
+    def _probe(pid: str) -> ProviderFreshness:
+        calls.append(pid)
+        return ProviderFreshness(
+            provider_id=pid,
+            status="ok",
+            observed_at=now,
+            ttl_seconds=900.0,
+            source="live-probe",
+            reason=None,
+        )
+
+    budget = ProbeBudget(ttl_seconds=300.0, timeout_seconds=5.0, max_probes=2, now=lambda: now)
+
+    # 同一批次五張 card 都需要同一個 provider → 只能探測一次（快取共用）。
+    for _ in range(5):
+        result = run_runtime_preflight(
+            card="c",
+            requirements=(provider,),
+            identity=_BUILDER,
+            environment=_host_env(tmp_path),
+            snapshot_lookup=lambda pid: stale,
+            provider_prober=_probe,
+            budget=budget,
+            now=now,
+        )
+        assert result.outcome is PreflightOutcome.OK
+    assert calls == ["github:acme/repo"], "同 provider identity 必須共用快取，不重複探測"
+    assert budget.timeout_seconds == 5.0
+
+    # rate-limit 預算：不同 provider 耗盡額度後不得再探測。
+    other_calls: list[str] = []
+
+    def _counting(pid: str) -> ProviderFreshness:
+        other_calls.append(pid)
+        return ProviderFreshness(
+            provider_id=pid,
+            status="ok",
+            observed_at=now,
+            ttl_seconds=900.0,
+            source="live-probe",
+            reason=None,
+        )
+
+    exhausted: list[PreflightOutcome] = []
+    for index in range(4):
+        pid = f"github:acme/repo-{index}"
+        result = run_runtime_preflight(
+            card="c",
+            requirements=(RuntimeCapability("provider", pid),),
+            identity=_BUILDER,
+            environment=_host_env(tmp_path),
+            snapshot_lookup=lambda _pid: ProviderFreshness(
+                provider_id=_pid,
+                status="degraded",
+                observed_at=now - 5000.0,
+                ttl_seconds=900.0,
+                source="snapshot",
+                reason="stale",
+            ),
+            provider_prober=_counting,
+            budget=budget,
+            now=now,
+        )
+        exhausted.append(result.outcome)
+
+    # budget max_probes=2，第一次探測已在上面用掉 1 → 只剩 1 次。
+    assert len(other_calls) == 1
+    assert exhausted[0] is PreflightOutcome.OK
+    # 額度耗盡後不再探測，退為 probe inconclusive（而非假裝失敗）。
+    assert exhausted[1:] == [PreflightOutcome.PROBE_INCONCLUSIVE] * 3
+
+
+# ------------------------------------------------------------------ R2 / D5
+
+
+def test_reroute_when_alternative_identity_available(tmp_path):
+    """D5：有合法替代 identity 時自動 re-route，仍滿足 capability 與 domain 規則。"""
+
+    bindir = tmp_path / "alt-bin"
+    bindir.mkdir()
+    _executable(bindir, "socat")
+
+    def _environment_for(identity: ModelIdentity) -> ExecutorEnvironment:
+        if identity.executor == "claude":
+            return _isolated_env(tmp_path, name="claude-sandbox")
+        return _isolated_env(tmp_path, name="codex-sandbox", path=str(bindir))
+
+    factory = _CountingLauncherFactory()
+    decision = evaluate_dispatch_gate(
+        card="requesting-code-review",
+        requirements=(RuntimeCapability("executable", "socat"),),
+        candidates=(_BUILDER, _ALT_BUILDER),
+        environment_for=_environment_for,
+        launcher_factory=factory,
+    )
+
+    assert decision.action == "reroute"
+    assert decision.identity == _ALT_BUILDER
+    # 語意：確實換了 identity，且沿用既有 candidate 順序與 domain 規則。
+    assert decision.identity.independence_domain == "openai"
+    assert decision.reason == "capability-missing-rerouted"
+    # 被否決的 primary 必須留下具體證據。
+    assert len(decision.attempts) == 2
+    assert decision.attempts[0].identity_token == "claude/opus-5"
+    assert decision.attempts[0].outcome is PreflightOutcome.CAPABILITY_MISSING
+    assert decision.attempts[0].missing_capabilities == ("executable:socat",)
+    assert decision.attempts[1].outcome is PreflightOutcome.OK
+    # 只有最終被選中的 identity 建立 launcher，被 preflight 否決的不建立。
+    assert factory.model_invocations == 1
+    assert decision.model_invocations == 0
+
+
+def test_needs_human_carries_specific_reason(tmp_path):
+    """D5/R5：無替代時進入 needs_human 且帶具體 reason 與可觀測欄位。"""
+
+    factory = _CountingLauncherFactory()
+    decision = evaluate_dispatch_gate(
+        card="requesting-code-review",
+        requirements=(
+            RuntimeCapability("executable", "socat"),
+            RuntimeCapability("module", "pytest"),
+        ),
+        candidates=(_BUILDER, _ALT_BUILDER),
+        environment_for=lambda identity: _isolated_env(
+            tmp_path, name=f"{identity.executor}-sandbox"
+        ),
+        launcher_factory=factory,
+    )
+
+    assert decision.action == "needs_human"
+    assert decision.identity is None
+    assert factory.model_invocations == 0
+
+    # reason 必須具體：指出缺哪些 capability，不能只是 "preflight failed"。
+    assert "executable:socat" in decision.reason
+    assert "module:pytest" in decision.reason
+
+    payload = decision.to_dict()
+    assert payload["action"] == "needs_human"
+    # R5：顯示缺少的 capability、使用中的 executor environment、snapshot 新鮮度。
+    assert set(payload["missing_capabilities"]) == {"executable:socat", "module:pytest"}
+    environments = [attempt["executor_environment"]["name"] for attempt in payload["attempts"]]
+    assert environments == ["claude-sandbox", "codex-sandbox"]
+    assert "provider_freshness" in payload["attempts"][0]
+    # 兩個 candidate 都被實際檢查過，且都失敗。
+    assert len(payload["attempts"]) == 2
+    assert all(
+        attempt["outcome"] == PreflightOutcome.CAPABILITY_MISSING.value
+        for attempt in payload["attempts"]
+    )
+
+
+def test_card_contract_declares_capabilities_in_shipped_deck():
+    """R1：出貨的 card 契約真的用資料宣告了 capability。"""
+
+    from paulsha_cortex.coordinator.runtime_preflight import card_runtime_requirements
+    from paulsha_cortex.deck.schema import DEFAULT_CARDS_PATH, load_cards
+
+    cards = load_cards(DEFAULT_CARDS_PATH)
+
+    # 跑測試的三張 card 宣告了 pytest —— 正是 #262 撞到的缺口。
+    for card_id in ("tdd-red", "subagent-build", "verification"):
+        requirements = card_runtime_requirements(card_id, cards=cards)
+        assert RuntimeCapability("module", "pytest") in requirements, card_id
+
+    # 未宣告的 card 是 no-op，行為與 #262 之前相同。
+    assert card_runtime_requirements("workflow-claim", cards=cards) == ()
+    assert card_runtime_requirements("no-such-card", cards=cards) == ()
+
+
+def test_card_contract_rejects_malformed_capability_declaration(tmp_path):
+    """R1：宣告是資料，但 fail-closed —— 非法 kind 在載入時就擋下，避免無聲漏檢。"""
+
+    from paulsha_cortex.deck.schema import DeckSchemaError, load_cards
+
+    bad = tmp_path / "cards.yaml"
+    bad.write_text(
+        "version: 0\n"
+        "cards:\n"
+        "  - id: broken\n"
+        "    kind: skill\n"
+        "    type: headless\n"
+        "    class: core\n"
+        '    skill_ref: "x:y"\n'
+        '    runtime_capabilities: ["nonsense:thing"]\n',
+        encoding="utf-8",
+    )
+    with pytest.raises(DeckSchemaError) as excinfo:
+        load_cards(bad)
+    assert "runtime_capabilities" in str(excinfo.value)
+
+
+def test_manager_gate_blocks_dispatch_before_model_session(tmp_path):
+    """R2：manager 的 dispatch seam 在建立 model session 前就攔下缺 capability 的 card。"""
+
+    from paulsha_cortex.coordinator import manager
+    from paulsha_cortex.coordinator.model_identities import IdentityRegistry
+
+    class _FakeStep:
+        card = "tdd-red"  # 出貨契約宣告 module:pytest
+        persona = "builder"
+        phase = "build"
+        commit_policy = "required"
+
+    class _FakeRun:
+        steps = ()
+        primary_domain = None
+
+    launched: list[str] = []
+    specialized: list[str] = []
+
+    class _Launcher:
+        """只描述環境；一旦 launch 被呼叫就代表 gate 沒擋住。"""
+
+        def __init__(self, identity, *, commit_required: bool = False):
+            self._identity = identity
+            self._commit_required = commit_required
+
+        def as_commit_required(self):
+            specialized.append(self._identity.executor)
+            return _Launcher(self._identity, commit_required=True)
+
+        def executor_environment(self):
+            # 只有 specialize 後的 launcher 才回報正式 job 的環境，
+            # 藉此證明 preflight 檢查的是 job 真正會用的環境。
+            assert self._commit_required, "preflight 必須使用與正式 job 相同的 launcher 契約"
+            return _isolated_env(tmp_path, name=f"{self._identity.executor}-sandbox")
+
+        def launch(self, **kwargs):  # pragma: no cover - 被呼叫即測試失敗
+            launched.append(self._identity.executor)
+            raise AssertionError("preflight 失敗時不得建立 model session")
+
+    registry = IdentityRegistry(schema_version=2, identities=(_BUILDER, _ALT_BUILDER))
+    decision = manager._runtime_preflight_gate(
+        _FakeRun(),
+        _FakeStep(),
+        identities=registry,
+        launcher_factory=_Launcher,
+    )
+
+    assert decision is not None
+    assert decision.action == "needs_human"
+    assert decision.result.outcome is PreflightOutcome.CAPABILITY_MISSING
+    assert decision.result.missing_capabilities == ("module:pytest",)
+    # 兩個 candidate 都被實際檢查，且都沒有啟動 model session。
+    assert len(decision.attempts) == 2
+    assert launched == []
+    # 兩個 candidate 都經過與正式 job 相同的 launcher specialize。
+    assert specialized == ["claude", "codex"]
+
+    # 對照：未宣告 capability 的 card → gate 是 no-op，完全走原路徑。
+    class _PlainStep:
+        card = "workflow-claim"
+        persona = "builder"
+        phase = "claim"
+        commit_policy = None
+
+    assert (
+        manager._runtime_preflight_gate(
+            _FakeRun(), _PlainStep(), identities=registry, launcher_factory=_Launcher
+        )
+        is None
+    )
+
+
+def test_launcher_reports_same_environment_as_real_job():
+    """D2：preflight 用的環境與正式 job 是同一份 env，不是另建一套。"""
+
+    from paulsha_cortex.coordinator import launcher as launcher_mod
+
+    subprocess_launcher = launcher_mod.SubprocessLauncher(executor="claude", model="opus-5")
+    env = subprocess_launcher.executor_environment()
+
+    # 與 launch() 內部用的 _git_scope_env() 完全一致的 PATH/HOME。
+    expected = launcher_mod._git_scope_env()
+    assert env.path == expected.get("PATH", "")
+    assert env.home == expected.get("HOME", "")
+    assert env.name == "claude:workspace-write"
+
+    # reviewer 走 review scope（最小 env），且模式可辨識。
+    review = subprocess_launcher.as_review_only(
+        terminal_kind="workflow-review-result"
+    ).executor_environment()
+    assert review.name == "claude:review-only"
+    assert review.path == launcher_mod._review_scope_env().get("PATH", "")
+
+
+def test_status_renders_missing_capability_and_freshness(tmp_path, capsys):
+    """R5：status/inspect 顯示缺少的 capability、executor environment 與 snapshot 新鮮度。"""
+
+    from paulsha_cortex.porcelain import inspect as inspect_mod
+
+    now = 9000.0
+    stale = ProviderFreshness(
+        provider_id="github:acme/repo",
+        status="degraded",
+        observed_at=now - 5000.0,
+        ttl_seconds=900.0,
+        source="snapshot",
+        reason="github rate limit exceeded",
+    )
+    decision = evaluate_dispatch_gate(
+        card="verification",
+        requirements=(
+            RuntimeCapability("module", "pytest"),
+            RuntimeCapability("provider", "github:acme/repo"),
+        ),
+        candidates=(_BUILDER,),
+        environment_for=lambda identity: _isolated_env(tmp_path, name="spark-sandbox"),
+        snapshot_lookup=lambda pid: stale,
+        provider_prober=None,
+        now=now,
+    )
+
+    inspect_mod._print_status(
+        {"updated_at": "now", "degraded": False, "runtime_preflight": decision.to_dict()}
+    )
+    out = capsys.readouterr().out
+
+    assert "runtime-preflight: needs_human" in out
+    # 缺少的 capability
+    assert "module:pytest" in out
+    # 使用中的 executor environment
+    assert "env=spark-sandbox" in out
+    assert str(tmp_path / "sandbox-home") in out
+    # snapshot 新鮮度：來源、TTL、是否過期都看得到
+    assert "provider github:acme/repo" in out
+    assert "source=snapshot" in out
+    assert "ttl=900.0s" in out
+    assert "fresh=False" in out
+
+
+def test_capability_parse_rejects_unknown_kind():
+    """R1：宣告是資料，但 kind 必須在白名單內，避免無聲漏檢。"""
+
+    with pytest.raises(ValueError):
+        RuntimeCapability.parse("nonsense:thing")
+    with pytest.raises(ValueError):
+        RuntimeCapability.parse("module:")
+    assert RuntimeCapability.parse("module:pytest") == RuntimeCapability("module", "pytest")


### PR DESCRIPTION
## 摘要

修 #262：dispatch 前於**實際將被使用的 executor 環境**驗證 runtime capability 與 provider snapshot 新鮮度，避免昂貴 job 啟動後才因可廉價預判的條件失敗。

## 改動

| 檔案 | 作用 |
|---|---|
| `coordinator/runtime_preflight.py`（新，~600 行） | capability 宣告、executor 環境探測、provider 三層新鮮度、四結果、probe 預算、dispatch gate |
| `deck/schema.py` | R1：`Card.runtime_capabilities` + fail-closed 驗證（非法 kind／空 name／重複 → `DeckSchemaError`） |
| `deck/data/cards.yaml` | `tdd-red`／`subagent-build`／`verification` 宣告 `module:pytest` |
| `coordinator/launcher.py` | 新增 `executor_environment()`，**重用 `launch()` 的同一份 `_git_scope_env()`／`_review_scope_env()`** |
| `coordinator/manager.py` | 抽出 `_workflow_identity_candidates()`（過濾規則零改動）；在 identity 選定後、worktree/sandbox/job row/launch **之前**插入 gate |
| `porcelain/inspect.py` | R5：status 渲染 preflight |

## 驗證

- `pytest tests/ -q` → **1659 passed, 32 subtests**（基準 1644，新增 15 個測試）
- 帶 PR 上下文的 `policy_check` → **pass: 25, fail: 0, warn: 1**（R-22 陳年 advisory）

**R2 的測試用真實子行程而非 stub**：`_isolated_env` 是 `sys.executable -I -S`，測試先斷言 host `find_spec("pytest") is not None`，再證明該 interpreter 判為缺失；另有單一變因版本（只換 interpreter、HOME/PATH 與 host 相同）仍判缺失。四結果測試斷言 `len(set(outcomes)) == 4` 且 blocking 語意各異，不只驗欄位存在。

## 實作過程中發現的兩個真實問題

1. **HOME 影響 module 可見性** —— pytest 裝在 `$HOME/.local`，換 HOME 即等於換 executor 環境。這反過來證實 sandbox policy 必須納入 preflight 的環境定義。
2. **launcher 重複 specialize** —— 初版 gate 對通過的 identity 多呼叫一次 `as_commit_required()`，打壞 `test_workflow_production_wiring.py` 的精確計數斷言。改為 per-identity memoize，讓 preflight 與最終 dispatch **共用同一個 launcher 實例** —— 這同時讓 D2 更嚴格：檢查的就是 job 實際會用的那個物件。

## 已知缺口（誠實標註，非靜默省略）

- **`socat` 未在出貨 `cards.yaml` 宣告**。測試已覆蓋 executable 缺失路徑，但要不要對 review card 硬宣告 `bridge:socat` 取決於部署環境是否普遍具備；貿然宣告會讓 review 在缺 socat 的機器上直接 needs_human。留給 operator 依環境決定。
- **provider capability 尚未接上真實 snapshot 來源**。`runtime_preflight` 的 provider 三層（快照 + TTL + 有界 probe）完整且有測試，但 `_runtime_preflight_gate` 目前未傳 `snapshot_lookup`／`provider_prober`，因為出貨 `cards.yaml` 還沒有 `provider:` 宣告，接上等於死碼。啟用需把 `work_snapshot.ProviderSnapshot`（欄位是 `last_attempt_at`／`last_success_at`，非 `observed_at`）轉接成 `ProviderFreshness`。
- **`_environment_for` 對未實作 `executor_environment()` 的 launcher 會 fail-soft 退回 `host_environment()`**，該路徑下 D2 保證降級。已確認 **production `launcher.py:667` 有實作該方法**，只有測試用的 fake launcher 會走退回路徑，因此 production dispatch 不受影響。

Closes #262

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MBuP74pQJyBBcX17DDxBAo
