### PR TITLE
docs(specs): 交付 #137 one-shot 成效閉環（lesson-loop + 棘輪計分）設計文件

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@
 
 ## [Unreleased]
 ### Added
+- **Issue #137：交付 one-shot 成效閉環（lesson-loop + 棘輪計分）設計文件**：新增
+  `docs/superpowers/specs/oneshot-lesson-loop-{spec,design}.md`。凍結 `task_type ×
+  outcome` 計分 schema（計分鍵沿用 `#139` taxonomy 的 `(type, scope)` tuple、`outcome`
+  三態 `clean`／`fixup`／`fail`、`cost` reserved 並定義由 `#325` 已落地的 usage 聚合投
+  影）；定案 session-health 為診斷特徵、不進 reward；定案 cortex 端只產出 lesson
+  payload、不觸碰 `paulsha-hippo` `knowledge/` 目錄的跨 repo 邊界；定案棘輪介面契約與
+  `#209 capable()` 既有簽章相容，建議掛點為 `capable()` 判準之一而非另開
+  `autonomy.py` 內部路徑。詳見 `changelog.d/oneshot-lesson-loop-design.md`。
 - **Issue #340：builder persona 契約新增 `completion_obligations`（結束前必須 commit）**：`PersonaContract` 新增 `completion_obligations` 欄位（fail-closed schema 檢查），`personas.yaml` 的 `builder` 角色新增義務宣告「完成前必須 git add＋git commit，worktree 不乾淨不得回報完成」，由 `render_contract_prompt` 注入實際派工的 dispatch prompt，補上既有 `commit_policy: required`（只管寫入權限）與 manager 端事後 dirty-worktree 安全網之間「事前宣告義務」的缺口；空清單角色不受影響。
 ### Fixed
 - **Issue #339：run tick 對已有 needs_human 終局紀錄的 slice 不再重複 fanout**：`run_tick` 原本的冪等防護只排除 registry 中仍在 `dispatched`/`running` 的 job，job 一旦 poll 到 exited 就離開這個集合，不論其 `gate_status` 是 `needs_human`／`failed`／`passed`；`ready_units`/`default_is_satisfied` 只檢查「別人 depends_on 我」是否滿足，從未檢查「我自己是否已經跑過」，導致下一趟 tick 對已完成待人工的 slice 重新 fanout，撞 `ScriptWorktreeCreator.create` 的 `"worktree target already exists"`。現在派工前會掃描每個 slice 是否已有 handoff 終局紀錄，併入排除集合；此掃描不受 idle gate 影響，`require_idle` 擋下新工作時 `needs_human` 清單仍會回報。summary 新增 `needs_human: [{slice_id, gate_reason, handoff_path}, ...]` 欄位。

--- a/changelog.d/oneshot-lesson-loop-design.md
+++ b/changelog.d/oneshot-lesson-loop-design.md
@@ -1,0 +1,18 @@
+### Added
+- **Issue #137：交付 one-shot 成效閉環（lesson-loop + 棘輪計分）設計文件**：新增
+  `docs/superpowers/specs/oneshot-lesson-loop-{spec,design}.md`。凍結 `task_type ×
+  outcome` 計分 schema——計分鍵沿用 `#139` taxonomy loader 取得的 `(type, scope)`
+  tuple、`outcome` 為 `clean`／`fixup`／`fail` 三態並給出機械推導規則（`delivery.
+  ReviewLoop.fix_rounds`）、`cost` 為 reserved／nullable 且明定其未來由 `#325` 已落地
+  的 `usage_aggregate.aggregate_usage_by_run()` 投影而來；定案 session-health 為診斷
+  特徵而非 reward 成分的語意邊界；定案 lesson 萃取的 cortex 端輸出介面契約——只產出
+  payload，MUST NOT import 或操作 `paulsha-hippo` 的 `knowledge/` 目錄，recall 完全屬
+  hippo range；定案棘輪 `track_record(resource, task_type, scope=None) -> float` 介面
+  契約，與 `#209` 已凍結的 `capable()` 第六項簽章相容，並建議掛點為 `#209 capable()`
+  的判準之一（供 `#138` judge 消費）而非另開 `autonomy.py` 內部路徑。Decisions 段落另
+  查證 `#275` engineering-outcome outbox 目前未捕捉 `fix_rounds`，建議未來實作票在
+  `_ship_action`／`_abandon_action` 既有 `emit_outcome()` 呼叫點 additive 補上該欄位，
+  讓 track_record 可作為該 outbox 的下游 reducer 而非另開一條終局捕捉路徑。本票不實作
+  `track_record.py`、不動 hippo、不開 `openspec/changes/**`（依 issue 原文，落地時再
+  依 OpenSpec 流程另開）。同步更新
+  `docs/superpowers/workstreams/cost-governance-cluster/todo.md` 的 `#137` 列狀態。

--- a/docs/superpowers/specs/oneshot-lesson-loop-design.md
+++ b/docs/superpowers/specs/oneshot-lesson-loop-design.md
@@ -16,7 +16,7 @@ work_item: oneshot-lesson-loop
 |---|---|---|
 | `gate_ledger.py` | 由 manager 掌控 wrapper 執行、模型結束**之後**才產生的**確定性 gate 通過/失敗**紀錄（R2 重驗，模型不可自述、不可控） | fail-closed 契約很緊；混入「one-shot 整體品質」這種較軟的分類語意，會污染既有 gate pass/fail 的精確性 |
 | `completion.py` 的 `CompletionRecord.sizing_score`／`sizing_band` | work item **複雜度屬性**的快照（`#222`／design `#208` H.2），每次 repair／re-claim 重算 | 衡量的是「這件事有多難」，不是「這次做得好不好」；band 是輸入特徵，不是 track_record 要的結果標籤 |
-| `engineering_outcome.py` | `#275` 落地的「一個 work item 終局落在哪」outbox，`outcome ∈ {shipped, abandoned, rejected, failed, rolled_back}`（`engineering_outcome.py:37`） | 語意層級是「work item 級終局」而非「one-shot 嘗試品質」——一個 `shipped` outcome 底下可能已經吃了 2 輪 repair，`shipped` 本身無法回答「這次是 clean 還是 fixup」 |
+| `engineering_outcome.py` | `#275` 落地的「一個 work item 終局落在哪」outbox，`outcome ∈ {shipped, abandoned, rejected, failed, rolled_back}`（`engineering_outcome.py:51`-`:56`） | 語意層級是「work item 級終局」而非「one-shot 嘗試品質」——一個 `shipped` outcome 底下可能已經吃了 2 輪 repair，`shipped` 本身無法回答「這次是 clean 還是 fixup」 |
 
 理由：`gate_ledger.py` 與 `CompletionRecord` 的語意早已被既有測試與呼叫端鎖死，混用
 會製造「一個欄位身兼兩種不相干語意」的技術債（正是 issue 偵察階段要避免誤認的兩個
