### PR TITLE
fix(coordinator): claim 的 provider 檢查 scope 到實際依賴的 provider（#530）

### DIFF
--- a/.cortex/work-items.yaml
+++ b/.cortex/work-items.yaml
@@ -682,3 +682,9 @@ work_items:
       - kind: github_issue
         ref: 'hamanpaul/paulsha-cortex#527'
     excludes: []
+  fix-claim-provider-scope:
+    title: 'fix-claim-provider-scope'
+    links:
+      - kind: path
+        ref: 'docs/superpowers/workstreams/fix-claim-provider-scope/todo.md'
+    excludes: []

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@
 ## [Unreleased]
 
 ### Fixed
+- **Issue #530：claim 的 GitHub provider 檢查是 repo 範圍且無條件，把一次 GitHub 可用性
+  事故放大成整個 fleet 的派工停擺**——`_authority_from_canonical_row` 在驗完「必須有
+  todo-kind 來源」之後，完全不看那些 source 由誰供應，直接要求 `github:<repo>` 為 `ok`。
+  實測 2026-08-14 帳號遭 abuse-detection 封鎖 REST 期間，confirmed sources 只有一筆
+  `kind=todo`／`provider=repo:...` 的 work item（`fix-instance-config-isolation`）被
+  `provider-authority-rate-limited-canonical` 擋死——它要讀的 todo 就在磁碟上、內容從未變動。
+  連「修 GitHub 壓力問題」本身都因此做不了，形成「限流 → 無法派工 → 修不了限流」的死結。
+  修法為**收斂適用範圍而非放寬強度**：新增 `WorkAuthority.requires_github_authority`
+  （預設 True），由 confirmed sources 的 `provider` 前綴（`github:`／`github-terminal:`）
+  與 `kind` 判定；為 False 且 last-known-good 齊全時才豁免。`provider` 欄位缺席一律保守視為
+  需要 GitHub 權威。同時修正第二層放大：`_authority_is_fresh` 不再以 GitHub 的 last-success
+  時鐘判定不依賴 GitHub 之 authority 的過期。第三層（`reduce_lifecycle` 的
+  `provider_degraded_freeze` 與 `hard_gates.auto_claim`）留待後續。
 - **Issue #506：auto-claim scan 是 fleet 對 GitHub 最大的持續壓力來源，且不受
   `#512` 的節流閘門管轄**——`run_auto_claim_scan()` 對每個 `confirmed_todo` authority
   的每個 mapped issue 各發一次即時 `gh api` 讀 label。實測 cortex instance 有 57 個

--- a/changelog.d/claim-provider-scope.md
+++ b/changelog.d/claim-provider-scope.md
@@ -1,0 +1,26 @@
+# claim-provider-scope
+
+- **`#530`：claim 的 GitHub provider 檢查改為 scope 到 work item 實際依賴的 provider**——
+  `coordinator/claim.py:_authority_from_canonical_row` 原本無條件要求 `github:<repo>` 為 `ok`，
+  完全不看該 work item 的 confirmed sources 由誰供應。於是 GitHub REST 不可用時，**連權威
+  全部來自本機檔案系統 provider（`repo:<owner>/<name>`）的 work item 也無法 claim**——實測
+  2026-08-14 帳號遭 abuse-detection 封鎖期間，只掛一份 workstream `todo.md` 的
+  `fix-instance-config-isolation` 被 `provider-authority-rate-limited-canonical` 擋死，
+  而它要讀的 todo 就在磁碟上、內容從未變動。一次 GitHub 可用性事故因此放大成整個 fleet 的
+  派工全面停擺，包括「修 GitHub 壓力問題」本身，形成
+  「限流 → 無法派工 → 修不了限流」的死結。
+- fail-closed 對**確實掛著 GitHub source** 的 work item 仍然必要（provider 過時代表可能去做
+  一張已被關閉、或 label 已被移除的 issue），故本次只收斂適用範圍，不放寬強度：
+  - 新增 `WorkAuthority.requires_github_authority`（預設 **True**，保守）；由 confirmed
+    sources 的 `provider` 前綴判定，`github:` 與 `github-terminal:` 皆屬 GitHub 來源，
+    `kind in {github_issue, github_pr}` 為第二道保險（remote todo／openspec 的 kind 看不出來源）。
+  - **資訊缺席一律保守**：`provider` 欄位缺失或非字串時視為可能來自 GitHub，維持既有嚴格
+    fail-closed；放寬只發生在 source 明確標示了非 GitHub provider 時——亦即有正面證據，
+    而非「沒看到證據」。
+  - 豁免仍要求 last-known-good（`revision` 與 `last_success_at` 齊全）；缺 revision／壞
+    timestamp 屬真正的 authority 損毀，照常拒絕。
+- 同步修正**第二層放大**：`_authority_is_fresh` 以 GitHub 的 last-success 當時鐘判定過期，
+  對不依賴 GitHub 的 authority 是錯配（其內容新鮮度已由 `source_revisions` 承載）。只修
+  provider 檢查而不修這裡，claim 仍會在 `decide_manual_start`／auto-claim 被擋下。
+- 第三層放大（`reduce_lifecycle` 的 `provider_degraded_freeze` 與 `hard_gates.auto_claim`）
+  記錄在 `docs/superpowers/workstreams/fix-claim-provider-scope/todo.md` 待辦，本 PR 不動。

