### PR TITLE
fix(monitor): refresh 失敗不再靜默，並收斂 duplicate ID 與 collision 影響範圍

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 
 ## [Unreleased]
 ### Fixed
+- **Issue #273：修復 Monitor refresh 靜默失敗、同 Repo 多 Checkout 衝突與 Source Collision 歸零缺陷**：
+  - 缺陷一：`ProjectMonitorService._refresh_work_model` 不再靜默吞掉 `ValueError` / `OSError` 例外，加入 log 紀錄並於 store / status / snapshot 記錄 `last_refresh_error` 與連續失敗計數；`cortex work show` / `work start` 在 snapshot 停更或 refresh 失敗時直接回報真正原因。
+  - 缺陷二：`WorkModelRefresher` 掃描專案時依 git 身分去重同 repo 的多個 checkout，優先選擇 canonical checkout 避免 duplicate work item ID 錯誤，並在 status diagnostics 中明確標示碰撞目錄。
+  - 缺陷三：`correlate_work_sources` 與 `project_work_items` 發生 source collision 時，將影響限縮於相關 Work Item 並標記 `degraded` 診斷，不再導致整個 repo 的 Work Item projection 歸零。
 - **Issue #284：persona 歷史回放測試改釘固定錨點**：原以浮動的 `main` ref 回放，merge／rebase 進行中 `prs_scanned` 可能落到 0 而讓斷言失敗（「掃不到」被誤判為「有誤殺」，實測 merge 期間出現過一次隨機紅）；且 `actions/checkout` 預設 shallow（實測 depth 1 的 clone `git log --merges -n 30` 回 0 個），CI 實際回放範圍遠少於宣稱的 30 個 PR 卻仍以「歷史回放零誤殺」通過。改釘固定 commit 錨點（`6813058`，即 #135 切換 enforce 當下的 main），使結果不隨 HEAD 移動而改變，並新增「錨點不可解析時明確 skip」的分支，避免在淺 clone 環境靜默宣稱零誤殺。偵測新 PR 誤殺仍由 CI `persona-scope` workflow 對 PR diff 負責，`replay.py` CLI 的動態回放能力不受影響。
 
 ### Changed

--- a/changelog.d/monitor-silent-failure.md
+++ b/changelog.d/monitor-silent-failure.md
@@ -1,0 +1,5 @@
+### Fixed
+- **Issue #273：修復 Monitor refresh 靜默失敗、同 Repo 多 Checkout 衝突與 Source Collision 歸零缺陷**：
+  - 缺陷一：`ProjectMonitorService._refresh_work_model` 不再靜默吞掉 `ValueError` / `OSError` 例外，加入 log 紀錄並於 store / status / snapshot 記錄 `last_refresh_error` 與連續失敗計數；`cortex work show` / `work start` 在 snapshot 停更或 refresh 失敗時直接回報真正原因。
+  - 缺陷二：`WorkModelRefresher` 掃描專案時依 git 身分去重同 repo 的多個 checkout，優先選擇 canonical checkout 避免 duplicate work item ID 錯誤，並在 status diagnostics 中明確標示碰撞目錄。
+  - 缺陷三：`correlate_work_sources` 與 `project_work_items` 發生 source collision 時，將影響限縮於相關 Work Item 並標記 `degraded` 診斷，不再導致整個 repo 的 Work Item projection 歸零。