@@ -48,7 +48,7 @@ issue 原文 §6「lesson 進 memory(`knowledge/`) → wakeup 召回」把 lesso
 
 先例：`engineering_outcome.py` 模組 docstring 已明文「本模組也不 import 任何 hippo
 套件——這是外部 learning systems（含 Hippo）消費的唯讀 outbox，Hippo 未安裝時本模組
-的一切行為必須維持不變」（`engineering_outcome.py:22`-`:25`）。lesson payload 的出口
+的一切行為必須維持不變」（`engineering_outcome.py:25`-`:27`）。lesson payload 的出口
 SHALL 沿用同一原則，但 MUST 是獨立檔案／schema（見 R3 的「不可複用同一份
 `engineering-outcomes/<repo-slug>.jsonl`」），因為 outcome 詞彙與粒度不同，混用會讓
 既有 `#275` 消費端（含 Hippo）收到語意混雜的 `outcome` 值。
@@ -104,7 +104,7 @@ R2 已把 `session_health` 定義為不透明 pass-through 欄位，即使某些
 
 ### D5 track_record 是既有終局訊號的下游 reducer，非重複捕捉——但需要一個小型 additive 缺口
 
-查證 `_ship_action`（`work_actions.py:3259`）呼叫 `emit_outcome()` 時傳入的
+查證 `_ship_action`（`work_actions.py:3262`）呼叫 `emit_outcome()` 時傳入的
 `review={"merge_authorization_hash": ...}`（`work_actions.py:3277`-`:3280`），**未包含**
 `fix_rounds`／`finding_count`——即使同一個作用域內 `active.get("repair_rounds", 0)`
 （`work_actions.py:3506`）已經算出這個值可用。`_abandon_action`

