### PR TITLE
fix(tests): persona 歷史回放改釘固定錨點，消除 merge 期間隨機紅

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 本專案遵循 hamanpaul project policy v1.0.15。
 
 ## [Unreleased]
+### Fixed
+- **Issue #284：persona 歷史回放測試改釘固定錨點**：原以浮動的 `main` ref 回放，merge／rebase 進行中 `prs_scanned` 可能落到 0 而讓斷言失敗（「掃不到」被誤判為「有誤殺」，實測 merge 期間出現過一次隨機紅）；且 `actions/checkout` 預設 shallow（實測 depth 1 的 clone `git log --merges -n 30` 回 0 個），CI 實際回放範圍遠少於宣稱的 30 個 PR 卻仍以「歷史回放零誤殺」通過。改釘固定 commit 錨點（`6813058`，即 #135 切換 enforce 當下的 main），使結果不隨 HEAD 移動而改變，並新增「錨點不可解析時明確 skip」的分支，避免在淺 clone 環境靜默宣稱零誤殺。偵測新 PR 誤殺仍由 CI `persona-scope` workflow 對 PR diff 負責，`replay.py` CLI 的動態回放能力不受影響。
+
 ### Changed
 - **Issue #135：persona enforcement shadow → enforce**：切換前先以
   `python -m paulsha_cortex.persona.replay`（新增，可重跑）回放最近已合併 PR 的

--- a/changelog.d/replay-test-determinism.md
+++ b/changelog.d/replay-test-determinism.md
@@ -1,0 +1,6 @@
+### Fixed
+- **Issue #284：persona 歷史回放測試改釘固定錨點**：`test_historical_replay_has_zero_false_positives`
+  原以浮動的 `main` ref 回放，merge／rebase 進行中 `prs_scanned` 可能落到 0 而讓斷言失敗
+  （「掃不到」被誤判為「有誤殺」）；且 `actions/checkout` 預設 shallow，CI 實際回放範圍
+  遠少於宣稱的 30 個 PR 卻仍通過。改釘固定 commit 錨點使結果不隨 HEAD 移動而改變，
+  並在錨點不可解析（淺 clone）時明確 skip 而非靜默通過。`replay.py` CLI 的動態回放不受影響。

--- a/tests/test_persona_scope_enforcement.py
+++ b/tests/test_persona_scope_enforcement.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import io
 import json
+import subprocess
 import tempfile
 import unittest
 from contextlib import redirect_stdout
@@ -70,12 +71,48 @@ def _patch_enforcement(case: unittest.TestCase, mode: str) -> None:
     case.addCleanup(setattr, scope_ci, "load_enforcement", original)
 
 
+# #284：回放錨點釘在固定 commit，而非浮動的 `main`。
+#
+# 原本以 `ref="main"` 回放有兩個問題：
+#   1. **flaky**：merge／rebase 進行中 `main` ref 正在變動，`prs_scanned` 可能落到 0
+#      而讓斷言失敗——「掃不到」不等於「有誤殺」，兩者被混為一談。
+#   2. **CI 上驗證力未知**：`actions/checkout` 預設 shallow（實測 depth 1 的 clone
+#      `git log --merges -n 30` 回 0 個），CI 實際回放範圍遠少於宣稱的 30 個 PR，
+#      卻仍以「歷史回放零誤殺」通過。
+#
+# 釘住錨點後語意變誠實：這是「#135 切換 enforce 當下、對該段真實歷史證明零誤殺」
+# 的固化證據，不隨 HEAD 移動而改變。偵測新 PR 是否引入誤殺是 CI `persona-scope`
+# workflow 對 PR diff 的職責；要對當前歷史手動回放請用
+# `python -m paulsha_cortex.persona.replay --ref main`。
+REPLAY_ANCHOR_SHA = "6813058f8fa748c7d89a07d0cab5bd825fd37f2e"
+REPLAY_ANCHOR_LIMIT = 30
+
+
+def _anchor_available(repo_root: Path, sha: str) -> bool:
+    """錨點 commit 在本地是否可解析（shallow clone 環境不會有）。"""
+    proc = subprocess.run(
+        ["git", "-C", str(repo_root), "cat-file", "-e", f"{sha}^{{commit}}"],
+        capture_output=True,
+    )
+    return proc.returncode == 0
+
+
 class HistoricalReplayTests(unittest.TestCase):
     def test_historical_replay_has_zero_false_positives(self) -> None:
-        """R1 / D1：以近期已合併 PR 檔案清單回放 persona scope 判定，零誤殺、可重跑。"""
+        """R1 / D1：以固定歷史區段回放 persona scope 判定，零誤殺、可重跑。"""
         from paulsha_cortex.persona import replay
 
