### PR TITLE
feat(coverage): v4 R1 responsibility coverage validator shadow 骨架

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@
 ## [Unreleased]
 
 ### Added
+- **v4 R1（方案 A）：responsibility coverage validator 的 shadow 骨架（零行為變更）**
+  ——新增 `paulsha_cortex/coordinator/coverage.py`：新的 coverage validator 與現行
+  topology validator（`validate_manager_spine()`，未動）**並行跑、比對、記 telemetry**，
+  但 production 決策仍完全由舊 validator 主導。含 `SafetyStage` 列舉、
+  `ResponsibilityCoverage` 結構、legacy `phase → responsibility` adapter，deck card
+  schema 加 optional `satisfies`（capability declaration，非 self-certification；現有
+  deck 不需改）。shadow 掛在 `manager.py` production 派工 gate 旁，永不 raise，受
+  `PSC_RESPONSIBILITY_COVERAGE` 閘控（`off` 停用，預設 `on`）；disagreement telemetry
+  原子落 `coordinator_root()/coverage-shadow/`。詳見
+  `changelog.d/r1-coverage-validator-shadow.md`。新增 `tests/test_coverage_shadow_r1.py`。
 - **Issue #506 / D5：headless-only hook 儀器化（claude 先）——D4 spool 的第一個
   producer**——D4 開了本機事件通道卻**沒有任何 producer**：monitor 每輪掃到的永遠
   是空目錄，D1–D3 省下配額的代價（發現延遲）一分錢也沒買回來。新增

--- a/changelog.d/r1-coverage-validator-shadow.md
+++ b/changelog.d/r1-coverage-validator-shadow.md
@@ -1,0 +1,20 @@
+### Added
+- **v4 R1（方案 A）：responsibility coverage validator 的 shadow 骨架——零行為變更**
+  ——v4 的核心論點是「safety truth 不該依賴 `current_phase`（workflow topology），而該
+  依賴責任覆蓋（responsibility coverage）」。本 PR 是這個重構的**觀測期**第一步：新增
+  `paulsha_cortex/coordinator/coverage.py`，把新的 coverage validator 與現行 topology
+  validator（`WorkflowManifest.validate_manager_spine()`，一 byte 未動）**並行跑、比對、
+  記 telemetry**，但 production 決策**仍完全由舊 validator 主導**。新增 `SafetyStage`
+  列舉（七個 safety responsibility，與七 phase 一一對映；`INTAKE`/`DELIVERY` 為
+  Manager-owned authority boundary）、`ResponsibilityCoverage` 結構、legacy
+  `phase → responsibility` adapter，以及 deck card schema 的 optional `satisfies` 欄位
+  （capability declaration，**非** self-certification；現有 deck 不需改，由 adapter 從
+  phase 兜底）。shadow 掛在 `manager.py` 的 production 派工 gate（`_manager_workflow`
+  start）呼叫點旁，**全程 try/except、永不 raise**，且受 `PSC_RESPONSIBILITY_COVERAGE`
+  閘控（`off` 連比對都不跑，預設 `on`）。disagreement telemetry 以一次比對一檔的原子
+  寫入落在 `coordinator_root()/coverage-shadow/`（比照 D4 event-spool 語意），含 manifest
+  識別、兩方判定、disagreement 細節，供兩週觀測期分析。**零行為變更**：測試證明無論
+  coverage validator 判 pass 或 fail，`validate_manager_spine()` 的結果（pass/raise 與
+  原因訊息）與本 PR 前逐位元組相同，manifest 序列化 bytes 不含 `satisfies`；shadow 只
+  多寫 telemetry。不做 Compact reuse／auto_develop／monotonic escalation（R2）、不碰
+  GitHub 邊界／trust-root／採信契約。新增 `tests/test_coverage_shadow_r1.py`（26 個測試）。

--- a/paulsha_cortex/config/paths.py
+++ b/paulsha_cortex/config/paths.py
@@ -30,6 +30,16 @@ def coordinator_root() -> Path:
     return resolve_runtime_root("PSC_COORDINATOR_ROOT")
 
 
+def coverage_shadow_telemetry_root() -> Path:
+    """v4 R1（方案 A）coverage validator shadow 的 disagreement telemetry 落點。
+
+    每次 shadow 比對落一檔（原子寫入，見 `coordinator/coverage.py`），供兩週觀測期
+    的 disagreement 分析。掛在 `coordinator_root()`（`PSC_COORDINATOR_ROOT`）底下——
+    這是 coordinator 產出的 telemetry，與 monitor 的傳輸層狀態分族。
+    """
+    return coordinator_root() / "coverage-shadow"
+
+
 def specs_root() -> Path:
     return resolve_runtime_root("PSC_SPECS_ROOT")
 