--- a/docs/superpowers/specs/oneshot-lesson-loop-design.md
+++ b/docs/superpowers/specs/oneshot-lesson-loop-design.md
@@ -1,0 +1,158 @@
+---
+status: accepted
+work_item: oneshot-lesson-loop
+---
+
+# oneshot-lesson-loop Design
+
+## Decisions
+
+### D1 outcome ledger 落點——新檔 `track_record.py`，不擴充既有三個「看似相關」模組
+
+新增獨立模組 `paulsha_cortex/coordinator/track_record.py`（實作票落點，本票不寫程式
+碼），不擴充下列任一既有模組：
+
+| 既有模組 | 實際語意 | 為何不適合承載 track_record |
+|---|---|---|
+| `gate_ledger.py` | 由 manager 掌控 wrapper 執行、模型結束**之後**才產生的**確定性 gate 通過/失敗**紀錄（R2 重驗，模型不可自述、不可控） | fail-closed 契約很緊；混入「one-shot 整體品質」這種較軟的分類語意，會污染既有 gate pass/fail 的精確性 |
+| `completion.py` 的 `CompletionRecord.sizing_score`／`sizing_band` | work item **複雜度屬性**的快照（`#222`／design `#208` H.2），每次 repair／re-claim 重算 | 衡量的是「這件事有多難」，不是「這次做得好不好」；band 是輸入特徵，不是 track_record 要的結果標籤 |
+| `engineering_outcome.py` | `#275` 落地的「一個 work item 終局落在哪」outbox，`outcome ∈ {shipped, abandoned, rejected, failed, rolled_back}`（`engineering_outcome.py:37`） | 語意層級是「work item 級終局」而非「one-shot 嘗試品質」——一個 `shipped` outcome 底下可能已經吃了 2 輪 repair，`shipped` 本身無法回答「這次是 clean 還是 fixup」 |
+
+理由：`gate_ledger.py` 與 `CompletionRecord` 的語意早已被既有測試與呼叫端鎖死，混用
+會製造「一個欄位身兼兩種不相干語意」的技術債（正是 issue 偵察階段要避免誤認的兩個
+陷阱）。`engineering_outcome.py` 語意上最接近，但粒度不同——見 D5 的化解方案（track_record
+**消費**它而非**擴充**它）。
+
+風險與緩解：新檔會是第四個「終局相關」模組（`gate_ledger`／`completion`／
+`engineering_outcome`／`track_record`），閱讀成本上升——緩解：本文件的表格即是
+「哪個模組管哪個語意」的權威對照，未來任一模組的 docstring 都應反向連結回本節。
+
+### D2 跨 repo 邊界：cortex 只產出 lesson payload，recall 完全屬 hippo（本票最重要的落差修正）
+
+issue 原文 §6「lesson 進 memory(`knowledge/`) → wakeup 召回」把 lesson 儲存與召回都
+寫在同一句話裡，容易誤導後續實作者把 hippo 內部邏輯直接搬進 cortex repo。但
+`CLAUDE.md` 明文：
+
+> 對 `paulsha-hippo` 維持零 runtime 依賴；僅 `persona/loader.py` 保留 upstream deck
+> schema lazy import。
+
+因此本票劃線：
+
+- **cortex 端（本票範圍）**：只定義並（未來由實作票）產出一份結構化 lesson payload
+  （R3 已凍結欄位），透過一個新的 append-only 出口寫出到本機檔案系統（比照 `#275`
+  `engineering_outcome.py` 的 `OutcomeStore` 慣例：append-only、`outcome_id` 式
+  idempotency key、`list`/`show` 唯讀 surface）。
+- **hippo 端（不屬本票，不屬 cortex repo）**：讀取該出口檔案、決定怎麼存進
+  `knowledge/`、決定 wakeup 時怎麼召回、決定索引與相似度比對方式——這些全部是 hippo
+  的內部實作細節，cortex 不 import 任何 hippo 模組，不直接操作 `knowledge/` 目錄。
+
+先例：`engineering_outcome.py` 模組 docstring 已明文「本模組也不 import 任何 hippo
+套件——這是外部 learning systems（含 Hippo）消費的唯讀 outbox，Hippo 未安裝時本模組
+的一切行為必須維持不變」（`engineering_outcome.py:22`-`:25`）。lesson payload 的出口
+SHALL 沿用同一原則，但 MUST 是獨立檔案／schema（見 R3 的「不可複用同一份
+`engineering-outcomes/<repo-slug>.jsonl`」），因為 outcome 詞彙與粒度不同，混用會讓
+既有 `#275` 消費端（含 Hippo）收到語意混雜的 `outcome` 值。
+
+風險與緩解：「cortex 只產出」的邊界如果實作票沒看到本節，容易照 issue 原文字面誤植
+hippo 邏輯——緩解：R3 已把「MUST NOT import hippo／MUST NOT 操作 `knowledge/`」寫成
+SHALL 條文，且本節與 `#275` 既有先例互相印證，非本票孤立主張。
+
+### D3 session-health 跨 vendor 缺口——標注待確認，不杜撰路徑
+
+issue §5 提及 `docs/research/05` backlog（「能解析 Claude Code session、產出與 codex
+同 schema」），本票查證 `find docs -iname '*research*05*'` 於本 repo **零命中**。此
+backlog 極可能存在於外部 `hamanpaul/session-health` repo，而非本 repo。
+
+決議：本文件與未來實作票 MUST NOT 杜撰此路徑；若需要引用，SHALL 標注「待向外部
+`session-health` repo 確認位置」，或直接略去具體路徑只描述現象（「Claude Code session
+格式的 session-health 解析目前不完整，屬外部 repo 的已知缺口」）。本票不因此阻擋——
+R2 已把 `session_health` 定義為不透明 pass-through 欄位，即使某些 executor
+（Claude Code）暫時沒有完整 session-health report，`session_health: None` 本身就是
+合法值，不影響 outcome 計分（R2 已明文 session-health 不進 reward）。
+
+### D4 棘輪自主度調整的既有掛勾點
+
+候選掛點（供未來實作票選擇，本票只列出，不寫程式碼）：
+
+1. **`paulsha_cortex/coordinator/autonomy.py:421` `default_is_satisfied()`**——目前
+   判定來源是「handoff 是否有有效 `CompletionRecord`」，是一個布林謂詞。棘輪訊號若要
+   影響「這個 slice 是否可以自動派工」，理論上可以作為 `is_satisfied` 之外的**額外**
+   閘門疊加（例如 `ready_units` 呼叫端在 `is_satisfied` 之外再檢查
+   `track_record(resource, task_type, scope) ≥ threshold`），但 `default_is_satisfied`
+   本身的簽章（`slice_id, handoff_dir, *, repo_root, git_runner`）不含 `resource`／
+   `task_type` 參數，直接塞入會破壞既有純粹的「有沒有 CompletionRecord」語意。
+2. **`paulsha_cortex/coordinator/autonomy.py:394` `ready_units()`**——目前的三條件
+   （`slice_id` 合法 ∧ `dispatch == 'auto'` ∧ `plan` 非空 ∧ `depends_on` 全滿足）是
+   **就緒**判定，不是**信任**判定。棘輪的「調高/調低 autonomy 門檻」語意更接近「這個
+   `task_type` 允許派到哪個 band／哪個 resource」，與 `ready_units` 的「這個 slice
+   結構上齊備了嗎」是正交的兩件事，不應該混進同一個函式。
+3. **`paulsha_cortex/coordinator/autonomy.py:447` `dispatch_ready()`**——fan-out 入口，
+   對每個就緒單位呼叫 headless `AgentLauncher`。這是「已經決定要派」之後才執行的動作
+   點，若棘輪要**否決**某個 band/resource 組合，理論上要在呼叫 `dispatch_ready` **之
+   前**、`ready_units` 拿到就緒集**之後**插入一層新的過濾（形狀類似
+   `design-model-capability-envelope-spec.md` R1 的 `capable()` 六項判準，`track_record`
+   正是其第六項）——即棘輪不是 `autonomy.py` 內部新函式，而是 `#209 capable()` 的
+   一個因子，`capable()` 本身再被 `#138` judge 呼叫、`judge` 的呼叫結果才餵給
+   `dispatch_ready` 決定要不要對某個 (slice, resource) 組合派工。
+
+**建議**（本票只建議候選掛點，最終落點屬未來實作票）：優先方案 3——棘輪不新開一條
+`autonomy.py` 內部路徑，而是作為 `#209 capable()` 第六項判準的實作，被 `#138` judge
+消費，`judge` 的輸出（選哪個 resource／要不要延後）才是 `dispatch_ready` 派工前讀到
+的訊號。這樣「調自主度門檻」的決策權留在 `#138` judge 這一層，`autonomy.py` 的
+`ready_units`／`dispatch_ready` 維持現有的「結構完整性」判定不被污染，與 R4 已定案的
+函式簽章相容性（D 相容 `#209`）完全對齊。
+
+### D5 track_record 是既有終局訊號的下游 reducer，非重複捕捉——但需要一個小型 additive 缺口
+
+查證 `_ship_action`（`work_actions.py:3259`）呼叫 `emit_outcome()` 時傳入的
+`review={"merge_authorization_hash": ...}`（`work_actions.py:3277`-`:3280`），**未包含**
+`fix_rounds`／`finding_count`——即使同一個作用域內 `active.get("repair_rounds", 0)`
+（`work_actions.py:3506`）已經算出這個值可用。`_abandon_action`
+（`work_actions.py:2308`）同樣不傳 `review`。
+
+這代表：track_record **無法**單純讀 `#275` 既有 outbox 就推導出 `clean`／`fixup`——
+`engineering_outcome.py` 現有 record 只夠回答「shipped 還是 abandoned」，不夠回答「是
+一次過還是修過才過」。
+
+決議：track_record.py 的設計 SHALL 兩段式——
+
+1. **短期／本票範圍**：track_record 的 R1 判定規則（見 spec R1 表格）直接引用
+   `delivery.ReviewLoop.fix_rounds`（`delivery.py:131`）與 `work_actions.py:3506` 的
+   `active["repair_rounds"]`，**不假設**這個值已經被 `#275` 的 outbox 帶出來。
+2. **未來實作票的建議路徑**：在 `_ship_action`／`_abandon_action` 呼叫
+   `emit_outcome()` 的既有兩處呼叫點，**additively** 把 `fix_rounds` 加進 `review`
+   dict（例如 `review={"fix_rounds": active.get("repair_rounds", 0), ...}`）——這符合
+   `design-task-type-taxonomy-v2-spec.md` R7「實作票如需增欄 MUST 以 additive 方式擴
+   充，MUST NOT 改既有欄位語意」的既有紀律，也符合 `engineering_outcome.py`
+   `review: Mapping[str, Any] | None` 本來就是自由 mapping 的既有型別。這麼一來
+   track_record 就能把 `#275` outbox 當作**唯一**的終局訊號來源（`list_outcomes`／
+   `replay_outcomes`，`engineering-outcome-contract-spec.md` R6），不需要另開一條並行
+   的終局捕捉邏輯，把 `outcome_id` 的 idempotency 保證也一併繼承過來。
+
+風險與緩解：如果未來實作票忽略這個 additive 缺口、自己在 `work_actions.py` 別處另開
+一條捕捉路徑，會產生兩份不一致的「這次 ship 是 clean 還是 fixup」判定——緩解：本節
+明文指出精確的插入點（`work_actions.py:3277`／`:2308` 附近）與資料來源
+（`active.get("repair_rounds", 0)`），降低實作票自行摸索、繞出第二條路的機率。
+
+## 風險與緩解
+
+- **`cost` 欄位長期空值**：即使 `#325` 已落地 job 級 `usage`，track_record 到
+  `(task_type, scope)` 的 join 仍是未來票的工作；若該票被無限期延後，`cost` 會一直是
+  `null`——緩解：R1 已把 `cost` 定為 reserved／nullable，棘輪與 lesson 觸發規則（R3／
+  R4）皆不依賴 `cost` 是否有值，`cost` 缺席不阻擋核心閉環運作。
+- **taxonomy scope 詞典過緊，計分鍵稀疏**：`design-task-type-taxonomy-v2-spec.md`
+  受控詞典目前只收錄 7 個 scope，且非本票所有——沿用該票已有的緩解語言：詞典擴充是
+  `task-types.yaml` 的 data-only PR，成本低；`ambiguous`（scope 不在詞典）分類本身
+  fail-closed 且可觀測，是詞典維護的觸發訊號，不是 track_record 需要另外處理的例外。
+- **`#209` 簽章相容性判斷錯誤**：若未來 `#209` 實際落地 `capable()` 時對 `track_record`
+  的呼叫方式與本票 R4 假設不同（例如永遠只傳 `task_type` 不傳 `scope`），track_record
+  內部仍必須能在 `scope=None` 時給出有意義的邊際化分數——緩解：R4 已明文
+  `scope: str | None = None` 為必要的預設參數設計，非事後修補。
+- **lesson payload 出口與 `#275` outbox 撞名或撞檔**：若實作票偷懶直接寫進
+  `engineering-outcomes/<repo-slug>.jsonl`，會讓 Hippo 等既有消費端讀到非預期的
+  `outcome` 值域——緩解：R3／D2 已明文「MUST NOT 複用同一份檔案或 schema」，且給出
+  `OutcomeStore` 式獨立實作的具體先例可抄。
+- **棘輪掛點選錯，繞出 `#136`/`#138`/`#209` 三閘體系**：若實作票貪快直接在
+  `autonomy.py` 加一個獨立的棘輪檢查函式，會與 D4 建議的「棘輪是 `capable()` 第六項」
+  分裂成兩條決策路徑——緩解：D4 已明文優先方案與理由，未來實作票的 code review
+  checklist 可要求「是否有新增獨立於 `capable()` 之外的棘輪檢查」作為機械檢查點。

