### PR TITLE
feat(coordinator): work GC 與產物生命週期回收

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Changed
 - **封存批次 W2 三個已交付的 OpenSpec changes**：#294／#263／#202 的 change 已隨 PR 合併，但本批改由人工管線收尾未經 cortex ship，故 change 目錄仍 active；以官方 archive 折入 canonical specs。
 ### Added
+- **Issue #178：新增 `cortex work gc` 交付後產物回收命令**：proposal-first 回收殘留 build worktree 與已 merge 的 repo local branch；預設 dry-run 只輸出候選清單與逐項 `reclaim`／`keep`＋reason code，`--apply` 才執行且逐項重驗（TOCTOU-safe）。merged 判定改走內容層驗證鏈（`git merge-base --is-ancestor` → `git cherry` 內容等價），修正 squash-merge 後 ref-ancestry 失真、`git branch -d`／`--merged` 誤拒已合併分支的既有陷阱；任何疑義一律 `keep` 並附 reason code，closed-unmerged PR 分支保留。新模組 `paulsha_cortex/coordinator/gc.py` 由 umbrella CLI 攔截路由，不經 manager daemon、對 registry 唯讀、不動 remote。
 - **Refs #294：slice spec 可宣告 executor/model_id 並於派工前強制 registry 驗證**：`dispatch_ready` 支援逐 slice 的 builder identity 覆寫，unknown identity fail-closed 並列出可用 candidates；同時 `cortex fanout`／`tick` 的明確 `(executor, model)` 與 periodic tick 預設 model 也改為先查 `model-identities.yaml`，避免 typo 直到 session 內才失敗。
 - **Issue #202：task_type 自動選牌與 fix-standard combo**：新增 deck taxonomy loader／selector、`fix-standard` workflow combo、`WorkflowRun.combo_selection` provenance、`cortex work start --combo` authoritative override，以及 `cortex stat --combo-selections` 彙總。Refs #202。
 

--- a/changelog.d/feat-work-gc-v2.md
+++ b/changelog.d/feat-work-gc-v2.md
@@ -1,0 +1,16 @@
+### Added
+- **Issue #178：新增 `cortex work gc` 交付後產物回收命令**：proposal-first
+  回收殘留 build worktree（worktree pool，`PSC_WORKTREE_ROOT` 可覆寫）與已
+  merge 的 repo local branch；預設 dry-run 只輸出候選清單與逐項
+  `reclaim`／`keep`＋reason code，帶 `--apply` 才執行且只處理 `reclaim`
+  項目，執行前逐項重新驗證（TOCTOU-safe）。merged 判定改走內容層驗證鏈
+  （`git merge-base --is-ancestor` → `git cherry` 內容等價），修正
+  squash-merge 後 ref-ancestry 失真、`git branch -d`／`--merged` 誤拒已合併
+  分支的既有陷阱；不影響本次交付範圍的 upstream ref 判定，全程不主動
+  fetch。任何疑義（unmerged content、dirty worktree、git 命令失敗、
+  default／目前 checked-out／掛在保留 worktree 上的 branch）一律 `keep`
+  並附機器可讀 reason code；closed-unmerged PR 分支保留，PR 查詢為
+  best-effort 註記、不可用時安全退化。新模組 `paulsha_cortex/coordinator/gc.py`
+  由 umbrella CLI 在 `work show` 之後同一層攔截路由，不經 manager daemon、
+  不動 control queue `WORK_ACTIONS` 白名單；對 `jobs.json`／manager 狀態檔
+  唯讀，不刪 remote branch、不操作 PR、不清 delivery journal／correlation。

--- a/docs/superpowers/workstreams/feat-work-gc-v2/todo.md
+++ b/docs/superpowers/workstreams/feat-work-gc-v2/todo.md
@@ -7,8 +7,8 @@ work_item: feat-work-gc-v2
 
 ## Tasks
 
-- [ ] 將 issue #178、active OpenSpec change `2026-08-04-feat-work-gc` 與本 Todo 綁定為同一 confirmed Work Item。
-- [ ] coordinator 派工 copilot（gpt-5.4）以 TDD 完成 #178：先寫 RED 測試（squash-merge 判 merged、unmerged 絕不進 apply 清單、dirty worktree 保留、closed-unmerged PR 分支保留），再實作到 GREEN。
+- [ ] 將 issue #178、active OpenSpec change `2026-08-04-feat-work-gc` 與本 Todo 綁定為同一 confirmed Work Item。（未執行：需 manager/daemon `cortex work link`，本次實作在隔離 worktree 內進行，未觸碰 `~/.agents` 真實狀態）
+- [x] 以 TDD 完成 #178：先寫 RED 測試（squash-merge 判 merged、unmerged 絕不進 apply 清單、dirty worktree 保留、closed-unmerged PR 分支保留），再實作到 GREEN。（本次由 Claude/Sonnet 直接實作，非 coordinator 派工 copilot/gpt-5.4；RED 已確認 ImportError 失敗，GREEN 後 14+ 支測試全過）
 - [ ] ForeignReview（claude／sonnet）review 通過；operator 驗收核可。
-- [ ] `changelog.d/feat-work-gc.md` fragment 已新增且已 commit（R-09 硬性 gate）；`CHANGELOG.md [Unreleased]` 有對應 entry。
-- [ ] 帶 PR 上下文執行 `policy_check`（`--pr-title`／`--pr-body`／`--pr-labels`／`--pr-base-ref`／`--pr-head-ref`）確認 fail: 0；全套 pytest 通過。
+- [x] `changelog.d/feat-work-gc-v2.md` fragment 已新增且已 commit（R-09 硬性 gate）；`CHANGELOG.md [Unreleased]` 有對應 entry。（檔名依分支 slug 用 `-v2`，與本節原述的 `feat-work-gc.md` 不同）
+- [x] 帶 PR 上下文執行 `policy_check`（`--pr-title`／`--pr-body`／`--pr-labels`／`--pr-base-ref`／`--pr-head-ref`）確認 fail: 0；全套 pytest 通過。

--- a/openspec/changes/2026-08-04-feat-work-gc/tasks.md
+++ b/openspec/changes/2026-08-04-feat-work-gc/tasks.md
@@ -5,10 +5,10 @@ work_item: feat-work-gc-v2
 
 # Tasks
 
