### PR TITLE
fix(coordinator): worktree registry 原子回收與 planning evidence 世代隔離

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,29 @@
   advisory lock、以及 worktree drift 仍被分類為 `content` 而禁用 `recover-planning`，
   均留待後續。
 
+- **Issue #478／#535（前代殘留回收族）：worktree registry 原子回收與 planning evidence
+  世代隔離**——`#478`：`recover-pre-candidate` 只刪 build worktree 目錄、未清 git worktree
+  registry，下一 tick 的 `git worktree add` 立即以 `cannot force update the branch ...
+  used by worktree at ...` 失敗，slice 被打回 `needs_human`。根因是兩份各自手寫的回收
+  片段——`manager.apply_slice_action` 在 `dispatcher._git_runner` 為 `None`（生產合法狀態）
+  時整段跳過 git 清理，且呼叫 seam 時多塞前導 `git`；`work_actions._recover_pre_candidate_action`
+  用裸 `subprocess.run` 無 `-C <repo>` 又 `check=False` 吞錯；兩者皆只在「目錄還在」時才
+  清理，「目錄已消失但 registry 殘留」的既存壞狀態永遠自癒不了。新增
+  `coordinator/worktree_reclaim.py` 收斂為單一回收函式：後置條件（目錄不存在 ＋ registry
+  無該筆）驗證不過即 fail closed 不回 `ok`；registry 探測先於目錄探測以支援自癒
+  （`worktree remove --force` 失敗再以 `worktree prune` 兜底）；dirty 內容先封存到
+  `evidence/worktree-reclaim/` 再刪，封存失敗即拒絕刪除（對應未追蹤 `.project-policy.yml`
+  被靜默刪除的回報）；並設安全閘拒收「非 linked worktree」的路徑，避免陳舊 job 記錄
+  （實測 `job.worktree` 會等於 run 的 `workspace_root`）讓回收遞迴刪掉主 checkout。
+  `abandon`（supersede）路徑改走同一支回收函式，補上 `#527` 根因之一的「supersede 不回收
+  build worktree」。`#535`：brainstorm evidence 的 content-addressed 檔名原本只由
+  `(scope, question_pack_id)` 決定，前代 abandon 後殘留檔佔住同一落點，下一世代 byte 不同
+  即撞 no-clobber fail-closed。改為命名空間帶 run identity
+  （`brainstorm-<run_id>-<hash>.json`，run_id 亦進 hash 輸入）——取捨為不搬動前代 evidence，
+  因為搬檔會讓前代 run 逐字記錄的 `gate_refs`／`evidence_refs` 絕對路徑整批懸空，違反審計
+  不可變原則；世代內的衝突偵測維持 fail closed。no-clobber 錯誤訊息另附
+  `existing owner=/mtime=/publishing run=`，operator 不必再挖 mtime 對時間軸。
+
 - **R0.5 D1（部分）：auto-claim label 判定改走 monitor 鏡像**——monitor 把持有
   `cortex:auto-on-going` 的 open issue 編號寫進 provider observations（issues 回應本來就含
   labels，零額外 API）；canonical claim 路徑據此導出 `auto_label`（原硬編 False）；

--- a/changelog.d/worktree-registry-reclaim.md
+++ b/changelog.d/worktree-registry-reclaim.md
@@ -1,0 +1,53 @@
+# worktree-registry-reclaim
+
+- **`#478`：recover-pre-candidate 只刪目錄未清 git worktree registry，下一 tick 重派必失敗**——
+  兩份各自手寫的回收片段（`manager.apply_slice_action` 的 `recover-pre-candidate` 分支、
+  `work_actions._recover_pre_candidate_action`）都有同一組缺陷：前者
+  `runner = git_runner or getattr(dispatcher, "_git_runner", None)`，而生產 dispatcher 的
+  `_git_runner` **合法為 `None`**（它自己在 dispatch 時才 fallback），於是整段 git 清理被
+  跳過、只 `rmtree` 目錄；即使 runner 存在，呼叫也多塞一個前導 `git`（seam 只吃 git 子命令
+  參數，實際變成 `git -C <repo> git worktree remove ...`）。後者用裸
+  `subprocess.run(["git", "worktree", ...])`（無 `-C <repo>`，跑在 manager 進程的 cwd 上）
+  加 `check=False` 吞錯。兩者又都只在「目錄還在」時才嘗試清理，於是
+  **「目錄已消失、registry 殘留」永遠自癒不了**——`git worktree list --porcelain` 留著
+  `prunable gitdir file points to non-existent location`，下一輪
+  `git worktree add` 以 `cannot force update the branch ... used by worktree at ...` 失敗，
+  slice 被打回 `needs_human`（生產連續四次重現）。
+  修法：新增 `coordinator/worktree_reclaim.py` 收斂成單一回收函式，契約為
+  **原子性**（目錄不存在 ＋ registry 無該筆，兩個後置條件都驗證過才回報成功，任一條無法
+  證實即 `failed`、呼叫端 fail closed 不回 `ok`）、**自癒**（registry 探測先於目錄探測，
+  既存壞狀態照樣收乾淨，`worktree remove --force` 失敗再以 `worktree prune` 兜底）、
+  **不銷毀證據**（目錄帶未提交／未追蹤內容時先複製到 `<state 檔目錄>/evidence/worktree-reclaim/`
+  再刪，封存失敗即 fail closed 一個位元組都不刪——對應 issue 回報的未追蹤
+  `.project-policy.yml` 被靜默刪除）。另設**安全閘**：registry 沒這筆、目錄也沒有
+  linked-worktree 標記（`.git` 為檔案）時一律拒絕回收——實測 `job.worktree` 會等於 run 的
+  `workspace_root`（主 checkout，`.git` 是目錄），無條件 `rmtree` 的爆炸半徑不可接受。
+- **`#478`／`#527`：supersede 不回收 build worktree**——`abandon`（run 終態化為
+  `superseded`）過去只清 planning artifacts，build worktree 連同它的 registry 記錄留著，
+  下一世代重派同名分支必失敗。改為與 `_gc_abandoned_planning_artifacts` 同一掛載點呼叫
+  同一支回收函式，範圍以 job 的 `workflow_run_id` 精準框定（與 `emit_outcome` 同一條歸屬
+  判準）；紀律亦相同——回收是 abandon 的附帶效果，失敗只落 diagnostics，不得讓已成立的
+  abandon 反悔。
+- **`#535`：abandon 後的 planning evidence 佔住 content-addressed 命名空間**——brainstorm
+  evidence 檔名原本只由 `(scope, question_pack_id)` 決定，前一世代 abandon 後檔案仍在，
+  下一世代重跑 brainstorm 落點完全相同；模型輸出語意相同但 byte 不同，撞上 `publish()`
+  的 no-clobber fail-closed，新世代必然以
+  `ValueError: planning artifact no-clobber conflict` 收場。
+  修法採 issue 建議 **(b) 命名空間帶 run identity**，而非 (a) 的「abandon 時搬走前代
+  evidence」：**取捨理由**是 evidence 不可銷毀（審計不可變原則）意味著也不該被**搬動**——
+  前代 run 的 `gate_refs`／`evidence_refs` 逐字記著絕對路徑，搬檔會讓那些稽核指標整批
+  懸空，等於用「稽核紀錄失聯」換「命名空間騰出」。帶 run identity 則前代 evidence 原位
+  不動、原路徑仍可稽核，新世代自然不撞，且無須在 abandon 路徑新增檔案搬移這種不可逆
+  副作用。檔名改為 `brainstorm-<run_id>-<hash>.json`，run_id 同時進 hash 輸入（手改檔名
+  偽造不出同一份 content address）；未帶 run identity 時退回舊命名，既有殘留檔仍可讀。
+  **世代內**的衝突偵測不放寬——同一個 run 兩次輸出不同仍舊 fail closed。
+- **`#535` 建議 3：no-clobber 衝突訊息附上歸屬**——訊息補
+  `existing owner=<run_id|legacy-unscoped> mtime=<ISO> publishing run=<run_id>`，operator
+  不必再自己挖 mtime 對時間軸判斷殘留檔屬於哪個世代。
+- **測試**：`tests/test_worktree_registry_reclaim_478.py` 以**真實** temporary git repo ＋
+  真實 linked worktree 驗證 registry 後置條件（含「同一 feature branch 立刻可重掛」與
+  `ScriptWorktreeCreator.create()` 重建成功，即下一 tick 的實際動作）；
+  `tests/test_pre_candidate_recovery.py` 的既有 fixture 一併從普通暫存目錄升級為真實
+  linked worktree——issue 明確指出正是那個 fixture 讓缺陷四次在生產重現而測試全綠。
+  `tests/test_planning_evidence_generation_scope_535.py` 釘住跨世代不衝突、世代內仍
+  fail closed，並以「不帶 run identity」版本重現根因。

--- a/paulsha_cortex/coordinator/manager.py
+++ b/paulsha_cortex/coordinator/manager.py
@@ -33,6 +33,7 @@ from . import seams
 from . import review as foreign_review
 from . import terminal_contract
 from . import verification
+from . import worktree_reclaim
 from .spawn_admission import SpawnAdmissionLimiter, resolve_limiter, resolve_provider
 from .registry import slice_repin_eligible
 from ..config.paths import worktree_root_for
