### PR TITLE
feat(coordinator): 重派 prompt 機械附上前次採信失敗證據

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,30 @@
 ## [Unreleased]
 
 ### Added
+- **#606：重派 prompt 機械附上前次採信失敗證據——無回饋的重試不再是決定論的重複**
+  ——現場 run `workflow-7812abefede9d9b5d601` 的 subagent-build（job 492／493）：builder
+  兩次自稱 `pytest: passed`，Manager 的 gate ledger 兩次獨立重跑抓到**同一個**失敗，兩次
+  `GateContradictionError` 逐字相同。根因不是重派錯誤（`retry-card` 刻意用原卡 prompt，
+  契約不可竄改是對的），而是 prompt 沒有任何通道攜帶「上一次為什麼被拒」。新增
+  `manager._workflow_retry_context()`：輸入是 `_dispatch_workflow_card` 既有的 `matching`
+  （同一張卡的先前 job），輸出機械組出一個 `retry_context` 區塊塞進 dispatch contract，
+  內容全部來自 **Manager 自產證據**、一個字都不取自模型輸出（與 #540 的不可竄改性同一條
+  紀律）——**採信錯誤類別＋canonical 訊息**（不讀敘事欄位，而是對舊 job 重跑既有採信路徑
+  的前兩段，`GateContradictionError` 與「log 無 JSON envelope」兩型都覆蓋）、**gate ledger
+  的 failed gates**（名稱＋exit code＋截尾輸出，「哪些算 failed」複用採信端的
+  `terminal_contract._ledger_outcomes`，不另立第二份判準），加上明示語句「前次嘗試因以下
+  Manager 獨立證據被拒；先重現並修復，再完成本卡」。`retry-card` 與 daemon 的 forced retry
+  都收斂在同一個 prompt 組裝點，兩條路徑同時拿到回饋。**首派逐字不變**：`retry_context`
+  預設 `None`，首派 `matching` 為空即不產生任何差異（測試釘住，含走真正 dispatch 路徑的
+  那條）。截斷上限 `RETRY_CONTEXT_EVIDENCE_LIMIT=2000`（全體 gate `detail` 合計預算，保留
+  尾段、被截明示 `detail_truncated`）與 `RETRY_CONTEXT_MESSAGE_LIMIT=600`，並 fail-soft
+  ——證據讀不到不得害死一次合法重派。附帶收斂 issue 的第二個觀察：
+  `terminal_schema.status_policy` 末段接上新的 `gate_ledger.gate_scope_honesty_hint()`，
+  明說「focused 綠不得推定宣告的 gate 綠」，且**實際會被 Manager 重跑的命令逐字進 prompt**
+  （與 #541 的 `allowed_names` 同一條機械生成紀律）。`retry_context` 另帶 `attempt`／
+  `redispatch_count`（由這張卡已燒掉的 job 數機械導出）作為 #555 per-card 熔斷的計數鉤子
+  ——**本票不實作熔斷**。詳見 `changelog.d/retry-feedback-context.md`。新增
+  `tests/test_retry_feedback_context_606.py`（14 測試）。
 - **R0.5 D6 / trust-root 隔離 Phase 2b：permgen 產 systemd unit ＋ polkit 規則，
   runbook 收斂為可執行版（仍不需 root）**——`permgen.py` 新增 `PathLayout`，把
   operator 0816 第二輪裁決的路徑（`/var/lib/cortex`、worktree pool

--- a/changelog.d/retry-feedback-context.md
+++ b/changelog.d/retry-feedback-context.md
@@ -1,0 +1,86 @@
+# retry-feedback-context
+
+**#606：重派 prompt 機械附上前次採信失敗證據——無回饋的重試不再是決定論的重複。**
+
+## 現場
+
+run `workflow-7812abefede9d9b5d601`（#501 dogfooding）的 subagent-build，job 492 與
+493：builder（codex／gpt-5.6-luna）兩次自稱 `pytest: passed`，Manager 的 gate ledger
+兩次獨立重跑抓到**同一個**失敗
+（`tests/test_workflow_registry.py::test_v1_migration_creates_immutable_backup_and_isolates_legacy_records`），
+兩次 `GateContradictionError` 逐字相同。
+
+根因不是重派錯誤。`retry-card`（#545／#569）刻意用**原卡 prompt** 重派——契約不可
+竄改是對的——但 prompt 沒有任何通道攜帶「上一次為什麼被拒」。builder 每次都跑
+focused tests 看到綠、自稱全套 passed，ledger 每次抓包；沒有回饋，重試就只是燒 job。
+
+## 修法（比照 #521／#540「prompt 由判準／證據機械生成」）
+
+### 1. `retry_context`：重派 prompt 的證據回饋通道
+
+新增 `manager._workflow_retry_context()`，輸入就是 `_dispatch_workflow_card` 既有的
+`matching`（同一張卡的先前 job；verify／review 另以 candidate 定錨），輸出機械組出
+一個 `retry_context` 區塊塞進 dispatch contract：
+
+- **採信錯誤類別＋canonical 訊息**（`acceptance_error`）：不讀任何敘事欄位
+  （`run.needs_human_reason` 在 `retry-card` 重置時依診斷 invariant 已被清空），而是
+  對舊 job **重跑既有採信路徑的前兩段**——同一份 log、同一份 gate ledger、同一組判準
+  函式，因此拿到的錯誤與當初 harvest 擲出的逐字相同。兩型都覆蓋：`GateContradictionError`
+  （#606 現場）與「log 完全沒有 JSON envelope」（#569 現場）。
+- **gate ledger 的 failed gates**（`failed_gates`）：名稱＋exit code＋截尾輸出。
+  「哪些算 failed」複用 `terminal_contract._ledger_outcomes`（採信端判定矛盾用的就是
+  它，exit_code 非 0 覆寫自述 status）——retry-context 不得另立第二份判準，否則 prompt
+  會告訴 builder 一組跟採信不同的失敗集合。
+- **明示語句**：prompt 散文段落多一句「attempt N was rejected by the Manager's own
+  independent evidence … Reproduce that failure first, fix it, and only then complete
+  this card」，並點明那份證據是 Manager 自產、不是前一次嘗試的自述。
+
+內容**一個字都不取自模型輸出**（與 #540 的不可竄改性同一條紀律）；來源全是 Manager
+在模型行程結束**之後**於自己掌控的 wrapper 內產生的 ledger 與自己的採信判準。
+
+`retry-card` 與 daemon 的 forced retry 都收斂在 `_dispatch_workflow_card` 這唯一一個
+prompt 組裝點，因此兩條路徑同時拿到回饋，不需要第二份實作。
+
+### 2. 首派逐字不變
+
+`_workflow_job_prompt(retry_context=None)` 是預設值；首派時 `matching` 為空 →
+`_workflow_retry_context` 回 `None` → contract 沒有 `retry_context` 鍵、散文也不多一
+個字，prompt 與本票之前**逐字相同**（有測試釘住，含走真正 dispatch 路徑的那條）。
+
+### 3. 截斷上限（prompt 不得被 gate 輸出撐爆）
+
+- `RETRY_CONTEXT_EVIDENCE_LIMIT = 2000`：**全體** failed gate `detail` 的合計預算，
+  保留尾段（pytest 的 short summary 在最後，那才是可重現的線索；與
+  `gate_ledger.run_gates` 自己的 `[-2000:]` 同向）。被截的項目帶 `detail_truncated`
+  明示，不假裝完整。
+- `RETRY_CONTEXT_MESSAGE_LIMIT = 600`：`GateContradictionError` 的訊息會把 ledger
+  detail 內嵌進去，同樣要有上限（`message_truncated`）。
+
+fail-soft：log／ledger 讀不到或壞掉時回空證據＋計數，**不得讓「讀不到舊證據」害死
+一次合法重派**。
+
+### 4. status 語意補上範圍紀律（issue 附帶觀察）
+
+`terminal_schema.status_policy` 末段接上新的 `gate_ledger.gate_scope_honesty_hint()`：
+明說「focused 綠 **不是** 宣告的 gate 綠」的推定不成立，而且**實際會被 Manager 重跑的
+命令逐字出現在 prompt 裡**——與 #541 的 `allowed_names` 同一條機械生成紀律（值由
+operator 的 `PSC_GATE_CMD_*` 宣告導出，不手寫第二份真實來源）。現場的行為模式
+（run `084f...` 的 job 488、run `7812...` 的 492／493）過去在 prompt 裡隻字未提。
+
+### 5. 與 #555 的接口
+
+`retry_context` 帶 `attempt`（本次是這張卡的第 N 次派工）與 `redispatch_count`
+（已重派過幾次），由這張卡已燒掉的 job 數機械導出。**本票不實作熔斷**，只把計數落到
+prompt 與 retry-context 上，讓 #555 的 per-card 熔斷判準之後有一個既有的、機械的來源
+可接。
+
+## 變更檔案
+
+- `paulsha_cortex/coordinator/manager.py`：新增 `RETRY_CONTEXT_EVIDENCE_LIMIT`／
+  `RETRY_CONTEXT_MESSAGE_LIMIT`／`_retry_context_error_row`／
+  `_prior_card_acceptance_error`／`_prior_card_failed_gates`／`_workflow_retry_context`；
+  `_workflow_job_prompt` 新增 `retry_context` 參數（預設 `None`）與散文段落；
+  `_dispatch_workflow_card` 在唯一的 prompt 組裝點注入。
+- `paulsha_cortex/coordinator/gate_ledger.py`：新增 `gate_scope_honesty_hint()`。
+- `tests/test_retry_feedback_context_606.py`：14 個測試（現場形狀 fixture、首派逐字
+  不變、截斷上限、兩型採信錯誤、計數、status 範圍紀律、真正 dispatch 路徑、fail-soft）。

