### PR TITLE
docs(planning): W1 canary authority 補強與 abandon 審計附註

### DIFF
--- a/.cortex/work-items.yaml
+++ b/.cortex/work-items.yaml
@@ -400,6 +400,10 @@ work_items:
         ref: docs/superpowers/workstreams/fix-persona-catalog-portability/todo.md
       - kind: path
         ref: docs/superpowers/specs/fix-persona-catalog-portability-spec.md
+      - kind: path
+        ref: docs/superpowers/specs/fix-persona-catalog-portability-design.md
+      - kind: path
+        ref: docs/superpowers/plans/fix-persona-catalog-portability.md
   fix-repair-commit-recovery:
     title: repair commit 缺 terminal evidence 的窄化恢復與 stale job 選擇修正 (#260)
     links:

--- a/changelog.d/w1-canary-reclaim.md
+++ b/changelog.d/w1-canary-reclaim.md
@@ -1,0 +1,4 @@
+### Changed
+- **W1 canary work item authority 補強（#295／#291）**：`fix-persona-catalog-portability`
+  於 `.cortex/work-items.yaml` 補綁 design／plan path 連結，並於 workstream todo 記錄
+  首次 claim 環境性 stall 的 abandon 審計附註；使 authority digest 前進以重新 claim。

--- a/docs/superpowers/workstreams/fix-persona-catalog-portability/todo.md
+++ b/docs/superpowers/workstreams/fix-persona-catalog-portability/todo.md
@@ -12,3 +12,9 @@ work_item: fix-persona-catalog-portability
 - [ ] ForeignReview（claude/sonnet）review 通過；operator 驗收核可。
 - [ ] `changelog.d/fix-persona-catalog-portability.md` fragment 已新增且已 commit（R-09 硬性 gate）；`CHANGELOG.md [Unreleased]` 有對應 entry。
 - [ ] 帶 PR 上下文執行 `policy_check`（`--pr-title`／`--pr-body`／`--pr-labels`／`--pr-base-ref`／`--pr-head-ref`）確認 fail: 0；全套 pytest 通過。
+
+## 附註（dogfood 審計）
+
+- 2026-08-04：首次 claim（run `workflow-e351e829c925c40f400d`）因 secondary planner
+  身分缺 planning capability 的環境性 stall 而 abandon 釋放；身分矩陣已補
+  agy planning＋live_probe。本次 authority 補綁 design／plan 路徑連結後重新 claim。


### PR DESCRIPTION
## 摘要

fix-persona-catalog-portability 於 .cortex/work-items.yaml 補綁 design／plan path 連結，workstream todo 記錄首次 claim 環境性 stall（secondary planner 身分缺 planning capability）之 abandon 審計附註。authority digest 前進後以新 claim key 重新 claim。

- [x] changelog.d/w1-canary-reclaim.md fragment 已 commit（R-09）
- [x] docs-only、無程式碼變更

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JZKZjogV1MPL8DyiHwRnob