### PR TITLE
feat(launcher): headless-only 事件 hook 讓 claude job 動過的 GitHub 物件當輪被驗證

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,45 @@
 ## [Unreleased]
 
 ### Added
+- **Issue #506 / D5：headless-only hook 儀器化（claude 先）——D4 spool 的第一個
+  producer**——D4 開了本機事件通道卻**沒有任何 producer**：monitor 每輪掃到的永遠
+  是空目錄，D1–D3 省下配額的代價（發現延遲）一分錢也沒買回來。新增
+  `paulsha_cortex/porcelain/headless_hook.py` 與 `cortex headless-hook
+  post-tool-use`：headless claude **builder** job 每跑完一次 `Bash` 工具，由
+  launcher 注入的 PostToolUse hook 從命令解析出被動過的 GitHub 物件，依 D4 契約寫一
+  則 `github_object` 事件。**使用者硬約束「hook 不得影響正常的互動式 agent 使用」以
+  兩道彼此獨立的結構保證落地**（任一道成立，互動 session 即完全 no-op）：(1) **hook
+  只經 launcher 注入且從不落地任何檔案**——宣告由 `SubprocessLauncher.launch()` 每次
+  現場組出（`_claude_spool_hook_settings()`），經 argv 的 `--settings` 只交給該 job
+  的行程，**不寫 `~/.claude/settings.json`、不寫任何 user 層設定、不寫磁碟**；互動
+  session 讀 operator 自己的設定，那裡沒有這個 hook，因此**連呼叫寫入端的機會都
+  沒有**；打包的使用者全域模板 `scripts/hooks/claude.json`（paulshaclaw thin install
+  的切點）刻意不含它，並有測試釘死。(2) **`PSC_JOB_ID` 自守**——`launch()`／
+  `executor_environment()` 為派工的 job 注入該標記，`emit_for_tool_use()` 讀不到就直
+  接返回，**不建 spool 目錄、不寫檔、不起 subprocess、連命令都不解析**。**只有
+  builder 掛 hook**：read-only planner 走 `--tools ""`（沒有 Bash），review-only
+  reviewer 是 read-only 契約且其 `--settings` 是那份 deny 掉 `$HOME` 的 sandbox 政策；
+  marker 與注入點成對出現，不留「有標記卻沒 hook」的半套狀態。**為何是 `--settings`
+  overlay 而非 hermetic `CLAUDE_CONFIG_DIR`**：#404 為 planning 的純 JSON 回聲任務所做
+  的 hermetic 選擇若搬到 builder，會一併抽掉 operator 的 `permissions` allowlist，讓
+  headless job 卡在無人可核可的授權提示——那是遠超出 D5 範圍的行為變更；overlay 同樣
+  是 per-job、走 argv、不落地，且 builder 既有設定原封不動。**hint 不是 authority**：
+  事件只帶 repo＋kind＋編號、**不帶新狀態**，`action` 純屬診斷；解析刻意往「寧可漏
+  報」失準——只認封閉列舉的 `gh issue`／`gh pr` mutation 動詞與非 GET/HEAD 的
+  `gh api` 單物件路徑（`issues/comments/{id}` 改的是留言、不會被誤認成 issue），旗標
+  一律當成吃一個值跳過（`--add-label 3` 的 `3` 不會被當編號），一行內 `&&`／`;` 串接
+  的多個命令全解析並收斂去重，沒帶 `--repo` 時從 job worktree 的 `origin` 補、補不到
+  就丟掉。漏報只是退回 refresh 週期延遲（D3 每日 anti-entropy 的守備範圍），誤報只是
+  白花一次條件請求且永遠不污染鏡像。**fire-and-forget**：所有失敗吞成 debug log，CLI
+  一律 exit 0 且 **stdout 保持空**（PostToolUse 的 stdout 會被當決策讀、非零 exit 會
+  被回報成 hook 失敗甚至回饋給模型），注入的命令再以 `|| true` 兜住 CLI 之外的失敗
+  （`cortex` 不在 PATH／套件損壞）並設 `timeout` 上限確保不阻塞 job。**#536／#488 心
+  跳本次只預留信封**：每則事件都帶 `job_id`，D4 信封的 `job_id` 欄位與
+  `RESERVED_EVENT_TYPES` 的 `job` 型別因此已備妥，心跳 consumer 落地時不需改寫入端契
+  約；本次不發 `job` 型別事件。**範圍**：codex 免 hook（`codex exec --json` 的 JSONL
+  已被 parse），copilot／agy 留後續，D4 消費端一行未動。詳見
+  `changelog.d/d5-headless-claude-hook.md`。新增
+  `tests/test_headless_claude_hook_506.py`（73 個測試）。
 - **Issue #506 / D4：monitor 的本機事件入口（spool）＋targeted refresh——事件是
   **hint 不是 authority**——新增 `paulsha_cortex/monitor/event_spool.py` 作為本機
   事件契約與唯一入口。D1–D3 把常態讀取壓到每 repo 每日 26 次計費請求，代價是**發現

--- a/changelog.d/d5-headless-claude-hook.md
+++ b/changelog.d/d5-headless-claude-hook.md
@@ -1,0 +1,94 @@
+# D5：headless-only hook 儀器化（claude 先）——D4 spool 的第一個 producer
+
+## 問題
+
+D4 開了本機事件通道（`monitor/event_spool.py`），但**沒有任何 producer**：monitor
+每輪掃 spool，掃到的永遠是空目錄。fleet 自己剛動過的 GitHub 物件，仍然只能等下一
+次輪詢把整個清單再問一遍——D1–D3 省下配額的代價（發現延遲）因此一分錢也沒買回來。
+
+## 改法
+
+headless claude job 每跑完一次 `Bash` 工具，由 launcher 注入的 PostToolUse hook
+呼叫 `cortex headless-hook post-tool-use`，把「我剛動了哪個 GitHub 物件」寫進 D4
+spool。monitor 下一輪對被點名的物件做 targeted 條件驗證。
+
+本次**只做 claude**：codex 的 `codex exec --json` JSONL 已被 parse，不需要 hook；
+copilot/agy 留後續。D4 消費端一行未動。
+
+## 使用者硬約束：hook 不得影響正常的互動式 agent 使用
+
+這是紅線，因此不靠設定開關，靠**兩道彼此獨立的結構性保證**——任一道成立，互動
+session 就是完全的 no-op：
+
+1. **hook 只經 launcher 注入，從不落地任何檔案**。宣告由
+   `SubprocessLauncher.launch()` 每次現場組出（`_claude_spool_hook_settings()`），
+   經 argv 的 `--settings` 只交給這一個 job 的行程。**不寫 `~/.claude/settings.json`、
+   不寫任何 user 層設定、不寫磁碟**。operator 自己開的互動 session 讀的是 operator
+   的設定，那裡沒有這個 hook，因此互動 session **連呼叫寫入端的機會都沒有**。
+   打包在 `scripts/hooks/claude.json` 的**使用者全域**模板（paulshaclaw thin install
+   的切點）刻意不含這個 hook，並有測試釘死它永遠不出現在那裡。
+2. **`PSC_JOB_ID` 自守**。就算宣告以任何方式流到互動 session（例如有人手動複製那段
+   JSON），`headless_hook.emit_for_tool_use()` 讀不到 `PSC_JOB_ID` 就直接返回——
+   **不建 spool 目錄、不寫檔、不起 subprocess、連命令都不解析**。這個變數只由
+   launcher 為 cortex 派工的 job 注入。
+
+**只有 builder 掛 hook**：read-only planner 走 `--tools ""`（連 Bash 都沒有），
+review-only reviewer 是 read-only 契約且其 `--settings` 是那份 deny 掉 `$HOME` 的
+sandbox 政策；兩者都不注入，`PSC_JOB_ID` 也只在 builder/planner 的 env 分支出現，
+marker 與注入點成對，不留「有標記卻沒 hook」的半套狀態。
+
+### 為什麼是 `--settings` overlay 而不是 hermetic `CLAUDE_CONFIG_DIR`
+
+#404 為 planning 的純 JSON 回聲任務做了 hermetic per-job `CLAUDE_CONFIG_DIR`
+（只播種 credentials，藉此隔離 operator 的 plugin／MCP／user CLAUDE.md）。同樣的做法
+搬到 builder 會**一併抽掉 operator 的 `permissions` allowlist**，讓 headless job
+卡在無人可核可的授權提示——那是遠超出 D5 範圍的行為變更。`--settings` 是與其他設定
+來源合併的一層 overlay：per-job、走 argv、不落地，同時 builder 既有的 operator 設定
+原封不動。兩者共享 #404 的核心不變量（per-job，不碰 user 全域），本次取風險較低的
+那一種。
+
+## 事件內容：hint 不是 authority
+
+事件只帶「哪個 repo 的哪個編號被動了」，**不帶新狀態**；`action` 純屬診斷。命令解析
+因此刻意往「寧可漏報」的方向失準：
+
+- 只認**封閉列舉**的 mutation 動詞（`gh issue close/comment/edit/…`、
+  `gh pr merge/review/…`）與會改狀態的 `gh api`（`-X`／`--method`，或帶
+  `-f`/`-F`/`--field` 隱含 POST；GET/HEAD 一律不算）。
+- 一行內以 `&&`／`||`／`;`／`|` 串接的多個命令全部解析，同一物件收斂成一則事件。
+- 旗標一律當成「吃一個值」跳過，因此 `--add-label 3` 的 `3` 不會被誤認成 issue 編號
+  （代價：`gh pr merge --squash 45` 這種旗標在前的寫法會漏報）。
+- `repos/{owner}/{repo}/issues/comments/{id}` 改的是留言不是 issue，不會被誤認。
+- 命令沒寫 `--repo` 時，從 job worktree 的 `origin` 補（只讀本機 git 設定、帶超時）；
+  補不到就丟掉這則 hint。
+
+漏報的後果只是退回原本的 refresh 週期延遲，而那正是 D3 每日 anti-entropy 的守備
+範圍；誤報的後果是 monitor 白花一次條件請求（多半 304），且**永遠不會污染鏡像**
+——鏡像只寫 GitHub 自己回的內容。
+
+## fire-and-forget
+
+hook 掛在別人（job）的工作路徑上，因此每一層都不得外溢：`emit_for_tool_use()` 以
+總括的 `except Exception` 把所有失敗吞成 debug log（D4 的 `EventSpool.emit()` 本身
+也永不 raise），CLI 一律 exit 0 且 **stdout 保持空**（PostToolUse 的 stdout 會被
+Claude Code 當決策讀、非零 exit 會被回報成 hook 失敗甚至回饋給模型），launcher 注入
+的命令再以 `|| true` 兜住 CLI 之外的失敗（`cortex` 不在 PATH、套件損壞），並設
+`timeout` 上限確保 hook 不可能阻塞 job。
+
+## #536／#488 心跳：本次只預留信封
+
+同一條 hook 是 job 心跳的天然訊號源（每次 tool call 都觸發）。本次只發
+`github_object` 事件，但每一則都帶 `job_id`——D4 信封的 `job_id` 欄位與
+`RESERVED_EVENT_TYPES` 裡的 `job` 型別因此已備妥，心跳 consumer 落地時不需要改寫入
+端契約。心跳消費不在本次。
+
+## 變更
+
+- 新增 `paulsha_cortex/porcelain/headless_hook.py`：命令解析、repo 補值、寫入端與
+  `cortex headless-hook post-tool-use` CLI；登記進 `_FAMILY_MODULES`。
+- `paulsha_cortex/coordinator/launcher.py`：`_claude_spool_hook_settings()`＋
+  builder 分支的 `--settings` 注入；`launch()`／`executor_environment()` 的 job env
+  加 `PSC_JOB_ID`（兩處必須同步，否則 preflight 只是安慰劑）。
+- `docs/monitor-config.md`：補 spool 的 producer 一節。
+- 新增 `tests/test_headless_claude_hook_506.py`（73 個測試），A 節（自守 no-op）與
+  E 節（注入面／使用者全域無傷）先於功能面存在。

