### PR TITLE
fix(coordinator): marker 詞界化與 worktree drift 環境分類

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,39 @@
 ## [Unreleased]
 
 ### Fixed
+- **Issue #554：taxonomy marker 無詞界，與 #543 的 `<unavailable>` 佔位符相撞；worktree
+  drift 的 `content` 誤分類死鎖一併解除**——兩個缺陷共用同一組現場（planning worktree
+  drift 的失敗訊息）。**缺陷一**：`_operator_drift_message` 尾端是
+  `evidence={location}`，退化值原為 `"<unavailable>"`，而 PR #542 落地的
+  `outcome_taxonomy.TRANSIENT_SERVICE_MARKERS` 含**裸** `"unavailable"`（#533 為 agy
+  的 `UNAVAILABLE (code 503)` 而收），比對是無界子字串——於是「drift 且備份／報告雙雙
+  寫入失敗」這個純環境事件，會靠子字串巧合被判成 transient-service（`evidence=/tmp/
+  psc-report.json` → False，`evidence=<unavailable>` → True）。這是 #500（`\btimeout\b`
+  命中 nested tool result）、#487（`oauth` 命中 `doc-coauthoring`）的同族無界 token 缺陷
+  第三次命中。**兩邊都修**：(a) marker 比對改詞界（新增
+  `TRANSIENT_SERVICE_MARKER_RE`），擋住 marker 被埋在更長 word token 裡的誤中——全表
+  掃描顯示裸短字串 `"503"`／`"429"` 誤中面最大（`workflow-1a503f0429ab` 這種 run id 修
+  法前就會被判 transient），`"unavailable"` 次之（`envelope_unavailable` 等內部欄位
+  值）；(b) 佔位符改為
+  `planning_runtime.PLANNING_WORKTREE_DRIFT_EVIDENCE_PLACEHOLDER = "<not-written>"`
+  並附不變式測試——詞界擋不住「整個 token 就是 marker」，`<unavailable>` 與
+  `<evidence-unavailable>` 的 `<`／`>`／`-` 都不是 word char，詞界照樣成立。詞界化會讓
+  原本靠子字串巧合命中的真陽性落空，因此 `rate limited`／`rate limiting`／`timeouts`／
+  `timeouterror`／`timeoutexpired`／`serviceunavailable` 改為顯式列舉入表（CamelCase
+  例外類名尤其關鍵：`TimeoutExpired` 的訊息常在 reason 的 160 字截斷處被切掉
+  `timed out`，只剩型別名帶得動訊號）。**缺陷二**：「planning launcher modified
+  operator worktree」家族從 `content` 改判 `environment`——#543 之後 drift 不再銷毀任何
+  資料（只備份與報告），語意上就是環境事件，維持 `content` 只會讓唯一出口是
+  `abandon`（#507 comment 2 記錄、#543 明文留待後續的死鎖）。新增
+  `manager._is_planning_worktree_drift_failure`，判準只認 `planning_runtime` 新匯出的
+  穩定前綴 `PLANNING_WORKTREE_DRIFT_MESSAGE_PREFIX`，不依賴訊息尾段（尾段已在 #543
+  由 `changes rolled back` 改為 `operator content preserved`）；`disposable read-only
+  sandbox` 家族刻意不在此列，維持 `content`。並把 `_run_define_stage` 中段的三元表達式
+  抽成具名的 `_classify_planning_failure`，讓 reason → classification 有單一可測入口。
+  `recover-planning` 自身行為一字未改，本次只是讓 drift 案例走得到它。詳見
+  `changelog.d/marker-word-boundary.md`。新增
+  `tests/test_planning_drift_classification_554.py`（47 個回歸測試）。
+
 - **Issue #536（後半）：planning artifacts 發佈與 run 狀態更新不是同一事務，中間態對
   所有恢復迴圈永久隱形**——define 的 brainstorm 有兩次分離的 durable 寫入：先發佈
   spec/design/plan 到 operator worktree，再把 run 推進到 `plan` 並寫入 gate_refs／

