### PR TITLE
fix(terminal): verify phase 移出 gate ledger 必要集

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ## [Unreleased]
 ### Fixed
+- **Issue #313：verify phase 移出 gate ledger 必要集**：verification 卡的 review-only 沙箱依設計不寫 ledger，要求 ledger＝verification 卡結構性永不可過。`GATE_LEDGER_REQUIRED_PHASES` 收斂為 `{build}`；verify 的獨立證據層是 deterministic verification report 管線。
 - **Issue #310 補遺：reviewer frozen authority 驗證沿用 checkbox 容忍**：`verify_authority_in_input_snapshot` 的 pinned 期望值改由 `_authority_map_with_checkbox_tolerance` 提供，checkbox 容忍成立的 tasks/todo 以候選實際 hash 比對；其他差異維持 fail-closed。
 - **Issue #310：pinned planning input 對 task checkbox 更新的 drift 容忍**：kind=plan 的 `tasks.md`／`todo.md` 於 raw-hash 不符時做 checkbox-insensitive 比對（baseline 取自 operator_root 並先驗 hash）；其他差異維持 fail-closed。修正卡片契約要求勾選 checkbox 與 verify 派工 drift 檢查的互斥。
 - **Issue #308：零 gate 設定下模型自述 gate_evidence 不再觸發 fail-closed**：ledger `gates: []` 時 `authorize_terminal` 跳過 unknown-gate 對照（#261 文件：零 gate＝無 R2 保護）；ledger 非空維持 fail-closed。

--- a/changelog.d/verify-ledger-requirement.md
+++ b/changelog.d/verify-ledger-requirement.md
@@ -1,0 +1,7 @@
+### Fixed
+- **Issue #313：verify phase 移出 gate ledger 必要集**：verification 卡以
+  review-only 沙箱啟動，`launcher._should_run_gates` 依設計不讓唯讀 reviewer
+  跑 gate（也不寫 ledger）；`GATE_LEDGER_REQUIRED_PHASES` 含 verify 使
+  verification 卡的 passed terminal 一律「沒有可重驗的 gate ledger」
+  fail-closed（結構性永不可過）。收斂為 `{build}`；verify 的獨立證據層是
+  deterministic verification report 管線。

--- a/paulsha_cortex/coordinator/manager.py
+++ b/paulsha_cortex/coordinator/manager.py
@@ -2527,7 +2527,11 @@ def _terminal_parse_diagnostics(
 
 # #261 R2：會實際跑確定性 gate 的 phase。這些 phase 的 `passed` 必須有 manager 獨立
 # 產生的 gate ledger 背書；plan card 不改動 candidate、不跑 gate，故不在此列。
-GATE_LEDGER_REQUIRED_PHASES = frozenset({"build", "verify"})
+# #313：verify 亦不在此列——verification 卡以 review-only 沙箱啟動，
+# `launcher._should_run_gates` 依設計不讓唯讀 reviewer 跑 gate（也不寫 ledger），
+# 要求 ledger 等於讓 verification 卡結構性永不可過；verify 的獨立證據層是
+# deterministic verification report 管線（schema／binding／report 重驗）。
+GATE_LEDGER_REQUIRED_PHASES = frozenset({"build"})
 
 
 def _assert_terminal_gate_consistency(

--- a/tests/test_verify_phase_ledger_requirement.py
+++ b/tests/test_verify_phase_ledger_requirement.py
@@ -1,0 +1,52 @@
+"""#313：verify phase 不得要求 gate ledger。
+
+verification 卡以 review-only 沙箱啟動，`launcher._should_run_gates` 對
+review-only／read-only 明確回 False——wrapper 不含 ledger 階段。若
+`GATE_LEDGER_REQUIRED_PHASES` 仍含 verify，verification 卡的 passed terminal
+一律「沒有可重驗的 gate ledger」fail-closed（結構性永不可過）。verify 的獨立
+證據層是 deterministic verification report 管線，不是 wrapper gate ledger；
+build phase 的 ledger 要求維持不變。
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from paulsha_cortex.coordinator import manager, terminal_contract
+
+
+def _passed_raw() -> dict[str, object]:
+    return {
+        "schema_version": terminal_contract.TERMINAL_SCHEMA_VERSION,
+        "kind": "workflow-card",
+        "status": "passed",
+        "run_id": "run",
+        "card_id": "card",
+        "candidate": "a" * 40,
+        "outputs": [],
+        "diagnostics": {},
+        "gate_evidence": [],
+    }
+
+
+def test_gate_ledger_required_phases_is_build_only() -> None:
+    assert manager.GATE_LEDGER_REQUIRED_PHASES == frozenset({"build"})
+
+
+def test_verify_phase_passed_without_ledger_is_accepted(tmp_path: Path) -> None:
+    job = {
+        "workflow_phase": "verify",
+        "log_path": str(tmp_path / "job.jsonl"),
+    }
+    manager._assert_terminal_gate_consistency(_passed_raw(), job=job)
+
+
+def test_build_phase_passed_without_ledger_still_fail_closed(tmp_path: Path) -> None:
+    job = {
+        "workflow_phase": "build",
+        "log_path": str(tmp_path / "job.jsonl"),
+    }
+    with pytest.raises(terminal_contract.TerminalContractError):
+        manager._assert_terminal_gate_consistency(_passed_raw(), job=job)


### PR DESCRIPTION
## 摘要

verification 卡以 review-only 沙箱啟動，launcher._should_run_gates 依設計不讓唯讀 reviewer 跑 gate（也不寫 ledger）；GATE_LEDGER_REQUIRED_PHASES 含 verify 使 verification 卡的 passed terminal 一律「沒有可重驗的 gate ledger」fail-closed——結構性永不可過（7/25-26 批次 runs 全停 verify 至今、W1 四 run 實測同型）。

修法：GATE_LEDGER_REQUIRED_PHASES 收斂為 {build}。verify 的獨立證據層是 deterministic verification report 管線（schema／binding／report 重驗），不是 wrapper gate ledger；build 的 ledger 要求不變。

## 驗證

- [x] TDD：tests/test_verify_phase_ledger_requirement.py 3 測試（常數收斂、verify 無 ledger 放行、build 無 ledger 仍 fail-closed）先 RED 後 GREEN
- [x] 全套 pytest 1761 passed
- [x] changelog.d fragment 已 commit（R-09）＋ CHANGELOG entry

Closes #313

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JZKZjogV1MPL8DyiHwRnob