### PR TITLE
fix(coordinator): planner 暫時性服務失敗改判 environment 並留存輸出片段

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@
 ## [Unreleased]
 
 ### Fixed
+- **planner launcher 暫時性服務失敗被判 `content` 死路**——agy 暫時性 503 會印錯誤文字但
+  exit 0，launcher parse 不到 JSON 即以 `content` 分類收場，而 `content` 禁用
+  recover-planning：自癒型服務錯誤變永久死路。修法：`_extract_json` no-JSON 失敗帶 stdout
+  截斷片段（503 當場可見、不再隨 temp_dir 丟棄）；新增
+  `_is_planning_transient_service_failure` 判準（比照 #416 殘留例外），服務層暫時性樣態
+  改判 `environment` 使 recover-planning 可用；內容不從維持 `content`。
 - **Issue #523：degraded 保留分支的 ownership collision 讓 work model refresh 永久失敗**
   ——`monitor/lifecycle.py` 的保留分支只比對 work_id、不比對 sources，source 歸屬由
   fallback work item 轉移到新宣告的 work item 時，舊 fallback 連同舊 sources 被整筆放回，

--- a/changelog.d/planning-transient-classification.md
+++ b/changelog.d/planning-transient-classification.md
@@ -1,0 +1,17 @@
+# planning-transient-classification
+
+- **planner launcher 的暫時性服務失敗不再被判 `content` 死路**——實測（2026-08-14，run
+  `workflow-88d089d71416a754dda8`）：agy 服務暫時回
+  `Error: Eligibility check failed: UNAVAILABLE (code 503)`，**印錯誤文字但 exit 0**；
+  launcher 信任 exit 0 去 parse stdout、找不到 JSON，失敗以
+  `primary-integration-malformed: … returned no JSON object` 收場並被預設分類 `content`
+  → `recover-planning` 遭 #393 fail-closed 禁止 → 一個十分鐘後自癒的 503（同一指令重跑
+  即成功）成為永久死路，唯一出口 abandon。transient-誤判-死路模式第五次命中
+  （#500、#507 的 content 誤分類同族）。兩項修正：
+  - `planning_runtime._extract_json`：no-JSON 失敗必須帶 stdout 截斷片段——修法前錯誤
+    文字隨 temp_dir 一併丟棄，operator 只看得到「no JSON object」六個字，診斷得靠手動重現。
+  - `manager._is_planning_transient_service_failure`：與 #416 殘留例外同路的第二個例外判準
+    ——reason 命中服務層暫時性樣態（UNAVAILABLE／503／429／rate limit／timeout／
+    connection reset|refused／overloaded 等）時分類改落 `environment`，
+    `_resume_decision` 因此浮現 `recover-planning`。判準刻意窄：模型「內容不從」
+    （回散文不回 JSON、schema 不合、標題缺失）維持 `content` 與既有 fail-closed 意圖。

--- a/paulsha_cortex/coordinator/manager.py
+++ b/paulsha_cortex/coordinator/manager.py
@@ -5966,6 +5966,52 @@ def _is_planning_authority_residue_failure(reason: str | None) -> bool:
     )
 
 
