### PR TITLE
fix(autonomy): _infer_repo_root 拒收空 .git 目錄並設共享暫存根為搜尋上界

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -348,6 +348,27 @@
   `tests/test_monitor_git_native_reads_506.py`（16 個測試，含量化驗收樁）。
 
 ### Fixed
+- **#565：`/tmp` 的空 `.git` 目錄使 `_infer_repo_root` 全域劫持到 `/tmp`，production
+  推斷與測試皆不 hermetic**——agent sandbox 基礎設施會在 sandbox 存活期間於 `/tmp`
+  暫態 `mkdir` 一個**空的** `.git`（teardown 後消失，`rm` 被防護 hook 擋下只能 `mv`
+  隔離），舊判準 `(parent / ".git").exists()` 把它認作 repo 根，於是任何 `/tmp` 底下
+  （含 pytest `tmp_path`）的 spec 路徑都被推斷成 `/tmp`。這使
+  `tests/test_fix_dispatch_spec_path.py` 的兩個推斷測試在「當下剛好有 sandbox 存活」
+  時必紅，Manager gate ledger 對 builder candidate 重跑全套 pytest 因而拒掉**合格**
+  candidate（`GateContradictionError`，0816 run `workflow-7812abefede9d9b5d601` 實測），
+  且與 builder 真實缺陷混在一起干擾判讀。**production 補兩道判準**：`.git` 必須是**有效**
+  repo 標記——目錄需含 `HEAD`、檔案需以 `gitdir:` 開頭（linked worktree／submodule）——
+  由新增的 `_is_git_repo_root()` 判定，**不 fork `git rev-parse`**（`_infer_repo_root`
+  在派工熱路徑上，對每個 parent 開 subprocess 的代價與 flakiness 都不划算，而檔案級
+  判準已足以排除唯一實測到的偽陽性）；同時新增 `_repo_search_boundaries()`
+  （`TMPDIR`／`/tmp`／`/var/tmp`）作為向上搜尋的**上界**，共享暫存根本身永遠不是任何
+  spec 的 repo 根，其**之下**的真 repo 照常命中。**測試 hermetic 化**：新增
+  `tests/git_fixtures.py`（`make_fake_repo()` 建含 `.git/HEAD` 的完整假 repo，
+  `make_empty_git_dir()` 建污染形狀），六個測試檔不再以空 `.git` 目錄冒充 repo 根；
+  `tests/test_fix_dispatch_spec_path.py` 補 8 個回歸（鏈上空 `.git` 必須穿過、只有空
+  `.git` 時落回既有 fallback、worktree `gitdir:` 檔案仍算 repo 根、共享根即使是有效
+  repo 也不落錨、上界之下的 repo 照常命中……），污染由測試自備，host `/tmp` 的當下
+  狀態不再影響任何判定。
 - **Issue #518：instance config isolation**——`cortex install service` 會遷移 legacy
   instance env，原子產生可驗證的 exact-project monitor config 並保留 rollback；monitor
   不再因父目錄 workspace 掃到 sibling repos，`cortex doctor` 也會從本機 env 檔告警 shared

--- a/changelog.d/infer-repo-root-hermetic.md
+++ b/changelog.d/infer-repo-root-hermetic.md
@@ -1,0 +1,29 @@
+# infer-repo-root-hermetic
+
+- **`#565` `_infer_repo_root` 不再被空 `.git` 目錄劫持，推斷測試 hermetic 化**——
+  agent sandbox 基礎設施會在 sandbox 存活期間於 `/tmp` 暫態 `mkdir` 一個**空的**
+  `.git`（teardown 後消失、`rm` 被防護 hook 擋下），舊判準
+  `(parent / ".git").exists()` 把它當 repo 根，於是任何 `/tmp` 底下（含 pytest
+  `tmp_path`）的 spec 路徑都被推斷成 `/tmp`。後果是 Manager gate ledger 對 builder
+  candidate 重跑全套 pytest 時，只要那一刻 sandbox 存活，
+  `tests/test_fix_dispatch_spec_path.py` 兩測必紅，**合格 candidate 被
+  `GateContradictionError` 拒絕**（0816 run `workflow-7812abefede9d9b5d601` 實測，
+  且與 builder 真實缺陷混在一起干擾判讀）。
+
+  production 兩道判準：**(1) 有效性**——新增 `_is_git_repo_root()`，`.git` 為目錄時
+  必須含 `HEAD`（`git init` 必寫），為檔案時必須以 `gitdir:` 開頭（linked
+  worktree／submodule）；刻意不 fork `git rev-parse`，`_infer_repo_root` 在派工熱
+  路徑上、對每個 parent 開 subprocess 的代價與 flakiness 都不划算，而檔案級判準已
+  足以排除唯一實測到的偽陽性。**(2) 搜尋上界**——新增
+  `_repo_search_boundaries()`（`TMPDIR` / `/tmp` / `/var/tmp`），共享暫存根本身永遠
+  不是任何 spec 的 repo 根，向上搜尋到此即停；上界**之下**的真 repo（`/tmp/x/repo`）
+  照常命中。
+
+  測試 hermetic 化：新增 `tests/git_fixtures.py`（`make_fake_repo()` 造含
+  `.git/HEAD` 的完整假 repo、`make_empty_git_dir()` 造污染形狀），全 repo 六個測試
+  檔改用它，不再以「`mkdir .git` 空目錄」冒充 repo 根。
+  `tests/test_fix_dispatch_spec_path.py` 補 8 個回歸：鏈上有空 `.git` 時必須穿過、
+  只有空 `.git` 時落回既有 fallback、worktree 的 `gitdir:` 檔案仍算 repo 根、非
+  `gitdir:` 檔案不算、共享根即使是**有效** repo 也不落錨、上界之下的 repo 照常命中、
+  `/tmp` 與 `TMPDIR` 確實在上界集合內。污染一律由測試自備，host `/tmp` 當下的狀態
+  不再影響任何判定。

