### PR TITLE
docs(workstream): 建立 fix-brainstorm-revalidation-diagnostics workstream（#514）

### DIFF
--- a/changelog.d/workstream-514-brainstorm-revalidation.md
+++ b/changelog.d/workstream-514-brainstorm-revalidation.md
@@ -1,0 +1,9 @@
+# workstream-514-brainstorm-revalidation
+
+- **`#514` workstream 佈線**——新增 `docs/superpowers/workstreams/fix-brainstorm-revalidation-diagnostics/todo.md`，
+  為 `#514`（`_validated_brainstorm_planning_authority()` 對已持久化 artifact 的重驗失敗，只 raise 不含
+  `ref` 與 `assessment.reasons` 的例外）建立 work item 的 **todo 來源**。cortex 的 lifecycle
+  （`monitor/lifecycle.py:reduce_lifecycle`）需要 `active_todo` 才會把 work item 由 `topic` 推進到
+  `todo`；缺此來源時 `cortex work start` 會以 `authority-not-startable` 拒絕、auto-claim 亦不受理。
+  內容記錄根因、四項驗收任務，以及它與 `#511`／PR `#513` 的關係（同類缺陷、不同觸發時機：首次寫入
+  vs 已持久化 artifact 的重驗）。

--- a/docs/superpowers/workstreams/fix-brainstorm-revalidation-diagnostics/todo.md
+++ b/docs/superpowers/workstreams/fix-brainstorm-revalidation-diagnostics/todo.md
@@ -1,0 +1,28 @@
+---
+status: accepted
+work_item: fix-brainstorm-revalidation-diagnostics
+---
+
+# fix-brainstorm-revalidation-diagnostics Todo
+
+`#514`：`_validated_brainstorm_planning_authority()`（`coordinator/manager.py:2695-2696`）對已發佈 artifact
+的重新驗證若判定不合格，拋出的例外**不含路徑、不含原因**：
+
+```python
+if not assess_planning_artifact(PlanningArtifact(kind=kind, ref=ref, text=text)).accepted:
+    raise ValueError("workflow brainstorm artifact is not accepted")
+```
+
+operator 只看得到一句 `workflow brainstorm artifact is not accepted`——不知道是迴圈中的哪一個 artifact，
+也不知道是 `status-not-accepted`／`required-section-missing`／`blocking-decision` 三種判準中的哪一種。
+
+這是 `#511`（已由 PR `#513` 在 `manager.py:6023` 的首次寫入路徑修正）的同類未修處。差別在觸發時機：
+本處是 workflow 續跑時對**已持久化 artifact** 的重驗，命中情境包含 artifact 在磁碟上被改動、或先前以
+較寬鬆規則通過的舊 artifact 在規則收緊後不再合格——這類情境對 operator 更難自行推理。
+
+## Tasks
+
+- [ ] 例外訊息帶上 `ref`（指出是哪一個 artifact）與 `assessment.reasons`，`blocking-decision` 時附 marker 行號
+- [ ] 沿用 `#513` 建立的 `cortex-planning-artifact-rejection/v1` evidence 落檔（`<coordinator_root>/evidence/planning-artifacts/`），讓重驗失敗同樣留下可查的完整內容
+- [ ] 訊息欄位順序比照 `#513`（reasons → markers → evidence path），確保在上游 `planning.py:1165` 的 `str(exc)[:160]` 截斷後關鍵資訊仍存活
+- [ ] 測試涵蓋三種 reason 在重驗路徑上的訊息內容，並鎖住「訊息含 ref」


### PR DESCRIPTION
Refs #514

## 變更

新增 `docs/superpowers/workstreams/fix-brainstorm-revalidation-diagnostics/todo.md`，為 `#514` 建立 work item 的 **todo 來源**。

cortex 的 lifecycle（`monitor/lifecycle.py:reduce_lifecycle`）需要 `active_todo`（workstream todo.md 或 openspec change）才會把 work item 由 `topic` 推進到 `todo`；沒有它，`cortex work start` 會以 `authority-not-startable` 拒絕，auto-claim 也不會受理。本檔即該來源。

內容記錄 `#514` 的根因（`coordinator/manager.py:2695-2696` 對已持久化 artifact 的重驗失敗，只 raise 一句不含 `ref`、不含 `assessment.reasons` 的例外）與四項驗收任務，並標明它與 `#511`／PR `#513` 的關係：同類缺陷、不同觸發時機（首次寫入 vs 重驗）。

## 驗證

- 純文件新增，無程式碼變更
- 以 v1.0.17 引擎 `policy_check --repo .`：EXIT=0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E7w9kaUxAzCCEk7piD5hfK
