### PR TITLE
fix(sandbox): guard AF_UNIX bind tests under builder workspace-write sandbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -240,6 +240,21 @@
   instance env，原子產生可驗證的 exact-project monitor config 並保留 rollback；monitor
   不再因父目錄 workspace 掃到 sibling repos，`cortex doctor` 也會從本機 env 檔告警 shared
   project config root 與重複掃描影響。
+- **#586（缺陷 A）：builder sandbox 無法 bind AF_UNIX socket，全套 pytest 假失敗**
+  ——builder（codex，`codex exec --sandbox workspace-write`）的沙箱實測**允許**
+  `socket(AF_UNIX)` 建立與 `socketpair()`，但用 seccomp 把 **`bind()`** 擋成 EPERM
+  （網路隔離），即使 socket 路徑在可寫根內。凡是 bind 本地 unix-domain socket（起
+  `MonitorServer`／直接綁）的測試在 builder 沙箱內必失敗，令 builder 自跑整套
+  `python3 -m pytest -q` 永遠有失敗、與 manager 獨立 ledger（正常環境 passed）系統性
+  分歧。codex 的 seccomp 無法從本 repo 細粒度只放行 AF_UNIX bind（唯一開關是整片打開
+  網路的 `network_access`／`danger-full-access`，正是 #586 安全邊界所禁），故採環境修復：
+  新增 `tests/sandbox_support.py` 偵測當前 runtime 能否 bind AF_UNIX，凡需 bind 的測試
+  在無法 bind 的沙箱下**明確 skip（帶原因）**而非假失敗，使 builder 自跑 pytest 由「有
+  失敗」變 exit 0，與權威 ledger 源頭一致。**安全邊界**：只改「無法 bind 時 run vs skip」
+  的判定，不放寬任何 syscall／不打開網路／不允許 builder 連上 manager socket（與 #584
+  trust-root 隔離不衝突）。防護 `test_stage9_project_monitor_service.py`、
+  `test_monitor_work_api.py`、`test_doctor.py`；新增 `tests/test_sandbox_afunix_skip_586.py`
+  以模擬沙箱子行程證明防護測試 skip 而非 fail。
 - **Issue #569：reviewer 卡的 `retry-verify` 只重置不重派——`retry-card` 放寬到
   verify／review 的 reviewer 卡**——實測 run `workflow-084f75e2178cf7547476` 的
   verification job（agy，#568 權限剖面缺陷）exit 0 但 log 無 JSON envelope，

