### PR TITLE
fix(work): abandon 孤兒救援窄放行（issue 410 建議 2）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- **abandon 孤兒救援窄放行（issue 410 建議 2）**：work item 改名／重識別後，舊識別 authority 失去 issue／openspec 映射，run refs 與 authority 恆不相等，嚴格相等守衛使孤兒 run 永遠不可 abandon、其 issue 認領持續與新識別相撞。僅在「authority 兩類映射皆空、run 仍留 refs」的孤兒簽名下放行（expected_run_id／actor／reason 強制項與單一 ongoing 檢查不變、evidence 照常落盤）；authority 映射非空的真 refs 漂移維持 fail-closed。
+
 ### Changed
 - **v2 墓碑錨點（issue 410 改名死結短期解）**：`fix-log-error-dedup-v2` 改名 v3 時仍有 ongoing run，形成「孤兒 run 不可 abandon（authority 隨改名消失）→ 其 issue 認領與 v3 相撞 → repo provider degraded → 全域凍結」三環死結。重加 v2 tombstone row（僅 path 錨點＋明示 exclude issue 374）恢復 authority 以 abandon 孤兒；abandon 後於收尾打掃移除。
 

--- a/changelog.d/abandon-orphan-rescue.md
+++ b/changelog.d/abandon-orphan-rescue.md
@@ -1,0 +1,2 @@
+### Fixed
+- **abandon 孤兒救援窄放行（issue 410 建議 2）**：work item 改名／重識別後，舊識別 authority 失去 issue／openspec 映射，run refs 與 authority 恆不相等，嚴格相等守衛使孤兒 run 永遠不可 abandon、其 issue 認領持續與新識別相撞。僅在「authority 兩類映射皆空、run 仍留 refs」的孤兒簽名下放行（expected_run_id／actor／reason 強制項與單一 ongoing 檢查不變、evidence 照常落盤）；authority 映射非空的真 refs 漂移維持 fail-closed。

--- a/paulsha_cortex/coordinator/work_actions.py
+++ b/paulsha_cortex/coordinator/work_actions.py
@@ -2335,7 +2335,21 @@ def _abandon_action(
         f"{authority.repo}#{number}" for number in authority.mapped_issues
     )
     if run.issue_refs != expected_issues or run.openspec_refs != authority.mapped_openspec:
-        raise RuntimeError("abandon WorkflowRun refs differ from current WorkAuthority")
+        # #410（孤兒救援，建議 2 的窄放行）：work item 改名／重識別後，舊識別的
+        # authority 會失去 issue/openspec 映射（例如 tombstone row 只剩 path 錨點、
+        # 或 collision 使 correlation 不再把 issue 分派給本 work_id），此時 run 的
+        # refs 與 authority 恆不相等，孤兒 run 永遠不可 abandon——與 v3 相撞的
+        # 認領也永遠無法釋放。僅在「authority 完全失去 issue 與 openspec 映射、
+        # 而 run 仍留有 refs」這個孤兒簽名下放行；一般 abandon（authority 映射
+        # 完整）維持嚴格相等。expected_run_id／actor／reason 的強制項與上方的
+        # 單一 ongoing 檢查不變，abandon evidence 照常落盤留稽核。
+        orphan_rescue = (
+            not authority.mapped_issues
+            and not authority.mapped_openspec
+            and bool(run.issue_refs or run.openspec_refs)
+        )
+        if not orphan_rescue:
+            raise RuntimeError("abandon WorkflowRun refs differ from current WorkAuthority")
     body = {
         "schema": "cortex-work-abandon/v1",
         "repo": authority.repo,

--- a/tests/test_work_actions.py
+++ b/tests/test_work_actions.py
@@ -620,6 +620,70 @@ def test_abandon_supersedes_exact_pre_delivery_run_with_immutable_reason(
         )
 
 
+def test_abandon_orphan_rescue_allows_refs_drift_when_authority_lost_all_mappings(
+    tmp_path: Path,
+) -> None:
+    """issue #410（孤兒救援窄放行）：work item 改名／重識別後，舊識別的
+    authority 失去 issue 與 openspec 映射（tombstone row 只剩 path 錨點），
+    run 的 refs 與 authority 恆不相等——嚴格相等守衛使孤兒 run 永遠不可
+    abandon。僅在「authority 兩類映射皆空、run 仍留 refs」的孤兒簽名下放行；
+    authority 映射非空但內容不同（真正的 refs 漂移）仍必須 fail-closed。"""
+    snapshot = _snapshot(tmp_path / "snapshot.json", prs=())
+    state = tmp_path / "runs.json"
+    registry = JobRegistry(state_path=tmp_path / "jobs.json")
+    started = work_actions.execute_work_action(
+        args={"action": "start", "repo": "acme/demo", "work_id": "demo"},
+        requested_by="operator",
+        snapshot_path=snapshot,
+        state_path=state,
+        now=lambda: 200,
+        workflow_registry=registry,
+    )
+    run_id = started["result"]["run"]["run_id"]
+    args = {
+        "action": "abandon",
+        "repo": "acme/demo",
+        "work_id": "demo",
+        "actor": "operator",
+        "expected_run_id": run_id,
+        "reason": "issue 410 孤兒救援：改名後清理舊識別的 ongoing run。",
+    }
+
+    # 真正的 refs 漂移（authority 仍有映射、只是內容不同）必須維持 fail-closed。
+    drifted = _snapshot(
+        tmp_path / "snapshot-drifted.json",
+        issues=(13,),
+        source_revisions=("issue:13@open", "openspec:demo@1"),
+    )
+    with pytest.raises(RuntimeError, match="refs differ"):
+        work_actions.execute_work_action(
+            args=args,
+            requested_by="operator",
+            snapshot_path=drifted,
+            state_path=state,
+            workflow_registry=registry,
+        )
+
+    # 孤兒簽名：authority 失去全部 issue／openspec 映射（僅剩 todo 錨點）。
+    orphaned = _snapshot(
+        tmp_path / "snapshot-orphan.json",
+        issues=(),
+        changes=(),
+        prs=(),
+        source_revisions=("todo:docs/todo.md@1",),
+    )
+    result = work_actions.execute_work_action(
+        args=args,
+        requested_by="operator",
+        snapshot_path=orphaned,
+        state_path=state,
+        workflow_registry=registry,
+    )
+    assert result["result"]["action"] == "abandoned"
+    rescued = registry.get_workflow_run(run_id)
+    assert rescued.status == "superseded"
+
+
 def test_abandon_evidence_is_immutable_at_link_creation(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,


### PR DESCRIPTION
## 摘要
issue 410 建議 2 的實作（不關閉該票——改名守門 lint 與 parser 診斷仍待辦）：abandon 的 refs 嚴格相等守衛在孤兒場景（改名後 authority 失去 issue／openspec 映射）永遠不可能滿足，孤兒 run 不可清、其 issue 認領持續凍死新識別。

窄放行條件：`authority.mapped_issues` 與 `mapped_openspec` **皆空**且 run 仍留 refs（孤兒簽名）。expected_run_id／actor／reason 強制項、單一 ongoing 檢查、abandon evidence 落盤全部不變；authority 映射非空的真 refs 漂移維持 fail-closed（有負向測試釘住）。

## 驗證
- 新測試：孤兒簽名放行＋真漂移（authority 有不同 issue）仍拒。RED→GREEN：修正前 1 failed、修正後 66 passed（test_work_actions 全檔）。
- 全套：**2080 passed, 32 subtests, 0 failed**（基線 2079＋1）。

## Checklist
- [x] changelog.d fragment 已新增且已 commit
- [x] CHANGELOG.md [Unreleased] 有對應 entry
- [x] VERSION 與 latest tag 一致（非 release PR）
- [x] policy check 以 CI pin 版引擎為準（本機引擎 1.0.16≠宣告 1.0.15）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TstQEugFEoQt3WzrkBn3zc
