### PR TITLE
feat(trust-root): Phase 2a 權限產生器與 Phase 2b root 設定 runbook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@
 ## [Unreleased]
 
 ### Added
+- **R0.5 D6 / trust-root 隔離 Phase 2a（權限產生器）＋ Phase 2b root 設定 runbook
+  （純程式碼＋文件、不需 root）**——新增 `paulsha_cortex/trust_root/permgen.py`：吃
+  R1 `ASSET_REGISTRY` ＋參數化的 `UidScheme`（persona→OS 帳號映射），機械產生登記表
+  每一項的目標 `owner:group mode` ＋ per-account POSIX ACL，輸出結構化計畫（JSON）與
+  runbook 可引用的 `chown`／`chmod`／`setfacl` **命令字串——只產生字串、絕不執行**。
+  二分（`TWO_WAY_SCHEME`：`cortex-builder`／`cortex-svc`）為預設；同一資料結構表達
+  三分（`THREE_WAY_SCHEME`：把 svc 拆成 `cortex-manager`＋`cortex-reviewer-planner`）
+  **不改一行程式碼**——測試證明三分嚴格收緊（builder 於兩方案皆零寫入 Manager-owned；
+  三分下全部 headless 帳號零寫入）。on-demand 入口
+  `python -m paulsha_cortex.trust_root permissions [two-way|three-way] [--commands]`。
+  另新增 `docs/superpowers/runbooks/trust-root-phase2b-setup.md`（Phase 2b root 設定
+  runbook 草稿，8 段：前置檢查／建 UID／分樹＋legacy-import／Manager 遷 system-level
+  unit＋加固／降權啟動器／升級流程／R9 四族驗收／回滾，逐步標 operator sudo vs 驗證
+  命令，權限命令引用產生器為單一真相，標記 7 個未決點與 WSL2 最高風險步驟）。**本票
+  只交付程式碼與文件**：不建 UID、不 chown、不動 systemd/pipx/`~/.agents`。詳見
+  `changelog.d/p2a-permission-generator.md`。新增 `tests/test_trust_root_permgen_p2a.py`
+  （33 測試）。
 - **R0.5 D6 / trust-root 隔離 Phase 1（純程式碼、不需 root、含降級安全網）**
   ——新增 `paulsha_cortex/trust_root/` 子套件，依 spec `trust-root-isolation-spec.md`
   Phase 1 與 operator 0816 裁決交付 join gate 未達成期間的契約層地基：**R1 資產登記表**

--- a/changelog.d/p2a-permission-generator.md
+++ b/changelog.d/p2a-permission-generator.md
@@ -1,0 +1,45 @@
+---
+type: feat
+scope: trust-root
+---
+**R0.5 D6 / trust-root Phase 2a：權限產生器 + Phase 2b root 設定 runbook（純程式碼＋
+文件，不需 root、不執行任何 root 操作）**
+
+依 spec `trust-root-isolation-spec.md` §R10 Phase 2 第 2 步「目錄 owner／mode 由 R1
+登記表產生（不手寫）」與 operator 0816 裁決（路線 A、Manager 專屬 UID、現階段先二分
+但保留二往三分彈性、Manager 落 system-level unit、舊 state legacy-import、降級逐案
+核可）交付：
+
+- **`paulsha_cortex/trust_root/permgen.py`（權限產生器）**：吃 `ASSET_REGISTRY` ＋一個
+  參數化的 `UidScheme`（persona→OS 帳號映射），機械算出登記表每一項的目標
+  `owner:group mode` ＋ per-account POSIX ACL。輸出 (a) 結構化計畫（可轉 JSON）、
+  (b) 可供 runbook 引用的 `chown`／`chmod`／`setfacl` **命令字串**——**只產生字串，
+  絕不執行**（靜態測試釘住無 `subprocess`／`os.system`／`os.chown`／`os.chmod`）。
+  - **二分／三分參數化保留彈性**：`TWO_WAY_SCHEME`（`cortex-builder` ／
+    `cortex-svc`，後者即 durable state owner，Manager＋reviewer＋planner＋monitor 共用）
+    為預設；同一資料結構表達 `THREE_WAY_SCHEME`（把 `cortex-svc` 拆成
+    `cortex-manager` 與 `cortex-reviewer-planner`）**不改一行程式碼**。測試證明三分
+    嚴格收緊——二分下 reviewer/planner（＝svc）仍可寫 durable state（既知殘餘），
+    三分下**任何 headless 帳號皆零寫入** Manager-owned/deployment。
+  - policy：Manager-owned durable state → owner＝durable_state_owner、base owner-only
+    （dir 0700／file 0600）、跨帳號讀取走精確唯讀 ACL；enforcement plane／樹根 →
+    root 擁有、全部行程唯讀；job-visible 單 writer → 對應 job 帳號、Manager 唯讀
+    ACL；多 persona 容器（worktree pool）→ 容器 Manager-owned、per-job 子目錄由降權
+    啟動器逐案 chown（R2 在子目錄粒度強制）；spool → trusted consumer 擁有、producer
+    僅 ACL 授 write；control queue → 依 R4 收斂為 Manager-owned（提交改走 socket）。
+    group/other 一律無 write 位（收斂現存 g+w）。
+  - `python -m paulsha_cortex.trust_root permissions [two-way|three-way] [--commands]`
+    on-demand 入口。
+- **`docs/superpowers/runbooks/trust-root-phase2b-setup.md`（Phase 2b runbook 草稿）**：
+  8 段——前置檢查/baseline、建 UID（二分）、路徑分樹＋legacy-import（不 chown 舊
+  state）、Manager 遷 root-owned＋system-level unit（含 `NoNewPrivileges`/
+  `ProtectSystem=strict`/`ReadWritePaths`/`ProtectHome`/`CapabilityBoundingSet` 等切實
+  列出的加固指令、`EnvironmentFile` 去 `-` 改 fail-closed）、降權啟動器（關 FD、不傳
+  gh token）、Manager 升級（受控 sudo 替換而非裸 chown）、切換驗收（Phase 1 自檢轉綠
+  ＋R9 四族含 negative control）、回滾。每步標明 operator 手動 sudo vs 驗證命令；權限
+  命令一律引用產生器輸出（單一真相），標記 7 個待 operator 拍板的未決點（降權機制、
+  目標路徑、legacy-import 格式、部署路徑、加固白名單、是否 codify 子命令、R9 完整
+  矩陣）與 WSL2 三個最高風險步驟。
+
+**本票只交付程式碼與文件**：不建 UID、不 chown、不動 systemd/pipx/`~/.agents`。
+新增 `tests/test_trust_root_permgen_p2a.py`（33 測試）。