--- a/docs/superpowers/specs/oneshot-lesson-loop-spec.md
+++ b/docs/superpowers/specs/oneshot-lesson-loop-spec.md
@@ -1,0 +1,195 @@
+---
+status: accepted
+work_item: oneshot-lesson-loop
+---
+
+# oneshot-lesson-loop Specification
+
+#137：one-shot 成效閉環——`task_type × outcome` 計分表、session-health 診斷邊界、lesson
+萃取的介面契約、與棘輪（ratchet）調自主度門檻的介面契約。**本票是設計文件，不實作
+`track_record.py`、不實作 lesson reader/writer 本體、不動 `paulsha-hippo`。**
+
+## 背景
+
+issue 原文（2026-06-24 起，多則 comment 補充）主張「站在 RL 光譜最便宜端」：不訓模型，
+而是把 one-shot 的成敗結果（`clean`／`fixup`／`fail`）累積成 `task_type × outcome`
+計分表，供（a）棘輪調自主度門檻、（b）lesson 萃取供未來 plan 撰寫召回。issue 明確區分
+兩個不可混用的軸——**outcome（reward，用於棘輪）**與 **session-health（process 診斷，
+用於歸因，不得當 reward 用）**——並在結尾自陳「本 issue 為設計討論記錄，非實作 PR；
+落地時再依 OpenSpec 流程開 change」。
+
+`main` 現況（本票查證，非簡報時點）：
+
+- 全 repo `grep -rn "lesson\|ratchet\|track_record\|session.health"` 於 `paulsha_cortex/`
+  零命中——`#137` 完全沒有落地任何一部分，含 `docs/superpowers/specs/
+  design-model-capability-envelope-spec.md:98` 自己也明載
+  `` `#137`（尚未落地；`grep -rn "track_record" paulsha_cortex` 零命中，本票只引用函式
+  簽章，不假設其內部實作） ``。
+- `#139` taxonomy 契約（`design-task-type-taxonomy-v2-spec.md` R6）**已凍結**#137 的消費
+  義務：「`#137` ledger MUST 以 `(type, scope)` tuple 作為 `task_type × outcome` 計分
+  鍵」；loader 為 `paulsha_cortex/deck/task_types.py:61` `load_task_types()` 與
+  `paulsha_cortex/deck/task_types.py:134` `classify_title()`，值域凍結於
+  `paulsha_cortex/deck/task_types.py:13` `TASK_TYPE_VALUES`。
+- `#325`（token usage 收進 job record）**已落地**：`paulsha_cortex/coordinator/
+  registry.py` 的 job record 新增 `usage`／`usage_raw`／`usage_reason`／`started_at`／
+  `exited_at` 五欄位（fail-closed schema 檢查於 `registry.py:474` 與 `:479`，寫入於
+  `registry.py:935`／`:959`-`:971`），`paulsha_cortex/coordinator/usage_aggregate.py:15`
+  `aggregate_usage_by_run()` 依 `workflow_run_id` 彙總 `input_tokens`／`output_tokens`／
+  `cached_input_tokens`／`reasoning_output_tokens` 四欄位，`cortex stat --usage-by-run`
+  暴露唯讀查詢（`paulsha_cortex/coordinator/cli.py:135`）。**這改變了本票 cost 維度的
+  設計自由度**——見下方 R1 與 deviations。
+- `#275`（engineering outcome contract）**已落地**：`paulsha_cortex/coordinator/
+  engineering_outcome.py` 是「外部 learning systems（含 Hippo）消費的唯讀 append-only
+  outbox」，`_ship_action`／`_abandon_action`（`work_actions.py:3259`／`:2305`）在既有
+  終局轉換（`status="done"`／`status="superseded"`）之前 durable 寫入一筆
+  `shipped`／`abandoned` record。**這是本票 D2「cortex 只產出、不管 hippo 召回」邊界
+  的既有先例**，但其 outcome 詞彙（`shipped`／`abandoned`／`rejected`／`failed`／
+  `rolled_back`，`engineering_outcome.py:37`）與粒度（一個 work item 的終局轉換，可能
+  已含多輪 repair）都與本票的 `clean`／`fixup`／`fail`（一次 one-shot 嘗試的品質）不同
+  ——不可直接借用同一份 record 當 track_record 的 outcome 值，需要額外欄位（見 D1/D5）。
+- `#209`（model capability envelope）**已落地**：`capable()` 第六項判準已**凍結函式
+  簽章型別** `Callable[[Resource, str], float] ≥ float`（`design-model-capability-
+  envelope-spec.md:98`），第二參數為 `work.task_type`（單值字串），**不是** `(type,
+  scope)` tuple。其設計文件 D9（`design-model-capability-envelope-design.md:203`）已
+  明文「`#137` 定案後若簽章不同，只需改本票 R1 表格第 6 列」——本票需要在 R4 給出對齊
+  方案（見下）。
+
+`gate_ledger.py`（`paulsha_cortex/coordinator/gate_ledger.py`）記錄的是「這次 wrapper
+執行的確定性 gate 通過與否」（R2 重驗語意，模型不可自述、不可控），`CompletionRecord`
+的 `sizing_score`／`sizing_band`（`completion.py:262`-`:282`，`#222`／design `#208`
+H.2）記錄的是「work item 的複雜度屬性」——**兩者語意都不是「one-shot 整體是否需要
+repair 才過關」**，不可誤認為 track_record 已有雛形（issue 偵察已核實，見 notes）。
+
+## Goals
+
+- 凍結 `task_type(type,scope) × outcome(clean/fixup/fail)` 計分 schema，`cost` 欄位
+  reserved／nullable，並明定其未來資料來源投影規則（不寫聚合程式碼）。
+- 定案 session-health 為「診斷特徵」而非「reward 的一部分」的語意邊界，且明定其資料
+  型別為不透明 pass-through（本 repo 不驗證其內部結構語意）。
+- 定案 lesson 萃取觸發條件與**cortex 端輸出介面契約**，明文 MUST NOT 觸碰 hippo 內部
+  `knowledge/` 目錄。
+- 定案棘輪讀取 `(type,scope)` 歷史成功率、輸出「調高/調低 autonomy 門檻」訊號的介面
+  契約，且與已凍結的 `#209 capable()` 第六項簽章相容。
+- 明載非目標：不實作任何程式碼、不動 hippo、不開 `openspec/changes/**`。
+
+## Requirements
+
+### R1 outcome 計分 schema 凍結
+
+`track_record` 計分鍵 SHALL 為 `(task_type, scope)` tuple，經 `paulsha_cortex.deck.
+task_types.classify_title()` 對 work item 的 mapped issue 標題分類取得
+（`kind == "matched"` 時的 `(task_type, scope)`；`scope` 可為 `None`，比照
+`task_types.py:134` 既有語意）。MUST NOT 自建第二份值域或自行 regex 解析標題——這正是
+`design-task-type-taxonomy-v2-spec.md` R1 明文禁止的行為。
+
+> **落差提醒**：`paulsha_cortex/coordinator/workflow.py:420` `WorkflowRun.combo_selection`
+> 目前**只持久化 `task_type`（主軸），不持久化 `scope`**（`deck/selector.py`
+> `ComboSelection` dataclass 本身沒有 `scope` 欄位）。track_record 的 writer 要拿到
+> 完整 `(type, scope)` tuple，**無法只讀 `combo_selection`**，必須在寫入當下對
+> mapped issue 標題重新呼叫 `classify_title()`（複用既有 loader，不得另建 regex）。
+> 這是本票查證發現、简报未提及的落差，實作票需注意。
+
+`outcome` SHALL 為三態 `clean`／`fixup`／`fail`，且 MUST 有機械推導規則（供未來實作票
+直接引用，本票不寫程式碼）：
+
+| outcome | 判定依據（既有機制） |
+|---|---|
+| `clean` | ship 終局轉換時，`delivery.ReviewLoop.fix_rounds`（`delivery.py:131`，於 `work_actions.py:3506` 讀作 `active.get("repair_rounds", 0)`）＝`0` |
+| `fixup` | ship 終局轉換達成，但 `fix_rounds ≥ 1`（`delivery.py:39` `MAX_FIX_ROUNDS`／`#218` `repair_budget_for_band()` 之內完成） |
+| `fail` | run 走 `_abandon_action`（`status="superseded"`）終局，或 repair budget 耗盡進入 `needs_human`（`delivery.py:222` `"copilot-finding-budget-exhausted"`）且未再恢復 |
+
+`cost` SHALL 為 reserved、nullable 欄位。**`#325` 已於本批落地**（job record 的
+`usage`／`usage_raw` 欄位、`usage_aggregate.aggregate_usage_by_run()`），本票因此
+MUST NOT 再假設「完全沒有資料來源」；但 `usage` 現況只到 **job／`workflow_run_id`**
+粒度，尚未有任何程式碼把它 join 到 `(task_type, scope)` 計分鍵——這個 join（一個
+`workflow_run_id` 對應唯一一個 `WorkflowRun`，其 `combo_selection.task_type` ＋
+重新分類出的 `scope`）SHALL 由未來實作票完成，本票只凍結「`cost` 欄位存在、型別為
+`dict|None`、其非空時的內容形狀＝`aggregate_usage_by_run()` 的既有回傳形狀（四個
+token 欄位＋`job_count`／`jobs_with_usage`）」，MUST NOT 在本票內撰寫 join 程式碼。
+
+### R2 session-health 為診斷特徵，非 reward 成分
+
+session-health 特徵（issue 原文列舉 `SNR`／`STATE`／`CTX`／`REACT`／`DEPTH`／`CONV`／
+`TOOL`）SHALL 只用於**歸因**（lesson 萃取時解釋「為什麼」）與**早期預警**（session 中
+途收斂崩壞時的升級求助訊號），MUST NOT 併入棘輪讀取的 `outcome` 計分或以任何形式影響
+`clean`／`fixup`／`fail` 的判定——session-health 高但結果錯、或 session-health 低但結
+果對，兩種情形皆可能發生，混用會污染 outcome 訊號的純粹性（issue §3 已有此論證，本票
+轉為 SHALL 條文）。
+
+session-health report 的產生者是外部 `hamanpaul/session-health` repo，非本 repo 內建
+能力。本票的計分 payload SHALL 把 `session_health` 定義為**不透明 pass-through 欄位**
+（型別 `dict | None`），本 repo MUST NOT 驗證其內部鍵值的語意正確性，只驗證頂層型別。
+跨 vendor 缺口（Claude Code session 格式尚未被該外部 repo 完整支援，issue §5 提及的
+`docs/research/05` backlog）**經查證不在本 repo**（`find docs -iname '*research*05*'`
+於本 repo 無命中）；本票 MUST NOT 杜撰該檔案路徑，視為外部 repo 的已知 backlog，不在
+本 repo 範圍內，不予引用具體路徑。
+
+### R3 lesson 萃取觸發條件與 cortex 端輸出介面契約
+
+觸發條件 SHALL 為以下之一：`outcome == "fail"`；或 `session_health` 存在且其（由呼叫端
+定義的）綜合分數低於門檻（門檻數值本票 MUST NOT 凍結，留給實作票依據 `#210` 的自身 run
+歷史校準機制決定）。
+
+cortex 端 MUST 只定義**輸出**契約——一個結構化 dict（欄位：`task_type`／`scope`／
+`workflow_run_id`／`outcome`／`session_health`（可選，R2 型別）／`lesson`（自由格式
+文字或 dict，內容由萃取邏輯決定，本票不規定）／`emitted_at`／`repo`）——透過**新的
+append-only 出口**寫出，比照 `#275` `engineering_outcome.py`「外部 learning systems
+消費的唯讀 outbox」慣例（append-only、`outcome_id` 型 idempotency key、`OutcomeStore`
+式唯讀 `list`/`show` surface），但 MUST NOT 複用同一份 `engineering-outcomes/
+<repo-slug>.jsonl` 檔案或同一 schema——两者 outcome 詞彙與粒度不同（見背景段），混用
+會讓 `#275` 既有消費端（含 Hippo）收到語意不一致的 `outcome` 值。
+
+cortex 端 **MUST NOT** import `paulsha-hippo` 的任何模組、MUST NOT 直接讀寫 hippo 的
+`knowledge/` 目錄——這是 `CLAUDE.md` 明文「對 `paulsha-hippo` 維持零 runtime 依賴」的
+契約邊界。lesson 的**召回**（wakeup 階段依 `task_type` 讀回相關 lesson，issue §6）完全
+是 hippo range，本票的 spec 只做到「cortex 吐出什麼格式」為止，不規定 hippo 如何儲存
+或索引。
+
+### R4 棘輪介面契約
+
+棘輪 SHALL 提供函式 `track_record(resource, task_type: str, scope: str | None = None)
+-> float`，讀 `(task_type, scope)` 的歷史成功率（`clean`/(`clean`+`fixup`+`fail`) 或等
+價的加權公式，公式本身留給實作票），輸出範圍 `[0.0, 1.0]`。
+
+**與 `#209` 既有簽章相容**：`design-model-capability-envelope-spec.md:98` 已凍結
+`capable()` 第六項為 `track_record(resource, work.task_type) ≥ threshold`、型別
+`Callable[[Resource, str], float]`。上表簽章刻意讓 `scope` 帶預設值 `None`——呼叫端可
+只傳 `task_type`（滿足 `#209` 既有假設，`scope=None` 時 SHALL 邊際化該 `task_type` 下
+所有 `scope` 的加權平均），也可傳完整 `(task_type, scope)` 取得更細粒度的分數。本票
+MUST 保證省略 `scope` 時的呼叫形狀與 `#209` R1 表格第 6 列一致，不需要 `#209` 改文件；
+`#209` 是否要在未來把第六項升級成消費完整 tuple 屬 `#209` 的 follow-up，不在本票範圍。
+
+輸出的「調高/調低 autonomy 門檻」訊號 MUST 接到 `paulsha_cortex/coordinator/
+autonomy.py` 既有 dispatch 流程，而非另開一條路——具體候選掛點見
+`oneshot-lesson-loop-design.md` D4。
+
+## 非目標
+
+- 不實作 `track_record.py`（或任何同義模組）本體、不實作 lesson writer／reader 程式碼。
+- 不撰寫 `usage`→`(task_type,scope)` 的 cost join 聚合程式碼（R1 只凍結欄位形狀）。
+- 不修改 `paulsha-hippo` repo 或本 repo內任何 hippo 相關程式碼；不操作 `knowledge/`
+  目錄。
+- 不處理 issue comment 追加的「coaching / 改進建議」與 `project-usage-assess` 生產力
+  ROI 巨觀報表——issue 討論串已把這兩塊併入本 issue 範圍，但為避免這次設計票蔓延到
+  「session 品質教練」與「跨類別省時報表」兩個獨立子問題，本票 MUST NOT 展開其設計，
+  留待後續票（沿用同一 `(task_type, scope)` taxonomy，不重複發明）。
+- 不修改 `#209` `design-model-capability-envelope-{spec,design}.md` 的既有文字（R4 已
+  說明相容性不需要對方改動）。
+- 不新增 `openspec/changes/**` 底下的 change 目錄——issue 原文明文「落地時再依
+  OpenSpec 流程開 change」，本票（設計文件）本身不啟動 OpenSpec 流程。
+- 不改 `gate_ledger.py`、`CompletionRecord`（`completion.py`）、`engineering_outcome.py`
+  既有程式碼——即便 D1/D5 建議它們是未來 track_record 實作的鄰接／依賴模組。
+
+## 驗收面
+
+- `oneshot-lesson-loop-spec.md`／`oneshot-lesson-loop-design.md` 皆含非空 frontmatter
+  （`status`／`work_item`）與非空 Requirements／Decisions 段落，行數量級比照
+  `design-task-type-taxonomy-v2-{spec,design}.md`（92／60 行）。
+- R1 對 `paulsha_cortex.deck.task_types` 的函式簽章描述與實際 API 一致（可用
+  `python3 -c "from paulsha_cortex.deck import task_types; print(dir(task_types))"`
+  核對，已於本票撰寫時核對過）。
+- R4 的 `track_record()` 簽章與 `design-model-capability-envelope-spec.md:98` 第六項
+  的假設型別相容（省略 `scope` 時退化為 `Callable[[Resource, str], float]`）。
+- `docs/superpowers/workstreams/cost-governance-cluster/todo.md` 的 `#137` 列狀態更新
+  為「設計文件已交付」。
+- 全套 `pytest` 維持綠燈不倒退（本票不改 `.py`，屬留證性質而非風險緩解）。

