### PR TITLE
perf(monitor): issues 改走 since 游標與 ETag 條件請求的增量同步

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,39 @@
 ## [Unreleased]
 
 ### Changed
+- **Issue #506 / D3：GitHub issues 改走 `state=all&since=` ＋ ETag 條件請求的增量
+  同步，全量只作每日一次的 anti-entropy 對帳**——`GitHubWorkProvider` 過去每輪對
+  **每個** configured repo 全量分頁抓 issues（`--paginate`）；D2 把 `contents`／
+  `compare` 歸零之後，這是 monitor 對 REST 配額剩下的主要常態消耗（約 13 個
+  configured repo × 每日 288 輪 = **3744 次計費請求／日**），而絕大多數回應與上一
+  輪逐位元組相同。新增 `paulsha_cortex/monitor/github_issue_sync.py` 作為增量協定
+  與 per-repo durable 狀態（游標／ETag／鏡像投影）的唯一入口。**`state=all` 不可
+  退讓**：`state=open&since=` 看不到剛被關閉的 issue，closure reducer 拿不到
+  `closed` 證據，manager 可能 auto-claim 已被人類在網頁端關掉的工作；closed issue
+  的 `updated_at` 會隨關閉事件更新，`state=all&since=` 的增量天然攜帶關閉事件且
+  delta 極小。**`sort=updated&direction=desc` 同樣不可退讓**：預設的 `created`
+  desc 排序下，「一個舊 issue 剛被更新」可能落在第 2 頁而**不改變第 1 頁**，第 1
+  頁的 ETag 就不再是整個 delta 的變更偵測器、條件請求會漏發。**ETag**：第 1 頁帶
+  `If-None-Match`，304 **不計入** rate limit 配額（實測 `x-ratelimit-used` 在條件
+  請求前後不變）；ETag 綁定它所屬的 request path，`since` 一前進即作廢，且 304
+  一路**不**取回應的 ETag——GitHub 的 304 回強形式 `"<hash>"`、200 回
+  `W/"<hash>"`，覆蓋回去會讓條件請求永遠落空而悄悄退化成每輪全額計費。**游標
+  紀律**：`since` 取自回應中最大的 `updated_at`（不是本機時鐘），只在整輪完整成功
+  後推進、永不倒退；分頁中斷時游標／ETag／鏡像三者原封不動。**每日全量
+  anti-entropy**：增量看不到 issue 被刪除／transfer 這類不留 `updated_at` 痕跡的
+  事件，因此每 86400s 強制一次不帶 `since`／不帶 `If-None-Match` 的全量重讀對帳，
+  drift 一律以全量為準並同時記 log 與 `observations["issue_sync"]["drift"]`。
+  **fail closed**：狀態缺失／損壞／游標格式不合／ETag 與 path 失聯一律退回全量
+  重建，單一 repo 的紀錄壞掉不拖垮其他 repo。分頁改為本地依 Link header 逐頁重建，
+  **不跟隨**伺服器給的絕對 URL（跟隨等於讓對方指定 `gh` 把 token 送去哪），連帶讓
+  每一頁都經過 `GitHubPressureGate.throttle`——改動前 `--paginate` 是 gh 在行程內
+  自己連發，閘門完全管不到。D1 的 `observations["auto_label_issues"]` 改由 durable
+  鏡像導出，網頁端關閉事件因此在**同一個** refresh 週期內就讓該 issue 退出 auto
+  派工名單。穩態計費請求降為每日 **26 次**（每 repo 1 次 anti-entropy 全量 ＋ 1 次
+  無法沿用 ETag 的增量）。只動 issues 讀取路徑；D2 的 `monitor/git_mirror.py` 未動，
+  寫入路徑、label API、events API 均不在本次。詳見
+  `changelog.d/d3-incremental-issue-sync.md`。新增
+  `tests/test_monitor_incremental_issue_sync_506.py`（34 個測試）。
 - **Issue #506 / D2：git 的資料走 git——monitor 對 GitHub REST 的兩類高量讀取改為本機
   git 操作，一輪掃描的 REST `contents`／`compare` 呼叫數固定為 0**——
   `GitHubTerminalProvider` 過去每個 remote `todo.md`／archived `tasks.md` 各打一次

--- a/changelog.d/d3-incremental-issue-sync.md
+++ b/changelog.d/d3-incremental-issue-sync.md
@@ -1,0 +1,59 @@
+# D3：GitHub issues 增量同步——`state=all&since=` ＋ ETag 條件請求
+
+## 問題
+
+`GitHubWorkProvider` 每輪對**每個** configured repo 全量分頁抓 issues
+（`issues?state=all&per_page=100` ＋ `--paginate`）。D2（PR #566）把 `contents`／
+`compare` 歸零之後，這是 monitor 對 REST 配額剩下的主要常態消耗：configured repos
+約 13 個、`github_refresh_interval_seconds` 預設 300s（每日 288 輪），每輪每 repo
+至少 1 次計費請求，其中絕大多數回應與上一輪逐位元組相同。
+
+## 改法
+
+新增 `paulsha_cortex/monitor/github_issue_sync.py`，是增量協定與 per-repo durable
+狀態（游標／ETag／鏡像投影）的唯一入口：
+
+- **`state=all` 不可退讓**：`state=open&since=` 看不到剛被關閉的 issue，closure
+  reducer 因此拿不到 `closed` 證據，manager 可能 auto-claim 一件人類已經在網頁端
+  關掉的工作。closed issue 的 `updated_at` 會隨關閉事件更新，`state=all&since=`
+  的增量天然攜帶關閉事件且 delta 極小。
+- **`sort=updated&direction=desc` 不可退讓**：預設排序是 `created` desc，在那個
+  順序下「一個舊 issue 剛被更新」可能落在第 2 頁而**不改變第 1 頁**——第 1 頁的
+  ETag 就不再是整個 delta 的變更偵測器，條件請求會漏發。改成 updated desc 後，
+  任何 `updated_at` 前進的 issue 必然跳到第 1 筆。
+- **ETag 條件請求**：第 1 頁帶 `If-None-Match`；**304 不計入 rate limit 配額**
+  （實測 `x-ratelimit-used` 在條件請求前後不變）。ETag 綁定它所屬的 request path
+  （`etag_request`），`since` 一前進 path 就變、舊 ETag 立刻作廢。304 一路**不**
+  取回應的 ETag——GitHub 的 304 回強形式 `"<hash>"`、200 回 `W/"<hash>"`，覆蓋
+  回去會讓往後的條件請求永遠落空而悄悄退化成每輪全額計費。
+- **游標紀律**：`since` 取自**回應**中最大的 `updated_at`（不是本機時鐘），只在
+  整輪完整成功後推進，且永不倒退；分頁中斷時游標／ETag／鏡像三者原封不動。
+- **每日一次全量 anti-entropy**：增量看不到 issue 被刪除／transfer 這類不留
+  `updated_at` 痕跡的事件。每 86400s 強制一次不帶 `since`、不帶 `If-None-Match`
+  的全量重讀並與鏡像對帳，drift 一律**以全量為準**，同時記 log 與
+  `observations["issue_sync"]["drift"]`。
+- **fail closed**：durable 狀態缺失／損壞／游標格式不合／entries 形狀不對／ETag
+  與 path 失聯——一律退回全量重建，絕不拿半壞的游標去做增量。單一 repo 的紀錄
+  壞掉不會拖垮其他 repo。
+
+分頁改為本地依 Link header 逐頁重建，**不跟隨**伺服器給的絕對 URL（跟隨等於讓
+對方指定 `gh` 把 token 送去哪）；連帶讓每一頁都經過 `GitHubPressureGate.throttle`
+——改動前 `--paginate` 是 gh 在行程內自己連發，閘門完全管不到那些請求。
+
+`observations["auto_label_issues"]`（D1）改由 durable 鏡像導出，因此網頁端的關閉
+事件一進增量，該 issue 就在**同一個** refresh 週期內退出 auto 派工名單。
+
+## 每輪 API 呼叫數對比（13 repos、每日 288 輪）
+
+| | 改動前 | 改動後（穩態） |
+| --- | --- | --- |
+| 每輪每 repo 計費請求 | ≥ 1（issue 數過 100 再按頁加倍） | 0（免費 304） |
+| 每日計費請求合計 | 13 × 288 = **3744** | **26**（每 repo：1 次 anti-entropy 全量 ＋ 1 次無法沿用 ETag 的增量） |
+
+## 範圍
+
+只動 monitor 的 issues 讀取路徑。D2 的 `monitor/git_mirror.py` 未動；寫入路徑、
+label API、events API 均不在本次。
+
+新增 `tests/test_monitor_incremental_issue_sync_506.py`（34 個測試，含六項驗收與
+量化對比樁）。

--- a/paulsha_cortex/config/paths.py
+++ b/paulsha_cortex/config/paths.py
@@ -47,6 +47,16 @@ def work_items_snapshot_path() -> Path:
     return monitor_state_root() / "work-items.snapshot.json"
 
 
