### PR TITLE
fix(instance-config): 修復 #518 legacy instance 設定隔離

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -205,6 +205,10 @@
   `tests/test_monitor_git_native_reads_506.py`（16 個測試，含量化驗收樁）。
 
 ### Fixed
+- **Issue #518：instance config isolation**——`cortex install service` 會遷移 legacy
+  instance env，原子產生可驗證的 exact-project monitor config 並保留 rollback；monitor
+  不再因父目錄 workspace 掃到 sibling repos，`cortex doctor` 也會從本機 env 檔告警 shared
+  project config root 與重複掃描影響。
 - **Issue #569：reviewer 卡的 `retry-verify` 只重置不重派——`retry-card` 放寬到
   verify／review 的 reviewer 卡**——實測 run `workflow-084f75e2178cf7547476` 的
   verification job（agy，#568 權限剖面缺陷）exit 0 但 log 無 JSON envelope，

--- a/changelog.d/fix-instance-config-isolation.md
+++ b/changelog.d/fix-instance-config-isolation.md
@@ -1,0 +1,3 @@
+Fixed #518 instance config isolation: legacy service environments now adopt an atomic,
+rollback-safe exact-project monitor configuration, and doctor reports shared project config
+roots with their repeated scan impact.

--- a/openspec/changes/fix-instance-config-isolation/tasks.md
+++ b/openspec/changes/fix-instance-config-isolation/tasks.md
@@ -8,7 +8,7 @@ work_item: fix-instance-config-isolation
 - [x] 1.1 [RED] Add reproducible regression coverage for legacy env adoption,
       exact-project single-repo monitoring, rollback, shared config-root
       diagnostics, and post-migration managed-path drift.
-- [ ] 1.2 Implement the accepted legacy env migration and atomic rollback path.
-- [ ] 1.3 Implement exact-project workspace semantics without sibling scans.
-- [ ] 1.4 Add single-instance shared config-root diagnostics.
+- [x] 1.2 Implement the accepted legacy env migration and atomic rollback path.
+- [x] 1.3 Implement exact-project workspace semantics without sibling scans.
+- [x] 1.4 Add single-instance shared config-root diagnostics.
 - [ ] 1.5 Run the GREEN implementation and repository governance gates.

--- a/openspec/changes/fix-instance-config-isolation/tasks.md
+++ b/openspec/changes/fix-instance-config-isolation/tasks.md
@@ -1,0 +1,14 @@
+---
+status: accepted
+work_item: fix-instance-config-isolation
+---
+
+# Tasks
+
+- [x] 1.1 [RED] Add reproducible regression coverage for legacy env adoption,
+      exact-project single-repo monitoring, rollback, shared config-root
+      diagnostics, and post-migration managed-path drift.
+- [ ] 1.2 Implement the accepted legacy env migration and atomic rollback path.
+- [ ] 1.3 Implement exact-project workspace semantics without sibling scans.
+- [ ] 1.4 Add single-instance shared config-root diagnostics.
+- [ ] 1.5 Run the GREEN implementation and repository governance gates.

--- a/openspec/changes/fix-instance-config-isolation/tasks.md
+++ b/openspec/changes/fix-instance-config-isolation/tasks.md
@@ -11,4 +11,11 @@ work_item: fix-instance-config-isolation
 - [x] 1.2 Implement the accepted legacy env migration and atomic rollback path.
 - [x] 1.3 Implement exact-project workspace semantics without sibling scans.
 - [x] 1.4 Add single-instance shared config-root diagnostics.
-- [ ] 1.5 Run the GREEN implementation and repository governance gates.
+- [ ] 1.5 Run the GREEN implementation and repository governance gates before
+      archive (Manager-owned final preflight).
+
+      Pre-archive status for this card: the implementation-focused tests and
+      policy/OpenSpec validation passed. The authoritative full pytest gate is
+      pending because this sandbox rejects AF_UNIX socket creation with
+      `EPERM`; Manager must rerun it in an environment with that capability.
+      Archive, merge, issue closure, and done remain Manager actions.

--- a/paulsha_cortex/deploy/installer.py
+++ b/paulsha_cortex/deploy/installer.py
@@ -7,16 +7,22 @@ import re
 import shutil
 import subprocess
 import sys
+import tempfile
 from dataclasses import dataclass
 from importlib import resources
 from pathlib import Path
 from typing import Sequence
