### PR TITLE
chore(work): open-issue 批次 workstream todo 錨點（369–385）

### DIFF
--- a/.cortex/work-items.yaml
+++ b/.cortex/work-items.yaml
@@ -489,42 +489,56 @@ work_items:
     links:
     - kind: github_issue
       ref: hamanpaul/paulsha-cortex#374
+    - kind: path
+      ref: docs/superpowers/workstreams/fix-log-error-dedup/todo.md
     excludes: []
   fix-deck-verification-skeleton:
     title: deck compile verification 骨架由 project policy 導出
     links:
     - kind: github_issue
       ref: hamanpaul/paulsha-cortex#380
+    - kind: path
+      ref: docs/superpowers/workstreams/fix-deck-verification-skeleton/todo.md
     excludes: []
   fix-packaging-release-path:
     title: README release 安裝路徑與 packaging smoke matrix
     links:
     - kind: github_issue
       ref: hamanpaul/paulsha-cortex#385
+    - kind: path
+      ref: docs/superpowers/workstreams/fix-packaging-release-path/todo.md
     excludes: []
   feat-digest-outbox:
     title: 排程觸發的跨系統 digest 出口
     links:
     - kind: github_issue
       ref: hamanpaul/paulsha-cortex#372
+    - kind: path
+      ref: docs/superpowers/workstreams/feat-digest-outbox/todo.md
     excludes: []
   fix-authority-restart-loop:
     title: authority-restart 迴圈與 binding mismatch 抑制
     links:
     - kind: github_issue
       ref: hamanpaul/paulsha-cortex#373
+    - kind: path
+      ref: docs/superpowers/workstreams/fix-authority-restart-loop/todo.md
     excludes: []
   fix-registry-atomic-transitions:
     title: record_action 原子性與 gate_state 轉換表
     links:
     - kind: github_issue
       ref: hamanpaul/paulsha-cortex#382
+    - kind: path
+      ref: docs/superpowers/workstreams/fix-registry-atomic-transitions/todo.md
     excludes: []
   fix-handoff-manifest-reconcile:
     title: 殘留 handoff manifest 與 registry 對帳
     links:
     - kind: github_issue
       ref: hamanpaul/paulsha-cortex#383
+    - kind: path
+      ref: docs/superpowers/workstreams/fix-handoff-manifest-reconcile/todo.md
     excludes: []
   fix-installer-managed-env:
     title: installer managed_env 與 lock/specs 路徑合併修正
@@ -533,40 +547,54 @@ work_items:
       ref: hamanpaul/paulsha-cortex#371
     - kind: github_issue
       ref: hamanpaul/paulsha-cortex#375
+    - kind: path
+      ref: docs/superpowers/workstreams/fix-installer-managed-env/todo.md
     excludes: []
   fix-rate-limit-classification:
     title: GitHub rate limit 分類與 durable 退避
     links:
     - kind: github_issue
       ref: hamanpaul/paulsha-cortex#370
+    - kind: path
+      ref: docs/superpowers/workstreams/fix-rate-limit-classification/todo.md
     excludes: []
   fix-spawn-admission-limiter:
     title: per-provider spawn admission limiter
     links:
     - kind: github_issue
       ref: hamanpaul/paulsha-cortex#381
+    - kind: path
+      ref: docs/superpowers/workstreams/fix-spawn-admission-limiter/todo.md
     excludes: []
   feat-executor-auth-preflight:
     title: dispatch 前 executor 登入態驗證與 provider 探測接線
     links:
     - kind: github_issue
       ref: hamanpaul/paulsha-cortex#369
+    - kind: path
+      ref: docs/superpowers/workstreams/feat-executor-auth-preflight/todo.md
     excludes: []
   feat-provider-failure-semantics:
     title: LLM provider failure typed semantics 與 bounded recovery
     links:
     - kind: github_issue
       ref: hamanpaul/paulsha-cortex#384
+    - kind: path
+      ref: docs/superpowers/workstreams/feat-provider-failure-semantics/todo.md
     excludes: []
   feat-adversarial-evidence-review:
     title: 對抗式 evidence 驗證掛卡
     links:
     - kind: github_issue
       ref: hamanpaul/paulsha-cortex#378
+    - kind: path
+      ref: docs/superpowers/workstreams/feat-adversarial-evidence-review/todo.md
     excludes: []
   fix-gate-provenance:
     title: gate 清單來源改 spec/plan 導出與判準不可變
     links:
     - kind: github_issue
       ref: hamanpaul/paulsha-cortex#379
+    - kind: path
+      ref: docs/superpowers/workstreams/fix-gate-provenance/todo.md
     excludes: []

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 ## [Unreleased]
 
 ### Added
