### PR TITLE
docs(openspec): 跨 repo ad-hoc 一次性派工設計文件 (#279)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@
 
 ## [Unreleased]
 ### Added
+- **Issue #279：跨 repo ad-hoc 一次性派工——設計文件（design-doc）**：新增
+  `openspec/changes/2026-08-07-design-adhoc-oneshot-dispatch/`（proposal／
+  design／tasks／`specs/trusted-dispatch-completion/spec.md`）與
+  `docs/superpowers/specs/adhoc-oneshot-dispatch-{design,spec}.md`，定案
+  D1-D6：`cortex run once` 繞過 control queue、直接組裝既有
+  `JobRegistry`/`Dispatcher`/`manager.run_tick()` 於呼叫行程內完成派工，
+  job 狀態落 ephemeral tmp 路徑與宿主 `~/.agents` 物理隔離（不擴充
+  `PSC_INSTANCE`/`_installed_environment()` 機制）；repo-root 沿用既有
+  `_infer_repo_root()`，worktree／branch 建立行為不變，「呼叫方既有
+  branch/worktree 內工作」明確列為 v1 非目標；combo 重用 #324 的
+  `small-fix`，不新增更輕量 combo（`validate_manager_spine()` 七 phase
+  涵蓋為不可放寬的治理憲法）；builder identity 臨時放行透過既有
+  `load_model_identities()` 的 packaged+instance-local 合併機制，不改
+  registry 驗證邏輯。另發現 `depends_on` 列的 #338（persona catalog gate
+  對外部 repo 派工必炸）症狀已由 #341（commit `0264f3f`，早於本票查證
+  基準 main）解掉，判定其現況為「症狀已消失、issue 未關閉」。本票不動
+  任何 `paulsha_cortex/` 程式檔；code 落地拆為四張候選後續票（見
+  `tasks.md` 文末拆票建議）。
 - **Issue #340：builder persona 契約新增 `completion_obligations`（結束前必須 commit）**：`PersonaContract` 新增 `completion_obligations` 欄位（fail-closed schema 檢查），`personas.yaml` 的 `builder` 角色新增義務宣告「完成前必須 git add＋git commit，worktree 不乾淨不得回報完成」，由 `render_contract_prompt` 注入實際派工的 dispatch prompt，補上既有 `commit_policy: required`（只管寫入權限）與 manager 端事後 dirty-worktree 安全網之間「事前宣告義務」的缺口；空清單角色不受影響。
 ### Fixed
 - **Issue #339：run tick 對已有 needs_human 終局紀錄的 slice 不再重複 fanout**：`run_tick` 原本的冪等防護只排除 registry 中仍在 `dispatched`/`running` 的 job，job 一旦 poll 到 exited 就離開這個集合，不論其 `gate_status` 是 `needs_human`／`failed`／`passed`；`ready_units`/`default_is_satisfied` 只檢查「別人 depends_on 我」是否滿足，從未檢查「我自己是否已經跑過」，導致下一趟 tick 對已完成待人工的 slice 重新 fanout，撞 `ScriptWorktreeCreator.create` 的 `"worktree target already exists"`。現在派工前會掃描每個 slice 是否已有 handoff 終局紀錄，併入排除集合；此掃描不受 idle gate 影響，`require_idle` 擋下新工作時 `needs_human` 清單仍會回報。summary 新增 `needs_human: [{slice_id, gate_reason, handoff_path}, ...]` 欄位。

--- a/changelog.d/adhoc-oneshot-dispatch-design.md
+++ b/changelog.d/adhoc-oneshot-dispatch-design.md
@@ -1,0 +1,19 @@
+### Added
+- **Issue #279：跨 repo ad-hoc 一次性派工——設計文件（design-doc）**：新增
+  `openspec/changes/2026-08-07-design-adhoc-oneshot-dispatch/`（proposal／
+  design／tasks／`specs/trusted-dispatch-completion/spec.md`）與
+  `docs/superpowers/specs/adhoc-oneshot-dispatch-{design,spec}.md`，定案
+  D1-D6：`cortex run once` 繞過 control queue、直接組裝既有
+  `JobRegistry`/`Dispatcher`/`manager.run_tick()` 於呼叫行程內完成派工，
+  job 狀態落 ephemeral tmp 路徑與宿主 `~/.agents` 物理隔離（不擴充
+  `PSC_INSTANCE`/`_installed_environment()` 機制）；repo-root 沿用既有
+  `_infer_repo_root()`，worktree／branch 建立行為不變，「呼叫方既有
+  branch/worktree 內工作」明確列為 v1 非目標；combo 重用 #324 的
+  `small-fix`，不新增更輕量 combo（`validate_manager_spine()` 七 phase
+  涵蓋為不可放寬的治理憲法）；builder identity 臨時放行透過既有
+  `load_model_identities()` 的 packaged+instance-local 合併機制，不改
+  registry 驗證邏輯。另發現 `depends_on` 列的 #338（persona catalog gate
+  對外部 repo 派工必炸）症狀已由 #341（commit `0264f3f`，早於本票查證
+  基準 main）解掉，判定其現況為「症狀已消失、issue 未關閉」。本票不動
+  任何 `paulsha_cortex/` 程式檔；code 落地拆為四張候選後續票（見
+  `tasks.md` 文末拆票建議）。

--- a/docs/superpowers/specs/adhoc-oneshot-dispatch-design.md
+++ b/docs/superpowers/specs/adhoc-oneshot-dispatch-design.md
@@ -1,0 +1,341 @@
+---
+status: draft
+work_item: design-adhoc-oneshot-dispatch
+---
+
+# adhoc-oneshot-dispatch Design
+
+issue #279：想在不 `cortex install service` 的前提下，對任意 repo 派幾個
+一次性小工（例如「幫我在另一個 repo 寫 10 個 case 檔」），且不進入
+work-item lifecycle（不建 GitHub issue、不走 combo 全套 claim/ship）。本文
+定案該入口（暫名 `cortex run once`）的架構決策，作為後續拆碼票的單一依據。
+
+## 背景與現況查證（main @ a2e8d0c）
+
+issue 原文列出四個結構性阻礙；2026-08-01 官方 comment 逐項核對後標記
+「阻礙 2 前半已由 #288 解掉」。本文以 main @ a2e8d0c 重新核對全部四項，
+結論如下（詳細檔案:行號見各 Decision 段）：
+
+| # | 阻礙 | 官方 comment 判定 | 本次重新核查 |
+|---|---|---|---|
+| 1 | manager 綁單一 repo | 仍在 | **性質更根本**：不是「缺一個 CLI flag」，而是 `fanout`/`tick`/`work` 三個入口结构性依賴常駐 daemon 消費 control queue（見 D1） |
+| 2 | job 狀態疑似共用宿主 runtime | 前半已解、後半仍在 | 一致；後半（job 狀態隔離）就是 D1 要解的問題 |
+| 3 | deck combo 生命週期綁定 | 仍在 | **部分已解**：#324 落地 `small-fix` combo + instance-local override，但仍不足以滿足「單一 prompt-file 免 planning 文件」（見 D3） |
+| 4 | builder identity 門檻 | 仍在 | 一致；但發現可重用既有 instance-local identity override 機制（見 D5） |
+
+另外，`depends_on` 列的 #338（persona catalog gate 對外部 repo 派工必炸）
+经查已被 #341（commit `0264f3f`）解掉，且早於本次查證基準
+（見 D4）——這是官方 comment 未涵蓋的新發現。
+
+## Decisions
+
+### D1 runtime 隔離：繞過 control queue，直接組裝既有純函式，不擴充 instance 安裝機制
+
+**現況**：`coordinator/cli.py` 的 `fanout`（144 行起）／`tick`（226 行起）／
+`work`（191 行起）三個子指令全部經 `_submit_mutation_request()`
+（`cli.py:578-609`）運作：
+
+```python
+status = read_status_fn()
+if isinstance(status, dict) and status.get("degraded"):
+    reason = status.get("degraded_reason") or "unknown"
+    print(f"錯誤: manager daemon 未就緒（{reason}）；無法處理 {req_type}，請先啟動 daemon。")
+    return 1
+req_id = submit_request_fn(req_type, dict(args), DEFAULT_REQUESTED_BY)
+done = poll_done_fn(req_id, timeout_seconds, DEFAULT_REQUEST_POLL_INTERVAL_SECONDS)
+```
+
+`submit_request_fn`/`poll_done_fn` 預設走 `paulsha_cortex.control.client`，
+把 request 寫進 control queue 檔案，靠一個**已經在跑**的 manager daemon
+輪詢消費、寫回 done 檔。這代表：即使把所有 `PSC_*` root 都疊加成 ephemeral
+路徑，只要沒有行程在讀那個 ephemeral control queue，`submit_request_fn`
+送出的 request 永遠不會被消費，`poll_done_fn` 必然 timeout——這才是「必須
+先 `cortex install service --instance`」的真正根因，比官方 comment 描述的
+「job 狀態落在共用 runtime」更底層：不只是「寫錯地方」，而是「沒有讀者」。
+
+**決策**：`run once` 不透過 control queue，也不嘗試讓
+`resolve_runtime_root()`／`_installed_environment()`
+（`config/runtime.py:53-70`，讀 `~/.agents/core/runtime/<instance>-manager.env`
+bootstrap 檔）認得一個「immediate、免安裝」的合成 instance。改為直接在
+呼叫 `run once` 的同一行程內，組裝三個既有元件：
+
+1. `JobRegistry(state_path=<ephemeral tmp path>)`
+   （`coordinator/registry.py:217`）——建構子本就接受任意 `state_path`，
+   与 `PSC_COORDINATOR_ROOT`／`resolve_runtime_root()` 完全無耦合，測試
+   套件本來就是這樣用它的。
+2. `Dispatcher(registry, pane_sender, worktree_creator, git_runner)`
+   （`coordinator/dispatcher.py:96-107`）——三個依賴皆經建構子注入，
+   `run once` 傳入真正會動作的 `TmuxPaneSender`/`SubprocessLauncher`
+   組合（沿用 `coordinator/cli.py:_resolve_launcher()` 現行的
+   executor→launcher 映射，不新增第二套）與
+   `ScriptWorktreeCreator`（不需要新實作）。
+3. `manager.run_tick(dispatcher, metas=..., ...)`
+   （`coordinator/manager.py:1951`）——純函式：吃 `dispatcher` 與
+   `metas`（spec 解析後的 dict list）與一串 optional 注入點
+   （`handoff_dir`／`review_executor`／`identity_registry`／`reaper` 等），
+   跑完整 fanout→complete_tick→（可選）janitor 一輪，回傳
+   `{dispatch_skipped, dispatched, completed, errors, reaped, needs_human,
+   ...}`。**沒有任何全域 root 讀取**——所有狀態落點都經參數傳入。
+
+`run once` 的實作只需要一個新的**輪詢外殼**：反覆呼叫
+`run_tick()`（沿用 `manager_daemon.py:862` 起 `build_periodic_tick_runner`
+既有的 backoff 節奏思路，但不需要真的常駐——單一 slice 跑到終局
+`passed`/`needs_human`/`failed` 或 `--timeout` 就返回），不需要
+`build_request_executor`（`manager_daemon.py:445`）那層 control-queue
+adapter，也不需要 `run_loop`（`manager_daemon.py:1027`）那層 daemon
+主迴圈（含 signal handler、lock file、systemd 整合，這些都是「常駐服務」
+才需要的東西，一次性呼叫不需要）。
+
+ephemeral state（`JobRegistry` 的 `state_path`）落在系統 tmp 目錄（例如
+`tempfile.mkdtemp(prefix="cortex-run-once-")`），**不落在任何
+`PSC_AGENTS_ROOT` 之下**，與宿主 `~/.agents` 樹完全物理隔離——不是「疊加
+一層 namespace」，而是「壓根不共用同一棵目錄樹」。跑完依 `--keep-state`
+決定是否保留 state 目錄供除錯；worktree／git branch 一律保留供人工檢視
+（不是 state，是 git 側可觀察的產物，清掉反而破壞「可稽核」的訴求）。
+
+**為什麼不做**：擴充 `PSC_INSTANCE`／`_installed_environment()` 支援一種
+「免安裝、自動產生的 ephemeral instance」——考慮過但拒絕，理由：
+
+- `_installed_environment()` 的角色是讀「已經 `cortex install service`
+  裝過的」bootstrap env，語意就是「這是一個持久、已註冊的 instance」；
+  硬塞一個「免安裝」分支進去，會讓這個函式承擔兩種互斥語意（持久 vs
+  一次性），未來任何讀這個函式的程式碼都要多想一種分支，維護成本擴散到
+  一個本來單純的函式。
+- 直接組裝三個元件（`JobRegistry`／`Dispatcher`／`run_tick`）完全不需要
+  碰 `config/runtime.py`——`conflict_files` 原本列的這個檔案，在本設計下
+  **不需要修改**，衝突面比簡報預期小。
+
+### D2 repo-root／worktree 邊界：沿用既有解析機制，worktree／branch 建立維持不變，「in-place 派工」列為 v1 非目標
+
+**現況**：目標 repo 由 `PSC_REPO_ROOT`（`config/paths.py:89-90`，
+`_resolve_root("PSC_REPO_ROOT", Path.cwd())`，未設時退回 cwd）指定；
+`_infer_repo_root(spec_path)`（`coordinator/autonomy.py:217-235`，#288
+已修正）在 spec 不在 configured root 內時，沿路徑向上找 `.git` 推導
+spec 自身所屬 repo（排除 `~/.agents` 本身）。`run once` 沿用這條路徑：
+呼叫時把 `PSC_REPO_ROOT` 設成 `--repo-root` 指定的目標 repo，spec 檔寫在
+目標 repo 內某個 scratch specs-dir，`_infer_repo_root` 自然解析正確。
+
+**決策**：`Dispatcher.dispatch()` 的 worktree／branch 建立行為**不變**——
+一律呼叫 `worktree_creator.create(branch, base_sha=...)` 新建
+`feature/<slice_id>` worktree（`worktree-isolation` 卡註解原文：
+`"worktree 由 coordinator 派工時自建（feature/<slice_id>）"`，
+`deck/data/cards.yaml:62-75`）。issue 原文範例 CLI 帶的
+`--branch <existing-branch>`（「可指定在呼叫方的現有 branch/worktree 內
+工作」）**明確列為 v1 非目標**，理由：
+
+1. `ScriptWorktreeCreator.create()` 對已存在的 worktree 目錄
+   fail-closed 拒絕（`"worktree target already exists"`）是既有機制依賴
+   的不變式——#276（`builder-task-boundary-segmentation`）的 D1
+   `redispatch()` 同 worktree 續派原語，正是因為要繞開這條限制才需要新
+   增一個完全不同的方法，而不是放寬 `create()` 本身。放寬成「可指向呼叫方
+   任意既有路徑」風險同一等級：`poll_done` 的 baseline 判斷、GC
+   （`cortex work gc`）對 build worktree 的回收邏輯，都隱含假設「這個
+   worktree 是 coordinator 自己建的、生命週期由 coordinator 管」。
+2. `run once` 的訴求本質是「一次性、不進 work-item lifecycle」——建自己的
+   隔離 worktree／branch 反而更貼合這個訴求（呼叫方的既有 branch/worktree
+   不會被一次性小工的 commit 污染），字面滿足「in-place」不見得是更好的
+   設計，只是 issue 原作者當下的直覺期望。
+
+若未來真的需要「in-place 派工」，應獨立立案評估（見 `tasks.md` T3），不與
+本票的 v1 範圍捆綁。
+
+### D3 combo 骨架：重用 `small-fix`，不新增 combo schema，也不砍卡
+
+**現況**：#324（`e7792f6` merge）落地 `deck/schema.py:79-101` 的
+`combo_search_dirs()`／`resolve_combo_path()`／`iter_combo_files()`——
+`$PSC_AGENTS_ROOT/config/combos/` instance-local 目錄優先於套件內建目錄，
+同 id 覆蓋；並落地參考 combo `deck/data/combos/small-fix.yaml`：
+
+```yaml
+combo:
+  id: small-fix
+  task_type: small-fix
+  cards:
+    - ref: workflow-claim
+    - ref: brainstorming
+    - ref: writing-plans-light
+    - ref: subagent-build
+    - ref: verification
+    - ref: code-review
+    - ref: policy-commit
+  gate_spine:
+    - after: verification
+      exists: ["reports/verify/*<task-slug>*.md"]
+    - after: code-review
+      exists: ["reports/review/*<task-slug>*.md"]
+```
+
+七卡對應七 phase（claim／discuss／plan／build／verify／review／ship）各
+恰一張，兩條核心 gate_spine（無 `worktree-isolation`、無
+`openspec-propose`／`openspec-archive`、無 `tdd-red`）。`writing-plans-light`
+卡（`cards.yaml:52-58`）與 `writing-plans` 同 `skill_ref`，差異只在
+`requires` 只吃 `docs/superpowers/specs/*<task-slug>*-design.md`，不依賴
+`openspec/changes/<change>/proposal.md`，打斷了 #324 issue 原文描述的
+requires DAG 斷鏈。`default_workflow_manifest()`
+（`coordinator/work_bridge.py:170`）已接受 `combo_name` 參數，
+`cortex work start --combo small-fix` 已可用。
+
+**決策**：`run once` 直接重用 `small-fix`，**不新增 combo schema**，也
+**不進一步砍卡**。理由：`validate_manager_spine()` 要求 combo 涵蓋全部
+七個 phase、persona 綁死、ship 前必有 reviewer，這是 #324 issue 原文自己
+标注「這層憲法不該改」的非目標（`不放寬 validate_manager_spine() 的七
+phase 涵蓋、persona 綁定或 ship-前-reviewer 約束`）。`small-fix` 已經是
+這條治理憲法下卡數最少的合法骨架——`run once` 若想進一步跳過
+`brainstorming`／`writing-plans-light`，等於是在違反 #324 剛立下、issue
+本身標注不可動的約束，不是本票該碰的範圍。
+
+issue 原文期望的「單一 `--prompt-file`、不必事先寫 design/plan 文件」
+因此**只能部分滿足**：`run once` 的設計回應是——把 `--prompt-file` 的
+內容當作 `brainstorming`／`writing-plans-light` 兩張卡的輸入 brief（即
+「這就是這次任務的 design 討論起點與 plan 內容」），讓這兩張卡的執行
+（不論是否需要人工介入）消化掉這份 brief 產出 `docs/superpowers/plans/`
+下的 plan 檔案，而不是試圈略過這兩個 phase 本身。具體的 prompt 模板／
+skill 呼叫方式留給後續 code 票決定（見 `tasks.md` T1），本文件只定案
+「不砍卡、用 brief 餵卡」這個架構立場。
+
+### D4 跨 repo persona catalog 缺口：已由 #341 解掉，不需要繞過設計
+
+**現況**：`coordinator/verification.py:780-838` 的 `catalog_probe`：
+
+```python
+catalog_probe = _run_git(
+    ["-C", str(resolved_repo_root), "cat-file", "-e", f"{dispatch_base}:{PERSONA_CATALOG_PATH}"],
+    git_runner,
+)
+if catalog_probe["status"] == "ok":
+    # repo-local override：pin dispatch_base commit 讀取，壞損 fail-closed
+    ...
+else:
+    # 未宣告 override：canonical 來源改為 cortex 套件內建 catalog
+    from ..persona.loader import DEFAULT_PERSONAS_PATH
+    packaged_path = DEFAULT_PERSONAS_PATH
+    packaged_text = packaged_path.read_text(encoding="utf-8")
+    ...
+    details["persona_catalog"] = {..., "source": "packaged"}
+```
+
+這是 #341（commit `0264f3f`，`fix(verification): persona catalog 改以
+套件內建為 canonical 來源`）落地的行為，修正 #295（primary）／#291
+（duplicate）：verification 原本無條件 `git show
+{dispatch_base}:paulsha_cortex/persona/personas.yaml` 到**目標 repo**，
+該檔只存在於 paulsha-cortex 自身，任何非 cortex repo 必然
+`persona-catalog-unreadable`。修正後：目標 repo 沒有宣告 repo-local
+override 時，改讀套件內建 catalog，不再要求目標 repo git tree 長出這個
+檔案。
+
+`git merge-base --is-ancestor 0264f3f a2e8d0c` 核驗為真——`0264f3f` 是本次
+查證基準 main 的祖先，已經落地。`gh issue view 338 --json createdAt`
+回報建立時間 `2026-08-07T01:39:59Z`（= `09:39:59 +0800`），
+`git log -1 --format=%ci 0264f3f` 回報 `2026-08-07 09:47:25 +0800`——
+`0264f3f` 落地僅晚於 #338 建立約 8 分鐘。#338 描述的症狀（`git show`
+到 `hamanpaul/embedebuguide` 時 `fatal: path
+'paulsha_cortex/persona/personas.yaml' does not exist`）與 #295/#291
+的根因完全相同，這條 fallback 分支落地後理應同步解掉。
+
+**決策**：`run once` **不需要**任何繞過或停用 persona gate 的設計——`本
+depends_on` 列出的 #338 阻礙已經消失。唯一動作是**驗證＋關閉 #338**，
+建議操作者用一個已知外部 repo（無 repo-local override）跑一次 tick／
+`run once` 的最小 dogfood 驗證 evidence 出現 `source: "packaged"`
+後關閉該 issue；此動作已在外層任務清單的發版驗證步驟追蹤，不在本設計
+文件票的交付範圍內。
+
+### D5 builder identity 臨時放行：重用既有 instance-local identity override 機制
+
+**現況**：`model_identities.load_model_identities()`
+（`coordinator/model_identities.py:240-268`）：
+
+```python
+def load_model_identities(config_root=None, *, use_packaged_default=True):
+    root = Path(config_root) if config_root is not None else paths.project_config_root()
+    custom_path = root / "model-identities.yaml"
+    if not use_packaged_default:
+        return _load_model_identity_file(custom_path)
+    packaged = _load_model_identity_file(_packaged_registry_path())
+    if not custom_path.is_file():
+        return packaged
+    custom = _load_model_identity_file(custom_path)
+    packaged_by_key = {(item.executor, item.model_id): item for item in packaged.identities}
+    additions = []
+    for identity in custom.identities:
+        key = (identity.executor, identity.model_id)
+        packaged_identity = packaged_by_key.get(key)
+        if packaged_identity is not None and packaged_identity == identity:
+            continue
+        if packaged_identity is not None:
+            raise ValueError(f"model-identities custom identity shadows packaged default: {key[0]}/{key[1]}")
+        additions.append(identity)
+    return IdentityRegistry(schema_version=MODEL_IDENTITY_SCHEMA_VERSION,
+                             identities=tuple(additions) + packaged.identities)
+```
+
+`config_root` 預設 `paths.project_config_root()`
+（`resolve_project_config_root()` → `PSC_PROJECT_CONFIG_ROOT` 解析鏈，
+`config/runtime.py:137-147`），讀該目錄下 `model-identities.yaml` 作為
+**新增身分的疊加來源**，與 packaged 同鍵但內容不同 → `raise`（fail-closed，
+不靜默覆蓋 packaged）。這與 #324 的 combo instance-local override
+（`combo_search_dirs()`）是同一設計語彙：packaged 是 canonical baseline，
+instance-local 是可疊加的資源目錄，衝突 fail-closed。
+
+packaged registry（`coordinator/data/model-identities.yaml`）現況只有一個
+身分（`agy`/`gemini-3.1-pro-high`/`capabilities: [planning]`，見
+`docs/superpowers/specs/design-model-capability-envelope-design.md`
+「現況更正」段的核實），`gemini-3.6-flash-high` 不在其中——這正是 issue
+原文描述的「臨時要當 builder 需改 global 身份設定」阻礙的直接證據。
+
+**決策**：**要做，且完全重用既有機制**——`run once` 新增
+`--identity-overlay <path>`（YAML 檔，schema 與
+`model-identities.yaml` 相同）：dispatch 前，把該檔複製進 D1 建立的
+ephemeral `PSC_PROJECT_CONFIG_ROOT`（隨 ephemeral state 一起建、一起依
+`--keep-state` 決定去留），照常呼叫 `load_model_identities()`——**不修改
+`model_identities.py` 一行程式碼**，不新增第二套驗證路徑，shadow 衝突
+偵測、schema 驗證全部沿用既有邏輯。
+
+明確邊界：
+
+- overlay 只影響**這一次 `run once` 呼叫**——寫入的是 ephemeral 目錄，
+  MUST NOT 觸碰宿主 `~/.agents` 或使用者全域 `PSC_PROJECT_CONFIG_ROOT`。
+- 未提供 `--identity-overlay` 時行為與現行完全一致：packaged registry
+  單一身分，未註冊的 `(executor, model_id)` 依現行
+  `_require_registered_identity()`（`manager.py:265-271`）fail-closed，
+  `run once` 不做任何隱性放行。
+- overlay 檔案本身仍受 `IdentityRegistry.from_rows()` 既有的 schema 驗證
+  （型別、重複值、`agy` canonical model_id 特判等），格式錯誤一樣
+  fail-closed 拒載，不是「無條件信任呼叫方輸入」。
+
+這比 issue 原文暗示的「per-invocation 動態放寬 capabilities 判斷」風險
+低得多（不改判斷邏輯，只是多一個可疊加的資料來源），且與 D3 的 combo
+override 手法完全對稱，維護心智負擔低。
+
+### D6 與 #324／#338 的邊界收斂
+
+`conflict_files`（簡報列出）原本預期 `autonomy.py`／`manager.py`／
+`config/runtime.py`／`deck/data/combos/feature-oneshot.yaml`／
+`model_identities.py` 五個檔案會被多票同時觸碰。本設計下：
+
+- `config/runtime.py`：**不需修改**（D1 選擇不擴充 instance 安裝機制）。
+- `deck/data/combos/feature-oneshot.yaml`：**不需修改**（D3 重用
+  `small-fix`，不動 `feature-oneshot`）。
+- `model_identities.py`：**不需修改**（D5 重用既有合併邏輯）。
+- `autonomy.py`／`manager.py`：後續 code 票會**新增**函式／CLI 入口（
+  `run once` 子指令、輪詢外殼），但不修改這兩個檔案既有函式的既有行為——
+  `_infer_repo_root()`／`run_tick()` 簽名與語意皆不變，純粹是新呼叫端。
+
+`#324` 完全可重用（D3／D5 兩個決策都是站在它落地的基礎設施上）；`#338`
+現況已過期（D4），本設計不因它調整 persona gate 的任何行為。
+
+## 風險與緩解
+
+- **風險：ephemeral state 若沒清乾淨會在 tmp 目錄堆積殘留**。緩解：
+  預設跑完即清（除非 `--keep-state`），且落點是系統 tmp 而非任何
+  `PSC_*` root，即使清理失敗也不會汙染 `~/.agents`。
+- **風險：identity overlay 若誤植到宿主 project config root，會讓臨時
+  放行變成永久放行**。緩解：後續 code 票的驗收條件（`tasks.md` T2）
+  MUST 包含「overlay 只寫入 ephemeral 目錄，宿主 `~/.agents` 不受影響」
+  的迴歸測試，比照 `changelog.d/fix-test-production-state-leak.md`
+  （#303）已有的隔離測試模式。
+- **風險：`small-fix` combo 仍要求 `brainstorming`／`writing-plans-light`
+  兩張互動性質的 planning 卡，`run once` 若不能把這兩張卡跑得夠快，
+  「一次性小工」的體感會變成「還是要走一輪完整 planning」**。這是 D3
+  刻意接受的取捨（治理憲法優先於字面體感），緩解方式是 D3 段落描述的
+  「prompt-file 當 brief 餵卡」設計，把兩張卡的執行成本壓到最低，而非
+  跳過它們。

--- a/docs/superpowers/specs/adhoc-oneshot-dispatch-spec.md
+++ b/docs/superpowers/specs/adhoc-oneshot-dispatch-spec.md
@@ -1,0 +1,193 @@
+---
+status: draft
+work_item: design-adhoc-oneshot-dispatch
+---
+
+# adhoc-oneshot-dispatch Specification
+
+#279：想在不 `cortex install service` 的前提下，對任意 repo 派幾個一次性
+小工，且不進入 work-item lifecycle。本 spec 定案 `cortex run once` 入口的
+契約，作為後續拆分 code 票的 Requirements 依據。**本票不實作任何
+Requirement，僅定案契約供未來實作票對照驗收。**
+
+## 背景
+
+2026-07-31 對外部 repo（serialwrap）ad-hoc 派 10 個小工的實測撞到四個
+結構性阻礙，2026-08-01 官方 comment 標記「阻礙 2 前半已由 #288 解掉」。
+本次以 main @ a2e8d0c 重新查證（皆已在 main 上核實，見對應 R 條的
+檔案:行號）：
+
+- `coordinator/cli.py` 的 `fanout`（144 行起）／`tick`（226 行起）／
+  `work`（191 行起）皆經 `_submit_mutation_request()`（`cli.py:578-609`）
+  送 `ControlRequest` 給常駐 manager daemon 消費，daemon 未就緒直接
+  `return 1`——結构性依賴已安裝的 daemon（見 R1）。
+- `coordinator/registry.py:217` 的 `JobRegistry.__init__` 接受任意
+  `state_path`，`coordinator/manager.py:1951` 的 `run_tick()` 是不讀
+  任何全域 root 的純函式——組裝這兩者可繞開 control queue（見 R1）。
+- `config/paths.py:89-90` 的 `repo_root()`／`coordinator/autonomy.py:217-235`
+  的 `_infer_repo_root()`（#288 已修正）已可正確解析跨 repo spec，但
+  `Dispatcher.dispatch()` 一律新建 worktree／branch，無「呼叫方既有
+  branch/worktree 內工作」路徑（見 R2）。
+- `deck/data/combos/small-fix.yaml`（#324 已落地）是七 phase 各恰一卡的
+  合法治理下限，`writing-plans-light`／`brainstorming` 卡仍要求
+  planning 輸入（見 R3）。
+- `coordinator/verification.py:780-838` 的 persona catalog 讀取已有
+  packaged fallback（#341，commit `0264f3f`，已是 main 祖先），跨 repo
+  persona gate 缺口已解（見 R4）。
+- `coordinator/model_identities.py:240-268` 的 `load_model_identities()`
+  已支援 packaged + instance-local 合併、shadow 衝突 fail-closed（見 R5）。
+
+## Goals
+
+- `cortex run once` 能對任意 repo 派一次性小工，不需要 `cortex install
+  service`，job 狀態與宿主 `~/.agents` 完全隔離。
+- 沿用既有 repo-root 解析、combo、persona catalog、identity registry
+  機制，不重複造輪；明確劃出哪些既有不變式（worktree 建立、七 phase
+  spine）v1 刻意不放寬。
+- 未使用 `run once` 的既有入口（`fanout`／`tick`／`work`／已安裝
+  instance）行為位元不變。
+
+## Requirements
+
+### R1 ad-hoc 派工 MUST 繞過 control queue，job 狀態 MUST 與宿主 runtime 物理隔離（對應 D1）
+
+`cortex run once` SHALL 不透過 `coordinator/cli.py` 既有的
+`_submit_mutation_request()`／control-queue 機制派工，SHALL 直接在呼叫
+行程內組裝 `JobRegistry(state_path=<ephemeral 路徑>)`／`Dispatcher`／
+呼叫既有純函式 `manager.run_tick()` 完成一輪 fanout→completion。ephemeral
+`state_path` SHALL 落在系統 tmp 目錄，MUST NOT 落在任何
+`PSC_AGENTS_ROOT`／已安裝 instance 的 root 之下。`config/runtime.py` 的
+`PSC_INSTANCE`／`_installed_environment()` 機制 MUST NOT 因本功能而擴充
+出「免安裝合成 instance」分支。
+
+若不做：`run once` 若沿用 `fanout`/`tick` 現行入口，daemon 未安裝時
+`_submit_mutation_request()` 必定回傳 `manager daemon 未就緒` 錯誤（現行
+`cli.py:588-595` 行為），issue #279 訴求的「不需安裝 instance」完全無法
+成立；若改成讓 `run once` 也寫進宿主共用 `PSC_COORDINATOR_ROOT`，則
+issue 描述的「job 狀態記錄可能汙染現役 manager」風險原樣重現。
+
+#### Scenario: 未安裝任何 instance 的環境執行 `run once`
+
+- **WHEN** 呼叫端未曾執行過 `cortex install service`，`~/.agents/core/runtime/`
+  下無任何 `-manager.env` bootstrap 檔
+- **THEN** `run once` 仍可完成一輪派工到終局，不讀取、不要求該 bootstrap 檔存在
+
+#### Scenario: 宿主已有現役 instance 常駐時執行 `run once`
+
+- **WHEN** 宿主 `~/.agents/coordinator/jobs.json` 已有現役 manager daemon
+  的真實 job 記錄
+- **THEN** `run once` 產生的 job/slice 記錄寫入獨立的 ephemeral
+  `state_path`，該檔案內容 MUST NOT 出現在宿主 `jobs.json` 中
+- **THEN** 現役 daemon 的既有狀態不受任何欄位或筆數變化
+
+### R2 目標 repo 解析 MUST 沿用既有機制；worktree／branch 建立行為 MUST 不變（對應 D2）
+
+`run once` 的 `--repo-root` SHALL 透過既有 `PSC_REPO_ROOT` 解析鏈
+（`config/paths.py:89-90`）與 `_infer_repo_root()`
+（`coordinator/autonomy.py:217-235`）生效，MUST NOT 新增第二套 repo-root
+解析邏輯。`Dispatcher.dispatch()` 建立 worktree／`feature/<slice_id>`
+branch 的行為 MUST 維持不變；「在呼叫方既有 branch/worktree 內工作」
+（即不新建 worktree、直接對呼叫方指定的既有路徑派工）在本 spec 範圍內
+MUST NOT 實作，屬明確 v1 非目標。
+
+若不做（若反而放寬 `worktree_creator.create()` 允許指向任意既有路徑）：
+會破壞 `redispatch()`（#276 D1）、`poll_done` baseline 判斷、`cortex work
+gc` 隱含「worktree 由 coordinator 建立與回收」的既有不變式，屬未經獨立
+設計評估的高風險變更。
+
+#### Scenario: `--repo-root` 指向非 configured root 的外部 repo
+
+- **WHEN** `run once --repo-root <外部 repo 路徑>` 且該路徑與 manager
+  既有 configured root 不同
+- **THEN** spec 解析出的 repo root 為該外部 repo 自身（沿 `.git` 向上找），
+  不誤判為 manager 既有 configured root
+
+#### Scenario: `run once` 呼叫不帶 in-place 選項
+
+- **WHEN** `run once` 完成一次派工
+- **THEN** 目標 repo 內產生一個新建的 `feature/<slice_id>` worktree／branch，
+  呼叫方原本所在的 branch／worktree 內容不受任何 commit 影響
+
+### R3 combo 骨架 MUST 重用 `small-fix`，MUST NOT 新增更輕量的 combo 或砍卡（對應 D3）
+
+`run once` SHALL 透過 `default_workflow_manifest(combo_name="small-fix")`
+（`coordinator/work_bridge.py:170`）既有入口消費 combo，MUST NOT 新增
+違反 `validate_manager_spine()` 七 phase 涵蓋、persona 綁定、
+ship-前-reviewer 三條既有治理約束的新 combo。`--prompt-file` 提供的內容
+SHALL 作為 `brainstorming`／`writing-plans-light` 兩張卡的輸入 brief，
+MUST NOT 被設計為跳過這兩張卡本身。
+
+若不做（若新增砍掉 planning 卡的更輕量 combo）：直接違反 #324 issue 原文
+自行標注、`validate_manager_spine()` 強制的不可放寬約束，且與 #324 落地
+的治理模型產生兩套互相矛盾的「最小 combo」定義。
+
+#### Scenario: `run once` 消費 `small-fix` combo
+
+- **WHEN** `run once` 對某一次性任務建 WorkflowRun
+- **THEN** manifest 的 `combo` 欄位為 `small-fix`
+- **THEN** `validate_manager_spine()` 對該 manifest 通過（七 phase 涵蓋）
+
+#### Scenario: `--prompt-file` 內容餵入 planning 卡
+
+- **WHEN** `run once --prompt-file task.md` 執行到 `writing-plans-light` 卡
+- **THEN** 該卡的輸入 brief 含 `task.md` 內容
+- **THEN** 產出的 plan 檔案存在於 `docs/superpowers/plans/`，`gate_spine`
+  對應檢查通過
+
+### R4 跨 repo persona catalog 缺口 MUST NOT 需要額外繞過設計（對應 D4）
+
+`run once` 對外部 repo 的派工 MUST 沿用現行 `verification.py:780-838`
+的 packaged fallback（#341 已落地），MUST NOT 為 `run once` 新增停用或
+繞過 persona-scope 檢查的旁路。
+
+若不做（若誤判 #338 仍是阻礙而新增繞過邏輯）：會在已經 fail-closed 且
+可稽核（`source` 欄位）的既有機制之外，另開一條未受同等治理的旁路，
+擴大攻擊面且與現行機制邏輯重複。
+
+#### Scenario: `run once` 對無 repo-local override 的外部 repo 派工
+
+- **WHEN** 目標 repo 的 `dispatch_base` tree 內不存在
+  `paulsha_cortex/persona/personas.yaml`
+- **THEN** verification 的 `persona_catalog.source` 為 `"packaged"`
+- **THEN** 該 slice 不因 `persona-catalog-unreadable` 被擋
+
+### R5 builder identity 臨時放行 MUST 透過 ephemeral instance-local overlay，MUST NOT 修改 registry 驗證邏輯（對應 D5）
+
+`run once` SHALL 支援 optional `--identity-overlay <path>`：提供時，
+SHALL 把該檔案複製進 R1 所建 ephemeral `PSC_PROJECT_CONFIG_ROOT`，
+dispatch 前呼叫既有 `load_model_identities()`（
+`coordinator/model_identities.py:240-268`）取得合併後 registry。overlay
+檔案 MUST 經過現行 `IdentityRegistry.from_rows()` schema 驗證，格式錯誤
+或與 packaged 同鍵不同值（shadow）MUST fail-closed 拒絕整次 `run once`
+呼叫，MUST NOT 靜默略過該筆身分或退回無 overlay 狀態。overlay 檔案
+MUST NOT 寫入宿主 `~/.agents` 或使用者全域 `PSC_PROJECT_CONFIG_ROOT`。
+未提供 `--identity-overlay` 時，`run once` 的 identity 驗證行為 MUST 與
+現行 `fanout`／`tick` 完全一致（僅 packaged registry，未註冊身分
+fail-closed）。
+
+若不做（若改為在派工路徑內動態放寬 `capable()`／capability 判斷）：
+會新增一條繞過既有 fail-closed schema 驗證的邏輯路徑，且與 #209
+（`design-model-capability-envelope`）正在定案的 `capable()` 六項判準
+產生設計面衝突——本 R5 選擇「多一個可疊加資料來源」而非「改判斷邏輯」，
+與 #209 的 envelope 判準完全正交、互不影響。
+
+#### Scenario: 帶 `--identity-overlay` 臨時放行未註冊身分
+
+- **WHEN** `run once --identity-overlay overlay.yaml` 且該檔宣告
+  packaged registry 沒有的 `(executor, model_id)` 對
+- **THEN** 該次呼叫的派工使用該身分，registry 驗證通過
+- **THEN** 呼叫結束後，宿主 `~/.agents` 下任何 `model-identities.yaml`
+  內容不含該筆身分
+
+#### Scenario: overlay 與 packaged 同鍵不同值
+
+- **WHEN** overlay 檔宣告的 `(executor, model_id)` 與 packaged registry
+  相同，但 `capabilities` 或其他欄位不同
+- **THEN** `run once` fail-closed 拒絕整次呼叫，錯誤訊息指出衝突鍵
+- **THEN** 不啟動任何 model session、不建任何 job
+
+#### Scenario: 未提供 overlay 時行為不變
+
+- **WHEN** `run once` 呼叫未帶 `--identity-overlay`
+- **THEN** identity 驗證行為與現行 `fanout`／`tick` 對未註冊身分的
+  fail-closed 行為完全一致

--- a/openspec/changes/2026-08-07-design-adhoc-oneshot-dispatch/design.md
+++ b/openspec/changes/2026-08-07-design-adhoc-oneshot-dispatch/design.md
@@ -1,0 +1,92 @@
+---
+status: draft
+work_item: design-adhoc-oneshot-dispatch
+---
+
+# design-adhoc-oneshot-dispatch Design
+
+## Decisions
+
+- **D1（runtime 隔離）**：`run once` 不擴充 `PSC_INSTANCE`/`_installed_environment()`
+  （`config/runtime.py:53-70`）這條「已安裝 instance」機制。它改為直接在
+  同一行程內組裝 `JobRegistry(state_path=<ephemeral tmp path>)`
+  （`coordinator/registry.py:217`，建構子本就接受任意路徑，與
+  `PSC_COORDINATOR_ROOT` 無耦合）＋`Dispatcher`
+  （`coordinator/dispatcher.py:96-107`，三個依賴皆經建構子注入）＋既有純
+  函式 `manager.run_tick()`（`coordinator/manager.py:1951`，簽名只吃
+  `dispatcher`/`metas`/一串 optional 注入點，無任何全域 root 讀取），
+  完全繞過 `coordinator/cli.py` 的 control-queue 入口
+  （`_submit_mutation_request()`：daemon 未就緒直接印
+  `錯誤: manager daemon 未就緒` 並回傳非零，`fanout`/`tick`/`work`
+  三個 CLI 子指令全部經此函式送 `ControlRequest` 給常駐 daemon 消費——
+  這是「必須先 install service」的真正根因，不是表層 env var 問題）。
+  ephemeral state 存於系統 tmp 目錄（不落在任何 `PSC_AGENTS_ROOT`
+  底下），跑完依 `--keep-state` flag 決定保留或清除；worktree／git
+  artifacts 一律保留供人工檢視，不隨 state 一起清。
+- **D2（repo-root／worktree 邊界）**：目標 repo 透過既有
+  `PSC_REPO_ROOT`（`config/paths.py:89-90`，預設 `Path.cwd()`）指定，沿用
+  `_infer_repo_root()`（`coordinator/autonomy.py:217-235`，#288 已修正）
+  推導 spec 所屬 repo 的既有邏輯，不新增第二套 repo-root 解析。**但**
+  `Dispatcher.dispatch()` 一律呼叫 `worktree_creator.create()` 新建
+  worktree／`feature/<slice_id>` branch——issue 原文範例 CLI 帶的
+  `--branch <existing-branch>`（在呼叫方既有 branch/worktree 內工作）
+  明確列為 v1 **非目標**：`ScriptWorktreeCreator.create()` 對已存在的
+  worktree 目錄 fail-closed 拒絕是多處既有機制（#276 的 `redispatch()`
+  同 worktree 續派原語、`poll_done` baseline 判斷）依賴的不變式，貿然放寬
+  成「可指向呼叫方任意既有路徑」風險高、需要獨立設計，不與本票的 v1
+  範圍捆綁（見 `tasks.md` T3）。`run once` 產出的 worktree／branch 對
+  呼叫方而言是一次性、隔離的副產物，本身即符合「不進 work-item
+  lifecycle」的訴求精神——不建議為了字面滿足「in-place」而放棄這層隔離。
+- **D3（combo 骨架）**：不新增 combo schema。重用 #324 落地的
+  `small-fix` combo（`deck/data/combos/small-fix.yaml`：`workflow-claim`／
+  `brainstorming`／`writing-plans-light`／`subagent-build`／
+  `verification`／`code-review`／`policy-commit` 七卡對應七 phase，兩條
+  gate_spine）與 `combo_search_dirs()`（`deck/schema.py:79-101`）的
+  instance-local override 通路。**明確拒絕**進一步砍卡：`small-fix` 已是
+  `validate_manager_spine()`（#324 非目標段落明講不放寬）七 phase 涵蓋、
+  persona 綁定、ship-前-reviewer 這三條治理憲法下的合法下限——issue 原文
+  期望的「單一 `--prompt-file`、不必事先寫 design/plan 文件」的落差，
+  設計上以「`run once` 把 `--prompt-file` 內容接成
+  `brainstorming`／`writing-plans-light` 兩張卡的輸入 brief」解決，而非
+  跳過這兩張卡本身；`default_workflow_manifest()`
+  （`coordinator/work_bridge.py:170`）既有的 `combo_name` 參數已可直接
+  傳 `"small-fix"`，`run once` 走同一個入口，不繞道另建 manifest 組裝
+  邏輯。
+- **D4（跨 repo persona 缺口）**：#338 描述的
+  `persona-catalog-unreadable` 症狀已由 #341（commit `0264f3f`，`main`
+  祖先，早於本次查證基準 `a2e8d0c`）解掉——`verification.py:780-838`
+  現在對 `dispatch_base` tree 探測不到 repo-local override
+  （`git cat-file -e`）時 fallback 讀取
+  `persona.loader.DEFAULT_PERSONAS_PATH` 套件內建 catalog，evidence 記
+  `source: "packaged"` 可稽核。`0264f3f` 落地時間（`2026-08-07
+  09:47:25 +0800`）僅晚於 #338 建立時間（`2026-08-07 09:39:59 +0800`）約
+  8 分鐘，判定 #338 目前是「症狀已消失、issue 未關閉」的過期狀態。
+  `run once` **不需要**任何繞過或停用 persona gate 的設計；唯一殘留動作
+  是驗證＋關閉 #338 本身，該動作已在外層任務清單（非本票）追蹤。
+- **D5（builder identity 臨時放行）**：**要做，且重用既有機制**——
+  `model_identities.load_model_identities()`
+  （`coordinator/model_identities.py:240-268`）已經是「packaged registry
+  ＋instance-local `<PSC_PROJECT_CONFIG_ROOT>/model-identities.yaml`
+  合併」模型，與 #324 的 combo override 是同一設計語彙：instance-local
+  新增身分視為疊加，與 packaged 同鍵但內容不同即 raise
+  （`shadows packaged default`，fail-closed，不靜默覆蓋）。`run once`
+  的新職責僅止於：接受 `--identity-overlay <path>`（或等價 inline flag），
+  把它複製進**該次呼叫專屬**的 ephemeral `PSC_PROJECT_CONFIG_ROOT`
+  （隨 D1 的 ephemeral state root 一起建立、一起清除），dispatch 前照常
+  呼叫 `load_model_identities()`——不新增第二套驗證路徑，不修改
+  `model_identities.py`。overlay 檔案 MUST NOT 寫入宿主
+  `~/.agents`／使用者全域 project config；未提供 `--identity-overlay`
+  時行為與現行完全一致（沿用 packaged registry，`gemini-3.6-flash-high`
+  等未註冊身分依現行 `_require_registered_identity()` fail-closed）。
+  這比「in-process 動態放寬 capabilities 判斷」風險低得多，且不需要
+  `model_identities.py` 任何程式碼改動。
+- **D6（與 #324／#338 邊界）**：#324 完全可重用（D1 的 combo override
+  基礎設施、D5 的 identity override 基礎設施皆脫胎於此），不重複造輪；
+  #338 現況已過期（D4），本票不因它而改變 persona gate 設計；conflict_files
+  中列出的 `deck/data/combos/feature-oneshot.yaml`／`model_identities.py`
+  在本設計下皆**不需修改**——`run once` 只新增自己的 CLI 入口與 wiring，
+  不動這兩個既有檔案，衝突面比原簡報預期的小。
+
+詳細 D1–D6 全文論證、風險緩解與可證偽 Requirements 見
+`docs/superpowers/specs/adhoc-oneshot-dispatch-design.md`
+與 `docs/superpowers/specs/adhoc-oneshot-dispatch-spec.md`。

--- a/openspec/changes/2026-08-07-design-adhoc-oneshot-dispatch/proposal.md
+++ b/openspec/changes/2026-08-07-design-adhoc-oneshot-dispatch/proposal.md
@@ -1,0 +1,97 @@
+---
+status: draft
+work_item: design-adhoc-oneshot-dispatch
+---
+
+## Goals
+
+定案「跨 repo ad-hoc 一次性派工」（issue #279）的架構決策——`cortex run once`
+這個新入口的 job 狀態要落在哪、要不要新開 combo schema、跨 repo persona
+catalog 缺口是否仍需處理、builder identity 臨時放行的 fail-closed 邊界——
+作為後續 code 票的單一設計依據。**本票只交付設計文件，不動
+`paulsha_cortex/` 任何程式檔。**
+
+## Why
+
+2026-07-31 實際嘗試對外部 repo（serialwrap）以 ad-hoc 方式派 10 個小工時
+撞到四個結構性阻礙（manager 綁單一 repo、job 狀態疑似共用宿主 runtime、
+deck combo 生命週期綁定、builder identity 門檻），2026-08-01 官方 comment
+逐項核對後標記「阻礙 2 的 repo-root 解析前半已由 #288 解掉，其餘三項半
+仍在」。本次以 main @ a2e8d0c 重新查證，結論與官方 comment 大致一致，但
+發現兩處官方 comment 未涵蓋、影響設計走向的新事實：
+
+1. **阻礙 3（combo 生命週期）已有部分底座**：#324（combo 可擴充與可選，
+   已於 e7792f6 merge）落地了 instance-local combo override
+   （`paulsha_cortex/deck/schema.py:79-101` 的 `combo_search_dirs()`）與參考
+   輕量 combo `small-fix`（`paulsha_cortex/deck/data/combos/small-fix.yaml`，
+   7 卡 2 gate_spine，無 `worktree-isolation` 卡）。`run once` 不必重新設計
+   combo 骨架，但**不能**進一步砍到「零 planning 卡」——`small-fix` 已是
+   `validate_manager_spine()` 七 phase 涵蓋這條治理憲法下的合法下限（見
+   `design.md` D3），issue 原文期望的「單一 prompt-file、無需事先寫
+   design/plan 文件」只能部分滿足。
+2. **阻礙 4（persona catalog gate 對外部 repo 必炸）已經解掉**：本票
+   `depends_on` 列的 #338 描述的症狀（`persona-catalog-unreadable`），其
+   根因與 #295/#291 完全相同，且已由 #341（commit `0264f3f`，早於本次查證
+   基準 main @ a2e8d0c）修正——`verification.py:780-838` 現在對
+   `dispatch_base` tree 探測不到 repo-local override 時會 fallback 讀取
+   `paulsha_cortex.persona.loader.DEFAULT_PERSONAS_PATH` 套件內建 catalog。
+   `0264f3f` 是 `a2e8d0c` 的祖先（`git merge-base --is-ancestor` 已核驗），
+   而 #338 建立於 `2026-08-07T01:39:59Z`、`0264f3f` 落地於同日
+   `09:47:25 +0800`（約晚 8 分鐘）——**#338 這張 GitHub issue 本身仍是
+   OPEN，但它描述的 bug 在其建立當下幾乎同時就已被另一張票的 fix 解掉**，
+   目前處於「症狀已消失、票未關閉」的過期狀態。`run once` 的設計不需要為
+   跨 repo persona gate 另闢繞過路徑；本票在 `design.md` D4 記錄此發現，
+   關閉 #338 本身留給外層任務清單既有的驗證/發版步驟處理，不在本票範圍。
+
+真正未解的核心阻礙，經本次查證確認**性質比官方 comment 描述的更根本**：
+`cortex fanout`/`tick`/`work` 在 CLI 層一律經 control queue 送
+`ControlRequest` 給 manager daemon 消費（`coordinator/cli.py` 的
+`_submit_mutation_request()`，找不到就緒的 daemon 直接印
+`錯誤: manager daemon 未就緒`）——這些入口**结构性依賴一個已安裝、常駐
+的 daemon**，不是靠疊加 `PSC_*` env var 就能繞過的表層問題。`run once`
+要做到「不需安裝 instance」，必須繞過 control queue，直接在同一行程內
+組裝 `JobRegistry`（`coordinator/registry.py:217` 建構子接受任意
+`state_path`）／`Dispatcher`（`coordinator/dispatcher.py:96-107`）並呼叫
+既有的純函式 `manager.run_tick()`（`coordinator/manager.py:1951`）——這條
+組裝路徑本來就與 `PSC_INSTANCE`/`_installed_environment()`
+（`config/runtime.py:53-70`）完全解耦，`run once` 不需要、也不應該去擴充
+instance 安裝機制本身。
+
+## What Changes（設計層級，非程式碼變更）
+
+- 定案 D1：`run once` 的 job 狀態隔離模型——繞過 control queue，直接在同一
+  行程內組裝 `JobRegistry(state_path=<ephemeral tmp path>)` 並呼叫
+  `manager.run_tick()`，不嘗試擴充 `PSC_INSTANCE`/`_installed_environment()`
+  這條「已安裝 instance」機制；`PSC_AGENTS_ROOT` 之下其餘 root
+  （`PSC_COORDINATOR_ROOT` 等，`config/runtime.py:12-18`）維持現行
+  `RUNTIME_ROOT_DEFAULTS` 語意不動。
+- 定案 D2：repo-root／worktree 邊界——沿用既有
+  `PSC_REPO_ROOT`（`config/paths.py:89-90`）＋`_infer_repo_root()`
+  （`coordinator/autonomy.py:217-235`）機制指定目標 repo；`Dispatcher.dispatch()`
+  仍一律新建 worktree／`feature/<slice_id>` branch，不重用呼叫方既有
+  branch／worktree——issue 原文期望的「可指定在呼叫方現有 branch/worktree
+  內工作」明確列為 v1 非目標（見 `design.md` D2 風險說明）。
+- 定案 D3：combo 消費——重用 #324 的 `small-fix` combo 與 instance-local
+  override 機制，不新增 combo schema；`run once` 的職責是把
+  `--prompt-file` 內容接進 `brainstorming`／`writing-plans-light` 兩張
+  planning 卡的輸入，而非跳過整個 plan phase。
+- 定案 D4：跨 repo persona catalog 缺口——已由 #341 解掉（見上），
+  `run once` 不需要繞過或停用 persona gate。
+- 定案 D5：builder identity 臨時放行——重用
+  `model_identities.load_model_identities()`（`coordinator/model_identities.py:240-268`）
+  既有的「packaged + instance-local `model-identities.yaml` 合併、
+  shadow 衝突 fail-closed」機制，`run once` 只需把 overlay 檔案寫進其
+  ephemeral `PSC_PROJECT_CONFIG_ROOT`，不新增驗證邏輯。
+- 定案 D6：與 #324／#338 的關係收斂——#324 完全可重用，不重複造輪；#338
+  現況已過期（bug 已修、票未關）。
+- 不實作 D1–D5 任何一項；code 落地拆為三張候選後續票（見 `tasks.md`）。
+
+## Capabilities
+
+### Modified Capabilities
+
+- `trusted-dispatch-completion`：新增「ad-hoc oneshot dispatch 入口」的
+  contract delta，詳見 `specs/trusted-dispatch-completion/spec.md` 的
+  ADDED Requirements，與 `docs/superpowers/specs/
+  adhoc-oneshot-dispatch-spec.md` 的完整 Requirements、`docs/superpowers/
+  specs/adhoc-oneshot-dispatch-design.md` 的 Decisions。

--- a/openspec/changes/2026-08-07-design-adhoc-oneshot-dispatch/specs/trusted-dispatch-completion/spec.md
+++ b/openspec/changes/2026-08-07-design-adhoc-oneshot-dispatch/specs/trusted-dispatch-completion/spec.md
@@ -1,0 +1,59 @@
+---
+status: draft
+work_item: design-adhoc-oneshot-dispatch
+---
+
+## ADDED Requirements
+
+### Requirement: ad-hoc 一次性派工MUST繞過control queue且與宿主runtime物理隔離
+
+系統MUST提供一個不需已安裝instance即可運作的一次性派工入口（`cortex run
+once`）。該入口MUST NOT透過既有control-queue機制（`fanout`/`tick`/`work`
+共用的request/poll-done流程）運作，MUST直接組裝既有的
+`JobRegistry`/`Dispatcher`/`run_tick()`元件於呼叫行程內完成一輪派工。
+job/slice狀態MUST落在系統暫存路徑而非任何已安裝instance的root，MUST NOT
+寫入宿主`~/.agents`共用runtime狀態。既有`PSC_INSTANCE`/instance安裝機制
+MUST NOT因此新增「免安裝合成instance」分支。
+
+#### Scenario: 未安裝instance時執行一次性派工
+
+- **WHEN** 呼叫端未曾執行過install，本機無任何instance bootstrap設定
+- **THEN** 一次性派工入口仍可完成一輪派工至終局
+- **THEN** 不要求、不讀取任何instance bootstrap檔
+
+#### Scenario: 宿主已有現役instance時執行一次性派工
+
+- **WHEN** 宿主已有現役manager daemon與其對應state
+- **THEN** 一次性派工產生的狀態記錄於獨立暫存路徑，不出現在宿主state內
+- **THEN** 現役daemon既有狀態不受影響
+
+### Requirement: ad-hoc一次性派工MUST沿用既有combo治理約束，MUST NOT新增放寬七phase涵蓋的combo
+
+一次性派工入口MUST消費既有combo（受`validate_manager_spine()`七phase
+涵蓋、persona綁定、ship前reviewer三項約束管轄），MUST NOT新增違反上述
+約束的更輕量combo。呼叫端提供的任務描述MUST作為既有plan phase卡片的
+輸入內容，MUST NOT被設計為略過plan phase本身。
+
+#### Scenario: 一次性派工建立WorkflowRun
+
+- **WHEN** 一次性派工入口對某任務建立WorkflowRun
+- **THEN** 其combo通過`validate_manager_spine()`七phase涵蓋檢查
+
+### Requirement: ad-hoc一次性派工的builder identity放行MUST透過可疊加overlay，MUST NOT改動registry驗證邏輯
+
+一次性派工入口MAY支援optional身分overlay，提供時MUST寫入該次呼叫專屬的
+暫存project-config路徑後，經既有packaged+instance-local合併與shadow
+衝突fail-closed邏輯驗證，MUST NOT新增另一條驗證路徑，MUST NOT寫入宿主
+全域project-config路徑。未提供overlay時，身分驗證行為MUST與既有
+`fanout`/`tick`對未註冊身分的fail-closed行為一致。
+
+#### Scenario: 提供身分overlay
+
+- **WHEN** 呼叫端提供overlay宣告registry未收錄的builder身分
+- **THEN** 該次呼叫可使用該身分派工
+- **THEN** 呼叫結束後宿主全域身分設定不含該筆身分
+
+#### Scenario: overlay與packaged同鍵衝突
+
+- **WHEN** overlay宣告的身分鍵與packaged registry相同但內容不同
+- **THEN** 整次呼叫fail-closed拒絕，不啟動任何model session

--- a/openspec/changes/2026-08-07-design-adhoc-oneshot-dispatch/tasks.md
+++ b/openspec/changes/2026-08-07-design-adhoc-oneshot-dispatch/tasks.md
@@ -1,0 +1,86 @@
+---
+status: draft
+work_item: design-adhoc-oneshot-dispatch
+---
+
+# Tasks
+
+design-doc 票，非 code TDD RED/GREEN；驗收為文件三件套完整＋經至少一輪
+review，比照 `2026-08-04-design-task-type-taxonomy`／
+`2026-08-07-builder-task-boundary-segmentation`／
+`2026-08-07-design-model-capability-envelope` 等既有 design-doc 票慣例。
+
+- [ ] 1.1 `proposal.md`／`design.md`／
+      `specs/trusted-dispatch-completion/spec.md` 三件套完整，且與
+      `docs/superpowers/specs/adhoc-oneshot-dispatch-{design,spec}.md`
+      內容一致（openspec 三件套為摘要、docs/superpowers 為完整論證，
+      兩者不得互相矛盾）。
+- [ ] 1.2 `docs/superpowers/specs/adhoc-oneshot-dispatch-spec.md` 的
+      R1-R5 逐條可對應到 issue #279 原文四個阻礙之一，且每條皆指出
+      對應 D 決策與至少一個 main 上現有檔案／函式作為改動錨點（非空泛
+      陳述）。
+- [ ] 1.3 D4（跨 repo persona catalog 缺口已解）附上 #341 commit
+      `0264f3f` 為 `a2e8d0c`（本票查證基準）祖先的核驗方式（
+      `git merge-base --is-ancestor`）與 #338／`0264f3f` 的建立/落地
+      時間對照，作為「阻礙已消失、issue 未關閉」判定的可稽核依據。
+- [ ] 1.4 本設計文件經至少一輪 review（人工或 reviewer persona）才可
+      勾完此清單；不可自我勾完就 claim done。
+- [ ] 1.5 `changelog.d/adhoc-oneshot-dispatch-design.md` fragment 與
+      `CHANGELOG.md [Unreleased]` entry（#279）。
+- [ ] 1.6 `python3 -m pytest -q` 全綠（docs-only 變更，不應影響既有
+      測試）；帶 PR 上下文的 `policy_check` 0 fail；`git diff --check`
+      乾淨。
+
+## 驗收
+
+三件套（openspec proposal/design/spec）與 docs/superpowers 完整文件皆
+存在且互相一致；D1-D6／R1-R5 皆可證偽（每條指出改動錨點與「不做的
+後果」）；D4 明確記錄 #338 現況已過期且附可稽核依據；D6 明確記錄
+`conflict_files` 原列五檔中三檔（`config/runtime.py`／
+`deck/data/combos/feature-oneshot.yaml`／`model_identities.py`）在本
+設計下不需修改；不動 `paulsha_cortex/` 任何程式檔。
+
+## 後續應拆分的 code 票（建議，非本票範圍）
+
+比照 #276 design-doc 票拆碼的既有慣例，避免單票過大：
+
+1. **`cortex run once` 核心入口**（D1+D2+D3 最小組合，issue #279 核心
+   訴求）：
+   - 新 CLI 子指令（`coordinator/cli.py` 或 `cli.py`）：
+     `--repo-root`／`--executor`／`--model`／`--prompt-file`／
+     `--verify`／`--timeout`／`--keep-state`。
+   - 組裝 ephemeral `JobRegistry`／`Dispatcher`／輪詢外殼呼叫
+     `manager.run_tick()` 至終局或 timeout（D1）。
+   - `--prompt-file` 內容接入 `small-fix` combo 的
+     `brainstorming`／`writing-plans-light` 卡輸入（D3）。
+   - 驗收：對一個已知外部 repo（無 repo-local persona override）跑
+     `run once` 端到端完成一次 `passed`／`needs_human` 終局；未安裝任何
+     instance 的環境可執行；ephemeral state 不寫入宿主 `~/.agents`（
+     以偽造 `$HOME` 迴歸測試核驗，比照 `changelog.d/
+     fix-test-production-state-leak.md` 的隔離測試模式）；既有
+     `fanout`/`tick`/`work` 行為位元不變。
+   - 這張票落地後，issue #279 阻礙 1／阻礙 2 後半／阻礙 3（在 D3 定義
+     的部分滿足範圍內）即已解掉。
+2. **`--identity-overlay` 臨時放行**（D5，可獨立於票 1 開發測試，但
+   實際生效依賴票 1 的 ephemeral `PSC_PROJECT_CONFIG_ROOT` 存在）：
+   - `run once` 新增 `--identity-overlay <path>`，複製進 ephemeral
+     project-config root，dispatch 前呼叫既有 `load_model_identities()`。
+   - 不修改 `model_identities.py` 任何驗證邏輯。
+   - 驗收：overlay 身分可用於該次呼叫；shadow 衝突 fail-closed（既有
+     行為的迴歸驗證）；宿主全域身分設定不受影響。
+3. **驗證＋關閉 #338**（D4，非 code，屬外層任務清單既有的發版驗證
+   步驟，此處僅記錄依賴關係）：
+   - 用票 1 落地的 `run once`（或現行 `tick`）對一個無 repo-local
+     override 的外部 repo 跑一次派工，確認 evidence
+     `persona_catalog.source == "packaged"` 且不落 `needs_human`。
+   - 附 evidence 於 #338 comment 後關閉。
+4. **（backlog，明確 v1 非目標）「in-place」派工**（D2 風險段落）：
+   - 若未來真的需要「在呼叫方既有 branch/worktree 內工作」，需獨立
+     設計評估 `Dispatcher` 新增不重建 worktree 的變體（類比 #276 D1
+     的 `redispatch()` 先例，但針對呼叫方任意既有路徑而非前一個 job
+     自己的 worktree），並重新核對 `poll_done` baseline、`cortex work
+     gc` 對這類 worktree 的回收語意——風險等級不宜與票 1 捆綁。
+
+四張候選票各自可獨立驗收；票 1 是唯一解掉 issue #279 核心訴求的必要
+票，票 2／3 可平行或稍後跟進，票 4 除非有新的明確需求，否則不建議
+主動立案。


### PR DESCRIPTION
## 摘要

docs(openspec): 跨 repo ad-hoc 一次性派工設計文件 (#279)

Closes #279

## 交付內容

在 worktree /tmp/claude-1000/-home-paul-chen-prj-pri-paulsha-cortex/4a1318d8-3023-4199-8318-627f4e4a1dc5/scratchpad/wt/279-adhoc-oneshot-dispatch-design（branch feature/279-adhoc-oneshot-dispatch-design）完成 issue #279 的設計文件交付。\n\n新增檔案：\n- openspec/changes/2026-08-07-design-adhoc-oneshot-dispatch/{proposal.md,design.md,tasks.md,specs/trusted-dispatch-completion/spec.md}\n- docs/superpowers/specs/adhoc-oneshot-dispatch-{design,spec}.md（完整版，含 D1-D6 決策與 R1-R5 可證偽 Requirements）\n- changelog.d/adhoc-oneshot-dispatch-design.md ＋ CHANGELOG.md [Unreleased] entry\n\n設計核心結論（D1-D6，皆附 main 現況檔案:行號證據）：\nD1 runtime 隔離——run once 繞過 control queue（coordinator/cli.py 的 _submit_mutation_request 結构性依賴常駐 daemon），直接在同一行程組裝 JobRegistry(state_path=ephemeral)/Dispatcher/manager.run_tick() 三個既有元件，job 狀態落系統 tmp、與宿主 ~/.agents 物理隔離，不擴充 PSC_INSTANCE/_installed_environment() 安裝機制。\nD2 repo-root/worktree——沿用既有 PSC_REPO_ROOT/_infer_repo_root()；worktree/branch 建立行為不變，「呼叫方既有 branch/worktree 內工作」明確列為 v1 非目標（風險：破壞既有 create-only 不變式）。\nD3 combo——重用 #324 已落地的 small-fix combo，不新增更輕量 combo（validate_manager_spine() 七 phase 涵蓋是不可放寬的治理憲法）；prompt-file 內容餵入 planning 卡而非跳過。\nD4 persona catalog——查證發現 #338 描述的症狀已由 #341（commit 0264f3f，已核驗為 main 祖先，落地僅晚於 #338 建立約 8 分鐘）解掉，run once 不需要任何繞過設計。\nD5 builder identity——重用既有 model_identities.load_model_identities() 的 packaged+instance-local 合併/shadow-fail-closed 機制，新增 ephemeral overlay，不改 registry 驗證邏輯。\nD6——收斂與 #324/#338 邊界，conflict_files 中三個檔案本設計下不需修改。\n\ntasks.md 拆出 4 張候選後續 code 票（T1 核心 CLI 入口／T2 identity overlay／T3 驗證關閉 #338／T4 backlog 的 in-place 派工，明確不建議主動立案）。\n\ngit diff 只涉及 docs/**、openspec/**、changelog.d/**、CHANGELOG.md（8 files changed, 905 insertions），無任何個人絕對路徑或憑證命中（R-21 shareable tier 掃描通過）。

## 與偵察簡報／規劃的落差（如實記錄）

1. 簡報未涵蓋的重大新發現：#338（跨 repo persona catalog gate 必炸）症狀已由 #341（commit 0264f3f，已用 git merge-base --is-ancestor 核驗為 main@a2e8d0c 的祖先）解掉；0264f3f 落地時間僅晚於 #338 建立時間約 8 分鐘。判定 #338 現況為「症狀已消失、issue 未關閉」，本設計文件的阻礙 4（跨 repo persona 缺口）因此結論為「不需要繞過設計」，與簡報預期的「D4 需評估是否跳過 persona/deck gate」方向不同——本票明確拒絕新增任何 persona gate 繞過邏輯。\n2. 深挖阻礙 1 的根因後發現比簡報描述的更底層：不是「PSC_* env var 疊加不完整」的表層問題，而是 `fanout`/`tick`/`work` 三個 CLI 入口結构性依賴已安裝、常駐的 manager daemon 消費 control queue（`coordinator/cli.py:_submit_mutation_request()`）——daemon 未就緒直接回錯誤。設計因此改為「run once 完全繞過 control queue，直接在同一行程內組裝既有純函式 JobRegistry/Dispatcher/manager.run_tick()」，而非簡報提議的「擴充 PSC_INSTANCE 支援免安裝 ephemeral instance」；並明確論證為何不擴充 config/runtime.py 的 _installed_environment()。\n3. combo 骨架（阻礙3）：查證 #324 已 CLOSED 且完整落地 small-fix combo + instance-local override 機制，比簡報寫作當下（僅知標題與 OPEN 狀態）更明確。設計文件因此能給出具體結論：直接重用 small-fix、不新增更輕量 combo（因 validate_manager_spine() 七 phase 涵蓋是 #324 自行標注不可放寬的治理憲法），issue 原文「單一 prompt-file 免 planning 文件」的期望只能部分滿足（用 prompt-file 內容餵 planning 卡，而非跳過該卡）。\n4. builder identity（阻礙4/決策d）：查證 model_identities.load_model_identities() 已有 packaged+instance-local 合併＋shadow衝突fail-closed機制（與 #324 的 combo override 同一設計語彙），決策從簡報的「待決定要不要做」收斂為「要做，且完全重用既有機制，不改 model_identities.py 任何程式碼」。\n5. conflict_files 五檔中，本設計下 config/runtime.py／deck/data/combos/feature-oneshot.yaml／model_identities.py 三檔判定為「不需修改」，衝突面小於簡報預期（見 design.md D6）。\n以上皆已用 main 現況檔案:行號重新核對並寫入 design.md/spec.md 佐證，非直接沿用簡報行號。

## 獨立複驗

- 判定：**pass**（複驗 agent 實跑 pytest：2042 passed / 0 failed；基線 main 2042 + 32 subtests，docs-only 無變化）。

## 驗證

- [x] `python3 -m pytest -q` 全綠（2042 passed + 32 subtests）
- [x] diff 僅涉 docs/**、openspec/**、changelog.d/**、CHANGELOG.md（複驗確認未動任何產線 .py/.yaml）
- [x] 文件引用之檔案:行號經獨立抽查屬實
- [x] changelog fragment（R-09）＋ `CHANGELOG.md [Unreleased]` entry
- [x] 本地 policy_check 帶 PR 上下文 → fail: 0
- [x] R-21 掃描：無個人絕對路徑／憑證

## 稽核註記

本票由 sonnet subagent 撰寫設計文件、獨立 sonnet subagent 複驗（引用行號逐一對 main 抽查、設計問題完整性、diff 範圍、自報與交付一致性），PR 由主 session 統一開啟與合併。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T8j64kn6wKmL4WQA7wJL19

## 豁免說明

- **policy-exempt:issue-link（R-17）**：本 PR body 如實記錄交付與複驗過程，需引用相關 issue/PR（#324, #338, #341）作為上下文，僅 closing 目標為本票。