### PR TITLE
test(deck): 補齊 task_type taxonomy 契約的測試覆蓋

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - **Issue #202：task_type 自動選牌與 fix-standard combo**：新增 deck taxonomy loader／selector、`fix-standard` workflow combo、`WorkflowRun.combo_selection` provenance、`cortex work start --combo` authoritative override，以及 `cortex stat --combo-selections` 彙總。Refs #202。
 
 ### Fixed
+- **Issue #139：`task_type` taxonomy 契約補齊測試覆蓋並確認驗收面**：`paulsha_cortex/deck/data/task-types.yaml`（雙鎖值域＋scope 受控詞典）與 `paulsha_cortex/deck/task_types.py`（fail-closed loader、`classify_title` 五類判定）已隨 #202 提前落地，本票確認其符合 spec 的 R1–R6，並補齊 `tests/test_deck_task_types.py` 缺口測試（值域漂移拒載、空描述拒載、未知 combo 引用拒載、五類處置映射全稱驗證）；R7（統一 log reader／status view 介面契約）維持只定契約不實作。
 - **CI 測試閘門形同虛設（tests.yml 偵測誤判）**：`ls tests/test_*.py tests/*_test.py` 只要任一 glob 沒配到就回傳非零，本 repo 因此恆判為「無測試套件」而跳過整段 pytest 卻回報 success；改用 `find -print -quit`。
 - **Issue #263：ship validator 重排為本地 closeout 先於 PR metadata preflight**：archive commit 不再內嵌 push；pre-PR metadata preflight 失敗改回可 resume 的 `pr-preflight-blocked` typed stop、通過後照舊自動建立 PR；slice-based review worktree 補上 frozen authority materialize 與 hash 驗證。
 - **Issue #263 補遺（PR #336 code review）**：review worktree authority materialize 的路徑檢查改為先驗證後動作（拒絕 `..`／絕對路徑 ref 於任何 mkdir 之前）；`work_bridge._manager_archive_applied()` 改委派 `manager` 版避免與 `any(...)` 舊語意漂移；`_slice_review_authority_inputs()` 相對 plan/spec path 改以 repo_root 解析，對齊 `_pinned_input_mismatches()` 既有語意。

--- a/changelog.d/design-task-type-taxonomy-v2.md
+++ b/changelog.d/design-task-type-taxonomy-v2.md
@@ -1,0 +1,13 @@
+### Fixed
+- **Issue #139：`task_type` taxonomy 契約補齊測試覆蓋並確認驗收面**：
+  `paulsha_cortex/deck/data/task-types.yaml`（雙鎖值域＋scope 受控詞典）與
+  `paulsha_cortex/deck/task_types.py`（fail-closed loader、`classify_title`
+  五類判定）已隨 #202 提前落地（PR #335 為解 #202/#139 循環等待，在自身實作內
+  一併鋪好 #139 骨架），本票確認其符合
+  `docs/superpowers/specs/design-task-type-taxonomy-v2-spec.md` 的 R1–R6，
+  並補齊 `tests/test_deck_task_types.py` 缺口測試：值域漂移拒載、空描述拒載、
+  未知 combo 引用拒載、五類處置映射全稱驗證（`test_disposition_mapping_is_total`）。
+  `paulsha_cortex/deck/selector.py`／`coordinator/work_bridge.py` 均已透過
+  `classify_title`／`load_task_types` 消費本契約，未自建第二份值域，符合 R6
+  下游邊界。R7（統一 log reader／status view 介面契約）維持只定契約不實作，
+  如 spec 所載。

--- a/docs/superpowers/workstreams/design-task-type-taxonomy-v2/todo.md
+++ b/docs/superpowers/workstreams/design-task-type-taxonomy-v2/todo.md
@@ -7,8 +7,8 @@ work_item: design-task-type-taxonomy-v2
 
 ## Tasks
 
-- [ ] 將 issue #139、active OpenSpec change `2026-08-04-design-task-type-taxonomy` 與本 Todo 綁定為同一 confirmed Work Item。
-- [ ] coordinator 派工 copilot（gpt-5.4）以 TDD 完成 #139：先寫 RED 測試，再實作到 GREEN。
+- [x] 將 issue #139、active OpenSpec change `2026-08-04-design-task-type-taxonomy` 與本 Todo 綁定為同一 confirmed Work Item。（`.cortex/work-items.yaml` 已有 `design-task-type-taxonomy-v2` 條目連結本 todo 與 spec。）
+- [ ] coordinator 派工 copilot（gpt-5.4）以 TDD 完成 #139：先寫 RED 測試，再實作到 GREEN。（實際交付路徑與此不同：契約骨架與多數測試已隨 #202 的 PR #335 由該票的 TDD 循環提前落地；本輪由 Claude（Opus）在既有 worktree 直接補齊 plan 缺漏的四項測試並核對驗收面，非 coordinator 派工 copilot 走出的獨立 RED→GREEN 循環，故此項不勾。）
 - [ ] ForeignReview（claude（sonnet））review 通過；operator 驗收核可。
