### PR TITLE
docs(planning): abandon 尋址窗口放寬至全額認領

### DIFF
--- a/.cortex/work-items.yaml
+++ b/.cortex/work-items.yaml
@@ -420,22 +420,14 @@ work_items:
     links:
       - kind: path
         ref: docs/superpowers/workstreams/feat-work-gc/todo.md
-    excludes:
-      - kind: openspec
-        ref: 2026-08-04-feat-work-gc
   design-task-type-taxonomy:
     title: design-task-type-taxonomy（已由 -v2 重識別接手；舊 runs 為 superseded 審計）
     links:
       - kind: path
         ref: docs/superpowers/workstreams/design-task-type-taxonomy/todo.md
-    excludes:
-      - kind: openspec
-        ref: 2026-08-04-design-task-type-taxonomy
   feat-work-gc-v2:
     title: cortex work gc v2 重識別——世代熔斷後續作 (#178)
     links:
-      - kind: openspec
-        ref: 2026-08-04-feat-work-gc
       - kind: path
         ref: docs/superpowers/workstreams/feat-work-gc-v2/todo.md
       - kind: path
@@ -443,8 +435,6 @@ work_items:
   design-task-type-taxonomy-v2:
     title: task_type taxonomy v2 重識別——世代熔斷後續作 (#139)
     links:
-      - kind: openspec
-        ref: 2026-08-04-design-task-type-taxonomy
       - kind: path
         ref: docs/superpowers/workstreams/design-task-type-taxonomy-v2/todo.md
       - kind: path

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ## [Unreleased]
 ### Fixed
+- **abandon 尋址窗口放寬至全額認領**：abandon 校驗 run refs 與 authority 全等；窗口期舊識別全額認領（撤 openspec exclude）、-v2 暫撤 openspec link。
 - **舊識別墓碑 todo（abandon 尋址窗口）**：authority 需檔案級來源，-v2 遷移後舊識別無檔化致 abandon 不可尋址；暫置墓碑 todo，abandon 後移除。
 - **-v2 issue links 暫撤（abandon 尋址窗口）**：解 issue contested → authority ambiguous → abandon 無從尋址的死鎖；隨後還原並補 excludes（abandon 先於 exclude 的正確時序）。
 - **-v2 excludes 收窄至 openspec ref**：保留舊識別可尋址性（abandon 需 authority），僅排除實際碰撞的 openspec 認領。

--- a/changelog.d/w1-v2-full-window.md
+++ b/changelog.d/w1-v2-full-window.md
@@ -1,0 +1,5 @@
+### Fixed
+- **abandon 尋址窗口放寬至全額認領**：abandon 校驗 run refs 與當前 authority
+  全等；舊識別的 openspec exclude 使 refs 永遠 differ。窗口期撤 openspec
+  excludes 並暫撤 -v2 的 openspec links（維持無 collision），abandon 後由
+  終態 PR 一次還原。


### PR DESCRIPTION
## 摘要

abandon 校驗 WorkflowRun refs 與當前 WorkAuthority 全等；舊識別的 openspec exclude 使 refs 永遠 differ、abandon 不可能通過。窗口期：撤舊識別 openspec excludes（全額認領 issue＋openspec＋墓碑 todo）並暫撤 -v2 的 openspec links（維持無 collision）。abandon×2 完成後由終態 PR 一次還原（-v2 全 links 回歸＋舊識別 links 清空＋issue/openspec 全 excludes＋撤墓碑）。

- [x] changelog.d fragment（R-09）＋ CHANGELOG entry
- [x] docs-only、無程式碼變更

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JZKZjogV1MPL8DyiHwRnob