+def github_issue_sync_path() -> Path:
+    """#506 / D3：GitHub issues 增量同步的 per-repo 游標／ETag／鏡像投影。
+
+    與 `work_items_snapshot_path()` 分開存放：這份是 monitor 對 GitHub 的**傳輸層
+    狀態**（下一次要從哪個 `since` 續讀、上次的 ETag），不是讀模型；讀模型損壞時
+    重建的代價是一次全量掃描，這份損壞時的代價也一樣，但兩者的生命週期無關。
+    """
+    return monitor_state_root() / "github-issue-sync.json"
+
+
 def skill_registry_root() -> Path:
     """Skill governance 治理平面根目錄（issue #204）：ledger／park state／proposal 共用。
 

--- a/paulsha_cortex/monitor/github_issue_sync.py
+++ b/paulsha_cortex/monitor/github_issue_sync.py
@@ -1,0 +1,517 @@
+"""#506 / D3：GitHub issues 增量同步——``state=all&since=`` ＋ ETag 條件請求。
+
+## 問題
+
+``GitHubWorkProvider`` 每輪對**每個** configured repo 全量分頁抓 issues
+（``issues?state=all&per_page=100`` ＋ ``--paginate``）。D2 把 ``contents``／
+``compare`` 歸零之後，這是 monitor 對 REST 配額剩下的主要常態消耗：每輪
+per-repo 至少 1 次、issue 數過 100 的 repo 每 100 個再多 1 次，而其中絕大多數
+回應與上一輪逐位元組相同。
+
+## 本模組的契約
+
+1. **``state=all`` 不可退讓**：``state=open&since=`` 看不到剛被關閉的 issue，
+   closure reducer 因此拿不到 ``closed`` 證據，manager 可能 auto-claim 一件人類
+   已經在網頁端關掉的工作。closed issue 的 ``updated_at`` 會隨關閉事件更新，
+   ``state=all&since=`` 的增量天然攜帶關閉事件，且 delta 極小。
+2. **``sort=updated&direction=desc`` 不可退讓**：預設排序是 ``created`` desc，
+   在那個順序下「一個舊 issue 剛被更新」可能落在第 2 頁而**不改變第 1 頁**——
+   第 1 頁的 ETag 就不再是整個 delta 的變更偵測器，條件請求會漏發。改成
+   updated desc 後，任何 ``updated_at`` 前進的 issue 必然跳到第 1 筆，第 1 頁
+   ETag 因此是 sound 的變更偵測器。
+3. **ETag 條件請求**：``If-None-Match`` 命中回 304，且 **304 不計入 GitHub rate
+   limit 配額**（實測 ``x-ratelimit-used`` 在 304 前後不變）。穩態時每輪每 repo
+   就是一次免費的條件請求。ETag 綁定它所屬的 request path（``etag_request``），
+   path 一變（``since`` 前進）就不再送舊 ETag。
+
+   .. warning:: 304 回應帶回來的 ``Etag`` 與 200 給的**形式不同**（實測 GitHub
+      200 回 ``W/"<hash>"``、304 回 ``"<hash>"`` 這個強形式）。因此 304 一路
+      **不得**拿回應的 ETag 去覆蓋既存狀態，否則下一輪送出的 header 會跟伺服器
+      認得的那顆對不上，條件請求從此永遠落空、悄悄退化成每輪全額計費。本模組的
+      作法是 304 時整份 state 原封不動（連寫都不寫），一併滿足驗收 2。
+4. **游標紀律**：``since`` 取自**回應**中最大的 ``updated_at``（不是本機時鐘），
+   只在該輪增量**完整成功**（所有分頁都拿到且解析成功）後才推進，且永不倒退。
+   分頁中斷、任一頁失敗——游標、ETag、鏡像三者一律原封不動。
+   ``since`` 在 GitHub 是**閉區間**（``>=``），因此邊界那筆 issue 每輪都會被重送；
+   這正是穩態下 body 穩定、ETag 穩定、304 成立的原因，重複合併本身是冪等的。
+5. **每日一次全量 anti-entropy**：增量看不到「issue 被刪除／transfer 出去」這類
+   不會留下 ``updated_at`` 痕跡的事件，也看不到任何一次被吞掉的漏發。因此每
+   ``full_sync_interval_seconds``（預設 86400s）強制一次不帶 ``since``、不帶
+   ``If-None-Match`` 的全量重讀，與鏡像對帳；有 drift 一律**以全量為準**，並記
+   log 與 ``observations["issue_sync"]["drift"]``。
+6. **fail closed**：durable 狀態缺失／損壞／``since`` 格式不合／entries 形狀不對
+   ——一律退回全量重建，**絕不**拿半壞的游標去做增量。
+
+``IssueSyncStore`` 是 per-repo durable 狀態（游標／ETag／鏡像投影）的唯一入口。
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import tempfile
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Sequence
+from urllib.parse import quote
+
+from paulsha_cortex.config.paths import github_issue_sync_path
+
+from .work_models import WorkSource
+
+
+SYNC_SCHEMA = "github-issue-sync/v1"
+
+# 每日一次全量對帳（計畫 R0.5 原則 4 明文）。
+DEFAULT_FULL_SYNC_INTERVAL_SECONDS = 86_400.0
+
+# GitHub 回傳的 ``updated_at``／要送回去的 ``since`` 一律是這個形狀。嚴格比對，
+# 因為這個字串會直接進 query string；同時它是純字典序可比的，max() 即時間最大。
+_API_TIMESTAMP = re.compile(r"\A\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z\Z")
+
+# ``gh api --include`` 的第一行；gh 用 Fprintln 寫它（結尾是 LF，不是 CRLF），
+# 其餘 header 才是 CRLF。實測 gh 2.45：``HTTP/2.0 304 Not Modified``。
+_STATUS_LINE = re.compile(r"\AHTTP/[0-9.]+ (?P<status>[0-9]{3})(?: |\Z)")
+
+HTTP_NOT_MODIFIED = 304
+
+
+class IssueSyncStateError(ValueError):
+    """durable 增量狀態不可信；呼叫端一律 fail closed 退回全量重建。"""
+
+
+# ---------------------------------------------------------------------------
+# request path
+# ---------------------------------------------------------------------------
+
+
+def issues_request_path(repo: str, *, since: str | None = None, page: int = 1) -> str:
+    """本模組是 issues 讀取 path 的唯一產生器（ETag 以 path 為 key，不容分歧）。"""
+
+    if page < 1:
+        raise ValueError("issue page number must be >= 1")
+    query = "state=all&per_page=100&sort=updated&direction=desc"
+    if since is not None:
+        if _API_TIMESTAMP.match(since) is None:
+            raise IssueSyncStateError(f"issue cursor is not an API timestamp: {since!r}")
+        query += f"&since={quote(since, safe='')}"
+    if page > 1:
+        # 刻意**不**跟隨回應 Link header 給的絕對 URL：那是伺服器可控字串，餵給
+        # ``gh api`` 等於讓對方指定 token 要送去哪。Link 只當「還有下一頁」的
+        # 布林訊號用，path 永遠由本地重建。
+        query += f"&page={page}"
+    return f"repos/{repo}/issues?{query}"
+
+
+# ---------------------------------------------------------------------------
+# gh --include 回應
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class GitHubResponse:
+    """``gh api --include`` 的一次回應（狀態行 ＋ header ＋ body）。"""
+
+    status: int
+    headers: Mapping[str, str]
+    body: str
+
+    @property
+    def etag(self) -> str | None:
+        value = self.headers.get("etag")
+        return value or None
+
+    @property
+    def not_modified(self) -> bool:
+        return self.status == HTTP_NOT_MODIFIED
+
+    @property
+    def has_next_page(self) -> bool:
+        link = self.headers.get("link", "")
+        return any(
+            'rel="next"' in part or "rel=next" in part for part in link.split(",")
+        )
+
+
+def parse_include_response(stdout: str) -> GitHubResponse:
+    """解析 ``gh api --include`` 的輸出。
+
+    刻意不做「沒有狀態行就當成純 body」的寬容退化：那會把一個缺 header 的回應
+    靜默當成「單頁、無 ETag」，也就是**靜默截斷鏡像**。缺狀態行一律是錯誤。
+    """
+
+    total = len(stdout)
+    index = 0
+
+    def next_line() -> str:
+        nonlocal index
+        end = stdout.find("\n", index)
+        if end < 0:
+            line, index = stdout[index:], total
+        else:
+            line, index = stdout[index:end], end + 1
+        return line.rstrip("\r")
+
+    match = _STATUS_LINE.match(next_line())
+    if match is None:
+        raise ValueError("gh response is missing an HTTP status line")
+    headers: dict[str, str] = {}
+    while index < total:
+        line = next_line()
+        if not line:
+            break
+        name, separator, value = line.partition(":")
+        if not separator or not name.strip():
+            raise ValueError("gh response header line is malformed")
+        headers[name.strip().lower()] = value.strip()
+    return GitHubResponse(
+        status=int(match.group("status")), headers=headers, body=stdout[index:]
+    )
+
+
+# ---------------------------------------------------------------------------
+# 鏡像投影
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class IssueEntry:
+    """issues 回應中我們真正用到的欄位投影（durable 鏡像的一列）。
+
+    ``labels`` 整份留著而非只留一個 auto-claim 布林：D1 的
+    ``observations["auto_label_issues"]`` 是從鏡像導出的，label 常數改名或日後
+    多看一個 label 時，不該被迫把全 fleet 的游標作廢重抓。
+    """
+
+    number: int
+    title: str
+    state: str
+    node_id: str
+    updated_at: str
+    is_pull_request: bool = False
+    labels: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        if isinstance(self.number, bool) or not isinstance(self.number, int):
+            raise ValueError("invalid issue number")
+        if self.number <= 0:
+            raise ValueError("invalid issue number")
+        for value in (self.title, self.state, self.node_id, self.updated_at):
+            if not isinstance(value, str) or not value:
+                raise ValueError("invalid GitHub entity fields")
+        if _API_TIMESTAMP.match(self.updated_at) is None:
+            raise ValueError("invalid GitHub updated_at timestamp")
+        if not isinstance(self.is_pull_request, bool):
+            raise ValueError("invalid pull_request flag")
+        object.__setattr__(self, "labels", tuple(self.labels))
+        if any(not isinstance(name, str) or not name for name in self.labels):
+            raise ValueError("invalid GitHub label entry")
+
+    @property
+    def kind(self) -> str:
+        return "github_pr" if self.is_pull_request else "github_issue"
+
+    @classmethod
+    def from_api(cls, entity: object) -> "IssueEntry":
+        """由 issues 回應的一個物件建投影；欄位形狀不合一律 raise ValueError。
+
+        與改動前的 ``_entity_source`` / ``_auto_label_issue_numbers`` 同一套嚴格
+        度——半壞的回應整包降級成 ``malformed JSON``，不靜默吞掉。
+        """
+
+        if not isinstance(entity, Mapping):
+            raise ValueError("GitHub entity is not an object")
+        labels = entity.get("labels", [])
+        if not isinstance(labels, list):
+            raise ValueError("invalid GitHub labels field")
+        names: list[str] = []
+        for label in labels:
+            if not isinstance(label, Mapping) or not isinstance(label.get("name"), str):
+                raise ValueError("invalid GitHub label entry")
+            names.append(label["name"])
+        return cls(
+            number=entity["number"],
+            title=entity["title"],
+            state=entity["state"],
+            node_id=entity["node_id"],
+            updated_at=entity["updated_at"],
+            is_pull_request="pull_request" in entity,
+            labels=tuple(names),
+        )
+
+    def to_source(self, *, repo: str, provider_id: str) -> WorkSource:
+        ref = f"{repo}#{self.number}"
+        return WorkSource(
+            source_id=f"{self.kind}:{ref}",
+            kind=self.kind,
+            ref=ref,
+            revision=f"github:{self.node_id}:{self.updated_at}",
+            status=self.state,
+            confidence="confirmed",
+            provider=provider_id,
+            title=self.title,
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "number": self.number,
+            "title": self.title,
+            "state": self.state,
+            "node_id": self.node_id,
+            "updated_at": self.updated_at,
+        }
+        if self.is_pull_request:
+            payload["is_pull_request"] = True
+        if self.labels:
+            payload["labels"] = list(self.labels)
+        return payload
+
+    @classmethod
+    def from_dict(cls, payload: object) -> "IssueEntry":
+        if not isinstance(payload, Mapping):
+            raise IssueSyncStateError("issue entry must be an object")
+        labels = payload.get("labels", [])
+        if not isinstance(labels, list):
+            raise IssueSyncStateError("issue entry labels must be an array")
+        try:
+            return cls(
+                number=payload["number"],
+                title=payload["title"],
+                state=payload["state"],
+                node_id=payload["node_id"],
+                updated_at=payload["updated_at"],
+                is_pull_request=bool(payload.get("is_pull_request", False)),
+                labels=tuple(labels),
+            )
+        except (KeyError, TypeError, ValueError) as error:
+            raise IssueSyncStateError(f"issue entry is invalid: {error}") from error
+
+    def differs_from(self, other: "IssueEntry") -> bool:
+        return (
+            self.state != other.state
+            or self.updated_at != other.updated_at
+            or self.title != other.title
+            or self.node_id != other.node_id
+            or self.is_pull_request != other.is_pull_request
+            or self.labels != other.labels
+        )
+
+
+def _parse_local_timestamp(value: str) -> datetime:
+    """解析我們自己時鐘寫下的 ISO-8601（帶不帶微秒都吃）。"""
+
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except (AttributeError, TypeError, ValueError) as error:
+        raise IssueSyncStateError(f"timestamp is not ISO-8601: {value!r}") from error
+    if parsed.tzinfo is None:
+        raise IssueSyncStateError(f"timestamp is missing a timezone: {value!r}")
+    return parsed.astimezone(timezone.utc)
+
+
+@dataclass(frozen=True)
+class IssueSyncState:
+    """單一 repo 的 durable 增量狀態。"""
+
+    repo: str
+    entries: tuple[IssueEntry, ...] = ()
+    since: str | None = None
+    etag: str | None = None
+    etag_request: str | None = None
+    last_full_sync_at: str | None = None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.repo, str) or self.repo.count("/") != 1:
+            raise IssueSyncStateError("issue sync state repo must be owner/name")
+        entries = tuple(self.entries)
+        numbers = [entry.number for entry in entries]
+        if len(set(numbers)) != len(numbers):
+            raise IssueSyncStateError("issue sync state has duplicate issue numbers")
+        object.__setattr__(self, "entries", tuple(sorted(entries, key=lambda e: e.number)))
+        if self.since is not None and _API_TIMESTAMP.match(self.since) is None:
+            raise IssueSyncStateError(
+                f"issue cursor is not an API timestamp: {self.since!r}"
+            )
+        if (self.etag is None) != (self.etag_request is None):
+            raise IssueSyncStateError("issue ETag must travel with its request path")
+        if self.last_full_sync_at is not None:
+            _parse_local_timestamp(self.last_full_sync_at)
+
+    @property
+    def by_number(self) -> dict[int, IssueEntry]:
+        return {entry.number: entry for entry in self.entries}
+
+    def needs_full_sync(self, *, now: str, interval_seconds: float) -> bool:
+        """是否該跑每日全量對帳。
+
+        ``last_full_sync_at`` 缺失、無法解析、或落在**未來**（時鐘回捲／狀態被
+        竄改）一律回 True——fail closed 寧可多跑一次全量。
+        """
+
+        if self.last_full_sync_at is None:
+            return True
+        try:
+            last = _parse_local_timestamp(self.last_full_sync_at)
+            current = _parse_local_timestamp(now)
+        except IssueSyncStateError:
+            return True
+        elapsed = (current - last).total_seconds()
+        return elapsed < 0 or elapsed >= interval_seconds
+
+    def merged(self, delta: Sequence[IssueEntry]) -> tuple[IssueEntry, ...]:
+        """把增量 delta 疊到鏡像上（同號覆蓋——delta 依定義較新）。"""
+
+        merged = self.by_number
+        for entry in delta:
+            merged[entry.number] = entry
+        return tuple(sorted(merged.values(), key=lambda e: e.number))
+
+    def to_dict(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {"entries": [entry.to_dict() for entry in self.entries]}
+        for field_name in ("since", "etag", "etag_request", "last_full_sync_at"):
+            value = getattr(self, field_name)
+            if value is not None:
+                payload[field_name] = value
+        return payload
+
+    @classmethod
+    def from_dict(cls, repo: str, payload: object) -> "IssueSyncState":
+        if not isinstance(payload, Mapping):
+            raise IssueSyncStateError("issue sync state must be an object")
+        entries = payload.get("entries")
+        if not isinstance(entries, list):
+            raise IssueSyncStateError("issue sync state entries must be an array")
+        optional: dict[str, str | None] = {}
+        for field_name in ("since", "etag", "etag_request", "last_full_sync_at"):
+            value = payload.get(field_name)
+            if value is not None and not isinstance(value, str):
+                raise IssueSyncStateError(f"issue sync state {field_name} must be a string")
+            optional[field_name] = value
+        return cls(
+            repo=repo,
+            entries=tuple(IssueEntry.from_dict(row) for row in entries),
+            **optional,
+        )
+
+
+def cursor_from(entries: Iterable[IssueEntry], *, floor: str | None = None) -> str | None:
+    """游標＝回應中最大的 ``updated_at``（非本機時鐘），且永不倒退。
+
+    ``updated_at`` 是零填充的 ``...THH:MM:SSZ``，字典序即時間序。
+    """
+
+    candidates = [entry.updated_at for entry in entries]
+    if floor is not None:
+        candidates.append(floor)
+    return max(candidates) if candidates else None
+
+
+def drift_between(
+    previous: Sequence[IssueEntry], authoritative: Sequence[IssueEntry]
+) -> dict[str, list[int]] | None:
+    """全量對帳：鏡像相對於全量真相的偏差。無偏差回 ``None``。"""
+
+    before = {entry.number: entry for entry in previous}
+    after = {entry.number: entry for entry in authoritative}
+    missing = sorted(set(before) - set(after))
+    extra = sorted(set(after) - set(before))
+    changed = sorted(
+        number
+        for number in set(before) & set(after)
+        if after[number].differs_from(before[number])
+    )
+    if not (missing or extra or changed):
+        return None
+    return {"stale": missing, "unseen": extra, "changed": changed}
+
+
+# ---------------------------------------------------------------------------
+# durable store
+# ---------------------------------------------------------------------------
+
+
+class IssueSyncStore:
+    """per-repo 游標／ETag／鏡像投影的 durable 存放點（單一檔案，repo 為 key）。"""
+
+    def __init__(self, path: str | Path | None = None) -> None:
+        self.path = Path(path) if path is not None else github_issue_sync_path()
+
+    def _load_document(self) -> dict[str, Any]:
+        try:
+            raw = self.path.read_text(encoding="utf-8")
+        except FileNotFoundError:
+            return {"schema": SYNC_SCHEMA, "repos": {}}
+        except (OSError, UnicodeError) as error:
+            raise IssueSyncStateError(f"issue sync state unreadable: {error}") from error
+        try:
+            payload = json.loads(raw)
+        except json.JSONDecodeError as error:
+            raise IssueSyncStateError(f"issue sync state is not JSON: {error}") from error
+        if not isinstance(payload, Mapping):
+            raise IssueSyncStateError("issue sync state document must be an object")
+        if payload.get("schema") != SYNC_SCHEMA:
+            raise IssueSyncStateError(
+                f"unsupported issue sync schema: {payload.get('schema')!r}"
+            )
+        repos = payload.get("repos")
+        if not isinstance(repos, Mapping):
+            raise IssueSyncStateError("issue sync state repos must be an object")
+        return {"schema": SYNC_SCHEMA, "repos": dict(repos)}
+
+    def load(self, repo: str) -> IssueSyncState | None:
+        """回傳該 repo 的狀態；沒有紀錄回 ``None``，損壞則 raise。
+
+        兩者的呼叫端行為相同（全量重建），分開只為了讓「第一次見到這個 repo」
+        不會被記成一則 drift 診斷。單一 repo 的紀錄壞掉不會拖垮其他 repo；
+        整份文件壞掉才會讓每個 repo 都退回全量。
+        """
+
+        record = self._load_document()["repos"].get(repo)
+        if record is None:
+            return None
+        return IssueSyncState.from_dict(repo, record)
+
+    def save(self, state: IssueSyncState) -> None:
+        try:
+            document = self._load_document()
+        except IssueSyncStateError:
+            # 正在覆寫的就是壞掉的那份文件——這是復原路徑，不是資料遺失。
+            document = {"schema": SYNC_SCHEMA, "repos": {}}
+        document["repos"][state.repo] = state.to_dict()
+        self._write(document)
+
+    def _write(self, document: Mapping[str, Any]) -> None:
+        # 與 ``work_snapshot.WorkSnapshotStore._write_payload`` 同一套原子寫入
+        # （temp + fsync + rename + dir fsync + 0600）。刻意不共用私有方法，
+        # 避免為了 25 行工具碼把兩個 store 的生命週期綁在一起。
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        body = (
+            json.dumps(document, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+        ).encode("utf-8")
+        handle_fd, temp_name = tempfile.mkstemp(
+            prefix=f".{self.path.name}.", suffix=".tmp", dir=self.path.parent
+        )
+        temp_path = Path(temp_name)
+        try:
+            os.fchmod(handle_fd, 0o600)
+            with os.fdopen(handle_fd, "wb") as handle:
+                handle.write(body)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(temp_path, self.path)
+            directory_fd = os.open(
+                self.path.parent, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0)
+            )
+            try:
+                os.fsync(directory_fd)
+            finally:
+                os.close(directory_fd)
+        except BaseException:
+            try:
+                os.close(handle_fd)
+            except OSError:
+                pass
+            temp_path.unlink(missing_ok=True)
+            raise

--- a/paulsha_cortex/monitor/github_issue_sync.py
+++ b/paulsha_cortex/monitor/github_issue_sync.py
@@ -396,6 +396,23 @@ class IssueSyncState:
         )
 
 
