### PR TITLE
docs(cost-governance): 交付成本治理 judge 設計文件（#138）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@
 
 ## [Unreleased]
 ### Added
+- **Issue #138：交付成本治理 judge（cost-aware dispatch + 控速分流，不擋）設計文件**：新增
+  `docs/superpowers/specs/cost-governance-judge-{spec,design}.md` 與
+  `docs/superpowers/plans/cost-governance-judge.md`。凍結 `rate` 自追資料契約
+  （`RateSnapshot`）與新模組落點 `rate_tracker.py`；凍結控速分流層 `filter_ready()` 介面
+  契約，掛點為 `autonomy.ready_units()` 與 `dispatch_ready()` 之間，並與 `#136` 已落地的
+  `capacity_gate.py`（daemon-idle 布林閘）劃清「並行兩把閘、不同稀缺資源軸」的邊界；429
+  回授裁定重用 `manager_daemon._tick_backoff_seconds()` 的指數封頂公式、不重用其
+  daemon-level 狀態；凍結 judge MVP 四因子合取判斷式（`rate_available × quota_remaining
+  × capable() × track_record()`）與四個 interim stub 契約——`#137`／`#209` 尚未
+  code-landed 期間全恆真，行為與現況等價；串接 `#137` `session_health` opaque
+  pass-through 邊界，凍結 `should_terminate()` 五類終止觸發契約。裁定 MVP 不新增
+  `resource-inventory.yaml`，遵循 `#209` 既定路徑。本票不實作任何程式碼、不開
+  `openspec/changes/**`。詳見 `changelog.d/cost-governance-judge-design.md`。
 - **Issue #340：builder persona 契約新增 `completion_obligations`（結束前必須 commit）**：`PersonaContract` 新增 `completion_obligations` 欄位（fail-closed schema 檢查），`personas.yaml` 的 `builder` 角色新增義務宣告「完成前必須 git add＋git commit，worktree 不乾淨不得回報完成」，由 `render_contract_prompt` 注入實際派工的 dispatch prompt，補上既有 `commit_policy: required`（只管寫入權限）與 manager 端事後 dirty-worktree 安全網之間「事前宣告義務」的缺口；空清單角色不受影響。
 ### Fixed
 - **Issue #339：run tick 對已有 needs_human 終局紀錄的 slice 不再重複 fanout**：`run_tick` 原本的冪等防護只排除 registry 中仍在 `dispatched`/`running` 的 job，job 一旦 poll 到 exited 就離開這個集合，不論其 `gate_status` 是 `needs_human`／`failed`／`passed`；`ready_units`/`default_is_satisfied` 只檢查「別人 depends_on 我」是否滿足，從未檢查「我自己是否已經跑過」，導致下一趟 tick 對已完成待人工的 slice 重新 fanout，撞 `ScriptWorktreeCreator.create` 的 `"worktree target already exists"`。現在派工前會掃描每個 slice 是否已有 handoff 終局紀錄，併入排除集合；此掃描不受 idle gate 影響，`require_idle` 擋下新工作時 `needs_human` 清單仍會回報。summary 新增 `needs_human: [{slice_id, gate_reason, handoff_path}, ...]` 欄位。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,10 @@
   code-landed 期間全恆真，行為與現況等價；串接 `#137` `session_health` opaque
   pass-through 邊界，凍結 `should_terminate()` 五類終止觸發契約。裁定 MVP 不新增
   `resource-inventory.yaml`，遵循 `#209` 既定路徑。本票不實作任何程式碼、不開
-  `openspec/changes/**`。詳見 `changelog.d/cost-governance-judge-design.md`。
+  `openspec/changes/**`。複驗訂正：`#137` 的設計文件實際只存在於未合併分支
+  `feature/137-oneshot-lesson-loop-design`（main 上不存在），初版誤標其為「已落地
+  設計」已訂正；另補上與已落地票 `#325`／`#324` 的介面關係查證。詳見
+  `changelog.d/cost-governance-judge-design.md`。
 - **Issue #340：builder persona 契約新增 `completion_obligations`（結束前必須 commit）**：`PersonaContract` 新增 `completion_obligations` 欄位（fail-closed schema 檢查），`personas.yaml` 的 `builder` 角色新增義務宣告「完成前必須 git add＋git commit，worktree 不乾淨不得回報完成」，由 `render_contract_prompt` 注入實際派工的 dispatch prompt，補上既有 `commit_policy: required`（只管寫入權限）與 manager 端事後 dirty-worktree 安全網之間「事前宣告義務」的缺口；空清單角色不受影響。
 ### Fixed
 - **Issue #339：run tick 對已有 needs_human 終局紀錄的 slice 不再重複 fanout**：`run_tick` 原本的冪等防護只排除 registry 中仍在 `dispatched`/`running` 的 job，job 一旦 poll 到 exited 就離開這個集合，不論其 `gate_status` 是 `needs_human`／`failed`／`passed`；`ready_units`/`default_is_satisfied` 只檢查「別人 depends_on 我」是否滿足，從未檢查「我自己是否已經跑過」，導致下一趟 tick 對已完成待人工的 slice 重新 fanout，撞 `ScriptWorktreeCreator.create` 的 `"worktree target already exists"`。現在派工前會掃描每個 slice 是否已有 handoff 終局紀錄，併入排除集合；此掃描不受 idle gate 影響，`require_idle` 擋下新工作時 `needs_human` 清單仍會回報。summary 新增 `needs_human: [{slice_id, gate_reason, handoff_path}, ...]` 欄位。

--- a/changelog.d/cost-governance-judge-design.md
+++ b/changelog.d/cost-governance-judge-design.md
@@ -1,0 +1,23 @@
+### Added
+- **Issue #138：交付成本治理 judge（cost-aware dispatch + 控速分流，不擋）設計文件**：新增
+  `docs/superpowers/specs/cost-governance-judge-{spec,design}.md` 與
+  `docs/superpowers/plans/cost-governance-judge.md`。凍結 `rate` 自追資料契約
+  （`RateSnapshot`：`available`／`tokens_remaining`／`window_seconds`／`last_429_at`），
+  新模組落點 `rate_tracker.py`（不擴充 `model_identities.py`／`claim_readiness.py`／
+  `manager_daemon.py`，理由分述於 design D3）；凍結控速分流層 `filter_ready()` 介面契約，
+  掛點為 `autonomy.ready_units()` 與 `dispatch_ready()` 之間的新過濾步驟，並與 `#136`
+  已落地的 `capacity_gate.py`（daemon-idle 布林閘）劃清「並行兩把閘、不同稀缺資源軸」的
+  邊界；429 回授裁定重用 `manager_daemon._tick_backoff_seconds()` 的指數封頂**公式**、
+  不重用其 daemon-level **狀態**；凍結 judge MVP 四因子合取判斷式（`rate_available ×
+  quota_remaining × capable() × track_record()`），並定案四個 interim stub 契約——`#137`
+  `track_record()`／`#209` `capable()` 尚未 code-landed 期間全恆真，行為與現況等價（安全
+  no-op），四者可獨立分批替換為真值；串接 `#137` 已落地設計的 `session_health` opaque
+  pass-through 邊界，凍結 `should_terminate()` 五類終止觸發契約（含「precompact harvest
+  hook」查無實據、stall/報酬遞減本 repo 無既有機制的誠實記錄）。裁定 MVP 不新增
+  `context_window`／`quota_window_kind`／`autonomy_safety_profile` 三個靜態欄位，未來
+  如需新增遵循 `#209` R3 既定路徑（additive 擴充 `model-identities.yaml`，不新開
+  `resource-inventory.yaml`）。查證「haman/arc 多帳號池」config 在本 repo 不存在，不予
+  假設。本票不實作任何程式碼、不動 `autonomy.py`／`claim_readiness.py`／
+  `manager_daemon.py`／`capacity_gate.py`、不開 `openspec/changes/**`（依 issue 原文，
+  落地時再依 OpenSpec 流程另開）。同步更新
+  `docs/superpowers/workstreams/cost-governance-cluster/todo.md` 的 `#138` 列狀態。

--- a/changelog.d/cost-governance-judge-design.md
+++ b/changelog.d/cost-governance-judge-design.md
@@ -11,7 +11,7 @@
   不重用其 daemon-level **狀態**；凍結 judge MVP 四因子合取判斷式（`rate_available ×
   quota_remaining × capable() × track_record()`），並定案四個 interim stub 契約——`#137`
   `track_record()`／`#209` `capable()` 尚未 code-landed 期間全恆真，行為與現況等價（安全
-  no-op），四者可獨立分批替換為真值；串接 `#137` 已落地設計的 `session_health` opaque
+  no-op），四者可獨立分批替換為真值；串接 `#137` `session_health` opaque
   pass-through 邊界，凍結 `should_terminate()` 五類終止觸發契約（含「precompact harvest
   hook」查無實據、stall/報酬遞減本 repo 無既有機制的誠實記錄）。裁定 MVP 不新增
   `context_window`／`quota_window_kind`／`autonomy_safety_profile` 三個靜態欄位，未來
@@ -21,3 +21,10 @@
   `manager_daemon.py`／`capacity_gate.py`、不開 `openspec/changes/**`（依 issue 原文，
   落地時再依 OpenSpec 流程另開）。同步更新
   `docs/superpowers/workstreams/cost-governance-cluster/todo.md` 的 `#138` 列狀態。
+  複驗訂正：初版誤將 `#137`（one-shot 成效閉環／track-record）標注為「已落地設計」，
+  查證 main 上不存在 `#137` 的設計文件（僅存在於未合併分支
+  `feature/137-oneshot-lesson-loop-design`），已訂正為「設計初稿、尚未合併」，
+  design.md／spec.md／plan.md 相應處已同步更正；另補上與已落地票 `#325`（job usage
+  schema）、`#324`（combo 可擴充與可選）的介面關係查證——`#325` 提供歷史 per-job
+  用量記錄與本票即時 per-resource rate 閘門互補不重疊，`#324` 屬 workflow/card 骨架層
+  與本票無介面耦合，兩者查證結果詳見 spec.md／design.md「與相鄰票的介面關係」段落。

--- a/docs/superpowers/plans/cost-governance-judge.md
+++ b/docs/superpowers/plans/cost-governance-judge.md
@@ -13,12 +13,21 @@ work_item: cost-governance-judge
 
 ## 依賴前提（派工前必讀）
 
-- `#209 capable()` 本體與 `#137 track_record()` 本體目前皆為**已落地設計、尚未
-  code-landed**——下列子票中標「可獨立先做」的不需要等它們，標「依賴」的需要等對應
-  票的程式碼落地。
+- `#209 capable()` 本體目前為**已落地設計（`design-model-capability-envelope-
+  {spec,design}.md` 在 main）、尚未 code-landed**。`#137 track_record()` 本體現況
+  更早一階——**設計本身也尚未落地 main**（`oneshot-lesson-loop-{spec,design}.md`
+  只存在於未合併的 `feature/137-oneshot-lesson-loop-design` 分支，詳見
+  `cost-governance-judge-design.md`「與 `#137` 狀態的訂正說明」），須先合併設計、
+  再落地程式碼。下列子票中標「可獨立先做」的不需要等它們，標「依賴」的需要等對應
+  票的程式碼落地（`#137` 一項還額外多一道「先合併設計」的前置）。
 - 四個 interim stub（design D6／spec R4）保證骨架先行不會讓現有派工行為退化，因此
   子票 2（`filter_ready` 骨架）可以在子票 1（`rate_tracker`）之前或並行動工，不構成
   阻擋。
