### PR TITLE
fix(coordinator): semantic-reclaim 世代熔斷補上帶審計的重置路徑（#519）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@
 ## [Unreleased]
 
 ### Fixed
+- **Issue #519：semantic-reclaim 世代熔斷補上帶審計的重置路徑**——`#218 AC2` 的
+  世代熔斷對 `(repo, work_id)` 的全部 superseded 歷史無條件累加，且沒有任何重置
+  路徑，導致根因（`#507`／`#511`／`#516` 等 cortex 自身缺陷）修好之後 work item
+  仍永久鎖死。新增 `cortex work reset-reclaim-budget`（必帶 `--actor`／單行
+  `--reason`，走既有單一 writer work-action 路徑），以 **append-only 水位**
+  （狀態檔新增加法相容的 `reclaim_resets` 根欄位）記錄「本次赦免哪幾個 superseded
+  run_id」，熔斷計數改為扣掉已赦免者——既有 run 紀錄一列不刪不改，run 歷史維持
+  為稽核來源；重置後新產生的世代照常累加，熔斷會再次上膛。每次重置落一筆
+  immutable `cortex-work-reclaim-reset/v1` evidence（canonical json hash 命名、
+  原子唯讀寫入、內容衝突 raise）。熔斷本身的 `needs_human` 結果同步回報
+  `legal_next_steps`／`next_step_hint`，直接指出這條解鎖路徑。未採建議 1（引擎
+  版本維度），理由見 PR。詳見 `changelog.d/reclaim-budget-reset.md`。
 - **Issue #520：必要標題要求改由驗收判準機械產生，消除雙讀法**——integrator
   prompt 舊句「required headings: Requirements for spec, Decisions for design,
   Tasks for plan」原意是逐 kind 對應，字面卻同樣可讀成「必要標題是

--- a/changelog.d/reclaim-budget-reset.md
+++ b/changelog.d/reclaim-budget-reset.md
@@ -1,0 +1,61 @@
+---
+type: fix
+scope: coordinator
+---
+**Issue #519：semantic-reclaim 世代熔斷補上帶審計的重置路徑**
+
+`coordinator/work_actions.py` 的 `_claim_action` 在 `#218 AC2` 對同一
+`(repo, work_id)` 累積 `SEMANTIC_RECLAIM_LIMIT`（3）個 `superseded` 世代後熔斷
+為 `needs_human: semantic-reclaim-budget-exhausted`。計數是對**全部歷史**無條件
+累加：不看時間窗、不看失敗原因、不看引擎是否已修好，而且完全沒有重置路徑，CLI
+也沒有 force／override。檢查點位在 `decide_auto_claim`／`decide_manual_start`
+之後、`workflow_starter` 之前，auto 與明示 `work start` 共用——結果是根因修好之
+後 work item 仍永久鎖死。實測（2026-08-14 dogfooding）`fix-brainstorm-revalidation-diagnostics`
+在四分鐘內因三個 cortex 自身缺陷（成功卻被自行 supersede、codex exec 逾時、前代
+殘留 artifact 使 authority fail-closed）耗盡額度，無一是工作項本身的問題；
+`fix-rate-limit-classification` 的三次 abandon 同樣全肇因於當時未修的 `#507`／
+`#511`／`#516`（皆已修復部署）。
+
+本次採 `#519` 建議 4（帶審計的重置動作）：
+
+- **新增 `reset-reclaim-budget` work action**：走既有 work-action 路徑（單一
+  writer、經 manager daemon），要求 `--actor` 與單行 `--reason`，界限與
+  `abandon`／`retire-delivered` 逐字相同（actor ≤128、reason ≤500、單行、可列
+  印）。刻意不要 `--expected-run-id`：熔斷觸發的前提就是 `decide_*_claim` 已判
+  成 claim、沒有 active run 可供 CAS，硬要 exact run id 等同讓解鎖路徑永遠打不
+  開。白名單外參數一律 fail-closed 拒絕。
+- **重置以 append-only 水位實作**：把當下所有未赦免的 superseded `run_id` 記成
+  一筆 registry 授權列（coordinator 狀態檔新增 `reclaim_resets` 根欄位），熔斷
+  計數改為「superseded 世代扣掉所有已赦免 run_id」
+  （`_effective_superseded_generations()`，claim 路徑與重置動作共用同一支計
+  數）。**既有 `WorkflowRun` row 一列不刪不改**——run 歷史是稽核來源，重置是新
+  增一筆授權事實，不是抹掉失敗紀錄。水位以 run_id 集合而非時間戳表達，不依賴
+  任何時鐘假設；重置後新產生的世代照常累加，熔斷會再次上膛，不是永久關閉安全
+  機制。`_manager_record_reclaim_reset()` 拒絕赦免不存在或非 superseded 的
+  run_id（不得預先授權未來的失敗），同 `evidence_ref` 重入冪等。
+- **`cortex-work-reclaim-reset/v1` evidence**：落在
+  `<coordinator_root>/evidence/work-reclaim-reset/{work_id}-{hash}.json`，含
+  `repo`／`work_id`／`actor`／`reason`／重置前的世代數與其 run_id 清單／
+  `created_at`；canonical json hash 命名、create-with-O_EXCL + hardlink + fsync
+  + 0444、內容衝突 raise，全部沿用 `_write_supersede_evidence()`（新增 `stem`／
+  `label` 參數以支援 work-item 級而非 run 級的記錄）。順序比照 `#275`：先寫
+  durable evidence 再改狀態。
+- **熔斷訊息指出下一步**：`semantic-reclaim-budget-exhausted` 結果新增
+  `reclaim_budget_limit`／`superseded_run_ids`／`legal_next_steps`／
+  `next_step_hint`（比照 `#218 AC3` 的 `legal_next_steps` 慣例），operator 不再
+  只看到「額度用盡」而不知有解。
+- **rate-limit 容忍**：`reset-reclaim-budget` 併入 retirement family 既有的
+  `allow_rate_limited_last_known_good` 集合（`_LOCAL_UNBLOCK_ACTIONS`）——同樣只
+  動本機狀態、不依賴 issue 當下 open/closed，而系統被限流的當下正是卡死 work
+  item 最需要被解開的時候。
+
+`reclaim_resets` 是**加法相容**的可選根欄位：不 bump `schema_version`，不列入
+`_load()` 的 `missing_v2_roots` fail-closed 清單，本欄位出現前寫下的既有狀態檔
+照常載入（缺欄位＝沒有任何重置授權，即維持熔斷最嚴格的既有行為）。
+`monitor/providers.py` 的唯讀 canonical root 驗證同步接受「有」與「沒有」兩種形
+狀，仍不接受任何其他未知根欄位。
+
+**未採建議 1（納入引擎版本維度）**，理由見 PR body：`WorkflowRun` 沒有引擎版本
+欄位且既有 row 無法回填、cortex 發版頻率遠高於單一 work item 燒完三代（熔斷會近
+乎失效）、且「引擎已修好所以舊失敗不算數」本質上是需要具名負責的人工判斷——正
+是建議 4 所提供的東西。

--- a/changelog.d/reclaim-budget-reset.md
+++ b/changelog.d/reclaim-budget-reset.md
@@ -38,8 +38,10 @@ scope: coordinator
   `repo`／`work_id`／`actor`／`reason`／重置前的世代數與其 run_id 清單／
   `created_at`；canonical json hash 命名、create-with-O_EXCL + hardlink + fsync
   + 0444、內容衝突 raise，全部沿用 `_write_supersede_evidence()`（新增 `stem`／
-  `label` 參數以支援 work-item 級而非 run 級的記錄）。順序比照 `#275`：先寫
-  durable evidence 再改狀態。
+  `label`／`max_size` 參數：支援 work-item 級而非 run 級的記錄，並讓大小上界逐
+  caller 指定——本 body 隨被赦免世代數線性成長，沿用 abandon 的 4096 會讓長歷史
+  work item 的 byte-identical 重放被誤判成 conflict、冪等重入必然 fail）。順序
+  比照 `#275`：先寫 durable evidence 再改狀態。
 - **熔斷訊息指出下一步**：`semantic-reclaim-budget-exhausted` 結果新增
   `reclaim_budget_limit`／`superseded_run_ids`／`legal_next_steps`／
   `next_step_hint`（比照 `#218 AC3` 的 `legal_next_steps` 慣例），operator 不再

--- a/docs/unified-work-lifecycle.md
+++ b/docs/unified-work-lifecycle.md
@@ -61,6 +61,8 @@ cortex work retry-build unified-work-lifecycle --repo owner/repo --issue 14 --ac
 cortex work abandon stale-canary --repo owner/repo --actor operator \
   --expected-run-id workflow-0123456789abcdef0123 \
   --reason 'Superseded by the terminal canary.'
+cortex work reset-reclaim-budget stale-canary --repo owner/repo --actor operator \
+  --reason '三代 abandon 皆肇因於已修復的引擎缺陷，非工作項本身'
 cortex work auto unified-work-lifecycle --repo owner/repo --enable
 cortex work auto unified-work-lifecycle --repo owner/repo --disable
 cortex stat --combo-selections
@@ -116,6 +118,8 @@ transaction、凍結 authority 做 abandon CAS、不放寬 `claim.py` 既有的�
 `resume`／`retry-build` 的 job 選擇同樣於 #260 收斂：operator resume 遇到已 terminalized 的失敗 job 時（`status == "failed"`，或 `status == "exited"` 且 exit code 非 0），第一次 `cortex work resume` 即 dispatch replacement job，不再重選 stale failed job 空轉一輪（過去只認 `status == "failed"`，`exited` 非 0 的 stale terminal 會讓第一次 resume 只重新回報 `job-failed`、要再執行一次才 dispatch replacement）；exited/0 的既有三條路徑（unbound terminal recovery、malformed schema retry、正常 terminalize）條件式不動。replacement dispatch 後再次 resume 回報 in-flight，不產生第二個 replacement job。失敗回報一律附掛 `_terminal_parse_diagnostics` 的唯讀 `terminal_diagnostics`（observed HEAD、job id、失敗原因），與既有的 `authority_granted: false` 模型一致：可觀測不等於可授權，不會因此讓 candidate 取得任何 authority。
 
 `abandon`只處理尚未進入delivery的舊run：exact run CAS、current WorkAuthority refs、actor與單行reason全部重驗，且任何active Job、PR ref、passed ship step或CompletionRecord都會拒絕。成功後只把該run標成`superseded`，並以immutable `cortex-work-abandon/v1` evidence保存reason；不勾未完成tasks、不建立CompletionRecord，也不把abandoned work投影成done。重送同一CAS/reason冪等，不同reason或已有另一個active run則fail-closed。