--- a/paulsha_cortex/coordinator/autonomy.py
+++ b/paulsha_cortex/coordinator/autonomy.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import tempfile
 from pathlib import Path
 from typing import Callable
 
@@ -234,6 +235,54 @@ def _normalize_depends_on(value: object) -> list[str]:
     return []
 
 
+def _is_git_repo_root(candidate: Path) -> bool:
+    """`<candidate>/.git` 是否為**有效** git repo 標記（#565）。
+
+    原判準是 `(candidate / ".git").exists()`，把「存在」等同「是 repo」。實測
+    （#565）agent sandbox 基礎設施會在 `/tmp` **暫態**建立一個 `mkdir` 出來的
+    **空 `.git` 目錄**（sandbox 存活期間存在、teardown 消失），於是任何 `/tmp`
+    底下的 spec 路徑在向上搜尋時都會停在 `/tmp`，repo 根被全域劫持成 `/tmp`。
+
+    真 repo 的兩種合法形狀都能不開 subprocess 就分辨：
+    - 正規 repo：`.git` 是目錄且必含 `HEAD`（`git init` 寫的第一批檔案之一）；
+    - linked worktree／submodule：`.git` 是內含 `gitdir: <path>` 的檔案。
+
+    刻意不呼叫 `git rev-parse --git-dir`：`_infer_repo_root` 落在派工熱路徑上，
+    對每個 parent 都 fork 一次 git 的代價與 flakiness 都不划算，而 `HEAD`／
+    `gitdir:` 這兩個檔案級判準已足以排除「空目錄」這唯一實測到的偽陽性。
+    """
+    git_path = candidate / ".git"
+    if git_path.is_dir():
+        return (git_path / "HEAD").exists()
+    if git_path.is_file():
+        try:
+            head = git_path.read_bytes()[:8]
+        except OSError:
+            return False
+        return head.startswith(b"gitdir:")
+    return False
+
+
+def _repo_search_boundaries() -> frozenset[Path]:
+    """向上搜尋 repo 根時的上界——共享暫存根（#565）。
+
+    `/tmp`（與 `TMPDIR` 指到的任何目錄）是全機器互不相干的行程共用的，誰都能
+    在其下留下 `.git`。共享根本身永遠不是任何 spec 的 repo 根，因此搜尋到這裡
+    就停：`/tmp/<something>/repo` 這種真 repo 仍照常命中（它在上界**之下**），
+    但 `/tmp` 自己與其之上不再是候選。
+
+    另外開一個函式（而非 inline 常數）是為了讓測試能 monkeypatch 出一個 tmp_path
+    內的假共享根，驗證上界語意時不必依賴 host `/tmp` 的實際狀態。
+    """
+    roots: set[Path] = set()
+    for raw in (tempfile.gettempdir(), "/tmp", "/var/tmp"):
+        try:
+            roots.add(Path(raw).resolve())
+        except OSError:  # pragma: no cover - resolve 對不存在路徑不拋，僅防禦
+            continue
+    return frozenset(roots)
+
+
 def _infer_repo_root(spec_path: Path) -> Path:
     configured = paths.repo_root().resolve()
     resolved_spec = spec_path.resolve()
@@ -244,8 +293,11 @@ def _infer_repo_root(spec_path: Path) -> Path:
         pass
 
     agents_dir = Path.home() / ".agents"
