### PR TITLE
fix(planning): destinations 支援 workstream todo 錨點，artifact-write 失敗透傳例外摘要

### DIFF
--- a/.cortex/work-items.yaml
+++ b/.cortex/work-items.yaml
@@ -590,11 +590,11 @@ work_items:
     - kind: path
       ref: docs/superpowers/workstreams/fix-gate-provenance/todo.md
     excludes: []
-  fix-log-error-dedup-v2:
+  fix-log-error-dedup-v3:
     title: manager_daemon _log_error 多槽去重
     links:
     - kind: github_issue
       ref: hamanpaul/paulsha-cortex#374
     - kind: path
-      ref: docs/superpowers/workstreams/fix-log-error-dedup-v2/todo.md
+      ref: docs/superpowers/workstreams/fix-log-error-dedup-v3/todo.md
     excludes: []

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 ## [Unreleased]
 
 ### Fixed
+- **`_planning_destinations` 支援 workstream todo 錨點，修復 small-fix combo 的 artifact write 必拒**：過去只從 `openspec/changes/<slug>/…` 形 source_refs 導出目的地，todo.md 錨定的 work item（無 openspec-propose 卡的 combo）拿到空 destinations，integrator 只能發明路徑、必被 `_publish_planning_artifacts` 的 governed-roots 驗證拒收（canary v2 gen3 實測）。新增 `docs/superpowers/workstreams/<slug>/todo.md` 推導（openspec 優先、歧義維持 fail-closed 空 dict）；並補上 #397 漏掉的第四個裸吞分支——artifact-write 失敗的 reason 現在附例外摘要。另附 work item `-v3` 重識別（v2 三世代同樣全數耗於基礎設施缺陷）。
+
+### Fixed
 - **integrator prompt 補結構語意，修復必然的空 `artifact_refs` 驗證失敗**：`build_production_planning_runtime` 的 integrator prompt 過去只列欄位名，未說明 `artifact_refs` 須為非空的 destination path 清單、`artifact_kind` 須對應 question kind 去掉 `missing-` 前綴、artifacts path 集合須恰等於 refs 聯集、每題恰一 resolution——模型在無語意指引下把不確定欄位留空，`validate_primary_integration` 必然拒收（canary v2 gen2 實測）。prompt 補上四項約束並以回歸測試釘住關鍵語句；validator 不動。
 
 ### Changed

--- a/changelog.d/planning-destinations-todo-anchor.md
+++ b/changelog.d/planning-destinations-todo-anchor.md
@@ -1,0 +1,2 @@
+### Fixed
+- **`_planning_destinations` 支援 workstream todo 錨點，修復 small-fix combo 的 artifact write 必拒**：過去只從 `openspec/changes/<slug>/…` 形 source_refs 導出目的地，todo.md 錨定的 work item（無 openspec-propose 卡的 combo）拿到空 destinations，integrator 只能發明路徑、必被 `_publish_planning_artifacts` 的 governed-roots 驗證拒收（canary v2 gen3 實測）。新增 `docs/superpowers/workstreams/<slug>/todo.md` 推導（openspec 優先、歧義維持 fail-closed 空 dict）；並補上 #397 漏掉的第四個裸吞分支——artifact-write 失敗的 reason 現在附例外摘要。另附 work item `-v3` 重識別（v2 三世代同樣全數耗於基礎設施缺陷）。

--- a/docs/superpowers/workstreams/fix-log-error-dedup-v3/todo.md
+++ b/docs/superpowers/workstreams/fix-log-error-dedup-v3/todo.md
@@ -1,9 +1,9 @@
 ---
 status: accepted
-work_item: fix-log-error-dedup-v2
+work_item: fix-log-error-dedup-v3
 ---
 
-# fix-log-error-dedup-v2 Todo
+# fix-log-error-dedup-v3 Todo
 
 ## Tasks
 
@@ -14,3 +14,5 @@ work_item: fix-log-error-dedup-v2
 > 2026-08-10：v1 識別的三個世代（6569c45012d9／71f912efc167／244b7cfdee54）全數燒於基礎設施缺陷
 > （#390 combo 凍結、#397 pycache 誤殺、#399 runtime churn 誤殺、#401 extractor envelope fallthrough），
 > 非工作本身失敗；依 #218 世代熔斷的重識別逃生門改為 -v2。
+> 2026-08-10（v3）：v2 三世代亦全數燒於基礎設施缺陷（gen1 於 #404 修復前、gen2 於 #406 修復前、
+> gen3 於 #408 destinations 缺口），工作本身仍未開始；依 #218 熔斷逃生門再遷 -v3。

