### PR TITLE
docs(workstreams): #518 todo scope 修正——legacy env 遷移＋exact-project 語意

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@
   phase filter 納入 `define`；stalled define run 每 tick 由 `resume_workflow_run` 接手
   （其本已支援 define：reconcile planning transaction → dispatch planner 卡）。
   needs_human 縱深防禦守衛不變。
+- **#518 workstream todo scope 修正**——初版誤把 installer 已具備的 config-root 派生當成
+  待實作項；收斂為 legacy env 遷移＋exact-project workspace 語意＋doctor 共用 root 告警。
+  舊世代 run 已結算，此為換代邊界的 todo 修正。
 - **planner launcher 暫時性服務失敗被判 `content` 死路**——agy 暫時性 503 會印錯誤文字但
   exit 0，launcher parse 不到 JSON 即以 `content` 分類收場，而 `content` 禁用
   recover-planning：自癒型服務錯誤變永久死路。修法：`_extract_json` no-JSON 失敗帶 stdout

--- a/changelog.d/518-todo-scope-correction.md
+++ b/changelog.d/518-todo-scope-correction.md
@@ -1,0 +1,9 @@
+# 518-todo-scope-correction
+
+- **`#518` workstream todo scope 修正**——初版要求「installer 讓 `PSC_PROJECT_CONFIG_ROOT`
+  隨 `PSC_AGENTS_ROOT` instance-scope」，但該派生現行 `deploy/installer.py:280-307` 已具備
+  （adversarial review 查核）。scope 收斂為實際缺口：**legacy instance env 遷移**（原子＋
+  可回滾，對應 doctor `managed-path-drift` 徵兆）、**workspace 語意裁決**（exact-project
+  宣告，禁止猜 parent 目錄重掃 sibling repo）、**共用 config root 的 doctor 告警**。
+  前一世代 run（authority 為錯誤前提的初版 todo）已依 v4 計畫結算，本修正即「於
+  supersede/reclaim 邊界修正 todo」的執行。

--- a/docs/superpowers/workstreams/fix-instance-config-isolation/todo.md
+++ b/docs/superpowers/workstreams/fix-instance-config-isolation/todo.md
@@ -5,31 +5,52 @@ work_item: fix-instance-config-isolation
 
 # fix-instance-config-isolation Todo
 
-`#518`：`PSC_AGENTS_ROOT` 已隨 instance 隔離，但 `PSC_PROJECT_CONFIG_ROOT` 沒有。
-`hippo` instance 因此讀到 `cortex` instance 的 `project-cortex.yaml`、繼承其
-`workspaces`（operator 的多專案根目錄），掃出**與 cortex 完全相同的 13 個 GitHub repo**
-（實測兩者 provider 集合逐一相同）。
+`#518`：`hippo` instance 的 monitor 讀到 `cortex` instance 的 `project-cortex.yaml`、
+繼承其 workspaces，掃描出**與 cortex 完全相同的 13 個 GitHub repo**——GitHub API 壓力
+平白翻倍且完全隱形（兩邊 snapshot 各自看起來都正常）。
 
-危害不是重複工作，而是 **GitHub API 壓力平白翻倍且完全隱形**：`#512` 的
-`GitHubPressureGate` 是 per-process 的，兩個 instance 各自節流到設定速率、互不知情
-彼此的退避窗，合計卻是兩倍。這是 `#506` secondary rate limit 難以靠節流壓下來的
-結構性成因之一——實測 primary 配額幾乎未動（`core remaining 4879/5000`）而 secondary
-反覆觸發，正符合「總量不高、瞬時併發過密」的特徵。兩個 instance 的 snapshot
-各自看起來都正常，operator 沒有任何訊號可察覺。
+## Scope 修正（0815，取代初版；經 adversarial review 與 installer 現況查核）
 
-與 `scripts/service-manager.sh` `#375` 註解記載的是同一類 isolation 破口
-（`PSC_MANAGER_SPECS_DIR`／`PSC_COORDINATOR_ROOT`／`PSC_SPECS_ROOT` 刻意留在 operator 域）；
-差別在於 specs 共掃只造成派工範圍重疊，project config 共用則直接放大 API 壓力。
+初版 todo 要求「installer 讓 `PSC_PROJECT_CONFIG_ROOT` 隨 `PSC_AGENTS_ROOT` instance-scope」
+——**這個派生現行 `deploy/installer.py:280-307` 已經具備**。實際缺口是三件別的事：
 
