### PR TITLE
feat(monitor): 事件 spool 入口與 targeted refresh 讓被點名物件不必等輪詢

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,45 @@
 
 ## [Unreleased]
 
+### Added
+- **Issue #506 / D4：monitor 的本機事件入口（spool）＋targeted refresh——事件是
+  **hint 不是 authority**——新增 `paulsha_cortex/monitor/event_spool.py` 作為本機
+  事件契約與唯一入口。D1–D3 把常態讀取壓到每 repo 每日 26 次計費請求，代價是**發現
+  延遲**：fleet 自己剛動過的物件也只能等下一次輪詢把整個清單再問一遍。D5（headless
+  agent hook，**不在本次**）將依本契約把「我剛動了 GitHub 物件」寫進 spool，monitor
+  每輪消費它。**spool 契約**：目錄 `monitor_event_spool_root()`（預設
+  `<agents>/monitor/event-spool/`，壞檔隔離到同層 `quarantine/`），**每事件一檔**
+  （`<emitted_at 壓平>-<event_id 前綴>.json`，因此消費就是 per-file `unlink`，不需
+  鎖或 offset 檔），**原子寫入**（temp 檔 `.` 前綴 → fsync → `os.replace`，消費端
+  不可能讀到半寫入的檔案），信封欄位 `schema_version`／`event_id`／`event_type`／
+  `emitted_at`／`source`＋選配 `job_id`／`payload`。**fire-and-forget 寫入端語意**：
+  `EventSpool.emit()` 不等回應、不與 monitor 交握、**永不 raise**——hook 掛在別人
+  （agent job）的工作路徑上，spool 寫不進去絕不能影響工作本體，掉一則 hint 的後果
+  只是退回原本的 refresh 週期延遲，而那正是 D3 每日 anti-entropy 的守備範圍。事件
+  **契約層就不給 producer 塞新狀態的欄位**，`action` 純屬診斷——對應 `correlation`
+  既有的 inferred→confirmed 語彙：spool hint 是 inferred 訊號，只有 targeted 驗證
+  回來的物件才是 confirmed、才進鏡像。**消費端**：D3 清單同步跑完後才消費 spool，
+  對被點名物件發單物件 `repos/{repo}/issues/{number}` 的**targeted 條件請求**，
+  per-object ETag 存進 `IssueSyncState.targeted_etags` 並與清單端點的 `etag` **分開
+  存**（兩者 request path 不同，混用會讓條件請求永遠落空；304 一路不取回應的 ETag，
+  與 D3 同一顆地雷）；targeted 讀回來的新狀態**不得推進 `since` 游標**（游標只能由
+  清單回應推進，否則會跳過那之間被更新的其他物件）。**去重**：同物件多事件收斂成
+  一次驗證，所有貢獻事件檔一起消費。**過期安全跳過**：事件早於本輪請求、且該物件已
+  被本輪讀取涵蓋（在增量 delta 裡，或本輪是全量）就直接消費、不花請求；清單回 304
+  **不算**一次讀取，不得算進涵蓋範圍。**處理成功才消費**：事件檔一路留到鏡像真的
+  落地為止。**fail safe**：targeted 請求失敗／壞 JSON／回錯物件一律不寫鏡像也不消費
+  事件；回 404 不從鏡像刪任何東西（刪除／transfer 只有每日全量對帳看得到），留給
+  anti-entropy。**壞檔隔離不阻塞**：壞 JSON／缺欄位／payload 形狀不合／超過 TTL 的
+  孤兒事件移進 `quarantine/`，同輪其餘事件照常處理。**per-cycle 上限 20**：hook 是
+  per-tool-call 觸發的，沒有上限等於把 D1–D3 省下的配額交還給事件量決定。**#498
+  擴充點**：`event_type` 為封閉列舉的擴充位，本次只消費 `github_object`；
+  `steering`／`job` 已在 `RESERVED_EVENT_TYPES` 佔位，掃到時**原地保留、只記 log 與
+  計數、絕不刪除**（那些事件屬於未來的另一個 consumer），未知型別與未知
+  `schema_version` 同樣保留不動。**D5 的 hook 注入不在本次**，launcher 未動；沒有
+  spool 目錄時 provider 行為與 D3 逐位元組相同。詳見
+  `changelog.d/d4-event-spool.md`。新增 `tests/test_monitor_event_spool_506.py`
+  （51 個測試）。
+
 ### Changed
 - **Issue #506 / D3：GitHub issues 改走 `state=all&since=` ＋ ETag 條件請求的增量
   同步，全量只作每日一次的 anti-entropy 對帳**——`GitHubWorkProvider` 過去每輪對

--- a/changelog.d/d4-event-spool.md
+++ b/changelog.d/d4-event-spool.md
@@ -1,0 +1,90 @@
+# D4：monitor 事件入口（spool）＋targeted refresh——事件是 hint，不是 authority
+
+## 問題
+
+D1–D3 把 monitor 對 GitHub 的常態讀取壓到每 repo 每日 26 次計費請求，代價是**發現
+延遲**：一件事發生在 GitHub 上，最壞要等一個 refresh 週期（預設 300s，實務上更久）
+才進鏡像。對「fleet 自己剛剛動過的物件」而言，這個延遲是白等的——動手的是我們自己，
+當下就知道哪個物件被動了，卻還是只能等下一次輪詢把整個清單再問一遍。
+
+## 改法
+
+新增 `paulsha_cortex/monitor/event_spool.py`，是本機事件入口的契約與唯一入口。D5
+（headless agent hook，**不在本次**）會依這份契約把「我剛動了 GitHub 物件」寫進
+spool；monitor 每輪消費它，對被點名的物件做 targeted 條件驗證後才更新鏡像。
+
+### spool 契約（D5 依此實作）
+
+- **位置**：`monitor_event_spool_root()`（預設 `<agents>/monitor/event-spool/`，隨
+  `PSC_MONITOR_STATE_ROOT`／`PSC_AGENTS_ROOT` 移動）；壞事件檔隔離到同層
+  `quarantine/`。目錄由**寫入端**建立——monitor 掃到目錄不存在就是「這台機器沒有
+  hook」，不是錯誤，也不會替它建目錄。
+- **每事件一檔**：`<emitted_at 壓平>-<event_id 前綴>.json`，因此消費就是 per-file
+  `unlink`，不需要鎖、offset 檔或任何跨行程協調。檔名全程過濾成 `[A-Za-z0-9._-]`，
+  事件內容無法影響它落在哪個路徑。
+- **原子寫入**：temp 檔（`.` 前綴，掃描端跳過 dotfile）→ fsync → `os.replace`；
+  消費端因此**不可能**讀到半寫入的檔案。權限 0600。
+- **fire-and-forget 寫入端語意**：`EventSpool.emit()` 不等回應、不與 monitor 交握、
+  **永不 raise**——寫失敗只回 `None` 並記 debug log。hook 掛在別人（agent job）的
+  工作路徑上，spool 寫不進去絕不能影響工作本體；掉一則 hint 的後果只是退回原本的
+  refresh 週期延遲，而那正是 D3 每日 anti-entropy 的守備範圍。
+- **信封欄位**（缺一即壞檔）：`schema_version`／`event_id`／`event_type`／
+  `emitted_at`／`source`；選配 `job_id`（D5 的 `PSC_JOB_ID` 自守標記）與 `payload`。
+- **hint 不是 authority**：`github_object` 事件只帶「哪個 repo 的哪個編號被動了」，
+  **契約層就不給 producer 塞新狀態的欄位**；`action` 純屬診斷，consumer 永不據以
+  寫鏡像。對應 `correlation` 既有的 inferred→confirmed 語彙：spool hint 是 inferred
+  訊號，只有 targeted 驗證回來的物件才是 confirmed、才進鏡像。
+
+### 消費端（`GitHubWorkProvider`）
+
+D3 的清單同步跑完之後才消費 spool——先做便宜的批次讀取，被它涵蓋到的事件就不必
+再各花一次請求。
+
+- **targeted 條件請求**：單物件 `repos/{repo}/issues/{number}`（PR 走同一端點），
+  沿用 D3 的 ETag／計費紀律。per-object ETag 存進 `IssueSyncState.targeted_etags`，
+  與清單端點的 `etag` **分開存**：兩者 request path 不同，混用會讓條件請求永遠
+  落空。這條 path 不含 `since`，因此游標前進不會讓它作廢；304 一路**不**取回應的
+  ETag（與 D3 同一顆地雷）。
+- **游標不受 targeted 影響**：targeted 讀回來的新狀態**不得**推進 `since`——游標
+  只能由清單回應推進，否則會跳過那之間被更新的其他物件。
+- **順序與去重**：同物件多事件收斂成**一次**驗證，所有貢獻事件檔一起消費（否則
+  下輪重驗）。事件之間本來就沒有全域順序，consumer 也不推論順序——每個物件只問
+  GitHub「你現在長怎樣」，答案與事件先後無關。
+- **過期安全跳過**：事件早於本輪請求、且該物件已被本輪讀取涵蓋（出現在增量 delta，
+  或本輪是全量），鏡像就已經至少和事件一樣新——直接消費事件、**不花請求**。spool
+  是本機目錄，producer 與 consumer 共用同一顆時鐘，這個時間比較才成立；GitHub 端的
+  replication lag 是唯一殘餘風險，而那本來就歸每日 anti-entropy。清單回 304 **不算**
+  一次讀取（它什麼都沒讀回來），不得算進涵蓋範圍。
+- **處理成功才消費**：事件檔一路留到鏡像真的落地（state 存檔成功）為止。中途 crash
+  的代價只是下一輪重驗一次，而條件請求命中 304 連配額都不花。
+- **fail safe**：targeted 請求失敗／回壞 JSON／回的不是問的那個物件——一律不寫鏡像
+  **也不消費事件**；回 404 則不從鏡像刪任何東西（刪除／transfer 只有每日全量對帳
+  看得到，一次 404 不足以當證據），但消費該事件以免無限重試燒配額。第一個 targeted
+  失敗即停掉本輪其餘 targeted 請求（多半是限流／認證，繼續打只會把退避窗撐更深）。
+- **壞檔隔離不阻塞**：JSON 壞掉、信封缺欄位、payload 形狀不合、超過 TTL 的孤兒事件
+  ——一律移進 `quarantine/`（隔離而非刪除：那是要給人看的），同一輪其餘事件照常處理。
+- **記帳**：`observations["event_spool"]`（未接 spool 時整個鍵不出現）記
+  pending／objects／superseded／verified／confirmed／not_modified／unverified／
+  requests／billed_requests／consumed／deferred／quarantined／ignored。
+- **per-cycle 上限**：預設一輪最多驗 20 個物件。hook 是 per-tool-call 觸發的，沒有
+  上限等於把 D1–D3 省下的配額交還給事件量決定；超出的事件留在 spool，下一輪依
+  `emitted_at` 先來先服務。
+
+## #498 擴充點
+
+`event_type` 是封閉列舉的擴充位。本次只消費 `github_object`；`steering`／`job`
+（#498 的 remote-control 佇列與 job 心跳）已在 `RESERVED_EVENT_TYPES` 佔位，掃到時
+**原地保留、只記 log 與計數，絕不刪除**——那些事件屬於未來的另一個 consumer，這裡
+刪掉就是替它們決定生命週期。同理，未知 `event_type` 與未知 `schema_version`（較新的
+producer 對上較舊的 consumer）一律保留不動，只有**結構壞掉**的檔案才會被隔離。
+#498 落地時只需新增一個消費該型別的 consumer，spool 契約、原子寫入與隔離機制照用。
+
+## 範圍
+
+只做 monitor 側的 spool 消費機制與契約。**D5 的 hook 注入不在本次**，launcher 未動；
+沒有 spool 目錄時 provider 行為與 D3 逐位元組相同（事件入口是加速器，不是任何東西的
+必要條件）。寫入路徑、label API、events API 均不在本次。
+
+新增 `tests/test_monitor_event_spool_506.py`（51 個測試，涵蓋 spool 寫入／消費／
+去重／亂序／過期跳過／壞檔隔離／targeted 驗證失敗 fail-safe，全程不打真實 GitHub
+API）。

--- a/docs/monitor-config.md
+++ b/docs/monitor-config.md
@@ -78,3 +78,29 @@ REST rate limit 管轄。
 - **provenance**：`github-terminal:` provider 的 observations 多一個 `remote_reads`
   欄位，記 transport、checkout 路徑、本輪 fetch 的 refspec、缺席物件、blob 讀取數
   與 ancestry 判定數。
