### PR TITLE
feat(coordinator): per-slice executor/model 宣告與 depends_on 顯式診斷

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 本專案遵循 hamanpaul project policy v1.0.15。
 
 ## [Unreleased]
+### Added
+- **Refs #294：slice spec 可宣告 executor/model_id 並於派工前強制 registry 驗證**：`dispatch_ready` 支援逐 slice 的 builder identity 覆寫，unknown identity fail-closed 並列出可用 candidates；同時 `cortex fanout`／`tick` 的明確 `(executor, model)` 與 periodic tick 預設 model 也改為先查 `model-identities.yaml`，避免 typo 直到 session 內才失敗。
 ### Fixed
 - **abandon 尋址窗口放寬至全額認領**：abandon 校驗 run refs 與 authority 全等；窗口期舊識別全額認領（撤 openspec exclude）、-v2 暫撤 openspec link。
 - **舊識別墓碑 todo（abandon 尋址窗口）**：authority 需檔案級來源，-v2 遷移後舊識別無檔化致 abandon 不可尋址；暫置墓碑 todo，abandon 後移除。

--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ cortex bootstrap --instance cortex --repo-root "$(git rev-parse --show-toplevel)
    ```
 
    `--executor`／`--model` 省略時由 daemon 採用部署設定；帶 `--wait [--timeout N]` 時成功為 exit 0、terminal failure 為 exit 1、逾時仍為 exit 3。所有 queue mutation 都可加 `--json` 取得 `cortex-porcelain/run/v1` 輸出。
+   若 spec frontmatter 成對宣告 optional `executor`／`model_id`，fanout/tick 會逐 slice 覆寫這裡的 builder 預設值；命令列明確指定與 spec frontmatter 宣告的 `(executor, model)` 都會先查 `model-identities.yaml`，unknown identity 直接 fail-closed 並列出可用 candidates。
    `cortex run work start/resume/...` 額外支援 `--planner-executor`／`--planner-model`／`--builder-executor`／`--builder-model`／`--reviewer-executor`／`--reviewer-model`：run-scoped 覆寫該 work item 這次 claim 的 planner/builder/reviewer 模型鏈，三段各自獨立、未指定的段落回退共享 `model-identities.yaml`。覆寫只影響這個 run，不改共享設定檔、不影響其他 active run 尚未派出的 card；於 claim（或首次 dispatch）時凍結，之後 resume／retry 沿用凍結值。指定的 identity 仍須通過既有 capability 與 builder/reviewer independence domain 檢查，違反時 CLI 直接回報錯誤原因並列出可用 identity，不會靜默退回共享預設。
 
 11. 用 `recover` 家族執行受限復原；slice/work mutation 的 `--actor` 為必要審計欄位：
@@ -281,7 +282,7 @@ cortex tick \
   --review-model "<reviewer-model-id>"
 ```
 
-`tick` 會依序處理 ready fanout、既有 Job 輪詢、deterministic verification、必要的 foreign review 與 completion 判斷。`--model` / `--review-model` 原樣傳給 executor，能否使用仍取決於該 CLI 與帳號權限。不要在一般操作加入 `--allow-unsafe`；它會旁路 executor approval/sandbox，且只允許單一 ready slice canary。
+`tick` 會依序處理 ready fanout、既有 Job 輪詢、deterministic verification、必要的 foreign review 與 completion 判斷。`--executor`／`--model` 是整批 builder 預設值；spec frontmatter 若成對宣告 `executor`／`model_id`，會逐 slice 覆寫且沿用同一套 commit-required／approval-safety 語意。命令列明確指定與 per-slice 覆寫的 `(executor, model)` 都必須存在於 `model-identities.yaml`，才會真正進 executor argv。不要在一般操作加入 `--allow-unsafe`；它會旁路 executor approval/sandbox，且只允許單一 ready slice canary。
 
 若 fanout 發生 `dispatch` 例外，`tick` 回傳仍包含 `completed` 與 `dispatched`，並在 `errors` 按 slice 回報 `slice_id`、`type`、`message`，讓上層在部分派送成功時仍可見完整狀態。
 
@@ -477,6 +478,7 @@ identities:
 
 - schema v1 仍可讀取並由 runtime 正規化；新設定使用 schema v2 的 `capabilities` / `live_probe`。packaged registry 已登錄 canonical agy identity，自訂檔不得以不同內容 shadow 它。
 - planner/builder/reviewer 必須是 explicit `(executor, model_id)` 且可解析；agy 只有在 `doctor --probe-live` 的 model discovery 與 plan/sandbox smoke 都吻合時才可用。
+- fanout/tick 明確指定的 builder `(executor, model_id)`，以及 spec frontmatter 成對宣告的 `executor`／`model_id`，都會先查這份 registry；unknown identity 會在派工前 fail-closed 並列出可用 candidates。
 - workflow reviewer 只會選擇明示 `capabilities: [review]` 且與 Builder 不同 independence domain 的 schema v2 identity；legacy v1 identity 只取得 planning capability，不能被猜成 reviewer。
 - Verify/Review 以 executor 的 enforced read-only mode在exact Candidate的remote-free disposable clone檢查；Claude reviewer固定使用`dontAsk`與`safe-mode`，只暴露OS-sandboxed Bash並要求structured JSON object，不載入Candidate `CLAUDE.md`/skills/plugins/MCP/remote session，也不進Plan Mode。Filesystem預設拒讀整個home、`/run/user`與Docker sockets，只重開Candidate與Python user-site工具鏈，並對Candidate clone設deny-write；review subprocess只保留`PATH`、`HOME`、locale、`TMPDIR`、`VIRTUAL_ENV`等非密鑰基礎環境，且不啟動login shell。Linux/WSL host必須安裝`bubblewrap`、`socat`與官方sandbox runtime（Ubuntu可用`sudo apt-get install bubblewrap socat`，再用`npm install -g @anthropic-ai/sandbox-runtime`）；任一依賴缺失、Unix-socket seccomp失效或命令要求unsandboxed fallback都拒絕啟動。Manager在所有terminal/launch failure/operator retry路徑重驗原Candidate完整tree snapshot後清除clone。agent只回傳substantive result、findings與inline report body；report僅能發布至phase專屬的`reports/verify/*.md`或`reports/review/*.md`，並由durable publication journal把多檔CAS、canonical evidence與registry bind組成可rollback/roll-forward的transaction。Manager會從durable Job注入Candidate、builder/reviewer job ID與launch identity，agent不取得report或Candidate寫入權。
 - `cortex doctor`會在identity registry配置Claude `review` capability時把Claude Code 2.1.187+、必要CLI flags、`bubblewrap`、`socat`與`srt`執行能力列為required probe；`--probe-live`另跑native read-only與Unix-socket seccomp smoke。沒有Claude reviewer的部署只顯示非必要warn。Claude的protected bind targets位於deterministic disposable session root，exact Candidate則固定在其無污染的`candidate/` checkout。

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ cortex bootstrap --instance cortex --repo-root "$(git rev-parse --show-toplevel)
    ```
 
    `--executor`／`--model` 省略時由 daemon 採用部署設定；帶 `--wait [--timeout N]` 時成功為 exit 0、terminal failure 為 exit 1、逾時仍為 exit 3。所有 queue mutation 都可加 `--json` 取得 `cortex-porcelain/run/v1` 輸出。
-   若 spec frontmatter 成對宣告 optional `executor`／`model_id`，fanout/tick 會逐 slice 覆寫這裡的 builder 預設值；命令列明確指定與 spec frontmatter 宣告的 `(executor, model)` 都會先查 `model-identities.yaml`，unknown identity 直接 fail-closed 並列出可用 candidates。
+   若 spec frontmatter 成對宣告 optional `executor`／`model_id`，fanout/tick 會逐 slice 覆寫這裡的 builder 預設值；命令列明確指定與 spec frontmatter 宣告的 `(executor, model_id)` 都會先查 `model-identities.yaml`，unknown identity 直接 fail-closed 並列出可用 candidates。
    `cortex run work start/resume/...` 額外支援 `--planner-executor`／`--planner-model`／`--builder-executor`／`--builder-model`／`--reviewer-executor`／`--reviewer-model`：run-scoped 覆寫該 work item 這次 claim 的 planner/builder/reviewer 模型鏈，三段各自獨立、未指定的段落回退共享 `model-identities.yaml`。覆寫只影響這個 run，不改共享設定檔、不影響其他 active run 尚未派出的 card；於 claim（或首次 dispatch）時凍結，之後 resume／retry 沿用凍結值。指定的 identity 仍須通過既有 capability 與 builder/reviewer independence domain 檢查，違反時 CLI 直接回報錯誤原因並列出可用 identity，不會靜默退回共享預設。
 
 11. 用 `recover` 家族執行受限復原；slice/work mutation 的 `--actor` 為必要審計欄位：
@@ -282,7 +282,7 @@ cortex tick \
   --review-model "<reviewer-model-id>"
 ```
 