--- a/docs/superpowers/workstreams/fix-claim-provider-scope/todo.md
+++ b/docs/superpowers/workstreams/fix-claim-provider-scope/todo.md
@@ -1,0 +1,34 @@
+---
+status: accepted
+work_item: fix-claim-provider-scope
+---
+
+# fix-claim-provider-scope Todo
+
+`#530`：`claim.py` 的 GitHub provider 檢查是 **repo 範圍且無條件**——不看該 work item
+實際依賴哪些 provider。於是 GitHub 不可用時，連權威完全來自本機檔案系統
+（`repo:<owner>/<name>` provider）的 work item 也無法 claim，一次可用性事故被放大成
+整個 fleet 的派工全面停擺，包括「修 GitHub 壓力問題」本身。
+
+## 已完成（本 work item 的第一階段）
+
+- [x] `_authority_from_canonical_row`：以 confirmed sources 的 `provider` 前綴（含
+      `github-terminal:`）與 `kind` 判定 `requires_github_authority`；為 False 且
+      last-known-good 齊全時豁免 `status != ok` 的擋阻
+- [x] `WorkAuthority.requires_github_authority` 欄位（預設 True，保守）
+- [x] `_authority_is_fresh`：不依賴 GitHub 的 authority 不受 `PROVIDER_MAX_AGE_SECONDS`
+      新鮮度擋阻（三層放大的第二層）
+- [x] 資訊缺席保守處理：`provider` 欄位缺失時維持嚴格 fail-closed
+- [x] 測試涵蓋純本機來源可 claim、GitHub 來源仍 fail-closed、`github-terminal:` 來源仍
+      fail-closed、缺 `provider` 保守、缺 last-known-good 仍拒絕
+
+## 待辦（第三層放大與後續）
+
+- [ ] `monitor/lifecycle.py:reduce_lifecycle` 的 `provider_degraded_freeze` 同樣 scope 到
+      相關 provider——目前它排在規則序最前面，GitHub 一 degraded 就把**所有** work item
+      凍在 `topic`，`cortex work show` 因此看不到可行動作
+- [ ] `hard_gates.auto_claim` 以 `github:<repo> stale` 為條件關閉，同一問題的第三個面向
+- [ ] 有 GitHub 來源的 work item 是否也該接受「有界過期」的 last-known-good（比照
+      `#370` follow-up 的退休語境豁免），並在 claim 結果標示 authority 新鮮度，讓 ship／
+      merge 等真正需要即時狀態的關卡自行再驗——需裁決
+- [ ] 文件化：`docs/unified-work-lifecycle.md` 說明「哪些 provider 會擋哪些 work item」

--- a/paulsha_cortex/coordinator/claim.py
+++ b/paulsha_cortex/coordinator/claim.py
@@ -176,6 +176,12 @@ class WorkAuthority:
     github_provider_revision: str
     github_last_success_epoch: float
     snapshot_hash: str