+
+## 事件入口（spool）：事件是 hint，不是 authority（#506 / D4）
+
+D1–D3 把常態讀取壓下來的代價是**發現延遲**——fleet 自己剛動過的物件，也只能等下
+一次輪詢把整個清單再問一遍。`paulsha_cortex.monitor.event_spool` 開一條本機通道：
+別的行程把「我剛動了哪個 GitHub 物件」寫成一個事件檔，monitor 每輪消費它，對被
+點名的物件做 targeted 條件驗證後才更新鏡像。
+
+- **spool 位置**：`monitor_event_spool_root()`，預設 `<agents>/monitor/event-spool/`
+  （隨 `PSC_MONITOR_STATE_ROOT` / `PSC_AGENTS_ROOT` 移動）。壞事件檔隔離到同層的
+  `quarantine/`。目錄由**寫入端**建立——monitor 掃到目錄不存在就是「這台機器沒有
+  事件 producer」，不是錯誤。
+- **一事件一檔、原子寫入**：temp 檔（`.` 前綴，掃描端跳過）→ fsync → `os.replace`，
+  0600。消費就是 per-file `unlink`，不需要鎖或 offset 檔。
+- **fire-and-forget**：`EventSpool.emit()` 永不 raise，失敗只回 `None`。寫入端掛在
+  別人的工作路徑上，spool 寫不進去不得影響工作本體。
+- **事件不帶新狀態**：`github_object` 事件只說「哪個 repo 的哪個編號被動了」，鏡像
+  只寫 GitHub 自己回的內容（`correlation` 的 inferred→confirmed 語彙）。
+- **targeted 驗證**：單物件 `repos/{repo}/issues/{number}`，帶 per-object ETag 的
+  條件請求（304 不計配額）。驗不到就不寫鏡像、不消費事件，留給每日 anti-entropy。
+  targeted 讀取**不推進** `since` 游標。
+- **上限**：預設一輪最多驗 20 個物件，超出的留到下一輪（依 `emitted_at` FIFO）。
+- **記帳**：`github:` provider 的 observations 多一個 `event_spool` 欄位（未接 spool
+  時不出現）。
+- **其他事件型別**：`steering` / `job`（#498）與未知型別一律**原地保留只記 log**，
+  等各自的 consumer 落地。

--- a/paulsha_cortex/config/paths.py
+++ b/paulsha_cortex/config/paths.py
@@ -57,6 +57,17 @@ def github_issue_sync_path() -> Path:
     return monitor_state_root() / "github-issue-sync.json"
 
 
+def monitor_event_spool_root() -> Path:
+    """#506 / D4：本機事件入口（spool）目錄。
+
+    與 `github_issue_sync_path()` 同一族（monitor 的傳輸層狀態），但生命週期相反：
+    這裡的檔案是**別的行程**（D5 的 headless agent hook）寫進來、monitor 消費掉即
+    消失的一次性 hint，不是 monitor 自己的 durable 狀態。目錄由寫入端建立——
+    monitor 掃到目錄不存在就是「這台機器沒有 hook」，不是錯誤。
+    """
+    return monitor_state_root() / "event-spool"
+
+
 def skill_registry_root() -> Path:
     """Skill governance 治理平面根目錄（issue #204）：ledger／park state／proposal 共用。
 

--- a/paulsha_cortex/monitor/event_spool.py
+++ b/paulsha_cortex/monitor/event_spool.py
@@ -1,0 +1,520 @@
+"""#506 / D4：monitor 的本機事件入口（spool）——事件是 hint，不是 authority。
+
+## 為什麼要有這個入口
+
+D1–D3 把 monitor 對 GitHub 的常態讀取壓到「每 repo 每日 26 次計費請求」，代價是
+**發現延遲**：一件事情發生在 GitHub 上，最壞要等一個 refresh 週期（30 分鐘）才會
+進鏡像。對「fleet 自己剛剛動過的物件」而言這個延遲是白等的——動手的是我們自己，
+我們當下就知道哪個物件被動了。
+
+D5 的 headless agent hook 會把「我剛動了 GitHub 物件」寫成一個事件檔丟進本模組的
+spool；monitor 每輪把 spool 掃一遍，對**被點名的物件**做一次 targeted 條件請求，
+驗證通過才更新鏡像。漏發的事件由 D3 已落地的每日全量 anti-entropy 兜底。
+
+## 契約（D5 hook 依此實作，本模組是唯一真值）
+
+1. **位置**：`monitor_event_spool_root()`（預設 `<agents>/monitor/event-spool/`，
+   隨 `PSC_MONITOR_STATE_ROOT`／`PSC_AGENTS_ROOT` 移動）。壞事件檔隔離到同層的
+   `quarantine/` 子目錄。
+2. **每事件一檔**：`<emitted_at 壓平>-<event_id 前綴>.json`，UTF-8 JSON 物件。
+   一檔一事件，因此消費是 per-file 的 `unlink`，不需要任何鎖或 offset 檔。
+3. **原子寫入**：temp 檔（前綴 `.`，掃描時跳過）→ fsync → `os.replace` 進 spool。
+   消費端因此**不可能**讀到半寫入的檔案。
+4. **fire-and-forget 寫入端語意**：:meth:`EventSpool.emit` 不等任何回應、不與
+   monitor 交握、**永不 raise**——寫失敗只回 ``None`` 並記 debug log。hook 是掛在
+   別人（agent job）的工作路徑上的，spool 寫不進去絕不能影響工作本體；掉一則
+   hint 的後果只是退回原本的 refresh 週期延遲，而那正是 anti-entropy 的守備範圍。
+5. **信封欄位**（缺一即壞檔）：``schema_version``／``event_id``／``event_type``／
+   ``emitted_at``／``source``；選配 ``job_id``（D5 的 `PSC_JOB_ID` 自守標記）與
+   ``payload``。
+6. **事件是 hint 不是 authority**：`github_object` 事件只帶「哪個 repo 的哪個編號
+   被動了」，**不帶新狀態**。payload 裡的 ``action`` 純屬診斷，consumer 永不據以
+   寫鏡像——鏡像只寫 GitHub 自己的回應。對應 ``correlation`` 既有的
+   inferred→confirmed 語彙：spool hint 是 inferred 訊號，只有 targeted 驗證回來的
+   物件才是 confirmed，才進鏡像。
+
+## #498 擴充點
+
+``event_type`` 是封閉列舉的**擴充位**：本次只消費 ``github_object``。
+``steering``／``job``（#498 的 remote-control 佇列與 job 心跳）已在
+:data:`RESERVED_EVENT_TYPES` 佔位，本模組掃到時**原地保留、只記 log 與計數**，
+絕不刪除——那些事件屬於未來的另一個 consumer，這裡刪掉就是替它們決定生命週期。
+同理，未知的 ``event_type`` 與未知的 ``schema_version``（較新的 producer 對上較舊
+的 consumer）一律保留不動，只有**結構壞掉**的檔案才會被隔離。
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import tempfile
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Sequence
+
+from paulsha_cortex.config.paths import monitor_event_spool_root
+
+
+logger = logging.getLogger(__name__)
+
+
+EVENT_SCHEMA = "monitor-event-spool/v1"
+
+#: 本次唯一會被消費的事件型別。
+EVENT_TYPE_GITHUB_OBJECT = "github_object"
+
+#: #498 預留：headless steering 佇列與 job 心跳。本模組只記 log、原地保留。
+EVENT_TYPE_STEERING = "steering"
+EVENT_TYPE_JOB = "job"
+RESERVED_EVENT_TYPES = frozenset({EVENT_TYPE_STEERING, EVENT_TYPE_JOB})
+
+#: `github_object` 事件的物件類型，與 ``IssueEntry.kind`` 同語彙。
+GITHUB_OBJECT_KINDS = frozenset({"github_issue", "github_pr"})
+
+#: 沒有任何 consumer 認領的事件超過這個歲數就隔離——configured repo 清單變動、
+#: 或 producer 打錯 repo 名，都會留下永遠等不到 consumer 的孤兒事件。
+DEFAULT_EVENT_TTL_SECONDS = 7 * 86_400.0
+
+QUARANTINE_DIRNAME = "quarantine"
+
+_EVENT_ID = re.compile(r"\A[A-Za-z0-9][A-Za-z0-9._-]{0,63}\Z")
+_UNSAFE_NAME = re.compile(r"[^A-Za-z0-9._-]")
+
+
+class SpoolEventError(ValueError):
+    """事件檔結構壞掉；呼叫端一律隔離該檔並繼續處理其餘事件。"""
+
+
+def parse_event_timestamp(value: object) -> datetime:
+    """解析事件時間戳。
+
+    spool 是**本機**目錄，producer 與 consumer 共用同一顆時鐘，因此
+    ``emitted_at`` 與 monitor 自己的 ``attempted_at`` 可以直接比大小——這是
+    「事件過期」判定成立的前提（見 ``providers`` 的 targeted refresh）。
+    """
+
+    if not isinstance(value, str) or not value:
+        raise SpoolEventError("event timestamp must be a non-empty string")
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as error:
+        raise SpoolEventError(f"event timestamp is not ISO-8601: {value!r}") from error
+    if parsed.tzinfo is None:
+        raise SpoolEventError(f"event timestamp is missing a timezone: {value!r}")
+    return parsed.astimezone(timezone.utc)
+
+
+def _utcnow() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+# ---------------------------------------------------------------------------
+# 事件
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SpoolEvent:
+    """一則 spool 事件的信封。
+
+    信封（誰、什麼型別、何時）與 ``payload``（型別自有的欄位）刻意分層：消費端
+    先看得懂信封才決定要不要碰 payload，未知型別因此不必也不該被解析。
+    """
+
+    event_id: str
+    event_type: str
+    emitted_at: str
+    source: str
+    payload: Mapping[str, Any] = field(default_factory=dict)
+    job_id: str | None = None
+    schema_version: str = EVENT_SCHEMA
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.event_id, str) or _EVENT_ID.fullmatch(self.event_id) is None:
+            raise SpoolEventError(f"invalid event_id: {self.event_id!r}")
+        for name in ("event_type", "source", "schema_version"):
+            value = getattr(self, name)
+            if not isinstance(value, str) or not value.strip():
+                raise SpoolEventError(f"event {name} must be a non-empty string")
+        parse_event_timestamp(self.emitted_at)
+        if not isinstance(self.payload, Mapping):
+            raise SpoolEventError("event payload must be an object")
+        if self.job_id is not None and (
+            not isinstance(self.job_id, str) or not self.job_id.strip()
+        ):
+            raise SpoolEventError("event job_id must be a non-empty string when present")
+        object.__setattr__(self, "payload", dict(self.payload))
+
+    @property
+    def emitted_at_time(self) -> datetime:
+        return parse_event_timestamp(self.emitted_at)
+
+    def to_dict(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "schema_version": self.schema_version,
+            "event_id": self.event_id,
+            "event_type": self.event_type,
+            "emitted_at": self.emitted_at,
+            "source": self.source,
+        }
+        if self.job_id is not None:
+            payload["job_id"] = self.job_id
+        if self.payload:
+            payload["payload"] = dict(self.payload)
+        return payload
+
+    @classmethod
+    def from_dict(cls, document: object) -> "SpoolEvent":
+        if not isinstance(document, Mapping):
+            raise SpoolEventError("event file must contain a JSON object")
+        payload = document.get("payload", {})
+        if not isinstance(payload, Mapping):
+            raise SpoolEventError("event payload must be an object")
+        job_id = document.get("job_id")
+        return cls(
+            event_id=document.get("event_id"),  # type: ignore[arg-type]
+            event_type=document.get("event_type"),  # type: ignore[arg-type]
+            emitted_at=document.get("emitted_at"),  # type: ignore[arg-type]
+            source=document.get("source"),  # type: ignore[arg-type]
+            payload=payload,
+            job_id=job_id,
+            schema_version=document.get("schema_version"),  # type: ignore[arg-type]
+        )
+
+
+@dataclass(frozen=True)
+class GitHubObjectHint:
+    """一個被點名的 GitHub 物件（＋它的來源事件檔）。"""
+
+    repo: str
+    kind: str
+    number: int
+    event: SpoolEvent
+    path: Path
+
+    @property
+    def ref(self) -> str:
+        return f"{self.repo}#{self.number}"
+
+
+def github_object_hint(event: SpoolEvent, path: Path) -> GitHubObjectHint:
+    """由 ``github_object`` 事件取出被點名的物件；欄位不合一律當壞檔。"""
+
+    payload = event.payload
+    repo = payload.get("repo")
+    if not isinstance(repo, str) or repo.count("/") != 1 or not all(repo.split("/")):
+        raise SpoolEventError(f"github_object repo must be owner/name: {repo!r}")
+    kind = payload.get("kind")
+    if kind not in GITHUB_OBJECT_KINDS:
+        raise SpoolEventError(f"unknown github_object kind: {kind!r}")
+    number = payload.get("number")
+    if isinstance(number, bool) or not isinstance(number, int) or number <= 0:
+        raise SpoolEventError(f"github_object number must be a positive int: {number!r}")
+    return GitHubObjectHint(repo=repo, kind=kind, number=number, event=event, path=path)
+
+
+# ---------------------------------------------------------------------------
+# 去重／收斂
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class TargetedRefresh:
+    """同一個物件的所有 hint 收斂成的一次 targeted 驗證。"""
+
+    repo: str
+    kind: str
+    number: int
+    emitted_at: str
+    paths: tuple[Path, ...]
+    event_ids: tuple[str, ...]
+
+    @property
+    def emitted_at_time(self) -> datetime:
+        return parse_event_timestamp(self.emitted_at)
+
+
+def coalesce_hints(
+    hints: Sequence[GitHubObjectHint], *, repo: str | None = None
+) -> tuple[TargetedRefresh, ...]:
+    """把 hint 收斂成 per-object 一次驗證。
+
+    - **去重**：同一個物件被點名 N 次只驗一次（N 次編輯的結果就是一個當下狀態，
+      逐次驗證是純粹的浪費）。所有貢獻事件的檔案路徑一併帶出——它們**共同**在
+      驗證成功後才被消費，避免「驗了一次、只刪一個檔、下輪又重驗」。
+    - **亂序**：事件之間沒有全域順序（不同 producer 行程各寫各的），本函式因此
+      不做任何順序推論，只取最大的 ``emitted_at`` 作為這次收斂的水位。
+    - 回傳依（最舊事件先、其次編號）排序：per-cycle 上限截斷時先服務等最久的。
+    """
+
+    grouped: dict[tuple[str, int], TargetedRefresh] = {}
+    for hint in hints:
+        if repo is not None and hint.repo != repo:
+            continue
+        key = (hint.repo, hint.number)
+        current = grouped.get(key)
+        if current is None:
+            grouped[key] = TargetedRefresh(
+                repo=hint.repo,
+                kind=hint.kind,
+                number=hint.number,
+                emitted_at=hint.event.emitted_at,
+                paths=(hint.path,),
+                event_ids=(hint.event.event_id,),
+            )
+            continue
+        newer = hint.event.emitted_at_time > current.emitted_at_time
+        grouped[key] = TargetedRefresh(
+            repo=current.repo,
+            # 同編號被兩種 kind 點名時以較新的事件為準；`issues/{number}` 對
+            # issue 與 PR 是同一個端點，kind 只影響診斷字串。
+            kind=hint.kind if newer else current.kind,
+            number=current.number,
+            emitted_at=hint.event.emitted_at if newer else current.emitted_at,
+            paths=(*current.paths, hint.path),
+            event_ids=(*current.event_ids, hint.event.event_id),
+        )
+    return tuple(
+        sorted(
+            grouped.values(),
+            key=lambda refresh: (refresh.emitted_at_time, refresh.number),
+        )
+    )
+
+
+# ---------------------------------------------------------------------------
+# 掃描結果
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SpoolScan:
+    """一次 spool 掃描的全貌。"""
+
+    hints: tuple[GitHubObjectHint, ...] = ()
+    ignored: Mapping[str, int] = field(default_factory=dict)
+    foreign_schema: int = 0
+    quarantined: tuple[str, ...] = ()
+    unreadable: int = 0
+
+    def for_repo(self, repo: str) -> tuple[GitHubObjectHint, ...]:
+        return tuple(hint for hint in self.hints if hint.repo == repo)
+
+
+# ---------------------------------------------------------------------------
+# spool
+# ---------------------------------------------------------------------------
+
+
+class EventSpool:
+    """本機事件目錄的唯一入口（寫入端與消費端共用）。"""
+
+    def __init__(
+        self,
+        root: str | Path | None = None,
+        *,
+        ttl_seconds: float = DEFAULT_EVENT_TTL_SECONDS,
+    ) -> None:
+        self.root = Path(root) if root is not None else monitor_event_spool_root()
+        self.ttl_seconds = float(ttl_seconds)
+
+    @property
+    def quarantine_root(self) -> Path:
+        return self.root / QUARANTINE_DIRNAME
+
+    # -- 寫入端（fire-and-forget；D5 hook 走這裡）--------------------------
+
+    def emit(self, event: SpoolEvent) -> Path | None:
+        """原子寫入一則事件；**永不 raise**，失敗回 ``None``。
+
+        寫入端掛在別人的工作路徑上（agent job 的 hook），因此這裡沒有任何
+        「回報失敗給呼叫者處理」的語意——掉一則 hint 只是退回 refresh 週期的
+        發現延遲，而讓 hook 的例外炸掉 job 本體是完全不成比例的代價。
+        """
+
+        try:
+            self.root.mkdir(parents=True, exist_ok=True)
+            body = (
+                json.dumps(event.to_dict(), ensure_ascii=False, sort_keys=True) + "\n"
+            ).encode("utf-8")
+            # temp 檔一律 `.` 前綴：掃描端跳過 dotfile，因此半寫入的檔案在
+            # rename 之前對 consumer 不可見。
+            handle_fd, temp_name = tempfile.mkstemp(
+                prefix=".event-", suffix=".tmp", dir=self.root
+            )
+            temp_path = Path(temp_name)
+            try:
+                os.fchmod(handle_fd, 0o600)
+                with os.fdopen(handle_fd, "wb") as handle:
+                    handle.write(body)
+                    handle.flush()
+                    os.fsync(handle.fileno())
+                os.replace(temp_path, self.root / _event_filename(event))
+            except BaseException:
+                try:
+                    os.close(handle_fd)
+                except OSError:
+                    pass
+                temp_path.unlink(missing_ok=True)
+                raise
+        except Exception as error:  # noqa: BLE001 - fire-and-forget 的全部意義
+            # 目錄不可寫、磁碟滿、路徑被換成檔案……一律吞掉。刻意用 debug：
+            # 寫入端可能是每個 tool call 都跑一次的 hook，warning 會變成噪音源。
+            logger.debug("monitor event spool write dropped: %s", error)
+            return None
+        return self.root / _event_filename(event)
+
+    def emit_github_object(
+        self,
+        *,
+        repo: str,
+        kind: str,
+        number: int,
+        source: str,
+        action: str | None = None,
+        job_id: str | None = None,
+        now: str | None = None,
+    ) -> Path | None:
+        """D5 hook 的便利入口：宣告「這個 GitHub 物件剛被動過」。
+
+        刻意**不收**新狀態（state／labels／body）：事件是 hint，鏡像只寫 GitHub
+        自己回的內容。``action`` 只進診斷。
+        """
+
+        payload: dict[str, Any] = {"repo": repo, "kind": kind, "number": number}
+        if action is not None:
+            payload["action"] = action
+        try:
+            event = SpoolEvent(
+                event_id=uuid.uuid4().hex,
+                event_type=EVENT_TYPE_GITHUB_OBJECT,
+                emitted_at=now or _utcnow(),
+                source=source,
+                payload=payload,
+                job_id=job_id,
+            )
+        except SpoolEventError as error:
+            logger.debug("monitor event spool rejected a malformed event: %s", error)
+            return None
+        return self.emit(event)
+
+    # -- 消費端 -----------------------------------------------------------
+
+    def scan(self, *, now: str | None = None) -> SpoolScan:
+        """掃一遍 spool；**永不 raise**。
+
+        壞檔在這裡就被隔離走，因此一個壞檔不會擋住同一輪的其他事件。目錄不存在
+        （D5 尚未落地、或這台機器沒有 hook）回空掃描，且**不建目錄**——只有寫入端
+        才有理由讓 spool 目錄出現。
+        """
+
+        try:
+            names = sorted(
+                entry.name
+                for entry in os.scandir(self.root)
+                if entry.is_file(follow_symlinks=False) and not entry.name.startswith(".")
+            )
+        except FileNotFoundError:
+            return SpoolScan()
+        except OSError as error:
+            logger.warning("monitor event spool is unreadable: %s", error)
+            return SpoolScan(unreadable=1)
+
+        hints: list[GitHubObjectHint] = []
+        ignored: dict[str, int] = {}
+        quarantined: list[str] = []
+        foreign = 0
+        horizon = parse_event_timestamp(now) if now else datetime.now(timezone.utc)
+        for name in names:
+            path = self.root / name
+            try:
+                document = json.loads(path.read_text(encoding="utf-8"))
+            except FileNotFoundError:
+                # 另一個 consumer（或另一個 repo 的 provider）剛消費掉它。
+                continue
+            except (OSError, UnicodeError, json.JSONDecodeError) as error:
+                quarantined.append(self._quarantine(path, reason=str(error)))
+                continue
+            schema = document.get("schema_version") if isinstance(document, Mapping) else None
+            if isinstance(schema, str) and schema and schema != EVENT_SCHEMA:
+                # 較新的 producer 對上較舊的 consumer：不是壞檔，也不是我們的。
+                foreign += 1
+                continue
+            try:
+                event = SpoolEvent.from_dict(document)
+            except SpoolEventError as error:
+                quarantined.append(self._quarantine(path, reason=str(error)))
+                continue
+            if (horizon - event.emitted_at_time).total_seconds() > self.ttl_seconds:
+                # 沒有任何 consumer 認領（repo 打錯／已從 configured 清單移除）的
+                # 孤兒事件，否則 spool 只會單調長大。隔離而非刪除：這是要給人看的。
+                quarantined.append(self._quarantine(path, reason="expired"))
+                continue
+            if event.event_type != EVENT_TYPE_GITHUB_OBJECT:
+                # #498 擴充點：steering／job／未知型別一律**原地保留**，只計數。
+                ignored[event.event_type] = ignored.get(event.event_type, 0) + 1
+                continue
+            try:
+                hints.append(github_object_hint(event, path))
+            except SpoolEventError as error:
+                quarantined.append(self._quarantine(path, reason=str(error)))
+        if ignored:
+            logger.info(
+                "monitor event spool holding %s unconsumed event(s) by type: %s",
+                sum(ignored.values()),
+                ignored,
+            )
+        return SpoolScan(
+            hints=tuple(hints),
+            ignored=dict(ignored),
+            foreign_schema=foreign,
+            quarantined=tuple(quarantined),
+        )
+
+    def consume(self, paths: Iterable[Path]) -> int:
+        """處理成功後才呼叫：移除這些事件檔。回傳實際移除數。
+
+        移除失敗不 raise——最差的後果是下一輪重跑一次 targeted 驗證，而驗證本身
+        是冪等的（條件請求命中 304，連配額都不花）。
+        """
+
+        removed = 0
+        for path in paths:
+            try:
+                Path(path).unlink()
+            except FileNotFoundError:
+                continue
+            except OSError as error:
+                logger.warning("monitor event spool could not consume %s: %s", path, error)
+                continue
+            removed += 1
+        return removed
+
+    def _quarantine(self, path: Path, *, reason: str) -> str:
+        """把壞檔移進 ``quarantine/``；移不動就留著並計數，絕不刪除證據。"""
+
+        logger.warning("monitor event spool quarantining %s: %s", path.name, reason)
+        try:
+            self.quarantine_root.mkdir(parents=True, exist_ok=True)
+            os.replace(path, self.quarantine_root / path.name)
+        except FileNotFoundError:
+            pass
+        except OSError as error:
+            logger.warning("monitor event spool could not quarantine %s: %s", path.name, error)
+        return path.name
+
+
+def _event_filename(event: SpoolEvent) -> str:
+    """``<emitted_at 壓平>-<event_id 前綴>.json``。
+
+    時間戳打頭讓 `ls` 就是時間序（僅便於人工 triage——**消費端不依賴檔名順序**，
+    順序一律取自 ``emitted_at`` 欄位）。名稱全程過濾成 ``[A-Za-z0-9._-]``，
+    事件內容因此無法影響它落在哪個路徑。
+    """
+
+    stamp = _UNSAFE_NAME.sub("", event.emitted_at.replace(":", "").replace("-", ""))
+    return f"{stamp or 'unknown'}-{event.event_id[:16]}.json"

