### PR TITLE
feat(trust-root): D6 Phase 1 資產登記表、啟動自檢與 capability 降級通道

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@
 ## [Unreleased]
 
 ### Added
+- **R0.5 D6 / trust-root 隔離 Phase 1（純程式碼、不需 root、含降級安全網）**
+  ——新增 `paulsha_cortex/trust_root/` 子套件，依 spec `trust-root-isolation-spec.md`
+  Phase 1 與 operator 0816 裁決交付 join gate 未達成期間的契約層地基：**R1 資產登記表**
+  （`registry.py`，單一機器可讀真相＋`config/paths.py`／`control/constants.py` 的雙向
+  等式測試，涵蓋 builder／reviewer／planner 三 persona）、**R3 啟動自檢**（`selfcheck.py`，
+  用登記表對照現行部署把 group/other-writable 的 Manager-owned 路徑標為 job-writable；
+  掛在 `manager_daemon` 啟動點，受 `PSC_TRUST_ROOT_SELFCHECK` 閘控，Phase 1 **只 WARN**）、
+  **R7 capability 通道＋降級運轉**（`capability.py`，敏感 action 無 capability 時 100%
+  被拒；capability action-bound＋single-use＋短效＋不落地 durable state；降級開關
+  `PSC_DEGRADED_OPERATION` 預設 `per-case-approval`、可切 `disabled`）。on-demand 入口
+  `python -m paulsha_cortex.trust_root {selfcheck,registry,equation}`。**Phase 1 不提供**
+  （需 Phase 2 OS 邊界）：真正不可寫強制、持久 nonce ledger、socket OS 隔離、自檢
+  fail-closed。詳見 `changelog.d/d6-trust-root-phase1.md`。新增
+  `tests/test_trust_root_{registry_r1,selfcheck_r3,capability_r7}.py`（43 測試）。
 - **v4 R1（方案 A）：responsibility coverage validator 的 shadow 骨架（零行為變更）**
   ——新增 `paulsha_cortex/coordinator/coverage.py`：新的 coverage validator 與現行
   topology validator（`validate_manager_spine()`，未動）**並行跑、比對、記 telemetry**，

--- a/changelog.d/d6-trust-root-phase1.md
+++ b/changelog.d/d6-trust-root-phase1.md
@@ -1,0 +1,36 @@
+### Added
+- **R0.5 D6 / trust-root 隔離 Phase 1（純程式碼、不需 root、含降級安全網）**
+  ——依 spec `docs/superpowers/specs/trust-root-isolation-spec.md` 的 Phase 1 條列與
+  operator 0816 裁決（路線 A 為 0.2.0 基礎；Manager 專屬 UID；headless 二分
+  builder／非 builder；舊 state 以 `legacy-import` 重入帳；降級運轉預設逐案核可），
+  新增 `paulsha_cortex/trust_root/` 子套件，交付 join gate 未達成期間的契約層地基：
+  - **R1 資產登記表**（`trust_root/registry.py`）：把全部 security-relevant durable
+    state 與 mutation ingress 固化為單一機器可讀真相（`TrustRootAsset` 常數），對每項
+    宣告 `asset_id`／`tier`（0/1/2）／`tree`（Manager-owned vs job-visible，裁決 10-1／
+    10-2）／`path_resolver`／`writers`／`readers`／`ingress_kind`，涵蓋 builder／reviewer／
+    planner 三個 headless persona。以反射對 `config/paths.py`＋`control/constants.py`
+    的每一個回傳 `Path` 的函式釘住**雙向等式**——新增未登記的 path 函式即 FAIL 並指名；
+    已知重複推導（`delivery-journal` 六處、`jobs-registry` 四處、
+    `work-items.snapshot` 兩處 fallback 分歧）固化為單一 canonical asset。
+  - **R3 啟動自檢（WARN-only）**（`trust_root/selfcheck.py`）：用登記表對照現行部署
+    實況，把帶 group／other 寫入位的 Manager-owned 路徑標為 `job-writable` 並輸出結構化
+    診斷；掛在 `manager_daemon.run_loop` 啟動點（受 `PSC_TRUST_ROOT_SELFCHECK` 閘控、
+    fire-and-forget、永不 raise）。Phase 1 **只 WARN、不 fail-closed**（fail-closed 是
+    Phase 2 R3 切換）。自檢在現行部署上獨立重現 spec 背景段盤點（`control`／
+    `coordinator`／`specs` 為 `drwxrwxr-x`），反證盤點正確。
+  - **R7 capability 通道 + 降級運轉**（`trust_root/capability.py`）：敏感 action
+    （`headless-acceptance`／`outbox-mutation`／`ship`／`merge` 封閉清單）在無 capability
+    時 100% 被拒；capability 為 action-bound（綁 `(action, work_id, run_id,
+    subject_hash, authority_revision)`）＋single-use（in-process nonce ledger）＋短效
+    （TTL ≤300s）＋不可經 durable state 重放（本體不落地，附常設掃描 helper）。降級
+    運轉開關（`PSC_DEGRADED_OPERATION`）預設 `per-case-approval`（裁決 10-5），提供
+    `disabled`（完全停用）切換。
+  - on-demand 診斷入口 `python -m paulsha_cortex.trust_root {selfcheck,registry,equation}`
+    （不動 `cortex` CLI，避開 R-16 help 對齊面）。
+  - **Phase 1 不提供（需 Phase 2 OS 邊界才完整）**：真正的不可寫強制（同 UID 下 mode
+    對 owner 無效）、跨 process／防重啟的持久 nonce ledger、capability 通道的 Unix
+    socket OS 隔離、自檢 fail-closed。Phase 1 建立契約與 fail-closed 語意，Phase 2 以
+    獨立 UID／目錄 owner 把它變成 kernel 強制。**不做** Phase 2（建 UID／分樹／部署遷移／
+    降權啟動器）與 Phase 3（簽章）。
+  - 新增 `tests/test_trust_root_registry_r1.py`、`tests/test_trust_root_selfcheck_r3.py`、
+    `tests/test_trust_root_capability_r7.py`（43 測試）。

--- a/paulsha_cortex/coordinator/manager_daemon.py
+++ b/paulsha_cortex/coordinator/manager_daemon.py
@@ -18,6 +18,7 @@ from typing import Any, Callable
 
 from paulsha_cortex.config import paths
 from ..control import constants, contract
+from ..trust_root import selfcheck as trust_root_selfcheck
 from . import autonomy, backoff, manager, planning_runtime
 from .cli import _refuse_unsafe_fanout, _resolve_launcher
 from .diagnostics import diagnostic_reason, summarize_exception