+- 已落地票 `#325`（job usage schema）與本票子票 1（`rate_tracker.py`）**無直接依賴**：
+  `#325` 的 `registry.py` `usage`／`usage_raw` 是歷史 per-job 記錄，子票 1 是即時
+  per-resource 速率閘門，兩者資料源不同（詳見 design.md／spec.md「與相鄰票的介面
+  關係」）；`#324`（combo 可擴充與可選）與本票任何子票皆無介面耦合，僅記錄查證結果
+  供派工參考，不影響本表拆分。
 
 ## 後續實作票拆分
 

--- a/docs/superpowers/plans/cost-governance-judge.md
+++ b/docs/superpowers/plans/cost-governance-judge.md
@@ -1,0 +1,82 @@
+---
+status: accepted
+work_item: cost-governance-judge
+---
+
+# cost-governance-judge Plan
+
+本票（`#138`）交付的是設計文件（`cost-governance-judge-{spec,design}.md`），不寫任何
+`.py` 程式碼。本檔案不是本票自己的 TDD 執行計畫，而是比照 `#208` → `#211`–`#223` 的
+拆分模式，把設計文件的七個 Requirements 拆成可獨立派工的後續**實作票**清單，供未來
+以 OpenSpec change 落地時當作派工前置清單（issue 原文結尾「落地時再依 OpenSpec 流程
+開 change」）。
+
+## 依賴前提（派工前必讀）
+
+- `#209 capable()` 本體與 `#137 track_record()` 本體目前皆為**已落地設計、尚未
+  code-landed**——下列子票中標「可獨立先做」的不需要等它們，標「依賴」的需要等對應
+  票的程式碼落地。
+- 四個 interim stub（design D6／spec R4）保證骨架先行不會讓現有派工行為退化，因此
+  子票 2（`filter_ready` 骨架）可以在子票 1（`rate_tracker`）之前或並行動工，不構成
+  阻擋。
+
+## 後續實作票拆分
+
+### 1. `rate_tracker.py`：token bucket 自追（可獨立先做，零外部前置）
+
+- 落地 `paulsha_cortex/coordinator/rate_tracker.py`：`consume()`／`record_429()`／
+  `rate_status()`（spec R1／R3／R7）。
+- 驗收：純函式單元測試涵蓋 bucket 惰性補充、429 收縮 `capacity`、冷啟動空桶行為；
+  `rate_status()` 回傳形狀與 `RateSnapshot`（spec R1 表格）一致。
+- 不依賴 `#137`／`#209`。
+
+### 2. `filter_ready` 骨架：控速分流層介面（可獨立先做，四因子 stub 全恆真）
+
+- 落地 `filter_ready()`（spec R2），掛在 `autonomy.ready_units()` 與
+  `dispatch_ready()` 之間的 manager tick 步驟。
+- 四因子（`rate_available`／`quota_remaining`／`capable`／`track_record`）依 spec R4
+  的 interim stub 表全部先恆真——驗收基準是「掛上此步驟後既有派工行為不變」（no-op
+  回歸測試：`filter_ready` 的輸出在四個 stub 恆真時應與輸入 `units` 完全相同，
+  `queued` 恆為空）。
+- 明確不依賴 `#136` `capacity_gate.py`，不得修改該檔案（design D4 邊界）。
+
+### 3. `rate_available` stub 替換為真值
+
+- 把子票 2 的 `rate_available` stub 換成呼叫子票 1 的 `rate_tracker.consume()`。
+- 依賴：子票 1、子票 2 皆完成。
+
+### 4. `capable` stub 替換為真值
+
+- 依賴：`#209` R1 `capable()` 本體 code-landed（跨票依賴，不在本 cluster 掌控範圍）。
+- 落地時需先確認 `model-identities.yaml` 是否已補上至少一個具 `build` capability 的
+  身分（`design-model-capability-envelope-design.md` D6／風險與緩解已載明此前置檢查）
+  ，否則 `capable()` 上線會讓現行 build 派工從「無過濾」變成「全部擋下」。
+
+### 5. `track_record` stub 替換為真值
+
+- 依賴：`#137` R4 `track_record()` 本體 code-landed。
+
+### 6. `quota_remaining` 接線（跨 repo，範圍最大，需先對齊 `paulshaclaw` owner）
+
+- 依賴：`paulshaclaw/cost/` 暴露可供本 repo 消費的 quota view 介面——這不是本 repo
+  單方面可以落地的票，需要先有一張與 `paulshaclaw` owner 對齊介面形狀的溝通/設計
+  子票，不建議直接開實作票。
+
+### 7. `should_terminate` 觸發框架 + session-health 門檻
+
+- 落地 `should_terminate()`（spec R5）與 `launcher.py` wrapper 執行迴圈的掛勾點。
+- session-health 門檻數值需 `#210`（以自身 run 歷史校準）先有基礎資料；stall／報酬
+  遞減判準本票明文不預先定義，此票需要自行設計判準（design D7 已標注為「本票範圍內
+  唯一全新概念」，風險最高，建議獨立一張票、不與觸發框架落地綁在同一顆 PR）。
+
+### 8.（可選）`resource-inventory` 新增靜態欄位
+
+- 僅在證實 MVP judge 需要 `context_window`／`quota_window_kind`／
+  `autonomy_safety_profile` 時才開票；遵循 spec R6 的 additive 擴充路徑，不新建檔案。
+
+## 建議派工順序
+
+第一波可並行：子票 1、子票 2（互不碰檔，且子票 2 不需要等子票 1）。
+子票 3 依賴子票 1+2；子票 4／5／6 各自依賴外部票（`#209`／`#137`／`paulshaclaw`）
+code-landed，屬長尾追蹤項，不建議現在派工，待前置條件成立後再開票。子票 7 可與第一波
+並行（觸發框架部分），但 session-health 門檻數值段落建議延後到 `#210` 有資料後再收斂。

--- a/docs/superpowers/specs/cost-governance-judge-design.md
+++ b/docs/superpowers/specs/cost-governance-judge-design.md
@@ -52,7 +52,7 @@ additive 擴充 `model-identities.yaml`，MUST NOT 新開第二個 inventory 檔
 | `quota` | cost meter（`paulshaclaw/cost/`，非本 repo） | 已有實作（跨 vendor quota 取數），未暴露成本票能消費的 view 介面——本票不落地此介接，留給後續實作票 |
 | `rate` | **`#138` 本票自己負責** | 全 repo zero 命中（`grep -rn "token_bucket\|rate_limit"` 於 `paulsha_cortex/` 無治理相關命中），本票 D3 定義其資料結構 |
 | `health` | `#139` 六項落地任務之一（跨 agent 存活） | 未落地，本票只消費其欄位契約，不重複定義 |
-| `track_record` | `#137`（已落地設計） | `track_record(resource, task_type, scope=None) -> float`（`oneshot-lesson-loop-spec.md` R4），型別已與 `#209 capable()` 第六項對齊 |
+| `track_record` | `#137`（**設計初稿，`feature/137-oneshot-lesson-loop-design` 分支，尚未合併 main**——訂正見文末「與 `#137` 狀態的訂正說明」） | `track_record(resource, task_type, scope=None) -> float`（草稿 `oneshot-lesson-loop-spec.md` R4），型別已與 `#209 capable()` 第六項對齊，但簽章本身尚未定案 |
 
 `rate` 欄位型別本票 SHALL 凍結為：`dict[str, RateSnapshot]`，鍵為
 `f"{executor}:{model_id}"`（與 `#209` R2 的 `(executor, model_id)` 複合鍵一致，字串化
@@ -76,7 +76,7 @@ additive 擴充 `model-identities.yaml`，MUST NOT 新開第二個 inventory 檔
 ### D3 rate 自追：新模組 `rate_tracker.py`，token bucket 資料結構
 
 新增獨立模組 `paulsha_cortex/coordinator/rate_tracker.py`（實作票落點，本票不寫程式
-碼），不擴充下列既有模組（避免撞責任邊界，比照 `#137` D1 的排除表寫法）：
+碼），不擴充下列既有模組（避免撞責任邊界，比照 `#137` 未合併草稿 D1 的排除表寫法）：
 
 | 既有模組 | 為何不適合承載 rate tracking |
 |---|---|
@@ -105,7 +105,7 @@ additive 擴充 `model-identities.yaml`，MUST NOT 新開第二個 inventory 檔
 明確裁量依據。
 
 ### D4 控速分流層：不是 `#136`，是夾在 `autonomy.py` `ready_units()` 與
-`dispatch_ready()` 之間的一層新過濾——與 `#137` D4 的建議掛點完全對齊
+`dispatch_ready()` 之間的一層新過濾——與 `#137` 未合併草稿 D4 的建議掛點一致
 
 issue §5 原文用詞「控速分流層」容易讓後續實作票誤認為與 `#136`（已落地）是同一層或
 要擴充 `#136`。查證 main 現況：`#136` 落地的 `paulsha_cortex/porcelain/capacity_gate.py`
@@ -120,7 +120,8 @@ admission 閘（不擋，只排隊/詢問），是同一閘序位置上的兩把
 `capacity_gate.evaluate_gate()`，也 MUST NOT 讓 `#138` 重新發明一個 daemon-idle 判斷
 （那是 `#136` 已解決的問題）。
 
-真正的掛點（沿用 `#137` design D4 已建議、本票確認採納的方案 3）：
+真正的掛點（沿用 `#137` design 草稿——未合併分支——D4 建議、本票確認採納的方案 3；
+該草稿本身尚未定案或合併，本票僅引其掛點分析作為對齊參考）：
 
 ```
 manager.ready_units()          -- autonomy.py:394，結構完整性判定（#136/#138 之前）
@@ -205,7 +206,7 @@ judge(work, resource) =
       rate_available(resource)                          -- D3，本票自己的 rate_tracker
     ∧ quota_remaining(resource) > 0                      -- cost meter（外部，非本 repo）
     ∧ capable(resource, work)                            -- #209 R1 六項合取（已落地設計）
-    ∧ track_record(resource, work.task_type) ≥ threshold -- #137 R4（已落地設計）
+    ∧ track_record(resource, work.task_type) ≥ threshold -- #137 R4（設計初稿，未合併）
 ```
 
 `judge` 選第一個滿足全部四項的 resource（deterministic 順序，比照 registry 既有迭代
@@ -216,12 +217,12 @@ judge(work, resource) =
 四個因子目前的實際落地狀態各自獨立，`filter_ready`（D4）落地時 **不需要等四者全部
 code-landed**，可先用以下 stub 逐步替換，且每個 stub 都已有明確的「真值」替換點：
 
-| 因子 | interim stub | 真值替換點（設計已定案，等實作票） |
+| 因子 | interim stub | 真值替換點 |
 |---|---|---|