--- a/paulsha_cortex/monitor/github_issue_sync.py
+++ b/paulsha_cortex/monitor/github_issue_sync.py
@@ -42,6 +42,12 @@ per-repo 至少 1 次、issue 數過 100 的 repo 每 100 個再多 1 次，而�
 6. **fail closed**：durable 狀態缺失／損壞／``since`` 格式不合／entries 形狀不對
    ——一律退回全量重建，**絕不**拿半壞的游標去做增量。
 
+7. **D4 的 per-object ETag**：``targeted_etags`` 存 ``repos/{repo}/issues/{number}``
+   這條 path 的條件請求 ETag，與清單端點的 ``etag`` 分開存——兩者 path 不同，
+   混用會讓條件請求永遠落空。它綁的 path 不含 ``since``，因此游標前進不會讓它
+   作廢；反過來，targeted 驗證讀回來的新狀態**不得**推進 ``since`` 游標（游標
+   只能由清單回應推進，否則會跳過那之間被更新的其他物件）。
+
 ``IssueSyncStore`` 是 per-repo durable 狀態（游標／ETag／鏡像投影）的唯一入口。
 """
 
@@ -51,7 +57,7 @@ import json
 import os
 import re
 import tempfile
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Iterable, Mapping, Sequence
@@ -76,6 +82,7 @@ _API_TIMESTAMP = re.compile(r"\A\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z\Z")
 _STATUS_LINE = re.compile(r"\AHTTP/[0-9.]+ (?P<status>[0-9]{3})(?: |\Z)")
 
 HTTP_NOT_MODIFIED = 304
+HTTP_NOT_FOUND = 404
 
 
 class IssueSyncStateError(ValueError):
@@ -103,6 +110,20 @@ def issues_request_path(repo: str, *, since: str | None = None, page: int = 1) -
         # 布林訊號用，path 永遠由本地重建。
         query += f"&page={page}"
     return f"repos/{repo}/issues?{query}"
+
+
+def issue_request_path(repo: str, number: int) -> str:
+    """#506 / D4：單一物件的 targeted 請求 path。
+
+    ``issues/{number}`` 對 issue 與 PR 都成立（PR 在 issues 端點回一份帶
+    ``pull_request`` 鍵的物件），因此 D4 的 targeted 驗證不需要先知道被點名的是
+    哪一種——事件帶的 ``kind`` 只進診斷。path 與清單端點不同，它的 ETag 因此
+    **不會**隨 ``since`` 游標作廢，可以一直沿用到該物件真的變動為止。
+    """
+
+    if isinstance(number, bool) or not isinstance(number, int) or number <= 0:
+        raise ValueError("GitHub object number must be a positive int")
+    return f"repos/{repo}/issues/{number}"
 
 
 # ---------------------------------------------------------------------------
@@ -321,6 +342,10 @@ class IssueSyncState:
     etag: str | None = None
     etag_request: str | None = None
     last_full_sync_at: str | None = None
+    # D4：per-object targeted 請求的 ETag（``(number, etag)`` 對，依編號排序）。
+    # 與清單端點的 ``etag`` 分開存：兩者的 request path 不同，混用會讓條件請求
+    # 永遠落空。以 tuple 而非 dict 保存，frozen dataclass 才維持可雜湊。
+    targeted_etags: tuple[tuple[int, str], ...] = ()
 
     def __post_init__(self) -> None:
         if not isinstance(self.repo, str) or self.repo.count("/") != 1:
@@ -338,10 +363,45 @@ class IssueSyncState:
             raise IssueSyncStateError("issue ETag must travel with its request path")
         if self.last_full_sync_at is not None:
             _parse_local_timestamp(self.last_full_sync_at)
+        targeted: dict[int, str] = {}
+        for pair in self.targeted_etags:
+            try:
+                number, etag = pair
+            except (TypeError, ValueError) as error:
+                raise IssueSyncStateError("targeted ETag must be a (number, etag) pair") from error
+            if isinstance(number, bool) or not isinstance(number, int) or number <= 0:
+                raise IssueSyncStateError(f"invalid targeted ETag number: {number!r}")
+            if not isinstance(etag, str) or not etag:
+                raise IssueSyncStateError(f"invalid targeted ETag value: {etag!r}")
+            targeted[number] = etag
+        object.__setattr__(
+            self, "targeted_etags", tuple(sorted(targeted.items(), key=lambda row: row[0]))
+        )
 
     @property
     def by_number(self) -> dict[int, IssueEntry]:
         return {entry.number: entry for entry in self.entries}
+
+    @property
+    def targeted_etags_by_number(self) -> dict[int, str]:
+        return dict(self.targeted_etags)
+
+    def with_targeted_etags(self, etags: Mapping[int, str]) -> "IssueSyncState":
+        """換掉 per-object ETag 表，並丟掉鏡像裡已經沒有的物件那幾顆。
+
+        物件從鏡像消失（被刪除／transfer 走）之後留著它的 ETag 只會單調長大，
+        而那顆 ETag 也永遠不會再被送出。
+        """
+
+        live = self.by_number
+        return replace(
+            self,
+            targeted_etags=tuple(
+                sorted(
+                    (number, etag) for number, etag in etags.items() if number in live
+                )
+            ),
+        )
 
     def needs_full_sync(self, *, now: str, interval_seconds: float) -> bool:
         """是否該跑每日全量對帳。
