### PR TITLE
fix(monitor): GitHub 掃描請求節流與 403 分診／退避（#506 部分實作）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@
 
 ## [Unreleased]
 
+### Fixed
+- **Issue #506（部分實作）：Monitor GitHub 掃描 burst 減壓**——新增
+  `paulsha_cortex/monitor/github_pressure.py` 的 `GitHubPressureGate`：
+  (1) 每次 `gh` 請求前插入可設定的間隔＋jitter，把一輪數百次請求攤平而非齊發
+  （`github_request_interval_ms` 預設 200、設 0 停用；`github_throttle_budget_seconds`
+  作為上限保護並夾在 refresh interval 一半以下）；(2) rate-limit 型失敗時以
+  不計配額的 `gh api rate_limit` 分診 primary／secondary，給出可分辨的 diagnostic；
+  (3) 命中後採指數退避（尊重 `Retry-After`／`x-ratelimit-reset`），退避期間
+  provider 的 `scan()` 直接跳過、不發任何請求。`GitHubTerminalProvider` 一併接上
+  同一套分診與退避，且不再重試 rate-limit 失敗。所有 rate-limit diagnostic 維持
+  被 `is_rate_limit_signal` 認得，`coordinator/claim.py` 的
+  `provider-authority-rate-limited-canonical` 行為不變。
+  詳見 `changelog.d/rate-limit-pressure.md`。
+
 ## [0.1.8] - 2026-08-12
 
 ### Fixed

--- a/changelog.d/rate-limit-pressure.md
+++ b/changelog.d/rate-limit-pressure.md
@@ -1,0 +1,37 @@
+---
+type: fix
+scope: monitor
+---
+**Issue #506（部分實作）：GitHub 掃描 burst 減壓——請求節流與 403 分診／退避**
+
+Monitor 的 `_github_refresh_loop` 每輪對每個 GitHub repo 跑兩個 provider 的
+`scan()`，而單 repo 單輪的 `gh` 呼叫是 O(issues 分頁 + remote todo 檔數 +
+workflow-linked merged PR 數) 而非 O(1)；約 40 個 repo 的 workspace 一輪會在
+數秒內齊發數百次請求，穩定觸發 GitHub secondary（abuse detection）rate limit，
+`github:` 與 `github-terminal:` 兩個 provider 同時 degraded（實測超過 35 分鐘），
+operator 的 `cortex work` 全被 `provider-authority-rate-limited-canonical` 擋下。
+
+- **請求節流（攤平）**：新增 `monitor/github_pressure.py` 的 `GitHubPressureGate`，
+  在**每一次** `gh` 請求前插入 `interval + jitter` 間隔（含 graphql 分頁與逐檔
+  `contents`）。參數由 `monitor:` 區段的 `github_request_interval_ms`（預設 200，
+  設 0 即停用）與 `github_request_jitter_ms`（預設 100）控制。預算計算：40 repo ×
+  約 5 次呼叫 × 0.2s ≈ 40s ≪ 一輪 300s；另有 `github_throttle_budget_seconds`
+  （預設 120，且夾在 refresh interval 的一半以下）作為極端情況的上限保護，
+  預算用盡後節流自動失效，不讓節流本身把掃描週期撐爆。閘門由 `WorkModelRefresher`
+  持有並跨 repo／跨輪次共用（壓力是 per-token 而非 per-repo）。
+- **403 分診**：命中 rate-limit 型失敗時再查一次 `gh api rate_limit`（此端點不計
+  配額）：`remaining > 0` → `github secondary rate limit`；`remaining == 0` →
+  `github primary rate limit exhausted`；探測失敗則退回既有的
+  `github rate limit exceeded`。三者都仍被 `is_rate_limit_signal` 認得，
+  `coordinator/claim.py` 的 `provider-authority-rate-limited-canonical`
+  reason code 行為不變（#370 的成果，已用測試鎖住）。
+- **退避**：命中後開啟指數退避窗（`github_backoff_base_seconds` 預設 60、
+  `github_backoff_max_seconds` 預設 1800），並尊重訊息中透出的 `Retry-After` /
+  `x-ratelimit-reset`；退避期間 provider 的 `scan()` 直接跳過、**不發任何請求**，
+  而不是每輪再硬撞一次 403。`GitHubTerminalProvider` 原本把限流混進
+  `github terminal evidence unavailable`、下游完全分辨不出來，本次一併接上同一套
+  分診與退避，並且不再重試 rate-limit 失敗。
+
+未注入閘門時 provider 行為與先前完全相同（節流／退避皆停用）。GraphQL 批次化、
+全域跨子系統預算、`gh auth status` 雙重驗證與緊迴圈輪詢規範不在本次範圍，
+留給 #506 的後續票。

--- a/docs/monitor-config.md
+++ b/docs/monitor-config.md
@@ -14,3 +14,36 @@
 
 - 在測試與腳本中指定 `config_path`，可避免意外引入外部環境專案清單。
 - 未指定時仍保留既有監控預設行為，會套用 ambient `project-hippo.yaml`（若存在）。
+
+## GitHub 掃描壓力設定（#506）
+
+`_github_refresh_loop` 每 `github_refresh_interval_seconds` 會對每個 GitHub repo
+跑一次 `GitHubWorkProvider` 與 `GitHubTerminalProvider`，兩者的 `gh` 呼叫數是
+O(issues 分頁 + remote todo 檔數 + workflow-linked merged PR 數) 而非 O(1)。
+repo 一多，一輪數百次請求齊發就會觸發 GitHub 的 secondary（abuse detection）
+rate limit，兩個 provider 一起 degraded，連帶擋掉 `cortex work` 的 claim。
+
+`monitor:` 區段新增下列鍵（全部可省略，預設值即保守值）：
+
+| 鍵 | 預設 | 說明 |
+| --- | --- | --- |
+| `github_request_interval_ms` | `200` | 每次 `gh` 請求前的固定間隔，`0` 代表完全停用節流 |
+| `github_request_jitter_ms` | `100` | 疊加在間隔上的隨機抖動上限，`0` 代表不抖動 |
+| `github_throttle_budget_seconds` | `120` | 單輪掃描花在節流的睡眠總上限；實際生效值另夾在 `github_refresh_interval_seconds` 的一半以下 |
+| `github_backoff_base_seconds` | `60` | 命中 rate limit 後的退避基準（指數退避的第一階） |
+| `github_backoff_max_seconds` | `1800` | 退避上限 |
+
+預算計算：40 個 repo × 約 5 次呼叫／repo × 0.2s ≈ 40s，遠低於一輪的 300s。
+預算用盡後節流自動失效——寧可讓該輪尾段恢復齊發，也不讓節流本身把掃描週期撐爆。
+
+命中 403 時會再查一次 `gh api rate_limit`（此端點不計入配額）分辨兩種限流，
+並寫入不同的 diagnostic：
+
+- `github secondary rate limit`：配額還有剩，是 burst 觸發的 abuse detection。
+- `github primary rate limit exhausted`：配額耗盡，只能等 reset。
+- `github rate limit exceeded`：探測本身失敗時的保守退回值。
+
+三者都仍會被 `paulsha_cortex.github_rate_limit.is_rate_limit_signal` 認得，
+`coordinator/claim.py` 的 `provider-authority-rate-limited-canonical` 行為不變。
+退避期間 provider 的 `scan()` 直接跳過、不發任何請求；退避窗綁的是 token
+（帳號層級）而非單一 repo，因為 GitHub 的 secondary limit 本來就綁 token。

--- a/paulsha_cortex/monitor/config.py
+++ b/paulsha_cortex/monitor/config.py
@@ -58,6 +58,29 @@ class MonitorConfig:
     socket_path: Path = field(default_factory=default_socket_path)
     ignore_dirs: tuple[str, ...] = ()
     hippo_projects: tuple[ProjectEntry, ...] = ()
+    # #506：GitHub 請求節流／退避參數（預算計算與取捨見
+    # monitor/github_pressure.py 的模組 docstring）。interval 設 0 即停用節流。
+    github_request_interval_ms: int = 200
+    github_request_jitter_ms: int = 100
+    github_throttle_budget_seconds: int = 120
+    github_backoff_base_seconds: int = 60
+    github_backoff_max_seconds: int = 1800
+
+    def github_throttle_budget(self) -> float:
+        """本輪節流可花掉的總睡眠秒數上限。
+
+        #506：節流的用途是攤平 burst，不是把掃描拖到追不上自己的週期。因此
+        設定值再大也夾在 ``github_refresh_interval_seconds`` 的一半以下——
+        刻意用夾擠而非 fail-loud：既有部署若把 refresh interval 調小，不該讓
+        monitor 因為一個預設值就啟動失敗。
+        """
+
+        return float(
+            min(
+                self.github_throttle_budget_seconds,
+                self.github_refresh_interval_seconds / 2,
+            )
+        )
 
 
 def _resolve_config_source(config_path: Path | None) -> Path | None:
