### PR TITLE
docs(planning): W1 canary 重識別 fix-persona-catalog-portability-v2

### DIFF
--- a/.cortex/work-items.yaml
+++ b/.cortex/work-items.yaml
@@ -387,8 +387,8 @@ work_items:
         ref: docs/superpowers/workstreams/persona-enforce-required-check/todo.md
       - kind: path
         ref: docs/superpowers/specs/persona-enforce-required-check-spec.md
-  fix-persona-catalog-portability:
-    title: persona catalog 可攜性——非 cortex repo verification 不再卡 persona-catalog-unreadable (#295/#291)
+  fix-persona-catalog-portability-v2:
+    title: persona catalog 可攜性 v2 重識別——#218 世代熔斷後續作 (#295/#291)
     links:
       - kind: github_issue
         ref: hamanpaul/paulsha-cortex#295

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 本專案遵循 hamanpaul project policy v1.0.15。
 
 ## [Unreleased]
+### Changed
+- **W1 canary 重識別為 fix-persona-catalog-portability-v2（#295／#291）**：三代 run 因 #299／#302／#303 基礎設施缺陷 superseded 觸發 #218 世代熔斷，依「-v2 識別」慣例重識別續作（檔案路徑不動）。
 ### Fixed
 - **Issue #302：registry 載入層 claim_key 唯一性改為只約束 ongoing runs**：與 abandon→reclaim（#256 D4／#299）語意對齊；重 claim persist 後 manager 重啟不再無法載回狀態檔。run_id 唯一性維持全域。
 - **批次 W1 openspec design.md 補件（#295／#291、#260、#178、#139）**：design kind 的 authority 來源是 `openspec/changes/<change>/design.md`，缺檔時 planning completeness 永遠 incomplete、claim 後 define 繞進 brainstorm 並靜默 needs_human（7/30 批次全卡 define 的根因）。為四個 work item 補上 design.md，使 define 走 planning-complete deterministic 路徑。

--- a/changelog.d/w1-canary-v2.md
+++ b/changelog.d/w1-canary-v2.md
@@ -1,0 +1,6 @@
+### Changed
+- **W1 canary 重識別為 fix-persona-catalog-portability-v2（#295／#291）**：三代 run
+  因基礎設施缺陷（#299 reclaim 短路、#302 載入唯一性、#303 gate 測試隔離洩漏）先後
+  superseded，觸發 #218 語意 re-claim 世代熔斷（SEMANTIC_RECLAIM_LIMIT=3）。依既有
+  「-v2 識別」慣例改 frontmatter `work_item` 與 `.cortex/work-items.yaml`（檔案路徑
+  不動），取得全新 claim identity 續作。

--- a/docs/superpowers/plans/fix-persona-catalog-portability.md
+++ b/docs/superpowers/plans/fix-persona-catalog-portability.md
@@ -1,6 +1,6 @@
 ---
 status: accepted
-work_item: fix-persona-catalog-portability
+work_item: fix-persona-catalog-portability-v2
 ---
 
 # fix-persona-catalog-portability Plan

--- a/docs/superpowers/specs/fix-persona-catalog-portability-design.md
+++ b/docs/superpowers/specs/fix-persona-catalog-portability-design.md
@@ -1,6 +1,6 @@
 ---
 status: accepted
-work_item: fix-persona-catalog-portability
+work_item: fix-persona-catalog-portability-v2
 ---
 
 # fix-persona-catalog-portability Design

--- a/docs/superpowers/specs/fix-persona-catalog-portability-spec.md
+++ b/docs/superpowers/specs/fix-persona-catalog-portability-spec.md
@@ -1,6 +1,6 @@
 ---
 status: accepted
-work_item: fix-persona-catalog-portability
+work_item: fix-persona-catalog-portability-v2
 ---
 
 # fix-persona-catalog-portability Specification

--- a/docs/superpowers/workstreams/fix-persona-catalog-portability/todo.md
+++ b/docs/superpowers/workstreams/fix-persona-catalog-portability/todo.md
@@ -1,6 +1,6 @@
 ---
 status: accepted
-work_item: fix-persona-catalog-portability
+work_item: fix-persona-catalog-portability-v2
 ---
 
 # fix-persona-catalog-portability Todo

--- a/openspec/changes/2026-08-04-fix-persona-catalog-portability/design.md
+++ b/openspec/changes/2026-08-04-fix-persona-catalog-portability/design.md
@@ -1,6 +1,6 @@
 ---
 status: accepted
-work_item: fix-persona-catalog-portability
+work_item: fix-persona-catalog-portability-v2
 ---
 
 # fix-persona-catalog-portability Design

--- a/openspec/changes/2026-08-04-fix-persona-catalog-portability/proposal.md
+++ b/openspec/changes/2026-08-04-fix-persona-catalog-portability/proposal.md
@@ -1,6 +1,6 @@
 ---
 status: accepted
-work_item: fix-persona-catalog-portability
+work_item: fix-persona-catalog-portability-v2
 ---
 
 ## Goals

--- a/openspec/changes/2026-08-04-fix-persona-catalog-portability/specs/trusted-dispatch-completion/spec.md
+++ b/openspec/changes/2026-08-04-fix-persona-catalog-portability/specs/trusted-dispatch-completion/spec.md
@@ -1,6 +1,6 @@
 ---
 status: accepted
-work_item: fix-persona-catalog-portability
+work_item: fix-persona-catalog-portability-v2
 ---
 
 ## ADDED Requirements

--- a/openspec/changes/2026-08-04-fix-persona-catalog-portability/tasks.md
+++ b/openspec/changes/2026-08-04-fix-persona-catalog-portability/tasks.md
@@ -1,6 +1,6 @@
 ---
 status: accepted
-work_item: fix-persona-catalog-portability
+work_item: fix-persona-catalog-portability-v2
 ---
 
 # Tasks


### PR DESCRIPTION
## 摘要

三代 run 因基礎設施缺陷（reclaim 短路、載入唯一性、gate 測試隔離洩漏）先後 superseded，觸發語意 re-claim 世代熔斷（SEMANTIC_RECLAIM_LIMIT=3）。依既有「-v2 識別」慣例改 frontmatter work_item 與 .cortex/work-items.yaml（檔案路徑不動），取得全新 claim identity 續作。

- [x] changelog.d/w1-canary-v2.md fragment 已 commit（R-09）＋ CHANGELOG entry
- [x] docs-only、無程式碼變更

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JZKZjogV1MPL8DyiHwRnob