### PR TITLE
fix(tests): 移除測試對真實 github.com 的網路依賴並加上守衛

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -372,6 +372,27 @@
   `tests/test_monitor_git_native_reads_506.py`（16 個測試，含量化驗收樁）。
 
 ### Fixed
+- **#610：測試套件有測試打真實 github.com，builder sandbox 全套中止於 71%；兩處修為
+  hermetic ＋ 加上 conftest 層網路守衛**——run `workflow-7812abefede9d9b5d601`（job 494）
+  的 builder 在 codex sandbox（network allowlist）跑全套被 egress 攔截、整個 process 被殺
+  （`exit -1`），誠實 builder 因此無法完成驗證。以「socket monkeypatch ＋ `PATH` 上的
+  `git`／`gh` 記錄 shim ＋ `unshare -rn` 斷網對照」定位出兩處真兇：
+  `tests/test_pre_candidate_recovery.py::test_candidate_worktree_dirty_reevaluation_on_tick`
+  （collection 順序 69.0%，緊接 `test_porcelain_*` 批次之後）用相對 `spec_path` 讓
+  `autonomy._infer_repo_root` 解析到「當下 cwd ＝ 真實 cortex checkout」，於是
+  `manager.complete_tick` 對真實 repo 跑 `git fetch --no-tags origin main` 直打
+  github.com；`tests/test_work_gc.py::test_cli_main_dry_run_text_and_json` 走 `gc.main`
+  時把 `default_pr_status_provider` 接上真的 `gh pr list`。前者改用 conftest 既有的
+  `git_origin` fixture（`insteadOf` 改寫到本機 bare origin）＋ fixture repo 內的絕對
+  spec 路徑，後者注入本機假 provider 並反過來斷言 CLI 佈線。新增
+  `tests/network_guard.py`：session-scope、預設啟用的兩層守衛（socket 層白名單
+  AF_UNIX／loopback；subprocess 層檢查 `git` 的 transport subcommand——以
+  `git ls-remote --get-url` 解出 `insteadOf` 改寫後的實際 URL 再判本機性——與 `gh`／
+  `curl`／`wget`／`pip` 等純網路 client），違規當場失敗並指名測試 nodeid，另有 per-test
+  帳本防止 `except Exception:` 吞掉守衛例外；逃生口 `PSC_TEST_ALLOW_NETWORK=1` 與
+  `@pytest.mark.network`（預設排除，`--run-network` 才跑）。新增
+  `tests/test_network_guard_610.py`（33 測試）自證守衛會抓也會放行。詳見
+  `changelog.d/test-network-hermetic.md`。
 - **#565：`/tmp` 的空 `.git` 目錄使 `_infer_repo_root` 全域劫持到 `/tmp`，production
   推斷與測試皆不 hermetic**——agent sandbox 基礎設施會在 sandbox 存活期間於 `/tmp`
   暫態 `mkdir` 一個**空的** `.git`（teardown 後消失，`rm` 被防護 hook 擋下只能 `mv`

--- a/README.md
+++ b/README.md
@@ -759,6 +759,14 @@ export PSC_DIGEST_DELIVERY_CMD='/path/to/relay-script --channel ops'
 - repo 宣告 `tier: shareable`，所有範例與測試都必須維持去識別化。
 - repo policy 由 canonical `.project-policy.yml` 宣告，並 pin paulsha-conventions v1.0.17。
 - agent 慣例檔採 symlink 模式：`AGENTS.md`、`GEMINI.md`、`.github/copilot-instructions.md` 都指向 `CLAUDE.md`。
+- **測試不得打真實網路（#610）**：`tests/network_guard.py` 是 session-scope、預設啟用的
+  守衛，攔 socket 層（白名單 AF_UNIX 與 loopback）與 subprocess 層（`git` 的 transport
+  subcommand 以 `git ls-remote --get-url` 解出 `insteadOf` 改寫後的實際 URL 再判本機性；
+  `gh`／`curl`／`wget`／`pip` 等純網路 client 一律違規）。違規當場失敗並指名測試 nodeid，
+  即使受測程式用 `except Exception:` 吞掉例外，per-test 帳本仍會在 teardown 讓它失敗。
+  需要 remote 的測試一律用本機 fixture（`git_origin` 造 tmp bare origin，或注入假
+  provider／runner）。本機除錯要放行整場用 `PSC_TEST_ALLOW_NETWORK=1`；本質上需要網路的
+  整合測試標 `@pytest.mark.network`（預設排除於全套，`--run-network` 才跑）。
 
 ## Version
 

