### PR TITLE
chore(work): open-issue 批次 369–385 work item 進件登錄

### DIFF
--- a/.cortex/work-items.yaml
+++ b/.cortex/work-items.yaml
@@ -3,484 +3,570 @@ work_items:
   unified-work-lifecycle:
     title: Unified work lifecycle
     links:
-      - kind: github_issue
-        ref: hamanpaul/paulsha-cortex#14
-      - kind: openspec
-        ref: unified-work-lifecycle
-      - kind: path
-        ref: docs/superpowers/specs/2026-07-17-unified-work-lifecycle.md
-      - kind: path
-        ref: docs/superpowers/plans/2026-07-17-unified-work-lifecycle.md
+    - kind: github_issue
+      ref: hamanpaul/paulsha-cortex#14
+    - kind: openspec
+      ref: unified-work-lifecycle
+    - kind: path
+      ref: docs/superpowers/specs/2026-07-17-unified-work-lifecycle.md
+    - kind: path
+      ref: docs/superpowers/plans/2026-07-17-unified-work-lifecycle.md
   docs-only-lifecycle-canary:
     title: Unified lifecycle live canary
     links:
-      - kind: github_issue
-        ref: hamanpaul/paulsha-cortex#20
-      - kind: openspec
-        ref: docs-only-lifecycle-canary
+    - kind: github_issue
+      ref: hamanpaul/paulsha-cortex#20
+    - kind: openspec
+      ref: docs-only-lifecycle-canary
   docs-only-lifecycle-canary-v2:
     title: Unified lifecycle clean live canary
     links:
-      - kind: github_issue
-        ref: hamanpaul/paulsha-cortex#27
-      - kind: openspec
-        ref: docs-only-lifecycle-canary-v2
+    - kind: github_issue
+      ref: hamanpaul/paulsha-cortex#27
+    - kind: openspec
+      ref: docs-only-lifecycle-canary-v2
   porcelain-bootstrap:
     title: porcelain bootstrap (B5)
     links:
-      - kind: github_issue
-        ref: hamanpaul/paulsha-cortex#91
-      - kind: openspec
-        ref: porcelain-bootstrap
-      - kind: path
-        ref: docs/superpowers/workstreams/porcelain-bootstrap/todo.md
+    - kind: github_issue
+      ref: hamanpaul/paulsha-cortex#91
+    - kind: openspec
+      ref: porcelain-bootstrap
+    - kind: path
+      ref: docs/superpowers/workstreams/porcelain-bootstrap/todo.md
   porcelain-service:
     title: porcelain service family (B4)
     links:
-      - kind: github_issue
-        ref: hamanpaul/paulsha-cortex#90
-      - kind: openspec
-        ref: porcelain-service
-      - kind: path
-        ref: docs/superpowers/workstreams/porcelain-service/todo.md
+    - kind: github_issue
+      ref: hamanpaul/paulsha-cortex#90
+    - kind: openspec
+      ref: porcelain-service
+    - kind: path
+      ref: docs/superpowers/workstreams/porcelain-service/todo.md
   porcelain-inspect:
     title: porcelain inspect family (B3)
     links:
-      - kind: github_issue
-        ref: hamanpaul/paulsha-cortex#89
-      - kind: openspec
-        ref: porcelain-inspect
-      - kind: path
-        ref: docs/superpowers/workstreams/porcelain-inspect/todo.md
+    - kind: github_issue
+      ref: hamanpaul/paulsha-cortex#89
+    - kind: openspec
+      ref: porcelain-inspect
+    - kind: path
+      ref: docs/superpowers/workstreams/porcelain-inspect/todo.md
   release-pipeline:
     title: release-pipeline (B9)
     links:
-      - kind: github_issue
-        ref: hamanpaul/paulsha-cortex#95
-      - kind: openspec
-        ref: release-pipeline
-      - kind: path
-        ref: docs/superpowers/workstreams/release-pipeline/todo.md
+    - kind: github_issue
+      ref: hamanpaul/paulsha-cortex#95
+    - kind: openspec
+      ref: release-pipeline
+    - kind: path
+      ref: docs/superpowers/workstreams/release-pipeline/todo.md
   onboarding-docs:
     title: onboarding-docs (B8)
     links:
-      - kind: github_issue
-        ref: hamanpaul/paulsha-cortex#94
-      - kind: openspec
-        ref: onboarding-docs
-      - kind: path
-        ref: docs/superpowers/workstreams/onboarding-docs/todo.md
+    - kind: github_issue
+      ref: hamanpaul/paulsha-cortex#94
+    - kind: openspec
+      ref: onboarding-docs
+    - kind: path
+      ref: docs/superpowers/workstreams/onboarding-docs/todo.md
   porcelain-init-sample:
     title: porcelain init-sample (B7)
     links:
-      - kind: github_issue
-        ref: hamanpaul/paulsha-cortex#93
-      - kind: openspec
-        ref: porcelain-init-sample
-      - kind: path
-        ref: docs/superpowers/workstreams/porcelain-init-sample/todo.md
+    - kind: github_issue
+      ref: hamanpaul/paulsha-cortex#93
+    - kind: openspec
+      ref: porcelain-init-sample
+    - kind: path
+      ref: docs/superpowers/workstreams/porcelain-init-sample/todo.md
   porcelain-run-recover:
     title: porcelain run/recover families (B6)
     links:
-      - kind: github_issue
-        ref: hamanpaul/paulsha-cortex#92
-      - kind: openspec
-        ref: porcelain-run-recover
-      - kind: path
-        ref: docs/superpowers/workstreams/porcelain-run-recover/todo.md
+    - kind: github_issue
+      ref: hamanpaul/paulsha-cortex#92
+    - kind: openspec
+      ref: porcelain-run-recover
+    - kind: path
+      ref: docs/superpowers/workstreams/porcelain-run-recover/todo.md
   porcelain-request:
     title: porcelain request family (B2)
     links:
-      - kind: github_issue
-        ref: hamanpaul/paulsha-cortex#88
-      - kind: openspec
-        ref: porcelain-request
-      - kind: path
-        ref: docs/superpowers/workstreams/porcelain-request/todo.md
+    - kind: github_issue
+      ref: hamanpaul/paulsha-cortex#88
+    - kind: openspec
+      ref: porcelain-request
+    - kind: path
+      ref: docs/superpowers/workstreams/porcelain-request/todo.md
   porcelain-skeleton:
     title: porcelain routing skeleton (B1)
     links:
-      - kind: github_issue
-        ref: hamanpaul/paulsha-cortex#87
-      - kind: openspec
-        ref: porcelain-skeleton
-      - kind: path
-        ref: docs/superpowers/workstreams/porcelain-skeleton/todo.md
+    - kind: github_issue
+      ref: hamanpaul/paulsha-cortex#87
+    - kind: openspec
+      ref: porcelain-skeleton
+    - kind: path
+      ref: docs/superpowers/workstreams/porcelain-skeleton/todo.md
   add-cortex-version-flag:
     title: cortex --version flag (porcelain dogfood canary)
     links:
-      - kind: github_issue
-        ref: hamanpaul/paulsha-cortex#86
-      - kind: openspec
-        ref: add-cortex-version-flag
-      - kind: path
-        ref: docs/superpowers/workstreams/add-cortex-version-flag/todo.md
-      - kind: path
-        ref: docs/superpowers/specs/add-cortex-version-flag-spec.md
-      - kind: path
-        ref: docs/superpowers/plans/add-cortex-version-flag.md
+    - kind: github_issue
+      ref: hamanpaul/paulsha-cortex#86
+    - kind: openspec
+      ref: add-cortex-version-flag
+    - kind: path
+      ref: docs/superpowers/workstreams/add-cortex-version-flag/todo.md
+    - kind: path
+      ref: docs/superpowers/specs/add-cortex-version-flag-spec.md
+    - kind: path
+      ref: docs/superpowers/plans/add-cortex-version-flag.md
   terminal-lifecycle-canary:
     title: Unified lifecycle terminal live canary
     links:
