### PR TITLE
fix(coordinator): 必要標題要求改由驗收判準機械產生（#520）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@
 ## [Unreleased]
 
 ### Fixed
+- **Issue #520：必要標題要求改由驗收判準機械產生，消除雙讀法**——integrator
+  prompt 舊句「required headings: Requirements for spec, Decisions for design,
+  Tasks for plan」原意是逐 kind 對應，字面卻同樣可讀成「必要標題是
+  `Requirements for spec`」。planner 採了後者、產出 `## Requirements for spec`，
+  而 `_has_required_heading()` 是 casefold 後完全相等比對（標題正規化只剝編號
+  前綴、不剝 ` for spec` 尾綴），因此必然 `required-section-missing`，Phase 1
+  派工死鎖。修法採 `#520` 建議 4：`planning.py` 的 `_ACCEPTED_HEADINGS` 成為唯一
+  真檔，`_REQUIRED_HEADINGS` 由它 casefold 派生（判準值一字未改），新增純函式
+  `required_heading_hint()` 機械產生 prompt 文字，`planning_runtime.py` 直接呼叫
+  ——prompt 端不再持有第二份真實來源（判準與 prompt 不同步已造成 `#516`／`#520`
+  兩次確定性失敗）。產生的文字逐 kind 給精確標題、明確禁止附加 kind 名稱，並揭露
+  完整可接受集合。validator 邏輯與判準內容不動。
+  詳見 `changelog.d/planning-heading-prompt.md`。
 - **Issue #516：integrator prompt 補上兩個 echo-back 欄位的值來源**——
   `_validate_primary_integration()` 要求 integrator 輸出的 `question_pack_id`
   與 `secondary_evidence_hash` 與輸入完全相符，兩個值也都已在模型輸入裡

--- a/changelog.d/planning-heading-prompt.md
+++ b/changelog.d/planning-heading-prompt.md
@@ -1,0 +1,47 @@
+---
+type: fix
+scope: coordinator
+---
+**Issue #520：必要標題要求改由驗收判準機械產生，消除雙讀法**
+
+`coordinator/planning_runtime.py` 的 integrator prompt 舊句：
+
+```
+content must be complete UTF-8 Markdown with frontmatter status: accepted,
+the matching work_item, and required headings: Requirements for spec,
+Decisions for design, Tasks for plan.
+```
+
+原意是「kind=spec → `Requirements`；kind=design → `Decisions`；kind=plan →
+`Tasks`」，但字面同樣可讀成「必要標題是 `Requirements for spec`」。實測 planner
+採了後者、產出 `## Requirements for spec`，而 `coordinator/planning.py` 的
+`_has_required_heading()` 是 casefold 後**完全相等**比對——標題正規化只剝編號前綴
+（`^\d+(\.\d+)*[.)]?\s+`），不剝 ` for spec` 尾綴——於是必然
+`required-section-missing`。實測 evidence：run `workflow-6b3e215f18c5b68b991c`，
+`reasons: ['required-section-missing']`、`markers: []`、frontmatter 完全正確。
+
+修法採 issue #520 建議 4 的結構性作法，而不只是改寫該句文字：判準與 prompt 過去是
+**兩份各自維護的真實來源**，已因不同步造成 `#516` 與 `#520` 兩次確定性失敗。現在
+`planning.py` 內：
+
+- `_ACCEPTED_HEADINGS`（依「首選在前」排序的顯示形）是唯一真檔；
+- `_REQUIRED_HEADINGS` 由它 casefold 派生（判準值一字未改，測試以 frozen
+  expectation 鎖住）；
+- 新增純函式 `required_heading_hint()` 由上述常數機械產生 prompt 文字，
+  `planning_runtime.py` 直接呼叫它，prompt 端不再持有第二份真實來源。
+
+產生出的文字逐 kind 給精確標題、明確禁止附加 kind 名稱，並揭露完整可接受集合
+（給模型合法替代選項而非單點命中）：
+
+> The required heading depends on the artifact kind: use exactly `## Requirements`
+> for kind=spec, exactly `## Decisions` for kind=design, exactly `## Tasks` for
+> kind=plan. The heading text is that word alone; do not append the kind name or
+> any other suffix such as "for spec", "for design", "for plan" to it. Heading
+> text is matched case-insensitively against a fixed set, so any one of these is
+> also accepted — spec: Requirements, Requirement, Problem, Problem and Outcome,
+> Goals; design: Decisions, Decision, Design, Architecture; plan: Tasks, Task.
+
+判準本身（`_REQUIRED_HEADINGS` 的可接受集合）與 validator 邏輯不動；驗收行為零變更。
+
+不在範圍（後續票）：`#516` 已修的 echo-back 欄位語意；其他 planning 失敗模式
+（`#507`／`#511`／`#514`／`#515`／`#519`）。