--- a/docs/superpowers/specs/oneshot-lesson-loop-spec.md
+++ b/docs/superpowers/specs/oneshot-lesson-loop-spec.md
@@ -33,18 +33,18 @@ issue 原文（2026-06-24 起，多則 comment 補充）主張「站在 RL 光�
 - `#325`（token usage 收進 job record）**已落地**：`paulsha_cortex/coordinator/
   registry.py` 的 job record 新增 `usage`／`usage_raw`／`usage_reason`／`started_at`／
   `exited_at` 五欄位（fail-closed schema 檢查於 `registry.py:474` 與 `:479`，寫入於
-  `registry.py:935`／`:959`-`:971`），`paulsha_cortex/coordinator/usage_aggregate.py:15`
+  `registry.py:939`／`:959`-`:971`），`paulsha_cortex/coordinator/usage_aggregate.py:15`
   `aggregate_usage_by_run()` 依 `workflow_run_id` 彙總 `input_tokens`／`output_tokens`／
   `cached_input_tokens`／`reasoning_output_tokens` 四欄位，`cortex stat --usage-by-run`
   暴露唯讀查詢（`paulsha_cortex/coordinator/cli.py:135`）。**這改變了本票 cost 維度的
   設計自由度**——見下方 R1 與 deviations。
 - `#275`（engineering outcome contract）**已落地**：`paulsha_cortex/coordinator/
   engineering_outcome.py` 是「外部 learning systems（含 Hippo）消費的唯讀 append-only