-- [ ] 1.1 RED：依 `docs/superpowers/plans/feat-work-gc-v2.md` 的 TDD RED 章節新增 `tests/test_work_gc.py`，確認失敗。
-- [ ] 1.2 實作至 GREEN，範圍限於 `docs/superpowers/specs/feat-work-gc-v2-spec.md` 的 Requirements（含 `_WORK_HELP` 同步與 `tests/test_cli_help_alignment.py` 斷言）。
-- [ ] 1.3 `changelog.d/feat-work-gc.md` fragment 與 `CHANGELOG.md [Unreleased]` entry（#178）。
-- [ ] 1.4 `python3 -m pytest tests/ -q` 全綠；帶 PR 上下文的 `policy_check` 0 fail；`git diff --check` 乾淨。
+- [x] 1.1 RED：依 `docs/superpowers/plans/feat-work-gc-v2.md` 的 TDD RED 章節新增 `tests/test_work_gc.py`，確認失敗。
+- [x] 1.2 實作至 GREEN，範圍限於 `docs/superpowers/specs/feat-work-gc-v2-spec.md` 的 Requirements（含 `_WORK_HELP` 同步與 `tests/test_cli_help_alignment.py` 斷言）。
+- [x] 1.3 `changelog.d/feat-work-gc-v2.md` fragment 與 `CHANGELOG.md [Unreleased]` entry（#178）。（檔名依分支 slug 用 `-v2`，與本節原述的 `feat-work-gc.md` 不同，詳見實作回報）
+- [x] 1.4 `python3 -m pytest tests/ -q` 全綠；帶 PR 上下文的 `policy_check` 0 fail；`git diff --check` 乾淨。
 
 ## 驗收
 

--- a/paulsha_cortex/cli.py
+++ b/paulsha_cortex/cli.py
@@ -46,10 +46,11 @@ run 'cortex <command> --help' for command-specific help.
 """
 
 _WORK_HELP = """\
-usage: cortex work <show|link|unlink|start|resume|retry-build|retry-verify|retry-review|recover-planning|recover-pre-candidate|abandon|auto|review-attest|ship> ...
+usage: cortex work <show|gc|link|unlink|start|resume|retry-build|retry-verify|retry-review|recover-planning|recover-pre-candidate|abandon|auto|review-attest|ship> ...
 
 work item commands:
   show      從 Monitor 讀取 Work Item 與關聯解釋
+  gc        proposal-first 回收殘留 build worktree 與已 merge local branch（唯讀 registry）
   link      由 Manager 寫入 confirmed association
   unlink    由 Manager 寫入 exclusion
   start     手動 claim 並建立 WorkflowRun（可用 --combo 明示 override）
@@ -135,6 +136,10 @@ def main(argv: Sequence[str] | None = None, *, work_client=None) -> int:
             return 0
         if args[1] == "show":
             return _work_read_main(args, work_client=work_client)
+        if args[1] == "gc":
+            from paulsha_cortex.coordinator import gc as gc_module
+
+            return int(gc_module.main(args[2:]) or 0)
     if args[0] == "doctor":
         from paulsha_cortex.doctor import main as doctor_main
 