@@ -145,10 +168,25 @@ def _load_manual_config(resolved: Path) -> MonitorConfig:
         ("watch_debounce_ms", 500),
         ("github_refresh_interval_seconds", 300),
         ("provider_stale_after_seconds", 900),
+        # #506：節流預算與退避參數。
+        ("github_throttle_budget_seconds", 120),
+        ("github_backoff_base_seconds", 60),
+        ("github_backoff_max_seconds", 1800),
     ):
         value = monitor.get(field_name, default)
         if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
             raise ValueError(f"config.monitor.{field_name} 必須是正整數，得到 {value!r}")
+        intervals[field_name] = value
+    # #506：節流間隔／jitter 允許 0（代表關閉節流），故與上面的正整數分開驗。
+    for field_name, default in (
+        ("github_request_interval_ms", 200),
+        ("github_request_jitter_ms", 100),
+    ):
+        value = monitor.get(field_name, default)
+        if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+            raise ValueError(
+                f"config.monitor.{field_name} 必須是非負整數，得到 {value!r}"
+            )
         intervals[field_name] = value
     poll_interval = intervals["poll_interval_seconds"]
     rescan_interval = intervals["rescan_interval_seconds"]
@@ -176,6 +214,11 @@ def _load_manual_config(resolved: Path) -> MonitorConfig:
         legacy_policy=legacy_policy,
         socket_path=socket_path,
         ignore_dirs=ignore_dirs,
+        github_request_interval_ms=intervals["github_request_interval_ms"],
+        github_request_jitter_ms=intervals["github_request_jitter_ms"],
+        github_throttle_budget_seconds=intervals["github_throttle_budget_seconds"],
+        github_backoff_base_seconds=intervals["github_backoff_base_seconds"],
+        github_backoff_max_seconds=intervals["github_backoff_max_seconds"],
     )
 
 

--- a/paulsha_cortex/monitor/github_pressure.py
+++ b/paulsha_cortex/monitor/github_pressure.py
@@ -1,0 +1,222 @@
+"""#506：GitHub 請求壓力閘門——把掃描 burst 攤平，並在限流時退避。
+
+## 問題
+
+Monitor 的 ``_github_refresh_loop``（``monitor/service.py``）每
+``github_refresh_interval_seconds``（預設 300s）會以 ``include_github=True``
+跑一次 work model refresh，對 workspace 內**每個** GitHub repo 各跑一次
+``GitHubWorkProvider.scan()`` 與 ``GitHubTerminalProvider.scan()``。單一 repo
+單輪的 ``gh`` 呼叫並不是 O(1)：
+
+- ``GitHubWorkProvider``：1 次 ``gh api --paginate``（issues；gh 內部再分頁）
+- ``GitHubTerminalProvider``：1 次 graphql（PR，可再分頁）＋ 1 次 git tree
+  ＋ **每個** remote todo／archived tasks.md 一次 ``contents`` ＋ **每個**
+  workflow-linked merged PR 一次 ``compare``
+
+亦即 per-repo per-cycle 是 O(issues 分頁 + todo 檔數)。實際 workspace 約 40 個
+repo，一輪數百次請求在數秒內齊發，穩定觸發 GitHub secondary（abuse detection）
+rate limit——實測 ``github:`` 與 ``github-terminal:`` 兩個 provider 同時
+degraded 超過 35 分鐘，operator 的 ``cortex work`` 全被 ``coordinator/claim.py``
+的 ``provider-authority-rate-limited-canonical`` 擋下（dogfooding 死結）。
+
+## 本模組提供的兩個機制
+
+1. **節流（攤平）**：每次 ``gh`` 請求前插入 ``interval + jitter`` 的間隔，讓
+   一輪的數百次請求攤平而非齊發。GitHub 的 secondary limit 主要抓「短時間內
+   的併發／連發」，攤平比降低總量更直接有效。
+2. **退避**：命中 rate limit 後記錄 next-attempt 時點，退避期間 provider 的
+   ``scan()`` 直接跳過（**不發任何請求**），而不是每輪硬撞一次 403。
+
+### 節流預算計算（務必隨參數調整同步更新）
+
+預設 ``interval=0.2s``：40 repo × 約 5 次呼叫／repo × 0.2s ≈ **40s**，遠低於
+一輪 ``github_refresh_interval_seconds=300s``，掃描不會追不上自己的週期。
+但 repo 數／todo 檔數是會長大的，所以另設 ``budget_seconds``（每輪節流可花掉
+的總睡眠上限，預設 120s，且由 ``MonitorConfig.github_throttle_budget()`` 進一步
+夾在 refresh interval 的一半以下）：預算用完後節流自動失效，寧可讓那一輪的尾
+段恢復齊發，也不能讓節流本身把掃描週期撐爆。
+
+### 為什麼退避是帳號層級而非 per-repo
+
+GitHub 的 secondary rate limit 綁的是 **token／帳號**，不是 repo。若退避狀態
+以 provider_id 為 key，40 個 repo 會各自燒掉一次 403 才進入退避，減壓形同虛設。
+因此本閘門的退避窗是單一共享窗；``blocked_seconds()`` 對所有 GitHub provider
+一視同仁。
+
+所有時間來源（``clock``／``sleeper``／``jitter_source``）皆可注入，測試不會真的
+sleep。
+"""
+
+from __future__ import annotations
+
+import math
+import random
+import threading
+import time
+from typing import TYPE_CHECKING, Callable
+
+if TYPE_CHECKING:  # pragma: no cover - 僅型別，避免 config ↔ providers 迴圈匯入
+    from .config import MonitorConfig
+
+
+# 保守預設：見上方「節流預算計算」。interval 設 0 即完全停用節流。
+DEFAULT_INTERVAL_SECONDS = 0.2
+DEFAULT_JITTER_SECONDS = 0.1
+DEFAULT_BUDGET_SECONDS = 120.0
+DEFAULT_BACKOFF_BASE_SECONDS = 60.0
+DEFAULT_BACKOFF_MAX_SECONDS = 1800.0
+
+# 退避延遲加上的相對 jitter 比例（避免多個 monitor 實例同步醒來再次齊發）。
+_BACKOFF_JITTER_RATIO = 0.1
+
+RATE_LIMIT_KIND_PRIMARY = "primary"
+RATE_LIMIT_KIND_SECONDARY = "secondary"
+RATE_LIMIT_KIND_UNKNOWN = "unknown"
+
+
+def _positive_number(value: object, *, field: str, allow_zero: bool = False) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError(f"{field} 必須是數值")
+    number = float(value)
+    if not math.isfinite(number) or number < 0 or (number == 0 and not allow_zero):
+        raise ValueError(f"{field} 必須是有限的非負數值，得到 {value!r}")
+    return number
+
+
+class GitHubPressureGate:
+    """GitHub 請求節流 + 限流退避的共享閘門（可注入、可停用、thread-safe）。"""
+
+    def __init__(
+        self,
+        *,
+        interval_seconds: float = DEFAULT_INTERVAL_SECONDS,
+        jitter_seconds: float = DEFAULT_JITTER_SECONDS,
+        budget_seconds: float = DEFAULT_BUDGET_SECONDS,
+        backoff_base_seconds: float = DEFAULT_BACKOFF_BASE_SECONDS,
+        backoff_max_seconds: float = DEFAULT_BACKOFF_MAX_SECONDS,
+        sleeper: Callable[[float], None] = time.sleep,
+        clock: Callable[[], float] = time.monotonic,
+        jitter_source: Callable[[], float] = random.random,
+    ) -> None:
+        self.interval_seconds = _positive_number(
+            interval_seconds, field="interval_seconds", allow_zero=True
+        )
+        self.jitter_seconds = _positive_number(
+            jitter_seconds, field="jitter_seconds", allow_zero=True
+        )
+        self.budget_seconds = _positive_number(
+            budget_seconds, field="budget_seconds", allow_zero=True
+        )
+        self.backoff_base_seconds = _positive_number(
+            backoff_base_seconds, field="backoff_base_seconds"
+        )
+        self.backoff_max_seconds = _positive_number(
+            backoff_max_seconds, field="backoff_max_seconds"
+        )
+        if self.backoff_max_seconds < self.backoff_base_seconds:
+            raise ValueError("backoff_max_seconds 不可小於 backoff_base_seconds")
+        self._sleeper = sleeper
+        self._clock = clock
+        self._jitter_source = jitter_source
+        self._lock = threading.Lock()
+        self._spent_seconds = 0.0
+        self._blocked_until: float | None = None
+        self._consecutive_failures = 0
+
+    @classmethod
+    def from_config(cls, config: "MonitorConfig", **overrides) -> "GitHubPressureGate":
+        """由 monitor config 建構；缺省值一律走本模組的保守預設。"""
+
+        settings: dict[str, float] = {
+            "interval_seconds": config.github_request_interval_ms / 1000.0,
+            "jitter_seconds": config.github_request_jitter_ms / 1000.0,
+            "budget_seconds": config.github_throttle_budget(),
+            "backoff_base_seconds": float(config.github_backoff_base_seconds),
+            "backoff_max_seconds": float(config.github_backoff_max_seconds),
+        }
+        settings.update(overrides)
+        return cls(**settings)
+
+    # ------------------------------------------------------------------
+    # 節流
+    # ------------------------------------------------------------------
+
+    def begin_cycle(self) -> None:
+        """一輪 GitHub 掃描開始：重置本輪節流預算（退避窗不受影響）。"""
+
+        with self._lock:
+            self._spent_seconds = 0.0
+
+    def throttle(self) -> float:
+        """在送出一次 ``gh`` 請求前呼叫；回傳實際 sleep 的秒數。
+
+        回傳值只為了診斷／測試；呼叫端不需要處理。
+        """
+
+        with self._lock:
+            if self.interval_seconds == 0 and self.jitter_seconds == 0:
+                return 0.0
+            delay = self.interval_seconds + self.jitter_seconds * self._jitter_source()
+            remaining_budget = self.budget_seconds - self._spent_seconds
+            if remaining_budget <= 0:
+                # 預算用盡：寧可讓尾段恢復齊發，也不讓節流撐爆 refresh 週期。
+                return 0.0
+            delay = min(delay, remaining_budget)
+            self._spent_seconds += delay
+        if delay > 0:
+            self._sleeper(delay)
+        return delay
+
+    # ------------------------------------------------------------------
+    # 退避
+    # ------------------------------------------------------------------
+
+    def blocked_seconds(self) -> float:
+        """退避剩餘秒數；``0.0`` 代表可以送請求。"""
+
+        with self._lock:
+            if self._blocked_until is None:
+                return 0.0
+            remaining = self._blocked_until - self._clock()
+            if remaining <= 0:
+                self._blocked_until = None
+                return 0.0
+            return remaining
+
+    def note_rate_limited(
+        self,
+        *,
+        kind: str = RATE_LIMIT_KIND_SECONDARY,
+        retry_after_seconds: float | None = None,
+    ) -> float:
+        """登記一次限流命中並開啟／延長退避窗；回傳本次退避秒數。
+
+        ``retry_after_seconds`` 來自回應透出的 ``Retry-After`` 或
+        ``x-ratelimit-reset``（primary 配額耗盡時是 reset 的剩餘秒數）；有給就
+        尊重它（取 max），沒有就純指數退避。
+        """
+
+        with self._lock:
+            self._consecutive_failures += 1
+            exponent = min(self._consecutive_failures - 1, 32)
+            delay = min(
+                self.backoff_base_seconds * (2.0**exponent), self.backoff_max_seconds
+            )
+            if retry_after_seconds is not None:
+                hint = _positive_number(
+                    retry_after_seconds, field="retry_after_seconds", allow_zero=True
+                )
+                delay = max(delay, hint)
+            delay += delay * _BACKOFF_JITTER_RATIO * self._jitter_source()
+            delay = min(delay, self.backoff_max_seconds)
+            candidate = self._clock() + delay
+            if self._blocked_until is None or candidate > self._blocked_until:
+                self._blocked_until = candidate
+            return delay
+
+    def note_success(self) -> None:
+        """一次成功的 GitHub 掃描：清空退避窗與連續失敗計數。"""
+
+        with self._lock:
+            self._blocked_until = None
+            self._consecutive_failures = 0

