### PR TITLE
fix(claim): planning_released 釋放後同 claim_key 可重新 claim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ## [Unreleased]
 ### Fixed
+- **Issue #299：planning_released 釋放後同 claim_key 可重新 claim**：`work_bridge.start_canonical_workflow` 的 existing-run reuse guard 原對 `superseded` run 無條件短路，未 honor #256 D4 釋放語意，abandon→reclaim 永久死路。新增 `_claimable_existing_runs` 過濾已釋放 run，未釋放 superseded／done／ongoing 行為不變。
 - **Issue #277：pre-candidate 失敗恢復與 stale candidate 重評**：新增 `recover-pre-candidate` work/slice action 以處置 candidate 為 null 時的 builder 失敗並回收殘留 worktree；修復 completion 對 `candidate-worktree-dirty` 的快照競態，改為在 tick 時以當前 branch HEAD 動態重評。
 - **Issue #286：fanout plan pinning 以 spec 檔自身所在 repo 解析**：修復 `coordinator/autonomy.py` 中 `_infer_repo_root(spec_path)` 於 `PSC_REPO_ROOT` 環境變數存在時盲目回傳 manager host repo 的問題。調整為優先以 `spec_path` 所在目錄向上推導專案 Git repository root；當 spec 位於 manager host 外部的其他 repository（如 `serialwrap` 或 worktree）時，能正確將 relative plan glob 解析至該專案目錄，解決跨 repo ad-hoc 派工觸發 `DispatchReadyError: plan file unreadable` 的問題，並使 `ready` 與 `fanout` 階段對專案 repo_root 的判定維持一致。
 - **Issue #273：修復 Monitor refresh 靜默失敗、同 Repo 多 Checkout 衝突與 Source Collision 歸零缺陷**：

--- a/changelog.d/planning-released-reclaim.md
+++ b/changelog.d/planning-released-reclaim.md
@@ -1,0 +1,7 @@
+### Fixed
+- **Issue #299：planning_released 釋放後同 claim_key 可重新 claim**：
+  `work_bridge.start_canonical_workflow` 的 existing-run reuse guard 原對
+  `superseded` run 無條件短路，未 honor #256 D4 的 `planning_released` 釋放語意，
+  導致 abandon→reclaim 永久死路。新增 `_claimable_existing_runs` 過濾已釋放
+  run；registry 層以 attempt 鹽化 run_id 建新 run 的既有支援因此可達。未釋放的
+  superseded／done／ongoing run 維持原短路行為。

--- a/paulsha_cortex/coordinator/work_bridge.py
+++ b/paulsha_cortex/coordinator/work_bridge.py
@@ -290,6 +290,23 @@ def _other_owner_ongoing_runs(registry, authority: WorkAuthority) -> list:
     ]
 
 