--- a/paulsha_cortex/coordinator/planning.py
+++ b/paulsha_cortex/coordinator/planning.py
@@ -23,11 +23,46 @@ BRAINSTORM_EVIDENCE_SCHEMA_VERSION = 1
 _STANDALONE_MARKERS = frozenset({"tbd", "[tbd]", "decision: tbd", "決策：未定"})
 _HEADING_RE = re.compile(r"^(#{1,6})\s+(.+?)\s*#*\s*$")
 _LIST_ITEM_RE = re.compile(r"^(?:[-+*]|\d+[.)])\s+(\S.*)$")
-_REQUIRED_HEADINGS = {
-    "spec": frozenset({"requirements", "requirement", "problem", "problem and outcome", "goals"}),
-    "design": frozenset({"decisions", "decision", "design", "architecture"}),
-    "plan": frozenset({"task", "tasks"}),
+# issue #520：驗收判準與 integrator prompt 的標題要求過去是兩份各自維護的真實來源，
+# 已因不同步造成兩次確定性失敗。這裡是唯一真檔：`_ACCEPTED_HEADINGS` 依「首選在前」
+# 排序（給 prompt 用的顯示形），`_REQUIRED_HEADINGS` 由它 casefold 派生（給驗收用），
+# prompt 文字則由 `required_heading_hint()` 機械產生，不得在 prompt 端另寫一份。
+_ACCEPTED_HEADINGS: dict[str, tuple[str, ...]] = {
+    "spec": ("Requirements", "Requirement", "Problem", "Problem and Outcome", "Goals"),
+    "design": ("Decisions", "Decision", "Design", "Architecture"),
+    "plan": ("Tasks", "Task"),
 }
+_REQUIRED_HEADINGS = {
+    kind: frozenset(title.casefold() for title in titles)
+    for kind, titles in _ACCEPTED_HEADINGS.items()
+}
+
+
+def required_heading_hint() -> str:
+    """回傳 integrator prompt 用的必要標題說明（由上面的判準常數機械產生）。
+
+    issue #520：舊 prompt 手寫「required headings: Requirements for spec, Decisions
+    for design, Tasks for plan」，原意是逐 kind 對應，字面卻同樣可讀成「必要標題就是
+    `Requirements for spec`」。模型採了後者、產出 `## Requirements for spec`，而
+    `_has_required_heading()` 是 casefold 後**完全相等**比對（`_headings_and_markers()`
+    的正規化只剝編號前綴，不剝 ` for spec` 尾綴），於是必然 `required-section-missing`。
+    此處逐 kind 給出精確標題、明確禁止附加 kind 名稱，並揭露完整可接受集合，讓模型有
+    合法替代選項而非單點命中。
+    """
+    preferred = ", ".join(
+        f'exactly "## {_ACCEPTED_HEADINGS[kind][0]}" for kind={kind}' for kind in PLANNING_KINDS
+    )
+    forbidden = ", ".join(f'"for {kind}"' for kind in PLANNING_KINDS)
+    alternatives = "; ".join(
+        f"{kind}: {', '.join(_ACCEPTED_HEADINGS[kind])}" for kind in PLANNING_KINDS
+    )
+    return (
+        "The required heading depends on the artifact kind: use "
+        f"{preferred}. The heading text is that word alone; do not append the kind name or "
+        f"any other suffix such as {forbidden} to it. Heading text is matched "
+        "case-insensitively against a fixed set, so any one of these is also accepted — "
+        f"{alternatives}."
+    )
 
 
 def _canonical_json(payload: object) -> str:

--- a/paulsha_cortex/coordinator/planning_runtime.py
+++ b/paulsha_cortex/coordinator/planning_runtime.py
@@ -22,6 +22,7 @@ from .model_identities import (
     load_model_identities,
     probe_agy_capability,
 )
+from .planning import required_heading_hint
 
 
 @dataclass(frozen=True)
@@ -645,6 +646,11 @@ def build_production_planning_runtime(
         # secondary_evidence.evidence_hash），模型只需原樣複製；但輸入欄位名
         # （evidence_hash）與輸出欄位名（secondary_evidence_hash）不同，後者字面上
         # 像是要模型自己算 hash，只列欄位名時會反覆撞 evidence hash mismatch。
+        # #520：第三輪，這次是必要標題。舊句「required headings: Requirements for
+        # spec, ...」字面上可讀成「標題就是 `Requirements for spec`」，模型照抄後必然
+        # 撞 required-section-missing。標題要求現改由 `planning.required_heading_hint()`
+        # 依驗收判準（`_ACCEPTED_HEADINGS` / `_REQUIRED_HEADINGS`）機械產生——prompt 端
+        # 不再持有第二份真實來源，判準改動會自動同步到 prompt。
         return invoke_primary(
             "Do not call tools or edit files. Integrate only the supplied evidence. Return exactly one "
             "JSON object with schema_version=1, question_pack_id, secondary_evidence_hash, resolutions, "
@@ -657,8 +663,9 @@ def build_production_planning_runtime(
             "resolution's artifact(s) are written to — the same strings used as artifacts[].path. "
             "The set of all artifacts[].path values must equal the union of all artifact_refs. "
             "Each artifact has only kind, path, content; content must be complete UTF-8 Markdown with "
-            "frontmatter status: accepted, the matching work_item, and required headings: Requirements "
-            "for spec, Decisions for design, Tasks for plan. Use the supplied destination paths. "
+            "frontmatter status: accepted and the matching work_item. "
+            + required_heading_hint()
+            + " Use the supplied destination paths. "
             + _JSON_OUTPUT_CONTRACT + " Input: "
             + json.dumps(
                 {

--- a/tests/test_planning_completeness.py
+++ b/tests/test_planning_completeness.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 
 import pytest
@@ -10,10 +11,13 @@ from paulsha_cortex.coordinator.model_identities import (
     IdentityRegistry,
 )
 from paulsha_cortex.coordinator.planning import (
+    PLANNING_KINDS,
     PlanningArtifact,
     PlanningScope,
+    _REQUIRED_HEADINGS,
     assess_planning_artifact,
     assess_planning_completeness,
+    required_heading_hint,
     run_heterogeneous_brainstorm,
     validate_question_pack,
     validate_secondary_evidence,
@@ -89,6 +93,36 @@ def test_artifact_acceptance_requires_status_sections_and_no_blocking_marker() -
         )
     )
     assert "status-not-accepted" in duplicate_status.reasons
+
+
+def test_required_heading_criterion_is_the_single_source_of_the_prompt_hint() -> None:
+    """issue #520：驗收判準（`_REQUIRED_HEADINGS`）與 integrator prompt 的標題要求
+    過去是兩份各自維護的真實來源，已因不同步造成 #516／#520 兩次確定性失敗。
+    `required_heading_hint()` 必須由判準機械產生：首選標題真的通過驗收、完整可接受
+    集合都揭露給模型，且附加 kind 名稱的寫法確實會被拒收。"""
+    # 判準本身不因本次重構而改變（frozen expectation）。
+    assert _REQUIRED_HEADINGS == {
+        "spec": frozenset({"requirements", "requirement", "problem", "problem and outcome", "goals"}),
+        "design": frozenset({"decisions", "decision", "design", "architecture"}),
+        "plan": frozenset({"task", "tasks"}),
+    }
+
+    hint = required_heading_hint()
+    for kind in PLANNING_KINDS:
+        for title in _REQUIRED_HEADINGS[kind]:
+            assert re.search(rf"\b{re.escape(title)}\b", hint.casefold()), title
+
+    for kind, heading in (("spec", "Requirements"), ("design", "Decisions"), ("plan", "Tasks")):
+        assert f'exactly "## {heading}" for kind={kind}' in hint
+        accepted = assess_planning_artifact(
+            _artifact(kind, f"---\nstatus: accepted\n---\n# T\n\n## {heading}\n\nBody.\n")
+        )
+        assert accepted.accepted is True, kind
+
+    rejected = assess_planning_artifact(
+        _artifact("spec", "---\nstatus: accepted\n---\n# T\n\n## Requirements for spec\n\nBody.\n")
+    )
+    assert "required-section-missing" in rejected.reasons
 
 
 def test_canonical_accepted_source_spec_and_plan_satisfy_required_sections() -> None:

--- a/tests/test_planning_runtime.py
+++ b/tests/test_planning_runtime.py
@@ -4,7 +4,7 @@ import json
 import os
 from pathlib import Path
 
-from paulsha_cortex.coordinator import planning_runtime
+from paulsha_cortex.coordinator import planning, planning_runtime
 import pytest
 
 from paulsha_cortex.coordinator.model_identities import AGY_MODEL_ID, IdentityRegistry, ModelIdentity
@@ -414,6 +414,56 @@ def test_integrator_prompt_states_echo_back_field_sources(monkeypatch, tmp_path:
     )
     # 明確禁止模型自行計算 hash——這正是 #516 的誤解來源。
     assert "do not compute, derive, or invent a hash" in integrator_prompt
+
+
+def test_integrator_prompt_states_exact_required_heading_per_kind(monkeypatch, tmp_path: Path) -> None:
+    """issue #520：舊 prompt 寫「required headings: Requirements for spec, Decisions
+    for design, Tasks for plan」，原意是逐 kind 對應，但字面同樣可讀成「必要標題就是
+    `Requirements for spec`」。實測 planner 採了後者、產出 `## Requirements for spec`，
+    而 `planning._has_required_heading()` 是 casefold 後**完全相等**比對（標題正規化只
+    剝編號前綴，不剝 ` for spec` 尾綴），因此必然 `required-section-missing`。prompt
+    必須逐 kind 給出精確標題文字，並明確禁止在標題後附加 kind 名稱。"""
+    registry = IdentityRegistry.from_rows(
+        [
+            {
+                "executor": "codex", "model_id": "primary", "independence_domain": "openai",
+                "capabilities": ["planning"],
+            },
+            {
+                "executor": "agy", "model_id": AGY_MODEL_ID, "independence_domain": "google",
+                "capabilities": ["planning"], "live_probe": "agy-plan-sandbox",
+            },
+        ]
+    )
+    monkeypatch.setattr(planning_runtime, "load_model_identities", lambda: registry)
+    prompts: list[str] = []
+
+    def runner(argv, **kwargs):
+        if argv == ["agy", "models"]:
+            return _completed(f"{AGY_MODEL_ID}\n")
+        prompt = argv[argv.index("--print") + 1] if "--print" in argv else argv[2]
+        prompts.append(prompt)
+        return _completed(json.dumps({"schema_version": 1, "question_pack_id": "qp-x"}))
+
+    runtime = planning_runtime.build_production_planning_runtime(
+        primary=("codex", "primary"), worktree=tmp_path, runner=runner
+    )
+    runtime.primary_integrator(
+        {"schema_version": 1, "pack_id": "qp-x", "questions": []},
+        {"schema_version": 1, "question_pack_id": "qp-x", "evidence": [], "evidence_hash": "dead"},
+    )
+
+    integrator_prompt = prompts[-1]
+    # 逐 kind 的精確標題，不留第二種讀法。
+    assert 'exactly "## Requirements" for kind=spec' in integrator_prompt
+    assert 'exactly "## Decisions" for kind=design' in integrator_prompt
+    assert 'exactly "## Tasks" for kind=plan' in integrator_prompt
+    # 明確禁止附加 kind 名稱——這正是 #520 的誤解結果。
+    assert "do not append the kind name" in integrator_prompt.casefold()
+    # 產生 #520 失敗態的那個字串本身不得再出現在 prompt 裡。
+    assert "Requirements for spec" not in integrator_prompt
+    # #520 建議 4：這段文字由 `planning` 的判準常數機械產生，prompt 端不得另寫一份。
+    assert planning.required_heading_hint() in integrator_prompt
 
 
 def test_planning_source_material_rejects_symlink_traversal(tmp_path: Path) -> None:


### PR DESCRIPTION
## 問題

`coordinator/planning_runtime.py` 的 integrator prompt 舊句：

```
content must be complete UTF-8 Markdown with frontmatter status: accepted,
the matching work_item, and required headings: Requirements for spec,
Decisions for design, Tasks for plan.
```

原意是「kind=spec → `Requirements`；kind=design → `Decisions`；kind=plan → `Tasks`」，
但字面同樣可讀成「必要標題是 `Requirements for spec`」。實測 planner 採了後者、產出
`## Requirements for spec`，而 `coordinator/planning.py` 的 `_has_required_heading()`
是 casefold 後**完全相等**比對——`_headings_and_markers()` 的標題正規化只剝編號前綴
（`^\d+(\.\d+)*[.)]?\s+`），不剝 ` for spec` 尾綴——於是必然 `required-section-missing`。

實測 evidence：run `workflow-6b3e215f18c5b68b991c`，`reasons: ['required-section-missing']`、
`markers: []`、frontmatter 完全正確。這是 Phase 1 派工死鎖的最後一個已知阻塞點。

## 修法

採 issue #520 建議 4 的**結構性**作法，而非只改寫該句文字。評估理由：判準
（`_REQUIRED_HEADINGS`）與 prompt 的標題要求過去是兩份各自維護的真實來源，已因不同步
造成 `#516` 與 `#520` 兩次確定性失敗；純文字修正只解掉這一輪，下次判準一動又會重演。
重構面極小且可逆——`_REQUIRED_HEADINGS` 只在 `planning.py` 內被引用一處
（`_has_required_heading()`），全 repo 無其他消費者，因此把它改成由顯示形常數派生不會
外溢；新增的是純函式，無 I/O、無狀態、無新依賴。

- `_ACCEPTED_HEADINGS`（依「首選在前」排序的顯示形）成為唯一真檔；
- `_REQUIRED_HEADINGS` 由它 casefold 派生——**判準值一字未改**，測試以 frozen
  expectation 鎖住原本的三組集合；
- 新增純函式 `planning.required_heading_hint()`，由上述常數機械產生 prompt 文字；
- `planning_runtime.py` 的 integrator prompt 直接呼叫它，不再自持第二份真實來源。

產生出的實際 prompt 文字：

> The required heading depends on the artifact kind: use exactly `## Requirements` for
> kind=spec, exactly `## Decisions` for kind=design, exactly `## Tasks` for kind=plan.
> The heading text is that word alone; do not append the kind name or any other suffix
> such as "for spec", "for design", "for plan" to it. Heading text is matched
> case-insensitively against a fixed set, so any one of these is also accepted —
> spec: Requirements, Requirement, Problem, Problem and Outcome, Goals; design:
> Decisions, Decision, Design, Architecture; plan: Tasks, Task.

逐 kind 給精確標題、明確禁止附加 kind 名稱，並依建議 3 揭露完整可接受集合，讓模型有
合法替代選項而非單點命中。**判準內容與 validator 邏輯不動，驗收行為零變更。**

## 測試（TDD，先紅後綠）

- `tests/test_planning_runtime.py::test_integrator_prompt_states_exact_required_heading_per_kind`
  ——斷言 prompt 逐 kind 的精確標題、含「do not append the kind name」禁止語、不再出現
  `Requirements for spec` 字串，且 prompt 內含 `planning.required_heading_hint()` 的輸出
  （＝確實由判準機械產生）。
- `tests/test_planning_completeness.py::test_required_heading_criterion_is_the_single_source_of_the_prompt_hint`
  ——鎖住 `_REQUIRED_HEADINGS` 三組集合不變、hint 揭露每一個可接受標題、三個首選標題
  實際通過 `assess_planning_artifact()`，且 `## Requirements for spec` 確實被判
  `required-section-missing`（#520 的實際失敗態）。

`python3 -m pytest -q`：**2520 passed, 49 subtests passed**（基準 2518 + 本次 2）。
`python3 -m policy_check --repo .`（帶 PR 上下文）：EXIT=0。

## 不在範圍

`#516` 已修的 echo-back 欄位語意（不重動）；其他 planning 失敗模式
（`#507`／`#511`／`#514`／`#515`／`#519`）。

## Checklist

- [x] 分支非 `main`（`feature/520-planning-heading-prompt`，自 `origin/main` 開出）
- [x] `changelog.d/planning-heading-prompt.md` fragment 已新增且已 commit
- [x] `CHANGELOG.md [Unreleased]` 有對應 entry
- [x] `VERSION` 未動（非 release PR）
- [x] 測試全綠（2520 passed）
- [x] `policy_check` 帶 PR 上下文跑，EXIT=0
- [x] 只引用不關閉 issue → 已上 `policy-exempt:issue-link`

Refs #520

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E7w9kaUxAzCCEk7piD5hfK