@@ -374,6 +434,10 @@ class IssueSyncState:
             value = getattr(self, field_name)
             if value is not None:
                 payload[field_name] = value
+        if self.targeted_etags:
+            payload["targeted_etags"] = {
+                str(number): etag for number, etag in self.targeted_etags
+            }
         return payload
 
     @classmethod
@@ -392,8 +456,35 @@ class IssueSyncState:
         return cls(
             repo=repo,
             entries=tuple(IssueEntry.from_dict(row) for row in entries),
+            targeted_etags=_targeted_etags_from_dict(payload.get("targeted_etags")),
             **optional,
         )
+
+
+def _targeted_etags_from_dict(payload: object) -> tuple[tuple[int, str], ...]:
+    """D4：`{"123": "W/\\"abc\\""}` → `((123, 'W/"abc"'),)`；壞形狀 fail closed。
+
+    與其餘 durable 欄位同一套紀律：半壞的 ETag 表會讓條件請求送出對不上的
+    header，退化成每次 targeted 驗證都全額計費且毫無察覺，所以寧可整份 state
+    退回全量重建。
+    """
+
+    if payload is None:
+        return ()
+    if not isinstance(payload, Mapping):
+        raise IssueSyncStateError("issue sync state targeted_etags must be an object")
+    rows: list[tuple[int, str]] = []
+    for key, value in payload.items():
+        try:
+            number = int(key)
+        except (TypeError, ValueError) as error:
+            raise IssueSyncStateError(
+                f"targeted ETag key is not an issue number: {key!r}"
+            ) from error
+        if number <= 0 or not isinstance(value, str) or not value:
+            raise IssueSyncStateError(f"invalid targeted ETag for {key!r}")
+        rows.append((number, value))
+    return tuple(sorted(rows))
 
 
 def dedupe_entries(entries: Sequence[IssueEntry]) -> tuple[IssueEntry, ...]:

--- a/paulsha_cortex/monitor/providers.py
+++ b/paulsha_cortex/monitor/providers.py
@@ -8,7 +8,7 @@ import math
 import re
 import subprocess
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable, Mapping, Protocol, Sequence
@@ -24,8 +24,15 @@ from .git_mirror import (
     LocalGitMirror,
     unavailable_provenance,
 )
+from .event_spool import (
+    EventSpool,
+    TargetedRefresh,
+    coalesce_hints,
+    parse_event_timestamp,
+)
 from .github_issue_sync import (
     DEFAULT_FULL_SYNC_INTERVAL_SECONDS,
+    HTTP_NOT_FOUND,
     GitHubResponse,
     IssueEntry,
     IssueSyncState,
@@ -34,6 +41,7 @@ from .github_issue_sync import (
     cursor_from,
     dedupe_entries,
     drift_between,
+    issue_request_path,
     issues_request_path,
     parse_include_response,
 )
@@ -897,6 +905,17 @@ class _FetchResult:
     etag: str | None
 
 
+@dataclass(frozen=True)
+class _SpoolResult:
+    """D4：一輪 spool 消費的結果（鏡像增量 ＋ 新的 per-object ETag ＋ 記帳）。"""
+
+    entries: tuple[IssueEntry, ...]
+    targeted_etags: Mapping[int, str]
+    consume: tuple[Path, ...]
+    changed: bool
+    report: Mapping[str, Any]
+
+
 class GitHubWorkProvider:
     """Read GitHub entities through authenticated ``gh api`` JSON only.
 
@@ -904,11 +923,20 @@ class GitHubWorkProvider:
     每日一次的 anti-entropy 對帳。協定本身（游標紀律／ETag 綁定 path／fail-closed
     條件／drift 對帳）全部定義在 ``monitor/github_issue_sync``；本類別只負責發
     ``gh`` 請求、分診失敗、把鏡像投影成 ``ProviderSnapshot``。
+
+    #506 / D4：增量之後再消費一次本機事件 spool（``monitor/event_spool``）——對被
+    點名的物件做 targeted 條件請求，驗證通過才更新鏡像。事件是 **hint 不是
+    authority**，驗不到的變更一律不寫鏡像，留給每日 anti-entropy。
     """
 
     # 100 筆/頁 × 50 頁＝5000 筆。超過視為分頁失控（伺服器沒收斂 Link），
     # fail closed，不讓一輪掃描無上限地打下去。
     _PAGE_LIMIT = 50
+
+    # D4：一輪最多驗幾個被點名的物件。hook 是 per-tool-call 觸發的，一個活躍
+    # job 可以在半小時內點名幾十次；沒有上限就等於把 D1–D3 省下的配額交還給
+    # 事件量決定。超出的事件留在 spool，下一輪再服務（依 emitted_at FIFO）。
+    _TARGETED_LIMIT = 20
 
     def __init__(
         self,
@@ -919,6 +947,8 @@ class GitHubWorkProvider:
         pressure_gate: GitHubPressureGate | None = None,
         sync_store: IssueSyncStore | None = None,
         full_sync_interval_seconds: float = DEFAULT_FULL_SYNC_INTERVAL_SECONDS,
+        event_spool: EventSpool | None = None,
+        targeted_refresh_limit: int | None = None,
         now: Callable[[], str] | None = None,
     ) -> None:
         if repo.count("/") != 1 or any(not part for part in repo.split("/")):
@@ -933,6 +963,12 @@ class GitHubWorkProvider:
         # 是「無狀態即無增量」的誠實契約（測試與一次性呼叫端走的就是它）。
         self.sync_store = sync_store
         self.full_sync_interval_seconds = float(full_sync_interval_seconds)
+        # D4：沒有 spool（或 spool 目錄不存在，例如 D5 hook 尚未部署到這台機器）
+        # 就完全維持 D3 行為——事件入口是**加速器**，不是任何東西的必要條件。
+        self.event_spool = event_spool
+        self.targeted_refresh_limit = (
+            self._TARGETED_LIMIT if targeted_refresh_limit is None else int(targeted_refresh_limit)
+        )
         self._now = now or _utcnow
 
     # -- 掃描 -------------------------------------------------------------
@@ -1049,6 +1085,31 @@ class GitHubWorkProvider:
             )
             notes.append(f"github issue mirror drift resolved by full sync: {drift}")
 
+        # D4：清單同步結束後才消費事件 spool——先做便宜的批次讀取，被它涵蓋到的
+        # 事件就不必再各花一次 targeted 請求。
+        spool: _SpoolResult | None = None
+        if self.event_spool is not None:
+            spool = self._consume_event_spool(
+                state=state,
+                attempted_at=attempted_at,
+                delta_numbers=frozenset(entry.number for entry in fetched.entries),
+                # 全量輪次重讀了**所有**物件，因此涵蓋掉所有比它早的事件；304
+                # 不是一次讀取（它什麼都沒讀回來），不得算進涵蓋範圍。
+                full_read=(mode == "full" and not fetched.not_modified),
+                notes=notes,
+            )
+            targeted_etags = dict(spool.targeted_etags)
+            if spool.changed or targeted_etags != state.targeted_etags_by_number:
+                try:
+                    state = replace(state, entries=spool.entries).with_targeted_etags(
+                        targeted_etags
+                    )
+                except IssueSyncStateError as error:
+                    return self._failure(
+                        attempted_at, f"github issue sync state rejected: {error}"
+                    )
+                entries = state.entries
+
         persisted = True
         if self.sync_store is not None and state is not previous:
             try:
@@ -1063,6 +1124,15 @@ class GitHubWorkProvider:
                 logger.warning(
                     "github issue sync state for %s was not persisted: %s", self.repo, error
                 )
+
+        if spool is not None:
+            if persisted:
+                # 驗收：**處理成功才消費**。事件檔一路留到鏡像真的落地為止——
+                # 中途 crash 的代價只是下一輪重驗一次（條件請求命中 304，免費）。
+                spool.report["consumed"] = self.event_spool.consume(spool.consume)
+            else:
+                spool.report["consumed"] = 0
+                spool.report["deferred"] += len(spool.consume)
 
         sources = tuple(
             sorted(
@@ -1114,6 +1184,9 @@ class GitHubWorkProvider:
                     "drift": drift,
                     "persisted": persisted,
                 },
+                # D4：事件入口的記帳。沒接 spool 時整個鍵不出現（既有觀測消費端
+                # 一行都不用改）。
+                **({"event_spool": dict(spool.report)} if spool is not None else {}),
             },
         )
 
@@ -1157,6 +1230,193 @@ class GitHubWorkProvider:
             etag=first.etag,
         )
 