+    #: `#530`：本 work item 的 confirmed sources 是否真的由 GitHub provider 供應。
+    #: 為 False 時（權威全部來自本機檔案系統 provider，例如只掛一份 workstream
+    #: `todo.md` 的 work item），GitHub provider 的健康度與新鮮度與這筆工作無關，
+    #: 不得用來擋 claim——否則一次 GitHub 可用性事故會放大成整個 fleet 的派工停擺。
+    #: 預設 True（保守：legacy schema 與未宣告來源者一律沿用嚴格 fail-closed）。
+    requires_github_authority: bool = True
 
     @classmethod
     def _verified(
@@ -194,6 +200,7 @@ class WorkAuthority:
         provider_id: str = GITHUB_PROVIDER_ID,
         last_success_epoch: float,
         snapshot_hash: str,
+        requires_github_authority: bool = True,
     ) -> "WorkAuthority":
         authority = object.__new__(cls)
         object.__setattr__(authority, "repo", repo)
@@ -209,6 +216,9 @@ class WorkAuthority:
         object.__setattr__(authority, "github_provider_revision", provider_revision)
         object.__setattr__(authority, "github_last_success_epoch", last_success_epoch)
         object.__setattr__(authority, "snapshot_hash", snapshot_hash)
+        object.__setattr__(
+            authority, "requires_github_authority", bool(requires_github_authority)
+        )
         return authority
 
 
@@ -544,6 +554,25 @@ def _authority_from_canonical_row(
             work_id=work_id_label,
             field="work_id",
         )
+    # #530：這筆 work item 的 confirmed sources 究竟由誰供應？只有真的用到 GitHub
+    # 的 work item 才該被 GitHub provider 的健康度擋下。
+    #
+    # 判準以 provider id 前綴為主（`github:`／`github-terminal:` 都是 GitHub 來源，
+    # `repo:` 是本機檔案系統），kind 為第二道保險——remote todo／openspec 由
+    # `github-terminal:` 供應，只看 kind 會漏掉它們。
+    #
+    # **資訊缺席一律保守**：`provider` 欄位缺失或非字串時視為「可能來自 GitHub」，
+    # 維持既有的嚴格 fail-closed。放寬只發生在 source 明確標示了非 GitHub provider
+    # 的情況——亦即我們有正面證據證明這筆工作不依賴 GitHub，而不是「沒看到證據」。
+    def _source_needs_github(source: dict) -> bool:
+        if source.get("kind") in {"github_issue", "github_pr"}:
+            return True
+        provider = source.get("provider")
+        if not isinstance(provider, str) or not provider:
+            return True
+        return provider.startswith(GITHUB_PROVIDER_ID)
+
+    requires_github_authority = any(_source_needs_github(source) for source in confirmed)
     provider_id = f"github:{repo}"
     github = providers.get(provider_id)
     if not isinstance(github, dict):
