### PR TITLE
docs(planning): feat-work-gc 與 design-task-type-taxonomy 重識別 -v2

### DIFF
--- a/.cortex/work-items.yaml
+++ b/.cortex/work-items.yaml
@@ -415,25 +415,25 @@ work_items:
         ref: docs/superpowers/workstreams/fix-repair-commit-recovery/todo.md
       - kind: path
         ref: docs/superpowers/specs/fix-repair-commit-recovery-spec.md
-  feat-work-gc:
-    title: cortex work gc——proposal-first 產物生命週期回收 (#178)
+  feat-work-gc-v2:
+    title: cortex work gc v2 重識別——世代熔斷後續作 (#178)
     links:
       - kind: github_issue
         ref: hamanpaul/paulsha-cortex#178
       - kind: openspec
         ref: 2026-08-04-feat-work-gc
       - kind: path
-        ref: docs/superpowers/workstreams/feat-work-gc/todo.md
+        ref: docs/superpowers/workstreams/feat-work-gc-v2/todo.md
       - kind: path
-        ref: docs/superpowers/specs/feat-work-gc-spec.md
-  design-task-type-taxonomy:
-    title: task_type taxonomy 契約定案與骨架——#8 叢集基礎 (#139)
+        ref: docs/superpowers/specs/feat-work-gc-v2-spec.md
+  design-task-type-taxonomy-v2:
+    title: task_type taxonomy v2 重識別——世代熔斷後續作 (#139)
     links:
       - kind: github_issue
         ref: hamanpaul/paulsha-cortex#139
       - kind: openspec
         ref: 2026-08-04-design-task-type-taxonomy
       - kind: path
-        ref: docs/superpowers/workstreams/design-task-type-taxonomy/todo.md
+        ref: docs/superpowers/workstreams/design-task-type-taxonomy-v2/todo.md
       - kind: path
-        ref: docs/superpowers/specs/design-task-type-taxonomy-spec.md
+        ref: docs/superpowers/specs/design-task-type-taxonomy-v2-spec.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 本專案遵循 hamanpaul project policy v1.0.15。
 
 ## [Unreleased]
+### Changed
+- **feat-work-gc 與 design-task-type-taxonomy 重識別為 -v2（#178／#139）**：三代 run 因基礎設施缺陷鏈 superseded 觸發 #218 世代熔斷，依「-v2 識別」慣例重識別於修復齊備的 main 重跑。
 ### Fixed
 - **封存 14 個 7/25–26 遺留 active OpenSpec changes**：功能已 merge 但缺 specs delta，validate --all 14 fail 擋所有 ship preflight；官方 archive 後 0 failed。
 - **Issue #315 補遺 3：review StructuredOutput 工具 schema 開放 authority_hashes**：additionalProperties:false 下模型無法交出驗證器要求的攻證欄位（#219 佈線缺口）；工具 schema 開放屬性，必填與比對仍由 manager 驗證。

--- a/changelog.d/w1-v2-reidentify-gc-taxonomy.md
+++ b/changelog.d/w1-v2-reidentify-gc-taxonomy.md
@@ -1,0 +1,5 @@
+### Changed
+- **feat-work-gc 與 design-task-type-taxonomy 重識別為 -v2（#178／#139）**：兩者
+  的三代 run 因基礎設施缺陷鏈（drift／ledger／schema 系列）superseded 觸發 #218
+  世代熔斷。依「-v2 識別」慣例改檔名、workstream 目錄、frontmatter `work_item`
+  與 `.cortex/work-items.yaml`，於修復齊備的 main 上以新 claim identity 重跑。

--- a/docs/superpowers/plans/design-task-type-taxonomy-v2.md
+++ b/docs/superpowers/plans/design-task-type-taxonomy-v2.md
@@ -1,6 +1,6 @@
 ---
 status: accepted
-work_item: design-task-type-taxonomy
+work_item: design-task-type-taxonomy-v2
 ---
 
 # design-task-type-taxonomy Plan

--- a/docs/superpowers/plans/feat-work-gc-v2.md
+++ b/docs/superpowers/plans/feat-work-gc-v2.md
@@ -1,6 +1,6 @@
 ---
 status: accepted
-work_item: feat-work-gc
+work_item: feat-work-gc-v2
 ---
 
 # feat-work-gc Plan

--- a/docs/superpowers/specs/design-task-type-taxonomy-v2-design.md
+++ b/docs/superpowers/specs/design-task-type-taxonomy-v2-design.md
@@ -1,6 +1,6 @@
 ---
 status: accepted
-work_item: design-task-type-taxonomy
+work_item: design-task-type-taxonomy-v2
 ---
 
 # design-task-type-taxonomy Design

--- a/docs/superpowers/specs/design-task-type-taxonomy-v2-spec.md
+++ b/docs/superpowers/specs/design-task-type-taxonomy-v2-spec.md
@@ -1,6 +1,6 @@
 ---
 status: accepted
-work_item: design-task-type-taxonomy
+work_item: design-task-type-taxonomy-v2
 ---
 
 # design-task-type-taxonomy Specification

--- a/docs/superpowers/specs/feat-work-gc-v2-design.md
+++ b/docs/superpowers/specs/feat-work-gc-v2-design.md
@@ -1,6 +1,6 @@
 ---
 status: accepted
-work_item: feat-work-gc
+work_item: feat-work-gc-v2
 ---
 
 # feat-work-gc Design

--- a/docs/superpowers/specs/feat-work-gc-v2-spec.md
+++ b/docs/superpowers/specs/feat-work-gc-v2-spec.md
@@ -1,6 +1,6 @@
 ---
 status: accepted
-work_item: feat-work-gc
+work_item: feat-work-gc-v2
 ---
 
 # feat-work-gc Specification

--- a/docs/superpowers/workstreams/design-task-type-taxonomy-v2/todo.md
+++ b/docs/superpowers/workstreams/design-task-type-taxonomy-v2/todo.md
@@ -1,6 +1,6 @@
 ---
 status: accepted
-work_item: design-task-type-taxonomy
+work_item: design-task-type-taxonomy-v2
 ---
 
 # design-task-type-taxonomy Todo

--- a/docs/superpowers/workstreams/feat-work-gc-v2/todo.md
+++ b/docs/superpowers/workstreams/feat-work-gc-v2/todo.md
@@ -1,6 +1,6 @@
 ---
 status: accepted
-work_item: feat-work-gc
+work_item: feat-work-gc-v2
 ---
 
 # feat-work-gc Todo

--- a/openspec/changes/2026-08-04-design-task-type-taxonomy/design.md
+++ b/openspec/changes/2026-08-04-design-task-type-taxonomy/design.md
@@ -1,6 +1,6 @@
 ---
 status: accepted
-work_item: design-task-type-taxonomy
+work_item: design-task-type-taxonomy-v2
 ---
 
 # design-task-type-taxonomy Design
@@ -18,4 +18,4 @@ work_item: design-task-type-taxonomy
 - 統一 log reader 與 status view 只定介面契約（來源路徑、欄位、責任邊界），實作留
   下游票；combo 值域缺口（實測最大宗 `fix` 無對應 combo）明載為 #202 的硬前提。
 
-詳細 D1–Dn 與風險緩解見 `docs/superpowers/specs/design-task-type-taxonomy-design.md`。
+詳細 D1–Dn 與風險緩解見 `docs/superpowers/specs/design-task-type-taxonomy-v2-design.md`。

--- a/openspec/changes/2026-08-04-design-task-type-taxonomy/proposal.md
+++ b/openspec/changes/2026-08-04-design-task-type-taxonomy/proposal.md
@@ -1,6 +1,6 @@
 ---
 status: accepted
-work_item: design-task-type-taxonomy
+work_item: design-task-type-taxonomy-v2
 ---
 
 ## Goals
@@ -22,4 +22,4 @@ repo 內存在至少四種互不相干的 task 分類軸，且無 issue 明確�
 ## Capabilities
 
 ### Modified Capabilities
-- `persona-workflow-orchestration`：詳見 `docs/superpowers/specs/design-task-type-taxonomy-spec.md` 的 Requirements 與 `docs/superpowers/specs/design-task-type-taxonomy-design.md` 的 Decisions。
+- `persona-workflow-orchestration`：詳見 `docs/superpowers/specs/design-task-type-taxonomy-v2-spec.md` 的 Requirements 與 `docs/superpowers/specs/design-task-type-taxonomy-v2-design.md` 的 Decisions。

--- a/openspec/changes/2026-08-04-design-task-type-taxonomy/specs/persona-workflow-orchestration/spec.md
+++ b/openspec/changes/2026-08-04-design-task-type-taxonomy/specs/persona-workflow-orchestration/spec.md
@@ -1,6 +1,6 @@
 ---
 status: accepted
-work_item: design-task-type-taxonomy
+work_item: design-task-type-taxonomy-v2
 ---
 
 ## ADDED Requirements

--- a/openspec/changes/2026-08-04-design-task-type-taxonomy/tasks.md
+++ b/openspec/changes/2026-08-04-design-task-type-taxonomy/tasks.md
@@ -1,12 +1,12 @@
 ---
 status: accepted
-work_item: design-task-type-taxonomy
+work_item: design-task-type-taxonomy-v2
 ---
 
 # Tasks
 
-- [ ] 1.1 RED：依 `docs/superpowers/plans/design-task-type-taxonomy.md` 的 TDD RED 章節新增 `tests/test_deck_task_types.py`，確認失敗。
-- [ ] 1.2 實作至 GREEN，範圍限於 `docs/superpowers/specs/design-task-type-taxonomy-spec.md` 的 Requirements（契約檔 `paulsha_cortex/deck/data/task-types.yaml` 與 `paulsha_cortex/deck/task_types.py`）。
+- [ ] 1.1 RED：依 `docs/superpowers/plans/design-task-type-taxonomy-v2.md` 的 TDD RED 章節新增 `tests/test_deck_task_types.py`，確認失敗。
+- [ ] 1.2 實作至 GREEN，範圍限於 `docs/superpowers/specs/design-task-type-taxonomy-v2-spec.md` 的 Requirements（契約檔 `paulsha_cortex/deck/data/task-types.yaml` 與 `paulsha_cortex/deck/task_types.py`）。
 - [ ] 1.3 `changelog.d/design-task-type-taxonomy.md` fragment 與 `CHANGELOG.md [Unreleased]` entry（#139）。
 - [ ] 1.4 `python3 -m pytest tests/ -q` 全綠；帶 PR 上下文的 `policy_check` 0 fail；`git diff --check` 乾淨。
 

--- a/openspec/changes/2026-08-04-feat-work-gc/design.md
+++ b/openspec/changes/2026-08-04-feat-work-gc/design.md
@@ -1,6 +1,6 @@
 ---
 status: accepted
-work_item: feat-work-gc
+work_item: feat-work-gc-v2
 ---
 
 # feat-work-gc Design
@@ -20,4 +20,4 @@ work_item: feat-work-gc
 - closed-unmerged PR 偵測為 best-effort 註記，不參與回收判定；remote branch 刪除與
   registry 壓縮列為非目標。
 
-詳細 D1–D6 與風險緩解見 `docs/superpowers/specs/feat-work-gc-design.md`。
+詳細 D1–D6 與風險緩解見 `docs/superpowers/specs/feat-work-gc-v2-design.md`。

--- a/openspec/changes/2026-08-04-feat-work-gc/proposal.md
+++ b/openspec/changes/2026-08-04-feat-work-gc/proposal.md
@@ -1,6 +1,6 @@
 ---
 status: accepted
-work_item: feat-work-gc
+work_item: feat-work-gc-v2
 ---
 
 ## Goals
@@ -23,4 +23,4 @@ cortex 每批次派工產生的 build 產物沒有生命週期回收，v0.1.0 �
 ## Capabilities
 
 ### Modified Capabilities
-- `governed-delivery-closure`：新增交付後產物回收（proposal-first、內容層 merged 驗證、fail-safe 保留、registry 唯讀）要求；詳見 `docs/superpowers/specs/feat-work-gc-spec.md` 的 Requirements 與 `docs/superpowers/specs/feat-work-gc-design.md` 的 Decisions。
+- `governed-delivery-closure`：新增交付後產物回收（proposal-first、內容層 merged 驗證、fail-safe 保留、registry 唯讀）要求；詳見 `docs/superpowers/specs/feat-work-gc-v2-spec.md` 的 Requirements 與 `docs/superpowers/specs/feat-work-gc-v2-design.md` 的 Decisions。

--- a/openspec/changes/2026-08-04-feat-work-gc/specs/governed-delivery-closure/spec.md
+++ b/openspec/changes/2026-08-04-feat-work-gc/specs/governed-delivery-closure/spec.md
@@ -1,6 +1,6 @@
 ---
 status: accepted
-work_item: feat-work-gc
+work_item: feat-work-gc-v2
 ---
 
 ## ADDED Requirements

--- a/openspec/changes/2026-08-04-feat-work-gc/tasks.md
+++ b/openspec/changes/2026-08-04-feat-work-gc/tasks.md
@@ -1,12 +1,12 @@
 ---
 status: accepted
-work_item: feat-work-gc
+work_item: feat-work-gc-v2
 ---
 
 # Tasks
 
-- [ ] 1.1 RED：依 `docs/superpowers/plans/feat-work-gc.md` 的 TDD RED 章節新增 `tests/test_work_gc.py`，確認失敗。
-- [ ] 1.2 實作至 GREEN，範圍限於 `docs/superpowers/specs/feat-work-gc-spec.md` 的 Requirements（含 `_WORK_HELP` 同步與 `tests/test_cli_help_alignment.py` 斷言）。
+- [ ] 1.1 RED：依 `docs/superpowers/plans/feat-work-gc-v2.md` 的 TDD RED 章節新增 `tests/test_work_gc.py`，確認失敗。
+- [ ] 1.2 實作至 GREEN，範圍限於 `docs/superpowers/specs/feat-work-gc-v2-spec.md` 的 Requirements（含 `_WORK_HELP` 同步與 `tests/test_cli_help_alignment.py` 斷言）。
 - [ ] 1.3 `changelog.d/feat-work-gc.md` fragment 與 `CHANGELOG.md [Unreleased]` entry（#178）。
 - [ ] 1.4 `python3 -m pytest tests/ -q` 全綠；帶 PR 上下文的 `policy_check` 0 fail；`git diff --check` 乾淨。
 


### PR DESCRIPTION
## 摘要

兩個 work item 的三代 run 因基礎設施缺陷鏈（reclaim 短路、載入唯一性、vacuous gate 自述、checkbox drift、verify ledger、retry 失效系列——均已修復並 merge）superseded，觸發世代熔斷（SEMANTIC_RECLAIM_LIMIT=3）。依「-v2 識別」慣例（檔名＋workstream 目錄＋frontmatter work_item＋work-items.yaml＋交叉引用，比照 canary v2 兩段式配方一次到位），於修復齊備的 main 上以新 claim identity 重跑。

- [x] changelog.d fragment（R-09）＋ CHANGELOG entry
- [x] docs-only rename、無程式碼變更
- [x] 本地 policy_check 帶 PR 上下文 fail: 0（僅 R-22 陳年 WARN）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JZKZjogV1MPL8DyiHwRnob