+
+`reset-reclaim-budget`（#519）是語意 re-claim 世代熔斷（#218 AC2）的唯一解鎖路徑。同一 `(repo, work_id)` 累積 `SEMANTIC_RECLAIM_LIMIT`（3）個 superseded 世代後，`start`／auto-claim 都會停在 `needs_human: semantic-reclaim-budget-exhausted`；熔斷的計數對全部歷史累加，不看時間窗也不看失敗原因，因此當三次 abandon 全肇因於 cortex 自身缺陷（而非工作項本身）時，缺陷修好之後 work item 仍會永久鎖死。此 action 要求 `--actor` 與單行 `--reason`（界限與 `abandon`／`retire-delivered` 完全相同：actor ≤128 字、reason ≤500 字、單行、可列印），不需要 `--expected-run-id`——熔斷觸發的前提就是沒有 active run 可供 CAS。重置以 **append-only 水位**實作：把當下所有未赦免的 superseded `run_id` 記成一筆 registry 授權列（狀態檔的 `reclaim_resets` 根欄位），熔斷計數改為「superseded 世代扣掉所有已赦免 run_id」。既有 WorkflowRun row 一列不刪不改——run 歷史是稽核來源，重置是新增一筆授權事實，不是抹掉失敗紀錄。水位以 run_id 集合而非時間戳表達，因此重置後新產生的 superseded 世代照常累加、熔斷會再次上膛，不是永久關閉安全機制。每次重置寫入一筆 immutable `cortex-work-reclaim-reset/v1` evidence（`repo`／`work_id`／`actor`／`reason`／重置前的世代數與其 run_id 清單／`created_at`），落在 `<coordinator_root>/evidence/work-reclaim-reset/{work_id}-{hash}.json`，命名與原子寫入慣例比照 `cortex-work-abandon/v1`。沒有任何可赦免世代時 fail-closed 拒絕（已重置過則回報 `already_reset`，不寫第二筆授權）。熔斷本身的 `needs_human` 結果也會回報 `legal_next_steps`／`next_step_hint`，直接指出這條解鎖路徑與所需的理由參數。`reclaim_resets` 是加法相容的可選根欄位（不 bump `schema_version`），本欄位出現前寫下的既有狀態檔照常載入，缺欄位一律視為沒有任何重置授權。
 
 若 delivery 尚未建立 immutable binding，就因 PR／OpenSpec／Todo target 數量不是各一個而停在 `needs_human: multiple-delivery-targets-unsupported`，operator 修正 repo-local correlation 後可明確 `resume` 同一 WorkflowRun。Manager 只會在 current authority 已重新收斂為恰好一組 target 時清除此特定 stop；已建立 binding 或其他 `needs_human` 原因仍維持 fail-closed。
 

--- a/paulsha_cortex/cli.py
+++ b/paulsha_cortex/cli.py
@@ -49,7 +49,7 @@ run 'cortex <command> --help' for command-specific help.
 """
 
 _WORK_HELP = """\
-usage: cortex work <show|gc|link|unlink|intake|start|resume|retry-build|retry-verify|retry-review|recover-planning|recover-pre-candidate|recover-repair-commit|abandon|retire-delivered|auto|review-attest|ship> ...
+usage: cortex work <show|gc|link|unlink|intake|start|resume|retry-build|retry-verify|retry-review|recover-planning|recover-pre-candidate|recover-repair-commit|abandon|retire-delivered|reset-reclaim-budget|auto|review-attest|ship> ...
 
 work item commands:
   show      從 Monitor 讀取 Work Item 與關聯解釋
@@ -67,6 +67,7 @@ work item commands:
   recover-planning  對 define/needs_human 的 planning 失敗作可恢復重跑
   recover-pre-candidate  對 candidate 產生前的 builder 失敗作可恢復重跑並回收 worktree
   recover-repair-commit  對 repair commit 已存在但缺 terminal evidence 的 build 失敗做具 CAS 的採納恢復
+  reset-reclaim-budget  明示重置 semantic-reclaim 世代熔斷計數（需 --actor／--reason，落稽核 evidence）
   auto      管理 cortex:auto-on-going issue label
   review-attest  建立 exact-HEAD maintainer review evidence
   ship      執行 fail-closed delivery state machine

--- a/paulsha_cortex/control/contract.py
+++ b/paulsha_cortex/control/contract.py
@@ -17,8 +17,8 @@ WORK_ACTIONS = frozenset(
     {
         "link", "unlink", "start", "resume", "retry-build", "retry-verify",
         "retry-review", "recover-planning", "recover-pre-candidate",
-        "recover-repair-commit", "abandon", "retire-delivered", "auto", "ship",
-        "review-attest", "intake",
+        "recover-repair-commit", "abandon", "retire-delivered",
+        "reset-reclaim-budget", "auto", "ship", "review-attest", "intake",
     }
 )
 WORK_SOURCE_KINDS = frozenset({"github_issue", "github_pr", "openspec", "path"})
@@ -177,6 +177,27 @@ def validate_request(payload: dict[str, Any]) -> dict[str, Any]:
                 or re.fullmatch(r"workflow-[0-9a-f]{20}", expected_run_id) is None
             ):
                 raise ValueError(f"work-action {action} requires exact expected_run_id")
+            if (
+                not isinstance(actor, str)
+                or actor != actor.strip()
+                or not 1 <= len(actor) <= 128
+                or not actor.isprintable()
+            ):
+                raise ValueError(f"work-action {action} requires bounded actor")
+            if (
+                not isinstance(reason, str)
+                or reason != reason.strip()
+                or not 1 <= len(reason) <= 500
+                or not reason.isprintable()
+            ):
+                raise ValueError(f"work-action {action} requires bounded reason")
+        if action == "reset-reclaim-budget":
+            # issue #519：明示重置 semantic-reclaim 世代熔斷。actor／reason 的
+            # 界限與 abandon／retire-delivered 完全一致（同樣是「一個人明示解
+            # 除一道安全機制」）；差別只在不要 expected_run_id——熔斷觸發的前
+            # 提就是沒有 active run 可供 CAS。
+            actor = args.get("actor")
+            reason = args.get("reason")
             if (
                 not isinstance(actor, str)
                 or actor != actor.strip()

--- a/paulsha_cortex/coordinator/cli.py
+++ b/paulsha_cortex/coordinator/cli.py
@@ -204,8 +204,8 @@ def _build_parser() -> argparse.ArgumentParser:
         choices=[
             "link", "unlink", "start", "resume", "retry-build", "retry-verify",
             "retry-review", "recover-planning", "recover-pre-candidate",
-            "recover-repair-commit", "abandon", "retire-delivered", "auto",
-            "ship", "review-attest", "intake",
+            "recover-repair-commit", "abandon", "retire-delivered",
+            "reset-reclaim-budget", "auto", "ship", "review-attest", "intake",
         ],
     )
     p_work.add_argument("work_id")
@@ -221,7 +221,8 @@ def _build_parser() -> argparse.ArgumentParser:
         help="abandon／retire-delivered 使用的 exact WorkflowRun CAS",
     )
     p_work.add_argument(
-        "--reason", help="abandon／retire-delivered 的單行審計理由（最多 500 字）"
+        "--reason",
+        help="abandon／retire-delivered／reset-reclaim-budget 的單行審計理由（最多 500 字）",
     )
     p_work.add_argument(
         "--combo",

--- a/paulsha_cortex/coordinator/registry.py
+++ b/paulsha_cortex/coordinator/registry.py
@@ -202,6 +202,16 @@ def _empty_legacy_records() -> dict[str, Any]:
     return {"source_schema_version": 1, "seq": 0, "jobs": [], "slices": []}
 
 
+# #519：semantic-reclaim 世代熔斷（work_actions.SEMANTIC_RECLAIM_LIMIT）的重置
+# 水位欄位集合。水位是 append-only 的「赦免名單」——記錄某次 operator 明示重置
+# 當下已存在的 superseded run_id，之後熔斷只計不在任何赦免名單裡的世代。刻意
+# 不改寫（更不刪除）任何既有 WorkflowRun row：run 歷史是稽核來源，重置是新增
+# 一筆授權事實，不是抹掉失敗紀錄。
+_RECLAIM_RESET_STRING_FIELDS = (
+    "repo", "work_id", "actor", "reason", "evidence_ref", "evidence_hash", "created_at",
+)
+
+
 def _fsync_directory(directory: Path) -> None:
     fd = os.open(directory, os.O_RDONLY)
     try:
@@ -255,6 +265,7 @@ class JobRegistry:
         self._slices: list[dict[str, Any]] = []
         self._workflows: list[WorkflowRun] = []
         self._legacy_records: dict[str, Any] = _empty_legacy_records()
+        self._reclaim_resets: list[dict[str, Any]] = []
         self._seq = seq_start
         self._state_mtime_ns: int | None = None
         self._state_size: int | None = None
@@ -355,12 +366,47 @@ class JobRegistry:
         ):
             raise ValueError(f"coordinator 狀態檔 workflow 重複識別（fail-closed）: {self._state_path}")
         self._validate_legacy_records(legacy_records)