+    boundaries = _repo_search_boundaries()
     for parent in [resolved_spec, *resolved_spec.parents]:
-        if (parent / ".git").exists():
+        if parent in boundaries:
+            break
+        if _is_git_repo_root(parent):
             if parent == agents_dir or parent.name in {".agents", "agents"}:
                 continue
             return parent

--- a/tests/git_fixtures.py
+++ b/tests/git_fixtures.py
@@ -1,0 +1,35 @@
+"""測試用的假 git repo fixture（#565）。
+
+`_infer_repo_root`（`coordinator/autonomy.py`）自 #565 起不再把「`.git` 存在」
+當作 repo 根，而要求 `.git` 是**有效** repo 標記：目錄含 `HEAD`，或是內含
+`gitdir:` 的檔案（linked worktree）。理由見該函式 docstring——agent sandbox
+基礎設施會在 `/tmp` 暫態 `mkdir` 一個空 `.git`，舊判準會把 repo 根全域劫持
+到 `/tmp`。
+
+測試若只 `(<root> / ".git").mkdir()`，造出的正是那種被判為「非 repo」的空目錄。
+需要一個「看起來像 repo 根」的目錄時一律用 `make_fake_repo()`：它產生的形狀與
+真 `git init` 的最小交集一致，`.git` 目錄本身也不需要真的跑 git。
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def make_fake_repo(root: Path, *, branch: str = "main") -> Path:
+    """在 `root` 建出被 `_infer_repo_root` 認可的最小 repo 標記，回傳 `root`。"""
+    git_dir = root / ".git"
+    git_dir.mkdir(parents=True, exist_ok=True)
+    (git_dir / "HEAD").write_text(f"ref: refs/heads/{branch}\n", encoding="utf-8")
+    return root
+
+
+def make_empty_git_dir(root: Path) -> Path:
+    """建出 #565 實測到的**污染形狀**：`mkdir` 出來、沒有 `HEAD` 的空 `.git`。
+
+    回傳該 `.git` 路徑。專供「路徑鏈上有空 `.git` 時不得被當 repo 根」的回歸
+    測試使用——它讓測試自備污染，不必依賴 host `/tmp` 當下是否真的被污染。
+    """
+    git_dir = root / ".git"
+    git_dir.mkdir(parents=True, exist_ok=True)
+    return git_dir

--- a/tests/test_coordinator_dependency_ancestry.py
+++ b/tests/test_coordinator_dependency_ancestry.py
@@ -6,6 +6,7 @@ import unittest
 from pathlib import Path
 from types import SimpleNamespace
 
+from git_fixtures import make_fake_repo
 from paulsha_cortex.coordinator import autonomy, completion, verification
 from paulsha_cortex.coordinator.dispatcher import Dispatcher
 from paulsha_cortex.coordinator.launcher import LaunchHandle
@@ -181,7 +182,7 @@ class DependencyAncestryDispatchTests(unittest.TestCase):
     def test_dispatch_ready_uses_target_ref_sha_for_worktree_base(self) -> None:
         with tempfile.TemporaryDirectory() as d:
             root = Path(d)
-            (root / ".git").mkdir()
+            make_fake_repo(root)
             handoff = root / "handoff"
             target_sha = "c" * 40
             candidate = "b" * 40
@@ -228,7 +229,7 @@ class DependencyAncestryDispatchTests(unittest.TestCase):
     def test_dispatch_ready_blocks_when_upstream_candidate_is_stale(self) -> None:
         with tempfile.TemporaryDirectory() as d:
             root = Path(d)
-            (root / ".git").mkdir()
+            make_fake_repo(root)
             handoff = root / "handoff"
             target_sha = "c" * 40
             candidate = "b" * 40
@@ -272,7 +273,7 @@ class DependencyAncestryDispatchTests(unittest.TestCase):
     def test_dispatch_ready_blocks_dependency_target_branch_mismatch(self) -> None:
         with tempfile.TemporaryDirectory() as d:
             root = Path(d)
-            (root / ".git").mkdir()
+            make_fake_repo(root)
             handoff = root / "handoff"
             target_sha = "c" * 40
             candidate = "b" * 40

--- a/tests/test_coordinator_dispatch_discipline_e2e.py
+++ b/tests/test_coordinator_dispatch_discipline_e2e.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest import mock
 
+from git_fixtures import make_fake_repo
 from paulsha_cortex.coordinator import autonomy, completion, manager, review, verification
 from paulsha_cortex.coordinator.dispatcher import Dispatcher
 from paulsha_cortex.coordinator.launcher import LaunchHandle
@@ -79,7 +80,7 @@ def _create_slice(
 ) -> dict:
     slice_id = job["task"]
     contract = _verification_contract(docs_class=docs_class)
-    (root / ".git").mkdir(exist_ok=True)
+    make_fake_repo(root)
     spec_path = root / "specs" / f"{slice_id}.md"
     plan_path = root / "docs" / "superpowers" / "plans" / f"{slice_id}.md"
     spec_path.parent.mkdir(parents=True, exist_ok=True)
@@ -670,7 +671,7 @@ class DispatchDisciplineCanaryTests(unittest.TestCase):
     def test_dispatch_ready_requires_target_base_to_include_upstream_candidates(self) -> None:
         with tempfile.TemporaryDirectory() as d:
             root = Path(d)
-            (root / ".git").mkdir()
+            make_fake_repo(root)
             handoff = root / "handoff"
             target_sha = "c" * 40
             candidate = "b" * 40

--- a/tests/test_coordinator_manager.py
+++ b/tests/test_coordinator_manager.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest import mock
 
+from git_fixtures import make_fake_repo
 from paulsha_cortex.coordinator import manager
 from paulsha_cortex.coordinator.autonomy import dispatch_ready
 from paulsha_cortex.coordinator.registry import JobRegistry
@@ -160,7 +161,7 @@ def _create_slice(
 ) -> dict:
     slice_id = job["task"]
     contract = _verification_contract(docs_class=docs_class)
-    (root / ".git").mkdir(exist_ok=True)
+    make_fake_repo(root)
     spec_path = root / "specs" / f"{slice_id}.md"
     plan_path = root / "docs" / "superpowers" / "plans" / f"{slice_id}.md"
     spec_path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/test_coordinator_operator_actions.py
+++ b/tests/test_coordinator_operator_actions.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import pytest
 
+from git_fixtures import make_fake_repo
 from paulsha_cortex.coordinator import manager, manager_daemon, verification
 from paulsha_cortex.coordinator.dispatcher import Dispatcher
 from paulsha_cortex.coordinator.launcher import LaunchHandle
@@ -163,7 +164,7 @@ def _create_slice_in_needs_human(
 
 def test_retry_build_dispatches_new_builder_and_clears_current_refs(tmp_path):
     repo_root = tmp_path / "repo"
-    (repo_root / ".git").mkdir(parents=True, exist_ok=True)
+    make_fake_repo(repo_root)
     state_path = tmp_path / "runtime" / "coordinator" / "jobs.json"
     registry = JobRegistry(state_path=state_path)
     _create_slice_in_needs_human(registry, repo_root=repo_root, slice_id="slice-a")
@@ -204,7 +205,7 @@ def test_retry_build_dispatches_new_builder_and_clears_current_refs(tmp_path):
 
 def test_retry_review_rejected_without_verified_evidence(tmp_path):
     repo_root = tmp_path / "repo"
-    (repo_root / ".git").mkdir(parents=True, exist_ok=True)
+    make_fake_repo(repo_root)
     state_path = tmp_path / "runtime" / "coordinator" / "jobs.json"
     registry = JobRegistry(state_path=state_path)
     registry_slice = _create_slice_in_needs_human(registry, repo_root=repo_root, slice_id="slice-a")
@@ -233,7 +234,7 @@ def test_retry_review_rejected_without_verified_evidence(tmp_path):
 
 def test_abandon_marks_slice_failed_and_records_result(tmp_path):
     repo_root = tmp_path / "repo"
-    (repo_root / ".git").mkdir(parents=True, exist_ok=True)
+    make_fake_repo(repo_root)
     state_path = tmp_path / "runtime" / "coordinator" / "jobs.json"
     registry = JobRegistry(state_path=state_path)
     _create_slice_in_needs_human(registry, repo_root=repo_root, slice_id="slice-a")
@@ -268,7 +269,7 @@ def test_abandon_supersedes_stale_handoff_manifest(tmp_path):
     # （run_tick 的放行判定已改成跟 registry 對帳，不依賴這個標記，見
     # dispatch_gate_scan/_manifest_still_blocks_fanout；這裡純粹驗證稽核可見性）。
     repo_root = tmp_path / "repo"
-    (repo_root / ".git").mkdir(parents=True, exist_ok=True)
+    make_fake_repo(repo_root)
     state_path = tmp_path / "runtime" / "coordinator" / "jobs.json"
     registry = JobRegistry(state_path=state_path)
     _create_slice_in_needs_human(registry, repo_root=repo_root, slice_id="slice-a")
@@ -306,7 +307,7 @@ def test_abandon_supersedes_stale_handoff_manifest(tmp_path):
 
 def test_runtime_status_provider_includes_attention_next_actions(tmp_path):
     repo_root = tmp_path / "repo"
-    (repo_root / ".git").mkdir(parents=True, exist_ok=True)
+    make_fake_repo(repo_root)
     handoff_dir = tmp_path / "handoff"
     handoff_dir.mkdir(parents=True, exist_ok=True)
     state_path = tmp_path / "runtime" / "coordinator" / "jobs.json"

--- a/tests/test_fanout_plan_pinning_cross_repo.py
+++ b/tests/test_fanout_plan_pinning_cross_repo.py
@@ -4,6 +4,7 @@ import os
 from pathlib import Path
 import pytest
 
+from git_fixtures import make_fake_repo
 from paulsha_cortex.coordinator import autonomy
 
 
@@ -33,8 +34,8 @@ def test_infer_repo_root_cross_repo(tmp_path: Path, monkeypatch: pytest.MonkeyPa
     """_infer_repo_root 應對 spec 檔解析其所屬 repo_root，無視 manager 的 PSC_REPO_ROOT 設定。"""
     repo_a = tmp_path / "repo_a"
     repo_b = tmp_path / "repo_b"
-    (repo_a / ".git").mkdir(parents=True)
-    (repo_b / ".git").mkdir(parents=True)
+    make_fake_repo(repo_a)
+    make_fake_repo(repo_b)
 
     spec_path = repo_a / "specs" / "feature-cross.md"
     spec_path.parent.mkdir(parents=True)
@@ -50,8 +51,8 @@ def test_pin_dispatch_inputs_cross_repo(tmp_path: Path, monkeypatch: pytest.Monk
     """pin_dispatch_inputs 應正確將 plan path 解析至 spec 所屬的 repo_a。"""
     repo_a = tmp_path / "repo_a"
     repo_b = tmp_path / "repo_b"
-    (repo_a / ".git").mkdir(parents=True)
-    (repo_b / ".git").mkdir(parents=True)
+    make_fake_repo(repo_a)
+    make_fake_repo(repo_b)
 
     specs_dir = repo_a / "specs"
     specs_dir.mkdir(parents=True)
@@ -85,8 +86,8 @@ def test_ready_and_fanout_consistency_cross_repo(tmp_path: Path, monkeypatch: py
     """斷言 ready 與 fanout (pinning) 對同一組跨 repo 輸入給出一致判定與相同的 repo_root。"""
     repo_a = tmp_path / "repo_a"
     repo_b = tmp_path / "repo_b"
-    (repo_a / ".git").mkdir(parents=True)
-    (repo_b / ".git").mkdir(parents=True)
+    make_fake_repo(repo_a)
+    make_fake_repo(repo_b)
 
     specs_dir = repo_a / "specs"
     specs_dir.mkdir(parents=True)
@@ -120,8 +121,8 @@ def test_ready_and_fanout_missing_plan_consistency(tmp_path: Path, monkeypatch: 
     """當 plan 檔不存在時，pin_dispatch_inputs 指向 repo_a 的正確報錯路徑，落實 fail-closed 判準。"""
     repo_a = tmp_path / "repo_a"
     repo_b = tmp_path / "repo_b"
-    (repo_a / ".git").mkdir(parents=True)
-    (repo_b / ".git").mkdir(parents=True)
+    make_fake_repo(repo_a)
+    make_fake_repo(repo_b)
 
     specs_dir = repo_a / "specs"
     specs_dir.mkdir(parents=True)

--- a/tests/test_fix_dispatch_spec_path.py
+++ b/tests/test_fix_dispatch_spec_path.py
@@ -1,16 +1,47 @@
+"""`_infer_repo_root` 的推斷契約（#565 後 hermetic 化）。
+
+本檔的推斷測試**不得**依賴 host `/tmp` 當下乾淨。#565 實測：agent sandbox
+基礎設施會在 sandbox 存活期間於 `/tmp` 暫態 `mkdir` 一個空的 `.git`，舊判準
+（`.git` 存在即 repo 根）會讓任何 `/tmp` 底下的 spec 路徑（含 pytest 的
+`tmp_path`）被推斷成 `/tmp`，於是這裡的測試在「當下剛好有 sandbox 存活」時
+必紅，Manager gate ledger 的全套 pytest 因此拒掉合格 candidate。
+
+hermetic 手法有二，兩者都用：
+1. 假 repo 一律用 `git_fixtures.make_fake_repo()` 建**完整**標記（`.git/HEAD`），
+   不再只 `mkdir` 一個空 `.git`——空目錄現在依契約就不是 repo 根；
+2. 污染由測試**自備**（`make_empty_git_dir()` / monkeypatch 搜尋上界），
+   host `/tmp` 有沒有 `.git` 都不影響結果。
+"""
+
 from pathlib import Path
 
+import pytest
+
+from git_fixtures import make_empty_git_dir, make_fake_repo
+from paulsha_cortex.coordinator import autonomy
 from paulsha_cortex.coordinator.autonomy import _infer_repo_root
 
 
+def _isolated_cwd(tmp_path: Path) -> Path:
+    """未設 `PSC_REPO_ROOT` 時 `paths.repo_root()` 退回 `Path.cwd()`。
+
+    要驗「向上搜尋」的分支，cwd 就不能是 spec 的祖先——否則第一段
+    `relative_to(configured)` 早退，根本走不到搜尋迴圈。給一個與受測路徑無
+    祖孫關係的空目錄當 cwd。
+    """
+    cwd = tmp_path / "unrelated-cwd"
+    cwd.mkdir(exist_ok=True)
+    return cwd
+
+
 def test_infer_repo_root_prefers_configured_repo_root_for_external_spec(monkeypatch, tmp_path):
-    repo_root = tmp_path / "repo"
-    repo_root.mkdir()
+    repo_root = make_fake_repo(tmp_path / "repo")
     spec_dir = tmp_path / "agents" / "specs"
     spec_path = spec_dir / "foo-spec.md"
     spec_dir.mkdir(parents=True)
     spec_path.write_text("# foo\n", encoding="utf-8")
-    (tmp_path / "agents" / ".git").mkdir()
+    # `~/.agents` 樹即使是**有效** repo 也不得被當成 spec 的 repo 根（名稱規則）。
+    make_fake_repo(tmp_path / "agents")
 
     monkeypatch.setenv("PSC_REPO_ROOT", str(repo_root))
 
@@ -18,9 +49,7 @@ def test_infer_repo_root_prefers_configured_repo_root_for_external_spec(monkeypa
 
 
 def test_infer_repo_root_keeps_in_repo_path_for_repo_relative_spec(monkeypatch, tmp_path):
-    repo_root = tmp_path / "repo"
-    repo_root.mkdir()
-    (repo_root / ".git").mkdir()
+    repo_root = make_fake_repo(tmp_path / "repo")
     spec_path = repo_root / "specs" / "foo-spec.md"
     spec_path.parent.mkdir(parents=True)
     spec_path.write_text("# foo\n", encoding="utf-8")
@@ -31,8 +60,7 @@ def test_infer_repo_root_keeps_in_repo_path_for_repo_relative_spec(monkeypatch, 
 
 
 def test_infer_repo_root_fallback_unchanged_without_configured_repo_root(monkeypatch, tmp_path):
-    repo_root = tmp_path / "repo"
-    repo_root.mkdir()
+    repo_root = make_fake_repo(tmp_path / "repo")
     spec_path = tmp_path / "outside" / "specs" / "foo-spec.md"
     spec_path.parent.mkdir(parents=True)
     spec_path.write_text("# foo\n", encoding="utf-8")
@@ -41,3 +69,110 @@ def test_infer_repo_root_fallback_unchanged_without_configured_repo_root(monkeyp
     monkeypatch.chdir(repo_root)
 
     assert _infer_repo_root(spec_path) == spec_path.parent
+
+
+# --- #565 回歸：空 .git 目錄不得被當 repo 根 ---------------------------------
+
+
+def test_empty_git_dir_on_path_chain_is_not_a_repo_root(monkeypatch, tmp_path):
+    """路徑鏈上有 `mkdir` 出來的空 `.git` 時，推斷必須「穿過」它。
+
+    這是 #565 的核心回歸：污染在 `tmp_path` 內自備，因此 host `/tmp` 的實際
+    狀態（有無 sandbox 存活）完全不影響判定。
+    """
+    shared = tmp_path / "shared"
+    real_repo = make_fake_repo(shared / "workspace" / "repo")
+    make_empty_git_dir(shared)  # 污染：空 .git，與 sandbox 在 /tmp 造的形狀相同
+
+    spec_path = real_repo / "specs" / "foo-spec.md"
+    spec_path.parent.mkdir(parents=True)
+    spec_path.write_text("# foo\n", encoding="utf-8")
+
+    monkeypatch.setenv("PSC_REPO_ROOT", str(tmp_path / "elsewhere"))
+
+    assert _infer_repo_root(spec_path) == real_repo
+
+
+def test_empty_git_dir_alone_does_not_anchor_repo_root(monkeypatch, tmp_path):
+    """鏈上**只有**空 `.git`（沒有任何真 repo）時，落到既有 fallback 而非污染點。"""
+    polluted = tmp_path / "polluted"
+    make_empty_git_dir(polluted)
+    spec_path = polluted / "nested" / "specs" / "foo-spec.md"
+    spec_path.parent.mkdir(parents=True)
+    spec_path.write_text("# foo\n", encoding="utf-8")
+
+    monkeypatch.delenv("PSC_REPO_ROOT", raising=False)
+    monkeypatch.chdir(_isolated_cwd(tmp_path))
+
+    assert _infer_repo_root(spec_path) == spec_path.parent
+
+
+def test_worktree_git_file_still_counts_as_repo_root(monkeypatch, tmp_path):
+    """linked worktree 的 `.git` 是 `gitdir:` **檔案**，仍必須被認為是 repo 根。"""
+    worktree = tmp_path / "repo-worktrees" / "feature"
+    worktree.mkdir(parents=True)
+    (worktree / ".git").write_text(
+        f"gitdir: {tmp_path / 'repo' / '.git' / 'worktrees' / 'feature'}\n",
+        encoding="utf-8",
+    )
+    spec_path = worktree / "specs" / "foo-spec.md"
+    spec_path.parent.mkdir(parents=True)
+    spec_path.write_text("# foo\n", encoding="utf-8")
+
+    monkeypatch.setenv("PSC_REPO_ROOT", str(tmp_path / "elsewhere"))
+
+    assert _infer_repo_root(spec_path) == worktree
+
+
+@pytest.mark.parametrize("contents", ["", "not a gitdir pointer\n"])
+def test_git_file_without_gitdir_pointer_is_not_a_repo_root(tmp_path, contents):
+    candidate = tmp_path / "candidate"
+    candidate.mkdir()
+    (candidate / ".git").write_text(contents, encoding="utf-8")
+
+    assert autonomy._is_git_repo_root(candidate) is False
+
+
+# --- #565 回歸：共享暫存根是搜尋上界 -----------------------------------------
+
+
+def test_search_stops_at_shared_temp_root(monkeypatch, tmp_path):
+    """即使共享根上是**有效** repo（有人在 `/tmp` 跑過 `git init`），也不落錨。
+
+    以 monkeypatch 換掉搜尋上界，用 `tmp_path` 內的假共享根重演此情境，
+    不依賴 host `/tmp` 真的被 `git init` 過。
+    """
+    shared = tmp_path / "fake-tmp"
+    make_fake_repo(shared)  # 共享根本身是有效 repo，但仍不該被採用
+    spec_path = shared / "job-1234" / "specs" / "foo-spec.md"
+    spec_path.parent.mkdir(parents=True)
+    spec_path.write_text("# foo\n", encoding="utf-8")
+
+    monkeypatch.setattr(autonomy, "_repo_search_boundaries", lambda: frozenset({shared}))
+    monkeypatch.delenv("PSC_REPO_ROOT", raising=False)
+    monkeypatch.chdir(_isolated_cwd(tmp_path))
+
+    assert _infer_repo_root(spec_path) == spec_path.parent
+
+
+def test_repo_below_shared_temp_root_still_resolves(monkeypatch, tmp_path):
+    """上界只擋共享根**自己**：其下的真 repo 照常命中。"""
+    shared = tmp_path / "fake-tmp"
+    real_repo = make_fake_repo(shared / "job-1234" / "repo")
+    spec_path = real_repo / "specs" / "foo-spec.md"
+    spec_path.parent.mkdir(parents=True)
+    spec_path.write_text("# foo\n", encoding="utf-8")
+
+    monkeypatch.setattr(autonomy, "_repo_search_boundaries", lambda: frozenset({shared}))
+    monkeypatch.setenv("PSC_REPO_ROOT", str(tmp_path / "elsewhere"))
+
+    assert _infer_repo_root(spec_path) == real_repo
+
+
+def test_real_tmp_is_a_search_boundary():
+    """契約釘選：`/tmp` 與 `TMPDIR` 都在上界集合內（#565 的實際污染點）。"""
+    boundaries = autonomy._repo_search_boundaries()
+    assert Path("/tmp").resolve() in boundaries
+    import tempfile
+
+    assert Path(tempfile.gettempdir()).resolve() in boundaries