--- a/changelog.d/marker-word-boundary.md
+++ b/changelog.d/marker-word-boundary.md
@@ -1,0 +1,81 @@
+---
+type: fix
+scope: coordinator
+---
+**Issue #554：taxonomy marker 無詞界，與 #543 的 `<unavailable>` 佔位符相撞；順帶收掉 worktree drift 的 `content` 誤分類死鎖**
+
+兩個缺陷共用同一組現場（planning worktree drift 的失敗訊息），一併處理。
+
+### 缺陷一：`<unavailable>` 佔位符誤中 transient marker
+
+`planning_runtime._operator_drift_message` 的尾端是 `evidence={location}`，
+`location = report_path or backup_root or "<unavailable>"`；而 PR #542 落地的
+`outcome_taxonomy.TRANSIENT_SERVICE_MARKERS` 含**裸** `"unavailable"`（#533 為 agy
+的 `UNAVAILABLE (code 503)` 而收），比對是無界子字串。因此 drift **且備份／報告
+雙雙寫入失敗**時，一個純環境事件會被 `matches_transient_service_markers` 判成
+transient-service：
+
+- `evidence=/tmp/psc-report.json` → False（正常）
+- `evidence=<unavailable>` → True（誤判，靠子字串巧合）
+
+這是 #500（`\btimeout\b` 命中 nested tool result 的 `Parser aborted (timeout, ...)`）、
+#487（`oauth` 命中技能名 `doc-coauthoring`）的同族無界 token 缺陷，第三次命中。
+
+**兩邊都修，缺一不可。**
+
+1. **marker 比對加詞界**：新增 `outcome_taxonomy.TRANSIENT_SERVICE_MARKER_RE`
+   （`\b(?:…)\b`，IGNORECASE），`matches_transient_service_markers` 改用它。這擋住
+   「marker 被埋在更長 word token 裡」的誤中面——全表掃描的結果是裸短字串
+   `"503"`／`"429"` 誤中面最大（run id、content-addressed digest、evidence 路徑裡
+   出現三個數字是家常便飯，例如 `workflow-1a503f0429ab` 修法前就會被判 transient），
+   `"unavailable"` 次之（`envelope_unavailable`、`provider_unavailable` 這類與服務層
+   無關的內部欄位值）。`INTERRUPTION_MARKERS`／`KNOWN_PROCESS_BANNERS`／
+   `_PLANNING_AUTHORITY_RESIDUE_MARKERS` 一併掃過：全是長片語或 snake_case 整串
+   token，沒有同型誤中面，不動。
+2. **佔位符不得含 marker**：詞界擋不住「整個 token 就是 marker」——`<unavailable>`
+   的 `<`／`>` 都不是 word char，詞界照樣成立（issue 順手提到的
+   `<evidence-unavailable>` 同理，`-` 也不是 word char）。因此新增
+   `planning_runtime.PLANNING_WORKTREE_DRIFT_EVIDENCE_PLACEHOLDER = "<not-written>"`
+   並附不變式測試，未來換佔位符會被測試擋下。
+
+詞界化的代價是「原本靠子字串巧合命中的真陽性變體」會落空。那些是真訊號，因此改為
+**顯式列舉**進表：`rate limits`／`rate limited`／`rate limiting`（provider 訊息實測
+三種都出現）、`timeouts`、`timeouterror`／`timeoutexpired`、`serviceunavailable`。
+其中 CamelCase 例外類名特別關鍵——planning lane 的 reason 格式是
+`<stage>-<kind>: <ExceptionTypeName>: <str(exc)[:160]>`，`subprocess.TimeoutExpired`
+的訊息（`Command '[...]' timed out after N seconds`）常因 argv 過長而在 160 字截斷
+處被切掉 `timed out`，此時**只剩型別名帶得動訊號**。表變長是刻意的：寧可每個變體都
+看得見，也不要再靠子字串巧合。
+
+### 缺陷二：worktree drift 改判 `environment`（operator 裁決）
+
+#507 前 drift 的處置是把 operator worktree 整棵抹除再從 baseline 還原——那確實會
+銷毀資料，歸 `content`（fail-closed、不給 `recover-planning`）在當時是合理的保守。
+#543 之後處置已改為「一個位元組都不動、只備份與報告」，drift 於是變成純粹的環境
+事件：本次 planning 結果不可信，但沒有任何東西被破壞，重跑就好。維持 `content` 讓
+唯一出口是 `abandon`（燒一個世代），即 #507 comment 2 記錄、#543 明文留待後續的
+死鎖。
+
+新增 `manager._is_planning_worktree_drift_failure`，判準只認 `planning_runtime`
+新匯出的**穩定前綴** `PLANNING_WORKTREE_DRIFT_MESSAGE_PREFIX`
+（`planning launcher modified operator worktree`）——訊息尾段已經在 #543 改過一次
+（`changes rolled back` → `operator content preserved`），計數與 evidence 路徑更是
+每次都不同，任何依賴尾段字面的判準都會再壞一次。判準刻意窄：同一段 finally 另有的
+`planning launcher modified disposable read-only sandbox`（launcher 寫壞拋棄式沙箱，
+屬 launcher 行為異常而非環境並行編輯）不在此列，維持 `content`。
+
+同時把 `_run_define_stage` 中段的三元表達式抽成具名的
+`manager._classify_planning_failure(reason) -> "environment" | "content"`，讓
+「reason → classification」這條映射有單一可測入口（過去它只活在函式中段，測不到也
+看不見）；三個 `environment` 例外（#416 authority 殘留、#533 暫時性服務、#554
+drift）在同一處列齊。
+
+### 範圍紀律
+
+只動分類與 marker 精度。`recover-planning` 自身的 admission、CAS、fail-closed 條件
+一字未改——本次只是讓 drift 案例走得到它。
+
+新增 `tests/test_planning_drift_classification_554.py`（47 個回歸測試：佔位符不變
+式、全表詞界不變式的參數化掃描、數字 marker 不再命中 run id／路徑、snake_case 內部
+欄位值不再命中、詞界化保留的真陽性變體、drift 新舊兩代訊息都正確分類、sandbox 家族
+維持 `content`、`_resume_decision` 對 drift 浮現 `recover-planning`）。

--- a/paulsha_cortex/coordinator/manager.py
+++ b/paulsha_cortex/coordinator/manager.py
@@ -6320,6 +6320,65 @@ def _is_planning_transient_service_failure(reason: str | None) -> bool:
     return outcome_taxonomy.matches_transient_service_markers(reason)
 
 