-        summary = replay.replay(repo_root=REPO_ROOT, limit=30, ref="main")
+        if not _anchor_available(REPO_ROOT, REPLAY_ANCHOR_SHA):
+            # 明確 skip 而非靜默通過：淺 clone 沒有足夠歷史可回放，
+            # 在這種環境下宣稱「零誤殺」沒有根據。
+            self.skipTest(
+                f"回放錨點 {REPLAY_ANCHOR_SHA[:12]} 不在本地（淺 clone？）；"
+                "歷史回放需完整 clone"
+            )
+
+        summary = replay.replay(
+            repo_root=REPO_ROOT, limit=REPLAY_ANCHOR_LIMIT, ref=REPLAY_ANCHOR_SHA
+        )
 
         # 回放必須實際掃到東西，避免空回放偽造零誤殺。
         self.assertGreater(summary["prs_scanned"], 0, msg="回放未掃到任何已合併 PR")
@@ -89,10 +126,16 @@ class HistoricalReplayTests(unittest.TestCase):
             ),
         )
 
+        # 錨點固定 ⇒ 掃描範圍必為滿額，不因 HEAD 位置而縮水。
+        self.assertEqual(summary["prs_scanned"], REPLAY_ANCHOR_LIMIT)
+
         # 可重跑：同樣輸入應得到同樣結論（結構化、非一次性手算）。
-        rerun = replay.replay(repo_root=REPO_ROOT, limit=30, ref="main")
+        rerun = replay.replay(
+            repo_root=REPO_ROOT, limit=REPLAY_ANCHOR_LIMIT, ref=REPLAY_ANCHOR_SHA
+        )
         self.assertEqual(rerun["false_positives"], summary["false_positives"])
         self.assertEqual(rerun["prs_scanned"], summary["prs_scanned"])
+        self.assertEqual(rerun["files_scanned"], summary["files_scanned"])
 
 
 class ViolationExitCodeTests(unittest.TestCase):


### PR DESCRIPTION
## 摘要

修 #284：`test_historical_replay_has_zero_false_positives` 改釘固定 commit 錨點，消除 merge 期間的隨機紅，並讓淺 clone 環境不再靜默宣稱「零誤殺」。

## 兩個問題

**1. flaky** —— 原本以浮動的 `main` ref 回放。merge／rebase 進行中 `main` 正在變動，`prs_scanned` 可能落到 0 而讓斷言失敗。但「掃不到」不等於「有誤殺」，兩者被混為一談。

實測（merge #281 到 feature 分支時）：

```
第一次（緊接在 git commit --no-edit 之後）：1 failed, 1665 passed
重跑三次：                                  1666 passed（每次都過）
```

**2. CI 上的驗證力是未知的** —— 這是查 flaky 時順帶發現、比 flaky 本身更值得注意的一點。`actions/checkout` 沒有設 `fetch-depth`，預設 shallow。實測 depth 1 的 clone：

```
是否 shallow: true
commit 數: 1
掃到的 merge 數: 0
```

也就是說 CI 上實際回放的範圍遠少於宣稱的 30 個 PR，卻仍以「歷史回放零誤殺」通過。這比隨機紅更值得修 —— 一個宣稱驗證了 30 個 PR 的測試，在 CI 上可能只驗了 1 個甚至 0 個。

## 修法

錨點釘在 `6813058`（#135 切換 enforce 當下的 main HEAD），語意變得誠實：這是**「切換 enforce 當下、對該段真實歷史證明零誤殺」的固化證據**，不隨 HEAD 移動而改變。

錨點不可解析（淺 clone）時**明確 `skipTest` 並說明原因**，而不是靜默通過：

```
SKIPPED [1] 回放錨點 6813058f8fa7 不在本地（淺 clone？）；歷史回放需完整 clone
```

另補兩條斷言：`prs_scanned` 必為滿額（錨點固定則掃描範圍不該縮水）、`files_scanned` 重跑一致。

保留不變的部分：仍是**真實歷史回放**（非人造 fixture），`prs_scanned > 0` / `files_scanned > 0` 的防呆保留（#135 D2 要求不得以空回放偽造零誤殺）。`replay.py` CLI 的動態回放能力完全不受影響，operator 仍可 `python -m paulsha_cortex.persona.replay --ref main` 對當前歷史回放。

偵測新 PR 是否引入誤殺，是 CI `persona-scope` workflow 對 PR diff 的職責，本來就不該靠這個測試。

## 驗證

| 環境 | 結果 |
|---|---|
| 完整 clone（連跑三次） | `7 passed` × 3，穩定 |
| shallow clone（depth 1） | `6 passed, 1 skipped`，skip 訊息指出錨點不在本地 |
| 全套 | **1700 passed, 32 subtests** |
| policy_check（帶 PR 上下文） | **fail: 0** |

Closes #284

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MBuP74pQJyBBcX17DDxBAo