+- **open-issue 批次 workstream todo 錨點**：為 14 個 work item 新增 `docs/superpowers/workstreams/<work-id>/todo.md`（frontmatter `status: accepted` + `work_item`），並在 `.cortex/work-items.yaml` 補上對應 `path` 連結。lifecycle reducer 需要 active todo 來源才會把 work item 推進 `todo` 態並開放 `start`——issue-only 連結停在 `topic` 不可 claim。各 todo 的任務清單取自對應 issue 2026-08-10 獨立複驗 comment 的修復標的，同時作為 ship gate 的勾選要件。
+
+### Added
 - **open-issue 批次（369–385）work item 進件登錄**：`.cortex/work-items.yaml` 新增 14 個 work item 條目，將 15 張 open issue（369、370、371、372、373、374、375、378、379、380、381、382、383、384、385）連結為可 claim 的 work authority；371 與 375 因同動 `installer.py` 的 `managed_env`／`preserve_existing` 而合併為單一 work item（`fix-installer-managed-env`）避免平行修改互撞；386 為 tracking gate 不建 work item。各 work item 的規劃權威為對應 issue 上 2026-08-10 的獨立複驗 comment（含 root cause 更正與修復標的）。純進件登錄，不含任何實作。
 
 ## [0.1.4] - 2026-08-08

--- a/changelog.d/workstream-todos-open-issue-batch.md
+++ b/changelog.d/workstream-todos-open-issue-batch.md
@@ -1,0 +1,2 @@
+### Added
+- **open-issue 批次 workstream todo 錨點**：為 14 個 work item 新增 `docs/superpowers/workstreams/<work-id>/todo.md`（frontmatter `status: accepted` + `work_item`），並在 `.cortex/work-items.yaml` 補上對應 `path` 連結。lifecycle reducer 需要 active todo 來源才會把 work item 推進 `todo` 態並開放 `start`——issue-only 連結停在 `topic` 不可 claim。各 todo 的任務清單取自對應 issue 2026-08-10 獨立複驗 comment 的修復標的，同時作為 ship gate 的勾選要件。

--- a/docs/superpowers/workstreams/feat-adversarial-evidence-review/todo.md
+++ b/docs/superpowers/workstreams/feat-adversarial-evidence-review/todo.md
@@ -1,0 +1,13 @@
+---
+status: accepted
+work_item: feat-adversarial-evidence-review
+---
+
+# feat-adversarial-evidence-review Todo
+
+## Tasks
+
+- [ ] adversarial-review 卡任務描述針對 evidence-claim rigged setup 改寫
+- [ ] evidence-claim 類 slice 強制掛對抗卡
+- [ ] blocking finding（verification-bypass/acceptance）fail-closed 接線驗證
+- [ ] 以 rigged 樣本設計紅隊回歸測試

--- a/docs/superpowers/workstreams/feat-digest-outbox/todo.md
+++ b/docs/superpowers/workstreams/feat-digest-outbox/todo.md
@@ -1,0 +1,13 @@
+---
+status: accepted
+work_item: feat-digest-outbox
+---
+
+# feat-digest-outbox Todo
+
+## Tasks
+
+- [ ] digest 組裝層彙整 attention/ready/held/degraded 摘要
+- [ ] 投遞用可設定命令（env 指定），預設落檔案 outbox；不得硬依賴 custom-skills 資源
+- [ ] inspect 文字模式補印 attention
+- [ ] 排程掛點（timer 樣板或 install service 選項）

--- a/docs/superpowers/workstreams/feat-executor-auth-preflight/todo.md
+++ b/docs/superpowers/workstreams/feat-executor-auth-preflight/todo.md
@@ -1,0 +1,13 @@
+---
+status: accepted
+work_item: feat-executor-auth-preflight
+---
+
+# feat-executor-auth-preflight Todo
+
+## Tasks
+
+- [ ] manager 呼叫 `evaluate_dispatch_gate` 傳入 snapshot_lookup/provider_prober（接活死碼）
+- [ ] cards 宣告 provider capability requirements
+- [ ] bootstrap copilot 登入態判定修正（限流輸出不得誤判為未登入）
+- [ ] dispatch 前 executor auth 驗證與 401/403/quota 分類

