### PR TITLE
fix(status): 補上 project 歸屬投影

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ## [Unreleased]
 ### Fixed
+- **paulshaclaw#264：status 條目補上明確 project 歸屬**：`recent_done`／`attention`／`slices` 現在投影明確的 `repo`；缺少來源時保留 `null`，不從 worktree 或 branch 猜測 project。
 - **Issue #295（primary）／#291（duplicate）：persona catalog 改以套件內建為 canonical 來源，非 cortex repo 的 slice 不再確定性卡 `persona-catalog-unreadable`**：`run_result_verification` 原本無條件從**目標 repo**讀 `paulsha_cortex/persona/personas.yaml`，該檔只存在於 paulsha-cortex 自身，跨 repo 治理必然卡 `needs_human`，且 `dispatch: auto` 又強制要求該 check 無法拿掉。改為先以 `git cat-file -e` 探測 `dispatch_base` tree 是否宣告 repo-local override：存在即維持既有 pin/fail-closed 行為；不存在則回退讀取 `paulsha_cortex.persona.loader.DEFAULT_PERSONAS_PATH` 套件內建 catalog 完成 scope 判定。override 壞損（不可讀／不合法）仍 fail-closed 不靜默回退；cortex repo 自身行為不退化。evidence 新增 `source`（`repo-local`／`packaged`）欄位可稽核判定依據。
 ### Changed
 - **封存批次 W2 三個已交付的 OpenSpec changes**：#294／#263／#202 的 change 已隨 PR 合併，但本批改由人工管線收尾未經 cortex ship，故 change 目錄仍 active；以官方 archive 折入 canonical specs。

--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ systemctl --user status cortex-manager.service cortex-monitor.service
 - `in_flight`：正在執行的 Job。
 - `slices`：交付生命週期、gate、Candidate 與 evidence 摘要。
 - `attention`：全部 `needs_human` 項目，包含 reason 與當下合法的 `next_actions`。
-- `recent_done`：最近完成或進入 terminal gate 的 slice 摘要，含 `slice_id`、`gate_status`、`at`、`gate_reason`、`job_id`、`branch`（manifest 缺該欄時為 `null`）。只回溯 `--recent-done-window-seconds`（預設 86400 秒／24 小時，可用 `PSC_MANAGER_RECENT_DONE_WINDOW_SECONDS` 覆寫）內完成的 handoff manifest；window 內沒有資料時回空陣列，不會回退撈更舊的紀錄，過期 manifest 檔案本身的清理屬於 #178 program teardown GC 的範圍，不在 `recent_done` provider 職責內。
+- `recent_done`：最近完成或進入 terminal gate 的 slice 摘要，含 `slice_id`、`gate_status`、`at`、`gate_reason`、`job_id`、`branch`、明確的 `repo` project 歸屬（manifest 缺該欄時為 `null`）。`attention`／`slices` 也只接受明確的 slice 或 workflow job repo；不從 branch、worktree 或 path 猜測 project。只回溯 `--recent-done-window-seconds`（預設 86400 秒／24 小時，可用 `PSC_MANAGER_RECENT_DONE_WINDOW_SECONDS` 覆寫）內完成的 handoff manifest；window 內沒有資料時回空陣列，不會回退撈更舊的紀錄，過期 manifest 檔案本身的清理屬於 #178 program teardown GC 的範圍，不在 `recent_done` provider 職責內。
 
 Job `exited` 只代表 Agent process 以 exit code 0 結束，**不代表任務交付完成**。只有 Slice 通過 deterministic verification、必要的 foreign review，且 Candidate 已進入 target branch 後，才會變成 `completed` 並釋放下游 dependency。
 

--- a/changelog.d/project-attribution.md
+++ b/changelog.d/project-attribution.md
@@ -1,0 +1,2 @@
+### Fixed
+- **paulshaclaw#264：status 條目補上明確 project 歸屬**：`recent_done` 從 completion manifest 的 `work_authority.repo` 投影 `repo`；`attention`／`slices` 從明確的 slice 或 workflow job repo 投影，沒有資料時保留 `null`，不從 worktree 路徑猜測。

