### PR TITLE
fix(coordinator): 診斷 invariant 家族強制狀態轉換附帶結構化理由

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,33 @@
   `changelog.d/marker-word-boundary.md`。新增
   `tests/test_planning_drift_classification_554.py`（47 個回歸測試）。
 
+- **診斷 invariant 家族（#527／#514／#515／#511／#482）：把「理由」從慣例升格成型別**
+  ——0813–0814 **五次**獨立命中同一條缺口：狀態被推向「人要接手」的那一刻，理由沒有
+  跟著落地。#527 的 build 階段無聲掛 `needs_human`（無 evidence、無 slice、
+  `cortex status` 不呈現、`next_actions` 空）、#514 的 brainstorm 重驗例外不含路徑與
+  原因、#515 的 `_post_integration_artifact_evidence()` **14 個裸 `return None`** 塌
+  縮成不透明的 `primary-artifact-invalid`、#511 的 planning artifact 拒收原因到不了
+  run、#482 的 absent evidence key 不含原因或 identity——五個形態不同、根卻同一條，
+  逐案補洞（#397／#408／#513 各補過一次）已證明無效。**invariant**：任何把 run 轉入
+  `needs_human`、或把 evidence 標為 absent 的狀態變更，必須同時落一份結構化理由（機
+  器可讀 reason ＋ 人可讀 detail ＋ 來源位置）並可由 `cortex status`／`work show` 曝
+  光。修法是把驗證層擋在**唯一**的進入點上：新增 `coordinator/diagnostics.py` 的
+  `DiagnosticReason`，並在 registry 的兩個狀態轉移 API（全庫唯一能把 `needs_human`
+  寫進 run row 的入口）強制「加 facet 必須帶理由／移除 facet 一併清理由／facet 已在
+  則沿用既有理由」三條規則，`WorkflowRun` 新增 `needs_human_reason` 欄位持有它；既有
+  部署那種「facet 有、理由沒有」的 legacy run 刻意放行，載入時 fail-closed 會把
+  manager 打掛。配套的**掃描式 invariant 測試**以 AST 枚舉全庫所有設置點斷言每一個都
+  帶理由（另有反證測試防止掃描器壞掉偽裝成通過）。呈現面：`manager.workflow_status_
+  entry()` 把 ongoing 且 needs_human 的 run 投影進 `cortex status` 的 `attention`
+  ——過去狀態快照 provider 只走 `list_slices()`，而 workflow lane 從不建立 slice
+  row，run 在五份清單裡一份都不出現；理由另經 monitor observations 曝光到
+  `cortex work show` 的 `blocking_reason`。#482 另把 pre-launch absent evaluation 的
+  落點納入原因與請求身分的指紋，`missing → unknown → registered` 這條合法的設定推進
+  不再需要刪 evidence 才能前進。**範圍紀律**：只修診斷與理由，後續處置（retry／
+  needs_human／fail-closed 邏輯）一律不變；呈現面沿用既有欄位機制，未另立平行欄位體
+  系。詳見 `changelog.d/diagnostic-invariant-family.md`。新增
+  `tests/test_diagnostic_invariant_family_527.py`（32 個測試）。
+
 - **Issue #536（後半）：planning artifacts 發佈與 run 狀態更新不是同一事務，中間態對
   所有恢復迴圈永久隱形**——define 的 brainstorm 有兩次分離的 durable 寫入：先發佈
   spec/design/plan 到 operator worktree，再把 run 推進到 `plan` 並寫入 gate_refs／

--- a/changelog.d/diagnostic-invariant-family.md
+++ b/changelog.d/diagnostic-invariant-family.md
@@ -1,0 +1,80 @@
+---
+type: fix
+scope: coordinator
+---
+**診斷 invariant 家族（#527／#514／#515／#511／#482）：把「理由」從慣例升格成型別**
+
+0813–0814 **五次**獨立命中同一條缺口：狀態被推向「人要接手」的那一刻，理由沒有
+跟著落地。五個現場形態不同、根卻同一條，逐案補洞已證明無效（#397／#408／#513 各
+補過一次，缺口照樣在下一個地方冒出來）。
+
+| issue | 現場 |
+| --- | --- |
+| #527 | build 階段無聲掛 `needs_human`——無 evidence、無 slice、`cortex status` 不呈現、`next_actions` 空 |
+| #514 | brainstorm artifact 重驗失敗的例外不含路徑與原因 |
+| #515 | `_post_integration_artifact_evidence()` 的 **14 個裸 `return None`** 塌縮成不透明的 `primary-artifact-invalid` |
+| #511 | planning artifact 拒收未帶原因也不留存內容（#513 已修訊息與 evidence，但那份結構化理由到不了 run） |
+| #482 | retry-review 的 absent evidence key 不含原因或 identity，合法重試撞 immutable artifact |
+
+### invariant
+
+> 任何把 run 轉入 `needs_human`、或把 evidence 標為 absent 的狀態變更，必須同時
+> 落一份結構化理由（機器可讀 reason ＋ 人可讀 detail ＋ 來源位置）到 run 或
+> evidence，並可由 `cortex status`／`work show` 曝光。
+
+### 修法：驗證層擋在唯一的進入點上
+
+新增 `coordinator/diagnostics.py` 的 `DiagnosticReason`（reason／detail／source
+＋可選的 evidence_refs／context），並在 registry 的狀態轉移 API
+（`_manager_update_workflow_run`／`_manager_create_workflow_run`——全庫**唯一**兩
+個能把 `needs_human` 寫進 run row 的入口）強制三條規則：把 facet 加進去必須帶理由
+（否則 `DiagnosticInvariantError`）、facet 移出時理由一併清掉（陳舊理由比沒有理由
+更糟）、facet 已在而這次沒帶新理由則沿用既有理由（大量呼叫端會重複寫同一個
+facet，第一次的理由才是根因）。`WorkflowRun` 新增 `needs_human_reason` 欄位持有這
+份理由，並鎖住「理由不得與 facet 脫鉤」；「facet 有、理由沒有」則刻意放行，既有
+部署的狀態檔裡就躺著這種 run，載入時 fail-closed 會把 manager 打掛。
+
+配套的**掃描式 invariant 測試**以 AST 枚舉全庫所有把 `needs_human` 寫進 facets 的
+設置點，斷言每一個都同時帶理由——新增一條忘了帶理由的設置點會在單元測試就炸，不
+必等到 dogfooding 現場。掃描器本身另有反證測試（一個刻意違規的樣本必須被抓出來），
+避免「掃描器壞掉」偽裝成「invariant 通過」。
+
+### 五張 issue 的補洞點
+
+- **#527**：`manager_daemon` resume 迴圈的例外過去只被 `_log_error` print 到
+  stderr（由 service-manager 導向 `~/.agents/log/manager.log`），run 上只剩一個沒
+  有理由的 facet；`exc` 就在手上，現在寫進 run。呈現面補上：狀態快照 provider 過
+  去只走 `list_slices()`，而 workflow lane 從不建立 slice row，run 因此在
+  `ready`／`held`／`slices`／`attention`／`recent_done` 五份清單裡**一份都不出現**
+  ——新增 `manager.workflow_status_entry()` 把 ongoing 且 needs_human 的 run 投影進
+  同一份 `attention` 清單。
+- **#514**：`_validated_brainstorm_planning_authority()` 迴圈裡每一條 raise 都補上
+  `ref=`；assessment 拒收沿用 #513 的 `(reasons=...; markers=Lnn:...; evidence=...)`
+  格式與 `cortex-planning-artifact-rejection/v1` evidence 落檔。依 0814 adversarial
+  review 的修正，診斷同時做在**真正會被走到的** hash drift 分支上（「artifact 在磁
+  碟上被改動」走不到 assessment），訊息帶 evidence／disk 兩邊的 digest。
+- **#515**：14 個裸 `return None` 全部改為帶原因的 `ArtifactEvidenceFailure`，環境
+  類（symlink／路徑逃逸／非一般檔案／解碼失敗）與內容類（assessment 不合格／整合
+  後仍不完整）分得開；assessment 類拒收透過新的 `rejection_recorder` 注入點沿用
+  #513 的 evidence 落檔（被拒內容會在緊接著的 `rollback_publication()` 被撤下，不
+  先存一份就再也看不到）。另加 AST 回歸樁鎖住「這個函式裡不得再出現裸
+  `return None`」。
+- **#511**：#513 的結構化理由現在經由 invariant 層真的落到 run 上（過去只剩上游
+  `str(exc)[:160]` 截斷後的字串殘骸），並經 monitor observations 曝光到
+  `cortex work show` 的 `blocking_reason`。
+- **#482**：pre-launch absent evaluation 的落點納入**原因與請求身分**的指紋
+  （`absent_evaluation_key()`）。同原因＋同身分仍是冪等重寫；不同原因或不同身分則
+  各自落地，`missing → unknown → registered` 這條合法的設定推進不再需要刪 evidence
+  才能前進，前一份 absent evidence 原位保留。reviewer job 已存在時的
+  `{slice_id}-{reviewer_job_id}.json` 一字未動。
+
+### 範圍紀律
+
+只修「診斷與理由」。後續處置（retry／needs_human／fail-closed 邏輯）一律不變——每
+個呼叫端原本會做什麼，改完之後照樣做什麼，只是多落一份可稽核的理由。呈現面沿用既
+有欄位機制（`blocking_reason`／`provider_outcome`／`gate_reason`），沒有另立平行欄
+位體系；`next_actions` 只沿用既有的 `_build_phase_recovery_actions`（只宣告會被受
+理的動作，#382 的教訓），不新增任何處置判定。
+
+新增 `tests/test_diagnostic_invariant_family_527.py`（32 個測試：掃描式 invariant
+＋執行期強制＋五張 issue 的原始現場 fixture）。

--- a/paulsha_cortex/cli.py
+++ b/paulsha_cortex/cli.py
@@ -258,6 +258,17 @@ def _work_read_main(args: list[str], *, work_client=None) -> int:
         print(f"{item.get('work_id', '-')}  {item.get('state', '-')}  {item.get('title', '-')}")
         print(f"repo: {item.get('repo', '-')}")
         print(f"phase: {item.get('phase') or '-'}")
+        # 診斷 invariant（#527）：run 掛著 needs_human 時的結構化理由。過去
+        # `work show` 只印 work_id/state/title/repo/phase，理由（若存在）連
+        # `--json` 都拿不到——這是「四個介面同時沉默」的其中一個。
+        blocking = data.get("blocking_reason")
+        if isinstance(blocking, dict) and blocking.get("reason"):
+            print(f"needs_human: {blocking.get('reason')}: {blocking.get('detail')}")
+            print(f"  source: {blocking.get('source')}")
+            if blocking.get("run_id"):
+                print(f"  run_id: {blocking.get('run_id')}")
+            for ref in blocking.get("evidence_refs") or []:
+                print(f"  evidence: {ref}")
         if parsed.explain:
             print(json.dumps(data.get("explanation", {}), ensure_ascii=False, indent=2))
     return 0