-| `rate_available` | 恆真（D3 `rate_tracker.py` 尚未落地） | `rate_tracker.consume()` |
-| `quota_remaining` | 恆真（cost meter 尚未暴露 view 介面給本 repo） | 待未來票把 `paulshaclaw/cost/` 接進 D2 status view |
-| `capable` | 恆真（`claim_readiness.py:421-437` 現況正是這個 bypass：`capability_lookup is None` 時 `_passed(..., bypass="envelope_unavailable")`） | `#209` R1 的實作票落地 `capable()` 本體後 |
-| `track_record` | 恆真（`#137` `track_record.py` 尚未落地） | `#137` R4 的實作票落地 `track_record()` 本體後 |
+| `rate_available` | 恆真（D3 `rate_tracker.py` 尚未落地） | `rate_tracker.consume()`（設計已定案，本票 D3，等實作票） |
+| `quota_remaining` | 恆真（cost meter 尚未暴露 view 介面給本 repo） | 待未來票把 `paulshaclaw/cost/` 接進 D2 status view（設計已定案，本票 D2，等實作票） |
+| `capable` | 恆真（`claim_readiness.py:421-437` 現況正是這個 bypass：`capability_lookup is None` 時 `_passed(..., bypass="envelope_unavailable")`） | `#209` R1 的實作票落地 `capable()` 本體後（`#209` 設計已落地 main，等 code） |
+| `track_record` | 恆真（`#137` `track_record.py` 尚未落地） | `#137` R4 的實作票落地 `track_record()` 本體後（`#137` **設計本身也尚未落地 main**——未合併分支草稿，需先合併設計、再落地 code） |
 
 四項全恆真時，`judge` 恆選第一個 eligibility 通過的 resource——這與**現況**
 （`ready_units()` 之後無任何 admission/routing 過濾，直接 `dispatch_ready()`）行為
@@ -236,7 +237,8 @@ release——緩解：本節明文「stub 全恆真＝現況等價的安全 no-o
 
 ### D7 session 終止槓桿：只定觸發契約，串接 `#137` `session_health`
 
-沿用 `#137`（已落地設計）R2 的既有邊界：`session_health` 是**不透明 pass-through**
+沿用 `#137`（**設計初稿，未合併 main**——見文末訂正說明）R2 的既有邊界：`session_health`
+是**不透明 pass-through**
 欄位（`dict | None`），MUST NOT 併入 outcome/reward 計分，但**可以**用於歸因與早期
 預警——本票的 session 終止觸發正是「早期預警」的消費端之一。
 
@@ -288,3 +290,36 @@ def should_terminate(signals: SessionSignals) -> TerminationDecision | None:
   照抄 issue 字面去找一個不存在的 config，會卡住——緩解：D4 已明文查證結果（本 repo
   不存在），並保留「池總吞吐＝各桶速率之和」的概念供未來若帳號池真的落地時直接套用
   D3 的 token bucket 模型，不需要另外設計聚合邏輯。
+
+## 與相鄰票的介面關係
+
+- **`#325`（已落地，main，PR `#356`）**：`registry.py` 落地的 job 級 `usage`／
+  `usage_raw` 欄位是歷史、per-job、事後的用量記錄，與本票 D3 `rate_tracker` 要的
+  即時、per-resource、事前速率閘門是不同資料形狀與更新時機，兩者互補不重疊——`#325`
+  issue 本文「非目標」段落自行排除「控速、告警 → #138」，確認邊界不衝突。完整查證見
+  `cost-governance-judge-spec.md` R1 段落。
+- **`#324`（已落地，main，「combo 可擴充與可選」）**：與本票**無資料或函式介面耦合**，
+  屬 workflow/card 派工骨架層（combo 搜尋路徑、`small-fix` 輕量 combo），`#324` issue
+  本文「非目標」段落自行畫出邊界（「cost-aware routing → #138」）。記錄查證結果供
+  複驗核對，非本票需要接線的相鄰模組。
+
+## 與 `#137` 狀態的訂正說明
+
+本文件初版多處把 `#137`（one-shot 成效閉環／track-record）標注為「已落地設計」，與
+`#209`（`design-model-capability-envelope-{spec,design}.md`，main 已落地）並列——
+**此標注不成立，已訂正為「設計初稿，`feature/137-oneshot-lesson-loop-design` 分支，
+尚未合併 main」**。查證依據：
+
+1. `git ls-tree -r main --name-only | grep -i oneshot` 於本 repo 零命中——main 上不
+   存在任何 `#137` 的設計文件。
+2. `git merge-base --is-ancestor feature/137-oneshot-lesson-loop-design main` 回傳
+   false（未合併）；`git ls-remote --heads origin` 亦無此分支（未推送）。
+3. `docs/superpowers/workstreams/cost-governance-cluster/todo.md` 的叢集 A 表格本身
+   把 `#137` 列為 `open`，與「已落地設計」矛盾。
+4. `#209` 自己的 `design-model-capability-envelope-spec.md:98` 在 R1 第 6 項判準把
+   `#137` 標注為「尚未落地」——`#209` 對 `#137` 狀態的表述才是準確的，本文件應與其
+   一致。
+
+本節訂正不改變本票任何 D/R 決策內容：interim stub 契約（D6／spec R4）本就已把
+`track_record` 列為恆真 stub，訂正只是把狀態描述從「已落地設計」精確化為「設計初稿、
+未合併」，前述 D2／D3／D4／D6／D7 各處提及 `#137` 之處已同步訂正引用文字。

