### PR TITLE
feat(coordinator): auto-claim label 走鏡像，manager 廢除逐 issue 輪詢（R0.5 D1）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@
 ## [Unreleased]
 
 ### Fixed
+- **R0.5 D1（部分）：auto-claim label 判定改走 monitor 鏡像**——monitor 把持有
+  `cortex:auto-on-going` 的 open issue 編號寫進 provider observations（issues 回應本來就含
+  labels，零額外 API）；canonical claim 路徑據此導出 `auto_label`（原硬編 False）；
+  auto-claim scan 廢除每 tick O(mapped issues) 的 live label sweep（實測 57 次/tick），
+  鏡像 False 零 API、鏡像 True 僅一次 targeted 複驗（以 live 為準、確認即 early-break）。
+  observations 缺失一律保守 False。
 - **planner launcher 暫時性服務失敗被判 `content` 死路**——agy 暫時性 503 會印錯誤文字但
   exit 0，launcher parse 不到 JSON 即以 `content` 分類收場，而 `content` 禁用
   recover-planning：自癒型服務錯誤變永久死路。修法：`_extract_json` no-JSON 失敗帶 stdout

--- a/changelog.d/d1a-manager-reads-mirror.md
+++ b/changelog.d/d1a-manager-reads-mirror.md
@@ -1,0 +1,23 @@
+# d1a-manager-reads-mirror
+
+- **R0.5 D1（部分）：auto-claim 的 label 判定改走 monitor 鏡像，manager 不再逐 issue 輪詢
+  GitHub**——先前 canonical 路徑的 `WorkAuthority.auto_label` 硬編 `False`，auto-claim scan
+  因此每 tick 對每個 mapped issue 各發一次 live `gh api` 讀 label（實測 57 次/tick、24 小時
+  不停，是 fleet 對 GitHub 最大的持續壓力源，#506），且 coordinator 側完全不受
+  `GitHubPressureGate` 管轄。三段鏈路：
+  - `monitor/providers.py`：`GitHubWorkProvider` 把持有 `cortex:auto-on-going` 的 open issue
+    編號寫進 provider `observations["auto_label_issues"]`——issues 回應本來就含 labels，
+    **零額外 API**；labels 欄位形狀不合 fail-closed（整包降級 malformed JSON）；PR 與
+    closed issue 不參與。
+  - `coordinator/claim.py`：`_authority_from_canonical_row` 由 observations 導出
+    `auto_label`（新增 `_auto_label_from_observations`）；observations 缺失／形狀不合一律
+    保守 `False`——auto 派工少跑一輪無害、誤跑才有害。
+  - `coordinator/work_actions.py`：`run_auto_claim_scan` 廢除 O(mapped issues) sweep——
+    鏡像為 `False` 的 authority **零 API** 直接進 claim 決策；鏡像為 `True` 才做**一次
+    targeted 複驗**（label 可能在兩次 refresh 之間被人類移除，claim 是不可逆動作），
+    以 live 結果為準，並在**第一次確認後 early-break**。#529 的節流與限流停手語意
+    完整保留於複驗路徑。
+- 穩態效果：常態（無 auto label 案件）manager 對 GitHub 的持續呼叫 **57 次/tick → 0**；
+  有 auto 案件時為 O(掛 label 的 authority 數)（通常 ≤2）。
+- 語意更新記錄於測試：`test_periodic_auto_scan_fails_closed_if_any_mapped_issue_read_fails`
+  改為「確認前的讀取失敗 fail-closed」（early-break 後不再讀取其餘 issue）。

--- a/paulsha_cortex/coordinator/claim.py
+++ b/paulsha_cortex/coordinator/claim.py
@@ -450,6 +450,28 @@ def _authority_from_row(
     )
 
 