--- a/paulsha_cortex/coordinator/diagnostics.py
+++ b/paulsha_cortex/coordinator/diagnostics.py
@@ -1,0 +1,284 @@
+"""診斷 invariant 家族（#527／#514／#515／#511／#482）的單一理由契約。
+
+0813–0814 五次獨立命中同一條缺口：狀態被推向「人要接手」的那一刻，**理由沒有
+跟著落地**。五個現場形態不同、根卻同一條——
+
+- **#527**：`manager_daemon` 的 workflow resume 迴圈把例外只 `print` 進
+  `~/.agents/log/manager.log`，run 上只留一個沒有理由的 `needs_human` facet；
+  `cortex status`／`work show`／`tick`／`complete` 四個介面同時沉默。
+- **#514**：`_validated_brainstorm_planning_authority()` 對已發佈 artifact 的
+  重驗失敗只丟一句 `workflow brainstorm artifact is not accepted`，不含 ref、
+  不含 `assess_planning_artifact()` 已經算好的 `reasons`／`markers`。
+- **#515**：`_post_integration_artifact_evidence()` 的 14 個裸 `return None`
+  把 symlink／路徑逃逸／解碼失敗／assessment 拒收全塌縮成一個
+  `primary-artifact-invalid`——環境類與內容類無從分辨。
+- **#511**：planning artifact 拒收未帶原因也不留存內容（PR #513 已修
+  `_publish_planning_artifacts` 的訊息與 evidence，但那份結構化理由到不了 run，
+  只能靠上游 `str(exc)[:160]` 截斷後的字串殘骸）。
+- **#482**：retry-review 的 absent evidence key 不含原因也不含 identity，合法
+  重試撞上 immutable artifact。
+
+逐案補洞已證明無效（五次），因此把「理由」本身升格成**型別**：任何把 run 轉入
+`needs_human`／`degraded`、或把 evidence 標為 absent 的狀態變更，都必須提供一份
+:class:`DiagnosticReason`——機器可讀 ``reason`` ＋ 人可讀 ``detail`` ＋ 來源位置
+``source``（＋可選的 evidence 位置與 context）。強制點在 registry 的狀態轉移
+API（見 ``registry._manager_update_workflow_run``／``_manager_create_workflow_run``），
+「忘記帶理由」因此在單元測試就炸，而不是在 dogfooding 現場靜默停滯。
+
+**範圍**：本模組只管「診斷與理由」。後續處置（retry／needs_human／fail-closed
+邏輯）一律不變——每個呼叫端原本會做什麼，改完之後照樣做什麼，只是多落一份可
+稽核的理由。
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Mapping
+
+__all__ = [
+    "DIAGNOSTIC_REASON_SCHEMA_VERSION",
+    "DIAGNOSTIC_DETAIL_MAX_LENGTH",
+    "DIAGNOSTIC_CONTEXT_VALUE_MAX_LENGTH",
+    "DiagnosticInvariantError",
+    "DiagnosticReason",
+    "diagnostic_reason",
+    "coerce_diagnostic_reason",
+    "summarize_exception",
+]
+
+
+DIAGNOSTIC_REASON_SCHEMA_VERSION = 1
+
+# `reason` 是機器可讀的分類碼：小寫、無空白、無換行。呼叫端既有的 reason 字面值
+# （`planning-publication-drift`、`provider-retry-exhausted`、
+# `reviewer-identity-missing` …）本來就是這個形狀，刻意沿用而不另立詞彙表——
+# 收斂成封閉 enum 會逼所有 lane 同步一張表，正是 #542 想避免的第三處列舉。
+# 底線一併放行：既有詞彙有一部分直接來自 snake_case 識別字（plan review 的
+# `contract_compatibility`、provider outcome 的 `rate_limited`），把它們硬改成
+# kebab 會讓同一個概念在 reason 與回傳值裡長得不一樣。
+DIAGNOSTIC_REASON_CODE_RE = re.compile(r"[a-z0-9]+(?:[-_][a-z0-9]+)*")
+
+# `source` 是來源位置：`<module>.<function>` 或再加 `:<標記>` 細分同一函式內的
+# 多個出口（例如 `manager.resume_workflow_run:planning-authority`）。
+DIAGNOSTIC_SOURCE_RE = re.compile(r"[A-Za-z0-9_.]+(?::[A-Za-z0-9_.\-]+)?")
+
+# `detail` 上限：比照 `manager.PLANNING_ARTIFACT_REJECTION_MESSAGE_MAX_LENGTH`
+# 的 400。完整內容一律以 evidence 為準，detail 只負責讓 operator 在 `cortex
+# status` 一行內看懂「卡在什麼事上」。
+DIAGNOSTIC_DETAIL_MAX_LENGTH = 400
+
+# context 每個值的上限：context 是給機器再消費的小欄位（run_id／card／path／
+# identity），不是給長文用的。
+DIAGNOSTIC_CONTEXT_VALUE_MAX_LENGTH = 200
+
+# context 最多幾個 key：擋住把整包 payload 倒進 run row 的用法。
+DIAGNOSTIC_CONTEXT_MAX_KEYS = 16
+
+_CONTEXT_KEY_RE = re.compile(r"[a-z0-9]+(?:_[a-z0-9]+)*")
+
+
+class DiagnosticInvariantError(ValueError):
+    """狀態轉入 needs_human／degraded／absent 卻沒帶結構化理由。
+
+    刻意繼承 ``ValueError``：registry 全部的 fail-closed 驗證都是 ``ValueError``，
+    而 daemon 的 tick isolation（#246）攔的也是 ``(ValueError, RuntimeError,
+    OSError)``——沿用同一族，違反 invariant 不會把整個 daemon 打掛，但在單元
+    測試裡會直接讓該筆狀態轉換失敗。
+    """
+
+
+def _utcnow() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _single_line(text: str) -> str:
+    """壓成單行。
+
+    理由字串會流進 `recover-planning` 的 `failure_reason` 與 evidence 的
+    `reason` 欄位，兩者都明確拒收換行（見 `work_actions`／`control.contract`
+    對 `"\\n" in failure_reason` 的檢查）。
+    """
+
+    return " ".join(str(text).split())
+
+
+@dataclass(frozen=True)
+class DiagnosticReason:
+    """一份結構化理由。
+
+    三個必要欄位對應 invariant 的三個要素：
+
+    - ``reason``：機器可讀分類碼（kebab-case），供 `work show`／`status` 分支與
+      operator grep。
+    - ``detail``：人可讀單行敘述，說明「實際發生什麼」。
+    - ``source``：來源位置（`<module>.<function>[:<出口標記>]`），讓 operator
+      不必反推是哪一條路徑寫的。
+
+    ``evidence_refs`` 指向已落檔的完整內容（planning-artifacts rejection、
+    planning-recovery、gate evaluation…）；``context`` 是小型 string→string 的
+    機器可讀附註（run_id、card、path、reviewer identity…）。
+    """
+
+    reason: str
+    detail: str
+    source: str
+    evidence_refs: tuple[str, ...] = ()
+    context: Mapping[str, str] = field(default_factory=dict)
+    recorded_at: str | None = None
+    schema_version: int = DIAGNOSTIC_REASON_SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        if self.schema_version != DIAGNOSTIC_REASON_SCHEMA_VERSION:
+            raise DiagnosticInvariantError(
+                f"diagnostic reason schema_version 非法: {self.schema_version!r}"
+            )
+        if not isinstance(self.reason, str) or DIAGNOSTIC_REASON_CODE_RE.fullmatch(self.reason) is None:
+            raise DiagnosticInvariantError(
+                f"diagnostic reason 必須為 kebab-case 機器可讀碼: {self.reason!r}"
+            )
+        if not isinstance(self.detail, str) or not self.detail.strip():
+            raise DiagnosticInvariantError("diagnostic detail 必須為非空人可讀字串")
+        if not isinstance(self.source, str) or DIAGNOSTIC_SOURCE_RE.fullmatch(self.source) is None:
+            raise DiagnosticInvariantError(
+                f"diagnostic source 必須為 <module>.<function>[:<標記>]: {self.source!r}"
+            )
+        detail = _single_line(self.detail)
+        if len(detail) > DIAGNOSTIC_DETAIL_MAX_LENGTH:
+            detail = detail[:DIAGNOSTIC_DETAIL_MAX_LENGTH].rstrip() + "…"
+        object.__setattr__(self, "detail", detail)
+        if not isinstance(self.evidence_refs, tuple) or any(
+            not isinstance(item, str) or not item.strip() for item in self.evidence_refs
+        ):
+            raise DiagnosticInvariantError("diagnostic evidence_refs 必須為非空字串 tuple")
+        if not isinstance(self.context, Mapping):
+            raise DiagnosticInvariantError("diagnostic context 必須為 mapping")
+        if len(self.context) > DIAGNOSTIC_CONTEXT_MAX_KEYS:
+            raise DiagnosticInvariantError(
+                f"diagnostic context key 數逾限（上限 {DIAGNOSTIC_CONTEXT_MAX_KEYS}）"
+            )
+        normalized: dict[str, str] = {}
+        for key, value in self.context.items():
+            if not isinstance(key, str) or _CONTEXT_KEY_RE.fullmatch(key) is None:
+                raise DiagnosticInvariantError(f"diagnostic context key 非法: {key!r}")
+            if value is None:
+                continue
+            text = _single_line(value)
+            if len(text) > DIAGNOSTIC_CONTEXT_VALUE_MAX_LENGTH:
+                text = text[:DIAGNOSTIC_CONTEXT_VALUE_MAX_LENGTH].rstrip() + "…"
+            normalized[key] = text
+        object.__setattr__(self, "context", normalized)
+        if self.recorded_at is None:
+            object.__setattr__(self, "recorded_at", _utcnow())
+        elif not isinstance(self.recorded_at, str) or not self.recorded_at:
+            raise DiagnosticInvariantError("diagnostic recorded_at 必須為 ISO8601 字串")
+
+    def to_dict(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "schema_version": self.schema_version,
+            "reason": self.reason,
+            "detail": self.detail,
+            "source": self.source,
+            "recorded_at": self.recorded_at,
+        }
+        if self.evidence_refs:
+            payload["evidence_refs"] = list(self.evidence_refs)
+        if self.context:
+            payload["context"] = dict(self.context)
+        return payload
+
+    @classmethod
+    def from_dict(cls, payload: object) -> DiagnosticReason:
+        if not isinstance(payload, Mapping):
+            raise DiagnosticInvariantError("diagnostic reason 格式錯誤")
+        unknown = set(payload) - {
+            "schema_version",
+            "reason",
+            "detail",
+            "source",
+            "recorded_at",
+            "evidence_refs",
+            "context",
+        }
+        if unknown:
+            raise DiagnosticInvariantError(
+                f"diagnostic reason 含未知欄位: {sorted(unknown)}"
+            )
+        evidence_refs = payload.get("evidence_refs", ())
+        if isinstance(evidence_refs, (list, tuple)):
+            evidence_refs = tuple(evidence_refs)
+        else:
+            raise DiagnosticInvariantError("diagnostic evidence_refs 格式錯誤")
+        context = payload.get("context") or {}
+        return cls(
+            reason=payload.get("reason"),
+            detail=payload.get("detail"),
+            source=payload.get("source"),
+            evidence_refs=evidence_refs,
+            context=context,
+            recorded_at=payload.get("recorded_at"),
+            schema_version=payload.get("schema_version", DIAGNOSTIC_REASON_SCHEMA_VERSION),
+        )
+
+    def rendered(self) -> str:
+        """單行摘要：`<reason>: <detail> (source=…; evidence=…)`。
+
+        `cortex status` 的 attention 條目與例外訊息共用這一份渲染，避免同一份
+        理由在兩個介面長得不一樣。
+        """
+
+        details = [f"source={self.source}"]
+        if self.evidence_refs:
+            details.append("evidence=" + ",".join(self.evidence_refs))
+        return _single_line(f"{self.reason}: {self.detail} ({'; '.join(details)})")
+
+
+def diagnostic_reason(
+    reason: str,
+    detail: str,
+    *,
+    source: str,
+    evidence_refs: tuple[str, ...] | list[str] = (),
+    recorded_at: str | None = None,
+    **context: object,
+) -> DiagnosticReason:
+    """建構 :class:`DiagnosticReason` 的呼叫端捷徑。
+
+    ``**context`` 收 string→string 的機器可讀附註；``None`` 值自動略去，讓呼叫
+    端可以直接把可能為 ``None`` 的欄位（`card`、`job_id`、`candidate`）傳進來
+    而不必逐個判斷。
+    """
+
+    return DiagnosticReason(
+        reason=reason,
+        detail=detail,
+        source=source,
+        evidence_refs=tuple(evidence_refs),
+        context={key: str(value) for key, value in context.items() if value is not None},
+        recorded_at=recorded_at,
+    )
+
+
+def coerce_diagnostic_reason(value: object) -> DiagnosticReason | None:
+    """把 registry 呼叫端傳進來的值正規化成 :class:`DiagnosticReason`。
+
+    接受 ``DiagnosticReason`` 本身或它的 dict 投影（狀態檔往返後就是 dict），
+    ``None`` 原樣回傳，其餘一律 fail-closed。
+    """
+
+    if value is None:
+        return None
+    if isinstance(value, DiagnosticReason):
+        return value
+    return DiagnosticReason.from_dict(value)
+
+
+def summarize_exception(exc: BaseException, *, limit: int = 200) -> str:
+    """例外的單行摘要：`<型別>: <訊息前 N 字>`。
+
+    沿用 #397／#408 已定案的格式（`f"{type(exc).__name__}: {str(exc)[:160]}"`），
+    只是收成一份實作——五個現場各自手寫一次正是理由格式漂移的來源。
+    """
+
+    return _single_line(f"{type(exc).__name__}: {str(exc)[:limit]}")

--- a/paulsha_cortex/coordinator/manager.py
+++ b/paulsha_cortex/coordinator/manager.py
@@ -39,6 +39,7 @@ from .spawn_admission import SpawnAdmissionLimiter, resolve_limiter, resolve_pro
 from .registry import slice_repin_eligible
 from ..config.paths import worktree_root_for
 from .claim import AuthorityValidationError, REASON_PROVIDER_RATE_LIMITED_CANONICAL, decomposition_route
+from .diagnostics import DiagnosticReason, diagnostic_reason, summarize_exception
 from .model_identities import (
     AGY_DOMAIN,
     AGY_LIVE_PROBE,
@@ -672,6 +673,59 @@ def slice_status_entry(registry, slice_row: dict, *, handoff_dir: str, git_runne
         "current_evidence_refs": list(slice_row.get("current_evidence_refs") or []),
         "current_evaluation_refs": list(slice_row.get("current_evaluation_refs") or []),
         "next_actions": allowed_slice_actions(registry, slice_row),
+        # 診斷 invariant：slice lane 的 attention 條目沿用既有的 `reason`／
+        # `provider_outcome`，沒有結構化理由可帶；`kind` 只是用來與同一份
+        # attention 清單裡的 workflow run 條目區分（#527 之前這份清單只有
+        # slice，run 完全不出現）。
+        "kind": "slice",
+        "blocking_reason": None,
+    }
+
+
+def workflow_status_entry(registry, run) -> dict[str, Any]:
+    """#527：把 `needs_human` 的 workflow run 投影成 attention 條目。
+
+    現場（run ``workflow-6607ac1307feb02ffe06``）：run 停在 build 階段掛著
+    `needs_human`，`cortex status` 的 `slices`／`ready`／`held`／`attention`
+    四份清單卻**一份都不含它**——狀態快照 provider 只走 `list_slices()`，從來
+    沒有呼叫過 `list_workflow_runs()`。`manager.reconcile_planning_transactions`
+    裡「補 needs_human facet，讓 cortex status 的 attention 清單有話說」那句
+    註解描述的投影，實際上並不存在。
+
+    欄位刻意沿用 slice 條目既有的詞彙（`slice_state`／`reason`／`next_actions`
+    ／`blocking_reason`），不另立一套平行欄位體系：既有的文字模式渲染與
+    `entry.get("slice_state") == "needs_human"` 這類過濾器因此原樣可用。
+    """
+
+    reason_payload = getattr(run, "needs_human_reason", None)
+    reason_code: str | None = None
+    if isinstance(reason_payload, dict):
+        value = reason_payload.get("reason")
+        if isinstance(value, str) and value:
+            reason_code = value
+    next_actions: tuple[str, ...] = ()
+    try:
+        from .work_actions import _build_phase_recovery_actions
+
+        next_actions = _build_phase_recovery_actions(run, registry)
+    except Exception:  # noqa: BLE001 - 呈現面不得因曝光計算失敗而讓 status 死掉
+        next_actions = ()
+    return {
+        "kind": "workflow_run",
+        "run_id": run.run_id,
+        "work_id": run.work_id,
+        "repo": run.repo,
+        "current_phase": run.current_phase,
+        "slice_state": "needs_human",
+        "gate_state": run.gate_status,
+        "reason": reason_code,
+        # 結構化理由整份帶出去（機器可讀 reason ＋ 人可讀 detail ＋ 來源位置
+        # ＋ evidence 位置）。欄位名沿用 `claim.ClaimDecision.blocking_reason`
+        # ——那是全庫既有的「為什麼卡住」欄位，不另發明。
+        "blocking_reason": dict(reason_payload) if isinstance(reason_payload, dict) else None,
+        "evidence_refs": list(run.evidence_refs),
+        "next_actions": list(next_actions),
+        "updated_at": run.updated_at,
     }
 
 
@@ -2753,27 +2807,69 @@ def _validated_brainstorm_planning_authority(
             target.relative_to(workspace)
         except ValueError as exc:
             raise ValueError("workflow brainstorm artifact escapes workspace") from exc
+        # #514：以下每一條 raise 過去都只有一句沒有主詞的英文。本函式在迴圈裡
+        # 掃多個 ref，operator 拿到訊息時完全不知道是哪一個 artifact 出問題——
+        # 而上游 `resume_workflow_run` 又把整個例外吞掉、只回一個籠統的
+        # `planning-authority-reconciliation-failed`。訊息一律補上 `ref=`。
         if not target.is_file():
-            raise ValueError("workflow brainstorm artifact hash drift")
+            raise ValueError(
+                f"workflow brainstorm artifact hash drift: ref={ref} (檔案不存在或不是一般檔案)"
+            )
         data = target.read_bytes()
-        if hashlib.sha256(data).hexdigest() != digest:
-            raise ValueError("workflow brainstorm artifact hash drift")
+        actual_digest = hashlib.sha256(data).hexdigest()
+        if actual_digest != digest:
+            # 0814 adversarial review 的修正：「artifact 在磁碟上被改動」這個
+            # 情境**先在這裡**失敗，走不到下面的 assessment 分支。它才是
+            # revalidation 最常見的現場，因此診斷必須做在這一條上。
+            raise ValueError(
+                f"workflow brainstorm artifact hash drift: ref={ref} "
+                f"(evidence={digest[:12]}; disk={actual_digest[:12]})"
+            )
         existing = persisted.get(ref)
         if existing is None:
             if not any(fnmatch.fnmatch(ref, pattern) for pattern in declared_patterns):
-                raise ValueError("workflow brainstorm artifact outside planner outputs")
+                raise ValueError(
+                    f"workflow brainstorm artifact outside planner outputs: ref={ref} "
+                    f"(declared={','.join(declared_patterns) or '-'})"
+                )
             try:
                 text = data.decode("utf-8")
             except UnicodeDecodeError as exc:
-                raise ValueError("workflow brainstorm artifact unreadable") from exc
-            if not assess_planning_artifact(PlanningArtifact(kind=kind, ref=ref, text=text)).accepted:
-                raise ValueError("workflow brainstorm artifact is not accepted")
+                raise ValueError(
+                    f"workflow brainstorm artifact unreadable: ref={ref} "
+                    f"({type(exc).__name__}: {str(exc)[:80]})"
+                ) from exc
+            assessment = assess_planning_artifact(PlanningArtifact(kind=kind, ref=ref, text=text))
+            if not assessment.accepted:
+                # 沿用 #513 的 `(reasons=...; markers=Lnn:...; evidence=...)`
+                # 格式與 `cortex-planning-artifact-rejection/v1` evidence 落檔，
+                # 讓首次寫入拒收與重驗拒收對 operator 長得一模一樣。
+                evidence_ref = _record_planning_artifact_rejection_evidence(
+                    coordinator_root=Path(coordinator_root) if coordinator_root else None,
+                    run_id=run.run_id,
+                    work_id=run.work_id,
+                    assessment=assessment,
+                )
+                message = _planning_artifact_rejection_message(
+                    assessment, evidence_ref=evidence_ref
+                )
+                logger.error(
+                    "workflow-brainstorm-artifact-rejected run_id=%s work_id=%s %s",
+                    run.run_id,
+                    run.work_id,
+                    message,
+                )
+                raise ValueError(f"workflow brainstorm artifact is not accepted: {message}")
         elif (
             existing.kind != kind
             or existing.work_id != run.work_id
             or existing.baseline_sha256 != digest
         ):
-            raise ValueError("workflow brainstorm artifact differs from persisted authority")
+            raise ValueError(
+                f"workflow brainstorm artifact differs from persisted authority: ref={ref} "
+                f"(kind={existing.kind}→{kind}; "
+                f"baseline={existing.baseline_sha256[:12]}→{digest[:12]})"
+            )
         scanned[ref] = PlanningArtifactAuthority(
             ref=ref,
             kind=kind,
@@ -2806,7 +2902,10 @@ def _validated_brainstorm_planning_authority(
             )
         }
         if unresolved:
-            raise ValueError("workflow brainstorm evidence omits persisted authority")
+            raise ValueError(
+                "workflow brainstorm evidence omits persisted authority: refs="
+                + ",".join(sorted(unresolved)[:5])
+            )
     # `ordered` 起始自 `run.planning_authority`（即 `persisted` 的來源），
     # 因此上面被判定為合法副本的 materialized plan entry 原樣留在回傳值
     # 裡——它必須繼續存在，好讓 build worktree 透過 `_workflow_input_snapshot`
@@ -6239,6 +6338,17 @@ def reconcile_planning_transactions(
                         run.run_id,
                         facets=tuple(dict.fromkeys((*run.facets, "needs_human"))),
                         gate_status="running",
+                        needs_human_reason=diagnostic_reason(
+                            "planning-publication-drift",
+                            f"planning 發佈事務無法自動收斂：{str(exc)[:200]}",
+                            source="manager.reconcile_planning_transactions",
+                            run_id=run.run_id,
+                            # sweep 走的是 `list_workflow_runs()` 的任意 row，
+                            # 注入型測試會給不完整的替身；診斷欄位缺席不得讓
+                            # 「呈現 needs_human」這件事本身失敗。
+                            work_id=getattr(run, "work_id", None),
+                            journal=str(path),
+                        ),
                     )
                     record["surfaced"] = True
                 except Exception as surface_exc:  # noqa: BLE001 - 呈現失敗不得吃掉診斷
@@ -7593,9 +7703,31 @@ def _dispatch_workflow_card(
                 # 3）。每次 dispatch 都會重新檢查 sizing_band，band 跨帶上升
                 # 至 red 時同樣在此攔下、不會以原身分繼續推進（驗收條件 4）。
                 route = decomposition_route(decomposition_depth=run.decomposition_depth)
+                route_reason = (
+                    "decomposition-depth-exceeded"
+                    if route == "needs_human"
+                    else "needs-decomposition"
+                )
                 updated = registry._manager_update_workflow_run(
                     run.run_id,
                     facets=tuple(dict.fromkeys((*run.facets, route))),
+                    # route 為 `needs_decomposition` 時不帶理由（那不是本 invariant
+                    # 的管轄範圍，且它自己就是可讀的路由結論）；只有轉入
+                    # `needs_human`（拆分深度已達 #223 的上限、不能再拆）才落理由。
+                    needs_human_reason=(
+                        diagnostic_reason(
+                            route_reason,
+                            f"sizing_band=red 但 decomposition_depth 已達上限"
+                            f"（depth={run.decomposition_depth}），不得再拆一層",
+                            source="manager._dispatch_workflow_card:decomposition-route",
+                            run_id=run.run_id,
+                            work_id=run.work_id,
+                            sizing_band=run.sizing_band,
+                            decomposition_depth=str(run.decomposition_depth),
+                        )
+                        if route == "needs_human"
+                        else None
+                    ),
                 )
                 return {
                     "run_id": updated.run_id,
@@ -7619,7 +7751,18 @@ def _dispatch_workflow_card(
                 if gate_outcome is not None and not gate_outcome.ready:
                     if gate_outcome.terminal:
                         updated = registry._manager_update_workflow_run(
-                            run.run_id, facets=tuple(dict.fromkeys((*run.facets, "needs_human"))),
+                            run.run_id,
+                            facets=tuple(dict.fromkeys((*run.facets, "needs_human"))),
+                            needs_human_reason=diagnostic_reason(
+                                f"plan-review-{gate_outcome.failed_check}",
+                                "Yellow band 的機械 plan review 判定為終局不通過"
+                                f"（failed_check={gate_outcome.failed_check}）",
+                                source="manager._dispatch_workflow_card:plan-review",
+                                run_id=run.run_id,
+                                work_id=run.work_id,
+                                card=step.card,
+                                sizing_band=run.sizing_band,
+                            ),
                         )
                         return {
                             "run_id": updated.run_id,
@@ -7715,6 +7858,16 @@ def _dispatch_workflow_card(
         updated = registry._manager_update_workflow_run(
             run.run_id,
             facets=tuple(dict.fromkeys((*run.facets, "needs_human"))),
+            needs_human_reason=diagnostic_reason(
+                f"runtime-preflight-{gate.result.outcome.value}",
+                "runtime preflight 在建立 worktree／job 之前判定不可派工："
+                f"{gate.reason or gate.result.blocking_reason() or gate.result.outcome.value}",
+                source="manager._dispatch_workflow_card:runtime-preflight",
+                run_id=run.run_id,
+                work_id=run.work_id,
+                card=step.card,
+                outcome=gate.result.outcome.value,
+            ),
         )
         return {
             "run_id": updated.run_id,
@@ -8229,9 +8382,19 @@ def resume_workflow_run(
             journal_root=Path(coordinator_root),
             run=run,
         )
-    except PlanningPublicationDrift:
+    except PlanningPublicationDrift as exc:
         updated = registry._manager_update_workflow_run(
-            run.run_id, facets=("needs_human",), gate_status="running"
+            run.run_id,
+            facets=("needs_human",),
+            gate_status="running",
+            needs_human_reason=diagnostic_reason(
+                "planning-publication-drift",
+                f"resume 前 reconcile planning 發佈事務偵測到 drift：{str(exc)[:200]}",
+                source="manager.resume_workflow_run:planning-publication-drift",
+                run_id=run.run_id,
+                work_id=run.work_id,
+                phase=run.current_phase,
+            ),
         )
         return {
             "run_id": updated.run_id,
@@ -8249,12 +8412,26 @@ def resume_workflow_run(
                     coordinator_root=coordinator_root,
                 )
             )
-        except ValueError:
+        except ValueError as exc:
             current = registry.get_workflow_run(run.run_id)
             updated = registry._manager_update_workflow_run(
                 run.run_id,
                 facets=tuple(dict.fromkeys((*current.facets, "needs_human"))),
                 gate_status=pre_resume_gate_status,
+                # #514：這條路徑過去把例外整個丟掉，run 上只留下
+                # `planning-authority-reconciliation-failed` 這個籠統的回傳值
+                # （而回傳值在 daemon periodic tick 根本沒人消費）。
+                # `_validated_brainstorm_planning_authority` 現在會把 ref、
+                # assessment reasons 與 blocking marker 行號寫進例外訊息，
+                # 這裡原樣透傳進 run 的結構化理由。
+                needs_human_reason=diagnostic_reason(
+                    "planning-authority-reconciliation-failed",
+                    f"已發佈 planning artifact 的重驗失敗：{summarize_exception(exc, limit=300)}",
+                    source="manager.resume_workflow_run:planning-authority",
+                    run_id=run.run_id,
+                    work_id=run.work_id,
+                    phase=run.current_phase,
+                ),
             )
             return {
                 "run_id": updated.run_id,
@@ -8298,12 +8475,21 @@ def resume_workflow_run(
                 retry_failed=retry,
                 spawn_admission=spawn_admission,
             )
-        except Exception:
+        except Exception as exc:
             current = registry.get_workflow_run(bound_run.run_id)
             registry._manager_update_workflow_run(
                 bound_run.run_id,
                 facets=tuple(dict.fromkeys((*current.facets, "needs_human"))),
                 gate_status="running",
+                needs_human_reason=diagnostic_reason(
+                    "workflow-card-dispatch-failed",
+                    f"派工卡片時擲出例外：{summarize_exception(exc)}",
+                    source="manager.resume_workflow_run:dispatch_or_stop",
+                    run_id=bound_run.run_id,
+                    work_id=bound_run.work_id,
+                    phase=bound_run.current_phase,
+                    retry="true" if retry else "false",
+                ),
             )
             raise
 
@@ -8346,6 +8532,14 @@ def resume_workflow_run(
                     run.run_id,
                     facets=tuple(dict.fromkeys((*current.facets, "needs_human"))),
                     gate_status="failed",
+                    needs_human_reason=diagnostic_reason(
+                        "review-advance-failed",
+                        f"review→ship 的 advance 擲出例外：{summarize_exception(exc)}",
+                        source="manager.resume_workflow_run:review-advance",
+                        run_id=run.run_id,
+                        work_id=run.work_id,
+                        card=last.card,
+                    ),
                 )
                 raise
         if run.current_phase == "ship" and run.status == "done" and post_merge_closure:
@@ -8473,7 +8667,19 @@ def resume_workflow_run(
                 }
             failure_reason = "provider-retry-exhausted"
         updated = registry._manager_update_workflow_run(
-            run.run_id, facets=("needs_human",), gate_status="running"
+            run.run_id,
+            facets=("needs_human",),
+            gate_status="running",
+            needs_human_reason=diagnostic_reason(
+                failure_reason,
+                "builder/reviewer job 以 provider 層失敗終局，"
+                f"bounded retry 已耗盡或不可重試：{diagnostics.reason or failure_reason}",
+                source="manager._poll_workflow_job:provider-failure",
+                run_id=run.run_id,
+                work_id=run.work_id,
+                job_id=str(job["job_id"]),
+                card=step.card,
+            ),
         )
         return {
             "run_id": run.run_id,
@@ -8502,6 +8708,18 @@ def resume_workflow_run(
                 run.run_id,
                 facets=tuple(dict.fromkeys((*current.facets, "needs_human"))),
                 gate_status="running",
+                needs_human_reason=diagnostic_reason(
+                    "card-terminal-schema-retry-exhausted",
+                    "同一張卡的 terminal envelope 連續 schema mismatch 已達上限"
+                    f"（{seen}/{terminal_contract.MAX_SCHEMA_RETRIES}）："
+                    f"{diagnostics.reason or 'terminal envelope 不符契約'}",
+                    source="manager._poll_workflow_job:schema-retry",
+                    run_id=run.run_id,
+                    work_id=run.work_id,
+                    job_id=str(job["job_id"]),
+                    card=step.card,
+                    validation_path=diagnostics.validation_path,
+                ),
             )
             return {
                 "run_id": run.run_id,
@@ -8541,7 +8759,7 @@ def resume_workflow_run(
             job_id=str(job["job_id"]),
             coordinator_root=coordinator_root,
         )
-    except Exception:
+    except Exception as exc:
         _discard_reviewer_sandbox(
             registry.get_job(str(job["job_id"])),
             coordinator_root=coordinator_root,
@@ -8552,6 +8770,15 @@ def resume_workflow_run(
             run.run_id,
             facets=tuple(dict.fromkeys((*current.facets, "needs_human"))),
             gate_status="running",
+            needs_human_reason=diagnostic_reason(
+                "terminalize-workflow-job-failed",
+                f"採信 terminal envelope 時擲出例外：{summarize_exception(exc)}",
+                source="manager._poll_workflow_job:terminalize",
+                run_id=run.run_id,
+                work_id=run.work_id,
+                job_id=str(job["job_id"]),
+                card=step.card,
+            ),
         )
         raise
     phase_steps = [item for item in run.steps if item.phase == run.current_phase]
@@ -8591,6 +8818,16 @@ def resume_workflow_run(
             run.run_id,
             facets=tuple(dict.fromkeys((*current.facets, "needs_human"))),
             gate_status="running",
+            needs_human_reason=diagnostic_reason(
+                "workflow-advance-failed",
+                f"卡片通過後推進 workflow 擲出例外：{summarize_exception(exc)}",
+                source="manager._poll_workflow_job:advance",
+                run_id=run.run_id,
+                work_id=run.work_id,
+                job_id=str(job["job_id"]),
+                card=step.card,
+                next_phase=next_phase,
+            ),
         )
         raise
     updated = registry.get_workflow_run(run.run_id)
@@ -8850,7 +9087,18 @@ def apply_workflow_action(
                     raise ValueError("local Copilot evidence is never trusted")
                 if ship_validator is None:
                     updated = registry._manager_update_workflow_run(
-                        run_id, facets=("needs_human",), gate_status="running"
+                        run_id,
+                        facets=("needs_human",),
+                        gate_status="running",
+                        needs_human_reason=diagnostic_reason(
+                            "ship-validator-unavailable",
+                            "review→ship 需要 ship validator 判定交付狀態，"
+                            "但呼叫端沒有提供（無法自行採信本地 Copilot 證據）",
+                            source="manager.apply_workflow_action:advance-ship",
+                            run_id=run_id,
+                            work_id=current.work_id,
+                            card=card_id,
+                        ),
                     )
                     return {
                         "run_id": updated.run_id,
@@ -8881,13 +9129,27 @@ def apply_workflow_action(
                         "reason": "delivery-in-progress",
                     }
                 if status == "needs_human":
+                    delivery_reason = trusted.get("reason") or "delivery-needs-human"
                     updated = registry._manager_update_workflow_run(
-                        run_id, facets=("needs_human",), gate_status="running"
+                        run_id,
+                        facets=("needs_human",),
+                        gate_status="running",
+                        needs_human_reason=diagnostic_reason(
+                            "delivery-needs-human",
+                            "ship validator 判定交付需要人工介入："
+                            f"{delivery_reason}",
+                            source="manager.apply_workflow_action:advance-ship",
+                            run_id=run_id,
+                            work_id=current.work_id,
+                            card=card_id,
+                            candidate=current.candidate_head,
+                            delivery_reason=str(delivery_reason),
+                        ),
                     )
                     return {
                         "run_id": updated.run_id,
                         "current_phase": updated.current_phase,
-                        "reason": trusted.get("reason") or "delivery-needs-human",
+                        "reason": delivery_reason,
                     }
                 refs = {item.kind: item for item in current.gate_refs}
                 review_kind = trusted["review_kind"]
@@ -9058,6 +9320,17 @@ def apply_workflow_action(
                 candidate_head=candidate,
                 verified_head=verified,
                 facets=tuple(dict.fromkeys((*current.facets, "needs_human"))),
+                needs_human_reason=diagnostic_reason(
+                    "blocking-findings",
+                    "reviewer 對 candidate 提出阻擋性 findings"
+                    f"（{len(evaluation.get('findings') or ())} 條），review gate 判定 rejected",
+                    source="manager.apply_workflow_action:advance-review",
+                    run_id=run_id,
+                    work_id=current.work_id,
+                    card=card_id,
+                    candidate=candidate,
+                    evidence_refs=(evidence_path,) if evidence_path else (),
+                ),
             )
             return {
                 "run_id": updated.run_id,
@@ -9079,11 +9352,23 @@ def apply_workflow_action(
             validate_workflow_phase_transition(current.current_phase, next_phase)
         facets = current.facets
         gate_status = current.gate_status
+        # 診斷 invariant：下面兩條會把 run 推進 needs_human 的分支各自帶上理由，
+        # 交給同一個 `_manager_update_workflow_run` 呼叫寫入（見結尾）。
+        facets_reason = None
         if current.current_phase == "review" and phase_done and next_phase == "ship":
             if ship_validator is None:
                 next_phase = "review"
                 facets = ("needs_human",)
                 gate_status = "running"
+                facets_reason = diagnostic_reason(
+                    "ship-validator-unavailable",
+                    "review 全數通過但呼叫端未提供 ship validator，"
+                    "無法判定交付狀態（本地 Copilot 證據一律不採信）",
+                    source="manager.apply_workflow_action:advance-phase",
+                    run_id=run_id,
+                    work_id=current.work_id,
+                    card=card_id,
+                )
             else:
                 status, trusted = validate_ship_result(
                     ship_validator(run=current, candidate=candidate),
@@ -9117,9 +9402,20 @@ def apply_workflow_action(
                     next_phase = "review"
                     gate_status = "running"
                     facets = ("needs_human",)
+                    facets_reason = diagnostic_reason(
+                        "delivery-needs-human",
+                        "ship validator 判定交付需要人工介入："
+                        f"{trusted.get('reason') or 'delivery-needs-human'}",
+                        source="manager.apply_workflow_action:advance-phase",
+                        run_id=run_id,
+                        work_id=current.work_id,
+                        card=card_id,
+                        candidate=candidate,
+                    )
         updated = registry._manager_update_workflow_run(
             run_id,
             current_phase=next_phase,
+            needs_human_reason=facets_reason,
             steps=(
                 _validated_ship_steps(
                     registry,
@@ -9275,9 +9571,19 @@ def apply_workflow_action(
             journal_root=transaction_root,
             run=run,
         )
-    except PlanningPublicationDrift:
+    except PlanningPublicationDrift as exc:
         run = registry._manager_update_workflow_run(
-            run.run_id, facets=("needs_human",), gate_status="running"
+            run.run_id,
+            facets=("needs_human",),
+            gate_status="running",
+            needs_human_reason=diagnostic_reason(
+                "planning-publication-drift",
+                f"start 前 reconcile planning 發佈事務偵測到 drift：{str(exc)[:200]}",
+                source="manager.apply_workflow_action:start",
+                run_id=run.run_id,
+                work_id=run.work_id,
+                artifact_root=str(artifact_root),
+            ),
         )
         return {
             "run_id": run.run_id,
@@ -9367,6 +9673,15 @@ def apply_workflow_action(
                 facets=("needs_human",),
                 brainstorm_required=True,
                 evidence_refs=evidence_refs,
+                needs_human_reason=diagnostic_reason(
+                    "planning-runtime-initialization-failed",
+                    f"planning runtime 初始化失敗：{summarize_exception(exc)}",
+                    source="manager.apply_workflow_action:start-planning-runtime",
+                    evidence_refs=evidence_refs,
+                    run_id=run.run_id,
+                    work_id=run.work_id,
+                    classification="environment",
+                ),
             )
             # #391：needs_human 的 reason 過去只塞進回傳值——daemon periodic
             # tick 觸發時（未經活人在旁的 request/response）沒人消費回傳值，
@@ -9406,6 +9721,16 @@ def apply_workflow_action(
             facets=("needs_human",),
             brainstorm_required=True,
             evidence_refs=evidence_refs,
+            needs_human_reason=diagnostic_reason(
+                "planning-runtime-unavailable",
+                "planning runtime 三個角色（primary_questioner／secondary_planner／"
+                "primary_integrator）未齊備，brainstorm 無法啟動",
+                source="manager.apply_workflow_action:start-planning-runtime",
+                evidence_refs=evidence_refs,
+                run_id=run.run_id,
+                work_id=run.work_id,
+                classification="environment",
+            ),
         )
         # #391：runtime_factory 沒被呼叫（或呼叫成功但沒補齊三個角色）時同樣
         # 落一筆 log，理由同上——reason 不能只活在回傳值裡。
@@ -9457,6 +9782,16 @@ def apply_workflow_action(
             coordinator_root=transaction_root,
         ),
         evidence_writer=publication.write_evidence,
+        # #515：post-integration 檢查判定 artifact 不合驗收條件時，被拒內容會在
+        # 緊接著的 `rollback_publication()` 被撤下——不先存一份，operator 就再也
+        # 看不到 planner 到底寫了什麼（#511 的同一個教訓）。沿用 #513 已建立的
+        # `cortex-planning-artifact-rejection/v1` evidence 落檔，不另創格式。
+        rejection_recorder=lambda assessment: _record_planning_artifact_rejection_evidence(
+            coordinator_root=transaction_root,
+            run_id=run.run_id,
+            work_id=run.work_id,
+            assessment=assessment,
+        ),
         # #535：brainstorm evidence 的 content-addressed 命名納入 run identity，
         # 前一世代（已 abandon）的殘留檔才不會佔住新世代的落點。前代檔案原位
         # 保留、原路徑仍可稽核——evidence 不搬不刪。
@@ -9482,15 +9817,34 @@ def apply_workflow_action(
         # worktree 在 planning 視窗內被動過。#543 之後 drift 不再銷毀任何資料
         # （只備份與報告），語意上就是環境事件，同歸 `environment`。
         brainstorm_not_ready_reason = result.reason or "brainstorm-not-ready"
+        # #554／PR #560：分類收斂進具名的 `_classify_planning_failure`（reason →
+        # classification 的單一可測入口，含 worktree drift 的 environment 例外）。
+        # 這裡把它 hoist 成區域變數，好讓 evidence 與 needs_human_reason 兩者
+        # 引用**同一個**判定結果，不各算一次。
+        brainstorm_classification = _classify_planning_failure(brainstorm_not_ready_reason)
+        brainstorm_evidence_refs = _record_planning_failure_evidence(
+            run,
+            coordinator_root=transaction_root,
+            classification=brainstorm_classification,
+            reason=brainstorm_not_ready_reason,
+        )
         run = registry._manager_update_workflow_run(
             run.run_id,
             facets=("needs_human",),
             brainstorm_required=True,
-            evidence_refs=_record_planning_failure_evidence(
-                run,
-                coordinator_root=transaction_root,
-                classification=_classify_planning_failure(brainstorm_not_ready_reason),
-                reason=brainstorm_not_ready_reason,
+            evidence_refs=brainstorm_evidence_refs,
+            # #515／#511：`result.reason` 現在帶得動實際的拒收原因（哪一個
+            # artifact、哪一條驗收條件、還是環境類的路徑／編碼問題），不再是
+            # 一個籠統的 `primary-artifact-invalid`。這裡把它原樣落進 run，
+            # operator 不必再從 `~/.agents/log` 反推。
+            needs_human_reason=diagnostic_reason(
+                "brainstorm-not-ready",
+                f"brainstorm 未收斂（state={result.state}）：{brainstorm_not_ready_reason}",
+                source="manager.apply_workflow_action:start-brainstorm",
+                evidence_refs=brainstorm_evidence_refs,
+                run_id=run.run_id,
+                work_id=run.work_id,
+                classification=brainstorm_classification,
             ),
         )
         # #391：run_heterogeneous_brainstorm 沒能收斂到 ready 狀態時，同樣的

--- a/paulsha_cortex/coordinator/manager_daemon.py
+++ b/paulsha_cortex/coordinator/manager_daemon.py
@@ -20,6 +20,7 @@ from paulsha_cortex.config import paths
 from ..control import constants, contract
 from . import autonomy, backoff, manager, planning_runtime
 from .cli import _refuse_unsafe_fanout, _resolve_launcher
+from .diagnostics import diagnostic_reason, summarize_exception
 from .dispatcher import Dispatcher
 from .model_identities import load_model_identities
 from .registry import JobRegistry
@@ -428,6 +429,25 @@ def build_runtime_status_provider(
                 slices.append(entry)
                 if entry.get("slice_state") == "needs_human":
                     attention.append(entry)
+        # #527：workflow run 過去完全不進 status——快照 provider 只走
+        # `list_slices()`，而 workflow lane 從不建立 slice row。run 停在 build
+        # 掛著 needs_human 時，`ready`／`held`／`slices`／`attention`／
+        # `recent_done` 五份清單一份都不含它，operator 無從分辨它是在等什麼、
+        # 還是已經壞掉。這裡把 ongoing 且 needs_human 的 run 投影進同一份
+        # attention 清單（連同結構化理由）。
+        list_workflow_runs = getattr(registry, "list_workflow_runs", None)
+        if callable(list_workflow_runs):
+            try:
+                runs = list(list_workflow_runs())
+            except Exception:  # noqa: BLE001 - 呈現面失效不得癱瘓整份 status
+                runs = []
+            for run in runs:
+                if (
+                    getattr(run, "status", None) != "ongoing"
+                    or "needs_human" not in getattr(run, "facets", ())
+                ):
+                    continue
+                attention.append(manager.workflow_status_entry(registry, run))
         return {
             "ready": ready,
             "held": held,
@@ -682,7 +702,7 @@ def build_request_executor(
                                 raise RuntimeError(
                                     f"{args.get('action')} produced no builder Job"
                                 )
-                        except Exception:
+                        except Exception as exc:
                             if forced_builder_retry:
                                 current = registry.get_workflow_run(run.run_id)
                                 registry._manager_update_workflow_run(
@@ -691,6 +711,15 @@ def build_request_executor(
                                         dict.fromkeys((*current.facets, "needs_human"))
                                     ),
                                     gate_status="running",
+                                    needs_human_reason=diagnostic_reason(
+                                        "forced-builder-retry-failed",
+                                        "operator 要求的 builder 重派沒有產生新 job："
+                                        f"{summarize_exception(exc)}",
+                                        source="manager_daemon._execute_request:retry-build",
+                                        run_id=run.run_id,
+                                        work_id=run.work_id,
+                                        action=str(args.get("action")),
+                                    ),
                                 )
                             raise
                         if job is not None:
@@ -1023,10 +1052,29 @@ def build_periodic_tick_runner(
                             "source_revision": workflow.source_revision,
                         },
                     )
+                    # #527 的根因就在這三行：例外只被 `_log_error` print 到
+                    # stderr，而 stderr 由 `service-manager.sh` 導向
+                    # `~/.agents/log/manager.log`——不進 journal、不進 evidence、
+                    # 不進 run。run 上只剩一個沒有理由的 `needs_human` facet，
+                    # 於是 `cortex status`／`work show`／`tick`／`complete`
+                    # 四個介面同時無話可說（實測 run
+                    # `workflow-6607ac1307feb02ffe06`：真正的原因是
+                    # `ValueError: worktree target already exists`，但 operator
+                    # 完全看不到）。exc 就在手上，寫進 run 的成本近乎零。
                     registry._manager_update_workflow_run(
                         workflow.run_id,
                         facets=("needs_human",),
                         gate_status="running",
+                        needs_human_reason=diagnostic_reason(
+                            "resume-workflow-failed",
+                            f"periodic tick 續跑 workflow 時擲出例外："
+                            f"{summarize_exception(exc)}",
+                            source="manager_daemon.periodic_tick:resume-workflow",
+                            run_id=workflow.run_id,
+                            work_id=workflow.work_id,
+                            repo=workflow.repo,
+                            phase=workflow.current_phase,
+                        ),
                     )
         metas = scan_specs_fn(specs_dir)
         _refuse_unsafe_fanout(metas, predicate, allow_unsafe=default_allow_unsafe)

--- a/paulsha_cortex/coordinator/planning.py
+++ b/paulsha_cortex/coordinator/planning.py
@@ -951,54 +951,163 @@ def _validate_primary_integration(
     }
 
 
+# --- issue #515：post-integration artifact 檢查的 14 個裸 return None ----------
+#
+# 修法前這個函式的每一條失敗路徑都是 `return None`：symlink、路徑逃逸、非一般
+# 檔案、UTF-8 解碼失敗、`assess_planning_artifact()` 判定不合格……語意完全不同
+# 的失敗全部塌縮成同一個回傳值，呼叫端只能給出 `primary-artifact-invalid` 五個
+# 字。operator 因此無法分辨究竟是「planner 產出的內容不合驗收條件」（可改
+# prompt／需人工裁決）還是「檔案系統層的路徑／權限／編碼問題」（環境問題，
+# 處置完全不同），也不知道是哪一個 artifact。
+#
+# 這正是 #397／#408 已針對「裸吞分支」做過兩輪儀器化、本函式是同一類規模最大
+# 的殘留。改法與那兩輪一致：把失敗升格成帶原因的值。
+#
+# **範圍**：只改「回傳什麼」，不改「呼叫端據此做什麼」——`primary-artifact-invalid`
+# 仍然 needs_human＋rollback_publication，classification 仍然走既有判準。
+@dataclass(frozen=True)
+class ArtifactEvidenceFailure:
+    """一條 post-integration 檢查失敗的結構化原因。"""
+
+    reason: str
+    detail: str
+    ref: str | None = None
+    assessment: ArtifactAssessment | None = None
+
+    def rendered(self) -> str:
+        """壓成單行 reason 字串，供 `BrainstormResult.reason` 使用。
+
+        欄位順序刻意排成 reason → ref → detail：上游
+        `manager._publish_planning_artifacts` 的訊息會再被
+        `str(exc)[:160]` 截斷一次（見 #513 的教訓），最短、最關鍵的分類碼與
+        路徑必須排在最前面才能存活。
+        """
+
+        parts = [self.reason]
+        if self.ref is not None:
+            parts.append(f"ref={self.ref}")
+        parts.append(self.detail)
+        return " ".join(" ".join(str(part).split()) for part in parts)
+
+
+# 內容類：planner 寫出來的東西不合驗收條件——改 prompt／人工裁決可能有效。
+ARTIFACT_EVIDENCE_CONTENT_REASONS = frozenset(
+    {
+        "artifact-assessment-rejected",
+        "post-integration-incomplete",
+        "integration-resolutions-invalid",
+    }
+)
+# 環境類：檔案系統／編碼層面的問題——重跑同一個 planner 不會有幫助。
+ARTIFACT_EVIDENCE_ENVIRONMENT_REASONS = frozenset(
+    {
+        "artifact-root-unresolvable",
+        "artifact-path-escapes-root",
+        "artifact-symlink-rejected",
+        "artifact-not-a-regular-file",
+        "artifact-unreadable",
+    }
+)
+
+
 def _post_integration_artifact_evidence(
     integration: Mapping[str, object],
     artifact_root: str | Path,
     original_report: CompletenessReport,
-) -> tuple[dict[str, str], ...] | None:
+    *,
+    rejection_recorder: Callable[[ArtifactAssessment], str | None] | None = None,
+) -> tuple[dict[str, str], ...] | ArtifactEvidenceFailure:
+    """回傳 artifact evidence，或一條說明「為什麼不行」的 :class:`ArtifactEvidenceFailure`。
+
+    ``rejection_recorder`` 由呼叫端注入（manager 會傳
+    ``_record_planning_artifact_rejection_evidence`` 的閉包），讓
+    assessment 類拒收沿用 #513 的 ``cortex-planning-artifact-rejection/v1``
+    evidence 落檔——被拒內容會在稍後的 ``rollback_publication()`` 被撤下，不先
+    存一份 operator 就再也看不到 planner 到底寫了什麼。
+    """
+
     try:
         root = Path(artifact_root).resolve()
-    except OSError:
-        return None
+    except OSError as exc:
+        return ArtifactEvidenceFailure(
+            "artifact-root-unresolvable",
+            f"artifact root 無法解析: {type(exc).__name__}: {str(exc)[:120]}",
+        )
     rows = integration.get("resolutions")
     if not isinstance(rows, list):
-        return None
+        return ArtifactEvidenceFailure(
+            "integration-resolutions-invalid", "integration.resolutions 不是 list"
+        )
     integrated: dict[str, PlanningArtifact] = {}
-    for row in rows:
+    for index, row in enumerate(rows):
         if not isinstance(row, dict):
-            return None
+            return ArtifactEvidenceFailure(
+                "integration-resolutions-invalid", f"resolutions[{index}] 不是 object"
+            )
         kind = row.get("artifact_kind")
         refs = row.get("artifact_refs")
-        if kind not in PLANNING_KINDS or not isinstance(refs, list) or not refs:
-            return None
+        if kind not in PLANNING_KINDS:
+            return ArtifactEvidenceFailure(
+                "integration-resolutions-invalid",
+                f"resolutions[{index}].artifact_kind 非法: {kind!r}",
+            )
+        if not isinstance(refs, list) or not refs:
+            return ArtifactEvidenceFailure(
+                "integration-resolutions-invalid",
+                f"resolutions[{index}].artifact_refs 必須是非空 list",
+            )
         for ref in refs:
             if not isinstance(ref, str) or not ref.strip():
-                return None
+                return ArtifactEvidenceFailure(
+                    "integration-resolutions-invalid",
+                    f"resolutions[{index}].artifact_refs 含空白或非字串項目",
+                )
             relative = Path(ref)
             if relative.is_absolute() or ".." in relative.parts:
-                return None
+                return ArtifactEvidenceFailure(
+                    "artifact-path-escapes-root",
+                    "artifact ref 為絕對路徑或含 `..`，逃出 artifact root",
+                    ref=ref,
+                )
             try:
                 unresolved = root / relative
                 if unresolved.is_symlink():
-                    return None
+                    return ArtifactEvidenceFailure(
+                        "artifact-symlink-rejected",
+                        "artifact 路徑是 symlink（發佈鏈路一律拒收）",
+                        ref=ref,
+                    )
                 path = unresolved.resolve()
                 path.relative_to(root)
                 if path.is_symlink() or not path.is_file():
-                    return None
+                    return ArtifactEvidenceFailure(
+                        "artifact-not-a-regular-file",
+                        "artifact 解析後不是一般檔案（symlink／目錄／不存在）",
+                        ref=ref,
+                    )
                 text = path.read_text(encoding="utf-8")
-            except (OSError, UnicodeDecodeError, ValueError):
-                return None
+            except (OSError, UnicodeDecodeError, ValueError) as exc:
+                return ArtifactEvidenceFailure(
+                    "artifact-unreadable",
+                    f"讀取 artifact 失敗: {type(exc).__name__}: {str(exc)[:120]}",
+                    ref=ref,
+                )
             artifact = PlanningArtifact(kind=str(kind), ref=ref, text=text)
-            if not assess_planning_artifact(artifact).accepted:
-                return None
+            assessment = assess_planning_artifact(artifact)
+            if not assessment.accepted:
+                return _artifact_assessment_failure(assessment, rejection_recorder)
             integrated[ref] = artifact
 
     post_integration: dict[str, PlanningArtifact] = {}
-    for assessment in original_report.assessments:
-        original = assessment.artifact
+    for assessment_row in original_report.assessments:
+        original = assessment_row.artifact
         relative = Path(original.ref)
         if relative.is_absolute() or ".." in relative.parts:
-            return None
+            return ArtifactEvidenceFailure(
+                "artifact-path-escapes-root",
+                "既有 artifact ref 為絕對路徑或含 `..`，逃出 artifact root",
+                ref=original.ref,
+            )
         replacement = integrated.get(original.ref)
         if replacement is not None:
             post_integration[original.ref] = PlanningArtifact(
@@ -1010,7 +1119,11 @@ def _post_integration_artifact_evidence(
         unresolved = root / relative
         try:
             if unresolved.is_symlink() or not unresolved.is_file():
-                return None
+                return ArtifactEvidenceFailure(
+                    "artifact-not-a-regular-file",
+                    "整合階段未覆寫的既有 artifact 不是一般檔案（symlink／不存在）",
+                    ref=original.ref,
+                )
             resolved = unresolved.resolve()
             resolved.relative_to(root)
             post_integration[original.ref] = PlanningArtifact(
@@ -1018,8 +1131,12 @@ def _post_integration_artifact_evidence(
                 ref=original.ref,
                 text=resolved.read_text(encoding="utf-8"),
             )
-        except (OSError, UnicodeDecodeError, ValueError):
-            return None
+        except (OSError, UnicodeDecodeError, ValueError) as exc:
+            return ArtifactEvidenceFailure(
+                "artifact-unreadable",
+                f"讀取既有 artifact 失敗: {type(exc).__name__}: {str(exc)[:120]}",
+                ref=original.ref,
+            )
     for ref, artifact in integrated.items():
         post_integration.setdefault(ref, artifact)
     final_artifacts: list[PlanningArtifact] = []
@@ -1029,13 +1146,21 @@ def _post_integration_artifact_evidence(
             relative = Path(artifact.ref)
             unresolved = root / relative
             if unresolved.is_symlink():
-                return None
+                return ArtifactEvidenceFailure(
+                    "artifact-symlink-rejected",
+                    "落 evidence 前重讀 artifact 時發現路徑已成為 symlink",
+                    ref=artifact.ref,
+                )
             resolved = unresolved.resolve()
             resolved.relative_to(root)
             content = resolved.read_bytes()
             text = content.decode("utf-8")
-        except (OSError, UnicodeDecodeError, ValueError):
-            return None
+        except (OSError, UnicodeDecodeError, ValueError) as exc:
+            return ArtifactEvidenceFailure(
+                "artifact-unreadable",
+                f"落 evidence 前重讀 artifact 失敗: {type(exc).__name__}: {str(exc)[:120]}",
+                ref=artifact.ref,
+            )
         final_artifacts.append(PlanningArtifact(kind=artifact.kind, ref=artifact.ref, text=text))
         artifact_evidence.append(
             {
@@ -1044,9 +1169,58 @@ def _post_integration_artifact_evidence(
                 "sha256": hashlib.sha256(content).hexdigest(),
             }
         )
-    if not assess_planning_completeness(final_artifacts).complete:
-        return None
+    completeness = assess_planning_completeness(final_artifacts)
+    if not completeness.complete:
+        rejected = [
+            item for item in completeness.assessments if not item.accepted
+        ]
+        detail = "整合後的 artifact 集合仍不完整"
+        if completeness.missing_kinds:
+            detail += f"；missing_kinds={','.join(completeness.missing_kinds)}"
+        if rejected:
+            detail += "；rejected=" + ", ".join(
+                f"{item.artifact.ref}({','.join(item.reasons)})" for item in rejected[:3]
+            )
+        return ArtifactEvidenceFailure("post-integration-incomplete", detail)
     return tuple(artifact_evidence)
+
+
+def _artifact_assessment_failure(
+    assessment: ArtifactAssessment,
+    rejection_recorder: Callable[[ArtifactAssessment], str | None] | None,
+) -> ArtifactEvidenceFailure:
+    """把 `assess_planning_artifact()` 的 reasons／markers 組成結構化原因。
+
+    格式比照 #513 在 `manager._planning_artifact_rejection_message` 定案的
+    `(reasons=...; markers=Lnn:...)`，讓兩個拒收點對 operator 長得一樣。
+    """
+
+    details = [f"reasons={','.join(assessment.reasons)}"]
+    markers = assessment.blocking_markers
+    if markers:
+        rendered = [
+            f"L{marker.line}:" + " ".join(marker.text.split())[:48] for marker in markers[:3]
+        ]
+        if len(markers) > 3:
+            rendered.append(f"+{len(markers) - 3}")
+        details.append("markers=" + ", ".join(rendered))
+    evidence_ref: str | None = None
+    if rejection_recorder is not None:
+        # evidence 記錄本身 fail-open（比照 #513 的
+        # `_record_planning_artifact_rejection_evidence`）：記不下診斷不得掩蓋
+        # 真正的拒收原因。
+        try:
+            evidence_ref = rejection_recorder(assessment)
+        except Exception:  # noqa: BLE001 - evidence 記錄 fail-open
+            evidence_ref = None
+    if evidence_ref is not None:
+        details.append(f"evidence={evidence_ref}")
+    return ArtifactEvidenceFailure(
+        "artifact-assessment-rejected",
+        "; ".join(details),
+        ref=assessment.artifact.ref,
+        assessment=assessment,
+    )
 
 
 @dataclass(frozen=True)
@@ -1170,6 +1344,7 @@ def run_heterogeneous_brainstorm(
     artifact_writer: Callable[[object], Callable[[], None] | None] | None = None,
     evidence_writer: Callable[[Path, object], None] | None = None,
     run_id: str | None = None,
+    rejection_recorder: Callable[[ArtifactAssessment], str | None] | None = None,
 ) -> BrainstormResult:
     empty_refs = PlanningGateRefs()
     if report.complete:
@@ -1246,13 +1421,21 @@ def run_heterogeneous_brainstorm(
                 empty_refs,
                 None,
             )
-    artifact_evidence = _post_integration_artifact_evidence(integration, artifact_root, report)
-    if artifact_evidence is None:
+    artifact_evidence = _post_integration_artifact_evidence(
+        integration,
+        artifact_root,
+        report,
+        rejection_recorder=rejection_recorder,
+    )
+    if isinstance(artifact_evidence, ArtifactEvidenceFailure):
         if rollback_publication is not None:
             rollback_publication()
+        # #515：`primary-artifact-invalid` 前綴保留（既有測試與 operator 的
+        # grep 習慣以它為錨點），但後面必須帶得出「哪一個 artifact、哪一條
+        # 判準」——過去這裡是一個沒有任何附加資訊的字面值。
         return BrainstormResult(
             "needs_human",
-            "primary-artifact-invalid",
+            f"primary-artifact-invalid: {artifact_evidence.rendered()}",
             selection.identity.independence_domain,
             empty_refs,
             None,

--- a/paulsha_cortex/coordinator/registry.py
+++ b/paulsha_cortex/coordinator/registry.py
@@ -12,6 +12,11 @@ from typing import Any, Callable, Mapping
 from paulsha_cortex.config import paths
 from . import verification
 from .claim import claim_key_for_authority_digest
+from .diagnostics import (
+    DiagnosticInvariantError,
+    DiagnosticReason,
+    coerce_diagnostic_reason,
+)
 from .usage_extractors import extract_usage
 from .workflow import (
     GateEvidenceRef,
@@ -1464,6 +1469,49 @@ class JobRegistry:
         self._persist()
         return _deepcopy_json(entry)
 
+    # --- 診斷 invariant 的強制點（#527／#514／#515／#511／#482）-----------------
+    #
+    # 這是全庫**唯一**能把 `needs_human` facet 寫進 run row 的兩個入口
+    # （`_manager_create_workflow_run`／`_manager_update_workflow_run`）。invariant
+    # 因此在這裡強制，而不是逐個呼叫端人工檢查——五次逐案補洞已證明後者無效。
+    #
+    # 規則只有三條：
+    #   1. 這次更新把 `needs_human` **加進**facets（先前沒有）→ 必須帶
+    #      `needs_human_reason`，否則 `DiagnosticInvariantError`。
+    #   2. 這次更新把 `needs_human` **移出**facets → 理由一併清掉（陳舊理由比沒
+    #      理由更糟；見 `WorkflowRun.__post_init__`）。
+    #   3. facet 已經在、這次沒帶新理由 → 沿用既有理由（大量呼叫端會在同一個
+    #      run 上重複寫 `facets=("needs_human",)`，不該因此把第一次的理由洗掉）。
+    #
+    # **範圍**：本層只管理由有沒有落地，不改任何呼叫端的後續處置。
+    @staticmethod
+    def _resolve_needs_human_reason(
+        *,
+        run_id: str,
+        current_facets: tuple[str, ...],
+        next_facets: tuple[str, ...],
+        current_reason: dict[str, Any] | None,
+        supplied: DiagnosticReason | Mapping[str, Any] | None,
+    ) -> dict[str, Any] | None:
+        reason = coerce_diagnostic_reason(supplied)
+        blocked = "needs_human" in next_facets
+        if reason is not None and not blocked:
+            raise DiagnosticInvariantError(
+                "workflow run 帶了 needs_human_reason 卻沒有設 needs_human facet"
+                f"（fail-closed）: {run_id}"
+            )
+        if not blocked:
+            return None
+        if reason is not None:
+            return reason.to_dict()
+        if "needs_human" not in current_facets:
+            raise DiagnosticInvariantError(
+                "把 workflow run 轉入 needs_human 必須同時提供結構化理由"
+                "（diagnostics.DiagnosticReason：機器可讀 reason ＋ 人可讀 detail "
+                f"＋ 來源位置）: {run_id}"
+            )
+        return dict(current_reason) if current_reason is not None else None
+
     def _manager_create_workflow_run(
         self,
         *,
@@ -1495,6 +1543,7 @@ class JobRegistry:
         frozen_readiness: dict[str, Any] | None = None,
         model_chain_override: dict[str, dict[str, str]] | None = None,
         combo_selection: dict[str, Any] | None = None,
+        needs_human_reason: DiagnosticReason | Mapping[str, Any] | None = None,
     ) -> WorkflowRun:
         matches = [
             existing
@@ -1524,6 +1573,13 @@ class JobRegistry:
         if any(run.run_id == run_id for run in self._workflows):
             raise ValueError(f"workflow run id collision: {run_id}")
         now = _now_iso()
+        resolved_needs_human_reason = self._resolve_needs_human_reason(
+            run_id=run_id,
+            current_facets=(),
+            next_facets=tuple(facets),
+            current_reason=None,
+            supplied=needs_human_reason,
+        )
         run = WorkflowRun(
             run_id=run_id,
             work_id=work_id,
@@ -1557,6 +1613,7 @@ class JobRegistry:
             frozen_readiness=frozen_readiness,
             model_chain_override=model_chain_override,
             combo_selection=combo_selection,
+            needs_human_reason=resolved_needs_human_reason,
         )
         superseded_at = _now_iso()
         next_workflows = [
@@ -1613,11 +1670,20 @@ class JobRegistry:
         model_chain_override: dict[str, dict[str, str]] | None = None,
         resolved_model_chain: dict[str, dict[str, str]] | None = None,
         combo_selection: dict[str, Any] | None = None,
+        needs_human_reason: DiagnosticReason | Mapping[str, Any] | None = None,
     ) -> WorkflowRun:
         index = self._find_workflow_run_index(run_id)
         current = self._workflows[index]
         next_phase = current.current_phase if current_phase is None else current_phase
         validate_workflow_phase_transition(current.current_phase, next_phase)
+        next_facets = current.facets if facets is None else tuple(facets)
+        resolved_needs_human_reason = self._resolve_needs_human_reason(
+            run_id=run_id,
+            current_facets=current.facets,
+            next_facets=next_facets,
+            current_reason=current.needs_human_reason,
+            supplied=needs_human_reason,
+        )
         updated = WorkflowRun(
             run_id=current.run_id,
             work_id=current.work_id,
@@ -1642,7 +1708,7 @@ class JobRegistry:
             primary_domain=current.primary_domain if primary_domain is None else primary_domain,
             candidate_head=current.candidate_head if candidate_head is None else candidate_head,
             verified_head=current.verified_head if verified_head is None else verified_head,
-            facets=current.facets if facets is None else tuple(facets),
+            facets=next_facets,
             gate_status=current.gate_status if gate_status is None else gate_status,
             created_at=current.created_at,
             updated_at=_now_iso(),
@@ -1712,6 +1778,7 @@ class JobRegistry:
             frozen_readiness=(
                 current.frozen_readiness if frozen_readiness is None else frozen_readiness
             ),
+            needs_human_reason=resolved_needs_human_reason,
         )
         self._workflows[index] = updated
         self._persist()
@@ -1754,6 +1821,9 @@ class JobRegistry:
             candidate_head=candidate_head,
             verified_head=None,
             facets=(),
+            # 診斷 invariant：清掉 needs_human facet 就必須清掉理由——
+            # 陳舊理由會讓 operator 讀到上一輪的原因（見 WorkflowRun.__post_init__）。
+            needs_human_reason=None,
             gate_status="running",
             updated_at=_now_iso(),
         )
@@ -1868,6 +1938,9 @@ class JobRegistry:
             facets=tuple(
                 facet for facet in current.facets if facet != "needs_human"
             ),
+            # 診斷 invariant：清掉 needs_human facet 就必須清掉理由——
+            # 陳舊理由會讓 operator 讀到上一輪的原因（見 WorkflowRun.__post_init__）。
+            needs_human_reason=None,
             gate_status="running",
             retry_classification=(
                 current.retry_classification
@@ -1959,6 +2032,9 @@ class JobRegistry:
                 "build": current.attempts.get("build", 0) + 1,
             },
             facets=tuple(facet for facet in current.facets if facet != "needs_human"),
+            # 診斷 invariant：清掉 needs_human facet 就必須清掉理由——
+            # 陳舊理由會讓 operator 讀到上一輪的原因（見 WorkflowRun.__post_init__）。
+            needs_human_reason=None,
             gate_status="running",
             retry_classification=(
                 current.retry_classification
@@ -2080,6 +2156,9 @@ class JobRegistry:
             candidate_head=adopted_candidate,
             verified_head=None,
             facets=tuple(facet for facet in current.facets if facet != "needs_human"),
+            # 診斷 invariant：清掉 needs_human facet 就必須清掉理由——
+            # 陳舊理由會讓 operator 讀到上一輪的原因（見 WorkflowRun.__post_init__）。
+            needs_human_reason=None,
             gate_status="running",
             evidence_refs=evidence_refs,
             updated_at=_now_iso(),
@@ -2150,6 +2229,9 @@ class JobRegistry:
             gate_refs=tuple(ref for ref in current.gate_refs if ref.kind == "brainstorm"),
             verified_head=None,
             facets=tuple(facet for facet in current.facets if facet != "needs_human"),
+            # 診斷 invariant：清掉 needs_human facet 就必須清掉理由——
+            # 陳舊理由會讓 operator 讀到上一輪的原因（見 WorkflowRun.__post_init__）。
+            needs_human_reason=None,
             gate_status="running",
             retry_classification=(
                 current.retry_classification
@@ -2224,6 +2306,9 @@ class JobRegistry:
             },
             gate_refs=tuple(ref for ref in current.gate_refs if ref.kind == "brainstorm"),
             facets=tuple(facet for facet in current.facets if facet != "needs_human"),
+            # 診斷 invariant：清掉 needs_human facet 就必須清掉理由——
+            # 陳舊理由會讓 operator 讀到上一輪的原因（見 WorkflowRun.__post_init__）。
+            needs_human_reason=None,
             gate_status="running",
             retry_classification=(
                 current.retry_classification
@@ -2303,6 +2388,9 @@ class JobRegistry:
             source_revision=authority_digest,
             verified_head=None,
             facets=tuple(facet for facet in current.facets if facet != "needs_human"),
+            # 診斷 invariant：清掉 needs_human facet 就必須清掉理由——
+            # 陳舊理由會讓 operator 讀到上一輪的原因（見 WorkflowRun.__post_init__）。
+            needs_human_reason=None,
             gate_status="running",
             retry_classification="authority_restart",
             updated_at=_now_iso(),

--- a/paulsha_cortex/coordinator/review.py
+++ b/paulsha_cortex/coordinator/review.py
@@ -4,6 +4,7 @@ import copy
 import hashlib
 import json
 import os
+import re
 import shutil
 import subprocess
 from hashlib import sha256
@@ -178,6 +179,58 @@ def review_verdict_path(worktree: str | Path) -> Path:
     return Path(worktree).resolve() / REVIEW_VERDICT_FILENAME
 
 
+# --- issue #482：pre-launch absent evaluation 的命名空間 ----------------------
+#
+# 修法前 absent 的落點只由 `(slice_id, builder_job_id, candidate)` 決定——
+# `reviewer_job_id` 在 reviewer job 誕生**之前**恆為 None，於是同一個 candidate
+# 的每一次 pre-launch 失敗都指向同一個 `...-absent.json`。實測現場：
+#
+#   1. builder 驗證完成、沒有 review identity → 寫下 `reviewer-identity-missing`
+#      （launch_identity 兩邊都是 null）。
+#   2. operator 依系統自己宣告的 next action 執行
+#      `cortex slice-action <slice> retry-review --review-executor codex
+#       --review-model <model>`。
+#   3. 該 identity 尚未註冊 → reviewer 選擇正確地改判
+#      `reviewer-identity-unknown`（launch_identity.builder 這次有值）。
+#   4. `write_gate_evaluation()` 解析到**同一個路徑**、看到不同 payload，
+#      raise `immutable gate evaluation already exists`。
+#
+# 沒有 reviewer job 被建立，官方復原動作因此無法回傳一個 typed absent 結果——
+# 而 immutable writer 本身是對的，錯的是 key 設計：它把「為什麼 absent」這件事
+# 排除在 identity 之外。修法即 issue 的第一項驗收條件——把**原因與請求身分**
+# 納入路徑，於是：
+#
+#   - 同原因＋同身分 → 同路徑 → byte-identical → 維持既有的冪等重寫語意；
+#   - 不同原因或不同身分 → 不同路徑 → 前一份 absent evidence 原位保留、
+#     新結果照常落地（`missing → unknown → registered` 這條合法的設定推進不再
+#     需要刪 evidence 才能前進）。
+#
+# **範圍**：只改 absent 這一支的命名。reviewer job 已存在時的
+# `{slice_id}-{reviewer_job_id}.json` 一字未動——那條路徑的 job id 重用碰撞是
+# 另一個獨立缺陷（見 issue #482 的 0812 留言），改它會動到 workflow lane 已
+# 落地的全部 evidence 路徑，不在本次診斷修正的範圍內。
+ABSENT_EVALUATION_KEY_LENGTH = 12
+
+
+def absent_evaluation_key(*, reason: str, launch_identity: Mapping[str, Any] | None) -> str:
+    """pre-launch absent evaluation 的原因＋身分指紋。
+
+    以 canonical JSON hash 取前 12 字元；輸入刻意只有 ``reason`` 與
+    ``launch_identity`` 兩項——它們正是同一個 `(slice, builder job, candidate)`
+    之下**唯一會變**的東西，也正是過去被排除在 key 之外、因而造成碰撞的東西。
+    """
+
+    if not isinstance(reason, str) or not reason:
+        raise ValueError("absent evaluation reason must be a non-empty string")
+    identity = launch_identity if isinstance(launch_identity, Mapping) else {}
+    fingerprint = {
+        "reason": reason,
+        "builder": identity.get("builder"),
+        "reviewer": identity.get("reviewer"),
+    }
+    return verification.canonical_json_hash(fingerprint)[:ABSENT_EVALUATION_KEY_LENGTH]
+
+
 def gate_evaluation_path(
     *,
     slice_id: str,
@@ -185,12 +238,17 @@ def gate_evaluation_path(
     candidate: str,
     reviewer_job_id: str | None,
     coordinator_root: str | Path | None = None,
+    absent_key: str | None = None,
 ) -> Path:
     root = Path(coordinator_root) if coordinator_root is not None else paths.coordinator_root()
     if verification.SAFE_SHA_RE.fullmatch(candidate) is None:
         raise ValueError(f"unsafe candidate: {candidate!r}")
     if reviewer_job_id is None:
         suffix = f"{builder_job_id}-{candidate.lower()[:12]}-absent"
+        if absent_key is not None:
+            if re.fullmatch(r"[0-9a-f]{4,64}", absent_key) is None:
+                raise ValueError(f"unsafe absent evaluation key: {absent_key!r}")
+            suffix = f"{suffix}-{absent_key}"
     else:
         suffix = reviewer_job_id
     return root.resolve() / "evidence" / "review" / f"{slice_id}-{suffix}.json"
@@ -728,6 +786,16 @@ def write_gate_evaluation(
         candidate=payload["candidate"],
         reviewer_job_id=payload.get("reviewer_job_id"),
         coordinator_root=coordinator_root,
+        # #482：只有 pre-launch absent（尚無 reviewer job）需要這把鑰匙——
+        # 它把「為什麼 absent」與「請求了誰當 reviewer」納入命名空間。
+        absent_key=(
+            absent_evaluation_key(
+                reason=payload["reason"],
+                launch_identity=payload.get("launch_identity"),
+            )
+            if payload.get("reviewer_job_id") is None
+            else None
+        ),
     )
     content_hash = verification.canonical_json_hash(payload)
     if path.exists():

--- a/paulsha_cortex/coordinator/work_actions.py
+++ b/paulsha_cortex/coordinator/work_actions.py
@@ -21,6 +21,7 @@ from paulsha_cortex.config import paths
 from paulsha_cortex._yaml import safe_load
 from paulsha_cortex.github_rate_limit import is_rate_limit_signal
 
+from .diagnostics import diagnostic_reason
 from .claim import (
     AUTO_LABEL,
     ClaimCandidate,
@@ -1406,6 +1407,18 @@ def _fallback_workflow_starter(workflow_registry, state_path: Path):
             attempts={"claim": 1, "define": 1},
             facets=("needs_human",) if reason is not None else (),
             gate_status="running",
+            needs_human_reason=(
+                diagnostic_reason(
+                    "claim-blocked",
+                    f"claim 判定需要人工介入即建立 run：{reason}",
+                    source="work_actions._fallback_workflow_starter",
+                    work_id=bound_authority.work_id,
+                    repo=bound_authority.repo,
+                    claim_key=claim_key,
+                )
+                if reason is not None
+                else None
+            ),
         )
 
     return start
@@ -4321,6 +4334,17 @@ def _ship_action(
             canonical_run.run_id,
             facets=("needs_human",),
             gate_status="running",
+            needs_human_reason=diagnostic_reason(
+                "multiple-delivery-targets-unsupported",
+                "work item 綁到多於一組交付目標（PR／openspec change／todo 路徑），"
+                f"ship lane 不支援：prs={len(authority.mapped_prs)} "
+                f"openspec={len(authority.mapped_openspec)} "
+                f"todo={len(authority.mapped_todo_paths)}",
+                source="work_actions._ship_action:delivery-targets",
+                run_id=canonical_run.run_id,
+                work_id=canonical_run.work_id,
+                repo=authority.repo,
+            ),
         )
         return {
             "action": "needs_human",
@@ -4557,7 +4581,19 @@ def _ship_action(
             }
             _save_runs(state_path, state)
             workflow_registry._manager_update_workflow_run(
-                canonical_run.run_id, facets=("needs_human",), gate_status="running"
+                canonical_run.run_id,
+                facets=("needs_human",),
+                gate_status="running",
+                needs_human_reason=diagnostic_reason(
+                    "merged-awaiting-closure",
+                    "PR 已在遠端 merge，本地 closeout（openspec archive／todo 回寫）"
+                    "尚未完成，需要人工接手收尾",
+                    source="work_actions._ship_action:merged-awaiting-closure",
+                    run_id=canonical_run.run_id,
+                    work_id=canonical_run.work_id,
+                    head=expected_head,
+                    merge_commit=merge_status.merge_commit,
+                ),
             )
             return {"action": "merged-awaiting-closure", "head": expected_head}
 
@@ -4637,7 +4673,19 @@ def _ship_action(
             }
             _save_runs(state_path, state)
             workflow_registry._manager_update_workflow_run(
-                canonical_run.run_id, facets=("needs_human",), gate_status="running"
+                canonical_run.run_id,
+                facets=("needs_human",),
+                gate_status="running",
+                needs_human_reason=diagnostic_reason(
+                    "external-merge-without-authorization",
+                    "PR 在 cortex 授權之外被 merge（本地沒有對應的 merge "
+                    "authorization 紀錄），交付鏈路不得自行採信",
+                    source="work_actions._ship_action:external-merge",
+                    run_id=canonical_run.run_id,
+                    work_id=canonical_run.work_id,
+                    head=preflight.head,
+                    tree_hash=preflight.tree_hash,
+                ),
             )
             return {
                 "action": "needs_human",
@@ -4704,7 +4752,19 @@ def _ship_action(
             }
             _save_runs(state_path, state)
             workflow_registry._manager_update_workflow_run(
-                canonical_run.run_id, facets=("needs_human",), gate_status="running"
+                canonical_run.run_id,
+                facets=("needs_human",),
+                gate_status="running",
+                needs_human_reason=diagnostic_reason(
+                    "copilot-finding-budget-exhausted",
+                    f"Copilot review 修復輪次已達上限（{fix_rounds}/{max_fix_rounds}），"
+                    "不再自動重跑",
+                    source="work_actions._ship_action:copilot-budget",
+                    run_id=canonical_run.run_id,
+                    work_id=canonical_run.work_id,
+                    head=preflight.head,
+                    fix_rounds=str(fix_rounds),
+                ),
             )
             return {
                 "action": "needs_human",
@@ -4753,7 +4813,18 @@ def _ship_action(
         if float(now_epoch) - float(requested_at) > 15 * 60:
             active["ship"] = {**ship, "phase": "needs_human", "reason": "copilot-review-timeout"}
             workflow_registry._manager_update_workflow_run(
-                canonical_run.run_id, facets=("needs_human",), gate_status="running"
+                canonical_run.run_id,
+                facets=("needs_human",),
+                gate_status="running",
+                needs_human_reason=diagnostic_reason(
+                    "copilot-review-timeout",
+                    "已請求 Copilot review 超過 15 分鐘仍未收到對應 HEAD 的回覆",
+                    source="work_actions._ship_action:copilot-timeout",
+                    run_id=canonical_run.run_id,
+                    work_id=canonical_run.work_id,
+                    head=preflight.head,
+                    requested_at=str(requested_at),
+                ),
             )
             _save_runs(state_path, state)
             return {"action": "needs_human", "reason": "copilot-review-timeout"}
@@ -4795,7 +4866,19 @@ def _ship_action(
         active["ship"] = {**ship, "phase": "needs_human", "reason": copilot.reason}
         _save_runs(state_path, state)
         workflow_registry._manager_update_workflow_run(
-            canonical_run.run_id, facets=("needs_human",), gate_status="running"
+            canonical_run.run_id,
+            facets=("needs_human",),
+            gate_status="running",
+            needs_human_reason=diagnostic_reason(
+                str(copilot.reason),
+                f"Copilot review loop 判定為需要人工介入：{copilot.reason}"
+                f"（阻擋性 findings {finding_count} 條）",
+                source="work_actions._ship_action:copilot-review-loop",
+                run_id=canonical_run.run_id,
+                work_id=canonical_run.work_id,
+                head=preflight.head,
+                fix_rounds=str(fix_rounds),
+            ),
         )
         extra = (
             _repair_budget_status(

--- a/paulsha_cortex/coordinator/work_bridge.py
+++ b/paulsha_cortex/coordinator/work_bridge.py
@@ -39,6 +39,7 @@ from .claim import (
     sizing_band,
     work_authority_digest,
 )
+from .diagnostics import diagnostic_reason
 from .github_delivery import GitHubDeliveryClient
 from .model_identities import IdentityRegistry, load_model_identities
 from .planning import (
@@ -468,6 +469,17 @@ def start_canonical_workflow(
             sizing_band=claim_sizing_band,
             model_chain_override=effective_model_chain_override,
             combo_selection=_combo_selection_payload(combo_selection),
+            # 診斷 invariant：`needs_human_reason` 本來就是這條路徑的參數名，
+            # 過去只是個沒有落地的字串——run 建出來就掛 needs_human，理由卻
+            # 留在呼叫端。這裡把它升格成結構化理由寫進 run。
+            needs_human_reason=diagnostic_reason(
+                "claim-blocked",
+                f"claim 判定需要人工介入即建立 run：{needs_human_reason}",
+                source="work_bridge.start_workflow_for_authority",
+                work_id=authority.work_id,
+                repo=authority.repo,
+                claim_key=claim_key,
+            ),
         )
         return run
     manifest_path = _write_manifest(Path(coordinator_root), claim_key, manifest)

--- a/paulsha_cortex/coordinator/workflow.py
+++ b/paulsha_cortex/coordinator/workflow.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from . import verification
 from .claim import sizing_band as compute_sizing_band
+from .diagnostics import DiagnosticReason
 
 
 DEFAULT_WORKFLOW_COMBO = "feature-oneshot"
@@ -425,6 +426,22 @@ class WorkflowRun:
     # provenance，不影響既有 workflow 語意。
     resolved_model_chain: dict[str, dict[str, str]] | None = None
     combo_selection: dict[str, Any] | None = None
+    # 診斷 invariant 家族（#527／#514／#515／#511／#482）：把 run 轉入
+    # `needs_human` 的那一刻必須同時落一份結構化理由（`diagnostics.
+    # DiagnosticReason` 的 dict 投影：機器可讀 reason ＋ 人可讀 detail ＋ 來源
+    # 位置）。過去 reason 只活在 `_dispatch_workflow_card`／`resume_workflow_run`
+    # 的回傳值裡，daemon periodic tick 沒人消費回傳值，reason 隨呼叫堆疊蒸發
+    # ——run row 只剩一個查不出原因的 facet（#527 現場：四個介面同時沉默）。
+    #
+    # 這裡只**持有**理由，不做強制：強制點在 registry 的狀態轉移 API
+    # （`_manager_update_workflow_run`／`_manager_create_workflow_run`），
+    # 「忘記帶理由」因此在單元測試就炸。dataclass 這層只鎖住一條反向不變式
+    # ——**理由不得與 facet 脫鉤**（見下方 __post_init__）：facet 清掉了理由
+    # 卻留著，operator 會讀到上一輪的陳舊原因，比沒有理由更糟。
+    #
+    # 反過來「facet 有、理由沒有」則刻意放行：既有部署的狀態檔裡就躺著這種
+    # run（本 invariant 之前寫的），載入時 fail-closed 會直接把 manager 打掛。
+    needs_human_reason: dict[str, Any] | None = None
 
     def __post_init__(self) -> None:
         for field, value in (
@@ -597,6 +614,19 @@ class WorkflowRun:
         _validate_model_chain_override(self.model_chain_override, field_name="model_chain_override")
         _validate_model_chain_resolution(self.resolved_model_chain, field_name="resolved_model_chain")
         _validate_combo_selection(self.combo_selection)
+        if self.needs_human_reason is not None:
+            # 形狀驗證：DiagnosticReason.from_dict 自己 fail-closed（reason 必須
+            # 是 kebab-case 機器碼、detail 非空、source 為 <module>.<function>）。
+            reason = DiagnosticReason.from_dict(self.needs_human_reason)
+            if "needs_human" not in self.facets:
+                # 陳舊理由比沒有理由更糟：facet 已清掉代表阻塞已解除，理由卻還
+                # 留著會讓 `cortex status` 對一個正在跑的 run 顯示上一輪的原因。
+                # 清 facet 的呼叫端必須同時清理由（registry 的狀態轉移 API 會
+                # 自動代勞，直接 `replace()` 的呼叫端則由這條攔下）。
+                raise ValueError(
+                    "workflow run needs_human_reason 必須與 needs_human facet 同進同退"
+                )
+            object.__setattr__(self, "needs_human_reason", reason.to_dict())
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -652,6 +682,9 @@ class WorkflowRun:
             ),
             "combo_selection": (
                 dict(self.combo_selection) if self.combo_selection is not None else None
+            ),
+            "needs_human_reason": (
+                dict(self.needs_human_reason) if self.needs_human_reason is not None else None
             ),
         }
 
@@ -734,6 +767,14 @@ class WorkflowRun:
             model_chain_override=payload.get("model_chain_override"),
             resolved_model_chain=payload.get("resolved_model_chain"),
             combo_selection=payload.get("combo_selection"),
+            # 既有部署的狀態檔沒有這個欄位；缺席時維持 None（facet 有、理由沒有
+            # 的 legacy run 照常載入，見上方 __post_init__ 的說明）。facet 已清
+            # 掉卻殘留理由的狀態檔（手改／舊版寫壞）在此直接丟掉，避免載入即炸。
+            needs_human_reason=(
+                payload.get("needs_human_reason")
+                if "needs_human" in tuple(payload["facets"])
+                else None
+            ),
         )
 
 

--- a/paulsha_cortex/monitor/providers.py
+++ b/paulsha_cortex/monitor/providers.py
@@ -286,6 +286,7 @@ class WorkflowRegistryProvider:
             sources: list[WorkSource] = []
             links: dict[str, str] = {}
             schema_retry: dict[str, dict[str, int]] = {}
+            needs_human_reasons: dict[str, dict[str, object]] = {}
             diagnostics: list[str] = []
             validated_completions: dict[str, list[dict[str, object]]] = {}
             for row in rows:
@@ -323,6 +324,15 @@ class WorkflowRegistryProvider:
                 retry_rows = _schema_retry_rows(row.get("attempts"))
                 if retry_rows:
                     schema_retry.setdefault(work_id, {}).update(retry_rows)
+                # 診斷 invariant（#527）：run 掛著 needs_human 時，把它的結構化
+                # 理由帶進 observations，`cortex work show` 才有得印。手法比照
+                # 上面的 `schema_retry`——資料走既有的 observations 通道隨
+                # snapshot round-trip，不必在 WorkItem／WorkSnapshot 上新增欄位
+                # （新增欄位會讓每個 row 落在 `_WORKFLOW_V2_OPTIONAL_ROW_KEYS`
+                # 之外而讓整份 projection degraded，#261 已付過這個學費）。
+                blocking = _needs_human_reason_row(row)
+                if blocking is not None:
+                    needs_human_reasons[work_id] = {"run_id": run_id, **blocking}
                 if status != "superseded":
                     for ref in row.get("issue_refs", []):
                         _add_workflow_link(links, f"github_issue:{ref}", work_id)
@@ -360,6 +370,7 @@ class WorkflowRegistryProvider:
                 "workflow_links": links,
                 "validated_completions": validated_completions,
                 "schema_retry": schema_retry,
+                "needs_human_reasons": needs_human_reasons,
             },
         )
 
@@ -381,6 +392,40 @@ def _schema_retry_rows(attempts: object) -> dict[str, int]:
             continue
         rows[key[len(SCHEMA_RETRY_ATTEMPT_PREFIX):]] = value
     return rows
+
+
+def _needs_human_reason_row(row: Mapping[str, Any]) -> dict[str, object] | None:
+    """診斷 invariant（#527）：從 run row 取出 needs_human 的結構化理由。
+
+    只在 run 仍 ongoing 且確實掛著 `needs_human` 時回傳——已 done／superseded 的
+    run 的舊理由不該出現在 `cortex work show` 上。缺欄位（本 invariant 之前寫的
+    legacy run）回傳 ``None``，讓呈現面自然退回舊行為，不 fail-closed：
+    provider 一旦 degraded，整個 work item 的讀模型都會被凍住（#523）。
+    """
+
+    if row.get("status", "ongoing") != "ongoing":
+        return None
+    facets = row.get("facets")
+    if not isinstance(facets, (list, tuple)) or "needs_human" not in facets:
+        return None
+    payload = row.get("needs_human_reason")
+    if not isinstance(payload, Mapping):
+        return None
+    reason = payload.get("reason")
+    detail = payload.get("detail")
+    source = payload.get("source")
+    if not all(isinstance(item, str) and item for item in (reason, detail, source)):
+        return None
+    evidence_refs = payload.get("evidence_refs")
+    return {
+        "reason": reason,
+        "detail": detail,
+        "source": source,
+        "recorded_at": payload.get("recorded_at"),
+        "evidence_refs": [
+            item for item in (evidence_refs or []) if isinstance(item, str) and item
+        ],
+    }
 
 
 def _nonempty(value: object, field: str) -> str:
@@ -422,6 +467,12 @@ _WORKFLOW_V2_OPTIONAL_ROW_KEYS = frozenset(
         "model_chain_override", "resolved_model_chain",
         # #202：combo 選牌來源／task_type／bypass reason 的 provenance-only 欄位。
         "combo_selection",
+        # 診斷 invariant（#527／#514／#515／#511／#482）：run 被轉入 needs_human
+        # 時同時落地的結構化理由（機器可讀 reason ＋ 人可讀 detail ＋ 來源位置）。
+        # **必須列在這裡**：這個 whitelist 是封閉的，漏掉會讓每一個 run row 都被
+        # 判成「含不支援的欄位」，整份 workflow projection 因此 degraded——那正是
+        # #261 D5 選擇把 schema retry 計數塞進既有 `attempts` 而不新增欄位的原因。
+        "needs_human_reason",
     }
 )
 

--- a/paulsha_cortex/monitor/work_api.py
+++ b/paulsha_cortex/monitor/work_api.py
@@ -252,7 +252,29 @@ class WorkReadModelStore:
             retries = self._schema_retry(item.repo, item.work_id)
             if retries:
                 envelope["schema_retry"] = retries
+            # 診斷 invariant（#527）：run 掛著 needs_human 時把結構化理由帶出來。
+            # 資料源與 `schema_retry` 完全相同（workflow provider 的
+            # observations），欄位名沿用 `claim.ClaimDecision.blocking_reason`
+            # ——那是全庫既有的「為什麼卡住」欄位，不另發明平行體系。
+            blocking = self._needs_human_reason(item.repo, item.work_id)
+            if blocking:
+                envelope["blocking_reason"] = blocking
             return envelope
+
+    def _needs_human_reason(self, repo: str, work_id: str) -> dict:
+        for provider_id, provider in self._snapshot.providers.items():
+            if not provider_id.startswith("workflow:"):
+                continue
+            observations = provider.observations
+            if not isinstance(observations, Mapping):
+                continue
+            rows = observations.get("needs_human_reasons", {})
+            if not isinstance(rows, Mapping):
+                continue
+            found = rows.get(work_id)
+            if isinstance(found, Mapping) and found.get("reason"):
+                return dict(found)
+        return {}
 
     def _schema_retry(self, repo: str, work_id: str) -> dict:
         for provider_id, provider in self._snapshot.providers.items():

--- a/paulsha_cortex/porcelain/inspect.py
+++ b/paulsha_cortex/porcelain/inspect.py
@@ -108,6 +108,23 @@ def _print_status(status: dict[str, Any]) -> None:
             f"  provider_failure[{entry.get('slice_id', '-')}]: {outcome.get('outcome')} "
             f"(authority={outcome.get('authority')}, retryable={outcome.get('retryable')})\n"
         )
+    # 診斷 invariant（#527／#514／#515／#511／#482）：把 run 轉入 needs_human 的
+    # 那一刻必須落一份結構化理由。既然理由已經在 attention 條目上，文字模式就
+    # 該直接印出來——五個現場的共同症狀正是「理由存在於某處，但沒有任何一個
+    # operator 會看的介面印它」。格式比照上面的 provider_failure 摘要行。
+    for entry in status.get("attention", []) or []:
+        if not isinstance(entry, dict):
+            continue
+        blocking = entry.get("blocking_reason")
+        if not isinstance(blocking, dict) or not blocking.get("reason"):
+            continue
+        subject = entry.get("run_id") or entry.get("slice_id") or "-"
+        sys.stdout.write(
+            f"  needs_human[{subject}]: {blocking.get('reason')}: {blocking.get('detail')} "
+            f"(source={blocking.get('source')})\n"
+        )
+        for ref in blocking.get("evidence_refs") or []:
+            sys.stdout.write(f"    evidence: {ref}\n")
     sys.stdout.write(
         "in_flight: " + json.dumps(status.get("in_flight", []), ensure_ascii=False, sort_keys=True) + "\n"
     )

--- a/tests/diagnostic_fixtures.py
+++ b/tests/diagnostic_fixtures.py
@@ -1,0 +1,28 @@
+"""測試 fixture 用的結構化 needs_human 理由。
+
+診斷 invariant（#527／#514／#515／#511／#482）把「把 run 轉入 needs_human」這件
+事變成必須帶理由的狀態轉移。測試在建立「已經卡住的 run」這種前置狀態時同樣要
+過這一關——這是刻意的：fixture 若能無理由地製造 needs_human，invariant 就有一個
+測試看不到的後門，而後門正是本家族五張 issue 的共同形態。
+
+這裡提供一個統一的 fixture 理由，讓測試不必各自發明一份。
+"""
+
+from __future__ import annotations
+
+from paulsha_cortex.coordinator.diagnostics import DiagnosticReason, diagnostic_reason
+
+
+def fixture_needs_human_reason(
+    reason: str = "test-fixture-blocked",
+    detail: str = "測試前置狀態：直接把 run 佈置成 needs_human",
+    **context: object,
+) -> DiagnosticReason:
+    """測試前置狀態專用的結構化理由。"""
+
+    return diagnostic_reason(
+        reason,
+        detail,
+        source="tests.diagnostic_fixtures.fixture_needs_human_reason",
+        **context,
+    )

--- a/tests/test_claim_inflight_supersede_524.py
+++ b/tests/test_claim_inflight_supersede_524.py
@@ -40,6 +40,8 @@ from paulsha_cortex.coordinator.registry import JobRegistry
 from paulsha_cortex.coordinator.work_bridge import _artifact_rows
 from paulsha_cortex.coordinator.workflow import PlanningArtifactAuthority
 
+from diagnostic_fixtures import fixture_needs_human_reason
+
 _REPO = "acme/demo"
 _WORK_ID = "fix-inflight-supersede"
 
@@ -188,7 +190,7 @@ def test_failed_run_stays_reclaimable(tmp_path: Path) -> None:
         registry=registry, starter=starter, authority=before, state_path=state, action="start"
     )
     run_id = first["run"]["run_id"]
-    registry._manager_update_workflow_run(run_id, facets=("needs_human",))
+    registry._manager_update_workflow_run(run_id, facets=("needs_human",), needs_human_reason=fixture_needs_human_reason())
 
     after = load_work_authority(
         repo=_REPO,

--- a/tests/test_diagnostic_invariant_family_527.py
+++ b/tests/test_diagnostic_invariant_family_527.py
@@ -1,0 +1,997 @@
+"""診斷 invariant 家族：#527／#514／#515／#511／#482 一次收編。
+
+0813–0814 五次獨立命中同一條 invariant 的缺口，逐案補洞已證明無效。本檔把
+invariant 本身變成測試對象：
+
+> 任何把 run 轉入 ``needs_human``、把 evidence 標為 absent 的狀態變更，必須
+> 同時落一份結構化理由（機器可讀 reason ＋ 人可讀 detail ＋ 來源位置）到 run
+> 或 evidence，並可由 ``cortex status``／``work show`` 曝光。
+
+三層測試：
+
+1. **掃描式 invariant**（``test_every_needs_human_setter_supplies_a_reason``）——
+   AST 枚舉全庫所有把 ``needs_human`` 寫進 facets 的設置點，斷言每一個都同時
+   帶 ``needs_human_reason``。新增一個忘了帶理由的設置點會在這裡炸，不必等到
+   dogfooding 現場。
+2. **執行期強制**——registry 的狀態轉移 API 對「沒帶理由」fail-closed，對
+   「清了 facet」自動清理由。
+3. **五張 issue 的原始現場**各自成為 fixture。
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+import pytest
+
+from paulsha_cortex.coordinator import manager, manager_daemon, review
+from paulsha_cortex.coordinator.diagnostics import (
+    DiagnosticInvariantError,
+    DiagnosticReason,
+    diagnostic_reason,
+)
+from paulsha_cortex.coordinator.planning import (
+    ArtifactEvidenceFailure,
+    PlanningArtifact,
+    _post_integration_artifact_evidence,
+    assess_planning_completeness,
+)
+from paulsha_cortex.coordinator.registry import JobRegistry
+from paulsha_cortex.coordinator.workflow import WorkflowRun, WorkflowStep
+
+from diagnostic_fixtures import fixture_needs_human_reason
+
+
+PACKAGE_ROOT = Path(__file__).resolve().parent.parent / "paulsha_cortex"
+
+_MUTATION_FUNCTIONS = {
+    "_manager_update_workflow_run",
+    "_manager_create_workflow_run",
+}
+
+
+def _step(
+    phase: str = "define",
+    card: str = "brainstorming",
+    gate_result: str = "pending",
+) -> WorkflowStep:
+    return WorkflowStep(
+        phase=phase,
+        persona="planner" if phase in {"define", "plan"} else "builder",
+        card=card,
+        executor="codex",
+        model="gpt-primary",
+        domain="openai",
+        inputs=(),
+        outputs=(),
+        gate_result=gate_result,
+    )
+
+
+class _FakeDispatcher:
+    """periodic tick runner 只從 dispatcher 取 registry 與 git runner。"""
+
+    def __init__(self, registry: JobRegistry) -> None:
+        self._registry = registry
+        self._git_runner = None
+
+
+def _seed_run(registry: JobRegistry, **overrides) -> WorkflowRun:
+    fields = dict(
+        work_id="diagnostic-invariant",
+        repo="hamanpaul/paulsha-cortex",
+        claim_key="claim:v1:" + "1" * 64,
+        source_revision="2" * 64,
+        workspace_root="/tmp/workspace",
+        combo="feature-oneshot",
+        current_phase="define",
+        steps=(_step(),),
+        issue_refs=("hamanpaul/paulsha-cortex#527",),
+        openspec_refs=("diagnostic-invariant",),
+        attempts={"define": 1},
+        gate_status="running",
+    )
+    fields.update(overrides)
+    return registry._manager_create_workflow_run(**fields)
+
+
+# ---------------------------------------------------------------------------
+# 第 1 層：掃描式 invariant
+# ---------------------------------------------------------------------------
+
+
+def _introduces_needs_human(call: ast.Call) -> bool:
+    """這個 registry 呼叫的 `facets=` 引數會不會把 `needs_human` 寫進去？
+
+    保守判定：只要引數的原始碼裡出現 `"needs_human"` 字面值，且不是
+    「把它濾掉」的形態（`facet != "needs_human"`），就算會設置。掃描式
+    invariant 寧可誤報也不可漏報——漏報正是這五張 issue 的形態。
+    """
+
+    for keyword in call.keywords:
+        if keyword.arg != "facets":
+            continue
+        source = ast.unparse(keyword.value)
+        if "needs_human" not in source:
+            return False
+        if "!=" in source and "needs_human" in source.split("!=", 1)[1]:
+            return False
+        return True
+    return False
+
+
+def _supplies_reason(call: ast.Call) -> bool:
+    return any(keyword.arg == "needs_human_reason" for keyword in call.keywords)
+
+
+def _needs_human_setter_sites(source_root: Path = PACKAGE_ROOT) -> list[tuple[Path, ast.Call]]:
+    sites: list[tuple[Path, ast.Call]] = []
+    for path in sorted(source_root.rglob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            name = func.attr if isinstance(func, ast.Attribute) else getattr(func, "id", None)
+            if name not in _MUTATION_FUNCTIONS:
+                continue
+            if not _introduces_needs_human(node):
+                continue
+            sites.append((path, node))
+    return sites
+
+
+def test_scan_finds_the_known_needs_human_setters() -> None:
+    """掃描器本身必須真的掃得到東西——否則上面那條 invariant 是空的通過。"""
+
+    sites = _needs_human_setter_sites()
+    assert len(sites) >= 20, sites
+    files = {path.name for path, _ in sites}
+    # #527 的根因現場（daemon resume 迴圈）與 planning lane 都必須在掃描範圍內。
+    assert "manager_daemon.py" in files
+    assert "manager.py" in files
+    assert "work_actions.py" in files
+
+
+def test_every_needs_human_setter_supplies_a_reason() -> None:
+    """invariant 主體：沒有任何一個設置點可以不帶結構化理由。
+
+    這是本 PR 的核心斷言。新增一條 `facets=(..., "needs_human")` 而忘了帶
+    `needs_human_reason` 會在這裡失敗——不必等到 operator 在 dogfooding 現場
+    看到一個沒有理由的 run。
+    """
+
+    offenders = [
+        f"{path.relative_to(PACKAGE_ROOT.parent)}:{node.lineno}\n{ast.unparse(node)[:300]}"
+        for path, node in _needs_human_setter_sites()
+        if not _supplies_reason(node)
+    ]
+    assert offenders == [], "以下設置點把 run 轉入 needs_human 卻沒帶理由：\n" + "\n\n".join(
+        offenders
+    )
+
+
+def test_the_scan_actually_catches_a_missing_reason(tmp_path: Path) -> None:
+    """掃描器的反證：一個忘了帶理由的設置點必須被抓出來。
+
+    沒有這條，上面的 invariant 可能只是因為掃描器壞掉而「通過」。
+    """
+
+    offender = tmp_path / "offender.py"
+    offender.write_text(
+        'registry._manager_update_workflow_run(run.run_id, facets=("needs_human",))\n',
+        encoding="utf-8",
+    )
+    compliant = tmp_path / "compliant.py"
+    compliant.write_text(
+        "registry._manager_update_workflow_run(\n"
+        '    run.run_id, facets=("needs_human",), needs_human_reason=reason\n'
+        ")\n",
+        encoding="utf-8",
+    )
+    filtering = tmp_path / "filtering.py"
+    filtering.write_text(
+        "registry._manager_update_workflow_run(\n"
+        '    run.run_id, facets=tuple(f for f in run.facets if f != "needs_human")\n'
+        ")\n",
+        encoding="utf-8",
+    )
+
+    sites = _needs_human_setter_sites(tmp_path)
+    flagged = {path.name for path, node in sites if not _supplies_reason(node)}
+    assert flagged == {"offender.py"}
+    # 「把 needs_human 濾掉」的形態不得被誤判為設置點。
+    assert "filtering.py" not in {path.name for path, _ in sites}
+
+
+# ---------------------------------------------------------------------------
+# 第 2 層：registry 狀態轉移 API 的執行期強制
+# ---------------------------------------------------------------------------
+
+
+def test_transition_into_needs_human_without_reason_is_rejected(tmp_path: Path) -> None:
+    registry = JobRegistry(state_path=tmp_path / "jobs.json")
+    run = _seed_run(registry)
+    with pytest.raises(DiagnosticInvariantError) as excinfo:
+        registry._manager_update_workflow_run(run.run_id, facets=("needs_human",))
+    assert "結構化理由" in str(excinfo.value)
+    # fail-closed：狀態一個位元組都沒動。
+    assert registry.get_workflow_run(run.run_id).facets == ()
+
+
+def test_creating_a_run_already_blocked_without_reason_is_rejected(tmp_path: Path) -> None:
+    registry = JobRegistry(state_path=tmp_path / "jobs.json")
+    with pytest.raises(DiagnosticInvariantError):
+        _seed_run(registry, facets=("needs_human",))
+
+
+def test_reason_without_the_facet_is_rejected(tmp_path: Path) -> None:
+    """反向也 fail-closed：帶了理由卻不設 facet 是不一致的狀態。"""
+
+    registry = JobRegistry(state_path=tmp_path / "jobs.json")
+    run = _seed_run(registry)
+    with pytest.raises(DiagnosticInvariantError):
+        registry._manager_update_workflow_run(
+            run.run_id, facets=(), needs_human_reason=fixture_needs_human_reason()
+        )
+
+
+def test_reason_is_persisted_and_survives_reload(tmp_path: Path) -> None:
+    state = tmp_path / "jobs.json"
+    registry = JobRegistry(state_path=state)
+    run = _seed_run(registry)
+    registry._manager_update_workflow_run(
+        run.run_id,
+        facets=("needs_human",),
+        needs_human_reason=diagnostic_reason(
+            "worktree-target-exists",
+            "worktree target already exists",
+            source="tests.test_diagnostic_invariant_family_527",
+            run_id=run.run_id,
+        ),
+    )
+    reloaded = JobRegistry(state_path=state).get_workflow_run(run.run_id)
+    assert reloaded.needs_human_reason["reason"] == "worktree-target-exists"
+    assert reloaded.needs_human_reason["detail"] == "worktree target already exists"
+    assert reloaded.needs_human_reason["source"].startswith("tests.")
+    assert reloaded.needs_human_reason["recorded_at"]
+
+
+def test_reason_is_carried_forward_on_repeat_updates(tmp_path: Path) -> None:
+    """facet 已在、再寫一次同樣的 facet 不得把第一次的理由洗掉。
+
+    大量呼叫端會在同一個 run 上重複寫 `facets=("needs_human",)`（例如
+    `dispatch_or_stop` 的 except 分支再被 resume 迴圈碰一次）——第一次的理由
+    才是真正的根因。
+    """
+
+    registry = JobRegistry(state_path=tmp_path / "jobs.json")
+    run = _seed_run(registry)
+    registry._manager_update_workflow_run(
+        run.run_id,
+        facets=("needs_human",),
+        needs_human_reason=diagnostic_reason(
+            "root-cause",
+            "第一次的真正原因",
+            source="tests.first",
+        ),
+    )
+    later = registry._manager_update_workflow_run(
+        run.run_id, facets=("needs_human",), gate_status="failed"
+    )
+    assert later.needs_human_reason["reason"] == "root-cause"
+
+
+def test_clearing_the_facet_clears_the_reason(tmp_path: Path) -> None:
+    """陳舊理由比沒有理由更糟：facet 清掉了理由必須跟著清。"""
+
+    registry = JobRegistry(state_path=tmp_path / "jobs.json")
+    run = _seed_run(registry)
+    registry._manager_update_workflow_run(
+        run.run_id, facets=("needs_human",), needs_human_reason=fixture_needs_human_reason()
+    )
+    cleared = registry._manager_update_workflow_run(run.run_id, facets=())
+    assert cleared.needs_human_reason is None
+
+
+def test_workflow_run_rejects_a_reason_without_the_facet() -> None:
+    """dataclass 這層也鎖住同一條耦合，`replace()` 的直呼叫端一併涵蓋。"""
+
+    registry_free_reason = fixture_needs_human_reason().to_dict()
+    with pytest.raises(ValueError, match="同進同退"):
+        WorkflowRun(
+            run_id="workflow-" + "a" * 20,
+            work_id="diagnostic-invariant",
+            repo="hamanpaul/paulsha-cortex",
+            claim_key="claim:v1:" + "1" * 64,
+            source_revision="2" * 64,
+            workspace_root="/tmp/workspace",
+            combo="feature-oneshot",
+            current_phase="define",
+            steps=(_step(),),
+            issue_refs=(),
+            openspec_refs=(),
+            pr_refs=(),
+            attempts={},
+            evidence_refs=(),
+            gate_refs=(),
+            brainstorm_required=False,
+            primary_domain=None,
+            candidate_head=None,
+            verified_head=None,
+            facets=(),
+            gate_status="running",
+            created_at=manager._utcnow(),
+            updated_at=manager._utcnow(),
+            needs_human_reason=registry_free_reason,
+        )
+
+
+def test_legacy_state_without_a_reason_still_loads(tmp_path: Path) -> None:
+    """既有部署的狀態檔裡就躺著「有 facet、沒理由」的 run。
+
+    載入時 fail-closed 會直接把 manager 打掛——本 invariant 之前寫進去的 run
+    必須照常載入，只是沒有理由可呈現。
+    """
+
+    state = tmp_path / "jobs.json"
+    registry = JobRegistry(state_path=state)
+    run = _seed_run(registry)
+    registry._manager_update_workflow_run(
+        run.run_id, facets=("needs_human",), needs_human_reason=fixture_needs_human_reason()
+    )
+    payload = json.loads(state.read_text(encoding="utf-8"))
+    for row in payload["workflows"]:
+        row.pop("needs_human_reason", None)
+    state.write_text(json.dumps(payload), encoding="utf-8")
+
+    reloaded = JobRegistry(state_path=state).get_workflow_run(run.run_id)
+    assert reloaded.facets == ("needs_human",)
+    assert reloaded.needs_human_reason is None
+
+
+def test_reason_shape_is_fail_closed() -> None:
+    """機器可讀 reason ＋ 人可讀 detail ＋ 來源位置，三者缺一不可。"""
+
+    with pytest.raises(DiagnosticInvariantError):
+        DiagnosticReason(reason="Not A Code", detail="x", source="mod.fn")
+    with pytest.raises(DiagnosticInvariantError):
+        DiagnosticReason(reason="ok-code", detail="   ", source="mod.fn")
+    with pytest.raises(DiagnosticInvariantError):
+        DiagnosticReason(reason="ok-code", detail="x", source="not a source location")
+    # 換行會撞上 recover-planning 的 `failure_reason` 檢查，一律壓成單行。
+    assert "\n" not in DiagnosticReason(
+        reason="ok-code", detail="a\nb", source="mod.fn"
+    ).detail
+
+
+# ---------------------------------------------------------------------------
+# 第 3 層：五張 issue 的原始現場
+# ---------------------------------------------------------------------------
+
+
+def test_issue_527_resume_failure_lands_the_exception_on_the_run(tmp_path: Path) -> None:
+    """#527 現場：build 階段無聲掛 needs_human。
+
+    真正的原因是 ``ValueError: worktree target already exists``，但它只被
+    ``_log_error`` print 到 stderr（由 service-manager 導向
+    ``~/.agents/log/manager.log``），run 上只留一個沒有理由的 facet。
+    """
+
+    registry = JobRegistry(state_path=tmp_path / "jobs.json")
+    run = _seed_run(
+        registry,
+        current_phase="build",
+        steps=(_step("build", "worktree-isolation"),),
+        claim_key="claim:legacy:diagnostic-invariant",
+    )
+
+    def exploding_resume(*args, **kwargs):
+        # `seams.ScriptWorktreeCreator.create()` 對已存在的 target fail-closed
+        # ——#527 現場的實際例外（前代 run 死亡時未回收 worktree）。
+        raise ValueError("worktree target already exists")
+
+    monkeypatch = pytest.MonkeyPatch()
+    try:
+        monkeypatch.setattr(manager_daemon.manager, "resume_workflow_run", exploding_resume)
+        runner = manager_daemon.build_periodic_tick_runner(
+            dispatcher=_FakeDispatcher(registry),
+            specs_dir=str(tmp_path / "specs"),
+            handoff_dir=str(tmp_path / "handoff"),
+            launcher=object(),
+            run_tick_fn=lambda dispatcher_arg, **kwargs: {
+                "dispatch_skipped": False,
+                "dispatched": [],
+                "completed": [],
+                "errors": [],
+                "reaped": None,
+            },
+            scan_specs_fn=lambda specs_dir: [],
+            auto_claim_fn=lambda: [],
+            workflow_identity_registry=object(),
+        )
+        runner()
+    finally:
+        monkeypatch.undo()
+
+    persisted = registry.get_workflow_run(run.run_id)
+    assert "needs_human" in persisted.facets
+    reason = persisted.needs_human_reason
+    assert reason is not None, "#527：needs_human 不得再是唯一訊號"
+    assert reason["reason"] == "resume-workflow-failed"
+    assert "worktree target already exists" in reason["detail"]
+    assert reason["source"] == "manager_daemon.periodic_tick:resume-workflow"
+    assert reason["context"]["phase"] == "build"
+
+
+def test_issue_527_status_attention_surfaces_the_blocked_run(tmp_path: Path) -> None:
+    """#527 的呈現面：run 過去在 `cortex status` 的五份清單裡一份都不出現。"""
+
+    registry = JobRegistry(state_path=tmp_path / "jobs.json")
+    run = _seed_run(registry, current_phase="build", steps=(_step("build", "tdd-red"),))
+    registry._manager_update_workflow_run(
+        run.run_id,
+        facets=("needs_human",),
+        needs_human_reason=diagnostic_reason(
+            "resume-workflow-failed",
+            "ValueError: worktree target already exists",
+            source="manager_daemon.periodic_tick:resume-workflow",
+        ),
+    )
+
+    provider = manager_daemon.build_runtime_status_provider(
+        registry=registry,
+        specs_dir=str(tmp_path / "specs"),
+        handoff_dir=str(tmp_path / "handoff"),
+        scan_specs_fn=lambda _: [],
+        ready_units_fn=lambda metas, predicate: [],
+    )
+    payload = provider()
+
+    entries = [row for row in payload["attention"] if row.get("kind") == "workflow_run"]
+    assert len(entries) == 1
+    entry = entries[0]
+    assert entry["run_id"] == run.run_id
+    assert entry["current_phase"] == "build"
+    assert entry["reason"] == "resume-workflow-failed"
+    assert entry["blocking_reason"]["detail"].startswith("ValueError")
+    assert entry["blocking_reason"]["source"].startswith("manager_daemon.")
+
+
+def test_issue_527_status_text_mode_prints_the_reason(capsys) -> None:
+    """理由存在卻沒有任何 operator 會看的介面印它——正是五個現場的共同症狀。"""
+
+    from paulsha_cortex.porcelain import inspect as porcelain_inspect
+
+    porcelain_inspect._print_status(
+        {
+            "updated_at": "2026-08-15T00:00:00Z",
+            "attention": [
+                {
+                    "kind": "workflow_run",
+                    "run_id": "workflow-abc",
+                    "slice_state": "needs_human",
+                    "blocking_reason": {
+                        "reason": "resume-workflow-failed",
+                        "detail": "ValueError: worktree target already exists",
+                        "source": "manager_daemon.periodic_tick:resume-workflow",
+                        "evidence_refs": ["/tmp/evidence/planning-recovery/x.json"],
+                    },
+                }
+            ],
+        }
+    )
+    out = capsys.readouterr().out
+    assert "needs_human[workflow-abc]: resume-workflow-failed" in out
+    assert "worktree target already exists" in out
+    assert "evidence: /tmp/evidence/planning-recovery/x.json" in out
+
+
+ACCEPTED_SPEC = """---
+status: accepted
+work_item: diagnostic-invariant
+---
+
+## Requirements
+
+- 一條需求。
+"""
+
+BLOCKED_SPEC = """---
+status: accepted
+work_item: diagnostic-invariant
+---
+
+## Requirements
+
+- 一條需求。
+
+## Open Questions
+
+- 要選 A 還是 B？
+"""
+
+
+def _write_run_with_brainstorm_evidence(
+    tmp_path: Path, *, spec_text: str
+) -> tuple[JobRegistry, WorkflowRun, Path]:
+    """造出 #514 的現場：已發佈 artifact ＋ 綁定它的 brainstorm evidence。"""
+
+    import hashlib
+
+    workspace = tmp_path / "workspace"
+    coordinator = tmp_path / "coordinator"
+    spec_ref = "docs/superpowers/specs/diagnostic-invariant-spec.md"
+    spec_path = workspace / spec_ref
+    spec_path.parent.mkdir(parents=True, exist_ok=True)
+    spec_path.write_text(spec_text, encoding="utf-8")
+    digest = hashlib.sha256(spec_path.read_bytes()).hexdigest()
+
+    evidence_dir = coordinator / "evidence" / "planning"
+    evidence_dir.mkdir(parents=True, exist_ok=True)
+    evidence_path = evidence_dir / "brainstorm-fixture.json"
+    evidence_payload = {
+        "schema_version": 1,
+        "kind": "brainstorm-peer",
+        "scope": {
+            "repo": "hamanpaul/paulsha-cortex",
+            "work_id": "diagnostic-invariant",
+            "source_revision": "2" * 64,
+        },
+        "artifacts": [{"kind": "spec", "ref": spec_ref, "sha256": digest}],
+    }
+    evidence_path.write_text(
+        json.dumps(evidence_payload, ensure_ascii=False, sort_keys=True), encoding="utf-8"
+    )
+
+    registry = JobRegistry(state_path=tmp_path / "jobs.json")
+    planner_step = WorkflowStep(
+        phase="define",
+        persona="planner",
+        card="brainstorming",
+        executor="codex",
+        model="gpt-primary",
+        domain="openai",
+        inputs=(),
+        outputs=("docs/superpowers/specs/*.md",),
+        gate_result="pending",
+    )
+    run = _seed_run(
+        registry,
+        workspace_root=str(workspace),
+        steps=(planner_step,),
+        brainstorm_required=True,
+    )
+    run = registry._manager_update_workflow_run(
+        run.run_id,
+        gate_refs=(
+            manager.GateEvidenceRef(
+                "brainstorm",
+                str(evidence_path),
+                hashlib.sha256(evidence_path.read_bytes()).hexdigest(),
+            ),
+        ),
+        planning_source_revision="2" * 64,
+    )
+    return registry, run, coordinator
+
+
+def test_issue_514_revalidation_rejection_names_the_ref_and_reasons(tmp_path: Path) -> None:
+    """#514 現場：重驗失敗只丟一句 `workflow brainstorm artifact is not accepted`。"""
+
+    _registry, run, coordinator = _write_run_with_brainstorm_evidence(
+        tmp_path, spec_text=BLOCKED_SPEC
+    )
+    with pytest.raises(ValueError) as excinfo:
+        manager._validated_brainstorm_planning_authority(run, coordinator_root=coordinator)
+
+    message = str(excinfo.value)
+    assert message.startswith("workflow brainstorm artifact is not accepted:")
+    # 哪一個 artifact。
+    assert "diagnostic-invariant-spec.md" in message
+    # 哪一條判準——三種 reason 必須分得開。
+    assert "reasons=blocking-decision" in message
+    # blocking marker 的行號（#513 已定案的格式）。
+    assert "markers=L" in message
+    # 被拒內容落 `cortex-planning-artifact-rejection/v1` evidence。
+    rejection_dir = coordinator / "evidence" / "planning-artifacts"
+    written = sorted(rejection_dir.glob("*.json"))
+    assert written, "#514：重驗拒收也要留下可查的完整內容"
+    body = json.loads(written[0].read_text(encoding="utf-8"))
+    assert body["schema"] == manager.PLANNING_ARTIFACT_REJECTION_SCHEMA
+    assert body["reasons"] == ["blocking-decision"]
+    assert "要選 A 還是 B？" in body["content"]
+
+
+def test_issue_514_hash_drift_names_the_ref_and_both_digests(tmp_path: Path) -> None:
+    """0814 adversarial review 的修正：「磁碟被改動」其實先在 hash drift 失敗。
+
+    診斷必須做在這條真正會被走到的分支上，而不是只做在走不到的 assessment 上。
+    """
+
+    _registry, run, coordinator = _write_run_with_brainstorm_evidence(
+        tmp_path, spec_text=ACCEPTED_SPEC
+    )
+    spec_path = (
+        Path(run.workspace_root) / "docs/superpowers/specs/diagnostic-invariant-spec.md"
+    )
+    spec_path.write_text(ACCEPTED_SPEC + "\n<!-- operator edit -->\n", encoding="utf-8")
+
+    with pytest.raises(ValueError) as excinfo:
+        manager._validated_brainstorm_planning_authority(run, coordinator_root=coordinator)
+    message = str(excinfo.value)
+    assert message.startswith("workflow brainstorm artifact hash drift:")
+    assert "diagnostic-invariant-spec.md" in message
+    assert "evidence=" in message and "disk=" in message
+
+
+def _completeness_report() -> object:
+    return assess_planning_completeness(
+        [PlanningArtifact(kind="spec", ref="docs/spec.md", text=ACCEPTED_SPEC)]
+    )
+
+
+@pytest.mark.parametrize(
+    ("ref", "expected_reason"),
+    [
+        ("../outside-root.md", "artifact-path-escapes-root"),
+        ("/etc/passwd", "artifact-path-escapes-root"),
+        ("docs/missing.md", "artifact-not-a-regular-file"),
+    ],
+)
+def test_issue_515_each_branch_keeps_its_own_reason(
+    tmp_path: Path, ref: str, expected_reason: str
+) -> None:
+    """#515 現場：14 個裸 `return None` 塌縮成不透明的 `primary-artifact-invalid`。
+
+    每一條分支現在都必須保有自己的 reason——環境類（路徑／權限／編碼）與內容類
+    （assessment 不合格）的處置完全不同，塌縮成同一個值等於把診斷丟掉。
+    """
+
+    integration = {
+        "resolutions": [
+            {
+                "question_id": "q-1",
+                "decision": "x",
+                "artifact_kind": "spec",
+                "artifact_refs": [ref],
+            }
+        ]
+    }
+    failure = _post_integration_artifact_evidence(
+        integration, tmp_path, _completeness_report()
+    )
+    assert isinstance(failure, ArtifactEvidenceFailure)
+    assert failure.reason == expected_reason
+    assert ref in failure.rendered()
+
+
+def test_issue_515_symlink_is_distinguishable_from_content_rejection(tmp_path: Path) -> None:
+    target = tmp_path / "real.md"
+    target.write_text(ACCEPTED_SPEC, encoding="utf-8")
+    link = tmp_path / "docs" / "linked.md"
+    link.parent.mkdir(parents=True, exist_ok=True)
+    link.symlink_to(target)
+
+    integration = {
+        "resolutions": [
+            {
+                "question_id": "q-1",
+                "decision": "x",
+                "artifact_kind": "spec",
+                "artifact_refs": ["docs/linked.md"],
+            }
+        ]
+    }
+    failure = _post_integration_artifact_evidence(
+        integration, tmp_path, _completeness_report()
+    )
+    assert isinstance(failure, ArtifactEvidenceFailure)
+    assert failure.reason == "artifact-symlink-rejected"
+
+
+def test_issue_515_assessment_rejection_carries_reasons_markers_and_evidence(
+    tmp_path: Path,
+) -> None:
+    """內容類拒收沿用 #513 的 `(reasons=...; markers=Lnn:...)` 格式與 evidence 落檔。"""
+
+    blocked = tmp_path / "docs" / "blocked.md"
+    blocked.parent.mkdir(parents=True, exist_ok=True)
+    blocked.write_text(BLOCKED_SPEC, encoding="utf-8")
+
+    recorded: list[str] = []
+
+    def recorder(assessment) -> str:
+        recorded.append(assessment.artifact.ref)
+        return "/tmp/evidence/planning-artifacts/run-abc.json"
+
+    integration = {
+        "resolutions": [
+            {
+                "question_id": "q-1",
+                "decision": "x",
+                "artifact_kind": "spec",
+                "artifact_refs": ["docs/blocked.md"],
+            }
+        ]
+    }
+    failure = _post_integration_artifact_evidence(
+        integration,
+        tmp_path,
+        _completeness_report(),
+        rejection_recorder=recorder,
+    )
+    assert isinstance(failure, ArtifactEvidenceFailure)
+    assert failure.reason == "artifact-assessment-rejected"
+    assert failure.ref == "docs/blocked.md"
+    assert "reasons=blocking-decision" in failure.detail
+    assert "markers=L" in failure.detail
+    assert "evidence=/tmp/evidence/planning-artifacts/run-abc.json" in failure.detail
+    assert recorded == ["docs/blocked.md"]
+
+
+def test_issue_515_no_bare_return_none_remains_in_the_checker() -> None:
+    """反模式回歸樁：這個函式裡不得再出現裸 `return None`。
+
+    #397／#408 已為同一類缺陷做過兩輪儀器化；本函式是規模最大的殘留（14 個
+    分支）。用 AST 鎖住，避免下一次修改又長回來。
+    """
+
+    source = (PACKAGE_ROOT / "coordinator" / "planning.py").read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    target = next(
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef)
+        and node.name == "_post_integration_artifact_evidence"
+    )
+    bare = [
+        node.lineno
+        for node in ast.walk(target)
+        if isinstance(node, ast.Return)
+        and (node.value is None or (isinstance(node.value, ast.Constant) and node.value.value is None))
+    ]
+    assert bare == [], f"仍有裸 return None（行號 {bare}）——#515 的反模式又長回來了"
+
+
+def test_issue_511_brainstorm_failure_reason_reaches_the_run(tmp_path: Path) -> None:
+    """#511 現場：operator 只拿到路徑、沒有拒收原因，且被拒內容不留存。
+
+    PR #513 已把原因與內容補在 `_publish_planning_artifacts`，但那份結構化理由
+    到不了 run——只能靠上游 `str(exc)[:160]` 截斷後的字串殘骸。本測試鎖住
+    「理由確實落到 run 上、而且是結構化的」。
+    """
+
+    registry = JobRegistry(state_path=tmp_path / "jobs.json")
+    run = _seed_run(registry, brainstorm_required=True)
+    evidence_ref = str(tmp_path / "evidence" / "planning-recovery" / "run.json")
+    registry._manager_update_workflow_run(
+        run.run_id,
+        facets=("needs_human",),
+        evidence_refs=(evidence_ref,),
+        needs_human_reason=diagnostic_reason(
+            "brainstorm-not-ready",
+            "brainstorm 未收斂（state=needs_human）：primary-artifact-write-rejected: "
+            "ValueError: planning artifact is not accepted: docs/spec.md "
+            "(reasons=blocking-decision; markers=L9:要選 A 還是 B？)",
+            source="manager.apply_workflow_action:start-brainstorm",
+            evidence_refs=(evidence_ref,),
+            classification="content",
+        ),
+    )
+    persisted = registry.get_workflow_run(run.run_id)
+    reason = persisted.needs_human_reason
+    assert reason["reason"] == "brainstorm-not-ready"
+    # 三種 reason 必須分得開——`blocking-decision` 代表 planner 刻意標記待裁決
+    # 事項，重試只會原地打轉。
+    assert "reasons=blocking-decision" in reason["detail"]
+    assert reason["evidence_refs"] == [evidence_ref]
+    assert reason["context"]["classification"] == "content"
+
+
+def test_issue_511_reason_is_visible_from_work_show(tmp_path: Path) -> None:
+    """理由必須能由 `cortex work show` 曝光，不能只活在 run row 裡。"""
+
+    from paulsha_cortex.monitor.providers import _needs_human_reason_row
+
+    registry = JobRegistry(state_path=tmp_path / "jobs.json")
+    run = _seed_run(registry)
+    registry._manager_update_workflow_run(
+        run.run_id,
+        facets=("needs_human",),
+        needs_human_reason=diagnostic_reason(
+            "brainstorm-not-ready",
+            "planning artifact is not accepted (reasons=blocking-decision)",
+            source="manager.apply_workflow_action:start-brainstorm",
+        ),
+    )
+    row = registry.get_workflow_run(run.run_id).to_dict()
+    projected = _needs_human_reason_row(row)
+    assert projected is not None
+    assert projected["reason"] == "brainstorm-not-ready"
+    assert projected["source"].startswith("manager.")
+
+    # 已離開 ongoing 的 run 不得把舊理由帶到面板上。
+    row["status"] = "superseded"
+    assert _needs_human_reason_row(row) is None
+
+
+def test_issue_511_workflow_row_still_passes_the_monitor_projection(tmp_path: Path) -> None:
+    """新欄位必須列進 monitor 的封閉 whitelist，否則整份 projection 會 degraded。"""
+
+    from paulsha_cortex.monitor.providers import _validate_workflow_v2_row
+
+    registry = JobRegistry(state_path=tmp_path / "jobs.json")
+    run = _seed_run(registry)
+    registry._manager_update_workflow_run(
+        run.run_id, facets=("needs_human",), needs_human_reason=fixture_needs_human_reason()
+    )
+    _validate_workflow_v2_row(registry.get_workflow_run(run.run_id).to_dict())
+
+
+CANDIDATE = "a" * 40
+
+
+def _absent_payload(reason: str, *, builder=None, reviewer=None) -> dict:
+    return review.build_gate_evaluation(
+        slice_id="slice-482",
+        state="absent",
+        reason=reason,
+        builder_job_id="builder-1",
+        reviewer_job_id=None,
+        candidate=CANDIDATE,
+        launch_identity={"builder": builder, "reviewer": reviewer},
+    )
+
+
+_BUILDER = {"executor": "codex", "model_id": "gpt-primary", "independence_domain": "openai"}
+_REVIEWER = {"executor": "agy", "model_id": "gemini", "independence_domain": "google"}
+
+
+def test_issue_482_retry_with_a_new_identity_no_longer_collides(tmp_path: Path) -> None:
+    """#482 現場：合法的 `missing → unknown → registered` 推進撞 immutable artifact。
+
+    第一次 pre-launch 失敗寫下 `reviewer-identity-missing`；operator 依系統自己
+    宣告的 next action 帶新 identity 重試，reviewer 選擇正確地改判
+    `reviewer-identity-unknown`——但兩者映到同一個 `...-absent.json`，
+    immutable writer 因此 raise，沒有任何 reviewer job 被建立。
+    """
+
+    first = review.write_gate_evaluation(
+        _absent_payload("reviewer-identity-missing"), coordinator_root=tmp_path
+    )
+    second = review.write_gate_evaluation(
+        _absent_payload("reviewer-identity-unknown", builder=_BUILDER),
+        coordinator_root=tmp_path,
+    )
+    third = review.write_gate_evaluation(
+        _absent_payload("same-independence-domain", builder=_BUILDER, reviewer=_REVIEWER),
+        coordinator_root=tmp_path,
+    )
+
+    paths = {first["path"], second["path"], third["path"]}
+    assert len(paths) == 3, "#482：三個不同的 absent 結論不得共用一個落點"
+    # 前一份 absent evidence 原位保留——設定推進不該需要刪 evidence 才能前進。
+    for row in (first, second, third):
+        assert Path(row["path"]).is_file()
+    assert json.loads(Path(first["path"]).read_text(encoding="utf-8"))["reason"] == (
+        "reviewer-identity-missing"
+    )
+
+
+def test_issue_482_same_reason_and_identity_stays_idempotent(tmp_path: Path) -> None:
+    """同原因＋同身分仍必須是冪等重寫，既有語意一字不改。"""
+
+    first = review.write_gate_evaluation(
+        _absent_payload("reviewer-identity-missing"), coordinator_root=tmp_path
+    )
+    again = review.write_gate_evaluation(
+        _absent_payload("reviewer-identity-missing"), coordinator_root=tmp_path
+    )
+    assert first["path"] == again["path"]
+    assert first["hash"] == again["hash"]
+
+
+def test_issue_482_absent_key_carries_reason_and_identity() -> None:
+    """key 的輸入就是過去被排除在外、因而造成碰撞的兩項東西。"""
+
+    missing = review.absent_evaluation_key(
+        reason="reviewer-identity-missing", launch_identity={"builder": None, "reviewer": None}
+    )
+    unknown = review.absent_evaluation_key(
+        reason="reviewer-identity-unknown", launch_identity={"builder": None, "reviewer": None}
+    )
+    same_reason_other_identity = review.absent_evaluation_key(
+        reason="reviewer-identity-missing",
+        launch_identity={"builder": _BUILDER, "reviewer": None},
+    )
+    assert len({missing, unknown, same_reason_other_identity}) == 3
+    assert len(missing) == review.ABSENT_EVALUATION_KEY_LENGTH
+
+
+def test_issue_482_reviewer_job_keyed_path_is_unchanged(tmp_path: Path) -> None:
+    """範圍紀律：reviewer job 已存在時的落點一字未動。"""
+
+    path = review.gate_evaluation_path(
+        slice_id="slice-482",
+        builder_job_id="builder-1",
+        candidate=CANDIDATE,
+        reviewer_job_id="reviewer-9",
+        coordinator_root=tmp_path,
+    )
+    assert path.name == "slice-482-reviewer-9.json"
+
+
+def test_issue_527_provider_projects_the_reason_without_degrading(tmp_path: Path) -> None:
+    """理由必須能過 monitor 的 workflow projection，且不得讓 provider degraded。
+
+    #205 曾因為新增 WorkflowRun 欄位而讓每一個 row 落在 optional-key 白名單之外、
+    整份 workflow projection 變 degraded（#261 D5 因此選擇不新增欄位）。本測試
+    同時鎖住兩件事：理由確實被投影出來，以及 provider 仍為 ok、run 仍在。
+    """
+
+    from paulsha_cortex.monitor.providers import WorkflowRegistryProvider
+
+    state = tmp_path / "jobs.json"
+    registry = JobRegistry(state_path=state)
+    run = _seed_run(registry)
+    registry._manager_update_workflow_run(
+        run.run_id,
+        facets=("needs_human",),
+        needs_human_reason=diagnostic_reason(
+            "resume-workflow-failed",
+            "ValueError: worktree target already exists",
+            source="manager_daemon.periodic_tick:resume-workflow",
+        ),
+    )
+
+    result = WorkflowRegistryProvider("hamanpaul/paulsha-cortex", state_path=state).scan()
+
+    assert result.status == "ok"
+    assert result.diagnostics == ()
+    assert [source.ref for source in result.sources] == [run.run_id]
+    projected = result.observations["needs_human_reasons"]["diagnostic-invariant"]
+    assert projected["run_id"] == run.run_id
+    assert projected["reason"] == "resume-workflow-failed"
+    assert projected["detail"] == "ValueError: worktree target already exists"
+    assert projected["source"] == "manager_daemon.periodic_tick:resume-workflow"
+
+
+def test_issue_527_work_show_text_mode_prints_the_reason(capsys) -> None:
+    """`cortex work show` 過去只印 work_id/state/title/repo/phase。"""
+
+    from paulsha_cortex import cli
+
+    class _FakeClient:
+        def request(self, request):
+            assert request["kind"] == "get_work_item"
+            return {
+                "ok": True,
+                "data": {
+                    "item": {
+                        "work_id": "diagnostic-invariant",
+                        "state": "on-going",
+                        "title": "診斷 invariant",
+                        "repo": "hamanpaul/paulsha-cortex",
+                        "phase": "build",
+                    },
+                    "blocking_reason": {
+                        "run_id": "workflow-abc",
+                        "reason": "resume-workflow-failed",
+                        "detail": "ValueError: worktree target already exists",
+                        "source": "manager_daemon.periodic_tick:resume-workflow",
+                        "evidence_refs": ["/tmp/evidence/planning-recovery/x.json"],
+                    },
+                },
+            }
+
+    assert cli._work_read_main(
+        ["work", "show", "diagnostic-invariant"], work_client=_FakeClient()
+    ) == 0
+    out = capsys.readouterr().out
+    assert "needs_human: resume-workflow-failed" in out
+    assert "worktree target already exists" in out
+    assert "run_id: workflow-abc" in out
+    assert "evidence: /tmp/evidence/planning-recovery/x.json" in out

