### PR TITLE
fix(launcher): review StructuredOutput 工具 schema 開放 authority_hashes（#315 補遺 3）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ## [Unreleased]
 ### Fixed
+- **Issue #315 補遺 3：review StructuredOutput 工具 schema 開放 authority_hashes**：additionalProperties:false 下模型無法交出驗證器要求的攻證欄位（#219 佈線缺口）；工具 schema 開放屬性，必填與比對仍由 manager 驗證。
 - **Issue #315 補遺 2：review 派工 schema 把 authority_hashes 列入 fixed 逐字照抄**：修正 sonnet reviewer 條件性解讀導致整組省略、review terminal 恆 schema invalid；harvest 精確比對不變。
 - **Issue #315 補遺：retry-review 重置時同步失效舊 exited review job**：比照 retry-verify，reset 時標記 failed 讓 resume 走 replacement dispatch。
 - **Issue #315：retry-verify 重置時失效舊 exited verification job**：沙箱已清的舊 job 維持 exited 會讓 dispatch 先 terminalize 而永遠 `input snapshot file missing`；reset 時標記 failed，resume 走 replacement dispatch。

--- a/changelog.d/review-tool-schema-authority-hashes.md
+++ b/changelog.d/review-tool-schema-authority-hashes.md
@@ -1,0 +1,8 @@
+### Fixed
+- **Issue #315 補遺 3：review StructuredOutput 工具 schema 開放 authority_hashes**：
+  manager 驗證器在 input snapshot 含 planning-authority 列時要求
+  `authority_hashes`，但 `_claude_review_json_schema` 的
+  `additionalProperties:false` 未含此屬性——模型遵循 prompt 也交不出來（工具
+  層拒收），review terminal 恆 schema invalid（#219 attestation 佈線缺口）。
+  工具 schema 開放屬性（sha256 pattern），必填與精確比對仍由 manager 依
+  context 驗證。

--- a/paulsha_cortex/coordinator/launcher.py
+++ b/paulsha_cortex/coordinator/launcher.py
@@ -130,6 +130,19 @@ def _claude_review_json_schema(kind: str) -> str:
                 "reason": {"type": "string", "minLength": 1},
                 "findings": {"type": "array", "items": finding},
                 "reports": {"type": "array", "minItems": 1, "items": report},
+                # #315 補遺 3（#219 attestation 缺口）：manager 驗證器在 input
+                # snapshot 含 planning-authority 列時「要求」authority_hashes，
+                # 但本工具 schema additionalProperties:false 之前沒有此屬性——
+                # 模型再遵循 prompt 也交不出來（工具層拒收），review terminal
+                # 恆 schema invalid。是否必填由 manager 依 context 驗證，工具
+                # schema 僅開放屬性。
+                "authority_hashes": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string",
+                        "pattern": "^[0-9a-f]{64}$",
+                    },
+                },
             },
         }
     else:

--- a/tests/test_retry_verify_job_invalidation.py
+++ b/tests/test_retry_verify_job_invalidation.py
@@ -174,3 +174,15 @@ def test_retry_review_reset_marks_exited_review_job_failed(tmp_path: Path) -> No
         run.run_id, expected_candidate=CANDIDATE
     )
     assert registry.get_job(job["job_id"])["status"] == "failed"
+
+
+def test_review_tool_schema_allows_authority_hashes() -> None:
+    """#315 補遺 3：StructuredOutput 工具 schema 必須開放 authority_hashes 屬性，
+    否則 additionalProperties:false 下模型無法交出 manager 驗證器要求的攻證欄位。"""
+    import json as _json
+
+    from paulsha_cortex.coordinator.launcher import _claude_review_json_schema
+
+    schema = _json.loads(_claude_review_json_schema("workflow-review-result"))
+    assert "authority_hashes" in schema["properties"]
+    assert schema["properties"]["authority_hashes"]["type"] == "object"


### PR DESCRIPTION
## 摘要

manager 驗證器在 input snapshot 含 planning-authority 列時要求 authority_hashes、派工 prompt 也已 MANDATORY 逐字照抄（PR #318）；但 _claude_review_json_schema 的 additionalProperties:false 沒有此屬性——模型遵循 prompt 也交不出來（StructuredOutput 工具層拒收），review terminal 恆 schema invalid（W1 四輪 review 實測 0/4 攜帶，#219 attestation 佈線缺口）。

修法：工具 schema 開放 authority_hashes 屬性（值為 64-hex sha256 pattern）；必填語意與精確比對維持 manager 端 context 驗證不變。

## 驗證

- [x] TDD：test_review_tool_schema_allows_authority_hashes；全套 pytest 1766 passed
- [x] changelog.d fragment 已 commit（R-09）＋ CHANGELOG entry

Closes #315

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JZKZjogV1MPL8DyiHwRnob