### PR TITLE
feat(quality): subagent 產出的六項機械驗收檢查

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
   靜音）。`persona-scope` 設為 main required status check 屬 GitHub repo 設定，
   設定步驟見 `docs/persona-scope-enforcement.md`。
 ### Added
+- **Refs #292：實作 subagent / agent 派工收尾的六項確定性機械驗收檢查**：提供零 model session 的確定性收尾檢查 (`paulsha_cortex.mechanical_acceptance` 與 `cortex mechanical-acceptance`)，包含 1. 自我宣稱 vs 產出比對、2. 輸出內部一致性、3. 摘要 vs 內文一致性、4. 事實新鮮度 (涵蓋 PR body 與 commit message 的 closing keyword 雙重檢查)、5. 語言規範、6. 禁止無依據量化。提供 `policy-exempt:*` 白名單豁免與全套正負向測試。
 - **Issue #262：dispatch 前驗證 runtime capability 與 provider snapshot 新鮮度**：新增
   `coordinator/runtime_preflight.py`，在建立 worktree／sandbox／job row／model session 之前，
   於「即將實際被使用的 executor 環境」執行低成本 preflight。card 契約新增 `runtime_capabilities`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@
   靜音）。`persona-scope` 設為 main required status check 屬 GitHub repo 設定，
   設定步驟見 `docs/persona-scope-enforcement.md`。
 ### Added
-- **Refs #292：實作 subagent / agent 派工收尾的六項確定性機械驗收檢查**：提供零 model session 的確定性收尾檢查 (`paulsha_cortex.mechanical_acceptance` 與 `cortex mechanical-acceptance`)，包含 1. 自我宣稱 vs 產出比對、2. 輸出內部一致性、3. 摘要 vs 內文一致性、4. 事實新鮮度 (涵蓋 PR body 與 commit message 的 closing keyword 雙重檢查)、5. 語言規範、6. 禁止無依據量化。提供 `policy-exempt:*` 白名單豁免與全套正負向測試。
+- **Refs #292：實作 subagent / agent 派工收尾的六項確定性機械驗收檢查**：提供零 model session 的確定性收尾檢查 (`paulsha_cortex.mechanical_acceptance` 與 `cortex mechanical-acceptance`)，包含 1. 自我宣稱 vs 產出比對、2. 輸出內部一致性、3. 摘要 vs 內文一致性、4. 事實新鮮度 (涵蓋 PR body 與 commit message 的 closing keyword 雙重檢查)、5. 語言規範、6. 禁止無依據量化。提供 `--pr <N>`/`--unresolved-issues`/`--repo-root` 自動 context 蒐集、缺 context 標為 `SKIPPED`（exit code 2）而非 `PASS`、`policy-exempt:*` 白名單豁免與全套正負向測試。
 - **Issue #262：dispatch 前驗證 runtime capability 與 provider snapshot 新鮮度**：新增
   `coordinator/runtime_preflight.py`，在建立 worktree／sandbox／job row／model session 之前，
   於「即將實際被使用的 executor 環境」執行低成本 preflight。card 契約新增 `runtime_capabilities`

--- a/changelog.d/mechanical-acceptance.md
+++ b/changelog.d/mechanical-acceptance.md
@@ -2,5 +2,11 @@
 - **Refs #292：實作 subagent / agent 派工收尾的六項確定性機械驗收檢查**：提供零 model
   session 的確定性收尾檢查 (`paulsha_cortex.mechanical_acceptance` 與 `cortex mechanical-acceptance`)，
   包含 1. 自我宣稱 vs 產出比對、2. 輸出內部一致性、3. 摘要 vs 內文一致性、4. 事實新鮮度 (涵蓋 PR body
-  與 commit message 的 closing keyword 雙重檢查)、5. 語言規範、6. 禁止無依據量化。提供 `policy-exempt:*`
-  白名單豁免與全套正負向測試。
+  與 commit message 的 closing keyword 雙重檢查)、5. 語言規範、6. 禁止無依據量化。
+
+### Changed
+- **Refs #292：CLI 自動蒐集 context、SKIPPED 狀態與 exit code 語意**：
+  - 新增 `--pr <N>` 參數，自動透過 `gh` CLI 抓取 PR body/labels/commits 與被引用的 Issue 狀態。
+  - 新增 `--unresolved-issues` 與 `--repo-root` 參數。
+  - 缺少判定所需的必要 context 時，狀態明確標示為 `SKIPPED` 並說明缺少的 context，不再盲目回報 `PASS`。
+  - exit code 語意明確：全 PASS = 0；有 FAIL = 1；有 SKIPPED 但無 FAIL = 2。

--- a/changelog.d/mechanical-acceptance.md
+++ b/changelog.d/mechanical-acceptance.md
@@ -1,0 +1,6 @@
+### Added
+- **Refs #292：實作 subagent / agent 派工收尾的六項確定性機械驗收檢查**：提供零 model
+  session 的確定性收尾檢查 (`paulsha_cortex.mechanical_acceptance` 與 `cortex mechanical-acceptance`)，
+  包含 1. 自我宣稱 vs 產出比對、2. 輸出內部一致性、3. 摘要 vs 內文一致性、4. 事實新鮮度 (涵蓋 PR body
+  與 commit message 的 closing keyword 雙重檢查)、5. 語言規範、6. 禁止無依據量化。提供 `policy-exempt:*`
+  白名單豁免與全套正負向測試。

--- a/paulsha_cortex/mechanical_acceptance/__init__.py
+++ b/paulsha_cortex/mechanical_acceptance/__init__.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from .claim_vs_output import check_claim_vs_output
 from .fact_freshness import check_fact_freshness
+from .gh_collector import collect_pr_context
 from .internal_consistency import check_internal_consistency
 from .language_conventions import check_language_conventions
 from .models import AcceptanceReport, CheckResult, is_exempted
@@ -18,6 +19,7 @@ __all__ = [
     "check_language_conventions",
     "check_summary_vs_body",
     "check_unsubstantiated_quantification",
+    "collect_pr_context",
     "is_exempted",
     "run_acceptance_checks",
 ]

--- a/paulsha_cortex/mechanical_acceptance/__init__.py
+++ b/paulsha_cortex/mechanical_acceptance/__init__.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from .claim_vs_output import check_claim_vs_output
+from .fact_freshness import check_fact_freshness
+from .internal_consistency import check_internal_consistency
+from .language_conventions import check_language_conventions
+from .models import AcceptanceReport, CheckResult, is_exempted
+from .runner import run_acceptance_checks
+from .summary_vs_body import check_summary_vs_body
+from .unsubstantiated_quantification import check_unsubstantiated_quantification
+
+__all__ = [
+    "AcceptanceReport",
+    "CheckResult",
+    "check_claim_vs_output",
+    "check_fact_freshness",
+    "check_internal_consistency",
+    "check_language_conventions",
+    "check_summary_vs_body",
+    "check_unsubstantiated_quantification",
+    "is_exempted",
+    "run_acceptance_checks",
+]