@@ -192,6 +193,20 @@ def _supersede_handoff_manifest(
         handoff.write_manifest(manifest_path, payload)
     except OSError:
         pass
+
+
+def _reclaim_preserve_root(registry) -> Path:
+    """#478：worktree 回收時 dirty 內容的封存落點（`<state 檔目錄>/evidence`）。
+
+    與 `verification.write_verification_evidence`／`_recover_planning_record`
+    同一個 coordinator 狀態根，operator 只要看同一棵 evidence 樹就找得到；
+    registry 未帶 state path（測試 double）時退回 `paths.coordinator_root()`。
+    """
+
+    state_path = getattr(registry, "_state_path", None)
+    if isinstance(state_path, (str, Path)):
+        return Path(state_path).resolve().parent / "evidence"
+    return paths.coordinator_root() / "evidence"
 
 
 def _is_workflow_lane_job(job: dict) -> bool:
@@ -1395,17 +1410,24 @@ def apply_slice_action(
             slug = slice_row["branch"].replace("/", "-")
             wt_path = str(Path(paths.worktree_root()) / slug)
 
+        # #478：舊碼在 `runner is None`（生產 dispatcher 的合法狀態）時整段跳過
+        # git 清理只 rmtree 目錄，registry 記錄留下來讓下一 tick 的
+        # `git worktree add` 必失敗；且清理只在「目錄還在」時觸發，既存的
+        # 「目錄已消失、registry 殘留」壞狀態永遠自癒不了。改走單一回收函式：
+        # 預設 runner 由 `worktree_reclaim` 自行 fallback，後置條件（目錄不存在
+        # ＋ registry 無該筆）驗證不過就 fail closed，不再回報 ok。
+        reclaim = None
         if wt_path and isinstance(wt_path, (str, Path)):
-            target_wt = Path(wt_path)
-            if target_wt.exists() or target_wt.is_symlink():
-                if runner is not None:
-                    try:
-                        runner(["git", "worktree", "remove", "--force", str(target_wt)])
-                    except Exception:
-                        pass
-                if target_wt.exists() or target_wt.is_symlink():
-                    import shutil
-                    shutil.rmtree(target_wt, ignore_errors=True)
+            reclaim = worktree_reclaim.reclaim_worktree(
+                wt_path,
+                git_runner=runner,
+                preserve_root=_reclaim_preserve_root(registry),
+            )
+            if not reclaim.ok:
+                raise RuntimeError(
+                    "recover-pre-candidate worktree reclaim failed: "
+                    f"{reclaim.detail or reclaim.status} ({reclaim.path})"
+                )
 
         consumed_at = clock()
         registry.record_action(
@@ -1433,7 +1455,7 @@ def apply_slice_action(
             clock=clock,
         )
         latest = registry.get_slice(slice_id)
-        return {
+        payload = {
             "slice_id": slice_id,
             "action": action,
             "slice_state": latest.get("state"),
@@ -1442,6 +1464,9 @@ def apply_slice_action(
             "requested_at": requested_at,
             "consumed_at": consumed_at,
         }
+        if reclaim is not None:
+            payload["worktree_reclaim"] = reclaim.to_dict()
+        return payload
 
     if action == "retry-build":
         metas = scan_specs_fn(specs_dir)
@@ -5502,6 +5527,25 @@ def _sha256_path(path: Path) -> str:
     return hashlib.sha256(path.read_bytes()).hexdigest()
 
 
+def _planning_conflict_hint(path: Path, *, run_id: str | None) -> str:
+    """#535：no-clobber 衝突訊息附上殘留檔的歸屬與時間，供 operator 直接判讀。
+
+    `owner=` 取自檔名帶的 run identity（`brainstorm-<run_id>-<hash>.json`，見
+    `planning.brainstorm_evidence_filename`）；舊命名的殘留檔沒有這段，回
+    `legacy-unscoped`——那正是「前代殘留」最典型的樣態。
+    """
+
+    owner = "legacy-unscoped"
+    match = re.match(r"^[a-z-]+-(workflow-[0-9a-f]{20})-[0-9a-f]+\.json$", path.name)
+    if match is not None:
+        owner = match.group(1)
+    try:
+        modified = datetime.fromtimestamp(path.stat().st_mtime, timezone.utc).isoformat()
+    except OSError:
+        modified = "unknown"
+    return f"existing owner={owner} mtime={modified} publishing run={run_id or 'unknown'}"
+
+
 class PlanningPublicationDrift(RuntimeError):
     """A durable planning intent cannot be safely committed or rolled back."""
 
@@ -5634,7 +5678,13 @@ class _PlanningPublicationTransaction:
             raise ValueError(f"planning immutable evidence mode conflict: {relative}")
         if existed and baseline_hash is None:
             if not idempotent_evidence:
-                raise ValueError(f"planning artifact no-clobber conflict: {relative}")
+                # #535：舊訊息只有相對路徑，operator 得自己挖 mtime 對時間軸才
+                # 知道那份殘留檔屬於哪個 run、是不是已 superseded 的前代產物。
+                # 這裡直接附上落點歸屬（檔名帶的 run identity）與 mtime。
+                raise ValueError(
+                    f"planning artifact no-clobber conflict: {relative}"
+                    f" ({_planning_conflict_hint(path, run_id=self.run_id)})"
+                )
         if baseline_hash is not None and (not existed or before_hash != baseline_hash):
             raise ValueError(f"planning artifact baseline CAS conflict: {relative}")
         missing_dirs: list[str] = []
@@ -9083,6 +9133,10 @@ def apply_workflow_action(
             coordinator_root=transaction_root,
         ),
         evidence_writer=publication.write_evidence,
+        # #535：brainstorm evidence 的 content-addressed 命名納入 run identity，
+        # 前一世代（已 abandon）的殘留檔才不會佔住新世代的落點。前代檔案原位
+        # 保留、原路徑仍可稽核——evidence 不搬不刪。
+        run_id=run.run_id,
     )
     if result.state != "ready" or result.gate_refs.brainstorm_peer is None:
         publication.rollback()

--- a/paulsha_cortex/coordinator/planning.py
+++ b/paulsha_cortex/coordinator/planning.py
@@ -1112,6 +1112,49 @@ def _write_immutable_json(path: Path, payload: object) -> None:
         os.close(directory_fd)
 
 
+SAFE_RUN_ID_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]{0,63}")
+
+
+def brainstorm_evidence_filename(
+    *,
+    scope: PlanningScope,
+    question_pack_id: str,
+    run_id: str | None = None,
+) -> str:
+    """brainstorm evidence 的檔名（issue #535：世代隔離的 content-addressed 命名）。
+
+    原本檔名只由 `(scope, question_pack_id)` 決定，於是同一個 work item 的**下一
+    世代**（前一世代已 abandon）重跑 brainstorm 時，落點與前代殘留檔完全相同；
+    模型輸出語意相同但 byte 不同，撞上 `_PlanningPublicationTransaction.publish()`
+    的 no-clobber fail-closed，新世代必然 `ValueError: planning artifact no-clobber
+    conflict`。
+
+    修法取 issue 建議的第 (b) 案——**讓命名空間帶 run identity**，而不是第 (a) 案
+    的「abandon 時把前代 evidence 搬到 archive」：evidence 不可銷毀（審計不可變
+    原則）意味著也不該被**搬動**，前代 run 的 `gate_refs`／`evidence_refs` 逐字
+    記著絕對路徑，搬檔會讓那些稽核指標整批懸空。帶 run identity 則前代 evidence
+    原位不動、原路徑仍可稽核，新世代自然不撞。
+
+    run_id 同時進檔名（可直接看出歸屬，免去 operator 挖 mtime 對時間軸）與 hash
+    輸入（避免有人手改檔名就偽造歸屬）。`run_id` 缺席或格式不安全時退回舊命名，
+    保持既有呼叫端與既有殘留檔的可讀性。
+    """
+
+    identity: str | None = None
+    if isinstance(run_id, str) and SAFE_RUN_ID_RE.fullmatch(run_id) is not None:
+        identity = run_id
+    key_payload: dict[str, object] = {
+        "scope": scope.to_dict(),
+        "question_pack_id": question_pack_id,
+    }
+    if identity is not None:
+        key_payload["run_id"] = identity
+    evidence_key = _hash_payload(key_payload)[:32]
+    if identity is None:
+        return f"brainstorm-{evidence_key}.json"
+    return f"brainstorm-{identity}-{evidence_key}.json"
+
+
 def run_heterogeneous_brainstorm(
     *,
     report: CompletenessReport,
@@ -1126,6 +1169,7 @@ def run_heterogeneous_brainstorm(
     primary_integrator: Callable[[Mapping[str, object], Mapping[str, object]], object],
     artifact_writer: Callable[[object], Callable[[], None] | None] | None = None,
     evidence_writer: Callable[[Path, object], None] | None = None,
+    run_id: str | None = None,
 ) -> BrainstormResult:
     empty_refs = PlanningGateRefs()
     if report.complete:
@@ -1224,13 +1268,9 @@ def run_heterogeneous_brainstorm(
         "primary_integration": integration,
         "artifacts": list(artifact_evidence),
     }
-    evidence_key = _hash_payload(
-        {
-            "scope": scope.to_dict(),
-            "question_pack_id": pack.pack_id,
-        }
-    )[:32]
-    evidence_path = Path(evidence_dir) / f"brainstorm-{evidence_key}.json"
+    evidence_path = Path(evidence_dir) / brainstorm_evidence_filename(
+        scope=scope, question_pack_id=pack.pack_id, run_id=run_id
+    )
     try:
         if evidence_writer is None:
             _write_immutable_json(evidence_path, evidence_payload)

--- a/paulsha_cortex/coordinator/work_actions.py
+++ b/paulsha_cortex/coordinator/work_actions.py
@@ -55,6 +55,7 @@ from .github_delivery import (
 )
 from . import engineering_outcome
 from . import verification
+from . import worktree_reclaim
 from .preflight import PreflightRequest, load_preflight_command, run_preflight
 from .work_bridge import current_sizing_snapshot, resolve_trusted_repo_root, workflow_status
 from .workflow import GateEvidenceRef
@@ -2484,6 +2485,56 @@ def _gc_abandoned_planning_artifacts(run) -> None:
             )
 
 
+def _reclaim_abandoned_build_worktrees(run, workflow_registry, *, state_path: Path) -> None:
+    """#478／#527：run 被 supersede（abandon）之後回收它名下的 build worktree。
+
+    #527 的根因之一是 supersede 只改 run 狀態、不動 build worktree——那份
+    worktree 連同它在 git registry 的記錄留著，下一世代重派同名分支時
+    `git worktree add` 直接以「branch used by worktree at ...」失敗。這裡與
+    `_gc_abandoned_planning_artifacts` 走同一個掛載點與同一套 best-effort 紀律：
+    回收只能是 abandon 的附帶效果，任何失敗只落 diagnostics，不得讓已經成立的
+    abandon 反悔（abandon 的 evidence 與終態轉換此時皆已 durable）。
+
+    範圍以 job 的 `workflow_run_id` 精準框定——與 `engineering_outcome.
+    emit_outcome` 同一條歸屬判準，不用 work_id 前綴猜。
+    """
+
+    try:
+        jobs = workflow_registry.list_jobs()
+    except Exception as exc:  # noqa: BLE001 - best-effort：不得讓 abandon 失敗
+        logger.warning(
+            "build-worktree-reclaim-listing-failed run_id=%s error=%s: %s",
+            run.run_id, type(exc).__name__, str(exc)[:200],
+        )
+        return
+    targets = [
+        job.get("worktree")
+        for job in jobs
+        if job.get("workflow_run_id") == run.run_id
+        and isinstance(job.get("worktree"), str)
+        and job.get("worktree")
+    ]
+    if not targets:
+        return
+    try:
+        results = worktree_reclaim.reclaim_worktrees(
+            targets, preserve_root=state_path.resolve().parent / "evidence"
+        )
+    except Exception as exc:  # noqa: BLE001 - best-effort：不得讓 abandon 失敗
+        logger.warning(
+            "build-worktree-reclaim-failed run_id=%s error=%s: %s",
+            run.run_id, type(exc).__name__, str(exc)[:200],
+        )
+        return
+    for result in results:
+        if result.ok:
+            continue
+        logger.warning(
+            "build-worktree-reclaim-failed run_id=%s path=%s detail=%s",
+            run.run_id, result.path, result.detail,
+        )
+
+
 def _superseded_abandon_body(
     run,
     *,
@@ -2631,6 +2682,9 @@ def _abandon_action(
         # 呼叫之前殘留仍未清乾淨」的窗口；已清過的項目在這裡自然是 no-op
         # （`_gc_one_abandoned_planning_artifact` 對已不存在的檔案直接略過）。
         _gc_abandoned_planning_artifacts(updated)
+        _reclaim_abandoned_build_worktrees(
+            updated, workflow_registry, state_path=state_path
+        )
         return {
             "action": "abandoned",
             "reason": reason,
@@ -2706,6 +2760,8 @@ def _abandon_action(
     # artifacts——放在狀態轉換之後，確保只有 abandon 真的成立時才動檔案；
     # GC 本身 best-effort、不 raise，失敗不得讓已經成功的 abandon 跟著失敗。
     _gc_abandoned_planning_artifacts(updated)
+    # #478／#527：supersede 也要回收 build worktree，紀律同上（best-effort）。
+    _reclaim_abandoned_build_worktrees(updated, workflow_registry, state_path=state_path)
     return {
         "action": "abandoned",
         "reason": reason,
@@ -3428,16 +3484,21 @@ def _recover_pre_candidate_action(
         slug = target_slice["branch"].replace("/", "-")
         wt_path = str(Path(paths.worktree_root()) / slug)
 
+    # #478：舊碼用裸 `subprocess.run(["git", "worktree", ...])`（無 `-C <repo>`，
+    # 實際跑在 manager 進程的 cwd 上）、`check=False` 吞錯，且只在目錄還在時
+    # 觸發——registry 殘留與「目錄已消失但 registry 還在」都清不掉。統一改走
+    # `worktree_reclaim`，後置條件不成立即 fail closed。
+    reclaim = None
     if wt_path and isinstance(wt_path, (str, Path)):
-        target_wt = Path(wt_path)
-        if target_wt.exists() or target_wt.is_symlink():
-            try:
-                subprocess.run(["git", "worktree", "remove", "--force", str(target_wt)], check=False)
-            except Exception:
-                pass
-            if target_wt.exists() or target_wt.is_symlink():
-                import shutil
-                shutil.rmtree(target_wt, ignore_errors=True)
+        reclaim = worktree_reclaim.reclaim_worktree(
+            wt_path,
+            preserve_root=state_path.resolve().parent / "evidence",
+        )
+        if not reclaim.ok:
+            raise RuntimeError(
+                "recover-pre-candidate worktree reclaim failed: "
+                f"{reclaim.detail or reclaim.status} ({reclaim.path})"
+            )
 
     actor = args.get("actor") or requested_by
     workflow_registry.record_action(
@@ -3456,13 +3517,16 @@ def _recover_pre_candidate_action(
         candidate=None,
     )
     updated = workflow_registry.get_slice(slice_id)
-    return {
+    payload: dict[str, Any] = {
         "action": "recover-pre-candidate",
         "reason": "pre-candidate-slice-reset",
         "slice_id": slice_id,
         "slice_state": updated.get("state"),
         "gate_state": updated.get("gate_state"),
     }
+    if reclaim is not None:
+        payload["worktree_reclaim"] = reclaim.to_dict()
+    return payload
 
 
 def _find_repair_adoption_record(

--- a/paulsha_cortex/coordinator/worktree_reclaim.py
+++ b/paulsha_cortex/coordinator/worktree_reclaim.py
@@ -1,0 +1,460 @@
+"""issue #478：build worktree 的原子化回收（目錄 ＋ git worktree registry）。
+
+回收 build worktree 一直分散在兩處手寫片段（`manager.apply_slice_action` 的
+`recover-pre-candidate` 分支與 `work_actions._recover_pre_candidate_action`），
+兩處都只在「目錄還在」時才嘗試 git 清理、失敗一律吞掉，於是產生 #478 的生產
+現場：目錄刪了、`git worktree list --porcelain` 仍留著同一條 registry 記錄
+（`prunable gitdir file points to non-existent location`），下一個 tick 的
+`git worktree add` 立刻以 `cannot force update the branch ... used by worktree
+at ...` 失敗，slice 被打回 `needs_human`。
+
+本模組把回收收斂成單一函式，契約如下：
+
+- **原子性**：「目錄不存在」與「registry 無該筆記錄」兩個後置條件必須同時成立，
+  否則回收判定為 ``failed``——呼叫端據此 fail closed，不得回報成功。
+- **自癒**：既存壞狀態（目錄已不存在、registry 殘留）也要能收乾淨；因此
+  registry 探測先於目錄探測，不以目錄存在與否作為要不要清 registry 的條件。
+- **不銷毀證據**：目錄若帶未提交／未追蹤內容，先複製到 ``preserve_root`` 底下
+  的 reclaim 封存再刪；封存失敗即 ``failed``，一個位元組都不刪（#478 的
+  `.project-policy.yml` 資料遺失回報）。
+
+git_runner seam 沿用 `dispatcher.GitRunner` 契約：收 **git 子命令參數**（不含
+前導 ``git``、不含 ``-C``），對 repo root 執行，失敗時 raise。#478 驗收條款
+「do not prepend `git` if the seam accepts Git subcommand arguments only」指的
+就是舊碼在此處多塞一個 ``git`` 造成 `git -C <repo> git worktree remove ...`。
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+import subprocess
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable
+from uuid import uuid4
+
+from paulsha_cortex.config import paths
+
+from .dispatcher import _default_git_runner
+
+logger = logging.getLogger(__name__)
+
+GitRunner = Callable[[list[str]], Any]
+
+# 回收結果三態。`absent` 與 `reclaimed` 都算成功（後置條件成立）；只有
+# `failed` 代表後置條件無法證實，呼叫端必須 fail closed。
+RECLAIM_RECLAIMED = "reclaimed"
+RECLAIM_ABSENT = "absent"
+RECLAIM_FAILED = "failed"
+
+# 封存單檔上限；超過者只記名不複製（builder worktree 偶有大型 build 產物，
+# 全複製會讓回收變成不可預期的 I/O）。
+PRESERVE_FILE_MAX_BYTES = 4 * 1024 * 1024
+# 封存檔數上限，理由同上。
+PRESERVE_FILE_MAX_COUNT = 512
+
+
+@dataclass(frozen=True)
+class WorktreeReclaim:
+    """單一 worktree 的回收結果（機器可讀，供 action record／診斷帶出）。"""
+
+    status: str
+    path: str
+    registry_entry_found: bool = False
+    registry_removed: bool = False
+    directory_removed: bool = False
+    preserved_ref: str | None = None
+    preserved_files: int = 0
+    detail: str | None = None
+
+    @property
+    def ok(self) -> bool:
+        return self.status in {RECLAIM_RECLAIMED, RECLAIM_ABSENT}
+
+    def to_dict(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "status": self.status,
+            "path": self.path,
+            "registry_entry_found": self.registry_entry_found,
+            "registry_removed": self.registry_removed,
+            "directory_removed": self.directory_removed,
+        }
+        if self.preserved_ref is not None:
+            payload["preserved_ref"] = self.preserved_ref
+            payload["preserved_files"] = self.preserved_files
+        if self.detail is not None:
+            payload["detail"] = self.detail
+        return payload
+
+
+def _pinned_git_runner(repo_root: Path) -> GitRunner:
+    def _runner(args: list[str]) -> str:
+        proc = subprocess.run(
+            ["git", "-C", str(repo_root), *args],
+            capture_output=True,
+            text=True,
+        )
+        if proc.returncode != 0:
+            raise RuntimeError(
+                f"git -C {repo_root} {' '.join(args)} 失敗: {proc.stderr.strip()}"
+            )
+        return proc.stdout.strip()
+
+    return _runner
+
+
+def resolve_git_runner(
+    git_runner: GitRunner | None = None,
+    *,
+    repo_root: str | Path | None = None,
+) -> GitRunner:
+    """#478 驗收條款：未注入 runner 時必須退回 production-safe 的預設實作。
+
+    舊碼是 `runner = git_runner or getattr(dispatcher, "_git_runner", None)`，
+    而生產 dispatcher 的 `_git_runner` 合法為 ``None``（它自己在 dispatch 時
+    才 fallback 到預設），於是 recovery 整段 git 清理被跳過。
+    """
+
+    if git_runner is not None:
+        return git_runner
+    if repo_root is not None:
+        return _pinned_git_runner(Path(repo_root))
+    return _default_git_runner
+
+
+def _run(runner: GitRunner, args: list[str]) -> tuple[bool, str, str]:
+    """執行 git 子命令；回傳 (成功, stdout, 錯誤摘要)。
+
+    同時吃兩種 runner 回傳型別：dispatcher 風格（回 stdout 字串、失敗 raise）
+    與 `subprocess.CompletedProcess` 風格，避免呼叫端被迫改造既有 seam。
+    """
+
+    try:
+        raw = runner(list(args))
+    except Exception as exc:  # noqa: BLE001 - seam 失敗一律轉成結構化結果
+        return False, "", f"{type(exc).__name__}: {str(exc)[:400]}"
+    if isinstance(raw, str):
+        return True, raw, ""
+    returncode = getattr(raw, "returncode", None)
+    stdout = getattr(raw, "stdout", "") or ""
+    stderr = getattr(raw, "stderr", "") or ""
+    if isinstance(stdout, bytes):
+        stdout = stdout.decode("utf-8", errors="replace")
+    if isinstance(stderr, bytes):
+        stderr = stderr.decode("utf-8", errors="replace")
+    if not isinstance(returncode, int):
+        # 無法判定回傳碼的 seam（多半是測試 double）視為成功但無輸出。
+        return True, str(stdout), ""
+    if returncode != 0:
+        return False, str(stdout), str(stderr).strip()[:400]
+    return True, str(stdout), ""
+
+
+def _identity_keys(path: str | Path) -> set[str]:
+    text = str(path)
+    keys = {text, os.path.normpath(text)}
+    try:
+        keys.add(os.path.realpath(text))
+    except OSError:  # pragma: no cover - realpath 幾乎不拋
+        pass
+    return {key.rstrip("/") or "/" for key in keys}
+
+
+def list_registered_worktrees(runner: GitRunner) -> tuple[list[str], str | None]:
+    """`git worktree list --porcelain` 的 worktree 路徑清單。
+
+    回傳 ``(paths, error)``；``error`` 非 None 代表無法取得清單——呼叫端必須
+    視為「後置條件不可證實」而 fail closed，不得當成「沒有殘留」。
+    """
+
+    ok, stdout, stderr = _run(runner, ["worktree", "list", "--porcelain"])
+    if not ok:
+        return [], stderr or "git worktree list failed"
+    entries = [
+        line[len("worktree ") :].strip()
+        for line in stdout.splitlines()
+        if line.startswith("worktree ")
+    ]
+    return entries, None
+
+
+def _registry_contains(runner: GitRunner, target: Path) -> tuple[bool, str | None]:
+    entries, error = list_registered_worktrees(runner)
+    if error is not None:
+        return False, error
+    wanted = _identity_keys(target)
+    for entry in entries:
+        if _identity_keys(entry) & wanted:
+            return True, None
+    return False, None
+
+
+def _looks_like_linked_worktree(target: Path) -> bool:
+    """linked worktree 的根目錄帶的是 `.git` **檔案**（內容 `gitdir: ...`）。
+
+    `.git` 是**目錄**代表那是一個主 checkout（獨立 repo，例如 run 的
+    `workspace_root`）——那絕不是本模組該遞迴刪除的東西，一律回 False。
+    """
+
+    marker = target / ".git"
+    return marker.is_file() and not marker.is_symlink()
+
+
+def _timestamp_slug() -> str:
+    return datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
+def _dirty_entries(runner: GitRunner, target: Path) -> tuple[list[str], str | None]:
+    """列出 worktree 內未提交／未追蹤（不含 ignored）的相對路徑。
+
+    透過 ``git -C <worktree>`` 走同一個 seam：git 允許重複 ``-C``，後者為絕對
+    路徑時直接生效，因此不必為了讀 worktree 狀態另開一條 runner 契約。
+
+    刻意**不用** ``git status --porcelain``：seam 契約回傳的是已 ``strip()`` 的
+    字串，porcelain 的兩字狀態碼首欄可能是空白（`` M README.md``），首筆記錄會
+    被 strip 掉一個字元、路徑跟著錯位。改用兩個只吐裸路徑的命令，對 strip 免疫。
+    """
+
+    entries: list[str] = []
+    ok, stdout, stderr = _run(
+        runner, ["-C", str(target), "diff", "--name-only", "-z", "HEAD"]
+    )
+    if not ok:
+        return [], stderr or "git diff failed"
+    entries.extend(field for field in stdout.split("\0") if field)
+    ok, stdout, stderr = _run(
+        runner,
+        ["-C", str(target), "ls-files", "--others", "--exclude-standard", "-z"],
+    )
+    if not ok:
+        return [], stderr or "git ls-files failed"
+    entries.extend(field for field in stdout.split("\0") if field)
+    seen: set[str] = set()
+    unique: list[str] = []
+    for entry in entries:
+        if entry in seen:
+            continue
+        seen.add(entry)
+        unique.append(entry)
+    return unique, None
+
+
+def _preserve_dirty_content(
+    target: Path,
+    entries: list[str],
+    *,
+    preserve_root: Path,
+) -> tuple[str, int]:
+    """把 dirty 內容複製到 reclaim 封存目錄，回傳 (封存路徑, 檔數)。"""
+
+    destination = (
+        Path(preserve_root)
+        / "worktree-reclaim"
+        / f"{target.name}-{_timestamp_slug()}-{uuid4().hex[:8]}"
+    )
+    destination.mkdir(parents=True, exist_ok=False)
+    copied = 0
+    skipped: list[str] = []
+    for relative in entries[:PRESERVE_FILE_MAX_COUNT]:
+        source = target / relative
+        if source.is_symlink() or not source.is_file():
+            continue
+        if source.stat().st_size > PRESERVE_FILE_MAX_BYTES:
+            skipped.append(relative)
+            continue
+        copy_to = destination / relative
+        copy_to.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source, copy_to)
+        copied += 1
+    overflow = entries[PRESERVE_FILE_MAX_COUNT:]
+    if skipped or overflow:
+        manifest = destination / "_reclaim-skipped.txt"
+        manifest.write_text(
+            "\n".join([*skipped, *overflow]) + "\n", encoding="utf-8"
+        )
+    return str(destination), copied
+
+
+def reclaim_worktree(
+    path: str | Path,
+    *,
+    git_runner: GitRunner | None = None,
+    repo_root: str | Path | None = None,
+    preserve_root: str | Path | None = None,
+) -> WorktreeReclaim:
+    """原子回收單一 build worktree（目錄 ＋ registry），並驗證後置條件。
+
+    後置條件（兩者皆須成立才回報成功）：
+
+    1. ``git worktree list --porcelain`` 不再含該路徑；
+    2. 該路徑在檔案系統上不存在。
+
+    任一條無法證實（含 registry 清單本身讀不到）一律回 ``failed``；呼叫端
+    MUST NOT 在 ``failed`` 上回報 recovery 成功——這正是 #478 的核心缺陷。
+    """
+
+    runner = resolve_git_runner(git_runner, repo_root=repo_root)
+    target = Path(path)
+    text = str(target)
+
+    registered, list_error = _registry_contains(runner, target)
+    if list_error is not None:
+        return WorktreeReclaim(
+            RECLAIM_FAILED, text, detail=f"worktree-registry-unreadable: {list_error}"
+        )
+
+    exists = target.exists() or target.is_symlink()
+    if not registered and not exists:
+        return WorktreeReclaim(RECLAIM_ABSENT, text)
+
+    # 安全閘（先於任何寫入／掃描）：registry 沒這筆、目錄本身也沒有
+    # linked-worktree 標記，代表這個路徑不是（也不曾是）build worktree——
+    # job／slice 記錄可能陳舊或指錯（實測 `job.worktree` 會等於 run 的
+    # `workspace_root`，那是主 checkout），遞迴刪除的爆炸半徑不可接受。
+    # 回報 failed 讓 operator 看見異常，而不是靜默刪掉別人的目錄，也不是
+    # 靜默留下會擋住下一次 `worktree add` 的殘骸。
+    if (
+        exists
+        and not registered
+        and not target.is_symlink()
+        and target.is_dir()
+        and not _looks_like_linked_worktree(target)
+    ):
+        return WorktreeReclaim(RECLAIM_FAILED, text, detail="worktree-path-not-a-worktree")
+
+    preserved_ref: str | None = None
+    preserved_files = 0
+    if exists and not target.is_symlink() and target.is_dir():
+        entries, dirty_error = _dirty_entries(runner, target)
+        if dirty_error is not None:
+            # gitdir 已壞（正是 #478 的殘留態）時 status 讀不到；此時目錄要嘛
+            # 不存在、要嘛只剩無主檔案，記錄後照常回收，不阻斷自癒。
+            logger.warning(
+                "worktree-reclaim-dirty-scan-unavailable path=%s error=%s",
+                text,
+                dirty_error,
+            )
+        elif entries:
+            root = Path(preserve_root) if preserve_root is not None else (
+                paths.coordinator_root() / "evidence"
+            )
+            try:
+                preserved_ref, preserved_files = _preserve_dirty_content(
+                    target, entries, preserve_root=root
+                )
+            except OSError as exc:
+                # 證據沒保住就一個位元組都不刪——#478 的 `.project-policy.yml`
+                # 資料遺失回報要求「preserve or fail closed」，不得兩者皆非。
+                return WorktreeReclaim(
+                    RECLAIM_FAILED,
+                    text,
+                    registry_entry_found=registered,
+                    detail=(
+                        "worktree-dirty-preserve-failed: "
+                        f"{type(exc).__name__}: {str(exc)[:200]}"
+                    ),
+                )
+
+    registry_removed = False
+    remove_error: str | None = None
+    if registered:
+        ok, _, stderr = _run(runner, ["worktree", "remove", "--force", text])
+        if not ok:
+            remove_error = stderr or "git worktree remove failed"
+            # `--force` 拒收時（例如 gitdir 檔已被外力刪除）再試 prune，
+            # 這是 native `git worktree prune` 的等價操作。
+            _run(runner, ["worktree", "prune"])
+        still_registered, list_error = _registry_contains(runner, target)
+        if list_error is not None:
+            return WorktreeReclaim(
+                RECLAIM_FAILED,
+                text,
+                registry_entry_found=True,
+                preserved_ref=preserved_ref,
+                preserved_files=preserved_files,
+                detail=f"worktree-registry-unreadable: {list_error}",
+            )
+        if still_registered:
+            return WorktreeReclaim(
+                RECLAIM_FAILED,
+                text,
+                registry_entry_found=True,
+                preserved_ref=preserved_ref,
+                preserved_files=preserved_files,
+                detail=(
+                    "worktree-registry-entry-remains: "
+                    f"{remove_error or 'git worktree remove reported success'}"
+                ),
+            )
+        registry_removed = True
+
+    directory_removed = False
+    if target.exists() or target.is_symlink():
+        is_link_or_file = target.is_symlink() or target.is_file()
+        try:
+            if is_link_or_file:
+                target.unlink()
+            else:
+                shutil.rmtree(target)
+        except OSError as exc:
+            return WorktreeReclaim(
+                RECLAIM_FAILED,
+                text,
+                registry_entry_found=registered,
+                registry_removed=registry_removed,
+                preserved_ref=preserved_ref,
+                preserved_files=preserved_files,
+                detail=f"worktree-directory-remove-failed: {type(exc).__name__}: {str(exc)[:200]}",
+            )
+        directory_removed = True
+
+    if target.exists() or target.is_symlink():
+        return WorktreeReclaim(
+            RECLAIM_FAILED,
+            text,
+            registry_entry_found=registered,
+            registry_removed=registry_removed,
+            preserved_ref=preserved_ref,
+            preserved_files=preserved_files,
+            detail="worktree-directory-remains",
+        )
+
+    return WorktreeReclaim(
+        RECLAIM_RECLAIMED,
+        text,
+        registry_entry_found=registered,
+        registry_removed=registry_removed,
+        directory_removed=directory_removed,
+        preserved_ref=preserved_ref,
+        preserved_files=preserved_files,
+    )
+
+
+def reclaim_worktrees(
+    worktrees: list[str | Path],
+    *,
+    git_runner: GitRunner | None = None,
+    repo_root: str | Path | None = None,
+    preserve_root: str | Path | None = None,
+) -> list[WorktreeReclaim]:
+    """對多個 worktree 逐一回收（去重、保序）；不因單筆失敗而中止。"""
+
+    seen: set[str] = set()
+    results: list[WorktreeReclaim] = []
+    for item in worktrees:
+        text = str(item)
+        if not text or text in seen:
+            continue
+        seen.add(text)
+        results.append(
+            reclaim_worktree(
+                text,
+                git_runner=git_runner,
+                repo_root=repo_root,
+                preserve_root=preserve_root,
+            )
+        )
+    return results

--- a/tests/test_planning_evidence_generation_scope_535.py
+++ b/tests/test_planning_evidence_generation_scope_535.py
@@ -1,0 +1,269 @@
+"""issue #535：abandon 後的 planning evidence 不得佔住下一世代的命名空間。
+
+生產現場：前一世代（`workflow-88d089d71416a754dda8`）的 brainstorm evidence 落
+在 `evidence/planning/brainstorm-<hash>.json`，run 被 abandon 之後檔案留著；下一
+世代重跑 brainstorm，scope 與 question pack 都相同 → 檔名相同，但模型輸出語意
+相同而 byte 不同 → `publish()` 的 no-clobber fail-closed 直接把新世代打死。
+
+修法採 issue 建議 (b)：命名空間帶 run identity。evidence 不搬不刪（審計不可變），
+前代檔案原位保留、原路徑仍可稽核，新世代自然不撞。
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from paulsha_cortex.coordinator import manager
+from paulsha_cortex.coordinator.model_identities import CapabilityProbe, IdentityRegistry
+from paulsha_cortex.coordinator.planning import (
+    PlanningArtifact,
+    PlanningScope,
+    assess_planning_completeness,
+    brainstorm_evidence_filename,
+    run_heterogeneous_brainstorm,
+)
+
+GEN_ONE = "workflow-88d089d71416a754dda8"
+GEN_TWO = "workflow-7a430d31eff66ef13630"
+
+SCOPE = PlanningScope(
+    repo="hamanpaul/paulsha-cortex",
+    work_id="fix-instance-config-isolation",
+    source_revision="tree:0123456789abcdef",
+)
+
+ACCEPTED_SPEC = """\
+---
+status: accepted
+---
+# Feature specification
+
+## Requirements
+
+The behavior is fixed.
+"""
+
+ACCEPTED_DESIGN = """\
+---
+status: accepted
+---
+# Feature design
+
+## Decisions
+
+Use one durable writer.
+"""
+
+ACCEPTED_PLAN = """\
+---
+status: accepted
+---
+# Feature plan
+
+## Tasks
+
+- [ ] Task 1: implement
+"""
+
+
+def _registry() -> IdentityRegistry:
+    return IdentityRegistry.from_rows(
+        [
+            {
+                "executor": "codex",
+                "model_id": "gpt-primary",
+                "independence_domain": "openai",
+                "capabilities": ["planning"],
+            },
+            {
+                "executor": "agy",
+                "model_id": "Gemini 3.1 Pro (High)",
+                "independence_domain": "google",
+                "capabilities": ["planning"],
+                "live_probe": "agy-plan-sandbox",
+            },
+        ]
+    )
+
+
+_PROBES = {
+    ("agy", "Gemini 3.1 Pro (High)"): CapabilityProbe.ready_for(
+        "agy", "Gemini 3.1 Pro (High)", "google"
+    )
+}
+
+
+def _brainstorm(tmp_path: Path, *, claim: str, run_id: str | None):
+    """跑一次 brainstorm；`claim` 模擬「語意相同、措辭不同」的模型輸出。"""
+
+    report = assess_planning_completeness(
+        [PlanningArtifact(kind="spec", ref="docs/spec.md", text=ACCEPTED_SPEC)]
+    )
+    existing_spec = tmp_path / "docs" / "spec.md"
+    existing_spec.parent.mkdir(parents=True, exist_ok=True)
+    existing_spec.write_text(ACCEPTED_SPEC, encoding="utf-8")
+
+    def primary_questioner(_payload):
+        return report.default_question_pack.to_dict()
+
+    def secondary_planner(pack_payload, identity):
+        return {
+            "schema_version": 1,
+            "question_pack_id": pack_payload["pack_id"],
+            "evidence": [
+                {
+                    "question_id": question["question_id"],
+                    "claims": [claim],
+                    "source_refs": ["docs/planning-index.md:1"],
+                }
+                for question in pack_payload["questions"]
+            ],
+        }
+
+    def primary_integrator(pack_payload, evidence_payload):
+        bodies = {"spec": ACCEPTED_SPEC, "design": ACCEPTED_DESIGN, "plan": ACCEPTED_PLAN}
+        resolutions = []
+        for question in pack_payload["questions"]:
+            kind = question["kind"].removeprefix("missing-")
+            ref = f"docs/{kind}.md"
+            target = tmp_path / ref
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(bodies[kind], encoding="utf-8")
+            resolutions.append(
+                {
+                    "question_id": question["question_id"],
+                    "decision": "Create and accept the missing artifact.",
+                    "artifact_kind": kind,
+                    "artifact_refs": [ref],
+                }
+            )
+        return {
+            "schema_version": 1,
+            "question_pack_id": pack_payload["pack_id"],
+            "secondary_evidence_hash": evidence_payload["evidence_hash"],
+            "resolutions": resolutions,
+        }
+
+    return run_heterogeneous_brainstorm(
+        report=report,
+        primary=("codex", "gpt-primary"),
+        registry=_registry(),
+        probes=_PROBES,
+        evidence_dir=tmp_path / "evidence" / "planning",
+        artifact_root=tmp_path,
+        scope=SCOPE,
+        primary_questioner=primary_questioner,
+        secondary_planner=secondary_planner,
+        primary_integrator=primary_integrator,
+        run_id=run_id,
+    )
+
+
+def test_evidence_filename_is_scoped_by_run_identity() -> None:
+    pack_id = "pack-0123456789abcdef"
+    first = brainstorm_evidence_filename(
+        scope=SCOPE, question_pack_id=pack_id, run_id=GEN_ONE
+    )
+    second = brainstorm_evidence_filename(
+        scope=SCOPE, question_pack_id=pack_id, run_id=GEN_TWO
+    )
+    assert first != second
+    assert first.startswith(f"brainstorm-{GEN_ONE}-")
+    assert second.startswith(f"brainstorm-{GEN_TWO}-")
+    # 同一 run 內必須完全穩定（冪等重跑仍落同一個檔）。
+    assert first == brainstorm_evidence_filename(
+        scope=SCOPE, question_pack_id=pack_id, run_id=GEN_ONE
+    )
+    # 未帶 run identity 時退回舊命名，既有殘留檔仍可讀。
+    legacy = brainstorm_evidence_filename(scope=SCOPE, question_pack_id=pack_id)
+    assert legacy.startswith("brainstorm-") and GEN_ONE not in legacy
+    # run_id 也進 hash：改檔名偽造不出同一份 content address。
+    assert legacy.removeprefix("brainstorm-") != first.removeprefix(
+        f"brainstorm-{GEN_ONE}-"
+    )
+
+
+def test_next_generation_does_not_collide_with_abandoned_generation(
+    tmp_path: Path,
+) -> None:
+    first = _brainstorm(tmp_path, claim="No accepted artifact found.", run_id=GEN_ONE)
+    assert first.state == "ready"
+    stale = Path(first.gate_refs.brainstorm_peer.ref)
+    stale_bytes = stale.read_bytes()
+
+    # 前一世代 abandon；evidence 依審計不可變原則原位保留（不搬、不刪）。
+    second = _brainstorm(
+        tmp_path,
+        claim="The repository has no accepted planning artifact.",
+        run_id=GEN_TWO,
+    )
+
+    assert second.state == "ready", second.reason
+    fresh = Path(second.gate_refs.brainstorm_peer.ref)
+    assert fresh != stale
+    assert stale.is_file() and stale.read_bytes() == stale_bytes
+    assert json.loads(fresh.read_text(encoding="utf-8"))["kind"] == "brainstorm-peer"
+
+
+def test_same_generation_still_fails_closed_on_divergent_content(
+    tmp_path: Path,
+) -> None:
+    """世代內的衝突偵測不得被放寬——同一個 run 兩次輸出不同仍必須 fail closed。"""
+
+    first = _brainstorm(tmp_path, claim="No accepted artifact found.", run_id=GEN_ONE)
+    assert first.state == "ready"
+    conflict = _brainstorm(
+        tmp_path, claim="A completely different observation.", run_id=GEN_ONE
+    )
+    assert (conflict.state, conflict.reason) == (
+        "needs_human",
+        "brainstorm-evidence-conflict",
+    )
+
+
+def test_unscoped_naming_reproduces_the_cross_generation_collision(
+    tmp_path: Path,
+) -> None:
+    """釘住根因：不帶 run identity 時，下一世代必然撞上前代殘留（#535 現場）。"""
+
+    first = _brainstorm(tmp_path, claim="No accepted artifact found.", run_id=None)
+    assert first.state == "ready"
+    second = _brainstorm(
+        tmp_path,
+        claim="The repository has no accepted planning artifact.",
+        run_id=None,
+    )
+    assert (second.state, second.reason) == (
+        "needs_human",
+        "brainstorm-evidence-conflict",
+    )
+
+
+def test_no_clobber_conflict_message_names_the_owning_run(tmp_path: Path) -> None:
+    """#535 建議 3：衝突訊息要直接說出殘留檔屬於哪個 run，免得 operator 挖 mtime。"""
+
+    root = tmp_path / "workspace"
+    journal_root = tmp_path / "coordinator" / "evidence"
+    (root).mkdir(parents=True, exist_ok=True)
+    evidence_dir = journal_root / "planning"
+    evidence_dir.mkdir(parents=True, exist_ok=True)
+    residue = evidence_dir / f"brainstorm-{GEN_ONE}-{'0' * 32}.json"
+    residue.write_bytes(b'{"kind": "brainstorm-peer"}\n')
+
+    transaction = manager._PlanningPublicationTransaction(
+        root=root,
+        run_id=GEN_TWO,
+        journal_root=journal_root,
+    )
+    with pytest.raises(ValueError) as error:
+        transaction.publish(
+            residue, b"different bytes\n", baseline_hash=None, kind="evidence"
+        )
+
+    message = str(error.value)
+    assert "planning artifact no-clobber conflict" in message
+    assert f"existing owner={GEN_ONE}" in message
+    assert f"publishing run={GEN_TWO}" in message

--- a/tests/test_pre_candidate_recovery.py
+++ b/tests/test_pre_candidate_recovery.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock
 import pytest
@@ -40,11 +41,30 @@ def test_allowed_slice_actions_when_candidate_is_null(tmp_path: Path) -> None:
     assert "retry-build" not in actions
 
 
-def test_recover_pre_candidate_removes_worktree_and_resets_slice(tmp_path: Path) -> None:
+def _git(repo: Path, *args: str) -> None:
+    proc = subprocess.run(["git", "-C", str(repo), *args], capture_output=True, text=True)
+    assert proc.returncode == 0, f"git {' '.join(args)} failed: {proc.stderr}"
+
+
+def test_recover_pre_candidate_removes_worktree_and_resets_slice(
+    tmp_path: Path, monkeypatch
+) -> None:
+    # issue #478：這個 fixture 原本只是一個普通暫存目錄，因此只證明得了「檔案被
+    # 刪掉」、看不見 git worktree registry 殘留（正是 #478 連續四次在生產重現卻
+    # 測試全綠的原因）。改用真實 repo ＋ 真實 linked worktree。
     state_path = tmp_path / "jobs.json"
     reg = JobRegistry(state_path=state_path)
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q", "-b", "main")
+    _git(repo, "config", "user.email", "recover@example.invalid")
+    _git(repo, "config", "user.name", "recover-test")
+    (repo / "README.md").write_text("seed\n", encoding="utf-8")
+    _git(repo, "add", "README.md")
+    _git(repo, "commit", "-qm", "init")
+    monkeypatch.setenv("PSC_REPO_ROOT", str(repo))
     wt_dir = tmp_path / "wt" / "feature-slice-3a"
-    wt_dir.mkdir(parents=True, exist_ok=True)
+    _git(repo, "worktree", "add", "-q", str(wt_dir), "-b", "feature/slice-3a")
     (wt_dir / "leftover.txt").write_text("residual", encoding="utf-8")
 
     builder_job = reg.create_job(
@@ -84,6 +104,12 @@ def test_recover_pre_candidate_removes_worktree_and_resets_slice(tmp_path: Path)
 
     assert res["result"] == "ok"
     assert not wt_dir.exists()
+    listing = subprocess.run(
+        ["git", "-C", str(repo), "worktree", "list", "--porcelain"],
+        capture_output=True,
+        text=True,
+    ).stdout
+    assert str(wt_dir) not in listing
     latest_slice = reg.get_slice("slice-3a")
     assert latest_slice["state"] == "pending"
     assert latest_slice["gate_state"] == "pending"

--- a/tests/test_worktree_registry_reclaim_478.py
+++ b/tests/test_worktree_registry_reclaim_478.py
@@ -1,0 +1,413 @@
+"""issue #478：recover-pre-candidate 必須同時清掉目錄與 git worktree registry。
+
+這裡刻意用**真實** temporary git repo 與真實 linked worktree，而不是普通暫存
+目錄——#478 的既有測試（`tests/test_pre_candidate_recovery.py`）正是因為只驗
+「目錄被刪掉」而看不見 registry 殘留，讓生產現場連續四次重現同一個缺陷。
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from paulsha_cortex.coordinator import manager, work_actions, worktree_reclaim
+from paulsha_cortex.coordinator.dispatcher import Dispatcher
+from paulsha_cortex.coordinator.registry import JobRegistry
+from paulsha_cortex.coordinator.seams import ScriptWorktreeCreator
+
+
+def _git(repo: Path, *args: str) -> str:
+    proc = subprocess.run(
+        ["git", "-C", str(repo), *args], capture_output=True, text=True
+    )
+    assert proc.returncode == 0, f"git {' '.join(args)} failed: {proc.stderr}"
+    return proc.stdout
+
+
+def _init_repo(root: Path) -> Path:
+    repo = root / "repo"
+    repo.mkdir(parents=True, exist_ok=True)
+    _git(repo, "init", "-q", "-b", "main")
+    _git(repo, "config", "user.email", "reclaim@example.invalid")
+    _git(repo, "config", "user.name", "reclaim-test")
+    (repo / "README.md").write_text("seed\n", encoding="utf-8")
+    _git(repo, "add", "README.md")
+    _git(repo, "commit", "-qm", "init")
+    return repo
+
+
+def _registered_worktrees(repo: Path) -> set[str]:
+    return {
+        line[len("worktree ") :].strip()
+        for line in _git(repo, "worktree", "list", "--porcelain").splitlines()
+        if line.startswith("worktree ")
+    }
+
+
+def _runner_for(repo: Path):
+    def _runner(args: list[str]) -> str:
+        proc = subprocess.run(
+            ["git", "-C", str(repo), *args], capture_output=True, text=True
+        )
+        if proc.returncode != 0:
+            raise RuntimeError(proc.stderr.strip())
+        return proc.stdout.strip()
+
+    return _runner
+
+
+# --------------------------------------------------------------------------
+# reclaim_worktree 本身
+# --------------------------------------------------------------------------
+
+
+def test_reclaim_removes_directory_and_registry_entry(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    worktree = tmp_path / "pool" / "feature-slice-a"
+    _git(repo, "worktree", "add", "-q", str(worktree), "-b", "feature/slice-a")
+    assert str(worktree) in _registered_worktrees(repo)
+
+    result = worktree_reclaim.reclaim_worktree(
+        worktree, git_runner=_runner_for(repo), preserve_root=tmp_path / "evidence"
+    )
+
+    assert result.status == worktree_reclaim.RECLAIM_RECLAIMED
+    assert result.registry_entry_found is True
+    assert result.registry_removed is True
+    assert not worktree.exists()
+    assert str(worktree) not in _registered_worktrees(repo)
+    # #478 驗收條款：同一條 feature branch 必須能立刻重新掛上。
+    _git(repo, "worktree", "add", "-q", str(worktree), "feature/slice-a")
+
+
+def test_reclaim_self_heals_stale_registry_when_directory_already_gone(
+    tmp_path: Path,
+) -> None:
+    """既存壞狀態（目錄不存在、registry 殘留 prunable 記錄）也要能收乾淨。"""
+
+    repo = _init_repo(tmp_path)
+    worktree = tmp_path / "pool" / "feature-slice-b"
+    _git(repo, "worktree", "add", "-q", str(worktree), "-b", "feature/slice-b")
+    # 模擬舊版 recover-pre-candidate：只 rmtree 目錄、不動 registry。
+    subprocess.run(["rm", "-rf", str(worktree)], check=True)
+    assert str(worktree) in _registered_worktrees(repo)
+
+    result = worktree_reclaim.reclaim_worktree(
+        worktree, git_runner=_runner_for(repo), preserve_root=tmp_path / "evidence"
+    )
+
+    assert result.status == worktree_reclaim.RECLAIM_RECLAIMED
+    assert result.registry_entry_found is True
+    assert result.registry_removed is True
+    assert str(worktree) not in _registered_worktrees(repo)
+    _git(repo, "worktree", "add", "-q", str(worktree), "feature/slice-b")
+
+
+def test_reclaim_reports_absent_when_nothing_to_reclaim(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    result = worktree_reclaim.reclaim_worktree(
+        tmp_path / "pool" / "never-existed", git_runner=_runner_for(repo)
+    )
+    assert result.status == worktree_reclaim.RECLAIM_ABSENT
+    assert result.ok is True
+
+
+def test_reclaim_preserves_dirty_content_before_removing(tmp_path: Path) -> None:
+    """#478 comment：未追蹤的 agent 產物不得被 rmtree 靜默丟掉。"""
+
+    repo = _init_repo(tmp_path)
+    worktree = tmp_path / "pool" / "feature-slice-c"
+    _git(repo, "worktree", "add", "-q", str(worktree), "-b", "feature/slice-c")
+    (worktree / ".project-policy.yml").write_text("policy_version: 1.0.17\n", encoding="utf-8")
+    (worktree / "README.md").write_text("seed\nmutated\n", encoding="utf-8")
+
+    result = worktree_reclaim.reclaim_worktree(
+        worktree, git_runner=_runner_for(repo), preserve_root=tmp_path / "evidence"
+    )
+
+    assert result.status == worktree_reclaim.RECLAIM_RECLAIMED
+    assert result.preserved_ref is not None
+    preserved = Path(result.preserved_ref)
+    assert (preserved / ".project-policy.yml").read_text(encoding="utf-8") == (
+        "policy_version: 1.0.17\n"
+    )
+    assert (preserved / "README.md").read_text(encoding="utf-8") == "seed\nmutated\n"
+    assert not worktree.exists()
+
+
+def test_reclaim_fails_closed_when_registry_entry_survives(tmp_path: Path) -> None:
+    """`git worktree remove` 失敗時不得回報成功（#478 驗收條款第三條）。"""
+
+    repo = _init_repo(tmp_path)
+    worktree = tmp_path / "pool" / "feature-slice-d"
+    _git(repo, "worktree", "add", "-q", str(worktree), "-b", "feature/slice-d")
+    real = _runner_for(repo)
+
+    def stubborn(args: list[str]) -> str:
+        if args[:2] == ["worktree", "remove"]:
+            raise RuntimeError("fatal: validation failed, cannot remove working tree")
+        if args[:2] == ["worktree", "prune"]:
+            return ""
+        return real(args)
+
+    result = worktree_reclaim.reclaim_worktree(
+        worktree, git_runner=stubborn, preserve_root=tmp_path / "evidence"
+    )
+
+    assert result.status == worktree_reclaim.RECLAIM_FAILED
+    assert result.ok is False
+    assert "worktree-registry-entry-remains" in (result.detail or "")
+    # fail closed：目錄必須原封不動，不得先刪目錄再回報失敗。
+    assert worktree.is_dir()
+
+
+def test_reclaim_refuses_a_path_that_is_not_a_worktree(tmp_path: Path) -> None:
+    """陳舊／指錯的 job 記錄不得讓回收遞迴刪掉任意目錄。"""
+
+    repo = _init_repo(tmp_path)
+    innocent = tmp_path / "not-a-worktree"
+    innocent.mkdir()
+    (innocent / "precious.json").write_text("{}", encoding="utf-8")
+
+    result = worktree_reclaim.reclaim_worktree(innocent, git_runner=_runner_for(repo))
+
+    assert result.status == worktree_reclaim.RECLAIM_FAILED
+    assert result.detail == "worktree-path-not-a-worktree"
+    assert (innocent / "precious.json").is_file()
+
+
+def test_reclaim_refuses_a_main_checkout(tmp_path: Path) -> None:
+    """job.worktree 實測會等於 run 的 `workspace_root`（主 checkout，`.git` 為
+    目錄）——回收絕不能把整個 repo 刪掉。"""
+
+    repo = _init_repo(tmp_path)
+    other = _init_repo(tmp_path / "elsewhere")
+
+    result = worktree_reclaim.reclaim_worktree(other, git_runner=_runner_for(repo))
+
+    assert result.status == worktree_reclaim.RECLAIM_FAILED
+    assert result.detail == "worktree-path-not-a-worktree"
+    assert (other / "README.md").is_file()
+
+
+def test_reclaim_fails_closed_when_registry_is_unreadable(tmp_path: Path) -> None:
+    def broken(_args: list[str]) -> str:
+        raise RuntimeError("fatal: not a git repository")
+
+    result = worktree_reclaim.reclaim_worktree(tmp_path / "pool" / "x", git_runner=broken)
+    assert result.status == worktree_reclaim.RECLAIM_FAILED
+    assert "worktree-registry-unreadable" in (result.detail or "")
+
+
+def test_resolve_git_runner_falls_back_to_production_default(tmp_path: Path) -> None:
+    """#478 驗收條款第一條：未注入 runner 時退回 production-safe 預設實作。"""
+
+    from paulsha_cortex.coordinator import dispatcher
+
+    assert worktree_reclaim.resolve_git_runner(None) is dispatcher._default_git_runner
+
+
+# --------------------------------------------------------------------------
+# recover-pre-candidate（slice lane，manager.apply_slice_action）
+# --------------------------------------------------------------------------
+
+
+def _seed_recoverable_slice(
+    registry: JobRegistry, *, slice_id: str, branch: str, worktree: Path
+) -> None:
+    builder_job = registry.create_job(
+        task=slice_id, persona="builder", branch=branch, pane="", worktree=str(worktree)
+    )
+    registry.update_headless_result(builder_job["job_id"], status="failed", exit_code=1)
+    registry.create_slice(
+        slice_id=slice_id,
+        spec_path=f"specs/{slice_id}.md",
+        spec_hash="spec-sha",
+        plan_path=f"plans/{slice_id}.md",
+        plan_hash="plan-sha",
+        target_branch="main",
+        builder_job_id=builder_job["job_id"],
+        reviewer_job_id=None,
+        candidate=None,
+    )
+    registry.update_slice(slice_id, state="needs_human", gate_state="needs_human")
+
+
+def test_recover_pre_candidate_clears_registry_and_allows_redispatch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """生產現場重現：dispatcher._git_runner is None 時仍必須清掉 registry。
+
+    舊碼 `runner = git_runner or getattr(dispatcher, "_git_runner", None)` 在
+    runner 為 None 時整段跳過 git 清理，只 rmtree 目錄——registry 留著，下一輪
+    `git worktree add` 立刻以 `cannot force update the branch ...` 失敗。
+    """
+
+    repo = _init_repo(tmp_path)
+    pool = tmp_path / "repo-worktrees"
+    worktree = pool / "feature-slice-e"
+    _git(repo, "worktree", "add", "-q", str(worktree), "-b", "feature/slice-e")
+    monkeypatch.setenv("PSC_REPO_ROOT", str(repo))
+    monkeypatch.setenv("PSC_WORKTREE_ROOT", str(pool))
+
+    registry = JobRegistry(state_path=tmp_path / "jobs.json")
+    _seed_recoverable_slice(
+        registry, slice_id="slice-e", branch="feature/slice-e", worktree=worktree
+    )
+    dispatcher = Dispatcher(
+        registry, pane_sender=MagicMock(), worktree_creator=MagicMock()
+    )
+    assert getattr(dispatcher, "_git_runner", "missing") is None
+
+    result = manager.apply_slice_action(
+        dispatcher=dispatcher,
+        slice_id="slice-e",
+        action="recover-pre-candidate",
+        actor="test-operator",
+        specs_dir=str(tmp_path / "specs"),
+        handoff_dir=str(tmp_path / "handoff"),
+    )
+
+    assert result["result"] == "ok"
+    assert result["worktree_reclaim"]["status"] == "reclaimed"
+    assert not worktree.exists()
+    assert str(worktree) not in _registered_worktrees(repo)
+    assert registry.get_slice("slice-e")["state"] == "pending"
+    # 下一 tick 的實際動作：dispatch 會呼叫 ScriptWorktreeCreator.create()。
+    recreated = ScriptWorktreeCreator(repo=repo, wt_root=pool, base="main").create(
+        "feature/slice-e"
+    )
+    assert Path(recreated) == worktree
+
+
+def test_recover_pre_candidate_self_heals_orphan_registry_entry(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """目錄已被前一次（壞掉的）回收刪掉，registry 殘留——本次必須自癒。"""
+
+    repo = _init_repo(tmp_path)
+    pool = tmp_path / "repo-worktrees"
+    worktree = pool / "feature-slice-f"
+    _git(repo, "worktree", "add", "-q", str(worktree), "-b", "feature/slice-f")
+    subprocess.run(["rm", "-rf", str(worktree)], check=True)
+    monkeypatch.setenv("PSC_REPO_ROOT", str(repo))
+    monkeypatch.setenv("PSC_WORKTREE_ROOT", str(pool))
+
+    registry = JobRegistry(state_path=tmp_path / "jobs.json")
+    _seed_recoverable_slice(
+        registry, slice_id="slice-f", branch="feature/slice-f", worktree=worktree
+    )
+    dispatcher = Dispatcher(
+        registry, pane_sender=MagicMock(), worktree_creator=MagicMock()
+    )
+
+    result = manager.apply_slice_action(
+        dispatcher=dispatcher,
+        slice_id="slice-f",
+        action="recover-pre-candidate",
+        actor="test-operator",
+        specs_dir=str(tmp_path / "specs"),
+        handoff_dir=str(tmp_path / "handoff"),
+    )
+
+    assert result["result"] == "ok"
+    assert str(worktree) not in _registered_worktrees(repo)
+    ScriptWorktreeCreator(repo=repo, wt_root=pool, base="main").create("feature/slice-f")
+
+
+def test_recover_pre_candidate_fails_closed_when_reclaim_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """回收失敗時 recovery 必須 raise，不得回報 pending/ok。"""
+
+    repo = _init_repo(tmp_path)
+    pool = tmp_path / "repo-worktrees"
+    worktree = pool / "feature-slice-g"
+    _git(repo, "worktree", "add", "-q", str(worktree), "-b", "feature/slice-g")
+    monkeypatch.setenv("PSC_REPO_ROOT", str(repo))
+    monkeypatch.setenv("PSC_WORKTREE_ROOT", str(pool))
+
+    registry = JobRegistry(state_path=tmp_path / "jobs.json")
+    _seed_recoverable_slice(
+        registry, slice_id="slice-g", branch="feature/slice-g", worktree=worktree
+    )
+    dispatcher = Dispatcher(
+        registry, pane_sender=MagicMock(), worktree_creator=MagicMock()
+    )
+    real = _runner_for(repo)
+
+    def stubborn(args: list[str]) -> str:
+        if args[:2] in (["worktree", "remove"], ["worktree", "prune"]):
+            raise RuntimeError("fatal: refusing to remove")
+        return real(args)
+
+    with pytest.raises(RuntimeError, match="worktree reclaim failed"):
+        manager.apply_slice_action(
+            dispatcher=dispatcher,
+            slice_id="slice-g",
+            action="recover-pre-candidate",
+            actor="test-operator",
+            specs_dir=str(tmp_path / "specs"),
+            handoff_dir=str(tmp_path / "handoff"),
+            git_runner=stubborn,
+        )
+
+    # slice 必須停在原狀態（不是假的 pending），operator 才知道要介入。
+    assert registry.get_slice("slice-g")["state"] == "needs_human"
+    assert str(worktree) in _registered_worktrees(repo)
+
+
+# --------------------------------------------------------------------------
+# supersede（abandon）路徑共用同一回收函式
+# --------------------------------------------------------------------------
+
+
+def test_abandon_reclaims_build_worktree_of_the_superseded_run(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#527 root cause 之一：supersede 不回收 build worktree。"""
+
+    repo = _init_repo(tmp_path)
+    pool = tmp_path / "repo-worktrees"
+    mine = pool / "feature-mine"
+    other = pool / "feature-other"
+    _git(repo, "worktree", "add", "-q", str(mine), "-b", "feature/mine")
+    _git(repo, "worktree", "add", "-q", str(other), "-b", "feature/other")
+    monkeypatch.setenv("PSC_REPO_ROOT", str(repo))
+
+    run = SimpleNamespace(run_id="workflow-" + "a" * 20)
+    workflow_registry = SimpleNamespace(
+        list_jobs=lambda: [
+            {"workflow_run_id": run.run_id, "worktree": str(mine)},
+            {"workflow_run_id": "workflow-" + "b" * 20, "worktree": str(other)},
+            {"workflow_run_id": run.run_id, "worktree": None},
+        ]
+    )
+
+    work_actions._reclaim_abandoned_build_worktrees(
+        run, workflow_registry, state_path=tmp_path / "jobs.json"
+    )
+
+    registered = _registered_worktrees(repo)
+    assert str(mine) not in registered
+    assert not mine.exists()
+    # 別的 run 的 worktree 一律不碰。
+    assert str(other) in registered
+    assert other.is_dir()
+
+
+def test_abandon_worktree_reclaim_never_raises(tmp_path: Path) -> None:
+    """回收是 abandon 的附帶效果，失敗只落 diagnostics、不得讓 abandon 反悔。"""
+
+    def explode() -> list[dict[str, object]]:
+        raise RuntimeError("registry unavailable")
+
+    work_actions._reclaim_abandoned_build_worktrees(
+        SimpleNamespace(run_id="workflow-" + "c" * 20),
+        SimpleNamespace(list_jobs=explode),
+        state_path=tmp_path / "jobs.json",
+    )


### PR DESCRIPTION
前代殘留回收族：`#478`（build worktree registry 殘留）與 `#535`（planning evidence 佔住
content-addressed 命名空間）一次修。兩者同屬 v4 重構計畫 R0 桶 B「前代殘留阻斷下一世代」模式。

## 根因

### `#478` recover-pre-candidate 只刪目錄未清 git worktree registry

回收 build worktree 在庫內有**兩份各自手寫**的片段，各帶不同缺陷：

- `coordinator/manager.py::apply_slice_action` 的 `recover-pre-candidate` 分支
  `runner = git_runner or getattr(dispatcher, "_git_runner", None)`，而生產 dispatcher 的
  `_git_runner` **合法為 `None`**（它自己在 `dispatch()` 時才 fallback 到預設實作），於是
  `if runner is not None` 整段 git 清理被跳過，只剩 `shutil.rmtree`。即使 runner 存在，呼叫
  也多塞一個前導 `git`——該 seam 只吃 git **子命令參數**，實際跑成
  `git -C <repo> git worktree remove ...`。
- `coordinator/work_actions.py::_recover_pre_candidate_action` 用裸
  `subprocess.run(["git", "worktree", ...])`（無 `-C <repo>`，實際跑在 manager 進程的 cwd 上）
  加 `check=False`，失敗整段吞掉。

兩者又都只在「目錄還在」時才嘗試清理，因此**「目錄已消失、registry 殘留」的既存壞狀態
永遠自癒不了**：`git worktree list --porcelain` 留著
`prunable gitdir file points to non-existent location`，下一輪
`git worktree add` 以 `cannot force update the branch ... used by worktree at ...` 失敗，
slice 被打回 `needs_human`（issue 記錄連續四次生產重現）。同族根因是 `abandon`（supersede）
完全不回收 build worktree（`#527` 根因之一）。

### `#535` abandon 後 planning evidence 佔住 content-addressed 命名空間

brainstorm evidence 檔名原本只由 `(scope, question_pack_id)` 決定
（`coordinator/planning.py`）。前一世代 abandon 後檔案仍在，下一世代重跑 brainstorm 的
scope 與 question pack 都相同 → 落點完全相同；模型輸出語意相同但 byte 不同 → 不符
`publish()` 的冪等豁免（`before == content`）→ no-clobber fail-closed
`ValueError: planning artifact no-clobber conflict`，新世代必然死在 define。

## 修法

### `#478`：新增 `coordinator/worktree_reclaim.py`，兩條路徑共用

- **原子性**：「目錄不存在」與「registry 無該筆記錄」兩個後置條件都重新驗證過才回報成功；
  任一條無法證實（含 registry 清單本身讀不到）一律回 `failed`，呼叫端 fail closed 不再回
  `pending/ok`。
- **自癒**：registry 探測**先於**目錄探測，不以目錄存在與否作為要不要清 registry 的條件；
  `git worktree remove --force` 失敗再以 `git worktree prune` 兜底，之後重新對帳。
- **runner 契約**：未注入時退回 production-safe 預設（`dispatcher._default_git_runner`），
  且不再多塞前導 `git`。
- **不銷毀證據**：目錄帶未提交／未追蹤內容時，先複製到
  `<state 檔目錄>/evidence/worktree-reclaim/<slug>-<ts>-<uuid>/` 再刪；封存失敗即 `failed`，
  一個位元組都不刪（對應 issue 回報的未追蹤 `.project-policy.yml` 被靜默刪除）。
- **安全閘**：registry 沒這筆、目錄也沒有 linked-worktree 標記（`.git` 為**檔案**）時一律
  拒絕回收。開發中實測 `job.worktree` 會等於 run 的 `workspace_root`（主 checkout，`.git`
  是**目錄**），無條件 `rmtree` 的爆炸半徑不可接受。
- **supersede 走同一函式**：`_abandon_action` 的兩條出口（首次與重入）在
  `_gc_abandoned_planning_artifacts` 同一掛載點呼叫 `_reclaim_abandoned_build_worktrees`，
  範圍以 job 的 `workflow_run_id` 精準框定（與 `engineering_outcome.emit_outcome` 同一條
  歸屬判準，不用 work_id 前綴猜）。紀律同 planning GC：best-effort，失敗只落 diagnostics，
  不得讓已成立的 abandon 反悔。

### `#535`：命名空間帶 run identity（issue 建議 (b) 案）

檔名改為 `brainstorm-<run_id>-<hash>.json`，`run_id` 同時進 hash 輸入（手改檔名偽造不出
同一份 content address）；`run_id` 缺席或格式不安全時退回舊命名，既有殘留檔仍可讀。

**取捨說明（為何不採 (a) 案「abandon 時把前代 evidence 移到 run-scoped archive」）**：
evidence 不可銷毀（審計不可變原則）意味著也不該被**搬動**——前代 run 的 `gate_refs`／
`evidence_refs` 逐字記著**絕對路徑**，搬檔會讓那些稽核指標整批懸空，等於用「稽核紀錄
失聯」換「命名空間騰出」。(b) 案則前代 evidence 原位不動、原路徑仍可稽核，新世代自然
不撞，且不必在 abandon 這條終態路徑新增「搬移檔案」這種不可逆副作用（abandon 已經是
best-effort GC 密集的路徑，再加一個可能半途失敗的搬移只會擴大失敗模式）。代價是同一
work item 的 evidence 目錄會隨世代累積檔案——這正是稽核所要的，且既有的
`cortex work gc` 與 evidence 保留策略不受影響。

**世代內的衝突偵測不放寬**：同一個 run 兩次輸出內容不同，仍舊 `brainstorm-evidence-conflict`
fail closed。

另補 issue 建議 3：no-clobber 衝突訊息附
`existing owner=<run_id|legacy-unscoped> mtime=<ISO> publishing run=<run_id>`，operator
不必再自己挖 mtime 對時間軸判斷殘留檔屬於哪個世代。

## 測試證據

新增 `tests/test_worktree_registry_reclaim_478.py`（14 項），用**真實** temporary git repo ＋
真實 linked worktree：

- registry 後置條件（`git worktree list --porcelain` 無該筆）＋ **同一 feature branch 立刻
  可重掛**；並實跑 `ScriptWorktreeCreator.create()`——那正是下一 tick dispatch 的實際動作。
- 「目錄已消失、registry 殘留」自癒。
- `git worktree remove` 失敗時 fail closed：slice 停在 `needs_human`、目錄原封不動、
  `apply_slice_action` raise。
- 生產現場重現：`dispatcher._git_runner is None` 時仍必須清掉 registry。
- dirty 內容（未追蹤 `.project-policy.yml` ＋ 已修改的 tracked 檔）先封存再刪。
- 安全閘：拒絕回收非 worktree 目錄與主 checkout。
- supersede 路徑只回收該 run 名下的 worktree，別的 run 不碰；回收失敗不得讓 abandon raise。

`tests/test_pre_candidate_recovery.py` 的既有 fixture 一併從普通暫存目錄升級為真實 linked
worktree 並斷言 registry——issue 明確指出正是那個 fixture 讓缺陷四次在生產重現而測試全綠。

新增 `tests/test_planning_evidence_generation_scope_535.py`（5 項）：跨世代不衝突且前代
evidence bytes 原封不動、世代內仍 fail closed、以「不帶 run identity」版本重現根因、
衝突訊息帶歸屬。

```
$ python3 -m pytest -q
2615 passed, 49 subtests passed in 43.54s
```

Refs #478 #535

- [x] `changelog.d/worktree-registry-reclaim.md` fragment 已新增且已 commit
- [x] `CHANGELOG.md [Unreleased]` 有對應 entry
- [x] 全套 `python3 -m pytest -q` 通過（2615 passed）
- [x] 只引用不關閉 issue（兩張票另有後續項目），已上 `policy-exempt:issue-link`
