### PR TITLE
perf(monitor): 以本機 git 取代 REST contents 與 compare 讀取

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@
 
 ## [Unreleased]
 
+### Changed
+- **Issue #506 / D2：git 的資料走 git——monitor 對 GitHub REST 的兩類高量讀取改為本機
+  git 操作，一輪掃描的 REST `contents`／`compare` 呼叫數固定為 0**——
+  `GitHubTerminalProvider` 過去每個 remote `todo.md`／archived `tasks.md` 各打一次
+  `repos/{repo}/contents/...`（實測生產 workspace 一輪 **91 次**），每個
+  workflow-linked merged PR 各打一次 `repos/{repo}/compare/{merge}...{default}`；讀的
+  全是本機 git checkout 本來就有的東西，而 git 協定（fetch）不受 REST rate limit
+  管轄。新增 `paulsha_cortex/monitor/git_mirror.py`（`LocalGitMirror`）作為唯一入口：
+  blob 一律以 REST tree 給的 blob sha 定址、整批一次 `git cat-file --batch` 讀完
+  （sha 定址本身就是內容識別，取代舊 `contents` 路徑的 type／path／sha／encoding
+  四項比對）；ancestry 改用 `git merge-base --is-ancestor`，判準與 `compare` 的
+  `status in {ahead, identical}` 等價。一輪先做一次 `cat-file --batch-check` 批次
+  查缺，**有缺才** fetch（因此 fetch 頻率沿用既有 refresh 週期），refspec 帶
+  `--refmap=` 並寫進私有 namespace `refs/cortex/mirror/<hash>/*`，不動
+  `refs/remotes/origin/*`、工作區與任何本地分支；merge commit 不在本機的 PR 會把
+  `refs/pull/<n>/head` 一併掛進同一次 fetch（該 refspec 屬選配，remote 沒有它時退回
+  只 fetch default branch）。身分先驗讀 raw `remote.origin.url`（不套
+  `url.*.insteadOf` 改寫）確認 checkout 真的追著宣稱的 repo。**fail closed**：ref
+  不存在、fetch 失敗、blob 讀不到、沒有本機 checkout、origin 指向別的 repo、shallow
+  checkout 無法判 ancestry——一律 degraded 並由 `_retain_last_good` 保留上一份鏡像，
+  絕不把讀取失敗靜默降級成「檔案不存在」或「不是 ancestor」；provenance 落在
+  `observations["remote_reads"]`。`work_api` 把該 repo 在 workspace 的 canonical
+  checkout（與 `RepoWorkProvider` 同一個 root）傳給 provider。只動讀取路徑，寫入與
+  D3 的 `state=all&since=`＋ETag 增量不在本次；`coordinator/github_delivery.py` 的
+  `fetch_remote_closure`（每次 PR closure 1 次 compare ＋ N 次 contents，不在掃描
+  迴圈內）僅盤點未遷移。詳見 `changelog.d/d2-git-native-reads.md`。新增
+  `tests/test_monitor_git_native_reads_506.py`（16 個測試，含量化驗收樁）。
+
 ### Fixed
 - **Issue #536（後半）：planning artifacts 發佈與 run 狀態更新不是同一事務，中間態對
   所有恢復迴圈永久隱形**——define 的 brainstorm 有兩次分離的 durable 寫入：先發佈

--- a/changelog.d/d2-git-native-reads.md
+++ b/changelog.d/d2-git-native-reads.md
@@ -1,0 +1,76 @@
+# D2：git 的資料走 git——monitor 的 remote 讀取移出 GitHub REST
+
+## 問題
+
+`GitHubTerminalProvider` 一輪掃描對 GitHub REST 發出兩類「每個……一次」的讀取，
+讀的全是本機 git checkout 本來就有（或 `git fetch` 一次就有）的東西：
+
+- **`contents`**：每個 remote `todo.md` / archived `tasks.md` 各一次。實測生產
+  workspace 一輪 **91 次**。
+- **`compare`**：每個 workflow-linked merged PR 各一次，判的是「merge commit 還在
+  不在 default branch 上」，也就是一次 ancestry。
+
+REST 有 primary／secondary rate limit；git 協定（fetch/clone）不受它管轄。
+0813–0815 三度進 REST 懲罰窗，這兩類是主要配額消耗之一。
+
+## 改法
+
+新增 `paulsha_cortex/monitor/git_mirror.py`（`LocalGitMirror`），是「本機 git 當成
+遠端事實來源」的唯一入口：
+
+- **contents → `git cat-file --batch`**：blob 一律用 REST tree 給的 blob sha 定址
+  讀取，整批一次讀完（不是每檔一個 process）。sha 定址本身就是內容識別，取代舊
+  `contents` 路徑的 `type`／`path`／`sha`／`encoding` 四項比對。
+- **compare → `git merge-base --is-ancestor`**：判準與 REST `compare` 的
+  `status in {ahead, identical}` 等價。
+- **一輪最多一次 fetch**：先一次 `cat-file --batch-check` 批次查缺，有缺才 fetch；
+  refspec 帶 `--refmap=` 並寫進私有 namespace `refs/cortex/mirror/<hash>/*`，
+  **不動** `refs/remotes/origin/*`、工作區與任何本地分支。merge commit 不在本機的
+  PR 會把 `refs/pull/<n>/head` 一併掛進同一次 fetch。fetch 頻率因此沿用 monitor
+  既有的 refresh 週期。
+- **身分先驗**：`git config --get remote.origin.url`（讀 raw config，不套
+  `url.*.insteadOf` 改寫）必須解析成同一個 `owner/name`，否則 fail closed——monitor
+  掃的 workspace 目錄不保證是我們以為的那個 repo。
+
+## fail closed
+
+ref 不存在、fetch 失敗、blob 讀不到、沒有本機 checkout、origin 指向別的 repo、
+shallow checkout 無法判 ancestry——一律 raise `GitMirrorError`（繼承 `OSError`，
+即使日後有人漏接也只會退回既有的通用診斷），provider 轉成 degraded 快照、上層
+`_retain_last_good` 保留上一份鏡像。**絕不**把讀取失敗靜默降級成「檔案不存在」
+或「不是 ancestor」。
+
+唯一的例外是「default branch 已在本機、repo 非 shallow，而 merge commit 仍不在
+本機」——在 git 的可達性語意下這就是「不是 ancestor」的定義（等同 REST `compare`
+回 `behind`／`diverged` 的那一格），不是讀取失敗。shallow 破壞這個前提，因此
+shallow + 缺物件一律 fail closed。
+
+## 語意差異（行為等價的邊界）
+
+1. **`remote Todo content identity mismatch` 這個失敗模式消失了**——sha 定址下
+   內容不可能對不上。取而代之的是「物件不在本機」，兩者都 degraded。
+2. **REST `contents` 對不存在的路徑回 404，git 是「物件不存在」**——但這條路徑
+   本來就只讀 tree 已經列出的 blob，兩邊都不會走到「路徑不存在」。
+3. **ancestry 判的是 merge commit，不是 PR head**——與舊 `compare` 的 base 一致。
+   `refs/pull/<n>/head` 只在 merge commit 缺席時一併 fetch，且屬選配：remote 沒有
+   該 ref 時退回只 fetch default branch，不讓一條選配 refspec 把整輪打成 degraded。
+4. **REST tree 截斷檢查仍在 REST 端**：`git/trees?recursive=1` 這 1 次／輪的呼叫
+   不在本次範圍（不屬 contents／compare 兩類）。
+
+## 量化
+
+`tests/test_monitor_git_native_reads_506.py::test_scan_round_issues_zero_rest_contents_and_compare_calls`
+把「一輪掃描的 REST contents/compare 呼叫數」釘死在 0：12 個 todo ＋ 3 個 merged PR
+的那一輪，改動前是 12 次 `contents` ＋ 3 次 `compare`；改動後整輪 REST 只剩 2 次
+（graphql ＋ git tree）。生產基準：91+/輪 → 0。
+
+provenance 落在 `github-terminal:` provider 的 `observations["remote_reads"]`
+（transport／checkout 路徑／本輪 fetch 的 refspec／缺席物件／blob 讀取數／ancestry
+判定數）。
+
+## 範圍
+
+只動讀取路徑。寫入（issue/PR/label mutation）不在本次；`state=all&since=`＋ETag
+增量（D3）是另一個工項。`coordinator/github_delivery.py` 的 `fetch_remote_closure`
+也有一組 `contents`／`compare`（每次 PR closure 各 1＋N 次，不在掃描迴圈內），
+本次僅盤點未遷移。

--- a/docs/monitor-config.md
+++ b/docs/monitor-config.md
@@ -18,10 +18,12 @@
 ## GitHub 掃描壓力設定（#506）
 
 `_github_refresh_loop` 每 `github_refresh_interval_seconds` 會對每個 GitHub repo
-跑一次 `GitHubWorkProvider` 與 `GitHubTerminalProvider`，兩者的 `gh` 呼叫數是
-O(issues 分頁 + remote todo 檔數 + workflow-linked merged PR 數) 而非 O(1)。
-repo 一多，一輪數百次請求齊發就會觸發 GitHub 的 secondary（abuse detection）
-rate limit，兩個 provider 一起 degraded，連帶擋掉 `cortex work` 的 claim。
+跑一次 `GitHubWorkProvider` 與 `GitHubTerminalProvider`。repo 一多，一輪數百次
+請求齊發就會觸發 GitHub 的 secondary（abuse detection）rate limit，兩個 provider
+一起 degraded，連帶擋掉 `cortex work` 的 claim。
+
+D2 之後（見下節）`GitHubTerminalProvider` 的 REST 呼叫數已降為每輪固定 2 次
+（graphql PR 分頁 ＋ 1 次 git tree）；`GitHubWorkProvider` 仍是 O(issues 分頁)。
 
 `monitor:` 區段新增下列鍵（全部可省略，預設值即保守值）：
 
@@ -47,3 +49,32 @@ rate limit，兩個 provider 一起 degraded，連帶擋掉 `cortex work` 的 cl
 `coordinator/claim.py` 的 `provider-authority-rate-limited-canonical` 行為不變。
 退避期間 provider 的 `scan()` 直接跳過、不發任何請求；退避窗綁的是 token
 （帳號層級）而非單一 repo，因為 GitHub 的 secondary limit 本來就綁 token。
+
+## git 的資料走 git：remote 讀取不吃 REST 配額（#506 / D2）
+
+`GitHubTerminalProvider` 過去有兩類「每個……一次」的 REST 讀取，讀的都是本機
+git checkout 本來就有的東西：
+
+- 每個 remote `todo.md` / archived `tasks.md` 一次 `repos/{repo}/contents/...`
+  （實測生產 workspace 一輪 **91 次**）
+- 每個 workflow-linked merged PR 一次 `repos/{repo}/compare/{merge}...{default}`
+  （判「merge commit 還在不在 default branch 上」）
+
+兩者已改由 `paulsha_cortex.monitor.git_mirror.LocalGitMirror` 以本機 git 回答，
+**一輪的 REST `contents` / `compare` 呼叫數固定為 0**。git 協定（fetch）不受
+REST rate limit 管轄。
+
+- **讀哪個 checkout**：`work_api` 把該 repo 在 workspace 的 canonical checkout
+  （與 `RepoWorkProvider` 同一個 root）傳給 provider。
+- **身分驗證**：`git config --get remote.origin.url` 必須解析成同一個
+  `owner/name`（讀 raw config，不套 `url.*.insteadOf` 改寫），否則 fail closed。
+- **fetch 頻率**：沿用既有 refresh 週期——一輪最多 fetch 一次，而且只在本機真的
+  缺物件時才 fetch。refspec 一律寫進私有 namespace `refs/cortex/mirror/<hash>/*`
+  並帶 `--refmap=`，不動 `refs/remotes/origin/*`、工作區與任何本地分支。
+- **fail closed**：ref 不存在、fetch 失敗、blob 讀不到、shallow checkout 無法判
+  ancestry——一律 degraded（diagnostic 前綴 `github terminal git mirror
+  unavailable:`），由 `_retain_last_good` 保留上一份鏡像，**絕不**把讀不到當成
+  「檔案不存在」或「不是 ancestor」。
+- **provenance**：`github-terminal:` provider 的 observations 多一個 `remote_reads`
+  欄位，記 transport、checkout 路徑、本輪 fetch 的 refspec、缺席物件、blob 讀取數
+  與 ancestry 判定數。

