### PR TITLE
chore(work): v2 墓碑錨點救援孤兒 run（issue 410 短期解）

### DIFF
--- a/.cortex/work-items.yaml
+++ b/.cortex/work-items.yaml
@@ -598,3 +598,11 @@ work_items:
     - kind: path
       ref: docs/superpowers/workstreams/fix-log-error-dedup-v3/todo.md
     excludes: []
+  fix-log-error-dedup-v2:
+    title: （墓碑）v2 孤兒 run 救援錨點——見 issue 410
+    links:
+    - kind: path
+      ref: docs/superpowers/workstreams/fix-log-error-dedup-v2/todo.md
+    excludes:
+    - kind: github_issue
+      ref: hamanpaul/paulsha-cortex#374

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 
 ## [Unreleased]
 
+### Changed
+- **v2 墓碑錨點（issue 410 改名死結短期解）**：`fix-log-error-dedup-v2` 改名 v3 時仍有 ongoing run，形成「孤兒 run 不可 abandon（authority 隨改名消失）→ 其 issue 認領與 v3 相撞 → repo provider degraded → 全域凍結」三環死結。重加 v2 tombstone row（僅 path 錨點＋明示 exclude issue 374）恢復 authority 以 abandon 孤兒；abandon 後於收尾打掃移除。
+
 ### Fixed
 - **`_planning_destinations` 支援 workstream todo 錨點，修復 small-fix combo 的 artifact write 必拒**：過去只從 `openspec/changes/<slug>/…` 形 source_refs 導出目的地，todo.md 錨定的 work item（無 openspec-propose 卡的 combo）拿到空 destinations，integrator 只能發明路徑、必被 `_publish_planning_artifacts` 的 governed-roots 驗證拒收（canary v2 gen3 實測）。新增 `docs/superpowers/workstreams/<slug>/todo.md` 推導（openspec 優先、歧義維持 fail-closed 空 dict）；並補上 #397 漏掉的第四個裸吞分支——artifact-write 失敗的 reason 現在附例外摘要。另附 work item `-v3` 重識別（v2 三世代同樣全數耗於基礎設施缺陷）。
 

--- a/changelog.d/v2-tombstone-orphan-rescue.md
+++ b/changelog.d/v2-tombstone-orphan-rescue.md
@@ -1,0 +1,2 @@
+### Changed
+- **v2 墓碑錨點（issue 410 改名死結短期解）**：`fix-log-error-dedup-v2` 改名 v3 時仍有 ongoing run，形成「孤兒 run 不可 abandon（authority 隨改名消失）→ 其 issue 認領與 v3 相撞 → repo provider degraded → 全域凍結」三環死結。重加 v2 tombstone row（僅 path 錨點＋明示 exclude issue 374）恢復 authority 以 abandon 孤兒；abandon 後於收尾打掃移除。

--- a/docs/superpowers/workstreams/fix-log-error-dedup-v2/todo.md
+++ b/docs/superpowers/workstreams/fix-log-error-dedup-v2/todo.md
@@ -1,0 +1,10 @@
+---
+status: accepted
+work_item: fix-log-error-dedup-v2
+---
+
+# fix-log-error-dedup-v2 Todo（墓碑）
+
+## Tasks
+
+- [x] 墓碑錨點：恢復 v2 的 work authority（todo source），使孤兒 run workflow-99cac69a966168627cfe 可被 abandon（issue 410 改名死結的短期解）。abandon 完成後本檔與對應 row 於收尾打掃移除。


### PR DESCRIPTION
## 摘要
issue 410（改名死結）的短期解：v2→v3 重識別時 v2 仍有 ongoing run，形成「孤兒 run 不可 abandon → issue 認領相撞 → repo provider degraded → 全域凍結」三環死結（機制詳見 issue 410，含 `_authority_from_canonical_row` 三個靜默 None 條件的實證）。

- 重建 `docs/superpowers/workstreams/fix-log-error-dedup-v2/todo.md`（墓碑，單一已勾任務說明用途）
- work-items.yaml 重加 v2 row：links 僅 path 錨點、**excludes 明列 github_issue 374**（雙保險切斷 registry 側認領）
- abandon 孤兒後於收尾打掃移除本墓碑

長期修法（改名守門 lint／孤兒救援動作／None 條件診斷）循 issue 410。

## Checklist
- [x] changelog.d fragment 已新增且已 commit
- [x] CHANGELOG.md [Unreleased] 有對應 entry
- [x] VERSION 與 latest tag 一致（非 release PR）
- [x] policy check 以 CI pin 版引擎為準（本機引擎 1.0.16≠宣告 1.0.15）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TstQEugFEoQt3WzrkBn3zc
