### PR TITLE
docs(workstreams): 桶C slice 迴圈家族 dogfooding todos

### DIFF
--- a/.cortex/work-items.yaml
+++ b/.cortex/work-items.yaml
@@ -694,3 +694,27 @@ work_items:
       - kind: path
         ref: 'docs/superpowers/workstreams/fix-degraded-retention-collision/todo.md'
     excludes: []
+  fix-verification-contract-hash-overwrite:
+    title: 'fix-verification-contract-hash-overwrite'
+    links:
+      - kind: path
+        ref: 'docs/superpowers/workstreams/fix-verification-contract-hash-overwrite/todo.md'
+      - kind: github_issue
+        ref: 'hamanpaul/paulsha-cortex#501'
+    excludes: []
+  fix-superseded-terminal-replay:
+    title: 'fix-superseded-terminal-replay'
+    links:
+      - kind: path
+        ref: 'docs/superpowers/workstreams/fix-superseded-terminal-replay/todo.md'
+      - kind: github_issue
+        ref: 'hamanpaul/paulsha-cortex#497'
+    excludes: []
+  fix-dirty-recheck-idempotency:
+    title: 'fix-dirty-recheck-idempotency'
+    links:
+      - kind: path
+        ref: 'docs/superpowers/workstreams/fix-dirty-recheck-idempotency/todo.md'
+      - kind: github_issue
+        ref: 'hamanpaul/paulsha-cortex#496'
+    excludes: []

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,14 @@
   只做 reader ＋ retention；#591 其餘項（`satisfies` projection、雙 legacy phase 對映
   收斂、第二呼叫點儀器化）屬 R2。詳見 `changelog.d/shadow-telemetry-reader.md`。
   新增 `tests/test_coverage_shadow_reader_591.py`（27 測試）。
+- **桶C「slice 迴圈家族」workstream 佈線（`#501`／`#497`／`#496`）**——新增三份 todo
+  來源（`fix-verification-contract-hash-overwrite`／`fix-superseded-terminal-replay`／
+  `fix-dirty-recheck-idempotency`）並在 `.cortex/work-items.yaml` 註冊對應 work item，
+  讓 cortex 可自行受理這三張 issue。三張已對 main `48b0205` 逐條複查，缺陷全部仍成立；
+  每份 todo 含現況查核段（精確檔案行號）、有界 scope（明列「主體是 X 不是 Y」與禁止
+  越界項）與可測驗收條件。三張刻意不合併：`#497` 是 terminal job 重播來源、`#496` 是
+  dirty recheck 迴圈、`#501` 是兩者共用的 `_apply_verification_result()` 污染原語。
+  純佈線變更，不改動任何執行路徑程式碼。詳見 `changelog.d/bucket-c-workstream-todos.md`。
 - **R0.5 D6 / trust-root 隔離 Phase 2a（權限產生器）＋ Phase 2b root 設定 runbook
   （純程式碼＋文件、不需 root）**——新增 `paulsha_cortex/trust_root/permgen.py`：吃
   R1 `ASSET_REGISTRY` ＋參數化的 `UidScheme`（persona→OS 帳號映射），機械產生登記表

