### PR TITLE
fix(work): repo rebind 後 legacy config 明確拒絕、work link 寫入後驗證

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 
 ## [Unreleased]
 ### Fixed
+- **Issue #277：repo rebind 後 monitor 投影與 work authority 跟隨 `PSC_REPO_ROOT`**：
+  - monitor 設定解析遇到 deprecated legacy 設定（`PAULSHACLAW_CONFIG` 或 `paulshaclaw.yaml`）時改為 fail-loudly 拋出 `ValueError`，不再靜默降級至舊 repo 設定。
+  - monitor config 載入時自動將 `PSC_REPO_ROOT` 納入監控專案集，確保 instance 換綁 repo 後 monitor 投影能正確解析當前 repo 的 work items。
+  - `work link` / `unlink` 重寫 `.cortex/work-items.yaml` 時保留原始鍵（key）排序，避免無謂重排導致 git status 變 dirty，並於寫入後新增 readback 讀回驗證。
 - **Issue #284：persona 歷史回放測試改釘固定錨點**：原以浮動的 `main` ref 回放，merge／rebase 進行中 `prs_scanned` 可能落到 0 而讓斷言失敗（「掃不到」被誤判為「有誤殺」，實測 merge 期間出現過一次隨機紅）；且 `actions/checkout` 預設 shallow（實測 depth 1 的 clone `git log --merges -n 30` 回 0 個），CI 實際回放範圍遠少於宣稱的 30 個 PR 卻仍以「歷史回放零誤殺」通過。改釘固定 commit 錨點（`6813058`，即 #135 切換 enforce 當下的 main），使結果不隨 HEAD 移動而改變，並新增「錨點不可解析時明確 skip」的分支，避免在淺 clone 環境靜默宣稱零誤殺。偵測新 PR 誤殺仍由 CI `persona-scope` workflow 對 PR diff 負責，`replay.py` CLI 的動態回放能力不受影響。
 
 ### Changed

--- a/changelog.d/repo-rebind-work-item.md
+++ b/changelog.d/repo-rebind-work-item.md
@@ -1,0 +1,5 @@
+### Fixed
+- **Issue #277：repo rebind 後 monitor 投影與 work authority 跟隨 `PSC_REPO_ROOT`**：
+  - monitor 設定解析遇到 deprecated legacy 設定（`PAULSHACLAW_CONFIG` 或 `paulshaclaw.yaml`）時改為 fail-loudly 拋出 `ValueError`，不再靜默降級至舊 repo 設定。
+  - monitor config 載入時自動將 `PSC_REPO_ROOT` 納入監控專案集，確保 instance 換綁 repo 後 monitor 投影能正確解析當前 repo 的 work items。
+  - `work link` / `unlink` 重寫 `.cortex/work-items.yaml` 時保留原始鍵（key）排序，避免無謂重排導致 git status 變 dirty，並於寫入後新增 readback 讀回驗證。

--- a/paulsha_cortex/coordinator/work_actions.py
+++ b/paulsha_cortex/coordinator/work_actions.py
@@ -286,7 +286,7 @@ def _canonical_source(*, args: dict[str, Any], repo: str) -> dict[str, str]:
 
 def _write_override(path: Path, payload: dict[str, Any]) -> None:
     lines = ["version: 1", "work_items:"]
-    for work_id, row in sorted(payload["work_items"].items()):
+    for work_id, row in payload["work_items"].items():
         lines.extend([f"  {work_id}:", f"    title: {row['title']!r}"])
         for field in ("links", "excludes"):
             lines.append(f"    {field}:")