--- a/tests/test_gate_acceptance_chain_540.py
+++ b/tests/test_gate_acceptance_chain_540.py
@@ -35,6 +35,8 @@ from paulsha_cortex.coordinator import terminal_contract as tc
 from paulsha_cortex.coordinator.registry import JobRegistry
 from paulsha_cortex.coordinator.workflow import WorkflowStep
 
+from diagnostic_fixtures import fixture_needs_human_reason
+
 
 # ==========================================================================
 # 段 1：doctor 前置驗證 gate 宣告存在且非空
@@ -375,6 +377,7 @@ def _stuck_run(tmp_path: Path):
         candidate_head=HEAD,
         facets=("needs_human",),
         gate_status="failed",
+        needs_human_reason=fixture_needs_human_reason(),
     )
     worktree = tmp_path / "worktree"
     worktree.mkdir()

--- a/tests/test_midchain_builder_retry_545.py
+++ b/tests/test_midchain_builder_retry_545.py
@@ -45,6 +45,8 @@ from paulsha_cortex.deck.schema import (
 )
 from paulsha_cortex.porcelain import recover as porcelain_recover
 
+from diagnostic_fixtures import fixture_needs_human_reason
+
 
 HEAD = "d" * 40
 REPO = "acme/demo"
@@ -137,6 +139,7 @@ def _stuck_run(tmp_path: Path, *, stopped_at: str = "tdd-red"):
         attempts={"build": 1},
         facets=("needs_human",),
         gate_status="failed",