+
+import yaml
 
 from paulsha_cortex.config import paths
 from paulsha_cortex.deploy import hooks as hook_reconcile
 
 _INSTANCE_RE = re.compile(r"[a-z0-9][a-z0-9-]*")
 _SUPPORTED_EXECUTORS = frozenset({"copilot", "claude", "codex"})
+_PRESERVE_EXISTING_PATHS = frozenset(
+    {"PSC_INSTANCE", "PSC_RUN_ROOT", "PSC_MONITOR_STATE_ROOT"}
+)
 
 
 @dataclass(frozen=True)
@@ -249,6 +255,111 @@ def _instance_env_file(runtime_dir: Path, instance: str) -> Path:
     return runtime_dir / f"{instance}.env"
 
 
+def _is_exact_project_config(config_path: Path, repo_root: Path) -> bool:
+    try:
+        from paulsha_cortex.monitor.config import load_config
+
+        config = load_config(config_path=config_path)
+    except (OSError, ValueError):
+        return False
+    if len(config.workspaces) != 1:
+        return False
+    workspace = config.workspaces[0]
+    return (
+        workspace.exact_project
+        and workspace.path.expanduser().resolve() == repo_root.expanduser().resolve()
+    )
+
+
+def _is_loadable_model_identities(config_root: Path) -> bool:
+    try:
+        from paulsha_cortex.coordinator.model_identities import load_model_identities
+
+        load_model_identities(config_root, use_packaged_default=False)
+    except (OSError, ValueError):
+        return False
+    return True
+
+
+def _restore_file(path: Path, previous: bytes | None) -> None:
+    if previous is None:
+        path.unlink(missing_ok=True)
+        return
+    path.write_bytes(previous)
+
+
+def _migrate_instance_config(
+    *,
+    env_file: Path,
+    existing: dict[str, str],
+    config_root: Path,
+    repo_root: Path,
+    managed_env: dict[str, str],
+) -> None:
+    """Adopt a legacy instance with a validated, rollback-safe config bundle."""
+    project_config = config_root / "project-cortex.yaml"
+    identities = config_root / "model-identities.yaml"
+    project_needs_update = not _is_exact_project_config(project_config, repo_root)
+    identities_need_update = not _is_loadable_model_identities(config_root)
+    current_root = existing.get("PSC_PROJECT_CONFIG_ROOT", "").strip()
+    root_needs_update = (
+        not current_root
+        or Path(current_root).expanduser().resolve() != config_root.resolve()
+    )
+    if not (project_needs_update or identities_need_update or root_needs_update):
+        _write_managed_env(
+            env_file,
+            managed_env,
+            preserve_existing=_PRESERVE_EXISTING_PATHS,
+        )
+        return
+
+    config_root.mkdir(parents=True, exist_ok=True)
+    project_payload = {
+        "workspaces": [
+            {
+                "name": repo_root.name,
+                "path": str(repo_root),
+                "exact_project": True,
+            }
+        ]
+    }
+    project_text = yaml.safe_dump(project_payload, sort_keys=False)
+    identities_text = "schema_version: 3\nidentities: []\n"
+    previous = {
+        env_file: env_file.read_bytes() if env_file.is_file() else None,
+        project_config: project_config.read_bytes() if project_config.is_file() else None,
+        identities: identities.read_bytes() if identities.is_file() else None,
+    }
+    staging = Path(tempfile.mkdtemp(prefix=".cortex-migration-", dir=config_root))
+    try:
+        staged_project = staging / "project-cortex.yaml"
+        staged_identities = staging / "model-identities.yaml"
+        staged_project.write_text(project_text, encoding="utf-8")
+        staged_identities.write_text(identities_text, encoding="utf-8")
+        from paulsha_cortex.coordinator.model_identities import load_model_identities
+        from paulsha_cortex.monitor.config import load_config
+
+        load_config(config_path=staged_project)
+        load_model_identities(staging, use_packaged_default=False)
+        if project_needs_update:
+            os.replace(staged_project, project_config)
+        if identities_need_update:
+            os.replace(staged_identities, identities)
+        _write_managed_env(
+            env_file,
+            managed_env,
+            preserve_existing=_PRESERVE_EXISTING_PATHS,
+        )
+    except Exception:
+        _restore_file(env_file, previous[env_file])
+        _restore_file(project_config, previous[project_config])
+        _restore_file(identities, previous[identities])
+        raise
+    finally:
+        shutil.rmtree(staging, ignore_errors=True)
+
+
 def install_service_result(
     instance: str, interval: int, repo_root: Path, *, rebind: bool = False
 ) -> InstallServiceResult:
@@ -318,23 +429,12 @@ def install_service_result(
         if executor_override not in _SUPPORTED_EXECUTORS:
             raise ValueError("PSC_MANAGER_EXECUTOR 必須為 copilot、claude 或 codex")
         managed_env["PSC_MANAGER_EXECUTOR"] = executor_override
-    _write_managed_env(
-        env_file,
-        managed_env,
-        # PSC_PROJECT_CONFIG_ROOT 與 PSC_CONTROL_ROOT 刻意不在這裡：兩者都是純粹
-        # 依 PSC_AGENTS_ROOT／instance 推導的 managed path，放進 preserve_existing
-        # 等於允許一個早期殘留的錯誤值被永久鎖死、重裝也修不好（#371 的根因；
-        # #375 加入 PSC_CONTROL_ROOT 時複驗明確警告過不得重蹈覆轍）。
-        # PSC_MANAGER_SPECS_DIR／PSC_COORDINATOR_ROOT／PSC_SPECS_ROOT 目前仍不在
-        # managed_env 之列（維持 operator 域，見 issue #375 comment 的評估與
-        # test_install_leaves_specs_and_coordinator_roots_as_operator_domain）。
-        preserve_existing=frozenset(
-            {
-                "PSC_INSTANCE",
-                "PSC_RUN_ROOT",
-                "PSC_MONITOR_STATE_ROOT",
-            }
-        ),
+    _migrate_instance_config(
+        env_file=env_file,
+        existing=existing,
+        config_root=Path(managed_env["PSC_PROJECT_CONFIG_ROOT"]),
+        repo_root=repo_root,
+        managed_env=managed_env,
     )
     hook_reconcile_result = hook_reconcile.reconcile_codex_hooks(
         hook_reconcile.default_codex_hooks_path(home)

--- a/paulsha_cortex/doctor.py
+++ b/paulsha_cortex/doctor.py
@@ -874,6 +874,71 @@ def _managed_path_drift_probe(
     )
 
 
+def _shared_project_config_root_probe(
+    effective: Mapping[str, str], *, home: Path, instance: str
+) -> ProbeResult:
+    """Detect shared project config roots from local bootstrap env files only."""
+    raw_root = effective.get("PSC_PROJECT_CONFIG_ROOT", "").strip()
+    if not raw_root:
+        return ProbeResult(
+            "shared-project-config-root",
+            "pass",
+            "PSC_PROJECT_CONFIG_ROOT is not set; shared-root check not applicable",
+            False,
+        )
+    project_root = Path(raw_root).expanduser().resolve()
+    runtime_dir = home / ".agents" / "core" / "runtime"
+    owners: dict[str, Path] = {instance: project_root}
+    if runtime_dir.is_dir():
+        for env_file in sorted(runtime_dir.glob("*-manager.env")):
+            name = env_file.name[: -len("-manager.env")]
+            if INSTANCE_RE.fullmatch(name) is None:
+                continue
+            try:
+                values = _parse_environment_file(env_file)
+            except (OSError, ValueError):
+                continue
+            candidate = values.get("PSC_PROJECT_CONFIG_ROOT", "").strip()
+            if not candidate:
+                agents = values.get("PSC_AGENTS_ROOT", "").strip()
+                candidate = str(Path(agents).expanduser() / "config" / "paulsha") if agents else ""
+            if candidate:
+                owners[name] = Path(candidate).expanduser().resolve()
+    shared_instances = sorted(
+        name for name, candidate in owners.items() if candidate == project_root
+    )
+    if len(shared_instances) < 2:
+        return ProbeResult(
+            "shared-project-config-root",
+            "pass",
+            "project config root is not shared by multiple local instances",
+            False,
+        )
+
+    repo_paths: tuple[str, ...] = ()
+    config_path = project_root / "project-cortex.yaml"
+    try:
+        from .monitor.config import load_config
+        from .monitor.scanner import scan_workspaces
+
+        states = scan_workspaces(load_config(config_path=config_path))
+        repo_paths = tuple(sorted({str(Path(state.path).resolve()) for state in states}))
+    except (OSError, ValueError):
+        pass
+    impact = (
+        f"repeated scan repos={len(repo_paths)} ({', '.join(repo_paths)})"
+        if repo_paths
+        else "repeated scan repos=unknown"
+    )
+    return ProbeResult(
+        "shared-project-config-root",
+        "warn",
+        f"project config root {project_root} is shared by instances "
+        f"{', '.join(shared_instances)}; {impact}",
+        False,
+    )
+
+
 def _service_paths_probe(*, home: Path, instance: str, live: bool) -> ProbeResult:
     result, _effective = _service_environment_probe(
         home=home,
@@ -1048,6 +1113,7 @@ def run_doctor(
         service_probe,
         _repo_identity_probe(effective),
         _managed_path_drift_probe(effective, agents_root=agents_root, instance=instance),
+        _shared_project_config_root_probe(effective, home=home_path, instance=instance),
         state_probe,
         socket_probe,
     ]

--- a/paulsha_cortex/monitor/config.py
+++ b/paulsha_cortex/monitor/config.py
@@ -44,6 +44,7 @@ def default_socket_path() -> Path:
 class WorkspaceConfig:
     path: Path
     name: str
+    exact_project: bool = False
 
 
 @dataclass(frozen=True)
@@ -123,10 +124,16 @@ def _parse_workspaces(raw: Any) -> tuple[WorkspaceConfig, ...]:
             raise ValueError(f"config.workspaces[{index}].path 缺失")
         if not name_value:
             raise ValueError(f"config.workspaces[{index}].name 缺失")
+        exact_project = entry.get("exact_project", entry.get("exact", False))
+        if not isinstance(exact_project, bool):
+            raise ValueError(
+                f"config.workspaces[{index}].exact_project 必須是布林值"
+            )
         items.append(
             WorkspaceConfig(
                 path=Path(str(path_value)).expanduser(),
                 name=str(name_value),
+                exact_project=exact_project,
             )
         )
     return tuple(items)
@@ -261,4 +268,3 @@ def load_config(*, config_path: Path | None = None) -> MonitorConfig:
         _load_manual_config(resolved),
         hippo_projects=tuple(hippo_list),
     )
-

--- a/paulsha_cortex/monitor/scanner.py
+++ b/paulsha_cortex/monitor/scanner.py
@@ -179,7 +179,11 @@ def scan_workspaces_detailed(config: MonitorConfig) -> ScanResult:
     degraded_diagnostics: list[DegradedDiagnostic] = []
 
     for workspace in config.workspaces:
-        project_dirs, error = _list_project_dirs_checked(workspace.path, ignore)
+        if workspace.exact_project:
+            resolved_project, error = checked_resolve(workspace.path)
+            project_dirs = [] if error is not None else [resolved_project]
+        else:
+            project_dirs, error = _list_project_dirs_checked(workspace.path, ignore)
         if error is not None:
             degraded_roots.append(workspace.path)
             degraded_workspaces.append(workspace.name)

--- a/tests/test_instance_config_isolation.py
+++ b/tests/test_instance_config_isolation.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+def _init_project(path: Path) -> Path:
+    path.mkdir(parents=True, exist_ok=True)
+    subprocess.run(["git", "init", "-q", str(path)], check=True)
+    (path / ".project-policy.yml").write_text(
+        "policy_profile: flat\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def _legacy_instance_fixture(tmp_path: Path) -> tuple[Path, Path, Path, Path]:
+    repo_parent = tmp_path / "repos"
+    target_repo = _init_project(repo_parent / "hippo")
+    _init_project(repo_parent / "sibling")
+    home = tmp_path / "home"
+    agents_root = home / ".agents" / "instances" / "hippo-open-issues"
+    env_file = home / ".agents" / "core" / "runtime" / "hippo-manager.env"
+    env_file.parent.mkdir(parents=True, exist_ok=True)
+    env_file.write_text(
+        f"PSC_AGENTS_ROOT={agents_root}\n"
+        f"PSC_REPO_ROOT={target_repo}\n",
+        encoding="utf-8",
+    )
+    return home, agents_root, target_repo, env_file
+
+
+def _env_values(path: Path) -> dict[str, str]:
+    return {
+        key: value
+        for key, value in (
+            line.split("=", 1)
+            for line in path.read_text(encoding="utf-8").splitlines()
+            if line and not line.startswith("#") and "=" in line
+        )
+    }
+
+
+def test_install_service_migrates_legacy_instance_to_one_exact_project(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#518 RED: legacy env adoption must materialize an isolated monitor config."""
+    from paulsha_cortex.deploy import installer
+    from paulsha_cortex.monitor.config import load_config
+    from paulsha_cortex.monitor.scanner import scan_workspaces
+
+    home, agents_root, target_repo, _env_file = _legacy_instance_fixture(tmp_path)
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.delenv("PSC_AGENTS_ROOT", raising=False)
+    monkeypatch.setattr(installer, "_systemctl_available", lambda: False)
+
+    assert installer.main(["service", "--instance", "hippo", "--repo-root", str(target_repo)]) == 0
+
+    config_root = agents_root / "config" / "paulsha"
+    project_config = config_root / "project-cortex.yaml"
+    identities = config_root / "model-identities.yaml"
+    assert _env_values(home / ".agents" / "core" / "runtime" / "hippo-manager.env")[
+        "PSC_PROJECT_CONFIG_ROOT"
+    ] == str(config_root)
+    assert project_config.is_file()
+    assert identities.is_file()
+    project_payload = yaml.safe_load(project_config.read_text(encoding="utf-8"))
+    assert isinstance(project_payload, dict)
+    assert isinstance(project_payload.get("workspaces"), list)
+    assert project_payload["workspaces"]
+    assert isinstance(yaml.safe_load(identities.read_text(encoding="utf-8")), dict)
+
+    monkeypatch.setenv("PSC_PROJECT_CONFIG_ROOT", str(config_root))
+    monkeypatch.setenv("PSC_REPO_ROOT", str(target_repo))
+    config = load_config()
+    states = scan_workspaces(config)
+    assert {Path(state.path).resolve() for state in states} == {target_repo.resolve()}
+
+    from paulsha_cortex.doctor import run_doctor
+
+    monkeypatch.setattr(
+        "paulsha_cortex.doctor._load_runtime_preflight_command",
+        lambda environment: ("true",),
+    )
+    monkeypatch.setattr(
+        "paulsha_cortex.doctor._load_runtime_model_identities",
+        lambda config_root: 1,
+    )
+    report = run_doctor(
+        probe_live=False,
+        instance="hippo",
+        env={
+            "HOME": str(home),
+            "PSC_REPO_ROOT": str(target_repo),
+            "PSC_PROJECT_CONFIG_ROOT": str(config_root),
+        },
+        home=home,
+    )
+    drift = next(probe for probe in report.probes if probe.name == "managed-path-drift")
+    assert drift.status == "pass"
+
+
+def test_install_service_rolls_back_legacy_adoption_after_managed_env_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#518 RED: a failed migration must restore env and generated config files."""
+    from paulsha_cortex.deploy import installer
+
+    home, agents_root, target_repo, env_file = _legacy_instance_fixture(tmp_path)
+    config_root = agents_root / "config" / "paulsha"
+    config_root.mkdir(parents=True)
+    project_config = config_root / "project-cortex.yaml"
+    identities = config_root / "model-identities.yaml"
+    project_config.write_text("legacy: project-config\n", encoding="utf-8")
+    identities.write_text("legacy: identities\n", encoding="utf-8")
+    before_env = env_file.read_bytes()
+    before_project = project_config.read_bytes()
+    before_identities = identities.read_bytes()
+
+    original_write_managed_env = installer._write_managed_env
+
+    def fail_after_env_write(*args, **kwargs):
+        original_write_managed_env(*args, **kwargs)
+        raise RuntimeError("injected migration failure")
+
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.delenv("PSC_AGENTS_ROOT", raising=False)
+    monkeypatch.setattr(installer, "_systemctl_available", lambda: False)
+    monkeypatch.setattr(installer, "_write_managed_env", fail_after_env_write)
+
+    with pytest.raises(RuntimeError, match="injected migration failure"):
+        installer.main(["service", "--instance", "hippo", "--repo-root", str(target_repo)])
+
+    assert env_file.read_bytes() == before_env
+    assert project_config.read_bytes() == before_project
+    assert identities.read_bytes() == before_identities
+
+
+def test_doctor_warns_when_instances_share_project_config_root_and_repo_scan(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#518 RED: one instance-local doctor run must expose shared-root impact."""
+    from paulsha_cortex.doctor import run_doctor
+
+    home, _agents_root, target_repo, _env_file = _legacy_instance_fixture(tmp_path)
+    sibling_repo = target_repo.parent / "sibling"
+    shared_root = home / ".agents" / "config" / "paulsha"
+    shared_root.mkdir(parents=True)
+    (shared_root / "project-cortex.yaml").write_text(
+        "workspaces:\n"
+        f"  - name: shared\n    path: {target_repo.parent}\n",
+        encoding="utf-8",
+    )
+    (shared_root / "model-identities.yaml").write_text(
+        "schema_version: 1\nidentities: []\n",
+        encoding="utf-8",
+    )
+    runtime = home / ".agents" / "core" / "runtime"
+    for instance in ("cortex", "hippo"):
+        instance_agents = home / ".agents" / "instances" / instance
+        (runtime / f"{instance}-manager.env").write_text(
+            f"PSC_REPO_ROOT={target_repo}\n"
+            f"PSC_AGENTS_ROOT={instance_agents}\n"
+            f"PSC_RUN_ROOT={instance_agents / 'run' / instance}\n"
+            f"PSC_MONITOR_STATE_ROOT={instance_agents / 'monitor'}\n"
+            f"PSC_PROJECT_CONFIG_ROOT={shared_root}\n"
+            f"PSC_CONTROL_ROOT={instance_agents / 'control' / instance}\n",
+            encoding="utf-8",
+        )
+    unit_dir = home / ".config" / "systemd" / "user"
+    unit_dir.mkdir(parents=True)
+    for instance in ("cortex", "hippo"):
+        for unit in (f"{instance}-manager.service", f"{instance}-monitor.service"):
+            (unit_dir / unit).write_text(
+                "[Unit]\n"
+                f"EnvironmentFile=-%h/.agents/core/runtime/{instance}-manager.env\n",
+                encoding="utf-8",
+            )
+        (unit_dir / f"{instance}-manager.timer").write_text("[Timer]\n", encoding="utf-8")
+
+    monkeypatch.setattr(
+        "paulsha_cortex.doctor._load_runtime_preflight_command",
+        lambda environment: ("true",),
+    )
+    monkeypatch.setattr(
+        "paulsha_cortex.doctor._load_runtime_model_identities",
+        lambda config_root: 1,
+    )
+    report = run_doctor(
+        probe_live=False,
+        instance="hippo",
+        env={
+            "HOME": str(home),
+            "PSC_REPO_ROOT": str(target_repo),
+            "PSC_PROJECT_CONFIG_ROOT": str(shared_root),
+        },
+        home=home,
+    )
+
+    assert any(
+        probe.status == "warn"
+        and "hippo" in probe.detail
+        and "cortex" in probe.detail
+        and str(sibling_repo) in probe.detail
+        and "2" in probe.detail
+        for probe in report.probes
+    )


### PR DESCRIPTION
## 摘要

修復 issue #518：hippo 與 cortex 兩 instance 因 `PSC_PROJECT_CONFIG_ROOT` 未隨 instance 隔離，掃到相同 13 個 repo。

- **installer（legacy env 遷移）**：`cortex install service` 遷移 legacy instance env，原子產生可驗證的 exact-project monitor config（`workspaces[].exact_project: true` 綁定該 repo）並保留 rollback；驗證失敗時還原 env／project-cortex.yaml／model-identities.yaml。
- **doctor（共用 config root 告警）**：新增 `shared-project-config-root` probe，純從本機 `*-manager.env` 讀取，偵測多個 instance 共用同一 project config root 時 warn，並附重複掃描 repo 影響。
- **monitor（exact-project 語意）**：`WorkspaceConfig.exact_project` 讓 workspace 只解析為單一指定 repo，不再因父目錄 workspace 掃到 sibling repos。

## 採納脈絡

此為 dogfooding run `workflow-084f75e2178cf7547476` 的產出，operator 手動採納收尾（原因：builder sandbox AF_UNIX EPERM 環境誤報 #586，非修復本身問題，導致 cortex 內無法自動採信）。三個 commit（RED 回歸測試／主修復／openspec pre-archive gate 狀態）以 cherry-pick rebase 到當前 main。

與 R0.5 的共存：doctor.py（#570 診斷 invariant、#534 模型鏈 probe）與 monitor/（#566 D2 git 化、#575 D3 增量）的改動落在非重疊區段，#518 的修復意圖完整套用於新版程式；僅 CHANGELOG 有放置衝突，已把 #518 條目併入既有 `### Fixed` 段首。

## 測試

- `tests/test_instance_config_isolation.py`：3 passed（遷移／rollback／doctor 告警）
- 全套 `python3 -m pytest -q`：3032 passed, 49 subtests passed, 0 failed

Refs #518 #586