+# --- issue #554：operator worktree drift 是環境事件，不是內容缺陷 -------------
+#
+# #507 前，drift 的處置是把 operator worktree 整棵抹除再從 baseline 還原——
+# 那確實會銷毀資料，把它歸 `content`（fail-closed、不給 recover-planning）
+# 在當時是合理的保守。#543 之後處置已改為「一個位元組都不動、只備份與報告」，
+# drift 於是變成一個純粹的環境事件：operator／其他 agent／編輯器在 planning
+# 視窗內動了樹，本次 planning 結果不可信，但**沒有任何東西被破壞**，重跑
+# planning 就好。維持 `content` 只會讓唯一出口是 abandon（燒一個世代），
+# 這是 #507 comment 2 記錄、#543 明文留待後續的死鎖。
+#
+# 判準只認 `planning_runtime` 匯出的穩定前綴：訊息尾段已在 #543 改過一次
+# （`changes rolled back` → `operator content preserved`），計數與 evidence 路徑
+# 每次都不同，任何依賴尾段字面的判準都會再壞一次。
+_PLANNING_WORKTREE_DRIFT_MARKER = planning_runtime.PLANNING_WORKTREE_DRIFT_MESSAGE_PREFIX
+
+
+def _is_planning_worktree_drift_failure(reason: str | None) -> bool:
+    """判斷 planning 失敗的 reason 是否為 operator worktree drift（#507／#554）。
+
+    reason 的實際樣貌是 `run_heterogeneous_brainstorm` 對 launcher 例外包出的
+    `<stage>-<kind>: ValueError: <drift message>`，因此比對用 `in` 而非
+    `startswith`——前綴指的是「drift 訊息自己的前綴」，不是整個 reason 的前綴。
+
+    判準刻意窄：只認 operator worktree 這一族。同一段 finally 另有
+    `planning launcher modified disposable read-only sandbox`（launcher 寫壞了
+    拋棄式沙箱）——那是 launcher 行為異常而非環境並行編輯，不在此列，維持
+    既有 `content` 分類。
+    """
+
+    return reason is not None and _PLANNING_WORKTREE_DRIFT_MARKER in reason
+
+
+def _classify_planning_failure(reason: str | None) -> str:
+    """brainstorm not-ready 的 reason → `environment` / `content` 的**單一判準**。
+
+    #393 的預設是 `content`（fail-closed，`_resume_decision` 不浮現
+    `recover-planning`）。三個具名例外改歸 `environment`：
+
+    1. `_is_planning_authority_residue_failure`（#416）——abandon 未回滾的發佈
+       殘留撞見 authority fail-closed，是狀態殘留而非模型內容缺陷。
+    2. `_is_planning_transient_service_failure`（#533）——launcher/service 層
+       的暫時性錯誤（503／限流／逾時），幾分鐘後自癒。
+    3. `_is_planning_worktree_drift_failure`（#507／#554）——operator worktree
+       在 planning 視窗內被動過；#543 之後不再銷毀資料，是環境事件。
+
+    三個判準合成一個具名函式，是為了讓「reason → classification」這條映射有
+    單一可測的入口（過去它只以三元表達式活在 `_run_define_stage` 中段，測不到
+    也看不見）。
+    """
+
+    if (
+        _is_planning_authority_residue_failure(reason)
+        or _is_planning_transient_service_failure(reason)
+        or _is_planning_worktree_drift_failure(reason)
+    ):
+        return "environment"
+    return "content"
+
+
 # --- issue #511：planning artifact 拒收的診斷面 -------------------------------
 #
 # 修法前拒收只丟一句 `planning artifact is not accepted: <path>`：