--- a/paulsha_cortex/coordinator/planning.py
+++ b/paulsha_cortex/coordinator/planning.py
@@ -1143,10 +1143,13 @@ def run_heterogeneous_brainstorm(
             if not integration.get("artifacts"):
                 raise ValueError("structured artifact content missing")
             rollback_publication = artifact_writer(integration.get("artifacts", []))
-        except Exception:
+        except Exception as exc:
+            # #408：這是 #397 儀器化時漏掉的第四個裸吞分支——artifact write 的
+            # 實際拒絕原因（哪條驗證、哪個路徑）必須透傳進 reason，與其餘三個
+            # 分支的例外摘要格式一致。
             return BrainstormResult(
                 "needs_human",
-                "primary-artifact-write-rejected",
+                f"primary-artifact-write-rejected: {type(exc).__name__}: {str(exc)[:160]}",
                 selection.identity.independence_domain,
                 empty_refs,
                 None,

--- a/paulsha_cortex/coordinator/planning_runtime.py
+++ b/paulsha_cortex/coordinator/planning_runtime.py
@@ -542,6 +542,24 @@ def _planning_destinations(pack: Mapping[str, object]) -> dict[str, str]:
         and (parts := PurePosixPath(ref).parts)[:2] == ("openspec", "changes")
         and len(parts) >= 4
     }
+    if not slugs:
+        # #408：small-fix 等無 openspec-propose 卡的 combo，work item 錨點是
+        # workstream todo（docs/superpowers/workstreams/<slug>/todo.md）——
+        # 沒有這個 fallback 時 destinations 恆為空，integrator 被要求
+        # 「Use the supplied destination paths」卻拿到空 dict，只能自行發明
+        # 路徑、必被 _publish_planning_artifacts 的 governed-roots 驗證拒收。
+        # openspec 錨點優先；兩者皆無或歧義（多 slug）維持空 dict 的
+        # 既有 fail-closed 行為。
+        slugs = {
+            parts[3]
+            for question in questions if isinstance(question, dict)
+            for ref in question.get("source_refs", [])
+            if isinstance(ref, str)
+            and (parts := PurePosixPath(ref).parts)[:3]
+            == ("docs", "superpowers", "workstreams")
+            and len(parts) >= 5
+            and parts[4] == "todo.md"
+        }
     if len(slugs) != 1:
         return {}
     slug = next(iter(slugs))

--- a/tests/test_planning_completeness.py
+++ b/tests/test_planning_completeness.py
@@ -572,6 +572,104 @@ def test_brainstorm_reason_includes_underlying_exception_summary_for_questioner(
     assert "questioner exploded" in result.reason
 
 
+def test_brainstorm_reason_includes_underlying_exception_summary_for_artifact_write(
+    tmp_path: Path,
+) -> None:
+    """Issue #408：artifact-write 分支是 #397 儀器化時漏掉的第四個裸吞
+    `except Exception`——canary v2 gen3 只看得到 `primary-artifact-write-rejected`
+    卻查不到是哪條驗證拒的。這裡讓整條 brainstorm 走到 artifact_writer，
+    驗證 reason 併入例外型別與訊息片段。"""
+    report = assess_planning_completeness([_artifact("spec", ACCEPTED_SPEC)])
+    registry = IdentityRegistry.from_rows(
+        [
+            {
+                "executor": "codex",
+                "model_id": "primary",
+                "independence_domain": "openai",
+                "capabilities": ["planning"],
+            },
+            {
+                "executor": "agy",
+                "model_id": "Gemini 3.1 Pro (High)",
+                "independence_domain": "google",
+                "capabilities": ["planning"],
+                "live_probe": "agy-plan-sandbox",
+            },
+        ]
+    )
+    probes = {
+        ("agy", "Gemini 3.1 Pro (High)"): CapabilityProbe.ready_for(
+            "agy", "Gemini 3.1 Pro (High)", "google"
+        )
+    }
+
+    def questioner(_report_payload):
+        return report.default_question_pack.to_dict()
+
+    def secondary(pack_payload, identity):
+        return {
+            "schema_version": 1,
+            "question_pack_id": pack_payload["pack_id"],
+            "evidence": [
+                {
+                    "question_id": q["question_id"],
+                    "claims": ["No accepted artifact found."],
+                    "source_refs": ["docs/planning-index.md:1"],
+                }
+                for q in pack_payload["questions"]
+            ],
+        }
+
+    kind_to_body = {"design": ACCEPTED_DESIGN, "plan": ACCEPTED_PLAN}
+
+    def integrator(pack_payload, evidence_payload):
+        resolutions = []
+        artifacts = []
+        for question in pack_payload["questions"]:
+            artifact_kind = question["kind"].removeprefix("missing-")
+            artifact_ref = f"docs/{artifact_kind}.md"
+            resolutions.append(
+                {
+                    "question_id": question["question_id"],
+                    "decision": "Create and accept the missing artifact.",
+                    "artifact_kind": artifact_kind,
+                    "artifact_refs": [artifact_ref],
+                }
+            )
+            artifacts.append(
+                {"kind": artifact_kind, "path": artifact_ref, "content": kind_to_body[artifact_kind]}
+            )
+        return {
+            "schema_version": 1,
+            "question_pack_id": pack_payload["pack_id"],
+            "secondary_evidence_hash": evidence_payload["evidence_hash"],
+            "resolutions": resolutions,
+            "artifacts": artifacts,
+        }
+
+    def exploding_writer(_rows):
+        raise RuntimeError("publication transaction refused")
+
+    result = run_heterogeneous_brainstorm(
+        report=report,
+        primary=("codex", "primary"),
+        registry=registry,
+        probes=probes,
+        evidence_dir=tmp_path,
+        artifact_root=tmp_path,
+        scope=SCOPE,
+        primary_questioner=questioner,
+        secondary_planner=secondary,
+        primary_integrator=integrator,
+        artifact_writer=exploding_writer,
+    )
+    assert result.state == "needs_human"
+    assert result.reason is not None
+    assert result.reason.startswith("primary-artifact-write-rejected:")
+    assert "RuntimeError" in result.reason
+    assert "publication transaction refused" in result.reason
+
+
 def test_primary_must_write_accepted_artifacts_before_brainstorm_gate_passes(tmp_path: Path) -> None:
     report = assess_planning_completeness([_artifact("spec", ACCEPTED_SPEC)])
     registry = IdentityRegistry.from_rows(

--- a/tests/test_planning_runtime.py
+++ b/tests/test_planning_runtime.py
@@ -165,6 +165,46 @@ def test_secondary_prompt_embeds_bounded_repo_sources_without_tool_access(
     )["plan"] == "docs/superpowers/plans/demo.md"
 
 
+def test_planning_destinations_derives_slug_from_workstream_todo_anchor() -> None:
+    """issue #408：small-fix 等無 openspec-propose 卡的 combo，work item 錨點是
+    workstream todo——destinations 必須能從
+    docs/superpowers/workstreams/<slug>/todo.md 推導，否則 integrator 拿到空
+    destinations、發明路徑、必被 governed-roots 驗證拒收。"""
+    destinations = planning_runtime._planning_destinations(
+        {
+            "questions": [
+                {"source_refs": ["docs/superpowers/workstreams/fix-demo-v2/todo.md"]},
+                {"source_refs": ["docs/superpowers/workstreams/fix-demo-v2/todo.md"]},
+            ]
+        }
+    )
+    assert destinations == {
+        "spec": "docs/superpowers/specs/fix-demo-v2-spec.md",
+        "design": "docs/superpowers/specs/fix-demo-v2-design.md",
+        "plan": "docs/superpowers/plans/fix-demo-v2.md",
+    }
+    # openspec 錨點優先：兩種 ref 並存時仍以 openspec slug 為準。
+    assert planning_runtime._planning_destinations(
+        {
+            "questions": [
+                {"source_refs": [
+                    "openspec/changes/demo/proposal.md",
+                    "docs/superpowers/workstreams/other/todo.md",
+                ]}
+            ]
+        }
+    )["plan"] == "docs/superpowers/plans/demo.md"
+    # 歧義（多個 workstream slug）維持 fail-closed 空 dict。
+    assert planning_runtime._planning_destinations(
+        {
+            "questions": [
+                {"source_refs": ["docs/superpowers/workstreams/a/todo.md"]},
+                {"source_refs": ["docs/superpowers/workstreams/b/todo.md"]},
+            ]
+        }
+    ) == {}
+
+
 def test_planning_argv_claude_branch_omits_permission_mode(tmp_path: Path) -> None:
     """issue #404：plan 模式的系統提示（「必須產出計畫或呼叫
     ExitPlanMode」）與這裡「必須回傳純 JSON」的確定性回聲任務衝突——issue


### PR DESCRIPTION
## 摘要
Closes #408——canary v2 gen3 的 brainstorm 三棒全過後死於落盤：`_planning_destinations` 只認 openspec 錨點，small-fix combo（無 openspec-propose 卡）的 todo.md 錨定 work item 拿到**空 destinations**，integrator 被迫發明路徑、`_publish_planning_artifacts` 的 governed-roots 驗證必拒。

1. `_planning_destinations` 新增 workstream 錨點推導（`docs/superpowers/workstreams/<slug>/todo.md` → 同組 destinations）；openspec 優先、歧義維持 fail-closed 空 dict。
2. artifact-write 分支（#397 儀器化漏掉的第四個裸吞 `except Exception`）reason 補例外摘要。
3. 附 canary work item `-v3` 重識別（v2 三世代同樣全數耗於基礎設施缺陷：gen1 於 404 前、gen2 於 406 前、gen3 於本缺口）。

## 驗證
- 新測試：todo 錨點導出／openspec 優先／歧義 fail-closed；artifact-write reason 含例外型別與訊息。
- RED→GREEN：修正前 2 failed、修正後 40 passed（兩測試檔）。
- 全套：**2079 passed, 32 subtests, 0 failed**（基線 2077＋2）。

## Checklist
- [x] changelog.d fragment 已新增且已 commit
- [x] CHANGELOG.md [Unreleased] 有對應 entry
- [x] VERSION 與 latest tag 一致（非 release PR）
- [x] policy check 以 CI pin 版引擎為準（本機引擎 1.0.16≠宣告 1.0.15，平行升版所致）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TstQEugFEoQt3WzrkBn3zc