-  outbox」，`_ship_action`／`_abandon_action`（`work_actions.py:3259`／`:2305`）在既有
+  outbox」，`_ship_action`／`_abandon_action`（`work_actions.py:3262`／`:2308`）在既有
   終局轉換（`status="done"`／`status="superseded"`）之前 durable 寫入一筆
   `shipped`／`abandoned` record。**這是本票 D2「cortex 只產出、不管 hippo 召回」邊界
   的既有先例**，但其 outcome 詞彙（`shipped`／`abandoned`／`rejected`／`failed`／
-  `rolled_back`，`engineering_outcome.py:37`）與粒度（一個 work item 的終局轉換，可能
+  `rolled_back`，`engineering_outcome.py:51`-`:56`）與粒度（一個 work item 的終局轉換，可能
   已含多輪 repair）都與本票的 `clean`／`fixup`／`fail`（一次 one-shot 嘗試的品質）不同
   ——不可直接借用同一份 record 當 track_record 的 outcome 值，需要額外欄位（見 D1/D5）。
 - `#209`（model capability envelope）**已落地**：`capable()` 第六項判準已**凍結函式
@@ -96,7 +96,7 @@ task_types.classify_title()` 對 work item 的 mapped issue 標題分類取得
 |---|---|
 | `clean` | ship 終局轉換時，`delivery.ReviewLoop.fix_rounds`（`delivery.py:131`，於 `work_actions.py:3506` 讀作 `active.get("repair_rounds", 0)`）＝`0` |
 | `fixup` | ship 終局轉換達成，但 `fix_rounds ≥ 1`（`delivery.py:39` `MAX_FIX_ROUNDS`／`#218` `repair_budget_for_band()` 之內完成） |
