### PR TITLE
fix(coordinator): provenance pin 改行掃描——真 deck 多行欄位不再誤觸 fail-closed

### DIFF
--- a/changelog.d/provenance-pin-line-scan.md
+++ b/changelog.d/provenance-pin-line-scan.md
@@ -1,0 +1,8 @@
+# provenance-pin-line-scan
+
+- **#466 實跑驗證的 follow-up：deck 指紋的 provenance pin 改行掃描**——A-3 原實作把整份
+  `provenance.yaml` 餵零依賴 subset YAML parser，但真 deck 的 provenance 含多行自由文字
+  欄位（`variant_notes` zh-TW 折行），超出 parser 子集，`cortex model profile` 對真
+  pilot-v1 直接 fail-closed 誤觸（`unexpected indentation`）。改為行掃描機器寫入、格式
+  固定的頂層 `content_sha256: <64 hex>` pin 行（恰一行才收，容許引號），已對真 deck
+  全 8 關驗證；fixture 加入多行折行欄位鎖回歸。

--- a/paulsha_cortex/coordinator/model_profile.py
+++ b/paulsha_cortex/coordinator/model_profile.py
@@ -74,6 +74,8 @@ DEFAULT_DECK_ID = "pilot-v1"
 DEFAULT_LOADOUT = "P0T0R0"
 
 _RATE_LIMIT_RE = re.compile(r"\b429\b|rate.?limit", re.IGNORECASE)
+#: encounter provenance 的 pin 行（patchmud 機器寫入：頂層 64-hex，容許引號）。
+_CONTENT_SHA_LINE_RE = re.compile(r"^content_sha256:\s*['\"]?([0-9a-f]{64})['\"]?\s*$")
 _MAX_ENCOUNTER_ATTEMPTS = 3
 _PLAIN_SCALAR_RE = re.compile(r"[A-Za-z][A-Za-z0-9._+:/@#-]*")
 
@@ -111,19 +113,28 @@ def deck_content_sha256(deck_dir: Path) -> str:
     for encounter in _encounter_dirs(deck_dir):
         provenance_path = encounter / "provenance.yaml"
         try:
-            provenance = safe_load(provenance_path.read_text(encoding="utf-8"))
-        except (OSError, UnicodeDecodeError, YAMLError) as exc:
+            text = provenance_path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError) as exc:
             raise ValueError(
                 f"encounter provenance 不可讀：{provenance_path}（{type(exc).__name__}: {exc}）"
             ) from exc
-        content_sha = (
-            provenance.get("content_sha256") if isinstance(provenance, Mapping) else None
-        )
-        if not isinstance(content_sha, str) or not content_sha.strip():
-            raise ValueError(f"encounter provenance 缺 content_sha256：{provenance_path}")
+        # 行掃描取 pin，不整份餵 subset YAML parser：provenance 含自由文字
+        # 多行欄位（如 variant_notes 折行），超出零依賴 parser 的子集，實跑
+        # pilot-v1 已踩到 fail-closed 誤觸。pin 行由 patchmud 機器寫入、
+        # 格式固定（頂層 `content_sha256: <64 hex>`），恰一行才收。
+        matches = [
+            match.group(1)
+            for line in text.splitlines()
+            if (match := _CONTENT_SHA_LINE_RE.match(line))
+        ]
+        if len(matches) != 1:
+            raise ValueError(
+                f"encounter provenance 應恰含一行 content_sha256 pin"
+                f"（實得 {len(matches)} 行）：{provenance_path}"
+            )
         digest.update(encounter.name.encode("utf-8"))
         digest.update(b"\0")
-        digest.update(content_sha.strip().encode("utf-8"))
+        digest.update(matches[0].encode("utf-8"))
         digest.update(b"\0")
     return digest.hexdigest()
 

--- a/tests/test_model_profile_cli.py
+++ b/tests/test_model_profile_cli.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import stat
@@ -93,6 +94,11 @@ def _report_yaml(
     )
 
 