+def _claimable_existing_runs(registry, claim_key: str) -> list:
+    """#299：同 claim_key 既有 run 中，過濾掉 abandon 已釋放（``superseded`` 且帶
+    ``planning_released`` facet）的歷史紀錄。
+
+    #256 D4 的釋放語意允許同識別重新 claim；released run 若仍參與 reuse guard
+    短路，abandon→reclaim 即永久死路（registry 層的
+    ``_manager_create_workflow_run`` 本已支援以 attempt 鹽化 run_id 建新 run）。
+    其餘狀態（ongoing／done／未釋放的 superseded）維持原短路行為。
+    """
+    return [
+        run
+        for run in registry.list_workflow_runs()
+        if run.claim_key == claim_key
+        and not (run.status == "superseded" and "planning_released" in run.facets)
+    ]
+
+
 def start_canonical_workflow(
     *,
     registry,
@@ -304,7 +321,7 @@ def start_canonical_workflow(
 ):
     """Create/resume the real WorkflowRun for a WorkAuthority claim."""
 
-    existing = [run for run in registry.list_workflow_runs() if run.claim_key == claim_key]
+    existing = _claimable_existing_runs(registry, claim_key)
     existing_run = None
     if existing:
         if len(existing) != 1 or existing[0].repo != authority.repo or existing[0].work_id != authority.work_id:

--- a/tests/test_planning_released_reclaim.py
+++ b/tests/test_planning_released_reclaim.py
@@ -1,0 +1,94 @@
+"""#299：abandon 已釋放（superseded＋planning_released）的 run 不得短路同
+claim_key 的重新 claim（#256 D4 釋放語意）。
+
+registry 層（`_manager_create_workflow_run` 以 attempt 鹽化 run_id）本已支援
+abandon→reclaim 循環；缺口在 `work_bridge.start_canonical_workflow` 的
+existing-run reuse guard 對 superseded run 無條件短路。本測試鎖定過濾 helper
+與 registry reclaim 循環兩層。
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from paulsha_cortex.coordinator.registry import JobRegistry
+from paulsha_cortex.coordinator.work_bridge import _claimable_existing_runs
+from paulsha_cortex.coordinator.workflow import WorkflowStep
+
+CLAIM_KEY = "claim:v1:" + "a" * 64
+
+
+def _step() -> WorkflowStep:
+    return WorkflowStep(
+        phase="define",
+        persona="planner",
+        card="brainstorming",
+        executor=None,
+        model=None,
+        domain=None,
+        inputs=(),
+        outputs=(),
+        gate_result="pending",
+    )
+
+
+def _create_run(registry: JobRegistry, **overrides: object):
+    fields: dict[str, object] = {
+        "work_id": "released-reclaim-work",
+        "repo": "hamanpaul/paulsha-cortex",
+        "claim_key": CLAIM_KEY,
+        "source_revision": "rev-a",
+        "workspace_root": "/tmp/workspace",
+        "combo": "feature-oneshot",
+        "current_phase": "define",
+        "steps": (_step(),),
+        "issue_refs": ("hamanpaul/paulsha-cortex#299",),
+        "attempts": {"claim": 1},
+        "facets": ("needs_human",),
+    }
+    fields.update(overrides)
+    return registry._manager_create_workflow_run(**fields)
+
+
+def test_released_run_not_claimable_match(tmp_path: Path) -> None:
+    registry = JobRegistry(state_path=tmp_path / "jobs.json")
+    run = _create_run(registry)
+    registry._manager_abandon_workflow_run(
+        run.run_id, evidence_ref="evidence/work-abandon/test-released.json"
+    )
+    released = registry.get_workflow_run(run.run_id)
+    assert released.status == "superseded"
+    assert "planning_released" in released.facets
+
+    assert _claimable_existing_runs(registry, CLAIM_KEY) == []
+
+
+def test_ongoing_run_still_matches(tmp_path: Path) -> None:
+    registry = JobRegistry(state_path=tmp_path / "jobs.json")
+    run = _create_run(registry)
+    matches = _claimable_existing_runs(registry, CLAIM_KEY)
+    assert [match.run_id for match in matches] == [run.run_id]
+
+
+def test_unreleased_superseded_run_still_matches(tmp_path: Path) -> None:
+    """digest 前進造成的 superseded（無 planning_released）維持原短路行為。"""
+    registry = JobRegistry(state_path=tmp_path / "jobs.json")
+    run = _create_run(registry)
+    registry._manager_update_workflow_run(run.run_id, status="superseded")
+    matches = _claimable_existing_runs(registry, CLAIM_KEY)
+    assert [match.run_id for match in matches] == [run.run_id]
+    assert "planning_released" not in matches[0].facets
+
+
+def test_registry_reclaim_creates_fresh_run_after_release(tmp_path: Path) -> None:
+    registry = JobRegistry(state_path=tmp_path / "jobs.json")
+    first = _create_run(registry)
+    registry._manager_abandon_workflow_run(
+        first.run_id, evidence_ref="evidence/work-abandon/test-cycle.json"
+    )
+    second = _create_run(registry)
+    assert second.run_id != first.run_id
+    assert second.status == "ongoing"
+    old = registry.get_workflow_run(first.run_id)
+    assert old.status == "superseded"
+    assert "planning_released" in old.facets


### PR DESCRIPTION
## 摘要

work_bridge.start_canonical_workflow 的 existing-run reuse guard 原對 superseded run 無條件短路，未 honor #256 D4 的 planning_released 釋放語意，導致 abandon→reclaim 永久死路（W1 批次 dogfood 實測，run workflow-e351e829c925c40f400d）。

新增 _claimable_existing_runs 過濾已釋放（superseded＋planning_released）run；registry 層以 attempt 鹽化 run_id 建新 run 的既有支援因此可達。未釋放的 superseded／done／ongoing run 維持原短路行為。

## 驗證

- [x] TDD：tests/test_planning_released_reclaim.py 4 測試（released 過濾、ongoing 保留、未釋放 superseded 保留、registry reclaim 循環）先 RED 後 GREEN
- [x] 全套 pytest 1746 passed
- [x] changelog.d/planning-released-reclaim.md fragment 已 commit（R-09）＋ CHANGELOG entry
- [x] 本地 policy_check 帶 PR 上下文 fail: 0

Closes #299

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JZKZjogV1MPL8DyiHwRnob