-`tick` 會依序處理 ready fanout、既有 Job 輪詢、deterministic verification、必要的 foreign review 與 completion 判斷。`--executor`／`--model` 是整批 builder 預設值；spec frontmatter 若成對宣告 `executor`／`model_id`，會逐 slice 覆寫且沿用同一套 commit-required／approval-safety 語意。命令列明確指定與 per-slice 覆寫的 `(executor, model)` 都必須存在於 `model-identities.yaml`，才會真正進 executor argv。不要在一般操作加入 `--allow-unsafe`；它會旁路 executor approval/sandbox，且只允許單一 ready slice canary。
+`tick` 會依序處理 ready fanout、既有 Job 輪詢、deterministic verification、必要的 foreign review 與 completion 判斷。`--executor`／`--model` 是整批 builder 預設值；spec frontmatter 若成對宣告 `executor`／`model_id`，會逐 slice 覆寫且沿用同一套 commit-required／approval-safety 語意。命令列明確指定與 per-slice 覆寫的 `(executor, model_id)` 都必須存在於 `model-identities.yaml`，才會真正進 executor argv。不要在一般操作加入 `--allow-unsafe`；它會旁路 executor approval/sandbox，且只允許單一 ready slice canary。
 
 若 fanout 發生 `dispatch` 例外，`tick` 回傳仍包含 `completed` 與 `dispatched`，並在 `errors` 按 slice 回報 `slice_id`、`type`、`message`，讓上層在部分派送成功時仍可見完整狀態。
 

--- a/changelog.d/feat-slice-executor-model.md
+++ b/changelog.d/feat-slice-executor-model.md
@@ -1,0 +1,2 @@
+### Added
+- **Refs #294：slice spec 可宣告 executor/model_id 並於派工前強制 registry 驗證**：`dispatch_ready` 支援逐 slice 的 builder identity 覆寫，unknown identity fail-closed 並列出可用 candidates；同時 `cortex fanout`／`tick` 的明確 `(executor, model)` 與 periodic tick 預設 model 也改為先查 `model-identities.yaml`，避免 typo 直到 session 內才失敗。

--- a/docs/superpowers/specs/fix-deck-emit-frontmatter-dispatch-contract.md
+++ b/docs/superpowers/specs/fix-deck-emit-frontmatter-dispatch-contract.md
@@ -11,6 +11,7 @@
   - `checks`
   - `tests`
   - `full_suite`
+- `executor` / `model_id`：optional，但必須成對宣告且皆為非空字串；宣告時 manager 會先用 `model-identities.yaml` 驗證該 `(executor, model_id)` 是否已註冊，未宣告時沿用 fanout/tick 的 builder 預設值。Deck compile 本身不會自動輸出這兩欄，需要 operator 在確定要逐 slice 覆寫時手動補上。
 
 ### `checks` 要求
 

--- a/docs/superpowers/workstreams/feat-slice-executor-model/todo.md
+++ b/docs/superpowers/workstreams/feat-slice-executor-model/todo.md
@@ -7,8 +7,8 @@ work_item: feat-slice-executor-model
 
 ## Tasks
 
-- [ ] 將 issue #294、active OpenSpec change `2026-08-04-feat-slice-executor-model` 與本 Todo 綁定為同一 confirmed Work Item。
-- [ ] coordinator 派工 copilot（gpt-5.4）以 TDD 完成 #294：先依 `docs/superpowers/plans/feat-slice-executor-model.md` 寫 RED 測試，再實作到 GREEN。
-- [ ] ForeignReview（claude/sonnet）review 通過；operator 驗收核可。
-- [ ] `changelog.d/feat-slice-executor-model.md` fragment 已新增且已 commit（R-09 硬性 gate）；`CHANGELOG.md [Unreleased]` 有對應 entry。
-- [ ] 帶 PR 上下文執行 `policy_check`（`--pr-title`／`--pr-body`／`--pr-labels`／`--pr-base-ref`／`--pr-head-ref`）確認 fail: 0；全套 pytest 通過。
+- [x] 將 issue #294、active OpenSpec change `2026-08-04-feat-slice-executor-model` 與本 Todo 綁定為同一 confirmed Work Item。
+- [x] coordinator 派工 copilot（gpt-5.4）以 TDD 完成 #294：先依 `docs/superpowers/plans/feat-slice-executor-model.md` 寫 RED 測試，再實作到 GREEN。
+- [x] ForeignReview（claude/sonnet）review 通過；operator 驗收核可。
+- [x] `changelog.d/feat-slice-executor-model.md` fragment 已新增且已 commit（R-09 硬性 gate）；`CHANGELOG.md [Unreleased]` 有對應 entry。
+- [x] 帶 PR 上下文執行 `policy_check`（`--pr-title`／`--pr-body`／`--pr-labels`／`--pr-base-ref`／`--pr-head-ref`）確認 fail: 0；全套 pytest 通過。

--- a/openspec/changes/2026-08-04-feat-slice-executor-model/tasks.md
+++ b/openspec/changes/2026-08-04-feat-slice-executor-model/tasks.md
@@ -6,9 +6,9 @@ work_item: feat-slice-executor-model
 # Tasks
 
 - [x] 1.1 RED：依 `docs/superpowers/plans/feat-slice-executor-model.md` 的 TDD RED 章節新增 `tests/test_slice_executor_model.py`，確認全部失敗。
-- [ ] 1.2 實作至 GREEN，範圍限於 `docs/superpowers/specs/feat-slice-executor-model-spec.md` 的 Requirements（R1–R5）；未宣告 per-slice identity 的路徑行為位元不變，不動 #295 的 persona catalog 來源邏輯與 #205 的 workflow model chain override。
-- [ ] 1.3 `changelog.d/feat-slice-executor-model.md` fragment 與 `CHANGELOG.md [Unreleased]` entry（#294）；CLI help、README、auto dispatch 契約文件同步。
-- [ ] 1.4 `python3 -m pytest tests/ -q` 全綠；帶 PR 上下文的 `policy_check` 0 fail；`git diff --check` 乾淨。
+- [x] 1.2 實作至 GREEN，範圍限於 `docs/superpowers/specs/feat-slice-executor-model-spec.md` 的 Requirements（R1–R5）；未宣告 per-slice identity 的路徑行為位元不變，不動 #295 的 persona catalog 來源邏輯與 #205 的 workflow model chain override。
+- [x] 1.3 `changelog.d/feat-slice-executor-model.md` fragment 與 `CHANGELOG.md [Unreleased]` entry（#294）；CLI help、README、auto dispatch 契約文件同步。
+- [x] 1.4 `python3 -m pytest tests/ -q` 全綠；帶 PR 上下文的 `policy_check` 0 fail；`git diff --check` 乾淨。
 
 ## 驗收
 

--- a/openspec/changes/2026-08-04-feat-slice-executor-model/tasks.md
+++ b/openspec/changes/2026-08-04-feat-slice-executor-model/tasks.md
@@ -5,7 +5,7 @@ work_item: feat-slice-executor-model
 
 # Tasks
 
-- [ ] 1.1 RED：依 `docs/superpowers/plans/feat-slice-executor-model.md` 的 TDD RED 章節新增 `tests/test_slice_executor_model.py`，確認全部失敗。
+- [x] 1.1 RED：依 `docs/superpowers/plans/feat-slice-executor-model.md` 的 TDD RED 章節新增 `tests/test_slice_executor_model.py`，確認全部失敗。
 - [ ] 1.2 實作至 GREEN，範圍限於 `docs/superpowers/specs/feat-slice-executor-model-spec.md` 的 Requirements（R1–R5）；未宣告 per-slice identity 的路徑行為位元不變，不動 #295 的 persona catalog 來源邏輯與 #205 的 workflow model chain override。
 - [ ] 1.3 `changelog.d/feat-slice-executor-model.md` fragment 與 `CHANGELOG.md [Unreleased]` entry（#294）；CLI help、README、auto dispatch 契約文件同步。
 - [ ] 1.4 `python3 -m pytest tests/ -q` 全綠；帶 PR 上下文的 `policy_check` 0 fail；`git diff --check` 乾淨。

--- a/paulsha_cortex/coordinator/autonomy.py
+++ b/paulsha_cortex/coordinator/autonomy.py
@@ -62,7 +62,8 @@ def _split_frontmatter(text: str) -> str | None:
 def parse_spec_frontmatter(path) -> dict:
     """解析 superpowers spec 開頭 --- frontmatter。
 
-    回 {path, dispatch, slice_id, plan, depends_on, executor, model_id}。
+    回 {path, dispatch, slice_id, plan, depends_on, target_branch, verification,
+    executor, model_id, parse_error}。
     硬約束：dispatch 僅在字面值為 'auto' 時為 'auto'，其餘一律 'hold'（fail-safe）。
     容忍無 frontmatter（視為 hold），不 raise。
     """
@@ -495,11 +496,19 @@ def dispatch_ready(
         try:
             prompt = build_dispatch_prompt(persona, task=slice_id, plan_path=m["plan"])
             pinned_inputs = pin_dispatch_inputs(m)
+            # best-effort baseline（reviewer #333-1）：identity/launcher_factory 檢查
+            # 或 base_sha 解析若晚點失敗，slice 落 needs_human 後 dispatch_base 不會
+            # 再被更新（見下方 _mark_slice_needs_human），故先嘗試取現有 branch head
+            # 存底；branch 尚未建立（首次派工常態）時取不到，None 為預期落點。
+            try:
+                early_dispatch_head: str | None = runner(["rev-parse", _branch_for_slice(slice_id)])
+            except Exception:
+                early_dispatch_head = None
             _record_pending_slice(
                 dispatcher=dispatcher,
                 slice_id=slice_id,
                 pinned_inputs=pinned_inputs,
-                dispatch_base=None,
+                dispatch_base=early_dispatch_head,
             )
             active_launcher = launcher
             executor = m.get("executor")

--- a/paulsha_cortex/coordinator/autonomy.py
+++ b/paulsha_cortex/coordinator/autonomy.py
@@ -11,6 +11,7 @@ from . import completion
 from .contract_command import build_dispatch_prompt
 from .dispatcher import _default_git_runner
 from .launcher import AgentLauncher, LaunchHandle
+from .model_identities import load_model_identities
 from . import verification
 
 # is_satisfied predicate 型別：收 slice_id，回該相依是否「已滿足」（可釋放下游）。
@@ -61,7 +62,7 @@ def _split_frontmatter(text: str) -> str | None:
 def parse_spec_frontmatter(path) -> dict:
     """解析 superpowers spec 開頭 --- frontmatter。
 
-    回 {path, dispatch, slice_id, plan, depends_on}。
+    回 {path, dispatch, slice_id, plan, depends_on, executor, model_id}。
     硬約束：dispatch 僅在字面值為 'auto' 時為 'auto'，其餘一律 'hold'（fail-safe）。
     容忍無 frontmatter（視為 hold），不 raise。
     """
@@ -77,6 +78,8 @@ def parse_spec_frontmatter(path) -> dict:
         "depends_on": [],
         "target_branch": None,
         "verification": None,
+        "executor": None,
+        "model_id": None,
         "parse_error": None,
     }
     if block is None:
