### PR TITLE
fix(coordinator): auto-claim scan 節流並在限流時停手（#506）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@
 ## [Unreleased]
 
 ### Fixed
+- **Issue #506：auto-claim scan 是 fleet 對 GitHub 最大的持續壓力來源，且不受
+  `#512` 的節流閘門管轄**——`run_auto_claim_scan()` 對每個 `confirmed_todo` authority
+  的每個 mapped issue 各發一次即時 `gh api` 讀 label。實測 cortex instance 有 57 個
+  這樣的 issue，配上 `PSC_MANAGER_INTERVAL_SECONDS=30` 就是 **114 次／分鐘的連發**；
+  而 PR `#512` 的 `GitHubPressureGate` 只注入到 `monitor/providers.py`，`coordinator/`
+  這一側完全不受節流也不受退避管——monitor 進入退避時 manager 照打。實測把整個帳號
+  推進 secondary 懲罰窗（`gh api rate_limit` 顯示 `core remaining 4991/5000`，同一條
+  `--paginate` 請求 0.4 秒即 403），`provider-authority-rate-limited-canonical` 因而
+  擋下所有 claim，形成「限流 → 無法派工 → 修不了限流」的死結。修法兩項：(1) 逐次讀取
+  之間插入 `PSC_MANAGER_GITHUB_INTERVAL_MS`（預設 1000ms）的間隔，且**跨 authority
+  累計**——secondary limit 綁 token 不綁 repo，per-authority 重置節流等於沒有節流；
+  (2) 命中 rate-limit 型失敗即**中止整輪掃描**，其餘 authority 標成
+  `github-rate-limited-scan-aborted`。舊行為是每個 authority 各自撞一次才 break 自己
+  那圈，於是限流期間每個 tick 仍送出 O(authorities) 次必定失敗的請求，每一次都在延長
+  懲罰窗——「越限流越打、越打越限流」的正回饋。非限流的讀取失敗維持舊語意（只擋該
+  authority），以測試釘住。
 - **Issue #524：planning 成功的 in-flight run 被自行 supersede，其產出又使後續
   世代 fail-closed**——`claim_key`／`run.source_revision` 都由
   `work_authority_digest()` 導出，而該 digest 折入 `source_revisions`；run 自己的

--- a/changelog.d/506-manager-scan-pressure.md
+++ b/changelog.d/506-manager-scan-pressure.md
@@ -1,0 +1,11 @@
+# 506-manager-scan-pressure
+
+- **`#506` workstream 補上 2026-08-14 的量測結論**——主壓力源是 **manager**（`work_actions.py:3425`
+  的 auto-claim scan 每 tick 對每個 mapped issue 各發一次即時 `gh api` 讀 label，實測
+  30s × 57 issue ＝ **114 次／分鐘**），而不是先前一直在調的 monitor（1200s × 約 300 次
+  ≈ 15 次／分鐘）。PR `#512` 的 `GitHubPressureGate` 只注入到 `monitor/providers.py`，
+  **`coordinator/` 這一側完全不受節流也不受退避管**——monitor 退避期間 manager 照打。
+  這是先前三輪 monitor 參數調校（1000ms → 2000ms → 收斂掃描面）都無法讓 provider 離開
+  degraded 的原因。新增四項驗收任務：閘門涵蓋 coordinator、scan 改消費 monitor 既有資料
+  或加 TTL 快取、`doctor` 呈現每分鐘請求數、重新檢視 `PSC_MANAGER_INTERVAL_SECONDS` 預設值。
+- 純文件變更：不改動任何執行路徑程式碼。

--- a/changelog.d/506-manager-scan-pressure.md
+++ b/changelog.d/506-manager-scan-pressure.md
@@ -8,4 +8,12 @@
   這是先前三輪 monitor 參數調校（1000ms → 2000ms → 收斂掃描面）都無法讓 provider 離開
   degraded 的原因。新增四項驗收任務：閘門涵蓋 coordinator、scan 改消費 monitor 既有資料
   或加 TTL 快取、`doctor` 呈現每分鐘請求數、重新檢視 `PSC_MANAGER_INTERVAL_SECONDS` 預設值。
