### PR TITLE
fix(coordinator): tick resume 迴圈納入 define 階段的 ongoing run（#536 最小修）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
   auto-claim scan 廢除每 tick O(mapped issues) 的 live label sweep（實測 57 次/tick），
   鏡像 False 零 API、鏡像 True 僅一次 targeted 複驗（以 live 為準、確認即 early-break）。
   observations 缺失一律保守 False。
+- **Issue #536（最小修）：define 階段的 ongoing run 不再對 tick resume 迴圈隱形**——
+  phase filter 納入 `define`；stalled define run 每 tick 由 `resume_workflow_run` 接手
+  （其本已支援 define：reconcile planning transaction → dispatch planner 卡）。
+  needs_human 縱深防禦守衛不變。
 - **planner launcher 暫時性服務失敗被判 `content` 死路**——agy 暫時性 503 會印錯誤文字但
   exit 0，launcher parse 不到 JSON 即以 `content` 分類收場，而 `content` 禁用
   recover-planning：自癒型服務錯誤變永久死路。修法：`_extract_json` no-JSON 失敗帶 stdout

--- a/changelog.d/define-resume-coverage.md
+++ b/changelog.d/define-resume-coverage.md
@@ -1,0 +1,11 @@
+# define-resume-coverage
+
+- **`#536`（最小修）：tick resume 迴圈納入 define 階段的 ongoing run**——實測 run
+  `workflow-7a430d31eff66ef13630` 停在 define/ongoing/facets 空（brainstorm 已把 spec/design
+  發佈到 operator worktree，但 run 狀態未推進——發佈與狀態更新非同一事務），而
+  `manager_daemon` 的 resume 迴圈 phase filter 排除 `define`，使這種 run **對所有恢復機制
+  永久隱形**：無 facet 可呈現、`next_actions` 空、無任何 tick 會再碰它。
+  `resume_workflow_run` 本身完整支援 define（先 reconcile planning publication transaction、
+  再 dispatch planner 卡），排除毫無必要。#373 的 needs_human 縱深防禦守衛不受影響
+  （測試釘住）。`#536` 其餘項目（發佈／狀態同一事務、phase 心跳）留待 R0.5 D5 與
+  attestation 狀態機。

--- a/paulsha_cortex/coordinator/manager_daemon.py
+++ b/paulsha_cortex/coordinator/manager_daemon.py
@@ -952,7 +952,14 @@ def build_periodic_tick_runner(
                     or "needs_human" in workflow.facets
                 ):
                     continue
-                if workflow.current_phase not in {"plan", "build", "verify", "review"}:
+                # #536：define 必須在集合內。實測 run `workflow-7a430d31eff66ef13630`
+                # 停在 define/ongoing/facets 空（brainstorm 已發佈 artifacts 但 run
+                # 狀態未推進——發佈與狀態更新非同一事務），而 resume 迴圈排除
+                # define 使它**對所有恢復機制永久隱形**：無 facet 可呈現、無
+                # next_actions、無任何 tick 會再碰它。resume_workflow_run 本身
+                # 完整支援 define（先 reconcile planning publication transaction、
+                # 再 dispatch planner 卡），排除毫無必要。
+                if workflow.current_phase not in {"define", "plan", "build", "verify", "review"}:
                     continue
                 try:
                     active_ship_validator = workflow_ship_validator