+        needs_human_reason=fixture_needs_human_reason(),
     )
     # worktree-isolation 已錨定 candidate（現場即如此，所以 recover-pre-candidate
     # 也走不通）。
@@ -507,6 +510,7 @@ def test_retry_build_final_card_semantics_do_not_regress(tmp_path: Path) -> None
         attempts={"build": 1},
         facets=("needs_human",),
         gate_status="failed",
+        needs_human_reason=fixture_needs_human_reason(),
     )
     unbound = registry.create_job(
         task="wf-subagent-build",

--- a/tests/test_planning_claim_recovery.py
+++ b/tests/test_planning_claim_recovery.py
@@ -17,6 +17,8 @@ from paulsha_cortex.coordinator.claim import (
 )
 from paulsha_cortex.coordinator.registry import JobRegistry
 
+from diagnostic_fixtures import fixture_needs_human_reason
+
 RECOVERY_ACTION = "recover-planning"
 
 
@@ -167,6 +169,7 @@ def _seed_planning_failure_run(
         facets=("needs_human",),
         attempts={"claim": 1, "define": 1},
         evidence_refs=(failure_record,),
+        needs_human_reason=fixture_needs_human_reason(),
     )
     return run_id, registry, state, snapshot
 

--- a/tests/test_planning_completeness.py
+++ b/tests/test_planning_completeness.py
@@ -465,7 +465,12 @@ def test_brainstorm_is_heterogeneous_persists_immutable_peer_evidence_and_keeps_
         secondary_planner=secondary_evidence,
         primary_integrator=primary_integrator,
     )