+def dedupe_entries(entries: Sequence[IssueEntry]) -> tuple[IssueEntry, ...]:
+    """同號去重，保留 ``updated_at`` 最新的那筆。
+
+    分頁跑的是一個**活的**、依 ``updated`` 排序的清單：某個 issue 在我們讀第 1 頁
+    與第 2 頁之間被更新，就會在兩頁各出現一次。這是分頁本身的產物，不是壞回應——
+    但重複進到 :class:`IssueSyncState` 會直接 raise，因此在傳輸層就收斂掉。
+    （反向的漏抓由每日全量 anti-entropy 兜底。）
+    """
+
+    latest: dict[int, IssueEntry] = {}
+    for entry in entries:
+        current = latest.get(entry.number)
+        if current is None or entry.updated_at >= current.updated_at:
+            latest[entry.number] = entry
+    return tuple(sorted(latest.values(), key=lambda entry: entry.number))
+
+
 def cursor_from(entries: Iterable[IssueEntry], *, floor: str | None = None) -> str | None:
     """游標＝回應中最大的 ``updated_at``（非本機時鐘），且永不倒退。
 

--- a/paulsha_cortex/monitor/github_pressure.py
+++ b/paulsha_cortex/monitor/github_pressure.py
@@ -18,6 +18,13 @@ Monitor 的 ``_github_refresh_loop``（``monitor/service.py``）每
      的 REST 只剩 graphql 分頁與 1 次 git tree。下面的問題描述與預算計算保留
      當時的實測基準，因為節流／退避機制本身沒有變。
 
+  .. note:: #506 / D3 之後，``GitHubWorkProvider`` 改走
+     ``state=all&since=`` ＋ ETag 條件請求的增量協定（``monitor/github_issue_sync``），
+     穩態下每輪每 repo 是 **1 次免費 304**；全量只在每日一次的 anti-entropy
+     對帳、以及游標／ETag 狀態損壞的 fail-closed 重建時發生。分頁也從
+     ``--paginate``（gh 在行程內自己連發，閘門完全管不到）改成本地逐頁重建，
+     因此**每一頁**都會經過 :meth:`GitHubPressureGate.throttle`。
+
 亦即 per-repo per-cycle 是 O(issues 分頁 + todo 檔數)。實際 workspace 約 40 個
 repo，一輪數百次請求在數秒內齊發，穩定觸發 GitHub secondary（abuse detection）
 rate limit——實測 ``github:`` 與 ``github-terminal:`` 兩個 provider 同時

--- a/paulsha_cortex/monitor/providers.py
+++ b/paulsha_cortex/monitor/providers.py
@@ -3,10 +3,12 @@ from __future__ import annotations
 
 import hashlib
 import json
+import logging
 import math
 import re
 import subprocess
 import time
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable, Mapping, Protocol, Sequence
@@ -22,6 +24,18 @@ from .git_mirror import (
     LocalGitMirror,
     unavailable_provenance,
 )
+from .github_issue_sync import (
+    DEFAULT_FULL_SYNC_INTERVAL_SECONDS,
+    GitHubResponse,
+    IssueEntry,
+    IssueSyncState,
+    IssueSyncStateError,
+    IssueSyncStore,
+    cursor_from,
+    drift_between,
+    issues_request_path,
+    parse_include_response,
+)
 from .github_pressure import (
     RATE_LIMIT_KIND_PRIMARY,
     RATE_LIMIT_KIND_SECONDARY,
@@ -30,6 +44,8 @@ from .github_pressure import (
 )
 from .work_models import ProviderSnapshot, WorkSource
 
+
+logger = logging.getLogger(__name__)
 
 _ARCHIVE_DATE_PREFIX = re.compile(r"^\d{4}-\d{2}-\d{2}-(?P<name>.+)$")
 
@@ -863,8 +879,35 @@ def _backoff_diagnostic(prefix: str, blocked_seconds: float) -> str:
     return f"{prefix} rate limit backoff active; retry in {blocked_seconds:.0f}s"
 
 
+class _GitHubRequestError(Exception):
+    """一次 issues 請求失敗，已附好要寫進 diagnostics 的字串。"""
+
+    def __init__(self, diagnostic: str) -> None:
+        super().__init__(diagnostic)
+        self.diagnostic = diagnostic
+
+
+@dataclass(frozen=True)
+class _FetchResult:
+    entries: tuple[IssueEntry, ...]
+    not_modified: bool
+    requests: int
+    pages: int
+    etag: str | None
+
+
 class GitHubWorkProvider:
-    """Read GitHub entities through authenticated ``gh api`` JSON only."""
+    """Read GitHub entities through authenticated ``gh api`` JSON only.
+
+    #506 / D3：讀取走 ``state=all&since=`` ＋ ETag 條件請求的增量協定，全量只作
+    每日一次的 anti-entropy 對帳。協定本身（游標紀律／ETag 綁定 path／fail-closed
+    條件／drift 對帳）全部定義在 ``monitor/github_issue_sync``；本類別只負責發
+    ``gh`` 請求、分診失敗、把鏡像投影成 ``ProviderSnapshot``。
+    """
+
+    # 100 筆/頁 × 50 頁＝5000 筆。超過視為分頁失控（伺服器沒收斂 Link），
+    # fail closed，不讓一輪掃描無上限地打下去。
+    _PAGE_LIMIT = 50
 
     def __init__(
         self,
@@ -873,6 +916,9 @@ class GitHubWorkProvider:
         runner: CommandRunner | None = None,
         timeout_seconds: float = 30,
         pressure_gate: GitHubPressureGate | None = None,
+        sync_store: IssueSyncStore | None = None,
+        full_sync_interval_seconds: float = DEFAULT_FULL_SYNC_INTERVAL_SECONDS,
+        now: Callable[[], str] | None = None,
     ) -> None:
         if repo.count("/") != 1 or any(not part for part in repo.split("/")):
             raise ValueError("GitHub repo must use owner/name")
@@ -882,70 +928,142 @@ class GitHubWorkProvider:
         self.timeout_seconds = timeout_seconds
         # #506：未注入 gate 時完全維持舊行為（不節流、不退避）。
         self.pressure_gate = pressure_gate
+        # D3：沒有 durable store 就沒有游標可續——每輪都是全量。這不是降級路徑，
+        # 是「無狀態即無增量」的誠實契約（測試與一次性呼叫端走的就是它）。
+        self.sync_store = sync_store
+        self.full_sync_interval_seconds = float(full_sync_interval_seconds)
+        self._now = now or _utcnow
+
+    # -- 掃描 -------------------------------------------------------------
 
     def scan(self) -> ProviderSnapshot:
-        attempted_at = _utcnow()
+        attempted_at = self._now()
         if self.pressure_gate is not None:
             blocked = self.pressure_gate.blocked_seconds()
             if blocked > 0:
                 # #506：退避期間直接跳過，不再硬撞一次 403 去加深限流。
                 return self._failure(attempted_at, _backoff_diagnostic("github", blocked))
-            self.pressure_gate.throttle()
-        argv = (
-            "gh",
-            "api",
-            "--method",
-            "GET",
-            "--paginate",
-            "--jq",
-            ".[]",
-            f"repos/{self.repo}/issues?state=all&per_page=100",
-        )
-        try:
-            completed = self.runner.run(argv, timeout=self.timeout_seconds)
-        except subprocess.TimeoutExpired:
-            return self._failure(attempted_at, "github timeout")
-        except FileNotFoundError:
-            return self._failure(attempted_at, "github CLI unavailable")
-        except OSError:
-            return self._failure(attempted_at, "github provider I/O failure")
-        if completed.returncode != 0:
-            message = completed.stderr.decode(errors="replace") if isinstance(completed.stderr, bytes) else completed.stderr
-            # #370: rate limit must be checked *before* auth -- GitHub's own
-            # secondary/abuse-detection rate limit messages mention "OAuth"
-            # and invite re-authenticating, so an auth-first check
-            # misclassifies a retryable rate limit as a dead credential.
-            if is_rate_limit_signal(message):
-                # #506：403 再分診成 primary／secondary，並開啟退避窗。
-                return self._failure(
-                    attempted_at,
-                    _rate_limit_diagnostic(
-                        runner=self.runner,
-                        timeout_seconds=self.timeout_seconds,
-                        message=message,
-                        gate=self.pressure_gate,
-                        prefix="github",
-                    ),
+        notes: list[str] = []
+        previous: IssueSyncState | None = None
+        if self.sync_store is not None:
+            try:
+                previous = self.sync_store.load(self.repo)
+            except IssueSyncStateError as error:
+                # 驗收 4：游標／ETag 狀態損壞 → fail closed 全量重建，
+                # **絕不**拿半壞的游標去做增量。
+                notes.append(f"github issue sync state unusable; rebuilt in full: {error}")
+                logger.warning(
+                    "github issue sync state for %s is unusable; rebuilding in full: %s",
+                    self.repo,
+                    error,
                 )
-            if is_auth_signal(message):
-                diagnostic = "github authentication failed"
-            else:
-                diagnostic = "github API request failed"
-            return self._failure(attempted_at, diagnostic)
-        stdout = completed.stdout.decode() if isinstance(completed.stdout, bytes) else completed.stdout
+        if previous is None:
+            mode, reason = "full", notes[0] if notes else "no durable cursor"
+        elif previous.needs_full_sync(
+            now=attempted_at, interval_seconds=self.full_sync_interval_seconds
+        ):
+            mode, reason = "full", "anti-entropy"
+        else:
+            mode, reason = "incremental", None
+
+        since = previous.since if (mode == "incremental" and previous is not None) else None
         try:
-            entities = [
-                json.loads(line)
-                for line in stdout.splitlines()
-                if line.strip()
-            ]
-            if any(not isinstance(entity, dict) for entity in entities):
-                raise ValueError("GitHub entity is not an object")
-            sources = tuple(self._entity_source(entity) for entity in entities)
-            auto_label_issues = _auto_label_issue_numbers(entities)
-        except (json.JSONDecodeError, TypeError, ValueError, KeyError):
-            return self._failure(attempted_at, "github API returned malformed JSON")
-        sources = tuple(sorted(sources, key=lambda source: (source.kind, source.ref)))
+            base_path = issues_request_path(self.repo, since=since)
+        except IssueSyncStateError:
+            # 游標通過了 state 驗證卻做不出 path——只可能是驗證漏了，退回全量。
+            mode, reason, since = "full", "cursor rejected by request builder", None
+            base_path = issues_request_path(self.repo)
+        # anti-entropy 一輪刻意**不**帶 If-None-Match：全量的職責就是真的重讀一次，
+        # 拿 304 換來的「跟上次一樣」不是對帳，是把待驗證的假設當成結論。
+        etag = (
+            previous.etag
+            if (
+                mode == "incremental"
+                and previous is not None
+                and previous.etag is not None
+                and previous.etag_request == base_path
+            )
+            else None
+        )
+
+        try:
+            fetched = self._fetch_pages(base_path=base_path, since=since, etag=etag)
+        except _GitHubRequestError as error:
+            # 分頁中斷／任一頁失敗：游標、ETag、鏡像三者原封不動（上層
+            # `_retain_last_good` 續用上一份好的快照）。
+            return self._failure(attempted_at, error.diagnostic)
+
+        drift: dict[str, list[int]] | None = None
+        if fetched.not_modified:
+            # 驗收 2：304 不改 mirror、不動游標、不動 ETag——連寫都不寫。
+            # （ETag 也刻意不從 304 回應取回：GitHub 的 304 回的是強形式
+            # `"<hash>"`，與 200 給的 `W/"<hash>"` 不同，覆蓋回去會讓往後的條件
+            # 請求永遠落空。）
+            if previous is None:
+                # etag 只可能來自 previous，走到這裡代表狀態機被破壞。
+                return self._failure(attempted_at, "github returned 304 without a cursor")
+            state = previous
+            entries = previous.entries
+        else:
+            if mode == "full":
+                entries = fetched.entries
+                if previous is not None:
+                    drift = drift_between(previous.entries, entries)
+            else:
+                entries = (
+                    previous.merged(fetched.entries)
+                    if previous is not None
+                    else tuple(sorted(fetched.entries, key=lambda entry: entry.number))
+                )
+            state = IssueSyncState(
+                repo=self.repo,
+                entries=entries,
+                # 游標取自回應中最大的 updated_at（非本機時鐘），且永不倒退。
+                since=cursor_from(
+                    fetched.entries, floor=previous.since if previous is not None else None
+                ),
+                etag=fetched.etag,
+                etag_request=base_path if fetched.etag else None,
+                last_full_sync_at=(
+                    attempted_at
+                    if mode == "full"
+                    else (previous.last_full_sync_at if previous is not None else None)
+                ),
+            )
+
+        if drift is not None:
+            # 驗收 5：全量對帳發現 drift → 以全量為準，並同時留 log 與 observation。
+            logger.warning(
+                "github issue mirror drift for %s resolved in favour of the full sync: %s",
+                self.repo,
+                drift,
+            )
+            notes.append(f"github issue mirror drift resolved by full sync: {drift}")
+
+        persisted = True
+        if self.sync_store is not None and state is not previous:
+            try:
+                self.sync_store.save(state)
+            except OSError as error:
+                # 快照本身是對的，只是游標沒存下來——下一輪會退回全量重建（合併
+                # 本來就冪等），所以這是效能退化而非正確性問題，不該讓整輪 degraded。
+                persisted = False
+                notes.append(
+                    f"github issue sync state not persisted; next cycle rebuilds in full: {error}"
+                )
+                logger.warning(
+                    "github issue sync state for %s was not persisted: %s", self.repo, error
+                )
+
+        sources = tuple(
+            sorted(
+                (
+                    entry.to_source(repo=self.repo, provider_id=self.provider_id)
+                    for entry in entries
+                ),
+                key=lambda source: (source.kind, source.ref),
+            )
+        )
         revision = "github-snapshot:" + _digest(
             tuple(
                 f"{source.source_id}\0{source.revision}\0{source.status}".encode("utf-8")
@@ -961,14 +1079,142 @@ class GitHubWorkProvider:
             last_attempt_at=attempted_at,
             last_success_at=attempted_at,
             revision=revision,
-            diagnostics=(),
+            diagnostics=tuple(notes),
             sources=sources,
-            # R0.5 D1：issues 回應本來就含 labels——把 auto 派工 label 的持有者
-            # 記進 observations，讓 manager 的 auto-claim scan 讀鏡像即可判定，
-            # 不必每 tick 對每個 mapped issue 各發一次 live `gh api`（實測
-            # 57 次/tick，是 fleet 對 GitHub 最大的持續壓力源）。
-            observations={"auto_label_issues": auto_label_issues},
+            observations={
+                # R0.5 D1：issues 回應本來就含 labels——把 auto 派工 label 的持有者
+                # 記進 observations，讓 manager 的 auto-claim scan 讀鏡像即可判定，
+                # 不必每 tick 對每個 mapped issue 各發一次 live `gh api`（實測
+                # 57 次/tick，是 fleet 對 GitHub 最大的持續壓力源）。D3 之後這份
+                # 由 durable 鏡像導出，因此關閉事件一進增量就會讓該 issue 立刻
+                # 退出 auto 派工名單。
+                "auto_label_issues": _auto_label_issue_numbers(entries),
+                "issue_sync": {
+                    "mode": mode,
+                    "reason": reason,
+                    "not_modified": fetched.not_modified,
+                    "requests": fetched.requests,
+                    "conditional_requests": 1 if etag is not None else 0,
+                    # 304 不計入 GitHub rate limit 配額（實測 x-ratelimit-used
+                    # 在條件請求前後不變），因此配額帳與請求帳要分開記。
+                    "billed_requests": fetched.requests - (1 if fetched.not_modified else 0),
+                    "pages": fetched.pages,
+                    "delta_entries": len(fetched.entries),
+                    "mirror_entries": len(entries),
+                    "since": state.since,
+                    "drift": drift,
+                    "persisted": persisted,
+                },
+            },
         )
+
+    # -- 傳輸 -------------------------------------------------------------
+
+    def _fetch_pages(
+        self, *, base_path: str, since: str | None, etag: str | None
+    ) -> _FetchResult:
+        first = self._request(base_path, etag=etag)
+        if first.not_modified:
+            if etag is None:
+                # 沒送 If-None-Match 卻收到 304：協定被破壞。把它當成「沒有變更」
+                # 會讓鏡像被一份空回應定住，寧可 degraded。
+                raise _GitHubRequestError("github returned 304 without a conditional request")
+            return _FetchResult(
+                entries=(), not_modified=True, requests=1, pages=0, etag=etag
+            )
+        entries = list(self._entries(first))
+        requests = 1
+        pages = 1
+        response = first
+        while response.has_next_page:
+            if pages >= self._PAGE_LIMIT:
+                raise _GitHubRequestError("github issue pagination incomplete")
+            pages += 1
+            response = self._request(
+                issues_request_path(self.repo, since=since, page=pages)
+            )
+            requests += 1
+            if response.not_modified:
+                # 續頁沒送 If-None-Match，回 304 代表協定被破壞——寧可整輪
+                # degraded，也不能把一個空頁當成「這頁沒東西」而截斷鏡像。
+                raise _GitHubRequestError("github issue pagination returned 304")
+            entries.extend(self._entries(response))
+        return _FetchResult(
+            entries=tuple(entries),
+            not_modified=False,
+            requests=requests,
+            pages=pages,
+            etag=first.etag,
+        )
+
+    def _entries(self, response: GitHubResponse) -> tuple[IssueEntry, ...]:
+        try:
+            payload = json.loads(response.body)
+            if not isinstance(payload, list):
+                raise ValueError("GitHub issues response is not an array")
+            return tuple(IssueEntry.from_api(entity) for entity in payload)
+        except (json.JSONDecodeError, TypeError, ValueError, KeyError) as error:
+            raise _GitHubRequestError("github API returned malformed JSON") from error
+
+    def _request(self, path: str, *, etag: str | None = None) -> GitHubResponse:
+        if self.pressure_gate is not None:
+            # 節流改為 per-request：改動前一次 `--paginate` 是 gh 在行程內自己
+            # 連發分頁，閘門完全管不到那些請求。
+            self.pressure_gate.throttle()
+        argv: list[str] = ["gh", "api", "--method", "GET", "--include"]
+        if etag is not None:
+            argv += ["--header", f"If-None-Match: {etag}"]
+        argv.append(path)
+        try:
+            completed = self.runner.run(tuple(argv), timeout=self.timeout_seconds)
+        except subprocess.TimeoutExpired:
+            raise _GitHubRequestError("github timeout") from None
+        except FileNotFoundError:
+            raise _GitHubRequestError("github CLI unavailable") from None
+        except OSError:
+            raise _GitHubRequestError("github provider I/O failure") from None
+        stdout = (
+            completed.stdout.decode(errors="replace")
+            if isinstance(completed.stdout, bytes)
+            else (completed.stdout or "")
+        )
+        try:
+            response = parse_include_response(stdout)
+        except ValueError:
+            response = None
+        # 304 必須先判：gh 對任何非 2xx 都以非零離開（實測 `gh: HTTP 304`），
+        # 但條件請求命中是**成功**，不是失敗。
+        if response is not None and response.not_modified:
+            return response
+        if completed.returncode != 0:
+            message = (
+                completed.stderr.decode(errors="replace")
+                if isinstance(completed.stderr, bytes)
+                else (completed.stderr or "")
+            )
+            # #370: rate limit must be checked *before* auth -- GitHub's own
+            # secondary/abuse-detection rate limit messages mention "OAuth"
+            # and invite re-authenticating, so an auth-first check
+            # misclassifies a retryable rate limit as a dead credential.
+            if is_rate_limit_signal(message):
+                # #506：403 再分診成 primary／secondary，並開啟退避窗。
+                raise _GitHubRequestError(
+                    _rate_limit_diagnostic(
+                        runner=self.runner,
+                        timeout_seconds=self.timeout_seconds,
+                        message=message,
+                        gate=self.pressure_gate,
+                        prefix="github",
+                    )
+                )
+            if is_auth_signal(message):
+                raise _GitHubRequestError("github authentication failed")
+            raise _GitHubRequestError("github API request failed")
+        if response is None:
+            raise _GitHubRequestError("github API returned a malformed response")
+        if response.status // 100 != 2:
+            raise _GitHubRequestError("github API request failed")
+        return response
 
     def _failure(self, attempted_at: str, diagnostic: str) -> ProviderSnapshot:
         return ProviderSnapshot(
@@ -981,29 +1227,6 @@ class GitHubWorkProvider:
             sources=(),
         )
 
-    def _entity_source(self, entity: dict) -> WorkSource:
-        number = entity["number"]
-        title = entity["title"]
-        state = entity["state"]
-        node_id = entity["node_id"]
-        updated_at = entity["updated_at"]
-        if isinstance(number, bool) or not isinstance(number, int):
-            raise ValueError("invalid issue number")
-        if any(not isinstance(value, str) or not value for value in (title, state, node_id, updated_at)):
-            raise ValueError("invalid GitHub entity fields")
-        kind = "github_pr" if "pull_request" in entity else "github_issue"
-        ref = f"{self.repo}#{number}"
-        return WorkSource(
-            source_id=f"{kind}:{ref}",
-            kind=kind,
-            ref=ref,
-            revision=f"github:{node_id}:{updated_at}",
-            status=state,
-            confidence="confirmed",
-            provider=self.provider_id,
-            title=title,
-        )
-
 
 # 與 coordinator/claim.py 的 AUTO_LABEL、doctor.py 的 AUTO_LABEL 同值。monitor 不
 # import coordinator.claim（避免把 deck/verification 整串拉進 monitor 行程），以
@@ -1012,32 +1235,23 @@ class GitHubWorkProvider:
 AUTO_CLAIM_LABEL = "cortex:auto-on-going"
 
 
-def _auto_label_issue_numbers(entities: list[dict]) -> list[int]:
+def _auto_label_issue_numbers(entries: Sequence[IssueEntry]) -> list[int]:
     """開啟 auto 派工 label 的 open issue 編號（排序去重）。
 
