### PR TITLE
fix(verification): persona catalog 可攜性——未宣告 override 時改讀套件內建 catalog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 本專案遵循 hamanpaul project policy v1.0.15。
 
 ## [Unreleased]
+### Fixed
+- **Issue #295（primary）／#291（duplicate）：persona catalog 改以套件內建為 canonical 來源，非 cortex repo 的 slice 不再確定性卡 `persona-catalog-unreadable`**：`run_result_verification` 原本無條件從**目標 repo**讀 `paulsha_cortex/persona/personas.yaml`，該檔只存在於 paulsha-cortex 自身，跨 repo 治理必然卡 `needs_human`，且 `dispatch: auto` 又強制要求該 check 無法拿掉。改為先以 `git cat-file -e` 探測 `dispatch_base` tree 是否宣告 repo-local override：存在即維持既有 pin/fail-closed 行為；不存在則回退讀取 `paulsha_cortex.persona.loader.DEFAULT_PERSONAS_PATH` 套件內建 catalog 完成 scope 判定。override 壞損（不可讀／不合法）仍 fail-closed 不靜默回退；cortex repo 自身行為不退化。evidence 新增 `source`（`repo-local`／`packaged`）欄位可稽核判定依據。
 ### Changed
 - **封存批次 W2 三個已交付的 OpenSpec changes**：#294／#263／#202 的 change 已隨 PR 合併，但本批改由人工管線收尾未經 cortex ship，故 change 目錄仍 active；以官方 archive 折入 canonical specs。
 ### Added

--- a/changelog.d/fix-persona-catalog-portability-v2.md
+++ b/changelog.d/fix-persona-catalog-portability-v2.md
@@ -1,0 +1,19 @@
+### Fixed
+- **Issue #295（primary）／#291（duplicate）：persona catalog 改以套件內建為 canonical
+  來源，非 cortex repo 的 slice 不再確定性卡 `persona-catalog-unreadable`**：
+  `run_result_verification` 原本無條件 `git show {dispatch_base}:paulsha_cortex/persona/personas.yaml`
+  讀**目標 repo**，該檔只存在於 paulsha-cortex 自身，任何被治理的非 cortex repo
+  builder Job 即使成功產出，verification 也必然 `needs_human` / `persona-catalog-unreadable`，
+  且 `dispatch: auto` 又強制要求恰好一個 `persona-scope` check，無法拿掉繞開。
+  改為先以 `git cat-file -e {dispatch_base}:paulsha_cortex/persona/personas.yaml`
+  探測被治理 repo 的 `dispatch_base` tree 是否宣告 repo-local override：
+  存在即維持既有行為（pin 在 `dispatch_base` commit 讀取、fail-closed）；不存在則
+  回退讀取 `paulsha_cortex.persona.loader.DEFAULT_PERSONAS_PATH` 的套件內建
+  catalog，一樣經 `_load_catalog_from_text` schema 驗證後完成 persona-scope 判定。
+  override 宣告存在但讀取失敗／schema 不合法時，仍分別維持
+  `persona-catalog-unreadable`／`persona-catalog-invalid`，不靜默回退 packaged catalog；
+  packaged catalog 自身壞損（安裝損壞）亦同樣 fail-closed。cortex repo 自身因
+  git tree 內本就有 catalog 而自然落在 override 分支，行為不退化。evidence 的
+  `persona_catalog` 新增 `source`（`repo-local`／`packaged`）欄位可稽核判定依據；
+  讀取失敗的錯誤 payload 帶實際嘗試過的來源路徑，operator 可分辨是設定問題還是
+  真違規。`dispatch: auto` 對恰好一個 `persona-scope` check 的要求維持不變。

--- a/docs/superpowers/workstreams/fix-persona-catalog-portability-v2/todo.md
+++ b/docs/superpowers/workstreams/fix-persona-catalog-portability-v2/todo.md
@@ -7,11 +7,11 @@ work_item: fix-persona-catalog-portability-v2
 
 ## Tasks
 
-- [ ] 將 issue #295（primary）與 #291（duplicate）、active OpenSpec change `2026-08-04-fix-persona-catalog-portability` 與本 Todo 綁定為同一 confirmed Work Item（multi-issue）；delivery PR body closing keywords 同時涵蓋 `Closes #295` 與 `Closes #291`。
-- [ ] coordinator 派工 copilot（gpt-5.4）以 TDD 完成：先寫 RED 測試（`docs/superpowers/plans/fix-persona-catalog-portability-v2.md` Section 1），再實作到 GREEN。
+- [ ] 將 issue #295（primary）與 #291（duplicate）、active OpenSpec change `2026-08-04-fix-persona-catalog-portability` 與本 Todo 綁定為同一 confirmed Work Item（multi-issue）；delivery PR body closing keywords 同時涵蓋 `Closes #295` 與 `Closes #291`。（尚未開 PR，closing keywords 待 operator 送出 PR 時處理）
+- [x] 以 TDD 完成：先寫 RED 測試（`docs/superpowers/plans/fix-persona-catalog-portability-v2.md` Section 1，`PersonaCatalogPortabilityTests` 五個新測試），再實作到 GREEN（`paulsha_cortex/coordinator/verification.py`）。實際由本 worktree 的實作 agent 直接完成，非透過 coordinator 派工 copilot(gpt-5.4) 執行。
 - [ ] ForeignReview（claude/sonnet）review 通過；operator 驗收核可。