-    assert (unsafe.state, unsafe.reason) == ("needs_human", "primary-artifact-invalid")
+    # #515：`primary-artifact-invalid` 不再是一個沒有附加資訊的字面值——
+    # 環境類（路徑逃出 artifact root）與內容類（assessment 不合格）現在分得開，
+    # 且訊息帶得出是哪一個 ref。
+    assert unsafe.state == "needs_human"
+    assert unsafe.reason.startswith("primary-artifact-invalid: artifact-path-escapes-root")
+    assert "ref=../outside-root.md" in unsafe.reason
 
 
 def test_brainstorm_fails_closed_when_no_heterogeneous_peer_or_output_is_malformed(tmp_path: Path) -> None:
@@ -791,7 +796,10 @@ def test_primary_must_write_accepted_artifacts_before_brainstorm_gate_passes(tmp
         primary_integrator=integration,
     )
 
-    assert (result.state, result.reason) == ("needs_human", "primary-artifact-invalid")
+    # #515：整合階段宣稱的 artifact 根本沒落到磁碟上——過去與「內容不合驗收
+    # 條件」共用同一個 `primary-artifact-invalid`，現在分得開。
+    assert result.state == "needs_human"
+    assert result.reason.startswith("primary-artifact-invalid: artifact-not-a-regular-file")
     assert not (tmp_path / "evidence").exists()
 
     blocked_path = tmp_path / "docs/spec-blocked.md"