--- a/paulsha_cortex/coordinator/manager.py
+++ b/paulsha_cortex/coordinator/manager.py
@@ -515,22 +515,39 @@ def _resolve_ancestry_status(slice_row: dict, *, git_runner) -> dict[str, Any]:
     return summary
 
 
+def _status_repo(*values: object) -> str | None:
+    """Return an explicit ``owner/repo`` value, never infer one from a path."""
+    for value in values:
+        if not isinstance(value, str) or value.count("/") != 1:
+            continue
+        owner, repo = value.split("/", 1)
+        if owner and repo:
+            return value
+    return None
+
+
 def slice_status_entry(registry, slice_row: dict, *, handoff_dir: str, git_runner=None) -> dict[str, Any]:
     slice_id = str(slice_row.get("slice_id") or "")
     builder_job_id = slice_row.get("builder_job_id")
     reviewer_job_id = slice_row.get("reviewer_job_id")
+    builder_job: dict[str, Any] | None = None
+    reviewer_job: dict[str, Any] | None = None
     builder_job_state: str | None = None
     reviewer_job_state: str | None = None
     if hasattr(registry, "get_job"):
         try:
             if isinstance(builder_job_id, str):
-                builder_job_state = str(registry.get_job(builder_job_id).get("status"))
+                builder_job = registry.get_job(builder_job_id)
+                builder_job_state = str(builder_job.get("status"))
         except Exception:
+            builder_job = None
             builder_job_state = None
         try:
             if isinstance(reviewer_job_id, str):
-                reviewer_job_state = str(registry.get_job(reviewer_job_id).get("status"))
+                reviewer_job = registry.get_job(reviewer_job_id)
+                reviewer_job_state = str(reviewer_job.get("status"))
         except Exception:
+            reviewer_job = None
             reviewer_job_state = None
     reason = None
     manifest = _read_manifest_payload(Path(handoff_dir) / f"{slice_id}.json")