@@ -586,7 +615,16 @@ def _authority_from_canonical_row(
         have_last_known_good = (
             isinstance(revision, str) and bool(revision) and isinstance(last_success_at, str)
         )
-        if not (allow_rate_limited_last_known_good and rate_limited and have_last_known_good):
+        # #530：不依賴 GitHub 的 work item（confirmed sources 全部來自本機檔案系統
+        # provider）只要 snapshot 還留有 last-known-good 的 revision/timestamp，就
+        # 沿用它建構 authority——GitHub 此刻健不健康與這筆工作無關。這道豁免與上面
+        # 的退休語境豁免（#370 follow-up）條件並列而非取代：兩者都要求
+        # last-known-good 齊全，差別只在放行的理由。缺 revision／壞 timestamp 仍嚴格拒絕。
+        github_authority_waived = not requires_github_authority and have_last_known_good
+        if not (
+            github_authority_waived
+            or (allow_rate_limited_last_known_good and rate_limited and have_last_known_good)
+        ):
             if status != "ok":
                 if rate_limited:
                     raise AuthorityValidationError(
@@ -716,6 +754,7 @@ def _authority_from_canonical_row(
         provider_id=provider_id,
         last_success_epoch=last_success,
         snapshot_hash=snapshot_hash,
+        requires_github_authority=requires_github_authority,
     )
 
 
@@ -1202,6 +1241,13 @@ def _authority_is_fresh(authority: WorkAuthority, *, now_epoch: int | float) -> 
         or not math.isfinite(float(now_epoch))
     ):
         raise ValueError("claim clock must be finite")
+    # #530：新鮮度檢查衡量的是「GitHub 觀測有多舊」。權威不依賴 GitHub 的 work
+    # item（sources 全部來自本機檔案系統 provider）沒有這個維度可言——它的內容新鮮度
+    # 已由 `source_revisions` 承載，拿 GitHub 的 last-success 時間去擋它是錯配。
+    # 這是 `#530` 三層放大中的第二層；只修 `_authority_from_canonical_row` 而不修
+    # 這裡，claim 仍會在 decide_manual_start／auto-claim 被擋下。
+    if not getattr(authority, "requires_github_authority", True):
+        return True
     age = float(now_epoch) - authority.github_last_success_epoch
     return 0 <= age <= PROVIDER_MAX_AGE_SECONDS
 

--- a/tests/test_claim_provider_scope_530.py
+++ b/tests/test_claim_provider_scope_530.py
@@ -1,0 +1,220 @@
+"""`#530`：claim 的 GitHub provider 檢查必須 scope 到 work item 實際依賴的 provider。
+
+背景（2026-08-14 實測）：GitHub REST 遭 abuse-detection 封鎖期間，**所有** work item
+都無法 claim——包含權威完全來自本機檔案系統 provider（`repo:<owner>/<name>`）、
+與 GitHub 毫無關係的 work item：
+
+```
+$ cortex work start fix-instance-config-isolation --repo hamanpaul/paulsha-cortex
+錯誤: AuthorityValidationError: durable GitHub provider authority rate-limited
+  (reason=provider-authority-rate-limited-canonical, provider_id=github:hamanpaul/paulsha-cortex)
+```
+
+該 work item 的 confirmed sources 只有一筆 `kind=todo`、`provider=repo:...`。
+`_authority_from_canonical_row` 卻無條件要求 `github:<repo>` 為 `ok`，於是一次 GitHub
+可用性事故被放大成整個 fleet 的派工全面停擺——連「修 GitHub 壓力問題」本身都做不了。
+
+fail-closed 對**確實掛著 GitHub source** 的 work item 是必要的（provider 過時代表可能去做
+一張已被關閉、或 label 已被移除的 issue），錯的是把它套在整個 repo 上。
+
+本檔釘住三件事：
+1. 純本機來源的 work item 在 GitHub provider degraded 時仍可取得 authority；
+2. 有 GitHub 來源的 work item 維持既有的嚴格 fail-closed（不得因本修正而鬆掉）；
+3. `provider` 欄位缺席時保守視為需要 GitHub 權威（資訊缺席 ≠ 正面證據）。
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from paulsha_cortex.coordinator.claim import (
+    PROVIDER_MAX_AGE_SECONDS,
+    REASON_PROVIDER_RATE_LIMITED_CANONICAL,
+    AuthorityValidationError,
+    _authority_is_fresh,
+    load_work_authority,
+)
+
+_DEGRADED_GITHUB = {
+    "status": "degraded",
+    "revision": "gh-rev-last-known-good",
+    "last_success_at": "2026-08-14T08:59:31Z",
+    "diagnostics": [
+        "github rate limit backoff active; retry in 64s",
+        "github:acme/demo stale",
+    ],
+}
+
+
+def _snapshot(path: Path, *, sources: list[dict], providers: dict | None = None) -> Path:
+    path.write_text(
+        json.dumps(
+            {
+                "schema": "work-items-snapshot/v1",
+                "providers": providers or {"github:acme/demo": dict(_DEGRADED_GITHUB)},
+                "work_items": [
+                    {
+                        "repo": "acme/demo",
+                        "work_id": "local-only-work",
+                        "sources": sources,
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _local_todo_source() -> dict:
+    return {
+        "confidence": "confirmed",
+        "kind": "todo",
+        "ref": "docs/superpowers/workstreams/local-only-work/todo.md",
+        "source_id": "todo:acme/demo:docs/superpowers/workstreams/local-only-work/todo.md",
+        "revision": "local-sha256:abc123",
+        "provider": "repo:acme/demo",
+    }
+
+
+def test_local_only_work_item_claimable_while_github_provider_degraded(
+    tmp_path: Path,
+) -> None:
+    """本案的核心：權威全來自本機檔案的 work item 不得被 GitHub 狀態擋死。"""
+
+    snapshot = _snapshot(tmp_path / "snapshot.json", sources=[_local_todo_source()])
+
+    authority = load_work_authority(
+        repo="acme/demo", work_id="local-only-work", snapshot_path=snapshot
+    )
+
+    assert authority.requires_github_authority is False
+    assert authority.confirmed_todo is True
+    assert authority.mapped_todo_paths == (
+        "docs/superpowers/workstreams/local-only-work/todo.md",
+    )
+    # last-known-good 仍被沿用，authority 的識別欄位不因豁免而改變形狀。
+    assert authority.github_provider_id == "github:acme/demo"
+    assert authority.github_provider_revision == "gh-rev-last-known-good"
+
+
+def test_local_only_authority_is_never_stale_by_github_clock(tmp_path: Path) -> None:
+    """第二層放大：`_authority_is_fresh` 用 GitHub 的 last-success 當時鐘。
+
+    只修 `_authority_from_canonical_row` 而不修這裡，claim 仍會在
+    `decide_manual_start`／auto-claim 被 `authority-stale` 擋下。
+    """
+
+    snapshot = _snapshot(tmp_path / "snapshot.json", sources=[_local_todo_source()])
+    authority = load_work_authority(
+        repo="acme/demo", work_id="local-only-work", snapshot_path=snapshot
+    )
+
+    # GitHub 觀測已經舊了一整天，對純本機來源的 work item 不構成過期。
+    ancient = authority.github_last_success_epoch + PROVIDER_MAX_AGE_SECONDS * 100
+    assert _authority_is_fresh(authority, now_epoch=ancient) is True
+
+
+def test_github_sourced_work_item_still_fails_closed(tmp_path: Path) -> None:
+    """回歸防護：真的掛著 GitHub source 的 work item 不得因本修正而放行。"""
+
+    snapshot = _snapshot(
+        tmp_path / "snapshot.json",
+        sources=[
+            _local_todo_source(),
+            {
+                "confidence": "confirmed",
+                "kind": "github_issue",
+                "ref": "acme/demo#42",
+                "source_id": "github_issue:acme/demo#42",
+                "revision": "github:NODE:2026-08-14T00:00:00Z",
+                "provider": "github:acme/demo",
+            },
+        ],
+    )
+
+    with pytest.raises(AuthorityValidationError) as excinfo:
+        load_work_authority(
+            repo="acme/demo", work_id="local-only-work", snapshot_path=snapshot
+        )
+
+    assert excinfo.value.reason_code == REASON_PROVIDER_RATE_LIMITED_CANONICAL
+    assert excinfo.value.provider_id == "github:acme/demo"
+
+
+def test_remote_todo_from_github_terminal_provider_still_fails_closed(
+    tmp_path: Path,
+) -> None:
+    """`github-terminal:` 供應的 remote todo／openspec 也是 GitHub 來源。
+
+    只看 `kind` 會漏掉它們（kind 是 `todo`／`openspec`，看不出來源），
+    所以判準以 provider id 前綴為主。
+    """
+
+    snapshot = _snapshot(
+        tmp_path / "snapshot.json",
+        sources=[
+            {
+                "confidence": "confirmed",
+                "kind": "todo",
+                "ref": "docs/superpowers/workstreams/remote-work/todo.md",
+                "source_id": "todo:acme/demo:remote",
+                "revision": "github-blob:deadbeef",
+                "provider": "github-terminal:acme/demo",
+            }
+        ],
+    )
+
+    with pytest.raises(AuthorityValidationError) as excinfo:
+        load_work_authority(
+            repo="acme/demo", work_id="local-only-work", snapshot_path=snapshot
+        )
+
+    assert excinfo.value.reason_code == REASON_PROVIDER_RATE_LIMITED_CANONICAL
+
+
+def test_missing_provider_field_is_treated_conservatively(tmp_path: Path) -> None:
+    """資訊缺席 ≠ 正面證據：沒宣告 `provider` 時維持嚴格 fail-closed。
+
+    放寬只發生在 source 明確標示了非 GitHub provider 的情況。
+    """
+
+    source = _local_todo_source()
+    del source["provider"]
+    snapshot = _snapshot(tmp_path / "snapshot.json", sources=[source])
+
+    with pytest.raises(AuthorityValidationError) as excinfo:
+        load_work_authority(
+            repo="acme/demo", work_id="local-only-work", snapshot_path=snapshot
+        )
+
+    assert excinfo.value.reason_code == REASON_PROVIDER_RATE_LIMITED_CANONICAL
+
+
+def test_waiver_still_requires_last_known_good(tmp_path: Path) -> None:
+    """豁免不是無條件放行：缺 revision／timestamp 仍嚴格拒絕。
+
+    authority 的 `provider_revision`／`last_success_epoch` 是必要欄位，沒有
+    last-known-good 就無法建構——那是真正的 authority 損毀，不是可用性問題。
+    """
+
+    snapshot = _snapshot(
+        tmp_path / "snapshot.json",
+        sources=[_local_todo_source()],
+        providers={
+            "github:acme/demo": {
+                "status": "degraded",
+                "revision": "",
+                "last_success_at": "2026-08-14T08:59:31Z",
+                "diagnostics": ["github rate limit backoff active; retry in 64s"],
+            }
+        },
+    )
+
+    with pytest.raises(AuthorityValidationError):
+        load_work_authority(
+            repo="acme/demo", work_id="local-only-work", snapshot_path=snapshot
+        )


### PR DESCRIPTION
## 摘要

Closes #530。

`coordinator/claim.py:_authority_from_canonical_row` 的 GitHub provider 檢查是 **repo 範圍
且無條件**——就在它上方幾行，同一個函式才剛算出 `confirmed` sources、驗過「必須存在
todo-kind 來源」，接著卻完全不看那些 source 由誰供應，直接要求 `github:<repo>` 為 `ok`。

實測（2026-08-14，帳號遭 GitHub abuse-detection 封鎖 REST 期間）：

```
$ cortex work start fix-instance-config-isolation --repo hamanpaul/paulsha-cortex
錯誤: AuthorityValidationError: durable GitHub provider authority rate-limited
  (reason=provider-authority-rate-limited-canonical, provider_id=github:hamanpaul/paulsha-cortex)
```

該 work item 的 confirmed sources 只有一筆：`kind=todo`、`provider=repo:hamanpaul/paulsha-cortex`
（本機檔案系統）。**零個 GitHub 來源**，要讀的 todo 就在磁碟上、內容從未變動，卻因為同一個
repo 的、與它無關的 provider 在退避中而不可 claim。一次 GitHub 可用性事故因此放大成整個
fleet 的派工全面停擺——包括「修 GitHub 壓力問題」本身，形成
「限流 → 無法派工 → 修不了限流」的死結。

## 修法：收斂適用範圍，不放寬強度

fail-closed 對**確實掛著 GitHub source** 的 work item 仍然必要（provider 過時代表可能去做
一張已被關閉、或 label 已被移除的 issue）。本 PR 只把它 scope 到實際依賴：

- 新增 `WorkAuthority.requires_github_authority`（預設 **True**，保守）。判準以 confirmed
  sources 的 `provider` 前綴為主——`github:` 與 `github-terminal:` 皆屬 GitHub 來源，
  `repo:` 是本機檔案系統；`kind in {github_issue, github_pr}` 為第二道保險（remote todo／
  openspec 由 `github-terminal:` 供應，光看 kind 看不出來源）。
- **資訊缺席一律保守**：`provider` 欄位缺失或非字串時視為可能來自 GitHub，維持既有嚴格
  fail-closed。放寬只發生在 source 明確標示了非 GitHub provider 時——有正面證據，而非
  「沒看到證據」。
- 豁免仍要求 last-known-good（`revision` 與 `last_success_at` 齊全）。缺 revision／壞
  timestamp 是真正的 authority 損毀，照常拒絕。
- 同步修正**第二層放大**：`_authority_is_fresh` 以 GitHub 的 last-success 當時鐘判定過期，
  對不依賴 GitHub 的 authority 是錯配（其內容新鮮度已由 `source_revisions` 承載）。只修
  provider 檢查而不修這裡，claim 仍會在 `decide_manual_start`／auto-claim 被擋下。

## 不在本 PR 範圍

第三層放大——`monitor/lifecycle.py:reduce_lifecycle` 的 `provider_degraded_freeze`
（排在規則序最前面，GitHub 一 degraded 就把所有 work item 凍在 `topic`）與
`hard_gates.auto_claim`——記錄在
`docs/superpowers/workstreams/fix-claim-provider-scope/todo.md` 待辦。

## 驗收

- [x] `changelog.d/claim-provider-scope.md` fragment 已新增並 commit
- [x] `CHANGELOG.md [Unreleased]` 已補對應 entry
- [x] 新增 `tests/test_claim_provider_scope_530.py`：純本機來源可 claim、不受 GitHub 時鐘
      判定過期、GitHub 來源仍 fail-closed、`github-terminal:` 來源仍 fail-closed、
      缺 `provider` 保守、缺 last-known-good 仍拒絕
- [x] 全套測試通過：**2565 passed**
- [x] `policy-check` 帶完整 PR context
