### PR TITLE
fix(coordinator): 修正 profile 巷道對 patchmud main 的 drift（聚合鍵／別名表／deck 指紋／run 封存）

### DIFF
--- a/changelog.d/profile-lane-patchmud-drift.md
+++ b/changelog.d/profile-lane-patchmud-drift.md
@@ -1,0 +1,29 @@
+# profile-lane-patchmud-drift
+
+- **Issue #466：profile 巷道對 patchmud main（PR #15 後）的 drift 修正**
+  （`paulsha_cortex/coordinator/model_profile.py`）：
+  - **A-1 report 聚合鍵改從 report 本身取**：patchmud PR #15 起 `run.yaml` 記
+    `normalize_model_spec()` 展開後的完整 model spec（非 CLI 別名，且
+    anthropic↔claude CLI fallback 隨憑證狀態浮動），舊實作以別名查
+    `clear_rate` 榜必落 `identity-not-in-report`、巷道永遠產不出實測封套。
+    新增 `_report_group_key()`：profile 的 runs_root 為單一身分專用，report 內
+    必恰一組 `(model, loadout)`，多組即 `report-group-ambiguous` fail-closed。
+  - **A-2 adapter 別名表更新**：patchmud 已落地 codex／agy OAuth headless
+    adapter（paulsha-patchmud#14），「僅 anthropic adapter」的誠實約束註解過時；
+    補 `("agy", "gemini-3.1-pro-high") → "agy:gemini-3.1-pro"` 對應（完整 spec、
+    不用短別名），明寫 CLI adapter effort 硬編 `high` 的對應限制；codex 身分
+    待 #456 R4 登錄後補格。
+  - **A-3 deck 指紋改聚合 encounter provenance pin**：原 rglob 全檔 hash 會把
+    `patchmud validate-deck` 對 `reference_timings` 的例行覆寫誤判成 deck 變更、
+    誤觸全量重評；改為聚合各 encounter `provenance.yaml` 的 `content_sha256`
+    （與 patchmud `encounter_content_sha256` pin 同語意，#452 D 票面原意），
+    provenance 缺漏 fail-closed。
+  - **A-4 run 封存耐久化**：runs_root 從 `mkdtemp` 改落 patchmud repo
+    `runs/profile-<executor>-<model_id>-<stamp>/`（比照 #455 實測慣例，不進
+    版控），registry 的 `profile_provenance.observation.runs_root` 記出處——
+    落進 registry 的封套值可回溯到 events／ledger／replay 證據。
+- **spec 勘誤追記**（`envelope-mapping-spec.md`、`benchmark-cost-baseline.md`）：
+  paulsha-patchmud#21 證實「haiku 4/8」與「同母題變體 clear 分歧」兩個定案錨點
+  實為 unified diff 協定噪音（非能力／變體訊號）；定案方向不變，但 R3 人工閘
+  追記「pilot-v1 來源的降級提案 MUST 先以 `end_reason`／`protocol_failed`
+  排除協定噪音」（paulsha-patchmud#24 落地後可直接讀 report `runs[]`）。

--- a/docs/superpowers/specs/benchmark-cost-baseline.md
+++ b/docs/superpowers/specs/benchmark-cost-baseline.md
@@ -144,3 +144,19 @@ state-recovery 0/1），證明變體確實提供獨立訊號，不可抽掉。
   sonnet／opus 級成本會再降。
 - pilot-v1 只覆蓋 builder 維度；planner／reviewer 的成本要等
   `paulsha-patchmud#13` 題庫落地後才能實測。