--- a/docs/superpowers/specs/cost-governance-judge-design.md
+++ b/docs/superpowers/specs/cost-governance-judge-design.md
@@ -1,0 +1,290 @@
+---
+status: accepted
+work_item: cost-governance-judge
+---
+
+# cost-governance-judge Design
+
+## Decisions
+
+### D1 靜態 resource-inventory：不新開檔案，`#138` 本身不新增靜態欄位
+
+issue §3 原文把供給側靜態 inventory 列為「能力 tier／context window／cost 模型／
+autonomy-safety profile」四類；但查證 `#209`（已落地設計，`design-model-capability-
+envelope-{spec,design}.md`）D3／R3 已經定案：**不新建 `resource-inventory.yaml`**，
+四個新靜態欄位（`accepts_bands`／`invariant_ceiling`／`consistency_scope`／
+`acceptance_modes`）additive 掛在既有 `paulsha_cortex/coordinator/data/
+model-identities.yaml`（`(executor, model_id)` 複合鍵，schema version 2→3）。這已
+覆蓋 issue §3「能力 tier」語意（`capabilities`／`accepts_bands`）。
+
+`#138` 自身查證 main 現況：`context_window`（模型宣告的 token 上限）、
+`quota_window_kind`（訂閱制 quota 窗口類型：5h／weekly／premium interaction）、
+`autonomy_safety_profile` 三者在全 repo 皆無任何落地或設計欄位（`grep -rn
+"context_window\|quota_window\|autonomy_safety"` 於 `paulsha_cortex/`／
+`docs/superpowers/specs/` 零命中；唯一命中的 `context window` 字串是
+`builder-task-boundary-segmentation-{spec,design}.md` 裡的 turn-failed **錯誤訊息
+偵測字串**——`"ran out of room in the model's context window"`，語意是「builder 這次
+執行途中撞牆的事後偵測」，與本票要的「resource 靜態宣告值」完全不同概念，命名相似但
+不可混用，比照 `#209` D8 對 `acceptance_mode`／`acceptance_surfaces` 的消歧手法）。
+
+**裁定**：MVP judge 規則（見 D6）不需要這三個欄位——`#138` 自己在 issue §4／
+cluster todo.md 的四因子分工表裡只認領「rate token」一項，quota／能力／戰績分屬
+cost meter／`#209`／`#137`。因此本票 **不** 在 MVP 範圍新增
+`context_window`／`quota_window_kind`／`autonomy_safety_profile` 三欄位；若未來
+判定 judge 需要更細的靜態資訊（例如用 `quota_window_kind` 正確解讀 `rate`
+與 `quota` 兩訊號的交互關係，見 D2），後續實作票 SHALL 遵循 `#209` R3 的既有先例：
+additive 擴充 `model-identities.yaml`，MUST NOT 新開第二個 inventory 檔案、MUST NOT
+與 `#209` 既有四欄位撞名。
+
+風險與緩解：若後續票誤以為「issue §3 列了四類就要建四類欄位」，會重建
+`resource-inventory.yaml` 這個 `#209` 已明文否決的路徑——緩解：本節與 `#209` D3／R3
+互相印證，任何要新增靜態欄位的實作票 code review 應先核對「有沒有新開檔案」作為機械
+檢查點。
+
+### D2 動態 status view：`#138` 只交付 `rate` 這一格，其餘三格引用既有歸屬
+
+`#139`（已落地設計，`design-task-type-taxonomy-v2-spec.md` R7）已凍結 status view
+的欄位契約為 `quota`／`rate`／`health`／`track_record` 四鍵的動態 JOIN（非第四個資料
+倉庫）。四鍵歸屬（cluster todo.md 四因子分工表 + `#139` R7 逐一核對）：
+
+| 欄位 | 歸屬 | 落地狀態 |
+|---|---|---|
+| `quota` | cost meter（`paulshaclaw/cost/`，非本 repo） | 已有實作（跨 vendor quota 取數），未暴露成本票能消費的 view 介面——本票不落地此介接，留給後續實作票 |
+| `rate` | **`#138` 本票自己負責** | 全 repo zero 命中（`grep -rn "token_bucket\|rate_limit"` 於 `paulsha_cortex/` 無治理相關命中），本票 D3 定義其資料結構 |
+| `health` | `#139` 六項落地任務之一（跨 agent 存活） | 未落地，本票只消費其欄位契約，不重複定義 |
+| `track_record` | `#137`（已落地設計） | `track_record(resource, task_type, scope=None) -> float`（`oneshot-lesson-loop-spec.md` R4），型別已與 `#209 capable()` 第六項對齊 |
+
+`rate` 欄位型別本票 SHALL 凍結為：`dict[str, RateSnapshot]`，鍵為
+`f"{executor}:{model_id}"`（與 `#209` R2 的 `(executor, model_id)` 複合鍵一致，字串化
+只為 view 層可序列化），`RateSnapshot` 至少含：
+
+| 子欄位 | 型別 | 語意 |
+|---|---|---|
+| `available` | `bool` | 本票 MVP 判斷式唯一實際消費的欄位——「這個 resource 現在還能不能再送一次請求」 |
+| `tokens_remaining` | `float \| None` | token bucket 目前餘量，reserved（見 D3），可為 `None`（尚未觀測過此 resource） |
+| `window_seconds` | `float \| None` | bucket 補充週期，reserved |
+| `last_429_at` | `str \| None`（ISO8601） | 供 D5 429 回授判讀 |
+
+`status view` 是動態 JOIN、不是新資料倉庫——`rate` 子系統（D3）只需要提供一個純函式
+`rate_status(executor, model_id) -> RateSnapshot`，被同一個 JOIN 呼叫端與 `quota`／
+`health`／`track_record` 並列讀取，不得自建獨立的 CLI 或儲存路徑與其他三格分裂。
+
+風險與緩解：若 `rate` 落地時走出一條與 `quota`／`health`／`track_record` 不同的查詢
+介面（例如另開一個 CLI 子命令），會讓 status view「動態 JOIN」的單一入口承諾破功——
+緩解：本節明文 `rate_status()` 的純函式簽章，供未來實作票與 view JOIN 層的介接對照。
+
+### D3 rate 自追：新模組 `rate_tracker.py`，token bucket 資料結構
+
+新增獨立模組 `paulsha_cortex/coordinator/rate_tracker.py`（實作票落點，本票不寫程式
+碼），不擴充下列既有模組（避免撞責任邊界，比照 `#137` D1 的排除表寫法）：
+
+| 既有模組 | 為何不適合承載 rate tracking |
+|---|---|
+| `paulsha_cortex/coordinator/model_identities.py` | 承載**靜態** identity registry（`IdentityRegistry`），`rate` 是**動態、高頻寫入**的觀測值，混入會讓 fail-closed 的靜態 schema 驗證邏輯與高頻寫入路徑攪在一起 |
+| `paulsha_cortex/coordinator/claim_readiness.py` | 承載**一次性交易**（每次 claim 評估一次六項檢查後即結束），`rate` 需要跨多次 claim／dispatch 持續累積狀態，語意上是常駐計數器而非交易快照 |
+| `paulsha_cortex/coordinator/manager_daemon.py` | 承載 daemon tick 迴圈與**該迴圈自身**的 backoff（見 D5），不是「每個 resource 各自的請求速率」——兩者粒度不同，混入會讓 `_tick_backoff_seconds` 的單一 daemon-level 退避與多 resource 的個別 rate 狀態糾纏 |
+
+`rate_tracker.py` 的資料結構（本票凍結契約，不寫實作）：
+
+- **token bucket**，鍵為 `(executor, model_id)`（與 `#209` R2 同一複合鍵，一致性優先於
+  自創新鍵）。
+- 每桶至少追蹤：`capacity`（每分鐘可送出請求數上限，可設定）、`tokens`（目前餘量，
+  float，支援分數補充）、`refilled_at`（上次補充時間戳，用於惰性補充計算，不需要背景
+  timer thread）。
+- `consume(executor, model_id) -> bool`：惰性補充後嘗試扣一個 token，成功回 `True`（可
+  送），失敗回 `False`（暫時不可送，觸發 D4 排隊）——純函式風格，狀態經由呼叫端傳入/
+  持久化位置留給實作票決定（in-memory dict 供 daemon 單進程使用即可，不必比照
+  `registry.py` 的 durable JSON persistence，因為 rate 狀態本質上是短期的、daemon
+  重啟後從空桶重新學習是可接受的降級，不是持久事實）。
+- `record_429(executor, model_id) -> None`：D5 消費，收縮 `capacity`（乘法退避）並記錄
+  `last_429_at`。
+
+風險與緩解：若後續實作票把 rate 狀態誤植為需要跨 daemon 重啟持久化的「事實」（比照
+`registry.py` job record 等級的 durability），會過度工程化一個本質上可容忍冷啟動的
+觀測值——緩解：本節明文「daemon 重啟後從空桶重新學習是可接受降級」，作為實作票的
+明確裁量依據。
+
+### D4 控速分流層：不是 `#136`，是夾在 `autonomy.py` `ready_units()` 與
+`dispatch_ready()` 之間的一層新過濾——與 `#137` D4 的建議掛點完全對齊
+
+issue §5 原文用詞「控速分流層」容易讓後續實作票誤認為與 `#136`（已落地）是同一層或
+要擴充 `#136`。查證 main 現況：`#136` 落地的 `paulsha_cortex/porcelain/capacity_gate.py`
+（`evaluate_gate()`）管的是 **Claude Code PreToolUse hook**——互動 session 中 agent
+自己手動呼叫 `Task`/`Agent` 或起一個 headless `codex exec`/`claude -p` 時，查
+`daemon.idle` 布林決定要不要 `ask`。這是「daemon 忙不忙」這一個軸，與本票要的
+「這個 (executor, model_id) 的 quota／rate 是否還有餘裕」是**不同的稀缺資源軸**——
+`#136` 忙碌時全域 `ask`，即使某個 resource 的 rate/quota 明明還有餘量；本票的控速
+分流不看 daemon 忙不忙，只看 resource 級的額度。**兩者都屬 R4（`#209` spec）的
+admission 閘（不擋，只排隊/詢問），是同一閘序位置上的兩把並行鎖，不是同一把鎖的
+兩個名字**——後續實作票 MUST NOT 把 `#138` 的控速邏輯塞進
+`capacity_gate.evaluate_gate()`，也 MUST NOT 讓 `#138` 重新發明一個 daemon-idle 判斷
+（那是 `#136` 已解決的問題）。
+
+真正的掛點（沿用 `#137` design D4 已建議、本票確認採納的方案 3）：
+
+```
+manager.ready_units()          -- autonomy.py:394，結構完整性判定（#136/#138 之前）
+        |
+        v
+   【控速分流層（#138 本票）】  -- 新過濾層，本票只定介面，不寫程式碼：
+        |                         filter_ready(units, judge) -> (dispatchable, queued)
+        |                         judge = D6 的四因子合取式
+        v
+autonomy.py dispatch_ready()   -- fan-out 入口，只對 dispatchable 呼叫 AgentLauncher
+```
+
+介面契約（本票凍結，供未來實作票直接引用）：
+
+```
+def filter_ready(
+    units: Sequence[ReadyUnit],
+    judge: Callable[[ReadyUnit], JudgeResult],
+) -> tuple[Sequence[ReadyUnit], Sequence[QueuedUnit]]:
+    """依 D6 judge 規則把 ready_units() 的輸出分成「現在可派」與「先排隊」。
+
+    不擋（fail-closed 的「不該派」屬 eligibility，不在本函式範圍——那類已在
+    ready_units() 之前被 #208 sizing／#209 capable() 的 eligibility 閘擋掉）。
+    QueuedUnit 只是延後，下一輪 tick 重新評估，不寫入任何 terminal 狀態。
+    """
+```
+
+`dispatch_ready()`（`autonomy.py:447`）簽章本身 MUST NOT 改動——`filter_ready` 插在
+`ready_units()` 呼叫端與 `dispatch_ready()` 呼叫端之間，是 **manager tick 迴圈**
+（`manager_daemon.py`）裡的一個新步驟，不是這兩個既有函式內部的修改。
+
+**多帳號分流（issue §5「config 已有 haman/arc + claude/codex」）查證結果：main 現況
+不成立**——`model-identities.yaml` 全文只有一個身分，全 repo grep `paulc-arc`／
+`hamanpaul` 只命中 `mechanical_acceptance/`（policy 語言規範判準，與帳號池無關）。
+issue 原文這句描述在 main 上找不到對應設定，**本票不假設它存在**於本 repo；若「多帳號
+池」確實存在於某個外部 repo（如 `paulshaclaw`）的設定，那是那個 repo 的落地範圍，本票
+只記錄「池總吞吐＝各帳號速率之和」這個**概念**留給 D3 的 token bucket 天然支援（多個
+`(executor, model_id)` 各自一個桶，加總即池吞吐），不虛構任何本 repo 不存在的帳號池
+config 路徑。
+
+風險與緩解：若實作票把控速邏輯誤塞進 `capacity_gate.py`，會讓一個原本乾淨的
+「daemon 忙不忙」判準混入「resource quota/rate 夠不夠」的完全不同語意，兩者未來各自
+獨立演進會互相干擾——緩解：本節明文兩者是並行的兩把鎖而非同一把鎖的擴充，
+code review checklist 可要求「新的 rate/quota 邏輯是否誤入 `capacity_gate.py`」作為
+機械檢查點。
+
+### D5 429 回授：退避公式可重用，退避狀態不可重用——`manager_daemon.py`
+`_tick_backoff_seconds` 與本票的粒度不同
+
+查證 `manager_daemon.py:210` `_tick_backoff_seconds(base_interval, consecutive_failures)`
+（`TICK_BACKOFF_MAX_EXPONENT = 4`，退避公式 `base_interval * 2**min(exponent, 4)`，封頂
+16 倍）：這是 **daemon tick 迴圈自身**的退避——「這一輪 tick 處理失敗了，下一輪 tick
+延後多久再試」，狀態只有一份（整個 daemon 一個 `consecutive_tick_failures` 計數器）。
+
+本票要的是 **per-resource** 退避——「`(executor, model_id)` 這個 resource 剛吃了 429，
+它自己的 token bucket `capacity` 要收縮多久」，狀態需要一份 per `(executor, model_id)`。
+兩者**狀態粒度不同，不可直接重用同一個計數器或函式**，但**退避公式本身**（指數成長、
+封頂）值得重用同一個模式，避免發明第三種退避演算法。
+
+裁定：`rate_tracker.record_429()`（D3）SHALL 重用 `_tick_backoff_seconds` 的
+**公式結構**（指數成長＋封頂常數），但落地為 `rate_tracker.py` 內部獨立的
+per-resource 狀態，MUST NOT 呼叫或依賴 `manager_daemon._tick_backoff_seconds` 本身
+（那個函式簽章是 daemon-level 的，硬塞 resource 參數會污染其既有用途）。
+
+issue §7「重用 bot 既有 backoff」提及的 Telegram/bro 側 backoff **本票查無實據**——
+`bro` 不在本 repo（`docs/superpowers/workstreams/cost-governance-cluster/todo.md`
+未提及任何 bro repo 路徑，本 repo 亦無 `bro`／`telegram` 相關退避程式碼命中）。本票
+MUST NOT 杜撰其路徑或介面；後續實作票若要重用 bro 側 pattern，SHALL 先向 bro repo
+owner 確認介面存在，若查無則直接採用本節裁定的 `manager_daemon` 公式模式即可，不必
+空等一個未經證實的重用來源。
+
+風險與緩解：若實作票誤以為可以直接 import `manager_daemon._tick_backoff_seconds` 並塞入
+resource 參數，會破壞該函式現有的 daemon-level 純粹語意——緩解：本節明文「公式重用、
+狀態不重用」的精確界線。
+
+### D6 judge MVP 判斷式：四因子合取，interim stub 明確標注
+
+沿用 issue §3／cluster todo.md 已定案的 MVP 形態（`#209` spec 明文「不做成優化器」）：
+
+```
+judge(work, resource) =
+      rate_available(resource)                          -- D3，本票自己的 rate_tracker
+    ∧ quota_remaining(resource) > 0                      -- cost meter（外部，非本 repo）
+    ∧ capable(resource, work)                            -- #209 R1 六項合取（已落地設計）
+    ∧ track_record(resource, work.task_type) ≥ threshold -- #137 R4（已落地設計）
+```
+
+`judge` 選第一個滿足全部四項的 resource（deterministic 順序，比照 registry 既有迭代
+順序），不做評分排序——與 `#209` D1「不做加權評分」、cluster todo.md「已定案」第 5 條
+一致。
+
+**interim stub 契約（本票必須明寫，避免實作票誤判「四因子都要等對方落地才能開工」）**：
+四個因子目前的實際落地狀態各自獨立，`filter_ready`（D4）落地時 **不需要等四者全部
+code-landed**，可先用以下 stub 逐步替換，且每個 stub 都已有明確的「真值」替換點：
+
+| 因子 | interim stub | 真值替換點（設計已定案，等實作票） |
+|---|---|---|
+| `rate_available` | 恆真（D3 `rate_tracker.py` 尚未落地） | `rate_tracker.consume()` |
+| `quota_remaining` | 恆真（cost meter 尚未暴露 view 介面給本 repo） | 待未來票把 `paulshaclaw/cost/` 接進 D2 status view |
+| `capable` | 恆真（`claim_readiness.py:421-437` 現況正是這個 bypass：`capability_lookup is None` 時 `_passed(..., bypass="envelope_unavailable")`） | `#209` R1 的實作票落地 `capable()` 本體後 |
+| `track_record` | 恆真（`#137` `track_record.py` 尚未落地） | `#137` R4 的實作票落地 `track_record()` 本體後 |
+
+四項全恆真時，`judge` 恆選第一個 eligibility 通過的 resource——這與**現況**
+（`ready_units()` 之後無任何 admission/routing 過濾，直接 `dispatch_ready()`）行為
+等價，即 `filter_ready` 的落地本身即使在四個 stub 全恆真的狀態下也是**安全的
+no-op 疊加**，不會讓現有派工行為退化，這也是為何本票主張 D4 的介面骨架可以先落地、
+四個因子可以獨立分批替換為真值，不需要一次到位。
+
+風險與緩解：若實作票誤以為 stub 必須全部替換完才能上線 `filter_ready`，會不必要地
+把四張獨立的票（本票、`#137` 實作票、`#209` 實作票、cost meter 接線票）綁成一個大
+release——緩解：本節明文「stub 全恆真＝現況等價的安全 no-op」，讓 `filter_ready`
+骨架可以先落地，後續逐一替換 stub 而不影響既有派工行為。
+
+### D7 session 終止槓桿：只定觸發契約，串接 `#137` `session_health`
+
+沿用 `#137`（已落地設計）R2 的既有邊界：`session_health` 是**不透明 pass-through**
+欄位（`dict | None`），MUST NOT 併入 outcome/reward 計分，但**可以**用於歸因與早期
+預警——本票的 session 終止觸發正是「早期預警」的消費端之一。
+
+`terminate_session` 觸發契約（本票凍結，不寫實作）：
+
+```
+def should_terminate(signals: SessionSignals) -> TerminationDecision | None:
+    """任一觸發條件成立即回傳非 None 的終止決策；全不成立回 None（繼續跑）。"""
+```
+
+觸發來源（issue §6 五項，逐一標註 main 現況）：
+
+| 觸發來源 | main 現況查證 |
+|---|---|
+| context size 逼近上限 | issue 原文稱「precompact harvest hook 已部分處理」——**本票查無實據**：`grep -rn "precompact\|PreCompact"` 於 `paulsha_cortex/` 零命中；`harvest` 一詞在本 repo 現有語意是 `gate_ledger.py` 的**終局後**收割（`manager.py`／`launcher.py` 註解），與「context 逼近上限時**主動**觸發」的 precompact 語意不同。本票不杜撰該 hook 存在，標注為待確認 |
+| checkpoint | `manager_daemon.py`／`claim.py` 已有 phase 級 checkpoint（`cost-governance-cluster/todo.md`「關鍵事實」已載明），可作為終止後安全恢復點，非本票新建 |
+| **session-health 退化** | 串接 `#137` R2 的 `session_health` opaque dict；門檔數值 **`#137` R3 已明文不凍結**，留給消費端（即本票的實作票）依 `#210`（以自身 run 歷史校準）決定 |
+| stall／報酬遞減 | issue 引用 MAF Magentic `max_stall` 為類比，**本 repo 查無同義既有機制**（無 `stall`／`diminishing`／`max_turn` 相關治理程式碼），是本票範圍內唯一**全新**需要設計的訊號，本票不預先定義判準（留給實作票，屬「MVP 別做成優化器」同一精神：先有觸發框架，判準可迭代） |
+| per-task quota 上限 | 串接 D3 token bucket——`rate_tracker` 若擴充為 per-task（而非只 per-resource）計數，可直接供應此訊號；本票只記錄此依賴方向，不預先擴充 D3 的資料結構（D3 目前只定義 per-resource 桶） |
+
+`should_terminate` 的呼叫端（哪個 daemon 迴圈輪詢它、多久評估一次）本票 MUST NOT
+決定——這需要與 executor session 的既有生命週期掛勾點（`launcher.py` 的 wrapper
+執行迴圈）對齊，屬未來實作票的範圍，本票只凍結函式簽章與五個觸發來源的資料契約。
+
+風險與緩解：若實作票把「context size 逼近上限」的觸發誤植為已有 hook 可以直接調用，
+會在找不到 `precompact` hook 時卡住——緩解：本節明文標注「查無實據」，實作票應先確認
+該 hook 是否存在於外部 repo 或本身要新建，不得假設已存在。
+
+## 風險與緩解
+
+- **`filter_ready` 骨架先行，四因子 stub 逐一替換的時序風險**：若某個因子（例如
+  `#137` track_record）長期不落地，`judge` 會長期停在「三真一 stub」狀態——緩解：
+  D6 已明文 stub 全恆真＝現況等價安全 no-op，不會因任何單一因子延後而阻塞其餘部分
+  上線。
+- **`rate_tracker.py` 與 `#136` `capacity_gate.py` 邊界混淆**：兩者都是 admission 層
+  的「不擋、只排隊/詢問」閘，命名相似（都叫「容量／控速」）容易被誤合併——緩解：D4
+  已用架構圖與明文對照表區分兩者管的稀缺資源軸完全不同，code review checklist 可要求
+  「新的 rate/quota PR 有沒有誤動 `capacity_gate.py`」作為機械檢查點。
+- **429 退避粒度誤用**：`manager_daemon._tick_backoff_seconds` 與本票 per-resource
+  退避狀態粒度不同，若實作票圖方便直接 import 該函式並塞入 resource 參數，會污染既有
+  daemon-level 純粹語意——緩解：D5 明文「公式重用、狀態不重用」。
+- **`context_window`／`quota_window_kind`／`autonomy_safety_profile` 三個 issue 原文
+  提及但本票裁定不落地的欄位，未來若證實 MVP judge 真的需要**：緩解路徑已在 D1
+  明文——遵循 `#209` R3 先例 additive 擴充 `model-identities.yaml`，不重開檔案。
+- **stall／報酬遞減訊號是本票唯一全新概念、無既有先例可抄**：判準設計風險最高的一格
+  ——緩解：D7 明文本票不預先定義判準數值，只凍結觸發框架的存在，把判準留給實作票依
+  `#210`（run 歷史校準）決定，避免本設計票憑空發明一個未經實測驗證的門檻。
+- **「haman/arc + claude/codex 多帳號池」issue 原文描述與 main 現況不符**：若實作票
+  照抄 issue 字面去找一個不存在的 config，會卡住——緩解：D4 已明文查證結果（本 repo
+  不存在），並保留「池總吞吐＝各桶速率之和」的概念供未來若帳號池真的落地時直接套用
+  D3 的 token bucket 模型，不需要另外設計聚合邏輯。