--- a/paulsha_cortex/monitor/git_mirror.py
+++ b/paulsha_cortex/monitor/git_mirror.py
@@ -1,0 +1,383 @@
+"""#506 / D2：git 的資料走 git——把 repo 檔案讀取與 ancestry 判定移出 REST。
+
+## 問題
+
+``GitHubTerminalProvider`` 一輪掃描對 GitHub REST 發出的兩類請求，讀的全是本機
+git checkout 裡本來就有（或 ``git fetch`` 一次就有）的東西：
+
+- **``contents``**：每個 remote ``todo.md`` / archived ``tasks.md`` 各一次，實測一輪
+  91 次——讀的是 default branch 上某個 blob 的內容。
+- **``compare``**：每個 workflow-linked merged PR 各一次——判的是「merge commit 還在
+  不在 default branch 上」，也就是一次 ancestry。
+
+REST 有 primary／secondary rate limit；git 協定（fetch）不受它管轄。0813–0815 三度
+進 REST 懲罰窗，這兩類是主要配額消耗之一。
+
+## 本模組的契約
+
+``LocalGitMirror`` 是「本機 git 當成遠端事實來源」的唯一入口：
+
+1. **身分先驗**：``origin`` 必須真的指向宣稱的 ``owner/name``，否則 fail closed。
+   monitor 掃的 workspace 目錄不保證是我們以為的那個 repo。
+2. **sha 定址**：blob 一律用 REST tree 給的 blob sha 讀（``git cat-file --batch``），
+   不用 path 讀。內容識別由 sha 本身保證，取代舊的
+   ``remote Todo content identity mismatch`` 檢查。
+3. **一輪最多一次 fetch**：``require()`` 先批次查缺（一次 ``--batch-check``），有缺才
+   fetch，refspec 目的地一律落在私有 namespace ``refs/cortex/mirror/<hash>/*``，
+   並以 ``--refmap=`` 關掉 configured refspec 的順帶更新，**不動**
+   ``refs/remotes/origin/*``、工作區與使用者的任何分支。fetch 頻率因此沿用 monitor
+   既有的 refresh 週期。
+4. **fail closed**：ref 不存在、fetch 失敗、物件讀不到、shallow checkout 無法判
+   ancestry——一律 raise :class:`GitMirrorError`，由 provider 轉成 degraded 快照、
+   上層 ``_retain_last_good`` 保留上一份鏡像。**絕不**把讀不到靜默當成「檔案不存在」
+   或「不是 ancestor」。唯一的例外是「default branch 已在本機、repo 非 shallow，而
+   merge commit 仍不在本機」——這在 git 的可達性語意下就是「不是 ancestor」的定義，
+   不是讀取失敗（見 :meth:`LocalGitMirror.is_ancestor`）。
+
+:class:`GitMirrorError` 刻意繼承 ``OSError``，即使日後有人漏接這個新型別，
+``GitHubTerminalProvider.scan()`` 既有的 catch-all 仍然接得住，只會退回通用診斷而不會
+讓例外逸出 provider。
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+import subprocess
+from pathlib import Path
+from typing import Mapping, Protocol, Sequence
+
+
+# 與 ``monitor/work_api.py`` 的 ``_repo_identity`` 共用同一組樣式（該檔 import 本檔），
+# 避免「provider 認定是 GitHub repo、mirror 卻認不出 origin」的分歧。
+GITHUB_SSH_REMOTE = re.compile(
+    r"^(?:ssh://)?git@github\.com[:/](?P<repo>[^/]+/[^/]+?)(?:\.git)?$"
+)
+GITHUB_HTTPS_REMOTE = re.compile(
+    r"^https?://github\.com/(?P<repo>[^/]+/[^/]+?)(?:\.git)?/?$"
+)
+
+_OBJECT_ID = re.compile(r"[0-9a-fA-F]{40}")
+# git ref component 的保守子集：不接受前導 ``-``（避免被當成 git 旗標）、``..``、
+# ``.lock`` 結尾與空白。default branch 名稱來自 GraphQL，仍當成不可信輸入處理。
+_SAFE_BRANCH = re.compile(r"[A-Za-z0-9_][A-Za-z0-9._/-]*")
+
+# ``relevant_pr_numbers=None`` 時 candidate 可能是整個 repo 的 merged PR。PR head
+# refspec 只是選配（見 ``_fetch``），不值得為它把 fetch 撐爆。
+_PULL_REF_LIMIT = 64
+
+
+class GitMirrorError(OSError):
+    """本機 git 鏡像不可用；呼叫端一律 fail closed。"""
+
+
+class GitRunner(Protocol):
+    def run(
+        self,
+        argv: Sequence[str],
+        *,
+        timeout: float,
+        stdin: bytes | None = None,
+    ) -> subprocess.CompletedProcess[bytes]: ...
+
+
+class SubprocessGitRunner:
+    """git 一律以 bytes 收；blob 內容的 utf-8 解碼由呼叫端顯式負責。"""
+
+    def run(
+        self,
+        argv: Sequence[str],
+        *,
+        timeout: float,
+        stdin: bytes | None = None,
+    ) -> subprocess.CompletedProcess[bytes]:
+        return subprocess.run(
+            list(argv),
+            check=False,
+            capture_output=True,
+            input=b"" if stdin is None else stdin,
+            timeout=timeout,
+        )
+
+
+def _validate_object_ids(values: Sequence[str]) -> tuple[str, ...]:
+    ordered = tuple(dict.fromkeys(values))
+    for value in ordered:
+        if not isinstance(value, str) or _OBJECT_ID.fullmatch(value) is None:
+            raise GitMirrorError("git mirror object id is invalid")
+    return tuple(value.lower() for value in ordered)
+
+
+class LocalGitMirror:
+    """以本機 git objects 回答「default branch 上的檔案內容／ancestry」。"""
+
+    def __init__(
+        self,
+        repo_root: str | Path,
+        *,
+        repo: str,
+        runner: GitRunner | None = None,
+        timeout_seconds: float = 30.0,
+    ) -> None:
+        self.repo_root = Path(repo_root)
+        self.repo = repo
+        self.runner = runner or SubprocessGitRunner()
+        self.timeout_seconds = float(timeout_seconds)
+        # 私有 namespace 以 repo slug 的 hash 命名：永遠是合法 ref component，
+        # 且兩個 repo 不會互撞。
+        self._namespace = (
+            "refs/cortex/mirror/"
+            + hashlib.sha256(repo.encode("utf-8")).hexdigest()[:16]
+        )
+        self._verified = False
+        self._fetched_refs: tuple[str, ...] = ()
+        self._absent: frozenset[str] = frozenset()
+        self._blob_reads = 0
+        self._ancestry_checks = 0
+
+    # -- 基礎設施 ---------------------------------------------------------
+
+    def _run(
+        self,
+        args: Sequence[str],
+        *,
+        stdin: bytes | None = None,
+        ok: tuple[int, ...] = (0,),
+    ) -> subprocess.CompletedProcess[bytes]:
+        argv = ("git", "--no-optional-locks", "-C", str(self.repo_root), *args)
+        try:
+            completed = self.runner.run(
+                argv, timeout=self.timeout_seconds, stdin=stdin
+            )
+        except subprocess.TimeoutExpired as error:
+            raise GitMirrorError(f"git mirror timeout: {args[0]}") from error
+        except GitMirrorError:
+            raise
+        except OSError as error:
+            raise GitMirrorError(f"git mirror unavailable: {error}") from error
+        if completed.returncode not in ok:
+            detail = (completed.stderr or b"").decode("utf-8", "replace").strip()
+            raise GitMirrorError(
+                f"git {args[0]} failed in {self.repo_root}: {detail.splitlines()[-1] if detail else 'no stderr'}"
+            )
+        return completed
+
+    def _verify_origin(self) -> None:
+        if self._verified:
+            return
+        # 讀 raw config 而非 ``git remote get-url``：後者會套用 ``url.*.insteadOf``
+        # 改寫，回傳的是 transport 目的地（企業 mirror／本機路徑），不是這個
+        # checkout 宣告要追的 repo。身分判準要的是後者。
+        completed = self._run(("config", "--get", "remote.origin.url"), ok=(0, 1))
+        remote = (completed.stdout or b"").decode("utf-8", "replace").strip()
+        if not remote:
+            raise GitMirrorError(
+                f"local checkout {self.repo_root} has no origin remote"
+            )
+        for pattern in (GITHUB_SSH_REMOTE, GITHUB_HTTPS_REMOTE):
+            match = pattern.fullmatch(remote)
+            if match is not None and match.group("repo").lower() == self.repo.lower():
+                self._verified = True
+                return
+        raise GitMirrorError(
+            f"local checkout {self.repo_root} does not track {self.repo}"
+        )
+
+    def _missing(self, oids: Sequence[str]) -> frozenset[str]:
+        if not oids:
+            return frozenset()
+        payload = ("\n".join(oids) + "\n").encode("ascii")
+        completed = self._run(("cat-file", "--batch-check"), stdin=payload)
+        lines = (completed.stdout or b"").decode("utf-8", "replace").splitlines()
+        if len(lines) != len(oids):
+            raise GitMirrorError("git cat-file --batch-check output malformed")
+        missing: set[str] = set()
+        for oid, line in zip(oids, lines):
+            fields = line.split()
+            if len(fields) == 2 and fields[1] == "missing":
+                missing.add(oid)
+                continue
+            if len(fields) != 3 or fields[0].lower() != oid:
+                raise GitMirrorError("git cat-file --batch-check output malformed")
+        return frozenset(missing)
+
+    def _fetch(self, *, default_branch: str, pull_numbers: Sequence[int]) -> None:
+        if _SAFE_BRANCH.fullmatch(default_branch) is None or ".." in default_branch:
+            raise GitMirrorError("default branch name is not a safe git ref")
+        branch_refspec = (
+            f"+refs/heads/{default_branch}:{self._namespace}/default"
+        )
+        pull_refspecs = tuple(
+            f"+refs/pull/{number}/head:{self._namespace}/pull/{number}"
+            for number in sorted(set(pull_numbers))[:_PULL_REF_LIMIT]
+        )
+        # ``--refmap=`` 關掉 configured refspec 的「順帶更新」——沒有它，即使命令列
+        # 給了顯式 refspec，git 仍會一併寫 ``refs/remotes/origin/*``。monitor 是在
+        # operator 正在工作的 checkout 上跑，不該動它的 remote-tracking refs。
+        base = ("fetch", "--refmap=", "--no-tags", "--quiet", "origin")
+        try:
+            self._run((*base, branch_refspec, *pull_refspecs))
+        except GitMirrorError:
+            if not pull_refspecs:
+                raise
+            # ``refs/pull/*`` 只有 GitHub 提供；fork mirror／自架 remote 沒有它時，
+            # 讓整輪掃描因為一個**選配** refspec 而 degraded 是錯的。退回只 fetch
+            # default branch——ancestry 的判準本來就只靠 default branch 的可達性。
+            self._run((*base, branch_refspec))
+            self._fetched_refs = (branch_refspec,)
+            return
+        self._fetched_refs = (branch_refspec, *pull_refspecs)
+
+    def _is_shallow(self) -> bool:
+        completed = self._run(("rev-parse", "--is-shallow-repository"))
+        return (completed.stdout or b"").decode("utf-8", "replace").strip() == "true"
+
+    # -- 對外契約 ---------------------------------------------------------
+
+    def require(
+        self,
+        *,
+        required: Sequence[str],
+        ancestry: Sequence[tuple[int, str]] = (),
+        default_branch: str,
+    ) -> None:
+        """確保本輪要讀的物件都在本機；缺就 fetch 一次（最多一次）。
+
+        ``required``（default branch commit ＋ 要讀的 blob）缺一個就 fail closed。
+        ``ancestry`` 是 ``(PR 編號, merge commit)``——merge commit 缺席本身是一項
+        事實（見 :meth:`is_ancestor`），不是錯誤；但缺席的那幾個 PR 會把
+        ``refs/pull/<n>/head`` 一併掛進同一次 fetch，讓本機真的握有那些 PR 的物件。
+        """
+
+        self._verify_origin()
+        wanted_required = _validate_object_ids(required)
+        pairs = tuple(
+            (number, revision)
+            for number, revision in ancestry
+            if isinstance(number, int) and not isinstance(number, bool) and number > 0
+        )
+        if len(pairs) != len(tuple(ancestry)):
+            raise GitMirrorError("pull request numbers must be positive integers")
+        normalized_pairs = tuple(
+            (number, _validate_object_ids((revision,))[0]) for number, revision in pairs
+        )
+        wanted_optional = tuple(
+            oid
+            for oid in dict.fromkeys(revision for _, revision in normalized_pairs)
+            if oid not in set(wanted_required)
+        )
+        wanted = (*wanted_required, *wanted_optional)
+        missing = self._missing(wanted)
+        if missing:
+            self._fetch(
+                default_branch=default_branch,
+                # 只替「merge commit 不在本機」的 PR 拉 head ref——已經握有 merge
+                # commit 的 PR 不需要，多掛一條 refspec 只是徒增 fetch 失敗面。
+                pull_numbers=tuple(
+                    number
+                    for number, revision in normalized_pairs
+                    if revision in missing
+                ),
+            )
+            missing = self._missing(wanted)
+        unresolved = tuple(oid for oid in wanted_required if oid in missing)
+        if unresolved:
+            raise GitMirrorError(
+                "git mirror is missing required objects after fetch: "
+                + ", ".join(unresolved)
+            )
+        self._absent = missing
+
+    def read_blobs(self, shas: Sequence[str]) -> dict[str, str]:
+        """一次 ``git cat-file --batch`` 讀完整批 blob（取代逐檔 contents 請求）。"""
+
+        order = _validate_object_ids(shas)
+        if not order:
+            return {}
+        payload = ("\n".join(order) + "\n").encode("ascii")
+        completed = self._run(("cat-file", "--batch"), stdin=payload)
+        out = completed.stdout or b""
+        result: dict[str, str] = {}
+        offset = 0
+        for oid in order:
+            end = out.find(b"\n", offset)
+            if end < 0:
+                raise GitMirrorError("git cat-file --batch output is truncated")
+            header = out[offset:end].decode("utf-8", "replace").split()
+            offset = end + 1
+            if len(header) == 2 and header[1] == "missing":
+                raise GitMirrorError(f"git mirror blob is missing: {oid}")
+            if len(header) != 3 or header[0].lower() != oid or header[1] != "blob":
+                raise GitMirrorError("git cat-file --batch header is malformed")
+            try:
+                size = int(header[2])
+            except ValueError as error:
+                raise GitMirrorError(
+                    "git cat-file --batch header is malformed"
+                ) from error
+            body = out[offset : offset + size]
+            if len(body) != size:
+                raise GitMirrorError("git cat-file --batch output is truncated")
+            offset += size
+            if out[offset : offset + 1] != b"\n":
+                raise GitMirrorError("git cat-file --batch framing is malformed")
+            offset += 1
+            try:
+                # 與舊 contents 路徑同語意：非 utf-8 是「內容無效」（ValueError），
+                # 不是「鏡像不可用」。
+                result[oid] = body.decode("utf-8")
+            except UnicodeDecodeError as error:
+                raise ValueError(f"remote blob is not utf-8: {oid}") from error
+            self._blob_reads += 1
+        if offset != len(out):
+            raise GitMirrorError("git cat-file --batch output has trailing data")
+        return result
+
+    def is_ancestor(self, ancestor: str, descendant: str) -> bool:
+        """``git merge-base --is-ancestor``（取代逐 PR ``compare``）。"""
+
+        (normalized_ancestor,) = _validate_object_ids((ancestor,))
+        (normalized_descendant,) = _validate_object_ids((descendant,))
+        self._ancestry_checks += 1
+        if normalized_ancestor in self._absent:
+            # descendant（default branch tip）已在本機且 repo 非 shallow 時，git 保證
+            # 它的祖先全部在本機——物件不在本機就等價於「走不到」，也就是 REST
+            # ``compare`` 回 ``behind``／``diverged`` 的那一格。shallow 破壞這個前提，
+            # 此時無法判定，一律 fail closed。
+            if self._is_shallow():
+                raise GitMirrorError(
+                    "shallow local checkout cannot decide merge ancestry"
+                )
+            return False
+        completed = self._run(
+            ("merge-base", "--is-ancestor", normalized_ancestor, normalized_descendant),
+            ok=(0, 1),
+        )
+        return completed.returncode == 0
+
+    @property
+    def provenance(self) -> dict[str, object]:
+        return {
+            "transport": "git",
+            "repo_root": str(self.repo_root),
+            "remote": self.repo,
+            "fetched_refs": list(self._fetched_refs),
+            "absent_objects": sorted(self._absent),
+            "blob_reads": self._blob_reads,
+            "ancestry_checks": self._ancestry_checks,
+        }
+
+
+def unavailable_provenance(reason: str) -> Mapping[str, object]:
+    """沒有動用鏡像（本輪沒有任何 remote 檔案／ancestry 要判）時的 provenance。"""
+
+    return {
+        "transport": "git",
+        "repo_root": None,
+        "remote": None,
+        "fetched_refs": [],
+        "absent_objects": [],
+        "blob_reads": 0,
+        "ancestry_checks": 0,
+        "note": reason,
+    }

--- a/paulsha_cortex/monitor/github_pressure.py
+++ b/paulsha_cortex/monitor/github_pressure.py
@@ -13,6 +13,11 @@ Monitor 的 ``_github_refresh_loop``（``monitor/service.py``）每
   ＋ **每個** remote todo／archived tasks.md 一次 ``contents`` ＋ **每個**
   workflow-linked merged PR 一次 ``compare``
 
+  .. note:: #506 / D2 之後，上面那兩項「每個……一次」已改走本機 git
+     （``monitor/git_mirror``），不再消耗 REST 配額；``GitHubTerminalProvider``
+     的 REST 只剩 graphql 分頁與 1 次 git tree。下面的問題描述與預算計算保留
+     當時的實測基準，因為節流／退避機制本身沒有變。
+
 亦即 per-repo per-cycle 是 O(issues 分頁 + todo 檔數)。實際 workspace 約 40 個
 repo，一輪數百次請求在數秒內齊發，穩定觸發 GitHub secondary（abuse detection）
 rate limit——實測 ``github:`` 與 ``github-terminal:`` 兩個 provider 同時

--- a/paulsha_cortex/monitor/providers.py
+++ b/paulsha_cortex/monitor/providers.py
@@ -2,8 +2,6 @@
 from __future__ import annotations
 
 import hashlib
-import base64
-import binascii
 import json
 import math
 import re
@@ -12,13 +10,18 @@ import time
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable, Mapping, Protocol, Sequence
-from urllib.parse import quote
 
 import yaml
 
 from paulsha_cortex.config import paths
 from paulsha_cortex.github_rate_limit import is_auth_signal, is_rate_limit_signal
 
+from .git_mirror import (
+    GitMirrorError,
+    GitRunner,
+    LocalGitMirror,
+    unavailable_provenance,
+)
 from .github_pressure import (
     RATE_LIMIT_KIND_PRIMARY,
     RATE_LIMIT_KIND_SECONDARY,
@@ -1015,13 +1018,21 @@ class GitHubTerminalProvider:
         sleeper: Callable[[float], None] = time.sleep,
         relevant_pr_numbers: tuple[int, ...] | None = None,
         pressure_gate: GitHubPressureGate | None = None,
+        repo_root: str | Path | None = None,
+        git_runner: GitRunner | None = None,
     ) -> None:
         self.repo = repo
         self.provider_id = f"github-terminal:{repo}"
         self.runner = runner or SubprocessCommandRunner()
         self.timeout_seconds = timeout_seconds
-        # #506：本 provider 是請求量最大的一支（graphql 分頁 + tree + 逐檔
-        # contents + 逐 PR compare），節流／退避沒接上它等於沒做減壓。
+        # #506 / D2：remote 檔案內容與 merge ancestry 一律走本機 git（見
+        # ``git_mirror``）。``repo_root`` 是該 repo 在 workspace 的 canonical
+        # checkout；缺它就沒有鏡像，本輪一旦真的需要讀檔／判 ancestry 就 fail
+        # closed（degraded），**不會**退回 REST，也不會當成「檔案不存在」。
+        self.repo_root = None if repo_root is None else Path(repo_root)
+        self.git_runner = git_runner
+        # #506：本 provider 仍是 REST 請求量最大的一支（graphql 分頁 + 1 次
+        # git tree），節流／退避沒接上它等於沒做減壓。
         self.pressure_gate = pressure_gate
         if any(
             not isinstance(delay, (int, float))
@@ -1091,10 +1102,7 @@ class GitHubTerminalProvider:
                 raise ValueError("default branch tree is truncated")
             if not isinstance(tree.get("tree"), list):
                 raise ValueError("default branch tree entries are invalid")
-            remote_todos = self._remote_todos(
-                tree,
-                default_revision=default_revision.lower(),
-            )
+            todo_entries = self._remote_todo_entries(tree)
             paths = {
                 row["path"]
                 for row in tree["tree"]
@@ -1136,6 +1144,9 @@ class GitHubTerminalProvider:
             links: dict[str, str] = {}
             remote_prs: list[dict[str, object]] = []
             branches: list[dict[str, str]] = []
+            # D2：ancestry 不再逐 PR 打 ``compare``；先把候選收集起來，等本輪唯一
+            # 一次 ``mirror.require()`` 把物件備齊後再用本機 ``merge-base`` 判定。
+            ancestry_candidates: list[tuple[int, str, dict[str, object]]] = []
             for pull in pull_nodes:
                 number = pull["number"]
                 pr_source_id = f"github_pr:{self.repo}#{number}"
@@ -1169,35 +1180,56 @@ class GitHubTerminalProvider:
                         or number in self.relevant_pr_numbers
                     )
                 )
-                if merge_commit:
-                    comparison = self._json(
-                        (
-                            "gh", "api", "--method", "GET",
-                            f"repos/{self.repo}/compare/{merge_revision}...{default_revision}",
-                        )
-                    )
-                    merge_commit = comparison.get("status") in {"ahead", "identical"}
                 candidate = pull.get("headRefOid")
-                remote_prs.append(
-                    {
-                        "source_id": pr_source_id,
-                        "candidate": (
-                            candidate.lower()
-                            if isinstance(candidate, str)
-                            and re.fullmatch(r"[0-9a-fA-F]{40}", candidate)
-                            else None
-                        ),
-                        "merge_revision": (
-                            merge_revision.lower()
-                            if isinstance(merge_revision, str)
-                            and re.fullmatch(r"[0-9a-fA-F]{40}", merge_revision)
-                            else None
-                        ),
-                        "merged_with_merge_commit": merge_commit,
-                    }
+                row: dict[str, object] = {
+                    "source_id": pr_source_id,
+                    "candidate": (
+                        candidate.lower()
+                        if isinstance(candidate, str)
+                        and re.fullmatch(r"[0-9a-fA-F]{40}", candidate)
+                        else None
+                    ),
+                    "merge_revision": (
+                        merge_revision.lower()
+                        if isinstance(merge_revision, str)
+                        and re.fullmatch(r"[0-9a-fA-F]{40}", merge_revision)
+                        else None
+                    ),
+                    "merged_with_merge_commit": False,
+                }
+                if merge_commit:
+                    ancestry_candidates.append(
+                        (number, str(row["merge_revision"]), row)
+                    )
+                remote_prs.append(row)
+            mirror: LocalGitMirror | None = None
+            if todo_entries or ancestry_candidates:
+                mirror = self._mirror()
+                mirror.require(
+                    required=(
+                        default_revision.lower(),
+                        *(entry[1] for entry in todo_entries),
+                    ),
+                    ancestry=tuple(
+                        (number, revision)
+                        for number, revision, _ in ancestry_candidates
+                    ),
+                    default_branch=default_branch,
                 )
+            remote_todos = self._remote_todos(todo_entries, mirror=mirror)
+            if mirror is not None:
+                for _, merge_revision, row in ancestry_candidates:
+                    row["merged_with_merge_commit"] = mirror.is_ancestor(
+                        merge_revision, default_revision.lower()
+                    )
         except subprocess.TimeoutExpired:
             return self._failure(attempted_at, "github terminal timeout")
+        except GitMirrorError as error:
+            # D2：本機 git 讀不到就 fail closed——上層 ``_retain_last_good`` 會保留
+            # 上一份鏡像，絕不把讀取失敗降級成「檔案不存在／不是 ancestor」。
+            return self._failure(
+                attempted_at, f"github terminal git mirror unavailable: {error}"
+            )
         except _GitHubRateLimitError as error:
             # #506：與 GitHubWorkProvider 同一套分診／退避；本 provider 原本把
             # 限流混進 "evidence unavailable"，下游完全分辨不出來。
@@ -1227,6 +1259,18 @@ class GitHubTerminalProvider:
             "default_revision": default_revision.lower(),
             "remote_todos": remote_todos,
             "branches": branches,
+            # D2 provenance：這一輪的 remote 檔案內容與 ancestry 是從哪裡、用哪些
+            # ref 讀來的。degraded 的那一輪不會走到這裡，因此 provenance 永遠對應
+            # 一份成功的鏡像讀取。
+            "remote_reads": (
+                dict(mirror.provenance)
+                if mirror is not None
+                else dict(
+                    unavailable_provenance(
+                        "no remote artifact or ancestry required this cycle"
+                    )
+                )
+            ),
         }
         if self.pressure_gate is not None:
             # #506：整支 scan 走完都沒被限流，退避窗可以關掉。
@@ -1263,8 +1307,9 @@ class GitHubTerminalProvider:
         completed = None
         for attempt in range(len(self.retry_delays) + 1):
             if self.pressure_gate is not None:
-                # #506：節流點在**每一次**請求前，含分頁與逐檔 contents——
-                # 一輪掃描的請求數就是靠這裡攤平的。
+                # #506：節流點在**每一次** REST 請求前（graphql 分頁與 git tree）。
+                # D2 之後逐檔 contents 與逐 PR compare 已改走本機 git，不經此路徑
+                # ——git 協定不受 REST rate limit 管轄，節流它只是白白拖慢掃描。
                 self.pressure_gate.throttle()
             completed = self.runner.run(argv, timeout=self.timeout_seconds)
             if completed.returncode == 0:
@@ -1298,13 +1343,28 @@ class GitHubTerminalProvider:
             observations={},
         )
 
-    def _remote_todos(
-        self,
+    def _mirror(self) -> LocalGitMirror:
+        if self.repo_root is None:
+            raise GitMirrorError(
+                "no local checkout configured for git-native remote reads"
+            )
+        return LocalGitMirror(
+            self.repo_root,
+            repo=self.repo,
+            runner=self.git_runner,
+            timeout_seconds=self.timeout_seconds,
+        )
+
+    @staticmethod
+    def _remote_todo_entries(
         tree: Mapping,
-        *,
-        default_revision: str,
-    ) -> list[dict[str, object]]:
-        rows: list[dict[str, object]] = []
+    ) -> tuple[tuple[str, str, re.Match[str] | None], ...]:
+        """從 REST tree 挑出要讀的 blob（path、blob sha、archive match）。
+
+        只解析、不讀內容——內容統一在本輪唯一一次 ``git cat-file --batch`` 取得。
+        """
+
+        entries: list[tuple[str, str, re.Match[str] | None]] = []
         for entry in tree.get("tree", []):
             if not isinstance(entry, Mapping):
                 continue
@@ -1325,35 +1385,29 @@ class GitHubTerminalProvider:
                 r"[0-9a-fA-F]{40}", revision
             ) is None:
                 raise ValueError("remote Todo tree entry is invalid")
-            content_file = self._json(
-                (
-                    "gh", "api", "--method", "GET",
-                    (
-                        f"repos/{self.repo}/contents/{quote(path, safe='/')}"
-                        f"?ref={default_revision}"
-                    ),
-                )
-            )
-            if (
-                content_file.get("type") != "file"
-                or content_file.get("path") != path
-                or not isinstance(content_file.get("sha"), str)
-                or content_file["sha"].lower() != revision.lower()
-                or content_file.get("encoding") != "base64"
-            ):
-                raise ValueError("remote Todo content identity mismatch")
-            content = content_file.get("content")
-            if not isinstance(content, str):
-                raise ValueError("remote Todo content is invalid")
-            try:
-                text = base64.b64decode(
-                    re.sub(r"\s+", "", content), validate=True
-                ).decode("utf-8")
-            except (binascii.Error, UnicodeDecodeError) as error:
-                raise ValueError("remote Todo content is invalid") from error
+            entries.append((path, revision.lower(), archive_match))
+        return tuple(entries)
+
+    def _remote_todos(
+        self,
+        entries: Sequence[tuple[str, str, re.Match[str] | None]],
+        *,
+        mirror: LocalGitMirror | None,
+    ) -> list[dict[str, object]]:
+        if not entries:
+            return []
+        if mirror is None:  # pragma: no cover - 呼叫端保證 entries 非空即有鏡像
+            raise GitMirrorError("git mirror is required to read remote artifacts")
+        # D2：blob 一律以 tree 給的 sha 定址讀取。sha 定址本身就是內容識別，取代
+        # 舊 ``contents`` 路徑的 type／path／sha／encoding 四項比對；讀不到會由
+        # ``read_blobs`` raise（fail closed），不會退化成「檔案不存在」。
+        texts = mirror.read_blobs(tuple(revision for _, revision, _ in entries))
+        rows: list[dict[str, object]] = []
+        for path, revision, archive_match in entries:
+            text = texts[revision]
             row: dict[str, object] = {
                 "path": path,
-                "revision": revision.lower(),
+                "revision": revision,
                 "complete": _markdown_tasks_complete_text(text),
             }
             if archive_match is not None:

--- a/paulsha_cortex/monitor/work_api.py
+++ b/paulsha_cortex/monitor/work_api.py
@@ -13,6 +13,7 @@ from typing import Callable, Mapping, Sequence
 
 from .config import load_config
 from .correlation import InferredSignal, correlate_work_sources
+from .git_mirror import GITHUB_HTTPS_REMOTE, GITHUB_SSH_REMOTE
 from .github_pressure import GitHubPressureGate
 from .lifecycle import ClosureEvidence, project_work_items
 from .models import ProjectState
@@ -511,6 +512,10 @@ class WorkModelRefresher:
                                 repo=repo,
                             ),
                             pressure_gate=self.github_pressure_gate,
+                            # D2：remote 檔案內容與 merge ancestry 走本機 git，
+                            # 讀的就是這個 repo 在 workspace 的 canonical checkout
+                            # （與 ``RepoWorkProvider`` 同一個 root）。
+                            repo_root=root,
                         )
                         if self._uses_default_github_terminal_provider
                         else self.github_terminal_provider_factory(repo)
@@ -1058,8 +1063,11 @@ def _provider_repo(provider_id: str) -> str | None:
     return None
 
 
-_GITHUB_SSH = re.compile(r"^(?:ssh://)?git@github\.com[:/](?P<repo>[^/]+/[^/]+?)(?:\.git)?$")
-_GITHUB_HTTPS = re.compile(r"^https?://github\.com/(?P<repo>[^/]+/[^/]+?)(?:\.git)?/?$")
+# D2：與 ``git_mirror.LocalGitMirror`` 共用同一組 origin 樣式——provider 認定「這是
+# GitHub repo」與 mirror 認定「origin 真的指向它」必須用同一個判準，否則會出現
+# 「派了 GitHub provider、鏡像卻拒認 origin」的分歧。
+_GITHUB_SSH = GITHUB_SSH_REMOTE
+_GITHUB_HTTPS = GITHUB_HTTPS_REMOTE
 
 
 def _repo_identity(root: Path, fallback: str) -> tuple[str, bool]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Mapping
 import os
 import shutil
+import subprocess
 
 import pytest
 
@@ -50,3 +52,113 @@ def _prefer_local_openspec(monkeypatch: pytest.MonkeyPatch) -> None:
     wrapper_parent = str(wrapper.parent.resolve())
     if wrapper_parent not in original_path.split(os.pathsep):
         monkeypatch.setenv("PATH", f"{wrapper_parent}{os.pathsep}{original_path}")
+
+
+# --- #506 / D2：git-native remote reads 用的真 git fixture --------------------
+#
+# monitor 的 remote 檔案讀取與 merge ancestry 已改走本機 git（``monitor/git_mirror``）。
+# 這類測試一律用本機 tmp git repo，**不打**任何真實 GitHub API／網路：
+# ``origin`` 的 URL 字面值寫成 GitHub HTTPS（鏡像的身分驗證讀的是 raw config），
+# 實際 transport 由 ``url.<local>.insteadOf`` 改寫到同一個 tmp 目錄下的 bare repo。
+
+
+class GitOriginFixture:
+    """一組 bare ``origin`` ＋ 一個本機 checkout，對外偽裝成 GitHub repo。"""
+
+    def __init__(self, root: Path, repo: str) -> None:
+        self.repo = repo
+        self.root = root
+        self.origin = root / "origin.git"
+        self.checkout = root / "checkout"
+        self.url = f"https://github.com/{repo}.git"
+        # ``-b main``：bare repo 的 HEAD 必須指向真的會存在的分支，否則
+        # ``git clone --depth=1`` 會把它當成空 repo。
+        self._git(("init", "--quiet", "--bare", "-b", "main", str(self.origin)), cwd=root)
+        self._git(("init", "--quiet", "-b", "main", str(self.checkout)), cwd=root)
+        self.git("remote", "add", "origin", self.url)
+        self.git("config", f"url.{self.origin}.insteadOf", self.url)
+        self.git("config", "user.email", "fixture@example.invalid")
+        self.git("config", "user.name", "fixture")
+
+    @staticmethod
+    def _git(argv: tuple[str, ...], *, cwd: Path) -> str:
+        completed = subprocess.run(
+            ("git", *argv),
+            cwd=str(cwd),
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        return completed.stdout.strip()
+
+    def git(self, *argv: str) -> str:
+        return self._git(argv, cwd=self.checkout)
+
+    def commit(self, files: Mapping[str, str], *, message: str = "commit") -> str:
+        for relative, text in files.items():
+            target = self.checkout / relative
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(text, encoding="utf-8")
+            self.git("add", "--", relative)
+        self.git("commit", "--quiet", "-m", message)
+        return self.git("rev-parse", "HEAD")
+
+    def branch_commit(
+        self,
+        branch: str,
+        files: Mapping[str, str],
+        *,
+        message: str = "branch commit",
+        base: str = "main",
+    ) -> str:
+        self.git("checkout", "--quiet", "-b", branch, base)
+        head = self.commit(files, message=message)
+        self.git("checkout", "--quiet", "main")
+        return head
+
+    def merge(self, branch: str, *, message: str = "merge") -> str:
+        """真的 merge commit（``--no-ff``），parents >= 2。"""
+
+        self.git("merge", "--quiet", "--no-ff", "-m", message, branch)
+        return self.git("rev-parse", "HEAD")
+
+    def blob_sha(self, path: str, *, revision: str = "HEAD") -> str:
+        return self.git("rev-parse", f"{revision}:{path}")
+
+    def head(self, revision: str = "HEAD") -> str:
+        return self.git("rev-parse", revision)
+
+    def publish(self, branch: str = "main") -> None:
+        """把 checkout 的分支推到 bare origin（模擬遠端已經前進）。"""
+
+        self.git("push", "--quiet", "origin", f"{branch}:{branch}")
+
+    def publish_pull_head(self, number: int, revision: str) -> None:
+        """在 origin 上建立 ``refs/pull/<n>/head``（GitHub 才有的唯讀 ref）。"""
+
+        self.git("push", "--quiet", "origin", f"{revision}:refs/pull/{number}/head")
+
+    def detach(self) -> Path:
+        """回傳一個『只有 origin 設定、還沒有任何物件』的空 checkout。"""
+
+        empty = self.root / "empty-checkout"
+        self._git(("init", "--quiet", "-b", "main", str(empty)), cwd=self.root)
+        self._git(("remote", "add", "origin", self.url), cwd=empty)
+        self._git(("config", f"url.{self.origin}.insteadOf", self.url), cwd=empty)
+        return empty
+
+
+@pytest.fixture
+def git_origin(tmp_path: Path):
+    """factory：``git_origin("example/acme")`` → :class:`GitOriginFixture`。"""
+
+    created: list[GitOriginFixture] = []
+
+    def _make(repo: str = "example/acme") -> GitOriginFixture:
+        root = tmp_path / f"gitfixture-{len(created)}"
+        root.mkdir(parents=True, exist_ok=True)
+        fixture = GitOriginFixture(root, repo)
+        created.append(fixture)
+        return fixture
+
+    return _make

--- a/tests/test_monitor_git_native_reads_506.py
+++ b/tests/test_monitor_git_native_reads_506.py
@@ -1,0 +1,572 @@
+"""#506 / D2：git 的資料走 git——monitor 的 remote 讀取不再吃 REST 配額。
+
+改動前，``GitHubTerminalProvider`` 一輪掃描對 GitHub REST 發出：
+
+- 每個 remote ``todo.md`` / archived ``tasks.md`` 一次 ``contents``（實測 91 次／輪）
+- 每個 workflow-linked merged PR 一次 ``compare``
+
+兩者讀的都是本機 git 就有的東西。本檔的驗收樁把「一輪掃描的 REST contents/compare
+呼叫數」釘死在 **0**，其餘測試釘住行為等價與 fail-closed 語意。
+
+所有測試都用本機 tmp git repo（``git_origin`` fixture，見 ``tests/conftest.py``），
+不打真實 GitHub API、不連網。
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+
+import pytest
+
+from paulsha_cortex.monitor.git_mirror import GitMirrorError, LocalGitMirror
+from paulsha_cortex.monitor.providers import GitHubTerminalProvider
+from paulsha_cortex.monitor.work_api import _retain_last_good
+
+
+class RecordingRunner:
+    """依序回傳預備好的 ``gh`` 回應，並記下每一次 argv 供配額計數。"""
+
+    def __init__(self, payloads):
+        self._payloads = list(payloads)
+        self.calls: list[tuple[str, ...]] = []
+
+    def run(self, argv, *, timeout):
+        self.calls.append(tuple(argv))
+        if not self._payloads:
+            raise AssertionError(f"unexpected extra gh call: {tuple(argv)}")
+        payload = self._payloads.pop(0)
+        return subprocess.CompletedProcess(
+            args=tuple(argv),
+            returncode=0,
+            stdout=json.dumps(payload),
+            stderr="",
+        )
+
+    @property
+    def rest_contents_calls(self) -> int:
+        return sum(1 for call in self.calls if any("/contents/" in arg for arg in call))
+
+    @property
+    def rest_compare_calls(self) -> int:
+        return sum(1 for call in self.calls if any("/compare/" in arg for arg in call))
+
+
+def _graph(*, default_revision: str, pulls=(), branch: str = "main") -> dict:
+    return {
+        "data": {
+            "repository": {
+                "defaultBranchRef": {
+                    "name": branch,
+                    "target": {"oid": default_revision},
+                },
+                "pullRequests": {
+                    "pageInfo": {"hasNextPage": False, "endCursor": None},
+                    "nodes": list(pulls),
+                },
+            }
+        }
+    }
+
+
+def _merged_pull(number: int, merge_revision: str, head_revision: str) -> dict:
+    return {
+        "number": number,
+        "body": "",
+        "headRefName": f"feature/{number}-work",
+        "headRefOid": head_revision,
+        "state": "MERGED",
+        "mergedAt": "2026-08-15T10:00:00Z",
+        "mergeCommit": {"oid": merge_revision, "parents": {"totalCount": 2}},
+        "closingIssuesReferences": {
+            "pageInfo": {"hasNextPage": False},
+            "nodes": [{"number": number, "state": "CLOSED"}],
+        },
+    }
+
+
+def _tree(entries) -> dict:
+    return {
+        "truncated": False,
+        "tree": [
+            {"path": path, "type": "blob", "sha": sha} for path, sha in entries
+        ],
+    }
+
+
+TODO_TEXT = "---\nwork_item: work\n---\n- [x] one\n- [x] two\n"
+TODO_PATH = "docs/superpowers/workstreams/work/todo.md"
+
+
+def test_remote_todo_content_comes_from_local_git_objects(git_origin):
+    repo = git_origin()
+    repo.commit({TODO_PATH: TODO_TEXT}, message="add todo")
+    runner = RecordingRunner(
+        [
+            _graph(default_revision=repo.head()),
+            _tree([(TODO_PATH, repo.blob_sha(TODO_PATH))]),
+        ]
+    )
+
+    result = GitHubTerminalProvider(
+        repo.repo, runner=runner, repo_root=repo.checkout
+    ).scan()
+
+    assert result.status == "ok"
+    assert result.observations["remote_todos"] == [
+        {
+            "path": TODO_PATH,
+            "revision": repo.blob_sha(TODO_PATH),
+            "complete": True,
+            "work_id": "work",
+        }
+    ]
+    assert runner.rest_contents_calls == 0
+    assert result.observations["remote_reads"]["transport"] == "git"
+    assert result.observations["remote_reads"]["blob_reads"] == 1
+
+
+def test_remote_archived_openspec_tasks_are_read_from_local_git(git_origin):
+    repo = git_origin()
+    tasks = "openspec/changes/archive/2026-08-15-canary/tasks.md"
+    repo.commit({tasks: "- [x] task one\n- [x] task two\n"}, message="archive")
+    runner = RecordingRunner(
+        [
+            _graph(default_revision=repo.head()),
+            _tree([(tasks, repo.blob_sha(tasks))]),
+        ]
+    )
+
+    result = GitHubTerminalProvider(
+        repo.repo, runner=runner, repo_root=repo.checkout
+    ).scan()
+
+    assert result.status == "ok"
+    assert result.observations["remote_todos"] == [
+        {
+            "path": tasks,
+            "revision": repo.blob_sha(tasks),
+            "complete": True,
+            "openspec_ref": "canary",
+        }
+    ]
+    assert runner.rest_contents_calls == 0
+
+
+def test_merge_ancestry_uses_local_merge_base_not_compare(git_origin):
+    repo = git_origin()
+    repo.commit({"README.md": "# base\n"}, message="base")
+    head = repo.branch_commit("feature/9-work", {"src.py": "x = 1\n"})
+    merge = repo.merge("feature/9-work")
+    runner = RecordingRunner(
+        [
+            _graph(
+                default_revision=repo.head(),
+                pulls=[_merged_pull(9, merge, head)],
+            ),
+            _tree([]),
+        ]
+    )
+
+    result = GitHubTerminalProvider(
+        repo.repo, runner=runner, repo_root=repo.checkout
+    ).scan()
+
+    assert result.status == "ok"
+    assert result.observations["remote_prs"] == [
+        {
+            "source_id": f"github_pr:{repo.repo}#9",
+            "candidate": head,
+            "merge_revision": merge,
+            "merged_with_merge_commit": True,
+        }
+    ]
+    assert runner.rest_compare_calls == 0
+    assert result.observations["remote_reads"]["ancestry_checks"] == 1
+
+
+def test_merge_commit_off_default_branch_is_not_terminal(git_origin):
+    """REST ``compare`` 回 ``diverged`` 的那一格，git 版必須答同一個 False。"""
+
+    repo = git_origin()
+    repo.commit({"README.md": "# base\n"}, message="base")
+    head = repo.branch_commit("feature/9-work", {"src.py": "x = 1\n"})
+    # merge commit 建在側枝上，main 完全走不到它。
+    repo.git("checkout", "--quiet", "-b", "release", "main")
+    repo.git("merge", "--quiet", "--no-ff", "-m", "side merge", "feature/9-work")
+    merge = repo.head("release")
+    repo.git("checkout", "--quiet", "main")
+    repo.commit({"README.md": "# moved on\n"}, message="advance main")
+    runner = RecordingRunner(
+        [
+            _graph(
+                default_revision=repo.head("main"),
+                pulls=[_merged_pull(9, merge, head)],
+            ),
+            _tree([]),
+        ]
+    )
+
+    result = GitHubTerminalProvider(
+        repo.repo, runner=runner, repo_root=repo.checkout
+    ).scan()
+
+    assert result.status == "ok"
+    assert result.observations["remote_prs"][0]["merged_with_merge_commit"] is False
+    assert runner.rest_compare_calls == 0
+
+
+def test_scan_round_issues_zero_rest_contents_and_compare_calls(git_origin):
+    """量化驗收：一輪掃描的 REST ``contents`` / ``compare`` 呼叫數 = 0。
+
+    改動前這一輪會是 12 次 ``contents`` ＋ 3 次 ``compare`` = 15 次 REST（實測
+    生產 workspace 一輪是 91 次 contents）；改動後同一輪的 REST 只剩 graphql
+    與一次 git tree。
+    """
+
+    repo = git_origin()
+    todo_paths = [
+        f"docs/superpowers/workstreams/work-{index}/todo.md" for index in range(12)
+    ]
+    repo.commit(
+        {
+            path: f"---\nwork_item: work-{index}\n---\n- [x] done\n"
+            for index, path in enumerate(todo_paths)
+        },
+        message="todos",
+    )
+    merges = []
+    for number in (7, 8, 9):
+        head = repo.branch_commit(f"feature/{number}-work", {f"src{number}.py": "x\n"})
+        merges.append((number, repo.merge(f"feature/{number}-work"), head))
+    runner = RecordingRunner(
+        [
+            _graph(
+                default_revision=repo.head(),
+                pulls=[
+                    _merged_pull(number, merge, head)
+                    for number, merge, head in merges
+                ],
+            ),
+            _tree([(path, repo.blob_sha(path)) for path in todo_paths]),
+        ]
+    )
+
+    result = GitHubTerminalProvider(
+        repo.repo, runner=runner, repo_root=repo.checkout
+    ).scan()
+
+    assert result.status == "ok"
+    assert len(result.observations["remote_todos"]) == 12
+    assert all(
+        row["merged_with_merge_commit"] for row in result.observations["remote_prs"]
+    )
+    assert runner.rest_contents_calls == 0
+    assert runner.rest_compare_calls == 0
+    # 一輪只剩 graphql（PR 分頁）＋ 1 次 git tree。
+    assert len(runner.calls) == 2
+    assert runner.calls[0][:3] == ("gh", "api", "graphql")
+    assert "git/trees" in runner.calls[1][-1]
+
+
+def test_stale_checkout_fetches_missing_revision_before_reading(git_origin):
+    """本機落後時走 ``git fetch``（不吃 REST 配額），fetch 後再本機讀。"""
+
+    repo = git_origin()
+    repo.commit({TODO_PATH: TODO_TEXT}, message="add todo")
+    repo.publish()
+    empty = repo.detach()
+    runner = RecordingRunner(
+        [
+            _graph(default_revision=repo.head()),
+            _tree([(TODO_PATH, repo.blob_sha(TODO_PATH))]),
+        ]
+    )
+
+    result = GitHubTerminalProvider(repo.repo, runner=runner, repo_root=empty).scan()
+
+    assert result.status == "ok"
+    assert result.observations["remote_todos"][0]["work_id"] == "work"
+    assert result.observations["remote_reads"]["fetched_refs"] == [
+        "+refs/heads/main:"
+        + LocalGitMirror(empty, repo=repo.repo)._namespace
+        + "/default"
+    ]
+    assert runner.rest_contents_calls == 0
+    # fetch 不得動使用者的 remote-tracking refs。
+    assert (
+        subprocess.run(
+            ("git", "-C", str(empty), "for-each-ref", "refs/remotes"),
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+        == ""
+    )
+
+
+def test_pull_head_refspec_is_optional_when_origin_lacks_it(git_origin):
+    """``refs/pull/<n>/head`` 是選配；remote 沒有它時仍要能判 ancestry。"""
+
+    repo = git_origin()
+    repo.commit({"README.md": "# base\n"}, message="base")
+    head = repo.branch_commit("feature/9-work", {"src.py": "x = 1\n"})
+    merge = repo.merge("feature/9-work")
+    repo.publish()
+    empty = repo.detach()
+    runner = RecordingRunner(
+        [
+            _graph(
+                default_revision=repo.head(),
+                pulls=[_merged_pull(9, merge, head)],
+            ),
+            _tree([]),
+        ]
+    )
+
+    result = GitHubTerminalProvider(repo.repo, runner=runner, repo_root=empty).scan()
+
+    assert result.status == "ok"
+    assert result.observations["remote_prs"][0]["merged_with_merge_commit"] is True
+    assert runner.rest_compare_calls == 0
+
+
+def test_pull_head_refspec_is_fetched_when_merge_commit_is_missing(git_origin):
+    repo = git_origin()
+    repo.commit({"README.md": "# base\n"}, message="base")
+    head = repo.branch_commit("feature/9-work", {"src.py": "x = 1\n"})
+    merge = repo.merge("feature/9-work")
+    repo.publish()
+    repo.publish_pull_head(9, head)
+    empty = repo.detach()
+    runner = RecordingRunner(
+        [
+            _graph(
+                default_revision=repo.head(),
+                pulls=[_merged_pull(9, merge, head)],
+            ),
+            _tree([]),
+        ]
+    )
+
+    result = GitHubTerminalProvider(repo.repo, runner=runner, repo_root=empty).scan()
+
+    assert result.status == "ok"
+    namespace = LocalGitMirror(empty, repo=repo.repo)._namespace
+    assert result.observations["remote_reads"]["fetched_refs"] == [
+        f"+refs/heads/main:{namespace}/default",
+        f"+refs/pull/9/head:{namespace}/pull/9",
+    ]
+    assert result.observations["remote_prs"][0]["merged_with_merge_commit"] is True
+
+
+def test_unreadable_remote_blob_fails_closed_instead_of_absent(git_origin):
+    """讀不到不得靜默當成「檔案不存在」——整支 provider degraded。"""
+
+    repo = git_origin()
+    repo.commit({TODO_PATH: TODO_TEXT}, message="add todo")
+    repo.publish()
+    runner = RecordingRunner(
+        [
+            _graph(default_revision=repo.head()),
+            # tree 指向一個 origin 上根本不存在的 blob：fetch 成功，物件仍不在。
+            _tree([(TODO_PATH, "0" * 40)]),
+        ]
+    )
+
+    result = GitHubTerminalProvider(
+        repo.repo, runner=runner, repo_root=repo.checkout
+    ).scan()
+
+    assert result.status == "degraded"
+    assert result.observations == {}
+    assert result.sources == ()
+    assert len(result.diagnostics) == 1
+    assert "git mirror" in result.diagnostics[0]
+    assert "missing required objects" in result.diagnostics[0]
+
+
+def test_missing_local_checkout_fails_closed(git_origin):
+    repo = git_origin()
+    repo.commit({TODO_PATH: TODO_TEXT}, message="add todo")
+    runner = RecordingRunner(
+        [
+            _graph(default_revision=repo.head()),
+            _tree([(TODO_PATH, repo.blob_sha(TODO_PATH))]),
+        ]
+    )
+
+    result = GitHubTerminalProvider(repo.repo, runner=runner).scan()
+
+    assert result.status == "degraded"
+    assert result.diagnostics == (
+        "github terminal git mirror unavailable: "
+        "no local checkout configured for git-native remote reads",
+    )
+
+
+def test_checkout_tracking_another_repo_fails_closed(git_origin):
+    repo = git_origin()
+    repo.commit({TODO_PATH: TODO_TEXT}, message="add todo")
+    runner = RecordingRunner(
+        [
+            _graph(default_revision=repo.head()),
+            _tree([(TODO_PATH, repo.blob_sha(TODO_PATH))]),
+        ]
+    )
+
+    result = GitHubTerminalProvider(
+        "other/impostor", runner=runner, repo_root=repo.checkout
+    ).scan()
+
+    assert result.status == "degraded"
+    assert "does not track other/impostor" in result.diagnostics[0]
+
+
+def test_fetch_failure_is_degraded_and_previous_mirror_is_retained(git_origin):
+    repo = git_origin()
+    repo.commit({TODO_PATH: TODO_TEXT}, message="add todo")
+    repo.publish()
+    empty = repo.detach()
+    # origin 宣告仍是 GitHub，但 transport 被改寫到一個不存在的路徑：fetch 必敗。
+    subprocess.run(
+        ("git", "-C", str(empty), "config", "--unset-all", f"url.{repo.origin}.insteadOf"),
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        (
+            "git",
+            "-C",
+            str(empty),
+            "config",
+            f"url.{repo.root / 'nonexistent.git'}.insteadOf",
+            repo.url,
+        ),
+        check=True,
+        capture_output=True,
+    )
+    runner = RecordingRunner(
+        [
+            _graph(default_revision=repo.head()),
+            _tree([(TODO_PATH, repo.blob_sha(TODO_PATH))]),
+        ]
+    )
+
+    result = GitHubTerminalProvider(repo.repo, runner=runner, repo_root=empty).scan()
+
+    assert result.status == "degraded"
+    assert "git mirror" in result.diagnostics[0]
+    assert "rate limit" not in result.diagnostics[0]
+
+    previous = GitHubTerminalProvider(
+        repo.repo,
+        runner=RecordingRunner(
+            [
+                _graph(default_revision=repo.head()),
+                _tree([(TODO_PATH, repo.blob_sha(TODO_PATH))]),
+            ]
+        ),
+        repo_root=repo.checkout,
+    ).scan()
+    retained = _retain_last_good(previous, result)
+
+    assert retained.status == "degraded"
+    assert retained.revision == previous.revision
+    assert retained.sources == previous.sources
+
+
+def test_shallow_checkout_cannot_decide_ancestry(git_origin):
+    repo = git_origin()
+    repo.commit({"README.md": "# base\n"}, message="base")
+    head = repo.branch_commit("feature/9-work", {"src.py": "x = 1\n"})
+    merge = repo.merge("feature/9-work")
+    repo.commit({"README.md": "# moved on\n"}, message="advance")
+    repo.publish()
+    shallow = repo.root / "shallow"
+    subprocess.run(
+        (
+            "git",
+            "clone",
+            "--quiet",
+            "--depth=1",
+            f"file://{repo.origin}",
+            str(shallow),
+        ),
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ("git", "-C", str(shallow), "remote", "set-url", "origin", repo.url),
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        (
+            "git",
+            "-C",
+            str(shallow),
+            "config",
+            f"url.{repo.origin}.insteadOf",
+            repo.url,
+        ),
+        check=True,
+        capture_output=True,
+    )
+    runner = RecordingRunner(
+        [
+            _graph(
+                default_revision=repo.head("main"),
+                pulls=[_merged_pull(9, merge, head)],
+            ),
+            _tree([]),
+        ]
+    )
+
+    result = GitHubTerminalProvider(
+        repo.repo, runner=runner, repo_root=shallow
+    ).scan()
+
+    assert result.status == "degraded"
+    assert "shallow" in result.diagnostics[0]
+
+
+def test_mirror_rejects_unsafe_default_branch_names(git_origin):
+    repo = git_origin()
+    repo.commit({"README.md": "# base\n"}, message="base")
+    mirror = LocalGitMirror(repo.checkout, repo=repo.repo)
+
+    with pytest.raises(GitMirrorError, match="not a safe git ref"):
+        mirror.require(
+            required=("0" * 40,),
+            default_branch="--upload-pack=touch /tmp/pwned",
+        )
+
+
+def test_mirror_rejects_malformed_object_ids(git_origin):
+    repo = git_origin()
+    repo.commit({"README.md": "# base\n"}, message="base")
+    mirror = LocalGitMirror(repo.checkout, repo=repo.repo)
+
+    with pytest.raises(GitMirrorError, match="object id is invalid"):
+        mirror.require(required=("HEAD",), default_branch="main")
+
+
+def test_mirror_reads_multiple_blobs_in_one_batch(git_origin):
+    repo = git_origin()
+    repo.commit({"a.md": "alpha\n", "b.md": "beta\n"}, message="two files")
+    calls: list[tuple[str, ...]] = []
+
+    class CountingRunner:
+        def run(self, argv, *, timeout, stdin=None):
+            calls.append(tuple(argv))
+            return subprocess.run(
+                list(argv), capture_output=True, input=b"" if stdin is None else stdin
+            )
+
+    mirror = LocalGitMirror(repo.checkout, repo=repo.repo, runner=CountingRunner())
+    shas = (repo.blob_sha("a.md"), repo.blob_sha("b.md"))
+    texts = mirror.read_blobs(shas)
+
+    assert texts == {shas[0]: "alpha\n", shas[1]: "beta\n"}
+    assert sum(1 for call in calls if "cat-file" in call) == 1

--- a/tests/test_monitor_work_providers.py
+++ b/tests/test_monitor_work_providers.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-import base64
 import subprocess
 from pathlib import Path
 
@@ -828,22 +827,32 @@ def test_workflow_registry_rejects_completion_record_outside_safe_root(tmp_path)
     )
 
 