--- a/changelog.d/builder-sandbox-afunix.md
+++ b/changelog.d/builder-sandbox-afunix.md
@@ -1,0 +1,27 @@
+### Fixed
+- **#586（缺陷 A）：builder sandbox 無法 bind AF_UNIX socket，全套 pytest 假失敗**
+  ——builder（codex executor）以 `codex exec --sandbox workspace-write` 執行，實測
+  （codex-cli 0.147.0 `codex sandbox`）該沙箱**允許** `socket(AF_UNIX)` 建立與
+  `socketpair()`，但用 seccomp 把 **`bind()`** 這個網路類 syscall 擋成 EPERM（errno 1）
+  ——即使 socket 路徑落在 workspace-write 的可寫根內。凡是 bind 本地 unix-domain
+  socket（起 `MonitorServer`／直接綁 socket）的測試在 builder 沙箱內必失敗，使 builder
+  自跑的整套 `python3 -m pytest -q` 永遠有失敗，與正常環境（manager 獨立 ledger／CI）
+  結果系統性不一致（envelope failed vs ledger passed 分歧的環境根因）。
+  - **根因與放寬邊界**：codex 的 seccomp 是編譯進二進位、無法從 paulsha-cortex 端做
+    「只放行 AF_UNIX bind」的細粒度放寬；codex 只提供 `network_access` /
+    `danger-full-access` 這種「整片網路打開」的粗粒度開關，而那正是 #586 安全邊界
+    明文禁止的（不放寬網路、不放寬 builder 連上 manager 既有 socket）。因此採**環境
+    修復**的可行且安全路徑：測試層偵測「當前 runtime 能否 bind AF_UNIX」，凡需要
+    bind 的測試在無法 bind 的沙箱語境下**明確 skip（帶原因）**，而非假失敗。
+  - **效果**：builder 自跑整套 pytest 在沙箱下由「有失敗」變「skip 不失敗」（exit 0），
+    與 manager 權威 ledger（正常環境 run→pass）在源頭一致，消除 envelope/ledger 分歧；
+    正常環境／CI／manager 下 bind 可用，這些測試照常執行、零覆蓋損失。
+  - **安全邊界**：只改變測試在「無法 bind AF_UNIX」時的判定（run vs skip），**不**放寬
+    任何 syscall、不打開網路、不允許 builder 連上 manager 的 socket——與 trust-root
+    隔離（#584）方向不衝突。
+  - 新增 `tests/sandbox_support.py`（`af_unix_bind_available()` probe + `requires_af_unix_bind`
+    marker），防護 `tests/test_stage9_project_monitor_service.py`、
+    `tests/test_monitor_work_api.py`、`tests/test_doctor.py` 內會 bind socket 的測試；
+    新增 `tests/test_sandbox_afunix_skip_586.py` 證明 probe 判定與真實 bind 能力一致，
+    並以子行程在**模擬沙箱**（process-wide 把 `bind` 打成 EPERM）下跑防護測試檔，驗證
+    需 bind 的測試 skip 而非 fail、整檔 exit 0。

--- a/tests/sandbox_support.py
+++ b/tests/sandbox_support.py
@@ -1,0 +1,84 @@
+"""Sandbox-aware guards for tests that stand up AF_UNIX (unix-domain) sockets.
+
+issue #586 的根因（實測，codex-cli 0.147.0 `codex sandbox`）：
+
+  * `socket.socket(AF_UNIX, SOCK_STREAM)` **建立** socket → OK
+  * `socketpair()` → OK
+  * `sock.bind(<path>)` → **PermissionError EPERM（errno 1）**，即使 path 落在
+    workspace-write 的可寫根內。
+
+也就是說，builder（codex executor，`--sandbox workspace-write`）的沙箱是用
+seccomp 把 `bind` 這個「網路類」syscall 擋掉（網路隔離的一環），**不是**檔案系統
+路徑問題。這無法從 paulsha-cortex 這端對 codex 編譯進去的 seccomp 做「只放行
+AF_UNIX」的細粒度放寬——codex 只提供 `network_access` / `danger-full-access` 這種
+「整片網路打開」的粗粒度開關，而那正是 #586 安全邊界明文禁止的。
+
+因此環境修復落在測試層：偵測「當前 runtime 是否能 bind() 一個 AF_UNIX socket」，
+凡是需要 bind（起 `MonitorServer` 或直接綁 unix socket）的測試，在 builder 沙箱
+語境下明確 **skip（帶原因）**，而非假失敗。這讓 builder 自跑的整套
+`python3 -m pytest -q` 結果（skip → exit 0）與 manager 權威 ledger（正常環境
+run → pass）在源頭一致，消除 envelope/ledger 分歧。正常環境／CI 下 bind 可用，
+這些測試照常執行，不損失任何覆蓋。
+
+安全邊界：本模組**只**改變測試在「無法 bind AF_UNIX」時的判定（run vs skip），
+不放寬任何 syscall、不打開網路、不允許 builder 連上 manager 既有 socket。
+"""
+
+from __future__ import annotations
+
+import errno
+import functools
+import socket
+import tempfile
+from pathlib import Path
+
+import pytest
+
+AF_UNIX_SKIP_REASON = (
+    "builder sandbox forbids binding an AF_UNIX socket (bind() -> EPERM); "
+    "codex --sandbox workspace-write blocks the bind syscall as part of "
+    "network isolation. Skipped to keep the sandboxed pytest result "
+    "consistent with the manager's authoritative ledger. See issue #586."
+)
+
+
+@functools.lru_cache(maxsize=1)
+def af_unix_bind_available() -> bool:
+    """Return ``True`` when the current runtime can ``bind()`` an AF_UNIX socket.
+
+    Probes once (result cached). Treats an EPERM on either socket *creation*
+    (e.g. the srt reviewer sandbox blocks creation) or ``bind()`` (codex
+    workspace-write blocks the bind syscall) as "unavailable". Any other
+    unexpected ``OSError`` is likewise treated as unavailable so a guarded test
+    skips rather than erroring in a hostile environment; a normal host binds
+    cleanly and returns ``True``.
+    """
+
+    with tempfile.TemporaryDirectory(prefix="psc-afunix-probe-") as tmp:
+        sock_path = Path(tmp) / "probe.sock"
+        try:
+            sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        except (PermissionError, OSError):
+            return False
+        try:
+            sock.bind(str(sock_path))
+        except PermissionError as exc:
+            # errno is informational here: any PermissionError on bind means the
+            # sandbox forbids standing up a local listener.
+            _ = exc.errno == errno.EPERM
+            return False
+        except OSError:
+            return False
+        finally:
+            sock.close()
+    return True
+
+
+#: ``@requires_af_unix_bind`` for pytest-style test functions. For
+#: ``unittest.TestCase`` subclasses use ``@unittest.skipUnless(
+#: af_unix_bind_available(), AF_UNIX_SKIP_REASON)`` instead (native and honored
+#: identically under pytest).
+requires_af_unix_bind = pytest.mark.skipif(
+    not af_unix_bind_available(),
+    reason=AF_UNIX_SKIP_REASON,
+)

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -10,6 +10,8 @@ from pathlib import Path
 
 import pytest
 