@@ -9419,6 +9478,9 @@ def apply_workflow_action(
         # 例外二——`_is_planning_transient_service_failure`：launcher/service 層
         # 的暫時性錯誤（503/限流/逾時；agy 實測會印錯誤文字但 exit 0），同歸
         # `environment`。一個幾分鐘後自癒的服務錯誤不得被判成 `content` 死路。
+        # 例外三（#554）——`_is_planning_worktree_drift_failure`：operator
+        # worktree 在 planning 視窗內被動過。#543 之後 drift 不再銷毀任何資料
+        # （只備份與報告），語意上就是環境事件，同歸 `environment`。
         brainstorm_not_ready_reason = result.reason or "brainstorm-not-ready"
         run = registry._manager_update_workflow_run(
             run.run_id,
@@ -9427,12 +9489,7 @@ def apply_workflow_action(
             evidence_refs=_record_planning_failure_evidence(
                 run,
                 coordinator_root=transaction_root,
-                classification=(
-                    "environment"
-                    if _is_planning_authority_residue_failure(brainstorm_not_ready_reason)
-                    or _is_planning_transient_service_failure(brainstorm_not_ready_reason)
-                    else "content"
-                ),
+                classification=_classify_planning_failure(brainstorm_not_ready_reason),
                 reason=brainstorm_not_ready_reason,
             ),
         )

--- a/paulsha_cortex/coordinator/outcome_taxonomy.py
+++ b/paulsha_cortex/coordinator/outcome_taxonomy.py
@@ -66,6 +66,7 @@ __all__ = [
     "TextSignal",
     "StructuredKind",
     "TRANSIENT_SERVICE_MARKERS",
+    "TRANSIENT_SERVICE_MARKER_RE",
     "INTERRUPTION_MARKERS",
     "KNOWN_PROCESS_BANNERS",
     "QUOTA_RE",
@@ -143,21 +144,76 @@ class StructuredKind(str, Enum):
 # 不回 JSON、schema 不合）不在此列，維持 `content` 分類與 fail-closed 意圖
 # ——分辨依據是這些字樣出自 launcher 轉印的服務錯誤，不會出現在合法的規劃
 # 輸出裡。
+#
+# #554：本表**以詞界比對**（見 :data:`TRANSIENT_SERVICE_MARKER_RE`），不再是
+# 裸子字串。裸子字串比對是 #500／#487 同族的無界 token 缺陷——短 marker 對長
+# 訊息的誤中面極大：
+#   - `"503"`／`"429"` 會命中 run id／digest／路徑裡的任意數字片段
+#     （`workflow-1a503f…`、`…/run-4290/report.json`）；
+#   - `"unavailable"` 會命中 `envelope_unavailable`、`provider_unavailable`
+#     這類與服務層無關的內部欄位值。
+# 詞界化的代價是「靠子字串巧合命中的真陽性變體」會落空（`rate limited`、
+# `TimeoutExpired`、`ServiceUnavailable`……）。那些是真訊號，因此改為**顯式
+# 列舉**：表變長是刻意的——寧可每個變體都看得見，也不要再靠子字串巧合。
 TRANSIENT_SERVICE_MARKERS: tuple[str, ...] = (
     "unavailable",
     "503",
     "429",
     "rate limit",
+    # `rate limit` 的英文屈折變體。詞界化前靠 `rate limit` 的子字串涵蓋，
+    # 詞界化後必須各自列出（provider 訊息實測三種都出現過）。
+    "rate limits",
+    "rate limited",
+    "rate limiting",
     "too many requests",
     "timed out",
     "timeout",
+    "timeouts",
+    # CamelCase 例外類名。planning lane 的 reason 格式是
+    # `<stage>-<kind>: <ExceptionTypeName>: <str(exc)[:160]>`，其中
+    # `subprocess.TimeoutExpired` 的訊息（`Command '[...]' timed out after
+    # N seconds`）常因 argv 過長而在 160 字截斷處被切掉「timed out」，此時
+    # **只剩型別名帶得動訊號**。詞界化前靠 `timeout` 的子字串涵蓋。
+    "timeouterror",
+    "timeoutexpired",
     "connection reset",
     "connection refused",
     "overloaded",
     "temporarily",
     "service_unavailable",
+    # 詞界化前靠 `unavailable` 的子字串涵蓋（`_` 與駝峰都算 word char，詞界
+    # 比對不會從 `ServiceUnavailable` 中間切出 `unavailable`）。
+    "serviceunavailable",
     "eligibility check failed",
 )
+
+
+def _compile_marker_pattern(markers: Sequence[str]) -> re.Pattern[str]:
+    """把字面 marker 表編成**詞界**比對的單一 pattern（#554）。
+
+    `\\b` 是「word char ↔ 非 word char 的交界」。因此：
+
+    - `\\b503\\b` 不再命中 `1a503f`（前後都是 word char），但仍命中
+      `code 503`、`(503)`、`HTTP/1.1 503`；
+    - `\\bunavailable\\b` 不再命中 `envelope_unavailable`（`_` 是 word char），
+      但**仍會命中 `<unavailable>`**（`<`／`>` 不是 word char）——詞界解決不了
+      「整個 token 就是 marker」的佔位符相撞，那一半由呼叫端負責：佔位符本身
+      不得含 marker（見 `planning_runtime.
+      PLANNING_WORKTREE_DRIFT_EVIDENCE_PLACEHOLDER`）。兩邊都修才擋得住。
+
+    長 marker 排前面只是為了讓 alternation 的命中片段可讀（本函式只回布林，
+    順序不影響結果）。
+    """
+
+    ordered = sorted(markers, key=len, reverse=True)
+    return re.compile(
+        r"\b(?:" + "|".join(re.escape(marker) for marker in ordered) + r")\b",
+        re.IGNORECASE,
+    )
+
+
+#: :data:`TRANSIENT_SERVICE_MARKERS` 的詞界比對 pattern（#554）。
+TRANSIENT_SERVICE_MARKER_RE = _compile_marker_pattern(TRANSIENT_SERVICE_MARKERS)
 
 # Quota：固定週期用量上限（月配額、bulk usage limit），與 rate_limit（滑動時間窗、
 # 通常數十秒到數分鐘內重置）語意不同，值得分開分類以利未來對 quota 採不同的
@@ -259,13 +315,15 @@ def matches_transient_service_markers(reason: str | None) -> bool:
     """判斷一段失敗描述是否命中服務層暫時性樣態（:data:`TRANSIENT_SERVICE_MARKERS`）。
 
     planning lane（`manager._is_planning_transient_service_failure`）的判準即
-    本函式；收編自 #533 的先行實作，行為逐字不變。
+    本函式；收編自 #533 的先行實作。
+
+    #554：比對由裸子字串改為**詞界**（:data:`TRANSIENT_SERVICE_MARKER_RE`），
+    真陽性樣態逐一保留在表內、不靠子字串巧合。
     """
 
     if reason is None:
         return False
-    lowered = reason.lower()
-    return any(marker in lowered for marker in TRANSIENT_SERVICE_MARKERS)
+    return TRANSIENT_SERVICE_MARKER_RE.search(reason) is not None
 
 
 def strip_known_process_banners(lines: Sequence[str]) -> list[str]:

--- a/paulsha_cortex/coordinator/planning_runtime.py
+++ b/paulsha_cortex/coordinator/planning_runtime.py
@@ -258,6 +258,24 @@ PLANNING_WORKTREE_DRIFT_DIRNAME = "planning-worktree-drift"
 # `backed_up: false`，並且**一律逐出 rollback 範圍**——備份不成功就不准抹除，
 # 是本 issue 最低限度的保命索。
 PLANNING_DRIFT_BACKUP_MAX_BYTES = 64_000_000
+# #554：drift 失敗訊息的**穩定前綴**。這串字是下游分類（`manager.
+# _is_planning_worktree_drift_failure`）唯一可以依賴的部分——訊息尾段已經在
+# #543 改過一次（`changes rolled back` → `operator content preserved`），計數與
+# evidence 路徑更是每次都不同。改動本常數等同改動分類契約，必須同步改判準與
+# 其回歸測試。
+PLANNING_WORKTREE_DRIFT_MESSAGE_PREFIX = "planning launcher modified operator worktree"
+# #554：備份與報告雙雙寫不出去時，evidence 欄位的退化佔位符。
+#
+# 原值是 `<unavailable>`，而 `outcome_taxonomy.TRANSIENT_SERVICE_MARKERS` 含裸
+# `"unavailable"`（#533 為 agy 的 `UNAVAILABLE (code 503)` 而收）：於是「備份寫
+# 入失敗」這個純環境事件，會因為佔位符裡有 `unavailable` 六個字而被判成
+# transient-service。詞界比對擋不住這一種——整個 token 就是 marker——所以佔位符
+# 這一側必須自己保證**不含任何 taxonomy marker**。
+#
+# 換佔位符時務必重跑 `tests/test_outcome_taxonomy.py` 的佔位符不變式測試；
+# 注意 `<evidence-unavailable>` 這種看似安全的寫法仍會命中（`-` 不是 word
+# char，詞界照樣成立）。
+PLANNING_WORKTREE_DRIFT_EVIDENCE_PLACEHOLDER = "<not-written>"
 # 受保護的權威文件前綴：這些是 work item 的 source 文件與 cortex 自己登記在
 # `planning_authority` 內的受管產物，不論 `rollback_scope` 怎麼要求都不得被
 # rollback 動到。
@@ -647,9 +665,13 @@ def _operator_drift_message(summary: Mapping[str, object]) -> str:
 
     counts = summary.get("counts")
     counts = counts if isinstance(counts, Mapping) else {}
-    location = summary.get("report_path") or summary.get("backup_root") or "<unavailable>"
+    location = (
+        summary.get("report_path")
+        or summary.get("backup_root")
+        or PLANNING_WORKTREE_DRIFT_EVIDENCE_PLACEHOLDER
+    )
     return (
-        "planning launcher modified operator worktree; operator content preserved "
+        f"{PLANNING_WORKTREE_DRIFT_MESSAGE_PREFIX}; operator content preserved "
         f"(added={counts.get('added', 0)} modified={counts.get('modified', 0)} "
         f"removed={counts.get('removed', 0)}); evidence={location}"
     )

--- a/paulsha_cortex/coordinator/planning_runtime.py
+++ b/paulsha_cortex/coordinator/planning_runtime.py
@@ -272,9 +272,9 @@ PLANNING_WORKTREE_DRIFT_MESSAGE_PREFIX = "planning launcher modified operator wo
 # transient-service。詞界比對擋不住這一種——整個 token 就是 marker——所以佔位符
 # 這一側必須自己保證**不含任何 taxonomy marker**。
 #
-# 換佔位符時務必重跑 `tests/test_outcome_taxonomy.py` 的佔位符不變式測試；
-# 注意 `<evidence-unavailable>` 這種看似安全的寫法仍會命中（`-` 不是 word
-# char，詞界照樣成立）。
+# 換佔位符時務必重跑 `tests/test_planning_drift_classification_554.py` 的佔位符
+# 不變式測試；注意 `<evidence-unavailable>` 這種看似安全的寫法仍會命中
+# （`-` 不是 word char，詞界照樣成立）。
 PLANNING_WORKTREE_DRIFT_EVIDENCE_PLACEHOLDER = "<not-written>"
 # 受保護的權威文件前綴：這些是 work item 的 source 文件與 cortex 自己登記在
 # `planning_authority` 內的受管產物，不論 `rollback_scope` 怎麼要求都不得被

--- a/tests/test_planning_drift_classification_554.py
+++ b/tests/test_planning_drift_classification_554.py
@@ -1,0 +1,350 @@
+"""issue #554：taxonomy marker 詞界化 ＋ worktree drift 改判 environment。
+
+兩個相關缺陷共用同一組 fixture（drift 訊息），因此併在同一份測試裡：
+
+**缺陷一——`<unavailable>` 佔位符誤中 transient marker。**
+`planning_runtime._operator_drift_message` 的尾端是 `evidence={location}`，而
+`location` 的退化值原本是 `<unavailable>`；`outcome_taxonomy.
+TRANSIENT_SERVICE_MARKERS` 含裸 `"unavailable"`（#533 為 agy 的
+`UNAVAILABLE (code 503)` 而收）。於是**備份與報告雙雙寫入失敗**時，一個純環境
+事件會靠子字串巧合被判成 transient-service。這是 #500（`\\btimeout\\b` 命中
+nested tool result）／#487（`oauth` 命中 `doc-coauthoring`）的同族缺陷。
+
+修法兩邊都做，缺一不可：
+- marker 比對加詞界——擋住 marker 被埋在更長 token 裡的誤中（`workflow-1a503f`
+  裡的 `503`、`envelope_unavailable` 裡的 `unavailable`）；
+- 佔位符本身不得含 marker——詞界擋不住「整個 token 就是 marker」的相撞，
+  `<unavailable>` 與 `<evidence-unavailable>` 都會照樣命中（`<`／`>`／`-` 都不是
+  word char）。
+
+**缺陷二——worktree drift 仍歸 `content` → `recover-planning` 禁用 → 永久死鎖。**
+#543 之後 drift 的處置已改為「一個位元組都不動、只備份與報告」，語意上是環境
+事件，改判 `environment` 讓 `recover-planning` 可用。判準用穩定前綴，不得依賴
+訊息尾段——尾段已經在 #543 改過一次（`changes rolled back` →
+`operator content preserved`）。
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from paulsha_cortex.coordinator import manager, outcome_taxonomy, planning_runtime
+from paulsha_cortex.coordinator.claim import (
+    ClaimCandidate,
+    WorkAuthority,
+    _resume_decision,
+    build_claim_key,
+    load_work_authority,
+    work_authority_digest,
+)
+from paulsha_cortex.coordinator.outcome_taxonomy import matches_transient_service_markers
+from paulsha_cortex.coordinator.planning_runtime import _operator_drift_message
+
+# `run_heterogeneous_brainstorm` 對 launcher 例外的包裝格式（planning.py 四個
+# `except` 分支共用）：`<stage>-<kind>: <ExceptionTypeName>: <str(exc)[:160]>`。
+_WRAP = "primary-integration-malformed: ValueError: "
+
+# #543 之前的 drift 訊息尾段。留在測試裡是為了釘住「判準不依賴尾段」——這串字
+# 已經被改過一次，再改一次也必須照樣分類正確。
+_LEGACY_DRIFT_MESSAGE = (
+    "planning launcher modified operator worktree; changes rolled back "
+    "(added=1 modified=0 removed=0); evidence=/tmp/psc/report.json"
+)
+
+
+def _drift_message(*, report_path: str | None = None, backup_root: str | None = None) -> str:
+    return _operator_drift_message(
+        {
+            "counts": {"added": 1, "modified": 2, "removed": 0},
+            "report_path": report_path,
+            "backup_root": backup_root,
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# 缺陷一：佔位符不得含 taxonomy marker
+# ---------------------------------------------------------------------------
+
+
+def test_degraded_drift_message_is_not_a_transient_service_failure() -> None:
+    """備份與報告都寫不出去時，drift 仍然不是 transient-service（修法前為 True）。"""
+
+    message = _drift_message()
+    assert planning_runtime.PLANNING_WORKTREE_DRIFT_EVIDENCE_PLACEHOLDER in message
+    assert matches_transient_service_markers(_WRAP + message) is False
+
+
+def test_the_old_placeholder_is_the_documented_collision() -> None:
+    """釘住缺陷本體：舊佔位符確實會命中 marker，所以它非換不可。"""
+
+    assert matches_transient_service_markers("evidence=<unavailable>") is True
+    # 連 issue 裡順手提到的 `<evidence-unavailable>` 也一樣會撞——`-` 不是 word
+    # char，詞界照樣成立。這條是給未來改佔位符的人看的。
+    assert matches_transient_service_markers("evidence=<evidence-unavailable>") is True
+
+
+def test_drift_evidence_placeholder_contains_no_marker() -> None:
+    """佔位符不變式：任何 taxonomy marker 都不得在佔位符內成立詞界命中。"""
+
+    placeholder = planning_runtime.PLANNING_WORKTREE_DRIFT_EVIDENCE_PLACEHOLDER
+    assert matches_transient_service_markers(placeholder) is False
+    assert matches_transient_service_markers(f"evidence={placeholder}") is False
+
+
+def test_normal_drift_message_with_real_evidence_path_stays_clean() -> None:
+    message = _drift_message(report_path="/tmp/psc-report.json")
+    assert "evidence=/tmp/psc-report.json" in message
+    assert matches_transient_service_markers(_WRAP + message) is False
+
+
+# ---------------------------------------------------------------------------
+# 缺陷一：全表詞界不變式（同型風險掃描的可執行版本）
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("marker", outcome_taxonomy.TRANSIENT_SERVICE_MARKERS)
+def test_every_marker_needs_word_boundaries(marker: str) -> None:
+    """全表掃描：**每一個** marker 埋進更長的 word token 裡都不得命中。
+
+    修法前 `"503"`／`"429"` 這種裸短字串對長訊息的誤中面極大——run id、
+    content-addressed digest、evidence 路徑裡出現三個數字是家常便飯。
+    """
+
+    assert matches_transient_service_markers(f"prefix{marker}suffix") is False
+    assert matches_transient_service_markers(f"9{marker}9") is False
+    assert matches_transient_service_markers(f"x_{marker}_x") is False
+    # 反面：獨立成詞時仍必須命中，詞界化不得把真訊號一起關掉。
+    assert matches_transient_service_markers(f"launcher said: {marker} — retry later") is True
+
+
+def test_short_numeric_markers_no_longer_hit_ids_and_paths() -> None:
+    """實際誤中面：run id／digest／evidence 路徑裡的數字片段。"""
+
+    assert (
+        matches_transient_service_markers(
+            _WRAP
+            + "planning launcher modified operator worktree; operator content preserved "
+            "(added=1 modified=0 removed=0); evidence=/tmp/x/workflow-1a503f0429ab/report.json"
+        )
+        is False
+    )
+    assert matches_transient_service_markers("run_id=workflow-88d089d7429654a75503") is False
+    # 真的 HTTP status 仍要命中。
+    assert matches_transient_service_markers("Eligibility check failed: UNAVAILABLE (code 503)") is True
+    assert matches_transient_service_markers("HTTP/1.1 429 Too Many Requests") is True
+
+
+def test_internal_snake_case_reason_values_no_longer_hit_unavailable() -> None:
+    """`envelope_unavailable`／`provider_unavailable` 是內部欄位值，不是服務錯誤。"""
+
+    assert matches_transient_service_markers("bypass=envelope_unavailable") is False
+    assert matches_transient_service_markers("preflight=provider_unavailable") is False
+    # `service_unavailable` 自己在表上，仍命中。
+    assert matches_transient_service_markers('{"code": "service_unavailable"}') is True
+
+
+@pytest.mark.parametrize(
+    "reason",
+    [
+        # 詞界化前靠子字串巧合命中的真陽性；改為顯式列舉後必須照樣命中。
+        "provider says the account is rate limited until 03:00",
+        "rate limiting in effect",
+        "two rate limits tripped",
+        "primary-integration-malformed: TimeoutExpired: Command '['claude', '--model', "
+        "'claude-opus-4', '--print', '--output-format', 'json', '--add-dir', '/tmp/psc-xxxx",
+        "primary-integration-malformed: TimeoutError: connection lost",
+        "secondary-output-malformed: ValueError: ServiceUnavailable",
+    ],
+)
+def test_boundary_fix_keeps_the_true_positives(reason: str) -> None:
+    assert matches_transient_service_markers(reason) is True
+
+
+def test_shared_marker_table_stays_the_single_source() -> None:
+    """#533 的別名不得在本次修改中漂開（`test_outcome_taxonomy` 的同一條約束）。"""
+
+    assert manager._PLANNING_TRANSIENT_SERVICE_MARKERS is outcome_taxonomy.TRANSIENT_SERVICE_MARKERS
+
+
+# ---------------------------------------------------------------------------
+# 缺陷二：drift 判準用穩定前綴，分類落 environment
+# ---------------------------------------------------------------------------
+
+
+def test_drift_predicate_matches_both_message_generations() -> None:
+    """新舊兩種訊息字串都要被認出來——尾段已在 #543 改過一次。"""
+
+    current = _WRAP + _drift_message(report_path="/tmp/psc-report.json")
+    legacy = _WRAP + _LEGACY_DRIFT_MESSAGE
+
+    assert manager._is_planning_worktree_drift_failure(current) is True
+    assert manager._is_planning_worktree_drift_failure(legacy) is True
+    # 連退化到佔位符的那一版也要認得。
+    assert manager._is_planning_worktree_drift_failure(_WRAP + _drift_message()) is True
+
+
+def test_drift_predicate_rejects_the_sandbox_family() -> None:
+    """拋棄式沙箱被寫壞是 launcher 行為異常，不是環境事件——維持 `content`。"""
+
+    sandbox = _WRAP + "planning launcher modified disposable read-only sandbox"
+    assert manager._is_planning_worktree_drift_failure(sandbox) is False
+    assert manager._classify_planning_failure(sandbox) == "content"
+
+
+@pytest.mark.parametrize(
+    "reason",
+    [
+        None,
+        "brainstorm-not-ready",
+        "primary-integration-malformed: ValueError: planning launcher result is not "
+        "JSON: 我認為這個問題應該從三個面向來分析",
+    ],
+)
+def test_drift_predicate_does_not_touch_other_reasons(reason: str | None) -> None:
+    assert manager._is_planning_worktree_drift_failure(reason) is False
+    assert manager._classify_planning_failure(reason) == "content"
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        _LEGACY_DRIFT_MESSAGE,
+        "planning launcher modified operator worktree; operator content preserved "
+        "(added=1 modified=2 removed=0); evidence=/tmp/psc/report.json",
+        "planning launcher modified operator worktree; operator content preserved "
+        "(added=0 modified=0 removed=0); evidence=<not-written>",
+    ],
+)
+def test_drift_classifies_as_environment(message: str) -> None:
+    assert manager._classify_planning_failure(_WRAP + message) == "environment"
+
+
+def test_prefix_constant_is_actually_the_message_prefix() -> None:
+    """常數與訊息不得漂開——判準整個建立在這條上。"""
+
+    assert _drift_message().startswith(planning_runtime.PLANNING_WORKTREE_DRIFT_MESSAGE_PREFIX)
+    assert _LEGACY_DRIFT_MESSAGE.startswith(
+        planning_runtime.PLANNING_WORKTREE_DRIFT_MESSAGE_PREFIX
+    )
+    assert manager._PLANNING_WORKTREE_DRIFT_MARKER == (
+        planning_runtime.PLANNING_WORKTREE_DRIFT_MESSAGE_PREFIX
+    )
+
+
+# ---------------------------------------------------------------------------
+# 缺陷二：recover-planning 對 drift 案例可用（`_resume_decision` 的 next_actions）
+# ---------------------------------------------------------------------------
+
+
+def _snapshot(path: Path) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "schema": "work-items-snapshot/v1",
+                "providers": {
+                    "github": {
+                        "provider_id": "github",
+                        "revision": "gh-1",
+                        "last_success_epoch": 100,
+                        "degraded": False,
+                    }
+                },
+                "work_items": [
+                    {
+                        "repo": "acme/demo",
+                        "work_id": "demo",
+                        "mapped_issues": [12],
+                        "mapped_prs": [8],
+                        "mapped_openspec": ["demo"],
+                        "mapped_todo_paths": ["docs/todo.md"],
+                        "confirmed_todo": True,
+                        "auto_label": True,
+                        "source_revisions": ["issue:12@open", "openspec:demo@1"],
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _authority(tmp_path: Path) -> WorkAuthority:
+    return load_work_authority(
+        repo="acme/demo",
+        work_id="demo",
+        snapshot_path=_snapshot(tmp_path / "snapshot.json"),
+    )
+
+
+def _needs_human_candidate(tmp_path: Path, *, reason: str) -> ClaimCandidate:
+    authority = _authority(tmp_path)
+    base = ClaimCandidate(
+        authority=authority,
+        repo="acme/demo",
+        work_id="demo",
+        source_revisions=authority.source_revisions,
+        confirmed_todo=authority.confirmed_todo,
+        confirmed_issue=12,
+        auto_label=False,
+        active_run_id=None,
+        active_claim_key=None,
+    )
+    return replace(
+        base,
+        active_run_id="workflow-" + "a" * 20,
+        active_claim_key=build_claim_key(base),
+        active_status="needs_human",
+        active_snapshot_hash=authority.snapshot_hash,
+        active_source_revisions=authority.source_revisions,
+        active_provider_revision=authority.github_provider_revision,
+        active_authority_digest=work_authority_digest(authority),
+        active_phase="define",
+        # 分類刻意由**產品判準**算出來，測試不自己填答案——這條就是把
+        # 「drift → environment」與「environment → recover-planning」綁在一起。
+        active_planning_failure_classification=manager._classify_planning_failure(reason),
+        active_planning_failure_reason=reason,
+    )
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        _LEGACY_DRIFT_MESSAGE,
+        "planning launcher modified operator worktree; operator content preserved "
+        "(added=1 modified=0 removed=0); evidence=/tmp/psc/report.json",
+        "planning launcher modified operator worktree; operator content preserved "
+        "(added=1 modified=0 removed=0); evidence=<not-written>",
+    ],
+)
+def test_recover_planning_is_available_for_drift(tmp_path: Path, message: str) -> None:
+    """drift 卡在 define 時，唯一出口不再只有 abandon。"""
+
+    reason = _WRAP + message
+    decision = _resume_decision(_needs_human_candidate(tmp_path, reason=reason))
+
+    assert decision.action == "needs_human"
+    assert decision.next_actions == ("recover-planning", "abandon")
+    assert decision.blocking_reason == f"planning-failure:environment:{reason}"
+
+
+def test_content_failures_still_only_offer_abandon(tmp_path: Path) -> None:
+    """#393 的 fail-closed 一字未動：內容缺陷仍不得由本路徑繞過。"""
+
+    reason = _WRAP + "planning launcher result is not JSON: 我先說明一下我的規劃方向"
+    decision = _resume_decision(_needs_human_candidate(tmp_path, reason=reason))
+
+    assert decision.next_actions == ("abandon",)
+
+
+def test_drift_reason_stays_single_line_for_recover_planning(tmp_path: Path) -> None:
+    """`recover-planning` 拒收含換行的 failure_reason——drift 訊息必須單行。"""
+
+    assert "\n" not in _drift_message()
+    assert "\n" not in _drift_message(report_path="/tmp/psc/report.json")


### PR DESCRIPTION
## 摘要

一次修 issue #554 的兩個相關缺陷。兩者共用同一組現場（planning worktree drift 的失敗訊息），因此併在同一個 PR、共用同一份測試 fixture。

## 缺陷一：`<unavailable>` 佔位符誤中 transient marker

`planning_runtime._operator_drift_message` 的尾端是 `evidence={location}`，而 `location = report_path or backup_root or "<unavailable>"`；PR #542 落地的 `outcome_taxonomy.TRANSIENT_SERVICE_MARKERS` 含**裸** `"unavailable"`（#533 為 agy 的 `UNAVAILABLE (code 503)` 而收），比對是無界子字串。於是「drift **且**備份／報告雙雙寫入失敗」這個純環境事件，會靠子字串巧合被判成 transient-service：

| evidence 值 | 修法前 `matches_transient_service_markers` |
| --- | --- |
| `evidence=/tmp/psc-report.json` | False（正常） |
| `evidence=<unavailable>` | **True（誤判）** |

這是 #500（`\btimeout\b` 命中 nested tool result 的 `Parser aborted (timeout, ...)`）、#487（`oauth` 命中技能名 `doc-coauthoring`）的同族無界 token 缺陷，第三次命中。

**兩邊都修，缺一不可：**

1. **marker 比對加詞界**——新增 `outcome_taxonomy.TRANSIENT_SERVICE_MARKER_RE`（`\b(?:…)\b`，IGNORECASE），`matches_transient_service_markers` 改用它。
2. **佔位符不得含 marker**——新增 `planning_runtime.PLANNING_WORKTREE_DRIFT_EVIDENCE_PLACEHOLDER = "<not-written>"`，並附不變式測試。

第 2 點不是保險而是必要：詞界擋不住「整個 token 就是 marker」。`<unavailable>` 的 `<`／`>` 都不是 word char，詞界照樣成立；issue 順手提到的 `<evidence-unavailable>` 同理（`-` 也不是 word char）。這一點寫進了常數旁的註解與測試，避免下一個人再踩。

### 全表同型風險掃描

| marker | 修法前的誤中面 | 詞界化後 |
| --- | --- | --- |
| `"503"` / `"429"` | **最大**。run id、content-addressed digest、evidence 路徑裡出現三個數字是家常便飯——`workflow-1a503f0429ab` 修法前直接被判 transient | 只認獨立成詞的 `code 503`、`HTTP/1.1 429` |
| `"unavailable"` | 次之。`envelope_unavailable`、`provider_unavailable` 這類與服務層無關的內部欄位值 | `_` 是 word char，不再命中；`service_unavailable` 自己在表上仍命中 |
| `"timeout"` | `timeouts`、`TimeoutExpired`、`TimeoutError` | 見下方「顯式列舉」 |
| `"rate limit"` | 涵蓋 `rate limited` 等屈折變體 | 見下方「顯式列舉」 |
| 其餘（`too many requests`、`connection reset`、`eligibility check failed`…） | 長片語，無誤中面 | 行為不變 |

另外掃過的三張表，判定不需動：`INTERRUPTION_MARKERS`（`aborted_streaming`、`request interrupted by user` — 長片語或 snake_case 整串 token）、`KNOWN_PROCESS_BANNERS`（本來就要求精確字面相等）、`manager._PLANNING_AUTHORITY_RESIDUE_MARKERS`（兩條完整句子，且另有 `startswith` 前綴把關）。

### 詞界化的代價：真陽性變體改為顯式列舉

詞界化會讓「原本靠子字串巧合命中的真陽性」落空。那些是真訊號，因此逐一列進表：`rate limits` / `rate limited` / `rate limiting`（provider 訊息實測三種都出現）、`timeouts`、`timeouterror` / `timeoutexpired`、`serviceunavailable`。

其中 CamelCase 例外類名特別關鍵。planning lane 的 reason 格式是 `<stage>-<kind>: <ExceptionTypeName>: <str(exc)[:160]>`，而 `subprocess.TimeoutExpired` 的訊息（`Command '[...]' timed out after N seconds`）常因 argv 過長而在 160 字截斷處被切掉 `timed out`——此時**只剩型別名帶得動訊號**。表變長是刻意的：寧可每個變體都看得見，也不要再靠子字串巧合。

## 缺陷二：worktree drift 改判 `environment`（照 operator 裁決）

#507 前 drift 的處置是把 operator worktree 整棵抹除再從 baseline 還原——那確實會銷毀資料，歸 `content`（fail-closed、不給 `recover-planning`）在當時是合理的保守。#543 之後處置已改為「一個位元組都不動、只備份與報告」，drift 於是變成純粹的環境事件：本次 planning 結果不可信，但沒有任何東西被破壞，重跑就好。維持 `content` 只會讓唯一出口是 `abandon`（燒一個世代），即 #507 comment 2 記錄、#543 明文留待後續的死鎖。

新增 `manager._is_planning_worktree_drift_failure`，判準只認 `planning_runtime` 新匯出的**穩定前綴**：

```python
PLANNING_WORKTREE_DRIFT_MESSAGE_PREFIX = "planning launcher modified operator worktree"
```

不依賴訊息尾段——尾段已經在 #543 改過一次（`changes rolled back` → `operator content preserved`），計數與 evidence 路徑更是每次都不同。測試對**新舊兩代訊息字串**都斷言分類正確。

判準刻意窄：同一段 `finally` 另有的 `planning launcher modified disposable read-only sandbox`（launcher 寫壞拋棄式沙箱，屬 launcher 行為異常而非環境並行編輯）不在此列，維持 `content`。

順帶把 `_run_define_stage` 中段的三元表達式抽成具名的 `manager._classify_planning_failure(reason) -> "environment" | "content"`，讓「reason → classification」這條映射有單一可測入口（過去它只活在函式中段，測不到也看不見），三個 `environment` 例外（#416 authority 殘留、#533 暫時性服務、#554 drift）在同一處列齊。

## 範圍紀律

只動分類與 marker 精度。`recover-planning` 自身的 admission、CAS、fail-closed 條件**一字未改**——本次只是讓 drift 案例走得到它。`_resume_decision` 的邏輯亦未動，測試以產品判準（`_classify_planning_failure`）算出 classification 再餵進去，把「drift → environment」與「environment → recover-planning」兩段綁在一起驗。

## 變更檔案

- `paulsha_cortex/coordinator/outcome_taxonomy.py` — 詞界 pattern、marker 表補真陽性變體
- `paulsha_cortex/coordinator/planning_runtime.py` — 穩定前綴常數、佔位符常數（`<not-written>`）
- `paulsha_cortex/coordinator/manager.py` — drift 判準、`_classify_planning_failure`
- `tests/test_planning_drift_classification_554.py` — 新增 47 個回歸測試
- `CHANGELOG.md` / `changelog.d/marker-word-boundary.md`

## 測試

- `python3 -m pytest tests/test_planning_drift_classification_554.py -q` → 47 passed
- `python3 -m pytest -q`（全套）→ **2743 passed, 49 subtests passed**

## Checklist

- [x] `changelog.d/marker-word-boundary.md` fragment 已新增且已 commit
- [x] `CHANGELOG.md [Unreleased]` 有對應 entry
- [x] `VERSION` 與意圖一致（非 release PR，未動）
- [x] 全套測試通過
- [x] 分支非 `main`，命名符合 `feature/<slug>`

`policy-exempt:issue-link`：本 PR 只引用不關閉 #554（#554 尚有 operator 後續裁決面），故用 `Refs` 而非 closing keyword。

Refs #554 #533 #507