--- a/docs/monitor-config.md
+++ b/docs/monitor-config.md
@@ -104,3 +104,29 @@ D1–D3 把常態讀取壓下來的代價是**發現延遲**——fleet 自己�
   時不出現）。
 - **其他事件型別**：`steering` / `job`（#498）與未知型別一律**原地保留只記 log**，
   等各自的 consumer 落地。
+
+### producer：headless job 的 hook（#506 / D5）
+
+spool 目前唯一的 producer 是 headless **claude builder** job 的 PostToolUse hook
+（`cortex headless-hook post-tool-use`，實作在
+`paulsha_cortex/porcelain/headless_hook.py`）。job 每跑完一次 `Bash` 工具，hook 就
+從命令解析出被動過的 GitHub 物件並寫一則 `github_object` 事件。
+
+- **只在 headless 觸發（使用者硬約束：不得影響正常互動 agent）**，兩道獨立保證：
+  1. hook 宣告由 `SubprocessLauncher.launch()` 每次現場組出，經 argv 的
+     `--settings` 只交給該 job 的行程，**從不寫入任何檔案**——尤其不寫
+     `~/.claude/settings.json`。互動 session 讀 operator 自己的設定，那裡沒有這個
+     hook。打包的使用者全域模板 `scripts/hooks/claude.json` 刻意不含它。
+  2. 寫入端以 `PSC_JOB_ID` 自守：讀不到就直接返回，不建目錄、不寫檔、不起
+     subprocess、不解析命令。這個變數只由 launcher 為派工的 job 注入。
+- **只有 builder 掛**：read-only planner（`--tools ""`，沒有 Bash）與 review-only
+  reviewer（read-only 契約）都不注入。
+- **只認會改狀態的命令**：封閉列舉的 `gh issue`／`gh pr` 動詞，以及非 GET/HEAD 的
+  `gh api` 單物件路徑。命令沒帶 `--repo` 時從 job worktree 的 `origin` 補；補不到
+  就丟掉這則 hint（漏報退回輪詢週期，是安全的方向）。
+- **fire-and-forget**：解析／寫入的任何失敗都只記 debug log，CLI 一律 exit 0 且
+  stdout 保持空，注入的命令另以 `|| true` 與 `timeout` 兜底——hook 不得讓 job 看到
+  非零 exit，也不得阻塞它。
+- **心跳預留**：每則事件都帶 `job_id`，供 #536／#488 的心跳 consumer 日後消費；
+  本次不發 `job` 型別事件。
+- codex 免 hook（`codex exec --json` 的 JSONL 已被 parse）；copilot／agy 未接。

--- a/paulsha_cortex/coordinator/launcher.py
+++ b/paulsha_cortex/coordinator/launcher.py
@@ -297,6 +297,61 @@ def _claude_review_settings(worktree: str) -> str:
     return json.dumps(settings, ensure_ascii=True, sort_keys=True, separators=(",", ":"))
 
 
+# #506 / D5：headless job 的事件 hook 命令。`cortex headless-hook post-tool-use`
+# 讀 stdin 的 PostToolUse payload，把被動過的 GitHub 物件寫進 monitor 的 D4 event
+# spool（見 `porcelain/headless_hook.py`）。
+#
+# `|| true`：hook 掛在別人（job）的工作路徑上。CLI 本身已一律 exit 0，這一段兜的是
+# CLI 之外的失敗——`cortex` 不在 PATH（127）、套件安裝損壞、python 起不來。任何情況
+# 下 hook 都不得讓 job 看到非零 exit（PostToolUse 的非零 exit 會被回報成 hook 失敗，
+# 甚至把 stderr 回饋給模型）。
+_CLAUDE_SPOOL_HOOK_COMMAND = "cortex headless-hook post-tool-use || true"
+
+# 逾時上限：hook 只寫一個本機檔案（外加最多一次本機 `git config` 讀取），秒級都嫌多；
+# 設上限是為了「hook 永不阻塞 job」這條硬約束，不是為了正常路徑。
+_CLAUDE_SPOOL_HOOK_TIMEOUT_SECONDS = 10
+
+
+def _claude_spool_hook_settings() -> str:
+    """Build the per-job PostToolUse hook settings for a headless Claude builder.
+
+    #506 / D5，使用者硬約束「**hook 不得影響正常的互動式 agent 使用**」的第一道
+    結構保證：這份宣告是每次 `launch()` 現場組出來、經 argv 的 `--settings` 交給
+    這一個 job 的行程，**從不寫入任何檔案**——尤其不寫 `~/.claude/settings.json`。
+    operator 自己開的互動 session 讀的是 operator 的設定，那裡永遠沒有這個 hook。
+
+    刻意只宣告 `hooks`：`--settings` 是與其他設定來源合併的一層 overlay，因此
+    builder job 既有的 operator 設定（permissions allowlist 等）原封不動——換成
+    hermetic `CLAUDE_CONFIG_DIR`（#404 為 planning 的純 JSON 回聲任務所做的選擇）
+    會把那些設定一併抽掉，對 builder 是遠超出 D5 範圍的行為變更（例如失去
+    permissions allowlist 會讓 headless job 卡在無人可核可的授權提示）。
+
+    第二道保證在 hook 自己身上：`porcelain/headless_hook.py` 沒有 `PSC_JOB_ID`
+    就是完全的 no-op。兩道保證彼此獨立。
+    """
+
+    settings = {
+        "hooks": {
+            "PostToolUse": [
+                {
+                    # 只掛 Bash：GitHub 物件的 mutation 一律經 `gh`（CLI 或 `gh api`）
+                    # 發生。其餘工具（Read/Edit/Task…）不可能動到遠端物件，掛上去
+                    # 只會讓每次 tool call 都多跑一個沒事做的行程。
+                    "matcher": "Bash",
+                    "hooks": [
+                        {
+                            "type": "command",
+                            "command": _CLAUDE_SPOOL_HOOK_COMMAND,
+                            "timeout": _CLAUDE_SPOOL_HOOK_TIMEOUT_SECONDS,
+                        }
+                    ],
+                }
+            ]
+        }
+    }
+    return json.dumps(settings, ensure_ascii=True, sort_keys=True, separators=(",", ":"))
+
+
 def _git_scope_env() -> dict[str, str]:
     """Drop inherited Git repository/config selectors before scope binding."""
 
@@ -597,6 +652,14 @@ def build_claude_argv(
             "--no-chrome",
             "--no-session-persistence",
         ]
+    else:
+        # #506 / D5：只有 builder（可寫入、有 Bash、會動 GitHub 物件的那一種 job）
+        # 掛事件 hook。
+        # - read_only planner 走 `--tools ""`，連 Bash 都沒有，掛了也永遠不會觸發；
+        # - review_only reviewer 是 read-only 契約，且它的 `--settings` 是那份
+        #   sandbox 政策（deny 掉 $HOME 讀寫），事件根本寫不出去。
+        # 這一行是 hook 的**唯一**注入點：per-job、走 argv、不落地任何檔案。
+        argv += ["--settings", _claude_spool_hook_settings()]
     if model is not None:
         argv += ["--model", model]
     if worktree is not None and not review_only:
@@ -938,6 +1001,7 @@ class SubprocessLauncher:
             env = {
                 **_git_scope_env(),
                 "PSC_SLICE_ID": slice_id,
+                "PSC_JOB_ID": slice_id,
                 "PSC_REPO_ROOT": str(Path(__file__).resolve().parents[2]),
             }
             if self._relay_target is not None:
