### PR TITLE
fix(registry): retry-verify 重置時失效舊 exited verification job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ## [Unreleased]
 ### Fixed
+- **Issue #315：retry-verify 重置時失效舊 exited verification job**：沙箱已清的舊 job 維持 exited 會讓 dispatch 先 terminalize 而永遠 `input snapshot file missing`；reset 時標記 failed，resume 走 replacement dispatch。
 - **Issue #313：verify phase 移出 gate ledger 必要集**：verification 卡的 review-only 沙箱依設計不寫 ledger，要求 ledger＝verification 卡結構性永不可過。`GATE_LEDGER_REQUIRED_PHASES` 收斂為 `{build}`；verify 的獨立證據層是 deterministic verification report 管線。
 - **Issue #310 補遺：reviewer frozen authority 驗證沿用 checkbox 容忍**：`verify_authority_in_input_snapshot` 的 pinned 期望值改由 `_authority_map_with_checkbox_tolerance` 提供，checkbox 容忍成立的 tasks/todo 以候選實際 hash 比對；其他差異維持 fail-closed。
 - **Issue #310：pinned planning input 對 task checkbox 更新的 drift 容忍**：kind=plan 的 `tasks.md`／`todo.md` 於 raw-hash 不符時做 checkbox-insensitive 比對（baseline 取自 operator_root 並先驗 hash）；其他差異維持 fail-closed。修正卡片契約要求勾選 checkbox 與 verify 派工 drift 檢查的互斥。

--- a/changelog.d/retry-verify-job-invalidation.md
+++ b/changelog.d/retry-verify-job-invalidation.md
@@ -1,0 +1,8 @@
+### Fixed
+- **Issue #315：retry-verify 重置時失效舊 exited verification job**：
+  reviewer sandbox 依設計已清除、舊 job terminal 證據不可重驗，維持 exited
+  會讓 dispatch 先 terminalize 舊 job 而永遠卡在
+  `workflow input snapshot file missing`。`_manager_reset_workflow_for_retry_verify`
+  於 CAS／admission 通過後將本 run 的 exited verify-phase job 標記 failed，
+  explicit resume 隨即走 replacement dispatch；build phase job 與 active job
+  不受影響。

--- a/paulsha_cortex/coordinator/registry.py
+++ b/paulsha_cortex/coordinator/registry.py
@@ -1646,6 +1646,18 @@ class JobRegistry:
         build_steps = [step for step in current.steps if step.phase == "build"]
         if not build_steps or any(step.gate_result != "passed" for step in build_steps):
             raise ValueError("retry-verify reset requires completed build phase")