-    labels 欄位缺失或形狀不合時 raise——與 `_entity_source` 同一個 try 區塊，
-    整包降級成 `github API returned malformed JSON`，不靜默吞掉半壞回應。
-    PR（`pull_request` 鍵存在）不參與 auto 派工，跳過。
+    D3 之後輸入是 durable 鏡像而非單輪回應：一個 issue 在網頁端被關閉，關閉事件
+    會隨 `state=all&since=` 的增量進來覆蓋掉鏡像那一列，該 issue 因此在同一個
+    refresh 週期內就退出這份名單——manager 不會再 auto-claim 它。
+    欄位形狀的嚴格驗證前移到 `IssueEntry`（回應與 durable 狀態兩邊共用同一套）。
+    PR 不參與 auto 派工，跳過。
     """
 
-    numbers: set[int] = set()
-    for entity in entities:
-        if "pull_request" in entity:
-            continue
-        if entity.get("state") != "open":
-            continue
-        labels = entity.get("labels", [])
-        if not isinstance(labels, list):
-            raise ValueError("invalid GitHub labels field")
-        for label in labels:
-            if not isinstance(label, dict) or not isinstance(label.get("name"), str):
-                raise ValueError("invalid GitHub label entry")
-            if label["name"] == AUTO_CLAIM_LABEL:
-                number = entity["number"]
-                if isinstance(number, bool) or not isinstance(number, int):
-                    raise ValueError("invalid issue number")
-                numbers.add(number)
-    return sorted(numbers)
+    return sorted(
+        entry.number
+        for entry in entries
+        if not entry.is_pull_request
+        and entry.state == "open"
+        and AUTO_CLAIM_LABEL in entry.labels
+    )
 
 
 class _GitHubRateLimitError(OSError):

--- a/paulsha_cortex/monitor/providers.py
+++ b/paulsha_cortex/monitor/providers.py
@@ -32,6 +32,7 @@ from .github_issue_sync import (
     IssueSyncStateError,
     IssueSyncStore,
     cursor_from,
+    dedupe_entries,
     drift_between,
     issues_request_path,
     parse_include_response,
@@ -1015,21 +1016,29 @@ class GitHubWorkProvider:
                     if previous is not None
                     else tuple(sorted(fetched.entries, key=lambda entry: entry.number))
                 )
-            state = IssueSyncState(
-                repo=self.repo,
-                entries=entries,
-                # 游標取自回應中最大的 updated_at（非本機時鐘），且永不倒退。
-                since=cursor_from(
-                    fetched.entries, floor=previous.since if previous is not None else None
-                ),
-                etag=fetched.etag,
-                etag_request=base_path if fetched.etag else None,
-                last_full_sync_at=(
-                    attempted_at
-                    if mode == "full"
-                    else (previous.last_full_sync_at if previous is not None else None)
-                ),
-            )
+            try:
+                state = IssueSyncState(
+                    repo=self.repo,
+                    entries=entries,
+                    # 游標取自回應中最大的 updated_at（非本機時鐘），且永不倒退。
+                    since=cursor_from(
+                        fetched.entries,
+                        floor=previous.since if previous is not None else None,
+                    ),
+                    etag=fetched.etag,
+                    etag_request=base_path if fetched.etag else None,
+                    last_full_sync_at=(
+                        attempted_at
+                        if mode == "full"
+                        else (previous.last_full_sync_at if previous is not None else None)
+                    ),
+                )
+            except IssueSyncStateError as error:
+                # 合出來的狀態自己過不了驗證：degraded（上層續用上一份好的快照），
+                # 絕不讓例外逸出 provider 把整個 refresh 迴圈打斷。
+                return self._failure(
+                    attempted_at, f"github issue sync state rejected: {error}"
+                )
 
         if drift is not None:
             # 驗收 5：全量對帳發現 drift → 以全量為準，並同時留 log 與 observation。
@@ -1140,7 +1149,8 @@ class GitHubWorkProvider:
                 raise _GitHubRequestError("github issue pagination returned 304")
             entries.extend(self._entries(response))
         return _FetchResult(
-            entries=tuple(entries),
+            # 分頁跑的是活清單，同一個 issue 可能跨頁重複出現——傳輸層先收斂。
+            entries=dedupe_entries(entries),
             not_modified=False,
             requests=requests,
             pages=pages,

--- a/paulsha_cortex/monitor/work_api.py
+++ b/paulsha_cortex/monitor/work_api.py
@@ -14,6 +14,7 @@ from typing import Callable, Mapping, Sequence
 from .config import load_config
 from .correlation import InferredSignal, correlate_work_sources
 from .git_mirror import GITHUB_HTTPS_REMOTE, GITHUB_SSH_REMOTE
+from .github_issue_sync import IssueSyncStore
 from .github_pressure import GitHubPressureGate
 from .lifecycle import ClosureEvidence, project_work_items
 from .models import ProjectState
@@ -428,6 +429,7 @@ class WorkModelRefresher:
         stale_after_seconds: int = 900,
         now: Callable[[], datetime] | None = None,
         github_pressure_gate: GitHubPressureGate | None = None,
+        issue_sync_store: IssueSyncStore | None = None,
     ) -> None:
         self.durable_store = durable_store
         self.read_store = read_store
@@ -443,6 +445,10 @@ class WorkModelRefresher:
         # 但壓力是 per-token 的，所以閘門必須活得比 provider 久（由 refresher
         # 持有），否則節流只在單一 repo 內生效、退避每個 repo 各燒一次 403。
         self.github_pressure_gate = github_pressure_gate
+        # #506 / D3：issues 增量同步的 per-repo 游標／ETag／鏡像。跟壓力閘門一樣
+        # 必須活得比 provider 久——provider 是 per-repo per-cycle 建的，游標卻要
+        # 跨輪次續存，狀態掛在 provider 上等於每輪都全量。
+        self.issue_sync_store = issue_sync_store or IssueSyncStore()
         self.workflow_provider_factory = workflow_provider_factory or WorkflowRegistryProvider
         self.stale_after_seconds = stale_after_seconds
         self.now = now or (lambda: datetime.now(timezone.utc))
@@ -517,7 +523,10 @@ class WorkModelRefresher:
                     # 呼叫端（測試／上層組裝）行為完全不變。
                     github_provider = (
                         GitHubWorkProvider(
-                            repo, pressure_gate=self.github_pressure_gate
+                            repo,
+                            pressure_gate=self.github_pressure_gate,
+                            # D3：沒有這個 store 就沒有游標可續，每輪都會退回全量。
+                            sync_store=self.issue_sync_store,
                         )
                         if self._uses_default_github_provider
                         else self.github_provider_factory(repo)

--- a/tests/test_auto_label_mirror_d1.py
+++ b/tests/test_auto_label_mirror_d1.py
@@ -39,8 +39,8 @@ def test_auto_label_constant_alignment() -> None:
 # ---------------------------------------------------------------------------
 
 
-def _issue_line(number: int, *, state: str = "open", labels: list[str] | None = None,
-                pull_request: bool = False) -> str:
+def _issue(number: int, *, state: str = "open", labels: list[str] | None = None,
+           pull_request: bool = False) -> dict:
     entity: dict = {
         "number": number,
         "title": f"issue {number}",
@@ -51,7 +51,12 @@ def _issue_line(number: int, *, state: str = "open", labels: list[str] | None = 
     }
     if pull_request:
         entity["pull_request"] = {"url": "x"}
-    return json.dumps(entity)
+    return entity
+
+
+def _issues_response(*entities: dict) -> str:
+    """D3：issues 讀取改走 `gh api --include`（狀態行 + header + JSON 陣列）。"""
+    return 'HTTP/2.0 200 OK\nEtag: W/"d1"\r\n\r\n' + json.dumps(list(entities))
 
 
 class _Runner:
@@ -63,27 +68,25 @@ class _Runner:
 
 
 def test_work_provider_records_auto_label_issue_numbers() -> None:
-    stdout = "\n".join(
-        [
-            _issue_line(7, labels=[AUTO_CLAIM_LABEL, "bug"]),
-            _issue_line(9, labels=["bug"]),
-            # closed 不參與 auto 派工
-            _issue_line(11, state="closed", labels=[AUTO_CLAIM_LABEL]),
-            # PR 不參與
-            _issue_line(13, labels=[AUTO_CLAIM_LABEL], pull_request=True),
-            _issue_line(21, labels=[AUTO_CLAIM_LABEL]),
-        ]
+    stdout = _issues_response(
+        _issue(7, labels=[AUTO_CLAIM_LABEL, "bug"]),
+        _issue(9, labels=["bug"]),
+        # closed 不參與 auto 派工
+        _issue(11, state="closed", labels=[AUTO_CLAIM_LABEL]),
+        # PR 不參與
+        _issue(13, labels=[AUTO_CLAIM_LABEL], pull_request=True),
+        _issue(21, labels=[AUTO_CLAIM_LABEL]),
     )
     snapshot = GitHubWorkProvider("acme/demo", runner=_Runner(stdout)).scan()
     assert snapshot.status == "ok"
-    assert snapshot.observations == {"auto_label_issues": [7, 21]}
+    assert snapshot.observations["auto_label_issues"] == [7, 21]
 
 
 def test_work_provider_malformed_labels_fail_closed() -> None:
-    entity = json.loads(_issue_line(7))
+    entity = _issue(7)
     entity["labels"] = "not-a-list"
     snapshot = GitHubWorkProvider(
-        "acme/demo", runner=_Runner(json.dumps(entity))
+        "acme/demo", runner=_Runner(_issues_response(entity))
     ).scan()
     assert snapshot.status == "degraded"
     assert "malformed" in snapshot.diagnostics[0]

--- a/tests/test_monitor_github_pressure_506.py
+++ b/tests/test_monitor_github_pressure_506.py
@@ -112,10 +112,11 @@ def _completed(payload, *, returncode=0, stderr=""):
 
 
 def _issues(*rows):
+    """D3：issues 讀取改走 `gh api --include`，body 是整個 JSON 陣列。"""
     return subprocess.CompletedProcess(
         args=("gh",),
         returncode=0,
-        stdout="\n".join(json.dumps(row) for row in rows) + "\n",
+        stdout='HTTP/2.0 200 OK\nEtag: W/"issues"\r\n\r\n' + json.dumps(list(rows)),
         stderr="",
     )
 

--- a/tests/test_monitor_incremental_issue_sync_506.py
+++ b/tests/test_monitor_incremental_issue_sync_506.py
@@ -1,0 +1,756 @@
+"""#506 / D3：GitHub issues 增量同步（``state=all&since=`` ＋ ETag）的驗收鎖。
+
+改動前：``GitHubWorkProvider`` 每輪對**每個** configured repo 全量分頁抓 issues，
+configured repos 約 13 個，是 D2 之後 REST 配額剩下的主要常態消耗。
+
+改動後的協定（契約全文見 ``monitor/github_issue_sync`` 模組 docstring）：
+
+- 增量請求 ``issues?state=all&per_page=100&sort=updated&direction=desc&since=<游標>``
+- 第 1 頁帶 ``If-None-Match``；304 不計 GitHub rate limit 配額
+- 游標取自**回應**中最大的 ``updated_at``，只在整輪完整成功後推進，且永不倒退
+- 每日一次不帶 ``since``／不帶 ETag 的全量 anti-entropy 對帳，drift 以全量為準
+- 游標／ETag／鏡像損壞一律 fail closed 退回全量重建
+
+本檔逐條鎖住計畫明文的六項驗收。
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from paulsha_cortex.monitor.github_issue_sync import (
+    IssueSyncStateError,
+    IssueSyncStore,
+    issues_request_path,
+)
+from paulsha_cortex.monitor.providers import AUTO_CLAIM_LABEL, GitHubWorkProvider
+
+
+REPO = "acme/demo"
+BASE_PATH = "repos/acme/demo/issues?state=all&per_page=100&sort=updated&direction=desc"
+
+
+# ---------------------------------------------------------------------------
+# 測試替身：mock 的是 HTTP 層（`gh api` 的輸出），不打真實 GitHub API
+# ---------------------------------------------------------------------------
+
+
+def issue(
+    number: int,
+    *,
+    state: str = "open",
+    updated_at: str = "2026-08-15T00:00:00Z",
+    labels: tuple[str, ...] = (),
+    title: str | None = None,
+    pull_request: bool = False,
+) -> dict:
+    entity: dict = {
+        "number": number,
+        "title": title or f"issue {number}",
+        "state": state,
+        "node_id": f"NODE{number}",
+        "updated_at": updated_at,
+        "labels": [{"name": name} for name in labels],
+    }
+    if pull_request:
+        entity["pull_request"] = {"url": f"https://api.github.test/pulls/{number}"}
+    return entity
+
+
+def ok(*entities: dict, etag: str = 'W/"page1"', next_page: bool = False):
+    """200 回應。狀態行以 LF 結尾、其餘 header CRLF——實測 gh 2.45 的真實形狀。"""
+    headers = [f"Etag: {etag}\r"] if etag else []
+    if next_page:
+        # 伺服器給的是絕對 URL；provider 只把它當「還有下一頁」的布林訊號，
+        # path 一律本地重建（見 test_pagination_never_follows_server_urls）。
+        headers.append(
+            'Link: <https://evil.test/repositories/1/issues?page=2>; rel="next"\r'
+        )
+    stdout = "\n".join(["HTTP/2.0 200 OK", *headers, "\r"]) + "\n" + json.dumps(list(entities))
+    return subprocess.CompletedProcess(args=("gh",), returncode=0, stdout=stdout, stderr="")
+
+
+def not_modified(etag: str = '"page1"'):
+    """304：gh 以**非零**離開，stdout 仍有 header 區塊，stderr 是 `gh: HTTP 304`。
+
+    回的 ETag 刻意用強形式（GitHub 實測行為），鎖住「304 不得把它寫回狀態」。
+    """
+    stdout = f"HTTP/2.0 304 Not Modified\nEtag: {etag}\r\n\r\n"
+    return subprocess.CompletedProcess(
+        args=("gh",), returncode=1, stdout=stdout, stderr="gh: HTTP 304"
+    )
+
+
+def failure(stderr: str = "HTTP 500: upstream exploded"):
+    return subprocess.CompletedProcess(
+        args=("gh",), returncode=1, stdout="", stderr=stderr
+    )
+
+
+class Runner:
+    """依序回應的 fake `gh` runner，記錄每次 argv。"""
+
+    def __init__(self, *responses) -> None:
+        self.responses = list(responses)
+        self.calls: list[tuple[str, ...]] = []
+
+    def run(self, argv, *, timeout=None):  # noqa: ARG002 - 契約簽章
+        argv = tuple(argv)
+        self.calls.append(argv)
+        if not self.responses:
+            raise AssertionError(f"未預期的第 {len(self.calls)} 次 gh 呼叫：{argv}")
+        return self.responses.pop(0)
+
+    @property
+    def paths(self) -> list[str]:
+        return [argv[-1] for argv in self.calls]
+
+    def conditional_headers(self) -> list[str]:
+        headers = []
+        for argv in self.calls:
+            for index, token in enumerate(argv):
+                if token == "--header" and argv[index + 1].startswith("If-None-Match:"):
+                    headers.append(argv[index + 1])
+        return headers
+
+
+def provider(store, runner, *, now="2026-08-15T12:00:00Z", **kwargs):
+    return GitHubWorkProvider(
+        REPO, runner=runner, sync_store=store, now=lambda: now, **kwargs
+    )
+
+
+@pytest.fixture()
+def store(tmp_path: Path) -> IssueSyncStore:
+    return IssueSyncStore(tmp_path / "github-issue-sync.json")
+
+
+def statuses(snapshot) -> dict[str, str]:
+    return {source.ref: source.status for source in snapshot.sources}
+
+
+STEADY_ETAG = 'W/"steady"'
+
+
+def bootstrap(store, *entities, now="2026-08-15T12:00:00Z"):
+    """把 store 跑到穩態（下一輪就會送條件請求）。
+
+    ETag 綁定它所屬的 request path，所以全量之後的**第一個**增量輪次必然是一次
+    無條件 200——那一輪的 path 多了 `&since=`，與全量那顆 ETag 的 path 不同。
+    第二個增量輪次起 path 不再變動，才進入每輪 304 的穩態。這一輪的成本是
+    每次全量／每次游標前進各多一次計費請求，見
+    test_cursor_advance_retires_the_stale_etag。
+    """
+    provider(store, Runner(ok(*entities)), now=now).scan()
+    provider(store, Runner(ok(*entities, etag=STEADY_ETAG)), now=now).scan()
+
+
+# ---------------------------------------------------------------------------
+# A. 協定形狀：第一輪全量、之後增量
+# ---------------------------------------------------------------------------
+
+
+def test_first_cycle_without_state_is_a_full_scan(store):
+    runner = Runner(ok(issue(1, updated_at="2026-08-15T09:00:00Z")))
+
+    snapshot = provider(store, runner).scan()
+
+    assert snapshot.status == "ok"
+    # 沒有 durable 游標 → 全量：不帶 since、不帶條件請求。
+    assert runner.paths == [BASE_PATH]
+    assert runner.conditional_headers() == []
+    assert snapshot.observations["issue_sync"]["mode"] == "full"
+    # 游標與 ETag 落成 durable 狀態，供下一輪續讀。
+    state = store.load(REPO)
+    assert state.since == "2026-08-15T09:00:00Z"
+    assert state.etag == 'W/"page1"'
+    assert state.etag_request == BASE_PATH
+    assert state.last_full_sync_at == "2026-08-15T12:00:00Z"
+
+
+def test_second_cycle_is_incremental_with_since_but_no_stale_etag(store):
+    """全量之後的第一個增量輪次帶 `since`，但**不**帶條件請求。
+
+    全量那顆 ETag 屬於沒有 `&since=` 的 path；拿它去問一個不同的 URL，伺服器的
+    回答對不上我們手上的資料。ETag 因此必須跟著它的 request path 一起被作廢。
+    """
+    provider(store, Runner(ok(issue(1, updated_at="2026-08-15T09:00:00Z")))).scan()
+
+    runner = Runner(ok(issue(1, updated_at="2026-08-15T09:00:00Z")))
+    snapshot = provider(store, runner).scan()
+
+    assert snapshot.observations["issue_sync"]["mode"] == "incremental"
+    assert runner.paths == [f"{BASE_PATH}&since=2026-08-15T09%3A00%3A00Z"]
+    assert runner.conditional_headers() == []
+
+
+def test_steady_state_cycle_sends_the_conditional_request(store):
+    bootstrap(store, issue(1, updated_at="2026-08-15T09:00:00Z"))
+
+    runner = Runner(not_modified())
+    snapshot = provider(store, runner).scan()
+
+    assert runner.paths == [f"{BASE_PATH}&since=2026-08-15T09%3A00%3A00Z"]
+    assert runner.conditional_headers() == [f"If-None-Match: {STEADY_ETAG}"]
+    assert snapshot.observations["issue_sync"]["not_modified"] is True
+
+
+def test_cursor_advance_retires_the_stale_etag(store):
+    """游標一前進，request path 就變了——舊 ETag 屬於舊 path，不得再送。
+
+    這是穩態被打斷後重新暖機的完整序列：有活動的那一輪仍是條件請求（path 尚未
+    變），它把游標推前；下一輪 path 變了，舊 ETag 一律作廢、退回無條件 200；
+    再下一輪 path 穩定下來，才重新回到 304。
+    """
+    bootstrap(store, issue(1, updated_at="2026-08-15T09:00:00Z"))
+
+    # 有新活動：這一輪仍問 since=09:00，游標被推到 10:00。
+    advanced = Runner(ok(issue(1, updated_at="2026-08-15T10:00:00Z"), etag='W/"page2"'))
+    provider(store, advanced).scan()
+    assert advanced.conditional_headers() == [f"If-None-Match: {STEADY_ETAG}"]
+
+    # path 換成 since=10:00：`W/"page2"` 屬於 since=09:00 那個 path，作廢。
+    retired = Runner(ok(issue(1, updated_at="2026-08-15T10:00:00Z"), etag='W/"page3"'))
+    provider(store, retired).scan()
+    assert retired.paths == [f"{BASE_PATH}&since=2026-08-15T10%3A00%3A00Z"]
+    assert retired.conditional_headers() == []
+
+    # path 穩定，重回 304 穩態。
+    runner = Runner(not_modified())
+    provider(store, runner).scan()
+    assert runner.paths == [f"{BASE_PATH}&since=2026-08-15T10%3A00%3A00Z"]
+    assert runner.conditional_headers() == ['If-None-Match: W/"page3"']
+
+
+# ---------------------------------------------------------------------------
+# B. 驗收 1：網頁端關閉 issue → 一個 refresh 週期內 mirror 轉 closed 且不再 auto-claim
+# ---------------------------------------------------------------------------
+
+
+def test_web_closed_issue_flips_mirror_and_leaves_auto_claim_within_one_cycle(store):
+    """`state=open&since=` 看不到剛被關閉的 issue——這正是必須用 `state=all` 的理由。
+
+    「不得再被 auto-claim」在鏡像這一層的具體判準就是退出
+    ``observations["auto_label_issues"]``：D1 之後 claim.py 的 canonical
+    ``WorkAuthority.auto_label`` 就是從這份名單導出的
+    （由 test_auto_label_mirror_d1.py 鎖住）。
+    """
+    opened = issue(
+        7, state="open", updated_at="2026-08-15T09:00:00Z", labels=(AUTO_CLAIM_LABEL,)
+    )
+    first = provider(store, Runner(ok(opened))).scan()
+    assert statuses(first) == {"acme/demo#7": "open"}
+    assert first.observations["auto_label_issues"] == [7]
+
+    # 人類在網頁端按下 Close：closed issue 的 updated_at 會前進，因此這件事
+    # 天然搭著 `state=all&since=` 的增量進來。
+    closed = issue(
+        7, state="closed", updated_at="2026-08-15T11:00:00Z", labels=(AUTO_CLAIM_LABEL,)
+    )
+    runner = Runner(ok(closed, etag='W/"closed"'))
+    second = provider(store, runner).scan()
+
+    assert runner.paths == [f"{BASE_PATH}&since=2026-08-15T09%3A00%3A00Z"]
+    assert statuses(second) == {"acme/demo#7": "closed"}
+    assert second.observations["auto_label_issues"] == []
+    assert store.load(REPO).by_number[7].state == "closed"
+
+
+# ---------------------------------------------------------------------------
+# C. 驗收 2：304 不改 mirror、不亂動游標、計為條件請求
+# ---------------------------------------------------------------------------
+
+
+def test_not_modified_leaves_mirror_cursor_and_etag_untouched(store):
+    bootstrap(
+        store, issue(1, updated_at="2026-08-15T09:00:00Z", labels=(AUTO_CLAIM_LABEL,))
+    )
+    before = store.path.read_text(encoding="utf-8")
+
+    runner = Runner(not_modified())
+    snapshot = provider(store, runner).scan()
+
+    assert snapshot.status == "ok"
+    # mirror 照樣完整投影出來（304 是「沒有變更」，不是「沒有資料」）。
+    assert statuses(snapshot) == {"acme/demo#1": "open"}
+    assert snapshot.observations["auto_label_issues"] == [1]
+    # 游標、ETag、鏡像三者連檔案位元組都沒動。
+    assert store.path.read_text(encoding="utf-8") == before
+    state = store.load(REPO)
+    assert state.since == "2026-08-15T09:00:00Z"
+    # 特別是 ETag 不得被 304 回應的強形式 `"page1"` 覆蓋掉。
+    assert state.etag == STEADY_ETAG
+
+
+def test_not_modified_is_counted_as_a_free_conditional_request(store):
+    bootstrap(store, issue(1, updated_at="2026-08-15T09:00:00Z"))
+
+    snapshot = provider(store, Runner(not_modified())).scan()
+
+    sync = snapshot.observations["issue_sync"]
+    assert sync["not_modified"] is True
+    assert sync["conditional_requests"] == 1
+    assert sync["requests"] == 1
+    # 304 不計入 GitHub rate limit 配額，因此計費請求數是 0。
+    assert sync["billed_requests"] == 0
+
+
+def test_unsolicited_304_without_a_conditional_request_is_degraded(store):
+    """沒送 If-None-Match 卻收到 304：協定被破壞，不得當成「沒有變更」。"""
+    snapshot = provider(store, Runner(not_modified())).scan()
+
+    assert snapshot.status == "degraded"
+    assert any("304" in item for item in snapshot.diagnostics)
+
+
+# ---------------------------------------------------------------------------
+# D. 驗收 3：增量回應含新開／更新／關閉三類，mirror 收斂正確
+# ---------------------------------------------------------------------------
+
+
+def test_incremental_delta_converges_opened_updated_and_closed(store):
+    provider(
+        store,
+        Runner(
+            ok(
+                issue(1, state="open", updated_at="2026-08-15T09:00:00Z", title="one"),
+                issue(2, state="open", updated_at="2026-08-15T08:00:00Z", title="two"),
+                issue(3, state="open", updated_at="2026-08-15T07:00:00Z", title="three"),
+            )
+        ),
+    ).scan()
+
+    runner = Runner(
+        ok(
+            # 新開
+            issue(4, state="open", updated_at="2026-08-15T11:00:00Z", title="four"),
+            # 更新（改標題、仍 open）
+            issue(2, state="open", updated_at="2026-08-15T10:30:00Z", title="two-v2"),
+            # 關閉
+            issue(3, state="closed", updated_at="2026-08-15T10:00:00Z", title="three"),
+            etag='W/"delta"',
+        )
+    )
+    snapshot = provider(store, runner).scan()
+
+    assert statuses(snapshot) == {
+        "acme/demo#1": "open",  # 不在 delta 內 → 沿用鏡像
+        "acme/demo#2": "open",
+        "acme/demo#3": "closed",
+        "acme/demo#4": "open",
+    }
+    titles = {source.ref: source.title for source in snapshot.sources}
+    assert titles["acme/demo#2"] == "two-v2"
+    assert titles["acme/demo#1"] == "one"
+    sync = snapshot.observations["issue_sync"]
+    assert (sync["delta_entries"], sync["mirror_entries"]) == (3, 4)
+    # 游標推進到 delta 的最大 updated_at。
+    assert store.load(REPO).since == "2026-08-15T11:00:00Z"
+
+
+# ---------------------------------------------------------------------------
+# E. 驗收 4：游標／ETag 狀態損壞 → fail closed 全量重建
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "payload, label",
+    [
+        ("{ not json at all", "檔案不是 JSON"),
+        (json.dumps({"schema": "github-issue-sync/v99", "repos": {}}), "schema 不認得"),
+        (json.dumps({"schema": "github-issue-sync/v1", "repos": []}), "repos 形狀不對"),
+        (
+            json.dumps(
+                {
+                    "schema": "github-issue-sync/v1",
+                    "repos": {REPO: {"entries": [], "since": "not-a-timestamp"}},
+                }
+            ),
+            "游標格式不合",
+        ),
+        (
+            json.dumps(
+                {
+                    "schema": "github-issue-sync/v1",
+                    "repos": {REPO: {"entries": [{"number": 1}]}},
+                }
+            ),
+            "entries 缺欄位",
+        ),
+        (
+            json.dumps(
+                {
+                    "schema": "github-issue-sync/v1",
+                    # ETag 沒有它所屬的 request path，就無從判斷該不該送
+                    "repos": {REPO: {"entries": [], "etag": 'W/"orphan"'}},
+                }
+            ),
+            "ETag 與 path 失聯",
+        ),
+    ],
+)
+def test_corrupt_state_fails_closed_to_a_full_rebuild(store, payload, label):
+    store.path.parent.mkdir(parents=True, exist_ok=True)
+    store.path.write_text(payload, encoding="utf-8")
+
+    runner = Runner(ok(issue(1, updated_at="2026-08-15T09:00:00Z")))
+    snapshot = provider(store, runner).scan()
+
+    assert snapshot.status == "ok", label
+    # 全量重建：不帶 since、不帶條件請求——絕不拿半壞的游標去做增量。
+    assert runner.paths == [BASE_PATH], label
+    assert runner.conditional_headers() == [], label
+    assert snapshot.observations["issue_sync"]["mode"] == "full", label
+    assert any("unusable" in item for item in snapshot.diagnostics), label
+    # 壞掉的那份被健康的狀態覆蓋，下一輪恢復增量。
+    assert store.load(REPO).since == "2026-08-15T09:00:00Z", label
+
+
+def test_one_repo_corruption_does_not_disturb_another_repo(store):
+    """單一 repo 的紀錄壞掉不該讓其他 repo 一起退回全量。"""
+    bootstrap(store, issue(1, updated_at="2026-08-15T09:00:00Z"))
+    document = json.loads(store.path.read_text(encoding="utf-8"))
+    document["repos"]["other/repo"] = {"entries": [{"number": "not-an-int"}]}
+    store.path.write_text(json.dumps(document), encoding="utf-8")
+
+    runner = Runner(not_modified())
+    snapshot = provider(store, runner).scan()
+
+    assert snapshot.status == "ok"
+    assert snapshot.observations["issue_sync"]["not_modified"] is True
+    with pytest.raises(IssueSyncStateError):
+        store.load("other/repo")
+
+
+def test_missing_state_file_is_a_full_rebuild_not_an_error(store):
+    runner = Runner(ok(issue(1, updated_at="2026-08-15T09:00:00Z")))
+
+    snapshot = provider(store, runner).scan()
+
+    assert snapshot.status == "ok"
+    assert runner.paths == [BASE_PATH]
+    # 「第一次見到這個 repo」不該被記成 drift／損壞診斷。
+    assert snapshot.diagnostics == ()
+
+
+def test_provider_without_a_store_always_runs_a_full_scan(store):
+    """無 durable 狀態即無增量——這是誠實的契約，不是靜默降級。"""
+    runner = Runner(ok(issue(1, updated_at="2026-08-15T09:00:00Z")))
+
+    snapshot = GitHubWorkProvider(REPO, runner=runner).scan()
+
+    assert snapshot.status == "ok"
+    assert runner.paths == [BASE_PATH]
+    assert snapshot.observations["issue_sync"]["mode"] == "full"
+
+
+def test_unwritable_state_does_not_degrade_the_snapshot(store, monkeypatch):
+    """游標存不下來是效能退化（下輪重來一次全量），不是正確性問題。"""
+
+    def explode(_state):
+        raise OSError("read-only filesystem")
+
+    monkeypatch.setattr(store, "save", explode)
+    runner = Runner(ok(issue(1, updated_at="2026-08-15T09:00:00Z")))
+
+    snapshot = provider(store, runner).scan()
+
+    assert snapshot.status == "ok"
+    assert statuses(snapshot) == {"acme/demo#1": "open"}
+    assert snapshot.observations["issue_sync"]["persisted"] is False
+    assert any("not persisted" in item for item in snapshot.diagnostics)
+
+
+# ---------------------------------------------------------------------------
+# F. 驗收 5：每日全量 anti-entropy 的觸發與對帳
+# ---------------------------------------------------------------------------
+
+
+def test_daily_full_sync_triggers_after_the_interval(store):
+    bootstrap(store, issue(1, updated_at="2026-08-15T09:00:00Z"))
+
+    # 未滿 24h：仍是增量。
+    runner = Runner(not_modified())
+    snapshot = provider(store, runner, now="2026-08-16T11:59:00Z").scan()
+    assert snapshot.observations["issue_sync"]["mode"] == "incremental"
+
+    # 滿 24h：強制全量。
+    runner = Runner(ok(issue(1, updated_at="2026-08-15T09:00:00Z")))
+    snapshot = provider(store, runner, now="2026-08-16T12:00:01Z").scan()
+
+    assert snapshot.observations["issue_sync"]["mode"] == "full"
+    assert snapshot.observations["issue_sync"]["reason"] == "anti-entropy"
+    assert runner.paths == [BASE_PATH]
+    # 全量刻意不帶 If-None-Match：對帳的職責就是真的重讀一次。
+    assert runner.conditional_headers() == []
+    assert store.load(REPO).last_full_sync_at == "2026-08-16T12:00:01Z"
+
+
+def test_a_clock_that_ran_backwards_forces_a_full_sync(store):
+    provider(
+        store, Runner(ok(issue(1, updated_at="2026-08-15T09:00:00Z"))), now="2026-08-15T12:00:00Z"
+    ).scan()
+
+    runner = Runner(ok(issue(1, updated_at="2026-08-15T09:00:00Z")))
+    snapshot = provider(store, runner, now="2026-08-14T00:00:00Z").scan()
+
+    assert snapshot.observations["issue_sync"]["mode"] == "full"
+
+
+def test_full_sync_reconciles_drift_in_favour_of_the_full_read(store, caplog):
+    """增量看不到刪除／transfer，也看不到任何一次被吞掉的漏發——全量兜底。"""
+    provider(
+        store,
+        Runner(
+            ok(
+                issue(1, state="open", updated_at="2026-08-15T09:00:00Z"),
+                issue(2, state="open", updated_at="2026-08-15T08:00:00Z"),
+            )
+        ),
+        now="2026-08-15T12:00:00Z",
+    ).scan()
+
+    # 24h 後的全量看到的真相：#2 消失（被刪除／transfer）、#3 從沒進過增量、
+    # #1 的狀態與鏡像不符。
+    runner = Runner(
+        ok(
+            issue(1, state="closed", updated_at="2026-08-16T09:00:00Z"),
+            issue(3, state="open", updated_at="2026-08-16T08:00:00Z"),
+            etag='W/"full"',
+        )
+    )
+    with caplog.at_level(logging.WARNING, logger="paulsha_cortex.monitor.providers"):
+        snapshot = provider(store, runner, now="2026-08-16T12:00:01Z").scan()
+
+    # 以全量為準：鏡像就是全量結果，沒有殘留的 #2。
+    assert statuses(snapshot) == {"acme/demo#1": "closed", "acme/demo#3": "open"}
+    drift = snapshot.observations["issue_sync"]["drift"]
+    assert drift == {"stale": [2], "unseen": [3], "changed": [1]}
+    # log 與 observation 兩邊都要留痕。
+    assert any("drift" in record.getMessage() for record in caplog.records)
+    assert any("drift" in item for item in snapshot.diagnostics)
+
+
+def test_full_sync_without_drift_reports_none(store):
+    provider(
+        store,
+        Runner(ok(issue(1, state="open", updated_at="2026-08-15T09:00:00Z"))),
+        now="2026-08-15T12:00:00Z",
+    ).scan()
+
+    runner = Runner(ok(issue(1, state="open", updated_at="2026-08-15T09:00:00Z")))
+    snapshot = provider(store, runner, now="2026-08-16T12:00:01Z").scan()
+
+    assert snapshot.observations["issue_sync"]["drift"] is None
+    assert snapshot.diagnostics == ()
+
+
+# ---------------------------------------------------------------------------
+# G. 游標推進紀律
+# ---------------------------------------------------------------------------
+
+
+def test_pagination_failure_does_not_advance_the_cursor(store):
+    provider(store, Runner(ok(issue(1, updated_at="2026-08-15T09:00:00Z")))).scan()
+    before = store.path.read_text(encoding="utf-8")
+
+    # 第 1 頁成功、第 2 頁炸掉：整輪 degraded，游標／ETag／鏡像原封不動。
+    runner = Runner(
+        ok(issue(9, updated_at="2026-08-15T11:00:00Z"), next_page=True),
+        failure(),
+    )
+    snapshot = provider(store, runner).scan()
+
+    assert snapshot.status == "degraded"
+    assert snapshot.sources == ()
+    assert store.path.read_text(encoding="utf-8") == before
+    assert store.load(REPO).since == "2026-08-15T09:00:00Z"
+
+
+def test_cursor_comes_from_the_response_not_the_local_clock(store):
+    runner = Runner(
+        ok(
+            issue(1, updated_at="2026-08-15T09:00:00Z"),
+            issue(2, updated_at="2026-08-15T10:30:00Z"),
+        )
+    )
+
+    provider(store, runner, now="2026-08-15T23:59:59Z").scan()
+
+    # 本機時鐘是 23:59:59，游標必須是回應中最大的 updated_at。用本機時鐘會把
+    # 「回應產生後、本輪結束前」發生的更新永久跳過。
+    assert store.load(REPO).since == "2026-08-15T10:30:00Z"
+
+
+def test_cursor_never_regresses(store):
+    provider(store, Runner(ok(issue(1, updated_at="2026-08-15T10:00:00Z")))).scan()
+
+    # 全量回應裡最新的那筆被刪掉了，最大 updated_at 因此倒退——游標不得跟著退。
+    runner = Runner(ok(issue(2, updated_at="2026-08-15T08:00:00Z")))
+    provider(store, runner, now="2026-08-16T12:00:01Z").scan()
+
+    assert store.load(REPO).since == "2026-08-15T10:00:00Z"
+
+
+def test_empty_delta_keeps_the_cursor(store):
+    provider(store, Runner(ok(issue(1, updated_at="2026-08-15T09:00:00Z")))).scan()
+
+    runner = Runner(ok(etag='W/"empty"'))
+    snapshot = provider(store, runner).scan()
+
+    assert snapshot.observations["issue_sync"]["mode"] == "incremental"
+    assert store.load(REPO).since == "2026-08-15T09:00:00Z"
+    # 空 delta 不得把鏡像清空。
+    assert statuses(snapshot) == {"acme/demo#1": "open"}
+
+
+# ---------------------------------------------------------------------------
+# H. 分頁
+# ---------------------------------------------------------------------------
+
+
+def test_pagination_never_follows_server_supplied_urls(store):
+    """Link header 只當「還有下一頁」的布林訊號；path 一律本地重建。
+
+    跟隨伺服器給的絕對 URL 等於讓對方指定 `gh` 要把 token 送去哪。
+    """
+    runner = Runner(
+        ok(issue(1, updated_at="2026-08-15T09:00:00Z"), next_page=True),
+        ok(issue(2, updated_at="2026-08-15T08:00:00Z")),
+    )
+
+    snapshot = provider(store, runner).scan()
+
+    assert runner.paths == [BASE_PATH, f"{BASE_PATH}&page=2"]
+    assert all("evil.test" not in path for path in runner.paths)
+    assert set(statuses(snapshot)) == {"acme/demo#1", "acme/demo#2"}
+    assert snapshot.observations["issue_sync"]["pages"] == 2
+
+
+def test_continuation_pages_do_not_carry_the_conditional_header(store):
+    bootstrap(store, issue(1, updated_at="2026-08-15T09:00:00Z"))
+
+    runner = Runner(
+        ok(issue(1, updated_at="2026-08-15T09:00:00Z"), next_page=True),
+        ok(issue(2, updated_at="2026-08-15T08:00:00Z")),
+    )
+    provider(store, runner).scan()
+
+    # 只有第 1 頁是條件請求；續頁若回 304 會是協定破壞。
+    assert len(runner.conditional_headers()) == 1
+    assert "--header" not in runner.calls[1]
+
+
+def test_runaway_pagination_fails_closed(store):
+    runner = Runner(
+        *[ok(issue(n + 1, updated_at="2026-08-15T09:00:00Z"), next_page=True) for n in range(60)]
+    )
+
+    snapshot = provider(store, runner).scan()
+
+    assert snapshot.status == "degraded"
+    assert any("pagination incomplete" in item for item in snapshot.diagnostics)
+    assert len(runner.calls) == GitHubWorkProvider._PAGE_LIMIT
+
+
+# ---------------------------------------------------------------------------
+# I. 驗收 6：每輪 API 呼叫數對比（量化樁）
+# ---------------------------------------------------------------------------
+
+
+def test_steady_state_cycle_costs_one_free_conditional_request(store):
+    """改動前：每輪每 repo 至少 1 次計費請求（issue 數過 100 再每 100 筆加 1 次）。
+
+    改動後穩態：每輪每 repo 1 次條件請求，而 304 **不計入 rate limit 配額**，
+    因此計費請求數為 0；配額只在真的有 issue 活動或每日 anti-entropy 時消耗。
+    """
+    bootstrap(store, issue(1, updated_at="2026-08-15T09:00:00Z"))
+
+    billed = 0
+    requests = 0
+    for _ in range(10):
+        snapshot = provider(store, Runner(not_modified())).scan()
+        sync = snapshot.observations["issue_sync"]
+        requests += sync["requests"]
+        billed += sync["billed_requests"]
+
+    assert requests == 10
+    assert billed == 0
+
+
+def test_a_full_day_of_thirteen_repos_costs_far_less_than_the_old_full_scan(tmp_path):
+    """13 個 configured repo、每 300s 一輪 → 每日 288 輪。
+
+    改動前：每輪每 repo 至少 1 次計費請求 → 13 × 288 = **3744 次／日**（issue 數
+    過 100 的 repo 再按頁數加倍）。
+
+    改動後（repo 全日無 issue 活動的穩態）：條件請求同樣是 13 × 288 次，但除了
+    每日 1 次 anti-entropy 全量、以及它後面那一次無法沿用 ETag 的增量之外，
+    全部是免費 304 → **每 repo 每日 2 次計費請求**，合計 26 次／日。
+    """
+    repos = [f"acme/repo{index}" for index in range(13)]
+    cycles_per_day = 288
+    now = "2026-08-15T00:00:00Z"
+    billed = 0
+    conditional = 0
+
+    for repo in repos:
+        repo_store = IssueSyncStore(tmp_path / f"{repo.replace('/', '_')}.json")
+
+        def scan(response):
+            return GitHubWorkProvider(
+                repo,
+                runner=Runner(response),
+                sync_store=repo_store,
+                now=lambda: now,
+            ).scan()
+
+        # 第 1 輪：當日的 anti-entropy 全量（計費）。
+        # 第 2 輪：path 多了 &since=，沿用不到全量那顆 ETag，無條件 200（計費）。
+        cycle_responses = [
+            ok(issue(1, updated_at="2026-08-15T09:00:00Z")),
+            ok(issue(1, updated_at="2026-08-15T09:00:00Z"), etag=STEADY_ETAG),
+        ]
+        # 其餘輪次進入穩態，每輪一次免費 304。
+        cycle_responses += [not_modified()] * (cycles_per_day - 2)
+        for response in cycle_responses:
+            sync = scan(response).observations["issue_sync"]
+            billed += sync["billed_requests"]
+            conditional += sync["conditional_requests"]
+
+    assert billed == 2 * len(repos) == 26
+    assert conditional == len(repos) * (cycles_per_day - 2)
+    # 相對舊路徑（每輪每 repo 至少 1 次計費）降兩個數量級。
+    assert billed * 100 < len(repos) * cycles_per_day
+
+
+# ---------------------------------------------------------------------------
+# J. request path 契約
+# ---------------------------------------------------------------------------
+
+
+def test_request_path_pins_state_all_and_updated_sort():
+    """兩個不可退讓的 query 參數。
+
+    - `state=all`：`state=open&since=` 看不到剛被關閉的 issue，closure reducer
+      因此拿不到 closed 證據。
+    - `sort=updated&direction=desc`：預設的 created desc 排序下，一個舊 issue 剛被
+      更新可能落在第 2 頁而不改變第 1 頁，第 1 頁的 ETag 就不再是整個 delta 的
+      變更偵測器，條件請求會漏發。
+    """
+    path = issues_request_path(REPO, since="2026-08-15T09:00:00Z")
+
+    assert "state=all" in path
+    assert "sort=updated" in path and "direction=desc" in path
+    # 游標進 query string 前一律 percent-encode。
+    assert "since=2026-08-15T09%3A00%3A00Z" in path
+
+
+def test_request_path_rejects_a_non_api_timestamp_cursor():
+    with pytest.raises(IssueSyncStateError):
+        issues_request_path(REPO, since="2026-08-15 09:00:00")