@@ -1006,6 +1070,12 @@ class SubprocessLauncher:
             env = {
                 **_git_scope_env(),
                 "PSC_SLICE_ID": slice_id,
+                # #506 / D5：cortex 派工的 headless job 標記。事件 hook 以它自守
+                # ——沒有這個變數就是完全的 no-op（見 `porcelain/headless_hook.py`）。
+                # 互動 session 的環境裡不存在，因此 hook 即使被誤裝也不會有事件。
+                # reviewer 分支刻意不設：它走 read-only 契約、不掛 hook，marker 與
+                # 注入點成對出現才不會出現「有標記卻沒 hook」的半套狀態。
+                "PSC_JOB_ID": slice_id,
                 "PSC_REPO_ROOT": str(Path(__file__).resolve().parents[2]),
             }
             if self._relay_target is not None:

--- a/paulsha_cortex/porcelain/__init__.py
+++ b/paulsha_cortex/porcelain/__init__.py
@@ -25,6 +25,7 @@ _FAMILY_MODULES: tuple[str, ...] = (
     "paulsha_cortex.porcelain.init_sample",
     "paulsha_cortex.porcelain.mechanical_acceptance",
     "paulsha_cortex.porcelain.capacity_gate",
+    "paulsha_cortex.porcelain.headless_hook",
     "paulsha_cortex.porcelain.model_profile",
 )
 _LOADED_MODULES: set[str] = set()

