### PR TITLE
docs(planning): 批次 W1 planning artifacts（四個 work item）

### DIFF
--- a/.cortex/work-items.yaml
+++ b/.cortex/work-items.yaml
@@ -387,3 +387,49 @@ work_items:
         ref: docs/superpowers/workstreams/persona-enforce-required-check/todo.md
       - kind: path
         ref: docs/superpowers/specs/persona-enforce-required-check-spec.md
+  fix-persona-catalog-portability:
+    title: persona catalog 可攜性——非 cortex repo verification 不再卡 persona-catalog-unreadable (#295/#291)
+    links:
+      - kind: github_issue
+        ref: hamanpaul/paulsha-cortex#295
+      - kind: github_issue
+        ref: hamanpaul/paulsha-cortex#291
+      - kind: openspec
+        ref: 2026-08-04-fix-persona-catalog-portability
+      - kind: path
+        ref: docs/superpowers/workstreams/fix-persona-catalog-portability/todo.md
+      - kind: path
+        ref: docs/superpowers/specs/fix-persona-catalog-portability-spec.md
+  fix-repair-commit-recovery:
+    title: repair commit 缺 terminal evidence 的窄化恢復與 stale job 選擇修正 (#260)
+    links:
+      - kind: github_issue
+        ref: hamanpaul/paulsha-cortex#260
+      - kind: openspec
+        ref: 2026-08-04-fix-repair-commit-recovery
+      - kind: path
+        ref: docs/superpowers/workstreams/fix-repair-commit-recovery/todo.md
+      - kind: path
+        ref: docs/superpowers/specs/fix-repair-commit-recovery-spec.md
+  feat-work-gc:
+    title: cortex work gc——proposal-first 產物生命週期回收 (#178)
+    links:
+      - kind: github_issue
+        ref: hamanpaul/paulsha-cortex#178
+      - kind: openspec
+        ref: 2026-08-04-feat-work-gc
+      - kind: path
+        ref: docs/superpowers/workstreams/feat-work-gc/todo.md
+      - kind: path
+        ref: docs/superpowers/specs/feat-work-gc-spec.md
+  design-task-type-taxonomy:
+    title: task_type taxonomy 契約定案與骨架——#8 叢集基礎 (#139)
+    links:
+      - kind: github_issue
+        ref: hamanpaul/paulsha-cortex#139
+      - kind: openspec
+        ref: 2026-08-04-design-task-type-taxonomy
+      - kind: path
+        ref: docs/superpowers/workstreams/design-task-type-taxonomy/todo.md
+      - kind: path
+        ref: docs/superpowers/specs/design-task-type-taxonomy-spec.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,12 @@
   靜音）。`persona-scope` 設為 main required status check 屬 GitHub repo 設定，
   設定步驟見 `docs/persona-scope-enforcement.md`。
 ### Added
+- **批次 W1 planning artifacts（#295／#291、#260、#178、#139）**：為四個 work item
+  （`fix-persona-catalog-portability`〔#295 primary＋#291 duplicate 一修多關的 multi-issue
+  Work Item〕、`fix-repair-commit-recovery`、`feat-work-gc`、`design-task-type-taxonomy`）
+  新增 spec／design／plan／todo 與 `openspec/changes/2026-08-04-<wi>/` planning artifacts，
+  並登錄 `.cortex/work-items.yaml` 作為 confirmed authority；只提供 planning authority，
+  不含實作。
 - **Refs #292：實作 subagent / agent 派工收尾的六項確定性機械驗收檢查**：提供零 model session 的確定性收尾檢查 (`paulsha_cortex.mechanical_acceptance` 與 `cortex mechanical-acceptance`)，包含 1. 自我宣稱 vs 產出比對、2. 輸出內部一致性、3. 摘要 vs 內文一致性、4. 事實新鮮度 (涵蓋 PR body 與 commit message 的 closing keyword 雙重檢查)、5. 語言規範、6. 禁止無依據量化。提供 `--pr <N>`/`--unresolved-issues`/`--repo-root` 自動 context 蒐集、缺 context 標為 `SKIPPED`（exit code 2）而非 `PASS`、`policy-exempt:*` 白名單豁免與全套正負向測試。
 - **Issue #262：dispatch 前驗證 runtime capability 與 provider snapshot 新鮮度**：新增
   `coordinator/runtime_preflight.py`，在建立 worktree／sandbox／job row／model session 之前，

--- a/changelog.d/batch-w1-planning.md
+++ b/changelog.d/batch-w1-planning.md
@@ -1,0 +1,8 @@
+### Added
+- **批次 W1 planning artifacts（#295／#291、#260、#178、#139）**：為四個 work item
+  （`fix-persona-catalog-portability`〔#295 primary＋#291 duplicate 一修多關的 multi-issue
+  Work Item〕、`fix-repair-commit-recovery`、`feat-work-gc`、`design-task-type-taxonomy`）
+  各新增 `docs/superpowers/specs/<wi>-spec.md`、`-design.md`、`docs/superpowers/plans/<wi>.md`、
+  `docs/superpowers/workstreams/<wi>/todo.md` 與 `openspec/changes/2026-08-04-<wi>/`
+  （proposal／tasks／spec delta），並登錄 `.cortex/work-items.yaml`，作為 cortex
+  work-item lifecycle 的 confirmed authority。本 PR 只提供 planning authority，不含實作。

--- a/docs/superpowers/plans/design-task-type-taxonomy.md
+++ b/docs/superpowers/plans/design-task-type-taxonomy.md
@@ -1,0 +1,57 @@
+---
+status: accepted
+work_item: design-task-type-taxonomy
+---
+
+# design-task-type-taxonomy Plan
+
+## Tasks
+
+### 1. TDD RED
+
+- [ ] 新增 `tests/test_deck_task_types.py`，全部先紅：
+  - `test_task_types_yaml_loads_frozen_six_values`：載入 `paulsha_cortex/deck/data/task-types.yaml` 成功，值域恰為 `feat`／`fix`／`docs`／`test`／`ci`／`refactor` 六值，`feat` 的 combo 為 `feature-oneshot`、其餘五值 combo 為 None。
+  - `test_loader_rejects_unknown_top_level_key`：頂層出現白名單（`version`、`task_types`、`scopes`）以外的鍵時拋 `DeckSchemaError`。
+  - `test_loader_rejects_value_domain_drift`：YAML 多一值（如 `perf`）或少一值（移除 `refactor`）皆拋 `DeckSchemaError`，錯誤訊息含缺漏／多出的值。
+  - `test_loader_rejects_empty_description`：任一 type 描述為空字串時拒載。
+  - `test_loader_rejects_unknown_combo_reference`：帶入 combo 對照表時，combo 欄位指向不存在的 combo id 即拒載。
+  - `test_loader_rejects_invalid_scopes`：scopes 空清單、重複值、或不合 `^[a-z][a-z0-9-]*$` 的 token 皆拒載。
+  - `test_classify_matched_with_scope`：`"fix(cli): 修正 exit code"` → kind `matched`、`("fix", "cli")`、處置 proceed。
+  - `test_classify_matched_without_scope`：`"feat: 新增選牌"` → kind `matched`、scope 為 None、處置 proceed。
+  - `test_classify_unknown_type_fail_closed`：`"perf(cli): 加速"` → kind `unknown_type`、處置 fail-closed。
+  - `test_classify_out_of_vocab_scope_ambiguous`：`"fix(claimx): 修正"`（scope 不在受控詞典）→ kind `ambiguous`、處置 fail-closed。
+  - `test_classify_absent_bypass`：`"修 monitor 掃描漏洞"`（無 prefix）→ kind `absent`、處置 bypass。
+  - `test_classify_unparseable_bypass`：`"fix(: broken"`（括號未閉合）→ kind `unparseable`、處置 bypass。
+  - `test_disposition_mapping_is_total`：五類 kind 皆有唯一處置（`matched`→proceed；`unknown_type`／`ambiguous`→fail_closed；`absent`／`unparseable`→bypass），無未定義分支。
+
+### 2. taxonomy 契約檔
+
+- [ ] 新增 `paulsha_cortex/deck/data/task-types.yaml`：
+  - 頂層鍵限 `version`（0）、`task_types`、`scopes`。
+  - `task_types` 恰含六值，每值含 `description`（非空 zh-tw 描述）與 `combo`（`feat: feature-oneshot`，其餘五值 `null`）。
+  - `scopes` 受控詞典七值：`coordinator`、`porcelain`、`workflow`、`cli`、`deck`、`monitor`、`onboarding`。
+- 驗收：task 1 中三個 loader happy-path／drift 測試對此檔為真。
+
+### 3. loader 與資料類
+
+- [ ] 新增 `paulsha_cortex/deck/task_types.py`：
+  - 凍結常數 `TASK_TYPE_VALUES = ("feat", "fix", "docs", "test", "ci", "refactor")` 與 `DEFAULT_TASK_TYPES_PATH`（比照 `schema.py` 的 `DEFAULT_CARDS_PATH` 寫法）。
+  - frozen dataclass `TaskTypeSpec`（`name`／`description`／`combo: str | None`）與 `TaskTypeTaxonomy`（`version`／`task_types: Mapping`／`scopes: tuple`）。
+  - `load_task_types(path=DEFAULT_TASK_TYPES_PATH, *, combos=None) -> TaskTypeTaxonomy`：重用 `schema.DeckSchemaError` 與未知鍵檢查慣例；值域與 `TASK_TYPE_VALUES` 不一致、描述空、scopes 非法皆收集錯誤後整批拒載；`combos` 對照表非 None 時驗證 combo 引用存在。
+- 驗收：task 1 的六個 loader 測試轉綠；`python3 -m pytest tests/test_deck_schema.py tests/test_deck_data.py -q` 仍全綠（不影響既有載入）。
+
+### 4. 分類 helper 與處置映射
+
+- [ ] 於 `paulsha_cortex/deck/task_types.py` 增加：
+  - 分類常數：kind 五值（`matched`／`unknown_type`／`ambiguous`／`absent`／`unparseable`）與處置三值（`proceed`／`fail_closed`／`bypass`）。
+  - frozen dataclass `TitleClassification`（`kind`／`task_type: str | None`／`scope: str | None`／`disposition`／`reason: str`）。
+  - `classify_title(title: str, taxonomy: TaskTypeTaxonomy) -> TitleClassification`：以正規表示式解析 `type(scope): subject`／`type: subject` prefix；判準＝「有主張而不合法 → fail_closed；沒有主張 → bypass」；`reason` 帶具體原因（如列出合法值域）。
+- 驗收：task 1 的七個 classify／disposition 測試轉綠；helper 為純函式、不做任何 dispatch 決策、不發事件。
+
+### 5. 交付要件
+
+- [ ] `changelog.d/design-task-type-taxonomy.md` fragment（R-09 硬性 gate，須 commit 才進 diff）。
+- [ ] `CHANGELOG.md [Unreleased]` 對應 entry。
+- [ ] 本票不動 CLI；若實作過程確有新增 CLI 面，須同步 `cortex` CLI help（R-16）。
+- [ ] 帶 PR 上下文執行 `policy_check`（`--pr-title`／`--pr-body`／`--pr-labels`／`--pr-base-ref`／`--pr-head-ref`），確認 fail: 0。
+- [ ] `python3 -m pytest tests/ -q` 全綠。

--- a/docs/superpowers/plans/feat-work-gc.md
+++ b/docs/superpowers/plans/feat-work-gc.md
@@ -1,0 +1,53 @@
+---
+status: accepted
+work_item: feat-work-gc
+---
+
+# feat-work-gc Plan
+
+## Tasks
+
+### 1. TDD RED
+
+- [ ] `tests/test_work_gc.py`（以 tmp git repo fixture 建構，全程不碰真 repo、不需網路）：
+  - `test_squash_merged_branch_classified_reclaim`：分支內容以單一新 commit（squash）落地 default branch、原分支 commit 不在其歷史時，該分支判 `reclaim`（reason `merged-content`），不被誤判 unmerged。
+  - `test_ancestor_merged_branch_classified_reclaim`：tip 為 default branch ancestor 的分支判 `reclaim`（reason `merged-ancestor`）。
+  - `test_unmerged_branch_never_in_apply_list`：含未落地 commit 的分支判 `keep`（reason `unmerged-content`），且 `--apply` 執行後分支仍存在。
+  - `test_dirty_worktree_kept`：有未 commit 變更（含 untracked）的 worktree 判 `keep`（reason `dirty-worktree`），`--apply` 不移除。
+  - `test_closed_unmerged_pr_branch_kept_with_annotation`：注入的 PR 狀態 provider 回報 closed-unmerged 時，分支判 `keep` 且 reason 為 `pr-closed-unmerged`；provider 拋錯或缺席時退化為 `unmerged-content`，同樣 `keep`。
+  - `test_default_dry_run_mutates_nothing`：未帶 `--apply` 時，所有 worktree、分支與 `jobs.json` 內容皆不變。
+  - `test_git_error_fails_safe`：注入會失敗的 git runner 時，該 artifact 判 `keep`（reason `verification-error`），且不中斷其餘項目的判定。
+
+### 2. 偵測與分類核心
+
+- [ ] 新增 `paulsha_cortex/coordinator/gc.py`：掃描 worktree pool（用 `paulsha_cortex/config/paths.py` 的 `worktree_root_for()`，`PSC_WORKTREE_ROOT` 可覆寫）與 local branch，產出逐項分類（`reclaim`／`keep`＋reason code）。git 執行以可注入 runner 抽象，比照 `paulsha_cortex/coordinator/verification.py` 的 `_run_git` 慣例。
+- [ ] merged 驗證鏈：`git merge-base --is-ancestor <tip> <default>` → 不成立再 `git cherry <default> <branch>` 檢查無 `+` 行 → 皆不成立判 unmerged。default branch 依 `origin/HEAD` 解析、缺席退回 `main`；不主動 fetch。禁止使用 `git branch -d`／`--merged` 作判定。
+- [ ] 保護清單：default branch、目前 checked-out branch、掛在 `keep` worktree 上的 branch 一律 `keep`（reason `protected`）。
+- 驗收：第 1 節分類相關測試轉綠；分類函式對注入 runner 可完全離線測試。
+
+### 3. `--apply` 執行與 fail-safe
+
+- [ ] `paulsha_cortex/coordinator/gc.py`：`--apply` 只處理 `reclaim` 清單；clean worktree 用 `git worktree remove`，merged branch 於刪除前重跑一次驗證鏈再 `git branch -D`；狀態已變（TOCTOU）或單項失敗記 `keep`（reason `apply-error`）並續行。
+- [ ] gc 模組不 import 任何 registry 寫入 API，不開檔寫 `jobs.json`。
+- 驗收：`test_unmerged_branch_never_in_apply_list`、`test_dirty_worktree_kept`、`test_default_dry_run_mutates_nothing` 轉綠。
+
+### 4. CLI 接線與 help 同步
+
+- [ ] `paulsha_cortex/cli.py`：在 `work` 分支比照 `work show` 攔截 `work gc`，路由至 `paulsha_cortex/coordinator/gc.py` 的 `main()`（不透傳 coordinator mutation 路徑、不動 control queue `WORK_ACTIONS`）；`_WORK_HELP` 加入 `gc` 一行說明。
+- [ ] gc argparse：`cortex work gc [--repo-root PATH] [--apply] [--json]`，`--repo-root` 預設用 `paulsha_cortex/config/paths.py` 的 `repo_root()`。
+- [ ] `tests/test_cli_help_alignment.py`：加斷言確認 `_WORK_HELP` 列出 `gc`（R-16 CLI help 同步）。
+- 驗收：`cortex work gc --help` 可執行；help 對齊測試轉綠。
+
+### 5. 報告輸出
+
+- [ ] 文字報告：每 artifact 一行（種類／路徑或分支名／`reclaim`|`keep`／reason）；`--json` 輸出 `cortex-work-gc/v1` schema（命名比照 `cortex-porcelain/run/v1`），含 `schema`、`repo_root`、`applied`、逐項 `artifacts[]`。
+- [ ] closed-unmerged PR 註記：PR 狀態 provider 介面可注入，預設實作走 `gh`（typed argv、失敗吞回退化），僅升級 keep 理由、不參與回收判定。
+- 驗收：`test_closed_unmerged_pr_branch_kept_with_annotation` 轉綠；`--json` 輸出可被 `json.loads` 解析且含上述欄位。
+
+### 6. 交付要件
+
+- [ ] `changelog.d/feat-work-gc.md` fragment（R-09 硬性 gate，須 commit 才進 diff）。
+- [ ] `CHANGELOG.md [Unreleased]` 對應 entry。
+- [ ] CLI help 同步（R-16）：`_WORK_HELP` 與 gc argparse help 覆蓋新命令。
+- [ ] 帶 PR 上下文執行 policy_check（`--pr-title`／`--pr-body`／`--pr-labels`／`--pr-base-ref`／`--pr-head-ref`），確認 fail: 0。
+- [ ] `python3 -m pytest tests/ -q` 全綠。

--- a/docs/superpowers/plans/fix-persona-catalog-portability.md
+++ b/docs/superpowers/plans/fix-persona-catalog-portability.md
@@ -1,0 +1,45 @@
+---
+status: accepted
+work_item: fix-persona-catalog-portability
+---
+
+# fix-persona-catalog-portability Plan
+
+## Tasks
+
+### 1. TDD RED
+
+- [ ] `tests/test_coordinator_candidate_verification.py` 新增 test class `PersonaCatalogPortabilityTests`，複用同檔既有 helpers（`_contract`、`_slice_row`、`_job`、`_persona_catalog`、`_git_ok`、`_git_fail`、`FakeGitRunner`、`FakeSubprocessRunner`）：
+  - `test_non_cortex_repo_without_local_catalog_passes_persona_gate`：`("-C", str(root), "cat-file", "-e", dispatch_base + ":paulsha_cortex/persona/personas.yaml")` 回 `_git_fail`，且 response map **不含** `show` 該路徑的呼叫；驗證 gate 以 packaged catalog 完成 scope 判定，`payload["summary"]` 不是 `persona-catalog-unreadable`，`details["persona_catalog"]["source"] == "packaged"` 且 `commit is None`。
+  - `test_repo_local_catalog_overrides_packaged`：探測回 `_git_ok`、`git show` 回 `_persona_catalog(builder_paths=[...])`（write_paths 與 packaged 內容不同以資區辨）；驗證 scope 判定採 repo-local 內容、`source == "repo-local"`、`commit == dispatch_base`。
+  - `test_declared_override_unreadable_fails_closed`：探測回 `_git_ok`、`git show` 回 `_git_fail`；驗證 `status == "needs_human"`、`summary == "persona-catalog-unreadable"`，且 `details["persona_catalog"]` 的錯誤內容含 repo-local 路徑與 `dispatch_base`。
+  - `test_declared_override_invalid_fails_closed`：`git show` 回壞 YAML（例如 `"roles: [broken"`）；驗證 `summary == "persona-catalog-invalid"`，不回退 packaged。
+  - `test_cortex_repo_behavior_unchanged`：repo-local 存在且合法時，`details["persona_catalog"]` 的 `path == "paulsha_cortex/persona/personas.yaml"`、`commit == dispatch_base`、`hash == sha256(catalog 文字)`，與現行欄位一致。
+- 驗收：`python3 -m pytest tests/test_coordinator_candidate_verification.py -q -k PersonaCatalogPortability` 五個新測試全數 FAIL（RED），其餘既有測試不動。
+
+### 2. catalog 來源解析（GREEN）
+
+- [ ] `paulsha_cortex/coordinator/verification.py`：改寫 `run_result_verification` 的 catalog 讀取段（現行 `:780-804`，位置維持在 checks 迴圈之前、required_artifacts 檢查之後）：
+  - 先跑 `_run_git(["-C", str(resolved_repo_root), "cat-file", "-e", f"{dispatch_base}:{PERSONA_CATALOG_PATH}"], git_runner)` 探測 override。
+  - 探測 `status == "ok"`：走既有 `git show` 讀取與 `_load_catalog_from_text`；show 失敗回 `persona-catalog-unreadable`、驗證失敗回 `persona-catalog-invalid`（現行為不變）。
+  - 探測非 ok：`from ..persona.loader import DEFAULT_PERSONAS_PATH`，讀 `DEFAULT_PERSONAS_PATH.read_text(encoding="utf-8")` 後同樣以 `_load_catalog_from_text` 驗證；`OSError` 回 `persona-catalog-unreadable`、`ValueError` 回 `persona-catalog-invalid`。
+- 驗收：Section 1 的 `test_non_cortex_repo_without_local_catalog_passes_persona_gate`、`test_repo_local_catalog_overrides_packaged`、`test_declared_override_unreadable_fails_closed`、`test_declared_override_invalid_fails_closed` 轉綠。
+
+### 3. evidence 與錯誤訊息
+
+- [ ] 同檔同段：成功時 `details["persona_catalog"]` 增加 `"source"`（`"repo-local"`／`"packaged"`）；repo-local 分支既有 `path`／`commit`／`hash` 欄位不變；packaged 分支 `path` 記 `str(DEFAULT_PERSONAS_PATH)`、`commit` 記 `None`、`hash` 記內容 sha256。失敗時 error payload 記錄實際嘗試過的來源（repo-local 分支：`path` 與 `commit`；packaged 分支：packaged `path`）。
+- 驗收：Section 1 全部五個測試對 evidence 欄位的斷言通過（含 `test_cortex_repo_behavior_unchanged`）。
+
+### 4. 既有測試同步
+
+- [ ] `tests/test_coordinator_candidate_verification.py` 既有會走到 catalog 段的測試，在 `FakeGitRunner` response map 補 `("-C", str(root), "cat-file", "-e", dispatch_base + ":paulsha_cortex/persona/personas.yaml")` 項回 `_git_ok("")`，其餘 responses 與斷言不變。
+- 驗收：`python3 -m pytest tests/test_coordinator_candidate_verification.py -q` 全綠。
+
+### 5. 交付要件
+
+- [ ] `changelog.d/fix-persona-catalog-portability.md` fragment（R-09 硬性 gate，須 commit 才進 diff）。
+- [ ] `CHANGELOG.md [Unreleased]` 對應 entry。
+- [ ] 本次不動 CLI 介面，無 R-16 CLI help 同步需求；若實作過程動到 CLI 輸出則需同步 help 與 docs。
+- [ ] 帶 PR 上下文執行 policy_check（`--pr-title`／`--pr-body`／`--pr-labels`／`--pr-base-ref`／`--pr-head-ref`），確認 fail: 0。
+- [ ] `python3 -m pytest tests/ -q` 全綠。
+- [ ] delivery PR body closing keywords 同時涵蓋 `Closes #295` 與 `Closes #291`（#295 為 primary）。

--- a/docs/superpowers/plans/fix-repair-commit-recovery.md
+++ b/docs/superpowers/plans/fix-repair-commit-recovery.md
@@ -1,0 +1,64 @@
+---
+status: accepted
+work_item: fix-repair-commit-recovery
+---
+
+# fix-repair-commit-recovery Plan
+
+## Tasks
+
+### 1. TDD RED
+
+- [ ] 新增 `tests/test_repair_commit_recovery.py`（fixture 風格比照 `tests/test_pre_candidate_recovery.py`：`JobRegistry(state_path=tmp_path / "jobs.json")` + 真實 git worktree in tmp_path），先寫以下測試並確認全部失敗：
+  - `test_recover_repair_commit_adopts_descendant_head_without_terminal_evidence`：build phase、final builder card pending、最新 builder job `status="failed"`、worktree HEAD 為原 candidate 的 descendant commit；執行 `recover-repair-commit` 後 `candidate_head` 更新為該 SHA、run 進 verify phase、產生 `cortex-work-repair-adoption/v1` evidence record 與 exited/0 adoption job row。
+  - `test_recover_repair_commit_rejects_non_descendant_head`：worktree HEAD 不是原 candidate 的 descendant 時 fail closed，run 狀態不變。
+  - `test_recover_repair_commit_rejects_dirty_worktree`：worktree 有未 commit 變更時 fail closed，run 狀態不變。
+  - `test_recover_repair_commit_fail_closed_when_terminal_evidence_bound`：最新 builder job 已有 `workflow_evidence` 時拒絕（不得成為繞過 terminalization 的後門）。
+  - `test_recover_repair_commit_replay_already_recovered_no_new_job`：adoption 成功後重送相同 request 回 `already-recovered`，job 總數與 evidence record 數不變。
+  - `test_recover_repair_commit_rejects_unauthorized_issue`：`--issue` 不在 WorkAuthority mapped issues 時拒絕。
+  - `test_resume_first_call_dispatches_replacement_not_stale_failed_job`：最新同 card job 為 `status="exited"`、exit code 非 0 時，第一次 operator resume 即 dispatch replacement job，不回報 stale job 的 `job-failed`。
+  - `test_resume_replay_keeps_single_replacement_job`：replacement dispatch 後再次 resume 回報 in-flight，不產生第二個 replacement job。
+  - `test_retry_build_expected_candidate_cas_unchanged`：`retry-build` 缺 `expected_candidate` 或 SHA 不符 `run.candidate_head` 時，錯誤訊息與現況一致（`retry-build requires exact expected_candidate`／`retry-build expected Candidate CAS mismatch`），確認 CAS 未被放寬。
+- [ ] 驗收：`python3 -m pytest tests/test_repair_commit_recovery.py -q` 顯示上述測試全部 FAIL（RED）。
+
+### 2. registry 原子 adoption 方法
+
+- [ ] `paulsha_cortex/coordinator/registry.py`：新增 `_manager_adopt_repair_candidate(run_id, *, expected_candidate, adopted_candidate, adoption_job_id, evidence_ref)`，緊鄰 `_manager_reset_workflow_for_retry_build`（約 line 1485 起）並沿用其 CAS／admission 風格：ongoing + `needs_human` + `current_phase == "build"`、`candidate_head == expected_candidate`、前置 build steps 全 passed、final build card pending、無 `ACTIVE_JOB_STATUSES` job。單一 persist 內完成：`candidate_head=adopted_candidate`、final build step 以 adoption job 的 executor/model/independence_domain 標 passed、`current_phase="verify"`、`attempts["verify"]` 遞增、移除 `needs_human` facet、`verified_head=None`、evidence_refs 附掛 `evidence_ref`。
+- [ ] 驗收：task 1 的 adopts 測試中對 run 欄位的斷言通過；不新增任何 WorkflowRun／job row 欄位名。
+
+### 3. work action 本體
+
+- [ ] `paulsha_cortex/coordinator/work_actions.py`：新增 `_recover_repair_commit_action`（緊鄰 `_recover_pre_candidate_action`，約 line 2405 後），參數白名單 `{"action","repo","work_id","issue","actor","expected_run_id","expected_candidate"}`，其餘一律 `rejects caller evidence/input`。流程：驗 `expected_run_id`（`workflow-[0-9a-f]{20}`）與 `expected_candidate`（`verification.SAFE_SHA_RE`）→ issue 授權檢查 → 以 run 事實找出 final build card 最新 builder job（失敗終止且 `workflow_evidence is None`）→ 取其 worktree 做 git 驗證（HEAD 精確等於 expected SHA、`git status --porcelain` 空、`cat-file -e` 存在、`merge-base --is-ancestor` 原 candidate 為祖先且兩者不等）→ 寫 `cortex-work-repair-adoption/v1` record（`evidence/work-repair-adoption/<run_id>-<digest>.json`，比照 `_abandon_record` 的 digest 命名；body 含 failed job id、observed HEAD、adopted/previous candidate、actor）→ 登錄 adoption job row（identity/worktree/dispatch_head 複製自 failed job、`subject_head=adopted SHA`、exited/0、`workflow_evidence` 指向 record；不新增欄位）→ 呼叫 `_manager_adopt_repair_candidate`。冪等分支：`candidate_head` 已等於 expected SHA 且 record 存在 → 回 `already-recovered`。
+- [ ] `execute_work_action`（約 line 3263 的 action 白名單與 dispatch 分支）加入 `"recover-repair-commit"`。
+- [ ] 驗收：task 1 的六條 `recover_repair_commit` 測試全綠。
+
+### 4. resume／dispatch stale failed job 選擇修正
+
+- [ ] `paulsha_cortex/coordinator/manager.py`：`resume_workflow_run` 的 replacement 判定（約 line 6506：`job.get("status") == "failed"` 條件組）與 `_dispatch_workflow_card` 的 `retryable_latest` 判定（約 line 5785）各補上「`status == "exited"` 且 `exit_code` 為非 0 int」分支；exited/0 的既有路徑（unbound terminal、malformed schema retry、正常 terminalize）條件式不動。
+- [ ] resume 對失敗 job 的 `job-failed` 回報附掛 `_terminal_parse_diagnostics(job).as_dict()`（唯讀診斷，不授予 authority）。
+- [ ] 驗收：task 1 的兩條 resume 測試全綠；`python3 -m pytest tests/test_work_actions.py tests/test_retry_classification.py -q` 全綠（既有行為不回歸）。
+
+### 5. control queue 契約
+
+- [ ] `paulsha_cortex/control/contract.py`：`WORK_ACTIONS` frozenset 加入 `"recover-repair-commit"`；`validate_request` 比照 `recover-planning` 分支新增驗證——`expected_run_id` 須 `workflow-[0-9a-f]{20}`、`expected_candidate` 須 40-hex，缺漏或格式錯誤時拋 `ValueError`。
+- [ ] 驗收：`python3 -m pytest tests/test_control_client.py -q` 全綠；task 1 中經 control 路徑的測試（若有觸及）不因白名單缺項失敗。
+
+### 6. CLI 與 porcelain 面（R-16）
+
+- [ ] `paulsha_cortex/cli.py`：`cortex work` usage 行（line 49）與動作說明清單（line 61-62 附近）加入 `recover-repair-commit  對 repair commit 已存在但缺 terminal evidence 的 build 失敗做具 CAS 的採納恢復`。
+- [ ] `paulsha_cortex/coordinator/cli.py`：work action choices（約 line 136）加入 `"recover-repair-commit"`。
+- [ ] `paulsha_cortex/porcelain/recover.py`：`recover work` 的 action choices（line 50）加入 `"recover-repair-commit"`（`--expected-candidate`／`--expected-run-id` 既有 flags 直接沿用，`_work_args` 無需改動）。
+- [ ] 驗收：`cortex work` 與 `cortex recover work` 的 `--help`／usage 輸出含新動作；`python3 -m pytest tests/test_work_cli.py -q` 全綠。
+
+### 7. operator 文件
+
+- [ ] `docs/unified-work-lifecycle.md`：在既有 recovery 敘述段（retry-build 窄化入口與 recover-planning／recover-pre-candidate 說明附近）補一段 `recover-repair-commit`：適用情境（failed repair job 留下 descendant commit）、雙 CAS 參數、判準全取自系統事實、冪等語意、adoption 後由 verify → foreign review → exact-head final 重新把關、periodic runner 不取得此 authority。
+- [ ] 驗收：段落存在且與 spec R1–R5 敘述一致；`python3 -m policy_check` 的 doc 相關規則無新增 FAIL。
+
+### 8. 交付要件
+
+- [ ] `changelog.d/fix-repair-commit-recovery.md` fragment 已新增且已 commit（R-09 硬性 gate，只 add 不 commit 仍 FAIL）。
+- [ ] `CHANGELOG.md [Unreleased]` 對應 entry（Refs #260）。
+- [ ] cortex CLI help 同步（R-16；task 6 的 usage 文字即為其落點，交付前重驗）。
+- [ ] 帶 PR 上下文執行 policy_check 確認 0 fail：`python3 -m policy_check --repo . --pr-title "..." --pr-body "..." --pr-labels "..." --pr-base-ref main --pr-head-ref "feature/260-fix-repair-commit-recovery"`。
+- [ ] `python3 -m pytest tests/ -q` 全綠。

--- a/docs/superpowers/specs/design-task-type-taxonomy-design.md
+++ b/docs/superpowers/specs/design-task-type-taxonomy-design.md
@@ -1,0 +1,60 @@
+---
+status: accepted
+work_item: design-task-type-taxonomy
+---
+
+# design-task-type-taxonomy Design
+
+## Decisions
+
+### D1 主軸採 conventional-commit `type`，機械判定
+
+`task_type` 主軸為 `feat`／`fix`／`docs`／`test`／`ci`／`refactor` 六值，由 issue 標題 prefix 機械解析取得，不依賴模型推理、不需人工貼標。
+
+理由：使用者已於 2026-07-27 在 issue #139 裁決此方向。標題 prefix 解析已是 repo 習慣，機械判定滿足「一套分類三處共用」的可重現性要求；且 `type` 與 deck workflow-shape 正交——把 combo 當成 `type × scope` 的輸出而非輸入，#139 與 #202 的循環等待即解開。
+
+### D2 契約檔與程式凍結常數雙鎖
+
+值域同時存在於 `paulsha_cortex/deck/data/task-types.yaml`（資料，含描述與 combo 映射）與 `paulsha_cortex/deck/task_types.py` 的凍結常數（程式契約）；loader 驗證兩者一致，不一致即拒載。
+
+理由：只放 YAML 會讓值域被一次資料 PR 悄悄改掉；只放程式會讓描述與 combo 映射失去資料化彈性。雙鎖使「改值域」必然是兩處同動的顯式決策，而描述與 combo 映射仍可走 data-only PR。骨架落 deck 套件並沿用 `schema.py` 的 `DeckSchemaError` fail-closed 慣例，不另造錯誤體系。
+
+### D3 combo 為輸出投影，缺口以 null 明示
+
+每個 type 的 `combo` 欄位是「分類結果投影到哪個 combo」的映射；現況只有 `feat` → `feature-oneshot`，其餘五值為 null。不在本票新造 combo。
+
+理由：實測最大宗的 `fix`（24/68）沒有 combo 是既成事實；用 null 明示缺口，讓 #202 的 additive-with-fallback 能機械判定「無映射 → 可觀測 bypass」，而不是讓 selector 猜一個最像的 combo。缺口補齊（如 `fix-standard`）屬叢集另案，與 taxonomy 定案解耦。
+
+風險與緩解：null 可能被下游誤當「可自行猜測」——契約明文 MUST bypass，且測試鎖死處置映射。
+
+### D4 分類五類、判準＝「是否明確主張 taxonomy 語彙」
+
+分類結果為 `matched`／`unknown_type`／`ambiguous`／`absent`／`unparseable` 五類；`unknown_type` 與 `ambiguous` 處置為 fail-closed，`absent` 與 `unparseable` 處置為 bypass。
+
+理由：叢集已定案「`ambiguous` fail closed；`absent` 與 `unparseable` bypass 落回明示路徑且須可觀測」。`unknown_type`（如 `perf(cli):`）是「明確主張了一個值域外的 type」——多半是錯字或詞彙漂移，靜默 bypass 會把它藏起來，fail-closed 讓錯誤立刻可見。判準統一為「有主張而不合法 → fail-closed；沒有主張 → bypass」，五類皆有唯一處置，無灰帶。
+
+### D5 受控詞典外的 scope 歸 `ambiguous`、fail-closed
+
+標題 type 合法但 scope 不在受控詞典（例：`fix(claimx): ...`）判為 `ambiguous`，處置 fail-closed；scope 缺省（`fix: ...`）則為合法 `matched`。
+
+理由：#139 的責任是「凍結 scope 受控詞典」；詞典外的 scope 是一個無法對映到既有元件軸的主張，靜默放行會讓 `(type, scope)` 計分鍵（#137／#138／#204 共用）被未受控值污染。緩解：詞典擴充是改 `task-types.yaml` 的 data-only PR，成本低；fail-closed 使詞典缺口立即可見而非累積漂移。
+
+### D6 分類 helper 落在 #139，selector 行為留在 #202
+
+標題解析與五類判定的 helper 由本票落地於 `paulsha_cortex/deck/task_types.py`；「依分類結果選 combo、發 bypass 事件、落回明示路徑」的行為屬 #202。
+
+理由：#202／#137／#138／#204 都需要同一套判定，若各自實作解析必然漂移——這正是 #139 存在的原因。helper 只回傳分類與處置，不做任何 dispatch 決策，邊界乾淨可測。
+
+### D7 log reader 與 status view 只凍結介面契約
+
+R7 的統一 log reader（三合一、64MB/mtime 邊界）與 resource status view（quota＋rate＋health＋track-record 的 JOIN）在本票只定欄位契約，不實作。
+
+理由：本票是 design 票，deliverable 是定案文件＋輕量骨架；reader 與 view 的實作各自是獨立可派工的實作票。先凍結欄位契約讓 #137／#138 可據以並行設計而不互等。緩解「契約與未來實作不符」：實作票只允許 additive 增欄，既有欄位語意凍結。
+
+## 風險與緩解
+
+- **雙鎖兩處漂移**：YAML 與程式常數不一致——loader fail-closed 拒載，任何一處單獨改動都會使全套測試立即變紅。
+- **scope 詞典過緊**：合法新元件的標題被判 `ambiguous`——詞典擴充為 data-only PR；fail-closed 的可見性本身就是詞典維護的觸發訊號。
+- **legacy `task_type` 欄位撞名混淆**（combo 檔的 `feature`／`mcu-feature` vs taxonomy 的 `feat`）：spec 明載 legacy 欄位為 workflow-shape 標籤、不屬值域；本票不改該欄位，測試不把兩者交叉驗證。
+- **下游繞過 loader 自建值域**：R1 明文 MUST NOT；後續 #202／#137／#138／#204 的 review checklist 以「是否 import `task_types`」為機械檢查點。
+- **介面契約草案與實作票衝突**：additive-only 擴充規則寫入 R7；欄位語意凍結，變更需回到 #139 修約。

--- a/docs/superpowers/specs/design-task-type-taxonomy-spec.md
+++ b/docs/superpowers/specs/design-task-type-taxonomy-spec.md
@@ -1,0 +1,92 @@
+---
+status: accepted
+work_item: design-task-type-taxonomy
+---
+
+# design-task-type-taxonomy Specification
+
+#139：定案 `task_type` taxonomy 契約（主軸 conventional-commit `type`、次軸 `scope`），並落地輕量契約骨架（taxonomy 契約檔＋loader／分類 helper＋測試），作為 #202／#137／#138／#204 的單一真相源。
+
+## 背景
+
+repo 內同時存在至少四種互不相干的「task 分類軸」：deck combo 的 workflow-shape（`feature`／`mcu-feature` 兩值，見 `paulsha_cortex/deck/data/combos/`）、conventional-commit `type`（issue 標題慣例）、conventional-commit `scope`（元件軸）、agent-usage-stats 的 repo 級 5 類。因為沒有任何 issue 明確擁有「task_type 由我定義」的權責，#139、#202、#137、#138 陷入循環等待。
+
+使用者已於 2026-07-27 裁決（見 issue #139 comment）：主軸採 conventional-commit `type`（`feat`／`fix`／`docs`／`test`／`ci`／`refactor`），以 issue 標題 prefix 機械解析、不依賴模型推理；**#139 為 taxonomy 所有者**。依同一決策 comment「如無異議即一併成立」順推成立並由本 spec 凍結：次軸為 `scope`、deck combo 的 workflow-shape 是分類的**輸出**而非輸入、agent-usage-stats 5 類因粒度為 repo 級排除於 taxonomy 之外。
+
+實測 68 張 issue 中 `fix` 佔 24（約 35%）為最大宗，而 deck combo 目前只有 `feature` 與 `mcu-feature`，`fix` 尚無對應 combo——此覆蓋缺口是 #202 選牌器的硬前提。本票以「combo 欄位可為 null、null 即 bypass」明示缺口，不在本票補 combo（#202 已定為 additive with fallback，缺口不再阻擋其落地）。
+
+## Goals
+
+- `task_type` taxonomy 契約定案並凍結：主軸值域、次軸 scope 受控詞典、分類處置語意（fail-closed vs bypass）。
+- 落地收斂且可測的最小契約骨架：契約檔 `paulsha_cortex/deck/data/task-types.yaml`、loader／驗證函式與分類 helper（`paulsha_cortex/deck/task_types.py`）、對應測試。
+- 定案下游消費者（#202 selector、#137 ledger、#138 judge、#204 skill ledger）的契約邊界，與統一 log reader／status view 的介面契約草案（只定契約，不實作 reader 與 view）。
+- 明載：**本票為 taxonomy 單一真相源；後續 #202／#137／#138／#204 引用此契約，不得自建值域。**
+
+## Requirements
+
+### R1 主軸值域凍結且為單一真相源
+
+`task_type` 主軸值域 SHALL 為 conventional-commit `type` 六值：`feat`、`fix`、`docs`、`test`、`ci`、`refactor`，凍結於契約檔 `paulsha_cortex/deck/data/task-types.yaml` 與程式凍結常數（雙鎖，兩處必須一致）。
+
+下游消費者（#202／#137／#138／#204）MUST 經 loader 取得值域，MUST NOT 自建或硬編碼第二份值域。agent-usage-stats 的 repo 級 5 類（coding／testing／PM／learning／bug）MUST NOT 納入 taxonomy，僅保留展示用途。
+
+### R2 次軸 scope 為受控詞典
+
+次軸 SHALL 為 conventional-commit `scope`，受控詞典初始收錄實測既有七值：`coordinator`、`porcelain`、`workflow`、`cli`、`deck`、`monitor`、`onboarding`。scope 為可選（標題 `fix: ...` 無 scope 即合法）。
+
+詞典擴充 MUST 以修改 `task-types.yaml` 的資料 PR 進行，MUST NOT 在任何消費端旁路新增。type 與 scope SHALL 獨立正交（任一 type 可搭配詞典內任一 scope），以避免 M×N 組合爆炸。
+
+### R3 契約檔載入必須 fail-closed
+
+loader MUST 驗證契約檔結構：未知鍵拒絕、每值描述為非空字串、combo 欄位為 null 或非空字串、scopes 為非空且不重複的合法 token 清單。任一錯誤 MUST 拒載並回報具體原因（比照 `paulsha_cortex/deck/schema.py` 的 `DeckSchemaError` fail-closed 慣例）。
+
+契約檔值域與程式凍結常數不一致（多值、少值、改名）MUST 拒載，MUST NOT 靜默取交集或聯集。
+
+### R4 分類語意必須區分 fail-closed 與 bypass
+
+分類 helper SHALL 將 issue 標題判為五類之一：
+
+- `matched`：type 在值域、scope 在受控詞典內或缺省。
+- `unknown_type`：具 conventional-commit prefix 形式，但 type 不在值域（例：`perf(cli): ...`）。
+- `ambiguous`：type 在值域但 scope 在受控詞典之外，或其他「有主張而無法解析為唯一合法值」的情形。
+- `absent`：標題完全沒有 conventional-commit prefix。
+- `unparseable`：有 prefix 形式痕跡但不合文法（例：括號未閉合）。
+
+處置映射 MUST 為：`matched` → proceed；`unknown_type` 與 `ambiguous` → **fail-closed**（下游 MUST 拒絕自動決策，不得猜測、不得靜默改判）；`absent` 與 `unparseable` → **bypass**（落回明示路徑，且 bypass MUST 可觀測）。
+
+判準 SHALL 為「標題是否明確主張了 taxonomy 語彙」：有主張而不合法即 fail-closed，沒有主張即 bypass。
+
+### R5 combo 對應為輸出投影且缺口明示
+
+每個 type SHALL 有 `combo` 欄位（既有 combo id 或 null）。初始映射：`feat` → `feature-oneshot`；`fix`／`docs`／`test`／`ci`／`refactor` → null（現況缺口，明示不猜）。非 null 值 MUST 指向既有 combo id，loader 於帶入 combo 對照表時 MUST 驗證並對未知引用 fail-closed。
+
+deck combo 檔的 `task_type` 欄位（`feature`／`mcu-feature`）為 legacy workflow-shape 標籤，MUST NOT 當作 taxonomy 值域，本票也 MUST NOT 改名或遷移該欄位。下游 selector 遇 combo 為 null 時 MUST 走可觀測 bypass。
+
+### R6 下游消費契約邊界
+
+- **#202 selector**：MUST 消費本票的分類 helper 與 combo 映射——`matched` 時查映射選 combo、fail-closed 類拒絕自動選牌、bypass 類落回明示路徑並發可觀測事件。MUST NOT 自行實作標題解析。
+- **#137 ledger（成效閉環）**：MUST 以 `(type, scope)` tuple 作為 `task_type × outcome` 計分鍵。
+- **#138 judge（cost-aware dispatch）**：MUST 以 `(type, scope)` tuple 作為路由主軸。
+- **#204 skill ledger**：MUST 以同一 tuple 作為 skill 使用歸屬鍵。
+
+### R7 統一 log reader 與 status view 介面契約（草案定案，不實作）
+
+- **log reader 契約**：單一有邊界 reader 掃 `$HOME/.claude`、`$HOME/.codex`、`$HOME/.copilot` 的 session log（單檔 64MB 上限與 mtime 篩選邊界），輸出統一 schema 的 session 紀錄，欄位 SHALL 為：`source_agent`、`session_id`、`project`（經 hippo `project_resolver` 歸屬）、`started_at`、`usage`（tokens／cost）、`transcript_path`。harvest 取 transcript、cost 取 usage、usage-assess 取歸屬，三消費者 MUST 讀同一 schema。
+- **status view 契約**：動態 JOIN（非第四個資料倉庫），欄位 SHALL 為：`quota`（餘量／reset）、`rate`（瞬時速率）、`health`（跨 agent 存活）、`track_record`（以 `(type, scope)` 為鍵的成功率）。#138 judge 與 #137 棘輪 MUST 讀同一 view。
+- 本票只凍結欄位契約；reader 與 view 的實作屬後續實作票。實作票如需增欄 MUST 以 additive 方式擴充，MUST NOT 改既有欄位語意。
+
+## 非目標
+
+- 不實作 #202 的 combo selector（含 bypass 事件發送機制）。
+- 不實作 #137 ledger、#138 judge、#204 skill ledger。
+- 不實作統一 log reader 與 status view（R7 只凍結介面契約）。
+- 不新增 `fix` 等 type 的 combo，不改既有 combo 檔的 `task_type` 欄位（`fix-standard` combo 是否採納屬叢集另案）。
+- 不做舊 issue 的 task_type 反推遷移（#202 落地時再決定強制範圍）。
+- 不動 CLI（`cortex deck` 子命令與 help 不變）。
+
+## 驗收面
+
+- `task-types.yaml` 可載入且值域為凍結六值；值域漂移、未知鍵、空描述、非法 combo 引用、非法 scope 詞典皆 fail-closed 拒載。
+- 分類 helper 對 `matched`／`unknown_type`／`ambiguous`／`absent`／`unparseable` 五類判定正確，且處置映射（proceed／fail-closed／bypass）可程式化查詢、五類皆有定義。
+- spec 與 design 文件明載本票為 taxonomy 單一真相源與 #202／#137／#138／#204 的引用邊界。
+- 全套 pytest 通過；既有 deck 載入行為與測試不受影響。

--- a/docs/superpowers/specs/feat-work-gc-design.md
+++ b/docs/superpowers/specs/feat-work-gc-design.md
@@ -1,0 +1,51 @@
+---
+status: accepted
+work_item: feat-work-gc
+---
+
+# feat-work-gc Design
+
+## Decisions
+
+### D1 新模組 gc.py＋umbrella CLI 攔截，不經 manager daemon
+
+實作放在新模組 `paulsha_cortex/coordinator/gc.py`；CLI 子命令 `cortex work gc` 由 `paulsha_cortex/cli.py` 比照既有 `work show` 的模式，在透傳 coordinator mutation 路徑之前攔截並路由到 gc 模組，同步更新 `_WORK_HELP` 文字。
+
+理由：GC 是「唯讀偵測＋本機 git 操作」，不是 work lifecycle mutation——不寫 registry、不動 run 狀態，走 manager daemon 的單一 writer 佇列既無必要也增加故障面。umbrella 攔截已有 `work show` 前例（讀 Monitor 而非送 daemon），`gc` 沿用同一路由模式即可；control queue 的 `WORK_ACTIONS` 白名單完全不動。
+
+### D2 proposal-first：預設 dry-run，`--apply` 才執行
+
+預設只輸出候選清單與逐項理由；`--apply` 才對 `reclaim` 項目執行回收。
+
+理由：issue #178 的核心教訓是「標準 git 訊號會騙人」——squash merge、經另一分支併入、fragment 收攏、跨 repo 搬移都會讓 ref 層訊號與內容真相背離。operator 必須先看到「GC 打算刪什麼、為什麼」才授權執行；`reap-brokers` 的 dry-run/apply 介面已是 repo 內既有慣例，沿用同一心智模型。
+
+### D3 merged 判定用兩段驗證鏈：ancestor → `git cherry` 內容等價
+
+先跑 `git merge-base --is-ancestor <tip> <default>`（普通 merge 的快速路徑）；不成立再跑 `git cherry <default> <branch>`，輸出無 `+` 行即為「所有 patch 已以等價內容落地」；兩者皆不成立視為 unmerged。default branch 依 `origin/HEAD` 解析、退回 `main`，且不主動 fetch。刪除一律用 `git branch -D`，但僅在驗證鏈通過後。
+
+理由：v0.1.0 收尾實證 `git branch -d`／`--merged` 對 upstream 判定會誤拒已合併分支，而 ref-ancestry 對 squash-merge 必然誤報 unmerged；`git cherry` 以 patch-id 等價比對內容層，正好覆蓋 squash／rebase 案例。不 fetch 讓命令離線可用，且基準過時的失效方向是「多保留」——與 fail-safe 同向，不會誤刪。
+
+### D4 fail-safe 分類輸出：每項 artifact 標 action＋reason code
+
+每個候選 artifact 產出 `reclaim` 或 `keep`，並附機器可讀 reason code：`merged-ancestor`、`merged-content`、`unmerged-content`、`dirty-worktree`、`protected`、`pr-closed-unmerged`、`verification-error`、`apply-error`。任何 git 命令失敗一律轉 `keep`＋`verification-error`；`--apply` 單項失敗記 `apply-error` 並續行。
+
+理由：靜默跳過與靜默刪除都是最糟行為——operator 需要能從報告直接回答「為什麼這條分支沒被收」。reason code 讓報告可 grep、可 JSON 消費，也讓測試能對每個負向案例逐一斷言。
+
+### D5 GitHub 資訊只做 best-effort 註記，不參與回收判定
+
+回收判定純本機 git；closed-unmerged PR 的偵測透過可注入的 PR 狀態 provider（預設走 `gh`）把 keep 理由升級為 `pr-closed-unmerged`，provider 不可用時退化為 `unmerged-content`。
+
+理由：closed-unmerged 分支的內容必然不在 default branch，內容層判定已保證它被保留——GitHub 查詢只影響「理由標註的精確度」，不影響安全性。這讓 GC 離線可用、測試不需網路，也避免 gh 故障變成 GC 故障。
+
+### D6 範圍收斂：worktree＋local branch，registry 唯讀，remote 非目標
+
+本次只做殘留 worktree 與已 merge local branch 的回收與報告。registry（`jobs.json`）壓縮／歸檔、remote branch 刪除、死 PR／correlation 退場（#175）、journal 清理全部列非目標；gc 模組不 import 任何 registry 寫入 API。
+
+理由：manager 是 registry 的單一 writer，GC 兼寫會破壞既有一致性模型；remote 刪除不可逆且跨越本機安全邊界。worktree＋branch 是 v0.1.0 收尾實際手動清理量最大、且可用純本機 git 安全判定的部分——先把這塊做到絕不誤刪，其餘留給 #175 與後續 issue。
+
+## 風險與緩解
+
+- **`git cherry` 對大分支較慢**：候選數量以 worktree pool 與 local branch 為界（數十級），且 ancestor 快速路徑先行；dry-run 為互動命令可接受秒級延遲。
+- **內容曾落地後又被 revert**：`git cherry` 仍會判 merged 而回收——但此時內容確實曾完整進入 default branch 歷史，revert 是後續獨立決策，分支本身已無獨有內容，符合「不刪 unmerged content」的安全定義。
+- **umbrella help 與實際子命令漂移（R-16）**：`_WORK_HELP` 更新納入 plan 任務，並在 `tests/test_cli_help_alignment.py` 加斷言鎖住。
+- **`--apply` 與判定之間的 TOCTOU**：apply 對每個 `reclaim` 項目在執行前重跑一次驗證鏈，狀態已變時轉 `keep`＋`apply-error`。

--- a/docs/superpowers/specs/feat-work-gc-spec.md
+++ b/docs/superpowers/specs/feat-work-gc-spec.md
@@ -1,0 +1,91 @@
+---
+status: accepted
+work_item: feat-work-gc
+---
+
+# feat-work-gc Specification
+
+#178：提煉 v0.1.0 收尾的爛尾清理邏輯為 `cortex work gc` 命令，讓 operator 以單一 proposal-first 命令安全回收殘留 build worktree 與已 merge 的 local branch，且絕不誤刪任何內容尚未落地的產物。
+
+## 背景
+
+cortex 每批次派工會產生大量 build 產物（worktree、交付分支、run、PR、journal、correlation），但沒有生命週期回收；v0.1.0 收尾時 operator 手動清了 8 個批次 worktree 與約 19 個分支，並暴露三個反直覺陷阱：
+
+- **squash / rebase merge 後 ref-ancestry 失真**：PR squash 後原分支 commit 不在 default branch 歷史，`git branch --merged`／`rev-list main..branch` 顯示 unmerged，但內容其實已落地。經另一分支併入、fragment 收攏、跨 repo 搬移也都會造成同樣假象。
+- **`git branch -d` 誤拒**：`-d` 對「配置的 upstream」判定而非對 default branch，導致確定已合併（`main..branch` 為 +0）的分支仍被拒刪。
+- **closed-unmerged PR 的 correlation 凍結**：已關閉未合併的 PR 其 `closingIssuesReferences` 被 GitHub 凍結，對應分支的內容去向必須人工考證，絕不可自動回收。
+
+因此安全清理必須做內容層驗證（deliverable 是否已存在於 default branch），不能只信 ref-ancestry；任何疑義都必須保留並回報，讓 operator 審閱後決定。
+
+## Goals
+
+- operator 以單一命令列出並回收一個 repo 的殘留 build worktree 與已 merge local branch。
+- squash-merge 後的分支被正確判為 merged，不因 ref-ancestry 失真而漏收。
+- 任何內容尚未落地的分支、dirty worktree 或判定疑義一律保留並附理由，絕不誤刪。
+
+## Requirements
+
+### R1 proposal-first 回收命令
+
+`cortex work gc` SHALL 提供 repo 層的產物回收命令。
+
+預設模式 MUST 為 dry-run：只輸出候選清單，逐項標明 artifact 種類（worktree／branch）、判定結果（`reclaim`／`keep`）與 reason code，MUST NOT 改變任何 git 狀態。
+
+只有帶 `--apply` 時 MAY 執行回收，且 MUST 只處理判定為 `reclaim` 的項目。
+
+### R2 merged 判定必須內容層驗證
+
+分支是否 merged 的判定 MUST 依序採用以下驗證鏈，任一成立即視為 merged：
+
+1. **ancestor 判定**：`git merge-base --is-ancestor <branch-tip> <default-branch>` 成立。
+2. **內容等價判定**：`git cherry <default-branch> <branch>` 輸出不含 `+` 行（所有 patch 皆已以等價內容存在於 default branch）。
+
+兩者皆不成立時 MUST 視為 unmerged。
+
+判定 MUST NOT 以 `git branch -d`、`git branch --merged` 或 upstream ref-ancestry 為準。squash-merge 後內容已落地 default branch 的分支 MUST 被正確判為 merged。
+
+default branch MUST 依 `origin/HEAD` 解析，無法解析時退回 `main`；GC MUST NOT 主動 fetch（比對基準過時只會導致多保留，不會導致誤刪）。
+
+### R3 fail-safe：疑義一律保留
+
+任何疑義 MUST 判 `keep` 並附具體 reason code，MUST NOT 進入 `--apply` 執行清單：
+
+- 內容比對不吻合（unmerged content）。
+- worktree 有未 commit 變更或 untracked 檔案（dirty worktree）。
+- 判定過程任何 git 命令失敗（verification error）。
+- default branch、目前 checked-out branch、掛在 keep worktree 上的 branch（protected）。
+
+對應 PR 為 closed-unmerged 的分支 MUST 保留；PR 狀態查詢屬 best-effort 註記，查詢不可用時 MUST 安全退化為內容層判定結果（同樣保留）。
+
+`--apply` 執行中單項失敗 MUST 記為 `keep` 並附 reason，且 MUST 續行其餘項目，MUST NOT 因單項失敗中斷整批。
+
+### R4 回收範圍與報告
+
+候選範圍 SHALL 為：worktree pool（repo 同層 `<repo>-worktrees`，`PSC_WORKTREE_ROOT` 可覆寫）內的殘留 build worktree，與 repo 的 local branch。
+
+`--apply` 對 clean 且 merged 的 worktree MUST 以 `git worktree remove` 移除；對通過 R2 驗證鏈的 merged branch MUST 於刪除前重新驗證一次，再以 `git branch -D` 刪除。
+
+報告 MUST 逐項列出 artifact、判定與 reason；`--json` MUST 輸出 versioned schema（`cortex-work-gc/v1`），含 dry-run／apply 模式標記與逐項結果。
+
+### R5 registry 唯讀與範圍邊界
+
+GC MUST NOT 寫入 `jobs.json` 或任何 manager 狀態檔（manager 是單一 writer，GC 僅讀）。
+
+GC MUST NOT 刪除 remote branch、MUST NOT 操作 PR、MUST NOT 清理 delivery journal 或 correlation（皆屬非目標）。
+
+## 非目標
+
+- remote branch 刪除（本命令僅處理 local 產物）。
+- registry（`jobs.json`）的壓縮、歸檔或任何 mutate（manager 單一 writer；GC 僅讀）。
+- 死 PR／closed-PR correlation 凍結的退場規則（#175 範圍）。
+- delivery journal 孤兒 row 清理（#175 範圍）。
+- 跨 repo 搬移的自動偵測（此類分支經 R2 判 unmerged 而保留，由 operator 依 keep 清單人工處置）。
+
+## 驗收面
+
+- squash-merge 後的分支被正確判 merged 並可回收，不被誤判 unmerged。
+- unmerged 分支絕不出現在 `--apply` 執行清單，`--apply` 後仍存在。
+- dirty worktree 保留並附 `dirty-worktree` 理由。
+- closed-unmerged PR 對應分支保留；PR 查詢不可用時安全退化仍保留。
+- 預設 dry-run 對 worktree、分支與 `jobs.json` 皆零變更。
+- git 命令失敗時該項判 `keep` 並附理由，不中斷整批。

--- a/docs/superpowers/specs/fix-persona-catalog-portability-design.md
+++ b/docs/superpowers/specs/fix-persona-catalog-portability-design.md
@@ -1,0 +1,46 @@
+---
+status: accepted
+work_item: fix-persona-catalog-portability
+---
+
+# fix-persona-catalog-portability Design
+
+## Decisions
+
+### D1 canonical catalog 改為套件內建來源，復用既有驗證路徑
+
+verification 讀 catalog 的 canonical 來源改為 `paulsha_cortex.persona.loader.DEFAULT_PERSONAS_PATH`（`persona/loader.py:12`，package-relative，隨安裝發佈）。packaged 檔案文字讀入後仍走既有 `_load_catalog_from_text`（`verification.py:478`）做 schema 驗證，不另開驗證路徑。
+
+理由：根因是 verification 隱含假設「被治理 repo == cortex repo」。persona 定義是 cortex 的產品資產，該從安裝的套件解析，而不是要求每個被治理 repo 的 git tree 都長出 cortex 的內部檔案。復用 `_load_catalog_from_text` 讓 packaged 與 repo-local 兩個來源吃同一套驗證，行為可預測。
+
+### D2 override 偵測與讀取分離：以 dispatch_base tree 存在性探測
+
+先以 `git cat-file -e {dispatch_base}:{PERSONA_CATALOG_PATH}` 探測 override 是否宣告存在：exit 0 表示宣告存在，必須接著以既有 `git show` 讀取成功，讀不到即 fail-closed；exit 非零視為未宣告，回退 packaged catalog。
+
+理由：單靠 `git show` 失敗無法區分「路徑不存在於該 commit」與「repo 或物件層的其他錯誤」，解析 stderr 字串脆弱且受 locale 影響。existence probe 讓「未宣告，回退」與「宣告但不可讀，fail-closed」成為兩個確定性分支，正好對應架構裁決的兩個語意。
+
+風險與緩解：repo 整體損壞時 `cat-file -e` 也回非零，會被歸類為「未宣告」——但緊接的 persona scope diff（`verification.py:805-819`）仍要對同一 repo 跑 `git diff`，repo 損壞會在該步以 `persona-scope-error` fail-closed，不會靜默通過。
+
+### D3 override 壞損不回退，fail-closed 語意維持
+
+override 宣告存在但讀取失敗維持 `persona-catalog-unreadable`；可讀但解析／schema 不合法維持 `persona-catalog-invalid`。不因 packaged catalog 可用而靜默降級。packaged 分支自身讀檔 OSError 對應 `persona-catalog-unreadable`、驗證 ValueError 對應 `persona-catalog-invalid`。
+
+理由：repo 明示提供 override，代表其 persona 契約可能刻意與 packaged 不同；壞損時退 packaged 等於拿錯的契約做 scope 判定，且 operator 事後看不出來。靜默回退是最糟的行為，fail-closed 加明確 reason 才是 verification 既有的一貫語意。
+
+### D4 cortex repo 行為由 override 分支自然保留，不做 repo 身分特判
+
+cortex repo 自身 git tree 本來就有 `paulsha_cortex/persona/personas.yaml`，必然落在 override 分支：仍 pin 在 `dispatch_base` commit 讀取、記 content hash，與現行為一致。程式不辨識「這個 repo 是不是 cortex」。
+
+理由：以「檔案是否存在於 dispatch_base tree」做行為分界是可測、確定性的；以 repo 身分特判需要辨識 remote／路徑等環境訊號，脆弱且在 fork、鏡像、worktree 情境下語意不明。
+
+### D5 evidence 加來源標記、錯誤帶 attempted sources（additive）
+
+成功時 `details["persona_catalog"]` 增加 `"source"` 欄位（`"repo-local"` 或 `"packaged"`）；repo-local 分支既有欄位（`path`／`commit`／`hash`）不變；packaged 分支 `path` 記 packaged 來源路徑、`commit` 記 `None`、`hash` 記內容 sha256。失敗時 error payload 記錄實際嘗試過的來源（repo-local 的 path 加 commit，或 packaged 的 path）。
+
+理由：#295 明確要求 operator 能分辨「catalog 不可得」是設定問題還是真違規；來源標記讓每次 scope 判定的依據可稽核。additive 欄位不動 repo-local 分支既有形態，evidence consumer 不受影響；packaged 分支的新形態只出現在過去必 fail 的情境，沒有回溯相容問題。
+
+## 風險與緩解
+
+- **既有測試的 FakeGitRunner 對未知 git call 直接 AssertionError**：新增 `cat-file -e` 探測呼叫後，`tests/test_coordinator_candidate_verification.py` 既有走到 catalog 段的測試需在 response map 補探測項（回 exit 0）。屬機械性同步，plan 以獨立 task 一次到位，驗收為該測試檔全綠。
+- **packaged catalog 與被治理 repo CI 端 persona-scope 檢查的 catalog 版本漂移**：verification evidence 記 source 與 content hash，漂移可稽核；catalog 內容治理仍歸 cortex repo，被治理 repo 要客製即走 repo-local override 顯式宣告。
+- **packaged catalog 在安裝損壞時缺檔**：D3 已涵蓋——packaged 讀取失敗同樣 fail-closed 並在錯誤中帶 packaged 路徑，operator 可直接看出是安裝問題而非 repo 問題。

--- a/docs/superpowers/specs/fix-persona-catalog-portability-spec.md
+++ b/docs/superpowers/specs/fix-persona-catalog-portability-spec.md
@@ -1,0 +1,68 @@
+---
+status: accepted
+work_item: fix-persona-catalog-portability
+---
+
+# fix-persona-catalog-portability Specification
+
+#295（primary）＋#291（duplicate）：verification gate 在被治理 repo 內 `git show paulsha_cortex/persona/personas.yaml`，非 cortex repo 必卡 `needs_human(persona-catalog-unreadable)`。改為以 cortex 套件內建 catalog 為 canonical 來源、被治理 repo 可選擇性提供 repo-local override，讓跨 repo 治理的 slice 能通過 persona gate。
+
+## 背景
+
+`run_result_verification` 在 persona scope 判定前，無條件從**目標 repo** 的 `dispatch_base` commit 讀取 `paulsha_cortex/persona/personas.yaml`（`paulsha_cortex/coordinator/verification.py:27` 的 `PERSONA_CATALOG_PATH` 常數、`:780-804` 的 `git show` 段）。該檔只存在於 paulsha-cortex 自己的 git tree，因此任何被治理的非 cortex repo，builder Job 即使成功產出，verification 也確定性停在 `needs_human` / `persona-catalog-unreadable`。
+
+同時 `dispatch: auto` 強制要求恰好一個 persona-scope check（`verification.py:284-294`），spec 拿掉該 check 即 `invalid-frontmatter`。兩邊構成封閉矛盾：必須宣告，宣告必失敗，拿掉則 spec 不合法。#295 於 IntelliDbgKit、#291 於 serialwrap 皆實測到 build 成功但產出被結構性卡在 verification 門口，下游 `depends_on` 永不滿足。
+
+`paulsha_cortex/persona/loader.py:12` 已有 package-relative 的 `DEFAULT_PERSONAS_PATH` 可復用：persona 定義是 cortex 的產品資產，隨安裝套件發佈，不是被派工 repo 的資產。
+
+## Goals
+
+- 非 cortex repo（無 repo-local catalog）的 slice 可通過 persona gate，跨 repo 治理不再於 verify 階段確定性失敗。
+- 被治理 repo 可用 repo-local catalog override 覆寫 packaged catalog，且壞損時維持 fail-closed。
+- cortex repo 自身（repo 內有 catalog）行為不退化。
+- catalog 讀取失敗時 operator 可從錯誤訊息分辨是設定問題還是真違規。
+
+## Requirements
+
+### R1 packaged catalog 為 canonical 來源
+
+verification 的 persona gate SHALL 以 cortex 套件內建 catalog（`paulsha_cortex.persona.loader.DEFAULT_PERSONAS_PATH`，package-relative）為 canonical 來源。
+
+被治理 repo 的 `dispatch_base` tree 內不存在 `paulsha_cortex/persona/personas.yaml` 時，persona gate MUST 以 packaged catalog 完成 scope 判定，MUST NOT 回 `needs_human(persona-catalog-unreadable)`。packaged catalog 內容 MUST 經與現行 `_load_catalog_from_text` 相同的 schema 驗證。
+
+### R2 repo-local override 以 dispatch_base tree 存在性判定
+
+被治理 repo MAY 於自身 git tree 提供同路徑檔案 `paulsha_cortex/persona/personas.yaml` 作為 repo-local override。
+
+override 生效判定 MUST pin 在 `dispatch_base` commit：該 commit tree 內存在該路徑即 override 生效並優先於 packaged catalog；不存在即回退 packaged catalog。override 生效時 MUST 從 `dispatch_base` commit 讀取內容（不讀 working tree），維持與現行相同的 pinning 語意。
+
+### R3 override 宣告存在但壞損 MUST fail-closed
+
+override 於 `dispatch_base` tree 宣告存在但內容不可讀時，MUST 維持 `needs_human` / `persona-catalog-unreadable`；可讀但解析或 schema 不合法時 MUST 維持 `needs_human` / `persona-catalog-invalid`。兩者皆 MUST NOT 靜默回退 packaged catalog。
+
+packaged catalog 自身不可讀或不合法（安裝損壞）時亦 MUST fail-closed，分別對應 `persona-catalog-unreadable` 與 `persona-catalog-invalid`。
+
+### R4 cortex repo 自身行為不可退化
+
+repo git tree 內有 catalog 的 repo（含 cortex repo 自身）MUST 落在 R2 的 override 分支：仍自 `dispatch_base` commit 讀取 catalog、以其內容做 scope 判定並記錄 content hash，與現行為一致。既有 verification 測試 MUST 在不改斷言語意的前提下維持全綠。
+
+### R5 錯誤與 evidence 必須可稽核來源
+
+persona catalog 讀取失敗時，錯誤 payload MUST 帶實際嘗試過的來源：repo-local 分支記 repo 內路徑與 `dispatch_base` commit；packaged 分支記 packaged 來源路徑。
+
+成功時 evidence 的 `persona_catalog` MUST 記錄採用來源標記（`repo-local` 或 `packaged`）、來源路徑與 content hash，使事後可稽核 scope 判定依據哪一份 catalog。
+
+## 非目標
+
+- 不放寬 `dispatch: auto` 對恰好一個 persona-scope check 的要求（`verification.py:284-294`）；packaged fallback 已解除「必須宣告、宣告必失敗」的封閉矛盾，該檢查維持原樣。
+- 不新增 env／instance config 指定 catalog 路徑的通道（#295 期望選項 2）；本次採選項 1（packaged canonical）加上 repo-local override。
+- 不改 persona scope 判定演算法（`gate.build_verdict`）與 catalog schema 驗證規則。
+- 不處理 #291 附帶觀察的 manager 單例、systemd sanitized env、target branch 預先存在、builder Bash 白名單議題（各屬另案）。
+
+## 驗收面
+
+- 非 cortex repo（無 repo-local catalog）的 slice verification 通過 persona gate，不再 `needs_human(persona-catalog-unreadable)`。
+- repo-local override 存在時優先於 packaged，且內容 pin 在 `dispatch_base` commit。
+- override 宣告存在但不可讀／不合法時 fail-closed，reason 分別維持 `persona-catalog-unreadable`／`persona-catalog-invalid`。
+- cortex repo 自身現行為不變，既有 verification 測試全綠。
+- evidence 記錄 catalog 來源標記與 hash；讀取失敗的錯誤帶實際嘗試過的來源路徑。

--- a/docs/superpowers/specs/fix-repair-commit-recovery-design.md
+++ b/docs/superpowers/specs/fix-repair-commit-recovery-design.md
@@ -1,0 +1,52 @@
+---
+status: accepted
+work_item: fix-repair-commit-recovery
+---
+
+# fix-repair-commit-recovery Design
+
+## Decisions
+
+### D1 新增獨立窄化 action，不放寬 retry-build 的 CAS
+
+以 `_recover_planning_action` 為模板（`_recover_pre_candidate_action` 為第二個先例）新增 `_recover_repair_commit_action`；`_retry_build_action` 的 `expected_candidate` exact CAS 與 `_manager_reset_workflow_for_retry_build` 的 exited/0 unbound 窄化入口原封不動。
+
+理由：issue #260 的 2026-08-01 複驗結論明確要求沿用既有恢復動作的形狀而非另立一套，也明確要求不得放寬既有關卡。放寬 retry-build 的 admission 會讓「失敗 job 的 worktree 內容」在沒有 operator 明確指認 SHA 的情況下取得重派資格，模糊 CAS 的責任邊界；獨立 action 讓「adopt 既有 commit」與「重派新 builder」是兩個語意分離、各自 fail-closed 的入口。
+
+### D2 判準全部取自系統事實，caller 參數只做交叉比對
+
+worktree 路徑取自 failed builder job row；HEAD、乾淨度、descendant lineage 全部由 manager 側 git 呼叫確認（沿用 `_verify_exact_candidate`／`_verify_build_candidate_transition` 的驗證語意）；operator 提供的 `expected_run_id` 與 `expected_candidate` 只用來與系統事實交叉比對，白名單外參數一律拒絕。
+
+理由：這是 `recover-planning`／`recover-pre-candidate` 已確立的模式——caller 帶的內容永遠不成為 evidence。操作面上 operator 仍必須明確指認要 adopt 的 SHA（對應 issue 期望行為「要求 operator 提供 exact expected SHA」），但授權判準的每一項都能被系統獨立重算，錯誤的指認只會 fail closed，不會 bind 錯 commit。
+
+### D3 adoption 以 manager 登錄的 adoption job row 承載觀測事實
+
+adoption 成功時登錄一筆新 job row：欄位沿用既有 job row 欄位集合（不新增欄位），identity、worktree、dispatch_head 複製自 failed job，`subject_head` 為 adopted candidate，狀態 exited/0，`workflow_evidence` 指向 adoption record；failed job 原始 row 原樣保留。provenance（failed job id、observed HEAD、失敗原因）記錄在 adoption evidence record 內，不新增 job row 欄位。
+
+理由：下游的 `_verify_exact_candidate` 與 `_review_builder_job_binding` 都要求「一筆 exited/0、subject_head 等於 candidate 的 builder job」才能繼續 verify／exact-head review。與其放寬這兩個 binding（會弱化所有 run 的驗證強度），不如補一筆完整通過驗證的事實紀錄——row 上每個欄位都是 manager 確定性驗證過的 git／registry 事實。不新增欄位是 #205 的教訓：新欄位落在 providers 投影白名單之外會讓整份 projection 變 degraded。改寫 failed job row 則違反 job 紀錄不可變原則，故不採用。
+
+### D4 evidence record 與 CAS 冪等，比照 recover-planning 的 already-recovered 模式
+
+adoption 寫入 `cortex-work-repair-adoption/v1` durable record（`evidence/work-repair-adoption/<run_id>-<digest>.json`，digest 取 canonical JSON hash，比照 `_abandon_record`）。重送相同 request 時，若 run 的 `candidate_head` 已是 expected SHA 且對應 record 存在，直接回 `already-recovered`，不做任何第二次變更。
+
+理由：`recover-planning` 已用「掃描既有 recovery evidence → already-recovered」實現冪等，同一模式讓 operator 與 auto-run 重送 request 時天然安全（對應 issue 期望行為「同一 recovery request 不得重複啟動 model session」——本 action 更進一步：任何情況都不啟動 model session）。CAS 失敗（run 已前進到其他 candidate）則 fail closed，不做模糊比對。
+
+### D5 registry 原子方法完成 bind 與 phase 前進
+
+新增 `_manager_adopt_repair_candidate`（`paulsha_cortex/coordinator/registry.py`），比照 `_manager_reset_workflow_for_retry_build` 的 CAS／admission 風格：驗 run 狀態、final build card pending、無 active job 後，在單一 persist 內完成——`candidate_head` 更新為 adopted SHA、final build step 以 adoption job 的 builder identity 標 passed、`current_phase` 進 verify、`attempts["verify"]` 遞增、移除 `needs_human` facet、`verified_head` 歸零、evidence_refs 附掛 adoption record。
+
+理由：分散多次 update 會產生「candidate 已換但 card 還 pending」的 crash window，dispatch 可能在中間狀態重派 builder。registry 既有的 retry reset 方法都是單一原子 persist，adoption 沿用同一風格。build step 用 builder identity（複製自 failed job）而非 manager identity 標 passed，是為了讓 review phase 的 foreign-domain 檢查（builder_domains 取自 build steps）對照的是真正寫出 commit 的 builder domain。
+
+### D6 resume／dispatch 的 failed terminal 判定補上 exited 非 0
+
+`resume_workflow_run` 的 replacement 判定與 `_dispatch_workflow_card` 的 `retryable_latest` 判定，在 retry_failed 情境下把「`status == "exited"` 且 exit code 非 0」視同 `status == "failed"`（對齊 `TERMINAL_STATUSES` 的終止語意）；exited/0 的路徑（unbound terminal、malformed schema retry）原封不動。失敗回報附掛 `_terminal_parse_diagnostics` 唯讀診斷。
+
+理由：兩處判定目前只認 `status == "failed"`，exited 非 0 的 stale terminal 會讓第一次 resume 空轉一輪（重新回報 job-failed、重掛 needs_human），第二次才 dispatch replacement——這正是 issue 複驗指出「仍未處理」的第三項。收斂點選在既有條件式，不另立選擇機制，改動面最小；診斷與授權分離沿用 #261 的 `authority_granted: false` 模型，可觀測不等於可授權。
+
+## 風險與緩解
+
+- **adoption job row 被誤讀為正常成功的 builder job**：row 的 `workflow_evidence` 指向 `cortex-work-repair-adoption/v1` record，record 內含 failed job id 與失敗原因，稽核可完整還原「誰失敗、誰採納、採納了什麼」；且 verify／review 仍會對 adopted candidate 完整重新把關，adoption 不授予任何品質判定。
+- **新欄位造成 Monitor 投影 degraded（#205 曾實際踩到）**：adoption job row 與 WorkflowRun 更新都只使用既有欄位；provenance 一律放 evidence record。測試以 providers 投影非 degraded 作為驗收之一。
+- **resume 條件變更影響既有 malformed-terminal／schema-retry 路徑**：擴充嚴格限定在「exit code 非 0 的 exited terminal」，exited/0 的三條既有路徑（unbound terminal recovery、malformed schema retry、正常 terminalize）條件式不動；以回歸測試鎖定 `test_resume_replay_keeps_single_replacement_job` 與既有 schema-retry 測試全綠。
+- **worktree 在 adoption 前被回收或改動**：所有 git 事實在 action 執行當下重新驗證，worktree 缺失、dirty、HEAD 不符即 fail closed；此時 operator 仍可改走既有 `retry-build`（重派新 builder session），不會卡死。
+- **adoption 與 retry-build 對 exited/0 unbound 情境重疊**：屬刻意設計——該情境兩個入口都合法（adopt 不花 model session、retry-build 重派修復），由 operator 依 commit 是否可信選擇；兩者 CAS 各自獨立，不互相放寬。

--- a/docs/superpowers/specs/fix-repair-commit-recovery-spec.md
+++ b/docs/superpowers/specs/fix-repair-commit-recovery-spec.md
@@ -1,0 +1,96 @@
+---
+status: accepted
+work_item: fix-repair-commit-recovery
+---
+
+# fix-repair-commit-recovery Specification
+
+#260：repair commit 已在 worktree 但缺 terminal evidence 時，提供具 CAS 的窄化 adopt/recover 動作，並修正 resume／retry-build 不再重選 stale failed job，讓 auto-run 修復迴路可自行閉環。
+
+## 背景
+
+以 Cortex auto-run dogfood 修復迴路時重現一條沒有 recovery path 的狀態：原 candidate 經對抗審查拒絕後，repair worker 在既有 builder worktree 產生新的 descendant commit，但 repair job 隨後以失敗終止、沒有留下可採用的 terminal evidence。
+
+現況有兩個缺口。第一，admission 缺口：`_manager_reset_workflow_for_retry_build`（`paulsha_cortex/coordinator/registry.py`）的 build phase 窄化入口只接受 `status == "exited"` 且 `exit_code == 0` 的 unbound terminal builder job，真正的 failed job（`status == "failed"` 或 exited 非 0）即使 git object 與 worktree HEAD 均存在也無法被 adopt；`_classify_retry`（`paulsha_cortex/coordinator/work_actions.py`）的 `terminal_with_evidence` 篩選同樣要求 `exit_code == 0`。第二，選擇缺口：`resume_workflow_run`（`paulsha_cortex/coordinator/manager.py`）的 replacement 判定只認 `status == "failed"`，對 `status == "exited"` 且 exit code 非 0 的 stale terminal job，第一次 resume 只會重新回報 `job-failed` 並重掛 needs_human，要再執行一次才 dispatch replacement。
+
+結果是可驗證的修復 commit 已存在，但 lifecycle 無法安全地 bind、驗證或繼續 exact-head review，operator 只能介入 runtime state。
+
+近期已落地的 `recover-planning`（#256）、`recover-pre-candidate` 與 dirty candidate 重評（#277／PR #290）同屬「lifecycle 卡死無出口」家族但情境各不相同：前者發生在 build 之前、與 candidate 無關；`recover-pre-candidate` 處理的是**沒有** commit 可 adopt 的情況；dirty candidate 重評是重跑 verification 重新判定。三者都沒有涵蓋本 work item 的核心——repair job 失敗終止、但已產生可驗證的 descendant commit。#292（機械驗收，PR #293）屬 quality 模組，與本缺口無關。
+
+## Goals
+
+- repair job 即使 process／terminal 失敗，也不默默遺失已產生 candidate 的可觀測性與可恢復性。
+- manager 在 fail-closed 前提下，對既有 repaired HEAD 提供明確、具 CAS 的 recovery action，通過確定性驗證後 bind 為新 candidate。
+- resume／retry-build 選擇最新且符合 run／action 的 eligible job，第一次 resume 即 dispatch replacement，不重選已 terminalized 的 stale failed job。
+- 同一 recovery request 具冪等性，不重複啟動 model session。
+
+## Requirements
+
+### R1 獨立窄化 recovery action
+
+系統 SHALL 新增獨立的 `recover-repair-commit` work action，比照 `_recover_planning_action`／`_recover_pre_candidate_action`（`paulsha_cortex/coordinator/work_actions.py`）的既有模式實作。
+
+此 action MUST 只在下列全部條件成立時可用，任一不成立 MUST fail closed 並回報具體原因：
+
+- WorkflowRun 為 ongoing、帶 `needs_human` facet、`current_phase == "build"`。
+- 前置 build card 全部 passed、final builder card 為 pending。
+- 最新同 card builder job 為失敗終止（`status == "failed"`，或 `status == "exited"` 且 exit code 非 0，或 exited/0 但 terminal payload 缺漏／malformed），且其 `workflow_evidence` 為 `None`。
+- 該 run 無任何 active（in-flight）workflow job。
+
+此 action MUST NOT 啟動任何 model session——adoption 完全由 manager 側確定性驗證完成。
+
+### R2 判準取自系統可驗證的事實
+
+recovery 的驗證輸入 MUST 取自系統既有紀錄與 git 事實，caller 帶的參數只做交叉比對、MUST NOT 被當作 evidence 採信：
+
+- worktree 路徑 MUST 取自 failed builder job row，不接受 caller 指定路徑。
+- operator 提供的 `expected_candidate`（40-hex exact SHA）MUST 精確等於該 worktree 的 `git rev-parse HEAD`。
+- 該 worktree MUST 乾淨（`git status --porcelain` 為空）；dirty worktree MUST 拒絕。
+- `expected_candidate` MUST 為原 candidate（`run.candidate_head`）的合法 descendant（`git merge-base --is-ancestor` 成立），且 MUST NOT 與原 candidate 相同——相同時代表沒有新 commit 可 adopt，MUST 拒絕並提示改走 `retry-verify`。
+- `--issue` 有指定時 MUST 屬於 WorkAuthority 的 mapped issues；run 的 issue_refs／openspec_refs MUST 與 authority 一致。
+- 白名單以外的 caller 參數 MUST 拒絕（比照既有 `rejects caller evidence/input` 模式）。
+
+### R3 CAS 與冪等性
+
+此 action MUST 要求 `expected_run_id`（`workflow-[0-9a-f]{20}` exact match）與 `expected_candidate` 雙重 CAS。
+
+adoption 成功後 MUST 產生 durable evidence record（schema `cortex-work-repair-adoption/v1`，存於 coordinator state 的 `evidence/work-repair-adoption/` 下），記錄 failed job id、observed HEAD、adopted candidate、previous candidate 與 actor。
+
+重送相同 request 時，若該 run 已存在對應的 adoption record 且 candidate 已前進，MUST 回報 `already-recovered` 且 MUST NOT 產生第二次 adoption、第二個 job row 或任何 model session。
+
+### R4 不放寬既有關卡
+
+`retry-build` 的 `expected_candidate` exact CAS（`paulsha_cortex/coordinator/work_actions.py` 的 `_retry_build_action`）MUST 保持原封不動；`retry-verify`／`retry-review` 的 CAS 與 admission 同樣不變。
+
+`recover-repair-commit` MUST NOT 成為繞過 terminalization 或 gate 驗證的後門：最新同 card job 已有 bound `workflow_evidence` 時 MUST 拒絕；`_manager_reset_workflow_for_retry_build` 既有的 exited/0 unbound 窄化入口行為 MUST 保持不變。
+
+### R5 adoption 後生命週期可續行
+
+adoption 成功後，run 的 `candidate_head` MUST 更新為 adopted candidate，final build card MUST 以確定性方式標為 passed，run MUST 進入 verify phase；既有 verify → foreign review → exact-head final 管線 MUST 以 adopted candidate 重新把關內容品質，MUST NOT 重跑已完成的 planning。
+
+為使既有 verify／review 的 builder job binding（`_review_builder_job_binding`、`_verify_exact_candidate`，`paulsha_cortex/coordinator/manager.py`）不需放寬，adoption MUST 登錄一筆 manager 記錄的 adoption job row：欄位沿用既有 job row 欄位集合（不新增欄位），identity（executor／model／independence_domain）、worktree 與 dispatch_head 複製自 failed job，`subject_head` 為 adopted candidate，`status`/`exit_code` 為 exited/0，`workflow_evidence` 指向 adoption record。failed job 的原始 row MUST 原樣保留不得改寫。
+
+### R6 resume／retry-build 不重選 stale failed job
+
+`resume_workflow_run` 與 `_dispatch_workflow_card`（`paulsha_cortex/coordinator/manager.py`）在 operator resume（retry_failed）情境下，對「已 terminalized 的失敗 job」的判定 MUST 涵蓋 `status == "exited"` 且 exit code 非 0 的情況（與既有 `status == "failed"` 並列），使第一次 resume 即 dispatch replacement job，MUST NOT 先重選 stale failed job 空轉一輪。
+
+replacement dispatch 後再次 resume MUST NOT 產生第二個 replacement job（in-flight job 存在時回報 in-flight）。
+
+resume 對失敗 job 的回報 MUST 附帶唯讀 terminal 診斷（沿用 #261 的 `_terminal_parse_diagnostics`：observed HEAD、job id、失敗原因），且 MUST NOT 因此授予任何 candidate authority。
+
+## 非目標
+
+- 不放寬 `retry-build`／`retry-verify`／`retry-review` 的 CAS 與 admission（R4 明確鎖定）。
+- 不改 gate ledger／terminal contract 本身（#261 已定案；本 work item 只引用其 evidence 驗證模式）。
+- 不涵蓋 slice lane 的 pre-candidate 恢復與 dirty candidate 重評（#277／PR #290 已落地）。
+- 不提供自動 adoption——periodic runner 不取得此 recovery authority，沿用既有 operator-only recovery 原則。
+- 不處理 malformed passed-terminal／null candidate（#106）與 slice failed state 無 action（#153）的既有範圍。
+
+## 驗收面
+
+- 測試重現 repair job 留下 descendant commit、exit 非 0／terminal missing 的情境，並可經 `recover-repair-commit` 恢復後繼續 verify → foreign review → exact-head final。
+- 非 descendant、dirty worktree、evidence 已 bind、issue 未授權時全部 fail closed 並回報具體原因。
+- 第一次 operator resume 即 dispatch replacement，不重選 stale failed job；重送相同 request 不產生第二個 replacement job 或第二次 adoption。
+- `retry-build` 的 exact expected_candidate CAS 行為與現況完全一致（回歸測試鎖定）。
+- 狀態面可見 observed worktree HEAD、job id、失敗原因，但未通過驗證前不授予 candidate authority。
+- operator 文件（`docs/unified-work-lifecycle.md`）與 CLI help 同步更新。

--- a/docs/superpowers/workstreams/design-task-type-taxonomy/todo.md
+++ b/docs/superpowers/workstreams/design-task-type-taxonomy/todo.md
@@ -1,0 +1,14 @@
+---
+status: accepted
+work_item: design-task-type-taxonomy
+---
+
+# design-task-type-taxonomy Todo
+
+## Tasks
+
+- [ ] 將 issue #139、active OpenSpec change `2026-08-04-design-task-type-taxonomy` 與本 Todo 綁定為同一 confirmed Work Item。
+- [ ] coordinator 派工 copilot（gpt-5.4）以 TDD 完成 #139：先寫 RED 測試，再實作到 GREEN。
+- [ ] ForeignReview（claude（sonnet））review 通過；operator 驗收核可。
+- [ ] `changelog.d/design-task-type-taxonomy.md` fragment 已新增且已 commit（R-09 硬性 gate）；`CHANGELOG.md [Unreleased]` 有對應 entry。
+- [ ] 帶 PR 上下文執行 `policy_check`（`--pr-title`／`--pr-body`／`--pr-labels`／`--pr-base-ref`／`--pr-head-ref`）確認 fail: 0；全套 pytest 通過。

--- a/docs/superpowers/workstreams/feat-work-gc/todo.md
+++ b/docs/superpowers/workstreams/feat-work-gc/todo.md
@@ -1,0 +1,14 @@
+---
+status: accepted
+work_item: feat-work-gc
+---
+
+# feat-work-gc Todo
+
+## Tasks
+
+- [ ] 將 issue #178、active OpenSpec change `2026-08-04-feat-work-gc` 與本 Todo 綁定為同一 confirmed Work Item。
+- [ ] coordinator 派工 copilot（gpt-5.4）以 TDD 完成 #178：先寫 RED 測試（squash-merge 判 merged、unmerged 絕不進 apply 清單、dirty worktree 保留、closed-unmerged PR 分支保留），再實作到 GREEN。
+- [ ] ForeignReview（claude／sonnet）review 通過；operator 驗收核可。
+- [ ] `changelog.d/feat-work-gc.md` fragment 已新增且已 commit（R-09 硬性 gate）；`CHANGELOG.md [Unreleased]` 有對應 entry。
+- [ ] 帶 PR 上下文執行 `policy_check`（`--pr-title`／`--pr-body`／`--pr-labels`／`--pr-base-ref`／`--pr-head-ref`）確認 fail: 0；全套 pytest 通過。

--- a/docs/superpowers/workstreams/fix-persona-catalog-portability/todo.md
+++ b/docs/superpowers/workstreams/fix-persona-catalog-portability/todo.md
@@ -1,0 +1,14 @@
+---
+status: accepted
+work_item: fix-persona-catalog-portability
+---
+
+# fix-persona-catalog-portability Todo
+
+## Tasks
+
+- [ ] 將 issue #295（primary）與 #291（duplicate）、active OpenSpec change `2026-08-04-fix-persona-catalog-portability` 與本 Todo 綁定為同一 confirmed Work Item（multi-issue）；delivery PR body closing keywords 同時涵蓋 `Closes #295` 與 `Closes #291`。
+- [ ] coordinator 派工 copilot（gpt-5.4）以 TDD 完成：先寫 RED 測試（`docs/superpowers/plans/fix-persona-catalog-portability.md` Section 1），再實作到 GREEN。
+- [ ] ForeignReview（claude/sonnet）review 通過；operator 驗收核可。
+- [ ] `changelog.d/fix-persona-catalog-portability.md` fragment 已新增且已 commit（R-09 硬性 gate）；`CHANGELOG.md [Unreleased]` 有對應 entry。
+- [ ] 帶 PR 上下文執行 `policy_check`（`--pr-title`／`--pr-body`／`--pr-labels`／`--pr-base-ref`／`--pr-head-ref`）確認 fail: 0；全套 pytest 通過。

--- a/docs/superpowers/workstreams/fix-repair-commit-recovery/todo.md
+++ b/docs/superpowers/workstreams/fix-repair-commit-recovery/todo.md
@@ -1,0 +1,14 @@
+---
+status: accepted
+work_item: fix-repair-commit-recovery
+---
+
+# fix-repair-commit-recovery Todo
+
+## Tasks
+
+- [ ] 將 issue #260、active OpenSpec change `2026-08-04-fix-repair-commit-recovery` 與本 Todo 綁定為同一 confirmed Work Item。
+- [ ] coordinator 派工 copilot（gpt-5.4）以 TDD 完成 #260：先依 `docs/superpowers/plans/fix-repair-commit-recovery.md` 寫 RED 測試，再實作到 GREEN。
+- [ ] ForeignReview（claude/sonnet）review 通過；operator 驗收核可。
+- [ ] `changelog.d/fix-repair-commit-recovery.md` fragment 已新增且已 commit（R-09 硬性 gate）；`CHANGELOG.md [Unreleased]` 有對應 entry。
+- [ ] 帶 PR 上下文執行 `policy_check`（`--pr-title`／`--pr-body`／`--pr-labels`／`--pr-base-ref`／`--pr-head-ref`）確認 fail: 0；全套 pytest 通過。

--- a/openspec/changes/2026-08-04-design-task-type-taxonomy/proposal.md
+++ b/openspec/changes/2026-08-04-design-task-type-taxonomy/proposal.md
@@ -1,0 +1,25 @@
+---
+status: accepted
+work_item: design-task-type-taxonomy
+---
+
+## Goals
+
+定案 `task_type` taxonomy 契約（主軸 conventional-commit `type` 六值、次軸 `scope` 受控詞典、fail-closed vs bypass 處置語意），並落地輕量契約骨架（契約檔＋loader／分類 helper＋測試），作為 #202／#137／#138／#204 的單一真相源。
+
+## Why
+
+repo 內存在至少四種互不相干的 task 分類軸，且無 issue 明確擁有 taxonomy 定義權，使 #139／#202／#137／#138 循環等待。使用者已於 2026-07-27 裁決主軸採 conventional-commit `type` 且 #139 為 taxonomy 所有者；deck combo 現況只有 `feature`／`mcu-feature`，實測最大宗的 `fix` 無 combo，缺口需以契約明示而非讓下游猜測。
+
+## What Changes
+
+- 新增契約檔 `paulsha_cortex/deck/data/task-types.yaml`：六值主軸（含描述與 combo 映射，`feat` → `feature-oneshot`、其餘為 null 明示缺口）＋ scope 受控詞典七值。
+- 新增 `paulsha_cortex/deck/task_types.py`：凍結常數與契約檔雙鎖、fail-closed loader（比照 `DeckSchemaError` 慣例）、標題分類 helper（`matched`／`unknown_type`／`ambiguous`／`absent`／`unparseable` 五類與 proceed／fail_closed／bypass 處置映射）。
+- 新增 `tests/test_deck_task_types.py` 覆蓋載入、值域漂移、combo 引用、五類分類與處置映射。
+- spec／design 文件定案下游消費契約邊界（#202 selector／#137 ledger／#138 judge／#204 skill ledger）與統一 log reader／status view 的介面契約草案（只定契約，不實作）。
+- 不實作 selector／ledger／judge／reader／view，不新增 combo，不動 CLI。
+
+## Capabilities
+
+### Modified Capabilities
+- `persona-workflow-orchestration`：詳見 `docs/superpowers/specs/design-task-type-taxonomy-spec.md` 的 Requirements 與 `docs/superpowers/specs/design-task-type-taxonomy-design.md` 的 Decisions。

--- a/openspec/changes/2026-08-04-design-task-type-taxonomy/specs/persona-workflow-orchestration/spec.md
+++ b/openspec/changes/2026-08-04-design-task-type-taxonomy/specs/persona-workflow-orchestration/spec.md
@@ -1,0 +1,54 @@
+---
+status: accepted
+work_item: design-task-type-taxonomy
+---
+
+## ADDED Requirements
+
+### Requirement: task_type taxonomy 必須有單一凍結真相源
+
+`task_type` 主軸值域 MUST 為 conventional-commit `type` 六值（`feat`／`fix`／`docs`／`test`／`ci`／`refactor`），凍結於契約檔 `paulsha_cortex/deck/data/task-types.yaml` 與程式凍結常數（雙鎖）。loader MUST fail-closed：未知鍵、空描述、非法 scopes、值域與凍結常數不一致（多值、少值、改名）皆 MUST 拒載並回報具體原因，MUST NOT 靜默取交集或聯集。下游消費者 MUST 經 loader 取得值域，MUST NOT 自建第二份值域；agent-usage-stats 的 repo 級 5 類 MUST NOT 納入 taxonomy。
+
+#### Scenario: 契約檔載入成功
+
+- **WHEN** 以預設路徑載入 `task-types.yaml`
+- **THEN** 值域恰為凍結六值，`feat` 映射至 `feature-oneshot`，其餘五值 combo 為 null
+- **THEN** scope 受控詞典為 `coordinator`／`porcelain`／`workflow`／`cli`／`deck`／`monitor`／`onboarding`
+
+#### Scenario: 值域漂移拒載
+
+- **WHEN** 契約檔多出 `perf` 或缺少 `refactor`
+- **THEN** loader 拒載並回報漂移的值，不靜默調和
+
+### Requirement: 標題分類必須區分 fail-closed 與 bypass
+
+分類 helper MUST 將 issue 標題判為 `matched`／`unknown_type`／`ambiguous`／`absent`／`unparseable` 五類之一，且處置映射 MUST 完備：`matched` → proceed；`unknown_type`（prefix 形式但 type 不在值域）與 `ambiguous`（含 type 合法但 scope 在受控詞典外）→ fail-closed，下游 MUST 拒絕自動決策；`absent`（無 prefix）與 `unparseable`（prefix 不合文法）→ bypass，落回明示路徑且 MUST 可觀測。判準 MUST 為「標題是否明確主張了 taxonomy 語彙」。
+
+#### Scenario: 未知 type fail-closed
+
+- **WHEN** 標題為 `perf(cli): 加速掃描`
+- **THEN** 判為 `unknown_type`，處置 fail-closed，理由列出合法值域
+
+#### Scenario: 受控詞典外 scope fail-closed
+
+- **WHEN** 標題為 `fix(claimx): 修正`，`claimx` 不在受控詞典
+- **THEN** 判為 `ambiguous`，處置 fail-closed
+
+#### Scenario: 無 prefix 標題 bypass
+
+- **WHEN** 標題為 `修 monitor 掃描漏洞`
+- **THEN** 判為 `absent`，處置 bypass，由下游落回明示路徑
+
+### Requirement: combo 對應必須為輸出投影且缺口明示
+
+每個 type MUST 有 `combo` 欄位（既有 combo id 或 null）；非 null 值 MUST 指向既有 combo，loader 帶入 combo 對照表時 MUST 對未知引用拒載。combo 為 null 的 type MUST 由下游以可觀測 bypass 處理，MUST NOT 猜測替代 combo。deck combo 檔既有 `task_type` 欄位（`feature`／`mcu-feature`）為 legacy workflow-shape 標籤，MUST NOT 當作 taxonomy 值域。
+
+#### Scenario: combo 缺口明示為 null
+
+- **WHEN** 查詢 `fix` 的 combo 映射
+- **THEN** 得到 null，語意為「缺口明示、下游走可觀測 bypass」，而非任何預設 combo
+
+#### Scenario: 非法 combo 引用拒載
+
+- **WHEN** 契約檔將某 type 的 combo 指向不存在的 combo id，且載入時帶入 combo 對照表
+- **THEN** loader 拒載並回報該引用

--- a/openspec/changes/2026-08-04-design-task-type-taxonomy/tasks.md
+++ b/openspec/changes/2026-08-04-design-task-type-taxonomy/tasks.md
@@ -1,0 +1,15 @@
+---
+status: accepted
+work_item: design-task-type-taxonomy
+---
+
+# Tasks
+
+- [ ] 1.1 RED：依 `docs/superpowers/plans/design-task-type-taxonomy.md` 的 TDD RED 章節新增 `tests/test_deck_task_types.py`，確認失敗。
+- [ ] 1.2 實作至 GREEN，範圍限於 `docs/superpowers/specs/design-task-type-taxonomy-spec.md` 的 Requirements（契約檔 `paulsha_cortex/deck/data/task-types.yaml` 與 `paulsha_cortex/deck/task_types.py`）。
+- [ ] 1.3 `changelog.d/design-task-type-taxonomy.md` fragment 與 `CHANGELOG.md [Unreleased]` entry（#139）。
+- [ ] 1.4 `python3 -m pytest tests/ -q` 全綠；帶 PR 上下文的 `policy_check` 0 fail；`git diff --check` 乾淨。
+
+## 驗收
+
+`task-types.yaml` 載入成功且值域凍結六值、任何結構或值域錯誤 fail-closed 拒載；分類 helper 五類判定正確且處置映射完備（`unknown_type`／`ambiguous` fail-closed、`absent`／`unparseable` bypass）；combo 缺口以 null 明示；文件明載本票為 taxonomy 單一真相源與下游引用邊界；既有 deck 測試不受影響。

--- a/openspec/changes/2026-08-04-feat-work-gc/proposal.md
+++ b/openspec/changes/2026-08-04-feat-work-gc/proposal.md
@@ -1,0 +1,26 @@
+---
+status: accepted
+work_item: feat-work-gc
+---
+
+## Goals
+
+提煉 v0.1.0 收尾的爛尾清理邏輯為 `cortex work gc` 命令：operator 以單一 proposal-first 命令安全回收殘留 build worktree 與已 merge 的 local branch，絕不誤刪任何內容尚未落地的產物。
+
+## Why
+
+cortex 每批次派工產生的 build 產物沒有生命週期回收，v0.1.0 收尾全靠手動考古式清理，且標準 git 訊號會騙人：squash merge 後 ref-ancestry 失真讓已落地分支顯示 unmerged、`git branch -d` 對 upstream 判定會誤拒已合併分支、closed-unmerged PR 對應分支的內容去向必須人工考證。安全清理必須做內容層驗證並對疑義 fail-safe。
+
+## What Changes
+
+- 新增 `paulsha_cortex/coordinator/gc.py` 與 CLI 子命令 `cortex work gc`（umbrella 攔截路由，不經 manager daemon、不動 control queue 白名單）。
+- proposal-first：預設 dry-run 只輸出候選清單與逐項理由（`reclaim`／`keep`＋reason code），`--apply` 才執行且僅處理 `reclaim` 項目。
+- merged 判定採內容層驗證鏈：`git merge-base --is-ancestor` → `git cherry` patch 等價比對 default branch；squash-merge 分支正確判 merged；禁止以 `git branch -d`／`--merged` 的 ref-ancestry 為準。
+- fail-safe：unmerged content、dirty worktree、git 命令失敗、protected refs 一律 `keep`＋理由；closed-unmerged PR 分支保留（PR 查詢為 best-effort 註記，不可用時安全退化）。
+- 範圍收斂：僅回收殘留 worktree 與已 merge local branch 並報告（文字＋`cortex-work-gc/v1` JSON）；registry（`jobs.json`）唯讀不 mutate，remote branch 刪除列非目標。
+- CLI help 同步：`_WORK_HELP` 加入 `gc`（R-16）。
+
+## Capabilities
+
+### Modified Capabilities
+- `governed-delivery-closure`：新增交付後產物回收（proposal-first、內容層 merged 驗證、fail-safe 保留、registry 唯讀）要求；詳見 `docs/superpowers/specs/feat-work-gc-spec.md` 的 Requirements 與 `docs/superpowers/specs/feat-work-gc-design.md` 的 Decisions。

--- a/openspec/changes/2026-08-04-feat-work-gc/specs/governed-delivery-closure/spec.md
+++ b/openspec/changes/2026-08-04-feat-work-gc/specs/governed-delivery-closure/spec.md
@@ -1,0 +1,58 @@
+---
+status: accepted
+work_item: feat-work-gc
+---
+
+## ADDED Requirements
+
+### Requirement: 交付後產物回收必須 proposal-first
+
+`cortex work gc` MUST 預設以 dry-run 模式執行：只輸出候選清單與逐項判定（`reclaim`／`keep`＋reason code），MUST NOT 改變任何 git 狀態。只有帶 `--apply` 時 MAY 執行回收，且 MUST 只處理判定為 `reclaim` 的項目；執行前 MUST 對每個項目重新驗證，狀態已變時 MUST 轉為保留並附理由。
+
+#### Scenario: 預設 dry-run 零變更
+
+- **WHEN** operator 執行 `cortex work gc` 未帶 `--apply`
+- **THEN** 所有 worktree、local branch 與 `jobs.json` 內容皆不變
+- **THEN** 報告逐項列出候選 artifact、判定與 reason code
+
+### Requirement: merged 判定必須內容層驗證
+
+分支 merged 判定 MUST 依序採用：`git merge-base --is-ancestor <tip> <default>` 成立即 merged；否則 `git cherry <default> <branch>` 輸出不含 `+` 行即 merged；兩者皆不成立 MUST 視為 unmerged。判定 MUST NOT 以 `git branch -d`、`git branch --merged` 或 upstream ref-ancestry 為準。squash-merge 後內容已落地 default branch 的分支 MUST 被正確判為 merged。default branch MUST 依 `origin/HEAD` 解析、無法解析時退回 `main`，且 MUST NOT 主動 fetch。
+
+#### Scenario: squash-merge 分支正確判 merged
+
+- **WHEN** 分支內容以單一 squash commit 落地 default branch，原分支 commit 不在其歷史
+- **THEN** 該分支判 `reclaim`（reason `merged-content`），不被誤判 unmerged
+
+#### Scenario: 內容比對不吻合視為 unmerged
+
+- **WHEN** `git cherry` 輸出含 `+` 行（存在未落地 patch）
+- **THEN** 該分支判 `keep`（reason `unmerged-content`）
+
+### Requirement: 回收必須 fail-safe 保留疑義
+
+unmerged content MUST NOT 出現在 `--apply` 執行清單。dirty worktree（未 commit 變更或 untracked 檔案）、判定過程 git 命令失敗、default branch、目前 checked-out branch 與掛在保留 worktree 上的 branch MUST 一律判 `keep` 並附具體 reason code。對應 PR 為 closed-unmerged 的分支 MUST 保留；PR 狀態查詢屬 best-effort 註記，查詢不可用時 MUST 安全退化為內容層判定結果。`--apply` 單項失敗 MUST 記為保留並續行，MUST NOT 中斷整批。
+
+#### Scenario: unmerged 分支絕不刪除
+
+- **WHEN** 分支含未落地 commit 且 operator 帶 `--apply` 執行
+- **THEN** 該分支不在執行清單，執行後仍存在
+
+#### Scenario: dirty worktree 保留
+
+- **WHEN** 候選 worktree 有未 commit 變更
+- **THEN** 判 `keep`（reason `dirty-worktree`），`--apply` 不移除
+
+#### Scenario: closed-unmerged PR 分支保留
+
+- **WHEN** 分支對應的 PR 已關閉且未合併
+- **THEN** 判 `keep`，PR 查詢可用時 reason 為 `pr-closed-unmerged`，不可用時退化為 `unmerged-content`
+
+### Requirement: GC 對 registry 唯讀且不動 remote
+
+GC MUST NOT 寫入 `jobs.json` 或任何 manager 狀態檔（manager 是單一 writer，GC 僅讀）。GC MUST NOT 刪除 remote branch，MUST NOT 操作 PR，MUST NOT 清理 delivery journal 或 correlation。
+
+#### Scenario: apply 後 registry 不變
+
+- **WHEN** operator 帶 `--apply` 完成回收
+- **THEN** `jobs.json` 位元組層不變，remote refs 不變

--- a/openspec/changes/2026-08-04-feat-work-gc/tasks.md
+++ b/openspec/changes/2026-08-04-feat-work-gc/tasks.md
@@ -1,0 +1,15 @@
+---
+status: accepted
+work_item: feat-work-gc
+---
+
+# Tasks
+
+- [ ] 1.1 RED：依 `docs/superpowers/plans/feat-work-gc.md` 的 TDD RED 章節新增 `tests/test_work_gc.py`，確認失敗。
+- [ ] 1.2 實作至 GREEN，範圍限於 `docs/superpowers/specs/feat-work-gc-spec.md` 的 Requirements（含 `_WORK_HELP` 同步與 `tests/test_cli_help_alignment.py` 斷言）。
+- [ ] 1.3 `changelog.d/feat-work-gc.md` fragment 與 `CHANGELOG.md [Unreleased]` entry（#178）。
+- [ ] 1.4 `python3 -m pytest tests/ -q` 全綠；帶 PR 上下文的 `policy_check` 0 fail；`git diff --check` 乾淨。
+
+## 驗收
+
+squash-merge 分支正確判 merged 並可回收；unmerged 分支絕不進 `--apply` 清單；dirty worktree 與 closed-unmerged PR 分支保留並附理由；預設 dry-run 對 worktree／分支／`jobs.json` 零變更；報告逐項含 action 與 reason code。

--- a/openspec/changes/2026-08-04-fix-persona-catalog-portability/proposal.md
+++ b/openspec/changes/2026-08-04-fix-persona-catalog-portability/proposal.md
@@ -1,0 +1,27 @@
+---
+status: accepted
+work_item: fix-persona-catalog-portability
+---
+
+## Goals
+
+修正 verification gate 從被治理 repo 的 git tree 讀 cortex 套件自身 persona catalog 的可攜性缺陷（#295 primary、#291 duplicate）：canonical 來源改為 cortex 套件內建 catalog，被治理 repo 可選擇性提供 repo-local override，讓非 cortex repo 的 slice 能通過 persona gate。
+
+## Why
+
+`run_result_verification` 無條件 `git show {dispatch_base}:paulsha_cortex/persona/personas.yaml` 讀**目標 repo**，該檔只存在於 paulsha-cortex 自身，因此任何被治理的非 cortex repo 都確定性停在 `needs_human(persona-catalog-unreadable)`；同時 `dispatch: auto` 又強制要求恰好一個 persona-scope check，構成「必須宣告、宣告必失敗、拿掉則 spec 不合法」的封閉矛盾。IntelliDbgKit（#295）與 serialwrap（#291）皆實測 build 成功但產出被卡在 verification 門口，下游 `depends_on` 永不滿足。
+
+## What Changes
+
+- persona catalog 的 canonical 來源改為 cortex 套件內建（`paulsha_cortex.persona.loader.DEFAULT_PERSONAS_PATH`），復用既有 `_load_catalog_from_text` 驗證。
+- 以 `git cat-file -e` 探測 `dispatch_base` tree 是否存在 repo-local override：存在即優先並 pin 在 `dispatch_base` commit 讀取；不存在即回退 packaged catalog。
+- override 宣告存在但不可讀維持 `persona-catalog-unreadable`、不合法維持 `persona-catalog-invalid`，不靜默回退 packaged；packaged 自身壞損亦 fail-closed。
+- cortex repo 自身因 git tree 內有 catalog 而自然落在 override 分支，行為不退化，不做 repo 身分特判。
+- evidence 的 `persona_catalog` 增加來源標記（`repo-local`／`packaged`）；讀取失敗的錯誤帶實際嘗試過的來源路徑。
+- `dispatch: auto` 的 persona-scope 必要性檢查維持不變（packaged fallback 已解除封閉矛盾）。
+
+## Capabilities
+
+### Modified Capabilities
+
+- `trusted-dispatch-completion`：deterministic ResultVerification 的 persona catalog 來源解析。詳見 `docs/superpowers/specs/fix-persona-catalog-portability-spec.md` 的 Requirements 與 `docs/superpowers/specs/fix-persona-catalog-portability-design.md` 的 Decisions。

--- a/openspec/changes/2026-08-04-fix-persona-catalog-portability/specs/trusted-dispatch-completion/spec.md
+++ b/openspec/changes/2026-08-04-fix-persona-catalog-portability/specs/trusted-dispatch-completion/spec.md
@@ -1,0 +1,32 @@
+---
+status: accepted
+work_item: fix-persona-catalog-portability
+---
+
+## ADDED Requirements
+
+### Requirement: persona catalog 來源解析必須可攜且 fail-closed
+
+ResultVerification 的 persona gate MUST 以 cortex 套件內建 catalog（package-relative `DEFAULT_PERSONAS_PATH`）為 canonical 來源。被治理 repo 的 `dispatch_base` tree 內存在 `paulsha_cortex/persona/personas.yaml` 時，MUST 以該 repo-local override 優先，並 pin 在 `dispatch_base` commit 讀取；不存在時 MUST 回退 packaged catalog 完成 scope 判定，MUST NOT 因此進入 `needs_human`。
+
+override 宣告存在但不可讀 MUST 維持 `persona-catalog-unreadable`；可讀但解析或 schema 不合法 MUST 維持 `persona-catalog-invalid`；兩者皆 MUST NOT 靜默回退 packaged catalog。packaged catalog 自身不可讀或不合法亦 MUST fail-closed。
+
+evidence 的 `persona_catalog` MUST 記錄採用來源標記（`repo-local`／`packaged`）、來源路徑與 content hash；catalog 讀取失敗的錯誤 payload MUST 帶實際嘗試過的來源路徑。
+
+#### Scenario: 非 cortex repo 無 repo-local catalog
+
+- **WHEN** builder Job 於 `dispatch_base` tree 不含 `paulsha_cortex/persona/personas.yaml` 的被治理 repo exit 0 進入 verification
+- **THEN** persona gate 以 packaged catalog 完成 scope 判定，不產生 `persona-catalog-unreadable`
+- **THEN** evidence 的 `persona_catalog` 記錄 `source: packaged` 與 content hash
+
+#### Scenario: repo-local override 優先且 pin 在 dispatch_base
+
+- **WHEN** `dispatch_base` tree 內存在該路徑（cortex repo 自身即此情境）
+- **THEN** persona gate 以該 commit 的 catalog 內容做 scope 判定並記錄 content hash
+- **THEN** 行為與既有 cortex repo verification 一致，不退化
+
+#### Scenario: override 宣告存在但壞損
+
+- **WHEN** 該路徑存在於 `dispatch_base` tree 但讀取失敗，或可讀但 schema 不合法
+- **THEN** slice 進入 `needs_human`，reason 分別為 `persona-catalog-unreadable`／`persona-catalog-invalid`
+- **THEN** 錯誤 payload 帶實際嘗試過的來源路徑，不靜默回退 packaged catalog

--- a/openspec/changes/2026-08-04-fix-persona-catalog-portability/tasks.md
+++ b/openspec/changes/2026-08-04-fix-persona-catalog-portability/tasks.md
@@ -1,0 +1,15 @@
+---
+status: accepted
+work_item: fix-persona-catalog-portability
+---
+
+# Tasks
+
+- [ ] 1.1 RED：依 `docs/superpowers/plans/fix-persona-catalog-portability.md` Section 1 於 `tests/test_coordinator_candidate_verification.py` 新增 `PersonaCatalogPortabilityTests`，確認五個新測試失敗。
+- [ ] 1.2 實作至 GREEN，範圍限於 `docs/superpowers/specs/fix-persona-catalog-portability-spec.md` 的 Requirements（`paulsha_cortex/coordinator/verification.py` catalog 讀取段與 evidence 欄位、既有測試 response map 同步）。
+- [ ] 1.3 `changelog.d/fix-persona-catalog-portability.md` fragment 與 `CHANGELOG.md [Unreleased]` entry（#295、#291）。
+- [ ] 1.4 `python3 -m pytest tests/ -q` 全綠；帶 PR 上下文的 `policy_check` 0 fail；`git diff --check` 乾淨；delivery PR body 同時帶 `Closes #295` 與 `Closes #291`。
+
+## 驗收
+
+非 cortex repo（無 repo-local catalog）slice verification 通過 persona gate；repo-local override 優先於 packaged 且 pin 在 `dispatch_base`；override 壞損 fail-closed 且 reason 維持 `persona-catalog-unreadable`／`persona-catalog-invalid`；cortex repo 自身現行為不變、既有測試全綠；evidence 記錄來源標記、錯誤帶實際嘗試過的來源路徑。

--- a/openspec/changes/2026-08-04-fix-repair-commit-recovery/proposal.md
+++ b/openspec/changes/2026-08-04-fix-repair-commit-recovery/proposal.md
@@ -1,0 +1,27 @@
+---
+status: accepted
+work_item: fix-repair-commit-recovery
+---
+
+## Goals
+
+repair commit 已在 worktree 但缺 terminal evidence 時，提供具 CAS 的窄化 `recover-repair-commit` 動作將其確定性地 bind 為新 candidate，並修正 resume／retry-build 的 job 選擇不再重選 stale failed job，讓 auto-run 修復迴路可自行閉環（#260）。
+
+## Why
+
+repair job 失敗終止但已在 builder worktree 產生合法 descendant commit 時，`retry-build` 的窄化入口只接受 exited/0 的 unbound terminal builder job，可驗證的修復 commit 無法被 bind、驗證或繼續 exact-head review；同時 `resume` 對 exited 非 0 的 stale terminal job 會先空轉一輪重新回報失敗，第二次才 dispatch replacement。operator 只能介入 runtime state，auto-run 無法閉環。近期落地的 `recover-planning`（#256）與 `recover-pre-candidate`／dirty candidate 重評（#277）情境各不相同，均未涵蓋此缺口。
+
+## What Changes
+
+- 新增獨立窄化 `recover-repair-commit` work action（模板：`_recover_planning_action`／`_recover_pre_candidate_action`）：`expected_run_id` 與 `expected_candidate` 雙 CAS；判準全部取自系統事實（worktree 取自 failed job row、HEAD 精確比對、乾淨度、descendant lineage、authority），caller 參數只做交叉比對；不啟動任何 model session。
+- adoption 產生 `cortex-work-repair-adoption/v1` durable evidence record 與一筆沿用既有欄位集合的 adoption job row（identity 複製自 failed job、subject_head 為 adopted SHA、exited/0、workflow_evidence 指向 record），failed job row 原樣保留；registry 以原子方法完成 candidate bind、final build card 標 passed 與 verify phase 前進。
+- 冪等：重送相同 request 回 `already-recovered`，不產生第二次 adoption、第二個 job row 或 model session。
+- `retry-build` 的 exact expected_candidate CAS 與既有 exited/0 窄化入口原封不動；最新 job 已有 bound evidence 時 `recover-repair-commit` 拒絕。
+- `resume_workflow_run`／`_dispatch_workflow_card` 的 failed terminal 判定補上「exited 且 exit code 非 0」，第一次 operator resume 即 dispatch replacement；失敗回報附掛唯讀 terminal 診斷（不授予 authority）。
+- control queue 白名單、`cortex work`／`cortex recover work` CLI surface 與 `docs/unified-work-lifecycle.md` 同步。
+
+## Capabilities
+
+### Modified Capabilities
+
+- `persona-workflow-orchestration`：詳見 `docs/superpowers/specs/fix-repair-commit-recovery-spec.md` 的 Requirements 與 `docs/superpowers/specs/fix-repair-commit-recovery-design.md` 的 Decisions。

--- a/openspec/changes/2026-08-04-fix-repair-commit-recovery/specs/persona-workflow-orchestration/spec.md
+++ b/openspec/changes/2026-08-04-fix-repair-commit-recovery/specs/persona-workflow-orchestration/spec.md
@@ -1,0 +1,72 @@
+---
+status: accepted
+work_item: fix-repair-commit-recovery
+---
+
+## ADDED Requirements
+
+### Requirement: repair commit 缺 terminal evidence 時必須有窄化 adoption 出口
+
+repair job 失敗終止（`status == "failed"`、exited 且 exit code 非 0，或 exited/0 但 terminal payload 缺漏／malformed）而其 worktree 留有合法 descendant commit 時，Manager MUST 提供獨立的 `recover-repair-commit` action 將該 commit 確定性地 bind 為新 candidate。此 action MUST 只在 run 為 ongoing、帶 `needs_human`、停在 build phase、前置 build card 全 passed、final builder card pending、最新同 card job 無 bound `workflow_evidence` 且無 active job 時可用，且 MUST NOT 啟動任何 model session。
+
+#### Scenario: failed repair job 留下 descendant commit
+
+- **WHEN** repair job 以非 0 exit code 終止、無 terminal evidence，worktree HEAD 為原 candidate 的 descendant，operator 以 exact run id 與 exact SHA 執行 `recover-repair-commit`
+- **THEN** run 的 `candidate_head` 更新為該 SHA、final build card 標 passed、run 進入 verify phase
+- **THEN** 產生 `cortex-work-repair-adoption/v1` durable evidence record，且未啟動任何 model session
+
+#### Scenario: evidence 已 bind 時拒絕
+
+- **WHEN** 最新同 card builder job 已有 bound `workflow_evidence`
+- **THEN** `recover-repair-commit` fail closed 並回報具體原因，run 狀態不變
+
+### Requirement: adoption 判準必須取自系統可驗證的事實
+
+`recover-repair-commit` 的驗證輸入 MUST 取自系統既有紀錄與 git 事實：worktree 路徑 MUST 取自 failed builder job row；operator 提供的 `expected_candidate` MUST 精確等於該 worktree HEAD；worktree MUST 乾淨；`expected_candidate` MUST 為原 candidate 的合法 descendant 且不得與其相同；issue MUST 經 WorkAuthority 授權。caller 參數 MUST 只做交叉比對、MUST NOT 被當作 evidence 採信；白名單外參數 MUST 拒絕。任一判準不符 MUST fail closed。
+
+#### Scenario: 非 descendant 拒絕
+
+- **WHEN** operator 提供的 SHA 不是原 candidate 的合法 descendant
+- **THEN** fail closed 並回報具體原因，candidate authority 不變
+
+#### Scenario: dirty worktree 拒絕
+
+- **WHEN** failed job 的 worktree 有未 commit 的變更
+- **THEN** fail closed 並回報具體原因，不 bind 任何 candidate
+
+### Requirement: adoption 必須具 CAS 冪等且不放寬既有關卡
+
+`recover-repair-commit` MUST 要求 `expected_run_id` 與 `expected_candidate` 雙重 CAS；重送相同 request MUST 回報 `already-recovered`，MUST NOT 產生第二次 adoption、第二個 job row 或任何 model session。`retry-build` 的 exact `expected_candidate` CAS 與既有 exited/0 unbound terminal 窄化入口 MUST 保持原封不動。
+
+#### Scenario: 重送相同 request
+
+- **WHEN** adoption 成功後 operator 重送相同的 `recover-repair-commit` request
+- **THEN** 回報 `already-recovered`，job 總數與 evidence record 數不變
+
+#### Scenario: retry-build CAS 不放寬
+
+- **WHEN** `retry-build` 未提供 `expected_candidate` 或 SHA 與 `candidate_head` 不符
+- **THEN** 以與現況一致的錯誤 fail closed，admission 未因新 action 放寬
+
+### Requirement: adoption 後生命週期必須可續行且可稽核
+
+adoption 成功後，run MUST 進入 verify phase，既有 verify → foreign review → exact-head final 管線 MUST 以 adopted candidate 重新把關，MUST NOT 重跑已完成的 planning。adoption MUST 登錄一筆沿用既有欄位集合的 adoption job row（identity 複製自 failed job、`subject_head` 為 adopted SHA、exited/0、`workflow_evidence` 指向 adoption record），使既有 builder job binding 驗證不需放寬；failed job 原始 row MUST 原樣保留；provenance（failed job id、observed HEAD、失敗原因）MUST 記錄於 adoption evidence record。
+
+#### Scenario: adoption 後繼續 exact-head review
+
+- **WHEN** adoption 完成後 workflow 繼續推進
+- **THEN** verify 與 foreign review 對 adopted candidate 完整重新把關，reviewer 可 bind 到 adoption job row 的 worktree 與 exact HEAD
+
+### Requirement: resume 不得重選 stale failed job
+
+`resume`／`retry-build` 的 job 選擇 MUST 選擇最新且符合 run／action 的 eligible job。operator resume 遇到已 terminalized 的失敗 job（`status == "failed"`，或 exited 且 exit code 非 0）時，第一次 resume MUST 即 dispatch replacement job，MUST NOT 先重選 stale failed job；replacement 在飛行中時再次 resume MUST 回報 in-flight 且 MUST NOT 產生第二個 replacement job。失敗回報 MUST 附帶唯讀 terminal 診斷（observed HEAD、job id、失敗原因），且 MUST NOT 因此授予 candidate authority。
+
+#### Scenario: 第一次 resume 即 dispatch replacement
+
+- **WHEN** 最新同 card job 為 exited 且 exit code 非 0 的 stale terminal，operator 執行第一次 `resume`
+- **THEN** Manager dispatch replacement job，不重新回報 stale job 的失敗
+
+#### Scenario: 重送 resume 不產生第二個 replacement
+
+- **WHEN** replacement job 仍在飛行中，operator 再次執行 `resume`
+- **THEN** 回報 in-flight，job 總數不變

--- a/openspec/changes/2026-08-04-fix-repair-commit-recovery/tasks.md
+++ b/openspec/changes/2026-08-04-fix-repair-commit-recovery/tasks.md
@@ -1,0 +1,15 @@
+---
+status: accepted
+work_item: fix-repair-commit-recovery
+---
+
+# Tasks
+
+- [ ] 1.1 RED：依 `docs/superpowers/plans/fix-repair-commit-recovery.md` 的 TDD RED 章節新增 `tests/test_repair_commit_recovery.py`，確認全部失敗。
+- [ ] 1.2 實作至 GREEN，範圍限於 `docs/superpowers/specs/fix-repair-commit-recovery-spec.md` 的 Requirements（R1–R6）；不放寬 retry-build CAS 與既有窄化入口。
+- [ ] 1.3 `changelog.d/fix-repair-commit-recovery.md` fragment 與 `CHANGELOG.md [Unreleased]` entry（#260）；`docs/unified-work-lifecycle.md` 與 CLI help 同步。
+- [ ] 1.4 `python3 -m pytest tests/ -q` 全綠；帶 PR 上下文的 `policy_check` 0 fail；`git diff --check` 乾淨。
+
+## 驗收
+
+failed repair job 留下的 descendant commit 可經 `recover-repair-commit` 以雙 CAS 確定性 bind 為新 candidate，並繼續 verify → foreign review → exact-head final；非 descendant、dirty worktree、evidence 已 bind、authority 不符全部 fail closed；第一次 operator resume 即 dispatch replacement 且重送不產生第二個 replacement job；retry-build CAS 行為與現況完全一致。


### PR DESCRIPTION
## 摘要

為批次 W1 的四個 work item（fix-persona-catalog-portability〔multi-issue〕、fix-repair-commit-recovery、feat-work-gc、design-task-type-taxonomy）新增完整 cortex planning artifacts：spec／design／plan／workstream todo 與 openspec change（2026-08-04-*），並登錄 .cortex/work-items.yaml 作為 confirmed authority。

## 驗證

- [x] 四組皆通過 assess_planning_completeness（status: accepted、必要章節、零 blocking marker）
- [x] 四組 openspec validate 通過
- [x] changelog.d/batch-w1-planning.md fragment 已 commit（R-09）
- [x] CHANGELOG.md [Unreleased] 對應 entry
- [x] 本地 policy_check 帶 PR 上下文 fail: 0
- [x] 本 PR 只提供 planning authority，不含實作

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JZKZjogV1MPL8DyiHwRnob