--- a/changelog.d/bucket-c-workstream-todos.md
+++ b/changelog.d/bucket-c-workstream-todos.md
@@ -1,0 +1,29 @@
+# bucket-c-workstream-todos
+
+- **桶C「slice 迴圈家族」workstream 佈線（`#501`／`#497`／`#496`）**——新增三份 todo
+  來源並在 `.cortex/work-items.yaml` 註冊對應 work item，讓 cortex 可自行受理這三張
+  issue（dogfooding 前置；intake 由 operator 逐案執行）。三張已對 main `48b0205`
+  逐條複查，缺陷**全部仍成立**，todo 內含現況查核段與精確檔案行號：
+  - `fix-verification-contract-hash-overwrite`（`#501`）：`_apply_verification_result()`
+    把 verification **證據** payload hash 經 `update_slice(verification_hash=...)`
+    寫進 `slice_row["verification"]["hash"]`，而該欄位是
+    `_pinned_input_mismatches()` 賴以比對的 pinned **contract** hash——verification
+    一成功、foreign-review 又未即時綁上 reviewer，下一 tick 必然自舉
+    `pinned-input-mismatch: verification-hash`。全 repo 僅
+    `manager.py:406` 一個呼叫點會這樣寫，修復邊界極窄。現有 slice
+    `add-cortex-version-flag-build` 正卡在此現場。
+  - `fix-superseded-terminal-replay`（`#497`）：`complete_tick` 全量列舉
+    `registry.list_jobs()`，唯一冪等短路是 handoff manifest 的**單槽** job_id，
+    同 slice 的其餘歷史 terminal job 每輪重跑；unbound job 更會先以 branch HEAD
+    解出 candidate 並寫 `missing-slice-proof`，撞爆 bound job 的不可變證據位址。
+    `#383` 只修了 fanout 側（`_manifest_still_blocks_fanout`），completion 側至今
+    沒有 supersession 概念，job schema 也無 consumed／attempt 欄位——daemon 正常
+    重啟即可讓已 `completed/passed` 的 slice 被回寫並反鎖下游。
+  - `fix-dirty-recheck-idempotency`（`#496`）：`candidate-worktree-dirty` 的
+    recheck 迴圈（設計意圖，保留）在結果完全未變時仍無條件套用，每 tick 各記
+    一筆 `verification-failed` action ＋ evidence_history，實測 116 秒 33 筆。
+    既有測試只覆蓋「結果有變」，缺「結果未變不得寫入」的斷言。
+- 三張刻意**不合併**：`#497` 是重播來源、`#496` 是 recheck 迴圈、`#501` 是兩者共用
+  的污染原語，各自獨立可驗收。每份 todo 的 scope 段明列「本 work item 的主體是 X
+  不是 Y」與禁止越界項，供 headless planner／builder 定界。
+- 純佈線變更：不改動任何執行路徑程式碼（全套 pytest 3108 passed，與 main 基線一致）。