--- a/docs/superpowers/runbooks/trust-root-phase2b-setup.md
+++ b/docs/superpowers/runbooks/trust-root-phase2b-setup.md
@@ -1,0 +1,527 @@
+---
+status: draft
+work_item: trust-root-isolation
+phase: 2b
+audience: operator
+supersedes: none
+refs:
+  - docs/superpowers/specs/trust-root-isolation-spec.md
+  - paulsha_cortex/trust_root/registry.py
+  - paulsha_cortex/trust_root/permgen.py
+---
+
+# trust-root Phase 2b：root 設定 runbook（草稿，供 operator review）
+
+> **本文件是草稿**，供 operator 逐步 review 後**手動** `sudo` 執行。文件本身
+> **不執行任何 root 操作**；所有特權步驟都由 operator 親自輸入。凡標記
+> **`⚠️ 未決`** 的段落，其最終形態待 operator 拍板後才可執行。
+
+實作 `trust-root-isolation-spec.md` 的 **Phase 2**（spec §R10 Phase 2 第 1–8 步）。
+Phase 2a 的權限產生器（`paulsha_cortex/trust_root/permgen.py`）已把 R1 登記表機械
+轉成目標 `owner:group mode`；本 runbook 是把那份計畫**落到 OS**的手動流程。
+
+## operator 0816 裁決（本 runbook 的前提）
+
+- **路線 A**（OS／MAC 邊界），非簽章路線。
+- **Manager 專屬 UID**：Manager 不再跑在 operator 帳號，改跑在服務帳號。
+- **現階段先二分**：`cortex-builder`（builder）／`cortex-svc`（Manager＋reviewer＋
+  planner＋monitor 共用，且為 durable state owner）。**保留二往三分彈性**——未來把
+  Manager 拆成第三個 UID 時，只需換 `permgen.THREE_WAY_SCHEME`，runbook 結構不變。
+- **Manager 落 system-level unit**（非 `--user`），以 `cortex-svc` 執行。
+- **舊 state 走 legacy-import 重新入帳**，**不**直接 `chown` 沿用（spec §R6(e)）。
+- **降級運轉逐案核可**（`PSC_DEGRADED_OPERATION=per-case-approval`，Phase 1 已上線）。
+
+## 當前環境事實（WSL2）
+
+| 項目 | 現況 |
+|---|---|
+| OS | WSL2、system-level systemd 可用（`systemctl is-system-running` = `running`） |
+| sudo | **需密碼**——每個 `sudo` 步驟都是互動式，**不可假設自動化** |
+| 帳號 | 單一 `operator` 登入帳號（本文以 `operator` 代稱，勿寫死使用者名） |
+| 部署 | pipx tree 在 operator HOME（`$HOME/.local/share/pipx/venvs/paulsha-cortex/`），實測 `drwxrwxr-x` |
+| headless job | 現以 operator 帳號跑 |
+| `~/.agents/{control,config/paulsha}` | 現為 `775`（`g+w`） |
+
+## 標記約定
+
+- **`🔧 operator sudo`**：operator 親自 `sudo` 執行的特權變更。
+- **`✅ 驗證`**：唯讀驗證命令（可由 operator 或 CI 執行，無特權）。
+- **`⚠️ 未決`**：最終形態待 operator 拍板；**未拍板前不得執行**。
+- 命令中的路徑一律以 shell 變數表示（如 `"$AGENTS_ROOT"`），**勿寫死絕對路徑**。
+
+## 權限命令的單一真相
+
+所有 `chown`／`chmod`／`setfacl` **不手寫**——由權限產生器輸出，operator 逐項對照
+登記表 review：
+
+```bash
+# ✅ 驗證：印出二分方案的完整權限計畫（JSON）
+python3 -m paulsha_cortex.trust_root permissions two-way
+
+# ✅ 驗證：印出可直接對照的命令序列（含 <PATH:asset_id> placeholder）
+python3 -m paulsha_cortex.trust_root permissions two-way --commands
+
+# ✅ 驗證：印出登記表摘要（含每項 path_resolver，供解析真實路徑）
+python3 -m paulsha_cortex.trust_root registry
+```
+
+> **路徑代入**：命令輸出以 `<PATH:asset_id>` placeholder 呈現。operator 依
+> `registry` 的 `path_resolver` 在目標主機解析真實路徑（見第 3 步的 `AGENTS_ROOT`
+> 等變數），再逐項替換。`path_resolver=None` 的葉資產（如 `jobs-registry` →
+> `<coordinator_root>/jobs.json`）依 spec 背景段的定義位置表解析。
+
+---
+
+## 第 0 步：前置檢查（不需特權，全部 `✅ 驗證`）
+
+先把 baseline 記下來，切換後才能對照。
+
+```bash
+# ✅ 系統 systemd 可用
+systemctl is-system-running || true          # 期望 running（degraded 亦可，記錄之）
+
+# ✅ sudo 可用（會要密碼；只驗證能取得，不做任何變更）
+sudo -v
+
+# ✅ Phase 1 自檢 baseline——記錄現況哪些 Manager-owned 路徑仍 job-writable
+python3 -m paulsha_cortex.trust_root selfcheck | tee "/tmp/trust-root-baseline-$(date +%Y%m%d).json"
+
+# ✅ 登記表等式必須綠（否則盤點已漂移，先修 Phase 1 再繼續）
+python3 -m paulsha_cortex.trust_root equation
+
+# ✅ 記錄現況權限（切換後對照）
+ls -ld "$HOME/.agents" "$HOME/.agents"/* 2>/dev/null
+ls -ld "$HOME/.local/share/pipx/venvs/paulsha-cortex" 2>/dev/null
+```
+
+**通過條件**：`equation` 回傳 `ok: true`；baseline JSON 已存檔。
+Phase 1 自檢此時**預期為紅**（有 `job-writable` finding）——那正是本 runbook 要收斂
+的清單，切換完成後（第 7 步）應轉綠。
+
+---
+
+## 第 1 步：建 UID（二分）
+
+建立兩個 **system service 帳號**，皆 **no-login**（`nologin` shell）、**最小 home**。
+慣例：每帳號一個同名 primary group（權限產生器的 ACL 以此為前提）。
+
+```bash
+# 🔧 operator sudo：建 cortex-svc（durable state owner + Manager/monitor/reviewer/planner）
+sudo groupadd --system cortex-svc
+sudo useradd  --system --gid cortex-svc \
+     --home-dir /var/lib/cortex-svc --create-home \
+     --shell /usr/sbin/nologin \
+     --comment "cortex trusted service (Manager/monitor/reviewer/planner)" cortex-svc
+
+# 🔧 operator sudo：建 cortex-builder（唯一完全隔離的 headless job 帳號）
+sudo groupadd --system cortex-builder
+sudo useradd  --system --gid cortex-builder \
+     --home-dir /var/lib/cortex-builder --create-home \
+     --shell /usr/sbin/nologin \
+     --comment "cortex headless builder job" cortex-builder
+```
+
+**群組設計理由**：跨帳號存取一律走 **per-account POSIX ACL**（見權限產生器輸出的
+`setfacl -m u:<acct>:rX`），**不**用共用 group 開放，避免「一個 group 開了就全開」的
+過寬授權。因此兩帳號各自獨立 group、彼此無交集。
+
+**為何 no-login／最小 home**：這兩個帳號只被 systemd 與降權啟動器使用，永不互動登入；
+最小 home 只放 per-user runtime（如 XDG dirs），不放 durable state（durable state 在
+第 3 步的分樹）。
+
+```bash
+# ✅ 驗證：帳號存在、shell 為 nologin、互不同 group
+getent passwd cortex-svc cortex-builder
+id cortex-svc; id cortex-builder
+# 期望：兩者 primary group 不同、彼此不在對方 group
+```
+
+> **⚠️ 未決 1（降權機制的先決條件）**：第 5 步的降權啟動器需要「`cortex-svc` 能把
+> 子行程降到 `cortex-builder`」。unprivileged 的 `cortex-svc` **無法**直接 setuid 到
+> 另一個 unprivileged 帳號——需 operator 在第 5 步的三個方案擇一（narrow polkit +
+> `systemd-run` transient unit／最小 setuid 助手／給 Manager unit 授
+> `AmbientCapabilities=CAP_SETUID CAP_SETGID`）。此決定影響本步是否要再建輔助群組。
+
+---
+
+## 第 2 步：解析目標路徑變數（不需特權，`✅ 驗證`）
+
+分樹前先把登記表的容器路徑解析成 shell 變數，供第 3 步引用。這些是**目標**部署下
+`cortex-svc` 的路徑（不是 operator HOME）。
+
+```bash
+# ⚠️ 未決 2：目標 AGENTS_ROOT 的最終位置待 operator 定。
+#   候選：/var/lib/cortex（system service 慣例）或保留 ~/.agents 但改 owner。
+#   本 runbook 以 /var/lib/cortex 為示例；operator 定案後替換下列變數。
+export AGENTS_ROOT="/var/lib/cortex/agents"          # ⚠️ 待定
+export CONTROL_ROOT="$AGENTS_ROOT/control"
+export COORDINATOR_ROOT="$AGENTS_ROOT/coordinator"
+export SPECS_ROOT="$AGENTS_ROOT/specs"
+export REGISTRY_ROOT="$AGENTS_ROOT/registry"
+export MONITOR_STATE_ROOT="$AGENTS_ROOT/monitor"
+export RUN_ROOT="$AGENTS_ROOT/run"
+
+# ✅ 驗證：確認變數與登記表 path_resolver 對得上
+python3 -m paulsha_cortex.trust_root registry | \
+  python3 -c "import sys,json;print('\n'.join(sorted(a['path_resolver'] or a['asset_id'] for a in json.load(sys.stdin)['assets'])))"
+```
+
+> **背景 §7 instance-scope 漏洞**：遷移前務必確認 bootstrap env 含
+> `PSC_CONTROL_ROOT`／`PSC_COORDINATOR_ROOT`／`PSC_SPECS_ROOT` 且已 instance-scope，
+> 否則兩個 instance 仍共用 `jobs.json`、分樹會失效（spec §R2 最後一條）。
+
+---
+
+## 第 3 步：路徑分樹 + legacy-import（**不 chown 舊 state**）
+
+裁決：舊 state **不**沿用（不 `chown` 現存 `~/.agents`），而是**建新樹→驗證→把舊
+state 標記為 `legacy-imported` 重新入帳**（spec §R6(e)）。`legacy-imported` 標記
+**不可**滿足任何 ship gate。
+
+### 3a. 建新樹骨架（Manager-owned 與 job-visible 兩棵）
+
+```bash
+# 🔧 operator sudo：建樹根（root 擁有樹根——headless/svc 皆不可 relink 整棵信任根，spec §1）
+sudo install -d -o root -g root -m 0755 "$AGENTS_ROOT"
+
+# 🔧 operator sudo：Manager-owned 子樹（cortex-svc 擁有、0700）
+for d in "$CONTROL_ROOT" "$COORDINATOR_ROOT" "$SPECS_ROOT" "$REGISTRY_ROOT" \
+         "$MONITOR_STATE_ROOT" "$RUN_ROOT"; do
+  sudo install -d -o cortex-svc -g cortex-svc -m 0700 "$d"
+done
+```
+
+> 上列 owner/mode **來自權限產生器**，勿手寫。逐項對照：
+> `python3 -m paulsha_cortex.trust_root permissions two-way --commands`
+> 的 `manager-state` 區塊（如 `control-root-tree`／`coordinator-root-tree`）。
+> 產生器對有跨帳號 reader 的容器（如 `control-root-tree` 有 operator 讀 done/status）
+> 會多出 `setfacl -m u:operator:rX`——照抄。
+
+### 3b. job-visible 樹（worktree pool：per-job 逐案 chown，容器 0701）
+
+```bash
+# ⚠️ 未決 2（同上）：worktree pool 目標位置
+export WORKTREE_ROOT="/var/lib/cortex/worktrees"     # ⚠️ 待定
+
+# 🔧 operator sudo：容器由 cortex-svc 擁有、0701；per-job 子目錄由第 5 步啟動器逐案 chown
+sudo install -d -o cortex-svc -g cortex-svc -m 0701 "$WORKTREE_ROOT"
+```
+
+> `dispatch-worktree-pool` 是 `runtime_managed` 資產——容器層只給 owner 寫，
+> **reviewer 與 builder 的 worktree 是各自被 chown 的子目錄**（R2 在子目錄粒度強制）。
+> `monitor-event-spool` 亦特殊：cortex-svc 擁有、以 `setfacl -m u:cortex-builder:wx`
+> 讓 builder 只能 append，consumer(svc) 讀＋消費。照抄產生器輸出。
+
+### 3c. legacy-import 重新入帳（**不滿足 ship gate**）
+
+```bash
+# ✅ 驗證：把舊 state 的內容 hash 記下（import attestation 的內容，spec §R6(e)）
+OLD="$HOME/.agents"
+find "$OLD" -type f -print0 2>/dev/null | \
+  xargs -0 sha256sum 2>/dev/null | tee "/tmp/legacy-import-manifest-$(date +%Y%m%d).txt"
+
+# 🔧 operator sudo：把舊樹整包搬到 quarantine（唯讀、cortex-svc 擁有），不併入新樹
+sudo install -d -o cortex-svc -g cortex-svc -m 0700 "$AGENTS_ROOT/legacy-imported"
+sudo cp -a "$OLD/." "$AGENTS_ROOT/legacy-imported/" 2>/dev/null || true
+sudo chown -R cortex-svc:cortex-svc "$AGENTS_ROOT/legacy-imported"
+sudo chmod -R a-w "$AGENTS_ROOT/legacy-imported"     # 唯讀，僅供查詢
+```
+
+> **關鍵**：新樹（3a/3b）是**空的、乾淨的**；舊 state 只進 `legacy-imported/`
+> quarantine，標記為不可信、唯讀、僅供歷史查詢。**不**把舊 `jobs.json`／evidence
+> 併入新 `COORDINATOR_ROOT`。任何切換後產生、無正常來源的 record 走正常 gate；
+> 帶 `legacy-imported` 來源者 **MUST NOT** 被 ship gate 採計。
+
+> **⚠️ 未決 3**：`legacy-imported` attestation 的實體格式（Phase 3 R6(e) 的
+> `trust: legacy-imported` 標記由簽章方案落地）。Phase 2b 先做「物理隔離＋內容
+> hash manifest」；正式 attestation 待 Phase 3。operator 需確認：切換期間是否需要
+> 把任何 in-flight 的 job 手動收尾（見第 8 步回滾對照）。
+
+### 3d. 移除舊 775 的 g+w
+
+```bash
+# 🔧 operator sudo：收斂現有 g+w（~/.agents 與 config/paulsha 實測 775）
+#   注意：新樹已在 3a 以正確 mode 建立；此步是清理**舊路徑殘留**，避免仍被引用。
+chmod -R g-w,o-w "$HOME/.agents" 2>/dev/null || true
+
+# ✅ 驗證：新樹 mode 與產生器一致、舊路徑不再 g+w
+sudo ls -ld "$CONTROL_ROOT" "$COORDINATOR_ROOT" "$WORKTREE_ROOT"
+```
+
+**執行後驗證（整步）**：以 `cortex-builder` 身分試寫 Manager-owned 樹須 `EACCES`
+（見第 7 步 R9 族 2）。
+
+---
+
+## 第 4 步：Manager 遷 root-owned 部署 + system-level unit
+
+### 4a. pipx tree 遷出 operator HOME
+
+```bash
+# ⚠️ 未決 4：Manager 部署路徑的確切位置待 operator 定。
+#   候選：/opt/cortex/venv（root 擁有、唯讀 for svc）。以下為示例。
+export DEPLOY_ROOT="/opt/cortex"                     # ⚠️ 待定
+
+# 🔧 operator sudo：把現有 pipx venv 複製到 root-owned 部署路徑（不是原地 chown）
+sudo install -d -o root -g root -m 0755 "$DEPLOY_ROOT"
+sudo cp -a "$HOME/.local/share/pipx/venvs/paulsha-cortex" "$DEPLOY_ROOT/venv"
+sudo chown -R root:root "$DEPLOY_ROOT/venv"
+sudo find "$DEPLOY_ROOT/venv" -type d -exec chmod 0755 {} +
+sudo find "$DEPLOY_ROOT/venv" -type f -exec chmod a-w {} +   # site-packages 對 svc/headless 唯讀
+```
+
+> spec §R3：executable／deps／launcher／venv 對 headless **不可寫**，owner=root。
+> 這封掉背景 §5 的「改寫 verifier／注入 `sitecustomize.py`／`.pth`」攻擊面。
+
+### 4b. bootstrap env 遷入受保護樹（fail-closed）
+
+```bash
+# 🔧 operator sudo：env 檔 root 擁有、0644（全部行程唯讀，spec §R3「全部行程唯讀」）
+export ENV_DIR="$AGENTS_ROOT/core/runtime"
+sudo install -d -o root -g root -m 0755 "$ENV_DIR"
+# 依 permgen 的 deployment 區塊（runtime-bootstrap-env）產生 owner/mode：
+#   chown root:root <PATH:runtime-bootstrap-env>; chmod 0644 ...
+```
+
+> env 檔內容須含 instance-scoped 的 `PSC_AGENTS_ROOT`／`PSC_CONTROL_ROOT`／
+> `PSC_COORDINATOR_ROOT`／`PSC_SPECS_ROOT`／`PSC_MONITOR_STATE_ROOT`，全部指向第 2 步
+> 的目標路徑（修掉背景 §7 漏洞）。
+
+### 4c. system-level unit（以 cortex-svc 跑、加固指令切實列出）
+
+```bash
+# ⚠️ 未決 5：unit 最終形態（含 ReadWritePaths 的精確清單）待 operator 定稿後寫入。
+# 🔧 operator sudo：寫 /etc/systemd/system/cortex-manager.service（示例骨架）
+sudo tee /etc/systemd/system/cortex-manager.service >/dev/null <<'UNIT'
+[Unit]
+Description=cortex Manager (trust-root Phase 2, system-level)
+After=network.target
+
+[Service]
+Type=simple
+User=cortex-svc
+Group=cortex-svc
+
+# --- fail-closed env（移除 EnvironmentFile 的 '-'，缺檔即拒絕啟動，spec §R3）---
+EnvironmentFile=/var/lib/cortex/agents/core/runtime/cortex-manager.env
+
+ExecStart=/opt/cortex/venv/bin/cortex service run
+WorkingDirectory=/var/lib/cortex
+
+# --- systemd 加固（spec §R3；現況三個 unit 一項都沒有）---
+NoNewPrivileges=yes
+ProtectSystem=strict
+ProtectHome=yes
+PrivateTmp=yes
+ProtectControlGroups=yes
+ProtectKernelModules=yes
+ProtectKernelTunables=yes
+ProtectClock=yes
+RestrictSUIDSGID=yes
+RestrictRealtime=yes
+LockPersonality=yes
+MemoryDenyWriteExecute=yes
+SystemCallFilter=@system-service
+SystemCallErrorNumber=EPERM
+CapabilityBoundingSet=
+# durable state 樹是唯一可寫路徑白名單（由 R1 登記表產生，勿手擴）：
+ReadWritePaths=/var/lib/cortex/agents /var/lib/cortex/worktrees
+
+[Install]
+WantedBy=multi-user.target
+UNIT
+
+# 🔧 operator sudo：載入與啟用（system-level，非 --user）
+sudo systemctl daemon-reload
+sudo systemctl enable --now cortex-manager.service
+```
+
+> **`EnvironmentFile` 無 `-` 前綴**＝缺檔 fail-closed（spec §R3 Scenario「刪除
+> EnvironmentFile」）。`CapabilityBoundingSet=`（空）＝丟掉所有 capability；若第 5 步
+> 選 CAP_SETUID 方案，這裡要改成 `CapabilityBoundingSet=CAP_SETUID CAP_SETGID
+> CAP_SETPCAP` 並加 `AmbientCapabilities=`——**但這會擴大 Manager 權限，見未決 1**。
+
+```bash
+# ✅ 驗證：unit 以 cortex-svc 跑、加固生效
+systemctl show cortex-manager.service -p User -p NoNewPrivileges -p ProtectSystem -p ReadWritePaths
+systemctl status cortex-manager.service
+sudo journalctl -u cortex-manager.service -n 50 --no-pager
+```
+
+> **WSL2 注意**：system-level unit 在 WSL2 需 `systemd=true`（`/etc/wsl.conf`）且已
+> `is-system-running: running`（第 0 步已驗）。system unit **不需** lingering
+> （lingering 只對 `--user` unit 有意義）。若 WSL 重啟後 systemd 未起，見第 8 步回滾。
+
+---
+
+## 第 5 步：降權啟動器啟用（Manager → cortex-builder，關 FD、不傳 token）
+
+Manager（cortex-svc）spawn headless job 時降到 `cortex-builder`，且：
+- **關閉 FD 傳遞**（`close_fds`，不繼承任何指向受保護資產的 fd——spec §R9 T4.1）；
+- **不傳 gh token**（scrub `GH_TOKEN`／`GITHUB_TOKEN`；GitHub 寫入改由 Manager 代理，
+  沿用 D1 outbox）；
+- 只暴露該 job 自己被 chown 的 worktree 子目錄。
+
+> **⚠️ 未決 1（降權機制最終形態，最高風險決策）**：unprivileged 的 cortex-svc
+> 無法直接 setuid 到 cortex-builder。三個候選，operator 擇一：
+>
+> | 方案 | 做法 | 代價 |
+> |---|---|---|
+> | **A. `systemd-run` transient unit**（建議） | Manager 呼叫 `systemd-run --uid=cortex-builder --pipe --collect --property=...` 起 job；乾淨環境天然關 FD／scrub env | 需一條 **narrow polkit rule** 允許 cortex-svc 對 `cortex-builder` 起 transient unit；WSL2 的 polkit 行為需先在拋棄式環境驗 |
+> | **B. 最小 setuid 助手** | root 擁有、setuid-root、**寫死只 exec 成 cortex-builder** 的小程式，cortex-svc 可呼叫 | 引入一支 setuid 二進位＝新攻擊面，需嚴格審查與 argv 白名單 |
+> | **C. Manager 授 `CAP_SETUID`** | unit 加 `AmbientCapabilities=CAP_SETUID CAP_SETGID` | CAP_SETUID 可變成**任意** uid，等於放大 Manager 權限，最不建議 |
+>
+> 本 runbook 以 **方案 A** 為預設示例；operator 定案前**第 5 步不可執行**。
+
+```bash
+# ⚠️ 未決 1：以下為方案 A 的 polkit rule 示例（待 operator 定案）
+# 🔧 operator sudo：/etc/polkit-1/rules.d/49-cortex-spawn.rules（示例）
+sudo tee /etc/polkit-1/rules.d/49-cortex-spawn.rules >/dev/null <<'RULES'
+// 僅允許 cortex-svc 對 cortex-builder 起 transient unit（最小授權）
+polkit.addRule(function(action, subject) {
+  if (action.id == "org.freedesktop.systemd1.manage-units" &&
+      subject.user == "cortex-svc") {
+    // TODO(operator): 收斂到只允許 --uid=cortex-builder 的 unit 名前綴
+    return polkit.Result.YES;
+  }
+});
+RULES
+```
+
+```bash
+# ✅ 驗證：以 cortex-svc 起一個降到 cortex-builder 的 transient job，檢查身分/FD/token
+sudo -u cortex-svc systemd-run --uid=cortex-builder --pipe --wait --collect \
+  /bin/sh -c 'id; echo "GH_TOKEN=[$GH_TOKEN]"; ls -l /proc/self/fd'
+# 期望：uid=cortex-builder；GH_TOKEN 為空；/proc/self/fd 無指向受保護資產的可寫 fd
+```
+
+---
+
+## 第 6 步：Manager 升級流程（設定後升級需 root）
+
+切換後，Manager 部署在 root-owned 樹（`/opt/cortex/venv`），升級**需 root**。設計一個
+**受控升級步驟**——驗證來源後**替換整棵 svc-owned/root-owned tree**，而非裸 `chown`。
+
+```bash
+# ✅ 驗證：先在 operator HOME 的 pipx 環境 build/驗證新版（不碰部署樹）
+pipx run --spec paulsha-cortex==<新版> cortex --version   # 或既有 build 流程
+# 產出 wheel/venv 後，先算內容 hash 與現行部署對照差異
+
+# 🔧 operator sudo：受控替換（atomic：新樹旁建→驗→切 symlink→保留舊樹回滾）
+export NEW="/opt/cortex/venv.next"
+sudo cp -a "$HOME/.local/share/pipx/venvs/paulsha-cortex" "$NEW"
+sudo chown -R root:root "$NEW"
+sudo find "$NEW" -type f -exec chmod a-w {} +
+# 驗證新樹自檢通過後才切換：
+sudo -u cortex-svc "$NEW/bin/python" -m paulsha_cortex.trust_root selfcheck
+sudo ln -sfn "$NEW" /opt/cortex/venv.active   # ExecStart 指向 venv.active
+sudo systemctl restart cortex-manager.service
+```
+
+> **不裸 chown**：升級不是「把 headless 產出的檔 chown 給 svc」，而是「operator 驗證
+> 來源後，以 root 身分整棵替換部署樹」。任何 headless 都碰不到 `/opt/cortex`。
+> 舊樹（`venv.active` 前一目標）保留一個 release 供回滾（第 8 步）。
+
+> **⚠️ 未決 6**：是否提供 `cortex install trust-root --system` 子命令把此流程
+> codify（spec 未決問題 #3）。codify 較可重複，但等於把特權操作寫進 codebase，本身
+> 需審查。Phase 2b 先走手動 runbook；子命令化留待 operator 決定。
+
+---
+
+## 第 7 步：切換驗收（Phase 1 自檢轉綠 + R9 四族實測）
+
+### 7a. Phase 1 自檢切 fail-closed 應綠
+
+```bash
+# ✅ 驗證：以 cortex-svc（Manager 身分）跑自檢——Manager-owned 樹應無 job-writable
+sudo -u cortex-svc /opt/cortex/venv.active/bin/python \
+  -m paulsha_cortex.trust_root selfcheck
+# 期望：ok=true、job_writable_count=0（對照第 0 步 baseline 的紅）
+```
+
+### 7b. R9 四族攻擊測試（以 `cortex-builder` shell 實測攻不進）
+
+每族都要有 **negative control**（以受信任身分執行相同動作**必須成功**，否則是環境
+壞掉的假綠，spec §R9）。
+
+```bash
+# 取一個 cortex-builder shell（經第 5 步降權機制）
+BUILDER='sudo -u cortex-svc systemd-run --uid=cortex-builder --pipe --wait --collect /bin/sh -c'
+
+# 族 1 capability-theft
+$BUILDER 'cat /var/lib/cortex/agents/core/runtime/*.env'      # 期望 EACCES（或無此權限）
+$BUILDER 'printf x > /var/lib/cortex/agents/control/requests/evil.json'  # 期望 EACCES
+
+# 族 2 durable-state-tampering（對每個 Tier-0/1 資產：modify/truncate/delete/replace/symlink/rollback）
+$BUILDER 'printf "{}" > /var/lib/cortex/agents/coordinator/jobs.json'    # 期望 EACCES、jobs.json 位元不變
+$BUILDER 'rm -f /var/lib/cortex/agents/coordinator/evidence/*'          # 期望 EACCES
+# review verdict 代寫（背景 §3 最短攻擊路徑）——builder 對 reviewer 產出零寫入
+$BUILDER 'printf "{\"verdict\":\"pass\"}" > <reviewer_worktree>/.psc-review-verdict.json'  # 期望 EACCES
+
+# 族 3 enforcement-plane-tampering（每案改完 MUST 實際重啟服務再驗證）
+$BUILDER 'echo x >> /opt/cortex/venv.active/lib/python*/site-packages/sitecustomize.py'  # 期望 EACCES
+$BUILDER 'echo x > /etc/systemd/system/cortex-manager.service'          # 期望 EACCES
+
+# 族 4 行程間路徑
+$BUILDER 'cat /proc/$(pgrep -u cortex-svc -n cortex)/environ'           # 期望 EACCES
+$BUILDER 'ls -l /proc/self/fd'                                          # 期望：無可寫的受保護 fd
+
+# negative control（以 cortex-svc 執行族 2 的寫入，必須成功）
+sudo -u cortex-svc /bin/sh -c 'touch /var/lib/cortex/agents/coordinator/.wtest && rm -f /var/lib/cortex/agents/coordinator/.wtest && echo NEG-OK'
+```
+
+**通過條件**：族 1–4 全部被 OS 拒絕（`EACCES`／`EPERM`／`ECONNREFUSED`）；每族的
+negative control 成功；族 3 每案**重啟服務後**仍綠。逐項對照 spec §R9 的 T1–T4 表。
+
+> **⚠️ 未決 7**：R9 的完整自動化矩陣（對登記表**每一項** Tier-0/1 資產機械展開族 2）
+> 是 Phase 2 的 R9 測試工項，**不在本 runbook**——本步是 operator 手動抽驗；完整
+> 矩陣另由測試碼交付並掛 CI。
+
+---
+
+## 第 8 步：回滾（每階段的退路 → 退回 Phase 1 降級運轉）
+
+Phase 1 完全不需 root 且含降級運轉安全網（`PSC_DEGRADED_OPERATION=per-case-approval`）。
+任一階段出問題即退回「operator 帳號跑 + 降級運轉」。
+
+| 出問題的階段 | 症狀 | 回滾動作（`🔧 operator sudo`） |
+|---|---|---|
+| 第 4c（system unit） | WSL2 重啟後 systemd 未起、Manager 起不來 | `sudo systemctl disable --now cortex-manager.service`；改回 operator 的 `systemctl --user` 舊 unit；确認 `PSC_DEGRADED_OPERATION` 仍在 |
+| 第 4c 加固誤擋 | 服務起來但功能靜默失效（`ProtectSystem`/`ReadWritePaths` 擋到寫入路徑） | 先看 `journalctl -u cortex-manager` 的 EPERM；把被擋路徑加進 `ReadWritePaths`（且回填 R1 登記表）→ `daemon-reload` + `restart` |
+| 第 5（降權機制） | polkit/systemd-run 在 WSL2 不如預期、job spawn 不了 | 暫停 headless 派工；Manager 以 `per-case-approval` 降級運轉（不 spawn），等機制修好 |
+| 第 3（分樹） | 新樹路徑契約破壞既有 instance | env 檔改指回 `~/.agents`（保留舊路徑一個 release 為唯讀相容層）；`legacy-imported/` 仍在，未污染新樹 |
+| 全面回退 | 任一不可解 | 停 system unit、回 operator HOME 部署、`PSC_DEGRADED_OPERATION=per-case-approval`（或 `disabled`），fleet 回到 Phase 1 狀態；**join gate 維持未通過**（不得宣告 0.2.0 stable，spec §R12） |
+
+```bash
+# ✅ 驗證（回滾後）：回到 Phase 1，自檢回 WARN-only、降級運轉生效
+python3 -m paulsha_cortex.trust_root selfcheck            # 預期回到有 WARN 的 Phase 1 狀態
+echo "PSC_DEGRADED_OPERATION=$PSC_DEGRADED_OPERATION"     # 期望 per-case-approval 或 disabled
+```
+
+> **回滾原則**：舊 state 走 legacy-import（第 3c）而非併入，所以回滾時新樹可整棵丟棄
+> 而不遺失舊資料；`legacy-imported/` quarantine 是唯讀副本，兩邊都不互相污染。
+
+---
+
+## 未決點彙整（需 operator 拍板）
+
+1. **降權機制最終形態**（最高風險）：`systemd-run`+polkit／setuid 助手／CAP_SETUID
+   三擇一（第 5 步）。**未定案前第 5 步不可執行。**
+2. **目標路徑位置**：`AGENTS_ROOT`／`WORKTREE_ROOT` 落 `/var/lib/cortex` 或保留
+   `~/.agents` 改 owner（第 2、3 步）。
+3. **legacy-import attestation 格式**：Phase 2b 只做物理隔離＋hash manifest；
+   `trust: legacy-imported` 正式標記待 Phase 3 簽章（第 3c 步）。
+4. **Manager 部署路徑**：`/opt/cortex/venv` 或其他 root-owned 位置（第 4a 步）。
+5. **unit 加固最終清單**：`ReadWritePaths` 的精確白名單（由 R1 登記表產生，第 4c 步）。
+6. **是否 codify 成 `cortex install trust-root --system`**（第 6 步；spec 未決問題 #3）。
+7. **R9 完整自動化矩陣**：本 runbook 只手動抽驗；完整矩陣由測試碼另交付（第 7b 步）。
+
+## 對 WSL2 環境，本 runbook 最不確定／最高風險的步驟
+
+1. **第 5 步降權機制（最高風險）**：unprivileged→unprivileged 的降權在 WSL2 上
+   （polkit daemon 是否常駐、`systemd-run --uid` transient unit 行為）需**先在拋棄式
+   環境跑通 R9 族 4** 再上正式機。三個方案各有攻擊面權衡（未決 1）。
+2. **第 4c system-level unit 在 WSL2 的持久性**：WSL 關閉/重啟後 systemd system session
+   是否可靠拉起 `cortex-manager.service`；lingering 對 system unit 無效，需驗 boot 行為。
+3. **第 4c 加固誤擋**：`ProtectSystem=strict` + `ReadWritePaths` 白名單若漏列某條實際
+   寫入路徑，會**靜默**功能失效（服務起得來但寫不進）；務必先跑既有 E2E 再收窄。

