### PR TITLE
feat(trust-root): permgen 產 systemd unit 與 polkit 規則，Phase 2b runbook 收斂為可執行版

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,44 @@
 ## [Unreleased]
 
 ### Added
+- **R0.5 D6 / trust-root 隔離 Phase 2b：permgen 產 systemd unit ＋ polkit 規則，
+  runbook 收斂為可執行版（仍不需 root）**——`permgen.py` 新增 `PathLayout`，把
+  operator 0816 第二輪裁決的路徑（`/var/lib/cortex`、worktree pool
+  `/var/lib/cortex/worktree`、部署樹 `/opt/cortex`）固化為機器可讀 config，對 R1 登記表
+  每一項給出真實絕對路徑（等式測試：無遺漏、無多餘），runbook 因此不再有 placeholder。
+  `build_manager_unit()`／`build_job_unit()` 機械產生 system-level unit：`User=` 服務
+  帳號、`ExecStart` 指 root-owned 部署樹、`EnvironmentFile=` **無 `-` 前綴＝fail-closed**、
+  27 項加固指令**逐項附「為何」註解**，而 **`ReadWritePaths=` 由 R1 登記表機械導出**
+  （未決 5 定案）——等式測試同時釘住無遺漏／無多餘／最小性／與 `ProtectSystem`
+  `ProtectHome` 的一致性，非登記表的額外可寫路徑只能經 `ExtraWritePath` 明示宣告且
+  **每條必須附理由**。降權 job 走 **root-owned 模板 unit**（`User=cortex-builder`
+  硬寫死、token 清空、命令來自 Manager-owned spool 且 job 唯讀）。`build_polkit_rule()`
+  以同一套邏輯產出**兩個降權方案**的規則：**A（`--transient`，預設）**對應 #603 的
+  `systemd-run`，unit pattern 與 `job_runner.UNIT_NAME_PREFIX` 是成對契約，且把
+  「polkit 只暴露 unit 名稱、**不暴露 `User=`／`--uid=`**」導致的殘餘風險由 `UidScheme`
+  機械導出並逐條寫進規則檔開頭（二分下 reviewer／planner 與 Manager 併帳，三分下該條
+  自動消失）；**B（`--template`）**配合 root-owned 模板 unit 把 `User=` 硬寫死、
+  transient unit 一律拒，殘餘為零。兩案骨架相同（**unit／verb 明細缺席即拒**、只放行
+  `start`/`stop`、錨定 pattern）且互不放行對方的 unit 形狀；`evaluate_polkit()` 是與
+  JS 共用常數的 Python 鏡像，兩案各跑一份決策矩陣。`transient_unit_properties()` 把
+  同一套加固表 ＋ 同一份 RWP 展開成 A 方案的 `systemd-run --property=` 對照清單。
+  三者**只產生內容字串**，靜態測試把
+  `open(`／`write_text`／`mkdir`／`shutil` 也納入禁用字串。CLI 新增
+  `python -m paulsha_cortex.trust_root {unit,polkit,scaffold}`（含
+  `unit --job-properties`、`polkit --transient|--template`）與
+  `permissions --commands --paths`。runbook `trust-root-phase2b-setup.md` 由 draft
+  改為 **executable**：7 個 `⚠️ 未決` 全數替換為裁決定案表，結構為執行前提 ＋ 9 步
+  ＋ WSL2 風險段 ＋ 附錄（24 個 sudo 點、94 個驗證點）。第 5 步把 A／B 兩案**都**寫成
+  完整可執行（共用前提含「polkit 能／不能強制什麼」對照表與 A/B 比較表，各自的正向／
+  反向驗證，A 方案另含「移除 polkit 規則後 dispatch 必須 fail-closed」的負控制與一條
+  **預期會成功**的殘餘風險實測），並在開頭標明這是全 runbook 唯一還需 operator 拍板
+  的一點（且與「是否提前三分」連動）。第 3b 節吸收 #599 的 review verdict 受控通道；
+  第 8 步 R9 手動抽驗給出四族 43 條攻擊命令與預期輸出＋三組 negative control；
+  第 9 步含每階段回滾與「全部退回 Phase 1 降級運轉」的總回滾；WSL2 段補上開機拉起
+  驗證與 `ProtectSystem=strict` 誤擋診斷。**本票只交付程式碼與文件**：不建
+  UID、不 chown、不動 systemd／polkit／pipx／`~/.agents`。詳見
+  `changelog.d/p2b-runbook-executable.md`。新增 `tests/test_trust_root_permgen_p2b.py`
+  （61 測試）。
 - **R0.5 D6 / trust-root 隔離 Phase 2a：review verdict 受控通道（per-job 單向 spool）**
   ——堵掉 spec 背景 §3 的最短攻擊路徑：verdict 原本由 reviewer 模型寫在**自己的
   worktree 內**（`.psc-review-verdict.json`），同 UID 下 builder 可直接覆寫／預埋，

--- a/changelog.d/p2b-runbook-executable.md
+++ b/changelog.d/p2b-runbook-executable.md
@@ -1,0 +1,119 @@
+# p2b-runbook-executable
+
+**R0.5 D6 / trust-root 隔離 Phase 2b：permgen 產 systemd unit ＋ polkit 規則，runbook
+收斂為可執行版**（純程式碼＋文件，仍不需 root、不動系統）。
+
+## permgen 擴充（`paulsha_cortex/trust_root/permgen.py`）
+
+- **`PathLayout`（部署 layout）**：把 operator 0816 第二輪裁決的路徑固化為機器可讀
+  config——`agents_root=/var/lib/cortex`、`worktree_root=/var/lib/cortex/worktree`、
+  `deploy_root=/opt/cortex`。`asset_paths()` 對 R1 登記表**每一項**給出目標主機的真實
+  絕對路徑（等式測試：無遺漏、無多餘），runbook 因此不再有 `<PATH:asset_id>` placeholder。
+  `with_job_segment("%i")` 讓 per-job 路徑在 systemd 模板 unit 中直接展開。
+  `scaffold_directories()` 另出非登記表資產的父層骨架（部署樹、兩個服務帳號 HOME、
+  job spool），原則是**凡保護資產的父目錄一律 root 擁有**——父目錄可寫者能 unlink／
+  rename 子物件，root-owned 檔放進服務帳號可寫的目錄等於沒保護。
+- **systemd unit 產生**（`build_manager_unit()`／`build_job_unit()`）：
+  - Manager 走 system-level unit，`User=<durable_state_owner>`、`ExecStart` 指 `/opt/cortex`
+    部署樹、`EnvironmentFile=`（**無 `-` 前綴＝fail-closed**，spec §R3）落在全 root-owned
+    的 `/opt/cortex/etc/`。
+  - **`ReadWritePaths=` 由 R1 登記表機械導出**（未決 5 的定案）：規則只有一條——某帳號
+    可寫的資產，目錄取自身、檔案取父目錄，再做最小覆蓋。等式測試同時釘住**無遺漏**
+    （每個 Manager 需寫的資產都被覆蓋）與**無多餘**（移除任一條就有資產失去覆蓋）、
+    最小性（沒有任何一條被另一條包含）、與 `ProtectSystem`／`ProtectHome` 的一致性
+    （部署樹永不可寫、RWP 不得落在 `ProtectHome` 遮蔽的 `/home`、`/root`）。非登記表
+    的額外可寫路徑只能經 `ExtraWritePath` 明示宣告，且**每條必須附理由**（測試強制）。
+  - 27 項加固指令逐項附「為何」的註解（測試斷言每一項都有前置註解），含
+    `NoNewPrivileges`／`ProtectSystem=strict`／`ProtectHome`／`PrivateTmp`／
+    `ProtectProc=invisible`（直接封 R9 族 4 的 `/proc/<pid>/environ`）／空的
+    `CapabilityBoundingSet` 與 `AmbientCapabilities`（裁決 6：cortex 任何元件永不具 root）。
+  - 降權 job 走 **root-owned 模板 unit** `cortex-job@.service`：`User=<job 帳號>`
+    **硬寫死**、`GH_TOKEN`／`GITHUB_TOKEN` 清空、`ExecStart` 讀 Manager-owned job spool
+    的 `run.sh`（job 帳號唯讀 ⇒ 改不了自己的命令列）、`CollectMode=inactive-or-failed`。
+    job 側 RWP 同樣機械導出，僅涵蓋 builder 需寫者（自己的 worktree ＋ event-spool
+    的 append ACL），不含任何 Manager-owned。
+- **polkit 規則產生**（`build_polkit_rule(..., plan=PolkitPlan.TRANSIENT|TEMPLATE)`）：
+  兩個降權方案共用同一套產生邏輯與同一組骨架（subject 檢查、action 檢查、
+  **unit／verb 明細缺席即拒**、verb 白名單 `start`/`stop`、錨定的 unit pattern），
+  差別只在 pattern 與說明段：
+  - **A（`TRANSIENT`，預設）**——`^cortex-job-<id>\.service$`，對應 #603 的
+    `job_runner.UNIT_NAME_PREFIX`（測試釘住這是**成對契約**）。`plan_residual_risk()`
+    由 `UidScheme` 機械導出殘餘風險並**逐條寫進規則檔開頭**：polkit 的
+    `manage-units` 只暴露 unit 名稱、**不暴露 `User=`／`--uid=`**，故與 `cortex-svc`
+    同 UID 的任何行程都能請求任意 `User=`（含 root）；二分方案下 reviewer／planner
+    跑模型且與 Manager 併帳，三分方案下該條自動消失（測試釘住這個差異）。
+  - **B（`TEMPLATE`）**——`^cortex-job@<id>\.service$`，配合 root-owned 模板 unit
+    把 `User=` 硬寫死，`residual_risks` 為空；檔頭寫明「為何 transient unit 一律拒」。
+  兩案互不放行對方的 unit 形狀（測試釘住）。`evaluate_polkit()` 是規則決策的 Python
+  鏡像（polkit 無法本機執行），與 JS **共用同一組常數**，兩案各跑一份決策矩陣
+  （含前綴／後綴名稱混淆、其他 verb、其他 action、其他 subject）。
+  `transient_unit_properties()` 另把同一套加固表 ＋ 同一份登記表導出的 RWP 展開成
+  A 方案的 `systemd-run --property=` 清單，作為「A 與 B 加固面是否等價」的對照。
+- **兩者都只產生內容字串**：新增靜態測試把 `open(`／`write_text`／`mkdir`／`shutil`
+  一併納入禁用字串（原本只擋 `subprocess`／`os.system`／`os.chown`／`os.chmod`），
+  維持 permgen 的無特權靜態測試不變式。
+- **命令輸出可直接執行**：目錄資產先出 `install -d`；尚未建立的葉檔包上
+  `[ ! -e <path> ] ||` 守衛（`sh -e` 下不中斷，且服務以 `UMask=0077` 建立即符合目標
+  權限）；per-job 資產（帶 `<job-id>` segment）以註解形式輸出，可讀但不會被誤執行。
+- **file/dir 推斷修正**：`evidence/*`、`workflow-report-transactions`、
+  `engineering-outcomes`、`gate-ledger` 等**目錄**先前被 token heuristic 誤判為單檔
+  （會產生 `chmod 0600` 到目錄上）；改為明列。多 persona 容器分支不再無條件視為目錄，
+  per-job handoff manifest 因此得到 `0600` 而非 `0701`。
+- **CLI**：`python -m paulsha_cortex.trust_root {unit,polkit,scaffold}`，
+  `permissions ... --commands --paths` 以真實 layout 路徑輸出。
+
+## runbook 收斂（`docs/superpowers/runbooks/trust-root-phase2b-setup.md`）
+
+`status: draft` → `status: executable`。7 個 `⚠️ 未決` 全數移除，替換為 0816 第二輪
+裁決定案表（含每點落在哪一步）。結構：**執行前提 ＋ 9 個步驟 ＋ WSL2 風險段 ＋ 附錄**，
+24 個 `🔧 sudo` 點、94 個 `✅ 驗證` 點。
+
+- **第 3b 節**吸收 PR #599 的 review verdict 受控通道（`review-verdict-spool` 已進登記表
+  ⇒ 權限由第 2 步的 script 一併套用，本節只做確認與三分方案下 reviewer write-only ACL
+  的說明）。
+- **執行前提**（新增）：in-flight job 手動收尾（裁決 3）、服務已停、Phase 1 自檢
+  baseline 存檔、登記表等式綠、`sudo` 可用、**polkit 在跑**（缺 polkit ⇒ 降權必然
+  fail-closed 全停）、磁碟空間。
+- 每步命令改為**真實絕對路徑**、可直接複製；權限／unit／polkit 一律「產生器輸出 →
+  operator 讀過 → 落檔」，並附 `diff <(產生器) <(系統檔)` 的漂移檢查。
+- **第 5 步（降權）兩案都寫完整**：5-0 共用前提（polkit 能／不能強制什麼的對照表、
+  A/B 比較表含「與提前三分的關係」、兩案規則並排 `diff`）；5-A 涵蓋 #603 的 argv 形狀、
+  env 白名單、unit 名前綴契約驗證、polkit 落檔、`PSC_JOB_RUNNER=systemd-run` 開關、
+  正向驗證、反向驗證（含**負控制：移除 polkit 規則後 dispatch 必須 fail-closed 落
+  `job-runner-transient-unit-start-failed` 而非退回 direct**）與殘餘風險實測；
+  5-B 涵蓋模板 unit ＋ polkit 落檔、job spool 的 ACL 佈置、正向驗證與 7 條反向驗證
+  （`systemd-run --uid=0`／`--uid=cortex-builder`／夾帶 `AmbientCapabilities`／起別的
+  unit／名稱混淆／其他 verb／直接改模板 unit）**全部必須非 0 退出**。
+- **第 8 步 R9 手動抽驗**（裁決 7）：一份逐條攻擊測試 script（族 1 五條／族 2 二十條／
+  族 3 十一條／族 4 七條），每條附確切命令與預期輸出（`denied (OK) rc=<非 0>`），
+  外加三組 negative control（受信任身分做同一件事必須成功）與族 3 的「重啟後仍綠」複驗。
+- **第 9 步回滾**：每階段各自的退路 ＋「全部退回 Phase 1 降級運轉」的總回滾（新樹整棵
+  丟棄不遺失資料，因為舊 state 走 legacy-import 物理隔離而非併入）。
+- **WSL2 風險段**補上：system unit 開機拉起的驗證流程（`wsl --shutdown` 前後的
+  `is-enabled`／`is-active`／`journalctl -b` 逐項）、`ProtectSystem=strict` 誤擋的
+  五步診斷（含以 root 的 `systemd-run` 在同一組沙箱條件下重現）與依機率排序的常見
+  誤擋清單；鐵律是「被擋路徑只能經回填登記表 → 重跑 permgen 進入 RWP，drop-in 只能
+  是當天的臨時措施」。
+
+## 唯一還需要 operator 拍板的一點（已在 runbook 開頭與 PR body 標明）
+
+裁決寫「systemd-run transient unit ＋ polkit 收窄到只能 `User=cortex-builder`」。
+#603 實測確認 polkit 的 `manage-units` action **只暴露 unit 名稱與 verb**，
+**不暴露 `User=`／`--uid=`**——「只能降到 job 帳號」這一半 polkit 無法強制。本 PR 因此
+把第 5 步寫成**兩案並列、各自完整可執行**：
+
+- **A（`systemd-run`，裁決的字面方案）**：程式碼已落地（#603），「降到哪個帳號」由
+  Manager 端封閉 argv 產生器在 code level 保證。殘餘風險寫死在 runbook 與規則檔裡，
+  且 5-A-5 (4) 是一條**預期會成功**的實測（`sudo -u cortex-svc systemd-run --uid=0`），
+  用途是讓 operator 親眼確認自己接受了什麼。
+- **B（root-owned 模板 unit）**：`User=` 硬寫死在 root 擁有的 `cortex-job@.service`，
+  polkit 只放行該模板實例、transient unit 一律拒，殘餘為零；代價是 Manager 端要從
+  `systemd-run` 改成 `systemctl start cortex-job@<id>`（待排的程式碼工項）。
+
+同時需一併裁決「**是否提前三分**」——三分把 A 的殘餘風險從「三個與 Manager 併帳的
+persona」縮回「Manager 自己」，permgen 只需把 `two-way` 換成 `three-way`。
+
+## 範圍
+
+**本票只交付程式碼與文件**：不建 UID、不 chown、不動 systemd／polkit／pipx／`~/.agents`。
+新增 `tests/test_trust_root_permgen_p2b.py`（61 測試）。

--- a/docs/superpowers/runbooks/trust-root-phase2b-setup.md
+++ b/docs/superpowers/runbooks/trust-root-phase2b-setup.md
@@ -1,40 +1,113 @@
 ---
-status: draft
+status: executable
 work_item: trust-root-isolation
 phase: 2b
 audience: operator
 supersedes: none
 tracking: "#584 — trust-root D6 母議題（本票 reference-only，不 auto-close；R-17 走 policy-exempt:issue-link 豁免）"
+decision: "operator 0816 第二輪裁決（#584 留言）——7 個未決點全數收斂"
 refs:
   - docs/superpowers/specs/trust-root-isolation-spec.md
   - paulsha_cortex/trust_root/registry.py
   - paulsha_cortex/trust_root/permgen.py
 ---
 
-# trust-root Phase 2b：root 設定 runbook（草稿，供 operator review）
+# trust-root Phase 2b：root 設定 runbook（可執行版）
 
-> **本文件是草稿**，供 operator 逐步 review 後**手動** `sudo` 執行。文件本身
-> **不執行任何 root 操作**；所有特權步驟都由 operator 親自輸入。凡標記
-> **`⚠️ 未決`** 的段落，其最終形態待 operator 拍板後才可執行。
+> **本文件是可執行版**：每一步的命令可直接複製、每一步有驗證、每一步可回滾。
+> 文件本身**不執行任何 root 操作**；所有 `sudo` 都由 operator 親自輸入。
+> **cortex 任何元件永不具 root**——cortex 只**產生**命令字串與驗證結果，
+> root 操作一律由 operator 手動執行（0816 裁決，未決 6）。
 
 實作 `trust-root-isolation-spec.md` 的 **Phase 2**（spec §R10 Phase 2 第 1–8 步）。
-Phase 2a 的權限產生器（`paulsha_cortex/trust_root/permgen.py`）已把 R1 登記表機械
-轉成目標 `owner:group mode`；本 runbook 是把那份計畫**落到 OS**的手動流程。
+Phase 2a 的權限產生器（`paulsha_cortex/trust_root/permgen.py`）把 R1 登記表機械轉成
+目標 `owner:group mode`、systemd unit 與 polkit 規則；本 runbook 是把那份計畫**落到
+OS** 的手動流程。
 
-## operator 0816 裁決（本 runbook 的前提）
+---
 
-- **路線 A**（OS／MAC 邊界），非簽章路線。
-- **Manager 專屬 UID**：Manager 不再跑在 operator 帳號，改跑在服務帳號。
-- **現階段先二分**：`cortex-builder`（builder）／`cortex-svc`（Manager＋reviewer＋
-  planner＋monitor 共用，且為 durable state owner）。**保留二往三分彈性**——未來把
-  Manager 拆成第三個 UID 時，只需換 `permgen.THREE_WAY_SCHEME`，runbook 結構不變。
-- **Manager 落 system-level unit**（非 `--user`），以 `cortex-svc` 執行。
-- **降權機制＝`systemd-run` transient unit**（未決 1 已裁決）。程式碼面 Phase 2a 已落地
-  （`paulsha_cortex/coordinator/job_runner.py`，`PSC_JOB_RUNNER` 預設 `direct`）；
-  本 runbook 第 5 步是把開關打開的部署動作。polkit 授權面收窄到 `cortex-job-` 前綴的
-  transient unit。
-- **舊 state 走 legacy-import 重新入帳**，**不**直接 `chown` 沿用（spec §R6(e)）。
-- **降級運轉逐案核可**（`PSC_DEGRADED_OPERATION=per-case-approval`，Phase 1 已上線）。
+## 0816 第二輪裁決定案表（本 runbook 的前提）
+
+| 原未決點 | 定案 | 落在本 runbook |
+|---|---|---|
+| 1 降權機制 | **systemd 降權 job unit ＋ polkit 收窄**（授權面只允許 `cortex-svc` 起 job unit）。**「降到哪個帳號」由誰強制**尚待 operator 在 A（`systemd-run`，code level 保證）／B（root-owned 模板 unit，OS 強制）之間擇一——兩案都已寫成完整可執行 | 第 5 步 |
+| 2 durable state 路徑 | **`/var/lib/cortex`**；worktree pool＝**`/var/lib/cortex/worktree`** | 第 2 步 |
+| 3 legacy-import | **物理隔離 ＋ hash manifest**（無簽章；簽章屬 Phase 3）。切換前 in-flight job **手動收尾** | 執行前提、第 3 步 |
+| 4 Manager 部署 | **`/opt/cortex`**（root 擁有，對服務唯讀） | 第 4 步 |
+| 5 `ReadWritePaths` | **由 R1 登記表經 permgen 機械產生**，不手寫 | 第 4c 步 |
+| 6 root 命令 codify | **不 codify**——不提供 `cortex install trust-root --system`；cortex 只產生命令字串 | 第 6 步 |
+| 7 R9 | **手動抽驗**（完整自動化矩陣屬另一工項） | 第 8 步 |
+| UID 方案 | **二分先行**（`cortex-svc` / `cortex-builder`），保留三分彈性（permgen 已參數化）；Manager 走 **system-level unit** | 第 1、4c 步 |
+
+### ⚠️ 唯一還需要 operator 拍板的一點（請先看這段）
+
+裁決寫的是「**systemd-run** transient unit ＋ polkit 收窄到只能 `User=cortex-builder`」。
+#603 實測確認一個**硬限制**：polkit 的 `org.freedesktop.systemd1.manage-units` action
+**只暴露 unit 名稱與 verb**，**不暴露 `User=`／`--uid=`**。授權之後，systemd 會照請求的
+**任意** `User=` 起 unit。因此「只能降到 `cortex-builder`」這一半 **polkit 無法強制**，
+必須另外找地方守：
+
+- **方案 A（`systemd-run` transient unit）**——0816 裁決的字面方案，程式碼**已落地**
+  （#603 `coordinator/job_runner.py`，`PSC_JOB_RUNNER=systemd-run`）。「降到哪個帳號」
+  由 Manager 端**封閉的 argv 產生器**在 code level 保證。
+  **殘餘風險**：與 `cortex-svc` **同 UID 的任何行程**都持有這個 grant，可請求任意
+  `User=`（含 `User=root`）的 transient unit——而**二分方案下跑模型的 reviewer／planner
+  就與 Manager 併帳**。這條風險與「**是否提前三分**」直接相關（三分把它縮回「只有
+  Manager 自己」）。
+- **方案 B（root-owned 模板 unit）**——`cortex-job@.service` 把 `User=cortex-builder`
+  硬寫死在 **root 擁有**的檔案裡，polkit 只放行該模板的實例、transient unit 一律拒。
+  「降到哪個帳號」因此由 **OS** 強制，殘餘為零。代價是 Manager 端要從 `systemd-run`
+  改成 `systemctl start cortex-job@<id>`，**屬待排的程式碼工項**。
+
+**兩案在第 5 步都寫成完整可執行**（含各自的正向／反向驗證、殘餘風險實測）；
+operator 選定後只跑那一節，其餘步驟（1–4、6–9）兩案共用。**同時要一併裁決的是
+「是否提前三分」**——permgen 已參數化，只需把命令中的 `two-way` 換成 `three-way`。
+
+---
+
+## 執行前提（開工前逐項確認，全部 `✅ 驗證`）
+
+```bash
+# ✅ 1. in-flight job 手動收尾（裁決 3：切換期間不得有半途 job）
+cortex jobs
+cortex status
+#   期望：`cortex jobs` 無 running／dispatched 狀態的列；`cortex status` 無 pending request。
+#   若有：(a) 等它自然結束；或 (b) `cortex slice-action` / `cortex work` 以 operator
+#   身分明示收尾後再繼續。
+#   **不可**在有 in-flight job 時切換——舊樹被隔離後那些 job 的 evidence 會變孤兒。
+
+# ✅ 2. Manager／Monitor 服務已停（切換期間不得有行程持續寫舊樹）
+systemctl --user stop cortex-manager.service cortex-monitor.service 2>/dev/null || true
+systemctl --user is-active cortex-manager.service || echo "manager stopped"
+pgrep -a -f "paulsha_cortex" || echo "no cortex process"
+
+# ✅ 3. Phase 1 自檢 baseline（切換後要對照）
+python3 -m paulsha_cortex.trust_root selfcheck \
+  | tee "/tmp/trust-root-baseline-$(date +%Y%m%d-%H%M).json" >/dev/null
+echo "baseline saved"
+
+# ✅ 4. 登記表雙向等式必須綠（紅＝盤點已漂移，先修 Phase 1 再繼續）
+python3 -m paulsha_cortex.trust_root equation
+
+# ✅ 5. sudo 可用（會要密碼；只取得授權，不做任何變更）
+sudo -v
+
+# ✅ 6. system systemd 與 polkit 皆在跑（缺 polkit＝第 5 步降權必失敗）
+systemctl is-system-running || true          # 期望 running；degraded 亦可，記錄之
+systemctl is-active polkit.service || systemctl is-active polkitd.service
+#   期望 active。若 inactive：`sudo systemctl enable --now polkit.service`
+#   若本機根本沒有 polkit 套件，**第 5 步不可執行**（見第 9 步回滾）。
+
+# ✅ 7. 磁碟空間足夠複製整棵 venv 與舊 state
+df -h /var /opt
+du -sh "$HOME/.agents" "$HOME/.local/share/pipx/venvs/paulsha-cortex" 2>/dev/null
+```
+
+**通過條件**：1–7 全部符合期望；`equation` 回傳 `ok: true`；baseline JSON 已存檔。
+Phase 1 自檢此時**預期為紅**（有 `job-writable` finding）——那正是本 runbook 要收斂的
+清單，切換完成後（第 7 步）應轉綠。
+
+---
 
 ## 當前環境事實（WSL2）
 
@@ -43,371 +116,463 @@ Phase 2a 的權限產生器（`paulsha_cortex/trust_root/permgen.py`）已把 R1
 | OS | WSL2、system-level systemd 可用（`systemctl is-system-running` = `running`） |
 | sudo | **需密碼**——每個 `sudo` 步驟都是互動式，**不可假設自動化** |
 | 帳號 | 單一 `operator` 登入帳號（本文以 `operator` 代稱，勿寫死使用者名） |
-| 部署 | pipx tree 在 operator HOME（`$HOME/.local/share/pipx/venvs/paulsha-cortex/`），實測 `drwxrwxr-x` |
+| 部署 | pipx tree 在 `$HOME/.local/share/pipx/venvs/paulsha-cortex/`，實測 `drwxrwxr-x` |
 | headless job | 現以 operator 帳號跑 |
-| `~/.agents/{control,config/paulsha}` | 現為 `775`（`g+w`） |
+| `$HOME/.agents/{control,config/paulsha}` | 現為 `775`（`g+w`） |
 
 ## 標記約定
 
-- **`🔧 operator sudo`**：operator 親自 `sudo` 執行的特權變更。
-- **`✅ 驗證`**：唯讀驗證命令（可由 operator 或 CI 執行，無特權）。
-- **`⚠️ 未決`**：最終形態待 operator 拍板；**未拍板前不得執行**。
-- 命令中的路徑一律以 shell 變數表示（如 `"$AGENTS_ROOT"`），**勿寫死絕對路徑**。
+- **`🔧 sudo`**：operator 親自 `sudo` 執行的特權變更。
+- **`✅ 驗證`**：唯讀驗證命令（無特權或只讀，可重複執行）。
+- 命令中的路徑一律為裁決定案的**真實絕對路徑**，可直接複製。
+- 個人路徑一律以 `$HOME` 表示，**不寫死使用者名**。
 
-## 權限命令的單一真相
+## 產生器＝權限／unit／polkit 的單一真相
 