+
+## 勘誤追記（2026-08-12，cortex#466）
+
+- **§4.3「同母題兩變體 clear 分歧證明變體提供獨立訊號」的證據不成立**：
+  paulsha-patchmud#21 的盤點顯示，本次實測 haiku 的 4 場失敗（含 input-validation
+  兩變體全敗）全是 unified diff 解析失敗（`production_loc: 0`），分歧反映的是
+  逐場的協定格式雜訊，不是變體設計出的獨立能力訊號。「8 關全跑」的定案維持
+  （成本差可忽略、變體對過擬合的偵測能力仍是真需求），但不得再引用本段當
+  變體有效性的實證。
+- **成本外推不受影響**：§2 的 token／wall-time／USD 是 billing facts，與失敗
+  原因無關。惟「haiku 4/8」不可再被引用為能力分佈的證據（同見
+  `envelope-mapping-spec.md` 勘誤追記）。
+- patchmud 已於 PR #15（08-12，本文件實測之後）落地 codex／agy OAuth headless
+  adapter：§3「近期可實測僅 builder 3 格」的前提改變，agy／codex 身分的 builder
+  格已可實測（效力範圍：effort 硬編 high 的檔位）；格數以 `#456` 矩陣的最新
+  狀態為準。

--- a/docs/superpowers/specs/envelope-mapping-spec.md
+++ b/docs/superpowers/specs/envelope-mapping-spec.md
@@ -207,3 +207,22 @@ patchmud_version, report_model, report_loadout) -> dict`：
   `DefaultFallbackTests`（逐欄 source＋理由碼斷言）。
 - 門檻邊界案例：`ClearRateLadderTests`（3/4、1/4 邊界皆含測試，含非二進位分母的
   整數算術案例 9/12、8/12、3/12、2/12）。
+
+## 勘誤追記（2026-08-12，cortex#466）
+
+定案方向不變，但兩處推導依據經 patchmud 端盤點（paulsha-patchmud#21）證實有誤，
+更正如下，避免後人沿假錨點調整門檻：
+
+1. **R2.2 的合理性錨點「haiku 4/8＝0.5 落 `[green]`，廉價模型吃小工作」不成立**：
+   cost-smoke3 那 4 場失敗的 `maintainability_breakdown.production_loc` 全為 0——
+   events.jsonl 顯示是連續 unified diff 解析失敗後棄局，`claim` 文字證明修法
+   早已想對。clear-rate 在 pilot-v1 上對弱模型量到的是「會不會寫 diff」的協定
+   格式能力，對中高階模型則整體飽和（haiku 與 opus 同卡同拿 Power 97.0）。
+2. **結構性後果——pilot-v1 上映射只能把身分「往下降」**：`DEFAULT_ENVELOPE`
+   builder 的 `accepts_bands` 預設即 `[green, yellow]`，與 R2.2 階梯可授予的最高
+   值相同；實測最好情況與預設同值（僅 provenance 換字），唯一改變派工行為的
+   是降級，而降級訊號現階段由上述格式噪音主導。**R3 人工複核閘的操作指引因此
+   追記一條**：pilot-v1 來源的降級提案（`[green]` 或 below-green-floor），落地前
+   MUST 先查 run 封存的 `end_reason`／`protocol_failed`（paulsha-patchmud#24 落地
+   後可直接讀 report `runs[]` 的同名欄位）排除協定噪音；無法排除者維持 default，
+   或等 paulsha-patchmud#21 的 deck 難度改造後重評。

--- a/paulsha_cortex/coordinator/model_profile.py
+++ b/paulsha_cortex/coordinator/model_profile.py
@@ -25,7 +25,6 @@ import os
 import re
 import shutil
 import subprocess
-import tempfile
 import time
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -44,12 +43,16 @@ from .model_identities import (
 
 PROFILE_SCHEMA = "cortex-model-profile/v1"
 
-#: cortex 身分 → patchmud model 別名。誠實約束（#452 票面）：patchmud 目前
-#: 只有 anthropic adapter（別名 sonnet/haiku/opus/fable）；roster 內只有
-#: claude/sonnet 可被驅動，copilot/codex/agy/cg 一律 per-identity skip
-#: （adapter-unavailable）維持 default，禁止假造可跑。
+#: cortex 身分 → patchmud model spec。patchmud 支援 anthropic HTTP／claude CLI
+#: fallback（別名 sonnet/haiku/opus/fable）與 codex／agy OAuth headless CLI
+#: adapter（paulsha-patchmud#14）。約束（cortex#466 A-2）：CLI adapter 的
+#: reasoning effort 硬編 `high`，只有 high 檔位身分可對應；agy 用完整 spec
+#: 而非 patchmud 短別名（別名表會演進）。copilot／cg 無 patchmud adapter，
+#: 一律 per-identity skip（adapter-unavailable）維持 default，禁止假造可跑；
+#: codex 身分待 #456 R4 登錄後再補格。
 PATCHMUD_MODEL_ALIASES: Mapping[tuple[str, str], str] = {
     ("claude", "sonnet"): "sonnet",
+    ("agy", "gemini-3.1-pro-high"): "agy:gemini-3.1-pro",
 }
 
 #: deck 可量測的 persona 維度：pilot-v1 只量 builder（#456 R7 分期註記；
@@ -95,19 +98,67 @@ class ProfileOptions:
 
 
 def deck_content_sha256(deck_dir: Path) -> str:
-    """deck 目錄的 deterministic content hash（排序後逐檔 path+bytes）。"""
+    """deck 指紋＝聚合各 encounter `provenance.yaml` 的 `content_sha256`。
+
+    與 patchmud 的 encounter pin 同語意（card + repo/** + hidden/**，排除快取
+    與 reference_timings）。逐檔 rglob hash 會把 `patchmud validate-deck` 對
+    reference_timings 的例行覆寫誤判成 deck 內容變更、誤觸全量重評
+    （cortex#466 A-3）；provenance 缺漏 fail-closed。
+    """
 
     digest = hashlib.sha256()
-    for path in sorted(p for p in deck_dir.rglob("*") if p.is_file()):
-        digest.update(path.relative_to(deck_dir).as_posix().encode("utf-8"))
+    for encounter in _encounter_dirs(deck_dir):
+        provenance_path = encounter / "provenance.yaml"
+        try:
+            provenance = safe_load(provenance_path.read_text(encoding="utf-8"))
+        except (OSError, UnicodeDecodeError, YAMLError) as exc:
+            raise ValueError(
+                f"encounter provenance 不可讀：{provenance_path}（{type(exc).__name__}: {exc}）"
+            ) from exc
+        content_sha = (
+            provenance.get("content_sha256") if isinstance(provenance, Mapping) else None
+        )
+        if not isinstance(content_sha, str) or not content_sha.strip():
+            raise ValueError(f"encounter provenance 缺 content_sha256：{provenance_path}")
+        digest.update(encounter.name.encode("utf-8"))
         digest.update(b"\0")
-        digest.update(path.read_bytes())
+        digest.update(content_sha.strip().encode("utf-8"))
         digest.update(b"\0")
     return digest.hexdigest()
 
 
 def _encounter_dirs(deck_dir: Path) -> list[Path]:
     return sorted(p for p in deck_dir.iterdir() if p.is_dir())
+
+
+def _report_group_key(report: object) -> tuple[str, str]:
+    """profile report 的聚合鍵 (model, loadout)：從 report 本身取，不猜測。
+
+    patchmud PR #15 起 run.yaml 記 `normalize_model_spec()` 展開後的完整
+    model spec——不是 CLI 別名，且 anthropic↔claude CLI fallback 隨執行當下
+    憑證狀態浮動，別名查表必落空（cortex#466 A-1）。profile 的 runs_root 為
+    單一身分專用，report 內必恰一組聚合鍵；多於一組＝runs_root 被污染，
+    fail-closed。
+    """
+
+    if not isinstance(report, Mapping):
+        raise ValueError("report 必須是 mapping")
+    leaderboards = report.get("leaderboards")
+    board = leaderboards.get("clear_rate") if isinstance(leaderboards, Mapping) else None
+    rows = board.get("rows") if isinstance(board, Mapping) else None
+    if not isinstance(rows, list) or not rows:
+        raise ValueError("report 缺 leaderboards.clear_rate.rows")
+    keys: set[tuple[str, str]] = set()
+    for row in rows:
+        if not isinstance(row, Mapping):
+            raise ValueError(f"clear_rate row 必須是 mapping：{row!r}")
+        keys.add((str(row.get("model")), str(row.get("loadout"))))
+    if len(keys) != 1:
+        raise ValueError(
+            "profile report 應恰含一組 (model, loadout)，實得："
+            + "; ".join(f"{model}/{loadout}" for model, loadout in sorted(keys))
+        )
+    return next(iter(keys))
 
 
 def _emit_scalar(value: object) -> str:
@@ -349,9 +400,9 @@ def run_model_profile(
     current_text = render_registry_file(rows)
     cells: list[dict[str, object]] = []
     applied_any = False
-    timestamp = (now() if now is not None else datetime.now(timezone.utc)).strftime(
-        "%Y-%m-%dT%H:%M:%SZ"
-    )
+    profiled_at = now() if now is not None else datetime.now(timezone.utc)
+    timestamp = profiled_at.strftime("%Y-%m-%dT%H:%M:%SZ")
+    run_stamp = profiled_at.strftime("%Y%m%dT%H%M%SZ")
 
     for identity, persona, persona_measurable in _profile_cells(registry, measured_personas):
         label = f"{identity.executor}/{identity.model_id}"
@@ -384,17 +435,32 @@ def run_model_profile(
             continue
         alias = PATCHMUD_MODEL_ALIASES.get((identity.executor, identity.model_id))
         if alias is None:
-            # 誠實約束：patchmud 僅 anthropic adapter，其餘 executor 不可驅動。
+            # 誠實約束：本身分沒有可驅動的 patchmud model spec 對應。
             cell["status"] = "skipped"
             cell["reason"] = "adapter-unavailable"
             cell["detail"] = (
-                "patchmud 僅 anthropic adapter（sonnet/haiku/opus/fable）；"
+                "PATCHMUD_MODEL_ALIASES 無此身分對應（copilot／cg 無 patchmud "
+                "adapter；CLI adapter effort 硬編 high，非 high 檔位不可對應）；"
                 "本身分維持 default 封套"
             )
             continue
 
-        runs_root = Path(tempfile.mkdtemp(prefix="cortex-model-profile-runs-"))
-        report_root = Path(tempfile.mkdtemp(prefix="cortex-model-profile-report-"))
+        # cortex#466 A-4：run 封存落耐久位置（比照 #455 實測慣例：patchmud
+        # repo runs/，不進版控），registry 的 provenance 才能回溯到 events／
+        # ledger／replay 證據；mkdtemp 用完即棄會讓封套值失去出處。
+        base_runs_root = (
+            Path(patchmud_root)
+            / "runs"
+            / f"profile-{identity.executor}-{identity.model_id}-{run_stamp}"
+        )
+        runs_root = base_runs_root
+        suffix = 1
+        while runs_root.exists():
+            suffix += 1
+            runs_root = base_runs_root.with_name(f"{base_runs_root.name}-{suffix}")
+        runs_root.mkdir(parents=True)
+        report_root = runs_root / "report"
+        cell["runs_root"] = str(runs_root)
         failures: list[str] = []
         for encounter_dir in encounters:
             ok, output = _run_encounter_with_backoff(
@@ -446,6 +512,15 @@ def run_model_profile(
             cell["detail"] = f"{type(exc).__name__}: {exc}"
             continue
         try:
+            # cortex#466 A-1：聚合鍵從 report 本身取（run.yaml 記 normalize
+            # 後的完整 spec，別名查表必落空且隨憑證狀態浮動）。
+            report_model, report_loadout = _report_group_key(report)
+        except ValueError as exc:
+            cell["status"] = "failed"
+            cell["reason"] = "report-group-ambiguous"
+            cell["detail"] = str(exc)
+            continue
+        try:
             mapping = map_report_to_envelope(
                 report,
                 executor=identity.executor,
@@ -453,8 +528,8 @@ def run_model_profile(
                 persona=persona,
                 deck=deck_info,
                 patchmud_version=patchmud_version,
-                report_model=alias,
-                report_loadout=options.loadout,
+                report_model=report_model,
+                report_loadout=report_loadout,
             )
         except EnvelopeMappingError as exc:
             cell["status"] = "failed"
@@ -462,7 +537,9 @@ def run_model_profile(
             cell["detail"] = str(exc)
             continue
         provenance = mapping["provenance"]
-        cell["observation"] = dict(provenance["observation"])
+        # A-4：觀測記錄帶 run 封存出處（observation 為自由欄，loader 不設鍵白名單）。
+        observation = {**dict(provenance["observation"]), "runs_root": str(runs_root)}
+        cell["observation"] = observation
         cell["mapping_reasons"] = dict(provenance["reasons"])
         if not provenance["registry_writable"]:
             # 空的實測 accepts_bands（below-green-floor）或全 default 結果不得
@@ -483,7 +560,7 @@ def run_model_profile(
             "fingerprint": dict(provenance["fingerprint"]),
             "source": dict(provenance["source"]),
             "reasons": dict(provenance["reasons"]),
-            "observation": dict(provenance["observation"]),
+            "observation": dict(observation),
             "profiled_at": timestamp,
         }
         proposed_text = render_registry_file(proposed_rows)

--- a/paulsha_cortex/coordinator/model_profile.py
+++ b/paulsha_cortex/coordinator/model_profile.py
@@ -43,7 +43,8 @@ from .model_identities import (
 
 PROFILE_SCHEMA = "cortex-model-profile/v1"
 
-#: cortex 身分 → patchmud model spec。patchmud 支援 anthropic HTTP／claude CLI
+#: cortex 身分 → patchmud `--model` 參數值（短別名或完整 spec 皆可，patchmud
+#: 端會 normalize）。patchmud 支援 anthropic HTTP／claude CLI
 #: fallback（別名 sonnet/haiku/opus/fable）與 codex／agy OAuth headless CLI
 #: adapter（paulsha-patchmud#14）。約束（cortex#466 A-2）：CLI adapter 的
 #: reasoning effort 硬編 `high`，只有 high 檔位身分可對應；agy 用完整 spec
@@ -152,7 +153,13 @@ def _report_group_key(report: object) -> tuple[str, str]:
     for row in rows:
         if not isinstance(row, Mapping):
             raise ValueError(f"clear_rate row 必須是 mapping：{row!r}")
-        keys.add((str(row.get("model")), str(row.get("loadout"))))
+        model = row.get("model")
+        loadout = row.get("loadout")
+        if not isinstance(model, str) or not model.strip():
+            raise ValueError(f"clear_rate row 缺非空 model：{row!r}")
+        if not isinstance(loadout, str) or not loadout.strip():
+            raise ValueError(f"clear_rate row 缺非空 loadout：{row!r}")
+        keys.add((model.strip(), loadout.strip()))
     if len(keys) != 1:
         raise ValueError(
             "profile report 應恰含一組 (model, loadout)，實得："

--- a/tests/test_model_profile_cli.py
+++ b/tests/test_model_profile_cli.py
@@ -316,6 +316,31 @@ def test_report_with_multiple_groups_is_explicit_failure(
     assert fake_patchmud.registry.read_text(encoding="utf-8") == REGISTRY_V3
 
 
+def test_report_row_without_model_is_explicit_failure(
+    fake_patchmud: SimpleNamespace,
+) -> None:
+    """malformed row（缺 model）不得被 str(None) 誤當成合法聚合鍵（review）。"""
+    template = (
+        "schema_version: 1\n"
+        "runs_included: 8\n"
+        "runs_skipped: []\n"
+        "leaderboards:\n"
+        "  clear_rate:\n"
+        "    status: ok\n"
+        "    rows:\n"
+        "      - loadout: P0T0R0\n"
+        "        runs: 8\n"
+        "        clears: 6\n"
+    )
+    (fake_patchmud.tools / "report-template.yaml").write_text(template, encoding="utf-8")
+    result = mp.run_model_profile(_options(fake_patchmud, apply=True), sleep=lambda _s: None)
+    cell = _cells_by_key(result)[("claude", "sonnet", "builder")]
+    assert cell["status"] == "failed"
+    assert cell["reason"] == "report-group-ambiguous"
+    assert "缺非空 model" in cell["detail"]
+    assert fake_patchmud.registry.read_text(encoding="utf-8") == REGISTRY_V3
+
+
 def test_deck_fingerprint_stable_across_timings_overwrite(
     fake_patchmud: SimpleNamespace,
 ) -> None:

--- a/tests/test_model_profile_cli.py
+++ b/tests/test_model_profile_cli.py
@@ -72,7 +72,12 @@ if __name__ == "__main__":
 """
 
 
-def _report_yaml(*, clears: int, runs: int = 8, model: str = "sonnet") -> str:
+def _report_yaml(
+    *, clears: int, runs: int = 8, model: str = "anthropic:claude-sonnet-5"
+) -> str:
+    # 聚合鍵 model 預設用 normalize 後的完整 spec（patchmud PR #15 起 run.yaml
+    # 即如此記錄）——與 CLI 別名 `sonnet` 不同，鎖住 #466 A-1「鍵值從 report
+    # 本身取」的修法。
     return (
         "schema_version: 1\n"
         f"runs_included: {runs}\n"
@@ -108,6 +113,10 @@ def fake_patchmud(tmp_path: Path) -> SimpleNamespace:
         encounter = deck / name
         encounter.mkdir(parents=True)
         (encounter / "card.yaml").write_text(f"id: {name}\n", encoding="utf-8")
+        # deck 指紋取自各 encounter 的 provenance pin（#466 A-3）。
+        (encounter / "provenance.yaml").write_text(
+            f"content_sha256: sha-{name}\n", encoding="utf-8"
+        )
     (root / "VERSION").write_text("0.0.1\n", encoding="utf-8")
     tools = tmp_path / "tools"
     tools.mkdir()
@@ -205,10 +214,10 @@ def test_profile_apply_writes_registry_and_fingerprint_skip_then_force(
     second = mp.run_model_profile(_options(fake_patchmud), sleep=lambda _s: None)
     assert _cells_by_key(second)[("claude", "sonnet", "builder")]["status"] == "already-profiled"
 
-    # deck 內容 pin 變更 → 指紋不同 → 重評。
-    (fake_patchmud.root / "decks" / "pilot-v1" / ENCOUNTERS[0] / "card.yaml").write_text(
-        "id: mutated\n", encoding="utf-8"
-    )
+    # deck 內容 pin 變更（encounter provenance 重 pin）→ 指紋不同 → 重評。
+    (
+        fake_patchmud.root / "decks" / "pilot-v1" / ENCOUNTERS[0] / "provenance.yaml"
+    ).write_text("content_sha256: sha-mutated\n", encoding="utf-8")
     changed = mp.run_model_profile(_options(fake_patchmud), sleep=lambda _s: None)
     assert _cells_by_key(changed)[("claude", "sonnet", "builder")]["status"] == "proposed"
 
@@ -273,6 +282,76 @@ def test_incomplete_deck_sample_falls_back_to_default(fake_patchmud: SimpleNames
     assert cell["status"] == "not-writable"
     assert cell["reason"] == "incomplete-deck-sample"
     assert fake_patchmud.registry.read_text(encoding="utf-8") == REGISTRY_V3
+
+
+def test_report_group_key_taken_from_report_not_alias(
+    fake_patchmud: SimpleNamespace,
+) -> None:
+    """#466 A-1：run.yaml 記 normalize 後的完整 spec，鍵值必須從 report 取。
+
+    fixture 模板的聚合鍵是 `anthropic:claude-sonnet-5`（≠ CLI 別名 `sonnet`）；
+    別名查表的舊實作在此必落 identity-not-in-report。"""
+    result = mp.run_model_profile(_options(fake_patchmud), sleep=lambda _s: None)
+    cell = _cells_by_key(result)[("claude", "sonnet", "builder")]
+    assert cell["status"] == "proposed"
+    assert cell["observation"]["model"] == "anthropic:claude-sonnet-5"
+
+
+def test_report_with_multiple_groups_is_explicit_failure(
+    fake_patchmud: SimpleNamespace,
+) -> None:
+    """profile 的 runs_root 為單一身分專用：report 多於一組聚合鍵＝污染，
+    fail-closed 明確報錯，不得猜一組來映射。"""
+    template = _report_yaml(clears=6) + (
+        "      - model: agy:gemini-3.1-pro\n"
+        "        loadout: P0T0R0\n"
+        "        runs: 8\n"
+        "        clears: 8\n"
+    )
+    (fake_patchmud.tools / "report-template.yaml").write_text(template, encoding="utf-8")
+    result = mp.run_model_profile(_options(fake_patchmud, apply=True), sleep=lambda _s: None)
+    cell = _cells_by_key(result)[("claude", "sonnet", "builder")]
+    assert cell["status"] == "failed"
+    assert cell["reason"] == "report-group-ambiguous"
+    assert fake_patchmud.registry.read_text(encoding="utf-8") == REGISTRY_V3
+
+
+def test_deck_fingerprint_stable_across_timings_overwrite(
+    fake_patchmud: SimpleNamespace,
+) -> None:
+    """#466 A-3：`patchmud validate-deck` 覆寫 reference_timings（或殘留快取）
+    不得使 deck 指紋漂移；指紋只跟 encounter provenance pin 走。"""
+    deck_dir = fake_patchmud.root / "decks" / "pilot-v1"
+    before = mp.deck_content_sha256(deck_dir)
+
+    hidden = deck_dir / ENCOUNTERS[0] / "hidden"
+    hidden.mkdir()
+    (hidden / "reference_timings.yaml").write_text(
+        "schema_version: 1\ntimings_ms: {}\n", encoding="utf-8"
+    )
+    assert mp.deck_content_sha256(deck_dir) == before
+
+    (deck_dir / ENCOUNTERS[0] / "provenance.yaml").write_text(
+        "content_sha256: sha-repinned\n", encoding="utf-8"
+    )
+    assert mp.deck_content_sha256(deck_dir) != before
+
+
+def test_profile_runs_archived_durably_and_traceable(
+    fake_patchmud: SimpleNamespace,
+) -> None:
+    """#466 A-4：run 封存落 patchmud runs/（耐久），registry provenance 的
+    observation.runs_root 可回溯到仍存在的封存目錄。"""
+    applied = mp.run_model_profile(_options(fake_patchmud, apply=True), sleep=lambda _s: None)
+    cell = _cells_by_key(applied)[("claude", "sonnet", "builder")]
+    runs_root = Path(cell["runs_root"])
+    assert runs_root.is_dir()
+    assert runs_root.parent == fake_patchmud.root / "runs"
+    assert (runs_root / f"profile-claude-sonnet-{ENCOUNTERS[0]}").is_dir()
+
+    registry = _load_model_identity_file(fake_patchmud.registry)
+    provenance = registry.require("claude", "sonnet").profile_provenance
+    assert provenance["observation"]["runs_root"] == str(runs_root)
 
 
 def test_porcelain_model_profile_text_output(fake_patchmud: SimpleNamespace, capsys) -> None:


### PR DESCRIPTION
Closes #466

## 背景

`#452`（PR #462）對著 patchmud v0.0.1 @ `abdf808` 驗證定案；patchmud PR #15 在七小時後落地一批行為變更，加上 patchmud 2026-08-12 的評測盤點（paulsha-patchmud#21～#24），profile 巷道一處已實際破裂、數處假設過時。本 PR 收攏修正，`map_report_to_envelope()` 純函式介面與既有定案方向不動。