@@ -1159,6 +1160,25 @@ def build_periodic_tick_runner(
     return execute
 
 
+def _run_trust_root_selfcheck() -> None:
+    """R3（Phase 1）：啟動時跑一次 trust-root 自檢並以 WARN 送出（fire-and-forget）。
+
+    受 ``PSC_TRUST_ROOT_SELFCHECK`` 閘控（``off``／``0``／``false`` 停用，預設 on）。
+    Phase 1 **只 WARN、不 fail-closed**：自檢用 R1 登記表對照現行部署實況，指出哪些
+    Manager-owned 路徑現在其實 headless 可寫（group/other 寫入位）。永不 raise——
+    自檢失敗不得阻擋 daemon 啟動（fail-closed 切換是 Phase 2 R3）。
+    """
+    flag = (os.environ.get("PSC_TRUST_ROOT_SELFCHECK", "on") or "").strip().lower()
+    if flag in {"off", "0", "false", "no"}:
+        return
+    try:
+        trust_root_selfcheck.emit_startup_warnings(
+            emit=lambda line: print(f"{contract.utcnow()} {line}", file=sys.stderr)
+        )
+    except Exception:  # noqa: BLE001 — WARN-only：永不阻擋啟動
+        pass
+
+
 def run_loop(
     *,
     request_executor: Callable[[dict[str, Any]], dict[str, Any]] | None = None,
@@ -1273,6 +1293,8 @@ def run_loop(
 
     constants.requests_dir().mkdir(parents=True, exist_ok=True)
     constants.done_dir().mkdir(parents=True, exist_ok=True)
+
+    _run_trust_root_selfcheck()
 
     last_tick_at: str | None = None
     daemon_idle = True

--- a/paulsha_cortex/trust_root/__init__.py
+++ b/paulsha_cortex/trust_root/__init__.py
@@ -1,0 +1,22 @@
+"""trust-root 隔離（R0.5 D6）Phase 1：純程式碼、不需 root 的地基。
+
+本子套件實作 `docs/superpowers/specs/trust-root-isolation-spec.md` 的 **Phase 1**
+（見 spec §R10「落地」）。Phase 1 **只**交付不需 root、不改部署拓撲的部分：
+
+- `registry`：R1 trust-root 資產登記表（宣告式單一真相，供 Phase 2 權限產生器取用）
+  ＋雙向等式測試。
+- `selfcheck`：R3 Manager 啟動自檢，用登記表對照現行部署實況並輸出結構化診斷；
+  Phase 1 **只 WARN**（不 fail-closed，那是 Phase 2 R3 切換）。
+- `capability`：R7 敏感 action 的 capability 通道與降級運轉開關；無 capability 時
+  fail-closed 拒絕，支援 operator 逐案核可（裁決 10-5）。
+
+**Phase 1 不提供**（需 Phase 2 的 OS 邊界才完整，見各模組 docstring 與 PR body）：
+真正的不可寫強制（同 UID 下檔案 mode 對 owner 無效）、跨 process／重啟持久的
+single-use nonce ledger、capability 通道的 Unix socket OS 隔離。Phase 1 建立的是
+**契約與 fail-closed 語意**，Phase 2 以獨立 UID／目錄 owner 把它變成 kernel 強制。
+"""
+from __future__ import annotations
+
+from . import capability, registry, selfcheck
+
+__all__ = ["registry", "selfcheck", "capability"]

--- a/paulsha_cortex/trust_root/__main__.py
+++ b/paulsha_cortex/trust_root/__main__.py
@@ -1,0 +1,78 @@
+"""`python -m paulsha_cortex.trust_root` —— on-demand trust-root 診斷。
+
+Phase 1 不改 `cortex` CLI（避免動到 R-16 help 對齊面）；operator／CI 以本模組
+入口取得 R1 登記表摘要與 R3 自檢診斷。全部唯讀。
+
+用法：
+    python -m paulsha_cortex.trust_root selfcheck   # R3 自檢診斷（JSON）
+    python -m paulsha_cortex.trust_root registry    # R1 登記表摘要（JSON）
+    python -m paulsha_cortex.trust_root equation     # R1 雙向等式結果
+"""
+from __future__ import annotations
+
+import json
+import sys
+from typing import Sequence
+
+from . import registry, selfcheck
+
+
+def _registry_summary() -> dict[str, object]:
+    return {
+        "asset_count": len(registry.ASSET_REGISTRY),
+        "tier0": len(registry.assets_by_tier(registry.AssetTier.TIER_0)),
+        "tier1": len(registry.assets_by_tier(registry.AssetTier.TIER_1)),
+        "manager_owned": len(registry.manager_owned_assets()),
+        "job_visible": len(registry.job_visible_assets()),
+        "headless_writable_manager_owned": [
+            a.asset_id for a in registry.headless_writable_manager_owned()
+        ],
+        "personas_covered": sorted(p.value for p in registry.personas_covered()),
+        "mutation_ingress": [i.ingress_id for i in registry.MUTATION_INGRESS],
+        "assets": [
+            {
+                "asset_id": a.asset_id,
+                "tier": a.tier.name,
+                "tree": a.tree.value,
+                "path_resolver": a.path_resolver,
+                "writers": [w.value for w in a.writers],
+                "ingress_kind": a.ingress_kind.value,
+            }
+            for a in registry.ASSET_REGISTRY
+        ],
+    }
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = list(sys.argv[1:] if argv is None else argv)
+    command = args[0] if args else "selfcheck"
+
+    if command == "selfcheck":
+        report = selfcheck.run_self_check()
+        print(json.dumps(report.to_dict(), ensure_ascii=False, indent=2))
+        for line in report.warning_lines():
+            print(line, file=sys.stderr)
+        return 0
+    if command == "registry":
+        print(json.dumps(_registry_summary(), ensure_ascii=False, indent=2))
+        return 0
+    if command == "equation":
+        result = registry.check_registry_equation()
+        print(json.dumps(
+            {
+                "ok": result.ok,
+                "unregistered_functions": list(result.unregistered_functions),
+                "dangling_resolvers": list(result.dangling_resolvers),
+                "stale_acknowledgements": list(result.stale_acknowledgements),
+            },
+            ensure_ascii=False,
+            indent=2,
+        ))
+        return 0 if result.ok else 1
+
+    print(f"unknown command: {command}", file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/paulsha_cortex/trust_root/capability.py
+++ b/paulsha_cortex/trust_root/capability.py
@@ -1,0 +1,256 @@
+"""R7：敏感 action 的 capability 通道 + 降級運轉開關（Phase 1）。
+
+spec §R7 要求 operator 逐案核可以 **capability** 形式表達，且滿足 action-bound＋
+single-use＋短效＋不可經 durable state 重放。裁決 10-5 定：D6 join gate 未達成前，
+降級運轉**預設為「逐案核可」**（非完全停用），並提供切到「完全停用」的 config。
+
+**Phase 1（不需 root）交付**：capability 的資料形態、grant/consume 授權語意、
+fail-closed（無 capability 一律拒絕）、逐案核可 vs 完全停用的降級開關、以及
+「capability 本體不得落地 durable state」的常設掃描 helper。
+
+**Phase 1 不提供（需 Phase 2 OS 邊界才完整）**：
+- 通道的 OS 隔離：R7 要求通道為 Manager-owned `0700` 目錄下的 Unix socket，使
+  headless UID 因目錄 traverse 被拒而無法 connect。Phase 1 尚無獨立 headless UID，
+  socket 的 OS 隔離無意義，故本階段 capability 以 in-process broker 表達授權語意，
+  **不**開 socket。
+- 跨 process／重啟持久的 single-use nonce ledger：spec §R7 要求 nonce ledger 位於
+  R2 的 OS 邊界內。Phase 1 的 nonce ledger 是 **in-process**（同一 broker 實例內
+  single-use），足以示範語意；跨 process 去重與防重啟重放留待 Phase 2 落在受保護樹。
+
+因此 Phase 1 的降級網在同 UID 下**不是**完整隔離——它是 join gate 未達成期間的
+契約層安全網，把 fail-closed 語意先立起來，OS 強制由 Phase 2 承接。
+"""
+from __future__ import annotations
+
+import os
+import secrets
+import time
+from dataclasses import dataclass
+from enum import Enum
+from typing import Callable, Mapping
+
+#: 逐案核可的預設 TTL（秒）；spec §R7 建議 ≤300。
+DEFAULT_TTL_SECONDS = 300.0
+#: 降級運轉開關的環境變數。
+DEGRADED_MODE_ENV = "PSC_DEGRADED_OPERATION"
+
+
+class SensitiveAction(Enum):
+    """降級網涵蓋的敏感 action 封閉清單（spec §R10 Phase 1 第 6 條）。
+
+    新增須改本 enum（比照 spec §R4 的封閉清單語意）——不接受任意字串。
+    """
+
+    HEADLESS_ACCEPTANCE = "headless-acceptance"
+    OUTBOX_MUTATION = "outbox-mutation"
+    SHIP = "ship"
+    MERGE = "merge"
+
+
+class DegradedMode(Enum):
+    """降級運轉開關（裁決 10-5）。"""
+
+    #: 預設：敏感 action 需 operator 逐案明示核可（有效 capability 才放行）。
+    PER_CASE_APPROVAL = "per-case-approval"
+    #: 完全停用：敏感 action 一律拒絕，capability 也不放行（供 operator 切換）。
+    DISABLED = "disabled"
+
+
+def resolve_degraded_mode(env: Mapping[str, str] | None = None) -> DegradedMode:
+    """從環境解析降級模式；預設 PER_CASE_APPROVAL（裁決 10-5）。
+
+    無法辨識的值一律回退到**最保守可用**的預設（逐案核可），而非靜默放行。
+    """
+    environ = os.environ if env is None else env
+    raw = (environ.get(DEGRADED_MODE_ENV, "") or "").strip().lower()
+    if raw == DegradedMode.DISABLED.value:
+        return DegradedMode.DISABLED
+    if raw == DegradedMode.PER_CASE_APPROVAL.value or raw == "":
+        return DegradedMode.PER_CASE_APPROVAL
+    return DegradedMode.PER_CASE_APPROVAL
+
+
+@dataclass(frozen=True)
+class CapabilityBinding:
+    """capability 綁定的五元組（spec §R7 action-bound）。
+
+    任一項不符即無效，MUST NOT 可轉用到其他 action 或 work。
+    """
+
+    action: SensitiveAction
+    work_id: str
+    run_id: str
+    subject_hash: str
+    authority_revision: str
+
+
+@dataclass(frozen=True)
+class Capability:
+    """一次性授權憑證。
+
+    **MUST NOT 落地任何 durable state**（spec §R7）——本物件只存在於記憶體與
+    授權往返；落地的只有「已消耗 nonce」與不可還原的授權 attestation。
+    `__str__`／`to_public_dict` 皆不吐 nonce，避免不慎寫進 log／journal。
+    """
+
+    nonce: str
+    binding: CapabilityBinding
+    issued_at: float          # broker clock（單調）
+    ttl_seconds: float = DEFAULT_TTL_SECONDS
+
+    def expires_at(self) -> float:
+        return self.issued_at + self.ttl_seconds
+
+    def to_public_dict(self) -> dict[str, object]:
+        """不含 nonce 的展示投影（可安全記錄）。"""
+        return {
+            "action": self.binding.action.value,
+            "work_id": self.binding.work_id,
+            "run_id": self.binding.run_id,
+            "ttl_seconds": self.ttl_seconds,
+        }
+
+    def __str__(self) -> str:  # pragma: no cover - 防呆
+        return f"Capability(action={self.binding.action.value}, work_id={self.binding.work_id})"
+
+    __repr__ = __str__
+
+
+@dataclass(frozen=True)
+class AuthorizationDecision:
+    """授權判定結果（結構化，供 audit）。"""
+
+    allowed: bool
+    reason: str
+    action: SensitiveAction
+    mode: DegradedMode
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "allowed": self.allowed,
+            "reason": self.reason,
+            "action": self.action.value,
+            "mode": self.mode.value,
+        }
+
+
+class CapabilityBroker:
+    """發放與消費 capability；維護 in-process single-use nonce ledger。
+
+    Phase 1：nonce ledger 是本實例的記憶體集合（同一 broker 內 single-use）。
+    Phase 2 會把 ledger 移到 R2 OS 邊界內的 Manager-owned 樹以支援跨 process／
+    防重啟重放（見模組 docstring）。
+    """
+
+    def __init__(
+        self,
+        *,
+        clock: Callable[[], float] = time.monotonic,
+        nonce_factory: Callable[[], str] = lambda: secrets.token_hex(16),
+    ) -> None:
+        self._clock = clock
+        self._nonce_factory = nonce_factory
+        self._consumed: set[str] = set()
+
+    def grant(
+        self,
+        binding: CapabilityBinding,
+        *,
+        ttl_seconds: float = DEFAULT_TTL_SECONDS,
+    ) -> Capability:
+        """operator 逐案核可：對指定 binding 鑄造一份短效、一次性 capability。"""
+        return Capability(
+            nonce=self._nonce_factory(),
+            binding=binding,
+            issued_at=self._clock(),
+            ttl_seconds=ttl_seconds,
+        )
+
+    def consume(
+        self,
+        capability: Capability,
+        binding: CapabilityBinding,
+    ) -> AuthorizationDecision:
+        """驗證並消費 capability。成功即作廢該 nonce（single-use）。
+
+        依序檢查：nonce 未曾消費（single-use）→ 未過期（短效）→ binding 完全相符
+        （action-bound）。任一不符即拒絕；**不**因失敗而消費 nonce（避免 DoS 把
+        合法 capability 提前作廢——但相同 nonce 一旦成功消費即永久作廢）。
+        """
+        action = binding.action
+        mode = DegradedMode.PER_CASE_APPROVAL
+        if capability.nonce in self._consumed:
+            return AuthorizationDecision(False, "nonce-already-consumed", action, mode)
+        now = self._clock()
+        if now >= capability.expires_at():
+            return AuthorizationDecision(False, "capability-expired", action, mode)
+        if capability.binding != binding:
+            return AuthorizationDecision(False, "binding-mismatch", action, mode)
+        # 通過：消費 nonce（single-use），放行。
+        self._consumed.add(capability.nonce)
+        return AuthorizationDecision(True, "capability-consumed", action, mode)
+
+    def consumed_count(self) -> int:
+        return len(self._consumed)
+
+
+class DegradedOperationGate:
+    """降級運轉閘：敏感 action 的唯一放行點（fail-closed）。
+
+    - `DISABLED`：一律拒絕（reason=`degraded-operation-disabled`），連 capability
+      也不放行。
+    - `PER_CASE_APPROVAL`：需附一份對本 binding 有效的 capability；`None` 即拒絕
+      （reason=`no-capability`），否則交由 broker consume 判定。
+    """
+
+    def __init__(self, *, mode: DegradedMode, broker: CapabilityBroker) -> None:
+        self._mode = mode
+        self._broker = broker
+
+    @property
+    def mode(self) -> DegradedMode:
+        return self._mode
+
+    def authorize(
+        self,
+        binding: CapabilityBinding,
+        capability: Capability | None,
+    ) -> AuthorizationDecision:
+        action = binding.action
+        if self._mode is DegradedMode.DISABLED:
+            return AuthorizationDecision(
+                False, "degraded-operation-disabled", action, self._mode
+            )
+        # PER_CASE_APPROVAL
+        if capability is None:
+            return AuthorizationDecision(False, "no-capability", action, self._mode)
+        decision = self._broker.consume(capability, binding)
+        # broker 以 PER_CASE_APPROVAL 記 mode；此處已知，直接沿用其 allowed/reason。
+        return AuthorizationDecision(
+            decision.allowed, decision.reason, action, self._mode
+        )
+
+
+def build_gate(
+    *,
+    env: Mapping[str, str] | None = None,
+    broker: CapabilityBroker | None = None,
+) -> DegradedOperationGate:
+    """依環境建構降級閘（供 daemon／敏感 action 呼叫點取用）。"""
+    return DegradedOperationGate(
+        mode=resolve_degraded_mode(env),
+        broker=broker or CapabilityBroker(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# spec §R7 Scenario「capability 不得出現在 durable state」——常設掃描 helper。
+# ---------------------------------------------------------------------------
+
+def find_capability_material(text: str, nonces: list[str]) -> list[str]:
+    """在一段 durable-state 內容中找出任何 capability nonce 的可還原形式。
+
+    回傳命中的 nonce 清單（空＝乾淨）。供常設測試對全部 Tier-0／Tier-1 資產內容
+    掃描時使用；命中即代表 capability 本體外洩到 durable state（R7 違規）。
+    """
+    return [n for n in nonces if n and n in text]

--- a/paulsha_cortex/trust_root/registry.py
+++ b/paulsha_cortex/trust_root/registry.py
@@ -1,0 +1,567 @@
+"""R1：trust-root 資產登記表——單一機器可讀真相。
+
+spec §R1 要求把所有 security-relevant durable state 與 mutation ingress 固化為
+**單一模組常數**（非散落字串），對每項資產宣告
+`asset_id`／`tier`／`path_resolver`／`writers`／`readers`／`ingress_kind`，並以
+機械測試釘住雙向等式：`config/paths.py`、`control/constants.py` 中**每一個回傳
+durable path 的函式** SHALL 在登記表中有對應項目，新增一個 path 函式而未登記即 FAIL。
+
+本登記表同時是 Phase 2 權限產生器的輸入（宣告式：哪些資產屬 Manager-owned 樹、
+哪些屬 job-visible 樹），因此把裁決 10-1／10-2 的兩棵樹分類固化在此：
+
+- **Manager-owned 樹**（`TrustTree.MANAGER_OWNED`）：只有受信任身分（Manager 專屬
+  UID，裁決 10-1）可寫；全部 headless persona 不可寫。
+- **job-visible 樹**（`TrustTree.JOB_VISIBLE`）：對應 headless UID 可在自己的
+  worktree／staging 區寫入，但 reviewer 與 builder 互不可寫（裁決 10-2 硬性要求）。
+
+Phase 1 **不**產生任何實際權限、**不**建 UID、**不** chmod；本模組純為宣告。
+"""
+from __future__ import annotations
+
+import importlib
+import inspect
+from dataclasses import dataclass
+from enum import Enum
+from typing import Callable
+
+
+class AssetTier(Enum):
+    """spec §資產分級 A。"""
+
+    TIER_0 = 0  # authority-bearing：竄改後可直接偽造 acceptance 或取得 ship authority
+    TIER_1 = 1  # integrity-bearing：竄改導致錯誤決策但不直接授權發佈
+    TIER_2 = 2  # advisory：顯示性欄位、文字 marker、宣告式 persona write_paths
+
+
+class TrustTree(Enum):
+    """裁決 10-1／10-2 的兩棵樹。Phase 2 權限產生器以此決定目錄 owner／mode。"""
+
+    MANAGER_OWNED = "manager-owned"  # 僅 Manager 專屬 UID 可寫；全 headless 不可寫
+    JOB_VISIBLE = "job-visible"      # 對應 headless UID 可在自己區域寫；跨 persona 互不可寫
+
+
+class Principal(Enum):
+    """writer／reader 身分。headless persona 三者必須分別可辨（spec §R1）。"""
+
+    MANAGER = "manager"
+    MONITOR = "monitor"
+    INSTALLER = "installer"          # 部署身分（Phase 2 收斂為 root／部署帳號）
+    OPERATOR = "operator"
+    BUILDER = "builder"              # headless
+    REVIEWER = "reviewer"            # headless
+    PLANNER = "planner"              # headless
+    HEADLESS_HOOK = "headless-hook"  # D5 headless 事件 hook（寫 event-spool）
+    EXTERNAL = "external"            # 外送管線／外部學習系統（唯讀）
+    ANY_SAME_UID = "any-same-uid"    # 現況：同 UID 任何行程皆可寫（含全部 headless persona）
+
+
+#: 三個不受信任 headless persona；spec §R1 要求盤點必須分別涵蓋，不能只封 builder。
+HEADLESS_PERSONAS: frozenset[Principal] = frozenset(
+    {Principal.BUILDER, Principal.REVIEWER, Principal.PLANNER}
+)
+
+
+class IngressKind(Enum):
+    """spec §C mutation ingress 盤點的種類。"""
+
+    MANAGER_INTERNAL = "manager-internal"      # 僅 Manager 自身寫入
+    MONITOR_INTERNAL = "monitor-internal"      # 僅 Monitor 自身寫入
+    CONTROL_FILE_QUEUE = "control-file-queue"  # <control_root>/requests/：未認證入口
+    CLI_STATE_PATH = "cli-state-path"          # CLI --state 直指
+    DIRECT_FILE_WRITE = "direct-file-write"    # 任何同 UID 行程直寫
+    ENV_REDIRECT = "env-redirect"              # PSC_* / bootstrap env 重導
+    ENV_NAMED_EXEC = "env-named-exec"          # env 指名並執行任意程式
+    CONFIG_OVERLAY = "config-overlay"          # overlay 覆蓋（model-identity/combo/persona）
+    DEPLOYMENT_WRITE = "deployment-write"      # unit/venv/launcher/sitecustomize/.pth/hooks
+    INTERPROCESS = "interprocess"              # inherited FD / ptrace / /proc / signal / spool
+    STAGING_SPOOL = "staging-spool"            # headless 寫自己 worktree / staging 區
+
+
+@dataclass(frozen=True)
+class TrustRootAsset:
+    """單一 durable state 資產的宣告。"""
+
+    asset_id: str
+    tier: AssetTier
+    tree: TrustTree
+    #: `"module:function"` 形式，指向 `config.paths`／`control.constants` 中回傳
+    #: 該資產路徑的**單一** canonical 函式；若路徑在別的模組以字面量推導（尚未收斂
+    #: 到 path 契約模組），則為 None 並在 `derived_in` 記錄實際推導位置。
+    path_resolver: str | None
+    writers: tuple[Principal, ...]
+    readers: tuple[Principal, ...]
+    ingress_kind: IngressKind
+    #: 現況路徑推導位置（`檔案:行號`），供 Phase 2 收斂與交叉複驗；spec §R1 要求
+    #: 把重複推導收斂到登記表，故一律登記全部已知推導點。
+    derived_in: tuple[str, ...] = ()
+    note: str = ""
+
+    def is_manager_owned(self) -> bool:
+        return self.tree is TrustTree.MANAGER_OWNED
+
+    def headless_writable(self) -> bool:
+        """現況是否有任何 headless persona（或同 UID 任意行程）可寫。
+
+        Phase 2 權限產生器據此決定哪些 Manager-owned 資產必須移出 headless 寫入域。
+        """
+        return any(
+            w is Principal.ANY_SAME_UID or w in HEADLESS_PERSONAS for w in self.writers
+        )
+
+
+# ---------------------------------------------------------------------------
+# 登記表本體。順序：先 config.paths／control.constants 有 resolver 的容器與葉，
+# 再列在別處以字面量推導、path_resolver=None 的 Tier-0／Tier-1 資產。
+# ---------------------------------------------------------------------------
+
+_T0 = AssetTier.TIER_0
+_T1 = AssetTier.TIER_1
+_MO = TrustTree.MANAGER_OWNED
+_JV = TrustTree.JOB_VISIBLE
+
+ASSET_REGISTRY: tuple[TrustRootAsset, ...] = (
+    # ---- resolver-backed 容器樹 --------------------------------------------
+    TrustRootAsset(
+        "runtime-agents-tree", _T0, _MO, "paulsha_cortex.config.paths:agents_root",
+        (Principal.INSTALLER, Principal.MANAGER, Principal.ANY_SAME_UID),
+        (Principal.MANAGER, Principal.MONITOR),
+        IngressKind.ENV_REDIRECT,
+        note="~/.agents 樹根；解析鏈本身即信任根（runtime.py:89），實測 group-writable。",
+    ),
+    TrustRootAsset(
+        "control-root-tree", _T0, _MO, "paulsha_cortex.config.paths:control_root",
+        (Principal.MANAGER, Principal.ANY_SAME_UID),
+        (Principal.MANAGER, Principal.OPERATOR),
+        IngressKind.ENV_REDIRECT,
+        note="control 樹容器；子資產 requests/done/status/lock 各自登記。",
+    ),
+    TrustRootAsset(
+        "coordinator-root-tree", _T0, _MO, "paulsha_cortex.config.paths:coordinator_root",
+        (Principal.MANAGER, Principal.ANY_SAME_UID),
+        (Principal.MANAGER,),
+        IngressKind.ENV_REDIRECT,
+        note="jobs.json／evidence 樹／journal 的容器；實測 drwxrwxr-x（group-writable）。",
+    ),
+    TrustRootAsset(
+        "dispatch-specs-tree", _T0, _MO, "paulsha_cortex.config.paths:specs_root",
+        (Principal.MANAGER, Principal.PLANNER, Principal.ANY_SAME_UID),
+        (Principal.MANAGER,),
+        IngressKind.DIRECT_FILE_WRITE,
+        note="staged dispatch specs；planner 產出的 spec/plan 直接餵給 Compact reuse。",
+    ),
+    TrustRootAsset(
+        "runtime-run-tree", _T0, _MO, "paulsha_cortex.config.paths:run_root",
+        (Principal.MANAGER, Principal.MONITOR),
+        (Principal.MANAGER, Principal.OPERATOR),
+        IngressKind.MANAGER_INTERNAL,
+        note="socket／lock run dir；monitor socket 已 0600、run dir 0700（正面前例）。",
+    ),
+    TrustRootAsset(
+        "project-config-tree", _T0, _MO, "paulsha_cortex.config.paths:project_config_root",
+        (Principal.OPERATOR, Principal.ANY_SAME_UID),
+        (Principal.MANAGER,),
+        IngressKind.CONFIG_OVERLAY,
+        note="model-identities.yaml overlay 所在；overlay 可壓過 packaged registry。",
+    ),
+    TrustRootAsset(
+        "coverage-shadow-telemetry", _T1, _MO,
+        "paulsha_cortex.config.paths:coverage_shadow_telemetry_root",
+        (Principal.MANAGER,), (Principal.MANAGER, Principal.OPERATOR),
+        IngressKind.MANAGER_INTERNAL,
+        note="v4 R1 coverage shadow disagreement telemetry；本票撰寫期間新增的 durable state。",
+    ),
+    # ---- monitor state 族 --------------------------------------------------
+    TrustRootAsset(
+        "monitor-state-tree", _T1, _MO, "paulsha_cortex.config.paths:monitor_state_root",
+        (Principal.MONITOR,), (Principal.MANAGER, Principal.MONITOR),
+        IngressKind.MONITOR_INTERNAL,
+        note="monitor 讀模型與傳輸層狀態的容器。",
+    ),
+    TrustRootAsset(
+        "monitor-work-items-snapshot", _T1, _MO,
+        "paulsha_cortex.config.paths:work_items_snapshot_path",
+        (Principal.MONITOR,), (Principal.MANAGER,),
+        IngressKind.MONITOR_INTERNAL,
+        derived_in=("config/paths.py:56-57", "coordinator/claim.py:225-228"),
+        note="fallback 推導分歧（claim.py 另有一處）；Phase 2 前須收斂為單一 resolver。",
+    ),
+    TrustRootAsset(
+        "monitor-github-sync-cursor", _T1, _MO,
+        "paulsha_cortex.config.paths:github_issue_sync_path",
+        (Principal.MONITOR,), (Principal.MANAGER,),
+        IngressKind.MONITOR_INTERNAL,
+        note="GitHub 增量同步游標／ETag（D3）。",
+    ),
+    TrustRootAsset(
+        "monitor-event-spool", _T1, _JV,
+        "paulsha_cortex.config.paths:monitor_event_spool_root",
+        (Principal.HEADLESS_HOOK, Principal.ANY_SAME_UID), (Principal.MONITOR,),
+        IngressKind.INTERPROCESS,
+        note="D5 headless 事件 hint spool；別的行程寫入、monitor 消費即消失（一次性）。",
+    ),
+    # ---- skill governance 族 -----------------------------------------------
+    TrustRootAsset(
+        "skill-registry-tree", _T1, _MO, "paulsha_cortex.config.paths:skill_registry_root",
+        (Principal.MANAGER, Principal.ANY_SAME_UID), (Principal.MANAGER, Principal.OPERATOR),
+        IngressKind.DIRECT_FILE_WRITE,
+        note="skill ledger／park／proposal 容器；現況寫入皆無 chmod。",
+    ),
+    TrustRootAsset(
+        "skill-usage-ledger", _T1, _MO, "paulsha_cortex.config.paths:skill_usage_ledger_path",
+        (Principal.MANAGER, Principal.ANY_SAME_UID), (Principal.MANAGER, Principal.OPERATOR),
+        IngressKind.DIRECT_FILE_WRITE,
+    ),
+    TrustRootAsset(
+        "skill-park-state", _T1, _MO, "paulsha_cortex.config.paths:skill_park_state_path",
+        (Principal.MANAGER, Principal.ANY_SAME_UID), (Principal.MANAGER, Principal.OPERATOR),
+        IngressKind.DIRECT_FILE_WRITE,
+    ),
+    TrustRootAsset(
+        "skill-park-proposals", _T1, _MO, "paulsha_cortex.config.paths:skill_park_proposals_root",
+        (Principal.MANAGER, Principal.ANY_SAME_UID), (Principal.MANAGER, Principal.OPERATOR),
+        IngressKind.DIRECT_FILE_WRITE,
+    ),
+    # ---- control queue 族（resolver 在 control.constants）--------------------
+    TrustRootAsset(
+        "control-request-queue", _T0, _JV, "paulsha_cortex.control.constants:requests_dir",
+        (Principal.OPERATOR, Principal.ANY_SAME_UID), (Principal.MANAGER,),
+        IngressKind.CONTROL_FILE_QUEUE,
+        derived_in=("control/constants.py:21-26", "manager_daemon.py:1431-1436"),
+        note="全部 7 種 request／22 種 work-action 的入口；未認證，處理順序由 mtime 決定。",
+    ),
+    TrustRootAsset(
+        "control-done-queue", _T0, _MO, "paulsha_cortex.control.constants:done_dir",
+        (Principal.MANAGER,), (Principal.OPERATOR,),
+        IngressKind.MANAGER_INTERNAL,
+    ),
+    TrustRootAsset(
+        "control-status", _T0, _MO, "paulsha_cortex.control.constants:status_path",
+        (Principal.MANAGER,), (Principal.OPERATOR,),
+        IngressKind.MANAGER_INTERNAL,
+    ),
+    TrustRootAsset(
+        "control-daemon-lock", _T0, _MO, "paulsha_cortex.control.constants:lock_path",
+        (Principal.MANAGER,), (Principal.OPERATOR,),
+        IngressKind.MANAGER_INTERNAL,
+        note="lock 檔實測 0o644；owner 可 unlink 後重建。",
+    ),
+    # ---- job-visible worktree 族 -------------------------------------------
+    TrustRootAsset(
+        "repo-worktree", _T1, _JV, "paulsha_cortex.config.paths:repo_root",
+        (Principal.BUILDER,), (Principal.MANAGER,),
+        IngressKind.STAGING_SPOOL,
+        note="builder write_paths:['**']，可寫 worktree 內任何路徑（含 .cortex/.github）。",
+    ),
+    TrustRootAsset(
+        "dispatch-worktree-pool", _T1, _JV, "paulsha_cortex.config.paths:worktree_root",
+        (Principal.BUILDER, Principal.REVIEWER, Principal.PLANNER), (Principal.MANAGER,),
+        IngressKind.STAGING_SPOOL,
+        note="派工 worktree pool；reviewer 與 builder 必須分屬互不可寫域（裁決 10-2）。",
+    ),
+    # ---- path_resolver=None：在別處以字面量推導的 Tier-0／Tier-1 資產 --------
+    TrustRootAsset(
+        "jobs-registry", _T0, _MO, None,
+        (Principal.MANAGER, Principal.ANY_SAME_UID), (Principal.MANAGER,),
+        IngressKind.DIRECT_FILE_WRITE,
+        derived_in=(
+            "coordinator/registry.py:185-186", "coordinator/work_actions.py:4184,5097",
+            "coordinator/manager_daemon.py:1199", "porcelain/request.py:11",
+        ),
+        note="Job/Slice/workflow-run registry；四處建立 registry，monitor/providers.py:264 繞過直讀。",
+    ),
+    TrustRootAsset(
+        "review-verdict", _T0, _JV, None,
+        (Principal.REVIEWER, Principal.ANY_SAME_UID), (Principal.MANAGER,),
+        IngressKind.DIRECT_FILE_WRITE,
+        derived_in=("coordinator/review.py:22-23,176-185",),
+        note="§3 最短攻擊路徑：builder 同 UID 可直接代寫 reviewer 的 .psc-review-verdict.json。",
+    ),
+    TrustRootAsset(
+        "verification-evidence", _T0, _MO, None,
+        (Principal.MANAGER,), (Principal.MANAGER,), IngressKind.MANAGER_INTERNAL,
+        derived_in=("coordinator/verification.py:305-316",),
+    ),
+    TrustRootAsset(
+        "maintainer-attestation", _T0, _MO, None,
+        (Principal.MANAGER, Principal.ANY_SAME_UID), (Principal.MANAGER,),
+        IngressKind.DIRECT_FILE_WRITE,
+        derived_in=("coordinator/work_actions.py:1027-1060",),
+        note="_review_attest_action：誰能寫 queue，誰就能發 maintainer review attestation。",
+    ),
+    TrustRootAsset(
+        "completion-record", _T0, _MO, None,
+        (Principal.MANAGER,), (Principal.MANAGER,), IngressKind.MANAGER_INTERNAL,
+        derived_in=("coordinator/completion.py:74-83",),
+    ),
+    TrustRootAsset(
+        "full-suite-evidence", _T0, _MO, None,
+        (Principal.MANAGER,), (Principal.MANAGER,), IngressKind.MANAGER_INTERNAL,
+        derived_in=("coordinator/preflight.py:68-76",),
+    ),
+    TrustRootAsset(
+        "workflow-inputs", _T0, _MO, None,
+        (Principal.MANAGER,), (Principal.MANAGER,), IngressKind.MANAGER_INTERNAL,
+        derived_in=("coordinator/manager.py:4039",),
+    ),
+    TrustRootAsset(
+        "workflow-evidence", _T0, _MO, None,
+        (Principal.MANAGER,), (Principal.MANAGER,), IngressKind.MANAGER_INTERNAL,
+        derived_in=("coordinator/work_bridge.py:947,514,553-579,605-620,1245,1503",),
+    ),
+    TrustRootAsset(
+        "gate-ledger", _T0, _MO, None,
+        (Principal.MANAGER,), (Principal.MANAGER,), IngressKind.MANAGER_INTERNAL,
+        derived_in=("coordinator/terminal_contract.py:488-494",),
+        note="刻意放在 manager log_dir（模型 cwd 拿不到）——D6 要系統化的正面前例。",
+    ),
+    TrustRootAsset(
+        "delivery-journal", _T0, _MO, None,
+        (Principal.MANAGER, Principal.ANY_SAME_UID), (Principal.MANAGER,),
+        IngressKind.DIRECT_FILE_WRITE,
+        derived_in=(
+            "coordinator/work_actions.py:516-517", "coordinator/work_bridge.py:771,838,1382,1815",
+            "coordinator/manager.py:7289,8290",
+        ),
+        note="六處獨立字面量推導；spec §R1 要求收斂到登記表以免權限產生器有盲點。",
+    ),
+    TrustRootAsset(
+        "provider-backoff", _T1, _MO, None,
+        (Principal.MANAGER,), (Principal.MANAGER,), IngressKind.MANAGER_INTERNAL,
+        derived_in=("coordinator/provider_backoff.py:22,38-39",),
+    ),
+    TrustRootAsset(
+        "workflow-report-journal", _T1, _MO, None,
+        (Principal.MANAGER,), (Principal.MANAGER,), IngressKind.MANAGER_INTERNAL,
+        derived_in=("coordinator/manager.py:4434",),
+    ),
+    TrustRootAsset(
+        "digest-outbox", _T1, _MO, None,
+        (Principal.MANAGER,), (Principal.EXTERNAL,), IngressKind.MANAGER_INTERNAL,
+        derived_in=("coordinator/digest.py:158-161,181-188",),
+        note="外送管線唯讀；發佈類 outbox mutation 屬 R7 敏感 action。",
+    ),
+    TrustRootAsset(
+        "engineering-outcome-outbox", _T1, _MO, None,
+        (Principal.MANAGER,), (Principal.EXTERNAL,), IngressKind.MANAGER_INTERNAL,
+        derived_in=("coordinator/engineering_outcome.py:508-524,451-468",),
+    ),
+    TrustRootAsset(
+        "model-identity-overlay", _T0, _MO, None,
+        (Principal.OPERATOR, Principal.ANY_SAME_UID), (Principal.MANAGER,),
+        IngressKind.CONFIG_OVERLAY,
+        derived_in=("coordinator/model_identities.py:564-565,604-631",),
+        note="independence_domain 的來源；host overlay 可壓過 packaged registry（R5／R8）。",
+    ),
+    TrustRootAsset(
+        "combo-card-override", _T0, _MO, None,
+        (Principal.OPERATOR, Principal.PLANNER, Principal.ANY_SAME_UID), (Principal.MANAGER,),
+        IngressKind.CONFIG_OVERLAY,
+        derived_in=("deck/schema.py:70-87", "deck/compile.py:201-208,740-800"),
+        note="instance-local combo 壓過 packaged；workflow 定義本身即同 UID 可寫 YAML。",
+    ),
+    TrustRootAsset(
+        "handoff-manifest", _T0, _JV, None,
+        (Principal.BUILDER, Principal.REVIEWER, Principal.PLANNER), (Principal.MANAGER,),
+        IngressKind.STAGING_SPOOL,
+        derived_in=("persona/handoff.py:17-20", "coordinator/autonomy.py:23", "coordinator/manager.py:185"),
+        note="裸 write_text、無原子性、無 mode；staging→Manager 收（Phase 2）。",
+    ),
+    TrustRootAsset(
+        "runtime-bootstrap-env", _T0, _MO, None,
+        (Principal.INSTALLER, Principal.ANY_SAME_UID), (Principal.MANAGER, Principal.MONITOR),
+        IngressKind.ENV_REDIRECT,
+        derived_in=("config/runtime.py:61-66", "deploy/installer.py:162"),
+        note="裸寫、無 mode；實測 -rw-rw-r--。改此檔的 PSC_* 即重導整棵 durable state。",
+    ),
+    TrustRootAsset(
+        "codex-hooks", _T0, _MO, None,
+        (Principal.INSTALLER, Principal.ANY_SAME_UID), (Principal.MANAGER,),
+        IngressKind.DEPLOYMENT_WRITE,
+        derived_in=("deploy/hooks.py:48-60",),
+        note="$HOME/.codex/hooks.json；enforcement plane 的一部分。",
+    ),
+    TrustRootAsset(
+        "work-items-yaml", _T1, _JV, None,
+        (Principal.OPERATOR, Principal.BUILDER, Principal.ANY_SAME_UID), (Principal.MONITOR,),
+        IngressKind.DIRECT_FILE_WRITE,
+        derived_in=("monitor/correlation.py:79-80,463-487",),
+        note="git-tracked correlation authority；builder ['**'] 可寫，即一次 correlation 變更。",
+    ),
+)
+
+
+#: spec §R1 Scenario「重複路徑推導」：同一資產在多處以字面量重複推導，Phase 2 前
+#: 必須收斂。此處把已知的重複點固化為單一真相（key＝canonical asset_id）。
+KNOWN_DUPLICATE_DERIVATIONS: dict[str, tuple[str, ...]] = {
+    "delivery-journal": (
+        "coordinator/work_actions.py:516-517", "coordinator/work_bridge.py:771",
+        "coordinator/work_bridge.py:838", "coordinator/work_bridge.py:1382",
+        "coordinator/work_bridge.py:1815", "coordinator/manager.py:7289",
+        "coordinator/manager.py:8290",
+    ),
+    "jobs-registry": (
+        "coordinator/registry.py:185-186", "coordinator/work_actions.py:4184",
+        "coordinator/work_actions.py:5097", "coordinator/manager_daemon.py:1199",
+        "porcelain/request.py:11",
+    ),
+    "monitor-work-items-snapshot": (
+        "config/paths.py:56-57", "coordinator/claim.py:225-228",
+    ),
+}
+
+
+@dataclass(frozen=True)
+class MutationIngress:
+    """spec §C mutation ingress 盤點的一項。"""
+
+    ingress_id: str
+    kind: IngressKind
+    authenticated: bool          # 現況是否認證 issuer
+    headless_reachable: bool     # headless persona 是否結構性可達
+    note: str = ""
+
+
+MUTATION_INGRESS: tuple[MutationIngress, ...] = (
+    MutationIngress("control-file-queue", IngressKind.CONTROL_FILE_QUEUE, False, True,
+                    "唯一門檻是能否在該目錄建檔；處理順序由 mtime 決定。"),
+    MutationIngress("cli-state-path", IngressKind.CLI_STATE_PATH, False, True,
+                    "work_actions.py:4184,5097 接受 --state。"),
+    MutationIngress("direct-file-write", IngressKind.DIRECT_FILE_WRITE, False, True,
+                    "任何同 UID 行程直寫 durable state 檔。"),
+    MutationIngress("env-redirect", IngressKind.ENV_REDIRECT, False, True,
+                    "PSC_* / bootstrap env 重導（runtime.py:98-134）。"),
+    MutationIngress("env-named-exec", IngressKind.ENV_NAMED_EXEC, False, True,
+                    "PSC_MANAGER_INSTALLER／PSC_REPLY_BRIDGE／PSC_DIGEST_DELIVERY_CMD 無 typed-argv 守衛。"),
+    MutationIngress("config-overlay", IngressKind.CONFIG_OVERLAY, False, True,
+                    "model-identity／combo／persona tool_allowlist_additions（只加不減、無上限）。"),
+    MutationIngress("deployment-write", IngressKind.DEPLOYMENT_WRITE, False, True,
+                    "unit／venv／launcher／sitecustomize／.pth／PATH／~/.codex/hooks.json。"),
+    MutationIngress("interprocess", IngressKind.INTERPROCESS, False, True,
+                    "inherited FD／ptrace／/proc/<pid>/mem／signal。"),
+)
+
+
+# ---------------------------------------------------------------------------
+# 雙向等式（spec §R1）——供 CI 機械測試。
+# ---------------------------------------------------------------------------
+
+#: config.paths／control.constants 中回傳 Path 但**不是** trust-root durable-state
+#: 資產的函式；每項附理由。新增到此清單等同「明示豁免」，仍在 review 視野內。
+ACKNOWLEDGED_NON_ASSET_PATHS: dict[str, str] = {
+    "paulsha_cortex.config.paths:config_path": "helper（接受 *parts），非單一資產。",
+    "paulsha_cortex.config.paths:worktree_root_for": "helper（接受 repo 參數），由 worktree_root 登記。",
+    "paulsha_cortex.config.paths:config_root": "~/.config/paulshaclaw app 設定根，非治理 durable-state 資產。",
+    "paulsha_cortex.control.constants:control_root": "委派給 config.paths.control_root；由 control-root-tree 登記。",
+}
+
+_PATH_FUNCTION_MODULES: tuple[str, ...] = (
+    "paulsha_cortex.config.paths",
+    "paulsha_cortex.control.constants",
+)
+
+
+def discover_path_functions() -> dict[str, Callable[..., object]]:
+    """反射列舉 config.paths／control.constants 中每一個回傳 `Path` 的公開函式。
+
+    回傳 `"module:function" -> callable`。這是 spec §R1 雙向等式的 LHS。
+    """
+    found: dict[str, Callable[..., object]] = {}
+    for modname in _PATH_FUNCTION_MODULES:
+        mod = importlib.import_module(modname)
+        for name, obj in vars(mod).items():
+            if name.startswith("_") or not inspect.isfunction(obj):
+                continue
+            if obj.__module__ != modname:
+                continue
+            # `from __future__ import annotations` → return annotation 為字串。
+            if obj.__annotations__.get("return") != "Path":
+                continue
+            found[f"{modname}:{name}"] = obj
+    return found
+
+
+def registered_path_resolvers() -> set[str]:
+    """登記表 RHS：所有 asset 宣告的非 None path_resolver。"""
+    return {a.path_resolver for a in ASSET_REGISTRY if a.path_resolver is not None}
+
+
+@dataclass(frozen=True)
+class EquationResult:
+    """雙向等式檢查結果。`ok` 為 True 表示登記表與 path 契約完全對齊。"""
+
+    ok: bool
+    unregistered_functions: tuple[str, ...]   # path fn 存在但未登記且未豁免 → Scenario 1 FAIL
+    dangling_resolvers: tuple[str, ...]        # asset 指向不存在的 path fn
+    stale_acknowledgements: tuple[str, ...]    # 豁免清單指向已不存在的 path fn
+
+    def failure_summary(self) -> str:
+        parts: list[str] = []
+        if self.unregistered_functions:
+            parts.append("未登記的 path 函式: " + ", ".join(self.unregistered_functions))
+        if self.dangling_resolvers:
+            parts.append("指向不存在函式的 resolver: " + ", ".join(self.dangling_resolvers))
+        if self.stale_acknowledgements:
+            parts.append("已失效的豁免項: " + ", ".join(self.stale_acknowledgements))
+        return "; ".join(parts)
+
+
+def check_registry_equation() -> EquationResult:
+    """spec §R1：釘住 path 契約 ⟷ 登記表的雙向等式。
+
+    - **Scenario 1**（新增 durable path 未登記）：某 path fn 既非 resolver 也未在
+      `ACKNOWLEDGED_NON_ASSET_PATHS` → `unregistered_functions` 非空、FAIL 並指名。
+    - resolver 指向不存在的 path fn → `dangling_resolvers`（打錯字／函式被刪）。
+    - 豁免清單指向已不存在的 fn → `stale_acknowledgements`（清單過期）。
+    """
+    discovered = set(discover_path_functions().keys())
+    resolvers = registered_path_resolvers()
+    acknowledged = set(ACKNOWLEDGED_NON_ASSET_PATHS.keys())
+
+    accounted = resolvers | acknowledged
+    unregistered = tuple(sorted(discovered - accounted))
+    dangling = tuple(sorted(resolvers - discovered))
+    stale = tuple(sorted(acknowledged - discovered))
+    return EquationResult(
+        ok=not (unregistered or dangling or stale),
+        unregistered_functions=unregistered,
+        dangling_resolvers=dangling,
+        stale_acknowledgements=stale,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 便利查詢（Phase 2 權限產生器與 R3 自檢共用）。
+# ---------------------------------------------------------------------------
+
+def asset_by_id(asset_id: str) -> TrustRootAsset:
+    for a in ASSET_REGISTRY:
+        if a.asset_id == asset_id:
+            return a
+    raise KeyError(asset_id)
+
+
+def manager_owned_assets() -> tuple[TrustRootAsset, ...]:
+    return tuple(a for a in ASSET_REGISTRY if a.is_manager_owned())
+
+
+def job_visible_assets() -> tuple[TrustRootAsset, ...]:
+    return tuple(a for a in ASSET_REGISTRY if a.tree is TrustTree.JOB_VISIBLE)
+
+
+def assets_by_tier(tier: AssetTier) -> tuple[TrustRootAsset, ...]:
+    return tuple(a for a in ASSET_REGISTRY if a.tier is tier)
+
+
+def headless_writable_manager_owned() -> tuple[TrustRootAsset, ...]:
+    """Manager-owned 但現況 headless 可寫的資產——Phase 2 必須收斂的核心清單。"""
+    return tuple(a for a in manager_owned_assets() if a.headless_writable())
+
+
+def personas_covered() -> frozenset[Principal]:
+    """登記表 writer 面實際涵蓋到的 headless persona（spec §R1 要求三者都在）。"""
+    covered: set[Principal] = set()
+    for a in ASSET_REGISTRY:
+        for w in a.writers:
+            if w in HEADLESS_PERSONAS:
+                covered.add(w)
+    return frozenset(covered)

--- a/paulsha_cortex/trust_root/selfcheck.py
+++ b/paulsha_cortex/trust_root/selfcheck.py
@@ -1,0 +1,224 @@
+"""R3：Manager 啟動自檢（Phase 1 只 WARN）。
+
+spec §R3 要求 Manager 啟動自檢驗證 enforcement plane 對 headless 不可寫。Phase 1
+（不需 root）只實作**可先行部分**（spec §R10 Phase 1 第 5 條）：用 R1 登記表對照
+**現行部署實況**，輸出結構化診斷——哪些該 Manager-owned 的路徑現在其實 headless
+可寫。Phase 1 **只 WARN、不 fail-closed**（fail-closed 是 Phase 2 R3 切換）。
+
+「headless 可寫」在 Phase 1（同 UID、尚無獨立 headless UID）以**檔案 mode 的
+group／other 寫入位**近似：裁決 10-1／10-2 下 Phase 2 會把 headless job 降權到與
+Manager 不同的 UID 但**同一個 group**（或無交集），因此一個 Manager-owned 目錄若
+帶 `g+w`／`o+w`，在 Phase 2 的 shared-group 佈局下即等於 headless 可寫。這個近似
+**足以反證 spec 背景段的盤點**（實測 control／coordinator／core／specs 為
+`drwxrwxr-x`、bootstrap env 為 `-rw-rw-r--`）——這正是本自檢的驗收依據。
+
+自檢是唯讀觀測，**永不改動任何檔案**、永不 raise（fire-and-forget）。
+"""
+from __future__ import annotations
+
+import os
+import pwd
+import stat as stat_module
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Callable
+
+from . import registry
+from .registry import TrustRootAsset, TrustTree
+
+GROUP_WRITE = 0o020
+OTHER_WRITE = 0o002
+
+
+class FindingStatus(Enum):
+    OK = "ok"                      # Manager-owned 且無 group/other 寫入位
+    JOB_WRITABLE = "job-writable"  # Manager-owned 但 group/other 可寫 → Phase 2 須收斂
+    MISSING = "missing"            # 路徑尚未存在（未部署／未初始化）
+    UNRESOLVED = "unresolved"      # path_resolver=None 或解析失敗，本階段無法就地檢查
+    NOT_APPLICABLE = "n/a"         # job-visible 樹：本來就允許對應 headless 寫入
+
+
+@dataclass(frozen=True)
+class PathObservation:
+    exists: bool
+    is_symlink: bool
+    mode: int          # st_mode & 0o777
+    owner: str
+    group: str
+    group_writable: bool
+    other_writable: bool
+
+
+@dataclass(frozen=True)
+class Finding:
+    asset_id: str
+    tier: str
+    tree: str
+    status: FindingStatus
+    path: str          # 已遮蔽 $HOME 的展示字串
+    detail: str
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "asset_id": self.asset_id,
+            "tier": self.tier,
+            "tree": self.tree,
+            "status": self.status.value,
+            "path": self.path,
+            "detail": self.detail,
+        }
+
+
+@dataclass(frozen=True)
+class SelfCheckReport:
+    findings: tuple[Finding, ...]
+    #: Phase 1 只 WARN——本旗標永遠為 True 表示「即使有 job-writable 也不阻擋啟動」。
+    warn_only: bool = True
+
+    @property
+    def job_writable(self) -> tuple[Finding, ...]:
+        return tuple(f for f in self.findings if f.status is FindingStatus.JOB_WRITABLE)
+
+    @property
+    def ok(self) -> bool:
+        """無任何 job-writable 的 Manager-owned 資產。Phase 1 不用它 gate，只供觀測。"""
+        return not self.job_writable
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "check": "trust-root-selfcheck",
+            "phase": 1,
+            "enforcement": "warn-only",
+            "ok": self.ok,
+            "job_writable_count": len(self.job_writable),
+            "findings": [f.to_dict() for f in self.findings],
+        }
+
+    def warning_lines(self) -> tuple[str, ...]:
+        """人可讀的 WARN 行（每個 job-writable finding 一行）。"""
+        lines: list[str] = []
+        for f in self.job_writable:
+            lines.append(
+                f"trust-root WARN [{f.tier}] {f.asset_id}: {f.path} → {f.detail} "
+                f"(Phase 1 僅告警；Phase 2 OS 邊界會強制收斂)"
+            )
+        return tuple(lines)
+
+
+def _mask_home(path: Path, home: Path) -> str:
+    try:
+        rel = path.relative_to(home)
+        return str(Path("$HOME") / rel)
+    except ValueError:
+        return str(path)
+
+
+def observe_path(path: Path) -> PathObservation:
+    """唯讀 stat 一個路徑（不跟隨 symlink 判斷 owner／mode）。"""
+    st = os.lstat(path)  # raises if missing; caller guards
+    is_link = stat_module.S_ISLNK(st.st_mode)
+    mode = st.st_mode & 0o777
+    try:
+        owner = pwd.getpwuid(st.st_uid).pw_name
+    except (KeyError, OSError):
+        owner = str(st.st_uid)
+    try:
+        import grp
+
+        group = grp.getgrgid(st.st_gid).gr_name
+    except (KeyError, OSError, ImportError):
+        group = str(st.st_gid)
+    return PathObservation(
+        exists=True,
+        is_symlink=is_link,
+        mode=mode,
+        owner=owner,
+        group=group,
+        group_writable=bool(mode & GROUP_WRITE),
+        other_writable=bool(mode & OTHER_WRITE),
+    )
+
+
+def _resolve_asset_path(asset: TrustRootAsset) -> Path | None:
+    """呼叫 asset 的 canonical path_resolver 取得實際路徑。resolver=None → None。"""
+    if asset.path_resolver is None:
+        return None
+    modname, _, funcname = asset.path_resolver.partition(":")
+    try:
+        import importlib
+
+        mod = importlib.import_module(modname)
+        func = getattr(mod, funcname)
+        result = func()
+    except Exception:  # noqa: BLE001 — 唯讀自檢永不 raise
+        return None
+    return result if isinstance(result, Path) else None
+
+
+def _evaluate(asset: TrustRootAsset, home: Path) -> Finding:
+    tier = asset.tier.name
+    tree = asset.tree.value
+    path = _resolve_asset_path(asset)
+    if path is None:
+        return Finding(
+            asset.asset_id, tier, tree, FindingStatus.UNRESOLVED,
+            asset.path_resolver or "(derived elsewhere)",
+            "path_resolver=None 或解析失敗；就地 mode 檢查留待路徑收斂／Phase 2。",
+        )
+    shown = _mask_home(path, home)
+    try:
+        obs = observe_path(path)
+    except (FileNotFoundError, OSError):
+        return Finding(asset.asset_id, tier, tree, FindingStatus.MISSING, shown,
+                       "路徑尚未存在（未部署／未初始化）。")
+
+    if asset.tree is TrustTree.JOB_VISIBLE:
+        # job-visible 樹本來就允許對應 headless 寫入；group/other 寫入非缺陷。
+        return Finding(asset.asset_id, tier, tree, FindingStatus.NOT_APPLICABLE, shown,
+                       f"job-visible（{'g+w ' if obs.group_writable else ''}"
+                       f"{'o+w ' if obs.other_writable else ''}mode={oct(obs.mode)}）。")
+
+    # Manager-owned 樹：group／other 寫入位即 Phase 2 shared-group 下的 headless 可寫。
+    if obs.group_writable or obs.other_writable:
+        bits = []
+        if obs.group_writable:
+            bits.append("g+w")
+        if obs.other_writable:
+            bits.append("o+w")
+        return Finding(
+            asset.asset_id, tier, tree, FindingStatus.JOB_WRITABLE, shown,
+            f"Manager-owned 但 {'/'.join(bits)}（mode={oct(obs.mode)} "
+            f"owner={obs.owner} group={obs.group}）。",
+        )
+    return Finding(asset.asset_id, tier, tree, FindingStatus.OK, shown,
+                   f"mode={oct(obs.mode)} owner={obs.owner}。")
+
+
+def run_self_check(*, home: Path | None = None) -> SelfCheckReport:
+    """對登記表全部資產跑一次唯讀自檢，回傳結構化報告（Phase 1 WARN-only）。"""
+    resolved_home = (home or Path.home()).expanduser()
+    findings = tuple(_evaluate(asset, resolved_home) for asset in registry.ASSET_REGISTRY)
+    return SelfCheckReport(findings=findings)
+
+
+def emit_startup_warnings(
+    *,
+    emit: Callable[[str], None],
+    home: Path | None = None,
+) -> SelfCheckReport:
+    """Manager 啟動時呼叫：跑自檢並把每個 job-writable finding 以 WARN 送出。
+
+    `emit` 由呼叫端提供（daemon 傳入寫 stderr 的 callable）。**永不 raise**——
+    自檢失敗不得阻擋 daemon 啟動（Phase 1 WARN-only 語意）。回傳報告供測試斷言。
+    """
+    try:
+        report = run_self_check(home=home)
+    except Exception:  # noqa: BLE001
+        return SelfCheckReport(findings=())
+    for line in report.warning_lines():
+        try:
+            emit(line)
+        except Exception:  # noqa: BLE001
+            pass
+    return report

--- a/tests/test_trust_root_capability_r7.py
+++ b/tests/test_trust_root_capability_r7.py
@@ -1,0 +1,199 @@
+"""R7（trust-root Phase 1）：capability 通道 + 降級運轉開關。
+
+驗收：
+- 敏感 action 在無 capability 時 100% 被拒（單元測試）。
+- 降級運轉開關行為（逐案核可放行、無核可拒絕、完全停用一律拒絕）。
+- capability action-bound／single-use／短效／不可經 durable state 重放。
+"""
+from __future__ import annotations
+
+import pytest
+
+from paulsha_cortex.trust_root import capability
+from paulsha_cortex.trust_root.capability import (
+    Capability,
+    CapabilityBinding,
+    CapabilityBroker,
+    DEGRADED_MODE_ENV,
+    DegradedMode,
+    DegradedOperationGate,
+    SensitiveAction,
+    build_gate,
+    find_capability_material,
+    resolve_degraded_mode,
+)
+
+
+def _binding(action: SensitiveAction, work_id: str = "W1", run_id: str = "R1") -> CapabilityBinding:
+    return CapabilityBinding(
+        action=action,
+        work_id=work_id,
+        run_id=run_id,
+        subject_hash="sha256:deadbeef",
+        authority_revision="auth-rev-1",
+    )
+
+
+class _FakeClock:
+    def __init__(self) -> None:
+        self.now = 1000.0
+
+    def __call__(self) -> float:
+        return self.now
+
+
+# --- 無 capability 一律被拒（100%）-----------------------------------------
+
+@pytest.mark.parametrize("action", list(SensitiveAction))
+def test_no_capability_denied_for_every_action(action: SensitiveAction) -> None:
+    gate = DegradedOperationGate(
+        mode=DegradedMode.PER_CASE_APPROVAL, broker=CapabilityBroker()
+    )
+    decision = gate.authorize(_binding(action), capability=None)
+    assert decision.allowed is False
+    assert decision.reason == "no-capability"
+    assert decision.action is action
+
+
+@pytest.mark.parametrize("action", list(SensitiveAction))
+def test_disabled_mode_denies_even_with_valid_capability(action: SensitiveAction) -> None:
+    broker = CapabilityBroker()
+    binding = _binding(action)
+    cap = broker.grant(binding)
+    gate = DegradedOperationGate(mode=DegradedMode.DISABLED, broker=broker)
+    decision = gate.authorize(binding, capability=cap)
+    assert decision.allowed is False
+    assert decision.reason == "degraded-operation-disabled"
+    # 完全停用不得消費 capability（未放行）。
+    assert broker.consumed_count() == 0
+
+
+# --- 逐案核可放行 -----------------------------------------------------------
+
+def test_per_case_approval_allows_with_valid_capability() -> None:
+    clock = _FakeClock()
+    broker = CapabilityBroker(clock=clock)
+    binding = _binding(SensitiveAction.SHIP)
+    cap = broker.grant(binding)
+    gate = DegradedOperationGate(mode=DegradedMode.PER_CASE_APPROVAL, broker=broker)
+    decision = gate.authorize(binding, capability=cap)
+    assert decision.allowed is True
+    assert decision.reason == "capability-consumed"
+    assert decision.mode is DegradedMode.PER_CASE_APPROVAL
+
+
+# --- single-use：重放被拒 ---------------------------------------------------
+
+def test_single_use_replay_denied() -> None:
+    broker = CapabilityBroker()
+    binding = _binding(SensitiveAction.OUTBOX_MUTATION)
+    cap = broker.grant(binding)
+    gate = DegradedOperationGate(mode=DegradedMode.PER_CASE_APPROVAL, broker=broker)
+
+    first = gate.authorize(binding, capability=cap)
+    assert first.allowed is True
+
+    replay = gate.authorize(binding, capability=cap)
+    assert replay.allowed is False
+    assert replay.reason == "nonce-already-consumed"
+
+
+# --- action-bound：跨 action 轉用被拒 --------------------------------------
+
+def test_action_bound_cross_action_denied() -> None:
+    """一次核可 outbox-mutation 不得轉用去 ship（binding 不符）。"""
+    broker = CapabilityBroker()
+    granted_binding = _binding(SensitiveAction.OUTBOX_MUTATION)
+    cap = broker.grant(granted_binding)
+    gate = DegradedOperationGate(mode=DegradedMode.PER_CASE_APPROVAL, broker=broker)
+
+    target_binding = _binding(SensitiveAction.SHIP)
+    decision = gate.authorize(target_binding, capability=cap)
+    assert decision.allowed is False
+    assert decision.reason == "binding-mismatch"
+
+
+def test_action_bound_revision_mismatch_denied() -> None:
+    broker = CapabilityBroker()
+    binding = _binding(SensitiveAction.SHIP)
+    cap = broker.grant(binding)
+    gate = DegradedOperationGate(mode=DegradedMode.PER_CASE_APPROVAL, broker=broker)
+
+    stale = CapabilityBinding(
+        action=binding.action,
+        work_id=binding.work_id,
+        run_id=binding.run_id,
+        subject_hash=binding.subject_hash,
+        authority_revision="auth-rev-2",  # authority_revision 前進了
+    )
+    decision = gate.authorize(stale, capability=cap)
+    assert decision.allowed is False
+    assert decision.reason == "binding-mismatch"
+
+
+# --- 短效：逾時被拒 ---------------------------------------------------------
+
+def test_expired_capability_denied() -> None:
+    clock = _FakeClock()
+    broker = CapabilityBroker(clock=clock)
+    binding = _binding(SensitiveAction.MERGE)
+    cap = broker.grant(binding, ttl_seconds=60.0)
+    gate = DegradedOperationGate(mode=DegradedMode.PER_CASE_APPROVAL, broker=broker)
+
+    clock.now += 61.0  # 逾 TTL
+    decision = gate.authorize(binding, capability=cap)
+    assert decision.allowed is False
+    assert decision.reason == "capability-expired"
+
+
+# --- 不可經 durable state 重放：capability 本體不得落地 ---------------------
+
+def test_capability_material_absent_from_durable_state() -> None:
+    broker = CapabilityBroker()
+    cap = broker.grant(_binding(SensitiveAction.SHIP))
+    # 模擬 durable state 內容（jobs.json / journal / done 結果的公開投影）。
+    public = cap.to_public_dict()
+    serialized = repr(public) + str(cap)
+    assert cap.nonce not in serialized
+    assert find_capability_material(serialized, [cap.nonce]) == []
+
+
+def test_public_dict_and_str_never_leak_nonce() -> None:
+    cap = CapabilityBroker().grant(_binding(SensitiveAction.SHIP))
+    assert cap.nonce not in str(cap)
+    assert cap.nonce not in repr(cap)
+    assert "nonce" not in cap.to_public_dict()
+
+
+def test_find_capability_material_detects_leak() -> None:
+    cap = CapabilityBroker().grant(_binding(SensitiveAction.SHIP))
+    leaked = f'{{"note": "{cap.nonce}"}}'  # 若 nonce 不慎寫進 durable state
+    assert find_capability_material(leaked, [cap.nonce]) == [cap.nonce]
+
+
+# --- 降級開關解析（裁決 10-5：預設逐案核可）--------------------------------
+
+def test_default_mode_is_per_case_approval() -> None:
+    assert resolve_degraded_mode({}) is DegradedMode.PER_CASE_APPROVAL
+
+
+def test_disabled_mode_from_env() -> None:
+    assert resolve_degraded_mode({DEGRADED_MODE_ENV: "disabled"}) is DegradedMode.DISABLED
+
+
+def test_unknown_mode_falls_back_to_per_case_approval() -> None:
+    """無法辨識的值回退到最保守可用預設，而非靜默放行。"""
+    assert resolve_degraded_mode({DEGRADED_MODE_ENV: "wide-open"}) is DegradedMode.PER_CASE_APPROVAL
+
+
+def test_build_gate_wires_env_mode() -> None:
+    gate = build_gate(env={DEGRADED_MODE_ENV: "disabled"})
+    assert gate.mode is DegradedMode.DISABLED
+    gate2 = build_gate(env={})
+    assert gate2.mode is DegradedMode.PER_CASE_APPROVAL
+
+
+def test_sensitive_action_closed_list() -> None:
+    """封閉清單：涵蓋 headless acceptance／outbox mutation／ship／merge。"""
+    values = {a.value for a in SensitiveAction}
+    assert values == {"headless-acceptance", "outbox-mutation", "ship", "merge"}

--- a/tests/test_trust_root_registry_r1.py
+++ b/tests/test_trust_root_registry_r1.py
@@ -1,0 +1,150 @@
+"""R1（trust-root Phase 1）：登記表雙向等式與分類完整性。
+
+驗收：登記表等式測試綠——每個 durable path 函式都被分類（無遺漏）、每個 resolver
+都對應到實際函式（無矛盾），且新增未登記的 path 函式即 FAIL 並指名。
+"""
+from __future__ import annotations
+
+import dataclasses
+from pathlib import Path  # noqa: F401 — 供假函式的 return annotation 字串比對
+
+import pytest
+
+from paulsha_cortex.config import paths
+from paulsha_cortex.trust_root import registry
+from paulsha_cortex.trust_root.registry import (
+    ASSET_REGISTRY,
+    AssetTier,
+    HEADLESS_PERSONAS,
+    KNOWN_DUPLICATE_DERIVATIONS,
+    Principal,
+    TrustTree,
+    check_registry_equation,
+    discover_path_functions,
+)
+
+
+def test_equation_holds_on_current_tree() -> None:
+    """spec §R1 雙向等式：現況登記表與 path 契約完全對齊。"""
+    result = check_registry_equation()
+    assert result.ok, result.failure_summary()
+    assert result.unregistered_functions == ()
+    assert result.dangling_resolvers == ()
+    assert result.stale_acknowledgements == ()
+
+
+def test_every_path_function_is_accounted_for() -> None:
+    """每個回傳 Path 的公開函式都被登記或明示豁免（無遺漏）。"""
+    discovered = set(discover_path_functions())
+    accounted = registry.registered_path_resolvers() | set(
+        registry.ACKNOWLEDGED_NON_ASSET_PATHS
+    )
+    assert discovered <= accounted, discovered - accounted
+
+
+def test_scenario_new_unregistered_path_function_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Scenario：新增一個回傳 durable 路徑的函式但未登記 → 等式測試 FAIL 並指名。"""
+
+    def brand_new_durable_root() -> "Path":  # noqa: F821
+        return Path("/tmp/brand-new")
+
+    # 讓反射認得它屬 config.paths 且回傳 Path。
+    brand_new_durable_root.__module__ = "paulsha_cortex.config.paths"
+    brand_new_durable_root.__annotations__ = {"return": "Path"}
+    monkeypatch.setattr(paths, "brand_new_durable_root", brand_new_durable_root, raising=False)
+
+    result = check_registry_equation()
+    assert not result.ok
+    assert "paulsha_cortex.config.paths:brand_new_durable_root" in result.unregistered_functions
+    assert "brand_new_durable_root" in result.failure_summary()
+
+
+def test_dangling_resolver_detected(monkeypatch: pytest.MonkeyPatch) -> None:
+    """resolver 指向不存在的函式（打錯字／函式被刪）→ FAIL。"""
+    bad = dataclasses.replace(
+        ASSET_REGISTRY[0], path_resolver="paulsha_cortex.config.paths:nope"
+    )
+    patched = (bad,) + tuple(ASSET_REGISTRY[1:])
+    monkeypatch.setattr(registry, "ASSET_REGISTRY", patched)
+    result = check_registry_equation()
+    assert not result.ok
+    assert "paulsha_cortex.config.paths:nope" in result.dangling_resolvers
+
+
+def test_asset_ids_unique() -> None:
+    ids = [a.asset_id for a in ASSET_REGISTRY]
+    assert len(ids) == len(set(ids)), "asset_id 必須唯一（無矛盾）"
+
+
+def test_every_asset_fully_classified() -> None:
+    """每個資產都有 tier ∈ enum、tree ∈ enum、至少一個 writer/reader、ingress_kind。"""
+    for a in ASSET_REGISTRY:
+        assert isinstance(a.tier, AssetTier)
+        assert isinstance(a.tree, TrustTree)
+        assert a.writers, a.asset_id
+        assert a.readers, a.asset_id
+        assert a.ingress_kind is not None, a.asset_id
+
+
+def test_all_three_headless_personas_covered() -> None:
+    """spec §R1：盤點必須涵蓋 builder／reviewer／planner 三者，不能只封 builder。"""
+    assert registry.personas_covered() == HEADLESS_PERSONAS
+
+
+def test_review_verdict_is_shortest_attack_path() -> None:
+    """§3 最短攻擊路徑：review-verdict 為 job-visible 且 reviewer/同UID 可寫。"""
+    verdict = registry.asset_by_id("review-verdict")
+    assert verdict.tree is TrustTree.JOB_VISIBLE
+    assert Principal.ANY_SAME_UID in verdict.writers
+    assert verdict.tier is AssetTier.TIER_0
+
+
+def test_headless_writable_manager_owned_flags_the_drift() -> None:
+    """Manager-owned 但 headless 可寫的資產清單非空——這正是 Phase 2 要收斂的核心。"""
+    flagged = {a.asset_id for a in registry.headless_writable_manager_owned()}
+    # 背景段點名的幾項必在其中。
+    for expected in {
+        "runtime-agents-tree",
+        "coordinator-root-tree",
+        "jobs-registry",
+        "delivery-journal",
+        "runtime-bootstrap-env",
+        "model-identity-overlay",
+    }:
+        assert expected in flagged, expected
+
+
+def test_known_duplicate_derivations_are_registered_single_source() -> None:
+    """spec §R1 Scenario「重複路徑推導」：已知重複點固化為單一 canonical asset。"""
+    for asset_id, sites in KNOWN_DUPLICATE_DERIVATIONS.items():
+        asset = registry.asset_by_id(asset_id)  # 單一 asset_id → 單一真相
+        assert len(sites) >= 2, "重複推導清單至少兩處"
+        # 該資產自身的 derived_in 也必須記錄這些推導點（收斂到登記表）。
+        for site in sites:
+            assert any(site.split(":")[0] in d for d in asset.derived_in), (asset_id, site)
+
+
+def test_mutation_ingress_inventory_complete() -> None:
+    """spec §C：八類 mutation ingress 全數登記，且現況全部未認證、headless 可達。"""
+    assert len(registry.MUTATION_INGRESS) == 8
+    for ingress in registry.MUTATION_INGRESS:
+        assert ingress.authenticated is False
+        assert ingress.headless_reachable is True
+
+
+def test_tier0_assets_present() -> None:
+    """Tier-0 資產至少涵蓋 spec §A 點名的 authority-bearing 清單核心。"""
+    tier0_ids = {a.asset_id for a in registry.assets_by_tier(AssetTier.TIER_0)}
+    for expected in {
+        "jobs-registry",
+        "review-verdict",
+        "maintainer-attestation",
+        "gate-ledger",
+        "delivery-journal",
+        "control-request-queue",
+        "runtime-bootstrap-env",
+        "model-identity-overlay",
+    }:
+        assert expected in tier0_ids, expected

--- a/tests/test_trust_root_selfcheck_r3.py
+++ b/tests/test_trust_root_selfcheck_r3.py
@@ -1,0 +1,121 @@
+"""R3（trust-root Phase 1）：Manager 啟動自檢，WARN-only。
+
+驗收：自檢在現行部署上輸出的診斷與 spec 背景段盤點一致（反證盤點正確）——本測試
+以一棵刻意複製部署現況（group-writable 的 Manager-owned 目錄）的合成樹驗證自檢能
+把它們正確標為 job-writable，且 job-visible 樹不誤報、缺檔標 MISSING、永不 fail。
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from paulsha_cortex.trust_root import selfcheck
+from paulsha_cortex.trust_root.selfcheck import FindingStatus, run_self_check
+
+
+def _mkdir(path: Path, mode: int) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    os.chmod(path, mode)
+
+
+@pytest.fixture()
+def deployment_tree(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """複製 spec 背景段實測：control/coordinator/specs 為 group-writable。"""
+    agents = tmp_path / "agents"
+    # Manager-owned 樹：coordinator/control/specs group-writable（drwxrwxr-x）。
+    _mkdir(agents / "coordinator", 0o775)
+    _mkdir(agents / "control", 0o775)
+    _mkdir(agents / "specs", 0o775)
+    # monitor 為 drwxr-xr-x（新加、非 group-writable）。
+    _mkdir(agents / "monitor", 0o755)
+    monkeypatch.setenv("PSC_AGENTS_ROOT", str(agents))
+    return tmp_path
+
+
+def _finding(report: selfcheck.SelfCheckReport, asset_id: str):
+    return next(f for f in report.findings if f.asset_id == asset_id)
+
+
+def test_group_writable_manager_owned_flagged_job_writable(deployment_tree: Path) -> None:
+    report = run_self_check(home=deployment_tree)
+    for asset_id in ("coordinator-root-tree", "control-root-tree", "dispatch-specs-tree"):
+        finding = _finding(report, asset_id)
+        assert finding.status is FindingStatus.JOB_WRITABLE, (asset_id, finding.detail)
+        assert "g+w" in finding.detail
+
+
+def test_monitor_tree_not_flagged(deployment_tree: Path) -> None:
+    finding = _finding(run_self_check(home=deployment_tree), "monitor-state-tree")
+    assert finding.status is FindingStatus.OK
+
+
+def test_job_visible_tree_not_reported_as_defect(deployment_tree: Path) -> None:
+    """job-visible 樹即使 group/other 可寫也是 NOT_APPLICABLE，不誤報成缺陷。"""
+    report = run_self_check(home=deployment_tree)
+    for f in report.findings:
+        if f.tree == "job-visible":
+            assert f.status in {
+                FindingStatus.NOT_APPLICABLE,
+                FindingStatus.MISSING,
+                FindingStatus.UNRESOLVED,
+            }
+
+
+def test_missing_path_reported_missing(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("PSC_AGENTS_ROOT", str(tmp_path / "does-not-exist"))
+    report = run_self_check(home=tmp_path)
+    coord = _finding(report, "coordinator-root-tree")
+    assert coord.status is FindingStatus.MISSING
+
+
+def test_report_is_warn_only(deployment_tree: Path) -> None:
+    """Phase 1：即使偵測到 job-writable，warn_only 為 True、不 fail-closed。"""
+    report = run_self_check(home=deployment_tree)
+    assert report.warn_only is True
+    assert report.job_writable  # 有偵測到漂移
+    assert report.ok is False   # ok 只供觀測，不 gate 啟動
+
+
+def test_warning_lines_generated(deployment_tree: Path) -> None:
+    report = run_self_check(home=deployment_tree)
+    lines = report.warning_lines()
+    assert lines
+    assert all("trust-root WARN" in ln and "Phase 2" in ln for ln in lines)
+
+
+def test_home_is_masked_in_findings(deployment_tree: Path) -> None:
+    """診斷路徑遮蔽 $HOME（R-21 tier: shareable：不得吐個人絕對路徑）。"""
+    report = run_self_check(home=deployment_tree)
+    coord = _finding(report, "coordinator-root-tree")
+    assert coord.path.startswith("$HOME")
+    assert str(deployment_tree) not in coord.path
+
+
+def test_emit_startup_warnings_never_raises_and_returns_report(
+    deployment_tree: Path,
+) -> None:
+    captured: list[str] = []
+    report = selfcheck.emit_startup_warnings(
+        emit=captured.append, home=deployment_tree
+    )
+    assert report.job_writable
+    assert captured  # 每個 job-writable 一行
+
+
+def test_emit_startup_warnings_swallows_emit_errors(deployment_tree: Path) -> None:
+    def boom(_line: str) -> None:
+        raise RuntimeError("sink down")
+
+    # 不得傳播——WARN-only 永不阻擋啟動。
+    report = selfcheck.emit_startup_warnings(emit=boom, home=deployment_tree)
+    assert isinstance(report, selfcheck.SelfCheckReport)
+
+
+def test_to_dict_structure(deployment_tree: Path) -> None:
+    payload = run_self_check(home=deployment_tree).to_dict()
+    assert payload["check"] == "trust-root-selfcheck"
+    assert payload["phase"] == 1
+    assert payload["enforcement"] == "warn-only"
+    assert isinstance(payload["findings"], list)


### PR DESCRIPTION
## 這是什麼

R0.5 D6 trust-root 隔離的 **Phase 1**（純程式碼、不需 root、含降級安全網），依
spec `docs/superpowers/specs/trust-root-isolation-spec.md` 的「落地計畫 Phase 1」
條列與 operator 0816 裁決實作。D6 是 0.2.0 不可豁免的 join gate；本 PR 是它的第一
階段——**不改部署拓撲、不需 root、不動 systemd、不動 `~/.agents/` 執行期狀態**。

### operator 裁決（0816，本 PR 遵循）
- 路線 A（OS/MAC 邊界）為 0.2.0 必要基礎；路線 B（簽章）降 Phase 3，本次不做。
- 受信任身分＝Manager 專屬 UID；headless UID 二分（builder／非 builder，planner 併入
  非 builder；reviewer 與 builder 互不可寫）。
- 舊 state 視為不可信，以 `legacy-import` 重新入帳（不 chown 沿用）。
- 降級運轉預設「逐案核可」（非完全停用），故 R7 capability 通道須支援逐案核可。

## 交付內容

新增 `paulsha_cortex/trust_root/` 子套件：

- **R1 資產登記表**（`registry.py`）：把全部 security-relevant durable state 與
  mutation ingress 固化為**單一機器可讀真相**（`ASSET_REGISTRY` 常數，41 項：25 個
  Tier-0、16 個 Tier-1），對每項宣告
  `asset_id`／`tier`／`tree`（Manager-owned vs job-visible，對應裁決 10-1／10-2）／
  `path_resolver`／`writers`／`readers`／`ingress_kind`，**涵蓋 builder／reviewer／
  planner 三個 headless persona**（不只 builder）。以反射對 `config/paths.py` ＋
  `control/constants.py` 的**每一個回傳 `Path` 的函式**釘住**雙向等式**——新增一個
  path 函式而未登記即 FAIL 並指名（Scenario 1）；resolver 指向不存在的函式亦 FAIL。
  已知重複推導（`delivery-journal` 六處、`jobs-registry` 四處、`work-items.snapshot`
  兩處 fallback 分歧）固化為單一 canonical asset（Scenario 2 收斂基礎）。另登記八類
  mutation ingress（`MUTATION_INGRESS`）。

- **R3 啟動自檢（先以 WARN 上線）**（`selfcheck.py`）：用登記表對照**現行部署實況**，
  把帶 group／other 寫入位的 Manager-owned 路徑標為 `job-writable` 並輸出結構化診斷
  （$HOME 已遮蔽，符合 R-21）。掛在 `manager_daemon.run_loop` 啟動點，受
  `PSC_TRUST_ROOT_SELFCHECK` 閘控、fire-and-forget、**永不 raise**。Phase 1 **只
  WARN、不 fail-closed**（fail-closed 是 Phase 2 R3 切換）。

- **R7 capability 通道 ＋ 降級運轉**（`capability.py`）：敏感 action 封閉清單
  （`headless-acceptance`／`outbox-mutation`／`ship`／`merge`）在無 capability 時
  **100% 被拒**；capability 為 **action-bound**（綁 `(action, work_id, run_id,
  subject_hash, authority_revision)`）＋**single-use**（in-process nonce ledger，
  消費即作廢）＋**短效**（TTL ≤300s）＋**不可經 durable state 重放**（本體不落地，
  `to_public_dict`／`__str__` 皆不吐 nonce，附常設掃描 helper `find_capability_material`）。
  降級運轉開關 `PSC_DEGRADED_OPERATION` **預設 `per-case-approval`**（裁決 10-5），
  提供切到 `disabled`（完全停用）的 config；無法辨識的值回退到最保守可用預設。

- on-demand 診斷入口：`python -m paulsha_cortex.trust_root {selfcheck,registry,equation}`
  （刻意不動 `cortex` CLI，避開 R-16 help 對齊面）。

## Phase 1 提供什麼／不提供什麼（需 Phase 2 OS 邊界才完整的部分）

**Phase 1 提供（本 PR）**：
- 宣告式的 trust-root 資產分類（兩棵樹）＋雙向等式 CI 測試，作為 Phase 2 權限產生器
  的單一輸入真相。
- 啟動自檢的**觀測**：獨立重現 spec 背景段盤點，把現存漂移變成可見診斷（WARN）。
- capability 通道的**契約與 fail-closed 語意**：無 capability 拒絕、action-bound、
  single-use、短效、不落地。
- 降級運轉開關：逐案核可 vs 完全停用。

**Phase 1 不提供（需 Phase 2 的 OS 邊界才完整）**：
- **真正的不可寫強制**：同 UID 下檔案 mode 對 owner 無效；Phase 1 的降級網在同 UID
  下**不是**完整隔離。Phase 2 以獨立 UID／目錄 owner／`0700` 把「不可寫」變成 kernel
  強制。
- **持久／跨 process 的 single-use nonce ledger**：Phase 1 的 nonce ledger 是
  in-process（同一 broker 內 single-use）；防重啟重放與跨 process 去重需把 ledger
  落在 R2 的 OS 保護樹（Phase 2）。
- **capability 通道的 Unix socket OS 隔離**：R7 要求通道為 Manager-owned `0700` 目錄
  下的 socket，使 headless UID 因目錄 traverse 被拒而無法 connect；Phase 1 尚無獨立
  headless UID，故以 in-process broker 表達授權語意，**不**開 socket。
- **自檢 fail-closed**：Phase 1 只 WARN；切 fail-closed 是 Phase 2 R3。
- 不做 **Phase 2**（建 UID／路徑分樹／部署遷移／降權啟動器）與 **Phase 3**（簽章）。

## 驗收（spec 明定，四項）

- ✅ 登記表等式測試綠（`test_trust_root_registry_r1.py`：等式、Scenario 1 指名、
  分類完整、三 persona 覆蓋）。
- ✅ 敏感 action 在無 capability 時 100% 被拒的單元測試（`test_trust_root_capability_r7.py`：
  四個 action × per-case／disabled 全拒）。
- ✅ 自檢在現行部署上的診斷與 spec 背景段盤點一致：實跑 `control`／`coordinator`／
  `specs` 皆 `drwxrwxr-x`（g+w）→ 標 `job-writable`，反證盤點正確
  （`test_trust_root_selfcheck_r3.py` 以合成樹複現同一判定）。
- ✅ 降級運轉開關行為測試：逐案核可放行、無核可拒絕、完全停用一律拒絕、single-use
  重放拒絕、跨 action 轉用拒絕、逾時拒絕。

**自檢在現行部署上的診斷（反證盤點）＋相鄰缺陷**：除 spec §1 點名的
`control`／`coordinator`／`specs` 為 group-writable 外，自檢另揭露兩個**相鄰缺陷**：
(1) `~/.agents/config/paulsha`（存放 `model-identities.yaml` overlay，即
`independence_domain` 來源，Tier-0）同為 `drwxrwxr-x`，對應 spec §6；(2)
`~/.agents/control/done` 亦 group-writable。另 `runtime-bootstrap-env`／`jobs.json`
等以字面量在別處推導（`path_resolver=None`）的資產在自檢中標為 `unresolved`——這是
Phase 1 誠實的覆蓋邊界（就地 mode 檢查待路徑推導收斂與 Phase 2）。

## 測試

- 目標測試：`tests/test_trust_root_{registry_r1,selfcheck_r3,capability_r7}.py` → 43 passed。
- 全套：`python3 -m pytest -q` → 3072 passed（本次連 #565 暫態測試也綠）。

## 範圍紀律

純程式碼、不需 root、不改 systemd、不動 `~/.agents/` 執行期狀態。`manager_daemon` 的
唯一改動是啟動點掛一個 env-gated、fire-and-forget、永不 raise 的 WARN 自檢（比照
既有 coverage shadow 的注入模式）。

Refs #584 #484 #480 #489

## PR checklist
- [x] `changelog.d/d6-trust-root-phase1.md` fragment 已新增且已 commit
- [x] `CHANGELOG.md [Unreleased]` 有對應 entry
- [x] `VERSION` 未變（非 release PR）
- [x] 目標測試與全套測試通過
- [x] 語言 zh-tw