--- a/paulsha_cortex/monitor/providers.py
+++ b/paulsha_cortex/monitor/providers.py
@@ -19,6 +19,12 @@ import yaml
 from paulsha_cortex.config import paths
 from paulsha_cortex.github_rate_limit import is_auth_signal, is_rate_limit_signal
 
+from .github_pressure import (
+    RATE_LIMIT_KIND_PRIMARY,
+    RATE_LIMIT_KIND_SECONDARY,
+    RATE_LIMIT_KIND_UNKNOWN,
+    GitHubPressureGate,
+)
 from .work_models import ProviderSnapshot, WorkSource
 
 
@@ -669,6 +675,129 @@ class SubprocessCommandRunner:
         )
 
 
+# #506：rate-limit 診斷字串。三者**都必須**讓
+# ``github_rate_limit.is_rate_limit_signal`` 為真——``coordinator/claim.py`` 靠它
+# 產生 ``provider-authority-rate-limited-canonical`` 這個 reason code（#370 的
+# 成果），字串一旦不含 "rate limit" 就會靜默回歸成「authority 損毀」語意。
+# tests/test_monitor_github_pressure_506.py 鎖住這點。
+_RATE_LIMIT_DIAGNOSTICS = {
+    RATE_LIMIT_KIND_SECONDARY: "secondary rate limit",
+    RATE_LIMIT_KIND_PRIMARY: "primary rate limit exhausted",
+    RATE_LIMIT_KIND_UNKNOWN: "rate limit exceeded",
+}
+
+_RETRY_AFTER = re.compile(r"retry[-\s]?after[\"'\s:=]+(\d+)", re.IGNORECASE)
+_RATE_LIMIT_RESET = re.compile(r"x-ratelimit-reset[\"'\s:=]+(\d+)", re.IGNORECASE)
+
+
+def _retry_after_seconds(message: str | None) -> float | None:
+    """從失敗訊息取出 ``Retry-After``／``x-ratelimit-reset`` 提示（沒有就 None）。
+
+    #506：gh 不保證把 header 透出到 stderr，所以這只是「有就尊重」的加值路徑；
+    取不到時退避純靠指數。
+    """
+
+    if not message:
+        return None
+    match = _RETRY_AFTER.search(message)
+    if match is not None:
+        return float(match.group(1))
+    match = _RATE_LIMIT_RESET.search(message)
+    if match is not None:
+        remaining = float(match.group(1)) - time.time()
+        return remaining if remaining > 0 else None
+    return None
+
+
+def _probe_rate_limit(
+    runner: CommandRunner, *, timeout_seconds: float
+) -> tuple[str, float | None]:
+    """#506：以 ``gh api rate_limit`` 分辨 primary 與 secondary rate limit。
+
+    ``rate_limit`` 端點**不計入配額**，所以即使已經被限流也能安全查詢：
+    ``remaining > 0`` 代表配額還在，403 只可能來自 secondary（abuse detection，
+    burst 觸發，攤平請求即可緩解）；``remaining == 0`` 才是 primary 配額耗盡
+    （只能等 reset）。兩者的處置完全不同，因此值得多花這一次不計費的請求。
+
+    回傳 ``(kind, reset_after_seconds)``；探測本身失敗／回應不可解時回
+    ``unknown``——寧可退回既有的通用診斷，也不要猜錯方向。
+    """
+
+    argv = ("gh", "api", "--method", "GET", "rate_limit")
+    try:
+        completed = runner.run(argv, timeout=timeout_seconds)
+    except (OSError, subprocess.TimeoutExpired):
+        return RATE_LIMIT_KIND_UNKNOWN, None
+    if completed.returncode != 0:
+        return RATE_LIMIT_KIND_UNKNOWN, None
+    stdout = (
+        completed.stdout.decode(errors="replace")
+        if isinstance(completed.stdout, bytes)
+        else completed.stdout
+    )
+    try:
+        payload = json.loads(stdout or "")
+    except (json.JSONDecodeError, TypeError, ValueError):
+        return RATE_LIMIT_KIND_UNKNOWN, None
+    if not isinstance(payload, Mapping):
+        return RATE_LIMIT_KIND_UNKNOWN, None
+    buckets: list[Mapping] = []
+    resources = payload.get("resources")
+    if isinstance(resources, Mapping):
+        # core 與 graphql 是本 monitor 實際會打的兩個 bucket（REST 與 graphql
+        # provider 各一），任一耗盡都算 primary。
+        buckets = [
+            bucket
+            for name in ("core", "graphql")
+            if isinstance(bucket := resources.get(name), Mapping)
+        ]
+    if not buckets and isinstance(payload.get("rate"), Mapping):
+        buckets = [payload["rate"]]
+    remainings = [
+        bucket
+        for bucket in buckets
+        if isinstance(bucket.get("remaining"), int)
+        and not isinstance(bucket.get("remaining"), bool)
+    ]
+    if not remainings:
+        return RATE_LIMIT_KIND_UNKNOWN, None
+    exhausted = [bucket for bucket in remainings if bucket["remaining"] <= 0]
+    if not exhausted:
+        return RATE_LIMIT_KIND_SECONDARY, None
+    resets = [
+        float(bucket["reset"])
+        for bucket in exhausted
+        if isinstance(bucket.get("reset"), int) and not isinstance(bucket.get("reset"), bool)
+    ]
+    reset_after = max(0.0, max(resets) - time.time()) if resets else None
+    return RATE_LIMIT_KIND_PRIMARY, reset_after
+
+
+def _rate_limit_diagnostic(
+    *,
+    runner: CommandRunner,
+    timeout_seconds: float,
+    message: str | None,
+    gate: GitHubPressureGate | None,
+    prefix: str,
+) -> str:
+    """分診 rate-limit 失敗、登記退避，並回傳要寫進 diagnostics 的字串。"""
+
+    kind, reset_after = _probe_rate_limit(runner, timeout_seconds=timeout_seconds)
+    hint = _retry_after_seconds(message)
+    if reset_after is not None:
+        hint = reset_after if hint is None else max(hint, reset_after)
+    diagnostic = f"{prefix} {_RATE_LIMIT_DIAGNOSTICS[kind]}"
+    if gate is None:
+        return diagnostic
+    delay = gate.note_rate_limited(kind=kind, retry_after_seconds=hint)
+    return f"{diagnostic}; backing off {delay:.0f}s"
+
+
+def _backoff_diagnostic(prefix: str, blocked_seconds: float) -> str:
+    return f"{prefix} rate limit backoff active; retry in {blocked_seconds:.0f}s"
+
+
 class GitHubWorkProvider:
     """Read GitHub entities through authenticated ``gh api`` JSON only."""
 