--- a/tests/test_monitor_incremental_issue_sync_506.py
+++ b/tests/test_monitor_incremental_issue_sync_506.py
@@ -646,6 +646,30 @@ def test_continuation_pages_do_not_carry_the_conditional_header(store):
     assert "--header" not in runner.calls[1]
 
 
+def test_an_issue_updated_mid_pagination_does_not_crash_the_scan(store):
+    """分頁跑的是一個**活的**、依 updated 排序的清單。
+
+    某個 issue 在我們讀第 1 頁與第 2 頁之間被更新，就會在兩頁各出現一次。這是分頁
+    本身的產物，不是壞回應——但重複的 issue 號會讓 durable 狀態的驗證直接 raise，
+    例外若逸出 provider 會打斷整個 refresh 迴圈。收斂時保留較新的那筆。
+    """
+    runner = Runner(
+        ok(
+            issue(1, state="open", updated_at="2026-08-15T09:00:00Z"),
+            issue(2, state="open", updated_at="2026-08-15T08:00:00Z"),
+            next_page=True,
+        ),
+        # #2 在翻頁期間被關閉，於是在第 2 頁又出現一次（updated_at 更新）。
+        ok(issue(2, state="closed", updated_at="2026-08-15T09:30:00Z")),
+    )
+
+    snapshot = provider(store, runner).scan()
+
+    assert snapshot.status == "ok"
+    assert statuses(snapshot) == {"acme/demo#1": "open", "acme/demo#2": "closed"}
+    assert store.load(REPO).since == "2026-08-15T09:30:00Z"
+
+
 def test_runaway_pagination_fails_closed(store):
     runner = Runner(
         *[ok(issue(n + 1, updated_at="2026-08-15T09:00:00Z"), next_page=True) for n in range(60)]

--- a/tests/test_monitor_work_providers.py
+++ b/tests/test_monitor_work_providers.py
@@ -123,6 +123,23 @@ def _completed(payload, *, returncode=0, stderr=""):
     )
 
 
