### PR TITLE
fix(planning-transaction): 發佈與 run 狀態更新收進同一事務邊界

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,30 @@
 ## [Unreleased]
 
 ### Fixed
+- **Issue #536（後半）：planning artifacts 發佈與 run 狀態更新不是同一事務，中間態對
+  所有恢復迴圈永久隱形**——define 的 brainstorm 有兩次分離的 durable 寫入：先發佈
+  spec/design/plan 到 operator worktree，再把 run 推進到 `plan` 並寫入 gate_refs／
+  planning_authority。兩者之間崩潰就留下「artifacts 已落地、run 狀態停在原地」的中間
+  態。journal（`planning-transactions/<run_id>.json`）本來就記了 before/after hash，缺
+  的是**誰去看它**：`reconcile()` 只能由持有該 run 的呼叫端逐 run 觸發，run 一旦離開
+  `ongoing`（superseded／done）就再也沒有任何迴圈會碰它——實測 coordinator root 上就
+  躺著兩份孤兒 journal，其中一份正是 #536 現場的 `workflow-7a430d31eff66ef13630`（run
+  已 abandon 成 superseded，兩份 spec/design 殘留檔永久留在 operator worktree，成為
+  下一世代 define 撞 #416／#535 authority fail-closed 的地雷）。修法：新增
+  `prepare_commit()` 把事務邊界寫成 durable 事實（journal schema v3 的 `phase`，
+  `prepared` 之後不得再發佈）；新增 `reconcile_planning_transactions()`——掃整個 journal
+  目錄、與 run 狀態無關的**唯一**恢復路徑，由 tick 驅動，判準只有一條「registry 的 run
+  row 上有沒有這次的 brainstorm gate ref」：有則前滾（逐位元組驗證後退役 journal）、
+  沒有則回退（選回退的理由是沒有 gate ref 就代表這批產出從未被綁進任何 run，前滾在語意
+  上不成立；現場殘留的 `expected_gate_ref` 更是 `null`，根本沒有可前滾的目標）。既有
+  v2 journal 相容，因此實際部署的殘留與未來崩潰走同一條路自癒。護欄：未滿 5 分鐘的
+  journal 視為可能仍在飛而不碰；已被 git 追蹤的殘留檔跳過刪除並回報 `adopted`（#507
+  教訓）；找不到 run row 時 fail closed 只回報不刪檔；sweep 整批失效比照 #246 降級不
+  癱瘓 tick。收斂結果全部落結構化 log 並進 tick summary，drift 且 run 仍 ongoing 時補
+  `needs_human` facet。不動 #538 已修的 resume 迴圈 phase filter。詳見
+  `changelog.d/publish-state-transaction.md`。新增
+  `tests/test_planning_publication_transaction_536.py`（14 個回歸測試）。
+
 - **Issue #540：tdd-red terminal 採信三段連鎖——builder 的正確 RED commit 無法被採信**
   ——run `workflow-084f75e2178cf7547476` 的 builder 交付了合格 RED commit，terminal
   採信卻連撞三個獨立缺陷。**(1) gate 宣告缺漏事前無診斷**：manager env 漏

--- a/changelog.d/publish-state-transaction.md
+++ b/changelog.d/publish-state-transaction.md
@@ -1,0 +1,49 @@
+# publish-state-transaction
+
+- **`#536`（後半）：planning artifacts 發佈與 run 狀態更新收進同一個 crash-safe 事務，
+  並補上唯一的恢復路徑**——define 的 brainstorm 有兩次分離的 durable 寫入：先把
+  spec/design/plan 發佈到 operator worktree（`_publish_planning_artifacts` →
+  `_PlanningPublicationTransaction`），再把 run 推進到 `plan` 並寫入 gate_refs／
+  planning_authority（`registry._manager_update_workflow_run`）。兩者之間崩潰就留下
+  「artifacts 已落地、run 狀態停在原地」的中間態，正是 #536 現場。
+
+  journal（`<coordinator_root>/planning-transactions/<run_id>.json`）本來就記了每個
+  mutation 的 before/after hash，缺的是**誰去看它**：`reconcile()` 只能由持有該 run
+  的呼叫端逐 run 觸發（define 起始、`resume_workflow_run`），run 一旦離開 `ongoing`
+  （superseded／done）就再也沒有任何迴圈會碰它。實測 coordinator root 上躺著兩份這種
+  孤兒 journal，其中一份正是 #536 現場的 `workflow-7a430d31eff66ef13630`——run 已被
+  abandon 成 `superseded`，兩份 `before_exists=false` 的 spec/design 殘留檔就此永久
+  留在 operator worktree，成為下一世代 define 撞 #416／#535 authority fail-closed 的
+  地雷。另一份 `workflow-29a1247ddaf88d11eda8` 同型（8/11 起）。
+
+  修法三項：
+  1. **`prepare_commit()` 把事務邊界寫成 durable 事實**——journal schema 升到 v3 並新增
+     `phase`（`publishing` → `prepared`）。`prepared` 表示檔案側已全部落地且 fsync，
+     下一步就是本事務唯一的 commit point（registry 的原子寫入）；封住之後再呼叫
+     `publish()` 一律 fail-closed。`phase` 只供診斷，**不參與** commit 判準。
+  2. **`reconcile_planning_transactions()`：掃整個 journal 目錄的唯一恢復路徑**——與
+     run 狀態無關，ongoing／superseded／done 一視同仁，因此既有殘留與未來崩潰走同一條
+     程式路徑自癒。判準只有一條：**registry 的 run row 上有沒有這次的 brainstorm
+     gate ref**。有 → 前滾（逐位元組驗證每個已提交產物後退役 journal）；沒有 → 回退。
+     選回退而非前滾的理由：沒有那個 gate ref 就代表這批產出從未被綁進任何 run（無
+     authority、無 source revision、steps 沒有 outputs），前滾在語意上不成立；而
+     現場殘留的 `expected_gate_ref` 是 `null`（崩在 evidence 落地之前），根本沒有可以
+     前滾的目標。回退全程受既有 CAS 護欄把關（`before_exists` ＋ `after_hash` 必須
+     完全吻合），撞到 operator drift 一律拒絕並改為呈現。
+  3. **收斂結果不得靜默**——每份 journal 的處理結果（`rolled-back`／`committed`／
+     `adopted`／`drift`／`unknown-run`／`in-flight`）都落結構化 log 並進 tick summary；
+     無法自動收斂（drift）且 run 仍 `ongoing` 時補 `needs_human` facet，讓
+     `cortex status` 的 attention 清單有話說。
+
+  安全護欄：(a) journal 寫下未滿 5 分鐘者視為「可能還在飛」，本輪不碰——發佈側最後
+  一次 fsync 到 registry 提交正常是次秒級，這個餘裕純粹是為了絕不誤傷 daemon 之外
+  的前景發佈；(b) 殘留檔若已被 operator 納入 git 追蹤，就不再是「未提交的發佈殘留」，
+  跳過刪除並回報 `adopted`（比照 `work_actions._gc_one_abandoned_planning_artifact`
+  的既有紀律，#507 的教訓）；(c) 找不到對應 run row 時 fail closed——無法驗證 journal
+  自報的 workspace root 就不刪檔，只留 log 與回報；(d) sweep 整批失效比照 #246 的 tick
+  isolation 降級，不得癱瘓本輪 tick。
+
+  恢復路徑相容 v2 journal（升級前的格式，實際部署上就有殘留），自癒不要求 operator
+  先手動搬遷。不動 #538 已修的 resume 迴圈 phase filter；phase 心跳仍屬 R0.5 D5。
+  新增 `tests/test_planning_publication_transaction_536.py`（14 個回歸測試，含「發佈後、
+  狀態更新前行程當場死亡」的端到端邊界測試與既有 v2 殘留自癒測試）。