@@ -386,6 +386,13 @@ def _mutate_override(*, args: dict[str, Any], repo: str, work_id: str) -> dict[s
             row["excludes"].append(ref)
     _validate_override_payload(payload, repo=repo)
     _write_override(path, payload)
+    from paulsha_cortex.monitor.correlation import load_work_item_overrides
+    try:
+        loaded = load_work_item_overrides(path.parent.parent)
+        if work_id not in loaded.work_items:
+            raise ValueError(f"work override readback failed: {work_id} missing after write")
+    except Exception as exc:
+        raise ValueError(f"work override readback failed: {exc}") from exc
     return {"action": args["action"], "override_path": str(path), "source": ref}
 
 

--- a/paulsha_cortex/monitor/config.py
+++ b/paulsha_cortex/monitor/config.py
@@ -8,7 +8,7 @@ from typing import Any
 
 import yaml
 from paulsha_cortex.config import paths
-from paulsha_cortex.monitor.registry import ProjectEntry, load_hippo_projects
+from paulsha_cortex.monitor.registry import ProjectEntry, load_hippo_projects, merge_projects
 
 ENV_CONFIG_VAR = "PAULSHACLAW_CONFIG"
 NEW_ENV_CONFIG_VAR = "PSC_MONITOR_CONFIG"
@@ -63,37 +63,26 @@ class MonitorConfig:
 def _resolve_config_source(config_path: Path | None) -> Path | None:
     if config_path is not None:
         return Path(config_path)
-    for env in (NEW_ENV_CONFIG_VAR, ENV_CONFIG_VAR):
-        raw = os.environ.get(env, "").strip()
-        if not raw:
-            continue
-        if env == ENV_CONFIG_VAR:
-            if _warn_deprecated_once(
-                "legacy-monitor-env",
-                "PAULSHACLAW_CONFIG 已 deprecated，改用 project-cortex.yaml",
-            ):
-                warnings.warn(
-                    "PAULSHACLAW_CONFIG 已 deprecated，改用 project-cortex.yaml",
-                    stacklevel=2,
-                )
-                _WARNED_DEPRECATIONS.add("legacy-monitor-env")
-        return Path(raw).expanduser()
+    raw_new_env = os.environ.get(NEW_ENV_CONFIG_VAR, "").strip()
+    if raw_new_env:
+        return Path(raw_new_env).expanduser()
+
+    raw_legacy_env = os.environ.get(ENV_CONFIG_VAR, "").strip()
+    if raw_legacy_env:
+        raise ValueError("PAULSHACLAW_CONFIG 已 deprecated，改用 project-cortex.yaml")
+
     new = _new_manual_path()
     if new.exists():
         return new
+
     legacy = _legacy_manual_path()
     if legacy.exists():
-        if _warn_deprecated_once(
-            "legacy-monitor-file",
-            f"讀取 deprecated legacy monitor 設定 {legacy}，請遷移至 {new}",
-        ):
-            warnings.warn(
-                f"讀取 deprecated legacy monitor 設定 {legacy}，請遷移至 {new}",
-                stacklevel=2,
-            )
-            _WARNED_DEPRECATIONS.add("legacy-monitor-file")
-        return legacy
+        raise ValueError(
+            f"讀取 deprecated legacy monitor 設定 {legacy}，請遷移至 {new}"
+        )
+
     return None
+
 
 
 def _parse_workspaces(raw: Any) -> tuple[WorkspaceConfig, ...]:
@@ -190,24 +179,43 @@ def _load_manual_config(resolved: Path) -> MonitorConfig:
     )
 
 
+def _get_active_repo_projects() -> list[ProjectEntry]:
+    raw = os.environ.get("PSC_REPO_ROOT", "").strip()
+    if not raw:
+        return []
+    repo_path = Path(raw).expanduser()
+    if not repo_path.exists():
+        return []
+    from paulsha_cortex.monitor.fs import stable_path
+    return [ProjectEntry(path=stable_path(repo_path), name=repo_path.name, source="repo_root")]
+
+
 def load_config(*, config_path: Path | None = None) -> MonitorConfig:
     """Load the global paulshaclaw config.
 
     Resolution order: explicit `config_path` → `PSC_MONITOR_CONFIG` env →
-    `PAULSHACLAW_CONFIG` env → `project-cortex.yaml` → legacy `paulshaclaw.yaml`.
+    `project-cortex.yaml`.
     """
     resolved = _resolve_config_source(config_path)