--- a/docs/superpowers/workstreams/feat-provider-failure-semantics/todo.md
+++ b/docs/superpowers/workstreams/feat-provider-failure-semantics/todo.md
@@ -1,0 +1,13 @@
+---
+status: accepted
+work_item: feat-provider-failure-semantics
+---
+
+# feat-provider-failure-semantics Todo
+
+## Tasks
+
+- [ ] ProviderOutcome typed 分類；executor CLI 文字 signal 定義中間 authority 等級
+- [ ] bounded durable retry 比照 schema-retry 樣板（attempts 持久化、上限、逾限 needs_human）
+- [ ] policy-aware fallback 不放寬 independence domain
+- [ ] inspect/work_api 投影 provider failure 欄位

--- a/docs/superpowers/workstreams/fix-authority-restart-loop/todo.md
+++ b/docs/superpowers/workstreams/fix-authority-restart-loop/todo.md
@@ -1,0 +1,13 @@
+---
+status: accepted
+work_item: fix-authority-restart-loop
+---
+
+# fix-authority-restart-loop Todo
+
+## Tasks
+
+- [ ] `_manager_reset_workflow_for_authority_restart` 同步更新 claim_key（或觸發改冪等/一次性）
+- [ ] source_revision 改寫時 rebind/invalidate 對應 job
+- [ ] manager_daemon resume 迴圈守衛補 needs_human（縱深防禦）
+- [ ] 回歸測試重現「剝除 facet → 放行 → mismatch → 寫回」三步迴圈並驗證收斂

--- a/docs/superpowers/workstreams/fix-deck-verification-skeleton/todo.md
+++ b/docs/superpowers/workstreams/fix-deck-verification-skeleton/todo.md
@@ -1,0 +1,13 @@
+---
+status: accepted
+work_item: fix-deck-verification-skeleton
+---
+
+# fix-deck-verification-skeleton Todo
+
+## Tasks
+
+- [ ] `_verification_skeleton` 從 `.project-policy.yml` 的 `preflight.steps` 導出 checks/tests/full_suite argv
+- [ ] 偵測不到 policy steps 時填 fail-closed placeholder 與醒目 warning（不留空）
+- [ ] `name: "policy"` 保留、argv 改 policy_check；同步修 docs 樣板與 init-sample 陳舊提示
+- [ ] 回歸測試涵蓋「有 preflight.steps」與「無 policy 檔」兩型 repo

--- a/docs/superpowers/workstreams/fix-gate-provenance/todo.md
+++ b/docs/superpowers/workstreams/fix-gate-provenance/todo.md
@@ -1,0 +1,13 @@
+---
+status: accepted
+work_item: fix-gate-provenance
+---
+
+# fix-gate-provenance Todo
+
+## Tasks
+
+- [ ] gate 清單來源由 spec/plan 導出，取代 PSC_GATE_CMD_* 全權
+- [ ] 空 ledger 不再 vacuous pass（無 gate 宣告時 fail-closed 或明示 bypass）
+- [ ] 驗收判準定義納入 pinned input，builder 改判準即 mismatch
+- [ ] slice lane 接上自報 vs ledger 對照

--- a/docs/superpowers/workstreams/fix-handoff-manifest-reconcile/todo.md
+++ b/docs/superpowers/workstreams/fix-handoff-manifest-reconcile/todo.md
@@ -1,0 +1,13 @@
+---
+status: accepted
+work_item: fix-handoff-manifest-reconcile
+---
+
+# fix-handoff-manifest-reconcile Todo
+
+## Tasks
+
+- [ ] run_tick 的 already_terminal 掃描改與 registry 對帳
+- [ ] fanout lane 補同等過濾
+- [ ] recovery 動作作廢或標記 superseded manifest
+- [ ] 回歸測試：殘留 manifest 且 registry 已復原時 tick 不再略過

--- a/docs/superpowers/workstreams/fix-installer-managed-env/todo.md
+++ b/docs/superpowers/workstreams/fix-installer-managed-env/todo.md
@@ -1,0 +1,14 @@
+---
+status: accepted
+work_item: fix-installer-managed-env
+---
+
+# fix-installer-managed-env Todo
+
+## Tasks
+
+- [ ] `preserve_existing` 移除 `PSC_PROJECT_CONFIG_ROOT`（含既有 env 遷移語意）
+- [ ] `PSC_CONTROL_ROOT` 納入 managed_env 且不得進 preserve_existing
+- [ ] shell wrapper lock 路徑改用 Python path 契約，消除 shell/Python 解析分歧
+- [ ] specs/coordinator root 的 per-instance 隔離納入驗收
+- [ ] 回歸測試：雙 instance 相同與不同 agents_root 兩情境的 lock/specs 隔離