--- a/docs/superpowers/workstreams/fix-dirty-recheck-idempotency/todo.md
+++ b/docs/superpowers/workstreams/fix-dirty-recheck-idempotency/todo.md
@@ -1,0 +1,102 @@
+---
+status: accepted
+work_item: fix-dirty-recheck-idempotency
+---
+
+# fix-dirty-recheck-idempotency Todo
+
+`#496`：slice 因 `candidate-worktree-dirty` 掛上 `needs_human` 後，manager 每個
+tick 都會重跑同一份 verification，並**無條件**寫入一筆新的 `verification-failed`
+action ＋ 一筆 evidence_history——即使 worktree、candidate、結果、證據位址
+四者全部沒變。實測 5 秒 timer 下約 2 分鐘累積 **33 筆**重複紀錄，`jobs.json`
+在等待 operator 期間無界成長。
+
+## 現況查核（0816，對 main `48b0205`）
+
+**缺陷仍完整成立。** 兩段程式碼構成迴圈：
+
+1. `manager.py:1815-1853` —— `complete_tick` 開頭掃 `list_slices()`，對
+   `state == "needs_human"` 且 current evidence summary 落在
+   `{"candidate-worktree-dirty", "candidate-worktree-dirty-after-verification"}`
+   的 slice **刻意**重跑 `verification_runner`。這個 recheck 行為本身是設計意圖
+   （讓 operator 清乾淨 worktree 後能自動脫困），**不是缺陷、不要移除**。
+2. `manager.py:1845-1851` —— 重跑結果經 `_validate_result_evidence()` 後，
+   **無條件**呼叫 `_apply_verification_result(registry, slice_item["slice_id"], validated_ev)`。
+   沒有任何「與現況比對」的閘門。
+3. `manager.py:386-409` —— `_apply_verification_result()` 一律
+   `registry.record_action(...)`（`:395`）＋ `registry.update_slice(...)`（`:404`），
+   本身不具冪等性，也不該由它自己承擔冪等責任（它是「套用一個真實轉換」的原語）。
+
+因此「沒變化」與「有變化」走完全相同的寫入路徑，每 tick 各記一筆。
+
+**放大效應**：`_apply_verification_result()` 同時會把證據 hash 寫進
+`slice_row["verification"]["hash"]`（見 `#501`），所以這個迴圈**每 tick 還會
+重覆污染 contract hash**。`#501` 0812-18:05 留言即由此現場觸發。本張不修那條，
+但實作者需知道兩者共用同一個原語。
+
+### 既有測試覆蓋
+
+`tests/test_pre_candidate_recovery.py:218`
+`test_candidate_worktree_dirty_reevaluation_on_tick` **只覆蓋「結果有變」**
+（dirty → verified，candidate 換新）並斷言轉換發生。**沒有任何測試斷言
+「結果沒變時不得寫入」**——這正是本張要補的缺口。修復不得讓這個既有測試轉紅。
+
+## Scope（明確邊界）
+
+**本 work item 的主體是「recheck 結果未變時的寫入冪等」，不是「recheck 該不該存在」，
+也不是「terminal job 重播治理」。**
+
+- 要做：在套用 recheck 結果**之前**，與當前狀態比對——至少涵蓋 verification
+  evidence hash、`state`、`gate_state`、summary、candidate、
+  `current_evidence_refs` 六者。完全相同就直接 return，**不 `record_action`、
+  不 append `evidence_history`、不 `update_slice`**。
+- 要做：worktree 真的變乾淨、verification 結果真的改變時，**恰好記錄一次**
+  真實轉換（不得因為新增比對而漏記，也不得記兩次）。
+- 要做：保持 fail-closed——證據不可讀、schema 不合法、內容不一致時，
+  維持現行的保守行為，**不得**因為「比對不出差異」就把壞證據當成「沒變化」放行。
+- 可做：若確有觀測需求，另立 `last_rechecked_at` 之類的欄位承載「我有在輪詢」
+  這個事實，**與 lifecycle history 分離**（`#496` 建議驗收最後一條）。
+  這是 optional，不做也可驗收。
+- **不要做**：移除或停用 `manager.py:1815-1853` 的 dirty recheck。它是 operator
+  清理後的自動脫困路徑，移掉會製造新的人工卡點。
+- **不要做**：把冪等閘門塞進 `_apply_verification_result()` 內部去「一次修好所有
+  呼叫點」。該函式另有五個呼叫點（`manager.py:1851`、`1960`、`2046`、`2057`，
+  以及 `1623`／`1638` 的 slice action 路徑），它們的語意是「一個真實轉換剛發生」，
+  在原語層加靜默 skip 會改變那些路徑的行為並可能遮蔽真實轉換。
+  **閘門應加在 recheck 呼叫點（本張現場）**；若實作者評估後仍主張下沉到原語層，
+  必須為上述每個呼叫點補測試證明語意不變。
+- **不要做**：修 `#501` 的 contract／evidence hash 欄位混用、或 `#497` 的
+  superseded terminal job 重播。本張驗收**不得依賴**那兩張是否已落地。
+
+## Tasks
+
+- [ ] **冪等閘門**：dirty recheck 套用前與當前 verification hash／`state`／
+      `gate_state`／summary／candidate／evidence refs 比對；一致即 no-op 返回
+- [ ] **真實轉換恰好一次**：worktree 轉乾淨後，脫離 dirty 狀態只產生**一筆**
+      action ＋ 一筆 evidence_history
+- [ ] **fail-closed 保留**：證據不可讀／schema 不合法／與 registry 現況不一致時，
+      不得被冪等閘門誤判為「沒變化」而靜默略過
+- [ ] **（optional）觀測分離**：如需呈現「仍在輪詢」，以獨立欄位承載，
+      不寫進 lifecycle action／evidence_history
+- [ ] **測試**：
+      - 對未變的 dirty worktree 連續呼叫 `complete_tick` N 次（N ≥ 5），
+        斷言 action 數與 evidence_history 數**完全不變**（`#496` 建議驗收第 5 條）
+      - tick 之間把 worktree 清乾淨，斷言**恰好一次**脫離 dirty 的轉換
+        （`#496` 建議驗收第 6 條）
+      - 既有 `test_candidate_worktree_dirty_reevaluation_on_tick` 維持綠燈
+      - 證據檔被破壞／不可讀時仍 fail-closed，不因冪等閘門而放行
+
+## 現場紀錄（供實作者參考）
+
+- issue `#496` 首則：slice `task-3-private-repo-and-forbidden-documentation-scan-build`、
+  candidate `0c9faff9…`，5 秒 timer 下
+  `2026-08-12T14:12:06.381861Z` → `14:14:02.820132Z` 約 **116 秒累積 33 筆**
+  `verification-failed` action ＋ 33 筆 evidence_history，worktree／candidate／
+  結果／證據位址全程未變
+- issue 首則的 root cause 段已精準點出
+  「`_apply_verification_result` always record_action and update_slice.
+  There is no comparison against the current verification hash, status, summary,
+  candidate, or refs」——0816 複查確認這段描述與 main 現況逐字相符
+- 本張與 `#501`／`#497` 同屬「桶C slice 迴圈家族」。三者的關係：
+  `#497` 是重播**來源**、`#496` 是 recheck **迴圈**、`#501` 是兩者共用的
+  **污染原語**。三張各自獨立可驗收，不得合併修

