### PR TITLE
fix(registry): 狀態檔載入 claim_key 唯一性只約束 ongoing runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ## [Unreleased]
 ### Fixed
+- **Issue #302：registry 載入層 claim_key 唯一性改為只約束 ongoing runs**：與 abandon→reclaim（#256 D4／#299）語意對齊；重 claim persist 後 manager 重啟不再無法載回狀態檔。run_id 唯一性維持全域。
 - **批次 W1 openspec design.md 補件（#295／#291、#260、#178、#139）**：design kind 的 authority 來源是 `openspec/changes/<change>/design.md`，缺檔時 planning completeness 永遠 incomplete、claim 後 define 繞進 brainstorm 並靜默 needs_human（7/30 批次全卡 define 的根因）。為四個 work item 補上 design.md，使 define 走 planning-complete deterministic 路徑。
 - **Issue #299：planning_released 釋放後同 claim_key 可重新 claim**：`work_bridge.start_canonical_workflow` 的 existing-run reuse guard 原對 `superseded` run 無條件短路，未 honor #256 D4 釋放語意，abandon→reclaim 永久死路。新增 `_claimable_existing_runs` 過濾已釋放 run，未釋放 superseded／done／ongoing 行為不變。
 - **Issue #277：pre-candidate 失敗恢復與 stale candidate 重評**：新增 `recover-pre-candidate` work/slice action 以處置 candidate 為 null 時的 builder 失敗並回收殘留 worktree；修復 completion 對 `candidate-worktree-dirty` 的快照競態，改為在 tick 時以當前 branch HEAD 動態重評。

--- a/changelog.d/registry-released-claimkey-load.md
+++ b/changelog.d/registry-released-claimkey-load.md
@@ -1,0 +1,7 @@
+### Fixed
+- **Issue #302：registry 載入層 claim_key 唯一性改為只約束 ongoing runs**：
+  `_load_state` 原對 claim_key 做全域唯一性 fail-closed，與 abandon→reclaim
+  （#256 D4／#299）的「released row＋新 ongoing run 合法共用 claim_key」語意矛盾；
+  重 claim persist 後 manager 重啟即無法載回狀態檔，且 builder worktree 內讀取
+  production 狀態檔的測試全數 fail-closed。改為 ongoing runs 內唯一；run_id
+  唯一性維持全域。

--- a/paulsha_cortex/coordinator/registry.py
+++ b/paulsha_cortex/coordinator/registry.py
@@ -304,9 +304,19 @@ class JobRegistry:
             raise ValueError(
                 f"coordinator 狀態檔 workflow 格式錯誤（fail-closed）: {self._state_path}: {exc}"
             ) from exc
-        claim_keys = [run.claim_key for run in validated_workflows]
+        # claim_key 唯一性只約束 ongoing runs：abandon→reclaim（#256 D4／#299）會讓
+        # released（superseded＋planning_released）歷史 row 與新 ongoing run 合法共用同
+        # 一 claim_key（_manager_create_workflow_run 以 attempt 鹽化 run_id）。全域唯一
+        # 性會讓重 claim persist 後的狀態檔無法重新載入（manager 重啟即 brick）。
+        # run_id 唯一性維持全域 fail-closed。
+        ongoing_claim_keys = [
+            run.claim_key for run in validated_workflows if run.status == "ongoing"
+        ]
         run_ids = [run.run_id for run in validated_workflows]
-        if len(set(claim_keys)) != len(claim_keys) or len(set(run_ids)) != len(run_ids):
+        if (
+            len(set(ongoing_claim_keys)) != len(ongoing_claim_keys)
+            or len(set(run_ids)) != len(run_ids)
+        ):
             raise ValueError(f"coordinator 狀態檔 workflow 重複識別（fail-closed）: {self._state_path}")
         self._validate_legacy_records(legacy_records)
         self._jobs = jobs