+# --- planner launcher 的暫時性服務失敗 ----------------------------------------
+#
+# 實測（2026-08-14，run `workflow-88d089d71416a754dda8`）：agy 服務暫時回
+# `Error: Eligibility check failed: UNAVAILABLE (code 503)`——**印錯誤文字但
+# exit 0**，launcher 因此去 parse stdout、找不到 JSON，失敗以
+# `primary-integration-malformed: ValueError: planning launcher returned no
+# JSON object` 收場，預設分類 `content` → `recover-planning` 被 #393 的
+# fail-closed 禁止 → 一個幾分鐘後自癒的 503 變成永久死路（同一指令 10 分鐘
+# 後重跑即成功）。這是 transient-誤判-死路模式的第五次命中（#500、#507 的
+# content 誤分類、worktree 汙染誤分類皆同族）。
+#
+# 判準刻意窄：只認 CLI/service 層的暫時性錯誤樣態（服務不可用、限流、逾時、
+# 連線層失敗）。模型「內容不從」（回散文不回 JSON、schema 不合）不在此列，
+# 維持 `content` 分類與 fail-closed 意圖——分辨依據是這些字樣出自 launcher
+# 轉印的服務錯誤，不會出現在合法的規劃輸出裡。
+_PLANNING_TRANSIENT_SERVICE_MARKERS = (
+    "unavailable",
+    "503",
+    "429",
+    "rate limit",
+    "too many requests",
+    "timed out",
+    "timeout",
+    "connection reset",
+    "connection refused",
+    "overloaded",
+    "temporarily",
+    "service_unavailable",
+    "eligibility check failed",
+)
+
+
+def _is_planning_transient_service_failure(reason: str | None) -> bool:
+    """判斷 planning 失敗的 reason 是否為 launcher/service 層的暫時性失敗。
+
+    命中者分類改落 `environment`（與 #416 的殘留例外同路），讓
+    `_resume_decision` 浮現 `recover-planning`——暫時性服務錯誤等它過去重跑
+    即可，不該燒掉一個世代或落入 abandon 死路。
+    """
+
+    if reason is None:
+        return False
+    lowered = reason.lower()
+    return any(marker in lowered for marker in _PLANNING_TRANSIENT_SERVICE_MARKERS)
+
+
 # --- issue #511：planning artifact 拒收的診斷面 -------------------------------
 #
 # 修法前拒收只丟一句 `planning artifact is not accepted: <path>`：