+    # -- D4：事件入口 -----------------------------------------------------
+
+    def _consume_event_spool(
+        self,
+        *,
+        state: IssueSyncState,
+        attempted_at: str,
+        delta_numbers: frozenset[int],
+        full_read: bool,
+        notes: list[str],
+    ) -> _SpoolResult:
+        """掃 spool → 對被點名物件做 targeted 條件驗證 → 更新鏡像。
+
+        規則（計畫 R0.5 原則 6）：
+
+        - **事件是 hint 不是 authority**：只有 GitHub 自己回的物件才進鏡像。驗證
+          失敗（請求錯誤）不寫鏡像**也不消費事件**；驗證回 404（物件被刪除／
+          transfer 走）不從鏡像刪任何東西——那是每日全量 anti-entropy 的職責，
+          單一 targeted 404 不足以區分「真的沒了」與「權限／路徑一時讀不到」。
+        - **去重**：同物件多事件收斂成一次驗證（見 ``coalesce_hints``）。
+        - **過期安全跳過**：事件比本輪清單讀取早、而該物件又已被本輪讀取涵蓋
+          （出現在增量 delta 裡，或本輪是全量），鏡像就已經至少和事件一樣新，
+          直接消費事件、不花請求。spool 是本機目錄，producer 與 consumer 共用
+          同一顆時鐘，這個時間比較才成立。
+        - **亂序無害**：事件本來就沒有全域順序，這裡也不推論順序——每個物件只問
+          GitHub「你現在長怎樣」，答案與事件先後無關。
+        """
+
+        assert self.event_spool is not None  # 呼叫端已檢查
+        report: dict[str, Any] = {
+            "pending": 0,
+            "objects": 0,
+            "superseded": 0,
+            "verified": 0,
+            "confirmed": 0,
+            "not_modified": 0,
+            "unverified": 0,
+            "requests": 0,
+            "billed_requests": 0,
+            "consumed": 0,
+            "deferred": 0,
+            "quarantined": 0,
+            "ignored": {},
+            "foreign_schema": 0,
+        }
+        scan = self.event_spool.scan(now=attempted_at)
+        report["quarantined"] = len(scan.quarantined)
+        report["ignored"] = dict(scan.ignored)
+        report["foreign_schema"] = scan.foreign_schema
+        hints = scan.for_repo(self.repo)
+        report["pending"] = len(hints)
+        refreshes = coalesce_hints(hints, repo=self.repo)
+        report["objects"] = len(refreshes)
+        if not refreshes:
+            return _SpoolResult(
+                entries=state.entries,
+                targeted_etags=state.targeted_etags_by_number,
+                consume=(),
+                changed=False,
+                report=report,
+            )
+
+        try:
+            cycle_started = parse_event_timestamp(attempted_at)
+        except ValueError:
+            cycle_started = None
+        by_number = state.by_number
+        etags = state.targeted_etags_by_number
+        consume: list[Path] = []
+        changed = False
+        for index, refresh in enumerate(refreshes):
+            if index >= self.targeted_refresh_limit:
+                # 超出本輪上限：事件留在 spool，下一輪照 emitted_at 先來先服務。
+                report["deferred"] += sum(len(row.paths) for row in refreshes[index:])
+                notes.append(
+                    "github event spool deferred "
+                    f"{len(refreshes) - index} object(s) past the per-cycle targeted limit"
+                )
+                break
+            if self._already_covered(
+                refresh,
+                cycle_started=cycle_started,
+                delta_numbers=delta_numbers,
+                full_read=full_read,
+            ):
+                report["superseded"] += 1
+                consume.extend(refresh.paths)
+                continue
+            try:
+                response = self._request(
+                    issue_request_path(self.repo, refresh.number),
+                    etag=etags.get(refresh.number),
+                    not_found_ok=True,
+                )
+            except _GitHubRequestError as error:
+                # 驗證不到就不寫鏡像、不消費事件——留給下一輪或每日 anti-entropy。
+                # 一併停掉本輪剩餘的 targeted 請求：第一個失敗多半是限流／認證，
+                # 繼續打只是把退避窗撐得更深。
+                report["deferred"] += sum(len(row.paths) for row in refreshes[index:])
+                notes.append(f"github event spool targeted refresh failed: {error.diagnostic}")
+                logger.warning(
+                    "github event spool targeted refresh for %s#%s failed: %s",
+                    self.repo,
+                    refresh.number,
+                    error.diagnostic,
+                )
+                break
+            report["requests"] += 1
+            if response.not_modified:
+                # 條件請求命中：物件自上次 targeted 讀取以來沒變，鏡像已經是對的。
+                # 304 不計配額，因此 billed_requests 不動。
+                report["not_modified"] += 1
+                consume.extend(refresh.paths)
+                continue
+            report["billed_requests"] += 1
+            if response.status == HTTP_NOT_FOUND:
+                # 物件讀不到——**不**動鏡像（不刪、不改）。刪除／transfer 這類
+                # 事件本來就只有每日全量對帳看得到，一次 404 不足以當證據。
+                report["unverified"] += 1
+                consume.extend(refresh.paths)
+                notes.append(
+                    f"github event spool hint for {refresh.repo}#{refresh.number} "
+                    "could not be verified (404); left to the daily anti-entropy sweep"
+                )
+                continue
+            try:
+                entry = IssueEntry.from_api(json.loads(response.body))
+            except (json.JSONDecodeError, TypeError, ValueError, KeyError):
+                # 壞回應不寫鏡像，也不消費事件（下一輪重試）。
+                report["deferred"] += len(refresh.paths)
+                notes.append(
+                    f"github event spool targeted refresh for {refresh.repo}#{refresh.number} "
+                    "returned malformed JSON"
+                )
+                continue
+            if entry.number != refresh.number:
+                # 回的不是我們問的那個物件（transfer 重編號等）——不信。
+                report["deferred"] += len(refresh.paths)
+                notes.append(
+                    f"github event spool targeted refresh for {refresh.repo}#{refresh.number} "
+                    f"returned issue #{entry.number}"
+                )
+                continue
+            report["verified"] += 1
+            if response.etag is not None:
+                etags = {**etags, refresh.number: response.etag}
+            known = by_number.get(entry.number)
+            if known is None or known.differs_from(entry):
+                # inferred（事件）→ confirmed（GitHub 自己回的物件）才進鏡像。
+                by_number[entry.number] = entry
+                changed = True
+                report["confirmed"] += 1
+            consume.extend(refresh.paths)
+
+        return _SpoolResult(
+            entries=tuple(sorted(by_number.values(), key=lambda item: item.number)),
+            targeted_etags=etags,
+            consume=tuple(consume),
+            changed=changed,
+            report=report,
+        )
+
+    def _already_covered(
+        self,
+        refresh: TargetedRefresh,
+        *,
+        cycle_started: datetime | None,
+        delta_numbers: frozenset[int],
+        full_read: bool,
+    ) -> bool:
+        """本輪的清單讀取是否已經涵蓋這個事件（→ 免一次 targeted 請求）。
+
+        成立條件：事件在本輪請求發出**之前**產生，且該物件確實被本輪讀回來過
+        （出現在增量 delta，或本輪是全量重讀）。GitHub 端的 replication lag 是這
+        個推論唯一的殘餘風險，而那本來就是每日 anti-entropy 的守備範圍。
+        """
+
+        if cycle_started is None:
+            return False
+        try:
+            emitted = refresh.emitted_at_time
+        except ValueError:
+            return False
+        if emitted > cycle_started:
+            return False
+        return full_read or refresh.number in delta_numbers
+
     def _entries(self, response: GitHubResponse) -> tuple[IssueEntry, ...]:
         try:
             payload = json.loads(response.body)
@@ -1166,7 +1426,9 @@ class GitHubWorkProvider:
         except (json.JSONDecodeError, TypeError, ValueError, KeyError) as error:
             raise _GitHubRequestError("github API returned malformed JSON") from error
 
-    def _request(self, path: str, *, etag: str | None = None) -> GitHubResponse:
+    def _request(
+        self, path: str, *, etag: str | None = None, not_found_ok: bool = False
+    ) -> GitHubResponse:
         if self.pressure_gate is not None:
             # 節流改為 per-request：改動前一次 `--paginate` 是 gh 在行程內自己
             # 連發分頁，閘門完全管不到那些請求。
@@ -1195,6 +1457,11 @@ class GitHubWorkProvider:
         # 304 必須先判：gh 對任何非 2xx 都以非零離開（實測 `gh: HTTP 304`），
         # 但條件請求命中是**成功**，不是失敗。
         if response is not None and response.not_modified:
+            return response
+        # D4：targeted 驗證要能分辨 404（物件讀不到，交給 anti-entropy）與其他
+        # 失敗（重試）。與 304 同理，gh 對 404 也以非零離開，所以得在 returncode
+        # 分診之前先認狀態行——但只有明確要求的呼叫端才拿得到這個回應。
+        if not_found_ok and response is not None and response.status == HTTP_NOT_FOUND:
             return response
         if completed.returncode != 0:
             message = (

--- a/paulsha_cortex/monitor/work_api.py
+++ b/paulsha_cortex/monitor/work_api.py
@@ -13,6 +13,7 @@ from typing import Callable, Mapping, Sequence
 
 from .config import load_config
 from .correlation import InferredSignal, correlate_work_sources
+from .event_spool import EventSpool
 from .git_mirror import GITHUB_HTTPS_REMOTE, GITHUB_SSH_REMOTE
 from .github_issue_sync import IssueSyncStore
 from .github_pressure import GitHubPressureGate
@@ -430,6 +431,7 @@ class WorkModelRefresher:
         now: Callable[[], datetime] | None = None,
         github_pressure_gate: GitHubPressureGate | None = None,
         issue_sync_store: IssueSyncStore | None = None,
+        event_spool: EventSpool | None = None,
     ) -> None:
         self.durable_store = durable_store
         self.read_store = read_store
@@ -449,6 +451,10 @@ class WorkModelRefresher:
         # 必須活得比 provider 久——provider 是 per-repo per-cycle 建的，游標卻要
         # 跨輪次續存，狀態掛在 provider 上等於每輪都全量。
         self.issue_sync_store = issue_sync_store or IssueSyncStore()
+        # #506 / D4：本機事件入口。跟游標一樣必須活得比 per-repo provider 久——
+        # spool 是跨 repo 的單一目錄，掃描結果由各 repo 的 provider 各取所需。
+        # 目錄不存在（D5 hook 尚未部署）就是一次空掃描，不建目錄、不報錯。
+        self.event_spool = event_spool or EventSpool()
         self.workflow_provider_factory = workflow_provider_factory or WorkflowRegistryProvider
         self.stale_after_seconds = stale_after_seconds
         self.now = now or (lambda: datetime.now(timezone.utc))
@@ -527,6 +533,9 @@ class WorkModelRefresher:
                             pressure_gate=self.github_pressure_gate,
                             # D3：沒有這個 store 就沒有游標可續，每輪都會退回全量。
                             sync_store=self.issue_sync_store,
+                            # D4：事件 spool 是加速器——沒有它就純粹退回 D3 的
+                            # refresh 週期發現延遲，不影響正確性。
+                            event_spool=self.event_spool,
                         )
                         if self._uses_default_github_provider
                         else self.github_provider_factory(repo)

