### PR TITLE
feat(trust-root): Phase 2a 降權啟動器——builder job 經 systemd-run transient unit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,30 @@
   （Phase 1 自檢已知），本階段交付的是**通道結構**（路徑／守衛／登記／身分推導），
   OS 強制等 Phase 2b。詳見 `changelog.d/p2a-verdict-channel.md`。新增
   `tests/test_review_verdict_channel_p2a.py`（47 測試）。
+- **R0.5 D6 / trust-root 隔離 Phase 2a（降權啟動器，預設關閉）**——新增
+  `paulsha_cortex/coordinator/job_runner.py`：Manager spawn headless **builder** job 時
+  改經 `systemd-run --uid=cortex-builder` 的 transient unit 執行（operator 0816 第二輪
+  對「未決 1 降權機制」的裁決）。`PSC_JOB_RUNNER` **預設 `direct`＝現行行為逐字不變**，
+  設為 `systemd-run` 才降權；值非法時 fail-closed，不靜默當成 direct。builder job 的
+  環境改為**白名單**而非黑名單 scrub——transient unit 本來就不繼承呼叫端 environ，因此
+  job 只看得到轉發類 7 項（`PATH`／`LANG`／`LC_ALL`／`LC_CTYPE`／`SSL_CERT_FILE`／
+  `SSL_CERT_DIR`／`NODE_EXTRA_CA_CERTS`，每項在 `BUILDER_FORWARDED_ENV` 帶「為何需要」
+  的 rationale）加合成類 5 項（`PSC_JOB_ID`／`PSC_SLICE_ID`／`PSC_REPO_ROOT`／選配
+  `PSC_RELAY_TARGET`／選配 `HOME`），**gh token、daemon 的 `CLAUDE_CONFIG_DIR`／
+  `GH_CONFIG_DIR` 一律不在其中**（issue #588 第 1 點）；降權模式的 shell 改
+  `bash -c`（非 `-lc`，#588 第 2 點——login shell 會讓 `~/.profile` 在 env 約束建立後
+  重新匯入），**direct 模式維持 `-lc` 不動**。FD 只交出 stdin/stdout/stderr 且 stdin
+  顯式接 `/dev/null`。判定點與既有 persona 分支對齊：reviewer／planner 在二分方案裡與
+  Manager 同帳號，**不經降權**。fail-fast 走 #570 `DiagnosticReason` 契約——systemd-run
+  缺席／未以 systemd 開機／builder 帳號或 group 不存在在任何副作用前擋下，polkit 拒絕
+  與 unit 名衝突由起動確認（「client 已結束**且** exit sentinel 不存在」）擋下並帶回
+  systemd-run 的實際錯誤訊息，**任一條都不退回 direct**。unit 名前綴 `cortex-job-` 是與
+  Phase 2b polkit 規則成對的契約。**本項是機制不是生效**：實際降權要等 Phase 2b 建好
+  帳號＋polkit 後把 `PSC_JOB_RUNNER=systemd-run` 寫進 Manager env。同步改寫
+  `docs/superpowers/runbooks/trust-root-phase2b-setup.md` 第 5 步（含 polkit 只暴露 unit
+  名、不暴露 `--uid=` 的誠實標註）與 README 的 env 說明。詳見
+  `changelog.d/p2a-systemd-run-launcher.md`。新增
+  `tests/test_trust_root_job_runner_p2a.py`（61 測試，systemd-run 本體全程 mock）。
 - **v4 R1：shadow telemetry 的 aggregation reader ＋ TTL retention（Go/No-Go 的直接
   輸入）**——PR #590 落地了 coverage validator shadow 的 sink（一次比對一檔），但沒有
   讀端；R1 的 Go/No-Go 判準是「兩週 telemetry 中所有 disagreement 可解釋」，沒有統計

--- a/README.md
+++ b/README.md
@@ -106,6 +106,13 @@ cortex bootstrap --instance cortex --repo-root "$(git rev-parse --show-toplevel)
    PSC_MANAGER_RECENT_DONE_WINDOW_SECONDS=86400
    ```
 
+   **`PSC_JOB_RUNNER`（trust-root Phase 2 降權啟動器）**：預設 `direct`＝headless job 與
+   Manager 同帳號執行（現行行為）。設為 `systemd-run` 後，builder persona 的 job 改以
+   `systemd-run --uid=cortex-builder` 的 transient unit 執行，只帶白名單 env（**不含任何
+   token**）。**這個開關要在 `cortex-builder` 帳號與 polkit 規則就位之後才可打開**，
+   步驟見 `docs/superpowers/runbooks/trust-root-phase2b-setup.md` 第 5 步；相關選配變數
+   為 `PSC_BUILDER_ACCOUNT`／`PSC_BUILDER_GROUP`／`PSC_BUILDER_HOME`／`PSC_BUILDER_PATH`。
+
 3. 使用 Deck 先 dry-run，再 emit `dispatch: hold` specs：
 
    ```bash

--- a/changelog.d/p2a-systemd-run-launcher.md
+++ b/changelog.d/p2a-systemd-run-launcher.md
@@ -1,0 +1,89 @@
+# trust-root Phase 2a：降權啟動器（`systemd-run` transient unit，預設關閉）
+
+`Refs #584 #588`
+
+## 背景
+
+trust-root spec §R10 Phase 2 第 5 條要求「Manager 以降權方式 spawn headless job，明確
+關閉 FD 傳遞、不傳遞 gh token」。operator 0816 第二輪裁決把「未決 1（降權機制）」收斂為
+**`systemd-run` transient unit**、UID **二分**（`cortex-svc` / `cortex-builder`）、
+builder env 不傳 gh token。本次落地的是那條裁決的**程式碼前置**。
+
+issue #588 的兩條缺口同時被這個機制解掉一半：
+
+1. builder 繼承 daemon 全部 environ（含 token 與 daemon 自己的 `CLAUDE_CONFIG_DIR`）；
+2. builder 走 `bash -lc`（login shell），`~/.profile` 會在 launcher 設好 env 之後重新
+   匯入 operator 環境，把任何 env 約束覆寫掉。
+
+## 變更
+
+### 新增 `paulsha_cortex/coordinator/job_runner.py`
+
+- **`PSC_JOB_RUNNER`**：`direct`（**預設**，現行行為逐字不變）或 `systemd-run`（降權）。
+  值非法時 **fail-closed**，不靜默當成 `direct`——「打錯字＝以為隔離生效但其實沒有」正是
+  要消除的失效模式。
+- **builder env 白名單**（不是黑名單 scrub）：transient unit 不繼承呼叫端的 environ，
+  因此 job 的環境**就是**白名單本身。轉發類 7 項（`PATH`／`LANG`／`LC_ALL`／`LC_CTYPE`／
+  `SSL_CERT_FILE`／`SSL_CERT_DIR`／`NODE_EXTRA_CA_CERTS`，每項在
+  `BUILDER_FORWARDED_ENV` 上帶「為何需要」的 rationale 欄位），合成類 5 項
+  （`PSC_JOB_ID`／`PSC_SLICE_ID`／`PSC_REPO_ROOT`／選配 `PSC_RELAY_TARGET`／
+  選配 `HOME`）。`EXCLUDED_ENV_RATIONALE` 另記錄**刻意不轉發**的項目與理由
+  （`HOME`／`USER`／`SHELL` 交給 systemd 依 passwd 填、`TMPDIR`／`XDG_*`／`VIRTUAL_ENV`
+  會指回 cortex-svc 的樹、`*_PROXY` 可內嵌 `user:pass@` 屬憑證面）。
+- **defense-in-depth 守衛**：白名單成品再過一次憑證形狀（與 launcher 共用同一條
+  `CREDENTIAL_ENV_RE`）與注入孔名單（`BASH_ENV`／`LD_PRELOAD`／`PYTHONPATH`／
+  `NODE_OPTIONS`／`CLAUDE_CONFIG_DIR`／`GH_CONFIG_DIR` …），命中即 fail-closed。
+  白名單是靜態的，這道守衛存在的意義是「有人往白名單加一項憑證時測試當場紅」。
+- **封閉的 argv 產生器**：`--quiet --collect --pipe --wait --unit=cortex-job-<slug>-<sha8>.service
+  --uid --gid --service-type=exec --working-directory=<worktree>
+  --property=NoNewPrivileges=yes --setenv=…（排序）-- bash -c <script>`。
+  unit 名前綴 `cortex-job-` 是與 Phase 2b polkit 規則成對的**契約**
+  （polkit 以 `action.lookup("unit")` 比對）。
+- **fail-fast 診斷（#570 `DiagnosticReason` 契約）**：`preflight_systemd_run()` 在任何
+  副作用之前檢查 systemd-run 二進位／`/run/systemd/system`／builder 帳號／group；
+  `confirm_transient_unit_started()` 補上只能在起動當下才知道的失敗（polkit 拒絕、
+  unit 名衝突），判準是「systemd-run 已結束**且** exit sentinel 不存在」，並把
+  systemd-run 的實際錯誤訊息帶進 `detail`。**任何一條都不會退回 direct。**
+
+### `paulsha_cortex/coordinator/launcher.py`
+
+- `SubprocessLauncher.launch()` 在降權模式下改走 transient unit。判定點與既有 persona
+  分支對齊：`review_only`＝reviewer、`read_only`＝planner，**兩者皆非才是 builder**；
+  二分方案裡 reviewer／planner 與 Manager 同帳號，**不經降權**。
+- 降權模式的 shell 改 `bash -c`（#588 第 2 點）；**direct 模式維持 `-lc` 不動**。
+- FD：`--pipe` 只交出 stdin/stdout/stderr（Popen `close_fds` 預設 True），且 stdin
+  顯式接 `/dev/null`——direct 模式今天仍把 daemon 的 stdin 交給 job，降權模式在這點上
+  比 direct 更緊。
+- `_CREDENTIAL_ENV_RE` 改為 `job_runner.CREDENTIAL_ENV_RE` 的別名，reviewer sandbox
+  政策與 builder 白名單守衛永遠共用同一條 pattern。
+- `executor_environment()`（#262 D2）在降權模式下回報 builder env，否則 preflight 報的
+  PATH／HOME 與正式 job 無關，只是安慰劑。
+
+### 文件
+
+- `docs/superpowers/runbooks/trust-root-phase2b-setup.md` 第 5 步改寫：未決 1 標為已裁決、
+  補上 Manager 端實際會發出的 argv 形狀、可執行的 polkit 規則（含**誠實標註**：polkit 的
+  `manage-units` action 只暴露 unit 名、**不暴露 `--uid=`**，「只能降到 cortex-builder」
+  那一半只能由 Manager 端封閉 argv 保證）、開關寫法與負控制驗證。
+- `README.md` 補 `PSC_JOB_RUNNER` 與 builder 相關選配變數。
+
+## 誠實邊界
+
+**本 PR 是機制，不是生效。** 預設 `PSC_JOB_RUNNER=direct`＝現行行為完全不變。實際降權要
+等 Phase 2b 建好 `cortex-builder` 帳號＋polkit 規則，再把 `PSC_JOB_RUNNER=systemd-run`
+寫進 Manager env——那是部署期動作。另外兩點必須一併知道：
+
+- **builder 帳號要有自己的模型 CLI 登入態**。Manager 不傳自己的憑證，因此 copilot builder
+  在降權模式下拿不到 `COPILOT_GITHUB_TOKEN`（`_copilot_credential_env()` 讀的是白名單
+  env，裡面沒有任何 token 候選，自然變 no-op）。
+- **builder 必須能寫該 job 的 log 目錄**（JSONL log／exit sentinel／gate ledger 都落在
+  那裡），並能讀 `PSC_REPO_ROOT`（wrapper 內 gate ledger writer 的 `PYTHONPATH`）。
+  這兩條的權限由 Phase 2b 的 permgen 計畫決定。
+
+## 測試
+
+`tests/test_trust_root_job_runner_p2a.py`（61 測試）：direct 零回歸（預設與顯式 `direct`
+形狀一致、仍走 `bash -lc`、仍繼承 daemon env）、systemd-run argv 組裝、env 白名單**不含
+token 類**（`GH_TOKEN`／`GITHUB_TOKEN`／`ANTHROPIC_API_KEY`／`CLAUDE_CONFIG_DIR` … 逐一
+斷言，並在整條 argv 上做值層面兜底）、reviewer／planner 不降權、四條 fail-fast 路徑。
+`systemd-run` 本體全程 mock，測試不真跑 systemd、不建帳號、不碰 polkit。

--- a/docs/superpowers/runbooks/trust-root-phase2b-setup.md
+++ b/docs/superpowers/runbooks/trust-root-phase2b-setup.md
@@ -29,6 +29,10 @@ Phase 2a 的權限產生器（`paulsha_cortex/trust_root/permgen.py`）已把 R1
   planner＋monitor 共用，且為 durable state owner）。**保留二往三分彈性**——未來把
   Manager 拆成第三個 UID 時，只需換 `permgen.THREE_WAY_SCHEME`，runbook 結構不變。
 - **Manager 落 system-level unit**（非 `--user`），以 `cortex-svc` 執行。
+- **降權機制＝`systemd-run` transient unit**（未決 1 已裁決）。程式碼面 Phase 2a 已落地
+  （`paulsha_cortex/coordinator/job_runner.py`，`PSC_JOB_RUNNER` 預設 `direct`）；
+  本 runbook 第 5 步是把開關打開的部署動作。polkit 授權面收窄到 `cortex-job-` 前綴的
+  transient unit。
 - **舊 state 走 legacy-import 重新入帳**，**不**直接 `chown` 沿用（spec §R6(e)）。
 - **降級運轉逐案核可**（`PSC_DEGRADED_OPERATION=per-case-approval`，Phase 1 已上線）。
 
@@ -137,11 +141,11 @@ id cortex-svc; id cortex-builder
 # 期望：兩者 primary group 不同、彼此不在對方 group
 ```
 
-> **⚠️ 未決 1（降權機制的先決條件）**：第 5 步的降權啟動器需要「`cortex-svc` 能把
-> 子行程降到 `cortex-builder`」。unprivileged 的 `cortex-svc` **無法**直接 setuid 到
-> 另一個 unprivileged 帳號——需 operator 在第 5 步的三個方案擇一（narrow polkit +
-> `systemd-run` transient unit／最小 setuid 助手／給 Manager unit 授
-> `AmbientCapabilities=CAP_SETUID CAP_SETGID`）。此決定影響本步是否要再建輔助群組。
+> **✅ 未決 1 已裁決**：降權經 **`systemd-run` transient unit** ＋ narrow polkit rule
+> （見第 5 步）。unprivileged 的 `cortex-svc` 無法直接 setuid，改由 systemd（PID 1）
+> 代為切換身分。本步因此**不需要**額外的輔助群組——只要兩個帳號各自有同名 primary
+> group（`job_runner` 的 `--gid` 預設即帳號同名 group，與 `permgen.UidScheme.group_of()`
+> 同一慣例）。
 
 ---
 
@@ -365,9 +369,10 @@ sudo systemctl enable --now cortex-manager.service
 ```
 
 > **`EnvironmentFile` 無 `-` 前綴**＝缺檔 fail-closed（spec §R3 Scenario「刪除