--- a/docs/superpowers/workstreams/fix-superseded-terminal-replay/todo.md
+++ b/docs/superpowers/workstreams/fix-superseded-terminal-replay/todo.md
@@ -1,0 +1,134 @@
+---
+status: accepted
+work_item: fix-superseded-terminal-replay
+---
+
+# fix-superseded-terminal-replay Todo
+
+`#497`：**已被取代（superseded／unbound）的 terminal job 會被 `complete_tick`
+反覆重新終局化**，並在「slice_id + candidate SHA」這個決定性證據位址上撞上
+不可變證據寫入器，fail-closed 阻斷本輪 fanout。實測後果包含：復原後不派新
+builder、`completed/passed` 的 slice 被回寫成 `needs_human`、下游 slice 被
+`deps-unsatisfied` 反向鎖死。
+
+## 現況查核（0816，對 main `48b0205`）
+
+**缺陷仍成立。`#383` 只修了 fanout 側，completion 側完全沒有 supersession 概念。**
+
+已落地的部分（不要重做）：
+
+- `manager.py:2194-2215` `_manifest_still_blocks_fanout()`：fanout 放行改與
+  registry 現況對帳，復原成 `pending` 的 slice 不再被殘留 manifest 永久跳過。
+- `manager.py:164-199` `_supersede_handoff_manifest()`：復原動作後替 manifest 補
+  `superseded_at`／`superseded_by`／`superseded_reason` 稽核欄位。
+
+**沒修到的部分（本 work item 的主體）**：
+
+1. `manager.py:1855` —— `complete_tick` 直接 `for snapshot in registry.list_jobs():`
+   **全量列舉**所有 job，對每個 terminal job 嘗試終局化。沒有任何
+   supersession／attempt 過濾。
+2. `manager.py:1879` —— 唯一的冪等短路是
+   `if _existing_manifest_job_id(manifest_path) == job_id: continue`。
+   這是**每 slice 單槽**的記憶：manifest 只記得住**一個** job_id。同一 slice
+   歷史上若有 `-6`／`-8`／`-9` 三個 terminal job，manifest 指向 `-9` 時，
+   `-6`／`-8` 完全不受保護，每輪都重跑。
+3. `manager.py:154-161` —— `_existing_manifest_job_id()` 另外在
+   `gate_status in {"passed","verified"}`、以及
+   `needs_human + verification_evidence_path is None + gate_reason ∈
+   {pinned-input-mismatch, verification-runner-error, verification-state-update-error}`
+   時**主動回 None**（＝放行重播）。證據寫入撞衝突時 `evidence` 留 None，正好落進
+   第二個條件，形成穩定的每 tick 重播迴圈。
+4. `manager.py:226-236` `_slice_for_job()` 在 `builder_job_id != job_id` 時回 None，
+   但**回 None 不等於跳過**：build lane 會掉進 `manager.py:1997-2010` 的
+   `missing-slice-proof` 分支，該分支**照樣寫證據**——且 candidate 由
+   `_candidate_for_evidence()`（`manager.py:285-309`）以 **branch 當前 HEAD**
+   解析。這就是 `#497` 0812-18:05 現場的機制：舊的 unbound job `-8` 先被終局化，
+   用 branch HEAD 解出 `6421bc98…`，把 `missing-slice-proof` 寫進本該屬於
+   bound job `-9` 的證據位址；`-9` 隨後撞
+   `conflicting verification evidence … (content mismatch)`。
+5. `registry.create_job()`（`registry.py:873-900`）的 job schema **沒有任何**
+   consumed／superseded／attempt 欄位，因此 supersession 目前根本無處持久化。
+6. `manager.py:1477-1560` `recover-pre-candidate`：把 slice 撥回 `pending`、
+   `builder_job_id=None`、`candidate=None`，並標記 manifest——但**舊 job row
+   本身完全沒動**，仍是 `list_jobs()` 的合法 terminal 成員。
+7. `verification.py:377-397` `_existing_evidence_result_or_raise()`：同位址內容不同時
+   把原檔 `os.replace` 進 `quarantine/` 後 `raise RuntimeError`。**這一段是對的
+   （不可變證據 fail-closed），不要為了消 symptom 去放寬它。**
+
+## Scope（明確邊界）
+
+**本 work item 的主體是「completion 側的 attempt 身分與 supersession 過濾」，
+不是「證據不可變規則放寬」，也不是「證據位址重設計以外的其他一切」。**
+
+- 要做：terminal job 在被終局化**之前**先判定它是否仍是該 slice 當前 attempt 的
+  綁定 job；不是就跳過——且**必須在「解析 candidate／推導證據位址」之前**跳過，
+  否則就像現況一樣，已經寫壞了才發現。
+- 要做：supersession 需**持久化在 registry**（job row 或 attempt 層），
+  不能只靠 handoff manifest 的單槽 job_id 或檔案系統狀態——`#497` 的
+  0812-19:10 現場證明 daemon 重啟後重播照樣發生。
+- 要做：舊 job 保持**可稽核**（不刪 row、不刪既有證據），只是不再有資格成為
+  當前 attempt 的終局。
+- 可做（若判定必要）：在證據位址中納入 job／attempt 身分，讓「同 slice 同 SHA
+  的多次合法終局觀測」各有位址——這是 `#497` 建議驗收的第 4 條。若採此路，
+  **既有證據路徑必須保持可讀**（completion record 會引用舊位址，
+  見 `manager.py:843` `verification_evidence_path`）。
+- **不要做**：放寬 `write_verification_evidence()` 的不可變性、或把 quarantine
+  改成靜默覆寫。fail-closed 抓到的是真問題，本修復要消除的是「不該發生的
+  第二次寫入」，不是「抓到衝突時的反應」。
+- **不要做**：修 `#501` 的 contract／evidence hash 欄位混用，或 `#496` 的
+  dirty recheck 冪等。本張假設 `#501` 可能尚未落地，因此**驗收不得依賴
+  contract hash 正確性**；若 `#501` 已先行 merge，測試可一併收緊。
+- **不要做**：改動 `_manifest_still_blocks_fanout()`／`dispatch_gate_scan()`
+  的 fanout 語意（`#383` 已定案且有測試）。本張只碰 completion 側。
+- **不要做**：新增自動 retry／自動修復。`needs_human` 在 operator 動作前必須
+  **靜止**（quiescent），這正是驗收條件之一。
+
+## Tasks
+
+- [ ] **attempt 身分持久化**：registry 提供「此 terminal job 已被消費／已被取代」
+      的持久標記（CAS 更新，restart-safe），並在
+      `recover-pre-candidate`／`abandon`／新 attempt 派工時原子地設定
+- [ ] **completion 前置過濾**：`complete_tick`（`manager.py:1855` 起）在**推導
+      candidate 與證據位址之前**先跳過非當前 attempt 的 terminal job；
+      `_slice_for_job()` 回 None 的 build-lane 情境不得再無條件寫
+      `missing-slice-proof` 證據（`manager.py:1997-2010`）
+- [ ] **單槽記憶除役**：不再以 handoff manifest 的單一 `job_id`
+      （`manager.py:1879`／`_existing_manifest_job_id`）作為多 terminal job 的
+      冪等權威；改以持久 attempt 標記為準
+- [ ] **completion 證明穩定性**：已 `completed/passed` 且持有合法 completion record
+      的 slice，其被引用的 verification evidence 位址在 daemon 重啟後不得被任何
+      重播改寫（`#497` 0812-19:10 現場）
+- [ ] **測試**：
+      - terminal dirty builder → `recover-pre-candidate` → tick：舊 job 被跳過、
+        無證據衝突、**恰好**派出一個新 builder
+      - 上述情境的 **daemon restart 變體**：跳過語意跨重啟存活
+      - 同 slice 多 terminal job（`-6`／`-8`／`-9`）：只有當前綁定的 job 被終局化，
+        unbound job 不寫任何證據、不解析 branch HEAD 當 candidate
+      - `completed/passed` slice 在 manager 重啟後連續多 tick：completion record
+        與其引用證據 byte 不變、下游 slice 不被 `deps-unsatisfied` 反向鎖
+      - `needs_human` 靜止性：連續 tick 不新增 action／evidence_history
+        （與 `#496` 的驗收互補，但本張測的是「重播來源」而非「recheck 迴圈」）
+      - 舊證據與舊 job row 仍可稽核讀取（不因修復而遺失歷史）
+
+## 現場紀錄（供實作者參考）
+
+- issue `#497` 首則：Task 3 `recover-pre-candidate` 後首個 tick 未派工，
+  改為重跑舊 terminal builder 並撞 `conflicting verification evidence … (content mismatch)`
+- 0812-14:57 留言：recovery 回 `slice_state: pending` 後 8 秒，terminal reviewer
+  `-2` 被重跑，slice 退回 `needs_human / missing-slice-proof`
+- 0812-16:11 留言：重複 recovery 每次都被同一個 terminal job 打回，
+  「pending 無法存活」——明確要求 consumed／superseded marker CAS
+- 0812-17:25 留言：foreign-review launch 失敗後，約 90 秒累積 **24 筆**
+  evidence_history（本張是重播來源，`#496`／`#501` 是放大器）
+- 0812-18:05 留言：unbound job `-8` 先於 bound job `-9` 被終局化，
+  造成同 candidate `6421bc98…` 證據位址衝突與兩份 quarantine 檔——
+  這則最精確地指出「必須在解析 candidate 之前跳過」
+- 0812-19:10 留言：**daemon 正常重啟**即可讓已 `completed/passed` 的 Task 4
+  被重播回寫成 305-byte 的 `missing-slice-proof`，handoff 被改寫為
+  `completion-record-missing`，Task 5 被 `deps-unsatisfied` 反鎖——
+  證明缺陷不限於 recovery 競態
+- 0812-19:40／21:09 留言：狀態快照內部不一致（`completed/passed` 併
+  `reason=completion-record-missing`）；以及 manager interval 被夾到 3600 秒
+  當 workaround 後，`stat`／`status` 無法收割已存在的 exit sentinel。
+  **後者（sentinel 收割／targeted `complete <job-id>`）屬觀測面 follow-up，
+  不在本張 scope 內**——本張只負責讓重播不再發生