--- a/paulsha_cortex/coordinator/gc.py
+++ b/paulsha_cortex/coordinator/gc.py
@@ -1,0 +1,521 @@
+"""`cortex work gc`：交付後產物回收（#178 feat-work-gc-v2）。
+
+回收範圍僅限 worktree pool 內殘留的 build worktree，與 repo 的 local branch；
+唯讀 registry（不 import 任何 manager 狀態檔寫入 API），不刪 remote branch、不動
+PR、不清 delivery journal／correlation（見
+`docs/superpowers/specs/feat-work-gc-v2-spec.md` 非目標）。
+
+proposal-first：預設 dry-run 只分類不執行；`--apply` 才對 `reclaim` 項目執行，
+且逐項於執行前重新驗證（防 TOCTOU）。merged 判定一律走內容層驗證鏈
+（`git merge-base --is-ancestor` → `git cherry` 內容等價），不得以
+`git branch -d`／`--merged`／ref-ancestry 為準——squash-merge 後 ref 層訊號會
+騙人，這是本模組存在的核心理由。任何疑義（unmerged content、dirty worktree、
+git 命令失敗、default／current／掛在 keep worktree 上的 branch）一律 `keep`
+並附機器可讀 reason code，絕不誤刪。
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Sequence
+
+from paulsha_cortex.config.paths import repo_root as default_repo_root
+from paulsha_cortex.config.paths import worktree_root_for
+
+from . import verification
+
+GC_SCHEMA = "cortex-work-gc/v1"
+
+GitRunner = Callable[[list[str]], object]
+PRStatusProvider = Callable[[Path, str], "str | None"]
+
+ACTION_RECLAIM = "reclaim"
+ACTION_KEEP = "keep"
+
+REASON_MERGED_ANCESTOR = "merged-ancestor"
+REASON_MERGED_CONTENT = "merged-content"
+REASON_UNMERGED_CONTENT = "unmerged-content"
+REASON_DIRTY_WORKTREE = "dirty-worktree"
+REASON_PROTECTED = "protected"
+REASON_PR_CLOSED_UNMERGED = "pr-closed-unmerged"
+REASON_VERIFICATION_ERROR = "verification-error"
+REASON_APPLY_ERROR = "apply-error"
+
+
+@dataclass
+class Artifact:
+    kind: str  # "worktree" | "branch"
+    identifier: str  # worktree 絕對路徑 or 分支名
+    action: str
+    reason: str
+    branch: str | None = None
+    detail: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "kind": self.kind,
+            "identifier": self.identifier,
+            "action": self.action,
+            "reason": self.reason,
+        }
+        if self.branch is not None:
+            payload["branch"] = self.branch
+        if self.detail is not None:
+            payload["detail"] = self.detail
+        return payload
+
+
+@dataclass
+class GCReport:
+    repo_root: str
+    applied: bool
+    artifacts: list[Artifact] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema": GC_SCHEMA,
+            "repo_root": self.repo_root,
+            "applied": self.applied,
+            "artifacts": [artifact.to_dict() for artifact in self.artifacts],
+        }
+
+    def render_text(self) -> str:
+        lines = []
+        for artifact in self.artifacts:
+            branch_note = ""
+            if artifact.kind == "worktree" and artifact.branch:
+                branch_note = f" [{artifact.branch}]"
+            lines.append(
+                f"{artifact.kind}\t{artifact.identifier}{branch_note}\t"
+                f"{artifact.action}\t{artifact.reason}"
+            )
+        return "\n".join(lines)
+
+
+@dataclass
+class _WorktreeEntry:
+    path: Path
+    branch: str | None
+
+
+def _default_git_runner(args: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(["git", *args], capture_output=True, text=True)
+
+
+def _git(repo: Path, args: list[str], git_runner: GitRunner | None) -> dict[str, Any]:
+    runner = git_runner or _default_git_runner
+    return verification._run_git(["-C", str(repo), *args], runner)
+
+
+def _is_under(path: Path, root: Path) -> bool:
+    try:
+        path.relative_to(root)
+    except ValueError:
+        return False
+    return True
+
+
+def resolve_default_branch(repo_root: Path, git_runner: GitRunner | None = None) -> str:
+    """依 `origin/HEAD` 解析 default branch，無法解析時退回 `main`；MUST NOT fetch。"""
+    result = _git(repo_root, ["symbolic-ref", "--short", "refs/remotes/origin/HEAD"], git_runner)
+    if result["status"] == "ok":
+        value = result["stdout"].strip()
+        if value.startswith("origin/"):
+            value = value[len("origin/") :]
+        if value:
+            return value
+    return "main"
+
+
+def resolve_current_branch(repo_root: Path, git_runner: GitRunner | None = None) -> str | None:
+    """repo_root 本身（非 worktree pool）目前 checked-out 的分支；detached 時回 None。"""
+    result = _git(repo_root, ["symbolic-ref", "--short", "HEAD"], git_runner)
+    if result["status"] == "ok":
+        value = result["stdout"].strip()
+        return value or None
+    return None
+
+
+def list_worktrees(repo_root: Path, git_runner: GitRunner | None = None) -> list[_WorktreeEntry]:
+    result = _git(repo_root, ["worktree", "list", "--porcelain"], git_runner)
+    if result["status"] != "ok":
+        return []
+    entries: list[_WorktreeEntry] = []
+    current: dict[str, str] = {}
+
+    def _flush() -> None:
+        if not current:
+            return
+        worktree = current.get("worktree")
+        if not worktree:
+            return
+        branch_ref = current.get("branch")
+        branch = None
+        if branch_ref:
+            branch = branch_ref[len("refs/heads/") :] if branch_ref.startswith("refs/heads/") else branch_ref
+        entries.append(_WorktreeEntry(path=Path(worktree), branch=branch))
+
+    for line in result["stdout"].splitlines():
+        line = line.rstrip("\n")
+        if not line:
+            _flush()
+            current = {}
+            continue
+        if line.startswith("worktree "):
+            _flush()
+            current = {"worktree": line[len("worktree ") :]}
+        elif line.startswith("branch "):
+            current["branch"] = line[len("branch ") :]
+    _flush()
+    return entries
+
+
+def list_local_branches(repo_root: Path, git_runner: GitRunner | None = None) -> list[str]:
+    result = _git(
+        repo_root, ["for-each-ref", "--format=%(refname:short)", "refs/heads/"], git_runner
+    )
+    if result["status"] != "ok":
+        return []
+    return [line.strip() for line in result["stdout"].splitlines() if line.strip()]
+
+
+def _classify_merge(
+    repo_root: Path,
+    default_branch: str,
+    ref: str,
+    git_runner: GitRunner | None,
+) -> tuple[bool, str]:
+    """R2 兩段驗證鏈：ancestor → cherry 內容等價。回傳 (merged, reason)。"""
+    ancestor = _git(repo_root, ["merge-base", "--is-ancestor", ref, default_branch], git_runner)
+    if ancestor["status"] == "ok":
+        return True, REASON_MERGED_ANCESTOR
+    if not (ancestor["status"] == "non-zero" and ancestor["returncode"] == 1):
+        # runner-error / partial-evidence，或非預期 returncode（如 bad revision）
+        return False, REASON_VERIFICATION_ERROR
+
+    cherry = _git(repo_root, ["cherry", default_branch, ref], git_runner)
+    if cherry["status"] != "ok":
+        return False, REASON_VERIFICATION_ERROR
+    lines = [line for line in cherry["stdout"].splitlines() if line.strip()]
+    if any(line.startswith("+") for line in lines):
+        return False, REASON_UNMERGED_CONTENT
+    return True, REASON_MERGED_CONTENT
+
+
+def _annotate_pr_status(
+    repo_root: Path,
+    branch: str | None,
+    reason: str,
+    pr_status_provider: PRStatusProvider | None,
+) -> tuple[str, str | None]:
+    """closed-unmerged PR best-effort 註記；provider 缺席／拋錯一律安全退化。"""
+    if reason != REASON_UNMERGED_CONTENT or branch is None or pr_status_provider is None:
+        return reason, None
+    try:
+        status = pr_status_provider(repo_root, branch)
+    except Exception:
+        return reason, None
+    if status == "closed_unmerged":
+        return REASON_PR_CLOSED_UNMERGED, f"PR for {branch} is closed and unmerged"
+    return reason, None
+
+
+def _classify_worktree(
+    entry: _WorktreeEntry,
+    *,
+    repo_root: Path,
+    default_branch: str,
+    current_branch: str | None,
+    git_runner: GitRunner | None,
+    pr_status_provider: PRStatusProvider | None,
+) -> Artifact:
+    identifier = str(entry.path)
+    if entry.branch is not None and entry.branch in (default_branch, current_branch):
+        return Artifact("worktree", identifier, ACTION_KEEP, REASON_PROTECTED, branch=entry.branch)
+
+    status = _git(entry.path, ["status", "--porcelain"], git_runner)
+    if status["status"] != "ok":
+        return Artifact(
+            "worktree", identifier, ACTION_KEEP, REASON_VERIFICATION_ERROR, branch=entry.branch
+        )
+    if status["stdout"].strip():
+        return Artifact("worktree", identifier, ACTION_KEEP, REASON_DIRTY_WORKTREE, branch=entry.branch)
+
+    head_result = _git(entry.path, ["rev-parse", "HEAD"], git_runner)
+    if head_result["status"] != "ok":
+        return Artifact(
+            "worktree", identifier, ACTION_KEEP, REASON_VERIFICATION_ERROR, branch=entry.branch
+        )
+    ref = entry.branch or head_result["stdout"].strip()
+
+    merged, reason = _classify_merge(repo_root, default_branch, ref, git_runner)
+    if merged:
+        return Artifact("worktree", identifier, ACTION_RECLAIM, reason, branch=entry.branch)
+    reason, detail = _annotate_pr_status(repo_root, entry.branch, reason, pr_status_provider)
+    return Artifact("worktree", identifier, ACTION_KEEP, reason, branch=entry.branch, detail=detail)
+
+
+def _classify_branch(
+    branch: str,
+    *,
+    repo_root: Path,
+    default_branch: str,
+    current_branch: str | None,
+    protected_branches: set[str],
+    git_runner: GitRunner | None,
+    pr_status_provider: PRStatusProvider | None,
+) -> Artifact:
+    if branch == default_branch or branch == current_branch or branch in protected_branches:
+        return Artifact("branch", branch, ACTION_KEEP, REASON_PROTECTED, branch=branch)
+
+    merged, reason = _classify_merge(repo_root, default_branch, branch, git_runner)
+    if merged:
+        return Artifact("branch", branch, ACTION_RECLAIM, reason, branch=branch)
+    reason, detail = _annotate_pr_status(repo_root, branch, reason, pr_status_provider)
+    return Artifact("branch", branch, ACTION_KEEP, reason, branch=branch, detail=detail)
+
+
+def scan(
+    repo_root: Path,
+    *,
+    git_runner: GitRunner | None = None,
+    pr_status_provider: PRStatusProvider | None = None,
+    worktree_root: Path | None = None,
+) -> list[Artifact]:
+    """唯讀分類：不改變任何 git 狀態，回傳逐項 Artifact。"""
+    repo_root = Path(repo_root).resolve()
+    default_branch = resolve_default_branch(repo_root, git_runner)
+    current_branch = resolve_current_branch(repo_root, git_runner)
+    pool_root = (worktree_root if worktree_root is not None else worktree_root_for(repo_root)).resolve()
+
+    artifacts: list[Artifact] = []
+    protected_branches: set[str] = set()
+
+    for entry in list_worktrees(repo_root, git_runner):
+        try:
+            resolved = entry.path.resolve()
+        except OSError:
+            continue
+        if not _is_under(resolved, pool_root):
+            continue
+        artifact = _classify_worktree(
+            entry,
+            repo_root=repo_root,
+            default_branch=default_branch,
+            current_branch=current_branch,
+            git_runner=git_runner,
+            pr_status_provider=pr_status_provider,
+        )
+        artifacts.append(artifact)
+        if artifact.action != ACTION_RECLAIM and entry.branch:
+            protected_branches.add(entry.branch)
+
+    for branch in list_local_branches(repo_root, git_runner):
+        artifact = _classify_branch(
+            branch,
+            repo_root=repo_root,
+            default_branch=default_branch,
+            current_branch=current_branch,
+            protected_branches=protected_branches,
+            git_runner=git_runner,
+            pr_status_provider=pr_status_provider,
+        )
+        artifacts.append(artifact)
+
+    return artifacts
+
+
+def _keep_apply_error(artifact: Artifact, detail: str) -> Artifact:
+    return Artifact(
+        artifact.kind, artifact.identifier, ACTION_KEEP, REASON_APPLY_ERROR,
+        branch=artifact.branch, detail=detail,
+    )
+
+
+def _apply_worktree(
+    repo_root: Path,
+    artifact: Artifact,
+    default_branch: str,
+    git_runner: GitRunner | None,
+) -> Artifact:
+    path = Path(artifact.identifier)
+    if not path.exists():
+        return _keep_apply_error(artifact, "worktree path no longer exists")
+    status = _git(path, ["status", "--porcelain"], git_runner)
+    if status["status"] != "ok" or status["stdout"].strip():
+        return _keep_apply_error(artifact, "worktree no longer clean")
+    head_result = _git(path, ["rev-parse", "HEAD"], git_runner)
+    if head_result["status"] != "ok":
+        return _keep_apply_error(artifact, "unable to resolve worktree HEAD")
+    ref = artifact.branch or head_result["stdout"].strip()
+    merged, reason = _classify_merge(repo_root, default_branch, ref, git_runner)
+    if not merged:
+        return _keep_apply_error(artifact, "worktree no longer verified merged")
+    removal = _git(repo_root, ["worktree", "remove", str(path)], git_runner)
+    if removal["status"] != "ok":
+        return _keep_apply_error(artifact, f"git worktree remove failed: {removal['stderr']}")
+    return Artifact(
+        artifact.kind, artifact.identifier, ACTION_RECLAIM, reason,
+        branch=artifact.branch, detail="removed",
+    )
+
+
+def _apply_branch(
+    repo_root: Path,
+    artifact: Artifact,
+    default_branch: str,
+    git_runner: GitRunner | None,
+) -> Artifact:
+    branch = artifact.identifier
+    exists = _git(repo_root, ["show-ref", "--verify", "--quiet", f"refs/heads/{branch}"], git_runner)
+    if exists["status"] != "ok":
+        return _keep_apply_error(artifact, "branch no longer exists")
+    merged, reason = _classify_merge(repo_root, default_branch, branch, git_runner)
+    if not merged:
+        return _keep_apply_error(artifact, "branch no longer verified merged")
+    deletion = _git(repo_root, ["branch", "-D", branch], git_runner)
+    if deletion["status"] != "ok":
+        return _keep_apply_error(artifact, f"git branch -D failed: {deletion['stderr']}")
+    return Artifact(
+        artifact.kind, artifact.identifier, ACTION_RECLAIM, reason,
+        branch=branch, detail="deleted",
+    )
+
+
+def apply_gc(
+    repo_root: Path,
+    artifacts: list[Artifact],
+    *,
+    default_branch: str | None = None,
+    git_runner: GitRunner | None = None,
+) -> list[Artifact]:
+    """`--apply`：只處理 reclaim 項目，執行前逐項重新驗證（TOCTOU-safe）。
+
+    順序固定為 worktree 先、branch 後——分支若仍掛在 worktree 上，
+    `git branch -D` 必然失敗；先移除 worktree 才能安全刪除底下的分支。
+    """
+    repo_root = Path(repo_root).resolve()
+    if default_branch is None:
+        default_branch = resolve_default_branch(repo_root, git_runner)
+
+    results_by_key: dict[tuple[str, str], Artifact] = {}
+    for artifact in artifacts:
+        key = (artifact.kind, artifact.identifier)
+        if artifact.kind == "worktree" and artifact.action == ACTION_RECLAIM:
+            results_by_key[key] = _apply_worktree(repo_root, artifact, default_branch, git_runner)
+        else:
+            results_by_key[key] = artifact
+
+    for artifact in artifacts:
+        key = (artifact.kind, artifact.identifier)
+        if artifact.kind == "branch" and artifact.action == ACTION_RECLAIM:
+            results_by_key[key] = _apply_branch(repo_root, artifact, default_branch, git_runner)
+
+    return [results_by_key[(artifact.kind, artifact.identifier)] for artifact in artifacts]
+
+
+def run_gc(
+    repo_root: Path,
+    *,
+    apply: bool = False,
+    git_runner: GitRunner | None = None,
+    pr_status_provider: PRStatusProvider | None = None,
+    worktree_root: Path | None = None,
+) -> GCReport:
+    repo_root = Path(repo_root).resolve()
+    artifacts = scan(
+        repo_root,
+        git_runner=git_runner,
+        pr_status_provider=pr_status_provider,
+        worktree_root=worktree_root,
+    )
+    if apply:
+        default_branch = resolve_default_branch(repo_root, git_runner)
+        artifacts = apply_gc(
+            repo_root, artifacts, default_branch=default_branch, git_runner=git_runner
+        )
+    return GCReport(repo_root=str(repo_root), applied=apply, artifacts=artifacts)
+
+
+def default_pr_status_provider(
+    repo_root: Path,
+    branch: str,
+    *,
+    runner: Callable[..., Any] | None = None,
+    timeout: float = 15.0,
+) -> str | None:
+    """best-effort `gh pr list` 查詢；不可用（無 gh／逾時／解析失敗）一律回 None。"""
+    run = runner or subprocess.run
+    try:
+        proc = run(
+            [
+                "gh", "pr", "list", "--head", branch, "--state", "all",
+                "--json", "state", "--limit", "1",
+            ],
+            cwd=str(repo_root),
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except Exception:
+        return None
+    if getattr(proc, "returncode", 1) != 0:
+        return None
+    try:
+        data = json.loads(proc.stdout or "[]")
+    except (json.JSONDecodeError, TypeError):
+        return None
+    if not data:
+        return None
+    state = str(data[0].get("state", "")).upper()
+    if state == "MERGED":
+        return "merged"
+    if state == "CLOSED":
+        return "closed_unmerged"
+    if state == "OPEN":
+        return "open"
+    return None
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="cortex work gc",
+        description="proposal-first 回收殘留 build worktree 與已 merge local branch",
+    )
+    parser.add_argument(
+        "--repo-root", default=None, help="被治理的目標 git repo 根目錄（預設：cortex 路徑契約 repo_root()）"
+    )
+    parser.add_argument(
+        "--apply", action="store_true",
+        help="執行回收（只處理 reclaim 項目）；未帶此旗標為預設 dry-run，不改變任何 git 狀態",
+    )
+    parser.add_argument("--json", action="store_true", help="輸出 cortex-work-gc/v1 JSON")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(list(argv) if argv is not None else None)
+    repo_root = Path(args.repo_root).resolve() if args.repo_root else default_repo_root()
+
+    report = run_gc(
+        repo_root, apply=args.apply, pr_status_provider=default_pr_status_provider
+    )
+
+    if args.json:
+        print(json.dumps(report.to_dict(), ensure_ascii=False, sort_keys=True))
+    else:
+        text = report.render_text()
+        if text:
+            print(text)
+        mode = "apply" if report.applied else "dry-run"
+        print(f"repo_root={report.repo_root} mode={mode} artifacts={len(report.artifacts)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_cli_help_alignment.py
+++ b/tests/test_cli_help_alignment.py
@@ -52,6 +52,11 @@ def test_subcommand_help_uses_installed_cortex_invocations() -> None:
     assert build_monitor_parser().prog == "cortex monitor"
 
 
+def test_work_help_lists_gc_subcommand() -> None:
+    assert "gc" in umbrella_cli._WORK_HELP
+    assert "回收" in umbrella_cli._WORK_HELP
+
+
 def test_unified_lifecycle_docs_use_typed_repo_scoped_work_mutations() -> None:
     docs = (Path(__file__).parents[1] / "docs" / "unified-work-lifecycle.md").read_text(
         encoding="utf-8"

--- a/tests/test_work_cli.py
+++ b/tests/test_work_cli.py
@@ -149,7 +149,7 @@ def test_cortex_work_help_lists_read_and_manager_actions(capsys):
     assert cli.main(["work", "--help"]) == 0
     output = capsys.readouterr().out
     for command in (
-        "show", "link", "unlink", "start", "resume", "retry-build", "auto",
+        "show", "gc", "link", "unlink", "start", "resume", "retry-build", "auto",
         "abandon", "review-attest", "ship",
     ):
         assert command in output
@@ -164,3 +164,30 @@ def test_cortex_work_mutation_routes_to_coordinator(monkeypatch):
 
     assert cli.main(["work", "start", "work", "--repo", "example/acme"]) == 0
     assert calls == [["work", "start", "work", "--repo", "example/acme"]]
+
+
+def test_cortex_work_gc_routes_to_gc_module_not_coordinator(monkeypatch, tmp_path):
+    coordinator_calls = []
+    monkeypatch.setattr(
+        "paulsha_cortex.coordinator.cli.main",
+        lambda argv: coordinator_calls.append(argv) or 0,
+    )
+    gc_calls = []
+    monkeypatch.setattr(
+        "paulsha_cortex.coordinator.gc.main",
+        lambda argv: gc_calls.append(argv) or 0,
+    )
+
+    assert cli.main(["work", "gc", "--repo-root", str(tmp_path), "--json"]) == 0
+
+    assert gc_calls == [["--repo-root", str(tmp_path), "--json"]]
+    assert coordinator_calls == []
+
+
+def test_cortex_work_gc_help_is_executable(capsys):
+    with pytest.raises(SystemExit) as error:
+        cli.main(["work", "gc", "--help"])
+    assert error.value.code == 0
+    output = capsys.readouterr().out
+    assert "--apply" in output
+    assert "--repo-root" in output

--- a/tests/test_work_gc.py
+++ b/tests/test_work_gc.py
@@ -1,0 +1,449 @@
+"""RED→GREEN tests for `cortex work gc`（#178 feat-work-gc-v2）。
+
+全程在 tmp git repo fixture 內建構，不碰真 repo、不需網路。任何跟真實
+`~/.agents` 或 `paulsha-cortex-worktrees` 有關的路徑一律不得出現於這支測試。
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from paulsha_cortex.coordinator import gc
+
+
+def _git(root: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", "-C", str(root), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _init_repo(root: Path) -> None:
+    root.mkdir(parents=True, exist_ok=True)
+    _git(root, "init", "-q", "-b", "main")
+    _git(root, "config", "user.email", "test@example.com")
+    _git(root, "config", "user.name", "Test User")
+    (root / "README.md").write_text("init\n", encoding="utf-8")
+    _git(root, "add", "README.md")
+    _git(root, "commit", "-qm", "init")
+
+
+def _artifact(artifacts, kind: str, identifier: str) -> gc.Artifact:
+    for artifact in artifacts:
+        if artifact.kind == kind and artifact.identifier == identifier:
+            return artifact
+    raise AssertionError(f"no {kind} artifact for {identifier!r} in {artifacts!r}")
+
+
+def _branch_exists(root: Path, branch: str) -> bool:
+    result = subprocess.run(
+        ["git", "-C", str(root), "show-ref", "--verify", "--quiet", f"refs/heads/{branch}"],
+        check=False,
+    )
+    return result.returncode == 0
+
+
+# ---------------------------------------------------------------------------
+# R2: merged 判定必須內容層驗證
+# ---------------------------------------------------------------------------
+
+
+def test_ancestor_merged_branch_classified_reclaim(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+
+    _git(repo, "checkout", "-qb", "feature/ancestor")
+    (repo / "ancestor.txt").write_text("ancestor\n", encoding="utf-8")
+    _git(repo, "add", "ancestor.txt")
+    _git(repo, "commit", "-qm", "ancestor commit")
+    _git(repo, "checkout", "-q", "main")
+    _git(repo, "merge", "-q", "--ff-only", "feature/ancestor")
+
+    report = gc.run_gc(repo, worktree_root=tmp_path / "no-pool")
+
+    artifact = _artifact(report.artifacts, "branch", "feature/ancestor")
+    assert artifact.action == gc.ACTION_RECLAIM
+    assert artifact.reason == gc.REASON_MERGED_ANCESTOR
+    assert _branch_exists(repo, "feature/ancestor")
+
+
+def test_squash_merged_branch_classified_reclaim(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+
+    _git(repo, "checkout", "-qb", "feature/squash")
+    (repo / "squash.txt").write_text("squash payload\n", encoding="utf-8")
+    _git(repo, "add", "squash.txt")
+    _git(repo, "commit", "-qm", "squash source commit")
+    _git(repo, "checkout", "-q", "main")
+    _git(repo, "merge", "-q", "--squash", "feature/squash")
+    _git(repo, "commit", "-qm", "squash merge feature/squash")
+
+    # squash-merge 後原分支 commit 不在 default branch 歷史（ref-ancestry 失真）。
+    ancestor_probe = subprocess.run(
+        ["git", "-C", str(repo), "merge-base", "--is-ancestor", "feature/squash", "main"],
+        check=False,
+    )
+    assert ancestor_probe.returncode != 0
+
+    report = gc.run_gc(repo, worktree_root=tmp_path / "no-pool")
+
+    artifact = _artifact(report.artifacts, "branch", "feature/squash")
+    assert artifact.action == gc.ACTION_RECLAIM
+    assert artifact.reason == gc.REASON_MERGED_CONTENT
+
+
+def test_content_mismatch_classified_unmerged(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+
+    _git(repo, "checkout", "-qb", "feature/unmerged")
+    (repo / "unmerged.txt").write_text("never landed\n", encoding="utf-8")
+    _git(repo, "add", "unmerged.txt")
+    _git(repo, "commit", "-qm", "unmerged commit")
+    _git(repo, "checkout", "-q", "main")
+
+    report = gc.run_gc(repo, worktree_root=tmp_path / "no-pool")
+
+    artifact = _artifact(report.artifacts, "branch", "feature/unmerged")
+    assert artifact.action == gc.ACTION_KEEP
+    assert artifact.reason == gc.REASON_UNMERGED_CONTENT
+
+
+# ---------------------------------------------------------------------------
+# R3: fail-safe：疑義一律保留
+# ---------------------------------------------------------------------------
+
+
+def test_unmerged_branch_never_in_apply_list(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+
+    _git(repo, "checkout", "-qb", "feature/unmerged")
+    (repo / "unmerged.txt").write_text("never landed\n", encoding="utf-8")
+    _git(repo, "add", "unmerged.txt")
+    _git(repo, "commit", "-qm", "unmerged commit")
+    _git(repo, "checkout", "-q", "main")
+
+    report = gc.run_gc(repo, apply=True, worktree_root=tmp_path / "no-pool")
+
+    artifact = _artifact(report.artifacts, "branch", "feature/unmerged")
+    assert artifact.action == gc.ACTION_KEEP
+    assert artifact.reason == gc.REASON_UNMERGED_CONTENT
+    assert _branch_exists(repo, "feature/unmerged")
+
+
+def test_dirty_worktree_kept(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    pool = tmp_path / "repo-worktrees"
+    pool.mkdir()
+    worktree_path = pool / "feature-dirty"
+    _git(repo, "worktree", "add", str(worktree_path), "-b", "feature/dirty")
+    (worktree_path / "scratch.txt").write_text("untracked\n", encoding="utf-8")
+
+    report = gc.run_gc(repo, apply=True, worktree_root=pool)
+
+    wt_artifact = _artifact(report.artifacts, "worktree", str(worktree_path))
+    assert wt_artifact.action == gc.ACTION_KEEP
+    assert wt_artifact.reason == gc.REASON_DIRTY_WORKTREE
+    assert worktree_path.exists()
+    assert (worktree_path / "scratch.txt").exists()
+
+    # 分支掛在被保留的 worktree 上：即便內容本身可判 merged，仍必須 protected，
+    # 不得被 `git branch -D`（git 本身也會拒絕，但 GC 必須先分類正確並附理由）。
+    branch_artifact = _artifact(report.artifacts, "branch", "feature/dirty")
+    assert branch_artifact.action == gc.ACTION_KEEP
+    assert branch_artifact.reason == gc.REASON_PROTECTED
+    assert _branch_exists(repo, "feature/dirty")
+
+
+def test_closed_unmerged_pr_branch_kept_with_annotation(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+
+    _git(repo, "checkout", "-qb", "feature/pr-closed")
+    (repo / "pr.txt").write_text("closed pr content\n", encoding="utf-8")
+    _git(repo, "add", "pr.txt")
+    _git(repo, "commit", "-qm", "pr commit")
+    _git(repo, "checkout", "-q", "main")
+
+    def closed_provider(_repo_root: Path, branch: str) -> str | None:
+        return "closed_unmerged" if branch == "feature/pr-closed" else None
+
+    report = gc.run_gc(
+        repo,
+        worktree_root=tmp_path / "no-pool",
+        pr_status_provider=closed_provider,
+    )
+    artifact = _artifact(report.artifacts, "branch", "feature/pr-closed")
+    assert artifact.action == gc.ACTION_KEEP
+    assert artifact.reason == gc.REASON_PR_CLOSED_UNMERGED
+
+    def raising_provider(_repo_root: Path, _branch: str) -> str | None:
+        raise RuntimeError("gh unavailable")
+
+    degraded_report = gc.run_gc(
+        repo,
+        worktree_root=tmp_path / "no-pool",
+        pr_status_provider=raising_provider,
+    )
+    degraded_artifact = _artifact(degraded_report.artifacts, "branch", "feature/pr-closed")
+    assert degraded_artifact.action == gc.ACTION_KEEP
+    assert degraded_artifact.reason == gc.REASON_UNMERGED_CONTENT
+
+    absent_report = gc.run_gc(
+        repo,
+        worktree_root=tmp_path / "no-pool",
+        pr_status_provider=None,
+    )
+    absent_artifact = _artifact(absent_report.artifacts, "branch", "feature/pr-closed")
+    assert absent_artifact.action == gc.ACTION_KEEP
+    assert absent_artifact.reason == gc.REASON_UNMERGED_CONTENT
+
+
+def test_git_error_fails_safe(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+
+    _git(repo, "checkout", "-qb", "feature/ok")
+    (repo / "ok.txt").write_text("ok\n", encoding="utf-8")
+    _git(repo, "add", "ok.txt")
+    _git(repo, "commit", "-qm", "ok commit")
+    _git(repo, "checkout", "-q", "main")
+    _git(repo, "merge", "-q", "--ff-only", "feature/ok")
+
+    _git(repo, "checkout", "-qb", "feature/broken")
+    (repo / "broken.txt").write_text("broken\n", encoding="utf-8")
+    _git(repo, "add", "broken.txt")
+    _git(repo, "commit", "-qm", "broken commit")
+    _git(repo, "checkout", "-q", "main")
+
+    def flaky_runner(args: list[str]) -> subprocess.CompletedProcess[str]:
+        if "cherry" in args:
+            raise RuntimeError("simulated git failure")
+        return subprocess.run(["git", *args], capture_output=True, text=True)
+
+    report = gc.run_gc(
+        repo,
+        worktree_root=tmp_path / "no-pool",
+        git_runner=flaky_runner,
+    )
+
+    broken_artifact = _artifact(report.artifacts, "branch", "feature/broken")
+    assert broken_artifact.action == gc.ACTION_KEEP
+    assert broken_artifact.reason == gc.REASON_VERIFICATION_ERROR
+
+    # 單一 git 命令失敗不得中斷整批判定：其餘項目仍要照常分類。
+    ok_artifact = _artifact(report.artifacts, "branch", "feature/ok")
+    assert ok_artifact.action == gc.ACTION_RECLAIM
+    assert ok_artifact.reason == gc.REASON_MERGED_ANCESTOR
+
+
+# ---------------------------------------------------------------------------
+# R1: proposal-first 回收命令
+# ---------------------------------------------------------------------------
+
+
+def test_default_dry_run_mutates_nothing(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    pool = tmp_path / "repo-worktrees"
+    pool.mkdir()
+
+    # 已 merge 分支：也建一個乾淨 worktree 掛在上面，驗證即使分類為 reclaim，
+    # dry-run 仍完全不動它。
+    _git(repo, "checkout", "-qb", "feature/clean-merged")
+    (repo / "clean.txt").write_text("clean\n", encoding="utf-8")
+    _git(repo, "add", "clean.txt")
+    _git(repo, "commit", "-qm", "clean commit")
+    _git(repo, "checkout", "-q", "main")
+    _git(repo, "merge", "-q", "--ff-only", "feature/clean-merged")
+    clean_worktree = pool / "feature-clean-merged"
+    _git(repo, "worktree", "add", str(clean_worktree), "feature/clean-merged")
+
+    # 未 merge 分支。
+    _git(repo, "checkout", "-qb", "feature/still-open")
+    (repo / "open.txt").write_text("open\n", encoding="utf-8")
+    _git(repo, "add", "open.txt")
+    _git(repo, "commit", "-qm", "open commit")
+    _git(repo, "checkout", "-q", "main")
+
+    # dirty worktree。
+    dirty_worktree = pool / "feature-dirty"
+    _git(repo, "worktree", "add", str(dirty_worktree), "-b", "feature/dirty")
+    (dirty_worktree / "scratch.txt").write_text("untracked\n", encoding="utf-8")
+
+    jobs_json = tmp_path / "jobs.json"
+    jobs_json.write_text('{"jobs": []}\n', encoding="utf-8")
+
+    def _snapshot() -> tuple[str, str, bytes, bool, bool]:
+        worktree_list = _git(repo, "worktree", "list", "--porcelain").stdout
+        branch_list = _git(repo, "for-each-ref", "--format=%(refname:short)", "refs/heads/").stdout
+        return (
+            worktree_list,
+            branch_list,
+            jobs_json.read_bytes(),
+            (dirty_worktree / "scratch.txt").exists(),
+            clean_worktree.exists(),
+        )
+
+    before = _snapshot()
+    report = gc.run_gc(repo, apply=False, worktree_root=pool)
+    after = _snapshot()
+
+    assert before == after
+
+    # 分類仍要如實回報（即使不執行）。
+    clean_artifact = _artifact(report.artifacts, "worktree", str(clean_worktree))
+    assert clean_artifact.action == gc.ACTION_RECLAIM
+    dirty_artifact = _artifact(report.artifacts, "worktree", str(dirty_worktree))
+    assert dirty_artifact.action == gc.ACTION_KEEP
+    assert dirty_artifact.reason == gc.REASON_DIRTY_WORKTREE
+    open_artifact = _artifact(report.artifacts, "branch", "feature/still-open")
+    assert open_artifact.action == gc.ACTION_KEEP
+    assert open_artifact.reason == gc.REASON_UNMERGED_CONTENT
+    assert report.applied is False
+
+
+# ---------------------------------------------------------------------------
+# R4/R5: apply 執行、報告 schema、registry 唯讀
+# ---------------------------------------------------------------------------
+
+
+def test_apply_reclaims_clean_merged_worktree_and_branch(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    pool = tmp_path / "repo-worktrees"
+    pool.mkdir()
+
+    _git(repo, "checkout", "-qb", "feature/clean-merged")
+    (repo / "clean.txt").write_text("clean\n", encoding="utf-8")
+    _git(repo, "add", "clean.txt")
+    _git(repo, "commit", "-qm", "clean commit")
+    _git(repo, "checkout", "-q", "main")
+    _git(repo, "merge", "-q", "--ff-only", "feature/clean-merged")
+    clean_worktree = pool / "feature-clean-merged"
+    _git(repo, "worktree", "add", str(clean_worktree), "feature/clean-merged")
+
+    report = gc.run_gc(repo, apply=True, worktree_root=pool)
+
+    assert report.applied is True
+    wt_artifact = _artifact(report.artifacts, "worktree", str(clean_worktree))
+    assert wt_artifact.action == gc.ACTION_RECLAIM
+    assert not clean_worktree.exists()
+
+    branch_artifact = _artifact(report.artifacts, "branch", "feature/clean-merged")
+    assert branch_artifact.action == gc.ACTION_RECLAIM
+    assert not _branch_exists(repo, "feature/clean-merged")
+
+
+def test_apply_reverifies_before_mutating_toctou(tmp_path: Path) -> None:
+    """R1／D2：`--apply` 對每個 reclaim 項目在執行前重新驗證，狀態已變時轉 keep+apply-error。"""
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    pool = tmp_path / "repo-worktrees"
+    pool.mkdir()
+
+    _git(repo, "checkout", "-qb", "feature/clean-merged")
+    (repo / "clean.txt").write_text("clean\n", encoding="utf-8")
+    _git(repo, "add", "clean.txt")
+    _git(repo, "commit", "-qm", "clean commit")
+    _git(repo, "checkout", "-q", "main")
+    _git(repo, "merge", "-q", "--ff-only", "feature/clean-merged")
+    clean_worktree = pool / "feature-clean-merged"
+    _git(repo, "worktree", "add", str(clean_worktree), "feature/clean-merged")
+
+    artifacts = gc.scan(repo, worktree_root=pool)
+    wt_artifact = _artifact(artifacts, "worktree", str(clean_worktree))
+    assert wt_artifact.action == gc.ACTION_RECLAIM
+
+    # 在 scan 與 apply 之間注入一筆未 commit 變更，模擬 TOCTOU race。
+    (clean_worktree / "late.txt").write_text("late change\n", encoding="utf-8")
+
+    applied = gc.apply_gc(repo, artifacts, default_branch="main")
+    result = _artifact(applied, "worktree", str(clean_worktree))
+
+    assert result.action == gc.ACTION_KEEP
+    assert result.reason == gc.REASON_APPLY_ERROR
+    assert clean_worktree.exists()
+    assert (clean_worktree / "late.txt").exists()
+
+    # 分支候選也要重驗：worktree 未真的被移除，branch 仍掛在上面，
+    # `git branch -D` 若被誤觸會失敗；apply 必須把它安全地記為 apply-error。
+    branch_artifact = _artifact(applied, "branch", "feature/clean-merged")
+    assert branch_artifact.action == gc.ACTION_KEEP
+    assert branch_artifact.reason == gc.REASON_APPLY_ERROR
+    assert _branch_exists(repo, "feature/clean-merged")
+
+
+def test_cli_main_dry_run_text_and_json(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+
+    _git(repo, "checkout", "-qb", "feature/unmerged")
+    (repo / "unmerged.txt").write_text("never landed\n", encoding="utf-8")
+    _git(repo, "add", "unmerged.txt")
+    _git(repo, "commit", "-qm", "unmerged commit")
+    _git(repo, "checkout", "-q", "main")
+
+    rc = gc.main(["--repo-root", str(repo)])
+    assert rc == 0
+    text_output = capsys.readouterr().out
+    assert "feature/unmerged" in text_output
+    assert "keep" in text_output
+    assert "mode=dry-run" in text_output
+
+    rc = gc.main(["--repo-root", str(repo), "--json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["schema"] == "cortex-work-gc/v1"
+    assert payload["applied"] is False
+    branch_entry = next(
+        entry for entry in payload["artifacts"]
+        if entry["kind"] == "branch" and entry["identifier"] == "feature/unmerged"
+    )
+    assert branch_entry["action"] == "keep"
+    assert branch_entry["reason"] == "unmerged-content"
+
+    # dry-run CLI 呼叫過後分支仍在。
+    assert _branch_exists(repo, "feature/unmerged")
+
+
+def test_json_report_matches_versioned_schema(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+
+    report = gc.run_gc(repo, worktree_root=tmp_path / "no-pool")
+    payload = report.to_dict()
+
+    assert payload["schema"] == "cortex-work-gc/v1"
+    assert payload["applied"] is False
+    assert payload["repo_root"] == str(repo.resolve())
+    assert isinstance(payload["artifacts"], list)
+    for entry in payload["artifacts"]:
+        assert {"kind", "identifier", "action", "reason"} <= set(entry)
+
+
+def test_default_branch_and_current_branch_are_protected(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+
+    report = gc.run_gc(repo, worktree_root=tmp_path / "no-pool")
+
+    main_artifact = _artifact(report.artifacts, "branch", "main")
+    assert main_artifact.action == gc.ACTION_KEEP
+    assert main_artifact.reason == gc.REASON_PROTECTED
+
+
+def test_scan_does_not_import_registry_writers() -> None:
+    import inspect
+
+    source = inspect.getsource(gc)
+    assert "JobRegistry" not in source
+    assert "jobs.json" not in source

--- a/tests/test_work_gc.py
+++ b/tests/test_work_gc.py
@@ -441,6 +441,37 @@ def test_default_branch_and_current_branch_are_protected(tmp_path: Path) -> None
     assert main_artifact.reason == gc.REASON_PROTECTED
 
 
+def test_current_checked_out_branch_protected_even_when_content_mergeable(tmp_path: Path) -> None:
+    """current-checked-out-branch 保護與 default-branch 保護是兩條獨立規則：
+    repo_root 目前 checked out 在一個「內容上已可判 merged」的非 default 分支時，
+    仍必須因為它是目前 checkout 而 protected，不得被 apply 誤刪。
+    """
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+
+    _git(repo, "checkout", "-qb", "feature/checked-out-elsewhere")
+    (repo / "here.txt").write_text("here\n", encoding="utf-8")
+    _git(repo, "add", "here.txt")
+    _git(repo, "commit", "-qm", "commit on checked-out branch")
+    _git(repo, "checkout", "-q", "main")
+    _git(repo, "merge", "-q", "--ff-only", "feature/checked-out-elsewhere")
+    # main 現在與 feature/checked-out-elsewhere 同 tip（merged-ancestor 可判）；
+    # 接著把 repo_root 本身切到該分支，驗證它因為是「目前 checkout」而受保護。
+    _git(repo, "checkout", "-q", "feature/checked-out-elsewhere")
+
+    report = gc.run_gc(repo, apply=True, worktree_root=tmp_path / "no-pool")
+
+    checked_out_artifact = _artifact(report.artifacts, "branch", "feature/checked-out-elsewhere")
+    assert checked_out_artifact.action == gc.ACTION_KEEP
+    assert checked_out_artifact.reason == gc.REASON_PROTECTED
+    assert _branch_exists(repo, "feature/checked-out-elsewhere")
+
+    # default branch 本身依然獨立受保護（fallback "main"）。
+    main_artifact = _artifact(report.artifacts, "branch", "main")
+    assert main_artifact.action == gc.ACTION_KEEP
+    assert main_artifact.reason == gc.REASON_PROTECTED
+
+
 def test_scan_does_not_import_registry_writers() -> None:
     import inspect
 


### PR DESCRIPTION
## 摘要

新增 `cortex work gc`：把 v0.1.0 收尾時手工做的爛尾清理（殘留 worktree、已合併分支）提煉成可稽核的指令。

Closes #178

## 設計要點

- **預設唯讀**：不帶 `--apply` 只做分類並輸出，`mode=dry-run`。
- **兩段式合併驗證**（R2）：`git merge-base --is-ancestor` → `git cherry` 內容等價。第二段是關鍵——**squash-merge 後分支不是 main 的祖先，只靠第一段會漏判**。
- **8 種 reason code**（design D4），每個產物都說明保留或回收的理由。
- **一律 keep 的保護**：git 命令失敗、default branch、當前 checked-out branch、掛在 keep worktree 上的 branch。
- **TOCTOU 安全**：`--apply` 在實際 `git worktree remove` / `git branch -D` 前重新驗證一次。
- PR 狀態查詢失敗時 best-effort 降級（D5），不因外部服務不可用而誤判。

## 驗證

- [x] 新增 `tests/test_work_gc.py`（15 個測試）＋ `test_work_cli.py`、`test_cli_help_alignment.py`（R-16）補充，共 18 個新測試
- [x] `python3 -m pytest tests/ -q` → 1886 passed（含併入 main 後）
- [x] 本地 policy_check 帶 PR 上下文 → `fail: 0`
- [x] `changelog.d/feat-work-gc-v2.md` fragment（R-09）＋ `CHANGELOG.md [Unreleased]` entry
- [x] openspec tasks.md 4 項全勾

## 對真實 repo 的 dry-run 實測

在本 repo（當時有 8 個活躍 worktree）跑 scan，判斷全部正確：

- 8 個活躍 worktree 全部 `keep`，理由精確區分 `unmerged-content` 與 `dirty-worktree`
- 掛在 worktree 上的分支與 `main` 全部 `keep / protected`
- 8 個確實已合併的舊分支判為 `reclaim / merged-ancestor`——逐一以 `git merge-base --is-ancestor` 獨立複驗，**零假陽性**

## 規劃文件落差（如實記錄）

`tasks.md` 與 workstream `todo.md` 都寫 fragment 檔名為 `changelog.d/feat-work-gc.md`（無 `-v2`），但分支是 `feature/178-feat-work-gc-v2`、所有規劃文件 frontmatter 都用 `work_item: feat-work-gc-v2`。依 CLAUDE.md 的 slug 規則採用 `-v2`，並在兩份 checklist 中註記此差異，未逕自選一個了事。

## 稽核註記

本次由 Claude Code subagent 直接完成 TDD，未透過 coordinator 派工；workstream todo 中「以 `cortex work link` 綁定 Work Item」與「ForeignReview／operator 驗收」兩項據實未勾。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QEGoUsBgzDSa6h9Ch8H5iX