--- a/paulsha_cortex/coordinator/manager.py
+++ b/paulsha_cortex/coordinator/manager.py
@@ -5550,6 +5550,17 @@ class PlanningPublicationDrift(RuntimeError):
     """A durable planning intent cannot be safely committed or rolled back."""
 
 
+# #536：journal 的 schema 版本。v3 新增 `phase` 欄位（見
+# `_PlanningPublicationTransaction.prepare_commit`），把「發佈 artifacts」與
+# 「registry 提交 run 狀態」之間那條事務邊界寫成 durable 事實，恢復路徑才能
+# 分辨「崩在發佈中途」與「崩在提交邊界」。v2 是升級前既有 journal 的格式，
+# 恢復路徑必須繼續接受它——實際部署上就有 v2 的殘留（#536 現場的
+# `workflow-7a430d31eff66ef13630`），自癒不能要求 operator 先手動搬遷。
+_PLANNING_TRANSACTION_SCHEMA_VERSION = 3
+_PLANNING_TRANSACTION_SCHEMA_VERSIONS = (2, _PLANNING_TRANSACTION_SCHEMA_VERSION)
+_PLANNING_TRANSACTION_PHASES = ("publishing", "prepared")
+
+
 class _PlanningPublicationTransaction:
     """Recoverable filesystem side of the brainstorm -> registry commit.
 
@@ -5569,6 +5580,12 @@ class _PlanningPublicationTransaction:
         self.run_id = run_id
         self.operations: list[dict[str, object]] = []
         self.expected_gate_ref: dict[str, str] | None = None
+        # #536：`publishing` = 檔案側還在發佈中，registry 提交尚未被嘗試；
+        # `prepared` = 檔案側已全部落地且已 fsync，下一步就是唯一的 commit
+        # point（registry 的 durable run row）。兩者都不改變 commit 判準
+        # （判準永遠是 registry row 上有沒有這次的 brainstorm gate ref），
+        # 只讓恢復路徑能誠實描述殘留是哪一種。
+        self.phase = "publishing"
         self.journal_root = journal_root.resolve() if journal_root is not None else None
         self.journal_path = (
             self.journal_root / "planning-transactions" / f"{run_id}.json"
@@ -5578,13 +5595,28 @@ class _PlanningPublicationTransaction:
 
     def _payload(self) -> dict[str, object]:
         return {
-            "schema_version": 2,
+            "schema_version": _PLANNING_TRANSACTION_SCHEMA_VERSION,
             "kind": "planning-publication-intent",
             "run_id": self.run_id,
             "root": str(self.root),
+            "phase": self.phase,
             "operations": self.operations,
             "expected_gate_ref": self.expected_gate_ref,
         }
+
+    def prepare_commit(self) -> None:
+        """封住檔案側、宣告下一步是 registry 這個唯一的 commit point。
+
+        呼叫端必須在「所有 artifacts／evidence 都已發佈完成」與「registry
+        提交 run 狀態」之間呼叫一次；之後不得再 `publish()`。這一筆
+        durable 記錄本身不是 commit——commit 由 registry 的原子寫入決定——
+        它只是把事務邊界寫進 journal，讓崩潰後的恢復路徑（見
+        `reconcile_planning_transactions`）能區分兩種殘留並如實回報。
+        """
+
+        if self.phase != "prepared":
+            self.phase = "prepared"
+            self._persist()
 
     def _persist(self) -> None:
         if self.journal_path is None:
@@ -5651,6 +5683,11 @@ class _PlanningPublicationTransaction:
         mode: int = 0o644,
         kind: str = "artifact",
     ) -> None:
+        if self.phase != "publishing":
+            # #536：事務邊界一旦封住（prepare_commit），檔案側就不得再變動——
+            # 否則 journal 記載的「已全部落地」與磁碟事實脫節，恢復路徑的
+            # 前滾驗證會拿不到一致的 after_hash 集合。
+            raise ValueError("planning publication is already prepared for commit")
         path = Path(os.path.abspath(path))
         boundary = self.root
         try:
@@ -5734,9 +5771,23 @@ class _PlanningPublicationTransaction:
         }
         self.publish(path, content, baseline_hash=None, mode=0o600, kind="evidence")
 
-    def rollback(self) -> None:
+    def rollback(self, *, adopted: Callable[[Path], bool] | None = None) -> tuple[str, ...]:
+        """回退本事務所有已落地的變動；回傳被 ``adopted`` 判定為「已被採納」
+        而**刻意跳過**的路徑。
+
+        ``adopted``（只有崩潰後的 sweep 會傳）用來擋住「這份未提交的發佈殘留
+        後來已被 operator 納入 git 追蹤」的情形——比照
+        `work_actions._gc_one_abandoned_planning_artifact` 的既有紀律：已被
+        git 追蹤的檔案不是未提交殘留，刪掉等同銷毀 operator 的工作（#507 的
+        教訓）。in-process 的回退一律不傳，語意與修法前逐位元組相同。
+        """
+
+        skipped: list[str] = []
         for operation in reversed(self.operations):
             path = Path(str(operation["path"]))
+            if adopted is not None and adopted(path):
+                skipped.append(str(path))
+                continue
             after_hash = str(operation["after_hash"])
             boundary = (
                 self.journal_root
@@ -5785,6 +5836,7 @@ class _PlanningPublicationTransaction:
                     pass
         self.operations.clear()
         self.commit()
+        return tuple(skipped)
 
     def commit(self) -> None:
         if self.journal_path is not None:
@@ -5921,19 +5973,34 @@ class _PlanningPublicationTransaction:
                 raise PlanningPublicationDrift("planning committed evidence binding drift")
 
     @classmethod
-    def reconcile(cls, *, root: Path, journal_root: Path, run) -> None:
+    def reconcile(
+        cls,
+        *,
+        root: Path,
+        journal_root: Path,
+        run,
+        adopted: Callable[[Path], bool] | None = None,
+    ) -> dict[str, object] | None:
+        """把一份 durable 發佈意圖收斂到與 registry 權威狀態一致。
+
+        判準只有一條：**registry 的 run row 上有沒有這次的 brainstorm gate
+        ref**。有 → 前滾（驗證每個已提交產物仍逐位元組吻合，然後退役
+        journal）；沒有 → 回退（把檔案側還原成發佈前的樣子）。沒有 journal
+        時回傳 ``None``；其餘回傳 ``{"outcome", "phase", "skipped"}``。
+        """
+
         path = journal_root.resolve() / "planning-transactions" / f"{run.run_id}.json"
         if path.is_symlink():
             raise PlanningPublicationDrift("planning transaction journal symlink rejected")
         if not path.is_file():
-            return
+            return None
         try:
             payload = json.loads(path.read_text(encoding="utf-8"))
         except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
             raise PlanningPublicationDrift("planning transaction journal is unreadable") from exc
         if (
             not isinstance(payload, dict)
-            or payload.get("schema_version") != 2
+            or payload.get("schema_version") not in _PLANNING_TRANSACTION_SCHEMA_VERSIONS
             or payload.get("kind") != "planning-publication-intent"
             or payload.get("run_id") != run.run_id
             or payload.get("root") != str(root.resolve())
@@ -5942,7 +6009,19 @@ class _PlanningPublicationTransaction:
             and not isinstance(payload.get("expected_gate_ref"), dict)
         ):
             raise PlanningPublicationDrift("planning transaction journal is invalid")
+        # #536：v2 沒有 phase 欄位，一律視為 `publishing`（升級前的 journal
+        # 從未宣告過事務邊界）；v3 必須帶合法 phase。phase 純粹是診斷用的
+        # durable 事實，**不參與** commit 判準——判準永遠是 registry row。
+        if payload["schema_version"] == 2:
+            if "phase" in payload:
+                raise PlanningPublicationDrift("planning transaction journal is invalid")
+            phase = "publishing"
+        else:
+            phase = payload.get("phase")
+            if phase not in _PLANNING_TRANSACTION_PHASES:
+                raise PlanningPublicationDrift("planning transaction phase is invalid")
         transaction = cls(root=root, run_id=run.run_id, journal_root=journal_root)
+        transaction.phase = phase
         expected_gate_ref = payload["expected_gate_ref"]
         expected: GateEvidenceRef | None = None
         if expected_gate_ref is not None:
@@ -5972,11 +6051,171 @@ class _PlanningPublicationTransaction:
             for operation in transaction.operations:
                 transaction._validate_committed_operation(operation)
             transaction.commit()
-        else:
-            try:
-                transaction.rollback()
-            except RuntimeError as exc:
-                raise PlanningPublicationDrift("planning uncommitted rollback drift") from exc
+            return {"outcome": "committed", "phase": phase, "skipped": ()}
+        try:
+            skipped = transaction.rollback(adopted=adopted)
+        except RuntimeError as exc:
+            raise PlanningPublicationDrift("planning uncommitted rollback drift") from exc
+        return {
+            "outcome": "adopted" if skipped else "rolled-back",
+            "phase": phase,
+            "skipped": skipped,
+        }
+
+
+# #536：崩潰殘留的 journal 要多久之後才被視為「不可能還在飛」。發佈側最後
+# 一次 fsync 到 registry 提交之間正常是次秒級（`prepare_commit` 之後只剩
+# `_validated_brainstorm_planning_authority` 與一次原子寫入），這裡留 5 分鐘
+# 的極寬裕餘裕，純粹是為了讓 sweep 絕不可能誤傷一個仍在進行中的發佈——
+# 即使它是由 daemon 之外的行程（operator 的前景 `cortex work start`）發起。
+_PLANNING_TRANSACTION_GRACE_SECONDS = 300.0
+
+
+def _planning_artifact_adopted_by_git(path: Path, *, workspace_root: Path) -> bool:
+    """殘留檔是否已被 operator 納入 git 追蹤（＝不再是「未提交的發佈殘留」）。
+
+    與 `work_actions._gc_one_abandoned_planning_artifact` 同一條判準與同一個
+    理由：git 已追蹤代表 operator 已經採納這份產出，刪掉就是銷毀他人工作
+    （#507）。無法判定時（workspace 不是 git repo、git 不可用）回傳 False，
+    讓回退照常進行——回退本身還有逐位元組的 CAS 護欄（`before_exists=False`
+    ＋ `after_hash` 必須完全吻合），不依賴這層。
+    """
+
+    try:
+        relative = path.resolve().relative_to(workspace_root.resolve())
+    except (ValueError, OSError):
+        return False
+    try:
+        tracked = subprocess.run(
+            [
+                "git", "-C", str(workspace_root), "ls-files", "--error-unmatch",
+                "--", str(relative),
+            ],
+            shell=False,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+    return tracked.returncode == 0
+
+
+def reconcile_planning_transactions(
+    *,
+    registry,
+    coordinator_root: str | Path,
+    now: float | None = None,
+    grace_seconds: float = _PLANNING_TRANSACTION_GRACE_SECONDS,
+) -> list[dict[str, object]]:
+    """#536：把 planning-transactions journal 目錄整個掃過，逐份收斂。
+
+    根因：「發佈 planning artifacts」與「更新 run 狀態」是兩次分離的 durable
+    寫入，中間崩潰會留下「artifacts 已落地、run 狀態停在原地」的中間態。
+    journal 早就記了 before/after hash，但 `reconcile()` **只能由持有該 run
+    的呼叫端逐 run 觸發**（define 起始、`resume_workflow_run`）——一旦那個
+    run 離開 `ongoing`（superseded／done），或 run 從沒被任何迴圈再訪，
+    journal 與它描述的殘留檔就永遠沒有人看，正是 #536 說的「對所有恢復迴圈
+    隱形」。實測 coordinator root 上就躺著兩份這種孤兒 journal（其中一份正是
+    #536 現場的 `workflow-7a430d31eff66ef13630`，run 已 superseded）。
+
+    這個 sweep 是**唯一**的恢復路徑：不管 run 是 ongoing、superseded 還是
+    done，只要 journal 還在就把它收斂掉，因此既有殘留與未來崩潰走同一條
+    程式路徑自癒。每一份 journal 的結果都會回報並落 log，不得靜默。
+    """
+
+    journal_root = Path(coordinator_root).resolve()
+    directory = journal_root / "planning-transactions"
+    if directory.is_symlink() or not directory.is_dir():
+        return []
+    runs = {run.run_id: run for run in registry.list_workflow_runs()}
+    moment = time.time() if now is None else now
+    report: list[dict[str, object]] = []
+    for path in sorted(directory.glob("*.json")):
+        run_id = path.name[: -len(".json")]
+        record: dict[str, object] = {"run_id": run_id}
+        if path.is_symlink() or not path.is_file():
+            record.update(outcome="invalid", detail="journal is not a regular file")
+            logger.error(
+                "planning-transaction-invalid run_id=%s detail=%s", run_id, record["detail"]
+            )
+            report.append(record)
+            continue
+        try:
+            age = moment - path.stat().st_mtime
+        except OSError as exc:
+            record.update(outcome="invalid", detail=f"{type(exc).__name__}: {str(exc)[:120]}")
+            logger.error(
+                "planning-transaction-invalid run_id=%s detail=%s", run_id, record["detail"]
+            )
+            report.append(record)
+            continue
+        if age < grace_seconds:
+            # 仍可能在飛：不碰，下一輪再看。
+            record.update(outcome="in-flight", age_seconds=round(age, 3))
+            report.append(record)
+            continue
+        run = runs.get(run_id)
+        if run is None:
+            # fail-closed：沒有 run row 就無法驗證 journal 宣稱的 workspace
+            # root，不能拿 journal 自報的路徑去刪檔。留檔＋落 log，讓它可見。
+            record.update(outcome="unknown-run", detail="no workflow run owns this journal")
+            logger.error(
+                "planning-transaction-orphan run_id=%s detail=%s", run_id, record["detail"]
+            )
+            report.append(record)
+            continue
+        workspace_root = Path(run.workspace_root)
+        try:
+            outcome = _PlanningPublicationTransaction.reconcile(
+                root=workspace_root,
+                journal_root=journal_root,
+                run=run,
+                adopted=lambda target: _planning_artifact_adopted_by_git(
+                    target, workspace_root=workspace_root
+                ),
+            )
+        except PlanningPublicationDrift as exc:
+            record.update(outcome="drift", detail=str(exc)[:200], status=run.status)
+            logger.error(
+                "planning-transaction-drift run_id=%s status=%s detail=%s",
+                run_id,
+                run.status,
+                str(exc)[:200],
+            )
+            if run.status == "ongoing" and "needs_human" not in run.facets:
+                # 無法自動收斂的殘留必須有人接手——補 needs_human facet，
+                # 讓 `cortex status` 的 attention 清單與 next_actions 有話說。
+                try:
+                    registry._manager_update_workflow_run(
+                        run.run_id,
+                        facets=tuple(dict.fromkeys((*run.facets, "needs_human"))),
+                        gate_status="running",
+                    )
+                    record["surfaced"] = True
+                except Exception as surface_exc:  # noqa: BLE001 - 呈現失敗不得吃掉診斷
+                    logger.error(
+                        "planning-transaction-surface-failed run_id=%s error=%s: %s",
+                        run_id,
+                        type(surface_exc).__name__,
+                        str(surface_exc)[:200],
+                    )
+            report.append(record)
+            continue
+        if outcome is None:
+            continue
+        record.update(outcome, status=run.status)
+        record["skipped"] = list(outcome.get("skipped", ()))
+        logger.info(
+            "planning-transaction-reconciled run_id=%s outcome=%s phase=%s status=%s skipped=%d",
+            run_id,
+            record["outcome"],
+            record["phase"],
+            run.status,
+            len(record["skipped"]),
+        )
+        report.append(record)
+    return report
 
 
 # #416：`_publish_planning_artifacts` 對「檔案已存在但無/與目前 authority
@@ -9180,6 +9419,11 @@ def apply_workflow_action(
             result.reason,
         )
         return {"run_id": run.run_id, "current_phase": run.current_phase, "reason": result.reason}
+    # #536：檔案側到此為止全部落地且已 fsync，接下來 registry 的那一次原子
+    # 寫入就是本事務唯一的 commit point。把這條邊界寫成 durable 事實，崩潰
+    # 後的 sweep（`reconcile_planning_transactions`）才能誠實區分「崩在發佈
+    # 中途」與「崩在提交邊界」，而不是只看到一坨無主檔案。
+    publication.prepare_commit()
     try:
         planning_authority, planning_source_revision = _validated_brainstorm_planning_authority(
             run,

--- a/paulsha_cortex/coordinator/manager_daemon.py
+++ b/paulsha_cortex/coordinator/manager_daemon.py
@@ -932,6 +932,8 @@ def build_periodic_tick_runner(
             _log_error(exc, context={"action": "auto-claim-scan"})
             auto_claims = []
             auto_claim_error = safe_exception_summary(exc)
+        planning_transactions: list[dict[str, Any]] = []
+        planning_transaction_error: str | None = None
         if registry is not None and hasattr(registry, "list_workflow_runs"):
             state_path = getattr(registry, "_state_path", None)
             coordinator_root = (
@@ -939,6 +941,22 @@ def build_periodic_tick_runner(
                 if state_path is not None
                 else paths.coordinator_root().resolve()
             )
+            # #536：planning 發佈事務的唯一恢復路徑。「發佈 artifacts」與
+            # 「更新 run 狀態」是兩次分離的 durable 寫入，中間崩潰會留下
+            # 「artifacts 已落地、run 狀態停在原地」的中間態；journal 早有
+            # before/after hash，但過去只能由持有該 run 的呼叫端逐 run
+            # reconcile——run 一旦離開 ongoing（superseded／done）就再也沒人
+            # 看它。這個 sweep 掃整個 journal 目錄，與 run 狀態無關，因此
+            # 既有殘留與未來崩潰走同一條路自癒。比照 #246 的 tick isolation：
+            # 整個子系統失效不得癱瘓本輪 tick，降級後照常跑 resume 迴圈。
+            try:
+                planning_transactions = manager.reconcile_planning_transactions(
+                    registry=registry,
+                    coordinator_root=coordinator_root,
+                )
+            except Exception as exc:  # noqa: BLE001 - tick isolation
+                _log_error(exc, context={"action": "planning-transaction-sweep"})
+                planning_transaction_error = safe_exception_summary(exc)
             for workflow in registry.list_workflow_runs():
                 if (
                     workflow.status != "ongoing"
@@ -1056,6 +1074,17 @@ def build_periodic_tick_runner(
             )
         result = _call_with_supported_kwargs(run_tick_fn, dispatcher, **run_tick_kwargs)
         summary = {**result, "auto_claims": auto_claims}
+        # #536：只在有話可說時才進 summary，避免每輪 tick 都塞一個空清單。
+        # 收斂結果（rolled-back／committed／adopted／drift／unknown-run）必須
+        # 對 operator 可見，不得只活在 log 裡。
+        actionable = [
+            row for row in planning_transactions if row.get("outcome") != "in-flight"
+        ]
+        if actionable:
+            summary["planning_transactions"] = actionable
+        if planning_transaction_error is not None:
+            summary["planning_transaction_failed"] = True
+            summary["planning_transaction_error"] = planning_transaction_error
         if auto_claim_error is not None:
             # 讓 operator 能從 status/summary 看出 auto-claim 這輪降級了，
             # 而不是靜默吞掉——不含絕對路徑／token，只有型別＋訊息摘要。

--- a/tests/test_planning_publication_transaction_536.py
+++ b/tests/test_planning_publication_transaction_536.py
@@ -1,0 +1,629 @@
+"""#536：planning artifacts 發佈與 run 狀態更新的單一事務邊界與恢復迴圈。
+
+現場（run `workflow-7a430d31eff66ef13630`）：define 階段的 run，brainstorm 已把
+spec/design 發佈到 operator worktree，但 run 狀態永不推進——`updated_at` 停在建立
+時刻、`gate_refs=[]`、facets 空、manager log 無錯誤。根因之一是「發佈 artifacts」
+與「更新 run 狀態」是兩次分離的 durable 寫入，中間崩潰就留下「artifacts 已落地、
+run 狀態停在原地」的中間態。
+
+journal（`<coordinator_root>/planning-transactions/<run_id>.json`）本來就記了每個
+mutation 的 before/after hash，但 `reconcile()` **只能由持有該 run 的呼叫端逐 run
+觸發**（define 起始、`resume_workflow_run`）。run 一旦離開 `ongoing`
+（superseded／done），journal 與它描述的殘留檔就再也沒有任何迴圈會看——實測
+coordinator root 上就躺著兩份這種孤兒 journal。
+
+本檔釘住的修法：`reconcile_planning_transactions` 掃整個 journal 目錄、與 run 狀態
+無關，成為唯一的恢復路徑；`prepare_commit()` 把事務邊界寫成 durable 事實。
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import time
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from paulsha_cortex.coordinator import manager, manager_daemon
+from paulsha_cortex.coordinator.model_identities import CapabilityProbe, IdentityRegistry
+from paulsha_cortex.coordinator.registry import JobRegistry
+from paulsha_cortex.deck.compile import compile_combo
+from paulsha_cortex.deck.schema import DEFAULT_CARDS_PATH, DEFAULT_COMBOS_DIR, load_cards, load_combo
+from paulsha_cortex.coordinator.workflow import GateEvidenceRef, WorkflowManifest
+
+
+class _HardCrash(BaseException):
+    """模擬行程被 SIGKILL：沒有任何 except/finally handler 會跑。"""
+
+
+# --- 低階事務／sweep 用的最小樁 -------------------------------------------------
+
+
+class _FakeRegistry:
+    def __init__(self, runs) -> None:
+        self._runs = list(runs)
+        self.updates: list[tuple[str, dict]] = []
+
+    def list_workflow_runs(self):
+        return list(self._runs)
+
+    def _manager_update_workflow_run(self, run_id: str, **kwargs):
+        self.updates.append((run_id, kwargs))
+        return self._runs[0]
+
+
+def _fake_run(
+    *,
+    run_id: str,
+    workspace_root: Path,
+    gate_refs: tuple[GateEvidenceRef, ...] = (),
+    status: str = "ongoing",
+    facets: tuple[str, ...] = (),
+):
+    return SimpleNamespace(
+        run_id=run_id,
+        workspace_root=str(workspace_root),
+        gate_refs=gate_refs,
+        status=status,
+        facets=facets,
+    )
+
+
+def _roots(tmp_path: Path) -> tuple[Path, Path]:
+    workspace = tmp_path / "workspace"
+    coordinator = tmp_path / "coordinator"
+    workspace.mkdir()
+    coordinator.mkdir()
+    return workspace, coordinator
+
+
+def _publish_generation(
+    workspace: Path,
+    coordinator: Path,
+    *,
+    run_id: str = "workflow-1",
+    with_evidence: bool = True,
+    prepared: bool = False,
+):
+    """走真正的發佈路徑產生一份未收斂的 journal（＝崩潰現場）。"""
+
+    transaction = manager._PlanningPublicationTransaction(
+        root=workspace, run_id=run_id, journal_root=coordinator
+    )
+    artifacts = []
+    for name in ("demo-spec.md", "demo-design.md"):
+        target = workspace / "docs/superpowers/specs" / name
+        transaction.publish(
+            target, f"# {name}\n".encode("utf-8"), baseline_hash=None, kind="artifact"
+        )
+        artifacts.append(target)
+    evidence = None
+    if with_evidence:
+        evidence = coordinator / "evidence" / f"brainstorm-{run_id}.json"
+        transaction.write_evidence(evidence, {"schema_version": 1, "kind": "brainstorm-peer"})
+    if prepared:
+        transaction.prepare_commit()
+    return transaction, tuple(artifacts), evidence
+
+
+def _journal(coordinator: Path, run_id: str = "workflow-1") -> Path:
+    return coordinator / "planning-transactions" / f"{run_id}.json"
+
+
+def _sweep(registry, coordinator: Path, **kwargs):
+    kwargs.setdefault("now", time.time() + 10_000)
+    return manager.reconcile_planning_transactions(
+        registry=registry, coordinator_root=coordinator, **kwargs
+    )
+
+
+# --- 事務邊界本身 ---------------------------------------------------------------
+
+
+def test_prepare_commit_seals_the_file_side_of_the_transaction(tmp_path: Path) -> None:
+    """`prepare_commit` 把「檔案側已全部落地、下一步是唯一的 commit point」
+    寫成 durable 事實，且封住之後不得再發佈。"""
+
+    workspace, coordinator = _roots(tmp_path)
+    transaction, _, _ = _publish_generation(workspace, coordinator)
+
+    body = json.loads(_journal(coordinator).read_text(encoding="utf-8"))
+    assert body["schema_version"] == 3
+    assert body["phase"] == "publishing"
+
+    transaction.prepare_commit()
+    sealed = json.loads(_journal(coordinator).read_text(encoding="utf-8"))
+    assert sealed["phase"] == "prepared"
+    assert sealed["operations"] == body["operations"]
+
+    with pytest.raises(ValueError, match="already prepared for commit"):
+        transaction.publish(
+            workspace / "docs/superpowers/specs/late.md",
+            b"# Late\n",
+            baseline_hash=None,
+            kind="artifact",
+        )
+
+
+# --- 恢復迴圈：崩在提交邊界 ------------------------------------------------------
+
+
+@pytest.mark.parametrize("prepared", [False, True])
+def test_sweep_rolls_back_uncommitted_publication_regardless_of_phase(
+    tmp_path: Path, prepared: bool
+) -> None:
+    """發佈完成（甚至已封邊界）但 registry 從未提交 → 回退，並且收斂。
+
+    判準只有一條：run row 上有沒有這次的 brainstorm gate ref。沒有就代表這批
+    產出從未被綁進任何 run（無 authority、無 source revision），前滾在語意上
+    不成立——回退才是唯一定義良好的收斂方向。
+    """
+
+    workspace, coordinator = _roots(tmp_path)
+    _, artifacts, evidence = _publish_generation(workspace, coordinator, prepared=prepared)
+    assert all(path.is_file() for path in artifacts)
+    registry = _FakeRegistry([_fake_run(run_id="workflow-1", workspace_root=workspace)])
+
+    report = _sweep(registry, coordinator)
+
+    assert [row["outcome"] for row in report] == ["rolled-back"]
+    assert report[0]["phase"] == ("prepared" if prepared else "publishing")
+    assert not any(path.exists() for path in artifacts)
+    assert evidence is not None and not evidence.exists()
+    assert not _journal(coordinator).exists()
+    assert registry.updates == []
+
+
+def test_sweep_rolls_forward_when_registry_row_carries_the_gate_ref(tmp_path: Path) -> None:
+    """registry 已提交、只差退役 journal → 前滾（逐位元組驗證後退役）。"""
+
+    workspace, coordinator = _roots(tmp_path)
+    _, artifacts, evidence = _publish_generation(workspace, coordinator, prepared=True)
+    assert evidence is not None
+    committed_ref = GateEvidenceRef(
+        "brainstorm", str(evidence), manager._sha256_path(evidence)
+    )
+    registry = _FakeRegistry(
+        [
+            _fake_run(
+                run_id="workflow-1", workspace_root=workspace, gate_refs=(committed_ref,)
+            )
+        ]
+    )
+
+    report = _sweep(registry, coordinator)
+
+    assert [row["outcome"] for row in report] == ["committed"]
+    assert all(path.is_file() for path in artifacts)
+    assert evidence.is_file()
+    assert not _journal(coordinator).exists()
+
+
+# --- 恢復迴圈：既有殘留自癒 ------------------------------------------------------
+
+
+def test_sweep_heals_legacy_v2_journal_of_a_superseded_run(tmp_path: Path) -> None:
+    """實際部署上的殘留：v2 journal ＋ run 已 superseded。
+
+    這正是 #536 現場留下的形態（`expected_gate_ref: null`、兩筆
+    `before_exists: false` 的 artifact op、run 後來被 abandon 成
+    `superseded`）。resume 迴圈只看 `ongoing`，所以修法前沒有任何路徑會碰它；
+    sweep 與 run 狀態無關，因此同一條恢復路徑就把它收斂掉。
+    """
+
+    workspace, coordinator = _roots(tmp_path)
+    _, artifacts, _ = _publish_generation(workspace, coordinator, with_evidence=False)
+    journal = _journal(coordinator)
+    legacy = json.loads(journal.read_text(encoding="utf-8"))
+    legacy.pop("phase")
+    legacy["schema_version"] = 2
+    journal.write_text(json.dumps(legacy, ensure_ascii=False, sort_keys=True) + "\n", encoding="utf-8")
+
+    registry = _FakeRegistry(
+        [
+            _fake_run(
+                run_id="workflow-1",
+                workspace_root=workspace,
+                status="superseded",
+                facets=("blocked", "planning_released"),
+            )
+        ]
+    )
+
+    report = _sweep(registry, coordinator)
+
+    assert [row["outcome"] for row in report] == ["rolled-back"]
+    assert report[0]["phase"] == "publishing"
+    assert report[0]["status"] == "superseded"
+    assert not any(path.exists() for path in artifacts)
+    assert not journal.exists()
+    # superseded run 不得被改動（abandon 已是終態）。
+    assert registry.updates == []
+
+
+def test_sweep_rejects_v2_journal_that_smuggles_a_phase_field(tmp_path: Path) -> None:
+    workspace, coordinator = _roots(tmp_path)
+    _publish_generation(workspace, coordinator, with_evidence=False)
+    journal = _journal(coordinator)
+    body = json.loads(journal.read_text(encoding="utf-8"))
+    body["schema_version"] = 2
+    journal.write_text(json.dumps(body, ensure_ascii=False, sort_keys=True) + "\n", encoding="utf-8")
+    registry = _FakeRegistry([_fake_run(run_id="workflow-1", workspace_root=workspace)])
+
+    report = _sweep(registry, coordinator)
+
+    assert report[0]["outcome"] == "drift"
+    assert journal.is_file()
+
+
+# --- 恢復迴圈：安全護欄 ---------------------------------------------------------
+
+
+def test_sweep_leaves_in_flight_journals_alone(tmp_path: Path) -> None:
+    """剛寫下的 journal 可能還在飛（daemon 之外的前景發佈），不得誤傷。"""
+
+    workspace, coordinator = _roots(tmp_path)
+    _, artifacts, _ = _publish_generation(workspace, coordinator)
+    registry = _FakeRegistry([_fake_run(run_id="workflow-1", workspace_root=workspace)])
+
+    report = manager.reconcile_planning_transactions(
+        registry=registry, coordinator_root=coordinator
+    )
+
+    assert [row["outcome"] for row in report] == ["in-flight"]
+    assert all(path.is_file() for path in artifacts)
+    assert _journal(coordinator).is_file()
+
+
+def test_sweep_surfaces_drift_instead_of_forcing_a_rollback(tmp_path: Path) -> None:
+    """operator 改過殘留檔 → 不刪、不靜默：留檔＋落 needs_human facet。"""
+
+    workspace, coordinator = _roots(tmp_path)
+    _, artifacts, _ = _publish_generation(workspace, coordinator, prepared=True)
+    artifacts[0].write_text("operator edit\n", encoding="utf-8")
+    registry = _FakeRegistry([_fake_run(run_id="workflow-1", workspace_root=workspace)])
+
+    report = _sweep(registry, coordinator)
+
+    assert report[0]["outcome"] == "drift"
+    assert report[0]["surfaced"] is True
+    assert artifacts[0].read_text(encoding="utf-8") == "operator edit\n"
+    assert _journal(coordinator).is_file()
+    assert registry.updates and registry.updates[0][0] == "workflow-1"
+    assert "needs_human" in registry.updates[0][1]["facets"]
+
+
+def test_sweep_does_not_touch_a_journal_whose_run_is_unknown(tmp_path: Path) -> None:
+    """沒有 run row 就無法驗證 journal 自報的 workspace root——fail closed，
+    但必須留下可見紀錄，不得靜默。"""
+
+    workspace, coordinator = _roots(tmp_path)
+    _, artifacts, _ = _publish_generation(workspace, coordinator)
+    registry = _FakeRegistry([])
+
+    report = _sweep(registry, coordinator)
+
+    assert report[0]["outcome"] == "unknown-run"
+    assert all(path.is_file() for path in artifacts)
+    assert _journal(coordinator).is_file()
+
+
+def test_sweep_never_deletes_an_artifact_the_operator_already_committed(
+    tmp_path: Path,
+) -> None:
+    """殘留檔若已被納入 git 追蹤，就不再是「未提交的發佈殘留」——跳過刪除、
+    退役 journal（比照 `work_actions._gc_one_abandoned_planning_artifact`）。"""
+
+    workspace, coordinator = _roots(tmp_path)
+    subprocess.run(["git", "init", "-q", str(workspace)], check=True)
+    _, artifacts, _ = _publish_generation(workspace, coordinator, prepared=True)
+    subprocess.run(
+        ["git", "-C", str(workspace), "add", "--", str(artifacts[0].relative_to(workspace))],
+        check=True,
+    )
+    registry = _FakeRegistry([_fake_run(run_id="workflow-1", workspace_root=workspace)])
+
+    report = _sweep(registry, coordinator)
+
+    assert report[0]["outcome"] == "adopted"
+    assert report[0]["skipped"] == [str(artifacts[0])]
+    assert artifacts[0].is_file()
+    assert not artifacts[1].exists()
+    assert not _journal(coordinator).exists()
+
+
+# --- daemon 接線 ----------------------------------------------------------------
+
+
+def test_periodic_tick_runs_the_planning_transaction_sweep(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """恢復迴圈必須真的被 tick 驅動，且結果對 operator 可見。"""
+
+    registry = SimpleNamespace(
+        _state_path=str(tmp_path / "jobs.json"), list_workflow_runs=lambda: []
+    )
+    dispatcher = SimpleNamespace(_registry=registry, _git_runner=lambda args: "")
+    calls: list[Path] = []
+
+    def fake_sweep(*, registry, coordinator_root):
+        calls.append(Path(coordinator_root))
+        return [
+            {"run_id": "workflow-1", "outcome": "rolled-back", "phase": "prepared"},
+            {"run_id": "workflow-2", "outcome": "in-flight"},
+        ]
+
+    monkeypatch.setattr(manager_daemon.manager, "reconcile_planning_transactions", fake_sweep)
+    runner = manager_daemon.build_periodic_tick_runner(
+        dispatcher=dispatcher,
+        specs_dir=str(tmp_path / "specs"),
+        handoff_dir=str(tmp_path / "handoff"),
+        launcher=object(),
+        run_tick_fn=lambda dispatcher_arg, **kwargs: {
+            "dispatch_skipped": False, "dispatched": [], "completed": [],
+            "errors": [], "reaped": None,
+        },
+        scan_specs_fn=lambda specs_dir: [],
+        auto_claim_fn=lambda: [],
+        workflow_identity_registry=object(),
+    )
+
+    summary = runner()
+
+    assert calls == [tmp_path]
+    # in-flight 是「這輪沒事做」，不佔 summary 版面；已收斂的必須現身。
+    assert summary["planning_transactions"] == [
+        {"run_id": "workflow-1", "outcome": "rolled-back", "phase": "prepared"}
+    ]
+
+
+def test_planning_transaction_sweep_failure_cannot_break_the_tick(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """#246 的 tick isolation 紀律：sweep 整批失效只降級並回報。"""
+
+    workflow = SimpleNamespace(
+        run_id="run-1", work_id="demo", repo="acme/demo", status="ongoing",
+        facets=(), current_phase="build", claim_key="claim:legacy:demo",
+        source_revision="",
+    )
+    registry = SimpleNamespace(
+        _state_path=str(tmp_path / "jobs.json"), list_workflow_runs=lambda: [workflow]
+    )
+    dispatcher = SimpleNamespace(_registry=registry, _git_runner=lambda args: "")
+    resumed: list[str] = []
+
+    def boom(**kwargs):
+        raise OSError("journal directory unreadable")
+
+    monkeypatch.setattr(manager_daemon.manager, "reconcile_planning_transactions", boom)
+    monkeypatch.setattr(
+        manager_daemon.manager,
+        "resume_workflow_run",
+        lambda dispatcher_arg, **kwargs: resumed.append(kwargs["run_id"]),
+    )
+    runner = manager_daemon.build_periodic_tick_runner(
+        dispatcher=dispatcher,
+        specs_dir=str(tmp_path / "specs"),
+        handoff_dir=str(tmp_path / "handoff"),
+        launcher=object(),
+        run_tick_fn=lambda dispatcher_arg, **kwargs: {
+            "dispatch_skipped": False, "dispatched": [], "completed": [],
+            "errors": [], "reaped": None,
+        },
+        scan_specs_fn=lambda specs_dir: [],
+        auto_claim_fn=lambda: [],
+        workflow_identity_registry=object(),
+    )
+
+    summary = runner()
+
+    assert summary["planning_transaction_failed"] is True
+    assert "OSError" in summary["planning_transaction_error"]
+    assert resumed == ["run-1"]
+
+
+# --- 端到端：真正的 define 流程 --------------------------------------------------
+
+
+def _manifest() -> WorkflowManifest:
+    cards = load_cards(DEFAULT_CARDS_PATH)
+    combo = load_combo(DEFAULT_COMBOS_DIR / "feature-oneshot.yaml", cards)
+    result = compile_combo(combo, cards, "production wiring", change="production-wiring")
+    assert result.workflow_manifest is not None
+    return result.workflow_manifest
+
+
+def _identities() -> IdentityRegistry:
+    return IdentityRegistry.from_rows(
+        [
+            {
+                "executor": "codex", "model_id": "primary",
+                "independence_domain": "openai", "capabilities": ["planning"],
+            },
+            {
+                "executor": "claude", "model_id": "secondary",
+                "independence_domain": "anthropic", "capabilities": ["planning"],
+            },
+        ]
+    )
+
+
+def _questioner(report):
+    from paulsha_cortex.coordinator.planning import assess_planning_completeness
+
+    return assess_planning_completeness([]).default_question_pack.to_dict()
+
+
+def _secondary(pack, identity):
+    return {
+        "schema_version": 1,
+        "question_pack_id": pack["pack_id"],
+        "evidence": [
+            {"question_id": row["question_id"], "claims": ["missing"], "source_refs": ["scan:1"]}
+            for row in pack["questions"]
+        ],
+    }
+
+
+def _integrator(pack, evidence):
+    bodies = {
+        "spec": "---\nstatus: accepted\n---\n# Spec\n## Requirements\nBound.\n",
+        "design": "---\nstatus: accepted\n---\n# Design\n## Decisions\nBound.\n",
+        "plan": "---\nstatus: accepted\n---\n# Plan\n## Task 1\nBuild.\n",
+    }
+    refs = {
+        "spec": "docs/superpowers/specs/production-wiring-spec.md",
+        "design": "docs/superpowers/specs/production-wiring-design.md",
+        "plan": "docs/superpowers/plans/production-wiring-plan.md",
+    }
+    resolutions = []
+    artifacts = []
+    for row in pack["questions"]:
+        kind = row["kind"].removeprefix("missing-")
+        resolutions.append(
+            {
+                "question_id": row["question_id"], "decision": "accepted",
+                "artifact_kind": kind, "artifact_refs": [refs[kind]],
+            }
+        )
+        artifacts.append({"kind": kind, "path": refs[kind], "content": bodies[kind]})
+    return {
+        "schema_version": 1, "question_pack_id": pack["pack_id"],
+        "secondary_evidence_hash": evidence["evidence_hash"],
+        "resolutions": resolutions, "artifacts": artifacts,
+    }
+
+
+def _define_args(manifest_path: Path, artifact_root: Path) -> dict[str, object]:
+    return {
+        "action": "start",
+        "manifest_path": str(manifest_path),
+        "work_id": "production-wiring",
+        "repo": "hamanpaul/paulsha-cortex",
+        "claim_key": "hamanpaul/paulsha-cortex/production-wiring/rev-a",
+        "source_revision": "rev-a",
+        "artifact_root": str(artifact_root),
+        "planning_artifacts": [],
+        "primary_executor": "codex",
+        "primary_model": "primary",
+        "evidence_dir": str(artifact_root / "evidence"),
+    }
+
+
+def _apply_define(registry, tmp_path: Path):
+    manifest_path = tmp_path / "manifest.json"
+    if not manifest_path.exists():
+        manifest_path.write_text(json.dumps(_manifest().to_dict()), encoding="utf-8")
+    return manager.apply_workflow_action(
+        registry,
+        args=_define_args(manifest_path, tmp_path),
+        identity_registry=_identities(),
+        probes={
+            ("claude", "secondary"): CapabilityProbe.ready_for(
+                "claude", "secondary", "anthropic"
+            )
+        },
+        primary_questioner=_questioner,
+        secondary_planner=_secondary,
+        primary_integrator=_integrator,
+        coordinator_root=tmp_path,
+    )
+
+
+def test_hard_crash_between_publication_and_state_update_is_healed_by_the_sweep(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#536 主回歸：發佈後、狀態更新前行程當場死亡。
+
+    以「registry 提交那一刻炸掉 ＋ 事務的清理路徑全部失效」模擬 SIGKILL——
+    沒有任何 handler 有機會回滾。修法前這會留下一個對所有恢復迴圈隱形的中間態
+    （artifacts 已落地、run 停在 define、facets 空、無 gate_refs、journal 無人
+    問津）。修法後同一條恢復路徑（sweep）必須把它收斂掉。
+    """
+
+    state_path = tmp_path / "registry.json"
+    registry = JobRegistry(state_path=state_path)
+    original_rollback = manager._PlanningPublicationTransaction.rollback
+    original_commit = manager._PlanningPublicationTransaction.commit
+    real_write = registry._write_payload_atomically
+
+    def crash_on_plan_transition(payload):
+        if any(
+            row.get("current_phase") == "plan" and row.get("gate_refs")
+            for row in payload.get("workflows", [])
+        ):
+            raise _HardCrash("manager process killed at the commit boundary")
+        real_write(payload)
+
+    monkeypatch.setattr(
+        manager._PlanningPublicationTransaction, "rollback", lambda self, **kwargs: ()
+    )
+    monkeypatch.setattr(manager._PlanningPublicationTransaction, "commit", lambda self: None)
+    monkeypatch.setattr(registry, "_write_payload_atomically", crash_on_plan_transition)
+
+    with pytest.raises(_HardCrash):
+        _apply_define(registry, tmp_path)
+
+    monkeypatch.setattr(manager._PlanningPublicationTransaction, "rollback", original_rollback)
+    monkeypatch.setattr(manager._PlanningPublicationTransaction, "commit", original_commit)
+    monkeypatch.setattr(registry, "_write_payload_atomically", real_write)
+
+    # ---- 中間態確實成立（修法前的永久隱形現場）----
+    restarted = JobRegistry(state_path=state_path)
+    stalled = restarted.list_workflow_runs()[0]
+    assert stalled.current_phase == "define"
+    assert stalled.status == "ongoing"
+    assert stalled.facets == ()
+    assert stalled.gate_refs == ()
+    published = sorted((tmp_path / "docs/superpowers").rglob("*.md"))
+    assert published
+    journal = _journal(tmp_path, stalled.run_id)
+    assert journal.is_file()
+    assert json.loads(journal.read_text(encoding="utf-8"))["phase"] == "prepared"
+
+    # ---- 同一條恢復路徑收斂 ----
+    report = _sweep(restarted, tmp_path)
+
+    assert [row["outcome"] for row in report] == ["rolled-back"]
+    assert report[0]["run_id"] == stalled.run_id
+    assert not journal.exists()
+    assert not any(path.exists() for path in published)
+    assert not list((tmp_path / "evidence").glob("brainstorm-*.json"))
+
+    # ---- 收斂後重跑 define 正常成功（殘留不再是下一輪的地雷）----
+    result = _apply_define(JobRegistry(state_path=state_path), tmp_path)
+    assert result["reason"] == "brainstorm-complete"
+    assert result["current_phase"] == "plan"
+
+
+def test_successful_define_seals_the_boundary_and_retires_the_journal(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """正常路徑不回歸：邊界在 registry 提交前就已封住，成功後 journal 退役，
+    sweep 也不會再對它做任何事。"""
+
+    registry = JobRegistry(state_path=tmp_path / "registry.json")
+    observed: list[str] = []
+    original = manager._validated_brainstorm_planning_authority
+
+    def spy(run, **kwargs):
+        journal = _journal(tmp_path, run.run_id)
+        observed.append(json.loads(journal.read_text(encoding="utf-8"))["phase"])
+        return original(run, **kwargs)
+
+    monkeypatch.setattr(manager, "_validated_brainstorm_planning_authority", spy)
+
+    result = _apply_define(registry, tmp_path)
+
+    assert result["reason"] == "brainstorm-complete"
+    assert result["current_phase"] == "plan"
+    # registry 提交之前，journal 已經宣告「檔案側封住、下一步是 commit point」。
+    assert observed == ["prepared"]
+    run = registry.list_workflow_runs()[0]
+    assert not _journal(tmp_path, run.run_id).exists()
+    assert sorted(path.name for path in (tmp_path / "docs/superpowers").rglob("*.md"))
+
+    assert _sweep(registry, tmp_path) == []


### PR DESCRIPTION
## 根因

define 的 brainstorm 有**兩次分離的 durable 寫入**：

1. 發佈 planning artifacts 到 operator worktree
   （`manager._publish_planning_artifacts` → `_PlanningPublicationTransaction`）；
2. 把 run 推進到 `plan` 並寫入 `gate_refs` / `planning_authority`
   （`registry._manager_update_workflow_run`）。

兩者之間崩潰，就留下「artifacts 已落地、run 狀態停在原地」的中間態——正是 #536 現場
（run `workflow-7a430d31eff66ef13630`：`updated_at` 停在建立時刻、`gate_refs=[]`、
facets 空、manager log 無錯誤）。

journal（`<coordinator_root>/planning-transactions/<run_id>.json`）本來就記了每個
mutation 的 before/after hash，**缺的是誰去看它**：`_PlanningPublicationTransaction.reconcile()`
只能由持有該 run 的呼叫端逐 run 觸發（define 起始、`resume_workflow_run`）。run 一旦
離開 `ongoing`（superseded / done），journal 與它描述的殘留檔就再也沒有任何迴圈會碰。

本機 coordinator root 上實測躺著兩份這種孤兒 journal：

| journal | 內容 | run 現況 |
| --- | --- | --- |
| `workflow-7a430d31eff66ef13630.json` | `expected_gate_ref: null`、兩筆 `before_exists=false` 的 spec/design artifact op | `status=superseded`、`facets=[blocked, planning_released]` |
| `workflow-29a1247ddaf88d11eda8.json` | 同型（8/11 起） | 同上 |

兩份殘留 spec/design 因此永久留在 operator worktree，成為下一世代 define 撞
#416 / #535 authority fail-closed 的地雷——「成功產出再次變成下一輪的地雷」。

## 修法

### 1. `prepare_commit()`：把事務邊界寫成 durable 事實

journal schema 升到 v3，新增 `phase`（`publishing` → `prepared`）。`prepared` 表示
檔案側已全部落地且已 fsync，下一步就是本事務**唯一的 commit point**（registry 的原子
寫入）。封住之後再呼叫 `publish()` 一律 fail-closed。`phase` 只供診斷，**不參與**
commit 判準。

### 2. `reconcile_planning_transactions()`：掃整個 journal 目錄的唯一恢復路徑

與 run 狀態無關——ongoing / superseded / done 一視同仁，由 periodic tick 驅動，因此
**既有殘留與未來崩潰走同一條程式路徑自癒**。判準只有一條：**registry 的 run row 上
有沒有這次的 brainstorm gate ref**。

- 有 → **前滾**：逐位元組驗證每個已提交產物仍吻合，然後退役 journal。
- 沒有 → **回退**：把檔案側還原成發佈前的樣子。

**為什麼選回退而不是前滾**：沒有那個 gate ref，就代表這批產出從未被綁進任何 run
（無 `planning_authority`、無 `planning_source_revision`、`steps` 沒有 outputs），
前滾在語意上不成立；而現場殘留的 `expected_gate_ref` 是 `null`（崩在 evidence 落地
之前），根本沒有可以前滾的目標。回退全程受既有 CAS 護欄把關（`before_exists` +
`after_hash` 必須完全吻合），撞到 operator drift 一律拒絕並改為呈現。

### 3. 收斂結果不得靜默

每份 journal 的處理結果（`rolled-back` / `committed` / `adopted` / `drift` /
`unknown-run` / `in-flight`）都落結構化 log 並進 tick summary；無法自動收斂（drift）
且 run 仍 `ongoing` 時補 `needs_human` facet，讓 `cortex status` 的 attention 清單與
`next_actions` 有話說。

### 安全護欄

- **in-flight**：journal 寫下未滿 5 分鐘者本輪不碰。發佈側最後一次 fsync 到 registry
  提交正常是次秒級，這個餘裕純粹是為了絕不誤傷 daemon 之外的前景發佈。
- **adopted**：殘留檔若已被 operator 納入 git 追蹤，就不再是「未提交的發佈殘留」，
  跳過刪除並回報——比照 `work_actions._gc_one_abandoned_planning_artifact` 的既有紀律
  （#507 的教訓：不得銷毀 operator 的工作）。
- **unknown-run**：找不到對應 run row 時 fail closed——無法驗證 journal 自報的
  workspace root 就不刪檔，只留 log 與回報。
- **tick isolation**：sweep 整批失效比照 #246 降級為 `planning_transaction_failed`，
  不得癱瘓本輪 tick，resume 迴圈照常執行。

恢復路徑**相容 v2 journal**（升級前的格式，實際部署上就有殘留），自癒不要求 operator
先手動搬遷。

### 範圍紀律

- 不動 #538 已修的 resume 迴圈 phase filter。
- 不做 phase 心跳（R0.5 D5）。
- 不動 GitHub 邊界。
- 沿用既有 journal / CAS 慣例，未引入新框架。

## 測試證據

新增 `tests/test_planning_publication_transaction_536.py`（14 個回歸測試）：

- **邊界測試（主回歸）**：`test_hard_crash_between_publication_and_state_update_is_healed_by_the_sweep`
  ——以「registry 提交那一刻炸掉 + 事務清理路徑全部失效」模擬 SIGKILL（沒有任何 handler
  有機會回滾），先斷言中間態確實成立（run 停在 define / facets 空 / `gate_refs=()` /
  artifacts 已落地 / journal `phase=prepared`），再斷言同一條恢復路徑把它收斂掉，最後
  重跑 define 成功（殘留不再是下一輪的地雷）。
- **既有殘留自癒**：`test_sweep_heals_legacy_v2_journal_of_a_superseded_run`——v2 journal
  + `status=superseded`，正是現場殘留的形態；superseded run 本身不得被改動。
- **前滾**：`test_sweep_rolls_forward_when_registry_row_carries_the_gate_ref`。
- **回退（兩種 phase）**：`test_sweep_rolls_back_uncommitted_publication_regardless_of_phase`。
- **護欄**：in-flight 不誤傷、drift 留檔並補 `needs_human`、unknown-run fail closed、
  已被 git 追蹤的殘留檔不刪（真的 `git init` + `git add`）。
- **daemon 接線**：tick 真的驅動 sweep 且結果進 summary；sweep 失效不癱瘓 tick。
- **正常路徑不回歸**：`test_successful_define_seals_the_boundary_and_retires_the_journal`
  ——斷言 registry 提交前 journal 已是 `prepared`、成功後 journal 退役、sweep 無事可做。

```
python3 -m pytest -q
2652 passed, 49 subtests passed in 47.12s
```

`python3 -m pytest -q tests/test_planning_publication_transaction_536.py` → 14 passed。
`tests/test_workflow_production_wiring.py` + `tests/test_manager_daemon_tick_isolation.py`
→ 104 passed（既有事務／tick 測試全數不回歸）。

Refs #536

## Checklist

- [x] `changelog.d/publish-state-transaction.md` fragment 已新增且已 commit
- [x] `CHANGELOG.md [Unreleased]` 有對應 entry
- [x] `VERSION` 與意圖一致（非 release PR，未動）
- [x] 全套 `python3 -m pytest -q` 通過
- [x] 只引用不關閉 issue（#536 尚有 R0.5 D5 的 phase 心跳未做）→ 帶 `policy-exempt:issue-link`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E7w9kaUxAzCCEk7piD5hfK
