### PR TITLE
docs(planning): -v2 重識別補 excludes 斷開舊識別 source 認領

### DIFF
--- a/.cortex/work-items.yaml
+++ b/.cortex/work-items.yaml
@@ -415,6 +415,22 @@ work_items:
         ref: docs/superpowers/workstreams/fix-repair-commit-recovery/todo.md
       - kind: path
         ref: docs/superpowers/specs/fix-repair-commit-recovery-spec.md
+  feat-work-gc:
+    title: feat-work-gc（已由 -v2 重識別接手；舊 runs 為 superseded 審計）
+    links: []
+    excludes:
+      - kind: openspec
+        ref: 2026-08-04-feat-work-gc
+      - kind: github_issue
+        ref: hamanpaul/paulsha-cortex#178
+  design-task-type-taxonomy:
+    title: design-task-type-taxonomy（已由 -v2 重識別接手；舊 runs 為 superseded 審計）
+    links: []
+    excludes:
+      - kind: openspec
+        ref: 2026-08-04-design-task-type-taxonomy
+      - kind: github_issue
+        ref: hamanpaul/paulsha-cortex#139
   feat-work-gc-v2:
     title: cortex work gc v2 重識別——世代熔斷後續作 (#178)
     links:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 本專案遵循 hamanpaul project policy v1.0.15。
 
 ## [Unreleased]
+### Fixed
+- **-v2 重識別補 excludes 斷開舊識別的 source 認領**：消除 confirmed source collision 造成的 repo provider degraded（比照 dispatch-reliability-batch 先例）。
 ### Changed
 - **feat-work-gc 與 design-task-type-taxonomy 重識別為 -v2（#178／#139）**：三代 run 因基礎設施缺陷鏈 superseded 觸發 #218 世代熔斷，依「-v2 識別」慣例重識別於修復齊備的 main 重跑。
 ### Fixed

--- a/changelog.d/w1-v2-exclusions.md
+++ b/changelog.d/w1-v2-exclusions.md
@@ -1,0 +1,5 @@
+### Fixed
+- **-v2 重識別補 excludes 斷開舊識別的 source 認領**：舊識別的 superseded runs
+  經 workflow metadata 仍 confirmed 認領 openspec／issue source，與 -v2 新連結
+  形成 confirmed source collision → repo provider degraded、Manager 不得派工。
+  比照 dispatch-reliability-batch 先例，舊 work_id 以空 links＋excludes 重登錄。


### PR DESCRIPTION
## 摘要

舊識別的 superseded runs 經 workflow metadata 仍 confirmed 認領 openspec／issue source，與 -v2 新連結形成 confirmed source collision，repo provider degraded、Manager 不得派工。比照既有先例（dispatch-reliability-batch）以空 links＋excludes 重登錄舊 work_id。

- [x] changelog.d fragment（R-09）＋ CHANGELOG entry
- [x] docs-only、無程式碼變更

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JZKZjogV1MPL8DyiHwRnob