--- a/changelog.d/test-network-hermetic.md
+++ b/changelog.d/test-network-hermetic.md
@@ -1,0 +1,53 @@
+# test-network-hermetic
+
+- **`#610` 測試套件不再打真實 github.com，並加上永久守衛**——現場 run
+  `workflow-7812abefede9d9b5d601`（job 494）：builder 在 codex sandbox（network allowlist）
+  單體 `python3 -m pytest -q` 跑到約 71% 被 `Network access to "github.com" was blocked`
+  直接殺掉整個 process（`exit -1`），誠實的 builder（#609 honesty hint 生效後）因此永遠
+  無法宣告 `passed`，合格 candidate 卡在契約外。這是繼 #565（`/tmp` 空 `.git`）、#586
+  （AF_UNIX `bind` EPERM）、#608（`sun_path` 長度）之後**第四個 ledger gate 環境敏感點**，
+  且是唯一一個屬於「測試自身 hermeticity 缺陷」的。
+- **定位手法**：全套跑在 socket monkeypatch ＋ `PATH` 上的 `git`／`gh` 記錄 shim 底下
+  （shim 記 argv、cwd、`ls-remote --get-url` 解出的**實際** remote URL，並以
+  `pytest_runtest_protocol` 掛上 nodeid），另以 `unshare -rn` 斷網對照。命中兩處：
+  - `tests/test_pre_candidate_recovery.py::test_candidate_worktree_dirty_reevaluation_on_tick`
+    ——**真兇**，collection 順序 69.0%，緊接在 `test_porcelain_*` 批次之後（與 issue 描述的
+    「約 71%／porcelain 批次條件性命中」吻合）。slice 的 `spec_path` 寫成相對路徑
+    `specs/slice-3b.md`，`autonomy._infer_repo_root` 對它 `Path.resolve()` 時接到「當下
+    cwd ＝ 真實 cortex checkout」上，於是 `manager.complete_tick` 的 completion 判準對
+    **真實 repo** 跑 `git -C <真實 checkout> fetch --no-tags origin main`，origin 就是
+    `https://github.com/hamanpaul/paulsha-cortex.git`。正常環境靜默成功、sandbox 整個
+    process 被殺——測試結果從來看不出來。改用 conftest 既有的 `git_origin` fixture
+    （origin 字面值仍是 GitHub HTTPS，transport 由 `url.<local>.insteadOf` 改寫到同一個
+    tmp 目錄下的 bare repo），並把 `spec_path` 指到該 fixture repo 內的絕對路徑。
+  - `tests/test_work_gc.py::test_cli_main_dry_run_text_and_json`——`gc.main` 是唯一會把
+    `default_pr_status_provider` 接上去的入口，而該 provider 直接 spawn 真的
+    `gh pr list --head <branch> --state all`（讀 operator 的真 token）。本次環境下該 repo
+    沒有 remote，`gh` 在送出請求前就以 `no git remotes found` 短路，因此不是 71% 那次的
+    死因，但它是同族的活火山。改注入本機假 provider，並反過來斷言 CLI 真的有把 provider
+    佈線進 `run_gc`（比原本更嚴）。
+- **永久守衛 `tests/network_guard.py`（session-scope，預設啟用）**：兩層攔截，違規當場
+  raise 並**指名測試 nodeid**。
+  - **socket 層**：`socket.socket.connect` / `connect_ex` / `socket.create_connection`。
+    白名單 AF_UNIX（#586 家族）、AF_INET/AF_INET6 的 loopback（`127.0.0.0/8`、`::1`、
+    `::ffff:127.x`、`localhost`、未指定位址），其餘 family 一律放行。
+  - **subprocess 層**：`subprocess.Popen.__init__`（`run`／`call`／`check_output` 全部
+    收斂於此）。實測四起事故全在這一層——socket patch 看不到子行程自己開的 socket。
+    `git` 只檢查真的會走 transport 的 subcommand（`clone`／`fetch`／`pull`／`push`／
+    `ls-remote`），並用 `git ls-remote --get-url`（該旗標不與遠端通訊）把
+    `url.<local>.insteadOf` 改寫後的**實際** URL 解出來再判本機性，因此既有那批「字面值
+    是 GitHub、transport 在本機」的 hermetic fixture 一個都不會被自己的守衛誤殺；`gh`、
+    `curl`、`wget`、`pip` 等純網路 client 則一律視為違規（`--version`／`--help` 例外）。
+  - **帳本後盾**：`verification._run_git` 這類 `except Exception:` 形狀會吞掉守衛的例外，
+    因此違規同時記進 per-test 帳本，conftest 的 autouse teardown 無論如何都讓該測試失敗。
+  - **逃生口**：`PSC_TEST_ALLOW_NETWORK=1`（在 `pytest_configure` 讀，早於會清掉 `PSC_*`
+    的 `_clear_runtime_env`）整場停用；`@pytest.mark.network` 標記「本質上需要網路的整合
+    測試」，預設排除於全套，`--run-network` 才跑。
+  - **已知邊界**：守衛住在 pytest process 內，只看得到本 process 直接 spawn 的子行程；
+    測試若先 spawn python 子行程、再由它去 `git fetch` 則看不到（實測目前全套無此路徑）。
+- 新增 `tests/test_network_guard_610.py`（33 測試）自證守衛**會抓**（對外 TCP connect、
+  origin 指向 github.com 的 `git fetch`、隱式 origin、遠端 URL `clone`／`ls-remote`、
+  `gh api`、shell 字串形式、被吞掉的例外仍留帳）與**會放行**（loopback 往返、AF_UNIX、
+  AF_NETLINK、本機 bare remote、`insteadOf` 改寫後的 GitHub origin、`status`／`rev-parse`
+  等本機 subcommand、逃生口）。這些「會抓」案例在 syscall／spawn 之前就 raise，
+  **不發出任何真實封包**，sandbox 內同樣安全。

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,72 @@ import subprocess
 
 import pytest
 
+import network_guard
+
+
+# --- #610：測試不得出實網 ------------------------------------------------------
+#
+# builder 在 codex sandbox 內跑全套會被 egress 攔截整個殺掉（run 7812 死在 69%
+# 的 `git -C <真實 repo checkout> fetch origin main`），而正常環境網路是通的，
+# 缺陷從測試結果上完全看不出來。守衛把「靜默出網」變成當場失敗並指名測試。
+# 逃生口 `PSC_TEST_ALLOW_NETWORK=1` 在這裡讀——早於底下會清掉 `PSC_*` 的
+# `_clear_runtime_env`。
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    config.addinivalue_line(
+        "markers",
+        "network: 本質上需要真實網路的整合測試；預設全套不跑（需 --run-network）。",
+    )
+    network_guard.install()
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    parser.addoption(
+        "--run-network",
+        action="store_true",
+        default=False,
+        help="#610：連 @pytest.mark.network 的整合測試一起跑（會打真實網路）。",
+    )
+
+
+def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
+    if config.getoption("--run-network"):
+        return
+    skip_network = pytest.mark.skip(
+        reason="#610：需要真實網路的整合測試，預設排除於全套（--run-network 才跑）"
+    )
+    for item in items:
+        if item.get_closest_marker("network") is not None:
+            item.add_marker(skip_network)
+
+
+def pytest_runtest_protocol(item: pytest.Item, nextitem: pytest.Item | None):
+    """讓守衛在任何 setup/call/teardown 出網時都能指名是哪個測試。"""
+
+    network_guard.set_current_test(item.nodeid)
+    return None
+
+
+@pytest.fixture(autouse=True)
+def _network_guard(request: pytest.FixtureRequest):
+    """守衛的 per-test 帳本。
+
+    直接 raise 有可能被受測程式的 ``except Exception`` 吞掉（`_run_git` 就是
+    這種形狀），所以違規同時記在帳本裡，teardown 時無論如何都讓該測試失敗。
+    """
+
+    network_guard.drain_violations()
+    if request.node.get_closest_marker("network") is not None:
+        with network_guard.allow_network():
+            yield
+        network_guard.drain_violations()
+        return
+    yield
+    violations = network_guard.drain_violations()
+    if violations:
+        pytest.fail("\n\n".join(violations), pytrace=False)
+
 
 @pytest.fixture(autouse=True)
 def _clear_runtime_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:

--- a/tests/network_guard.py
+++ b/tests/network_guard.py
@@ -1,0 +1,503 @@
+"""#610：測試套件的「不得出實網」守衛。
+
+## 為什麼需要
+
+`builder` 在 codex sandbox（network allowlist）內跑單體 `python3 -m pytest -q`
+會被 egress 攔截直接殺掉整個 process（`Network access to "github.com" was
+blocked` → `exit -1`），誠實的 builder 因此永遠無法宣告 `passed`。真兇是
+**測試自身的 hermeticity 缺陷**：測試在真實 repo checkout 內觸發
+`git fetch origin main`（origin = github.com），或直接 spawn 真的 `gh`。
+
+正常環境（Manager ledger、CI）網路是通的，所以這種缺陷四年來從未被測試結果
+揭露——只有在斷網／allowlist 環境才會爆。守衛的目的就是把「靜默出網」變成
+**當場失敗並指名測試**，不必等到某個 sandbox 把整個 run 殺掉才發現。
+
+## 兩層攔截
+
+1. **socket 層**：`socket.socket.connect` / `connect_ex` / `create_connection`。
+   白名單：AF_UNIX（#586 的 sun_path 家族要用）、AF_INET/AF_INET6 的 loopback
+   （127.0.0.0/8、`::1`、`localhost`、未指定位址），其餘 family（AF_NETLINK…）
+   一律放行。這層擋的是 in-process 的 `urllib` / `http.client` / `asyncio`。
+
+2. **subprocess 層**：`subprocess.Popen.__init__`。實測的四起事故全部發生在
+   這一層——socket patch 看不到子行程自己開的 socket。`git` 只有真的會走
+   transport 的 subcommand（fetch/pull/push/clone/ls-remote）才檢查，並且用
+   `git ls-remote --get-url` 把 `url.<local>.insteadOf` 改寫後的**實際** URL
+   解出來再判 loopback／本機路徑；`gh`、`curl`、`wget` 這類純網路 client 則
+   一律視為違規（`--version` / `--help` 例外）。
+
+## 已知邊界
+
+守衛住在 pytest 的 process 裡，只看得到「本 process 直接 spawn 的子行程」。
+測試若先 spawn 一個 python 子行程、由該子行程再去 `git fetch`，守衛看不到
+（實測目前全套沒有這種路徑）。真要覆蓋孫行程得走 sitecustomize/LD_PRELOAD，
+代價與風險都高於它擋下的殘量，暫不做。
+
+## 逃生口
+
+`PSC_TEST_ALLOW_NETWORK=1`（在 `pytest_configure` 當下讀，早於會清掉 `PSC_*`
+的 autouse fixture）整場停用守衛，供本機除錯用。程式內另有
+:func:`allow_network` context manager 給守衛自己的測試與「本質上就是需要網路
+的整合測試」使用。
+"""
+
+from __future__ import annotations
+
+import contextlib
+import ipaddress
+import os
+import re
+import shlex
+import socket
+import subprocess
+import threading
+from pathlib import PurePath
+from typing import Any, Iterable, Sequence
+
+__all__ = [
+    "ALLOW_ENV",
+    "NetworkGuardViolation",
+    "allow_network",
+    "check_command",
+    "check_socket_address",
+    "current_test",
+    "drain_violations",
+    "enabled",
+    "install",
+    "set_current_test",
+    "uninstall",
+]
+
+ALLOW_ENV = "PSC_TEST_ALLOW_NETWORK"
+
+#: `gh` 之外仍會直接出網的 client；`git` 另外處理（它多數 subcommand 是本機的）。
+NETWORK_BINARIES = frozenset(
+    {
+        "gh",
+        "hub",
+        "glab",
+        "curl",
+        "wget",
+        "ssh",
+        "scp",
+        "sftp",
+        "rsync",
+        "nc",
+        "ncat",
+        "telnet",
+        "pip",
+        "pip3",
+        "npm",
+        "npx",
+        "yarn",
+        "pnpm",
+    }
+)
+
+#: 這些旗標只印本地資訊，不出網。
+OFFLINE_ONLY_FLAGS = frozenset({"--version", "-V", "--help", "-h", "help", "version"})
+
+#: `git` 真的會開 transport 的 subcommand。
+GIT_NETWORK_SUBCOMMANDS = frozenset(
+    {"clone", "fetch", "pull", "push", "ls-remote", "remote-http", "remote-https"}
+)
+
+#: `git <sub>` 之後、真正的位置參數之前可以出現、而且**自己吃掉下一個 token**
+#: 的選項（其餘 `-x` / `--x` 一律當成不吃參數的旗標）。
+GIT_VALUE_OPTIONS = frozenset(
+    {
+        "-o",
+        "--upload-pack",
+        "--receive-pack",
+        "--exec",
+        "--depth",
+        "--shallow-since",
+        "--shallow-exclude",
+        "--reference",
+        "--separate-git-dir",
+        "--branch",
+        "-b",
+        "--origin",
+        "--template",
+        "--config",
+        "-c",
+        "--server-option",
+        "--negotiation-tip",
+        "--jobs",
+        "-j",
+        "--recurse-submodules-default",
+        "--filter",
+        "--push-option",
+        "--receive-pack",
+        "--refmap",
+    }
+)
+
+_SCP_LIKE = re.compile(r"^[^/@]*@[^/:]+:")
+
+_LOOPBACK_HOSTNAMES = frozenset({"", "localhost", "localhost.localdomain", "ip6-localhost"})
+
+
+class NetworkGuardViolation(RuntimeError):
+    """測試嘗試對外連線。訊息一律帶上測試 nodeid 與被連的目標。"""
+
+
+_state = threading.local()
+_lock = threading.Lock()
+_current_test: str | None = None
+_violations: list[str] = []
+_enabled = False
+_installed = False
+
+_real_socket_connect = None
+_real_socket_connect_ex = None
+_real_create_connection = None
+_real_popen_init = None
+
+
+# --- 內部：re-entrancy ---------------------------------------------------------
+#
+# 守衛自己要 spawn `git ls-remote --get-url` 來解 insteadOf；那次 spawn 不能再
+# 被守衛檢查一輪（會無限遞迴）。
+
+
+def _reentrant() -> bool:
+    return getattr(_state, "inside", False)
+
+
+@contextlib.contextmanager
+def _reentrancy():
+    previous = getattr(_state, "inside", False)
+    _state.inside = True
+    try:
+        yield
+    finally:
+        _state.inside = previous
+
+
+@contextlib.contextmanager
+def allow_network():
+    """暫時放行對外連線——守衛自身的測試與 network-marked 整合測試專用。"""
+
+    previous = getattr(_state, "allowed", False)
+    _state.allowed = True
+    try:
+        yield
+    finally:
+        _state.allowed = previous
+
+
+def _bypassed() -> bool:
+    return not _enabled or _reentrant() or getattr(_state, "allowed", False)
+
+
+# --- 對外狀態 -----------------------------------------------------------------
+
+
+def enabled() -> bool:
+    return _enabled
+
+
+def current_test() -> str:
+    return _current_test or "<session>"
+
+
+def set_current_test(nodeid: str | None) -> None:
+    global _current_test
+    _current_test = nodeid
+
+
+def drain_violations() -> list[str]:
+    """取出並清空本測試累積的違規紀錄。"""
+
+    with _lock:
+        drained = list(_violations)
+        _violations.clear()
+    return drained
+
+
+def _violate(kind: str, target: str, detail: str = "") -> NetworkGuardViolation:
+    message = (
+        f"測試 {current_test()} 嘗試對外連線（{kind}）：{target}"
+        f"{f' — {detail}' if detail else ''}\n"
+        "測試必須 hermetic：改用本機 fixture（tmp git repo 當 remote、注入假的 "
+        "runner/provider），不得打真實網路。\n"
+        f"本機除錯若真的需要網路：{ALLOW_ENV}=1 python3 -m pytest ..."
+    )
+    with _lock:
+        _violations.append(message)
+    return NetworkGuardViolation(message)
+
+
+# --- socket 層 -----------------------------------------------------------------
+
+
+def _is_loopback_host(host: object) -> bool:
+    if isinstance(host, (bytes, bytearray)):
+        try:
+            host = host.decode("ascii")
+        except UnicodeDecodeError:
+            return False
+    if not isinstance(host, str):
+        # AF_INET 的位址一定是 str；不是的話交給 socket 自己去噴型別錯誤。
+        return True
+    candidate = host.strip()
+    if candidate.lower() in _LOOPBACK_HOSTNAMES:
+        return True
+    if candidate.startswith("::ffff:"):
+        candidate = candidate[len("::ffff:") :]
+    try:
+        parsed = ipaddress.ip_address(candidate.split("%", 1)[0])
+    except ValueError:
+        return False
+    return parsed.is_loopback or parsed.is_unspecified
+
+
+def check_socket_address(family: Any, address: Any) -> None:
+    """判定一次 socket connect；違規時 raise :class:`NetworkGuardViolation`。
+
+    公開出來讓守衛自己的測試能在**不真的發出封包**的前提下驗證判準。
+    """
+
+    if _bypassed():
+        return
+    if family not in (socket.AF_INET, socket.AF_INET6):
+        # AF_UNIX（#586）、AF_NETLINK…：本機通訊，不是 egress。
+        return
+    if not isinstance(address, tuple) or not address:
+        return
+    if _is_loopback_host(address[0]):
+        return
+    port = address[1] if len(address) > 1 else "?"
+    raise _violate("socket", f"{address[0]}:{port}")
+
+
+def _guarded_connect(self, address):
+    check_socket_address(getattr(self, "family", None), address)
+    return _real_socket_connect(self, address)
+
+
+def _guarded_connect_ex(self, address):
+    check_socket_address(getattr(self, "family", None), address)
+    return _real_socket_connect_ex(self, address)
+
+
+def _guarded_create_connection(address, *args, **kwargs):
+    if not _bypassed() and isinstance(address, tuple) and address and not _is_loopback_host(address[0]):
+        port = address[1] if len(address) > 1 else "?"
+        raise _violate("socket", f"{address[0]}:{port}")
+    return _real_create_connection(address, *args, **kwargs)
+
+
+# --- subprocess 層 -------------------------------------------------------------
+
+
+def _argv_of(args: Any, shell: bool) -> list[str]:
+    if isinstance(args, (str, bytes, PurePath)):
+        text = args.decode() if isinstance(args, bytes) else str(args)
+        if not shell:
+            return [text]
+        try:
+            return shlex.split(text)
+        except ValueError:
+            return [text]
+    if isinstance(args, Sequence):
+        out: list[str] = []
+        for token in args:
+            out.append(token.decode() if isinstance(token, bytes) else str(token))
+        return out
+    return []
+
+
+def _program_name(argv: Sequence[str]) -> str:
+    if not argv:
+        return ""
+    return PurePath(argv[0]).name
+
+
+def _raw_git_output(argv: list[str], cwd: str | None) -> str | None:
+    """用未被守衛攔截的 subprocess 問 git，失敗一律回 None。"""
+
+    with _reentrancy():
+        try:
+            proc = subprocess.run(
+                argv,
+                cwd=cwd,
+                capture_output=True,
+                text=True,
+                timeout=15,
+                check=False,
+            )
+        except Exception:
+            return None
+    if proc.returncode != 0:
+        return None
+    return proc.stdout.strip()
+
+
+def _split_git_command(argv: Sequence[str], cwd: str | None) -> tuple[str, list[str], str | None]:
+    """回傳 ``(subcommand, 其後的參數, 作用的 repo 目錄)``。"""
+
+    repo_dir = cwd
+    index = 1
+    while index < len(argv):
+        token = argv[index]
+        if token == "-C":
+            if index + 1 < len(argv):
+                repo_dir = os.path.join(repo_dir or os.getcwd(), argv[index + 1])
+            index += 2
+            continue
+        if token == "-c":
+            index += 2
+            continue
+        if token.startswith("-"):
+            index += 1
+            continue
+        break
+    if index >= len(argv):
+        return "", [], repo_dir
+    return argv[index], list(argv[index + 1 :]), repo_dir
+
+
+def _first_positional(tokens: Iterable[str]) -> str | None:
+    skip_next = False
+    for token in tokens:
+        if skip_next:
+            skip_next = False
+            continue
+        if token in GIT_VALUE_OPTIONS:
+            skip_next = True
+            continue
+        if token.startswith("-"):
+            continue
+        return token
+    return None
+
+
+def _is_local_git_url(url: str) -> bool:
+    candidate = url.strip()
+    if not candidate:
+        # 解不出 URL：多半是 `git -C <非 repo>`，那道 git 指令自己就會先失敗，
+        # 不會出網。這裡 fail-open，避免守衛製造偽陽性。
+        return True
+    if candidate.startswith(("/", "./", "../", "~")):
+        return True
+    lowered = candidate.lower()
+    if lowered.startswith("file://"):
+        return True
+    if "://" in candidate:
+        host = candidate.split("://", 1)[1].split("/", 1)[0]
+        host = host.rsplit("@", 1)[-1]
+        if host.startswith("["):
+            host = host[1 : host.find("]")] if "]" in host else host[1:]
+        else:
+            host = host.split(":", 1)[0]
+        return _is_loopback_host(host)
+    if _SCP_LIKE.match(candidate):
+        host = candidate.split("@", 1)[1].split(":", 1)[0]
+        return _is_loopback_host(host)
+    # 沒有 scheme 也沒有 `user@host:` → 相對路徑，本機。
+    return True
+
+
+def _check_git(argv: Sequence[str], cwd: str | None) -> None:
+    subcommand, rest, repo_dir = _split_git_command(argv, cwd)
+    if subcommand not in GIT_NETWORK_SUBCOMMANDS:
+        return
+    target = _first_positional(rest)
+    if subcommand == "clone":
+        raw = target or ""
+        resolved = _raw_git_output(["git", "ls-remote", "--get-url", raw], repo_dir) if raw else ""
+    else:
+        raw = target or "origin"
+        resolved = _raw_git_output(
+            ["git", "-C", str(repo_dir or os.getcwd()), "ls-remote", "--get-url", raw],
+            None,
+        )
+    effective = resolved if resolved else raw
+    if _is_local_git_url(effective):
+        return
+    raise _violate(
+        "git",
+        effective,
+        f"git {subcommand} (repo={repo_dir or os.getcwd()})",
+    )
+
+
+def check_command(args: Any, *, shell: bool = False, cwd: Any = None) -> None:
+    """判定一次 subprocess spawn；違規時 raise :class:`NetworkGuardViolation`。
+
+    公開出來讓守衛自己的測試能在**不真的 spawn**的前提下驗證判準。
+    """
+
+    if _bypassed():
+        return
+    argv = _argv_of(args, shell)
+    if not argv:
+        return
+    program = _program_name(argv)
+    cwd_text = str(cwd) if cwd is not None else None
+    if program == "git":
+        _check_git(argv, cwd_text)
+        return
+    if program in NETWORK_BINARIES:
+        if any(token in OFFLINE_ONLY_FLAGS for token in argv[1:]):
+            return
+        raise _violate("subprocess", " ".join(argv[:6]), f"{program} 是純網路 client")
+
+
+def _guarded_popen_init(self, *args, **kwargs):
+    try:
+        command = kwargs["args"] if "args" in kwargs else (args[0] if args else None)
+        shell = kwargs.get("shell", args[8] if len(args) > 8 else False)
+        cwd = kwargs.get("cwd", args[9] if len(args) > 9 else None)
+    except Exception:  # pragma: no cover - 只防禦奇怪的呼叫形狀
+        command, shell, cwd = None, False, None
+    if command is not None:
+        check_command(command, shell=bool(shell), cwd=cwd)
+    return _real_popen_init(self, *args, **kwargs)
+
+
+# --- 安裝／卸載 ---------------------------------------------------------------
+
+
+def install() -> bool:
+    """安裝守衛；回傳是否真的啟用（逃生口打開時回 ``False``）。"""
+
+    global _enabled, _installed
+    global _real_socket_connect, _real_socket_connect_ex, _real_create_connection
+    global _real_popen_init
+
+    if os.environ.get(ALLOW_ENV, "").strip() in {"1", "true", "yes", "on"}:
+        _enabled = False
+        return False
+    if _installed:
+        _enabled = True
+        return True
+
+    _real_socket_connect = socket.socket.connect
+    _real_socket_connect_ex = socket.socket.connect_ex
+    _real_create_connection = socket.create_connection
+    _real_popen_init = subprocess.Popen.__init__
+
+    socket.socket.connect = _guarded_connect
+    socket.socket.connect_ex = _guarded_connect_ex
+    socket.create_connection = _guarded_create_connection
+    subprocess.Popen.__init__ = _guarded_popen_init
+
+    _installed = True
+    _enabled = True
+    return True
+
+
+def uninstall() -> None:
+    global _enabled, _installed
+    if not _installed:
+        _enabled = False
+        return
+    socket.socket.connect = _real_socket_connect
+    socket.socket.connect_ex = _real_socket_connect_ex
+    socket.create_connection = _real_create_connection
+    subprocess.Popen.__init__ = _real_popen_init
+    _installed = False
+    _enabled = False