--- a/paulsha_cortex/coordinator/gate_ledger.py
+++ b/paulsha_cortex/coordinator/gate_ledger.py
@@ -165,6 +165,41 @@ def gate_evidence_name_hint(env: Mapping[str, str] | None = None) -> str:
     )
 
 
+def gate_scope_honesty_hint(env: Mapping[str, str] | None = None) -> str:
+    """回傳 dispatch prompt 用的「gate 範圍紀律」說明（同樣由 gate 宣告機械產生）。
+
+    issue #606 的附帶觀察：builder 在兩個 run（``workflow-084f...`` 的 job 488、
+    ``workflow-7812...`` 的 job 492／493）重複出現同一個行為模式——只跑 focused
+    測試看到綠，就自報 ``status=passed`` 並宣稱整組 gate 通過；manager 事後以
+    宣告的 gate 命令獨立重跑，每次都抓到同一個失敗。prompt 的 ``status_policy``
+    過去只說「gate 實際通過才回 passed」，沒有點名「focused 綠 ≠ 宣告的 gate
+    綠」這個推定，模型因此把自己選的子集當成整組的證據。
+
+    修法與 :func:`gate_evidence_name_hint`（#541／#540）同一條紀律：說明文字裡的
+    具體值（gate 名稱與**它真正會被重跑的命令**）由 operator 的 ``PSC_GATE_CMD_*``
+    宣告機械導出，與 :func:`write_gate_ledger` 同源，不手寫第二份真實來源。
+    """
+
+    try:
+        specs = load_gate_specs(env)
+    except GateSpecError:
+        specs = ()
+    if not specs:
+        return (
+            "Scope discipline: a gate counts as passed only when the Manager's own declared "
+            "gate command passes as the Manager runs it. Running a narrower subset of your "
+            "own choosing never authorizes claiming the declared gate is green."
+        )
+    rendered = "; ".join(f'"{spec.name}" = `{spec.command}`' for spec in specs)
+    return (
+        "Scope discipline: after your process exits the Manager re-runs exactly these commands "
+        f"({rendered}), and a passed status is judged against those real results. Running a "
+        "focused subset first is fine, but then report only the scope you actually ran: a green "
+        "focused subset is NOT evidence that the declared gate is green, and inferring the full "
+        "gate from it fails the card closed."
+    )
+
+
 def _gate_timeout(env: Mapping[str, str]) -> int:
     raw = str(env.get(GATE_TIMEOUT_ENV, "")).strip()
     if not raw:

--- a/paulsha_cortex/coordinator/manager.py
+++ b/paulsha_cortex/coordinator/manager.py
@@ -15,7 +15,7 @@ import time
 from datetime import datetime, timezone
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any, Callable, Mapping, Protocol
+from typing import Any, Callable, Mapping, Protocol, Sequence
 from uuid import uuid4
 
 from paulsha_cortex.config import paths
@@ -7465,6 +7465,163 @@ def _repair_findings_prompt_suffix(run, *, coordinator_root: str | Path) -> str:
     return suffix[:2000]
 
 