-所有 `chown`／`chmod`／`setfacl` **不手寫**——由權限產生器輸出，operator 逐項對照
-登記表 review：
+`chown`／`chmod`／`setfacl`／unit 內容／polkit 規則**一律不手寫**，全部由 permgen 由
+R1 登記表機械產生：
 
 ```bash
-# ✅ 驗證：印出二分方案的完整權限計畫（JSON）
+# ✅ 完整權限計畫（JSON，含每項 rationale）
 python3 -m paulsha_cortex.trust_root permissions two-way
 
-# ✅ 驗證：印出可直接對照的命令序列（含 <PATH:asset_id> placeholder）
-python3 -m paulsha_cortex.trust_root permissions two-way --commands
+# ✅ 可直接執行的權限命令（帶真實絕對路徑，無 placeholder）
+python3 -m paulsha_cortex.trust_root permissions two-way --commands --paths
 
-# ✅ 驗證：印出登記表摘要（含每項 path_resolver，供解析真實路徑）
-python3 -m paulsha_cortex.trust_root registry
+# ✅ 骨架目錄（非登記表資產的父層）
+python3 -m paulsha_cortex.trust_root scaffold two-way
+
+# ✅ Manager system unit 內容（ReadWritePaths 由登記表導出）
+python3 -m paulsha_cortex.trust_root unit two-way --manager
+
+# ✅ 降權 polkit 規則內容（方案 A：systemd-run transient unit）
+python3 -m paulsha_cortex.trust_root polkit two-way --transient
+
+# ✅ 降權 polkit 規則內容（方案 B：root-owned 模板 unit）
+python3 -m paulsha_cortex.trust_root polkit two-way --template
+
+# ✅ 方案 B 的 job 模板 unit 內容（User=cortex-builder 硬寫死）
+python3 -m paulsha_cortex.trust_root unit two-way --job
+
+# ✅ 方案 A 的 --property= 建議清單（與 B 同源：同一加固表 ＋ 同一份 RWP）
+python3 -m paulsha_cortex.trust_root unit two-way --job-properties
 ```
 
-> **路徑代入**：命令輸出以 `<PATH:asset_id>` placeholder 呈現。operator 依
-> `registry` 的 `path_resolver` 在目標主機解析真實路徑（見第 3 步的 `AGENTS_ROOT`
-> 等變數），再逐項替換。`path_resolver=None` 的葉資產（如 `jobs-registry` →
-> `<coordinator_root>/jobs.json`）依 spec 背景段的定義位置表解析。
-
----
-
-## 第 0 步：前置檢查（不需特權，全部 `✅ 驗證`）
-
-先把 baseline 記下來，切換後才能對照。
-
-```bash
-# ✅ 系統 systemd 可用
-systemctl is-system-running || true          # 期望 running（degraded 亦可，記錄之）
-
-# ✅ sudo 可用（會要密碼；只驗證能取得，不做任何變更）
-sudo -v
-
-# ✅ Phase 1 自檢 baseline——記錄現況哪些 Manager-owned 路徑仍 job-writable
-python3 -m paulsha_cortex.trust_root selfcheck | tee "/tmp/trust-root-baseline-$(date +%Y%m%d).json"
-
-# ✅ 登記表等式必須綠（否則盤點已漂移，先修 Phase 1 再繼續）
-python3 -m paulsha_cortex.trust_root equation
-
-# ✅ 記錄現況權限（切換後對照）
-ls -ld "$HOME/.agents" "$HOME/.agents"/* 2>/dev/null
-ls -ld "$HOME/.local/share/pipx/venvs/paulsha-cortex" 2>/dev/null
-```
-
-**通過條件**：`equation` 回傳 `ok: true`；baseline JSON 已存檔。
-Phase 1 自檢此時**預期為紅**（有 `job-writable` finding）——那正是本 runbook 要收斂
-的清單，切換完成後（第 7 步）應轉綠。
+> **未來若換三分**：把上列每個 `two-way` 改成 `three-way`，runbook 其餘結構不變
+> （permgen 已參數化；第 1 步多建一個帳號）。
 
 ---
 
 ## 第 1 步：建 UID（二分）
 
-建立兩個 **system service 帳號**，皆 **no-login**（`nologin` shell）、**最小 home**。
+建立兩個 **system service 帳號**，皆 **no-login**、**home 由 root 擁有**。
 慣例：每帳號一個同名 primary group（權限產生器的 ACL 以此為前提）。
 
 ```bash
-# 🔧 operator sudo：建 cortex-svc（durable state owner + Manager/monitor/reviewer/planner）
+# 🔧 sudo：cortex-svc（durable state owner ＋ Manager/monitor/reviewer/planner）
 sudo groupadd --system cortex-svc
 sudo useradd  --system --gid cortex-svc \
-     --home-dir /var/lib/cortex-svc --create-home \
+     --home-dir /var/lib/cortex-svc --no-create-home \
      --shell /usr/sbin/nologin \
      --comment "cortex trusted service (Manager/monitor/reviewer/planner)" cortex-svc
 
-# 🔧 operator sudo：建 cortex-builder（唯一完全隔離的 headless job 帳號）
+# 🔧 sudo：cortex-builder（唯一完全隔離的 headless job 帳號）
 sudo groupadd --system cortex-builder
 sudo useradd  --system --gid cortex-builder \
-     --home-dir /var/lib/cortex-builder --create-home \
+     --home-dir /var/lib/cortex-builder --no-create-home \
      --shell /usr/sbin/nologin \
      --comment "cortex headless builder job" cortex-builder
 ```
 
-**群組設計理由**：跨帳號存取一律走 **per-account POSIX ACL**（見權限產生器輸出的
-`setfacl -m u:<acct>:rX`），**不**用共用 group 開放，避免「一個 group 開了就全開」的
-過寬授權。因此兩帳號各自獨立 group、彼此無交集。
+**為何 `--no-create-home`**：兩個帳號的 HOME 由第 2 步以 **root 擁有**的方式建立
+（`useradd --create-home` 會把 HOME 建成帳號自己擁有）。HOME 若由帳號自己擁有，
+它就能 rename 掉 `~/.codex`／`~/.gitconfig` 這類 root-owned 設定的**父目錄**——
+父目錄可寫者能 unlink／rename 子物件，等於保護失效。只有 `cache/` 子目錄開放給帳號寫。
 
-**為何 no-login／最小 home**：這兩個帳號只被 systemd 與降權啟動器使用，永不互動登入；
-最小 home 只放 per-user runtime（如 XDG dirs），不放 durable state（durable state 在
-第 3 步的分樹）。
+**群組設計理由**：跨帳號存取一律走 **per-account POSIX ACL**（見 permgen 輸出的
+`setfacl -m u:<acct>:rX`），**不**用共用 group 開放，避免「一個 group 開了就全開」。
 
 ```bash
-# ✅ 驗證：帳號存在、shell 為 nologin、互不同 group
+# ✅ 驗證：帳號存在、shell 為 nologin、互不同 group、互不在對方 group
 getent passwd cortex-svc cortex-builder
 id cortex-svc; id cortex-builder
-# 期望：兩者 primary group 不同、彼此不在對方 group
+#   期望：uid/gid 各自成對；cortex-svc 的 groups 不含 cortex-builder，反之亦然
+getent group cortex-svc cortex-builder
 ```
 
-> **✅ 未決 1 已裁決**：降權經 **`systemd-run` transient unit** ＋ narrow polkit rule
-> （見第 5 步）。unprivileged 的 `cortex-svc` 無法直接 setuid，改由 systemd（PID 1）
-> 代為切換身分。本步因此**不需要**額外的輔助群組——只要兩個帳號各自有同名 primary
-> group（`job_runner` 的 `--gid` 預設即帳號同名 group，與 `permgen.UidScheme.group_of()`
-> 同一慣例）。
+**回滾**：`sudo userdel cortex-svc; sudo userdel cortex-builder;
+sudo groupdel cortex-svc; sudo groupdel cortex-builder`（此時尚無任何檔案屬於它們）。
 
 ---
 
-## 第 2 步：解析目標路徑變數（不需特權，`✅ 驗證`）
+## 第 2 步：建目標樹並套用權限（全部機械產生）
 
-分樹前先把登記表的容器路徑解析成 shell 變數，供第 3 步引用。這些是**目標**部署下
-`cortex-svc` 的路徑（不是 operator HOME）。
+裁決：`AGENTS_ROOT=/var/lib/cortex`、`WORKTREE_ROOT=/var/lib/cortex/worktree`、
+`DEPLOY_ROOT=/opt/cortex`。這些值已固化在 `permgen.DEFAULT_LAYOUT`，下列命令直接引用。
+
+### 2a. 產生兩份 script 並**先讀過**
 
 ```bash
-# ⚠️ 未決 2：目標 AGENTS_ROOT 的最終位置待 operator 定。
-#   候選：/var/lib/cortex（system service 慣例）或保留 ~/.agents 但改 owner。
-#   本 runbook 以 /var/lib/cortex 為示例；operator 定案後替換下列變數。
-export AGENTS_ROOT="/var/lib/cortex/agents"          # ⚠️ 待定
-export CONTROL_ROOT="$AGENTS_ROOT/control"
-export COORDINATOR_ROOT="$AGENTS_ROOT/coordinator"
-export SPECS_ROOT="$AGENTS_ROOT/specs"
-export REGISTRY_ROOT="$AGENTS_ROOT/registry"
-export MONITOR_STATE_ROOT="$AGENTS_ROOT/monitor"
-export RUN_ROOT="$AGENTS_ROOT/run"
+# ✅ 產生骨架目錄 script（非登記表資產的父層：/opt/cortex、HOME、job spool…）
+python3 -m paulsha_cortex.trust_root scaffold two-way > /tmp/p2b-scaffold.sh
 
-# ✅ 驗證：確認變數與登記表 path_resolver 對得上
-python3 -m paulsha_cortex.trust_root registry | \
-  python3 -c "import sys,json;print('\n'.join(sorted(a['path_resolver'] or a['asset_id'] for a in json.load(sys.stdin)['assets'])))"
+# ✅ 產生權限 script（登記表每一項的 install -d／chown／chmod／setfacl）
+python3 -m paulsha_cortex.trust_root permissions two-way --commands --paths \
+  > /tmp/p2b-permissions.sh
+
+# ✅ 逐行讀過再執行——這是 operator 核可的實體動作
+less /tmp/p2b-scaffold.sh
+less /tmp/p2b-permissions.sh
+
+# ✅ 稽核 1：所有 mode 都不得有 group／other 寫入位（spec §R2）
+grep -oE "chmod [0-7]{4}" /tmp/p2b-permissions.sh | sort -u \
+ | awk '{m=$2; if (substr(m,3,1) ~ /[2367]/ || substr(m,4,1) ~ /[2367]/) {print "!! group/other writable: " m; bad=1}}
+        END{ if (!bad) print "no group/other write: OK" }'
+
+# ✅ 稽核 2：ACL 授「寫」只准出現在 event-spool（producer 只能 append）
+grep -E "^setfacl" /tmp/p2b-permissions.sh | grep -E ":[^ ]*w"
+#   期望：**恰好兩行**，皆為 u:cortex-builder:wx /var/lib/cortex/monitor/event-spool
+#         （access 與 default 各一）。多出任何一行都要停下來查。
+
+# ✅ 稽核 3：setfacl 可用（缺 acl 套件會讓跨帳號唯讀授權整段失效）
+command -v setfacl >/dev/null && echo "setfacl: OK" || echo "!! 請先 sudo apt-get install acl"
 ```
 
-> **背景 §7 instance-scope 漏洞**：遷移前務必確認 bootstrap env 含
-> `PSC_CONTROL_ROOT`／`PSC_COORDINATOR_ROOT`／`PSC_SPECS_ROOT` 且已 instance-scope，
-> 否則兩個 instance 仍共用 `jobs.json`、分樹會失效（spec §R2 最後一條）。
+### 2b. 執行（順序固定：先骨架、後權限）
+
+```bash
+# 🔧 sudo：骨架目錄（root-owned 父層先就位，權限 script 才不會建出錯誤的中間層）
+sudo sh -e /tmp/p2b-scaffold.sh && echo "scaffold applied"
+
+# 🔧 sudo：登記表每一項的目標權限（冪等，可重複執行）
+sudo sh -e /tmp/p2b-permissions.sh 2>&1 | tee /tmp/p2b-permissions.log
+echo "exit=${PIPESTATUS[0]}"     # 期望 0
+```
+
+> **葉檔守衛**：尚未建立的葉檔（`jobs.json`、`status.json`、ledger…）由產生器包上
+> `[ ! -e <path> ] ||` 前綴——不存在就跳過，`sh -e` 不會中斷。它們由服務首次寫入時
+> 建立，而 unit 的 `UMask=0077` 讓新檔**出生即 0600**，容器目錄已是 owner-only，
+> 因此跳過不留缺口。`/tmp/p2b-permissions.log` 應**沒有**任何
+> `No such file or directory`——若有，代表某個**目錄**沒建起來，需查。
+
+> **為何要先 scaffold**：`install -d a/b/c` 會把**新建的每一層**都套上同一組
+> `-o/-g/-m`。先讓 `/opt/cortex`、`/var/lib/cortex/config`、`/var/lib/cortex/run`、
+> `/var/lib/cortex/runtime`、兩個 HOME 以 root 身分就位，權限 script 之後只會補
+> 葉節點，不會把 root-owned 父層蓋成服務帳號所有。
+
+```bash
+# ✅ 驗證：樹根 root 擁有、Manager-owned 子樹 cortex-svc 0700、無 g+w／o+w
+ls -ld /var/lib/cortex /opt/cortex
+ls -ld /var/lib/cortex/control /var/lib/cortex/coordinator /var/lib/cortex/specs \
+       /var/lib/cortex/monitor /var/lib/cortex/registry /var/lib/cortex/worktree
+#   期望：/var/lib/cortex → root:root 0755
+#         control/coordinator/specs/monitor/registry → cortex-svc:cortex-svc 0700
+#         worktree → cortex-svc:cortex-svc 0701（others 只 traverse，不可列目錄）
+
+# ✅ 驗證：全樹沒有任何 group/other 可寫的路徑（spec §R2 硬性要求）
+sudo find /var/lib/cortex /opt/cortex -perm /022 -print | tee /tmp/p2b-world-writable.txt
+#   期望：空輸出
+
+# ✅ 驗證：ACL 已就位（跨帳號讀取一律唯讀）
+sudo getfacl -p /var/lib/cortex/monitor/event-spool 2>/dev/null | grep -E "^user:"
+#   期望：user:cortex-builder:-wx（producer 只能 append，不可讀他人）
+
+# ✅ 驗證：HOME 與 ~/.codex 由 root 擁有（帳號不得替換自己的設定）
+ls -ld /var/lib/cortex-builder /var/lib/cortex-builder/.codex /var/lib/cortex-builder/cache
+#   期望：前兩者 root:root 0755；cache 為 cortex-builder:cortex-builder 0700
+```
+
+**回滾**：`sudo rm -rf /var/lib/cortex /var/lib/cortex-svc /var/lib/cortex-builder /opt/cortex`
+（此時新樹仍空，舊樹完全未動）。
 
 ---
 
-## 第 3 步：路徑分樹 + legacy-import（**不 chown 舊 state**）
+## 第 3 步：legacy-import（物理隔離 ＋ hash manifest；**不 chown 沿用**）
 
-裁決：舊 state **不**沿用（不 `chown` 現存 `~/.agents`），而是**建新樹→驗證→把舊
-state 標記為 `legacy-imported` 重新入帳**（spec §R6(e)）。`legacy-imported` 標記
-**不可**滿足任何 ship gate。
-
-### 3a. 建新樹骨架（Manager-owned 與 job-visible 兩棵）
+裁決 3：舊 state **不**併入新樹、**不** `chown` 沿用，而是整包搬到 quarantine，
+留下內容 hash manifest。`legacy-imported` 來源 **MUST NOT** 滿足任何 ship gate。
 
 ```bash
-# 🔧 operator sudo：建樹根（root 擁有樹根——headless/svc 皆不可 relink 整棵信任根，spec §1）
-sudo install -d -o root -g root -m 0755 "$AGENTS_ROOT"
+# ✅ 1. 先確認 in-flight 已收尾（執行前提第 1 項；此處再確認一次，直接讀舊 jobs.json）
+python3 - <<'PY'
+import json, os, pathlib
+p = pathlib.Path(os.path.expanduser("~/.agents/coordinator/jobs.json"))
+if not p.exists():
+    print("no jobs.json — nothing in flight")
+else:
+    blob = json.loads(p.read_text(encoding="utf-8") or "{}")
+    rows = blob.get("jobs") or blob.get("records") or []
+    live = [r for r in rows if str(r.get("status", "")).lower() in {"running", "dispatched", "launched"}]
+    print(f"in-flight = {len(live)}")
+    for r in live:
+        print("  ", r.get("job_id"), r.get("status"))
+PY
+#   期望：in-flight = 0
 
-# 🔧 operator sudo：Manager-owned 子樹（cortex-svc 擁有、0700）
-for d in "$CONTROL_ROOT" "$COORDINATOR_ROOT" "$SPECS_ROOT" "$REGISTRY_ROOT" \
-         "$MONITOR_STATE_ROOT" "$RUN_ROOT"; do
-  sudo install -d -o cortex-svc -g cortex-svc -m 0700 "$d"
-done
+# ✅ 2. 內容 hash manifest（import attestation 的實體，spec §R6(e)）
+STAMP="$(date +%Y%m%d-%H%M)"
+( cd "$HOME/.agents" && find . -type f -print0 | sort -z | xargs -0 sha256sum ) \
+  > "/tmp/legacy-import-manifest-$STAMP.txt"
+wc -l "/tmp/legacy-import-manifest-$STAMP.txt"
+sha256sum "/tmp/legacy-import-manifest-$STAMP.txt"
+#   ↑ 把這個 manifest 自身的 hash 記在 #584，作為 import 的錨點
+
+# 🔧 sudo：建 quarantine 並整包搬入（唯讀、cortex-svc 擁有，不併入新樹）
+sudo install -d -o cortex-svc -g cortex-svc -m 0700 /var/lib/cortex/legacy-imported
+sudo cp -a "$HOME/.agents/." /var/lib/cortex/legacy-imported/
+sudo cp "/tmp/legacy-import-manifest-$STAMP.txt" \
+        /var/lib/cortex/legacy-imported/.legacy-import-manifest.txt
+sudo chown -R cortex-svc:cortex-svc /var/lib/cortex/legacy-imported
+sudo chmod -R a-w /var/lib/cortex/legacy-imported
 ```
-
-> 上列 owner/mode **來自權限產生器**，勿手寫。逐項對照：
-> `python3 -m paulsha_cortex.trust_root permissions two-way --commands`
-> 的 `manager-state` 區塊（如 `control-root-tree`／`coordinator-root-tree`）。
-> 產生器對有跨帳號 reader 的容器（如 `control-root-tree` 有 operator 讀 done/status）
-> 會多出 `setfacl -m u:operator:rX`——照抄。
-
-### 3b. job-visible 樹（worktree pool：per-job 逐案 chown，容器 0701）
 
 ```bash
-# ⚠️ 未決 2（同上）：worktree pool 目標位置
-export WORKTREE_ROOT="/var/lib/cortex/worktrees"     # ⚠️ 待定
-
-# 🔧 operator sudo：容器由 cortex-svc 擁有、0701；per-job 子目錄由第 5 步啟動器逐案 chown
-sudo install -d -o cortex-svc -g cortex-svc -m 0701 "$WORKTREE_ROOT"
+# ✅ 驗證：quarantine 唯讀、內容與 manifest 相符、新樹仍是空的
+sudo find /var/lib/cortex/legacy-imported -perm /222 -print | head
+#   期望：空輸出（整棵唯讀）
+( cd /var/lib/cortex/legacy-imported && sudo sha256sum -c .legacy-import-manifest.txt ) \
+  2>&1 | grep -c ": OK$"
+#   期望：與 manifest 行數相同
+ls -A /var/lib/cortex/coordinator /var/lib/cortex/control
+#   期望：空（或只有第 2 步建的空子目錄）——舊 jobs.json／evidence **沒有**被併進來
 ```
 
-> `dispatch-worktree-pool` 是 `runtime_managed` 資產——容器層只給 owner 寫，
-> **reviewer 與 builder 的 worktree 是各自被 chown 的子目錄**（R2 在子目錄粒度強制）。
-> `monitor-event-spool` 亦特殊：cortex-svc 擁有、以 `setfacl -m u:cortex-builder:wx`
-> 讓 builder 只能 append，consumer(svc) 讀＋消費。照抄產生器輸出。
+> **重要**：新樹是**乾淨的**。切換後產生的 record 一律走正常 gate；
+> `legacy-imported/` 只是唯讀歷史副本，任何從中還原的內容**不得**被 ship gate 採計。
+> 正式的 `trust: legacy-imported` 簽章標記屬 **Phase 3**，本階段以「物理隔離＋hash
+> manifest」達成同等的不可竄改性主張（裁決 3）。
 
-### 3b-2. review verdict spool（Phase 2a 已就位的受控通道）
+### 3b. review verdict spool（Phase 2a 已就位的受控通道）
 
-Phase 2a 已把 review verdict 的落點從 reviewer worktree 搬到
-`<coordinator_root>/review-verdicts/<reviewer_job_id>/verdict.json`（登記表
-`review-verdict-spool`，spec §R2 ＋未決 10-6 的 per-job spool 案）。**程式碼側
-已完成**：per-job 目錄由 Manager 在 dispatch 當下以 `0700` 建立、帶 pre-seed
-守衛，落地後轉 `0444`；reviewer 身分由 Manager job registry 推導，verdict payload
-的自述綁定欄位一律忽略。
+Phase 2a（PR #599）已把 review verdict 的落點從 reviewer worktree 搬到
+`/var/lib/cortex/coordinator/review-verdicts/<reviewer_job_id>/verdict.json`
+（登記表 `review-verdict-spool`，spec §R2）。**程式碼側已完成**：per-job 目錄由
+Manager 在 dispatch 當下以 `0700` 建立、帶 pre-seed 守衛，落地後轉 `0444`；reviewer
+身分由 Manager job registry 推導，verdict payload 的自述綁定欄位一律忽略。
+
+spool 根的權限**已包含在第 2 步的權限 script 內**（它是登記表資產），這裡只做確認：
 
 ```bash
-# 🔧 operator sudo：spool 根由 cortex-svc（Manager）擁有；builder 完全無權限
-sudo install -d -o cortex-svc -g cortex-svc -m 0700 "$COORDINATOR_ROOT/review-verdicts"
+# ✅ 驗證：spool 根由 cortex-svc 擁有、0700；builder 完全無權限
+ls -ld /var/lib/cortex/coordinator/review-verdicts
+sudo getfacl -p /var/lib/cortex/coordinator/review-verdicts | grep -E "^user:" || echo "(二分方案無跨帳號 ACL：reviewer 與 Manager 併帳，owner 位已涵蓋)"
 
-# 三分方案才需要：reviewer 帳號以 **write-only** ACL 進入（寫得進自己那格、讀不到他人）
-# sudo setfacl -m u:cortex-reviewer-planner:wx "$COORDINATOR_ROOT/review-verdicts"
-# sudo setfacl -d -m u:cortex-reviewer-planner:wx "$COORDINATOR_ROOT/review-verdicts"
+# ✅ 驗證：產生器對本資產的計畫（三分方案才會出現 reviewer 的 write-only ACL）
+python3 -m paulsha_cortex.trust_root permissions three-way --commands --paths \
+  | grep -A6 "review-verdict-spool"
+#   期望（三分）：setfacl -m u:cortex-reviewer-planner:wx …
+#   **wx 無 r**——寫得進自己那格、讀不到他人 verdict。builder 兩案下都零權限。
 ```
 
-> 二分方案下 reviewer 與 Manager 併帳（`cortex-svc`），owner 位已涵蓋寫入權，
-> 產生器不會輸出多餘 ACL。**builder（`cortex-builder`）在兩個方案下都拿不到任何
-> 權限**——這一步完成後，spec 背景 §3 的「builder 代寫 verdict」最短攻擊路徑才
-> 從「結構上不可能被採信」升級為「OS 層寫不進去」。
+> 這一步完成後，spec 背景 §3 的「builder 代寫 verdict」最短攻擊路徑才從「結構上
+> 不可能被採信」升級為「**OS 層寫不進去**」。
 >
-> 另：Phase 2a 的降權啟動器需把該 job 的 spool 目錄放進 executor sandbox 的放行
-> 清單（`--add-dir`，見 `SubprocessLauncher.as_verdict_spool_writer()`）——只放行
-> **那一格**，不是整棵 coordinator 樹。
+> 另：降權啟動器需把該 job 的 spool 目錄放進 executor sandbox 的放行清單
+> （`--add-dir`，見 `SubprocessLauncher.as_verdict_spool_writer()`）——只放行**那一格**，
+> 不是整棵 coordinator 樹。
 
-### 3c. legacy-import 重新入帳（**不滿足 ship gate**）
-
-```bash
-# ✅ 驗證：把舊 state 的內容 hash 記下（import attestation 的內容，spec §R6(e)）
-OLD="$HOME/.agents"
-find "$OLD" -type f -print0 2>/dev/null | \
-  xargs -0 sha256sum 2>/dev/null | tee "/tmp/legacy-import-manifest-$(date +%Y%m%d).txt"
-
-# 🔧 operator sudo：把舊樹整包搬到 quarantine（唯讀、cortex-svc 擁有），不併入新樹
-sudo install -d -o cortex-svc -g cortex-svc -m 0700 "$AGENTS_ROOT/legacy-imported"
-sudo cp -a "$OLD/." "$AGENTS_ROOT/legacy-imported/" 2>/dev/null || true
-sudo chown -R cortex-svc:cortex-svc "$AGENTS_ROOT/legacy-imported"
-sudo chmod -R a-w "$AGENTS_ROOT/legacy-imported"     # 唯讀，僅供查詢
-```
-
-> **關鍵**：新樹（3a/3b）是**空的、乾淨的**；舊 state 只進 `legacy-imported/`
-> quarantine，標記為不可信、唯讀、僅供歷史查詢。**不**把舊 `jobs.json`／evidence
-> 併入新 `COORDINATOR_ROOT`。任何切換後產生、無正常來源的 record 走正常 gate；
-> 帶 `legacy-imported` 來源者 **MUST NOT** 被 ship gate 採計。
-
-> **⚠️ 未決 3**：`legacy-imported` attestation 的實體格式（Phase 3 R6(e) 的
-> `trust: legacy-imported` 標記由簽章方案落地）。Phase 2b 先做「物理隔離＋內容
-> hash manifest」；正式 attestation 待 Phase 3。operator 需確認：切換期間是否需要
-> 把任何 in-flight 的 job 手動收尾（見第 8 步回滾對照）。
-
-### 3d. 移除舊 775 的 g+w
+### 3c. 收斂舊路徑殘留的 `g+w`
 
 ```bash
-# 🔧 operator sudo：收斂現有 g+w（~/.agents 與 config/paulsha 實測 775）
-#   注意：新樹已在 3a 以正確 mode 建立；此步是清理**舊路徑殘留**，避免仍被引用。
+# 🔧 sudo：舊樹的 775 殘留（避免仍被任何殘留設定引用時再度成為寫入面）
 chmod -R g-w,o-w "$HOME/.agents" 2>/dev/null || true
 
-# ✅ 驗證：新樹 mode 與產生器一致、舊路徑不再 g+w
-sudo ls -ld "$CONTROL_ROOT" "$COORDINATOR_ROOT" "$WORKTREE_ROOT"
+# ✅ 驗證
+find "$HOME/.agents" -perm /022 -print | head
+#   期望：空輸出
 ```
 
-**執行後驗證（整步）**：以 `cortex-builder` 身分試寫 Manager-owned 樹須 `EACCES`
-（見第 7 步 R9 族 2）。
+**回滾**：`sudo rm -rf /var/lib/cortex/legacy-imported`；舊 `$HOME/.agents` 未被刪除，
+原地仍可用（第 9 步全面回退即用它）。
 
 ---
 
