### PR TITLE
docs(planning): 批次 W1 openspec design.md 補件（define planning-complete 路徑）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ## [Unreleased]
 ### Fixed
+- **批次 W1 openspec design.md 補件（#295／#291、#260、#178、#139）**：design kind 的 authority 來源是 `openspec/changes/<change>/design.md`，缺檔時 planning completeness 永遠 incomplete、claim 後 define 繞進 brainstorm 並靜默 needs_human（7/30 批次全卡 define 的根因）。為四個 work item 補上 design.md，使 define 走 planning-complete deterministic 路徑。
 - **Issue #299：planning_released 釋放後同 claim_key 可重新 claim**：`work_bridge.start_canonical_workflow` 的 existing-run reuse guard 原對 `superseded` run 無條件短路，未 honor #256 D4 釋放語意，abandon→reclaim 永久死路。新增 `_claimable_existing_runs` 過濾已釋放 run，未釋放 superseded／done／ongoing 行為不變。
 - **Issue #277：pre-candidate 失敗恢復與 stale candidate 重評**：新增 `recover-pre-candidate` work/slice action 以處置 candidate 為 null 時的 builder 失敗並回收殘留 worktree；修復 completion 對 `candidate-worktree-dirty` 的快照競態，改為在 tick 時以當前 branch HEAD 動態重評。
 - **Issue #286：fanout plan pinning 以 spec 檔自身所在 repo 解析**：修復 `coordinator/autonomy.py` 中 `_infer_repo_root(spec_path)` 於 `PSC_REPO_ROOT` 環境變數存在時盲目回傳 manager host repo 的問題。調整為優先以 `spec_path` 所在目錄向上推導專案 Git repository root；當 spec 位於 manager host 外部的其他 repository（如 `serialwrap` 或 worktree）時，能正確將 relative plan glob 解析至該專案目錄，解決跨 repo ad-hoc 派工觸發 `DispatchReadyError: plan file unreadable` 的問題，並使 `ready` 與 `fanout` 階段對專案 repo_root 的判定維持一致。

--- a/changelog.d/w1-openspec-design.md
+++ b/changelog.d/w1-openspec-design.md
@@ -1,0 +1,7 @@
+### Fixed
+- **批次 W1 openspec design.md 補件（#295／#291、#260、#178、#139）**：`_artifact_rows`
+  的 design kind 來源是 `openspec/changes/<change>/design.md`；缺檔時
+  `assess_planning_completeness` 永遠 incomplete，claim 後 define 必然繞進 heterogeneous
+  brainstorm 並靜默 needs_human（7/30 批次全卡 define 的根因）。為四個 work item 補上
+  design.md（決策摘要＋指回 superpowers design 全文），使 define 走 planning-complete
+  deterministic 路徑。

--- a/openspec/changes/2026-08-04-design-task-type-taxonomy/design.md
+++ b/openspec/changes/2026-08-04-design-task-type-taxonomy/design.md
@@ -1,0 +1,21 @@
+---
+status: accepted
+work_item: design-task-type-taxonomy
+---
+
+# design-task-type-taxonomy Design
+
+## Decisions
+
+- `task_type` 主軸定案為 conventional-commit type 六值（`feat`／`fix`／`docs`／`test`／
+  `ci`／`refactor`），次軸 `scope`；本 work item 是 taxonomy 的單一真相源（#8 叢集
+  收斂裁決，2026-07-27）。
+- `ambiguous`（多個互斥訊號）fail-closed 帶診斷；`absent`／`unparseable` 走 bypass 用
+  現行預設並記可觀測標記——「擋」只用於不可自癒的失敗。
+- taxonomy 契約落地為 `deck/data/task-types.yaml`＋loader 驗證函式（值域、ambiguous／
+  absent 判定 helper）＋測試；selector（#202）、outcome ledger（#137）、cost judge
+  （#138）、skill ledger（#204）只消費此契約，不在本票實作。
+- 統一 log reader 與 status view 只定介面契約（來源路徑、欄位、責任邊界），實作留
+  下游票；combo 值域缺口（實測最大宗 `fix` 無對應 combo）明載為 #202 的硬前提。
+
+詳細 D1–Dn 與風險緩解見 `docs/superpowers/specs/design-task-type-taxonomy-design.md`。

--- a/openspec/changes/2026-08-04-feat-work-gc/design.md
+++ b/openspec/changes/2026-08-04-feat-work-gc/design.md
@@ -1,0 +1,23 @@
+---
+status: accepted
+work_item: feat-work-gc
+---
+
+# feat-work-gc Design
+
+## Decisions
+
+- 新模組 `coordinator/gc.py`＋umbrella CLI 子命令 `cortex work gc`，不經 manager daemon、
+  不動 control queue 白名單；registry（jobs.json）唯讀（manager 單一 writer 紅線）。
+- proposal-first：預設 dry-run 只輸出候選清單與逐項 reason code；`--apply` 才執行且僅
+  處理 reclaim 項目，執行前逐項重驗（防 TOCTOU）。
+- merged 判定用兩段內容層驗證鏈：`git merge-base --is-ancestor` → `git cherry` 無 `+` 行
+  即內容等價；禁止只靠 ref-ancestry（squash-merge 陷阱）；default branch 依 origin/HEAD
+  解析退回 main、不主動 fetch（基準過時只多保留不誤刪）。
+- fail-safe reason code 分類（merged-ancestor／merged-content／unmerged-content／
+  dirty-worktree／protected／pr-closed-unmerged／verification-error／apply-error）；任何
+  git 失敗或疑義一律 keep 並標註原因，絕不刪 unmerged content。
+- closed-unmerged PR 偵測為 best-effort 註記，不參與回收判定；remote branch 刪除與
+  registry 壓縮列為非目標。
+
+詳細 D1–D6 與風險緩解見 `docs/superpowers/specs/feat-work-gc-design.md`。