--- a/tests/test_manager_daemon_tick_isolation.py
+++ b/tests/test_manager_daemon_tick_isolation.py
@@ -207,3 +207,118 @@ def test_periodic_tick_regression_no_failure_matches_existing_behavior(
     assert result["auto_claims"] == [{"work_id": "demo", "action": "claim"}]
     assert "auto_claim_failed" not in result
     assert "auto_claim_error" not in result
+
+
+def test_periodic_tick_resumes_stalled_define_phase_workflow(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """#536 迴歸：define 階段的 ongoing run 必須在 resume 迴圈視野內。
+
+    實測現場（run `workflow-7a430d31eff66ef13630`）：brainstorm 成功、spec/design
+    已發佈到 operator worktree，但 run 狀態未推進——`updated_at` 停在建立時刻、
+    facets 空、無錯誤。修法前 resume 迴圈的 phase filter 排除 `define`，這種 run
+    對所有恢復機制永久隱形（無 facet 可呈現、無 next_actions、無任何 tick 會碰它）。
+    `resume_workflow_run` 本身完整支援 define（先 reconcile planning publication
+    transaction、再 dispatch planner 卡），排除毫無必要。
+    """
+
+    workflow = SimpleNamespace(
+        run_id="run-define-stalled",
+        work_id="fix-instance-config-isolation",
+        repo="acme/demo",
+        status="ongoing",
+        facets=(),
+        current_phase="define",
+        claim_key="claim:legacy:demo",
+        source_revision="",
+    )
+    registry = SimpleNamespace(
+        _state_path=str(tmp_path / "jobs.json"),
+        list_workflow_runs=lambda: [workflow],
+    )
+    dispatcher = SimpleNamespace(_registry=registry, _git_runner=lambda args: "")
+
+    resume_calls: list[str] = []
+
+    def fake_resume_workflow_run(dispatcher_arg, **kwargs):
+        resume_calls.append(kwargs["run_id"])
+
+    monkeypatch.setattr(
+        manager_daemon.manager, "resume_workflow_run", fake_resume_workflow_run
+    )
+
+    def fake_run_tick(dispatcher_arg, **kwargs):
+        return {
+            "dispatch_skipped": False,
+            "dispatched": [],
+            "completed": [],
+            "errors": [],
+            "reaped": None,
+        }
+
+    runner = manager_daemon.build_periodic_tick_runner(
+        dispatcher=dispatcher,
+        specs_dir=str(tmp_path / "specs"),
+        handoff_dir=str(tmp_path / "handoff"),
+        launcher=object(),
+        run_tick_fn=fake_run_tick,
+        scan_specs_fn=lambda specs_dir: [],
+        auto_claim_fn=lambda: [],
+        workflow_identity_registry=object(),
+    )
+
+    runner()
+
+    assert resume_calls == ["run-define-stalled"]
+
+
+def test_periodic_tick_still_skips_needs_human_define_workflow(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """#536 反向守衛：define 納入後，needs_human 的 define run 仍須被跳過
+    （#373 縱深防禦不得因本修正而鬆動）。"""
+
+    workflow = SimpleNamespace(
+        run_id="run-define-nh",
+        work_id="demo",
+        repo="acme/demo",
+        status="ongoing",
+        facets=("needs_human",),
+        current_phase="define",
+        claim_key="claim:legacy:demo",
+        source_revision="",
+    )
+    registry = SimpleNamespace(
+        _state_path=str(tmp_path / "jobs.json"),
+        list_workflow_runs=lambda: [workflow],
+    )
+    dispatcher = SimpleNamespace(_registry=registry, _git_runner=lambda args: "")
+
+    resume_calls: list[str] = []
+
+    monkeypatch.setattr(
+        manager_daemon.manager,
+        "resume_workflow_run",
+        lambda dispatcher_arg, **kwargs: resume_calls.append(kwargs["run_id"]),
+    )
+
+    runner = manager_daemon.build_periodic_tick_runner(
+        dispatcher=dispatcher,
+        specs_dir=str(tmp_path / "specs"),
+        handoff_dir=str(tmp_path / "handoff"),
+        launcher=object(),
+        run_tick_fn=lambda dispatcher_arg, **kwargs: {
+            "dispatch_skipped": False,
+            "dispatched": [],
+            "completed": [],
+            "errors": [],
+            "reaped": None,
+        },
+        scan_specs_fn=lambda specs_dir: [],
+        auto_claim_fn=lambda: [],
+        workflow_identity_registry=object(),
+    )
+
+    runner()
+
+    assert resume_calls == []


### PR DESCRIPTION
#536 最小修：daemon resume 迴圈 phase filter 納入 define——stalled define run 不再對所有恢復機制隱形。needs_human 縱深防禦守衛不變。

- [x] changelog fragment＋CHANGELOG [Unreleased]
- [x] 全套測試 2588 passed（新增 2 案）
- [x] policy-check：23 pass / 0 fail（policy-exempt:issue-link）