### PR DESCRIPTION
## 問題

`_infer_repo_root`（`paulsha_cortex/coordinator/autonomy.py`）向上搜尋 repo 根時，
判準是 `(parent / ".git").exists()`——「`.git` 存在」等同「是 repo 根」。

實測（#565，0815／0816）：**agent sandbox 基礎設施會在 sandbox 存活期間於 `/tmp`
暫態 `mkdir` 一個空的 `.git`**（非 `git init`；teardown 後消失，`rm` 被防護 hook
擋下只能 `mv` 隔離）。於是任何 `/tmp` 底下（含 pytest `tmp_path`）的 spec 路徑
都被推斷成 `/tmp`，`tests/test_fix_dispatch_spec_path.py` 的兩個推斷測試在「當下
剛好有 sandbox 存活」時必紅。

這條在 dogfooding 已從偶發騷擾升級為硬 blocker：Manager gate ledger 對 builder
candidate 重跑全套 pytest 時撞上這扇窗，就以 `GateContradictionError` 拒掉**合格**
candidate（0816 run `workflow-7812abefede9d9b5d601` 實測），而且與 builder 的真實
缺陷混在一起干擾判讀。

## 修法

### 1. production：兩道判準

**有效性**——新增 `_is_git_repo_root()`：
- `.git` 是目錄 → 必須含 `HEAD`（`git init` 寫的第一批檔案之一，真 repo 必有）；
- `.git` 是檔案 → 必須以 `gitdir:` 開頭（linked worktree／submodule 的合法形狀）；
- 其餘（含空目錄、broken symlink、非 `gitdir:` 檔案）→ 不是 repo 根。