--- a/tests/test_registry_released_claimkey_load.py
+++ b/tests/test_registry_released_claimkey_load.py
@@ -1,0 +1,108 @@
+"""#302（暫名）：registry 載入層的 claim_key 全域唯一性與 abandon→reclaim 語意矛盾。
+
+`_manager_create_workflow_run` 允許 released（superseded＋planning_released）run 之後
+以同 claim_key、attempt 鹽化 run_id 建新 run（#256 D4／#299）；但 `_load_state` 對
+claim_key 做全域唯一性 fail-closed，重 claim 一旦 persist，manager 重啟即無法載回
+自己的狀態檔。唯一性應只約束 ongoing runs；run_id 唯一性維持全域。
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from paulsha_cortex.coordinator.registry import JobRegistry
+from paulsha_cortex.coordinator.workflow import WorkflowStep
+
+CLAIM_KEY = "claim:v1:" + "c" * 64
+
+
+def _step() -> WorkflowStep:
+    return WorkflowStep(
+        phase="define",
+        persona="planner",
+        card="brainstorming",
+        executor=None,
+        model=None,
+        domain=None,
+        inputs=(),
+        outputs=(),
+        gate_result="pending",
+    )
+
+
+def _create_run(registry: JobRegistry, **overrides: object):
+    fields: dict[str, object] = {
+        "work_id": "released-claimkey-load-work",
+        "repo": "hamanpaul/paulsha-cortex",
+        "claim_key": CLAIM_KEY,
+        "source_revision": "rev-a",
+        "workspace_root": "/tmp/workspace",
+        "combo": "feature-oneshot",
+        "current_phase": "define",
+        "steps": (_step(),),
+        "issue_refs": ("hamanpaul/paulsha-cortex#302",),
+        "attempts": {"claim": 1},
+        "facets": ("needs_human",),
+    }
+    fields.update(overrides)
+    return registry._manager_create_workflow_run(**fields)
+
+
+def test_reload_after_release_reclaim_cycle(tmp_path: Path) -> None:
+    """abandon→reclaim persist 後，同一狀態檔必須能重新載入。"""
+    state_path = tmp_path / "jobs.json"
+    registry = JobRegistry(state_path=state_path)
+    first = _create_run(registry)
+    registry._manager_abandon_workflow_run(
+        first.run_id, evidence_ref="evidence/work-abandon/reload-cycle.json"
+    )
+    second = _create_run(registry)
+    assert second.run_id != first.run_id
+
+    reloaded = JobRegistry(state_path=state_path)
+    runs = {run.run_id: run for run in reloaded.list_workflow_runs()}
+    assert set(runs) == {first.run_id, second.run_id}
+    assert runs[first.run_id].status == "superseded"
+    assert runs[second.run_id].status == "ongoing"
+
+
+def test_duplicate_ongoing_claim_key_still_fail_closed(tmp_path: Path) -> None:
+    state_path = tmp_path / "jobs.json"
+    registry = JobRegistry(state_path=state_path)
+    first = _create_run(registry)
+    registry._manager_abandon_workflow_run(
+        first.run_id, evidence_ref="evidence/work-abandon/dup-ongoing.json"
+    )
+    _create_run(registry)
+
+    import json
+
+    payload = json.loads(state_path.read_text(encoding="utf-8"))
+    for row in payload["workflows"]:
+        if row["run_id"] == first.run_id:
+            row["status"] = "ongoing"
+            row["facets"] = []
+    state_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="重複識別"):
+        JobRegistry(state_path=state_path)
+
+
+def test_duplicate_run_id_still_fail_closed(tmp_path: Path) -> None:
+    state_path = tmp_path / "jobs.json"
+    registry = JobRegistry(state_path=state_path)
+    run = _create_run(registry)
+
+    import json
+
+    payload = json.loads(state_path.read_text(encoding="utf-8"))
+    duplicate = dict(payload["workflows"][0])
+    duplicate["claim_key"] = "claim:v1:" + "d" * 64
+    payload["workflows"].append(duplicate)
+    state_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    assert duplicate["run_id"] == run.run_id
+    with pytest.raises(ValueError, match="重複識別"):
+        JobRegistry(state_path=state_path)


### PR DESCRIPTION
## 摘要

abandon→reclaim（#256 D4／#299）允許 released（superseded＋planning_released）row 與新 ongoing run 合法共用 claim_key；但 _load_state 的全域唯一性 fail-closed 使重 claim persist 後 manager 重啟即無法載回狀態檔（Restart=on-failure 死循環），builder worktree 內讀 production 狀態檔的三個測試（#303）也全 fail-closed、pytest gate 全紅。

修法：claim_key 唯一性只約束 ongoing runs（與 _manager_create_workflow_run 語意鏡像）；run_id 唯一性維持全域。

## 驗證

- [x] TDD：tests/test_registry_released_claimkey_load.py 3 測試（reclaim 循環後可重載、ongoing 重複仍 fail-closed、run_id 重複仍 fail-closed）先 RED 後 GREEN
- [x] 全套 pytest 1749 passed
- [x] changelog.d fragment 已 commit（R-09）＋ CHANGELOG entry

Closes #302

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JZKZjogV1MPL8DyiHwRnob