@@ -840,7 +848,12 @@ def test_primary_must_write_accepted_artifacts_before_brainstorm_gate_passes(tmp
         secondary_planner=secondary,
         primary_integrator=leaves_original_blocker,
     )
-    assert (blocker_result.state, blocker_result.reason) == (
-        "needs_human",
-        "primary-artifact-invalid",
+    # #515：這個 fixture 過去只斷言籠統的 `primary-artifact-invalid`，因而遮住
+    # 了它**真正**卡在哪裡——不是 blocking marker，而是 `docs/design.md` 這個
+    # 既有 artifact 根本沒落到磁碟上（fixture 只在記憶體裡造了 report）。
+    # reason 現在說得出 ref 與類別，正是本 issue 要修的東西。
+    assert blocker_result.state == "needs_human"
+    assert blocker_result.reason.startswith(
+        "primary-artifact-invalid: artifact-not-a-regular-file"
     )
+    assert "ref=docs/design.md" in blocker_result.reason

--- a/tests/test_planning_released_reclaim.py
+++ b/tests/test_planning_released_reclaim.py
@@ -15,6 +15,8 @@ from paulsha_cortex.coordinator.registry import JobRegistry
 from paulsha_cortex.coordinator.work_bridge import _claimable_existing_runs
 from paulsha_cortex.coordinator.workflow import WorkflowStep
 
+from diagnostic_fixtures import fixture_needs_human_reason
+
 CLAIM_KEY = "claim:v1:" + "a" * 64
 
 
@@ -47,6 +49,8 @@ def _create_run(registry: JobRegistry, **overrides: object):
         "facets": ("needs_human",),
     }
     fields.update(overrides)