-## 第 4 步：Manager 遷 root-owned 部署 + system-level unit
+## 第 4 步：Manager 遷 root-owned 部署 ＋ system-level unit
 
-### 4a. pipx tree 遷出 operator HOME
+### 4a. venv 遷入 `/opt/cortex`
 
 ```bash
-# ⚠️ 未決 4：Manager 部署路徑的確切位置待 operator 定。
-#   候選：/opt/cortex/venv（root 擁有、唯讀 for svc）。以下為示例。
-export DEPLOY_ROOT="/opt/cortex"                     # ⚠️ 待定
+# 🔧 sudo：複製（不是原地 chown）到 root-owned 部署路徑
+sudo rm -rf /opt/cortex/venv.new
+sudo cp -a "$HOME/.local/share/pipx/venvs/paulsha-cortex" /opt/cortex/venv.new
+sudo chown -R root:root /opt/cortex/venv.new
+sudo find /opt/cortex/venv.new -type d -exec chmod 0755 {} +
+sudo find /opt/cortex/venv.new -type f -exec chmod a-w {} +
+sudo find /opt/cortex/venv.new/bin -type f -exec chmod 0755 {} +
 
-# 🔧 operator sudo：把現有 pipx venv 複製到 root-owned 部署路徑（不是原地 chown）
-sudo install -d -o root -g root -m 0755 "$DEPLOY_ROOT"
-sudo cp -a "$HOME/.local/share/pipx/venvs/paulsha-cortex" "$DEPLOY_ROOT/venv"
-sudo chown -R root:root "$DEPLOY_ROOT/venv"
-sudo find "$DEPLOY_ROOT/venv" -type d -exec chmod 0755 {} +
-sudo find "$DEPLOY_ROOT/venv" -type f -exec chmod a-w {} +   # site-packages 對 svc/headless 唯讀
+# 🔧 sudo：切成 active（venv 目錄本身即 ExecStart 的目標；保留舊的供回滾）
+sudo rm -rf /opt/cortex/venv.prev
+[ -d /opt/cortex/venv ] && sudo mv /opt/cortex/venv /opt/cortex/venv.prev
+sudo mv /opt/cortex/venv.new /opt/cortex/venv
 ```
 
-> spec §R3：executable／deps／launcher／venv 對 headless **不可寫**，owner=root。
+```bash
+# ✅ 驗證：對服務帳號唯讀、可執行、版本正確
+sudo -u cortex-svc /opt/cortex/venv/bin/cortex --version
+sudo -u cortex-svc test -w /opt/cortex/venv/bin/cortex && echo "!! 可寫，停止" || echo "read-only: OK"
+sudo find /opt/cortex/venv -perm /022 -print | head
+#   期望：空輸出
+# ✅ 沒有可注入點
+sudo find /opt/cortex/venv -name "sitecustomize.py" -o -name "*.pth" | xargs -r ls -l
+#   期望：若有，全部 root:root 且不可寫
+```
+
+> spec §R3：executable／deps／launcher／venv 對 headless **不可寫**、owner=root。
 > 這封掉背景 §5 的「改寫 verifier／注入 `sitecustomize.py`／`.pth`」攻擊面。
 
-### 4b. bootstrap env 遷入受保護樹（fail-closed）
+### 4b. bootstrap env 遷入部署樹（root 擁有、fail-closed）
+
+env 檔放在 **`/opt/cortex/etc/`**（全 root-owned 樹）而**不是** `/var/lib/cortex` 底下：
+`/var/lib/cortex` 的子樹由 `cortex-svc` 擁有，**目錄可寫者能 unlink／replace 其中的
+root-owned 檔案**——把 env 檔放進去等於沒保護。
 
 ```bash
-# 🔧 operator sudo：env 檔 root 擁有、0644（全部行程唯讀，spec §R3「全部行程唯讀」）
-export ENV_DIR="$AGENTS_ROOT/core/runtime"
-sudo install -d -o root -g root -m 0755 "$ENV_DIR"
-# 依 permgen 的 deployment 區塊（runtime-bootstrap-env）產生 owner/mode：
-#   chown root:root <PATH:runtime-bootstrap-env>; chmod 0644 ...
+# 🔧 sudo：寫 EnvironmentFile（instance-scoped，修掉背景 §7 的多 instance 共用漏洞）
+sudo tee /opt/cortex/etc/cortex-manager.env >/dev/null <<'ENVFILE'
+PSC_INSTANCE=cortex
+PSC_AGENTS_ROOT=/var/lib/cortex
+PSC_CONTROL_ROOT=/var/lib/cortex/control
+PSC_COORDINATOR_ROOT=/var/lib/cortex/coordinator
+PSC_SPECS_ROOT=/var/lib/cortex/specs
+PSC_MONITOR_STATE_ROOT=/var/lib/cortex/monitor
+PSC_PROJECT_CONFIG_ROOT=/var/lib/cortex/config/paulsha
+PSC_RUN_ROOT=/var/lib/cortex/run/cortex
+PSC_WORKTREE_ROOT=/var/lib/cortex/worktree
+PSC_DEGRADED_OPERATION=per-case-approval
+ENVFILE
+sudo chown root:root /opt/cortex/etc/cortex-manager.env
+sudo chmod 0644 /opt/cortex/etc/cortex-manager.env
 ```
 
-> env 檔內容須含 instance-scoped 的 `PSC_AGENTS_ROOT`／`PSC_CONTROL_ROOT`／
-> `PSC_COORDINATOR_ROOT`／`PSC_SPECS_ROOT`／`PSC_MONITOR_STATE_ROOT`，全部指向第 2 步
-> 的目標路徑（修掉背景 §7 漏洞）。
+```bash
+# ✅ 驗證：owner/mode 與 permgen 的 deployment 區塊一致
+python3 -m paulsha_cortex.trust_root permissions two-way --commands --paths \
+  | grep -A3 "runtime-bootstrap-env"
+ls -l /opt/cortex/etc/cortex-manager.env
+#   期望：-rw-r--r-- root root
 
-### 4c. system-level unit（以 cortex-svc 跑、加固指令切實列出）
+# ✅ 驗證：env 生效後路徑解析全部落在受保護樹內
+sudo -u cortex-svc env $(grep -v '^#' /opt/cortex/etc/cortex-manager.env | xargs) \
+  /opt/cortex/venv/bin/python -c \
+  "from paulsha_cortex.config import paths; print(paths.agents_root(), paths.control_root(), paths.coordinator_root())"
+#   期望：三者都在 /var/lib/cortex 底下
+```
+
+> **為何 unit 的 `EnvironmentFile` 一定生效**：`config/runtime.py` 的
+> `resolve_runtime_root()` **先看行程 env**，其次才看 `$HOME/.agents/core/runtime/`
+> 的 bootstrap 檔。unit 注入的 `PSC_*` 因此優先，且 `ProtectHome=yes` 讓 HOME fallback
+> 根本不可見——雙保險。
+
+### 4c. Manager system-level unit（內容由 permgen 產生）
 
 ```bash
-# ⚠️ 未決 5：unit 最終形態（含 ReadWritePaths 的精確清單）待 operator 定稿後寫入。
-# 🔧 operator sudo：寫 /etc/systemd/system/cortex-manager.service（示例骨架）
-sudo tee /etc/systemd/system/cortex-manager.service >/dev/null <<'UNIT'
-[Unit]
-Description=cortex Manager (trust-root Phase 2, system-level)
-After=network.target
+# ✅ 先看內容（ReadWritePaths 逐條附「涵蓋哪些登記表資產」註解）
+python3 -m paulsha_cortex.trust_root unit two-way --manager | less
 
-[Service]
-Type=simple
-User=cortex-svc
-Group=cortex-svc
+# 🔧 sudo：寫入 unit（內容一字不改，直接由產生器落檔）
+python3 -m paulsha_cortex.trust_root unit two-way --manager \
+  | sudo tee /etc/systemd/system/cortex-manager.service >/dev/null
+sudo chown root:root /etc/systemd/system/cortex-manager.service
+sudo chmod 0644 /etc/systemd/system/cortex-manager.service
 
-# --- fail-closed env（移除 EnvironmentFile 的 '-'，缺檔即拒絕啟動，spec §R3）---
-EnvironmentFile=/var/lib/cortex/agents/core/runtime/cortex-manager.env
-
-ExecStart=/opt/cortex/venv/bin/cortex service run
-WorkingDirectory=/var/lib/cortex
-
-# --- systemd 加固（spec §R3；現況三個 unit 一項都沒有）---
-NoNewPrivileges=yes
-ProtectSystem=strict
-ProtectHome=yes
-PrivateTmp=yes
-ProtectControlGroups=yes
-ProtectKernelModules=yes
-ProtectKernelTunables=yes
-ProtectClock=yes
-RestrictSUIDSGID=yes
-RestrictRealtime=yes
-LockPersonality=yes
-MemoryDenyWriteExecute=yes
-SystemCallFilter=@system-service
-SystemCallErrorNumber=EPERM
-CapabilityBoundingSet=
-# durable state 樹是唯一可寫路徑白名單（由 R1 登記表產生，勿手擴）：
-ReadWritePaths=/var/lib/cortex/agents /var/lib/cortex/worktrees
-
-[Install]
-WantedBy=multi-user.target
-UNIT
-
-# 🔧 operator sudo：載入與啟用（system-level，非 --user）
+# 🔧 sudo：載入並啟用（system-level，非 --user）
 sudo systemctl daemon-reload
-sudo systemctl enable --now cortex-manager.service
+sudo systemctl enable cortex-manager.service
+sudo systemctl start cortex-manager.service
 ```
-
-> **`EnvironmentFile` 無 `-` 前綴**＝缺檔 fail-closed（spec §R3 Scenario「刪除
-> EnvironmentFile」）。`CapabilityBoundingSet=`（空）＝丟掉所有 capability，且因為
-> 未決 1 已裁決走 `systemd-run`（由 PID 1 代為切換身分，Manager 自己不需要任何
-> capability），**這裡維持空集合，不加 `AmbientCapabilities=`**——落選的 CAP_SETUID
-> 方案才需要放寬，那正是它被否決的理由。
 
 ```bash
-# ✅ 驗證：unit 以 cortex-svc 跑、加固生效
-systemctl show cortex-manager.service -p User -p NoNewPrivileges -p ProtectSystem -p ReadWritePaths
-systemctl status cortex-manager.service
-sudo journalctl -u cortex-manager.service -n 50 --no-pager
+# ✅ 驗證：身分、加固、ReadWritePaths 都如產生器所述
+systemctl show cortex-manager.service \
+  -p User -p NoNewPrivileges -p ProtectSystem -p ProtectHome -p PrivateTmp \
+  -p CapabilityBoundingSet -p ReadWritePaths
+#   期望：User=cortex-svc、NoNewPrivileges=yes、ProtectSystem=strict、
+#         ProtectHome=yes、PrivateTmp=yes、CapabilityBoundingSet=（空）
+
+# ✅ 驗證：unit 檔內容與產生器輸出逐位元相同（防手改漂移）
+diff <(python3 -m paulsha_cortex.trust_root unit two-way --manager) \
+     /etc/systemd/system/cortex-manager.service && echo "unit in sync: OK"
+
+# ✅ 驗證：加固評分（systemd 自己的評估，僅供對照）
+systemd-analyze security cortex-manager.service | tail -5
+
+# ✅ 驗證：服務起得來、無 EPERM/EROFS
+systemctl status cortex-manager.service --no-pager
+sudo journalctl -u cortex-manager.service -n 100 --no-pager | grep -Ei "eperm|erofs|eacces|read-only" || echo "no denial in log: OK"
+
+# ✅ 驗證：fail-closed——刪掉 env 檔必須拒絕啟動（測完立刻還原）
+sudo mv /opt/cortex/etc/cortex-manager.env /opt/cortex/etc/cortex-manager.env.bak
+sudo systemctl restart cortex-manager.service; echo "exit=$?"
+#   期望：restart 失敗（非 0），status 顯示 EnvironmentFile 缺檔
+sudo mv /opt/cortex/etc/cortex-manager.env.bak /opt/cortex/etc/cortex-manager.env
+sudo systemctl restart cortex-manager.service && echo "restored: OK"
 ```
 
-> **WSL2 注意**：system-level unit 在 WSL2 需 `systemd=true`（`/etc/wsl.conf`）且已
-> `is-system-running: running`（第 0 步已驗）。system unit **不需** lingering
-> （lingering 只對 `--user` unit 有意義）。若 WSL 重啟後 systemd 未起，見第 8 步回滾。
+**回滾**：`sudo systemctl disable --now cortex-manager.service;
+sudo rm /etc/systemd/system/cortex-manager.service; sudo systemctl daemon-reload`，
+再以 `systemctl --user start cortex-manager.service` 回到舊部署（見第 9 步）。
 
 ---
 
-## 第 5 步：降權啟動器啟用（Manager → cortex-builder，關 FD、不傳 token）
+## 第 5 步：降權啟用（`cortex-svc` → `cortex-builder`，關 FD、不傳 token）
 
-Manager（cortex-svc）spawn headless job 時降到 `cortex-builder`，且：
-- **關閉 FD 傳遞**（`close_fds`，不繼承任何指向受保護資產的 fd——spec §R9 T4.1）；
-- **不傳 gh token**（scrub `GH_TOKEN`／`GITHUB_TOKEN`；GitHub 寫入改由 Manager 代理，
-  沿用 D1 outbox）；
-- 只暴露該 job 自己被 chown 的 worktree 子目錄。
+> **⏸ 本步有兩個方案，正等 operator 拍板**——這是全 runbook 唯一還需要決定的地方。
+> 兩案都寫成完整可執行；**選了哪一個就只跑那一節**，其餘步驟（1–4、6–9）兩案共用。
+> 同時要一併裁決的是「**是否提前三分**」（見下方風險比較）。
 
-> **✅ 未決 1 已裁決（operator 0816 第二輪）**：降權機制＝**`systemd-run` transient
-> unit**（方案 A）。落選案留檔備查：B（最小 setuid 助手）引入 setuid 二進位＝新攻擊面；
-> C（Manager 授 `CAP_SETUID`）可切到**任意** uid，等於放大 Manager 權限。
->
-> 程式碼面已落地（Phase 2a，`paulsha_cortex/coordinator/job_runner.py`）：
-> `PSC_JOB_RUNNER` 預設 `direct`（現行行為不變），設為 `systemd-run` 才降權。
-> **本步驟即「把那個開關打開」的部署動作**，前提是本 runbook 第 1 步的帳號已建立、
-> 以及下面的 polkit 規則已就位。
+### 5-0. 共同前提：polkit 到底能收窄什麼（先讀完再選）
 
-### 5a. Manager 端會實際發出的 argv（polkit 規則要收窄的那個面）
+**實測事實**（#603 驗證）：polkit 的 `org.freedesktop.systemd1.manage-units` action
+**只暴露 unit 名稱與 verb**，**不暴露 `User=`／`--uid=`**。授權之後，systemd 會照請求
+的**任意** `User=` 起 unit。因此：
 
-`job_runner.build_systemd_run_argv()` 產出的形狀是**封閉**的（新增旗標要改程式碼並過
-測試），因此 polkit 規則可以據此收窄：
+| polkit **能**強制 | polkit **不能**強制 |
+|---|---|
+| 呼叫者是哪個 UID（`subject.user`） | job 降到哪個帳號（`User=`／`--uid=`） |
+| unit 名前綴／pattern（`action.lookup("unit")`） | 任何 unit 屬性（`AmbientCapabilities=`、`ExecStart=`…） |
+| verb（只放行 `start`／`stop`） | — |
+
+「只能降到 `cortex-builder`」這一半必須另外找地方強制——這就是 A／B 兩案的分野。
+兩案共用的 polkit 骨架（subject 檢查、action 檢查、**明細缺席即拒**、verb 白名單、
+unit pattern）由同一個產生器產出，只有 pattern 與說明段不同。
+
+```bash
+# ✅ 兩案的規則內容各印一份，並排比較後再選
+python3 -m paulsha_cortex.trust_root polkit two-way --transient | tee /tmp/polkit-A.rules
+python3 -m paulsha_cortex.trust_root polkit two-way --template  | tee /tmp/polkit-B.rules
+diff /tmp/polkit-A.rules /tmp/polkit-B.rules
+```
+
+#### 兩案比較（含「是否提前三分」的關聯）
+
+| | **方案 A：`systemd-run` transient unit** | **方案 B：root-owned 模板 unit** |
+|---|---|---|
+| 裁決對應 | 0816 裁決的**字面**方案 | 同一意圖的 OS 強制版 |
+| 程式碼狀態 | **已落地**（#603 `coordinator/job_runner.py`，`PSC_JOB_RUNNER=systemd-run`） | 需 Manager 端改以 `systemctl start cortex-job@<id>` 起 job——**尚待程式碼工項** |
+| 「降到哪個帳號」由誰強制 | Manager 端**封閉的 argv 產生器**（code level，`--uid` 受 POSIX 帳號名 pattern 檢查） | **OS**：`User=` 硬寫死在 root-owned 的 `/etc/systemd/system/cortex-job@.service` |
+| 特權屬性（`AmbientCapabilities=` 等） | 呼叫端**可以**傳（polkit 看不到），靠 argv 產生器不傳 | 呼叫端**連提都提不了**（屬性只存在於 root-owned 檔內） |
+| **殘餘風險** | 與 `cortex-svc` **同 UID 的任何行程**都持有這個 grant，可請求任意 `User=`（含 `User=root`）的 transient unit。**二分方案下 reviewer／planner 跑模型且與 Manager 併帳**——其中任一被攻陷即取得該能力 | 無（OS 層封閉） |
+| 與「提前三分」的關係 | **強相關**：改三分後 reviewer／planner 移出 `cortex-svc`，A 的殘餘風險縮回「只有 Manager 自己」 | 不相關（B 本來就不靠 UID 隔離來守這一半） |
+| 立即可執行 | ✅ | ⚠️ 規則與模板 unit 可先裝，但 Manager 端要等程式碼 |
+
+**建議判讀**（不代替裁決）：若要**現在**打開降權 → 選 A，並**同時**決定是否提前三分
+（三分把 A 的殘餘風險從「三個模型 persona」縮到「Manager 自己」）。若可以等一個程式碼
+工項 → B 是唯一能把整個分界線放進 OS 的做法。
+
+```bash
+# ✅ 三分方案的權限／unit／polkit 也已可產生（決定提前三分時把 two-way 換成 three-way）
+python3 -m paulsha_cortex.trust_root permissions three-way --commands --paths | head -20
+python3 -m paulsha_cortex.trust_root polkit three-way --transient | sed -n '/未強制/,/^\/\/$/p'
+#   期望：三分下的殘餘風險清單**不再**包含 reviewer／planner 併帳那一條
+```
+
+---
+
+### 5-A. 方案 A：`systemd-run` transient unit（0816 裁決的字面方案）
+
+#### 5-A-1. Manager 端會實際發出的 argv（polkit 要收窄的那個面）
+
+`job_runner.build_systemd_run_argv()` 的形狀是**封閉**的（新增旗標要改程式碼並過測試）：
 
 ```text
 systemd-run --quiet --collect --pipe --wait \
@@ -420,18 +585,14 @@ systemd-run --quiet --collect --pipe --wait \
   -- bash -c '<job wrapper script>'
 ```
 
-- unit 名前綴固定為 `cortex-job-`（`job_runner.UNIT_NAME_PREFIX`，polkit 以
-  `action.lookup("unit")` 比對的就是它）；接上 job_id 的 sha256 前 8 碼確保消毒後仍唯一。
+- unit 名前綴固定 `cortex-job-`（`job_runner.UNIT_NAME_PREFIX`）——**與 polkit 規則是
+  成對契約**，改任一邊都要同步改另一邊，否則所有 job 被拒（fail-closed，不會退回同 UID）。
 - `--wait` 讓 client 與 unit 同壽命，Manager 既有的 `pid_alive()` 判活不必改。
-- `--quiet` 是必要的：`systemd-run` 的狀態訊息會被 `--pipe` 導進 job 的 JSONL log，
-  那份 log 是 terminal evidence 的來源。
-- FD：只有 stdin/stdout/stderr 三個（Python `close_fds=True`），且 **stdin 顯式接
-  `/dev/null`**；stdout/stderr 是 Manager 開的 job log。
-- **env 不是 scrub 黑名單，而是白名單**：transient unit 不繼承呼叫端的 environ，
-  job 只看得到 `--setenv` 列出的那幾項（`PATH`／`LANG`／`LC_ALL`／`LC_CTYPE`／
-  `SSL_CERT_FILE`／`SSL_CERT_DIR`／`NODE_EXTRA_CA_CERTS` ＋ `PSC_JOB_ID`／
-  `PSC_SLICE_ID`／`PSC_REPO_ROOT`／選配的 `PSC_RELAY_TARGET`／`HOME`）。
-  gh token、daemon 的 `CLAUDE_CONFIG_DIR`／`GH_CONFIG_DIR` 都**不在**白名單上。
+- `--quiet` 必要：`systemd-run` 的狀態訊息會被 `--pipe` 導進 job 的 JSONL log，而那份
+  log 是 terminal evidence 的來源。
+- FD 只有 stdin/stdout/stderr（`close_fds=True`），stdin 顯式接 `/dev/null`。
+- **env 是白名單不是黑名單 scrub**：transient unit 不繼承呼叫端 environ，job 只看得到
+  `--setenv` 列出的那幾項；gh token、`CLAUDE_CONFIG_DIR`／`GH_CONFIG_DIR` 都**不在**上面。
 
 ```bash
 # ✅ 驗證（不需 root）：印出本機會發出的白名單與旗標，與上表逐項對照
@@ -443,198 +604,657 @@ print("synthesized:", job_runner.BUILDER_SYNTHESIZED_ENV)
 print("unit prefix:", job_runner.UNIT_NAME_PREFIX)
 print("properties :", job_runner.TRANSIENT_UNIT_PROPERTIES)
 PY
+
+# ✅ 契約對齊：polkit 規則的 pattern 前綴必須等於 job_runner 的常數
+python3 - <<'PY'
+from paulsha_cortex.coordinator import job_runner
+from paulsha_cortex.trust_root import permgen
+prefix = permgen.transient_unit_prefix(permgen.DEFAULT_LAYOUT)
+assert prefix == job_runner.UNIT_NAME_PREFIX, (prefix, job_runner.UNIT_NAME_PREFIX)
+print("unit prefix contract OK:", prefix)
+PY
 ```
 
-### 5b. polkit 規則（收窄到「只能以 cortex-builder 身分、限定 unit 名」）
+#### 5-A-2. 安裝 polkit 規則
 
 ```bash
-# 🔧 operator sudo：/etc/polkit-1/rules.d/49-cortex-spawn.rules
-sudo tee /etc/polkit-1/rules.d/49-cortex-spawn.rules >/dev/null <<'RULES'
-// 僅允許 cortex-svc 起「cortex-job-」前綴的 transient unit（最小授權）。
-// 注意：unit 名是 Manager 端產生的（job_runner.UNIT_NAME_PREFIX），這條規則與
-// 那個常數是成對契約——改任一邊都必須同步改另一邊。
-polkit.addRule(function(action, subject) {
-  if (subject.user !== "cortex-svc") {
-    return polkit.Result.NOT_HANDLED;
-  }
-  if (action.id !== "org.freedesktop.systemd1.manage-units") {
-    return polkit.Result.NOT_HANDLED;
-  }
-  var unit = action.lookup("unit");
-  if (unit && unit.indexOf("cortex-job-") === 0 && unit.indexOf(".service", unit.length - 8) !== -1) {
-    return polkit.Result.YES;
-  }
-  return polkit.Result.NOT_HANDLED;
-});
-RULES
+# ✅ 先讀（規則檔開頭把殘餘風險逐條寫出來，勿跳過）
+less /tmp/polkit-A.rules
+
+# 🔧 sudo：落檔
+sudo install -o root -g root -m 0644 /tmp/polkit-A.rules \
+     /etc/polkit-1/rules.d/49-cortex-downgrade.rules
+sudo systemctl restart polkit.service 2>/dev/null || sudo systemctl restart polkitd.service
+
+# ✅ 驗證：載入無語法錯誤、與產生器逐位元相同
+sudo journalctl -u polkit -n 30 --no-pager | grep -Ei "error|syntax" || echo "polkit loaded clean: OK"
+diff <(python3 -m paulsha_cortex.trust_root polkit two-way --transient) \
+     /etc/polkit-1/rules.d/49-cortex-downgrade.rules && echo "polkit in sync: OK"
 ```
 
-> **⚠️ 殘餘限制（誠實標註）**：polkit 的 `manage-units` action 只暴露 unit **名稱**，
-> **不暴露 `User=`／`--uid=`**。因此「只能降到 cortex-builder」這一半在 polkit 層
-> 無法強制，只能由 Manager 端的封閉 argv 產生器保證（`--uid` 來自
-> `PSC_BUILDER_ACCOUNT`，值受 POSIX 帳號名 pattern 檢查、拒絕注入）。要在 OS 層
-> 也硬化這一半，需另設一支 root 擁有的 wrapper unit template 並只授權該 template
-> ——屬 Phase 3 的加固，不是 0.2.0 的 join gate。
-
-### 5c. 打開開關（Manager env）
+#### 5-A-3. 打開開關（Manager env）
 
 ```bash
-# 🔧 operator sudo：把降權模式寫進 Manager 的 EnvironmentFile（見第 4b 步）
-#   PSC_JOB_RUNNER=systemd-run        # 必要；預設 direct＝不降權
-#   PSC_BUILDER_ACCOUNT=cortex-builder # 選配（預設值即此）
-#   PSC_BUILDER_HOME=/var/lib/cortex-builder  # 選配；未設時 systemd 依 passwd 填
-#   PSC_BUILDER_PATH=...              # 選配；模型 CLI 不在 Manager PATH 上時用
-sudo systemctl restart cortex-manager
+# 🔧 sudo：把降權模式寫進第 4b 步的 EnvironmentFile
+sudo tee -a /opt/cortex/etc/cortex-manager.env >/dev/null <<'ENVFILE'
+PSC_JOB_RUNNER=systemd-run
+PSC_BUILDER_ACCOUNT=cortex-builder
+PSC_BUILDER_HOME=/var/lib/cortex-builder
+ENVFILE
+sudo systemctl restart cortex-manager.service
 ```
 
-builder 帳號必須自己具備模型 CLI 的登入態（`sudo -u cortex-builder claude /login` 之類），
-**Manager 不會把自己的憑證傳過去**——那正是本步驟的重點。
+> `PSC_JOB_RUNNER` 預設 `direct`＝不降權；值非法時**fail-closed**（不會靜默當成
+> `direct`）。`PSC_BUILDER_PATH` 選配——模型 CLI 不在 Manager `PATH` 上時才需要。
+> **builder 帳號必須自己有模型 CLI 的登入態**（`sudo -u cortex-builder claude /login`
+> 之類）；Manager 不會把自己的憑證傳過去，那正是本步驟的重點。
+
+#### 5-A-4. 驗證（正向必須成功）
 
 ```bash
-# ✅ 驗證 1：以 cortex-svc 起一個降到 cortex-builder 的 transient job，檢查身分/FD/token
+# ✅ 以 cortex-svc 起一個降到 cortex-builder 的 transient job
 sudo -u cortex-svc systemd-run --quiet --collect --pipe --wait \
   --unit=cortex-job-smoke-00000000.service \
   --uid=cortex-builder --gid=cortex-builder --service-type=exec \
   --property=NoNewPrivileges=yes \
   /bin/sh -c 'id; echo "GH_TOKEN=[$GH_TOKEN]"; ls -l /proc/self/fd'
-# 期望：uid=cortex-builder；GH_TOKEN 為空；/proc/self/fd 只有 0/1/2
+#   期望：uid=…(cortex-builder)；GH_TOKEN=[]；/proc/self/fd 只有 0/1/2
 ```
 
