### PR TITLE
test(workflow): 補 builder tick tasks.md 的 production-fidelity 回歸覆蓋

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@
 - **Issue #202：task_type 自動選牌與 fix-standard combo**：新增 deck taxonomy loader／selector、`fix-standard` workflow combo、`WorkflowRun.combo_selection` provenance、`cortex work start --combo` authoritative override，以及 `cortex stat --combo-selections` 彙總。Refs #202。
 
 ### Fixed
+- **Issue #296：builder tick tasks.md 與 reviewer authority-proving 凍結
+  baseline 矛盾——確認已由 #310 修復，補 production-fidelity 迴歸測試**：
+  #296 與 #310 為同一起 2026-08-04 hippo 事故的獨立提報；#310 的修法（PR
+  #311／#312）已在 #296 提報後數小時落地，但 #296 未被關閉核實。新增
+  `tests/test_builder_tasks_tick_verify_dispatch.py` 以真實 git repo 重現
+  `_dispatch_workflow_card` reviewer 分支（verify／review 共用），涵蓋
+  checkbox-only 通過、tasks.md 文字改動仍擋、proposal.md 等 spec 檔改動仍擋
+  三種情境；無需再改動 production code。
 - **CI 測試閘門形同虛設（tests.yml 偵測誤判）**：`ls tests/test_*.py tests/*_test.py` 只要任一 glob 沒配到就回傳非零，本 repo 因此恆判為「無測試套件」而跳過整段 pytest 卻回報 success；改用 `find -print -quit`。
 - **Issue #263：ship validator 重排為本地 closeout 先於 PR metadata preflight**：archive commit 不再內嵌 push；pre-PR metadata preflight 失敗改回可 resume 的 `pr-preflight-blocked` typed stop、通過後照舊自動建立 PR；slice-based review worktree 補上 frozen authority materialize 與 hash 驗證。
 - **Issue #263 補遺（PR #336 code review）**：review worktree authority materialize 的路徑檢查改為先驗證後動作（拒絕 `..`／絕對路徑 ref 於任何 mkdir 之前）；`work_bridge._manager_archive_applied()` 改委派 `manager` 版避免與 `any(...)` 舊語意漂移；`_slice_review_authority_inputs()` 相對 plan/spec path 改以 repo_root 解析，對齊 `_pinned_input_mismatches()` 既有語意。

--- a/changelog.d/fix-builder-tasks-tick-drift.md
+++ b/changelog.d/fix-builder-tasks-tick-drift.md
@@ -1,0 +1,14 @@
+### Fixed
+- **Issue #296：builder tick tasks.md 與 reviewer authority-proving 凍結
+  baseline 矛盾——確認已由 #310 修復，補production-fidelity 迴歸測試**：
+  #296 與 #310 描述同一起 2026-08-04 hippo 事故，各自獨立提報；#310
+  的修法（PR #311／#312，`_workflow_input_snapshot` 與
+  `_authority_map_with_checkbox_tolerance` 對 kind=plan 的
+  `tasks.md`／`todo.md` 做 checkbox-insensitive 容忍）在 #296 提報後數小時
+  即落地，但 #296 本身從未被關閉核實。新增
+  `tests/test_builder_tasks_tick_verify_dispatch.py`，以真實 git repo（而非
+  單元層級 fixture）重現 `_dispatch_workflow_card` 的 reviewer 分支
+  （verify／review 兩個 phase 共用）：(a) 僅切換 checkbox 通過、(b) tasks.md
+  文字被改動仍擋下、(c) proposal.md 等 spec 檔被改動即使伴隨合法 checkbox
+  tick 仍擋下；並以還原至 #310 修法前的 manager.py 反向驗證這些測試在缺修法
+  時確實會炸，證實非空判。無需再改動 production code。