刻意**不** fork `git rev-parse --git-dir`：`_infer_repo_root` 落在派工熱路徑上，
對每個 parent 開一次 subprocess 的代價與 flakiness 都不划算，而這兩個檔案級判準
已足以排除唯一實測到的偽陽性。

**搜尋上界**——新增 `_repo_search_boundaries()`（`tempfile.gettempdir()`／`/tmp`／
`/var/tmp`）：共享暫存根由全機器互不相干的行程共用，誰都能在其下留 `.git`，因此
它**本身**永遠不是任何 spec 的 repo 根，向上搜尋到此即停。上界**之下**的真 repo
（`/tmp/<something>/repo`）照常命中——上界只擋共享根自己與其之上。

### 2. 測試 hermetic 化

新增 `tests/git_fixtures.py`：
- `make_fake_repo()` 建**完整**假 repo（含 `.git/HEAD`），取代原本「`mkdir` 空
  `.git` 冒充 repo 根」的寫法（六個測試檔共 15 處）；
- `make_empty_git_dir()` 建 #565 實測到的**污染形狀**，讓測試自備污染。

`tests/test_fix_dispatch_spec_path.py` 補 8 個回歸：
- 路徑鏈上有空 `.git` 時推斷必須「穿過」它，命中真正的 repo；
- 鏈上**只有**空 `.git` 時落回既有 fallback，而非污染點；
- linked worktree 的 `gitdir:` 檔案仍算 repo 根（不得誤殺）；
- 空檔案／非 `gitdir:` 內容的 `.git` 檔案不算 repo 根；
- 共享根即使是**有效** repo（有人在 `/tmp` 跑過 `git init`）也不落錨；
- 上界之下的 repo 照常命中；
- `/tmp` 與 `TMPDIR` 確實在上界集合內（契約釘選）。