@@ -9015,11 +9061,14 @@ def apply_workflow_action(
         # （見 claim.py 的 fail-closed 判準），行為與 issue 393 的 fail-closed
         # 意圖一致。`result.reason` 理論上不應為空，仍防禦性 fallback 避免
         # evidence 的 reason 欄位落空字串。
-        # #416：唯一例外——reason 命中 `_is_planning_authority_residue_failure`
+        # #416：例外一——reason 命中 `_is_planning_authority_residue_failure`
         # 判準時（abandon 未回滾的發佈殘留撞見 `_publish_planning_artifacts`
         # 的 authority fail-closed），這其實是環境／狀態殘留而非模型內容
         # 缺陷，改歸 `environment`，讓 `_resume_decision` 可以浮現
         # recover-planning，不必再燒一個世代改名重識別才能繞過。
+        # 例外二——`_is_planning_transient_service_failure`：launcher/service 層
+        # 的暫時性錯誤（503/限流/逾時；agy 實測會印錯誤文字但 exit 0），同歸
+        # `environment`。一個幾分鐘後自癒的服務錯誤不得被判成 `content` 死路。
         brainstorm_not_ready_reason = result.reason or "brainstorm-not-ready"
         run = registry._manager_update_workflow_run(
             run.run_id,
@@ -9031,6 +9080,7 @@ def apply_workflow_action(
                 classification=(
                     "environment"
                     if _is_planning_authority_residue_failure(brainstorm_not_ready_reason)
+                    or _is_planning_transient_service_failure(brainstorm_not_ready_reason)
                     else "content"
                 ),
                 reason=brainstorm_not_ready_reason,

--- a/paulsha_cortex/coordinator/planning_runtime.py
+++ b/paulsha_cortex/coordinator/planning_runtime.py
@@ -335,7 +335,17 @@ def _extract_json(stdout: str, output_path: Path) -> object:
             detail = fallback_snippet if fallback_snippet is not None else "<no string field>"
             raise ValueError(f"planning launcher result is not JSON: {detail}")
         return value
-    raise ValueError("planning launcher returned no JSON object")
+    # 2026-08-14 實測：agy 服務暫時性 503 時**印錯誤文字但 exit 0**
+    # （`Error: Eligibility check failed: UNAVAILABLE (code 503)`），launcher
+    # 因此走到這裡。修法前這行不帶任何 stdout 內容，錯誤文字隨 temp_dir 一起
+    # 被丟棄——operator 只看得到「no JSON object」，診斷得靠手動重現。帶上
+    # 截斷片段後：(1) 503 當場可見；(2) 上游 `_is_planning_transient_service_failure`
+    # 能據此把分類從 `content` 改判 `environment`，recover-planning 才有路。
+    snippet = next(
+        (candidate[:160] for candidate in candidates if candidate),
+        "<empty output>",
+    )
+    raise ValueError(f"planning launcher returned no JSON object: {snippet}")
 
 
 def _seed_hermetic_claude_env(temp_dir: str) -> dict[str, str] | None:

--- a/tests/test_planning_transient_service_failure.py
+++ b/tests/test_planning_transient_service_failure.py
@@ -1,0 +1,125 @@
+"""planner launcher 暫時性服務失敗的分類與診斷（2026-08-14 實測）。
+
+現場：run `workflow-88d089d71416a754dda8`（work_id `fix-instance-config-isolation`）
+的 define 失敗於：
+
+```
+primary-integration-malformed: ValueError: planning launcher returned no JSON object
+classification: content
+```
+
+追根究柢是 agy 服務暫時回 `Error: Eligibility check failed: UNAVAILABLE (code 503)`
+——**印錯誤文字但 exit 0**。launcher 信任 exit 0 去 parse stdout、找不到 JSON，而：
+
+1. 錯誤文字不進 reason 也不進 evidence（temp_dir 一併丟棄），operator 只看到
+   「no JSON object」六個字；
+2. 失敗被預設分類 `content` → `recover-planning` 被 #393 fail-closed 禁止 →
+   一個十分鐘後自癒的 503（同一指令重跑即成功）成為永久死路，唯一出口 abandon。
+
+這是 transient-誤判-死路模式的第五次命中（#500、#507 的 content 誤分類同族）。
+
+本檔釘住兩個修正：
+- `_extract_json` 的 no-JSON 失敗必須帶 stdout 截斷片段（503 當場可見）；
+- `_is_planning_transient_service_failure` 把服務層暫時性樣態改判 `environment`
+  （與 #416 的殘留例外同路，recover-planning 因此可用），且判準刻意窄——
+  模型「內容不從」（回散文、schema 不合）維持 `content`。
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from paulsha_cortex.coordinator import manager
+from paulsha_cortex.coordinator.planning_runtime import _extract_json
+
+
+# ---------------------------------------------------------------------------
+# _extract_json：no-JSON 失敗必須帶輸出片段
+# ---------------------------------------------------------------------------
+
+
+def test_no_json_error_carries_stdout_snippet(tmp_path: Path) -> None:
+    stdout = "Error: Eligibility check failed: UNAVAILABLE (code 503): The service is currently unavailable."
+    with pytest.raises(ValueError) as excinfo:
+        _extract_json(stdout, tmp_path / "absent.json")
+    message = str(excinfo.value)
+    assert "returned no JSON object" in message
+    assert "UNAVAILABLE (code 503)" in message, "錯誤文字必須進 reason，不得只留六個字"
+
+
+def test_no_json_error_snippet_is_truncated(tmp_path: Path) -> None:
+    stdout = "x" * 500
+    with pytest.raises(ValueError) as excinfo:
+        _extract_json(stdout, tmp_path / "absent.json")
+    # reason 上游會再截 160；這裡確保片段本身有界，不把整包輸出塞進例外。
+    assert len(str(excinfo.value)) < 260
+
+
+def test_no_json_error_with_empty_output_says_so(tmp_path: Path) -> None:
+    with pytest.raises(ValueError) as excinfo:
+        _extract_json("", tmp_path / "absent.json")
+    assert "<empty output>" in str(excinfo.value)
+
+
+def test_valid_json_still_extracts(tmp_path: Path) -> None:
+    assert _extract_json('{"questions": []}', tmp_path / "absent.json") == {"questions": []}
+
+
+# ---------------------------------------------------------------------------
+# 分類判準：服務層暫時性 → environment；內容不從 → 維持 content
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "reason",
+    [
+        # 實際現場（agy 503，經 _extract_json 片段與 planning.py 前綴包裝後的樣貌）
+        "primary-integration-malformed: ValueError: planning launcher returned no "
+        "JSON object: Error: Eligibility check failed: UNAVAILABLE (code 503): The service is",
+        "question-pack-malformed: ValueError: planning launcher returned no JSON "
+        "object: 429 Too Many Requests",
+        "secondary-output-malformed: ValueError: planning launcher returned no JSON "
+        "object: upstream connect error: connection timed out",
+        "primary-integration-malformed: TimeoutExpired: command timed out after 300s",
+        "secondary-output-malformed: ValueError: planning launcher returned no JSON "
+        "object: model is overloaded, please retry",
+    ],
+)
+def test_transient_service_failures_are_recognized(reason: str) -> None:
+    assert manager._is_planning_transient_service_failure(reason) is True
+
+
+@pytest.mark.parametrize(
+    "reason",
+    [
+        None,
+        "brainstorm-not-ready",
+        # 模型內容不從：回散文不回 JSON——這是 content，不是服務錯誤。
+        "primary-integration-malformed: ValueError: planning launcher result is not "
+        "JSON: 我認為這個問題應該從三個面向來分析",
+        # 標題/schema 類拒收維持 content。
+        "primary-artifact-write-rejected: ValueError: required section missing: Requirements",
+        "question-pack-malformed: KeyError: 'questions'",
+    ],
+)
+def test_content_failures_stay_content(reason: str | None) -> None:
+    assert manager._is_planning_transient_service_failure(reason) is False
+
+
+def test_residue_and_transient_predicates_are_disjoint_paths() -> None:
+    """兩個例外判準各自命中各自的情境，互不誤觸。"""
+
+    residue = (
+        "primary-artifact-write-rejected: ValueError: planning artifact lacks "
+        "current planning authority: docs/superpowers/specs/x.md"
+    )
+    transient = (
+        "primary-integration-malformed: ValueError: planning launcher returned no "
+        "JSON object: UNAVAILABLE (code 503)"
+    )
+    assert manager._is_planning_authority_residue_failure(residue) is True
+    assert manager._is_planning_transient_service_failure(residue) is False
+    assert manager._is_planning_authority_residue_failure(transient) is False
+    assert manager._is_planning_transient_service_failure(transient) is True


### PR DESCRIPTION
## 摘要

planner launcher 的**暫時性服務失敗**不再被判 `content` 死路。

## 現場（2026-08-14，run `workflow-88d089d71416a754dda8`）

agy 服務暫時回 `Error: Eligibility check failed: UNAVAILABLE (code 503)`——
**印錯誤文字但 exit 0**。launcher 信任 exit 0 去 parse stdout、找不到 JSON：

```
primary-integration-malformed: ValueError: planning launcher returned no JSON object
classification: content
```

`content` 依 #393 禁用 `recover-planning` → 唯一出口 abandon。**同一條 agy 指令十分鐘後
重跑即成功**——一個自癒型服務錯誤被判了死刑。這是 transient-誤判-死路模式的第五次命中
（#500、#507 的 content 誤分類同族）。且錯誤文字隨 planning temp_dir 一併丟棄，
operator 只看得到「no JSON object」六個字，診斷得靠手動重現。

## 修法（兩項，判準刻意窄）

1. **`planning_runtime._extract_json`**：no-JSON 失敗帶 stdout 截斷片段——503 當場可見。
2. **`manager._is_planning_transient_service_failure`**：比照 #416 殘留例外的第二個例外
   判準——reason 命中服務層暫時性樣態（UNAVAILABLE／503／429／rate limit／timeout／
   connection reset|refused／overloaded）時分類改落 `environment`，`_resume_decision`
   因此浮現 `recover-planning`。**模型「內容不從」**（回散文不回 JSON、schema 不合、
   標題缺失）**維持 `content`** 與既有 fail-closed 意圖，測試釘住兩判準互斥。

## 驗收

- [x] changelog fragment＋CHANGELOG [Unreleased] 已補
- [x] 新增 `tests/test_planning_transient_service_failure.py`（15 案：片段留存/截斷/空輸出、
      五種 transient 樣態、五種 content 反例、與 #416 判準互斥）
- [x] 全套測試 **2586 passed**
- [x] policy-check 帶 PR context：24 pass / 0 fail