+# #606：重派 prompt 內 retry-context 的截斷上限。retry-context 的內容全部來自
+# manager 自產證據（gate ledger 的 detail 是 gate 命令的 stderr/stdout 尾段，
+# 見 `gate_ledger.run_gates`），長度不受控——一個失敗的全套 pytest 可以吐出數萬
+# 字。沒有上限的話「附上證據」會直接把 dispatch prompt 撐爆，反而讓重派更糟。
+RETRY_CONTEXT_EVIDENCE_LIMIT = 2000
+RETRY_CONTEXT_MESSAGE_LIMIT = 600
+
+
+def _retry_context_error_row(exc: BaseException) -> dict[str, object]:
+    """把採信錯誤壓成 prompt 可帶的機械欄位（類別＋canonical 訊息＋reason）。
+
+    刻意只取例外物件自己的欄位：``TerminalContractError``／
+    ``GateContradictionError`` 的訊息是 manager 側判準產生的 canonical 文字
+    （見 :mod:`.terminal_contract`），不是模型講的話。
+    """
+
+    message = str(exc)
+    row: dict[str, object] = {
+        "error_class": type(exc).__name__,
+        "message": message[:RETRY_CONTEXT_MESSAGE_LIMIT],
+    }
+    if len(message) > RETRY_CONTEXT_MESSAGE_LIMIT:
+        row["message_truncated"] = True
+    reason = getattr(exc, "reason", None)
+    if isinstance(reason, str) and reason:
+        row["reason"] = reason
+    validation_path = getattr(exc, "validation_path", None)
+    if isinstance(validation_path, str) and validation_path:
+        row["validation_path"] = validation_path
+    return row
+
+
+def _prior_card_acceptance_error(
+    job: Mapping[str, object], *, registry=None
+) -> dict[str, object] | None:
+    """重新導出「上一次這張卡為什麼沒被採信」的 canonical 錯誤。
+
+    不讀任何既存的敘事欄位（``run.needs_human_reason`` 在 ``retry-card`` 重置時
+    依診斷 invariant 已被清空，見 ``registry._manager_reset_workflow_for_retry_card``），
+    而是對舊 job 重跑既有採信路徑的前兩段——同一份 log、同一份 gate ledger、
+    同一組判準函式，因此拿到的錯誤與當初 harvest 擲出的逐字相同：
+
+    - log 裡沒有可用的 terminal JSON（#569 現場）→ :func:`_extract_terminal_json`
+      的 ``ValueError`` 文字；
+    - 有 envelope 但與 manager 自產 gate ledger 矛盾（#606 現場）→
+      :func:`_assert_terminal_gate_consistency` 擲出的
+      ``GateContradictionError``／``TerminalContractError``。
+
+    取不到就回 ``None``——證據是加值，不得讓「讀不到舊證據」害死一次合法重派。
+    """
+
+    log_path = job.get("log_path")
+    if not isinstance(log_path, str) or not log_path:
+        return None
+    try:
+        raw = _extract_terminal_json(log_path)
+    except ValueError as exc:
+        return _retry_context_error_row(exc)
+    except Exception:  # pragma: no cover - fail-soft：prompt 組裝不得炸掉 dispatch
+        return None
+    try:
+        _assert_terminal_gate_consistency(raw, job=job, registry=registry)
+    except terminal_contract.TerminalContractError as exc:
+        return _retry_context_error_row(exc)
+    except Exception:  # pragma: no cover - 同上
+        return None
+    return None
+
+
+def _prior_card_failed_gates(job: Mapping[str, object]) -> list[dict[str, object]]:
+    """從舊 job 的 gate ledger 機械讀出 failed gate（名稱＋exit code＋截尾輸出）。
+
+    「哪些算 failed」刻意複用 :func:`terminal_contract._ledger_outcomes`——採信端
+    判定矛盾用的就是它（exit_code 非 0 覆寫自述 status），retry-context 不得另立
+    第二份判準，否則 prompt 會告訴 builder 一組跟採信不同的失敗集合。
+
+    ``detail`` 依 :data:`RETRY_CONTEXT_EVIDENCE_LIMIT` 做**全體**預算截斷（保留
+    尾段，與 ``gate_ledger.run_gates`` 自己的 ``[-2000:]`` 同向：pytest 的 short
+    summary 在尾巴），被截的項目帶 ``detail_truncated`` 明示，不假裝完整。
+    """
+
+    log_path = job.get("log_path")
+    if not isinstance(log_path, str) or not log_path:
+        return []
+    try:
+        found = terminal_contract.read_gate_ledger(
+            terminal_contract.gate_ledger_path(log_path)
+        )
+        if found is None:
+            return []
+        outcomes = terminal_contract._ledger_outcomes(found[0])
+    except Exception:
+        # ledger 缺席／壞掉／是 symlink：沒有可附的獨立證據，回空集合即可。
+        return []
+    rows: list[dict[str, object]] = []
+    budget = RETRY_CONTEXT_EVIDENCE_LIMIT
+    for name, outcome in outcomes.items():
+        if outcome.get("status") == "passed":
+            continue
+        row: dict[str, object] = {"name": name, "status": "failed"}
+        exit_code = outcome.get("exit_code")
+        if type(exit_code) is int:
+            row["exit_code"] = exit_code
+        detail = outcome.get("detail")
+        if isinstance(detail, str) and detail:
+            kept = detail[-budget:] if budget > 0 else ""
+            budget -= len(kept)
+            row["detail"] = kept
+            if len(kept) < len(detail):
+                row["detail_truncated"] = True
+        rows.append(row)
+    return rows
+
+
+def _workflow_retry_context(
+    prior_jobs: Sequence[Mapping[str, object]], *, registry=None
+) -> dict[str, object] | None:
+    """#606：重派這張卡時要機械附進 prompt 的「前次採信失敗證據」。
+
+    現場（run ``workflow-7812abefede9d9b5d601`` 的 subagent-build，job 492／493）：
+    builder 兩次自稱 ``pytest: passed``，manager ledger 兩次獨立重跑抓到**同一個**
+    失敗，``GateContradictionError`` 逐字相同。``retry-card``（#545／#569）重派用
+    的是原卡 prompt——契約不可竄改，這是對的——但 prompt 裡沒有任何通道讓 builder
+    知道「上次為什麼被拒」，於是無回饋的重試就是決定論的重複，只是燒 job。
+
+    ``prior_jobs`` 就是 :func:`_dispatch_workflow_card` 算出的 ``matching``（同一
+    張卡、同一個 phase，verify／review 另以 candidate 定錨），因此：
+
+    - **首派必然是空集合 → 回 ``None`` → prompt 逐字不變**（#606 要求 2，有測試釘住）；
+    - 內容全部來自 manager 自產證據（自己的 gate ledger、自己的採信判準），一個
+      字都不取自模型輸出，與 #540 的不可竄改性一致。
+
+    ``attempt``／``redispatch_count`` 由這張卡已燒掉的 job 數機械導出，是 #555
+    （per-card 熔斷）要的計數鉤子：本 PR 不實作熔斷，只把計數落到 prompt 與
+    retry-context 上，讓熔斷判準之後有一個既有的、機械的來源可接。
+    """
+
+    if not prior_jobs:
+        return None
+    latest = prior_jobs[-1]
+    context: dict[str, object] = {
+        # 本次是這張卡的第 N 次派工；首派為 1，故 retry-context 恆有 attempt >= 2。
+        "attempt": len(prior_jobs) + 1,
+        # #555 的鉤子：已重派過幾次（首次重派為 1）。
+        "redispatch_count": len(prior_jobs),
+        "previous_job_id": str(latest.get("job_id")),
+        "previous_job_ids": [str(job.get("job_id")) for job in prior_jobs],
+        "evidence_source": "manager-independent",
+        "evidence_char_limit": RETRY_CONTEXT_EVIDENCE_LIMIT,
+        "failed_gates": _prior_card_failed_gates(latest),
+    }
+    error = _prior_card_acceptance_error(latest, registry=registry)
+    if error is not None:
+        context["acceptance_error"] = error
+    return context
+
+
 def _workflow_job_prompt(
     run,
     step,
@@ -7474,6 +7631,7 @@ def _workflow_job_prompt(
     input_snapshot: tuple[dict[str, str], ...] = (),
     candidate_checkout: str | None = None,
     env: Mapping[str, str] | None = None,
+    retry_context: Mapping[str, object] | None = None,
 ) -> str:
     """組出單張 workflow card 的派工 prompt。
 
@@ -7481,6 +7639,10 @@ def _workflow_job_prompt(
     機械導出（預設 ``os.environ``——與 launcher 交給 wrapper 的 env 同源，見
     ``launcher._git_scope_env``），因此 prompt 告訴模型的 gate 名稱集合，與
     job 結束後 manager 自己寫出的 ledger 必為同一組。
+
+    ``retry_context``（#606）：由 :func:`_workflow_retry_context` 從**這張卡的
+    前次 job** 機械導出的採信失敗證據。``None``（首派、或呼叫端未提供）時
+    prompt 逐字不變——重派回饋只加在真的有前次失敗的那條路徑上。
     """
     fallback = _LEGACY_CARD_EXECUTION.get(step.card, (None, None, None, None))
     effective_test_policy = step.test_policy or fallback[3]
@@ -7591,12 +7753,17 @@ def _workflow_job_prompt(
             # #261 R2：成功必須由 gate evidence 證明。模型自述、exit code 為 0、
             # 「沒看到錯誤」三者皆不構成成功授權；manager 會重讀 gate ledger 做
             # 確定性 cross-check，矛盾即 fail closed。
+            #
+            # #606：末段的範圍紀律（「focused 綠不得推定宣告的 gate 綠」）與
+            # 下面 gate_evidence 的 allowed_names 說明同一條機械生成紀律——具體
+            # 的 gate 名稱與命令由 operator 的 PSC_GATE_CMD_* 宣告導出，不手寫。
             "status_policy": (
                 "Report passed only when every deterministic gate you ran (OpenSpec / pytest / "
                 "policy) actually passed. Natural-language confidence, an exit code of 0, and "
                 "the absence of an explicit error do NOT authorize passed. If any gate failed, "
                 "report failed; the Manager re-reads the gate ledger and fails closed on any "
-                "contradiction, so a dishonest passed only costs you a retry."
+                "contradiction, so a dishonest passed only costs you a retry. "
+                + gate_ledger.gate_scope_honesty_hint(env)
             ),
             "outputs": {
                 "type": "array",
@@ -7670,6 +7837,9 @@ def _workflow_job_prompt(
         contract["builder_job_id"] = builder_job_id
     if candidate_checkout is not None:
         contract["candidate_checkout"] = candidate_checkout
+    if retry_context is not None:
+        # #606：首派沒有這個鍵，prompt 因此逐字不變（見 `_workflow_retry_context`）。
+        contract["retry_context"] = dict(retry_context)
     effective_commit_policy = step.commit_policy or fallback[2]
     tasks_path = (
         f"openspec/changes/{contract['openspec_ref']}/tasks.md"
@@ -7702,6 +7872,21 @@ def _workflow_job_prompt(
         if effective_commit_policy == "required"
         else ""
     )
+    # #606：明示語句與 retry_context 區塊成對出現。文字固定、數字機械帶入——
+    # 「上一次為什麼被拒」的內容一律留在 retry_context 的結構化欄位裡。
+    retry_context_contract = (
+        (
+            f" This card is being redispatched: attempt {int(retry_context.get('attempt', 2)) - 1} "
+            "was rejected by the Manager's own independent evidence, reproduced verbatim in "
+            "the retry_context block of the contract below. That block is Manager-generated "
+            "(its own gate ledger and its own acceptance error), not the previous attempt's "
+            "self-report, and it is not negotiable. Reproduce that failure first, fix it, and "
+            "only then complete this card; repeating the previous attempt without addressing "
+            "it will be rejected identically."
+        )
+        if retry_context is not None
+        else ""
+    )
     return (
         "Execute exactly one workflow card. End with one JSON object only; do not supply an evidence "
         "path or hash because Manager will canonicalize it. For workflow-card outputs, return only "
@@ -7715,6 +7900,7 @@ def _workflow_job_prompt(
         + reviewer_contract
         + commit_required_contract
         + repair_findings_contract
+        + retry_context_contract
         + " Contract: "
         + json.dumps(contract, ensure_ascii=False, sort_keys=True)
     )
@@ -8362,6 +8548,11 @@ def _dispatch_workflow_card(
                     if step.persona == "reviewer" and identity.executor == "claude"
                     else None
                 ),
+                # #606：`matching` 就是這張卡先前燒掉的 job（首派為空 →
+                # retry_context 為 None → prompt 逐字不變）。retry-card 的重派與
+                # daemon 的 forced retry 都走這唯一一條組裝路徑，因此兩者同時
+                # 拿到回饋，不需要第二份實作。
+                retry_context=_workflow_retry_context(matching, registry=registry),
             ),
             worktree=worktree,
             log_dir=str(Path(coordinator_root).resolve() / "logs" / "workflow"),

--- a/tests/test_retry_feedback_context_606.py
+++ b/tests/test_retry_feedback_context_606.py
@@ -1,0 +1,673 @@
+"""#606：retry-card 重派 prompt 不含前次採信失敗證據——無回饋重試是決定論的重複。
+
+現場（0816，run ``workflow-7812abefede9d9b5d601``，#501 dogfooding）：
+subagent-build 的 job 492 與 493，builder（codex／gpt-5.6-luna）兩次自稱
+``pytest: passed``，Manager 的 gate ledger 兩次獨立重跑抓到**同一個**失敗
+（``test_workflow_registry.py::test_v1_migration_creates_immutable_backup_and_isolates_legacy_records``），
+兩次 ``GateContradictionError`` 內容逐字相同。
+
+根因不是重派錯誤：``retry-card``（#545／#569）刻意用原卡 prompt，契約不可竄改是
+對的。缺的是**回饋通道**——prompt 沒有任何欄位攜帶「上一次為什麼被拒」，於是
+builder 每次都跑 focused tests 自認綠、自稱全套 passed，ledger 每次抓包，重試
+只是決定論的重複。
+
+本檔釘住三件事：
+
+1. 重派時 ``_workflow_job_prompt`` 機械附上 retry-context，內容全部來自 **Manager
+   自產證據**（自己的 gate ledger、自己的採信判準），一個字都不取自模型輸出
+   （與 #540 的不可竄改性同一條紀律）；
+2. **首派 prompt 逐字不變**——回饋只加在真的有前次失敗的那條路徑上；
+3. status 語意補上範圍紀律：「focused 綠不得推定宣告的 gate 綠」，具體的 gate
+   名稱與命令由 ``PSC_GATE_CMD_*`` 宣告機械導出（#541 的同一條生成紀律）。
+
+計數（``attempt``／``redispatch_count``）是 #555（per-card 熔斷）的鉤子：本票不
+實作熔斷，只保證計數存在且正確。
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+import json
+from pathlib import Path
+
+import pytest
+
+from paulsha_cortex.coordinator import gate_ledger, manager
+from paulsha_cortex.coordinator import terminal_contract as tc
+from paulsha_cortex.coordinator.launcher import LaunchHandle
+from paulsha_cortex.coordinator.model_identities import IdentityRegistry
+from paulsha_cortex.coordinator.registry import JobRegistry
+from paulsha_cortex.coordinator.workflow import WorkflowStep
+
+from diagnostic_fixtures import fixture_needs_human_reason
+
+
+HEAD = "d" * 40
+CARD = "subagent-build"
+# 現場逐字的失敗測試名（issue #606 的 ledger detail）。
+FIELD_FAILURE = (
+    "FAILED tests/test_workflow_registry.py::"
+    "test_v1_migration_creates_immutable_backup_and_isolates_legacy_records"
+    " - AssertionError: legacy v1 slices 遷移 round-trip 不一致"
+)
+
+
+def _step(card: str = CARD, *, gate_result: str = "pending") -> WorkflowStep:
+    return WorkflowStep(
+        phase="build",
+        persona="builder",
+        card=card,
+        executor=None,
+        model=None,
+        domain=None,
+        inputs=(),
+        outputs=(),
+        gate_result=gate_result,
+        test_policy="focused",
+        action="Implement the accepted plan with the minimum diff.",
+        commit_policy="required",
+    )
+
+
+def _run(registry: JobRegistry, tmp_path: Path, **overrides):
+    payload = {
+        "work_id": "demo",
+        "repo": "acme/demo",
+        "claim_key": "claim:v1:" + "1" * 64,
+        "source_revision": "2" * 64,
+        "workspace_root": str(tmp_path),
+        "combo": "feature-oneshot",
+        "current_phase": "build",
+        "steps": (_step(),),
+        "issue_refs": (),
+        "openspec_refs": (),
+        "pr_refs": (),
+        "candidate_head": HEAD,
+        "attempts": {"build": 1},
+        "facets": (),
+        "gate_status": "running",
+    }
+    payload.update(overrides)
+    return registry._manager_create_workflow_run(**payload)
+
+
+def _terminal_payload(run, card: str = CARD) -> dict:
+    """builder 自稱 passed 且自報 ``pytest: passed`` 的 canonical envelope。"""
+
+    return {
+        "schema_version": tc.TERMINAL_SCHEMA_VERSION,
+        "kind": "workflow-card",
+        "status": "passed",
+        "run_id": run.run_id,
+        "card_id": card,
+        "candidate": HEAD,
+        "outputs": [],
+        "diagnostics": {},
+        "gate_evidence": [{"name": "pytest", "status": "passed"}],
+    }
+
+
+def _prior_job(
+    registry: JobRegistry,
+    run,
+    tmp_path: Path,
+    *,
+    terminal: dict | None,
+    ledger_detail: str | None = FIELD_FAILURE,
+    card: str = CARD,
+    name: str = "prior",
+):
+    """重建一顆「已終止但 evidence 綁不上」的舊 job（log ＋ manager 自產 ledger）。"""
+
+    log = tmp_path / "logs" / "workflow" / f"{name}.jsonl"
+    log.parent.mkdir(parents=True, exist_ok=True)
+    log.write_text(
+        "" if terminal is None else json.dumps(terminal) + "\n", encoding="utf-8"
+    )
+    if ledger_detail is not None:
+        tc.gate_ledger_path(log).write_text(
+            json.dumps(
+                {
+                    "schema_version": tc.GATE_LEDGER_SCHEMA_VERSION,
+                    "kind": tc.GATE_LEDGER_KIND,
+                    "slice_id": name,
+                    "gates": [
+                        {
+                            "name": "pytest",
+                            "command": "python3 -m pytest -q",
+                            "exit_code": 1,
+                            "status": "failed",
+                            "detail": ledger_detail,
+                        }
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+    job = registry.create_job(
+        task=f"wf-{card}",
+        persona="builder",
+        branch="feature/12-demo",
+        pane="",
+        worktree=str(tmp_path),
+        workflow_run_id=run.run_id,
+        workflow_card=card,
+        workflow_phase="build",
+        workflow_test_policy="focused",
+    )
+    registry.attach_launch_handle(job["job_id"], log_path=str(log))
+    registry.update_headless_result(job["job_id"], status="exited", exit_code=0)
+    return registry.get_job(job["job_id"])
+
+
+def _contract(prompt: str) -> dict:
+    return json.loads(prompt[prompt.index("{") : prompt.rindex("}") + 1])
+
+
+# ==========================================================================
+# 段 1：重派 prompt 機械附上前次採信失敗證據
+# ==========================================================================
+
+
+def test_retry_prompt_carries_the_previous_gate_ledger_failure(tmp_path: Path) -> None:
+    """RED（修復前）：重派 prompt 與首派逐字相同，builder 看不到自己被抓包的證據。"""
+
+    registry = JobRegistry(state_path=tmp_path / "registry.json")
+    run = _run(registry, tmp_path)
+    prior = _prior_job(registry, run, tmp_path, terminal=_terminal_payload(run))
+
+    context = manager._workflow_retry_context([prior], registry=registry)
+    assert context is not None
+
+    # 採信錯誤類別與 canonical 文字：來自 manager 自己的判準，不是模型文字。
+    error = context["acceptance_error"]
+    assert error["error_class"] == "GateContradictionError"
+    assert error["reason"] == "gate-status-contradiction"
+    assert "pytest" in error["message"]
+
+    # gate ledger 的 failed gate：名稱＋exit code＋截尾輸出。
+    assert context["failed_gates"] == [
+        {"name": "pytest", "status": "failed", "exit_code": 1, "detail": FIELD_FAILURE}
+    ]
+
+    prompt = manager._workflow_job_prompt(
+        run,
+        run.steps[0],
+        builder_job_id=None,
+        coordinator_root=tmp_path,
+        env={"PSC_GATE_CMD_PYTEST": "python3 -m pytest -q"},
+        retry_context=context,
+    )
+    contract = _contract(prompt)
+    assert contract["retry_context"] == context
+    # 現場逐字的失敗測試名必須真的到得了模型眼前。
+    assert "test_v1_migration_creates_immutable_backup_and_isolates_legacy_records" in prompt
+    # 明示語句：先重現並修復，再完成本卡。
+    assert "redispatched" in prompt
+    assert "Reproduce that failure first" in prompt
+    assert "not the previous attempt's self-report" in prompt
+
+
+def test_retry_context_evidence_is_manager_generated_not_model_text(
+    tmp_path: Path,
+) -> None:
+    """模型自報的 gate 結果不得成為 retry-context 的內容來源。
+
+    舊 envelope 自報 ``pytest: passed``；retry-context 只能說 failed——它讀的是
+    manager 在模型行程結束**之後**寫出的 ledger（``gate_ledger.write_gate_ledger``）。
+    """
+
+    registry = JobRegistry(state_path=tmp_path / "registry.json")
+    run = _run(registry, tmp_path)
+    prior = _prior_job(registry, run, tmp_path, terminal=_terminal_payload(run))
+
+    context = manager._workflow_retry_context([prior], registry=registry)
+
+    assert context["evidence_source"] == "manager-independent"
+    assert [row["status"] for row in context["failed_gates"]] == ["failed"]
+    assert context["previous_job_id"] == str(prior["job_id"])
+
+
+def test_retry_prompt_covers_the_no_json_terminal_shape(tmp_path: Path) -> None:
+    """#569 形狀：job exit 0 但 log 完全沒有 JSON envelope，也要有回饋。"""
+
+    registry = JobRegistry(state_path=tmp_path / "registry.json")
+    run = _run(registry, tmp_path)
+    prior = _prior_job(registry, run, tmp_path, terminal=None, ledger_detail=None)
+
+    context = manager._workflow_retry_context([prior], registry=registry)
+
+    assert context["acceptance_error"]["message"] == (
+        "workflow terminal log has no JSON evidence"
+    )
+    # 沒有 ledger 就沒有 failed gate 可附；不得編造。
+    assert context["failed_gates"] == []
+
+    prompt = manager._workflow_job_prompt(
+        run,
+        run.steps[0],
+        builder_job_id=None,
+        coordinator_root=tmp_path,
+        retry_context=context,
+    )
+    assert "workflow terminal log has no JSON evidence" in prompt
+
+
+# ==========================================================================
+# 段 2：首派逐字不變
+# ==========================================================================
+
+
+def test_first_dispatch_prompt_is_byte_identical(tmp_path: Path) -> None:
+    """沒有前次失敗時，prompt 與加上 retry-context 通道之前**逐字相同**。"""
+
+    registry = JobRegistry(state_path=tmp_path / "registry.json")
+    run = _run(registry, tmp_path)
+    env = {"PSC_GATE_CMD_PYTEST": "python3 -m pytest -q"}
+
+    # 空的 prior job 集合（＝首派）不得產生 retry-context。
+    assert manager._workflow_retry_context([], registry=registry) is None
+
+    baseline = manager._workflow_job_prompt(
+        run, run.steps[0], builder_job_id=None, coordinator_root=tmp_path, env=env
+    )
+    with_default = manager._workflow_job_prompt(
+        run,
+        run.steps[0],
+        builder_job_id=None,
+        coordinator_root=tmp_path,
+        env=env,
+        retry_context=manager._workflow_retry_context([], registry=registry),
+    )
+
+    assert with_default == baseline
+    assert "retry_context" not in baseline
+    assert "redispatched" not in baseline
+
+
+def test_first_dispatch_of_a_card_is_unaffected_by_other_cards(tmp_path: Path) -> None:
+    """另一張卡失敗過，不得污染這張卡的首派 prompt。
+
+    `_dispatch_workflow_card` 的 ``matching`` 已經以「同一張卡（verify／review 另
+    以 candidate 定錨）」過濾；這裡釘住 retry-context 完全依賴那份過濾結果。
+    """
+
+    registry = JobRegistry(state_path=tmp_path / "registry.json")
+    run = _run(
+        registry,
+        tmp_path,
+        steps=(_step("tdd-red", gate_result="passed"), _step()),
+    )
+    other = _prior_job(
+        registry,
+        run,
+        tmp_path,
+        terminal=_terminal_payload(run, card="tdd-red"),
+        card="tdd-red",
+        name="other-card",
+    )
+    matching = [
+        job
+        for job in registry.list_jobs()
+        if job.get("workflow_run_id") == run.run_id
+        and job.get("workflow_card") == CARD
+    ]
+
+    assert other["workflow_card"] == "tdd-red"
+    assert matching == []
+    assert manager._workflow_retry_context(matching, registry=registry) is None
+
+
+# ==========================================================================
+# 段 3：證據截斷上限（prompt 不得被 gate 輸出撐爆）
+# ==========================================================================
+
+
+def test_gate_detail_is_truncated_to_the_evidence_budget(tmp_path: Path) -> None:
+    """失敗的全套 pytest 可以吐出數萬字；retry-context 有硬上限且明示被截。"""
+
+    registry = JobRegistry(state_path=tmp_path / "registry.json")
+    run = _run(registry, tmp_path)
+    detail = "x" * 5000 + FIELD_FAILURE
+    prior = _prior_job(
+        registry, run, tmp_path, terminal=_terminal_payload(run), ledger_detail=detail
+    )
+
+    context = manager._workflow_retry_context([prior], registry=registry)
+    row = context["failed_gates"][0]
+
+    assert len(row["detail"]) == manager.RETRY_CONTEXT_EVIDENCE_LIMIT
+    assert row["detail_truncated"] is True
+    # 保留尾段：pytest 的 short summary 在最後，那才是可重現的線索。
+    assert row["detail"].endswith(FIELD_FAILURE)
+
+
+def test_acceptance_error_message_is_truncated(tmp_path: Path) -> None:
+    """``GateContradictionError`` 的訊息會把 ledger detail 內嵌進去，同樣要有上限。"""
+
+    registry = JobRegistry(state_path=tmp_path / "registry.json")
+    run = _run(registry, tmp_path)
+    prior = _prior_job(
+        registry,
+        run,
+        tmp_path,
+        terminal=_terminal_payload(run),
+        ledger_detail="y" * 4000,
+    )
+
+    context = manager._workflow_retry_context([prior], registry=registry)
+    error = context["acceptance_error"]
+
+    assert len(error["message"]) == manager.RETRY_CONTEXT_MESSAGE_LIMIT
+    assert error["message_truncated"] is True
+
+
+def test_multiple_failed_gates_share_one_evidence_budget(tmp_path: Path) -> None:
+    """預算是**全體**的：第一個 gate 吃滿之後，後續 gate 的 detail 被丟掉但明示。"""
+
+    registry = JobRegistry(state_path=tmp_path / "registry.json")
+    run = _run(registry, tmp_path)
+    log = tmp_path / "logs" / "workflow" / "multi.jsonl"
+    log.parent.mkdir(parents=True, exist_ok=True)
+    log.write_text(json.dumps(_terminal_payload(run)) + "\n", encoding="utf-8")
+    tc.gate_ledger_path(log).write_text(
+        json.dumps(
+            {
+                "schema_version": tc.GATE_LEDGER_SCHEMA_VERSION,
+                "kind": tc.GATE_LEDGER_KIND,
+                "slice_id": "multi",
+                "gates": [
+                    {"name": "pytest", "exit_code": 1, "status": "failed", "detail": "a" * 4000},
+                    {"name": "openspec", "exit_code": 2, "status": "failed", "detail": "b" * 100},
+                    {"name": "policy", "exit_code": 0, "status": "passed", "detail": ""},
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    job = registry.create_job(
+        task="wf-multi",
+        persona="builder",
+        branch="feature/12-demo",
+        pane="",
+        worktree=str(tmp_path),
+        workflow_run_id=run.run_id,
+        workflow_card=CARD,
+        workflow_phase="build",
+        workflow_test_policy="focused",
+    )
+    registry.attach_launch_handle(job["job_id"], log_path=str(log))
+    registry.update_headless_result(job["job_id"], status="exited", exit_code=0)
+
+    rows = manager._prior_card_failed_gates(registry.get_job(job["job_id"]))
+
+    # passed 的 gate 不入列（判準與採信端 `_ledger_outcomes` 同一份）。
+    assert [row["name"] for row in rows] == ["pytest", "openspec"]
+    assert sum(len(row["detail"]) for row in rows) == manager.RETRY_CONTEXT_EVIDENCE_LIMIT
+    assert rows[1]["detail"] == ""
+    assert rows[1]["detail_truncated"] is True
+    assert rows[1]["exit_code"] == 2
+
+
+# ==========================================================================
+# 段 4：重派計數（#555 per-card 熔斷的鉤子）
+# ==========================================================================
+
+
+def test_redispatch_count_tracks_the_burned_jobs(tmp_path: Path) -> None:
+    """#606 現場燒了兩顆 job（492／493）：第三次派工必須自報 attempt=3。"""
+
+    registry = JobRegistry(state_path=tmp_path / "registry.json")
+    run = _run(registry, tmp_path)
+    first = _prior_job(
+        registry, run, tmp_path, terminal=_terminal_payload(run), name="job-492"
+    )
+    second = _prior_job(
+        registry, run, tmp_path, terminal=_terminal_payload(run), name="job-493"
+    )
+
+    one = manager._workflow_retry_context([first], registry=registry)
+    two = manager._workflow_retry_context([first, second], registry=registry)
+
+    assert (one["attempt"], one["redispatch_count"]) == (2, 1)
+    assert (two["attempt"], two["redispatch_count"]) == (3, 2)
+    # 最新那顆才是證據來源；全部 job id 仍列出供稽核（#555 的計數來源）。
+    assert two["previous_job_id"] == str(second["job_id"])
+    assert two["previous_job_ids"] == [str(first["job_id"]), str(second["job_id"])]
+
+    prompt = manager._workflow_job_prompt(
+        run,
+        run.steps[0],
+        builder_job_id=None,
+        coordinator_root=tmp_path,
+        retry_context=two,
+    )
+    assert "attempt 2 was rejected" in prompt
+
+
+# ==========================================================================
+# 段 5：status 語意的範圍紀律（#541 的同一條機械生成紀律）
+# ==========================================================================
+
+
+def test_status_policy_forbids_inferring_the_full_gate_from_a_focused_subset(
+    tmp_path: Path,
+) -> None:
+    """現場的行為模式：focused 綠 → 自稱全套綠。prompt 過去對此隻字未提。"""
+
+    registry = JobRegistry(state_path=tmp_path / "registry.json")
+    run = _run(registry, tmp_path)
+    env = {"PSC_GATE_CMD_PYTEST": "python3 -m pytest -q"}
+
+    schema = _contract(
+        manager._workflow_job_prompt(
+            run, run.steps[0], builder_job_id=None, coordinator_root=tmp_path, env=env
+        )
+    )["terminal_schema"]
+    policy = schema["status_policy"]
+
+    assert "focused subset" in policy
+    # 機械生成：實際會被 manager 重跑的命令逐字出現，不是手寫的泛稱。
+    assert "python3 -m pytest -q" in policy
+    assert policy.endswith(gate_ledger.gate_scope_honesty_hint(env))
+
+
+def test_status_policy_scope_hint_tracks_the_declaration(tmp_path: Path) -> None:
+    """宣告改動自動同步進 prompt——與 #541 的 allowed_names 同一條導出路徑。"""
+
+    registry = JobRegistry(state_path=tmp_path / "registry.json")
+    run = _run(registry, tmp_path)
+
+    changed = _contract(
+        manager._workflow_job_prompt(
+            run,
+            run.steps[0],
+            builder_job_id=None,
+            coordinator_root=tmp_path,
+            env={"PSC_GATE_CMD_PYTEST": "python3 -m pytest -q -x"},
+        )
+    )["terminal_schema"]["status_policy"]
+    assert "python3 -m pytest -q -x" in changed
+
+    empty = _contract(
+        manager._workflow_job_prompt(
+            run, run.steps[0], builder_job_id=None, coordinator_root=tmp_path, env={}
+        )
+    )["terminal_schema"]["status_policy"]
+    assert "never authorizes claiming the declared gate is green" in empty
+
+
+# ==========================================================================
+# 段 6：真正的重派路徑（retry-card／forced retry 共用的唯一組裝點）
+# ==========================================================================
+
+
+class _Launcher:
+    def __init__(self, sink: list[str]) -> None:
+        self._sink = sink
+
+    def as_commit_required(self):
+        return self
+
+    def launch(self, *, slice_id, prompt, worktree, log_dir):
+        self._sink.append(prompt)
+        return LaunchHandle(
+            executor="codex",
+            model_id="gpt-primary",
+            session_name=slice_id,
+            pid=100,
+            log_path=str(Path(log_dir) / f"{slice_id}.jsonl"),
+        )
+
+
+def _identities() -> IdentityRegistry:
+    return IdentityRegistry.from_rows(
+        [
+            {
+                "executor": "codex",
+                "model_id": "gpt-primary",
+                "independence_domain": "openai",
+                "capabilities": ["build"],
+            }
+        ]
+    )
+
+
+def test_forced_redispatch_prompt_carries_the_evidence(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """retry-card／daemon forced retry 真的派出去的那份 prompt 必須帶回饋。
+
+    兩條路徑都收斂在 `manager._dispatch_workflow_card` 這一個組裝點，所以這裡
+    只需要釘住那一點。
+    """
+
+    monkeypatch.setenv("PSC_GATE_CMD_PYTEST", "python3 -m pytest -q")
+    registry = JobRegistry(state_path=tmp_path / "registry.json")
+    run = _run(registry, tmp_path)
+    anchor = registry.create_job(
+        task="wf-anchor",
+        persona="builder",
+        branch="feature/12-demo",
+        pane="",
+        worktree=str(tmp_path),
+        dispatch_head="b" * 40,
+        subject_head=HEAD,
+        workflow_run_id=run.run_id,
+        workflow_card="worktree-isolation",
+        workflow_phase="build",
+    )
+    registry.update_headless_result(anchor["job_id"], status="exited", exit_code=0)
+    _prior_job(registry, run, tmp_path, terminal=_terminal_payload(run))
+    # 重派前的狀態：該卡被打回 pending（`_manager_reset_workflow_for_retry_card`
+    # 做的就是這件事），run 回到 ongoing。
+    run = registry._manager_update_workflow_run(
+        run.run_id,
+        steps=tuple(replace(step, gate_result="pending") for step in run.steps),
+    )
+    prompts: list[str] = []
+
+    replacement = manager.dispatch_workflow_card(
+        type("D", (), {"_registry": registry, "_git_runner": None})(),
+        run=registry.get_workflow_run(run.run_id),
+        identities=_identities(),
+        launcher_factory=lambda _: _Launcher(prompts),
+        coordinator_root=tmp_path / "coordinator",
+        force_new_card=True,
+    )
+
+    assert replacement is not None
+    assert len(prompts) == 1
+    contract = _contract(prompts[0])
+    assert contract["retry_context"]["attempt"] == 2
+    assert contract["retry_context"]["failed_gates"][0]["name"] == "pytest"
+    assert (
+        "test_v1_migration_creates_immutable_backup_and_isolates_legacy_records"
+        in prompts[0]
+    )
+    # 卡片契約本身一個字都沒被改（重派的是原卡）。
+    assert contract["card_id"] == CARD
+    assert contract["action"] == "Implement the accepted plan with the minimum diff."
+
+
+def test_first_dispatch_through_the_real_path_has_no_retry_context(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """同一條 dispatch 路徑，首派 prompt 不得出現 retry_context。"""
+
+    monkeypatch.setenv("PSC_GATE_CMD_PYTEST", "python3 -m pytest -q")
+    registry = JobRegistry(state_path=tmp_path / "registry.json")
+    run = _run(registry, tmp_path)
+    # worktree-isolation 已錨定 worktree／branch（現場即如此）；這張卡自己還沒派過。
+    anchor = registry.create_job(
+        task="wf-anchor",
+        persona="builder",
+        branch="feature/12-demo",
+        pane="",
+        worktree=str(tmp_path),
+        dispatch_head="b" * 40,
+        subject_head=HEAD,
+        workflow_run_id=run.run_id,
+        workflow_card="worktree-isolation",
+        workflow_phase="build",
+    )
+    registry.update_headless_result(anchor["job_id"], status="exited", exit_code=0)
+    prompts: list[str] = []
+
+    manager.dispatch_workflow_card(
+        type("D", (), {"_registry": registry, "_git_runner": None})(),
+        run=registry.get_workflow_run(run.run_id),
+        identities=_identities(),
+        launcher_factory=lambda _: _Launcher(prompts),
+        coordinator_root=tmp_path / "coordinator",
+    )
+
+    assert len(prompts) == 1
+    assert "retry_context" not in prompts[0]
+    assert "redispatched" not in prompts[0]
+
+
+# ==========================================================================
+# 段 7：fail-soft——證據取不到不得害死一次合法重派
+# ==========================================================================
+
+
+def test_unreadable_evidence_does_not_block_the_redispatch(tmp_path: Path) -> None:
+    """log 不存在／ledger 壞掉時仍回傳計數，只是沒有證據可附。"""
+
+    registry = JobRegistry(state_path=tmp_path / "registry.json")
+    run = _run(registry, tmp_path)
+    log = tmp_path / "logs" / "workflow" / "broken.jsonl"
+    log.parent.mkdir(parents=True, exist_ok=True)
+    log.write_text("{}\n", encoding="utf-8")
+    tc.gate_ledger_path(log).write_text("not json", encoding="utf-8")
+    job = registry.create_job(
+        task="wf-broken",
+        persona="builder",
+        branch="feature/12-demo",
+        pane="",
+        worktree=str(tmp_path),
+        workflow_run_id=run.run_id,
+        workflow_card=CARD,
+        workflow_phase="build",
+    )
+    registry.attach_launch_handle(job["job_id"], log_path=str(log))
+    registry.update_headless_result(job["job_id"], status="exited", exit_code=0)
+
+    context = manager._workflow_retry_context(
+        [registry.get_job(job["job_id"])], registry=registry
+    )
+
+    assert context["attempt"] == 2
+    assert context["failed_gates"] == []
+    # log 有內容但沒有 terminal payload：仍是可用的 canonical 診斷。
+    assert context["acceptance_error"]["error_class"] == "ValueError"
+
+    prompt = manager._workflow_job_prompt(
+        run,
+        run.steps[0],
+        builder_job_id=None,
+        coordinator_root=tmp_path,
+        retry_context=context,
+    )
+    assert "retry_context" in prompt


### PR DESCRIPTION
## 問題

現場（0816，run `workflow-7812abefede9d9b5d601`，#501 dogfooding）的 subagent-build，job 492 與 493：builder（codex／gpt-5.6-luna）兩次自稱 `pytest: passed`，Manager 的 gate ledger 兩次獨立重跑抓到**同一個**失敗（`tests/test_workflow_registry.py::test_v1_migration_creates_immutable_backup_and_isolates_legacy_records`），兩次 `GateContradictionError` 逐字相同。

根因不是重派錯誤。`retry-card`（#545／#574）刻意用**原卡 prompt** 重派——契約不可竄改是對的——但 prompt 沒有任何通道攜帶「上一次為什麼被拒」。builder 每次都跑 focused tests 看到綠、自稱全套 passed，ledger 每次抓包；沒有回饋，重試就只是燒 job。

## 修法（比照 #521／#540「prompt 由判準／證據機械生成」）

### 1. `retry_context`：重派 prompt 的證據回饋通道

新增 `manager._workflow_retry_context()`，輸入就是 `_dispatch_workflow_card` 既有的 `matching`（同一張卡的先前 job；verify／review 另以 candidate 定錨），輸出機械組出一個 `retry_context` 區塊塞進 dispatch contract：

- **採信錯誤類別＋canonical 訊息**（`acceptance_error`）：不讀任何敘事欄位——`run.needs_human_reason` 在 `retry-card` 重置時依診斷 invariant 已被清空——而是對舊 job **重跑既有採信路徑的前兩段**（同一份 log、同一份 gate ledger、同一組判準函式），因此拿到的錯誤與當初 harvest 擲出的逐字相同。兩型都覆蓋：`GateContradictionError`（#606 現場）與「log 完全沒有 JSON envelope」（#569 現場）。
- **gate ledger 的 failed gates**（`failed_gates`）：名稱＋exit code＋截尾輸出。「哪些算 failed」複用 `terminal_contract._ledger_outcomes`（採信端判定矛盾用的就是它，exit_code 非 0 覆寫自述 status）——retry-context 不得另立第二份判準，否則 prompt 會告訴 builder 一組跟採信不同的失敗集合。
- **明示語句**：prompt 散文多一句「attempt N was rejected by the Manager's own independent evidence … Reproduce that failure first, fix it, and only then complete this card」，並點明那份證據是 Manager 自產、不是前一次嘗試的自述。

內容**一個字都不取自模型輸出**（與 #540 的不可竄改性同一條紀律）。`retry-card` 與 daemon 的 forced retry 都收斂在 `_dispatch_workflow_card` 這唯一一個 prompt 組裝點，因此兩條路徑同時拿到回饋，不需要第二份實作。

### 2. 首派逐字不變

`_workflow_job_prompt(retry_context=None)` 是預設值；首派時 `matching` 為空 → 回 `None` → contract 沒有 `retry_context` 鍵、散文也不多一個字，prompt 與本票之前**逐字相同**。有兩個測試釘住（直接比對字串相等，以及走真正 dispatch 路徑的那條）。

### 3. 截斷上限（prompt 不得被 gate 輸出撐爆）

- `RETRY_CONTEXT_EVIDENCE_LIMIT = 2000`：**全體** failed gate `detail` 的合計預算，保留尾段（pytest 的 short summary 在最後，那才是可重現的線索；與 `gate_ledger.run_gates` 自己的 `[-2000:]` 同向），被截的項目帶 `detail_truncated` 明示。
- `RETRY_CONTEXT_MESSAGE_LIMIT = 600`：`GateContradictionError` 的訊息會把 ledger detail 內嵌進去，同樣要有上限。
- fail-soft：log／ledger 讀不到或壞掉時回空證據＋計數，**不得讓「讀不到舊證據」害死一次合法重派**。

### 4. status 語意補上範圍紀律（issue 附帶觀察）

`terminal_schema.status_policy` 末段接上新的 `gate_ledger.gate_scope_honesty_hint()`：明說「focused 綠**不是**宣告的 gate 綠」的推定不成立，而且**實際會被 Manager 重跑的命令逐字出現在 prompt 裡**——與 #541 的 `allowed_names` 同一條機械生成紀律（值由 operator 的 `PSC_GATE_CMD_*` 宣告導出，不手寫第二份真實來源）。現場的行為模式（run `084f...` 的 job 488、run `7812...` 的 492／493）過去在 prompt 裡隻字未提。

### 5. 與 #555 的接口

`retry_context` 帶 `attempt`（本次是這張卡的第 N 次派工）與 `redispatch_count`（已重派過幾次），由這張卡已燒掉的 job 數機械導出。**本 PR 不實作熔斷**，只把計數落到 prompt 與 retry-context 上，讓 #555 的 per-card 熔斷判準之後有一個既有的、機械的來源可接。

## 變更檔案

- `paulsha_cortex/coordinator/manager.py`：新增 `RETRY_CONTEXT_EVIDENCE_LIMIT`／`RETRY_CONTEXT_MESSAGE_LIMIT`／`_retry_context_error_row`／`_prior_card_acceptance_error`／`_prior_card_failed_gates`／`_workflow_retry_context`；`_workflow_job_prompt` 新增 `retry_context` 參數（預設 `None`）與散文段落；`_dispatch_workflow_card` 在唯一的 prompt 組裝點注入。
- `paulsha_cortex/coordinator/gate_ledger.py`：新增 `gate_scope_honesty_hint()`。
- `tests/test_retry_feedback_context_606.py`：14 測試。
- `CHANGELOG.md` ＋ `changelog.d/retry-feedback-context.md`。

## 測試

- 新檔 14 測試：重派 prompt 含前次 ledger 失敗證據（#606 現場形狀 fixture，含逐字的失敗測試名）、證據來源是 Manager 而非模型自述、`GateContradictionError` 與 no-JSON 兩型、首派逐字不變（直接字串相等）＋別張卡的失敗不得污染本卡首派、gate detail 截斷上限、錯誤訊息截斷上限、多個 failed gate 共用同一份預算、重派計數正確、status_policy 的範圍紀律＋宣告改動自動同步、真正 dispatch 路徑（forced retry 帶證據／首派不帶）、fail-soft。
- 修復前跑新檔：**13 failed, 1 passed**（RED 已驗）。
- 全套 `python3 -m pytest -q`：**3325 passed, 49 subtests passed**（無 red）。

## Checklist

- [x] `changelog.d/retry-feedback-context.md` fragment 已新增且已 commit
- [x] `CHANGELOG.md [Unreleased]` 有對應 entry
- [x] `VERSION` 未動（非 release PR）
- [x] 全套測試通過
- [x] 分支命名 `feature/<N>-<slug>`，非 `main`

Refs #606 #555 #540