--- a/docs/superpowers/runbooks/trust-root-phase2b-setup.md
+++ b/docs/superpowers/runbooks/trust-root-phase2b-setup.md
@@ -4,6 +4,7 @@ work_item: trust-root-isolation
 phase: 2b
 audience: operator
 supersedes: none
+tracking: "#584 — trust-root D6 母議題（本票 reference-only，不 auto-close；R-17 走 policy-exempt:issue-link 豁免）"
 refs:
   - docs/superpowers/specs/trust-root-isolation-spec.md
   - paulsha_cortex/trust_root/registry.py

--- a/paulsha_cortex/trust_root/__init__.py
+++ b/paulsha_cortex/trust_root/__init__.py
@@ -17,6 +17,6 @@ single-use nonce ledger、capability 通道的 Unix socket OS 隔離。Phase 1 �
 """
 from __future__ import annotations
 
-from . import capability, registry, selfcheck
+from . import capability, permgen, registry, selfcheck
 
-__all__ = ["registry", "selfcheck", "capability"]
+__all__ = ["registry", "selfcheck", "capability", "permgen"]

--- a/paulsha_cortex/trust_root/__main__.py
+++ b/paulsha_cortex/trust_root/__main__.py
@@ -7,6 +7,11 @@ Phase 1 不改 `cortex` CLI（避免動到 R-16 help 對齊面）；operator／C
     python -m paulsha_cortex.trust_root selfcheck   # R3 自檢診斷（JSON）
     python -m paulsha_cortex.trust_root registry    # R1 登記表摘要（JSON）
     python -m paulsha_cortex.trust_root equation     # R1 雙向等式結果
+    python -m paulsha_cortex.trust_root permissions [two-way|three-way] [--commands]
+                                                    # Phase 2a 權限計畫（JSON 或命令序列）
+
+`permissions` 只**產生**權限計畫／命令字串，**絕不執行**任何 root 操作——命令供
+operator 在 Phase 2b runbook 中手動 sudo 執行。
 """
 from __future__ import annotations
 