--- a/tests/test_builder_tasks_tick_verify_dispatch.py
+++ b/tests/test_builder_tasks_tick_verify_dispatch.py
@@ -1,0 +1,224 @@
+"""Regression coverage for issue #296.
+
+2026-08-04 hippo incident: six parallel workflow lanes cleared claim→define
+→plan→build, then every lane deadlocked at verify dispatch with
+``ValueError: workflow planning input drift`` — the tdd-red/subagent-build
+card contract requires the builder to tick ``tasks.md`` checkboxes, while the
+#219 reviewer authority-proving mechanism froze that same file's baseline at
+claim time and fail-closed on any hash drift, including the mandated tick.
+
+Investigation for #296 found the underlying mechanism had already been fixed
+the same day by issue #310 (PRs #311 and #312 — commits ``5dc5899`` and
+``3f234a8``): ``_workflow_input_snapshot`` and
+``_authority_map_with_checkbox_tolerance`` both tolerate a checkbox-only
+``- [ ]`` ↔ ``- [x]`` change on ``kind=plan`` ``tasks.md``/``todo.md`` refs,
+while any other byte difference — on those files or on any ``kind=spec``
+authority ref such as ``proposal.md`` — still fails closed. #296 was filed
+independently a few hours *before* #310's fix landed, describing the same
+incident with a deeper three-mechanism root-cause writeup; it was never
+closed as a duplicate.
+
+``tests/test_checkbox_drift_tolerance.py`` already pins the #310 fix at the
+level of the individual helper functions with synthetic (non-git) fixtures.
+These tests instead exercise the exact call sequence
+``_dispatch_workflow_card`` performs for a ``persona == "reviewer"`` step
+(covering both the ``verify`` and ``review`` phases, per
+``WORKFLOW_PHASES`` / ``_PHASE_PERSONA`` in workflow.py) — authority-map
+build, input-snapshot build, cross-authority proof, and reviewer sandbox
+materialization from a *real* git repository — to pin the fix at production
+fidelity and close out #296 with confirming, not merely inherited, coverage.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from paulsha_cortex.coordinator import manager
+from paulsha_cortex.coordinator import review as foreign_review
+from paulsha_cortex.coordinator.workflow import PlanningArtifactAuthority
+
+TASKS_REF = "openspec/changes/2026-08-04-demo-296/tasks.md"
+PROPOSAL_REF = "openspec/changes/2026-08-04-demo-296/proposal.md"
+
+TASKS_BASELINE = """---
+status: accepted
+work_item: demo-296
+---
+
+# Tasks
+
+- [ ] 1.1 RED：新增測試。
+- [ ] 1.2 GREEN：實作。
+"""
+
+PROPOSAL_BASELINE = "# Proposal\n\nAccepted scope: fix the drift guard.\n"
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(["git", "-C", str(repo), *args], check=True, capture_output=True, text=True)
+
+
+def _rev_parse(repo: Path) -> str:
+    return subprocess.run(
+        ["git", "-C", str(repo), "rev-parse", "HEAD"],
+        check=True, capture_output=True, text=True,
+    ).stdout.strip()
+
+
+def _init_candidate_repo(repo: Path) -> None:
+    """Seed a real git repo at the claim-time baseline (mirrors the operator
+    workspace at the moment planning authority is frozen)."""
+    repo.mkdir(parents=True)
+    _git(repo, "init", "-q")
+    _git(repo, "config", "user.email", "canary@example.invalid")
+    _git(repo, "config", "user.name", "Canary")
+    (repo / TASKS_REF).parent.mkdir(parents=True, exist_ok=True)
+    (repo / TASKS_REF).write_text(TASKS_BASELINE, encoding="utf-8")
+    (repo / PROPOSAL_REF).write_text(PROPOSAL_BASELINE, encoding="utf-8")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "base")
+
+
+def _commit_build(repo: Path, *, tasks_text: str, proposal_text: str | None = None) -> str:
+    """Simulate the builder's build commit landing in the same worktree the
+    manager reuses (``builder_jobs[-1]["worktree"]``) for verify/review
+    dispatch."""
+    (repo / TASKS_REF).write_text(tasks_text, encoding="utf-8")
+    if proposal_text is not None:
+        (repo / PROPOSAL_REF).write_text(proposal_text, encoding="utf-8")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "build: tick task checkboxes")
+    return _rev_parse(repo)
+
+
+def _operator_root(tmp_path: Path) -> Path:
+    """The frozen claim-time source (``run.workspace_root``): untouched by
+    the build, used as the checkbox-tolerance baseline-bytes source."""
+    root = tmp_path / "operator"
+    (root / TASKS_REF).parent.mkdir(parents=True, exist_ok=True)
+    (root / TASKS_REF).write_text(TASKS_BASELINE, encoding="utf-8")
+    (root / PROPOSAL_REF).write_text(PROPOSAL_BASELINE, encoding="utf-8")
+    return root
+
+
+def _planning_authority() -> tuple[PlanningArtifactAuthority, ...]:
+    return (
+        PlanningArtifactAuthority(
+            ref=TASKS_REF, kind="plan", work_id="demo-296",
+            baseline_sha256=hashlib.sha256(TASKS_BASELINE.encode()).hexdigest(),
+        ),
+        PlanningArtifactAuthority(
+            ref=PROPOSAL_REF, kind="spec", work_id="demo-296",
+            baseline_sha256=hashlib.sha256(PROPOSAL_BASELINE.encode()).hexdigest(),
+        ),
+    )
+
+
+def _dispatch_reviewer_like(
+    *, operator_root: Path, repo: Path, candidate: str, coordinator_root: Path,
+):
+    """Reproduce the ``persona == "reviewer"`` branch of
+    ``manager._dispatch_workflow_card`` (verify and review phases share this
+    branch — see ``_PHASE_PERSONA["verify"] == "reviewer"`` in workflow.py):
+    authority map -> input snapshot -> cross-authority proof -> sandbox
+    materialization -> post-materialization snapshot revalidation.
+    """
+    run = SimpleNamespace(
+        run_id="workflow-" + "b" * 20,
+        work_id="demo-296",
+        repo="hamanpaul/paulsha-hippo",
+        source_revision="2" * 64,
+        candidate_head=candidate,
+        workspace_root=str(operator_root),
+        planning_authority=_planning_authority(),
+    )
+    step = SimpleNamespace(card="verification")
+    patterns = (TASKS_REF, PROPOSAL_REF)
+
+    authority_map = manager._authority_map_with_checkbox_tolerance(run, candidate_root=repo)
+    input_snapshot = manager._workflow_input_snapshot(
+        run=run, repo_root=repo, patterns=patterns, coordinator_root=coordinator_root,
+    )
+    foreign_review.verify_authority_in_input_snapshot(
+        authority=authority_map, input_snapshot=input_snapshot,
+    )
+    sandbox, checkout = manager._create_reviewer_sandbox(
+        run=run, step=step, executor="codex", candidate_root=repo,
+        coordinator_root=coordinator_root, input_snapshot=input_snapshot,
+    )
+    manager._validate_workflow_input_snapshot(
+        checkout, list(input_snapshot), coordinator_root=coordinator_root,
+    )
+    return sandbox, checkout, input_snapshot
+
+
+def test_checkbox_only_tick_clears_verify_dispatch_end_to_end(tmp_path: Path) -> None:
+    """(a) builder ticks only the checkbox markers -> verify dispatch must
+    succeed, and the reviewer sandbox must actually contain the ticked
+    content (proving the reviewer sees real build output, not the stale
+    baseline)."""
+    operator_root = _operator_root(tmp_path)
+    repo = tmp_path / "repo"
+    _init_candidate_repo(repo)
+    ticked = TASKS_BASELINE.replace("- [ ] 1.1", "- [x] 1.1").replace("- [ ] 1.2", "- [X] 1.2")
+    candidate = _commit_build(repo, tasks_text=ticked)
+
+    sandbox, checkout, input_snapshot = _dispatch_reviewer_like(
+        operator_root=operator_root, repo=repo, candidate=candidate,
+        coordinator_root=tmp_path / "coordinator",
+    )
+    try:
+        assert (checkout / TASKS_REF).read_text(encoding="utf-8") == ticked
+        rows = {row["path"]: row for row in input_snapshot}
+        assert rows[TASKS_REF]["sha256"] == hashlib.sha256(ticked.encode()).hexdigest()
+        assert rows[PROPOSAL_REF]["sha256"] == hashlib.sha256(PROPOSAL_BASELINE.encode()).hexdigest()
+    finally:
+        import shutil
+
+        shutil.rmtree(sandbox, ignore_errors=True)
+
+
+def test_tasks_md_textual_edit_still_fails_closed(tmp_path: Path) -> None:
+    """(b) any non-checkbox byte change to the pinned tasks.md — even
+    alongside a legitimate checkbox tick — must still trip the drift guard.
+    This is exactly the #310/#321 boundary: builders may toggle checkboxes,
+    nothing else."""
+    operator_root = _operator_root(tmp_path)
+    repo = tmp_path / "repo"
+    _init_candidate_repo(repo)
+    mutated = (
+        TASKS_BASELINE
+        .replace("- [ ] 1.1", "- [x] 1.1")
+        .replace("1.2 GREEN：實作。", "1.2 GREEN：偷改任務語意。")
+    )
+    candidate = _commit_build(repo, tasks_text=mutated)
+
+    with pytest.raises(ValueError, match="planning input drift"):
+        _dispatch_reviewer_like(
+            operator_root=operator_root, repo=repo, candidate=candidate,
+            coordinator_root=tmp_path / "coordinator",
+        )
+
+
+def test_proposal_md_spec_edit_still_fails_closed_alongside_legitimate_tick(tmp_path: Path) -> None:
+    """(c) a spec-kind authority ref (proposal.md) drifting must still fail
+    closed even when bundled with an otherwise-legitimate tasks.md checkbox
+    tick in the same build commit — the checkbox tolerance is scoped to
+    kind=plan tasks/todo files only and must not leak into spec files."""
+    operator_root = _operator_root(tmp_path)
+    repo = tmp_path / "repo"
+    _init_candidate_repo(repo)
+    ticked = TASKS_BASELINE.replace("- [ ] 1.1", "- [x] 1.1").replace("- [ ] 1.2", "- [x] 1.2")
+    drifted_proposal = PROPOSAL_BASELINE.replace("fix the drift guard.", "偷改規格範圍。")
+    candidate = _commit_build(repo, tasks_text=ticked, proposal_text=drifted_proposal)
+
+    with pytest.raises(ValueError, match="planning input drift"):
+        _dispatch_reviewer_like(
+            operator_root=operator_root, repo=repo, candidate=candidate,
+            coordinator_root=tmp_path / "coordinator",
+        )


### PR DESCRIPTION
## 摘要

**issue #296 描述的 bug 早已被修掉了，但該 issue 從未被標為已解決。**

同一起 2026-08-04 hippo 事故在 #296 之後約 4.5 小時被另開為 **#310**，並於當天由 PR #311／#312 修完：

- **PR #311**：`_workflow_input_snapshot` 對 `kind=plan` 且檔名為 `tasks.md`／`todo.md` 的 ref 做 checkbox-insensitive 比對（`- [ ]`↔`- [x]` 正規化）；任何其他 byte 差異仍 fail closed。
- **PR #312**：`_authority_map_with_checkbox_tolerance` 把同一套容忍延伸進 #219 reviewer authority-proving 交叉檢查——正是 #296 指出的第三個衝突機制。

兩個 PR 都早於本分支切出的時間點落在 main，且正是 #296 自己建議的「方向一」。

Closes #296

## 順帶釐清：PR #321 不是這題的修法

`changelog.d/pinned-plan-edit-guard.md`（PR #321）是**純 prompt／指引**變更——它在 build 卡加上「pinned tasks/todo 僅可切換 checkbox」的指示文字，避免 builder 在容忍邊界外**加註記**。它沒有動 drift 偵測程式碼，也不解決 #296 的機制矛盾。

## 因此本 PR 不含 production code，只補回歸覆蓋

既有的 `tests/test_checkbox_drift_tolerance.py` 用的是**合成的非 git fixture**。本 PR 新增 `tests/test_builder_tasks_tick_verify_dispatch.py`，用**真實 git repo** 重現完整的 reviewer-dispatch 呼叫序列，涵蓋三種必要情境：

| 情境 | 期望 | 結果 |
|---|---|---|
| (a) 僅 checkbox tick | 通過，且 reviewer sandbox 實際含勾選後內容 | ✅ |
| (b) tasks.md 文字被改（即使同時有合法 tick） | 仍 `ValueError: ...planning input drift` | ✅ |
| (c) proposal.md（`kind=spec`）被改 ＋ 合法 tasks.md tick | 仍 fail closed | ✅ |

**證明測試不是空的**：暫時把 `manager.py` 換成 #310 修正前的版本（`5dc5899^`），三個測試全部失敗（缺 `_authority_map_with_checkbox_tolerance`）；還原後重新確認全綠。

## 追蹤範圍

已追完 `_dispatch_workflow_card` 的 reviewer 分支（`verify` 與 `review` 兩個 phase 共用，見 `workflow.py:309`），確認容忍機制端到端接通：`_authority_map_with_checkbox_tolerance` → `_workflow_input_snapshot` → `foreign_review.verify_authority_in_input_snapshot` → `_create_reviewer_sandbox`（真實 git clone/checkout）→ `_validate_workflow_input_snapshot`。

另有一套 slice-based review 子系統（`_launch_foreign_review`／`review.prepare_review_worktree`）與 #296 描述的 `WorkflowRun.planning_authority` 流程無關，未動。

## 驗證

- [x] 新增 3 個測試全過
- [x] `python3 -m pytest tests/ -q` → 1871 passed（含併入 main 後）
- [x] 本地 policy_check 帶 PR 上下文 → `fail: 0`
- [x] `changelog.d/fix-builder-tasks-tick-drift.md` fragment（R-09）＋ `CHANGELOG.md [Unreleased]` entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QEGoUsBgzDSa6h9Ch8H5iX