### PR TITLE
docs(planning): -v2 issue links 暫撤開 abandon 尋址窗口

### DIFF
--- a/.cortex/work-items.yaml
+++ b/.cortex/work-items.yaml
@@ -430,8 +430,6 @@ work_items:
   feat-work-gc-v2:
     title: cortex work gc v2 重識別——世代熔斷後續作 (#178)
     links:
-      - kind: github_issue
-        ref: hamanpaul/paulsha-cortex#178
       - kind: openspec
         ref: 2026-08-04-feat-work-gc
       - kind: path
@@ -441,8 +439,6 @@ work_items:
   design-task-type-taxonomy-v2:
     title: task_type taxonomy v2 重識別——世代熔斷後續作 (#139)
     links:
-      - kind: github_issue
-        ref: hamanpaul/paulsha-cortex#139
       - kind: openspec
         ref: 2026-08-04-design-task-type-taxonomy
       - kind: path

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ## [Unreleased]
 ### Fixed
+- **-v2 issue links 暫撤（abandon 尋址窗口）**：解 issue contested → authority ambiguous → abandon 無從尋址的死鎖；隨後還原並補 excludes（abandon 先於 exclude 的正確時序）。
 - **-v2 excludes 收窄至 openspec ref**：保留舊識別可尋址性（abandon 需 authority），僅排除實際碰撞的 openspec 認領。
 - **-v2 重識別補 excludes 斷開舊識別的 source 認領**：消除 confirmed source collision 造成的 repo provider degraded（比照 dispatch-reliability-batch 先例）。
 ### Changed

--- a/changelog.d/w1-v2-unlink-window.md
+++ b/changelog.d/w1-v2-unlink-window.md
@@ -1,0 +1,5 @@
+### Fixed
+- **-v2 issue links 暫撤（abandon 尋址窗口）**：issue 被新舊識別 contested 時
+  authority 判 ambiguous，舊識別 abandon 無從尋址。暫撤 -v2 的 github_issue
+  links 使舊識別 uncontested 可 abandon；隨後 PR 還原 links 並補舊識別 issue
+  excludes（正確時序：abandon 先於 exclude）。


### PR DESCRIPTION
## 摘要

issue 被新舊識別 contested 時 authority 判 ambiguous，舊識別 abandon 無從尋址（abandon 需認領活著、exclude 會殺認領、去 contested 需 exclude——三方死鎖）。暫撤 -v2 的 github_issue links 使舊識別 uncontested 可 abandon；隨後 PR 還原 links 並補舊識別 issue excludes（正確時序：abandon 先於 exclude）。

- [x] changelog.d fragment（R-09）＋ CHANGELOG entry
- [x] docs-only、無程式碼變更

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JZKZjogV1MPL8DyiHwRnob