-| `fail` | run 走 `_abandon_action`（`status="superseded"`）終局，或 repair budget 耗盡進入 `needs_human`（`delivery.py:222` `"copilot-finding-budget-exhausted"`）且未再恢復 |
+| `fail` | run 走 `_abandon_action`（`status="superseded"`）終局，或 repair budget 耗盡進入 `needs_human`（`delivery.py:234` `"copilot-finding-budget-exhausted"`）且未再恢復 |
 
 `cost` SHALL 為 reserved、nullable 欄位。**`#325` 已於本批落地**（job record 的
 `usage`／`usage_raw` 欄位、`usage_aggregate.aggregate_usage_by_run()`），本票因此

--- a/docs/superpowers/workstreams/cost-governance-cluster/todo.md
+++ b/docs/superpowers/workstreams/cost-governance-cluster/todo.md
@@ -39,7 +39,7 @@ TOCTOU 縫、StageExecutionKey 派工端消費、reviewer attestation 強度升�
 |---|---|---|
 | `#139` | 共用基礎設施：task_type / log reader / 歸屬 / status view / ledger / session-health | **硬 blocker**；已定案為 taxonomy 所有者 |
 | `#138` | 成本治理：meter → governance，cost-aware dispatch + 控速分流（judge 公式） | open |
-| `#137` | one-shot 成效閉環：lesson-loop + 棘輪計分（track-record） | open |
+| `#137` | one-shot 成效閉環：lesson-loop + 棘輪計分（track-record） | 設計文件已交付（`docs/superpowers/specs/oneshot-lesson-loop-{spec,design}.md`），待實作票落地 `track_record.py` 後可開 `openspec/changes/**` |
 | `#136` | PreToolUse 容量閘門 hook（admission control） | open；「擋 vs 不擋」裁決已貼 |
 | `#202` | feat(deck)：以 task_type 自動選擇 combo | open；已改為 additive with fallback，不再被 combo 缺口阻擋 |
 | `#208` | sizing gate + lifecycle retry 成本治理 | open；已拆分 |


### PR DESCRIPTION
## 摘要

docs(specs): 交付 #137 one-shot 成效閉環（lesson-loop + 棘輪計分）設計文件

Closes #137

## 交付內容

已交付 #137 的設計文件對（docs/superpowers/specs/oneshot-lesson-loop-{spec,design}.md），並更新 cost-governance-cluster/todo.md #137 列狀態、changelog.d fragment 與 CHANGELOG.md [Unreleased] entry，全數已 commit（d61c42c），worktree git status 乾淨。