+def _gh_response(rows, *, status=200, headers=None):
+    """`gh api --include` 的輸出形狀（狀態行 LF、header CRLF、空行、body）。
+
+    這是實測 gh 2.45 的真實輸出（見 `monitor/github_issue_sync` 模組 docstring）。
+    """
+    lines = [f"HTTP/2.0 {status} OK"]
+    lines += [f"{name}: {value}\r" for name, value in (headers or {}).items()]
+    lines.append("\r")
+    body = "" if rows is None else json.dumps(rows)
+    return subprocess.CompletedProcess(
+        args=("gh",),
+        returncode=0 if status < 300 else 1,
+        stdout="\n".join(lines) + "\n" + body,
+        stderr="" if status < 300 else f"gh: HTTP {status}",
+    )
+
+
 def test_github_provider_uses_typed_argv_and_json():
     rows = [
         {
@@ -142,14 +159,7 @@ def test_github_provider_uses_typed_argv_and_json():
             "pull_request": {"url": "https://api.github.test/pr/15"},
         },
     ]
-    runner = FakeRunner(
-        subprocess.CompletedProcess(
-            args=("gh",),
-            returncode=0,
-            stdout="\n".join(json.dumps(row) for row in rows) + "\n",
-            stderr="",
-        )
-    )
+    runner = FakeRunner(_gh_response(rows))
 
     result = GitHubWorkProvider("example/acme", runner=runner, timeout_seconds=12).scan()
 
