### PR TITLE
fix(coordinator): in-flight run 不得被自己的 planning 產出作廢（#524）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,25 @@
 ## [Unreleased]
 
 ### Fixed
+- **Issue #524：planning 成功的 in-flight run 被自行 supersede，其產出又使後續
+  世代 fail-closed**——`claim_key`／`run.source_revision` 都由
+  `work_authority_digest()` 導出，而該 digest 折入 `source_revisions`；run 自己的
+  `brainstorming`／`writing-plans` 卡把 spec/design/plan 寫進 governed roots 後，
+  monitor 會把它們當成新的 confirmed source 併入同一個 work item，digest 因此改變、
+  run 的持久化識別與「目前 authority 算出來的識別」再也對不上。`_claim_action()`
+  的 active-run 偵測第二段 fallback 只在 auto-scan／explicit resume 時才跑，
+  `start`／`intake` 整段跳過，於是把仍在 flight 的 run 當成陳舊世代，
+  `_manager_create_workflow_run()` 再無條件把同 `(repo, work_id)` 的 ongoing run
+  全部作廢（現場 `workflow-009fe9ab303df196209d` 四張卡全 passed、phase 已達 build
+  仍被 90 秒後自行 supersede）。修法在 `_claim_action()` 補上不分呼叫端的 in-flight
+  保護傘，判準為「`run.status` 與 `workflow_status()` 皆為 ongoing」且「剝除
+  `superpowers_spec:`／`superpowers_plan:` 這兩類 planning **產出** source 後重算的
+  authority digest 與 run 的 `source_revision` 逐字相符」——即整段漂移都是 run 自己
+  造成的才保護，真正的 authority 變更維持既有換代語意。另修 `_artifact_rows()` 依
+  檔名尾綴把 `*-design.md` 還原為 kind `design`（monitor 一律標成
+  `superpowers_spec`，與 planning 產線的 `design` 不一致），讓下一代能承接前代的
+  artifact authority，解開 `planning artifact lacks current planning authority`
+  的死結。詳見 `changelog.d/supersede-active-run.md`。
 - **Issue #519：semantic-reclaim 世代熔斷補上帶審計的重置路徑**——`#218 AC2` 的
   世代熔斷對 `(repo, work_id)` 的全部 superseded 歷史無條件累加，且沒有任何重置
   路徑，導致根因（`#507`／`#511`／`#516` 等 cortex 自身缺陷）修好之後 work item

