### PR TITLE
fix(coordinator): 統一 outcome classification taxonomy 收編三 lane 分類器

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,20 @@
   不可變原則；世代內的衝突偵測維持 fail closed。no-clobber 錯誤訊息另附
   `existing owner=/mtime=/publishing run=`，operator 不必再挖 mtime 對時間軸。
 
+- **Issue #499 #500 #487 #485：三套 outcome 分類器收編成單一 taxonomy 模組**——
+  「executor 失敗該歸哪一類」在 planning／build／review 三個 lane 各自實作、各自漂移，
+  同型缺陷已第六次命中。根因不是關鍵字表寫錯，是餵進表裡的東西一開始就不該進來
+  （nested tool result、init metadata、CLI banner），或該當證據的結構化終局記錄被忽略。
+  新增 `coordinator/outcome_taxonomy.py`：四大類 outcome family（transient-service／
+  content／environment／auth）＋共用 markers 表＋證據分層，三個 lane 共同消費；#533 的
+  planning 先行實作一併收編。四張 issue 各自的誤判：#499 Claude review 429 被投影成
+  `foreign-review-absent`／`provider_outcome` null，改以結構化權威落 `rate_limited` 並
+  保留權威重置時刻（新增可選欄位 `provider_outcome.reset_at`）；#500 nested tool result
+  的 `timeout` 字樣被判 network transient，改由證據分層排除、終局 `aborted_streaming` 落
+  `unknown`；#487 init skill 清單的 `doc-coauthoring` 命中無界 `oauth` 被判 auth，收緊為
+  `\boauth\b` 並排除 init metadata；#485 Codex stdin banner 讓每次 foreign review 都成
+  `invalid-process-output`，改為 parse 前只剝離精確、位於串流開頭的已知 banner。
+  各 lane 對每類 outcome 的後續處置（retry／needs_human／終止）維持現狀。
 - **R0.5 D1（部分）：auto-claim label 判定改走 monitor 鏡像**——monitor 把持有
   `cortex:auto-on-going` 的 open issue 編號寫進 provider observations（issues 回應本來就含
   labels，零額外 API）；canonical claim 路徑據此導出 `auto_label`（原硬編 False）；

--- a/changelog.d/unified-outcome-taxonomy.md
+++ b/changelog.d/unified-outcome-taxonomy.md
@@ -1,0 +1,45 @@
+# unified-outcome-taxonomy
+
+- **`#499`／`#500`／`#487`／`#485`：三套 outcome 分類器收編成單一 taxonomy 模組**——
+  「executor 失敗該歸哪一類」在 planning／build／review 三個 lane 各自實作了一次，各自
+  漂移，於是同一型缺陷被踩了六次。根因不是關鍵字表寫錯，是**餵給關鍵字表的東西一開始
+  就不該進來**（nested tool result、init metadata、CLI banner），或反過來**該當證據的
+  結構化終局記錄被整個忽略**。新模組 `coordinator/outcome_taxonomy.py` 定義四大類
+  outcome family（transient-service／content／environment／auth）＋共用 markers 表，
+  三個 lane 共同消費；`#533` 的 planning 先行實作一併收編（其測試涵蓋原樣保留）。
+  分類器拆成兩層，順序不可互換：
+  - **證據分層**（`parse_stream_evidence`）：結構化終局記錄、CLI 原生 stderr、error 記錄
+    屬 provider 證據；模型自己的話只拿來判 content；nested tool result 與 init metadata
+    兩者皆不是，直接丟棄。64 KiB tail 開頭的殘行視為截斷產物，不當證據。
+  - **共用 markers 表**：結構化證據優先於文字關鍵字；文字判定順序沿用 `#369`/`#370`
+    （rate limit 必須先於 auth，限流訊息常同時帶 "authenticate" 字樣）。
+- **`#499`：Claude review 429 被投影成 `foreign-review-absent`、`provider_outcome` null**
+  ——stream-json 早就帶了機器可讀的限流證據（`rate_limit_event.status = rejected`、
+  `rateLimitType = five_hour`、`resetsAt`，終局 `api_error_status = 429`），review lane
+  卻完全不看，一律壓平成「沒有 review 結論」，operator 得自己翻 raw JSONL 才知道要等到
+  什麼時候才值得 retry-review。修法：結構化限流證據以 `STRUCTURED` authority 落
+  `rate_limited`、保留權威重置時刻（新增可選欄位 `provider_outcome.reset_at`，epoch 秒，
+  舊四鍵 payload 原樣合法）；review lane 補上 build lane 早已有的分類投影線，
+  `gate_reason` 改為 `foreign-review-provider-<outcome>`。**後續處置不變**：仍是
+  needs_human、仍只提供既有的手動 retry-review 出口。
+- **`#500`：tool parser 的 `timeout` 文字被誤判成 network failure**——`_TRANSIENT_RE` 的
+  無界 `timeout` token 命中了 nested tool-result 裡的
+  `Parser aborted (timeout, resource limit, or over-length)`，於是一個被 controller
+  SIGTERM 停掉 no-progress 迴圈的 job 被判成 `transient`／`retryable: true`，recovery
+  policy 據此排了不該排的重試，真正的 no-progress/tool-use 缺陷被 provider-degraded
+  標籤蓋掉。修法在證據分層：tool result 不是 provider 診斷，根本不會走到關鍵字表；
+  終局 `aborted_streaming` 以 `STRUCTURED` authority 落 `unknown`（維持既有不自動重試）。
+- **`#487`：`doc-coauthoring` 被誤判成 OAuth authentication failure**——
+  `github_rate_limit._AUTH_PATTERN` 的 `oauth` 是無界的，命中了 Claude init 正常技能名
+  `doc-coauthoring` 裡的 `coauthoring` 子字串，把一次無關的工具失敗轉成不可重試的
+  `auth`、封死正確的復原路徑。雙重修法：訊號收緊為 `\boauth\b`（`oauth token`／
+  `OAuth-2.0` 仍命中，`coauthoring` 不再命中），且 init metadata 本來就不該是分類證據
+  ——證據分層已將其排除。真正的 OAuth 失敗維持正向命中。
+- **`#485`：Codex JSONL stdin banner 讓每次 foreign review 都成 `invalid-process-output`**
+  ——Codex CLI 0.147.0 的 `codex exec ... --json` 會先把
+  `Reading additional input from stdin...` 印進同一份 evidence log，
+  `_review_log_has_only_json_lines()` 對每行做 `json.loads()`，於是 process exit 0、
+  `.psc-review-verdict.json` 也寫好了的成功 review 永遠到不了 verdict 驗證。採 issue 列
+  的第二條路：只在 parse 前剝離**精確、adapter 自有、且位於串流開頭**的已知 banner
+  （`KNOWN_PROCESS_BANNERS`）。JSONL 純度檢查本身一格未放寬——不在該表上的任何非 JSON
+  文字、以及出現在串流中段的同一句話，仍舊 fail closed。

--- a/paulsha_cortex/coordinator/manager.py
+++ b/paulsha_cortex/coordinator/manager.py
@@ -28,6 +28,7 @@ from . import completion
 from . import gate_ledger
 from . import planning_runtime
 from . import provider_backoff
+from . import outcome_taxonomy
 from . import provider_outcome
 from . import seams
 from . import review as foreign_review