--- a/paulsha_cortex/coordinator/claim.py
+++ b/paulsha_cortex/coordinator/claim.py
@@ -714,6 +714,11 @@ def load_work_authority(
     for exc in skipped:
         if exc.repo == repo and exc.work_id in (None, work_id):
             raise exc
+    payload, _ = _load_snapshot(snapshot_path)
+    if isinstance(payload, dict) and payload.get("last_refresh_error"):
+        raise ValueError(
+            f"confirmed work authority missing or ambiguous (monitor refresh failed: {payload['last_refresh_error']})"
+        )
     raise ValueError("confirmed work authority missing or ambiguous")
 
 

--- a/paulsha_cortex/monitor/correlation.py
+++ b/paulsha_cortex/monitor/correlation.py
@@ -287,15 +287,6 @@ def correlate_work_sources(
             )
         elif len(work_ids) == 1:
             owners[source_id] = next(iter(work_ids))
-    if diagnostics:
-        return CorrelationResult(
-            groups=(),
-            source_owners={},
-            exclusions=tuple(all_exclusions),
-            explanations={},
-            degraded=True,
-            diagnostics=tuple(diagnostics),
-        )
 
     groups: dict[str, list[WorkSource]] = {}
     for source in sources:
@@ -404,6 +395,8 @@ def correlate_work_sources(
         source_owners=owners,
         exclusions=tuple(all_exclusions),
         explanations=explanations,
+        degraded=bool(diagnostics),
+        diagnostics=tuple(diagnostics),
     )
 
 

--- a/paulsha_cortex/monitor/lifecycle.py
+++ b/paulsha_cortex/monitor/lifecycle.py
@@ -112,38 +112,6 @@ def project_work_items(
         work_id: dict(explanation)
         for work_id, explanation in correlation.explanations.items()
     }
-    if correlation.degraded:
-        frozen_items: list[WorkItem] = []
-        for item in previous.values():
-            decision = reduce_lifecycle(
-                LifecycleFacts(
-                    previous_state=item.state,
-                    provider_degraded=True,
-                    facets=tuple(facet for facet in item.facets if facet != "degraded"),
-                )
-            )
-            frozen_items.append(
-                WorkItem(
-                    work_id=item.work_id,
-                    repo=item.repo,
-                    title=item.title,
-                    state=decision.state,
-                    phase=item.phase,
-                    facets=decision.facets,
-                    sources=item.sources,
-                    next_actions=item.next_actions,
-                    workflow_run_id=item.workflow_run_id,
-                    updated_at=updated_at,
-                )
-            )
-            explanation = dict(explanations.get(item.work_id, _empty_explanation(item.work_id)))
-            explanation["reducer_trace"] = list(decision.trace)
-            explanations[item.work_id] = explanation
-        return LifecycleProjection(
-            items=tuple(sorted(frozen_items, key=lambda item: (item.repo, item.work_id))),
-            explanations=explanations,
-        )
-
     projected: list[WorkItem] = []
     todo_kinds = {"todo", "superpowers_spec", "superpowers_plan", "openspec"}
     for group in correlation.groups:
@@ -166,6 +134,7 @@ def project_work_items(
                 for source in group.sources
             ),
             closure=closure_by_work.get(group.work_id),
+            provider_degraded=correlation.degraded,
             facets=tuple(
                 facet for facet in (prior.facets if prior is not None else ())
                 if facet != "degraded"
@@ -194,6 +163,37 @@ def project_work_items(
         )
         explanation["reducer_trace"] = list(decision.trace)
         explanations[group.work_id] = explanation
+
+    if correlation.degraded:
+        projected_ids = {group.work_id for group in correlation.groups}
+        for item in previous.values():
+            if item.work_id in projected_ids:
+                continue
+            decision = reduce_lifecycle(
+                LifecycleFacts(
+                    previous_state=item.state,
+                    provider_degraded=True,
+                    facets=tuple(facet for facet in item.facets if facet != "degraded"),
+                )
+            )
+            projected.append(
+                WorkItem(
+                    work_id=item.work_id,
+                    repo=item.repo,
+                    title=item.title,
+                    state=decision.state,
+                    phase=item.phase,
+                    facets=decision.facets,
+                    sources=item.sources,
+                    next_actions=item.next_actions,
+                    workflow_run_id=item.workflow_run_id,
+                    updated_at=updated_at,
+                )
+            )
+            explanation = dict(explanations.get(item.work_id, _empty_explanation(item.work_id)))
+            explanation["reducer_trace"] = list(decision.trace)
+            explanations[item.work_id] = explanation
+
     return LifecycleProjection(
         items=tuple(sorted(projected, key=lambda item: (item.repo, item.work_id))),
         explanations=explanations,

--- a/paulsha_cortex/monitor/service.py
+++ b/paulsha_cortex/monitor/service.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import logging
 import os
 import stat
 import threading
 from pathlib import Path
+
+logger = logging.getLogger(__name__)
 
 from .config import MonitorConfig
 from .fs import checked_resolve, checked_stat_mode
@@ -347,9 +350,15 @@ class ProjectMonitorService:
             events = self._work_refresher.refresh(
                 self._store.current_snapshot(), include_github=include_github
             )
-        except (OSError, ValueError):
-            # Durable last-good remains available; the next scheduled refresh retries.
+        except Exception as exc:
+            self._work_store.record_refresh_failure(exc)
+            if isinstance(exc, ValueError):
+                logger.error("deterministic work model refresh failure: %s", exc, exc_info=True)
+            else:
+                logger.warning("transient work model refresh failure: %s", exc, exc_info=True)
             return
+        else:
+            self._work_store.record_refresh_success()
         if events:
             self._server.publish_work_events(events)
 

--- a/paulsha_cortex/monitor/work_api.py
+++ b/paulsha_cortex/monitor/work_api.py
@@ -86,6 +86,8 @@ class WorkReadModelStore:
             identity: dict(explanation)
             for identity, explanation in (explanations or {}).items()
         }
+        self._last_refresh_error: str | None = snapshot.last_refresh_error
+        self._consecutive_refresh_failures: int = snapshot.consecutive_refresh_failures
 
     @classmethod
     def empty(cls) -> "WorkReadModelStore":
@@ -104,6 +106,36 @@ class WorkReadModelStore:
     def sequence(self) -> int:
         with self._lock:
             return self._snapshot.sequence
+
+    @property
+    def last_refresh_error(self) -> str | None:
+        with self._lock:
+            return self._last_refresh_error or self._snapshot.last_refresh_error
+
+    @property
+    def consecutive_refresh_failures(self) -> int:
+        with self._lock:
+            return self._consecutive_refresh_failures or self._snapshot.consecutive_refresh_failures
+
+    def record_refresh_failure(self, exc: Exception | str) -> None:
+        with self._lock:
+            self._last_refresh_error = str(exc)
+            self._consecutive_refresh_failures += 1
+            self._snapshot = replace(
+                self._snapshot,
+                last_refresh_error=self._last_refresh_error,
+                consecutive_refresh_failures=self._consecutive_refresh_failures,
+            )
+
+    def record_refresh_success(self) -> None:
+        with self._lock:
+            self._last_refresh_error = None
+            self._consecutive_refresh_failures = 0
+            self._snapshot = replace(
+                self._snapshot,
+                last_refresh_error=None,
+                consecutive_refresh_failures=0,
+            )
 
     def current_items(self) -> tuple[WorkItem, ...]:
         with self._lock:
@@ -202,7 +234,10 @@ class WorkReadModelStore:
                 if item_id == work_id and (repo is None or item_repo == repo)
             ]
             if not matches:
-                raise KeyError(work_id)
+                err_msg = work_id
+                if self.last_refresh_error is not None:
+                    err_msg = f"{work_id} (monitor refresh failing: {self.last_refresh_error})"
+                raise KeyError(err_msg)
             if len(matches) > 1:
                 raise AmbiguousWorkItemError(work_id)
             item = matches[0]
@@ -401,12 +436,37 @@ class WorkModelRefresher:
             if current_time.tzinfo is None:
                 raise ValueError("now must include timezone")
             attempted_at = current_time.isoformat().replace("+00:00", "Z")
-            for project in sorted(projects, key=lambda item: item.path):
-                if project.legacy:
-                    continue
+            active_projects = [p for p in sorted(projects, key=lambda item: item.path) if not p.legacy]
+            repo_groups: dict[str, list[tuple[ProjectState, Path, bool]]] = {}
+            for project in active_projects:
                 root = Path(project.path)
                 repo, is_github = _repo_identity(root, project.project_id)
+                repo_groups.setdefault(repo, []).append((project, root, is_github))
+
+            for repo, group in sorted(repo_groups.items(), key=lambda row: row[0]):
+                # Sort so main git repo (.git is dir) comes first, then shortest path
+                def _is_canonical(root: Path) -> int:
+                    git_dir = root / ".git"
+                    return 0 if git_dir.is_dir() else 1
+
+                sorted_group = sorted(
+                    group, key=lambda row: (_is_canonical(row[1]), len(row[1].parts), str(row[1]))
+                )
+                project, root, is_github = sorted_group[0]
+                duplicate_roots = [row[1] for row in sorted_group[1:]]
+
                 local_result = RepoWorkProvider(root, repo=repo).scan()
+                if duplicate_roots:
+                    dup_paths = ", ".join(str(r) for r in duplicate_roots)
+                    local_result = replace(
+                        local_result,
+                        diagnostics=tuple(
+                            (
+                                *local_result.diagnostics,
+                                f"duplicate checkout of repo {repo} at {dup_paths}; ignoring non-canonical checkouts",
+                            )
+                        ),
+                    )
                 previous_local = providers.get(local_result.provider_id)
                 local = _retain_last_good(previous_local, local_result)
                 providers[local.provider_id] = local
@@ -541,22 +601,22 @@ class WorkModelRefresher:
                     (work_key(repo, work_id), explanation)
                     for work_id, explanation in projection.explanations.items()
                 )