@@ -14,7 +19,7 @@ import json
 import sys
 from typing import Sequence
 
-from . import registry, selfcheck
+from . import permgen, registry, selfcheck
 
 
 def _registry_summary() -> dict[str, object]:
@@ -69,6 +74,25 @@ def main(argv: Sequence[str] | None = None) -> int:
             indent=2,
         ))
         return 0 if result.ok else 1
+    if command == "permissions":
+        rest = args[1:]
+        scheme_id = "two-way"
+        want_commands = False
+        for token in rest:
+            if token == "--commands":
+                want_commands = True
+            elif token in permgen.SCHEMES:
+                scheme_id = token
+            else:
+                print(f"unknown permissions arg: {token}", file=sys.stderr)
+                return 2
+        plan = permgen.generate_plan(permgen.SCHEMES[scheme_id])
+        if want_commands:
+            for line in permgen.plan_to_commands(plan):
+                print(line)
+        else:
+            print(json.dumps(plan.to_dict(), ensure_ascii=False, indent=2))
+        return 0
 
     print(f"unknown command: {command}", file=sys.stderr)
     return 2

--- a/paulsha_cortex/trust_root/permgen.py
+++ b/paulsha_cortex/trust_root/permgen.py
@@ -1,0 +1,515 @@
+"""Phase 2a：權限產生器——用 R1 登記表機械產生目錄 owner／group／mode 清單。
+
+spec §R10 Phase 2 第 2 條要求「目錄 owner／mode **由 R1 登記表產生**（權限產生器以
+登記表為輸入，不手寫）」。本模組即該產生器：吃 `registry.ASSET_REGISTRY` ＋一個
+**UID 方案 config**（`UidScheme`，persona→OS 帳號的映射），機械算出每個資產路徑的
+目標權限，輸出 (a) 結構化清單（可轉 JSON）與 (b) 可供 Phase 2b runbook 引用的
+`chown`／`chmod`／`setfacl` 命令字串。
+
+**本模組純為產生器：只回傳資料與字串，絕不執行任何 root 操作、不 chown、不 chmod、
+不建 UID。** 命令字串供 operator 在 runbook 中手動 `sudo` 執行。
+
+## UID 方案的參數化（operator 0816 裁決：路線 A、Manager 專屬 UID、現階段先二分、
+## 但保留「二往三分」彈性）
+
+`UidScheme` 把每個 `Principal` 映射到具體 OS 帳號名，並指定：
+- `durable_state_owner`：擁有 Manager-owned durable state 樹的帳號；
+- `deploy_account`：enforcement plane（部署面）的擁有者（root／部署帳號）。
+
+**二分**（預設，`TWO_WAY_SCHEME`）：只有兩個 headless-相關帳號——
+`cortex-builder`（builder）與 `cortex-svc`（Manager＋reviewer＋planner＋monitor
+共用，且即 durable state owner）。reviewer 與 builder 因此落在互不可寫的不同帳號
+（滿足 spec §R2 對 independence 的最低要求）。
+
+**三分**（`THREE_WAY_SCHEME`）：把 `cortex-svc` 拆為 `cortex-manager`（僅 Manager／
+monitor，且為 durable state owner）與 `cortex-reviewer-planner`（reviewer＋planner
+的 job 帳號，**不**擁有 durable state）。這實現裁決要保留的「未來把 Manager 拆成
+第三個 UID」彈性——**只換 config，不改本模組任何一行程式碼**。
+
+兩個方案套用**同一套 policy 函式**，因此都能對登記表每一項產出一致（滿足同一組
+不變式）的權限集合：Manager-owned／deployment 樹對任何 headless 帳號皆不可寫，
+job-visible 樹由對應 job 帳號寫、跨 persona 互不可寫。
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Mapping
+
+from . import registry
+from .registry import (
+    HEADLESS_PERSONAS,
+    AssetTier,
+    IngressKind,
+    Principal,
+    TrustRootAsset,
+    TrustTree,
+)
+
+
+# ---------------------------------------------------------------------------
+# UID 方案 config（參數化——二分為預設，同一資料結構可表達三分）
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class UidScheme:
+    """persona→OS 帳號的映射方案。
+
+    `account_of` 必須涵蓋登記表出現過的所有非 `ANY_SAME_UID` principal
+    （`ANY_SAME_UID` 是「現況同 UID 任意行程」的標記，正是 Phase 2 要移除的對象，
+    故**不**映射到任何目標帳號）。
+    """
+
+    scheme_id: str
+    account_of: Mapping[Principal, str]
+    #: 擁有 Manager-owned durable state 樹的帳號（Manager 本人的服務帳號）。
+    durable_state_owner: str
+    #: enforcement plane（unit／venv／launcher／env／codex hooks）的擁有者。
+    deploy_account: str = "root"
+    #: 外部唯讀消費者（digest／engineering-outcome outbox 的下游）帳號。
+    external_reader: str = "cortex-outbox"
+
+    def resolve(self, principal: Principal) -> str | None:
+        """回傳 principal 的目標帳號；`ANY_SAME_UID` 與未映射者回傳 None。"""
+        if principal is Principal.ANY_SAME_UID:
+            return None
+        if principal is Principal.INSTALLER:
+            return self.deploy_account
+        if principal is Principal.EXTERNAL:
+            return self.external_reader
+        return self.account_of.get(principal)
+
+    def group_of(self, account: str) -> str:
+        """帳號的 primary group（慣例：每帳號一個同名 group）。"""
+        return account
+
+    def headless_accounts(self) -> frozenset[str]:
+        """全部 headless persona（含 headless hook）解析到的帳號集合。
+
+        Manager-owned／deployment 樹對這些帳號**必須**零寫入權——這是本產生器的
+        核心不變式。
+        """
+        accts: set[str] = set()
+        for p in list(HEADLESS_PERSONAS) + [Principal.HEADLESS_HOOK]:
+            a = self.resolve(p)
+            if a is not None:
+                accts.add(a)
+        return frozenset(accts)
+
+
+#: 二分（預設）：builder 一個帳號，其餘 headless／Manager／monitor 共用 cortex-svc。
+TWO_WAY_SCHEME = UidScheme(
+    scheme_id="two-way",
+    account_of={
+        Principal.MANAGER: "cortex-svc",
+        Principal.MONITOR: "cortex-svc",
+        Principal.REVIEWER: "cortex-svc",
+        Principal.PLANNER: "cortex-svc",
+        Principal.BUILDER: "cortex-builder",
+        Principal.HEADLESS_HOOK: "cortex-builder",
+        Principal.OPERATOR: "operator",
+    },
+    durable_state_owner="cortex-svc",
+    deploy_account="root",
+)
+
+#: 三分：把 cortex-svc 拆成 cortex-manager（durable state owner）與
+#: cortex-reviewer-planner（reviewer＋planner 的 job 帳號，不持有 durable state）。
+#: **與二分共用同一套 policy，僅換 config。**
+THREE_WAY_SCHEME = UidScheme(
+    scheme_id="three-way",
+    account_of={
+        Principal.MANAGER: "cortex-manager",
+        Principal.MONITOR: "cortex-manager",
+        Principal.REVIEWER: "cortex-reviewer-planner",
+        Principal.PLANNER: "cortex-reviewer-planner",
+        Principal.BUILDER: "cortex-builder",
+        Principal.HEADLESS_HOOK: "cortex-builder",
+        Principal.OPERATOR: "operator",
+    },
+    durable_state_owner="cortex-manager",
+    deploy_account="root",
+)
+
+SCHEMES: dict[str, UidScheme] = {
+    TWO_WAY_SCHEME.scheme_id: TWO_WAY_SCHEME,
+    THREE_WAY_SCHEME.scheme_id: THREE_WAY_SCHEME,
+}
+
+
+# ---------------------------------------------------------------------------
+# 權限模型
+# ---------------------------------------------------------------------------
+
+class OwnerClass(Enum):
+    """資產的擁有類別，決定 owner 帳號來源。"""
+
+    DEPLOYMENT = "deployment"        # enforcement plane：owner＝deploy/root
+    MANAGER_STATE = "manager-state"  # Manager-owned durable state：owner＝durable_state_owner
+    JOB = "job"                      # job-visible：owner＝對應 job 帳號（或 runtime 逐案 chown）
+
+
+@dataclass(frozen=True)
+class AclEntry:
+    """單條 POSIX ACL（供跨帳號的精確授權；Manager-owned 上只會出現唯讀條目）。"""
+
+    account: str
+    perms: str          # "rX"（讀，dir 自動含 traverse）／"rwx"／"wx"
+    default: bool = False  # 是否為 default ACL（dir 內新建物件繼承）
+
+    @property
+    def writable(self) -> bool:
+        return "w" in self.perms
+
+    def render(self, path: str) -> str:
+        flag = "-d -m" if self.default else "-m"
+        return f"setfacl {flag} u:{self.account}:{self.perms} {path}"
+
+
+@dataclass(frozen=True)
+class PermissionEntry:
+    """單一資產路徑的目標權限（機械產生，不含任何實際 IO）。"""
+
+    asset_id: str
+    tier: str
+    tree: str
+    owner_class: OwnerClass
+    owner: str
+    group: str
+    mode: int                     # 0o 值，僅 0o777 部分
+    is_directory: bool
+    #: 目標可寫帳號（含 owner 與 ACL 授寫者）——供不變式測試。
+    writer_accounts: frozenset[str]
+    reader_accounts: frozenset[str]
+    acls: tuple[AclEntry, ...] = ()
+    #: True＝容器的 per-child owner 由 launcher 在 spawn 時逐案 chown（如 worktree pool）。
+    runtime_managed: bool = False
+    #: 現況 writer（含 ANY_SAME_UID）——保留供對照，非目標。
+    legacy_writers: tuple[str, ...] = ()
+    rationale: str = ""
+    #: 待 operator 拍板的未決點（例如部署路徑最終位置）。
+    open_points: tuple[str, ...] = ()
+
+    @property
+    def mode_str(self) -> str:
+        return format(self.mode, "04o")
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "asset_id": self.asset_id,
+            "tier": self.tier,
+            "tree": self.tree,
+            "owner_class": self.owner_class.value,
+            "owner": self.owner,
+            "group": self.group,
+            "mode": self.mode_str,
+            "is_directory": self.is_directory,
+            "writer_accounts": sorted(self.writer_accounts),
+            "reader_accounts": sorted(self.reader_accounts),
+            "acls": [
+                {"account": a.account, "perms": a.perms, "default": a.default}
+                for a in self.acls
+            ],
+            "runtime_managed": self.runtime_managed,
+            "legacy_writers": list(self.legacy_writers),
+            "rationale": self.rationale,
+            "open_points": list(self.open_points),
+        }
+
+    def commands(self, path: str) -> list[str]:
+        """產生本資產的 chown／chmod／setfacl 命令字串（**只回傳字串，不執行**）。
+
+        `path` 由呼叫端提供（runbook 以 shell 變數帶入真實路徑）；未提供具體路徑時
+        以清楚標記的 placeholder 呈現。
+        """
+        cmds = [
+            f"chown {self.owner}:{self.group} {path}",
+            f"chmod {self.mode_str} {path}",
+        ]
+        for acl in self.acls:
+            cmds.append(acl.render(path))
+            # dir 需同時設 access 與 default ACL，讓新建物件繼承。
+            if self.is_directory and not acl.default:
+                cmds.append(AclEntry(acl.account, acl.perms, default=True).render(path))
+        return cmds
+
+
+# ---------------------------------------------------------------------------
+# 目錄／檔案推斷（登記表未編碼 file/dir，以 resolver 名與 asset_id 機械推斷）
+# ---------------------------------------------------------------------------
+
+_DIR_ASSET_TOKENS = (
+    "tree", "root", "queue", "pool", "spool", "proposals", "outbox", "combos",
+)
+_DIR_ASSET_IDS = frozenset({
+    "combo-card-override",       # <agents_root>/config/combos/ 目錄
+    "skill-park-proposals",
+    "digest-outbox",
+})
+_FILE_ASSET_IDS = frozenset({
+    "engineering-outcome-outbox",  # 單一 .jsonl 檔（名稱含 outbox 但是檔）
+    "control-daemon-lock",
+    "control-status",
+})
+
+
+def infer_is_directory(asset: TrustRootAsset) -> bool:
+    """機械推斷資產是目錄或檔案。
+
+    優先序：明列覆寫 → resolver 名後綴（`_path`＝檔、`_root`/`_dir`＝目錄）→
+    asset_id token。path_resolver=None 的葉資產以 asset_id 推斷，**屬 heuristic**，
+    runbook 標明 operator 應對 path_resolver=None 的葉逐一確認 file/dir。
+    """
+    if asset.asset_id in _DIR_ASSET_IDS:
+        return True
+    if asset.asset_id in _FILE_ASSET_IDS:
+        return False
+    if asset.path_resolver is not None:
+        fn = asset.path_resolver.split(":", 1)[1]
+        if fn.endswith("_path"):
+            return False
+        if fn.endswith("_root") or fn.endswith("_dir"):
+            return True
+    return any(tok in asset.asset_id for tok in _DIR_ASSET_TOKENS)
+
+
+# ---------------------------------------------------------------------------
+# owner class 分類 + policy
+# ---------------------------------------------------------------------------
+
+def classify_owner(asset: TrustRootAsset) -> OwnerClass:
+    """把資產分到 DEPLOYMENT／MANAGER_STATE／JOB。
+
+    - enforcement plane（`DEPLOYMENT_WRITE`，或 writer 含 INSTALLER 的 bootstrap env）
+      → DEPLOYMENT（owner＝root/deploy）。
+    - control file queue（`CONTROL_FILE_QUEUE`）：登記表現況標為 job-visible（任何同
+      UID 可建檔），但 spec §R4 明定其提交改走 Manager-owned authenticated socket、
+      queue 目錄不再世界可寫——故目標 owner 收斂為 MANAGER_STATE（附 open point）。
+    - Manager-owned 樹的其餘資產 → MANAGER_STATE。
+    - 其餘 job-visible 樹 → JOB。
+    """
+    if asset.ingress_kind is IngressKind.DEPLOYMENT_WRITE:
+        return OwnerClass.DEPLOYMENT
+    if Principal.INSTALLER in asset.writers:
+        # runtime bootstrap env：現況 installer 裸寫、無 mode——目標由 deploy 身分持有。
+        return OwnerClass.DEPLOYMENT
+    if asset.ingress_kind is IngressKind.CONTROL_FILE_QUEUE:
+        return OwnerClass.MANAGER_STATE
+    if asset.tree is TrustTree.MANAGER_OWNED:
+        return OwnerClass.MANAGER_STATE
+    return OwnerClass.JOB
+
+
+def _dir_file_mode(is_dir: bool, owner_bits: int, group_bits: int, other_bits: int) -> int:
+    """組出 mode；owner/group/other 各給 rwx 位（0-7）。dir 才有 x 意義。"""
+    return (owner_bits << 6) | (group_bits << 3) | other_bits
+
+
+def _mask_write(bits: int) -> int:
+    """移除 write 位（用於確保 group/other 永不可寫）。"""
+    return bits & ~0o2 & 0o7
+
+
+def build_entry(asset: TrustRootAsset, scheme: UidScheme) -> PermissionEntry:
+    """對單一資產機械產生目標權限。純函式、無 IO。"""
+    owner_class = classify_owner(asset)
+    is_dir = infer_is_directory(asset)
+    legacy = tuple(w.value for w in asset.writers)
+
+    # 目標 reader 帳號（去掉 ANY_SAME_UID／未映射者）。
+    reader_accounts = frozenset(
+        a for a in (scheme.resolve(r) for r in asset.readers) if a is not None
+    )
+
+    open_points: list[str] = []
+    acls: list[AclEntry] = []
+    runtime_managed = False
+
+    if owner_class is OwnerClass.DEPLOYMENT:
+        owner = scheme.deploy_account
+        # enforcement plane：owner（root）可寫，全部行程唯讀（spec §R3「全部行程唯讀」）。
+        mode = _dir_file_mode(is_dir, 0o7 if is_dir else 0o6, 0o5 if is_dir else 0o4, 0o5 if is_dir else 0o4)
+        writer_accounts = frozenset({owner})
+        rationale = (
+            "部署身分（root）擁有——enforcement plane（env／hooks），或 durable-state "
+            "樹根（解析鏈即信任根，spec §1）：root 擁有使 headless／svc 皆無法 relink "
+            "整棵樹；對全部 headless 唯讀，現況裸寫／group-writable 於此收斂。"
+        )
+        open_points.append(
+            "部署路徑最終位置待 operator 定（pipx tree 遷到 root/svc-owned 部署路徑；"
+            "bootstrap env／codex hooks 是否移出 operator HOME）。"
+        )
+
+    elif owner_class is OwnerClass.MANAGER_STATE:
+        owner = scheme.durable_state_owner
+        writer_accounts = {owner}
+        # 基準 owner-only（dir 0700／file 0600）；跨帳號讀取一律走精確 ACL（唯讀）。
+        mode = _dir_file_mode(is_dir, 0o7 if is_dir else 0o6, 0, 0)
+        for racct in sorted(reader_accounts):
+            if racct == owner:
+                continue
+            acls.append(AclEntry(racct, "rX" if is_dir else "r"))
+        rationale = (
+            "Manager-owned durable state：owner＝durable_state_owner，headless 零寫入；"
+            "跨帳號讀取以 per-account 唯讀 ACL 精確授予（不開 group/other 寫入位）。"
+        )
+        # control file queue 現況未認證、任何同 UID 可寫——目標改由 Manager 持有、
+        # 提交改走 R7 authenticated socket（spec §R4）。
+        if asset.ingress_kind is IngressKind.CONTROL_FILE_QUEUE:
+            rationale += " 提交通道 Phase 2 改為 Manager-owned socket（R7），queue 目錄不再世界可寫。"
+            open_points.append(
+                "control queue：確認 operator 提交改走 authenticated socket 後，"
+                "requests/ 目錄可收斂為 owner-only（本表已如此產生）。"
+            )
+        writer_accounts = frozenset(writer_accounts)
+
+    else:  # JOB
+        job_writers = frozenset(
+            a
+            for a in (
+                scheme.resolve(w)
+                for w in asset.writers
+                if w in HEADLESS_PERSONAS or w is Principal.HEADLESS_HOOK
+            )
+            if a is not None
+        )
+        trusted_owner = scheme.durable_state_owner
+
+        if asset.ingress_kind is IngressKind.INTERPROCESS:
+            # spool：trusted consumer 擁有並讀＋unlink，untrusted producer 只准 append。
+            owner = trusted_owner
+            mode = _dir_file_mode(is_dir, 0o7 if is_dir else 0o6, 0, 0)
+            for pacct in sorted(job_writers):
+                acls.append(AclEntry(pacct, "wx" if is_dir else "w"))
+            writer_accounts = frozenset({owner} | job_writers)
+            rationale = (
+                "job-visible spool：trusted consumer 擁有（讀＋消費），untrusted "
+                "producer 僅以 ACL 授予 write（append），不得讀他人。"
+            )
+        elif len(job_writers) > 1:
+            # 多 job persona 共享容器（worktree pool）：不得做成共寫目錄（會破 R2）。
+            # 容器由 Manager 擁有，per-job 子目錄在 spawn 時逐案 chown 給該 job 帳號。
+            owner = trusted_owner
+            runtime_managed = True
+            is_dir = True  # 多 persona 容器一律視為目錄（per-job 子物件容器）
+            mode = _dir_file_mode(True, 0o7, 0, 0o1)  # 0701：others 僅 traverse 進自己被 chown 的子目錄
+            writer_accounts = frozenset({owner})  # 容器層僅 Manager 建子目錄
+            rationale = (
+                "job-visible 多 persona 容器：Manager 擁有容器，per-job worktree 於 "
+                "spawn 時由降權啟動器 chown 給該 job 帳號——R2 在**子目錄粒度**強制"
+                "（reviewer 與 builder 互不可寫）。容器層零 group/other 寫入。"
+            )
+            open_points.append(
+                f"{asset.asset_id}：per-job 子目錄 chown 由 Phase 2 降權啟動器負責；"
+                "本表只定容器層權限。"
+            )
+        else:
+            # 單一 job writer：owner＝該 job 帳號，Manager 以唯讀 ACL 讀取產出（D2 走 git）。
+            owner = next(iter(job_writers), trusted_owner)
+            mode = _dir_file_mode(is_dir, 0o7 if is_dir else 0o6, 0, 0)
+            for racct in sorted(reader_accounts):
+                if racct == owner:
+                    continue
+                acls.append(AclEntry(racct, "rX" if is_dir else "r"))
+            writer_accounts = frozenset({owner})
+            rationale = (
+                "job-visible 單一 writer：owner＝對應 job 帳號可寫；trusted reader "
+                "（Manager）以唯讀 ACL 讀取（交換面沿用 D2 git 讀）。"
+            )
+
+    # 安全網：group/other 一律不得帶 write 位（spec §R2「group 寫入權 MUST 移除」）。
+    group_bits = _mask_write((mode >> 3) & 0o7)
+    other_bits = _mask_write(mode & 0o7)
+    mode = (mode & 0o700) | (group_bits << 3) | other_bits
+
+    return PermissionEntry(
+        asset_id=asset.asset_id,
+        tier=asset.tier.name,
+        tree=asset.tree.value,
+        owner_class=owner_class,
+        owner=owner,
+        group=scheme.group_of(owner),
+        mode=mode,
+        is_directory=is_dir,
+        writer_accounts=writer_accounts,
+        reader_accounts=reader_accounts,
+        acls=tuple(acls),
+        runtime_managed=runtime_managed,
+        legacy_writers=legacy,
+        rationale=rationale,
+        open_points=tuple(open_points),
+    )
+
+
+# ---------------------------------------------------------------------------
+# 產生器入口
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class PermissionPlan:
+    """完整權限計畫（登記表全項）。"""
+
+    scheme_id: str
+    entries: tuple[PermissionEntry, ...]
+
+    def by_id(self, asset_id: str) -> PermissionEntry:
+        for e in self.entries:
+            if e.asset_id == asset_id:
+                return e
+        raise KeyError(asset_id)
+
+    def all_writable_accounts(self, entry: PermissionEntry) -> frozenset[str]:
+        """entry 上所有實際可寫的帳號（owner＋ACL 授寫者）。"""
+        accts = set(entry.writer_accounts)
+        for acl in entry.acls:
+            if acl.writable:
+                accts.add(acl.account)
+        return frozenset(accts)
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "scheme_id": self.scheme_id,
+            "asset_count": len(self.entries),
+            "entries": [e.to_dict() for e in self.entries],
+        }
+
+
+def generate_plan(
+    scheme: UidScheme,
+    assets: tuple[TrustRootAsset, ...] = registry.ASSET_REGISTRY,
+) -> PermissionPlan:
+    """對登記表每一項機械產生權限，回傳完整計畫（涵蓋無遺漏）。"""
+    entries = tuple(build_entry(a, scheme) for a in assets)
+    return PermissionPlan(scheme_id=scheme.scheme_id, entries=entries)
+
+
+def _placeholder_path(entry: PermissionEntry) -> str:
+    """未提供真實路徑時的清楚標記 placeholder。"""
+    return f"<PATH:{entry.asset_id}>"
+
+
+def plan_to_commands(
+    plan: PermissionPlan,
+    path_of: Mapping[str, str] | None = None,
+) -> list[str]:
+    """把計畫轉成 runbook 可引用的命令序列（**只產生字串，絕不執行**）。
+
+    `path_of`：asset_id→真實路徑字串；未提供者以 placeholder 呈現，供 runbook 以
+    shell 變數替換。輸出含分節註解，方便 operator 對照登記表逐項核可。
+    """
+    lines: list[str] = [
+        f"# trust-root Phase 2b 權限套用命令（scheme={plan.scheme_id}）",
+        "# 由 permgen 機械產生；operator 逐項 review 後手動 sudo 執行。",
+        "# 未提供真實路徑者以 <PATH:asset_id> placeholder 呈現。",
+    ]
+    for e in plan.entries:
+        path = (path_of or {}).get(e.asset_id) or _placeholder_path(e)
+        lines.append("")
+        lines.append(f"# [{e.tier}] {e.asset_id} ({e.owner_class.value}) — {e.rationale}")
+        if e.runtime_managed:
+            lines.append("#   注意：per-child owner 由降權啟動器逐案 chown（本節僅容器層）。")
+        for op in e.open_points:
+            lines.append(f"#   未決：{op}")
+        for cmd in e.commands(path):
+            lines.append(cmd)
+    return lines

--- a/tests/test_trust_root_permgen_p2a.py
+++ b/tests/test_trust_root_permgen_p2a.py
@@ -1,0 +1,253 @@
+"""Phase 2a（權限產生器）：涵蓋等式、二分/三分不變式、非執行保證。
+
+驗收（對應 task 產出 1 的等式測試）：
+- 產生器涵蓋登記表每一項、無遺漏；
+- 二分與三分 config 都能產出一致（滿足同一組不變式）的權限集合；
+- builder（及三分下全部 headless）對 Manager-owned／deployment 樹零寫入；
+- 只產生命令字串、絕不執行任何 root 操作。
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from paulsha_cortex.trust_root import permgen
+from paulsha_cortex.trust_root.permgen import (
+    THREE_WAY_SCHEME,
+    TWO_WAY_SCHEME,
+    OwnerClass,
+    PermissionPlan,
+    generate_plan,
+)
+from paulsha_cortex.trust_root.registry import ASSET_REGISTRY, Principal
+
+ALL_SCHEMES = [TWO_WAY_SCHEME, THREE_WAY_SCHEME]
+
+
+def _plan(scheme) -> PermissionPlan:
+    return generate_plan(scheme)
+
+
+# ---------------------------------------------------------------------------
+# 涵蓋：登記表每一項、無遺漏
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
+def test_plan_covers_every_asset_exactly_once(scheme) -> None:
+    plan = _plan(scheme)
+    plan_ids = [e.asset_id for e in plan.entries]
+    registry_ids = [a.asset_id for a in ASSET_REGISTRY]
+    assert plan_ids == registry_ids, "順序與內容必須逐項對齊登記表"
+    assert len(plan_ids) == len(set(plan_ids)), "無重複"
+    assert len(plan.entries) == len(ASSET_REGISTRY), "無遺漏"
+
+
+@pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
+def test_every_entry_fully_populated(scheme) -> None:
+    plan = _plan(scheme)
+    for e in plan.entries:
+        assert e.owner, e.asset_id
+        assert e.group, e.asset_id
+        assert 0 <= e.mode <= 0o777, e.asset_id
+        assert e.owner_class in OwnerClass, e.asset_id
+        assert e.writer_accounts, e.asset_id  # 至少 owner 可寫
+        assert e.rationale, e.asset_id
+
+
+# ---------------------------------------------------------------------------
+# 核心不變式（兩個 scheme 都成立）
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
+def test_builder_never_writes_manager_owned_or_deployment(scheme) -> None:
+    """spec §R2：builder 對 Manager-owned／deployment 樹零寫入（兩 scheme 皆然）。"""
+    builder = scheme.resolve(Principal.BUILDER)
+    plan = _plan(scheme)
+    for e in plan.entries:
+        if e.owner_class in (OwnerClass.MANAGER_STATE, OwnerClass.DEPLOYMENT):
+            writable = plan.all_writable_accounts(e)
+            assert builder not in writable, (scheme.scheme_id, e.asset_id, sorted(writable))
+
+
+@pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
+def test_reviewer_and_builder_are_different_accounts(scheme) -> None:
+    """spec §R2 硬性要求：reviewer 與 builder 互不可寫 → 必為不同帳號。"""
+    assert scheme.resolve(Principal.REVIEWER) != scheme.resolve(Principal.BUILDER)
+
+
+@pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
+def test_group_and_other_never_writable(scheme) -> None:
+    """spec §R2：現存 group-writable 現況必須收斂——group/other 一律無 write 位。"""
+    plan = _plan(scheme)
+    for e in plan.entries:
+        assert not (e.mode & 0o020), (e.asset_id, e.mode_str)  # group w
+        assert not (e.mode & 0o002), (e.asset_id, e.mode_str)  # other w
+
+
+@pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
+def test_manager_owned_acls_are_read_only(scheme) -> None:
+    """Manager-owned/deployment 上的 ACL 只能是唯讀（跨帳號讀），永不授寫。"""
+    plan = _plan(scheme)
+    for e in plan.entries:
+        if e.owner_class in (OwnerClass.MANAGER_STATE, OwnerClass.DEPLOYMENT):
+            for acl in e.acls:
+                assert not acl.writable, (e.asset_id, acl.account, acl.perms)
+
+
+@pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
+def test_review_verdict_shortest_attack_path_closed(scheme) -> None:
+    """§3 最短攻擊路徑：builder 不得寫 reviewer 的 verdict 檔（兩 scheme 皆然）。"""
+    plan = _plan(scheme)
+    e = plan.by_id("review-verdict")
+    builder = scheme.resolve(Principal.BUILDER)
+    assert builder not in plan.all_writable_accounts(e)
+    # verdict owner 必為 reviewer 所在帳號（reviewer 產出、builder 攻不進）。
+    assert e.owner == scheme.resolve(Principal.REVIEWER)
+
+
+@pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
+def test_control_queue_headless_not_writable(scheme) -> None:
+    """spec §R4：control queue 收斂為 Manager-owned，headless 不可寫。"""
+    plan = _plan(scheme)
+    e = plan.by_id("control-request-queue")
+    assert e.owner_class is OwnerClass.MANAGER_STATE
+    assert scheme.resolve(Principal.BUILDER) not in plan.all_writable_accounts(e)
+    assert any("socket" in op for op in e.open_points), "須標記提交改走 socket 的未決點"
+
+
+@pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
+def test_worktree_pool_enforces_r2_at_subdir(scheme) -> None:
+    """多 persona 容器：不得做成共寫目錄；per-job chown 由 runtime 負責。"""
+    plan = _plan(scheme)
+    e = plan.by_id("dispatch-worktree-pool")
+    assert e.runtime_managed is True
+    assert e.is_directory is True
+    # 容器層只有 owner 可寫（避免 reviewer/builder 互寫破 R2）。
+    assert plan.all_writable_accounts(e) == {e.owner}
+    assert scheme.resolve(Principal.BUILDER) not in {e.owner} or e.owner == scheme.durable_state_owner
+
+
+@pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
+def test_spool_producer_gets_write_via_acl_only(scheme) -> None:
+    """spool：builder（producer）以 ACL 取得 write，且非 owner（trusted consumer 擁有）。"""
+    plan = _plan(scheme)
+    e = plan.by_id("monitor-event-spool")
+    builder = scheme.resolve(Principal.BUILDER)
+    assert e.owner == scheme.durable_state_owner
+    assert e.owner != builder
+    acl_writers = {a.account for a in e.acls if a.writable}
+    assert builder in acl_writers
+
+
+# ---------------------------------------------------------------------------
+# 二分 vs 三分：結構一致 + 三分嚴格收緊（保留彈性有實效）
+# ---------------------------------------------------------------------------
+
+def test_owner_class_is_scheme_independent() -> None:
+    """兩 scheme 對每個資產分到相同 owner_class——分類只依登記表，不依 UID 方案。"""
+    two = {e.asset_id: e.owner_class for e in _plan(TWO_WAY_SCHEME).entries}
+    three = {e.asset_id: e.owner_class for e in _plan(THREE_WAY_SCHEME).entries}
+    assert two == three
+
+
+def test_two_way_merges_reviewer_planner_into_durable_owner() -> None:
+    """二分（現階段）：reviewer＋planner 併入 durable_state_owner（可寫 durable state
+    的既知殘餘），這正是三分要移除的對象。"""
+    s = TWO_WAY_SCHEME
+    assert s.resolve(Principal.REVIEWER) == s.durable_state_owner
+    assert s.resolve(Principal.PLANNER) == s.durable_state_owner
+
+
+def test_three_way_splits_manager_out_without_code_change() -> None:
+    """三分：Manager（durable_state_owner）與 reviewer/planner 帳號分離——僅換
+    config、未改任何程式碼即達成 spec 風險段的『待驗證後再細分』。"""
+    s = THREE_WAY_SCHEME
+    rp = s.resolve(Principal.REVIEWER)
+    assert s.resolve(Principal.PLANNER) == rp
+    assert rp != s.durable_state_owner
+    assert s.resolve(Principal.MANAGER) == s.durable_state_owner
+
+
+def test_three_way_strictly_tightens_manager_owned() -> None:
+    """三分嚴格收緊：**沒有任何 headless 帳號**（含 reviewer/planner）可寫
+    Manager-owned／deployment——這是保留彈性的實質收益。"""
+    plan = _plan(THREE_WAY_SCHEME)
+    headless = THREE_WAY_SCHEME.headless_accounts()
+    for e in plan.entries:
+        if e.owner_class in (OwnerClass.MANAGER_STATE, OwnerClass.DEPLOYMENT):
+            assert not (plan.all_writable_accounts(e) & headless), (e.asset_id,)
+
+
+def test_custom_scheme_needs_no_code_change() -> None:
+    """資料結構足以表達任意分法：臨時造一個把 planner 也獨立的『四分』方案，
+    產生器不改一行即可運作。"""
+    four_way = permgen.UidScheme(
+        scheme_id="four-way",
+        account_of={
+            Principal.MANAGER: "cortex-manager",
+            Principal.MONITOR: "cortex-manager",
+            Principal.REVIEWER: "cortex-reviewer",
+            Principal.PLANNER: "cortex-planner",
+            Principal.BUILDER: "cortex-builder",
+            Principal.HEADLESS_HOOK: "cortex-builder",
+            Principal.OPERATOR: "operator",
+        },
+        durable_state_owner="cortex-manager",
+    )
+    plan = generate_plan(four_way)
+    assert len(plan.entries) == len(ASSET_REGISTRY)
+    # 四分下 reviewer 與 planner 也互為不同帳號。
+    assert four_way.resolve(Principal.REVIEWER) != four_way.resolve(Principal.PLANNER)
+
+
+# ---------------------------------------------------------------------------
+# 決定性 + 非執行保證
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
+def test_generation_is_deterministic(scheme) -> None:
+    assert _plan(scheme).to_dict() == _plan(scheme).to_dict()
+
+
+@pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
+def test_plan_is_json_serializable(scheme) -> None:
+    blob = json.dumps(_plan(scheme).to_dict(), ensure_ascii=False)
+    assert json.loads(blob)["asset_count"] == len(ASSET_REGISTRY)
+
+
+@pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
+def test_commands_are_strings_only_and_never_execute(scheme) -> None:
+    """產出只能是 chown／chmod／setfacl 字串——絕不執行任何 root 操作。"""
+    plan = _plan(scheme)
+    lines = permgen.plan_to_commands(plan)
+    allowed = ("chown ", "chmod ", "setfacl ")
+    for line in lines:
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        assert stripped.startswith(allowed), stripped
+    # 每個資產都要在命令輸出裡出現（以 placeholder 或註解形式）。
+    joined = "\n".join(lines)
+    for a in ASSET_REGISTRY:
+        assert a.asset_id in joined, a.asset_id
+
+
+def test_commands_honour_supplied_paths() -> None:
+    """runbook 帶入真實路徑時，命令引用該路徑；未帶入者以 placeholder。"""
+    plan = _plan(TWO_WAY_SCHEME)
+    lines = permgen.plan_to_commands(plan, path_of={"jobs-registry": "/srv/agents/coordinator/jobs.json"})
+    joined = "\n".join(lines)
+    assert "/srv/agents/coordinator/jobs.json" in joined
+    assert "<PATH:review-verdict>" in joined  # 未帶入者仍是 placeholder
+
+
+def test_permgen_module_does_not_import_subprocess() -> None:
+    """靜態保證：permgen 不觸及任何執行面（無 subprocess/os.system）。"""
+    import inspect
+
+    src = inspect.getsource(permgen)
+    assert "subprocess" not in src
+    assert "os.system" not in src
+    assert "os.chown" not in src
+    assert "os.chmod" not in src