@@ -678,6 +807,7 @@ class GitHubWorkProvider:
         *,
         runner: CommandRunner | None = None,
         timeout_seconds: float = 30,
+        pressure_gate: GitHubPressureGate | None = None,
     ) -> None:
         if repo.count("/") != 1 or any(not part for part in repo.split("/")):
             raise ValueError("GitHub repo must use owner/name")
@@ -685,9 +815,17 @@ class GitHubWorkProvider:
         self.provider_id = f"github:{repo}"
         self.runner = runner or SubprocessCommandRunner()
         self.timeout_seconds = timeout_seconds
+        # #506：未注入 gate 時完全維持舊行為（不節流、不退避）。
+        self.pressure_gate = pressure_gate
 
     def scan(self) -> ProviderSnapshot:
         attempted_at = _utcnow()
+        if self.pressure_gate is not None:
+            blocked = self.pressure_gate.blocked_seconds()
+            if blocked > 0:
+                # #506：退避期間直接跳過，不再硬撞一次 403 去加深限流。
+                return self._failure(attempted_at, _backoff_diagnostic("github", blocked))
+            self.pressure_gate.throttle()
         argv = (
             "gh",
             "api",
@@ -713,8 +851,18 @@ class GitHubWorkProvider:
             # and invite re-authenticating, so an auth-first check
             # misclassifies a retryable rate limit as a dead credential.
             if is_rate_limit_signal(message):
-                diagnostic = "github rate limit exceeded"
-            elif is_auth_signal(message):
+                # #506：403 再分診成 primary／secondary，並開啟退避窗。
+                return self._failure(
+                    attempted_at,
+                    _rate_limit_diagnostic(
+                        runner=self.runner,
+                        timeout_seconds=self.timeout_seconds,
+                        message=message,
+                        gate=self.pressure_gate,
+                        prefix="github",
+                    ),
+                )
+            if is_auth_signal(message):
                 diagnostic = "github authentication failed"
             else:
                 diagnostic = "github API request failed"
@@ -738,6 +886,9 @@ class GitHubWorkProvider:
                 for source in sources
             )
         )
+        if self.pressure_gate is not None:
+            # #506：一次成功即代表限流窗已過，清空退避與連續失敗計數。
+            self.pressure_gate.note_success()
         return ProviderSnapshot(
             provider_id=self.provider_id,
             status="ok",
@@ -783,6 +934,19 @@ class GitHubWorkProvider:
         )
 
 
+class _GitHubRateLimitError(OSError):
+    """#506：``_json`` 內部命中 rate limit 的專用訊號。
+
+    刻意繼承 ``OSError``——既有 ``scan()`` 的 catch-all（``except (OSError, ...)``）
+    仍然接得住，即使日後有人漏接這個新型別也只會退回舊的通用診斷，不會讓
+    provider 例外逸出。
+    """
+
+    def __init__(self, message: str) -> None:
+        super().__init__("gh api rate limited")
+        self.detail = message
+
+
 class GitHubTerminalProvider:
     """Read closing references and remote default-branch archive evidence."""
 
@@ -798,11 +962,15 @@ class GitHubTerminalProvider:
         retry_delays: tuple[float, ...] = (2.0, 5.0, 10.0),
         sleeper: Callable[[float], None] = time.sleep,
         relevant_pr_numbers: tuple[int, ...] | None = None,
+        pressure_gate: GitHubPressureGate | None = None,
     ) -> None:
         self.repo = repo
         self.provider_id = f"github-terminal:{repo}"
         self.runner = runner or SubprocessCommandRunner()
         self.timeout_seconds = timeout_seconds
+        # #506：本 provider 是請求量最大的一支（graphql 分頁 + tree + 逐檔
+        # contents + 逐 PR compare），節流／退避沒接上它等於沒做減壓。
+        self.pressure_gate = pressure_gate
         if any(
             not isinstance(delay, (int, float))
             or isinstance(delay, bool)
@@ -829,6 +997,13 @@ class GitHubTerminalProvider:
 
     def scan(self) -> ProviderSnapshot:
         attempted_at = _utcnow()
+        if self.pressure_gate is not None:
+            blocked = self.pressure_gate.blocked_seconds()
+            if blocked > 0:
+                # #506：退避期間整支 scan 跳過——這裡省下的是一輪裡最大宗的請求量。
+                return self._failure(
+                    attempted_at, _backoff_diagnostic("github terminal", blocked)
+                )
         owner, name = self.repo.split("/", 1)
         try:
             graph = self._json(self._pull_request_argv(owner=owner, name=name))
@@ -971,6 +1146,19 @@ class GitHubTerminalProvider:
                 )
         except subprocess.TimeoutExpired:
             return self._failure(attempted_at, "github terminal timeout")
+        except _GitHubRateLimitError as error:
+            # #506：與 GitHubWorkProvider 同一套分診／退避；本 provider 原本把
+            # 限流混進 "evidence unavailable"，下游完全分辨不出來。
+            return self._failure(
+                attempted_at,
+                _rate_limit_diagnostic(
+                    runner=self.runner,
+                    timeout_seconds=self.timeout_seconds,
+                    message=error.detail,
+                    gate=self.pressure_gate,
+                    prefix="github terminal",
+                ),
+            )
         except FileNotFoundError:
             return self._failure(attempted_at, "github CLI unavailable")
         except (OSError, KeyError, TypeError, ValueError, json.JSONDecodeError):
@@ -988,6 +1176,9 @@ class GitHubTerminalProvider:
             "remote_todos": remote_todos,
             "branches": branches,
         }