--- a/openspec/changes/2026-08-04-fix-persona-catalog-portability/design.md
+++ b/openspec/changes/2026-08-04-fix-persona-catalog-portability/design.md
@@ -1,0 +1,25 @@
+---
+status: accepted
+work_item: fix-persona-catalog-portability
+---
+
+# fix-persona-catalog-portability Design
+
+## Decisions
+
+- persona catalog 的 canonical 來源改為 cortex 套件內建 catalog（`persona/loader` 的
+  package-relative `DEFAULT_PERSONAS_PATH`）；persona 定義是 cortex 的產品資產，隨安裝
+  套件發佈，不是被派工 repo 的資產。
+- repo-local override 以 `git cat-file -e <dispatch_base>:<catalog path>` 在 `dispatch_base`
+  commit tree 判定存在性：存在即必須讀取成功，否則維持 fail-closed
+  （`persona-catalog-unreadable`／`persona-catalog-invalid` 分流）；不存在即回退 packaged
+  catalog，兩者為確定性分支，不解析 stderr 字串。
+- cortex repo 自身（git tree 內有 catalog）落在 override 分支，行為與現行一致，不做
+  repo 身分特判。
+- 兩來源共用既有 `_load_catalog_from_text` schema 驗證，不另開驗證路徑。
+- evidence 的 `persona_catalog` 增記來源標記（`repo-local`／`packaged`）與 content hash；
+  讀取失敗錯誤帶實際嘗試過的來源路徑。
+- `dispatch: auto` 對恰好一個 persona-scope check 的要求維持原樣（packaged fallback 已
+  解除「必須宣告、宣告必失敗」的封閉矛盾）。
+
+詳細 D1–D5 與風險緩解見 `docs/superpowers/specs/fix-persona-catalog-portability-design.md`。

--- a/openspec/changes/2026-08-04-fix-repair-commit-recovery/design.md
+++ b/openspec/changes/2026-08-04-fix-repair-commit-recovery/design.md
@@ -1,0 +1,26 @@
+---
+status: accepted
+work_item: fix-repair-commit-recovery
+---
+
+# fix-repair-commit-recovery Design
+
+## Decisions
+
+- 新增獨立窄化 `recover-repair-commit` work action（模板：`_recover_planning_action`），
+  不放寬 `retry-build` 的 exact `expected_candidate` CAS 與既有 exited/0 unbound terminal
+  窄化入口。
+- 判準全部取自系統可驗證事實：worktree 路徑取自 failed builder job row；operator 的
+  `expected_run_id`＋`expected_candidate` 雙 CAS 只做交叉比對（HEAD 精確相等、worktree
+  乾淨、descendant lineage、authority 授權），任一不符 fail closed。
+- adoption 以 manager 登錄的 adoption job row 承載觀測事實（identity 複製自 failed job、
+  `subject_head`=adopted SHA、exited/0、`workflow_evidence` 指向
+  `cortex-work-repair-adoption/v1` record），不新增任何 run／job row 欄位；failed job row
+  原樣保留。
+- registry 新增原子 `_manager_adopt_repair_candidate`（單一 persist 完成 candidate bind、
+  final build step 標 passed、verify phase 前進），adoption 不授予品質判定，verify →
+  foreign review → exact-head final 對 adopted candidate 完整重新把關。
+- `resume`／`_dispatch_workflow_card` 的 stale failed job 判定補「exited 且 exit code 非 0」
+  分支；exited/0 的既有三條路徑不動；失敗回報附掛唯讀 terminal 診斷。
+
+詳細 D1–D5 與風險緩解見 `docs/superpowers/specs/fix-repair-commit-recovery-design.md`。


### PR DESCRIPTION
## 摘要

design kind 的 planning authority 來源是 openspec/changes/<change>/design.md（work_bridge._artifact_rows）；缺檔時 completeness 永遠 incomplete，claim 後 define 必進 heterogeneous brainstorm 並靜默 needs_human——這是 7/30 批次全卡 define 的根因（有 design.md 的 7/25-26 批次 runs 均推進至 verify 可證）。

為 W1 四個 work item 補 openspec design.md（決策摘要，指回 superpowers design 全文）。四組經 production 等效分類（openspec design.md=design kind）驗證 assess_planning_completeness complete=True。

- [x] changelog.d/w1-openspec-design.md fragment 已 commit（R-09）＋ CHANGELOG entry
- [x] docs-only、無程式碼變更

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JZKZjogV1MPL8DyiHwRnob