### PR DESCRIPTION
## 摘要

實作 trust-root（R0.5 D6）**Phase 2a 權限產生器**（程式碼，用 Phase 1 登記表機械產生目錄 owner/mode 清單）＋草擬 **Phase 2b root 設定 runbook**（給 operator 手動 sudo 執行）。**純程式碼＋文件，不需 root、不執行任何 root 操作。** Refs #584

依 spec `trust-root-isolation-spec.md` §R10 Phase 2 第 2 步「目錄 owner/mode 由 R1 登記表產生（不手寫）」與 operator 0816 裁決（路線 A、Manager 專屬 UID、現階段先二分但保留二往三分彈性、Manager 落 system-level unit、舊 state legacy-import、降級逐案核可）。

## 產出 1：權限產生器 `paulsha_cortex/trust_root/permgen.py`

- 吃 `ASSET_REGISTRY` ＋參數化的 `UidScheme`（persona→OS 帳號映射），機械產生登記表**每一項**的目標 `owner:group mode` ＋ per-account POSIX ACL。
- 輸出 (a) 結構化計畫（可轉 JSON）；(b) runbook 可引用的 `chown`/`chmod`/`setfacl` **命令字串——只產生字串、絕不執行**（靜態測試釘住無 `subprocess`/`os.system`/`os.chown`/`os.chmod`）。
- **二分/三分參數化保留彈性**：`TWO_WAY_SCHEME`（`cortex-builder`／`cortex-svc`，後者為 durable state owner，Manager＋reviewer＋planner＋monitor 共用）為預設；同一資料結構表達 `THREE_WAY_SCHEME`（把 svc 拆成 `cortex-manager`＋`cortex-reviewer-planner`）**不改一行程式碼**。測試證明三分**嚴格收緊**——二分下 reviewer/planner(=svc) 仍可寫 durable state（既知殘餘），三分下**任何 headless 帳號皆零寫入** Manager-owned/deployment。builder 於兩方案皆零寫入 Manager-owned（spec §R2 核心不變式）。
- on-demand 入口 `python -m paulsha_cortex.trust_root permissions [two-way|three-way] [--commands]`。