--- a/docs/superpowers/workstreams/fix-verification-contract-hash-overwrite/todo.md
+++ b/docs/superpowers/workstreams/fix-verification-contract-hash-overwrite/todo.md
@@ -1,0 +1,116 @@
+---
+status: accepted
+work_item: fix-verification-contract-hash-overwrite
+---
+
+# fix-verification-contract-hash-overwrite Todo
+
+`#501`：**verification 一旦跑出任何結果，slice 的「pinned contract 身分」就被證據
+身分覆寫掉**——`slice_row["verification"]["hash"]` 這個欄位同時被兩種語意寫入，
+下一 tick 必然自舉出 `pinned-input-mismatch: verification-hash`，即使 spec／plan／
+verification contract 一個 byte 都沒動。
+
+## 現況查核（0816，對 main `48b0205`）
+
+**缺陷仍完整成立，未被 R0／R0.5 任何一批動到。** 三個座標互相咬合：
+
+1. `paulsha_cortex/coordinator/manager.py:404-409` —— `_apply_verification_result()`
+   把**證據 payload 的 canonical hash** 當 `verification_hash` 餵進 `update_slice()`：
+   ```python
+   registry.update_slice(
+       slice_id,
+       verification_hash=evidence["hash"],   # ← 這是 evidence hash，不是 contract hash
+       current_evidence_refs=refs,
+       candidate=payload["candidate"],
+   )
+   ```
+2. `paulsha_cortex/coordinator/registry.py:1305-1306` —— `update_slice()` 把它直接
+   寫進 `slice_row["verification"]["hash"]`。
+3. `paulsha_cortex/coordinator/manager.py:278-281` —— `_pinned_input_mismatches()`
+   把**同一欄位**當成不可變的 pinned contract hash，拿去和
+   `verification.canonical_json_hash(current_meta["verification"])` 比對，不等就
+   `mismatches.append("verification-hash")`。
+
+也就是說：欄位的**唯一合法寫入者**應該只有派工當下的 pin
+（`registry.repin_slice()`，`registry.py:1172`／`create_slice()` `registry.py:1149-1152`，
+由 `autonomy._pin_slice_inputs()` `autonomy.py:742,760` 呼叫），
+而 `update_slice(verification_hash=...)` 這條路徑**全 repo 只有 `manager.py:406`
+一個呼叫點**（已全庫確認），正是缺陷本身。這讓修復邊界異常乾淨。
+
+補充現況：`manager.py:1158` 的 `verification_hash=slice_row["verification"]["hash"]`
+是寫進 **reviewer job row** 的欄位（`create_job`），不是 slice contract 欄位，
+語意正確，**不要動**。
+
+### 為什麼平常看不到
+
+只有在 `_apply_verification_result()` 之後**沒有**成功綁上 reviewer job 時才會爆——
+綁上時 `complete_tick` 的 builder 完成分支會被 `manager.py:1886-1887`
+（`slice_row.get("reviewer_job_id")` → `continue`）跳過，缺陷被遮住。
+`#501` 現場是 foreign-review dispatch 因 tier config-error launch 失敗
+（`manager.py:2064-2082` 的 `_launch_foreign_review` 未 `launched`），遮罩消失，
+下一 tick 立刻自舉 mismatch。
+
+### 活現場
+
+現有 slice `add-cortex-version-flag-build` 正卡在這個 `pinned-input-mismatch`，
+是可直接觀察的活體：`slice.verification.hash` 已是證據 hash，spec frontmatter 的
+contract hash 未變。修完後這個 slice 應該不必改任何 spec／plan bytes 就能脫困。
+
+## Scope（明確邊界）
+
+**本 work item 的主體是「欄位語意分離」，不是「pinned-input 檢查邏輯重寫」，
+也不是「terminal job 重播治理」。**
+
+- 要做：讓 contract 身分與 execution evidence 身分成為**兩個不同欄位**，
+  且證據側寫入**永不觸碰** contract 側。
+- 要做：`update_slice()` 不再提供「用證據 hash 覆寫 contract hash」的能力
+  （移除該參數，或改名為明確的 evidence 欄位；`create_slice`／`repin_slice`
+  的 `verification_hash` 參數維持原樣，那是合法的 pin 入口）。
+- 要做：證據 hash 改存進與 current evidence ref 同層的獨立欄位
+  （建議 `current_verification_evidence_hash`），讓 `manager.py:2096`
+  `_current_verification_ref()` 一類讀取端仍取得到。
+- **不要做**：改 `_pinned_input_mismatches()` 的比對規則、放寬 fail-closed、
+  或為了讓現場過關而略過 `verification-hash` 檢查——那是把體溫計摔了。
+- **不要做**：處理 `#497` 的 superseded terminal job 重播，或 `#496` 的
+  dirty recheck 冪等。那兩張是獨立 work item；本張只負責「就算被重播，
+  contract 身分也不該被寫壞」。
+- **不要做**：改動 `manager.py:1158` 的 reviewer job `verification_hash` 欄位、
+  或 `_review_inputs_drifted()`（`manager.py:967-973`）的比對語意——它們讀的是
+  正確的 contract 值，本修復只是讓那個值真的維持正確。
+- 資料相容：既有 `jobs.json` 內已被寫壞的 slice row 需要有可判定的處理方式
+  （migration 或 repin 路徑），不得讓升級後既有 instance 直接 crash。
+
+## Tasks
+
+- [ ] **欄位分離**：`slice_row["verification"]["hash"]` 收斂為唯一語意＝pinned
+      verification contract hash；新增獨立欄位承載 current verification evidence
+      hash，兩者在 registry schema 層各有明確歸屬
+- [ ] **切斷覆寫路徑**：`_apply_verification_result()`（`manager.py:386-409`）不再
+      經 `update_slice(verification_hash=...)` 寫 contract 欄位；`update_slice()`
+      移除／改名該參數，使「證據覆寫 contract」在型別層就不可表達
+- [ ] **讀取端對齊**：確認 `_current_verification_ref()`、completion record
+      （`manager.py:833`／`843`）、handoff manifest（`manager.py:2142-2146`）三處
+      各自讀到語意正確的欄位——completion record 的 `verification_hash` 應為
+      contract hash，`verification_evidence_hash` 應為證據 hash，不得互串
+- [ ] **既有壞資料**：對 `verification.hash` 已被寫成證據 hash 的既有 slice row
+      提供可判定的復原路徑（migration 或明確的 operator 指示），並確保
+      `add-cortex-version-flag-build` 這類活現場可脫困
+- [ ] **測試**：
+      - contract hash 在 `_apply_verification_result()` 前後**完全相同**，
+        而 evidence hash 可獨立取回（`#501` 建議驗收第 5 條）
+      - verification pass → foreign-review launch 失敗（config-error）→ 下一 tick
+        **不得**回報 `pinned-input-mismatch`，且原成功證據不被替換
+      - 失敗／狀態證據（`_write_status_evidence` 路徑，`manager.py:1949-1961`）
+        同樣不得污染 contract hash——`#501` 0812 留言確認失敗證據也會寫壞
+      - repin（`retry-build` 走 `registry.repin_slice`）仍能合法更新 contract hash
+
+## 現場紀錄（供實作者參考）
+
+- issue `#501` 首則：Task 4 candidate `77e13f2` 的完整量測，contract hash
+  `f30e5bfe…` vs 寫入值 `98b73f70…`（證據 payload hash）
+- issue `#501` 0812-18:05 留言：candidate `6421bc98…` 的復發，寫入值
+  `c64340c4…` 恰為 **pinned-input-mismatch 證據 payload** 的 canonical hash——
+  證明失敗證據也走同一條污染路徑；每約 4 秒一 tick、隔離前累積 18+ 份 quarantine
+- 本張與 `#496`／`#497` 同屬「桶C slice 迴圈家族」，三者都經 `_apply_verification_result()`
+  放大。**本張建議最先派工**：它是三張裡邊界最窄、單一呼叫點、可完全由單元測試
+  判定的一張，另外兩張的驗收都會踩到它