--- a/changelog.d/supersede-active-run.md
+++ b/changelog.d/supersede-active-run.md
@@ -1,0 +1,117 @@
+---
+type: fix
+scope: coordinator
+---
+**Issue #524：planning 成功的 in-flight run 被自行 supersede，其產出又使後續世代 fail-closed**
+
+生產現場（work_id `fix-brainstorm-revalidation-diagnostics`／issue #514，
+2026-08-14 04:55–05:00）：`workflow-009fe9ab303df196209d` 04:55:07 claim，
+`workflow-claim`／`brainstorming`／`openspec-propose`／`writing-plans` 四張卡全
+`passed`、phase 已達 `build`，卻在 04:56:42 被系統自行標成 `superseded`——facets
+只有 supersede 順手加上的 `blocked`，沒有任何 work-abandon evidence。同一毫秒建立
+的 `workflow-952a3652afc51ab4f29c` 與其後的 `workflow-7bb3a83c2c1fc37359d5` 都只
+完成 `workflow-claim`，四分鐘內用掉全部三次語意 re-claim 額度（`#519` 熔斷），
+無一次失敗肇因於工作項本身。
+
+## (A) 根因：run 被自己的成功產出擠掉識別
+
+`claim_key` 與 `run.source_revision` 都由 `claim.work_authority_digest()` 導出，
+而該 digest 折入 `source_revisions`。monitor 的 repo provider 以
+`docs/superpowers/specs/**/*.md`／`docs/superpowers/plans/**/*.md` 掃描產生
+`superpowers_spec:`／`superpowers_plan:` source——**run 自己的 `brainstorming`／
+`writing-plans` 卡一旦把 spec/design/plan 寫進 governed roots，下一輪 correlation
+就把它們當成新的 confirmed source 併進同一個 work item**，digest 因此改變、
+`claim_key` 隨之漂移。
+
+以現場 snapshot 反算，三個世代的 `claim_key` 逐字對應三種 source 集合：
+
+| run | 對應的 planning-artifact source 集合 |
+| --- | --- |
+| `workflow-009fe9ab303df196209d` | 無（claim 當下尚未產出） |
+| `workflow-952a3652afc51ab4f29c` | ＋2 個 `superpowers_spec`（spec／design） |
+| `workflow-7bb3a83c2c1fc37359d5` | ＋2 個 `superpowers_spec` ＋1 個 `superpowers_plan` |
+
+`_claim_action()` 的 active-run 偵測因此完全找不到那個 run：第一段用漂移後的
+`_expected_claim_key(authority)` 比對 persisted `run.claim_key` 必然落空；第二段
+fallback 雖改用不受 planning 產出影響的穩定識別，卻只在 `automatic`（auto-scan）
+或 `args["action"] == "resume"` 時才跑——`start`／`intake` 這兩個 control-request
+入口整段跳過。canonical_run 保持 `None`，claim 路徑把它當成全新 claim，
+`registry._manager_create_workflow_run()` 再無條件把同 `(repo, work_id)` 的所有
+ongoing run 標成 `superseded`。
+
+**修法**：`_claim_action()` 新增第三段、不分呼叫端的 in-flight 保護傘，判準有二、
+缺一不可——
+
+1. **未失敗**：`run.status == "ongoing"` 且 `workflow_status(run) == "ongoing"`。
+   兩個都要：`workflow_status()` 對 abandon 釋放過的 run（`superseded` ＋
+   `planning_released`）刻意回傳 `"ongoing"`，只看它會把 `#256`／`#416` 的
+   abandon→reclaim 出口一併鎖死；只看 `run.status` 又會誤納 needs_human／
+   needs_decomposition／blocked 的 run。
+2. **漂移完全來自 run 自己的產出**：新增
+   `claim.authority_digest_without_planning_outputs()`，把 `superpowers_spec:`／
+   `superpowers_plan:` 前綴的 source 剝掉後重算 digest，必須與 run 持久化的
+   `source_revision` 逐字相符。這兩類 source 依構造永遠是 planning phase 的
+   **產出**——canonical row 解析只認 `github_issue`／`github_pr`／`openspec`／
+   `todo` 四種 kind，`superpowers_*` 只會被 monitor 掃出來，不可能是 operator 在
+   `.cortex/work-items.yaml` 宣告的授權來源。
+
+判準 2 同時守住既有的 operator 逃生口：issue 開關、openspec revision、todo 成員
+變動等**真正的** authority 變更不會被剝除，digest 依然不同，`start` 照舊開新世代
+（`tests/test_work_actions.py::test_source_change_starts_new_canonical_run` 未改動
+仍綠）。以現場資料驗證：剝除後的 digest 為
+`039e89aab0a56384bce29bc89dc638c4e176f96873e9a4d89627b223d79a31bf`，與被誤
+supersede 的 `workflow-009fe9ab303df196209d` 持久化的 `source_revision` 逐字相符。
+
+命中保護傘時以既有的 `#216 AC5` resume 分支收尾（該分支條件加上
+`inflight_resume`）；否則會落到 `decide_manual_start()` → `_existing()`，那裡對
+「persisted claim_key 與目前 authority 不符」是直接
+`raise ValueError("persisted claim key does not match authority")`——等於把自行
+supersede 換成一個例外，run 一樣救不回來。
+
+`#519` 的 `SEMANTIC_RECLAIM_LIMIT` 計數邏輯一字未動。
+
+## (B) 前代產出使後續世代 fail-closed：承接前代的 artifact authority
+
+`#524` 原始描述推測本情境的分類仍是 `content`、連 `recover-planning` 都不受理。
+實測**不成立**：`evidence/planning-recovery/workflow-7bb3a83c2c1fc37359d5-*.json`
+的 `classification` 是 `environment`，`#416` 的
+`_is_planning_authority_residue_failure()` carve-out 已正確涵蓋
+`planning artifact lacks current planning authority`。真正的死結在更下游——
+即使 `recover-planning` 受理、重跑 brainstorm，也必然再撞同一堵牆。
+
+實際成因是 **artifact kind taxonomy 兩邊不一致**：monitor 的 provider 規則把
+`docs/superpowers/specs/**/*.md` 一律標成 `superpowers_spec`，而 planning 產線的
+canonical destinations（`planning_runtime.py` 的
+`{"spec": …-spec.md, "design": …-design.md, "plan": …}`）把同目錄下的
+`*-design.md` 定義為 kind `design`。`work_bridge._artifact_rows()` 過去把這條差異
+直接抹平成 `spec`，於是新世代 claim 時 seed 進 `run.planning_authority` 的 design
+檔掛著 kind `spec`；等 brainstorming 用 kind `design` 對同一路徑重新發佈，
+`manager._publish_planning_artifacts()` 的 `owner.kind != row["kind"]` 立刻
+fail-closed，訊息即現場的
+`primary-artifact-write-rejected: ValueError: planning artifact lacks current
+planning authority: …-design.md`。**下一代因此永遠承接不了前一代的 artifact
+authority。**
+
+三條候選路線中採「讓下一代能承接前代的 artifact authority」：另外兩條都治標不治本
+——把 supersede 殘留納入 `#416` carve-out 只是改分類，`recover-planning` 重跑仍會
+撞同一個 kind 比對；在 supersede 時回滾該代發佈則會刪掉 planning 唯一有價值的成功
+產出（現場那三份 artifact 正是本 issue 的關鍵證物）。
+
+**修法**：新增 `work_bridge._superpowers_spec_kind()`，依檔名尾綴把
+`*-design.md` 還原為 kind `design`，其餘維持 `spec`。只用檔名判定（不讀內容）
+——這與 `planning_runtime` 的 destinations 是同一組字面約定，也是唯一能在「尚未
+讀檔」的 claim 時點取得的訊號。
+
+**遷移註記**：現存 jobs.json 有 54 個 run 的 `planning_authority` 把 `-design.md`
+記成 kind `spec`，其中 52 個已終態（`superseded`／`done`，不再被重新掃描）、1 個在
+`build` phase（`start_canonical_workflow` 對非 `define` phase 早退，不會重掃）、
+1 個即本 issue 的 `workflow-7bb3a83c2c1fc37359d5`（已 `needs_human`，本就需
+abandon）。因此不另加相容層。
+
+## 不在範圍
+
+`#519` 的熔斷額度重置（另有 PR 平行處理）、`#507` 的 worktree 抹除、`#523` 的
+collision。另記錄一個同類但本次未觸發的潛在缺口：run 自己的 `openspec-propose` 卡
+若讓 `authority.mapped_openspec` 長出新項，`_claim_action()` 第二段 fallback 的
+`run.openspec_refs == authority.mapped_openspec` 比對同樣會落空（本次現場的
+work item 未宣告 openspec source，故未踩到）；新的保護傘不比對該欄位，已間接覆蓋。

--- a/paulsha_cortex/coordinator/claim.py
+++ b/paulsha_cortex/coordinator/claim.py
@@ -731,21 +731,72 @@ def _safe_todo_path(value: object) -> bool:
     )
 
 