-> EnvironmentFile」）。`CapabilityBoundingSet=`（空）＝丟掉所有 capability；若第 5 步
-> 選 CAP_SETUID 方案，這裡要改成 `CapabilityBoundingSet=CAP_SETUID CAP_SETGID
-> CAP_SETPCAP` 並加 `AmbientCapabilities=`——**但這會擴大 Manager 權限，見未決 1**。
+> EnvironmentFile」）。`CapabilityBoundingSet=`（空）＝丟掉所有 capability，且因為
+> 未決 1 已裁決走 `systemd-run`（由 PID 1 代為切換身分，Manager 自己不需要任何
+> capability），**這裡維持空集合，不加 `AmbientCapabilities=`**——落選的 CAP_SETUID
+> 方案才需要放寬，那正是它被否決的理由。
 
 ```bash
 # ✅ 驗證：unit 以 cortex-svc 跑、加固生效
@@ -390,37 +395,115 @@ Manager（cortex-svc）spawn headless job 時降到 `cortex-builder`，且：
   沿用 D1 outbox）；
 - 只暴露該 job 自己被 chown 的 worktree 子目錄。
 
-> **⚠️ 未決 1（降權機制最終形態，最高風險決策）**：unprivileged 的 cortex-svc
-> 無法直接 setuid 到 cortex-builder。三個候選，operator 擇一：
+> **✅ 未決 1 已裁決（operator 0816 第二輪）**：降權機制＝**`systemd-run` transient
+> unit**（方案 A）。落選案留檔備查：B（最小 setuid 助手）引入 setuid 二進位＝新攻擊面；
+> C（Manager 授 `CAP_SETUID`）可切到**任意** uid，等於放大 Manager 權限。
 >
-> | 方案 | 做法 | 代價 |
-> |---|---|---|
-> | **A. `systemd-run` transient unit**（建議） | Manager 呼叫 `systemd-run --uid=cortex-builder --pipe --collect --property=...` 起 job；乾淨環境天然關 FD／scrub env | 需一條 **narrow polkit rule** 允許 cortex-svc 對 `cortex-builder` 起 transient unit；WSL2 的 polkit 行為需先在拋棄式環境驗 |
-> | **B. 最小 setuid 助手** | root 擁有、setuid-root、**寫死只 exec 成 cortex-builder** 的小程式，cortex-svc 可呼叫 | 引入一支 setuid 二進位＝新攻擊面，需嚴格審查與 argv 白名單 |
-> | **C. Manager 授 `CAP_SETUID`** | unit 加 `AmbientCapabilities=CAP_SETUID CAP_SETGID` | CAP_SETUID 可變成**任意** uid，等於放大 Manager 權限，最不建議 |
->
-> 本 runbook 以 **方案 A** 為預設示例；operator 定案前**第 5 步不可執行**。
+> 程式碼面已落地（Phase 2a，`paulsha_cortex/coordinator/job_runner.py`）：
+> `PSC_JOB_RUNNER` 預設 `direct`（現行行為不變），設為 `systemd-run` 才降權。
+> **本步驟即「把那個開關打開」的部署動作**，前提是本 runbook 第 1 步的帳號已建立、
+> 以及下面的 polkit 規則已就位。
+
+### 5a. Manager 端會實際發出的 argv（polkit 規則要收窄的那個面）
+
+`job_runner.build_systemd_run_argv()` 產出的形狀是**封閉**的（新增旗標要改程式碼並過
+測試），因此 polkit 規則可以據此收窄：
+
+```text
+systemd-run --quiet --collect --pipe --wait \
+  --unit=cortex-job-<job_id 片段>-<sha256 前 8 碼>.service \
+  --uid=cortex-builder --gid=cortex-builder \
+  --service-type=exec \
+  --working-directory=<該 job 的 worktree> \
+  --property=NoNewPrivileges=yes \
+  --setenv=<白名單 env 逐項> \
+  -- bash -c '<job wrapper script>'
+```
+
+- unit 名前綴固定為 `cortex-job-`（`job_runner.UNIT_NAME_PREFIX`，polkit 以
+  `action.lookup("unit")` 比對的就是它）；接上 job_id 的 sha256 前 8 碼確保消毒後仍唯一。
+- `--wait` 讓 client 與 unit 同壽命，Manager 既有的 `pid_alive()` 判活不必改。
+- `--quiet` 是必要的：`systemd-run` 的狀態訊息會被 `--pipe` 導進 job 的 JSONL log，
+  那份 log 是 terminal evidence 的來源。
+- FD：只有 stdin/stdout/stderr 三個（Python `close_fds=True`），且 **stdin 顯式接
+  `/dev/null`**；stdout/stderr 是 Manager 開的 job log。
+- **env 不是 scrub 黑名單，而是白名單**：transient unit 不繼承呼叫端的 environ，
+  job 只看得到 `--setenv` 列出的那幾項（`PATH`／`LANG`／`LC_ALL`／`LC_CTYPE`／
+  `SSL_CERT_FILE`／`SSL_CERT_DIR`／`NODE_EXTRA_CA_CERTS` ＋ `PSC_JOB_ID`／
+  `PSC_SLICE_ID`／`PSC_REPO_ROOT`／選配的 `PSC_RELAY_TARGET`／`HOME`）。
+  gh token、daemon 的 `CLAUDE_CONFIG_DIR`／`GH_CONFIG_DIR` 都**不在**白名單上。
 
 ```bash
-# ⚠️ 未決 1：以下為方案 A 的 polkit rule 示例（待 operator 定案）
-# 🔧 operator sudo：/etc/polkit-1/rules.d/49-cortex-spawn.rules（示例）
+# ✅ 驗證（不需 root）：印出本機會發出的白名單與旗標，與上表逐項對照
+python3 - <<'PY'
+from paulsha_cortex.coordinator import job_runner
+for item in job_runner.BUILDER_FORWARDED_ENV:
+    print(f"{item.name:22} {item.rationale}")
+print("synthesized:", job_runner.BUILDER_SYNTHESIZED_ENV)
+print("unit prefix:", job_runner.UNIT_NAME_PREFIX)
+print("properties :", job_runner.TRANSIENT_UNIT_PROPERTIES)
+PY
+```
+
+### 5b. polkit 規則（收窄到「只能以 cortex-builder 身分、限定 unit 名」）
+
+```bash
+# 🔧 operator sudo：/etc/polkit-1/rules.d/49-cortex-spawn.rules
 sudo tee /etc/polkit-1/rules.d/49-cortex-spawn.rules >/dev/null <<'RULES'
