### PR TITLE
feat(coverage): R1 shadow telemetry aggregation reader 與 TTL retention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@
 ## [Unreleased]
 
 ### Added
+- **v4 R1：shadow telemetry 的 aggregation reader ＋ TTL retention（Go/No-Go 的直接
+  輸入）**——PR #590 落地了 coverage validator shadow 的 sink（一次比對一檔），但沒有
+  讀端；R1 的 Go/No-Go 判準是「兩週 telemetry 中所有 disagreement 可解釋」，沒有統計
+  就無從判讀。新增**唯讀** aggregation reader `build_shadow_report()` 與 on-demand CLI
+  `python -m paulsha_cortex.coordinator.coverage --report [--json]`（比照
+  `python -m paulsha_cortex.trust_root ...` 的模組入口慣例，不動 `cortex` 傘狀 CLI）：
+  總筆數、agreement／disagreement 計數與比例、觀測窗、disagreement 依 `kind` 分組
+  （理論上只有 `topology-fail-coverage-pass`），每組附 combo／task_slug／callsite／
+  missing-responsibility 分佈與逐筆樣本（含 `context` 與 `satisfied_by`，足供人工
+  逐筆解釋）。同時加 TTL 清掃（`DEFAULT_SHADOW_TTL_SECONDS`，預設 30 天，比照 D4
+  event spool 慣例）——**只在 reader 執行時順帶清**、無 daemon 常駐邏輯，以
+  `recorded_at` 判齡、缺漏時降級用 mtime（壞檔亦隨時間退場），刪不掉只計數不 raise；
+  `--ttl-days` 可調、`--no-sweep` 純唯讀。單筆 JSON 壞損跳過並計數，絕不炸掉整份報告。
+  只做 reader ＋ retention；#591 其餘項（`satisfies` projection、雙 legacy phase 對映
+  收斂、第二呼叫點儀器化）屬 R2。詳見 `changelog.d/shadow-telemetry-reader.md`。
+  新增 `tests/test_coverage_shadow_reader_591.py`（27 測試）。
 - **R0.5 D6 / trust-root 隔離 Phase 2a（權限產生器）＋ Phase 2b root 設定 runbook
   （純程式碼＋文件、不需 root）**——新增 `paulsha_cortex/trust_root/permgen.py`：吃
   R1 `ASSET_REGISTRY` ＋參數化的 `UidScheme`（persona→OS 帳號映射），機械產生登記表

--- a/changelog.d/shadow-telemetry-reader.md
+++ b/changelog.d/shadow-telemetry-reader.md
@@ -1,0 +1,32 @@
+### Added
+- **R1 shadow telemetry 的 aggregation reader ＋ TTL retention（R1 Go/No-Go 的直接輸入）**
+  ——PR #590 落地了 coverage validator shadow 的 sink（一次比對一檔），但沒有讀端；
+  R1 的 Go/No-Go 判準是「兩週 telemetry 中所有 disagreement 可解釋」，沒有統計就無從
+  判讀。本次於 `paulsha_cortex/coordinator/coverage.py` 新增**唯讀** aggregation reader
+  `build_shadow_report()` 與 on-demand CLI
+  `python -m paulsha_cortex.coordinator.coverage --report [--json]`（比照
+  `python -m paulsha_cortex.trust_root ...` 的模組入口慣例，不動 `cortex` 傘狀 CLI）：
+  輸出總筆數、agreement／disagreement 計數與比例、觀測窗（earliest/latest）、
+  disagreement 依 `kind` 分組（理論上只有 `topology-fail-coverage-pass`），每組附
+  combo／task_slug／callsite／missing-responsibility 的分佈計數與逐筆樣本明細
+  （含 `context` 與 `satisfied_by`，足供人工逐筆解釋）。`--json` 輸出結構化報告
+  （`schema_version` 獨立於單筆 telemetry 的 schema），`--samples N`（`0`＝全部）
+  控制樣本數。
+- **shadow telemetry 的 TTL 清掃**——新增 `DEFAULT_SHADOW_TTL_SECONDS`（預設 30 天），
+  比照 D4 event spool 的 `DEFAULT_EVENT_TTL_SECONDS` 慣例：**只在 reader 執行時順帶
+  清**，不加任何 daemon 常駐邏輯。以記錄的 `recorded_at` 判齡，缺漏或解析不出來
+  （含壞檔）時降級用檔案 mtime，讓壞檔也會隨時間退場而非永久堆積；被清掉的記錄不
+  計入統計母體。`--ttl-days N` 可調、`--no-sweep` 純唯讀。刪不掉（唯讀掛載、或
+  trust-root Phase 2 之後 Manager-owned 樹對 operator 唯讀）時只計入 `sweep_failed`
+  並照常出報告，不 raise。
+- **壞檔容錯**——單筆 JSON 讀不到／不是 JSON／不是 object 一律跳過並計入 `corrupt`，
+  絕不炸掉整份報告；記錄內部欄位型別歪掉（`manifest` 不是 mapping、`recorded_at`
+  不是字串……）亦逐欄降級為 `-` 而非例外。掃描端跳過 dotfile，與 sink 的
+  `.coverage-*.tmp` 半寫入檔約定閉合。
+- 新增 `tests/test_coverage_shadow_reader_591.py`（27 個測試）：統計正確性（分組、
+  分佈、樣本、觀測窗、樣本上限）、TTL 清掃（過期清除、邊界、自訂 TTL、`--no-sweep`、
+  mtime 兜底、清掃失敗只計數）、壞檔容錯、與真實 sink 的端到端、CLI 文字／JSON 輸出
+  與參數驗證。
+- **範圍**：只做 reader ＋ retention。#591 其餘項（`satisfies` projection 進 manifest、
+  雙 legacy phase 對映收斂、`work_bridge.default_workflow_manifest()` 第二呼叫點
+  儀器化）屬 R2，本次不做；telemetry 的寫入端與 `validate_manager_spine()` 一 byte 未動。

--- a/paulsha_cortex/coordinator/coverage.py
+++ b/paulsha_cortex/coordinator/coverage.py
@@ -34,21 +34,42 @@ R1 是重構的**觀測期**，不是切換期：
   self-certification。:func:`resolve_card_satisfies` 是它的 deck-side adapter——
   有宣告用宣告、沒宣告則從 ``phase`` 推導。R1 完整驗證並單測這個 adapter，但
   **尚未**把它 projection 進 manifest（那是 R2 的責任契約）。