@@ -107,6 +110,8 @@ def parse_spec_frontmatter(path) -> dict:
         meta["target_branch"] = (
             data.get("target_branch") if isinstance(data.get("target_branch"), str) else None
         )
+        meta["executor"] = data.get("executor") if isinstance(data.get("executor"), str) else None
+        meta["model_id"] = data.get("model_id") if isinstance(data.get("model_id"), str) else None
         meta["parse_error"] = exc.as_payload()
         return meta
 
@@ -119,6 +124,8 @@ def _normalize_frontmatter(path: Path, data: dict) -> dict:
         "depends_on",
         "target_branch",
         "verification",
+        "executor",
+        "model_id",
         "parse_error",
     }
     extras = set(data) - allowed
@@ -136,6 +143,8 @@ def _normalize_frontmatter(path: Path, data: dict) -> dict:
         "depends_on": _normalize_depends_on(data.get("depends_on")),
         "target_branch": None,
         "verification": None,
+        "executor": None,
+        "model_id": None,
         "parse_error": None,
     }
     plan = data.get("plan")
@@ -169,6 +178,24 @@ def _normalize_frontmatter(path: Path, data: dict) -> dict:
     elif dispatch == "auto":
         raise verification.ContractValidationError(
             "verification", "auto dispatch requires a verification contract"
+        )
+    has_executor = data.get("executor") is not None
+    has_model_id = data.get("model_id") is not None
+    if has_executor != has_model_id:
+        missing = "model_id" if has_executor else "executor"
+        counterpart = "executor" if missing == "model_id" else "model_id"
+        raise verification.ContractValidationError(
+            missing,
+            f"{missing} must be declared together with {counterpart}",
+        )
+    if has_executor:
+        meta["executor"] = verification.normalize_non_empty_string(
+            data.get("executor"),
+            field="executor",
+        )
+        meta["model_id"] = verification.normalize_non_empty_string(
+            data.get("model_id"),
+            field="model_id",
         )
     if data.get("parse_error") is not None:
         raise verification.ContractValidationError(
@@ -313,12 +340,27 @@ def _build_graph(metas: list[dict]) -> dict[str, list[str]]:
     return graph
 
 
+def classify_batch_dependency(
+    dep: str,
+    *,
+    batch_ids: set[str],
+    handoff_dir: str,
+) -> str | None:
+    if dep in batch_ids:
+        return None
+    manifest_path = Path(handoff_dir) / f"{dep}.json"
+    if manifest_path.is_file():
+        return f"deps-external:{dep}"
+    return f"deps-unknown:{dep}"
+
+
 def detect_cycles(metas: list[dict]) -> None:
     """以 slice_id 為節點、depends_on 為有向邊偵測循環相依。
 
     成環 → raise ValueError（帶 cycle path）。
     重複 slice_id → raise ValueError（先於 DFS，見 _build_graph）。
-    指向不在 metas 的 slice_id 的邊不算環（外部/未掃到，交給 is_satisfied）。
+    指向不在 metas 的 slice_id 的邊不算環（外部/未掃到；診斷責任在
+    classify_batch_dependency）。
     """
     graph = _build_graph(metas)
 
@@ -409,6 +451,8 @@ def dispatch_ready(
     git_runner=None,
     launcher: AgentLauncher | None = None,
     handoff_dir: str = DEFAULT_HANDOFF_DIR,
+    identity_registry=None,
+    launcher_factory=None,
 ) -> list[dict]:
     """算就緒集，對每單位經注入的 headless AgentLauncher 各啟一個 agent（一單位一 job）。
 
@@ -441,6 +485,7 @@ def dispatch_ready(
         if callable(commit_required_factory):
             launcher = commit_required_factory()
     runner = git_runner or _default_git_runner
+    resolved_identity_registry = identity_registry
     jobs: list[dict] = []
     errors: list[tuple[str, Exception]] = []
     for m in ready:
@@ -450,6 +495,36 @@ def dispatch_ready(
         try:
             prompt = build_dispatch_prompt(persona, task=slice_id, plan_path=m["plan"])
             pinned_inputs = pin_dispatch_inputs(m)
+            _record_pending_slice(
+                dispatcher=dispatcher,
+                slice_id=slice_id,
+                pinned_inputs=pinned_inputs,
+                dispatch_base=None,
+            )
+            active_launcher = launcher
+            executor = m.get("executor")
+            model_id = m.get("model_id")
+            if isinstance(executor, str) and executor and isinstance(model_id, str) and model_id:
+                if resolved_identity_registry is None:
+                    resolved_identity_registry = load_model_identities()
+                identity = resolved_identity_registry.get(executor, model_id)
+                if identity is None:
+                    available = ", ".join(
+                        f"{item.executor}/{item.model_id}"
+                        for item in resolved_identity_registry.identities
+                    ) or "(none)"
+                    raise ValueError(
+                        f"spec identity unknown: {executor}/{model_id}（可用 candidates: {available}）"
+                    )
+                if launcher_factory is None:
+                    raise ValueError(
+                        f"slice {slice_id} declares executor/model_id but launcher_factory is unavailable"
+                    )
+                active_launcher = launcher_factory(identity)
+                if persona == "builder":
+                    commit_required_factory = getattr(active_launcher, "as_commit_required", None)
+                    if callable(commit_required_factory):
+                        active_launcher = commit_required_factory()
             base_sha = _resolve_target_base_sha(
                 meta=m,
                 pinned_inputs=pinned_inputs,
@@ -462,12 +537,6 @@ def dispatch_ready(
                 dispatch_head: str | None = runner(["rev-parse", _branch_for_slice(slice_id)])
             except Exception:
                 dispatch_head = None
-            _record_pending_slice(
-                dispatcher=dispatcher,
-                slice_id=slice_id,
-                pinned_inputs=pinned_inputs,
-                dispatch_base=base_sha or dispatch_head,
-            )
             log_dir = str(Path("runtime/dispatch") / slice_id)
             # 在 launch 前先落地 registry row：Popen 之後、記錄完成之前若 daemon
             # 崩潰，仍有可回收的 job 列（否則 agent 在跑卻無 job / in_flight / 輪詢）。
@@ -484,7 +553,7 @@ def dispatch_ready(
                 builder_job_id=job.get("job_id"),
                 dispatch_base=base_sha or dispatch_head,
             )
-            handle = launcher.launch(
+            handle = active_launcher.launch(
                 slice_id=slice_id,
                 prompt=prompt,
                 worktree=worktree,

--- a/paulsha_cortex/coordinator/cli.py
+++ b/paulsha_cortex/coordinator/cli.py
@@ -102,7 +102,14 @@ def _build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="高風險：旁路 executor approval/sandbox；只允許單一 ready slice canary",
     )
-    p_fanout.add_argument("--model", default=None, help="原樣傳給 builder executor 的 model ID")
+    p_fanout.add_argument(
+        "--model",
+        default=None,
+        help=(
+            "builder model ID 預設值；spec frontmatter 宣告 executor/model_id 時逐 slice 覆寫；"
+            "明確指定的 (executor, model) 須為 model-identities 已註冊身分"
+        ),
+    )
 
     p_complete = sub.add_parser(
         "complete",
@@ -180,7 +187,14 @@ def _build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="高風險：旁路 executor approval/sandbox；只允許單一 ready slice canary",
     )
-    p_tick.add_argument("--model", default=None, help="原樣傳給 builder executor 的 model ID")
+    p_tick.add_argument(
+        "--model",
+        default=None,
+        help=(
+            "builder model ID 預設值；spec frontmatter 宣告 executor/model_id 時逐 slice 覆寫；"
+            "明確指定的 (executor, model) 須為 model-identities 已註冊身分"
+        ),
+    )
     p_tick.add_argument(
         "--review-executor", choices=sorted(_ARGV_BUILDERS), default=None,
         help="foreign reviewer executor",
@@ -238,8 +252,27 @@ def main(
     if args.cmd == "ready":
         predicate = is_satisfied if is_satisfied is not None else autonomy.default_is_satisfied
         metas = autonomy.scan_specs(args.specs_dir)
+        batch_ids = {
+            slice_id
+            for meta in metas
+            if isinstance((slice_id := meta.get("slice_id")), str) and slice_id
+        }
         try:
             ready = autonomy.ready_units(metas, predicate)
+            for meta in metas:
+                slice_id = meta.get("slice_id")
+                if not isinstance(slice_id, str) or not slice_id:
+                    continue
+                for dep in meta.get("depends_on", []):
+                    if predicate(dep):
+                        continue
+                    reason = autonomy.classify_batch_dependency(
+                        dep,
+                        batch_ids=batch_ids,
+                        handoff_dir=autonomy.DEFAULT_HANDOFF_DIR,
+                    )
+                    if reason and reason.startswith("deps-unknown:"):
+                        print(f"診斷: {slice_id} {reason}", file=sys.stderr)
             print(json.dumps(ready, ensure_ascii=False))
             return 0
         except (ValueError, autonomy.DispatchReadyRequiresLauncherError) as exc:

--- a/paulsha_cortex/coordinator/cli.py
+++ b/paulsha_cortex/coordinator/cli.py
@@ -107,7 +107,7 @@ def _build_parser() -> argparse.ArgumentParser:
         default=None,
         help=(
             "builder model ID 預設值；spec frontmatter 宣告 executor/model_id 時逐 slice 覆寫；"
-            "明確指定的 (executor, model) 須為 model-identities 已註冊身分"
+            "明確指定的 (executor, model_id) 須為 model-identities 已註冊身分"
         ),
     )
 
@@ -192,7 +192,7 @@ def _build_parser() -> argparse.ArgumentParser:
         default=None,
         help=(
             "builder model ID 預設值；spec frontmatter 宣告 executor/model_id 時逐 slice 覆寫；"
-            "明確指定的 (executor, model) 須為 model-identities 已註冊身分"
+            "明確指定的 (executor, model_id) 須為 model-identities 已註冊身分"
         ),
     )
     p_tick.add_argument(

--- a/paulsha_cortex/coordinator/manager.py
+++ b/paulsha_cortex/coordinator/manager.py
@@ -1855,6 +1855,8 @@ def run_tick(
     reaper: Callable[[], dict] | None = None,
     review_executor: str | None = None,
     review_model: str | None = None,
+    identity_registry=None,
+    launcher_factory=None,
 ) -> dict:
     """跑完整 manager tick：fanout（dispatch_ready）→ complete_tick →（可選）收尾 janitor。
 
@@ -1895,6 +1897,8 @@ def run_tick(
                 launcher=launcher,
                 git_runner=getattr(dispatcher, "_git_runner", None),
                 handoff_dir=handoff_dir,
+                identity_registry=identity_registry,
+                launcher_factory=launcher_factory,
             )
         except autonomy.DispatchReadyError as exc:
             dispatched = list(exc.jobs)

--- a/paulsha_cortex/coordinator/manager_daemon.py
+++ b/paulsha_cortex/coordinator/manager_daemon.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
-import json
 import argparse
 import fcntl
+import inspect
+import json
 import os
 import re
 import signal
@@ -229,7 +230,53 @@ def _in_flight_status(registry) -> list[dict[str, Any]]:
     return in_flight
 
 
-def _held_reasons(meta: dict[str, Any], is_satisfied: Callable[[str], bool]) -> list[str]:
+def _available_identity_candidates(identity_registry) -> str:
+    identities = getattr(identity_registry, "identities", ())
+    return ", ".join(
+        f"{identity.executor}/{identity.model_id}"
+        for identity in identities
+        if isinstance(getattr(identity, "executor", None), str)
+        and isinstance(getattr(identity, "model_id", None), str)
+    ) or "(none)"
+
+
+def _require_registered_identity(*, identity_registry, executor: str, model_id: str, context: str):
+    identity = identity_registry.get(executor, model_id)
+    if identity is None:
+        available = _available_identity_candidates(identity_registry)
+        raise ValueError(f"{context}: {executor}/{model_id}（可用 candidates: {available}）")
+    return identity
+
+
+def _call_with_supported_kwargs(func, *args, **kwargs):
+    try:
+        signature = inspect.signature(func)
+    except (TypeError, ValueError):
+        return func(*args, **kwargs)
+    if any(
+        parameter.kind == inspect.Parameter.VAR_KEYWORD
+        for parameter in signature.parameters.values()
+    ):
+        return func(*args, **kwargs)
+    supported = {
+        name
+        for name, parameter in signature.parameters.items()
+        if parameter.kind in {
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            inspect.Parameter.KEYWORD_ONLY,
+        }
+    }
+    filtered_kwargs = {name: value for name, value in kwargs.items() if name in supported}
+    return func(*args, **filtered_kwargs)
+
+
+def _held_reasons(
+    meta: dict[str, Any],
+    is_satisfied: Callable[[str], bool],
+    *,
+    batch_ids: set[str],
+    handoff_dir: str,
+) -> list[str]:
     reasons: list[str] = []
     if isinstance(meta.get("parse_error"), dict):
         reasons.append(f"parse-error:{meta['parse_error'].get('field', 'frontmatter')}")
@@ -239,7 +286,12 @@ def _held_reasons(meta: dict[str, Any], is_satisfied: Callable[[str], bool]) -> 
         reasons.append("dispatch-hold")
     for dep in meta.get("depends_on", []):
         if not is_satisfied(dep):
-            reasons.append(f"deps-unsatisfied:{dep}")
+            reason = autonomy.classify_batch_dependency(
+                dep,
+                batch_ids=batch_ids,
+                handoff_dir=handoff_dir,
+            )
+            reasons.append(reason or f"deps-unsatisfied:{dep}")
     return reasons
 
 
@@ -316,6 +368,11 @@ def build_runtime_status_provider(
             handoff_dir=handoff_dir,
             git_runner=git_runner,
         )
+        batch_ids = {
+            slice_id
+            for meta in metas
+            if isinstance((slice_id := meta.get("slice_id")), str) and slice_id
+        }
         ready_units = ready_units_fn(metas, predicate)
         ready = [meta["slice_id"] for meta in ready_units]
         ready_ids = set(ready)
@@ -326,7 +383,12 @@ def build_runtime_status_provider(
                 continue
             if slice_id in ready_ids:
                 continue
-            reasons = _held_reasons(meta, predicate)
+            reasons = _held_reasons(
+                meta,
+                predicate,
+                batch_ids=batch_ids,
+                handoff_dir=handoff_dir,
+            )
             if reasons:
                 held.append({"slice_id": slice_id, "reasons": reasons})
         slices: list[dict[str, Any]] = []
@@ -397,13 +459,32 @@ def build_request_executor(
         requested_model = args.get("model", default_model)
         requested_review_executor = args.get("review_executor", default_review_executor)
         requested_review_model = args.get("review_model", default_review_model)
+        request_type = request["type"]
         active_review_launcher = _resolve_launcher(
             requested_review_executor,
             launcher,
             allow_unsafe=allow_unsafe,
             model=requested_review_model,
         )
-        if request["type"] == "workflow-action":
+        builder_identity_registry = None
+        builder_launcher_factory = None
+        if request_type in {"dispatch", "fanout", "tick"}:
+            builder_identity_registry = workflow_identity_registry or load_model_identities()
+            builder_launcher_factory = lambda identity: _resolve_launcher(
+                identity.executor,
+                launcher,
+                allow_unsafe=allow_unsafe,
+                model=identity.model_id,
+            )
+            requested_executor = args.get("executor", default_executor)
+            if isinstance(requested_executor, str) and requested_executor and isinstance(requested_model, str) and requested_model:
+                _require_registered_identity(
+                    identity_registry=builder_identity_registry,
+                    executor=requested_executor,
+                    model_id=requested_model,
+                    context=f"{request_type} request 指定的 identity 不存在於 registry",
+                )
+        if request_type == "workflow-action":
             registry = getattr(dispatcher, "_registry", None)
             if registry is None:
                 raise RuntimeError("workflow-action requires dispatcher._registry")
@@ -489,7 +570,7 @@ def build_request_executor(
                     if job is not None:
                         result["job_id"] = job["job_id"]
             return result
-        if request["type"] == "work-action":
+        if request_type == "work-action":
             registry = getattr(dispatcher, "_registry", None)
             if registry is None:
                 raise RuntimeError("work-action requires dispatcher._registry")
@@ -585,7 +666,7 @@ def build_request_executor(
                         if job is not None:
                             result["result"]["job_id"] = job["job_id"]
             return result
-        if request["type"] == "complete":
+        if request_type == "complete":
             complete_metas = scan_specs_fn(request_specs_dir) if args.get("specs_dir") else None
             complete_kwargs = {
                 "handoff_dir": request_handoff_dir,
@@ -603,7 +684,7 @@ def build_request_executor(
                 dispatcher,
                 **complete_kwargs,
             )
-        if request["type"] == "slice-action":
+        if request_type == "slice-action":
             slice_id = args.get("slice_id")
             action = args.get("action")
             actor = args.get("actor")
@@ -633,7 +714,7 @@ def build_request_executor(
                 git_runner=getattr(dispatcher, "_git_runner", None),
             )
         metas = scan_specs_fn(request_specs_dir)
-        if request["type"] == "dispatch":
+        if request_type == "dispatch":
             slice_id = args.get("slice_id")
             target = next((meta for meta in metas if meta.get("slice_id") == slice_id), None)
             if target is None:
@@ -668,7 +749,8 @@ def build_request_executor(
                 allow_unsafe=allow_unsafe,
                 model=requested_model,
             )
-            dispatched = dispatch_ready_fn(
+            dispatched = _call_with_supported_kwargs(
+                dispatch_ready_fn,
                 [{**target, "dispatch": "auto"}],
                 lambda _slice_id: True,
                 dispatcher,
@@ -676,6 +758,8 @@ def build_request_executor(
                 launcher=active_launcher,
                 handoff_dir=request_handoff_dir,
                 git_runner=getattr(dispatcher, "_git_runner", None),
+                identity_registry=builder_identity_registry,
+                launcher_factory=builder_launcher_factory,
             )
             job = dispatched[0]
             if registry is None:
@@ -703,8 +787,9 @@ def build_request_executor(
             allow_unsafe=allow_unsafe,
             model=requested_model,
         )
-        if request["type"] == "fanout":
-            jobs = dispatch_ready_fn(
+        if request_type == "fanout":
+            jobs = _call_with_supported_kwargs(
+                dispatch_ready_fn,
                 metas,
                 predicate,
                 dispatcher,
@@ -712,6 +797,8 @@ def build_request_executor(
                 launcher=active_launcher,
                 handoff_dir=request_handoff_dir,
                 git_runner=getattr(dispatcher, "_git_runner", None),
+                identity_registry=builder_identity_registry,
+                launcher_factory=builder_launcher_factory,
             )
             return {
                 "dispatch_skipped": False,
@@ -729,6 +816,8 @@ def build_request_executor(
             "require_idle": bool(args.get("require_idle", False)),
             "max_load": float(args.get("max_load", default_max_load)),
             "reaper": reaper,
+            "identity_registry": builder_identity_registry,
+            "launcher_factory": builder_launcher_factory,
         }
         if requested_review_executor is not None or requested_review_model is not None:
             run_tick_kwargs.update(
@@ -738,7 +827,8 @@ def build_request_executor(
                     "review_model": requested_review_model,
                 }
             )
-        return run_tick_fn(
+        return _call_with_supported_kwargs(
+            run_tick_fn,
             dispatcher,
             **run_tick_kwargs,
         )
@@ -774,6 +864,13 @@ def build_periodic_tick_runner(
     )
 
     def execute() -> dict[str, Any]:
+        identities = workflow_identity_registry or load_model_identities()
+        workflow_launcher_factory = lambda identity: _resolve_launcher(
+            identity.executor,
+            launcher,
+            allow_unsafe=False,
+            model=identity.model_id,
+        )
         registry = getattr(dispatcher, "_registry", None)
         auto_claim_error: str | None = None
         try:
@@ -800,13 +897,6 @@ def build_periodic_tick_runner(
                 if state_path is not None
                 else paths.coordinator_root().resolve()
             )
-            identities = workflow_identity_registry or load_model_identities()
-            launcher_factory = lambda identity: _resolve_launcher(
-                identity.executor,
-                launcher,
-                allow_unsafe=False,
-                model=identity.model_id,
-            )
             for workflow in registry.list_workflow_runs():
                 if workflow.status != "ongoing" or "blocked" in workflow.facets:
                     continue
@@ -829,7 +919,7 @@ def build_periodic_tick_runner(
                         dispatcher,
                         run_id=workflow.run_id,
                         identities=identities,
-                        launcher_factory=launcher_factory,
+                        launcher_factory=workflow_launcher_factory,
                         coordinator_root=coordinator_root,
                         ship_validator=active_ship_validator,
                     )
@@ -850,6 +940,18 @@ def build_periodic_tick_runner(
                     )
         metas = scan_specs_fn(specs_dir)
         _refuse_unsafe_fanout(metas, predicate, allow_unsafe=default_allow_unsafe)
+        if (
+            isinstance(default_executor, str)
+            and default_executor
+            and isinstance(default_model, str)
+            and default_model
+        ):
+            _require_registered_identity(
+                identity_registry=identities,
+                executor=default_executor,
+                model_id=default_model,
+                context="periodic tick 預設 identity 不存在於 registry",
+            )
         active_launcher = _resolve_launcher(
             default_executor,
             launcher,
@@ -871,6 +973,13 @@ def build_periodic_tick_runner(
             "require_idle": require_idle,
             "max_load": default_max_load,
             "reaper": reaper,
+            "identity_registry": identities,
+            "launcher_factory": lambda identity: _resolve_launcher(
+                identity.executor,
+                launcher,
+                allow_unsafe=default_allow_unsafe,
+                model=identity.model_id,
+            ),
         }
         if default_review_executor is not None or default_review_model is not None:
             run_tick_kwargs.update(
@@ -880,7 +989,7 @@ def build_periodic_tick_runner(
                     "review_model": default_review_model,
                 }
             )
-        result = run_tick_fn(dispatcher, **run_tick_kwargs)
+        result = _call_with_supported_kwargs(run_tick_fn, dispatcher, **run_tick_kwargs)
         summary = {**result, "auto_claims": auto_claims}
         if auto_claim_error is not None:
             # 讓 operator 能從 status/summary 看出 auto-claim 這輪降級了，

--- a/paulsha_cortex/deck/schema.py
+++ b/paulsha_cortex/deck/schema.py
@@ -16,6 +16,8 @@ EMITTED_FRONTMATTER_FIELDS = (
     "depends_on",
     "target_branch",
     "verification",
+    "executor",
+    "model_id",
     "parse_error",
 )
 CARD_KINDS = ("skill",)

--- a/paulsha_cortex/porcelain/run.py
+++ b/paulsha_cortex/porcelain/run.py
@@ -41,7 +41,7 @@ def _add_executor_options(parser: argparse.ArgumentParser, *, review: bool) -> N
         default=None,
         help=(
             "覆寫 builder model ID 預設值；spec frontmatter 宣告 executor/model_id 時逐 slice 覆寫；"
-            "明確指定的 (executor, model) 須為 model-identities 已註冊身分"
+            "明確指定的 (executor, model_id) 須為 model-identities 已註冊身分"
         ),
     )
     if review:

--- a/paulsha_cortex/porcelain/run.py
+++ b/paulsha_cortex/porcelain/run.py
@@ -36,7 +36,14 @@ def _add_tracking_options(parser: argparse.ArgumentParser) -> None:
 def _add_executor_options(parser: argparse.ArgumentParser, *, review: bool) -> None:
     parser.add_argument("--specs-dir", default=None, help="覆寫 daemon specs 目錄")
     parser.add_argument("--executor", default=None, help="覆寫 builder executor")
-    parser.add_argument("--model", default=None, help="覆寫 builder model ID")
+    parser.add_argument(
+        "--model",
+        default=None,
+        help=(
+            "覆寫 builder model ID 預設值；spec frontmatter 宣告 executor/model_id 時逐 slice 覆寫；"
+            "明確指定的 (executor, model) 須為 model-identities 已註冊身分"
+        ),
+    )
     if review:
         parser.add_argument("--review-executor", default=None, help="覆寫 reviewer executor")
         parser.add_argument("--review-model", default=None, help="覆寫 reviewer model ID")

--- a/tests/test_coordinator_manager_daemon.py
+++ b/tests/test_coordinator_manager_daemon.py
@@ -1354,7 +1354,7 @@ def test_runtime_status_provider_classifies_held_units(monkeypatch, tmp_path):
     assert status["held"] == [
         {"slice_id": "slice-no-plan", "reasons": ["no-plan"]},
         {"slice_id": "slice-held", "reasons": ["dispatch-hold"]},
-        {"slice_id": "slice-blocked", "reasons": ["deps-unsatisfied:slice-dep"]},
+        {"slice_id": "slice-blocked", "reasons": ["deps-unknown:slice-dep"]},
     ]
     assert {item["slice_id"] for item in status["held"]} == {"slice-no-plan", "slice-held", "slice-blocked"}
 
@@ -1672,7 +1672,7 @@ def test_periodic_tick_runner_passes_default_builder_model(monkeypatch, tmp_path
         handoff_dir=str(tmp_path / "handoff"),
         launcher=launcher,
         default_executor="copilot",
-        default_model="claude-haiku-4.5",
+        default_model="gpt-5.4",
         run_tick_fn=fake_run_tick,
         scan_specs_fn=lambda specs_dir: [],
         auto_claim_fn=lambda: [],
@@ -1681,7 +1681,7 @@ def test_periodic_tick_runner_passes_default_builder_model(monkeypatch, tmp_path
     runner()
 
     assert calls and calls[0]["dispatcher"] is dispatcher
-    assert captured[0] == {"executor": "copilot", "model": "claude-haiku-4.5"}
+    assert captured[0] == {"executor": "copilot", "model": "gpt-5.4"}
 
 
 def test_dispatch_no_plan(monkeypatch, tmp_path):

--- a/tests/test_coordinator_manager_daemon.py
+++ b/tests/test_coordinator_manager_daemon.py
@@ -14,6 +14,7 @@ import pytest
 
 from paulsha_cortex.control import constants, contract
 from paulsha_cortex.coordinator import autonomy as coordinator_autonomy, completion, manager_daemon, verification
+from paulsha_cortex.coordinator.model_identities import IdentityRegistry
 from paulsha_cortex.coordinator.registry import JobRegistry
 
 
@@ -1640,6 +1641,20 @@ def test_work_action_request_has_one_manager_owned_execution_path(tmp_path):
 
 
 def test_periodic_tick_runner_passes_default_builder_model(monkeypatch, tmp_path):
+    # #294 R5：build_periodic_tick_runner 對 default_executor/default_model 做
+    # fail-closed identity registry 驗證，因此測試需自帶一份包含
+    # copilot/gpt-5.4 的假 registry，不可依賴套件內建或使用者機器上的
+    # model-identities.yaml（兩者都不保證含這個 identity，會讓測試在乾淨環境
+    # 假失敗）。
+    identity_registry = IdentityRegistry.from_rows(
+        [
+            {
+                "executor": "copilot",
+                "model_id": "gpt-5.4",
+                "independence_domain": "github",
+            }
+        ]
+    )
     dispatcher = FakeDispatcher(FakeRegistry())
     launcher = object()
     calls: list[dict[str, object]] = []
@@ -1673,6 +1688,7 @@ def test_periodic_tick_runner_passes_default_builder_model(monkeypatch, tmp_path
         launcher=launcher,
         default_executor="copilot",
         default_model="gpt-5.4",
+        workflow_identity_registry=identity_registry,
         run_tick_fn=fake_run_tick,
         scan_specs_fn=lambda specs_dir: [],
         auto_claim_fn=lambda: [],

--- a/tests/test_deck_compile.py
+++ b/tests/test_deck_compile.py
@@ -285,11 +285,12 @@ def test_compile_quotes_plan_ref_for_frontmatter(tmp_path):
 def test_compile_frontmatter_exact_keyset(tmp_path):
     from paulsha_cortex.deck.schema import EMITTED_FRONTMATTER_FIELDS
 
+    runtime_only = {"executor", "model_id"}
     cards, combo = _feature_oneshot(tmp_path)
     result = compile_combo(combo, cards, "示例 LED 功能", change="demo", allow_external=True)
     for slice_doc in result.slices:
         block = slice_doc.content.split("---\n")[1]
-        assert set(yaml.safe_load(block)) == set(EMITTED_FRONTMATTER_FIELDS)
+        assert set(yaml.safe_load(block)) == set(EMITTED_FRONTMATTER_FIELDS) - runtime_only
 
 
 def test_requires_uncovered_blocks_without_allow_external(tmp_path):

--- a/tests/test_persona_phase4_fanout_autonomy.py
+++ b/tests/test_persona_phase4_fanout_autonomy.py
@@ -865,8 +865,19 @@ class FanoutTests(unittest.TestCase):
             self.assertEqual(launcher.calls, ["real-a", "real-b"])
             self.assertEqual(sender.sent, [])   # headless：不送 tmux pane
             self.assertEqual(real_calls, [])     # 注入 git_runner → 全程不啟動真 git
+            # 每 slice 兩次 rev-parse baseline：_record_pending_slice 前的 best-effort
+            # early fetch（identity/base_sha 若晚點失敗仍留診斷基準）＋ launch 前的
+            # 權威 dispatch_head（見 autonomy.py 內 reviewer #333-1 註解）。
             baseline_calls = [call for call in git_calls if call[:1] == ["rev-parse"]]
-            self.assertEqual(baseline_calls, [["rev-parse", "feature/real-a"], ["rev-parse", "feature/real-b"]])
+            self.assertEqual(
+                baseline_calls,
+                [
+                    ["rev-parse", "feature/real-a"],
+                    ["rev-parse", "feature/real-a"],
+                    ["rev-parse", "feature/real-b"],
+                    ["rev-parse", "feature/real-b"],
+                ],
+            )
             self.assertEqual(sum(1 for call in git_calls if len(call) >= 3 and call[2] == "fetch"), 2)
             self.assertEqual(
                 sum(

--- a/tests/test_slice_executor_model.py
+++ b/tests/test_slice_executor_model.py
@@ -1,0 +1,636 @@
+from __future__ import annotations
+
+import io
+import json
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+
+import pytest
+
+from paulsha_cortex.coordinator import cli, manager_daemon
+from paulsha_cortex.coordinator.autonomy import (
+    DispatchReadyError,
+    dispatch_ready,
+    parse_spec_frontmatter,
+)
+from paulsha_cortex.coordinator.model_identities import IdentityRegistry
+
+
+def _write_spec(dirpath: Path, name: str, frontmatter: str | None, body: str = "x") -> Path:
+    path = dirpath / name
+    if frontmatter is None:
+        path.write_text(body + "\n", encoding="utf-8")
+    else:
+        path.write_text(f"---\n{frontmatter}\n---\n\n{body}\n", encoding="utf-8")
+    return path
+
+
+def _verification_block(*, docs_class: str = "code") -> str:
+    return (
+        "target_branch: main\n"
+        "verification:\n"
+        f"  docs_class: {docs_class}\n"
+        "  required_artifacts: []\n"
+        "  checks:\n"
+        "    - kind: persona-scope\n"
+        "    - kind: command\n"
+        "      name: policy\n"
+        "      argv: [python3, -m, pytest, -q]\n"
+        "      cwd: .\n"
+        "      timeout_seconds: 30\n"
+        "  tests: []\n"
+        "  full_suite:\n"
+        "    argv: [python3, -m, pytest, -q]\n"
+        "    cwd: .\n"
+        "    timeout_seconds: 60\n"
+        "    baseline: no-regression"
+    )
+
+
+def _meta(
+    slice_id: str,
+    *,
+    dispatch: str = "auto",
+    plan: str = "docs/superpowers/plans/example.md",
+    depends_on: list[str] | None = None,
+    executor: str | None = None,
+    model_id: str | None = None,
+) -> dict:
+    spec_path = f"/specs/{slice_id}.md"
+    return {
+        "path": spec_path,
+        "dispatch": dispatch,
+        "slice_id": slice_id,
+        "plan": plan,
+        "depends_on": list(depends_on or []),
+        "target_branch": "main",
+        "verification": {
+            "docs_class": "code",
+            "review_policy": "required",
+            "required_artifacts": [],
+            "checks": [
+                {"kind": "persona-scope"},
+                {
+                    "kind": "command",
+                    "name": "policy",
+                    "argv": ["python3", "-m", "pytest", "-q"],
+                    "cwd": ".",
+                    "timeout_seconds": 300,
+                },
+            ],
+            "tests": [],
+            "full_suite": {
+                "argv": ["python3", "-m", "pytest", "-q"],
+                "cwd": ".",
+                "timeout_seconds": 300,
+                "baseline": "no-regression",
+            },
+        },
+        "parse_error": None,
+        "executor": executor,
+        "model_id": model_id,
+        "_pinned_inputs": {
+            "spec_path": spec_path,
+            "spec_hash": "0" * 64,
+            "plan_path": plan,
+            "plan_hash": "1" * 64,
+            "target_branch": "main",
+            "target_remote": "origin",
+            "verification_hash": "2" * 64,
+        },
+    }
+
+
+def _identity_registry() -> IdentityRegistry:
+    return IdentityRegistry.from_rows(
+        [
+            {
+                "executor": "codex",
+                "model_id": "gpt-5.4-codex",
+                "independence_domain": "openai",
+            },
+            {
+                "executor": "copilot",
+                "model_id": "claude-haiku-4.5",
+                "independence_domain": "anthropic",
+            },
+        ]
+    )
+
+
+def _default_git_runner(args: list[str]):
+    if not args:
+        return ""
+    if args[0] == "rev-parse":
+        return "f" * 40
+    if len(args) >= 5 and args[0] == "-C" and args[2] == "fetch":
+        return ""
+    if len(args) >= 4 and args[0] == "-C" and args[2] == "rev-parse":
+        return "f" * 40
+    if len(args) >= 6 and args[0] == "-C" and args[2] == "merge-base":
+        return ""
+    return ""
+
+
+class FakeRegistry:
+    def __init__(self) -> None:
+        self._jobs: list[dict] = []
+        self._seq = 0
+        self._slices: list[dict] = []
+
+    def list_jobs(self) -> list[dict]:
+        return [dict(job) for job in self._jobs]
+
+    def create_job(
+        self,
+        *,
+        task: str,
+        persona: str,
+        branch: str,
+        pane: str,
+        worktree: str,
+        dispatch_head: str | None = None,
+        executor: str | None = None,
+        session_name: str | None = None,
+        pid: int | None = None,
+        log_path: str | None = None,
+        exit_code: int | None = None,
+        kind: str = "build",
+        model_id: str | None = None,
+        independence_domain: str | None = None,
+        subject_head: str | None = None,
+        spec_hash: str | None = None,
+        plan_hash: str | None = None,
+        verification_hash: str | None = None,
+    ) -> dict:
+        self._seq += 1
+        job = {
+            "job_id": f"{task}-{self._seq}",
+            "task": task,
+            "persona": persona,
+            "kind": kind,
+            "branch": branch,
+            "pane": pane,
+            "worktree": worktree,
+            "status": "dispatched",
+            "dispatch_head": dispatch_head,
+            "executor": executor,
+            "model_id": model_id,
+            "independence_domain": independence_domain,
+            "session_name": session_name,
+            "pid": pid,
+            "log_path": log_path,
+            "exit_code": exit_code,
+            "subject_head": subject_head,
+            "spec_hash": spec_hash,
+            "plan_hash": plan_hash,
+            "verification_hash": verification_hash,
+        }
+        self._jobs.append(job)
+        return dict(job)
+
+    def attach_launch_handle(
+        self,
+        job_id: str,
+        *,
+        executor: str | None = None,
+        model_id: str | None = None,
+        session_name: str | None = None,
+        pid: int | None = None,
+        log_path: str | None = None,
+    ) -> dict:
+        for job in self._jobs:
+            if job["job_id"] == job_id:
+                job["executor"] = executor
+                if model_id is not None:
+                    job["model_id"] = model_id
+                job["session_name"] = session_name
+                job["pid"] = pid
+                job["log_path"] = log_path
+                return dict(job)
+        raise KeyError(job_id)
+
+    def update_status(self, job_id: str, status: str) -> dict:
+        for job in self._jobs:
+            if job["job_id"] == job_id:
+                job["status"] = status
+                return dict(job)
+        raise KeyError(job_id)
+
+    def create_slice(
+        self,
+        *,
+        slice_id: str,
+        spec_path: str,
+        spec_hash: str,
+        plan_path: str,
+        plan_hash: str,
+        target_branch: str,
+        target_remote: str = "origin",
+        verification_hash: str | None = None,
+        verification: dict | None = None,
+        dispatch_base: str | None = None,
+        builder_job_id: str | None = None,
+        reviewer_job_id: str | None = None,
+        candidate: str | None = None,
+    ) -> dict:
+        row = {
+            "slice_id": slice_id,
+            "spec": {"path": spec_path, "hash": spec_hash},
+            "plan": {"path": plan_path, "hash": plan_hash},
+            "target_branch": target_branch,
+            "target_remote": target_remote,
+            "verification": {"hash": verification_hash or ("0" * 64), "contract": verification},
+            "dispatch_base": dispatch_base,
+            "builder_job_id": builder_job_id,
+            "reviewer_job_id": reviewer_job_id,
+            "candidate": candidate,
+            "state": "pending",
+            "gate_state": "pending",
+            "actions": [],
+        }
+        self._slices.append(row)
+        return dict(row)
+
+    def update_slice(self, slice_id: str, **updates) -> dict:
+        for row in self._slices:
+            if row["slice_id"] == slice_id:
+                for key, value in updates.items():
+                    if value is None:
+                        continue
+                    if key == "verification_hash":
+                        row["verification"]["hash"] = value
+                    else:
+                        row[key] = value
+                return dict(row)
+        raise KeyError(slice_id)
+
+    def record_action(self, slice_id: str, **kwargs) -> dict:
+        for row in self._slices:
+            if row["slice_id"] == slice_id:
+                row["actions"].append(dict(kwargs))
+                return dict(row)
+        raise KeyError(slice_id)
+
+    def get_slice(self, slice_id: str) -> dict:
+        for row in self._slices:
+            if row["slice_id"] == slice_id:
+                return dict(row)
+        raise KeyError(slice_id)
+
+
+class FakeWorktreeCreator:
+    def __init__(self, base_dir: Path) -> None:
+        self._base_dir = base_dir
+        self.calls: list[tuple[str, str | None]] = []
+
+    def create(self, branch: str, base_sha: str | None = None) -> str:
+        self.calls.append((branch, base_sha))
+        return str(self._base_dir / branch.replace("/", "__"))
+
+
+class FakeDispatcher:
+    def __init__(self, registry: FakeRegistry, worktree_creator: FakeWorktreeCreator | None = None) -> None:
+        self._registry = registry
+        self._worktree_creator = worktree_creator
+        self._git_runner = _default_git_runner
+
+
+class RecordingLauncher:
+    def __init__(self, *, executor: str, model_id: str | None, label: str) -> None:
+        self.executor = executor
+        self.model_id = model_id
+        self.label = label
+        self.calls: list[dict[str, str]] = []
+        self.commit_capability_requests = 0
+
+    def as_commit_required(self):
+        self.commit_capability_requests += 1
+        return self
+
+    def launch(self, *, slice_id: str, prompt: str, worktree: str, log_dir: str):
+        from paulsha_cortex.coordinator.launcher import LaunchHandle
+
+        self.calls.append(
+            {
+                "slice_id": slice_id,
+                "prompt": prompt,
+                "worktree": worktree,
+                "log_dir": log_dir,
+            }
+        )
+        return LaunchHandle(
+            executor=self.executor,
+            model_id=self.model_id,
+            session_name=f"{self.label}:{slice_id}",
+            pid=1000 + len(self.calls),
+            log_path=f"{log_dir}/{slice_id}.jsonl",
+        )
+
+
+def test_frontmatter_paired_executor_model_id_parsed(tmp_path: Path) -> None:
+    spec = _write_spec(
+        tmp_path,
+        "paired.md",
+        "dispatch: auto\n"
+        "slice_id: paired-slice\n"
+        "plan: docs/superpowers/plans/paired.md\n"
+        "executor: codex\n"
+        "model_id: gpt-5.4-codex\n"
+        f"{_verification_block()}",
+    )
+
+    meta = parse_spec_frontmatter(spec)
+
+    assert meta["dispatch"] == "auto"
+    assert meta["slice_id"] == "paired-slice"
+    assert meta["plan"] == "docs/superpowers/plans/paired.md"
+    assert meta.get("executor") == "codex"
+    assert meta.get("model_id") == "gpt-5.4-codex"
+    assert meta["parse_error"] is None
+
+
+def test_frontmatter_executor_without_model_id_invalid(tmp_path: Path) -> None:
+    executor_only = parse_spec_frontmatter(
+        _write_spec(
+            tmp_path,
+            "executor-only.md",
+            "dispatch: auto\n"
+            "slice_id: executor-only\n"
+            "plan: docs/superpowers/plans/executor-only.md\n"
+            "executor: codex\n"
+            f"{_verification_block()}",
+        )
+    )
+    model_only = parse_spec_frontmatter(
+        _write_spec(
+            tmp_path,
+            "model-only.md",
+            "dispatch: auto\n"
+            "slice_id: model-only\n"
+            "plan: docs/superpowers/plans/model-only.md\n"
+            "model_id: gpt-5.4-codex\n"
+            f"{_verification_block()}",
+        )
+    )
+
+    assert executor_only["parse_error"]["code"] == "invalid-frontmatter"
+    assert executor_only["parse_error"]["field"] == "model_id"
+    assert model_only["parse_error"]["code"] == "invalid-frontmatter"
+    assert model_only["parse_error"]["field"] == "executor"
+
+
+def test_emitted_frontmatter_fields_include_identity() -> None:
+    from paulsha_cortex.deck.schema import EMITTED_FRONTMATTER_FIELDS
+
+    assert "executor" in EMITTED_FRONTMATTER_FIELDS
+    assert "model_id" in EMITTED_FRONTMATTER_FIELDS
+
+
+def test_dispatch_ready_per_slice_override_reaches_job_row(tmp_path: Path) -> None:
+    registry = FakeRegistry()
+    dispatcher = FakeDispatcher(registry, worktree_creator=FakeWorktreeCreator(tmp_path / "worktrees"))
+    default_launcher = RecordingLauncher(executor="copilot", model_id=None, label="default")
+    identities = _identity_registry()
+    factory_calls: list[tuple[str, str]] = []
+    override_launchers: list[RecordingLauncher] = []
+
+    def launcher_factory(identity):
+        factory_calls.append((identity.executor, identity.model_id))
+        launcher = RecordingLauncher(
+            executor=identity.executor,
+            model_id=identity.model_id,
+            label="override",
+        )
+        override_launchers.append(launcher)
+        return launcher
+
+    jobs = dispatch_ready(
+        [
+            _meta("slice-override", executor="codex", model_id="gpt-5.4-codex"),
+            _meta("slice-default"),
+        ],
+        is_satisfied=lambda _slice_id: True,
+        dispatcher=dispatcher,
+        persona="builder",
+        launcher=default_launcher,
+        identity_registry=identities,
+        launcher_factory=launcher_factory,
+        git_runner=_default_git_runner,
+    )
+
+    override_job = next(job for job in jobs if job["task"] == "slice-override")
+    default_job = next(job for job in jobs if job["task"] == "slice-default")
+
+    assert factory_calls == [("codex", "gpt-5.4-codex")]
+    assert len(override_launchers) == 1
+    assert override_launchers[0].commit_capability_requests == 1
+    assert override_launchers[0].calls[0]["slice_id"] == "slice-override"
+    assert default_launcher.commit_capability_requests == 1
+    assert default_launcher.calls[0]["slice_id"] == "slice-default"
+    assert (override_job["executor"], override_job["model_id"]) == ("codex", "gpt-5.4-codex")
+    assert (default_job["executor"], default_job["model_id"]) == ("copilot", None)
+    assert registry.get_slice("slice-override")["builder_job_id"] == override_job["job_id"]
+
+
+def test_dispatch_ready_unknown_identity_fail_closed_lists_available(tmp_path: Path) -> None:
+    registry = FakeRegistry()
+    dispatcher = FakeDispatcher(registry, worktree_creator=FakeWorktreeCreator(tmp_path / "worktrees"))
+    default_launcher = RecordingLauncher(executor="copilot", model_id=None, label="default")
+    identities = _identity_registry()
+
+    with pytest.raises(DispatchReadyError) as excinfo:
+        dispatch_ready(
+            [
+                _meta("slice-bad", executor="codex", model_id="missing-model"),
+                _meta("slice-good"),
+            ],
+            is_satisfied=lambda _slice_id: True,
+            dispatcher=dispatcher,
+            persona="builder",
+            launcher=default_launcher,
+            identity_registry=identities,
+            launcher_factory=lambda identity: RecordingLauncher(
+                executor=identity.executor,
+                model_id=identity.model_id,
+                label="override",
+            ),
+            git_runner=_default_git_runner,
+        )
+
+    assert [job["task"] for job in excinfo.value.jobs] == ["slice-good"]
+    assert "codex/missing-model" in str(excinfo.value)
+    assert "codex/gpt-5.4-codex" in str(excinfo.value)
+    assert default_launcher.calls[0]["slice_id"] == "slice-good"
+    assert registry.get_slice("slice-bad")["state"] == "needs_human"
+
+
+def test_dispatch_ready_no_declaration_behavior_unchanged(tmp_path: Path) -> None:
+    registry = FakeRegistry()
+    dispatcher = FakeDispatcher(registry, worktree_creator=FakeWorktreeCreator(tmp_path / "worktrees"))
+    default_launcher = RecordingLauncher(executor="copilot", model_id=None, label="default")
+
+    jobs = dispatch_ready(
+        [_meta("slice-plain")],
+        is_satisfied=lambda _slice_id: True,
+        dispatcher=dispatcher,
+        persona="builder",
+        launcher=default_launcher,
+        identity_registry=_identity_registry(),
+        launcher_factory=lambda identity: (_ for _ in ()).throw(
+            AssertionError(f"launcher_factory should not run for undeclared slice: {identity}")
+        ),
+        git_runner=_default_git_runner,
+    )
+
+    assert [job["task"] for job in jobs] == ["slice-plain"]
+    assert default_launcher.commit_capability_requests == 1
+    assert default_launcher.calls[0]["slice_id"] == "slice-plain"
+
+
+def test_held_reasons_classified(tmp_path: Path) -> None:
+    handoff_dir = tmp_path / "handoff"
+    handoff_dir.mkdir()
+    (handoff_dir / "external-dep.json").write_text("{}", encoding="utf-8")
+
+    reasons = manager_daemon._held_reasons(
+        {
+            "slice_id": "slice-x",
+            "dispatch": "auto",
+            "plan": "x.md",
+            "depends_on": ["batch-dep", "external-dep", "unknown-dep"],
+        },
+        lambda _slice_id: False,
+        batch_ids={"slice-x", "batch-dep"},
+        handoff_dir=str(handoff_dir),
+    )
+
+    assert reasons == [
+        "deps-unsatisfied:batch-dep",
+        "deps-external:external-dep",
+        "deps-unknown:unknown-dep",
+    ]
+
+
+def test_ready_cli_unknown_dep_stderr_diagnostic(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    specs_dir = tmp_path / "specs"
+    specs_dir.mkdir()
+    _write_spec(
+        specs_dir,
+        "slice-a.md",
+        "dispatch: auto\n"
+        "slice_id: slice-a\n"
+        "plan: docs/superpowers/plans/slice-a.md\n"
+        "depends_on: [ghost-dep]\n"
+        f"{_verification_block()}",
+    )
+
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    with redirect_stdout(stdout), redirect_stderr(stderr):
+        rc = cli.main(
+            ["ready", "--specs-dir", str(specs_dir)],
+            is_satisfied=lambda _slice_id: False,
+        )
+
+    assert rc == 0
+    assert json.loads(stdout.getvalue()) == []
+    assert "deps-unknown:ghost-dep" in stderr.getvalue()
+
+
+def test_fanout_request_unknown_builder_identity_rejected(tmp_path: Path) -> None:
+    registry = FakeRegistry()
+    dispatcher = FakeDispatcher(registry, worktree_creator=FakeWorktreeCreator(tmp_path / "worktrees"))
+    request_executor = manager_daemon.build_request_executor(
+        dispatcher=dispatcher,
+        specs_dir=str(tmp_path / "specs"),
+        handoff_dir=str(tmp_path / "handoff"),
+        launcher=object(),
+        scan_specs_fn=lambda _specs_dir: [_meta("slice-a")],
+        dispatch_ready_fn=lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("dispatch_ready should not run")
+        ),
+        workflow_identity_registry=_identity_registry(),
+    )
+
+    with pytest.raises(ValueError) as excinfo:
+        request_executor(
+            {
+                "type": "fanout",
+                "args": {"executor": "codex", "model": "missing-model"},
+                "requested_by": "operator",
+            }
+        )
+
+    assert "codex/missing-model" in str(excinfo.value)
+    assert "codex/gpt-5.4-codex" in str(excinfo.value)
+
+
+def test_fanout_request_without_model_unchanged(tmp_path: Path) -> None:
+    class NoValidationRegistry:
+        identities: tuple[object, ...] = ()
+
+        def get(self, executor: str, model_id: str):
+            raise AssertionError(f"registry validation should not run for {executor}/{model_id}")
+
+    registry = NoValidationRegistry()
+    dispatcher = FakeDispatcher(
+        FakeRegistry(),
+        worktree_creator=FakeWorktreeCreator(tmp_path / "worktrees"),
+    )
+    seen: list[dict[str, object]] = []
+
+    def fake_dispatch_ready(
+        metas,
+        predicate,
+        dispatcher,
+        *,
+        persona,
+        launcher,
+        handoff_dir,
+        git_runner,
+        identity_registry,
+        launcher_factory,
+    ):
+        seen.append(
+            {
+                "metas": list(metas),
+                "persona": persona,
+                "handoff_dir": handoff_dir,
+                "identity_registry": identity_registry,
+                "launcher_factory": launcher_factory,
+            }
+        )
+        return [
+            {
+                "job_id": "slice-a-1",
+                "task": "slice-a",
+                "branch": "feature/slice-a",
+                "worktree": "/wt/slice-a",
+            }
+        ]
+
+    request_executor = manager_daemon.build_request_executor(
+        dispatcher=dispatcher,
+        specs_dir=str(tmp_path / "specs"),
+        handoff_dir=str(tmp_path / "handoff"),
+        launcher=object(),
+        scan_specs_fn=lambda _specs_dir: [_meta("slice-a")],
+        dispatch_ready_fn=fake_dispatch_ready,
+        workflow_identity_registry=registry,
+    )
+
+    result = request_executor(
+        {
+            "type": "fanout",
+            "args": {"executor": "codex"},
+            "requested_by": "operator",
+        }
+    )
+
+    assert result["dispatch_skipped"] is False
+    assert [job["task"] for job in result["dispatched"]] == ["slice-a"]
+    assert len(seen) == 1
+    assert seen[0]["identity_registry"] is registry
+    assert callable(seen[0]["launcher_factory"])

--- a/tests/test_slice_executor_model.py
+++ b/tests/test_slice_executor_model.py
@@ -463,6 +463,10 @@ def test_dispatch_ready_unknown_identity_fail_closed_lists_available(tmp_path: P
     assert "codex/gpt-5.4-codex" in str(excinfo.value)
     assert default_launcher.calls[0]["slice_id"] == "slice-good"
     assert registry.get_slice("slice-bad")["state"] == "needs_human"
+    # reviewer #333-1：identity 檢查失敗於 base_sha 解析前，needs_human 之後
+    # dispatch_base 不會再被更新，故 pending slice 建立時須先嘗試填入既有
+    # branch head（非硬編碼 None），保留可診斷基準。
+    assert registry.get_slice("slice-bad")["dispatch_base"] == "f" * 40
 
 
 def test_dispatch_ready_no_declaration_behavior_unchanged(tmp_path: Path) -> None:

--- a/tests/test_workflow_manifest.py
+++ b/tests/test_workflow_manifest.py
@@ -111,6 +111,7 @@ def test_manifest_roundtrips_card_execution_contract() -> None:
 def test_manifest_resolves_inputs_outputs_and_preserves_slice_frontmatter() -> None:
     cards, combo = _feature_oneshot()
     result = compile_combo(combo, cards, "manifest demo", change="demo")
+    runtime_only = {"executor", "model_id"}
 
     plan = next(step for step in result.workflow_manifest.steps if step.card == "writing-plans")
     assert plan.inputs == ("openspec/changes/demo/proposal.md",)
@@ -120,7 +121,7 @@ def test_manifest_resolves_inputs_outputs_and_preserves_slice_frontmatter() -> N
         frontmatter = slice_doc.content.split("---\n", 2)[1]
         import yaml
 
-        assert set(yaml.safe_load(frontmatter)) == set(EMITTED_FRONTMATTER_FIELDS)
+        assert set(yaml.safe_load(frontmatter)) == set(EMITTED_FRONTMATTER_FIELDS) - runtime_only
 
 
 def test_manifest_rejects_unknown_persona_binding(tmp_path) -> None:


### PR DESCRIPTION
## 摘要

讓 plan slice 可各自宣告 `executor`／`model`，不再被迫為異質 executor 切 specs-dir；並讓跨 dir／不存在的 `depends_on` 產生顯式診斷，取代原本的 fail-silent。

Closes #294

## 內容

- `deck/schema.py`：slice 層新增 `executor`／`model` 欄位。
- `coordinator/autonomy.py`、`manager_daemon.py`、`cli.py`、`porcelain/run.py`：派工鏈路傳遞 slice 層覆寫。
- `manager_daemon.py` 對 executor/model pair 做 fail-closed identity registry 驗證（未註冊的組合直接拒絕派工，不再靜默採用）。
- `depends_on` 指向跨 dir 或不存在的 slice 時回報明確錯誤。

## 驗證

- [x] `python3 -m pytest tests/ -q` → 1776 passed（main 基線為 1765 passed + 1 個 thread-timing flaky）
- [x] 本地 policy_check 帶 PR 上下文 → `fail: 0`（唯一 warn 為 R-22 陳年 dangling reference，非本次造成）
- [x] `changelog.d/feat-slice-executor-model.md` fragment 已 commit（R-09）＋ `CHANGELOG.md [Unreleased]` entry
- [x] openspec tasks.md 與 workstream todo.md 全勾

### 附註：一個被掩蓋的測試環境依賴

`test_periodic_tick_runner_passes_default_builder_model` 原本沒有注入 `workflow_identity_registry`，因此新增的 fail-closed 驗證會 fall back 到 `load_model_identities()`——套件內建 registry 只有 `agy/gemini-3.1-pro-high`，實際能通過只是因為開發機 `$HOME` 下剛好有含 `copilot/gpt-5.4` 的個人設定檔。該測試在乾淨環境（CI／sandbox）會假失敗。已改為注入只含所需 identity 的假 registry，與同分支既有慣例一致；驗證邏輯本身未弱化。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QEGoUsBgzDSa6h9Ch8H5iX