-      - kind: github_issue
-        ref: hamanpaul/paulsha-cortex#31
-      - kind: openspec
-        ref: terminal-lifecycle-canary
-      - kind: path
-        ref: docs/superpowers/workstreams/terminal-lifecycle-canary/todo.md
+    - kind: github_issue
+      ref: hamanpaul/paulsha-cortex#31
+    - kind: openspec
+      ref: terminal-lifecycle-canary
+    - kind: path
+      ref: docs/superpowers/workstreams/terminal-lifecycle-canary/todo.md
   fix-git-runner-cwd:
     title: fix git runner cwd coupling (#99)
     links:
-      - kind: github_issue
-        ref: hamanpaul/paulsha-cortex#99
-      - kind: openspec
-        ref: 2026-07-25-fix-git-runner-cwd
-      - kind: path
-        ref: docs/superpowers/workstreams/fix-git-runner-cwd/todo.md
-      - kind: path
-        ref: docs/superpowers/specs/fix-git-runner-cwd-spec.md
-      - kind: path
-        ref: docs/superpowers/specs/fix-git-runner-cwd-design.md
-      - kind: path
-        ref: docs/superpowers/plans/fix-git-runner-cwd.md
+    - kind: github_issue
+      ref: hamanpaul/paulsha-cortex#99
+    - kind: openspec
+      ref: 2026-07-25-fix-git-runner-cwd
+    - kind: path
+      ref: docs/superpowers/workstreams/fix-git-runner-cwd/todo.md
+    - kind: path
+      ref: docs/superpowers/specs/fix-git-runner-cwd-spec.md
+    - kind: path
+      ref: docs/superpowers/specs/fix-git-runner-cwd-design.md
+    - kind: path
+      ref: docs/superpowers/plans/fix-git-runner-cwd.md
   fix-dispatch-exception-detail:
     title: fix DispatchReadyError detail + manager.log timestamp (#100)
     links:
-      - kind: github_issue
-        ref: hamanpaul/paulsha-cortex#100
-      - kind: openspec
-        ref: 2026-07-25-fix-dispatch-exception-detail
-      - kind: path
-        ref: docs/superpowers/workstreams/fix-dispatch-exception-detail/todo.md
-      - kind: path
-        ref: docs/superpowers/specs/fix-dispatch-exception-detail-spec.md
-      - kind: path
-        ref: docs/superpowers/specs/fix-dispatch-exception-detail-design.md
-      - kind: path
-        ref: docs/superpowers/plans/fix-dispatch-exception-detail.md
+    - kind: github_issue
+      ref: hamanpaul/paulsha-cortex#100
+    - kind: openspec
+      ref: 2026-07-25-fix-dispatch-exception-detail
+    - kind: path
+      ref: docs/superpowers/workstreams/fix-dispatch-exception-detail/todo.md
+    - kind: path
+      ref: docs/superpowers/specs/fix-dispatch-exception-detail-spec.md
+    - kind: path
+      ref: docs/superpowers/specs/fix-dispatch-exception-detail-design.md
+    - kind: path
+      ref: docs/superpowers/plans/fix-dispatch-exception-detail.md
   fix-mutation-request-timeout:
     title: fix mutation request 5s timeout (#152)
     links:
-      - kind: github_issue
-        ref: hamanpaul/paulsha-cortex#152
-      - kind: openspec
-        ref: 2026-07-25-fix-mutation-request-timeout
-      - kind: path
-        ref: docs/superpowers/workstreams/fix-mutation-request-timeout/todo.md
-      - kind: path
-        ref: docs/superpowers/specs/fix-mutation-request-timeout-spec.md
-      - kind: path
-        ref: docs/superpowers/specs/fix-mutation-request-timeout-design.md
-      - kind: path
-        ref: docs/superpowers/plans/fix-mutation-request-timeout.md
+    - kind: github_issue
+      ref: hamanpaul/paulsha-cortex#152
+    - kind: openspec
+      ref: 2026-07-25-fix-mutation-request-timeout
+    - kind: path
+      ref: docs/superpowers/workstreams/fix-mutation-request-timeout/todo.md
+    - kind: path
+      ref: docs/superpowers/specs/fix-mutation-request-timeout-spec.md
+    - kind: path
+      ref: docs/superpowers/specs/fix-mutation-request-timeout-design.md
+    - kind: path
+      ref: docs/superpowers/plans/fix-mutation-request-timeout.md
   multi-issue-worktree:
     title: multi-issue Work Item + repo-scoped builder worktree (#134)
     links:
-      - kind: github_issue
-        ref: hamanpaul/paulsha-cortex#134
-      - kind: openspec
-        ref: 2026-07-26-multi-issue-worktree
-      - kind: path
-        ref: docs/superpowers/workstreams/multi-issue-worktree/todo.md
-      - kind: path
-        ref: docs/superpowers/specs/multi-issue-worktree-spec.md
-      - kind: path
-        ref: docs/superpowers/specs/multi-issue-worktree-design.md
-      - kind: path
-        ref: docs/superpowers/plans/multi-issue-worktree.md
+    - kind: github_issue
+      ref: hamanpaul/paulsha-cortex#134
+    - kind: openspec
+      ref: 2026-07-26-multi-issue-worktree
+    - kind: path
+      ref: docs/superpowers/workstreams/multi-issue-worktree/todo.md
+    - kind: path
+      ref: docs/superpowers/specs/multi-issue-worktree-spec.md
+    - kind: path
+      ref: docs/superpowers/specs/multi-issue-worktree-design.md
+    - kind: path
+      ref: docs/superpowers/plans/multi-issue-worktree.md
   reclaim-pr-inheritance:
     title: re-claim PR inheritance + closed-unmapped terminal correlation (#175)
     links:
-      - kind: github_issue
-        ref: hamanpaul/paulsha-cortex#175
-      - kind: openspec
-        ref: 2026-07-26-reclaim-pr-inheritance
-      - kind: path
-        ref: docs/superpowers/workstreams/reclaim-pr-inheritance/todo.md
-      - kind: path
-        ref: docs/superpowers/specs/reclaim-pr-inheritance-spec.md
-      - kind: path
-        ref: docs/superpowers/specs/reclaim-pr-inheritance-design.md
-      - kind: path
-        ref: docs/superpowers/plans/reclaim-pr-inheritance.md
+    - kind: github_issue
+      ref: hamanpaul/paulsha-cortex#175
+    - kind: openspec
+      ref: 2026-07-26-reclaim-pr-inheritance
+    - kind: path
+      ref: docs/superpowers/workstreams/reclaim-pr-inheritance/todo.md
+    - kind: path
+      ref: docs/superpowers/specs/reclaim-pr-inheritance-spec.md
+    - kind: path
+      ref: docs/superpowers/specs/reclaim-pr-inheritance-design.md
+    - kind: path
+      ref: docs/superpowers/plans/reclaim-pr-inheritance.md
   driving-cortex-skill:
     title: driving-cortex skill (#177)
     links:
-      - kind: github_issue
-        ref: hamanpaul/paulsha-cortex#177
-      - kind: openspec
-        ref: 2026-07-26-driving-cortex-skill
-      - kind: path
-        ref: docs/superpowers/workstreams/driving-cortex-skill/todo.md
-      - kind: path
-        ref: docs/superpowers/specs/driving-cortex-skill-spec.md
-      - kind: path
-        ref: docs/superpowers/specs/driving-cortex-skill-design.md
-      - kind: path
-        ref: docs/superpowers/plans/driving-cortex-skill.md
+    - kind: github_issue
+      ref: hamanpaul/paulsha-cortex#177
+    - kind: openspec
+      ref: 2026-07-26-driving-cortex-skill
+    - kind: path
+      ref: docs/superpowers/workstreams/driving-cortex-skill/todo.md
+    - kind: path
+      ref: docs/superpowers/specs/driving-cortex-skill-spec.md
+    - kind: path
+      ref: docs/superpowers/specs/driving-cortex-skill-design.md
+    - kind: path
+      ref: docs/superpowers/plans/driving-cortex-skill.md
   fix-dispatch-spec-path:
     title: fix dispatch spec path resolution (#98)
     links:
-      - kind: github_issue
-        ref: hamanpaul/paulsha-cortex#98
-      - kind: openspec
-        ref: 2026-07-26-fix-dispatch-spec-path
-      - kind: path
-        ref: docs/superpowers/specs/fix-dispatch-spec-path-spec.md
-      - kind: path
-        ref: docs/superpowers/specs/fix-dispatch-spec-path-design.md
-      - kind: path
-        ref: docs/superpowers/plans/fix-dispatch-spec-path.md
+    - kind: github_issue
+      ref: hamanpaul/paulsha-cortex#98
+    - kind: openspec
+      ref: 2026-07-26-fix-dispatch-spec-path
+    - kind: path
+      ref: docs/superpowers/specs/fix-dispatch-spec-path-spec.md
+    - kind: path
+      ref: docs/superpowers/specs/fix-dispatch-spec-path-design.md
+    - kind: path
+      ref: docs/superpowers/plans/fix-dispatch-spec-path.md
   fix-deck-emit-frontmatter:
     title: fix deck emit frontmatter for dispatch contract (#101)
     links:
-      - kind: github_issue
-        ref: hamanpaul/paulsha-cortex#101
-      - kind: openspec
-        ref: 2026-07-26-fix-deck-emit-frontmatter
-      - kind: path
-        ref: docs/superpowers/specs/fix-deck-emit-frontmatter-spec.md
-      - kind: path
-        ref: docs/superpowers/specs/fix-deck-emit-frontmatter-design.md
-      - kind: path
-        ref: docs/superpowers/plans/fix-deck-emit-frontmatter.md
+    - kind: github_issue
+      ref: hamanpaul/paulsha-cortex#101
+    - kind: openspec
+      ref: 2026-07-26-fix-deck-emit-frontmatter
+    - kind: path
+      ref: docs/superpowers/specs/fix-deck-emit-frontmatter-spec.md
+    - kind: path
+      ref: docs/superpowers/specs/fix-deck-emit-frontmatter-design.md
+    - kind: path
+      ref: docs/superpowers/plans/fix-deck-emit-frontmatter.md
   fix-builder-write-paths:
     title: fix builder write_paths cross-repo (#118)
     links:
-      - kind: github_issue
-        ref: hamanpaul/paulsha-cortex#118
-      - kind: openspec
-        ref: 2026-07-26-fix-builder-write-paths
-      - kind: path
-        ref: docs/superpowers/specs/fix-builder-write-paths-spec.md
-      - kind: path
-        ref: docs/superpowers/specs/fix-builder-write-paths-design.md
-      - kind: path
-        ref: docs/superpowers/plans/fix-builder-write-paths.md
+    - kind: github_issue
+      ref: hamanpaul/paulsha-cortex#118
+    - kind: openspec
+      ref: 2026-07-26-fix-builder-write-paths
+    - kind: path
+      ref: docs/superpowers/specs/fix-builder-write-paths-spec.md
+    - kind: path
+      ref: docs/superpowers/specs/fix-builder-write-paths-design.md
+    - kind: path
+      ref: docs/superpowers/plans/fix-builder-write-paths.md
   docs-monitor-load-config:
     title: docs monitor load_config explicit/ambient (#143)
     links:
-      - kind: github_issue
-        ref: hamanpaul/paulsha-cortex#143
-      - kind: openspec
-        ref: 2026-07-26-docs-monitor-load-config
-      - kind: path
-        ref: docs/superpowers/specs/docs-monitor-load-config-spec.md
-      - kind: path
-        ref: docs/superpowers/specs/docs-monitor-load-config-design.md
-      - kind: path
-        ref: docs/superpowers/plans/docs-monitor-load-config.md
+    - kind: github_issue
+      ref: hamanpaul/paulsha-cortex#143
+    - kind: openspec
+      ref: 2026-07-26-docs-monitor-load-config
+    - kind: path
+      ref: docs/superpowers/specs/docs-monitor-load-config-spec.md
+    - kind: path
+      ref: docs/superpowers/specs/docs-monitor-load-config-design.md
+    - kind: path
+      ref: docs/superpowers/plans/docs-monitor-load-config.md
   fix-service-install-overwrite:
     title: fix service install overwrite guard (#148)
     links:
-      - kind: github_issue
-        ref: hamanpaul/paulsha-cortex#148
-      - kind: openspec
-        ref: 2026-07-26-fix-service-install-overwrite
-      - kind: path
-        ref: docs/superpowers/specs/fix-service-install-overwrite-spec.md
-      - kind: path
-        ref: docs/superpowers/specs/fix-service-install-overwrite-design.md
-      - kind: path
-        ref: docs/superpowers/plans/fix-service-install-overwrite.md
+    - kind: github_issue
+      ref: hamanpaul/paulsha-cortex#148
+    - kind: openspec
+      ref: 2026-07-26-fix-service-install-overwrite
+    - kind: path
+      ref: docs/superpowers/specs/fix-service-install-overwrite-spec.md
+    - kind: path
+      ref: docs/superpowers/specs/fix-service-install-overwrite-design.md
+    - kind: path
+      ref: docs/superpowers/plans/fix-service-install-overwrite.md
   fix-slice-failed-deadend:
     title: fix slice failed state dead-end (#153)
     links:
-      - kind: github_issue
-        ref: hamanpaul/paulsha-cortex#153
-      - kind: openspec
-        ref: 2026-07-26-fix-slice-failed-deadend
-      - kind: path
-        ref: docs/superpowers/specs/fix-slice-failed-deadend-spec.md
-      - kind: path
-        ref: docs/superpowers/specs/fix-slice-failed-deadend-design.md
-      - kind: path
-        ref: docs/superpowers/plans/fix-slice-failed-deadend.md
+    - kind: github_issue
+      ref: hamanpaul/paulsha-cortex#153
+    - kind: openspec
+      ref: 2026-07-26-fix-slice-failed-deadend
+    - kind: path
+      ref: docs/superpowers/specs/fix-slice-failed-deadend-spec.md
+    - kind: path
+      ref: docs/superpowers/specs/fix-slice-failed-deadend-design.md
+    - kind: path
+      ref: docs/superpowers/plans/fix-slice-failed-deadend.md
   docs-archived-spec-purpose:
     title: docs archived spec Purpose TBD (#158)
     links:
-      - kind: github_issue
-        ref: hamanpaul/paulsha-cortex#158
-      - kind: openspec
-        ref: 2026-07-26-docs-archived-spec-purpose
-      - kind: path
-        ref: docs/superpowers/specs/docs-archived-spec-purpose-spec.md
-      - kind: path
-        ref: docs/superpowers/specs/docs-archived-spec-purpose-design.md
-      - kind: path
-        ref: docs/superpowers/plans/docs-archived-spec-purpose.md
+    - kind: github_issue
+      ref: hamanpaul/paulsha-cortex#158
+    - kind: openspec
+      ref: 2026-07-26-docs-archived-spec-purpose
+    - kind: path
+      ref: docs/superpowers/specs/docs-archived-spec-purpose-spec.md
+    - kind: path
+      ref: docs/superpowers/specs/docs-archived-spec-purpose-design.md
+    - kind: path
+      ref: docs/superpowers/plans/docs-archived-spec-purpose.md
   test-r21-regex-resilience:
     title: test R-21 regex resilience CRLF + Windows (#169)
     links:
-      - kind: github_issue
-        ref: hamanpaul/paulsha-cortex#169
-      - kind: openspec
-        ref: 2026-07-26-test-r21-regex-resilience
-      - kind: path
-        ref: docs/superpowers/specs/test-r21-regex-resilience-spec.md
-      - kind: path
-        ref: docs/superpowers/specs/test-r21-regex-resilience-design.md
-      - kind: path
-        ref: docs/superpowers/plans/test-r21-regex-resilience.md
+    - kind: github_issue
+      ref: hamanpaul/paulsha-cortex#169
+    - kind: openspec
+      ref: 2026-07-26-test-r21-regex-resilience
+    - kind: path
+      ref: docs/superpowers/specs/test-r21-regex-resilience-spec.md
+    - kind: path
+      ref: docs/superpowers/specs/test-r21-regex-resilience-design.md
+    - kind: path
+      ref: docs/superpowers/plans/test-r21-regex-resilience.md
   dispatch-reliability-batch:
-    title: dispatch reliability batch (abandoned, #134)
+    title: dispatch reliability batch (abandoned,
     links: []
     excludes:
-      - kind: github_issue
-        ref: hamanpaul/paulsha-cortex#99
-      - kind: github_issue
-        ref: hamanpaul/paulsha-cortex#100
-      - kind: github_issue
-        ref: hamanpaul/paulsha-cortex#152
+    - kind: github_issue
+      ref: hamanpaul/paulsha-cortex#99
+    - kind: github_issue
+      ref: hamanpaul/paulsha-cortex#100
+    - kind: github_issue
+      ref: hamanpaul/paulsha-cortex#152
   terminal-result-contract:
     title: terminal/result contract 誠實表達 gate failure (#261)
     links:
-      - kind: github_issue
-        ref: hamanpaul/paulsha-cortex#261
-      - kind: openspec
-        ref: 2026-07-30-terminal-result-contract
-      - kind: path
-        ref: docs/superpowers/workstreams/terminal-result-contract/todo.md
-      - kind: path
-        ref: docs/superpowers/specs/terminal-result-contract-spec.md
+    - kind: github_issue
+      ref: hamanpaul/paulsha-cortex#261
+    - kind: openspec
+      ref: 2026-07-30-terminal-result-contract
+    - kind: path
+      ref: docs/superpowers/workstreams/terminal-result-contract/todo.md
+    - kind: path
+      ref: docs/superpowers/specs/terminal-result-contract-spec.md
   planning-claim-recovery:
     title: planning claim 前向恢復與 abandon 釋放語意 (#256)
     links:
-      - kind: github_issue
-        ref: hamanpaul/paulsha-cortex#256
-      - kind: openspec
-        ref: 2026-07-30-planning-claim-recovery
-      - kind: path
-        ref: docs/superpowers/workstreams/planning-claim-recovery/todo.md
-      - kind: path
-        ref: docs/superpowers/specs/planning-claim-recovery-spec.md
+    - kind: github_issue
+      ref: hamanpaul/paulsha-cortex#256
+    - kind: openspec
+      ref: 2026-07-30-planning-claim-recovery
+    - kind: path
+      ref: docs/superpowers/workstreams/planning-claim-recovery/todo.md
+    - kind: path
+      ref: docs/superpowers/specs/planning-claim-recovery-spec.md
   dispatch-runtime-preflight:
     title: dispatch 前 runtime capability 與 provider 新鮮度驗證 (#262)
     links:
-      - kind: github_issue
-        ref: hamanpaul/paulsha-cortex#262
-      - kind: openspec
-        ref: 2026-07-30-dispatch-runtime-preflight
-      - kind: path
-        ref: docs/superpowers/workstreams/dispatch-runtime-preflight/todo.md
-      - kind: path
-        ref: docs/superpowers/specs/dispatch-runtime-preflight-spec.md
+    - kind: github_issue
+      ref: hamanpaul/paulsha-cortex#262
+    - kind: openspec
+      ref: 2026-07-30-dispatch-runtime-preflight
+    - kind: path
+      ref: docs/superpowers/workstreams/dispatch-runtime-preflight/todo.md
+    - kind: path
+      ref: docs/superpowers/specs/dispatch-runtime-preflight-spec.md
   per-work-model-chain:
     title: per-work 模型鏈覆寫 (#205)
     links:
-      - kind: github_issue
-        ref: hamanpaul/paulsha-cortex#205
-      - kind: openspec
-        ref: 2026-07-30-per-work-model-chain
-      - kind: path
-        ref: docs/superpowers/workstreams/per-work-model-chain/todo.md
-      - kind: path
-        ref: docs/superpowers/specs/per-work-model-chain-spec.md
+    - kind: github_issue
+      ref: hamanpaul/paulsha-cortex#205
+    - kind: openspec
+      ref: 2026-07-30-per-work-model-chain
+    - kind: path
+      ref: docs/superpowers/workstreams/per-work-model-chain/todo.md
+    - kind: path
+      ref: docs/superpowers/specs/per-work-model-chain-spec.md
   persona-enforce-required-check:
     title: persona enforcement 切 enforce 並設 required check (#135)
     links:
-      - kind: github_issue
-        ref: hamanpaul/paulsha-cortex#135
-      - kind: openspec
-        ref: 2026-07-30-persona-enforce-required-check
-      - kind: path
-        ref: docs/superpowers/workstreams/persona-enforce-required-check/todo.md
-      - kind: path
-        ref: docs/superpowers/specs/persona-enforce-required-check-spec.md
+    - kind: github_issue
+      ref: hamanpaul/paulsha-cortex#135
+    - kind: openspec
+      ref: 2026-07-30-persona-enforce-required-check
+    - kind: path
+      ref: docs/superpowers/workstreams/persona-enforce-required-check/todo.md
+    - kind: path
+      ref: docs/superpowers/specs/persona-enforce-required-check-spec.md
   fix-persona-catalog-portability-v2:
     title: persona catalog 可攜性 v2 重識別——#218 世代熔斷後續作 (#295/#291)
     links:
-      - kind: github_issue
-        ref: hamanpaul/paulsha-cortex#295
-      - kind: github_issue
-        ref: hamanpaul/paulsha-cortex#291
-      - kind: openspec
-        ref: 2026-08-04-fix-persona-catalog-portability
-      - kind: path
-        ref: docs/superpowers/workstreams/fix-persona-catalog-portability-v2/todo.md
-      - kind: path
-        ref: docs/superpowers/specs/fix-persona-catalog-portability-v2-spec.md
-      - kind: path
-        ref: docs/superpowers/specs/fix-persona-catalog-portability-v2-design.md
-      - kind: path
-        ref: docs/superpowers/plans/fix-persona-catalog-portability-v2.md
+    - kind: github_issue
+      ref: hamanpaul/paulsha-cortex#295
+    - kind: github_issue
+      ref: hamanpaul/paulsha-cortex#291
+    - kind: openspec
+      ref: 2026-08-04-fix-persona-catalog-portability
+    - kind: path
+      ref: docs/superpowers/workstreams/fix-persona-catalog-portability-v2/todo.md
+    - kind: path
+      ref: docs/superpowers/specs/fix-persona-catalog-portability-v2-spec.md
+    - kind: path
+      ref: docs/superpowers/specs/fix-persona-catalog-portability-v2-design.md
+    - kind: path
+      ref: docs/superpowers/plans/fix-persona-catalog-portability-v2.md
   fix-repair-commit-recovery:
     title: repair commit 缺 terminal evidence 的窄化恢復與 stale job 選擇修正 (#260)
     links:
-      - kind: github_issue
-        ref: hamanpaul/paulsha-cortex#260
-      - kind: openspec
-        ref: 2026-08-04-fix-repair-commit-recovery
-      - kind: path
-        ref: docs/superpowers/workstreams/fix-repair-commit-recovery/todo.md
-      - kind: path
-        ref: docs/superpowers/specs/fix-repair-commit-recovery-spec.md
+    - kind: github_issue
+      ref: hamanpaul/paulsha-cortex#260
+    - kind: openspec
+      ref: 2026-08-04-fix-repair-commit-recovery
+    - kind: path
+      ref: docs/superpowers/workstreams/fix-repair-commit-recovery/todo.md
+    - kind: path
+      ref: docs/superpowers/specs/fix-repair-commit-recovery-spec.md
   feat-work-gc:
     title: feat-work-gc（已由 -v2 重識別接手；舊 runs 為 superseded 審計）
     links:
-      - kind: path
-        ref: docs/superpowers/workstreams/feat-work-gc/todo.md
+    - kind: path
+      ref: docs/superpowers/workstreams/feat-work-gc/todo.md
   design-task-type-taxonomy:
     title: design-task-type-taxonomy（已由 -v2 重識別接手；舊 runs 為 superseded 審計）
     links:
-      - kind: path
-        ref: docs/superpowers/workstreams/design-task-type-taxonomy/todo.md
+    - kind: path
+      ref: docs/superpowers/workstreams/design-task-type-taxonomy/todo.md
   feat-work-gc-v2:
     title: cortex work gc v2 重識別——世代熔斷後續作 (#178)
     links:
-      - kind: path
-        ref: docs/superpowers/workstreams/feat-work-gc-v2/todo.md
-      - kind: path
-        ref: docs/superpowers/specs/feat-work-gc-v2-spec.md
+    - kind: path
+      ref: docs/superpowers/workstreams/feat-work-gc-v2/todo.md
+    - kind: path
+      ref: docs/superpowers/specs/feat-work-gc-v2-spec.md
   design-task-type-taxonomy-v2:
     title: task_type taxonomy v2 重識別——世代熔斷後續作 (#139)
     links:
-      - kind: path
-        ref: docs/superpowers/workstreams/design-task-type-taxonomy-v2/todo.md
-      - kind: path
-        ref: docs/superpowers/specs/design-task-type-taxonomy-v2-spec.md
+    - kind: path
+      ref: docs/superpowers/workstreams/design-task-type-taxonomy-v2/todo.md
+    - kind: path
+      ref: docs/superpowers/specs/design-task-type-taxonomy-v2-spec.md
   feat-slice-executor-model:
     title: per-slice executor/model 宣告與 depends_on 顯式診斷 (#294)
     links:
-      - kind: github_issue
-        ref: hamanpaul/paulsha-cortex#294
-      - kind: openspec
-        ref: 2026-08-04-feat-slice-executor-model
-      - kind: path
-        ref: docs/superpowers/workstreams/feat-slice-executor-model/todo.md
-      - kind: path
-        ref: docs/superpowers/specs/feat-slice-executor-model-spec.md
-      - kind: path
-        ref: docs/superpowers/specs/feat-slice-executor-model-design.md
-      - kind: path
-        ref: docs/superpowers/plans/feat-slice-executor-model.md
+    - kind: github_issue
+      ref: hamanpaul/paulsha-cortex#294
+    - kind: openspec
+      ref: 2026-08-04-feat-slice-executor-model
+    - kind: path
+      ref: docs/superpowers/workstreams/feat-slice-executor-model/todo.md
+    - kind: path
+      ref: docs/superpowers/specs/feat-slice-executor-model-spec.md
+    - kind: path
+      ref: docs/superpowers/specs/feat-slice-executor-model-design.md
+    - kind: path
+      ref: docs/superpowers/plans/feat-slice-executor-model.md
   fix-preflight-closeout-order:
     title: 本地 closeout 先於 PR metadata preflight 與 frozen artifacts materialize (#263)
     links:
-      - kind: github_issue
-        ref: hamanpaul/paulsha-cortex#263
-      - kind: openspec
-        ref: 2026-08-04-fix-preflight-closeout-order
-      - kind: path
-        ref: docs/superpowers/workstreams/fix-preflight-closeout-order/todo.md
-      - kind: path
-        ref: docs/superpowers/specs/fix-preflight-closeout-order-spec.md
-      - kind: path
-        ref: docs/superpowers/specs/fix-preflight-closeout-order-design.md
-      - kind: path
-        ref: docs/superpowers/plans/fix-preflight-closeout-order.md
+    - kind: github_issue
+      ref: hamanpaul/paulsha-cortex#263
+    - kind: openspec
+      ref: 2026-08-04-fix-preflight-closeout-order
+    - kind: path
+      ref: docs/superpowers/workstreams/fix-preflight-closeout-order/todo.md
+    - kind: path
+      ref: docs/superpowers/specs/fix-preflight-closeout-order-spec.md
+    - kind: path
+      ref: docs/superpowers/specs/fix-preflight-closeout-order-design.md
+    - kind: path
+      ref: docs/superpowers/plans/fix-preflight-closeout-order.md
   feat-task-type-combo-selector:
     title: task_type 自動選 combo 與 fix-standard combo (#202)
     links:
-      - kind: github_issue
-        ref: hamanpaul/paulsha-cortex#202
-      - kind: openspec
-        ref: 2026-08-04-feat-task-type-combo-selector
-      - kind: path
-        ref: docs/superpowers/workstreams/feat-task-type-combo-selector/todo.md
-      - kind: path
-        ref: docs/superpowers/specs/feat-task-type-combo-selector-spec.md
-      - kind: path
-        ref: docs/superpowers/specs/feat-task-type-combo-selector-design.md
-      - kind: path
-        ref: docs/superpowers/plans/feat-task-type-combo-selector.md
+    - kind: github_issue
+      ref: hamanpaul/paulsha-cortex#202
+    - kind: openspec
+      ref: 2026-08-04-feat-task-type-combo-selector
+    - kind: path
+      ref: docs/superpowers/workstreams/feat-task-type-combo-selector/todo.md
+    - kind: path
+      ref: docs/superpowers/specs/feat-task-type-combo-selector-spec.md
+    - kind: path
+      ref: docs/superpowers/specs/feat-task-type-combo-selector-design.md
+    - kind: path
+      ref: docs/superpowers/plans/feat-task-type-combo-selector.md
+  fix-log-error-dedup:
+    title: manager_daemon _log_error 多槽去重
+    links:
+    - kind: github_issue
+      ref: hamanpaul/paulsha-cortex#374
+    excludes: []
+  fix-deck-verification-skeleton:
+    title: deck compile verification 骨架由 project policy 導出
+    links:
+    - kind: github_issue
+      ref: hamanpaul/paulsha-cortex#380
+    excludes: []
+  fix-packaging-release-path:
+    title: README release 安裝路徑與 packaging smoke matrix
+    links:
+    - kind: github_issue
+      ref: hamanpaul/paulsha-cortex#385
+    excludes: []
+  feat-digest-outbox:
+    title: 排程觸發的跨系統 digest 出口
+    links:
+    - kind: github_issue
+      ref: hamanpaul/paulsha-cortex#372
+    excludes: []
+  fix-authority-restart-loop:
+    title: authority-restart 迴圈與 binding mismatch 抑制
+    links:
+    - kind: github_issue
+      ref: hamanpaul/paulsha-cortex#373
+    excludes: []
+  fix-registry-atomic-transitions:
+    title: record_action 原子性與 gate_state 轉換表
+    links:
+    - kind: github_issue
+      ref: hamanpaul/paulsha-cortex#382
+    excludes: []
+  fix-handoff-manifest-reconcile:
+    title: 殘留 handoff manifest 與 registry 對帳
+    links:
+    - kind: github_issue
+      ref: hamanpaul/paulsha-cortex#383
+    excludes: []
+  fix-installer-managed-env:
+    title: installer managed_env 與 lock/specs 路徑合併修正
+    links:
+    - kind: github_issue
+      ref: hamanpaul/paulsha-cortex#371
+    - kind: github_issue
+      ref: hamanpaul/paulsha-cortex#375
+    excludes: []
+  fix-rate-limit-classification:
+    title: GitHub rate limit 分類與 durable 退避
+    links:
+    - kind: github_issue
+      ref: hamanpaul/paulsha-cortex#370
+    excludes: []
+  fix-spawn-admission-limiter:
+    title: per-provider spawn admission limiter
+    links:
+    - kind: github_issue
+      ref: hamanpaul/paulsha-cortex#381
+    excludes: []
+  feat-executor-auth-preflight:
+    title: dispatch 前 executor 登入態驗證與 provider 探測接線
+    links:
+    - kind: github_issue
+      ref: hamanpaul/paulsha-cortex#369
+    excludes: []
+  feat-provider-failure-semantics:
+    title: LLM provider failure typed semantics 與 bounded recovery
+    links:
+    - kind: github_issue
+      ref: hamanpaul/paulsha-cortex#384
+    excludes: []
+  feat-adversarial-evidence-review:
+    title: 對抗式 evidence 驗證掛卡
+    links:
+    - kind: github_issue
+      ref: hamanpaul/paulsha-cortex#378
+    excludes: []
+  fix-gate-provenance:
+    title: gate 清單來源改 spec/plan 導出與判準不可變
+    links:
+    - kind: github_issue
+      ref: hamanpaul/paulsha-cortex#379
+    excludes: []

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 
 ## [Unreleased]
 
+### Added
+- **open-issue 批次（369–385）work item 進件登錄**：`.cortex/work-items.yaml` 新增 14 個 work item 條目，將 15 張 open issue（369、370、371、372、373、374、375、378、379、380、381、382、383、384、385）連結為可 claim 的 work authority；371 與 375 因同動 `installer.py` 的 `managed_env`／`preserve_existing` 而合併為單一 work item（`fix-installer-managed-env`）避免平行修改互撞；386 為 tracking gate 不建 work item。各 work item 的規劃權威為對應 issue 上 2026-08-10 的獨立複驗 comment（含 root cause 更正與修復標的）。純進件登錄，不含任何實作。
+
 ## [0.1.4] - 2026-08-08
 
 ### Changed

--- a/changelog.d/work-items-intake-batch.md
+++ b/changelog.d/work-items-intake-batch.md
@@ -1,0 +1,2 @@
+### Added
+- **open-issue 批次（369–385）work item 進件登錄**：`.cortex/work-items.yaml` 新增 14 個 work item 條目，將 15 張 open issue（369、370、371、372、373、374、375、378、379、380、381、382、383、384、385）連結為可 claim 的 work authority；371 與 375 因同動 `installer.py` 的 `managed_env`／`preserve_existing` 而合併為單一 work item（`fix-installer-managed-env`）避免平行修改互撞；386 為 tracking gate 不建 work item。各 work item 的規劃權威為對應 issue 上 2026-08-10 的獨立複驗 comment（含 root cause 更正與修復標的）。純進件登錄，不含任何實作。


### PR DESCRIPTION
## 目的
為 open-issue 批次（369–385）建立 cortex work item 進件登錄，讓後續修復可經 `cortex work intake` 走治理管線派工。

## 變更
- `.cortex/work-items.yaml`：新增 14 個 work item 條目——371 與 375 因同動 installer 的 `managed_env`／`preserve_existing` 合併為 `fix-installer-managed-env`；386 為 tracking gate 不建 work item
- `changelog.d/work-items-intake-batch.md` 與 `CHANGELOG.md [Unreleased]` 對應 entry

## 不含
任何實作——純進件登錄。各 work item 的規劃權威為對應 issue 上 2026-08-10 的獨立複驗 comment。

## Checklist
- [x] changelog.d fragment 已新增且已 commit
- [x] CHANGELOG.md [Unreleased] 有對應 entry
- [x] VERSION 與 latest tag 一致（非 release PR）
- [x] policy_check 已帶 PR 上下文本機通過


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TstQEugFEoQt3WzrkBn3zc