+
+## Go/No-Go 的讀端：aggregation reader
+
+R1 的 Go/No-Go 判準是「兩週 telemetry 中所有 disagreement 可解釋」，因此 sink
+本身不夠——還需要一支把整個 ``coverage-shadow/`` 目錄收斂成統計的**唯讀** reader：
+
+    python -m paulsha_cortex.coordinator.coverage --report [--json]
+
+:func:`build_shadow_report` 是它的純函式核心：總筆數／agreement 比例／
+disagreement 依 kind 分組（理論上只有 ``topology-fail-coverage-pass``）／每組的
+combo・task_slug・callsite 分佈與樣本明細（含 ``satisfied_by``，足供人工逐筆解釋）。
+單筆 JSON 壞損只跳過並計數，絕不炸掉整份報告——telemetry 是觀測資料，一顆壞檔讓
+Go/No-Go 讀不出來是完全不成比例的代價。
+
+reader 同時順帶做 **TTL 清掃**（:data:`DEFAULT_SHADOW_TTL_SECONDS`，預設 30 天，
+比照 D4 event spool 的 ``DEFAULT_EVENT_TTL_SECONDS`` 慣例）：**只在 reader 執行時
+清**，不引入任何常駐 daemon 邏輯。刪不掉（唯讀掛載、Phase 2 之後 Manager-owned
+樹對 operator 唯讀）時只計數不 raise，report 照樣讀得出來。
 """
 
 from __future__ import annotations
 
+import argparse
 import json
 import logging
 import os
 import re
+import sys
 import tempfile
 import uuid
+from collections import Counter
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from enum import Enum
 from pathlib import Path
-from typing import Any, Iterable, Mapping
+from typing import Any, Iterable, Mapping, Sequence
 
 from paulsha_cortex.config.paths import coverage_shadow_telemetry_root
 
@@ -436,3 +457,500 @@ def run_coverage_shadow(
     except Exception as error:  # noqa: BLE001 - shadow 絕不影響 production
         logger.debug("coverage shadow skipped after error: %s", error)
         return None
+
+
+# ---------------------------------------------------------------------------
+# aggregation reader ＋ retention（R1 Go/No-Go 的直接輸入）
+# ---------------------------------------------------------------------------
+
+#: 彙總報告的 schema 版本（獨立於單筆 telemetry 的 :data:`SHADOW_TELEMETRY_SCHEMA`）。
+SHADOW_REPORT_SCHEMA = "1"
+
+#: shadow telemetry 的預設保留期。比照 D4 event spool 的
+#: ``DEFAULT_EVENT_TTL_SECONDS``：TTL 只在 reader 執行時順帶清掃，不加常駐 daemon。
+DEFAULT_SHADOW_TTL_SECONDS = 30 * 86_400.0
+
+#: 每組 disagreement 預設附幾筆樣本明細（``0`` ＝全部）。
+DEFAULT_SAMPLE_LIMIT = 5
+
+#: 記錄缺 ``disagreement.kind``（舊 schema／半截資料）時的分組名。
+UNKNOWN_DISAGREEMENT_KIND = "unknown"
+
+
+def _now_utc() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _parse_timestamp(value: object) -> datetime | None:
+    """寬鬆解析 ISO-8601 時間戳；解析不出來回 ``None`` 而非 raise。
+
+    比 ``monitor/event_spool.py`` 的 :func:`parse_event_timestamp` 寬鬆一級：那邊是
+    寫入端契約（壞掉就該隔離），這邊是**唯讀 reader**，任何一筆解析不出來都只能降級
+    成「用檔案 mtime 判齡」，絕不能讓整份報告讀不出來。
+    """
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _as_mapping(value: object) -> Mapping[str, Any]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def _as_text(value: object) -> str | None:
+    return value if isinstance(value, str) and value else None
+
+
+def _as_name(value: object) -> str:
+    """把任意欄位值收斂成分佈統計用的 key（缺漏／型別不對一律 ``-``）。"""
+    return value if isinstance(value, str) and value else "-"
+
+
+def _ranked(counter: Counter[str]) -> dict[str, int]:
+    """分佈計數的 canonical 排序：count 由大到小，同 count 依名稱字典序。"""
+    return dict(sorted(counter.items(), key=lambda item: (-item[1], item[0])))
+
+
+@dataclass(frozen=True)
+class DisagreementGroup:
+    """同一個 ``disagreement.kind`` 的全部記錄之彙總。
+
+    ``combos`` / ``task_slugs`` / ``callsites`` / ``missing_responsibilities`` 是分佈
+    計數（供「這族 disagreement 集中在哪些 manifest／呼叫點」的判讀），``samples`` 是
+    逐筆明細（供人工解釋單一案例）。
+    """
+
+    kind: str
+    count: int
+    combos: Mapping[str, int]
+    task_slugs: Mapping[str, int]
+    callsites: Mapping[str, int]
+    missing_responsibilities: Mapping[str, int]
+    samples: tuple[Mapping[str, Any], ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "kind": self.kind,
+            "count": self.count,
+            "combos": dict(self.combos),
+            "task_slugs": dict(self.task_slugs),
+            "callsites": dict(self.callsites),
+            "missing_responsibilities": dict(self.missing_responsibilities),
+            "samples": [dict(sample) for sample in self.samples],
+        }
+
+
+@dataclass(frozen=True)
+class ShadowReport:
+    """整個 ``coverage-shadow/`` 目錄的彙總——R1 Go/No-Go 判讀的單一輸入。"""
+
+    root: Path
+    generated_at: str
+    root_exists: bool
+    root_error: str | None
+    total: int
+    agreements: int
+    disagreements: int
+    groups: tuple[DisagreementGroup, ...]
+    corrupt: tuple[str, ...]
+    swept: tuple[str, ...]
+    sweep_failed: tuple[str, ...]
+    ttl_seconds: float | None
+    earliest: str | None
+    latest: str | None
+
+    @property
+    def agreement_rate(self) -> float | None:
+        """agreement 佔比（``total`` 為 0 時為 ``None``，不編造 100%）。"""
+        if self.total <= 0:
+            return None
+        return self.agreements / self.total
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": SHADOW_REPORT_SCHEMA,
+            "generated_at": self.generated_at,
+            "root": str(self.root),
+            "root_exists": self.root_exists,
+            "root_error": self.root_error,
+            "records": {
+                "total": self.total,
+                "agreement": self.agreements,
+                "disagreement": self.disagreements,
+                "agreement_rate": self.agreement_rate,
+            },
+            "window": {"earliest": self.earliest, "latest": self.latest},
+            "corrupt": {"count": len(self.corrupt), "files": list(self.corrupt)},
+            "retention": {
+                "ttl_seconds": self.ttl_seconds,
+                "swept": {"count": len(self.swept), "files": list(self.swept)},
+                "sweep_failed": {
+                    "count": len(self.sweep_failed),
+                    "files": list(self.sweep_failed),
+                },
+            },
+            "disagreements": [group.to_dict() for group in self.groups],
+        }
+
+    def render_text(self) -> str:
+        lines = [
+            "coverage shadow telemetry 報告",
+            f"root: {self.root}",
+        ]
+        if not self.root_exists:
+            lines.append("（telemetry 目錄尚不存在——shadow 還沒寫過任何記錄）")
+        if self.root_error:
+            lines.append(f"（目錄讀取失敗：{self.root_error}）")
+        rate = self.agreement_rate
+        rate_text = "n/a" if rate is None else f"{rate * 100:.1f}%"
+        lines.append(
+            f"records: {self.total}"
+            f"（agreement {self.agreements} / disagreement {self.disagreements}"
+            f"；agreement rate {rate_text}）"
+        )
+        lines.append(f"window: {self.earliest or '-'} .. {self.latest or '-'}")
+        lines.append(f"壞檔（跳過、未計入統計）: {len(self.corrupt)}")
+        if self.ttl_seconds is None:
+            lines.append("retention: 本次未清掃（--no-sweep）")
+        else:
+            lines.append(
+                f"retention: TTL {self.ttl_seconds / 86_400:.1f} 天"
+                f"；本次清掃 {len(self.swept)} 筆"
+                f"；清掃失敗 {len(self.sweep_failed)} 筆"
+            )
+        lines.append("")
+        if not self.groups:
+            lines.append("disagreement 分組: （無）——所有記錄兩方判定一致。")
+            return "\n".join(lines) + "\n"
+        lines.append("disagreement 分組:")
+        for group in self.groups:
+            lines.append(f"  [{group.kind}] {group.count} 筆")
+            lines.append(f"    combo:     {_render_distribution(group.combos)}")
+            lines.append(f"    task_slug: {_render_distribution(group.task_slugs)}")
+            lines.append(f"    callsite:  {_render_distribution(group.callsites)}")
+            lines.append(
+                f"    missing:   {_render_distribution(group.missing_responsibilities)}"
+            )
+            lines.append(f"    樣本（{len(group.samples)}／{group.count}）:")
+            for index, sample in enumerate(group.samples, start=1):
+                lines.extend(_render_sample(index, sample))
+            lines.append("")
+        return "\n".join(lines).rstrip() + "\n"
+
+
+def _render_distribution(distribution: Mapping[str, int]) -> str:
+    if not distribution:
+        return "（無）"
+    return "  ".join(f"{key}={count}" for key, count in distribution.items())
+
+
+def _render_sample(index: int, sample: Mapping[str, Any]) -> list[str]:
+    context = _as_mapping(sample.get("context"))
+    context_text = (
+        "  ".join(f"{key}={context[key]}" for key in sorted(context)) or "（無）"
+    )
+    satisfied_by = _as_mapping(sample.get("satisfied_by"))
+    lines = [
+        f"      {index}) {sample.get('recorded_at') or '-'}"
+        f"  file={sample.get('file') or '-'}",
+        f"         callsite={sample.get('callsite') or '-'}"
+        f"  combo={sample.get('combo') or '-'}"
+        f"  task_slug={sample.get('task_slug') or '-'}"
+        f"  steps={sample.get('steps')}",
+        f"         context: {context_text}",
+        f"         topology: {sample.get('topology_reason') or 'pass'}",
+        f"         coverage: {sample.get('coverage_reason') or 'pass'}",
+        f"         missing: {', '.join(sample.get('missing') or ()) or '（無）'}",
+    ]
+    if satisfied_by:
+        rendered = "; ".join(
+            f"{stage}={','.join(str(card) for card in cards)}"
+            for stage, cards in satisfied_by.items()
+            if isinstance(cards, (list, tuple))
+        )
+        lines.append(f"         satisfied_by: {rendered}")
+    return lines
+
+
+def _sample_of(payload: Mapping[str, Any], filename: str) -> dict[str, Any]:
+    """把一筆 telemetry 投影成報告樣本——**足供人工逐筆解釋**的最小欄位集。"""
+    manifest = _as_mapping(payload.get("manifest"))
+    disagreement = _as_mapping(payload.get("disagreement"))
+    topology = _as_mapping(payload.get("topology"))
+    coverage_payload = _as_mapping(payload.get("coverage"))
+    missing = disagreement.get("missing_responsibilities")
+    if not isinstance(missing, list):
+        missing = coverage_payload.get("missing")
+    return {
+        "file": filename,
+        "recorded_at": _as_text(payload.get("recorded_at")),
+        "callsite": _as_text(payload.get("callsite")),
+        "combo": _as_text(manifest.get("combo")),
+        "task_slug": _as_text(manifest.get("task_slug")),
+        "steps": manifest.get("steps"),
+        "context": dict(_as_mapping(payload.get("context"))),
+        "topology_reason": _as_text(disagreement.get("topology_reason"))
+        or _as_text(topology.get("reason")),
+        "coverage_reason": _as_text(disagreement.get("coverage_reason"))
+        or _as_text(coverage_payload.get("reason")),
+        "missing": [str(item) for item in missing] if isinstance(missing, list) else [],
+        "covered": [
+            str(item) for item in coverage_payload.get("covered", []) or ()
+        ],
+        "satisfied_by": dict(_as_mapping(coverage_payload.get("satisfied_by"))),
+    }
+
+
+class _GroupAccumulator:
+    """單一 disagreement kind 的可變累加器（只在 :func:`build_shadow_report` 內用）。"""
+
+    def __init__(self, kind: str) -> None:
+        self.kind = kind
+        self.count = 0
+        self.combos: Counter[str] = Counter()
+        self.task_slugs: Counter[str] = Counter()
+        self.callsites: Counter[str] = Counter()
+        self.missing: Counter[str] = Counter()
+        self.samples: list[Mapping[str, Any]] = []
+
+    def add(self, payload: Mapping[str, Any], filename: str, *, sample_limit: int) -> None:
+        manifest = _as_mapping(payload.get("manifest"))
+        self.count += 1
+        self.combos[_as_name(manifest.get("combo"))] += 1
+        self.task_slugs[_as_name(manifest.get("task_slug"))] += 1
+        self.callsites[_as_name(payload.get("callsite"))] += 1
+        sample = _sample_of(payload, filename)
+        for stage in sample["missing"]:
+            self.missing[stage] += 1
+        if sample_limit <= 0 or len(self.samples) < sample_limit:
+            self.samples.append(sample)
+
+    def freeze(self) -> DisagreementGroup:
+        return DisagreementGroup(
+            kind=self.kind,
+            count=self.count,
+            combos=_ranked(self.combos),
+            task_slugs=_ranked(self.task_slugs),
+            callsites=_ranked(self.callsites),
+            missing_responsibilities=_ranked(self.missing),
+            samples=tuple(self.samples),
+        )
+
+
+def _record_paths(directory: Path) -> tuple[list[Path], str | None]:
+    """列出目錄下的 telemetry 檔；不可讀時回 ``([], 錯誤訊息)``。
+
+    刻意跳過 dotfile：sink 的半寫入 temp 檔是 ``.coverage-*.tmp``，與 D4 event spool
+    同一個約定（掃描端跳過 dotfile ⟹ consumer 不可能讀到半寫入檔）。
+    """
+    try:
+        entries = sorted(directory.iterdir())
+    except OSError as error:
+        return [], str(error)
+    return [
+        path
+        for path in entries
+        if path.suffix == ".json" and not path.name.startswith(".") and path.is_file()
+    ], None
+
+
+def build_shadow_report(
+    *,
+    root: str | Path | None = None,
+    ttl_seconds: float | None = DEFAULT_SHADOW_TTL_SECONDS,
+    sample_limit: int = DEFAULT_SAMPLE_LIMIT,
+    now: datetime | None = None,
+) -> ShadowReport:
+    """讀完整個 telemetry 目錄並收斂成 :class:`ShadowReport`（順帶做 TTL 清掃）。
+
+    語意合約：
+
+    1. **壞檔容錯**——單筆讀不到／不是 JSON／不是 object 一律跳過並計入
+       ``corrupt``，絕不讓整份報告失敗。
+    2. **TTL 清掃**（``ttl_seconds=None`` 停用）——記錄的 ``recorded_at`` 超過 TTL 就
+       刪；``recorded_at`` 缺漏或解析不出來（含壞檔）時降級用檔案 mtime 判齡，讓壞檔
+       也會隨時間退場而不是永久堆積。刪不掉只計入 ``sweep_failed``，不 raise。
+    3. **被清掉的記錄不計入統計**——報告描述的是「保留窗內」的母體。
+    """
+    directory = Path(root) if root is not None else coverage_shadow_telemetry_root()
+    horizon = now or _now_utc()
+    root_exists = directory.is_dir()
+    paths, root_error = _record_paths(directory) if root_exists else ([], None)
+
+    total = 0
+    agreements = 0
+    corrupt: list[str] = []
+    swept: list[str] = []
+    sweep_failed: list[str] = []
+    groups: dict[str, _GroupAccumulator] = {}
+    earliest: datetime | None = None
+    latest: datetime | None = None
+    earliest_text: str | None = None
+    latest_text: str | None = None
+
+    for path in paths:
+        payload = _load_record(path)
+        stamp = _parse_timestamp(payload.get("recorded_at")) if payload is not None else None
+        if stamp is None:
+            stamp = _file_mtime(path)
+        if (
+            ttl_seconds is not None
+            and stamp is not None
+            and (horizon - stamp).total_seconds() > ttl_seconds
+        ):
+            if _unlink_record(path):
+                swept.append(path.name)
+            else:
+                sweep_failed.append(path.name)
+            continue
+        if payload is None:
+            corrupt.append(path.name)
+            continue
+        total += 1
+        recorded_text = _as_text(payload.get("recorded_at"))
+        if stamp is not None:
+            if earliest is None or stamp < earliest:
+                earliest, earliest_text = stamp, recorded_text or stamp.isoformat()
+            if latest is None or stamp > latest:
+                latest, latest_text = stamp, recorded_text or stamp.isoformat()
+        if payload.get("agreement") is True:
+            agreements += 1
+            continue
+        kind = _as_text(_as_mapping(payload.get("disagreement")).get("kind"))
+        kind = kind or UNKNOWN_DISAGREEMENT_KIND
+        groups.setdefault(kind, _GroupAccumulator(kind)).add(
+            payload, path.name, sample_limit=sample_limit
+        )
+
+    ordered = tuple(
+        accumulator.freeze()
+        for accumulator in sorted(
+            groups.values(), key=lambda item: (-item.count, item.kind)
+        )
+    )
+    return ShadowReport(
+        root=directory,
+        generated_at=_utcnow(),
+        root_exists=root_exists,
+        root_error=root_error,
+        total=total,
+        agreements=agreements,
+        disagreements=total - agreements,
+        groups=ordered,
+        corrupt=tuple(corrupt),
+        swept=tuple(swept),
+        sweep_failed=tuple(sweep_failed),
+        ttl_seconds=ttl_seconds,
+        earliest=earliest_text,
+        latest=latest_text,
+    )
+
+
+def _load_record(path: Path) -> dict[str, Any] | None:
+    """讀一筆 telemetry；讀不到／不是 JSON object 一律回 ``None``（呼叫端計為壞檔）。"""
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as error:
+        logger.debug("coverage shadow record unreadable (%s): %s", path.name, error)
+        return None
+    if not isinstance(payload, dict):
+        logger.debug("coverage shadow record is not a JSON object: %s", path.name)
+        return None
+    return payload
+
+
+def _file_mtime(path: Path) -> datetime | None:
+    try:
+        return datetime.fromtimestamp(path.stat().st_mtime, tz=timezone.utc)
+    except OSError:
+        return None
+
+
+def _unlink_record(path: Path) -> bool:
+    """刪一筆過期記錄；失敗只記 debug 回 ``False``（唯讀掛載／權限不足是合法現況）。"""
+    try:
+        path.unlink()
+    except OSError as error:
+        logger.debug("coverage shadow retention sweep failed (%s): %s", path.name, error)
+        return False
+    return True
+
+
+# ---------------------------------------------------------------------------
+# CLI（唯讀 on-demand 入口；比照 `python -m paulsha_cortex.trust_root ...` 慣例）
+# ---------------------------------------------------------------------------
+
+
+def _build_report_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="python -m paulsha_cortex.coordinator.coverage",
+        description=(
+            "讀 coverage validator shadow telemetry 並輸出 disagreement 統計"
+            "（R1 Go/No-Go 的直接輸入）；順帶做 TTL 清掃。"
+        ),
+    )
+    parser.add_argument(
+        "--report",
+        action="store_true",
+        help="輸出彙總報告（目前唯一動作，必須明示）",
+    )
+    parser.add_argument(
+        "--root",
+        default=None,
+        help="telemetry 目錄（預設 <coordinator_root>/coverage-shadow）",
+    )
+    parser.add_argument("--json", action="store_true", help="輸出結構化 JSON")
+    parser.add_argument(
+        "--ttl-days",
+        type=float,
+        default=DEFAULT_SHADOW_TTL_SECONDS / 86_400,
+        help="保留天數，超過即於本次執行順帶刪除（預設 30）",
+    )
+    parser.add_argument(
+        "--no-sweep",
+        action="store_true",
+        help="完全不清掃，純唯讀讀取",
+    )
+    parser.add_argument(
+        "--samples",
+        type=int,
+        default=DEFAULT_SAMPLE_LIMIT,
+        help="每組 disagreement 附幾筆樣本明細（0＝全部，預設 5）",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = _build_report_parser()
+    args = parser.parse_args(list(sys.argv[1:] if argv is None else argv))
+    if not args.report:
+        parser.print_usage(sys.stderr)
+        sys.stderr.write("錯誤: 需指定 --report\n")
+        return 2
+    if args.ttl_days < 0:
+        sys.stderr.write("錯誤: --ttl-days 不可為負\n")
+        return 2
+    ttl_seconds = None if args.no_sweep else args.ttl_days * 86_400
+    report = build_shadow_report(
+        root=args.root,
+        ttl_seconds=ttl_seconds,
+        sample_limit=max(args.samples, 0),
+    )
+    if args.json:
+        sys.stdout.write(
+            json.dumps(report.to_dict(), ensure_ascii=False, sort_keys=True) + "\n"
+        )
+    else:
+        sys.stdout.write(report.render_text())
+    # 唯讀觀測工具：有沒有 disagreement 是 Go/No-Go 的人工判讀，不是本指令的 exit code。
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI 進入點
+    raise SystemExit(main())

--- a/tests/test_coverage_shadow_reader_591.py
+++ b/tests/test_coverage_shadow_reader_591.py
@@ -1,0 +1,480 @@
+"""#591：R1 shadow telemetry 的 aggregation reader ＋ retention 的測試。
+
+reader 是 R1 Go/No-Go（「兩週 telemetry 中所有 disagreement 可解釋」）的直接輸入，
+因此這裡釘住三件事：統計正確性（含分組與樣本明細）、TTL 清掃、壞檔容錯絕不炸掉
+整份報告。
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from paulsha_cortex.coordinator import coverage
+from paulsha_cortex.coordinator.coverage import (
+    DEFAULT_SHADOW_TTL_SECONDS,
+    SHADOW_REPORT_SCHEMA,
+    UNKNOWN_DISAGREEMENT_KIND,
+    build_shadow_report,
+    main,
+    run_coverage_shadow,
+)
+from paulsha_cortex.coordinator.work_bridge import default_workflow_manifest
+from paulsha_cortex.coordinator.workflow import WorkflowManifest
+
+NOW = datetime(2026, 8, 16, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _stamp(days_ago: float) -> str:
+    return (NOW - timedelta(days=days_ago)).isoformat().replace("+00:00", "Z")
+
+
+def _write(
+    root,
+    name: str,
+    *,
+    agreement: bool,
+    days_ago: float = 1,
+    kind: str | None = "topology-fail-coverage-pass",
+    combo: str = "feature-oneshot",
+    task_slug: str = "demo-work",
+    callsite: str = "manager.start",
+    missing: tuple[str, ...] = (),
+    work_id: str = "w-1",
+) -> None:
+    """寫一筆合成 telemetry（欄位集與 `ShadowComparison.to_dict()` 同型）。"""
+    disagreement = None
+    if not agreement:
+        disagreement = {
+            "topology_reason": "workflow steps 未依 phase 順序排列",
+            "coverage_reason": None,
+            "missing_responsibilities": list(missing),
+        }
+        if kind is not None:
+            disagreement["kind"] = kind
+    payload = {
+        "schema_version": coverage.SHADOW_TELEMETRY_SCHEMA,
+        "recorded_at": _stamp(days_ago),
+        "callsite": callsite,
+        "manifest": {
+            "combo": combo,
+            "task_slug": task_slug,
+            "version": 1,
+            "steps": 7,
+        },
+        "context": {"work_id": work_id, "repo": "owner/repo"},
+        "topology": {"passed": agreement, "reason": None if agreement else "順序錯"},
+        "coverage": {
+            "passed": True,
+            "reason": None,
+            "required": ["intake", "specification"],
+            "covered": ["intake", "specification"],
+            "missing": list(missing),
+            "satisfied_by": {"intake": ["claim-card"], "specification": ["define-card"]},
+        },
+        "agreement": agreement,
+        "disagreement": disagreement,
+    }
+    (root / name).write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
+
+
+# --------------------------------------------------------------------------
+# 統計正確性
+# --------------------------------------------------------------------------
+
+
+def test_report_counts_agreement_and_disagreement(tmp_path) -> None:
+    _write(tmp_path, "a1.json", agreement=True)
+    _write(tmp_path, "a2.json", agreement=True)
+    _write(tmp_path, "a3.json", agreement=True)
+    _write(tmp_path, "d1.json", agreement=False)
+    _write(tmp_path, "d2.json", agreement=False)
+
+    report = build_shadow_report(root=tmp_path, now=NOW)
+
+    assert report.total == 5
+    assert report.agreements == 3
+    assert report.disagreements == 2
+    assert report.agreement_rate == pytest.approx(0.6)
+    assert report.corrupt == ()
+    assert report.swept == ()
+
+
+def test_disagreements_group_by_kind_with_distributions(tmp_path) -> None:
+    _write(tmp_path, "d1.json", agreement=False, combo="feature-oneshot", task_slug="w-a")
+    _write(tmp_path, "d2.json", agreement=False, combo="feature-oneshot", task_slug="w-b")
+    _write(
+        tmp_path,
+        "d3.json",
+        agreement=False,
+        combo="hotfix",
+        task_slug="w-a",
+        callsite="work_bridge.default",
+        missing=("review",),
+    )
+
+    report = build_shadow_report(root=tmp_path, now=NOW)
+
+    assert len(report.groups) == 1
+    group = report.groups[0]
+    assert group.kind == "topology-fail-coverage-pass"
+    assert group.count == 3
+    # 分佈依 count 由大到小、同 count 依名稱字典序。
+    assert group.combos == {"feature-oneshot": 2, "hotfix": 1}
+    assert group.task_slugs == {"w-a": 2, "w-b": 1}
+    assert group.callsites == {"manager.start": 2, "work_bridge.default": 1}
+    assert group.missing_responsibilities == {"review": 1}
+
+
+def test_multiple_kinds_are_ordered_by_count(tmp_path) -> None:
+    _write(tmp_path, "d1.json", agreement=False, kind="topology-fail-coverage-pass")
+    _write(tmp_path, "d2.json", agreement=False, kind="topology-fail-coverage-pass")
+    _write(tmp_path, "d3.json", agreement=False, kind="topology-pass-coverage-fail")
+
+    report = build_shadow_report(root=tmp_path, now=NOW)
+
+    assert [group.kind for group in report.groups] == [
+        "topology-fail-coverage-pass",
+        "topology-pass-coverage-fail",
+    ]
+    assert [group.count for group in report.groups] == [2, 1]
+
+
+def test_disagreement_without_kind_falls_into_unknown_group(tmp_path) -> None:
+    _write(tmp_path, "d1.json", agreement=False, kind=None)
+
+    report = build_shadow_report(root=tmp_path, now=NOW)
+
+    assert [group.kind for group in report.groups] == [UNKNOWN_DISAGREEMENT_KIND]
+
+
+def test_samples_carry_enough_detail_to_explain_a_case(tmp_path) -> None:
+    _write(tmp_path, "d1.json", agreement=False, work_id="w-42")
+
+    group = build_shadow_report(root=tmp_path, now=NOW).groups[0]
+    sample = group.samples[0]
+
+    assert sample["file"] == "d1.json"
+    assert sample["callsite"] == "manager.start"
+    assert sample["combo"] == "feature-oneshot"
+    assert sample["task_slug"] == "demo-work"
+    assert sample["context"]["work_id"] == "w-42"
+    assert sample["topology_reason"] == "workflow steps 未依 phase 順序排列"
+    assert sample["satisfied_by"]["intake"] == ["claim-card"]
+
+
+def test_sample_limit_caps_details_without_capping_counts(tmp_path) -> None:
+    for index in range(4):
+        _write(tmp_path, f"d{index}.json", agreement=False)
+
+    limited = build_shadow_report(root=tmp_path, sample_limit=1, now=NOW).groups[0]
+    unlimited = build_shadow_report(root=tmp_path, sample_limit=0, now=NOW).groups[0]
+
+    assert limited.count == unlimited.count == 4
+    assert len(limited.samples) == 1
+    assert len(unlimited.samples) == 4
+
+
+def test_window_spans_earliest_and_latest_records(tmp_path) -> None:
+    _write(tmp_path, "old.json", agreement=True, days_ago=9)
+    _write(tmp_path, "mid.json", agreement=True, days_ago=4)
+    _write(tmp_path, "new.json", agreement=True, days_ago=0.5)
+
+    report = build_shadow_report(root=tmp_path, now=NOW)
+
+    assert report.earliest == _stamp(9)
+    assert report.latest == _stamp(0.5)
+
+
+def test_empty_and_missing_root_report_zero_without_faking_a_rate(tmp_path) -> None:
+    missing = build_shadow_report(root=tmp_path / "never-written", now=NOW)
+    assert missing.root_exists is False
+    assert missing.total == 0
+    assert missing.agreement_rate is None
+
+    present = build_shadow_report(root=tmp_path, now=NOW)
+    assert present.root_exists is True
+    assert present.total == 0
+
+
+def test_dotfiles_and_temp_files_are_ignored(tmp_path) -> None:
+    _write(tmp_path, "good.json", agreement=True)
+    (tmp_path / ".coverage-half.tmp").write_text("{partial", encoding="utf-8")
+    (tmp_path / ".hidden.json").write_text("{}", encoding="utf-8")
+    (tmp_path / "notes.txt").write_text("not telemetry", encoding="utf-8")
+
+    report = build_shadow_report(root=tmp_path, now=NOW)
+
+    assert report.total == 1
+    assert report.corrupt == ()
+
+
+# --------------------------------------------------------------------------
+# 壞檔容錯
+# --------------------------------------------------------------------------
+
+
+def test_corrupt_records_are_skipped_and_counted(tmp_path) -> None:
+    _write(tmp_path, "good.json", agreement=True)
+    (tmp_path / "truncated.json").write_text('{"schema_version": "1"', encoding="utf-8")
+    (tmp_path / "not-an-object.json").write_text("[1, 2, 3]", encoding="utf-8")
+    (tmp_path / "empty.json").write_text("", encoding="utf-8")
+
+    report = build_shadow_report(root=tmp_path, now=NOW)
+
+    assert report.total == 1
+    assert set(report.corrupt) == {"truncated.json", "not-an-object.json", "empty.json"}
+    # 壞檔不進統計母體，也不改變 agreement 比例。
+    assert report.agreement_rate == pytest.approx(1.0)
+
+
+def test_record_with_broken_inner_shapes_still_reports(tmp_path) -> None:
+    (tmp_path / "weird.json").write_text(
+        json.dumps(
+            {
+                "recorded_at": 12345,
+                "callsite": None,
+                "manifest": "not-a-mapping",
+                "context": ["not", "a", "mapping"],
+                "coverage": None,
+                "agreement": False,
+                "disagreement": {"kind": "topology-fail-coverage-pass"},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    report = build_shadow_report(root=tmp_path, now=NOW)
+
+    assert report.total == 1
+    group = report.groups[0]
+    assert group.combos == {"-": 1}
+    assert group.callsites == {"-": 1}
+    assert group.samples[0]["context"] == {}
+    # 型別再怎麼歪，render 都不能炸。
+    assert "topology-fail-coverage-pass" in report.render_text()
+
+
+# --------------------------------------------------------------------------
+# TTL 清掃（retention）
+# --------------------------------------------------------------------------
+
+
+def test_expired_records_are_swept_and_excluded_from_stats(tmp_path) -> None:
+    _write(tmp_path, "fresh.json", agreement=True, days_ago=2)
+    _write(tmp_path, "stale.json", agreement=False, days_ago=45)
+
+    report = build_shadow_report(root=tmp_path, now=NOW)
+
+    assert report.swept == ("stale.json",)
+    assert not (tmp_path / "stale.json").exists()
+    assert (tmp_path / "fresh.json").exists()
+    assert report.total == 1
+    assert report.disagreements == 0
+    assert report.ttl_seconds == DEFAULT_SHADOW_TTL_SECONDS
+
+
+def test_ttl_boundary_keeps_records_inside_the_window(tmp_path) -> None:
+    _write(tmp_path, "just-inside.json", agreement=True, days_ago=29.9)
+    _write(tmp_path, "just-outside.json", agreement=True, days_ago=30.1)
+
+    report = build_shadow_report(root=tmp_path, now=NOW)
+
+    assert report.swept == ("just-outside.json",)
+    assert report.total == 1
+
+
+def test_custom_ttl_is_honoured(tmp_path) -> None:
+    _write(tmp_path, "a.json", agreement=True, days_ago=8)
+
+    report = build_shadow_report(root=tmp_path, ttl_seconds=7 * 86_400, now=NOW)
+
+    assert report.swept == ("a.json",)
+    assert report.total == 0
+
+
+def test_no_sweep_keeps_expired_records(tmp_path) -> None:
+    _write(tmp_path, "stale.json", agreement=True, days_ago=90)
+
+    report = build_shadow_report(root=tmp_path, ttl_seconds=None, now=NOW)
+
+    assert report.swept == ()
+    assert report.ttl_seconds is None
+    assert (tmp_path / "stale.json").exists()
+    # 停用清掃時，過期記錄仍計入統計母體。
+    assert report.total == 1
+
+
+def test_unparsable_timestamp_falls_back_to_mtime_for_sweeping(tmp_path) -> None:
+    corrupt = tmp_path / "corrupt.json"
+    corrupt.write_text("{not json", encoding="utf-8")
+    old = (NOW - timedelta(days=99)).timestamp()
+    os.utime(corrupt, (old, old))
+
+    report = build_shadow_report(root=tmp_path, now=NOW)
+
+    # 壞檔沒有可解析的 recorded_at，仍必須隨時間退場而不是永久堆積。
+    assert report.swept == ("corrupt.json",)
+    assert report.corrupt == ()
+    assert not corrupt.exists()
+
+
+def test_sweep_failure_is_counted_not_raised(tmp_path) -> None:
+    if os.geteuid() == 0:  # pragma: no cover - CI 以 root 跑時 chmod 擋不住 unlink
+        pytest.skip("root 可無視目錄權限刪檔")
+    root = tmp_path / "readonly"
+    root.mkdir()
+    _write(root, "stale.json", agreement=True, days_ago=90)
+    root.chmod(0o500)
+    try:
+        report = build_shadow_report(root=root, now=NOW)
+    finally:
+        root.chmod(0o700)
+
+    assert report.sweep_failed == ("stale.json",)
+    assert report.swept == ()
+    assert (root / "stale.json").exists()
+
+
+# --------------------------------------------------------------------------
+# 與真實 sink 端到端
+# --------------------------------------------------------------------------
+
+
+def _topology_broken_manifest() -> WorkflowManifest:
+    valid = default_workflow_manifest("demo-work", change=None, combo_name="feature-oneshot")
+    return WorkflowManifest(
+        combo=valid.combo, task_slug=valid.task_slug, steps=tuple(reversed(valid.steps))
+    )
+
+
+def test_reader_consumes_records_written_by_the_real_sink(tmp_path, monkeypatch) -> None:
+    monkeypatch.delenv("PSC_RESPONSIBILITY_COVERAGE", raising=False)
+    run_coverage_shadow(
+        default_workflow_manifest("demo-work", change=None, combo_name="feature-oneshot"),
+        callsite="manager.start",
+        context={"work_id": "w-1"},
+        root=tmp_path,
+    )
+    run_coverage_shadow(
+        _topology_broken_manifest(),
+        callsite="manager.start",
+        context={"work_id": "w-2"},
+        root=tmp_path,
+    )
+
+    report = build_shadow_report(root=tmp_path, now=NOW)
+
+    assert report.total == 2
+    assert report.agreements == 1
+    assert [group.kind for group in report.groups] == ["topology-fail-coverage-pass"]
+    assert report.groups[0].samples[0]["context"] == {"work_id": "w-2"}
+
+
+def test_default_root_follows_coordinator_root(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("PSC_COORDINATOR_ROOT", str(tmp_path))
+    monkeypatch.delenv("PSC_RESPONSIBILITY_COVERAGE", raising=False)
+    run_coverage_shadow(
+        default_workflow_manifest("demo-work", change=None, combo_name="feature-oneshot"),
+        callsite="test",
+    )
+
+    report = build_shadow_report(now=NOW)
+
+    assert report.root == tmp_path / "coverage-shadow"
+    assert report.total == 1
+
+
+# --------------------------------------------------------------------------
+# CLI
+# --------------------------------------------------------------------------
+
+
+def test_cli_json_output_shape(tmp_path, capsys) -> None:
+    _write(tmp_path, "a.json", agreement=True)
+    _write(tmp_path, "d.json", agreement=False)
+    _write(tmp_path, "stale.json", agreement=True, days_ago=99)
+    (tmp_path / "bad.json").write_text("{", encoding="utf-8")
+
+    assert main(["--report", "--root", str(tmp_path), "--json"]) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["schema_version"] == SHADOW_REPORT_SCHEMA
+    assert payload["root"] == str(tmp_path)
+    assert payload["records"] == {
+        "total": 2,
+        "agreement": 1,
+        "disagreement": 1,
+        "agreement_rate": 0.5,
+    }
+    assert payload["corrupt"]["count"] == 1
+    assert payload["retention"]["ttl_seconds"] == DEFAULT_SHADOW_TTL_SECONDS
+    assert payload["retention"]["swept"]["files"] == ["stale.json"]
+    assert payload["disagreements"][0]["kind"] == "topology-fail-coverage-pass"
+    assert payload["disagreements"][0]["samples"][0]["file"] == "d.json"
+
+
+def test_cli_text_output_lists_groups_and_samples(tmp_path, capsys) -> None:
+    _write(tmp_path, "a.json", agreement=True)
+    _write(tmp_path, "d.json", agreement=False, missing=("review",))
+
+    assert main(["--report", "--root", str(tmp_path)]) == 0
+
+    out = capsys.readouterr().out
+    assert "coverage shadow telemetry 報告" in out
+    assert "agreement 1 / disagreement 1" in out
+    assert "[topology-fail-coverage-pass] 1 筆" in out
+    assert "combo=feature-oneshot" in out
+    assert "satisfied_by:" in out
+
+
+def test_cli_text_output_says_so_when_all_agree(tmp_path, capsys) -> None:
+    _write(tmp_path, "a.json", agreement=True)
+
+    assert main(["--report", "--root", str(tmp_path)]) == 0
+
+    assert "disagreement 分組: （無）" in capsys.readouterr().out
+
+
+def test_cli_no_sweep_flag_disables_retention(tmp_path, capsys) -> None:
+    _write(tmp_path, "stale.json", agreement=True, days_ago=99)
+
+    assert main(["--report", "--root", str(tmp_path), "--no-sweep", "--json"]) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["retention"]["ttl_seconds"] is None
+    assert (tmp_path / "stale.json").exists()
+
+
+def test_cli_ttl_days_flag(tmp_path, capsys) -> None:
+    _write(tmp_path, "a.json", agreement=True, days_ago=3)
+
+    assert main(["--report", "--root", str(tmp_path), "--ttl-days", "2", "--json"]) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["retention"]["swept"]["files"] == ["a.json"]
+    assert payload["retention"]["ttl_seconds"] == 2 * 86_400
+
+
+def test_cli_requires_an_explicit_action(tmp_path, capsys) -> None:
+    assert main(["--root", str(tmp_path)]) == 2
+    assert "需指定 --report" in capsys.readouterr().err
+
+
+def test_cli_rejects_negative_ttl(tmp_path, capsys) -> None:
+    assert main(["--report", "--root", str(tmp_path), "--ttl-days", "-1"]) == 2
+    assert "不可為負" in capsys.readouterr().err
+
+
+def test_cli_survives_a_directory_full_of_garbage(tmp_path, capsys) -> None:
+    for index in range(3):
+        (tmp_path / f"junk{index}.json").write_text("nonsense", encoding="utf-8")
+
+    assert main(["--report", "--root", str(tmp_path), "--json"]) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["records"]["total"] == 0
+    assert payload["corrupt"]["count"] == 3


### PR DESCRIPTION
## 這是什麼

PR #590 落地了 v4 R1 coverage validator shadow 的 **sink**（每次 workflow spine 驗證落一筆比對 JSON 到 `<coordinator_root>/coverage-shadow/`），但沒有**讀端**。R1 的 Go/No-Go 判準是「兩週 telemetry 中所有 disagreement 可解釋」——沒有統計就無從判讀，因此 #591 把這支 aggregation reader 標為**優先於其他後續項**。

本 PR 只做 **reader ＋ retention**；#591 其餘三項（`satisfies` projection 進 manifest、雙 legacy phase 對映收斂、`work_bridge.default_workflow_manifest()` 第二呼叫點儀器化）屬 R2，不在本 PR 範圍。

Refs #591

## CLI 落點

跟隨 repo 既有的**模組級 on-demand 入口**慣例（`python -m paulsha_cortex.trust_root {selfcheck,registry,equation}`、`python -m paulsha_cortex.coordinator.gate_ledger`），不動 `cortex` 傘狀 CLI 的 help 契約：

```
python -m paulsha_cortex.coordinator.coverage --report [--json]
                                              [--root PATH] [--ttl-days N]
                                              [--no-sweep] [--samples N]
```

`--report` 必須明示（保留未來加其他唯讀動作的空間）；exit code 恆為 0——**有沒有 disagreement 是人工判讀，不是本指令的 exit code**。

## 報告輸出

```
coverage shadow telemetry 報告
root: <coordinator_root>/coverage-shadow
records: 4（agreement 3 / disagreement 1；agreement rate 75.0%）
window: 2026-08-16T10:14:11.591910Z .. 2026-08-16T10:14:11.598726Z
壞檔（跳過、未計入統計）: 0
retention: TTL 30.0 天；本次清掃 0 筆；清掃失敗 0 筆

disagreement 分組:
  [topology-fail-coverage-pass] 1 筆
    combo:     feature-oneshot=1
    task_slug: demo-work=1
    callsite:  manager.start=1
    missing:   （無）
    樣本（1／1）:
      1) 2026-08-16T10:14:11.598726Z  file=2026-08-16t101411.598726z-demo-work-3d30c91e.json
         callsite=manager.start  combo=feature-oneshot  task_slug=demo-work  steps=12
         context: repo=owner/repo  work_id=w-9
         topology: workflow manifest phases 必須依生命週期單調排列
         coverage: pass
         missing: （無）
         satisfied_by: delivery=policy-commit,openspec-archive; implementation=subagent-build,tdd-red,worktree-isolation; intake=workflow-claim; planning=writing-plans; review=adversarial-review,code-review; specification=openspec-propose,brainstorming; verification=verification
```

樣本刻意帶 `context`（work_id／repo／claim_key）與 `satisfied_by`（責任 → 覆蓋它的 card id）——這兩欄是「這筆 disagreement 為什麼可解釋」的判讀依據：看得到是哪一個 work、哪張卡覆蓋了哪個責任，才能逐筆下結論。

`--json` 為結構化輸出，`schema_version` 獨立於單筆 telemetry 的 `SHADOW_TELEMETRY_SCHEMA`：

```json
{
  "schema_version": "1",
  "generated_at": "...", "root": "...", "root_exists": true, "root_error": null,
  "records": {"total": 4, "agreement": 3, "disagreement": 1, "agreement_rate": 0.75},
  "window": {"earliest": "...", "latest": "..."},
  "corrupt": {"count": 0, "files": []},
  "retention": {"ttl_seconds": 2592000.0,
                "swept": {"count": 0, "files": []},
                "sweep_failed": {"count": 0, "files": []}},
  "disagreements": [{"kind": "topology-fail-coverage-pass", "count": 1,
                     "combos": {...}, "task_slugs": {...}, "callsites": {...},
                     "missing_responsibilities": {...}, "samples": [...]}]
}
```

## Retention（TTL 清掃）

比照 D4 event spool 的 `DEFAULT_EVENT_TTL_SECONDS` 慣例，新增 `DEFAULT_SHADOW_TTL_SECONDS`（預設 **30 天**）：

- **只在 reader 執行時順帶清**，不加任何 daemon 常駐邏輯（#591 明確要求）。
- 以記錄的 `recorded_at` 判齡；缺漏或解析不出來（**含壞檔**）時降級用檔案 mtime——否則壞檔沒有可解析時間戳，會永久堆積。
- 被清掉的記錄**不計入統計母體**：報告描述的是「保留窗內」的觀測母體。
- 刪不掉時只計入 `sweep_failed`、照常出報告，**不 raise**。唯讀掛載、或 trust-root Phase 2 之後 Manager-owned 樹對 operator 唯讀，都是合法現況；reader 必須在那種環境下降級成純唯讀報告而不是失敗。
- `--ttl-days N` 可調、`--no-sweep` 完全停用清掃（純唯讀讀取，過期記錄仍計入統計）。

## 壞檔容錯

telemetry 是觀測資料，一顆壞檔讓 Go/No-Go 讀不出來是完全不成比例的代價，因此兩層防線：

1. **檔層**：讀不到／不是 JSON／不是 JSON object 一律跳過並計入 `corrupt`（不進統計母體，因此不污染 agreement 比例）。
2. **欄層**：記錄內部型別歪掉（`manifest` 不是 mapping、`recorded_at` 不是字串、`context` 是 list……）逐欄降級為 `-`／空值，render 也不炸。

掃描端跳過 dotfile，與 sink 的 `.coverage-*.tmp` 半寫入檔約定閉合（consumer 不可能讀到半寫入檔），與 D4 event spool 同一組語意。

## 零行為變更

- `WorkflowManifest.validate_manager_spine()`、`run_coverage_shadow()`、`write_shadow_record()` 與 `manager.py` 的呼叫點**一 byte 未動**——本 PR 純加讀端。
- reader 唯一的寫入是 TTL 清掃的 `unlink`，且失敗只計數。
- 既有 `tests/test_coverage_shadow_r1.py` 26 個測試全數未改、全綠。

## 測試

新增 `tests/test_coverage_shadow_reader_591.py`（27 個）：

- **統計正確性**：agreement/disagreement 計數與比例、依 `kind` 分組與組序（count 由大到小）、combo/task_slug/callsite/missing 分佈與排序、樣本明細欄位、樣本上限（`--samples 0` ＝全部）、觀測窗 earliest/latest、缺 `kind` 落入 `unknown` 組、空目錄／目錄不存在不編造 100% 比例、dotfile 與非 `.json` 被忽略。
- **TTL 清掃**：過期清除且不計入統計、TTL 邊界（29.9 天留／30.1 天清）、自訂 TTL、`--no-sweep` 保留、時間戳解析不出來時用 mtime 兜底、清掃失敗只計數不 raise（唯讀目錄；root 執行時 skip）。
- **壞檔容錯**：截斷 JSON／非 object／空檔／內部型別全歪。
- **端到端**：用真實 `run_coverage_shadow()` 寫入、reader 讀回。
- **CLI**：文字與 JSON 輸出、`--no-sweep`／`--ttl-days`、缺 `--report` 回 2、負 TTL 回 2、整個目錄都是垃圾仍回 0。

目標測試：`tests/test_coverage_shadow_reader_591.py tests/test_coverage_shadow_r1.py` → **53 passed**。
全套：`python3 -m pytest -q` → **3135 passed, 49 subtests passed**（本機無 #565 `/tmp/.git` 暫態紅）。

## 相鄰缺陷（不在本 PR 修）

- **trust-root 登記表的 writer 宣告**：`coverage-shadow-telemetry` 現宣告 `writers=(MANAGER,)`／`readers=(MANAGER, OPERATOR)`，但 TTL 清掃是由**跑 reader 的身分**執行的刪除。Phase 2 權限落地後，operator 直跑 reader 會撞 Manager-owned 樹的唯讀 ACL。本 PR 選擇**不動登記表**（改 writers 會連動 permgen 的 Manager-owned 唯讀不變式，屬 trust-root workstream 的裁決），改以「清掃失敗只計數、報告照出」讓 reader 在該環境下優雅降級。
- **母體仍只有一個呼叫點**：`work_bridge.default_workflow_manifest()` 也驗 spine 但未 shadow（#591 第 3 項），因此本報告的母體偏小；Go/No-Go 判讀時需意識到這點。

## Checklist
- [x] `changelog.d/shadow-telemetry-reader.md` fragment 已新增並 commit
- [x] `CHANGELOG.md [Unreleased]` 有對應 entry
- [x] 分支非 main（`feature/591-shadow-telemetry-reader`）
- [x] 目標測試與全套測試通過
- [x] 只引用不關閉 issue（#591 其餘項屬 R2），已上 `policy-exempt:issue-link`
