### PR TITLE
fix(terminal): 零 gate ledger 時模型自述 gate_evidence 視為 vacuous

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 本專案遵循 hamanpaul project policy v1.0.15。
 
 ## [Unreleased]
+### Fixed
+- **Issue #308：零 gate 設定下模型自述 gate_evidence 不再觸發 fail-closed**：ledger `gates: []` 時 `authorize_terminal` 跳過 unknown-gate 對照（#261 文件：零 gate＝無 R2 保護）；ledger 非空維持 fail-closed。
 ### Changed
 - **W1 canary v2 檔名對齊（#295／#291）**：build 卡 declared inputs 以 `*<work_id>*` glob 檔名，v2 僅改 frontmatter 導致 declared input missing；檔名與 workstream 目錄補 `-v2` 並同步引用。
 - **W1 canary 重識別為 fix-persona-catalog-portability-v2（#295／#291）**：三代 run 因 #299／#302／#303 基礎設施缺陷 superseded 觸發 #218 世代熔斷，依「-v2 識別」慣例重識別續作（檔案路徑不動）。

--- a/changelog.d/gate-evidence-empty-ledger.md
+++ b/changelog.d/gate-evidence-empty-ledger.md
@@ -1,0 +1,7 @@
+### Fixed
+- **Issue #308：零 gate 設定下模型自述 gate_evidence 不再觸發 fail-closed**：
+  operator 顯式未宣告任何 `PSC_GATE_CMD_*`（ledger `gates: []`）時，
+  `authorize_terminal` 跳過 gate_evidence 的 unknown-gate 對照（自述視為
+  vacuous，#261 文件本就聲明零 gate＝無 R2 保護）；ledger 非空時維持原
+  fail-closed。修正 gpt-5.4 builder 隨機把 shell 指令填進 gate_evidence
+  導致同卡重派時好時壞的問題。

--- a/paulsha_cortex/coordinator/terminal_contract.py
+++ b/paulsha_cortex/coordinator/terminal_contract.py
@@ -568,6 +568,20 @@ def authorize_terminal(
     # 模型自述的 gate 宣告必須與 ledger 一致：宣稱跑了 ledger 沒有的 gate，或宣稱
     # 的結果與 ledger 不符，都是 R2 定義的矛盾（前者代表自述不可信，後者已被上面
     # 的迴圈攔下，這裡補上「宣稱 failed 卻整體 passed」這類不一致）。
+    #
+    # #308：operator 顯式零 gate（ledger 存在但 gates 為空）時跳過此對照——此設定
+    # 依 #261 文件本就沒有 R2 保護，空 ledger 下沒有可對照的獨立證據層；模型自述
+    # 不構成授權，對照它只會讓授權結果隨模型是否填寫 gate_evidence 而隨機化
+    # （gpt-5.4 會把 shell 指令如 `pwd` 填進 gate_evidence）。ledger 非空時維持
+    # fail-closed。
+    if not outcomes:
+        return TerminalAuthorization(
+            status="passed",
+            authorized=True,
+            verified_gates=(),
+            ledger_digest=digest,
+            legacy=envelope.legacy,
+        )
     for item in envelope.gate_evidence:
         name = item["name"]
         if name not in outcomes:

--- a/tests/test_gate_evidence_empty_ledger.py
+++ b/tests/test_gate_evidence_empty_ledger.py
@@ -1,0 +1,75 @@
+"""#308：operator 顯式零 gate（ledger gates 為空）時，模型自述的 gate_evidence
+不得觸發 gate-evidence-unknown-gate fail-closed。
+
+#261 文件明示「未宣告 gate＝operator 顯式選擇、此設定下沒有 R2 保護」；空 ledger
+下沒有可對照的獨立證據層，模型自述本就不構成授權，對照它只會把授權結果變成
+模型隨機行為（gpt-5.4 會把 shell 指令如 `pwd` 填進 gate_evidence，W1 批次
+job wf-efce4a166b-worktree-isolation-419 實測卡死）。ledger 非空時维持 fail-closed。
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from paulsha_cortex.coordinator import gate_ledger, terminal_contract
+
+
+def _passed_envelope(gate_evidence: list[dict[str, object]]) -> object:
+    return terminal_contract.validate_envelope(
+        {
+            "schema_version": terminal_contract.TERMINAL_SCHEMA_VERSION,
+            "kind": "workflow-card",
+            "status": "passed",
+            "run_id": "run",
+            "card_id": "card",
+            "candidate": "a" * 40,
+            "outputs": [],
+            "diagnostics": {},
+            "gate_evidence": gate_evidence,
+        }
+    )
+
+
+def _empty_ledger(tmp_path: Path) -> Path:
+    ledger_path = tmp_path / "job.gates.json"
+    payload = gate_ledger.write_gate_ledger(
+        ledger_path=ledger_path, worktree=tmp_path, env={}
+    )
+    assert payload["gates"] == []
+    return ledger_path
+
+
+def test_empty_ledger_tolerates_model_claimed_gates(tmp_path: Path) -> None:
+    ledger_path = _empty_ledger(tmp_path)
+    envelope = _passed_envelope([{"name": "pwd", "status": "passed"}])
+    authorization = terminal_contract.authorize_terminal(
+        envelope, ledger_path=ledger_path, require_ledger=True
+    )
+    assert authorization.authorized is True
+    assert authorization.verified_gates == ()
+
+
+def test_empty_ledger_without_claims_still_authorized(tmp_path: Path) -> None:
+    ledger_path = _empty_ledger(tmp_path)
+    envelope = _passed_envelope([])
+    authorization = terminal_contract.authorize_terminal(
+        envelope, ledger_path=ledger_path, require_ledger=True
+    )
+    assert authorization.authorized is True
+
+
+def test_nonempty_ledger_unknown_claim_still_fail_closed(tmp_path: Path) -> None:
+    ledger_path = tmp_path / "job.gates.json"
+    gate_ledger.write_gate_ledger(
+        ledger_path=ledger_path,
+        worktree=tmp_path,
+        env={"PSC_GATE_CMD_SMOKE": "python3 -c pass"},
+    )
+    envelope = _passed_envelope([{"name": "pwd", "status": "passed"}])
+    with pytest.raises(terminal_contract.TerminalContractError) as excinfo:
+        terminal_contract.authorize_terminal(
+            envelope, ledger_path=ledger_path, require_ledger=True
+        )
+    assert excinfo.value.reason == "gate-evidence-unknown-gate"


### PR DESCRIPTION
## 摘要

operator 顯式零 gate（ledger gates:[]）依 #261 文件本就無 R2 保護；authorize_terminal 仍拿空 ledger 對照模型自述的 gate_evidence 並 fail-closed（gate-evidence-unknown-gate），使授權結果隨模型是否填寫該欄而隨機化（gpt-5.4 會把 pwd 等 shell 指令填進 gate_evidence，W1 批次實測卡死）。

修法：ledger 存在且 gates 為空時跳過 unknown-gate 對照（自述視為 vacuous）；ledger 非空時維持原 fail-closed。

## 驗證

- [x] TDD：tests/test_gate_evidence_empty_ledger.py 3 測試（空 ledger 容忍自述、空 ledger 無自述照常、非空 ledger unknown 宣稱仍 fail-closed）先 RED 後 GREEN
- [x] 全套 pytest 1752 passed
- [x] changelog.d fragment 已 commit（R-09）＋ CHANGELOG entry

Closes #308

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JZKZjogV1MPL8DyiHwRnob