### PR TITLE
fix(planning): missing-kind 問題 source_refs 補 accepted fallback（408 補完）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 ## [Unreleased]
 
 ### Fixed
+- **missing-kind 問題的 source_refs 補 accepted fallback（#408 補完）**：`_build_default_question_pack` 對 `missing-{kind}` 只取同 kind refs——同 kind 有草稿時語意正確（重寫以草稿為本），但 todo 錨定的 work item 該 kind 完全不存在，refs 恆空，`_planning_destinations` 與 `_planning_source_material` 雙雙斷炊（PR #409 的 workstream 推導因此拿不到料，v3 gen1 實測 destinations 仍空、模型輸出裸路徑被 governed-roots 拒）。同 kind refs 為空時 fallback 至全部 accepted refs；端對端實測 brainstorm 三棒＋integration 驗證全通、destinations 正確導出。
+
+### Fixed
 - **abandon 孤兒救援窄放行（issue 410 建議 2）**：work item 改名／重識別後，舊識別 authority 失去 issue／openspec 映射，run refs 與 authority 恆不相等，嚴格相等守衛使孤兒 run 永遠不可 abandon、其 issue 認領持續與新識別相撞。僅在「authority 兩類映射皆空、run 仍留 refs」的孤兒簽名下放行（expected_run_id／actor／reason 強制項與單一 ongoing 檢查不變、evidence 照常落盤）；authority 映射非空的真 refs 漂移維持 fail-closed。
 
 ### Changed

--- a/changelog.d/question-pack-source-refs.md
+++ b/changelog.d/question-pack-source-refs.md
@@ -1,0 +1,2 @@
+### Fixed
+- **missing-kind 問題的 source_refs 補 accepted fallback（#408 補完）**：`_build_default_question_pack` 對 `missing-{kind}` 只取同 kind refs——同 kind 有草稿時語意正確（重寫以草稿為本），但 todo 錨定的 work item 該 kind 完全不存在，refs 恆空，`_planning_destinations` 與 `_planning_source_material` 雙雙斷炊（PR #409 的 workstream 推導因此拿不到料，v3 gen1 實測 destinations 仍空、模型輸出裸路徑被 governed-roots 拒）。同 kind refs 為空時 fallback 至全部 accepted refs；端對端實測 brainstorm 三棒＋integration 驗證全通、destinations 正確導出。

--- a/paulsha_cortex/coordinator/planning.py
+++ b/paulsha_cortex/coordinator/planning.py
@@ -240,8 +240,21 @@ def _build_default_question_pack(
     assessments: tuple[ArtifactAssessment, ...], missing_kinds: tuple[str, ...]
 ) -> QuestionPack:
     questions: list[PlanningQuestion] = []
+    # #408（補完）：missing-{kind} 問題的 source_refs 過去只取「同 kind 的
+    # assessments refs」。同 kind 有草稿（rejected/draft）時這是對的——重寫要
+    # 以草稿為本（見 test_rejected_artifacts_remain_authoritative_sources_...）；
+    # 但 todo 錨定的 work item（如 small-fix combo）該 kind 完全不存在，
+    # source_refs 恆為空 tuple，造成兩個下游斷點：
+    # (a) `_planning_destinations` 的 openspec／workstream 錨點推導拿不到任何
+    #     路徑 → destinations 空 → integrator 發明路徑必被 governed-roots 拒；
+    # (b) `_planning_source_material` 無檔可讀 → secondary planner 兩手空空。
+    # 故補 fallback：同 kind refs 為空時退到全部 accepted artifacts 的 refs
+    # ——既有權威素材正是「建立 accepted {kind} 需要什麼權威內容」的來源。
+    accepted_refs = tuple(
+        assessment.artifact.ref for assessment in assessments if assessment.accepted
+    )
     for kind in missing_kinds:
-        source_refs = tuple(
+        same_kind_refs = tuple(
             assessment.artifact.ref
             for assessment in assessments
             if assessment.artifact.kind == kind
@@ -250,7 +263,7 @@ def _build_default_question_pack(
             _make_question(
                 f"missing-{kind}",
                 f"What authoritative content is required to create an accepted {kind}?",
-                source_refs,
+                same_kind_refs or accepted_refs,
             )
         )
     for assessment in assessments:

--- a/tests/test_planning_completeness.py
+++ b/tests/test_planning_completeness.py
@@ -175,6 +175,26 @@ def test_rejected_artifacts_remain_authoritative_sources_for_missing_kind_questi
     ]
 
 
+def test_missing_kind_questions_fall_back_to_accepted_refs_when_kind_absent() -> None:
+    """issue #408（補完）：todo 錨定的 work item（small-fix combo）缺 spec/design
+    時，同 kind 完全不存在 → source_refs 過去恆為空，destinations 推導與
+    secondary source material 雙雙斷炊。fallback 到 accepted refs 後，
+    `_planning_destinations` 能從 workstream todo 路徑導出目的地。"""
+    todo_ref = "docs/superpowers/workstreams/fix-demo-v3/todo.md"
+    report = assess_planning_completeness(
+        [
+            _artifact(
+                "plan",
+                "---\nstatus: accepted\nwork_item: fix-demo-v3\n---\n## Tasks\n- [ ] 修好它。\n",
+                todo_ref,
+            )
+        ]
+    )
+    assert report.missing_kinds == ("spec", "design")
+    for question in report.default_question_pack.questions:
+        assert question.source_refs == (todo_ref,)
+
+
 def test_any_blocking_marker_triggers_brainstorm_even_when_an_alternate_artifact_is_accepted() -> None:
     report = assess_planning_completeness(
         [


### PR DESCRIPTION
## 摘要
Closes #408（補完；reopen comment 有完整分析）——PR #409 的 workstream 推導吃 question `source_refs`，但 `_build_default_question_pack` 對 missing-kind 問題只取**同 kind** refs（該 kind 正因缺席才成題，恆空 tuple）。v3 gen1 實測：destinations 仍空、模型輸出裸 `spec.md` 被 governed-roots 拒（#408 例外透傳精確呈現）。

修法：同 kind refs 為空時 fallback 至全部 accepted refs——同 kind 草稿存在時維持既有語意（`test_rejected_artifacts_remain_authoritative_sources_...` 續綠）；todo 錨定場景 destinations 與 secondary source material 同時恢復供料。

## 驗證
- 新測試釘 fallback；RED→GREEN：修正前 1 failed、修正後全綠。
- 全套：**2081 passed, 32 subtests, 0 failed**（基線 2080＋1）。
- **端對端生產等價實測**：questioner→secondary（agy）→integrator 三棒全通，destinations 正確導出，`_validate_primary_integration` PASS，artifact 路徑落在 governed roots。

## Checklist
- [x] changelog.d fragment 已新增且已 commit
- [x] CHANGELOG.md [Unreleased] 有對應 entry
- [x] VERSION 與 latest tag 一致（非 release PR）
- [x] policy check 以 CI pin 版引擎為準（本機引擎 1.0.16≠宣告 1.0.15）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TstQEugFEoQt3WzrkBn3zc