--- a/paulsha_cortex/coordinator/coverage.py
+++ b/paulsha_cortex/coordinator/coverage.py
@@ -1,0 +1,438 @@
+"""v4 R1（方案 A）：responsibility **coverage** validator 的 shadow 骨架。
+
+## 為什麼要有這個模組
+
+v4 的核心論點：safety truth 不該依賴 ``current_phase``（workflow topology），
+而該依賴「責任覆蓋」（responsibility coverage）。今日 production 的唯一真相源是
+:meth:`WorkflowManifest.validate_manager_spine`——它驗的是**執行拓撲**（phase 單調
+排列、phase↔persona 綁定、ship 前有 review step）。本模組新增一個**獨立**的
+coverage validator，從「這份 workflow 是否覆蓋每一個必要 safety responsibility」
+的角度重新判定同一份 manifest。
+
+## R1 的鐵律：零行為變更（shadow only）
+
+R1 是重構的**觀測期**，不是切換期：
+
+1. **topology validator 仍是 production 唯一真相源**——``validate_manager_spine()``
+   一個 byte 都沒動，所有 gate/dispatch/acceptance 決策仍完全由它主導。
+2. **coverage validator 的判定只進 telemetry**——:func:`run_coverage_shadow` 在
+   production 呼叫點旁並行跑兩個 validator、比對、把 disagreement 落成結構化
+   telemetry，供兩週觀測期累積資料後再決定是否進 R2 啟用。
+3. **shadow 絕不影響 production**——:func:`run_coverage_shadow` 全程包在
+   ``try/except`` 內、永不 raise，且受 ``PSC_RESPONSIBILITY_COVERAGE`` 閘控
+   （``off`` 連比對都不跑）。無論 coverage validator 判 pass 或 fail，後續的
+   ``validate_manager_spine()`` 呼叫結果與本模組落地前**逐位元組相同**。
+
+## R1 的 scope 邊界（誠實聲明）
+
+- coverage validator 讀的是 **manifest 的 step.phase**，經
+  :data:`_PHASE_TO_STAGE`（legacy ``phase → responsibility`` adapter）投影成
+  :class:`SafetyStage`。manifest step 今日**不**攜帶 ``satisfies``——把它投影進
+  manifest 會改變 manifest 的序列化 bytes（= 行為變更），屬 R2。
+- Card 的 optional ``satisfies``（見 ``deck/schema.py``）是**宣告 seam**：它是
+  capability declaration（「這張卡負責哪個 responsibility」），**不是**
+  self-certification。:func:`resolve_card_satisfies` 是它的 deck-side adapter——
+  有宣告用宣告、沒宣告則從 ``phase`` 推導。R1 完整驗證並單測這個 adapter，但
+  **尚未**把它 projection 進 manifest（那是 R2 的責任契約）。
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import tempfile
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+from pathlib import Path
+from typing import Any, Iterable, Mapping
+
+from paulsha_cortex.config.paths import coverage_shadow_telemetry_root
+
+from .workflow import WORKFLOW_PHASES, WorkflowManifest
+
+logger = logging.getLogger(__name__)
+
+#: telemetry 落檔的 schema 版本（獨立於 manifest schema）。
+SHADOW_TELEMETRY_SCHEMA = "1"
+
+#: 回滾開關的環境變數名。``off`` = 完全停用 shadow（連比對都不跑）；預設 ``on``。
+COVERAGE_ENV_FLAG = "PSC_RESPONSIBILITY_COVERAGE"
+
+_FILENAME_SAFE = re.compile(r"[^a-z0-9._-]+")
+
+
+class SafetyStage(Enum):
+    """一個 workflow 必須覆蓋的 safety **responsibility**（責任），不是執行拓撲。
+
+    v4 constitution：「七步是 Safety Responsibility（責任覆蓋），不是 Workflow
+    topology（執行拓撲）。Pattern 可以繞路解題，但不能繞過 Safety Responsibility。」
+    這個列舉即那組責任的載體——與現行七 phase 一一對映（見 :data:`_PHASE_TO_STAGE`），
+    但語意是「責任是否被滿足」而非「這個 phase 是否照拓撲順序出現」。
+
+    ``INTAKE`` 與 ``DELIVERY`` 是 Manager-owned authority boundary（constitution
+    decision 3：Claim/Ship 為 Manager 的分權邊界，只收斂不放寬）——見
+    :data:`MANAGER_AUTHORITY_STAGES`。這對映關係也預留 R2 的
+    Compact/Standard/Elevated 責任分級：Compact 仍要求全部責任，只是 Define/Plan
+    可由既有可信 evidence 覆蓋（本 R1 不實作 reuse，僅建立責任列舉本身）。
+    """
+
+    INTAKE = "intake"  # claim：Manager 授權邊界——工作在授權下被納入
+    SPECIFICATION = "specification"  # define：問題／需求被界定
+    PLANNING = "planning"  # plan：解法被規劃
+    IMPLEMENTATION = "implementation"  # build：變更被實作
+    VERIFICATION = "verification"  # verify：變更被驗證（測試／檢查）
+    REVIEW = "review"  # review：獨立審查
+    DELIVERY = "delivery"  # ship：Manager 授權邊界——交付
+
+
+#: 全部 safety responsibility，依責任生命週期的 canonical 順序。
+SAFETY_STAGES: tuple[SafetyStage, ...] = tuple(SafetyStage)
+
+#: Manager-owned authority boundary（constitution decision 3）。
+MANAGER_AUTHORITY_STAGES: frozenset[SafetyStage] = frozenset(
+    {SafetyStage.INTAKE, SafetyStage.DELIVERY}
+)
+
+#: legacy ``phase → responsibility`` adapter：讓不帶顯式 ``satisfies`` 的現行 card／
+#: manifest（step 只帶 phase）也能被 coverage validator 讀。key 為 WORKFLOW_PHASES
+#: 的 phase 字面值，與 ``deck/compile.py`` 的 phase 產線同一組約定。
+_PHASE_TO_STAGE: dict[str, SafetyStage] = {
+    "claim": SafetyStage.INTAKE,
+    "define": SafetyStage.SPECIFICATION,
+    "plan": SafetyStage.PLANNING,
+    "build": SafetyStage.IMPLEMENTATION,
+    "verify": SafetyStage.VERIFICATION,
+    "review": SafetyStage.REVIEW,
+    "ship": SafetyStage.DELIVERY,
+}
+
+# build-time 完整性檢查：phase↔stage 必須雙滿射，任何一邊漏掉都是編碼錯誤。
+assert set(_PHASE_TO_STAGE) == set(WORKFLOW_PHASES), "phase↔stage 對映不完整"
+assert set(_PHASE_TO_STAGE.values()) == set(SAFETY_STAGES), "stage 未被 phase 全覆蓋"
+
+#: coverage validator 認得的 responsibility 名稱（deck ``satisfies`` 宣告的合法值域）。
+SAFETY_STAGE_NAMES: frozenset[str] = frozenset(stage.value for stage in SAFETY_STAGES)
+
+
+def stage_for_phase(phase: str) -> SafetyStage:
+    """legacy adapter：把一個 workflow phase 投影成它負責的 safety responsibility。"""
+    try:
+        return _PHASE_TO_STAGE[phase]
+    except KeyError as exc:  # pragma: no cover - phase 合法性由 WorkflowStep 保證
+        raise ValueError(f"未知 workflow phase，無法對映 safety stage: {phase!r}") from exc
+
+
+def resolve_card_satisfies(card: Any) -> tuple[SafetyStage, ...]:
+    """Card 的 ``satisfies`` adapter：**宣告優先、phase 兜底**。
+
+    - 若 card 顯式宣告 ``satisfies``（capability declaration），以宣告為準（去重、
+      保序）；未知的 responsibility 名稱一律略過（coverage validator 是責任名稱的
+      唯一權威，deck 層刻意不驗語意，見 ``deck/schema.py`` 對 ``satisfies`` 的註解）。
+    - 否則從 ``card.phase`` 經 :func:`stage_for_phase` 推導——這正是「現有不帶
+      ``satisfies`` 的 card 也能被 coverage validator 讀」的兜底路徑。
+
+    **這是宣告 seam，不是 self-certification**：它只表達「這張卡宣稱負責哪個
+    responsibility」，覆蓋是否真的成立由 evidence 決定（R2）。
+    """
+    declared = getattr(card, "satisfies", ()) or ()
+    stages: list[SafetyStage] = []
+    for name in declared:
+        if name in SAFETY_STAGE_NAMES:
+            stage = SafetyStage(name)
+            if stage not in stages:
+                stages.append(stage)
+    if stages:
+        return tuple(stages)
+    phase = getattr(card, "phase", None)
+    if phase in _PHASE_TO_STAGE:
+        return (_PHASE_TO_STAGE[phase],)
+    return ()
+
+
+@dataclass(frozen=True)
+class ResponsibilityCoverage:
+    """一份 workflow 是否覆蓋每個必要 safety responsibility 的結構。
+
+    - ``required``：本次判定要求覆蓋的責任集合（R1 shadow 一律為全部
+      :data:`SAFETY_STAGES`，與 topology validator「必須涵蓋完整 phase spine」對齊）。
+    - ``covered``：實際被至少一個 step 覆蓋到的責任。
+    - ``missing``：``required`` 中未被覆蓋者（依 canonical 順序）。
+    - ``satisfied_by``：每個責任由哪些 card id 覆蓋（供 disagreement 溯源）。
+    """
+
+    required: frozenset[SafetyStage]
+    covered: frozenset[SafetyStage]
+    missing: tuple[SafetyStage, ...]
+    satisfied_by: Mapping[SafetyStage, tuple[str, ...]]
+
+    @property
+    def is_complete(self) -> bool:
+        return not self.missing
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "required": [stage.value for stage in SAFETY_STAGES if stage in self.required],
+            "covered": [stage.value for stage in SAFETY_STAGES if stage in self.covered],
+            "missing": [stage.value for stage in self.missing],
+            "satisfied_by": {
+                stage.value: list(self.satisfied_by.get(stage, ()))
+                for stage in SAFETY_STAGES
+                if stage in self.covered
+            },
+        }
+
+
+@dataclass(frozen=True)
+class Verdict:
+    """一個 validator 的 pass/fail 判定＋原因（fail 時為訊息，pass 時為 None）。"""
+
+    passed: bool
+    reason: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"passed": self.passed, "reason": self.reason}
+
+
+@dataclass(frozen=True)
+class ShadowComparison:
+    """一次 shadow 比對的完整結果（純資料，供落 telemetry 與測試斷言）。"""
+
+    manifest_combo: str
+    manifest_task_slug: str
+    manifest_version: int
+    step_count: int
+    topology: Verdict
+    coverage_verdict: Verdict
+    coverage: ResponsibilityCoverage
+    callsite: str
+    context: Mapping[str, Any]
+    recorded_at: str
+
+    @property
+    def agreement(self) -> bool:
+        return self.topology.passed == self.coverage_verdict.passed
+
+    @property
+    def disagreement_kind(self) -> str | None:
+        if self.agreement:
+            return None
+        if self.topology.passed and not self.coverage_verdict.passed:
+            return "topology-pass-coverage-fail"
+        return "topology-fail-coverage-pass"
+
+    def to_dict(self) -> dict[str, Any]:
+        disagreement: dict[str, Any] | None = None
+        if not self.agreement:
+            disagreement = {
+                "kind": self.disagreement_kind,
+                "topology_reason": self.topology.reason,
+                "coverage_reason": self.coverage_verdict.reason,
+                "missing_responsibilities": [stage.value for stage in self.coverage.missing],
+            }
+        return {
+            "schema_version": SHADOW_TELEMETRY_SCHEMA,
+            "recorded_at": self.recorded_at,
+            "callsite": self.callsite,
+            "manifest": {
+                "combo": self.manifest_combo,
+                "task_slug": self.manifest_task_slug,
+                "version": self.manifest_version,
+                "steps": self.step_count,
+            },
+            "context": dict(self.context),
+            "topology": self.topology.to_dict(),
+            "coverage": {
+                **self.coverage_verdict.to_dict(),
+                **self.coverage.to_dict(),
+            },
+            "agreement": self.agreement,
+            "disagreement": disagreement,
+        }
+
+
+# ---------------------------------------------------------------------------
+# validators
+# ---------------------------------------------------------------------------
+
+
+def topology_verdict(manifest: WorkflowManifest) -> Verdict:
+    """production topology validator 的 pass/fail **觀測**（不改變其行為）。
+
+    刻意直接呼叫 ``validate_manager_spine()`` 並捕捉其例外——如此 shadow 對 topology
+    的判定與 production **就是同一份邏輯**，不另抄一份、不可能 drift。
+    """
+    try:
+        manifest.validate_manager_spine()
+    except ValueError as exc:
+        return Verdict(passed=False, reason=str(exc))
+    return Verdict(passed=True, reason=None)
+
+
+def evaluate_coverage(
+    manifest: WorkflowManifest,
+    *,
+    required: Iterable[SafetyStage] = SAFETY_STAGES,
+) -> ResponsibilityCoverage:
+    """coverage validator：從責任覆蓋角度獨立判定同一份 manifest。
+
+    R1 shadow 讀 manifest 的 ``step.phase``，經 legacy adapter 投影成
+    :class:`SafetyStage`，記錄每個責任由哪些 card 覆蓋，再對照 ``required`` 算出
+    ``missing``。**與 topology 無關**：不看順序、不看 persona 綁定、不看 ship 前是否
+    有 review step——只問「每個必要責任是否被某個 step 覆蓋」。
+    """
+    required_set = frozenset(required)
+    satisfied_by: dict[SafetyStage, list[str]] = {}
+    for step in manifest.steps:
+        stage = stage_for_phase(step.phase)
+        satisfied_by.setdefault(stage, [])
+        if step.card not in satisfied_by[stage]:
+            satisfied_by[stage].append(step.card)
+    covered = frozenset(satisfied_by)
+    missing = tuple(stage for stage in SAFETY_STAGES if stage in required_set and stage not in covered)
+    return ResponsibilityCoverage(
+        required=required_set,
+        covered=covered,
+        missing=missing,
+        satisfied_by={stage: tuple(cards) for stage, cards in satisfied_by.items()},
+    )
+
+
+def coverage_verdict(coverage: ResponsibilityCoverage) -> Verdict:
+    """把 :class:`ResponsibilityCoverage` 收斂成 pass/fail 判定。"""
+    if coverage.is_complete:
+        return Verdict(passed=True, reason=None)
+    missing = ", ".join(stage.value for stage in coverage.missing)
+    return Verdict(passed=False, reason=f"未覆蓋的 safety responsibility: {missing}")
+
+
+# ---------------------------------------------------------------------------
+# shadow 比對＋telemetry
+# ---------------------------------------------------------------------------
+
+
+def shadow_enabled(environment: Mapping[str, str] | None = None) -> bool:
+    """回滾開關：``PSC_RESPONSIBILITY_COVERAGE=off`` → False（連比對都不跑）。
+
+    未設或設為 ``off`` 以外的值 → True（預設 shadow）。``off`` 判定 case-insensitive、
+    去前後空白。
+    """
+    env = os.environ if environment is None else environment
+    return env.get(COVERAGE_ENV_FLAG, "").strip().lower() != "off"
+
+
+def _utcnow() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def compare_manifest(
+    manifest: WorkflowManifest,
+    *,
+    callsite: str = "unknown",
+    context: Mapping[str, Any] | None = None,
+    recorded_at: str | None = None,
+) -> ShadowComparison:
+    """純函式：跑兩個 validator 並打包成 :class:`ShadowComparison`（不落檔）。"""
+    topo = topology_verdict(manifest)
+    coverage = evaluate_coverage(manifest)
+    return ShadowComparison(
+        manifest_combo=manifest.combo,
+        manifest_task_slug=manifest.task_slug,
+        manifest_version=manifest.version,
+        step_count=len(manifest.steps),
+        topology=topo,
+        coverage_verdict=coverage_verdict(coverage),
+        coverage=coverage,
+        callsite=callsite,
+        context=dict(context or {}),
+        recorded_at=recorded_at or _utcnow(),
+    )
+
+
+def _record_filename(comparison: ShadowComparison) -> str:
+    flat_ts = _FILENAME_SAFE.sub("", comparison.recorded_at.lower())
+    slug = _FILENAME_SAFE.sub("-", comparison.manifest_task_slug.lower()).strip("-") or "manifest"
+    return f"{flat_ts}-{slug}-{uuid.uuid4().hex[:8]}.json"
+
+
+def write_shadow_record(
+    comparison: ShadowComparison,
+    *,
+    root: str | Path | None = None,
+) -> Path | None:
+    """原子寫入一則 shadow telemetry 記錄；**永不 raise**，失敗回 ``None``。
+
+    比照 ``monitor/event_spool.py`` 的寫入端語意（一檔一記錄、``.`` 前綴 temp 檔 →
+    fsync → ``os.replace``，因此不需鎖、consumer 不可能讀到半寫入檔）。shadow 掛在
+    production 派工路徑上，寫不進去絕不能影響派工本體——所以吞掉全部例外、記 debug。
+    """
+    directory = Path(root) if root is not None else coverage_shadow_telemetry_root()
+    try:
+        directory.mkdir(parents=True, exist_ok=True)
+        body = (json.dumps(comparison.to_dict(), ensure_ascii=False, sort_keys=True) + "\n").encode(
+            "utf-8"
+        )
+        handle_fd, temp_name = tempfile.mkstemp(prefix=".coverage-", suffix=".tmp", dir=directory)
+        temp_path = Path(temp_name)
+        try:
+            os.fchmod(handle_fd, 0o600)
+            with os.fdopen(handle_fd, "wb") as handle:
+                handle.write(body)
+                handle.flush()
+                os.fsync(handle.fileno())
+            final_path = directory / _record_filename(comparison)
+            os.replace(temp_path, final_path)
+        except BaseException:
+            try:
+                os.close(handle_fd)
+            except OSError:
+                pass
+            temp_path.unlink(missing_ok=True)
+            raise
+    except Exception as error:  # noqa: BLE001 - fire-and-forget 的全部意義
+        logger.debug("coverage shadow telemetry write dropped: %s", error)
+        return None
+    return final_path
+
+
+def run_coverage_shadow(
+    manifest: WorkflowManifest,
+    *,
+    callsite: str = "unknown",
+    context: Mapping[str, Any] | None = None,
+    root: str | Path | None = None,
+) -> ShadowComparison | None:
+    """production 呼叫點旁的 shadow 入口——**永不影響 production**。
+
+    語意合約（R1 鐵律）：
+
+    1. ``PSC_RESPONSIBILITY_COVERAGE=off`` → 直接回 ``None``，連比對都不跑。
+    2. 否則跑 coverage validator 與 topology validator（後者只是**觀測**現行
+       ``validate_manager_spine()``），比對後把結果落成 telemetry。
+    3. **全程 try/except、永不 raise**——任何 shadow 內部錯誤（比對 bug、寫檔失敗、
+       telemetry 目錄不可寫……）一律吞成 debug log，讓呼叫端後續的
+       ``validate_manager_spine()`` 照舊執行、結果逐位元組不變。
+
+    回傳 :class:`ShadowComparison`（供測試斷言）或 ``None``（停用／發生被吞的例外）。
+    coverage validator 的判定**只**在這裡進 telemetry，絕不回傳給任何 gate 消費。
+    """
+    try:
+        if not shadow_enabled():
+            return None
+        comparison = compare_manifest(manifest, callsite=callsite, context=context)
+        write_shadow_record(comparison, root=root)
+        if not comparison.agreement:
+            logger.info(
+                "coverage shadow disagreement (%s): topology.passed=%s coverage.passed=%s missing=%s",
+                comparison.disagreement_kind,
+                comparison.topology.passed,
+                comparison.coverage_verdict.passed,
+                [stage.value for stage in comparison.coverage.missing],
+            )
+        return comparison
+    except Exception as error:  # noqa: BLE001 - shadow 絕不影響 production
+        logger.debug("coverage shadow skipped after error: %s", error)
+        return None

--- a/paulsha_cortex/coordinator/manager.py
+++ b/paulsha_cortex/coordinator/manager.py
@@ -25,6 +25,7 @@ from ..lib import idle
 from ..persona import gate, handoff
 from . import autonomy
 from . import completion
+from . import coverage
 from . import gate_ledger
 from . import planning_runtime
 from . import provider_backoff
@@ -9610,6 +9611,23 @@ def apply_workflow_action(
         raise ValueError(f"unsupported workflow action: {action}")
 
     manifest = _load_workflow_manifest(_required_workflow_string(args, "manifest_path"))
+    # v4 R1（方案 A）coverage validator **shadow**：在 production topology validator
+    # 呼叫點旁並行跑 coverage validator 並記 telemetry。**零行為變更**——
+    # run_coverage_shadow 全程 try/except、永不 raise，且受
+    # PSC_RESPONSIBILITY_COVERAGE 閘控（off 連比對都不跑）；下面的
+    # validate_manager_spine() 仍是唯一 production 真相源。coverage validator 的判定
+    # 只進 telemetry，絕不影響此處 gate。放在 validate 之前，是為了連 topology 即將
+    # raise 的案例也能被 shadow 觀測到（disagreement 資料才完整）。
+    coverage.run_coverage_shadow(
+        manifest,
+        callsite="manager.start",
+        context={
+            "work_id": args.get("work_id"),
+            "repo": args.get("repo"),
+            "claim_key": args.get("claim_key"),
+            "combo": manifest.combo,
+        },
+    )
     manifest.validate_manager_spine()
     # #208 收口 wiring 1：work_bridge.start_canonical_workflow 在呼叫端已算好
     # （fail-soft，可能是 None）的 claim-time sizing 快照透過 args 帶進來，這裡

--- a/paulsha_cortex/deck/schema.py
+++ b/paulsha_cortex/deck/schema.py
@@ -41,6 +41,7 @@ _CARD_KEYS = frozenset(
         "slice_group",
         "execution",
         "runtime_capabilities",
+        "satisfies",
     }
 )
 # #262 R1：card 以資料宣告執行所需 runtime capability，形式為 `<kind>:<name>`
@@ -126,6 +127,13 @@ class Card:
     test_policy: str | None = None
     # #262 R1：dispatch 前 preflight 依這份宣告逐項檢查。
     runtime_capabilities: tuple[str, ...] = ()
+    # v4 R1（方案 A）：optional capability declaration——宣告「這張卡負責哪個 safety
+    # responsibility」。**非 self-certification**（只表達宣稱，不表達覆蓋已成立）。
+    # deck 層刻意只做結構檢查（非空字串、去重），不驗語意值域：responsibility 名稱的
+    # 唯一權威是 coordinator 的 coverage validator（`coordinator/coverage.py`），deck→
+    # coordinator 的依賴方向不反轉。不帶 `satisfies` 的現有 card 由 coverage validator
+    # 的 legacy `phase → satisfies` adapter 兜底，因此**現有 deck 檔不需改**。
+    satisfies: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -293,6 +301,14 @@ def load_cards(path: str | Path) -> dict[str, Card]:
                 )
         if len(set(runtime_capabilities)) != len(runtime_capabilities):
             rec_errors.append(f"{cid}: runtime_capabilities 有重複宣告")
+        # v4 R1：satisfies 只做結構檢查（字串清單、非空、去重），語意值域交給
+        # coverage validator——deck 不認識 responsibility taxonomy，維持解耦。
+        satisfies = _str_tuple(rec.get("satisfies"), cid, "satisfies", rec_errors)
+        for token in satisfies:
+            if not token.strip():
+                rec_errors.append(f"{cid}: satisfies 不得含空字串")
+        if len(set(satisfies)) != len(satisfies):
+            rec_errors.append(f"{cid}: satisfies 有重複宣告")
         if rec_errors:
             errors.extend(rec_errors)
             continue
@@ -312,6 +328,7 @@ def load_cards(path: str | Path) -> dict[str, Card]:
             commit_policy=commit_policy,
             test_policy=test_policy,
             runtime_capabilities=runtime_capabilities,
+            satisfies=satisfies,
         )
     if errors:
         raise DeckSchemaError(f"cards 驗證失敗: {source}: " + "; ".join(errors))

--- a/tests/test_coverage_shadow_r1.py
+++ b/tests/test_coverage_shadow_r1.py
@@ -1,0 +1,333 @@
+"""v4 R1（方案 A）coverage validator shadow 骨架的測試。
+
+重點是**零行為變更的證明**：無論 coverage validator 判 pass 或 fail，production 的
+``validate_manager_spine()`` 結果與本 PR 前逐位元組相同；shadow 只多寫 telemetry。
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from paulsha_cortex.coordinator import coverage
+from paulsha_cortex.coordinator.coverage import (
+    SAFETY_STAGE_NAMES,
+    SAFETY_STAGES,
+    ResponsibilityCoverage,
+    SafetyStage,
+    compare_manifest,
+    coverage_verdict,
+    evaluate_coverage,
+    resolve_card_satisfies,
+    run_coverage_shadow,
+    shadow_enabled,
+    stage_for_phase,
+    topology_verdict,
+)
+from paulsha_cortex.coordinator.workflow import (
+    WORKFLOW_PHASES,
+    WorkflowManifest,
+    WorkflowStep,
+)
+from paulsha_cortex.deck.schema import DEFAULT_CARDS_PATH, Card, DeckSchemaError, load_cards
+from paulsha_cortex.coordinator.work_bridge import default_workflow_manifest
+
+
+# --------------------------------------------------------------------------
+# 型別：SAFETY_STAGES / phase adapter
+# --------------------------------------------------------------------------
+
+
+def test_safety_stages_map_one_to_one_with_phases() -> None:
+    assert len(SAFETY_STAGES) == len(set(SAFETY_STAGES)) == len(WORKFLOW_PHASES)
+    mapped = {stage_for_phase(phase) for phase in WORKFLOW_PHASES}
+    assert mapped == set(SAFETY_STAGES)
+    assert SAFETY_STAGE_NAMES == {stage.value for stage in SAFETY_STAGES}
+
+
+def test_manager_authority_stages_are_claim_and_ship() -> None:
+    assert stage_for_phase("claim") in coverage.MANAGER_AUTHORITY_STAGES
+    assert stage_for_phase("ship") in coverage.MANAGER_AUTHORITY_STAGES
+    assert coverage.MANAGER_AUTHORITY_STAGES == frozenset(
+        {SafetyStage.INTAKE, SafetyStage.DELIVERY}
+    )
+
+
+def test_stage_for_phase_rejects_unknown() -> None:
+    with pytest.raises(ValueError):
+        stage_for_phase("not-a-phase")
+
+
+# --------------------------------------------------------------------------
+# satisfies adapter（宣告優先、phase 兜底）
+# --------------------------------------------------------------------------
+
+
+def _card(**overrides) -> Card:
+    base = dict(
+        id="c", kind="skill", type="headless", card_class="core", skill_ref="skills/x"
+    )
+    base.update(overrides)
+    return Card(**base)
+
+
+def test_resolve_card_satisfies_prefers_declaration() -> None:
+    card = _card(phase="build", satisfies=("review", "verification"))
+    assert resolve_card_satisfies(card) == (SafetyStage.REVIEW, SafetyStage.VERIFICATION)
+
+
+def test_resolve_card_satisfies_falls_back_to_phase() -> None:
+    card = _card(phase="review")
+    assert resolve_card_satisfies(card) == (SafetyStage.REVIEW,)
+
+
+def test_resolve_card_satisfies_skips_unknown_names() -> None:
+    card = _card(phase="build", satisfies=("bogus", "planning"))
+    assert resolve_card_satisfies(card) == (SafetyStage.PLANNING,)
+
+
+def test_resolve_card_satisfies_empty_when_no_signal() -> None:
+    assert resolve_card_satisfies(_card(phase=None)) == ()
+
+
+# --------------------------------------------------------------------------
+# deck schema：optional satisfies
+# --------------------------------------------------------------------------
+
+
+def test_existing_default_cards_have_empty_satisfies() -> None:
+    cards = load_cards(DEFAULT_CARDS_PATH)
+    assert cards
+    assert all(card.satisfies == () for card in cards.values())
+
+
+def test_schema_parses_optional_satisfies(tmp_path) -> None:
+    path = tmp_path / "cards.yaml"
+    path.write_text(
+        "version: 0\n"
+        "cards:\n"
+        "  - id: with-satisfies\n"
+        "    kind: skill\n"
+        "    type: headless\n"
+        "    class: core\n"
+        "    skill_ref: skills/a\n"
+        "    phase: review\n"
+        "    satisfies: [review]\n"
+        "  - id: without-satisfies\n"
+        "    kind: skill\n"
+        "    type: headless\n"
+        "    class: core\n"
+        "    skill_ref: skills/b\n"
+        "    phase: build\n",
+        encoding="utf-8",
+    )
+    cards = load_cards(path)
+    assert cards["with-satisfies"].satisfies == ("review",)
+    assert cards["without-satisfies"].satisfies == ()
+
+
+def test_schema_rejects_duplicate_satisfies(tmp_path) -> None:
+    path = tmp_path / "cards.yaml"
+    path.write_text(
+        "version: 0\n"
+        "cards:\n"
+        "  - id: dup\n"
+        "    kind: skill\n"
+        "    type: headless\n"
+        "    class: core\n"
+        "    skill_ref: skills/a\n"
+        "    phase: review\n"
+        "    satisfies: [review, review]\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(DeckSchemaError):
+        load_cards(path)
+
+
+# --------------------------------------------------------------------------
+# coverage validator
+# --------------------------------------------------------------------------
+
+
+def _valid_manifest() -> WorkflowManifest:
+    return default_workflow_manifest("demo-work", change=None, combo_name="feature-oneshot")
+
+
+def _topology_broken_manifest() -> WorkflowManifest:
+    """全部 7 phase 都在、但順序反轉——topology fail、coverage pass。"""
+    valid = _valid_manifest()
+    return WorkflowManifest(
+        combo=valid.combo,
+        task_slug=valid.task_slug,
+        steps=tuple(reversed(valid.steps)),
+    )
+
+
+def test_evaluate_coverage_complete_on_valid_manifest() -> None:
+    cov = evaluate_coverage(_valid_manifest())
+    assert cov.is_complete
+    assert cov.missing == ()
+    assert cov.covered == frozenset(SAFETY_STAGES)
+    assert coverage_verdict(cov).passed
+
+
+def test_coverage_missing_responsibility_when_phase_absent() -> None:
+    step = WorkflowStep(
+        phase="build",
+        persona="builder",
+        card="only-build",
+        executor=None,
+        model=None,
+        domain=None,
+        inputs=(),
+        outputs=(),
+    )
+    manifest = WorkflowManifest(combo="c", task_slug="s", steps=(step,))
+    cov = evaluate_coverage(manifest)
+    assert not cov.is_complete
+    assert SafetyStage.IMPLEMENTATION in cov.covered
+    assert SafetyStage.REVIEW in cov.missing
+    verdict = coverage_verdict(cov)
+    assert not verdict.passed
+    assert "review" in verdict.reason
+
+
+def test_responsibility_coverage_to_dict_roundtrips_stage_values() -> None:
+    cov: ResponsibilityCoverage = evaluate_coverage(_valid_manifest())
+    payload = cov.to_dict()
+    assert payload["missing"] == []
+    assert set(payload["covered"]) == SAFETY_STAGE_NAMES
+    assert all(payload["satisfied_by"][stage.value] for stage in SAFETY_STAGES)
+
+
+# --------------------------------------------------------------------------
+# shadow 比對：disagreement 只可能是 topology-fail / coverage-pass
+# --------------------------------------------------------------------------
+
+
+def test_valid_manifest_yields_agreement() -> None:
+    comparison = compare_manifest(_valid_manifest(), callsite="test")
+    assert comparison.topology.passed
+    assert comparison.coverage_verdict.passed
+    assert comparison.agreement
+    assert comparison.disagreement_kind is None
+
+
+def test_topology_broken_manifest_is_a_disagreement() -> None:
+    comparison = compare_manifest(_topology_broken_manifest(), callsite="test")
+    assert comparison.topology.passed is False
+    assert comparison.coverage_verdict.passed is True
+    assert comparison.agreement is False
+    assert comparison.disagreement_kind == "topology-fail-coverage-pass"
+    payload = comparison.to_dict()
+    assert payload["disagreement"]["kind"] == "topology-fail-coverage-pass"
+    assert payload["topology"]["passed"] is False
+    assert payload["coverage"]["passed"] is True
+
+
+# --------------------------------------------------------------------------
+# 零行為變更的證明
+# --------------------------------------------------------------------------
+
+
+def test_shadow_does_not_change_topology_pass_result(tmp_path) -> None:
+    manifest = _valid_manifest()
+    run_coverage_shadow(manifest, callsite="test", root=tmp_path)
+    # production gate 仍照舊通過，未被 shadow 影響。
+    manifest.validate_manager_spine()
+
+
+def test_shadow_does_not_change_topology_fail_result(tmp_path) -> None:
+    manifest = _topology_broken_manifest()
+    # coverage validator 判 pass，但 production gate 仍必須照舊 raise（逐位元組不變）。
+    comparison = run_coverage_shadow(manifest, callsite="test", root=tmp_path)
+    assert comparison is not None and comparison.coverage_verdict.passed
+    with pytest.raises(ValueError):
+        manifest.validate_manager_spine()
+
+
+def test_topology_verdict_reason_matches_raised_message() -> None:
+    manifest = _topology_broken_manifest()
+    verdict = topology_verdict(manifest)
+    with pytest.raises(ValueError) as excinfo:
+        manifest.validate_manager_spine()
+    # shadow 對 topology 的判定就是 production 邏輯本身——原因訊息逐字一致。
+    assert verdict.reason == str(excinfo.value)
+
+
+def test_manifest_bytes_carry_no_satisfies() -> None:
+    manifest = _valid_manifest()
+    serialized = json.dumps(manifest.to_dict(), sort_keys=True)
+    assert "satisfies" not in serialized
+    for step in manifest.to_dict()["steps"]:
+        assert "satisfies" not in step
+
+
+def test_run_coverage_shadow_never_raises_even_if_compare_breaks(tmp_path, monkeypatch) -> None:
+    def boom(*_args, **_kwargs):
+        raise RuntimeError("shadow internal explosion")
+
+    monkeypatch.setattr(coverage, "compare_manifest", boom)
+    # 內部炸掉也必須被吞掉、回 None，絕不外溢到 production。
+    assert run_coverage_shadow(_valid_manifest(), callsite="test", root=tmp_path) is None
+
+
+def test_write_shadow_record_never_raises_on_unwritable_root(tmp_path) -> None:
+    blocker = tmp_path / "blocker"
+    blocker.write_text("i am a file, not a dir", encoding="utf-8")
+    comparison = compare_manifest(_valid_manifest(), callsite="test")
+    # root 是檔案不是目錄 → mkdir 失敗 → 吞掉回 None。
+    assert coverage.write_shadow_record(comparison, root=blocker / "sub") is None
+
+
+# --------------------------------------------------------------------------
+# 回滾開關與 telemetry 落點
+# --------------------------------------------------------------------------
+
+
+def test_shadow_enabled_default_on() -> None:
+    assert shadow_enabled({}) is True
+    assert shadow_enabled({"PSC_RESPONSIBILITY_COVERAGE": "on"}) is True
+    assert shadow_enabled({"PSC_RESPONSIBILITY_COVERAGE": "anything"}) is True
+
+
+def test_shadow_enabled_off_disables() -> None:
+    assert shadow_enabled({"PSC_RESPONSIBILITY_COVERAGE": "off"}) is False
+    assert shadow_enabled({"PSC_RESPONSIBILITY_COVERAGE": " OFF "}) is False
+
+
+def test_env_off_skips_comparison_and_writes_nothing(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("PSC_RESPONSIBILITY_COVERAGE", "off")
+    assert run_coverage_shadow(_valid_manifest(), callsite="test", root=tmp_path) is None
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_env_on_writes_one_telemetry_file_with_required_fields(tmp_path, monkeypatch) -> None:
+    monkeypatch.delenv("PSC_RESPONSIBILITY_COVERAGE", raising=False)
+    comparison = run_coverage_shadow(
+        _topology_broken_manifest(),
+        callsite="manager.start",
+        context={"work_id": "w-1", "repo": "owner/repo"},
+        root=tmp_path,
+    )
+    assert comparison is not None
+    files = [p for p in tmp_path.iterdir() if p.suffix == ".json"]
+    assert len(files) == 1
+    record = json.loads(files[0].read_text(encoding="utf-8"))
+    # 至少含：manifest 識別、兩方判定、disagreement 細節。
+    assert record["manifest"]["combo"] and record["manifest"]["task_slug"]
+    assert record["callsite"] == "manager.start"
+    assert record["context"] == {"work_id": "w-1", "repo": "owner/repo"}
+    assert record["topology"]["passed"] is False
+    assert record["coverage"]["passed"] is True
+    assert record["disagreement"]["kind"] == "topology-fail-coverage-pass"
+    assert record["schema_version"] == coverage.SHADOW_TELEMETRY_SCHEMA
+
+
+def test_default_telemetry_root_follows_coordinator_root(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("PSC_COORDINATOR_ROOT", str(tmp_path))
+    monkeypatch.delenv("PSC_RESPONSIBILITY_COVERAGE", raising=False)
+    run_coverage_shadow(_valid_manifest(), callsite="test")
+    written = list((tmp_path / "coverage-shadow").glob("*.json"))
+    assert len(written) == 1


### PR DESCRIPTION
## 這是什麼

v4 重構計畫 R1（方案 A）的第一個 PR：**responsibility coverage validator 的 shadow 骨架**。

v4 核心論點：safety truth 不該依賴 `current_phase`（workflow topology），而該依賴「責任覆蓋」（responsibility coverage）。R1 是這個重構的**觀測期**——把新的 coverage validator 與現行 topology validator（`WorkflowManifest.validate_manager_spine()`）並行跑、比對、記 telemetry，但 production 決策**仍完全由舊 validator 主導**。累積兩週 disagreement telemetry 後才決定是否進 R2 啟用。

Refs: v4 R1 方案 A（計畫 `cortex-redesign-rollout-plan.md` §三 Phase R1）。

## 拆分設計與新型別

- **topology validator**＝現行 `validate_manager_spine()`，**一 byte 未動**，繼續是 production 唯一真相源。
- **coverage validator**＝新增 `paulsha_cortex/coordinator/coverage.py`，讀同一份 manifest，以責任覆蓋角度獨立判定。
- `SafetyStage`（Enum）：七個 safety responsibility，與七 phase 一一對映（`intake`/`specification`/`planning`/`implementation`/`verification`/`review`/`delivery`）；`INTAKE`/`DELIVERY` 為 Manager-owned authority boundary（constitution decision 3）。`SAFETY_STAGES` 為 canonical 排序的 tuple。
- `ResponsibilityCoverage`（frozen dataclass）：`required` / `covered` / `missing` / `satisfied_by`（責任 → 覆蓋它的 card id），附 `is_complete`。
- **satisfies adapter**：deck card schema 加 optional `satisfies`（capability declaration，**非** self-certification）。`resolve_card_satisfies()` 宣告優先、`phase` 兜底，因此**現有 deck 檔不需改**（不帶 `satisfies` 的 card 由 legacy `phase → responsibility` adapter 讀）。deck 層只做結構檢查、不驗語意值域——responsibility taxonomy 的權威在 coverage validator，維持 deck→coordinator 依賴方向不反轉。

## 零行為變更如何保證

R1 鐵律：coverage validator 的判定**絕不影響任何 production gate/dispatch/acceptance**。本 PR 以四道結構保證落地：

1. **topology validator 未修改**——`validate_manager_spine()` 原始碼一 byte 未動，仍是 production 唯一決策源。
2. **shadow 永不 raise**——`run_coverage_shadow()` 全程包在 `try/except Exception`，任何內部錯誤（比對 bug、寫檔失敗、目錄不可寫）一律吞成 debug log；掛在 `manager.py` production 派工 gate（`_manager_workflow` start）呼叫點旁，放在 `validate_manager_spine()` 之前只為讓「topology 即將 raise」的案例也被觀測到，但因永不 raise，後續 gate 照舊執行。
3. **回滾開關**——`PSC_RESPONSIBILITY_COVERAGE=off` 完全停用 shadow（連比對都不跑）；預設 `on`（只 shadow、不決策）。
4. **manifest bytes 不變**——`satisfies` 只加在 Card（deck 層），**未** projection 進 `WorkflowStep`/`WorkflowManifest`，manifest 序列化 bytes 逐位元組不變（projection 會改 bytes＝行為變更，屬 R2）。

測試證明（`tests/test_coverage_shadow_r1.py`，26 個）：
- `test_shadow_does_not_change_topology_pass_result` / `_fail_result`：無論 coverage 判 pass 或 fail，`validate_manager_spine()` 的 pass/raise 結果不變。
- `test_topology_verdict_reason_matches_raised_message`：shadow 對 topology 的判定就是 production 邏輯本身（原因訊息逐字一致，不另抄一份、不可能 drift）。
- `test_manifest_bytes_carry_no_satisfies`：manifest 序列化不含 `satisfies`。
- `test_run_coverage_shadow_never_raises_even_if_compare_breaks` / `test_write_shadow_record_never_raises_on_unwritable_root`：shadow 內部炸掉、sink 不可寫，皆吞掉回 None。
- `test_env_off_skips_comparison_and_writes_nothing` / `test_env_on_writes_one_telemetry_file_with_required_fields`：回滾開關與 telemetry 落點。

**disagreement 方向性**：因 coverage 的完整性要求較 topology 寬鬆（topology pass ⟹ 全 phase 齊 ⟹ 全責任覆蓋 ⟹ coverage pass），唯一可能的 disagreement 是 `topology-fail-coverage-pass`——這正是報告「topology 過度約束」論點的可觀測形式。

## 四檔 source-of-truth 查核結論（計畫 §3 要求）

計畫風險聲明 §3 要求 R1 開工前對四檔做現況查核，確認報告（0814 main）前提仍成立：

- **`coordinator/workflow.py`**：`validate_manager_spine()`（L325）確為現行 topology 真相源，驗 phase 單調排列＋claim 起頭＋完整 phase spine＋phase↔persona 綁定＋ship 前有 reviewer step。前提**成立**，未受 R0/R0.5 影響。
- **`deck/schema.py`**：`Card` 有 optional `phase`；`_CARD_KEYS` 白名單 fail-closed；既有 `runtime_capabilities` 提供了 optional list 欄位的解析範式，`satisfies` 照此加入。前提**成立**。
- **`deck/compile.py`**：`_workflow_phase()`（L464）＋`_LEGACY_CARD_PHASES` 已存在一組 legacy `card id → phase` 對映；`_compile_workflow_manifest()` 由 card 欄位建 `WorkflowStep`，**不**含 `satisfies`——確認加 `satisfies` 不影響 manifest 產出。前提**成立**。
- **`coordinator/work_bridge.py`**：`default_workflow_manifest()`（L184）與 `manager.py:9631`（start action）為 `validate_manager_spine()` 的兩個 production-ish 呼叫點；本 PR shadow 掛在 `manager.py` 的 production 派工 gate。前提**成立**。

四檔前提**全部仍成立**，報告 R1 的拆分假設無需修訂。

## Shadow telemetry 落點與格式

- **落點**：`coordinator_root()/coverage-shadow/`（新增 `paths.coverage_shadow_telemetry_root()`，隨 `PSC_COORDINATOR_ROOT`/`PSC_AGENTS_ROOT` 移動）。
- **格式**：一次比對一檔的原子 JSON（`.` 前綴 temp → fsync → `os.replace`，比照 D4 event-spool 語意，不需鎖、consumer 不可能讀到半寫入檔）。每筆含 `schema_version`、`recorded_at`、`callsite`、`manifest`（combo/task_slug/version/steps）、`context`（work_id/repo/claim_key/combo）、`topology`（passed/reason）、`coverage`（passed/reason/required/covered/missing/satisfied_by）、`agreement`、`disagreement`（kind＋兩方 reason＋missing responsibilities）。供兩週觀測期的 disagreement 分析。

## 範圍紀律

不做 Compact reuse／auto_develop／monotonic escalation（R2）；不碰 GitHub 邊界／trust-root／採信契約；manifest v2 未擴（production 仍 v1）。

## 測試

- 目標測試：`tests/test_coverage_shadow_r1.py` 26 passed。
- 全套：`python3 -m pytest -q` → **3029 passed, 49 subtests passed**（本機無 #565 `/tmp/.git` 暫態紅）。

## Checklist
- [x] `changelog.d/r1-coverage-validator-shadow.md` fragment 已新增並 commit
- [x] `CHANGELOG.md [Unreleased]` 有對應 entry
- [x] 分支非 main（`feature/r1-coverage-validator-shadow`）
- [x] 全套測試通過
- [x] 零行為變更已由測試證明
