### PR TITLE
fix(monitor): degraded 保留分支不得複製已轉移歸屬的 source（#523）

### DIFF
--- a/.cortex/work-items.yaml
+++ b/.cortex/work-items.yaml
@@ -688,3 +688,9 @@ work_items:
       - kind: path
         ref: 'docs/superpowers/workstreams/fix-claim-provider-scope/todo.md'
     excludes: []
+  fix-degraded-retention-collision:
+    title: 'fix-degraded-retention-collision'
+    links:
+      - kind: path
+        ref: 'docs/superpowers/workstreams/fix-degraded-retention-collision/todo.md'
+    excludes: []

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@
 ## [Unreleased]
 
 ### Fixed
+- **Issue #523：degraded 保留分支的 ownership collision 讓 work model refresh 永久失敗**
+  ——`monitor/lifecycle.py` 的保留分支只比對 work_id、不比對 sources，source 歸屬由
+  fallback work item 轉移到新宣告的 work item 時，舊 fallback 連同舊 sources 被整筆放回，
+  兩者同時宣稱擁有同一個 source → `validate_ownership()` raise。而該例外發生在
+  `WorkSnapshot.__post_init__`、早於 `replace_durably()`，那一輪算出的 provider 新狀態
+  （含「backoff 已結束」）一併被丟棄，`previous` 永遠停在崩潰前那版、`degraded` 永遠為真，
+  下一輪重演——provider 無法離開 degraded，因為記錄它恢復的那次寫入正是拋例外的那次寫入。
+  修法：保留時剝除已被本輪認領的 source（全數被認領即整筆丟棄，原本無 source 者維持既有
+  語意）；projection 驗證失敗降級為保留上一版 projection ＋ 讓 provider 觀測落地，並把
+  失敗原因寫入 provider diagnostics。**成因更正**：先前記為「時序競態」有誤，真正的觸發
+  條件是 `correlation.degraded`，亦即限流本身——`#506` 與本缺陷互鎖。
 - **Issue #530：claim 的 GitHub provider 檢查是 repo 範圍且無條件，把一次 GitHub 可用性
   事故放大成整個 fleet 的派工停擺**——`_authority_from_canonical_row` 在驗完「必須有
   todo-kind 來源」之後，完全不看那些 source 由誰供應，直接要求 `github:<repo>` 為 `ok`。

--- a/changelog.d/degraded-retention-collision.md
+++ b/changelog.d/degraded-retention-collision.md
@@ -1,0 +1,26 @@
+# degraded-retention-collision
+
+- **`#523`：degraded 保留分支造成 ownership collision，且該 collision 會讓 work model
+  refresh 永久失敗**——兩個獨立缺陷疊成一個永不自癒的死鎖：
+  - `monitor/lifecycle.py` 的 degraded 保留分支只比對 **work_id**、不比對 **sources**。
+    當某個 source 的歸屬從 fallback work item（`correlation.py:_fallback_work_id` 產生的
+    `issue:<ref>`）轉移到新宣告的 work item 時，本輪 correlation 已不再產生該 fallback，
+    於是它「不在 `projected_ids` 裡」→ 連同**舊的 sources** 被整筆放回 → 兩個 work item
+    同時宣稱擁有同一個 source → `work_snapshot.validate_ownership()` raise。
+    修法：保留時剝除已被本輪認領的 source；原本有 source 而全數被認領者整筆丟棄
+    （內容已完整轉移，留空殼無意義）。原本就沒有 source 的 previous item 維持既有語意。
+  - `monitor/work_api.py`：上述例外發生在 `WorkSnapshot.__post_init__`、**早於**
+    `replace_durably()`，於是那一輪算出的 provider 新狀態（包含「rate limit backoff
+    已結束、provider 恢復 ok」這個事實）**一併被丟棄**。`previous` 因此永遠停在崩潰前
+    那一版、`correlation.degraded` 永遠為真，下一輪以相同輸入重演——**provider 無法離開
+    degraded，因為記錄它恢復的那次寫入正是拋例外的那次寫入**。修法：projection 是衍生
+    資料、provider 觀測是第一手事實，兩者不該同生共死；projection 驗證失敗時降級為
+    「保留上一版 projection ＋ 讓新的 provider 觀測落地」，並把失敗原因寫進該輪
+    provider 的 `diagnostics` 讓 operator 看得見，而非無聲降級。
+- 實測現場：全部 52 個 provider 的 `last_attempt_at` 同時凍在同一時刻（含根本不碰 GitHub
+  的 `repo:`／`workflow:` provider），而 `work-items.snapshot.json` 的 mtime 仍每 30 秒更新
+  ——外觀完全正常，與單純限流難以區分；唯一線索在 `journalctl -u <instance>-monitor`。
+- **成因更正**：先前把它記為「時序競態」（unlink → recover → re-link 即可）。那次受控實驗
+  之所以成功，只是因為當下 provider 恰好健康、保留分支根本沒跑。真正的觸發條件是
+  `correlation.degraded`——亦即**限流本身**。`#506` 的限流與本缺陷因此互鎖：限流讓
+  provider degraded → registry 一有變更就 collision → collision 讓 provider 永遠 degraded。

