### PR TITLE
fix(workflow): review 派工 schema 將 authority_hashes 列入 fixed 逐字照抄（#315 補遺 2）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ## [Unreleased]
 ### Fixed
+- **Issue #315 補遺 2：review 派工 schema 把 authority_hashes 列入 fixed 逐字照抄**：修正 sonnet reviewer 條件性解讀導致整組省略、review terminal 恆 schema invalid；harvest 精確比對不變。
 - **Issue #315 補遺：retry-review 重置時同步失效舊 exited review job**：比照 retry-verify，reset 時標記 failed 讓 resume 走 replacement dispatch。
 - **Issue #315：retry-verify 重置時失效舊 exited verification job**：沙箱已清的舊 job 維持 exited 會讓 dispatch 先 terminalize 而永遠 `input snapshot file missing`；reset 時標記 failed，resume 走 replacement dispatch。
 - **Issue #313：verify phase 移出 gate ledger 必要集**：verification 卡的 review-only 沙箱依設計不寫 ledger，要求 ledger＝verification 卡結構性永不可過。`GATE_LEDGER_REQUIRED_PHASES` 收斂為 `{build}`；verify 的獨立證據層是 deterministic verification report 管線。

--- a/changelog.d/review-authority-hashes-fixed.md
+++ b/changelog.d/review-authority-hashes-fixed.md
@@ -1,0 +1,5 @@
+### Fixed
+- **Issue #315 補遺 2：review 派工 schema 把 authority_hashes 列入 fixed 逐字照抄**：
+  sonnet reviewer 對「actually opened」措辭的條件性解讀會整組省略
+  `authority_hashes`（實測 2/2），review terminal 恆 schema invalid。expected
+  值由 manager 原樣提供並列入 fixed；harvest 端精確比對不變。

--- a/paulsha_cortex/coordinator/manager.py
+++ b/paulsha_cortex/coordinator/manager.py
@@ -5589,7 +5589,20 @@ def _workflow_job_prompt(
                 "schema_version", "kind", "reason", "findings", "reports",
                 *(["authority_hashes"] if authority_hashes_expected else []),
             ],
-            "fixed": {"schema_version": 1, "kind": "workflow-review-result"},
+            "fixed": {
+                "schema_version": 1,
+                "kind": "workflow-review-result",
+                # #315 補遺 2：sonnet reviewer 對「actually opened」措辭的條件性
+                # 解讀會整組省略 authority_hashes（實測 2/2）。expected 值由
+                # manager 原樣提供，列入 fixed 要求逐字照抄——照抄本身即攻證
+                # 「收到的 frozen authority 與 pinned hash 一致」；harvest 端
+                # 的精確比對不變。
+                **(
+                    {"authority_hashes": dict(authority_hashes_expected)}
+                    if authority_hashes_expected
+                    else {}
+                ),
+            },
             # #261 R1：選填欄位；review verdict 仍由 findings 決定，status 只用來
             # 誠實表達「這張 review card 自己沒能完成」。
             "optional": ["status"],
@@ -5613,9 +5626,10 @@ def _workflow_job_prompt(
         if authority_hashes_expected:
             terminal_schema["authority_hashes"] = {
                 "description": (
-                    "Echo back the pinned sha256 for every frozen planning authority ref you "
-                    "actually opened in source_material; the verdict is rejected unless it "
-                    "matches exactly."
+                    "MANDATORY: copy the expected mapping below verbatim into the "
+                    "authority_hashes field of your terminal JSON. It attests the frozen "
+                    "planning authority you received; the verdict is rejected if the field "
+                    "is missing or differs in any way."
                 ),
                 "expected": dict(authority_hashes_expected),
             }


### PR DESCRIPTION
## 摘要

sonnet reviewer 對 authority_hashes 描述「actually opened」的條件性解讀會整組省略該欄（W1 實測 2/2），review terminal 恆 schema invalid。expected 值本就由 manager 在 prompt 中原樣提供——改列入 fixed 要求逐字照抄（照抄即攻證收到的 frozen authority），描述改為無條件 MANDATORY；harvest 端精確比對維持不變。

## 驗證

- [x] 全套 pytest 1765 passed（prompt schema 構造變更，行為由 harvest 既有比對測試覆蓋）
- [x] changelog.d fragment 已 commit（R-09）＋ CHANGELOG entry

Closes #315

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JZKZjogV1MPL8DyiHwRnob