### PR TITLE
docs(planning): 舊識別墓碑 todo 開 abandon 尋址窗口

### DIFF
--- a/.cortex/work-items.yaml
+++ b/.cortex/work-items.yaml
@@ -417,13 +417,17 @@ work_items:
         ref: docs/superpowers/specs/fix-repair-commit-recovery-spec.md
   feat-work-gc:
     title: feat-work-gc（已由 -v2 重識別接手；舊 runs 為 superseded 審計）
-    links: []
+    links:
+      - kind: path
+        ref: docs/superpowers/workstreams/feat-work-gc/todo.md
     excludes:
       - kind: openspec
         ref: 2026-08-04-feat-work-gc
   design-task-type-taxonomy:
     title: design-task-type-taxonomy（已由 -v2 重識別接手；舊 runs 為 superseded 審計）
-    links: []
+    links:
+      - kind: path
+        ref: docs/superpowers/workstreams/design-task-type-taxonomy/todo.md
     excludes:
       - kind: openspec
         ref: 2026-08-04-design-task-type-taxonomy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ## [Unreleased]
 ### Fixed
+- **舊識別墓碑 todo（abandon 尋址窗口）**：authority 需檔案級來源，-v2 遷移後舊識別無檔化致 abandon 不可尋址；暫置墓碑 todo，abandon 後移除。
 - **-v2 issue links 暫撤（abandon 尋址窗口）**：解 issue contested → authority ambiguous → abandon 無從尋址的死鎖；隨後還原並補 excludes（abandon 先於 exclude 的正確時序）。
 - **-v2 excludes 收窄至 openspec ref**：保留舊識別可尋址性（abandon 需 authority），僅排除實際碰撞的 openspec 認領。
 - **-v2 重識別補 excludes 斷開舊識別的 source 認領**：消除 confirmed source collision 造成的 repo provider degraded（比照 dispatch-reliability-batch 先例）。

--- a/changelog.d/w1-v2-tombstones.md
+++ b/changelog.d/w1-v2-tombstones.md
@@ -1,0 +1,4 @@
+### Fixed
+- **舊識別墓碑 todo（abandon 尋址窗口）**：可尋址 work authority 需 repo 檔案級
+  來源；-v2 遷移後舊識別無檔化致 abandon 恆 missing or ambiguous。暫置墓碑
+  todo（frontmatter 綁舊識別＋yaml path link），abandon 完成後由終態 PR 移除。

--- a/docs/superpowers/workstreams/design-task-type-taxonomy/todo.md
+++ b/docs/superpowers/workstreams/design-task-type-taxonomy/todo.md
@@ -1,0 +1,10 @@
+---
+status: accepted
+work_item: design-task-type-taxonomy
+---
+
+# design-task-type-taxonomy Todo（墓碑——識別已遷移）
+
+## Tasks
+
+- [x] 識別已由 `design-task-type-taxonomy-v2` 接手（世代熔斷）；本 Todo 僅為 abandon 尋址窗口的暫時墓碑，abandon 完成後由終態 PR 移除。

--- a/docs/superpowers/workstreams/feat-work-gc/todo.md
+++ b/docs/superpowers/workstreams/feat-work-gc/todo.md
@@ -1,0 +1,10 @@
+---
+status: accepted
+work_item: feat-work-gc
+---
+
+# feat-work-gc Todo（墓碑——識別已遷移）
+
+## Tasks
+
+- [x] 識別已由 `feat-work-gc-v2` 接手（世代熔斷）；本 Todo 僅為 abandon 尋址窗口的暫時墓碑，abandon 完成後由終態 PR 移除。


### PR DESCRIPTION
## 摘要

可尋址 work authority 需 repo 檔案級來源（todo frontmatter）；-v2 遷移後舊識別無檔化，abandon 恆 confirmed work authority missing or ambiguous。暫置墓碑 todo（frontmatter 綁舊識別＋yaml path link）使 abandon 可尋址；完成後由終態 PR 移除墓碑並補 excludes。

- [x] changelog.d fragment（R-09）＋ CHANGELOG entry
- [x] docs-only、無程式碼變更

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JZKZjogV1MPL8DyiHwRnob