-- 純文件變更：不改動任何執行路徑程式碼。
+- **`#506` 修正：auto-claim scan 的 GitHub 請求壓力控制**——
+  - **攤平**：逐 issue 讀 label 之間插入 `PSC_MANAGER_GITHUB_INTERVAL_MS`（預設 1000ms）的
+    間隔，且間隔跨 authority 累計（secondary limit 綁 token 不綁 repo，per-authority 重置
+    等於沒有節流）。設 0 停用，保留舊行為。
+  - **限流即停手**：一旦命中 rate-limit 型失敗（沿用 `github_rate_limit.is_rate_limit_signal`）
+    就中止整輪掃描，其餘 authority 標成 `github-rate-limited-scan-aborted`。舊行為是每個
+    authority 各自撞一次才 break 自己那圈，於是限流期間每個 tick 仍送出 O(authorities) 次
+    必定失敗的請求，每一次都在延長帳號層級懲罰窗——「越限流越打、越打越限流」的正回饋。
+  - 非限流的讀取失敗維持舊語意（只擋該 authority，其餘照跑），以測試釘住。

--- a/docs/superpowers/workstreams/fix-rate-limit-classification/todo.md
+++ b/docs/superpowers/workstreams/fix-rate-limit-classification/todo.md
@@ -29,3 +29,27 @@ foreign review／digest 共用同一個帳號配額。實測（2026-08-13 fleet 
 - [ ] 全域 API 預算節流：scan／auto-advance／foreign review／digest 共用一個 in-process rate budget，逼近上限時降頻而非硬撞
 - [ ] 測試涵蓋：secondary 403（remaining>0）不得走憑證路徑、primary 403（remaining=0）睡到 reset、`gh auth status` 誤報 invalid 時的交叉驗證分支
 
+## 2026-08-14 量測：主壓力源是 manager，不是 monitor，且節流閘門沒涵蓋它
+
+PR `#512` 把 `GitHubPressureGate` 注入到 `monitor/providers.py` 的 provider，**`coordinator/`
+這一側完全沒有節流也沒有退避**。實測數字：
+
+| 來源 | 週期 | 每輪呼叫 | 換算 |
+|---|---|---|---|
+| cortex **manager**（`work_actions.py:3425` per-issue label 讀取） | **30s** | 57 個 mapped issue | **114 次／分鐘** |
+| hippo manager | 60s | 10 | 10 次／分鐘 |
+| cortex monitor（有節流） | 1200s | 約 300 | 約 15 次／分鐘 |
+
+manager 一支就是 monitor 的七倍以上、24 小時不停。**monitor 進入退避時 manager 照打**——
+一邊踩煞車一邊踩油門，這是先前反覆調 monitor 參數（1000ms → 2000ms → 收斂掃描面）都無法讓
+provider 離開 degraded 的原因。
+
+複現：`gh api --method GET --paginate --jq '.[]' "repos/<owner>/<repo>/issues?state=all&per_page=100"`
+**0.4 秒即回 403**（懲罰窗作用中），同時 `gh api rate_limit` 顯示 `core remaining 4991/5000`
+——再次印證這是 secondary 而非配額耗盡。
+
+- [ ] **`GitHubPressureGate` 必須涵蓋 coordinator 側所有 `gh` 呼叫**（退避窗既是帳號層級，就該由所有打 GitHub 的路徑共用；現況 monitor 退避期間 manager 仍照打）
+- [ ] **auto-claim scan 不得 per-tick per-issue 打即時 API**：monitor 的 `GitHubWorkProvider` 每輪已把 issues 連同 labels 全撈回來，coordinator 應消費那份資料或加 TTL 快取，而不是同一份資料由兩個子系統各自向 GitHub 索取、其中一個還高頻
+- [ ] **`doctor` 呈現「manager 週期 × mapped issue 數 ＝ 每分鐘請求數」**：這個數字目前對 operator 完全不可見，是本次繞遠路的直接原因
+- [ ] **重新檢視 `PSC_MANAGER_INTERVAL_SECONDS` 預設值**，並讓它隨 mapped issue 數自適應（或至少在超過安全速率時 fail-loud 告警）
+