+    if "needs_human" in tuple(fields.get("facets") or ()):
+        fields.setdefault("needs_human_reason", fixture_needs_human_reason())
     return registry._manager_create_workflow_run(**fields)
 
 

--- a/tests/test_registry_released_claimkey_load.py
+++ b/tests/test_registry_released_claimkey_load.py
@@ -15,6 +15,8 @@ import pytest
 from paulsha_cortex.coordinator.registry import JobRegistry
 from paulsha_cortex.coordinator.workflow import WorkflowStep
 
+from diagnostic_fixtures import fixture_needs_human_reason
+
 CLAIM_KEY = "claim:v1:" + "c" * 64
 
 
@@ -47,6 +49,8 @@ def _create_run(registry: JobRegistry, **overrides: object):
         "facets": ("needs_human",),
     }
     fields.update(overrides)
+    if "needs_human" in tuple(fields.get("facets") or ()):
+        fields.setdefault("needs_human_reason", fixture_needs_human_reason())
     return registry._manager_create_workflow_run(**fields)
 
 

--- a/tests/test_repair_commit_recovery.py
+++ b/tests/test_repair_commit_recovery.py
@@ -21,6 +21,8 @@ from paulsha_cortex.coordinator.model_identities import IdentityRegistry
 from paulsha_cortex.coordinator.registry import JobRegistry
 from paulsha_cortex.coordinator.workflow import WorkflowStep
 