@@ -160,15 +170,15 @@ def test_github_provider_uses_typed_argv_and_json():
     ]
     assert result.sources[0].title == "umbrella"
     argv, timeout = runner.calls[0]
+    # D3：`--include` 取代 `--paginate --jq`——分頁由本地依 Link header 重建
+    # （path 永不採信伺服器給的絕對 URL），header 則是 ETag 條件請求的載體。
     assert argv == (
         "gh",
         "api",
         "--method",
         "GET",
-        "--paginate",
-        "--jq",
-        ".[]",
-        "repos/example/acme/issues?state=all&per_page=100",
+        "--include",
+        "repos/example/acme/issues?state=all&per_page=100&sort=updated&direction=desc",
     )
     assert timeout == 12
 
@@ -229,7 +239,7 @@ def test_github_provider_timeout_is_degraded():
 def test_github_provider_malformed_json_is_degraded():
     runner = FakeRunner(
         subprocess.CompletedProcess(
-            args=("gh",), returncode=0, stdout="not-json", stderr=""
+            args=("gh",), returncode=0, stdout="HTTP/2.0 200 OK\n\r\nnot-json", stderr=""
         )
     )
 
@@ -237,6 +247,18 @@ def test_github_provider_malformed_json_is_degraded():
 
     assert result.status == "degraded"
     assert any("JSON" in item for item in result.diagnostics)
