### PR TITLE
docs(workstreams): 佈線 #518／#507／#527 三張 issue 的 work item

### DIFF
--- a/.cortex/work-items.yaml
+++ b/.cortex/work-items.yaml
@@ -650,3 +650,35 @@ work_items:
       - kind: path
         ref: 'docs/superpowers/workstreams/fix-read-repo-tier-fail-closed/todo.md'
     excludes: []
+  fix-brainstorm-revalidation-diagnostics:
+    title: 'fix-brainstorm-revalidation-diagnostics'
+    links:
+      - kind: path
+        ref: 'docs/superpowers/workstreams/fix-brainstorm-revalidation-diagnostics/todo.md'
+      - kind: github_issue
+        ref: 'hamanpaul/paulsha-cortex#514'
+    excludes: []
+  fix-instance-config-isolation:
+    title: 'fix-instance-config-isolation'
+    links:
+      - kind: path
+        ref: 'docs/superpowers/workstreams/fix-instance-config-isolation/todo.md'
+      - kind: github_issue
+        ref: 'hamanpaul/paulsha-cortex#518'
+    excludes: []
+  fix-planning-rollback-destroys-operator-work:
+    title: 'fix-planning-rollback-destroys-operator-work'
+    links:
+      - kind: path
+        ref: 'docs/superpowers/workstreams/fix-planning-rollback-destroys-operator-work/todo.md'
+      - kind: github_issue
+        ref: 'hamanpaul/paulsha-cortex#507'
+    excludes: []
+  fix-build-needs-human-diagnostics:
+    title: 'fix-build-needs-human-diagnostics'
+    links:
+      - kind: path
+        ref: 'docs/superpowers/workstreams/fix-build-needs-human-diagnostics/todo.md'
+      - kind: github_issue
+        ref: 'hamanpaul/paulsha-cortex#527'
+    excludes: []

--- a/changelog.d/workstream-518-507-527.md
+++ b/changelog.d/workstream-518-507-527.md
@@ -1,0 +1,17 @@
+# workstream-518-507-527
+
+- **`#518`／`#507`／`#527` workstream 佈線**——新增三份 todo 來源並在 `.cortex/work-items.yaml`
+  註冊對應 work item，讓 cortex 可自行受理這三張 issue：
+  - `fix-instance-config-isolation`（`#518`）：`PSC_PROJECT_CONFIG_ROOT` 未隨 instance 隔離，
+    `hippo` 繼承 `cortex` 的 `workspaces` 而掃描相同的 13 個 repo，per-process 節流閘門互不知情
+    致合計速率翻倍——`#506` secondary rate limit 的結構性成因之一。
+  - `fix-planning-rollback-destroys-operator-work`（`#507`）：`_restore_operator_tree()` 抹除
+    worktree 內除 `.git` 外全部內容再還原 T0 baseline，實測兩度造成不可復原的資料遺失
+    （operator 未追蹤檔、以及 cortex 自己前一代的合格 planning artifact）。
+  - `fix-build-needs-human-diagnostics`（`#527`）：build 階段無聲掛上 `needs_human`，
+    `evidence_refs` 空、`next_actions` 空、`cortex status` 不呈現；與 `#511`／`#514`／`#515`
+    同屬「狀態轉換未強制附帶可稽核理由」，為第四次命中。
+- 同時補上 `#514`（`fix-brainstorm-revalidation-diagnostics`）的 work item 註冊——PR `#522`
+  只佈了 todo.md，registry 條目先前僅存在於 operator 本機未提交狀態，正是 `#507` 抹除風險的
+  暴露面之一。
+- 純佈線變更：不改動任何執行路徑程式碼。

