### PR TITLE
feat(model-resolution): 三層解析鏈讓人工指定壓過 packaged roster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,33 @@
   寫入路徑、label API、events API 均不在本次。詳見
   `changelog.d/d3-incremental-issue-sync.md`。新增
   `tests/test_monitor_incremental_issue_sync_506.py`（34 個測試）。
+- **Issue #534 / #509 / #490 / #475：模型引擎解析改為三層解析鏈，packaged roster 降級為
+  候選池**——落實使用者裁決「人工指定清單優先 → agent 從 patchmud 評估合格清單挑 →
+  未評估模型須先經 eval、合格後人工複核加入清單」。新增
+  `paulsha_cortex/coordinator/model_resolution.py` 作為解析鏈單一真值：第 1 層
+  `operator-overlay`（host overlay 人工指定，**列序即優先序**）、第 2 層
+  `evaluated-roster`（新契約 `model-eval-roster.yaml`，須 `verdict: pass` **且**
+  `review_status: approved` 且角色相符）、第 3 層 `packaged-fallback`（候選池，受
+  `resolution_policy.packaged_fallback` 的 allow／warn／deny 管制）。解析層是排序主鍵且
+  為 stable sort，`#452` 的 measured 側寫優先與 `#262` 的 `primary_domain` 偏好降級為
+  同層內次要偏好——packaged roster 的內建列序（「agy 維持首位」）不再壓過人工指定，
+  planner 也不會再跑到 operator 未核可的引擎上。`resolved_model_chain` 的 `source` 改記
+  解析層（`run-override`／`operator-overlay`／`evaluated-roster`／`packaged-fallback`），
+  封套來源移至新的選配欄位 `envelope_source`；#534 之前的紀錄維持可載入。兩處寫死的
+  優先序一併移除：`select_secondary_planner` 不再迭代 `PLANNER_PRIORITY`（該常數曾把
+  agy 釘在首位、且只認三組 `(executor, domain)`，operator 宣告的 cg／新 executor planner
+  永遠不可達），`work_bridge` 的 primary planner 不再寫死 `("codex","claude","agy")`。
+  **#509 殘項**：overlay 與 packaged 同鍵不再 `raise ValueError` 打掛 periodic tick——
+  改為以 overlay 為準並留下診斷（明示 `override_packaged: true` 記 info、未明示記 warn），
+  另新增 `packaged_overrides` 讓 overlay 明示 `park`／`demote` packaged 身分；新增
+  `cortex doctor` 的 `model-resolution` probe，走與 tick 相同的載入器與排序函式、明示
+  config root，並以不變式守衛「overlay 宣告某角色 → 生效解析必須在第 1 層」。**#490**：
+  `review.load_model_identity_registry` 改用合併 registry，packaged 身分不必複製進 overlay
+  才能被 retry-review 解析。**#475** 現場收編為測試 fixture（自訂 Claude-compatible 身分
+  不得被 packaged 同 executor 身分靜默取代；executable 綁定仍為未竟部分）。所有新能力皆為
+  選配欄位／檔案，既有 overlay 不改一行也照載照解析。詳見
+  `changelog.d/model-resolution-chain.md`。新增 `tests/test_model_resolution_chain_534.py`
+  （29 個測試）。
 - **Issue #506 / D2：git 的資料走 git——monitor 對 GitHub REST 的兩類高量讀取改為本機
   git 操作，一輪掃描的 REST `contents`／`compare` 呼叫數固定為 0**——
   `GitHubTerminalProvider` 過去每個 remote `todo.md`／archived `tasks.md` 各打一次

--- a/README.md
+++ b/README.md
@@ -201,12 +201,15 @@ cortex bootstrap --instance cortex --repo-root "$(git rev-parse --show-toplevel)
    patchmud 目前僅有 anthropic adapter，roster 內只有 `claude/sonnet` 可被驅動；
    其餘身分會逐一回報 `adapter-unavailable` 並誠實維持預設封套。
 
+   `cortex inspect models` 另顯示每列的 `layer=`，即該身分在三層解析鏈中的位置
+   （`operator-overlay`／`evaluated-roster`／`packaged-fallback`／`parked`）。
+
    > **升級遷移註記**：packaged roster 已收編 `copilot/gpt-5.4`、
    > `claude/sonnet`、`codex/gpt-5.3-codex-spark`、`cg/glm-5.2` 四個身分。
-   > 若 host overlay（`$PSC_PROJECT_CONFIG_ROOT/model-identities.yaml`）先前
-   > 已自行宣告其中任一鍵、且內容與 packaged 列不逐欄相等，升級後 registry
-   > 載入會 fail-closed（`custom identity shadows packaged default`）——請自
-   > overlay 移除該列，或改成與 packaged 逐欄相等。
+   > host overlay（`$PSC_PROJECT_CONFIG_ROOT/model-identities.yaml`）宣告其中
+   > 任一鍵時，**以 overlay 為準**（人工指定優先，見下方三層解析鏈）；建議在
+   > 該列加上 `override_packaged: true` 明示覆寫意圖，否則 `cortex doctor` 會
+   > 提出警示。（此處先前為 fail-closed 中止載入，已於 #534／#509 改為降級。）
 
 9. 用 `service` 家族管理 installer、systemd runtime 與 fallback logs：
 