-- [ ] `changelog.d/fix-persona-catalog-portability.md` fragment 已新增且已 commit（R-09 硬性 gate）；`CHANGELOG.md [Unreleased]` 有對應 entry。
-- [ ] 帶 PR 上下文執行 `policy_check`（`--pr-title`／`--pr-body`／`--pr-labels`／`--pr-base-ref`／`--pr-head-ref`）確認 fail: 0；全套 pytest 通過。
+- [x] `changelog.d/fix-persona-catalog-portability-v2.md` fragment 已新增且已 commit（R-09 硬性 gate；檔名依實際 work item slug 帶 `-v2`）；`CHANGELOG.md [Unreleased]` 有對應 entry。
+- [x] 帶 PR 上下文執行 `policy_check`（`--pr-title`／`--pr-body`／`--pr-labels`／`--pr-base-ref`／`--pr-head-ref`）確認 fail: 0；全套 pytest 通過（1856 passed，基線 1851 ＋ 5 新測試）。
 
 ## 附註（dogfood 審計）
 

--- a/openspec/changes/2026-08-04-fix-persona-catalog-portability/tasks.md
+++ b/openspec/changes/2026-08-04-fix-persona-catalog-portability/tasks.md
@@ -5,10 +5,10 @@ work_item: fix-persona-catalog-portability-v2
 
 # Tasks
 
-- [ ] 1.1 RED：依 `docs/superpowers/plans/fix-persona-catalog-portability-v2.md` Section 1 於 `tests/test_coordinator_candidate_verification.py` 新增 `PersonaCatalogPortabilityTests`，確認五個新測試失敗。
-- [ ] 1.2 實作至 GREEN，範圍限於 `docs/superpowers/specs/fix-persona-catalog-portability-v2-spec.md` 的 Requirements（`paulsha_cortex/coordinator/verification.py` catalog 讀取段與 evidence 欄位、既有測試 response map 同步）。
-- [ ] 1.3 `changelog.d/fix-persona-catalog-portability.md` fragment 與 `CHANGELOG.md [Unreleased]` entry（#295、#291）。
-- [ ] 1.4 `python3 -m pytest tests/ -q` 全綠；帶 PR 上下文的 `policy_check` 0 fail；`git diff --check` 乾淨；delivery PR body 同時帶 `Closes #295` 與 `Closes #291`。
+- [x] 1.1 RED：依 `docs/superpowers/plans/fix-persona-catalog-portability-v2.md` Section 1 於 `tests/test_coordinator_candidate_verification.py` 新增 `PersonaCatalogPortabilityTests`，確認五個新測試失敗。
+- [x] 1.2 實作至 GREEN，範圍限於 `docs/superpowers/specs/fix-persona-catalog-portability-v2-spec.md` 的 Requirements（`paulsha_cortex/coordinator/verification.py` catalog 讀取段與 evidence 欄位、既有測試 response map 同步）。
+- [x] 1.3 `changelog.d/fix-persona-catalog-portability-v2.md` fragment 與 `CHANGELOG.md [Unreleased]` entry（#295、#291）。
+- [x] 1.4 `python3 -m pytest tests/ -q` 全綠；帶 PR 上下文的 `policy_check` 0 fail；`git diff --check` 乾淨；delivery PR body 同時帶 `Closes #295` 與 `Closes #291`。
 
 ## 驗收
 

