### PR TITLE
fix(coordinator): integrator prompt 補上兩個 echo-back 欄位的值來源（#516）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@
 ## [Unreleased]
 
 ### Fixed
+- **Issue #516：integrator prompt 補上兩個 echo-back 欄位的值來源**——
+  `_validate_primary_integration()` 要求 integrator 輸出的 `question_pack_id`
+  與 `secondary_evidence_hash` 與輸入完全相符，兩個值也都已在模型輸入裡
+  （`question_pack.pack_id`、`secondary_evidence.evidence_hash`），模型只需原樣
+  複製；但 prompt 只把它們當欄位名列在輸出鍵清單，且輸入欄位名（`evidence_hash`）
+  與輸出欄位名（`secondary_evidence_hash`）不同，後者字面上像是要模型自己算 hash。
+  planning 因此反覆以 `primary integration evidence hash mismatch` 落 needs_human，
+  Phase 1 派工死鎖。prompt 現在明寫兩者「copied verbatim from」的來源欄位並禁止
+  自行計算 hash（`do not compute, derive, or invent a hash`），`#406` 註解旁補記
+  本次補齊的欄位。只改 prompt 文字與對應測試，validator 邏輯與資料流不動。
+  詳見 `changelog.d/integrator-prompt-semantics.md`。
 - **Issue #511（診斷面，前兩項）：planning artifact 被拒時的原因與內容可觀測**——
   `manager._publish_planning_artifacts()` 過去只取 `assess_planning_artifact()`
   的布林值，`reasons`／`blocking_markers` 全被丟棄，被拒內容又只活在 planning

--- a/changelog.d/integrator-prompt-semantics.md
+++ b/changelog.d/integrator-prompt-semantics.md
@@ -1,0 +1,46 @@
+---
+type: fix
+scope: coordinator
+---
+**Issue #516：integrator prompt 補上兩個 echo-back 欄位的值來源**
+
+`coordinator/planning.py` 的 `_validate_primary_integration()` 要求 integrator
+輸出的 `question_pack_id` 與 `secondary_evidence_hash` 與輸入完全相符：
+
+```python
+if payload.get("question_pack_id") != question_pack.pack_id:
+    raise ValueError("primary integration pack mismatch")
+if payload.get("secondary_evidence_hash") != secondary_evidence_hash:
+    raise ValueError("primary integration evidence hash mismatch")
+```
+
+兩個值本來就都在模型輸入裡——`pack.to_dict()` 帶 `pack_id`，
+`callback_payload = {**secondary_payload, "evidence_hash": evidence_hash}` 帶
+`evidence_hash`——模型只需**原樣複製**，不需要也不可能自己算出正確的 hash
+（`_hash_payload()` 對的是 canonical 化後的 `secondary_payload`）。但
+`coordinator/planning_runtime.py` 的 integrator prompt 只把這兩個欄位當欄位名
+列在輸出鍵清單裡，沒說值從哪來；更關鍵的是**輸入欄位名（`evidence_hash`）與
+輸出欄位名（`secondary_evidence_hash`）不同**，後者字面上像是在要求模型計算
+「secondary evidence 的 hash」。模型因此反覆自行算 hash，planning 每次都以
+`primary-integration-malformed: ValueError: primary integration evidence hash mismatch`
+落 needs_human，Phase 1 派工死鎖。
+
+prompt 現在明確寫出兩者的來源，並直接禁止自算：
+
+> `question_pack_id` must be copied verbatim from the input `question_pack.pack_id`
+> value. `secondary_evidence_hash` must be copied verbatim from the input
+> `secondary_evidence.evidence_hash` field; do not compute, derive, or invent a hash.
+
+這是 `#406` 註解已記載的同一個教訓（「只列欄位名、不給語意時模型會猜錯」）的第二輪
+——當時只補了 `artifact_refs`，兩個 echo-back 欄位漏掉。該註解旁一併補記本次補齊的
+是哪兩個欄位。
+
+只改 prompt 文字與對應測試，validator 邏輯與資料流不動。同批盤點過 integrator
+prompt 其餘欄位，未再發現同類（會確定性導致驗證失敗的）缺口：`schema_version`
+已直接給值，`resolutions[].question_id`／`artifact_kind`／`artifact_refs` 與
+`artifacts[].path` 於 `#406` already 補齊語意。`resolutions[].decision` 確實未給
+內容期待，但 validator 只要求非空字串（`decision.strip()`），不構成同一失敗模式，
+本次不動以維持最小 diff。
+
+不在範圍（後續票）：把 echo-back 值改由呼叫端填入、不交給模型複製（#516 建議 4 的
+架構改法）；其他 planning 失敗模式（#507／#511／#514／#515）。