### PR DESCRIPTION
為「桶C slice 迴圈家族」建立 cortex dogfooding 派工所需的 workstream todo 來源。
issue 只是 topic，要有 active Todo 來源才會進 `todo` 狀態、可 claim／intake；
本 PR 只佈線，intake 由 operator 逐案執行。

## 內容

新增三份 `docs/superpowers/workstreams/<slug>/todo.md`（`status: accepted`），
並在 `.cortex/work-items.yaml` 註冊對應 work item：

| slug | issue | 現場摘要 |
| --- | --- | --- |
| `fix-verification-contract-hash-overwrite` | `#501` | `_apply_verification_result()` 把 verification **證據** payload hash 經 `update_slice(verification_hash=...)` 寫進 `slice_row["verification"]["hash"]`，而該欄位是 `_pinned_input_mismatches()` 賴以比對的 pinned **contract** hash |
| `fix-superseded-terminal-replay` | `#497` | `complete_tick` 全量列舉 `registry.list_jobs()`，唯一冪等短路是 handoff manifest 的**單槽** job_id，同 slice 其餘歷史 terminal job 每輪重跑並撞不可變證據位址 |
| `fix-dirty-recheck-idempotency` | `#496` | `candidate-worktree-dirty` recheck 在結果完全未變時仍無條件套用，每 tick 各記一筆 action ＋ evidence_history |