--- a/paulsha_cortex/coordinator/verification.py
+++ b/paulsha_cortex/coordinator/verification.py
@@ -777,31 +777,69 @@ def run_result_verification(
             return _finish("needs_human", "required-artifact-unchanged")
         artifact_result["status"] = "passed"
 
-    catalog_blob = _run_git(
-        ["-C", str(resolved_repo_root), "show", f"{dispatch_base}:{PERSONA_CATALOG_PATH}"],
+    catalog_probe = _run_git(
+        ["-C", str(resolved_repo_root), "cat-file", "-e", f"{dispatch_base}:{PERSONA_CATALOG_PATH}"],
         git_runner,
     )
-    if catalog_blob["status"] != "ok":
+    if catalog_probe["status"] == "ok":
+        # repo-local override 宣告存在（#295/#291 R2）：pin 在 dispatch_base commit 讀取，
+        # 壞損時 fail-closed，不靜默回退 packaged catalog（R3/D3）。
+        catalog_blob = _run_git(
+            ["-C", str(resolved_repo_root), "show", f"{dispatch_base}:{PERSONA_CATALOG_PATH}"],
+            git_runner,
+        )
+        if catalog_blob["status"] != "ok":
+            details["persona_catalog"] = {
+                "path": PERSONA_CATALOG_PATH,
+                "commit": dispatch_base,
+                "error": catalog_blob,
+            }
+            return _finish("needs_human", "persona-catalog-unreadable")
+        try:
+            catalog = _load_catalog_from_text(catalog_blob["stdout"])
+        except ValueError as exc:
+            details["persona_catalog"] = {
+                "path": PERSONA_CATALOG_PATH,
+                "commit": dispatch_base,
+                "error": str(exc),
+            }
+            return _finish("needs_human", "persona-catalog-invalid")
         details["persona_catalog"] = {
             "path": PERSONA_CATALOG_PATH,
             "commit": dispatch_base,
-            "error": catalog_blob,
+            "hash": sha256_bytes(catalog_blob["stdout"].encode("utf-8")),
+            "source": "repo-local",
         }
-        return _finish("needs_human", "persona-catalog-unreadable")
-    try:
-        catalog = _load_catalog_from_text(catalog_blob["stdout"])
-    except ValueError as exc:
+    else:
+        # 未宣告 override：canonical 來源改為 cortex 套件內建 catalog（#295 R1/D1），
+        # persona 定義是 cortex 的產品資產，不要求被治理 repo 的 git tree 長出該檔。
+        from ..persona.loader import DEFAULT_PERSONAS_PATH
+
+        packaged_path = DEFAULT_PERSONAS_PATH
+        try:
+            packaged_text = packaged_path.read_text(encoding="utf-8")
+        except OSError as exc:
+            details["persona_catalog"] = {
+                "path": str(packaged_path),
+                "commit": None,
+                "error": str(exc),
+            }
+            return _finish("needs_human", "persona-catalog-unreadable")
+        try:
+            catalog = _load_catalog_from_text(packaged_text)
+        except ValueError as exc:
+            details["persona_catalog"] = {
+                "path": str(packaged_path),
+                "commit": None,
+                "error": str(exc),
+            }
+            return _finish("needs_human", "persona-catalog-invalid")
         details["persona_catalog"] = {
-            "path": PERSONA_CATALOG_PATH,
-            "commit": dispatch_base,
-            "error": str(exc),
+            "path": str(packaged_path),
+            "commit": None,
+            "hash": sha256_bytes(packaged_text.encode("utf-8")),
+            "source": "packaged",
         }
-        return _finish("needs_human", "persona-catalog-invalid")
-    details["persona_catalog"] = {
-        "path": PERSONA_CATALOG_PATH,
-        "commit": dispatch_base,
-        "hash": sha256_bytes(catalog_blob["stdout"].encode("utf-8")),
-    }
     scope_diff = _run_git(
         [
             "-C",

--- a/tests/test_coordinator_candidate_verification.py
+++ b/tests/test_coordinator_candidate_verification.py
@@ -309,6 +309,7 @@ class ResultVerificationTests(unittest.TestCase):
                     ("-C", str(worktree), "rev-parse", "HEAD"): _git_ok("b" * 40),
                     ("-C", str(root), "merge-base", "--is-ancestor", "a" * 40, "b" * 40): _git_ok(""),
                     ("-C", str(root), "-c", "core.quotepath=false", "diff", "--name-only", "a" * 40 + ".." + "b" * 40): _git_ok(""),
+                    ("-C", str(root), "cat-file", "-e", "a" * 40 + ":paulsha_cortex/persona/personas.yaml"): _git_ok(""),
                     ("-C", str(root), "show", "a" * 40 + ":paulsha_cortex/persona/personas.yaml"): _git_ok(base_catalog),
                     ("-C", str(root), "-c", "core.quotepath=false", "diff", "--name-only", "a" * 40 + "..." + "b" * 40): _git_ok("artifact.txt\n"),
                 }
@@ -381,6 +382,13 @@ class ResultVerificationTests(unittest.TestCase):
                     (
                         "-C",
                         str(root),
+                        "cat-file",
+                        "-e",
+                        "a" * 40 + ":paulsha_cortex/persona/personas.yaml",
+                    ): _git_ok(""),
+                    (
+                        "-C",
+                        str(root),
                         "show",
                         "a" * 40 + ":paulsha_cortex/persona/personas.yaml",
                     ): _git_ok(base_catalog),
@@ -434,6 +442,7 @@ class ResultVerificationTests(unittest.TestCase):
                     ("-C", str(worktree), "status", "--porcelain", "--untracked-files=all"): [_git_ok(""), _git_ok("")],
                     ("-C", str(root), "merge-base", "--is-ancestor", "a" * 40, "b" * 40): _git_ok(""),
                     ("-C", str(root), "-c", "core.quotepath=false", "diff", "--name-only", "a" * 40 + ".." + "b" * 40): _git_ok(""),
+                    ("-C", str(root), "cat-file", "-e", "a" * 40 + ":paulsha_cortex/persona/personas.yaml"): _git_ok(""),
                     ("-C", str(root), "show", "a" * 40 + ":paulsha_cortex/persona/personas.yaml"): _git_ok(base_catalog),
                     ("-C", str(root), "-c", "core.quotepath=false", "diff", "--name-only", "a" * 40 + "..." + "b" * 40): _git_ok("src/code.py\n"),
                 }
@@ -484,6 +493,7 @@ class ResultVerificationTests(unittest.TestCase):
                             ("-C", str(worktree), "rev-parse", "HEAD"): _git_ok("b" * 40),
                             ("-C", str(root), "merge-base", "--is-ancestor", "a" * 40, "b" * 40): _git_ok(""),
                             ("-C", str(root), "-c", "core.quotepath=false", "diff", "--name-only", "a" * 40 + ".." + "b" * 40): _git_ok(""),
+                            ("-C", str(root), "cat-file", "-e", "a" * 40 + ":paulsha_cortex/persona/personas.yaml"): _git_ok(""),
                             ("-C", str(root), "show", "a" * 40 + ":paulsha_cortex/persona/personas.yaml"): _git_ok(base_catalog),
                             ("-C", str(root), "-c", "core.quotepath=false", "diff", "--name-only", "a" * 40 + "..." + "b" * 40): _git_ok(""),
                         }
@@ -554,6 +564,7 @@ class ResultVerificationTests(unittest.TestCase):
                     ("-C", str(worktree), "rev-parse", "HEAD"): _git_ok("b" * 40),
                     ("-C", str(root), "merge-base", "--is-ancestor", "a" * 40, "b" * 40): _git_ok(""),
                     ("-C", str(root), "-c", "core.quotepath=false", "diff", "--name-only", "a" * 40 + ".." + "b" * 40): _git_ok(""),
+                    ("-C", str(root), "cat-file", "-e", "a" * 40 + ":paulsha_cortex/persona/personas.yaml"): _git_ok(""),
                     ("-C", str(root), "show", "a" * 40 + ":paulsha_cortex/persona/personas.yaml"): _git_ok(base_catalog),
                     ("-C", str(root), "-c", "core.quotepath=false", "diff", "--name-only", "a" * 40 + "..." + "b" * 40): _git_ok(""),
                     (
@@ -616,6 +627,7 @@ class ResultVerificationTests(unittest.TestCase):
                     ("-C", str(worktree), "rev-parse", "HEAD"): _git_ok("b" * 40),
                     ("-C", str(root), "merge-base", "--is-ancestor", "a" * 40, "b" * 40): _git_ok(""),
                     ("-C", str(root), "-c", "core.quotepath=false", "diff", "--name-only", "a" * 40 + ".." + "b" * 40): _git_ok(""),
+                    ("-C", str(root), "cat-file", "-e", "a" * 40 + ":paulsha_cortex/persona/personas.yaml"): _git_ok(""),
                     ("-C", str(root), "show", "a" * 40 + ":paulsha_cortex/persona/personas.yaml"): _git_ok(base_catalog),
                     ("-C", str(root), "-c", "core.quotepath=false", "diff", "--name-only", "a" * 40 + "..." + "b" * 40): _git_ok(""),
                     (
@@ -674,6 +686,7 @@ class ResultVerificationTests(unittest.TestCase):
                             ("-C", str(worktree), "rev-parse", "HEAD"): _git_ok("b" * 40),
                             ("-C", str(root), "merge-base", "--is-ancestor", "a" * 40, "b" * 40): _git_ok(""),
                             ("-C", str(root), "-c", "core.quotepath=false", "diff", "--name-only", "a" * 40 + ".." + "b" * 40): _git_ok(""),
+                            ("-C", str(root), "cat-file", "-e", "a" * 40 + ":paulsha_cortex/persona/personas.yaml"): _git_ok(""),
                             ("-C", str(root), "show", "a" * 40 + ":paulsha_cortex/persona/personas.yaml"): _git_ok(base_catalog),
                             ("-C", str(root), "-c", "core.quotepath=false", "diff", "--name-only", "a" * 40 + "..." + "b" * 40): _git_ok(""),
                             (
@@ -762,6 +775,7 @@ class ResultVerificationTests(unittest.TestCase):
                     ],
                     ("-C", str(root), "merge-base", "--is-ancestor", "a" * 40, "b" * 40): _git_ok(""),
                     ("-C", str(root), "-c", "core.quotepath=false", "diff", "--name-only", "a" * 40 + ".." + "b" * 40): _git_ok(""),
+                    ("-C", str(root), "cat-file", "-e", "a" * 40 + ":paulsha_cortex/persona/personas.yaml"): _git_ok(""),
                     ("-C", str(root), "show", "a" * 40 + ":paulsha_cortex/persona/personas.yaml"): _git_ok(base_catalog),
                     ("-C", str(root), "-c", "core.quotepath=false", "diff", "--name-only", "a" * 40 + "..." + "b" * 40): _git_ok(""),
                     (
@@ -818,6 +832,7 @@ class ResultVerificationTests(unittest.TestCase):
                     ("-C", str(worktree), "status", "--porcelain", "--untracked-files=all"): [_git_ok(""), _git_ok("")],
                     ("-C", str(root), "merge-base", "--is-ancestor", "a" * 40, "b" * 40): _git_ok(""),
                     ("-C", str(root), "-c", "core.quotepath=false", "diff", "--name-only", "a" * 40 + ".." + "b" * 40): _git_ok(""),
+                    ("-C", str(root), "cat-file", "-e", "a" * 40 + ":paulsha_cortex/persona/personas.yaml"): _git_ok(""),
                     ("-C", str(root), "show", "a" * 40 + ":paulsha_cortex/persona/personas.yaml"): _git_ok(base_catalog),
                     ("-C", str(root), "-c", "core.quotepath=false", "diff", "--name-only", "a" * 40 + "..." + "b" * 40): _git_ok(""),
                     (
@@ -874,6 +889,7 @@ class ResultVerificationTests(unittest.TestCase):
                     ("-C", str(worktree), "status", "--porcelain", "--untracked-files=all"): [_git_ok(""), _git_ok("")],
                     ("-C", str(root), "merge-base", "--is-ancestor", "a" * 40, "b" * 40): _git_ok(""),
                     ("-C", str(root), "-c", "core.quotepath=false", "diff", "--name-only", "a" * 40 + ".." + "b" * 40): _git_ok(""),
+                    ("-C", str(root), "cat-file", "-e", "a" * 40 + ":paulsha_cortex/persona/personas.yaml"): _git_ok(""),
                     ("-C", str(root), "show", "a" * 40 + ":paulsha_cortex/persona/personas.yaml"): _git_ok(base_catalog),
                     ("-C", str(root), "-c", "core.quotepath=false", "diff", "--name-only", "a" * 40 + "..." + "b" * 40): _git_ok(""),
                     (
@@ -914,6 +930,262 @@ class ResultVerificationTests(unittest.TestCase):
 
             self.assertEqual(evidence["payload"]["status"], "needs_human")
             self.assertEqual(evidence["payload"]["summary"], "base-full-suite-timeout")
+
+
+class PersonaCatalogPortabilityTests(unittest.TestCase):
+    """#295／#291：非 cortex repo 的 dispatch_base tree 沒有
+    paulsha_cortex/persona/personas.yaml 時，persona gate 必須回退套件內建 catalog，
+    而不是確定性卡在 persona-catalog-unreadable。"""
+
+    def test_non_cortex_repo_without_local_catalog_passes_persona_gate(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            root = Path(d)
+            worktree = root / "candidate"
+            worktree.mkdir()
+            contract = _contract(docs_class="code")
+            slice_row = _slice_row(root, "slice-a", contract, dispatch_base="a" * 40, worktree=worktree)
+            job = _job("slice-a", worktree)
+            git_runner = FakeGitRunner(
+                {
+                    ("-C", str(root), "rev-parse", job["branch"]): [_git_ok("b" * 40), _git_ok("b" * 40)],
+                    ("-C", str(worktree), "rev-parse", "HEAD"): _git_ok("b" * 40),
+                    ("-C", str(root), "merge-base", "--is-ancestor", "a" * 40, "b" * 40): _git_ok(""),
+                    ("-C", str(root), "-c", "core.quotepath=false", "diff", "--name-only", "a" * 40 + ".." + "b" * 40): _git_ok(""),
+                    ("-C", str(root), "cat-file", "-e", "a" * 40 + ":paulsha_cortex/persona/personas.yaml"): _git_fail(),
+                    ("-C", str(root), "-c", "core.quotepath=false", "diff", "--name-only", "a" * 40 + "..." + "b" * 40): _git_ok(""),
+                    (
+                        "-C",
+                        str(root),
+                        "worktree",
+                        "add",
+                        "--detach",
+                        str(root / ".psc-verification-worktrees" / "slice-a-aaaaaaaaaaaa"),
+                        "a" * 40,
+                    ): _git_ok(""),
+                    (
+                        "-C",
+                        str(root),
+                        "worktree",
+                        "remove",
+                        "--force",
+                        str(root / ".psc-verification-worktrees" / "slice-a-aaaaaaaaaaaa"),
+                    ): _git_ok(""),
+                }
+            )
+            proc_runner = FakeSubprocessRunner(
+                {
+                    ("python3", "-m", "pytest", "-q", "tests/policy.py"): _proc_ok(),
+                    ("python3", "-m", "pytest", "-q"): [_proc_ok(), _proc_ok()],
+                }
+            )
+
+            evidence = verification.run_result_verification(
+                slice_row=slice_row,
+                job=job,
+                repo_root=root,
+                coordinator_root=root / "coordinator",
+                git_runner=git_runner,
+                subprocess_runner=proc_runner,
+            )
+
+            self.assertNotEqual(evidence["payload"]["summary"], "persona-catalog-unreadable")
+            self.assertEqual(evidence["payload"]["status"], "reviewing")
+            persona_catalog = evidence["payload"]["details"]["persona_catalog"]
+            self.assertEqual(persona_catalog["source"], "packaged")
+            self.assertIsNone(persona_catalog["commit"])
+            self.assertNotIn(
+                ("-C", str(root), "show", "a" * 40 + ":paulsha_cortex/persona/personas.yaml"),
+                [tuple(call) for call in git_runner.calls],
+            )
+
+    def test_repo_local_catalog_overrides_packaged(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            root = Path(d)
+            worktree = root / "candidate"
+            worktree.mkdir()
+            override_catalog = _persona_catalog(builder_paths=["docs/**"])
+            contract = _contract(docs_class="code")
+            slice_row = _slice_row(root, "slice-a", contract, dispatch_base="a" * 40, worktree=worktree)
+            job = _job("slice-a", worktree)
+            git_runner = FakeGitRunner(
+                {
+                    ("-C", str(root), "rev-parse", job["branch"]): [_git_ok("b" * 40), _git_ok("b" * 40)],
+                    ("-C", str(worktree), "rev-parse", "HEAD"): _git_ok("b" * 40),
+                    ("-C", str(root), "merge-base", "--is-ancestor", "a" * 40, "b" * 40): _git_ok(""),
+                    ("-C", str(root), "-c", "core.quotepath=false", "diff", "--name-only", "a" * 40 + ".." + "b" * 40): _git_ok(""),
+                    ("-C", str(root), "cat-file", "-e", "a" * 40 + ":paulsha_cortex/persona/personas.yaml"): _git_ok(""),
+                    ("-C", str(root), "show", "a" * 40 + ":paulsha_cortex/persona/personas.yaml"): _git_ok(override_catalog),
+                    ("-C", str(root), "-c", "core.quotepath=false", "diff", "--name-only", "a" * 40 + "..." + "b" * 40): _git_ok(""),
+                    (
+                        "-C",
+                        str(root),
+                        "worktree",
+                        "add",
+                        "--detach",
+                        str(root / ".psc-verification-worktrees" / "slice-a-aaaaaaaaaaaa"),
+                        "a" * 40,
+                    ): _git_ok(""),
+                    (
+                        "-C",
+                        str(root),
+                        "worktree",
+                        "remove",
+                        "--force",
+                        str(root / ".psc-verification-worktrees" / "slice-a-aaaaaaaaaaaa"),
+                    ): _git_ok(""),
+                }
+            )
+            proc_runner = FakeSubprocessRunner(
+                {
+                    ("python3", "-m", "pytest", "-q", "tests/policy.py"): _proc_ok(),
+                    ("python3", "-m", "pytest", "-q"): [_proc_ok(), _proc_ok()],
+                }
+            )
+
+            evidence = verification.run_result_verification(
+                slice_row=slice_row,
+                job=job,
+                repo_root=root,
+                coordinator_root=root / "coordinator",
+                git_runner=git_runner,
+                subprocess_runner=proc_runner,
+            )
+
+            self.assertEqual(evidence["payload"]["status"], "reviewing")
+            persona_catalog = evidence["payload"]["details"]["persona_catalog"]
+            self.assertEqual(persona_catalog["source"], "repo-local")
+            self.assertEqual(persona_catalog["commit"], "a" * 40)
+            self.assertEqual(persona_catalog["hash"], sha256(override_catalog.encode("utf-8")).hexdigest())
+
+    def test_declared_override_unreadable_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            root = Path(d)
+            worktree = root / "candidate"
+            worktree.mkdir()
+            contract = _contract(docs_class="code")
+            slice_row = _slice_row(root, "slice-a", contract, dispatch_base="a" * 40, worktree=worktree)
+            job = _job("slice-a", worktree)
+            git_runner = FakeGitRunner(
+                {
+                    ("-C", str(root), "rev-parse", job["branch"]): _git_ok("b" * 40),
+                    ("-C", str(worktree), "rev-parse", "HEAD"): _git_ok("b" * 40),
+                    ("-C", str(root), "merge-base", "--is-ancestor", "a" * 40, "b" * 40): _git_ok(""),
+                    ("-C", str(root), "-c", "core.quotepath=false", "diff", "--name-only", "a" * 40 + ".." + "b" * 40): _git_ok(""),
+                    ("-C", str(root), "cat-file", "-e", "a" * 40 + ":paulsha_cortex/persona/personas.yaml"): _git_ok(""),
+                    ("-C", str(root), "show", "a" * 40 + ":paulsha_cortex/persona/personas.yaml"): _git_fail("blob missing"),
+                }
+            )
+            proc_runner = FakeSubprocessRunner({})
+
+            evidence = verification.run_result_verification(
+                slice_row=slice_row,
+                job=job,
+                repo_root=root,
+                coordinator_root=root / "coordinator",
+                git_runner=git_runner,
+                subprocess_runner=proc_runner,
+            )
+
+            self.assertEqual(evidence["payload"]["status"], "needs_human")
+            self.assertEqual(evidence["payload"]["summary"], "persona-catalog-unreadable")
+            persona_catalog = evidence["payload"]["details"]["persona_catalog"]
+            self.assertEqual(persona_catalog["path"], "paulsha_cortex/persona/personas.yaml")
+            self.assertEqual(persona_catalog["commit"], "a" * 40)
+
+    def test_declared_override_invalid_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            root = Path(d)
+            worktree = root / "candidate"
+            worktree.mkdir()
+            contract = _contract(docs_class="code")
+            slice_row = _slice_row(root, "slice-a", contract, dispatch_base="a" * 40, worktree=worktree)
+            job = _job("slice-a", worktree)
+            git_runner = FakeGitRunner(
+                {
+                    ("-C", str(root), "rev-parse", job["branch"]): _git_ok("b" * 40),
+                    ("-C", str(worktree), "rev-parse", "HEAD"): _git_ok("b" * 40),
+                    ("-C", str(root), "merge-base", "--is-ancestor", "a" * 40, "b" * 40): _git_ok(""),
+                    ("-C", str(root), "-c", "core.quotepath=false", "diff", "--name-only", "a" * 40 + ".." + "b" * 40): _git_ok(""),
+                    ("-C", str(root), "cat-file", "-e", "a" * 40 + ":paulsha_cortex/persona/personas.yaml"): _git_ok(""),
+                    ("-C", str(root), "show", "a" * 40 + ":paulsha_cortex/persona/personas.yaml"): _git_ok("roles: [broken"),
+                }
+            )
+            proc_runner = FakeSubprocessRunner({})
+
+            evidence = verification.run_result_verification(
+                slice_row=slice_row,
+                job=job,
+                repo_root=root,
+                coordinator_root=root / "coordinator",
+                git_runner=git_runner,
+                subprocess_runner=proc_runner,
+            )
+
+            self.assertEqual(evidence["payload"]["status"], "needs_human")
+            self.assertEqual(evidence["payload"]["summary"], "persona-catalog-invalid")
+            persona_catalog = evidence["payload"]["details"]["persona_catalog"]
+            self.assertEqual(persona_catalog["path"], "paulsha_cortex/persona/personas.yaml")
+            self.assertEqual(persona_catalog["commit"], "a" * 40)
+
+    def test_cortex_repo_behavior_unchanged(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            root = Path(d)
+            worktree = root / "candidate"
+            worktree.mkdir()
+            base_catalog = _persona_catalog(builder_paths=["**"])
+            contract = _contract(docs_class="code")
+            slice_row = _slice_row(root, "slice-a", contract, dispatch_base="a" * 40, worktree=worktree)
+            job = _job("slice-a", worktree)
+            git_runner = FakeGitRunner(
+                {
+                    ("-C", str(root), "rev-parse", job["branch"]): [_git_ok("b" * 40), _git_ok("b" * 40)],
+                    ("-C", str(worktree), "rev-parse", "HEAD"): _git_ok("b" * 40),
+                    ("-C", str(root), "merge-base", "--is-ancestor", "a" * 40, "b" * 40): _git_ok(""),
+                    ("-C", str(root), "-c", "core.quotepath=false", "diff", "--name-only", "a" * 40 + ".." + "b" * 40): _git_ok(""),
+                    ("-C", str(root), "cat-file", "-e", "a" * 40 + ":paulsha_cortex/persona/personas.yaml"): _git_ok(""),
+                    ("-C", str(root), "show", "a" * 40 + ":paulsha_cortex/persona/personas.yaml"): _git_ok(base_catalog),
+                    ("-C", str(root), "-c", "core.quotepath=false", "diff", "--name-only", "a" * 40 + "..." + "b" * 40): _git_ok(""),
+                    (
+                        "-C",
+                        str(root),
+                        "worktree",
+                        "add",
+                        "--detach",
+                        str(root / ".psc-verification-worktrees" / "slice-a-aaaaaaaaaaaa"),
+                        "a" * 40,
+                    ): _git_ok(""),
+                    (
+                        "-C",
+                        str(root),
+                        "worktree",
+                        "remove",
+                        "--force",
+                        str(root / ".psc-verification-worktrees" / "slice-a-aaaaaaaaaaaa"),
+                    ): _git_ok(""),
+                }
+            )
+            proc_runner = FakeSubprocessRunner(
+                {
+                    ("python3", "-m", "pytest", "-q", "tests/policy.py"): _proc_ok(),
+                    ("python3", "-m", "pytest", "-q"): [_proc_ok(), _proc_ok()],
+                }
+            )
+
+            evidence = verification.run_result_verification(
+                slice_row=slice_row,
+                job=job,
+                repo_root=root,
+                coordinator_root=root / "coordinator",
+                git_runner=git_runner,
+                subprocess_runner=proc_runner,
+            )
+
+            self.assertEqual(evidence["payload"]["status"], "reviewing")
+            persona_catalog = evidence["payload"]["details"]["persona_catalog"]
+            self.assertEqual(persona_catalog["path"], "paulsha_cortex/persona/personas.yaml")
+            self.assertEqual(persona_catalog["commit"], "a" * 40)
+            self.assertEqual(persona_catalog["hash"], sha256(base_catalog.encode("utf-8")).hexdigest())
+            self.assertEqual(persona_catalog["source"], "repo-local")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 摘要

verification gate 先前無條件在**被治理 repo** 內 `git show <dispatch_base>:paulsha_cortex/persona/personas.yaml`。非 cortex repo 的 git tree 沒有這個檔，於是一律卡 `persona-catalog-unreadable` 且無法迴避。

persona 定義是 cortex 的產品資產，不該要求被治理 repo 長出該檔。

Closes #295
Closes #291

## 修法

`run_result_verification` 的 catalog 讀取段改為兩段式：

1. 先 `git cat-file -e {dispatch_base}:paulsha_cortex/persona/personas.yaml` 探測被治理 repo 是否**宣告** repo-local override。
2. 探測成功 → 照舊 pin 在 `dispatch_base` 讀取並驗證（`source: "repo-local"`）；**壞損時 fail-closed，不靜默回退**（R3／D3）。
3. 探測失敗（未宣告）→ 讀 `paulsha_cortex.persona.loader.DEFAULT_PERSONAS_PATH` 套件內建 catalog，同樣經 `_load_catalog_from_text` 驗證（`source: "packaged"`）。

兩個分支各自 fail-closed，不互相回退——這點很重要：宣告了 override 卻壞掉，必須報錯而非悄悄用內建版頂替。

## 驗證

- [x] 新增 `PersonaCatalogPortabilityTests`（5 個測試，對應 R1–R4）
- [x] `python3 -m pytest tests/ -q` → 1856 passed（main 基線約 1851）
- [x] 以隔離的 `PSC_MONITOR_STATE_ROOT`／`PSC_PROJECT_CONFIG_ROOT` 複驗，避免宿主狀態掩蓋
- [x] 本地 policy_check 帶 PR 上下文 → `fail: 0`
- [x] `changelog.d/fix-persona-catalog-portability-v2.md` fragment（R-09）＋ `CHANGELOG.md [Unreleased]` entry
- [x] openspec tasks.md 4 項全勾

## 規劃文件的兩處落差（如實記錄）

1. plan 的 RED 階段描述「五個新測試全數 FAIL」與 D3「既有 fail-closed 行為不可變」在字面上不一致——其中兩個測試（override 宣告存在但壞損）在新舊實作下輸出相同，實作前就已通過。未強改測試去湊出人為的全 FAIL。
2. plan Section 5 寫的 fragment 檔名為 `fix-persona-catalog-portability.md`（無 `-v2`），與分支 slug 規則不符；採用 `-v2` 檔名。

## 稽核註記

本次由 Claude Code subagent 直接完成 TDD，未透過 coordinator 實際派工 copilot 執行；workstream todo 中對應項目已據實標註，「ForeignReview／operator 驗收」未勾。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QEGoUsBgzDSa6h9Ch8H5iX