### PR TITLE
chore(policy): 同步 project policy 1.0.15 → 1.0.17，修正 R-19 條件式測試 gate

### DIFF
--- a/.github/workflows/persona-scope.yml
+++ b/.github/workflows/persona-scope.yml
@@ -32,8 +32,10 @@ jobs:
           python-version: "3.12"
 
       - name: Install dependencies
+        # 不裝 pytest：scope_ci 不使用測試框架（pytest 屬 `.[test]` extra），
+        # 且安裝行出現 pytest 會被 R-19 解析器誤判為未確認的測試執行點。
         run: |
-          python -m pip install --upgrade pip pytest
+          python -m pip install --upgrade pip
           python -m pip install -e .
 
       - name: Run persona-scope

--- a/.github/workflows/policy-check.yml
+++ b/.github/workflows/policy-check.yml
@@ -9,8 +9,8 @@ permissions:
 
 jobs:
   policy:
-    uses: hamanpaul/paulsha-conventions/.github/workflows/reusable-policy-check.yml@a764806046c410eb4f254ac0b6a8aec8b7559dab  # v1.0.15
+    uses: hamanpaul/paulsha-conventions/.github/workflows/reusable-policy-check.yml@9e7fabbf0b5eea9ad933fa6798764b723934a0b7  # v1.0.17
     with:
       policy_profile: flat
-      policy_version: "1.0.15"
-      policy_engine_ref: a764806046c410eb4f254ac0b6a8aec8b7559dab
+      policy_version: "1.0.17"
+      policy_engine_ref: 9e7fabbf0b5eea9ad933fa6798764b723934a0b7

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,7 +1,9 @@
 name: Tests
 
-# Template 骨架：tests/ 尚不存在時整個 job 跳過（新 repo 出生即綠燈）；
-# 一旦加入測試套件，pytest 自動成為 PR gate（滿足 policy R-19）。
+# 測試 gate 無條件執行：本 repo 的 tests/ 已是核心資產，不再需要 template
+# 骨架的「tests/ 不存在就整個 job 跳過」機制——條件式 gate 只剩假綠風險
+# （detect 一旦誤判，整個測試套件會靜默 skip 成綠）。policy R-19（1.0.16 起
+# 改為結構化偵測）也將條件式測試 gate 標為高風險樣式，下一版轉 FAIL。
 on:
   pull_request:
   push:
@@ -22,34 +24,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
 
-      - name: Detect test suite
-        id: detect
-        # 用 find 而非 `ls A B`：`ls` 只要任一 glob 沒配到就回傳非零，
-        # 於是「有 test_*.py 但沒有 *_test.py」的 repo 會被誤判為無測試，
-        # 整個 pytest 段落被跳過卻仍回報 success（假綠燈）。
-        run: |
-          if [ -d tests ] && [ -n "$(find tests -maxdepth 1 \( -name 'test_*.py' -o -name '*_test.py' \) -print -quit)" ]; then
-            echo "has_tests=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "has_tests=false" >> "$GITHUB_OUTPUT"
-            echo "No test suite yet; skipping pytest."
-          fi
-
       - name: Setup Python
-        if: steps.detect.outputs.has_tests == 'true'
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Install project and test dependencies
-        if: steps.detect.outputs.has_tests == 'true'
         run: |
           python -m pip install --upgrade pip
           if [ -f pyproject.toml ]; then python -m pip install -e ".[test]"; fi
           if [ -f requirements.txt ]; then python -m pip install -r requirements.txt; fi
 
       - name: Run test suite
-        if: steps.detect.outputs.has_tests == 'true'
         run: python -m pytest tests/ -q
 
   build:

--- a/.project-policy.yml
+++ b/.project-policy.yml
@@ -1,5 +1,5 @@
 policy_profile: flat
