### PR TITLE
fix(registry): retry-review 重置時同步失效舊 exited review job（#315 補遺）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ## [Unreleased]
 ### Fixed
+- **Issue #315 補遺：retry-review 重置時同步失效舊 exited review job**：比照 retry-verify，reset 時標記 failed 讓 resume 走 replacement dispatch。
 - **Issue #315：retry-verify 重置時失效舊 exited verification job**：沙箱已清的舊 job 維持 exited 會讓 dispatch 先 terminalize 而永遠 `input snapshot file missing`；reset 時標記 failed，resume 走 replacement dispatch。
 - **Issue #313：verify phase 移出 gate ledger 必要集**：verification 卡的 review-only 沙箱依設計不寫 ledger，要求 ledger＝verification 卡結構性永不可過。`GATE_LEDGER_REQUIRED_PHASES` 收斂為 `{build}`；verify 的獨立證據層是 deterministic verification report 管線。
 - **Issue #310 補遺：reviewer frozen authority 驗證沿用 checkbox 容忍**：`verify_authority_in_input_snapshot` 的 pinned 期望值改由 `_authority_map_with_checkbox_tolerance` 提供，checkbox 容忍成立的 tasks/todo 以候選實際 hash 比對；其他差異維持 fail-closed。

--- a/changelog.d/retry-review-job-invalidation.md
+++ b/changelog.d/retry-review-job-invalidation.md
@@ -1,0 +1,4 @@
+### Fixed
+- **Issue #315 補遺：retry-review 重置時同步失效舊 exited review job**：比照
+  retry-verify，reviewer sandbox 已清的舊 review job 標記 failed，explicit
+  resume 走 replacement dispatch；verify／build job 不受影響。

--- a/paulsha_cortex/coordinator/registry.py
+++ b/paulsha_cortex/coordinator/registry.py
@@ -1722,6 +1722,17 @@ class JobRegistry:
         verify_steps = [step for step in current.steps if step.phase == "verify"]
         if not verify_steps or any(step.gate_result != "passed" for step in verify_steps):
             raise ValueError("retry-review reset requires completed verify phase")
+        # #315（review 版）：operator 已以 CAS 顯式授權重跑 review；舊 exited
+        # review job 的 reviewer sandbox 已清、terminal 不可重驗，維持 "exited"
+        # 會讓 resume 先 terminalize 舊 job 而卡死。標記 failed 讓 explicit
+        # resume 走 replacement dispatch；verify／build job 不受影響。
+        for job in self._jobs:
+            if (
+                job.get("workflow_run_id") == current.run_id
+                and job.get("workflow_phase") == "review"
+                and job.get("status") == "exited"
+            ):
+                job["status"] = "failed"
         steps = tuple(
             replace(step, gate_result="pending") if step.phase == "review" else step
             for step in current.steps

--- a/tests/test_retry_verify_job_invalidation.py
+++ b/tests/test_retry_verify_job_invalidation.py
@@ -123,3 +123,54 @@ def test_reset_still_refuses_active_verify_job(tmp_path: Path) -> None:
         registry._manager_reset_workflow_for_retry_verify(
             run.run_id, expected_candidate=CANDIDATE
         )
+
+
+def test_retry_review_reset_marks_exited_review_job_failed(tmp_path: Path) -> None:
+    registry = JobRegistry(state_path=tmp_path / "jobs.json")
+    build = WorkflowStep(
+        phase="build", persona="builder", card="subagent-build",
+        executor="copilot", model="gpt-5.4", domain="github",
+        inputs=(), outputs=(), gate_result="passed",
+    )
+    verify = WorkflowStep(
+        phase="verify", persona="reviewer", card="verification",
+        executor=None, model=None, domain=None,
+        inputs=(), outputs=(), gate_result="passed",
+    )
+    review = WorkflowStep(
+        phase="review", persona="reviewer", card="code-review",
+        executor=None, model=None, domain=None,
+        inputs=(), outputs=(), gate_result="needs_human",
+    )
+    run = registry._manager_create_workflow_run(
+        work_id="retry-review-work",
+        repo="hamanpaul/paulsha-cortex",
+        claim_key="claim:v1:" + "f" * 64,
+        source_revision="rev-f",
+        workspace_root="/tmp/workspace",
+        combo="feature-oneshot",
+        current_phase="review",
+        steps=(build, verify, review),
+        issue_refs=("hamanpaul/paulsha-cortex#315",),
+        attempts={"claim": 1, "review": 1},
+        facets=("needs_human",),
+        candidate_head=CANDIDATE,
+        verified_head=CANDIDATE,
+    )
+    job = registry.create_job(
+        task="wf-demo-code-review",
+        persona="reviewer",
+        branch="feature/315-demo",
+        pane="",
+        worktree=str(tmp_path / "sandbox"),
+        workflow_run_id=run.run_id,
+        workflow_claim_key=run.claim_key,
+        workflow_repo=run.repo,
+        workflow_card="code-review",
+        workflow_phase="review",
+    )
+    registry.update_headless_result(job["job_id"], status="exited", exit_code=0)
+    registry._manager_reset_workflow_for_retry_review(
+        run.run_id, expected_candidate=CANDIDATE
+    )
+    assert registry.get_job(job["job_id"])["status"] == "failed"


### PR DESCRIPTION
## 摘要

比照 retry-verify（PR #316）：reviewer sandbox 已清的舊 review job 維持 exited 會讓 resume 先 terminalize 而卡死（W1 三張 code-review 卡在 review terminal schema invalid 後 resume 恆炸）。reset 於 CAS／admission 通過後將本 run 的 exited review-phase job 標記 failed，explicit resume 走 replacement dispatch。

## 驗證

- [x] TDD：新增 test_retry_review_reset_marks_exited_review_job_failed，全檔 4 測試綠
- [x] 全套 pytest 1765 passed
- [x] changelog.d fragment 已 commit（R-09）＋ CHANGELOG entry

Closes #315

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JZKZjogV1MPL8DyiHwRnob