+        # #315：operator 已以 CAS 顯式授權重跑 verification；舊 exited verify job
+        # 的 reviewer sandbox 依設計已清除、terminal 證據不可重驗，維持 "exited"
+        # 會讓 dispatch 先 terminalize 舊 job 而永遠卡在 input-snapshot-missing。
+        # 標記 failed 讓 explicit resume 走 replacement dispatch；build phase job
+        # 與 active job（前面 admission 已擋）不受影響。
+        for job in self._jobs:
+            if (
+                job.get("workflow_run_id") == current.run_id
+                and job.get("workflow_phase") == "verify"
+                and job.get("status") == "exited"
+            ):
+                job["status"] = "failed"
         steps = tuple(
             replace(step, gate_result="pending") if step.phase == "verify" else step
             for step in current.steps

--- a/tests/test_retry_verify_job_invalidation.py
+++ b/tests/test_retry_verify_job_invalidation.py
@@ -1,0 +1,125 @@
+"""#315：retry-verify 重置 verify step 時必須失效舊 exited verification job。
+
+否則 dispatch 路徑對 exited+sentinel 的最新 job 先 terminalize——reviewer
+sandbox 依設計已清除，input snapshot 實檔不可重驗，run 永遠卡在
+`workflow input snapshot file missing`，到不了 fresh dispatch。
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from paulsha_cortex.coordinator.registry import JobRegistry
+from paulsha_cortex.coordinator.workflow import WorkflowStep
+
+CANDIDATE = "c" * 40
+
+
+def _steps() -> tuple[WorkflowStep, ...]:
+    build = WorkflowStep(
+        phase="build",
+        persona="builder",
+        card="subagent-build",
+        executor="copilot",
+        model="gpt-5.4",
+        domain="github",
+        inputs=(),
+        outputs=(),
+        gate_result="passed",
+    )
+    verify = WorkflowStep(
+        phase="verify",
+        persona="reviewer",
+        card="verification",
+        executor=None,
+        model=None,
+        domain=None,
+        inputs=(),
+        outputs=(),
+        gate_result="needs_human",
+    )
+    return (build, verify)
+
+
+def _run_with_exited_verify_job(tmp_path: Path):
+    registry = JobRegistry(state_path=tmp_path / "jobs.json")
+    run = registry._manager_create_workflow_run(
+        work_id="retry-verify-work",
+        repo="hamanpaul/paulsha-cortex",
+        claim_key="claim:v1:" + "e" * 64,
+        source_revision="rev-e",
+        workspace_root="/tmp/workspace",
+        combo="feature-oneshot",
+        current_phase="verify",
+        steps=_steps(),
+        issue_refs=("hamanpaul/paulsha-cortex#315",),
+        attempts={"claim": 1, "verify": 1},
+        facets=("needs_human",),
+        candidate_head=CANDIDATE,
+    )
+    job = registry.create_job(
+        task="wf-demo-verification",
+        persona="reviewer",
+        branch="feature/315-demo",
+        pane="",
+        worktree=str(tmp_path / "sandbox"),
+        workflow_run_id=run.run_id,
+        workflow_claim_key=run.claim_key,
+        workflow_repo=run.repo,
+        workflow_card="verification",
+        workflow_phase="verify",
+    )
+    registry.update_headless_result(job["job_id"], status="exited", exit_code=0)
+    return registry, run, job["job_id"]
+
+
+def test_reset_marks_exited_verify_job_failed(tmp_path: Path) -> None:
+    registry, run, job_id = _run_with_exited_verify_job(tmp_path)
+    registry._manager_reset_workflow_for_retry_verify(
+        run.run_id, expected_candidate=CANDIDATE
+    )
+    row = registry.get_job(job_id)
+    assert row["status"] == "failed"
+
+
+def test_reset_leaves_build_phase_jobs_untouched(tmp_path: Path) -> None:
+    registry, run, _ = _run_with_exited_verify_job(tmp_path)
+    build_job = registry.create_job(
+        task="wf-demo-build",
+        persona="builder",
+        branch="feature/315-demo",
+        pane="",
+        worktree=str(tmp_path / "wt"),
+        workflow_run_id=run.run_id,
+        workflow_claim_key=run.claim_key,
+        workflow_repo=run.repo,
+        workflow_card="subagent-build",
+        workflow_phase="build",
+    )
+    registry.update_headless_result(build_job["job_id"], status="exited", exit_code=0)
+    registry._manager_reset_workflow_for_retry_verify(
+        run.run_id, expected_candidate=CANDIDATE
+    )
+    assert registry.get_job(build_job["job_id"])["status"] == "exited"
+
+
+def test_reset_still_refuses_active_verify_job(tmp_path: Path) -> None:
+    registry, run, _ = _run_with_exited_verify_job(tmp_path)
+    registry.create_job(
+        task="wf-demo-verification-2",
+        persona="reviewer",
+        branch="feature/315-demo",
+        pane="",
+        worktree=str(tmp_path / "sandbox2"),
+        workflow_run_id=run.run_id,
+        workflow_claim_key=run.claim_key,
+        workflow_repo=run.repo,
+        workflow_card="verification",
+        workflow_phase="verify",
+    )
+    with pytest.raises(ValueError, match="active workflow job"):
+        registry._manager_reset_workflow_for_retry_verify(
+            run.run_id, expected_candidate=CANDIDATE
+        )


### PR DESCRIPTION
## 摘要

retry-verify（#216 AC2）把 verify step 打回 pending，但舊 verification job row 維持 exited；dispatch 路徑對 exited+sentinel 的最新 job 先 terminalize——reviewer sandbox 依設計已清除，input snapshot 實檔不可重驗 → workflow input snapshot file missing → 永遠到不了 fresh dispatch（W1 四條 run 實測）。

修法：_manager_reset_workflow_for_retry_verify 於 CAS／admission 通過後，將本 run 的 exited verify-phase job rows 標記 failed（operator 已顯式授權重跑）；explicit resume 隨即走 replacement dispatch。build phase job 與 active job（admission 已擋）不受影響。

## 驗證

- [x] TDD：tests/test_retry_verify_job_invalidation.py 3 測試（exited verify job 標 failed、build job 不動、active job 仍拒絕 reset）先 RED 後 GREEN
- [x] 全套 pytest 1764 passed
- [x] changelog.d fragment 已 commit（R-09）＋ CHANGELOG entry

Closes #315

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JZKZjogV1MPL8DyiHwRnob