spec.md（195 行）R1-R4 逐一回答簡報 plan 的設計問題：R1 凍結 (type,scope)×outcome(clean/fixup/fail)+cost(reserved) 計分 schema，並具體引用 delivery.py:131 ReviewLoop.fix_rounds／work_actions.py:3506 作為 outcome 機械推導依據；R2 定案 session-health 為診斷特徵、不透明 pass-through、不進 reward；R3 定案 lesson 萃取觸發條件與 cortex 端輸出介面（MUST NOT import hippo／操作 knowledge/）；R4 定案 track_record(resource, task_type, scope=None)->float 棘輪介面，並證明與 #209 已凍結簽章相容。

design.md（158 行）D1-D5：D1 決定新開 track_record.py、不擴充 gate_ledger.py/CompletionRecord/engineering_outcome.py（附三者語意對照表）；D2 是本票最重要的落差修正——明確劃出 cortex 只產出 payload、recall 完全屬 hippo 的邊界，並引用 #275 engineering_outcome.py 既有先例佐證；D3 標注 docs/research/05 backlog 查無此檔、待確認外部位置；D4 逐一評估 autonomy.py 三個候選掛點（ready_units/default_is_satisfied/dispatch_ready），建議棘輪應作為 #209 capable() 的判準之一而非另開 autonomy.py 內部路徑；D5 是新查證出的具體發現——#275 的 emit_outcome() 呼叫點（work_actions.py:3259/:2305）目前未捕捉 fix_rounds，建議未來實作票 additive 補上該欄位使 track_record 可作為既有 outbox 的下游 reducer。

全部設計問題皆有具體 main 現況檔案:行號佐證（非簡報舊行號，均已用當前 main 重新核對），並明確標出與 #325/#209/#275/#139 四個已落地件的介面關係與已知落差（scope 未持久化於 WorkflowRun.combo_selection、fix_rounds 未進 engineering-outcome record）。pytest 跑出 2042 passed + 32 subtests（33.65s），與基線完全一致。git diff 僅觸及 docs/**、changelog.d/**、CHANGELOG.md，未動任何 .py。未開 openspec/changes/**（依 issue 原文與簡報指示）。

## 與偵察簡報／規劃的落差（如實記錄）

簡報寫於 main a2e8d0c 之前，本票撰寫時已用現況重新核對並發現多處與簡報不同：
1. #325 已落地（非簡報假設的「零記錄」），因此 R1 的 cost 欄位不再是「純假設 reserved」，而是「有明確資料來源（usage_aggregate.aggregate_usage_by_run）但尚無 (type,scope) join 程式碼」——已在 spec R1 與 design 風險段落改寫此落差，不再照抄簡報「本票 MUST NOT 假設 #325 已完成」的舊字面。
2. #275（engineering outcome contract）已落地——簡報完全沒提到這個模組（因它與本票同批平行完成）。這是本票查證出的最重要新事實：D2 的跨 repo 邊界決議直接引用 #275 的既有先例（同款 append-only outbox、不 import hippo）；D1／D5 進一步發現 #275 的 outbox 目前**沒有**捕捉 fix_rounds，因此 track_record 無法單純當它的 reducer，需要未來實作票 additive 補一個欄位——這是簡報完全沒有的具體發現，已寫入 D5 並附精確行號（work_actions.py:3277 / :3506）。
3. #209（model capability envelope）已落地，且已凍結 track_record() 的函式簽章型別為 `Callable[[Resource, str], float]`（第二參數是單一 task_type 字串，非 (type,scope) tuple）——這與 #139 taxonomy R6「MUST 用 (type,scope) tuple 當計分鍵」之間有落差，簡報未提及此張力。本票 R4 用「scope 帶預設值 None、省略時邊際化」的簽章設計同時滿足兩份已凍結文件，不需要改動 #209 的文件（#209 D9 本就預留此彈性）。
4. 查證 WorkflowRun.combo_selection（workflow.py:420）目前只持久化 task_type、不持久化 scope（ComboSelection dataclass 無 scope 欄位）——這是簡報未發現的落差，已寫入 spec R1 提醒未來實作票不能只讀 combo_selection，需重跑 classify_title。
5. gh CLI 這次可正常存取（簡報寫作時 rate-limited），已直接讀到 issue #137 全文與全部 6 則 comment，確認 issue 結尾「本 issue 為設計討論記錄，非實作 PR」與 depends_on #325 現況說明（#210 comment 已更正「不用 patchmud 當資料源，track-record 改由 cortex 自身 workflow registry/CompletionRecord/PR diff 產生」），與簡報一致，無新矛盾。
6. issue comment 追加把「session-coaching / 改進建議」與 project-usage-assess 生產力 ROI 巨觀報表併入本 issue 範圍——本票在「非目標」明文排除展開這兩塊的設計，避免範圍蔓延，留待後續票。
7. todo.md 只做了單列最小編輯（#137 那一行狀態），未動其他列，避免與其他並行票撞車。

## 獨立複驗

- 判定：**pass**（複驗 agent 實跑 pytest：2042 passed / 0 failed；基線 main 2042 + 32 subtests，docs-only 無變化）。
- 首輪複驗抓到 6 個問題（含引用行號誤差／自報與交付不符），已逐項修復並經第二輪複驗通過；細節見 commit 歷史。

## 驗證

- [x] `python3 -m pytest -q` 全綠（2042 passed + 32 subtests）
- [x] diff 僅涉 docs/**、openspec/**、changelog.d/**、CHANGELOG.md（複驗確認未動任何產線 .py/.yaml）
- [x] 文件引用之檔案:行號經獨立抽查屬實
- [x] changelog fragment（R-09）＋ `CHANGELOG.md [Unreleased]` entry
- [x] 本地 policy_check 帶 PR 上下文 → fail: 0
- [x] R-21 掃描：無個人絕對路徑／憑證

## 稽核註記

本票由 sonnet subagent 撰寫設計文件、獨立 sonnet subagent 複驗（引用行號逐一對 main 抽查、設計問題完整性、diff 範圍、自報與交付一致性），PR 由主 session 統一開啟與合併。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T8j64kn6wKmL4WQA7wJL19

## 豁免說明

- **policy-exempt:issue-link（R-17）**：本 PR body 如實記錄交付與複驗過程，需引用相關 issue/PR（#139, #209, #210, #275, #325）作為上下文，僅 closing 目標為本票。