--- a/tests/test_network_guard_610.py
+++ b/tests/test_network_guard_610.py
@@ -1,0 +1,287 @@
+"""#610：網路守衛的自證測試。
+
+守衛本身是「防第五次同族事件」的唯一機制，因此它必須被證明**會抓**（真的對外
+連線／spawn 網路 client 時失敗並指名測試）而且**會放行**（loopback、AF_UNIX、
+本機 git remote 一律不受影響）。
+
+本檔案刻意**不發出任何真實封包**：守衛在 syscall／spawn 之前就 raise，所以
+「會抓」的案例對 sandbox 是安全的；「會放行」的案例則用純判準函式或本機
+transport（file path remote，git 走本機不開 socket）驗證。
+"""
+
+from __future__ import annotations
+
+import socket
+import subprocess
+from pathlib import Path
+
+import pytest
+
+import network_guard
+from network_guard import NetworkGuardViolation
+
+#: TEST-NET-3（RFC 5737），任何情況下都不該真的被連上；守衛會先擋下來。
+UNROUTABLE = ("203.0.113.7", 443)
+
+#: 逃生口打開時整個守衛不安裝，這份自證測試自然不適用。
+pytestmark = pytest.mark.skipif(
+    not network_guard.enabled(),
+    reason=f"{network_guard.ALLOW_ENV} 已開，守衛停用；本檔案是守衛自身的自證測試",
+)
+
+
+@pytest.fixture
+def swallowed_violations():
+    """收下本測試刻意觸發的違規，讓 conftest 的 teardown 帳本不會誤判。"""
+
+    network_guard.drain_violations()
+    yield
+    assert network_guard.drain_violations(), "預期至少記下一筆違規"
+
+
+# --- 守衛預設啟用 --------------------------------------------------------------
+
+
+def test_guard_is_installed_by_default() -> None:
+    assert network_guard.enabled() is True
+    assert network_guard.ALLOW_ENV == "PSC_TEST_ALLOW_NETWORK"
+
+
+def test_violation_message_names_the_current_test(swallowed_violations) -> None:
+    with pytest.raises(NetworkGuardViolation) as excinfo:
+        network_guard.check_socket_address(socket.AF_INET, UNROUTABLE)
+    message = str(excinfo.value)
+    assert "test_violation_message_names_the_current_test" in message
+    assert "203.0.113.7:443" in message
+    assert network_guard.ALLOW_ENV in message
+
+
+# --- socket 層 -----------------------------------------------------------------
+
+
+def test_outbound_tcp_connect_is_blocked_before_any_packet(swallowed_violations) -> None:
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        with pytest.raises(NetworkGuardViolation):
+            sock.connect(UNROUTABLE)
+    finally:
+        sock.close()
+
+
+def test_outbound_connect_ex_is_blocked(swallowed_violations) -> None:
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        with pytest.raises(NetworkGuardViolation):
+            sock.connect_ex(UNROUTABLE)
+    finally:
+        sock.close()
+
+
+def test_create_connection_is_blocked(swallowed_violations) -> None:
+    with pytest.raises(NetworkGuardViolation):
+        socket.create_connection(UNROUTABLE, timeout=0.01)
+
+
+@pytest.mark.parametrize(
+    "family, address",
+    [
+        (socket.AF_INET, ("127.0.0.1", 8765)),
+        (socket.AF_INET, ("localhost", 8765)),
+        (socket.AF_INET, ("", 8765)),
+        (socket.AF_INET, ("0.0.0.0", 8765)),
+        (socket.AF_INET6, ("::1", 8765, 0, 0)),
+        (socket.AF_INET6, ("::ffff:127.0.0.1", 8765, 0, 0)),
+        (socket.AF_UNIX, "/run/whatever.sock"),
+        (socket.AF_NETLINK, (0, 0)),
+    ],
+)
+def test_local_socket_targets_are_allowed(family, address) -> None:
+    network_guard.check_socket_address(family, address)
+
+
+def test_loopback_tcp_round_trip_is_untouched() -> None:
+    """真的起一個 loopback listener 並連上去——守衛不得干擾本機通訊。"""
+
+    listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        try:
+            listener.bind(("127.0.0.1", 0))
+        except OSError as exc:  # sandbox 可能連 bind 都擋（見 #586）
+            pytest.skip(f"runtime forbids binding a loopback listener: {exc}")
+        listener.listen(1)
+        client = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        try:
+            client.settimeout(5)
+            client.connect(listener.getsockname())
+            served, _ = listener.accept()
+            with served:
+                served.sendall(b"pong")
+            assert client.recv(4) == b"pong"
+        finally:
+            client.close()
+    finally:
+        listener.close()
+
+
+# --- subprocess 層：git --------------------------------------------------------
+
+
+def _init_repo(root: Path, *, origin: str | None = None) -> Path:
+    root.mkdir(parents=True, exist_ok=True)
+    subprocess.run(["git", "init", "--quiet", "-b", "main", str(root)], check=True)
+    subprocess.run(["git", "-C", str(root), "config", "user.email", "t@example.invalid"], check=True)
+    subprocess.run(["git", "-C", str(root), "config", "user.name", "t"], check=True)
+    if origin is not None:
+        subprocess.run(["git", "-C", str(root), "remote", "add", "origin", origin], check=True)
+    return root
+
+
+def test_git_fetch_against_a_github_origin_is_blocked(tmp_path: Path, swallowed_violations) -> None:
+    """#610 真兇一號的最小重現：origin 指到 github.com 的 repo 上跑 fetch。"""
+
+    repo = _init_repo(tmp_path / "repo", origin="https://github.com/hamanpaul/paulsha-cortex.git")
+    with pytest.raises(NetworkGuardViolation) as excinfo:
+        subprocess.run(
+            ["git", "-C", str(repo), "fetch", "--no-tags", "origin", "main"],
+            capture_output=True,
+            text=True,
+        )
+    assert "github.com" in str(excinfo.value)
+
+
+def test_git_fetch_with_implicit_origin_is_blocked(tmp_path: Path, swallowed_violations) -> None:
+    repo = _init_repo(tmp_path / "repo", origin="git@github.com:hamanpaul/paulsha-cortex.git")
+    with pytest.raises(NetworkGuardViolation):
+        subprocess.run(["git", "-C", str(repo), "fetch"], capture_output=True, text=True)
+
+
+def test_git_clone_from_a_remote_url_is_blocked(tmp_path: Path, swallowed_violations) -> None:
+    with pytest.raises(NetworkGuardViolation):
+        subprocess.run(
+            ["git", "clone", "https://github.com/hamanpaul/paulsha-cortex.git", str(tmp_path / "x")],
+            capture_output=True,
+            text=True,
+        )
+
+
+def test_git_ls_remote_against_a_remote_url_is_blocked(tmp_path: Path, swallowed_violations) -> None:
+    repo = _init_repo(tmp_path / "repo")
+    with pytest.raises(NetworkGuardViolation):
+        subprocess.run(
+            ["git", "-C", str(repo), "ls-remote", "https://github.com/example/acme.git"],
+            capture_output=True,
+            text=True,
+        )
+
+
+def test_local_git_remote_is_allowed(tmp_path: Path) -> None:
+    """本機 bare repo 當 remote：fetch 全程走檔案，守衛不得擋。"""
+
+    bare = tmp_path / "origin.git"
+    subprocess.run(["git", "init", "--quiet", "--bare", "-b", "main", str(bare)], check=True)
+    seed = _init_repo(tmp_path / "seed", origin=str(bare))
+    (seed / "README.md").write_text("seed\n", encoding="utf-8")
+    subprocess.run(["git", "-C", str(seed), "add", "README.md"], check=True)
+    subprocess.run(["git", "-C", str(seed), "commit", "--quiet", "-m", "seed"], check=True)
+    subprocess.run(["git", "-C", str(seed), "push", "--quiet", "origin", "main:main"], check=True)
+
+    consumer = _init_repo(tmp_path / "consumer", origin=str(bare))
+    completed = subprocess.run(
+        ["git", "-C", str(consumer), "fetch", "--no-tags", "origin", "main"],
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == 0, completed.stderr
+
+
+def test_insteadof_rewritten_github_origin_is_allowed(git_origin) -> None:
+    """conftest 的 `git_origin`：origin 字面值是 GitHub，transport 被 insteadOf
+    改寫到本機 bare。守衛必須看**改寫後**的 URL，否則整批既有 hermetic 測試會
+    被自己的守衛誤殺。"""
+
+    origin = git_origin("example/acme")
+    origin.commit({"README.md": "seed\n"})
+    origin.publish()
+    completed = subprocess.run(
+        ["git", "-C", str(origin.checkout), "fetch", "--no-tags", "origin", "main"],
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == 0, completed.stderr
+
+
+def test_local_git_subcommands_are_not_treated_as_network(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path / "repo", origin="https://github.com/example/acme.git")
+    for argv in (
+        ["git", "-C", str(repo), "status", "--porcelain"],
+        ["git", "-C", str(repo), "rev-parse", "--git-dir"],
+        ["git", "-C", str(repo), "config", "--get", "remote.origin.url"],
+        ["git", "-C", str(repo), "for-each-ref", "refs/remotes"],
+    ):
+        completed = subprocess.run(argv, capture_output=True, text=True)
+        assert completed.returncode == 0, completed.stderr
+
+
+# --- subprocess 層：純網路 client ----------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["gh", "api", "repos/hamanpaul/paulsha-cortex"],
+        ["gh", "pr", "list", "--head", "feature/x"],
+        ["curl", "https://example.invalid"],
+        ["wget", "https://example.invalid"],
+        ["pip", "install", "requests"],
+    ],
+)
+def test_network_clients_are_blocked(argv, swallowed_violations) -> None:
+    with pytest.raises(NetworkGuardViolation):
+        network_guard.check_command(argv)
+
+
+@pytest.mark.parametrize("argv", [["gh", "--version"], ["curl", "--version"], ["pip", "--help"]])
+def test_offline_only_invocations_of_network_clients_are_allowed(argv) -> None:
+    network_guard.check_command(argv)
+
+
+def test_shell_string_commands_are_inspected(swallowed_violations) -> None:
+    with pytest.raises(NetworkGuardViolation):
+        network_guard.check_command("gh api repos/hamanpaul/paulsha-cortex", shell=True)
+
+
+# --- 帳本：例外被吞掉仍要失敗 --------------------------------------------------
+
+
+def test_swallowed_violation_is_still_recorded_in_the_ledger() -> None:
+    """`verification._run_git` 這種 `except Exception:` 形狀會吞掉守衛的例外；
+    帳本是後盾，conftest 的 teardown 會據此讓測試失敗。"""
+
+    network_guard.drain_violations()
+    try:
+        network_guard.check_command(["gh", "api", "repos/x/y"])
+    except Exception:  # noqa: BLE001 - 刻意模擬受測程式吞例外
+        pass
+    recorded = network_guard.drain_violations()
+    assert len(recorded) == 1
+    assert "test_swallowed_violation_is_still_recorded_in_the_ledger" in recorded[0]
+    assert not network_guard.drain_violations(), "drain 後帳本必須清空"
+
+
+# --- 逃生口 --------------------------------------------------------------------
+
+
+def test_allow_network_context_manager_disables_the_guard() -> None:
+    with network_guard.allow_network():
+        network_guard.check_socket_address(socket.AF_INET, UNROUTABLE)
+        network_guard.check_command(["gh", "api", "repos/x/y"])
+        network_guard.check_command(["git", "clone", "https://github.com/example/acme.git", "/tmp/x"])
+    assert not network_guard.drain_violations(), "放行期間不得留下違規紀錄"
+    with pytest.raises(NetworkGuardViolation):
+        network_guard.check_command(["gh", "api", "repos/x/y"])
+    network_guard.drain_violations()
+
+
+def test_network_marker_is_registered(pytestconfig: pytest.Config) -> None:
+    markers = pytestconfig.getini("markers")
+    assert any(marker.startswith("network:") for marker in markers)