+def _pin(seed: str) -> str:
+    """仿 patchmud pin 格式的 deterministic 64-hex。"""
+    return hashlib.sha256(seed.encode("utf-8")).hexdigest()
+
+
 ENCOUNTERS = (
     "input-validation-v1",
     "input-validation-v2",
@@ -113,9 +119,16 @@ def fake_patchmud(tmp_path: Path) -> SimpleNamespace:
         encounter = deck / name
         encounter.mkdir(parents=True)
         (encounter / "card.yaml").write_text(f"id: {name}\n", encoding="utf-8")
-        # deck 指紋取自各 encounter 的 provenance pin（#466 A-3）。
+        # deck 指紋取自各 encounter 的 provenance pin（#466 A-3）。仿真 deck 的
+        # provenance 形狀：pin 之外還有多行自由文字欄位（zh-TW 折行）——
+        # subset YAML parser 讀不了整份文件，pin 必須以行掃描取（回歸鎖）。
         (encounter / "provenance.yaml").write_text(
-            f"content_sha256: sha-{name}\n", encoding="utf-8"
+            "schema_version: 1\n"
+            f"issue_id: {name}\n"
+            "variant_notes: 多行自由文字欄位\n"
+            "  ——第二行縮排折行，subset parser 不支援的 plain scalar\n"
+            f"content_sha256: {_pin(name)}\n",
+            encoding="utf-8",
         )
     (root / "VERSION").write_text("0.0.1\n", encoding="utf-8")
     tools = tmp_path / "tools"
@@ -217,7 +230,7 @@ def test_profile_apply_writes_registry_and_fingerprint_skip_then_force(
     # deck 內容 pin 變更（encounter provenance 重 pin）→ 指紋不同 → 重評。
     (
         fake_patchmud.root / "decks" / "pilot-v1" / ENCOUNTERS[0] / "provenance.yaml"
-    ).write_text("content_sha256: sha-mutated\n", encoding="utf-8")
+    ).write_text(f"content_sha256: {_pin('mutated')}\n", encoding="utf-8")
     changed = mp.run_model_profile(_options(fake_patchmud), sleep=lambda _s: None)
     assert _cells_by_key(changed)[("claude", "sonnet", "builder")]["status"] == "proposed"
 
@@ -357,7 +370,7 @@ def test_deck_fingerprint_stable_across_timings_overwrite(
     assert mp.deck_content_sha256(deck_dir) == before
 
     (deck_dir / ENCOUNTERS[0] / "provenance.yaml").write_text(
-        "content_sha256: sha-repinned\n", encoding="utf-8"
+        f"content_sha256: {_pin('repinned')}\n", encoding="utf-8"
     )
     assert mp.deck_content_sha256(deck_dir) != before
 


### PR DESCRIPTION
Refs #466（實跑驗證 follow-up）

## 現象

`#467` 合併後的首次實跑 `cortex model profile --identity claude/sonnet` 在 deck 指紋階段即失敗：

```
錯誤: encounter provenance 不可讀：decks/pilot-v1/input-validation-v2/provenance.yaml（YAMLError: unexpected indentation at line 6）
```

A-3 的實作把整份 `provenance.yaml` 餵零依賴 subset YAML parser，但真 deck 的 provenance 含多行自由文字欄位（`variant_notes` zh-TW 折行 plain scalar），超出 parser 子集——fail-closed 在完全合法的 YAML 上誤觸。

## 修法

不整份解析：pin 行由 patchmud 機器寫入、格式固定（頂層 `content_sha256: <64 hex>`），改用行掃描正則取值，**恰一行才收**（0 行或多行皆 fail-closed），容許引號。已確認真 pilot-v1 全 8 關的 provenance 皆恰一行且格式吻合，並對真 deck 實算出指紋。

## 驗證

- `tests/test_model_profile_cli.py`：16 passed；fixture 的 provenance 仿真加入多行折行欄位（回歸鎖），pin 改 deterministic 64-hex。
- 對真 deck 實算：`deck_content_sha256(decks/pilot-v1)` 正常產出。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012GaAW12AtreaDpskkk8DeP