-// 僅允許 cortex-svc 對 cortex-builder 起 transient unit（最小授權）
+// 僅允許 cortex-svc 起「cortex-job-」前綴的 transient unit（最小授權）。
+// 注意：unit 名是 Manager 端產生的（job_runner.UNIT_NAME_PREFIX），這條規則與
+// 那個常數是成對契約——改任一邊都必須同步改另一邊。
 polkit.addRule(function(action, subject) {
-  if (action.id == "org.freedesktop.systemd1.manage-units" &&
-      subject.user == "cortex-svc") {
-    // TODO(operator): 收斂到只允許 --uid=cortex-builder 的 unit 名前綴
+  if (subject.user !== "cortex-svc") {
+    return polkit.Result.NOT_HANDLED;
+  }
+  if (action.id !== "org.freedesktop.systemd1.manage-units") {
+    return polkit.Result.NOT_HANDLED;
+  }
+  var unit = action.lookup("unit");
+  if (unit && unit.indexOf("cortex-job-") === 0 && unit.indexOf(".service", unit.length - 8) !== -1) {
     return polkit.Result.YES;
   }
+  return polkit.Result.NOT_HANDLED;
 });
 RULES
 ```
 
+> **⚠️ 殘餘限制（誠實標註）**：polkit 的 `manage-units` action 只暴露 unit **名稱**，
+> **不暴露 `User=`／`--uid=`**。因此「只能降到 cortex-builder」這一半在 polkit 層
+> 無法強制，只能由 Manager 端的封閉 argv 產生器保證（`--uid` 來自
+> `PSC_BUILDER_ACCOUNT`，值受 POSIX 帳號名 pattern 檢查、拒絕注入）。要在 OS 層
+> 也硬化這一半，需另設一支 root 擁有的 wrapper unit template 並只授權該 template
+> ——屬 Phase 3 的加固，不是 0.2.0 的 join gate。
+
+### 5c. 打開開關（Manager env）
+
 ```bash
-# ✅ 驗證：以 cortex-svc 起一個降到 cortex-builder 的 transient job，檢查身分/FD/token
-sudo -u cortex-svc systemd-run --uid=cortex-builder --pipe --wait --collect \
+# 🔧 operator sudo：把降權模式寫進 Manager 的 EnvironmentFile（見第 4b 步）
+#   PSC_JOB_RUNNER=systemd-run        # 必要；預設 direct＝不降權
+#   PSC_BUILDER_ACCOUNT=cortex-builder # 選配（預設值即此）
+#   PSC_BUILDER_HOME=/var/lib/cortex-builder  # 選配；未設時 systemd 依 passwd 填
+#   PSC_BUILDER_PATH=...              # 選配；模型 CLI 不在 Manager PATH 上時用
+sudo systemctl restart cortex-manager
+```
+
+builder 帳號必須自己具備模型 CLI 的登入態（`sudo -u cortex-builder claude /login` 之類），
+**Manager 不會把自己的憑證傳過去**——那正是本步驟的重點。
+
+```bash
+# ✅ 驗證 1：以 cortex-svc 起一個降到 cortex-builder 的 transient job，檢查身分/FD/token
+sudo -u cortex-svc systemd-run --quiet --collect --pipe --wait \
+  --unit=cortex-job-smoke-00000000.service \
+  --uid=cortex-builder --gid=cortex-builder --service-type=exec \
+  --property=NoNewPrivileges=yes \
   /bin/sh -c 'id; echo "GH_TOKEN=[$GH_TOKEN]"; ls -l /proc/self/fd'
-# 期望：uid=cortex-builder；GH_TOKEN 為空；/proc/self/fd 無指向受保護資產的可寫 fd
+# 期望：uid=cortex-builder；GH_TOKEN 為空；/proc/self/fd 只有 0/1/2
+```
+
+```bash
+# ✅ 驗證 2（負控制）：暫時移除 polkit 規則後，dispatch 必須 fail-closed 而非退回 direct
+#   期望：job 落 needs_human，理由碼 job-runner-transient-unit-start-failed，
+#   detail 帶 systemd-run 的實際拒絕訊息。**不得**出現以 cortex-svc 身分跑起來的 job。
 ```
 
 ---
@@ -546,9 +629,11 @@ echo "PSC_DEGRADED_OPERATION=$PSC_DEGRADED_OPERATION"     # 期望 per-case-appr
 
 ## 對 WSL2 環境，本 runbook 最不確定／最高風險的步驟
 
-1. **第 5 步降權機制（最高風險）**：unprivileged→unprivileged 的降權在 WSL2 上
-   （polkit daemon 是否常駐、`systemd-run --uid` transient unit 行為）需**先在拋棄式
-   環境跑通 R9 族 4** 再上正式機。三個方案各有攻擊面權衡（未決 1）。
+1. **第 5 步降權機制（最高風險）**：機制已裁決為 `systemd-run` transient unit 且程式碼
+   已落地（`PSC_JOB_RUNNER=systemd-run`），但 WSL2 上 polkit daemon 是否常駐、
+   `systemd-run --uid` 的實際行為仍需**先在拋棄式環境跑通 R9 族 4** 再上正式機。
+   啟動器對「systemd 不可用／帳號不存在／unit 起不來（含 polkit 拒絕）」一律
+   fail-closed，不會靜默退回同 UID 執行——負控制驗證見第 5c 步驗證 2。
 2. **第 4c system-level unit 在 WSL2 的持久性**：WSL 關閉/重啟後 systemd system session
    是否可靠拉起 `cortex-manager.service`；lingering 對 system unit 無效，需驗 boot 行為。
 3. **第 4c 加固誤擋**：`ProtectSystem=strict` + `ReadWritePaths` 白名單若漏列某條實際

--- a/paulsha_cortex/coordinator/job_runner.py
+++ b/paulsha_cortex/coordinator/job_runner.py
@@ -1,0 +1,720 @@
+"""Phase 2a 降權啟動器：builder headless job 經 `systemd-run` transient unit 降權。
+
+trust-root spec（`docs/superpowers/specs/trust-root-isolation-spec.md`）§R10 Phase 2
+第 5 條要求「**降權啟動器**：Manager 以降權方式 spawn headless job，明確關閉 FD 傳遞、
+不傳遞 gh token」。operator 0816 第二輪裁決把「未決 1（降權機制）」收斂為
+**systemd-run transient unit**、UID **二分**（`cortex-svc` / `cortex-builder`），並要求
+polkit 授權面收窄到「cortex-svc 只能以 cortex-builder 身分、限定 unit 屬性起 job」。
+
+本模組是那條裁決的**程式碼面**：組出降權 argv、算出 builder 專屬的 env 白名單、對
+「systemd 不可用／帳號不存在／transient unit 起不來（含 polkit 拒絕）」fail-closed。
+
+## 誠實邊界（非常重要）
+
+**本模組不會讓任何既有部署自動降權。** `PSC_JOB_RUNNER` 預設 `direct`＝現行行為
+逐字不變；只有 operator 在 Phase 2b 建好 `cortex-builder` 帳號＋polkit 規則之後，把
+`PSC_JOB_RUNNER=systemd-run` 寫進 Manager 的 env，降權才會生效。切換是**部署期動作**，
+不是這支程式碼的預設。
+
+## 為什麼 transient unit 天然解掉 #588 的一半
+
+issue #588 的兩條缺口：(1) builder 繼承 daemon 全部 environ（含 token 與 daemon 自己的
+`CLAUDE_CONFIG_DIR`）；(2) builder 走 `bash -lc`（login shell），`~/.profile` 會在
+launcher 設好 env 之後重新匯入 operator 環境，把任何 env 約束覆寫掉。
+
+- 對 (1)：transient unit **不繼承呼叫端的環境**——unit 的環境是 PID 1 的 manager
+  environment 加上我們顯式列出的 `--setenv`。因此「不傳 token」在這裡不是靠 scrub
+  黑名單，而是靠「只有白名單裡的名字會被送進去」這個結構事實（見
+  :data:`BUILDER_FORWARDED_ENV`）。為了不讓 PID 1 環境的殘留（主要是 PATH）滲進來，
+  白名單一律顯式設定 `PATH`。
+- 對 (2)：降權模式的 shell 一律 `bash -c`（非 `-lc`），與 reviewer 早已採用的作法一致。
+  direct 模式**維持現行 `-lc` 不動**（零回歸），只有 systemd-run 模式改。
+
+## FD
+
+`--pipe` 讓 transient unit 的 stdio 接上呼叫端的 stdin/stdout/stderr——這正是 JSONL log
+與 exit sentinel 得以沿用既有 harvest 管線的原因。除了這三個 fd 之外沒有任何東西被傳遞：
+Python `Popen` 預設 `close_fds=True`，且 launcher 在降權模式顯式把 stdin 接 `/dev/null`
+（direct 模式今天還會把 daemon 的 stdin 交給 job——降權模式在這點上比 direct 更緊）。
+
+## 為什麼要 `--wait`
+
+`dispatcher.pid_alive()` 以 `os.kill(pid, 0)` 判活。`--wait` 讓 `systemd-run` 這個 client
+行程存活到 unit 結束為止，因此 `LaunchHandle.pid` 仍然是一個「與 job 同壽命」的 pid，
+既有的存活判定不必改。少了 `--wait`，client 會立刻返回，dispatcher 會把還在跑的 job
+判成已死。
+
+## 為什麼要 `--quiet`
+
+`systemd-run` 會把 "Running as unit: …" 之類的狀態訊息寫到 stderr，而 launcher 把
+stderr 併進 JSONL log（`stderr=STDOUT`）。不加 `--quiet` 就等於在 terminal evidence 的
+來源檔裡插入非 JSON 行。
+
+本模組只組字串與做唯讀探測，**不執行任何 root 操作、不建帳號、不寫 polkit**。
+"""
+from __future__ import annotations
+
+import grp
+import hashlib
+import os
+import pwd
+import re
+import shutil
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Mapping, Sequence
+
+from .diagnostics import DiagnosticReason, diagnostic_reason
+
+__all__ = [
+    "BUILDER_ACCOUNT_ENV",
+    "BUILDER_FORWARDED_ENV",
+    "BUILDER_GROUP_ENV",
+    "BUILDER_HOME_ENV",
+    "BUILDER_PATH_ENV",
+    "BUILDER_SYNTHESIZED_ENV",
+    "CREDENTIAL_ENV_RE",
+    "DEFAULT_BUILDER_ACCOUNT",
+    "DEFAULT_START_TIMEOUT_MS",
+    "ForwardedEnvVar",
+    "JOB_RUNNER_ENV",
+    "JobRunnerError",
+    "RUNNER_DIRECT",
+    "RUNNER_MODES",
+    "RUNNER_SYSTEMD_RUN",
+    "START_TIMEOUT_ENV",
+    "SystemdRunPlan",
+    "TRANSIENT_UNIT_PROPERTIES",
+    "UNIT_NAME_PREFIX",
+    "build_builder_env",
+    "build_systemd_run_argv",
+    "confirm_transient_unit_started",
+    "preflight_systemd_run",
+    "prepare_systemd_run",
+    "resolve_builder_account",
+    "resolve_builder_group",
+    "resolve_runner_mode",
+    "resolve_start_timeout_ms",
+    "transient_unit_name",
+]
+
+
+# ---------------------------------------------------------------------------
+# config（全部走 env；預設值＝現行行為）
+# ---------------------------------------------------------------------------
+
+#: 執行模式開關。`direct`（預設）＝現行 `Popen(bash -lc …)`；`systemd-run`＝降權。
+JOB_RUNNER_ENV = "PSC_JOB_RUNNER"
+
+#: builder 的 OS 帳號名。預設對齊 `trust_root.permgen.TWO_WAY_SCHEME` 的
+#: `Principal.BUILDER` → `cortex-builder`；可 config 是為了對齊 permgen 的
+#: `UidScheme` 參數化（二分→三分只換 config，不改程式碼）。
+BUILDER_ACCOUNT_ENV = "PSC_BUILDER_ACCOUNT"
+DEFAULT_BUILDER_ACCOUNT = "cortex-builder"
+
+#: builder 的 primary group。未設時沿用 `UidScheme.group_of()` 的慣例（每帳號一個同名
+#: group），因此預設等於帳號名。
+BUILDER_GROUP_ENV = "PSC_BUILDER_GROUP"
+
+#: builder 自己的 HOME。**未設時刻意不傳 HOME**——systemd 對設了 `User=` 的 unit 會
+#: 依 passwd 自行填入該帳號的 `$HOME`／`$USER`／`$LOGNAME`／`$SHELL`，那份值必然正確；
+#: 反之 daemon 的 HOME 絕不可轉發（那是 cortex-svc 的樹，且是 #588 第 1 點的核心）。
+BUILDER_HOME_ENV = "PSC_BUILDER_HOME"
+
+#: builder 的 PATH 覆寫。未設時轉發 Manager 的 PATH（見 `BUILDER_FORWARDED_ENV`）；
+#: Phase 2b 若把模型 CLI 裝在 builder 才讀得到的路徑，用這個覆寫。
+BUILDER_PATH_ENV = "PSC_BUILDER_PATH"
+
+#: transient unit 起動確認窗（毫秒）。見 :func:`confirm_transient_unit_started`。
+START_TIMEOUT_ENV = "PSC_JOB_RUNNER_START_TIMEOUT_MS"
+DEFAULT_START_TIMEOUT_MS = 200
+
+RUNNER_DIRECT = "direct"
+RUNNER_SYSTEMD_RUN = "systemd-run"
+RUNNER_MODES = (RUNNER_DIRECT, RUNNER_SYSTEMD_RUN)
+
+#: transient unit 名前綴。polkit 規則以 `action.lookup("unit")` 收窄授權面時，比對的
+#: 就是這個前綴（見 Phase 2b runbook 第 5 步）——因此它是**契約**，不可隨手改。
+UNIT_NAME_PREFIX = "cortex-job-"
+
+#: transient unit 的封閉屬性集合。polkit 規則要「限定 unit 屬性」，前提是 Manager 端
+#: 產出的屬性集合是**固定且最小**的；因此這裡刻意不開放 config 疊加。
+#:
+#: - `NoNewPrivileges=yes`：builder 內部不得再提權（setuid 二進位對它失效）。
+#:   `ReadWritePaths=` 等與部署路徑相關的加固**不在這裡**——它們由 Phase 1 登記表經
+#:   `trust_root.permgen` 機械產生並寫進 unit／runbook（operator 未決 5 的裁決），
+#:   在啟動器裡手寫會變成第二份真相。
+TRANSIENT_UNIT_PROPERTIES = ("NoNewPrivileges=yes",)
+
+
+# ---------------------------------------------------------------------------
+# 憑證形狀（與 launcher 共用同一份 pattern，避免兩處漂移）
+# ---------------------------------------------------------------------------
+
+#: 憑證形狀的 env 名稱。`launcher._CREDENTIAL_ENV_RE` 直接別名到這裡，兩處永遠同一份。
+CREDENTIAL_ENV_RE = re.compile(
+    r"(?:^|_)(?:API_?KEY|AUTH|COOKIE|CREDENTIALS?|PASSWORD|PRIVATE_?KEY|SECRET|TOKEN)(?:$|_)",
+    re.IGNORECASE,
+)
+
+#: 明列的必拒名單。`CREDENTIAL_ENV_RE` 已涵蓋 `*_TOKEN`／`*_API_KEY` 這類形狀，但
+#: 有幾個名字不帶憑證字樣卻同樣是 trust-root 資產，必須逐一點名：
+#:
+#: - `CLAUDE_CONFIG_DIR`：#588 第 1 點——builder 繼承 daemon 的 config dir 等於拿到
+#:   daemon 的登入態與信任設定（Tier-0 資產）。builder 的登入態必須是 builder 帳號
+#:   自己 HOME 底下那一份（Phase 2b 由 operator 以 cortex-builder 身分登入）。
+#: - `GH_CONFIG_DIR`／`GH_HOST`：同理，gh CLI 的設定樹指向 daemon 的憑證。
+#: - `BASH_ENV`／`ENV`／`SHELLOPTS`／`BASHOPTS`：非互動 bash 會 source `$BASH_ENV`，
+#:   等於在 `bash -c` 之下重開一個 #588 第 2 點的注入孔。
+#: - `LD_PRELOAD`／`LD_LIBRARY_PATH`／`PYTHONPATH`／`PYTHONSTARTUP`／`NODE_OPTIONS`：
+#:   都能讓呼叫端把程式碼注進 builder 的行程。
+DENIED_ENV_NAMES = frozenset(
+    {
+        "BASHOPTS",
+        "BASH_ENV",
+        "CLAUDE_CONFIG_DIR",
+        "ENV",
+        "GH_CONFIG_DIR",
+        "GH_HOST",
+        "LD_LIBRARY_PATH",
+        "LD_PRELOAD",
+        "NODE_OPTIONS",
+        "PYTHONPATH",
+        "PYTHONSTARTUP",
+        "SHELLOPTS",
+    }
+)
+
+
+class JobRunnerError(ValueError):
+    """降權啟動器 fail-closed。
+
+    刻意繼承 ``ValueError``：本 repo 全部的 fail-closed 驗證都是 ``ValueError``，
+    daemon 的 tick isolation（#246）攔的也是 ``(ValueError, RuntimeError, OSError)``，
+    因此一次派工失敗不會打掛 daemon，但**絕不會**退回 direct 模式。
+
+    ``diagnostic`` 是 #570／#527 的 :class:`DiagnosticReason` 契約：呼叫端把它落進
+    run／slice 的 needs_human 理由，operator 不必反推是哪一條路徑拒絕的。
+    """
+
+    def __init__(self, diagnostic: DiagnosticReason) -> None:
+        self.diagnostic = diagnostic
+        # `rendered()`＝`<reason>: <detail> (source=…)`。既有呼叫端（autonomy 的
+        # `_mark_slice_needs_human(reason=str(exc))`）拿到的字串因此已經含有機器可讀
+        # 分類碼與來源位置，不必先改呼叫端就有可稽核的理由。
+        super().__init__(diagnostic.rendered())
+
+
+def _fail(reason: str, detail: str, *, source: str, **context: object) -> JobRunnerError:
+    return JobRunnerError(
+        diagnostic_reason(reason, detail, source=f"job_runner.{source}", **context)
+    )
+
+
+# ---------------------------------------------------------------------------
+# 模式與身分解析
+# ---------------------------------------------------------------------------
+
+def resolve_runner_mode(env: Mapping[str, str]) -> str:
+    """解析 `PSC_JOB_RUNNER`。未設＝`direct`；不認得的值 fail-closed。
+
+    刻意**不**把非法值當成 `direct`：一個打錯字的部署設定若被靜默解讀成「不降權」，
+    operator 會以為隔離已生效而實際上沒有——那正是本票要消除的失效模式。
+    """
+
+    raw = (env.get(JOB_RUNNER_ENV) or "").strip()
+    if not raw:
+        return RUNNER_DIRECT
+    mode = raw.lower()
+    if mode not in RUNNER_MODES:
+        raise _fail(
+            "job-runner-mode-invalid",
+            f"{JOB_RUNNER_ENV} 只能是 {' 或 '.join(RUNNER_MODES)}，收到 {raw!r}",
+            source="resolve_runner_mode",
+            requested=raw,
+        )
+    return mode
+
+
+def _resolve_identity(env: Mapping[str, str], *, key: str, default: str, source: str) -> str:
+    raw = (env.get(key) or "").strip()
+    name = raw or default
+    # POSIX 帳號名的保守形狀；同時擋掉把 shell/argv metacharacter 塞進 `--uid=` 的用法。
+    if re.fullmatch(r"[a-z_][a-z0-9_-]{0,31}", name) is None:
+        raise _fail(
+            "job-runner-account-name-invalid",
+            f"{key} 非法的 POSIX 帳號／群組名: {name!r}",
+            source=source,
+            requested=name,
+        )
+    return name
+
+
+def resolve_builder_account(env: Mapping[str, str]) -> str:
+    """builder 的 OS 帳號名（`PSC_BUILDER_ACCOUNT`，預設 `cortex-builder`）。"""
+
+    return _resolve_identity(
+        env,
+        key=BUILDER_ACCOUNT_ENV,
+        default=DEFAULT_BUILDER_ACCOUNT,
+        source="resolve_builder_account",
+    )
+
+
+def resolve_builder_group(env: Mapping[str, str]) -> str:
+    """builder 的 primary group（`PSC_BUILDER_GROUP`，預設＝帳號名）。
+
+    預設值沿用 `trust_root.permgen.UidScheme.group_of()`：每帳號一個同名 group。
+    """
+
+    return _resolve_identity(
+        env,
+        key=BUILDER_GROUP_ENV,
+        default=resolve_builder_account(env),
+        source="resolve_builder_group",
+    )
+
+
+def resolve_start_timeout_ms(env: Mapping[str, str]) -> int:
+    """起動確認窗（毫秒）。非法值 fail-closed，不靜默落回預設。"""
+
+    raw = (env.get(START_TIMEOUT_ENV) or "").strip()
+    if not raw:
+        return DEFAULT_START_TIMEOUT_MS
+    try:
+        value = int(raw)
+    except ValueError as exc:
+        raise _fail(
+            "job-runner-start-timeout-invalid",
+            f"{START_TIMEOUT_ENV} 必須是整數毫秒，收到 {raw!r}",
+            source="resolve_start_timeout_ms",
+            requested=raw,
+        ) from exc
+    if value < 0:
+        raise _fail(
+            "job-runner-start-timeout-invalid",
+            f"{START_TIMEOUT_ENV} 不得為負，收到 {raw!r}",
+            source="resolve_start_timeout_ms",
+            requested=raw,
+        )
+    return value
+
+
+# ---------------------------------------------------------------------------
+# env 白名單
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class ForwardedEnvVar:
+    """一個可從 Manager env 轉發給 builder 的變數，附「為何需要」。
+
+    `rationale` 不是註解裝飾：白名單的每一項都是一個刻意打開的孔，理由必須跟著值走，
+    未來要收窄時才有依據。
+    """
+
+    name: str
+    rationale: str
+
+
+#: **轉發類**白名單：只有這些名字會從 Manager env 複製進 transient unit。
+#:
+#: 白名單的判準：(a) 缺了它模型 CLI 或 wrapper 會直接失敗；(b) 它本身不是憑證、
+#: 也不指向任何 trust-root 資產。不符合任一條的一律不列——包含所有 token、
+#: `CLAUDE_CONFIG_DIR`／`GH_CONFIG_DIR`、以及下面「刻意排除」段列出的項目。
+BUILDER_FORWARDED_ENV: tuple[ForwardedEnvVar, ...] = (
+    ForwardedEnvVar(
+        "PATH",
+        # 沒有 PATH，transient unit 只會拿到 PID 1 的 manager PATH（通常是
+        # /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin），裡面沒有 npm global／
+        # pipx shim，`claude`／`codex`／`copilot` 一律 127；wrapper 內的 `python3`
+        # （gate ledger writer，見 launcher.build_wrapper_script）與 `git`（builder
+        # 要 commit candidate）同樣靠它解析。可用 PSC_BUILDER_PATH 覆寫成 builder
+        # 帳號讀得到的路徑。
+        "模型 CLI（claude／codex／copilot）、wrapper 的 python3 gate writer 與 git 的解析路徑",
+    ),
+    ForwardedEnvVar(
+        "LANG",
+        # claude／copilot 是 node CLI、codex 是 rust CLI，prompt 與 candidate 檔案
+        # 常含非 ASCII（本 repo 的 spec／CHANGELOG 全是 zh-tw）；locale 缺失時
+        # wrapper 內的 python3 會以 ASCII 解讀檔案而丟 UnicodeDecodeError。
+        "UTF-8 locale：prompt／spec／CHANGELOG 皆含 zh-tw，缺 locale 會讓 gate writer 解碼失敗",
+    ),
+    ForwardedEnvVar(
+        "LC_ALL",
+        "同 LANG（覆寫優先序較高的那一個），與 reviewer 既有最小 env 的 LC_* 處置一致",
+    ),
+    ForwardedEnvVar(
+        "LC_CTYPE",
+        "同 LANG；只轉發字元分類這一項，其餘 LC_*（金額／日期格式）對 headless job 無意義",
+    ),
+    ForwardedEnvVar(
+        "SSL_CERT_FILE",
+        # 值是 CA bundle 的**路徑**，不是憑證內容；企業／自簽 CA 環境下缺它，
+        # 模型 CLI 對 API 端點的 HTTPS 直接失敗，且失敗訊息與「未登入」難以區分。
+        "自訂 CA 環境下 python/openssl 的 CA bundle 路徑（值是路徑，非憑證內容）",
+    ),
+    ForwardedEnvVar(
+        "SSL_CERT_DIR",
+        "同 SSL_CERT_FILE 的目錄形式",
+    ),
+    ForwardedEnvVar(
+        "NODE_EXTRA_CA_CERTS",
+        # claude／copilot CLI 是 node 進程，node 不讀 SSL_CERT_FILE，只讀這一個。
+        "node 版模型 CLI（claude／copilot）唯一認得的額外 CA 路徑",
+    ),
+)
+
+#: **合成類**白名單：由 launcher 現場算出、絕不從 Manager env 繼承的變數。
+#:
+#: - `PSC_JOB_ID`：#506／D5 的 headless job 標記，`porcelain/headless_hook.py`
+#:   沒有它就是完全 no-op；#587／#588 第 3 點另有 job_id 語意收斂的後續。
+#: - `PSC_SLICE_ID`：既有 job 標記（launcher 現行行為）。
+#: - `PSC_REPO_ROOT`：relay hook 的 script 解析點，以及 wrapper 內 gate ledger writer
+#:   的 `PYTHONPATH`。Phase 2b 之後它指向 root-owned 部署樹，builder 唯讀。
+#: - `PSC_RELAY_TARGET`：僅在 launcher 有設定時才出現（與 direct 模式同條件）。
+#: - `HOME`：僅在 `PSC_BUILDER_HOME` 明示時才設；未設時交給 systemd 依 passwd 填入
+#:   builder 帳號自己的 HOME。**任何情況下都不會是 daemon 的 HOME。**
+BUILDER_SYNTHESIZED_ENV = (
+    "HOME",
+    "PSC_JOB_ID",
+    "PSC_RELAY_TARGET",
+    "PSC_REPO_ROOT",
+    "PSC_SLICE_ID",
+)
+
+#: 刻意**不**轉發、且值得記錄理由的項目（本身不是憑證，但轉發會出錯或擴大信任面）：
+#:
+#: - `HOME`／`USER`／`LOGNAME`／`SHELL`：systemd 對設了 `User=` 的 unit 會依 passwd
+#:   自行填入正確的值；轉發 daemon 的版本只會指回 cortex-svc 的樹。
+#: - `TMPDIR`：Manager unit 若啟用 `PrivateTmp=`，它的 TMPDIR 是 builder 進不去的
+#:   命名空間路徑；不轉發，讓 builder 用預設 `/tmp`。
+#: - `XDG_*`：預設由 HOME 推導；轉發 daemon 的值會讓 builder 的 cache／config 落回
+#:   cortex-svc 的樹（Manager-owned，builder 無寫入權 → 模型 CLI 起不來）。
+#: - `HTTP_PROXY`／`HTTPS_PROXY`／`NO_PROXY`：proxy URL 可內嵌 `user:pass@`，屬憑證面。
+#:   需要 proxy 的部署由 builder 自己的 systemd drop-in／EnvironmentFile 提供，不由
+#:   Manager 轉發。
+#: - `VIRTUAL_ENV`／`PYTHONHOME`：指向 Manager 的部署 venv；builder 的 python 應由
+#:   PATH 決定，不該被綁進 Manager 的 venv。
+EXCLUDED_ENV_RATIONALE: Mapping[str, str] = {
+    "HOME": "systemd 依 passwd 填入 builder 自己的 HOME；daemon 的 HOME 絕不轉發",
+    "HTTPS_PROXY": "proxy URL 可內嵌 user:pass，屬憑證面；由 builder 自己的 drop-in 提供",
+    "HTTP_PROXY": "同 HTTPS_PROXY",
+    "LOGNAME": "systemd 依 passwd 填入",
+    "NO_PROXY": "與 *_PROXY 成對，單獨轉發無意義",
+    "PYTHONHOME": "會把 builder 綁進 Manager 的部署 venv",
+    "SHELL": "systemd 依 passwd 填入",
+    "TMPDIR": "Manager 若啟用 PrivateTmp=，該路徑 builder 進不去",
+    "USER": "systemd 依 passwd 填入",
+    "VIRTUAL_ENV": "指向 Manager 部署 venv，builder 的 python 應由 PATH 決定",
+    "XDG_CACHE_HOME": "轉發會讓 builder 的 cache 落回 cortex-svc 的樹",
+    "XDG_CONFIG_HOME": "轉發會讓 builder 的 config 落回 cortex-svc 的樹",
+    "XDG_RUNTIME_DIR": "cortex-svc 的 runtime dir，builder 無權存取",
+}
+
+
+def _reject_unsafe(env: Mapping[str, str], *, source: str) -> None:
+    """最後一道守衛：白名單即使被改壞，憑證形狀與注入孔仍然出不去。
+
+    白名單是靜態的，正常情況下這個檢查永遠不會命中——它存在的意義是：往
+    `BUILDER_FORWARDED_ENV` 加一項憑證形狀的變數時，**測試會當場紅**，而不是等
+    dogfooding 現場才發現 token 又跟著 job 出去了。
+    """
+
+    for key, value in env.items():
+        if CREDENTIAL_ENV_RE.search(key) is not None or key in DENIED_ENV_NAMES:
+            raise _fail(
+                "job-runner-credential-env-leak",
+                f"builder env 白名單命中憑證／注入形狀變數: {key}",
+                source=source,
+                variable=key,
+            )
+        if "\n" in value or "\0" in value:
+            raise _fail(
+                "job-runner-env-value-invalid",
+                f"builder env 值含換行或 NUL，無法安全交給 systemd --setenv: {key}",
+                source=source,
+                variable=key,
+            )
+
+
+def build_builder_env(
+    *,
+    manager_env: Mapping[str, str],
+    job_id: str,
+    slice_id: str,
+    repo_root: str,
+    relay_target: str | None = None,
+) -> dict[str, str]:
+    """算出 builder transient unit 的**完整**環境（白名單，非黑名單 scrub）。
+
+    回傳值就是會逐項變成 `--setenv=` 的內容——沒列在這裡的名字不會出現在 job 的
+    環境裡，因為 transient unit 本來就不繼承呼叫端的 environ。
+    """
+
+    env: dict[str, str] = {}
+    for forwarded in BUILDER_FORWARDED_ENV:
+        value = manager_env.get(forwarded.name)
+        if value:
+            env[forwarded.name] = value
+    path_override = (manager_env.get(BUILDER_PATH_ENV) or "").strip()
+    if path_override:
+        env["PATH"] = path_override
+    home = (manager_env.get(BUILDER_HOME_ENV) or "").strip()
+    if home:
+        env["HOME"] = home
+    env["PSC_SLICE_ID"] = slice_id
+    env["PSC_JOB_ID"] = job_id
+    env["PSC_REPO_ROOT"] = repo_root
+    if relay_target is not None:
+        env["PSC_RELAY_TARGET"] = relay_target
+    _reject_unsafe(env, source="build_builder_env")
+    return env
+
+
+# ---------------------------------------------------------------------------
+# transient unit
+# ---------------------------------------------------------------------------
+
+def transient_unit_name(job_id: str) -> str:
+    """`cortex-job-<可辨識片段>-<job_id 雜湊>.service`。
+
+    兩個需求同時滿足：
+    - **可追蹤**：unit 名帶得出 job_id 的可讀片段，`systemctl list-units` 與 journal
+      能一眼對回 registry 的 job。
+    - **唯一且合法**：job_id 不保證只含 systemd unit 名允許的字元，直接消毒又可能
+      讓兩個不同 job_id 撞成同一個 unit（第二個會起不來）。因此固定接上 job_id 的
+      sha256 前 8 碼——消毒後相同也不會碰撞。
+    """
+
+    raw = str(job_id).strip()
+    if not raw:
+        raise _fail(
+            "job-runner-unit-name-invalid",
+            "job_id 為空，無法組出可追蹤的 transient unit 名",
+            source="transient_unit_name",
+        )
+    slug = re.sub(r"[^A-Za-z0-9_.-]", "-", raw).strip("-")[:64]
+    digest = hashlib.sha256(raw.encode("utf-8")).hexdigest()[:8]
+    if not slug:
+        slug = "job"
+    return f"{UNIT_NAME_PREFIX}{slug}-{digest}.service"
+
+
+def build_systemd_run_argv(
+    *,
+    systemd_run: str,
+    unit: str,
+    account: str,
+    group: str,
+    working_directory: str,
+    env: Mapping[str, str],
+    command: Sequence[str],
+) -> list[str]:
+    """組出降權 argv。
+
+    旗標逐項理由（同時是 Phase 2b polkit 規則要收窄的那個面）：
+
+    - `--quiet`：不要把 "Running as unit: …" 寫進 JSONL log（terminal evidence 來源）。
+    - `--collect`：unit 結束即卸載，不留 failed unit 殘骸讓下一次同名 job 起不來。
+    - `--pipe`：把 job 的 stdout/stderr 接回 launcher 開的 log fd，沿用既有 harvest。
+    - `--wait`：client 存活到 unit 結束，`dispatcher.pid_alive()` 的 pid 判活仍成立。
+    - `--unit=`：可追蹤，且是 polkit `action.lookup("unit")` 收窄授權的比對對象。
+    - `--uid=`／`--gid=`：降權本身（等價於 `--property=User=`／`Group=`）。
+    - `--service-type=exec`：exec 失敗（CLI 不在 PATH、帳號無法切換）會在**起動**階段
+      就報錯，而不是先報成功再讓 job 靜默死掉。
+    - `--working-directory=`：對齊 direct 模式的 `Popen(cwd=worktree)`。刻意不用
+      `--same-dir`——Manager 的 cwd 不是 worktree。
+    - `--setenv=`：白名單 env 逐項送入（排序後輸出，argv 因此可預期、可比對、可稽核）。
+    """
+
+    argv = [
+        systemd_run,
+        "--quiet",
+        "--collect",
+        "--pipe",
+        "--wait",
+        f"--unit={unit}",
+        f"--uid={account}",
+        f"--gid={group}",
+        "--service-type=exec",
+        f"--working-directory={working_directory}",
+    ]
+    argv.extend(f"--property={prop}" for prop in TRANSIENT_UNIT_PROPERTIES)
+    argv.extend(f"--setenv={key}={env[key]}" for key in sorted(env))
+    argv.append("--")
+    argv.extend(command)
+    return argv
+
+
+def preflight_systemd_run(
+    *,
+    account: str,
+    group: str,
+    which: Callable[[str], str | None] = shutil.which,
+    account_exists: Callable[[str], bool] | None = None,
+    group_exists: Callable[[str], bool] | None = None,
+    systemd_booted: Callable[[], bool] | None = None,
+) -> str:
+    """降權前的靜態檢查；任何一項不成立即 fail-closed，回傳 systemd-run 絕對路徑。
+
+    **絕不退回 direct**：這裡每一個 raise 都代表「operator 以為隔離生效、實際不生效」
+    的風險，靜默降級正是本票要消除的失效模式。
+
+    polkit 拒絕沒有可靠的唯讀探測面（systemd 沒有 dry-run／can-start 介面），它由
+    :func:`confirm_transient_unit_started` 在起動階段補上。
+    """
+
+    resolved = which("systemd-run")
+    if not resolved:
+        raise _fail(
+            "job-runner-systemd-run-missing",
+            "PATH 上找不到 systemd-run；降權模式無法執行",
+            source="preflight_systemd_run",
+        )
+    booted = systemd_booted or _systemd_booted
+    if not booted():
+        raise _fail(
+            "job-runner-systemd-unavailable",
+            "/run/systemd/system 不存在——本機未以 systemd 開機，transient unit 不可用",
+            source="preflight_systemd_run",
+        )
+    exists_account = account_exists or _account_exists
+    if not exists_account(account):
+        raise _fail(
+            "job-runner-builder-account-missing",
+            f"builder 帳號不存在: {account}（Phase 2b runbook 第 1 步尚未執行？）",
+            source="preflight_systemd_run",
+            account=account,
+        )
+    exists_group = group_exists or _group_exists
+    if not exists_group(group):
+        raise _fail(
+            "job-runner-builder-group-missing",
+            f"builder group 不存在: {group}",
+            source="preflight_systemd_run",
+            group=group,
+        )
+    return resolved
+
+
+@dataclass(frozen=True)
+class SystemdRunPlan:
+    """一次降權派工要用到的、**已驗證過**的身分與 unit 資訊。
+
+    把「解析 config → 靜態 preflight → 算 unit 名」收成一個回傳值，呼叫端就不必在
+    launch 的主流程裡拿著四個 `str | None` 再逐一判斷（也就不需要 `assert` 收窄型別）。
+    """
+
+    binary: str
+    unit: str
+    account: str
+    group: str
+
+
+def prepare_systemd_run(env: Mapping[str, str], *, job_id: str) -> SystemdRunPlan:
+    """降權派工的前置：解析身分 config、跑靜態 preflight、算出 transient unit 名。
+
+    **在任何副作用之前呼叫**——這裡的每一個 raise 都代表本次派工不該發生，呼叫端
+    必須讓它往上傳（fail-closed），不得改走 direct。
+    """
+
+    account = resolve_builder_account(env)
+    group = resolve_builder_group(env)
+    binary = preflight_systemd_run(account=account, group=group)
+    return SystemdRunPlan(
+        binary=binary,
+        unit=transient_unit_name(job_id),
+        account=account,
+        group=group,
+    )
+
+
+def confirm_transient_unit_started(
+    *,
+    process,
+    sentinel: str,
+    unit: str,
+    account: str,
+    log_path: str | None = None,
+    timeout_ms: int = DEFAULT_START_TIMEOUT_MS,
+    monotonic: Callable[[], float] = time.monotonic,
+    sleep: Callable[[float], None] = time.sleep,
+) -> None:
+    """確認 transient unit 真的起來了；起不來就 fail-closed。
+
+    polkit 拒絕、unit 名衝突、`--uid` 帳號在 systemd 端被拒——這些都只在**起動當下**
+    才知道，而 `systemd-run` 在這些情況下會**立刻**以非零 exit 收場。
+
+    判準刻意是**兩個條件同時成立**才算失敗：``systemd-run 已結束`` **且**
+    ``exit sentinel 不存在``。sentinel 由 wrapper 在模型結束後寫入
+    （見 `launcher.build_wrapper_script`），所以一個真的跑完的極短命 job 必然留下
+    sentinel——不會被誤判。反之「行程沒了、sentinel 也沒有」就是 job 從未真正執行。
+
+    成功路徑會等滿整個確認窗（預設 200ms）才返回；這是為了讓 polkit 的 D-Bus 往返有
+    時間收斂，代價是每次 builder 派工多 200ms，相對於一次 headless job 可忽略。
+    """
+
+    deadline = monotonic() + max(timeout_ms, 0) / 1000.0
+    while True:
+        status = process.poll()
+        if status is not None:
+            if Path(sentinel).exists():
+                # job 真的跑完了（且已寫下 exit sentinel）——不是起動失敗。
+                return
+            raise _fail(
+                "job-runner-transient-unit-start-failed",
+                (
+                    f"transient unit {unit} 未能以 {account} 起動"
+                    f"（systemd-run exit={status}；常見原因：polkit 拒絕、"
+                    f"unit 名衝突、帳號無法切換）{_log_tail(log_path)}"
+                ),
+                source="confirm_transient_unit_started",
+                unit=unit,
+                account=account,
+                exit_status=status,
+            )
+        remaining = deadline - monotonic()
+        if remaining <= 0:
+            return
+        sleep(min(0.01, remaining))
+
+
+def _log_tail(log_path: str | None, *, limit: int = 200) -> str:
+    """把 systemd-run 自己的錯誤訊息（經 --pipe 落進 job log）帶進診斷理由。
+
+    沒有這一段，operator 只會看到「unit 起不來」而看不到 polkit 的實際拒絕訊息。
+    讀不到就回空字串——診斷用的補充資訊不該反過來變成新的失敗來源。
+    """
+
+    if not log_path:
+        return ""
+    try:
+        text = Path(log_path).read_text(encoding="utf-8", errors="replace").strip()
+    except OSError:
+        return ""
+    if not text:
+        return ""
+    return f"；systemd-run 輸出: {text[-limit:]}"
+
+
+def _systemd_booted() -> bool:
+    """等價於 `sd_booted(3)`：以 `/run/systemd/system` 是否為目錄判定。"""
+
+    return os.path.isdir("/run/systemd/system")
+
+
+def _account_exists(name: str) -> bool:
+    try:
+        pwd.getpwnam(name)
+    except KeyError:
+        return False
+    return True
+
+
+def _group_exists(name: str) -> bool:
+    try:
+        grp.getgrnam(name)
+    except KeyError:
+        return False
+    return True

--- a/paulsha_cortex/coordinator/launcher.py
+++ b/paulsha_cortex/coordinator/launcher.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import json
 import os
-import re
 import shlex
 import shutil
 import subprocess
@@ -11,7 +10,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Mapping, Protocol, Sequence, runtime_checkable
 
-from . import gate_ledger, terminal_contract
+from . import gate_ledger, job_runner, terminal_contract
 
 
 _GIT_REPOSITORY_ENV_KEYS = frozenset(
@@ -38,10 +37,10 @@ _GIT_REPOSITORY_ENV_KEYS = frozenset(
     }
 )
 
-_CREDENTIAL_ENV_RE = re.compile(
-    r"(?:^|_)(?:API_?KEY|AUTH|COOKIE|CREDENTIALS?|PASSWORD|PRIVATE_?KEY|SECRET|TOKEN)(?:$|_)",
-    re.IGNORECASE,
-)
+# 憑證形狀的 env 名稱。定義搬到 `job_runner`（Phase 2a 降權啟動器的 env 白名單守衛
+# 需要同一份判準），這裡保留原名別名——reviewer sandbox 政策與 builder transient unit
+# 的憑證判準永遠是同一條 pattern，不會兩處漂移。
+_CREDENTIAL_ENV_RE = job_runner.CREDENTIAL_ENV_RE
 
 
 def _claude_review_json_schema(kind: str) -> str:
@@ -1065,6 +1064,26 @@ class SubprocessLauncher:
             return False
         return env.get("PSC_REPO_ROOT") is not None
 
+    def _degraded_runner(self, env: Mapping[str, str]) -> bool:
+        """本次 launch 是否要走 Phase 2a 的降權啟動器（`systemd-run` transient unit）。
+
+        兩個條件同時成立才降權：
+
+        1. `PSC_JOB_RUNNER=systemd-run`（部署期設定；預設 `direct`＝現行行為不變）。
+        2. **這是 builder persona**——判定點與本檔既有的 persona 分支完全對齊
+           （`_should_run_gates`／`launch()` 的 env 分支用的是同一組條件）：
+           `review_only`＝reviewer、`read_only`＝planner，兩者皆非才是 builder。
+
+        operator 0816 裁決的二分 UID 方案裡，reviewer 與 planner 和 Manager 同帳號
+        （`cortex-svc`），因此**不經降權**；只有 builder 落到 `cortex-builder`。
+        `PSC_JOB_RUNNER` 的值即使非法，也在這裡 fail-closed（見
+        `job_runner.resolve_runner_mode`），不會被靜默當成 direct。
+        """
+
+        if job_runner.resolve_runner_mode(env) != job_runner.RUNNER_SYSTEMD_RUN:
+            return False
+        return not self._review_only and not self._read_only
+
     def executor_environment(self, *, slice_id: str = "preflight"):
         """#262 D2：回報正式 job 會實際看到的 executor 環境。
 
@@ -1077,6 +1096,17 @@ class SubprocessLauncher:
 
         if self._review_only:
             env = _review_scope_env()
+        elif self._degraded_runner(os.environ):
+            # 降權模式下 job 實際看到的是 transient unit 的白名單 env，不是 daemon 的
+            # environ；preflight 若仍回報 daemon env，它報的 PATH／HOME 就與正式 job
+            # 無關（見本方法 docstring 的「不然只是安慰劑」）。
+            env = job_runner.build_builder_env(
+                manager_env=os.environ,
+                job_id=slice_id,
+                slice_id=slice_id,
+                repo_root=str(Path(__file__).resolve().parents[2]),
+                relay_target=self._relay_target,
+            )
         else:
             env = {
                 **_git_scope_env(),
@@ -1106,6 +1136,14 @@ class SubprocessLauncher:
         )
 
     def launch(self, *, slice_id: str, prompt: str, worktree: str, log_dir: str) -> LaunchHandle:
+        # Phase 2a 降權啟動器（#584 未決 1 裁決＝systemd-run transient unit）。
+        # 這一行在**任何**副作用（mkdir／清 sentinel／Popen）之前求值：`PSC_JOB_RUNNER`
+        # 非法或 builder 帳號不存在時，本次派工必須在還沒改動任何狀態前就 fail-closed，
+        # 而不是先做一半再退回 direct。
+        runner_plan: job_runner.SystemdRunPlan | None = None
+        if self._degraded_runner(os.environ):
+            runner_plan = job_runner.prepare_systemd_run(os.environ, job_id=slice_id)
+        degraded = runner_plan is not None
         resolved_worktree = Path(worktree).resolve(strict=True)
         if not resolved_worktree.is_dir():
             raise ValueError("launcher worktree must be a directory")
@@ -1155,6 +1193,19 @@ class SubprocessLauncher:
         # 不可依賴相對 cwd；互動 session 亦不應因相對路徑找不到 script 而報錯）。
         if self._review_only:
             env = _review_scope_env()
+        elif degraded:
+            # #588 第 1 點的結構性解法：transient unit **不繼承呼叫端的 environ**，
+            # 因此 builder 的環境就是這份白名單本身（不是「daemon environ 減去黑名單」）。
+            # gh token、daemon 的 CLAUDE_CONFIG_DIR 都不在白名單上，因此不會出現在
+            # job 裡——包括 `_copilot_credential_env()` 也因此自然回傳空 dict（它讀的是
+            # 這份 env，裡面沒有任何 token 候選），不必為降權模式另設特例。
+            env = job_runner.build_builder_env(
+                manager_env=os.environ,
+                job_id=slice_id,
+                slice_id=slice_id,
+                repo_root=str(Path(__file__).resolve().parents[2]),
+                relay_target=self._relay_target,
+            )
         else:
             env = {
                 **_git_scope_env(),
@@ -1197,14 +1248,48 @@ class SubprocessLauncher:
             stdin_prompt=stdin_prompt,
         )
         # Reviewer 不使用 login shell，避免 ~/.profile 等在最小 env 建立後重新匯入 secrets。
-        argv = ["bash", "-c" if self._review_only else "-lc", script]
-        with open(log_path, "wb") as logf:
-            proc = subprocess.Popen(
-                argv,
-                cwd=worktree,
+        # 降權模式的 builder 同理（#588 第 2 點）：login shell 會在 transient unit 的
+        # 白名單 env 建立完成之後重新 source ~/.profile，把 env 約束整個覆寫掉。
+        # direct 模式的 builder 維持 `-lc` 不動——那是既有行為，本票不改。
+        argv = ["bash", "-c" if (self._review_only or degraded) else "-lc", script]
+        popen_kwargs: dict[str, object] = {
+            "cwd": worktree,
+            "env": env,
+            "stderr": subprocess.STDOUT,
+        }
+        if runner_plan is not None:
+            argv = job_runner.build_systemd_run_argv(
+                systemd_run=runner_plan.binary,
+                unit=runner_plan.unit,
+                account=runner_plan.account,
+                group=runner_plan.group,
+                working_directory=worktree,
                 env=env,
-                stdout=logf,
-                stderr=subprocess.STDOUT,
+                command=argv,
+            )
+            # systemd-run **client 自己**的環境。它不會流進 transient unit——unit 的
+            # 環境只有 PID 1 的 manager environment 加上 `--setenv` 白名單（這正是
+            # #588 第 1 點在此模式下結構性成立的原因）。client 端保留完整 env 是刻意
+            # 的：polkit 授權可能要查呼叫端的 session（XDG_SESSION_ID 等），砍掉會讓
+            # 授權在某些部署下無故失敗。
+            popen_kwargs["env"] = _git_scope_env()
+            # FD：Popen 預設 close_fds=True，因此只有 0/1/2 會經 `--pipe` 進到 unit；
+            # stdin 顯式接 /dev/null（direct 模式今天仍把 daemon 的 stdin 交給 job，
+            # 降權模式在這點上比 direct 更緊）。
+            popen_kwargs["stdin"] = subprocess.DEVNULL
+        with open(log_path, "wb") as logf:
+            popen_kwargs["stdout"] = logf
+            proc = subprocess.Popen(argv, **popen_kwargs)
+        if runner_plan is not None:
+            # polkit 拒絕／unit 名衝突只在起動當下才知道；確認不到就 fail-closed，
+            # **絕不**退回 direct（見 job_runner.confirm_transient_unit_started）。
+            job_runner.confirm_transient_unit_started(
+                process=proc,
+                sentinel=sentinel,
+                unit=runner_plan.unit,
+                account=runner_plan.account,
+                log_path=log_path,
+                timeout_ms=job_runner.resolve_start_timeout_ms(os.environ),
             )
         return LaunchHandle(
             executor=self._executor,

--- a/tests/test_trust_root_job_runner_p2a.py
+++ b/tests/test_trust_root_job_runner_p2a.py
@@ -1,0 +1,749 @@
+"""Phase 2a 降權啟動器（#584 未決 1 裁決＝systemd-run transient unit）的測試。
+
+覆蓋面：
+
+1. **direct 零回歸**——預設模式下 argv／env／shell flag 與改動前逐字相同。
+2. **systemd-run argv 組裝**——unit 名（可追蹤＋唯一）／uid／gid／白名單 `--setenv`／
+   `bash -c`（非 `-lc`，#588 第 2 點）。
+3. **env 白名單不含 token 類**——GH_TOKEN／GITHUB_TOKEN／ANTHROPIC_API_KEY／
+   CLAUDE_CONFIG_DIR 等在任何情況下都不得出現（#588 第 1 點）。
+4. **fail-fast**——systemd 不可用／帳號不存在／模式值非法／transient unit 起不來時
+   fail-closed 並帶 DiagnosticReason，**絕不**退回 direct。
+
+`systemd-run` 本體全程 mock，測試不真跑 systemd、不建帳號、不碰 polkit。
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import paulsha_cortex.coordinator.job_runner as job_runner
+import paulsha_cortex.coordinator.launcher as launcher_module
+from paulsha_cortex.coordinator.diagnostics import DiagnosticReason
+from paulsha_cortex.coordinator.job_runner import JobRunnerError
+from paulsha_cortex.coordinator.launcher import SubprocessLauncher
+
+
+# 每一輪 launch 測試都在乾淨的 env 上疊加，避免 operator 自己的 shell 汙染判定。
+_BASE_ENV = {
+    "PATH": "/usr/local/bin:/usr/bin:/bin",
+    "HOME": "/var/lib/cortex-svc",
+    "LANG": "en_US.UTF-8",
+}
+
+_SECRET_ENV = {
+    "GH_TOKEN": "gh-secret",
+    "GITHUB_TOKEN": "github-secret",
+    "COPILOT_GITHUB_TOKEN": "copilot-secret",
+    "ANTHROPIC_API_KEY": "anthropic-secret",
+    "OPENAI_API_KEY": "openai-secret",
+    "AWS_SECRET_ACCESS_KEY": "aws-secret",
+    "CLAUDE_CONFIG_DIR": "/var/lib/cortex-svc/.claude",
+    "GH_CONFIG_DIR": "/var/lib/cortex-svc/.config/gh",
+    "BASH_ENV": "/tmp/credential-exporter",
+    "NODE_OPTIONS": "--require /tmp/inject.js",
+    "PGPASSWORD": "postgres-secret",
+}
+
+
+class _FakeProc:
+    """systemd-run client 的替身。`poll()` 語意即真實 Popen 的語意。"""
+
+    def __init__(self, *, pid: int = 4242, exit_status: int | None = None) -> None:
+        self.pid = pid
+        self._exit_status = exit_status
+
+    def poll(self) -> int | None:
+        return self._exit_status
+
+
+class _RecordingPopen:
+    def __init__(self, *, proc: _FakeProc | None = None) -> None:
+        self.calls: list[dict] = []
+        self._proc = proc or _FakeProc()
+
+    def __call__(self, argv, **kwargs):
+        self.calls.append({"argv": argv, **kwargs})
+        return self._proc
+
+    @property
+    def call(self) -> dict:
+        return self.calls[0]
+
+
+def _degraded_env(**overrides: str) -> dict[str, str]:
+    env = {
+        **_BASE_ENV,
+        **_SECRET_ENV,
+        job_runner.JOB_RUNNER_ENV: job_runner.RUNNER_SYSTEMD_RUN,
+    }
+    env.update(overrides)
+    return env
+
+
+def _launch(
+    launcher: SubprocessLauncher,
+    *,
+    env: dict[str, str],
+    popen: _RecordingPopen,
+    slice_id: str = "psc-0001-demo",
+    preflight_ok: bool = True,
+) -> None:
+    """在完全受控的 env／systemd 探測 seam 下跑一次 launch。"""
+
+    original = launcher_module.subprocess.Popen
+    launcher_module.subprocess.Popen = popen
+    patches = []
+    if preflight_ok:
+        patches = [
+            mock.patch.object(job_runner.shutil, "which", return_value="/usr/bin/systemd-run"),
+            mock.patch.object(job_runner, "_systemd_booted", return_value=True),
+            mock.patch.object(job_runner, "_account_exists", return_value=True),
+            mock.patch.object(job_runner, "_group_exists", return_value=True),
+        ]
+    try:
+        with tempfile.TemporaryDirectory() as d, mock.patch.dict(
+            os.environ, env, clear=True
+        ):
+            with _nested(patches):
+                launcher.launch(
+                    slice_id=slice_id,
+                    prompt="PROMPT",
+                    worktree=d,
+                    log_dir=str(Path(d) / "logs"),
+                )
+    finally:
+        launcher_module.subprocess.Popen = original
+
+
+class _nested:
+    """把可變數量的 context manager 疊起來（測試 helper，不進生產路徑）。"""
+
+    def __init__(self, managers) -> None:
+        self._managers = list(managers)
+
+    def __enter__(self):
+        self._entered = [m.__enter__() for m in self._managers]
+        return self._entered
+
+    def __exit__(self, *exc_info):
+        for manager in reversed(self._managers):
+            manager.__exit__(*exc_info)
+        return False
+
+
+def _setenv_map(argv: list[str]) -> dict[str, str]:
+    """把 argv 上的 `--setenv=K=V` 還原成 dict——transient unit 實際看到的環境。"""
+
+    out: dict[str, str] = {}
+    for item in argv:
+        if item.startswith("--setenv="):
+            key, _, value = item[len("--setenv=") :].partition("=")
+            out[key] = value
+    return out
+
+
+class RunnerModeTests(unittest.TestCase):
+    def test_unset_is_direct(self) -> None:
+        self.assertEqual(job_runner.resolve_runner_mode({}), job_runner.RUNNER_DIRECT)
+
+    def test_blank_is_direct(self) -> None:
+        self.assertEqual(
+            job_runner.resolve_runner_mode({job_runner.JOB_RUNNER_ENV: "  "}),
+            job_runner.RUNNER_DIRECT,
+        )
+
+    def test_explicit_modes(self) -> None:
+        for value, expected in (
+            ("direct", job_runner.RUNNER_DIRECT),
+            ("systemd-run", job_runner.RUNNER_SYSTEMD_RUN),
+            ("SYSTEMD-RUN", job_runner.RUNNER_SYSTEMD_RUN),
+        ):
+            self.assertEqual(
+                job_runner.resolve_runner_mode({job_runner.JOB_RUNNER_ENV: value}),
+                expected,
+            )
+
+    def test_unknown_mode_is_fail_closed_not_direct(self) -> None:
+        with self.assertRaises(JobRunnerError) as ctx:
+            job_runner.resolve_runner_mode({job_runner.JOB_RUNNER_ENV: "systemdrun"})
+        self.assertEqual(ctx.exception.diagnostic.reason, "job-runner-mode-invalid")
+
+    def test_builder_account_defaults_to_permgen_two_way_scheme(self) -> None:
+        from paulsha_cortex.trust_root import permgen
+        from paulsha_cortex.trust_root.registry import Principal
+
+        self.assertEqual(
+            job_runner.resolve_builder_account({}),
+            permgen.TWO_WAY_SCHEME.resolve(Principal.BUILDER),
+        )
+
+    def test_builder_account_is_configurable(self) -> None:
+        env = {job_runner.BUILDER_ACCOUNT_ENV: "cortex-worker"}
+        self.assertEqual(job_runner.resolve_builder_account(env), "cortex-worker")
+        # group 預設沿用 UidScheme.group_of（每帳號一個同名 group）
+        self.assertEqual(job_runner.resolve_builder_group(env), "cortex-worker")
+
+    def test_builder_group_is_separately_configurable(self) -> None:
+        env = {
+            job_runner.BUILDER_ACCOUNT_ENV: "cortex-worker",
+            job_runner.BUILDER_GROUP_ENV: "cortex-jobs",
+        }
+        self.assertEqual(job_runner.resolve_builder_group(env), "cortex-jobs")
+
+    def test_account_name_injection_is_rejected(self) -> None:
+        with self.assertRaises(JobRunnerError) as ctx:
+            job_runner.resolve_builder_account(
+                {job_runner.BUILDER_ACCOUNT_ENV: "root --property=User=root"}
+            )
+        self.assertEqual(ctx.exception.diagnostic.reason, "job-runner-account-name-invalid")
+
+    def test_start_timeout_invalid_is_fail_closed(self) -> None:
+        for value in ("abc", "-1"):
+            with self.assertRaises(JobRunnerError):
+                job_runner.resolve_start_timeout_ms({job_runner.START_TIMEOUT_ENV: value})
+
+    def test_start_timeout_default_and_override(self) -> None:
+        self.assertEqual(
+            job_runner.resolve_start_timeout_ms({}), job_runner.DEFAULT_START_TIMEOUT_MS
+        )
+        self.assertEqual(
+            job_runner.resolve_start_timeout_ms({job_runner.START_TIMEOUT_ENV: "0"}), 0
+        )
+
+
+class BuilderEnvAllowlistTests(unittest.TestCase):
+    def _build(self, **overrides) -> dict[str, str]:
+        manager_env = {**_BASE_ENV, **_SECRET_ENV}
+        manager_env.update(overrides)
+        return job_runner.build_builder_env(
+            manager_env=manager_env,
+            job_id="job-1",
+            slice_id="slice-1",
+            repo_root="/opt/cortex/src",
+        )
+
+    def test_never_carries_token_shaped_variables(self) -> None:
+        env = self._build()
+        for name in _SECRET_ENV:
+            self.assertNotIn(name, env, f"{name} 不得出現在 builder env")
+
+    def test_no_key_matches_credential_pattern(self) -> None:
+        env = self._build()
+        for key in env:
+            self.assertIsNone(
+                job_runner.CREDENTIAL_ENV_RE.search(key),
+                f"builder env 出現憑證形狀變數: {key}",
+            )
+            self.assertNotIn(key, job_runner.DENIED_ENV_NAMES)
+
+    def test_exact_key_set_is_the_allowlist(self) -> None:
+        env = self._build()
+        allowed = {item.name for item in job_runner.BUILDER_FORWARDED_ENV}
+        allowed |= set(job_runner.BUILDER_SYNTHESIZED_ENV)
+        self.assertLessEqual(set(env), allowed)
+
+    def test_synthesized_markers_are_present(self) -> None:
+        env = self._build()
+        self.assertEqual(env["PSC_JOB_ID"], "job-1")
+        self.assertEqual(env["PSC_SLICE_ID"], "slice-1")
+        self.assertEqual(env["PSC_REPO_ROOT"], "/opt/cortex/src")
+
+    def test_daemon_home_is_never_forwarded(self) -> None:
+        # #588 第 1 點：daemon 的 HOME 是 cortex-svc 的樹；未設 PSC_BUILDER_HOME 時
+        # 交給 systemd 依 passwd 填 builder 自己的 HOME，launcher 一律不轉發。
+        env = self._build()
+        self.assertNotIn("HOME", env)
+
+    def test_builder_home_override_is_used(self) -> None:
+        env = self._build(**{job_runner.BUILDER_HOME_ENV: "/var/lib/cortex-builder"})
+        self.assertEqual(env["HOME"], "/var/lib/cortex-builder")
+        self.assertNotEqual(env["HOME"], _BASE_ENV["HOME"])
+
+    def test_path_is_forwarded_and_overridable(self) -> None:
+        self.assertEqual(self._build()["PATH"], _BASE_ENV["PATH"])
+        env = self._build(**{job_runner.BUILDER_PATH_ENV: "/opt/cortex/bin:/usr/bin"})
+        self.assertEqual(env["PATH"], "/opt/cortex/bin:/usr/bin")
+
+    def test_relay_target_only_when_configured(self) -> None:
+        manager_env = {**_BASE_ENV}
+        without = job_runner.build_builder_env(
+            manager_env=manager_env, job_id="j", slice_id="s", repo_root="/r"
+        )
+        self.assertNotIn("PSC_RELAY_TARGET", without)
+        with_relay = job_runner.build_builder_env(
+            manager_env=manager_env,
+            job_id="j",
+            slice_id="s",
+            repo_root="/r",
+            relay_target="psc",
+        )
+        self.assertEqual(with_relay["PSC_RELAY_TARGET"], "psc")
+
+    def test_git_repository_selectors_are_not_forwarded(self) -> None:
+        env = self._build(GIT_DIR="/evil/.git", GIT_WORK_TREE="/evil", GIT_CONFIG_COUNT="1")
+        for key in ("GIT_DIR", "GIT_WORK_TREE", "GIT_CONFIG_COUNT"):
+            self.assertNotIn(key, env)
+
+    def test_every_forwarded_entry_carries_a_rationale(self) -> None:
+        for item in job_runner.BUILDER_FORWARDED_ENV:
+            self.assertTrue(item.rationale.strip(), f"{item.name} 缺少白名單理由")
+
+    def test_credential_pattern_is_shared_with_launcher(self) -> None:
+        # 兩處漂移就會出現「reviewer sandbox 認為是 secret、builder 白名單不認為」。
+        self.assertIs(launcher_module._CREDENTIAL_ENV_RE, job_runner.CREDENTIAL_ENV_RE)
+
+    def test_guard_rejects_credential_shaped_allowlist_entry(self) -> None:
+        # defense-in-depth：白名單被改壞時當場紅，而不是等 dogfooding 才發現漏 token。
+        poisoned = job_runner.BUILDER_FORWARDED_ENV + (
+            job_runner.ForwardedEnvVar("SOME_API_KEY", "刻意注入的壞白名單"),
+        )
+        with mock.patch.object(job_runner, "BUILDER_FORWARDED_ENV", poisoned):
+            with self.assertRaises(JobRunnerError) as ctx:
+                job_runner.build_builder_env(
+                    manager_env={"SOME_API_KEY": "leaked"},
+                    job_id="j",
+                    slice_id="s",
+                    repo_root="/r",
+                )
+        self.assertEqual(ctx.exception.diagnostic.reason, "job-runner-credential-env-leak")
+
+    def test_newline_in_value_is_rejected(self) -> None:
+        with self.assertRaises(JobRunnerError) as ctx:
+            job_runner.build_builder_env(
+                manager_env={"PATH": "/usr/bin\n--property=User=root"},
+                job_id="j",
+                slice_id="s",
+                repo_root="/r",
+            )
+        self.assertEqual(ctx.exception.diagnostic.reason, "job-runner-env-value-invalid")
+
+
+class TransientUnitNameTests(unittest.TestCase):
+    def test_name_is_traceable_and_scoped_to_prefix(self) -> None:
+        unit = job_runner.transient_unit_name("psc-0042-add-thing")
+        self.assertTrue(unit.startswith(job_runner.UNIT_NAME_PREFIX))
+        self.assertTrue(unit.endswith(".service"))
+        self.assertIn("psc-0042-add-thing", unit)
+
+    def test_illegal_characters_are_sanitized(self) -> None:
+        unit = job_runner.transient_unit_name("job/../etc passwd")
+        self.assertNotIn("/", unit[: -len(".service")])
+        self.assertNotIn(" ", unit)
+
+    def test_distinct_job_ids_never_collide_after_sanitization(self) -> None:
+        first = job_runner.transient_unit_name("job/a")
+        second = job_runner.transient_unit_name("job:a")
+        self.assertNotEqual(first, second)
+
+    def test_deterministic(self) -> None:
+        self.assertEqual(
+            job_runner.transient_unit_name("job-1"), job_runner.transient_unit_name("job-1")
+        )
+
+    def test_empty_job_id_is_fail_closed(self) -> None:
+        with self.assertRaises(JobRunnerError) as ctx:
+            job_runner.transient_unit_name("  ")
+        self.assertEqual(ctx.exception.diagnostic.reason, "job-runner-unit-name-invalid")
+
+    def test_length_is_bounded(self) -> None:
+        unit = job_runner.transient_unit_name("x" * 400)
+        self.assertLess(len(unit), 128)
+
+
+class SystemdRunArgvTests(unittest.TestCase):
+    def _argv(self, **overrides) -> list[str]:
+        kwargs = {
+            "systemd_run": "/usr/bin/systemd-run",
+            "unit": "cortex-job-demo-deadbeef.service",
+            "account": "cortex-builder",
+            "group": "cortex-builder",
+            "working_directory": "/var/lib/cortex/worktree/demo",
+            "env": {"PATH": "/usr/bin", "PSC_JOB_ID": "demo"},
+            "command": ["bash", "-c", "echo hi"],
+        }
+        kwargs.update(overrides)
+        return job_runner.build_systemd_run_argv(**kwargs)
+
+    def test_core_flags(self) -> None:
+        argv = self._argv()
+        self.assertEqual(argv[0], "/usr/bin/systemd-run")
+        for flag in (
+            "--quiet",
+            "--collect",
+            "--pipe",
+            "--wait",
+            "--unit=cortex-job-demo-deadbeef.service",
+            "--uid=cortex-builder",
+            "--gid=cortex-builder",
+            "--service-type=exec",
+            "--working-directory=/var/lib/cortex/worktree/demo",
+            "--property=NoNewPrivileges=yes",
+        ):
+            self.assertIn(flag, argv)
+
+    def test_command_follows_double_dash(self) -> None:
+        argv = self._argv()
+        self.assertIn("--", argv)
+        self.assertEqual(argv[argv.index("--") + 1 :], ["bash", "-c", "echo hi"])
+
+    def test_setenv_is_sorted_and_complete(self) -> None:
+        argv = self._argv(env={"B": "2", "A": "1"})
+        self.assertEqual(
+            [item for item in argv if item.startswith("--setenv=")],
+            ["--setenv=A=1", "--setenv=B=2"],
+        )
+
+    def test_no_same_dir_flag(self) -> None:
+        # Manager 的 cwd 不是 worktree，`--same-dir` 會把 unit 的 cwd 指錯。
+        argv = self._argv()
+        self.assertNotIn("--same-dir", argv)
+        self.assertNotIn("-d", argv)
+
+
+class PreflightTests(unittest.TestCase):
+    def _preflight(self, **overrides):
+        kwargs = {
+            "account": "cortex-builder",
+            "group": "cortex-builder",
+            "which": lambda name: "/usr/bin/systemd-run",
+            "account_exists": lambda name: True,
+            "group_exists": lambda name: True,
+            "systemd_booted": lambda: True,
+        }
+        kwargs.update(overrides)
+        return job_runner.preflight_systemd_run(**kwargs)
+
+    def test_happy_path_returns_absolute_binary(self) -> None:
+        self.assertEqual(self._preflight(), "/usr/bin/systemd-run")
+
+    def test_missing_systemd_run_binary(self) -> None:
+        with self.assertRaises(JobRunnerError) as ctx:
+            self._preflight(which=lambda name: None)
+        self.assertEqual(ctx.exception.diagnostic.reason, "job-runner-systemd-run-missing")
+
+    def test_not_booted_with_systemd(self) -> None:
+        with self.assertRaises(JobRunnerError) as ctx:
+            self._preflight(systemd_booted=lambda: False)
+        self.assertEqual(ctx.exception.diagnostic.reason, "job-runner-systemd-unavailable")
+
+    def test_missing_builder_account(self) -> None:
+        with self.assertRaises(JobRunnerError) as ctx:
+            self._preflight(account_exists=lambda name: False)
+        self.assertEqual(ctx.exception.diagnostic.reason, "job-runner-builder-account-missing")
+        self.assertEqual(ctx.exception.diagnostic.context["account"], "cortex-builder")
+
+    def test_missing_builder_group(self) -> None:
+        with self.assertRaises(JobRunnerError) as ctx:
+            self._preflight(group_exists=lambda name: False)
+        self.assertEqual(ctx.exception.diagnostic.reason, "job-runner-builder-group-missing")
+
+    def test_every_failure_carries_a_diagnostic_reason(self) -> None:
+        # #570／#527 契約：fail-closed 一定帶結構化理由，不是裸字串。
+        for override in (
+            {"which": lambda name: None},
+            {"systemd_booted": lambda: False},
+            {"account_exists": lambda name: False},
+            {"group_exists": lambda name: False},
+        ):
+            with self.assertRaises(JobRunnerError) as ctx:
+                self._preflight(**override)
+            self.assertIsInstance(ctx.exception.diagnostic, DiagnosticReason)
+            self.assertTrue(ctx.exception.diagnostic.source.startswith("job_runner."))
+            self.assertIn(ctx.exception.diagnostic.reason, str(ctx.exception))
+
+
+class PreparePlanTests(unittest.TestCase):
+    def _prepare(self, env: dict[str, str]):
+        with mock.patch.object(
+            job_runner.shutil, "which", return_value="/usr/bin/systemd-run"
+        ), mock.patch.object(
+            job_runner, "_systemd_booted", return_value=True
+        ), mock.patch.object(
+            job_runner, "_account_exists", return_value=True
+        ), mock.patch.object(
+            job_runner, "_group_exists", return_value=True
+        ):
+            return job_runner.prepare_systemd_run(env, job_id="psc-0001-demo")
+
+    def test_plan_carries_verified_identity(self) -> None:
+        plan = self._prepare({})
+        self.assertEqual(plan.binary, "/usr/bin/systemd-run")
+        self.assertEqual(plan.account, job_runner.DEFAULT_BUILDER_ACCOUNT)
+        self.assertEqual(plan.group, job_runner.DEFAULT_BUILDER_ACCOUNT)
+        self.assertEqual(plan.unit, job_runner.transient_unit_name("psc-0001-demo"))
+
+    def test_preflight_failure_propagates(self) -> None:
+        with mock.patch.object(job_runner.shutil, "which", return_value=None):
+            with self.assertRaises(JobRunnerError):
+                job_runner.prepare_systemd_run({}, job_id="j")
+
+
+class StartConfirmationTests(unittest.TestCase):
+    def test_running_unit_passes_after_window(self) -> None:
+        slept: list[float] = []
+        clock = iter([0.0, 0.05, 0.3])
+        job_runner.confirm_transient_unit_started(
+            process=_FakeProc(exit_status=None),
+            sentinel="/nonexistent/sentinel",
+            unit="cortex-job-x.service",
+            account="cortex-builder",
+            timeout_ms=200,
+            monotonic=lambda: next(clock),
+            sleep=slept.append,
+        )
+        self.assertTrue(slept)
+
+    def test_immediate_exit_without_sentinel_is_fail_closed(self) -> None:
+        with self.assertRaises(JobRunnerError) as ctx:
+            job_runner.confirm_transient_unit_started(
+                process=_FakeProc(exit_status=1),
+                sentinel="/nonexistent/sentinel",
+                unit="cortex-job-x.service",
+                account="cortex-builder",
+                timeout_ms=200,
+                monotonic=lambda: 0.0,
+                sleep=lambda _s: None,
+            )
+        diagnostic = ctx.exception.diagnostic
+        self.assertEqual(diagnostic.reason, "job-runner-transient-unit-start-failed")
+        self.assertEqual(diagnostic.context["unit"], "cortex-job-x.service")
+        self.assertEqual(diagnostic.context["account"], "cortex-builder")
+
+    def test_polkit_denial_text_reaches_the_diagnostic(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            log_path = Path(d) / "job.jsonl"
+            log_path.write_text(
+                "Failed to start transient service unit: Access denied\n", encoding="utf-8"
+            )
+            with self.assertRaises(JobRunnerError) as ctx:
+                job_runner.confirm_transient_unit_started(
+                    process=_FakeProc(exit_status=1),
+                    sentinel=str(Path(d) / "missing.exit"),
+                    unit="cortex-job-x.service",
+                    account="cortex-builder",
+                    log_path=str(log_path),
+                    timeout_ms=0,
+                    monotonic=lambda: 0.0,
+                    sleep=lambda _s: None,
+                )
+        self.assertIn("Access denied", ctx.exception.diagnostic.detail)
+
+    def test_fast_job_with_sentinel_is_not_a_failure(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            sentinel = Path(d) / "job.exit"
+            sentinel.write_text("0", encoding="utf-8")
+            job_runner.confirm_transient_unit_started(
+                process=_FakeProc(exit_status=0),
+                sentinel=str(sentinel),
+                unit="cortex-job-x.service",
+                account="cortex-builder",
+                timeout_ms=200,
+                monotonic=lambda: 0.0,
+                sleep=lambda _s: None,
+            )
+
+
+class DirectModeRegressionTests(unittest.TestCase):
+    """預設（未設 PSC_JOB_RUNNER）與顯式 direct 一律走現行路徑。"""
+
+    def test_default_builder_uses_login_shell_and_no_systemd_run(self) -> None:
+        popen = _RecordingPopen()
+        _launch(SubprocessLauncher("codex"), env=dict(_BASE_ENV), popen=popen, preflight_ok=False)
+        argv = popen.call["argv"]
+        self.assertEqual(argv[:2], ["bash", "-lc"])
+        self.assertNotIn("stdin", popen.call)
+
+    def test_explicit_direct_matches_default(self) -> None:
+        default = _RecordingPopen()
+        explicit = _RecordingPopen()
+        _launch(SubprocessLauncher("codex"), env=dict(_BASE_ENV), popen=default, preflight_ok=False)
+        _launch(
+            SubprocessLauncher("codex"),
+            env={**_BASE_ENV, job_runner.JOB_RUNNER_ENV: "direct"},
+            popen=explicit,
+            preflight_ok=False,
+        )
+        # argv 內嵌各自的 tempdir，因此比對「形狀」而非逐字：同樣的 shell flag、
+        # 同樣不經 systemd-run、同樣的 Popen kwargs 形狀。
+        self.assertEqual(default.call["argv"][:2], explicit.call["argv"][:2])
+        self.assertEqual(len(default.call["argv"]), len(explicit.call["argv"]))
+        self.assertEqual(set(default.call) - {"argv"}, set(explicit.call) - {"argv"})
+        self.assertEqual(
+            set(default.call["env"]) | {job_runner.JOB_RUNNER_ENV},
+            set(explicit.call["env"]) | {job_runner.JOB_RUNNER_ENV},
+        )
+
+    def test_direct_mode_still_inherits_daemon_env(self) -> None:
+        # 現行行為（#588 尚未修的那一半）：direct 模式下 builder 仍拿到 daemon environ。
+        # 這條測試釘住「本 PR 不改 direct 行為」，也標出降權模式才是解法。
+        popen = _RecordingPopen()
+        _launch(
+            SubprocessLauncher("codex"),
+            env={**_BASE_ENV, "GH_TOKEN": "gh-secret"},
+            popen=popen,
+            preflight_ok=False,
+        )
+        self.assertEqual(popen.call["env"].get("GH_TOKEN"), "gh-secret")
+
+    def test_invalid_mode_fails_closed_before_any_spawn(self) -> None:
+        popen = _RecordingPopen()
+        with self.assertRaises(JobRunnerError):
+            _launch(
+                SubprocessLauncher("codex"),
+                env={**_BASE_ENV, job_runner.JOB_RUNNER_ENV: "systemd_run"},
+                popen=popen,
+                preflight_ok=False,
+            )
+        self.assertEqual(popen.calls, [])
+
+
+class DegradedLaunchTests(unittest.TestCase):
+    def _launch_builder(self, *, env=None, executor: str = "codex") -> _RecordingPopen:
+        popen = _RecordingPopen()
+        _launch(
+            SubprocessLauncher(executor),
+            env=env if env is not None else _degraded_env(),
+            popen=popen,
+        )
+        return popen
+
+    def test_builder_is_wrapped_in_systemd_run(self) -> None:
+        argv = self._launch_builder().call["argv"]
+        self.assertEqual(argv[0], "/usr/bin/systemd-run")
+        self.assertIn("--uid=cortex-builder", argv)
+        self.assertIn("--gid=cortex-builder", argv)
+        self.assertIn("--collect", argv)
+        self.assertIn("--pipe", argv)
+
+    def test_unit_name_carries_the_job_id(self) -> None:
+        argv = self._launch_builder().call["argv"]
+        unit = next(item for item in argv if item.startswith("--unit="))
+        self.assertTrue(unit.startswith(f"--unit={job_runner.UNIT_NAME_PREFIX}"))
+        self.assertIn("psc-0001-demo", unit)
+
+    def test_inner_shell_is_non_login(self) -> None:
+        # #588 第 2 點：login shell 會讓 ~/.profile 在白名單 env 之後重新匯入。
+        argv = self._launch_builder().call["argv"]
+        tail = argv[argv.index("--") + 1 :]
+        self.assertEqual(tail[:2], ["bash", "-c"])
+        self.assertNotIn("-lc", argv)
+
+    def test_unit_env_never_contains_tokens(self) -> None:
+        argv = self._launch_builder().call["argv"]
+        unit_env = _setenv_map(argv)
+        for name in _SECRET_ENV:
+            self.assertNotIn(name, unit_env)
+        for key in unit_env:
+            self.assertIsNone(job_runner.CREDENTIAL_ENV_RE.search(key))
+        # 值層面的兜底：任何一個 secret 值都不得出現在整條 argv 上。
+        joined = "\x00".join(argv)
+        for value in _SECRET_ENV.values():
+            self.assertNotIn(value, joined)
+
+    def test_copilot_token_normalization_is_inert_under_degraded_runner(self) -> None:
+        # direct 模式會把 GH_TOKEN 正規化成 COPILOT_GITHUB_TOKEN 送進 job；
+        # 降權模式下 env 白名單裡沒有任何 token 候選，因此那條路徑自然變成 no-op。
+        argv = self._launch_builder(executor="copilot").call["argv"]
+        self.assertNotIn("COPILOT_GITHUB_TOKEN", _setenv_map(argv))
+
+    def test_unit_env_carries_job_markers(self) -> None:
+        unit_env = _setenv_map(self._launch_builder().call["argv"])
+        self.assertEqual(unit_env["PSC_JOB_ID"], "psc-0001-demo")
+        self.assertEqual(unit_env["PSC_SLICE_ID"], "psc-0001-demo")
+        self.assertIn("PSC_REPO_ROOT", unit_env)
+        self.assertEqual(unit_env["PATH"], _BASE_ENV["PATH"])
+
+    def test_stdin_is_devnull_and_working_directory_is_the_worktree(self) -> None:
+        call = self._launch_builder().call
+        self.assertEqual(call["stdin"], subprocess.DEVNULL)
+        worktree = call["cwd"]
+        self.assertIn(f"--working-directory={worktree}", call["argv"])
+
+    def test_client_env_is_not_the_unit_env(self) -> None:
+        # systemd-run client 保留完整 env（polkit 可能要查 session），但那份 env
+        # 不會進到 unit——unit 只看得到 `--setenv` 白名單。
+        call = self._launch_builder().call
+        self.assertIn("GH_TOKEN", call["env"])
+        self.assertNotIn("GH_TOKEN", _setenv_map(call["argv"]))
+
+    def test_builder_account_override_flows_into_argv(self) -> None:
+        env = _degraded_env(**{job_runner.BUILDER_ACCOUNT_ENV: "cortex-worker"})
+        argv = self._launch_builder(env=env).call["argv"]
+        self.assertIn("--uid=cortex-worker", argv)
+        self.assertNotIn("--uid=cortex-builder", argv)
+
+    def test_reviewer_is_never_degraded(self) -> None:
+        # 二分方案：reviewer 與 Manager 同帳號（cortex-svc），不經降權。
+        popen = _RecordingPopen()
+        _launch(
+            SubprocessLauncher("claude").as_review_only(
+                terminal_kind="workflow-verification-result"
+            ),
+            env=_degraded_env(),
+            popen=popen,
+        )
+        self.assertEqual(popen.call["argv"][:2], ["bash", "-c"])
+        self.assertNotIn("stdin", popen.call)
+
+    def test_planner_is_never_degraded(self) -> None:
+        popen = _RecordingPopen()
+        _launch(SubprocessLauncher("codex").as_read_only(), env=_degraded_env(), popen=popen)
+        self.assertEqual(popen.call["argv"][:2], ["bash", "-lc"])
+
+    def test_missing_account_fails_closed_without_spawning(self) -> None:
+        popen = _RecordingPopen()
+        original = launcher_module.subprocess.Popen
+        launcher_module.subprocess.Popen = popen
+        try:
+            with tempfile.TemporaryDirectory() as d, mock.patch.dict(
+                os.environ, _degraded_env(), clear=True
+            ), mock.patch.object(
+                job_runner.shutil, "which", return_value="/usr/bin/systemd-run"
+            ), mock.patch.object(
+                job_runner, "_systemd_booted", return_value=True
+            ), mock.patch.object(
+                job_runner, "_account_exists", return_value=False
+            ):
+                with self.assertRaises(JobRunnerError) as ctx:
+                    SubprocessLauncher("codex").launch(
+                        slice_id="s", prompt="P", worktree=d, log_dir=str(Path(d) / "logs")
+                    )
+        finally:
+            launcher_module.subprocess.Popen = original
+        self.assertEqual(
+            ctx.exception.diagnostic.reason, "job-runner-builder-account-missing"
+        )
+        # 不得靜默退回 direct：一個 job 都不能被 spawn。
+        self.assertEqual(popen.calls, [])
+
+    def test_transient_unit_start_failure_fails_closed(self) -> None:
+        popen = _RecordingPopen(proc=_FakeProc(exit_status=1))
+        with self.assertRaises(JobRunnerError) as ctx:
+            _launch(
+                SubprocessLauncher("codex"),
+                env=_degraded_env(**{job_runner.START_TIMEOUT_ENV: "0"}),
+                popen=popen,
+            )
+        self.assertEqual(
+            ctx.exception.diagnostic.reason, "job-runner-transient-unit-start-failed"
+        )
+
+    def test_executor_environment_reports_the_builder_env(self) -> None:
+        # #262 D2：preflight 必須回報 job 真的會看到的環境，否則只是安慰劑。
+        with mock.patch.dict(
+            os.environ,
+            _degraded_env(**{job_runner.BUILDER_HOME_ENV: "/var/lib/cortex-builder"}),
+            clear=True,
+        ):
+            reported = SubprocessLauncher("codex").executor_environment()
+        self.assertEqual(reported.home, "/var/lib/cortex-builder")
+        self.assertEqual(reported.path, _BASE_ENV["PATH"])
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## 摘要

trust-root spec §R10 **Phase 2 第 5 條**（降權啟動器）的**程式碼前置**。operator 在 #584
0816 第二輪把「未決 1（降權機制）」收斂為 **`systemd-run` transient unit**、UID **二分**
（`cortex-svc` / `cortex-builder`）、**builder env 不傳 gh token**；本 PR 落地那條裁決的
機制面，同時解掉 #588 兩條缺口中的兩條（env 繼承、login shell）。

## ⚠️ 誠實邊界（請先讀這段）

**本 PR 是機制，不是生效。** `PSC_JOB_RUNNER` **預設 `direct`＝現行行為逐字不變**，
merge 後不會有任何 job 被降權。實際降權要等 **Phase 2b** 建好 `cortex-builder` 帳號
＋polkit 規則，再把 `PSC_JOB_RUNNER=systemd-run` 寫進 Manager 的 env——那是**部署期動作**，
步驟見本 PR 一併改寫的 `docs/superpowers/runbooks/trust-root-phase2b-setup.md` 第 5 步。

另外三點必須一併知道：

1. **builder 帳號要有自己的模型 CLI 登入態**（`sudo -u cortex-builder claude /login` 之類）。
   Manager 不傳自己的憑證，因此 copilot builder 在降權模式下拿不到
   `COPILOT_GITHUB_TOKEN`——`_copilot_credential_env()` 讀的就是白名單 env，裡面沒有任何
   token 候選，該路徑自然變成 no-op（不必為降權模式另設特例）。
2. **builder 必須能寫該 job 的 log 目錄**（JSONL log／exit sentinel／gate ledger 都落在
   那裡），並能讀 `PSC_REPO_ROOT`（wrapper 內 gate ledger writer 的 `PYTHONPATH`）。
   這兩條的權限由 Phase 2b 的 permgen 計畫決定，不在本 PR 範圍。
3. **polkit 只能收窄一半**：`org.freedesktop.systemd1.manage-units` 這個 action 只暴露
   unit **名稱**，**不暴露 `User=`／`--uid=`**。因此「只能降到 cortex-builder」在 polkit
   層無法強制，只能由 Manager 端封閉的 argv 產生器保證（`--uid` 值受 POSIX 帳號名 pattern
   檢查、拒絕注入）。要在 OS 層也硬化這一半需另設 root 擁有的 wrapper unit template，
   屬 Phase 3 加固，已在 runbook 明文標註。

## 變更

### 新增 `paulsha_cortex/coordinator/job_runner.py`

- **`PSC_JOB_RUNNER`**：`direct`（預設）／`systemd-run`（降權）。值非法時 **fail-closed**，
  不靜默當成 `direct`——「打錯字＝以為隔離生效但其實沒有」正是要消除的失效模式。
- **builder env 白名單（不是黑名單 scrub）**：transient unit **不繼承呼叫端的 environ**，
  因此 builder 的環境**就是**白名單本身。完整表列見下。
- **封閉的 argv 產生器**：
  `--quiet --collect --pipe --wait --unit=cortex-job-<slug>-<sha8>.service --uid --gid
  --service-type=exec --working-directory=<worktree> --property=NoNewPrivileges=yes
  --setenv=…（排序）-- bash -c <script>`。unit 名前綴 `cortex-job-` 是與 Phase 2b polkit
  規則成對的**契約**（polkit 以 `action.lookup("unit")` 比對）。
- **fail-fast 診斷（#570 `DiagnosticReason` 契約）**：`preflight_systemd_run()` 在**任何
  副作用之前**檢查 systemd-run 二進位／`/run/systemd/system`／builder 帳號／group；
  `confirm_transient_unit_started()` 補上只能在起動當下才知道的失敗（polkit 拒絕、unit
  名衝突），判準是「systemd-run 已結束**且** exit sentinel 不存在」（真跑完的極短命 job
  必然留下 sentinel，不會誤判），並把 systemd-run 的實際錯誤訊息帶進 `detail`。
  **任何一條都不會退回 direct。**

### `paulsha_cortex/coordinator/launcher.py`

- 判定點與**既有 persona 分支對齊**：`review_only`＝reviewer、`read_only`＝planner，
  **兩者皆非才是 builder**（與 `_should_run_gates()` 用同一組條件）。二分方案裡
  reviewer／planner 與 Manager 同帳號，**不經降權**。
- 降權模式的 shell 改 **`bash -c`**（#588 第 2 點：login shell 會讓 `~/.profile` 在 env
  約束建立完成後重新匯入）；**direct 模式維持 `-lc` 不動**。
- **FD**：`--pipe` 只交出 stdin/stdout/stderr（Popen `close_fds` 預設 True），且 stdin
  顯式接 `/dev/null`——direct 模式今天仍把 daemon 的 stdin 交給 job，降權模式在這點上
  比 direct **更緊**。
- `_CREDENTIAL_ENV_RE` 改為 `job_runner.CREDENTIAL_ENV_RE` 的別名：reviewer sandbox 政策
  與 builder 白名單守衛永遠共用同一條 pattern，不會兩處漂移。
- `executor_environment()`（#262 D2）在降權模式回報 builder env——否則 preflight 報的
  PATH／HOME 與正式 job 無關，只是安慰劑。

## builder env 白名單全表（每項為何需要）

**轉發類**（從 Manager env 複製；判準：缺了它 CLI／wrapper 會直接失敗，且本身不是憑證、
不指向任何 trust-root 資產）：

| 變數 | 為何需要 |
|---|---|
| `PATH` | 模型 CLI（`claude`／`codex`／`copilot`）的解析路徑；systemd 只會給 PID 1 的 manager PATH，裡面沒有 npm global／pipx shim → 一律 127。wrapper 內的 `python3`（gate ledger writer）與 `git`（builder 要 commit candidate）同樣靠它。可用 `PSC_BUILDER_PATH` 覆寫成 builder 讀得到的路徑 |
| `LANG` | UTF-8 locale。本 repo 的 spec／CHANGELOG／prompt 全是 zh-tw；缺 locale 時 wrapper 內的 python3 會以 ASCII 解讀檔案而丟 `UnicodeDecodeError` |
| `LC_ALL` | 同上（覆寫優先序較高的那一個），與 reviewer 既有最小 env 的 LC_* 處置一致 |
| `LC_CTYPE` | 同上；只轉發字元分類，其餘 LC_*（金額／日期格式）對 headless job 無意義 |
| `SSL_CERT_FILE` | 自訂／企業 CA 環境下 python/openssl 的 CA bundle **路徑**（值是路徑，非憑證內容）；缺它時模型 CLI 的 HTTPS 直接失敗，且失敗訊息與「未登入」難以區分 |
| `SSL_CERT_DIR` | 同上的目錄形式 |
| `NODE_EXTRA_CA_CERTS` | `claude`／`copilot` CLI 是 node 進程，node **不讀** `SSL_CERT_FILE`，只認這一個 |

**合成類**（launcher 現場算出，絕不從 Manager env 繼承）：

| 變數 | 為何需要 |
|---|---|
| `PSC_JOB_ID` | #506／D5 的 headless job 標記；`porcelain/headless_hook.py` 沒有它就是完全 no-op |
| `PSC_SLICE_ID` | 既有 job 標記（launcher 現行行為） |
| `PSC_REPO_ROOT` | relay hook 的 script 解析點，以及 wrapper 內 gate ledger writer 的 `PYTHONPATH` |
| `PSC_RELAY_TARGET` | **僅在 launcher 有設定時**才出現（與 direct 模式同條件） |
| `HOME` | **僅在 `PSC_BUILDER_HOME` 明示時**才設；未設時交給 systemd 依 passwd 填入 builder 帳號自己的 HOME。**任何情況下都不會是 daemon 的 HOME** |

**刻意不轉發**（記在 `EXCLUDED_ENV_RATIONALE`，本身不是憑證但轉發會出錯或擴大信任面）：
`HOME`／`USER`／`LOGNAME`／`SHELL`（systemd 依 passwd 填正確值）、`TMPDIR`（Manager 若啟用
`PrivateTmp=`，該路徑 builder 進不去）、`XDG_*`（會讓 builder 的 cache／config 落回
cortex-svc 的樹）、`*_PROXY`（proxy URL 可內嵌 `user:pass@`，屬憑證面，改由 builder 自己的
drop-in 提供）、`VIRTUAL_ENV`／`PYTHONHOME`（會把 builder 綁進 Manager 的部署 venv）。

**永不出現**（`_reject_unsafe()` defense-in-depth 守衛，命中即 fail-closed）：任何符合
`CREDENTIAL_ENV_RE`（`*_TOKEN`／`*_API_KEY`／`*_SECRET`／`*_PASSWORD`…）的名稱，加上明列的
`CLAUDE_CONFIG_DIR`／`GH_CONFIG_DIR`／`GH_HOST`／`BASH_ENV`／`ENV`／`SHELLOPTS`／`BASHOPTS`／
`LD_PRELOAD`／`LD_LIBRARY_PATH`／`PYTHONPATH`／`PYTHONSTARTUP`／`NODE_OPTIONS`。白名單是靜態
的，這道守衛的意義是：**有人往白名單加一項憑證時測試會當場紅**。

## 測試

`tests/test_trust_root_job_runner_p2a.py`（63 測試）：

- **direct 零回歸**：預設與顯式 `direct` 形狀一致、仍走 `bash -lc`、**仍繼承 daemon env**
  （刻意釘住現行行為，同時標出降權模式才是 #588 的解法）、Popen kwargs 形狀不變。
- **systemd-run argv**：unit 名可追蹤＋消毒後仍唯一、`--uid`／`--gid`、`--setenv` 排序、
  `--` 後是 `bash -c`、不使用 `--same-dir`（Manager 的 cwd 不是 worktree）。
- **env 白名單不含 token 類**：`GH_TOKEN`／`GITHUB_TOKEN`／`COPILOT_GITHUB_TOKEN`／
  `ANTHROPIC_API_KEY`／`OPENAI_API_KEY`／`AWS_SECRET_ACCESS_KEY`／`CLAUDE_CONFIG_DIR`／
  `GH_CONFIG_DIR`／`BASH_ENV`／`NODE_OPTIONS`／`PGPASSWORD` 逐一斷言不存在，並在**整條
  argv 上做值層面兜底**（任何 secret 的**值**都不得出現）。
- **reviewer／planner 不降權**、builder 帳號 config 生效。
- **fail-fast**：模式值非法、systemd-run 缺席、未以 systemd 開機、帳號／group 不存在
  （且**一個 job 都不能被 spawn**）、transient unit 起不來（polkit 拒絕訊息進 `detail`）。

`systemd-run` 本體**全程 mock**：測試不真跑 systemd、不建帳號、不碰 polkit。

**全套結果**：`python3 -m pytest -q` → **3203 passed, 49 subtests passed**（零紅，
#565 的暫態 `/tmp/.git` 兩紅本次未重現）。
`policy_check`（帶 PR 上下文）→ **pass 24 / fail 0 / warn 1**（warn 為 R-22 的 69 條
**既有**懸空引用，advisory）。

## Checklist

- [x] `changelog.d/p2a-systemd-run-launcher.md` fragment 已新增且已 commit
- [x] `CHANGELOG.md [Unreleased]` 有對應 entry
- [x] `VERSION` 未變更（非 release PR）
- [x] 全套測試綠（3203 passed）
- [x] `policy_check` 帶 PR 上下文跑，fail: 0
- [x] docs 同步（Phase 2b runbook 第 5 步改寫、README env 說明）
- [x] 不動 systemd／不建帳號／不寫 polkit（本 PR 純程式碼＋文件）

Refs #584 #588