--- a/docs/superpowers/specs/cost-governance-judge-design.md
+++ b/docs/superpowers/specs/cost-governance-judge-design.md
@@ -323,3 +323,8 @@ def should_terminate(signals: SessionSignals) -> TerminationDecision | None:
 本節訂正不改變本票任何 D/R 決策內容：interim stub 契約（D6／spec R4）本就已把
 `track_record` 列為恆真 stub，訂正只是把狀態描述從「已落地設計」精確化為「設計初稿、
 未合併」，前述 D2／D3／D4／D6／D7 各處提及 `#137` 之處已同步訂正引用文字。
+
+> **後記（merge 時點更新）**：本節查證反映的是撰寫當下的狀態。`#137` 設計文件其後已隨
+> PR #361 合併進 main（`docs/superpowers/specs/oneshot-lesson-loop-{spec,design}.md`），
+> 上述「尚未合併」的描述自 PR #361 起不再成立；查證鏈保留作為撰寫過程的如實記錄。
+

--- a/docs/superpowers/specs/cost-governance-judge-spec.md
+++ b/docs/superpowers/specs/cost-governance-judge-spec.md
@@ -1,0 +1,237 @@
+---
+status: accepted
+work_item: cost-governance-judge
+---
+
+# cost-governance-judge Specification
+
+#138：成本治理 judge——把 Stage 8「跨三家額度計量器（meter）」升級為
+「不擋、只 routing + 控速」的 governance 半邊。凍結 `rate` 自追資料契約、控速分流層
+介面契約、429 回授裁定、judge MVP 四因子判斷式、session 終止觸發契約。**本票是設計
+文件，不實作 `rate_tracker.py`、不實作控速分流層本體、不改 `autonomy.py`／
+`claim_readiness.py`／`manager_daemon.py` 任何一行程式碼。**
+
+## 背景
+
+issue 原文（2026-07-27 起，多則 comment 補充）主張 Stage 8 目前是「強觀測、弱治理」
+——`paulshaclaw/cost/`（~1,872 行）做到了跨 vendor quota 計量，但搜不到
+budget／limit／alert／throttle／enforce／policy，看得到額度、不做任何控制。本票定義
+如何在**不停工**（治理 = routing ＋ 控速，不是 block）的前提下補上治理半邊。
+
+`main` 現況（本票查證，非簡報時點，main @ `a2e8d0c`）：
+
+- 全 repo `grep -rn "token_bucket\|rate_limit"` 於 `paulsha_cortex/` **無治理相關實作
+  命中**——「rate 自追」是本票唯一自己負責、且完全空白的因子（cluster todo.md 四因子
+  分工表：rate token＝`#138`、quota＝cost meter、戰績＝`#137`、能力＝`#209`）。
+- `resource-inventory.yaml`（issue §8.2 指名檔案）**在 repo 中不存在**，且 `#209`
+  （已落地設計）D3／R3 已明文裁定 **不新建**此檔，四個能力封套靜態欄位 additive 掛在
+  `model-identities.yaml`（schema v2→v3）。本票 D1 沿用此裁定，MVP 不新增第二批靜態
+  欄位。
+- `capable()`（`#209`，已落地設計，尚未 code-landed）：`claim_readiness.py:18` 與
+  `:421-437` 明文標註 `#209 not yet landed`，`capability_probe()` 目前恆
+  `_passed("capability", bypass="envelope_unavailable")`——即這格闖關永遠通過。
+- `track_record()`（`#137`，已落地設計，尚未 code-landed）：全 repo `grep -rn
+  "track_record"` 於 `paulsha_cortex/` 零命中，`oneshot-lesson-loop-spec.md` R4 已
+  凍結函式簽章 `track_record(resource, task_type: str, scope: str | None = None) ->
+  float`，與 `#209` R1 第六項判準相容。
+- `#136`（已落地，code + design）：`paulsha_cortex/porcelain/capacity_gate.py`
+  `evaluate_gate()` 是 **PreToolUse hook 用的 daemon-idle 布林閘**，管的是互動 session
+  中手動 spawn subagent/headless 的破口，與本票要的「resource 級 quota/rate 是否有
+  餘裕」是不同稀缺資源軸的並行閘，非同一機制的擴充（見 design D4）。
+- `#139`（已落地設計）R7 已凍結 status view 四鍵契約（`quota`／`rate`／`health`／
+  `track_record`）；本票只交付 `rate` 這一格的資料契約，其餘三格分屬 cost meter／
+  `#139`／`#137`。
+- `manager_daemon.py:210` `_tick_backoff_seconds()` 是 **daemon tick 迴圈**自身的
+  退避（單一 `consecutive_tick_failures` 計數器），粒度上不是「每個 resource 各自的
+  請求速率退避」，公式模式可重用，狀態不可重用（見 design D5）。
+- `autonomy.py:394` `ready_units()` 與 `autonomy.py:447` `dispatch_ready()` 之間目前
+  **沒有任何** admission/routing 過濾層——`ready_units()` 判斷結構完整性後直接交給
+  `dispatch_ready()` fan-out，這正是本票 D4 要插入「控速分流層」的空隙，且此掛點選擇
+  與同批 `#137` design D4 的建議完全對齊（`#137` 已明文「棘輪不是 `autonomy.py` 內部
+  新函式，而是 `#209 capable()` 的一個因子，被 `#138` judge 呼叫」）。
+
+## Goals
+
+- 凍結 `rate` 自追（token bucket）資料契約，作為 `#139` R7 status view `rate` 鍵的
+  資料源。
+- 凍結控速分流層 `filter_ready()` 介面契約，明確掛點為 `autonomy.py` `ready_units()`
+  與 `dispatch_ready()` 之間的新過濾步驟，並與 `#136` 既有 `capacity_gate.py` 劃清
+  「不同稀缺資源軸」的邊界。
+- 凍結 429 回授裁定：退避公式重用 `manager_daemon._tick_backoff_seconds` 的指數封頂
+  模式，退避狀態不重用（per-resource 獨立）。
+- 凍結 judge MVP 四因子合取判斷式，並明定四因子在對應設計票（`#137`／`#209`）尚未
+  code-landed 期間的 interim stub 契約——stub 全恆真時行為與現況等價（安全 no-op）。
+- 凍結 session 終止觸發契約（`should_terminate`），串接 `#137` R2 的 `session_health`
+  opaque pass-through 邊界，五個觸發來源逐一標註 main 現況（含「查無實據」的誠實記錄）。
+- 明載非目標：不新增 `resource-inventory.yaml`／不新增 `model-identities.yaml` 第二批
+  靜態欄位、不實作任何程式碼、不改 `#136`／`#137`／`#209` 既有文字、不開
+  `openspec/changes/**`。
+
+## Requirements
+
+### R1 `rate` 自追資料契約凍結
+
+`rate` 狀態 SHALL 為鍵 `f"{executor}:{model_id}"`（複合鍵字串化，底層 `(executor,
+model_id)` 與 `#209` R2 一致）到 `RateSnapshot` 的映射，`RateSnapshot` 欄位：
+
+| 欄位 | 型別 | 語意 |
+|---|---|---|
+| `available` | `bool` | MVP judge（R4）唯一實際消費的欄位 |
+| `tokens_remaining` | `float \| None` | token bucket 餘量，reserved，`None`＝尚未觀測 |
+| `window_seconds` | `float \| None` | bucket 補充週期，reserved |
+| `last_429_at` | `str \| None`（ISO8601） | 供 R3 429 回授判讀 |
+
+`rate_tracker` 模組（實作票落點：新檔 `paulsha_cortex/coordinator/rate_tracker.py`）
+SHALL 提供純函式 `consume(executor: str, model_id: str) -> bool`（惰性補充後嘗試扣一
+token，回傳是否可送）與 `record_429(executor: str, model_id: str) -> None`（收縮
+`capacity`、記錄 `last_429_at`）。token bucket 內部狀態 MUST NOT 要求跨 daemon 重啟
+持久化（冷啟動重新學習是可接受降級，MUST NOT 比照 `registry.py` job record 等級的
+durable JSON persistence 設計）。
+
+`rate_tracker` MUST NOT 擴充 `model_identities.py`（靜態 registry）、
+`claim_readiness.py`（一次性交易）、或 `manager_daemon.py`（daemon-level 迴圈狀態）
+三者任一——三者的既有語意邊界理由見 design D3。
+
+### R2 控速分流層介面契約凍結，掛點為 `autonomy.py` 兩函式之間
+
+新函式契約（實作票落點：新模組，命名與檔案位置留給實作票，不預先綁定）：
+
+```python
+def filter_ready(
+    units: Sequence[ReadyUnit],
+    judge: Callable[[ReadyUnit], JudgeResult],
+) -> tuple[Sequence[ReadyUnit], Sequence[QueuedUnit]]:
+    ...
+```
+
+`filter_ready` SHALL 插在 `autonomy.ready_units()`（`autonomy.py:394`）呼叫端與
+`autonomy.dispatch_ready()`（`autonomy.py:447`）呼叫端之間，屬 manager tick 迴圈
+（`manager_daemon.py`）新增的一個步驟，MUST NOT 修改 `ready_units()` 或
+`dispatch_ready()` 既有簽章。`filter_ready` 只做「現在派 vs 先排隊」的二分，MUST NOT
+承擔 eligibility（該不該派）判斷——那已在 `ready_units()` 之前由 `#208` sizing／
+`#209` capable() 的 eligibility 閘處理完畢。`QueuedUnit` 只是延後到下一輪 tick 重新
+評估，MUST NOT 寫入任何 terminal 狀態（不得標記為 failed/needs_human）。
+
+`filter_ready` 與 `#136` `capacity_gate.evaluate_gate()` 是**並行的兩把閘**，
+MUST NOT 合併實作或互相呼叫——`capacity_gate` 判 daemon 忙不忙（單一布林），
+`filter_ready` 判各 resource 的 quota/rate 是否有餘裕（per-resource），兩者是 admission
+層（`#209` R4 表格）上不同稀缺資源軸的獨立判準。
+
+### R3 429 回授：公式重用，狀態不重用
+
+`rate_tracker.record_429()`（R1）SHALL 重用 `manager_daemon._tick_backoff_seconds()`
+（`manager_daemon.py:210`）的**指數成長＋封頂公式結構**（`base * 2**min(exponent,
+cap)`），MUST NOT 直接呼叫或依賴該函式本身、MUST NOT 與 daemon-level
+`consecutive_tick_failures` 共用同一個計數器——429 退避狀態 SHALL 為 per
+`(executor, model_id)` 獨立追蹤。
+
+Telegram/bro 側既有 backoff（issue §7 提及）本票 MUST NOT 假設其介面存在或杜撰其
+路徑——`bro` 不在本 repo，本票查無實據。後續實作票 SHALL 優先採用本節裁定的
+`manager_daemon` 公式模式；若要重用 bro 側 pattern，MUST 先向該 repo owner 確認介面
+存在，不得憑空假設。
+
+### R4 judge MVP 四因子判斷式凍結
+
+```
+judge(work, resource) =
+      rate_available(resource)                            -- R1，本票
+    ∧ quota_remaining(resource) > 0                        -- cost meter（外部）
+    ∧ capable(resource, work)                              -- #209 R1（六項合取）
+    ∧ track_record(resource, work.task_type) ≥ threshold   -- #137 R4
+```
+
+`judge` SHALL 選第一個四項皆真的 resource（deterministic 迭代順序），MUST NOT 做加權
+評分或優化排序（比照 `#209` D1、cluster todo.md「已定案」第 5 條）。
+
+**interim stub 契約（MUST 遵循）**：四因子中任一因子的對應設計票尚未 code-landed
+時，`filter_ready`（R2）的實作 SHALL 對該因子使用恆真 stub，且此狀態 MUST 視為與
+「`ready_units()` 之後無任何過濾、直接 `dispatch_ready()`」的現況行為等價（安全
+no-op）。四個 stub 的真值替換點：
+
+| 因子 | stub 替換為真值的前置條件 |
+|---|---|
+| `rate_available` | `rate_tracker.consume()` 落地（R1 實作票） |
+| `quota_remaining` | cost meter 接進 status view（`#139` R7，未來票） |
+| `capable` | `#209` R1 的 `capable()` 本體落地 |
+| `track_record` | `#137` R4 的 `track_record()` 本體落地 |
+
+`filter_ready` 骨架 MUST NOT 因任一因子的對應票延後而被阻擋上線——四者可獨立分批
+替換。
+
+### R5 session 終止觸發契約凍結
+
+```python
+def should_terminate(signals: SessionSignals) -> TerminationDecision | None:
+    ...
+```
+
+任一觸發條件成立即回傳非 `None` 的終止決策，全不成立回 `None`。觸發來源 SHALL 涵蓋
+以下五類，且 `session-health` 一項 MUST 遵循 `#137` R2 既有邊界（`session_health` 為
+`dict | None` opaque pass-through，MUST NOT 併入任何 reward/outcome 計分，只可用於
+早期預警／終止判斷）：
+
+1. context size 逼近上限（本票查無現成 hook，見背景段「precompact」查證）。
+2. checkpoint（重用既有 `manager_daemon.py`／`claim.py` phase 級 checkpoint 作為安全
+   恢復點）。
+3. session-health 退化（`#137` `session_health`，門檻數值 `#137` R3 已明文不凍結，
+   留給本票未來實作票依 `#210` 校準）。
+4. stall／報酬遞減（本 repo 無既有同義機制，本票不預先定義判準數值）。
+5. per-task quota 上限（依賴 R1 token bucket 若未來擴充為 per-task 計數；本票不預先
+   擴充 R1 的資料結構）。
+
+`should_terminate` 的呼叫端輪詢頻率與掛勾的 executor session 生命週期位置（例如
+`launcher.py` wrapper 執行迴圈）本票 MUST NOT 決定，留給未來實作票對齊既有生命週期
+掛勾點。
+
+### R6 靜態欄位裁定：MVP 不新增，未來如需新增遵循 `#209` R3 先例
+
+MVP judge（R4）不需要 `context_window`／`quota_window_kind`／`autonomy_safety_profile`
+三個 issue §3 原文提及的靜態欄位。若未來票證實需要，SHALL additive 擴充既有
+`model-identities.yaml`（`#209` R3 既定路徑），MUST NOT 新建
+`resource-inventory.yaml` 或任何第二個 inventory 檔案，MUST NOT 與 `#209` 既有四欄位
+（`accepts_bands`／`invariant_ceiling`／`consistency_scope`／`acceptance_modes`）撞名。
+
+### R7 `rate` 鍵回填 `#139` status view 契約，不另開查詢介面
+
+`rate_tracker` SHALL 提供 `rate_status(executor: str, model_id: str) ->
+RateSnapshot`，作為 `#139`（`design-task-type-taxonomy-v2-spec.md` R7）status view
+動態 JOIN 的 `rate` 鍵資料源，與 `quota`／`health`／`track_record` 三格並列被同一個
+JOIN 呼叫端讀取。`rate_tracker` MUST NOT 自建獨立 CLI 或另一條查詢路徑與其餘三格
+分裂。
+
+## 非目標
+
+- 不實作 `rate_tracker.py`、`filter_ready()`、`should_terminate()` 任一本體。
+- 不接線 cost meter（`paulshaclaw/cost/`）進 status view `quota` 鍵——那是待未來票對齊
+  `paulshaclaw` owner 的跨 repo工作，本票只記錄依賴方向。
+- 不實作 `#209` `capable()`、不實作 `#137` `track_record()`——本票只引用兩者已凍結的
+  函式簽章。
+- 不修改 `autonomy.py`／`claim_readiness.py`／`manager_daemon.py`／
+  `capacity_gate.py` 既有程式碼一行。
+- 不修改 `#136`／`#137`／`#209` 既有設計文件文字。
+- 不新增 `model-identities.yaml` 第二批靜態欄位（R6）、不新建
+  `resource-inventory.yaml`。
+- 不新增 `openspec/changes/**` 底下的 change 目錄——issue 原文明文「落地時再依
+  OpenSpec 流程開 change」。
+- 不定義 stall／報酬遞減、session-health 退化兩項終止觸發的具體數值門檻（R5 已明文
+  留給實作票）。
+- 不決定 `weight(work)`／`headroom(resource)` 是否為單一標量（cluster todo.md 未決
+  事項 #2 原樣保留）。
+
+## 驗收面
+
+- `cost-governance-judge-spec.md`／`cost-governance-judge-design.md` 皆含非空
+  frontmatter（`status`／`work_item`）與非空 Requirements／Decisions 段落，行數量級
+  比照 `oneshot-lesson-loop-{spec,design}.md`（195／158 行）與
+  `design-model-capability-envelope-{spec,design}.md`（256／227 行）。
+- R1 `RateSnapshot` 欄位與 `#209` R2 的 `(executor, model_id)` 複合鍵一致（可用
+  `grep -n "(executor, model_id)"` 於 `design-model-capability-envelope-spec.md`
+  與本文件互相核對）。
+- R4 的四因子判斷式逐項可追溯到對應已落地設計票的函式簽章（`capable()` 見
+  `design-model-capability-envelope-spec.md:98`；`track_record()` 見
+  `oneshot-lesson-loop-spec.md:150`）。
+- R2 的 `filter_ready` 掛點（`autonomy.py:394` 與 `:447` 之間）與 `#137`
+  `oneshot-lesson-loop-design.md` D4 的建議掛點描述一致（互相印證，非本票孤立主張）。
+- `docs/superpowers/workstreams/cost-governance-cluster/todo.md` 的 `#138` 列狀態
+  更新為「設計文件已交付」。
+- 全套 `pytest` 維持綠燈不倒退（本票不改 `.py`，屬留證性質而非風險緩解）。