-def work_authority_digest(authority: WorkAuthority) -> str:
-    if not isinstance(authority, WorkAuthority):
-        raise ValueError("confirmed WorkAuthority is required")
-    payload = {
+def _authority_digest_payload(
+    authority: WorkAuthority, source_revisions: tuple[str, ...]
+) -> dict:
+    return {
         "repo": authority.repo,
         "work_id": authority.work_id,
         "provider_id": authority.github_provider_id,
-        "source_revisions": list(authority.source_revisions),
+        "source_revisions": list(source_revisions),
         "mapped_issues": list(authority.mapped_issues),
         "mapped_prs": list(authority.mapped_prs),
         "mapped_openspec": list(authority.mapped_openspec),
         "mapped_todo_paths": list(authority.mapped_todo_paths),
         "confirmed_todo": authority.confirmed_todo,
     }
-    return verification.canonical_json_hash(payload)
+
+
+def work_authority_digest(authority: WorkAuthority) -> str:
+    if not isinstance(authority, WorkAuthority):
+        raise ValueError("confirmed WorkAuthority is required")
+    return verification.canonical_json_hash(
+        _authority_digest_payload(authority, authority.source_revisions)
+    )
+
+
+# #524：monitor 的 repo provider 以 glob 掃 `docs/superpowers/specs/**/*.md` 與
+# `docs/superpowers/plans/**/*.md` 產生的 source id 前綴（見 monitor/providers.py）。
+#
+# 這兩類 source 依構造永遠是 **planning phase 自己的產出**，不可能是 operator 在
+# `.cortex/work-items.yaml` 宣告的授權來源——canonical row 解析
+# （`_authority_from_canonical_row`）只認 `github_issue`／`github_pr`／`openspec`／
+# `todo` 四種 kind，`superpowers_*` 完全不在其中，只會被 monitor 掃出來。因此它們
+# 在 authority 裡「出現」這件事，只代表該 work item 的 run 正在成功推進，不代表
+# authority 被任何外部事實改動過。
+PLANNING_OUTPUT_SOURCE_PREFIXES = ("superpowers_spec:", "superpowers_plan:")
+
+
+def authority_digest_without_planning_outputs(authority: WorkAuthority) -> str:
+    """把 planning phase 自產的 source 剝掉之後重算的 authority digest。
+
+    #524：`claim_key`／`run.source_revision` 都由 `work_authority_digest` 導出，
+    而該 digest 折入 `source_revisions`。run 的 brainstorming／writing-plans 卡一旦
+    把 spec/design/plan 寫進 governed roots，monitor 下一輪就把它們當成新的
+    confirmed source 併進同一個 work item——digest 因此改變，run 的持久化識別與
+    「目前 authority 算出來的識別」再也對不上，claim 路徑於是把仍在 flight 的 run
+    當成陳舊世代作廢。
+
+    本函式提供的是「若不算 run 自己的產出，authority 是否仍是 claim 當下那一份」
+    這個判準：與 `run.source_revision` 相等即代表**整段漂移都是自己造成的**，此時
+    不得換代。反之（issue 開關、openspec revision、todo 成員變動……）維持既有的
+    新世代語意，operator 明確 `start` 換代的逃生口不受影響。
+
+    生產現場驗證：以 2026-08-14 的 snapshot 剝除兩個 `superpowers_spec` 與一個
+    `superpowers_plan` source 後重算，digest 為
+    `039e89aab0a56384bce29bc89dc638c4e176f96873e9a4d89627b223d79a31bf`，與被誤
+    supersede 的 `workflow-009fe9ab303df196209d` 持久化的 `source_revision` 逐字
+    相符。
+    """
+
+    if not isinstance(authority, WorkAuthority):
+        raise ValueError("confirmed WorkAuthority is required")
+    kept = tuple(
+        revision
+        for revision in authority.source_revisions
+        if not revision.startswith(PLANNING_OUTPUT_SOURCE_PREFIXES)
+    )
+    return verification.canonical_json_hash(_authority_digest_payload(authority, kept))
 
 
 def claim_identity_digest(authority: WorkAuthority) -> str:

--- a/paulsha_cortex/coordinator/work_actions.py
+++ b/paulsha_cortex/coordinator/work_actions.py
@@ -22,6 +22,7 @@ from paulsha_cortex._yaml import safe_load
 
 from .claim import (
     ClaimCandidate,
+    authority_digest_without_planning_outputs,
     build_claim_key,
     build_label_argv,
     claim_identity_digest,
@@ -1432,6 +1433,9 @@ def _claim_action(
     """
 
     canonical_run = None
+    # #524：canonical_run 是靠「in-flight 保護傘」而非 claim_key／identity 比對
+    # 找回來的旗標，供下方 #216 AC5 的 resume 分支判定用（見該處註解）。
+    inflight_resume = False
     if workflow_registry is not None:
         all_runs = workflow_registry.list_workflow_runs()
         expected_key = _expected_claim_key(authority)
@@ -1463,6 +1467,64 @@ def _claim_action(
             if len(active) > 1:
                 raise RuntimeError("active workflow identity is ambiguous")
             canonical_run = active[0] if active else None
+        if canonical_run is None:
+            # #524：in-flight 保護傘——「已在 flight 且未失敗的 run 不得被新的
+            # claim 作廢」。
+            #
+            # 根因：`claim_key` 由 `work_authority_digest` 導出，而該 digest 折入
+            # `source_revisions`。run 自己的 planning 卡把 spec/design/plan 寫進
+            # governed roots 之後，monitor 會把這些檔案當成**新的 confirmed
+            # source** 併入同一個 work item，digest 因此改變、`claim_key` 隨之
+            # 漂移——run 是被自己的成功產出擠掉識別的。上面第一段用
+            # `_expected_claim_key(authority)` 比對 persisted `run.claim_key`
+            # 於是必然落空。
+            #
+            # 第二段 fallback 雖然改用不受 planning 產出影響的穩定識別
+            # （issue_refs/openspec_refs），卻只在 `automatic`（auto-scan）或
+            # `args["action"] == "resume"` 時才跑；`start`／`intake` 這兩個
+            # control-request 入口整段跳過，canonical_run 保持 None，claim 路徑
+            # 把它當成全新 claim，`registry._manager_create_workflow_run` 再無
+            # 條件把同 (repo, work_id) 的 ongoing run 全部標成 superseded
+            # （見 registry.py 的 supersede 迴圈）——這正是 #524 生產現場
+            # `workflow-009fe9ab303df196209d` 四張卡全 passed、phase 已達 build
+            # 卻在 90 秒後被自行作廢的路徑。
+            #
+            # 這裡補的是最後一道、不分呼叫端的防線，判準有二，缺一不可：
+            #
+            # (1)「未失敗」：`run.status == "ongoing"` 且
+            #     `workflow_status(run) == "ongoing"`。兩個都要——`workflow_status`
+            #     對 abandon 釋放過的 run（`superseded` + `planning_released`）
+            #     刻意回傳 `"ongoing"`（見 work_bridge.py），只看它會把
+            #     #256／#416 的 abandon→reclaim 出口一併鎖死；只看
+            #     `run.status` 又會把 needs_human／needs_decomposition／blocked
+            #     的 run 誤納入保護。
+            #
+            # (2)「漂移完全來自 run 自己的產出」：把 planning phase 自產的
+            #     `superpowers_spec:`／`superpowers_plan:` source 剝掉之後重算的
+            #     authority digest，必須與 run 持久化的 `source_revision`（claim
+            #     當下的 `work_authority_digest`）逐字相符。相符即代表「除了這個
+            #     run 自己寫出來的 spec/design/plan 以外，authority 一個字都沒
+            #     變」，此時換代純屬自我作廢。
+            #
+            # 判準 (2) 同時守住既有的 operator 逃生口：issue 開關、openspec
+            # revision、todo 成員變動等**真正的** authority 變更不會被剝除，
+            # digest 依然不同，`start` 照舊開新世代（見
+            # tests/test_work_actions.py::test_source_change_starts_new_canonical_run）。
+            inflight_digest = authority_digest_without_planning_outputs(authority)
+            inflight = [
+                run
+                for run in all_runs
+                if run.repo == authority.repo
+                and run.work_id == authority.work_id
+                and run.status == "ongoing"
+                and workflow_status(run) == "ongoing"
+                and run.source_revision == inflight_digest
+            ]
+            if len(inflight) > 1:
+                raise RuntimeError("active workflow identity is ambiguous")
+            if inflight:
+                canonical_run = inflight[0]
+                inflight_resume = True
         if canonical_run is None and args.get("action") == "resume":
             completed = [
                 run
@@ -1539,8 +1601,14 @@ def _claim_action(
     if (
         canonical_run is not None
         and canonical_run.claim_key != _expected_claim_key(authority)
-        and (automatic or args.get("action") == "resume")
+        and (automatic or args.get("action") == "resume" or inflight_resume)
     ):
+        # #524：`inflight_resume` 讓 `start`／`intake` 也走進本分支。上面的
+        # 保護傘既然把 in-flight run 找了回來，就必須在這裡以 resume 收尾——
+        # 否則會落到下方 `decide_manual_start` -> `_existing()`，那裡對
+        # 「persisted claim_key 與目前 authority 不符」是直接
+        # `raise ValueError("persisted claim key does not match authority")`，
+        # 等於把原本的自行 supersede 換成一個例外，run 一樣救不回來。
         # #216 AC5：authority 宣告已變更（claim_key 不比對即代表 authority_digest
         # 不同）——只 invalidate 依賴該 authority 內容的 verify/review gate，
         # build phase 已產出的 Candidate 保持不變。僅在 verify/review phase 且

--- a/paulsha_cortex/coordinator/work_bridge.py
+++ b/paulsha_cortex/coordinator/work_bridge.py
@@ -183,6 +183,32 @@ def default_workflow_manifest(work_id: str, *, change: str | None, combo_name: s
     return result.workflow_manifest
 
 
+def _superpowers_spec_kind(ref: str) -> str:
+    """把 monitor 的 ``superpowers_spec`` source 還原成 planning 產線的 kind。
+
+    #524（B）：monitor 的 provider 規則把 ``docs/superpowers/specs/**/*.md``
+    一律標成 ``superpowers_spec``（見 ``monitor/providers.py``），但 planning
+    產線的 canonical destinations（見 ``planning_runtime.py`` 的
+    ``{"spec": ...-spec.md, "design": ...-design.md, "plan": ...}``）把同一個
+    目錄底下的 ``*-design.md`` 定義為 kind ``design``。
+
+    這條差異過去被 ``_artifact_rows`` 直接抹平成 ``spec``，於是新世代 claim 時
+    seed 進 ``run.planning_authority`` 的 design 檔掛著 kind ``spec``；等
+    brainstorming 用 kind ``design`` 對同一路徑重新發佈，
+    ``manager._publish_planning_artifacts`` 的 ``owner.kind != row["kind"]``
+    立刻 fail-closed，訊息即生產現場 ``workflow-7bb3a83c2c1fc37359d5`` 的
+    ``primary-artifact-write-rejected: ValueError: planning artifact lacks
+    current planning authority: ...-design.md``。下一代因此永遠承接不了前一代
+    的 artifact authority，連 ``recover-planning`` 重跑也是同一堵牆。
+
+    只用檔名尾綴判定（不讀內容）：``-design.md`` 對應 kind ``design``，其餘
+    維持 ``spec``。這與 ``planning_runtime`` 的 destinations 是同一組字面約定，
+    也是唯一能在「尚未讀檔」的 claim 時點取得的訊號。
+    """
+
+    return "design" if ref.endswith("-design.md") else "spec"
+
+
 def _artifact_rows(root: Path, authority: WorkAuthority) -> list[dict[str, str]]:
     rows: list[dict[str, str]] = []
     seen: set[tuple[str, str]] = set()
@@ -197,7 +223,7 @@ def _artifact_rows(root: Path, authority: WorkAuthority) -> list[dict[str, str]]
         source_id = revision.rsplit("@", 1)[0]
         prefix = f"superpowers_spec:{authority.repo}:"
         if source_id.startswith(prefix):
-            add("spec", source_id[len(prefix) :])
+            add(_superpowers_spec_kind(source_id[len(prefix) :]), source_id[len(prefix) :])
         prefix = f"superpowers_plan:{authority.repo}:"
         if source_id.startswith(prefix):
             add("plan", source_id[len(prefix) :])

--- a/tests/test_claim_inflight_supersede_524.py
+++ b/tests/test_claim_inflight_supersede_524.py
@@ -1,0 +1,288 @@
+"""issue #524 迴歸測試：planning 成功、已推進到 build 的 in-flight run 不得被
+新 claim 作廢；前代 artifact 殘留也不得讓下一代 fail-closed。
+
+生產現場（work_id ``fix-brainstorm-revalidation-diagnostics``／issue #514，
+2026-08-14 04:55-05:00）：
+
+* ``workflow-009fe9ab303df196209d`` 04:55:07 claim，``workflow-claim``／
+  ``brainstorming``／``openspec-propose``／``writing-plans`` 四張卡全 passed、
+  phase 已達 ``build``，卻在 04:56:42 被系統自行 supersede，且無任何
+  work-abandon evidence。
+* 同一毫秒建立的 ``workflow-952a3652afc51ab4f29c`` 與其後的
+  ``workflow-7bb3a83c2c1fc37359d5`` 只完成 ``workflow-claim``，四分鐘內用掉
+  全部三次 reclaim 額度（#519 熔斷），無一次失敗肇因於工作項本身。
+
+根因（以三個 persisted claim_key 反算複現，見 PR body）：``claim_key`` 由
+``work_authority_digest`` 導出，而該 digest 折入 ``source_revisions``——run 自己
+的 planning 卡把 spec/design/plan 寫進 governed roots 後，monitor 會把它們當成
+**新的 confirmed source** 併入 authority，於是 digest 改變、``claim_key`` 漂移。
+三個世代的 claim_key 恰好對應「無 planning artifact」／「+2 個 spec」／
+「+2 個 spec +1 個 plan」三種 source 集合，證明 run 是被自己的成功產出擠掉的。
+
+``_claim_action`` 的 active-run 偵測因此找不到那個 run：第一段用漂移後的
+``_expected_claim_key(authority)`` 比對 persisted ``run.claim_key`` 必然落空，
+第二段 fallback 又只在 ``automatic`` 或 ``args["action"] == "resume"`` 時才跑，
+``start``／``intake`` 這兩個入口整段跳過。canonical_run 於是為 None，claim 路徑
+把它當成全新 claim，``_manager_create_workflow_run`` 再無條件把同 (repo, work_id)
+的 ongoing run 全部標成 superseded。
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from paulsha_cortex.coordinator import manager, work_actions
+from paulsha_cortex.coordinator.claim import load_work_authority
+from paulsha_cortex.coordinator.registry import JobRegistry
+from paulsha_cortex.coordinator.work_bridge import _artifact_rows
+from paulsha_cortex.coordinator.workflow import PlanningArtifactAuthority
+
+_REPO = "acme/demo"
+_WORK_ID = "fix-inflight-supersede"
+
+
+def _snapshot(path: Path, *, source_revisions: list[str]) -> Path:
+    """以 legacy row 形狀寫一份 durable snapshot。
+
+    ``source_revisions`` 是本測試唯一變動的軸——模擬 run 自己的 planning 卡把
+    artifact 寫進 governed roots 之後，monitor 把它們併入 authority 的效果。
+    """
+
+    path.write_text(
+        json.dumps(
+            {
+                "schema": "work-items-snapshot/v1",
+                "providers": {
+                    "github": {
+                        "provider_id": "github",
+                        "revision": "gh-1",
+                        "last_success_epoch": 100,
+                        "degraded": False,
+                    }
+                },
+                "work_items": [
+                    {
+                        "repo": _REPO,
+                        "work_id": _WORK_ID,
+                        "mapped_issues": [514],
+                        "mapped_prs": [],
+                        "mapped_openspec": [],
+                        "mapped_todo_paths": [
+                            f"docs/superpowers/workstreams/{_WORK_ID}/todo.md"
+                        ],
+                        "confirmed_todo": True,
+                        "auto_label": True,
+                        "source_revisions": source_revisions,
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+_BASE_REVISIONS = [f"todo:{_REPO}:docs/superpowers/workstreams/{_WORK_ID}/todo.md@identity:todo"]
+# run 自己的 brainstorming／writing-plans 卡發佈後，monitor 併入的新 confirmed
+# source——這正是讓 claim_key 漂移的那三筆。
+_PLANNING_REVISIONS = [
+    f"superpowers_spec:{_REPO}:docs/superpowers/specs/{_WORK_ID}-spec.md@identity:spec",
+    f"superpowers_spec:{_REPO}:docs/superpowers/specs/{_WORK_ID}-design.md@identity:design",
+    f"superpowers_plan:{_REPO}:docs/superpowers/plans/{_WORK_ID}.md@identity:plan",
+]
+
+
+def _claim(*, registry, starter, authority, state_path: Path, action: str):
+    """比照生產呼叫端：只有 ``run_auto_claim_scan`` 會帶 ``automatic=True``
+    （見 work_actions.run_auto_claim_scan），其餘入口一律 False。"""
+
+    return work_actions._claim_action(
+        args={"action": action},
+        authority=authority,
+        now_epoch=200,
+        state_path=state_path,
+        automatic=action == "auto-scan",
+        workflow_registry=registry,
+        workflow_starter=starter,
+    )
+
+
+@pytest.mark.parametrize("action", ["start", "intake", "auto-scan", "resume"])
+def test_inflight_run_survives_claim_after_own_planning_artifacts_drift_claim_key(
+    tmp_path: Path, action: str
+) -> None:
+    """#524 (A)：run 自己的 planning 產出讓 claim_key 漂移之後，任何 claim 入口
+    都不得把仍在 flight、未失敗的 run 作廢。
+
+    四個 action 一起參數化的理由：``auto-scan``／``resume`` 走的是既有 fallback
+    （#216 AC5 已保護，屬防迴歸），``start``／``intake`` 才是生產現場踩到的
+    未保護入口。四者行為必須一致，否則同一個 run 會因為呼叫端不同而生死有別。
+    """
+
+    state = tmp_path / "runs.json"
+    registry = JobRegistry(state_path=tmp_path / "jobs.json")
+    starter = work_actions._fallback_workflow_starter(registry, state)
+
+    before = load_work_authority(
+        repo=_REPO,
+        work_id=_WORK_ID,
+        snapshot_path=_snapshot(tmp_path / "before.json", source_revisions=_BASE_REVISIONS),
+    )
+    first = _claim(
+        registry=registry, starter=starter, authority=before, state_path=state, action=action
+    )
+    assert first["action"] == "claim"
+    run_id = first["run"]["run_id"]
+
+    # 把 run 推進到 build——即現場那個「四張卡全 passed」的健康 in-flight 狀態。
+    for phase in ("plan", "build"):
+        registry._manager_update_workflow_run(run_id, current_phase=phase)
+    inflight = registry.get_workflow_run(run_id)
+    assert inflight.status == "ongoing"
+    assert inflight.current_phase == "build"
+    assert inflight.facets == ()
+
+    # planning artifact 併入 authority -> digest 改變 -> claim_key 漂移。
+    after = load_work_authority(
+        repo=_REPO,
+        work_id=_WORK_ID,
+        snapshot_path=_snapshot(
+            tmp_path / "after.json", source_revisions=_BASE_REVISIONS + _PLANNING_REVISIONS
+        ),
+    )
+    assert work_actions._expected_claim_key(after) != inflight.claim_key
+
+    second = _claim(
+        registry=registry, starter=starter, authority=after, state_path=state, action=action
+    )
+
+    # 不得開新世代，也不得把原 run 作廢。
+    runs = registry.list_workflow_runs()
+    assert [run.run_id for run in runs] == [run_id], "in-flight run 不得被新 claim 換代"
+    survivor = registry.get_workflow_run(run_id)
+    assert survivor.status == "ongoing"
+    assert survivor.current_phase == "build"
+    assert "blocked" not in survivor.facets
+    assert second["action"] == "resume"
+    assert second["run"]["run_id"] == run_id
+
+
+def test_failed_run_stays_reclaimable(tmp_path: Path) -> None:
+    """#524 (A) 的反向邊界：``needs_human`` 的 run 不算「在 flight 且未失敗」，
+    既有的換代出口必須原封不動——保護傘不得寬到把已失敗的 run 也鎖死，否則
+    #416／#256 的 abandon→reclaim 復原路徑會一起壞掉。"""
+
+    state = tmp_path / "runs.json"
+    registry = JobRegistry(state_path=tmp_path / "jobs.json")
+    starter = work_actions._fallback_workflow_starter(registry, state)
+
+    before = load_work_authority(
+        repo=_REPO,
+        work_id=_WORK_ID,
+        snapshot_path=_snapshot(tmp_path / "before.json", source_revisions=_BASE_REVISIONS),
+    )
+    first = _claim(
+        registry=registry, starter=starter, authority=before, state_path=state, action="start"
+    )
+    run_id = first["run"]["run_id"]
+    registry._manager_update_workflow_run(run_id, facets=("needs_human",))
+
+    after = load_work_authority(
+        repo=_REPO,
+        work_id=_WORK_ID,
+        snapshot_path=_snapshot(
+            tmp_path / "after.json", source_revisions=_BASE_REVISIONS + _PLANNING_REVISIONS
+        ),
+    )
+    second = _claim(
+        registry=registry, starter=starter, authority=after, state_path=state, action="start"
+    )
+
+    # 已失敗的 run 仍可被換代取代（既有行為），不得被 #524 的保護傘鎖住。
+    assert second["action"] == "claim"
+    assert registry.get_workflow_run(run_id).status == "superseded"
+    assert len(registry.list_workflow_runs()) == 2
+
+
+def test_design_artifact_authority_kind_matches_publication_taxonomy(tmp_path: Path) -> None:
+    """#524 (B)：``docs/superpowers/specs/<slug>-design.md`` 必須以 kind
+    ``design`` 承接，下一代才吃得下前代殘留。
+
+    monitor 的 provider 規則把 ``docs/superpowers/specs/**/*.md`` 一律標成
+    ``superpowers_spec``（見 monitor/providers.py），``_artifact_rows`` 過去照單
+    全收成 kind ``spec``；但 planning 產線的 canonical destination
+    （planning_runtime.py 的 ``"design": f"docs/superpowers/specs/{slug}-design.md"``）
+    是 kind ``design``。兩邊 taxonomy 不一致，下一代 claim 時 seed 進
+    ``run.planning_authority`` 的 design 檔就掛著 kind ``spec``，等
+    brainstorming 用 kind ``design`` 重新發佈同一路徑，
+    ``_publish_planning_artifacts`` 的 ``owner.kind != row["kind"]`` 立刻
+    fail-closed，正是現場 ``workflow-7bb3a83c2c1fc37359d5`` 的
+    ``primary-artifact-write-rejected: ... lacks current planning authority:
+    ...-design.md``。
+    """
+
+    root = tmp_path / "repo"
+    spec_ref = f"docs/superpowers/specs/{_WORK_ID}-spec.md"
+    design_ref = f"docs/superpowers/specs/{_WORK_ID}-design.md"
+    plan_ref = f"docs/superpowers/plans/{_WORK_ID}.md"
+    for ref in (spec_ref, design_ref, plan_ref):
+        target = root / ref
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text("# 前代殘留\n", encoding="utf-8")
+
+    authority = load_work_authority(
+        repo=_REPO,
+        work_id=_WORK_ID,
+        snapshot_path=_snapshot(
+            tmp_path / "snapshot.json",
+            source_revisions=_BASE_REVISIONS + _PLANNING_REVISIONS,
+        ),
+    )
+    rows = {row["ref"]: row["kind"] for row in _artifact_rows(root, authority)}
+
+    assert rows[spec_ref] == "spec"
+    assert rows[design_ref] == "design", "design 檔不得以 kind spec 承接"
+    assert rows[plan_ref] == "plan"
+
+
+def test_next_generation_republishes_inherited_design_artifact(tmp_path: Path) -> None:
+    """#524 (B) 端到端：以 ``_artifact_rows`` seed 出來的 authority 承接前代殘留
+    後，下一代 brainstorming 重新發佈同一組路徑必須成功，不得再撞
+    ``planning artifact lacks current planning authority``。"""
+
+    root = tmp_path / "repo"
+    design_ref = f"docs/superpowers/specs/{_WORK_ID}-design.md"
+    residue = root / design_ref
+    residue.parent.mkdir(parents=True, exist_ok=True)
+    residue.write_text("# 前代殘留 design\n", encoding="utf-8")
+
+    authority = load_work_authority(
+        repo=_REPO,
+        work_id=_WORK_ID,
+        snapshot_path=_snapshot(
+            tmp_path / "snapshot.json",
+            source_revisions=_BASE_REVISIONS + _PLANNING_REVISIONS,
+        ),
+    )
+    row = next(row for row in _artifact_rows(root, authority) if row["ref"] == design_ref)
+    seeded = (
+        PlanningArtifactAuthority(
+            ref=design_ref,
+            kind=row["kind"],
+            work_id=_WORK_ID,
+            baseline_sha256=manager._sha256_path(residue),
+        ),
+    )
+
+    republished = "---\nstatus: accepted\n---\n# Design\n\n## Decisions\n\n新一代重新發佈。\n"
+    manager._publish_planning_artifacts(
+        str(root),
+        [{"kind": "design", "path": design_ref, "content": republished}],
+        work_id=_WORK_ID,
+        allowed_refs=(design_ref,),
+        authorities=seeded,
+    )
+    assert residue.read_text(encoding="utf-8") == republished


### PR DESCRIPTION
## 摘要

`#524`：planning 成功並進入 build 的 run 在 90 秒後被系統自行 supersede，其產出又
使後續世代 fail-closed。兩個問題同源於「**run 自己的成功產出改變了 authority**」。

Refs #524

## (A) 實際查證根因（與 issue 推測不同）

issue 推測是「claim 路徑沒把該 run 視為 active」的競態。查證後**根因更上游、且非
競態**：run 是被自己的成功產出擠掉識別的。

`claim_key` 與 `run.source_revision` 都由 `claim.work_authority_digest()` 導出，而該
digest 折入 `source_revisions`。monitor 的 repo provider 以
`docs/superpowers/specs/**/*.md`／`docs/superpowers/plans/**/*.md` 掃描產生
`superpowers_spec:`／`superpowers_plan:` source——run 自己的 `brainstorming`／
`writing-plans` 卡一旦把 spec/design/plan 寫進 governed roots，下一輪 correlation 就
把它們當成**新的 confirmed source** 併進同一個 work item，digest 因此改變、`claim_key`
隨之漂移。

以現場 snapshot 反算，三個世代的 `claim_key` 逐字對應三種 source 集合（決定性複現）：

| run | 對應的 planning-artifact source 集合 |
| --- | --- |
| `workflow-009fe9ab303df196209d` | 無（claim 當下尚未產出） |
| `workflow-952a3652afc51ab4f29c` | ＋2 個 `superpowers_spec`（spec／design） |
| `workflow-7bb3a83c2c1fc37359d5` | ＋2 個 `superpowers_spec` ＋1 個 `superpowers_plan` |

`work_actions._claim_action()` 的 active-run 偵測因此完全找不到那個 run：

1. 第一段用漂移後的 `_expected_claim_key(authority)` 比對 persisted `run.claim_key`
   → 必然落空。
2. 第二段 fallback 雖改用不受 planning 產出影響的穩定識別（issue_refs／openspec_refs），
   卻只在 `automatic`（auto-scan）或 `args["action"] == "resume"` 時才跑——
   **`start`／`intake` 這兩個 control-request 入口整段跳過**。

canonical_run 保持 `None`，claim 路徑把它當成全新 claim，
`registry._manager_create_workflow_run()` 再無條件把同 `(repo, work_id)` 的所有 ongoing
run 標成 `superseded`。這解釋了為何**沒有 work-abandon evidence**、facets 只有 supersede
順手加的 `blocked`。

新增測試以參數化四個入口驗證：修法前 `auto-scan`／`resume` 綠、`start`／`intake` 紅，
與上述分析完全吻合。

### 修法

`_claim_action()` 新增第三段、**不分呼叫端**的 in-flight 保護傘，判準有二、缺一不可：

1. **未失敗**：`run.status == "ongoing"` 且 `workflow_status(run) == "ongoing"`。兩個都
   要——`workflow_status()` 對 abandon 釋放過的 run（`superseded` ＋ `planning_released`）
   刻意回傳 `"ongoing"`，只看它會把 `#256`／`#416` 的 abandon→reclaim 出口一併鎖死；只看
   `run.status` 又會誤納 needs_human／needs_decomposition／blocked 的 run。
2. **漂移完全來自 run 自己的產出**：新增
   `claim.authority_digest_without_planning_outputs()`，剝除 `superpowers_spec:`／
   `superpowers_plan:` 前綴的 source 後重算 digest，必須與 run 持久化的 `source_revision`
   逐字相符。這兩類 source 依構造永遠是 planning phase 的**產出**——canonical row 解析
   （`_authority_from_canonical_row`）只認 `github_issue`／`github_pr`／`openspec`／`todo`
   四種 kind，`superpowers_*` 只會被 monitor 掃出來，不可能是 operator 在
   `.cortex/work-items.yaml` 宣告的授權來源。

判準 2 同時守住既有的 operator 逃生口：issue 開關、openspec revision、todo 成員變動等
**真正的** authority 變更不會被剝除，digest 依然不同，`start` 照舊開新世代
（`test_source_change_starts_new_canonical_run` 未改動仍綠）。

以現場資料驗證：剝除後的 digest 為
`039e89aab0a56384bce29bc89dc638c4e176f96873e9a4d89627b223d79a31bf`，與被誤 supersede 的
`workflow-009fe9ab303df196209d` 持久化的 `source_revision` **逐字相符**。

命中保護傘時以既有的 `#216 AC5` resume 分支收尾（該分支條件加上 `inflight_resume`）；
否則會落到 `decide_manual_start()` → `_existing()`，那裡對「persisted claim_key 與目前
authority 不符」是直接 `raise ValueError`，等於把自行 supersede 換成一個例外，run 一樣
救不回來。

`#519` 的 `SEMANTIC_RECLAIM_LIMIT` 計數邏輯（`work_actions.py` 熔斷段）**一字未動**。

## (B) 採「讓下一代能承接前代的 artifact authority」

**先更正 issue 的一項前提**：issue 描述「實測分類仍是 `content`，連 `recover-planning`
都不受理」。實測**不成立**——
`evidence/planning-recovery/workflow-7bb3a83c2c1fc37359d5-*.json` 的 `classification`
是 `environment`，`#416` 的 `_is_planning_authority_residue_failure()` carve-out 已正確
涵蓋 `planning artifact lacks current planning authority`。

真正的死結在更下游：即使 `recover-planning` 受理、重跑 brainstorm，也必然再撞同一堵牆。
成因是 **artifact kind taxonomy 兩邊不一致**——monitor 的 provider 規則把
`docs/superpowers/specs/**/*.md` 一律標成 `superpowers_spec`，而 planning 產線的
canonical destinations（`planning_runtime.py` 的
`{"spec": …-spec.md, "design": …-design.md, "plan": …}`）把同目錄下的 `*-design.md`
定義為 kind `design`。`work_bridge._artifact_rows()` 過去把這條差異直接抹平成 `spec`，
於是新世代 claim 時 seed 進 `run.planning_authority` 的 design 檔掛著 kind `spec`；等
brainstorming 用 kind `design` 對同一路徑重新發佈，`_publish_planning_artifacts()` 的
`owner.kind != row["kind"]` 立刻 fail-closed，訊息即現場的
`primary-artifact-write-rejected: ValueError: planning artifact lacks current planning
authority: …-design.md`。注意錯誤只點名 `-design.md`、不含 `-spec.md`，正是 kind 只在
design 這一項對不上的直接佐證。

**選擇理由**：另外兩條路線都治標不治本——把 supersede 殘留納入 `#416` carve-out 只是改
分類，`recover-planning` 重跑仍會撞同一個 kind 比對；在 supersede 時回滾該代發佈則會
刪掉 planning 唯一有價值的成功產出（現場那三份 artifact 正是本 issue 的關鍵證物）。

**修法**：新增 `work_bridge._superpowers_spec_kind()`，依檔名尾綴把 `*-design.md` 還原為
kind `design`，其餘維持 `spec`。只用檔名判定（不讀內容）——這與 `planning_runtime` 的
destinations 是同一組字面約定，也是唯一能在「尚未讀檔」的 claim 時點取得的訊號。

**遷移註記**：現存 jobs.json 有 54 個 run 的 `planning_authority` 把 `-design.md` 記成
kind `spec`，其中 52 個已終態（`superseded`／`done`，不再被重新掃描）、1 個在 `build`
phase（`start_canonical_workflow` 對非 `define` phase 早退，不會重掃）、1 個即本 issue 的
`workflow-7bb3a83c2c1fc37359d5`（已 `needs_human`，本就需 abandon）。因此不另加相容層。

## TDD

先寫失敗測試 `tests/test_claim_inflight_supersede_524.py`（7 項），再實作：

- `test_inflight_run_survives_claim_after_own_planning_artifacts_drift_claim_key`
  （參數化 `start`／`intake`／`auto-scan`／`resume`）——in-flight 且成功推進到 build 的
  run 不被新 claim supersede。
- `test_failed_run_stays_reclaimable`——反向邊界：`needs_human` 的 run 仍可換代，保護傘
  不得寬到把已失敗的 run 鎖死。
- `test_design_artifact_authority_kind_matches_publication_taxonomy`
- `test_next_generation_republishes_inherited_design_artifact`——端到端重現並修復
  `lacks current planning authority`。

## 驗證

- `python3 -m pytest -q`：**2553 passed, 49 subtests passed**（rebase 後基準 2546 ＋ 本次新增 7）。
- `#519`（PR #525）的 `tests/test_reclaim_budget_reset_519.py` **26 passed**，語意未被本次解衝突破壞。
- `python3 -m policy_check`（帶完整 PR context flags）：**EXIT=0**。

## Rebase 於 #525（2026-08-14）

`#519` 的 PR #525 先行 merge 進 main（merge commit `27c38fe`），同樣動到
`_claim_action()`。已 rebase 到 `origin/main`：**衝突只落在 `CHANGELOG.md`
`[Unreleased]` 的 `### Fixed` 區塊**（兩邊各自新增一則條目的純加法衝突），
`work_actions.py` 由 git 自動合併成功。

兩者語意互補、無實質衝突——#525 改的是「熔斷計數怎麼算」
（`_effective_superseded_generations()` ＋ append-only `reclaim_resets` 水位），
本 PR 改的是「claim 前先認出 in-flight run」。合併後的呼叫順序即為正解：
in-flight 保護傘在 `_claim_action()` 前段解析 `canonical_run`，命中時於
`#216 AC5` 分支直接 `return {"action": "resume"}`，**根本走不到**下游
`decision.action == "claim"` 才會執行的 `_effective_superseded_generations()`
計數——真正 in-flight 的 run 因此既不會被作廢，也不會白白消耗 reclaim 額度。
`_effective_superseded_generations()`／`reclaim_resets` 相關程式碼一字未動。

## 不在範圍

`#519` 熔斷額度重置（另有 PR 平行處理，本 PR 未動該段計數邏輯）、`#507` worktree 抹除、
`#523` collision。另記錄一個同類但本次未觸發的潛在缺口：run 自己的 `openspec-propose`
卡若讓 `authority.mapped_openspec` 長出新項，第二段 fallback 的
`run.openspec_refs == authority.mapped_openspec` 比對同樣會落空（本次現場的 work item
未宣告 openspec source，故未踩到）；新的保護傘不比對該欄位，已間接覆蓋。

## Checklist

- [x] `changelog.d/supersede-active-run.md` fragment 已新增且已 commit（R-09）
- [x] `CHANGELOG.md [Unreleased]` 有對應 entry
- [x] `VERSION` 未改（非 release PR）
- [x] 分支名符合 `feature/<slug>` 且不含點號（R-12）
- [x] 全套 pytest 通過（2527 passed）
- [x] policy_check 帶 PR 上下文跑，EXIT=0
- [x] zh-tw 註解／commit／PR body
- [x] 引用 issue 為 `Refs #524`（非 closing keyword），已上 `policy-exempt:issue-link`（R-17）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E7w9kaUxAzCCEk7piD5hfK
