### PR TITLE
fix(planning-runtime): 移除整棵 operator worktree 還原並改為備份加報告

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,37 @@
   `status=passed` 並誠實自報 `pytest: failed`」，消除泛用 `status_policy` 與實際採信
   規則相反的字面陷阱。詳見 `changelog.d/gate-acceptance-chain.md`。新增
   `tests/test_gate_acceptance_chain_540.py`（15 個回歸測試）與 2 個 doctor 整合測試。
+
+- **Issue #507：planning 失敗時整棵 operator worktree 抹除還原，靜默銷毀並行的 operator
+  工作（實測資料遺失）**——`planning_runtime._invoke_json` 的 finally 區塊只要偵測到
+  T0→T1 之間 operator worktree 有任何差異，就呼叫 `_restore_operator_tree()`：刪光
+  worktree 內除 `.git` 以外的**全部內容**再從 T0 baseline 整棵還原。偵測條件
+  （`_tree_snapshot` 前後比對）分不出「launcher 越界寫入」與「operator／其他 agent／
+  編輯器的正常並行編輯」，而 launcher 早已以 `cwd=sandbox`（拋棄式複本）執行——安全網的
+  補救動作被設成整棵樹抹除，誤傷機率遠高於它要防的越界；baseline 又由非原子 `copytree`
+  取樣，歸因本身就不可靠。Phase 1 dogfooding 兩次實測命中：(1) run
+  `workflow-0529388d8e290c8fb938` 抹除 operator 在視窗內新建的
+  `docs/superpowers/workstreams/<slug>/todo.md`，連帶讓 `.cortex/work-items.yaml` 留下
+  懸空連結、`active_todo` 為假、lifecycle 停在 `topic` 不可 claim；(2) 更嚴重的形態是
+  **被抹除的是 cortex 自己的成功產出**——前一代 planning 產出的三份合格 artifact 屬未追蹤
+  檔、不在後續那次的 baseline 內，遭下一次失敗的 rollback 刪除，run 的
+  `planning_authority` 隨即指向不存在的檔案（`workflow planning input missing`），work
+  item 卡死且 git 救不回。R0 修法四項：整棵還原的程式路徑**移除**
+  （`_restore_operator_tree()` 刪除，`_make_tree_traversable()` 收斂為只能指向拋棄式
+  sandbox）；drift 分析改走全新的**唯讀且對讀取失敗容錯**的 `_tree_manifest()`／
+  `_diff_tree_manifests()`，預設不改寫 operator worktree 一個位元組；受影響檔案的 T0／T1
+  兩版**完整備份**進 `<coordinator_root>/evidence/planning-worktree-drift/<run_id>-<digest>/`
+  並落一份 `cortex-planning-worktree-drift/v1` 結構化 diff 報告（失敗訊息帶計數與 evidence
+  路徑，另落完整 `logger.error`）；還原改為需明示 opt-in 的逐路徑 `rollback_scope`，經三道
+  fail-closed 閘門把守——不在本次 diff 內、命中受保護的權威文件
+  （`docs/superpowers/{workstreams,specs,plans}/**`、`openspec/changes/**`、`.cortex/**`）、
+  備份未成功者一律拒絕還原（**備份不成功就不准抹除**）。`manager.apply_workflow_action`
+  把 `evidence_root` 與 `run_id` 交給 runtime factory，operator 得以用同一組 run_id 同時撈
+  `planning-recovery`／`planning-artifacts`／`planning-worktree-drift` 三份 evidence。
+  結構解（planning 產出完全不進 operator 樹）、baseline 取樣的非原子 race、planning 期間的
+  advisory lock、以及 worktree drift 仍被分類為 `content` 而禁用 `recover-planning`，
+  均留待後續。
+
 - **R0.5 D1（部分）：auto-claim label 判定改走 monitor 鏡像**——monitor 把持有
   `cortex:auto-on-going` 的 open issue 編號寫進 provider observations（issues 回應本來就含
   labels，零額外 API）；canonical claim 路徑據此導出 `auto_label`（原硬編 False）；

--- a/changelog.d/rollback-containment.md
+++ b/changelog.d/rollback-containment.md
@@ -1,0 +1,48 @@
+# rollback-containment
+
+- **`#507`：planning 失敗時整棵 operator worktree 抹除還原，會靜默銷毀並行的 operator 工作
+  （實測資料遺失）**——`planning_runtime._invoke_json` 的 finally 區塊只要偵測到 T0→T1 之間
+  operator worktree 有任何差異，就呼叫 `_restore_operator_tree()`：刪光 worktree 內除 `.git`
+  以外的**全部內容**，再從 T0 baseline 複本整棵還原。偵測條件（`_tree_snapshot` 前後比對）
+  完全無法分辨「launcher 越界寫入」與「operator／其他 agent／編輯器在同一時間的正常編輯」，
+  而 launcher 本身早已以 `cwd=sandbox`（拋棄式複本）執行——安全網的補救動作被設成整棵樹抹除，
+  誤傷機率遠高於它要防的越界。加上 baseline 由非原子 `copytree` 取樣，歸因本身就不可靠。
+  Phase 1 dogfooding 兩次實測命中：
+  - run `workflow-0529388d8e290c8fb938`：operator 在 planning 視窗內新建的
+    `docs/superpowers/workstreams/<slug>/todo.md` 被抹除。連帶後果不只丟檔——`cortex work link`
+    已把該 todo 寫進 `.cortex/work-items.yaml` 成為 path source，檔案消失後 registry 留下懸空
+    連結、`active_todo` 為假、lifecycle 停在 `topic` → 不可 claim。
+  - 更嚴重的形態：**被抹除的是 cortex 自己的成功產出**。前一代 planning 產出的三份合格
+    artifact 是未追蹤檔、不在後續那次的 T0 baseline 內，被下一次失敗的 rollback 當成 launcher
+    產物刪除；run 的 `planning_authority` 隨即指向不存在的檔案
+    （`manager._workflow_input_snapshot` → `workflow planning input missing`），work item 卡死，
+    且 ship 前皆未追蹤、git 救不回。
+- **R0 修法（範圍收斂 ＋ 備份 ＋ 報告，不改結構）**：
+  - **整棵還原的程式路徑移除**：`_restore_operator_tree()` 刪除，改由
+    `_contain_operator_drift()` 承接。`_make_tree_traversable()` 收斂為只能指向拋棄式
+    sandbox——它把整棵樹的目錄 mode 強制改成 `0o700`，本身就是一次寫入，過去靠事後整棵還原
+    蓋回去才成立。
+  - **預設不改寫 operator worktree 一個位元組**：drift 分析改走全新的唯讀
+    `_tree_manifest()`／`_diff_tree_manifests()`，對讀取失敗容錯（被 chmod 0 的角落記成
+    `unreadable` 繼續，不再為了讀取而 chmod 整棵樹）。偵測到 drift 仍 fail-closed，但處置權
+    交回 operator。
+  - **受影響檔案完整備份進 run-scoped evidence**：
+    `<coordinator_root>/evidence/planning-worktree-drift/<run_id>-<digest>/` 下同時保存
+    `observed/`（T1，也就是萬一被抹除就永久消失的那一版）與 `baseline/`（T0），並落一份
+    `cortex-planning-worktree-drift/v1` 結構化 diff 報告（逐路徑 change／mode／sha256／
+    symlink target／xattr 摘要／備份落點）。失敗訊息帶上計數與 evidence 路徑，另落一筆
+    `logger.error` 保全完整訊息（比照 `#511`）。
+  - **還原改為需明示 opt-in 且逐路徑收斂**：`rollback_scope` 預設空集合；`_invoke_json` 明確
+    傳空集合——launcher 以 `cwd=sandbox` 執行，這條路徑在 operator 樹裡沒有任何「本次 run
+    自產」的產物可言，可證明的還原範圍就是空的。三道 fail-closed 閘門：不在本次 diff 內、
+    命中受保護的權威文件（`docs/superpowers/{workstreams,specs,plans}/**`、
+    `openspec/changes/**`、`.cortex/**`）、備份未成功者，一律拒絕還原——**備份不成功就不准
+    抹除**是本 issue 最低限度的保命索。
+  - `manager.apply_workflow_action` 把 `evidence_root`（transaction root）與 `run_id` 交給
+    runtime factory，operator 因此能用同一組 run_id 同時撈 `planning-recovery`、
+    `planning-artifacts`、`planning-worktree-drift` 三份 evidence。未帶入時**不寫任何
+    evidence**，刻意不 fallback 到 `paths.coordinator_root()`，避免非 daemon 呼叫端在
+    operator 執行期狀態目錄留下非預期檔案。
+- 結構解（planning 產出完全不進 operator 樹）屬 R2 evidence 模型範疇，不在本次範圍；
+  baseline 取樣的非原子 race、planning 期間的 advisory lock、以及 worktree drift 仍被分類為
+  `content`（`recover-planning` 因此禁用）同樣留待後續。