--- a/tests/test_pre_candidate_recovery.py
+++ b/tests/test_pre_candidate_recovery.py
@@ -215,8 +215,21 @@ def test_recover_pre_candidate_fail_closed_when_candidate_exists(tmp_path: Path)
         )
 
 
-def test_candidate_worktree_dirty_reevaluation_on_tick(tmp_path: Path, monkeypatch) -> None:
+def test_candidate_worktree_dirty_reevaluation_on_tick(tmp_path: Path, monkeypatch, git_origin) -> None:
     monkeypatch.setattr(manager, "_pinned_input_mismatches", lambda _slice: [])
+
+    # #610：`complete_tick` 的 completion 判準會對 slice 的 repo 根跑
+    # `git fetch --no-tags origin main`，而 repo 根是 `autonomy._infer_repo_root`
+    # 從 spec path 推出來的。原本 spec path 寫成相對的 `specs/slice-3b.md`，
+    # `Path.resolve()` 會把它接到「當下 cwd＝真實 cortex checkout」上，於是這個
+    # 單元測試每跑一次就對 github.com 發一次真的 fetch——正常環境靜默成功，
+    # sandbox（network allowlist）則整個 process 被殺（run 7812 死在 69% 就是這裡）。
+    # 改成本機 fixture repo：origin 的字面值仍是 GitHub HTTPS（保留生產形狀），
+    # 實際 transport 由 `url.<local>.insteadOf` 改寫到同一個 tmp 目錄下的 bare repo。
+    origin = git_origin("example/acme")
+    origin.commit({"README.md": "seed\n"})
+    origin.publish()
+    repo_root = origin.checkout
 
     state_path = tmp_path / "jobs.json"
     reg = JobRegistry(state_path=state_path)