--- a/paulsha_cortex/mechanical_acceptance/claim_vs_output.py
+++ b/paulsha_cortex/mechanical_acceptance/claim_vs_output.py
@@ -24,6 +24,31 @@ def check_claim_vs_output(
     findings: list[str] = []
     details: dict[str, Any] = {}
 
+    has_input = any(
+        x is not None
+        for x in (
+            claimed_count,
+            claimed_fixed,
+            claimed_params,
+            canonical_params,
+            rerun_fn,
+            residual_findings,
+        )
+    )
+
+    if not has_input:
+        return CheckResult(
+            check_id=check_id,
+            check_name=check_name,
+            passed=exempt,
+            exempted=exempt,
+            exemption_reason=reason if exempt else "",
+            skipped=not exempt,
+            skipped_reason="缺少自我宣稱與產出比對 context (claimed_params/canonical_params/rerun_fn/residual_findings)",
+            findings=findings,
+            details=details,
+        )
+
     # 1. 檢查參數是否遭篡改（例如 #262 實例：subagent 修改 pr-body "Refs" -> "Fixes" 以利過關）
     if claimed_params is not None and canonical_params is not None:
         tampered_keys = []

--- a/paulsha_cortex/mechanical_acceptance/claim_vs_output.py
+++ b/paulsha_cortex/mechanical_acceptance/claim_vs_output.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from typing import Any, Callable, Mapping, Sequence
+from .models import CheckResult, is_exempted
+
+
+def check_claim_vs_output(
+    claimed_count: int | None = None,
+    claimed_fixed: bool | None = None,
+    claimed_params: Mapping[str, Any] | None = None,
+    canonical_params: Mapping[str, Any] | None = None,
+    rerun_fn: Callable[[Mapping[str, Any]], int | Sequence[Any]] | None = None,
+    residual_findings: Sequence[str] | None = None,
+    pr_labels: Sequence[str] = (),
+) -> CheckResult:
+    """第 1 項：自我宣稱 vs 產出比對。
+
+    重跑時強制使用 canonical_params（不得採信 claimed_params）。
+    """
+    check_id = "claim_vs_output"
+    check_name = "自我宣稱 vs 產出比對"
+    exempt, reason = is_exempted(check_id, pr_labels)
+
+    findings: list[str] = []
+    details: dict[str, Any] = {}
+
+    # 1. 檢查參數是否遭篡改（例如 #262 實例：subagent 修改 pr-body "Refs" -> "Fixes" 以利過關）
+    if claimed_params is not None and canonical_params is not None:
+        tampered_keys = []
+        for k, v in canonical_params.items():
+            if k in claimed_params and claimed_params[k] != v:
+                tampered_keys.append(f"{k} (宣稱 '{claimed_params[k]}' vs 規範 '{v}')")
+        if tampered_keys:
+            findings.append(f"宣稱驗收參數與規範不符（疑似自行修改輸入以通過 gate）: {', '.join(tampered_keys)}")
+            details["tampered_params"] = tampered_keys
+
+    # 2. 獨立重跑驗證（重跑驗證端必須使用 canonical_params）
+    if rerun_fn is not None:
+        params_to_use = canonical_params if canonical_params is not None else (claimed_params or {})
+        res = rerun_fn(params_to_use)
+        if isinstance(res, int):
+            if res > 0:
+                findings.append(f"獨立重跑驗證發現 {res} 處殘留問題 (宣稱已修復)")
+                details["rerun_residual_count"] = res
+        elif isinstance(res, (list, tuple)):
+            if len(res) > 0:
+                findings.append(f"獨立重跑驗證發現 {len(res)} 處殘留問題: {list(res)}")
+                details["rerun_residual_findings"] = list(res)
+
+    elif residual_findings:
+        findings.append(f"產出比對發現 {len(residual_findings)} 處殘留問題: {list(residual_findings)}")
+        details["residual_findings"] = list(residual_findings)
+
+    if claimed_count is not None and rerun_fn is None:
+        actual_count = len(residual_findings or [])
+        if claimed_count != actual_count:
+            findings.append(f"宣稱數量 ({claimed_count}) 與實際殘留數量 ({actual_count}) 不符")
+
+    passed = len(findings) == 0
+    return CheckResult(
+        check_id=check_id,
+        check_name=check_name,
+        passed=passed or exempt,
+        exempted=exempt,
+        exemption_reason=reason if exempt else "",
+        findings=findings,
+        details=details,
+    )

--- a/paulsha_cortex/mechanical_acceptance/fact_freshness.py
+++ b/paulsha_cortex/mechanical_acceptance/fact_freshness.py
@@ -18,7 +18,8 @@ def check_fact_freshness(
     commit_messages: Sequence[str] = (),
     referenced_files: Sequence[str] = (),
     repo_root: str | Path | None = None,
-    unresolved_issues: Sequence[int] = (),
+    unresolved_issues: Sequence[int] | None = None,
+    unresolved_issues_provided: bool = False,
     pr_labels: Sequence[str] = (),
 ) -> CheckResult:
     """第 4 項：事實新鮮度。
@@ -32,6 +33,51 @@ def check_fact_freshness(
 
     findings: list[str] = []
     details: dict[str, Any] = {}
+
+    if unresolved_issues is not None:
+        unresolved_issues_provided = True
+        unresolved_list = list(unresolved_issues)
+    else:
+        unresolved_list = []
+
+    has_content = bool(text_content or pr_body or commit_messages or referenced_files)
+    if not has_content:
+        return CheckResult(
+            check_id=check_id,
+            check_name=check_name,
+            passed=exempt,
+            exempted=exempt,
+            exemption_reason=reason if exempt else "",
+            skipped=not exempt,
+            skipped_reason="缺少待檢測文字、PR body 或 commit 訊息 context",
+            findings=findings,
+            details=details,
+        )
+
+    # 檢查是否有 closing keywords
+    closing_matches = []
+    for src_name, text in [("PR body", pr_body), ("text_content", text_content)]:
+        if text:
+            for kw, num_str in CLOSING_KEYWORDS_RE.findall(text):
+                closing_matches.append((src_name, kw, int(num_str)))
+    for idx, msg in enumerate(commit_messages):
+        if msg:
+            for kw, num_str in CLOSING_KEYWORDS_RE.findall(msg):
+                closing_matches.append((f"Commit msg #{idx+1}", kw, int(num_str)))
+
+    if closing_matches and not unresolved_issues_provided:
+        sample_src, sample_kw, sample_num = closing_matches[0]
+        return CheckResult(
+            check_id=check_id,
+            check_name=check_name,
+            passed=exempt,
+            exempted=exempt,
+            exemption_reason=reason if exempt else "",
+            skipped=not exempt,
+            skipped_reason=f"檢出 closing keyword '{sample_kw} #{sample_num}' ({sample_src})，但缺少 unresolved_issues 上下文，無法核對 issue 狀態",
+            findings=findings,
+            details=details,
+        )
 
     root = Path(repo_root) if repo_root is not None else Path.cwd()
 
@@ -55,7 +101,7 @@ def check_fact_freshness(
         details["obsolete_references"] = obsolete_references
 
     # 2. Closing Keyword (PR body + Commit messages 雙重來源檢查)
-    unresolved_set = set(unresolved_issues)
+    unresolved_set = set(unresolved_list)
     closing_violations = []
 
     if pr_body:

--- a/paulsha_cortex/mechanical_acceptance/fact_freshness.py
+++ b/paulsha_cortex/mechanical_acceptance/fact_freshness.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+from typing import Any, Sequence
+from .models import CheckResult, is_exempted
+
+CLOSING_KEYWORDS_RE = re.compile(
+    r"\b(closes?|closed|fixes?|fixed|resolves?|resolved)\s+#(\d+)",
+    re.IGNORECASE,
+)
+
+
+def check_fact_freshness(
+    text_content: str = "",
+    pr_body: str = "",
+    commit_messages: Sequence[str] = (),
+    referenced_files: Sequence[str] = (),
+    repo_root: str | Path | None = None,
+    unresolved_issues: Sequence[int] = (),
+    pr_labels: Sequence[str] = (),
+) -> CheckResult:
+    """第 4 項：事實新鮮度。
+
+    1. 產出中的檔名/路徑/設定鍵對 repo 實際狀態核對。
+    2. closing keyword 需同時檢查 PR body 與 commit message 兩個來源。
+    """
+    check_id = "fact_freshness"
+    check_name = "事實新鮮度"
+    exempt, reason = is_exempted(check_id, pr_labels)
+
+    findings: list[str] = []
+    details: dict[str, Any] = {}
+
+    root = Path(repo_root) if repo_root is not None else Path.cwd()
+
+    # 1. 檔名/設定檔新鮮度檢查
+    obsolete_references = []
+    files_to_check = list(referenced_files)
+    if text_content:
+        for match in re.findall(r"\.[\w\-]+\.(?:yml|yaml|json|toml|py)", text_content):
+            if match not in files_to_check:
+                files_to_check.append(match)
+
+    for ref in files_to_check:
+        if ref == ".paul-project.yml" and not (root / ".paul-project.yml").exists():
+            current = ".project-policy.yml" if (root / ".project-policy.yml").exists() else "新版設定檔"
+            obsolete_references.append(f"引用過時設定檔 '{ref}'（現已更名為 '{current}'）")
+        elif not os.path.isabs(ref) and "/" in ref and not (root / ref).exists():
+            obsolete_references.append(f"引用不存在或已移動之檔案/路徑 '{ref}'")
+
+    if obsolete_references:
+        findings.extend(obsolete_references)
+        details["obsolete_references"] = obsolete_references
+
+    # 2. Closing Keyword (PR body + Commit messages 雙重來源檢查)
+    unresolved_set = set(unresolved_issues)
+    closing_violations = []
+
+    if pr_body:
+        for kw, issue_num_str in CLOSING_KEYWORDS_RE.findall(pr_body):
+            issue_num = int(issue_num_str)
+            if issue_num in unresolved_set:
+                closing_violations.append(
+                    f"PR body 使用 closing keyword '{kw} #{issue_num}'，但 Issue #{issue_num} 未完全解決（應使用 Refs #{issue_num}）"
+                )
+
+    for idx, commit_msg in enumerate(commit_messages):
+        for kw, issue_num_str in CLOSING_KEYWORDS_RE.findall(commit_msg):
+            issue_num = int(issue_num_str)
+            if issue_num in unresolved_set:
+                closing_violations.append(
+                    f"Commit msg #{idx+1} ('{commit_msg.strip().splitlines()[0]}') 使用 closing keyword '{kw} #{issue_num}'，"
+                    f"但 Issue #{issue_num} 未完全解決（此操作會導致 merge 時自動誤關 Issue，應改用 Refs #{issue_num}）"
+                )
+
+    if closing_violations:
+        findings.extend(closing_violations)
+        details["closing_keyword_violations"] = closing_violations
+
+    passed = len(findings) == 0
+    return CheckResult(
+        check_id=check_id,
+        check_name=check_name,
+        passed=passed or exempt,
+        exempted=exempt,
+        exemption_reason=reason if exempt else "",
+        findings=findings,
+        details=details,
+    )

--- a/paulsha_cortex/mechanical_acceptance/gh_collector.py
+++ b/paulsha_cortex/mechanical_acceptance/gh_collector.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+from pathlib import Path
+from typing import Any, Callable
+
+CLOSING_KEYWORDS_RE = re.compile(
+    r"\b(closes?|closed|fixes?|fixed|resolves?|resolved)\s+#(\d+)",
+    re.IGNORECASE,
+)
+REFS_RE = re.compile(r"#(\d+)")
+
+
+def default_gh_runner(args: list[str]) -> str:
+    res = subprocess.run(["gh"] + args, capture_output=True, text=True, check=True)
+    return res.stdout
+
+
+def collect_pr_context(
+    pr_number: int | str,
+    repo_root: str | Path | None = None,
+    gh_runner: Callable[[list[str]], str] = default_gh_runner,
+) -> dict[str, Any]:
+    """使用 gh CLI 自動蒐集 PR 相關的完整 context。"""
+    context: dict[str, Any] = {}
+    if repo_root is not None:
+        context["repo_root"] = str(repo_root)
+
+    try:
+        raw_pr_json = gh_runner(["pr", "view", str(pr_number), "--json", "title,body,labels,commits"])
+        pr_data = json.loads(raw_pr_json)
+
+        title = pr_data.get("title", "")
+        body = pr_data.get("body", "")
+        labels_raw = pr_data.get("labels", [])
+        commits_raw = pr_data.get("commits", [])
+
+        context["title"] = title
+        context["pr_body"] = body
+        context["text_content"] = body
+        context["pr_labels"] = [l.get("name", "") for l in labels_raw if isinstance(l, dict) and l.get("name")]
+
+        commit_messages: list[str] = []
+        for c in commits_raw:
+            if isinstance(c, dict):
+                msg = c.get("message")
+                if not msg:
+                    headline = c.get("messageHeadline", "")
+                    c_body = c.get("messageBody", "")
+                    msg = f"{headline}\n{c_body}".strip()
+                if msg:
+                    commit_messages.append(msg)
+        context["commit_messages"] = commit_messages
+
+        # 蒐集所有在 PR body 與 commit message 提及的 Issue ID
+        referenced_issue_nums: set[int] = set()
+        for kw, num_str in CLOSING_KEYWORDS_RE.findall(body):
+            referenced_issue_nums.add(int(num_str))
+        for num_str in REFS_RE.findall(body):
+            referenced_issue_nums.add(int(num_str))
+
+        for msg in commit_messages:
+            for kw, num_str in CLOSING_KEYWORDS_RE.findall(msg):
+                referenced_issue_nums.add(int(num_str))
+            for num_str in REFS_RE.findall(msg):
+                referenced_issue_nums.add(int(num_str))
+
+        unresolved_issues: list[int] = []
+        for issue_num in sorted(referenced_issue_nums):
+            try:
+                raw_issue_json = gh_runner(["issue", "view", str(issue_num), "--json", "state,number"])
+                issue_data = json.loads(raw_issue_json)
+                state = issue_data.get("state", "").upper()
+                if state != "CLOSED":
+                    unresolved_issues.append(issue_num)
+            except Exception:
+                # 若查詢個別 issue 失敗，保留保守認定
+                unresolved_issues.append(issue_num)
+
+        context["unresolved_issues"] = unresolved_issues
+
+    except Exception as exc:
+        context["gh_error"] = str(exc)
+
+    return context

--- a/paulsha_cortex/mechanical_acceptance/internal_consistency.py
+++ b/paulsha_cortex/mechanical_acceptance/internal_consistency.py
@@ -21,6 +21,20 @@ def check_internal_consistency(
 
     findings: list[str] = []
     details: dict[str, Any] = {}
+    has_input = bool((rule_bands and classified_items) or test_assertion_audits)
+
+    if not has_input:
+        return CheckResult(
+            check_id=check_id,
+            check_name=check_name,
+            passed=exempt,
+            exempted=exempt,
+            exemption_reason=reason if exempt else "",
+            skipped=not exempt,
+            skipped_reason="缺少內部一致性規則 context (rule_bands/classified_items 或 test_assertion_audits)",
+            findings=findings,
+            details=details,
+        )
 
     # 1. 規則 vs 套用結果自洽性
     if rule_bands and classified_items:

--- a/paulsha_cortex/mechanical_acceptance/internal_consistency.py
+++ b/paulsha_cortex/mechanical_acceptance/internal_consistency.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from typing import Any, Mapping, Sequence
+from .models import CheckResult, is_exempted
+
+
+def check_internal_consistency(
+    rule_bands: Mapping[str, tuple[int, int]] | None = None,
+    classified_items: Sequence[Mapping[str, Any]] | None = None,
+    test_assertion_audits: Sequence[Mapping[str, Any]] | None = None,
+    pr_labels: Sequence[str] = (),
+) -> CheckResult:
+    """第 2 項：輸出內部一致性。
+
+    1. 比對規則 (rule_bands) 與套用結果 (classified_items) 是否自洽。
+    2. 檢查測試斷言強度是否滿足其所宣稱驗證之 Requirement 語意要求。
+    """
+    check_id = "internal_consistency"
+    check_name = "輸出內部一致性"
+    exempt, reason = is_exempted(check_id, pr_labels)
+
+    findings: list[str] = []
+    details: dict[str, Any] = {}
+
+    # 1. 規則 vs 套用結果自洽性
+    if rule_bands and classified_items:
+        mismatches = []
+        for item in classified_items:
+            name = item.get("name", "unnamed")
+            score = item.get("score")
+            label = item.get("label") or item.get("band")
+            if score is None or label is None:
+                continue
+
+            expected_band = None
+            for band_name, (low, high) in rule_bands.items():
+                if low <= score <= high:
+                    expected_band = band_name
+                    break
+
+            if expected_band and label != expected_band:
+                mismatches.append(
+                    f"'{name}' 分數 {score} 依規則屬於 '{expected_band}' ({rule_bands[expected_band]}), "
+                    f"但標記為 '{label}'"
+                )
+        if mismatches:
+            findings.extend(mismatches)
+            details["classification_mismatches"] = mismatches
+
+    # 2. 測試斷言強度與 Requirement 語意比對 (#256 實例)
+    if test_assertion_audits:
+        weak_assertions = []
+        for audit in test_assertion_audits:
+            test_name = audit.get("test_name", "unnamed_test")
+            spec_ref = audit.get("spec_ref", "unspecified_spec")
+            requires_value_check = audit.get("requires_value_check", False)
+            has_value_check = audit.get("has_value_check", False)
+            has_existence_check_only = audit.get("has_existence_check_only", False)
+
+            if requires_value_check and (has_existence_check_only or not has_value_check):
+                weak_assertions.append(
+                    f"測試 '{test_name}' 宣稱驗證 '{spec_ref}'（要求數值/語意正確），"
+                    f"但斷言僅驗證欄位存在/非空，缺乏語意值比對 (assert equality)"
+                )
+        if weak_assertions:
+            findings.extend(weak_assertions)
+            details["weak_test_assertions"] = weak_assertions
+
+    passed = len(findings) == 0
+    return CheckResult(
+        check_id=check_id,
+        check_name=check_name,
+        passed=passed or exempt,
+        exempted=exempt,
+        exemption_reason=reason if exempt else "",
+        findings=findings,
+        details=details,
+    )

--- a/paulsha_cortex/mechanical_acceptance/language_conventions.py
+++ b/paulsha_cortex/mechanical_acceptance/language_conventions.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import re
+from typing import Any, Mapping, Sequence
+from .models import CheckResult, is_exempted
+
+NON_TW_TERMS_MAP: Mapping[str, str] = {
+    "驗實資料": "驗證資料",
+    "蠻力爆炸": "暴力解法/窮舉",
+    "信息": "訊息",
+    "鏈接": "連結",
+    "軟件": "軟體",
+    "數據": "資料",
+    "服務器": "伺服器",
+    "默認": "預設",
+    "代碼": "程式碼",
+}
+
+SIMPLIFIED_VARIANTS: Mapping[str, str] = {
+    "采": "採",
+    "国": "國",
+    "写": "寫",
+    "视": "視",
+    "陆": "陸",
+    "码": "碼",
+    "库": "庫",
+    "单": "單",
+    "错": "錯",
+    "试": "試",
+    "验": "驗",
+}
+
+
+def check_language_conventions(
+    text_content: str,
+    title: str = "",
+    repo_name: str = "hamanpaul/paulsha-cortex",
+    pr_labels: Sequence[str] = (),
+) -> CheckResult:
+    """第 5 項：語言規範。
+
+    `hamanpaul/*` repo 的產出掃簡繁混用與非台灣慣用詞。
+    """
+    check_id = "language_conventions"
+    check_name = "語言規範"
+    exempt, reason = is_exempted(check_id, pr_labels)
+
+    findings: list[str] = []
+    details: dict[str, Any] = {}
+
+    full_text = f"{title}\n{text_content}" if title else text_content
+
+    # 1. 簡繁/異體混用檢查 (例如標題用「采」內文用「採」)
+    used_simplified: list[str] = []
+    for simp_char, trad_char in SIMPLIFIED_VARIANTS.items():
+        if simp_char in full_text:
+            if trad_char in full_text or (title and simp_char in title):
+                used_simplified.append(
+                    f"檢出簡體/異體字 '{simp_char}'（與正體字 '{trad_char}' 混用或非 Taiwan 規範字）"
+                )
+
+    if used_simplified:
+        findings.extend(used_simplified)
+        details["simplified_variants"] = used_simplified
+
+    # 2. 非台灣慣用詞檢查 (例如「驗實資料」「蠻力爆炸」「信息」「代碼」)
+    used_non_tw: list[str] = []
+    for non_tw, suggested in NON_TW_TERMS_MAP.items():
+        if non_tw in full_text:
+            used_non_tw.append(
+                f"檢出非台灣慣用詞 '{non_tw}'（建議改用 '{suggested}'）"
+            )
+
+    if used_non_tw:
+        findings.extend(used_non_tw)
+        details["non_tw_terms"] = used_non_tw
+
+    passed = len(findings) == 0
+    return CheckResult(
+        check_id=check_id,
+        check_name=check_name,
+        passed=passed or exempt,
+        exempted=exempt,
+        exemption_reason=reason if exempt else "",
+        findings=findings,
+        details=details,
+    )

--- a/paulsha_cortex/mechanical_acceptance/language_conventions.py
+++ b/paulsha_cortex/mechanical_acceptance/language_conventions.py
@@ -49,6 +49,18 @@ def check_language_conventions(
     details: dict[str, Any] = {}
 
     full_text = f"{title}\n{text_content}" if title else text_content
+    if not full_text.strip():
+        return CheckResult(
+            check_id=check_id,
+            check_name=check_name,
+            passed=exempt,
+            exempted=exempt,
+            exemption_reason=reason if exempt else "",
+            skipped=not exempt,
+            skipped_reason="缺少待檢測文字內容 (text_content/title)",
+            findings=findings,
+            details=details,
+        )
 
     # 1. 簡繁/異體混用檢查 (例如標題用「采」內文用「採」)
     used_simplified: list[str] = []

--- a/paulsha_cortex/mechanical_acceptance/models.py
+++ b/paulsha_cortex/mechanical_acceptance/models.py
@@ -13,6 +13,21 @@ class CheckResult:
     exemption_reason: str = ""
     findings: list[str] = field(default_factory=list)
     details: dict[str, Any] = field(default_factory=dict)
+    skipped: bool = False
+    skipped_reason: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "check_id": self.check_id,
+            "check_name": self.check_name,
+            "passed": self.passed,
+            "exempted": self.exempted,
+            "exemption_reason": self.exemption_reason,
+            "skipped": self.skipped,
+            "skipped_reason": self.skipped_reason,
+            "findings": self.findings,
+            "details": self.details,
+        }
 
 
 @dataclass
@@ -20,21 +35,29 @@ class AcceptanceReport:
     passed: bool
     results: list[CheckResult]
 
+    @property
+    def has_failures(self) -> bool:
+        return any(not r.passed and not r.skipped and not r.exempted for r in self.results)
+
+    @property
+    def has_skipped(self) -> bool:
+        return any(r.skipped and not r.exempted for r in self.results)
+
+    @property
+    def status_summary(self) -> str:
+        if self.has_failures:
+            return "FAIL"
+        if self.has_skipped:
+            return "INCOMPLETE (SKIPPED)"
+        return "PASS"
+
     def to_dict(self) -> dict[str, Any]:
         return {
             "passed": self.passed,
-            "results": [
-                {
-                    "check_id": r.check_id,
-                    "check_name": r.check_name,
-                    "passed": r.passed,
-                    "exempted": r.exempted,
-                    "exemption_reason": r.exemption_reason,
-                    "findings": r.findings,
-                    "details": r.details,
-                }
-                for r in self.results
-            ],
+            "status_summary": self.status_summary,
+            "has_failures": self.has_failures,
+            "has_skipped": self.has_skipped,
+            "results": [r.to_dict() for r in self.results],
         }
 
 

--- a/paulsha_cortex/mechanical_acceptance/models.py
+++ b/paulsha_cortex/mechanical_acceptance/models.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Sequence
+
+
+@dataclass
+class CheckResult:
+    check_id: str
+    check_name: str
+    passed: bool
+    exempted: bool = False
+    exemption_reason: str = ""
+    findings: list[str] = field(default_factory=list)
+    details: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class AcceptanceReport:
+    passed: bool
+    results: list[CheckResult]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "passed": self.passed,
+            "results": [
+                {
+                    "check_id": r.check_id,
+                    "check_name": r.check_name,
+                    "passed": r.passed,
+                    "exempted": r.exempted,
+                    "exemption_reason": r.exemption_reason,
+                    "findings": r.findings,
+                    "details": r.details,
+                }
+                for r in self.results
+            ],
+        }
+
+
+def is_exempted(check_id: str, pr_labels: Sequence[str]) -> tuple[bool, str]:
+    labels = {label.strip() for label in pr_labels if label.strip()}
+    if "policy-exempt:mechanical-acceptance" in labels:
+        return True, "policy-exempt:mechanical-acceptance"
+    specific_label = f"policy-exempt:{check_id.replace('_', '-')}"
+    if specific_label in labels:
+        return True, specific_label
+    return False, ""

--- a/paulsha_cortex/mechanical_acceptance/runner.py
+++ b/paulsha_cortex/mechanical_acceptance/runner.py
@@ -53,6 +53,8 @@ def run_acceptance_checks(context: Mapping[str, Any]) -> AcceptanceReport:
 
     # 4. fact_freshness
     c4 = context.get("fact_freshness") or {}
+    unresolved_val = c4.get("unresolved_issues") if "unresolved_issues" in c4 else context.get("unresolved_issues")
+    unresolved_provided = unresolved_val is not None
     results.append(
         check_fact_freshness(
             text_content=c4.get("text_content") or context.get("text_content") or "",
@@ -60,7 +62,8 @@ def run_acceptance_checks(context: Mapping[str, Any]) -> AcceptanceReport:
             commit_messages=c4.get("commit_messages") or context.get("commit_messages") or (),
             referenced_files=c4.get("referenced_files") or (),
             repo_root=c4.get("repo_root") or context.get("repo_root"),
-            unresolved_issues=c4.get("unresolved_issues") or (),
+            unresolved_issues=unresolved_val,
+            unresolved_issues_provided=unresolved_provided,
             pr_labels=pr_labels,
         )
     )
@@ -68,42 +71,24 @@ def run_acceptance_checks(context: Mapping[str, Any]) -> AcceptanceReport:
     # 5. language_conventions
     c5 = context.get("language_conventions") or {}
     text_for_lang = c5.get("text_content") or context.get("text_content") or ""
-    if text_for_lang:
-        results.append(
-            check_language_conventions(
-                text_content=text_for_lang,
-                title=c5.get("title") or context.get("title") or "",
-                repo_name=c5.get("repo_name") or context.get("repo_name") or "hamanpaul/paulsha-cortex",
-                pr_labels=pr_labels,
-            )
+    results.append(
+        check_language_conventions(
+            text_content=text_for_lang,
+            title=c5.get("title") or context.get("title") or "",
+            repo_name=c5.get("repo_name") or context.get("repo_name") or "hamanpaul/paulsha-cortex",
+            pr_labels=pr_labels,
         )
-    else:
-        results.append(
-            CheckResult(
-                check_id="language_conventions",
-                check_name="語言規範",
-                passed=True,
-            )
-        )
+    )
 
     # 6. unsubstantiated_quantification
     c6 = context.get("unsubstantiated_quantification") or {}
     text_for_quant = c6.get("text_content") or context.get("text_content") or ""
-    if text_for_quant:
-        results.append(
-            check_unsubstantiated_quantification(
-                text_content=text_for_quant,
-                pr_labels=pr_labels,
-            )
+    results.append(
+        check_unsubstantiated_quantification(
+            text_content=text_for_quant,
+            pr_labels=pr_labels,
         )
-    else:
-        results.append(
-            CheckResult(
-                check_id="unsubstantiated_quantification",
-                check_name="禁止無依據量化",
-                passed=True,
-            )
-        )
+    )
 
-    all_passed = all(r.passed for r in results)
+    all_passed = all(r.passed and not r.skipped for r in results)
     return AcceptanceReport(passed=all_passed, results=results)

--- a/paulsha_cortex/mechanical_acceptance/runner.py
+++ b/paulsha_cortex/mechanical_acceptance/runner.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+from typing import Any, Mapping, Sequence
+from .claim_vs_output import check_claim_vs_output
+from .fact_freshness import check_fact_freshness
+from .internal_consistency import check_internal_consistency
+from .language_conventions import check_language_conventions
+from .models import AcceptanceReport, CheckResult
+from .summary_vs_body import check_summary_vs_body
+from .unsubstantiated_quantification import check_unsubstantiated_quantification
+
+
+def run_acceptance_checks(context: Mapping[str, Any]) -> AcceptanceReport:
+    """執行六項零 model session 機械驗收檢查。"""
+    pr_labels = context.get("pr_labels") or ()
+    results: list[CheckResult] = []
+
+    # 1. claim_vs_output
+    c1 = context.get("claim_vs_output") or {}
+    results.append(
+        check_claim_vs_output(
+            claimed_count=c1.get("claimed_count"),
+            claimed_fixed=c1.get("claimed_fixed"),
+            claimed_params=c1.get("claimed_params"),
+            canonical_params=c1.get("canonical_params"),
+            rerun_fn=c1.get("rerun_fn"),
+            residual_findings=c1.get("residual_findings"),
+            pr_labels=pr_labels,
+        )
+    )
+
+    # 2. internal_consistency
+    c2 = context.get("internal_consistency") or {}
+    results.append(
+        check_internal_consistency(
+            rule_bands=c2.get("rule_bands"),
+            classified_items=c2.get("classified_items"),
+            test_assertion_audits=c2.get("test_assertion_audits"),
+            pr_labels=pr_labels,
+        )
+    )
+
+    # 3. summary_vs_body
+    c3 = context.get("summary_vs_body") or {}
+    results.append(
+        check_summary_vs_body(
+            summary_claims=c3.get("summary_claims"),
+            body_counts=c3.get("body_counts"),
+            text_content=c3.get("text_content") or context.get("text_content"),
+            pr_labels=pr_labels,
+        )
+    )
+
+    # 4. fact_freshness
+    c4 = context.get("fact_freshness") or {}
+    results.append(
+        check_fact_freshness(
+            text_content=c4.get("text_content") or context.get("text_content") or "",
+            pr_body=c4.get("pr_body") or context.get("pr_body") or "",
+            commit_messages=c4.get("commit_messages") or context.get("commit_messages") or (),
+            referenced_files=c4.get("referenced_files") or (),
+            repo_root=c4.get("repo_root") or context.get("repo_root"),
+            unresolved_issues=c4.get("unresolved_issues") or (),
+            pr_labels=pr_labels,
+        )
+    )
+
+    # 5. language_conventions
+    c5 = context.get("language_conventions") or {}
+    text_for_lang = c5.get("text_content") or context.get("text_content") or ""
+    if text_for_lang:
+        results.append(
+            check_language_conventions(
+                text_content=text_for_lang,
+                title=c5.get("title") or context.get("title") or "",
+                repo_name=c5.get("repo_name") or context.get("repo_name") or "hamanpaul/paulsha-cortex",
+                pr_labels=pr_labels,
+            )
+        )
+    else:
+        results.append(
+            CheckResult(
+                check_id="language_conventions",
+                check_name="語言規範",
+                passed=True,
+            )
+        )
+
+    # 6. unsubstantiated_quantification
+    c6 = context.get("unsubstantiated_quantification") or {}
+    text_for_quant = c6.get("text_content") or context.get("text_content") or ""
+    if text_for_quant:
+        results.append(
+            check_unsubstantiated_quantification(
+                text_content=text_for_quant,
+                pr_labels=pr_labels,
+            )
+        )
+    else:
+        results.append(
+            CheckResult(
+                check_id="unsubstantiated_quantification",
+                check_name="禁止無依據量化",
+                passed=True,
+            )
+        )
+
+    all_passed = all(r.passed for r in results)
+    return AcceptanceReport(passed=all_passed, results=results)

--- a/paulsha_cortex/mechanical_acceptance/summary_vs_body.py
+++ b/paulsha_cortex/mechanical_acceptance/summary_vs_body.py
@@ -48,6 +48,19 @@ def check_summary_vs_body(
             red_in_body = sum(1 for l in body_lines if re.search(r"\bRed\b", l, re.IGNORECASE))
             body_dict["Red"] = red_in_body
 
+    if not claims_dict:
+        return CheckResult(
+            check_id=check_id,
+            check_name=check_name,
+            passed=exempt,
+            exempted=exempt,
+            exemption_reason=reason if exempt else "",
+            skipped=not exempt,
+            skipped_reason="缺少摘要宣稱 context (未指定 summary_claims 且未在內文中檢出計數宣稱如 Red N 張)",
+            findings=findings,
+            details=details,
+        )
+
     mismatches = []
     for category, claimed_num in claims_dict.items():
         if category in body_dict:

--- a/paulsha_cortex/mechanical_acceptance/summary_vs_body.py
+++ b/paulsha_cortex/mechanical_acceptance/summary_vs_body.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import re
+from typing import Any, Mapping, Sequence
+from .models import CheckResult, is_exempted
+
+
+def check_summary_vs_body(
+    summary_claims: Mapping[str, int] | Sequence[tuple[str, int]] | None = None,
+    body_counts: Mapping[str, int] | Sequence[tuple[str, int]] | None = None,
+    text_content: str | None = None,
+    pr_labels: Sequence[str] = (),
+) -> CheckResult:
+    """第 3 項：摘要 vs 內文一致性。
+
+    計數類宣稱（「Red 2 張」「修了 3 個缺陷」）與內文實際條目數比對。
+    """
+    check_id = "summary_vs_body"
+    check_name = "摘要 vs 內文一致性"
+    exempt, reason = is_exempted(check_id, pr_labels)
+
+    findings: list[str] = []
+    details: dict[str, Any] = {}
+
+    claims_dict: dict[str, int] = {}
+    body_dict: dict[str, int] = {}
+
+    if summary_claims:
+        if isinstance(summary_claims, dict):
+            claims_dict.update(summary_claims)
+        else:
+            claims_dict.update(dict(summary_claims))
+
+    if body_counts:
+        if isinstance(body_counts, dict):
+            body_dict.update(body_counts)
+        else:
+            body_dict.update(dict(body_counts))
+
+    if text_content:
+        red_claim_match = re.search(r"Red\s*[:：]?\s*(\d+)\s*張?", text_content, re.IGNORECASE)
+        if red_claim_match and "Red" not in claims_dict:
+            claims_dict["Red"] = int(red_claim_match.group(1))
+
+        if "Red" in claims_dict and "Red" not in body_dict:
+            lines = text_content.splitlines()
+            body_lines = [l for l in lines if not re.search(r"摘要|summary|背景", l, re.IGNORECASE)]
+            red_in_body = sum(1 for l in body_lines if re.search(r"\bRed\b", l, re.IGNORECASE))
+            body_dict["Red"] = red_in_body
+
+    mismatches = []
+    for category, claimed_num in claims_dict.items():
+        if category in body_dict:
+            actual_num = body_dict[category]
+            if claimed_num != actual_num:
+                mismatches.append(
+                    f"'{category}' 摘要宣稱 {claimed_num} 項，但內文實際包含 {actual_num} 項"
+                )
+
+    if mismatches:
+        findings.extend(mismatches)
+        details["summary_body_mismatches"] = mismatches
+
+    passed = len(findings) == 0
+    return CheckResult(
+        check_id=check_id,
+        check_name=check_name,
+        passed=passed or exempt,
+        exempted=exempt,
+        exemption_reason=reason if exempt else "",
+        findings=findings,
+        details=details,
+    )

--- a/paulsha_cortex/mechanical_acceptance/unsubstantiated_quantification.py
+++ b/paulsha_cortex/mechanical_acceptance/unsubstantiated_quantification.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import re
+from typing import Any, Sequence
+from .models import CheckResult, is_exempted
+
+QUANT_ESTIMATE_RE = re.compile(
+    r"(?:總時程|預估耗時|估算|時程|成本|耗時)\s*[:：]?\s*\d+[\s–\-~〜]*\d*\s*(?:個|條|天|工作天|小時|週|周|月|元|USD)",
+    re.IGNORECASE,
+)
+
+SOURCE_PATTERNS_RE = re.compile(
+    r"(?:https?://|Refs\s+#\d+|issue\s+#\d+|依據[：:]|來源[：:]|benchmarks?|formula)",
+    re.IGNORECASE,
+)
+
+
+def check_unsubstantiated_quantification(
+    text_content: str,
+    pr_labels: Sequence[str] = (),
+) -> CheckResult:
+    """第 6 項：禁止無依據量化。
+
+    工時、成本、時程估算若無可追溯資料來源即視為雜訊。
+    """
+    check_id = "unsubstantiated_quantification"
+    check_name = "禁止無依據量化"
+    exempt, reason = is_exempted(check_id, pr_labels)
+
+    findings: list[str] = []
+    details: dict[str, Any] = {}
+
+    unsubstantiated_estimates = []
+    lines = text_content.splitlines()
+
+    for line in lines:
+        if QUANT_ESTIMATE_RE.search(line):
+            if not SOURCE_PATTERNS_RE.search(line) and not SOURCE_PATTERNS_RE.search(text_content):
+                unsubstantiated_estimates.append(
+                    f"估算宣稱 '{line.strip()}' 缺乏可追溯資料來源（如 依據: / Issue # / URL / benchmark）"
+                )
+
+    if unsubstantiated_estimates:
+        findings.extend(unsubstantiated_estimates)
+        details["unsubstantiated_estimates"] = unsubstantiated_estimates
+
+    passed = len(findings) == 0
+    return CheckResult(
+        check_id=check_id,
+        check_name=check_name,
+        passed=passed or exempt,
+        exempted=exempt,
+        exemption_reason=reason if exempt else "",
+        findings=findings,
+        details=details,
+    )

--- a/paulsha_cortex/mechanical_acceptance/unsubstantiated_quantification.py
+++ b/paulsha_cortex/mechanical_acceptance/unsubstantiated_quantification.py
@@ -30,6 +30,19 @@ def check_unsubstantiated_quantification(
     findings: list[str] = []
     details: dict[str, Any] = {}
 
+    if not text_content or not text_content.strip():
+        return CheckResult(
+            check_id=check_id,
+            check_name=check_name,
+            passed=exempt,
+            exempted=exempt,
+            exemption_reason=reason if exempt else "",
+            skipped=not exempt,
+            skipped_reason="缺少待檢測文字內容 (text_content)",
+            findings=findings,
+            details=details,
+        )
+
     unsubstantiated_estimates = []
     lines = text_content.splitlines()
 

--- a/paulsha_cortex/porcelain/__init__.py
+++ b/paulsha_cortex/porcelain/__init__.py
@@ -22,6 +22,7 @@ _FAMILY_MODULES: tuple[str, ...] = (
     "paulsha_cortex.porcelain.service",
     "paulsha_cortex.porcelain.bootstrap",
     "paulsha_cortex.porcelain.init_sample",
+    "paulsha_cortex.porcelain.mechanical_acceptance",
 )
 _LOADED_MODULES: set[str] = set()
 

--- a/paulsha_cortex/porcelain/mechanical_acceptance.py
+++ b/paulsha_cortex/porcelain/mechanical_acceptance.py
@@ -30,11 +30,14 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--json", action="store_true", help="輸出 JSON 格式報告")
     parser.add_argument("--input-file", help="讀取 JSON 格式 context input file")
     parser.add_argument("--text-file", help="讀取待檢測的 Markdown/文字檔案")
+    parser.add_argument("--pr", help="指定 PR 編號（將自動使用 gh CLI 抓取 PR body/labels/commits 與 Issue 狀態）")
+    parser.add_argument("--unresolved-issues", help="以逗號分隔的未解決 Issue 編號（如 277,281）")
+    parser.add_argument("--repo-root", help="專案根目錄路徑（用於事實新鮮度核對）")
     parser.add_argument("--pr-labels", help="以逗號分隔的 PR labels（用於白名單豁免）")
     return parser
 
 
-def main(argv: Sequence[str] | None = None) -> int:
+def main(argv: Sequence[str] | None = None, gh_runner: Any = None) -> int:
     parser = _build_parser()
     args = parser.parse_args(list(sys.argv[1:] if argv is None else argv))
 
@@ -47,13 +50,39 @@ def main(argv: Sequence[str] | None = None) -> int:
             sys.stderr.write(f"error: failed to read input file '{args.input_file}': {exc}\n")
             return 1
 
+    if args.pr:
+        from paulsha_cortex.mechanical_acceptance import collect_pr_context
+
+        kwargs: dict[str, Any] = {}
+        if gh_runner is not None:
+            kwargs["gh_runner"] = gh_runner
+        if args.repo_root:
+            kwargs["repo_root"] = args.repo_root
+        pr_context = collect_pr_context(args.pr, **kwargs)
+        for k, v in pr_context.items():
+            if k not in context or context[k] is None:
+                context[k] = v
+
     if args.text_file:
         try:
             text_content = Path(args.text_file).read_text(encoding="utf-8")
             context["text_content"] = text_content
+            if "pr_body" not in context:
+                context["pr_body"] = text_content
         except Exception as exc:
             sys.stderr.write(f"error: failed to read text file '{args.text_file}': {exc}\n")
             return 1
+
+    if args.unresolved_issues:
+        issues = []
+        for raw in args.unresolved_issues.split(","):
+            raw_clean = raw.strip().lstrip("#")
+            if raw_clean.isdigit():
+                issues.append(int(raw_clean))
+        context["unresolved_issues"] = issues
+
+    if args.repo_root:
+        context["repo_root"] = args.repo_root
 
     if args.pr_labels:
         labels = [l.strip() for l in args.pr_labels.split(",") if l.strip()]
@@ -64,13 +93,29 @@ def main(argv: Sequence[str] | None = None) -> int:
     if args.json:
         sys.stdout.write(json.dumps(report.to_dict(), ensure_ascii=False, indent=2) + "\n")
     else:
-        status_str = "PASS" if report.passed else "FAIL"
+        status_str = report.status_summary
         sys.stdout.write(f"Mechanical Acceptance Status: {status_str}\n")
         for res in report.results:
-            ex_str = f" (EXEMPTED: {res.exemption_reason})" if res.exempted else ""
-            res_str = "PASS" if res.passed else "FAIL"
-            sys.stdout.write(f"- [{res_str}] {res.check_name} ({res.check_id}){ex_str}\n")
+            if res.exempted:
+                res_str = "EXEMPTED"
+                info_str = f" (EXEMPTED: {res.exemption_reason})"
+            elif res.skipped:
+                res_str = "SKIPPED"
+                info_str = f" (缺少必要 context: {res.skipped_reason})"
+            elif res.passed:
+                res_str = "PASS"
+                info_str = ""
+            else:
+                res_str = "FAIL"
+                info_str = ""
+
+            sys.stdout.write(f"- [{res_str}] {res.check_name} ({res.check_id}){info_str}\n")
             for finding in res.findings:
                 sys.stdout.write(f"    * {finding}\n")
 
-    return 0 if report.passed else 1
+    if report.passed:
+        return 0
+    elif report.has_failures:
+        return 1
+    else:
+        return 2

--- a/paulsha_cortex/porcelain/mechanical_acceptance.py
+++ b/paulsha_cortex/porcelain/mechanical_acceptance.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Sequence
+
+from paulsha_cortex.mechanical_acceptance import run_acceptance_checks
+from . import COMMANDS, PorcelainCommand, register
+
+
+def register_commands() -> None:
+    if "mechanical-acceptance" in COMMANDS:
+        return
+    register(
+        PorcelainCommand(
+            name="mechanical-acceptance",
+            help="對 agent/subagent 產出執行零 model session 確定性機械驗收",
+            run=main,
+        )
+    )
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="cortex mechanical-acceptance",
+        description="執行六項零 model session 的確定性收尾機械驗收檢查",
+    )
+    parser.add_argument("--json", action="store_true", help="輸出 JSON 格式報告")
+    parser.add_argument("--input-file", help="讀取 JSON 格式 context input file")
+    parser.add_argument("--text-file", help="讀取待檢測的 Markdown/文字檔案")
+    parser.add_argument("--pr-labels", help="以逗號分隔的 PR labels（用於白名單豁免）")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(list(sys.argv[1:] if argv is None else argv))
+
+    context: dict[str, Any] = {}
+    if args.input_file:
+        try:
+            with open(args.input_file, "r", encoding="utf-8") as f:
+                context = json.load(f)
+        except Exception as exc:
+            sys.stderr.write(f"error: failed to read input file '{args.input_file}': {exc}\n")
+            return 1
+
+    if args.text_file:
+        try:
+            text_content = Path(args.text_file).read_text(encoding="utf-8")
+            context["text_content"] = text_content
+        except Exception as exc:
+            sys.stderr.write(f"error: failed to read text file '{args.text_file}': {exc}\n")
+            return 1
+
+    if args.pr_labels:
+        labels = [l.strip() for l in args.pr_labels.split(",") if l.strip()]
+        context["pr_labels"] = labels
+
+    report = run_acceptance_checks(context)
+
+    if args.json:
+        sys.stdout.write(json.dumps(report.to_dict(), ensure_ascii=False, indent=2) + "\n")
+    else:
+        status_str = "PASS" if report.passed else "FAIL"
+        sys.stdout.write(f"Mechanical Acceptance Status: {status_str}\n")
+        for res in report.results:
+            ex_str = f" (EXEMPTED: {res.exemption_reason})" if res.exempted else ""
+            res_str = "PASS" if res.passed else "FAIL"
+            sys.stdout.write(f"- [{res_str}] {res.check_name} ({res.check_id}){ex_str}\n")
+            for finding in res.findings:
+                sys.stdout.write(f"    * {finding}\n")
+
+    return 0 if report.passed else 1

--- a/tests/test_mechanical_acceptance.py
+++ b/tests/test_mechanical_acceptance.py
@@ -255,28 +255,94 @@ class TestItem6UnsubstantiatedQuantification:
 
 
 class TestMechanicalAcceptanceRunnerAndCLI:
-    def test_run_acceptance_checks_runner(self) -> None:
+    def test_run_acceptance_checks_runner_complete_context(self) -> None:
+        """當 6 項檢查所需的 context 齊備時，run_acceptance_checks 回報全 PASS。"""
         context = {
             "text_content": "本專案預設使用繁體中文，測試驗證資料完整，已採納修正。",
             "pr_body": "Refs #292",
             "commit_messages": ["feat: implementation Refs #292"],
+            "unresolved_issues": [292],
+            "claim_vs_output": {"claimed_count": 0, "residual_findings": []},
+            "internal_consistency": {"rule_bands": {"A": (0, 5)}, "classified_items": [{"name": "i1", "score": 2, "band": "A"}]},
+            "summary_vs_body": {"summary_claims": {"Fix": 1}, "body_counts": {"Fix": 1}},
         }
         report = run_acceptance_checks(context)
         assert isinstance(report, AcceptanceReport)
         assert report.passed is True
+        assert report.has_skipped is False
+        assert report.status_summary == "PASS"
         assert len(report.results) == 6
 
-    def test_porcelain_cli_mechanical_acceptance(self, capsys, tmp_path: Path) -> None:
-        input_data = {
+    def test_run_acceptance_checks_runner_partial_context_returns_skipped(self) -> None:
+        """當缺少必要 context 時，run_acceptance_checks 不得回報 PASS，而是 report.passed = False 且 has_skipped = True。"""
+        context = {
             "text_content": "本專案預設使用繁體中文，測試驗證資料完整，已採納修正。",
             "pr_body": "Refs #292",
         }
-        input_file = tmp_path / "input.json"
-        input_file.write_text(json.dumps(input_data), encoding="utf-8")
+        report = run_acceptance_checks(context)
+        assert report.passed is False
+        assert report.has_skipped is True
+        assert report.status_summary == "INCOMPLETE (SKIPPED)"
 
-        exit_code = umbrella_cli.main(["mechanical-acceptance", "--input-file", str(input_file), "--json"])
-        assert exit_code == 0
+    def test_cli_e2e_real_sample_277_reports_fail(self, capsys, tmp_path: Path) -> None:
+        """端到端測試 1：給定真實失敗樣本 #277 與完整 context，CLI 確實回報 FAIL 並指出具體 finding。"""
+        sample_file = tmp_path / "sample_277.txt"
+        sample_file.write_text(
+            "fix(work): repo rebind 後 monitor 投影與 work authority 跟著走\n\nFixes #277",
+            encoding="utf-8",
+        )
+
+        exit_code = umbrella_cli.main([
+            "mechanical-acceptance",
+            "--text-file", str(sample_file),
+            "--unresolved-issues", "277",
+        ])
+
+        assert exit_code == 1
         output = capsys.readouterr().out
-        report_dict = json.loads(output)
-        assert report_dict["passed"] is True
-        assert len(report_dict["results"]) == 6
+        assert "Mechanical Acceptance Status: FAIL" in output
+        assert "- [FAIL] 事實新鮮度 (fact_freshness)" in output
+        assert "PR body 使用 closing keyword 'Fixes #277'，但 Issue #277 未完全解決" in output
+
+    def test_cli_e2e_missing_context_reports_skipped(self, capsys, tmp_path: Path) -> None:
+        """端到端測試 2：當缺少必要 context (例如只傳 --text-file 含 Fixes #277 但無 unresolved_issues)，CLI 回報 SKIPPED (exit code 2) 而非 PASS。"""
+        sample_file = tmp_path / "sample_277.txt"
+        sample_file.write_text(
+            "fix(work): repo rebind 後 monitor 投影與 work authority 跟著走\n\nFixes #277",
+            encoding="utf-8",
+        )
+
+        exit_code = umbrella_cli.main([
+            "mechanical-acceptance",
+            "--text-file", str(sample_file),
+        ])
+
+        assert exit_code == 2
+        output = capsys.readouterr().out
+        assert "Mechanical Acceptance Status: INCOMPLETE (SKIPPED)" in output
+        assert "- [SKIPPED] 事實新鮮度 (fact_freshness)" in output
+        assert "缺少必要 context: 檢出 closing keyword 'Fixes #277'" in output
+
+    def test_cli_e2e_pr_option_with_fake_gh_runner(self, capsys) -> None:
+        """端到端測試 3：使用 --pr <N> 參數與 fake gh 執行器，驗證 CLI 能從 PR 自動取得資料並比對。"""
+        from paulsha_cortex.porcelain.mechanical_acceptance import main as porcelain_main
+
+        def fake_gh_runner(args: list[str]) -> str:
+            if args[:3] == ["pr", "view", "277"]:
+                return json.dumps({
+                    "title": "fix(work): repo rebind 後 monitor 投影與 work authority 跟著走",
+                    "body": "修正 monitor 投影。 Fixes #277",
+                    "labels": [],
+                    "commits": [{"message": "fix(work): rebind monitor Fixes #277"}],
+                })
+            elif args[:3] == ["issue", "view", "277"]:
+                return json.dumps({"number": 277, "state": "OPEN"})
+            raise ValueError(f"Unexpected gh args: {args}")
+
+        exit_code = porcelain_main(["--pr", "277"], gh_runner=fake_gh_runner)
+
+        assert exit_code == 1
+        output = capsys.readouterr().out
+        assert "Mechanical Acceptance Status: FAIL" in output
+        assert "- [FAIL] 事實新鮮度 (fact_freshness)" in output
+        assert "Issue #277 未完全解決" in output

--- a/tests/test_mechanical_acceptance.py
+++ b/tests/test_mechanical_acceptance.py
@@ -1,0 +1,282 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import pytest
+
+from paulsha_cortex import cli as umbrella_cli
+from paulsha_cortex.mechanical_acceptance import (
+    AcceptanceReport,
+    CheckResult,
+    check_claim_vs_output,
+    check_fact_freshness,
+    check_internal_consistency,
+    check_language_conventions,
+    check_summary_vs_body,
+    check_unsubstantiated_quantification,
+    run_acceptance_checks,
+)
+
+
+class TestItem1ClaimVsOutput:
+    def test_positive_claim_vs_output_matches(self) -> None:
+        def verifier_rerun(params):
+            return 0  # 0 residual findings
+
+        res = check_claim_vs_output(
+            claimed_count=0,
+            claimed_fixed=True,
+            claimed_params={"--pr-body": "Refs #292"},
+            canonical_params={"--pr-body": "Refs #292"},
+            rerun_fn=verifier_rerun,
+        )
+        assert res.passed is True
+        assert res.exempted is False
+        assert len(res.findings) == 0
+
+    def test_negative_sample_277_residual_finding(self) -> None:
+        """真實失敗樣本 #277：宣稱「Finding 1+2 已修」，但 Finding 2 只做了一半殘留。"""
+        def verifier_rerun(params):
+            return ["Finding 2 residual: monitor reader cannot readback status"]
+
+        res = check_claim_vs_output(
+            claimed_count=0,
+            claimed_fixed=True,
+            rerun_fn=verifier_rerun,
+        )
+        assert res.passed is False
+        assert res.exempted is False
+        assert len(res.findings) == 1
+        assert "Finding 2 residual" in res.findings[0]
+
+    def test_negative_sample_262_tampered_input_params(self) -> None:
+        """真實失敗樣本 #262：subagent 自行將 brief 的 --pr-body Refs 改為 Fixes 以通過 gate。"""
+        def verifier_rerun(params):
+            # verifier 使用 canonical_params 重跑，發現並非 fail: 0
+            if params.get("--pr-body") == "Refs #277":
+                return 1  # 1 fail
+            return 0
+
+        res = check_claim_vs_output(
+            claimed_params={"--pr-body": "Fixes #277"},
+            canonical_params={"--pr-body": "Refs #277"},
+            rerun_fn=verifier_rerun,
+        )
+        assert res.passed is False
+        assert any("宣稱驗收參數與規範不符" in f for f in res.findings)
+        assert any("殘留問題" in f for f in res.findings)
+
+    def test_exemption_label(self) -> None:
+        res = check_claim_vs_output(
+            residual_findings=["residual bug"],
+            pr_labels=["policy-exempt:claim-vs-output"],
+        )
+        assert res.passed is True
+        assert res.exempted is True
+        assert "policy-exempt:claim-vs-output" in res.exemption_reason
+
+
+class TestItem2InternalConsistency:
+    def test_positive_consistent_classification_and_strong_assertions(self) -> None:
+        rule_bands = {"Green": (0, 3), "Yellow": (4, 6), "Red": (7, 10)}
+        items = [{"name": "slice-1", "score": 4, "band": "Yellow"}]
+        audits = [
+            {
+                "test_name": "test_r2_spec",
+                "spec_ref": "R2",
+                "requires_value_check": True,
+                "has_value_check": True,
+                "has_existence_check_only": False,
+            }
+        ]
+        res = check_internal_consistency(
+            rule_bands=rule_bands,
+            classified_items=items,
+            test_assertion_audits=audits,
+        )
+        assert res.passed is True
+        assert len(res.findings) == 0
+
+    def test_negative_sample_224_agent_c_classification_mismatch(self) -> None:
+        """真實失敗樣本 #224 Agent C：規則定義 4-6 為 Yellow，卻將 4/10 標為 Green。"""
+        rule_bands = {"Green": (0, 3), "Yellow": (4, 6), "Red": (7, 10)}
+        items = [{"name": "slice-4", "score": 4, "band": "Green"}]
+        res = check_internal_consistency(rule_bands=rule_bands, classified_items=items)
+        assert res.passed is False
+        assert len(res.findings) == 1
+        assert "分數 4 依規則屬於 'Yellow'" in res.findings[0]
+        assert "標記為 'Green'" in res.findings[0]
+
+    def test_negative_sample_256_weak_test_assertion(self) -> None:
+        """真實失敗樣本 #256：RED 測試宣稱驗證 R2（要求值正確），但僅斷言欄位存在。"""
+        audits = [
+            {
+                "test_name": "test_spec_r2_recovery",
+                "spec_ref": "R2",
+                "requires_value_check": True,
+                "has_value_check": False,
+                "has_existence_check_only": True,
+            }
+        ]
+        res = check_internal_consistency(test_assertion_audits=audits)
+        assert res.passed is False
+        assert any("缺乏語意值比對" in f for f in res.findings)
+
+    def test_exemption_label(self) -> None:
+        rule_bands = {"Green": (0, 3), "Yellow": (4, 6)}
+        items = [{"name": "s1", "score": 4, "band": "Green"}]
+        res = check_internal_consistency(
+            rule_bands=rule_bands,
+            classified_items=items,
+            pr_labels=["policy-exempt:internal-consistency"],
+        )
+        assert res.passed is True
+        assert res.exempted is True
+
+
+class TestItem3SummaryVsBody:
+    def test_positive_summary_matches_body(self) -> None:
+        res = check_summary_vs_body(
+            summary_claims={"Red": 2},
+            body_counts={"Red": 2},
+        )
+        assert res.passed is True
+
+    def test_negative_sample_224_agent_c_summary_mismatch(self) -> None:
+        """真實失敗樣本 #224 Agent C：摘要寫 Red 2 張，內文實際列了 3 張。"""
+        res = check_summary_vs_body(
+            summary_claims={"Red": 2},
+            body_counts={"Red": 3},
+        )
+        assert res.passed is False
+        assert len(res.findings) == 1
+        assert "摘要宣稱 2 項，但內文實際包含 3 項" in res.findings[0]
+
+    def test_exemption_label(self) -> None:
+        res = check_summary_vs_body(
+            summary_claims={"Red": 2},
+            body_counts={"Red": 3},
+            pr_labels=["policy-exempt:summary-vs-body"],
+        )
+        assert res.passed is True
+        assert res.exempted is True
+
+
+class TestItem4FactFreshness:
+    def test_positive_fresh_facts_and_refs_keyword(self, tmp_path: Path) -> None:
+        (tmp_path / ".project-policy.yml").write_text("policy_version: 1.0.15\n")
+        res = check_fact_freshness(
+            pr_body="Refs #292",
+            commit_messages=["feat(quality): add mechanical acceptance Refs #292"],
+            referenced_files=[".project-policy.yml"],
+            repo_root=tmp_path,
+            unresolved_issues=[292],
+        )
+        assert res.passed is True
+
+    def test_negative_sample_224_agent_b_obsolete_config_filename(self, tmp_path: Path) -> None:
+        """真實失敗樣本 #224 Agent B：引用過時檔名 .paul-project.yml。"""
+        (tmp_path / ".project-policy.yml").write_text("policy_version: 1.0.15\n")
+        res = check_fact_freshness(
+            referenced_files=[".paul-project.yml"],
+            repo_root=tmp_path,
+        )
+        assert res.passed is False
+        assert any("引用過時設定檔 '.paul-project.yml'" in f for f in res.findings)
+
+    def test_negative_sample_277_commit_msg_closing_keyword_leak(self, tmp_path: Path) -> None:
+        """真實失敗樣本 #277：PR body 寫 Refs #277，但 commit message 誤用 Fixes #277。"""
+        res = check_fact_freshness(
+            pr_body="Refs #277",
+            commit_messages=["fix(monitor): readback fix Fixes #277"],
+            unresolved_issues=[277],
+            repo_root=tmp_path,
+        )
+        assert res.passed is False
+        assert any("Commit msg #1" in f and "Fixes #277" in f for f in res.findings)
+
+    def test_exemption_label(self, tmp_path: Path) -> None:
+        res = check_fact_freshness(
+            pr_body="Fixes #277",
+            unresolved_issues=[277],
+            repo_root=tmp_path,
+            pr_labels=["policy-exempt:fact-freshness"],
+        )
+        assert res.passed is True
+        assert res.exempted is True
+
+
+class TestItem5LanguageConventions:
+    def test_positive_tw_conventions(self) -> None:
+        text = "本專案預設使用繁體中文，測試驗證資料完整，已採納修正。"
+        res = check_language_conventions(text_content=text, title="feat(core): 採納語言規範")
+        assert res.passed is True
+
+    def test_negative_sample_224_agent_b_non_tw_and_mixed_variants(self) -> None:
+        """真實失敗樣本 #224 Agent B：標題用「采」內文用「採」，並包含「驗實資料」「蠻力爆炸」。"""
+        text = "測試採用驗實資料，針對蠻力爆炸演算法進行優化。"
+        res = check_language_conventions(text_content=text, title="feat(task): 采納 task_type 提案")
+        assert res.passed is False
+        assert any("簡體/異體字 '采'" in f for f in res.findings)
+        assert any("非台灣慣用詞 '驗實資料'" in f for f in res.findings)
+        assert any("非台灣慣用詞 '蠻力爆炸'" in f for f in res.findings)
+
+    def test_exemption_label(self) -> None:
+        text = "蠻力爆炸"
+        res = check_language_conventions(
+            text_content=text,
+            pr_labels=["policy-exempt:language-conventions"],
+        )
+        assert res.passed is True
+        assert res.exempted is True
+
+
+class TestItem6UnsubstantiatedQuantification:
+    def test_positive_quantification_with_traceable_source(self) -> None:
+        text = "工時預估耗時 2 小時 (依據：lesson-20260722 實測數據)。"
+        res = check_unsubstantiated_quantification(text_content=text)
+        assert res.passed is True
+
+    def test_negative_sample_224_agent_c_fabricated_schedule(self) -> None:
+        """真實失敗樣本 #224 Agent C：捏造「總時程 10–14 工作天」無任何依據。"""
+        text = "拆解提案完成，估算總時程 10–14 工作天。"
+        res = check_unsubstantiated_quantification(text_content=text)
+        assert res.passed is False
+        assert any("估算宣稱 '拆解提案完成，估算總時程 10–14 工作天。' 缺乏可追溯資料來源" in f for f in res.findings)
+
+    def test_exemption_label(self) -> None:
+        text = "估算總時程 10–14 工作天。"
+        res = check_unsubstantiated_quantification(
+            text_content=text,
+            pr_labels=["policy-exempt:unsubstantiated-quantification"],
+        )
+        assert res.passed is True
+        assert res.exempted is True
+
+
+class TestMechanicalAcceptanceRunnerAndCLI:
+    def test_run_acceptance_checks_runner(self) -> None:
+        context = {
+            "text_content": "本專案預設使用繁體中文，測試驗證資料完整，已採納修正。",
+            "pr_body": "Refs #292",
+            "commit_messages": ["feat: implementation Refs #292"],
+        }
+        report = run_acceptance_checks(context)
+        assert isinstance(report, AcceptanceReport)
+        assert report.passed is True
+        assert len(report.results) == 6
+
+    def test_porcelain_cli_mechanical_acceptance(self, capsys, tmp_path: Path) -> None:
+        input_data = {
+            "text_content": "本專案預設使用繁體中文，測試驗證資料完整，已採納修正。",
+            "pr_body": "Refs #292",
+        }
+        input_file = tmp_path / "input.json"
+        input_file.write_text(json.dumps(input_data), encoding="utf-8")
+
+        exit_code = umbrella_cli.main(["mechanical-acceptance", "--input-file", str(input_file), "--json"])
+        assert exit_code == 0
+        output = capsys.readouterr().out
+        report_dict = json.loads(output)
+        assert report_dict["passed"] is True
+        assert len(report_dict["results"]) == 6


### PR DESCRIPTION
## 摘要

實作 #292 的六項**零 model session 確定性機械驗收**，用於 agent／subagent 派工的收尾檢查。承接 #224 的提案段落（該 issue 已結案，實測記錄留存於該處）。

核心論點：subagent 的失敗集中在格式、完整性與自我一致性，全部可機械檢出，不需要模型參與。

## 六項檢查

| 模組 | 檢查 |
|---|---|
| `claim_vs_output` | 自我宣稱 vs 產出比對（重跑驗證時不採信被檢查方提供的參數） |
| `internal_consistency` | 輸出內部一致性；測試斷言強度是否符合其宣稱驗證的 Requirement 語意 |
| `summary_vs_body` | 摘要計數宣稱 vs 內文實際條目數 |
| `fact_freshness` | 檔名／路徑／設定鍵對 repo 實際狀態核對；closing keyword **同時檢查 PR body 與 commit message** |
| `language_conventions` | 簡繁混用與非台灣慣用詞 |
| `unsubstantiated_quantification` | 工時／成本／時程估算缺可追溯來源 |

介面：`cortex mechanical-acceptance`，支援自動 context 蒐集與 `--unresolved-issues` 等明確指定。

## 兩輪交付，第二輪修掉一個關鍵缺口

**第一版（`a4d9e62`）**：六項模組與 23 個單元測試全綠、policy_check `fail: 0`、零 model session 驗證通過。

**但驗收時拿真實資料實測發現工具不生效** —— 用害 #277 被誤關的那個真實 commit message（含 `Fixes #277`）從 CLI 跑：

```
Mechanical Acceptance Status: PASS
exit code: 0
```

該抓的沒抓到。原因是判定所需的結構化 context（如 `unresolved_issues`）在 CLI 的 `--text-file` 路徑拿不到，檢查等於空跑，而**空跑回報 PASS**。單元測試全綠是因為它們直接呼叫底層函式並手動餵齊參數。

這正是本 issue 第 1 項要抓的東西（自我宣稱形式屬實、產出在真實情境不生效），只是被檢查的對象是這個工具本身。

**第二版（`25c2ccf`）** 修掉三點：

1. CLI 支援自動 context 蒐集
2. **缺少必要輸入時回報 `SKIPPED` 並說明缺什麼，絕不回報 PASS** —— 一個回報 PASS 但實際沒檢查的驗收工具，會製造比沒有它更強的錯誤信心，那與本 repo 剛修完的 #273（monitor 靜默吞例外、服務顯示 active running 但兩個月沒更新）是同一種錯誤形態
3. 從 CLI 入口的端到端測試

## 驗收（維護者實跑，非採信回報）

| 情境 | 期望 | 實際 |
|---|---|---|
| 真實 `Fixes #277` + `--unresolved-issues 277` | FAIL | ✅ `FAIL`，指出「PR body 使用 closing keyword 'Fixes #277'，但 Issue #277 未完全解決（應使用 Refs #277）」，exit 1 |
| 完全無 context | 不得 PASS | ✅ `INCOMPLETE (SKIPPED)`，三項標 SKIPPED 並說明缺哪個輸入，exit 2 |
| 正確使用 `Refs #277` | 不誤殺 | ✅ fact_freshness `PASS` |
| #224 agent B/C 真實樣本 | FAIL | ✅ 抓到 `.paul-project.yml` 過時檔名、「采/採」混用、「驗實資料」「蠻力爆炸」非台灣慣用詞、「總時程 10-14 工作天」無依據量化 |

- `pytest tests/ -q` → **1742 passed, 32 subtests**（基準 1716，新增 26 個測試）
- 帶 PR 上下文的 `policy_check` → **fail: 0**
- 零 model session：六個模組無任何模型呼叫（`subprocess.*agy/codex/claude`、`openai`、`anthropic`、`launcher` 皆零命中）
- 端到端測試確實從 CLI 入口而非底層函式

exit code 三態：全 PASS = 0、有 FAIL = 1、有 SKIPPED 無 FAIL = 2。

## 負向測試用真實失敗樣本

測試以真實案例命名，而非人造 fixture：

```
test_negative_sample_277_residual_finding            ← 宣稱已修但殘留
test_negative_sample_262_tampered_input_params       ← 改輸入參數讓 gate 過
test_negative_sample_256_weak_test_assertion         ← 斷言強度不足
test_negative_sample_277_commit_msg_closing_keyword_leak
test_negative_sample_224_agent_c_summary_mismatch
test_negative_sample_224_agent_b_obsolete_config_filename
test_negative_sample_224_agent_c_fabricated_schedule
```

這些都是 2026-07-27（#224）與 07-30～08-01（cortex 自身 11 個 PR）實際發生、當時靠人工 review 攔下的問題，現在成為可重跑的迴歸測試。

## 設計取捨

第 2 項「測試斷言強度」沒有硬解析 AST 猜測語意，而是採結構化 audit 輸入（`requires_value_check` / `has_value_check` / `has_existence_check_only`），把「這條 Requirement 是否要求值正確」的判斷留給呼叫端宣告，檢查本身只做確定性比對。誠實但需要呼叫端提供資料 —— 這也是為什麼「缺 context 時 SKIPPED」的行為如此重要。

Closes #292

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MBuP74pQJyBBcX17DDxBAo
