### PR TITLE
docs(planning): -v2 excludes 收窄至 openspec ref

### DIFF
--- a/.cortex/work-items.yaml
+++ b/.cortex/work-items.yaml
@@ -421,16 +421,12 @@ work_items:
     excludes:
       - kind: openspec
         ref: 2026-08-04-feat-work-gc
-      - kind: github_issue
-        ref: hamanpaul/paulsha-cortex#178
   design-task-type-taxonomy:
     title: design-task-type-taxonomy（已由 -v2 重識別接手；舊 runs 為 superseded 審計）
     links: []
     excludes:
       - kind: openspec
         ref: 2026-08-04-design-task-type-taxonomy
-      - kind: github_issue
-        ref: hamanpaul/paulsha-cortex#139
   feat-work-gc-v2:
     title: cortex work gc v2 重識別——世代熔斷後續作 (#178)
     links:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ## [Unreleased]
 ### Fixed
+- **-v2 excludes 收窄至 openspec ref**：保留舊識別可尋址性（abandon 需 authority），僅排除實際碰撞的 openspec 認領。
 - **-v2 重識別補 excludes 斷開舊識別的 source 認領**：消除 confirmed source collision 造成的 repo provider degraded（比照 dispatch-reliability-batch 先例）。
 ### Changed
 - **feat-work-gc 與 design-task-type-taxonomy 重識別為 -v2（#178／#139）**：三代 run 因基礎設施缺陷鏈 superseded 觸發 #218 世代熔斷，依「-v2 識別」慣例重識別於修復齊備的 main 重跑。

--- a/changelog.d/w1-v2-exclusions-fix.md
+++ b/changelog.d/w1-v2-exclusions-fix.md
@@ -1,0 +1,5 @@
+### Fixed
+- **-v2 excludes 收窄至 openspec ref**：連 github_issue 一併 exclude 會令舊識別
+  的 work authority 全滅，abandon 無從尋址（confirmed work authority missing）；
+  issue 的 workflow-metadata＋新 yaml 雙認領本不構成 collision，僅 openspec ref
+  需要 exclude。


### PR DESCRIPTION
## 摘要

前一補丁連 github_issue 一併 exclude，令舊識別的 work authority 全滅、abandon 無從尋址（confirmed work authority missing or ambiguous）。issue 的 workflow-metadata＋新 yaml 雙認領本不構成 collision（先前診斷僅列 openspec），僅 openspec ref 需要 exclude。收窄後舊識別可 abandon 釋放 issue source 所有權，-v2 claim 的 source-owner 防線即解。

- [x] changelog.d fragment（R-09）＋ CHANGELOG entry
- [x] docs-only、無程式碼變更

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JZKZjogV1MPL8DyiHwRnob