-def test_github_terminal_provider_reads_closing_refs_and_remote_archive():
+def test_github_terminal_provider_reads_closing_refs_and_remote_archive(git_origin):
+    repo = git_origin()
+    repo.commit(
+        {"openspec/changes/archive/2026-07-17-work/proposal.md": "# archived\n"},
+        message="archive",
+    )
+    head = repo.branch_commit("feature/9-work", {"src.py": "x = 1\n"})
+    merge = repo.merge("feature/9-work")
     graph = {
         "data": {
             "repository": {
-                "defaultBranchRef": {"name": "main", "target": {"oid": "d" * 40}},
+                "defaultBranchRef": {
+                    "name": "main",
+                    "target": {"oid": repo.head()},
+                },
                 "pullRequests": {
                     "pageInfo": {"hasNextPage": False},
                     "nodes": [
                         {
                             "number": 9,
                             "body": "work_item: work\n",
-                            "headRefOid": "e" * 40,
+                            "headRefOid": head,
                             "state": "MERGED",
                             "mergedAt": "2026-07-17T10:00:00Z",
                             "mergeCommit": {
-                                "oid": "a" * 40,
+                                "oid": merge,
                                 "parents": {"totalCount": 2},
                             },
                             "closingIssuesReferences": {
@@ -862,11 +871,11 @@ def test_github_terminal_provider_reads_closing_refs_and_remote_archive():
             {"path": "openspec/changes/archive/2026-07-17-work/proposal.md"}
         ]
     }
-    runner = SequenceRunner(
-        [_completed(graph), _completed(tree), _completed({"status": "ahead"})]
-    )
+    runner = SequenceRunner([_completed(graph), _completed(tree)])
 
-    result = GitHubTerminalProvider("example/acme", runner=runner).scan()
+    result = GitHubTerminalProvider(
+        repo.repo, runner=runner, repo_root=repo.checkout
+    ).scan()
 
     assert result.status == "ok"
     assert result.observations["closing_links"] == {
@@ -875,8 +884,8 @@ def test_github_terminal_provider_reads_closing_refs_and_remote_archive():
     assert result.observations["remote_prs"] == [
         {
             "source_id": "github_pr:example/acme#9",
-            "candidate": "e" * 40,
-            "merge_revision": "a" * 40,
+            "candidate": head,
+            "merge_revision": merge,
             "merged_with_merge_commit": True,
         }
     ]
@@ -887,6 +896,8 @@ def test_github_terminal_provider_reads_closing_refs_and_remote_archive():
         "active": [],
         "archived": ["work"],
     }
+    # D2：ancestry 走本機 merge-base，一輪不再有 compare 請求。
+    assert not any("/compare/" in argv[-1] for argv in runner.calls)
 
 
 def test_github_terminal_provider_aggregates_pull_requests_across_pages():
@@ -1071,11 +1082,23 @@ def test_github_terminal_squash_merge_is_not_a_merge_commit():
     assert not result.observations["remote_prs"][0]["merged_with_merge_commit"]
 
 
-def test_github_terminal_merge_not_on_default_branch_is_not_terminal():
+def test_github_terminal_merge_not_on_default_branch_is_not_terminal(git_origin):
+    repo = git_origin()
+    repo.commit({"README.md": "# base\n"}, message="base")
+    repo.branch_commit("feature/9-work", {"src.py": "x = 1\n"})
+    # merge commit 落在側枝上，default branch 走不到它（等同舊 compare 的 diverged）。
+    repo.git("checkout", "--quiet", "-b", "release", "main")
+    repo.git("merge", "--quiet", "--no-ff", "-m", "side merge", "feature/9-work")
+    merge = repo.head("release")
+    repo.git("checkout", "--quiet", "main")
+    repo.commit({"README.md": "# moved on\n"}, message="advance")
     graph = {
         "data": {
             "repository": {
-                "defaultBranchRef": {"name": "main", "target": {"oid": "d" * 40}},
+                "defaultBranchRef": {
+                    "name": "main",
+                    "target": {"oid": repo.head("main")},
+                },
                 "pullRequests": {
                     "pageInfo": {"hasNextPage": False},
                     "nodes": [
@@ -1084,7 +1107,7 @@ def test_github_terminal_merge_not_on_default_branch_is_not_terminal():
                             "body": "work_item: work\n",
                             "state": "MERGED",
                             "mergedAt": "2026-07-17T10:00:00Z",
-                            "mergeCommit": {"oid": "a" * 40, "parents": {"totalCount": 2}},
+                            "mergeCommit": {"oid": merge, "parents": {"totalCount": 2}},
                             "closingIssuesReferences": {
                                 "pageInfo": {"hasNextPage": False},
                                 "nodes": [{"number": 7, "state": "CLOSED"}],
@@ -1096,28 +1119,39 @@ def test_github_terminal_merge_not_on_default_branch_is_not_terminal():
         }
     }
     runner = SequenceRunner(
-        [
-            _completed(graph),
-            _completed({"truncated": False, "tree": []}),
-            _completed({"status": "diverged"}),
-        ]
+        [_completed(graph), _completed({"truncated": False, "tree": []})]
     )
 
-    result = GitHubTerminalProvider("example/acme", runner=runner).scan()
+    result = GitHubTerminalProvider(
+        repo.repo, runner=runner, repo_root=repo.checkout
+    ).scan()
 
     assert not result.observations["remote_prs"][0]["merged_with_merge_commit"]
 
 
-def test_github_terminal_compares_only_workflow_linked_prs():
-    def merged(number: int, merge: str) -> dict:
+def test_github_terminal_resolves_ancestry_only_for_workflow_linked_prs(git_origin):
+    repo = git_origin()
+    repo.commit({"README.md": "# base\n"}, message="base")
+    merges: dict[int, str] = {}
+    heads: dict[int, str] = {}
+    for number in (8, 9):
+        heads[number] = repo.branch_commit(
+            f"feature/{number}-work", {f"src{number}.py": "x = 1\n"}
+        )
+        merges[number] = repo.merge(f"feature/{number}-work")
+
+    def merged(number: int) -> dict:
         return {
             "number": number,
             "body": "",
             "headRefName": f"feature/{number}-work",
-            "headRefOid": str(number % 10) * 40,
+            "headRefOid": heads[number],
             "state": "MERGED",
             "mergedAt": "2026-07-17T10:00:00Z",
-            "mergeCommit": {"oid": merge, "parents": {"totalCount": 2}},
+            "mergeCommit": {
+                "oid": merges[number],
+                "parents": {"totalCount": 2},
+            },
             "closingIssuesReferences": {
                 "pageInfo": {"hasNextPage": False},
                 "nodes": [{"number": number, "state": "CLOSED"}],
@@ -1127,31 +1161,32 @@ def test_github_terminal_compares_only_workflow_linked_prs():
     graph = {
         "data": {
             "repository": {
-                "defaultBranchRef": {"name": "main", "target": {"oid": "d" * 40}},
+                "defaultBranchRef": {
+                    "name": "main",
+                    "target": {"oid": repo.head()},
+                },
                 "pullRequests": {
                     "pageInfo": {"hasNextPage": False},
-                    "nodes": [merged(8, "a" * 40), merged(9, "b" * 40)],
+                    "nodes": [merged(8), merged(9)],
                 },
             }
         }
     }
     runner = SequenceRunner(
-        [
-            _completed(graph),
-            _completed({"truncated": False, "tree": []}),
-            _completed({"status": "ahead"}),
-        ]
+        [_completed(graph), _completed({"truncated": False, "tree": []})]
     )
 
     result = GitHubTerminalProvider(
-        "example/acme",
+        repo.repo,
         runner=runner,
         relevant_pr_numbers=(9,),
+        repo_root=repo.checkout,
     ).scan()
 
     assert result.status == "ok"
-    assert len(runner.calls) == 3
-    assert "compare/" + "b" * 40 in runner.calls[2][-1]
+    # D2：REST 只剩 graphql ＋ tree；ancestry 完全在本機解，且只解 workflow-linked 的那一個。
+    assert len(runner.calls) == 2
+    assert result.observations["remote_reads"]["ancestry_checks"] == 1
     by_number = {
         int(row["source_id"].rsplit("#", 1)[1]): row
         for row in result.observations["remote_prs"]
@@ -1233,17 +1268,29 @@ def test_github_terminal_does_not_retry_non_transient_api_failure():
     assert len(runner.calls) == 1
 
 
-def test_remote_default_branch_todo_blob_is_only_completion_authority(tmp_path):
+def test_remote_default_branch_todo_blob_is_only_completion_authority(
+    tmp_path, git_origin
+):
     todo = tmp_path / "docs/superpowers/workstreams/work/todo.md"
     todo.parent.mkdir(parents=True)
     todo.write_text("---\nwork_item: work\n---\n- [x] local only\n", encoding="utf-8")
     local = RepoWorkProvider(tmp_path, repo="example/acme").scan()
     assert local.observations.get("closure_by_work", {}) == {}
 
+    # D2：remote 那一份現在從本機 git objects 讀（sha 定址），不再打 contents API。
+    repo = git_origin()
+    todo_path = "docs/superpowers/workstreams/work/todo.md"
+    repo.commit(
+        {todo_path: "---\nwork_item: work\n---\n- [x] remote task\n"},
+        message="remote todo",
+    )
     graph = {
         "data": {
             "repository": {
-                "defaultBranchRef": {"name": "main", "target": {"oid": "d" * 40}},
+                "defaultBranchRef": {
+                    "name": "main",
+                    "target": {"oid": repo.head()},
+                },
                 "pullRequests": {"pageInfo": {"hasNextPage": False}, "nodes": []},
             }
         }
@@ -1252,74 +1299,68 @@ def test_remote_default_branch_todo_blob_is_only_completion_authority(tmp_path):
         "truncated": False,
         "tree": [
             {
-                "path": "docs/superpowers/workstreams/work/todo.md",
+                "path": todo_path,
                 "type": "blob",
-                "sha": "c" * 40,
+                "sha": repo.blob_sha(todo_path),
             }
         ],
     }
-    remote_body = "---\nwork_item: work\n---\n- [x] remote task\n"
-    blob = {
-        "type": "file",
-        "path": "docs/superpowers/workstreams/work/todo.md",
-        "encoding": "base64",
-        "content": base64.b64encode(remote_body.encode()).decode(),
-        "sha": "c" * 40,
-    }
-    runner = SequenceRunner([_completed(graph), _completed(tree), _completed(blob)])
+    runner = SequenceRunner([_completed(graph), _completed(tree)])
 
-    remote = GitHubTerminalProvider("example/acme", runner=runner).scan()
+    remote = GitHubTerminalProvider(
+        repo.repo, runner=runner, repo_root=repo.checkout
+    ).scan()
 
     assert remote.status == "ok"
     assert remote.observations["remote_todos"] == [
         {
             "work_id": "work",
-            "path": "docs/superpowers/workstreams/work/todo.md",
-            "revision": "c" * 40,
+            "path": todo_path,
+            "revision": repo.blob_sha(todo_path),
             "complete": True,
         }
     ]
-    assert runner.calls[2] == (
-        "gh",
-        "api",
-        "--method",
-        "GET",
-        "repos/example/acme/contents/docs/superpowers/workstreams/work/todo.md?ref="
-        + "d" * 40,
-    )
+    assert len(runner.calls) == 2
+    assert not any("/contents/" in argv[-1] for argv in runner.calls)
 
 
-def test_remote_archived_openspec_tasks_are_todo_completion_evidence():
+def test_remote_archived_openspec_tasks_are_todo_completion_evidence(git_origin):
+    repo = git_origin()
+    task_path = "openspec/changes/archive/2026-07-17-canary/tasks.md"
+    repo.commit({task_path: "- [x] task one\n- [x] task two\n"}, message="archive")
     graph = {
         "data": {
             "repository": {
-                "defaultBranchRef": {"name": "main", "target": {"oid": "d" * 40}},
+                "defaultBranchRef": {
+                    "name": "main",
+                    "target": {"oid": repo.head()},
+                },
                 "pullRequests": {"pageInfo": {"hasNextPage": False}, "nodes": []},
             }
         }
     }
-    task_path = "openspec/changes/archive/2026-07-17-canary/tasks.md"
     tree = {
         "truncated": False,
-        "tree": [{"path": task_path, "type": "blob", "sha": "c" * 40}],
+        "tree": [
+            {
+                "path": task_path,
+                "type": "blob",
+                "sha": repo.blob_sha(task_path),
+            }
+        ],
     }
-    blob = {
-        "type": "file",
-        "path": task_path,
-        "encoding": "base64",
-        "content": base64.b64encode(b"- [x] task one\n- [x] task two\n").decode(),
-        "sha": "c" * 40,
-    }
-    runner = SequenceRunner([_completed(graph), _completed(tree), _completed(blob)])
+    runner = SequenceRunner([_completed(graph), _completed(tree)])
 
-    result = GitHubTerminalProvider("example/acme", runner=runner).scan()
+    result = GitHubTerminalProvider(
+        repo.repo, runner=runner, repo_root=repo.checkout
+    ).scan()
 
     assert result.status == "ok"
     assert result.observations["remote_todos"] == [
         {
             "openspec_ref": "canary",
             "path": task_path,
-            "revision": "c" * 40,
+            "revision": repo.blob_sha(task_path),
             "complete": True,
         }
     ]
@@ -1328,33 +1369,42 @@ def test_remote_archived_openspec_tasks_are_todo_completion_evidence():
     ]
 
 
-def test_remote_todo_contents_identity_mismatch_is_degraded():
+def test_remote_todo_blob_absent_from_git_is_degraded(git_origin):
+    """D2：舊的 ``contents`` identity mismatch 由 sha 定址取代。
+
+    blob sha 讀回來的內容不可能對不上（sha 就是內容），剩下的失敗模式只有「物件
+    不在」——那一格必須 degraded，**不得**靜默當成「檔案不存在」而讓 remote todo
+    憑空消失（fail closed）。
+    """
+
+    repo = git_origin()
+    path = "docs/superpowers/workstreams/work/todo.md"
+    repo.commit({path: "---\nwork_item: work\n---\n- [x] task\n"}, message="todo")
+    repo.publish()
     graph = {
         "data": {
             "repository": {
-                "defaultBranchRef": {"name": "main", "target": {"oid": "d" * 40}},
+                "defaultBranchRef": {
+                    "name": "main",
+                    "target": {"oid": repo.head()},
+                },
                 "pullRequests": {"pageInfo": {"hasNextPage": False}, "nodes": []},
             }
         }
     }
-    path = "docs/superpowers/workstreams/work/todo.md"
     tree = {
         "truncated": False,
-        "tree": [{"path": path, "type": "blob", "sha": "c" * 40}],
+        "tree": [{"path": path, "type": "blob", "sha": "e" * 40}],
     }
-    contents = {
-        "type": "file",
-        "path": path,
-        "encoding": "base64",
-        "content": base64.b64encode(b"- [x] task\n").decode(),
-        "sha": "e" * 40,
-    }
-    runner = SequenceRunner([_completed(graph), _completed(tree), _completed(contents)])
+    runner = SequenceRunner([_completed(graph), _completed(tree)])
 
-    result = GitHubTerminalProvider("example/acme", runner=runner).scan()
+    result = GitHubTerminalProvider(
+        repo.repo, runner=runner, repo_root=repo.checkout
+    ).scan()
 
     assert result.status == "degraded"
     assert result.observations == {}
+    assert "git mirror" in result.diagnostics[0]
 
 
 def test_pr_body_work_item_is_not_confirmed_authority():

--- a/tests/test_monitor_work_review_regressions.py
+++ b/tests/test_monitor_work_review_regressions.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 from datetime import datetime, timezone
+from pathlib import Path
 
 import pytest
 
@@ -180,11 +181,20 @@ def test_default_terminal_provider_receives_only_registry_linked_prs(
 
     class CapturingTerminalProvider:
         # #506：預設 terminal provider 現在還會收到共享的 GitHub 壓力閘門
-        # （節流／退避），簽章跟著 work_api 的預設建構路徑走。
-        def __init__(self, repo: str, *, relevant_pr_numbers=None, pressure_gate=None):
-            captured.append((repo, relevant_pr_numbers))
+        # （節流／退避）與 D2 的本機 checkout root，簽章跟著 work_api 的預設
+        # 建構路徑走。
+        def __init__(
+            self,
+            repo: str,
+            *,
+            relevant_pr_numbers=None,
+            pressure_gate=None,
+            repo_root=None,
+        ):
+            captured.append((repo, relevant_pr_numbers, repo_root))
             self.repo = repo
             self.pressure_gate = pressure_gate
+            self.repo_root = repo_root
 
         def scan(self) -> ProviderSnapshot:
             return _provider(f"github-terminal:{self.repo}")
@@ -224,7 +234,9 @@ def test_default_terminal_provider_receives_only_registry_linked_prs(
         include_github=True,
     )
 
-    assert captured == [("example/acme", (9,))]
+    # D2：預設路徑必須把 repo 的 canonical checkout 傳下去，否則 provider 會因為
+    # 沒有鏡像而 fail closed。
+    assert captured == [("example/acme", (9,), Path(tmp_path))]
 
 
 def test_live_provider_freshness_uses_post_scan_clock(tmp_path):

--- a/tests/test_reclaim_pr_inheritance.py
+++ b/tests/test_reclaim_pr_inheritance.py
@@ -171,11 +171,16 @@ def test_new_claim_run_starts_with_empty_pr_refs(tmp_path: Path, monkeypatch: py
     assert start_run.pr_refs == ()
 
 
-def test_terminal_provider_skips_closed_unmerged_pr_closing_links():
+def test_terminal_provider_skips_closed_unmerged_pr_closing_links(git_origin):
+    # D2：merged PR 的 ancestry 走本機 git，因此本例需要一個真的 merge commit。
+    repo = git_origin()
+    repo.commit({"README.md": "# base\n"}, message="base")
+    merged_head = repo.branch_commit("feature/11-work", {"src.py": "x = 1\n"})
+    merge_revision = repo.merge("feature/11-work")
     graph = {
         "data": {
             "repository": {
-                "defaultBranchRef": {"name": "main", "target": {"oid": "d" * 40}},
+                "defaultBranchRef": {"name": "main", "target": {"oid": repo.head()}},
                 "pullRequests": {
                     "pageInfo": {"hasNextPage": False},
                     "nodes": [
@@ -206,11 +211,11 @@ def test_terminal_provider_skips_closed_unmerged_pr_closing_links():
                         {
                             "number": 11,
                             "body": "",
-                            "headRefOid": "g" * 40,
+                            "headRefOid": merged_head,
                             "state": "MERGED",
                             "mergedAt": "2026-07-17T10:00:00Z",
                             "mergeCommit": {
-                                "oid": "a" * 40,
+                                "oid": merge_revision,
                                 "parents": {"totalCount": 2},
                             },
                             "closingIssuesReferences": {
@@ -224,8 +229,10 @@ def test_terminal_provider_skips_closed_unmerged_pr_closing_links():
         }
     }
     tree = {"truncated": False, "tree": []}
-    runner = _FakeRunner([_completed(graph), _completed(tree), _completed({"status": "ahead"})])
-    result = GitHubTerminalProvider("example/acme", runner=runner).scan()
+    runner = _FakeRunner([_completed(graph), _completed(tree)])
+    result = GitHubTerminalProvider(
+        repo.repo, runner=runner, repo_root=repo.checkout
+    ).scan()
 
     assert result.status == "ok"
     assert result.observations["closing_links"] == {


### PR DESCRIPTION
## 背景

v4 重構計畫 R0.5 原則 2「git 的資料走 git」。實測 cortex 一輪掃描對 GitHub REST
發出 **91 次 `contents` 讀取**——讀的全是本機 git checkout 本來就有的 repo 內檔案；
另外 PR ancestry 判定用逐 PR `compare`。REST 有 primary／secondary rate limit，
git 協定（fetch/clone）不受它管轄；0813–0815 三度進 REST 懲罰窗，這兩類是主要
配額消耗之一。

Refs #506

## 1. 呼叫點盤點（全 repo grep `contents` / `/compare/` / `git/trees` / `git/commits` / `git/ref`）

### 本次遷移（掃描迴圈內，高量）

| # | 位置 | 端點 | 量級 | 狀態 |
| --- | --- | --- | --- | --- |
| A1 | `monitor/providers.py::GitHubTerminalProvider._remote_todos`（原 1372 行） | `repos/{repo}/contents/{path}?ref={sha}` | **每個 remote `todo.md`／archived `tasks.md` 各 1 次／輪**（實測 91／輪） | ✅ 已遷移 → `git cat-file --batch`（整批一次） |
| A2 | `monitor/providers.py::GitHubTerminalProvider.scan`（原 1176 行） | `repos/{repo}/compare/{merge}...{default}` | **每個 workflow-linked merged PR 各 1 次／輪** | ✅ 已遷移 → `git merge-base --is-ancestor` |

### 盤點到但本次不動（附理由）

| # | 位置 | 端點 | 量級 | 狀態與理由 |
| --- | --- | --- | --- | --- |
| B1 | `monitor/providers.py::GitHubTerminalProvider.scan`（1098 行） | `repos/{repo}/git/trees/{sha}?recursive=1` | 1 次／輪／repo | ⏸ **不在本次兩類範圍**（非 contents／非 compare），且量級 O(1)。它提供的 path＋blob sha 正是 A1 的定址來源，遷成 `git ls-tree` 是獨立小工項（見「相鄰缺陷」）。 |
| B2 | `coordinator/github_delivery.py::fetch_remote_closure`（827 行） | `repos/{repo}/contents/{path}?ref={sha}` | 每次 **PR closure** N 次（N＝該 run 的 todo_paths，通常 1–2） | ⏸ **不在掃描迴圈內**——由 `work_bridge.complete_*` 每個 workflow run 收尾時觸發一次，不是週期性輪詢，對配額窗的貢獻與 91／輪不同量級。且 coordinator 端沒有 plumb 到該 repo 的 canonical checkout，遷移需要另一條 wiring，屬獨立工項。 |
| B3 | `coordinator/github_delivery.py::fetch_remote_closure`（783 行） | `repos/{repo}/compare/{merge}...{default}` | 每次 PR closure 1 次 | ⏸ 同 B2。 |
| B4 | `coordinator/github_delivery.py`（499／513／771／787 行） | `git/trees`、`git/commits`、`git/ref` | 每次 closure／delivery 各 1 次 | ⏸ 同 B2，且不屬本次兩類。 |
| B5 | `doctor.py`（896／993 行） | 只是字串 `"contents/issues/pull_requests"`（token scope 名稱） | — | ➖ 非 API 呼叫，誤命中。 |

## 2. 改法

新增 `paulsha_cortex/monitor/git_mirror.py`（`LocalGitMirror`），是「本機 git 當成
遠端事實來源」的唯一入口：

- **contents → `git cat-file --batch`**：blob 一律用 REST tree 給的 **blob sha 定址**
  讀取，整批一次讀完（不是每檔一個 process）。sha 定址本身就是內容識別。
- **compare → `git merge-base --is-ancestor`**：判準與 REST `compare` 的
  `status in {ahead, identical}` 等價。
- **一輪最多一次 fetch**：先一次 `cat-file --batch-check` 批次查缺，**有缺才** fetch
  ——因此 fetch 頻率沿用 monitor 既有的 refresh 週期，穩態下一次網路都不打。
- **不污染 operator 的 checkout**：refspec 目的地一律是私有 namespace
  `refs/cortex/mirror/<sha256(repo)[:16]>/*`，並帶 `--refmap=` 關掉 configured
  refspec 的順帶更新——沒有它，即使給了顯式 refspec，git 仍會寫
  `refs/remotes/origin/*`。工作區、index、本地分支一律不動。（有回歸樁釘住
  `refs/remotes` 保持空。）
- **PR head ref**：merge commit 不在本機的 PR，會把 `+refs/pull/<n>/head:<ns>/pull/<n>`
  一併掛進**同一次** fetch（已握有 merge commit 的 PR 不掛，避免徒增失敗面）。
- **身分先驗**：`git config --get remote.origin.url` 必須解析成同一個 `owner/name`
  才動作。讀 **raw config** 而非 `git remote get-url`——後者會套 `url.*.insteadOf`
  改寫，回傳的是 transport 目的地而不是這個 checkout 宣告要追的 repo。
- **wiring**：`work_api.refresh` 把該 repo 在 workspace 的 canonical checkout（與
  `RepoWorkProvider` 同一個 `root`）以 `repo_root=` 傳給 provider。

## 3. fail closed

ref 不存在、fetch 失敗、blob 讀不到、沒有本機 checkout、origin 指向別的 repo、
shallow checkout 無法判 ancestry——一律 raise `GitMirrorError`，provider 轉成
`degraded` 快照（diagnostic 前綴 `github terminal git mirror unavailable:`），
上層 `_retain_last_good` 保留上一份鏡像。**絕不**把讀取失敗靜默降級成「檔案不存在」
或「不是 ancestor」。

`GitMirrorError` 刻意繼承 `OSError`：即使日後有人漏接這個新型別，`scan()` 既有的
catch-all 仍接得住，只會退回通用診斷，不會讓例外逸出 provider。診斷字串不含
"rate limit"，不會誤觸 `claim.py` 的 `provider-authority-rate-limited-canonical`
（有回歸樁）。

provenance 落在 `observations["remote_reads"]`：transport／checkout 路徑／本輪 fetch
的 refspec／缺席物件／blob 讀取數／ancestry 判定數。

## 4. 語意差異（逐一說明）

1. **`remote Todo content identity mismatch` 這個失敗模式消失了。** 舊路徑要比對
   `contents` 回應的 `type`／`path`／`sha`／`encoding` 四項，防的是「REST 回了別的
   檔案」。sha 定址下內容不可能對不上（sha 就是內容），這四項比對由 git 的
   content-addressing 取代。剩下的失敗模式只有「物件不在本機」——兩者都 degraded，
   語意等價（回歸樁：`test_remote_todo_blob_absent_from_git_is_degraded`）。
2. **REST 回 404 vs git ref/object 不存在。** 這條路徑只讀 REST tree 已經列出的
   blob，兩邊都不會走到「路徑不存在」。真正會出現的是「物件不在本機」，我們
   **不**把它當成 404（檔案不存在），而是 fail closed。
3. **ancestry 判的是 merge commit，不是 PR head。** 計畫書寫的是「fetch
   `refs/pull/<n>/head` ＋ `merge-base --is-ancestor`」；實際被取代的 `compare` 的
   base 是 **merge commit**（`mergeCommit.oid`），不是 PR head——squash／rebase merge
   的 head 根本不是 default branch 的祖先。為維持行為等價，`is_ancestor` 的第一個
   參數仍是 merge commit；`refs/pull/<n>/head` 依計畫一併 fetch，但只在該 PR 的
   merge commit 缺席時掛上，且屬**選配**：remote 沒有該 ref（fork mirror／非 GitHub
   remote）時退回只 fetch default branch，不讓一條選配 refspec 把整輪打成 degraded
   （回歸樁：`test_pull_head_refspec_is_optional_when_origin_lacks_it`）。
4. **「merge commit 不在本機」＝「不是 ancestor」的成立前提。** default branch tip
   已在本機且 repo **非 shallow** 時，git 保證其祖先全部在本機，因此物件缺席就是
   「走不到」，等同 `compare` 回 `behind`／`diverged`。shallow clone 破壞這個前提，
   所以 shallow ＋ 缺物件一律 fail closed，不猜（回歸樁：
   `test_shallow_checkout_cannot_decide_ancestry`）。
5. **節流語意縮小。** `github_pressure` 的 throttle 只掛在 REST 請求前；git 操作
   不經該路徑（節流一個不受 REST limit 管轄的協定只是白白拖慢掃描）。已更新
   `github_pressure.py` 的模組 docstring 與 `docs/monitor-config.md`。

## 5. 量化：91+／輪 → 0

驗收樁 `tests/test_monitor_git_native_reads_506.py::test_scan_round_issues_zero_rest_contents_and_compare_calls`
以 recording runner 直接數 argv：

| | 改動前 | 改動後 |
| --- | --- | --- |
| 該樁那一輪（12 個 todo ＋ 3 個 merged PR） | `contents` 12 次 ＋ `compare` 3 次 | **0 ＋ 0** |
| 同輪 REST 總數 | 17 次 | **2 次**（graphql 分頁 ＋ git tree） |
| 生產 workspace 一輪（實測基準） | `contents` **91 次** ＋ `compare` N 次 | **0 ＋ 0** |

另有 `test_github_terminal_resolves_ancestry_only_for_workflow_linked_prs` 釘住
「REST 只剩 2 次、ancestry 只解 workflow-linked 的那一個」。

## 6. 測試

- 新增 `tests/test_monitor_git_native_reads_506.py`（16 個測試）：量化驗收、本機讀取、
  fetch 補物件、PR head refspec 選配／必要兩路、缺物件 fail closed、無 checkout
  fail closed、origin 不符 fail closed、fetch 失敗 ＋ `_retain_last_good` 保留、
  shallow fail closed、branch 名注入防護、object id 驗證、批次讀取只開一個 process。
- `tests/conftest.py` 新增 `git_origin` fixture：bare `origin` ＋ 本機 checkout 的
  **真** git repo，origin URL 字面值是 GitHub HTTPS、transport 由
  `url.<local>.insteadOf` 改寫到 tmp 目錄。**不打真實 GitHub API、不連網。**
- 既有測試改用同一 fixture：`test_monitor_work_providers.py`（5 個）、
  `test_reclaim_pr_inheritance.py`（1 個）、`test_monitor_work_review_regressions.py`
  （預設 provider 簽章 ＋ 釘住 `repo_root` 有被傳下去）。
- 全套 `python3 -m pytest -q`：**2710 passed, 49 subtests passed, 2 failed**。
  2 個 failure 是 `tests/test_fix_dispatch_spec_path.py` 的
  `_infer_repo_root` 兩樁，**與本 PR 無關且在 `main` 上以同樣方式失敗**——該測試
  假設 `tmp_path` 之上沒有任何 `.git`，本機環境有一個殘留的空 `/tmp/.git` 就會讓
  `_infer_repo_root` 走到 `/tmp`（測試自身的 hermeticity 缺陷，見「相鄰缺陷」）。
- `python3 -m policy_check`（帶 PR 上下文）：**pass 24 / fail 0 / warn 1**
  （R-22 為陳年 README 懸空引用，WARN 不擋）。

## 7. 相鄰缺陷（供 operator 開 issue，本 PR 不處理）

1. **`repos/{repo}/git/trees/{sha}?recursive=1` 仍走 REST**（1 次／輪／repo）。既然
   default branch commit 已經在本機，`git ls-tree -r -t -z` 可以完全取代它，順帶
   幹掉「tree truncated（>100k entries）」這個 REST 限制。約 40 repo × 1 次／輪。
2. **`coordinator/github_delivery.py::fetch_remote_closure` 的 contents／compare
   未遷移**（B2／B3）。需要先把 repo 的 canonical checkout plumb 到 coordinator。
3. **`tests/test_fix_dispatch_spec_path.py` 的兩樁不 hermetic**：`_infer_repo_root`
   會一路往上走找 `.git`，測試沒有把 `tmp_path` 隔離在一個「祖先都沒有 `.git`」的
   環境裡，機器上任何 `/tmp/.git`（甚至 `/`）都會讓它們紅。
4. **`monitor/providers.py` 的 `Any` import 未使用**（`main` 上既有）。
5. **shallow / partial clone 的 workspace 會讓 ancestry 永久 degraded**：目前是
   fail closed（正確），但沒有自癒路徑（例如自動 `--unshallow` 或明確診斷指引
   operator）。若 fleet 裡真有 shallow checkout，需要一個決策。

## Checklist

- [x] `changelog.d/d2-git-native-reads.md` fragment 已新增且已 commit
- [x] `CHANGELOG.md [Unreleased]` 有對應 entry（`### Changed`）
- [x] `VERSION` 未動（非 release PR）
- [x] 測試通過（除 2 個與本 PR 無關、`main` 上同樣紅的環境敏感樁）
- [x] `policy_check` 帶 PR 上下文跑過：fail 0
- [x] docs 同步（`docs/monitor-config.md` 新增「git 的資料走 git」段）
- [x] 只動讀取路徑；寫入與 D3（`state=all&since=`＋ETag）不在本次
- [x] 帶 `policy-exempt:issue-link`：本 PR 只 `Refs #506`（GitHub 邊界家族母 issue），
      不關閉它