-- [ ] `changelog.d/design-task-type-taxonomy.md` fragment 已新增且已 commit（R-09 硬性 gate）；`CHANGELOG.md [Unreleased]` 有對應 entry。
-- [ ] 帶 PR 上下文執行 `policy_check`（`--pr-title`／`--pr-body`／`--pr-labels`／`--pr-base-ref`／`--pr-head-ref`）確認 fail: 0；全套 pytest 通過。
+- [x] `changelog.d/design-task-type-taxonomy-v2.md` fragment 已新增且已 commit（R-09 硬性 gate）；`CHANGELOG.md [Unreleased]` 有對應 entry。
+- [x] 帶 PR 上下文執行 `policy_check`（`--pr-title`／`--pr-body`／`--pr-labels`／`--pr-base-ref`／`--pr-head-ref`）確認 fail: 0；全套 pytest 通過。

--- a/openspec/changes/2026-08-04-design-task-type-taxonomy/tasks.md
+++ b/openspec/changes/2026-08-04-design-task-type-taxonomy/tasks.md
@@ -5,10 +5,10 @@ work_item: design-task-type-taxonomy-v2
 
 # Tasks
 
-- [ ] 1.1 RED：依 `docs/superpowers/plans/design-task-type-taxonomy-v2.md` 的 TDD RED 章節新增 `tests/test_deck_task_types.py`，確認失敗。
-- [ ] 1.2 實作至 GREEN，範圍限於 `docs/superpowers/specs/design-task-type-taxonomy-v2-spec.md` 的 Requirements（契約檔 `paulsha_cortex/deck/data/task-types.yaml` 與 `paulsha_cortex/deck/task_types.py`）。
-- [ ] 1.3 `changelog.d/design-task-type-taxonomy.md` fragment 與 `CHANGELOG.md [Unreleased]` entry（#139）。
-- [ ] 1.4 `python3 -m pytest tests/ -q` 全綠；帶 PR 上下文的 `policy_check` 0 fail；`git diff --check` 乾淨。
+- [x] 1.1 RED：依 `docs/superpowers/plans/design-task-type-taxonomy-v2.md` 的 TDD RED 章節新增 `tests/test_deck_task_types.py`，確認失敗。（`tests/test_deck_task_types.py` 與其實作已隨 #202 的 PR #335 提前落地，先於本票收斂；本票補齊 plan 列出但缺漏的四項覆蓋：值域漂移拒載、空描述拒載、未知 combo 引用拒載、`test_disposition_mapping_is_total`。）
+- [x] 1.2 實作至 GREEN，範圍限於 `docs/superpowers/specs/design-task-type-taxonomy-v2-spec.md` 的 Requirements（契約檔 `paulsha_cortex/deck/data/task-types.yaml` 與 `paulsha_cortex/deck/task_types.py`）。（同上，已由 #202 落地並經本票逐條核對 R1–R6 皆滿足；R5 的 `fix` → `fix-standard` 映射是 #202 openspec change 自身核可的顯式決策，屬 spec 非目標段落已預留的「叢集另案」，非本票偏離。）
+- [x] 1.3 `changelog.d/design-task-type-taxonomy-v2.md` fragment 與 `CHANGELOG.md [Unreleased]` entry（#139）。（檔名依實際分支 `feature/139-design-task-type-taxonomy-v2` 的 slug 命名為 `-v2`；plan／此檔原文的 `design-task-type-taxonomy.md` 為重識別前的舊稱。）
+- [x] 1.4 `python3 -m pytest tests/ -q` 全綠；帶 PR 上下文的 `policy_check` 0 fail；`git diff --check` 乾淨。
 
 ## 驗收
 

--- a/tests/test_deck_task_types.py
+++ b/tests/test_deck_task_types.py
@@ -62,6 +62,50 @@ def test_loader_rejects_invalid_scopes(tmp_path: Path, replace_with: str) -> Non
         load_task_types(_write(tmp_path, "task-types.yaml", bad), combos=_combo_catalog())
 
 