--- a/docs/superpowers/workstreams/fix-degraded-retention-collision/todo.md
+++ b/docs/superpowers/workstreams/fix-degraded-retention-collision/todo.md
@@ -1,0 +1,27 @@
+---
+status: accepted
+work_item: fix-degraded-retention-collision
+---
+
+# fix-degraded-retention-collision Todo
+
+`#523`：degraded 保留分支的 ownership collision，以及讓它永不自癒的死鎖。
+
+## 已完成
+
+- [x] `lifecycle.py` 保留分支剝除已被本輪認領的 source；原本有 source 而全數被認領者整筆丟棄
+- [x] 原本就沒有 source 的 previous item 維持既有保留語意（不誤傷僅由 workflow_run 衍生的項目）
+- [x] `work_api.py` projection 驗證失敗時降級保留上一版 projection，但讓 provider 觀測落地
+- [x] 降級時把失敗原因寫入 provider `diagnostics`，不得無聲降級
+- [x] 測試涵蓋：歸屬轉移不重複、`WorkSnapshot` 建構通過、部分轉移保留其餘 source、
+      無 source 的 previous item 仍保留、非 degraded 時行為不變、projection 失敗不丟棄 provider 觀測
+
+## 待辦
+
+- [ ] refresh 連續失敗需在 `cortex status`／`doctor` 有明確訊號——目前唯一線索在
+      `journalctl -u <instance>-monitor`，且被「看起來很正常的 snapshot」掩蓋
+      （全部 provider 的 `last_attempt_at` 同時凍住是唯一可觀測徵兆）
+- [ ] 檢視是否還有其他會產生 ownership collision 的歸屬轉移路徑（本次只修了
+      fallback → declared 這一條；降級保護是縱深防禦，不是免死金牌）
+- [ ] snapshot 只在整輪 refresh 結束才落地，診斷可整整落後一個 refresh 週期；
+      考慮 refresh 進行中先落 `in_progress` 標記或逐 provider 增量落地