@@ -546,6 +563,14 @@ def slice_status_entry(registry, slice_row: dict, *, handoff_dir: str, git_runne
                 latest_action = latest.get("action")
                 if isinstance(latest_action, str) and latest_action:
                     reason = latest_action
+    authority = manifest.get("work_authority") if isinstance(manifest, dict) else None
+    authority_repo = authority.get("repo") if isinstance(authority, dict) else None
+    repo = _status_repo(
+        slice_row.get("repo"),
+        authority_repo,
+        reviewer_job.get("workflow_repo") if reviewer_job else None,
+        builder_job.get("workflow_repo") if builder_job else None,
+    )
     return {
         "slice_id": slice_id,
         "slice_state": slice_row.get("state"),
@@ -556,6 +581,7 @@ def slice_status_entry(registry, slice_row: dict, *, handoff_dir: str, git_runne
         "reviewer_job_id": reviewer_job_id,
         "reviewer_job_state": reviewer_job_state,
         "reason": reason,
+        "repo": repo,
         "candidate": slice_row.get("candidate"),
         "target_remote": slice_row.get("target_remote"),
         "target_branch": slice_row.get("target_branch"),

--- a/paulsha_cortex/coordinator/manager_daemon.py
+++ b/paulsha_cortex/coordinator/manager_daemon.py
@@ -185,6 +185,28 @@ def _parse_iso8601(value: Any) -> datetime | None:
     return parsed
 
 
+def _status_repo(*values: object) -> str | None:
+    """Return an explicit ``owner/repo`` value, never infer one from a path."""
+    for value in values:
+        if not isinstance(value, str) or value.count("/") != 1:
+            continue
+        owner, repo = value.split("/", 1)
+        if owner and repo:
+            return value
+    return None
+
+
+def _repo_from_manifest(payload: dict[str, Any]) -> str | None:
+    """Project attribution from persisted status data, with legacy fallbacks."""
+    authority = payload.get("work_authority")
+    authority_repo = authority.get("repo") if isinstance(authority, dict) else None
+    return _status_repo(
+        payload.get("repo"),
+        payload.get("workflow_repo"),
+        authority_repo,
+    )
+
+
 def _tick_backoff_seconds(base_interval: float, consecutive_failures: int) -> float:
     """Exponential backoff interval for the next periodic-tick retry.
 
@@ -355,6 +377,7 @@ def build_runtime_status_provider(
                         "gate_reason": payload.get("gate_reason"),
                         "job_id": payload.get("job_id"),
                         "branch": payload.get("branch"),
+                        "repo": _repo_from_manifest(payload),
                     },
                 )
             )

--- a/tests/test_coordinator_manager_daemon.py
+++ b/tests/test_coordinator_manager_daemon.py
@@ -1138,6 +1138,7 @@ def test_recent_done_provider_projects_gate_reason_job_id_branch(monkeypatch, tm
                 "gate_reason": "missing-slice-proof",
                 "job_id": "wf-abc-code-review-1",
                 "branch": "feature/xyz",
+                "work_authority": {"repo": "hamanpaul/paulsha-cortex"},
             }
         ),
         encoding="utf-8",
@@ -1166,9 +1167,11 @@ def test_recent_done_provider_projects_gate_reason_job_id_branch(monkeypatch, tm
     assert entries["slice-full"]["gate_reason"] == "missing-slice-proof"
     assert entries["slice-full"]["job_id"] == "wf-abc-code-review-1"
     assert entries["slice-full"]["branch"] == "feature/xyz"
+    assert entries["slice-full"]["repo"] == "hamanpaul/paulsha-cortex"
     assert entries["slice-sparse"]["gate_reason"] is None
     assert entries["slice-sparse"]["job_id"] is None
     assert entries["slice-sparse"]["branch"] is None
+    assert entries["slice-sparse"]["repo"] is None
 
 
 def test_recent_done_provider_applies_recency_window(monkeypatch, tmp_path):

--- a/tests/test_coordinator_operator_actions.py
+++ b/tests/test_coordinator_operator_actions.py
@@ -101,6 +101,7 @@ def _create_slice_in_needs_human(
     repo_root: Path,
     slice_id: str,
     builder_status: str = "failed",
+    workflow_repo: str | None = None,
 ) -> dict:
     spec_path, plan_path = _write_spec(repo_root, slice_id)
     builder_job = registry.create_job(
@@ -114,6 +115,7 @@ def _create_slice_in_needs_human(
         session_name=f"builder-{slice_id}",
         pid=1111,
         log_path=str(repo_root / "logs" / f"{slice_id}.jsonl"),
+        workflow_repo=workflow_repo,
     )
     if builder_status in {"exited", "failed"}:
         registry.update_headless_result(
@@ -272,6 +274,7 @@ def test_runtime_status_provider_includes_attention_next_actions(tmp_path):
         repo_root=repo_root,
         slice_id="slice-a",
         builder_status="exited",
+        workflow_repo="hamanpaul/paulsha-cortex",
     )
 
     evidence = verification.write_verification_evidence(
@@ -314,4 +317,5 @@ def test_runtime_status_provider_includes_attention_next_actions(tmp_path):
     assert attention["slice_id"] == "slice-a"
     assert attention["slice_state"] == "needs_human"
     assert attention["reason"] == "foreign-review-absent"
+    assert attention["repo"] == "hamanpaul/paulsha-cortex"
     assert set(attention["next_actions"]) == {"retry-build", "retry-verify", "retry-review", "abandon"}


### PR DESCRIPTION
## 摘要

- `recent_done` 投影 completion manifest 的 `work_authority.repo`。
- `attention`／`slices` 投影明確的 slice 或 workflow job repo；缺少來源時維持 `null`。
- 不從 branch 或 worktree 路徑猜測 project。
- 補上 regression tests 與 changelog fragment。

## 驗證

- `python3 -m pytest tests/ -q`：1898 passed, 32 subtests passed。
- policy_check（PR context）：fail 0，warn 2（R-18 docs sync、R-22 既有 dangling refs）。
- R-17 因跨 repository reference 使用 `policy-exempt:issue-link`；目標：hamanpaul/paulshaclaw#264。

Refs hamanpaul/paulshaclaw#264