### PR TITLE
fix(workflow): pinned tasks/todo 的 checkbox 勾選不再視為 planning input drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ## [Unreleased]
 ### Fixed
+- **Issue #310：pinned planning input 對 task checkbox 更新的 drift 容忍**：kind=plan 的 `tasks.md`／`todo.md` 於 raw-hash 不符時做 checkbox-insensitive 比對（baseline 取自 operator_root 並先驗 hash）；其他差異維持 fail-closed。修正卡片契約要求勾選 checkbox 與 verify 派工 drift 檢查的互斥。
 - **Issue #308：零 gate 設定下模型自述 gate_evidence 不再觸發 fail-closed**：ledger `gates: []` 時 `authorize_terminal` 跳過 unknown-gate 對照（#261 文件：零 gate＝無 R2 保護）；ledger 非空維持 fail-closed。
 ### Changed
 - **W1 canary v2 檔名對齊（#295／#291）**：build 卡 declared inputs 以 `*<work_id>*` glob 檔名，v2 僅改 frontmatter 導致 declared input missing；檔名與 workstream 目錄補 `-v2` 並同步引用。

--- a/changelog.d/checkbox-drift-tolerance.md
+++ b/changelog.d/checkbox-drift-tolerance.md
@@ -1,0 +1,8 @@
+### Fixed
+- **Issue #310：pinned planning input 對 task checkbox 更新的 drift 容忍**：
+  卡片契約要求 builder 勾選 tasks.md checkbox，但 `_workflow_input_snapshot`
+  的嚴格 raw-hash 比對使 verify 派工必然 `planning input drift` fail-closed。
+  改為：authority kind=plan 且 basename 為 `tasks.md`／`todo.md` 的 ref，於
+  raw-hash 不符時以 operator_root 的 baseline（hash 先驗證）做
+  checkbox-insensitive 比對（`- [x]`→`- [ ]` 正規化後相等即放行）；任何其他
+  差異維持 fail-closed。