--- a/docs/superpowers/specs/cost-governance-judge-spec.md
+++ b/docs/superpowers/specs/cost-governance-judge-spec.md
@@ -91,6 +91,10 @@ budget／limit／alert／throttle／enforce／policy，看得到額度、不做�
 本身——interim stub 契約（R4）本就已把 `track_record` 列為恆真 stub，訂正只是狀態
 描述用語精確化，不變更設計。
 
+> **後記（merge 時點更新）**：本節查證反映的是撰寫當下的狀態。`#137` 設計文件其後已隨
+> PR #361 合併進 main（`docs/superpowers/specs/oneshot-lesson-loop-{spec,design}.md`），
+> 上述「尚未合併」的描述自 PR #361 起不再成立；查證鏈保留作為撰寫過程的如實記錄。
+
 ## Goals
 
 - 凍結 `rate` 自追（token bucket）資料契約，作為 `#139` R7 status view `rate` 鍵的

--- a/docs/superpowers/specs/cost-governance-judge-spec.md
+++ b/docs/superpowers/specs/cost-governance-judge-spec.md
@@ -27,13 +27,19 @@ budget／limit／alert／throttle／enforce／policy，看得到額度、不做�
   （已落地設計）D3／R3 已明文裁定 **不新建**此檔，四個能力封套靜態欄位 additive 掛在
   `model-identities.yaml`（schema v2→v3）。本票 D1 沿用此裁定，MVP 不新增第二批靜態
   欄位。