@@ -827,6 +828,20 @@ def _completion_candidate_ref(
 
 
 def _review_log_has_only_json_lines(log_path: object) -> bool:
+    """reviewer 的 evidence log 是否為純 JSONL（非純者一律 `invalid-process-output`）。
+
+    #485：Codex CLI 0.147.0 的 `codex exec ... --json` 會先把
+    `Reading additional input from stdin...` 印進同一份 evidence log，於是**每
+    一次**成功的 Codex foreign review 都在讀 verdict 之前就被判
+    `invalid-process-output`——process exit 0、`.psc-review-verdict.json` 也
+    寫好了，卻永遠到不了 verdict 驗證。
+
+    修法採 issue 列的第二條路：只在 parse 前剝離「精確、adapter 自有」的已知
+    banner（`outcome_taxonomy.KNOWN_PROCESS_BANNERS`，且只認開頭連續的那幾
+    行）。JSONL 純度檢查本身一格未放寬：不在該表上的任何非 JSON 文字仍舊
+    fail closed。
+    """
+
     if not isinstance(log_path, str) or not log_path:
         return True
     path = Path(log_path)
@@ -836,7 +851,7 @@ def _review_log_has_only_json_lines(log_path: object) -> bool:
         lines = path.read_text(encoding="utf-8").splitlines()
     except (OSError, UnicodeDecodeError):
         return False
-    for line in lines:
+    for line in outcome_taxonomy.strip_known_process_banners(lines):
         if not line.strip():
             continue
         try:
@@ -1168,6 +1183,27 @@ def _launch_foreign_review(
         }
 
 
+def _review_failure_gate_reason(review_job: Mapping[str, object]) -> str:
+    """reviewer process 失敗時的 gate_reason（#499）。
+
+    修法前一律 `foreign-review-absent`：一個 provider 講得清清楚楚的限流
+    （Claude stream-json 帶 `rate_limit_event.status = rejected`、
+    `rateLimitType = five_hour`、`resetsAt`，終局 `api_error_status = 429`）
+    被壓平成「沒有 review 結論」，operator 得自己去翻 raw JSONL 才知道要等到
+    什麼時候才值得 retry-review。
+
+    分類已由 `Dispatcher._finalize_headless` 在 finalize 當下寫在 job 上，這裡
+    只是把它顯露出來。**後續處置不變**：仍是 needs_human、仍只提供既有的
+    手動 retry-review 出口——本修法只修「分錯類」，不動 recovery policy。
+    未分類（legacy job）或分不出來（UNKNOWN）維持既有字面值，不偽造分類。
+    """
+
+    classification = provider_outcome.classification_from_job(review_job)
+    if classification is None or classification.outcome is provider_outcome.ProviderOutcome.UNKNOWN:
+        return "foreign-review-absent"
+    return f"foreign-review-provider-{classification.outcome.value}"
+
+
 def _finalize_review_job(
     *,
     registry,
@@ -1220,7 +1256,11 @@ def _finalize_review_job(
             coordinator_root=coordinator_root,
         )
         _apply_review_evaluation(registry, slice_id, evaluation)
-        return evaluation, "needs_human", "foreign-review-absent"
+        # #499：gate_reason 帶上 typed provider outcome（gate evaluation
+        # artifact 的 `reason` 刻意維持 `reviewer-process-failed` 不變——那份
+        # artifact 是 immutable 的，改字面值會讓升級前後同一個 reviewer_job_id
+        # 的重新 finalize 撞 immutability）。
+        return evaluation, "needs_human", _review_failure_gate_reason(review_job)
     worktree = Path(str(review_job["worktree"]))
     review_head = verification._run_git(["-C", str(worktree), "rev-parse", "HEAD"], git_runner)
     if review_head["status"] != "ok" or review_head["stdout"].strip().lower() != candidate.lower():
@@ -1835,6 +1875,14 @@ def complete_tick(
                         identity_registry=identity_registry,
                         git_runner=git_runner,
                     )
+                    # #499：review lane 過去完全不投影分類，`provider_outcome`
+                    # 因此永遠是 null——一筆機器可讀的 429 被壓平成「沒有
+                    # review 結論」。build lane 早已這麼做（見下面
+                    # `elif status == "failed":`），這裡補上同一條線。
+                    if status == "failed":
+                        review_classification = provider_outcome.classification_from_job(job)
+                        if review_classification is not None:
+                            slice_provider_outcome_payload = review_classification.to_dict()
             else:
                 mismatches = _pinned_input_mismatches(slice_row) if slice_row is not None else []
 
@@ -6011,34 +6059,10 @@ def _is_planning_authority_residue_failure(reason: str | None) -> bool:
 
 # --- planner launcher 的暫時性服務失敗 ----------------------------------------
 #
-# 實測（2026-08-14，run `workflow-88d089d71416a754dda8`）：agy 服務暫時回
-# `Error: Eligibility check failed: UNAVAILABLE (code 503)`——**印錯誤文字但
-# exit 0**，launcher 因此去 parse stdout、找不到 JSON，失敗以
-# `primary-integration-malformed: ValueError: planning launcher returned no
-# JSON object` 收場，預設分類 `content` → `recover-planning` 被 #393 的
-# fail-closed 禁止 → 一個幾分鐘後自癒的 503 變成永久死路（同一指令 10 分鐘
-# 後重跑即成功）。這是 transient-誤判-死路模式的第五次命中（#500、#507 的
-# content 誤分類、worktree 汙染誤分類皆同族）。
-#
-# 判準刻意窄：只認 CLI/service 層的暫時性錯誤樣態（服務不可用、限流、逾時、
-# 連線層失敗）。模型「內容不從」（回散文不回 JSON、schema 不合）不在此列，
-# 維持 `content` 分類與 fail-closed 意圖——分辨依據是這些字樣出自 launcher
-# 轉印的服務錯誤，不會出現在合法的規劃輸出裡。
-_PLANNING_TRANSIENT_SERVICE_MARKERS = (
-    "unavailable",
-    "503",
-    "429",
-    "rate limit",
-    "too many requests",
-    "timed out",
-    "timeout",
-    "connection reset",
-    "connection refused",
-    "overloaded",
-    "temporarily",
-    "service_unavailable",
-    "eligibility check failed",
-)
+# #533 先行實作，2026-08-15 隨 #499／#500／#487／#485 收編進
+# `outcome_taxonomy`：三個 lane 共用同一張 markers 表，避免第七次同型漂移。
+# 這裡保留別名與判準函式，因為 planning lane 的呼叫端與其測試以此為名。
+_PLANNING_TRANSIENT_SERVICE_MARKERS = outcome_taxonomy.TRANSIENT_SERVICE_MARKERS
 
 
 def _is_planning_transient_service_failure(reason: str | None) -> bool:
@@ -6047,12 +6071,14 @@ def _is_planning_transient_service_failure(reason: str | None) -> bool:
     命中者分類改落 `environment`（與 #416 的殘留例外同路），讓
     `_resume_decision` 浮現 `recover-planning`——暫時性服務錯誤等它過去重跑
     即可，不該燒掉一個世代或落入 abandon 死路。
+
+    判準刻意窄：只認 CLI/service 層的暫時性錯誤樣態（服務不可用、限流、逾時、
+    連線層失敗）。模型「內容不從」（回散文不回 JSON、schema 不合）不在此列，
+    維持 `content` 分類與 fail-closed 意圖——分辨依據是這些字樣出自 launcher
+    轉印的服務錯誤，不會出現在合法的規劃輸出裡。
     """
 
-    if reason is None:
-        return False
-    lowered = reason.lower()
-    return any(marker in lowered for marker in _PLANNING_TRANSIENT_SERVICE_MARKERS)
+    return outcome_taxonomy.matches_transient_service_markers(reason)
 
 
 # --- issue #511：planning artifact 拒收的診斷面 -------------------------------

--- a/paulsha_cortex/coordinator/outcome_taxonomy.py
+++ b/paulsha_cortex/coordinator/outcome_taxonomy.py
@@ -1,0 +1,601 @@
+"""#499／#500／#487／#485：planning／build／review 三個 lane 共用的 outcome 分類 taxonomy。
+
+Root cause（四張 issue 的同一個根）：executor 失敗「該歸哪一類」這件事在三個
+lane 各自實作了一次——
+
+- planning lane：`manager._is_planning_transient_service_failure`（#533 先行
+  實作，本模組收編）。
+- build lane：`provider_outcome.classify_provider_failure`（#384）。
+- review lane：`manager._review_log_has_only_json_lines` ＋
+  `manager._finalize_review_job` 的 absent 判定。
+
+三份判準各自漂移，於是同一型缺陷被踩了六次：分類器把「不該當證據的文字」
+（nested tool result、init metadata、CLI banner）餵進了關鍵字比對，或者反過來
+把「該當證據的結構化終局記錄」整個忽略掉。四張 issue 的實測現場：
+
+- **#499**：Claude stream-json 已有 `rate_limit_event.status = rejected`
+  （`rateLimitType = five_hour`、`resetsAt`）＋終局 `api_error_status = 429`
+  這種**機器可讀的**限流證據，review lane 卻完全不看，一律投影成
+  `foreign-review-absent`／`provider_outcome = null`。
+- **#500**：build lane 把 64 KiB log tail 整段丟給關鍵字比對，`\\btimeout\\b`
+  命中了 nested tool-result 裡的 `Parser aborted (timeout, resource limit, or
+  over-length)`，於是一個被 controller SIGTERM 中斷的 job 被判成可重試的
+  network transient。
+- **#487**：同一段 tail 含 Claude init 的 skill 清單，`oauth` 這個無界 pattern
+  命中了正常技能名 `doc-coauthoring` 裡的 `coauthoring`，非 auth 失敗被判成
+  不可重試的 auth 失敗。
+- **#485**：Codex `exec --json` 會先印 `Reading additional input from
+  stdin...` 這行 adapter 自有 banner，review lane 的 JSONL 純度檢查對每行做
+  `json.loads()`，於是**每一次**成功的 Codex foreign review 都被判
+  `invalid-process-output`。
+
+本模組因此把分類拆成兩層，兩層都只有一份實作：
+
+1. **證據分層**（:func:`parse_stream_evidence`）——先決定「什麼文字有資格當
+   provider 層證據」。結構化終局記錄、CLI 原生 stderr、error 記錄屬
+   provider 證據；模型自己的話（assistant/user 訊息）只拿來判 content；nested
+   tool result 與 init metadata 兩者皆不是，直接丟棄。#500 與 #487 修的正是
+   這一層——不是關鍵字表寫錯，是餵給關鍵字表的東西一開始就不該進來。
+2. **共用 markers 表**（:data:`TRANSIENT_SERVICE_MARKERS` 等）與其上的
+   :func:`classify_text`／:func:`classify_structured_evidence`——結構化證據
+   優先於文字關鍵字；文字關鍵字的判定順序（rate limit → quota → auth →
+   content → transient）沿用 #369/#370 的教訓，限流訊息常同時帶
+   "authenticate"／"login" 字樣，rate limit 必須先判。
+
+四大類 outcome family（:class:`OutcomeFamily`）是跨 lane 的共同語彙；各 lane
+仍保有自己的既有詞彙（build lane 的六值 :class:`ProviderOutcome`、planning lane
+的 content／environment 二值），由本模組提供對照表，**不改各 lane 對每一類
+outcome 的後續處置**（retry／needs_human／終止一律維持現狀）——本模組只修
+「分錯類」本身。
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Iterable, Sequence
+
+from paulsha_cortex.github_rate_limit import is_auth_signal, is_rate_limit_signal
+
+from . import executor_auth
+
+__all__ = [
+    "OutcomeFamily",
+    "TextSignal",
+    "StructuredKind",
+    "TRANSIENT_SERVICE_MARKERS",
+    "INTERRUPTION_MARKERS",
+    "KNOWN_PROCESS_BANNERS",
+    "QUOTA_RE",
+    "TRANSIENT_RE",
+    "CONTENT_RE",
+    "FAMILY_BY_TEXT_SIGNAL",
+    "FAMILY_BY_STRUCTURED_KIND",
+    "TextClassification",
+    "StructuredSignal",
+    "StreamEvidence",
+    "matches_transient_service_markers",
+    "strip_known_process_banners",
+    "parse_stream_evidence",
+    "classify_structured_evidence",
+    "classify_text",
+]
+
+
+class OutcomeFamily(str, Enum):
+    """跨 lane 的四大類 outcome 語彙（＋ UNKNOWN 哨兵）。
+
+    - ``TRANSIENT_SERVICE``：服務層暫時性失敗（限流、503、逾時、連線層錯誤）。
+      等時間窗過去重跑即可，不該燒世代、不該落死路。
+    - ``CONTENT``：模型輸出本身的問題（內容政策拒答、回散文不回 JSON、schema
+      不合）。重跑同一個 candidate 不會變，維持既有 fail-closed 意圖。
+    - ``ENVIRONMENT``：本機／狀態層問題（殘留 worktree、額度需人工處理的帳單
+      與方案上限）。要人動手，但不是模型內容缺陷。
+    - ``AUTH``：憑證失效，需要人工重新登入。
+    """
+
+    TRANSIENT_SERVICE = "transient-service"
+    CONTENT = "content"
+    ENVIRONMENT = "environment"
+    AUTH = "auth"
+    UNKNOWN = "unknown"
+
+
+class TextSignal(str, Enum):
+    """文字關鍵字層的細分訊號——比 family 細，因為 build lane 的既有六值詞彙
+    需要區分 rate_limit 與 quota（兩者同屬 environment/transient-service 家族，
+    但 backoff 策略不同）。"""
+
+    RATE_LIMIT = "rate_limit"
+    QUOTA = "quota"
+    AUTH = "auth"
+    CONTENT = "content"
+    TRANSIENT = "transient"
+    NONE = "none"
+
+
+class StructuredKind(str, Enum):
+    """結構化終局證據層的訊號。文字關鍵字沒有 ``INTERRUPTED``——「這個 job 是
+    被 controller 中斷的」只有結構化終局記錄講得準（#500：中斷的 job 之所以被
+    誤判成 transient，正是因為沒人看終局記錄）。"""
+
+    RATE_LIMITED = "rate_limited"
+    TRANSIENT = "transient"
+    AUTH = "auth"
+    INTERRUPTED = "interrupted"
+
+
+# --------------------------------------------------------------- 共用 markers 表
+
+# planner launcher 的暫時性服務失敗樣態（原 `manager._PLANNING_TRANSIENT_SERVICE_MARKERS`，
+# #533 先行實作，本模組收編為單一真源）。
+#
+# 實測（2026-08-14，run `workflow-88d089d71416a754dda8`）：agy 服務暫時回
+# `Error: Eligibility check failed: UNAVAILABLE (code 503)`——**印錯誤文字但
+# exit 0**，launcher 因此去 parse stdout、找不到 JSON，失敗以
+# `primary-integration-malformed: ValueError: planning launcher returned no
+# JSON object` 收場，預設分類 `content` → `recover-planning` 被 #393 的
+# fail-closed 禁止 → 一個幾分鐘後自癒的 503 變成永久死路。
+#
+# 判準刻意窄：只認 CLI/service 層的暫時性錯誤樣態。模型「內容不從」（回散文
+# 不回 JSON、schema 不合）不在此列，維持 `content` 分類與 fail-closed 意圖
+# ——分辨依據是這些字樣出自 launcher 轉印的服務錯誤，不會出現在合法的規劃
+# 輸出裡。
+TRANSIENT_SERVICE_MARKERS: tuple[str, ...] = (
+    "unavailable",
+    "503",
+    "429",
+    "rate limit",
+    "too many requests",
+    "timed out",
+    "timeout",
+    "connection reset",
+    "connection refused",
+    "overloaded",
+    "temporarily",
+    "service_unavailable",
+    "eligibility check failed",
+)
+
+# Quota：固定週期用量上限（月配額、bulk usage limit），與 rate_limit（滑動時間窗、
+# 通常數十秒到數分鐘內重置）語意不同，值得分開分類以利未來對 quota 採不同的
+# backoff 策略。
+#
+# 刻意不收 "quota exceeded"／"usage limit" 這兩個措辭：`executor_auth`
+# 複用的 rate-limit 正則（見 executor_auth._RATE_LIMIT_RE／
+# github_rate_limit._RATE_LIMIT_PATTERN）已經把它們算進 rate-limit（兩者
+# 語意接近——都是「等時間窗過了就會恢復」），而 rate-limit 判定排在
+# quota 檢查之前，故這兩個措辭實際上永遠命中不到這裡；本類別只收「不是等
+# 時間窗、而是要人工處理（帳單、方案升級）」的措辭，避免死碼與誤導。
+QUOTA_RE = re.compile(
+    r"""
+    monthly\ limit
+    | plan\ limit
+    | billing
+    | insufficient\ credits?
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
+
+# Transient：網路/服務暫時性錯誤，與 rate limit 不同——這裡沒有「額度」語意，
+# 純粹是這一次呼叫失敗，重試通常會成功。
+#
+# #500：`\btimeout\b` 這種無界 token 本身沒寫錯，錯的是**餵什麼文字進來**。
+# 修法在 `parse_stream_evidence`：nested tool result（例如
+# `Parser aborted (timeout, resource limit, or over-length)` 這種工具層診斷）
+# 不屬 provider 證據，根本不會走到這張表。
+TRANSIENT_RE = re.compile(
+    r"""
+    connection\ reset
+    | econnreset
+    | timed?\ ?out
+    | \btimeout\b
+    | temporarily\ unavailable
+    | service\ unavailable
+    | bad\ gateway
+    | gateway\ time-?out
+    | \b50[0234]\b
+    | network\ error
+    | dns\b
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
+
+# Content：模型基於內容政策拒答，屬於「這次呼叫本身不該被無腦重試」的類別。
+CONTENT_RE = re.compile(
+    r"""
+    content\ (policy|filtered)
+    | refus(e|ed|ing)\ to\ (assist|help|continue)
+    | cannot\ assist
+    | violates\ (our|the)\ (usage\ )?polic
+    | safety\ (guidelines|system|filter)
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
+
+# #500：controller 中斷（SIGTERM 停掉 no-progress 迴圈）的終局樣態。命中者是
+# 「這個 job 被我們自己停掉」，既不是 provider 失敗也不是模型內容缺陷——不得
+# 被判成可重試的 transient，否則 recovery policy 會排錯重試、真正的
+# no-progress/tool-use 缺陷被 provider-degraded 標籤蓋掉。
+INTERRUPTION_MARKERS: tuple[str, ...] = (
+    "aborted_streaming",
+    "request interrupted by user",
+    "interrupted by user",
+)
+
+# #485：adapter 自有、且會出現在 evidence log 裡的 banner。**只收精確字面值**
+# ——這張表存在的目的是讓「已知的、adapter 自己印的那一行」不再讓整份合法
+# JSONL 被判 invalid-process-output，而不是放寬 JSONL 純度檢查本身：任何不在
+# 這張表上的非 JSON 文字仍然 fail closed。
+#
+# 實測環境：Codex CLI 0.147.0，`codex exec ... --json`。
+KNOWN_PROCESS_BANNERS: tuple[str, ...] = ("Reading additional input from stdin...",)
+
+# 文字訊號 → 四大 family 的對照。quota 落 ENVIRONMENT 而非 TRANSIENT_SERVICE：
+# 固定週期額度不會「等一下就好」，要人去處理帳單／方案，語意上與服務暫時性
+# 失敗相反。
+FAMILY_BY_TEXT_SIGNAL: dict[TextSignal, OutcomeFamily] = {
+    TextSignal.RATE_LIMIT: OutcomeFamily.TRANSIENT_SERVICE,
+    TextSignal.QUOTA: OutcomeFamily.ENVIRONMENT,
+    TextSignal.AUTH: OutcomeFamily.AUTH,
+    TextSignal.CONTENT: OutcomeFamily.CONTENT,
+    TextSignal.TRANSIENT: OutcomeFamily.TRANSIENT_SERVICE,
+    TextSignal.NONE: OutcomeFamily.UNKNOWN,
+}
+
+FAMILY_BY_STRUCTURED_KIND: dict[StructuredKind, OutcomeFamily] = {
+    StructuredKind.RATE_LIMITED: OutcomeFamily.TRANSIENT_SERVICE,
+    StructuredKind.TRANSIENT: OutcomeFamily.TRANSIENT_SERVICE,
+    StructuredKind.AUTH: OutcomeFamily.AUTH,
+    # 中斷不是四大類的任何一類——它是「我們自己停的」，故落 UNKNOWN 哨兵，
+    # 由呼叫端維持既有的不自動重試處置。
+    StructuredKind.INTERRUPTED: OutcomeFamily.UNKNOWN,
+}
+
+
+def matches_transient_service_markers(reason: str | None) -> bool:
+    """判斷一段失敗描述是否命中服務層暫時性樣態（:data:`TRANSIENT_SERVICE_MARKERS`）。
+
+    planning lane（`manager._is_planning_transient_service_failure`）的判準即
+    本函式；收編自 #533 的先行實作，行為逐字不變。
+    """
+
+    if reason is None:
+        return False
+    lowered = reason.lower()
+    return any(marker in lowered for marker in TRANSIENT_SERVICE_MARKERS)
+
+
+def strip_known_process_banners(lines: Sequence[str]) -> list[str]:
+    """剝離 evidence log **開頭**的已知 adapter banner（#485）。
+
+    只剝離開頭連續、且與 :data:`KNOWN_PROCESS_BANNERS` 精確相等（去除首尾空白
+    後）的行；一碰到任何其他內容就停止。兩個刻意的窄化：
+
+    - **精確字面值**：非 JSON 的意外雜訊仍然留在原地讓上游 fail closed
+      （#485 acceptance：`Unexpected non-JSON text still fails closed`）。
+    - **只看開頭**：banner 的語意就是「JSONL 串流開始前印的那一行」。出現在
+      串流中段的同一句話並非 banner，不予剝離。
+    """
+
+    kept: list[str] = []
+    for index, line in enumerate(lines):
+        candidate = line.strip()
+        if not candidate:
+            kept.append(line)
+            continue
+        if candidate in KNOWN_PROCESS_BANNERS:
+            continue
+        return kept + list(lines[index:])
+    return kept
+
+
+# --------------------------------------------------------------- 證據分層
+
+# Claude stream-json 的 init 記錄（`{"type":"system","subtype":"init", ...}`）
+# 帶 tools／slash_commands／skills 清單。#487：正常技能名 `doc-coauthoring`
+# 裡的 `coauthoring` 命中了無界的 `oauth` pattern，一次無關的工具失敗因此被判
+# 成不可重試的 auth 失敗。init 是啟動 metadata，不是任何失敗的證據——整筆丟棄。
+_INIT_RECORD_TYPE = "system"
+_INIT_RECORD_SUBTYPE = "init"
+
+# assistant/user 訊息裡的 content block：`tool_use`／`tool_result` 是工具層的
+# 輸入輸出，既不是 provider 診斷也不是模型自己的話。#500 的 `Parser aborted
+# (timeout, ...)` 正是一筆 permission-denied 的 `tool_result`。
+_TOOL_BLOCK_TYPES = frozenset({"tool_use", "tool_result"})
+
+# 模型自己的話：只拿來判 content-policy 拒答，不得驅動 transient／auth／
+# rate-limit 判定（#500：`distinguish provider/API diagnostics from model prose`）。
+_MODEL_RECORD_TYPES = frozenset({"assistant", "user"})
+
+_TERMINAL_RECORD_TYPE = "result"
+
+# HTTP status → 結構化訊號。刻意只收沒有歧義的三種：429 限流、5xx 服務端
+# 暫時性失敗、401 憑證失效。403 不收——GitHub 用它表限流、其他 provider 用它
+# 表權限，沒有共識時交給文字層判。
+_STRUCTURED_KIND_BY_HTTP_STATUS: dict[int, StructuredKind] = {
+    401: StructuredKind.AUTH,
+    429: StructuredKind.RATE_LIMITED,
+    500: StructuredKind.TRANSIENT,
+    502: StructuredKind.TRANSIENT,
+    503: StructuredKind.TRANSIENT,
+    504: StructuredKind.TRANSIENT,
+    529: StructuredKind.TRANSIENT,
+}
+
+_RATE_LIMIT_EVENT_KEY = "rate_limit_event"
+_RATE_LIMIT_REJECTED_STATUSES = frozenset({"rejected"})
+_RESET_AT_KEYS = ("resetsAt", "resets_at", "reset_at", "resetAt")
+
+
+@dataclass(frozen=True)
+class StreamEvidence:
+    """一份 executor log tail 拆出的分層證據（純資料）。
+
+    ``provider_text``／``model_text`` 的分野即本模組存在的理由：關鍵字表沒寫
+    錯，錯的是餵進去的東西。
+    """
+
+    provider_text: str
+    model_text: str
+    terminal: dict[str, Any] | None
+    rate_limit_events: tuple[dict[str, Any], ...]
+    structured: bool
+
+
+@dataclass(frozen=True)
+class TextClassification:
+    signal: TextSignal
+    detail: str
+
+    @property
+    def family(self) -> OutcomeFamily:
+        return FAMILY_BY_TEXT_SIGNAL[self.signal]
+
+
+@dataclass(frozen=True)
+class StructuredSignal:
+    kind: StructuredKind
+    detail: str
+    # #499：provider 給的權威重置時刻（Claude `rate_limit_event.resetsAt`，
+    # epoch 秒）。保存下來，operator 與無人值守流程才不必自己翻 JSONL、也不會
+    # 在權威重置時刻之前就重試。
+    reset_at: int | None = None
+
+    @property
+    def family(self) -> OutcomeFamily:
+        return FAMILY_BY_STRUCTURED_KIND[self.kind]
+
+
+def _text_blocks(record: dict[str, Any]) -> list[str]:
+    """從 assistant/user 記錄抽出模型自己的話，跳過 tool_use／tool_result。"""
+
+    message = record.get("message")
+    content = message.get("content") if isinstance(message, dict) else record.get("content")
+    if isinstance(content, str):
+        return [content]
+    if not isinstance(content, list):
+        return []
+    texts: list[str] = []
+    for block in content:
+        if not isinstance(block, dict):
+            continue
+        if block.get("type") in _TOOL_BLOCK_TYPES:
+            continue
+        text = block.get("text")
+        if isinstance(text, str) and text:
+            texts.append(text)
+    return texts
+
+
+def _collect_rate_limit_events(record: dict[str, Any]) -> list[dict[str, Any]]:
+    events: list[dict[str, Any]] = []
+    nested = record.get(_RATE_LIMIT_EVENT_KEY)
+    if isinstance(nested, dict):
+        events.append(nested)
+    if record.get("type") == _RATE_LIMIT_EVENT_KEY or record.get("subtype") == _RATE_LIMIT_EVENT_KEY:
+        events.append(record)
+    return events
+
+
+def _coerce_int(value: object) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        try:
+            return int(value.strip())
+        except ValueError:
+            return None
+    return None
+
+
+def parse_stream_evidence(output: str | None) -> StreamEvidence:
+    """把 executor 的 log tail 拆成分層證據。
+
+    非 JSON 行一律視為 provider 證據——那是 CLI 自己印到 stdout/stderr 的東西
+    （agy 的 `Error: Eligibility check failed: UNAVAILABLE (code 503)` 即是），
+    也讓「呼叫端直接丟一段純文字進來」的既有用法行為完全不變。
+
+    64 KiB tail 的**第一行**常是被切半的 JSON。只要其他行解析得出 JSON 記錄，
+    這種開頭殘行就是截斷產物而非 CLI 輸出，予以丟棄——否則被切半的 tool
+    result 又會把 #500 的坑原樣搬回來。
+    """
+
+    text = output or ""
+    lines = text.splitlines()
+    records: list[dict[str, Any]] = []
+    raw_lines: list[str] = []
+    first_content_index: int | None = None
+    first_content_parsed = False
+    parsed_any = False
+
+    for index, line in enumerate(lines):
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if first_content_index is None:
+            first_content_index = index
+        try:
+            payload = json.loads(stripped)
+        except (json.JSONDecodeError, ValueError):
+            raw_lines.append(stripped)
+            continue
+        if isinstance(payload, dict):
+            records.append(payload)
+            parsed_any = True
+            if index == first_content_index:
+                first_content_parsed = True
+        else:
+            raw_lines.append(stripped)
+
+    if parsed_any and not first_content_parsed and raw_lines:
+        # 開頭殘行：丟棄（見 docstring）。
+        raw_lines = raw_lines[1:]
+
+    provider_chunks: list[str] = list(raw_lines)
+    model_chunks: list[str] = []
+    terminal: dict[str, Any] | None = None
+    rate_limit_events: list[dict[str, Any]] = []
+
+    for record in records:
+        record_type = record.get("type")
+        subtype = record.get("subtype")
+        events = _collect_rate_limit_events(record)
+        if events:
+            rate_limit_events.extend(events)
+            provider_chunks.append(json.dumps(record, ensure_ascii=False, sort_keys=True))
+            continue
+        if record_type == _INIT_RECORD_TYPE and subtype == _INIT_RECORD_SUBTYPE:
+            # #487：init metadata（skill/tool 清單）不是任何失敗的證據。
+            continue
+        if record_type in _MODEL_RECORD_TYPES:
+            # #500：模型自己的話只判 content；nested tool result 直接跳過。
+            model_chunks.extend(_text_blocks(record))
+            continue
+        if record_type == _TERMINAL_RECORD_TYPE:
+            # 終局記錄是權威證據，整筆納入 provider 證據（後者仍是最後一筆勝出）。
+            terminal = record
+            provider_chunks.append(json.dumps(record, ensure_ascii=False, sort_keys=True))
+            continue
+        provider_chunks.append(json.dumps(record, ensure_ascii=False, sort_keys=True))
+
+    return StreamEvidence(
+        provider_text="\n".join(provider_chunks),
+        model_text="\n".join(model_chunks),
+        terminal=terminal,
+        rate_limit_events=tuple(rate_limit_events),
+        structured=parsed_any,
+    )
+
+
+def _rejected_rate_limit_event(
+    events: Iterable[dict[str, Any]],
+) -> tuple[dict[str, Any], int | None] | None:
+    for event in events:
+        status = event.get("status")
+        if isinstance(status, str) and status.strip().lower() in _RATE_LIMIT_REJECTED_STATUSES:
+            reset_at = None
+            for key in _RESET_AT_KEYS:
+                reset_at = _coerce_int(event.get(key))
+                if reset_at is not None:
+                    break
+            return event, reset_at
+    return None
+
+
+def _terminal_http_status(terminal: dict[str, Any]) -> int | None:
+    for key in ("api_error_status", "status_code", "http_status"):
+        status = _coerce_int(terminal.get(key))
+        if status is not None:
+            return status
+    return None
+
+
+def _terminal_is_interrupted(terminal: dict[str, Any]) -> bool:
+    haystack = json.dumps(terminal, ensure_ascii=False, sort_keys=True).lower()
+    return any(marker in haystack for marker in INTERRUPTION_MARKERS)
+
+
+def classify_structured_evidence(evidence: StreamEvidence) -> StructuredSignal | None:
+    """結構化終局證據的分類——沒有可判定的結構化訊號時回 ``None``（呼叫端退回
+    文字關鍵字層）。
+
+    判定順序：provider 明講的限流事件 → 終局 HTTP status → 中斷樣態。前兩者
+    是 provider 對「發生了什麼」的權威陳述（#499 的 429 即在此浮現）；中斷樣態
+    排最後，因為一個先被限流、後被我們停掉的 job，限流才是根因。
+    """
+
+    rejected = _rejected_rate_limit_event(evidence.rate_limit_events)
+    if rejected is not None:
+        event, reset_at = rejected
+        limit_type = event.get("rateLimitType") or event.get("rate_limit_type")
+        suffix = f" ({limit_type})" if isinstance(limit_type, str) and limit_type else ""
+        return StructuredSignal(
+            kind=StructuredKind.RATE_LIMITED,
+            detail=f"structured rate_limit_event rejected{suffix}",
+            reset_at=reset_at,
+        )
+
+    terminal = evidence.terminal
+    if terminal is None:
+        return None
+
+    status = _terminal_http_status(terminal)
+    kind = _STRUCTURED_KIND_BY_HTTP_STATUS.get(status) if status is not None else None
+    if kind is not None:
+        return StructuredSignal(
+            kind=kind,
+            detail=f"structured terminal result api status {status}",
+        )
+
+    if _terminal_is_interrupted(terminal):
+        return StructuredSignal(
+            kind=StructuredKind.INTERRUPTED,
+            detail="structured terminal result reports controller interruption",
+        )
+    return None
+
+
+def classify_text(
+    *,
+    exit_code: int,
+    provider_text: str,
+    model_text: str = "",
+) -> TextClassification:
+    """文字關鍵字層的共用分類器。
+
+    判定順序沿用 #369/#370：rate limit 必須排在 auth 之前——GitHub／provider
+    的限流訊息常同時帶 "authenticate"／"login" 字樣（例如「請重新授權以取得
+    更高額度」），auth 先判會把可重試的限流誤判成死掉的憑證。
+
+    ``model_text`` 只參與 content-policy 判定：模型的散文不是 provider 診斷
+    （#500），但拒答本來就只會出現在模型自己的話裡。
+    """
+
+    cli_status, cli_detail = executor_auth.classify_cli_output(exit_code, provider_text)
+
+    if cli_status == "rate_limited" or is_rate_limit_signal(provider_text):
+        return TextClassification(
+            TextSignal.RATE_LIMIT,
+            f"rate limit signal detected in executor output ({cli_detail})",
+        )
+    if QUOTA_RE.search(provider_text):
+        return TextClassification(TextSignal.QUOTA, "quota signal detected in executor output")
+    if cli_status == "logged_out" or is_auth_signal(provider_text):
+        return TextClassification(
+            TextSignal.AUTH,
+            f"auth/login signal detected in executor output ({cli_detail})",
+        )
+    if CONTENT_RE.search(provider_text) or CONTENT_RE.search(model_text):
+        return TextClassification(
+            TextSignal.CONTENT, "content-policy signal detected in executor output"
+        )
+    if TRANSIENT_RE.search(provider_text):
+        return TextClassification(
+            TextSignal.TRANSIENT, "transient/network signal detected in executor output"
+        )
+    return TextClassification(TextSignal.NONE, f"no definitive signal (exit {exit_code})")

--- a/paulsha_cortex/coordinator/provider_outcome.py
+++ b/paulsha_cortex/coordinator/provider_outcome.py
@@ -30,18 +30,24 @@ hint 不升 authoritative」vs. recovery matrix 期待 rate_limited 在 copilot
   不矛盾。
 - :data:`SignalAuthority.HINT` —— exit code 非零但無任何已知訊號匹配。只供
   人類判讀，不驅動任何自動決策（既不 retry 也不變更 gate_reason 之外的欄位）。
+
+**#499／#500／#487（2026-08-15）**：分類器本身移交
+:mod:`paulsha_cortex.coordinator.outcome_taxonomy`——三個 lane 共用同一份
+markers 表與同一套證據分層，本模組只保留 build lane 的六值詞彙
+（:class:`ProviderOutcome`）與 authority 分級。三個實質修正隨之落地：
+
+- 結構化終局證據優先於文字關鍵字（#499：`rate_limit_event` / 429 終局狀態）。
+- nested tool result 與 init metadata 不再是分類證據（#500 / #487）。
+- rate-limit 帶回 provider 給的權威重置時刻（:attr:`ProviderFailureClassification.reset_at`）。
 """
 
 from __future__ import annotations
 
-import re
 from dataclasses import dataclass
 from enum import Enum
 from typing import Mapping
 
-from paulsha_cortex.github_rate_limit import is_auth_signal, is_rate_limit_signal
-
-from . import executor_auth
+from . import outcome_taxonomy
 
 __all__ = [
     "ProviderOutcome",
@@ -80,58 +86,31 @@ class SignalAuthority(str, Enum):
 # 沒有訊號可支持任何自動決策）。
 RETRYABLE_OUTCOMES = frozenset({ProviderOutcome.RATE_LIMITED, ProviderOutcome.TRANSIENT})
 
+# 分類結果 payload 的必要鍵。`reset_at` 是可選鍵（#499：只有帶得到權威重置
+# 時刻的 rate-limit 才會有），故舊狀態檔的四鍵 payload 仍原樣可讀。
 _PROVIDER_OUTCOME_FIELDS = frozenset({"outcome", "authority", "reason", "retryable"})
+_PROVIDER_OUTCOME_OPTIONAL_FIELDS = frozenset({"reset_at"})
 
-# Quota：固定週期用量上限（月配額、bulk usage limit），與 rate_limit（滑動時間窗、
-# 通常數十秒到數分鐘內重置）語意不同，值得分開分類以利未來對 quota 採不同的
-# backoff 策略（本票僅分類，不對 quota 做 bounded retry——見 RETRYABLE_OUTCOMES）。
-#
-# 刻意不收 "quota exceeded"／"usage limit" 這兩個措辭：`executor_auth`
-# 複用的 rate-limit 正則（見 executor_auth._RATE_LIMIT_RE／
-# github_rate_limit._RATE_LIMIT_PATTERN）已經把它們算進 rate-limit（兩者
-# 語意接近——都是「等時間窗過了就會恢復」），而 rate-limit 判定排在本模組
-# quota 檢查之前，故這兩個措辭實際上永遠命中不到這裡；本類別只收「不是等
-# 時間窗、而是要人工處理（帳單、方案升級）」的措辭，避免死碼與誤導。
-_QUOTA_RE = re.compile(
-    r"""
-    monthly\ limit
-    | plan\ limit
-    | billing
-    | insufficient\ credits?
-    """,
-    re.IGNORECASE | re.VERBOSE,
-)
+# markers 表已移交 outcome_taxonomy（#499／#500／#487／#485：三個 lane 共用
+# 單一真源）。以下對照表把 taxonomy 的細分訊號翻回本 lane 的六值詞彙。
+_OUTCOME_BY_TEXT_SIGNAL: dict[outcome_taxonomy.TextSignal, ProviderOutcome] = {
+    outcome_taxonomy.TextSignal.RATE_LIMIT: ProviderOutcome.RATE_LIMITED,
+    outcome_taxonomy.TextSignal.QUOTA: ProviderOutcome.QUOTA,
+    outcome_taxonomy.TextSignal.AUTH: ProviderOutcome.AUTH,
+    outcome_taxonomy.TextSignal.CONTENT: ProviderOutcome.CONTENT,
+    outcome_taxonomy.TextSignal.TRANSIENT: ProviderOutcome.TRANSIENT,
+    outcome_taxonomy.TextSignal.NONE: ProviderOutcome.UNKNOWN,
+}
 
-# Transient：網路/服務暫時性錯誤，與 rate limit 不同——這裡沒有「額度」語意，
-# 純粹是這一次呼叫失敗，重試通常會成功。
-_TRANSIENT_RE = re.compile(
-    r"""
-    connection\ reset
-    | econnreset
-    | timed?\ ?out
-    | \btimeout\b
-    | temporarily\ unavailable
-    | service\ unavailable
-    | bad\ gateway
-    | gateway\ time-?out
-    | \b50[0234]\b
-    | network\ error
-    | dns\b
-    """,
-    re.IGNORECASE | re.VERBOSE,
-)
-
-# Content：模型基於內容政策拒答，屬於「這次呼叫本身不該被無腦重試」的類別。
-_CONTENT_RE = re.compile(
-    r"""
-    content\ (policy|filtered)
-    | refus(e|ed|ing)\ to\ (assist|help|continue)
-    | cannot\ assist
-    | violates\ (our|the)\ (usage\ )?polic
-    | safety\ (guidelines|system|filter)
-    """,
-    re.IGNORECASE | re.VERBOSE,
-)
+# 結構化訊號 → 本 lane 詞彙。`INTERRUPTED` 落 UNKNOWN：controller 中斷既非
+# provider 失敗也非模型內容缺陷，維持既有「不自動重試」處置（#500 要的正是
+# 不要再把它當成 transient 排重試）。
+_OUTCOME_BY_STRUCTURED_KIND: dict[outcome_taxonomy.StructuredKind, ProviderOutcome] = {
+    outcome_taxonomy.StructuredKind.RATE_LIMITED: ProviderOutcome.RATE_LIMITED,
+    outcome_taxonomy.StructuredKind.TRANSIENT: ProviderOutcome.TRANSIENT,
+    outcome_taxonomy.StructuredKind.AUTH: ProviderOutcome.AUTH,
+    outcome_taxonomy.StructuredKind.INTERRUPTED: ProviderOutcome.UNKNOWN,
+}
 
 
 @dataclass(frozen=True)
@@ -141,6 +120,10 @@ class ProviderFailureClassification:
     outcome: ProviderOutcome
     authority: SignalAuthority
     reason: str
+    # #499：provider 給的權威重置時刻（epoch 秒），目前只有結構化限流證據
+    # （Claude `rate_limit_event.resetsAt`）帶得到。None 時 `to_dict()` 不寫這個
+    # 鍵，舊讀取端與舊狀態檔的四鍵形狀完全不受影響。
+    reset_at: int | None = None
 
     @property
     def retryable(self) -> bool:
@@ -149,12 +132,15 @@ class ProviderFailureClassification:
         return self.authority is not SignalAuthority.HINT and self.outcome in RETRYABLE_OUTCOMES
 
     def to_dict(self) -> dict[str, object]:
-        return {
+        payload: dict[str, object] = {
             "outcome": self.outcome.value,
             "authority": self.authority.value,
             "reason": self.reason,
             "retryable": self.retryable,
         }
+        if self.reset_at is not None:
+            payload["reset_at"] = self.reset_at
+        return payload
 
     @classmethod
     def from_dict(cls, payload: object) -> "ProviderFailureClassification | None":
@@ -162,7 +148,12 @@ class ProviderFailureClassification:
         不阻塞既有讀路徑——這只是輔助分類，不是授權欄位）。
         """
 
-        if not isinstance(payload, Mapping) or set(payload) != _PROVIDER_OUTCOME_FIELDS:
+        if not isinstance(payload, Mapping):
+            return None
+        keys = set(payload)
+        if not _PROVIDER_OUTCOME_FIELDS <= keys or keys - (
+            _PROVIDER_OUTCOME_FIELDS | _PROVIDER_OUTCOME_OPTIONAL_FIELDS
+        ):
             return None
         outcome = payload.get("outcome")
         authority = payload.get("authority")
@@ -174,20 +165,38 @@ class ProviderFailureClassification:
             return None
         if not isinstance(reason, str) or not reason:
             return None
-        return cls(outcome=outcome_enum, authority=authority_enum, reason=reason)
+        reset_at = payload.get("reset_at")
+        if reset_at is not None and (not isinstance(reset_at, int) or isinstance(reset_at, bool)):
+            return None
+        return cls(
+            outcome=outcome_enum,
+            authority=authority_enum,
+            reason=reason,
+            reset_at=reset_at,
+        )
 
 
 def classify_provider_failure(*, exit_code: int, output: str | None) -> ProviderFailureClassification:
     """把一次 executor 失敗的 (exit_code, 合併 stdout/stderr 文字) 分類成 typed outcome。
 
-    Rate limit 判定必須排在 auth 判定之前（沿用 #369/#370 的教訓：GitHub／
-    provider 的限流訊息常同時帶有 "authenticate"／"login" 字樣）。呼叫端只在
-    確認這是一次失敗（exit_code != 0 或呼叫端已知 status == "failed"）時呼叫
-    本函式；exit_code == 0 時仍會回傳一個防禦性的 UNKNOWN/HINT 分類而不拋錯，
-    避免呼叫端誤用時整條鏈路炸掉。
+    分兩層，順序不可互換（#499／#500／#487）：
+
+    1. **結構化終局證據優先**（:func:`outcome_taxonomy.classify_structured_evidence`）
+       ——provider 自己用機器可讀欄位講明白的事（`rate_limit_event.status =
+       rejected`、終局 `api_error_status = 429`、controller 中斷）具
+       ``STRUCTURED`` authority，不該被下一層的關鍵字比對翻案。#499 的 429 與
+       #500 的 `aborted_streaming` 都在這一層定案。
+    2. **文字關鍵字**（:func:`outcome_taxonomy.classify_text`）——只掃
+       provider 層證據；nested tool result 與 init metadata 已在
+       :func:`outcome_taxonomy.parse_stream_evidence` 被排除（#500／#487），
+       模型散文只參與 content 判定。判定順序沿用 #369/#370（rate limit 先於
+       auth）。
+
+    呼叫端只在確認這是一次失敗（exit_code != 0 或呼叫端已知 status ==
+    "failed"）時呼叫本函式；exit_code == 0 時仍會回傳一個防禦性的 UNKNOWN/HINT
+    分類而不拋錯，避免呼叫端誤用時整條鏈路炸掉。
     """
 
-    text = output or ""
     if exit_code == 0:
         return ProviderFailureClassification(
             ProviderOutcome.UNKNOWN,
@@ -195,43 +204,29 @@ def classify_provider_failure(*, exit_code: int, output: str | None) -> Provider
             "exit code 0 -- classify_provider_failure 不應被呼叫在成功案例",
         )
 
-    cli_status, cli_detail = executor_auth.classify_cli_output(exit_code, text)
+    evidence = outcome_taxonomy.parse_stream_evidence(output)
 
-    if cli_status == "rate_limited" or is_rate_limit_signal(text):
+    structured = outcome_taxonomy.classify_structured_evidence(evidence)
+    if structured is not None:
         return ProviderFailureClassification(
-            ProviderOutcome.RATE_LIMITED,
-            SignalAuthority.TEXT_SIGNAL,
-            f"rate limit signal detected in executor output ({cli_detail})",
+            _OUTCOME_BY_STRUCTURED_KIND[structured.kind],
+            SignalAuthority.STRUCTURED,
+            structured.detail,
+            reset_at=structured.reset_at,
         )
-    if _QUOTA_RE.search(text):
-        return ProviderFailureClassification(
-            ProviderOutcome.QUOTA,
-            SignalAuthority.TEXT_SIGNAL,
-            "quota signal detected in executor output",
-        )
-    if cli_status == "logged_out" or is_auth_signal(text):
-        return ProviderFailureClassification(
-            ProviderOutcome.AUTH,
-            SignalAuthority.TEXT_SIGNAL,
-            f"auth/login signal detected in executor output ({cli_detail})",
-        )
-    if _CONTENT_RE.search(text):
-        return ProviderFailureClassification(
-            ProviderOutcome.CONTENT,
-            SignalAuthority.TEXT_SIGNAL,
-            "content-policy signal detected in executor output",
-        )
-    if _TRANSIENT_RE.search(text):
-        return ProviderFailureClassification(
-            ProviderOutcome.TRANSIENT,
-            SignalAuthority.TEXT_SIGNAL,
-            "transient/network signal detected in executor output",
-        )
-    return ProviderFailureClassification(
-        ProviderOutcome.UNKNOWN,
-        SignalAuthority.HINT,
-        f"no definitive signal (exit {exit_code})",
+
+    classification = outcome_taxonomy.classify_text(
+        exit_code=exit_code,
+        provider_text=evidence.provider_text,
+        model_text=evidence.model_text,
     )
+    outcome = _OUTCOME_BY_TEXT_SIGNAL[classification.signal]
+    authority = (
+        SignalAuthority.HINT
+        if classification.signal is outcome_taxonomy.TextSignal.NONE
+        else SignalAuthority.TEXT_SIGNAL
+    )
+    return ProviderFailureClassification(outcome, authority, classification.detail)
 
 
 def classification_from_job(job: Mapping[str, object]) -> ProviderFailureClassification | None:

--- a/paulsha_cortex/coordinator/registry.py
+++ b/paulsha_cortex/coordinator/registry.py
@@ -599,12 +599,15 @@ class JobRegistry:
                 f"coordinator 狀態檔 workflow_evidence 格式錯誤（fail-closed）: {self._state_path}"
             )
         # #384：executor 失敗的 typed 分類（provider_outcome.py）。舊狀態檔沒有
-        # 這個欄位（None）；有的話必須是固定四鍵形狀，鍵值型別比照
+        # 這個欄位（None）；有的話必須帶齊四個必要鍵，鍵值型別比照
         # ProviderFailureClassification.to_dict()。
+        # #499：`reset_at`（provider 給的權威限流重置時刻，epoch 秒）為可選第五
+        # 鍵——只有結構化限流證據帶得到，故四鍵形狀的舊狀態檔仍原樣合法。
         provider_outcome = job.get("provider_outcome")
         if provider_outcome is not None and (
             not isinstance(provider_outcome, dict)
-            or set(provider_outcome) != {"outcome", "authority", "reason", "retryable"}
+            or not {"outcome", "authority", "reason", "retryable"} <= set(provider_outcome)
+            or set(provider_outcome) - {"outcome", "authority", "reason", "retryable", "reset_at"}
             or not isinstance(provider_outcome.get("outcome"), str)
             or not provider_outcome["outcome"]
             or not isinstance(provider_outcome.get("authority"), str)
@@ -612,6 +615,13 @@ class JobRegistry:
             or not isinstance(provider_outcome.get("reason"), str)
             or not provider_outcome["reason"]
             or not isinstance(provider_outcome.get("retryable"), bool)
+            or (
+                provider_outcome.get("reset_at") is not None
+                and (
+                    not isinstance(provider_outcome.get("reset_at"), int)
+                    or isinstance(provider_outcome.get("reset_at"), bool)
+                )
+            )
         ):
             raise ValueError(
                 f"coordinator 狀態檔 provider_outcome 格式錯誤（fail-closed）: {self._state_path}"
@@ -1057,9 +1067,11 @@ class JobRegistry:
             raise ValueError(
                 f"headless 完成結果 status 須為 'exited' 或 'failed'，收到: {status!r}"
             )
+        # #499：`reset_at` 為可選第五鍵（見 _validate_state 的同一份判準）。
         if provider_outcome is not None and (
             not isinstance(provider_outcome, Mapping)
-            or set(provider_outcome) != {"outcome", "authority", "reason", "retryable"}
+            or not {"outcome", "authority", "reason", "retryable"} <= set(provider_outcome)
+            or set(provider_outcome) - {"outcome", "authority", "reason", "retryable", "reset_at"}
         ):
             raise ValueError("provider_outcome 格式錯誤（fail-closed）")
         job = self._find_job(job_id)

--- a/paulsha_cortex/github_rate_limit.py
+++ b/paulsha_cortex/github_rate_limit.py
@@ -36,8 +36,17 @@ _RATE_LIMIT_PATTERN = re.compile(
     re.IGNORECASE | re.VERBOSE,
 )
 
+# #487: the ``oauth`` alternative used to be unbounded, so it matched *inside*
+# ordinary identifiers — a Claude builder's normal init skill list contains
+# ``doc-coauthoring``, whose ``coauthoring`` substring contains ``oauth``. That
+# turned an unrelated tool failure into a non-retryable ``auth`` classification
+# and blocked the correct recovery path. The signal is now bounded to a
+# standalone token: ``oauth token`` / ``OAuth-2.0`` still match, ``coauthoring``
+# does not. ``authenticat`` stays unbounded on purpose — it is a prefix of
+# ``authenticate``/``authentication``/``authenticating`` and has no benign
+# substring host of the same kind.
 _AUTH_PATTERN = re.compile(
-    r"bad credentials|\b401\b|authenticat|oauth|token.*invalid|invalid.*token",
+    r"bad credentials|\b401\b|authenticat|\boauth\b|token.*invalid|invalid.*token",
     re.IGNORECASE,
 )
 

--- a/tests/test_outcome_taxonomy.py
+++ b/tests/test_outcome_taxonomy.py
@@ -1,0 +1,563 @@
+"""#499／#500／#487／#485：統一 outcome classification taxonomy 的回歸測試。
+
+四張 issue 是同一型缺陷的第三～六次命中：分類器把「不該當證據的文字」餵進
+關鍵字比對，或反過來把「該當證據的結構化終局記錄」整個忽略。本檔的每一個
+fixture 都用 issue 現場的實際輸出文字，確保修法對著真正的形狀。
+
+- #499：Claude review 429 被投影成 foreign-review-absent、provider_outcome null。
+- #500：tool parser 的 `timeout` 文字被誤判成 network transient。
+- #487：init skill 清單裡的 `doc-coauthoring` 被誤判成 OAuth auth failure。
+- #485：Codex 的 stdin banner 讓每次 foreign review 都成 invalid-process-output。
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+from types import SimpleNamespace
+
+from paulsha_cortex.coordinator import manager, outcome_taxonomy
+from paulsha_cortex.coordinator.provider_outcome import (
+    ProviderOutcome,
+    SignalAuthority,
+    classify_provider_failure,
+)
+from paulsha_cortex.coordinator.registry import JobRegistry
+from paulsha_cortex.github_rate_limit import is_auth_signal
+
+
+# --------------------------------------------------------------- issue 現場 fixture
+
+
+# #499 現場（job task-3-private-repo-and-forbidden-documentation-scan-build-3，
+# 2026-08-13 00:54 Asia/Taipei）：五小時 session 額度用罄，stream-json 帶完整的
+# 結構化限流證據。
+ISSUE_499_CLAUDE_RATE_LIMIT_LOG = "\n".join(
+    [
+        json.dumps(
+            {
+                "type": "system",
+                "subtype": "init",
+                "tools": ["Bash", "Read"],
+                "skills": ["copilot-sdk", "doc-coauthoring", "docx"],
+            }
+        ),
+        json.dumps(
+            {
+                "type": "system",
+                "subtype": "rate_limit_event",
+                "rate_limit_event": {
+                    "status": "rejected",
+                    "rateLimitType": "five_hour",
+                    "resetsAt": 1786554000,
+                },
+            }
+        ),
+        json.dumps(
+            {
+                "type": "result",
+                "subtype": "error",
+                "is_error": True,
+                "api_error_status": 429,
+                "terminal_reason": "api_error",
+            }
+        ),
+    ]
+)
+
+
+# #500 現場（job task-4-deliver-export-tree-orchestrator-build-5）：controller
+# SIGTERM 停掉 no-progress 的 Edit 迴圈；log tail 裡稍早有一筆被拒的 Bash 工具
+# 呼叫，其 permission-denial 文字含 `timeout` 字樣。
+ISSUE_500_TOOL_PARSER_TIMEOUT_LOG = "\n".join(
+    [
+        json.dumps(
+            {
+                "type": "user",
+                "message": {
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "is_error": True,
+                            "content": "Parser aborted (timeout, resource limit, or over-length)",
+                        }
+                    ]
+                },
+            }
+        ),
+        json.dumps(
+            {
+                "type": "result",
+                "subtype": "error_during_execution",
+                "is_error": True,
+                "result": "[Request interrupted by user]",
+                "terminal_reason": "aborted_streaming",
+            }
+        ),
+    ]
+)
+
+
+# #487 現場（0.1.8 @ dc8a968）：連續四次 `InputValidationError: JSON parse
+# failed` 後被人工中斷；log 含 Claude init 的正常 skill 清單。
+ISSUE_487_DOC_COAUTHORING_LOG = "\n".join(
+    [
+        json.dumps(
+            {
+                "type": "system",
+                "subtype": "init",
+                "skills": ["copilot-sdk", "doc-coauthoring", "docx"],
+            }
+        ),
+        json.dumps(
+            {
+                "type": "assistant",
+                "message": {"content": [{"type": "text", "text": "重試中"}]},
+            }
+        ),
+        json.dumps(
+            {
+                "type": "result",
+                "subtype": "error",
+                "is_error": True,
+                "result": "InputValidationError: JSON parse failed",
+            }
+        ),
+    ]
+)
+
+
+# #485 現場（Codex CLI 0.147.0，`codex exec ... --json`）：JSONL 串流前先印一行
+# adapter 自有 banner。
+ISSUE_485_CODEX_BANNER_LOG = "\n".join(
+    [
+        "Reading additional input from stdin...",
+        json.dumps({"type": "thread.started", "thread_id": "th_1"}),
+        json.dumps({"type": "turn.started"}),
+        json.dumps({"type": "turn.completed", "usage": {"input_tokens": 10}}),
+    ]
+)
+
+
+# --------------------------------------------------------------- #499 build/review 分類
+
+
+def test_issue_499_structured_rate_limit_event_classifies_as_rate_limited():
+    """429 必須以結構化權威落 rate_limited，且保留 provider 給的重置時刻。"""
+
+    result = classify_provider_failure(exit_code=1, output=ISSUE_499_CLAUDE_RATE_LIMIT_LOG)
+
+    assert result.outcome is ProviderOutcome.RATE_LIMITED
+    assert result.authority is SignalAuthority.STRUCTURED
+    assert result.retryable is True
+    assert result.reset_at == 1786554000
+
+
+def test_issue_499_reset_at_survives_the_registry_payload_roundtrip():
+    result = classify_provider_failure(exit_code=1, output=ISSUE_499_CLAUDE_RATE_LIMIT_LOG)
+    payload = result.to_dict()
+
+    assert payload["reset_at"] == 1786554000
+    from paulsha_cortex.coordinator.provider_outcome import ProviderFailureClassification
+
+    assert ProviderFailureClassification.from_dict(payload) == result
+
+
+def test_provider_outcome_payload_without_reset_at_stays_four_keyed():
+    """舊四鍵形狀不得改變——已部署的狀態檔仍要能被 fail-closed 驗證讀回。"""
+
+    result = classify_provider_failure(exit_code=1, output="rate limit exceeded")
+
+    assert set(result.to_dict()) == {"outcome", "authority", "reason", "retryable"}
+
+
+def test_issue_499_review_lane_projects_provider_outcome_instead_of_absent():
+    """review lane 的終局投影：不得再是 provider_outcome null ＋ foreign-review-absent。"""
+
+    with tempfile.TemporaryDirectory() as d:
+        root = Path(d)
+        reg = JobRegistry(state_path=root / "jobs.json")
+        builder = reg.create_job(
+            task="slice-review-429",
+            persona="builder",
+            branch="feature/slice-review-429",
+            pane="",
+            worktree=str(root / "candidate"),
+            executor="copilot",
+            session_name="slice-review-429",
+            pid=1,
+            log_path="/builder-log",
+        )
+        reviewer_log = root / "review.jsonl"
+        reviewer_log.write_text(ISSUE_499_CLAUDE_RATE_LIMIT_LOG + "\n", encoding="utf-8")
+        reviewer = reg.create_job(
+            task="slice-review-429",
+            persona="reviewer",
+            kind="review",
+            branch="feature/slice-review-429",
+            pane="",
+            worktree=str(root / "review"),
+            executor="claude",
+            model_id="claude-sonnet-4.5",
+            independence_domain="anthropic",
+            session_name="slice-review-429-2",
+            pid=2,
+            log_path=str(reviewer_log),
+            subject_head="b" * 40,
+            spec_hash="new-spec",
+            plan_hash="new-plan",
+            verification_hash="new-verification",
+        )
+        # `Dispatcher._finalize_headless` 在 finalize 當下寫下的分類。
+        classification = classify_provider_failure(
+            exit_code=1, output=ISSUE_499_CLAUDE_RATE_LIMIT_LOG
+        )
+        reg.update_headless_result(
+            reviewer["job_id"],
+            status="failed",
+            exit_code=1,
+            provider_outcome=classification.to_dict(),
+        )
+        reg.create_slice(
+            slice_id="slice-review-429",
+            spec_path=str(root / "spec.md"),
+            spec_hash="new-spec",
+            plan_path=str(root / "plan.md"),
+            plan_hash="new-plan",
+            target_branch="main",
+            target_remote="origin",
+            verification_hash="new-verification",
+            verification={"docs_class": "code", "review_policy": "required"},
+            dispatch_base="a" * 40,
+            builder_job_id=builder["job_id"],
+            reviewer_job_id=reviewer["job_id"],
+            candidate="b" * 40,
+        )
+        reg.update_slice("slice-review-429", state="building", candidate="b" * 40)
+        reg.update_slice("slice-review-429", state="reviewing", candidate="b" * 40)
+        hdir = root / "handoff"
+
+        manager.complete_tick(
+            _NoopDispatcher(reg),
+            handoff_dir=str(hdir),
+            clock=lambda: "T0",
+            git_runner=lambda args: SimpleNamespace(returncode=0, stdout="b" * 40, stderr=""),
+        )
+
+        manifest = json.loads((hdir / "slice-review-429.json").read_text(encoding="utf-8"))
+        assert manifest["gate_reason"] == "foreign-review-provider-rate_limited"
+        assert manifest["gate_reason"] != "foreign-review-absent"
+        assert manifest["provider_outcome"] is not None
+        assert manifest["provider_outcome"]["outcome"] == "rate_limited"
+        assert manifest["provider_outcome"]["reset_at"] == 1786554000
+        # 後續處置維持現狀：仍是 needs_human，只修分錯類本身。
+        assert manifest["gate_status"] == "needs_human"
+
+
+def test_issue_499_unclassified_review_failure_keeps_the_legacy_reason():
+    """未分類（legacy／繞過 dispatcher）的 reviewer 失敗不得被偽造分類。"""
+
+    assert manager._review_failure_gate_reason({"job_id": "r-1"}) == "foreign-review-absent"
+    assert (
+        manager._review_failure_gate_reason(
+            {
+                "job_id": "r-1",
+                "provider_outcome": {
+                    "outcome": "unknown",
+                    "authority": "hint",
+                    "reason": "no definitive signal (exit 1)",
+                    "retryable": False,
+                },
+            }
+        )
+        == "foreign-review-absent"
+    )
+
+
+# --------------------------------------------------------------- #500 tool parser timeout
+
+
+def test_issue_500_tool_parser_timeout_is_not_a_network_transient():
+    """被 controller 中斷的 job 不得因 nested tool result 的 `timeout` 字樣成為
+    可重試的 network transient。"""
+
+    result = classify_provider_failure(exit_code=1, output=ISSUE_500_TOOL_PARSER_TIMEOUT_LOG)
+
+    assert result.outcome is not ProviderOutcome.TRANSIENT
+    assert result.outcome is ProviderOutcome.UNKNOWN
+    assert result.authority is SignalAuthority.STRUCTURED
+    assert result.retryable is False
+
+
+def test_issue_500_nested_tool_result_alone_never_reaches_the_keyword_table():
+    """就算終局記錄看不出中斷，nested tool result 也不該驅動 transient 判定。"""
+
+    log = "\n".join(
+        [
+            json.dumps(
+                {
+                    "type": "user",
+                    "message": {
+                        "content": [
+                            {
+                                "type": "tool_result",
+                                "content": "Parser aborted (timeout, resource limit, or over-length)",
+                            }
+                        ]
+                    },
+                }
+            ),
+            json.dumps({"type": "result", "subtype": "error", "is_error": True, "result": "stopped"}),
+        ]
+    )
+
+    result = classify_provider_failure(exit_code=1, output=log)
+
+    assert result.outcome is ProviderOutcome.UNKNOWN
+    assert result.authority is SignalAuthority.HINT
+
+
+def test_real_provider_transient_still_classifies_as_transient():
+    """反向護欄：provider 層真的回 503 時，transient 判定必須維持不變。"""
+
+    log = json.dumps(
+        {"type": "result", "subtype": "error", "is_error": True, "result": "503 Service Unavailable"}
+    )
+
+    result = classify_provider_failure(exit_code=1, output=log)
+
+    assert result.outcome is ProviderOutcome.TRANSIENT
+    assert result.retryable is True
+
+
+def test_truncated_leading_line_is_discarded_when_the_tail_parses_as_jsonl():
+    """64 KiB tail 的開頭殘行是截斷產物，不是 CLI 輸出——不得當證據。"""
+
+    log = "\n".join(
+        [
+            'sult":"Parser aborted (timeout, resource limit, or over-length)"}]}}',
+            json.dumps({"type": "result", "subtype": "error", "is_error": True, "result": "stopped"}),
+        ]
+    )
+
+    result = classify_provider_failure(exit_code=1, output=log)
+
+    assert result.outcome is ProviderOutcome.UNKNOWN
+
+
+# --------------------------------------------------------------- #487 doc-coauthoring
+
+
+def test_issue_487_doc_coauthoring_is_not_an_auth_failure():
+    result = classify_provider_failure(exit_code=1, output=ISSUE_487_DOC_COAUTHORING_LOG)
+
+    assert result.outcome is not ProviderOutcome.AUTH
+    assert result.outcome is ProviderOutcome.UNKNOWN
+
+
+def test_issue_487_oauth_signal_is_bounded_to_a_standalone_token():
+    # 根因：無界的 `oauth` 命中 `coauthoring` 裡的子字串。
+    assert is_auth_signal("...copilot-sdk,doc-coauthoring,docx...") is False
+    # 真正的 OAuth 失敗仍必須命中（issue 明列的正向保留）。
+    assert is_auth_signal("OAuth token invalid") is True
+    assert is_auth_signal("error: oauth-2.0 authorization failed") is True
+
+
+def test_issue_487_init_metadata_is_not_classification_evidence():
+    evidence = outcome_taxonomy.parse_stream_evidence(ISSUE_487_DOC_COAUTHORING_LOG)
+
+    assert "doc-coauthoring" not in evidence.provider_text
+    assert "doc-coauthoring" not in evidence.model_text
+
+
+def test_genuine_auth_failure_still_classifies_as_auth():
+    """反向護欄：真的 auth 失敗仍須落 auth（issue 要求保留正向測試）。"""
+
+    log = json.dumps(
+        {
+            "type": "result",
+            "subtype": "error",
+            "is_error": True,
+            "result": "Bad credentials -- run `claude auth login`",
+        }
+    )
+
+    result = classify_provider_failure(exit_code=1, output=log)
+
+    assert result.outcome is ProviderOutcome.AUTH
+
+
+# --------------------------------------------------------------- #485 Codex stdin banner
+
+
+def test_issue_485_codex_banner_no_longer_fails_the_jsonl_purity_check():
+    with tempfile.TemporaryDirectory() as d:
+        log_path = Path(d) / "review.jsonl"
+        log_path.write_text(ISSUE_485_CODEX_BANNER_LOG + "\n", encoding="utf-8")
+
+        assert manager._review_log_has_only_json_lines(str(log_path)) is True
+
+
+def test_issue_485_unexpected_non_json_text_still_fails_closed():
+    with tempfile.TemporaryDirectory() as d:
+        log_path = Path(d) / "review.jsonl"
+        log_path.write_text(
+            "Reading additional input from stdin...\n"
+            "Segmentation fault (core dumped)\n"
+            + json.dumps({"type": "turn.completed"})
+            + "\n",
+            encoding="utf-8",
+        )
+
+        assert manager._review_log_has_only_json_lines(str(log_path)) is False
+
+
+def test_issue_485_banner_in_the_middle_of_the_stream_is_not_stripped():
+    """banner 的語意是「串流開始前印的那一行」；出現在中段的同一句話不是 banner。"""
+
+    with tempfile.TemporaryDirectory() as d:
+        log_path = Path(d) / "review.jsonl"
+        log_path.write_text(
+            json.dumps({"type": "thread.started"})
+            + "\nReading additional input from stdin...\n"
+            + json.dumps({"type": "turn.completed"})
+            + "\n",
+            encoding="utf-8",
+        )
+
+        assert manager._review_log_has_only_json_lines(str(log_path)) is False
+
+
+def test_issue_485_codex_review_reaches_verdict_validation():
+    """end-to-end：banner ＋ 合法 JSONL 的 Codex review 必須走到 verdict 驗證階段
+    （此處 verdict 檔缺席，故落 `verdict-missing` 而非 `invalid-process-output`）。"""
+
+    with tempfile.TemporaryDirectory() as d:
+        root = Path(d)
+        reg = JobRegistry(state_path=root / "jobs.json")
+        builder = reg.create_job(
+            task="slice-codex-banner",
+            persona="builder",
+            branch="feature/slice-codex-banner",
+            pane="",
+            worktree=str(root / "candidate"),
+            executor="copilot",
+            session_name="slice-codex-banner",
+            pid=1,
+            log_path="/builder-log",
+        )
+        reg.attach_launch_handle(
+            builder["job_id"],
+            executor="copilot",
+            model_id="claude-haiku-4.5",
+            session_name="slice-codex-banner",
+            pid=1,
+            log_path="/builder-log",
+        )
+        reviewer_log = root / "review.jsonl"
+        reviewer_log.write_text(ISSUE_485_CODEX_BANNER_LOG + "\n", encoding="utf-8")
+        reviewer = reg.create_job(
+            task="slice-codex-banner",
+            persona="reviewer",
+            kind="review",
+            branch="feature/slice-codex-banner",
+            pane="",
+            worktree=str(root / "review"),
+            executor="codex",
+            model_id="gpt-5.4",
+            independence_domain="openai",
+            session_name="slice-codex-banner-2",
+            pid=2,
+            log_path=str(reviewer_log),
+            subject_head="b" * 40,
+            spec_hash="new-spec",
+            plan_hash="new-plan",
+            verification_hash="new-verification",
+        )
+        reg.update_status(reviewer["job_id"], "exited")
+        reg.create_slice(
+            slice_id="slice-codex-banner",
+            spec_path=str(root / "spec.md"),
+            spec_hash="new-spec",
+            plan_path=str(root / "plan.md"),
+            plan_hash="new-plan",
+            target_branch="main",
+            target_remote="origin",
+            verification_hash="new-verification",
+            verification={"docs_class": "code", "review_policy": "required"},
+            dispatch_base="a" * 40,
+            builder_job_id=builder["job_id"],
+            reviewer_job_id=reviewer["job_id"],
+            candidate="b" * 40,
+        )
+        reg.update_slice("slice-codex-banner", state="building", candidate="b" * 40)
+        reg.update_slice("slice-codex-banner", state="reviewing", candidate="b" * 40)
+        hdir = root / "handoff"
+
+        manager.complete_tick(
+            _NoopDispatcher(reg),
+            handoff_dir=str(hdir),
+            clock=lambda: "T0",
+            git_runner=lambda args: SimpleNamespace(returncode=0, stdout="b" * 40, stderr=""),
+        )
+
+        manifest = json.loads((hdir / "slice-codex-banner.json").read_text(encoding="utf-8"))
+        assert manifest["gate_verdict"]["reason"] == "verdict-missing"
+        assert manifest["gate_verdict"]["reason"] != "invalid-process-output"
+
+
+def test_strip_known_process_banners_only_removes_exact_leading_matches():
+    assert outcome_taxonomy.strip_known_process_banners(
+        ["Reading additional input from stdin...", '{"type":"turn.completed"}']
+    ) == ['{"type":"turn.completed"}']
+    assert outcome_taxonomy.strip_known_process_banners(
+        ["Reading additional input from stdin... plus extra", '{"type":"turn.completed"}']
+    ) == ["Reading additional input from stdin... plus extra", '{"type":"turn.completed"}']
+    assert outcome_taxonomy.strip_known_process_banners([]) == []
+
+
+# --------------------------------------------------------------- 收編：三 lane 共用同一份表
+
+
+def test_planning_lane_consumes_the_shared_marker_table():
+    """#533 的 planning 先行實作已收編：planning lane 與本模組同一張表。"""
+
+    assert manager._PLANNING_TRANSIENT_SERVICE_MARKERS is outcome_taxonomy.TRANSIENT_SERVICE_MARKERS
+    # #533 的判準行為逐字不變。
+    assert (
+        manager._is_planning_transient_service_failure(
+            "primary-integration-malformed: ValueError: planning launcher returned no JSON "
+            "object: Error: Eligibility check failed: UNAVAILABLE (code 503)"
+        )
+        is True
+    )
+    assert (
+        manager._is_planning_transient_service_failure(
+            "planning launcher returned no JSON object: 我先說明一下我的規劃方向"
+        )
+        is False
+    )
+
+
+def test_outcome_families_cover_the_four_declared_classes():
+    families = {family.value for family in outcome_taxonomy.OutcomeFamily}
+
+    assert {"transient-service", "content", "environment", "auth"} <= families
+
+
+def test_every_text_and_structured_signal_maps_to_a_family():
+    for signal in outcome_taxonomy.TextSignal:
+        assert signal in outcome_taxonomy.FAMILY_BY_TEXT_SIGNAL
+    for kind in outcome_taxonomy.StructuredKind:
+        assert kind in outcome_taxonomy.FAMILY_BY_STRUCTURED_KIND
+
+
+class _NoopDispatcher:
+    """已是終局狀態的 job 不需要 poll；complete_tick 只會讀 registry。"""
+
+    def __init__(self, registry: JobRegistry) -> None:
+        self._registry = registry
+
+    def poll_headless_done(self, job_id: str) -> dict:
+        return self._registry.get_job(job_id)


### PR DESCRIPTION
## 根因

「executor 失敗該歸哪一類」在 planning／build／review 三個 lane 各自實作了一次，各自漂移，
於是同一型缺陷被踩了六次。四張 issue 的共同根因**不是關鍵字表寫錯**，而是：

1. **餵給關鍵字表的東西一開始就不該進來**——nested tool result（#500）、init metadata（#487）、
   CLI banner（#485）都被當成了失敗證據。
2. **該當證據的結構化終局記錄被整個忽略**——#499 的 stream-json 早就帶了機器可讀的限流證據
   （`rate_limit_event.status = rejected`、`rateLimitType = five_hour`、`resetsAt`，終局
   `api_error_status = 429`），review lane 卻完全不看。

## 修法

新增 `paulsha_cortex/coordinator/outcome_taxonomy.py`：四大類 outcome family
（**transient-service／content／environment／auth**）＋共用 markers 表，planning／build／review
三個 lane 共同消費；#533 的 planning 先行實作一併收編（`_PLANNING_TRANSIENT_SERVICE_MARKERS`
成為 taxonomy 表的別名，其測試涵蓋原樣保留）。

分類拆成兩層，順序不可互換：

- **證據分層**（`parse_stream_evidence`）——結構化終局記錄、CLI 原生 stderr、error 記錄屬
  provider 證據；模型自己的話只拿來判 content；nested tool result 與 init metadata 兩者皆不是，
  直接丟棄。64 KiB tail 開頭的殘行視為截斷產物，不當證據。
- **共用 markers 表**——結構化證據優先於文字關鍵字；文字判定順序沿用 #369/#370（rate limit
  必須先於 auth，限流訊息常同時帶 "authenticate" 字樣）。

### 四張 issue 的誤判 → 正確分類

| Issue | 修法前（誤判） | 修法後（正確） |
| --- | --- | --- |
| #499 | `gate_reason: foreign-review-absent`、`provider_outcome: null` | `gate_reason: foreign-review-provider-rate_limited`、`provider_outcome.outcome = rate_limited`、`authority = structured`、`reset_at = <resetsAt>` |
| #500 | `outcome: transient`、`authority: text_signal`、`retryable: true` | `outcome: unknown`、`authority: structured`、`retryable: false`（controller 中斷） |
| #487 | `gate_reason: builder-failed-auth`、`outcome: auth`、`retryable: false` | `outcome: unknown`（無真實 auth 訊號時不偽造分類） |
| #485 | `state: absent`、`reason: invalid-process-output`（每次 Codex review 皆然） | 通過 JSONL 純度檢查、走到 verdict 驗證階段 |

各 issue 的個別修法：

- **#499**：結構化限流證據以 `STRUCTURED` authority 落 `rate_limited`，並保留 provider 給的
  權威重置時刻（`ProviderFailureClassification.reset_at`，新增**可選**第五鍵
  `provider_outcome.reset_at`，epoch 秒；舊四鍵 payload 原樣合法，registry fail-closed 驗證
  同步放行該可選鍵）。review lane 補上 build lane 早已有的分類投影線。
- **#500**：tool result 不是 provider 診斷，根本不會走到關鍵字表；終局 `aborted_streaming`
  以結構化權威落 `unknown`（維持既有不自動重試）。
- **#487**：`github_rate_limit._AUTH_PATTERN` 的 `oauth` 收緊為 `\boauth\b`
  （`oauth token`／`OAuth-2.0` 仍命中，`coauthoring` 不再命中），且 init metadata 已被證據分層排除
  ——雙重防線。真正的 OAuth 失敗維持正向命中（保留正向測試）。
- **#485**：採 issue 列的第二條路，只在 parse 前剝離**精確、adapter 自有、且位於串流開頭**的
  已知 banner（`KNOWN_PROCESS_BANNERS`）。JSONL 純度檢查本身**一格未放寬**：不在該表上的任何
  非 JSON 文字、以及出現在串流中段的同一句話，仍舊 fail closed。

## 範圍紀律

這是**分類層收編**，不是行為重設計。各 lane 對每一類 outcome 的後續處置（retry／needs_human／
終止）維持現狀——#499 的 429 仍落 needs_human、仍只提供既有的手動 `retry-review` 出口，只是
operator 與無人值守流程現在看得到「這是限流、權威重置時刻在何時」。

## 行為改變（不可避免的部分，逐項列出）

1. **`gate_reason` 新值**：reviewer process 失敗且已分類時，`foreign-review-absent` →
   `foreign-review-provider-<outcome>`。未分類（legacy job）或分不出來（`unknown`）維持
   `foreign-review-absent`。`gate_status` 不變（仍 needs_human），`allowed_slice_actions`
   由 slice row 導出、不讀 gate_reason，故 next actions 不變。
2. **slice handoff manifest 的 `provider_outcome` 欄位**：review-lane 終局過去恆為 `null`，
   現在會帶分類（僅當 review job 失敗且已分類）。
3. **`provider_outcome` payload 可選第五鍵 `reset_at`**：只有結構化限流證據帶得到。
   `to_dict()` 在 `reset_at is None` 時不寫該鍵，故絕大多數 payload 形狀不變。
   `registry` 的兩處 fail-closed 驗證同步改為「必要四鍵 ⊆ payload ⊆ 四鍵＋reset_at」。
4. **分類證據範圍收窄**：assistant／user 訊息的模型散文自此只參與 content-policy 判定，
   不再驅動 transient／auth／rate-limit 判定；init metadata 與 nested tool result 完全不參與。
   這正是 #500／#487 要求的，但確實是既有行為的改變。
5. **`SignalAuthority.STRUCTURED` 首次實際產出**：修法前所有分類皆為 `TEXT_SIGNAL` 或 `HINT`。
   `retryable` 的判定軸未變（authority 非 HINT ＋ outcome ∈ RETRYABLE_OUTCOMES）。

## 測試證據

新增 `tests/test_outcome_taxonomy.py`（21 tests），每張 issue 的誤判案例都用 issue 內的實際輸出
文字做 fixture，並含反向護欄（真 503 仍 transient、真 auth 仍 auth、非預期非 JSON 仍 fail closed）。

- 對修法**前**的程式碼跑同一份新測試：**12 failed / 9 passed**——四張 issue 的每個關鍵斷言
  皆在修法前失敗（`transient` vs `unknown`、`auth` vs `unknown`、banner `False` vs `True`、
  `foreign-review-absent` vs `foreign-review-provider-rate_limited`、`KeyError: 'reset_at'`）。
- 對修法**後**的程式碼：`python3 -m pytest -q tests/test_outcome_taxonomy.py` → **21 passed**。
- 目標既有測試：`tests/test_provider_outcome.py tests/test_provider_failure_slice_lane.py
  tests/test_provider_failure_recovery.py tests/test_planning_transient_service_failure.py
  tests/test_coordinator_foreign_review.py tests/test_claim_provider_rate_limit_authority.py`
  → **83 passed**（#533 的 planning 涵蓋原樣通過）。
- 全套：`python3 -m pytest -q` → **2617 passed, 49 subtests passed in 49.61s**，零 skip 遺漏。
- `python3 -m policy_check`（帶 PR 上下文）→ **pass: 23 / fail: 0 / warn: 2**
  （R-18 docs-sync 建議、R-22 陳年懸空引用，皆為 advisory 且非本 PR 造成）。

## Checklist

- [x] `changelog.d/unified-outcome-taxonomy.md` fragment 已新增且已 commit
- [x] `CHANGELOG.md [Unreleased]` 有對應 entry
- [x] 分支非 `main`，命名符合 `feature/<slug>`
- [x] 全套測試通過
- [x] policy_check 帶 PR 上下文跑過，fail: 0

Refs #499 #500 #487 #485