--- a/docs/superpowers/workstreams/fix-log-error-dedup/todo.md
+++ b/docs/superpowers/workstreams/fix-log-error-dedup/todo.md
@@ -1,0 +1,12 @@
+---
+status: accepted
+work_item: fix-log-error-dedup
+---
+
+# fix-log-error-dedup Todo
+
+## Tasks
+
+- [ ] `_log_error` 單槽去重改多槽（LRU/TTL 有界）
+- [ ] 新增交錯多 signature 的回歸測試（3+ signature 輪替下抑制摘要仍生效）
+- [ ] 保留既有單 signature 行為與 `LOG_ERROR_SUMMARY_INTERVAL` 週期摘要

--- a/docs/superpowers/workstreams/fix-packaging-release-path/todo.md
+++ b/docs/superpowers/workstreams/fix-packaging-release-path/todo.md
@@ -1,0 +1,13 @@
+---
+status: accepted
+work_item: fix-packaging-release-path
+---
+
+# fix-packaging-release-path Todo
+
+## Tasks
+
+- [ ] README 補 tag/wheel 安裝路徑與「git+main 為 mutable」告誡
+- [ ] pyproject 定義 `[project.optional-dependencies].test`；tests.yml 移除 `|| true`
+- [ ] smoke-install 加 Python 3.10–3.13 matrix；release.yml 補 tag vs VERSION 一致性檢查
+- [ ] `requires-python` 收上界或補 classifiers

--- a/docs/superpowers/workstreams/fix-rate-limit-classification/todo.md
+++ b/docs/superpowers/workstreams/fix-rate-limit-classification/todo.md
@@ -1,0 +1,13 @@
+---
+status: accepted
+work_item: fix-rate-limit-classification
+---
+
+# fix-rate-limit-classification Todo
+
+## Tasks
+
+- [ ] providers.py 分類順序修正（rate limit 判定先於 auth 字樣）
+- [ ] `_authority_from_canonical_row` 對 rate-limit degraded 給專屬 reason code
+- [ ] doctor gh-auth 區分限流與憑證失效
+- [ ] durable backoff deadline，operator resume 不再立即重撞

--- a/docs/superpowers/workstreams/fix-registry-atomic-transitions/todo.md
+++ b/docs/superpowers/workstreams/fix-registry-atomic-transitions/todo.md
@@ -1,0 +1,13 @@
+---
+status: accepted
+work_item: fix-registry-atomic-transitions
+---
+
+# fix-registry-atomic-transitions Todo
+
+## Tasks
+
+- [ ] `record_action`/`update_slice` 改先全驗證再全突變（消除髒寫外洩）
+- [ ] gate_state failed 補合法離開路徑並與 slice state 轉換表對齊
+- [ ] `allowed_slice_actions` 同時檢視 gate_state
+- [ ] 回歸測試覆蓋半突變外洩與 failed/failed 死角復原

--- a/docs/superpowers/workstreams/fix-spawn-admission-limiter/todo.md
+++ b/docs/superpowers/workstreams/fix-spawn-admission-limiter/todo.md
@@ -1,0 +1,13 @@
+---
+status: accepted
+work_item: fix-spawn-admission-limiter
+---
+
+# fix-spawn-admission-limiter Todo
+
+## Tasks
+
+- [ ] fanout lane（dispatch_ready）加 per-provider spawn admission limiter
+- [ ] workflow lane periodic tick 同樣受限
+- [ ] 預算按每次 spawn 的 credential-probe 次數估（三來源各帶重試）
+- [ ] regression test 驗 spawn timestamp 間隔而非全序列化


### PR DESCRIPTION
## 目的
補齊 open-issue 批次（369–385）work item 的 lifecycle 錨點：reducer 需要 active 的 todo 來源才會把 work item 推進 `todo` 態並開放 `start`——issue-only 連結會停在 `topic` 不可 claim（本批 intake 實測驗證）。

## 變更
- 新增 14 個 `docs/superpowers/workstreams/<work-id>/todo.md`（frontmatter `status: accepted` + `work_item`、`## Tasks` 勾選清單）
- `.cortex/work-items.yaml` 各 work item 補 `path` 連結
- `changelog.d/workstream-todos-open-issue-batch.md` 與 `CHANGELOG.md [Unreleased]`

## 說明
各 todo 的任務清單取自對應 issue 上 2026-08-10 獨立複驗 comment 的修復標的，之後同時作為 ship gate 的勾選要件（gate 讀候選 worktree 的 tasks 全勾）。

## Checklist
- [x] changelog.d fragment 已新增且已 commit
- [x] CHANGELOG.md [Unreleased] 有對應 entry
- [x] VERSION 與 latest tag 一致（非 release PR）
- [x] policy_check 已帶 PR 上下文本機通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TstQEugFEoQt3WzrkBn3zc