--- a/paulsha_cortex/coordinator/work_actions.py
+++ b/paulsha_cortex/coordinator/work_actions.py
@@ -19,6 +19,7 @@ from uuid import uuid4
 
 from paulsha_cortex.config import paths
 from paulsha_cortex._yaml import safe_load
+from paulsha_cortex.github_rate_limit import is_rate_limit_signal
 
 from .claim import (
     ClaimCandidate,
@@ -3687,6 +3688,35 @@ def _recover_repair_commit_action(
     }
 
 
+#: `#506`：auto-claim scan 逐 issue 讀 label 之間的最小間隔（毫秒）。
+#:
+#: 這條路徑是 fleet 對 GitHub 最大的持續壓力來源——實測 cortex instance 有 57 個
+#: `confirmed_todo` authority 帶 mapped issue，每個 tick 就是 57 次連發的 `gh api`，
+#: 且 PR `#512` 的 `GitHubPressureGate` 只注入到 `monitor/providers.py`，coordinator
+#: 這一側完全不受節流也不受退避管（monitor 退避期間 manager 照打）。GitHub 的
+#: secondary／abuse-detection limit 抓的正是這種連發形狀，實測會把整個帳號推進
+#: 懲罰窗，進而讓 `provider-authority-rate-limited-canonical` 擋下所有 claim。
+#:
+#: 這裡採用與 monitor 相同的「攤平」策略而非降頻：把一輪的 N 次請求攤在 N × interval
+#: 秒內送出。設 0 可完全停用（保留舊行為，供測試與單 issue 部署使用）。
+DEFAULT_AUTO_CLAIM_GITHUB_INTERVAL_MS = 1000
+
+
+def _auto_claim_github_interval_seconds() -> float:
+    raw = os.environ.get("PSC_MANAGER_GITHUB_INTERVAL_MS", "").strip()
+    if not raw:
+        return DEFAULT_AUTO_CLAIM_GITHUB_INTERVAL_MS / 1000.0
+    try:
+        value = int(raw)
+    except ValueError as error:
+        raise ValueError(
+            "PSC_MANAGER_GITHUB_INTERVAL_MS 必須是非負整數（毫秒）"
+        ) from error
+    if value < 0:
+        raise ValueError("PSC_MANAGER_GITHUB_INTERVAL_MS 必須是非負整數（毫秒）")
+    return value / 1000.0
+
+
 def run_auto_claim_scan(
     *,
     snapshot_path: str | Path | None = None,
@@ -3696,6 +3726,7 @@ def run_auto_claim_scan(
     workflow_registry=None,
     workflow_starter=None,
     readiness_checker=None,
+    sleeper: Callable[[float], None] = time.sleep,
 ) -> list[dict[str, Any]]:
     """Project the durable Monitor snapshot into Manager-owned auto claims."""
 
@@ -3713,13 +3744,35 @@ def run_auto_claim_scan(
     if workflow_starter is None:
         workflow_starter = _fallback_workflow_starter(workflow_registry, resolved_state)
     results: list[dict[str, Any]] = []
+    github_interval = _auto_claim_github_interval_seconds()
+    issued_github_reads = 0
+    # #506：一旦本輪撞到 rate limit 就整批停手。舊行為是每個 authority 各自撞一次
+    # 才 break 自己那圈，於是限流期間每個 tick 仍會送出 O(authorities) 次必定失敗
+    # 的請求——每一次都在延長帳號層級的懲罰窗，形成「越限流越打、越打越限流」的
+    # 正回饋。退避窗綁 token 不綁 repo，因此一次命中就足以判定整輪無效。
+    rate_limited = False
     for authority in authorities:
         if not authority.confirmed_todo:
             continue
         live_auto_label = False
         if authority.mapped_issues:
+            # 只有真的需要打 GitHub 的 authority 才受這道停手影響；沒有 mapped
+            # issue 的 authority 本來就不讀 label，限流與它無關，照常 claim。
+            if rate_limited:
+                results.append(
+                    {
+                        "repo": authority.repo,
+                        "work_id": authority.work_id,
+                        "action": "blocked",
+                        "reason": "github-rate-limited-scan-aborted",
+                    }
+                )
+                continue
             issue_reads_failed = False
             for issue in authority.mapped_issues:
+                if github_interval > 0 and issued_github_reads:
+                    sleeper(github_interval)
+                issued_github_reads += 1
                 completed = runner(
                     ["gh", "api", f"repos/{authority.repo}/issues/{issue}"],
                     shell=False,
@@ -3727,12 +3780,20 @@ def run_auto_claim_scan(
                     text=True,
                 )
                 if getattr(completed, "returncode", None) != 0:
+                    stderr = getattr(completed, "stderr", "") or ""
+                    stdout = getattr(completed, "stdout", "") or ""
+                    if is_rate_limit_signal(f"{stderr}\n{stdout}"):
+                        rate_limited = True
                     results.append(
                         {
                             "repo": authority.repo,
                             "work_id": authority.work_id,
                             "action": "blocked",
-                            "reason": "github-label-read-failed",
+                            "reason": (
+                                "github-rate-limited"
+                                if rate_limited
+                                else "github-label-read-failed"
+                            ),
                         }
                     )
                     issue_reads_failed = True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,6 +29,10 @@ def _clear_runtime_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     unset_root = tmp_path / "unset-psc-root-guard"
     monkeypatch.setenv("PSC_AGENTS_ROOT", str(unset_root / "agents"))
     monkeypatch.setenv("PSC_CONFIG_ROOT", str(unset_root / "config"))
+    # #506：auto-claim scan 的 GitHub 節流在生產預設 1000ms／請求。測試不打真的
+    # GitHub，也不該為了節流而真的 sleep——預設關閉，需要驗證節流行為的測試自行
+    # setenv 覆寫並注入 sleeper。
+    monkeypatch.setenv("PSC_MANAGER_GITHUB_INTERVAL_MS", "0")
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_work_actions_auto_claim_pressure.py
+++ b/tests/test_work_actions_auto_claim_pressure.py
@@ -1,0 +1,281 @@
+"""`#506` 迴歸測試：auto-claim scan 的 GitHub 請求壓力控制。
+
+實測背景：`run_auto_claim_scan` 對每個 `confirmed_todo` authority 的每個 mapped
+issue 各發一次即時 `gh api` 讀 label。cortex instance 有 57 個這樣的 issue，
+`PSC_MANAGER_INTERVAL_SECONDS=30` 時等於 **114 次／分鐘的連發**，而 PR `#512` 的
+`GitHubPressureGate` 只注入到 `monitor/providers.py`，coordinator 這一側完全不受
+節流也不受退避管——monitor 在退避期間 manager 照打。實測把整個帳號推進 secondary
+懲罰窗，`provider-authority-rate-limited-canonical` 因而擋下所有 claim。
+
+本檔驗證兩件事：
+
+1. **攤平**：連續的 issue 讀取之間插入設定的間隔（跨 authority 也算，因為壓力綁的
+   是 token 不是 repo）。
+2. **限流即停手**：一旦命中 rate-limit 型失敗就中止整輪掃描。舊行為是每個 authority
+   各自撞一次才 break 自己那圈，於是限流期間每個 tick 仍送出 O(authorities) 次必定
+   失敗的請求，每一次都在延長懲罰窗——「越限流越打、越打越限流」的正回饋。
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from paulsha_cortex.coordinator import work_actions
+from paulsha_cortex.coordinator.registry import JobRegistry
+
+
+def _snapshot(path: Path, count: int = 3) -> Path:
+    path.write_text(
+        json.dumps(
+            {
+                "schema": "work-items-snapshot/v1",
+                "providers": {
+                    "github": {
+                        "provider_id": "github",
+                        "revision": "gh-1",
+                        "last_success_epoch": 100,
+                        "degraded": False,
+                    }
+                },
+                "work_items": [
+                    {
+                        "repo": "acme/demo",
+                        "work_id": f"demo-{index}",
+                        "mapped_issues": [10 + index],
+                        "mapped_prs": [],
+                        "mapped_openspec": [f"demo-{index}"],
+                        "mapped_todo_paths": [f"docs/todo-{index}.md"],
+                        "confirmed_todo": True,
+                        "auto_label": True,
+                        "source_revisions": [
+                            f"issue:{10 + index}@open",
+                            f"openspec:demo-{index}@1",
+                        ],
+                    }
+                    for index in range(1, count + 1)
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _ok_runner(argv, **kwargs):
+    return SimpleNamespace(
+        returncode=0,
+        stdout=json.dumps({"labels": [{"name": "cortex:auto-on-going"}]}),
+        stderr="",
+    )
+
+
+def _rate_limited_runner(argv, **kwargs):
+    return SimpleNamespace(
+        returncode=1,
+        stdout="",
+        stderr=(
+            "gh: API rate limit exceeded for user ID 1. "
+            "If you reach out to GitHub Support for help ... (HTTP 403)"
+        ),
+    )
+
+
+def test_issue_reads_are_throttled_across_authorities(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """三個 authority 各一個 issue ＝ 三次讀取，之間插入兩段間隔。
+
+    間隔跨 authority 累計——secondary limit 綁 token 不綁 repo，per-authority
+    重置節流等於沒有節流。
+    """
+
+    monkeypatch.setenv("PSC_MANAGER_GITHUB_INTERVAL_MS", "250")
+    snapshot = _snapshot(tmp_path / "snapshot.json")
+    state = tmp_path / "runs.json"
+    registry = JobRegistry(state_path=tmp_path / "jobs.json")
+    slept: list[float] = []
+
+    work_actions.run_auto_claim_scan(
+        snapshot_path=snapshot,
+        state_path=state,
+        now=lambda: 200,
+        runner=_ok_runner,
+        workflow_registry=registry,
+        workflow_starter=work_actions._fallback_workflow_starter(registry, state),
+        sleeper=slept.append,
+    )
+
+    assert slept == [0.25, 0.25], "第一次讀取前不睡，其後每次讀取前各睡一次"
+
+
+def test_zero_interval_disables_throttle(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("PSC_MANAGER_GITHUB_INTERVAL_MS", "0")
+    snapshot = _snapshot(tmp_path / "snapshot.json")
+    state = tmp_path / "runs.json"
+    registry = JobRegistry(state_path=tmp_path / "jobs.json")
+    slept: list[float] = []
+
+    work_actions.run_auto_claim_scan(
+        snapshot_path=snapshot,
+        state_path=state,
+        now=lambda: 200,
+        runner=_ok_runner,
+        workflow_registry=registry,
+        workflow_starter=work_actions._fallback_workflow_starter(registry, state),
+        sleeper=slept.append,
+    )
+
+    assert slept == []
+
+
+def test_rate_limit_aborts_whole_scan_after_one_request(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """命中限流後不得再對其餘 authority 發任何請求。"""
+
+    monkeypatch.setenv("PSC_MANAGER_GITHUB_INTERVAL_MS", "0")
+    snapshot = _snapshot(tmp_path / "snapshot.json", count=5)
+    state = tmp_path / "runs.json"
+    registry = JobRegistry(state_path=tmp_path / "jobs.json")
+    calls: list[tuple[str, ...]] = []
+
+    def counting_runner(argv, **kwargs):
+        calls.append(tuple(argv))
+        return _rate_limited_runner(argv, **kwargs)
+
+    result = work_actions.run_auto_claim_scan(
+        snapshot_path=snapshot,
+        state_path=state,
+        now=lambda: 200,
+        runner=counting_runner,
+        workflow_registry=registry,
+        workflow_starter=work_actions._fallback_workflow_starter(registry, state),
+        sleeper=lambda _seconds: None,
+    )
+
+    assert len(calls) == 1, "整輪只應送出一次請求就停手"
+    assert result[0]["reason"] == "github-rate-limited"
+    assert [row["reason"] for row in result[1:]] == [
+        "github-rate-limited-scan-aborted"
+    ] * 4
+    assert registry.list_workflow_runs() == []
+
+
+def test_non_rate_limit_failure_still_isolates_per_authority(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """非限流的讀取失敗維持舊語意：只擋該 authority，其餘照跑。"""
+
+    monkeypatch.setenv("PSC_MANAGER_GITHUB_INTERVAL_MS", "0")
+    snapshot = _snapshot(tmp_path / "snapshot.json", count=3)
+    state = tmp_path / "runs.json"
+    registry = JobRegistry(state_path=tmp_path / "jobs.json")
+
+    def selective_runner(argv, **kwargs):
+        if argv[-1].endswith("/issues/12"):
+            return SimpleNamespace(returncode=1, stdout="", stderr="gh: Not Found (HTTP 404)")
+        return _ok_runner(argv, **kwargs)
+
+    result = work_actions.run_auto_claim_scan(
+        snapshot_path=snapshot,
+        state_path=state,
+        now=lambda: 200,
+        runner=selective_runner,
+        workflow_registry=registry,
+        workflow_starter=work_actions._fallback_workflow_starter(registry, state),
+        sleeper=lambda _seconds: None,
+    )
+
+    by_work = {row["work_id"]: row for row in result}
+    assert by_work["demo-2"]["reason"] == "github-label-read-failed"
+    assert by_work["demo-1"]["action"] == "claim"
+    assert by_work["demo-3"]["action"] == "claim"
+    assert {run.work_id for run in registry.list_workflow_runs()} == {"demo-1", "demo-3"}
+
+
+def test_rate_limited_scan_still_claims_authorities_needing_no_github_read(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """停手只影響真的要打 GitHub 的 authority。
+
+    沒有 mapped issue 的 authority 本來就不讀 label，限流與它無關——若連它也一併
+    中止，等於讓一次無關的 403 停掉本來完全可行的派工。
+    """
+
+    monkeypatch.setenv("PSC_MANAGER_GITHUB_INTERVAL_MS", "0")
+    snapshot = tmp_path / "snapshot.json"
+    snapshot.write_text(
+        json.dumps(
+            {
+                "schema": "work-items-snapshot/v1",
+                "providers": {
+                    "github": {
+                        "provider_id": "github",
+                        "revision": "gh-1",
+                        "last_success_epoch": 100,
+                        "degraded": False,
+                    }
+                },
+                "work_items": [
+                    {
+                        "repo": "acme/demo",
+                        "work_id": "with-issue",
+                        "mapped_issues": [11],
+                        "mapped_prs": [],
+                        "mapped_openspec": ["with-issue"],
+                        "mapped_todo_paths": ["docs/todo-1.md"],
+                        "confirmed_todo": True,
+                        "auto_label": True,
+                        "source_revisions": ["issue:11@open", "openspec:with-issue@1"],
+                    },
+                    {
+                        "repo": "acme/demo",
+                        "work_id": "no-issue",
+                        "mapped_issues": [],
+                        "mapped_prs": [],
+                        "mapped_openspec": ["no-issue"],
+                        "mapped_todo_paths": ["docs/todo-2.md"],
+                        "confirmed_todo": True,
+                        "auto_label": True,
+                        "source_revisions": ["openspec:no-issue@1"],
+                    },
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    state = tmp_path / "runs.json"
+    registry = JobRegistry(state_path=tmp_path / "jobs.json")
+
+    result = work_actions.run_auto_claim_scan(
+        snapshot_path=snapshot,
+        state_path=state,
+        now=lambda: 200,
+        runner=_rate_limited_runner,
+        workflow_registry=registry,
+        workflow_starter=work_actions._fallback_workflow_starter(registry, state),
+        sleeper=lambda _seconds: None,
+    )
+
+    by_work = {row["work_id"]: row for row in result}
+    assert by_work["with-issue"]["reason"] == "github-rate-limited"
+    # 沒有 mapped issue 的 authority 仍走完 _claim_action（此處因 auto_label 為 False
+    # 而落在 needs_human——那是既有語意，與限流無關）；重點是它**沒有**被停手擋掉。
+    assert by_work["no-issue"].get("reason") != "github-rate-limited-scan-aborted"
+    assert by_work["no-issue"]["action"] == "needs_human"
+
+
+def test_invalid_interval_env_fails_loud(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("PSC_MANAGER_GITHUB_INTERVAL_MS", "-1")
+    with pytest.raises(ValueError, match="PSC_MANAGER_GITHUB_INTERVAL_MS"):
+        work_actions._auto_claim_github_interval_seconds()
+
+    monkeypatch.setenv("PSC_MANAGER_GITHUB_INTERVAL_MS", "abc")
+    with pytest.raises(ValueError, match="PSC_MANAGER_GITHUB_INTERVAL_MS"):
+        work_actions._auto_claim_github_interval_seconds()


### PR DESCRIPTION
## 摘要

`#506` 的**請求壓力控制**部分。issue 其餘項目（label 讀取批次化、`doctor` 呈現每分鐘請求數、
`GitHubPressureGate` 全面涵蓋 coordinator）仍待處理，故本 PR 不關閉 issue。

## 根因

`run_auto_claim_scan()` 對每個 `confirmed_todo` authority 的每個 mapped issue 各發一次即時
`gh api` 讀 label。實測 cortex instance 有 **57** 個這樣的 issue，配上
`PSC_MANAGER_INTERVAL_SECONDS=30` 就是 **114 次／分鐘的連發、24 小時不停**；而 PR `#512` 的
`GitHubPressureGate` 只注入到 `monitor/providers.py`，`coordinator/` 這一側**完全不受節流也
不受退避管**——monitor 進入退避時 manager 照打。

實測後果：整個帳號被推進 GitHub abuse-detection 懲罰窗，**所有 REST 呼叫全域 403**
（連 `gh api repos/<owner>/<repo>` 都拒），而 `gh api rate_limit` 同時顯示
`core remaining 4991/5000`、全部 bucket 健康——證實是 secondary 而非配額耗盡。
provider 因此 degraded，`provider-authority-rate-limited-canonical` 擋下所有 claim，
形成「限流 → 無法派工 → 修不了限流」的死結。停掉全部 fleet 服務後花了約 50 分鐘才排空。

## 修法

1. **攤平**：逐次 issue 讀取之間插入 `PSC_MANAGER_GITHUB_INTERVAL_MS`（預設 1000ms）的間隔，
   且**跨 authority 累計**——secondary limit 綁 token 不綁 repo，per-authority 重置節流等於
   沒有節流。設 0 停用，保留舊行為。
2. **限流即停手**：命中 rate-limit 型失敗（沿用 `github_rate_limit.is_rate_limit_signal`，
   與 `#370` 同一套分類器）即中止整輪掃描，其餘需要 GitHub 讀取的 authority 標成
   `github-rate-limited-scan-aborted`。舊行為是每個 authority 各自撞一次才 break 自己那圈，
   於是限流期間每個 tick 仍送出 O(authorities) 次必定失敗的請求，每一次都在延長懲罰窗
   ——「越限流越打、越打越限流」的正回饋。
3. **停手範圍最小化**：沒有 mapped issue 的 authority 本來就不讀 label，不受停手影響、照常
   claim（以測試釘住）。

## 驗收

- [x] `changelog.d/506-manager-scan-pressure.md` fragment 已新增並 commit
- [x] `CHANGELOG.md [Unreleased]` 已補對應 entry
- [x] 新增 `tests/test_work_actions_auto_claim_pressure.py`（攤平間隔、停用、限流停手只送一次
      請求、非限流失敗維持 per-authority 隔離、無 issue 的 authority 不受影響、env 非法值 fail-loud）
- [x] 全套測試通過：**2559 passed**
- [x] `policy-check` 帶完整 PR context：25 pass / 0 fail