--- a/paulsha_cortex/monitor/lifecycle.py
+++ b/paulsha_cortex/monitor/lifecycle.py
@@ -166,8 +166,36 @@ def project_work_items(
 
     if correlation.degraded:
         projected_ids = {group.work_id for group in correlation.groups}
+        # #523：保留分支原本只比對 **work_id**，不比對 **sources**。當某個 source 的
+        # 歸屬從 fallback work item（`correlation.py:_fallback_work_id` 產生的
+        # `issue:<ref>`）轉移到新宣告的 work item 時，本輪 correlation 已不再產生那個
+        # fallback，於是它「不在 projected_ids 裡」→ 連同**舊的 sources** 被整筆放回
+        # → 兩個 work item 同時宣稱擁有同一個 source →
+        # `work_snapshot.validate_ownership()` raise → 整個 refresh 失敗。
+        #
+        # 而該例外發生在 `WorkSnapshot.__post_init__`、早於 `replace_durably()`，
+        # 所以那一輪算出的 provider 新狀態（包含「backoff 已結束」）一併被丟棄，
+        # `previous` 永遠停在崩潰前那一版、`degraded` 永遠為真 → 每輪重演。
+        # 亦即 provider 無法離開 degraded，因為記錄它恢復的那次寫入正是拋例外的那次。
+        #
+        # 修法：保留時剝除已被本輪認領的 source。source 全被認領（集合變空）代表這筆
+        # 舊 work item 的內容已完整轉移到新歸屬，整筆丟棄即可——保留一個沒有任何
+        # source 的空殼既無資訊也無意義。
+        claimed_source_ids = {
+            source.source_id for group in correlation.groups for source in group.sources
+        }
         for item in previous.values():
             if item.work_id in projected_ids:
+                continue
+            retained_sources = tuple(
+                source
+                for source in item.sources
+                if source.source_id not in claimed_source_ids
+            )
+            # 只有「原本有 source、且全部被本輪認領」才代表內容已完整轉移、該整筆丟棄。
+            # 原本就沒有 source 的 previous item（例如僅由 workflow_run 衍生的項目）
+            # 維持既有保留語意，不受本修正影響。
+            if item.sources and not retained_sources:
                 continue
             decision = reduce_lifecycle(
                 LifecycleFacts(
@@ -184,7 +212,7 @@ def project_work_items(
                     state=decision.state,
                     phase=item.phase,
                     facets=decision.facets,
-                    sources=item.sources,
+                    sources=retained_sources,
                     next_actions=item.next_actions,
                     workflow_run_id=item.workflow_run_id,
                     updated_at=updated_at,

--- a/paulsha_cortex/monitor/work_api.py
+++ b/paulsha_cortex/monitor/work_api.py
@@ -642,14 +642,55 @@ class WorkModelRefresher:
                 for provider_id, provider in providers.items()
                 if provider_id in active_provider_ids
             }
-            snapshot = WorkSnapshot(
-                sequence=previous.sequence + 1,
-                written_at=attempted_at,
-                providers=providers,
-                work_items=tuple(projected_items),
-                source_owners=source_owners,
-                exclusions=tuple(_dedupe_mappings(exclusions)),
-            )
+            try:
+                snapshot = WorkSnapshot(
+                    sequence=previous.sequence + 1,
+                    written_at=attempted_at,
+                    providers=providers,
+                    work_items=tuple(projected_items),
+                    source_owners=source_owners,
+                    exclusions=tuple(_dedupe_mappings(exclusions)),
+                )
+            except ValueError as error:
+                # #523：projection 層的 ownership 驗證失敗，原本會讓整個 refresh 拋
+                # 例外——而這個例外發生在 `replace_durably()` **之前**，於是那一輪算出
+                # 的 provider 新狀態（包含「rate limit backoff 已結束、provider 恢復
+                # ok」這個事實）**一併被丟棄**。`previous` 因此永遠停在崩潰前那一版、
+                # `correlation.degraded` 永遠為真，下一輪以相同輸入重演同樣的例外：
+                # provider 無法離開 degraded，因為記錄它恢復的那次寫入正是拋例外的
+                # 那次寫入。實測形成永不自癒的死鎖，且外觀與單純限流難以區分。
+                #
+                # projection 是衍生資料，provider 觀測是第一手事實——兩者不該同生共死。
+                # 因此降級為「保留上一版 projection，但讓新的 provider 觀測落地」，
+                # 並把失敗原因寫進 diagnostics 讓 operator 看得見。若連降級版本都建不
+                # 起來，那是真正的資料損毀，照常往外拋。
+                degraded_providers = {
+                    provider_id: replace(
+                        provider,
+                        status="degraded",
+                        diagnostics=tuple(
+                            dict.fromkeys(
+                                (
+                                    *provider.diagnostics,
+                                    "work model projection retained: "
+                                    f"{type(error).__name__}: {error}",
+                                )
+                            )
+                        ),
+                    )
+                    for provider_id, provider in providers.items()
+                }
+                snapshot = WorkSnapshot(
+                    sequence=previous.sequence + 1,
+                    written_at=attempted_at,
+                    providers=degraded_providers,
+                    work_items=previous.work_items,
+                    source_owners=dict(previous.source_owners),
+                    exclusions=tuple(_dedupe_mappings(list(previous.exclusions))),
+                )
+                return self.read_store.replace_durably(
+                    snapshot, self.durable_store.write
+                )
             return self.read_store.replace_durably(
                 snapshot, self.durable_store.write, explanations=explanations
             )

--- a/tests/test_monitor_degraded_retention_collision_523.py
+++ b/tests/test_monitor_degraded_retention_collision_523.py
@@ -1,0 +1,356 @@
+"""`#523`：degraded 保留分支的 ownership collision 與其永不自癒的死鎖。
+
+## 實測現場（2026-08-14）
+
+在 `.cortex/work-items.yaml` 新增三筆 registry 條目（把 `github_issue` source 由
+fallback work item 轉交給新宣告的 work item）之後，monitor 每一輪都拋：
+
+```
+ValueError: ownership collision for github_issue:hamanpaul/paulsha-cortex#507:
+  hamanpaul/paulsha-cortex::fix-planning-rollback-destroys-operator-work,
+  hamanpaul/paulsha-cortex::issue:hamanpaul/paulsha-cortex#507
+```
+
+全部 52 個 provider 的 `last_attempt_at` 同時凍在同一個時刻（含根本不碰 GitHub 的
+`repo:`／`workflow:` provider），而 `work-items.snapshot.json` 的 mtime 仍每 30 秒更新
+——外觀完全正常，與單純限流難以區分。
+
+## 兩個獨立缺陷
+
+1. **保留分支只比對 work_id，不比對 sources**（`lifecycle.py`）。source 歸屬從
+   `correlation.py:_fallback_work_id` 產生的 `issue:<ref>` 轉移到新宣告的 work item 時，
+   本輪 correlation 不再產生該 fallback → 它「不在 projected_ids 裡」→ 連同**舊的
+   sources** 被整筆放回 → 兩個 work item 宣稱擁有同一個 source。
+
+2. **projection 失敗會連帶丟棄 provider 觀測**（`work_api.py`）。例外發生在
+   `WorkSnapshot.__post_init__`、早於 `replace_durably()`，於是那一輪算出的
+   provider 新狀態（包含「backoff 已結束」）一併被丟棄，`previous` 永遠停在崩潰前
+   那一版、`degraded` 永遠為真 → 下一輪以相同輸入重演 → **provider 無法離開
+   degraded，因為記錄它恢復的那次寫入正是拋例外的那次寫入**。
+
+先前把成因誤判為「時序競態」（unlink → recover → re-link 就好）；那次實驗會成功只是
+因為當下 provider 恰好健康、保留分支根本沒跑。真正的觸發條件是 `correlation.degraded`。
+"""
+
+from __future__ import annotations
+
+from paulsha_cortex.monitor.correlation import CorrelationResult, CorrelatedWork
+from paulsha_cortex.monitor.lifecycle import project_work_items
+from paulsha_cortex.monitor.work_models import WorkItem, WorkSource
+from paulsha_cortex.monitor.work_snapshot import WorkSnapshot
+
+
+def _issue_source() -> WorkSource:
+    return WorkSource(
+        source_id="github_issue:example/acme#507",
+        kind="github_issue",
+        ref="example/acme#507",
+        revision="github:NODE:2026-08-14T00:00:00Z",
+        status="open",
+        confidence="confirmed",
+        provider="github:example/acme",
+    )
+
+
+def _degraded_correlation_owning_the_issue() -> CorrelationResult:
+    """本輪：issue 已改由宣告的 work item 持有，fallback 不再產生。"""
+
+    source = _issue_source()
+    return CorrelationResult(
+        groups=(
+            CorrelatedWork(
+                work_id="declared-work",
+                title="Declared Work",
+                sources=(source,),
+                confidence="confirmed",
+            ),
+        ),
+        source_owners={source.source_id: "declared-work"},
+        exclusions=(),
+        explanations={},
+        degraded=True,
+        diagnostics=("github rate limit backoff active; retry in 64s",),
+    )
+
+
+def _previous_fallback_item() -> WorkItem:
+    """上一版：同一個 issue 由 fallback work item `issue:<ref>` 持有。"""
+
+    return WorkItem(
+        work_id="issue:example/acme#507",
+        repo="example/acme",
+        title="example/acme#507",
+        state="topic",
+        phase=None,
+        facets=(),
+        sources=(_issue_source(),),
+        next_actions=(),
+        workflow_run_id=None,
+        updated_at="2026-08-14T08:00:00Z",
+    )
+
+
+def test_degraded_retention_does_not_duplicate_a_reowned_source() -> None:
+    """歸屬轉移的 source 不得同時出現在新舊兩個 work item。"""
+
+    projection = project_work_items(
+        _degraded_correlation_owning_the_issue(),
+        repo="example/acme",
+        updated_at="2026-08-14T09:00:00Z",
+        previous_items=(_previous_fallback_item(),),
+    )
+
+    owners = {
+        source.source_id: item.work_id
+        for item in projection.items
+        for source in item.sources
+    }
+    assert owners == {"github_issue:example/acme#507": "declared-work"}
+
+    # 舊 fallback 的 source 已完整轉移，整筆丟棄而非留下空殼。
+    assert [item.work_id for item in projection.items] == ["declared-work"]
+
+
+def test_projection_result_passes_ownership_validation() -> None:
+    """端到端：`WorkSnapshot` 建構不得因這個 projection 而 raise。
+
+    這是 `#523` 真正致命的那一步——`validate_ownership()` 在
+    `__post_init__` 拋出，整個 refresh 隨之失敗。
+    """
+
+    projection = project_work_items(
+        _degraded_correlation_owning_the_issue(),
+        repo="example/acme",
+        updated_at="2026-08-14T09:00:00Z",
+        previous_items=(_previous_fallback_item(),),
+    )
+
+    snapshot = WorkSnapshot(
+        sequence=2,
+        written_at="2026-08-14T09:00:00Z",
+        providers={},
+        work_items=projection.items,
+        source_owners={"github_issue:example/acme#507": "example/acme::declared-work"},
+        exclusions=(),
+    )
+    assert len(snapshot.work_items) == 1
+
+
+def test_partially_reowned_previous_item_keeps_its_remaining_sources() -> None:
+    """只有部分 source 被轉移時，舊 work item 保留其餘 source 而非整筆消失。"""
+
+    moved = _issue_source()
+    kept = WorkSource(
+        source_id="todo:example/acme:docs/other/todo.md",
+        kind="todo",
+        ref="docs/other/todo.md",
+        revision="local-sha256:beef",
+        status="active",
+        confidence="confirmed",
+        provider="repo:example/acme",
+    )
+    previous = WorkItem(
+        work_id="issue:example/acme#507",
+        repo="example/acme",
+        title="example/acme#507",
+        state="topic",
+        phase=None,
+        facets=(),
+        sources=(moved, kept),
+        next_actions=(),
+        workflow_run_id=None,
+        updated_at="2026-08-14T08:00:00Z",
+    )
+
+    projection = project_work_items(
+        _degraded_correlation_owning_the_issue(),
+        repo="example/acme",
+        updated_at="2026-08-14T09:00:00Z",
+        previous_items=(previous,),
+    )
+
+    by_id = {item.work_id: item for item in projection.items}
+    assert set(by_id) == {"declared-work", "issue:example/acme#507"}
+    assert [s.source_id for s in by_id["issue:example/acme#507"].sources] == [kept.source_id]
+
+
+def test_previous_item_without_sources_is_still_retained() -> None:
+    """原本就沒有 source 的 previous item 維持既有保留語意。
+
+    丟棄條件是「原本有 source、且全部被本輪認領」，不是「現在沒有 source」——
+    否則會誤傷僅由 workflow_run 衍生的項目。
+    """
+
+    sourceless = WorkItem(
+        work_id="sourceless-work",
+        repo="example/acme",
+        title="Sourceless",
+        state="done",
+        phase=None,
+        facets=(),
+        sources=(),
+        next_actions=(),
+        workflow_run_id=None,
+        updated_at="2026-08-14T08:00:00Z",
+    )
+
+    projection = project_work_items(
+        _degraded_correlation_owning_the_issue(),
+        repo="example/acme",
+        updated_at="2026-08-14T09:00:00Z",
+        previous_items=(sourceless,),
+    )
+
+    assert "sourceless-work" in {item.work_id for item in projection.items}
+
+
+def test_retention_filter_is_inert_when_not_degraded() -> None:
+    """非 degraded 時保留分支本來就不跑，行為不得因本修正改變。"""
+
+    correlation = _degraded_correlation_owning_the_issue()
+    healthy = CorrelationResult(
+        groups=correlation.groups,
+        source_owners=correlation.source_owners,
+        exclusions=(),
+        explanations={},
+        degraded=False,
+        diagnostics=(),
+    )
+
+    projection = project_work_items(
+        healthy,
+        repo="example/acme",
+        updated_at="2026-08-14T09:00:00Z",
+        previous_items=(_previous_fallback_item(),),
+    )
+
+    assert [item.work_id for item in projection.items] == ["declared-work"]
+
+
+# ---------------------------------------------------------------------------
+# 第二個缺陷：projection 失敗不得連帶丟棄 provider 觀測（否則永不自癒）
+# ---------------------------------------------------------------------------
+
+from datetime import datetime, timezone  # noqa: E402
+
+from paulsha_cortex.monitor.models import ProjectState  # noqa: E402
+from paulsha_cortex.monitor.work_api import (  # noqa: E402
+    WorkModelRefresher,
+    WorkReadModelStore,
+)
+from paulsha_cortex.monitor.work_models import ProviderSnapshot  # noqa: E402
+from paulsha_cortex.monitor.work_snapshot import WorkSnapshotStore  # noqa: E402
+
+_NOW = "2026-08-14T09:00:00Z"
+
+
+class _StaticProvider:
+    def __init__(self, snapshot: ProviderSnapshot):
+        self.snapshot = snapshot
+
+    def scan(self) -> ProviderSnapshot:
+        return self.snapshot
+
+
+def _ok_provider(provider_id: str) -> ProviderSnapshot:
+    return ProviderSnapshot(
+        provider_id=provider_id,
+        status="ok",
+        last_attempt_at=_NOW,
+        last_success_at=_NOW,
+        revision="revision:recovered",
+        diagnostics=(),
+        sources=(),
+        observations={},
+    )
+
+
+def _colliding_projection(*_args, **_kwargs):
+    """模擬任何導致 ownership collision 的 projection 結果。
+
+    本 PR 已修掉已知成因（保留分支），但死鎖性質本身是獨立缺陷：只要**任何**
+    collision 發生，`WorkSnapshot.__post_init__` 就會在 `replace_durably()` 之前
+    拋出，把該輪的 provider 觀測一併丟掉，使 provider 永遠離不開 degraded。
+    """
+
+    from paulsha_cortex.monitor.lifecycle import LifecycleProjection
+
+    duplicated = _issue_source()
+    return LifecycleProjection(
+        items=(
+            WorkItem(
+                work_id="alpha",
+                repo="example/acme",
+                title="Alpha",
+                state="topic",
+                phase=None,
+                facets=(),
+                sources=(duplicated,),
+                next_actions=(),
+                workflow_run_id=None,
+                updated_at=_NOW,
+            ),
+            WorkItem(
+                work_id="beta",
+                repo="example/acme",
+                title="Beta",
+                state="topic",
+                phase=None,
+                facets=(),
+                sources=(duplicated,),
+                next_actions=(),
+                workflow_run_id=None,
+                updated_at=_NOW,
+            ),
+        ),
+        explanations={},
+    )
+
+
+def test_projection_failure_does_not_discard_provider_observations(
+    tmp_path, monkeypatch
+) -> None:
+    """refresh 不得因 projection 失敗而整輪拋出、丟棄 provider 進展。
+
+    這是 `#523` 之所以「永不自癒」的機制：provider 恢復的事實與壞掉的 projection
+    寫在同一次 `replace_durably()`，於是 provider 無法離開 degraded——記錄它恢復的
+    那次寫入正是拋例外的那次寫入。
+    """
+
+    monkeypatch.setattr(
+        "paulsha_cortex.monitor.work_api.project_work_items", _colliding_projection
+    )
+    refresher = WorkModelRefresher(
+        durable_store=WorkSnapshotStore(tmp_path / "snapshot.json"),
+        read_store=WorkReadModelStore.empty(),
+        github_provider_factory=lambda _repo: _StaticProvider(
+            _ok_provider("github:example/acme")
+        ),
+        github_terminal_provider_factory=lambda _repo, **_kw: _StaticProvider(
+            _ok_provider("github-terminal:example/acme")
+        ),
+        workflow_provider_factory=lambda _repo: _StaticProvider(
+            _ok_provider("workflow:example/acme")
+        ),
+        now=lambda: datetime(2026, 8, 14, 9, 0, tzinfo=timezone.utc),
+    )
+
+    # 不得 raise。
+    refresher.refresh(
+        (
+            ProjectState(
+                project_id="example/acme", workspace="ws", path=str(tmp_path)
+            ),
+        ),
+        include_github=True,
+    )
+
+    snapshot = refresher.read_store.current_snapshot()
+    # provider 觀測已落地（這正是先前被丟棄的東西）。
+    assert snapshot.providers, "provider 觀測必須落地，否則 degraded 永遠解不開"
+    # 失敗原因對 operator 可見，不是無聲降級。
+    assert any(
+        "work model projection retained" in diagnostic
+        for provider in snapshot.providers.values()
+        for diagnostic in provider.diagnostics
+    )


### PR DESCRIPTION
## 摘要

Closes #523。兩個獨立缺陷疊成一個**永不自癒的死鎖**。

## 缺陷一：保留分支只比對 work_id，不比對 sources

`monitor/lifecycle.py` 的 degraded 保留分支：source 歸屬從 fallback work item
（`correlation.py:_fallback_work_id` 產生的 `issue:<ref>`）轉移到新宣告的 work item 時，
本輪 correlation 已不再產生該 fallback → 它「不在 `projected_ids` 裡」→ 連同**舊的
sources** 被整筆放回 → 兩個 work item 同時宣稱擁有同一個 source →
`work_snapshot.validate_ownership()` raise：

```
ValueError: ownership collision for github_issue:hamanpaul/paulsha-cortex#507:
  hamanpaul/paulsha-cortex::fix-planning-rollback-destroys-operator-work,
  hamanpaul/paulsha-cortex::issue:hamanpaul/paulsha-cortex#507
```

**修法**：保留時剝除已被本輪認領的 source。原本有 source 而全數被認領者整筆丟棄——
內容已完整轉移，留一個沒有任何 source 的空殼既無資訊也無意義。原本就沒有 source 的
previous item（例如僅由 `workflow_run` 衍生的項目）維持既有保留語意，不受影響。

## 缺陷二：projection 失敗連帶丟棄 provider 觀測

上述例外發生在 `WorkSnapshot.__post_init__`、**早於** `replace_durably()`
（`work_api.py`），於是那一輪算出的 provider 新狀態——**包含「rate limit backoff 已結束、
provider 恢復 ok」這個事實**——一併被丟棄。`previous` 因此永遠停在崩潰前那一版、
`correlation.degraded` 永遠為真，下一輪以相同輸入重演同樣的例外。

> provider 無法離開 degraded，因為記錄它恢復的那次寫入，正是拋例外的那次寫入。

**修法**：projection 是衍生資料，provider 觀測是第一手事實，兩者不該同生共死。
projection 驗證失敗時降級為「保留上一版 projection ＋ 讓新的 provider 觀測落地」，
並把失敗原因寫進該輪 provider 的 `diagnostics`，讓 operator 看得見而非無聲降級。
若連降級版本都建不起來，那是真正的資料損毀，照常往外拋。

## 成因更正

先前把它記為「時序競態」（unlink → recover → re-link 即可）。那次受控實驗之所以成功，
只是因為當下 provider 恰好健康、保留分支根本沒跑。真正的觸發條件是
`correlation.degraded`——亦即**限流本身**。`#506` 與本缺陷因此互鎖：
限流讓 provider degraded → registry 一有變更就 collision → collision 讓 provider 永遠 degraded。

## 實測現場

全部 52 個 provider 的 `last_attempt_at` 同時凍在同一時刻（含根本不碰 GitHub 的
`repo:`／`workflow:` provider），而 `work-items.snapshot.json` 的 mtime 仍每 30 秒更新
——外觀完全正常，與單純限流難以區分；唯一線索在 `journalctl -u <instance>-monitor`。
這道「全部 provider 的 last_attempt 同時凍住」是目前唯一可觀測的徵兆，已列入 workstream
待辦（應在 `cortex status`／`doctor` 有明確訊號）。

## 驗收

- [x] `changelog.d/degraded-retention-collision.md` fragment 已新增並 commit
- [x] `CHANGELOG.md [Unreleased]` 已補對應 entry
- [x] 新增 `tests/test_monitor_degraded_retention_collision_523.py`：歸屬轉移不重複、
      `WorkSnapshot` 建構通過、部分轉移保留其餘 source、無 source 的 previous item 仍保留、
      非 degraded 時行為不變、projection 失敗不丟棄 provider 觀測且留下可見診斷
- [x] 全套測試通過：**2571 passed**
- [x] `policy-check` 帶完整 PR context