--- a/tests/test_monitor_event_spool_506.py
+++ b/tests/test_monitor_event_spool_506.py
@@ -1,0 +1,838 @@
+"""#506 / D4：monitor 事件入口（spool）＋targeted refresh 的驗收鎖。
+
+契約全文見 ``monitor/event_spool`` 模組 docstring。本檔逐條鎖住：
+
+- **spool 契約**：一事件一檔、原子寫入、信封欄位、fire-and-forget 寫入端語意
+- **消費端**：targeted 條件請求 → 驗證通過才更新鏡像 → 處理成功才消費事件檔
+- **順序與去重**：同物件多事件收斂為一次驗證；亂序／過期事件安全跳過
+- **壞檔隔離**：壞事件檔隔離到 ``quarantine/``，不阻塞同一輪的其他事件
+- **fail-safe**：targeted 驗證失敗（請求錯誤／404／壞 JSON）一律不寫鏡像
+
+全程不打真實 GitHub API——mock 的是 ``gh api`` 的輸出（HTTP 層）。
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from paulsha_cortex.monitor.event_spool import (
+    EVENT_SCHEMA,
+    EVENT_TYPE_GITHUB_OBJECT,
+    EVENT_TYPE_JOB,
+    EVENT_TYPE_STEERING,
+    RESERVED_EVENT_TYPES,
+    EventSpool,
+    SpoolEvent,
+    SpoolEventError,
+    coalesce_hints,
+    github_object_hint,
+)
+from paulsha_cortex.monitor.github_issue_sync import (
+    IssueSyncState,
+    IssueSyncStore,
+    issue_request_path,
+)
+from paulsha_cortex.monitor.providers import GitHubWorkProvider
+
+
+REPO = "acme/demo"
+CYCLE = "2026-08-15T12:00:00Z"
+BEFORE = "2026-08-15T11:59:00Z"
+AFTER = "2026-08-15T12:00:30Z"
+
+
+# ---------------------------------------------------------------------------
+# 測試替身
+# ---------------------------------------------------------------------------
+
+
+def issue(
+    number: int,
+    *,
+    state: str = "open",
+    updated_at: str = "2026-08-15T09:00:00Z",
+    labels: tuple[str, ...] = (),
+    title: str | None = None,
+    pull_request: bool = False,
+) -> dict:
+    entity: dict = {
+        "number": number,
+        "title": title or f"issue {number}",
+        "state": state,
+        "node_id": f"NODE{number}",
+        "updated_at": updated_at,
+        "labels": [{"name": name} for name in labels],
+    }
+    if pull_request:
+        entity["pull_request"] = {"url": f"https://api.github.test/pulls/{number}"}
+    return entity
+
+
+def _response(status_line: str, payload: object, *, etag: str | None) -> subprocess.CompletedProcess:
+    headers = [f"Etag: {etag}\r"] if etag else []
+    body = "" if payload is None else json.dumps(payload)
+    stdout = "\n".join([status_line, *headers, "\r"]) + "\n" + body
+    returncode = 0 if status_line.endswith("200 OK") else 1
+    return subprocess.CompletedProcess(
+        args=("gh",), returncode=returncode, stdout=stdout, stderr=""
+    )
+
+
+def ok_list(*entities: dict, etag: str = 'W/"list"'):
+    return _response("HTTP/2.0 200 OK", list(entities), etag=etag)
+
+
+def ok_object(entity: dict, *, etag: str = 'W/"object"'):
+    """單物件 targeted 回應。"""
+    return _response("HTTP/2.0 200 OK", entity, etag=etag)
+
+
+def not_modified(etag: str = '"object"'):
+    return subprocess.CompletedProcess(
+        args=("gh",),
+        returncode=1,
+        stdout=f"HTTP/2.0 304 Not Modified\nEtag: {etag}\r\n\r\n",
+        stderr="gh: HTTP 304",
+    )
+
+
+def not_found():
+    return subprocess.CompletedProcess(
+        args=("gh",),
+        returncode=1,
+        stdout='HTTP/2.0 404 Not Found\r\n\r\n{"message":"Not Found"}',
+        stderr="gh: Not Found (HTTP 404)",
+    )
+
+
+def failure(stderr: str = "HTTP 500: upstream exploded"):
+    return subprocess.CompletedProcess(args=("gh",), returncode=1, stdout="", stderr=stderr)
+
+
+class Runner:
+    def __init__(self, *responses) -> None:
+        self.responses = list(responses)
+        self.calls: list[tuple[str, ...]] = []
+
+    def run(self, argv, *, timeout=None):  # noqa: ARG002 - 契約簽章
+        argv = tuple(argv)
+        self.calls.append(argv)
+        if not self.responses:
+            raise AssertionError(f"未預期的第 {len(self.calls)} 次 gh 呼叫：{argv}")
+        return self.responses.pop(0)
+
+    @property
+    def paths(self) -> list[str]:
+        return [argv[-1] for argv in self.calls]
+
+    def conditional_headers(self) -> list[str]:
+        headers = []
+        for argv in self.calls:
+            for index, token in enumerate(argv):
+                if token == "--header" and argv[index + 1].startswith("If-None-Match:"):
+                    headers.append(argv[index + 1])
+        return headers
+
+
+@pytest.fixture()
+def spool(tmp_path: Path) -> EventSpool:
+    return EventSpool(tmp_path / "event-spool")
+
+
+@pytest.fixture()
+def store(tmp_path: Path) -> IssueSyncStore:
+    return IssueSyncStore(tmp_path / "github-issue-sync.json")
+
+
+def provider(store, runner, spool=None, *, now=CYCLE, **kwargs):
+    return GitHubWorkProvider(
+        REPO,
+        runner=runner,
+        sync_store=store,
+        event_spool=spool,
+        now=lambda: now,
+        **kwargs,
+    )
+
+
+def seed_mirror(store: IssueSyncStore, *entries, since="2026-08-15T09:00:00Z") -> None:
+    """把 store 直接推到穩態：有鏡像、有游標、有清單 ETag。
+
+    目的是讓每個 targeted 測試只需要餵「清單端點的 304」＋targeted 回應，
+    專注在 D4 的行為上而不重跑 D3 的協定。
+    """
+
+    from paulsha_cortex.monitor.github_issue_sync import IssueEntry
+
+    store.save(
+        IssueSyncState(
+            repo=REPO,
+            entries=tuple(IssueEntry.from_api(entity) for entity in entries),
+            since=since,
+            etag='W/"list"',
+            etag_request=(
+                "repos/acme/demo/issues?state=all&per_page=100&sort=updated"
+                f"&direction=desc&since={since.replace(':', '%3A')}"
+            ),
+            last_full_sync_at=CYCLE,
+        )
+    )
+
+
+def hint(spool: EventSpool, number: int, *, emitted_at=BEFORE, kind="github_issue", repo=REPO):
+    path = spool.emit_github_object(
+        repo=repo,
+        kind=kind,
+        number=number,
+        source="agent-hook:claude",
+        action="commented",
+        job_id="job-1",
+        now=emitted_at,
+    )
+    assert path is not None
+    return path
+
+
+def spool_files(spool: EventSpool) -> list[str]:
+    return sorted(
+        p.name for p in spool.root.iterdir() if p.is_file() and not p.name.startswith(".")
+    )
+
+
+def observations(snapshot) -> dict:
+    return dict(snapshot.observations["event_spool"])
+
+
+def statuses(snapshot) -> dict[str, str]:
+    return {source.ref: source.status for source in snapshot.sources}
+
+
+# ---------------------------------------------------------------------------
+# A. spool 契約：寫入端
+# ---------------------------------------------------------------------------
+
+
+def test_each_event_is_one_self_describing_file(spool):
+    hint(spool, 11)
+    hint(spool, 12)
+    names = spool_files(spool)
+    assert len(names) == 2
+    document = json.loads((spool.root / names[0]).read_text(encoding="utf-8"))
+    assert document["schema_version"] == EVENT_SCHEMA
+    assert document["event_type"] == EVENT_TYPE_GITHUB_OBJECT
+    assert document["source"] == "agent-hook:claude"
+    assert document["job_id"] == "job-1"
+    assert document["emitted_at"] == BEFORE
+    assert set(document["payload"]) == {"repo", "kind", "number", "action"}
+    assert document["event_id"]
+
+
+def test_event_files_are_0600_and_leave_no_temp_files(spool):
+    path = hint(spool, 11)
+    assert path is not None and path.exists()
+    assert os.stat(path).st_mode & 0o777 == 0o600
+    assert not [p for p in spool.root.iterdir() if p.name.startswith(".")]
+
+
+def test_events_name_an_object_and_never_carry_its_state(spool):
+    """hint 不是 authority：契約層就不給 producer 塞狀態的欄位。"""
+
+    document = json.loads(Path(hint(spool, 11)).read_text(encoding="utf-8"))
+    assert set(document["payload"]) & {"state", "labels", "title", "updated_at"} == set()
+
+
+def test_emit_is_fire_and_forget_when_the_directory_is_unusable(tmp_path, caplog):
+    blocked = tmp_path / "blocked"
+    blocked.write_text("not a directory", encoding="utf-8")
+    spool = EventSpool(blocked / "event-spool")
+    assert (
+        spool.emit_github_object(
+            repo=REPO, kind="github_issue", number=11, source="agent-hook:claude"
+        )
+        is None
+    )
+
+
+def test_emit_rejects_a_malformed_envelope_without_raising(spool):
+    assert (
+        spool.emit_github_object(repo="not-a-repo", kind="github_issue", number=11, source="h")
+        is not None
+    ), "repo 形狀由消費端判定為壞檔，寫入端不做語意驗證"
+    assert (
+        spool.emit_github_object(repo=REPO, kind="github_issue", number=11, source=" ")
+        is None
+    ), "信封欄位缺失在寫入端就擋下，不讓壞檔進 spool"
+
+
+def test_scan_never_creates_the_spool_directory(tmp_path):
+    """D5 尚未部署的機器上，monitor 掃到目錄不存在是常態而非錯誤。"""
+
+    spool = EventSpool(tmp_path / "never-created")
+    assert spool.scan().hints == ()
+    assert not (tmp_path / "never-created").exists()
+
+
+# ---------------------------------------------------------------------------
+# B. 消費端：targeted 條件驗證 → 更新鏡像 → 消費事件
+# ---------------------------------------------------------------------------
+
+
+def test_a_named_object_is_verified_by_a_single_object_request(store, spool):
+    seed_mirror(store, issue(11, state="open"))
+    hint(spool, 11)
+    runner = Runner(
+        not_modified('"list"'),  # 清單端點：本輪沒有增量
+        ok_object(issue(11, state="closed", updated_at="2026-08-15T11:59:30Z")),
+    )
+    snapshot = provider(store, runner, spool).scan()
+
+    assert runner.paths[1] == issue_request_path(REPO, 11) == "repos/acme/demo/issues/11"
+    assert statuses(snapshot) == {"acme/demo#11": "closed"}
+    assert store.load(REPO).by_number[11].state == "closed"
+    report = observations(snapshot)
+    assert report["objects"] == 1 and report["verified"] == 1 and report["confirmed"] == 1
+    assert report["consumed"] == 1
+    assert spool_files(spool) == []
+
+
+def test_targeted_etag_is_persisted_and_replayed_as_a_conditional_request(store, spool):
+    seed_mirror(store, issue(11))
+    hint(spool, 11)
+    provider(
+        store,
+        Runner(not_modified('"list"'), ok_object(issue(11, updated_at="2026-08-15T11:59:30Z"), etag='W/"o1"')),
+        spool,
+    ).scan()
+    assert store.load(REPO).targeted_etags_by_number == {11: 'W/"o1"'}
+
+    hint(spool, 11, emitted_at=AFTER)
+    runner = Runner(not_modified('"list"'), not_modified('"o1"'))
+    snapshot = provider(store, runner, spool, now="2026-08-15T12:01:00Z").scan()
+    assert "If-None-Match: W/\"o1\"" in runner.conditional_headers()
+    report = observations(snapshot)
+    assert report["not_modified"] == 1 and report["billed_requests"] == 0
+    assert report["consumed"] == 1
+
+
+def test_targeted_304_never_overwrites_the_stored_etag(store, spool):
+    """與 D3 同一顆地雷：304 回強形式 ETag，寫回去會讓條件請求永遠落空。"""
+
+    seed_mirror(store, issue(11))
+    hint(spool, 11)
+    provider(
+        store,
+        Runner(not_modified('"list"'), ok_object(issue(11, updated_at="2026-08-15T11:59:30Z"), etag='W/"o1"')),
+        spool,
+    ).scan()
+    hint(spool, 11, emitted_at=AFTER)
+    provider(
+        store,
+        Runner(not_modified('"list"'), not_modified('"strong-form"')),
+        spool,
+        now="2026-08-15T12:01:00Z",
+    ).scan()
+    assert store.load(REPO).targeted_etags_by_number == {11: 'W/"o1"'}
+
+
+def test_targeted_reads_never_advance_the_list_cursor(store, spool):
+    """游標只能由清單回應推進——否則會跳過那之間被更新的其他物件。"""
+
+    seed_mirror(store, issue(11), since="2026-08-15T09:00:00Z")
+    hint(spool, 11)
+    provider(
+        store,
+        Runner(not_modified('"list"'), ok_object(issue(11, updated_at="2026-08-15T11:59:30Z"))),
+        spool,
+    ).scan()
+    state = store.load(REPO)
+    assert state.since == "2026-08-15T09:00:00Z"
+    assert state.by_number[11].updated_at == "2026-08-15T11:59:30Z"
+
+
+def test_verification_without_a_difference_leaves_the_mirror_alone(store, spool):
+    seed_mirror(store, issue(11, updated_at="2026-08-15T09:00:00Z"))
+    hint(spool, 11)
+    snapshot = provider(
+        store,
+        Runner(not_modified('"list"'), ok_object(issue(11, updated_at="2026-08-15T09:00:00Z"))),
+        spool,
+    ).scan()
+    report = observations(snapshot)
+    assert report["verified"] == 1 and report["confirmed"] == 0
+    assert report["consumed"] == 1
+
+
+def test_targeted_verification_can_admit_an_object_the_mirror_never_saw(store, spool):
+    seed_mirror(store, issue(11))
+    hint(spool, 77)
+    snapshot = provider(
+        store,
+        Runner(not_modified('"list"'), ok_object(issue(77, title="brand new"))),
+        spool,
+    ).scan()
+    assert sorted(statuses(snapshot)) == ["acme/demo#11", "acme/demo#77"]
+    assert observations(snapshot)["confirmed"] == 1
+
+
+def test_pull_request_hints_use_the_same_issues_endpoint(store, spool):
+    seed_mirror(store, issue(11))
+    hint(spool, 42, kind="github_pr")
+    snapshot = provider(
+        store,
+        Runner(not_modified('"list"'), ok_object(issue(42, pull_request=True))),
+        spool,
+    ).scan()
+    assert {source.ref: source.kind for source in snapshot.sources}["acme/demo#42"] == "github_pr"
+
+
+def test_a_provider_without_a_spool_behaves_exactly_like_d3(store, spool):
+    seed_mirror(store, issue(11))
+    hint(spool, 11)
+    runner = Runner(not_modified('"list"'))
+    snapshot = provider(store, runner, None).scan()
+    assert len(runner.calls) == 1
+    assert "event_spool" not in snapshot.observations
+    assert spool_files(spool), "事件檔原封不動"
+
+
+# ---------------------------------------------------------------------------
+# C. 順序與去重
+# ---------------------------------------------------------------------------
+
+
+def test_many_events_for_one_object_collapse_into_one_verification(store, spool):
+    seed_mirror(store, issue(11))
+    for stamp in ("2026-08-15T11:57:00Z", "2026-08-15T11:58:00Z", BEFORE):
+        hint(spool, 11, emitted_at=stamp)
+    runner = Runner(not_modified('"list"'), ok_object(issue(11, updated_at="2026-08-15T11:59:30Z")))
+    snapshot = provider(store, runner, spool).scan()
+
+    assert runner.paths.count(issue_request_path(REPO, 11)) == 1
+    report = observations(snapshot)
+    assert report["pending"] == 3 and report["objects"] == 1
+    assert report["consumed"] == 3, "收斂掉的事件必須一起被消費，否則下輪重驗"
+    assert spool_files(spool) == []
+
+
+def test_out_of_order_events_do_not_change_the_outcome(store, spool):
+    """事件之間沒有全域順序；每個物件只問 GitHub「你現在長怎樣」。"""
+
+    seed_mirror(store, issue(11))
+    hint(spool, 11, emitted_at=BEFORE)
+    hint(spool, 11, emitted_at="2026-08-15T11:50:00Z")
+    runner = Runner(not_modified('"list"'), ok_object(issue(11, state="closed", updated_at="2026-08-15T11:59:30Z")))
+    snapshot = provider(store, runner, spool).scan()
+    assert statuses(snapshot) == {"acme/demo#11": "closed"}
+    assert observations(snapshot)["objects"] == 1
+
+
+def test_an_event_already_covered_by_this_cycle_costs_no_request(store, spool):
+    """事件比本輪請求早、物件又在本輪 delta 裡 → 鏡像已至少同樣新。"""
+
+    seed_mirror(store, issue(11, state="open"))
+    hint(spool, 11, emitted_at=BEFORE)
+    runner = Runner(ok_list(issue(11, state="closed", updated_at="2026-08-15T11:59:30Z")))
+    snapshot = provider(store, runner, spool).scan()
+
+    assert len(runner.calls) == 1, "targeted 請求完全省下"
+    assert statuses(snapshot) == {"acme/demo#11": "closed"}
+    report = observations(snapshot)
+    assert report["superseded"] == 1 and report["requests"] == 0 and report["consumed"] == 1
+
+
+def test_a_full_sync_covers_every_earlier_event(store, spool):
+    seed_mirror(store, issue(11), issue(12))
+    hint(spool, 11, emitted_at=BEFORE)
+    hint(spool, 12, emitted_at=BEFORE)
+    runner = Runner(ok_list(issue(11), issue(12)))
+    snapshot = provider(
+        store, runner, spool, full_sync_interval_seconds=0.0
+    ).scan()
+    assert len(runner.calls) == 1
+    report = observations(snapshot)
+    assert report["superseded"] == 2 and report["consumed"] == 2
+
+
+def test_a_list_304_is_not_a_read_and_never_covers_an_event(store, spool):
+    """304 什麼都沒讀回來，不能當成「這個物件我剛讀過」。"""
+
+    seed_mirror(store, issue(11))
+    hint(spool, 11, emitted_at=BEFORE)
+    runner = Runner(not_modified('"list"'), ok_object(issue(11, updated_at="2026-08-15T11:59:30Z")))
+    snapshot = provider(store, runner, spool).scan()
+    assert runner.paths[1] == issue_request_path(REPO, 11)
+    assert observations(snapshot)["superseded"] == 0
+
+
+def test_an_event_emitted_after_the_request_is_not_covered(store, spool):
+    seed_mirror(store, issue(11))
+    hint(spool, 11, emitted_at=AFTER)
+    runner = Runner(
+        ok_list(issue(11, updated_at="2026-08-15T11:59:30Z")),
+        ok_object(issue(11, state="closed", updated_at="2026-08-15T12:00:40Z")),
+    )
+    snapshot = provider(store, runner, spool).scan()
+    assert runner.paths[1] == issue_request_path(REPO, 11)
+    assert statuses(snapshot) == {"acme/demo#11": "closed"}
+
+
+def test_events_for_another_repo_are_left_untouched(store, spool):
+    seed_mirror(store, issue(11))
+    hint(spool, 11, repo="other/repo")
+    runner = Runner(not_modified('"list"'))
+    snapshot = provider(store, runner, spool).scan()
+    assert len(runner.calls) == 1
+    assert observations(snapshot)["pending"] == 0
+    assert spool_files(spool), "留給那個 repo 的 provider"
+
+
+def test_events_past_the_per_cycle_limit_wait_for_the_next_cycle(store, spool):
+    seed_mirror(store, issue(11), issue(12), issue(13))
+    hint(spool, 11, emitted_at="2026-08-15T11:50:00Z")
+    hint(spool, 12, emitted_at="2026-08-15T11:51:00Z")
+    hint(spool, 13, emitted_at="2026-08-15T11:52:00Z")
+    runner = Runner(
+        not_modified('"list"'),
+        ok_object(issue(11, updated_at="2026-08-15T11:59:30Z")),
+    )
+    snapshot = provider(store, runner, spool, targeted_refresh_limit=1).scan()
+    report = observations(snapshot)
+    assert report["objects"] == 3 and report["verified"] == 1
+    assert report["consumed"] == 1 and report["deferred"] == 2
+    assert len(spool_files(spool)) == 2
+    assert any("deferred" in note for note in snapshot.diagnostics)
+
+
+def test_coalescing_serves_the_oldest_event_first(spool):
+    paths = [
+        hint(spool, 30, emitted_at="2026-08-15T11:58:00Z"),
+        hint(spool, 10, emitted_at="2026-08-15T11:50:00Z"),
+        hint(spool, 20, emitted_at="2026-08-15T11:55:00Z"),
+    ]
+    assert paths
+    refreshes = coalesce_hints(spool.scan(now=CYCLE).for_repo(REPO), repo=REPO)
+    assert [refresh.number for refresh in refreshes] == [10, 20, 30]
+
+
+# ---------------------------------------------------------------------------
+# D. fail-safe：驗證不到的變更不寫鏡像
+# ---------------------------------------------------------------------------
+
+
+def test_a_failed_verification_writes_nothing_and_consumes_nothing(store, spool):
+    seed_mirror(store, issue(11, state="open"))
+    hint(spool, 11)
+    runner = Runner(not_modified('"list"'), failure())
+    snapshot = provider(store, runner, spool).scan()
+
+    assert snapshot.status == "ok", "清單同步成功；hint 驗不到不是鏡像故障"
+    assert statuses(snapshot) == {"acme/demo#11": "open"}
+    assert store.load(REPO).by_number[11].state == "open"
+    report = observations(snapshot)
+    assert report["confirmed"] == 0 and report["consumed"] == 0 and report["deferred"] == 1
+    assert spool_files(spool), "事件留著，下一輪或每日對帳再處理"
+
+
+def test_the_first_failure_stops_the_remaining_targeted_requests(store, spool):
+    seed_mirror(store, issue(11), issue(12))
+    hint(spool, 11, emitted_at="2026-08-15T11:50:00Z")
+    hint(spool, 12, emitted_at="2026-08-15T11:51:00Z")
+    runner = Runner(not_modified('"list"'), failure())
+    snapshot = provider(store, runner, spool).scan()
+    assert len(runner.calls) == 2
+    assert observations(snapshot)["deferred"] == 2
+
+
+def test_a_404_never_deletes_anything_from_the_mirror(store, spool):
+    """刪除／transfer 只有每日全量對帳看得到；一次 404 不足以當證據。"""
+
+    seed_mirror(store, issue(11), issue(12))
+    hint(spool, 12)
+    runner = Runner(not_modified('"list"'), not_found())
+    snapshot = provider(store, runner, spool).scan()
+
+    assert sorted(statuses(snapshot)) == ["acme/demo#11", "acme/demo#12"]
+    report = observations(snapshot)
+    assert report["unverified"] == 1 and report["confirmed"] == 0
+    assert report["consumed"] == 1, "重試同一個 404 只是燒配額"
+    assert any("anti-entropy" in note for note in snapshot.diagnostics)
+
+
+def test_malformed_targeted_json_writes_nothing_and_consumes_nothing(store, spool):
+    seed_mirror(store, issue(11, state="open"))
+    hint(spool, 11)
+    runner = Runner(
+        not_modified('"list"'),
+        _response("HTTP/2.0 200 OK", {"number": 11, "title": "no node id"}, etag=None),
+    )
+    snapshot = provider(store, runner, spool).scan()
+    assert statuses(snapshot) == {"acme/demo#11": "open"}
+    assert observations(snapshot)["deferred"] == 1
+    assert spool_files(spool)
+
+
+def test_a_response_for_a_different_object_is_not_trusted(store, spool):
+    seed_mirror(store, issue(11, state="open"))
+    hint(spool, 11)
+    runner = Runner(not_modified('"list"'), ok_object(issue(99, state="closed")))
+    snapshot = provider(store, runner, spool).scan()
+    assert statuses(snapshot) == {"acme/demo#11": "open"}
+    assert observations(snapshot)["confirmed"] == 0
+    assert spool_files(spool)
+
+
+def test_the_backoff_window_leaves_the_spool_untouched(store, spool):
+    from paulsha_cortex.monitor.github_pressure import GitHubPressureGate
+
+    seed_mirror(store, issue(11))
+    hint(spool, 11)
+    gate = GitHubPressureGate(interval_seconds=0, jitter_seconds=0, sleeper=lambda _: None)
+    gate.note_rate_limited()
+    runner = Runner()
+    snapshot = provider(store, runner, spool, pressure_gate=gate).scan()
+    assert snapshot.status == "degraded" and runner.calls == []
+    assert spool_files(spool)
+
+
+def test_events_are_not_consumed_when_the_state_was_not_persisted(store, spool, monkeypatch):
+    seed_mirror(store, issue(11, state="open"))
+    hint(spool, 11)
+
+    def explode(self, state):  # noqa: ANN001 - monkeypatch
+        raise OSError("read-only file system")
+
+    monkeypatch.setattr(IssueSyncStore, "save", explode)
+    runner = Runner(not_modified('"list"'), ok_object(issue(11, state="closed", updated_at="2026-08-15T11:59:30Z")))
+    snapshot = provider(store, runner, spool).scan()
+    report = observations(snapshot)
+    assert report["consumed"] == 0 and report["deferred"] == 1
+    assert spool_files(spool), "鏡像沒落地，事件就還沒被處理完"
+
+
+# ---------------------------------------------------------------------------
+# E. 壞事件檔隔離
+# ---------------------------------------------------------------------------
+
+
+def test_a_bad_event_file_is_quarantined_without_blocking_the_rest(store, spool):
+    seed_mirror(store, issue(11))
+    hint(spool, 11)
+    spool.root.joinpath("00000000-broken.json").write_text("{ not json", encoding="utf-8")
+
+    runner = Runner(not_modified('"list"'), ok_object(issue(11, updated_at="2026-08-15T11:59:30Z")))
+    snapshot = provider(store, runner, spool).scan()
+
+    assert observations(snapshot)["quarantined"] == 1
+    assert observations(snapshot)["verified"] == 1
+    assert (spool.quarantine_root / "00000000-broken.json").exists()
+    assert spool_files(spool) == []
+
+
+@pytest.mark.parametrize(
+    ("document", "label"),
+    [
+        ({"schema_version": EVENT_SCHEMA}, "信封全缺"),
+        ({"schema_version": EVENT_SCHEMA, "event_id": "a", "event_type": "github_object",
+          "emitted_at": "2026-08-15T11:59:00", "source": "h",
+          "payload": {"repo": REPO, "kind": "github_issue", "number": 1}}, "時間戳無時區"),
+        ({"schema_version": EVENT_SCHEMA, "event_id": "a", "event_type": "github_object",
+          "emitted_at": BEFORE, "source": "h",
+          "payload": {"repo": "no-slash", "kind": "github_issue", "number": 1}}, "repo 形狀"),
+        ({"schema_version": EVENT_SCHEMA, "event_id": "a", "event_type": "github_object",
+          "emitted_at": BEFORE, "source": "h",
+          "payload": {"repo": REPO, "kind": "wiki", "number": 1}}, "未知 kind"),
+        ({"schema_version": EVENT_SCHEMA, "event_id": "a", "event_type": "github_object",
+          "emitted_at": BEFORE, "source": "h",
+          "payload": {"repo": REPO, "kind": "github_issue", "number": "1"}}, "編號非整數"),
+        ({"schema_version": EVENT_SCHEMA, "event_id": "a", "event_type": "github_object",
+          "emitted_at": BEFORE, "source": "h",
+          "payload": {"repo": REPO, "kind": "github_issue", "number": True}}, "bool 不是編號"),
+        ([1, 2, 3], "根不是物件"),
+    ],
+)
+def test_structurally_broken_events_are_quarantined(spool, document, label):
+    spool.root.mkdir(parents=True, exist_ok=True)
+    spool.root.joinpath("bad.json").write_text(json.dumps(document), encoding="utf-8")
+    scan = spool.scan(now=CYCLE)
+    assert scan.hints == (), label
+    assert scan.quarantined == ("bad.json",), label
+    assert (spool.quarantine_root / "bad.json").exists(), label
+
+
+def test_expired_orphan_events_are_quarantined_not_hoarded(spool):
+    hint(spool, 11, emitted_at="2026-07-01T00:00:00Z")
+    scan = spool.scan(now=CYCLE)
+    assert scan.hints == () and len(scan.quarantined) == 1
+    assert list(spool.quarantine_root.iterdir())
+
+
+def test_the_quarantine_directory_is_never_scanned_as_events(spool):
+    hint(spool, 11)
+    spool.quarantine_root.mkdir(parents=True, exist_ok=True)
+    spool.quarantine_root.joinpath("old.json").write_text("{ broken", encoding="utf-8")
+    scan = spool.scan(now=CYCLE)
+    assert len(scan.hints) == 1 and scan.quarantined == ()
+
+
+def test_a_half_written_temp_file_is_invisible_to_the_consumer(spool):
+    spool.root.mkdir(parents=True, exist_ok=True)
+    spool.root.joinpath(".event-halfwritten.tmp").write_text('{"schema', encoding="utf-8")
+    scan = spool.scan(now=CYCLE)
+    assert scan.hints == () and scan.quarantined == ()
+
+
+# ---------------------------------------------------------------------------
+# F. #498 擴充點：其他事件型別記 log 不處理
+# ---------------------------------------------------------------------------
+
+
+def test_steering_and_job_events_are_held_in_place_and_only_counted(store, spool, caplog):
+    seed_mirror(store, issue(11))
+    for event_type in (EVENT_TYPE_STEERING, EVENT_TYPE_JOB):
+        assert spool.emit(
+            SpoolEvent(
+                event_id=f"{event_type}-1",
+                event_type=event_type,
+                emitted_at=BEFORE,
+                source="agent-hook:claude",
+                payload={"job_id": "job-1"},
+            )
+        )
+    with caplog.at_level("INFO"):
+        snapshot = provider(store, Runner(not_modified('"list"')), spool).scan()
+
+    report = observations(snapshot)
+    assert report["ignored"] == {EVENT_TYPE_STEERING: 1, EVENT_TYPE_JOB: 1}
+    assert report["consumed"] == 0
+    assert len(spool_files(spool)) == 2, "屬於未來的 consumer，這裡不得刪"
+    assert not spool.quarantine_root.exists()
+    assert any("unconsumed event" in record.message for record in caplog.records)
+
+
+def test_reserved_event_types_stay_distinct_from_github_objects():
+    assert EVENT_TYPE_GITHUB_OBJECT not in RESERVED_EVENT_TYPES
+    assert RESERVED_EVENT_TYPES == {"steering", "job"}
+
+
+def test_unknown_types_and_schemas_are_held_not_quarantined(spool):
+    assert spool.emit(
+        SpoolEvent(
+            event_id="future-1",
+            event_type="workflow_run",
+            emitted_at=BEFORE,
+            source="agent-hook:claude",
+        )
+    )
+    spool.root.joinpath("future-schema.json").write_text(
+        json.dumps(
+            {
+                "schema_version": "monitor-event-spool/v2",
+                "event_id": "future-2",
+                "event_type": "github_object",
+                "emitted_at": BEFORE,
+                "source": "agent-hook:claude",
+            }
+        ),
+        encoding="utf-8",
+    )
+    scan = spool.scan(now=CYCLE)
+    assert scan.hints == () and scan.quarantined == ()
+    assert scan.ignored == {"workflow_run": 1} and scan.foreign_schema == 1
+    assert len(spool_files(spool)) == 2
+
+
+# ---------------------------------------------------------------------------
+# G. 契約單元
+# ---------------------------------------------------------------------------
+
+
+def test_targeted_path_is_a_single_object_endpoint():
+    assert issue_request_path(REPO, 11) == "repos/acme/demo/issues/11"
+    with pytest.raises(ValueError):
+        issue_request_path(REPO, 0)
+    with pytest.raises(ValueError):
+        issue_request_path(REPO, True)
+
+
+def test_targeted_etags_are_pruned_with_the_mirror():
+    from paulsha_cortex.monitor.github_issue_sync import IssueEntry
+
+    state = IssueSyncState(
+        repo=REPO, entries=(IssueEntry.from_api(issue(11)),)
+    ).with_targeted_etags({11: 'W/"a"', 99: 'W/"b"'})
+    assert state.targeted_etags_by_number == {11: 'W/"a"'}
+
+
+def test_targeted_etag_table_round_trips_and_fails_closed(store):
+    from paulsha_cortex.monitor.github_issue_sync import IssueEntry, IssueSyncStateError
+
+    state = IssueSyncState(
+        repo=REPO, entries=(IssueEntry.from_api(issue(11)),), targeted_etags=((11, 'W/"a"'),)
+    )
+    store.save(state)
+    assert store.load(REPO).targeted_etags_by_number == {11: 'W/"a"'}
+
+    document = json.loads(store.path.read_text(encoding="utf-8"))
+    document["repos"][REPO]["targeted_etags"] = {"eleven": 'W/"a"'}
+    store.path.write_text(json.dumps(document), encoding="utf-8")
+    with pytest.raises(IssueSyncStateError):
+        store.load(REPO)
+
+
+def test_event_filenames_cannot_be_steered_by_event_content(spool):
+    event = SpoolEvent(
+        event_id="a" * 64,
+        event_type=EVENT_TYPE_GITHUB_OBJECT,
+        emitted_at=BEFORE,
+        source="../../escape",
+        payload={"repo": REPO, "kind": "github_issue", "number": 1},
+    )
+    path = spool.emit(event)
+    assert path is not None and path.parent == spool.root
+    assert "/" not in path.name and ".." not in path.name
+
+
+def test_the_envelope_rejects_a_path_bearing_event_id():
+    with pytest.raises(SpoolEventError):
+        SpoolEvent(
+            event_id="../../etc/passwd",
+            event_type=EVENT_TYPE_GITHUB_OBJECT,
+            emitted_at=BEFORE,
+            source="h",
+        )
+
+
+def test_a_hint_keeps_its_originating_event_for_diagnostics(spool):
+    hint(spool, 11)
+    scanned = spool.scan(now=CYCLE).hints[0]
+    assert scanned.ref == "acme/demo#11"
+    assert scanned.event.source == "agent-hook:claude"
+    assert scanned.event.payload["action"] == "commented"
+    assert scanned.event.job_id == "job-1"
+
+
+def test_github_object_hint_validates_its_payload():
+    event = SpoolEvent(
+        event_id="e1",
+        event_type=EVENT_TYPE_GITHUB_OBJECT,
+        emitted_at=BEFORE,
+        source="h",
+        payload={"repo": REPO, "kind": "github_issue", "number": 11},
+    )
+    assert github_object_hint(event, Path("x.json")).number == 11
+    with pytest.raises(SpoolEventError):
+        github_object_hint(
+            SpoolEvent(
+                event_id="e2",
+                event_type=EVENT_TYPE_GITHUB_OBJECT,
+                emitted_at=BEFORE,
+                source="h",
+                payload={},
+            ),
+            Path("x.json"),
+        )


### PR DESCRIPTION
Refs #506 #498

v4 重構計畫 R0.5 **D4**：monitor 事件入口（spool）＋targeted refresh（原則 6）。
GitHub 邊界重構讀取側的最後一塊——D1／D2／D3 已落地，本 PR 只做 monitor 側的
**消費機制與契約**；**D5（headless agent hook 注入）不在本次**，launcher 一行未動。

## 問題

D1–D3 把 monitor 對 GitHub 的常態讀取壓到每 repo 每日 26 次計費請求，代價是**發現
延遲**：一件事發生在 GitHub 上，最壞要等一個 refresh 週期才進鏡像。對「fleet 自己
剛剛動過的物件」而言這個延遲是白等的——動手的是我們自己，當下就知道哪個物件被動
了，卻還是只能等下一次輪詢把整個清單再問一遍。

## spool 契約（D5 hook 依此實作；`paulsha_cortex/monitor/event_spool.py` 是唯一真值）

| 面向 | 契約 |
| --- | --- |
| 位置 | `monitor_event_spool_root()`＝`<agents>/monitor/event-spool/`（隨 `PSC_MONITOR_STATE_ROOT`／`PSC_AGENTS_ROOT` 移動）；壞檔隔離到同層 `quarantine/` |
| 粒度 | **每事件一檔**，`<emitted_at 壓平>-<event_id 前綴>.json` |
| 原子性 | temp 檔（`.` 前綴，掃描端跳過 dotfile）→ fsync → `os.replace`，權限 0600 |
| 信封 | `schema_version`／`event_id`／`event_type`／`emitted_at`／`source`（缺一即壞檔）＋選配 `job_id`／`payload` |
| 目錄建立 | 由**寫入端**建立。monitor 掃到目錄不存在＝「這台機器沒有 hook」，不是錯誤，也不替它建 |

**fire-and-forget 寫入端語意**：`EventSpool.emit()` 不等任何回應、不與 monitor 交握、
**永不 raise**——寫失敗只回 `None` 並記 debug log（不是 warning：寫入端可能是每個
tool call 都跑一次的 hook，warning 會變成噪音源）。hook 掛在別人（agent job）的工作
路徑上，spool 寫不進去絕不能影響工作本體；掉一則 hint 的後果只是退回原本的 refresh
週期延遲，而那正是 D3 每日 anti-entropy 的守備範圍。

**事件是 hint 不是 authority**：`github_object` 事件只帶「哪個 repo 的哪個編號被動
了」，**契約層就不給 producer 塞新狀態的欄位**（`action` 純屬診斷，consumer 永不
據以寫鏡像）。這對應 `correlation` 既有的 inferred→confirmed 語彙：spool hint 是
inferred 訊號，只有 targeted 驗證回來的物件才是 confirmed、才進鏡像。

一事件一檔讓「消費」就是 per-file `unlink`——不需要鎖、offset 檔或任何跨行程協調；
檔名全程過濾成 `[A-Za-z0-9._-]`，事件內容無法影響它落在哪個路徑。

## 消費端（`GitHubWorkProvider`）

D3 的清單同步跑完之後才消費 spool——先做便宜的批次讀取，被它涵蓋到的事件就不必再
各花一次請求。

- **targeted 條件請求**：單物件 `repos/{repo}/issues/{number}`（PR 走同一端點，
  事件的 `kind` 只進診斷），沿用 D3 的 ETag／計費紀律。per-object ETag 存進
  `IssueSyncState.targeted_etags`，與清單端點的 `etag` **分開存**：兩者 request path
  不同，混用會讓條件請求永遠落空。這條 path 不含 `since`，因此游標前進不會讓它作廢；
  **304 一路不取回應的 ETag**（GitHub 304 回強形式、200 回 `W/` 弱形式，覆蓋回去會
  讓條件請求永遠落空而悄悄退化成全額計費——與 D3 同一顆地雷）。
- **游標不受 targeted 影響**：targeted 讀回來的新狀態**不得**推進 `since`。游標只能
  由清單回應推進，否則會跳過那之間被更新的其他物件。
- **順序與去重**：同物件多事件收斂成**一次**驗證，所有貢獻事件檔**一起**消費（只刪
  一個檔就等於下輪重驗）。事件之間本來就沒有全域順序，consumer 也不推論順序——每個
  物件只問 GitHub「你現在長怎樣」，答案與事件先後無關，因此亂序天然無害。
- **過期安全跳過**：事件早於本輪請求、且該物件已被本輪讀取涵蓋（出現在增量 delta，
  或本輪是全量），鏡像就已經至少和事件一樣新——直接消費事件、**不花請求**。spool 是
  本機目錄，producer 與 consumer 共用同一顆時鐘，這個時間比較才成立；GitHub 端的
  replication lag 是唯一殘餘風險，而那本來就歸每日 anti-entropy。清單回 **304 不算
  一次讀取**（它什麼都沒讀回來），不得算進涵蓋範圍。
- **處理成功才消費**：事件檔一路留到鏡像真的落地（state 存檔成功）為止。中途 crash
  的代價只是下一輪重驗一次，而條件請求命中 304 連配額都不花。
- **fail safe**：targeted 請求失敗／回壞 JSON／回的不是問的那個物件——一律**不寫鏡像
  也不消費事件**；回 404 則**不從鏡像刪任何東西**（刪除／transfer 只有每日全量對帳
  看得到，一次 404 不足以區分「真的沒了」與「一時讀不到」），但消費該事件以免無限
  重試燒配額。第一個 targeted 失敗即停掉本輪其餘 targeted 請求（多半是限流／認證，
  繼續打只會把退避窗撐更深）。退避窗內整輪跳過，spool 原封不動。
- **壞檔隔離不阻塞**：JSON 壞掉、信封缺欄位、payload 形狀不合、超過 TTL（7 天）的
  孤兒事件——一律移進 `quarantine/`（隔離而非刪除：那是要給人看的），同一輪其餘事件
  照常處理。
- **per-cycle 上限 20**：hook 是 per-tool-call 觸發的，一個活躍 job 可以在半小時內
  點名幾十次；沒有上限就等於把 D1–D3 省下的配額交還給事件量決定。超出的事件留在
  spool，下一輪依 `emitted_at` 先來先服務。
- **記帳**：`observations["event_spool"]` 記 pending／objects／superseded／verified／
  confirmed／not_modified／unverified／requests／billed_requests／consumed／deferred／
  quarantined／ignored。**未接 spool 時整個鍵不出現**，既有觀測消費端一行都不用改。

## #498 預留與擴充點

`event_type` 是封閉列舉的**擴充位**。本次只消費 `github_object`；`steering`／`job`
（#498 的 remote-control 佇列與 job 心跳）已在 `RESERVED_EVENT_TYPES` 佔位，掃到時
**原地保留、只記 log 與計數、絕不刪除**——那些事件屬於未來的另一個 consumer，這裡
刪掉就是替它們決定生命週期。同理，未知 `event_type` 與未知 `schema_version`（較新的
producer 對上較舊的 consumer）一律保留不動，只有**結構壞掉**的檔案才會被隔離。

#498 落地時的擴充點：新增一個消費該型別的 consumer 即可，spool 契約（位置／一事件
一檔／原子寫入／fire-and-forget／信封欄位）、隔離機制與 TTL 全部照用；`payload` 是
per-type 自由欄位，`job_id` 信封欄位已備妥給 job 心跳（#536／#488）串接。

## 範圍紀律

- **不做**：D5 的 hook 注入、launcher 改動、寫入路徑、label API、events API。
- **相容**：沒有 spool 目錄（或未注入 `EventSpool`）時，provider 行為與 D3 逐位元組
  相同——事件入口是**加速器**，不是任何東西的必要條件。
- `IssueSyncState.targeted_etags` 為新增的選配欄位，#506/D3 之前寫下的 state 照載；
  壞形狀一律 fail closed 退回全量重建（與 D3 其餘欄位同一套紀律）。

## 測試

`tests/test_monitor_event_spool_506.py`（51 個測試，**不打真實 GitHub API**，mock 的
是 `gh api` 的 HTTP 層輸出）：spool 寫入契約／targeted 驗證與鏡像更新／per-object
ETag 條件請求與 304 紀律／游標不被 targeted 推進／同物件去重／亂序／已涵蓋事件零請求
／清單 304 不算涵蓋／per-cycle 上限／請求失敗與 404 與壞 JSON 的 fail-safe／狀態未
落地即不消費／壞檔與過期孤兒隔離／#498 預留型別原地保留。

- 目標測試：`tests/test_monitor_event_spool_506.py` 51 passed
- D2／D3 迴歸：`test_monitor_git_native_reads_506.py` ＋
  `test_monitor_incremental_issue_sync_506.py` 51 passed
- 全套：`python3 -m pytest -q` → **2930 passed, 49 subtests passed**

## Checklist

- [x] `changelog.d/d4-event-spool.md` fragment 已新增且已 commit
- [x] `CHANGELOG.md [Unreleased]` 有對應 entry
- [x] `VERSION` 與意圖一致（非 release PR，未動）
- [x] 全套測試通過
- [x] docs 同步（`docs/monitor-config.md` 新增 D4 段）
- [x] 語言 zh-tw（本 repo 屬 `hamanpaul`）

`policy-exempt:issue-link`：本 PR 是 #506 R0.5 D4 的其中一項交付，#506 需待 D5／D6
完成才收；#498 只是預留擴充點、本次不實作，兩者皆不可 closing-keyword 關閉。