+
+
+def test_github_provider_response_without_status_line_is_degraded():
+    """D3：缺狀態行不得寬容退化成「單頁、無 ETag」——那等於靜默截斷鏡像。"""
+    runner = FakeRunner(
+        subprocess.CompletedProcess(args=("gh",), returncode=0, stdout="[]", stderr="")
+    )
+
+    result = GitHubWorkProvider("example/acme", runner=runner).scan()
+
+    assert result.status == "degraded"
+    assert any("malformed response" in item for item in result.diagnostics)
 
 
 def test_workflow_registry_existing_completion_schema_remains_not_valid(monkeypatch, tmp_path):


### PR DESCRIPTION
## 問題

`GitHubWorkProvider` 每輪對**每個** configured repo 全量分頁抓 issues
（`issues?state=all&per_page=100` ＋ `--paginate`）。D2（PR #566）把 `contents`／
`compare` 歸零之後，這是 monitor 對 REST 配額剩下的主要常態消耗：configured repos
約 13 個、`github_refresh_interval_seconds` 預設 300s（每日 288 輪），每輪每 repo
至少 1 次計費請求，而其中絕大多數回應與上一輪逐位元組相同。

## 改法

新增 `paulsha_cortex/monitor/github_issue_sync.py`，作為增量協定與 per-repo durable
狀態（游標／ETag／鏡像投影）的唯一入口。

### 兩個不可退讓的 query 參數

- **`state=all`**：`state=open&since=` 看不到剛被關閉的 issue，closure reducer 因此
  拿不到 `closed` 證據，manager 可能 auto-claim 一件人類已經在網頁端關掉的工作。
  closed issue 的 `updated_at` 會隨關閉事件更新，`state=all&since=` 的增量天然攜帶
  關閉事件且 delta 極小。
- **`sort=updated&direction=desc`**：預設排序是 `created` desc，在那個順序下「一個
  舊 issue 剛被更新」可能落在第 2 頁而**不改變第 1 頁**——第 1 頁的 ETag 就不再是
  整個 delta 的變更偵測器，條件請求會漏發。改成 updated desc 後，任何 `updated_at`
  前進的 issue 必然跳到第 1 筆，第 1 頁 ETag 因此是 sound 的變更偵測器。

### ETag

第 1 頁帶 `If-None-Match`。ETag 綁定它所屬的 request path（`etag_request`），
`since` 一前進 path 就變、舊 ETag 立刻作廢。

**304 一路不取回應的 ETag**：實測 GitHub 200 回 `W/"<hash>"`、304 回強形式
`"<hash>"`，把它覆蓋回去會讓下一輪送出的 header 與伺服器認得的那顆對不上，條件
請求從此永遠落空、悄悄退化成每輪全額計費。304 時整份狀態原封不動（連寫都不寫）。

### 游標紀律

`since` 取自**回應**中最大的 `updated_at`（不是本機時鐘），只在整輪完整成功後推進，
且永不倒退。分頁中斷、任一頁失敗——游標、ETag、鏡像三者一律原封不動。
`since` 在 GitHub 是閉區間，邊界那筆每輪都會被重送，這正是穩態下 body 穩定、
ETag 穩定、304 成立的原因，重複合併本身冪等。

### 每日全量 anti-entropy

增量看不到 issue 被刪除／transfer 這類不留 `updated_at` 痕跡的事件。每 86400s 強制
一次不帶 `since`、不帶 `If-None-Match` 的全量重讀並與鏡像對帳（拿 304 換來的「跟
上次一樣」不是對帳，是把待驗證的假設當成結論），drift 一律**以全量為準**，同時記
log 與 `observations["issue_sync"]["drift"]`。

### fail closed

durable 狀態缺失／損壞／游標格式不合／entries 形狀不對／ETag 與 path 失聯——一律
退回全量重建，絕不拿半壞的游標去做增量。單一 repo 的紀錄壞掉不會拖垮其他 repo。

### 分頁

改為本地依 Link header 逐頁重建，**不跟隨**伺服器給的絕對 URL——跟隨等於讓對方
指定 `gh` 把 token 送去哪。連帶讓每一頁都經過 `GitHubPressureGate.throttle`：改動前
`--paginate` 是 gh 在行程內自己連發，閘門完全管不到那些請求。

分頁跑的是活清單，某個 issue 在讀第 1 頁與第 2 頁之間被更新會在兩頁各出現一次；
傳輸層同號去重（保留較新者），並把狀態建構包進 fail-closed 邊界，避免例外逸出
provider 打斷整個 refresh 迴圈。

## 每輪 API 呼叫數對比（13 repos、每日 288 輪）

| | 改動前 | 改動後（穩態） |
| --- | --- | --- |
| 每輪每 repo 計費請求 | ≥ 1（issue 數過 100 再按頁加倍） | 0（免費 304） |
| **每日計費請求合計** | 13 × 288 = **3744** | **26** |

改動後的 26 次 = 每 repo 2 次：1 次每日 anti-entropy 全量，＋ 1 次緊接其後、因 path
多了 `&since=` 而沿用不到全量那顆 ETag 的無條件增量。之後即進入每輪一次免費 304 的
穩態。游標每前進一次也同樣多付一次無條件請求（活動期才發生，而活動期本來就得讀）。

**304 不計配額為實測確認**：對同一資源連打兩次，第二次帶 `If-None-Match` 得到 304，
`x-ratelimit-used` 前後皆為 64、`x-ratelimit-remaining` 皆為 4936，未消耗配額。

由 `test_a_full_day_of_thirteen_repos_costs_far_less_than_the_old_full_scan` 釘住。

## 驗收對照

| 計畫驗收 | 測試 |
| --- | --- |
| 1. 網頁端關閉 → 一週期內轉 closed 且不再 auto-claim | `test_web_closed_issue_flips_mirror_and_leaves_auto_claim_within_one_cycle` |
| 2. 304 不改 mirror／不亂動游標／計為條件請求 | `test_not_modified_leaves_mirror_cursor_and_etag_untouched`、`test_not_modified_is_counted_as_a_free_conditional_request` |
| 3. 新開／更新／關閉三類收斂正確 | `test_incremental_delta_converges_opened_updated_and_closed` |
| 4. 狀態損壞 → fail-closed 全量重建 | `test_corrupt_state_fails_closed_to_a_full_rebuild`（6 種損壞形態）、`test_one_repo_corruption_does_not_disturb_another_repo` |
| 5. anti-entropy 觸發與對帳 | `test_daily_full_sync_triggers_after_the_interval`、`test_full_sync_reconciles_drift_in_favour_of_the_full_read` |
| 6. API 呼叫數對比 | 見上表 |

## 範圍紀律

只動 monitor 的 issues 讀取路徑。D2 的 `monitor/git_mirror.py` **未動**；寫入路徑、
label API、events API 均不在本次。

`observations["auto_label_issues"]`（D1）改由 durable 鏡像導出，語意不變（既有
`tests/test_auto_label_mirror_d1.py` 續綠）。

## 測試

`python3 -m pytest -q` → **2827 passed, 49 subtests passed**（全綠）。
新增 `tests/test_monitor_incremental_issue_sync_506.py`（35 個測試）。

`policy_check`（帶 PR 上下文）→ **pass 23 / fail 0 / warn 2**（R-18、R-22 皆為陳年
warn，非本 PR 新造成）。

## Checklist

- [x] `changelog.d/d3-incremental-issue-sync.md` fragment 已新增且已 commit
- [x] `CHANGELOG.md [Unreleased]` 有對應 entry
- [x] `VERSION` 與意圖一致（非 release PR，未動）
- [x] 全套測試通過
- [x] `policy_check` 帶 PR 上下文跑，fail 0

Refs #506