@@ -529,13 +532,84 @@ identities:
     capabilities: [planning, review]
 ```
 
-- schema v1 仍可讀取並由 runtime 正規化；新設定使用 schema v2 的 `capabilities` / `live_probe`。packaged registry 已登錄 canonical agy identity，自訂檔不得以不同內容 shadow 它。
+- schema v1 仍可讀取並由 runtime 正規化；新設定使用 schema v2 的 `capabilities` / `live_probe`。packaged registry 已登錄 canonical agy identity；host overlay 宣告同鍵身分時以 overlay 為準（見下方「模型引擎三層解析鏈」）。
 - planner/builder/reviewer 必須是 explicit `(executor, model_id)` 且可解析；agy 只有在 `doctor --probe-live` 的 model discovery 與 plan/sandbox smoke 都吻合時才可用。
 - fanout/tick 明確指定的 builder `(executor, model_id)`，以及 spec frontmatter 成對宣告的 `executor`／`model_id`，都會先查這份 registry；unknown identity 會在派工前 fail-closed 並列出可用 candidates。
 - workflow reviewer 只會選擇明示 `capabilities: [review]` 且與 Builder 不同 independence domain 的 schema v2 identity；legacy v1 identity 只取得 planning capability，不能被猜成 reviewer。
 - Verify/Review 以 executor 的 enforced read-only mode在exact Candidate的remote-free disposable clone檢查；Claude reviewer固定使用`dontAsk`與`safe-mode`，只暴露OS-sandboxed Bash並要求structured JSON object，不載入Candidate `CLAUDE.md`/skills/plugins/MCP/remote session，也不進Plan Mode。Filesystem預設拒讀整個home、`/run/user`與Docker sockets，只重開Candidate與Python user-site工具鏈，並對Candidate clone設deny-write；review subprocess只保留`PATH`、`HOME`、locale、`TMPDIR`、`VIRTUAL_ENV`等非密鑰基礎環境，且不啟動login shell。Linux/WSL host必須安裝`bubblewrap`、`socat`與官方sandbox runtime（Ubuntu可用`sudo apt-get install bubblewrap socat`，再用`npm install -g @anthropic-ai/sandbox-runtime`）；任一依賴缺失、Unix-socket seccomp失效或命令要求unsandboxed fallback都拒絕啟動。Manager在所有terminal/launch failure/operator retry路徑重驗原Candidate完整tree snapshot後清除clone。agent只回傳substantive result、findings與inline report body；report僅能發布至phase專屬的`reports/verify/*.md`或`reports/review/*.md`，並由durable publication journal把多檔CAS、canonical evidence與registry bind組成可rollback/roll-forward的transaction。Manager會從durable Job注入Candidate、builder/reviewer job ID與launch identity，agent不取得report或Candidate寫入權。
 - `cortex doctor`會在identity registry配置Claude `review` capability時把Claude Code 2.1.187+、必要CLI flags、`bubblewrap`、`socat`與`srt`執行能力列為required probe；`--probe-live`另跑native read-only與Unix-socket seccomp smoke。沒有Claude reviewer的部署只顯示非必要warn。Claude的protected bind targets位於deterministic disposable session root，exact Candidate則固定在其無污染的`candidate/` checkout。
 - 同 domain、未知 identity、缺 model 都會得到 `foreign-review-absent`（fail-closed）。
+- foreign review 與 manager／tick 解析**同一份**合併 registry（host overlay ＋ packaged 候選池）：packaged 身分不需要被複製進 overlay 才能被 retry-review 解析到。
+
+### 模型引擎三層解析鏈
+
+planner／builder／reviewer 的身分解析依序走三層，**層級是排序主鍵**：
+
+| 層 | provenance 值 | 來源 | 語意 |
+| --- | --- | --- | --- |
+| 1 | `operator-overlay` | host overlay `model-identities.yaml` | operator 人工指定；**列序即優先序**，壓過 packaged roster 的一切內建順序 |
+| 2 | `evaluated-roster` | host `model-eval-roster.yaml` | 經 patchmud 評估合格**且**人工複核通過的身分 |
+| 3 | `packaged-fallback` | packaged roster | 候選池：只供評估管線取材；解析落到這層一律 fail-loud |
+
+同層內維持既有偏好（`primary_domain` 偏好、patchmud 實測封套優先），因此這些偏好
+不會再把 operator 的人工指定擠到後面。run-scoped 覆寫（`--builder-model` 等）
+仍為最高優先，provenance 記 `run-override`。
+
+`WorkflowRun.resolved_model_chain` 逐段記錄解析層與封套來源：
+
+```json
+{"builder": {"executor": "codex", "model_id": "gpt-5.6-luna",
+             "independence_domain": "openai",
+             "source": "operator-overlay", "envelope_source": "default"}}
+```
+
+**第 2 層契約**——`$PSC_PROJECT_CONFIG_ROOT/model-eval-roster.yaml`（檔案不存在
+即空清單；可手工維護）：
+
+```yaml
+schema_version: 1
+entries:
+  - executor: claude
+    model_id: sonnet
+    roles: [build, review]        # planning / build / review
+    verdict: pass                 # pass / fail / pending（patchmud 評估結果）
+    evaluated_at: "2026-08-14"
+    eval_source: patchmud
+    eval_ref: patchmud-deck-v1/report-2026-08-14   # 選配：評估證據指標
+    review_status: approved       # approved / rejected / pending（人工複核）
+    reviewer: operator            # approved 時必填
+    reviewed_at: "2026-08-14"     # approved 時必填
+```
+
+只有 `verdict: pass` **且** `review_status: approved` **且**角色列於 `roles` 的
+身分才進第 2 層——「評估過」不等於「人工核可」。清單解析失敗時第 2 層視為空
+（保守方向，絕不因錯誤多授予資格），並由 `cortex doctor` 的 `model-resolution`
+probe 回報，不會中止 periodic tick。
+
+**overlay 的解析指令**（皆為選配，既有 overlay 檔案不改也照舊合法）：
+
+```yaml
+resolution_policy:
+  packaged_fallback: warn        # allow / warn（有 overlay 時的預設）/ deny
+identities:
+  - executor: claude
+    model_id: sonnet
+    independence_domain: anthropic
+    capabilities: [review]
+    override_packaged: true      # 明示覆寫同鍵 packaged 身分
+packaged_overrides:              # 對 packaged 身分的處置
+  - executor: agy
+    model_id: gemini-3.1-pro-high
+    action: park                 # park＝完全停用；demote＝降到同層最後
+    reason: operator 未核可此引擎
+```
+
+`packaged_fallback: deny` 時第 3 層完全不參與解析，某個 persona 因此無候選會
+fail-closed 並列出補救路徑（列入 overlay，或評估合格後加入 eval roster）。
+
+`cortex doctor` 的 `model-resolution` probe 走與 tick 相同的載入器與排序函式，
+回報每個 persona 的生效解析與所在層、使用的 config root；overlay 宣告了某角色
+卻不是生效解析（不變式被破壞）、或有 persona 無候選時 FAIL。
 
 ### Merge 限制與 completion/restart
 

--- a/changelog.d/model-resolution-chain.md
+++ b/changelog.d/model-resolution-chain.md
@@ -1,0 +1,56 @@
+# model-resolution-chain
+
+- **`#534` 模型引擎解析優先序顛倒：packaged roster 內建列序壓過人工指定——落實使用者裁決的
+  三層解析鏈**。現況與裁決相反：packaged roster 的註解明載「列序即候選優先序：agy 維持
+  首位」，planner 因此解析到 `agy/gemini-3.1-pro-high`，而 operator 當日在 host overlay
+  宣告的可用引擎清單**根本不含**它；該模型暫時 503 時 define 死亡（`#533` 已把死路修成
+  可 recover，但**選錯模型**本身沒修）。新增 `coordinator/model_resolution.py` 作為解析鏈的
+  單一真值：
+
+  - **第 1 層 `operator-overlay`（絕對優先）**：host overlay `model-identities.yaml` 宣告
+    的身分，**列序即優先序**。解析層是排序主鍵且為 stable sort，因此 `#452` 的 measured
+    側寫優先與 `#262` 的 `primary_domain` 偏好原封不動地降級為**同層內**的次要偏好——
+    packaged 候選再也沒有機會壓過人工指定。
+  - **第 2 層 `evaluated-roster`**：新契約 `$PSC_PROJECT_CONFIG_ROOT/model-eval-roster.yaml`
+    （扁平欄位、可手工維護、檔案不存在即空清單）。只有 `verdict: pass` **且**
+    `review_status: approved`（且 `reviewer`／`reviewed_at` 齊備）**且**角色列於 `roles`
+    的身分才入列——「評估過」不等於「人工核可」。patchmud eval 執行管線本身屬 v4 R2，
+    本次只做契約與消費端。清單解析失敗時第 2 層視為空（保守方向，絕不因錯誤多授予資格）
+    且**不丟例外**，避免 `#509` 的「一列設定過期打掛整條 tick」重演。
+  - **第 3 層 `packaged-fallback`**：packaged roster 降級為候選池，只供評估管線取材。
+    政策 `resolution_policy.packaged_fallback`：`allow`（無 overlay 的部署預設）／`warn`
+    （有 overlay 時預設，解析落到第 3 層即 fail-loud 打 log）／`deny`（嚴格 fail-closed，
+    無候選時錯誤訊息附兩條補救路徑）。
+  - **`resolved_model_chain` 改記解析層 provenance**：`source` ∈ `run-override`／
+    `operator-overlay`／`evaluated-roster`／`packaged-fallback`，封套來源移到新的選配欄位
+    `envelope_source`（`measured`／`default`）。舊值 `default-envelope` 這類不透明值只說得出
+    「封套來自預設」，說不出「這顆模型憑什麼進熱路徑」。`#534` 之前寫下的紀錄（legacy
+    source、無 `envelope_source`）維持可載入。
+  - **兩處寫死的優先序一併移除**：`select_secondary_planner` 過去迭代 `PLANNER_PRIORITY`
+    （agy 釘首位，且只認三組 `(executor, domain)`——operator 宣告的 `cg`／新 executor
+    planner **永遠不可達**）；`work_bridge` 的 primary planner 寫死 `("codex","claude","agy")`。
+    兩者改走三層解析鏈；`PLANNER_PRIORITY` 保留為歷史記錄，不再參與任何選擇。
+- **`#509` 殘項：overlay shadow 不再打掛 periodic tick，並補上合法的 operator 覆寫語意**。
+  同鍵且逐欄相等＝同一列；內容不同時**以 overlay 為準**（人工指定優先），明示
+  `override_packaged: true` 記 info、未明示記 warn 診斷並打 log——不再 `raise ValueError`
+  讓 tick 連續失敗開斷路器。新增 `packaged_overrides` 區塊讓 overlay 明示 `park`（完全
+  停用、身分仍留在 registry 故 doctor 的 canonical 檢查不破）或 `demote`（降到同層最後）
+  packaged 身分；指向不存在的 packaged 身分或與 `identities` 矛盾時 fail-closed。
+  新增 `cortex doctor` 的 **`model-resolution` probe**：走與 tick 相同的載入器與排序函式，
+  逐 persona 回報生效解析與所在層、明示自己讀的 config root（`#509` 假 PASS 的成因之一
+  就是 doctor 與 daemon 讀不同的 config root 卻看不出來），並以不變式守衛「overlay 宣告
+  了某角色 → 生效解析必須落在第 1 層」，破壞即 FAIL。
+- **`#490`：retry-review 與 manager／tick 改用同一份合併 registry**。
+  `review.load_model_identity_registry` 過去走 `use_packaged_default=False` 只讀 host
+  overlay，packaged 身分（如 `claude/sonnet`）在 retry-review 被記成
+  `reviewer-identity-unknown`；operator 只能把 packaged 那列複製進 overlay，複製回來又踩
+  `#509` 的 shadow 中止——死結。兩邊同源後這條矛盾一併消失。
+- **`#475` 現場收編為測試 fixture**：operator 於 overlay 宣告的 Claude-compatible 自訂身分
+  （`claude/gemma4-26b-a4b-nvfp4`）不得被 packaged 同 executor 身分（`claude/sonnet`）靜默
+  取代，解析結果與 `operator-overlay` provenance 皆以測試釘住。executable／launcher 綁定
+  屬 launcher 層，仍為 `#475` 的未竟部分。
+- `cortex inspect models` 每列加上 `layer=`（`operator-overlay`／`evaluated-roster`／
+  `packaged-fallback`／`parked`），JSON 輸出加 `resolution_layer` 欄位。
+- 既有部署零遷移成本：所有新能力皆為**選配**欄位／檔案，既有 v1／v2／v3 overlay 檔案不改
+  一行也照載、照解析（以測試釘住）。新增 `tests/test_model_resolution_chain_534.py`（29 個
+  測試，含 `#490`／`#475` 復現與向後相容不變式）。

--- a/docs/superpowers/specs/model-persona-roster-matrix.md
+++ b/docs/superpowers/specs/model-persona-roster-matrix.md
@@ -57,6 +57,12 @@ patchmud 實測或明示預設兩種 provenance。
 （屬 `#452` C 解析實作票的範圍），但該格仍列待 benchmark——override 巷道是真實巷道，且
 benchmark 結果是日後決定是否擴充優先序的依據。
 
+> **`#534` 後續更新（2026-08）**：`select_secondary_planner` 已改走三層解析鏈
+> （`model_resolution.rank_candidates`），不再迭代 `PLANNER_PRIORITY`——該常數僅
+> 保留為 executor↔domain 對應的歷史記錄，不參與任何選擇。因此本註記描述的
+> 「cg planner 永遠不可達」限制**已解除**：cg 只要列在 host overlay，或評估
+> 合格並人工複核進 `model-eval-roster.yaml`，即可被自動 fallback 選到。
+
 補充註記（非排除，實作票需知）：reviewer persona 的結構化終局契約目前只有 claude 有
 `--json-schema` 綁定（`launcher.py:993-994` 只對 claude 傳 `review_terminal_kind`，
 `_claude_review_json_schema`）；codex／agy／cg reviewer 依賴 prompt 側終局契約＋harvest

--- a/paulsha_cortex/coordinator/data/model-identities.yaml
+++ b/paulsha_cortex/coordinator/data/model-identities.yaml
@@ -1,7 +1,13 @@
 # #452 B／#456 R3：候選身分 roster（capabilities 為候選宣告，benchmark 前）。
 # 封套欄位「沒寫＝預設、有寫＝實測」（#453 R4：registry 永不寫入預設值）；
 # 實測值由 `cortex model profile` 產 diff、經人工複核 --apply 後落地。
-# 列序即候選優先序：agy 維持首位，保住既有 planner 熱路徑選擇不變。
+#
+# #534：本檔已降級為**候選池**，不再直接參與解析優先序。解析鏈為
+#   1. host overlay `model-identities.yaml`（operator 人工指定，列序即優先序）
+#   2. host `model-eval-roster.yaml`（patchmud 評估合格＋人工複核通過）
+#   3. 本檔（packaged fallback，fail-loud；可由 overlay 的 packaged_overrides
+#      park／demote）
+# 本檔的列序只在「同屬第 3 層」的候選之間有意義，**不再**壓過人工指定。
 schema_version: 3
 identities:
   - executor: agy

--- a/paulsha_cortex/coordinator/manager.py
+++ b/paulsha_cortex/coordinator/manager.py
@@ -39,6 +39,7 @@ from .spawn_admission import SpawnAdmissionLimiter, resolve_limiter, resolve_pro
 from .registry import RETRY_CARD_PHASE_PERSONA, slice_repin_eligible
 from ..config.paths import worktree_root_for
 from .claim import AuthorityValidationError, REASON_PROVIDER_RATE_LIMITED_CANONICAL, decomposition_route
+from . import model_resolution
 from .diagnostics import DiagnosticReason, diagnostic_reason, summarize_exception
 from .model_identities import (
     AGY_DOMAIN,
@@ -6936,7 +6937,66 @@ def _workflow_identity_candidates_for_persona(
                 f"no capable identity for workflow persona: {persona}（{detail}）"
             )
         candidates = ordered
-    return candidates
+    return _rank_candidates_by_resolution_layer(run, persona, candidates, identities)
+
+
+def _rank_candidates_by_resolution_layer(
+    run, persona: str, candidates: list, identities: IdentityRegistry
+) -> list:
+    """#534：把候選清單重排成三層解析鏈的順序，並套用 packaged fallback 政策。
+
+    層級是排序主鍵、**stable**：同層內完全維持上游既有順序，因此 #452 的
+    measured 側寫優先與 #262 的 primary_domain 偏好都原封不動地降級為同層內的
+    次要偏好。這正是本 issue 的核心修正——packaged roster 的內建列序（「agy 維持
+    首位」）不再有機會壓過 operator 在 host overlay 的人工指定。
+    """
+
+    role = model_resolution.role_for_persona(persona)
+    ranked = model_resolution.rank_candidates(
+        candidates, role=role, context=identities.resolution_context
+    )
+    for warning in ranked.warnings:
+        logger.warning(
+            "workflow run=%s persona=%s %s", getattr(run, "run_id", None), persona, warning
+        )
+    if ranked.excluded:
+        logger.info(
+            "workflow run=%s persona=%s 解析層剔除候選：%s（存活候選 %d）",
+            getattr(run, "run_id", None),
+            persona,
+            ranked.exclusion_detail(),
+            len(ranked.ordered),
+        )
+    if not ranked.ordered:
+        raise ValueError(
+            f"no resolvable identity for workflow persona: {persona}"
+            f"（{ranked.exclusion_detail()}）——第 1 層請於 host overlay 宣告身分，"
+            "第 2 層請以 patchmud 評估合格並人工複核後加入 model-eval-roster.yaml"
+        )
+    return list(ranked.ordered)
+
+
+def _resolution_layer_for(
+    identity, persona: str, identities: IdentityRegistry | None = None
+) -> str:
+    """本次解析結果落在哪一層（provenance 用；被 park 的身分不會走到這裡）。
+
+    `identities` 缺席（舊呼叫端／測試替身）時退回空的評估清單：overlay 來源
+    仍記第 1 層，packaged 來源記第 3 層——保守方向，不會把未評估的身分誤標成
+    已評估合格。
+    """
+
+    context = (
+        identities.resolution_context
+        if identities is not None
+        else model_resolution.DEFAULT_CONTEXT
+    )
+    layer = model_resolution.identity_layer(
+        identity,
+        role=model_resolution.role_for_persona(persona),
+        eval_roster=context.eval_roster,
+    )
+    return layer or model_resolution.RESOLUTION_LAYER_PACKAGED
 
 
 def _workflow_identity_candidates(run, step, identities: IdentityRegistry) -> list:
@@ -7155,36 +7215,44 @@ def _runtime_preflight_gate(
     )
 
 
-def _record_resolved_model_chain(registry, run, step, identity) -> None:
+def _record_resolved_model_chain(
+    registry, run, step, identity, identities: IdentityRegistry | None = None
+) -> None:
     """#205 R4/D5：把本次 dispatch 實際解析到的 executor/model/domain 與來源
     寫入 run，供事後稽核。純 provenance 寫入，逐段覆蓋合併既有紀錄，不影響
     既有 workflow 語意或推進邏輯。
 
-    #452 C：source 記錄實際解析依據——run-scoped 覆寫記 ``override``；身分帶
-    該 persona 的實測側寫記 ``patchmud-profile``；查表投影落在保守預設記
-    ``default-envelope``（``registry`` 保留為 #452 前既有紀錄的 legacy 值）。
+    #534：``source`` 改記**解析層**——``run-override``（run-scoped 覆寫）／
+    ``operator-overlay``／``evaluated-roster``／``packaged-fallback``。舊值
+    ``default-envelope``／``patchmud-profile`` 只說得出「封套來自實測或預設」，
+    說不出「這顆模型憑什麼進熱路徑」，operator 看到 `source: default-envelope`
+    根本無從得知跑的是未經核可的 packaged 候選。封套來源改記在獨立的
+    ``envelope_source`` 欄位，資訊不減。
     """
+    from .model_identities import (
+        DEFAULT_ENVELOPE,
+        ENVELOPE_SOURCE_DEFAULT,
+        ENVELOPE_SOURCE_MEASURED,
+        project_envelope,
+    )
+
     override = getattr(run, "model_chain_override", None)
     if isinstance(override, dict) and step.persona in override:
-        source = "override"
+        source = "run-override"
     else:
-        from .model_identities import (
-            DEFAULT_ENVELOPE,
-            ENVELOPE_SOURCE_MEASURED,
-            project_envelope,
-        )
-
-        source = "default-envelope"
-        if step.persona in DEFAULT_ENVELOPE:
-            projection = project_envelope(identity, step.persona)
-            if ENVELOPE_SOURCE_MEASURED in projection.source.values():
-                source = "patchmud-profile"
+        source = _resolution_layer_for(identity, step.persona, identities)
+    envelope_source = ENVELOPE_SOURCE_DEFAULT
+    if step.persona in DEFAULT_ENVELOPE:
+        projection = project_envelope(identity, step.persona)
+        if ENVELOPE_SOURCE_MEASURED in projection.source.values():
+            envelope_source = ENVELOPE_SOURCE_MEASURED
     resolved = dict(getattr(run, "resolved_model_chain", None) or {})
     resolved[step.persona] = {
         "executor": identity.executor,
         "model_id": identity.model_id,
         "independence_domain": identity.independence_domain,
         "source": source,
+        "envelope_source": envelope_source,
     }
     registry._manager_update_workflow_run(run.run_id, resolved_model_chain=resolved)
 
@@ -7915,7 +7983,7 @@ def _dispatch_workflow_card(
         launcher = _specialize_workflow_launcher(launcher, step)
     # #205 R4/D5：稽核實際解析到的模型鏈。接在兩條路徑之後，因此 #262 preflight
     # re-route 換掉的 identity 也會被如實記錄（記的是真正要跑的那個，不是原選擇）。
-    _record_resolved_model_chain(registry, run, step, identity)
+    _record_resolved_model_chain(registry, run, step, identity, identities)
     builder_jobs = [
         job
         for job in registry.list_jobs()

--- a/paulsha_cortex/coordinator/model_identities.py
+++ b/paulsha_cortex/coordinator/model_identities.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 import json
+import logging
 import re
 import subprocess
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import Callable, Iterable, Mapping
 
@@ -11,7 +12,10 @@ from paulsha_cortex.config import paths
 from paulsha_cortex.deck.schema import BAND_LEVELS
 
 from .._yaml import YAMLError, safe_load
+from . import model_resolution
 from .launcher import build_agy_argv
+
+logger = logging.getLogger(__name__)
 
 # #452 B：schema v3 新增封套四欄位＋profile_provenance（全選填）。v1/v2 檔案
 # 照載（缺省欄位由查表投影套 DEFAULT_ENVELOPE，見 project_envelope）。
@@ -25,6 +29,9 @@ AGY_MODEL_ID = "gemini-3.1-pro-high"
 _AGY_MODEL_ID_LEGACY_DISPLAY_NAME = "Gemini 3.1 Pro (High)"
 AGY_DOMAIN = "google"
 AGY_LIVE_PROBE = "agy-plan-sandbox"
+#: #534 起**不再是解析順序**：`select_secondary_planner` 改走三層解析鏈
+#: （model_resolution）。保留本常數僅為既有 executor↔domain 對應的歷史記錄
+#: （docs/superpowers/specs/model-persona-roster-matrix.md 引用），不參與任何選擇。
 PLANNER_PRIORITY = (
     ("agy", "google"),
     ("claude", "anthropic"),
@@ -288,8 +295,21 @@ class ModelIdentity:
     consistency_scope: tuple[str, ...] | None = None
     acceptance_modes: tuple[str, ...] | None = None
     # dict 不可 hash：排除在 __hash__ 之外（等值比較仍包含本欄位，shadow 檢查
-    # 語意不變——內容不同的同鍵身分仍會被 load_model_identities 拒載）。
+    # 語意不變——內容不同的同鍵身分在 load_model_identities 會被判為 overlay
+    # 覆寫 packaged，而不是相同列）。
     profile_provenance: Mapping[str, object] | None = field(default=None, hash=False)
+    # #534：解析層 provenance。三者皆為 loader 蓋章／overlay 指令，**不是** YAML
+    # 身分欄位，因此一律排除在等值比較與 hash 之外（shadow 判定只看身分內容），
+    # 也不進 `to_dict()`（registry 檔案格式不變，`write_registry_file` 寫出的
+    # packaged roster 逐欄與 #534 之前相同）。
+    #: 身分來自 host overlay 或 packaged roster（見 model_resolution）。
+    origin: str = field(
+        default=model_resolution.IDENTITY_ORIGIN_OVERLAY, compare=False, hash=False
+    )
+    #: overlay 對 packaged 身分的處置：None／"park"／"demote"（#509 殘項）。
+    operator_action: str | None = field(default=None, compare=False, hash=False)
+    #: overlay 是否明示宣告本列覆寫同鍵 packaged 身分（#509「合法覆寫語意」）。
+    override_packaged: bool = field(default=False, compare=False, hash=False)
 
     def legacy_dict(self) -> dict[str, str]:
         return {
@@ -329,6 +349,16 @@ class ModelIdentity:
 class IdentityRegistry:
     schema_version: int
     identities: tuple[ModelIdentity, ...]
+    # #534：本次載入的解析上下文（政策／評估合格清單／診斷）。手工建構的
+    # registry 不帶上下文，一律走 DEFAULT_CONTEXT（全視為 operator 指定，
+    # 維持既有順序語意）。不參與等值比較與 hash。
+    resolution: "model_resolution.ResolutionContext | None" = field(
+        default=None, compare=False, hash=False
+    )
+
+    @property
+    def resolution_context(self) -> "model_resolution.ResolutionContext":
+        return self.resolution or model_resolution.DEFAULT_CONTEXT
 
     @classmethod
     def from_rows(
@@ -336,6 +366,7 @@ class IdentityRegistry:
         rows: Iterable[Mapping[str, object]],
         *,
         schema_version: int = MODEL_IDENTITY_SCHEMA_VERSION,
+        origin: str = model_resolution.IDENTITY_ORIGIN_OVERLAY,
     ) -> "IdentityRegistry":
         identities: list[ModelIdentity] = []
         seen: set[tuple[str, str]] = set()
@@ -345,6 +376,8 @@ class IdentityRegistry:
             "independence_domain",
             "capabilities",
             "live_probe",
+            # #534／#509：overlay 明示覆寫同鍵 packaged 身分的旗標（選配）。
+            "override_packaged",
         }
         if int(schema_version) >= 3:
             # schema v3（#452 B）才認得封套欄位；v1/v2 帶了一律 fail-closed。
@@ -378,6 +411,11 @@ class IdentityRegistry:
                 if live_probe_raw is None
                 else _nonempty(live_probe_raw, f"model-identities[{index}].live_probe")
             )
+            override_packaged = row.get("override_packaged", False)
+            if not isinstance(override_packaged, bool):
+                raise ValueError(
+                    f"model-identities[{index}].override_packaged must be a boolean"
+                )
             if executor == "agy" and "planning" in capabilities:
                 if domain != AGY_DOMAIN or live_probe != AGY_LIVE_PROBE:
                     raise ValueError(
@@ -397,6 +435,8 @@ class IdentityRegistry:
                     independence_domain=domain,
                     capabilities=capabilities,
                     live_probe=live_probe,
+                    origin=origin,
+                    override_packaged=override_packaged,
                     **envelope,
                 )
             )
@@ -425,7 +465,9 @@ def _packaged_registry_path() -> Path:
     return Path(__file__).with_name("data") / "model-identities.yaml"
 
 
-def _load_model_identity_file(path: Path) -> IdentityRegistry:
+def _load_model_identity_file(
+    path: Path, *, origin: str = model_resolution.IDENTITY_ORIGIN_OVERLAY
+) -> IdentityRegistry:
     if not path.is_file():
         raise ValueError(f"model-identities missing: {path}")
     try:
@@ -436,7 +478,15 @@ def _load_model_identity_file(path: Path) -> IdentityRegistry:
         raise ValueError(f"model-identities unreadable: {path}: {exc}") from exc
     if not isinstance(payload, dict):
         raise ValueError(f"model-identities invalid root: {path}")
-    extras = set(payload) - {"schema_version", "identities"}
+    # #534：新增兩個**選配**頂層區塊——`packaged_overrides`（demote／park packaged
+    # 身分）與 `resolution_policy`（packaged fallback 政策）。既有 overlay 檔案不
+    # 帶這兩個 key 照舊合法，不需為升級改任何一行。
+    extras = set(payload) - {
+        "schema_version",
+        "identities",
+        "packaged_overrides",
+        "resolution_policy",
+    }
     if extras:
         raise ValueError(f"model-identities unexpected top-level key: {sorted(extras)[0]}")
     schema_version = payload.get("schema_version")
@@ -474,7 +524,24 @@ def _load_model_identity_file(path: Path) -> IdentityRegistry:
         rows = normalized_rows
     # 封套欄位是 schema v3（#452 B）才有的契約；v1/v2 檔案帶了照舊 fail-closed
     # （閘門在 from_rows 內由 schema_version 推導，建構層與檔案層同一條規則）。
-    return IdentityRegistry.from_rows(rows, schema_version=int(schema_version))
+    registry = IdentityRegistry.from_rows(
+        rows, schema_version=int(schema_version), origin=origin
+    )
+    overrides = model_resolution.parse_packaged_overrides(payload.get("packaged_overrides"))
+    # 沒有 overlay 檔案的部署＝operator 未宣告任何東西，packaged roster 就是全世界
+    # ——此時 fallback 預設 allow（僅留 provenance）；有 overlay 檔案時預設 warn
+    # （fail-loud），operator 可自行改成 deny 走嚴格 fail-closed。
+    policy = model_resolution.parse_resolution_policy(
+        payload.get("resolution_policy"),
+        default=model_resolution.PACKAGED_FALLBACK_WARN,
+    )
+    context = model_resolution.ResolutionContext(
+        policy=policy,
+        packaged_overrides=overrides,
+        config_root=str(path.parent),
+        overlay_present=origin == model_resolution.IDENTITY_ORIGIN_OVERLAY,
+    )
+    return replace(registry, resolution=context)
 
 
 def load_model_identities(
@@ -482,37 +549,138 @@ def load_model_identities(
     *,
     use_packaged_default: bool = True,
 ) -> IdentityRegistry:
+    """載入 host overlay ＋ packaged 候選池，並蓋上 #534 的解析層 provenance。
+
+    #534：overlay 絕對優先。overlay 列在合併結果中一律排在 packaged 之前，且
+    **同鍵時 overlay 覆寫 packaged**——後者過去是 `raise ValueError`，一列過期
+    設定就能打掛整條 periodic tick（#509）。現在改為：
+
+    - 逐欄相等 → 視為同一列，沿用 overlay 那份（無診斷）；
+    - 內容不同且 overlay 明示 ``override_packaged: true`` → 合法覆寫（info 診斷）；
+    - 內容不同但未明示 → 仍以 overlay 為準（裁決：人工指定優先），但留下 warn
+      診斷並打 log，請 operator 補旗標或移除該列。**不再中止載入。**
+    """
+
     root = Path(config_root) if config_root is not None else paths.project_config_root()
     custom_path = root / "model-identities.yaml"
     if not use_packaged_default:
-        return _load_model_identity_file(custom_path)
+        overlay_only = _load_model_identity_file(
+            custom_path, origin=model_resolution.IDENTITY_ORIGIN_OVERLAY
+        )
+        return replace(
+            overlay_only,
+            resolution=replace(
+                overlay_only.resolution_context,
+                eval_roster=model_resolution.load_eval_roster_degraded(root),
+            ),
+        )
 
-    packaged = _load_model_identity_file(_packaged_registry_path())
+    packaged = _load_model_identity_file(
+        _packaged_registry_path(), origin=model_resolution.IDENTITY_ORIGIN_PACKAGED
+    )
+    eval_roster = model_resolution.load_eval_roster_degraded(root)
+    notes: list[model_resolution.ResolutionNote] = []
+    if eval_roster.load_error is not None:
+        notes.append(
+            model_resolution.ResolutionNote(
+                "eval-roster-unreadable",
+                "fail",
+                f"{eval_roster.load_error}（第 2 層視為空清單，解析不會因此多授予資格）",
+            )
+        )
     if not custom_path.is_file():
-        return packaged
-    custom = _load_model_identity_file(custom_path)
+        # operator 未宣告任何 overlay：packaged 就是全世界，fallback 預設 allow。
+        context = model_resolution.ResolutionContext(
+            policy=model_resolution.ResolutionPolicy(
+                model_resolution.PACKAGED_FALLBACK_ALLOW
+            ),
+            eval_roster=eval_roster,
+            notes=tuple(notes),
+            config_root=str(root),
+            overlay_present=False,
+        )
+        return replace(packaged, resolution=context)
+    custom = _load_model_identity_file(
+        custom_path, origin=model_resolution.IDENTITY_ORIGIN_OVERLAY
+    )
+    overlay_context = custom.resolution_context
     packaged_by_key = {
         (item.executor, item.model_id): item for item in packaged.identities
     }
+    overlay_keys = {(item.executor, item.model_id) for item in custom.identities}
     additions: list[ModelIdentity] = []
+    shadowed: set[tuple[str, str]] = set()
     for identity in custom.identities:
         key = (identity.executor, identity.model_id)
         packaged_identity = packaged_by_key.get(key)
-        if packaged_identity is not None and packaged_identity == identity:
-            continue
         if packaged_identity is not None:
-            # #452 對抗審查修正：roster 擴為 5 身分後，既有 host overlay 撞鍵的
-            # 機率大增（尤其 claude/sonnet 舊 operator 寫法）——錯誤訊息附行動
-            # 指引，操作者不用翻 code 就知道怎麼解。
-            raise ValueError(
-                f"model-identities custom identity shadows packaged default: {key[0]}/{key[1]}"
-                "（packaged roster v3 已收編此身分：請自 host overlay 移除該列，"
-                "或改成與 packaged 逐欄相等）"
-            )
+            shadowed.add(key)
+            if packaged_identity != identity:
+                if identity.override_packaged:
+                    notes.append(
+                        model_resolution.ResolutionNote(
+                            "packaged-override",
+                            "info",
+                            f"host overlay 明示覆寫 packaged 身分 {key[0]}/{key[1]}",
+                        )
+                    )
+                else:
+                    detail = (
+                        f"host overlay 的 {key[0]}/{key[1]} 與 packaged roster 同鍵但內容不同，"
+                        "已以 overlay 為準（人工指定優先）。請於該列加上 "
+                        "`override_packaged: true` 明示覆寫意圖，或移除該列改用 packaged 版本。"
+                    )
+                    notes.append(
+                        model_resolution.ResolutionNote(
+                            "unflagged-packaged-override", "warn", detail
+                        )
+                    )
+                    logger.warning("model-identities %s", detail)
         additions.append(identity)
+    # #509 殘項：overlay 可 demote／park packaged 身分。
+    overrides_by_key = {item.key: item for item in overlay_context.packaged_overrides}
+    for key, override in overrides_by_key.items():
+        if key not in packaged_by_key:
+            raise ValueError(
+                "model-identities packaged_overrides 指向不存在的 packaged 身分: "
+                f"{key[0]}/{key[1]}（可處置的 packaged 身分: "
+                + ", ".join(f"{a}/{b}" for a, b in packaged_by_key)
+                + "）"
+            )
+        if key in overlay_keys:
+            raise ValueError(
+                "model-identities packaged_overrides 與 identities 同時宣告同一身分: "
+                f"{key[0]}/{key[1]}（兩者意圖矛盾：請擇一）"
+            )
+        notes.append(
+            model_resolution.ResolutionNote(
+                f"packaged-{override.action}",
+                "info",
+                f"host overlay {override.action} packaged 身分 {key[0]}/{key[1]}：{override.reason}",
+            )
+        )
+    retained: list[ModelIdentity] = []
+    for identity in packaged.identities:
+        key = (identity.executor, identity.model_id)
+        if key in shadowed:
+            # overlay 已宣告同鍵身分：以 overlay 那列為準，packaged 版本不重複登錄。
+            continue
+        override = overrides_by_key.get(key)
+        retained.append(
+            identity if override is None else replace(identity, operator_action=override.action)
+        )
+    context = model_resolution.ResolutionContext(
+        policy=overlay_context.policy,
+        eval_roster=eval_roster,
+        packaged_overrides=overlay_context.packaged_overrides,
+        notes=tuple(notes),
+        config_root=str(root),
+        overlay_present=True,
+    )
     return IdentityRegistry(
         schema_version=MODEL_IDENTITY_SCHEMA_VERSION,
-        identities=tuple(additions) + packaged.identities,
+        identities=tuple(additions) + tuple(retained),
+        resolution=context,
     )
 
 
@@ -642,27 +810,39 @@ def select_secondary_planner(
     primary: tuple[str, str],
     probes: Mapping[tuple[str, str], CapabilityProbe],
 ) -> SecondarySelection:
+    """挑異質 domain 的次要 planner。
+
+    #534：候選順序改走三層解析鏈（operator overlay → 評估合格清單 → packaged
+    fallback），不再是 ``PLANNER_PRIORITY`` 的寫死 executor 順序。舊實作把
+    ``agy`` 釘在第一位，且只認 ``PLANNER_PRIORITY`` 列出的三組
+    ``(executor, domain)``——operator 在 overlay 宣告的 planner（例如 `cg` 或
+    任何新 executor）**永遠不可達**，packaged 的 agy 卻穩坐熱路徑首位，正是
+    #534 的主訴現場。合法性條件（planning capability、異質 domain、probe
+    ready 且 probe 身分相符）逐項不變。
+    """
+
     primary_identity = registry.get(*primary)
     if primary_identity is None:
         return SecondarySelection("needs_human", "primary-identity-unknown", None)
-    for executor, domain in PLANNER_PRIORITY:
-        for identity in registry.identities:
-            if identity.executor != executor or identity.independence_domain != domain:
-                continue
-            if "planning" not in identity.capabilities:
-                continue
-            if identity.independence_domain == primary_identity.independence_domain:
-                continue
-            probe = probes.get((identity.executor, identity.model_id))
-            if probe is None or not probe.ready:
-                continue
-            if probe.identity != (
-                identity.executor,
-                identity.model_id,
-                identity.independence_domain,
-            ):
-                continue
-            return SecondarySelection("ready", None, identity)
+    planning = [
+        identity for identity in registry.identities if "planning" in identity.capabilities
+    ]
+    ranked = model_resolution.rank_candidates(
+        planning, role="planning", context=registry.resolution_context
+    )
+    for identity in ranked.ordered:
+        if identity.independence_domain == primary_identity.independence_domain:
+            continue
+        probe = probes.get((identity.executor, identity.model_id))
+        if probe is None or not probe.ready:
+            continue
+        if probe.identity != (
+            identity.executor,
+            identity.model_id,
+            identity.independence_domain,
+        ):
+            continue
+        return SecondarySelection("ready", None, identity)
     return SecondarySelection("needs_human", "no-heterogeneous-planner", None)
 
 

--- a/paulsha_cortex/coordinator/model_profile.py
+++ b/paulsha_cortex/coordinator/model_profile.py
@@ -619,13 +619,25 @@ def run_model_profile(
 
 
 def envelope_display_rows(registry: IdentityRegistry) -> list[dict[str, object]]:
-    """`cortex inspect models` 的顯示資料：每身分 × persona 的封套投影＋來源。"""
+    """`cortex inspect models` 的顯示資料：每身分 × persona 的封套投影＋來源。
 
+    #534：加上 ``resolution_layer``（operator-overlay／evaluated-roster／
+    packaged-fallback／parked），讓 operator 一眼看出每顆模型憑什麼進熱路徑。
+    """
+
+    from . import model_resolution
+
+    context = registry.resolution_context
     display: list[dict[str, object]] = []
     for identity in registry.identities:
         for persona in ("planner", "builder", "reviewer"):
             if _PERSONA_CAPABILITY[persona] not in identity.capabilities:
                 continue
+            resolution_layer = model_resolution.identity_layer(
+                identity,
+                role=model_resolution.role_for_persona(persona),
+                eval_roster=context.eval_roster,
+            ) or "parked"
             projection = project_envelope(identity, persona)
             provenance_summary: dict[str, object] | None = None
             if projection.provenance is not None:
@@ -640,6 +652,7 @@ def envelope_display_rows(registry: IdentityRegistry) -> list[dict[str, object]]
                     "model_id": identity.model_id,
                     "independence_domain": identity.independence_domain,
                     "persona": persona,
+                    "resolution_layer": resolution_layer,
                     "envelope": {
                         key: (list(value) if isinstance(value, (list, tuple)) else value)
                         for key, value in projection.envelope.items()

--- a/paulsha_cortex/coordinator/model_resolution.py
+++ b/paulsha_cortex/coordinator/model_resolution.py
@@ -1,0 +1,582 @@
+"""#534：模型引擎三層解析鏈（operator overlay → 評估合格清單 → packaged 候選池）。
+
+使用者裁決（2026-08-14）：**人工指定清單優先 → agent 從 patchmud 評估合格清單挑
+→ 未評估模型須先經 patchmud eval、合格後人工複核加入清單**。本模組是那條裁決的
+唯一真值：
+
+1. ``operator-overlay``——host overlay ``model-identities.yaml`` 宣告的身分。
+   operator 的列序即優先序，壓過 packaged roster 的一切內建順序。
+2. ``evaluated-roster``——``model-eval-roster.yaml`` 中 ``verdict: pass`` 且
+   ``review_status: approved`` 的身分（該角色）。patchmud eval 管線是這層的資料
+   供給端（管線本身屬 v4 R2，不在 #534；本層先把契約與消費端做出來，清單可手工
+   維護）。
+3. ``packaged-fallback``——packaged roster 只剩「候選池」：供評估管線取材，解析時
+   為最後一層，且受 ``resolution_policy.packaged_fallback`` 管制（allow／warn／
+   deny），選到時一律留下 provenance，不得靜默使用。
+
+本模組刻意不 import :mod:`model_identities`（避免循環 import）；identity 一律
+duck-typed 讀取，缺欄位時退回最寬鬆的預設，讓既有測試替身與手工建構的 registry
+維持原行為。
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable, Mapping, Sequence
+
+from .._yaml import YAMLError, safe_load
+
+# ---------------------------------------------------------------------------
+# 解析層與身分來源常數
+# ---------------------------------------------------------------------------
+
+#: 第 1 層：operator 於 host overlay 人工指定。
+RESOLUTION_LAYER_OVERLAY = "operator-overlay"
+#: 第 2 層：patchmud 評估合格＋人工複核通過的清單。
+RESOLUTION_LAYER_EVALUATED = "evaluated-roster"
+#: 第 3 層：packaged 候選池（未評估／未複核），僅為 fallback。
+RESOLUTION_LAYER_PACKAGED = "packaged-fallback"
+#: 宣告順序即優先序。
+RESOLUTION_LAYERS = (
+    RESOLUTION_LAYER_OVERLAY,
+    RESOLUTION_LAYER_EVALUATED,
+    RESOLUTION_LAYER_PACKAGED,
+)
+_LAYER_RANK = {name: index for index, name in enumerate(RESOLUTION_LAYERS)}
+
+#: identity 來源（載入時由 loader 蓋章，非 YAML 欄位）。
+IDENTITY_ORIGIN_OVERLAY = "operator-overlay"
+IDENTITY_ORIGIN_PACKAGED = "packaged"
+IDENTITY_ORIGINS = frozenset({IDENTITY_ORIGIN_OVERLAY, IDENTITY_ORIGIN_PACKAGED})
+
+#: overlay 對 packaged 身分的處置（#509 殘項：demote／park）。
+PACKAGED_ACTION_PARK = "park"
+PACKAGED_ACTION_DEMOTE = "demote"
+PACKAGED_ACTIONS = frozenset({PACKAGED_ACTION_PARK, PACKAGED_ACTION_DEMOTE})
+
+#: packaged fallback 政策。
+PACKAGED_FALLBACK_ALLOW = "allow"
+PACKAGED_FALLBACK_WARN = "warn"
+PACKAGED_FALLBACK_DENY = "deny"
+PACKAGED_FALLBACK_POLICIES = (
+    PACKAGED_FALLBACK_ALLOW,
+    PACKAGED_FALLBACK_WARN,
+    PACKAGED_FALLBACK_DENY,
+)
+
+#: persona → 評估角色／capability（與 manager 的
+#: ``_MODEL_CHAIN_CAPABILITY_BY_PERSONA`` 同一組值，避免兩處漂移）。
+ROLE_BY_PERSONA = {
+    "planner": "planning",
+    "builder": "build",
+    "reviewer": "review",
+}
+EVAL_ROSTER_ROLES = ("planning", "build", "review")
+
+EVAL_ROSTER_FILENAME = "model-eval-roster.yaml"
+EVAL_ROSTER_SCHEMA_VERSION = 1
+SUPPORTED_EVAL_ROSTER_SCHEMAS = frozenset({1})
+EVAL_VERDICTS = ("pass", "fail", "pending")
+REVIEW_STATUSES = ("approved", "rejected", "pending")
+
+_EVAL_REQUIRED_KEYS = (
+    "executor",
+    "model_id",
+    "roles",
+    "verdict",
+    "evaluated_at",
+    "eval_source",
+    "review_status",
+)
+_EVAL_OPTIONAL_KEYS = ("eval_ref", "reviewer", "reviewed_at", "notes")
+
+
+def role_for_persona(persona: str) -> str:
+    """persona → 評估角色；未知 persona 比照 manager 的 catch-all 視為 build。"""
+
+    return ROLE_BY_PERSONA.get(persona, "build")
+
+
+def _nonempty(value: object, field_name: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{field_name} must be a non-empty string")
+    return value.strip()
+
+
+# ---------------------------------------------------------------------------
+# 第 2 層契約：model-eval-roster.yaml
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class EvalRosterEntry:
+    """評估合格清單的一列（扁平欄位，可手工維護）。
+
+    合格判準（第 2 層可用）＝ ``verdict == "pass"`` **且**
+    ``review_status == "approved"`` **且**該角色列於 ``roles``。三者缺一即不入
+    第 2 層——「評估過」不等於「人工核可」，這正是裁決第 3 條的閘門。
+    """
+
+    executor: str
+    model_id: str
+    roles: tuple[str, ...]
+    verdict: str
+    evaluated_at: str
+    eval_source: str
+    review_status: str
+    eval_ref: str | None = None
+    reviewer: str | None = None
+    reviewed_at: str | None = None
+    notes: str | None = None
+
+    @property
+    def key(self) -> tuple[str, str]:
+        return (self.executor, self.model_id)
+
+    def qualified(self) -> bool:
+        return self.verdict == "pass" and self.review_status == "approved"
+
+    def approves(self, role: str) -> bool:
+        return self.qualified() and role in self.roles
+
+    def disqualified_reason(self) -> str | None:
+        if self.verdict != "pass":
+            return f"evaluation verdict={self.verdict}"
+        if self.review_status != "approved":
+            return f"human review={self.review_status}"
+        return None
+
+    def to_dict(self) -> dict[str, object]:
+        payload: dict[str, object] = {
+            "executor": self.executor,
+            "model_id": self.model_id,
+            "roles": list(self.roles),
+            "verdict": self.verdict,
+            "evaluated_at": self.evaluated_at,
+            "eval_source": self.eval_source,
+            "review_status": self.review_status,
+        }
+        for name in _EVAL_OPTIONAL_KEYS:
+            value = getattr(self, name)
+            if value is not None:
+                payload[name] = value
+        return payload
+
+
+@dataclass(frozen=True)
+class EvalRoster:
+    """``model-eval-roster.yaml`` 的載入結果。
+
+    ``load_error`` 非 None 代表清單存在但解析失敗——此時 entries 一律為空
+    （fail-closed：壞掉的清單絕不授予任何身分資格），但不丟例外，避免 #509 的
+    「一列設定過期把整條調度迴圈打掛」重演；診斷由 ``cortex doctor`` 呈現。
+    """
+
+    schema_version: int = EVAL_ROSTER_SCHEMA_VERSION
+    entries: tuple[EvalRosterEntry, ...] = ()
+    path: str | None = None
+    load_error: str | None = None
+
+    def entry_for(self, executor: str, model_id: str) -> EvalRosterEntry | None:
+        for entry in self.entries:
+            if entry.key == (executor, model_id):
+                return entry
+        return None
+
+    def approves(self, executor: str, model_id: str, role: str) -> bool:
+        entry = self.entry_for(executor, model_id)
+        return entry is not None and entry.approves(role)
+
+    def qualified_entries(self) -> tuple[EvalRosterEntry, ...]:
+        return tuple(entry for entry in self.entries if entry.qualified())
+
+    def pending_entries(self) -> tuple[EvalRosterEntry, ...]:
+        return tuple(entry for entry in self.entries if not entry.qualified())
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "schema_version": self.schema_version,
+            "path": self.path,
+            "load_error": self.load_error,
+            "entries": [entry.to_dict() for entry in self.entries],
+        }
+
+
+def parse_eval_roster(payload: object, *, path: str | None = None) -> EvalRoster:
+    """fail-closed 解析評估合格清單（未知欄位、非法值域一律拒絕）。"""
+
+    if not isinstance(payload, Mapping):
+        raise ValueError("model-eval-roster invalid root")
+    extras = set(payload) - {"schema_version", "entries"}
+    if extras:
+        raise ValueError(f"model-eval-roster unexpected top-level key: {sorted(extras)[0]}")
+    schema_version = payload.get("schema_version")
+    if type(schema_version) is not int or schema_version not in SUPPORTED_EVAL_ROSTER_SCHEMAS:
+        raise ValueError(
+            "model-eval-roster schema_version must be one of "
+            f"{sorted(SUPPORTED_EVAL_ROSTER_SCHEMAS)}, got {schema_version!r}"
+        )
+    rows = payload.get("entries", [])
+    if not isinstance(rows, list):
+        raise ValueError("model-eval-roster entries must be a list")
+    allowed = set(_EVAL_REQUIRED_KEYS) | set(_EVAL_OPTIONAL_KEYS)
+    entries: list[EvalRosterEntry] = []
+    seen: set[tuple[str, str]] = set()
+    for index, row in enumerate(rows):
+        prefix = f"model-eval-roster[{index}]"
+        if not isinstance(row, Mapping):
+            raise ValueError(f"{prefix} must be an object")
+        unexpected = set(row) - allowed
+        if unexpected:
+            raise ValueError(f"{prefix}.{sorted(unexpected)[0]} unexpected")
+        missing = [name for name in _EVAL_REQUIRED_KEYS if name not in row]
+        if missing:
+            raise ValueError(f"{prefix}.{missing[0]} is required")
+        executor = _nonempty(row.get("executor"), f"{prefix}.executor")
+        model_id = _nonempty(row.get("model_id"), f"{prefix}.model_id")
+        roles_raw = row.get("roles")
+        if not isinstance(roles_raw, list) or not roles_raw:
+            raise ValueError(f"{prefix}.roles must be a non-empty string list")
+        roles = tuple(_nonempty(item, f"{prefix}.roles[]") for item in roles_raw)
+        if len(set(roles)) != len(roles):
+            raise ValueError(f"{prefix}.roles contains duplicates")
+        invalid = [role for role in roles if role not in EVAL_ROSTER_ROLES]
+        if invalid:
+            raise ValueError(f"{prefix}.roles invalid: {invalid[0]!r}")
+        verdict = _nonempty(row.get("verdict"), f"{prefix}.verdict")
+        if verdict not in EVAL_VERDICTS:
+            raise ValueError(f"{prefix}.verdict invalid: {verdict!r}")
+        review_status = _nonempty(row.get("review_status"), f"{prefix}.review_status")
+        if review_status not in REVIEW_STATUSES:
+            raise ValueError(f"{prefix}.review_status invalid: {review_status!r}")
+        evaluated_at = _nonempty(row.get("evaluated_at"), f"{prefix}.evaluated_at")
+        eval_source = _nonempty(row.get("eval_source"), f"{prefix}.eval_source")
+        optional: dict[str, str | None] = {}
+        for name in _EVAL_OPTIONAL_KEYS:
+            raw = row.get(name)
+            optional[name] = None if raw is None else _nonempty(raw, f"{prefix}.{name}")
+        if review_status == "approved" and (
+            optional["reviewer"] is None or optional["reviewed_at"] is None
+        ):
+            # 人工複核標記必須可稽核：approved 卻沒有複核人／複核日期，等同無人複核。
+            raise ValueError(
+                f"{prefix}.review_status=approved requires reviewer and reviewed_at"
+            )
+        key = (executor, model_id)
+        if key in seen:
+            raise ValueError(f"model-eval-roster duplicate entry: {executor}/{model_id}")
+        seen.add(key)
+        entries.append(
+            EvalRosterEntry(
+                executor=executor,
+                model_id=model_id,
+                roles=roles,
+                verdict=verdict,
+                evaluated_at=evaluated_at,
+                eval_source=eval_source,
+                review_status=review_status,
+                **optional,
+            )
+        )
+    return EvalRoster(
+        schema_version=int(schema_version), entries=tuple(entries), path=path
+    )
+
+
+def load_eval_roster(config_root: str | Path) -> EvalRoster:
+    """讀取 host config root 的評估合格清單；檔案不存在＝空清單（全向後相容）。"""
+
+    path = Path(config_root) / EVAL_ROSTER_FILENAME
+    if not path.is_file():
+        return EvalRoster(path=str(path))
+    try:
+        text = path.read_text(encoding="utf-8")
+        payload = safe_load(text)
+    except (OSError, UnicodeDecodeError, YAMLError, ValueError) as exc:
+        raise ValueError(f"model-eval-roster unreadable: {path}: {exc}") from exc
+    return parse_eval_roster(payload, path=str(path))
+
+
+def load_eval_roster_degraded(config_root: str | Path) -> EvalRoster:
+    """載入清單但**永不丟例外**——解析失敗回空清單＋``load_error``。
+
+    #509 的教訓：設定資料的相容性問題不該讓調度迴圈整條停止。壞掉的清單只會讓
+    第 2 層變空（保守方向，絕不因錯誤而多授予資格），診斷交給 doctor。
+    """
+
+    try:
+        return load_eval_roster(config_root)
+    except ValueError as exc:
+        return EvalRoster(
+            path=str(Path(config_root) / EVAL_ROSTER_FILENAME), load_error=str(exc)
+        )
+
+
+# ---------------------------------------------------------------------------
+# overlay 的解析指令：packaged_overrides／resolution_policy
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PackagedOverride:
+    """overlay 對某個 packaged 身分的明示處置（#509 殘項）。
+
+    - ``park``：完全停用，該身分不再進入任何解析候選。
+    - ``demote``：保留可用性但降到最低位（排在同層其餘候選之後）。
+    """
+
+    executor: str
+    model_id: str
+    action: str
+    reason: str
+
+    @property
+    def key(self) -> tuple[str, str]:
+        return (self.executor, self.model_id)
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "executor": self.executor,
+            "model_id": self.model_id,
+            "action": self.action,
+            "reason": self.reason,
+        }
+
+
+def parse_packaged_overrides(value: object) -> tuple[PackagedOverride, ...]:
+    if value is None:
+        return ()
+    if not isinstance(value, list):
+        raise ValueError("model-identities packaged_overrides must be a list")
+    allowed = {"executor", "model_id", "action", "reason"}
+    overrides: list[PackagedOverride] = []
+    seen: set[tuple[str, str]] = set()
+    for index, row in enumerate(value):
+        prefix = f"model-identities.packaged_overrides[{index}]"
+        if not isinstance(row, Mapping):
+            raise ValueError(f"{prefix} must be an object")
+        extras = set(row) - allowed
+        if extras:
+            raise ValueError(f"{prefix}.{sorted(extras)[0]} unexpected")
+        missing = [name for name in sorted(allowed) if name not in row]
+        if missing:
+            raise ValueError(f"{prefix}.{missing[0]} is required")
+        executor = _nonempty(row.get("executor"), f"{prefix}.executor")
+        model_id = _nonempty(row.get("model_id"), f"{prefix}.model_id")
+        action = _nonempty(row.get("action"), f"{prefix}.action")
+        if action not in PACKAGED_ACTIONS:
+            raise ValueError(f"{prefix}.action invalid: {action!r}")
+        reason = _nonempty(row.get("reason"), f"{prefix}.reason")
+        key = (executor, model_id)
+        if key in seen:
+            raise ValueError(f"model-identities packaged_overrides duplicate: {executor}/{model_id}")
+        seen.add(key)
+        overrides.append(
+            PackagedOverride(
+                executor=executor, model_id=model_id, action=action, reason=reason
+            )
+        )
+    return tuple(overrides)
+
+
+@dataclass(frozen=True)
+class ResolutionPolicy:
+    """解析政策（overlay 的 ``resolution_policy`` 區塊，全選填）。"""
+
+    packaged_fallback: str = PACKAGED_FALLBACK_WARN
+
+    def __post_init__(self) -> None:
+        if self.packaged_fallback not in PACKAGED_FALLBACK_POLICIES:
+            raise ValueError(
+                "model-identities resolution_policy.packaged_fallback invalid: "
+                f"{self.packaged_fallback!r}"
+            )
+
+    def to_dict(self) -> dict[str, object]:
+        return {"packaged_fallback": self.packaged_fallback}
+
+
+def parse_resolution_policy(value: object, *, default: str) -> ResolutionPolicy:
+    if value is None:
+        return ResolutionPolicy(packaged_fallback=default)
+    if not isinstance(value, Mapping):
+        raise ValueError("model-identities resolution_policy must be an object")
+    extras = set(value) - {"packaged_fallback"}
+    if extras:
+        raise ValueError(
+            f"model-identities resolution_policy.{sorted(extras)[0]} unexpected"
+        )
+    raw = value.get("packaged_fallback")
+    if raw is None:
+        return ResolutionPolicy(packaged_fallback=default)
+    return ResolutionPolicy(
+        packaged_fallback=_nonempty(raw, "model-identities resolution_policy.packaged_fallback")
+    )
+
+
+@dataclass(frozen=True)
+class ResolutionNote:
+    """載入期留下的解析診斷（doctor／log 消費，不影響推進邏輯）。"""
+
+    code: str
+    severity: str  # "info" | "warn" | "fail"
+    detail: str
+
+    def __post_init__(self) -> None:
+        if self.severity not in {"info", "warn", "fail"}:
+            raise ValueError(f"resolution note severity invalid: {self.severity!r}")
+
+    def to_dict(self) -> dict[str, object]:
+        return {"code": self.code, "severity": self.severity, "detail": self.detail}
+
+
+@dataclass(frozen=True)
+class ResolutionContext:
+    """一次 registry 載入所帶的解析上下文（政策＋第 2 層清單＋診斷）。"""
+
+    policy: ResolutionPolicy = field(default_factory=ResolutionPolicy)
+    eval_roster: EvalRoster = field(default_factory=EvalRoster)
+    packaged_overrides: tuple[PackagedOverride, ...] = ()
+    notes: tuple[ResolutionNote, ...] = ()
+    config_root: str | None = None
+    overlay_present: bool = False
+
+    def with_notes(self, extra: Iterable[ResolutionNote]) -> "ResolutionContext":
+        return ResolutionContext(
+            policy=self.policy,
+            eval_roster=self.eval_roster,
+            packaged_overrides=self.packaged_overrides,
+            notes=self.notes + tuple(extra),
+            config_root=self.config_root,
+            overlay_present=self.overlay_present,
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "policy": self.policy.to_dict(),
+            "eval_roster": self.eval_roster.to_dict(),
+            "packaged_overrides": [item.to_dict() for item in self.packaged_overrides],
+            "notes": [item.to_dict() for item in self.notes],
+            "config_root": self.config_root,
+            "overlay_present": self.overlay_present,
+        }
+
+
+#: 手工建構的 registry（測試替身、程式內組裝）沒有 loader 蓋章，一律視為
+#: 「呼叫端自行宣告」＝第 1 層，維持 #534 之前的既有順序語意。
+DEFAULT_CONTEXT = ResolutionContext(policy=ResolutionPolicy(PACKAGED_FALLBACK_ALLOW))
+
+
+# ---------------------------------------------------------------------------
+# 解析：分層、排序、政策
+# ---------------------------------------------------------------------------
+
+
+def identity_origin(identity: object) -> str:
+    origin = getattr(identity, "origin", None)
+    return origin if origin in IDENTITY_ORIGINS else IDENTITY_ORIGIN_OVERLAY
+
+
+def identity_layer(
+    identity: object, *, role: str, eval_roster: EvalRoster | None = None
+) -> str | None:
+    """(identity, role) → 解析層；``None`` 代表被 operator park（不可解析）。"""
+
+    if getattr(identity, "operator_action", None) == PACKAGED_ACTION_PARK:
+        return None
+    if identity_origin(identity) == IDENTITY_ORIGIN_OVERLAY:
+        return RESOLUTION_LAYER_OVERLAY
+    roster = eval_roster or EvalRoster()
+    if roster.approves(
+        getattr(identity, "executor", ""), getattr(identity, "model_id", ""), role
+    ):
+        return RESOLUTION_LAYER_EVALUATED
+    return RESOLUTION_LAYER_PACKAGED
+
+
+@dataclass(frozen=True)
+class RankedCandidates:
+    """分層排序後的候選清單＋可觀測的排除理由與警示。"""
+
+    ordered: tuple
+    layers: Mapping[tuple[str, str], str]
+    excluded: tuple[tuple[object, str], ...] = ()
+    warnings: tuple[str, ...] = ()
+
+    def layer_of(self, identity: object) -> str | None:
+        return self.layers.get(
+            (getattr(identity, "executor", ""), getattr(identity, "model_id", ""))
+        )
+
+    def exclusion_detail(self) -> str:
+        return "; ".join(
+            f"{getattr(item, 'executor', '?')}/{getattr(item, 'model_id', '?')}: {reason}"
+            for item, reason in self.excluded
+        )
+
+
+def rank_candidates(
+    candidates: Sequence,
+    *,
+    role: str,
+    context: ResolutionContext | None = None,
+) -> RankedCandidates:
+    """把既有候選清單重排成三層解析鏈的順序，並套用 packaged fallback 政策。
+
+    排序為 **stable**：層級是主鍵，同層內完全維持呼叫端傳進來的既有順序——
+    #452 的 measured 側寫優先、#262 的 primary_domain 偏好因此降級為同層內的
+    次要偏好，不再有機會把 operator 的人工指定擠到後面（#534 主訴）。
+    """
+
+    ctx = context or DEFAULT_CONTEXT
+    roster = ctx.eval_roster
+    excluded: list[tuple[object, str]] = []
+    warnings: list[str] = []
+    layers: dict[tuple[str, str], str] = {}
+    ranked: list[tuple[int, int, int, object]] = []
+    for index, identity in enumerate(candidates):
+        layer = identity_layer(identity, role=role, eval_roster=roster)
+        if layer is None:
+            excluded.append((identity, "operator overlay parked this packaged identity"))
+            continue
+        if (
+            layer == RESOLUTION_LAYER_PACKAGED
+            and ctx.policy.packaged_fallback == PACKAGED_FALLBACK_DENY
+        ):
+            excluded.append(
+                (
+                    identity,
+                    "packaged-fallback denied by resolution_policy: 先經 patchmud eval "
+                    "並人工複核加入 model-eval-roster.yaml，或列入 host overlay",
+                )
+            )
+            continue
+        demoted = 1 if getattr(identity, "operator_action", None) == PACKAGED_ACTION_DEMOTE else 0
+        layers[
+            (getattr(identity, "executor", ""), getattr(identity, "model_id", ""))
+        ] = layer
+        ranked.append((_LAYER_RANK[layer], demoted, index, identity))
+    ranked.sort(key=lambda row: (row[0], row[1], row[2]))
+    ordered = tuple(row[3] for row in ranked)
+    if ordered:
+        top = ordered[0]
+        top_layer = layers[
+            (getattr(top, "executor", ""), getattr(top, "model_id", ""))
+        ]
+        if (
+            top_layer == RESOLUTION_LAYER_PACKAGED
+            and ctx.policy.packaged_fallback == PACKAGED_FALLBACK_WARN
+        ):
+            warnings.append(
+                f"role={role} 解析落到 packaged-fallback："
+                f"{getattr(top, 'executor', '?')}/{getattr(top, 'model_id', '?')}"
+                "——該身分僅為候選宣告（未經 patchmud eval／人工複核）。"
+                "請列入 host overlay 或評估合格後加入 model-eval-roster.yaml。"
+            )
+    return RankedCandidates(
+        ordered=ordered,
+        layers=layers,
+        excluded=tuple(excluded),
+        warnings=tuple(warnings),
+    )

--- a/paulsha_cortex/coordinator/review.py
+++ b/paulsha_cortex/coordinator/review.py
@@ -76,9 +76,15 @@ def _normalize_identity(
 
 
 def load_model_identity_registry(config_root: str | Path | None = None) -> dict[tuple[str, str], dict[str, str]]:
-    return model_identities.load_model_identities(
-        config_root, use_packaged_default=False
-    ).legacy_mapping()
+    """#490：foreign review 與 manager／tick 必須解析**同一份**合併 registry。
+
+    舊實作 `use_packaged_default=False` 只讀 host overlay，於是 packaged 身分
+    （例如 claude/sonnet）在 retry-review 被判 `reviewer-identity-unknown`，
+    operator 只能把 packaged 那列逐欄複製進 overlay——複製回來又踩 #509 的
+    shadow 中止。兩邊改用同一個合併載入器後，這條矛盾一併消失。
+    """
+
+    return model_identities.load_model_identities(config_root).legacy_mapping()
 
 
 def read_repo_tier(repo_root: str | Path | None = None) -> str:

--- a/paulsha_cortex/coordinator/work_bridge.py
+++ b/paulsha_cortex/coordinator/work_bridge.py
@@ -39,6 +39,7 @@ from .claim import (
     sizing_band,
     work_authority_digest,
 )
+from . import model_resolution
 from .diagnostics import diagnostic_reason
 from .github_delivery import GitHubDeliveryClient
 from .model_identities import IdentityRegistry, load_model_identities
@@ -487,10 +488,18 @@ def start_canonical_workflow(
     planning = [identity for identity in identities.identities if "planning" in identity.capabilities]
     if not planning:
         raise RuntimeError("no primary planning identity configured")
-    primary = next(
-        (identity for executor in ("codex", "claude", "agy") for identity in planning if identity.executor == executor),
-        planning[0],
+    # #534：primary planner 改依三層解析鏈挑（operator overlay → 評估合格清單 →
+    # packaged fallback）。舊實作寫死 executor 順序 ("codex", "claude", "agy")，
+    # 與 operator 在 host overlay 宣告的順序無關——人工指定形同不存在。
+    ranked = model_resolution.rank_candidates(
+        planning, role="planning", context=identities.resolution_context
     )
+    if not ranked.ordered:
+        raise RuntimeError(
+            "no resolvable primary planning identity"
+            f"（{ranked.exclusion_detail()}）"
+        )
+    primary = ranked.ordered[0]
     from . import manager
 
     result = manager.apply_workflow_action(

--- a/paulsha_cortex/coordinator/workflow.py
+++ b/paulsha_cortex/coordinator/workflow.py
@@ -22,13 +22,22 @@ STEP_GATE_RESULTS = frozenset({"pending", "running", "passed", "failed", "needs_
 # #205：run-scoped 模型鏈覆寫／解析結果三段固定為 planner／builder／reviewer，
 # 與 WorkflowStep.persona 的合法值對齊（見 deck.schema 對 persona 的定義）。
 MODEL_CHAIN_PERSONAS = frozenset({"planner", "builder", "reviewer"})
-# #452 C：source 值域擴充——"patchmud-profile"（該段身分帶該 persona 的實測
-# 側寫）／"default-envelope"（查表投影落在 DEFAULT_ENVELOPE 保守預設）。
-# "registry" 保留為既有 run 的 legacy 值（#452 前的紀錄照舊可載入）；新紀錄
-# 一律記 override／patchmud-profile／default-envelope 三者之一。
-MODEL_CHAIN_RESOLUTION_SOURCES = frozenset(
+# #534：source 改記**解析層** provenance——"run-override"（run-scoped 覆寫）／
+# "operator-overlay"（host overlay 人工指定）／"evaluated-roster"（patchmud 評估
+# 合格＋人工複核）／"packaged-fallback"（未評估候選池，fail-loud）。封套來源移到
+# 選配的 "envelope_source" 欄位（"measured"／"default"）。
+# legacy 值（"override"／"registry"／"patchmud-profile"／"default-envelope"）保留
+# 於值域內，讓 #534 之前寫下的 run 紀錄照舊可載入；新紀錄一律記解析層。
+MODEL_CHAIN_RESOLUTION_LAYERS = frozenset(
+    {"run-override", "operator-overlay", "evaluated-roster", "packaged-fallback"}
+)
+MODEL_CHAIN_RESOLUTION_LEGACY_SOURCES = frozenset(
     {"override", "registry", "patchmud-profile", "default-envelope"}
 )
+MODEL_CHAIN_RESOLUTION_SOURCES = (
+    MODEL_CHAIN_RESOLUTION_LAYERS | MODEL_CHAIN_RESOLUTION_LEGACY_SOURCES
+)
+MODEL_CHAIN_ENVELOPE_SOURCES = frozenset({"measured", "default"})
 COMBO_SELECTION_SOURCES = frozenset({"task-type-auto", "explicit-override", "bypass-default"})
 
 
@@ -53,9 +62,12 @@ def _validate_model_chain_override(value: object, *, field_name: str) -> None:
 
 
 def _validate_model_chain_resolution(value: object, *, field_name: str) -> None:
-    """#205 D5／#452 C：解析結果稽核紀錄——{persona: {executor, model_id,
-    independence_domain, source}}，source ∈ MODEL_CHAIN_RESOLUTION_SOURCES
-    （override／registry(legacy)／patchmud-profile／default-envelope）。"""
+    """#205 D5／#452 C／#534：解析結果稽核紀錄——{persona: {executor, model_id,
+    independence_domain, source, envelope_source?}}。
+
+    ``source`` ∈ MODEL_CHAIN_RESOLUTION_SOURCES（#534 的四個解析層，外加
+    #534 之前的 legacy 值以便舊 run 紀錄照舊可載入）；``envelope_source`` 為
+    #534 新增的**選配**欄位，缺席即為 #534 之前的紀錄。"""
     if value is None:
         return
     if not isinstance(value, dict):
@@ -64,8 +76,18 @@ def _validate_model_chain_resolution(value: object, *, field_name: str) -> None:
     for persona, row in value.items():
         if persona not in MODEL_CHAIN_PERSONAS:
             raise ValueError(f"workflow run {field_name} persona 非法: {persona!r}")
-        if not isinstance(row, dict) or set(row) != required_keys:
+        if not isinstance(row, dict) or not required_keys <= set(row):
             raise ValueError(f"workflow run {field_name}[{persona!r}] 格式錯誤")
+        if set(row) - (required_keys | {"envelope_source"}):
+            raise ValueError(f"workflow run {field_name}[{persona!r}] 格式錯誤")
+        if (
+            "envelope_source" in row
+            and row["envelope_source"] not in MODEL_CHAIN_ENVELOPE_SOURCES
+        ):
+            raise ValueError(
+                f"workflow run {field_name}[{persona!r}].envelope_source 非法: "
+                f"{row.get('envelope_source')!r}"
+            )
         for key in ("executor", "model_id", "independence_domain"):
             if not isinstance(row.get(key), str) or not row[key]:
                 raise ValueError(f"workflow run {field_name}[{persona!r}].{key} 必須為非空字串")

--- a/paulsha_cortex/doctor.py
+++ b/paulsha_cortex/doctor.py
@@ -271,6 +271,99 @@ def _identity_probe(env: Mapping[str, str], agents_root: Path) -> ProbeResult:
     )
 
 
+def _model_resolution_probe(env: Mapping[str, str], agents_root: Path) -> ProbeResult:
+    """#534／#509：診斷「overlay 宣告」與「生效解析」不一致。
+
+    #509 的假 PASS 有兩個成因：doctor 只驗 registry 載得起來，不驗**解析結果**；
+    而且沒有把自己讀的 config root 說出來，operator 無從發現 doctor 與 daemon
+    讀的根本是兩份檔案。本 probe 兩者都補：走與 tick 同一個合併載入器，跑與
+    manager 同一個 `model_resolution.rank_candidates`，並在 detail 裡明示
+    config root。
+    """
+
+    config_root = Path(
+        env.get("PSC_PROJECT_CONFIG_ROOT", str(agents_root / "config" / "paulsha"))
+    ).expanduser()
+    try:
+        from .coordinator import model_resolution
+        from .coordinator.model_identities import load_model_identities
+
+        registry = load_model_identities(config_root)
+    except Exception:
+        # registry 本身載不起來由 model-identities probe 負責報告，這裡不重複噪音。
+        return ProbeResult(
+            "model-resolution",
+            "fail",
+            f"identity registry unavailable at {config_root}; see model-identities probe",
+            True,
+        )
+    context = registry.resolution_context
+    failures: list[str] = []
+    warnings: list[str] = []
+    for note in context.notes:
+        if note.severity == "fail":
+            failures.append(f"{note.code}: {note.detail}")
+        elif note.severity == "warn":
+            warnings.append(f"{note.code}: {note.detail}")
+    summary: list[str] = []
+    for persona, role in sorted(model_resolution.ROLE_BY_PERSONA.items()):
+        candidates = [
+            identity for identity in registry.identities if role in identity.capabilities
+        ]
+        ranked = model_resolution.rank_candidates(
+            candidates, role=role, context=context
+        )
+        if not ranked.ordered:
+            failures.append(
+                f"{persona}: 無可解析身分（{ranked.exclusion_detail() or 'no candidate declared'}）"
+            )
+            continue
+        top = ranked.ordered[0]
+        layer = ranked.layer_of(top)
+        summary.append(f"{persona}={top.executor}/{top.model_id}[{layer}]")
+        overlay_declared = [
+            identity
+            for identity in candidates
+            if model_resolution.identity_origin(identity)
+            == model_resolution.IDENTITY_ORIGIN_OVERLAY
+        ]
+        if layer != model_resolution.RESOLUTION_LAYER_OVERLAY and overlay_declared:
+            # 不變式守衛：overlay 宣告了這個角色，生效解析就必須落在第 1 層。
+            # #534 之前正是這條不成立（packaged roster 的內建列序壓過人工指定），
+            # 而 doctor 只驗 registry 載得起來、驗不到解析結果，於是回報 PASS。
+            failures.append(
+                f"{persona}: overlay 宣告 "
+                + ", ".join(f"{i.executor}/{i.model_id}" for i in overlay_declared)
+                + f"，生效解析卻是 {top.executor}/{top.model_id}[{layer}]"
+            )
+        elif layer == model_resolution.RESOLUTION_LAYER_PACKAGED:
+            warnings.append(
+                f"{persona}: 解析落在 packaged 候選 {top.executor}/{top.model_id}"
+                "（未經 patchmud eval／人工複核）"
+            )
+    for entry in context.eval_roster.entries:
+        if registry.get(entry.executor, entry.model_id) is None:
+            warnings.append(
+                f"model-eval-roster 列出的 {entry.executor}/{entry.model_id} 不在 registry 內"
+                "（清單過期或身分已下架）"
+            )
+    detail_tail = f"（config root: {config_root}）"
+    if failures:
+        return ProbeResult(
+            "model-resolution", "fail", "; ".join(failures) + detail_tail, True
+        )
+    if warnings:
+        return ProbeResult(
+            "model-resolution", "warn", "; ".join(warnings) + detail_tail, False
+        )
+    return ProbeResult(
+        "model-resolution",
+        "pass",
+        "resolution chain consistent: " + ", ".join(summary) + detail_tail,
+        True,
+    )
+
+
 def _identity_failure_detail(exc: BaseException) -> str:
     message = str(exc).lower()
     if "model-identities missing" in message:
@@ -945,6 +1038,7 @@ def run_doctor(
         _preflight_probe(effective),
         _gate_declaration_probe(effective),
         _identity_probe(effective, agents_root),
+        _model_resolution_probe(effective, agents_root),
         _review_sandbox_probe(
             effective,
             agents_root,

--- a/paulsha_cortex/porcelain/inspect.py
+++ b/paulsha_cortex/porcelain/inspect.py
@@ -313,6 +313,7 @@ def _run_models(*, json_output: bool) -> int:
         ceiling = envelope.get("invariant_ceiling")
         sys.stdout.write(
             f"{row['executor']}/{row['model_id']}\t{row['persona']}\t"
+            f"layer={row.get('resolution_layer')}\t"
             f"accepts_bands={envelope.get('accepts_bands')}({source.get('accepts_bands')})\t"
             f"invariant_ceiling={'∅(bypass)' if ceiling is None else ceiling}"
             f"({source.get('invariant_ceiling')})\t"

--- a/tests/test_coordinator_foreign_review.py
+++ b/tests/test_coordinator_foreign_review.py
@@ -128,8 +128,12 @@ class ModelIdentityRegistryTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as d:
             config_root = Path(d)
 
-            with self.assertRaisesRegex(ValueError, "model-identities"):
-                review.load_model_identity_registry(config_root)
+            # #490／#534：foreign review 改走與 manager／tick 相同的合併載入器，
+            # 因此「沒有 host overlay」是合法部署（packaged 候選池即全部身分），
+            # 不再是錯誤；overlay 檔案本身的嚴格性（重複列、未知欄位、重複 key）
+            # 逐項不變。
+            packaged_only = review.load_model_identity_registry(config_root)
+            self.assertIn(("claude", "sonnet"), packaged_only)
 
             _write_model_identities(
                 config_root,

--- a/tests/test_model_chain_profile_resolution.py
+++ b/tests/test_model_chain_profile_resolution.py
@@ -110,10 +110,13 @@ def test_overlay_builder_survives_packaged_primary_domain_preference(tmp_path: P
         _run(primary_domain="anthropic"), _step("builder"), roster
     )
     keys = [(item.executor, item.model_id) for item in candidates]
-    # 偏好仍是偏好：同 domain 的 packaged 身分排前。
-    assert keys[0] == ("claude", "sonnet")
-    # overlay builder 不被剔除（v0.1.6 部署的實際可跑 builder 保住 fallback）。
-    assert ("codex", "gpt-5.4") in keys
+    # #534：解析層是排序主鍵——operator 在 host overlay 指定的 builder 排第一，
+    # primary_domain 偏好降級為**同層內**的次要偏好，不再有機會讓 packaged 候選
+    # （僅為候選宣告、未經評估）壓過人工指定。
+    assert keys[0] == ("codex", "gpt-5.4")
+    # packaged 候選仍保留在後（#262 preflight re-route 的 fallback 不丟）。
+    assert ("claude", "sonnet") in keys
+    assert keys.index(("codex", "gpt-5.4")) < keys.index(("claude", "sonnet"))
 
 
 def test_measured_band_filter_excludes_with_observable_reason(caplog) -> None:
@@ -172,17 +175,21 @@ class _RecordingRegistry:
 
 
 def test_resolved_model_chain_source_distinguishes_profile_and_default() -> None:
+    # #534：`source` 改記解析層，封套來源移到 `envelope_source`。REGISTRY 為手工
+    # 建構（無 loader 蓋章）→ 一律視為 operator 指定的第 1 層。
     registry = _RecordingRegistry()
     run = _run(sizing_band="green")
     measured_identity = REGISTRY.require("claude", "sonnet")
     manager._record_resolved_model_chain(registry, run, _step("builder"), measured_identity)
     resolved = registry.calls[-1][1]["resolved_model_chain"]
-    assert resolved["builder"]["source"] == "patchmud-profile"
+    assert resolved["builder"]["source"] == "operator-overlay"
+    assert resolved["builder"]["envelope_source"] == "measured"
 
     default_identity = REGISTRY.require("copilot", "gpt-5.4")
     manager._record_resolved_model_chain(registry, run, _step("builder"), default_identity)
     resolved = registry.calls[-1][1]["resolved_model_chain"]
-    assert resolved["builder"]["source"] == "default-envelope"
+    assert resolved["builder"]["source"] == "operator-overlay"
+    assert resolved["builder"]["envelope_source"] == "default"
 
     override_run = _run(
         sizing_band="green",
@@ -192,11 +199,20 @@ def test_resolved_model_chain_source_distinguishes_profile_and_default() -> None
         registry, override_run, _step("builder"), measured_identity
     )
     resolved = registry.calls[-1][1]["resolved_model_chain"]
-    assert resolved["builder"]["source"] == "override"
+    assert resolved["builder"]["source"] == "run-override"
 
 
 def test_workflow_validation_accepts_new_and_legacy_sources() -> None:
-    for source in ("override", "registry", "patchmud-profile", "default-envelope"):
+    for source in (
+        "override",
+        "registry",
+        "patchmud-profile",
+        "default-envelope",
+        "run-override",
+        "operator-overlay",
+        "evaluated-roster",
+        "packaged-fallback",
+    ):
         workflow._validate_model_chain_resolution(
             {
                 "builder": {

--- a/tests/test_model_identities.py
+++ b/tests/test_model_identities.py
@@ -176,13 +176,18 @@ identities:
         encoding="utf-8",
     )
 
-    assert review.load_model_identity_registry(tmp_path) == {
-        ("agy", AGY_MODEL_ID): {
-            "executor": "agy",
-            "model_id": AGY_MODEL_ID,
-            "independence_domain": "google",
-        }
+    mapping = review.load_model_identity_registry(tmp_path)
+
+    # legacy 投影只帶三欄，不外洩 capabilities／live_probe 等 planner metadata。
+    assert mapping[("agy", AGY_MODEL_ID)] == {
+        "executor": "agy",
+        "model_id": AGY_MODEL_ID,
+        "independence_domain": "google",
     }
+    # #490：foreign review 改用與 manager／tick 同一份合併 registry，packaged
+    # 身分不必再被複製進 host overlay 才解析得到。
+    assert ("claude", "sonnet") in mapping
+    assert all(set(row) == {"executor", "model_id", "independence_domain"} for row in mapping.values())
 
 
 def test_agy_probe_requires_model_listing_and_safe_headless_smoke() -> None:

--- a/tests/test_model_resolution_chain_534.py
+++ b/tests/test_model_resolution_chain_534.py
@@ -1,0 +1,851 @@
+"""#534：模型引擎三層解析鏈（operator overlay → 評估合格清單 → packaged 候選池）。
+
+現場（issue #534）：packaged roster 的註解明載「列序即候選優先序：agy 維持首位，
+保住既有 planner 熱路徑選擇不變」，於是 planner 解析到 `agy/gemini-3.1-pro-high`
+——而 operator 當日在 host overlay 宣告的可用引擎清單**根本不含**它。人工指定被
+內建列序壓過，未評估的候選宣告佔住 planner 熱路徑。
+
+本檔同時收編三個相鄰現場：
+- #509：overlay shadow packaged 直接 `raise ValueError` 打掛 periodic tick；
+  doctor 卻回報 PASS。
+- #490：retry-review 只載 host overlay，packaged 身分被判 unknown。
+- #475：operator 自訂的 Claude-compatible 身分不得被 packaged 同 executor 身分
+  靜默取代（executable 綁定屬 launcher 層，本票不做）。
+
+測試 fixture 一律比照 operator 現行部署：agy 的 capabilities 為 `[build]`
+（#568 暫時下架 review），**不假設 agy 有 review**。
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from paulsha_cortex.coordinator import manager, model_resolution, workflow
+from paulsha_cortex.coordinator.model_identities import (
+    AGY_MODEL_ID,
+    CapabilityProbe,
+    IdentityRegistry,
+    load_model_identities,
+    select_secondary_planner,
+)
+
+# operator 於 2026-08-14 實際部署的 overlay（#534／#509 的現場），逐列照抄：
+# build：copilot/MAI-Code-1.1-Flash、codex/gpt-5.6-luna、agy（#568 後只剩 build）
+# planning/review：claude/claude-opus-5
+_OPERATOR_OVERLAY = """\
+schema_version: 3
+identities:
+  - executor: claude
+    model_id: claude-opus-5
+    independence_domain: anthropic
+    capabilities: [planning, review]
+  - executor: codex
+    model_id: gpt-5.6-luna
+    independence_domain: openai
+    capabilities: [build]
+  - executor: copilot
+    model_id: MAI-Code-1.1-Flash
+    independence_domain: microsoft
+    capabilities: [build]
+  - executor: agy
+    model_id: gemini-3.6-flash-high
+    independence_domain: google
+    capabilities: [build]
+"""
+
+
+def _write(root: Path, name: str, text: str) -> None:
+    (root / name).write_text(text, encoding="utf-8")
+
+
+def _run(**kwargs):
+    defaults = {
+        "run_id": "run-534",
+        "steps": (),
+        "primary_domain": None,
+        "sizing_band": None,
+        "model_chain_override": None,
+    }
+    defaults.update(kwargs)
+    return SimpleNamespace(**defaults)
+
+
+def _step(persona: str):
+    return SimpleNamespace(persona=persona, phase="build", card="card")
+
+
+# ---------------------------------------------------------------------------
+# 第 1 層：overlay 絕對優先（#534 主訴）
+# ---------------------------------------------------------------------------
+
+
+def test_operator_overlay_outranks_packaged_roster_for_every_persona(tmp_path: Path) -> None:
+    _write(tmp_path, "model-identities.yaml", _OPERATOR_OVERLAY)
+    registry = load_model_identities(tmp_path)
+
+    for persona, expected in (
+        ("planner", ("claude", "claude-opus-5")),
+        ("builder", ("codex", "gpt-5.6-luna")),
+        ("reviewer", ("claude", "claude-opus-5")),
+    ):
+        identity = manager._select_workflow_identity(_run(), _step(persona), registry)
+        assert (identity.executor, identity.model_id) == expected, persona
+
+    # 修正前的實際行為：packaged 的 agy 佔住 planner 首位。這條釘住「不得回頭」。
+    planner = manager._select_workflow_identity(_run(), _step("planner"), registry)
+    assert (planner.executor, planner.model_id) != ("agy", AGY_MODEL_ID)
+
+
+def test_packaged_candidates_are_kept_as_lower_priority_fallback(tmp_path: Path) -> None:
+    """降級為候選池≠剔除：#262 的 preflight re-route 仍需要次佳候選。"""
+
+    _write(tmp_path, "model-identities.yaml", _OPERATOR_OVERLAY)
+    registry = load_model_identities(tmp_path)
+
+    candidates = manager._workflow_identity_candidates(_run(), _step("builder"), registry)
+    keys = [(item.executor, item.model_id) for item in candidates]
+    assert keys[0] == ("codex", "gpt-5.6-luna")
+    assert ("copilot", "gpt-5.4") in keys  # packaged 候選仍在，但排在 overlay 之後
+    overlay_keys = {("codex", "gpt-5.6-luna"), ("copilot", "MAI-Code-1.1-Flash"), ("agy", "gemini-3.6-flash-high")}
+    last_overlay = max(keys.index(key) for key in overlay_keys if key in keys)
+    assert keys.index(("copilot", "gpt-5.4")) > last_overlay
+
+
+def test_primary_domain_preference_no_longer_outranks_operator_overlay(tmp_path: Path) -> None:
+    """#452 的 primary_domain 偏好降級為**同層內**的次要偏好。"""
+
+    _write(tmp_path, "model-identities.yaml", _OPERATOR_OVERLAY)
+    registry = load_model_identities(tmp_path)
+
+    # primary_domain=anthropic 會把 packaged 的 claude/sonnet 排到 packaged 層之首，
+    # 但整個 packaged 層仍在 overlay 層之後。
+    candidates = manager._workflow_identity_candidates(
+        _run(primary_domain="anthropic"), _step("builder"), registry
+    )
+    keys = [(item.executor, item.model_id) for item in candidates]
+    assert keys[0] == ("codex", "gpt-5.6-luna")
+    assert keys.index(("codex", "gpt-5.6-luna")) < keys.index(("claude", "sonnet"))
+
+
+def test_secondary_planner_is_not_pinned_to_agy_anymore(tmp_path: Path) -> None:
+    """`PLANNER_PRIORITY` 寫死 agy 首位、且只認三組 (executor, domain)。
+
+    overlay 宣告的 planner 若不在那三組裡（例如 cg），舊實作**永遠不可達**。
+    """
+
+    _write(
+        tmp_path,
+        "model-identities.yaml",
+        """\
+schema_version: 3
+identities:
+  - executor: cg
+    model_id: glm-5.3
+    independence_domain: zhipu
+    capabilities: [planning]
+  - executor: claude
+    model_id: claude-opus-5
+    independence_domain: anthropic
+    capabilities: [planning]
+""",
+    )
+    registry = load_model_identities(tmp_path)
+    probes = {
+        ("cg", "glm-5.3"): CapabilityProbe.ready_for("cg", "glm-5.3", "zhipu"),
+        ("claude", "claude-opus-5"): CapabilityProbe.ready_for(
+            "claude", "claude-opus-5", "anthropic"
+        ),
+        ("agy", AGY_MODEL_ID): CapabilityProbe.ready_for("agy", AGY_MODEL_ID, "google"),
+    }
+
+    selection = select_secondary_planner(
+        registry=registry, primary=("codex", "gpt-5.3-codex-spark"), probes=probes
+    )
+
+    assert selection.state == "ready"
+    assert selection.identity is not None
+    assert (selection.identity.executor, selection.identity.model_id) == ("cg", "glm-5.3")
+
+
+def test_packaged_only_deployment_keeps_packaged_roster_order(tmp_path: Path) -> None:
+    """沒有 overlay 的部署＝operator 未宣告任何東西：packaged 順序照舊，
+    fallback 政策為 allow（不吵），但 provenance 仍如實標記第 3 層。"""
+
+    registry = load_model_identities(tmp_path)
+
+    assert registry.resolution_context.policy.packaged_fallback == "allow"
+    planner = manager._select_workflow_identity(_run(), _step("planner"), registry)
+    assert (planner.executor, planner.model_id) == ("agy", AGY_MODEL_ID)
+    assert (
+        manager._resolution_layer_for(planner, "planner", registry)
+        == model_resolution.RESOLUTION_LAYER_PACKAGED
+    )
+
+
+# ---------------------------------------------------------------------------
+# 第 2 層：patchmud 評估合格清單（model-eval-roster.yaml）
+# ---------------------------------------------------------------------------
+
+_EVAL_ROSTER = """\
+schema_version: 1
+entries:
+  - executor: claude
+    model_id: sonnet
+    roles: [build, review]
+    verdict: pass
+    evaluated_at: "2026-08-14"
+    eval_source: patchmud
+    eval_ref: patchmud-deck-v1/report-2026-08-14
+    review_status: approved
+    reviewer: operator
+    reviewed_at: "2026-08-14"
+  - executor: cg
+    model_id: glm-5.2
+    roles: [planning, review]
+    verdict: pass
+    evaluated_at: "2026-08-13"
+    eval_source: patchmud
+    review_status: pending
+"""
+
+
+def test_evaluated_roster_ranks_between_overlay_and_packaged(tmp_path: Path) -> None:
+    _write(
+        tmp_path,
+        "model-identities.yaml",
+        """\
+schema_version: 3
+identities:
+  - executor: codex
+    model_id: gpt-5.6-luna
+    independence_domain: openai
+    capabilities: [build]
+""",
+    )
+    _write(tmp_path, "model-eval-roster.yaml", _EVAL_ROSTER)
+    registry = load_model_identities(tmp_path)
+
+    candidates = manager._workflow_identity_candidates(_run(), _step("builder"), registry)
+    keys = [(item.executor, item.model_id) for item in candidates]
+
+    # 1. overlay；2. 評估合格且人工複核通過的 packaged claude/sonnet；3. 其餘 packaged。
+    assert keys[0] == ("codex", "gpt-5.6-luna")
+    assert keys[1] == ("claude", "sonnet")
+    assert keys.index(("claude", "sonnet")) < keys.index(("copilot", "gpt-5.4"))
+    assert (
+        manager._resolution_layer_for(candidates[1], "builder", registry)
+        == model_resolution.RESOLUTION_LAYER_EVALUATED
+    )
+
+
+def test_evaluation_without_human_review_does_not_qualify(tmp_path: Path) -> None:
+    """裁決第 3 條的閘門：評估過≠人工核可，`review_status: pending` 不入第 2 層。"""
+
+    _write(tmp_path, "model-eval-roster.yaml", _EVAL_ROSTER)
+    registry = load_model_identities(tmp_path)
+    roster = registry.resolution_context.eval_roster
+
+    assert roster.approves("claude", "sonnet", "build") is True
+    assert roster.approves("cg", "glm-5.2", "planning") is False
+    assert roster.approves("claude", "sonnet", "planning") is False  # 角色不符
+    assert [entry.key for entry in roster.pending_entries()] == [("cg", "glm-5.2")]
+
+
+def test_eval_roster_requires_auditable_human_review_marker() -> None:
+    with pytest.raises(ValueError, match="requires reviewer and reviewed_at"):
+        model_resolution.parse_eval_roster(
+            {
+                "schema_version": 1,
+                "entries": [
+                    {
+                        "executor": "claude",
+                        "model_id": "sonnet",
+                        "roles": ["build"],
+                        "verdict": "pass",
+                        "evaluated_at": "2026-08-14",
+                        "eval_source": "patchmud",
+                        "review_status": "approved",
+                    }
+                ],
+            }
+        )
+
+
+def test_eval_roster_is_strict_and_fail_closed() -> None:
+    base = {
+        "executor": "claude",
+        "model_id": "sonnet",
+        "roles": ["build"],
+        "verdict": "pass",
+        "evaluated_at": "2026-08-14",
+        "eval_source": "patchmud",
+        "review_status": "approved",
+        "reviewer": "operator",
+        "reviewed_at": "2026-08-14",
+    }
+    for mutation, match in (
+        ({"unexpected": "boom"}, "unexpected"),
+        ({"verdict": "maybe"}, "verdict invalid"),
+        ({"review_status": "ok"}, "review_status invalid"),
+        ({"roles": ["deploy"]}, "roles invalid"),
+    ):
+        with pytest.raises(ValueError, match=match):
+            model_resolution.parse_eval_roster(
+                {"schema_version": 1, "entries": [{**base, **mutation}]}
+            )
+    with pytest.raises(ValueError, match="schema_version"):
+        model_resolution.parse_eval_roster({"schema_version": 2, "entries": []})
+    with pytest.raises(ValueError, match="duplicate entry"):
+        model_resolution.parse_eval_roster(
+            {"schema_version": 1, "entries": [dict(base), dict(base)]}
+        )
+
+
+def test_broken_eval_roster_degrades_instead_of_killing_the_tick(tmp_path: Path) -> None:
+    """#509 的教訓：設定資料問題不得讓整條調度迴圈停止。
+
+    壞掉的清單只會讓第 2 層變空（保守方向），並留下 fail 級診斷給 doctor。
+    """
+
+    _write(tmp_path, "model-identities.yaml", _OPERATOR_OVERLAY)
+    _write(tmp_path, "model-eval-roster.yaml", "schema_version: 1\nentries:\n  - boom\n")
+
+    registry = load_model_identities(tmp_path)  # 不得丟例外
+
+    roster = registry.resolution_context.eval_roster
+    assert roster.entries == ()
+    assert roster.load_error is not None
+    assert any(
+        note.code == "eval-roster-unreadable" and note.severity == "fail"
+        for note in registry.resolution_context.notes
+    )
+    # 解析照常運作，operator 的人工指定不受影響。
+    identity = manager._select_workflow_identity(_run(), _step("builder"), registry)
+    assert (identity.executor, identity.model_id) == ("codex", "gpt-5.6-luna")
+
+
+# ---------------------------------------------------------------------------
+# #509：shadow 不再打掛 tick；overlay 可 demote／park packaged 身分
+# ---------------------------------------------------------------------------
+
+
+def test_overlay_shadowing_packaged_no_longer_aborts_the_load(tmp_path: Path) -> None:
+    """#509 現場：`claude/sonnet` 逐欄不等即 raise → tick 連續失敗 → 斷路器開。"""
+
+    _write(
+        tmp_path,
+        "model-identities.yaml",
+        """\
+schema_version: 3
+identities:
+  - executor: claude
+    model_id: sonnet
+    independence_domain: anthropic
+    capabilities: [review]
+""",
+    )
+
+    registry = load_model_identities(tmp_path)  # 修正前這行 raise ValueError
+
+    identity = registry.require("claude", "sonnet")
+    assert identity.capabilities == ("review",)  # 以 overlay 為準（人工指定優先）
+    assert identity.origin == model_resolution.IDENTITY_ORIGIN_OVERLAY
+    assert [note.code for note in registry.resolution_context.notes] == [
+        "unflagged-packaged-override"
+    ]
+    # 同鍵只登錄一次，不會出現 overlay／packaged 兩份。
+    assert sum(
+        1
+        for item in registry.identities
+        if (item.executor, item.model_id) == ("claude", "sonnet")
+    ) == 1
+
+
+def test_explicit_override_packaged_flag_is_the_sanctioned_syntax(tmp_path: Path) -> None:
+    _write(
+        tmp_path,
+        "model-identities.yaml",
+        """\
+schema_version: 3
+identities:
+  - executor: claude
+    model_id: sonnet
+    independence_domain: anthropic
+    capabilities: [review]
+    override_packaged: true
+""",
+    )
+
+    registry = load_model_identities(tmp_path)
+
+    assert [note.code for note in registry.resolution_context.notes] == ["packaged-override"]
+    assert all(note.severity == "info" for note in registry.resolution_context.notes)
+
+
+def test_overlay_can_park_and_demote_packaged_identities(tmp_path: Path) -> None:
+    _write(
+        tmp_path,
+        "model-identities.yaml",
+        _OPERATOR_OVERLAY
+        + """\
+packaged_overrides:
+  - executor: agy
+    model_id: gemini-3.1-pro-high
+    action: park
+    reason: operator 未核可此引擎
+  - executor: copilot
+    model_id: gpt-5.4
+    action: demote
+    reason: 尚未評估，僅供最後手段
+""",
+    )
+    registry = load_model_identities(tmp_path)
+
+    # park：身分仍在 registry（doctor 的 canonical 檢查不破），但不進候選。
+    assert registry.get("agy", AGY_MODEL_ID) is not None
+    planner_keys = [
+        (item.executor, item.model_id)
+        for item in manager._workflow_identity_candidates(_run(), _step("planner"), registry)
+    ]
+    assert ("agy", AGY_MODEL_ID) not in planner_keys
+
+    # demote：留在候選池但沉到同層最後。
+    builder_keys = [
+        (item.executor, item.model_id)
+        for item in manager._workflow_identity_candidates(_run(), _step("builder"), registry)
+    ]
+    assert builder_keys[-1] == ("copilot", "gpt-5.4")
+
+
+def test_packaged_overrides_are_fail_closed(tmp_path: Path) -> None:
+    _write(
+        tmp_path,
+        "model-identities.yaml",
+        _OPERATOR_OVERLAY
+        + """\
+packaged_overrides:
+  - executor: agy
+    model_id: does-not-exist
+    action: park
+    reason: typo
+""",
+    )
+    with pytest.raises(ValueError, match="不存在的 packaged 身分"):
+        load_model_identities(tmp_path)
+
+    _write(
+        tmp_path,
+        "model-identities.yaml",
+        """\
+schema_version: 3
+identities:
+  - executor: claude
+    model_id: sonnet
+    independence_domain: anthropic
+    capabilities: [review]
+    override_packaged: true
+packaged_overrides:
+  - executor: claude
+    model_id: sonnet
+    action: park
+    reason: 與 identities 矛盾
+""",
+    )
+    with pytest.raises(ValueError, match="同時宣告同一身分"):
+        load_model_identities(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# 第 3 層政策：fail-loud／fail-closed
+# ---------------------------------------------------------------------------
+
+
+def test_packaged_fallback_warns_when_resolution_falls_through(tmp_path: Path, caplog) -> None:
+    import logging
+
+    _write(
+        tmp_path,
+        "model-identities.yaml",
+        """\
+schema_version: 3
+identities:
+  - executor: codex
+    model_id: gpt-5.6-luna
+    independence_domain: openai
+    capabilities: [build]
+""",
+    )
+    registry = load_model_identities(tmp_path)
+    assert registry.resolution_context.policy.packaged_fallback == "warn"
+
+    with caplog.at_level(logging.WARNING, logger="paulsha_cortex.coordinator.manager"):
+        identity = manager._select_workflow_identity(_run(), _step("planner"), registry)
+
+    assert (identity.executor, identity.model_id) == ("agy", AGY_MODEL_ID)
+    assert "packaged-fallback" in caplog.text
+    assert (
+        manager._resolution_layer_for(identity, "planner", registry)
+        == model_resolution.RESOLUTION_LAYER_PACKAGED
+    )
+
+
+def test_deny_policy_fails_closed_with_actionable_message(tmp_path: Path) -> None:
+    _write(
+        tmp_path,
+        "model-identities.yaml",
+        """\
+schema_version: 3
+resolution_policy:
+  packaged_fallback: deny
+identities:
+  - executor: codex
+    model_id: gpt-5.6-luna
+    independence_domain: openai
+    capabilities: [build]
+""",
+    )
+    registry = load_model_identities(tmp_path)
+
+    # build 有 overlay 身分 → 照常解析。
+    identity = manager._select_workflow_identity(_run(), _step("builder"), registry)
+    assert (identity.executor, identity.model_id) == ("codex", "gpt-5.6-luna")
+
+    # planning 只剩 packaged 候選 → 不得靜默使用未核可模型。
+    with pytest.raises(ValueError) as excinfo:
+        manager._select_workflow_identity(_run(), _step("planner"), registry)
+    message = str(excinfo.value)
+    assert "no resolvable identity" in message
+    assert "model-eval-roster.yaml" in message
+
+
+def test_resolution_policy_value_is_validated(tmp_path: Path) -> None:
+    _write(
+        tmp_path,
+        "model-identities.yaml",
+        """\
+schema_version: 3
+resolution_policy:
+  packaged_fallback: sometimes
+identities: []
+""",
+    )
+    with pytest.raises(ValueError, match="packaged_fallback invalid"):
+        load_model_identities(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# provenance：resolved_model_chain 記錄解析層
+# ---------------------------------------------------------------------------
+
+
+class _RecordingRegistry:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict]] = []
+
+    def _manager_update_workflow_run(self, run_id, **kwargs):
+        self.calls.append((run_id, kwargs))
+        return SimpleNamespace(run_id=run_id, **kwargs)
+
+
+def test_resolved_model_chain_records_the_resolution_layer(tmp_path: Path) -> None:
+    _write(tmp_path, "model-identities.yaml", _OPERATOR_OVERLAY)
+    _write(tmp_path, "model-eval-roster.yaml", _EVAL_ROSTER)
+    identities = load_model_identities(tmp_path)
+    jobs = _RecordingRegistry()
+    run = _run()
+
+    for identity, expected in (
+        (identities.require("codex", "gpt-5.6-luna"), "operator-overlay"),
+        (identities.require("claude", "sonnet"), "evaluated-roster"),
+        (identities.require("copilot", "gpt-5.4"), "packaged-fallback"),
+    ):
+        manager._record_resolved_model_chain(
+            jobs, run, _step("builder"), identity, identities
+        )
+        row = jobs.calls[-1][1]["resolved_model_chain"]["builder"]
+        assert row["source"] == expected
+        assert row["envelope_source"] in {"measured", "default"}
+        # workflow 契約必須接受新值域（durable evidence 寫得進去）。
+        workflow._validate_model_chain_resolution(
+            jobs.calls[-1][1]["resolved_model_chain"], field_name="resolved_model_chain"
+        )
+
+
+def test_legacy_resolved_model_chain_rows_still_load() -> None:
+    """#534 之前寫下的 run 紀錄（無 envelope_source、legacy source）必須照舊可載入。"""
+
+    for source in ("override", "registry", "patchmud-profile", "default-envelope"):
+        workflow._validate_model_chain_resolution(
+            {
+                "builder": {
+                    "executor": "claude",
+                    "model_id": "sonnet",
+                    "independence_domain": "anthropic",
+                    "source": source,
+                }
+            },
+            field_name="resolved_model_chain",
+        )
+    with pytest.raises(ValueError, match="envelope_source 非法"):
+        workflow._validate_model_chain_resolution(
+            {
+                "builder": {
+                    "executor": "claude",
+                    "model_id": "sonnet",
+                    "independence_domain": "anthropic",
+                    "source": "operator-overlay",
+                    "envelope_source": "guessed",
+                }
+            },
+            field_name="resolved_model_chain",
+        )
+
+
+# ---------------------------------------------------------------------------
+# #490：retry-review 與 manager／tick 解析同一份 registry
+# ---------------------------------------------------------------------------
+
+
+def test_retry_review_resolves_packaged_identity_without_overlay_duplicate(
+    tmp_path: Path,
+) -> None:
+    """#490 復現：overlay 只宣告 builder，reviewer 用 packaged claude/sonnet。
+
+    修正前 `load_model_identity_registry` 走 `use_packaged_default=False`，
+    retry-review 記下 `reviewer-identity-unknown`；operator 只能把 packaged 那列
+    複製進 overlay，複製回來又踩 #509 的 shadow 中止——死結。
+    """
+
+    from paulsha_cortex.coordinator import review
+
+    _write(
+        tmp_path,
+        "model-identities.yaml",
+        """\
+schema_version: 3
+identities:
+  - executor: codex
+    model_id: gpt-5.6-luna
+    independence_domain: openai
+    capabilities: [build]
+""",
+    )
+
+    registry = review.load_model_identity_registry(tmp_path)
+    assert ("claude", "sonnet") in registry
+
+    decision = review.select_foreign_reviewer(
+        registry=registry,
+        builder_executor="codex",
+        builder_model_id="gpt-5.6-luna",
+        review_executor="claude",
+        review_model_id="sonnet",
+        tier="shareable",
+    )
+
+    assert decision["reason"] != "reviewer-identity-unknown"
+    assert decision["state"] == "ready"
+    assert decision["reviewer"]["model_id"] == "sonnet"
+
+
+def test_review_and_manager_see_the_same_identity_set(tmp_path: Path) -> None:
+    _write(tmp_path, "model-identities.yaml", _OPERATOR_OVERLAY)
+    from paulsha_cortex.coordinator import review
+
+    review_keys = set(review.load_model_identity_registry(tmp_path))
+    manager_keys = {
+        (item.executor, item.model_id) for item in load_model_identities(tmp_path).identities
+    }
+
+    assert review_keys == manager_keys
+
+
+# ---------------------------------------------------------------------------
+# #475：operator 自訂身分不得被 packaged 同 executor 身分靜默取代
+# ---------------------------------------------------------------------------
+
+
+def test_operator_declared_claude_compatible_identity_wins_its_slot(tmp_path: Path) -> None:
+    """#475 現場的解析層切片。
+
+    operator 用 Claude Code 介面但把 API 導向自架 Gemma4，於 overlay 宣告
+    `claude/gemma4-26b-a4b-nvfp4`。packaged roster 同 executor 有 `claude/sonnet`
+    ——若 packaged 內建列序仍能壓過人工指定，job record 的 model_id 就會與真實
+    provider 不一致（#475 的「靜默跑錯模型」）。本測試釘住：解析結果就是
+    operator 宣告的那顆，且 provenance 明示來自第 1 層。
+    （executable／launcher 綁定屬 launcher 層，仍為 #475 的未竟部分。）
+    """
+
+    _write(
+        tmp_path,
+        "model-identities.yaml",
+        """\
+schema_version: 3
+identities:
+  - executor: claude
+    model_id: gemma4-26b-a4b-nvfp4
+    independence_domain: self-hosted-gemma
+    capabilities: [build]
+""",
+    )
+    identities = load_model_identities(tmp_path)
+
+    identity = manager._select_workflow_identity(_run(), _step("builder"), identities)
+
+    assert (identity.executor, identity.model_id) == ("claude", "gemma4-26b-a4b-nvfp4")
+    assert identity.independence_domain == "self-hosted-gemma"
+    assert (
+        manager._resolution_layer_for(identity, "builder", identities)
+        == model_resolution.RESOLUTION_LAYER_OVERLAY
+    )
+
+
+# ---------------------------------------------------------------------------
+# 向後相容：既有 overlay 檔案不得因升級而失效
+# ---------------------------------------------------------------------------
+
+
+def test_existing_overlay_files_stay_valid_without_any_new_field(tmp_path: Path) -> None:
+    """新能力全為選配欄位：v1／v2／v3 既有檔案照載、照解析。"""
+
+    for text in (
+        "schema_version: 1\nidentities:\n  - executor: codex\n    model_id: gpt-primary\n"
+        "    independence_domain: openai\n",
+        "schema_version: 2\nidentities:\n  - executor: copilot\n    model_id: build-one\n"
+        "    independence_domain: microsoft\n    capabilities: [build]\n",
+        "schema_version: 3\nidentities:\n  - executor: codex\n    model_id: gpt-5.6-luna\n"
+        "    independence_domain: openai\n    capabilities: [build]\n",
+    ):
+        _write(tmp_path, "model-identities.yaml", text)
+        registry = load_model_identities(tmp_path)
+        assert registry.resolution_context.packaged_overrides == ()
+        assert registry.resolution_context.eval_roster.entries == ()
+        assert manager._workflow_identity_candidates(_run(), _step("builder"), registry)
+
+
+def test_hand_built_registries_keep_pre_534_ordering() -> None:
+    """程式內組裝的 registry（測試替身、其他呼叫端）沒有 loader 蓋章：
+    一律視為呼叫端自行宣告的第 1 層，順序與 #534 之前逐項相同。"""
+
+    registry = IdentityRegistry.from_rows(
+        [
+            {
+                "executor": "agy",
+                "model_id": AGY_MODEL_ID,
+                "independence_domain": "google",
+                "capabilities": ["planning"],
+                "live_probe": "agy-plan-sandbox",
+            },
+            {
+                "executor": "claude",
+                "model_id": "planner-two",
+                "independence_domain": "anthropic",
+                "capabilities": ["planning"],
+            },
+        ]
+    )
+
+    ranked = model_resolution.rank_candidates(
+        list(registry.identities), role="planning", context=registry.resolution_context
+    )
+
+    assert [(item.executor, item.model_id) for item in ranked.ordered] == [
+        ("agy", AGY_MODEL_ID),
+        ("claude", "planner-two"),
+    ]
+    assert ranked.warnings == ()
+
+
+# ---------------------------------------------------------------------------
+# doctor：診斷 overlay 宣告與生效解析不一致（#509 的假 PASS）
+# ---------------------------------------------------------------------------
+
+
+def test_doctor_resolution_probe_reports_layer_and_config_root(tmp_path: Path) -> None:
+    from paulsha_cortex.doctor import _model_resolution_probe
+
+    _write(tmp_path, "model-identities.yaml", _OPERATOR_OVERLAY)
+    result = _model_resolution_probe({"PSC_PROJECT_CONFIG_ROOT": str(tmp_path)}, tmp_path)
+
+    assert result.status == "pass"
+    assert "planner=claude/claude-opus-5[operator-overlay]" in result.detail
+    # #509：doctor 必須說出自己讀的是哪個 config root，否則與 daemon 讀不同檔案
+    # 也看不出來。
+    assert str(tmp_path) in result.detail
+
+
+def test_doctor_resolution_probe_flags_broken_eval_roster(tmp_path: Path) -> None:
+    from paulsha_cortex.doctor import _model_resolution_probe
+
+    _write(tmp_path, "model-identities.yaml", _OPERATOR_OVERLAY)
+    _write(tmp_path, "model-eval-roster.yaml", "schema_version: 9\nentries: []\n")
+
+    result = _model_resolution_probe({"PSC_PROJECT_CONFIG_ROOT": str(tmp_path)}, tmp_path)
+
+    assert result.status == "fail"
+    assert "eval-roster-unreadable" in result.detail
+
+
+def test_doctor_resolution_probe_warns_on_packaged_hot_path(tmp_path: Path) -> None:
+    from paulsha_cortex.doctor import _model_resolution_probe
+
+    _write(
+        tmp_path,
+        "model-identities.yaml",
+        """\
+schema_version: 3
+identities:
+  - executor: codex
+    model_id: gpt-5.6-luna
+    independence_domain: openai
+    capabilities: [build]
+""",
+    )
+    result = _model_resolution_probe({"PSC_PROJECT_CONFIG_ROOT": str(tmp_path)}, tmp_path)
+
+    assert result.status == "warn"
+    assert "planner" in result.detail
+    assert result.required is False
+
+
+def test_doctor_resolution_probe_fails_when_a_persona_has_no_candidate(tmp_path: Path) -> None:
+    from paulsha_cortex.doctor import _model_resolution_probe
+
+    _write(
+        tmp_path,
+        "model-identities.yaml",
+        """\
+schema_version: 3
+resolution_policy:
+  packaged_fallback: deny
+identities:
+  - executor: codex
+    model_id: gpt-5.6-luna
+    independence_domain: openai
+    capabilities: [build]
+""",
+    )
+    result = _model_resolution_probe({"PSC_PROJECT_CONFIG_ROOT": str(tmp_path)}, tmp_path)
+
+    assert result.status == "fail"
+    assert "planner" in result.detail and "reviewer" in result.detail
+    assert result.required is True
+
+
+def test_inspect_models_rows_expose_the_resolution_layer(tmp_path: Path) -> None:
+    from paulsha_cortex.coordinator.model_profile import envelope_display_rows
+
+    _write(tmp_path, "model-identities.yaml", _OPERATOR_OVERLAY)
+    _write(tmp_path, "model-eval-roster.yaml", _EVAL_ROSTER)
+    rows = envelope_display_rows(load_model_identities(tmp_path))
+
+    layers = {
+        (row["executor"], row["model_id"], row["persona"]): row["resolution_layer"]
+        for row in rows
+    }
+    assert layers[("claude", "claude-opus-5", "planner")] == "operator-overlay"
+    assert layers[("claude", "sonnet", "builder")] == "evaluated-roster"
+    assert layers[("cg", "glm-5.2", "planner")] == "packaged-fallback"

--- a/tests/test_per_work_model_chain.py
+++ b/tests/test_per_work_model_chain.py
@@ -295,24 +295,26 @@ def test_evidence_records_resolution_and_source(tmp_path: Path) -> None:
             "executor": "copilot",
             "model_id": "builder-two",
             "independence_domain": "microsoft",
-            "source": "override",
+            "source": "run-override",
+            "envelope_source": "default",
         }
     }
 
     # planner 段沒有覆寫，走共享 registry；來源標記必須能分辨兩者不同。
-    # #452 C：非覆寫段的 source 記實際解析依據——該身分無實測側寫、查表投影
-    # 落在保守預設 → "default-envelope"（"registry" 保留為 #452 前 legacy 值）。
+    # #534：非覆寫段的 source 記**解析層**——手工建構的 registry 視為 operator
+    # 指定（第 1 層）；封套來源改記在 envelope_source。
     planner_step = _step(after_builder, phase="plan", persona="planner")
     planner_identity = manager._select_workflow_identity(after_builder, planner_step, _BUILDER_IDENTITIES)
     manager._record_resolved_model_chain(registry, after_builder, planner_step, planner_identity)
 
     final_run = registry.get_workflow_run(run.run_id)
-    assert final_run.resolved_model_chain["builder"]["source"] == "override"
+    assert final_run.resolved_model_chain["builder"]["source"] == "run-override"
     assert final_run.resolved_model_chain["planner"] == {
         "executor": "claude",
         "model_id": "planner-one",
         "independence_domain": "anthropic",
-        "source": "default-envelope",
+        "source": "operator-overlay",
+        "envelope_source": "default",
     }
     # builder 段的紀錄沒有被 planner 段的更新蓋掉（逐段合併，不是整段覆蓋）。
     assert final_run.resolved_model_chain["builder"]["model_id"] == "builder-two"


### PR DESCRIPTION
## 摘要

落實 2026-08-14 使用者裁決的**模型引擎三層解析鏈**：人工指定清單優先 → agent 從 patchmud 評估合格清單挑 → 未評估模型須先經 eval、合格後人工複核加入清單。

現況與裁決相反（#534 主訴）：packaged roster 的註解明載「列序即候選優先序：agy 維持首位」，planner 因此解析到 `agy/gemini-3.1-pro-high`，而 operator 當日在 host overlay 宣告的可用引擎清單**根本不含**它；該模型暫時 503 時 define 死亡（#533 已把死路修成可 recover，但**選錯模型**本身沒修）。

## 三層解析鏈

| 層 | provenance 值 | 來源 | 語意 |
| --- | --- | --- | --- |
| 1 | `operator-overlay` | host overlay `model-identities.yaml` | operator 人工指定，**列序即優先序** |
| 2 | `evaluated-roster` | host `model-eval-roster.yaml`（新契約） | patchmud 評估合格**且**人工複核通過 |
| 3 | `packaged-fallback` | packaged roster | 候選池，只供評估管線取材；解析落到這層 fail-loud |

- 新增 `paulsha_cortex/coordinator/model_resolution.py` 作為解析鏈單一真值。
- **解析層是排序主鍵且為 stable sort**：#452 的 measured 側寫優先與 #262 的 `primary_domain` 偏好原封不動地降級為**同層內**的次要偏好——packaged 候選再也沒有機會壓過人工指定，同時 #262 preflight re-route 的 fallback 候選一個都沒丟。
- run-scoped 覆寫（`--builder-model` 等）仍為最高優先，provenance 記 `run-override`。

### 第 2 層契約 `model-eval-roster.yaml`

扁平欄位、可手工維護、檔案不存在即空清單：

```yaml
schema_version: 1
entries:
  - executor: claude
    model_id: sonnet
    roles: [build, review]        # planning / build / review
    verdict: pass                 # pass / fail / pending（patchmud 評估結果）
    evaluated_at: "2026-08-14"
    eval_source: patchmud
    eval_ref: patchmud-deck-v1/report-2026-08-14   # 選配：評估證據指標
    review_status: approved       # approved / rejected / pending（人工複核）
    reviewer: operator            # approved 時必填
    reviewed_at: "2026-08-14"     # approved 時必填
```

只有 `verdict: pass` **且** `review_status: approved`（且複核人／複核日期齊備）**且**角色相符才入第 2 層——「評估過」不等於「人工核可」。patchmud eval **執行管線**屬 v4 R2，不在本 PR；本次只做契約與消費端。清單解析失敗時第 2 層視為空（保守方向，絕不因錯誤多授予資格）且**不丟例外**，避免 #509 的「一列設定過期打掛整條 tick」重演。

### 第 3 層政策

`resolution_policy.packaged_fallback`：`allow`（無 overlay 的部署預設——operator 未宣告任何東西，packaged 就是全世界）／`warn`（有 overlay 時預設，落到第 3 層即打 log fail-loud）／`deny`（嚴格 fail-closed，無候選時錯誤訊息附兩條補救路徑）。

### 兩處寫死的優先序一併移除

- `select_secondary_planner` 過去迭代 `PLANNER_PRIORITY`（agy 釘首位，且只認三組 `(executor, domain)`——operator 宣告的 `cg`／新 executor planner **永遠不可達**）。
- `work_bridge` 的 primary planner 寫死 `("codex", "claude", "agy")`。

兩者改走解析鏈；`PLANNER_PRIORITY` 保留為歷史記錄，不再參與任何選擇（`docs/superpowers/specs/model-persona-roster-matrix.md` 的「cg planner 永遠不可達」註記已補上解除說明）。

## 收編的相鄰 issue

- **#509 殘項**：overlay 與 packaged 同鍵不再 `raise ValueError` 打掛 periodic tick——改為**以 overlay 為準**（人工指定優先）並留下診斷：明示 `override_packaged: true` 記 info、未明示記 warn 並打 log。新增 `packaged_overrides` 讓 overlay 明示 `park`（完全停用；身分仍留在 registry，doctor 的 canonical 檢查不破）或 `demote`（降到同層最後）packaged 身分。新增 `cortex doctor` 的 **`model-resolution` probe**：走與 tick 相同的載入器與排序函式、逐 persona 回報生效解析與所在層、**明示自己讀的 config root**（#509 假 PASS 的成因之一就是 doctor 與 daemon 讀不同 config root 卻看不出來），並以不變式守衛「overlay 宣告某角色 → 生效解析必須落在第 1 層」，破壞即 FAIL。
- **#490**：`review.load_model_identity_registry` 過去走 `use_packaged_default=False` 只讀 host overlay，packaged 身分在 retry-review 被記成 `reviewer-identity-unknown`；operator 只能把 packaged 那列複製進 overlay，複製回來又踩 #509 的 shadow 中止——死結。改用與 manager／tick 相同的合併 registry 後這條矛盾一併消失。
- **#475**：operator 於 overlay 宣告的 Claude-compatible 自訂身分（`claude/gemma4-26b-a4b-nvfp4`）不得被 packaged 同 executor 身分（`claude/sonnet`）靜默取代，解析結果與 `operator-overlay` provenance 以測試釘住。**executable／launcher 綁定屬 launcher 層，仍為 #475 的未竟部分。**

## provenance 改動

`resolved_model_chain[persona].source` 改記**解析層**（`run-override`／`operator-overlay`／`evaluated-roster`／`packaged-fallback`），封套來源移至新的**選配**欄位 `envelope_source`（`measured`／`default`）。舊值 `default-envelope` 這類不透明值只說得出「封套來自預設」，說不出「這顆模型憑什麼進熱路徑」。#534 之前寫下的紀錄（legacy source、無 `envelope_source`）維持可載入，以測試釘住。

`cortex inspect models` 每列加 `layer=`，JSON 加 `resolution_layer`。

## 相容性

**既有部署零遷移成本**：所有新能力皆為選配欄位／檔案，既有 v1／v2／v3 overlay 檔案不改一行也照載、照解析（`test_existing_overlay_files_stay_valid_without_any_new_field` 釘住）。程式內手工建構的 registry 沒有 loader 蓋章，一律視為第 1 層，順序與 #534 之前逐項相同。測試 fixture 比照 operator 現行部署：agy 的 capabilities 為 `[build]`（#568 暫時下架 review），不假設 agy 有 review。

## 測試

- 新增 `tests/test_model_resolution_chain_534.py`：29 個測試（三層排序、eval roster 契約與 fail-closed、壞清單降級、shadow 不中止、park／demote、deny fail-closed、provenance、doctor probe 四例、#490／#475 復現、向後相容不變式）。
- 全套 `python3 -m pytest -q`：**2820 passed, 49 subtests passed**，0 failed（已 rebase 於 `origin/main` e9911e6，含 PR #570）。
- `python3 -m policy_check`（帶 PR 上下文）：pass 24 / fail 0 / warn 1（R-22 陳年懸空引用，advisory）。

## Checklist

- [x] `changelog.d/model-resolution-chain.md` fragment 已新增且已 commit
- [x] `CHANGELOG.md [Unreleased]` 有對應 entry
- [x] `VERSION` 未變更（非 release PR）
- [x] 全套測試通過
- [x] policy_check 帶 PR 上下文跑過，fail: 0
- [x] README／spec 文件同步（三層解析鏈、eval roster 契約、shadow 語意更新）

Refs #534 #509 #490 #475