+from sandbox_support import requires_af_unix_bind
+
 from paulsha_cortex import cli
 from paulsha_cortex.doctor import (
     DoctorReport,
@@ -498,6 +500,7 @@ def test_monitor_live_probe_requires_connectable_unix_socket(tmp_path: Path) -> 
     assert "monitor socket" in monitor_socket.detail
 
 
+@requires_af_unix_bind
 def test_monitor_protocol_probe_rejects_transport_only_listener(tmp_path: Path, monkeypatch) -> None:
     socket_path = tmp_path / "run" / "project-monitor.sock"
     socket_path.parent.mkdir()

--- a/tests/test_monitor_work_api.py
+++ b/tests/test_monitor_work_api.py
@@ -7,6 +7,8 @@ from unittest import mock
 
 import pytest
 
+from sandbox_support import requires_af_unix_bind
+
 from paulsha_cortex.monitor.config import MonitorConfig
 from paulsha_cortex.monitor.server import MonitorServer
 from paulsha_cortex.monitor.server import _Subscriber
@@ -199,6 +201,7 @@ def test_recv_fails_fast_when_socket_closes_before_newline():
         client.close()
 
 
+@requires_af_unix_bind
 def test_socket_work_item_read_apis_and_subscription_preserve_legacy(tmp_path):
     project_store = SnapshotStore(config=MonitorConfig(workspaces=()))
     work_store = WorkReadModelStore(_snapshot(_item("active", "ongoing")))
@@ -254,6 +257,7 @@ def test_socket_work_item_read_apis_and_subscription_preserve_legacy(tmp_path):
         thread.join(timeout=2)
 
 
+@requires_af_unix_bind
 def test_work_subscription_can_scope_duplicate_work_id_by_repo(tmp_path):
     healthy = ProviderSnapshot(
         provider_id="github:example/acme",
@@ -328,6 +332,7 @@ def test_work_subscription_can_scope_duplicate_work_id_by_repo(tmp_path):
         thread.join(timeout=2)
 
 
+@requires_af_unix_bind
 def test_server_stopped_before_start_never_signals_ready(tmp_path):
     server = MonitorServer(
         store=SnapshotStore(config=MonitorConfig(workspaces=())),
@@ -349,6 +354,7 @@ def test_server_stopped_before_start_never_signals_ready(tmp_path):
     assert not server.wait_until_ready(timeout=0)
 
 
+@requires_af_unix_bind
 def test_old_server_teardown_does_not_unlink_replacement_socket(tmp_path):
     socket_path = tmp_path / "monitor.sock"
     store = SnapshotStore(config=MonitorConfig(workspaces=()))
@@ -391,6 +397,7 @@ def test_old_server_teardown_does_not_unlink_replacement_socket(tmp_path):
         old_thread.join(timeout=2.0)
 
 
+@requires_af_unix_bind
 def test_work_subscription_extension_preserves_legacy_queue_full_replacement(tmp_path):
     server = MonitorServer(
         store=SnapshotStore(config=MonitorConfig(workspaces=())),

--- a/tests/test_sandbox_afunix_skip_586.py
+++ b/tests/test_sandbox_afunix_skip_586.py
@@ -1,0 +1,163 @@
+"""issue #586：驗證 AF_UNIX bind 沙箱防護（probe 邏輯 + 全套 pytest 不假失敗）。
+
+證明兩件事：
+
+1. ``af_unix_bind_available()`` 忠實反映當前 runtime 能否 ``bind()`` 一個 AF_UNIX
+   socket——在 EPERM（沙箱擋 bind／擋 socket 建立）下回 ``False``，能綁時回
+   ``True``；且其判定與「當場真的 bind 一次」的 ground truth 一致（與環境無關，
+   在 builder 沙箱與正常環境都成立）。
+
+2. 在**模擬 builder 沙箱**（process-wide 把 ``socket.socket.bind`` 打成 EPERM）下，
+   跑真正被防護的測試檔（``tests/test_monitor_work_api.py``）時，需要 bind 的測試
+   會 **skip 而非 fail**，整個檔案 ``pytest`` **exit 0**——即修復後全套 pytest 在
+   builder 沙箱語境不再因 AF_UNIX EPERM 假失敗。
+"""
+
+from __future__ import annotations
+
+import errno
+import os
+import re
+import socket
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from unittest import mock
+
+import sandbox_support
+from sandbox_support import af_unix_bind_available
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_TESTS_DIR = Path(__file__).resolve().parent
+
+
+def _actual_bind_capability() -> bool:
+    """Ground truth：當場真的建立並 bind 一個 AF_UNIX socket。"""
+
+    with tempfile.TemporaryDirectory(prefix="psc-afunix-truth-") as tmp:
+        try:
+            sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        except OSError:
+            return False
+        try:
+            sock.bind(str(Path(tmp) / "truth.sock"))
+        except OSError:
+            return False
+        finally:
+            sock.close()
+    return True
+
+
+def test_probe_matches_actual_bind_capability() -> None:
+    """probe 的判定必須等於當前環境真實的 bind 能力（環境無關）。"""
+
+    af_unix_bind_available.cache_clear()
+    try:
+        assert af_unix_bind_available() is _actual_bind_capability()
+    finally:
+        af_unix_bind_available.cache_clear()
+
+
+def test_probe_returns_false_when_bind_raises_eperm() -> None:
+    """bind() → EPERM（codex workspace-write 的網路隔離）時 probe 回 False。"""
+
+    def _blocked_bind(self, *args, **kwargs):  # noqa: ANN001, ANN002, ANN003
+        raise PermissionError(errno.EPERM, "AF_UNIX bind blocked (sim)")
+
+    af_unix_bind_available.cache_clear()
+    try:
+        with mock.patch.object(sandbox_support.socket.socket, "bind", _blocked_bind):
+            assert af_unix_bind_available() is False
+    finally:
+        af_unix_bind_available.cache_clear()
+
+
+def test_probe_returns_false_when_socket_creation_raises_eperm() -> None:
+    """socket() 建立本身 → EPERM（srt reviewer 沙箱）時 probe 回 False。"""
+
+    af_unix_bind_available.cache_clear()
+    try:
+        with mock.patch.object(
+            sandbox_support.socket,
+            "socket",
+            side_effect=PermissionError(errno.EPERM, "AF_UNIX create blocked (sim)"),
+        ):
+            assert af_unix_bind_available() is False
+    finally:
+        af_unix_bind_available.cache_clear()
+
+
+def test_probe_returns_true_when_bind_succeeds() -> None:
+    """能建立且能 bind 時 probe 回 True（正常環境／CI／manager 不被 over-skip）。"""
+
+    fake_sock = mock.Mock()
+    fake_sock.bind.return_value = None
+    fake_sock.close.return_value = None
+
+    af_unix_bind_available.cache_clear()
+    try:
+        with mock.patch.object(sandbox_support.socket, "socket", return_value=fake_sock):
+            assert af_unix_bind_available() is True
+        fake_sock.bind.assert_called_once()
+        fake_sock.close.assert_called_once()
+    finally:
+        af_unix_bind_available.cache_clear()
+
+
+_SANDBOX_SIM_PLUGIN = """\
+# Simulate the builder sandbox: process-wide block AF_UNIX bind() with EPERM,
+# exactly like codex --sandbox workspace-write. Imported via `-p` before pytest
+# collects, so sandbox_support's probe sees the block and the guarded tests skip.
+import errno
+import socket
+
+
+def _blocked_bind(self, *args, **kwargs):
+    raise PermissionError(errno.EPERM, "AF_UNIX bind blocked (issue #586 sandbox sim)")
+
+
+socket.socket.bind = _blocked_bind
+"""
+
+
+def test_guarded_suite_skips_not_fails_under_simulated_sandbox() -> None:
+    """模擬沙箱下，真正的防護測試檔 skip 需 bind 的測試、exit 0（不假失敗）。"""
+
+    with tempfile.TemporaryDirectory(prefix="psc-afunix-simplugin-") as plugin_dir:
+        (Path(plugin_dir) / "afunix_sandbox_sim.py").write_text(
+            _SANDBOX_SIM_PLUGIN, encoding="utf-8"
+        )
+        env = dict(os.environ)
+        env["PYTHONPATH"] = os.pathsep.join(
+            [plugin_dir, str(_REPO_ROOT), env.get("PYTHONPATH", "")]
+        ).strip(os.pathsep)
+        # 只跑一個乾淨切分的檔（5 個 server 測試被防護、其餘 read-model 測試無 bind
+        # 必須照常通過），足以證明「skip 而非 fail、exit 0」。
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "pytest",
+                str(_TESTS_DIR / "test_monitor_work_api.py"),
+                "-p",
+                "afunix_sandbox_sim",
+                "-rs",
+                "-q",
+                "-o",
+                "addopts=",
+            ],
+            cwd=str(_REPO_ROOT),
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=300,
+        )
+    combined = result.stdout + result.stderr
+    # exit 0：pytest 只有在零 fail／零 error 時回 0。
+    assert result.returncode == 0, combined
+    # 至少 5 個 bind 測試被明確 skip（帶 #586 原因），而非靜默沒被收集。
+    skipped_match = re.search(r"(\d+) skipped", combined)
+    assert skipped_match is not None, combined
+    assert int(skipped_match.group(1)) >= 5, combined
+    assert "issue #586" in combined

--- a/tests/test_stage9_project_monitor_service.py
+++ b/tests/test_stage9_project_monitor_service.py
@@ -40,6 +40,8 @@ import unittest
 from pathlib import Path
 from unittest import mock
 
+from sandbox_support import AF_UNIX_SKIP_REASON, af_unix_bind_available
+
 # Imports from the Phase 3 modules (do not exist yet — Red).
 try:
     from paulsha_cortex.monitor.config import MonitorConfig, WorkspaceConfig
@@ -437,6 +439,7 @@ class Stage9StubWatcherTests(unittest.TestCase):
 # --- MonitorServer (Unix socket) ----------------------------------------
 
 
+@unittest.skipUnless(af_unix_bind_available(), AF_UNIX_SKIP_REASON)
 class Stage9ServerTests(unittest.TestCase):
     """Unix domain socket server: list / get / subscribe + permissions."""
 
@@ -864,6 +867,7 @@ class Stage9ServerTests(unittest.TestCase):
 # --- ProjectMonitorService end-to-end -----------------------------------
 
 
+@unittest.skipUnless(af_unix_bind_available(), AF_UNIX_SKIP_REASON)
 class Stage9ServiceTests(unittest.TestCase):
     """Full service: scanner + (stub) watcher + server."""
 
@@ -1116,6 +1120,7 @@ class Stage9ServiceTests(unittest.TestCase):
 # --- Real watchdog integration (optional) -------------------------------
 
 
+@unittest.skipUnless(af_unix_bind_available(), AF_UNIX_SKIP_REASON)
 @unittest.skipUnless(
     HAS_WATCHDOG_INTEGRATION,
     "requires real watchdog installed and WatchdogFileWatcher present",


### PR DESCRIPTION
## 摘要（缺陷 A：builder sandbox 無法 bind AF_UNIX socket）

修 issue #586 缺陷 A：run `workflow-084f75e2178cf7547476` 的 subagent-build job 488
（codex builder）在沙箱內跑 `python3 -m pytest -q` 撞 AF_UNIX EPERM，凡碰 monitor
socket／unix domain socket 的測試必失敗，令 builder 自報 `pytest failed`，而 manager
獨立 ledger（正常環境）為 passed。operator 裁定走**環境修復**路線（不改採信契約）。

## 根因（實測定位）

builder 是 codex executor，`coordinator/launcher.py` 的 `build_codex_argv` 以
`codex exec --sandbox workspace-write` 派工——沙箱是 **codex 自身**的 Landlock+seccomp，
非 paulsha-cortex 疊加。以 codex-cli 0.147.0 的 `codex sandbox` 子命令實測該沙箱：

| 操作 | 結果 |
| --- | --- |
| `socket.socket(AF_UNIX, SOCK_STREAM)` 建立 | **OK** |
| `socket.socketpair()` | **OK** |
| `sock.bind(<workspace 可寫根內路徑>)` | **PermissionError EPERM（errno 1）** |

即真正被擋的是 **`bind()`**（seccomp 把它當網路類 syscall 擋掉的網路隔離一環），
**不是** socket 建立、**也不是**檔案系統路徑問題——把 socket 放到 sandbox tmp 也沒用，
bind 在 syscall 層就 EPERM。issue 原文「AF_UNIX socket creation raised EPERM」是對此
的簡述；精確的失敗點在 bind。

`doctor.py` 的 `review-sandbox` probe 已把「AF_UNIX 建立被擋」當成 srt reviewer 沙箱
應有的（EPERM＝pass）性質，印證這類沙箱刻意阻斷本地 socket 作為網路封鎖。

### 受影響測試（會 bind 本地 unix-domain socket）
- `tests/test_stage9_project_monitor_service.py`：`Stage9ServerTests`、`Stage9ServiceTests`、
  `Stage9WatchdogIntegrationTests`（起 `MonitorServer.serve_forever()`／直接綁 socket）。
- `tests/test_monitor_work_api.py`：`test_socket_work_item_read_apis...`、
  `test_work_subscription_can_scope...`、`test_server_stopped_before_start...`、
  `test_old_server_teardown...`、`test_work_subscription_extension...`（起 `MonitorServer`）。
- `tests/test_doctor.py`：`test_monitor_protocol_probe_rejects_transport_only_listener`（直接 bind）。
- 不受影響（只建 socket／socketpair／連不存在的 socket／只讀路徑屬性，或只 refresh 不
  serve）：`test_recv_fails_fast...`、`test_monitor_config_resolution.py`、
  `test_issue_273_monitor_silent-failure.py`、`test_monitor_scan_health.py`（後兩者建
  `ProjectMonitorService` 但只測 refresh，`__init__` 不 bind、不呼叫 `serve_forever()`）。

## 放寬方式與安全邊界論證

**為何不是「真的放寬 codex 沙箱允許 bind」**：codex 的 seccomp 編譯進二進位，
paulsha-cortex 這端無法對它做「只放行 AF_UNIX bind」的細粒度放寬；codex 唯一可調的網路
開關是 `network_access` / `danger-full-access`，一開就是**整片網路打開**——而那正是 #586
安全邊界明文禁止的（不放寬網路、不放寬 builder 連上 manager 既有 socket）。因此無法在
邊界內「放寬沙箱建 socket」，改採 issue／任務授權的環境修復退路：

**測試層偵測 + 明確 skip**。新增 `tests/sandbox_support.py`：
- `af_unix_bind_available()`：一次性 probe，建立 AF_UNIX socket 並 bind 到暫存路徑，
  遇 socket 建立或 bind 的 EPERM（或其他 `OSError`）→ 回 `False`；能綁 → `True`。
- 需 bind 的測試以 `@requires_af_unix_bind`（pytest）或
  `@unittest.skipUnless(af_unix_bind_available(), ...)`（unittest）防護。

**效果**：builder 自跑整套 pytest 在沙箱下由「有失敗」變「skip 不失敗」（exit 0），與
manager 權威 ledger（正常環境 run→pass）在**源頭**一致，消除 envelope/ledger 分歧；
正常環境／CI／manager 下 bind 可用，這些測試照常執行，**零覆蓋損失**。

**安全邊界（為何不擴大 builder 攻擊面）**：本 PR 只改變測試在「無法 bind AF_UNIX」時的
判定（run vs skip），**不**放寬任何 syscall、**不**打開網路、**不**允許 builder 連上
manager 的 socket，也**不**動 codex 沙箱政策本身。builder 能不能建 socket 一如既往由
codex 沙箱決定；本 PR 沒有給 builder 任何新能力。與進行中的 trust-root 隔離（#584）
方向不衝突。

## 驗收

- `tests/test_sandbox_afunix_skip_586.py`（新增）：
  - probe 判定與「當場真的 bind 一次」的 ground truth 一致（環境無關）。
  - bind→EPERM／socket 建立→EPERM 時 probe 回 `False`；能綁時回 `True`。
  - **子行程在模擬沙箱**（process-wide 把 `socket.socket.bind` 打成 EPERM）下跑
    `tests/test_monitor_work_api.py`，斷言需 bind 的測試 **skip 而非 fail**、整檔
    **exit 0**、skip 原因含 `issue #586`。這證明修復後 builder 沙箱語境下全套 pytest
    不再因 AF_UNIX EPERM 假失敗。
- 目標檔：正常環境下 `test_stage9...`＋`test_monitor_work_api`＋`test_doctor` 100 passed
  （零 over-skip，與 manager／CI 一致）。
- 全套 `python3 -m pytest -q`：3034 passed、49 subtests passed。

## 變更檔案
- 新增 `tests/sandbox_support.py`
- 新增 `tests/test_sandbox_afunix_skip_586.py`
- 改 `tests/test_stage9_project_monitor_service.py`、`tests/test_monitor_work_api.py`、
  `tests/test_doctor.py`（加 skip 防護）
- `changelog.d/builder-sandbox-afunix.md`、`CHANGELOG.md [Unreleased]`

Refs #586