+#### 5-A-5. 驗證（反向必須被拒）
+
 ```bash
-# ✅ 驗證 2（負控制）：暫時移除 polkit 規則後，dispatch 必須 fail-closed 而非退回 direct
-#   期望：job 落 needs_human，理由碼 job-runner-transient-unit-start-failed，
-#   detail 帶 systemd-run 的實際拒絕訊息。**不得**出現以 cortex-svc 身分跑起來的 job。
+# ✅ (1) 不符前綴的 unit 名：必須被拒
+sudo -u cortex-svc systemd-run --quiet --unit=evil-0001.service --uid=cortex-builder \
+     --pipe --wait /bin/id; echo "exit=$?"          # 期望非 0
+
+# ✅ (2) 起既存 unit（含 Manager 自己）：必須被拒
+sudo -u cortex-svc systemctl restart cortex-manager.service; echo "exit=$?"   # 期望非 0
+sudo -u cortex-svc systemctl daemon-reload; echo "exit=$?"                    # 期望非 0
+
+# ✅ (3) 負控制：暫時移除 polkit 規則後，dispatch 必須 fail-closed 而非退回 direct
+sudo mv /etc/polkit-1/rules.d/49-cortex-downgrade.rules /tmp/polkit-A.disabled
+sudo systemctl restart polkit.service 2>/dev/null || sudo systemctl restart polkitd.service
+#   → 觸發一次 dispatch，期望：job 落 needs_human，理由碼
+#     job-runner-transient-unit-start-failed，detail 帶 systemd-run 的實際拒絕訊息。
+#     **不得**出現以 cortex-svc 身分跑起來的 job。
+sudo mv /tmp/polkit-A.disabled /etc/polkit-1/rules.d/49-cortex-downgrade.rules
+sudo systemctl restart polkit.service 2>/dev/null || sudo systemctl restart polkitd.service
+
+# ⚠️ (4) 已知**不會**被拒（這就是 A 的殘餘風險，實測確認它確實存在）
+sudo -u cortex-svc systemd-run --quiet --unit=cortex-job-probe-00000000.service \
+     --uid=0 --pipe --wait /bin/id; echo "exit=$?"
+#   期望：**成功並印出 uid=0(root)**。這不是設定錯誤，是 A 方案的本質限制：
+#   polkit 看不到 --uid。看到這個結果就代表你確實理解自己接受了什麼。
+#   選 B 方案時這條必須改為「期望非 0」。
+```
+
+#### 5-A-6. 建議的額外加固（與方案 B 同源，機械產生）
+
+`job_runner` 目前只送 `--property=NoNewPrivileges=yes`。同一套加固表與**由登記表導出
+的 `ReadWritePaths`** 可展開成 `--property=` 形式，作為 A 與 B 加固面是否等價的對照：
+
+```bash
+# ✅ 印出建議清單（%i 是模板 specifier；A 方案請由呼叫端代入該 job 的實際 worktree）
+python3 -m paulsha_cortex.trust_root unit two-way --job-properties
 ```
 
 ---
 
-## 第 6 步：Manager 升級流程（設定後升級需 root）
+### 5-B. 方案 B：root-owned 模板 unit（把整條分界線放進 OS）
 
-切換後，Manager 部署在 root-owned 樹（`/opt/cortex/venv`），升級**需 root**。設計一個
-**受控升級步驟**——驗證來源後**替換整棵 svc-owned/root-owned tree**，而非裸 `chown`。
+兩個 root-owned 檔一起構成邊界：
+
+1. **模板 unit** `/etc/systemd/system/cortex-job@.service`——`User=cortex-builder`
+   **硬寫死**；呼叫端只能給 instance 名，**選不了 UID、傳不了屬性**。
+2. **polkit 規則**——只放行 `cortex-svc` 對 `cortex-job@*.service` 的 `start`/`stop`，
+   **transient unit 一律拒**（明細缺席即拒）。
+
+> **前置條件**：Manager 端目前走 `systemd-run`（#603）。要真的用 B，需要一個程式碼
+> 工項把 spawn 改成「寫 `run.sh` 進 job spool → `systemctl start cortex-job@<id>.service`」。
+> **在那之前，B 的規則與模板 unit 仍可先裝並用下面的手動驗證證明邊界成立**，只是
+> Manager 還不會走它。
+
+#### 5-B-1. 安裝模板 unit
 
 ```bash
-# ✅ 驗證：先在 operator HOME 的 pipx 環境 build/驗證新版（不碰部署樹）
-pipx run --spec paulsha-cortex==<新版> cortex --version   # 或既有 build 流程
-# 產出 wheel/venv 後，先算內容 hash 與現行部署對照差異
+# ✅ 先看內容
+python3 -m paulsha_cortex.trust_root unit two-way --job | less
 
-# 🔧 operator sudo：受控替換（atomic：新樹旁建→驗→切 symlink→保留舊樹回滾）
-export NEW="/opt/cortex/venv.next"
-sudo cp -a "$HOME/.local/share/pipx/venvs/paulsha-cortex" "$NEW"
-sudo chown -R root:root "$NEW"
-sudo find "$NEW" -type f -exec chmod a-w {} +
-# 驗證新樹自檢通過後才切換：
-sudo -u cortex-svc "$NEW/bin/python" -m paulsha_cortex.trust_root selfcheck
-sudo ln -sfn "$NEW" /opt/cortex/venv.active   # ExecStart 指向 venv.active
-sudo systemctl restart cortex-manager.service
+# 🔧 sudo：落檔（root 擁有——這是 User= 不可被竄改的前提）
+python3 -m paulsha_cortex.trust_root unit two-way --job \
+  | sudo tee /etc/systemd/system/cortex-job@.service >/dev/null
+sudo chown root:root /etc/systemd/system/cortex-job@.service
+sudo chmod 0644 /etc/systemd/system/cortex-job@.service
+sudo systemctl daemon-reload
+```
+
+#### 5-B-2. 安裝 polkit 規則
+
+```bash
+# 🔧 sudo：落檔
+sudo install -o root -g root -m 0644 /tmp/polkit-B.rules \
+     /etc/polkit-1/rules.d/49-cortex-downgrade.rules
+sudo systemctl restart polkit.service 2>/dev/null || sudo systemctl restart polkitd.service
+
+# ✅ 驗證：與產生器逐位元相同、載入無錯
+diff <(python3 -m paulsha_cortex.trust_root polkit two-way --template) \
+     /etc/polkit-1/rules.d/49-cortex-downgrade.rules && echo "polkit in sync: OK"
+sudo journalctl -u polkit -n 30 --no-pager | grep -Ei "error|syntax" || echo "polkit loaded clean: OK"
+```
+
+#### 5-B-3. 準備 job spool 並實測降權（正向必須成功）
+
+job 的命令由 Manager 寫進 svc-owned spool，job 帳號只有讀權——因此**改不了自己的
+命令列，也埋伏不了下一個 job**。
+
+```bash
+JOB=selftest
+
+# 🔧 sudo：per-job spool（svc 擁有、builder 只讀）
+sudo install -d -o cortex-svc -g cortex-svc -m 0700 "/var/lib/cortex/jobs/$JOB"
+sudo setfacl -m u:cortex-builder:r-x "/var/lib/cortex/jobs/$JOB"
+sudo tee "/var/lib/cortex/jobs/$JOB/run.sh" >/dev/null <<'SH'
+#!/bin/sh
+echo "== identity =="; id
+echo "== tokens =="; echo "GH_TOKEN=[$GH_TOKEN] GITHUB_TOKEN=[$GITHUB_TOKEN]"
+echo "== inherited fds =="; ls -l /proc/self/fd
+echo "== home =="; echo "HOME=$HOME"; ls -ld "$HOME" 2>&1
+SH
+sudo chown cortex-svc:cortex-svc "/var/lib/cortex/jobs/$JOB/run.sh"
+sudo chmod 0600 "/var/lib/cortex/jobs/$JOB/run.sh"
+sudo setfacl -m u:cortex-builder:r-- "/var/lib/cortex/jobs/$JOB/run.sh"
+
+# 🔧 sudo：job 的 worktree（builder 擁有）
+sudo install -d -o cortex-builder -g cortex-builder -m 0700 "/var/lib/cortex/worktree/$JOB"
+
+# ✅ 驗證（正向）：以 cortex-svc 身分起 job——**必須成功**
+sudo -u cortex-svc systemctl start "cortex-job@$JOB.service"
+sudo journalctl -u "cortex-job@$JOB.service" -n 50 --no-pager
+#   期望輸出：
+#     uid=…(cortex-builder) gid=…(cortex-builder)
+#     GH_TOKEN=[] GITHUB_TOKEN=[]                ← token 已 scrub
+#     /proc/self/fd 只有 0/1/2                    ← 無指向受保護資產的可寫 fd（R9 T4.1）
+#     HOME=/var/lib/cortex-builder，且該目錄為 root:root
+```
+
+#### 5-B-4. 驗證（反向：全部必須失敗）
+
+```bash
+# ✅ (1) transient unit 起 root：必須被拒
+sudo -u cortex-svc systemd-run --uid=0 --pipe --wait /bin/id; echo "exit=$?"
+#   期望：非 0；訊息含 "Interactive authentication required" 或 "Access denied"
+
+# ✅ (2) transient unit 起 builder：**同樣**必須被拒（transient 一律封）
+sudo -u cortex-svc systemd-run --uid=cortex-builder --pipe --wait /bin/id; echo "exit=$?"
+#   期望：非 0。這就是 B 相對 A 多出來的那一半保證。
+
+# ✅ (3) transient unit 夾帶特權屬性：必須被拒
+sudo -u cortex-svc systemd-run --uid=cortex-builder \
+     --property=AmbientCapabilities=CAP_SETUID --pipe --wait /bin/id; echo "exit=$?"
+
+# ✅ (4) 起別的既存 unit（含 Manager 自己）：必須被拒
+sudo -u cortex-svc systemctl restart cortex-manager.service; echo "exit=$?"
+sudo -u cortex-svc systemctl start sshd.service 2>&1 | tail -1; echo "exit=$?"
+
+# ✅ (5) 名稱夾帶（前綴／後綴混淆）：必須被拒
+sudo -u cortex-svc systemctl start "evil-cortex-job@x.service"; echo "exit=$?"
+
+# ✅ (6) 其他 verb：必須被拒
+sudo -u cortex-svc systemctl mask "cortex-job@$JOB.service"; echo "exit=$?"
+sudo -u cortex-svc systemctl daemon-reload; echo "exit=$?"
+
+# ✅ (7) 直接改模板 unit：必須 EACCES
+sudo -u cortex-svc sh -c 'echo "User=root" >> /etc/systemd/system/cortex-job@.service'; echo "exit=$?"
+```
+
+**通過條件**：5-B-3 正向成功且輸出符合期望；5-B-4 的 (1)–(7) **全部**非 0 退出。
+任一反向測試通過（即攻擊成功）＝**立即停止**，回到第 9 步回滾。
+
+```bash
+# 🔧 sudo：清掉 selftest 殘留
+sudo systemctl stop "cortex-job@$JOB.service" 2>/dev/null || true
+sudo rm -rf "/var/lib/cortex/jobs/$JOB" "/var/lib/cortex/worktree/$JOB"
+```
+
+---
+
+### 5-C. 產生邏輯的離線對照（兩案共用）
+
+```bash
+# ✅ polkit 無法本機模擬時的第二證據：決策矩陣測試（含兩案互不放行對方的 unit 形狀）
+python3 -m pytest tests/test_trust_root_permgen_p2b.py -q -k polkit
+```
+
+**回滾**（兩案共用）：`sudo rm -f /etc/polkit-1/rules.d/49-cortex-downgrade.rules
+/etc/systemd/system/cortex-job@.service; sudo systemctl daemon-reload;
+sudo systemctl restart polkit.service`；A 方案另需把 `PSC_JOB_RUNNER` 移出
+EnvironmentFile（回 `direct`）。降權停用後 Manager 以
+`PSC_DEGRADED_OPERATION=per-case-approval` 不 spawn job 運轉。
+
+---
+
+## 第 6 步：升級流程（**不 codify**——手動 runbook，cortex 只產生字串）
+
+裁決 6：**不**提供 `cortex install trust-root --system` 子命令。把特權操作寫進
+codebase 等於把提權路徑收進攻擊面內；cortex 只負責產生命令字串與驗證，root 由
+operator 手動執行。升級因此是下列固定流程：
+
+```bash
+# ✅ 1. 在 operator 帳號的 pipx 環境驗新版（完全不碰 /opt/cortex）
+pipx upgrade paulsha-cortex     # 或既有 build 流程
+"$HOME/.local/share/pipx/venvs/paulsha-cortex/bin/cortex" --version
+
+# ✅ 2. 差異對照（新舊部署的內容 hash）
+( cd "$HOME/.local/share/pipx/venvs/paulsha-cortex" && find . -type f -print0 | sort -z | xargs -0 sha256sum ) > /tmp/cortex-new.sha
+( cd /opt/cortex/venv && sudo find . -type f -print0 | sort -z | sudo xargs -0 sha256sum ) > /tmp/cortex-cur.sha
+diff <(sort /tmp/cortex-cur.sha) <(sort /tmp/cortex-new.sha) | head -50
+
+# 🔧 3. sudo：旁建新樹（不覆蓋現行）
+sudo rm -rf /opt/cortex/venv.new
+sudo cp -a "$HOME/.local/share/pipx/venvs/paulsha-cortex" /opt/cortex/venv.new
+sudo chown -R root:root /opt/cortex/venv.new
+sudo find /opt/cortex/venv.new -type d -exec chmod 0755 {} +
+sudo find /opt/cortex/venv.new -type f -exec chmod a-w {} +
+sudo find /opt/cortex/venv.new/bin -type f -exec chmod 0755 {} +
+
+# ✅ 4. 新樹自檢通過才切換
+sudo -u cortex-svc /opt/cortex/venv.new/bin/python -m paulsha_cortex.trust_root selfcheck
+sudo -u cortex-svc /opt/cortex/venv.new/bin/python -m paulsha_cortex.trust_root equation
+
+# ✅ 5. 登記表若有變動，unit 必須重新產生（ReadWritePaths 可能改變）
+diff <(sudo -u cortex-svc /opt/cortex/venv.new/bin/python -m paulsha_cortex.trust_root unit two-way --manager) \
+     /etc/systemd/system/cortex-manager.service || echo "!! unit 需更新，見下"
+
+# 🔧 6. sudo：原子切換（保留前一版供回滾）
+sudo systemctl stop cortex-manager.service
+sudo rm -rf /opt/cortex/venv.prev
+sudo mv /opt/cortex/venv /opt/cortex/venv.prev
+sudo mv /opt/cortex/venv.new /opt/cortex/venv
+#   若第 5 步顯示 unit 需更新：
+#   python3 -m paulsha_cortex.trust_root unit two-way --manager | sudo tee /etc/systemd/system/cortex-manager.service >/dev/null
+#   sudo systemctl daemon-reload
+sudo systemctl start cortex-manager.service
+```
+
+```bash
+# ✅ 驗證：新版在跑、自檢綠
+sudo -u cortex-svc /opt/cortex/venv/bin/cortex --version
+systemctl status cortex-manager.service --no-pager | head -5
 ```
 
 > **不裸 chown**：升級不是「把 headless 產出的檔 chown 給 svc」，而是「operator 驗證
 > 來源後，以 root 身分整棵替換部署樹」。任何 headless 都碰不到 `/opt/cortex`。
-> 舊樹（`venv.active` 前一目標）保留一個 release 供回滾（第 8 步）。
-
-> **⚠️ 未決 6**：是否提供 `cortex install trust-root --system` 子命令把此流程
-> codify（spec 未決問題 #3）。codify 較可重複，但等於把特權操作寫進 codebase，本身
-> 需審查。Phase 2b 先走手動 runbook；子命令化留待 operator 決定。
+> **回滾**：`sudo systemctl stop cortex-manager; sudo rm -rf /opt/cortex/venv;
+> sudo mv /opt/cortex/venv.prev /opt/cortex/venv; sudo systemctl start cortex-manager`。
 
 ---
 
-## 第 7 步：切換驗收（Phase 1 自檢轉綠 + R9 四族實測）
-
-### 7a. Phase 1 自檢切 fail-closed 應綠
+## 第 7 步：切換驗收（Phase 1 自檢轉綠）
 
 ```bash
-# ✅ 驗證：以 cortex-svc（Manager 身分）跑自檢——Manager-owned 樹應無 job-writable
-sudo -u cortex-svc /opt/cortex/venv.active/bin/python \
-  -m paulsha_cortex.trust_root selfcheck
-# 期望：ok=true、job_writable_count=0（對照第 0 步 baseline 的紅）
+# ✅ 以 cortex-svc（Manager 身分）跑自檢——Manager-owned 樹應無 job-writable
+sudo -u cortex-svc env $(grep -v '^#' /opt/cortex/etc/cortex-manager.env | xargs) \
+  /opt/cortex/venv/bin/python -m paulsha_cortex.trust_root selfcheck \
+  | tee "/tmp/trust-root-after-$(date +%Y%m%d-%H%M).json"
+#   期望：JSON 的 "ok": true、"job_writable_count": 0
+
+# ✅ 與執行前提的 baseline 逐項對照（哪些 job-writable finding 被關掉了）
+python3 - <<'PY'
+import glob, json
+def load(pattern):
+    return json.load(open(sorted(glob.glob(pattern))[-1], encoding="utf-8"))
+def jw(d):
+    return {f["asset_id"] for f in d.get("findings", []) if f.get("status") == "job-writable"}
+before, after = load('/tmp/trust-root-baseline-*.json'), load('/tmp/trust-root-after-*.json')
+print("baseline job_writable_count =", before.get("job_writable_count"))
+print("after    job_writable_count =", after.get("job_writable_count"))
+print("closed   :", sorted(jw(before) - jw(after)))
+print("remaining:", sorted(jw(after)))
+PY
+#   期望：after job_writable_count = 0；remaining 為空；
+#         closed 涵蓋 baseline 列出的全部 job-writable 項
+
+# ✅ 等式仍綠（登記表沒被順手改壞）
+python3 -m paulsha_cortex.trust_root equation
 ```
 
-### 7b. R9 四族攻擊測試（以 `cortex-builder` shell 實測攻不進）
-
-每族都要有 **negative control**（以受信任身分執行相同動作**必須成功**，否則是環境
-壞掉的假綠，spec §R9）。
-
-```bash
-# 取一個 cortex-builder shell（經第 5 步降權機制）
-BUILDER='sudo -u cortex-svc systemd-run --uid=cortex-builder --pipe --wait --collect /bin/sh -c'
-
-# 族 1 capability-theft
-$BUILDER 'cat /var/lib/cortex/agents/core/runtime/*.env'      # 期望 EACCES（或無此權限）
-$BUILDER 'printf x > /var/lib/cortex/agents/control/requests/evil.json'  # 期望 EACCES
-
-# 族 2 durable-state-tampering（對每個 Tier-0/1 資產：modify/truncate/delete/replace/symlink/rollback）
-$BUILDER 'printf "{}" > /var/lib/cortex/agents/coordinator/jobs.json'    # 期望 EACCES、jobs.json 位元不變
-$BUILDER 'rm -f /var/lib/cortex/agents/coordinator/evidence/*'          # 期望 EACCES
-# review verdict 代寫（背景 §3 最短攻擊路徑）——builder 對 reviewer 產出零寫入
-$BUILDER 'printf "{\"verdict\":\"pass\"}" > <reviewer_worktree>/.psc-review-verdict.json'  # 期望 EACCES
-
-# 族 3 enforcement-plane-tampering（每案改完 MUST 實際重啟服務再驗證）
-$BUILDER 'echo x >> /opt/cortex/venv.active/lib/python*/site-packages/sitecustomize.py'  # 期望 EACCES
-$BUILDER 'echo x > /etc/systemd/system/cortex-manager.service'          # 期望 EACCES
-
-# 族 4 行程間路徑
-$BUILDER 'cat /proc/$(pgrep -u cortex-svc -n cortex)/environ'           # 期望 EACCES
-$BUILDER 'ls -l /proc/self/fd'                                          # 期望：無可寫的受保護 fd
-
-# negative control（以 cortex-svc 執行族 2 的寫入，必須成功）
-sudo -u cortex-svc /bin/sh -c 'touch /var/lib/cortex/agents/coordinator/.wtest && rm -f /var/lib/cortex/agents/coordinator/.wtest && echo NEG-OK'
-```
-
-**通過條件**：族 1–4 全部被 OS 拒絕（`EACCES`／`EPERM`／`ECONNREFUSED`）；每族的
-negative control 成功；族 3 每案**重啟服務後**仍綠。逐項對照 spec §R9 的 T1–T4 表。
-
-> **⚠️ 未決 7**：R9 的完整自動化矩陣（對登記表**每一項** Tier-0/1 資產機械展開族 2）
-> 是 Phase 2 的 R9 測試工項，**不在本 runbook**——本步是 operator 手動抽驗；完整
-> 矩陣另由測試碼交付並掛 CI。
+**通過條件**：自檢 `ok=true`、`remaining` 為空、`equation` 為 `ok: true`。
 
 ---
 
-## 第 8 步：回滾（每階段的退路 → 退回 Phase 1 降級運轉）
+## 第 8 步：R9 手動抽驗（operator 逐條攻擊測試）
+
+裁決 7：本階段為**手動抽驗**；完整自動化矩陣（對登記表每一項機械展開族 2）屬另一
+工項。下列每條都以 **`cortex-builder` 身分**執行，並附**確切命令**與**預期輸出**。
+每族末尾都有 **negative control**（以受信任身分做同一件事**必須成功**）——沒有它，
+環境壞掉（目錄根本不存在）會產生假綠（spec §R9）。
+
+### 8a. 起一個 R9 攻擊 job
+
+```bash
+JOB=r9
+sudo install -d -o cortex-svc -g cortex-svc -m 0700 "/var/lib/cortex/jobs/$JOB"
+sudo setfacl -m u:cortex-builder:r-x "/var/lib/cortex/jobs/$JOB"
+sudo install -d -o cortex-builder -g cortex-builder -m 0700 "/var/lib/cortex/worktree/$JOB"
+
+sudo tee "/var/lib/cortex/jobs/$JOB/run.sh" >/dev/null <<'SH'
+#!/bin/sh
+t() { printf '%s :: ' "$1"; shift; if "$@" >/dev/null 2>&1; then echo "!! SUCCEEDED (FAIL)"; else echo "denied (OK) rc=$?"; fi; }
+A=/var/lib/cortex
+
+echo "===== 族 1 capability-theft ====="
+t "T1.1 讀 EnvironmentFile"        cat /opt/cortex/etc/cortex-manager.env
+t "T1.1 讀 svc HOME cache"         ls /var/lib/cortex-svc/cache
+t "T1.2 連 Manager control socket" sh -c "ls $A/run/cortex && cat $A/run/cortex/*.sock"
+t "T1.3 呼叫 operator CLI"         /opt/cortex/venv/bin/cortex work ship --help
+t "T1.4 直寫 control queue"        sh -c "printf x > $A/control/requests/evil.json"
+
+echo "===== 族 2 durable-state-tampering ====="
+t "T2 modify jobs.json"            sh -c "printf '{}' > $A/coordinator/jobs.json"
+t "T2 truncate jobs.json"          sh -c ": > $A/coordinator/jobs.json"
+t "T2 delete jobs.json"            rm -f "$A/coordinator/jobs.json"
+t "T2 replace jobs.json"           sh -c "printf '{}' > /tmp/j && mv /tmp/j $A/coordinator/jobs.json"
+t "T2 symlink-swap jobs.json"      sh -c "ln -sf /tmp/evil $A/coordinator/jobs.json"
+t "T2 寫 verification evidence"    sh -c "printf x > $A/coordinator/evidence/verification/evil.json"
+t "T2 寫 maintainer attestation"   sh -c "printf x > $A/coordinator/evidence/maintainer-review/evil.json"
+t "T2 寫 completion record"        sh -c "printf x > $A/coordinator/evidence/completion/evil.json"
+t "T2 寫 full-suite evidence"      sh -c "printf x > $A/coordinator/evidence/full-suite/evil.json"
+t "T2 寫 gate ledger"              sh -c "printf x > $A/runtime/dispatch/evil.gates.json"
+t "T2 寫 delivery journal"         sh -c "printf x > $A/coordinator/delivery-journal.json"
+t "T2 寫 digest outbox"            sh -c "printf x > $A/coordinator/digest/outbox/evil.json"
+t "T2 寫 model-identity overlay"   sh -c "printf x > $A/config/paulsha/model-identities.yaml"
+t "T2 寫 combo override"           sh -c "printf x > $A/config/combos/evil.yaml"
+t "T2 寫 dispatch specs"           sh -c "printf x > $A/specs/evil.md"
+t "T2 寫 skill ledger"             sh -c "printf x >> $A/registry/skill_usage.jsonl"
+t "T2 讀 monitor 讀模型"           cat "$A/monitor/work-items.snapshot.json"
+t "T2 代寫他人 review verdict"     sh -c "printf '{\"verdict\":\"pass\"}' > $A/worktree/victim/.psc-review-verdict.json"
+t "T2 寫他人 worktree"             sh -c "printf x > $A/worktree/victim/evil"
+t "T2 列 worktree pool"            ls "$A/worktree"
+
+echo "===== 族 3 enforcement-plane-tampering ====="
+t "T3.1 改 site-packages verifier" sh -c "printf x >> /opt/cortex/venv/lib/python3*/site-packages/paulsha_cortex/coordinator/verification.py"
+t "T3.2 注入 sitecustomize"        sh -c "printf x > /opt/cortex/venv/lib/python3*/site-packages/sitecustomize.py"
+t "T3.2 注入 .pth"                 sh -c "printf x > /opt/cortex/venv/lib/python3*/site-packages/evil.pth"
+t "T3.3 改 Manager unit"           sh -c "printf x >> /etc/systemd/system/cortex-manager.service"
+t "T3.3 改 job 模板 unit"          sh -c "printf 'User=root' >> /etc/systemd/system/cortex-job@.service"  # 方案 B 才有此檔；A 下為 ENOENT，同樣算拒絕
+t "T3.4 改 EnvironmentFile"        sh -c "printf 'PSC_COORDINATOR_ROOT=/tmp/evil' >> /opt/cortex/etc/cortex-manager.env"
+t "T3.5 刪 EnvironmentFile"        rm -f /opt/cortex/etc/cortex-manager.env
+t "T3.6 改 venv launcher"          sh -c "printf x >> /opt/cortex/venv/bin/cortex"
+t "T3.9 改 codex hooks"            sh -c "printf x > /var/lib/cortex-builder/.codex/hooks.json"
+t "T3.9 換掉 ~/.codex 目錄"        sh -c "mv /var/lib/cortex-builder/.codex /var/lib/cortex-builder/.codex.bak"
+t "T3 改 polkit 規則"              sh -c "printf x >> /etc/polkit-1/rules.d/49-cortex-downgrade.rules"
+
+echo "===== 族 4 行程間路徑 ====="
+echo "T4.1 自己的 fd：" ; ls -l /proc/self/fd
+MPID=$(pgrep -u cortex-svc -n -f paulsha_cortex 2>/dev/null || echo 0)
+echo "manager pid = $MPID"
+t "T4.2 ptrace Manager"            sh -c "command -v gdb >/dev/null && gdb -p $MPID -batch -ex quit"
+t "T4.3 讀 Manager environ"        cat "/proc/$MPID/environ"
+t "T4.3 讀 Manager mem"            head -c 1 "/proc/$MPID/mem"
+t "T4.4 對 Manager 送 SIGSTOP"     kill -STOP "$MPID"
+t "T4 提權：systemd-run root"      systemd-run --uid=0 --pipe /bin/id
+t "T4 提權：起別的 job"            systemctl start cortex-job@other.service
+t "T4 提權：sudo"                  sudo -n true
+SH
+#   注意：以上三條是以 **cortex-builder 身分**執行——builder 在兩個方案下都**不在**
+#   polkit 授權面上（規則的 subject 只有 cortex-svc），故兩案都必須 denied。
+#   方案 A 的殘餘風險是「以 **cortex-svc** 身分」起任意 UID，那條在第 5-A-5 (4) 實測。
+sudo chown cortex-svc:cortex-svc "/var/lib/cortex/jobs/$JOB/run.sh"
+sudo chmod 0600 "/var/lib/cortex/jobs/$JOB/run.sh"
+sudo setfacl -m u:cortex-builder:r-- "/var/lib/cortex/jobs/$JOB/run.sh"
+
+# 準備一個「他人 worktree」作為跨 persona 攻擊目標
+sudo install -d -o cortex-svc -g cortex-svc -m 0700 /var/lib/cortex/worktree/victim
+sudo -u cortex-svc sh -c 'printf "{\"verdict\":\"fail\"}" > /var/lib/cortex/worktree/victim/.psc-review-verdict.json'
+
+# 🔧 sudo：以 svc 身分起攻擊 job（依第 5 步選定的方案二擇一）
+
+# 方案 A（systemd-run transient unit）：
+sudo -u cortex-svc systemd-run --quiet --collect --pipe --wait \
+  --unit="cortex-job-r9-00000000.service" \
+  --uid=cortex-builder --gid=cortex-builder --service-type=exec \
+  --property=NoNewPrivileges=yes \
+  --working-directory="/var/lib/cortex/worktree/$JOB" \
+  /bin/sh "/var/lib/cortex/jobs/$JOB/run.sh" | tee /tmp/r9-report.txt
+
+# 方案 B（root-owned 模板 unit）：
+# sudo -u cortex-svc systemctl start "cortex-job@$JOB.service"
+# sudo journalctl -u "cortex-job@$JOB.service" -n 300 --no-pager | tee /tmp/r9-report.txt
+```
+
+**預期輸出**：`/tmp/r9-report.txt` 中**每一條**都是 `denied (OK) rc=<非 0>`；
+`T4.1 自己的 fd` 只列 `0`、`1`、`2`（指向 journal socket 或 `/dev/null`），
+**沒有任何**指向 `/var/lib/cortex` 或 `/opt/cortex` 的可寫 fd。
+
+```bash
+# ✅ 一眼判讀
+grep -c "denied (OK)" /tmp/r9-report.txt
+grep "SUCCEEDED (FAIL)" /tmp/r9-report.txt && echo "!! 有攻擊成功，立即停止並回滾" || echo "R9 抽驗全綠"
+grep -A5 "自己的 fd" /tmp/r9-report.txt
+```
+
+### 8b. negative control（受信任身分做同樣的事**必須成功**）
+
+```bash
+# ✅ 族 1／2 的 negative control：cortex-svc 寫得進去
+sudo -u cortex-svc sh -c '
+set -e
+A=/var/lib/cortex
+printf "{}" > "$A/coordinator/.negctl.json" && rm -f "$A/coordinator/.negctl.json"
+printf x > "$A/control/requests/.negctl" && rm -f "$A/control/requests/.negctl"
+printf x > "$A/specs/.negctl" && rm -f "$A/specs/.negctl"
+printf x > "$A/config/paulsha/.negctl" && rm -f "$A/config/paulsha/.negctl"
+printf x >> "$A/registry/skill_usage.jsonl"
+cat /opt/cortex/etc/cortex-manager.env >/dev/null
+echo NEG-CONTROL-OK'
+#   期望：印出 NEG-CONTROL-OK。若這裡也失敗 ⇒ 環境壞掉，族 1/2 的綠是假綠。
+
+# ✅ 族 3 的 negative control：root 改得動 enforcement plane（且改完必須重啟複驗）
+sudo cp /etc/systemd/system/cortex-manager.service /tmp/unit.bak
+sudo sh -c 'printf "\n# negctl\n" >> /etc/systemd/system/cortex-manager.service'
+sudo systemctl daemon-reload && sudo systemctl restart cortex-manager.service && echo "NEG-CONTROL-3-OK"
+sudo cp /tmp/unit.bak /etc/systemd/system/cortex-manager.service
+sudo systemctl daemon-reload && sudo systemctl restart cortex-manager.service
+
+# ✅ 族 4 的 negative control：operator（有 sudo）讀得到 Manager environ
+MPID=$(pgrep -u cortex-svc -n -f paulsha_cortex); sudo cat "/proc/$MPID/environ" | tr '\0' '\n' | head -3 && echo "NEG-CONTROL-4-OK"
+```
+
+### 8c. 族 3 的「重啟後仍綠」複驗（spec §R9 硬性要求）
+
+```bash
+# ✅ 每個族 3 案例改完 MUST 實際重啟服務再驗證
+sudo systemctl restart cortex-manager.service
+sleep 3
+systemctl is-active cortex-manager.service
+sudo -u cortex-svc env $(grep -v '^#' /opt/cortex/etc/cortex-manager.env | xargs) \
+  /opt/cortex/venv/bin/python -m paulsha_cortex.trust_root selfcheck | head -20
+#   期望：服務 active、自檢仍 ok=true（族 3 的攻擊沒有留下任何持久效果）
+```
+
+### 8d. 清理
+
+```bash
+sudo systemctl stop "cortex-job@r9.service" 2>/dev/null || true   # 方案 B 才需要
+sudo rm -rf /var/lib/cortex/jobs/r9 /var/lib/cortex/worktree/r9 /var/lib/cortex/worktree/victim
+```
+
+**通過條件**：8a 全部 `denied (OK)`；8b 三組 negative control 全部印出 `*-OK`；
+8c 重啟後仍綠。任一條不符 ⇒ **D6 不算通過**，`0.2.0` 不得宣告 stable（spec §R12）。
+
+---
+
+## 第 9 步：回滾（每階段可回滾 ＋ 全面退回 Phase 1）
 
 Phase 1 完全不需 root 且含降級運轉安全網（`PSC_DEGRADED_OPERATION=per-case-approval`）。
