### PR TITLE
feat(cli): jobs/stat 補 workflow lane job 的歸屬欄位

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Changed
 - **封存批次 W2 三個已交付的 OpenSpec changes**：#294／#263／#202 的 change 已隨 PR 合併，但本批改由人工管線收尾未經 cortex ship，故 change 目錄仍 active；以官方 archive 折入 canonical specs。
 ### Added
+- **Issue #323：`cortex jobs`／`stat` 對 workflow lane job 補 work_id／primary issue 歸屬欄**：`wf-xxxxxxxx-<card>-<n>` job 輸出新增 `workflow_work_id`／`workflow_primary_issue` 兩欄，於輸出端以既有 `workflow_run_id` join registry 的 workflow run，零額外持久化狀態；card 已由既有 `workflow_card` 欄位提供。非 workflow lane job 與其餘既有欄位皆不受影響。
 - **Refs #294：slice spec 可宣告 executor/model_id 並於派工前強制 registry 驗證**：`dispatch_ready` 支援逐 slice 的 builder identity 覆寫，unknown identity fail-closed 並列出可用 candidates；同時 `cortex fanout`／`tick` 的明確 `(executor, model)` 與 periodic tick 預設 model 也改為先查 `model-identities.yaml`，避免 typo 直到 session 內才失敗。
 - **Issue #202：task_type 自動選牌與 fix-standard combo**：新增 deck taxonomy loader／selector、`fix-standard` workflow combo、`WorkflowRun.combo_selection` provenance、`cortex work start --combo` authoritative override，以及 `cortex stat --combo-selections` 彙總。Refs #202。
 

--- a/changelog.d/jobs-stat-attribution-columns.md
+++ b/changelog.d/jobs-stat-attribution-columns.md
@@ -1,0 +1,2 @@
+### Added
+- **Issue #323：`cortex jobs`／`stat` 對 workflow lane job 補 work_id／primary issue 歸屬欄**：`wf-xxxxxxxx-<card>-<n>` job 輸出新增 `workflow_work_id`／`workflow_primary_issue` 兩欄，於輸出端以既有 `workflow_run_id` join registry 的 workflow run（`work_id`／`issue_refs[0]`），零額外持久化狀態；card 已由既有 `workflow_card` 欄位提供。非 workflow lane job（無 `workflow_run_id`）與其餘既有欄位皆不受影響，兩新欄位一律出現、值為 `null`，operator 不再需要手動 join job row 與 run row 才能判讀某個 job 屬於哪個 work item、對應哪張 issue。

--- a/paulsha_cortex/coordinator/cli.py
+++ b/paulsha_cortex/coordinator/cli.py
@@ -4,12 +4,13 @@ import argparse
 import json
 import sys
 from pathlib import Path
-from typing import Callable, Sequence
+from typing import Any, Callable, Sequence
 
 from . import autonomy, broker_reaper
 from .launcher import _ARGV_BUILDERS, AgentLauncher, SubprocessLauncher
 from .registry import JobRegistry
 from .seams import PaneSender, ScriptWorktreeCreator, TmuxPaneSender, WorktreeCreator
+from .workflow import WorkflowRun
 
 DEFAULT_REQUEST_TIMEOUT_SECONDS = 5.0
 DEFAULT_REQUEST_POLL_INTERVAL_SECONDS = 0.1
@@ -45,6 +46,44 @@ def _refuse_unsafe_fanout(metas, predicate, *, allow_unsafe, max_ready=1):
         raise ValueError(
             f"--allow-unsafe 僅允許 ≤{max_ready} 個就緒 slice（canary 一次一個），實得 {len(ready)}"
         )