## 產出 2：`docs/superpowers/runbooks/trust-root-phase2b-setup.md`（草稿）

8 段：前置檢查/baseline、建 UID（二分）、路徑分樹＋legacy-import（**不 chown 舊 state**）、Manager 遷 root-owned＋system-level unit（含 `NoNewPrivileges`/`ProtectSystem=strict`/`ReadWritePaths`/`CapabilityBoundingSet` 等切實列出的加固、`EnvironmentFile` 去 `-` 改 fail-closed）、降權啟動器（關 FD、不傳 gh token）、Manager 升級（受控 sudo 替換而非裸 chown）、切換驗收（Phase 1 自檢轉綠＋R9 四族含 negative control）、回滾。每步標明 **operator 手動 sudo vs 驗證命令**；權限命令一律引用產生器輸出（單一真相）。

標記 7 個**未決點**（降權機制最終形態、目標路徑位置、legacy-import 格式、Manager 部署路徑、加固白名單、是否 codify 子命令、R9 完整矩陣）與 **WSL2 三個最高風險步驟**（降權機制、system unit 持久性、加固誤擋）。

## 範圍紀律

本 PR **只交付程式碼與文件**：不建 UID、不 chown、不動 systemd/pipx/`~/.agents`。runbook 是草稿供 operator review。

## 測試

- 新增 `tests/test_trust_root_permgen_p2a.py`（33 測試）：涵蓋等式（登記表每項無遺漏）、二分/三分不變式、決定性、非執行保證。
- 全套 `python3 -m pytest -q`：**3108 passed**。
- `policy_check`（帶 PR 上下文）：pass 24 / fail 0。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E7w9kaUxAzCCEk7piD5hfK