+        if self.pressure_gate is not None:
+            # #506：整支 scan 走完都沒被限流，退避窗可以關掉。
+            self.pressure_gate.note_success()
         return ProviderSnapshot(
             provider_id=self.provider_id,
             status="ok",
@@ -1019,10 +1210,17 @@ class GitHubTerminalProvider:
     def _json(self, argv: Sequence[str]) -> Mapping:
         completed = None
         for attempt in range(len(self.retry_delays) + 1):
+            if self.pressure_gate is not None:
+                # #506：節流點在**每一次**請求前，含分頁與逐檔 contents——
+                # 一輪掃描的請求數就是靠這裡攤平的。
+                self.pressure_gate.throttle()
             completed = self.runner.run(argv, timeout=self.timeout_seconds)
             if completed.returncode == 0:
                 break
             error = f"{completed.stderr}\n{completed.stdout}"
+            if is_rate_limit_signal(error):
+                # #506：限流一律不重試——重試 403 只會把 secondary limit 撞得更深。
+                raise _GitHubRateLimitError(error)
             if (
                 attempt >= len(self.retry_delays)
                 or re.search(r"\bHTTP (?:502|503|504)\b", error) is None

--- a/paulsha_cortex/monitor/service.py
+++ b/paulsha_cortex/monitor/service.py
@@ -10,6 +10,7 @@ logger = logging.getLogger(__name__)
 
 from .config import MonitorConfig
 from .fs import checked_resolve, checked_stat_mode
+from .github_pressure import GitHubPressureGate
 from .server import MonitorServer
 from .snapshot import ChangeEvent, SnapshotStore
 from .watcher import HAS_WATCHDOG, StubWatcher, WatchdogFileWatcher, Watcher
@@ -51,6 +52,8 @@ class ProjectMonitorService:
             durable_store=self._durable_work_store,
             read_store=self._work_store,
             stale_after_seconds=config.provider_stale_after_seconds,
+            # #506：GitHub 掃描的節流／退避閘門，跨 repo、跨輪次共用一份。
+            github_pressure_gate=GitHubPressureGate.from_config(config),
         )
         self._server = server or MonitorServer(
             store=self._store,

--- a/paulsha_cortex/monitor/work_api.py
+++ b/paulsha_cortex/monitor/work_api.py
@@ -13,6 +13,7 @@ from typing import Callable, Mapping, Sequence
 
 from .config import load_config
 from .correlation import InferredSignal, correlate_work_sources
+from .github_pressure import GitHubPressureGate
 from .lifecycle import ClosureEvidence, project_work_items
 from .models import ProjectState
 from .providers import (
@@ -403,6 +404,7 @@ class WorkModelRefresher:
         workflow_provider_factory: Callable[[str], WorkflowRegistryProvider] | None = None,
         stale_after_seconds: int = 900,
         now: Callable[[], datetime] | None = None,
+        github_pressure_gate: GitHubPressureGate | None = None,
     ) -> None:
         self.durable_store = durable_store
         self.read_store = read_store
@@ -410,9 +412,14 @@ class WorkModelRefresher:
         self.github_terminal_provider_factory = (
             github_terminal_provider_factory or GitHubTerminalProvider
         )
+        self._uses_default_github_provider = github_provider_factory is None
         self._uses_default_github_terminal_provider = (
             github_terminal_provider_factory is None
         )
+        # #506：跨 repo 共用的節流／退避閘門。掃描是 per-repo 建 provider、
+        # 但壓力是 per-token 的，所以閘門必須活得比 provider 久（由 refresher
+        # 持有），否則節流只在單一 repo 內生效、退避每個 repo 各燒一次 403。
+        self.github_pressure_gate = github_pressure_gate
         self.workflow_provider_factory = workflow_provider_factory or WorkflowRegistryProvider
         self.stale_after_seconds = stale_after_seconds
         self.now = now or (lambda: datetime.now(timezone.utc))
@@ -425,6 +432,9 @@ class WorkModelRefresher:
         include_github: bool,
     ) -> tuple[WorkChangeEvent, ...]:
         with self._lock:
+            if include_github and self.github_pressure_gate is not None:
+                # #506：一輪 GitHub 掃描開始，重置本輪節流預算。
+                self.github_pressure_gate.begin_cycle()
             previous = self.read_store.current_snapshot()
             providers = dict(previous.providers)
             active_provider_ids: set[str] = set()
@@ -480,7 +490,16 @@ class WorkModelRefresher:
                 github_id = f"github:{repo}"
                 terminal_id = f"github-terminal:{repo}"
                 if include_github and is_github:
-                    github_result = self.github_provider_factory(repo).scan()
+                    # #506：預設 provider 才注入壓力閘門；注入自訂 factory 的
+                    # 呼叫端（測試／上層組裝）行為完全不變。
+                    github_provider = (
+                        GitHubWorkProvider(
+                            repo, pressure_gate=self.github_pressure_gate
+                        )
+                        if self._uses_default_github_provider
+                        else self.github_provider_factory(repo)
+                    )
+                    github_result = github_provider.scan()
                     github = _retain_last_good(providers.get(github_id), github_result)
                     providers[github_id] = github
                     relevant.append(github)
@@ -491,6 +510,7 @@ class WorkModelRefresher:
                                 workflow,
                                 repo=repo,
                             ),
+                            pressure_gate=self.github_pressure_gate,
                         )
                         if self._uses_default_github_terminal_provider
                         else self.github_terminal_provider_factory(repo)