+
+
+def _workflow_run_attribution(run: WorkflowRun | None) -> dict[str, str | None]:
+    """把 WorkflowRun 投影成 job 輸出要補的歸屬欄位（#323）：
+    ``workflow_work_id``／``workflow_primary_issue``。``run`` 為 ``None``
+    （非 workflow lane job，或 workflow_run_id 已查無對應 run）時兩欄位皆為
+    ``None``，與既有 ``workflow_*`` 欄位「一律出現、N/A 時為 null」的慣例一致，
+    讓既有消費者可安全假設欄位存在而不必分支處理缺欄位。card 已由既有
+    ``workflow_card`` 欄位提供，不重複新增。"""
+    return {
+        "workflow_work_id": run.work_id if run is not None else None,
+        "workflow_primary_issue": (
+            run.issue_refs[0] if run is not None and run.issue_refs else None
+        ),
+    }
+
+
+def _attribute_job(job: dict[str, Any], reg: JobRegistry) -> dict[str, Any]:
+    """單一 job dict（``stat``）的輸出端補欄：依 ``workflow_run_id`` join
+    registry 現有的 workflow run，零額外持久化狀態。"""
+    workflow_run_id = job.get("workflow_run_id")
+    run: WorkflowRun | None = None
+    if isinstance(workflow_run_id, str) and workflow_run_id:
+        try:
+            run = reg.get_workflow_run(workflow_run_id)
+        except KeyError:
+            run = None
+    job.update(_workflow_run_attribution(run))
+    return job
+
+
+def _attribute_jobs(jobs: list[dict[str, Any]], reg: JobRegistry) -> list[dict[str, Any]]:
+    """``jobs`` 列表輸出端補欄：一次性把 workflow runs 建成 ``run_id`` 索引，
+    避免對每個 job 各自線性掃描 registry 的 workflow run 列表。"""
+    runs_by_id = {run.run_id: run for run in reg.list_workflow_runs()}
+    for job in jobs:
+        job.update(_workflow_run_attribution(runs_by_id.get(job.get("workflow_run_id"))))
+    return jobs
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -407,7 +446,7 @@ def main(
     reg = registry if registry is not None else JobRegistry()
 
     if args.cmd == "jobs":
-        print(json.dumps(reg.list_jobs(), ensure_ascii=False))
+        print(json.dumps(_attribute_jobs(reg.list_jobs(), reg), ensure_ascii=False))
         return 0
 
     if args.cmd == "stat":
@@ -455,7 +494,7 @@ def main(
         except KeyError as exc:
             print(f"錯誤: {exc}", file=sys.stderr)
             return 1
-        print(json.dumps(job, ensure_ascii=False))
+        print(json.dumps(_attribute_job(job, reg), ensure_ascii=False))
         return 0
 
     return 2  # pragma: no cover（argparse required=True 已擋）

--- a/tests/test_cli_jobs_stat_attribution_323.py
+++ b/tests/test_cli_jobs_stat_attribution_323.py
@@ -1,0 +1,226 @@
+"""#323：``cortex jobs``／``stat`` 對 workflow lane job 補 work_id／primary
+issue 歸屬欄——operator 原本得手動 join ``jobs.json`` 的 job row
+（``workflow_run_id``／``worktree``／``branch``）與 run row（``work_id``／
+``issue_refs``）才能判讀某個 ``wf-xxxxxxxx-<card>-<n>`` job 屬於哪個 work
+item、對應哪張 issue。card 已由既有 ``workflow_card`` 欄位提供，本次只補
+``workflow_work_id``／``workflow_primary_issue`` 兩欄，皆為輸出端 join，零
+額外持久化狀態；既有欄位一律保留不變。
+
+比照 #223 ``test_cli_stat_decomposition_depths_223.py`` 的 ``_manager_create_
+workflow_run`` 測試模式。
+"""
+
+from __future__ import annotations
+
+import io
+import json
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+
+from paulsha_cortex.coordinator import cli as coordinator_cli
+from paulsha_cortex.coordinator.registry import JobRegistry
+from paulsha_cortex.coordinator.workflow import WorkflowStep
+
+
+def _step() -> WorkflowStep:
+    return WorkflowStep(
+        phase="build",
+        persona="builder",
+        card="subagent-build",
+        executor="agy",
+        model="gemini-3.1-pro-high",
+        domain="google",
+        inputs=(),
+        outputs=(),
+        gate_result="pending",
+    )
+
+
+def _create_run(registry: JobRegistry, *, work_id: str, claim_seed: str, issue_refs=()):
+    return registry._manager_create_workflow_run(
+        repo="hamanpaul/paulsha-cortex",
+        work_id=work_id,
+        claim_key=f"claim:v1:{claim_seed * 64}",
+        source_revision="rev-323",
+        workspace_root="/tmp/workspace",
+        combo="feature-oneshot",
+        current_phase="build",
+        steps=(_step(),),
+        issue_refs=tuple(issue_refs),
+    )
+
+
+def test_jobs_workflow_lane_job_gets_work_id_and_primary_issue(tmp_path: Path) -> None:
+    registry = JobRegistry(state_path=tmp_path / "jobs.json")
+    run = _create_run(
+        registry,
+        work_id="323-jobs-stat-attribution",
+        claim_seed="1",
+        issue_refs=("hamanpaul/paulsha-cortex#323",),
+    )
+    registry.create_job(
+        task="wf-18dfaa134b-subagent-build",
+        persona="builder",
+        branch="feature/323-323-jobs-stat-attribution",
+        pane="",
+        worktree="/wt/323",
+        workflow_run_id=run.run_id,
+        workflow_card="subagent-build",
+    )
+
+    buffer = io.StringIO()
+    with redirect_stdout(buffer):
+        exit_code = coordinator_cli.main(["jobs"], registry=registry)
+    assert exit_code == 0
+    jobs = json.loads(buffer.getvalue())
+    assert len(jobs) == 1
+    job = jobs[0]
+
+    # 既有欄位不變（只增不改不刪）。
+    assert job["job_id"] == "wf-18dfaa134b-subagent-build-1"
+    assert job["workflow_run_id"] == run.run_id
+    assert job["workflow_card"] == "subagent-build"
+    assert job["worktree"] == "/wt/323"
+    assert job["branch"] == "feature/323-323-jobs-stat-attribution"
+
+    # 新欄位：join registry 的 workflow run 得出。
+    assert job["workflow_work_id"] == "323-jobs-stat-attribution"
+    assert job["workflow_primary_issue"] == "hamanpaul/paulsha-cortex#323"
+
+
+def test_jobs_non_workflow_job_new_fields_are_null(tmp_path: Path) -> None:
+    registry = JobRegistry(state_path=tmp_path / "jobs.json")
+    registry.create_job(
+        task="add-cortex-version-flag-build",
+        persona="builder",
+        branch="feature/add-cortex-version-flag-build",
+        pane="",
+        worktree="/wt/legacy",
+    )
+
+    buffer = io.StringIO()
+    with redirect_stdout(buffer):
+        exit_code = coordinator_cli.main(["jobs"], registry=registry)
+    assert exit_code == 0
+    jobs = json.loads(buffer.getvalue())
+    assert len(jobs) == 1
+    job = jobs[0]
+
+    assert job["workflow_run_id"] is None
+    assert job["workflow_card"] is None
+    # 非 workflow lane job 不受影響：新欄位存在但為 null（與既有 workflow_*
+    # 欄位「一律出現、N/A 時為 null」慣例一致），不是「不出現」。
+    assert "workflow_work_id" in job
+    assert job["workflow_work_id"] is None
+    assert "workflow_primary_issue" in job
+    assert job["workflow_primary_issue"] is None
+
+
+def test_jobs_workflow_run_with_no_issue_refs_primary_issue_is_null(tmp_path: Path) -> None:
+    # openspec-only work item：run 存在但 issue_refs 空，primary issue 應為 null
+    # 而非拋錯或省略欄位。
+    registry = JobRegistry(state_path=tmp_path / "jobs.json")
+    run = _create_run(
+        registry,
+        work_id="feat-work-gc-v2",
+        claim_seed="2",
+        issue_refs=(),
+    )
+    registry.create_job(
+        task="wf-abc123-subagent-build",
+        persona="builder",
+        branch="feature/feat-work-gc-v2",
+        pane="",
+        worktree="/wt/gc",
+        workflow_run_id=run.run_id,
+        workflow_card="subagent-build",
+    )
+
+    buffer = io.StringIO()
+    with redirect_stdout(buffer):
+        exit_code = coordinator_cli.main(["jobs"], registry=registry)
+    assert exit_code == 0
+    job = json.loads(buffer.getvalue())[0]
+    assert job["workflow_work_id"] == "feat-work-gc-v2"
+    assert job["workflow_primary_issue"] is None
+
+
+def test_jobs_dangling_workflow_run_id_does_not_crash(tmp_path: Path) -> None:
+    # 理論上不該發生，但輸出端 join 對查無 run 的 workflow_run_id 必須
+    # fail-soft（兩欄位皆 null），不得拋例外讓整個 jobs 輸出失敗。
+    registry = JobRegistry(state_path=tmp_path / "jobs.json")
+    registry.create_job(
+        task="wf-dangling-subagent-build",
+        persona="builder",
+        branch="feature/dangling",
+        pane="",
+        worktree="/wt/dangling",
+        workflow_run_id="workflow-does-not-exist",
+        workflow_card="subagent-build",
+    )
+
+    buffer = io.StringIO()
+    with redirect_stdout(buffer):
+        exit_code = coordinator_cli.main(["jobs"], registry=registry)
+    assert exit_code == 0
+    job = json.loads(buffer.getvalue())[0]
+    assert job["workflow_work_id"] is None
+    assert job["workflow_primary_issue"] is None
+
+
+def test_stat_single_job_workflow_lane_gets_attribution(tmp_path: Path) -> None:
+    registry = JobRegistry(state_path=tmp_path / "jobs.json")
+    run = _create_run(
+        registry,
+        work_id="323-jobs-stat-attribution",
+        claim_seed="3",
+        issue_refs=("hamanpaul/paulsha-cortex#323",),
+    )
+    registry.create_job(
+        task="wf-18dfaa134b-subagent-build",
+        persona="builder",
+        branch="feature/323-323-jobs-stat-attribution",
+        pane="",
+        worktree="/wt/323",
+        workflow_run_id=run.run_id,
+        workflow_card="subagent-build",
+    )
+
+    buffer = io.StringIO()
+    with redirect_stdout(buffer):
+        exit_code = coordinator_cli.main(
+            ["stat", "wf-18dfaa134b-subagent-build-1"], registry=registry
+        )
+    assert exit_code == 0
+    job = json.loads(buffer.getvalue())
+    assert job["job_id"] == "wf-18dfaa134b-subagent-build-1"
+    assert job["workflow_work_id"] == "323-jobs-stat-attribution"
+    assert job["workflow_primary_issue"] == "hamanpaul/paulsha-cortex#323"
+
+
+def test_stat_single_job_non_workflow_fields_are_null(tmp_path: Path) -> None:
+    registry = JobRegistry(state_path=tmp_path / "jobs.json")
+    registry.create_job(
+        task="legacy",
+        persona="builder",
+        branch="feature/legacy",
+        pane="",
+        worktree="/wt/legacy",
+    )
+
+    buffer = io.StringIO()
+    with redirect_stdout(buffer):
+        exit_code = coordinator_cli.main(["stat", "legacy-1"], registry=registry)
+    assert exit_code == 0
+    job = json.loads(buffer.getvalue())
+    assert job["workflow_work_id"] is None
+    assert job["workflow_primary_issue"] is None
+
+
+def test_stat_unknown_job_id_error_path_unchanged(tmp_path: Path) -> None:
+    registry = JobRegistry(state_path=tmp_path / "jobs.json")
+    err = io.StringIO()
+    with redirect_stderr(err):
+        exit_code = coordinator_cli.main(["stat", "nope-9"], registry=registry)
+    assert exit_code == 1
+    assert "nope-9" in err.getvalue()


### PR DESCRIPTION
## 摘要

`cortex jobs` 列出的 workflow lane job（`wf-xxxxxxxx-<card>-<n>`）看不出屬於哪個 work item、對應哪張 issue，operator 需手動 join job row 與 run row 才能判讀。本 PR 在輸出端補上這個 join。

Closes #323

## 內容

- `_workflow_run_attribution(run)`：把 `WorkflowRun` 投影成 `{workflow_work_id, workflow_primary_issue}`（primary issue 取 `run.issue_refs[0]`，無則 `null`）。
- `_attribute_job(job, reg)`（`stat` 用）與 `_attribute_jobs(jobs, reg)`（`jobs` 用，先建 `run_id` 索引，避免逐 job 查詢）。
- 純輸出端 join，**零額外持久化狀態**——符合 issue 的硬要求。
- 懸空的 `workflow_run_id`（run 不存在）fail-soft 回 `null`，不 crash。

`workflow_card` 原本就存在於每個 job dict（workflow lane 有值、其餘 `null`），所以實際缺口只有 `work_id` 與 primary issue。

**只增不改**：既有欄位完全未動；非 workflow job 的兩個新欄位為 `null`，與既有 `workflow_*` 欄位「恆存在、不適用時為 null」的慣例一致。

## 驗證

- [x] 新增 `tests/test_cli_jobs_stat_attribution_323.py`，7 個案例：workflow lane 歸屬、非 workflow job 欄位為 null、`issue_refs` 為空（openspec-only work item）、懸空 `workflow_run_id` fail-soft、`stat` 兩種情境、`stat` 未知 job_id 錯誤路徑不變
- [x] 全部測試用 `tmp_path` 的 `JobRegistry`，不觸及宿主狀態
- [x] `python3 -m pytest tests/ -q` → 1858 passed（main 基線約 1851）
- [x] 本地 policy_check 帶 PR 上下文 → `fail: 0`
- [x] `changelog.d/jobs-stat-attribution-columns.md` fragment（R-09）＋ `CHANGELOG.md [Unreleased]` entry

## 實資料驗證

以真實 registry 的唯讀副本（479 job）驗證：**478/478 個 workflow lane job 全數正確解出歸屬、零懸空**，唯一的非 workflow job 兩個新欄位皆為 `null`。

```json
{
  "job_id": "wf-18dfaa134b-subagent-build-479",
  "workflow_card": "subagent-build",
  "workflow_work_id": "feat-task-type-combo-selector",
  "workflow_primary_issue": "hamanpaul/paulsha-cortex#202"
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QEGoUsBgzDSa6h9Ch8H5iX