-任一階段出問題即退回「operator 帳號跑 + 降級運轉」。
+任一階段出問題即退回「operator 帳號跑 ＋ 降級運轉」。
 
-| 出問題的階段 | 症狀 | 回滾動作（`🔧 operator sudo`） |
+| 階段 | 症狀 | 回滾動作（`🔧 sudo`） |
 |---|---|---|
-| 第 4c（system unit） | WSL2 重啟後 systemd 未起、Manager 起不來 | `sudo systemctl disable --now cortex-manager.service`；改回 operator 的 `systemctl --user` 舊 unit；确認 `PSC_DEGRADED_OPERATION` 仍在 |
-| 第 4c 加固誤擋 | 服務起來但功能靜默失效（`ProtectSystem`/`ReadWritePaths` 擋到寫入路徑） | 先看 `journalctl -u cortex-manager` 的 EPERM；把被擋路徑加進 `ReadWritePaths`（且回填 R1 登記表）→ `daemon-reload` + `restart` |
-| 第 5（降權機制） | polkit/systemd-run 在 WSL2 不如預期、job spawn 不了 | 暫停 headless 派工；Manager 以 `per-case-approval` 降級運轉（不 spawn），等機制修好 |
-| 第 3（分樹） | 新樹路徑契約破壞既有 instance | env 檔改指回 `~/.agents`（保留舊路徑一個 release 為唯讀相容層）；`legacy-imported/` 仍在，未污染新樹 |
-| 全面回退 | 任一不可解 | 停 system unit、回 operator HOME 部署、`PSC_DEGRADED_OPERATION=per-case-approval`（或 `disabled`），fleet 回到 Phase 1 狀態；**join gate 維持未通過**（不得宣告 0.2.0 stable，spec §R12） |
+| 第 1（UID） | 帳號建錯／名稱衝突 | `sudo userdel cortex-svc; sudo userdel cortex-builder; sudo groupdel cortex-svc; sudo groupdel cortex-builder`（此時尚無檔案屬於它們） |
+| 第 2（樹／權限） | 權限套錯、`find -perm /022` 非空 | 重跑 `sudo sh -e /tmp/p2b-permissions.sh`（冪等）；仍不對則 `sudo rm -rf /var/lib/cortex /var/lib/cortex-svc /var/lib/cortex-builder` 後從第 2 步重來（舊樹未動） |
+| 第 3（legacy-import） | quarantine 內容不符 manifest | `sudo rm -rf /var/lib/cortex/legacy-imported`，重跑 3；`$HOME/.agents` 原地仍完整 |
+| 第 4a（部署） | 新 venv 起不來 | `sudo rm -rf /opt/cortex/venv; sudo mv /opt/cortex/venv.prev /opt/cortex/venv; sudo systemctl restart cortex-manager` |
+| 第 4c（system unit） | WSL 重啟後未拉起／服務起不來 | `sudo systemctl disable --now cortex-manager.service`；改回 `systemctl --user start cortex-manager.service`（舊部署仍在 `$HOME/.local/share/pipx`） |
+| 第 4c（加固誤擋） | 服務起來但功能靜默失效 | 見下方「`ProtectSystem=strict` 誤擋診斷」；**臨時** drop-in 放行、**同一天**把該路徑回填 R1 登記表並重跑 permgen |
+| 第 5（降權） | polkit／transient unit／模板 unit 在 WSL2 不如預期 | `sudo rm -f /etc/polkit-1/rules.d/49-cortex-downgrade.rules /etc/systemd/system/cortex-job@.service; sudo systemctl daemon-reload; sudo systemctl restart polkit.service`；**方案 A 另需**把 `PSC_JOB_RUNNER` 移出 EnvironmentFile（回 `direct`）並 `sudo systemctl restart cortex-manager`；Manager 以 `per-case-approval` 不 spawn job 運轉 |
+| 第 8（R9 有紅） | 任一攻擊成功 | **立即**停 job 派工，執行下方「全面回退」，在 #584 記錄該條攻擊路徑；D6 判定未通過 |
+
+### 全面回退到 Phase 1（降級運轉）
 
 ```bash
-# ✅ 驗證（回滾後）：回到 Phase 1，自檢回 WARN-only、降級運轉生效
-python3 -m paulsha_cortex.trust_root selfcheck            # 預期回到有 WARN 的 Phase 1 狀態
-echo "PSC_DEGRADED_OPERATION=$PSC_DEGRADED_OPERATION"     # 期望 per-case-approval 或 disabled
+# 🔧 sudo：停掉並移除 Phase 2 的一切
+sudo systemctl disable --now cortex-manager.service 2>/dev/null || true
+sudo rm -f /etc/systemd/system/cortex-manager.service /etc/systemd/system/cortex-job@.service
+sudo rm -f /etc/polkit-1/rules.d/49-cortex-downgrade.rules
+#   （方案 A：EnvironmentFile 隨 /opt/cortex 一併移除，PSC_JOB_RUNNER 自然失效）
+sudo systemctl daemon-reload
+sudo systemctl restart polkit.service 2>/dev/null || true
+
+# 🔧 sudo：新樹整棵丟棄（舊 state 從未被併入，故無資料損失）
+sudo rm -rf /var/lib/cortex /var/lib/cortex-svc /var/lib/cortex-builder /opt/cortex
+
+# ✅ 回到 operator 帳號部署 ＋ 降級運轉
+export PSC_DEGRADED_OPERATION=per-case-approval
+systemctl --user start cortex-manager.service
+python3 -m paulsha_cortex.trust_root selfcheck    # 預期回到有 WARN 的 Phase 1 狀態
+echo "PSC_DEGRADED_OPERATION=$PSC_DEGRADED_OPERATION"
 ```
 
-> **回滾原則**：舊 state 走 legacy-import（第 3c）而非併入，所以回滾時新樹可整棵丟棄
-> 而不遺失舊資料；`legacy-imported/` quarantine 是唯讀副本，兩邊都不互相污染。
+> **回滾原則**：舊 state 走 legacy-import（第 3 步）而非併入，所以回滾時新樹可整棵
+> 丟棄而不遺失舊資料；`legacy-imported/` 是唯讀副本，兩邊互不污染。
+> **join gate**：回退期間 D6 維持未通過，`0.2.0` **不得**宣告 stable，且**不得**以
+> 有界殘餘風險豁免放行（spec §R12）。
 
 ---
 
-## 未決點彙整（需 operator 拍板）
+## WSL2 專屬風險與診斷
 
-1. **降權機制最終形態**（最高風險）：`systemd-run`+polkit／setuid 助手／CAP_SETUID
-   三擇一（第 5 步）。**未定案前第 5 步不可執行。**
-2. **目標路徑位置**：`AGENTS_ROOT`／`WORKTREE_ROOT` 落 `/var/lib/cortex` 或保留
-   `~/.agents` 改 owner（第 2、3 步）。
-3. **legacy-import attestation 格式**：Phase 2b 只做物理隔離＋hash manifest；
-   `trust: legacy-imported` 正式標記待 Phase 3 簽章（第 3c 步）。
-4. **Manager 部署路徑**：`/opt/cortex/venv` 或其他 root-owned 位置（第 4a 步）。
-5. **unit 加固最終清單**：`ReadWritePaths` 的精確白名單（由 R1 登記表產生，第 4c 步）。
-6. **是否 codify 成 `cortex install trust-root --system`**（第 6 步；spec 未決問題 #3）。
-7. **R9 完整自動化矩陣**：本 runbook 只手動抽驗；完整矩陣由測試碼另交付（第 7b 步）。
+### A. system unit 開機拉起的驗證（WSL 重啟測試）
 
-## 對 WSL2 環境，本 runbook 最不確定／最高風險的步驟
+WSL2 沒有傳統 boot；systemd 在第一個 shell 進入時才起。lingering 只對 `--user`
+unit 有意義，**system unit 不需要**——但必須實測「WSL 重啟後有沒有自己拉起來」。
 
-1. **第 5 步降權機制（最高風險）**：機制已裁決為 `systemd-run` transient unit 且程式碼
-   已落地（`PSC_JOB_RUNNER=systemd-run`），但 WSL2 上 polkit daemon 是否常駐、
-   `systemd-run --uid` 的實際行為仍需**先在拋棄式環境跑通 R9 族 4** 再上正式機。
-   啟動器對「systemd 不可用／帳號不存在／unit 起不來（含 polkit 拒絕）」一律
-   fail-closed，不會靜默退回同 UID 執行——負控制驗證見第 5c 步驗證 2。
-2. **第 4c system-level unit 在 WSL2 的持久性**：WSL 關閉/重啟後 systemd system session
-   是否可靠拉起 `cortex-manager.service`；lingering 對 system unit 無效，需驗 boot 行為。
-3. **第 4c 加固誤擋**：`ProtectSystem=strict` + `ReadWritePaths` 白名單若漏列某條實際
-   寫入路徑，會**靜默**功能失效（服務起得來但寫不進）；務必先跑既有 E2E 再收窄。
+```bash
+# ✅ 1. 前置：確認 systemd 已在 wsl.conf 啟用
+grep -A2 "^\[boot\]" /etc/wsl.conf
+#   期望：systemd=true
+
+# ✅ 2. 確認已 enable（不是只有 start）
+systemctl is-enabled cortex-manager.service     # 期望 enabled
+systemctl show cortex-manager.service -p WantedBy
+#   期望：WantedBy=multi-user.target
+ls -l /etc/systemd/system/multi-user.target.wants/cortex-manager.service
+#   期望：symlink 存在
+
+# ---- 3. 在 Windows 端執行：wsl --shutdown ----
+#      然後重新開一個 WSL shell，再回來跑本段第 4 項。
+
+# ✅ 4. 重啟後驗證（重點：不需任何人工介入就已 active）
+uptime                                          # 確認真的重啟過
+systemctl is-system-running                     # 期望 running（degraded 也記錄）
+systemctl is-active cortex-manager.service      # 期望 active
+systemctl show cortex-manager.service -p ActiveEnterTimestamp -p NRestarts
+sudo journalctl -u cortex-manager.service -b --no-pager | head -30
+#   期望：本次 boot 的 log 裡服務正常啟動，無 EnvironmentFile／ReadWritePaths 錯誤
+
+# ✅ 5. polkit 也必須在重啟後自己起來（否則降權在重啟後靜默失效）
+systemctl is-active polkit.service || systemctl is-active polkitd.service
+#   方案 A：
+sudo -u cortex-svc systemd-run --quiet --collect --pipe --wait \
+  --unit=cortex-job-smoke-00000000.service --uid=cortex-builder --gid=cortex-builder \
+  --service-type=exec /bin/id && echo "降權重啟後仍可用（A）"
+#   方案 B：
+# sudo -u cortex-svc systemctl start cortex-job@selftest.service && echo "降權重啟後仍可用（B）"
+```
+
+**若重啟後未拉起**：依序查
+(1) `/etc/wsl.conf` 的 `systemd=true`；
+(2) `systemctl is-enabled`（只 `start` 沒 `enable` 是最常見原因）；
+(3) `journalctl -b -u cortex-manager` 的失敗原因；
+(4) `systemctl list-units --failed`。
+仍不行 → 第 9 步的「第 4c」列回滾（改回 `--user` unit）。
+
+### B. `ProtectSystem=strict` 誤擋的診斷
+
+**症狀**：服務 `active` 但功能靜默失效（寫不進去、evidence 沒落檔、job 起不來）。
+
+```bash
+# ✅ 1. 先看有沒有明確的拒絕
+sudo journalctl -u cortex-manager.service -b --no-pager | grep -Ei \
+  "read-only file system|erofs|eperm|eacces|permission denied|operation not permitted"
+
+# ✅ 2. 看實際生效的白名單（和產生器輸出對照）
+systemctl show cortex-manager.service -p ProtectSystem -p ReadWritePaths -p ProtectHome
+diff <(python3 -m paulsha_cortex.trust_root unit two-way --manager | grep '^ReadWritePaths=') \
+     <(systemctl show cortex-manager.service -p ReadWritePaths | tr ' ' '\n' | sed 's/^/ReadWritePaths=/' | head -50)
+
+# ✅ 3. 在**同一組沙箱條件**下重現（root 用 systemd-run 診斷，不放行給 svc）
+sudo systemd-run --pipe --wait --uid=cortex-svc \
+  --property=ProtectSystem=strict --property=ProtectHome=yes --property=PrivateTmp=yes \
+  --property="ReadWritePaths=/var/lib/cortex/coordinator" \
+  /bin/sh -c 'touch /var/lib/cortex/coordinator/.probe && echo WRITE-OK; touch /var/lib/cortex/specs/.probe || echo "specs blocked"'
+#   ↑ 逐條加/減 ReadWritePaths，找出到底缺哪一條
+
+# ✅ 4. 檢查有沒有落在 ProtectHome 遮住的區域（最常見的靜默失效）
+systemctl show cortex-manager.service -p ReadWritePaths | tr ' ' '\n' | grep -E "^/home|^/root" \
+  && echo "!! RWP 落在 ProtectHome 遮蔽區，必定失效"
+
+# ✅ 5. 臨時放行（僅供診斷；當天必須回填登記表）
+sudo systemctl edit cortex-manager.service     # 加入 [Service] ReadWritePaths=<被擋路徑>
+sudo systemctl daemon-reload && sudo systemctl restart cortex-manager.service
+```
+
+**常見誤擋清單（依發生機率）**：
+
+| 症狀 | 根因 | 正解 |
+|---|---|---|
+| dispatch log／gate ledger 寫不進 | `log_dir` 是**相對路徑** `runtime/dispatch/<slice>`，隨 `WorkingDirectory` 落在 `/var/lib/cortex/runtime/dispatch` | 已由登記表 `gate-ledger` 導出到 RWP；若改了 `WorkingDirectory` 必須同步 |
+| git／gh 報 cache 寫入失敗 | HOME 由 root 擁有，只有 `cache/` 可寫 | 確認 `XDG_CACHE_HOME` 已在 unit 內設定且該路徑在 RWP |
+| 服務起不來、Python 直接 crash | `MemoryDenyWriteExecute=yes` 撞到 C extension 的 ctypes trampoline | 先單獨註解該行複測；確認是它之後在 unit 產生器裡記錄例外理由 |
+| 任何 `$HOME/.agents` 路徑 | `ProtectHome=yes` 讓 HOME 不可見 | **這是刻意的**——代表還有程式碼在走舊 fallback，回頭修路徑契約，不要放寬 unit |
+| socket 建不出來 | `run_root` 不在 RWP | 檢查 `runtime-run-tree` 是否仍在登記表；重跑產生器 |
+
+> **鐵律**：被擋的路徑**只能**經「回填 R1 登記表 → 重跑 permgen → 重新落檔 unit」
+> 進入 `ReadWritePaths`。drop-in 只能作為**當天的**臨時措施，不得成為長期狀態——
+> 否則 unit 就不再是登記表的機械投影，`diff` 對齊檢查會紅。
+
+### C. WSL2 其他已知風險
+
+1. **polkit 未安裝／未啟動**：systemd 對 unprivileged client 的授權在 polkit 不可用時
+   **一律拒絕**（fail-closed）。表現為「Manager 完全 spawn 不了 job」而非提權——
+   安全但功能全停。執行前提第 6 項已檢查；重啟後由「A. 第 5 項」複驗。
+2. **`sudo` 需密碼**：所有 `🔧 sudo` 步驟皆互動式，**不可假設自動化**；
+   本 runbook 刻意不使用 `sudo -n`。
+3. **`/proc` 隱藏造成 R9 判讀差異**：`ProtectProc=invisible` 下讀他人
+   `/proc/<pid>/environ` 會是 `ENOENT`（No such file）而非 `EACCES`——
+   兩者都算**拒絕**（第 8 步的 `t()` 只看 rc 非 0，判定不受影響）。
+
+---
+
+## 附錄：本 runbook 的自我檢查
+
+```bash
+# ✅ unit／polkit 與產生器沒有漂移（建議排程每日跑）
+#   PLAN=transient（方案 A）或 template（方案 B）——填第 5 步選定的那個
+PLAN=transient
+diff <(python3 -m paulsha_cortex.trust_root unit two-way --manager) /etc/systemd/system/cortex-manager.service
+diff <(python3 -m paulsha_cortex.trust_root polkit two-way --$PLAN) /etc/polkit-1/rules.d/49-cortex-downgrade.rules
+[ "$PLAN" = template ] && diff <(python3 -m paulsha_cortex.trust_root unit two-way --job) \
+     /etc/systemd/system/cortex-job@.service
+
+# ✅ 方案 A 專屬：unit 名前綴契約沒有漂移（改任一邊都會讓所有 job 被 polkit 拒）
+[ "$PLAN" = transient ] && python3 - <<'PY'
+from paulsha_cortex.coordinator import job_runner
+from paulsha_cortex.trust_root import permgen
+assert permgen.transient_unit_prefix(permgen.DEFAULT_LAYOUT) == job_runner.UNIT_NAME_PREFIX
+print("unit prefix contract OK")
+PY
+
+# ✅ 權限沒有漂移
+sudo find /var/lib/cortex /opt/cortex -perm /022 -print | head
+
+# ✅ 產生器本身的等式測試（含 ReadWritePaths 無遺漏無多餘）
+python3 -m pytest tests/test_trust_root_permgen_p2a.py tests/test_trust_root_permgen_p2b.py -q
+```

--- a/paulsha_cortex/trust_root/__main__.py
+++ b/paulsha_cortex/trust_root/__main__.py
@@ -7,11 +7,24 @@ Phase 1 不改 `cortex` CLI（避免動到 R-16 help 對齊面）；operator／C
     python -m paulsha_cortex.trust_root selfcheck   # R3 自檢診斷（JSON）
     python -m paulsha_cortex.trust_root registry    # R1 登記表摘要（JSON）
     python -m paulsha_cortex.trust_root equation     # R1 雙向等式結果
-    python -m paulsha_cortex.trust_root permissions [two-way|three-way] [--commands]
+    python -m paulsha_cortex.trust_root permissions [two-way|three-way] [--commands] [--paths]
                                                     # Phase 2a 權限計畫（JSON 或命令序列）
+    python -m paulsha_cortex.trust_root unit [two-way|three-way]
+                                        [--manager|--job|--job-properties]
+                                                    # Phase 2b systemd unit 內容
+                                                    # （--job-properties＝方案 A 的
+                                                    #   systemd-run --property= 清單）
+    python -m paulsha_cortex.trust_root polkit [two-way|three-way] [--transient|--template]
+                                                    # Phase 2b 降權 polkit 規則內容
+                                                    # （--transient＝方案 A，預設；
+                                                    #   --template＝方案 B）
+    python -m paulsha_cortex.trust_root scaffold [two-way|three-way]
+                                                    # Phase 2b 骨架目錄的 install -d 命令
 
-`permissions` 只**產生**權限計畫／命令字串，**絕不執行**任何 root 操作——命令供
-operator 在 Phase 2b runbook 中手動 sudo 執行。
+`permissions`／`unit`／`polkit`／`scaffold` 只**產生**計畫與內容字串，**絕不執行**
+任何 root 操作、不寫任何系統路徑——命令供 operator 在 Phase 2b runbook 中手動
+sudo 執行。`--paths` 讓 `--commands` 以 `permgen.DEFAULT_LAYOUT` 的真實絕對路徑
+輸出（0816 裁決：/var/lib/cortex ＋ /opt/cortex），不再帶 placeholder。
 """
 from __future__ import annotations
 
@@ -78,9 +91,12 @@ def main(argv: Sequence[str] | None = None) -> int:
         rest = args[1:]
         scheme_id = "two-way"
         want_commands = False
+        want_paths = False
         for token in rest:
             if token == "--commands":
                 want_commands = True
+            elif token == "--paths":
+                want_paths = True
             elif token in permgen.SCHEMES:
                 scheme_id = token
             else:
@@ -88,10 +104,75 @@ def main(argv: Sequence[str] | None = None) -> int:
                 return 2
         plan = permgen.generate_plan(permgen.SCHEMES[scheme_id])
         if want_commands:
-            for line in permgen.plan_to_commands(plan):
+            path_of = permgen.asset_paths() if want_paths else None
+            for line in permgen.plan_to_commands(plan, path_of=path_of):
                 print(line)
         else:
             print(json.dumps(plan.to_dict(), ensure_ascii=False, indent=2))
+        return 0
+    if command == "unit":
+        rest = args[1:]
+        scheme_id = "two-way"
+        which = "manager"
+        for token in rest:
+            if token == "--manager":
+                which = "manager"
+            elif token == "--job":
+                which = "job"
+            elif token == "--job-properties":
+                which = "job-properties"
+            elif token in permgen.SCHEMES:
+                scheme_id = token
+            else:
+                print(f"unknown unit arg: {token}", file=sys.stderr)
+                return 2
+        scheme = permgen.SCHEMES[scheme_id]
+        if which == "job-properties":
+            print("# 方案 A（systemd-run transient unit）的 --property= 建議清單。")
+            print("# 與方案 B 的模板 unit 同源（同一加固表 ＋ 同一份登記表導出的 RWP）。")
+            print("# 注意：%i 是 systemd 模板 specifier；A 方案（transient）請由呼叫端")
+            print("#       代入該 job 的實際 worktree 路徑。")
+            for prop in permgen.transient_unit_properties(scheme):
+                print(prop)
+            return 0
+        unit = (
+            permgen.build_manager_unit(scheme)
+            if which == "manager"
+            else permgen.build_job_unit(scheme)
+        )
+        print(unit.content, end="")
+        return 0
+    if command == "polkit":
+        rest = args[1:]
+        scheme_id = "two-way"
+        plan = permgen.PolkitPlan.TRANSIENT
+        for token in rest:
+            if token == "--transient":
+                plan = permgen.PolkitPlan.TRANSIENT
+            elif token == "--template":
+                plan = permgen.PolkitPlan.TEMPLATE
+            elif token in permgen.SCHEMES:
+                scheme_id = token
+            else:
+                print(f"unknown polkit arg: {token}", file=sys.stderr)
+                return 2
+        rule = permgen.build_polkit_rule(permgen.SCHEMES[scheme_id], plan=plan)
+        print(rule.content, end="")
+        return 0
+    if command == "scaffold":
+        rest = args[1:]
+        scheme_id = "two-way"
+        for token in rest:
+            if token in permgen.SCHEMES:
+                scheme_id = token
+            else:
+                print(f"unknown scaffold arg: {token}", file=sys.stderr)
+                return 2
+        scheme = permgen.SCHEMES[scheme_id]
+        print("# trust-root Phase 2b 骨架目錄（非登記表資產的父層）——只產生字串。")
+        print(f"# scheme={scheme_id}；operator review 後手動 sudo 執行。")
+        for path, owner, group, mode in permgen.DEFAULT_LAYOUT.scaffold_directories(scheme):
+            print(f"install -d -o {owner} -g {group} -m {format(mode, '04o')} {path}")
         return 0
 
     print(f"unknown command: {command}", file=sys.stderr)

--- a/paulsha_cortex/trust_root/permgen.py
+++ b/paulsha_cortex/trust_root/permgen.py
@@ -32,6 +32,7 @@ job-visible 樹由對應 job 帳號寫、跨 persona 互不可寫。
 """
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Mapping
@@ -245,9 +246,20 @@ _DIR_ASSET_IDS = frozenset({
     "combo-card-override",       # <agents_root>/config/combos/ 目錄
     "skill-park-proposals",
     "digest-outbox",
+    # 以下皆為 evidence／journal **目錄**（逐 slice／逐 run 一檔），asset_id 的
+    # token heuristic 會誤判成單檔，故明列（路徑對照見 `PathLayout.asset_paths`）：
+    "verification-evidence",        # <coordinator>/evidence/verification/
+    "maintainer-attestation",       # <coordinator>/evidence/maintainer-review/
+    "completion-record",            # <coordinator>/evidence/completion/
+    "full-suite-evidence",          # <coordinator>/evidence/full-suite/
+    "workflow-inputs",              # <coordinator>/evidence/workflow-inputs/
+    "workflow-evidence",            # <coordinator>/evidence/workflow/
+    "workflow-report-journal",      # <coordinator>/workflow-report-transactions/
+    "engineering-outcome-outbox",   # <coordinator>/engineering-outcomes/<repo>.jsonl 的容器
+    "gate-ledger",                  # <agents_root>/runtime/dispatch/（manager log_dir）
+    "review-verdict-spool",         # <coordinator>/review-verdicts/<reviewer_job_id>/
 })
 _FILE_ASSET_IDS = frozenset({
-    "engineering-outcome-outbox",  # 單一 .jsonl 檔（名稱含 outbox 但是檔）
     "control-daemon-lock",
     "control-status",
 })