+@pytest.mark.parametrize(
+    "mutation, expected_marker",
+    [
+        (
+            lambda text: text.replace(
+                "scopes:\n",
+                "  perf:\n    description: 效能調校\n    combo: null\nscopes:\n",
+                1,
+            ),
+            "perf",
+        ),
+        (
+            lambda text: text.replace(
+                "  refactor:\n    description: 重構整理\n    combo: null\n", ""
+            ),
+            "refactor",
+        ),
+    ],
+)
+def test_loader_rejects_value_domain_drift(tmp_path: Path, mutation, expected_marker: str) -> None:
+    original = DEFAULT_TASK_TYPES_PATH.read_text(encoding="utf-8")
+    bad = mutation(original)
+    assert bad != original
+
+    with pytest.raises(DeckSchemaError, match=expected_marker):
+        load_task_types(_write(tmp_path, "task-types.yaml", bad), combos=_combo_catalog())
+
+
+def test_loader_rejects_empty_description(tmp_path: Path) -> None:
+    original = DEFAULT_TASK_TYPES_PATH.read_text(encoding="utf-8")
+    bad = original.replace("description: 新增功能", 'description: ""', 1)
+    assert bad != original
+
+    with pytest.raises(DeckSchemaError, match="description"):
+        load_task_types(_write(tmp_path, "task-types.yaml", bad), combos=_combo_catalog())
+
+
+def test_loader_rejects_unknown_combo_reference(tmp_path: Path) -> None:
+    incomplete_combos = {"feature-oneshot": object()}
+
+    with pytest.raises(DeckSchemaError, match="fix-standard"):
+        load_task_types(DEFAULT_TASK_TYPES_PATH, combos=incomplete_combos)
+
+
 def test_classify_matched_with_scope() -> None:
     taxonomy = load_task_types(combos=_combo_catalog())
 
@@ -117,3 +161,28 @@ def test_classify_absent_and_unparseable() -> None:
     assert absent.disposition == "bypass"
     assert unparseable.kind == "unparseable"
     assert unparseable.disposition == "bypass"
+
+
+def test_disposition_mapping_is_total() -> None:
+    taxonomy = load_task_types(combos=_combo_catalog())
+    representative_titles = {
+        "matched": "feat: 新增選牌",
+        "unknown_type": "perf(cli): accelerate combo lookup",
+        "ambiguous": "fix(claimx): 修正",
+        "absent": "repair selector fallback",
+        "unparseable": "fix(: broken",
+    }
+
+    classifications = {kind: classify_title(title, taxonomy) for kind, title in representative_titles.items()}
+    dispositions = {kind: classification.disposition for kind, classification in classifications.items()}
+
+    assert dispositions == {
+        "matched": "proceed",
+        "unknown_type": "fail_closed",
+        "ambiguous": "fail_closed",
+        "absent": "bypass",
+        "unparseable": "bypass",
+    }
+    # 五類皆有定義、無未定義分支：kind 本身也須與 representative title 對得上。
+    for kind, classification in classifications.items():
+        assert classification.kind == kind


### PR DESCRIPTION
## 摘要

**這張票的骨架已經被交付了。** `feat-task-type-combo-selector` 的實作者為了自己的 selector，把本 work item 的整套契約骨架（`deck/data/task-types.yaml`、`deck/task_types.py` 的 loader 與 `classify_title`、以及大部分測試）**一併內建交付**，沒有等本票先落地。

Closes #139

## 因此本 PR 不含 production code

逐條核對 `docs/superpowers/specs/design-task-type-taxonomy-v2-spec.md` 的每個 Requirement：

| Requirement | 狀態 |
|---|---|
| R1–R4（凍結 6 值域、scope 字典、fail-closed loader、5 路分類） | 既有實作已完全滿足 |
| R6（下游邊界） | 已確認 `deck/selector.py` 與 `coordinator/work_bridge.py` 都消費 `classify_title`／`load_task_types`，未自行實作解析或第二套值域 |
| R7（log reader／status view 介面契約） | 正確地維持為文件、無程式碼——符合 spec 自己的非目標 |

實際缺口只有**測試覆蓋**：plan 的 TDD RED 清單有四項未被既有測試涵蓋。本 PR 補上：

- `test_loader_rejects_value_domain_drift`
- `test_loader_rejects_empty_description`
- `test_loader_rejects_unknown_combo_reference`
- `test_disposition_mapping_is_total`

四項均對既有 production code 直接通過（實作本來就正確，只是測試薄）。

## R5 的規劃漂移（非未授權偏離）

spec 文字寫初始映射為 `feat → feature-oneshot`、其餘全 `null`（非目標明列「不新增 `fix` 等 type 的 combo」），但現況是 `fix → fix-standard`。

這是**刻意且經另案核可**的決定：`feat-task-type-combo-selector` 的 openspec proposal 明文記載「`task-types.yaml` 的 `fix` 映射改為 `fix-standard`」，而本票 spec 的非目標本來就把此事保留為「叢集另案」。屬凍結規劃快照與後續獨立決策之間的預期漂移，不是缺陷。

## 驗證

- [x] `python3 -m pytest tests/ -q` → 1856 passed（main 基線約 1851）
- [x] 本地 policy_check 帶 PR 上下文 → `fail: 0`
- [x] `changelog.d/design-task-type-taxonomy-v2.md` fragment（R-09）＋ `CHANGELOG.md [Unreleased]` entry
- [x] openspec tasks.md 全勾，並註記 provenance 與上述兩處落差

## 稽核註記

本次由 Claude Code subagent 直接完成，未透過 coordinator 派工；workstream todo 中「coordinator 派工 copilot」與「ForeignReview／operator 驗收」兩項據實未勾。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QEGoUsBgzDSa6h9Ch8H5iX