--- a/paulsha_cortex/coordinator/manager.py
+++ b/paulsha_cortex/coordinator/manager.py
@@ -8963,6 +8963,14 @@ def apply_workflow_action(
             runtime = runtime_factory(
                 primary=primary,
                 worktree=_required_workflow_string(args, "artifact_root"),
+                # #507：planning launcher 偵測到 operator worktree drift 時
+                # 不再整棵還原，改為把受影響檔案完整備份進 run-scoped evidence
+                # 並落一份結構化 diff 報告；這裡把 evidence 根與 run_id 交給
+                # runtime，operator 才能用同一組 run_id 同時撈
+                # `planning-recovery`、`planning-artifacts` 與
+                # `planning-worktree-drift` 三份 evidence。
+                evidence_root=transaction_root,
+                run_id=run.run_id,
             )
         except Exception as exc:
             # #393：recover-planning 靠 `cortex-planning-failure/v1` evidence

--- a/paulsha_cortex/coordinator/planning_runtime.py
+++ b/paulsha_cortex/coordinator/planning_runtime.py
@@ -2,16 +2,19 @@ from __future__ import annotations
 
 import json
 import hashlib
+import logging
 import os
 import re
 import shutil
 import stat
 import subprocess
 import tempfile
+from datetime import datetime, timezone
 from dataclasses import dataclass
 from pathlib import Path
 from pathlib import PurePosixPath
 from typing import Callable, Mapping
+from uuid import uuid4
 
 from .launcher import build_agy_argv
 from .model_identities import (
@@ -23,6 +26,9 @@ from .model_identities import (
     probe_agy_capability,
 )
 from .planning import required_heading_hint
+
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -70,6 +76,37 @@ def _planning_argv(identity: ModelIdentity, prompt: str, temp_dir: str, worktree
     raise ValueError(f"unsupported read-only planning executor: {identity.executor}")
 
 
+def _snapshot_skipped(relative: Path, name: str) -> bool:
+    """快照／drift 走訪共用的排除判準（`_tree_snapshot` 與 `_tree_manifest`）。
+
+    兩者必須永遠看同一組節點：`_tree_snapshot` 負責判斷「有沒有變」，
+    `_tree_manifest` 負責回答「變了什麼」。判準若各寫一份就會漂移，
+    出現「偵測到 dirty 卻報不出任何 diff」（或反之）的失真報告。
+
+    - `.git`：版控物件不在比對範圍。
+    - `__pycache__` / `*.pyc`（issue #397）：本機部署常見拓撲是 daemon 與
+      planning launcher 共用同一棵 operator 工作樹（daemon 以 repo 為
+      WorkingDirectory 常駐），daemon 對既有模組的 lazy import 會隨時在快照
+      窗口內重編 bytecode。這是可由原始碼 100% 重生的快取、不是 operator
+      內容，計入雜湊會把正常 churn 誤判成「planner 汙染 operator worktree」。
+      跳過的盲點取捨：CPython 的 .pyc 是 timestamp/hash-based 驗證（PEP 552），
+      植入的孤兒 .pyc 與對應 .py 不符會被直接忽略重編，不會被 import 採用；
+      真正的程式碼污染仍必須經過 .py／其他原始檔變更，不受此例外影響。
+    - 快照 root 直下的 `runtime/`（issue #399）：`.gitignore:8` 宣告的 daemon
+      狀態殘留（`runtime/handoff/wf-*.json` 每個 periodic tick 整份重寫，內容
+      含時間戳必變）。用 relative path 判斷而非只比對 dir name，避免誤跳深層
+      同名目錄（例如 `tests/fixtures/runtime/`）。
+    """
+
+    if name == ".git":
+        return True
+    if name == "__pycache__" or name.endswith(".pyc"):
+        return True
+    if relative == Path(".") and name == "runtime":
+        return True
+    return False
+
+
 def _tree_snapshot(root: Path) -> str:
     """Hash the complete tree shape, content, links, and stable metadata.
 
@@ -108,34 +145,9 @@ def _tree_snapshot(root: Path) -> str:
         elif stat.S_ISDIR(metadata.st_mode):
             digest.update(b"dir\0")
             for child in sorted(path.iterdir(), key=lambda item: item.name):
-                if child.name == ".git":
-                    continue
-                # issue #397：本機部署常見拓撲是 daemon 與 planning launcher
-                # 共用同一棵 operator 工作樹（daemon 以 repo 為
-                # WorkingDirectory 常駐），daemon 對既有模組的 lazy import
-                # 會隨時在快照窗口內重編 `__pycache__/*.pyc`。這是可由原始碼
-                # 100% 重生的 bytecode 快取、不是 operator 內容，計入雜湊會把
-                # 這種正常 churn 誤判成「planner 汙染 operator worktree」而
-                # fail-closed 到整段 raise + rollback。跳過的盲點取捨：CPython
-                # 的 .pyc 是 timestamp/hash-based 驗證（PEP 552），植入的孤兒
-                # .pyc 若與對應 .py 的 mtime／hash 不符會被直接忽略重新編譯，
-                # 不會被 import 採用，因此跳過雜湊不會讓惡意 bytecode 有機可乘
-                # ——真正的程式碼污染仍必須經過 .py／其他原始檔變更，那些不受
-                # 此例外規則影響，fail-closed 行為維持不變。
-                if child.name == "__pycache__" or child.name.endswith(".pyc"):
-                    continue
-                # issue #399：`.gitignore:8` 的 `/runtime/` 是 manager daemon
-                # 以 repo 為 WorkingDirectory 常駐時的狀態殘留（例如
-                # `runtime/handoff/wf-*.json` 每個 periodic tick 都會被整份
-                # 重寫，內容含時間戳必變，issue #373 的迴圈使其每 ~55 秒
-                # 必然發生一次）。它不受版控，verification gate 是讀 git
-                # diff 來判斷候選檔案，gitignored 的內容本就不會進候選
-                # 清單，跳過它的雜湊盲點可控——真正的程式碼污染必須經過
-                # git 追蹤的檔案，不受此例外規則影響，fail-closed 行為維持
-                # 不變。只跳過快照 root 直下的 `runtime/`（用 relative path
-                # 判斷，而非只比對 dir name），避免誤跳深層同名目錄（例如
-                # `tests/fixtures/runtime/`）。
-                if relative == Path(".") and child.name == "runtime":
+                # 排除判準見 `_snapshot_skipped`（與 `_tree_manifest` 共用同
+                # 一份，避免「偵測得到 dirty 卻報不出 diff」的判準漂移）。
+                if _snapshot_skipped(relative, child.name):
                     continue
                 visit(child, relative / child.name)
         elif stat.S_ISREG(metadata.st_mode):
@@ -179,11 +191,16 @@ def _copy_planning_sandbox(worktree: Path, destination: Path) -> None:
 
 
 def _make_tree_traversable(root: Path) -> None:
-    """Restore enough owner access to inspect and replace a hostile tree.
+    """Restore enough owner access to inspect and discard a hostile tree.
 
     The launcher can chmod directories through an absolute path.  Never follow
-    symlinks while recovering access; the immutable baseline restores the
-    original metadata after the polluted entries have been removed.
+    symlinks while recovering access.
+
+    issue #507：本函式**只能指向拋棄式 sandbox**。它把整棵樹的目錄 mode 強制
+    改成 0o700，本身就是一次寫入；修法前它被用在 operator worktree 上（靠事後
+    整棵還原把 mode 蓋回去）是可行的，移除整棵還原後就不再成立——對 operator
+    工作區只讀不寫是本 issue 的核心約束，drift 分析改走完全唯讀、對讀取失敗
+    容錯的 `_tree_manifest`。
     """
 
     if root.is_symlink():
@@ -203,26 +220,439 @@ def _make_tree_traversable(root: Path) -> None:
     visit(root)
 
 
-def _restore_operator_tree(worktree: Path, baseline: Path) -> None:
-    _make_tree_traversable(worktree)
-    for child in worktree.iterdir():
-        if child.name == ".git":
+# --- issue #507：operator worktree drift 的收斂處置 ---------------------------
+#
+# 修法前：`_invoke_json` 的 finally 區塊只要偵測到 T0→T1 之間 operator worktree
+# 有任何差異，就呼叫 `_restore_operator_tree()`——刪掉 worktree 內除 `.git` 以外
+# 的**全部內容**再從 T0 baseline 複本整棵還原。實測（2026-08-14，run
+# `workflow-0529388d8e290c8fb938`）兩種資料遺失：
+#   (1) operator 在 planning 視窗內新建的未追蹤檔（work item 的 todo 來源）
+#       被靜默銷毀，且 `.cortex/work-items.yaml` 留下懸空連結；
+#   (2) 前一代 planning **成功**產出的三份 artifact（未追蹤、不在本次 baseline
+#       內）被下一次失敗的 rollback 抹除，run 的 `planning_authority` 指向不
+#       存在的檔案 → `workflow planning input missing` → work item 卡死。
+#
+# 根因是歸因錯誤：launcher 以 `cwd=sandbox`（拋棄式複本）執行，operator 樹比對
+# 只是「防越界」的安全網；把安全網的補救動作設成整棵樹抹除，在多方並行（operator
+# 手動編輯、其他 agent、編輯器自動儲存、背景建置）的真實環境下誤傷機率遠高於
+# 真正的越界。加上 baseline 由非原子 `copytree` 取樣，歸因本身就不可靠。
+#
+# R0 修法（本檔）：
+#   1. 整棵還原的程式路徑**移除**，改為 `_contain_operator_drift()`。
+#   2. 預設不改寫 operator worktree 一個位元組——只做唯讀 diff、把受影響檔案
+#      完整備份進 run-scoped evidence，並落一份結構化報告供 operator 判讀。
+#   3. 還原改成需明示 opt-in 且逐路徑收斂（`rollback_scope`），並由三道
+#      fail-closed 閘門把守：不在本次 diff 內／命中受保護的權威文件／備份未
+#      成功者一律拒絕還原。
+#
+# 結構解（planning 產出完全不進 operator 樹）屬 R2 evidence 模型範疇，不在此。
+PLANNING_WORKTREE_DRIFT_SCHEMA = "cortex-planning-worktree-drift/v1"
+# evidence 目錄名刻意不用 `planning-recovery`——`work_actions.
+# _read_planning_failure_record` 用 `path.parent.name == "planning-recovery"`
+# 當 recover-planning 的收容判準，混進去會多出一筆無法解析的候選、撞上
+# `planning failure evidence ambiguous` 的 fail-closed（同 #511 對
+# `planning-artifacts` 目錄的處理）。
+PLANNING_WORKTREE_DRIFT_DIRNAME = "planning-worktree-drift"
+# 備份總量上限：drift 正常只有寥寥數檔，這個上限只用來擋住病態情境（例如
+# launcher 把整棵樹改寫）把 evidence 目錄灌爆。超出預算的檔案在報告內標記
+# `backed_up: false`，並且**一律逐出 rollback 範圍**——備份不成功就不准抹除，
+# 是本 issue 最低限度的保命索。
+PLANNING_DRIFT_BACKUP_MAX_BYTES = 64_000_000
+# 受保護的權威文件前綴：這些是 work item 的 source 文件與 cortex 自己登記在
+# `planning_authority` 內的受管產物，不論 `rollback_scope` 怎麼要求都不得被
+# rollback 動到。
+#   - `docs/superpowers/workstreams/**/todo.md`：work item 的 todo 來源
+#     （monitor repo provider 的 `todo` kind），被抹除即 `active_todo` 為假、
+#     lifecycle 退回 `topic`、不可 claim。
+#   - `docs/superpowers/specs/**`、`docs/superpowers/plans/**`：planning 產出
+#     的落地位置，同時是 provider 的 `superpowers_spec`／`superpowers_plan`
+#     來源；前代 run 的產出被抹除即造成 `workflow planning input missing`。
+#   - `openspec/changes/**`：openspec 變更提案，`_planning_destinations` 的
+#     首選錨點。
+#   - `.cortex/**`：work registry（`work-items.yaml`）本身。
+_PROTECTED_AUTHORITY_PREFIXES = (
+    ("docs", "superpowers", "workstreams"),
+    ("docs", "superpowers", "specs"),
+    ("docs", "superpowers", "plans"),
+    ("openspec", "changes"),
+    (".cortex",),
+)
+
+
+def _is_protected_authority_path(relative: str) -> bool:
+    """路徑是否落在受保護的權威文件範圍（見 `_PROTECTED_AUTHORITY_PREFIXES`）。"""
+
+    parts = PurePosixPath(relative).parts
+    return any(parts[: len(prefix)] == prefix for prefix in _PROTECTED_AUTHORITY_PREFIXES)
+
+
+def _entry_digest(path: Path, metadata: os.stat_result) -> dict[str, object]:
+    """單一節點的結構化描述；任何讀取錯誤都轉成欄位而非例外。"""
+
+    mode = f"{stat.S_IMODE(metadata.st_mode):04o}"
+    if stat.S_ISLNK(metadata.st_mode):
+        try:
+            target = os.readlink(path)
+        except OSError as exc:
+            return {"kind": "symlink", "mode": mode, "error": type(exc).__name__}
+        return {"kind": "symlink", "mode": mode, "target": target}
+    if stat.S_ISDIR(metadata.st_mode):
+        return {"kind": "dir", "mode": mode}
+    if stat.S_ISREG(metadata.st_mode):
+        try:
+            payload = path.read_bytes()
+        except OSError as exc:
+            return {"kind": "file", "mode": mode, "error": type(exc).__name__}
+        return {
+            "kind": "file",
+            "mode": mode,
+            "size": len(payload),
+            "sha256": hashlib.sha256(payload).hexdigest(),
+        }
+    return {"kind": "special", "mode": mode, "rdev": metadata.st_rdev}
+
+
+def _tree_manifest(root: Path) -> dict[str, dict[str, object]]:
+    """唯讀走訪整棵樹，產出 `relative posix path -> 節點描述`。
+
+    與 `_tree_snapshot` 共用 `_snapshot_skipped` 的排除判準——前者回答「有沒有
+    變」，本函式回答「變了什麼」。
+
+    兩個刻意的設計約束：
+
+    1. **絕不寫入**。修法前為了讀取被 launcher chmod 0 的目錄，會先跑
+       `_make_tree_traversable()` 把整棵樹的目錄 mode 改成 0o700（再靠整棵還原
+       蓋回去）。移除整棵還原後這條路不能再走，否則 drift 分析本身就在改
+       operator 的工作區。
+    2. **對讀取失敗容錯**。任何 `OSError` 都記成節點上的 `error` 欄位並繼續，
+       報告不會因為樹裡有一個不可讀的角落就整份消失。
+    """
+
+    manifest: dict[str, dict[str, object]] = {}
+
+    def visit(path: Path, relative: Path) -> None:
+        key = relative.as_posix()
+        try:
+            metadata = path.lstat()
+        except OSError as exc:
+            manifest[key] = {"kind": "unreadable", "error": type(exc).__name__}
+            return
+        entry = _entry_digest(path, metadata)
+        # xattr 也納入描述：`_tree_snapshot` 把它算進雜湊，這裡不看的話會出現
+        # 「偵測到 dirty 卻報不出任何 diff」的失真報告。
+        try:
+            names = sorted(os.listxattr(path, follow_symlinks=False))
+        except (AttributeError, OSError):
+            names = []
+        if names:
+            attributes: dict[str, str] = {}
+            for name in names:
+                try:
+                    value = os.getxattr(path, name, follow_symlinks=False)
+                except OSError:
+                    attributes[name] = "<unreadable>"
+                    continue
+                attributes[name] = hashlib.sha256(value).hexdigest()
+            entry["xattrs"] = attributes
+        manifest[key] = entry
+        if entry.get("kind") != "dir":
+            return
+        try:
+            children = sorted(path.iterdir(), key=lambda item: item.name)
+        except OSError as exc:
+            entry["children"] = f"unreadable:{type(exc).__name__}"
+            return
+        for child in children:
+            if _snapshot_skipped(relative, child.name):
+                continue
+            visit(child, relative / child.name)
+
+    visit(root, Path("."))
+    return manifest
+
+
+def _diff_tree_manifests(
+    baseline: Mapping[str, dict[str, object]],
+    observed: Mapping[str, dict[str, object]],
+) -> tuple[dict[str, object], ...]:
+    """兩份 manifest 的結構化 diff（`added` / `modified` / `removed`）。"""
+
+    rows: list[dict[str, object]] = []
+    for relative in sorted(set(baseline) | set(observed)):
+        before = baseline.get(relative)
+        after = observed.get(relative)
+        if before == after:
             continue
-        if child.is_symlink() or child.is_file():
-            child.unlink()
+        if before is None:
+            change = "added"
+        elif after is None:
+            change = "removed"
         else:
-            shutil.rmtree(child)
-    for source in baseline.iterdir():
-        target = worktree / source.name
-        if source.is_symlink():
-            target.symlink_to(os.readlink(source), target_is_directory=source.is_dir())
-        elif source.is_dir():
-            shutil.copytree(source, target, symlinks=True)
+            change = "modified"
+        rows.append(
+            {"path": relative, "change": change, "baseline": before, "observed": after}
+        )
+    return tuple(rows)
+
+
+def _write_evidence_bytes(target: Path, payload: bytes) -> None:
+    """原子寫入 + 0400（比照 `manager._write_planning_failure_evidence`）。"""
+
+    target.parent.mkdir(parents=True, exist_ok=True)
+    temporary = target.parent / f".{target.name}.{uuid4().hex}.tmp"
+    try:
+        with temporary.open("xb") as handle:
+            handle.write(payload)
+            handle.flush()
+            os.fsync(handle.fileno())
+        temporary.chmod(0o400)
+        os.replace(temporary, target)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def _backup_drift_entries(
+    *,
+    worktree: Path,
+    baseline: Path,
+    entries: tuple[dict[str, object], ...],
+    destination: Path,
+) -> tuple[dict[str, dict[str, object]], bool]:
+    """把 diff 命中的每個一般檔案的**兩個版本**完整備份進 evidence。
+
+    `observed/` 收 T1（也就是萬一被抹除就永久消失的那一版），`baseline/` 收
+    T0。symlink／目錄／特殊檔沒有位元組內容可存，其 target 與 mode 已完整記在
+    報告的 `baseline`／`observed` 欄位裡。
+
+    回傳 `(每條路徑的備份結果, 是否全數備份成功)`。任何一條備份失敗（讀不到、
+    超出預算）都會讓該路徑被逐出 rollback 範圍。
+    """
+
+    results: dict[str, dict[str, object]] = {}
+    complete = True
+    budget = PLANNING_DRIFT_BACKUP_MAX_BYTES
+    for row in entries:
+        relative = str(row["path"])
+        outcome: dict[str, object] = {"observed": None, "baseline": None}
+        for side, source_root in (("observed", worktree), ("baseline", baseline)):
+            descriptor = row.get(side)
+            if not isinstance(descriptor, dict) or descriptor.get("kind") != "file":
+                continue
+            source = source_root / PurePosixPath(relative)
+            try:
+                # 先看 size 再讀：病態情境（launcher 塞進一個超大檔）不該讓
+                # 備份本身先把記憶體吃光。
+                if source.lstat().st_size > budget:
+                    outcome[side] = {"backed_up": False, "reason": "budget-exceeded"}
+                    complete = False
+                    continue
+                payload = source.read_bytes()
+            except OSError as exc:
+                outcome[side] = {"backed_up": False, "reason": type(exc).__name__}
+                complete = False
+                continue
+            if len(payload) > budget:
+                outcome[side] = {"backed_up": False, "reason": "budget-exceeded"}
+                complete = False
+                continue
+            target = destination / side / PurePosixPath(relative)
+            try:
+                _write_evidence_bytes(target, payload)
+            except OSError as exc:
+                outcome[side] = {"backed_up": False, "reason": type(exc).__name__}
+                complete = False
+                continue
+            budget -= len(payload)
+            outcome[side] = {
+                "backed_up": True,
+                "path": str(target),
+                "size": len(payload),
+                "sha256": hashlib.sha256(payload).hexdigest(),
+            }
+        results[relative] = outcome
+    return results, complete
+
+
+def _restore_scoped_path(*, worktree: Path, baseline: Path, relative: str) -> None:
+    """把單一路徑還原成 baseline 版本（不在 baseline 內者刪除）。
+
+    只處理一般檔案與 symlink；目錄與特殊檔不在可還原範圍（見
+    `_contain_operator_drift` 的閘門）。
+    """
+
+    target = worktree / PurePosixPath(relative)
+    source = baseline / PurePosixPath(relative)
+    if target.is_symlink() or target.is_file():
+        target.unlink()
+    if source.is_symlink():
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.symlink_to(os.readlink(source))
+    elif source.is_file():
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source, target)
+
+
+def _contain_operator_drift(
+    worktree: Path,
+    baseline: Path,
+    *,
+    evidence_root: Path | None,
+    run_id: str,
+    rollback_scope: frozenset[str] = frozenset(),
+) -> dict[str, object]:
+    """收斂處置 operator worktree drift：唯讀 diff → 備份 → 報告 →（選擇性）逐路徑還原。
+
+    `rollback_scope` 是呼叫端**能證明由本次 run 自產**的 repo-relative 路徑；
+    預設空集合＝一個位元組都不動。三道 fail-closed 閘門：
+
+    1. 不在本次 diff 內的路徑不還原（避免把無關檔案捲進來）。
+    2. 命中 `_is_protected_authority_path` 的權威文件永不還原（todo.md 等 work
+       item source 文件、前代 planning artifact、work registry）。
+    3. 備份未成功（含 evidence 根不可用）的路徑永不還原——不可回復的抹除正是
+       本 issue 的核心傷害。
+
+    本函式不 raise：drift 報告是診斷面，寫不出去也不得掩蓋上游真正的失敗。
+    """
+
+    observed_manifest = _tree_manifest(worktree)
+    baseline_manifest = _tree_manifest(baseline)
+    entries = _diff_tree_manifests(baseline_manifest, observed_manifest)
+    counts = {
+        "added": sum(1 for row in entries if row["change"] == "added"),
+        "modified": sum(1 for row in entries if row["change"] == "modified"),
+        "removed": sum(1 for row in entries if row["change"] == "removed"),
+    }
+    drifted = {str(row["path"]) for row in entries}
+    summary: dict[str, object] = {
+        "schema": PLANNING_WORKTREE_DRIFT_SCHEMA,
+        "run_id": run_id,
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "worktree": str(worktree),
+        "counts": counts,
+        "entries": list(entries),
+        "rollback_scope_requested": sorted(rollback_scope),
+        "rollback_scope_applied": [],
+        "rollback_scope_refused": [],
+        "backup_root": None,
+        "backup_complete": False,
+        "report_path": None,
+    }
+
+    refused: list[dict[str, str]] = []
+    candidates: list[str] = []
+    for relative in sorted(rollback_scope):
+        if relative not in drifted:
+            refused.append({"path": relative, "reason": "outside-observed-drift"})
+        elif _is_protected_authority_path(relative):
+            refused.append({"path": relative, "reason": "protected-authority-document"})
         else:
-            shutil.copy2(source, target)
-    shutil.copystat(baseline, worktree, follow_symlinks=False)
-    if _tree_snapshot(worktree) != _tree_snapshot(baseline):
-        raise RuntimeError("planning operator restore verification failed")
+            candidates.append(relative)
+
+    backups: dict[str, dict[str, object]] = {}
+    destination: Path | None = None
+    if evidence_root is not None and entries:
+        digest = hashlib.sha256(
+            json.dumps(list(entries), ensure_ascii=False, sort_keys=True).encode("utf-8")
+        ).hexdigest()[:16]
+        destination = (
+            Path(evidence_root).resolve()
+            / "evidence"
+            / PLANNING_WORKTREE_DRIFT_DIRNAME
+            / f"{run_id}-{digest}"
+        )
+        try:
+            destination.mkdir(parents=True, exist_ok=True)
+            backups, complete = _backup_drift_entries(
+                worktree=worktree,
+                baseline=baseline,
+                entries=entries,
+                destination=destination,
+            )
+            summary["backup_root"] = str(destination)
+            summary["backup_complete"] = complete
+        except OSError as exc:
+            logger.error(
+                "planning-worktree-drift-backup-failed run_id=%s error=%s: %s",
+                run_id,
+                type(exc).__name__,
+                str(exc)[:200],
+            )
+            destination = None
+            backups = {}
+
+    for row in entries:
+        relative = str(row["path"])
+        row["backup"] = backups.get(relative)
+
+    rows_by_path = {str(row["path"]): row for row in entries}
+    applied: list[str] = []
+    for relative in candidates:
+        outcome = backups.get(relative)
+        row = rows_by_path[relative]
+        kinds: set[object] = set()
+        for side in ("baseline", "observed"):
+            descriptor = row.get(side)
+            if isinstance(descriptor, dict):
+                kinds.add(descriptor.get("kind"))
+        # 目錄／特殊檔／不可讀節點的還原語意不明（要不要遞迴？要不要重建
+        # mode？），一律不碰——這正是修法前整棵還原最容易造成附帶損害的部分。
+        if not kinds <= {"file", "symlink"}:
+            refused.append({"path": relative, "reason": "unsupported-node-kind"})
+            continue
+        if outcome is None or any(
+            isinstance(side, dict) and side.get("backed_up") is False
+            for side in outcome.values()
+        ):
+            refused.append({"path": relative, "reason": "backup-unavailable"})
+            continue
+        try:
+            _restore_scoped_path(worktree=worktree, baseline=baseline, relative=relative)
+        except OSError as exc:
+            refused.append({"path": relative, "reason": type(exc).__name__})
+            continue
+        applied.append(relative)
+
+    summary["rollback_scope_applied"] = applied
+    summary["rollback_scope_refused"] = refused
+
+    if destination is not None:
+        report = destination / "report.json"
+        try:
+            _write_evidence_bytes(
+                report,
+                (
+                    json.dumps(summary, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+                ).encode("utf-8"),
+            )
+        except OSError as exc:
+            logger.error(
+                "planning-worktree-drift-report-failed run_id=%s error=%s: %s",
+                run_id,
+                type(exc).__name__,
+                str(exc)[:200],
+            )
+        else:
+            summary["report_path"] = str(report)
+    return summary
+
+
+def _operator_drift_message(summary: Mapping[str, object]) -> str:
+    """drift 失敗訊息：計數在前、evidence 路徑在後。
+
+    上游 `run_heterogeneous_brainstorm` 會把本例外壓成 `secondary-output-
+    malformed: ...` 之類的短字串並截斷（`str(exc)[:160]`），因此把最短且最關鍵
+    的計數排在前面，即使被截掉尾巴也還看得到「動了幾個檔」；完整訊息另以
+    `logger.error` 落 log，evidence 也在固定目錄用 run_id 可查。
+    """
+
+    counts = summary.get("counts")
+    counts = counts if isinstance(counts, Mapping) else {}
+    location = summary.get("report_path") or summary.get("backup_root") or "<unavailable>"
+    return (
+        "planning launcher modified operator worktree; operator content preserved "
+        f"(added={counts.get('added', 0)} modified={counts.get('modified', 0)} "
+        f"removed={counts.get('removed', 0)}); evidence={location}"
+    )
 
 
 _FENCED_JSON = re.compile(
@@ -382,6 +812,8 @@ def _invoke_json(
     worktree: Path,
     runner: Callable[..., object],
     timeout_seconds: int,
+    evidence_root: str | Path | None = None,
+    run_id: str = "ephemeral",
 ) -> object:
     operator_before = _tree_snapshot(worktree)
     with tempfile.TemporaryDirectory(prefix="cortex-planning-") as temp_dir:
@@ -438,15 +870,39 @@ def _invoke_json(
             except BaseException:
                 operator_dirty = True
             if operator_dirty:
+                # issue #507：偵測到 drift 一律 fail-closed（本次 planning 呼叫
+                # 的結果不可信），但**不得改寫 operator worktree**。
+                # `rollback_scope` 傳空集合是刻意的：launcher 以 `cwd=sandbox`
+                # 執行、`--add-dir` 也只指向 sandbox，這條路徑在 operator 樹裡
+                # 沒有任何「本次 run 自產」的產物可言，因此可證明的還原範圍就是
+                # 空的。planning artifact 的落地另走
+                # `manager._publish_planning_artifacts`（有交易與 authority 把
+                # 關），不在此。任何差異都當成 operator／其他 agent 的並行工作
+                # 保留原地，只做備份與報告。
                 try:
-                    _restore_operator_tree(worktree, baseline)
-                except BaseException as exc:
-                    failure = RuntimeError("planning operator restore failed")
-                    failure.__cause__ = exc
-                else:
-                    failure = ValueError(
-                        "planning launcher modified operator worktree; changes rolled back"
+                    summary = _contain_operator_drift(
+                        worktree,
+                        baseline,
+                        evidence_root=(
+                            Path(evidence_root) if evidence_root is not None else None
+                        ),
+                        run_id=run_id,
+                        rollback_scope=frozenset(),
                     )
+                except BaseException as exc:  # noqa: BLE001 - 診斷面 fail-open
+                    # drift 收斂只負責診斷；它自己壞掉時仍要拋出可辨識的
+                    # planning 失敗，不得換成一個與現場無關的例外（修法前那條
+                    # 「restore failed」出口就是這個反例）。
+                    logger.error(
+                        "planning-worktree-drift-containment-failed run_id=%s error=%s: %s",
+                        run_id,
+                        type(exc).__name__,
+                        str(exc)[:200],
+                    )
+                    summary = {"counts": {}, "report_path": None, "backup_root": None}
+                message = _operator_drift_message(summary)
+                logger.error("planning-worktree-drift run_id=%s %s", run_id, message)
+                failure = ValueError(message)
         if failure is not None:
             raise failure
         return result
@@ -458,6 +914,8 @@ def _probe_identity(
     worktree: Path,
     runner: Callable[..., object],
     timeout_seconds: int,
+    evidence_root: str | Path | None = None,
+    run_id: str = "ephemeral",
 ) -> CapabilityProbe:
     expected = {
         "capability": "cortex-planning-json",
@@ -474,6 +932,8 @@ def _probe_identity(
             worktree=worktree,
             runner=runner,
             timeout_seconds=timeout_seconds,
+            evidence_root=evidence_root,
+            run_id=run_id,
         )
     except Exception as exc:
         return CapabilityProbe(
@@ -587,8 +1047,17 @@ def build_production_planning_runtime(
     worktree: str | Path,
     runner: Callable[..., object] = subprocess.run,
     timeout_seconds: int = 120,
+    evidence_root: str | Path | None = None,
+    run_id: str = "ephemeral",
 ) -> ProductionPlanningRuntime:
-    """Build the daemon's real, safe, heterogeneous planning adapters."""
+    """Build the daemon's real, safe, heterogeneous planning adapters.
+
+    issue #507：`evidence_root`／`run_id` 供 operator worktree drift 的備份與
+    報告落地（`<evidence_root>/evidence/planning-worktree-drift/<run_id>-<digest>/`）。
+    未帶入時（直呼叫、探測、測試）**不寫任何 evidence**——刻意不 fallback 到
+    `paths.coordinator_root()`，避免非 daemon 的呼叫端在 operator 的執行期狀態
+    目錄下留下非預期檔案。
+    """
 
     root = Path(worktree).resolve()
     registry = load_model_identities()
@@ -606,6 +1075,8 @@ def build_production_planning_runtime(
                 worktree=root,
                 runner=runner,
                 timeout_seconds=timeout_seconds,
+                evidence_root=evidence_root,
+                run_id=run_id,
             )
 
     primary_identity = registry.get(*primary)
@@ -619,6 +1090,8 @@ def build_production_planning_runtime(
             worktree=root,
             runner=runner,
             timeout_seconds=timeout_seconds,
+            evidence_root=evidence_root,
+            run_id=run_id,
         )
 
     def questioner(report: Mapping[str, object]) -> object:
@@ -646,6 +1119,8 @@ def build_production_planning_runtime(
             worktree=root,
             runner=runner,
             timeout_seconds=timeout_seconds,
+            evidence_root=evidence_root,
+            run_id=run_id,
         )
 
     def integrator(pack: Mapping[str, object], evidence: Mapping[str, object]) -> object:

--- a/tests/test_planning_runtime.py
+++ b/tests/test_planning_runtime.py
@@ -479,25 +479,242 @@ def test_planning_source_material_rejects_symlink_traversal(tmp_path: Path) -> N
 
 
 def test_planning_runtime_rejects_any_worktree_mutation(tmp_path: Path) -> None:
+    """issue #507：偵測到 operator worktree drift 仍必須 fail-closed，但
+    **不得改寫 operator worktree 一個位元組**。修法前這裡呼叫
+    `_restore_operator_tree()` 整棵抹除還原，實測把 operator 在同一視窗內新建
+    的未追蹤檔（work item 的 todo 來源）與前一代 planning 成功產出的 artifact
+    一併銷毀。修法後：內容原封不動，diff 落 evidence 交回 operator 判讀。"""
+
     identity = ModelIdentity("codex", "primary", "openai", ("planning",))
-    baseline = tmp_path / "tracked.md"
+    worktree = tmp_path / "worktree"
+    worktree.mkdir()
+    evidence_root = tmp_path / "coordinator"
+    baseline = worktree / "tracked.md"
     baseline.write_text("original\n", encoding="utf-8")
 
     def runner(argv, **kwargs):
         baseline.write_text("mutated\n", encoding="utf-8")
-        (tmp_path / "unexpected.md").write_text("leak\n", encoding="utf-8")
+        (worktree / "unexpected.md").write_text("leak\n", encoding="utf-8")
         return _completed("failure\n", returncode=9)
 
-    with pytest.raises(ValueError, match="operator worktree.*rolled back"):
+    with pytest.raises(ValueError, match="operator worktree.*content preserved"):
         planning_runtime._invoke_json(
             identity,
             "return JSON",
-            worktree=tmp_path,
+            worktree=worktree,
             runner=runner,
             timeout_seconds=30,
+            evidence_root=evidence_root,
+            run_id="workflow-507",
         )
-    assert baseline.read_text(encoding="utf-8") == "original\n"
-    assert not (tmp_path / "unexpected.md").exists()
+    assert baseline.read_text(encoding="utf-8") == "mutated\n"
+    assert (worktree / "unexpected.md").read_text(encoding="utf-8") == "leak\n"
+
+    report = _drift_report(evidence_root)
+    assert report["schema"] == planning_runtime.PLANNING_WORKTREE_DRIFT_SCHEMA
+    assert report["run_id"] == "workflow-507"
+    assert report["counts"] == {"added": 1, "modified": 1, "removed": 0}
+    assert report["rollback_scope_applied"] == []
+    changes = {row["path"]: row["change"] for row in report["entries"]}
+    assert changes == {"tracked.md": "modified", "unexpected.md": "added"}
+
+
+def _drift_report(evidence_root: Path) -> dict:
+    directory = (
+        evidence_root / "evidence" / planning_runtime.PLANNING_WORKTREE_DRIFT_DIRNAME
+    )
+    reports = sorted(directory.glob("*/report.json"))
+    assert len(reports) == 1, f"未見唯一 drift 報告，目錄內容：{list(directory.glob('*'))}"
+    return json.loads(reports[0].read_text(encoding="utf-8"))
+
+
+def test_operator_concurrent_untracked_file_survives_planning_drift(tmp_path: Path) -> None:
+    """issue #507 現場回歸：planning 視窗內由 operator（或其他 agent）新建的
+    未追蹤檔必須完好無損。實測 run `workflow-0529388d8e290c8fb938` 就是在這條
+    路徑上把 `docs/superpowers/workstreams/<slug>/todo.md` 抹除，連帶讓
+    `.cortex/work-items.yaml` 留下懸空連結、work item 不可 claim。"""
+
+    identity = ModelIdentity("codex", "primary", "openai", ("planning",))
+    worktree = tmp_path / "worktree"
+    (worktree / "docs" / "superpowers" / "workstreams" / "fix-x").mkdir(parents=True)
+    evidence_root = tmp_path / "coordinator"
+    concurrent = (
+        worktree / "docs" / "superpowers" / "workstreams" / "fix-x" / "todo.md"
+    )
+
+    def runner(argv, **kwargs):
+        # 與 launcher 無關的第三方並行寫入：operator 在 planning 視窗內新建檔案。
+        concurrent.write_text("# operator todo\n", encoding="utf-8")
+        return _completed(json.dumps({"ok": True}))
+
+    with pytest.raises(ValueError, match="operator worktree.*content preserved"):
+        planning_runtime._invoke_json(
+            identity,
+            "return JSON",
+            worktree=worktree,
+            runner=runner,
+            timeout_seconds=30,
+            evidence_root=evidence_root,
+            run_id="workflow-507",
+        )
+
+    assert concurrent.read_text(encoding="utf-8") == "# operator todo\n"
+    report = _drift_report(evidence_root)
+    assert report["counts"]["added"] == 1
+    added = [row for row in report["entries"] if row["change"] == "added"]
+    assert [row["path"] for row in added] == [
+        "docs/superpowers/workstreams/fix-x/todo.md"
+    ]
+    # 備份必須落地且可回復：evidence 內容與 worktree 內容逐位元組相同。
+    backup = Path(added[0]["backup"]["observed"]["path"])
+    assert backup.read_bytes() == concurrent.read_bytes()
+
+
+def test_previous_generation_planning_artifacts_survive_drift_containment(
+    tmp_path: Path,
+) -> None:
+    """issue #507 追加現場：被抹除的是 **cortex 自己的成功產出**。前一代 run
+    產出的三份合格 artifact 是未追蹤檔、不在後續那次的 T0 baseline 內，整棵還原
+    會把它們當成 launcher 產物刪掉，run 的 `planning_authority` 隨即指向不存在
+    的檔案（`workflow planning input missing`），work item 卡死且 git 救不回。"""
+
+    identity = ModelIdentity("codex", "primary", "openai", ("planning",))
+    worktree = tmp_path / "worktree"
+    specs = worktree / "docs" / "superpowers" / "specs"
+    plans = worktree / "docs" / "superpowers" / "plans"
+    specs.mkdir(parents=True)
+    plans.mkdir(parents=True)
+    evidence_root = tmp_path / "coordinator"
+    artifacts = {
+        specs / "fix-x-spec.md": "# spec\n",
+        specs / "fix-x-design.md": "# design\n",
+        plans / "fix-x.md": "# plan\n",
+    }
+
+    def runner(argv, **kwargs):
+        for path, body in artifacts.items():
+            path.write_text(body, encoding="utf-8")
+        return _completed(json.dumps({"ok": True}))
+
+    with pytest.raises(ValueError, match="operator worktree.*content preserved"):
+        planning_runtime._invoke_json(
+            identity,
+            "return JSON",
+            worktree=worktree,
+            runner=runner,
+            timeout_seconds=30,
+            evidence_root=evidence_root,
+            run_id="workflow-507",
+        )
+
+    for path, body in artifacts.items():
+        assert path.read_text(encoding="utf-8") == body
+    assert _drift_report(evidence_root)["counts"]["added"] == 3
+
+
+def test_drift_containment_refuses_to_roll_back_authority_documents(
+    tmp_path: Path,
+) -> None:
+    """issue #507：即使呼叫端明示要求還原，權威文件（work item 的 todo 來源、
+    前代 planning artifact、work registry）一律拒絕——這些是受管資產而非
+    launcher 汙染，抹除它們會讓 lifecycle／`planning_authority` 直接壞掉。"""
+
+    worktree = tmp_path / "worktree"
+    baseline = tmp_path / "baseline"
+    evidence_root = tmp_path / "coordinator"
+    for root in (worktree, baseline):
+        (root / "docs" / "superpowers" / "workstreams" / "fix-x").mkdir(parents=True)
+        (root / "docs" / "superpowers" / "specs").mkdir(parents=True)
+        (root / "openspec" / "changes" / "fix-x").mkdir(parents=True)
+        (root / ".cortex").mkdir(parents=True)
+    protected = {
+        "docs/superpowers/workstreams/fix-x/todo.md": "# todo\n",
+        "docs/superpowers/specs/fix-x-spec.md": "# spec\n",
+        "openspec/changes/fix-x/proposal.md": "# proposal\n",
+        ".cortex/work-items.yaml": "items: []\n",
+    }
+    for relative, body in protected.items():
+        (worktree / relative).write_text(body, encoding="utf-8")
+    (worktree / "scratch.txt").write_text("launcher\n", encoding="utf-8")
+
+    summary = planning_runtime._contain_operator_drift(
+        worktree,
+        baseline,
+        evidence_root=evidence_root,
+        run_id="workflow-507",
+        rollback_scope=frozenset({*protected, "scratch.txt"}),
+    )
+
+    for relative, body in protected.items():
+        assert (worktree / relative).read_text(encoding="utf-8") == body
+    refused = {row["path"]: row["reason"] for row in summary["rollback_scope_refused"]}
+    assert set(refused) == set(protected)
+    assert set(refused.values()) == {"protected-authority-document"}
+    # 範圍內、非權威文件、備份成功者才會被還原（此處 baseline 無該檔 → 刪除）。
+    assert summary["rollback_scope_applied"] == ["scratch.txt"]
+    assert not (worktree / "scratch.txt").exists()
+    backup = Path(_drift_report(evidence_root)["backup_root"])
+    assert (backup / "observed" / "scratch.txt").read_text(
+        encoding="utf-8"
+    ) == "launcher\n"
+
+
+def test_drift_containment_never_restores_a_path_it_could_not_back_up(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """issue #507 的最低保命索：備份不成功就不准抹除。修法前的整棵還原是
+    不可逆的，且錯誤訊息完全沒有指出檔案曾存在。"""
+
+    worktree = tmp_path / "worktree"
+    worktree.mkdir()
+    baseline = tmp_path / "baseline"
+    baseline.mkdir()
+    (worktree / "scratch.txt").write_text("launcher\n", encoding="utf-8")
+
+    # evidence 根不可用（None）＝ 沒有任何備份落地 → 一律拒絕還原。
+    summary = planning_runtime._contain_operator_drift(
+        worktree,
+        baseline,
+        evidence_root=None,
+        run_id="workflow-507",
+        rollback_scope=frozenset({"scratch.txt"}),
+    )
+
+    assert (worktree / "scratch.txt").read_text(encoding="utf-8") == "launcher\n"
+    assert summary["rollback_scope_applied"] == []
+    assert summary["rollback_scope_refused"] == [
+        {"path": "scratch.txt", "reason": "backup-unavailable"}
+    ]
+    assert summary["report_path"] is None
+
+
+def test_drift_containment_report_write_failure_does_not_raise(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """drift 報告是診斷面：寫不出去只能記 log，不得掩蓋（或取代）上游真正的
+    planning 失敗。"""
+
+    worktree = tmp_path / "worktree"
+    worktree.mkdir()
+    baseline = tmp_path / "baseline"
+    baseline.mkdir()
+    (worktree / "scratch.txt").write_text("launcher\n", encoding="utf-8")
+
+    def refuse(target, payload):
+        raise OSError("read-only evidence volume")
+
+    monkeypatch.setattr(planning_runtime, "_write_evidence_bytes", refuse)
+    summary = planning_runtime._contain_operator_drift(
+        worktree,
+        baseline,
+        evidence_root=tmp_path / "coordinator",
+        run_id="workflow-507",
+        rollback_scope=frozenset(),
+    )
+
+    assert summary["counts"]["added"] == 1
+    assert summary["report_path"] is None
+    assert (worktree / "scratch.txt").exists()
 
 
 def test_planning_runtime_checks_disposable_sandbox_even_on_nonzero(tmp_path: Path) -> None:
@@ -521,42 +738,96 @@ def test_planning_runtime_checks_disposable_sandbox_even_on_nonzero(tmp_path: Pa
     assert not (tmp_path / "leak.md").exists()
 
 
-def test_planning_runtime_detects_and_rolls_back_directory_and_metadata_pollution(
+def test_drift_report_covers_directory_symlink_and_metadata_changes(
     tmp_path: Path,
 ) -> None:
+    """issue #507：目錄／symlink／mode 這些非檔案內容的變化一樣要進得了報告
+    ——`_tree_snapshot` 抓得到它們，`_tree_manifest` 若看不到就會出現「偵測到
+    dirty 卻報不出任何 diff」的失真報告。修法前這些變化的處置是整棵抹除還原。"""
+
     identity = ModelIdentity("codex", "primary", "openai", ("planning",))
-    tracked = tmp_path / "tracked.md"
+    worktree = tmp_path / "worktree"
+    worktree.mkdir()
+    evidence_root = tmp_path / "coordinator"
+    tracked = worktree / "tracked.md"
     tracked.write_text("operator\n", encoding="utf-8")
     tracked.chmod(0o640)
-    empty = tmp_path / "empty"
+    empty = worktree / "empty"
     empty.mkdir()
-    target = tmp_path / "target"
+    target = worktree / "target"
     target.mkdir()
-    directory_link = tmp_path / "dir-link"
+    directory_link = worktree / "dir-link"
     directory_link.symlink_to("target", target_is_directory=True)
 
     def runner(argv, **kwargs):
         tracked.chmod(0o600)
         empty.rmdir()
-        (tmp_path / "pollution-empty").mkdir()
+        (worktree / "pollution-empty").mkdir()
         directory_link.unlink()
         directory_link.symlink_to("empty", target_is_directory=True)
         return _completed(json.dumps({"ok": True}))
 
-    with pytest.raises(ValueError, match="operator worktree.*rolled back"):
+    with pytest.raises(ValueError, match="operator worktree.*content preserved"):
         planning_runtime._invoke_json(
             identity,
             "return JSON",
-            worktree=tmp_path,
+            worktree=worktree,
             runner=runner,
             timeout_seconds=30,
+            evidence_root=evidence_root,
+            run_id="workflow-507",
         )
 
-    assert tracked.stat().st_mode & 0o777 == 0o640
-    assert empty.is_dir()
-    assert not (tmp_path / "pollution-empty").exists()
-    assert directory_link.is_symlink()
-    assert os.readlink(directory_link) == "target"
+    # 修法後不還原：launcher 造成的變化原樣留在原地，由報告交回 operator 判讀。
+    assert tracked.stat().st_mode & 0o777 == 0o600
+    assert not empty.exists()
+    assert (worktree / "pollution-empty").is_dir()
+    assert os.readlink(directory_link) == "empty"
+
+    report = _drift_report(evidence_root)
+    rows = {row["path"]: row for row in report["entries"]}
+    assert rows["tracked.md"]["change"] == "modified"
+    assert rows["tracked.md"]["baseline"]["mode"] == "0640"
+    assert rows["tracked.md"]["observed"]["mode"] == "0600"
+    assert rows["empty"]["change"] == "removed"
+    assert rows["pollution-empty"]["change"] == "added"
+    assert rows["dir-link"]["baseline"]["target"] == "target"
+    assert rows["dir-link"]["observed"]["target"] == "empty"
+
+
+def test_whole_tree_restore_code_path_is_gone(tmp_path: Path) -> None:
+    """issue #507 需求三：「整棵 worktree 還原」的程式路徑必須移除。這條斷言
+    是防回歸的門閂——`_restore_operator_tree()` 一旦被重新引入（或
+    `_make_tree_traversable()` 被重新指向 operator 樹），本測試立即 FAIL。"""
+
+    assert not hasattr(planning_runtime, "_restore_operator_tree")
+
+    identity = ModelIdentity("codex", "primary", "openai", ("planning",))
+    worktree = tmp_path / "worktree"
+    worktree.mkdir()
+    (worktree / "tracked.md").write_text("operator\n", encoding="utf-8")
+    protected = worktree / "protected"
+    protected.mkdir()
+    protected.chmod(0o750)
+
+    def runner(argv, **kwargs):
+        (worktree / "leak.md").write_text("launcher\n", encoding="utf-8")
+        return _completed(json.dumps({"ok": True}))
+
+    with pytest.raises(ValueError, match="operator worktree.*content preserved"):
+        planning_runtime._invoke_json(
+            identity,
+            "return JSON",
+            worktree=worktree,
+            runner=runner,
+            timeout_seconds=30,
+            evidence_root=tmp_path / "coordinator",
+            run_id="workflow-507",
+        )
+
+    # drift 分析全程唯讀：連「為了讀取而 chmod 0o700」都不得發生。
+    assert protected.stat().st_mode & 0o777 == 0o750
+    assert (worktree / "tracked.md").read_text(encoding="utf-8") == "operator\n"
 
 
 def test_tree_snapshot_covers_empty_directories_directory_links_and_modes(tmp_path: Path) -> None:
@@ -584,9 +855,17 @@ def test_tree_snapshot_covers_empty_directories_directory_links_and_modes(tmp_pa
     assert planning_runtime._tree_snapshot(tmp_path) != baseline
 
 
-def test_snapshot_permission_error_still_restores_operator_tree(tmp_path: Path) -> None:
+def test_snapshot_permission_error_still_produces_drift_evidence(tmp_path: Path) -> None:
+    """issue #507：launcher 把目錄 chmod 0 讓快照讀不下去時，仍必須 fail-closed
+    並產出可判讀的報告。修法前這條路徑走「整棵抹除還原」（先 chmod 整棵樹再刪
+    光重建）；修法後只做唯讀走訪，讀不到的節點記成 `unreadable` 繼續，baseline
+    版本完整備份進 evidence，operator 因此還救得回內容。"""
+
     identity = ModelIdentity("codex", "primary", "openai", ("planning",))
-    protected = tmp_path / "protected"
+    worktree = tmp_path / "worktree"
+    worktree.mkdir()
+    evidence_root = tmp_path / "coordinator"
+    protected = worktree / "protected"
     protected.mkdir()
     tracked = protected / "tracked.md"
     tracked.write_text("baseline\n", encoding="utf-8")
@@ -604,16 +883,30 @@ def test_snapshot_permission_error_still_restores_operator_tree(tmp_path: Path) 
         protected.chmod(0)
         return _completed(json.dumps({"ok": True}))
 
-    with pytest.raises(ValueError, match="operator worktree.*rolled back"):
-        planning_runtime._invoke_json(
-            identity, "return JSON", worktree=tmp_path, runner=runner,
-            timeout_seconds=30,
-        )
+    try:
+        with pytest.raises(ValueError, match="operator worktree.*content preserved"):
+            planning_runtime._invoke_json(
+                identity,
+                "return JSON",
+                worktree=worktree,
+                runner=runner,
+                timeout_seconds=30,
+                evidence_root=evidence_root,
+                run_id="workflow-507",
+            )
 
-    assert protected.stat().st_mode & 0o777 == 0o750
-    assert tracked.read_text(encoding="utf-8") == "baseline\n"
-    if xattr_supported:
-        assert os.getxattr(tracked, "user.cortex-test") == b"baseline"
+        report = _drift_report(evidence_root)
+        rows = {row["path"]: row for row in report["entries"]}
+        assert rows["protected"]["change"] == "modified"
+        assert rows["protected"]["baseline"]["mode"] == "0750"
+        assert rows["protected"]["observed"]["mode"] == "0000"
+        assert str(rows["protected"]["observed"]["children"]).startswith("unreadable:")
+        # 讀不到的子節點在報告中呈現為 removed，且 baseline 版本已完整備份。
+        assert rows["protected/tracked.md"]["change"] == "removed"
+        backup = Path(rows["protected/tracked.md"]["backup"]["baseline"]["path"])
+        assert backup.read_text(encoding="utf-8") == "baseline\n"
+    finally:
+        protected.chmod(0o750)
 
 
 def test_tree_snapshot_ignores_pycache_directories_and_pyc_files(tmp_path: Path) -> None:
@@ -827,29 +1120,38 @@ def test_planning_runtime_tolerates_shared_worktree_runtime_handoff_churn(
     assert (tmp_path / "runtime" / "handoff" / "wf-1.json").exists()
 
 
-def test_operator_restore_fault_is_fail_closed(
+def test_drift_containment_fault_does_not_mask_the_planning_failure(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    """issue #507：drift 收斂本身故障（evidence 目錄不可寫等）時仍必須
+    fail-closed 拋出可辨識的 planning 失敗，而不是把例外換成一個與現場無關的
+    「restore failed」——後者曾是修法前唯一的出口。"""
+
     identity = ModelIdentity("codex", "primary", "openai", ("planning",))
-    tracked = tmp_path / "tracked.md"
+    worktree = tmp_path / "worktree"
+    worktree.mkdir()
+    tracked = worktree / "tracked.md"
     tracked.write_text("baseline\n", encoding="utf-8")
-    real_restore = planning_runtime._restore_operator_tree
 
     def runner(argv, **kwargs):
         tracked.write_text("polluted\n", encoding="utf-8")
         return _completed(json.dumps({"ok": True}))
 
-    def restore_then_fail(worktree, baseline):
-        real_restore(worktree, baseline)
-        raise OSError("restore fsync fault")
+    def refuse(target, payload):
+        raise OSError("evidence volume is read-only")
 
-    monkeypatch.setattr(planning_runtime, "_restore_operator_tree", restore_then_fail)
-    with pytest.raises(RuntimeError, match="restore failed"):
+    monkeypatch.setattr(planning_runtime, "_write_evidence_bytes", refuse)
+    with pytest.raises(ValueError, match="operator worktree.*content preserved"):
         planning_runtime._invoke_json(
-            identity, "return JSON", worktree=tmp_path, runner=runner,
+            identity,
+            "return JSON",
+            worktree=worktree,
+            runner=runner,
             timeout_seconds=30,
+            evidence_root=tmp_path / "coordinator",
+            run_id="workflow-507",
         )
-    assert tracked.read_text(encoding="utf-8") == "baseline\n"
+    assert tracked.read_text(encoding="utf-8") == "polluted\n"
 
 
 def test_invoke_json_seeds_hermetic_claude_config_dir_from_home_credentials(

--- a/tests/test_workflow_production_wiring.py
+++ b/tests/test_workflow_production_wiring.py
@@ -351,7 +351,8 @@ def test_planning_runtime_initialization_failure_logs_reason_and_records_needs_h
     manifest_path.write_text(json.dumps(manifest.to_dict()), encoding="utf-8")
     args = _workflow_args(manifest_path, tmp_path)
 
-    def failing_runtime_factory(*, primary, worktree):
+    # #507：factory 另收 `evidence_root`／`run_id`（drift 報告的 run-scoped 落點）。
+    def failing_runtime_factory(*, primary, worktree, **_):
         raise RuntimeError("sandbox worktree creation refused")
 
     with caplog.at_level(logging.ERROR, logger="paulsha_cortex.coordinator.manager"):
@@ -5654,9 +5655,13 @@ def test_run_loop_workflow_request_calls_production_runtime_factory(
         ]
     )
     calls: list[tuple[tuple[str, str], Path]] = []
+    drift_wiring: list[tuple[Path, str]] = []
 
-    def factory(*, primary, worktree):
+    # #507：factory 另收 `evidence_root`／`run_id`——operator worktree drift 的
+    # 備份與報告要落在 run-scoped evidence 底下才找得到，這裡一併釘住 wiring。
+    def factory(*, primary, worktree, evidence_root, run_id):
         calls.append((primary, Path(worktree)))
+        drift_wiring.append((Path(evidence_root), run_id))
         return planning_runtime.ProductionPlanningRuntime(
             identities,
             {},
@@ -5683,6 +5688,11 @@ def test_run_loop_workflow_request_calls_production_runtime_factory(
     assert calls == [(('codex', 'gpt-primary'), tmp_path)]
     assert done and done["status"] == "ok"
     assert done["result"]["reason"] == "no-heterogeneous-planner"
+    assert len(drift_wiring) == 1
+    evidence_root, run_id = drift_wiring[0]
+    # `evidence_dir` 是 `<artifact_root>/evidence`，transaction_root 取其 parent。
+    assert evidence_root == tmp_path.resolve()
+    assert run_id == done["result"]["run_id"]
 
 
 def test_registry_restores_file_and_memory_when_directory_fsync_fails_after_replace(


### PR DESCRIPTION
## 根因

`planning_runtime._invoke_json` 的 finally 區塊，只要偵測到 T0→T1 之間 operator worktree 有**任何**差異（`_tree_snapshot` 前後比對），就呼叫 `_restore_operator_tree()`：刪光 worktree 內除 `.git` 以外的**全部內容**，再從 T0 baseline 複本整棵還原。

偵測條件完全分不出兩件事：

- launcher 越界寫入 operator 樹（要防的）；
- operator／其他 agent／編輯器自動儲存／背景建置在同一時間的正常編輯（誤傷的）。

而 launcher 本身早已以 `cwd=sandbox`（拋棄式複本）＋`--add-dir sandbox` 執行——operator 樹比對只是「防越界」的安全網，把安全網的補救動作設成整棵樹抹除，在多方並行的真實環境下誤傷機率遠高於它要防的越界。加上 baseline 由非原子 `copytree` 取樣（走訪期間的寫入隨遍歷順序隨機落在 baseline 內或外），**歸因本身就不可靠**。

Phase 1 dogfooding 兩次實測命中：

1. run `workflow-0529388d8e290c8fb938`：抹除 operator 在 planning 視窗內新建的 `docs/superpowers/workstreams/<slug>/todo.md`。後果不只丟檔——`cortex work link` 已把該 todo 寫進 `.cortex/work-items.yaml` 成為 path source，檔案消失後 registry 留下懸空連結、`active_todo` 為假、lifecycle 停在 `topic` → 不可 claim。
2. 更嚴重的形態：**被抹除的是 cortex 自己的成功產出**。前一代 planning 產出的三份合格 artifact 屬未追蹤檔、不在後續那次的 baseline 內，遭下一次失敗的 rollback 刪除；run 的 `planning_authority` 隨即指向不存在的檔案（`_workflow_input_snapshot` → `workflow planning input missing`），work item 卡死，且 ship 前皆未追蹤、git 救不回。

## 修法（R0：範圍收斂＋備份＋報告，不動結構）

1. **整棵還原的程式路徑移除**——`_restore_operator_tree()` 刪除，改由 `_contain_operator_drift()` 承接。`_make_tree_traversable()` 收斂為**只能指向拋棄式 sandbox**：它把整棵樹的目錄 mode 強制改成 `0o700`，本身就是一次寫入，過去只因為事後會整棵還原蓋回去才成立。
2. **預設不改寫 operator worktree 一個位元組**——drift 分析改走全新的唯讀 `_tree_manifest()`／`_diff_tree_manifests()`，對讀取失敗容錯（被 chmod 0 的角落記成 `unreadable` 繼續，不再為了讀取而 chmod 整棵樹）。與 `_tree_snapshot` 共用 `_snapshot_skipped` 排除判準，避免「偵測得到 dirty 卻報不出 diff」的判準漂移。偵測到 drift 仍 fail-closed，但處置權交回 operator。
3. **抹除前必有可回復備份＋結構化 diff 報告**——受影響檔案的 T0／T1 **兩版**完整備份進 `<coordinator_root>/evidence/planning-worktree-drift/<run_id>-<digest>/{baseline,observed}/`，同目錄落一份 `cortex-planning-worktree-drift/v1` 報告（逐路徑 change／mode／sha256／symlink target／xattr 摘要／備份落點／被拒還原的路徑與理由）。失敗訊息帶計數與 evidence 路徑（計數在前，抗上游 `[:160]` 截斷），完整訊息另落 `logger.error`。目錄名刻意不用 `planning-recovery`——那是 `work_actions._read_planning_failure_record` 的收容判準，混入會撞 `planning failure evidence ambiguous`。
4. **還原改為需明示 opt-in 且逐路徑收斂**——`rollback_scope` 預設空集合；`_invoke_json` 明確傳空集合（launcher 在 operator 樹裡沒有任何「本次 run 自產」的產物，可證明的還原範圍就是空的）。三道 fail-closed 閘門：不在本次 diff 內、命中受保護的權威文件（`docs/superpowers/{workstreams,specs,plans}/**`、`openspec/changes/**`、`.cortex/**`）、備份未成功者，一律拒絕還原——**備份不成功就不准抹除**。
5. `manager.apply_workflow_action` 把 `evidence_root`（transaction root）與 `run_id` 交給 runtime factory，operator 得以用同一組 run_id 同時撈 `planning-recovery`／`planning-artifacts`／`planning-worktree-drift` 三份 evidence。未帶入時**不寫任何 evidence**，刻意不 fallback 到 `paths.coordinator_root()`，避免非 daemon 呼叫端在 operator 執行期狀態目錄留下非預期檔案。

**刻意不做**（不越界，留待後續）：結構解（planning 產出完全不進 operator 樹，屬 R2 evidence 模型）、baseline 取樣的非原子 race、planning 期間的 advisory lock、以及 worktree drift 仍被分類為 `content` 而讓 `recover-planning` 禁用。

## 測試證據

`python3 -m pytest -q` → **2602 passed, 49 subtests passed**（0 failed）。

`tests/test_planning_runtime.py` 新增／改寫（36 passed）：

- `test_operator_concurrent_untracked_file_survives_planning_drift`——並行新建的未追蹤 todo.md 在 drift 後**逐位元組完好**，且備份 evidence 內容與 worktree 相同。
- `test_previous_generation_planning_artifacts_survive_drift_containment`——前代 planning 的三份 artifact 不被銷毀。
- `test_drift_containment_refuses_to_roll_back_authority_documents`——即使呼叫端明示要求，todo.md／spec／openspec proposal／`.cortex/work-items.yaml` 一律 `protected-authority-document` 拒絕；同批中的非權威路徑才被還原。
- `test_drift_containment_never_restores_a_path_it_could_not_back_up`——備份不可用時一律 `backup-unavailable` 拒絕還原。
- `test_whole_tree_restore_code_path_is_gone`——`_restore_operator_tree` 不存在的防回歸門閂，並斷言 drift 分析全程唯讀（受保護目錄 mode 不被 chmod）。
- `test_drift_report_covers_directory_symlink_and_metadata_changes`、`test_snapshot_permission_error_still_produces_drift_evidence`、`test_drift_containment_fault_does_not_mask_the_planning_failure`、`test_planning_runtime_rejects_any_worktree_mutation`（改寫為新語意）。

`tests/test_workflow_production_wiring.py`：釘住 `evidence_root`／`run_id` 的 factory wiring（99 passed）。

policy-check（帶 PR 上下文）：**pass 23 / fail 0 / warn 2**——warn 為 R-18 advisory 與 R-22 的 63 筆**陳年** README 懸空引用（非本次造成）。

Refs #507

- [x] changelog fragment（`changelog.d/rollback-containment.md`）＋ `CHANGELOG.md [Unreleased]`
- [x] 全套 `python3 -m pytest -q` 通過（2602 passed / 0 failed）
- [x] policy-check 帶 PR 上下文：23 pass / 0 fail（`policy-exempt:issue-link`）