+        # #519：`reclaim_resets` 刻意是「加法相容」的可選根欄位，不列入上面的
+        # `missing_v2_roots` fail-closed 清單，也不 bump schema_version——本欄位
+        # 出現前寫下的狀態檔（既有部署裡的每一份）都必須照常載入，否則升級即
+        # brick manager。缺欄位一律視為「沒有任何重置授權」，也就是熔斷維持最
+        # 嚴格的既有行為（fail-closed 方向）。
+        reclaim_resets = self._validate_reclaim_resets(payload.get("reclaim_resets", []))
         self._jobs = jobs
         self._slices = slices
         self._workflows = validated_workflows
         self._legacy_records = _deepcopy_json(legacy_records)
+        self._reclaim_resets = reclaim_resets
         self._seq = max(seq, self._seq)
         self._record_state_file_metadata()
+
+    def _validate_reclaim_resets(self, value: object) -> list[dict[str, Any]]:
+        """#519：semantic-reclaim 重置水位的載入驗證（malformed 一律 fail-closed）。"""
+
+        if not isinstance(value, list):
+            raise ValueError(
+                f"coordinator 狀態檔 reclaim_resets 格式錯誤（fail-closed）: {self._state_path}"
+            )
+        validated: list[dict[str, Any]] = []
+        for entry in value:
+            if not isinstance(entry, dict):
+                raise ValueError(
+                    f"coordinator 狀態檔 reclaim_resets 格式錯誤（fail-closed）: {self._state_path}"
+                )
+            for field in _RECLAIM_RESET_STRING_FIELDS:
+                if not isinstance(entry.get(field), str) or not entry[field]:
+                    raise ValueError(
+                        "coordinator 狀態檔 reclaim_resets 欄位缺漏（fail-closed）: "
+                        f"{self._state_path}: {field}"
+                    )
+            cleared = entry.get("cleared_run_ids")
+            if not _is_ref_list(cleared) or not cleared:
+                raise ValueError(
+                    "coordinator 狀態檔 reclaim_resets cleared_run_ids 格式錯誤"
+                    f"（fail-closed）: {self._state_path}"
+                )
+            validated.append(_deepcopy_json(entry))
+        return validated
 
     def _validate_state_records(
         self, payload: dict[str, Any]
@@ -473,6 +519,7 @@ class JobRegistry:
             "slices": self._slices,
             "workflows": [run.to_dict() for run in self._workflows],
             "legacy_records": self._legacy_records,
+            "reclaim_resets": self._reclaim_resets,
         }
         try:
             self._write_payload_atomically(payload)
@@ -485,6 +532,7 @@ class JobRegistry:
             self._slices = []
             self._workflows = []
             self._legacy_records = _empty_legacy_records()
+            self._reclaim_resets = []
             self._seq = 0
             self._load()
             raise
@@ -1336,6 +1384,73 @@ class JobRegistry:
 
     def get_workflow_run(self, run_id: str) -> WorkflowRun:
         return self._copy_workflow_run(self._workflows[self._find_workflow_run_index(run_id)])