污染與上界都由測試自備（自建 fixture ＋ monkeypatch `_repo_search_boundaries`），
**host `/tmp` 當下有沒有 `.git` 不再影響任何判定**。

## 驗證

| 條件 | 結果 |
| --- | --- |
| 全套 `python3 -m pytest -q`（一般環境） | `3319 passed, 49 subtests passed` |
| 全套 pytest，`TMPDIR` 指向自建污染目錄（祖先鏈上有空 `.git`） | `3319 passed, 49 subtests passed` |
| #565 點名的兩測，同一污染條件 | `2 passed` |
| **負控制**：同一污染條件下的**修前** code ＋ 原測試 | `2 failed, 1 passed`（正是 #565 描述的兩測） |

負控制證明模擬的污染條件是忠實的：同一個空 `.git` fixture 在修前必觸發劫持、
修後完全無感。

## Checklist

- [x] 分支非 `main`（`feature/565-infer-repo-root-hermetic`）
- [x] `changelog.d/infer-repo-root-hermetic.md` fragment 已新增並 commit
- [x] `CHANGELOG.md [Unreleased] / Fixed` 有對應 entry
- [x] `VERSION` 未動（非 release PR）
- [x] 全套 pytest 綠
- [x] 語言 zh-tw

## 相鄰觀察（不在本 PR 範圍）

- `Path.home()` 也是同族的「共享根」候選（dotfiles repo 會讓 home 成為有效 repo
  根）；現行 code 只以名稱規則排除 `~/.agents`，未納入上界。此情境無實測案例，
  本 PR 不擴大範圍。
- `paulsha_cortex/monitor/work_api.py` 也讀 `.git`，但只用 `is_dir()` 做
  canonical／worktree 排序，不做 repo 根落錨，無同類劫持風險。

Refs #565