-- `capable()`（`#209`，已落地設計，尚未 code-landed）：`claim_readiness.py:18` 與
-  `:421-437` 明文標註 `#209 not yet landed`，`capability_probe()` 目前恆
+- `capable()`（`#209`，已落地設計——`design-model-capability-envelope-{spec,design}.md`
+  於 main 存在，尚未 code-landed）：`claim_readiness.py:18` 與 `:421-437` 明文標註
+  `#209 not yet landed`，`capability_probe()` 目前恆
   `_passed("capability", bypass="envelope_unavailable")`——即這格闖關永遠通過。
-- `track_record()`（`#137`，已落地設計，尚未 code-landed）：全 repo `grep -rn
-  "track_record"` 於 `paulsha_cortex/` 零命中，`oneshot-lesson-loop-spec.md` R4 已
-  凍結函式簽章 `track_record(resource, task_type: str, scope: str | None = None) ->
-  float`，與 `#209` R1 第六項判準相容。
+- `track_record()`（`#137`，**設計初稿、尚未合併 main、尚未 code-landed**）：`git branch
+  -a` 顯示 `oneshot-lesson-loop-{spec,design}.md` 只存在於未合併的 sibling 分支
+  `feature/137-oneshot-lesson-loop-design`（`git merge-base --is-ancestor` 對 `main`
+  回傳 false；`git ls-remote --heads origin` 亦無此分支），main 上 `git ls-tree -r main
+  --name-only | grep oneshot` 零命中——**不可與 `#209`／`#139` 的「已落地設計」等同視之**。
+  函式簽章 `track_record(resource, task_type: str, scope: str | None = None) -> float`
+  引自該分支草稿 R4（與 `#209` R1 第六項判準相容），本票只引用其簽章作為介面對齊依據，
+  不代表該設計已定案落地；下文所有「`#137` 已落地設計」字樣統一訂正為此處的準確狀態，
+  詳見「與 #137 狀態的訂正說明」段落。
 - `#136`（已落地，code + design）：`paulsha_cortex/porcelain/capacity_gate.py`
   `evaluate_gate()` 是 **PreToolUse hook 用的 daemon-idle 布林閘**，管的是互動 session
   中手動 spawn subagent/headless 的破口，與本票要的「resource 級 quota/rate 是否有
@@ -47,8 +53,43 @@ budget／limit／alert／throttle／enforce／policy，看得到額度、不做�
 - `autonomy.py:394` `ready_units()` 與 `autonomy.py:447` `dispatch_ready()` 之間目前
   **沒有任何** admission/routing 過濾層——`ready_units()` 判斷結構完整性後直接交給
   `dispatch_ready()` fan-out，這正是本票 D4 要插入「控速分流層」的空隙，且此掛點選擇
-  與同批 `#137` design D4 的建議完全對齊（`#137` 已明文「棘輪不是 `autonomy.py` 內部
-  新函式，而是 `#209 capable()` 的一個因子，被 `#138` judge 呼叫」）。
+  與同批 `#137` design 草稿（未合併分支）D4 的建議掛點一致（該草稿主張「棘輪不是
+  `autonomy.py` 內部新函式，而是 `#209 capable()` 的一個因子，被 `#138` judge
+  呼叫」）——僅作為介面對齊參考，不代表該草稿已定案或已合併。
+- `#324`（已落地，main，「combo 可擴充與可選」）與本票**無資料或函式介面耦合**：
+  `#324` 落地的是 `deck/schema.py` 的 combo 搜尋路徑（instance-local override）與
+  `small-fix` 輕量 combo，屬 workflow/card 派工骨架層；`#324` issue 原文「非目標」
+  段落自行畫出邊界——「勝率／outcome scoring → `#137`；cost-aware routing →
+  `#138`」，即 `#324` 明文把本票的範圍排除在外。本票在此記錄查證結果：兩者是
+  **不相交**的責任邊界（combo 選牌 vs. resource 級 cost-aware routing），非「有
+  介面待對齊」關係，不需要本票額外定義接線點。
+
+## 與 `#137` 狀態的訂正說明
+
+本文件初版曾多處把 `#137`（one-shot 成效閉環／track-record）標注為「已落地設計」，
+與 `#209`（`design-model-capability-envelope-{spec,design}.md`）、`#139`
+（`design-task-type-taxonomy-v2-{spec,design}.md`）並列——**此標注不成立，已訂正**。
+複驗查證（`main @ a2e8d0c`）：
+
+- `git ls-tree -r main --name-only | grep -i oneshot`：零命中，main 上不存在任何
+  `#137` 的設計文件。
+- `#137` 的 `oneshot-lesson-loop-{spec,design}.md` 只存在於本 repo 本機的 sibling
+  分支 `feature/137-oneshot-lesson-loop-design`（`git merge-base --is-ancestor
+  feature/137-oneshot-lesson-loop-design main` 回傳 false）；`git ls-remote --heads
+  origin` 亦無此分支，未推送到遠端，更未合併。
+- `docs/superpowers/workstreams/cost-governance-cluster/todo.md` 自身的叢集 A 表格
+  （本檔緊鄰列）把 `#137` 標為 **`open`**，與「已落地設計」矛盾。
+- `#209` 自己的 `design-model-capability-envelope-spec.md:98` 在 R1 第 6 項判準把
+  `#137` 標注為「`#137`（**尚未落地**；`grep -rn "track_record" paulsha_cortex`
+  零命中，本票只引用函式簽章，不假設其內部實作）」——`#209` 才是對 `#137` 狀態的
+  準確表述，本文件應與其一致而非自相矛盾。
+
+**修正後的準確表述**：`#137` 的設計是**未合併的本機分支草稿**，非「已落地設計」。
+本文件下游所有引用 `#137` 函式簽章／掛點建議之處，語意皆改為「引用該草稿內容作為
+介面對齊參考，不代表其已定案、已合併或已落地」；`#137` 本體（設計與程式碼）皆待該
+分支正式開 PR 並合併 main 後才算落地。這不影響本票（`#138`）的任何 D/R 決策內容
+本身——interim stub 契約（R4）本就已把 `track_record` 列為恆真 stub，訂正只是狀態
+描述用語精確化，不變更設計。
 
 ## Goals
 
@@ -91,6 +132,18 @@ durable JSON persistence 設計）。
 `rate_tracker` MUST NOT 擴充 `model_identities.py`（靜態 registry）、
 `claim_readiness.py`（一次性交易）、或 `manager_daemon.py`（daemon-level 迴圈狀態）
 三者任一——三者的既有語意邊界理由見 design D3。
+
+**與 `#325`（已落地，main @ PR `#356`）的介面關係**：`#325`
+（「job record 收斂 token usage」）已在 `registry.py` 落地 job 級的 `usage`／
+`usage_raw` 欄位（`input_tokens`／`output_tokens`／`cached_input_tokens`／
+`reasoning_output_tokens`，per-executor adapter 抽取），是**歷史、per-job、事後**
+的用量歸屬記錄，供 `cortex jobs`/`stat` 輸出消費。`rate_tracker`（本節）是
+**即時、per-resource、事前**的請求速率閘門（token bucket 的 `available` 布林），
+兩者資料形狀與更新時機都不同，不是同一份資料的兩種投影——`rate_tracker` MUST NOT
+直接消費 `usage`/`usage_raw` 作為即時判斷依據（`#325` 的 issue 本文「非目標」段落
+自身也明文排除「不做預算、擋工、控速、告警 → #138」，確認兩者是互補而非重疊的
+分工）。若未來要用 `#325` 累積的歷史 usage 校準 `rate_tracker` 的 `capacity`
+初始值或做離線分析，屬後續實作票範圍，本票只記錄此依賴方向、不預先設計。
 
 ### R2 控速分流層介面契約凍結，掛點為 `autonomy.py` 兩函式之間
 