## 現況查核（對 main `48b0205` 逐條複查）

**三張缺陷全部仍成立**，未被 R0／R0.5 任何一批修掉。每份 todo 含「現況查核」段，
標到精確檔案行號：

- `#501`：`manager.py:404-409` → `registry.py:1305-1306` → `manager.py:278-281`
  三點咬合。全 repo 僅 `manager.py:406` 一個呼叫點會用證據 hash 覆寫 contract 欄位，
  修復邊界極窄。現有 slice `add-cortex-version-flag-build` 正卡在此現場（活體）。
- `#497`：`#383` 只修了 fanout 側（`_manifest_still_blocks_fanout`，`manager.py:2194`），
  completion 側至今**沒有 supersession 概念**，`registry.create_job()` 的 job schema
  也無 consumed／attempt 欄位。`_slice_for_job()` 回 None 不等於跳過——build lane
  會掉進 `manager.py:1997-2010` 的 `missing-slice-proof` 分支，照樣以 branch HEAD
  解析 candidate 並寫證據。
- `#496`：`manager.py:1845-1851` 無條件套用；既有測試
  `tests/test_pre_candidate_recovery.py:218` 只覆蓋「結果有變」，缺「結果未變不得寫入」
  的斷言。

## 設計取捨

- **三張刻意不合併**（單一 issue 單一修復）：`#497` 是重播**來源**、`#496` 是 recheck
  **迴圈**、`#501` 是兩者共用的**污染原語**。三張各自獨立可驗收，且 `#497`／`#496`
  的驗收條件明訂**不得依賴** `#501` 是否已落地。
- 每份 todo 的 scope 段明列「本 work item 的主體是 X 不是 Y」與禁止越界項
  （例如：不得放寬 `write_verification_evidence()` 的不可變性、不得移除 dirty recheck、
  不得為了讓現場過關而略過 `verification-hash` 檢查），供 headless planner／builder 定界。

## 驗證

- 全套 pytest：**3108 passed, 49 subtests passed**（與 main 基線逐項一致；docs-only 無影響）
- `.cortex/work-items.yaml` YAML 解析驗證通過（67 個 work item）

## Checklist

- [x] `changelog.d/bucket-c-workstream-todos.md` fragment 已新增且已 commit
- [x] `CHANGELOG.md [Unreleased]` 有對應 entry
- [x] 分支非 `main`（`feature/bucket-c-workstream-todos`）
- [x] 全套測試通過
- [x] 語言 zh-tw
- [x] 只引用不關閉 issue → 帶 `policy-exempt:issue-link`

Refs #501 #497 #496