--- a/paulsha_cortex/coordinator/manager.py
+++ b/paulsha_cortex/coordinator/manager.py
@@ -3160,6 +3160,23 @@ def _write_workflow_input_content(
     return str(path)
 
 
+_CHECKBOX_VOLATILE_PLAN_BASENAMES = frozenset({"tasks.md", "todo.md"})
+_CHECKBOX_RE = re.compile(r"^(\s*(?:[-+*]|\d+[.)])\s+)\[[xX]\]", re.M)
+
+
+def _checkbox_insensitive_equal(baseline: bytes, current: bytes) -> bool:
+    """#310：卡片契約要求 builder 勾選 tasks/todo 的 checkbox；只有 checkbox
+    狀態差異（``- [x]``→``- [ ]`` 正規化後相等）視為未漂移。任何其他 byte 差異
+    仍屬 drift。"""
+    try:
+        base_text = baseline.decode("utf-8")
+        cur_text = current.decode("utf-8")
+    except UnicodeDecodeError:
+        return False
+    normalize = lambda text: _CHECKBOX_RE.sub(lambda m: m.group(1) + "[ ]", text)
+    return normalize(base_text) == normalize(cur_text)
+
+
 def _workflow_input_snapshot(
     *,
     run,
@@ -3230,7 +3247,26 @@ def _workflow_input_snapshot(
             digest = hashlib.sha256(data).hexdigest()
             bound = authority.get(ref)
             if bound is not None and digest != bound.baseline_sha256:
-                raise ValueError("workflow planning input drift")
+                # #310：tasks/todo（kind=plan）的 checkbox 勾選是卡片契約的既定
+                # 行為，不得視為 drift。baseline bytes 取自 operator_root 的同
+                # ref 檔案，且必須先驗證其 hash 等於 authority baseline，才可
+                # 作為 checkbox-insensitive 比對的基準；其餘任何差異 fail-closed。
+                tolerated = False
+                if (
+                    bound.kind == "plan"
+                    and Path(ref).name in _CHECKBOX_VOLATILE_PLAN_BASENAMES
+                ):
+                    baseline_matches = _safe_input_matches(operator_root, ref)
+                    if len(baseline_matches) == 1:
+                        baseline_data = baseline_matches[0].read_bytes()
+                        if (
+                            hashlib.sha256(baseline_data).hexdigest()
+                            == bound.baseline_sha256
+                            and _checkbox_insensitive_equal(baseline_data, data)
+                        ):
+                            tolerated = True
+                if not tolerated:
+                    raise ValueError("workflow planning input drift")
             pattern_has_authority = any(
                 fnmatch.fnmatch(candidate_ref, pattern) for candidate_ref in authority
             )

--- a/tests/test_checkbox_drift_tolerance.py
+++ b/tests/test_checkbox_drift_tolerance.py
@@ -1,0 +1,113 @@
+"""#310：pinned planning input 的 drift 檢查對 task checkbox 更新的容忍。
+
+卡片契約要求 builder 勾選 openspec change tasks.md 的 checkbox；嚴格 raw-hash
+drift 比對使 verify 派工必然 fail-closed。修法：operator_root 的同 ref 檔案
+（已驗證等於 baseline）作為 baseline bytes，raw-hash 不符時對 authority
+kind=plan 且 basename 為 tasks.md／todo.md 的 ref 做 checkbox-insensitive
+比對；其餘差異維持 fail-closed。
+"""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from paulsha_cortex.coordinator import manager
+from paulsha_cortex.coordinator.workflow import PlanningArtifactAuthority
+
+REF = "openspec/changes/2026-08-04-demo/tasks.md"
+BASELINE = """---
+status: accepted
+work_item: demo
+---
+
+# Tasks
+
+- [ ] 1.1 RED：新增測試。
+- [ ] 1.2 GREEN：實作。
+"""
+
+
+def _setup(tmp_path: Path, worktree_content: str):
+    operator_root = tmp_path / "operator"
+    worktree = tmp_path / "worktree"
+    for root, content in ((operator_root, BASELINE), (worktree, worktree_content)):
+        target = root / REF
+        target.parent.mkdir(parents=True)
+        target.write_text(content, encoding="utf-8")
+    run = SimpleNamespace(
+        run_id="workflow-" + "a" * 20,
+        work_id="demo",
+        repo="hamanpaul/paulsha-cortex",
+        source_revision="rev-demo",
+        workspace_root=str(operator_root),
+        planning_authority=(
+            PlanningArtifactAuthority(
+                ref=REF,
+                kind="plan",
+                work_id="demo",
+                baseline_sha256=hashlib.sha256(BASELINE.encode()).hexdigest(),
+            ),
+        ),
+    )
+    return operator_root, worktree, run
+
+
+def test_checkbox_only_drift_tolerated(tmp_path: Path) -> None:
+    ticked = BASELINE.replace("- [ ] 1.1", "- [x] 1.1").replace("- [ ] 1.2", "- [X] 1.2")
+    _, worktree, run = _setup(tmp_path, ticked)
+    rows = manager._workflow_input_snapshot(
+        run=run,
+        repo_root=worktree,
+        patterns=(REF,),
+        coordinator_root=tmp_path / "coord",
+    )
+    assert rows[0]["path"] == REF
+    assert rows[0]["authority"] == "planning-authority"
+
+
+def test_substantive_drift_still_fail_closed(tmp_path: Path) -> None:
+    mutated = BASELINE.replace("新增測試。", "改掉任務語意。")
+    _, worktree, run = _setup(tmp_path, mutated)
+    with pytest.raises(ValueError, match="planning input drift"):
+        manager._workflow_input_snapshot(
+            run=run,
+            repo_root=worktree,
+            patterns=(REF,),
+            coordinator_root=tmp_path / "coord",
+        )
+
+
+def test_checkbox_drift_plus_substantive_change_fail_closed(tmp_path: Path) -> None:
+    mutated = BASELINE.replace("- [ ] 1.1", "- [x] 1.1").replace("實作。", "偷改範圍。")
+    _, worktree, run = _setup(tmp_path, mutated)
+    with pytest.raises(ValueError, match="planning input drift"):
+        manager._workflow_input_snapshot(
+            run=run,
+            repo_root=worktree,
+            patterns=(REF,),
+            coordinator_root=tmp_path / "coord",
+        )
+
+
+def test_non_plan_kind_checkbox_drift_fail_closed(tmp_path: Path) -> None:
+    ticked = BASELINE.replace("- [ ] 1.1", "- [x] 1.1")
+    operator_root, worktree, run = _setup(tmp_path, ticked)
+    run.planning_authority = (
+        PlanningArtifactAuthority(
+            ref=REF,
+            kind="spec",
+            work_id="demo",
+            baseline_sha256=hashlib.sha256(BASELINE.encode()).hexdigest(),
+        ),
+    )
+    with pytest.raises(ValueError, match="planning input drift"):
+        manager._workflow_input_snapshot(
+            run=run,
+            repo_root=worktree,
+            patterns=(REF,),
+            coordinator_root=tmp_path / "coord",
+        )


### PR DESCRIPTION
## 摘要

卡片契約（tdd-red／subagent-build）要求 builder 勾選 openspec change tasks.md 的 checkbox；_workflow_input_snapshot 對 pinned planning authority 的嚴格 raw-hash 比對使 verify 派工必然 planning input drift fail-closed（W1 批次實測：build 三卡全 passed 後 verify 永遠派不出）。

修法：authority kind=plan 且 basename 為 tasks.md／todo.md 的 ref，raw-hash 不符時以 operator_root 的 baseline bytes（hash 先驗證等於 authority baseline）做 checkbox-insensitive 比對（- [x] → - [ ] 正規化後相等即放行）；任何其他差異維持 fail-closed。

## 驗證

- [x] TDD：tests/test_checkbox_drift_tolerance.py 4 測試（純 checkbox 容忍、實質改動 fail-closed、混合改動 fail-closed、非 plan kind fail-closed）先 RED 後 GREEN
- [x] 全套 pytest 1756 passed
- [x] changelog.d fragment 已 commit（R-09）＋ CHANGELOG entry

Closes #310

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JZKZjogV1MPL8DyiHwRnob