@@ -234,7 +247,7 @@ def test_candidate_worktree_dirty_reevaluation_on_tick(tmp_path: Path, monkeypat
 
     reg.create_slice(
         slice_id="slice-3b",
-        spec_path="specs/slice-3b.md",
+        spec_path=str(repo_root / "specs" / "slice-3b.md"),
         spec_hash="spec-sha",
         plan_path="plans/slice-3b.md",
         plan_hash="plan-sha",

--- a/tests/test_work_gc.py
+++ b/tests/test_work_gc.py
@@ -382,7 +382,23 @@ def test_apply_reverifies_before_mutating_toctou(tmp_path: Path) -> None:
     assert _branch_exists(repo, "feature/clean-merged")
 
 
-def test_cli_main_dry_run_text_and_json(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+def test_cli_main_dry_run_text_and_json(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # #610：`gc.main` 是唯一會把 `default_pr_status_provider` 接上去的入口，而那個
+    # provider 直接 spawn 真的 `gh pr list`——讀 operator 的真 token、打 GitHub。
+    # 這裡要驗的是「CLI 有把 provider 佈線進 run_gc」，不是 gh 本身，因此把這條
+    # 網路 seam 換成本機假 provider，並反過來斷言它真的被呼叫到（比原本更嚴）。
+    pr_queries: list[tuple[Path, str]] = []
+
+    def fake_pr_status_provider(repo_root: Path, branch: str, **_kwargs: object) -> str | None:
+        pr_queries.append((Path(repo_root), branch))
+        return None
+
+    monkeypatch.setattr(gc, "default_pr_status_provider", fake_pr_status_provider)
+
     repo = tmp_path / "repo"
     _init_repo(repo)
 
@@ -413,6 +429,10 @@ def test_cli_main_dry_run_text_and_json(tmp_path: Path, capsys: pytest.CaptureFi
 
     # dry-run CLI 呼叫過後分支仍在。
     assert _branch_exists(repo, "feature/unmerged")
+
+    # CLI 兩次呼叫都要把 PR 狀態 seam 接上（unmerged-content 分支才會查詢）。
+    assert [branch for _, branch in pr_queries] == ["feature/unmerged", "feature/unmerged"]
+    assert {root.resolve() for root, _ in pr_queries} == {repo.resolve()}
 
 
 def test_json_report_matches_versioned_schema(tmp_path: Path) -> None:


### PR DESCRIPTION
## 問題

run `workflow-7812abefede9d9b5d601`（job 494）：builder 在 codex sandbox（network
allowlist）跑單體 `python3 -m pytest -q`，約 71% 處被

```
Network access to "github.com" was blocked: domain is not on the allowlist for the current sandbox mode.
exit -1
```

殺掉整個 process。誠實的 builder（#609 honesty hint 生效後）因此永遠無法宣告
`passed`，合格 candidate 卡在契約外。這是繼 #565（`/tmp` 空 `.git`）、#586
（AF_UNIX `bind` EPERM）、#608（`sun_path` 長度）之後**第四個 ledger gate 環境敏感點**，
而且是唯一一個屬於「測試自身 hermeticity 缺陷」的——其他三個至少是 host 形狀問題。

## 定位手法

在 worktree 內以三重攔截跑全套：

1. **socket monkeypatch**（`socket.socket.connect` / `connect_ex` / `create_connection`
   / `getaddrinfo`），非 loopback 目標即記 traceback。
2. **`PATH` 上的 `git`／`gh` 記錄 shim**：記 argv、cwd、`-C` 目標，並以
   `git ls-remote --get-url` 解出 `insteadOf` 改寫後的**實際** remote URL（這一層才是
   關鍵——socket patch 看不到子行程自己開的 socket，而實測四起事故全在子行程）。
3. **`unshare -rn` 斷網對照**：確認斷網下沒有任何測試「因為缺網路而失敗」，也就是說
   出網全部是靜默的、測試結果永遠看不出來。

以 `pytest_runtest_protocol` 把 nodeid 掛進 shim 的環境變數做歸因（注意 conftest 的
`_clear_runtime_env` 會清掉所有 `PSC_*`，歸因用的變數必須避開該前綴）。

## 真兇清單

| 測試 | 打網路的確切機制 | collection 位置 |
| --- | --- | --- |
| `tests/test_pre_candidate_recovery.py::test_candidate_worktree_dirty_reevaluation_on_tick` | slice 的 `spec_path` 寫成相對路徑 `specs/slice-3b.md`；`autonomy._infer_repo_root` 對它 `Path.resolve()` 時接到「當下 cwd ＝ **真實 cortex checkout**」上（`paths.repo_root()` 的預設就是 `Path.cwd()`），於是 `manager.complete_tick` → `_completion_candidate_ref` 對真實 repo 跑 `git -C <真實 checkout> fetch --no-tags origin main`，而該 repo 的 origin 就是 `https://github.com/hamanpaul/paulsha-cortex.git` | **69.0%**（3333 選中的第 2301 個），緊接在 `test_porcelain_*` 批次（結束於 68.9%）之後 |
| `tests/test_work_gc.py::test_cli_main_dry_run_text_and_json` | `gc.main` 是唯一會把 `default_pr_status_provider` 接上去的入口，該 provider 直接 `subprocess.run(["gh", "pr", "list", "--head", <branch>, "--state", "all", ...])`——spawn 真的 `gh`、讀 operator 的真 token | 95.0% |

第一筆就是 71% 那次的死因：它的位置與 issue 描述的「約 71%／porcelain 批次條件性命中」
完全吻合（`test_pre_candidate_recovery.py` 在字母序上緊接 `test_porcelain_*`，以
`tests/test_p*.py` 之類的 glob 分批時會被算進「porcelain 批次」）。

第二筆在本次環境下**沒有真的出網**：該測試的 tmp repo 沒有 remote，`gh` 在送出請求前就
以 `no git remotes found` 短路。但它一樣是同族的活火山（換個有 remote 的 fixture、或 `gh`
自己的 update check 觸發，就會出網），且它會讀 operator 的真實憑證，因此一併修掉並在此
如實說明其嚴重度差異。

**沒有動到任何 production 程式碼。** `_infer_repo_root` 與 `default_pr_status_provider`
的行為都是生產上正確的意圖，缺陷純粹在測試怎麼餵它們。

## hermetic 手法

- `test_candidate_worktree_dirty_reevaluation_on_tick`：改用 conftest 既有的 `git_origin`
  fixture——origin 的**字面值仍是 GitHub HTTPS**（保留生產形狀），實際 transport 由
  `url.<local>.insteadOf` 改寫到同一個 tmp 目錄下的 bare repo；`spec_path` 改指向該
  fixture repo 內的絕對路徑，`_infer_repo_root` 於是落在 tmp repo 而非真實 checkout。
  fetch → `rev-parse refs/remotes/origin/main` → `merge-base --is-ancestor` 這條 completion
  判準**逐字走同一條分支**，斷言零變動。
- `test_cli_main_dry_run_text_and_json`：把 `gc.default_pr_status_provider` 這條網路 seam
  monkeypatch 成本機假 provider，並**反過來斷言 CLI 真的有把 provider 佈線進 `run_gc`**
  （記錄呼叫的 repo_root 與 branch）——比原本只驗輸出更嚴，覆蓋沒有損失。

沒有刪任何測試，也沒有任何 skip。

## 守衛設計（`tests/network_guard.py`，session-scope，預設啟用）

兩層攔截，違規**當場 raise 並指名測試 nodeid**：

- **socket 層**：`socket.socket.connect` / `connect_ex` / `socket.create_connection`。
  白名單 AF_UNIX（#586／#608 家族要用）、AF_INET/AF_INET6 的 loopback（`127.0.0.0/8`、
  `::1`、`::ffff:127.x`、`localhost`、未指定位址），其餘 family（AF_NETLINK…）一律放行。
- **subprocess 層**：`subprocess.Popen.__init__`（`run`／`call`／`check_output` 全部收斂
  於此）。`git` 只檢查真的會走 transport 的 subcommand（`clone`／`fetch`／`pull`／`push`／
  `ls-remote`），並用 `git ls-remote --get-url`（該旗標明文「不與遠端通訊」）把
  `url.<local>.insteadOf` 改寫後的**實際** URL 解出來再判本機性——因此既有那批「字面值是
  GitHub、transport 在本機」的 hermetic fixture 一個都不會被自己的守衛誤殺。`gh`、`curl`、
  `wget`、`pip`、`npm` 等純網路 client 則一律視為違規（`--version`／`--help` 例外）。
- **帳本後盾**：`verification._run_git` 這類 `except Exception:` 形狀會吞掉守衛的例外，
  所以違規同時記進 per-test 帳本，conftest 的 autouse fixture 在 teardown 無論如何都讓該
  測試失敗。守衛因此無法被「剛好包在 try/except 裡」靜默繞過。
- **逃生口**：`PSC_TEST_ALLOW_NETWORK=1`（在 `pytest_configure` 讀，早於會清掉 `PSC_*` 的
  `_clear_runtime_env`）整場停用；程式內另有 `network_guard.allow_network()` context
  manager；`@pytest.mark.network` 標記「本質上就是需要網路的整合測試」，**預設排除於全套**，
  `--run-network` 才跑（目前沒有任何測試需要用它）。
- **已知邊界**（寫在模組 docstring）：守衛住在 pytest process 內，只看得到本 process 直接
  spawn 的子行程。測試若先 spawn python 子行程、再由它去 `git fetch` 就看不到；實測目前全套
  沒有這種路徑（`PATH` shim 會涵蓋孫行程，掃出來是零）。要覆蓋孫行程得走
  sitecustomize／LD_PRELOAD，代價與風險高於它擋下的殘量，暫不做。

`tests/test_network_guard_610.py`（33 測試）自證守衛：

- **會抓**：對外 TCP `connect`／`connect_ex`／`create_connection`；origin 指向 github.com
  的 `git fetch`（真兇一號的最小重現）；隱式 origin（`git fetch` 不帶 remote）；遠端 URL 的
  `clone`／`ls-remote`；`gh api`／`gh pr list`／`curl`／`wget`／`pip install`；shell 字串
  形式；被 `except Exception:` 吞掉的違規仍留在帳本；訊息確實含測試 nodeid 與逃生口說明。
- **會放行**：loopback TCP 真實往返、`localhost`／`::1`／`::ffff:127.x`／未指定位址、
  AF_UNIX、AF_NETLINK、本機 bare remote 的 push/fetch、`insteadOf` 改寫後的 GitHub origin
  （回歸鎖：否則整批既有 hermetic fixture 會被守衛誤殺）、`status`／`rev-parse`／`config`／
  `for-each-ref` 等本機 subcommand、`--version`／`--help`、`allow_network()` 逃生口。

「會抓」的案例在 syscall／spawn **之前**就 raise，**不發出任何真實封包**，因此這份自證
測試在 sandbox 內同樣安全。

## 測試結果

| 情境 | 結果 |
| --- | --- |
| 修前・正常環境 | `3333 passed, 49 subtests passed`（出網靜默成功，看不出問題） |
| 修前・`unshare -rn` 斷網 | `2 failed, 3330 passed, 1 skipped`——兩筆失敗都是 `unshare -r` 把使用者映射成 root 造成的權限測試假陰性（root 繞過檔案權限檢查），與網路無關 |
| **修後・正常環境（守衛啟用）** | **`3366 passed, 49 subtests passed` in 58s**（3333 + 33 新增守衛測試） |
| **修後・`unshare -rn` 斷網（守衛啟用）** | **`3363 passed, 1 skipped`**，只剩上述同樣那 2 筆 root 映射假陰性（修前修後逐字相同，非本 PR 造成） |
| 修後・`PSC_TEST_ALLOW_NETWORK=1`（守衛停用） | `3333 passed, 33 skipped`——逃生口生效，守衛自證測試自動 skip，其餘**零行為差異** |
| 修後・重跑攔截儀器 | `gh` spawn **0**（修前 2）；Python socket 外連 **0**；`git` 的 transport subcommand 對外目標 **0**（只剩守衛自己的 `ls-remote --get-url` 探測，該旗標不與遠端通訊） |

守衛的額外成本：整場多 50 次 `git ls-remote --get-url` 探測，總 runtime 61.4s vs 61.1s，
量測不到差異。

## 相鄰缺陷（本 PR 未處理，供後續判斷）

- **`autonomy._infer_repo_root` 的 fallback 對「相對 spec path」是危險預設**：
  `paths.repo_root()` 預設 `Path.cwd()`，任何拿相對 spec path 進來的呼叫者都會在 cwd 恰好
  是真實 repo 時把 production 動作打到真實 repo 上。#565 收掉了 `/tmp` 那一半，cwd 這一半
  還在。測試層現在有守衛擋住，production 層是否該要求絕對路徑（或至少在推斷落回 cwd 時
  發診斷）值得單獨開票。
- **守衛看不到孫行程**：如上述已知邊界。若日後有測試改成「spawn python 子行程再打 git」，
  守衛會漏掉，屆時需要 sitecustomize 或 LD_PRELOAD 層。
- **`gc.default_pr_status_provider` 沒有逾時以外的失敗可見性**：`except Exception: return
  None`，`gh` 不可用時完全靜默降級。生產上是刻意的 best-effort，但 operator 無從得知 PR
  狀態註記是否真的查過。

## Checklist

- [x] 分支不是 `main`（`feature/610-test-network-hermetic`）
- [x] 新增 `changelog.d/test-network-hermetic.md` fragment 並已 commit
- [x] `CHANGELOG.md [Unreleased] > Fixed` 已補對應 entry
- [x] `README.md` 開發備註補上「測試不得打真實網路」段（守衛用法與逃生口）
- [x] `VERSION` 未更動（非 release PR）
- [x] 全套 `python3 -m pytest -q` 綠（正常環境 3366 passed；斷網等效條件同樣綠）
- [x] 未刪除任何測試、未新增任何 skip 來規避問題
- [x] 未更動任何 production 程式碼
- [x] repo `tier: shareable`：新增內容無個人絕對路徑／使用者名／廠商識別

Refs #610