## 修正（`paulsha_cortex/coordinator/model_profile.py`）

- **A-1 report 聚合鍵改從 report 本身取**：patchmud main 的 `run.yaml` 記 `normalize_model_spec()` 展開後的完整 spec（非 CLI 別名，且 anthropic↔claude CLI fallback 隨憑證狀態浮動），舊實作以別名查 `clear_rate` 榜必落 `identity-not-in-report`。新增 `_report_group_key()`：profile 的 runs_root 為單一身分專用，report 內必恰一組 `(model, loadout)`，多組即 `report-group-ambiguous` fail-closed。
- **A-2 adapter 別名表更新**：patchmud 已落地 codex／agy OAuth headless adapter（paulsha-patchmud#14）；補 `agy/gemini-3.1-pro-high → agy:gemini-3.1-pro`（完整 spec、不用短別名），更正「僅 anthropic adapter」過時註解，明寫 CLI effort 硬編 `high` 的對應限制。codex 身分待 #456 R4 登錄後補格。
- **A-3 deck 指紋改聚合 encounter provenance pin**：原 rglob 全檔 hash 會把 `patchmud validate-deck` 對 `reference_timings` 的例行覆寫誤判成 deck 變更、誤觸全量重評；改聚合各 encounter `provenance.yaml` 的 `content_sha256`（與 `#452` D 票面「encounter_content_sha256」原意一致），缺漏 fail-closed。
- **A-4 run 封存耐久化**：runs_root 從 `mkdtemp` 改落 patchmud repo `runs/profile-<executor>-<model_id>-<stamp>/`（比照 #455 實測慣例，不進版控），`profile_provenance.observation.runs_root` 記出處——封套值可回溯到 events／ledger／replay 證據。