-policy_version: 1.0.15
+policy_version: 1.0.17
 tier: shareable
 code_paths:
   - ".project-policy.yml"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 本專案所有重大變更都會記錄在此檔案。
 
 格式基於 [Keep a Changelog 1.1.0](https://keepachangelog.com/zh-TW/1.1.0/)，
-本專案遵循 hamanpaul project policy v1.0.15。
+本專案遵循 hamanpaul project policy v1.0.17。
 
 ## [Unreleased]
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,15 +1,15 @@
-<!-- managed-by: hamanpaul/paulsha-conventions@v1.0.15 -->
+<!-- managed-by: hamanpaul/paulsha-conventions@v1.0.17 -->
 <!-- 此為 canonical 真檔；AGENTS.md / GEMINI.md / .github/copilot-instructions.md 為指向本檔的 symlink，只維護本檔 -->
-policy_version: 1.0.15
+policy_version: 1.0.17
 
 # Agent Policy Checklist
 
-本 repo 受 hamanpaul project policy v1.0.15 管轄。
+本 repo 受 hamanpaul project policy v1.0.17 管轄。
 所有 agent 進入 session 時，必須依下列 checklist 行動。
 
 ## 本 repo 的 profile
 - policy_profile: `flat` （見 `.project-policy.yml`）
-- policy_version: `1.0.15`
+- policy_version: `1.0.17`
 
 ## 本 repo 定位
 - `paulsha-cortex` 是治理平面拆包：persona 契約、coordinator 派工、control 檔案契約。

--- a/README.md
+++ b/README.md
@@ -676,7 +676,7 @@ export PSC_DIGEST_DELIVERY_CMD='/path/to/relay-script --channel ops'
 ## 開發備註
 
 - repo 宣告 `tier: shareable`，所有範例與測試都必須維持去識別化。
-- repo policy 由 canonical `.project-policy.yml` 宣告，並 pin paulsha-conventions v1.0.15。
+- repo policy 由 canonical `.project-policy.yml` 宣告，並 pin paulsha-conventions v1.0.17。
 - agent 慣例檔採 symlink 模式：`AGENTS.md`、`GEMINI.md`、`.github/copilot-instructions.md` 都指向 `CLAUDE.md`。
 
 ## Version

--- a/changelog.d/policy-1-0-17-sync.md
+++ b/changelog.d/policy-1-0-17-sync.md
@@ -1,0 +1,5 @@
+---
+type: change
+scope: policy
+---
+同步 hamanpaul project policy 1.0.15 → 1.0.17：`.project-policy.yml`、`Policy Check` workflow（`uses:` 與 `policy_engine_ref` 雙重釘選至 `9e7fabbf0b5eea9ad933fa6798764b723934a0b7`，尾註 `# v1.0.17` 供 R-23 對齊）、canonical `CLAUDE.md`（symlink `AGENTS.md`／`GEMINI.md`／`.github/copilot-instructions.md` 自動跟隨）與 `README.md`／`CHANGELOG.md` 內的版本引用全數同步。1.0.16／1.0.17 對下游 repo 未新增或變更任何規則；其中 1.0.16 引入的引擎版本 gate（執行中引擎與 repo 宣告 `policy_version` 不符即 fail-loud）是本次同步的實益。連帶依 R-19（1.0.16 起結構化偵測）移除 `tests.yml` 的條件式測試 gate（`Detect test suite` skeleton），pytest 改為無條件執行，消除 detect 誤判導致測試套件靜默 skip 成綠的風險。


### PR DESCRIPTION
Closes #504

## 變更

上游 hamanpaul/paulsha-conventions 已發布 v1.0.17。1.0.16 引入的引擎版本 gate 會在執行中引擎與 repo 宣告的 `policy_version` 不符時 fail-loud，因此 pin SHA 與 `policy_version` 必須**同 PR 原子更新**。1.0.16／1.0.17 對下游 repo 未新增或變更任何規則，本次為純版本同步：

- `.project-policy.yml` `policy_version` 1.0.15 → 1.0.17
- `Policy Check` workflow：`uses:` 與 `policy_engine_ref` 雙重釘選至 `9e7fabbf0b5eea9ad933fa6798764b723934a0b7`（尾註 `# v1.0.17`，R-23）
- canonical `CLAUDE.md`（`AGENTS.md`／`GEMINI.md`／`.github/copilot-instructions.md` symlink 自動跟隨）、`README.md`、`CHANGELOG.md` 版本引用同步
- changelog fragment：`changelog.d/policy-1-0-17-sync.md`

連帶修正 R-19（1.0.16 起改為結構化偵測）標出的兩個高風險樣式（訊息明言下一版轉 FAIL）：

- **tests.yml**：移除 `Detect test suite` 條件式 skeleton，pytest 無條件執行——本 repo `tests/` 已是核心資產（2475 個測試），條件式 gate 只剩「detect 誤判 → 測試套件靜默 skip 成綠」的假綠風險（同 paulsha-patchmud 1.0.17 同步時的工法）。
- **persona-scope.yml**：安裝行移除多餘的 `pytest`（`scope_ci` 不使用測試框架，pytest 屬 `.[test]` extra；安裝行的 pytest 字樣會被 R-19 解析器誤判為未確認的測試執行點）。

## 驗證

- 本機以 v1.0.17 引擎 `python3 -m policy_check --repo .`：**EXIT=0**，R-19／R-20／R-23 全 pass（僅 R-22 62 個 pre-existing dangling doc reference，advisory、非本次引入）。
- `.venv/bin/python -m pytest -q`：**2475 passed, 3 skipped, 49 subtests passed**（40.7s）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E7w9kaUxAzCCEk7piD5hfK