@@ -204,8 +257,9 @@ JOIN 呼叫端讀取。`rate_tracker` MUST NOT 自建獨立 CLI 或另一條查�
 - 不實作 `rate_tracker.py`、`filter_ready()`、`should_terminate()` 任一本體。
 - 不接線 cost meter（`paulshaclaw/cost/`）進 status view `quota` 鍵——那是待未來票對齊
   `paulshaclaw` owner 的跨 repo工作，本票只記錄依賴方向。
-- 不實作 `#209` `capable()`、不實作 `#137` `track_record()`——本票只引用兩者已凍結的
-  函式簽章。
+- 不實作 `#209` `capable()`、不實作 `#137` `track_record()`——本票只引用 `#209`
+  已凍結（main 落地）的函式簽章，以及 `#137` 未合併草稿分支提出、尚未定案的函式簽章
+  （見「與 `#137` 狀態的訂正說明」）。
 - 不修改 `autonomy.py`／`claim_readiness.py`／`manager_daemon.py`／
   `capacity_gate.py` 既有程式碼一行。
 - 不修改 `#136`／`#137`／`#209` 既有設計文件文字。
@@ -222,16 +276,20 @@ JOIN 呼叫端讀取。`rate_tracker` MUST NOT 自建獨立 CLI 或另一條查�
 
 - `cost-governance-judge-spec.md`／`cost-governance-judge-design.md` 皆含非空
   frontmatter（`status`／`work_item`）與非空 Requirements／Decisions 段落，行數量級
-  比照 `oneshot-lesson-loop-{spec,design}.md`（195／158 行）與
-  `design-model-capability-envelope-{spec,design}.md`（256／227 行）。
+  比照 `design-model-capability-envelope-{spec,design}.md`（256／227 行，main 已落地
+  可直接核對）；`oneshot-lesson-loop-{spec,design}.md`（195／158 行）僅存在於 `#137`
+  未合併的 `feature/137-oneshot-lesson-loop-design` 分支，**於 main checkout 上核對
+  此條會找不到檔案**——複驗者須先 `git fetch`／切到該分支才能核對，或視為暫不可驗證。
 - R1 `RateSnapshot` 欄位與 `#209` R2 的 `(executor, model_id)` 複合鍵一致（可用
   `grep -n "(executor, model_id)"` 於 `design-model-capability-envelope-spec.md`
-  與本文件互相核對）。
-- R4 的四因子判斷式逐項可追溯到對應已落地設計票的函式簽章（`capable()` 見
-  `design-model-capability-envelope-spec.md:98`；`track_record()` 見
-  `oneshot-lesson-loop-spec.md:150`）。
+  與本文件互相核對，兩者皆在 main，可直接驗證）。
+- R4 的四因子判斷式：`capable()` 簽章可在 main 核對，見
+  `design-model-capability-envelope-spec.md:98`；`track_record()` 簽章僅能在
+  `#137` 未合併分支的 `oneshot-lesson-loop-spec.md:150` 核對，main 上暫不可驗證
+  （見「與 `#137` 狀態的訂正說明」）。
 - R2 的 `filter_ready` 掛點（`autonomy.py:394` 與 `:447` 之間）與 `#137`
-  `oneshot-lesson-loop-design.md` D4 的建議掛點描述一致（互相印證，非本票孤立主張）。
+  未合併草稿 `oneshot-lesson-loop-design.md` D4 的建議掛點描述一致（互相印證，非本票
+  孤立主張；但該草稿本身尚未合併 main，此條驗證同樣需先取得該分支）。
 - `docs/superpowers/workstreams/cost-governance-cluster/todo.md` 的 `#138` 列狀態
   更新為「設計文件已交付」。
 - 全套 `pytest` 維持綠燈不倒退（本票不改 `.py`，屬留證性質而非風險緩解）。

--- a/docs/superpowers/workstreams/cost-governance-cluster/todo.md
+++ b/docs/superpowers/workstreams/cost-governance-cluster/todo.md
@@ -38,7 +38,7 @@ TOCTOU 縫、StageExecutionKey 派工端消費、reviewer attestation 強度升�
 | Issue | 標題要旨 | 狀態 |
 |---|---|---|
 | `#139` | 共用基礎設施：task_type / log reader / 歸屬 / status view / ledger / session-health | **硬 blocker**；已定案為 taxonomy 所有者 |
-| `#138` | 成本治理：meter → governance，cost-aware dispatch + 控速分流（judge 公式） | open |
+| `#138` | 成本治理：meter → governance，cost-aware dispatch + 控速分流（judge 公式） | 設計文件已交付（`docs/superpowers/specs/cost-governance-judge-{spec,design}.md`），拆分後續實作票清單見 `docs/superpowers/plans/cost-governance-judge.md`；待 `#137`/`#209` 本體 code-landed 後可依序替換 interim stub |
 | `#137` | one-shot 成效閉環：lesson-loop + 棘輪計分（track-record） | open |
 | `#136` | PreToolUse 容量閘門 hook（admission control） | open；「擋 vs 不擋」裁決已貼 |
 | `#202` | feat(deck)：以 task_type 自動選擇 combo | open；已改為 additive with fallback，不再被 combo 缺口阻擋 |


### PR DESCRIPTION
## 摘要

docs(cost-governance): 交付成本治理 judge 設計文件（#138）

Closes #138

## 交付內容

已交付 issue #138（成本治理 judge：cost-aware dispatch + 控速分流，不擋）的設計文件。新增 docs/superpowers/specs/cost-governance-judge-{spec,design}.md（D1-D7 決策/需求，仿 design-model-capability-envelope 與 oneshot-lesson-loop 模板格式）與 docs/superpowers/plans/cost-governance-judge.md（8 張後續實作子票拆分清單），更新 docs/superpowers/workstreams/cost-governance-cluster/todo.md 的 #138 狀態列。設計內容：(1) 靜態 resource-inventory——裁定 MVP 不新增欄位，沿用已落地的 #209 R3 路徑；(2) 動態 status view——只交付 rate 這一格的資料契約（RateSnapshot：available/tokens_remaining/window_seconds/last_429_at），對接 #139 R7 已凍結的四鍵 JOIN 契約；(3) rate 自追——新模組 rate_tracker.py（token bucket，鍵 (executor, model_id)），明確不擴充 model_identities.py/claim_readiness.py/manager_daemon.py；(4) 控速分流層——filter_ready() 介面，掛在 autonomy.ready_units() 與 dispatch_ready() 之間，與已落地的 #136 capacity_gate.py（daemon-idle 布林閘）劃清「並行兩把閘、不同稀缺資源軸」的邊界；(5) 429 回授——重用 manager_daemon._tick_backoff_seconds() 的指數封頂公式，不重用其 daemon-level 狀態；(6) judge MVP 四因子合取判斷式（rate_available × quota_remaining × capable() × track_record()）與四個 interim stub 契約，stub 全恆真時與現況行為等價（安全 no-op），四者可獨立分批替換為真值，明確不需要等 #137/#209 本體全部 code-landed 才能上線骨架；(7) session 終止——串接 #137 已落地設計的 session_health opaque pass-through 邊界，凍結 should_terminate() 五類觸發契約，並誠實標注「precompact harvest hook 查無實據」「stall/報酬遞減本 repo 無既有機制」。與 #137（同批鄰接 worktree、尚未 merge，已讀取其 D4 掛點建議並採納對齊）、#209（已落地）、#325 usage schema（已落地）、#324 combo（已落地）的介面關係均已在文件中標明。git diff 僅涉及 docs/**、changelog.d/**、CHANGELOG.md 六個檔案，共 646 行新增/1 行刪除，未動任何 .py 檔。python3 -m pytest -q 全綠 2042 passed + 32 subtests（33.22s），與基線一致。worktree 已 commit，git status 乾淨。

## 與偵察簡報／規劃的落差（如實記錄）

簡報寫於 main@9bda3c0，現以 main@a2e8d0c 重新核對後，多處引用改用現況：(1) D1 靜態 inventory 欄位——簡報 plan 原要求定義四個新靜態欄位 schema，但查證 main 上 #209 已落地設計並明文裁定「不新建 resource-inventory.yaml，additive 掛在 model-identities.yaml」，本票因此改為：MVP judge 不需要新靜態欄位（context_window/quota_window_kind/autonomy_safety_profile 三者裁定不落地，reserved 給未來票），只沿用 #209 R3 既定路徑。(2) D4 控速分流層——簡報未提及 #136 已落地，本票查證 main 上 #136（capacity_gate.py）已是完整落地的 code+design，因此新增專節明文區分「#136 是 daemon-idle 布林閘，#138 控速分流是 per-resource quota/rate 閘，兩者並行不合併」，避免與簡報寫作時尚不存在的 #136 混淆。(3) 掛點選擇——直接採納同批 #137 design D4 已建議的 autonomy.ready_units()/dispatch_ready() 之間掛點（#137 設計文件已在鄰接 worktree 完成，尚未 merge，本票依指示對齊其介面並標明「#137 設計（隨 PR 合併中）」）。(4) D5 429 回授——查證 manager_daemon.py 的 _tick_backoff_seconds 是 daemon tick 迴圈層級退避，非 per-resource，裁定只重用公式模式、不重用狀態/函式本身；issue 提及的 bro/Telegram 側 backoff 查無實據（bro 不在本 repo），未杜撰路徑。(5) D7 session 終止——issue 稱「precompact harvest hook 已部分處理」，查證 main 上無 precompact 相關程式碼命中，本票明文標注「查無實據」而非照抄。(6) issue §5「多帳號池（haman/arc）」在本 repo config 查無對應設定，本票明文記錄查證結果，不假設其存在。以上皆已寫入設計文件的對應 D 節與『風險與緩解』段落。plans/cost-governance-judge.md 未採用 design-task-type-taxonomy-v2 那種 TDD RED 執行計畫格式（因該票除設計外還落地了輕量契約骨架 code），本票純交付設計文件，故改寫成比照 #208→#211-#223 拆分模式的『後續實作票清單』，與 brief notes 的建議一致。

## 獨立複驗

- 判定：**pass**（複驗 agent 實跑 pytest：2042 passed / 0 failed；基線 main 2042 + 32 subtests，docs-only 無變化）。
- 首輪複驗抓到 2 個問題（含引用行號誤差／自報與交付不符），已逐項修復並經第二輪複驗通過；細節見 commit 歷史。

## 驗證

- [x] `python3 -m pytest -q` 全綠（2042 passed + 32 subtests）
- [x] diff 僅涉 docs/**、openspec/**、changelog.d/**、CHANGELOG.md（複驗確認未動任何產線 .py/.yaml）
- [x] 文件引用之檔案:行號經獨立抽查屬實
- [x] changelog fragment（R-09）＋ `CHANGELOG.md [Unreleased]` entry
- [x] 本地 policy_check 帶 PR 上下文 → fail: 0
- [x] R-21 掃描：無個人絕對路徑／憑證

## 稽核註記

本票由 sonnet subagent 撰寫設計文件、獨立 sonnet subagent 複驗（引用行號逐一對 main 抽查、設計問題完整性、diff 範圍、自報與交付一致性），PR 由主 session 統一開啟與合併。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T8j64kn6wKmL4WQA7wJL19

## 豁免說明

- **policy-exempt:issue-link（R-17）**：本 PR body 如實記錄交付與複驗過程，需引用相關 issue/PR（#136, #137, #139, #208, #209, #211, #223, #324, #325）作為上下文，僅 closing 目標為本票。