### PR TITLE
fix(coordinator): profile 巷道優先讀 report.json，subset YAML parser 補 indentless sequence

### DIFF
--- a/changelog.d/report-json-preferred.md
+++ b/changelog.d/report-json-preferred.md
@@ -1,0 +1,9 @@
+# report-json-preferred
+
+- **#466 實跑驗證 follow-up（二）：profile 巷道優先讀 `report.json`，subset YAML
+  parser 補 indentless sequence**——真 report.yaml（PyYAML `safe_dump`）連踩兩個
+  subset parser 讀不了的形狀：indentless block sequence（`rows:` 後同縮排 `- `）
+  與長 quoted scalar 折行（eutb reason 實例）。`_yaml.safe_load` 補前者（只在
+  「空值 key 緊接同縮排 dash」時轉序列解析，純擴大接受集，`tests/test_yaml_subset.py`
+  鎖回歸）；後者不追平 PyYAML folding——改吃 patchmud#26 新落盤的 `report.json`
+  機器契約，無檔時退回 YAML fallback（相容舊版 patchmud）。

--- a/paulsha_cortex/_yaml.py
+++ b/paulsha_cortex/_yaml.py
@@ -78,6 +78,17 @@ def safe_load(text: str):
                 result[key] = _parse_scalar(value_text)
                 i += 1
                 continue
+            if (
+                i + 1 < len(lines)
+                and lines[i + 1][1] == current_indent
+                and lines[i + 1][2].startswith("- ")
+            ):
+                # indentless block sequence（PyYAML safe_dump 預設輸出）：
+                # `key:` 之後、同縮排的 `- ` 序列屬於該 key。只在「空值 key
+                # 緊接同縮排 dash」時觸發，純擴大接受集，不改既有可解文件。
+                nested, i = parse_list(i + 1, current_indent)
+                result[key] = nested
+                continue
             if i + 1 >= len(lines) or lines[i + 1][1] <= current_indent:
                 result[key] = {}
                 i += 1

--- a/paulsha_cortex/coordinator/model_profile.py
+++ b/paulsha_cortex/coordinator/model_profile.py
@@ -31,7 +31,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Callable, Mapping, Sequence
 