+    active_repo_projects = _get_active_repo_projects() if config_path is None else []
+
     if resolved is None:
-        hippo = tuple(load_hippo_projects())
+        hippo = merge_projects(load_hippo_projects(), active_repo_projects)
         if not hippo:
             raise FileNotFoundError(
                 "無 project 設定：manual（project-cortex.yaml / legacy）與 "
                 "project-hippo.yaml 皆不存在"
             )
-        return MonitorConfig(workspaces=(), hippo_projects=hippo)
+        return MonitorConfig(workspaces=(), hippo_projects=tuple(hippo))
     if config_path is not None:
         return replace(_load_manual_config(resolved), hippo_projects=())
+    
+    hippo_list = merge_projects(
+        load_hippo_projects(resolved.parent / "project-hippo.yaml"),
+        active_repo_projects,
+    )
     return replace(
         _load_manual_config(resolved),
-        hippo_projects=tuple(load_hippo_projects(resolved.parent / "project-hippo.yaml")),
+        hippo_projects=tuple(hippo_list),
     )
+

--- a/paulsha_cortex/monitor/correlation.py
+++ b/paulsha_cortex/monitor/correlation.py
@@ -478,7 +478,7 @@ def _atomic_write_overrides(root: Path, overrides: WorkItemOverrides) -> None:
                 "links": [{"kind": link.kind, "ref": link.ref} for link in item.links],
                 "excludes": [{"kind": link.kind, "ref": link.ref} for link in item.excludes],
             }
-            for work_id, item in sorted(overrides.work_items.items())
+            for work_id, item in overrides.work_items.items()
         },
     }
     body = yaml.safe_dump(payload, allow_unicode=True, sort_keys=False).encode("utf-8")

--- a/tests/test_monitor_config_resolution.py
+++ b/tests/test_monitor_config_resolution.py
@@ -36,17 +36,17 @@ def test_prefers_new_project_cortex_over_legacy(monkeypatch, tmp_path):
     assert _resolve_config_source(None) == new
 
 
-def test_legacy_only_transition(monkeypatch, tmp_path, recwarn):
+def test_legacy_only_transition(monkeypatch, tmp_path):
     monkeypatch.delenv("PSC_MONITOR_CONFIG", raising=False)
     monkeypatch.delenv("PAULSHACLAW_CONFIG", raising=False)
     monkeypatch.setenv("PSC_PROJECT_CONFIG_ROOT", str(tmp_path / "agents"))
     monkeypatch.setenv("PSC_CONFIG_ROOT", str(tmp_path / "legacy"))
     legacy = _write(tmp_path / "legacy" / "paulshaclaw.yaml")
-    assert _resolve_config_source(None) == legacy
-    assert any("deprecated" in str(w.message).lower() for w in recwarn.list)
+    with pytest.raises(ValueError, match="deprecated legacy monitor"):
+        _resolve_config_source(None)
 
 
-def test_legacy_file_warning_once_per_process(monkeypatch, tmp_path, isolate_warning_state):
+def test_legacy_file_fails_loudly(monkeypatch, tmp_path):
     monkeypatch.delenv("PSC_MONITOR_CONFIG", raising=False)
     monkeypatch.delenv("PAULSHACLAW_CONFIG", raising=False)
     monkeypatch.setenv("PSC_PROJECT_CONFIG_ROOT", str(tmp_path / "agents"))
