### PR TITLE
fix(planning): integrator prompt 補結構語意，修復必然的空 artifact_refs 驗證失敗

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- **integrator prompt 補結構語意，修復必然的空 `artifact_refs` 驗證失敗**：`build_production_planning_runtime` 的 integrator prompt 過去只列欄位名，未說明 `artifact_refs` 須為非空的 destination path 清單、`artifact_kind` 須對應 question kind 去掉 `missing-` 前綴、artifacts path 集合須恰等於 refs 聯集、每題恰一 resolution——模型在無語意指引下把不確定欄位留空，`validate_primary_integration` 必然拒收（canary v2 gen2 實測）。prompt 補上四項約束並以回歸測試釘住關鍵語句；validator 不動。
+
 ### Changed
 - **work item `fix-log-error-dedup` 重識別為 `-v2`**：v1 的三個 run 世代全數消耗於基礎設施缺陷（#390/#397/#399/#401），觸發 #218 語意重宣告熔斷（`semantic-reclaim-budget-exhausted`）；依熔斷設計的逃生門改用新識別，issue 374 連結與 workstream todo 隨遷。此案例同時佐證 #331（-v2 重識別摩擦）所述成本。
 

--- a/changelog.d/integrator-prompt-contract.md
+++ b/changelog.d/integrator-prompt-contract.md
@@ -1,0 +1,2 @@
+### Fixed
+- **integrator prompt 補結構語意，修復必然的空 `artifact_refs` 驗證失敗**：`build_production_planning_runtime` 的 integrator prompt 過去只列欄位名，未說明 `artifact_refs` 須為非空的 destination path 清單、`artifact_kind` 須對應 question kind 去掉 `missing-` 前綴、artifacts path 集合須恰等於 refs 聯集、每題恰一 resolution——模型在無語意指引下把不確定欄位留空，`validate_primary_integration` 必然拒收（canary v2 gen2 實測）。prompt 補上四項約束並以回歸測試釘住關鍵語句；validator 不動。

--- a/paulsha_cortex/coordinator/planning_runtime.py
+++ b/paulsha_cortex/coordinator/planning_runtime.py
@@ -620,10 +620,16 @@ def build_production_planning_runtime(
         )
 
     def integrator(pack: Mapping[str, object], evidence: Mapping[str, object]) -> object:
+        # #406：prompt 必須把 validate_primary_integration 的結構約束逐條講給模型，
+        # 只列欄位名（不給語意）時模型會把不確定的 artifact_refs 留空 → 必然驗證失敗。
         return invoke_primary(
             "Do not call tools or edit files. Integrate only the supplied evidence. Return exactly one "
             "JSON object with schema_version=1, question_pack_id, secondary_evidence_hash, resolutions, "
             "and artifacts. Each resolution has only question_id, decision, artifact_kind, artifact_refs. "
+            "Resolve every question exactly once. artifact_kind must equal the question kind without its "
+            "'missing-' prefix. artifact_refs must be a NON-EMPTY list of the destination path(s) this "
+            "resolution's artifact(s) are written to — the same strings used as artifacts[].path. "
+            "The set of all artifacts[].path values must equal the union of all artifact_refs. "
             "Each artifact has only kind, path, content; content must be complete UTF-8 Markdown with "
             "frontmatter status: accepted, the matching work_item, and required headings: Requirements "
             "for spec, Decisions for design, Tasks for plan. Use the supplied destination paths. "

--- a/tests/test_planning_runtime.py
+++ b/tests/test_planning_runtime.py
@@ -315,6 +315,13 @@ def test_questioner_and_integrator_prompts_include_json_output_contract(
     assert len(prompts) >= 2
     assert contract in prompts[-2]
     assert contract in prompts[-1]
+    # issue #406：integrator prompt 必須把 validate_primary_integration 的
+    # 結構約束講成語意（不只是欄位名），否則模型會把 artifact_refs 留空。
+    integrator_prompt = prompts[-1]
+    assert "Resolve every question exactly once" in integrator_prompt
+    assert "without its 'missing-' prefix" in integrator_prompt
+    assert "NON-EMPTY list of the destination path(s)" in integrator_prompt
+    assert "must equal the union of all artifact_refs" in integrator_prompt
 
 
 def test_planning_source_material_rejects_symlink_traversal(tmp_path: Path) -> None:


### PR DESCRIPTION
## 摘要
Closes #406——integrator prompt 只列欄位名未給語意，模型必然把不確定的 `artifact_refs` 留空、`validate_primary_integration` 必然拒收（canary v2 gen2 run workflow-23693db2efe20b6da079 實測；questioner 與 secondary 在 404 修復後皆 PASS，僅剩此關）。prompt 補四項結構約束（refs 非空且為 destination path、kind 對應 missing- 前綴、artifacts path 集合恰等於 refs 聯集、每題恰一 resolution），validator 不動。

## 驗證
- 擴充既有 prompt 契約測試釘住四句關鍵語句；RED→GREEN：修正前 1 failed、修正後 27 passed。
- 全套：**2077 passed, 32 subtests, 0 failed**。

## Checklist
- [x] changelog.d fragment 已新增且已 commit
- [x] CHANGELOG.md [Unreleased] 有對應 entry
- [x] VERSION 與 latest tag 一致（非 release PR）
- [x] policy check 以 CI pin 版引擎為準（本機引擎 1.0.16 與 repo 宣告 1.0.15 不合，係平行 conventions 升版所致，本機無法實跑；CI 之 policy/check 為權威閘門）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TstQEugFEoQt3WzrkBn3zc