--- a/paulsha_cortex/coordinator/planning_runtime.py
+++ b/paulsha_cortex/coordinator/planning_runtime.py
@@ -640,10 +640,18 @@ def build_production_planning_runtime(
     def integrator(pack: Mapping[str, object], evidence: Mapping[str, object]) -> object:
         # #406：prompt 必須把 validate_primary_integration 的結構約束逐條講給模型，
         # 只列欄位名（不給語意）時模型會把不確定的 artifact_refs 留空 → 必然驗證失敗。
+        # #516：同一教訓的第二輪，這次補的是 question_pack_id 與 secondary_evidence_hash
+        # 兩個 echo-back 欄位——兩個值都已在輸入裡（question_pack.pack_id、
+        # secondary_evidence.evidence_hash），模型只需原樣複製；但輸入欄位名
+        # （evidence_hash）與輸出欄位名（secondary_evidence_hash）不同，後者字面上
+        # 像是要模型自己算 hash，只列欄位名時會反覆撞 evidence hash mismatch。
         return invoke_primary(
             "Do not call tools or edit files. Integrate only the supplied evidence. Return exactly one "
             "JSON object with schema_version=1, question_pack_id, secondary_evidence_hash, resolutions, "
-            "and artifacts. Each resolution has only question_id, decision, artifact_kind, artifact_refs. "
+            "and artifacts. question_pack_id must be copied verbatim from the input question_pack.pack_id "
+            "value. secondary_evidence_hash must be copied verbatim from the input "
+            "secondary_evidence.evidence_hash field; do not compute, derive, or invent a hash. "
+            "Each resolution has only question_id, decision, artifact_kind, artifact_refs. "
             "Resolve every question exactly once. artifact_kind must equal the question kind without its "
             "'missing-' prefix. artifact_refs must be a NON-EMPTY list of the destination path(s) this "
             "resolution's artifact(s) are written to — the same strings used as artifacts[].path. "

--- a/tests/test_planning_runtime.py
+++ b/tests/test_planning_runtime.py
@@ -364,6 +364,58 @@ def test_questioner_and_integrator_prompts_include_json_output_contract(
     assert "must equal the union of all artifact_refs" in integrator_prompt
 
 
+def test_integrator_prompt_states_echo_back_field_sources(monkeypatch, tmp_path: Path) -> None:
+    """issue #516：`_validate_primary_integration()` 要求 `question_pack_id` 與
+    `secondary_evidence_hash` 與輸入完全相符，兩個值都已在模型輸入裡（分別是
+    `question_pack.pack_id` 與 `secondary_evidence.evidence_hash`），模型只需原樣
+    複製。但輸入欄位名（`evidence_hash`）與輸出欄位名（`secondary_evidence_hash`）
+    不同，後者字面上像是要模型自己算 hash——prompt 只列欄位名時模型必然猜錯，
+    planning 反覆以 `primary integration evidence hash mismatch` 失敗。"""
+    registry = IdentityRegistry.from_rows(
+        [
+            {
+                "executor": "codex", "model_id": "primary", "independence_domain": "openai",
+                "capabilities": ["planning"],
+            },
+            {
+                "executor": "agy", "model_id": AGY_MODEL_ID, "independence_domain": "google",
+                "capabilities": ["planning"], "live_probe": "agy-plan-sandbox",
+            },
+        ]
+    )
+    monkeypatch.setattr(planning_runtime, "load_model_identities", lambda: registry)
+    prompts: list[str] = []
+
+    def runner(argv, **kwargs):
+        if argv == ["agy", "models"]:
+            return _completed(f"{AGY_MODEL_ID}\n")
+        prompt = argv[argv.index("--print") + 1] if "--print" in argv else argv[2]
+        prompts.append(prompt)
+        return _completed(json.dumps({"schema_version": 1, "question_pack_id": "qp-x"}))
+
+    runtime = planning_runtime.build_production_planning_runtime(
+        primary=("codex", "primary"), worktree=tmp_path, runner=runner
+    )
+    runtime.primary_integrator(
+        {"schema_version": 1, "pack_id": "qp-x", "questions": []},
+        {
+            "schema_version": 1,
+            "question_pack_id": "qp-x",
+            "evidence": [],
+            "evidence_hash": "deadbeef",
+        },
+    )
+
+    integrator_prompt = prompts[-1]
+    # 兩個 echo-back 欄位都必須指名值的來源（輸入的哪個欄位），而非只列欄位名。
+    assert "copied verbatim from the input question_pack.pack_id" in integrator_prompt
+    assert (
+        "copied verbatim from the input secondary_evidence.evidence_hash" in integrator_prompt
+    )
+    # 明確禁止模型自行計算 hash——這正是 #516 的誤解來源。
+    assert "do not compute, derive, or invent a hash" in integrator_prompt
+
+
 def test_planning_source_material_rejects_symlink_traversal(tmp_path: Path) -> None:
     outside = tmp_path / "outside.md"
     outside.write_text("secret\n", encoding="utf-8")


### PR DESCRIPTION
## 摘要

`coordinator/planning.py` 的 `_validate_primary_integration()` 要求 integrator 輸出的
`question_pack_id` 與 `secondary_evidence_hash` 與輸入**完全相符**：

```python
if payload.get("question_pack_id") != question_pack.pack_id:
    raise ValueError("primary integration pack mismatch")
if payload.get("secondary_evidence_hash") != secondary_evidence_hash:
    raise ValueError("primary integration evidence hash mismatch")
```

兩個值本來就都在模型輸入裡——`pack.to_dict()` 帶 `pack_id`（`planning.py:200`），
`callback_payload = {**secondary_payload, "evidence_hash": evidence_hash}`
（`planning.py:1137-1138`）帶 `evidence_hash`——模型只需**原樣複製**，不需要也不可能
自己算出正確的值（`_hash_payload()` 對的是 canonical 化後的 `secondary_payload`）。

但 `coordinator/planning_runtime.py` 的 integrator prompt 只把這兩個欄位當**欄位名**
列在輸出鍵清單裡，沒說值從哪來；更關鍵的是**輸入欄位名（`evidence_hash`）與輸出欄位名
（`secondary_evidence_hash`）不同**，後者字面上像是在要求模型計算「secondary evidence
的 hash」。模型因此反覆自行算 hash，planning 每次都以
`primary-integration-malformed: ValueError: primary integration evidence hash mismatch`
落 needs_human，Phase 1 派工死鎖。

這是 `planning_runtime.py` 上方 `#406` 註解已記載的同一個教訓（「只列欄位名、不給語意時
模型會猜錯」）的第二輪——當時只補了 `artifact_refs`，兩個 echo-back 欄位漏掉。

## 改動

**只改 prompt 文字與對應測試，validator 邏輯與資料流完全不動。**

1. `paulsha_cortex/coordinator/planning_runtime.py` — integrator prompt 加入兩句：

   > `question_pack_id` must be copied verbatim from the input `question_pack.pack_id`
   > value. `secondary_evidence_hash` must be copied verbatim from the input
   > `secondary_evidence.evidence_hash` field; do not compute, derive, or invent a hash.

   沿用該 prompt 既有風格（英文、祈使句、逐條約束）。兩個 dotted path 對得上實際輸入
   結構：input 為 `{"question_pack": pack, "secondary_evidence": callback_payload,
   "destinations": ...}`。

2. 同函式上方 `#406` 註解旁補記本次補齊的是哪兩個欄位（沿用該處以 issue 編號標註取捨的
   慣例）。

3. `tests/test_planning_runtime.py` — 新增
   `test_integrator_prompt_states_echo_back_field_sources`，斷言 prompt 內含兩個欄位的
   複製來源說明與「不得自行計算 hash」。沿用既有
   `test_questioner_and_integrator_prompts_include_json_output_contract`（#401／#406）
   的 prompt 內容斷言風格。TDD：先寫測試確認 red，再改 prompt 轉 green。

## 其餘欄位語意缺口盤點

依 issue 要求盤點 integrator prompt 其餘欄位對 `_validate_primary_integration()` 的覆蓋，
**未再發現同類（會確定性導致驗證失敗的）缺口**：

- `schema_version` — prompt 已直接給值（`schema_version=1`）。
- `resolutions[].question_id`／`artifact_kind`／`artifact_refs`、`artifacts[].path` — 已於
  `#406` 補齊語意（「Resolve every question exactly once」「without its 'missing-' prefix」
  「NON-EMPTY list of the destination path(s)」「must equal the union of all artifact_refs」）。
- `resolutions[].decision` — 確實**未給內容期待**，但 validator 只要求非空字串
  （`decision.strip()`，`planning.py:871-872`），任何模型輸出都會通過，不構成同一失敗模式。
  為維持這個解死鎖小修的最小 diff，本次不動；若要補內容期待建議另開票。
- `artifacts[].kind` — 值域（`PLANNING_KINDS = ("spec", "design", "plan")`）未直接列舉，但
  prompt 的 per-kind heading 規則（Requirements for spec／Decisions for design／Tasks for
  plan）已隱含三個 kind，實務上不致猜錯。

## 驗證

- `python3 -m pytest -q` → **2518 passed, 49 subtests passed**（baseline 2517 + 本次新增 1）
- `python3 -m policy_check --repo <worktree>`（帶完整 PR 上下文）→ **EXIT=0**
- 新測試 red→green 已分別確認

## 不在範圍

- 把 echo-back 值改由呼叫端填入、不交給模型複製（#516 建議 4 的架構改法）
- 其他 planning 失敗模式（#507／#511／#514／#515）

## Checklist

- [x] `changelog.d/integrator-prompt-semantics.md` fragment 已新增且已 commit
- [x] `CHANGELOG.md [Unreleased]` 有對應 entry
- [x] `VERSION` 內容與意圖一致（本 PR 不涉及版號變更）
- [x] 分支命名符合 `feature/<slug>`（`feature/516-integrator-prompt-semantics`）
- [x] 測試全數通過
- [x] policy_check 帶 PR 上下文跑過且 EXIT=0

Refs #516

> R-17 豁免說明：本 PR 只補 prompt 語意，是否完全解決 #516 需待實跑 planning 驗證
> （issue 另有建議 4 的架構改法待評估），因此刻意不用 closing keyword，改掛
> `policy-exempt:issue-link`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E7w9kaUxAzCCEk7piD5hfK