--- a/paulsha_cortex/porcelain/headless_hook.py
+++ b/paulsha_cortex/porcelain/headless_hook.py
@@ -1,0 +1,560 @@
+"""#506 / D5：headless job 的 GitHub 物件事件 hook——D4 spool 的寫入端。
+
+## 這個模組是什麼
+
+D4（`paulsha_cortex.monitor.event_spool`）開了一條本機事件通道，但**沒有任何
+producer**：monitor 每輪掃 spool，掃到的永遠是空目錄。本模組補上第一個 producer
+——headless claude job 每跑完一次 ``Bash`` 工具，就由 launcher 注入的 PostToolUse
+hook 呼叫 ``cortex headless-hook post-tool-use``，把「我剛動了哪個 GitHub 物件」
+寫進 spool。monitor 下一輪對被點名的物件做 targeted 條件驗證，發現延遲從一個
+refresh 週期（實務上 30 分鐘）壓到一輪。
+
+## 只在 headless 觸發：兩道**結構性**保證
+
+使用者的硬約束是「**不得影響正常的互動式 agent 使用**」。本模組不靠設定開關，
+靠兩件同時成立才會有事件的結構條件：
+
+1. **hook 只經 launcher 注入**：hook 宣告只存在於
+   `SubprocessLauncher.launch()` 為每個 job 現場組出來的 ``--settings`` JSON
+   （見 `coordinator/launcher.py` 的 `_claude_spool_hook_settings`），**從不寫入
+   任何檔案**，尤其不寫 `~/.claude/settings.json`。互動 session 讀的是 operator
+   自己的設定，那裡沒有這個 hook，因此互動 session **連呼叫本模組的機會都沒有**。
+2. **`PSC_JOB_ID` 自守**：即使 hook 宣告以任何方式流到互動 session（例如有人手動
+   複製那段 JSON），:func:`headless_job_id` 讀不到 ``PSC_JOB_ID`` 就直接回
+   ``None``，:func:`emit_for_tool_use` 隨即 return——**不建 spool 目錄、不寫任何
+   檔案、不跑任何 subprocess、不解析命令**。這個變數只由 launcher 為 cortex 派工
+   的 job 設定。
+
+兩道保證彼此獨立：任何一道成立，互動 session 就是完全的 no-op。
+
+## fire-and-forget
+
+hook 掛在**別人**（agent job）的工作路徑上，因此本模組的每一條路徑都是
+fire-and-forget：:func:`emit_for_tool_use` 用一個總括的 ``except Exception``
+把所有失敗吞成 debug log，CLI 一律 exit 0，launcher 注入的命令另外以
+``|| true`` 兜底。掉一則 hint 的後果只是退回原本的 refresh 週期延遲——那正是 D3
+每日 anti-entropy 的守備範圍；讓 hook 的例外炸掉一個跑到一半的 job 則是完全不成
+比例的代價。
+
+## hint 不是 authority
+
+事件只帶「哪個 repo 的哪個編號被動了」，**不帶新狀態**。命令解析因此可以（也應該）
+往「寧可漏報」的方向失準：解不出編號就不發事件，發現延遲退回輪詢週期；反之發出
+錯誤的物件只是讓 monitor 多花一次條件請求（多半 304），也不會污染鏡像——鏡像只寫
+GitHub 自己回的內容。``action`` 純屬診斷。
+
+## #536／#488 心跳（本次只預留信封）
+
+同一條 hook 也是 job 心跳的天然訊號源（每次 tool call 都會觸發）。本次**只發
+``github_object`` 事件**，但每一則都帶 ``job_id``——D4 信封的 ``job_id`` 欄位與
+``RESERVED_EVENT_TYPES`` 裡的 ``job`` 型別因此已經備妥，心跳 consumer
+（#536 define 停滯、#488 stale-progress）落地時不需要改寫入端契約。
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import shlex
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import PurePosixPath
+from typing import Any, Callable, Mapping, Sequence
+
+from paulsha_cortex.monitor.event_spool import EventSpool
+
+from . import COMMANDS, PorcelainCommand, register
+
+
+logger = logging.getLogger(__name__)
+
+
+#: launcher 為 cortex 派工的 job 設定的自守標記。**沒有它就沒有任何事件**。
+JOB_MARKER_ENV = "PSC_JOB_ID"
+
+#: 寫進事件信封的 ``source``；與 D4 消費端測試使用的字面值一致。
+EVENT_SOURCE = "agent-hook:claude"
+
+#: 解析 GitHub 物件時只認這兩種 kind（與 `IssueEntry.kind`／D4 同語彙）。
+KIND_ISSUE = "github_issue"
+KIND_PR = "github_pr"
+
+#: git remote 解析出來的 owner/name 之外，其餘一律視為解析失敗。
+_REPO_SLUG = re.compile(r"\A[A-Za-z0-9._-]+/[A-Za-z0-9._-]+\Z")
+
+# `gh issue`／`gh pr` 底下**會改動遠端物件**的動詞（封閉列舉）。
+# 只列會落在 `repos/{repo}/issues/{number}` 這個端點上看得到的動作；未知動詞一律
+# 不發事件——漏報退回輪詢週期，誤報則是白花一次條件請求。
+_GH_ISSUE_MUTATIONS = frozenset(
+    {
+        "close",
+        "comment",
+        "delete",
+        "develop",
+        "edit",
+        "lock",
+        "pin",
+        "reopen",
+        "transfer",
+        "unlock",
+        "unpin",
+    }
+)
+_GH_PR_MUTATIONS = frozenset(
+    {
+        "close",
+        "comment",
+        "edit",
+        "lock",
+        "merge",
+        "ready",
+        "reopen",
+        "review",
+        "unlock",
+        "update-branch",
+    }
+)
+
+# `gh api` 的請求方法：沒指定時，帶欄位參數即隱含 POST（gh 自己的行為）。
+_GH_API_FIELD_FLAGS = frozenset({"-f", "-F", "--field", "--raw-field", "--input"})
+_GH_API_FIELD_PREFIXES = ("--field=", "--raw-field=", "--input=")
+_READ_ONLY_METHODS = frozenset({"GET", "HEAD"})
+
+# `repos/{owner}/{repo}/{issues|pulls}/{number}`：編號必須是數字，因此
+# `issues/comments/{comment_id}`（改的是留言不是 issue）不會被誤認。
+# `{owner}`／`{repo}` 是 gh 自己的 placeholder（由 gh 依 cwd 展開），解析端
+# 認得它但不當成 repo 名，改走 cwd 的 git remote。
+_API_PLACEHOLDER = frozenset({"{owner}", "{repo}"})
+_API_OBJECT = re.compile(
+    r"repos/(?P<owner>\{owner\}|[A-Za-z0-9._-]+)/(?P<repo>\{repo\}|[A-Za-z0-9._-]+)"
+    r"/(?P<collection>issues|pulls)/(?P<number>\d+)(?![0-9])"
+)
+_HTML_OBJECT = re.compile(
+    r"https?://[^/\s]*github\.com/(?P<owner>[A-Za-z0-9._-]+)/(?P<repo>[A-Za-z0-9._-]+)"
+    r"/(?P<collection>issues|pull|pulls)/(?P<number>\d+)(?![0-9])"
+)
+_BARE_NUMBER = re.compile(r"\A#?(?P<number>\d+)\Z")
+
+# 命令前綴：只有這些包裝詞（與 `VAR=value` 賦值）之後的 `gh` 才算 gh 呼叫，
+# 避免把 `echo gh issue comment 1` 這種提到但沒執行的字串當成 mutation。
+_COMMAND_PREFIXES = frozenset({"command", "env", "nohup", "sudo"})
+_ENV_ASSIGNMENT = re.compile(r"\A[A-Za-z_][A-Za-z0-9_]*=")
+
+# shlex 的 punctuation_chars 會把 `&& || ; | ( ) < >` 切成獨立 token；
+# 由這些字元組成的 token 即為命令分隔點。
+_PUNCTUATION = set("();<>|&")
+
+_GIT_REMOTE_TIMEOUT_SECONDS = 5.0
+
+_UNRESOLVED = object()
+
+
+def register_commands() -> None:
+    if "headless-hook" in COMMANDS:
+        return
+    register(
+        PorcelainCommand(
+            name="headless-hook",
+            help="headless job 的事件 hook：把被動過的 GitHub 物件寫進 monitor spool",
+            run=main,
+        )
+    )
+
+
+# ---------------------------------------------------------------------------
+# 自守標記
+# ---------------------------------------------------------------------------
+
+
+def headless_job_id(env: Mapping[str, str] | None = None) -> str | None:
+    """回傳這個行程所屬的 cortex job id；不是 headless job 就回 ``None``。
+
+    這是「只在 headless 觸發」的機制保證：``PSC_JOB_ID`` 只由
+    `SubprocessLauncher.launch()` 為 cortex 派工的 job 注入，互動 session 的環境
+    裡不存在，因此呼叫端讀到 ``None`` 就該原地返回，**不做任何其他事**。
+    """
+
+    source = os.environ if env is None else env
+    try:
+        value = source.get(JOB_MARKER_ENV)
+    except Exception:  # noqa: BLE001 - env 可能是任意 Mapping 實作
+        return None
+    if not isinstance(value, str) or not value.strip():
+        return None
+    return value.strip()
+
+
+# ---------------------------------------------------------------------------
+# 命令解析
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class GitHubObjectRef:
+    """命令裡被動到的一個 GitHub 物件。``repo`` 為 ``None`` 代表命令沒寫，待 cwd 補。"""
+
+    kind: str
+    number: int
+    action: str
+    repo: str | None = None
+
+
+def _split_segments(command: str) -> tuple[tuple[str, ...], ...]:
+    """把一行 shell 命令切成「以 ``&&``／``||``／``;``／``|`` 分隔」的命令段。
+
+    job 常常一行內串好幾個命令（``gh issue comment ... && gh issue edit ...``），
+    只看第一個動詞會漏掉後面的物件。解析失敗（引號不對稱等）回空——寧可漏報。
+    """
+
+    lexer = shlex.shlex(command, posix=True, punctuation_chars=True)
+    lexer.whitespace_split = True
+    try:
+        tokens = list(lexer)
+    except ValueError:
+        return ()
+    segments: list[tuple[str, ...]] = []
+    current: list[str] = []
+    for token in tokens:
+        if token and all(char in _PUNCTUATION for char in token):
+            if current:
+                segments.append(tuple(current))
+                current = []
+            continue
+        current.append(token)
+    if current:
+        segments.append(tuple(current))
+    return tuple(segments)
+
+
+def _gh_arguments(segment: Sequence[str]) -> tuple[str, ...] | None:
+    """段落是 ``gh`` 呼叫時回傳 ``gh`` 之後的參數，否則回 ``None``。"""
+
+    for index, token in enumerate(segment):
+        if PurePosixPath(token).name == "gh":
+            return tuple(segment[index + 1 :])
+        if _ENV_ASSIGNMENT.match(token) or token in _COMMAND_PREFIXES:
+            continue
+        return None
+    return None
+
+
+def _positional_tokens(tokens: Sequence[str]) -> tuple[str, ...]:
+    """取出位置參數，並把旗標**與其值**一起跳過。
+
+    保守到「把每個旗標都當成吃一個值」：``gh pr merge --squash 45`` 因此會漏掉
+    編號。這是刻意的方向——漏報只是退回輪詢週期，而把 ``--add-label`` 的值誤認成
+    issue 編號會讓 monitor 去查一個不存在的物件。
+    """
+
+    positionals: list[str] = []
+    skip_next = False
+    for token in tokens:
+        if skip_next:
+            skip_next = False
+            continue
+        if token.startswith("--"):
+            skip_next = "=" not in token
+            continue
+        if token.startswith("-") and len(token) > 1:
+            skip_next = True
+            continue
+        positionals.append(token)
+    return tuple(positionals)
+
+
+def _flag_value(tokens: Sequence[str], names: tuple[str, ...]) -> str | None:
+    """讀 ``--name value``／``--name=value``／``-Xvalue`` 形式的旗標值。"""
+
+    for index, token in enumerate(tokens):
+        for name in names:
+            if token == name:
+                if index + 1 < len(tokens):
+                    return tokens[index + 1]
+                return None
+            if token.startswith(f"{name}="):
+                return token[len(name) + 1 :]
+            if name.startswith("-") and not name.startswith("--") and token.startswith(name):
+                remainder = token[len(name) :]
+                if remainder:
+                    return remainder
+    return None
+
+
+def _repo_from_match(match: "re.Match[str]") -> str | None:
+    owner = match.group("owner")
+    name = match.group("repo")
+    if owner in _API_PLACEHOLDER or name in _API_PLACEHOLDER:
+        return None
+    slug = f"{owner}/{name}"
+    return slug if _REPO_SLUG.fullmatch(slug) else None
+
+
+def _parse_gh_object(group: str, arguments: Sequence[str]) -> tuple[GitHubObjectRef, ...]:
+    """解析 ``gh issue <verb> ...``／``gh pr <verb> ...``。"""
+
+    if not arguments:
+        return ()
+    verb = arguments[0]
+    mutations = _GH_ISSUE_MUTATIONS if group == "issue" else _GH_PR_MUTATIONS
+    if verb not in mutations:
+        return ()
+    rest = arguments[1:]
+    kind = KIND_ISSUE if group == "issue" else KIND_PR
+    repo = _flag_value(rest, ("--repo", "-R"))
+    if repo is not None and not _REPO_SLUG.fullmatch(repo):
+        repo = None
+    for token in _positional_tokens(rest):
+        url = _HTML_OBJECT.search(token)
+        if url is not None:
+            return (
+                GitHubObjectRef(
+                    kind=KIND_ISSUE if url.group("collection") == "issues" else KIND_PR,
+                    number=int(url.group("number")),
+                    action=f"{group}-{verb}",
+                    repo=_repo_from_match(url) or repo,
+                ),
+            )
+        bare = _BARE_NUMBER.fullmatch(token)
+        if bare is not None:
+            number = int(bare.group("number"))
+            if number <= 0:
+                return ()
+            return (
+                GitHubObjectRef(kind=kind, number=number, action=f"{group}-{verb}", repo=repo),
+            )
+    # 沒有編號可解（例如 `gh pr comment` 靠 cwd 的分支推斷當前 PR）：不猜。
+    return ()
+
+
+def _parse_gh_api(arguments: Sequence[str]) -> tuple[GitHubObjectRef, ...]:
+    """解析 ``gh api``：只認會改狀態的方法＋單物件路徑。"""
+
+    method = _flag_value(arguments, ("--method", "-X"))
+    if method is None:
+        has_field = any(
+            token in _GH_API_FIELD_FLAGS or token.startswith(_GH_API_FIELD_PREFIXES)
+            for token in arguments
+        )
+        method = "POST" if has_field else "GET"
+    if method.strip().upper() in _READ_ONLY_METHODS:
+        return ()
+    action = f"api-{method.strip().lower()}"
+    for token in _positional_tokens(arguments):
+        match = _API_OBJECT.search(token)
+        if match is None:
+            continue
+        number = int(match.group("number"))
+        if number <= 0:
+            continue
+        return (
+            GitHubObjectRef(
+                kind=KIND_ISSUE if match.group("collection") == "issues" else KIND_PR,
+                number=number,
+                action=action,
+                repo=_repo_from_match(match),
+            ),
+        )
+    return ()
+
+
+def parse_bash_command(command: str) -> tuple[GitHubObjectRef, ...]:
+    """從一行 Bash 命令解析出被動過的 GitHub 物件；**永不 raise**。
+
+    同一行內同一個物件被點名多次只回一筆（monitor 端也會再收斂一次，這裡先省掉
+    重複的事件檔）。
+    """
+
+    if not isinstance(command, str) or not command.strip():
+        return ()
+    try:
+        segments = _split_segments(command)
+    except Exception as error:  # noqa: BLE001 - 解析失敗不得影響 job
+        logger.debug("headless hook could not lex a command: %s", error)
+        return ()
+    found: dict[tuple[str | None, str, int], GitHubObjectRef] = {}
+    for segment in segments:
+        arguments = _gh_arguments(segment)
+        if not arguments:
+            continue
+        group = arguments[0]
+        if group == "api":
+            refs = _parse_gh_api(arguments[1:])
+        elif group in {"issue", "pr"}:
+            refs = _parse_gh_object(group, arguments[1:])
+        else:
+            refs = ()
+        for ref in refs:
+            found.setdefault((ref.repo, ref.kind, ref.number), ref)
+    return tuple(found.values())
+
+
+# ---------------------------------------------------------------------------
+# repo 補值
+# ---------------------------------------------------------------------------
+
+
+def repo_from_remote_url(url: str) -> str | None:
+    """由 git remote URL 取 ``owner/name``；認不出來回 ``None``。"""
+
+    if not isinstance(url, str) or not url.strip():
+        return None
+    text = url.strip()
+    for prefix in ("git+", "ssh://", "git://", "https://", "http://"):
+        if text.startswith(prefix):
+            text = text[len(prefix) :]
+    if "@" in text and "://" not in text:
+        text = text.split("@", 1)[1]
+    text = text.replace(":", "/", 1) if ":" in text.split("/", 1)[0] else text
+    if text.endswith(".git"):
+        text = text[: -len(".git")]
+    parts = [part for part in text.strip("/").split("/") if part]
+    if len(parts) < 2:
+        return None
+    slug = f"{parts[-2]}/{parts[-1]}"
+    return slug if _REPO_SLUG.fullmatch(slug) else None
+
+
+def resolve_repo_from_worktree(
+    cwd: object,
+    *,
+    runner: Callable[..., Any] | None = None,
+) -> str | None:
+    """命令沒寫 ``--repo`` 時，從 job worktree 的 ``origin`` 補；失敗回 ``None``。
+
+    只讀本機 git 設定（不打網路、不碰 GitHub），並帶超時；任何失敗一律回 ``None``
+    ——沒有 repo 就沒有事件，發現延遲退回輪詢週期。
+    """
+
+    if not isinstance(cwd, str) or not cwd.strip():
+        return None
+    execute = subprocess.run if runner is None else runner
+    try:
+        completed = execute(
+            ["git", "-C", cwd, "config", "--get", "remote.origin.url"],
+            capture_output=True,
+            text=True,
+            timeout=_GIT_REMOTE_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except Exception as error:  # noqa: BLE001 - git 不在／不是 repo／逾時
+        logger.debug("headless hook could not read the job remote: %s", error)
+        return None
+    if getattr(completed, "returncode", 1) != 0:
+        return None
+    return repo_from_remote_url(getattr(completed, "stdout", "") or "")
+
+
+# ---------------------------------------------------------------------------
+# 寫入端
+# ---------------------------------------------------------------------------
+
+
+def emit_for_tool_use(
+    payload: object,
+    *,
+    env: Mapping[str, str] | None = None,
+    spool: EventSpool | None = None,
+    runner: Callable[..., Any] | None = None,
+) -> tuple[str, ...]:
+    """處理一次 PostToolUse 事件；回傳寫出去的物件 ref。**永不 raise**。
+
+    第一件事就是查 ``PSC_JOB_ID``：不是 headless job 就在**碰到 spool、cwd、
+    甚至解析命令之前**返回空 tuple。互動 session 走到這裡（照設計走不到，見模組
+    docstring）也只是這一行的成本。
+    """
+
+    try:
+        job_id = headless_job_id(env)
+        if job_id is None:
+            # 互動 session 的唯一結局：什麼都沒發生——沒有 spool 目錄、沒有檔案、
+            # 沒有 subprocess，也沒有任何行為改變。
+            return ()
+        if not isinstance(payload, Mapping):
+            return ()
+        if payload.get("tool_name") != "Bash":
+            return ()
+        tool_input = payload.get("tool_input")
+        command = tool_input.get("command") if isinstance(tool_input, Mapping) else None
+        if not isinstance(command, str):
+            return ()
+        refs = parse_bash_command(command)
+        if not refs:
+            return ()
+        fallback_repo: object = _UNRESOLVED
+        target = spool if spool is not None else EventSpool()
+        emitted: list[str] = []
+        for ref in refs:
+            repo = ref.repo
+            if repo is None:
+                if fallback_repo is _UNRESOLVED:
+                    fallback_repo = resolve_repo_from_worktree(
+                        payload.get("cwd"), runner=runner
+                    )
+                repo = fallback_repo if isinstance(fallback_repo, str) else None
+            if repo is None:
+                continue
+            path = target.emit_github_object(
+                repo=repo,
+                kind=ref.kind,
+                number=ref.number,
+                source=EVENT_SOURCE,
+                action=ref.action,
+                job_id=job_id,
+            )
+            if path is not None:
+                emitted.append(f"{repo}#{ref.number}")
+        return tuple(emitted)
+    except Exception as error:  # noqa: BLE001 - fire-and-forget 的全部意義
+        logger.debug("headless hook dropped a tool-use event: %s", error)
+        return ()
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _read_stdin_payload(stream: Any) -> dict[str, Any]:
+    try:
+        raw = stream.read()
+    except Exception:  # noqa: BLE001 - stdin 關閉／不可讀
+        return {}
+    if not raw or not str(raw).strip():
+        return {}
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError:
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def main(argv: Sequence[str]) -> int:
+    import argparse
+
+    parser = argparse.ArgumentParser(prog="cortex headless-hook")
+    sub = parser.add_subparsers(dest="command", required=True)
+    post_tool_use = sub.add_parser(
+        "post-tool-use",
+        help="讀 stdin 的 PostToolUse payload，把被動過的 GitHub 物件寫進 spool",
+    )
+    post_tool_use.add_argument(
+        "--spool-root",
+        default=None,
+        help="覆寫 monitor event spool 目錄（測試/fixture 注入用）",
+    )
+
+    args = parser.parse_args(list(argv))
+    if args.command != "post-tool-use":
+        parser.error(f"unsupported headless-hook command: {args.command}")
+        return 2
+
+    payload = _read_stdin_payload(sys.stdin)
+    spool = EventSpool(args.spool_root) if args.spool_root else None
+    emit_for_tool_use(payload, spool=spool)
+    # stdout 一律空、exit code 一律 0：PostToolUse 的非零 exit 會讓 Claude Code
+    # 把 stderr 回報成 hook 失敗（甚至回饋給模型），而這個 hook 對 job 本體
+    # 沒有任何話要說——它只是把一則 hint 丟進本機目錄。
+    return 0

--- a/tests/test_headless_claude_hook_506.py
+++ b/tests/test_headless_claude_hook_506.py
@@ -1,0 +1,736 @@
+"""#506 / D5：headless-only hook 儀器化——claude 先。
+
+本檔的第一責任不是「事件有沒有寫出來」，而是使用者的硬約束：**hook 絕不能影響
+正常的互動式 agent 使用**。因此 A 節（自守）與 E 節（注入面）先於功能面存在——
+它們釘死的是「沒有 `PSC_JOB_ID` 就什麼都不會發生」與「hook 只經 launcher 注入、
+不碰使用者全域設定」這兩條結構性保證。
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import shlex
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from paulsha_cortex.coordinator import launcher as launcher_module
+from paulsha_cortex.coordinator.launcher import (
+    SubprocessLauncher,
+    build_claude_argv,
+    build_codex_argv,
+    build_copilot_argv,
+)
+from paulsha_cortex.monitor.event_spool import EVENT_SCHEMA, EventSpool
+from paulsha_cortex.porcelain import headless_hook
+
+
+HOOK_TEMPLATES = Path(__file__).resolve().parents[1] / "paulsha_cortex" / "scripts" / "hooks"
+
+JOB_ENV = {"PSC_JOB_ID": "job-42"}
+MUTATION = "gh issue comment 123 --body hi"
+
+
+def _payload(command: str = MUTATION, *, cwd: str | None = None) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "session_id": "s-1",
+        "hook_event_name": "PostToolUse",
+        "tool_name": "Bash",
+        "tool_input": {"command": command},
+        "tool_response": {"stdout": "", "stderr": "", "interrupted": False},
+    }
+    if cwd is not None:
+        payload["cwd"] = cwd
+    return payload
+
+
+def _events(root: Path) -> list[dict[str, object]]:
+    if not root.exists():
+        return []
+    return [
+        json.loads(path.read_text(encoding="utf-8"))
+        for path in sorted(root.glob("*.json"))
+    ]
+
+
+def _fake_git_remote(url: str):
+    class _Completed:
+        returncode = 0
+        stdout = url
+
+    def _runner(argv, **kwargs):
+        assert argv[0] == "git"
+        return _Completed()
+
+    return _runner
+
+
+def _builder_argv(**overrides) -> list[str]:
+    kwargs: dict[str, object] = {
+        "prompt": "P",
+        "slice_id": "slice-a",
+        "log_dir": "/lg",
+        "worktree": None,
+    }
+    kwargs.update(overrides)
+    return build_claude_argv(**kwargs)  # type: ignore[arg-type]
+
+
+def _settings_from(argv: list[str]) -> dict[str, object] | None:
+    if "--settings" not in argv:
+        return None
+    return json.loads(argv[argv.index("--settings") + 1])
+
+
+def _hook_commands(settings: dict[str, object]) -> list[str]:
+    hooks = settings.get("hooks")
+    if not isinstance(hooks, dict):
+        return []
+    return [
+        entry.get("command", "")
+        for groups in hooks.values()
+        for group in groups
+        for entry in group.get("hooks", [])
+    ]
+
+
+# ---------------------------------------------------------------------------
+# A. 自守：沒有 PSC_JOB_ID 就是完全的 no-op（互動 session 的唯一結局）
+# ---------------------------------------------------------------------------
+
+
+def test_without_the_job_marker_nothing_is_emitted(tmp_path: Path) -> None:
+    """互動 session 的證明：連 spool 目錄都不會出現。"""
+
+    root = tmp_path / "event-spool"
+    emitted = headless_hook.emit_for_tool_use(
+        _payload(), env={"HOME": str(tmp_path)}, spool=EventSpool(root)
+    )
+
+    assert emitted == ()
+    assert not root.exists()
+    assert _events(root) == []
+
+
+@pytest.mark.parametrize("marker", ["", "   ", None])
+def test_a_blank_or_missing_marker_is_not_a_headless_job(marker: object) -> None:
+    env = {} if marker is None else {"PSC_JOB_ID": marker}
+    assert headless_hook.headless_job_id(env) is None  # type: ignore[arg-type]
+
+
+def test_the_marker_is_checked_before_anything_else_is_touched(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """無標記時不解析命令、不解 repo、不建 spool——連一個 subprocess 都不起。
+
+    這條比「沒有事件」更強：它釘住的是 hook 在互動 session 裡的**成本與副作用皆
+    為零**，而不只是輸出為空。
+    """
+
+    def _explode(*args, **kwargs):  # pragma: no cover - 觸發即失敗
+        raise AssertionError("no-op path must not run a subprocess")
+
+    monkeypatch.setattr(headless_hook.subprocess, "run", _explode)
+    monkeypatch.setattr(
+        headless_hook,
+        "parse_bash_command",
+        lambda command: pytest.fail("no-op path must not parse the command"),
+    )
+
+    root = tmp_path / "event-spool"
+    assert headless_hook.emit_for_tool_use(_payload(), env={}, spool=EventSpool(root)) == ()
+    assert not root.exists()
+
+
+def test_the_cli_is_a_no_op_without_the_marker(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = tmp_path / "event-spool"
+    monkeypatch.delenv("PSC_JOB_ID", raising=False)
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(_payload())))
+    captured = io.StringIO()
+    monkeypatch.setattr(sys, "stdout", captured)
+
+    code = headless_hook.main(["post-tool-use", "--spool-root", str(root)])
+
+    assert code == 0
+    assert captured.getvalue() == ""  # PostToolUse 的 stdout 會被當決策讀，保持空
+    assert not root.exists()
+
+
+def test_the_cli_stays_silent_and_successful_with_the_marker(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = tmp_path / "event-spool"
+    monkeypatch.setenv("PSC_JOB_ID", "job-42")
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(_payload("gh issue edit 5 -R o/r"))))
+    captured = io.StringIO()
+    monkeypatch.setattr(sys, "stdout", captured)
+
+    code = headless_hook.main(["post-tool-use", "--spool-root", str(root)])
+
+    assert code == 0
+    assert captured.getvalue() == ""
+    assert [event["payload"]["number"] for event in _events(root)] == [5]  # type: ignore[index]
+
+
+# ---------------------------------------------------------------------------
+# B. 有標記：寫出符合 D4 契約的事件
+# ---------------------------------------------------------------------------
+
+
+def test_a_headless_job_emits_a_d4_github_object_event(tmp_path: Path) -> None:
+    root = tmp_path / "event-spool"
+
+    emitted = headless_hook.emit_for_tool_use(
+        _payload("gh issue comment 123 -R acme/demo --body hi"),
+        env=JOB_ENV,
+        spool=EventSpool(root),
+    )
+
+    assert emitted == ("acme/demo#123",)
+    (event,) = _events(root)
+    assert event["schema_version"] == EVENT_SCHEMA
+    assert event["event_type"] == "github_object"
+    assert event["source"] == headless_hook.EVENT_SOURCE == "agent-hook:claude"
+    assert event["job_id"] == "job-42"
+    assert event["payload"] == {
+        "repo": "acme/demo",
+        "kind": "github_issue",
+        "number": 123,
+        "action": "issue-comment",
+    }
+
+
+def test_events_name_an_object_and_never_carry_its_state(tmp_path: Path) -> None:
+    """hint 不是 authority：信封裡沒有任何可以拿來直接改鏡像的欄位。"""
+
+    root = tmp_path / "event-spool"
+    headless_hook.emit_for_tool_use(
+        _payload("gh issue edit 7 -R acme/demo --add-label bug --title new"),
+        env=JOB_ENV,
+        spool=EventSpool(root),
+    )
+
+    (event,) = _events(root)
+    assert set(event["payload"]) & {"state", "labels", "title", "body", "updated_at"} == set()
+
+
+def test_the_event_is_consumable_by_the_d4_scanner(tmp_path: Path) -> None:
+    """端到端的契約面：D4 消費端掃得到、認得出、不隔離。"""
+
+    root = tmp_path / "event-spool"
+    spool = EventSpool(root)
+    headless_hook.emit_for_tool_use(
+        _payload("gh pr comment 45 -R acme/demo --body ok"), env=JOB_ENV, spool=spool
+    )
+
+    scan = spool.scan()
+
+    assert scan.quarantined == ()
+    assert [(hint.repo, hint.kind, hint.number) for hint in scan.hints] == [
+        ("acme/demo", "github_pr", 45)
+    ]
+
+
+def test_one_command_can_name_several_objects(tmp_path: Path) -> None:
+    root = tmp_path / "event-spool"
+
+    emitted = headless_hook.emit_for_tool_use(
+        _payload("gh issue comment 1 -R o/r --body a && gh pr edit 2 -R o/r --add-label x"),
+        env=JOB_ENV,
+        spool=EventSpool(root),
+    )
+
+    assert sorted(emitted) == ["o/r#1", "o/r#2"]
+
+
+def test_the_same_object_twice_in_one_command_is_one_event(tmp_path: Path) -> None:
+    root = tmp_path / "event-spool"
+
+    emitted = headless_hook.emit_for_tool_use(
+        _payload("gh issue comment 9 -R o/r --body a; gh issue comment 9 -R o/r --body b"),
+        env=JOB_ENV,
+        spool=EventSpool(root),
+    )
+
+    assert emitted == ("o/r#9",)
+    assert len(_events(root)) == 1
+
+
+def test_the_repo_falls_back_to_the_job_worktree_remote(tmp_path: Path) -> None:
+    root = tmp_path / "event-spool"
+
+    emitted = headless_hook.emit_for_tool_use(
+        _payload(cwd=str(tmp_path)),
+        env=JOB_ENV,
+        spool=EventSpool(root),
+        runner=_fake_git_remote("git@github.com:acme/demo.git\n"),
+    )
+
+    assert emitted == ("acme/demo#123",)
+
+
+def test_an_unresolvable_repo_drops_the_hint_instead_of_guessing(tmp_path: Path) -> None:
+    root = tmp_path / "event-spool"
+
+    class _Failed:
+        returncode = 128
+        stdout = ""
+
+    emitted = headless_hook.emit_for_tool_use(
+        _payload(cwd=str(tmp_path)),
+        env=JOB_ENV,
+        spool=EventSpool(root),
+        runner=lambda argv, **kwargs: _Failed(),
+    )
+
+    assert emitted == ()
+    assert not root.exists()
+
+
+def test_the_default_spool_follows_the_configured_monitor_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """不指定 spool 時走 D4 的 `monitor_event_spool_root()`，不是自訂路徑。"""
+
+    monkeypatch.setenv("PSC_MONITOR_STATE_ROOT", str(tmp_path / "monitor"))
+
+    emitted = headless_hook.emit_for_tool_use(
+        _payload("gh issue close 3 -R o/r"), env=JOB_ENV
+    )
+
+    assert emitted == ("o/r#3",)
+    assert len(_events(tmp_path / "monitor" / "event-spool")) == 1
+
+
+@pytest.mark.parametrize(
+    ("url", "expected"),
+    [
+        ("git@github.com:acme/demo.git\n", "acme/demo"),
+        ("https://github.com/acme/demo.git", "acme/demo"),
+        ("https://github.com/acme/demo", "acme/demo"),
+        ("ssh://git@github.com/acme/demo.git", "acme/demo"),
+        ("", None),
+        ("not-a-remote", None),
+    ],
+)
+def test_remote_urls_resolve_to_owner_and_name(url: str, expected: str | None) -> None:
+    assert headless_hook.repo_from_remote_url(url) == expected
+
+
+# ---------------------------------------------------------------------------
+# C. 命令解析：只認會改動遠端物件的動作
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("command", "expected"),
+    [
+        ("gh issue comment 12 -R o/r", [("o/r", "github_issue", 12)]),
+        ("gh issue close 12 --repo o/r", [("o/r", "github_issue", 12)]),
+        ("gh issue edit 12 --repo=o/r --add-label bug", [("o/r", "github_issue", 12)]),
+        ("gh pr merge 12 -R o/r --squash", [("o/r", "github_pr", 12)]),
+        ("gh pr review 12 -R o/r --approve", [("o/r", "github_pr", 12)]),
+        (
+            "gh pr comment https://github.com/acme/demo/pull/77 --body y",
+            [("acme/demo", "github_pr", 77)],
+        ),
+        ("gh api -X PATCH repos/o/r/issues/9", [("o/r", "github_issue", 9)]),
+        ("gh api --method=DELETE repos/o/r/pulls/9/requested_reviewers", [("o/r", "github_pr", 9)]),
+        ("gh api repos/o/r/issues/9/comments -f body=hi", [("o/r", "github_issue", 9)]),
+        (
+            "gh api https://api.github.com/repos/o/r/issues/9/labels -f labels[]=bug",
+            [("o/r", "github_issue", 9)],
+        ),
+        ("gh issue edit 12 -R o/r --add-label 3", [("o/r", "github_issue", 12)]),
+    ],
+)
+def test_mutating_commands_name_their_object(
+    command: str, expected: list[tuple[str, str, int]]
+) -> None:
+    assert [
+        (ref.repo, ref.kind, ref.number) for ref in headless_hook.parse_bash_command(command)
+    ] == expected
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "gh issue view 12 -R o/r",
+        "gh issue list -R o/r",
+        "gh pr diff 12 -R o/r",
+        "gh pr checks 12 -R o/r",
+        "gh api repos/o/r/issues/9",
+        "gh api -X GET repos/o/r/issues/9",
+        "gh api --method HEAD repos/o/r/issues/9",
+        "gh repo view o/r",
+        "gh release create v1",
+        "git commit -m 'gh issue comment 12'",
+        "echo gh issue comment 12 -R o/r",
+        "python3 -m pytest -q",
+        "",
+        "   ",
+    ],
+)
+def test_non_mutating_commands_name_nothing(command: str) -> None:
+    assert headless_hook.parse_bash_command(command) == ()
+
+
+def test_a_comment_edit_is_not_mistaken_for_its_issue() -> None:
+    """`issues/comments/{id}` 的數字是留言 id，不是 issue 編號。"""
+
+    assert headless_hook.parse_bash_command(
+        "gh api -X PATCH repos/o/r/issues/comments/98765 -f body=x"
+    ) == ()
+
+
+def test_gh_placeholders_leave_the_repo_for_the_worktree_to_resolve() -> None:
+    (ref,) = headless_hook.parse_bash_command("gh api -X PATCH repos/{owner}/{repo}/pulls/12")
+    assert (ref.repo, ref.kind, ref.number) == (None, "github_pr", 12)
+
+
+@pytest.mark.parametrize(
+    "command",
+    ['gh issue comment 1 -R o/r --body "unbalanced', "gh issue comment 0 -R o/r"],
+)
+def test_unparseable_or_impossible_commands_are_dropped_not_raised(command: str) -> None:
+    assert headless_hook.parse_bash_command(command) == ()
+
+
+# ---------------------------------------------------------------------------
+# D. fire-and-forget：hook 的失敗永不外溢到 job
+# ---------------------------------------------------------------------------
+
+
+def test_an_unusable_spool_is_swallowed(tmp_path: Path) -> None:
+    blocked = tmp_path / "event-spool"
+    blocked.write_text("not a directory", encoding="utf-8")
+
+    assert (
+        headless_hook.emit_for_tool_use(
+            _payload("gh issue comment 1 -R o/r"), env=JOB_ENV, spool=EventSpool(blocked)
+        )
+        == ()
+    )
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        None,
+        "not-a-mapping",
+        {},
+        {"tool_name": "Edit", "tool_input": {"command": MUTATION}},
+        {"tool_name": "Bash"},
+        {"tool_name": "Bash", "tool_input": "not-a-mapping"},
+        {"tool_name": "Bash", "tool_input": {"command": None}},
+    ],
+)
+def test_a_malformed_payload_never_raises(payload: object, tmp_path: Path) -> None:
+    root = tmp_path / "event-spool"
+    assert headless_hook.emit_for_tool_use(payload, env=JOB_ENV, spool=EventSpool(root)) == ()
+    assert not root.exists()
+
+
+def test_only_bash_tool_calls_are_inspected(tmp_path: Path) -> None:
+    root = tmp_path / "event-spool"
+    payload = _payload()
+    payload["tool_name"] = "Task"
+
+    assert headless_hook.emit_for_tool_use(payload, env=JOB_ENV, spool=EventSpool(root)) == ()
+
+
+def test_a_broken_git_lookup_never_raises(tmp_path: Path) -> None:
+    def _explode(argv, **kwargs):
+        raise OSError("git is not installed")
+
+    assert (
+        headless_hook.emit_for_tool_use(
+            _payload(cwd=str(tmp_path)),
+            env=JOB_ENV,
+            spool=EventSpool(tmp_path / "event-spool"),
+            runner=_explode,
+        )
+        == ()
+    )
+
+
+def test_the_cli_survives_garbage_on_stdin(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = tmp_path / "event-spool"
+    monkeypatch.setenv("PSC_JOB_ID", "job-42")
+    monkeypatch.setattr(sys, "stdin", io.StringIO("{not json"))
+
+    assert headless_hook.main(["post-tool-use", "--spool-root", str(root)]) == 0
+    assert not root.exists()
+
+
+# ---------------------------------------------------------------------------
+# E. 注入面：hook 只經 launcher 進入 job，永不落地使用者全域設定
+# ---------------------------------------------------------------------------
+
+
+def test_a_headless_claude_builder_carries_the_hook_on_argv() -> None:
+    settings = _settings_from(_builder_argv())
+
+    assert settings is not None
+    assert list(settings) == ["hooks"]  # 只加 hook，不動 permissions／sandbox
+    assert [group["matcher"] for group in settings["hooks"]["PostToolUse"]] == ["Bash"]
+    assert _hook_commands(settings) == ["cortex headless-hook post-tool-use || true"]
+    assert settings["hooks"]["PostToolUse"][0]["hooks"][0]["timeout"] > 0
+
+
+def test_the_hook_command_is_a_registered_porcelain_command() -> None:
+    from paulsha_cortex import porcelain
+
+    porcelain.load_commands()
+    command = _hook_commands(_settings_from(_builder_argv()) or {})[0]
+    argv = shlex.split(command.split("||")[0])
+
+    assert argv[0] == "cortex"
+    assert argv[1] in porcelain.COMMANDS
+    assert argv[2] == "post-tool-use"
+
+
+@pytest.mark.parametrize("mode", ["read_only", "review_only"])
+def test_read_only_personas_get_no_hook(mode: str) -> None:
+    """planner 沒有 Bash、reviewer 是 read-only 契約——兩者都不該掛 hook。"""
+
+    if mode == "read_only":
+        argv = _builder_argv(read_only=True)
+    else:
+        with tempfile.TemporaryDirectory() as worktree:
+            argv = _builder_argv(
+                review_only=True,
+                worktree=worktree,
+                review_terminal_kind="workflow-review-result",
+            )
+    settings = _settings_from(argv)
+
+    assert settings is None or "hooks" not in settings
+
+
+def test_other_executors_are_untouched() -> None:
+    """本次只做 claude：codex（JSONL 已被 parse）與 copilot 不得出現 hook。"""
+
+    for argv in (
+        build_codex_argv(prompt="P", slice_id="s", log_dir="/lg"),
+        build_copilot_argv(prompt="P", slice_id="s", log_dir="/lg"),
+    ):
+        assert not any("headless-hook" in token for token in argv)
+
+
+def test_the_launcher_marks_the_job_environment() -> None:
+    calls: list[dict[str, object]] = []
+
+    class _FakeProc:
+        pid = 4242
+
+    def _fake_popen(argv, *, cwd, env, stdout, stderr):
+        calls.append({"argv": argv, "env": env})
+        return _FakeProc()
+
+    original = launcher_module.subprocess.Popen
+    launcher_module.subprocess.Popen = _fake_popen
+    try:
+        with tempfile.TemporaryDirectory() as d:
+            SubprocessLauncher("claude").launch(
+                slice_id="slice-a",
+                prompt="P",
+                worktree=d,
+                log_dir=str(Path(d) / "logs"),
+            )
+    finally:
+        launcher_module.subprocess.Popen = original
+
+    env = calls[0]["env"]
+    assert env["PSC_JOB_ID"] == "slice-a"  # type: ignore[index]
+    # hook 與 marker 成對出現在同一個 job 的 argv/env 裡。
+    assert "cortex headless-hook post-tool-use" in calls[0]["argv"][2]  # type: ignore[index]
+
+
+def test_the_preflight_environment_matches_the_job_environment() -> None:
+    """`executor_environment()` 與 `launch()` 若不同步，preflight 就是安慰劑。"""
+
+    calls: list[dict[str, object]] = []
+
+    class _FakeProc:
+        pid = 1
+
+    def _fake_popen(argv, *, cwd, env, stdout, stderr):
+        calls.append({"env": env})
+        return _FakeProc()
+
+    original = launcher_module.subprocess.Popen
+    launcher_module.subprocess.Popen = _fake_popen
+    try:
+        with tempfile.TemporaryDirectory() as d:
+            launcher = SubprocessLauncher("claude")
+            launcher.launch(
+                slice_id="preflight", prompt="P", worktree=d, log_dir=str(Path(d) / "logs")
+            )
+            launcher.executor_environment()
+    finally:
+        launcher_module.subprocess.Popen = original
+
+    assert calls[0]["env"]["PSC_JOB_ID"] == "preflight"  # type: ignore[index]
+
+
+def test_launching_a_job_writes_nothing_into_the_user_home(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """紅線的直接證明：派工一個 claude job 之後，使用者的 `~/.claude` 毫髮無傷。"""
+
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+
+    class _FakeProc:
+        pid = 7
+
+    original = launcher_module.subprocess.Popen
+    launcher_module.subprocess.Popen = lambda argv, **kwargs: _FakeProc()
+    try:
+        worktree = tmp_path / "worktree"
+        worktree.mkdir()
+        SubprocessLauncher("claude").launch(
+            slice_id="slice-a",
+            prompt="P",
+            worktree=str(worktree),
+            log_dir=str(tmp_path / "logs"),
+        )
+    finally:
+        launcher_module.subprocess.Popen = original
+
+    assert list(home.iterdir()) == []
+
+
+def test_the_packaged_claude_template_never_ships_the_hook() -> None:
+    """`scripts/hooks/claude.json` 是**使用者全域**安裝用的模板（paulshaclaw thin
+    install 的切點）。事件 hook 一旦出現在這裡，就等於走上使用者全域設定那條被
+    明確禁止的路；因此這條測試釘死它永遠不在模板裡。
+    """
+
+    template = (HOOK_TEMPLATES / "claude.json").read_text(encoding="utf-8")
+
+    assert "headless-hook" not in template
+    assert "PostToolUse" not in template
+
+
+def test_no_executable_string_names_a_user_level_claude_settings_file() -> None:
+    """全套件掃描：`~/.claude/settings.json` 只出現在文件（docstring／註解）裡。
+
+    掃 AST 而非原始碼文字，因此 docstring 與註解裡的說明不算數——只有真的會被當成
+    資料用的字面值才會被抓到。目前結果是空集合：本 repo 沒有任何一條路徑會去組出
+    使用者全域的 claude 設定檔路徑，更不用說寫它。
+    """
+
+    import ast
+
+    package = Path(__file__).resolve().parents[1] / "paulsha_cortex"
+    offenders: list[str] = []
+    for path in sorted(package.rglob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        documentation = {
+            id(node.value)
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Expr)
+            and isinstance(node.value, ast.Constant)
+            and isinstance(node.value.value, str)
+        }
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Constant) or not isinstance(node.value, str):
+                continue
+            if id(node) in documentation:
+                continue
+            if ".claude/settings.json" in node.value or node.value == "settings.json":
+                offenders.append(f"{path.relative_to(package)}:{node.lineno}")
+
+    assert offenders == []
+
+
+def test_the_hook_never_touches_the_user_home(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """寫入端的同一條紅線：hook 只寫 spool，`$HOME` 完全不動。"""
+
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+
+    emitted = headless_hook.emit_for_tool_use(
+        _payload("gh issue comment 8 -R o/r --body x"),
+        env=JOB_ENV,
+        spool=EventSpool(tmp_path / "event-spool"),
+    )
+
+    assert emitted == ("o/r#8",)
+    assert list(home.iterdir()) == []
+
+
+# ---------------------------------------------------------------------------
+# F. 端到端：launcher 注入 → job 內 gh mutation → 事件落 spool
+# ---------------------------------------------------------------------------
+
+
+def test_end_to_end_from_launcher_injection_to_a_consumable_event(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """走完整條路：launcher 組出 hook 宣告與 job env，hook 依那份 env 執行，
+    事件落進 spool 並被 D4 消費端認得。中間沒有任何一步碰到使用者全域設定。
+    """
+
+    calls: list[dict[str, object]] = []
+
+    class _FakeProc:
+        pid = 99
+
+    def _fake_popen(argv, *, cwd, env, stdout, stderr):
+        calls.append({"argv": argv, "env": env})
+        return _FakeProc()
+
+    original = launcher_module.subprocess.Popen
+    launcher_module.subprocess.Popen = _fake_popen
+    try:
+        worktree = tmp_path / "worktree"
+        worktree.mkdir()
+        SubprocessLauncher("claude").launch(
+            slice_id="job-e2e",
+            prompt="P",
+            worktree=str(worktree),
+            log_dir=str(tmp_path / "logs"),
+        )
+    finally:
+        launcher_module.subprocess.Popen = original
+
+    job_env = calls[0]["env"]
+    script = calls[0]["argv"][2]  # type: ignore[index]
+    settings = json.loads(
+        [token for token in shlex.split(script) if token.startswith('{"hooks"')][0]
+    )
+    hook_command = _hook_commands(settings)[0]
+
+    # job 內跑的 gh mutation：以 launcher 實際交給 job 的 env 執行 hook 命令。
+    root = tmp_path / "spool"
+    monkeypatch.setattr(
+        sys,
+        "stdin",
+        io.StringIO(json.dumps(_payload("gh issue comment 314 -R acme/demo --body done"))),
+    )
+    monkeypatch.setattr(os, "environ", dict(job_env))  # type: ignore[arg-type]
+    assert headless_hook.main(
+        [*shlex.split(hook_command.split("||")[0])[2:], "--spool-root", str(root)]
+    ) == 0
+
+    scan = EventSpool(root).scan()
+    assert [(hint.repo, hint.kind, hint.number) for hint in scan.hints] == [
+        ("acme/demo", "github_issue", 314)
+    ]
+    assert scan.hints[0].event.job_id == "job-e2e"
+    assert scan.quarantined == ()


### PR DESCRIPTION
## 這張 PR 做什麼

D4（#583）開了 monitor 的本機事件通道，但**沒有任何 producer**：monitor 每輪掃
spool，掃到的永遠是空目錄，D1–D3 省下配額的代價（發現延遲）一分錢也沒買回來。
本 PR 補上第一個 producer——headless **claude builder** job 每跑完一次 `Bash` 工具，
由 launcher 注入的 PostToolUse hook 把「我剛動了哪個 GitHub 物件」依 D4 契約寫進
spool，monitor 下一輪對被點名的物件做 targeted 條件驗證。

範圍：**只做 claude 的注入與寫入端**。D4 消費端一行未動；codex 免 hook
（`codex exec --json` 的 JSONL 已被 parse）；copilot／agy 留後續；心跳消費不做
（信封已預留）。

## 如何保證正常 agent 不受影響

這是使用者的紅線，因此不靠設定開關，靠**兩道彼此獨立的結構性保證**——任何一道成立，
互動 session 就是完全的 no-op：

**（1）hook 只經 launcher 注入，從不落地任何檔案。**
宣告由 `SubprocessLauncher.launch()` 每次現場組出（`_claude_spool_hook_settings()`），
經 argv 的 `--settings` 只交給這一個 job 的行程。**不寫 `~/.claude/settings.json`、
不寫任何 user 層設定、不寫磁碟。** operator 自己開的互動 session 讀的是 operator 的
設定，那裡沒有這個 hook，因此互動 session **連呼叫寫入端的機會都沒有**。打包在
`paulsha_cortex/scripts/hooks/claude.json` 的**使用者全域**模板（paulshaclaw thin
install 的切點）刻意不含這個 hook。

**（2）`PSC_JOB_ID` 自守。**
就算宣告以任何方式流到互動 session（例如有人手動複製那段 JSON），
`emit_for_tool_use()` 讀不到 `PSC_JOB_ID` 就直接返回——**不建 spool 目錄、不寫檔、
不起 subprocess、連命令都不解析**。這個變數只由 launcher 為 cortex 派工的 job 注入。

**只有 builder 掛 hook**：read-only planner 走 `--tools ""`（連 Bash 都沒有），
review-only reviewer 是 read-only 契約且其 `--settings` 是那份 deny 掉 `$HOME` 的
sandbox 政策；`PSC_JOB_ID` 也只出現在同一個 env 分支，marker 與注入點成對，不留
「有標記卻沒 hook」的半套狀態。

**測試層面的證明**（`tests/test_headless_claude_hook_506.py`，A 節與 E 節）：

- 無 `PSC_JOB_ID` → 回空、**spool 目錄不存在**；且以 monkeypatch 讓「解析命令」與
  `subprocess.run` 一被呼叫就失敗，證明 no-op 路徑的**成本與副作用皆為零**，不只是
  輸出為空。
- 有 `PSC_JOB_ID` → 寫出符合 D4 信封的事件，且 D4 `scan()` 認得、不隔離。
- 派工一個 claude job 之後，monkeypatch 過的 `$HOME` **一個檔案都沒多**。
- 打包的使用者全域模板不含 `headless-hook`／`PostToolUse`（測試釘死）。
- AST 掃全套件：`~/.claude/settings.json` 只出現在 docstring／註解，**沒有任何可執行
  字面值**組得出使用者全域設定檔路徑。
- codex／copilot 的 argv 不含 hook；read-only／review-only 的 claude 也不含。

## 為何是 `--settings` overlay 而不是 hermetic `CLAUDE_CONFIG_DIR`

#404 為 planning 的**純 JSON 回聲任務**做了 hermetic per-job `CLAUDE_CONFIG_DIR`
（只播種 credentials，藉此隔離 operator 的 plugin／MCP／user CLAUDE.md）。同樣做法
搬到 builder 會**一併抽掉 operator 的 `permissions` allowlist**，讓 headless job 卡在
無人可核可的授權提示——那是遠超出 D5 範圍的行為變更。`--settings` 是與其他設定來源
合併的一層 overlay：同樣是 per-job、走 argv、不落地任何檔案（與 reviewer 既有的
`_claude_review_settings` 同一個機制），但 builder 既有的 operator 設定原封不動。
兩者共享 #404 的核心不變量（per-job，絕不碰 user 全域），本次取風險較低的那一種；
若 operator 仍要求 hermetic 形式，改動集中在 `_claude_spool_hook_settings()` 一處。

## hint 不是 authority

事件只帶 repo＋kind＋編號，**不帶新狀態**，`action` 純屬診斷。命令解析刻意往
「寧可漏報」失準：只認封閉列舉的 `gh issue`／`gh pr` mutation 動詞與非 GET/HEAD 的
`gh api` 單物件路徑（`issues/comments/{id}` 改的是留言，不會被誤認成 issue）；旗標
一律當成吃一個值跳過（`--add-label 3` 的 `3` 不會被當編號，代價是
`gh pr merge --squash 45` 會漏報）；一行內 `&&`／`;` 串接的多個命令全解析並收斂
去重；沒帶 `--repo` 時從 job worktree 的 `origin` 補（只讀本機 git 設定、帶超時），
補不到就丟掉這則 hint。漏報只是退回 refresh 週期延遲（D3 每日 anti-entropy 的守備
範圍）；誤報只是白花一次條件請求（多半 304），且**永遠不污染鏡像**。

## fire-and-forget

hook 掛在別人（job）的工作路徑上，因此每一層都不外溢：`emit_for_tool_use()` 以總括的
`except Exception` 吞成 debug log；CLI 一律 exit 0 且 **stdout 保持空**（PostToolUse
的 stdout 會被 Claude Code 當決策讀、非零 exit 會被回報成 hook 失敗甚至回饋給模型）；
launcher 注入的命令再以 `|| true` 兜住 CLI 之外的失敗（`cortex` 不在 PATH、套件損壞），
並設 `timeout` 上限確保 hook 不可能阻塞 job。

## #536／#488 心跳：本次只預留信封

同一條 hook 是 job 心跳的天然訊號源（每次 tool call 都觸發）。本次只發
`github_object` 事件，但每一則都帶 `job_id`——D4 信封的 `job_id` 欄位與
`RESERVED_EVENT_TYPES` 的 `job` 型別因此已備妥，心跳 consumer 落地時不需要改寫入端
契約。

## 變更檔案

- `paulsha_cortex/porcelain/headless_hook.py`（新）：命令解析、repo 補值、寫入端、
  `cortex headless-hook post-tool-use` CLI。
- `paulsha_cortex/porcelain/__init__.py`：登記家族。
- `paulsha_cortex/coordinator/launcher.py`：`_claude_spool_hook_settings()`＋builder
  分支的 `--settings` 注入；`launch()`／`executor_environment()` 的 job env 加
  `PSC_JOB_ID`（兩處必須同步，否則 preflight 只是安慰劑）。
- `docs/monitor-config.md`：spool 的 producer 一節。
- `CHANGELOG.md` / `changelog.d/d5-headless-claude-hook.md`。
- `tests/test_headless_claude_hook_506.py`（新，73 個測試）。

## 測試

- `python3 -m pytest tests/test_headless_claude_hook_506.py -q` → 73 passed
- `python3 -m pytest -q` → **3003 passed, 49 subtests passed**（全綠）

## Checklist

- [x] `changelog.d/<slug>.md` fragment 已新增且已 commit
- [x] `CHANGELOG.md [Unreleased]` 有對應 entry
- [x] `VERSION` 與意圖一致（非 release PR，未動）
- [x] 目標測試與全套 pytest 通過
- [x] 未跳過任何檢查（`policy-exempt:issue-link` 為 R-17 豁免：本 PR 只引用不關閉
      issue，D5 是 #506 的其中一項交付）

Refs #506 #404 #536 #488