@@ -334,10 +346,8 @@ def build_entry(asset: TrustRootAsset, scheme: UidScheme) -> PermissionEntry:
             "部署身分（root）擁有——enforcement plane（env／hooks），或 durable-state "
             "樹根（解析鏈即信任根，spec §1）：root 擁有使 headless／svc 皆無法 relink "
             "整棵樹；對全部 headless 唯讀，現況裸寫／group-writable 於此收斂。"
-        )
-        open_points.append(
-            "部署路徑最終位置待 operator 定（pipx tree 遷到 root/svc-owned 部署路徑；"
-            "bootstrap env／codex hooks 是否移出 operator HOME）。"
+            "0816 裁決已定案路徑：部署樹＝/opt/cortex、bootstrap env 落 /opt/cortex/etc/、"
+            "codex hooks 落 job 帳號 HOME 下的 root-owned .codex/（值見 PathLayout，勿手寫）。"
         )
 
     elif owner_class is OwnerClass.MANAGER_STATE:
@@ -398,8 +408,10 @@ def build_entry(asset: TrustRootAsset, scheme: UidScheme) -> PermissionEntry:
             # 容器由 Manager 擁有，per-job 子目錄在 spawn 時逐案 chown 給該 job 帳號。
             owner = trusted_owner
             runtime_managed = True