--- a/docs/superpowers/workstreams/fix-build-needs-human-diagnostics/todo.md
+++ b/docs/superpowers/workstreams/fix-build-needs-human-diagnostics/todo.md
@@ -1,0 +1,45 @@
+---
+status: accepted
+work_item: fix-build-needs-human-diagnostics
+---
+
+# fix-build-needs-human-diagnostics Todo
+
+`#527`：workflow run 在 `build` 階段被掛上 `needs_human`，但**沒有任何診斷訊號**——
+`evidence_refs` 為空、未產生 slice、`cortex status` 不呈現、`tick`／`complete` 皆回報無錯誤
+且不派工。operator 無從得知它在等什麼、還是已經壞掉。
+
+## 實測（run `workflow-6607ac1307feb02ffe06`，work_id `fix-brainstorm-revalidation-diagnostics`）
+
+```
+run: 6607ac13 | phase: build | status: ongoing | facets: ['needs_human']
+evidence_refs: []
+passed cards: workflow-claim, brainstorming, openspec-propose, writing-plans
+pending cards: worktree-isolation, tdd-red, subagent-build
+resolved_model_chain: {'builder': {'executor': 'codex', 'model_id': 'gpt-5.6-luna', 'source': 'default-envelope'}}
+```
+
+時間軸：`14:58:28` 進入 `build`、facets 為**空**；約兩分鐘後變成 `['needs_human']`，
+期間無 evidence 落檔、journal 無相關輸出。後續操作皆無效果且無訊息：
+`tick` → `dispatched: []`／`errors: []`；`complete` → `errors: []`／`needs_human: null`；
+`cortex status` → 本 run 不出現在 `slices`／`attention`／`ready`／`held` 任一清單；
+`cortex work show` → `next_actions: []`。
+
+## 系統性缺口（第四次命中）
+
+與 `#511`（PR `#513` 已修）／`#514`／`#515` 屬**同一類、不同階段**：狀態轉換未強制附帶
+可稽核理由。差別在於前三者至少留下一個（雖不完整的）reason 字串，**本情境連 reason 都沒有**
+——`needs_human` 是唯一訊號。四次獨立命中顯示這不是個別疏漏，而是不變式缺失。
+
+本 run 本身是好消息：它證明了 `#519` 的額度重置、`#524` 的 in-flight 保護傘與 artifact kind
+修正都已生效（claim 成功、繼承前代 artifact、150 秒後未被自我 supersede、builder 正確解析到
+`codex/gpt-5.6-luna`）。build 階段這道無聲停滯是鏈路上的下一層。
+
+## Tasks
+
+- [ ] **`needs_human` 必須永遠伴隨結構化理由**：所有設置該 facet 的路徑都要同時寫入 evidence（或在 run 記錄 `needs_human_reason`），無理由不得設置
+- [ ] **以不變式測試強制**：任何把 `needs_human` 加進 facets 的更新都必須提供 reason，涵蓋現有全部設置點（而非只補本次踩到的那一處）——這是與 `#511`／`#514`／`#515` 逐案補洞的差別所在
+- [ ] **`cortex status` 應呈現 needs_human 的 workflow run**，而非只呈現 slice；目前 run 停在 build 卻不出現在任何清單中
+- [ ] **`cortex work show` 的 `next_actions` 在此情境需給出可行動作**，或明確說明「無可用動作，原因為 X」，而非回空陣列
+- [ ] **釐清語意**：若此狀態實為設計上的等待（例如等待某外部條件），應以不同於 `needs_human` 的 facet 表達，避免與「需要人工介入」混淆
+- [ ] **找出並修正本次的實際成因**：build 階段從 facets 空 → `needs_human` 的那兩分鐘內究竟發生什麼（worktree-isolation／tdd-red 卡未派工），需在 evidence 中可追溯