+                source_owners.update(
+                    (source_id, work_key(repo, owner))
+                    for source_id, owner in correlation.source_owners.items()
+                )
+                exclusions.extend(correlation.exclusions)
                 if correlation.degraded:
                     projected_ids = {
                         work_key(item.repo, item.work_id) for item in projection.items
                     }
-                    source_owners.update(
-                        (source_id, owner)
-                        for source_id, owner in previous.source_owners.items()
-                        if owner in projected_ids
-                    )
+                    current_source_ids = {
+                        source.source_id for item in projection.items for source in item.sources
+                    }
+                    for source_id, owner in previous.source_owners.items():
+                        if owner in projected_ids and source_id not in current_source_ids and source_id not in source_owners:
+                            source_owners[source_id] = owner
                     exclusions.extend(previous.exclusions)
-                else:
-                    source_owners.update(
-                        (source_id, work_key(repo, owner))
-                        for source_id, owner in correlation.source_owners.items()
-                    )
-                    exclusions.extend(correlation.exclusions)
             providers = {
                 provider_id: provider
                 for provider_id, provider in providers.items()

--- a/paulsha_cortex/monitor/work_snapshot.py
+++ b/paulsha_cortex/monitor/work_snapshot.py
@@ -19,6 +19,8 @@ SNAPSHOT_SCHEMA = "work-items-snapshot/v1"
 
 def work_key(repo: str, work_id: str) -> str:
     """Stable external identity for a repo-scoped Work Item."""
+    if work_id.startswith(f"{repo}::"):
+        return work_id
     return f"{repo}::{work_id}"
 
 
@@ -38,6 +40,8 @@ class WorkSnapshot:
     work_items: tuple[WorkItem, ...]
     source_owners: Mapping[str, str]
     exclusions: tuple[Mapping[str, str], ...]
+    last_refresh_error: str | None = None
+    consecutive_refresh_failures: int = 0
 
     def __post_init__(self) -> None:
         if isinstance(self.sequence, bool) or not isinstance(self.sequence, int) or self.sequence < 0:
@@ -66,7 +70,12 @@ class WorkSnapshot:
                 raise ValueError("provider map key does not match provider snapshot")
         work_ids = {work_key(item.repo, item.work_id) for item in self.work_items}
         if len(work_ids) != len(self.work_items):
-            raise ValueError("duplicate work item ID")
+            counts: dict[str, int] = {}
+            for item in self.work_items:
+                k = work_key(item.repo, item.work_id)
+                counts[k] = counts.get(k, 0) + 1
+            dups = sorted(k for k, v in counts.items() if v > 1)
+            raise ValueError(f"duplicate work item ID: {', '.join(dups)}")
         for source_id, owner in self.source_owners.items():
             if not isinstance(source_id, str) or not source_id:
                 raise ValueError("ownership source ID must be non-empty")
@@ -91,7 +100,7 @@ class WorkSnapshot:
                 raise ValueError("exclusion keys and values must be strings")
 
     def to_dict(self) -> dict[str, Any]:
-        return {
+        payload = {
             "schema": SNAPSHOT_SCHEMA,
             "sequence": self.sequence,
             "written_at": self.written_at,
@@ -109,6 +118,11 @@ class WorkSnapshot:
             },
             "exclusions": [dict(item) for item in self.exclusions],
         }
+        if self.last_refresh_error is not None:
+            payload["last_refresh_error"] = self.last_refresh_error
+        if self.consecutive_refresh_failures:
+            payload["consecutive_refresh_failures"] = self.consecutive_refresh_failures
+        return payload
 
     @classmethod
     def from_dict(cls, payload: object) -> "WorkSnapshot":
@@ -124,6 +138,8 @@ class WorkSnapshot:
         work_items = payload.get("work_items")
         source_owners = payload.get("source_owners")
         exclusions = payload.get("exclusions")
+        last_refresh_error = payload.get("last_refresh_error")
+        consecutive_refresh_failures = payload.get("consecutive_refresh_failures", 0)
         if isinstance(sequence, bool) or not isinstance(sequence, int):
             raise ValueError("snapshot sequence must be an integer")
         if not isinstance(written_at, str):
@@ -146,6 +162,8 @@ class WorkSnapshot:
             work_items=tuple(WorkItem.from_dict(item) for item in work_items),
             source_owners=dict(source_owners),
             exclusions=tuple(exclusions),
+            last_refresh_error=str(last_refresh_error) if last_refresh_error is not None else None,
+            consecutive_refresh_failures=int(consecutive_refresh_failures) if isinstance(consecutive_refresh_failures, (int, float)) and not isinstance(consecutive_refresh_failures, bool) else 0,
         )
 
     def provider_is_fresh(

--- a/tests/test_issue_273_monitor_silent-failure.py
+++ b/tests/test_issue_273_monitor_silent-failure.py
@@ -1,0 +1,189 @@
+"""Tests for issue #273: monitor refresh silent failures, duplicate checkouts, and source collisions."""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from paulsha_cortex.monitor.config import MonitorConfig
+from paulsha_cortex.monitor.correlation import correlate_work_sources
+from paulsha_cortex.monitor.models import ProjectState
+from paulsha_cortex.monitor.service import ProjectMonitorService
+from paulsha_cortex.monitor.work_api import (
+    WorkModelRefresher,
+    WorkReadModelStore,
+)
+from paulsha_cortex.monitor.work_models import WorkSource
+from paulsha_cortex.monitor.work_snapshot import WorkSnapshot, WorkSnapshotStore
+from paulsha_cortex.coordinator.claim import load_work_authority
+
+
+def test_refresh_failure_observability_and_logging(tmp_path: Path, caplog: pytest.CapLogFixture) -> None:
+    """Defect 1: refresh exceptions are logged and tracked in store status."""
+    read_store = WorkReadModelStore.empty()
+    assert getattr(read_store, "last_refresh_error", None) is None
+    assert getattr(read_store, "consecutive_refresh_failures", 0) == 0
+
+    mock_refresher = MagicMock(spec=WorkModelRefresher)
+    mock_refresher.refresh.side_effect = ValueError("Frontmatter work_item mismatch in proposal.md")
+
+    svc = ProjectMonitorService(
+        config=MonitorConfig(workspaces=(), socket_path=tmp_path / "test.sock"),
+        work_store=read_store,
+        work_refresher=mock_refresher,
+    )
+
+    with caplog.at_level(logging.ERROR):
+        svc._refresh_work_model(include_github=False)
+
+    # 1. Logging verification: must write log when ValueError occurs
+    assert any("Frontmatter work_item mismatch" in rec.message for rec in caplog.records)
+
+    # 2. Status verification: consecutive failures and last error must be recorded
+    assert read_store.consecutive_refresh_failures == 1
+    assert "Frontmatter work_item mismatch" in str(read_store.last_refresh_error)
+
+    # Second failure increments failure count
+    with caplog.at_level(logging.ERROR):
+        svc._refresh_work_model(include_github=False)
+
+    assert read_store.consecutive_refresh_failures == 2
+
+    # Success resets consecutive failure count
+    mock_refresher.refresh.side_effect = None
+    mock_refresher.refresh.return_value = ()
+    svc._refresh_work_model(include_github=False)
+
+    assert read_store.consecutive_refresh_failures == 0
+    assert read_store.last_refresh_error is None
+
+
+def test_work_show_and_start_error_messaging_on_refresh_failure() -> None:
+    """Defect 1: get_work_item & load_work_authority report root cause when refresh failed."""
+    read_store = WorkReadModelStore.empty()
+    read_store.record_refresh_failure(ValueError("Frontmatter collision in repo X"))
+
+    # get_work_item on missing item when refresh failed
+    with pytest.raises(KeyError) as exc_info:
+        read_store.get_work_item("nonexistent-item", repo="test/repo")
+    assert "Frontmatter collision" in str(exc_info.value) or "refresh" in str(exc_info.value).lower()
+
+    # load_work_authority on snapshot payload containing last_refresh_error
+    snapshot_data = {
+        "schema": "work-items-snapshot/v1",
+        "sequence": 1,
+        "written_at": "2026-07-31T00:00:00Z",
+        "providers": {},
+        "work_items": [],
+        "source_owners": {},
+        "exclusions": [],
+        "last_refresh_error": "Frontmatter collision in repo X",
+        "consecutive_refresh_failures": 3,
+    }
+    with patch("paulsha_cortex.coordinator.claim._load_snapshot") as mock_load:
+        mock_load.return_value = (snapshot_data, "digest123")
+        with pytest.raises(ValueError) as claim_exc:
+            load_work_authority(repo="test/repo", work_id="nonexistent-item")
+        assert "Frontmatter collision" in str(claim_exc.value) or "refresh" in str(claim_exc.value).lower()
+
+
+def test_duplicate_checkout_same_repo_deduplication(tmp_path: Path) -> None:
+    """Defect 2: multiple checkouts of same repo don't throw opaque duplicate work item ID."""
+    repo_dir = tmp_path / "my-repo"
+    repo_dir.mkdir()
+    (repo_dir / ".git").mkdir()  # canonical git repo dir
+
+    wt_dir = tmp_path / "my-repo-wt"
+    wt_dir.mkdir()
+    (wt_dir / ".git").write_text("gitdir: /path/to/git\n")  # sibling worktree file
+
+    work_yaml = """
+version: 1
+work_items:
+  item-1:
+    title: "Item 1"
+    links:
+      - kind: path
+        ref: "docs/superpowers/workstreams/ws1/todo.md"
+"""
+    (repo_dir / ".cortex").mkdir()
+    (repo_dir / ".cortex" / "work-items.yaml").write_text(work_yaml)
+    todo_dir1 = repo_dir / "docs" / "superpowers" / "workstreams" / "ws1"
+    todo_dir1.mkdir(parents=True)
+    (todo_dir1 / "todo.md").write_text("# TODO\n<!-- work_item: item-1 -->\n- [ ] task\n")
+
+    (wt_dir / ".cortex").mkdir()
+    (wt_dir / ".cortex" / "work-items.yaml").write_text(work_yaml)
+    todo_dir2 = wt_dir / "docs" / "superpowers" / "workstreams" / "ws1"
+    todo_dir2.mkdir(parents=True)
+    (todo_dir2 / "todo.md").write_text("# TODO\n<!-- work_item: item-1 -->\n- [ ] task\n")
+
+    projects = (
+        ProjectState(project_id="my-org/my-repo", workspace="my-repo", path=str(repo_dir)),
+        ProjectState(project_id="my-org/my-repo", workspace="my-repo-wt", path=str(wt_dir)),
+    )
+
+    durable_store = WorkSnapshotStore(path=tmp_path / "snapshot.json")
+    read_store = WorkReadModelStore.empty()
+    refresher = WorkModelRefresher(durable_store=durable_store, read_store=read_store)
+
+    # Must NOT raise ValueError("duplicate work item ID")
+    refresher.refresh(projects, include_github=False)
+
+    snapshot = read_store.current_snapshot()
+    # Check that canonical project work item exists
+    work_ids = [item.work_id for item in snapshot.work_items]
+    assert "item-1" in work_ids
+
+    # Check provider diagnostics include directory paths of collision
+    repo_provider = snapshot.providers.get("repo:my-org/my-repo")
+    assert repo_provider is not None
+    assert any("my-repo-wt" in diag or "duplicate checkout" in diag for diag in repo_provider.diagnostics)
+
+
+def test_source_collision_localized_projection_impact(tmp_path: Path) -> None:
+    """Defect 3: single source collision degrades repo but does not wipe all unrelated work items."""
+    # Setup sources where item-1 and item-2 collide on openspec change-1, but item-3 is healthy on todo:tasks.md
+    change_dir = tmp_path / "openspec" / "changes" / "change-1"
+    change_dir.mkdir(parents=True)
+    (change_dir / "proposal.md").write_text("---\nwork_item: item-1\n---\n")
+    (change_dir / "tasks.md").write_text("---\nwork_item: item-2\n---\n")
+
+    tasks_file = tmp_path / "tasks.md"
+    tasks_file.write_text("---\nwork_item: item-3\n---\n# TODO\n- [ ] do task 3\n")
+
+    source_colliding_1 = WorkSource(
+        source_id="openspec:change-1",
+        kind="openspec",
+        ref="change-1",
+        status="active",
+        revision="rev1",
+        confidence="confirmed",
+        provider="repo:my-org/my-repo",
+    )
+    source_healthy = WorkSource(
+        source_id="todo:tasks.md",
+        kind="todo",
+        ref="tasks.md",
+        status="active",
+        revision="rev2",
+        confidence="confirmed",
+        provider="repo:my-org/my-repo",
+    )
+
+    sources = (source_colliding_1, source_healthy)
+    res = correlate_work_sources(
+        repo_root=tmp_path,
+        repo="my-org/my-repo",
+        sources=sources,
+    )
+
+    # 1. Correlation must be marked degraded
+    assert res.degraded is True
+    assert any("confirmed source collision: openspec:change-1" in diag for diag in res.diagnostics)
+
+    # 2. Healthy work item (item-3) MUST still be projected in groups!
+    group_work_ids = {group.work_id for group in res.groups}
+    assert "item-3" in group_work_ids


### PR DESCRIPTION
## 摘要

修 #273 的三個根本缺陷。這個 bug 讓 monitor 的 `work-items.snapshot.json` 從 2026-07-26 到 07-30 **完全沒更新**，期間服務一直顯示 `active running`、`journalctl` 沒有任何錯誤 —— 診斷花掉數小時，大部分時間耗在「服務看起來正常」這個假象上。

PR #274 只修掉觸發該次事故的單一實例（一個 openspec change 目錄內 frontmatter 不一致），三個根本缺陷留到本 PR。

## 缺陷一：refresh 例外被靜默吞掉

`monitor/service.py` 的 `_refresh_work_model` 原本：

```python
except (OSError, ValueError):
    # Durable last-good remains available; the next scheduled refresh retries.
    return
```

註解假設「下次重試就會好」，但失敗原因是**確定性**的資料問題時，每次重試都以同樣方式失敗，snapshot 永久凍結且沒有任何 log／status 訊號。

改為：失敗會寫 log，並在 status／snapshot 保留最後錯誤與連續失敗計數；`work show` / `work start` 在 snapshot 停更時，錯誤訊息指向真正原因，而不是只說 work item 不存在。

## 缺陷二：同 repo 多 checkout 造成 duplicate work item ID

`WorkSnapshot.validate_ownership()` 以 `work_key(repo, work_id)` 判重，而 `_repo_identity()` 由 git remote 解析 repo —— 所以同一 repo 的多個 checkout 解析出相同 repo 名而碰撞。實測本機三組：`IntelliDbgKit`（6 個目錄）、`paulsha-hippo`（2 個）、`testpilot`（2 個）。

**cortex 自己大量使用 sibling worktree（`<repo>-worktrees/`），這是結構性問題而非邊緣情況。**

改為：掃描階段對同一 repo 的多個 checkout 取 canonical、忽略其餘，並在診斷中**明確列出是哪些目錄**碰撞（`duplicate checkout of repo <repo> at <paths>; ignoring non-canonical checkouts`），而不是拋一個沒有上下文的 `duplicate work item ID`。

## 缺陷三：單一 source collision 使整個 repo 的 projection 歸零

`monitor/lifecycle.py` 原本在 `correlation.degraded` 時，把 **previous 的所有 item** 換成凍結版本 —— 等於整個 repo 的新投影消失。實測：一行 frontmatter 不一致讓 `hamanpaul/paulsha-cortex` 的 work item 從 43 個變成 **0 個**，任何 work item 都無法 claim。

改為只對**沒有成功投影出來的** item 補凍結版本：

```python
projected_ids = {group.work_id for group in correlation.groups}
for item in previous.values():
    if item.work_id in projected_ids:
        continue
    ...
```

collision 的影響因此限縮在相關 work item，成功投影的部分照常可用。

## 驗證

- `pytest tests/ -q` → **1704 passed, 32 subtests**（基準 1700，新增 4 個測試）
- 帶 PR 上下文的 `policy_check` → **pass: 24, fail: 0, warn: 2**（R-18／R-22 advisory）

| 測試 | 對應缺陷 |
|---|---|
| `test_refresh_failure_observability_and_logging` | 一 |
| `test_work_show_and_start_error_messaging_on_refresh_failure` | 一 |
| `test_duplicate_checkout_same_repo_deduplication` | 二 |
| `test_source_collision_localized_projection_impact` | 三 |

## 附帶效果

缺陷二落地後，`monitor.ignore_dirs` 不再需要為了迴避 checkout 碰撞而逐一列舉目錄（先前是靠手動排除 7 個目錄繞過）。既有的 `ignore_dirs` 設定仍然有效，只是不再是必要的。

Closes #273

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MBuP74pQJyBBcX17DDxBAo