@@ -55,17 +55,12 @@ def test_legacy_file_warning_once_per_process(monkeypatch, tmp_path, isolate_war
     expected_message = (
         f"讀取 deprecated legacy monitor 設定 {legacy}，請遷移至 {tmp_path / 'agents' / 'project-cortex.yaml'}"
     )
-
-    with warnings.catch_warnings(record=True) as caught:
-        warnings.simplefilter("always")
-        resolved = [_resolve_config_source(None) for _ in range(3)]
-
-    assert resolved == [legacy, legacy, legacy]
-    assert len(caught) == 1
-    assert str(caught[0].message) == expected_message
+    with pytest.raises(ValueError) as exc_info:
+        _resolve_config_source(None)
+    assert str(exc_info.value) == expected_message
 
 
-def test_legacy_env_warning_once_per_process(monkeypatch, tmp_path, isolate_warning_state):
+def test_legacy_env_fails_loudly(monkeypatch, tmp_path):
     legacy_env = tmp_path / "legacy-env-config.yaml"
     legacy = _write(legacy_env)
     monkeypatch.setenv("PAULSHACLAW_CONFIG", str(legacy))
@@ -73,31 +68,9 @@ def test_legacy_env_warning_once_per_process(monkeypatch, tmp_path, isolate_warn
     monkeypatch.setenv("PSC_PROJECT_CONFIG_ROOT", str(tmp_path / "agents"))
     monkeypatch.setenv("PSC_CONFIG_ROOT", str(tmp_path / "legacy"))
 
-    with warnings.catch_warnings(record=True) as caught:
-        warnings.simplefilter("always")
-        resolved = [_resolve_config_source(None) for _ in range(3)]
+    with pytest.raises(ValueError, match="PAULSHACLAW_CONFIG"):
+        _resolve_config_source(None)
 
-    assert resolved == [legacy, legacy, legacy]
-    assert len(caught) == 1
-    assert str(caught[0].message) == "PAULSHACLAW_CONFIG 已 deprecated，改用 project-cortex.yaml"
-
-
-def test_legacy_env_warning_stacklevel_points_to_caller(monkeypatch, tmp_path, isolate_warning_state):
-    legacy = _write(tmp_path / "legacy-env-config.yaml")
-    monkeypatch.setenv("PAULSHACLAW_CONFIG", str(legacy))
-    monkeypatch.delenv("PSC_MONITOR_CONFIG", raising=False)
-    monkeypatch.setenv("PSC_PROJECT_CONFIG_ROOT", str(tmp_path / "agents"))
-    monkeypatch.setenv("PSC_CONFIG_ROOT", str(tmp_path / "legacy"))
-
-    def resolve_once():
-        return _resolve_config_source(None)
-
-    with warnings.catch_warnings(record=True) as caught:
-        warnings.simplefilter("always")
-        resolve_once()
-
-    assert len(caught) == 1
-    assert Path(caught[0].filename).name == Path(__file__).name
 
 
 def test_new_config_has_no_deprecation_warning(monkeypatch, tmp_path, isolate_warning_state):

--- a/tests/test_repo_rebind_work_item.py
+++ b/tests/test_repo_rebind_work_item.py
@@ -1,0 +1,116 @@
+from pathlib import Path
+import os
+import subprocess
+import pytest
+
+from paulsha_cortex.monitor.config import load_config, _resolve_config_source
+from paulsha_cortex.coordinator.work_actions import execute_work_action
+from paulsha_cortex.doctor import run_doctor
+
+
+def test_legacy_config_fallback_fails_loudly(monkeypatch, tmp_path):
+    """Finding 1: Legacy config file fallback must fail loudly, not silently succeed."""
+    monkeypatch.delenv("PSC_MONITOR_CONFIG", raising=False)
+    monkeypatch.delenv("PAULSHACLAW_CONFIG", raising=False)
+    monkeypatch.setenv("PSC_PROJECT_CONFIG_ROOT", str(tmp_path / "agents"))
+    monkeypatch.setenv("PSC_CONFIG_ROOT", str(tmp_path / "legacy"))
+    
+    # Create legacy file only
+    legacy_file = tmp_path / "legacy" / "paulshaclaw.yaml"
+    legacy_file.parent.mkdir(parents=True, exist_ok=True)
+    legacy_file.write_text("workspaces:\n  - {name: old, path: /tmp/old}\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="deprecated legacy monitor"):
+        load_config()
+
+
+def test_legacy_config_env_fails_loudly(monkeypatch, tmp_path):
+    """Finding 1: Deprecated PAULSHACLAW_CONFIG env var must fail loudly."""
+    legacy_file = tmp_path / "legacy" / "paulshaclaw.yaml"
+    legacy_file.parent.mkdir(parents=True, exist_ok=True)
+    legacy_file.write_text("workspaces:\n  - {name: old, path: /tmp/old}\n", encoding="utf-8")
+
+    monkeypatch.setenv("PAULSHACLAW_CONFIG", str(legacy_file))
+    monkeypatch.delenv("PSC_MONITOR_CONFIG", raising=False)
+    monkeypatch.setenv("PSC_PROJECT_CONFIG_ROOT", str(tmp_path / "agents"))
+
+    with pytest.raises(ValueError, match="PAULSHACLAW_CONFIG"):
+        load_config()
+
+
+def test_monitor_config_includes_psc_repo_root(monkeypatch, tmp_path):
+    """Finding 1: Monitor config resolution must include PSC_REPO_ROOT as a monitored project."""
+    repo_b = tmp_path / "repoB"
+    repo_b.mkdir(parents=True)
+    (repo_b / ".cortex").mkdir()
+    (repo_b / ".cortex" / "work-items.yaml").write_text(
+        "version: 1\nwork_items:\n  item-b:\n    title: Item B\n    links: []\n    excludes: []\n",
+        encoding="utf-8"
+    )
+    
+    monkeypatch.setenv("PSC_REPO_ROOT", str(repo_b))
+    monkeypatch.setenv("PSC_PROJECT_CONFIG_ROOT", str(tmp_path / "agents"))
+    
+    config = load_config()
+    project_paths = [p.path for p in config.hippo_projects] + [w.path for w in config.workspaces]
+    assert repo_b.resolve() in [p.resolve() for p in project_paths]
+
+
+def test_doctor_fails_when_legacy_config_used(monkeypatch, tmp_path):
+    """Finding 1: Doctor probe must fail when legacy config is present/used."""
+    monkeypatch.delenv("PSC_MONITOR_CONFIG", raising=False)
+    monkeypatch.delenv("PAULSHACLAW_CONFIG", raising=False)
+    monkeypatch.setenv("PSC_PROJECT_CONFIG_ROOT", str(tmp_path / "agents"))
+    monkeypatch.setenv("PSC_CONFIG_ROOT", str(tmp_path / "legacy"))
+    
+    legacy_file = tmp_path / "legacy" / "paulshaclaw.yaml"
+    legacy_file.parent.mkdir(parents=True, exist_ok=True)
+    legacy_file.write_text("workspaces:\n  - {name: old, path: /tmp/old}\n", encoding="utf-8")
+
+    report = run_doctor(probe_live=False, env=os.environ, home=tmp_path)
+    assert not report.ok
+    assert any(p.name == "monitor-socket" and p.status == "fail" for p in report.probes)
+
+
+def test_work_link_preserves_yaml_key_ordering(tmp_path):
+    """Finding 2: work link must preserve key ordering in work-items.yaml."""
+    repo = tmp_path / "repo"
+    repo.mkdir(parents=True)
+    subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(["git", "remote", "add", "origin", "git@github.com:owner/repo.git"], cwd=repo, check=True, capture_output=True)
+
+    cortex_dir = repo / ".cortex"
+    cortex_dir.mkdir(parents=True)
+    yaml_file = cortex_dir / "work-items.yaml"
+    
+    # Write keys in non-alphabetical order
+    yaml_content = (
+        "version: 1\n"
+        "work_items:\n"
+        "  zebra-task:\n"
+        "    title: Zebra\n"
+        "    links: []\n"
+        "    excludes: []\n"
+        "  alpha-task:\n"
+        "    title: Alpha\n"
+        "    links: []\n"
+        "    excludes: []\n"
+    )
+    yaml_file.write_text(yaml_content, encoding="utf-8")
+
+    args = {
+        "action": "link",
+        "repo": "owner/repo",
+        "work_id": "alpha-task",
+        "kind": "github_issue",
+        "ref": "owner/repo#123",
+        "repo_root": str(repo),
+    }
+
+    result = execute_work_action(args=args, requested_by="operator")
+    
+    updated_content = yaml_file.read_text(encoding="utf-8")
+    zebra_pos = updated_content.find("zebra-task:")
+    alpha_pos = updated_content.find("alpha-task:")
+    assert zebra_pos != -1 and alpha_pos != -1
+    assert zebra_pos < alpha_pos, "zebra-task must remain before alpha-task (key order preserved)"


### PR DESCRIPTION
## 摘要

修 #277 的 **Finding 1 與 Finding 2**。**Finding 3 未修**，因此本 PR 刻意不使用 closing keyword —— issue 保持開啟。

## Finding 1：legacy config fallback 由「靜默降級」改為「明確拒絕」

`monitor/config.py` 的 `_resolve_config_source` 原本在遇到 legacy env（`PAULSHACLAW_CONFIG`）或 legacy 檔案時，發出 `UserWarning` 後**照樣降級使用**。issue 指出這個 fallback 是靜默的（警告不阻斷、doctor 不報），導致 rebind 後 monitor 投影來源沒跟著走、`work show` 永遠 `unknown work item`。

改為直接 `raise ValueError`，符合 issue 期望的「啟動時明確拒絕而非降級」。

**這是破壞性變更**：仍在使用 `PAULSHACLAW_CONFIG` env 或 `~/.config/paulshaclaw/paulshaclaw.yaml` 的部署會直接失敗，必須先遷移到 `~/.agents/config/paulsha/project-cortex.yaml`。錯誤訊息含來源路徑與目標路徑。

因此移除了 `tests/test_monitor_config_resolution.py` 的四個測試（`test_legacy_only_transition`、`test_legacy_file_warning_once_per_process`、`test_legacy_env_warning_once_per_process`、`test_legacy_env_warning_stacklevel_points_to_caller`）—— 它們驗的是 #254 交付的「警告去重與 stacklevel」行為，而該警告路徑已不存在。**不是弱化保護，是被驗證的行為本身被移除**。

## Finding 2：`work link` 寫入後驗證，且不再無謂重排 YAML

兩個改動：

1. `_write_override` 與 `_atomic_write_overrides` 移除 `sorted()` —— 原本每次寫入都把整份 YAML 按字母序重排，讓 governed repo 無謂變 dirty。
2. `_mutate_override` 寫入後**立即 readback**，`work_id` 讀不回來就 `raise`，不再「回報成功但實際讀不到」。

**範圍限制（誠實說明）**：readback 驗證的是「自己寫的自己讀得回來」，**並未驗證 monitor 的讀取端讀得到**。Finding 2 的根本問題（寫入端與 monitor 讀取端不同源）仍在，本 PR 只消除了「靜默回報成功」這個最糟的表現。

## Finding 3：未修

builder 死於 candidate 產生前（3a）與 completion 快照競態記下 stale candidate（3b）都涉及更深的狀態機改動，未在本 PR 處理。分析與後續建議：

- **3a**：可參考 #256 落地的 `recover-planning` 模式（分類判準取自系統寫入的 evidence、caller 帶的只做交叉比對、CAS 取得冪等性），新增獨立的 pre-candidate 恢復動作並回收殘留 worktree。**不應**讓 `retry-build` 接受 null candidate 而略過 CAS —— 那會讓 CAS 保護失效。
- **3b**：completion 對 `candidate-worktree-dirty` 的評估應為可重評的動態狀態，而非直接寫死終態；下一 tick 或 retry 時以 branch HEAD 重新評估。

## 驗證

- `pytest tests/ -q` → **1704 passed, 32 subtests**（基準 1700，新增 4 個測試）
- 帶 PR 上下文的 `policy_check`（含本 PR 的 `policy-exempt:issue-link` label）→ **pass: 23, fail: 0, warn: 2, skip(exempt): 1**

## 為什麼用 Refs 而非 Closes

Finding 3 尚未解決，issue 不應被 merge 自動關閉。套用 `policy-exempt:issue-link` 豁免 R-17。

Refs #277

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MBuP74pQJyBBcX17DDxBAo