+
+    def list_reclaim_resets(self) -> list[dict[str, Any]]:
+        """#519：唯讀列出所有 semantic-reclaim 熔斷重置授權（append-only 稽核列）。"""
+
+        return _deepcopy_json(self._reclaim_resets)
+
+    def reclaim_reset_cleared_run_ids(self, *, repo: str, work_id: str) -> frozenset[str]:
+        """#519：某 (repo, work_id) 已被明示重置赦免的 superseded run_id 聯集。
+
+        熔斷計數改以「superseded 世代扣掉這個集合」為準，因此重置只赦免當下已
+        存在的世代——重置之後新產生的 superseded 世代照常累加，熔斷會再次上膛。
+        """
+
+        cleared: set[str] = set()
+        for entry in self._reclaim_resets:
+            if entry.get("repo") == repo and entry.get("work_id") == work_id:
+                cleared.update(str(item) for item in entry.get("cleared_run_ids", ()))
+        return frozenset(cleared)
+
+    def _manager_record_reclaim_reset(
+        self,
+        *,
+        repo: str,
+        work_id: str,
+        actor: str,
+        reason: str,
+        evidence_ref: str,
+        evidence_hash: str,
+        cleared_run_ids: list[str],
+        created_at: str,
+    ) -> dict[str, Any]:
+        """#519：登錄一筆 semantic-reclaim 熔斷重置授權（唯一 writer 走 manager）。
+
+        純 append：既有 WorkflowRun row 一個位元組都不動。被赦免的 run_id 必須
+        確實存在且為 superseded，否則 fail closed——重置只能赦免「已經發生的
+        世代」，不得預先授權未來的失敗。同一 evidence_ref 重入視為冪等（比照
+        abandon 的 crash-window 契約，#275），不產生第二筆授權。
+        """
+
+        if not cleared_run_ids:
+            raise ValueError("workflow reclaim reset requires cleared run ids")
+        for existing in self._reclaim_resets:
+            if existing.get("evidence_ref") == evidence_ref:
+                return _deepcopy_json(existing)
+        superseded = {
+            run.run_id
+            for run in self._workflows
+            if run.repo == repo and run.work_id == work_id and run.status == "superseded"
+        }
+        unknown = sorted(set(cleared_run_ids) - superseded)
+        if unknown:
+            raise ValueError(
+                f"workflow reclaim reset 指向非 superseded run（fail-closed）: {unknown[0]}"
+            )
+        entry = {
+            "repo": repo,
+            "work_id": work_id,
+            "actor": actor,
+            "reason": reason,
+            "evidence_ref": evidence_ref,
+            "evidence_hash": evidence_hash,
+            "cleared_run_ids": sorted(set(cleared_run_ids)),
+            "created_at": created_at,
+        }
+        self._reclaim_resets.append(entry)
+        self._persist()
+        return _deepcopy_json(entry)
 
     def _manager_create_workflow_run(
         self,

--- a/paulsha_cortex/coordinator/work_actions.py
+++ b/paulsha_cortex/coordinator/work_actions.py
@@ -2060,17 +2060,21 @@ def _retry_review_action(*, args: dict[str, Any], authority, workflow_registry) 
 
 
 def _validate_abandon_evidence_target(
-    target: Path, content: bytes, *, label: str = "abandon"
+    target: Path, content: bytes, *, label: str = "abandon", max_size: int = 4096
 ) -> None:
     # ``label`` 只影響錯誤訊息（#519 讓 reclaim-reset 說自己的名字），判準本身
-    # 對每一種 supersede-family evidence 完全一致。
+    # 對每一種 supersede-family evidence 完全一致。``max_size`` 是「evidence 是
+    # 小文件」的防禦性上界：abandon／retire-delivered 的 body 欄位固定，4096 綽
+    # 綽有餘；#519 的 reclaim-reset body 則隨被赦免的世代數線性成長，沿用 4096
+    # 會讓「世代夠多時，byte-for-byte 相同的重放被誤判成 conflict」——冪等重入
+    # 因此必然 fail。上界逐 caller 指定，判準其餘部分完全共用。
     try:
         metadata = target.stat()
         conflict = (
             target.is_symlink()
             or not target.is_file()
             or metadata.st_size != len(content)
-            or metadata.st_size > 4096
+            or metadata.st_size > max_size
             or metadata.st_mode & 0o222
             or target.read_bytes() != content
         )
@@ -2087,6 +2091,7 @@ def _write_supersede_evidence(
     subdir: str,
     stem: str | None = None,
     label: str = "abandon",
+    max_size: int = 4096,
 ) -> dict[str, str]:
     """Durable, content-addressed supersede-evidence writer shared by the
     ``work-abandon`` and ``work-retire-delivered`` paths (create-with-O_EXCL +
@@ -2107,7 +2112,7 @@ def _write_supersede_evidence(
         json.dumps(body, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
     ).encode("utf-8")
     if target.exists():
-        _validate_abandon_evidence_target(target, content, label=label)
+        _validate_abandon_evidence_target(target, content, label=label, max_size=max_size)
     else:
         temporary = root / f".{target.name}.{uuid4().hex}.tmp"
         try:
@@ -2125,7 +2130,9 @@ def _write_supersede_evidence(
             try:
                 os.link(temporary, target)
             except FileExistsError:
-                _validate_abandon_evidence_target(target, content, label=label)
+                _validate_abandon_evidence_target(
+                    target, content, label=label, max_size=max_size
+                )
             else:
                 directory_fd = os.open(root, os.O_RDONLY | os.O_DIRECTORY)
                 try:
@@ -2181,6 +2188,10 @@ def _reclaim_reset_record(body: dict[str, Any], *, state_path: Path) -> dict[str
         subdir="work-reclaim-reset",
         stem=str(body["work_id"]),
         label="reclaim-reset",
+        # body 隨 cleared_run_ids 線性成長（每筆 run_id 約 40 bytes），共用 4096
+        # 會讓世代較多的重置一重放就誤判 conflict；放寬到 64KiB 仍是「小文件」
+        # 的防禦性上界，且 st_size != len(content) 才是真正的正確性判準。
+        max_size=65536,
     )
 
 

--- a/paulsha_cortex/coordinator/work_actions.py
+++ b/paulsha_cortex/coordinator/work_actions.py
@@ -9,6 +9,7 @@ import os
 import re
 import subprocess
 import time
+from datetime import datetime, timezone
 from enum import Enum
 from pathlib import Path
 from pathlib import PurePosixPath
@@ -66,6 +67,11 @@ ShipExecutor = Callable[[dict[str, Any], object], dict[str, Any]]
 # last-known-good canonical GitHub authority (see the ``load_work_authority``
 # call in ``execute_work_action``). Every other action keeps fail-closed.
 _RETIREMENT_ACTIONS = frozenset({"abandon", "retire-delivered"})
+
+# #519：`reset-reclaim-budget` 與 retirement family 同屬「只動本機 coordinator
+# 狀態、不依賴 issue 當下 open/closed 的解卡動作」，適用同一條 rate-limit 容忍
+# 理由——系統被限流的當下，正是卡死的 work item 最需要被解開的時候。
+_LOCAL_UNBLOCK_ACTIONS = _RETIREMENT_ACTIONS | {"reset-reclaim-budget"}
 
 
 def _positive_int(value: object, *, field: str) -> int:
@@ -1323,6 +1329,31 @@ def _recoverable_maintainer_ship_stop(
     )
 
 
+def _effective_superseded_generations(workflow_registry, *, repo: str, work_id: str) -> list:
+    """#519：計入 semantic-reclaim 熔斷的 superseded 世代（扣掉已赦免者）。
+
+    `_claim_action` 的熔斷判定與 `reset-reclaim-budget` 動作共用同一支計數，
+    兩邊對「還剩幾代額度」的認知不可能分歧。registry 沒有
+    `reclaim_reset_cleared_run_ids`（舊版本或測試 double）時視為沒有任何赦免，
+    也就是維持熔斷最嚴格的既有行為——fail-closed 方向。
+    """
+
+    cleared_lookup = getattr(workflow_registry, "reclaim_reset_cleared_run_ids", None)
+    cleared = (
+        cleared_lookup(repo=repo, work_id=work_id)
+        if callable(cleared_lookup)
+        else frozenset()
+    )
+    return [
+        run
+        for run in workflow_registry.list_workflow_runs()
+        if run.repo == repo
+        and run.work_id == work_id
+        and run.status == "superseded"
+        and run.run_id not in cleared
+    ]
+
+
 def _fallback_workflow_starter(workflow_registry, state_path: Path):
     """Test/embedding fallback; installed daemon supplies the production starter."""
 
@@ -1558,20 +1589,33 @@ def _claim_action(
         # 已累積 SEMANTIC_RECLAIM_LIMIT 個 superseded 世代（v1..v3）時，不得自動
         # 建立下一版 run（v4），強制 needs_human。計數以 registry 的 run 歷史為準
         # （跨 run_id，不受 active dict 換代歸零影響）。
+        # #519：計數改扣掉已被 `reset-reclaim-budget` 明示赦免的世代——熔斷原本
+        # 對全部歷史無條件累加且沒有任何重置路徑，根因（例如 #507／#511／#516
+        # 這些 cortex 自身缺陷）修好之後 work item 仍永久鎖死。
         if workflow_registry is not None:
-            superseded_generations = [
-                run
-                for run in workflow_registry.list_workflow_runs()
-                if run.repo == authority.repo
-                and run.work_id == authority.work_id
-                and run.status == "superseded"
-            ]
+            superseded_generations = _effective_superseded_generations(
+                workflow_registry, repo=authority.repo, work_id=authority.work_id
+            )
             if len(superseded_generations) >= SEMANTIC_RECLAIM_LIMIT:
                 return {
                     "action": "needs_human",
                     "reason": "semantic-reclaim-budget-exhausted",
                     "run": None,
                     "superseded_generations": len(superseded_generations),
+                    # #519：熔斷結果必須自帶下一步，否則 operator 只看到「額度
+                    # 用盡」而不知道有解（比照 #218 AC3 的 legal_next_steps 慣例）。
+                    "reclaim_budget_limit": SEMANTIC_RECLAIM_LIMIT,
+                    "superseded_run_ids": sorted(
+                        run.run_id for run in superseded_generations
+                    ),
+                    "legal_next_steps": ("reset-reclaim-budget",),
+                    "next_step_hint": (
+                        "世代熔斷已觸發；確認根因已排除後，以 "
+                        f"`cortex work reset-reclaim-budget {authority.work_id} "
+                        f"--repo {authority.repo} --actor <operator> --reason <單行理由>` "
+                        "明示重置額度（會留下 cortex-work-reclaim-reset/v1 稽核紀錄），"
+                        "再重新 start。"
+                    ),
                 }
         try:
             run = workflow_starter(authority, str(decision.claim_key), None)
@@ -2015,7 +2059,11 @@ def _retry_review_action(*, args: dict[str, Any], authority, workflow_registry) 
     }
 
 
-def _validate_abandon_evidence_target(target: Path, content: bytes) -> None:
+def _validate_abandon_evidence_target(
+    target: Path, content: bytes, *, label: str = "abandon"
+) -> None:
+    # ``label`` 只影響錯誤訊息（#519 讓 reclaim-reset 說自己的名字），判準本身
+    # 對每一種 supersede-family evidence 完全一致。
     try:
         metadata = target.stat()
         conflict = (
@@ -2027,35 +2075,46 @@ def _validate_abandon_evidence_target(target: Path, content: bytes) -> None:
             or target.read_bytes() != content
         )
     except OSError as error:
-        raise RuntimeError("workflow abandon evidence conflict") from error
+        raise RuntimeError(f"workflow {label} evidence conflict") from error
     if conflict:
-        raise RuntimeError("workflow abandon evidence conflict")
+        raise RuntimeError(f"workflow {label} evidence conflict")
 
 
 def _write_supersede_evidence(
-    body: dict[str, Any], *, state_path: Path, subdir: str
+    body: dict[str, Any],
+    *,
+    state_path: Path,
+    subdir: str,
+    stem: str | None = None,
+    label: str = "abandon",
 ) -> dict[str, str]:
     """Durable, content-addressed supersede-evidence writer shared by the
     ``work-abandon`` and ``work-retire-delivered`` paths (create-with-O_EXCL +
     hardlink + fsync; a colliding target is re-validated byte-for-byte, so a
-    replayed write is idempotent rather than a conflict)."""
+    replayed write is idempotent rather than a conflict).
+
+    ``stem`` overrides the filename prefix for records that are not scoped to a
+    single run — #519's ``work-reclaim-reset`` is keyed by ``work_id`` because
+    a reclaim-budget reset is a work-item-level authorization, not a run-level
+    one. Everything else about the durability contract is shared verbatim.
+    """
 
     digest = verification.canonical_json_hash(body)
     root = state_path.resolve().parent / "evidence" / subdir
     root.mkdir(parents=True, exist_ok=True)
-    target = root / f"{body['run_id']}-{digest}.json"
+    target = root / f"{stem if stem is not None else body['run_id']}-{digest}.json"
     content = (
         json.dumps(body, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
     ).encode("utf-8")
     if target.exists():
-        _validate_abandon_evidence_target(target, content)
+        _validate_abandon_evidence_target(target, content, label=label)
     else:
         temporary = root / f".{target.name}.{uuid4().hex}.tmp"
         try:
             fd = os.open(temporary, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
         except FileExistsError as error:
             raise RuntimeError(
-                "workflow abandon evidence temporary collision"
+                f"workflow {label} evidence temporary collision"
             ) from error
         try:
             with os.fdopen(fd, "wb") as handle:
@@ -2066,7 +2125,7 @@ def _write_supersede_evidence(
             try:
                 os.link(temporary, target)
             except FileExistsError:
-                _validate_abandon_evidence_target(target, content)
+                _validate_abandon_evidence_target(target, content, label=label)
             else:
                 directory_fd = os.open(root, os.O_RDONLY | os.O_DIRECTORY)
                 try:
@@ -2085,6 +2144,43 @@ def _abandon_record(body: dict[str, Any], *, state_path: Path) -> dict[str, str]
 def _retire_delivered_record(body: dict[str, Any], *, state_path: Path) -> dict[str, str]:
     return _write_supersede_evidence(
         body, state_path=state_path, subdir="work-retire-delivered"
+    )
+
+
+def _reclaim_reset_body(
+    *,
+    repo: str,
+    work_id: str,
+    actor: str,
+    reason: str,
+    cleared_run_ids: list[str],
+    created_at: str,
+) -> dict[str, Any]:
+    """#519：`cortex-work-reclaim-reset/v1` 的 canonical evidence body。
+
+    內容即稽核事實：誰、為什麼、在什麼時間點、赦免了哪幾個 superseded 世代。
+    `cleared_run_ids` 排序後入 body，讓同一組世代永遠算出同一個 canonical hash。
+    """
+
+    return {
+        "schema": "cortex-work-reclaim-reset/v1",
+        "repo": repo,
+        "work_id": work_id,
+        "actor": actor,
+        "reason": reason,
+        "superseded_generations": len(cleared_run_ids),
+        "cleared_run_ids": sorted(cleared_run_ids),
+        "created_at": created_at,
+    }
+
+
+def _reclaim_reset_record(body: dict[str, Any], *, state_path: Path) -> dict[str, str]:
+    return _write_supersede_evidence(
+        body,
+        state_path=state_path,
+        subdir="work-reclaim-reset",
+        stem=str(body["work_id"]),
+        label="reclaim-reset",
     )
 
 
@@ -2803,6 +2899,130 @@ def _retire_delivered_action(
         "pr_terminal_status": pr_terminal_status,
         "evidence": record,
         "run": updated.to_dict(),
+    }
+
+
+def _validate_reclaim_reset_operator_inputs(args: dict[str, Any]) -> tuple[str, str]:
+    """#519：`reset-reclaim-budget` 的 actor／reason 入場驗證。
+
+    界限刻意與 retirement family（`_validate_retirement_operator_inputs`）逐字
+    相同——同樣是「一個人、為了一個寫得出來的理由，明示解除一道安全機制」，
+    稽核欄位的規格沒有理由分歧。差別只在這裡不要 `expected_run_id`：熔斷觸發
+    的前提就是沒有 active run 可以 CAS（`decide_*_claim` 判成 claim 才會走到
+    熔斷），硬要一個 exact run id 等同讓這條解鎖路徑永遠打不開。
+    """
+
+    actor = args.get("actor")
+    reason = args.get("reason")
+    if (
+        not isinstance(actor, str)
+        or actor != actor.strip()
+        or not 1 <= len(actor) <= 128
+        or not actor.isprintable()
+    ):
+        raise ValueError("reset-reclaim-budget requires bounded actor")
+    if (
+        not isinstance(reason, str)
+        or reason != reason.strip()
+        or not 1 <= len(reason) <= 500
+        or not reason.isprintable()
+    ):
+        raise ValueError("reset-reclaim-budget requires bounded reason")
+    return actor, reason
+
+
+def _reset_reclaim_budget_action(
+    *,
+    args: dict[str, Any],
+    authority,
+    now_epoch: float,
+    state_path: Path,
+    workflow_registry,
+) -> dict[str, Any]:
+    """#519：明示重置 (repo, work_id) 的 semantic-reclaim 世代熔斷計數。
+
+    #218 AC2 的熔斷對全部 superseded 歷史無條件累加：不看時間窗、不看失敗原
+    因、不看引擎是否已修好，而且完全沒有重置路徑。實測（2026-08-14）一個
+    work item 在四分鐘內因三個 cortex 自身缺陷（成功卻被自行 supersede、codex
+    exec 逾時、前代殘留 artifact 使 authority fail-closed）耗盡額度後永久鎖
+    死——沒有一次是工作項本身的問題，卻再也無法派工。
+
+    重置的實作刻意是 **append-only 水位**：把「本次赦免的 superseded run_id」
+    寫成一筆 registry 授權列（`_manager_record_reclaim_reset`），熔斷計數改成
+    「superseded 世代扣掉所有已赦免 run_id」。既有 run row 一列不刪不改——run
+    歷史是稽核來源，重置是新增一筆授權事實，不是抹掉失敗紀錄。水位以 run_id
+    集合而非時間戳表達，因此不依賴任何時鐘假設，且重置後新產生的世代照常累
+    加，熔斷會再次上膛（不是永久關閉安全機制）。
+    """
+
+    extras = set(args) - {"action", "repo", "work_id", "actor", "reason"}
+    if extras:
+        raise ValueError(
+            f"reset-reclaim-budget rejects caller evidence/input: {sorted(extras)[0]}"
+        )
+    actor, reason = _validate_reclaim_reset_operator_inputs(args)
+    pending = _effective_superseded_generations(
+        workflow_registry, repo=authority.repo, work_id=authority.work_id
+    )
+    if not pending:
+        prior = [
+            entry
+            for entry in workflow_registry.list_reclaim_resets()
+            if entry.get("repo") == authority.repo
+            and entry.get("work_id") == authority.work_id
+        ]
+        if prior:
+            # 重送同一請求（含 crash window 重試）：額度已經是滿的，不再寫第二
+            # 筆授權，回報最後一筆既有紀錄讓呼叫端自證冪等。
+            latest = prior[-1]
+            return {
+                "action": "reclaim-budget-reset",
+                "already_reset": True,
+                "actor": actor,
+                "reason": reason,
+                "cleared_generations": 0,
+                "cleared_run_ids": [],
+                "reclaim_budget_limit": SEMANTIC_RECLAIM_LIMIT,
+                "evidence": {
+                    "ref": latest["evidence_ref"],
+                    "hash": latest["evidence_hash"],
+                },
+            }
+        # 從未燒過額度——重置是無意義的狀態變更，fail closed（比照本檔其餘
+        # recovery 動作「判準不符即拒絕，不做 best-effort」的慣例）。
+        raise RuntimeError("reset-reclaim-budget has no superseded generation to clear")
+    cleared_run_ids = sorted(run.run_id for run in pending)
+    body = _reclaim_reset_body(
+        repo=authority.repo,
+        work_id=authority.work_id,
+        actor=actor,
+        reason=reason,
+        cleared_run_ids=cleared_run_ids,
+        created_at=datetime.fromtimestamp(now_epoch, tz=timezone.utc).isoformat(),
+    )
+    # #275 的順序慣例：先把稽核事實寫成 durable evidence，再改狀態。兩步之間
+    # crash 時最壞只留下一份未被引用的 evidence 檔（水位是 run_id 集合聯集，
+    # 重放同一份授權在語意上冪等），不會出現「狀態已放寬但查無授權依據」。
+    record = _reclaim_reset_record(body, state_path=state_path)
+    entry = workflow_registry._manager_record_reclaim_reset(
+        repo=authority.repo,
+        work_id=authority.work_id,
+        actor=actor,
+        reason=reason,
+        evidence_ref=record["ref"],
+        evidence_hash=record["hash"],
+        cleared_run_ids=cleared_run_ids,
+        created_at=body["created_at"],
+    )
+    return {
+        "action": "reclaim-budget-reset",
+        "already_reset": False,
+        "actor": actor,
+        "reason": reason,
+        "cleared_generations": len(cleared_run_ids),
+        "cleared_run_ids": list(entry["cleared_run_ids"]),
+        "reclaim_budget_limit": SEMANTIC_RECLAIM_LIMIT,
+        "evidence": record,
     }
 
 
@@ -4177,8 +4397,8 @@ def execute_work_action(
     if action not in {
         "link", "unlink", "start", "resume", "retry-build", "retry-verify",
         "retry-review", "recover-planning", "recover-pre-candidate",
-        "recover-repair-commit", "abandon", "retire-delivered", "auto", "ship",
-        "review-attest", "intake",
+        "recover-repair-commit", "abandon", "retire-delivered",
+        "reset-reclaim-budget", "auto", "ship", "review-attest", "intake",
     }:
         raise ValueError("unsupported work action")
     repo = _repo_identity(repo)
@@ -4203,7 +4423,7 @@ def execute_work_action(
         # block cleanup — the very moment the system is throttled is when
         # stuck runs most need clearing. Claim/start and every other action
         # keep the strict fail-closed default: they need fresh authority.
-        allow_rate_limited_last_known_good=action in _RETIREMENT_ACTIONS,
+        allow_rate_limited_last_known_good=action in _LOCAL_UNBLOCK_ACTIONS,
     )
     now_epoch = now()
     resolved_state_path = Path(state_path) if state_path is not None else _run_state_path()
@@ -4290,6 +4510,14 @@ def execute_work_action(
             args=args,
             authority=authority,
             runner=runner,
+            state_path=resolved_state_path,
+            workflow_registry=workflow_registry,
+        )
+    elif action == "reset-reclaim-budget":
+        result = _reset_reclaim_budget_action(
+            args=args,
+            authority=authority,
+            now_epoch=now_epoch,
             state_path=resolved_state_path,
             workflow_registry=workflow_registry,
         )

--- a/paulsha_cortex/monitor/providers.py
+++ b/paulsha_cortex/monitor/providers.py
@@ -466,8 +466,18 @@ def _validate_canonical_coordinator_v2_root(payload: Mapping) -> list[dict[str, 
     migration path and violate the single-writer boundary.
     """
 
-    expected = {"schema_version", "seq", "jobs", "slices", "workflows", "legacy_records"}
-    if set(payload) != expected or payload.get("schema_version") != 2:
+    required = {"schema_version", "seq", "jobs", "slices", "workflows", "legacy_records"}
+    # #519：`reclaim_resets`（semantic-reclaim 熔斷的重置水位）是加法相容的可選
+    # 根欄位——寫入端不 bump schema_version，好讓本欄位出現前寫下的既有狀態檔照
+    # 常載入。Monitor 因此必須同時接受「有」與「沒有」兩種形狀；仍不接受任何其
+    # 他未知根欄位，維持既有的 fail-closed 嚴格度。
+    optional = {"reclaim_resets"}
+    keys = set(payload)
+    if (
+        not required <= keys
+        or not keys <= (required | optional)
+        or payload.get("schema_version") != 2
+    ):
         raise ValueError("canonical coordinator registry root keys are invalid")
     if (
         isinstance(payload.get("seq"), bool)
@@ -477,6 +487,7 @@ def _validate_canonical_coordinator_v2_root(payload: Mapping) -> list[dict[str, 
         or not isinstance(payload.get("slices"), list)
         or not isinstance(payload.get("workflows"), list)
         or not isinstance(payload.get("legacy_records"), Mapping)
+        or not isinstance(payload.get("reclaim_resets", []), list)
     ):
         raise ValueError("canonical coordinator registry root values are invalid")
     from paulsha_cortex.coordinator.workflow import WorkflowRun

--- a/paulsha_cortex/porcelain/recover.py
+++ b/paulsha_cortex/porcelain/recover.py
@@ -61,6 +61,7 @@ def _build_parser() -> argparse.ArgumentParser:
         choices=(
             "retry-build", "resume", "recover-pre-candidate",
             "recover-repair-commit", "abandon", "retire-delivered",
+            "reset-reclaim-budget",
         ),
     )
     work.add_argument("--repo", required=True)

--- a/tests/test_coordinator_registry_headless.py
+++ b/tests/test_coordinator_registry_headless.py
@@ -80,9 +80,15 @@ class VersionedRegistryTests(unittest.TestCase):
                 {"source_schema_version": 1, "seq": 0, "jobs": [], "slices": []},
             )
             self.assertEqual(len(payload["jobs"]), 1)
+            # #519：`reclaim_resets`（semantic-reclaim 熔斷重置水位）為加法相容
+            # 的新根欄位——寫入端一律寫出，讀取端對缺欄位的舊檔仍照常載入。
+            self.assertEqual(payload["reclaim_resets"], [])
             self.assertEqual(
                 set(payload.keys()),
-                {"schema_version", "seq", "jobs", "slices", "workflows", "legacy_records"},
+                {
+                    "schema_version", "seq", "jobs", "slices", "workflows",
+                    "legacy_records", "reclaim_resets",
+                },
             )
 
     def test_missing_schema_version_is_rejected_without_rewrite(self) -> None:

--- a/tests/test_reclaim_budget_reset_519.py
+++ b/tests/test_reclaim_budget_reset_519.py
@@ -1,0 +1,462 @@
+"""#519：semantic-reclaim 世代熔斷的明示重置動作（建議 4）。
+
+`_claim_action` 的 `semantic-reclaim-budget-exhausted` 熔斷（#218 AC2）對
+`(repo, work_id)` 的全部 superseded 歷史無條件累加，沒有任何重置路徑——根因
+修好之後 work item 仍永久鎖死（實測 `fix-brainstorm-revalidation-diagnostics`
+在 4 分鐘內因三個 cortex 自身缺陷累積滿額度）。本檔驗證新增的
+`reset-reclaim-budget` operator 動作：
+
+- 重置後同一 work item 可再次 claim；重置前行為完全不變。
+- 重置以 append-only 水位（cleared run_ids）表達，既有 run 歷史一列不改。
+- 重置後新產生的 superseded 世代重新計數，熔斷會再次上膛。
+- `--reason`／`--actor` 為必填且有界；白名單外參數 fail-closed。
+- 落 `cortex-work-reclaim-reset/v1` evidence（canonical json hash 命名、
+  唯讀原子寫入、內容衝突 raise）。
+- 熔斷回傳訊息本身要指出下一步。
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from paulsha_cortex.control import contract
+from paulsha_cortex.coordinator import work_actions
+from paulsha_cortex.coordinator.registry import JobRegistry
+from paulsha_cortex.coordinator.workflow import WorkflowStep
+
+
+def _init_repo(root: Path, repo: str = "acme/demo") -> Path:
+    root.mkdir(parents=True, exist_ok=True)
+    subprocess.run(["git", "init", "-q", str(root)], check=True)
+    remote = subprocess.run(
+        ["git", "-C", str(root), "remote", "get-url", "origin"],
+        capture_output=True,
+        text=True,
+    )
+    if remote.returncode != 0:
+        subprocess.run(
+            [
+                "git", "-C", str(root), "remote", "add", "origin",
+                f"git@github.com:{repo}.git",
+            ],
+            check=True,
+        )
+    return root
+
+
+def _snapshot(path: Path) -> Path:
+    _init_repo(path.parent)
+    path.write_text(
+        json.dumps(
+            {
+                "schema": "work-items-snapshot/v1",
+                "providers": {
+                    "github": {
+                        "provider_id": "github",
+                        "revision": "gh-1",
+                        "last_success_epoch": 100,
+                        "degraded": False,
+                    }
+                },
+                "work_items": [
+                    {
+                        "repo": "acme/demo",
+                        "work_id": "demo",
+                        "mapped_issues": [12],
+                        "mapped_prs": [],
+                        "mapped_openspec": ["demo"],
+                        "mapped_todo_paths": ["docs/todo.md"],
+                        "confirmed_todo": True,
+                        "auto_label": True,
+                        "source_revisions": ["issue:12@open", "openspec:demo@1"],
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+_CLAIM_STEP = WorkflowStep(
+    phase="claim",
+    persona="manager",
+    card="workflow-claim",
+    executor=None,
+    model=None,
+    domain=None,
+    inputs=(),
+    outputs=(),
+    gate_result="pending",
+)
+
+
+def _burn_generations(registry: JobRegistry, count: int, *, offset: int = 0) -> list[str]:
+    """建立 `count` 個世代並全部終結為 superseded，回傳其 run_id 清單。
+
+    `_manager_create_workflow_run` 會自動 supersede 同 (repo, work_id) 的前一
+    代，最後一代以 `_manager_abandon_workflow_run` 手動終結（比照
+    `tests/test_work_actions_repair_budget.py` 既有作法）。
+    """
+
+    created: list[str] = []
+    for index in range(count):
+        run = registry._manager_create_workflow_run(
+            repo="acme/demo",
+            work_id="demo",
+            claim_key=f"claim:v1:{str(offset + index) * 64}",
+            source_revision=f"rev-{offset + index}",
+            workspace_root="/tmp/workspace",
+            combo="feature-oneshot",
+            current_phase="claim",
+            steps=(_CLAIM_STEP,),
+            issue_refs=("acme/demo#12",),
+        )
+        created.append(run.run_id)
+    for run in registry.list_workflow_runs():
+        if run.status == "ongoing" and run.run_id in created:
+            registry._manager_abandon_workflow_run(
+                run.run_id, evidence_ref=f"abandon:test-{run.run_id}"
+            )
+    return created
+
+
+def _start(tmp_path: Path, registry: JobRegistry, snapshot: Path, *, starter=None):
+    return work_actions.execute_work_action(
+        args={"action": "start", "repo": "acme/demo", "work_id": "demo"},
+        requested_by="operator",
+        now=lambda: 150.0,
+        snapshot_path=snapshot,
+        state_path=tmp_path / "journal.jsonl",
+        workflow_registry=registry,
+        workflow_starter=starter,
+    )["result"]
+
+
+def _reset(
+    tmp_path: Path,
+    registry: JobRegistry,
+    snapshot: Path,
+    *,
+    actor: str = "operator",
+    reason: str = "#507/#511/#516 已修復部署，三代 abandon 全肇因於引擎缺陷",
+    extra: dict | None = None,
+):
+    args = {
+        "action": "reset-reclaim-budget",
+        "repo": "acme/demo",
+        "work_id": "demo",
+        "actor": actor,
+        "reason": reason,
+    }
+    if extra:
+        args.update(extra)
+    return work_actions.execute_work_action(
+        args=args,
+        requested_by="operator",
+        now=lambda: 1_755_000_000.0,
+        snapshot_path=snapshot,
+        state_path=tmp_path / "journal.jsonl",
+        workflow_registry=registry,
+    )["result"]
+
+
+# --------------------------------------------------------------------------
+# 熔斷仍在／重置後可再 claim
+# --------------------------------------------------------------------------
+
+
+def test_budget_exhausted_result_names_reset_as_next_step(tmp_path: Path) -> None:
+    """熔斷回傳必須指出下一步，operator 不該只看到「額度用盡」。"""
+
+    registry = JobRegistry(state_path=tmp_path / "jobs.json")
+    snapshot = _snapshot(tmp_path / "snapshot.json")
+    _burn_generations(registry, 3)
+
+    def _never_start(authority, claim_key, reason):
+        raise AssertionError("熔斷後不得建立新 run")
+
+    result = _start(tmp_path, registry, snapshot, starter=_never_start)
+    assert result["action"] == "needs_human"
+    assert result["reason"] == "semantic-reclaim-budget-exhausted"
+    assert result["superseded_generations"] == 3
+    assert result["reclaim_budget_limit"] == work_actions.SEMANTIC_RECLAIM_LIMIT
+    assert result["legal_next_steps"] == ("reset-reclaim-budget",)
+    assert "reset-reclaim-budget" in result["next_step_hint"]
+    assert "--reason" in result["next_step_hint"]
+
+
+def test_reset_reclaim_budget_restores_claimability(tmp_path: Path) -> None:
+    """重置後同一 work item 可再次 claim，且真的建立新 run。"""
+
+    registry = JobRegistry(state_path=tmp_path / "jobs.json")
+    snapshot = _snapshot(tmp_path / "snapshot.json")
+    burned = _burn_generations(registry, 3)
+
+    blocked = _start(tmp_path, registry, snapshot, starter=lambda *a: None)
+    assert blocked["reason"] == "semantic-reclaim-budget-exhausted"
+
+    reset = _reset(tmp_path, registry, snapshot)
+    assert reset["action"] == "reclaim-budget-reset"
+    assert reset["already_reset"] is False
+    assert reset["cleared_generations"] == 3
+    assert sorted(reset["cleared_run_ids"]) == sorted(burned)
+
+    claimed = _start(tmp_path, registry, snapshot)
+    assert claimed["action"] == "claim"
+    assert claimed["run"]["run_id"] not in burned
+
+
+def test_reset_preserves_every_superseded_run_row(tmp_path: Path) -> None:
+    """重置不得刪除或改寫任何既有 run 紀錄——run 歷史是稽核來源。"""
+
+    registry = JobRegistry(state_path=tmp_path / "jobs.json")
+    snapshot = _snapshot(tmp_path / "snapshot.json")
+    _burn_generations(registry, 3)
+    before = {run.run_id: run.to_dict() for run in registry.list_workflow_runs()}
+
+    _reset(tmp_path, registry, snapshot)
+
+    after = {run.run_id: run.to_dict() for run in registry.list_workflow_runs()}
+    assert after == before
+
+
+def test_reset_then_new_generations_rearm_the_breaker(tmp_path: Path) -> None:
+    """重置只赦免當下已存在的世代；之後新產生的 superseded 重新計數。"""
+
+    registry = JobRegistry(state_path=tmp_path / "jobs.json")
+    snapshot = _snapshot(tmp_path / "snapshot.json")
+    _burn_generations(registry, 3)
+    _reset(tmp_path, registry, snapshot)
+
+    # 重置後的前兩個世代：額度未滿，仍可 claim（這次 claim 會真的建 v_n run）。
+    _burn_generations(registry, 2, offset=10)
+    assert _start(tmp_path, registry, snapshot)["action"] == "claim"
+
+    # 再燒一代——連同上一行 claim 出來、隨即被 supersede 的那個 run，重置後的
+    # 未赦免世代累積到 4（2 + claim 出來的那個 + 1），熔斷再次上膛。
+    _burn_generations(registry, 1, offset=20)
+
+    def _never_start(authority, claim_key, reason):
+        raise AssertionError("重置後的額度用盡仍不得建立新 run")
+
+    again = _start(tmp_path, registry, snapshot, starter=_never_start)
+    assert again["reason"] == "semantic-reclaim-budget-exhausted"
+    assert again["superseded_generations"] == 4
+    # 被赦免的三代不得再出現在熔斷計數裡。
+    assert not set(again["superseded_run_ids"]) & set(
+        registry.list_reclaim_resets()[0]["cleared_run_ids"]
+    )
+
+
+def test_reset_survives_registry_reload(tmp_path: Path) -> None:
+    """水位必須持久化：manager 重啟後重置仍然有效，狀態檔可重新載入。"""
+
+    state = tmp_path / "jobs.json"
+    registry = JobRegistry(state_path=state)
+    snapshot = _snapshot(tmp_path / "snapshot.json")
+    _burn_generations(registry, 3)
+    _reset(tmp_path, registry, snapshot)
+
+    reloaded = JobRegistry(state_path=state)
+    assert len(reloaded.list_reclaim_resets()) == 1
+    assert _start(tmp_path, reloaded, snapshot)["action"] == "claim"
+
+
+def test_legacy_state_file_without_reclaim_resets_still_loads(tmp_path: Path) -> None:
+    """舊狀態檔沒有 `reclaim_resets` 根欄位時必須照常載入（加法相容）。"""
+
+    state = tmp_path / "jobs.json"
+    JobRegistry(state_path=state)
+    registry = JobRegistry(state_path=state)
+    _burn_generations(registry, 1)
+    payload = json.loads(state.read_text(encoding="utf-8"))
+    payload.pop("reclaim_resets", None)
+    state.write_text(json.dumps(payload), encoding="utf-8")
+
+    reloaded = JobRegistry(state_path=state)
+    assert reloaded.list_reclaim_resets() == []
+    assert len(reloaded.list_workflow_runs()) == 1
+
+
+# --------------------------------------------------------------------------
+# 入力驗證
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "reason",
+    [
+        None,
+        "",
+        "   ",
+        " leading",
+        "多行\n理由",
+        "x" * 501,
+    ],
+)
+def test_reset_requires_bounded_single_line_reason(tmp_path: Path, reason) -> None:
+    registry = JobRegistry(state_path=tmp_path / "jobs.json")
+    snapshot = _snapshot(tmp_path / "snapshot.json")
+    _burn_generations(registry, 3)
+    with pytest.raises(ValueError, match="reason"):
+        _reset(tmp_path, registry, snapshot, reason=reason)
+
+
+@pytest.mark.parametrize("actor", [None, "", " op", "y" * 129])
+def test_reset_requires_bounded_actor(tmp_path: Path, actor) -> None:
+    registry = JobRegistry(state_path=tmp_path / "jobs.json")
+    snapshot = _snapshot(tmp_path / "snapshot.json")
+    _burn_generations(registry, 3)
+    with pytest.raises(ValueError, match="actor"):
+        _reset(tmp_path, registry, snapshot, actor=actor)
+
+
+def test_reset_rejects_caller_supplied_evidence(tmp_path: Path) -> None:
+    """白名單外參數一律 fail-closed，caller 不得夾帶 evidence／水位。"""
+
+    registry = JobRegistry(state_path=tmp_path / "jobs.json")
+    snapshot = _snapshot(tmp_path / "snapshot.json")
+    _burn_generations(registry, 3)
+    with pytest.raises(ValueError, match="rejects caller evidence/input"):
+        _reset(
+            tmp_path,
+            registry,
+            snapshot,
+            extra={"cleared_run_ids": ["workflow-" + "0" * 20]},
+        )
+
+
+def test_reset_refuses_when_no_superseded_generation_exists(tmp_path: Path) -> None:
+    """沒有任何可赦免世代時拒絕——不做無意義的狀態變更。"""
+
+    registry = JobRegistry(state_path=tmp_path / "jobs.json")
+    snapshot = _snapshot(tmp_path / "snapshot.json")
+    with pytest.raises(RuntimeError, match="no superseded generation"):
+        _reset(tmp_path, registry, snapshot)
+
+
+def test_reset_resend_is_idempotent(tmp_path: Path) -> None:
+    """重送相同請求回報 already-reset，不寫第二筆水位。"""
+
+    registry = JobRegistry(state_path=tmp_path / "jobs.json")
+    snapshot = _snapshot(tmp_path / "snapshot.json")
+    _burn_generations(registry, 3)
+    first = _reset(tmp_path, registry, snapshot)
+    second = _reset(tmp_path, registry, snapshot)
+
+    assert second["already_reset"] is True
+    assert second["cleared_generations"] == 0
+    assert second["evidence"] == first["evidence"]
+    assert len(registry.list_reclaim_resets()) == 1
+
+
+# --------------------------------------------------------------------------
+# evidence
+# --------------------------------------------------------------------------
+
+
+def test_reset_writes_immutable_content_addressed_evidence(tmp_path: Path) -> None:
+    registry = JobRegistry(state_path=tmp_path / "jobs.json")
+    snapshot = _snapshot(tmp_path / "snapshot.json")
+    burned = _burn_generations(registry, 3)
+    result = _reset(tmp_path, registry, snapshot)
+
+    target = Path(result["evidence"]["ref"])
+    assert target.parent == (tmp_path / "evidence" / "work-reclaim-reset")
+    assert target.name == f"demo-{result['evidence']['hash']}.json"
+    assert not target.is_symlink()
+    assert target.stat().st_mode & 0o222 == 0
+
+    body = json.loads(target.read_text(encoding="utf-8"))
+    assert body["schema"] == "cortex-work-reclaim-reset/v1"
+    assert body["repo"] == "acme/demo"
+    assert body["work_id"] == "demo"
+    assert body["actor"] == "operator"
+    assert body["reason"].startswith("#507/#511/#516")
+    assert body["superseded_generations"] == 3
+    assert body["cleared_run_ids"] == sorted(burned)
+    assert body["created_at"] == "2025-08-12T12:00:00+00:00"
+
+    from paulsha_cortex.coordinator import verification
+
+    assert verification.canonical_json_hash(body) == result["evidence"]["hash"]
+
+
+def test_reset_evidence_conflict_fails_closed(tmp_path: Path) -> None:
+    """同名 evidence 檔內容不符時必須 raise，不得覆寫稽核紀錄。"""
+
+    registry = JobRegistry(state_path=tmp_path / "jobs.json")
+    snapshot = _snapshot(tmp_path / "snapshot.json")
+    _burn_generations(registry, 3)
+    body = work_actions._reclaim_reset_body(
+        repo="acme/demo",
+        work_id="demo",
+        actor="operator",
+        reason="conflict probe",
+        cleared_run_ids=["workflow-" + "0" * 20],
+        created_at="2025-08-12T12:00:00+00:00",
+    )
+    from paulsha_cortex.coordinator import verification
+
+    digest = verification.canonical_json_hash(body)
+    root = tmp_path / "evidence" / "work-reclaim-reset"
+    root.mkdir(parents=True, exist_ok=True)
+    (root / f"demo-{digest}.json").write_text("{}\n", encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="evidence conflict"):
+        work_actions._reclaim_reset_record(body, state_path=tmp_path / "journal.jsonl")
+
+
+# --------------------------------------------------------------------------
+# control contract
+# --------------------------------------------------------------------------
+
+
+def _request(args: dict) -> dict:
+    return contract.build_request(
+        req_type="work-action", args=args, requested_by="operator"
+    )
+
+
+def test_contract_accepts_well_formed_reset_request() -> None:
+    validated = contract.validate_request(
+        _request(
+            {
+                "action": "reset-reclaim-budget",
+                "repo": "acme/demo",
+                "work_id": "demo",
+                "actor": "operator",
+                "reason": "引擎缺陷已修復",
+            }
+        )
+    )
+    assert validated["args"]["action"] == "reset-reclaim-budget"
+
+
+@pytest.mark.parametrize(
+    "args",
+    [
+        {"action": "reset-reclaim-budget", "repo": "acme/demo", "work_id": "demo"},
+        {
+            "action": "reset-reclaim-budget",
+            "repo": "acme/demo",
+            "work_id": "demo",
+            "actor": "operator",
+        },
+        {
+            "action": "reset-reclaim-budget",
+            "repo": "acme/demo",
+            "work_id": "demo",
+            "actor": "operator",
+            "reason": "多行\n理由",
+        },
+    ],
+)
+def test_contract_rejects_incomplete_reset_request(args: dict) -> None:
+    with pytest.raises(ValueError, match="reset-reclaim-budget"):
+        contract.validate_request(_request(args))

--- a/tests/test_reclaim_budget_reset_519.py
+++ b/tests/test_reclaim_budget_reset_519.py
@@ -387,6 +387,28 @@ def test_reset_writes_immutable_content_addressed_evidence(tmp_path: Path) -> No
     assert verification.canonical_json_hash(body) == result["evidence"]["hash"]
 
 
+def test_reset_evidence_replay_is_idempotent_for_many_generations(tmp_path: Path) -> None:
+    """世代數多到 body 超過 4096 bytes 時，byte-identical 重放仍須冪等。
+
+    evidence body 隨 `cleared_run_ids` 線性成長，而 supersede-family 共用的
+    conflict 判準帶有防禦性大小上界；沿用 abandon 的 4096 會讓長歷史 work item
+    的重置一重放就被誤判成 conflict、冪等重入必然 fail。
+    """
+
+    body = work_actions._reclaim_reset_body(
+        repo="acme/demo",
+        work_id="demo",
+        actor="operator",
+        reason="長歷史 work item",
+        cleared_run_ids=[f"workflow-{index:020x}" for index in range(200)],
+        created_at="2025-08-12T12:00:00+00:00",
+    )
+    state_path = tmp_path / "journal.jsonl"
+    first = work_actions._reclaim_reset_record(body, state_path=state_path)
+    assert Path(first["ref"]).stat().st_size > 4096
+    assert work_actions._reclaim_reset_record(body, state_path=state_path) == first
+
+
 def test_reset_evidence_conflict_fails_closed(tmp_path: Path) -> None:
     """同名 evidence 檔內容不符時必須 raise，不得覆寫稽核紀錄。"""
 


### PR DESCRIPTION
Refs #519

## 問題

`coordinator/work_actions.py` 的 `_claim_action`（`#218 AC2`）在同一 `(repo, work_id)` 累積 `SEMANTIC_RECLAIM_LIMIT`（3）個 `superseded` 世代後，熔斷為 `needs_human: semantic-reclaim-budget-exhausted`：

```python
superseded_generations = [
    run for run in workflow_registry.list_workflow_runs()
    if run.repo == authority.repo and run.work_id == authority.work_id
    and run.status == "superseded"
]
if len(superseded_generations) >= SEMANTIC_RECLAIM_LIMIT:
    return {"action": "needs_human", "reason": "semantic-reclaim-budget-exhausted", ...}
```

計數是對**全部歷史**無條件累加：不看時間窗、不看失敗原因、不看引擎版本或 source revision 是否已變。檢查點位在 `decide_auto_claim`／`decide_manual_start` 之後、`workflow_starter` 之前，auto 與明示 `work start` 共用，CLI 無 force／override——**沒有任何重置路徑**，因此根因修好之後 work item 仍永久鎖死。

實測傷害（2026-08-14 dogfooding）：`fix-brainstorm-revalidation-diagnostics` 在 **4 分鐘內**累積 3 個 superseded 世代（成因分別是「成功卻被自行 supersede」「codex exec 逾時」「前代殘留 artifact 使 authority fail-closed」，**無一是工作項本身的問題**）而永久鎖死；`fix-rate-limit-classification` 的三次 abandon 全肇因於當時未修的 `#507`／`#511`／`#516`（皆已修復部署）。

## 解法：建議 4（帶審計的重置動作）

新增 `reset-reclaim-budget` operator 動作，走既有 work-action 路徑（單一 writer、經 manager daemon），與其他 action 一致。

### 重置機制的實作方式與選擇理由

**選擇：append-only 水位（cleared run_id 集合），不改寫任何既有 run 紀錄。**

coordinator 狀態檔（`jobs.json`）新增根欄位 `reclaim_resets`，每次重置 append 一列：

```json
{
  "repo": "...", "work_id": "...", "actor": "...", "reason": "...",
  "evidence_ref": "...", "evidence_hash": "...",
  "cleared_run_ids": ["workflow-...", "..."], "created_at": "..."
}
```

熔斷計數改為 `_effective_superseded_generations()`：superseded 世代**扣掉所有已赦免 run_id**。claim 路徑與重置動作共用同一支計數，兩邊對「還剩幾代額度」不可能分歧。

為什麼選這個作法：

- **run 歷史是稽核來源**：既有 `WorkflowRun` row 一列不刪不改（測試 `test_reset_preserves_every_superseded_run_row` 逐 row 比對 `to_dict()`）。重置是新增一筆授權事實，不是抹掉失敗紀錄。
- **不依賴時鐘**：水位以 run_id **集合**而非時間戳／序號表達，因此不需要任何「reset 之後建立的 run」時間假設，也不受 run row 排序或 clock skew 影響。
- **熔斷會再次上膛**：重置只赦免當下已存在的世代，之後新產生的 superseded 照常累加（測試 `test_reset_then_new_generations_rearm_the_breaker`）。這不是永久關閉安全機制。
- **不得預先授權未來的失敗**：`_manager_record_reclaim_reset()` 驗證每個被赦免的 run_id 確實存在且為 superseded，否則 fail-closed。
- **加法相容，不 bump `schema_version`**：`reclaim_resets` 不列入 `_load()` 的 `missing_v2_roots` fail-closed 清單，本欄位出現前寫下的既有狀態檔（所有現役部署）照常載入；缺欄位＝沒有任何重置授權，也就是熔斷維持最嚴格的既有行為（fail-closed 方向）。`monitor/providers.py` 的唯讀 canonical root 驗證同步接受「有」與「沒有」兩種形狀，仍不接受任何其他未知根欄位。

被否決的替代方案：在既有 superseded run 上加 facet／改寫 status——那是對稽核來源的改寫，且無法區分「這代被赦免過」與「這代本來就是這樣」。

### 參數與冪等

- 必帶 `--actor`（≤128 字、單行、可列印）與 `--reason`（≤500 字、單行、可列印），界限與 `abandon`／`retire-delivered` **逐字相同**，並在 `control/contract.py` 與 `work_actions.py` 兩層各驗一次（縱深防禦，比照既有慣例）。
- **刻意不要 `--expected-run-id`**：熔斷觸發的前提就是 `decide_*_claim` 已判成 claim、沒有 active run 可供 CAS；硬要一個 exact run id 等同讓這條解鎖路徑永遠打不開。
- 白名單外參數一律 fail-closed 拒絕（`reset-reclaim-budget rejects caller evidence/input: ...`），caller 不得夾帶 evidence 或水位。
- 沒有任何可赦免世代時 fail-closed 拒絕；已重置過而重送同一請求回報 `already_reset: true` 並回傳既有 evidence ref，不寫第二筆授權。
- 併入 rate-limit 容忍集合（`_LOCAL_UNBLOCK_ACTIONS`，原 `_RETIREMENT_ACTIONS`）：同樣只動本機狀態、不依賴 issue 當下 open/closed 狀態，而系統被限流的當下正是卡死 work item 最需要被解開的時候（沿用 `#370` follow-up 已寫下的理由）。

### Evidence schema

`cortex-work-reclaim-reset/v1`，落在 `<coordinator_root>/evidence/work-reclaim-reset/{work_id}-{canonical_json_hash}.json`：

```json
{
  "schema": "cortex-work-reclaim-reset/v1",
  "repo": "acme/demo",
  "work_id": "demo",
  "actor": "operator",
  "reason": "<單行審計理由>",
  "superseded_generations": 3,
  "cleared_run_ids": ["workflow-...", "workflow-...", "workflow-..."],
  "created_at": "2026-08-14T...+00:00"
}
```

寫入沿用 `_write_supersede_evidence()`（新增 `stem`／`label` 參數，讓 work-item 級記錄能以 `work_id` 而非 `run_id` 命名，並讓錯誤訊息說自己的名字）：canonical json hash 命名、create-with-`O_EXCL` → `fsync` → `fchmod 0444` → hardlink publish → 目錄 `fsync`，同名檔內容不符即 `RuntimeError`（不覆寫稽核紀錄）。順序比照 `#275`：先寫 durable evidence 再改狀態；兩步之間 crash 最壞只留下一份未被引用的 evidence 檔（水位是集合聯集，重放同一授權語意冪等），不會出現「狀態已放寬但查無授權依據」。

### 熔斷訊息指出下一步

`semantic-reclaim-budget-exhausted` 結果新增（比照 `#218 AC3` 的 `legal_next_steps` 慣例）：

- `reclaim_budget_limit`、`superseded_run_ids`
- `legal_next_steps: ("reset-reclaim-budget",)`
- `next_step_hint`：完整可貼上的 `cortex work reset-reclaim-budget <work_id> --repo <repo> --actor <operator> --reason <單行理由>`，並說明會留下稽核紀錄。

## 建議 1（納入引擎版本維度）：評估後不採

- `WorkflowRun` 沒有任何引擎版本／build 識別欄位，既有 row 也**無法回填**——所有歷史世代的引擎版本會是 `None`，「未知版本算不算數」只能猜，任一種猜法都是 fail-open 的模糊地帶。
- cortex 的發版頻率遠高於單一 work item 燒完三代（本次是 4 分鐘燒完三代）。以引擎版本當計數維度，熔斷幾乎每次發版都自動歸零，等同讓這道安全機制實質失效——而它擋下的正是「同一工作項反覆重試都失敗」這個真問題。
- 對本次情境也不具決定性：`#507`／`#511`／`#516` 是以 merge 到 main 的方式落地，run 紀錄裡沒有任何欄位能證明某個 superseded 世代是哪個引擎 build 產生的。
- 「引擎已修好，所以舊失敗不該再算數」本質上是一個**需要具名負責的人工判斷**——這正是建議 4 提供的東西：一個人、一個寫得出來的理由、一筆不可變的稽核紀錄。

因此本 PR 只做建議 4。若日後要做建議 1，前置條件是先在 `WorkflowRun` 上持久化引擎 provenance，且那應該是獨立的一次變更。

## 不在範圍

`#524`（成功 run 被 supersede）、失敗分類 content/environment 的改判（`#507`）、`#523` 的 collision 與 abandon CAS。

## 測試

TDD：先寫 25 個失敗測試（`tests/test_reclaim_budget_reset_519.py`，全紅）再實作。涵蓋：

- 重置後可再次 claim 且真的建立新 run；重置前行為完全不變。
- 重置不改動任何既有 run row（逐 row `to_dict()` 比對）。
- 重置後新世代重新計數、熔斷再次上膛，且已赦免 run_id 不再出現在計數裡。
- 水位持久化（registry 重載後仍有效）；缺 `reclaim_resets` 根欄位的舊狀態檔照常載入。
- `--reason`／`--actor` 的 6+4 組邊界（缺漏、空白、前後空白、多行、超長）。
- 白名單外參數拒絕；無可赦免世代時拒絕；重送冪等。
- evidence 內容、檔名（canonical hash）、`0444` 唯讀、非 symlink、canonical hash 自洽、內容衝突 raise。
- `control/contract.py` 的 request 層驗證（接受 well-formed、拒絕缺 actor／缺 reason／多行 reason）。

連帶更新 `tests/test_coordinator_registry_headless.py` 的狀態檔根欄位契約測試。

```
python3 -m pytest -q
2545 passed, 49 subtests passed
```
（基準 2520 + 新增 25）

## 檢查清單

- [x] `changelog.d/reclaim-budget-reset.md` fragment 已新增且已 commit（R-09）
- [x] `CHANGELOG.md [Unreleased]` 有對應 entry
- [x] `docs/unified-work-lifecycle.md` 同步（動作語意、水位機制、evidence schema、CLI 範例）
- [x] `cortex work --help` 與 coordinator／porcelain CLI choices 同步（R-16）
- [x] `VERSION` 未動（非 release PR）
- [x] 全套測試通過
- [x] policy_check 帶 PR context 跑過

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E7w9kaUxAzCCEk7piD5hfK
