### PR TITLE
fix(workflow): reviewer frozen authority 驗證沿用 checkbox 容忍（#310 補遺）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ## [Unreleased]
 ### Fixed
+- **Issue #310 補遺：reviewer frozen authority 驗證沿用 checkbox 容忍**：`verify_authority_in_input_snapshot` 的 pinned 期望值改由 `_authority_map_with_checkbox_tolerance` 提供，checkbox 容忍成立的 tasks/todo 以候選實際 hash 比對；其他差異維持 fail-closed。
 - **Issue #310：pinned planning input 對 task checkbox 更新的 drift 容忍**：kind=plan 的 `tasks.md`／`todo.md` 於 raw-hash 不符時做 checkbox-insensitive 比對（baseline 取自 operator_root 並先驗 hash）；其他差異維持 fail-closed。修正卡片契約要求勾選 checkbox 與 verify 派工 drift 檢查的互斥。
 - **Issue #308：零 gate 設定下模型自述 gate_evidence 不再觸發 fail-closed**：ledger `gates: []` 時 `authorize_terminal` 跳過 unknown-gate 對照（#261 文件：零 gate＝無 R2 保護）；ledger 非空維持 fail-closed。
 ### Changed

--- a/changelog.d/reviewer-checkbox-tolerance.md
+++ b/changelog.d/reviewer-checkbox-tolerance.md
@@ -1,0 +1,7 @@
+### Fixed
+- **Issue #310 補遺：reviewer frozen authority 驗證沿用 checkbox 容忍**：
+  input snapshot 建立已容忍 tasks/todo 的 checkbox 勾選後，reviewer 派工的
+  `verify_authority_in_input_snapshot` 仍以 baseline hash 比對而 fail-closed
+  （`review input snapshot authority hash drift`）。新增
+  `_authority_map_with_checkbox_tolerance`：容忍成立時以候選實際 hash 作為
+  pinned 期望值；其他差異維持 baseline fail-closed。

--- a/paulsha_cortex/coordinator/manager.py
+++ b/paulsha_cortex/coordinator/manager.py
@@ -3177,6 +3177,36 @@ def _checkbox_insensitive_equal(baseline: bytes, current: bytes) -> bool:
     return normalize(base_text) == normalize(cur_text)
 
 
+def _authority_map_with_checkbox_tolerance(run, *, candidate_root: Path) -> dict[str, str]:
+    """#310 補遺：reviewer 的 frozen authority 驗證沿用 checkbox-insensitive 容忍。
+
+    tasks/todo（kind=plan）在候選 worktree 的 checkbox 勾選不視為 drift；容忍
+    成立時以候選內容的實際 hash 作為 pinned 期望值——reviewer 收到的 input
+    snapshot 就是這份內容，hash 必須對得上實檔。其他差異維持 baseline，使
+    `verify_authority_in_input_snapshot` 照舊 fail-closed。baseline bytes 取自
+    operator_root 的同 ref 檔案，且必須先驗證其 hash 等於 authority baseline。
+    """
+    operator_root = Path(run.workspace_root).resolve()
+    mapping: dict[str, str] = {}
+    for item in run.planning_authority:
+        expected = item.baseline_sha256
+        if item.kind == "plan" and Path(item.ref).name in _CHECKBOX_VOLATILE_PLAN_BASENAMES:
+            candidate_matches = _safe_input_matches(candidate_root, item.ref)
+            baseline_matches = _safe_input_matches(operator_root, item.ref)
+            if len(candidate_matches) == 1 and len(baseline_matches) == 1:
+                candidate_data = candidate_matches[0].read_bytes()
+                baseline_data = baseline_matches[0].read_bytes()
+                digest = hashlib.sha256(candidate_data).hexdigest()
+                if (
+                    digest != expected
+                    and hashlib.sha256(baseline_data).hexdigest() == expected
+                    and _checkbox_insensitive_equal(baseline_data, candidate_data)
+                ):
+                    expected = digest
+        mapping[item.ref] = expected
+    return mapping
+
+
 def _workflow_input_snapshot(
     *,
     run,
@@ -6081,7 +6111,10 @@ def _dispatch_workflow_card(
     effective_inputs = _effective_workflow_inputs(run, step)
     if step.persona == "reviewer":
         reviewer_target = effective_repo_root
-        authority_map = {item.ref: item.baseline_sha256 for item in run.planning_authority}
+        # #310 補遺：checkbox 容忍成立的 tasks/todo 以候選實際 hash 為 pinned 期望值。
+        authority_map = _authority_map_with_checkbox_tolerance(
+            run, candidate_root=reviewer_target
+        )
         effective_inputs = _reviewer_input_patterns(run, effective_inputs)
         input_snapshot = _workflow_input_snapshot(
             run=run,

--- a/tests/test_checkbox_drift_tolerance.py
+++ b/tests/test_checkbox_drift_tolerance.py
@@ -111,3 +111,17 @@ def test_non_plan_kind_checkbox_drift_fail_closed(tmp_path: Path) -> None:
             patterns=(REF,),
             coordinator_root=tmp_path / "coord",
         )
+
+
+def test_reviewer_authority_map_uses_candidate_hash_for_ticked_tasks(tmp_path: Path) -> None:
+    ticked = BASELINE.replace("- [ ] 1.1", "- [x] 1.1")
+    operator_root, worktree, run = _setup(tmp_path, ticked)
+    mapping = manager._authority_map_with_checkbox_tolerance(run, candidate_root=worktree)
+    assert mapping[REF] == hashlib.sha256(ticked.encode()).hexdigest()
+
+
+def test_reviewer_authority_map_keeps_baseline_on_substantive_change(tmp_path: Path) -> None:
+    mutated = BASELINE.replace("實作。", "偷改。")
+    operator_root, worktree, run = _setup(tmp_path, mutated)
+    mapping = manager._authority_map_with_checkbox_tolerance(run, candidate_root=worktree)
+    assert mapping[REF] == run.planning_authority[0].baseline_sha256


### PR DESCRIPTION
## 摘要

PR #311 讓 input snapshot 建立容忍 tasks/todo 的 checkbox 勾選後，reviewer 派工的 verify_authority_in_input_snapshot 仍以 baseline hash 比對 snapshot 列而 fail-closed（W1 四條 run 於 verify 齊卡 review input snapshot authority hash drift）。

修法：新增 _authority_map_with_checkbox_tolerance——容忍成立（baseline hash 驗證＋checkbox-insensitive 相等）時以候選實際 hash 作為 pinned 期望值（reviewer 收到的就是這份內容）；其他差異維持 baseline，下游照舊 fail-closed。

## 驗證

- [x] TDD：tests/test_checkbox_drift_tolerance.py 新增 2 測試（容忍→候選 hash、實質改動→維持 baseline）先 RED 後 GREEN，全檔 6 測試綠
- [x] 全套 pytest 1758 passed
- [x] changelog.d fragment 已 commit（R-09）＋ CHANGELOG entry

Closes #310

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JZKZjogV1MPL8DyiHwRnob