+def _auto_label_from_observations(github: dict, issues: list[int]) -> bool:
+    """由 github provider 的 observations 判定 work item 是否掛 auto 派工 label。
+
+    來源：`monitor/providers.py` 的 `GitHubWorkProvider` 把持有 AUTO_LABEL 的
+    open issue 編號寫進 `observations["auto_label_issues"]`（issues 回應本來就含
+    labels，鏡像判定零額外 API）。缺失／形狀不合 → 保守 `False`。
+    """
+
+    observations = github.get("observations")
+    if not isinstance(observations, dict):
+        return False
+    raw = observations.get("auto_label_issues")
+    if not isinstance(raw, list):
+        return False
+    labeled: set[int] = set()
+    for value in raw:
+        if isinstance(value, bool) or not isinstance(value, int):
+            return False
+        labeled.add(value)
+    return any(number in labeled for number in issues)
+
+
 def _authority_from_canonical_row(
     *,
     row: dict,
@@ -748,7 +770,12 @@ def _authority_from_canonical_row(
         mapped_openspec=tuple(sorted(set(changes))),
         mapped_todo_paths=tuple(sorted(set(todo_paths))),
         confirmed_todo=confirmed_todo,
-        auto_label=False,
+        # R0.5 D1：auto label 改由 monitor 鏡像判定（GitHubWorkProvider 把持有
+        # `cortex:auto-on-going` 的 open issue 編號寫進 provider observations），
+        # 取代先前 canonical 路徑硬編 False＋manager 每 tick 逐 issue live 讀取。
+        # observations 缺失或形狀不合一律保守 False——auto 派工少跑一輪無害，
+        # 誤跑才有害；且 auto-claim 在真正 claim 前仍會做一次 targeted 複驗。
+        auto_label=_auto_label_from_observations(github, issues),
         source_revisions=source_revisions,
         provider_revision=revision,
         provider_id=provider_id,

--- a/paulsha_cortex/coordinator/work_actions.py
+++ b/paulsha_cortex/coordinator/work_actions.py
@@ -22,6 +22,7 @@ from paulsha_cortex._yaml import safe_load
 from paulsha_cortex.github_rate_limit import is_rate_limit_signal
 
 from .claim import (
+    AUTO_LABEL,
     ClaimCandidate,
     authority_digest_without_planning_outputs,
     build_claim_key,
@@ -3754,10 +3755,18 @@ def run_auto_claim_scan(
     for authority in authorities:
         if not authority.confirmed_todo:
             continue
-        live_auto_label = False
-        if authority.mapped_issues:
-            # 只有真的需要打 GitHub 的 authority 才受這道停手影響；沒有 mapped
-            # issue 的 authority 本來就不讀 label，限流與它無關，照常 claim。
+        # R0.5 D1：auto label 先讀鏡像（monitor 的 GitHubWorkProvider 已把持有
+        # auto label 的 issue 編號寫進 provider observations，authority.auto_label
+        # 據此導出）。鏡像為 False 的 authority **零 API 呼叫**直接進 claim 決策
+        # （decide_auto_claim 以 auto-label-missing ignore）——這一步把先前
+        # 每 tick 對每個 mapped issue 各發一次 live gh api 的 O(n) sweep
+        # （實測 57 次/tick）降為 O(鏡像為 True 的 authority 數)，通常為 0。
+        # 鏡像為 True 時才做**一次 targeted 複驗**：label 可能在兩次 monitor
+        # refresh 之間被人類移除，claim 是不可逆動作，行前以單發 live 讀取確認。
+        live_auto_label = authority.auto_label
+        if live_auto_label and authority.mapped_issues:
+            # 只有真的需要打 GitHub 的 authority 才受這道停手影響；鏡像 False
+            # 或沒有 mapped issue 的 authority 不讀 label，限流與它無關，照常 claim。
             if rate_limited:
                 results.append(
                     {
@@ -3769,6 +3778,7 @@ def run_auto_claim_scan(
                 )
                 continue
             issue_reads_failed = False
+            verified = False
             for issue in authority.mapped_issues:
                 if github_interval > 0 and issued_github_reads:
                     sleeper(github_interval)
@@ -3818,9 +3828,13 @@ def run_auto_claim_scan(
                     )
                     issue_reads_failed = True
                     break
-                live_auto_label = live_auto_label or "cortex:auto-on-going" in names
+                if AUTO_LABEL in names:
+                    verified = True
+                    break
             if issue_reads_failed:
                 continue
+            # 複驗結果為準：鏡像說有、live 說沒有 → 以 live 為準（label 已被移除）。
+            live_auto_label = verified
         try:
             result = _claim_action(
                 args={"action": "auto-scan"},

--- a/paulsha_cortex/monitor/providers.py
+++ b/paulsha_cortex/monitor/providers.py
@@ -888,6 +888,7 @@ class GitHubWorkProvider:
             if any(not isinstance(entity, dict) for entity in entities):
                 raise ValueError("GitHub entity is not an object")
             sources = tuple(self._entity_source(entity) for entity in entities)
+            auto_label_issues = _auto_label_issue_numbers(entities)
         except (json.JSONDecodeError, TypeError, ValueError, KeyError):
             return self._failure(attempted_at, "github API returned malformed JSON")
         sources = tuple(sorted(sources, key=lambda source: (source.kind, source.ref)))
@@ -908,6 +909,11 @@ class GitHubWorkProvider:
             revision=revision,
             diagnostics=(),
             sources=sources,
+            # R0.5 D1：issues 回應本來就含 labels——把 auto 派工 label 的持有者
+            # 記進 observations，讓 manager 的 auto-claim scan 讀鏡像即可判定，
+            # 不必每 tick 對每個 mapped issue 各發一次 live `gh api`（實測
+            # 57 次/tick，是 fleet 對 GitHub 最大的持續壓力源）。
+            observations={"auto_label_issues": auto_label_issues},
         )
 
     def _failure(self, attempted_at: str, diagnostic: str) -> ProviderSnapshot:
@@ -943,6 +949,41 @@ class GitHubWorkProvider:
             provider=self.provider_id,
             title=title,
         )
+
+
+# 與 coordinator/claim.py 的 AUTO_LABEL、doctor.py 的 AUTO_LABEL 同值。monitor 不
+# import coordinator.claim（避免把 deck/verification 整串拉進 monitor 行程），以
+# 常數複本＋本註解維持對齊；改名時三處同步（測試 test_auto_label_constant_alignment
+# 釘住）。
+AUTO_CLAIM_LABEL = "cortex:auto-on-going"
+
+
+def _auto_label_issue_numbers(entities: list[dict]) -> list[int]:
+    """開啟 auto 派工 label 的 open issue 編號（排序去重）。
+
+    labels 欄位缺失或形狀不合時 raise——與 `_entity_source` 同一個 try 區塊，
+    整包降級成 `github API returned malformed JSON`，不靜默吞掉半壞回應。
+    PR（`pull_request` 鍵存在）不參與 auto 派工，跳過。
+    """
+
+    numbers: set[int] = set()
+    for entity in entities:
+        if "pull_request" in entity:
+            continue
+        if entity.get("state") != "open":
+            continue
+        labels = entity.get("labels", [])
+        if not isinstance(labels, list):
+            raise ValueError("invalid GitHub labels field")
+        for label in labels:
+            if not isinstance(label, dict) or not isinstance(label.get("name"), str):
+                raise ValueError("invalid GitHub label entry")
+            if label["name"] == AUTO_CLAIM_LABEL:
+                number = entity["number"]
+                if isinstance(number, bool) or not isinstance(number, int):
+                    raise ValueError("invalid issue number")
+                numbers.add(number)
+    return sorted(numbers)
 
 
 class _GitHubRateLimitError(OSError):

--- a/tests/test_auto_label_mirror_d1.py
+++ b/tests/test_auto_label_mirror_d1.py
@@ -1,0 +1,172 @@
+"""R0.5 D1：auto label 走鏡像的三段鏈路（monitor 捕捉 → snapshot → claim 導出）。
+
+先前：canonical 路徑的 `WorkAuthority.auto_label` 硬編 `False`（claim.py），auto-claim
+scan 因此每 tick 對每個 mapped issue 各發一次 live `gh api` 讀 label——實測 57 次/tick，
+是 fleet 對 GitHub 最大的持續壓力源（#506），且 `GitHubPressureGate` 管不到 coordinator。
+
+D1 之後：`GitHubWorkProvider` 把持有 `cortex:auto-on-going` 的 open issue 編號寫進
+provider `observations["auto_label_issues"]`（issues 回應本來就含 labels，零額外 API）；
+`_authority_from_canonical_row` 據此導出 `auto_label`；scan 只對鏡像為 True 的 authority
+做一次 targeted 複驗。
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+from paulsha_cortex.coordinator import claim as claim_module
+from paulsha_cortex.coordinator.claim import load_work_authority
+from paulsha_cortex.monitor.providers import (
+    AUTO_CLAIM_LABEL,
+    GitHubWorkProvider,
+)
+from paulsha_cortex import doctor as doctor_module
+
+
+# ---------------------------------------------------------------------------
+# 常數對齊：三份複本不得漂移
+# ---------------------------------------------------------------------------
+
+
+def test_auto_label_constant_alignment() -> None:
+    assert AUTO_CLAIM_LABEL == claim_module.AUTO_LABEL == doctor_module.AUTO_LABEL
+
+
+# ---------------------------------------------------------------------------
+# monitor：GitHubWorkProvider 捕捉 label observation
+# ---------------------------------------------------------------------------
+
+
+def _issue_line(number: int, *, state: str = "open", labels: list[str] | None = None,
+                pull_request: bool = False) -> str:
+    entity: dict = {
+        "number": number,
+        "title": f"issue {number}",
+        "state": state,
+        "node_id": f"NODE{number}",
+        "updated_at": "2026-08-15T00:00:00Z",
+        "labels": [{"name": name} for name in (labels or [])],
+    }
+    if pull_request:
+        entity["pull_request"] = {"url": "x"}
+    return json.dumps(entity)
+
+
+class _Runner:
+    def __init__(self, stdout: str):
+        self._stdout = stdout
+
+    def run(self, argv, timeout):  # noqa: ARG002 - 契約簽章
+        return SimpleNamespace(returncode=0, stdout=self._stdout, stderr="")
+
+
+def test_work_provider_records_auto_label_issue_numbers() -> None:
+    stdout = "\n".join(
+        [
+            _issue_line(7, labels=[AUTO_CLAIM_LABEL, "bug"]),
+            _issue_line(9, labels=["bug"]),
+            # closed 不參與 auto 派工
+            _issue_line(11, state="closed", labels=[AUTO_CLAIM_LABEL]),
+            # PR 不參與
+            _issue_line(13, labels=[AUTO_CLAIM_LABEL], pull_request=True),
+            _issue_line(21, labels=[AUTO_CLAIM_LABEL]),
+        ]
+    )
+    snapshot = GitHubWorkProvider("acme/demo", runner=_Runner(stdout)).scan()
+    assert snapshot.status == "ok"
+    assert snapshot.observations == {"auto_label_issues": [7, 21]}
+
+
+def test_work_provider_malformed_labels_fail_closed() -> None:
+    entity = json.loads(_issue_line(7))
+    entity["labels"] = "not-a-list"
+    snapshot = GitHubWorkProvider(
+        "acme/demo", runner=_Runner(json.dumps(entity))
+    ).scan()
+    assert snapshot.status == "degraded"
+    assert "malformed" in snapshot.diagnostics[0]
+
+
+# ---------------------------------------------------------------------------
+# claim：canonical 路徑由 observations 導出 auto_label
+# ---------------------------------------------------------------------------
+
+
+def _canonical_snapshot(path: Path, *, observations: object) -> Path:
+    provider: dict = {
+        "status": "ok",
+        "revision": "gh-rev-1",
+        "last_success_at": "2026-08-15T00:00:00Z",
+    }
+    if observations is not None:
+        provider["observations"] = observations
+    path.write_text(
+        json.dumps(
+            {
+                "schema": "work-items-snapshot/v1",
+                "providers": {"github:acme/demo": provider},
+                "work_items": [
+                    {
+                        "repo": "acme/demo",
+                        "work_id": "auto-work",
+                        "sources": [
+                            {
+                                "confidence": "confirmed",
+                                "kind": "github_issue",
+                                "ref": "acme/demo#7",
+                                "source_id": "github_issue:acme/demo#7",
+                                "revision": "github:NODE7:2026-08-15T00:00:00Z",
+                                "status": "open",
+                                "provider": "github:acme/demo",
+                            },
+                            {
+                                "confidence": "confirmed",
+                                "kind": "todo",
+                                "ref": "docs/superpowers/workstreams/auto-work/todo.md",
+                                "source_id": "todo:acme/demo:docs/x",
+                                "revision": "local-sha256:abc",
+                                "status": "active",
+                                "provider": "repo:acme/demo",
+                            },
+                        ],
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_canonical_auto_label_derived_from_observations(tmp_path: Path) -> None:
+    snapshot = _canonical_snapshot(
+        tmp_path / "s.json", observations={"auto_label_issues": [7, 42]}
+    )
+    authority = load_work_authority(
+        repo="acme/demo", work_id="auto-work", snapshot_path=snapshot
+    )
+    assert authority.auto_label is True
+
+
+def test_canonical_auto_label_false_when_issue_not_listed(tmp_path: Path) -> None:
+    snapshot = _canonical_snapshot(
+        tmp_path / "s.json", observations={"auto_label_issues": [42]}
+    )
+    authority = load_work_authority(
+        repo="acme/demo", work_id="auto-work", snapshot_path=snapshot
+    )
+    assert authority.auto_label is False
+
+
+def test_canonical_auto_label_conservative_on_missing_or_malformed(
+    tmp_path: Path,
+) -> None:
+    for observations in (None, {}, {"auto_label_issues": "x"},
+                         {"auto_label_issues": [7, "x"]}, "not-a-dict"):
+        snapshot = _canonical_snapshot(tmp_path / "s.json", observations=observations)
+        authority = load_work_authority(
+            repo="acme/demo", work_id="auto-work", snapshot_path=snapshot
+        )
+        assert authority.auto_label is False, f"observations={observations!r} 應保守 False"

--- a/tests/test_work_actions.py
+++ b/tests/test_work_actions.py
@@ -2115,10 +2115,13 @@ def test_periodic_auto_scan_reads_every_issue_and_any_label_claims(tmp_path: Pat
 
 
 def test_periodic_auto_scan_fails_closed_if_any_mapped_issue_read_fails(tmp_path: Path) -> None:
+    # R0.5 D1 語意更新：targeted 複驗在**第一次確認 label** 後即停（early-break），
+    # 之後的 issue 不再讀取——fail-closed 適用於「確認前」的讀取失敗。
+    # 故本測試讓第一個 mapped issue（12）讀取失敗：複驗尚無任何確認 → 整體 blocked。
     snapshot = _snapshot(tmp_path / "snapshot.json", issues=(12, 13))
 
     def runner(argv, **kwargs):
-        if argv[-1].endswith("/13"):
+        if argv[-1].endswith("/12"):
             return SimpleNamespace(returncode=1, stdout="", stderr="boom")
         return SimpleNamespace(
             returncode=0,

--- a/tests/test_work_actions_auto_claim_pressure.py
+++ b/tests/test_work_actions_auto_claim_pressure.py
@@ -279,3 +279,104 @@ def test_invalid_interval_env_fails_loud(monkeypatch: pytest.MonkeyPatch) -> Non
     monkeypatch.setenv("PSC_MANAGER_GITHUB_INTERVAL_MS", "abc")
     with pytest.raises(ValueError, match="PSC_MANAGER_GITHUB_INTERVAL_MS"):
         work_actions._auto_claim_github_interval_seconds()
+
+
+# ---------------------------------------------------------------------------
+# R0.5 D1：鏡像優先——auto_label False 的 authority 零 API
+# ---------------------------------------------------------------------------
+
+
+def test_mirror_false_authorities_make_zero_github_calls(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """鏡像（authority.auto_label）為 False 時不得發出任何 gh 呼叫。
+
+    這是 D1 的核心承諾：先前的 O(mapped issues) sweep（實測 57 次/tick）
+    降為 O(鏡像為 True 的 authority 數)，常態為零。
+    """
+
+    monkeypatch.setenv("PSC_MANAGER_GITHUB_INTERVAL_MS", "0")
+    snapshot = tmp_path / "snapshot.json"
+    snapshot.write_text(
+        json.dumps(
+            {
+                "schema": "work-items-snapshot/v1",
+                "providers": {
+                    "github": {
+                        "provider_id": "github",
+                        "revision": "gh-1",
+                        "last_success_epoch": 100,
+                        "degraded": False,
+                    }
+                },
+                "work_items": [
+                    {
+                        "repo": "acme/demo",
+                        "work_id": f"demo-{index}",
+                        "mapped_issues": [10 + index],
+                        "mapped_prs": [],
+                        "mapped_openspec": [f"demo-{index}"],
+                        "mapped_todo_paths": [f"docs/todo-{index}.md"],
+                        "confirmed_todo": True,
+                        "auto_label": False,
+                        "source_revisions": [
+                            f"issue:{10 + index}@open",
+                            f"openspec:demo-{index}@1",
+                        ],
+                    }
+                    for index in range(1, 4)
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    state = tmp_path / "runs.json"
+    registry = JobRegistry(state_path=tmp_path / "jobs.json")
+    calls: list[tuple[str, ...]] = []
+
+    def counting_runner(argv, **kwargs):
+        calls.append(tuple(argv))
+        return _ok_runner(argv, **kwargs)
+
+    result = work_actions.run_auto_claim_scan(
+        snapshot_path=snapshot,
+        state_path=state,
+        now=lambda: 200,
+        runner=counting_runner,
+        workflow_registry=registry,
+        workflow_starter=work_actions._fallback_workflow_starter(registry, state),
+        sleeper=lambda _s: None,
+    )
+
+    assert calls == [], "鏡像 False 不得有任何 GitHub 呼叫"
+    # ignore 類決策不進 results（既有語意）：無可行動列＝正確
+    assert result == []
+    assert registry.list_workflow_runs() == []
+
+
+def test_mirror_true_but_label_removed_live_declines_claim(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """targeted 複驗以 live 為準：鏡像說有、live 已被人類移除 → 不 claim。"""
+
+    monkeypatch.setenv("PSC_MANAGER_GITHUB_INTERVAL_MS", "0")
+    snapshot = _snapshot(tmp_path / "snapshot.json", count=1)  # rows auto_label=True
+    state = tmp_path / "runs.json"
+    registry = JobRegistry(state_path=tmp_path / "jobs.json")
+
+    def no_label_runner(argv, **kwargs):
+        return SimpleNamespace(returncode=0, stdout=json.dumps({"labels": []}), stderr="")
+
+    result = work_actions.run_auto_claim_scan(
+        snapshot_path=snapshot,
+        state_path=state,
+        now=lambda: 200,
+        runner=no_label_runner,
+        workflow_registry=registry,
+        workflow_starter=work_actions._fallback_workflow_starter(registry, state),
+        sleeper=lambda _s: None,
+    )
+
+    # live 複驗未過 → decide_auto_claim ignore（不進 results）、不得建立 run
+    assert result == []
+    assert registry.list_workflow_runs() == []


### PR DESCRIPTION
R0.5 D1 部分交付：monitor observations 捕捉 auto label → canonical claim 導出 → scan 鏡像優先＋targeted 複驗。詳見 changelog fragment。

- [x] changelog fragment＋CHANGELOG [Unreleased]
- [x] 全套測試 2594 passed（新增 8 案：三段鏈路、鏡像 False 零呼叫、live 撤 label 不 claim、常數對齊）
- [x] policy-check 帶 PR context：24 pass / 0 fail