-            is_dir = True  # 多 persona 容器一律視為目錄（per-job 子物件容器）
-            mode = _dir_file_mode(True, 0o7, 0, 0o1)  # 0701：others 僅 traverse 進自己被 chown 的子目錄
+            # 目錄容器：0701——others 僅 traverse 進自己被 chown 的子目錄，不可列目錄。
+            # 檔案（如 per-job handoff manifest）：0600，owner-only；per-job owner 由
+            # 降權啟動器在 spawn 時逐案 chown，容器層不預先開放。
+            mode = _dir_file_mode(is_dir, 0o7 if is_dir else 0o6, 0, 0o1 if is_dir else 0)
             writer_accounts = frozenset({owner})  # 容器層僅 Manager 建子目錄
             rationale = (
                 "job-visible 多 persona 容器：Manager 擁有容器，per-job worktree 於 "
@@ -495,6 +507,11 @@ def _placeholder_path(entry: PermissionEntry) -> str:
     return f"<PATH:{entry.asset_id}>"
 
 
+#: per-job 路徑的標記 segment。帶此 segment 的資產由降權啟動器在 spawn 時逐案套用，
+#: **不**在 setup 階段執行——命令因此以註解形式輸出（可讀、不可誤執行）。
+PER_JOB_SEGMENT = "<job-id>"
+
+
 def plan_to_commands(
     plan: PermissionPlan,
     path_of: Mapping[str, str] | None = None,
@@ -502,21 +519,846 @@ def plan_to_commands(
     """把計畫轉成 runbook 可引用的命令序列（**只產生字串，絕不執行**）。
 
     `path_of`：asset_id→真實路徑字串；未提供者以 placeholder 呈現，供 runbook 以
-    shell 變數替換。輸出含分節註解，方便 operator 對照登記表逐項核可。
+    shell 變數替換（`PathLayout.asset_paths()` 可一次提供全部真實路徑）。輸出含
+    分節註解，方便 operator 對照登記表逐項核可；目錄資產會先出 `install -d`，
+    使整份輸出成為一份可直接執行的 setup script。
     """
     lines: list[str] = [
         f"# trust-root Phase 2b 權限套用命令（scheme={plan.scheme_id}）",
         "# 由 permgen 機械產生；operator 逐項 review 後手動 sudo 執行。",
-        "# 未提供真實路徑者以 <PATH:asset_id> placeholder 呈現。",
+        "# 帶 --paths 時路徑為 PathLayout 的真實絕對路徑；否則以 <PATH:asset_id> 呈現。",
+        f"# 含 {PER_JOB_SEGMENT} 的資產屬 per-job（降權啟動器逐案套用），已註解不執行。",
     ]
     for e in plan.entries:
         path = (path_of or {}).get(e.asset_id) or _placeholder_path(e)
+        per_job = PER_JOB_SEGMENT in path
         lines.append("")
         lines.append(f"# [{e.tier}] {e.asset_id} ({e.owner_class.value}) — {e.rationale}")
         if e.runtime_managed:
             lines.append("#   注意：per-child owner 由降權啟動器逐案 chown（本節僅容器層）。")
         for op in e.open_points:
-            lines.append(f"#   未決：{op}")
-        for cmd in e.commands(path):
-            lines.append(cmd)
+            lines.append(f"#   後續依賴：{op}")
+        if per_job:
+            lines.append("#   per-job：由降權啟動器在 spawn 時套用，setup 階段不執行。")
+        cmds = list(e.commands(path))
+        if e.is_directory:
+            # 目錄一定先建起來，後續 chown／chmod／setfacl 必然有對象。
+            cmds.insert(0, f"install -d {path}")
+        else:
+            # 葉檔在 setup 當下多半尚未存在（由服務首次寫入時建立）。加 `[ ! -e ] ||`
+            # 守衛：不存在就跳過（且在 `sh -e` 下不會中斷腳本），存在就套上目標權限。
+            # 尚未存在也安全——容器目錄已是 owner-only，且 unit 的 UMask=0077 讓新檔
+            # 出生即 0600。
+            lines.append(
+                f"#   葉檔守衛：{path} 尚未建立時跳過（服務以 UMask=0077 建立即符合目標）。"
+            )
+            cmds = [f"[ ! -e {path} ] || {cmd}" for cmd in cmds]
+        for cmd in cmds:
+            lines.append(f"#   {cmd}" if per_job else cmd)
     return lines
+
+
+# ---------------------------------------------------------------------------
+# Phase 2b：部署 layout（把登記表的抽象資產綁到目標主機的真實絕對路徑）
+#
+# operator 0816 第二輪裁決：durable state 落 `/var/lib/cortex`（worktree pool＝
+# `/var/lib/cortex/worktree`）、Manager 部署落 `/opt/cortex`。本 layout 是那份裁決
+# 的機器可讀形式——runbook 不再手寫路徑，全部從這裡取。
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class ExtraWritePath:
+    """非登記表資產、但服務身分確實需要寫的路徑（每條必須附理由）。
+
+    這是「無多餘」等式的唯一合法例外通道：ReadWritePaths 由登記表機械導出，
+    任何額外條目都必須在此明示宣告並說明理由，測試會強制理由非空。
+    """
+
+    path: str
+    reason: str
+
+
+@dataclass(frozen=True)
+class PathLayout:
+    """目標主機的絕對路徑 layout（0816 裁決值為預設）。"""
+
+    agents_root: str = "/var/lib/cortex"
+    worktree_root: str = "/var/lib/cortex/worktree"
+    deploy_root: str = "/opt/cortex"
+    instance: str = "cortex"
+    svc_home: str = "/var/lib/cortex-svc"
+    builder_home: str = "/var/lib/cortex-builder"
+    #: per-job 路徑的 segment；system unit 模板用 `%i`（systemd instance 名）。
+    job_segment: str = PER_JOB_SEGMENT
+
+    # -- 衍生根 -------------------------------------------------------------
+    @property
+    def control_root(self) -> str:
+        return f"{self.agents_root}/control"
+
+    @property
+    def coordinator_root(self) -> str:
+        return f"{self.agents_root}/coordinator"
+
+    @property
+    def specs_root(self) -> str:
+        return f"{self.agents_root}/specs"
+
+    @property
+    def monitor_state_root(self) -> str:
+        return f"{self.agents_root}/monitor"
+
+    @property
+    def project_config_root(self) -> str:
+        return f"{self.agents_root}/config/paulsha"
+
+    @property
+    def skill_registry_root(self) -> str:
+        return f"{self.agents_root}/registry"
+
+    @property
+    def run_root(self) -> str:
+        return f"{self.agents_root}/run/{self.instance}"
+
+    @property
+    def dispatch_log_root(self) -> str:
+        """Manager 的 job log_dir（`autonomy.py` 以相對 `runtime/dispatch/<slice>`
+        推導，故由 unit 的 `WorkingDirectory` 決定落點）。gate ledger 住在這裡。"""
+        return f"{self.agents_root}/runtime/dispatch"
+
+    @property
+    def job_spool_root(self) -> str:
+        """Manager 寫、job 只讀的 per-job 執行規格（`<id>/run.sh`）。"""
+        return f"{self.agents_root}/jobs"
+
+    @property
+    def venv_root(self) -> str:
+        return f"{self.deploy_root}/venv"
+
+    @property
+    def exec_start(self) -> str:
+        return f"{self.venv_root}/bin/cortex service run"
+
+    @property
+    def env_file(self) -> str:
+        return f"{self.deploy_root}/etc/{self.instance}-manager.env"
+
+    @property
+    def svc_cache(self) -> str:
+        return f"{self.svc_home}/cache"
+
+    @property
+    def builder_cache(self) -> str:
+        return f"{self.builder_home}/cache"
+
+    def with_job_segment(self, segment: str) -> "PathLayout":
+        """換掉 per-job segment（system unit 模板用 `%i`）。"""
+        return PathLayout(
+            agents_root=self.agents_root,
+            worktree_root=self.worktree_root,
+            deploy_root=self.deploy_root,
+            instance=self.instance,
+            svc_home=self.svc_home,
+            builder_home=self.builder_home,
+            job_segment=segment,
+        )
+
+    # -- 資產→路徑 ----------------------------------------------------------
+    def asset_paths(self) -> dict[str, str]:
+        """登記表每一項 asset_id → 目標主機絕對路徑（涵蓋全部、無多餘）。"""
+        a = self.agents_root
+        c = self.coordinator_root
+        ctl = self.control_root
+        mon = self.monitor_state_root
+        reg = self.skill_registry_root
+        wt = self.worktree_root
+        job = f"{wt}/{self.job_segment}"
+        return {
+            "runtime-agents-tree": a,
+            "control-root-tree": ctl,
+            "coordinator-root-tree": c,
+            "dispatch-specs-tree": self.specs_root,
+            "runtime-run-tree": self.run_root,
+            "project-config-tree": self.project_config_root,
+            "coverage-shadow-telemetry": f"{c}/coverage-shadow",
+            "monitor-state-tree": mon,
+            "monitor-work-items-snapshot": f"{mon}/work-items.snapshot.json",
+            "monitor-github-sync-cursor": f"{mon}/github-issue-sync.json",
+            "monitor-event-spool": f"{mon}/event-spool",
+            "skill-registry-tree": reg,
+            "skill-usage-ledger": f"{reg}/skill_usage.jsonl",
+            "skill-park-state": f"{reg}/skill_park.json",
+            "skill-park-proposals": f"{reg}/skill_park_proposals",
+            "control-request-queue": f"{ctl}/requests",
+            "control-done-queue": f"{ctl}/done",
+            "control-status": f"{ctl}/status.json",
+            "control-daemon-lock": f"{ctl}/manager.lock",
+            "repo-worktree": job,
+            "dispatch-worktree-pool": wt,
+            "jobs-registry": f"{c}/jobs.json",
+            "review-verdict": f"{job}/.psc-review-verdict.json",
+            # Phase 2a 受控通道（PR #599）：<coordinator>/review-verdicts/<reviewer_job_id>/
+            "review-verdict-spool": f"{c}/review-verdicts",
+            "verification-evidence": f"{c}/evidence/verification",
+            "maintainer-attestation": f"{c}/evidence/maintainer-review",
+            "completion-record": f"{c}/evidence/completion",
+            "full-suite-evidence": f"{c}/evidence/full-suite",
+            "workflow-inputs": f"{c}/evidence/workflow-inputs",
+            "workflow-evidence": f"{c}/evidence/workflow",
+            "gate-ledger": self.dispatch_log_root,
+            "delivery-journal": f"{c}/delivery-journal.json",
+            "provider-backoff": f"{c}/provider-rate-limit-backoff.json",
+            "workflow-report-journal": f"{c}/workflow-report-transactions",
+            "digest-outbox": f"{c}/digest/outbox",
+            "engineering-outcome-outbox": f"{c}/engineering-outcomes",
+            "model-identity-overlay": f"{self.project_config_root}/model-identities.yaml",
+            "combo-card-override": f"{a}/config/combos",
+            "handoff-manifest": f"{job}/.psc-handoff.json",
+            "runtime-bootstrap-env": self.env_file,
+            "codex-hooks": f"{self.builder_home}/.codex/hooks.json",
+            "work-items-yaml": f"{job}/.cortex/work-items.yaml",
+        }
+
+    # -- 非資產骨架目錄 -----------------------------------------------------
+    def scaffold_directories(self, scheme: UidScheme) -> tuple[tuple[str, str, str, int], ...]:
+        """`(path, owner, group, mode)`：不屬任何登記表資產、但必須先存在的父目錄。
+
+        原則：**凡是保護資產的父目錄，一律 root 擁有**——父目錄可寫者能 unlink／
+        rename 子物件，因此把 root-owned 檔放進 svc-owned 目錄等於沒保護。
+        """
+        svc = scheme.durable_state_owner
+        builder = scheme.resolve(Principal.BUILDER) or "cortex-builder"
+        root = scheme.deploy_account
+        g = scheme.group_of
+        return (
+            # 部署樹（enforcement plane）：全 root，對 svc／builder 唯讀。
+            (self.deploy_root, root, g(root), 0o755),
+            (f"{self.deploy_root}/etc", root, g(root), 0o755),
+            (self.venv_root, root, g(root), 0o755),
+            # durable state 樹的 root-owned 骨架（svc 不得 relink 這幾層）。
+            (f"{self.agents_root}/config", root, g(root), 0o755),
+            (f"{self.agents_root}/run", root, g(root), 0o755),
+            (f"{self.agents_root}/runtime", root, g(root), 0o755),
+            # svc 自己建得出來、但先建好可讓權限一次到位的中間層。
+            (f"{self.coordinator_root}/evidence", svc, g(svc), 0o700),
+            (f"{self.coordinator_root}/digest", svc, g(svc), 0o700),
+            # job spool：svc 寫 run.sh，job 帳號只 traverse＋讀（0711 不可列目錄）。
+            (self.job_spool_root, svc, g(svc), 0o711),
+            # 服務帳號 HOME：root 擁有（job 不得替換自己的 ~/.codex），只開 cache 子目錄。
+            (self.svc_home, root, g(root), 0o755),
+            (self.svc_cache, svc, g(svc), 0o700),
+            (self.builder_home, root, g(root), 0o755),
+            (f"{self.builder_home}/.codex", root, g(root), 0o755),
+            (self.builder_cache, builder, g(builder), 0o700),
+        )
+
+    # -- 額外可寫路徑（非登記表資產，須附理由）------------------------------
+    def manager_extra_write_paths(self) -> tuple[ExtraWritePath, ...]:
+        return (
+            ExtraWritePath(
+                self.job_spool_root,
+                "Manager 寫 per-job 執行規格（<id>/run.sh）供降權 job 讀取；job 帳號唯讀。",
+            ),
+            ExtraWritePath(
+                self.svc_cache,
+                "服務帳號 HOME 快取（git/gh/uv）；HOME 本身 root-owned，只開這一層。",
+            ),
+        )
+
+    def job_extra_write_paths(self) -> tuple[ExtraWritePath, ...]:
+        return (
+            ExtraWritePath(
+                self.builder_cache,
+                "job 帳號 HOME 快取（git/gh/uv）；HOME 與 ~/.codex 皆 root-owned 不可替換。",
+            ),
+        )
+
+
+DEFAULT_LAYOUT = PathLayout()
+
+
+def asset_paths(layout: PathLayout = DEFAULT_LAYOUT) -> dict[str, str]:
+    """模組層便利函式（CLI 與 runbook 引用）。"""
+    return layout.asset_paths()
+
+
+# ---------------------------------------------------------------------------
+# ReadWritePaths 的機械導出
+# ---------------------------------------------------------------------------
+
+def _parent_dir(path: str) -> str:
+    head = path.rsplit("/", 1)[0]
+    return head or "/"
+
+
+def _is_within(child: str, parent: str) -> bool:
+    """`child` 是否落在 `parent` 之內（含相等）——純字串前綴判定，無 IO。"""
+    return child == parent or child.startswith(parent.rstrip("/") + "/")
+
+
+def _minimize(paths: set[str]) -> tuple[str, ...]:
+    """去掉被其他條目涵蓋的子路徑，回傳排序後的最小覆蓋集合。"""
+    kept = [
+        p for p in paths
+        if not any(other != p and _is_within(p, other) for other in paths)
+    ]
+    return tuple(sorted(set(kept)))
+
+
+def required_write_targets(
+    plan: PermissionPlan,
+    layout: PathLayout,
+    account: str,
+) -> dict[str, str]:
+    """`asset_id → 該帳號必須可寫的目標路徑`（檔案取其父目錄）。
+
+    ProtectSystem=strict 下整個檔案系統唯讀；要**建立／取代**一個檔，必須對其
+    父目錄可寫，故檔案資產一律折算成父目錄。這就是「ReadWritePaths 由登記表機械
+    導出」的全部規則——沒有第二條。
+    """
+    targets: dict[str, str] = {}
+    paths = layout.asset_paths()
+    for entry in plan.entries:
+        if account not in plan.all_writable_accounts(entry):
+            continue
+        path = paths[entry.asset_id]
+        targets[entry.asset_id] = path if entry.is_directory else _parent_dir(path)
+    return targets
+
+
+def read_write_paths(
+    plan: PermissionPlan,
+    layout: PathLayout,
+    account: str,
+    extras: tuple[ExtraWritePath, ...] = (),
+) -> tuple[str, ...]:
+    """該帳號 unit 的 `ReadWritePaths=` 最小覆蓋集合（登記表導出 ∪ 明示 extras）。"""
+    wanted = set(required_write_targets(plan, layout, account).values())
+    wanted |= {e.path for e in extras}
+    return _minimize(wanted)
+
+
+def read_write_path_owners(
+    plan: PermissionPlan,
+    layout: PathLayout,
+    account: str,
+    extras: tuple[ExtraWritePath, ...] = (),
+) -> dict[str, tuple[str, ...]]:
+    """每條 ReadWritePaths → 它涵蓋的 asset_id（或 `extra:<reason>`），供逐條註解。"""
+    targets = required_write_targets(plan, layout, account)
+    result: dict[str, tuple[str, ...]] = {}
+    for rwp in read_write_paths(plan, layout, account, extras):
+        covered = sorted(aid for aid, t in targets.items() if _is_within(t, rwp))
+        covered += [f"extra:{e.reason}" for e in extras if _is_within(e.path, rwp)]
+        result[rwp] = tuple(covered)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# systemd unit 產生（Manager system unit ＋ 降權 job 模板 unit）
+# ---------------------------------------------------------------------------
+
+#: 加固指令 →（值, 為何）。逐項附註解是 spec §R3 的可審查性要求。
+_HARDENING: tuple[tuple[str, str, str], ...] = (
+    ("NoNewPrivileges", "yes",
+     "提權天花板：exec 後不得取得新特權，setuid 二進位／file capabilities 全部失效。"),
+    ("CapabilityBoundingSet", "",
+     "清空 capability 上界——服務永不具 root 能力（裁決：cortex 任何元件永不具 root）。"),
+    ("AmbientCapabilities", "",
+     "不夾帶任何 ambient capability；CAP_SETUID 路線已被裁決排除。"),
+    ("ProtectSystem", "strict",
+     "整個檔案系統唯讀，只有下方 ReadWritePaths 例外——/opt/cortex 部署樹因此唯讀。"),
+    ("ProtectHome", "yes",
+     "/home、/root、/run/user 一律不可見：state 已全數搬離 HOME，任何殘留的 HOME "
+     "路徑必須立刻失敗，而不是靜默沿用舊樹。"),
+    ("PrivateTmp", "yes",
+     "私有 /tmp、/var/tmp：切斷經共用 tmp 的跨 persona 檔案交換與 symlink 攻擊。"),
+    ("PrivateDevices", "yes",
+     "只掛最小 /dev；封掉 raw device 與 /dev/mem 這類旁路。"),
+    ("ProtectProc", "invisible",
+     "看不到其他 UID 的 /proc/<pid>——直接封 R9 族 4 的 environ／mem 讀取。"),
+    ("ProcSubset", "pid",
+     "/proc 只保留 pid 子集，隱藏 /proc/kcore 等核心介面。"),
+    ("ProtectControlGroups", "yes",
+     "cgroup 樹唯讀：不可經 cgroup 改寫資源或逃逸 unit 界線。"),
+    ("ProtectKernelModules", "yes", "禁止載入／卸載核心模組。"),
+    ("ProtectKernelTunables", "yes", "/proc/sys、/sys 唯讀，禁止改核心參數。"),
+    ("ProtectKernelLogs", "yes", "禁讀 kmsg，避免經核心日誌側錄他人資料。"),
+    ("ProtectClock", "yes", "禁止改系統時鐘——時間是 evidence 排序不變式的輸入。"),
+    ("ProtectHostname", "yes", "禁止改 hostname（稽核紀錄的主機標識）。"),
+    ("RestrictSUIDSGID", "yes",
+     "禁止建立 setuid/setgid 檔——關掉自製提權助手這條路。"),
+    ("RestrictNamespaces", "yes",
+     "禁止建立 namespace：user namespace 是 unprivileged 提權的常見起點。"),
+    ("RestrictRealtime", "yes", "禁 realtime 排程，避免 DoS 宿主。"),
+    ("RestrictAddressFamilies", "AF_UNIX AF_INET AF_INET6",
+     "只留 unix socket 與 IP：封掉 AF_NETLINK／AF_PACKET 等旁路。"),
+    ("LockPersonality", "yes", "鎖定執行域，禁止切換 personality 規避 seccomp。"),
+    ("MemoryDenyWriteExecute", "yes",
+     "禁 W+X 記憶體，封 JIT 型 shellcode。※ 若 Python C-extension（ctypes "
+     "trampoline）啟動失敗，這是第一嫌疑：先單獨註解本行複測。"),
+    ("SystemCallArchitectures", "native",
+     "只允許原生 ABI，封掉經 32-bit compat 介面規避 seccomp。"),
+    ("SystemCallFilter", "@system-service",
+     "seccomp 白名單：只留一般服務所需 syscall。"),
+    ("SystemCallErrorNumber", "EPERM",
+     "被過濾的 syscall 回 EPERM 而非 SIGSYS——失敗可觀測，不是無聲當掉。"),
+    ("RemoveIPC", "yes", "服務結束即清掉該 UID 的 IPC 物件，不留跨 job 殘留。"),
+    ("KeyringMode", "private", "私有 kernel keyring：不共用、不繼承金鑰。"),
+    ("UMask", "0077",
+     "新建檔預設 0600／目錄 0700，與權限產生器的 owner-only 基準一致。"),
+)
+
+
+@dataclass(frozen=True)
+class SystemdUnit:
+    """產生出來的 unit：**只有內容字串與結構化欄位，沒有任何寫檔／執行**。"""
+
+    unit_name: str
+    install_path: str
+    account: str
+    exec_start: str
+    environment_file: str | None
+    read_write_paths: tuple[str, ...]
+    content: str
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "unit_name": self.unit_name,
+            "install_path": self.install_path,
+            "account": self.account,
+            "exec_start": self.exec_start,
+            "environment_file": self.environment_file,
+            "read_write_paths": list(self.read_write_paths),
+            "content": self.content,
+        }
+
+
+def _hardening_lines(overrides: Mapping[str, str] | None = None) -> list[str]:
+    lines: list[str] = []
+    over = dict(overrides or {})
+    for key, value, why in _HARDENING:
+        effective = over.get(key, value)
+        lines.append(f"# {why}")
+        lines.append(f"{key}={effective}")
+    return lines
+
+
+def _rwp_lines(owners: Mapping[str, tuple[str, ...]]) -> list[str]:
+    lines = [
+        "# --- ReadWritePaths：由 R1 登記表機械導出（permgen），勿手擴 ---",
+        "# 每條後面列出它涵蓋的登記表資產；新增 durable state 時改登記表、重跑產生器。",
+    ]
+    for path, covered in owners.items():
+        lines.append(f"#   涵蓋：{', '.join(covered) if covered else '（無）'}")
+        lines.append(f"ReadWritePaths={path}")
+    return lines
+
+
+def build_manager_unit(
+    scheme: UidScheme,
+    layout: PathLayout = DEFAULT_LAYOUT,
+    plan: PermissionPlan | None = None,
+) -> SystemdUnit:
+    """Manager 的 system-level unit（`User=<durable_state_owner>`）。"""
+    plan = plan or generate_plan(scheme)
+    account = scheme.durable_state_owner
+    group = scheme.group_of(account)
+    extras = layout.manager_extra_write_paths()
+    owners = read_write_path_owners(plan, layout, account, extras)
+    unit_name = f"{layout.instance}-manager.service"
+
+    body = [
+        f"# {'/etc/systemd/system/' + unit_name}",
+        f"# 由 permgen 機械產生（scheme={scheme.scheme_id}）——勿手改；改登記表後重跑：",
+        f"#   python3 -m paulsha_cortex.trust_root unit {scheme.scheme_id} --manager",
+        "",
+        "[Unit]",
+        "Description=cortex Manager (trust-root Phase 2b, system-level)",
+        "Documentation=file://docs/superpowers/runbooks/trust-root-phase2b-setup.md",
+        "After=network-online.target",
+        "Wants=network-online.target",
+        "",
+        "[Service]",
+        "Type=simple",
+        "# 受信任服務身分。Manager 永不以 root 執行——root 操作只由 operator 手動 sudo。",
+        f"User={account}",
+        f"Group={group}",
+        "",
+        "# 部署樹在 root-owned 樹內，對本服務唯讀（ProtectSystem=strict 再加一層）：",
+        "# 改寫 verifier／注入 sitecustomize.py／.pth 皆 EACCES（spec §R3）。",
+        f"ExecStart={layout.exec_start}",
+        "# 相對 log_dir（runtime/dispatch/<slice>）由此解析，必須落在 ReadWritePaths 內。",
+        f"WorkingDirectory={layout.agents_root}",
+        "",
+        "# EnvironmentFile 無 '-' 前綴＝fail-closed：檔案缺席即拒絕啟動，",
+        "# MUST NOT 靜默落回 $HOME/.agents 預設（spec §R3 Scenario「刪除 EnvironmentFile」）。",
+        f"EnvironmentFile={layout.env_file}",
+        "# HOME 由 unit 指定；HOME 本身 root-owned，只有 cache 子目錄可寫。",
+        f"Environment=HOME={layout.svc_home}",
+        f"Environment=XDG_CACHE_HOME={layout.svc_cache}",
+        "",
+        "# --- 加固（spec §R3；逐項附理由供審查）---",
+    ]
+    body += _hardening_lines()
+    body += [""]
+    body += _rwp_lines(owners)
+    body += [
+        "",
+        "Restart=on-failure",
+        "RestartSec=5s",
+        "",
+        "[Install]",
+        "WantedBy=multi-user.target",
+    ]
+    return SystemdUnit(
+        unit_name=unit_name,
+        install_path=f"/etc/systemd/system/{unit_name}",
+        account=account,
+        exec_start=layout.exec_start,
+        environment_file=layout.env_file,
+        read_write_paths=tuple(owners.keys()),
+        content="\n".join(body) + "\n",
+    )
+
+
+def build_job_unit(
+    scheme: UidScheme,
+    layout: PathLayout = DEFAULT_LAYOUT,
+    principal: Principal = Principal.BUILDER,
+    plan: PermissionPlan | None = None,
+) -> SystemdUnit:
+    """降權 job 的**模板** unit（`cortex-job@.service`）。
+
+    這是降權/提權分界線的另一半：`User=` 在 root-owned 的 unit 檔裡**硬寫死**，
+    呼叫端（Manager）只能給 instance 名，**無法選擇 UID、無法夾帶任何屬性**。
+    polkit 規則只放行這個模板的實例（見 `build_polkit_rule`）。
+    """
+    plan = plan or generate_plan(scheme)
+    account = scheme.resolve(principal)
+    if account is None:
+        raise ValueError(f"principal 未映射到帳號: {principal}")
+    group = scheme.group_of(account)
+    # per-job 路徑在模板 unit 中以 systemd 的 %i 表示。
+    job_layout = layout.with_job_segment("%i")
+    extras = job_layout.job_extra_write_paths()
+    owners = read_write_path_owners(plan, job_layout, account, extras)
+    unit_name = f"{layout.instance}-job@.service"
+
+    body = [
+        f"# {'/etc/systemd/system/' + unit_name}",
+        f"# 由 permgen 機械產生（scheme={scheme.scheme_id}）——勿手改；重跑：",
+        f"#   python3 -m paulsha_cortex.trust_root unit {scheme.scheme_id} --job",
+        "#",
+        "# 降權/提權分界線：User= 在本 root-owned 檔內硬寫死。Manager（cortex-svc）",
+        "# 只能 `systemctl start cortex-job@<id>.service`，**不能**選 UID、不能傳屬性。",
+        "",
+        "[Unit]",
+        "Description=cortex headless job %i (downgraded, trust-root Phase 2b)",
+        f"After={layout.instance}-manager.service",
+        "",
+        "[Service]",
+        "Type=exec",
+        "# 硬寫死的 job 身分——這行是整套降權的唯一 UID 來源。",
+        f"User={account}",
+        f"Group={group}",
+        "",
+        "# 執行規格由 Manager 寫入 job spool（svc-owned，job 帳號唯讀）：",
+        "# job 因此無法改寫自己的命令列，也無法為下一個 job 埋伏。",
+        f"ExecStart=/bin/sh {job_layout.job_spool_root}/%i/run.sh",
+        f"WorkingDirectory={job_layout.worktree_root}/%i",
+        "# job 永不取得 gh token：GitHub 寫入由 Manager 代理（D1 outbox）。",
+        "Environment=GH_TOKEN=",
+        "Environment=GITHUB_TOKEN=",
+        f"Environment=HOME={job_layout.builder_home}",
+        f"Environment=XDG_CACHE_HOME={job_layout.builder_cache}",
+        "",
+        "# --- 加固（與 Manager 同一套；job 這側只多不少）---",
+    ]
+    body += _hardening_lines()
+    body += [""]
+    body += _rwp_lines(owners)
+    body += [
+        "",
+        "# job 為一次性：結束即回收 unit 狀態，不留可被重用的殘骸。",
+        "CollectMode=inactive-or-failed",
+        "Restart=no",
+        "StandardOutput=journal",
+        "StandardError=journal",
+    ]
+    return SystemdUnit(
+        unit_name=unit_name,
+        install_path=f"/etc/systemd/system/{unit_name}",
+        account=account,
+        exec_start=f"/bin/sh {job_layout.job_spool_root}/%i/run.sh",
+        environment_file=None,
+        read_write_paths=tuple(owners.keys()),
+        content="\n".join(body) + "\n",
+    )
+
+
+# ---------------------------------------------------------------------------
+# polkit 規則產生（授權面嚴格收窄）
+# ---------------------------------------------------------------------------
+
+#: 唯一被授權的 systemd polkit action。
+POLKIT_ACTION = "org.freedesktop.systemd1.manage-units"
+#: 唯一被授權的 verb（起／停 job；reload、mask、set-property 等一律拒）。
+POLKIT_ALLOWED_VERBS: tuple[str, ...] = ("start", "stop")
+
+
+class PolkitPlan(Enum):
+    """降權的兩個方案（operator 待拍板；兩案都完整產出，選了即可執行）。
+
+    - `TRANSIENT`（A）：Manager 以 `systemd-run` 起 transient unit（#603 的
+      `coordinator/job_runner.py` 已落地，`PSC_JOB_RUNNER=systemd-run` 開啟）。
+      polkit 能收窄的**只有**呼叫者 UID ＋ unit 名前綴；`User=`／`--uid=` **不在**
+      polkit detail 內，故「只能降到 job 帳號」這一半由 Manager 端封閉的 argv
+      產生器在 code level 保證，OS 層未強制（殘餘風險見 `plan_residual_risk`）。
+    - `TEMPLATE`（B）：root-owned 模板 unit（`<instance>-job@.service`）把 `User=`
+      硬寫死，polkit 只放行該模板的實例。**「降到哪個帳號」因此由 OS 強制**；
+      代價是 Manager 端要從 `systemd-run` 改成 `systemctl start <instance>-job@<id>`，
+      屬程式碼後續工項。
+    """
+
+    TRANSIENT = "transient"
+    TEMPLATE = "template"
+
+
+#: 明確被拒的特權 unit 屬性——列在規則檔開頭，讓審查者一眼看到邊界在哪。
+POLKIT_FORBIDDEN_PROPERTIES: tuple[str, ...] = (
+    "User=root",
+    "User=<任何非 job 帳號>",
+    "AmbientCapabilities=",
+    "CapabilityBoundingSet=",
+    "PrivateUsers=",
+    "SystemCallFilter=",
+    "ExecStart=（任意 argv）",
+)
+
+
+@dataclass(frozen=True)
+class PolkitRule:
+    """產生出來的 polkit 規則：**只有內容字串**，本模組不寫任何系統路徑。"""
+
+    install_path: str
+    plan: PolkitPlan
+    subject_account: str
+    target_account: str
+    unit_pattern: str
+    allowed_verbs: tuple[str, ...]
+    content: str
+    #: 本方案在 OS 層**未**強制的部分（空 tuple＝無殘餘）。
+    residual_risks: tuple[str, ...] = ()
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "install_path": self.install_path,
+            "plan": self.plan.value,
+            "subject_account": self.subject_account,
+            "target_account": self.target_account,
+            "unit_pattern": self.unit_pattern,
+            "allowed_verbs": list(self.allowed_verbs),
+            "residual_risks": list(self.residual_risks),
+            "content": self.content,
+        }
+
+
+#: A 方案的 transient unit 名前綴——與 `coordinator/job_runner.UNIT_NAME_PREFIX`
+#: 是**成對契約**：改任一邊都必須同步改另一邊，否則 polkit 會拒掉所有 job。
+def transient_unit_prefix(layout: "PathLayout") -> str:
+    return f"{layout.instance}-job-"
+
+
+def job_unit_pattern(
+    layout: "PathLayout" = None,  # type: ignore[assignment]
+    plan: PolkitPlan = PolkitPlan.TEMPLATE,
+) -> str:
+    """被授權的 unit 名 regex（錨定）。"""
+    layout = layout if layout is not None else DEFAULT_LAYOUT
+    if plan is PolkitPlan.TRANSIENT:
+        return r"^" + layout.instance + r"-job-[a-z0-9][a-z0-9._-]{0,62}\.service$"
+    return r"^" + layout.instance + r"-job@[a-z0-9][a-z0-9._-]{0,62}\.service$"
+
+
+def plan_residual_risk(plan: PolkitPlan, scheme: UidScheme) -> tuple[str, ...]:
+    """本方案在 OS 層未強制的部分（誠實標註，runbook 與 PR 皆引用）。"""
+    if plan is PolkitPlan.TEMPLATE:
+        return ()
+    svc = scheme.durable_state_owner
+    # 只列會跑模型的 persona——它們是「被攻陷」的實際入口。
+    same_uid = sorted(
+        {
+            p.value
+            for p in (Principal.REVIEWER, Principal.PLANNER)
+            if scheme.resolve(p) == svc
+        }
+    )
+    risks = [
+        f"polkit 的 {POLKIT_ACTION} 只暴露 unit 名稱，**不暴露 User=／--uid=**；"
+        f"授權後 systemd 會照請求的任意 User= 起 unit。「只能降到 job 帳號」這一半"
+        f"由 Manager 端封閉的 argv 產生器在 code level 保證，OS 層未強制。",
+        f"因此**與 {svc} 同 UID 的任何行程**都持有這個 grant，可請求任意 User= 的"
+        f" transient unit（含 User=root）。",
+    ]
+    if same_uid:
+        risks.append(
+            f"在 {scheme.scheme_id} 方案下，跑模型的 {'／'.join(same_uid)} 與 {svc} 同帳號，"
+            f"故其中任一被攻陷即取得上一條的能力——這正是「是否提前三分」要衡量的東西。"
+        )
+    return tuple(risks)
+
+
+def build_polkit_rule(
+    scheme: UidScheme,
+    layout: "PathLayout" = None,  # type: ignore[assignment]
+    plan: PolkitPlan = PolkitPlan.TRANSIENT,
+    principal: Principal = Principal.BUILDER,
+) -> PolkitRule:
+    """產生降權授權的 polkit 規則內容（A／B 兩方案共用同一套產生邏輯）。
+
+    兩案的授權面都收窄到「`<svc>` 對特定 unit 名 pattern 的 start/stop」，且
+    **unit／verb 明細缺席即拒**；差別在「降到哪個帳號」由誰強制（見 `PolkitPlan`）。
+    """
+    layout = layout if layout is not None else DEFAULT_LAYOUT
+    svc = scheme.durable_state_owner
+    target = scheme.resolve(principal)
+    if target is None:
+        raise ValueError(f"principal 未映射到帳號: {principal}")
+    pattern = job_unit_pattern(layout, plan)
+    verbs = POLKIT_ALLOWED_VERBS
+    verb_check = " && ".join(f'verb !== "{v}"' for v in verbs)
+    residual = plan_residual_risk(plan, scheme)
+
+    if plan is PolkitPlan.TRANSIENT:
+        headline = (
+            f"// 方案 A（transient unit）：{svc} 可 start/stop 名為\n"
+            f"//   {transient_unit_prefix(layout)}<job 片段>-<sha8>.service 的 transient unit。\n"
+            f"// unit 名前綴與 coordinator/job_runner.UNIT_NAME_PREFIX 是**成對契約**——\n"
+            f"// 改任一邊都必須同步改另一邊，否則所有 job 會被 polkit 拒掉（fail-closed）。\n"
+            f"//\n"
+            f"// ===== 本方案在 OS 層未強制的部分（務必知悉）=====\n"
+            + "\n".join(f"// - {r}" for r in residual)
+            + "\n//\n"
+            f"// 要把這一半也搬到 OS 層，改用方案 B（root-owned 模板 unit，User= 寫死）：\n"
+            f"//   python3 -m paulsha_cortex.trust_root polkit {scheme.scheme_id} --template\n"
+        )
+    else:
+        headline = (
+            f"// 方案 B（root-owned 模板 unit）：{svc} 只能 start/stop\n"
+            f"//   {layout.instance}-job@<id>.service 的實例。\n"
+            f"// 模板檔 /etc/systemd/system/{layout.instance}-job@.service 由 root 擁有，\n"
+            f"// 內容硬寫死 User={target}、NoNewPrivileges=yes、CapabilityBoundingSet=（空）。\n"
+            f"// 因此 {svc} **無法選擇 job 的 UID**，也**無法夾帶任何特權屬性**：\n"
+            + "\n".join(f"//     - {p}" for p in POLKIT_FORBIDDEN_PROPERTIES)
+            + "\n"
+            f"// 這些屬性全部只存在於 root-owned 的模板檔裡，呼叫端連提都提不了。\n"
+            f"//\n"
+            f"// ===== 為什麼 transient unit 在本方案下一律拒 =====\n"
+            f"// StartTransientUnit 的 polkit 檢查**不帶 unit 屬性明細**（規則只看得到\n"
+            f"// action id，看不到 User=／AmbientCapabilities=／ExecStart=）。放行 transient\n"
+            f"// unit 就等於允許 {svc} 傳 User=root。下方「unit／verb 明細缺席即拒」與\n"
+            f"// 只認 `@` 實例名的 pattern 一起把這條路關死。\n"
+        )
+
+    content = f"""// /etc/polkit-1/rules.d/49-{layout.instance}-downgrade.rules
+// 由 permgen 機械產生（scheme={scheme.scheme_id}, plan={plan.value}）——勿手改；重跑：
+//   python3 -m paulsha_cortex.trust_root polkit {scheme.scheme_id} --{plan.value}
+//
+// ===== 這是 cortex 的降權/提權分界線 =====
+{headline}//
+// ===== 審查者的一眼結論 =====
+// 唯一的放行出口需要同時滿足：
+//   (1) subject 是 {svc}；(2) action 是 {POLKIT_ACTION}；
+//   (3) unit／verb 明細存在；(4) verb ∈ {{{", ".join(verbs)}}}；
+//   (5) unit 名匹配 {pattern}
+// 任一不成立即拒絕。函式只有最後一行放行。
+
+polkit.addRule(function(action, subject) {{
+    if (subject.user !== "{svc}") {{
+        // 不干涉 operator／其他帳號的既有授權（交回 polkit 預設）。
+        return polkit.Result.NOT_HANDLED;
+    }}
+    if (action.id !== "{POLKIT_ACTION}") {{
+        // {svc} 的其他 polkit action 一律拒（含 login1／hostname1／systemd1 其他面）。
+        return polkit.Result.NO;
+    }}
+    var unit = action.lookup("unit");
+    var verb = action.lookup("verb");
+    if (!unit || !verb) {{
+        // 明細缺席就無從判斷，一律拒（fail-closed）。
+        return polkit.Result.NO;
+    }}
+    if ({verb_check}) {{
+        return polkit.Result.NO;
+    }}
+    if (!/{pattern}/.test(unit)) {{
+        // 只有上述 pattern 的 job unit；{layout.instance}-manager.service 等一律拒。
+        return polkit.Result.NO;
+    }}
+    return polkit.Result.YES;
+}});
+"""
+    return PolkitRule(
+        install_path=f"/etc/polkit-1/rules.d/49-{layout.instance}-downgrade.rules",
+        plan=plan,
+        subject_account=svc,
+        target_account=target,
+        unit_pattern=pattern,
+        allowed_verbs=verbs,
+        content=content,
+        residual_risks=residual,
+    )
+
+
+def transient_unit_properties(
+    scheme: UidScheme,
+    layout: "PathLayout" = None,  # type: ignore[assignment]
+    principal: Principal = Principal.BUILDER,
+    plan: PermissionPlan | None = None,
+) -> tuple[str, ...]:
+    """A 方案的 `--property=` 建議清單（與 B 方案模板 unit 同源，機械產生）。
+
+    `job_runner` 目前只送 `NoNewPrivileges=yes`；本函式把同一套加固表與**由登記表
+    導出的 ReadWritePaths** 展開成 `systemd-run --property=` 形式，供 operator 在
+    A 方案下逐條加固，或作為「A 與 B 的加固面是否等價」的對照表。
+    """
+    layout = layout if layout is not None else DEFAULT_LAYOUT
+    plan = plan or generate_plan(scheme)
+    account = scheme.resolve(principal)
+    if account is None:
+        raise ValueError(f"principal 未映射到帳號: {principal}")
+    job_layout = layout.with_job_segment("%i")
+    props = [f"--property={key}={value}" for key, value, _why in _HARDENING]
+    for rwp in read_write_paths(
+        plan, job_layout, account, job_layout.job_extra_write_paths()
+    ):
+        props.append(f"--property=ReadWritePaths={rwp}")
+    return tuple(props)
+
+
+def evaluate_polkit(
+    rule: PolkitRule,
+    *,
+    user: str,
+    action_id: str,
+    unit: str | None = None,
+    verb: str | None = None,
+) -> str:
+    """規則決策的 Python 鏡像（polkit 無法本機執行，故以純函式測產生邏輯）。
+
+    與 `build_polkit_rule` 產出的 JS **共用同一組常數**（subject／action／verbs／
+    pattern），因此決策矩陣測到的就是規則檔的語意。回傳 `"YES"`／`"NO"`／
+    `"NOT_HANDLED"`。
+    """
+    if user != rule.subject_account:
+        return "NOT_HANDLED"
+    if action_id != POLKIT_ACTION:
+        return "NO"
+    if not unit or not verb:
+        return "NO"
+    if verb not in rule.allowed_verbs:
+        return "NO"
+    if re.search(rule.unit_pattern, unit) is None:
+        return "NO"
+    return "YES"

--- a/tests/test_trust_root_permgen_p2a.py
+++ b/tests/test_trust_root_permgen_p2a.py
@@ -218,10 +218,11 @@ def test_plan_is_json_serializable(scheme) -> None:
 
 @pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
 def test_commands_are_strings_only_and_never_execute(scheme) -> None:
-    """產出只能是 chown／chmod／setfacl 字串——絕不執行任何 root 操作。"""
+    """產出只能是 install -d／chown／chmod／setfacl（可帶 `[ ! -e ] ||` 存在性守衛）
+    字串——絕不執行任何 root 操作。"""
     plan = _plan(scheme)
     lines = permgen.plan_to_commands(plan)
-    allowed = ("chown ", "chmod ", "setfacl ")
+    allowed = ("install -d ", "chown ", "chmod ", "setfacl ", "[ ! -e ")
     for line in lines:
         stripped = line.strip()
         if not stripped or stripped.startswith("#"):

--- a/tests/test_trust_root_permgen_p2b.py
+++ b/tests/test_trust_root_permgen_p2b.py
@@ -1,0 +1,535 @@
+"""Phase 2b（systemd unit ＋ polkit 產生器）：路徑 layout、ReadWritePaths 等式、
+降權授權面收窄、非執行保證。
+
+驗收：
+- layout 對登記表每一項給出真實絕對路徑（無遺漏、無多餘）；
+- Manager unit 的 `ReadWritePaths` **由登記表機械導出**：覆蓋每一個 Manager 需寫的
+  路徑（無遺漏），且每一條都是必要的（無多餘）；
+- 降權 job 模板 unit 硬寫死 `User=<job 帳號>`，job 側 RWP 不含任何 Manager-owned；
+- polkit 規則只放行「svc → job 模板實例的 start/stop」，transient unit／其他 verb／
+  其他 unit／其他 action 一律拒（決策矩陣）；
+- 兩者都只產生內容字串，絕不執行、不寫任何系統路徑。
+"""
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+from paulsha_cortex.trust_root import permgen
+from paulsha_cortex.trust_root.permgen import (
+    DEFAULT_LAYOUT,
+    THREE_WAY_SCHEME,
+    TWO_WAY_SCHEME,
+    OwnerClass,
+    PathLayout,
+    build_job_unit,
+    build_manager_unit,
+    PolkitPlan,
+    build_polkit_rule,
+    evaluate_polkit,
+    generate_plan,
+    read_write_paths,
+    required_write_targets,
+)
+from paulsha_cortex.trust_root.registry import ASSET_REGISTRY, Principal
+
+ALL_SCHEMES = [TWO_WAY_SCHEME, THREE_WAY_SCHEME]
+
+
+def _within(child: str, parent: str) -> bool:
+    return child == parent or child.startswith(parent.rstrip("/") + "/")
+
+
+# ---------------------------------------------------------------------------
+# 路徑 layout：對登記表的雙向等式
+# ---------------------------------------------------------------------------
+
+def test_layout_covers_every_registry_asset_exactly() -> None:
+    paths = DEFAULT_LAYOUT.asset_paths()
+    registry_ids = {a.asset_id for a in ASSET_REGISTRY}
+    assert set(paths) == registry_ids, "layout 與登記表必須逐項對齊（無遺漏、無多餘）"
+
+
+def test_layout_paths_are_absolute_and_match_operator_decision() -> None:
+    """0816 第二輪裁決：durable state 落 /var/lib/cortex、部署落 /opt/cortex。"""
+    paths = DEFAULT_LAYOUT.asset_paths()
+    for asset_id, path in paths.items():
+        assert path.startswith("/"), (asset_id, path)
+    assert DEFAULT_LAYOUT.agents_root == "/var/lib/cortex"
+    assert DEFAULT_LAYOUT.worktree_root == "/var/lib/cortex/worktree"
+    assert DEFAULT_LAYOUT.deploy_root == "/opt/cortex"
+    assert paths["dispatch-worktree-pool"] == "/var/lib/cortex/worktree"
+    # 部署面（enforcement plane）不得落在 durable state 樹內。
+    assert paths["runtime-bootstrap-env"].startswith("/opt/cortex/")
+
+
+def test_no_asset_path_remains_in_operator_home() -> None:
+    """Phase 2b 的重點就是把 durable state 全數搬離 operator HOME。"""
+    for asset_id, path in DEFAULT_LAYOUT.asset_paths().items():
+        assert not path.startswith("/home/"), (asset_id, path)
+        assert "~" not in path, (asset_id, path)
+
+
+def test_per_job_assets_carry_the_job_segment() -> None:
+    paths = DEFAULT_LAYOUT.asset_paths()
+    for asset_id in ("repo-worktree", "review-verdict", "handoff-manifest", "work-items-yaml"):
+        assert permgen.PER_JOB_SEGMENT in paths[asset_id], asset_id
+
+
+def test_with_job_segment_substitutes_systemd_specifier() -> None:
+    job_layout = DEFAULT_LAYOUT.with_job_segment("%i")
+    assert job_layout.asset_paths()["repo-worktree"] == "/var/lib/cortex/worktree/%i"
+    # 其餘欄位不變。
+    assert job_layout.agents_root == DEFAULT_LAYOUT.agents_root
+
+
+# ---------------------------------------------------------------------------
+# ReadWritePaths 等式（本 PR 的核心驗收）
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
+def test_manager_read_write_paths_cover_every_manager_writable_asset(scheme) -> None:
+    """無遺漏：登記表中每一個 Manager 需寫的資產都被某條 ReadWritePaths 覆蓋。"""
+    plan = generate_plan(scheme)
+    unit = build_manager_unit(scheme, DEFAULT_LAYOUT)
+    targets = required_write_targets(plan, DEFAULT_LAYOUT, scheme.durable_state_owner)
+    assert targets, "Manager 至少要有可寫資產"
+    for asset_id, target in targets.items():
+        assert any(_within(target, rwp) for rwp in unit.read_write_paths), (
+            scheme.scheme_id, asset_id, target, unit.read_write_paths,
+        )
+
+
+@pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
+def test_manager_read_write_paths_have_no_redundant_entry(scheme) -> None:
+    """無多餘：拿掉任何一條登記表導出的條目，就會有資產失去覆蓋。
+
+    明示宣告的 extras（job spool／HOME cache）是唯一例外，且每條必須附理由。
+    """
+    plan = generate_plan(scheme)
+    unit = build_manager_unit(scheme, DEFAULT_LAYOUT)
+    targets = required_write_targets(plan, DEFAULT_LAYOUT, scheme.durable_state_owner)
+    extras = {e.path for e in DEFAULT_LAYOUT.manager_extra_write_paths()}
+
+    for rwp in unit.read_write_paths:
+        if rwp in extras:
+            continue
+        remaining = [p for p in unit.read_write_paths if p != rwp]
+        uncovered = [
+            asset_id
+            for asset_id, target in targets.items()
+            if not any(_within(target, other) for other in remaining)
+        ]
+        assert uncovered, (scheme.scheme_id, f"{rwp} 是多餘條目——移除後無資產失去覆蓋")
+
+
+@pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
+def test_manager_read_write_paths_are_minimal_and_disjoint(scheme) -> None:
+    """最小覆蓋：沒有任何一條被另一條包含（否則等於重複開放）。"""
+    unit = build_manager_unit(scheme, DEFAULT_LAYOUT)
+    rwp = unit.read_write_paths
+    assert len(set(rwp)) == len(rwp)
+    for a in rwp:
+        for b in rwp:
+            if a != b:
+                assert not _within(a, b), (a, b)
+
+
+@pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
+def test_deployment_tree_never_writable_by_manager_unit(scheme) -> None:
+    """spec §R3：enforcement plane（/opt/cortex、env 檔、codex hooks）對服務唯讀。"""
+    plan = generate_plan(scheme)
+    unit = build_manager_unit(scheme, DEFAULT_LAYOUT)
+    paths = DEFAULT_LAYOUT.asset_paths()
+    for rwp in unit.read_write_paths:
+        assert not _within(rwp, DEFAULT_LAYOUT.deploy_root), rwp
+    for entry in plan.entries:
+        if entry.owner_class is not OwnerClass.DEPLOYMENT:
+            continue
+        target = paths[entry.asset_id]
+        assert not any(_within(target, rwp) for rwp in unit.read_write_paths), entry.asset_id
+
+
+@pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
+def test_read_write_paths_are_consistent_with_protect_home(scheme) -> None:
+    """`ProtectHome=yes` 會讓 /home、/root 不可見——RWP 落在那裡等於保證靜默失效。"""
+    unit = build_manager_unit(scheme, DEFAULT_LAYOUT)
+    for rwp in unit.read_write_paths:
+        assert not rwp.startswith("/home/"), rwp
+        assert not rwp.startswith("/root"), rwp
+
+
+@pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
+def test_extra_write_paths_all_carry_a_reason(scheme) -> None:
+    for extra in DEFAULT_LAYOUT.manager_extra_write_paths() + DEFAULT_LAYOUT.job_extra_write_paths():
+        assert extra.path.startswith("/")
+        assert extra.reason.strip(), extra.path
+
+
+@pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
+def test_job_unit_read_write_paths_exclude_manager_owned(scheme) -> None:
+    """降權 job 側：RWP 不得覆蓋任何 Manager-owned／deployment 資產。"""
+    plan = generate_plan(scheme)
+    job_layout = DEFAULT_LAYOUT.with_job_segment("%i")
+    unit = build_job_unit(scheme, DEFAULT_LAYOUT)
+    paths = job_layout.asset_paths()
+    for entry in plan.entries:
+        if entry.owner_class not in (OwnerClass.MANAGER_STATE, OwnerClass.DEPLOYMENT):
+            continue
+        target = paths[entry.asset_id]
+        builder = scheme.resolve(Principal.BUILDER)
+        if builder in plan.all_writable_accounts(entry):
+            continue  # spool 之類以 ACL 明示授權者（見下一個測試）
+        assert not any(_within(target, rwp) for rwp in unit.read_write_paths), (
+            scheme.scheme_id, entry.asset_id, unit.read_write_paths,
+        )
+
+
+@pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
+def test_job_unit_read_write_paths_match_builder_writable_assets(scheme) -> None:
+    """job 側同樣是機械導出：涵蓋 builder 需寫的每一項、且僅此。"""
+    plan = generate_plan(scheme)
+    job_layout = DEFAULT_LAYOUT.with_job_segment("%i")
+    builder = scheme.resolve(Principal.BUILDER)
+    assert builder is not None
+    unit = build_job_unit(scheme, DEFAULT_LAYOUT)
+    targets = required_write_targets(plan, job_layout, builder)
+    assert targets
+    for asset_id, target in targets.items():
+        assert any(_within(target, rwp) for rwp in unit.read_write_paths), (asset_id, target)
+    extras = {e.path for e in job_layout.job_extra_write_paths()}
+    for rwp in unit.read_write_paths:
+        if rwp in extras:
+            continue
+        assert any(_within(t, rwp) for t in targets.values()), rwp
+
+
+def test_read_write_paths_shift_when_registry_grows() -> None:
+    """機械性反證：把 Manager 可寫資產拿掉一項，導出的 RWP 必須跟著變。"""
+    plan = generate_plan(TWO_WAY_SCHEME)
+    full = read_write_paths(plan, DEFAULT_LAYOUT, TWO_WAY_SCHEME.durable_state_owner)
+    trimmed_assets = tuple(a for a in ASSET_REGISTRY if a.asset_id != "dispatch-specs-tree")
+    trimmed_plan = generate_plan(TWO_WAY_SCHEME, trimmed_assets)
+    trimmed = read_write_paths(trimmed_plan, DEFAULT_LAYOUT, TWO_WAY_SCHEME.durable_state_owner)
+    assert "/var/lib/cortex/specs" in full
+    assert "/var/lib/cortex/specs" not in trimmed
+
+
+# ---------------------------------------------------------------------------
+# unit 內容
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
+def test_manager_unit_runs_as_service_account_never_root(scheme) -> None:
+    """裁決：cortex 任何元件永不具 root。"""
+    unit = build_manager_unit(scheme, DEFAULT_LAYOUT)
+    assert f"User={scheme.durable_state_owner}" in unit.content
+    assert "User=root" not in unit.content
+    assert unit.account == scheme.durable_state_owner
+    assert "AmbientCapabilities=\n" in unit.content
+    assert "CapabilityBoundingSet=\n" in unit.content
+
+
+@pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
+def test_manager_unit_environment_file_is_fail_closed(scheme) -> None:
+    """spec §R3：`EnvironmentFile=-` 的靜默容忍必須改為缺檔即拒絕啟動。"""
+    unit = build_manager_unit(scheme, DEFAULT_LAYOUT)
+    assert f"EnvironmentFile={DEFAULT_LAYOUT.env_file}" in unit.content
+    assert "EnvironmentFile=-" not in unit.content
+
+
+@pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
+def test_manager_unit_carries_every_hardening_directive_with_a_comment(scheme) -> None:
+    """每一項加固都必須帶「為何」的註解——這是可審查性要求，不只是設定。"""
+    unit = build_manager_unit(scheme, DEFAULT_LAYOUT)
+    lines = unit.content.splitlines()
+    for key, value, why in permgen._HARDENING:
+        directive = f"{key}={value}"
+        assert directive in lines, directive
+        index = lines.index(directive)
+        assert lines[index - 1].startswith("# "), directive
+        assert why.split("：")[0][:6] in lines[index - 1], directive
+    for required in ("NoNewPrivileges=yes", "ProtectSystem=strict", "ProtectHome=yes",
+                     "PrivateTmp=yes"):
+        assert required in unit.content, required
+
+
+@pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
+def test_manager_unit_execstart_lives_in_root_owned_deploy_tree(scheme) -> None:
+    unit = build_manager_unit(scheme, DEFAULT_LAYOUT)
+    assert unit.exec_start.startswith(DEFAULT_LAYOUT.deploy_root + "/")
+    assert f"ExecStart={unit.exec_start}" in unit.content
+    assert f"WorkingDirectory={DEFAULT_LAYOUT.agents_root}" in unit.content
+
+
+@pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
+def test_job_unit_hardcodes_the_downgraded_identity(scheme) -> None:
+    """降權/提權分界線：`User=` 寫死在 root-owned unit 檔，呼叫端選不了 UID。"""
+    unit = build_job_unit(scheme, DEFAULT_LAYOUT)
+    builder = scheme.resolve(Principal.BUILDER)
+    assert unit.account == builder
+    assert f"User={builder}" in unit.content
+    assert "User=root" not in unit.content
+    assert unit.install_path == "/etc/systemd/system/cortex-job@.service"
+    assert "%i" in unit.content
+
+
+@pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
+def test_job_unit_scrubs_github_token(scheme) -> None:
+    """spec §R10 Phase 2 第 5 條：降權啟動器不傳遞 gh token。"""
+    unit = build_job_unit(scheme, DEFAULT_LAYOUT)
+    assert "Environment=GH_TOKEN=\n" in unit.content
+    assert "Environment=GITHUB_TOKEN=\n" in unit.content
+
+
+@pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
+def test_job_unit_command_comes_from_manager_owned_spool(scheme) -> None:
+    """job 不得改寫自己的命令列：run.sh 落在 svc-owned spool，job 只讀。"""
+    unit = build_job_unit(scheme, DEFAULT_LAYOUT)
+    assert DEFAULT_LAYOUT.job_spool_root in unit.exec_start
+    assert not any(
+        _within(DEFAULT_LAYOUT.job_spool_root, rwp) for rwp in unit.read_write_paths
+    )
+
+
+def test_units_are_deterministic() -> None:
+    a = build_manager_unit(TWO_WAY_SCHEME, DEFAULT_LAYOUT)
+    b = build_manager_unit(TWO_WAY_SCHEME, DEFAULT_LAYOUT)
+    assert a.content == b.content
+    assert a.to_dict() == b.to_dict()
+
+
+def test_three_way_scheme_changes_the_service_account() -> None:
+    """保留三分彈性：只換 config，unit 的身分與 RWP 隨之收緊、程式碼零改動。"""
+    two = build_manager_unit(TWO_WAY_SCHEME, DEFAULT_LAYOUT)
+    three = build_manager_unit(THREE_WAY_SCHEME, DEFAULT_LAYOUT)
+    assert two.account == "cortex-svc"
+    assert three.account == "cortex-manager"
+    # 三分下 reviewer/planner 不再是 durable state owner ⇒ verdict 不再落在
+    # Manager 的可寫面（worktree pool 容器仍由 Manager 建子目錄）。
+    plan = generate_plan(THREE_WAY_SCHEME)
+    verdict = plan.by_id("review-verdict")
+    assert THREE_WAY_SCHEME.durable_state_owner not in plan.all_writable_accounts(verdict)
+
+
+# ---------------------------------------------------------------------------
+# polkit 規則（A 方案 transient／B 方案 template，兩案都必須完整可用）
+# ---------------------------------------------------------------------------
+
+ALL_PLANS = [PolkitPlan.TRANSIENT, PolkitPlan.TEMPLATE]
+
+
+@pytest.mark.parametrize("plan", ALL_PLANS, ids=lambda p: p.value)
+@pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
+def test_polkit_rule_binds_svc_to_job_units_only(scheme, plan) -> None:
+    rule = build_polkit_rule(scheme, DEFAULT_LAYOUT, plan=plan)
+    assert rule.plan is plan
+    assert rule.subject_account == scheme.durable_state_owner
+    assert rule.target_account == scheme.resolve(Principal.BUILDER)
+    assert rule.install_path == "/etc/polkit-1/rules.d/49-cortex-downgrade.rules"
+    assert rule.allowed_verbs == ("start", "stop")
+    assert rule.unit_pattern.startswith("^cortex-job")
+    assert rule.unit_pattern.endswith("$")
+
+
+def test_transient_plan_unit_prefix_is_the_job_runner_contract() -> None:
+    """A 方案的 unit 名前綴與 coordinator/job_runner.UNIT_NAME_PREFIX 是成對契約。"""
+    rule = build_polkit_rule(TWO_WAY_SCHEME, DEFAULT_LAYOUT, plan=PolkitPlan.TRANSIENT)
+    assert permgen.transient_unit_prefix(DEFAULT_LAYOUT) == "cortex-job-"
+    assert rule.unit_pattern.startswith("^cortex-job-")
+    assert "job_runner.UNIT_NAME_PREFIX" in rule.content
+
+
+def test_template_plan_matches_the_generated_template_unit() -> None:
+    """B 方案的 pattern 必須恰好認得 build_job_unit() 產出的模板實例。"""
+    rule = build_polkit_rule(TWO_WAY_SCHEME, DEFAULT_LAYOUT, plan=PolkitPlan.TEMPLATE)
+    unit = build_job_unit(TWO_WAY_SCHEME, DEFAULT_LAYOUT)
+    assert unit.unit_name == "cortex-job@.service"
+    assert rule.unit_pattern.startswith("^cortex-job@")
+    assert evaluate_polkit(
+        rule, user=rule.subject_account, action_id=permgen.POLKIT_ACTION,
+        unit="cortex-job@abc.service", verb="start",
+    ) == "YES"
+
+
+@pytest.mark.parametrize("plan", ALL_PLANS, ids=lambda p: p.value)
+def test_polkit_rule_has_exactly_one_grant(plan) -> None:
+    """審查者的一眼結論：全檔只有一個 YES 出口。"""
+    rule = build_polkit_rule(TWO_WAY_SCHEME, DEFAULT_LAYOUT, plan=plan)
+    assert rule.content.count("polkit.Result.YES") == 1
+    assert rule.content.count("polkit.addRule(") == 1
+    assert 'action.id !== "org.freedesktop.systemd1.manage-units"' in rule.content
+    assert "if (!unit || !verb)" in rule.content
+
+
+def test_template_plan_documents_the_transient_closure() -> None:
+    """B 方案必須明寫「為何 transient unit 一律拒」——那是提權的封口。"""
+    rule = build_polkit_rule(TWO_WAY_SCHEME, DEFAULT_LAYOUT, plan=PolkitPlan.TEMPLATE)
+    assert "StartTransientUnit" in rule.content
+    for forbidden in permgen.POLKIT_FORBIDDEN_PROPERTIES:
+        assert forbidden in rule.content, forbidden
+    assert rule.residual_risks == (), "B 方案在 OS 層無殘餘（User= 由 root-owned 檔強制）"
+
+
+def test_transient_plan_states_its_residual_risk_honestly() -> None:
+    """A 方案的殘餘風險必須寫在規則檔裡：polkit 看不到 User=／--uid=。"""
+    rule = build_polkit_rule(TWO_WAY_SCHEME, DEFAULT_LAYOUT, plan=PolkitPlan.TRANSIENT)
+    assert rule.residual_risks, "A 方案必須明列殘餘風險"
+    joined = " ".join(rule.residual_risks)
+    assert "User=" in joined
+    assert "同 UID" in joined
+    # 二分方案下 reviewer／planner 與 Manager 併帳，故持有同一個 grant。
+    assert "reviewer" in joined and "planner" in joined
+    for risk in rule.residual_risks:
+        assert risk in rule.content, "殘餘風險必須逐條出現在規則檔開頭"
+    # 指出替代方案，operator 才有得選。
+    assert "--template" in rule.content
+
+
+def test_three_way_transient_risk_drops_the_model_persona_clause() -> None:
+    """三分下 reviewer／planner 不再與 Manager 併帳——那條風險自動消失。"""
+    rule = build_polkit_rule(THREE_WAY_SCHEME, DEFAULT_LAYOUT, plan=PolkitPlan.TRANSIENT)
+    joined = " ".join(rule.residual_risks)
+    assert "User=" in joined                 # polkit 的結構限制仍在
+    assert "reviewer" not in joined          # 但併帳那條不再成立
+
+
+def _matrix(prefix: str):
+    ok = f"{prefix}abc-1.service"
+    return [
+        (ok, "start", "YES"),
+        (ok, "stop", "YES"),
+        (None, None, "NO"),                       # transient 無明細／明細缺席
+        ("run-u1234.service", None, "NO"),
+        ("cortex-manager.service", "start", "NO"),
+        ("sshd.service", "start", "NO"),
+        (f"evil-{prefix}x.service", "start", "NO"),
+        (f"{ok}.evil", "start", "NO"),
+        (ok, "reload", "NO"),
+        (ok, "mask", "NO"),
+    ]
+
+
+@pytest.mark.parametrize("plan", ALL_PLANS, ids=lambda p: p.value)
+def test_polkit_decision_matrix(plan) -> None:
+    """polkit 無法本機執行——以規則常數的 Python 鏡像測產生邏輯。"""
+    rule = build_polkit_rule(TWO_WAY_SCHEME, DEFAULT_LAYOUT, plan=plan)
+    prefix = "cortex-job-" if plan is PolkitPlan.TRANSIENT else "cortex-job@"
+    for unit, verb, expected in _matrix(prefix):
+        got = evaluate_polkit(
+            rule, user="cortex-svc", action_id=permgen.POLKIT_ACTION, unit=unit, verb=verb,
+        )
+        assert got == expected, (plan.value, unit, verb, got)
+    # 其他 action：svc 的一切其他 polkit 面一律拒。
+    for action_id in ("org.freedesktop.systemd1.reload-daemon",
+                      "org.freedesktop.login1.power-off"):
+        assert evaluate_polkit(
+            rule, user="cortex-svc", action_id=action_id, unit="x.service", verb="start",
+        ) == "NO"
+    # 其他 subject 不受本規則干涉。
+    for user in ("operator", "cortex-builder", "root"):
+        assert evaluate_polkit(
+            rule, user=user, action_id=permgen.POLKIT_ACTION,
+            unit=f"{prefix}abc.service", verb="start",
+        ) == "NOT_HANDLED"
+
+
+@pytest.mark.parametrize("plan", ALL_PLANS, ids=lambda p: p.value)
+def test_plans_never_authorise_the_other_plans_unit_shape(plan) -> None:
+    """A 的規則不放行 B 的模板實例，反之亦然——兩案不得互相擴大授權面。"""
+    rule = build_polkit_rule(TWO_WAY_SCHEME, DEFAULT_LAYOUT, plan=plan)
+    other = "cortex-job@abc.service" if plan is PolkitPlan.TRANSIENT else "cortex-job-abc.service"
+    assert evaluate_polkit(
+        rule, user="cortex-svc", action_id=permgen.POLKIT_ACTION, unit=other, verb="start",
+    ) == "NO"
+
+
+@pytest.mark.parametrize("plan", ALL_PLANS, ids=lambda p: p.value)
+def test_polkit_mirror_and_rule_text_share_the_same_constants(plan) -> None:
+    """鏡像不可與規則檔漂移：verbs 與 unit regex 必須逐字出現在 JS 內。"""
+    rule = build_polkit_rule(TWO_WAY_SCHEME, DEFAULT_LAYOUT, plan=plan)
+    for verb in rule.allowed_verbs:
+        assert f'verb !== "{verb}"' in rule.content
+    assert f"/{rule.unit_pattern}/.test(unit)" in rule.content
+    assert f'subject.user !== "{rule.subject_account}"' in rule.content
+
+
+def test_transient_unit_properties_share_the_template_hardening() -> None:
+    """A 方案的 --property= 清單與 B 方案模板 unit 同源（同一加固表＋同一份 RWP）。"""
+    props = permgen.transient_unit_properties(TWO_WAY_SCHEME, DEFAULT_LAYOUT)
+    unit = build_job_unit(TWO_WAY_SCHEME, DEFAULT_LAYOUT)
+    for key, value, _why in permgen._HARDENING:
+        assert f"--property={key}={value}" in props, key
+    for rwp in unit.read_write_paths:
+        assert f"--property=ReadWritePaths={rwp}" in props, rwp
+    assert all(p.startswith("--property=") for p in props)
+
+
+# ---------------------------------------------------------------------------
+# 非執行保證（維持 permgen 的無特權靜態測試不變式）
+# ---------------------------------------------------------------------------
+
+def test_generators_return_strings_only() -> None:
+    unit = build_manager_unit(TWO_WAY_SCHEME, DEFAULT_LAYOUT)
+    job = build_job_unit(TWO_WAY_SCHEME, DEFAULT_LAYOUT)
+    rule = build_polkit_rule(TWO_WAY_SCHEME, DEFAULT_LAYOUT)
+    for blob in (unit.content, job.content, rule.content):
+        assert isinstance(blob, str) and blob
+
+
+def test_permgen_never_touches_the_filesystem() -> None:
+    """靜態保證：新增的 unit／polkit 產生器仍不含任何 IO 或執行面。"""
+    src = inspect.getsource(permgen)
+    for forbidden in ("subprocess", "os.system", "os.chown", "os.chmod",
+                      "open(", "write_text", "mkdir", "shutil"):
+        assert forbidden not in src, forbidden
+
+
+def test_scaffold_directories_are_command_strings_only() -> None:
+    dirs = DEFAULT_LAYOUT.scaffold_directories(TWO_WAY_SCHEME)
+    assert dirs
+    seen = set()
+    for path, owner, group, mode in dirs:
+        assert path.startswith("/")
+        assert path not in seen, f"骨架目錄重複：{path}"
+        seen.add(path)
+        assert owner and group
+        assert 0 <= mode <= 0o777
+    # 保護資產的父層一律 root 擁有（父目錄可寫者能 unlink/rename 子物件）。
+    by_path = {p: (o, m) for p, o, _g, m in dirs}
+    assert by_path[DEFAULT_LAYOUT.builder_home][0] == "root"
+    assert by_path[f"{DEFAULT_LAYOUT.builder_home}/.codex"][0] == "root"
+    assert by_path[DEFAULT_LAYOUT.svc_home][0] == "root"
+    assert by_path[DEFAULT_LAYOUT.deploy_root][0] == "root"
+
+
+def test_commands_with_real_layout_have_no_placeholder_left() -> None:
+    """runbook 引用形式：帶 layout 後輸出不再有 <PATH:...> placeholder。"""
+    plan = generate_plan(TWO_WAY_SCHEME)
+    lines = permgen.plan_to_commands(plan, path_of=permgen.asset_paths())
+    commands = [ln for ln in lines if ln.strip() and not ln.lstrip().startswith("#")]
+    assert commands
+    assert not any("<PATH:" in ln for ln in commands)
+    # per-job 資產以註解形式輸出（可讀、不會被誤執行）。
+    for line in lines:
+        if permgen.PER_JOB_SEGMENT in line:
+            assert line.lstrip().startswith("#"), line
+
+
+def test_custom_layout_needs_no_code_change() -> None:
+    """layout 是純 config：換部署位置不必改產生器一行程式碼。"""
+    alt = PathLayout(
+        agents_root="/srv/cortex",
+        worktree_root="/srv/cortex/wt",
+        deploy_root="/usr/local/cortex",
+        instance="alpha",
+    )
+    unit = build_manager_unit(TWO_WAY_SCHEME, alt)
+    assert unit.unit_name == "alpha-manager.service"
+    assert unit.exec_start == "/usr/local/cortex/venv/bin/cortex service run"
+    assert all(p.startswith(("/srv/cortex", "/var/lib/cortex-svc")) for p in unit.read_write_paths)
+    assert build_polkit_rule(TWO_WAY_SCHEME, alt, plan=PolkitPlan.TRANSIENT) \
+        .unit_pattern.startswith("^alpha-job-")
+    assert build_polkit_rule(TWO_WAY_SCHEME, alt, plan=PolkitPlan.TEMPLATE) \
+        .unit_pattern.startswith("^alpha-job@")


### PR DESCRIPTION
## 摘要

trust-root **Phase 2b** 的兩件事：(1) permgen 擴充為機械產生 **systemd unit** 與
**polkit 規則**；(2) 把 `docs/superpowers/runbooks/trust-root-phase2b-setup.md` 從草稿
收斂為**可執行版**——每一步可直接複製執行、每步可驗證、錯了可回滾。

依 #584 的 **0816 第二輪裁決**（7 個未決點全數收斂）。**本 PR 只交付程式碼與文件**：
不建 UID、不 chown、不動 systemd／polkit／pipx／`~/.agents`，permgen 的無特權靜態測試
不變式維持不變。

## ⚠️ 唯一還需 operator 拍板的一點（請先讀）

裁決寫「`systemd-run` transient unit ＋ polkit 收窄到只能 `User=cortex-builder`」。
#603 實測確認：polkit 的 `org.freedesktop.systemd1.manage-units` **只暴露 unit 名稱與
verb，不暴露 `User=`／`--uid=`**——「只能降到 job 帳號」這一半 **polkit 無法強制**。
因此第 5 步把兩案**都**寫成完整可執行：

| | **A：`systemd-run` transient unit** | **B：root-owned 模板 unit** |
|---|---|---|
| 程式碼狀態 | **已落地**（#603，`PSC_JOB_RUNNER=systemd-run`） | 需 Manager 端改走 `systemctl start cortex-job@<id>`，**待排工項** |
| 「降到哪個帳號」由誰強制 | Manager 端封閉 argv 產生器（code level） | **OS**（`User=` 硬寫死在 root-owned unit 檔） |
| 殘餘風險 | 與 `cortex-svc` 同 UID 的任何行程都可請求任意 `User=`（含 root）；**二分下 reviewer／planner 跑模型且與 Manager 併帳** | 無 |
| 與「是否提前三分」 | **強相關**（三分把風險縮回「只有 Manager 自己」） | 不相關 |

runbook 的 5-A-5 (4) 是一條**預期會成功**的實測（`sudo -u cortex-svc systemd-run --uid=0`），
用途是讓 operator 親眼確認 A 方案接受了什麼。**請一併裁決「是否提前三分」**——permgen
已參數化，只需把命令中的 `two-way` 換成 `three-way`。

## 工作 1：permgen 擴充

### `PathLayout`：把裁決的路徑變成機器可讀 config
`agents_root=/var/lib/cortex`、`worktree_root=/var/lib/cortex/worktree`、
`deploy_root=/opt/cortex`。`asset_paths()` 對 R1 登記表**每一項**給出真實絕對路徑
（等式測試：無遺漏、無多餘）。`scaffold_directories()` 出非登記表資產的父層骨架，
原則是**凡保護資產的父目錄一律 root 擁有**——父目錄可寫者能 unlink／rename 子物件。

### systemd unit
- **Manager system-level unit**：`User=` 服務帳號（永不 root）、`ExecStart` 指
  root-owned 部署樹、`EnvironmentFile=` **無 `-` 前綴＝fail-closed**、27 項加固**逐項
  附「為何」註解**（測試斷言每項都有前置註解）。
- **`ReadWritePaths=` 由 R1 登記表機械導出**（未決 5 定案）。規則只有一條：某帳號可寫
  的資產，目錄取自身、檔案取父目錄，再做最小覆蓋。**等式測試**同時釘住：
  - **無遺漏**——每個 Manager 需寫的資產都被某條覆蓋；
  - **無多餘**——移除任一條就有資產失去覆蓋；
  - **最小性**——沒有任何一條被另一條包含；
  - **一致性**——部署樹永不可寫、RWP 不得落在 `ProtectHome` 遮蔽的 `/home`、`/root`；
  - 非登記表的額外可寫路徑只能經 `ExtraWritePath` 明示宣告，**每條必須附理由**。
- **降權 job 模板 unit**（方案 B）：`User=` 硬寫死、`GH_TOKEN`／`GITHUB_TOKEN` 清空、
  `ExecStart` 讀 Manager-owned spool 的 `run.sh`（job 唯讀 ⇒ 改不了自己的命令列）、
  `CollectMode=inactive-or-failed`；job 側 RWP 同樣機械導出，不含任何 Manager-owned。

### polkit
兩案共用骨架：subject 檢查、action 檢查、**unit／verb 明細缺席即拒**、verb 白名單
（只 `start`/`stop`）、錨定 unit pattern，全檔只有一個放行出口。
- A 的 unit 前綴與 `job_runner.UNIT_NAME_PREFIX` 是**成對契約**（測試釘住）；
  `plan_residual_risk()` 由 `UidScheme` **機械導出**殘餘風險並逐條寫進規則檔開頭
  （三分下 reviewer／planner 併帳那條自動消失，測試釘住這個差異）。
- B 的 `residual_risks` 為空，檔頭寫明「為何 transient unit 一律拒」。
- 兩案互不放行對方的 unit 形狀（測試釘住）。
- `evaluate_polkit()` 是規則決策的 Python 鏡像（polkit 無法本機執行），與 JS **共用
  同一組常數**，兩案各跑一份決策矩陣。

### 非執行不變式
三者**只產生內容字串**；靜態測試把 `open(`／`write_text`／`mkdir`／`shutil` 也納入
禁用字串（原本只擋 `subprocess`／`os.system`／`os.chown`／`os.chmod`）。

### CLI
`python -m paulsha_cortex.trust_root {unit,polkit,scaffold}`
（`unit --manager|--job|--job-properties`、`polkit --transient|--template`）；
`permissions --commands --paths` 以真實 layout 路徑輸出，命令可直接執行
（目錄先 `install -d`；尚未建立的葉檔包 `[ ! -e ] ||` 守衛；per-job 資產以註解輸出）。

### 順帶修正
`evidence/*`、`workflow-report-transactions`、`engineering-outcomes`、`gate-ledger`
等**目錄**先前被 token heuristic 誤判為單檔（會產生 `chmod 0600` 到目錄上）；
多 persona 容器分支不再無條件視為目錄（per-job handoff manifest 得到 `0600`）。

## 工作 2：runbook 收斂

`status: draft` → `status: executable`。7 個 `⚠️ 未決` 全數替換為裁決定案表。
結構：**執行前提 ＋ 9 步 ＋ WSL2 風險段 ＋ 附錄**，**24 個 sudo 點、94 個驗證點**。

- **執行前提**（新增）：in-flight job 手動收尾、服務已停、Phase 1 自檢 baseline 存檔、
  登記表等式綠、`sudo` 可用、**polkit 在跑**（缺 polkit ⇒ 降權 fail-closed 全停）、磁碟空間。
- 命令改為**真實絕對路徑**；權限／unit／polkit 一律「產生器輸出 → operator 讀過 →
  落檔」，並附 `diff <(產生器) <(系統檔)` 的漂移檢查。
- **第 3b 節**吸收 #599 的 review verdict 受控通道（`review-verdict-spool` 已進登記表
  ⇒ 權限由第 2 步一併套用）。
- **第 5 步**：A／B 兩案完整（見上）。
- **第 8 步 R9 手動抽驗**（裁決 7）：四族 43 條攻擊命令，每條附確切命令與預期輸出
  （`denied (OK) rc=<非 0>`），加三組 **negative control**（受信任身分做同一件事必須
  成功）與族 3 的「重啟後仍綠」複驗。
- **第 9 步回滾**：每階段各自退路 ＋「全部退回 Phase 1 降級運轉」總回滾。
- **WSL2 風險段**：system unit 開機拉起的驗證流程（`wsl --shutdown` 前後逐項）、
  `ProtectSystem=strict` 誤擋的五步診斷與依機率排序的常見誤擋清單；鐵律是「被擋路徑
  只能經回填登記表 → 重跑 permgen 進入 RWP」。

## 測試

`python3 -m pytest -q` → **3248 passed, 49 subtests passed**。
新增 `tests/test_trust_root_permgen_p2b.py`（61 測試）。

## Checklist

- [x] `changelog.d/p2b-runbook-executable.md` fragment 已新增並 commit
- [x] `CHANGELOG.md [Unreleased]` 有對應 entry
- [x] 全套測試通過
- [x] 未執行任何 root／系統操作；permgen 無特權靜態不變式維持
- [x] `VERSION` 未變動（非 release PR）

Refs #584

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E7w9kaUxAzCCEk7piD5hfK