+from diagnostic_fixtures import fixture_needs_human_reason
+
 ACTION = "recover-repair-commit"
 
 _PERSONA_BY_PHASE = {
@@ -140,6 +142,9 @@ def _make_run(
         openspec_refs=authority.mapped_openspec,
         candidate_head=candidate_head,
         facets=facets,
+        needs_human_reason=(
+            fixture_needs_human_reason() if "needs_human" in facets else None
+        ),
         gate_status="running",
     )
 

--- a/tests/test_retry_classification.py
+++ b/tests/test_retry_classification.py
@@ -18,6 +18,8 @@ from paulsha_cortex.coordinator import work_actions
 from paulsha_cortex.coordinator.registry import JobRegistry
 from paulsha_cortex.coordinator.workflow import WorkflowRun, WorkflowStep
 
+from diagnostic_fixtures import fixture_needs_human_reason
+
 
 HEAD = "b" * 40
 NOW = "2026-07-27T00:00:00+00:00"
@@ -318,6 +320,7 @@ def test_retry_build_result_carries_orchestrator_retry_for_unbound_terminalizati
         candidate_head=HEAD,
         facets=("needs_human",),
         gate_status="running",
+        needs_human_reason=fixture_needs_human_reason(),
     )
     job_args = {
         "task": "wf-demo-subagent-build",
@@ -383,6 +386,7 @@ def test_retry_build_result_carries_model_repair_after_review_needs_human(
         verified_head=HEAD,
         facets=("needs_human",),
         gate_status="running",
+        needs_human_reason=fixture_needs_human_reason(),
     )
     result = work_actions.execute_work_action(
         args={

--- a/tests/test_retry_verify_job_invalidation.py
+++ b/tests/test_retry_verify_job_invalidation.py
@@ -14,6 +14,8 @@ import pytest
 from paulsha_cortex.coordinator.registry import JobRegistry
 from paulsha_cortex.coordinator.workflow import WorkflowStep
 
+from diagnostic_fixtures import fixture_needs_human_reason
+
 CANDIDATE = "c" * 40
 
 
@@ -58,6 +60,7 @@ def _run_with_exited_verify_job(tmp_path: Path):
         attempts={"claim": 1, "verify": 1},
         facets=("needs_human",),
         candidate_head=CANDIDATE,
+        needs_human_reason=fixture_needs_human_reason(),
     )
     job = registry.create_job(
         task="wf-demo-verification",
@@ -156,6 +159,7 @@ def test_retry_review_reset_marks_exited_review_job_failed(tmp_path: Path) -> No
         facets=("needs_human",),
         candidate_head=CANDIDATE,
         verified_head=CANDIDATE,
+        needs_human_reason=fixture_needs_human_reason(),
     )
     job = registry.create_job(
         task="wf-demo-code-review",

--- a/tests/test_wiring_retry_sizing_recompute.py
+++ b/tests/test_wiring_retry_sizing_recompute.py
@@ -23,6 +23,8 @@ from paulsha_cortex.coordinator import work_actions
 from paulsha_cortex.coordinator.registry import JobRegistry
 from paulsha_cortex.coordinator.workflow import PlanningArtifactAuthority, WorkflowStep
 
+from diagnostic_fixtures import fixture_needs_human_reason
+
 HEAD = "b" * 40
 
 _PERSONA_BY_PHASE = {
@@ -167,6 +169,9 @@ def _make_run(
         candidate_head=candidate_head,
         verified_head=verified_head,
         facets=facets,
+        needs_human_reason=(
+            fixture_needs_human_reason() if "needs_human" in facets else None
+        ),
         gate_status="running",
         planning_authority=planning_authority,
         sizing_score=sizing_score,

--- a/tests/test_work_actions.py
+++ b/tests/test_work_actions.py
@@ -24,6 +24,8 @@ from paulsha_cortex.coordinator.preflight import CommandResult, PreflightResult
 from paulsha_cortex.coordinator.registry import JobRegistry
 from paulsha_cortex.coordinator.workflow import GateEvidenceRef, PlanningArtifactAuthority
 
+from diagnostic_fixtures import fixture_needs_human_reason
+
 
 HEAD = "a" * 40
 TREE = "b" * 40
@@ -350,6 +352,7 @@ def test_retry_build_requires_exact_candidate_and_resets_downstream_authority(
         facets=("needs_human",),
         gate_refs=(GateEvidenceRef("foreign-review", "/evidence/review.json", "f" * 64),),
         gate_status="running",
+        needs_human_reason=fixture_needs_human_reason(),
     )
     args = {
         "action": "retry-build",
@@ -452,6 +455,7 @@ def test_retry_build_preserves_only_manager_owned_archive_authority(
         facets=("needs_human", "degraded"),
         gate_refs=(GateEvidenceRef("foreign-review", "/evidence/review.json", "f" * 64),),
         gate_status="failed",
+        needs_human_reason=fixture_needs_human_reason(),
     )
 
     result = work_actions.execute_work_action(
@@ -538,6 +542,7 @@ def test_retry_build_recovers_unbound_builder_terminalization(
         candidate_head=HEAD,
         facets=("needs_human",),
         gate_status="running",
+        needs_human_reason=fixture_needs_human_reason(),
     )
     job_args = {
         "task": "wf-demo-subagent-build",
@@ -1361,6 +1366,7 @@ def test_review_attest_writes_immutable_exact_head_evidence(
         gate_refs=(GateEvidenceRef("foreign-review", "/evidence/foreign.json", "f" * 64),),
         gate_status="passed",
         facets=("needs_human", "degraded"),
+        needs_human_reason=fixture_needs_human_reason(),
     )
 
     class GitHub:
@@ -1479,6 +1485,7 @@ def test_ship_reenters_copilot_stop_through_bound_maintainer_review(
         ),
         gate_status="passed",
         facets=("needs_human",),
+        needs_human_reason=fixture_needs_human_reason(),
     )
     _initialize_delivery_journal(snapshot=snapshot, state=state)
     persisted = json.loads(state.read_text(encoding="utf-8"))
@@ -2457,6 +2464,7 @@ def test_ship_resume_rearms_prebinding_target_cardinality_stop(tmp_path: Path) -
         run.run_id,
         source_revision=work_authority_digest(authority),
         facets=("needs_human", "degraded"),
+        needs_human_reason=fixture_needs_human_reason(),
     )
     work_bridge._rebase_delivery_journal_authority(
         state_root=state.parent,

--- a/tests/test_work_actions_retry_invalidation.py
+++ b/tests/test_work_actions_retry_invalidation.py
@@ -23,6 +23,8 @@ from paulsha_cortex.coordinator import work_actions
 from paulsha_cortex.coordinator.registry import JobRegistry
 from paulsha_cortex.coordinator.workflow import PlanningArtifactAuthority, WorkflowStep
 
+from diagnostic_fixtures import fixture_needs_human_reason
+
 
 HEAD = "b" * 40
 NOW = "2026-07-27T00:00:00+00:00"
@@ -137,6 +139,9 @@ def _make_run(
         candidate_head=candidate_head,
         verified_head=verified_head,
         facets=facets,
+        needs_human_reason=(
+            fixture_needs_human_reason() if "needs_human" in facets else None
+        ),
         gate_status="running",
         planning_authority=planning_authority,
     )
@@ -665,7 +670,10 @@ def test_repeated_automatic_scan_on_unchanged_authority_does_not_retrigger_resta
     # mismatch 後，manager_daemon.py 的 except handler 把 needs_human 寫回
     # （見 manager_daemon.py 的 resume 迴圈 except 分支）。
     registry._manager_update_workflow_run(
-        run.run_id, facets=("needs_human",), gate_status="running"
+        run.run_id,
+        facets=("needs_human",),
+        gate_status="running",
+        needs_human_reason=fixture_needs_human_reason(),
     )
 
     # Tick 2～4：authority 完全沒再變（模擬後續多次 daemon tick，snapshot 沒

--- a/tests/test_workflow_production_wiring.py
+++ b/tests/test_workflow_production_wiring.py
@@ -36,6 +36,8 @@ from paulsha_cortex.coordinator.workflow import (
 from paulsha_cortex.deck.compile import compile_combo, emit
 from paulsha_cortex.deck.schema import DEFAULT_CARDS_PATH, DEFAULT_COMBOS_DIR, load_cards, load_combo
 
+from diagnostic_fixtures import fixture_needs_human_reason
+
 
 def _gate_ledger_passed(log_path, *, gates: list[dict[str, object]] | None = None) -> None:
     """#261：模擬 manager wrapper 在模型行程結束後寫下的 gate ledger。
@@ -635,6 +637,7 @@ def test_public_work_resume_preserves_define_retry_result(
         facets=("needs_human",),
         brainstorm_required=True,
         gate_status="running",
+        needs_human_reason=fixture_needs_human_reason(),
     )
     dispatcher = type("D", (), {"_registry": registry, "_git_runner": None})()
     monkeypatch.setattr(
@@ -1006,6 +1009,7 @@ def test_periodic_resume_does_not_clear_needs_human_or_retry(tmp_path: Path) -> 
         attempts={"build": 1},
         facets=("needs_human",),
         gate_status="running",
+        needs_human_reason=fixture_needs_human_reason(),
     )
     dispatcher = type("D", (), {"_registry": registry, "_git_runner": None})()
 
@@ -1225,6 +1229,7 @@ def test_post_merge_closure_skips_active_planning_path_reconciliation(
         facets=("needs_human",),
         gate_status="failed",
         brainstorm_required=True,
+        needs_human_reason=fixture_needs_human_reason(),
     )
     (tmp_path / "delivery-journal.json").write_text(
         json.dumps(
@@ -1535,6 +1540,7 @@ def test_operator_resume_retries_bound_needs_human_terminal_without_rewriting_ol
         attempts={"build": 1},
         facets=("needs_human",),
         gate_status="running",
+        needs_human_reason=fixture_needs_human_reason(),
     )
     log = tmp_path / "needs-human.jsonl"
     log.write_text(json.dumps({
@@ -1644,6 +1650,7 @@ def test_operator_resume_retries_bound_needs_human_terminal_without_rewriting_ol
         run.run_id,
         facets=("needs_human",),
         gate_status="running",
+        needs_human_reason=fixture_needs_human_reason(),
     )
 
     result = manager.resume_workflow_run(
@@ -1919,6 +1926,7 @@ def test_operator_resume_recovers_only_exact_legacy_agy_reviewer_terminal(
         attempts={"verify": 1},
         facets=("needs_human",),
         gate_status="running",
+        needs_human_reason=fixture_needs_human_reason(),
     )
     builder = registry.create_job(
         task="wf-builder",
@@ -2287,6 +2295,7 @@ def test_operator_resume_reconciles_brainstorm_artifact_authority_before_dispatc
             GateEvidenceRef("brainstorm", str(evidence), manager._sha256_path(evidence)),
         ),
         gate_status="running",
+        needs_human_reason=fixture_needs_human_reason(),
     )
     legacy_state = json.loads(state_path.read_text(encoding="utf-8"))
     legacy_state["workflows"][0].pop("planning_source_revision")
@@ -2361,6 +2370,7 @@ def test_brainstorm_required_without_evidence_stays_stopped_before_dispatch(
         facets=("needs_human",),
         gate_status="running",
         brainstorm_required=True,
+        needs_human_reason=fixture_needs_human_reason(),
     )
     dispatched: list[str] = []
     monkeypatch.setattr(
@@ -2688,6 +2698,7 @@ def test_operator_resume_dispatch_error_restores_needs_human(
         attempts={"build": 1},
         facets=("needs_human", "degraded"),
         gate_status="running",
+        needs_human_reason=fixture_needs_human_reason(),
     )
     monkeypatch.setattr(
         manager,
@@ -3322,6 +3333,7 @@ def test_control_queue_manager_executes_heterogeneous_brainstorm_before_plan(tmp
         steps=replay_steps,
         facets=("needs_human",),
         gate_status="running",
+        needs_human_reason=fixture_needs_human_reason(),
     )
     jobs_before_replay = len(registry.list_jobs())
     replayed = executor(build_request(
@@ -5129,6 +5141,7 @@ def test_operator_resume_replaces_exact_bound_reviewer_without_terminal_json(
         attempts={"verify": 1},
         facets=("needs_human",),
         gate_status="running",
+        needs_human_reason=fixture_needs_human_reason(),
     )
     builder = registry.create_job(
         task="wf-builder",

--- a/tests/test_workflow_registry.py
+++ b/tests/test_workflow_registry.py
@@ -17,6 +17,8 @@ from paulsha_cortex.coordinator.workflow import (
     validate_ship_stage_transition,
 )
 
+from diagnostic_fixtures import fixture_needs_human_reason
+
 
 def _legacy_v1_payload() -> dict[str, object]:
     job = {"job_id": "legacy-build-1", "status": "exited", "task": "legacy-build"}
@@ -88,6 +90,7 @@ def _create_run(registry: JobRegistry) -> WorkflowRun:
                 baseline_sha256="a" * 64,
             ),
         ),
+        needs_human_reason=fixture_needs_human_reason(),
     )
 
 


### PR DESCRIPTION
## 根因

0813–0814 **五次**獨立命中同一條缺口：狀態被推向「人要接手」的那一刻，**理由沒有跟著落地**。五個現場形態不同、根卻同一條：

| issue | 現場 |
| --- | --- |
| #527 | build 階段無聲掛 `needs_human`——無 evidence、無 slice、`cortex status` 不呈現、`next_actions` 空 |
| #514 | brainstorm artifact 重驗失敗的例外不含路徑與原因 |
| #515 | `_post_integration_artifact_evidence()` 的 **14 個裸 `return None`** 塌縮成不透明的 `primary-artifact-invalid` |
| #511 | planning artifact 拒收未帶原因也不留存內容（#513 已修訊息與 evidence，但那份結構化理由到不了 run） |
| #482 | retry-review 的 absent evidence key 不含原因或 identity，合法重試撞 immutable artifact |

逐案補洞已證明無效——`#397`／`#408`／`#513` 各補過一次，缺口照樣在下一個地方冒出來。#527 的根因尤其說明問題：例外**就在 except 區塊的手上**（`ValueError: worktree target already exists`），只是被 `_log_error` print 到 stderr（由 `service-manager.sh` 導向 `~/.agents/log/manager.log`），不進 journal、不進 evidence、不進 run。run 上只剩一個沒有理由的 facet，於是 `cortex status`／`work show`／`tick`／`complete` 四個介面同時沉默。

## invariant

> 任何把 run 轉入 `needs_human`、或把 evidence 標為 absent 的狀態變更，必須同時落一份結構化理由（機器可讀 reason ＋ 人可讀 detail ＋ 來源位置）到 run 或 evidence，並可由 `cortex status`／`work show` 曝光。

## 修法

### 1. 驗證層擋在唯一的進入點上

新增 `coordinator/diagnostics.py` 的 `DiagnosticReason`（`reason`／`detail`／`source` ＋可選的 `evidence_refs`／`context`），並在 registry 的狀態轉移 API 強制規則——`_manager_update_workflow_run`／`_manager_create_workflow_run` 是全庫**唯一**兩個能把 `needs_human` 寫進 run row 的入口：

1. 把 facet **加進去**必須帶理由，否則 `DiagnosticInvariantError`（fail-closed，狀態一個位元組都不動）；
2. 把 facet **移出**時理由一併清掉——陳舊理由比沒有理由更糟，operator 會讀到上一輪的原因；
3. facet **已在**而這次沒帶新理由則沿用既有理由——大量呼叫端會在同一個 run 上重複寫同一個 facet，第一次的理由才是根因。

`WorkflowRun` 新增 `needs_human_reason` 欄位持有這份理由，dataclass 層另鎖住「理由不得與 facet 脫鉤」（涵蓋 registry 內直接 `replace()` 的七個 reset 路徑）。反過來「facet 有、理由沒有」**刻意放行**：既有部署的狀態檔裡就躺著這種 run，載入時 fail-closed 會直接把 manager 打掛。

### 2. 掃描式 invariant 測試

以 AST 枚舉全庫所有把 `needs_human` 寫進 facets 的設置點（目前 24 處），斷言每一個都同時帶 `needs_human_reason`。新增一條忘了帶理由的設置點會在**單元測試**就炸，不必等到 dogfooding 現場。掃描器本身另有反證測試——一個刻意違規的樣本必須被抓出來，且「把 needs_human 濾掉」的形態不得被誤判為設置點——避免「掃描器壞掉」偽裝成「invariant 通過」。

### 3. 五張 issue 的補洞點

- **#527**：`manager_daemon` resume 迴圈的例外寫進 run（`resume-workflow-failed` ＋例外摘要 ＋ phase）。呈現面補上 `manager.workflow_status_entry()`，把 ongoing 且 `needs_human` 的 run 投影進 `cortex status` 的 `attention`——過去狀態快照 provider 只走 `list_slices()`，而 workflow lane 從不建立 slice row，run 在 `ready`／`held`／`slices`／`attention`／`recent_done` 五份清單裡**一份都不出現**；`_print_status` 另加 `needs_human[...]` 摘要行（格式比照既有的 `provider_failure[...]`）。
- **#514**：`_validated_brainstorm_planning_authority()` 迴圈裡每一條 raise 都補上 `ref=`（該函式掃多個 ref，過去訊息沒有主詞）；assessment 拒收沿用 #513 的 `(reasons=...; markers=Lnn:...; evidence=...)` 格式與 `cortex-planning-artifact-rejection/v1` evidence 落檔。**依 0814 adversarial review 的修正**，診斷同時做在真正會被走到的 **hash drift** 分支上（「artifact 在磁碟上被改動」先在 `:2682` 失敗，走不到 assessment），訊息帶 evidence／disk 兩邊的 digest。
- **#515**：14 個裸 `return None` 全部改為帶原因的 `ArtifactEvidenceFailure`，環境類（`artifact-symlink-rejected`／`artifact-path-escapes-root`／`artifact-not-a-regular-file`／`artifact-unreadable`）與內容類（`artifact-assessment-rejected`／`post-integration-incomplete`／`integration-resolutions-invalid`）分得開。assessment 類拒收透過新的 `rejection_recorder` 注入點沿用 #513 的 evidence 落檔——被拒內容會在緊接著的 `rollback_publication()` 被撤下，不先存一份 operator 就再也看不到。另加 AST 回歸樁鎖住「這個函式裡不得再出現裸 `return None`」。
- **#511**：#513 的結構化理由現在經由 invariant 層真的落到 run 上（過去只剩上游 `str(exc)[:160]` 截斷後的字串殘骸），並經 monitor observations 曝光到 `cortex work show` 的 `blocking_reason`。
- **#482**：pre-launch absent evaluation 的落點納入**原因與請求身分**的指紋（`absent_evaluation_key()`）。同原因＋同身分仍是冪等重寫（既有語意一字不改）；不同原因或不同身分則各自落地，`missing → unknown → registered` 這條合法的設定推進不再需要刪 evidence 才能前進，前一份 absent evidence 原位保留於 evaluation history。

## 範圍紀律

只修**診斷與理由**。後續處置（retry／`needs_human`／fail-closed 邏輯）一律不變——每個呼叫端原本會做什麼，改完之後照樣做什麼，只是多落一份可稽核的理由：

- 呈現面沿用既有欄位機制（`blocking_reason`／`provider_outcome`／`gate_reason`），沒有另立平行欄位體系；
- `next_actions` 只沿用既有的 `_build_phase_recovery_actions`（只宣告會被受理的動作，#382 的教訓），不新增任何處置判定；
- #482 只改 absent 那一支的命名，reviewer job 已存在時的 `{slice_id}-{reviewer_job_id}.json` 一字未動；
- #515 的 classification 判準未動（環境類仍歸 `content`，見下方相鄰缺陷）；
- 不動 GitHub 邊界，不動 #536／#545 剛落地的機制。

`needs_human_reason` 已列入 monitor 的 `_WORKFLOW_V2_OPTIONAL_ROW_KEYS` 封閉白名單——漏掉會讓每一個 run row 被判「含不支援的欄位」而讓整份 workflow projection degraded（#205 付過這個學費，#261 D5 因此選擇不新增欄位）；本 PR 有回歸樁鎖住。

## 測試證據

- 全套 `python3 -m pytest -q`：**2791 passed, 49 subtests passed**（rebase 到 `origin/main` = `9c69742`，含 #560／#566 之後重跑）。
- 新增 `tests/test_diagnostic_invariant_family_527.py`（32 個測試）：掃描式 invariant ＋掃描器反證 ＋執行期強制（含 fail-closed／清理由／沿用理由／legacy state 載入）＋五張 issue 的**原始現場 fixture**。
- invariant 落地當下即抓出 **90 個**既有測試在無理由的情況下製造 `needs_human`——全部補上 fixture 理由（`tests/diagnostic_fixtures.py`）。fixture 若能無理由地製造 `needs_human`，invariant 就有一個測試看不到的後門，而後門正是本家族五張 issue 的共同形態。
- #515 的三個既有斷言由「籠統的 `primary-artifact-invalid`」收緊為具體 reason code——其中一個 fixture 因此暴露出它**真正**卡在哪裡（`docs/design.md` 根本沒落到磁碟上，過去被籠統的 reason 遮住）。

## 相鄰缺陷（未在本 PR 處理）

1. **`{slice_id}-{reviewer_job_id}.json` 的 job id 重用碰撞**（#482 的 0812 留言）：reviewer job 已存在時的路徑不含 candidate，registry recovery 重用 job id 會撞既有 immutable evidence。改它會動到 workflow lane 已落地的全部 evidence 路徑，屬獨立的 lifecycle 變更。
2. **#515 建議 4 未做**：環境類原因（symlink／路徑逃逸／解碼失敗）仍歸 `content`，因而仍不可走 `recover-planning`。分類即處置，屬本 PR 明示的範圍外；現在 reason code 已可機械區分，改起來是單點。
3. **非 build phase 的 `next_actions` 仍為空**：`_build_phase_recovery_actions` 只涵蓋 build。#527 現場其實可用 `recover-pre-candidate`，但要曝光它需新增前置驗判定（#382 的教訓要求「只宣告會成功的動作」），屬處置面。
4. **`degraded` 的理由未強制**：本 PR 只強制 `needs_human`。monitor provider／doctor／runtime_preflight 各有獨立的 degraded 狀態機，其設置點多半已帶 `diagnostics` 字串但格式不統一，收編需另案。
5. **`str(exc)[:160]` 這個共用瓶頸仍在**（#511 留言已記）：`planning.py` 上游截斷四個分支的例外摘要，evidence 絕對路徑仍可能被切掉。本 PR 靠結構化 `evidence_refs` 繞過（不再依賴字串存活），但字串路徑本身未處理。

Refs #527 #514 #515 #511 #482