--- a/docs/superpowers/workstreams/fix-build-needs-human-diagnostics/todo.md
+++ b/docs/superpowers/workstreams/fix-build-needs-human-diagnostics/todo.md
@@ -35,6 +35,36 @@ resolved_model_chain: {'builder': {'executor': 'codex', 'model_id': 'gpt-5.6-lun
 修正都已生效（claim 成功、繼承前代 artifact、150 秒後未被自我 supersede、builder 正確解析到
 `codex/gpt-5.6-luna`）。build 階段這道無聲停滯是鏈路上的下一層。
 
+## 根因（2026-08-14 已定位）
+
+`manager_daemon.py:983-996` 的 workflow resume 迴圈：
+
+```python
+except Exception as exc:
+    _log_error(exc, context={"action": "resume-workflow", "work_id": ..., ...})
+    registry._manager_update_workflow_run(
+        workflow.run_id, facets=("needs_human",), gate_status="running",
+    )
+```
+
+`_log_error()`（`:1404`）只 `print` 到 stderr，而 stderr 由 `scripts/service-manager.sh:149`
+（`>>"$manager_log" 2>&1`）導向 `~/.agents/log/manager.log`——**不進 journal、不進 evidence、
+不進 run**。run 上只留一個沒有理由的 `needs_human`，於是 `cortex status`／`work show`／
+`tick`／`complete` 四個介面同時沉默。例外物件 `exc` 就在 except 區塊內，資訊一直在手上，
+只是沒有寫進 run。
+
+本次的實際失敗（log 中該行，時間與 `14:58:28 進入 build → 約兩分鐘後 needs_human` 吻合）：
+
+```
+2026-08-14T06:59:32Z manager_daemon error: ValueError: worktree target already exists
+  (action=resume-workflow work_id=fix-brainstorm-revalidation-diagnostics ...)
+```
+
+`seams.py:70-77` `ScriptWorktreeCreator.create()` 對已存在的 target fail-closed。殘留物由
+**前一代**（即被 `#524` 自我 supersede 的那一代）建立、run 死亡時未回收，新一代的
+`worktree-isolation` 卡因此必然撞上。`manager.py:2180` 註解已記載此失敗模式（`#339`
+冪等過濾），但那層防護只涵蓋 slice 重複 fanout，不涵蓋「前代 run 殘留 → 後代 run 開新 worktree」。
+
 ## Tasks
 
 - [ ] **`needs_human` 必須永遠伴隨結構化理由**：所有設置該 facet 的路徑都要同時寫入 evidence（或在 run 記錄 `needs_human_reason`），無理由不得設置
@@ -42,4 +72,6 @@ resolved_model_chain: {'builder': {'executor': 'codex', 'model_id': 'gpt-5.6-lun
 - [ ] **`cortex status` 應呈現 needs_human 的 workflow run**，而非只呈現 slice；目前 run 停在 build 卻不出現在任何清單中
 - [ ] **`cortex work show` 的 `next_actions` 在此情境需給出可行動作**，或明確說明「無可用動作，原因為 X」，而非回空陣列
 - [ ] **釐清語意**：若此狀態實為設計上的等待（例如等待某外部條件），應以不同於 `needs_human` 的 facet 表達，避免與「需要人工介入」混淆
-- [ ] **找出並修正本次的實際成因**：build 階段從 facets 空 → `needs_human` 的那兩分鐘內究竟發生什麼（worktree-isolation／tdd-red 卡未派工），需在 evidence 中可追溯
+- [ ] **前代殘留回收**：run 被 supersede／abandon 時應回收其 build worktree，或讓後代能安全接手既有 worktree——否則 `#524` 每觸發一次就在磁碟留一顆地雷給下一代踩（與 `#478` 互為表裡：一邊只刪目錄未清 registry，一邊撞到目錄就 fail-closed）
+- [ ] **`recover-pre-candidate` 應出現在此情境的 `next_actions`**：該動作正是為「回收 worktree 後重跑」設計，但 operator 無從得知它可用——有動作卻不呈現等同沒有
+- [ ] **附帶：log 路徑未 instance-scope**：`scripts/service-manager.sh:135-136` 硬編 `$HOME/.agents/log/manager.log`，多 instance 錯誤交錯寫入同一檔案；與 `#518` 屬同一類 isolation 破口，修哪一邊需先裁定歸屬

--- a/docs/superpowers/workstreams/fix-instance-config-isolation/todo.md
+++ b/docs/superpowers/workstreams/fix-instance-config-isolation/todo.md
@@ -1,0 +1,35 @@
+---
+status: accepted
+work_item: fix-instance-config-isolation
+---
+
+# fix-instance-config-isolation Todo
+
+`#518`：`PSC_AGENTS_ROOT` 已隨 instance 隔離，但 `PSC_PROJECT_CONFIG_ROOT` 沒有。
+`hippo` instance 因此讀到 `cortex` instance 的 `project-cortex.yaml`、繼承其
+`workspaces`（operator 的多專案根目錄），掃出**與 cortex 完全相同的 13 個 GitHub repo**
+（實測兩者 provider 集合逐一相同）。
+
+危害不是重複工作，而是 **GitHub API 壓力平白翻倍且完全隱形**：`#512` 的
+`GitHubPressureGate` 是 per-process 的，兩個 instance 各自節流到設定速率、互不知情
+彼此的退避窗，合計卻是兩倍。這是 `#506` secondary rate limit 難以靠節流壓下來的
+結構性成因之一——實測 primary 配額幾乎未動（`core remaining 4879/5000`）而 secondary
+反覆觸發，正符合「總量不高、瞬時併發過密」的特徵。兩個 instance 的 snapshot
+各自看起來都正常，operator 沒有任何訊號可察覺。
+
+與 `scripts/service-manager.sh` `#375` 註解記載的是同一類 isolation 破口
+（`PSC_MANAGER_SPECS_DIR`／`PSC_COORDINATOR_ROOT`／`PSC_SPECS_ROOT` 刻意留在 operator 域）；
+差別在於 specs 共掃只造成派工範圍重疊，project config 共用則直接放大 API 壓力。
+
+已套用的 operator workaround（2026-08-14，非本 work item 的交付內容，僅為止血）：
+為 `hippo` instance 建立專屬 config root，provider 數 13 → 1，fleet 合計掃描面
+28 → 16。本 work item 要修的是**讓這件事不再需要 operator 手動發現與修補**。
+
+## Tasks
+
+- [ ] installer／`service-manager.sh` 建立 instance 時，`PSC_PROJECT_CONFIG_ROOT` 隨 `PSC_AGENTS_ROOT` 一併 instance-scope（含既有 instance 的遷移路徑，不得靜默沿用共用根）
+- [ ] 新 instance 的 config root 需自動具備最小可用內容：`project-cortex.yaml`（`workspaces` 不得為空清單，見 `monitor/config.py:_parse_workspaces`）與 `model-identities.yaml`，避免落入 `#476` 的 monitor restart loop
+- [ ] `cortex doctor` 新增檢查：偵測到多個 instance 解析到同一個 project config root 時明確告警，並列出重複掃描的 repo 數與涉及的 instance 名稱
+- [ ] 診斷需可在**單一 instance 內**判斷（不能要求 operator 去讀別的行程的 `/proc/<pid>/environ` 才發現問題）
+- [ ] 測試涵蓋：兩 instance 共用 config root（應告警）、各自隔離（應通過）、instance config root 缺 `project-cortex.yaml`（應給出可行動的錯誤而非 restart loop）
+- [ ] 與 `#506` 建議 7／8（token 層級共享退避窗與速率預算）互為補件：設定隔離後，多 instance 共用同一顆 token 的本質問題仍在，需在本 work item 的文件中明確指出殘餘風險與後續 issue

--- a/docs/superpowers/workstreams/fix-planning-rollback-destroys-operator-work/todo.md
+++ b/docs/superpowers/workstreams/fix-planning-rollback-destroys-operator-work/todo.md
@@ -1,0 +1,58 @@
+---
+status: accepted
+work_item: fix-planning-rollback-destroys-operator-work
+---
+
+# fix-planning-rollback-destroys-operator-work Todo
+
+`#507`：planning 階段偵測到 operator worktree 有變動時，`_restore_operator_tree()` 會
+**刪除該 worktree 內除 `.git` 以外的全部內容**，再從啟動當下（T0）的 baseline 複本還原。
+未追蹤檔不在 git 內，**不可復原**。
+
+## 根因（`coordinator/planning_runtime.py`）
+
+- `:375-378` — `operator_before = _tree_snapshot(worktree)` 與 `_copy_planning_sandbox(worktree, baseline)` 都在 T0 取樣。
+- `:423-437` — launcher 結束後（T1）以 `_tree_snapshot(worktree) != operator_before` 判定 `operator_dirty`，為真即還原。
+- `:205-224` — `_restore_operator_tree()` 逐一 `child.unlink()`／`shutil.rmtree(child)`（僅跳過 `.git`），再由 baseline 複製回來。
+
+亦即 **T0→T1 之間的任何差異都被歸因為 launcher 汙染**。但 launcher 本身已以
+`cwd=str(sandbox)`（可拋棄複本）執行，operator worktree 檢查本質上只是「防越界」的
+安全網；把安全網的補救動作設成整棵樹抹除還原，在多方並行（operator 手動編輯、其他
+agent、編輯器自動儲存、背景建置）的真實環境下，誤傷機率遠高於真正的越界。
+
+## 實測命中（Phase 1 dogfooding，兩次）
+
+1. **operator 工作被抹除**：run `workflow-0529388d8e290c8fb938`（`fix-rate-limit-classification`／
+   phase `define`）失敗時，抹掉 operator 在該視窗內新建的
+   `docs/superpowers/workstreams/fix-read-repo-tier-fail-closed/todo.md`。視窗**之前**已存在的
+   修改因已納入 baseline 而倖存，正好佐證「還原到 T0 baseline」的語意。
+   連帶後果：`cortex work link` 已把該 todo.md 寫進 `.cortex/work-items.yaml` 成為 path source，
+   檔案消失後 registry 留下懸空連結，`active_todo` 為假 → lifecycle 停在 `topic` → 不可 claim。
+2. **cortex 抹除自己的成功產出（嚴重度升級）**：`#514` 那一輪 planning 產出的三份合格 artifact
+   （前一代產生的未追蹤檔、不在後續那次的 baseline 內）被下一次失敗的 rollback 抹除，
+   導致 `workflow planning input missing`（`manager.py:3971`）、work item 卡死。
+   自外部備份還原後四個 `baseline_sha256` **全部 MATCH**，證實內容原本合法。
+   **含意：成功本身會被系統自己銷毀，且 git 救不回（ship 前皆未追蹤）。**
+
+## 第三則缺陷：非原子快照 race
+
+`_copy_planning_sandbox`（`:152-177`）以 `copytree` 取 baseline，過程非原子；在複製途中發生的
+operator 寫入可能落在 baseline 內或外，取決於遍歷順序——同一次編輯的多個檔案可能被拆成
+「一半保留、一半抹除」的不一致狀態。
+
+## 第四則缺陷：content 誤分類導致確定性死鎖
+
+worktree 汙染被分類為 `content`（`secondary-output-malformed: ... modified operator worktree`），
+而 `work_actions.py:2912` 依設計（`#393`）禁止 `content` 類失敗使用 `recover-planning`。
+於是這條路徑成為**永久死路**：唯一出口是 abandon，而 abandon 後重試會遇到完全相同的失敗。
+
+## Tasks
+
+- [ ] **預設不得改寫 operator worktree**：偵測到 dirty 時讓 planning run 失敗並在 evidence 報告 diff（路徑清單＋雜湊），處置權交回 operator；還原行為改為需明示 opt-in
+- [ ] **抹除前必須留下可復原備份**：若仍執行還原，先把當下 worktree 狀態存入 evidence 目錄（或 `git stash create` 等可回溯物件），並在錯誤訊息指明復原路徑
+- [ ] **縮小歸因範圍**：只還原 launcher 能證明寫過的路徑（provenance／fs 事件），而非整棵樹；至少排除 `.gitignore` 內容與已知 operator 產物（`.venv`、`build/`、`*.egg-info`）
+- [ ] **保護 cortex 自身的 planning 產出**：`docs/superpowers/{specs,plans}/**` 下由前代 run 產生的 artifact 不得被後續 rollback 抹除（否則 `manager.py:3971` 會把 work item 鎖死）
+- [ ] **baseline 取樣需一致**：非原子 `copytree` 的 race 需消除或明確界定（例如快照前後比對、或以 git 物件而非檔案樹為 baseline）
+- [ ] **並行保護**：planning 期間對該 repo 取 advisory lock 或記錄「planning 進行中」狀態供 operator／其他 agent 查詢
+- [ ] **失敗分類修正**：diff 明顯屬 operator 語意（tracked 檔的正常編輯、與 launcher 無 provenance 關聯的新檔）時分類為 `operator-concurrent-edit` 而非 launcher 汙染，且該分類**必須有非 abandon 的復原出口**（現況落入 `#393` 的 content 禁令而成死路）
+- [ ] **測試**：涵蓋「planning 期間第三方新增未追蹤檔」「planning 期間修改既有 tracked 檔」「前代 planning artifact 存在時發生 rollback」三情境，斷言內容不被銷毀且失敗訊息可辨識、可復原


### PR DESCRIPTION
## 摘要

為 `#518`／`#507`／`#527` 三張 issue 建立 work item 的 **todo 來源**與 registry 條目，
使 cortex 能自行受理這三項工作。cortex 的 lifecycle（`monitor/lifecycle.py:reduce_lifecycle`）
需要 `active_todo` 才會把 work item 由 `topic` 推進到 `todo`；缺此來源時 `cortex work start`
會以 `authority-not-startable` 拒絕、auto-claim 亦不受理。

## 內容

| work item | issue | 主題 |
|---|---|---|
| `fix-instance-config-isolation` | `#518` | `PSC_PROJECT_CONFIG_ROOT` 未隨 instance 隔離，GitHub API 壓力翻倍 |
| `fix-planning-rollback-destroys-operator-work` | `#507` | planning rollback 抹除整棵 operator worktree，實測兩度不可復原資料遺失 |
| `fix-build-needs-human-diagnostics` | `#527` | build 階段無聲掛上 `needs_human`，無 evidence、無 next_actions |

另補上 `#514`（`fix-brainstorm-revalidation-diagnostics`）的 registry 條目——PR `#522` 只佈了
todo.md，條目先前僅存在於 operator 本機未提交狀態，正是 `#507` 抹除風險的暴露面之一。

## 影響範圍

純佈線變更：新增三份 `docs/superpowers/workstreams/*/todo.md`、`.cortex/work-items.yaml`
新增四筆條目、一份 changelog fragment。**不觸及任何執行路徑程式碼**。