--- a/tests/test_monitor_github_pressure_506.py
+++ b/tests/test_monitor_github_pressure_506.py
@@ -1,0 +1,626 @@
+"""#506：GitHub 掃描 burst 減壓——請求節流與 403 分診／退避的回歸鎖。
+
+背景（issue #506）：monitor 的 ``_github_refresh_loop`` 每
+``github_refresh_interval_seconds``（預設 300s）對 workspace 內每個 GitHub
+repo 各跑一次 ``GitHubWorkProvider.scan()`` 與 ``GitHubTerminalProvider.scan()``。
+兩者單輪的 ``gh`` 呼叫都不是 O(1)（issues ``--paginate``、PR graphql 分頁、
+逐檔 contents、逐 PR compare），約 40 個 repo 的 workspace 一輪會在數秒內
+齊發數百次請求，穩定觸發 GitHub secondary（abuse detection）rate limit，
+``github:`` 與 ``github-terminal:`` 兩個 provider 同時 degraded 超過 35 分鐘，
+operator 的 ``cortex work`` 全被 ``claim.py`` 的
+``provider-authority-rate-limited-canonical`` 擋下。
+
+本檔鎖三件事：
+1. 節流：請求之間確實被攤平，可停用、有本輪總預算上限，且測試不真的 sleep。
+2. 403 分診：``gh api rate_limit`` 探測（此端點不計入配額）分辨 primary／
+   secondary，給不同 diagnostic。
+3. 退避：secondary 命中後指數退避，退避期間 scan 不發任何請求；且**所有**
+   rate-limit diagnostic 仍必須被 ``is_rate_limit_signal`` 認得，
+   否則 ``claim.py`` 既有的 reason code 行為會回歸（#370 的成果）。
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from paulsha_cortex.coordinator.claim import (
+    REASON_PROVIDER_RATE_LIMITED_CANONICAL,
+    AuthorityValidationError,
+    load_work_authority,
+)
+from paulsha_cortex.github_rate_limit import is_auth_signal, is_rate_limit_signal
+from paulsha_cortex.monitor.config import load_config
+from paulsha_cortex.monitor.github_pressure import GitHubPressureGate
+from paulsha_cortex.monitor.providers import GitHubTerminalProvider, GitHubWorkProvider
+from paulsha_cortex.monitor.work_api import WorkModelRefresher, WorkReadModelStore
+from paulsha_cortex.monitor.work_snapshot import WorkSnapshotStore
+
+
+SECONDARY_STDERR = (
+    "HTTP 403: You have exceeded a secondary rate limit for the OAuth App "
+    "associated with this personal access token. Please wait a few minutes "
+    "before you try again."
+)
+PRIMARY_STDERR = (
+    "HTTP 403: API rate limit exceeded for user ID 1. "
+    "(https://docs.github.com/rest/overview/rate-limits-for-the-rest-api)"
+)
+
+
+class FakeClock:
+    """可注入的 clock + sleeper：測試永遠不真的 sleep（節流全走假時間）。"""
+
+    def __init__(self, start: float = 1_000.0) -> None:
+        self.now = start
+        self.sleeps: list[float] = []
+
+    def __call__(self) -> float:
+        return self.now
+
+    def sleep(self, seconds: float) -> None:
+        self.sleeps.append(seconds)
+        self.now += seconds
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+class ScriptedRunner:
+    """依序回應的 fake runner；``rate_limit`` 探測有專屬回應槽。"""
+
+    def __init__(self, results, *, rate_limit=None) -> None:
+        self.results = list(results)
+        self.rate_limit = rate_limit
+        self.calls: list[tuple[str, ...]] = []
+
+    def run(self, argv, *, timeout):
+        argv = tuple(argv)
+        self.calls.append(argv)
+        if argv[-1] == "rate_limit":
+            if self.rate_limit is None:
+                raise AssertionError("未預期的 rate_limit 探測")
+            return self.rate_limit
+        if not self.results:
+            raise AssertionError(f"未預期的第 {len(self.calls)} 次 gh 呼叫：{argv}")
+        return self.results.pop(0)
+
+    @property
+    def api_calls(self) -> list[tuple[str, ...]]:
+        return [argv for argv in self.calls if argv[-1] != "rate_limit"]
+
+
+def _gate(clock: FakeClock, *, jitter: float = 0.0, **kwargs) -> GitHubPressureGate:
+    return GitHubPressureGate(
+        sleeper=clock.sleep,
+        clock=clock,
+        jitter_source=lambda: jitter,
+        **kwargs,
+    )
+
+
+def _completed(payload, *, returncode=0, stderr=""):
+    return subprocess.CompletedProcess(
+        args=("gh",),
+        returncode=returncode,
+        stdout=json.dumps(payload),
+        stderr=stderr,
+    )
+
+
+def _issues(*rows):
+    return subprocess.CompletedProcess(
+        args=("gh",),
+        returncode=0,
+        stdout="\n".join(json.dumps(row) for row in rows) + "\n",
+        stderr="",
+    )
+
+
+_ISSUE_ROW = {
+    "number": 506,
+    "title": "monitor github burst",
+    "state": "open",
+    "node_id": "ISSUE_node",
+    "updated_at": "2026-08-13T10:00:00Z",
+}
+
+_GRAPH = {
+    "data": {
+        "repository": {
+            "defaultBranchRef": {"name": "main", "target": {"oid": "d" * 40}},
+            "pullRequests": {"pageInfo": {"hasNextPage": False}, "nodes": []},
+        }
+    }
+}
+_TREE = {"truncated": False, "tree": []}
+
+
+def _rate_limit_payload(*, remaining: int, reset: int = 1_800_000_000):
+    return _completed(
+        {
+            "resources": {
+                "core": {"limit": 5000, "remaining": remaining, "reset": reset},
+                "graphql": {"limit": 5000, "remaining": 5000, "reset": reset},
+            },
+            "rate": {"limit": 5000, "remaining": remaining, "reset": reset},
+        }
+    )
+
+
+# --------------------------------------------------------------------------
+# A. 請求節流／攤平
+# --------------------------------------------------------------------------
+
+
+def test_throttle_spaces_each_request_instead_of_bursting():
+    clock = FakeClock()
+    runner = ScriptedRunner([_completed(_GRAPH), _completed(_TREE)])
+
+    result = GitHubTerminalProvider(
+        "example/acme",
+        runner=runner,
+        pressure_gate=_gate(clock, interval_seconds=0.2, jitter_seconds=0.1),
+    ).scan()
+
+    assert result.status == "ok"
+    # 兩次 gh 請求 → 兩段節流間隔（jitter_source 固定 0 → 純 interval）。
+    assert clock.sleeps == [0.2, 0.2]
+
+
+def test_throttle_jitter_is_added_on_top_of_interval():
+    clock = FakeClock()
+    runner = ScriptedRunner([_completed(_GRAPH), _completed(_TREE)])
+
+    GitHubTerminalProvider(
+        "example/acme",
+        runner=runner,
+        pressure_gate=_gate(clock, jitter=1.0, interval_seconds=0.2, jitter_seconds=0.1),
+    ).scan()
+
+    assert clock.sleeps == pytest.approx([0.3, 0.3])
+
+
+def test_throttle_zero_interval_disables_throttling():
+    clock = FakeClock()
+    runner = ScriptedRunner([_issues(_ISSUE_ROW)])
+
+    result = GitHubWorkProvider(
+        "example/acme",
+        runner=runner,
+        pressure_gate=_gate(clock, interval_seconds=0.0, jitter_seconds=0.0),
+    ).scan()
+
+    assert result.status == "ok"
+    assert clock.sleeps == []
+
+
+def test_throttle_budget_caps_total_sleep_and_resets_per_cycle():
+    """極端情況（repo 數暴增）不得讓節流本身吃掉整個 refresh interval。"""
+    clock = FakeClock()
+    gate = _gate(clock, interval_seconds=0.2, jitter_seconds=0.0, budget_seconds=0.25)
+    runner = ScriptedRunner([_completed(_GRAPH), _completed(_TREE)])
+
+    GitHubTerminalProvider("example/acme", runner=runner, pressure_gate=gate).scan()
+
+    # 第二次只剩 0.05 預算，之後即使還有請求也不再 sleep。
+    assert clock.sleeps == pytest.approx([0.2, 0.05])
+
+    gate.begin_cycle()
+    runner = ScriptedRunner([_completed(_GRAPH), _completed(_TREE)])
+    GitHubTerminalProvider("example/acme", runner=runner, pressure_gate=gate).scan()
+
+    assert clock.sleeps == pytest.approx([0.2, 0.05, 0.2, 0.05])
+
+
+def test_throttle_budget_never_exceeds_half_the_refresh_interval(tmp_path: Path):
+    """config 的 budget 不得超過一輪 refresh interval 的一半（見 #506 預算計算）。"""
+    config = tmp_path / "project-cortex.yaml"
+    config.write_text(
+        "workspaces:\n"
+        "  - name: demo\n"
+        "    path: /tmp/demo\n"
+        "monitor:\n"
+        "  github_refresh_interval_seconds: 60\n"
+        "  github_throttle_budget_seconds: 120\n",
+        encoding="utf-8",
+    )
+
+    cfg = load_config(config_path=config)
+
+    assert cfg.github_throttle_budget_seconds == 120
+    assert cfg.github_throttle_budget() == 30.0
+
+
+def test_monitor_config_parses_throttle_settings(tmp_path: Path):
+    config = tmp_path / "project-cortex.yaml"
+    config.write_text(
+        "workspaces:\n"
+        "  - name: demo\n"
+        "    path: /tmp/demo\n"
+        "monitor:\n"
+        "  github_request_interval_ms: 0\n"
+        "  github_request_jitter_ms: 50\n"
+        "  github_backoff_base_seconds: 30\n"
+        "  github_backoff_max_seconds: 900\n",
+        encoding="utf-8",
+    )
+
+    cfg = load_config(config_path=config)
+
+    assert cfg.github_request_interval_ms == 0
+    assert cfg.github_request_jitter_ms == 50
+    assert cfg.github_backoff_base_seconds == 30
+    assert cfg.github_backoff_max_seconds == 900
+
+
+@pytest.mark.parametrize(
+    "field, value",
+    [
+        ("github_request_interval_ms", -1),
+        ("github_request_jitter_ms", -5),
+        ("github_throttle_budget_seconds", 0),
+        ("github_backoff_base_seconds", 0),
+    ],
+)
+def test_monitor_config_rejects_invalid_throttle_settings(tmp_path: Path, field: str, value: int):
+    config = tmp_path / "project-cortex.yaml"
+    config.write_text(
+        "workspaces:\n"
+        "  - name: demo\n"
+        "    path: /tmp/demo\n"
+        f"monitor:\n  {field}: {value}\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError):
+        load_config(config_path=config)
+
+
+def test_default_throttle_budget_fits_a_forty_repo_cycle():
+    """預算計算（#506）：40 repo × 約 5 次呼叫 × 0.2s ≈ 40s ≪ 300s。"""
+    gate = GitHubPressureGate()
+
+    assert gate.interval_seconds * 40 * 5 < 300
+    assert gate.budget_seconds <= 150
+
+
+# --------------------------------------------------------------------------
+# B. 403 分診（primary vs secondary）
+# --------------------------------------------------------------------------
+
+
+def test_secondary_rate_limit_is_triaged_via_rate_limit_endpoint():
+    clock = FakeClock()
+    runner = ScriptedRunner(
+        [_completed({}, returncode=1, stderr=SECONDARY_STDERR)],
+        rate_limit=_rate_limit_payload(remaining=4_900),
+    )
+
+    result = GitHubWorkProvider(
+        "example/acme", runner=runner, pressure_gate=_gate(clock)
+    ).scan()
+
+    assert result.status == "degraded"
+    assert any("secondary rate limit" in item for item in result.diagnostics)
+    assert not any("primary" in item for item in result.diagnostics)
+    # 探測走的是不計配額的 rate_limit 端點。
+    assert runner.calls[-1] == ("gh", "api", "--method", "GET", "rate_limit")
+
+
+def test_primary_quota_exhaustion_is_reported_apart_from_secondary():
+    clock = FakeClock()
+    runner = ScriptedRunner(
+        [_completed({}, returncode=1, stderr=PRIMARY_STDERR)],
+        rate_limit=_rate_limit_payload(remaining=0),
+    )
+
+    result = GitHubWorkProvider(
+        "example/acme", runner=runner, pressure_gate=_gate(clock)
+    ).scan()
+
+    assert result.status == "degraded"
+    assert any("primary rate limit exhausted" in item for item in result.diagnostics)
+    assert not any("secondary" in item for item in result.diagnostics)
+
+
+def test_probe_failure_falls_back_to_generic_rate_limit_diagnostic():
+    clock = FakeClock()
+    runner = ScriptedRunner(
+        [_completed({}, returncode=1, stderr=SECONDARY_STDERR)],
+        rate_limit=_completed({}, returncode=1, stderr="gh: rate_limit unavailable"),
+    )
+
+    result = GitHubWorkProvider(
+        "example/acme", runner=runner, pressure_gate=_gate(clock)
+    ).scan()
+
+    assert result.status == "degraded"
+    assert any("github rate limit exceeded" in item for item in result.diagnostics)
+
+
+def test_auth_failure_does_not_trigger_the_rate_limit_probe():
+    clock = FakeClock()
+    runner = ScriptedRunner(
+        [_completed({}, returncode=1, stderr="HTTP 401: Bad credentials")]
+    )
+
+    result = GitHubWorkProvider(
+        "example/acme", runner=runner, pressure_gate=_gate(clock)
+    ).scan()
+
+    assert any("authentication" in item for item in result.diagnostics)
+    assert all(argv[-1] != "rate_limit" for argv in runner.calls)
+
+
+@pytest.mark.parametrize(
+    "stderr, remaining",
+    [(SECONDARY_STDERR, 4_900), (PRIMARY_STDERR, 0)],
+)
+def test_triaged_diagnostics_remain_rate_limit_signals(stderr: str, remaining: int):
+    """#370 回歸鎖：primary／secondary 都必須維持 ``is_rate_limit_signal`` 為真，
+    否則 ``claim.py`` 的 ``provider-authority-rate-limited-canonical`` 會消失。"""
+    clock = FakeClock()
+    runner = ScriptedRunner(
+        [_completed({}, returncode=1, stderr=stderr)],
+        rate_limit=_rate_limit_payload(remaining=remaining),
+    )
+
+    result = GitHubWorkProvider(
+        "example/acme", runner=runner, pressure_gate=_gate(clock)
+    ).scan()
+
+    assert result.diagnostics
+    assert all(is_rate_limit_signal(item) for item in result.diagnostics)
+    assert not any(
+        is_auth_signal(item) and not is_rate_limit_signal(item)
+        for item in result.diagnostics
+    )
+
+
+def test_claim_still_returns_the_rate_limited_reason_code(tmp_path: Path):
+    """端到端鎖：新 diagnostic 落進 durable snapshot 後，claim.py 的
+    canonical reason code 必須維持 ``provider-authority-rate-limited-canonical``。"""
+    clock = FakeClock()
+    runner = ScriptedRunner(
+        [_completed({}, returncode=1, stderr=SECONDARY_STDERR)],
+        rate_limit=_rate_limit_payload(remaining=4_900),
+    )
+    result = GitHubWorkProvider(
+        "acme/demo", runner=runner, pressure_gate=_gate(clock)
+    ).scan()
+
+    snapshot = tmp_path / "snapshot.json"
+    snapshot.write_text(
+        json.dumps(
+            {
+                "schema": "work-items-snapshot/v1",
+                "providers": {
+                    "github:acme/demo": {
+                        "status": "degraded",
+                        "revision": "gh-rev-1",
+                        "last_success_at": "2026-08-13T11:19:26Z",
+                        "diagnostics": list(result.diagnostics),
+                    }
+                },
+                "work_items": [
+                    {
+                        "repo": "acme/demo",
+                        "work_id": "rate-limited-work",
+                        "sources": [
+                            {
+                                "confidence": "confirmed",
+                                "kind": "todo",
+                                "ref": "docs/todo.md",
+                                "source_id": "todo:rate-limited-work",
+                                "revision": "todo-rev-1",
+                            }
+                        ],
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(AuthorityValidationError) as excinfo:
+        load_work_authority(
+            repo="acme/demo", work_id="rate-limited-work", snapshot_path=snapshot
+        )
+
+    assert excinfo.value.reason_code == REASON_PROVIDER_RATE_LIMITED_CANONICAL
+
+
+# --------------------------------------------------------------------------
+# C. 退避（退避期間不發請求）
+# --------------------------------------------------------------------------
+
+
+def test_backoff_window_skips_scan_without_issuing_requests():
+    clock = FakeClock()
+    gate = _gate(clock, backoff_base_seconds=60.0)
+    first_runner = ScriptedRunner(
+        [_completed({}, returncode=1, stderr=SECONDARY_STDERR)],
+        rate_limit=_rate_limit_payload(remaining=4_900),
+    )
+    GitHubWorkProvider("example/acme", runner=first_runner, pressure_gate=gate).scan()
+
+    second_runner = ScriptedRunner([])
+    result = GitHubWorkProvider(
+        "example/acme", runner=second_runner, pressure_gate=gate
+    ).scan()
+
+    assert second_runner.calls == []
+    assert result.status == "degraded"
+    assert any("backoff" in item for item in result.diagnostics)
+    assert all(is_rate_limit_signal(item) for item in result.diagnostics)
+
+
+def test_backoff_is_account_scoped_across_repos_and_providers():
+    """GitHub 的 secondary limit 綁 token 而非 repo：若退避只綁單一 provider，
+    40 個 repo 會各燒一次 403，減壓等於沒做。"""
+    clock = FakeClock()
+    gate = _gate(clock)
+    runner = ScriptedRunner(
+        [_completed({}, returncode=1, stderr=SECONDARY_STDERR)],
+        rate_limit=_rate_limit_payload(remaining=4_900),
+    )
+    GitHubWorkProvider("example/acme", runner=runner, pressure_gate=gate).scan()
+
+    other_runner = ScriptedRunner([])
+    other = GitHubWorkProvider(
+        "example/other", runner=other_runner, pressure_gate=gate
+    ).scan()
+    terminal_runner = ScriptedRunner([])
+    terminal = GitHubTerminalProvider(
+        "example/acme", runner=terminal_runner, pressure_gate=gate
+    ).scan()
+
+    assert other_runner.calls == []
+    assert terminal_runner.calls == []
+    assert other.status == terminal.status == "degraded"
+
+
+def test_scan_resumes_after_the_backoff_window_expires():
+    clock = FakeClock()
+    gate = _gate(clock, backoff_base_seconds=60.0)
+    runner = ScriptedRunner(
+        [_completed({}, returncode=1, stderr=SECONDARY_STDERR)],
+        rate_limit=_rate_limit_payload(remaining=4_900),
+    )
+    GitHubWorkProvider("example/acme", runner=runner, pressure_gate=gate).scan()
+
+    clock.advance(61.0)
+    recovered_runner = ScriptedRunner([_issues(_ISSUE_ROW)])
+    result = GitHubWorkProvider(
+        "example/acme", runner=recovered_runner, pressure_gate=gate
+    ).scan()
+
+    assert result.status == "ok"
+    assert recovered_runner.api_calls
+
+
+def test_consecutive_secondary_hits_back_off_exponentially_with_a_ceiling():
+    clock = FakeClock()
+    gate = _gate(clock, backoff_base_seconds=60.0, backoff_max_seconds=200.0)
+
+    delays = []
+    for _ in range(4):
+        delays.append(gate.note_rate_limited(kind="secondary"))
+        clock.advance(delays[-1] + 1.0)
+
+    assert delays == [60.0, 120.0, 200.0, 200.0]
+
+
+def test_successful_scan_clears_backoff_state():
+    clock = FakeClock()
+    gate = _gate(clock, backoff_base_seconds=60.0)
+    gate.note_rate_limited(kind="secondary")
+    clock.advance(61.0)
+
+    runner = ScriptedRunner([_issues(_ISSUE_ROW)])
+    assert (
+        GitHubWorkProvider(
+            "example/acme", runner=runner, pressure_gate=gate
+        ).scan().status
+        == "ok"
+    )
+
+    # 成功後重新計數：下一次 secondary 回到 base，而不是延續指數。
+    assert gate.note_rate_limited(kind="secondary") == 60.0
+
+
+def test_retry_after_wins_over_exponential_backoff():
+    clock = FakeClock()
+    gate = _gate(clock, backoff_base_seconds=60.0, backoff_max_seconds=1800.0)
+    runner = ScriptedRunner(
+        [
+            _completed(
+                {},
+                returncode=1,
+                stderr=SECONDARY_STDERR + "\nRetry-After: 300\n",
+            )
+        ],
+        rate_limit=_rate_limit_payload(remaining=4_900),
+    )
+
+    GitHubWorkProvider("example/acme", runner=runner, pressure_gate=gate).scan()
+
+    assert gate.blocked_seconds() == pytest.approx(300.0)
+
+
+def test_terminal_provider_rate_limit_is_classified_and_backed_off():
+    """終局 provider 是請求量最大的一支（graphql + tree + 逐檔 contents），
+    它若不參與退避，減壓形同虛設。"""
+    clock = FakeClock()
+    gate = _gate(clock)
+    runner = ScriptedRunner(
+        [_completed({}, returncode=1, stderr=SECONDARY_STDERR)],
+        rate_limit=_rate_limit_payload(remaining=4_900),
+    )
+
+    result = GitHubTerminalProvider(
+        "example/acme", runner=runner, pressure_gate=gate, retry_delays=()
+    ).scan()
+
+    assert result.status == "degraded"
+    assert any("secondary rate limit" in item for item in result.diagnostics)
+    assert all(is_rate_limit_signal(item) for item in result.diagnostics)
+    assert gate.blocked_seconds() > 0
+
+
+def test_terminal_provider_non_rate_limit_failure_keeps_existing_diagnostic():
+    """既有行為不得回歸：非 rate-limit 失敗仍是 evidence unavailable，且不退避。"""
+    clock = FakeClock()
+    gate = _gate(clock)
+    runner = ScriptedRunner(
+        [_completed({"message": "bad credentials"}, returncode=1, stderr="gh: bad credentials (HTTP 401)")]
+    )
+
+    result = GitHubTerminalProvider(
+        "example/acme", runner=runner, pressure_gate=gate, retry_delays=()
+    ).scan()
+
+    assert result.status == "degraded"
+    assert result.diagnostics == ("github terminal evidence unavailable",)
+    assert gate.blocked_seconds() == 0.0
+
+
+def test_refresher_resets_the_throttle_budget_once_per_github_cycle(tmp_path: Path):
+    """節流預算是「每輪」的：只有 ``include_github=True`` 的那條迴圈算一輪。"""
+
+    class _SpyGate(GitHubPressureGate):
+        def __init__(self) -> None:
+            super().__init__()
+            self.cycles = 0
+
+        def begin_cycle(self) -> None:
+            self.cycles += 1
+            super().begin_cycle()
+
+    gate = _SpyGate()
+    refresher = WorkModelRefresher(
+        durable_store=WorkSnapshotStore(tmp_path / "state/work-items.snapshot.json"),
+        read_store=WorkReadModelStore.empty(),
+        github_pressure_gate=gate,
+    )
+
+    refresher.refresh((), include_github=False)
+    assert gate.cycles == 0
+
+    refresher.refresh((), include_github=True)
+    refresher.refresh((), include_github=True)
+    assert gate.cycles == 2
+
+
+def test_provider_without_gate_behaves_exactly_as_before():
+    """gate 可停用（不注入即完全沒有節流／退避），既有呼叫端不受影響。"""
+    runner = ScriptedRunner([_issues(_ISSUE_ROW)])
+
+    result = GitHubWorkProvider("example/acme", runner=runner).scan()
+
+    assert result.status == "ok"
+    assert len(runner.calls) == 1

--- a/tests/test_monitor_work_review_regressions.py
+++ b/tests/test_monitor_work_review_regressions.py
@@ -179,9 +179,12 @@ def test_default_terminal_provider_receives_only_registry_linked_prs(
     captured: list[tuple[str, tuple[int, ...] | None]] = []
 
     class CapturingTerminalProvider:
-        def __init__(self, repo: str, *, relevant_pr_numbers=None):
+        # #506：預設 terminal provider 現在還會收到共享的 GitHub 壓力閘門
+        # （節流／退避），簽章跟著 work_api 的預設建構路徑走。
+        def __init__(self, repo: str, *, relevant_pr_numbers=None, pressure_gate=None):
             captured.append((repo, relevant_pr_numbers))
             self.repo = repo
+            self.pressure_gate = pressure_gate
 
         def scan(self) -> ProviderSnapshot:
             return _provider(f"github-terminal:{self.repo}")


### PR DESCRIPTION
## 摘要

Issue #506 的**核心減壓部分實作**（不關閉該 issue）：解掉目前 dogfooding 死結的 bootstrap 修正。

Monitor 的 `_github_refresh_loop` 每 `github_refresh_interval_seconds`（預設 300s）對 workspace 內每個 GitHub repo 各跑一次 `GitHubWorkProvider.scan()` 與 `GitHubTerminalProvider.scan()`，而單 repo 單輪的 `gh` 呼叫是 **O(issues 分頁 + remote todo 檔數 + workflow-linked merged PR 數)** 而非 O(1)：

| 位置 | 呼叫 |
| --- | --- |
| `providers.py:691` | `gh api --paginate ... repos/<repo>/issues?state=all&per_page=100`（分頁） |
| `providers.py:859`、`:948` | `gh api --method GET`（tree／compare） |
| `providers.py:1009` | `gh api graphql`（PR，可再分頁） |
| `providers.py:1080` | 逐檔 `gh api .../contents/...`（remote todo 內容） |

約 40 個 repo 的 workspace 一輪會在數秒內齊發數百次請求，穩定觸發 GitHub secondary（abuse detection）rate limit——實測 `github:` 與 `github-terminal:` 兩個 provider 同時 degraded 超過 35 分鐘，operator 的 `cortex work` 全被 `coordinator/claim.py` 的 `provider-authority-rate-limited-canonical` 擋下。

## 變更內容

### A. 請求節流／攤平（建議 5 的最小版）

- 新增 `paulsha_cortex/monitor/github_pressure.py` 的 `GitHubPressureGate`：**每一次** `gh` 請求前插入 `interval + jitter` 的間隔（含 graphql 分頁與逐檔 `contents`，也就是請求量最大的那條路徑）。
- `monitor:` 區段新增 `github_request_interval_ms`（預設 200，**設 0 即完全停用**）、`github_request_jitter_ms`（預設 100）、`github_throttle_budget_seconds`（預設 120）、`github_backoff_base_seconds`（60）、`github_backoff_max_seconds`（1800）。
- **預算計算**（寫在模組 docstring 與 `docs/monitor-config.md`）：40 repo × 約 5 次呼叫／repo × 0.2s ≈ **40s**，遠低於一輪的 300s。極端情況（repo／todo 檔數暴增）的上限保護是 `github_throttle_budget_seconds`，實際生效值另由 `MonitorConfig.github_throttle_budget()` 夾在 `github_refresh_interval_seconds` 的一半以下；預算用盡後節流自動失效——寧可讓該輪尾段恢復齊發，也不讓節流本身把掃描週期撐爆。
- 閘門由 `WorkModelRefresher` 持有，**跨 repo、跨輪次共用**（provider 是 per-repo 建立的短命物件，但壓力是 per-token 的）；`begin_cycle()` 在每輪 `include_github=True` 的 refresh 開頭重置預算。
- `clock` / `sleeper` / `jitter_source` 全部可注入，測試不會真的 sleep。

### B. 403 分診與退避（建議 1 的最小版）

- rate-limit 型失敗時再查一次 **不計入配額** 的 `gh api rate_limit`：`remaining > 0` → `github secondary rate limit`（burst 觸發）；`remaining == 0` → `github primary rate limit exhausted`（配額耗盡）；探測本身失敗則保守退回既有的 `github rate limit exceeded`。
- **三者都仍被 `github_rate_limit.is_rate_limit_signal` 認得**，`coordinator/claim.py` 的 `provider-authority-rate-limited-canonical` reason code 行為完全不變（#370 的成果）；本 PR 用兩個測試鎖住這點，含一個寫入 durable snapshot 後直接驗 `load_work_authority()` reason code 的端到端鎖。
- 命中後開啟指數退避（base 60s、上限 1800s，尊重訊息中透出的 `Retry-After` / `x-ratelimit-reset`），**退避期間 `scan()` 直接跳過、不發任何請求**。退避窗綁 token（帳號層級）而非單一 repo——GitHub 的 secondary limit 本來就綁 token，若以 provider_id 為 key，40 個 repo 會各燒一次 403 才進退避，減壓形同虛設。
- `GitHubTerminalProvider` 原本把限流混進 `github terminal evidence unavailable`、下游完全分辨不出來；本次接上同一套分診與退避，並且**不再重試** rate-limit 失敗（重試 403 只會把 secondary limit 撞得更深）。

### 不在本 PR 範圍（留給 #506 的後續票）

GraphQL 批次化（建議 4）、全域跨子系統預算、`gh auth status` 雙重驗證、緊迴圈輪詢規範。

## 相容性

未注入閘門時 provider 行為與先前**完全相同**（不節流、不退避），既有呼叫端與注入自訂 factory 的測試不受影響。唯一需要跟著改的既有測試是 `test_default_terminal_provider_receives_only_registry_linked_prs` 的 stub 簽章（預設 terminal provider 現在會收到 `pressure_gate`）。

## 驗證

- `python3 -m pytest tests/ -q` → **2503 passed, 3 skipped, 49 subtests passed**（新增 `tests/test_monitor_github_pressure_506.py`，28 個測試）。
- `python3 -m policy_check --repo .`（帶 PR 上下文）→ EXIT=0。

## Checklist

- [x] `changelog.d/rate-limit-pressure.md` fragment 已新增且已 commit
- [x] `CHANGELOG.md [Unreleased]` 有對應 entry
- [x] `VERSION` 與意圖一致（非 release PR，未動）
- [x] 分支為 `feature/506-rate-limit-pressure`（自 `origin/main`，不含點號）
- [x] 全套測試通過
- [x] docs 同步（`docs/monitor-config.md` 新增「GitHub 掃描壓力設定」段）
- [x] 語言 zh-tw（commit／PR／註解）

本 PR 只做 #506 的部分實作、**不關閉** issue，故引用為 `Refs #506` 並附 `policy-exempt:issue-link` 豁免 label。

Refs #506

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E7w9kaUxAzCCEk7piD5hfK