## spec 勘誤追記（定案方向不變）

- `envelope-mapping-spec.md`：R2.2 的「haiku 4/8」錨點實為 unified diff 協定噪音（paulsha-patchmud#21）；追記 R3 人工閘操作指引——pilot-v1 來源的**降級**提案 MUST 先以 `end_reason`／`protocol_failed` 排除協定噪音（paulsha-patchmud#24 落地後可直接讀 report `runs[]`）。
- `benchmark-cost-baseline.md`：§4.3 變體分歧證據同批噪音（全跑定案維持，證據引用更正）；§3 的「僅 builder 3 格」前提因 codex／agy adapter 落地而改變。

## 驗證

- `tests/test_model_profile_cli.py`：15 passed（fixture 報表聚合鍵改用 `anthropic:claude-sonnet-5` 鎖 A-1；新增多組聚合鍵 fail-closed、timings 覆寫指紋穩定、run 封存可回溯三案；指紋變更測試改為 provenance 重 pin 觸發）。
- 全套 `python3 -m pytest -q`：**2462 passed**；`tests/test_fix_dispatch_spec_path.py` 兩案在 main 上即失敗（本機 `~/.agents` 環境相關，與本 PR 無關）。
- 本機以 pinned 引擎（v1.0.15 @ a764806）帶 PR context 跑 `policy_check` 無 failure。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012GaAW12AtreaDpskkk8DeP