-from .._yaml import YAMLError, safe_load
+from .._yaml import safe_load
 from .envelope_mapping import EnvelopeMappingError, map_report_to_envelope
 from .model_identities import (
     ENVELOPE_FIELDS,
@@ -521,10 +521,18 @@ def run_model_profile(
             cell["reason"] = "report-failed"
             cell["detail"] = report_output.strip()[:400]
             continue
-        report_path = report_root / "report.yaml"
+        # 機器契約優先（paulsha-patchmud#26）：report.json 零歧義；無檔時退回
+        # subset YAML parser（相容舊版 patchmud——PyYAML 的長 scalar 折行
+        # 形狀仍可能超出子集，實跑驗證已踩過，升級 patchmud 即免疫）。
+        json_path = report_root / "report.json"
+        yaml_path = report_root / "report.yaml"
         try:
-            report = safe_load(report_path.read_text(encoding="utf-8"))
-        except (OSError, UnicodeDecodeError, YAMLError) as exc:
+            if json_path.is_file():
+                report = json.loads(json_path.read_text(encoding="utf-8"))
+            else:
+                report = safe_load(yaml_path.read_text(encoding="utf-8"))
+        except (OSError, UnicodeDecodeError, ValueError) as exc:
+            # json.JSONDecodeError 與 YAMLError 皆為 ValueError 子類。
             cell["status"] = "failed"
             cell["reason"] = "report-unreadable"
             cell["detail"] = f"{type(exc).__name__}: {exc}"

--- a/tests/test_model_profile_cli.py
+++ b/tests/test_model_profile_cli.py
@@ -60,8 +60,16 @@ def main():
     if cmd == "report":
         out = Path(opt(args, "--out"))
         out.mkdir(parents=True, exist_ok=True)
-        template = (HERE / "report-template.yaml").read_text(encoding="utf-8")
-        (out / "report.yaml").write_text(template, encoding="utf-8")
+        wrote = False
+        for name in ("report-template.json", "report-template.yaml"):
+            src = HERE / name
+            if src.exists():
+                target = out / name.replace("-template", "")
+                target.write_text(src.read_text(encoding="utf-8"), encoding="utf-8")
+                wrote = True
+        if not wrote:
+            print("fake patchmud: no report template", file=sys.stderr)
+            return 2
         print("report 輸出：" + str(out / "report.yaml"))
         return 0
     print("未知子命令", file=sys.stderr)
@@ -73,24 +81,53 @@ if __name__ == "__main__":
 """
 
 
-def _report_yaml(
-    *, clears: int, runs: int = 8, model: str = "anthropic:claude-sonnet-5"
-) -> str:
+def _report_dict(
+    *,
+    clears: int,
+    runs: int = 8,
+    model: str = "anthropic:claude-sonnet-5",
+    loadout: str = "P0T0R0",
+) -> dict:
     # 聚合鍵 model 預設用 normalize 後的完整 spec（patchmud PR #15 起 run.yaml
     # 即如此記錄）——與 CLI 別名 `sonnet` 不同，鎖住 #466 A-1「鍵值從 report
     # 本身取」的修法。
+    return {
+        "schema_version": 1,
+        "runs_included": runs,
+        "runs_skipped": [],
+        "leaderboards": {
+            "clear_rate": {
+                "status": "ok",
+                "rows": [
+                    {"model": model, "loadout": loadout, "runs": runs, "clears": clears}
+                ],
+            }
+        },
+    }
+
+
+def _report_json(**kwargs) -> str:
+    """機器契約模板（paulsha-patchmud#26）——lane 預設走 report.json。"""
+    return json.dumps(_report_dict(**kwargs), ensure_ascii=False, sort_keys=True)
+
+
+def _report_yaml(**kwargs) -> str:
+    """YAML fallback 模板：舊版 patchmud 只落 report.yaml 的相容路徑。
+    刻意用 PyYAML 的 indentless sequence 形狀，一併鎖住 subset parser 修正。"""
+    payload = _report_dict(**kwargs)
+    row = payload["leaderboards"]["clear_rate"]["rows"][0]
     return (
-        "schema_version: 1\n"
-        f"runs_included: {runs}\n"
-        "runs_skipped: []\n"
         "leaderboards:\n"
         "  clear_rate:\n"
-        "    status: ok\n"
         "    rows:\n"
-        f"      - model: {model}\n"
-        "        loadout: P0T0R0\n"
-        f"        runs: {runs}\n"
-        f"        clears: {clears}\n"
+        f"    - clears: {row['clears']}\n"
+        f"      loadout: {row['loadout']}\n"
+        f"      model: {row['model']}\n"
+        f"      runs: {row['runs']}\n"
+        "    status: ok\n"
+        f"runs_included: {payload['runs_included']}\n"
+        "runs_skipped: []\n"
+        "schema_version: 1\n"
     )
 
 
@@ -136,7 +173,7 @@ def fake_patchmud(tmp_path: Path) -> SimpleNamespace:
     bin_path = tools / "patchmud"
     bin_path.write_text(_FAKE_PATCHMUD, encoding="utf-8")
     bin_path.chmod(bin_path.stat().st_mode | stat.S_IXUSR)
-    (tools / "report-template.yaml").write_text(_report_yaml(clears=6), encoding="utf-8")
+    (tools / "report-template.json").write_text(_report_json(clears=6), encoding="utf-8")
     registry = tmp_path / "model-identities.yaml"
     registry.write_text(REGISTRY_V3, encoding="utf-8")
     return SimpleNamespace(root=root, bin=bin_path, registry=registry, tools=tools)
@@ -240,8 +277,8 @@ def test_profile_apply_writes_registry_and_fingerprint_skip_then_force(
 
 
 def test_below_green_floor_is_never_written(fake_patchmud: SimpleNamespace) -> None:
-    (fake_patchmud.tools / "report-template.yaml").write_text(
-        _report_yaml(clears=1), encoding="utf-8"
+    (fake_patchmud.tools / "report-template.json").write_text(
+        _report_json(clears=1), encoding="utf-8"
     )
     result = mp.run_model_profile(_options(fake_patchmud, apply=True), sleep=lambda _s: None)
     cell = _cells_by_key(result)[("claude", "sonnet", "builder")]
@@ -287,8 +324,8 @@ def test_rate_limit_backoff_retries_encounters(fake_patchmud: SimpleNamespace) -
 
 def test_incomplete_deck_sample_falls_back_to_default(fake_patchmud: SimpleNamespace) -> None:
     # report 只聚到 5/8 run → incomplete-deck-sample，誠實維持 default、不落檔。
-    (fake_patchmud.tools / "report-template.yaml").write_text(
-        _report_yaml(clears=4, runs=5), encoding="utf-8"
+    (fake_patchmud.tools / "report-template.json").write_text(
+        _report_json(clears=4, runs=5), encoding="utf-8"
     )
     result = mp.run_model_profile(_options(fake_patchmud, apply=True), sleep=lambda _s: None)
     cell = _cells_by_key(result)[("claude", "sonnet", "builder")]
@@ -310,18 +347,33 @@ def test_report_group_key_taken_from_report_not_alias(
     assert cell["observation"]["model"] == "anthropic:claude-sonnet-5"
 
 
+def test_yaml_only_report_falls_back_to_subset_parser(
+    fake_patchmud: SimpleNamespace,
+) -> None:
+    """舊版 patchmud 只落 report.yaml：fallback 走 subset parser——模板刻意用
+    PyYAML 的 indentless sequence 形狀，一併鎖住 parser 修正（#466 實跑回歸）。"""
+    (fake_patchmud.tools / "report-template.json").unlink()
+    (fake_patchmud.tools / "report-template.yaml").write_text(
+        _report_yaml(clears=6), encoding="utf-8"
+    )
+    result = mp.run_model_profile(_options(fake_patchmud), sleep=lambda _s: None)
+    cell = _cells_by_key(result)[("claude", "sonnet", "builder")]
+    assert cell["status"] == "proposed"
+    assert cell["envelope"]["accepts_bands"] == ["green", "yellow"]
+
+
 def test_report_with_multiple_groups_is_explicit_failure(
     fake_patchmud: SimpleNamespace,
 ) -> None:
     """profile 的 runs_root 為單一身分專用：report 多於一組聚合鍵＝污染，
     fail-closed 明確報錯，不得猜一組來映射。"""
-    template = _report_yaml(clears=6) + (
-        "      - model: agy:gemini-3.1-pro\n"
-        "        loadout: P0T0R0\n"
-        "        runs: 8\n"
-        "        clears: 8\n"
+    payload = _report_dict(clears=6)
+    payload["leaderboards"]["clear_rate"]["rows"].append(
+        {"model": "agy:gemini-3.1-pro", "loadout": "P0T0R0", "runs": 8, "clears": 8}
     )
-    (fake_patchmud.tools / "report-template.yaml").write_text(template, encoding="utf-8")
+    (fake_patchmud.tools / "report-template.json").write_text(
+        json.dumps(payload), encoding="utf-8"
+    )
     result = mp.run_model_profile(_options(fake_patchmud, apply=True), sleep=lambda _s: None)
     cell = _cells_by_key(result)[("claude", "sonnet", "builder")]
     assert cell["status"] == "failed"
@@ -333,19 +385,11 @@ def test_report_row_without_model_is_explicit_failure(
     fake_patchmud: SimpleNamespace,
 ) -> None:
     """malformed row（缺 model）不得被 str(None) 誤當成合法聚合鍵（review）。"""
-    template = (
-        "schema_version: 1\n"
-        "runs_included: 8\n"
-        "runs_skipped: []\n"
-        "leaderboards:\n"
-        "  clear_rate:\n"
-        "    status: ok\n"
-        "    rows:\n"
-        "      - loadout: P0T0R0\n"
-        "        runs: 8\n"
-        "        clears: 6\n"
+    payload = _report_dict(clears=6)
+    del payload["leaderboards"]["clear_rate"]["rows"][0]["model"]
+    (fake_patchmud.tools / "report-template.json").write_text(
+        json.dumps(payload), encoding="utf-8"
     )
-    (fake_patchmud.tools / "report-template.yaml").write_text(template, encoding="utf-8")
     result = mp.run_model_profile(_options(fake_patchmud, apply=True), sleep=lambda _s: None)
     cell = _cells_by_key(result)[("claude", "sonnet", "builder")]
     assert cell["status"] == "failed"

--- a/tests/test_yaml_subset.py
+++ b/tests/test_yaml_subset.py
@@ -1,0 +1,76 @@
+"""`paulsha_cortex._yaml` subset parser 的回歸測試。
+
+觸發事件（#466 實跑驗證）：`patchmud report` 以 PyYAML `safe_dump` 落盤的
+report.yaml 使用 **indentless block sequence**（`key:` 之後、同縮排的 `- ` 序列
+——PyYAML 預設輸出形狀），subset parser 原本在 `parse_mapping` 把空值 key 當
+空 dict 吞掉、隨即在 dash 行炸 `unexpected indentation`，`cortex model profile`
+的 report 讀取整條斷掉。修正只在「空值 key 緊接同縮排 dash」時轉進序列解析，
+純擴大接受集。
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from paulsha_cortex._yaml import YAMLError, safe_load
+
+
+def test_indentless_block_sequence_under_mapping_key() -> None:
+    text = (
+        "leaderboards:\n"
+        "  clear_rate:\n"
+        "    rows:\n"
+        "    - clears: 8\n"
+        "      loadout: P0T0R0\n"
+        "      model: claude:claude-sonnet-5\n"
+        "      runs: 8\n"
+        "      value: 1.0\n"
+        "    status: ok\n"
+    )
+    parsed = safe_load(text)
+    board = parsed["leaderboards"]["clear_rate"]
+    assert board["status"] == "ok"
+    # 注意 value 是字串：subset parser 的 scalar 只認 int（isdigit），float
+    # 維持原文——envelope mapping 規格本就只吃整數 runs/clears、不用浮點 value。
+    assert board["rows"] == [
+        {
+            "clears": 8,
+            "loadout": "P0T0R0",
+            "model": "claude:claude-sonnet-5",
+            "runs": 8,
+            "value": "1.0",
+        }
+    ]
+
+
+def test_indentless_sequence_at_top_level_key() -> None:
+    text = (
+        "runs:\n"
+        "- clear: 1\n"
+        "  encounter: input-validation-v1\n"
+        "  end_reason: commit\n"
+        "- clear: 0\n"
+        "  encounter: parser-edge-v1\n"
+        "  end_reason: 'failed:protocol'\n"
+        "schema_version: 1\n"
+    )
+    parsed = safe_load(text)
+    assert parsed["schema_version"] == 1
+    assert [row["encounter"] for row in parsed["runs"]] == [
+        "input-validation-v1",
+        "parser-edge-v1",
+    ]
+    assert parsed["runs"][1]["end_reason"] == "failed:protocol"
+
+
+def test_indented_sequence_still_parses() -> None:
+    """既有縮排式序列（fixture／手寫 YAML 常見）行為不變。"""
+    text = "rows:\n  - model: a\n    runs: 8\n  - model: b\n    runs: 8\n"
+    parsed = safe_load(text)
+    assert [row["model"] for row in parsed["rows"]] == ["a", "b"]
+
+
+def test_dash_without_preceding_empty_key_is_still_rejected() -> None:
+    """dash 不緊接空值 key（真 malformed）仍要炸，不得被新分支吞掉。"""
+    with pytest.raises(YAMLError):
+        safe_load("a: 1\n- x\n")


### PR DESCRIPTION
Refs #466（實跑驗證 follow-up 之二）＋ 相依 paulsha-patchmud#26（PR paulsha-patchmud#27）

## 現象

實跑驗證第二輪（provenance pin 修正後）：**8 關全部跑完**（sonnet 8/8 clear），但 report 讀取踩到 PyYAML `safe_dump` 的兩個輸出形狀：

1. **indentless block sequence**：`rows:` 之後、同縮排的 `- ` 序列（PyYAML 預設）→ subset parser `unexpected indentation`。
2. **長 quoted scalar 折行**：實跑 report 的 eutb `reason` 超過 width=80 被折成兩行——追平 PyYAML folding 規則不是 subset parser 該扛的。

## 修法

- `_yaml.safe_load` 補 indentless sequence：只在「空值 key 緊接同縮排 dash」時轉進序列解析——純擴大接受集，不改任何既有可解文件的語意；`tests/test_yaml_subset.py` 四案鎖回歸（含 malformed dash 仍拒收）。
- profile 巷道**優先讀 `report.json`**（paulsha-patchmud#26 的機器契約，json stdlib 零歧義），無檔時退回 YAML fallback（相容舊版 patchmud）。
- 測試 fixture 改雙軌：預設 JSON 模板；YAML fallback 測試刻意用 indentless 形狀，一併覆蓋 parser 修正。

## 驗證

- `tests/test_model_profile_cli.py`＋`tests/test_yaml_subset.py`＋`tests/test_envelope_mapping.py`：55 passed。
- 對實跑封存的真 report.yaml：indentless 段落可解（折行 scalar 段落由 report.json 路徑繞開）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012GaAW12AtreaDpskkk8DeP