-已套用的 operator workaround（2026-08-14，非本 work item 的交付內容，僅為止血）：
-為 `hippo` instance 建立專屬 config root，provider 數 13 → 1，fleet 合計掃描面
-28 → 16。本 work item 要修的是**讓這件事不再需要 operator 手動發現與修補**。
+1. **legacy instance 的 env 未遷移**：`hippo` 的 env 檔是舊版 installer 產的
+   （`cortex doctor` 的 `managed-path-drift` 警告即此徵兆：「legacy install predates this
+   key becoming instance-scoped managed state; rerun `cortex install service` to adopt」）。
+   本 work item 的主體是**遷移路徑**，不是重新實作派生。
+2. **workspace 語意未裁決**：scanner 把 workspace 當「多 repo 父目錄」掃描；instance 專屬
+   config 若以「猜 repo parent」自動生成，會把 sibling repo 全部重新掃進來（正是本 issue
+   要消除的行為）。0814 的 operator workaround 用「空 sentinel 目錄＋`project-hippo.yaml`
+   明確 projects 宣告」達成單 repo 監控——正式修法需要一級語意，不靠猜。
+3. **診斷不可見**：兩個 instance 解析到同一 config root 時沒有任何告警；operator 得靠
+   `/proc/<pid>/environ` 對照才能發現。
 
 ## Tasks
 
-- [ ] installer／`service-manager.sh` 建立 instance 時，`PSC_PROJECT_CONFIG_ROOT` 隨 `PSC_AGENTS_ROOT` 一併 instance-scope（含既有 instance 的遷移路徑，不得靜默沿用共用根）
-- [ ] 新 instance 的 config root 需自動具備最小可用內容：`project-cortex.yaml`（`workspaces` 不得為空清單，見 `monitor/config.py:_parse_workspaces`）與 `model-identities.yaml`，避免落入 `#476` 的 monitor restart loop
-- [ ] `cortex doctor` 新增檢查：偵測到多個 instance 解析到同一個 project config root 時明確告警，並列出重複掃描的 repo 數與涉及的 instance 名稱
-- [ ] 診斷需可在**單一 instance 內**判斷（不能要求 operator 去讀別的行程的 `/proc/<pid>/environ` 才發現問題）
-- [ ] 測試涵蓋：兩 instance 共用 config root（應告警）、各自隔離（應通過）、instance config root 缺 `project-cortex.yaml`（應給出可行動的錯誤而非 restart loop）
-- [ ] 與 `#506` 建議 7／8（token 層級共享退避窗與速率預算）互為補件：設定隔離後，多 instance 共用同一顆 token 的本質問題仍在，需在本 work item 的文件中明確指出殘餘風險與後續 issue
+- [ ] **legacy env 遷移**：`cortex install service` 對既有 instance 提供明確的 adopt/遷移
+      流程——偵測 env 檔缺 instance-scoped `PSC_PROJECT_CONFIG_ROOT`（或指向共用根）時，
+      產生遷移後的 env 與最小 instance config（含非空 `workspaces` 的合法
+      `project-cortex.yaml`——`monitor/config.py:_parse_workspaces` 拒絕空清單——與
+      `model-identities.yaml`），遷移必須原子（寫暫存、驗證可載入、再替換）且可回滾
+- [ ] **workspace 語意**：monitor config 支援 **exact-project 宣告**（明列 repo 路徑，
+      不掃父目錄），或等價機制（如僅含 `project-*.yaml` projects、workspaces 允許為空）；
+      instance 遷移產生的 config 一律用 exact-project，**禁止以猜測 parent 目錄生成
+      workspaces**
+- [ ] **doctor 檢查**：偵測多個 instance 解析到同一 project config root 時明確告警，
+      列出涉及的 instance 名稱與重複掃描的 repo 數；診斷須在單一 instance 內可判定
+      （不得要求 operator 讀其他行程的 environ）
+- [ ] **測試**：legacy env 遷移（含回滾）、exact-project 不掃 sibling、共用 config root
+      告警、遷移後 `managed-path-drift` 警告消失、hippo 情境 fixture
+      （instance-scoped agents root ＋ 共用 config root → 遷移後單 repo 監控）
+- [ ] **驗證現場**：0814 的 operator workaround（hippo 專屬 config root，provider 13→1）
+      以正式機制取代後，行為等價且 workaround 檔案可移除
+
+## 現場紀錄（供實作者參考）
+
+- operator workaround 細節與量測：issue `#518` 首則與 0814 留言
+- 初版 todo 的錯誤前提與更正：issue `#518` 的 0814-15 兩則更正留言
+  （含「artifact 引用要查 planning_authority／evidence／planning-transactions journal
+  三處」的教訓）
+- 前一世代 run `workflow-7a430d31eff66ef13630` 已依 v4 計畫結算（superseded、outputs
+  隔離於 `prj_pri/.cortex-artifact-backups/f13630-settled/`），其產出不得成為本 work item
+  的 build authority


### PR DESCRIPTION
#518 workstream todo scope 修正：初版誤把 installer 已具備的 config-root 派生（deploy/installer.py:280-307）當待實作項。收斂為：legacy env 遷移（原子＋可回滾）、exact-project workspace 語意（禁止猜 parent 重掃 sibling）、doctor 共用 root 告警。舊世代 f13630 已依 v4 計畫結算，此為換代邊界的 todo 修正。

- [x] changelog fragment＋CHANGELOG [Unreleased]
- [x] policy-check：24 pass / 0 fail（policy-exempt:issue-link）
