### PR TITLE
docs(trust-root): Phase 2b runbook 收斂為 A+B 單一路徑（三分 UID ＋ root-owned template unit）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@
 
 ## [Unreleased]
 
+### Changed
+- **#584 / trust-root Phase 2b runbook：A／B 兩案並列收斂為 A+B 單一路徑（docs-only）**
+  ——落實 operator 0816 第三輪裁決。polkit 的 `manage-units` 只暴露 unit 名與 verb、
+  不暴露 `User=`（#603 實測），因此「誰持有授權」與「授權能做什麼」兩層一起收：
+  **A＝UID 三分**（`cortex-manager` 不跑模型且是唯一 polkit subject／
+  `cortex-reviewer-planner`／`cortex-builder`，`THREE_WAY_SCHEME` 由備選轉定案，
+  全文 `two-way` → `three-way`，二分縮為一行歷史註記）＋
+  **B＝root-owned template unit**（`cortex-job@.service`，`User=cortex-builder` 寫死）＋
+  **C 由 root-owned shim 承接**（`/opt/cortex/bin/cortex-job-shim` 讀 Manager-owned
+  job-spec spool 導出 argv），切換點 `PSC_JOB_RUNNER=systemd-template`。第 5 步由
+  10 小節的兩案並列收斂為一條九節路徑；反向測試由「4＋7 條、其中 1 條期望成功」
+  收斂為 11 條**全部期望被拒**。殘餘風險重寫為「僅剩 `cortex-manager` 帳號的
+  supply-chain 類」，並誠實標註 M1／M2 分段（`_degraded_runner()` 目前只對 builder
+  persona 降權，reviewer／planner 的行程面降權屬後續工項）。**R9 攻擊矩陣四族 →
+  五族**：族 1–4 各跑 builder 與 reviewer-planner 兩個 subject，新增族 5
+  privilege-boundary——(a) 以 `cortex-manager` 請求 transient unit `--uid=root`
+  的五種形式（含 `--user` bus 與 `busctl` 直打 `StartTransientUnit`）必須被 polkit 拒、
+  (b) 三個 headless 帳號 × 九種手法改寫 template unit／shim／polkit 規則必須被
+  root-owned 拒（27 條），兩族各附 negative control。執行前提補三帳號與
+  `RUNNER_MODES` 檢查、回滾段補齊 template／shim／polkit／切換點／三帳號各自的回滾，
+  並重新統計為 9 步 ＋ 3 附錄、**32 個 sudo 點、122 個驗證點**（逐段落明細表）。
+  transient 路徑降為附錄 B 的降級備援並標明殘餘風險。
+  詳見 `changelog.d/ab-runbook-converged.md`。
+
 ### Added
 - **#606：重派 prompt 機械附上前次採信失敗證據——無回饋的重試不再是決定論的重複**
   ——現場 run `workflow-7812abefede9d9b5d601` 的 subagent-build（job 492／493）：builder

--- a/changelog.d/ab-runbook-converged.md
+++ b/changelog.d/ab-runbook-converged.md
@@ -1,0 +1,67 @@
+# ab-runbook-converged
+
+- **trust-root Phase 2b runbook 由「A／B 兩案並列、待 operator 拍板」收斂為
+  **A+B 單一路徑**（docs-only，不改任何一行程式碼、不動部署）**——落實 operator
+  0816 第三輪裁決（#584 留言）：polkit 的
+  `org.freedesktop.systemd1.manage-units` 只暴露 unit 名與 verb、**不暴露
+  `User=`／`--uid=`**（#603 實測），因此「誰持有授權」與「授權能做什麼」兩層必須
+  **一起收**，而不是二擇一。
+  - **UID 方案：三分為唯一路徑**。第 1 步由建兩個帳號改為建三個——
+    `cortex-manager`（Manager＋monitor、durable state owner、持 spawn 授權、
+    **不跑任何模型程式碼**）／`cortex-reviewer-planner`（reviewer＋planner 模型
+    job）／`cortex-builder`（builder 模型 job）。全文 `two-way` 改 `three-way`
+    （`permgen.THREE_WAY_SCHEME` 由備選轉定案）；二分縮為一行歷史註記與附錄 C 的
+    差異表，不再是可選路徑。新增三帳號的互斥驗證（互不可讀對方 HOME cache、
+    三者皆無 sudo、group 互不交集）。
+  - **第 5 步：A+B 合一，原 5-A／5-B 兩節（共 10 小節）收斂為一條九節路徑**——
+    (a) polkit 只授權 `cortex-manager` 對 `cortex-job@*.service` 的 `start`／`stop`，
+    **不授權 `manage-units` 的 transient 建立**（`polkit three-way --template`）；
+    (b) root-owned template unit `cortex-job@.service`（`User=cortex-builder` 寫死、
+    加固段寫死）；(c) **root-owned shim** `/opt/cortex/bin/cortex-job-shim` 讀
+    Manager-owned job-spec spool 導出 argv——把裁決保留的第三層 C（code-level argv
+    保證）從 Manager 端搬進 root 擁有的檔案；(d) 切換點
+    `PSC_JOB_RUNNER=systemd-template`。(c)(d) 依賴 #603 follow-up PR
+    （template-instance 模式），runbook 以「將由該 PR 提供」標註並附
+    「PR 未落地時做到哪裡」的分岔指引；每個落檔步驟後都跟一條對產生器的 `diff`，
+    介面一落地即自動對齊，runbook 不需改寫。
+  - **反向測試由「4 條 ＋ 7 條、其中 1 條期望成功」收斂為 5-7 的 11 條、全部期望被拒**
+    ——移除了舊版 5-A-5 (4) 那條「已知不會被拒（以 `cortex-svc` 起 `--uid=0`）」。
+  - **殘餘風險段重寫**：三分＋template 之下，「polkit 看不到 `User=`」與
+    「reviewer／planner 與 Manager 併帳」兩條殘餘**不再成立**（各附實測條目）；
+    polkit 的粗粒度仍在但已不構成提權（被授權的 unit 名 pattern 只對應一個
+    root-owned template，安全屬性全不由呼叫端提供）。剩下的殘餘收斂為
+    **`cortex-manager` 帳號的 supply-chain 類**（部署樹供應鏈、Manager 自身邏輯、
+    operator 帳號、polkit 不可用），逐條列出現有緩解與缺口。
+  - **R9 攻擊矩陣：四族 → 五族，且族 1–4 各跑兩個 subject**（`cortex-builder`
+    與 `cortex-reviewer-planner`，`cortex-manager` 僅作 negative control）。
+    新增**族 5 privilege-boundary**：(5.1) 以 `cortex-manager` 身分請求 transient
+    unit `--uid=root` 的五種形式（直接、借 job unit 名包裝、改用 `--property`
+    夾帶、`--user` bus 旁路、`busctl` 直打 `StartTransientUnit`）必須全部被 polkit
+    拒；(5.2) 三個 headless 帳號 × 九種手法（append／truncate／replace／drop-in／
+    改 shim／symlink 換 shim／rename `bin/`／改 polkit／刪 polkit）改寫
+    `/etc/systemd/system/cortex-job@.service` 或 `/opt/cortex/bin/cortex-job-shim`
+    必須全部被 root-owned 檔案權限拒（27 條）。兩族各附 negative control
+    （operator 的 sudo 做同樣的事必須成功；`cortex-manager` 起**合法** instance
+    必須成功），避免「polkit 把該帳號全擋掉」造成假綠。
+  - **執行前提補兩項**：三個帳號名稱未被占用＋產生器對 `three-way` 的 persona→帳號
+    映射自述；以及 `systemd-template` 是否已在 `job_runner.RUNNER_MODES`
+    （決定第 5 步 (d) 能不能開）。
+  - **回滾段補齊 A+B 的每個物件**：第 5-2（template unit，含 drop-in 目錄）、
+    5-3（shim）、5-4（polkit）、5-5（切換點）各自獨立一列；「全面回退」新增移除
+    shim、template drop-in 與**三個帳號**。
+  - **重新統計並列表**：9 步 ＋ 3 附錄、**32 個 `🔧 sudo` 點**、
+    **122 個 `✅ 驗證` 點**（逐段落明細表）。
+  - **新增附錄**：附錄 B「降級備援——transient unit」保留原方案 A 的完整操作，
+    但明示**不是主路徑**、必須在 #584 記錄啟用原因與預計關閉時間，並以對照表列出
+    降級期間多出來的殘餘風險（含產生器 `plan_residual_risk()` 的自述輸出）；
+    附錄 C 列出與第二輪裁決的逐項差異，供讀過舊版的人對照。
+  - **誠實邊界（M1／M2）**：`launcher.SubprocessLauncher._degraded_runner()` 目前
+    只對 builder persona 降權，因此 M1（本 runbook 全程）之後 reviewer／planner 仍
+    在 Manager 行程內以 `cortex-manager` 身分執行——「injection 可達的進程皆無
+    spawn 授權」在 M1 **只對 builder 成立**（builder 是唯一會跑 untrusted repo code
+    的 persona）。runbook 於開頭、5-8 殘餘風險表與第 8 步各標註一次，並要求把
+    「M2 是否完成」寫進 #584 的 D6 判定紀錄。
+  - 另標註 permgen 尚未跟上三分定案的兩個已知缺口（Manager HOME 仍沿用
+    `/var/lib/cortex-svc`；`cortex-reviewer-planner` 未進 `scaffold_directories`），
+    第 1 步以「一律以產生器輸出為準」＋手動補三行的方式處理，並在第 2 步稽核 3
+    給出對應的期望值。

--- a/docs/superpowers/runbooks/trust-root-phase2b-setup.md
+++ b/docs/superpowers/runbooks/trust-root-phase2b-setup.md
@@ -5,14 +5,15 @@ phase: 2b
 audience: operator
 supersedes: none
 tracking: "#584 — trust-root D6 母議題（本票 reference-only，不 auto-close；R-17 走 policy-exempt:issue-link 豁免）"
-decision: "operator 0816 第二輪裁決（#584 留言）——7 個未決點全數收斂"
+decision: "operator 0816 第三輪裁決（#584 留言）——降權機制定案 **A+B**：UID 三分 ＋ root-owned template unit，單一路徑，無 A／B 分歧"
 refs:
   - docs/superpowers/specs/trust-root-isolation-spec.md
   - paulsha_cortex/trust_root/registry.py
   - paulsha_cortex/trust_root/permgen.py
+  - paulsha_cortex/coordinator/job_runner.py
 ---
 
-# trust-root Phase 2b：root 設定 runbook（可執行版）
+# trust-root Phase 2b：root 設定 runbook（可執行版．A+B 單一路徑）
 
 > **本文件是可執行版**：每一步的命令可直接複製、每一步有驗證、每一步可回滾。
 > 文件本身**不執行任何 root 操作**；所有 `sudo` 都由 operator 親自輸入。
@@ -26,49 +27,73 @@ OS** 的手動流程。
 
 ---
 
-## 0816 第二輪裁決定案表（本 runbook 的前提）
+## 0816 第三輪裁決定案表（本 runbook 的前提）
 
-| 原未決點 | 定案 | 落在本 runbook |
+| 未決點 | 定案（0816 第三輪，#584 留言） | 落在本 runbook |
 |---|---|---|
-| 1 降權機制 | **systemd 降權 job unit ＋ polkit 收窄**（授權面只允許 `cortex-svc` 起 job unit）。**「降到哪個帳號」由誰強制**尚待 operator 在 A（`systemd-run`，code level 保證）／B（root-owned 模板 unit，OS 強制）之間擇一——兩案都已寫成完整可執行 | 第 5 步 |
-| 2 durable state 路徑 | **`/var/lib/cortex`**；worktree pool＝**`/var/lib/cortex/worktree`** | 第 2 步 |
-| 3 legacy-import | **物理隔離 ＋ hash manifest**（無簽章；簽章屬 Phase 3）。切換前 in-flight job **手動收尾** | 執行前提、第 3 步 |
-| 4 Manager 部署 | **`/opt/cortex`**（root 擁有，對服務唯讀） | 第 4 步 |
-| 5 `ReadWritePaths` | **由 R1 登記表經 permgen 機械產生**，不手寫 | 第 4c 步 |
-| 6 root 命令 codify | **不 codify**——不提供 `cortex install trust-root --system`；cortex 只產生命令字串 | 第 6 步 |
-| 7 R9 | **手動抽驗**（完整自動化矩陣屬另一工項） | 第 8 步 |
-| UID 方案 | **二分先行**（`cortex-svc` / `cortex-builder`），保留三分彈性（permgen 已參數化）；Manager 走 **system-level unit** | 第 1、4c 步 |
+| **降權機制** | **A+B 並行，單一路徑**。A＝UID **三分提前**；B＝**root-owned template unit**（`cortex-job@.service`，`User=` 寫死）。C（code-level argv 保證）自動保留為第三層，由 **root-owned shim** 承接 | 第 1、5 步 |
+| **UID 方案** | **三分為唯一路徑**：`cortex-manager`（Manager＋monitor，durable state owner，持 spawn 授權，**不跑任何模型程式碼**）／`cortex-reviewer-planner`（reviewer＋planner 模型 job）／`cortex-builder`（builder 模型 job）。`permgen.THREE_WAY_SCHEME` 由備選轉為**定案方案** | 第 1 步 |
+| durable state 路徑 | **`/var/lib/cortex`**；worktree pool＝**`/var/lib/cortex/worktree`** | 第 2 步 |
+| legacy-import | **物理隔離 ＋ hash manifest**（無簽章；簽章屬 Phase 3）。切換前 in-flight job **手動收尾** | 執行前提、第 3 步 |
+| Manager 部署 | **`/opt/cortex`**（root 擁有，對服務唯讀）；system-level unit，`User=cortex-manager` | 第 4 步 |
+| `ReadWritePaths` | **由 R1 登記表經 permgen 機械產生**，不手寫 | 第 4c 步 |
+| root 命令 codify | **不 codify**——不提供 `cortex install trust-root --system`；cortex 只產生命令字串 | 第 6 步 |
+| R9 | **手動抽驗**（五族；完整自動化矩陣屬另一工項） | 第 8 步 |
 
-### ⚠️ 唯一還需要 operator 拍板的一點（請先看這段）
+> **歷史註記（二分）**：0816 第二輪曾以二分（`cortex-svc` / `cortex-builder`）先行、
+> 三分為保留彈性；第三輪裁決後二分（`permgen.TWO_WAY_SCHEME`）**不再是可選路徑**，
+> 僅保留在程式碼中作為方案參數化的對照組，本 runbook 全文一律 `three-way`。
 
-裁決寫的是「**systemd-run** transient unit ＋ polkit 收窄到只能 `User=cortex-builder`」。
+### 為什麼是 A+B（而不是二選一）
+
 #603 實測確認一個**硬限制**：polkit 的 `org.freedesktop.systemd1.manage-units` action
 **只暴露 unit 名稱與 verb**，**不暴露 `User=`／`--uid=`**。授權之後，systemd 會照請求的
-**任意** `User=` 起 unit。因此「只能降到 `cortex-builder`」這一半 **polkit 無法強制**，
-必須另外找地方守：
+**任意** `User=` 起 unit。
 
-- **方案 A（`systemd-run` transient unit）**——0816 裁決的字面方案，程式碼**已落地**
-  （#603 `coordinator/job_runner.py`，`PSC_JOB_RUNNER=systemd-run`）。「降到哪個帳號」
-  由 Manager 端**封閉的 argv 產生器**在 code level 保證。
-  **殘餘風險**：與 `cortex-svc` **同 UID 的任何行程**都持有這個 grant，可請求任意
-  `User=`（含 `User=root`）的 transient unit——而**二分方案下跑模型的 reviewer／planner
-  就與 Manager 併帳**。這條風險與「**是否提前三分**」直接相關（三分把它縮回「只有
-  Manager 自己」）。
-- **方案 B（root-owned 模板 unit）**——`cortex-job@.service` 把 `User=cortex-builder`
-  硬寫死在 **root 擁有**的檔案裡，polkit 只放行該模板的實例、transient unit 一律拒。
-  「降到哪個帳號」因此由 **OS** 強制，殘餘為零。代價是 Manager 端要從 `systemd-run`
-  改成 `systemctl start cortex-job@<id>`，**屬待排的程式碼工項**。
+| polkit **能**強制 | polkit **不能**強制 |
+|---|---|
+| 呼叫者是哪個 UID（`subject.user`） | job 降到哪個帳號（`User=`／`--uid=`） |
+| unit 名前綴／pattern（`action.lookup("unit")`） | 任何 unit 屬性（`AmbientCapabilities=`、`ExecStart=`…） |
+| verb（只放行 `start`／`stop`） | — |
 
-**兩案在第 5 步都寫成完整可執行**（含各自的正向／反向驗證、殘餘風險實測）；
-operator 選定後只跑那一節，其餘步驟（1–4、6–9）兩案共用。**同時要一併裁決的是
-「是否提前三分」**——permgen 已參數化，只需把命令中的 `two-way` 換成 `three-way`。
+單靠 polkit 收窄，「只能降到 `cortex-builder`」這一半守不住。裁決因此把邊界拆成兩層，
+**兩層一起裝**：
+
+- **A（三分）縮小「誰持有授權」**：polkit 的 subject 只有 `cortex-manager`，而
+  `cortex-manager` **不跑任何模型程式碼**。prompt injection 可達的進程
+  （builder／reviewer／planner job）因此**完全不在授權面上**。
+- **B（template unit）縮小「授權能做什麼」**：被授權的唯一動作是 start／stop 一個
+  **root-owned** template 的 instance；`User=cortex-builder`、加固段、`ExecStart=` 全部
+  寫死在 root 擁有的檔案裡。**即使 `cortex-manager` 整個被攻陷，也改不了 `User=`、
+  傳不了屬性、換不掉 argv 的入口。**
+- **C（argv 保證）由 root-owned shim 承接**：`ExecStart=` 指向 `/opt/cortex/bin/` 底下
+  root 擁有的 shim，shim 讀 Manager-owned 的 job-spec spool 導出 argv。argv 的**形狀**
+  因此由 root-owned 程式決定，Manager 只能給參數。
+
+**transient unit（原方案 A 的主路徑）在本 runbook 中不再是主路徑**——polkit 規則
+**不授權** `manage-units` 的 transient 建立。它只保留在 **附錄 B（降級備援）** 供
+「template 路徑在本機不可用」時臨時使用，並在那裡逐條標明殘餘風險。
+
+### 分段落地（M1／M2）——請先讀完再開工
+
+| 里程碑 | 內容 | 本 runbook |
+|---|---|---|
+| **M1** | 三帳號建立、**檔案權限面完整三分**、builder job 經 `cortex-job@.service` 降權、polkit 只授 `cortex-manager` 對 `cortex-job@*` | ✅ 本 runbook 全程 |
+| **M2** | reviewer／planner job 也改經 template instance（`User=cortex-reviewer-planner`）落到自己的帳號 | ⏳ 程式碼工項（#603 follow-up；範圍以該 PR 實際落地為準） |
+
+**M1 下的誠實邊界**：`launcher.SubprocessLauncher._degraded_runner()` 目前只對 **builder
+persona** 降權（`review_only`＝reviewer、`read_only`＝planner 兩者皆非才降權）；因此在
+M2 之前，reviewer／planner 仍在 Manager 行程內以 `cortex-manager` 身分執行。
+「**injection 可達的進程皆無 spawn 授權**」這條在 M1 **只對 builder 成立**——而 builder
+正是攻擊面最大的那個（唯一會跑 untrusted repo code 的 persona）。M2 落地前，
+reviewer／planner 的三分只在**檔案權限層**成立（第 8 步族 2 會實測這一層）。
 
 ---
 
 ## 執行前提（開工前逐項確認，全部 `✅ 驗證`）
 
 ```bash
-# ✅ 1. in-flight job 手動收尾（裁決 3：切換期間不得有半途 job）
+# ✅ 1. in-flight job 手動收尾（裁決：切換期間不得有半途 job）
 cortex jobs
 cortex status
 #   期望：`cortex jobs` 無 running／dispatched 狀態的列；`cortex status` 無 pending request。
@@ -101,9 +126,40 @@ systemctl is-active polkit.service || systemctl is-active polkitd.service
 # ✅ 7. 磁碟空間足夠複製整棵 venv 與舊 state
 df -h /var /opt
 du -sh "$HOME/.agents" "$HOME/.local/share/pipx/venvs/paulsha-cortex" 2>/dev/null
+
+# ✅ 8.（A+B 新增）三分方案的三個帳號名稱皆未被占用，且產生器認得三分
+getent passwd cortex-manager cortex-reviewer-planner cortex-builder \
+  && echo "!! 已有同名帳號，先確認來源再繼續" || echo "three accounts free: OK"
+python3 - <<'PY'
+from paulsha_cortex.trust_root import permgen
+from paulsha_cortex.trust_root.registry import Principal
+s = permgen.SCHEMES["three-way"]
+print("scheme_id          :", s.scheme_id)
+print("manager            :", s.resolve(Principal.MANAGER))
+print("monitor            :", s.resolve(Principal.MONITOR))
+print("reviewer           :", s.resolve(Principal.REVIEWER))
+print("planner            :", s.resolve(Principal.PLANNER))
+print("builder            :", s.resolve(Principal.BUILDER))
+print("durable_state_owner:", s.durable_state_owner)
+print("headless_accounts  :", sorted(s.headless_accounts()))
+PY
+#   期望：manager/monitor → cortex-manager（＝durable_state_owner）；
+#         reviewer/planner → cortex-reviewer-planner；builder → cortex-builder。
+
+# ✅ 9.（A+B 新增）template-instance 模式是否已在程式碼落地（決定第 5 步 (d) 能不能開）
+python3 - <<'PY'
+from paulsha_cortex.coordinator import job_runner
+modes = getattr(job_runner, "RUNNER_MODES", ())
+print("RUNNER_MODES =", modes)
+print("systemd-template available:", "systemd-template" in modes)
+PY
+#   期望（#603 follow-up PR 落地後）：True。
+#   若 False：第 5 步的 (a)(b)(c) 仍可全部安裝並用 5-7 的反向測試證明邊界，
+#   只有 (d) 切換點暫不打開（Manager 維持 per-case-approval 不 spawn job）。
 ```
 
-**通過條件**：1–7 全部符合期望；`equation` 回傳 `ok: true`；baseline JSON 已存檔。
+**通過條件**：1–8 全部符合期望；`equation` 回傳 `ok: true`；baseline JSON 已存檔；
+第 9 項無論真假都**記錄**在 #584（決定本次是否走到 (d)）。
 Phase 1 自檢此時**預期為紅**（有 `job-writable` finding）——那正是本 runbook 要收斂的
 清單，切換完成後（第 7 步）應轉綠。
 
@@ -127,81 +183,185 @@ Phase 1 自檢此時**預期為紅**（有 `job-writable` finding）——那正
 - 命令中的路徑一律為裁決定案的**真實絕對路徑**，可直接複製。
 - 個人路徑一律以 `$HOME` 表示，**不寫死使用者名**。
 
-## 產生器＝權限／unit／polkit 的單一真相
+## 本 runbook 的規模（收斂後重新統計）
 
-`chown`／`chmod`／`setfacl`／unit 內容／polkit 規則**一律不手寫**，全部由 permgen 由
-R1 登記表機械產生：
+A/B 並列時同一件事要寫兩遍（5-A／5-B、第 8 步兩種起法、附錄兩組 diff）；
+收斂為單一路徑後統計如下：
 
-```bash
-# ✅ 完整權限計畫（JSON，含每項 rationale）
-python3 -m paulsha_cortex.trust_root permissions two-way
+| 段落 | 🔧 sudo 點 | ✅ 驗證點 |
+|---|---:|---:|
+| 執行前提 | 0 | 9 |
+| 產生器＝單一真相 | 0 | 6 |
+| 第 1 步：建三帳號 | 4 | 5 |
+| 第 2 步：目標樹與權限 | 2 | 12 |
+| 第 3 步：legacy-import | 2 | 8 |
+| 第 4 步：Manager 部署與 unit | 5 | 12 |
+| **第 5 步：降權（A+B）** | **7** | **24** |
+| 第 6 步：升級流程 | 2 | 5 |
+| 第 7 步：切換驗收 | 0 | 3 |
+| 第 8 步：R9 抽驗（五族） | 4 | 17 |
+| 第 9 步：回滾 | 3 | 1 |
+| WSL2 風險與診斷 | 1 | 12 |
+| 附錄 A：自我檢查 | 0 | 5 |
+| 附錄 B：降級備援 | 2 | 3 |
+| **合計** | **32** | **122** |
 
-# ✅ 可直接執行的權限命令（帶真實絕對路徑，無 placeholder）
-python3 -m paulsha_cortex.trust_root permissions two-way --commands --paths
+（統計方式：全文 `🔧`／`✅` 標記出現次數，扣除說明性用法——「標記約定」的定義行、
+段落標題內的標記、以及表格裡當狀態記號用的那幾個。）
 
-# ✅ 骨架目錄（非登記表資產的父層）
-python3 -m paulsha_cortex.trust_root scaffold two-way
-
-# ✅ Manager system unit 內容（ReadWritePaths 由登記表導出）
-python3 -m paulsha_cortex.trust_root unit two-way --manager
-
-# ✅ 降權 polkit 規則內容（方案 A：systemd-run transient unit）
-python3 -m paulsha_cortex.trust_root polkit two-way --transient
-
-# ✅ 降權 polkit 規則內容（方案 B：root-owned 模板 unit）
-python3 -m paulsha_cortex.trust_root polkit two-way --template
-
-# ✅ 方案 B 的 job 模板 unit 內容（User=cortex-builder 硬寫死）
-python3 -m paulsha_cortex.trust_root unit two-way --job
-
-# ✅ 方案 A 的 --property= 建議清單（與 B 同源：同一加固表 ＋ 同一份 RWP）
-python3 -m paulsha_cortex.trust_root unit two-way --job-properties
-```
-
-> **未來若換三分**：把上列每個 `two-way` 改成 `three-way`，runbook 其餘結構不變
-> （permgen 已參數化；第 1 步多建一個帳號）。
+- **步驟數**：9 步（未變）＋ 3 個附錄；第 5 步由「兩個並列方案（5-A 六節／5-B 四節，
+  共 10 節）」收斂為**一條九節路徑**（5-1…5-9）。
+- **反向測試**：原本分散在 5-A-5（4 條，其中 1 條「已知不會被拒」）與 5-B-4（7 條），
+  收斂後集中在 5-7（**11 條**），且**全部期望為「被拒」**——不再有任何一條期望成功。
+- **R9 族數**：4 → **5**（新增族 5 privilege-boundary），且族 1–4 各跑**兩個 subject**
+  （builder ／ reviewer-planner），實測條數約為舊版的兩倍。
 
 ---
 
-## 第 1 步：建 UID（二分）
+## 產生器＝權限／unit／polkit／shim 的單一真相
 
-建立兩個 **system service 帳號**，皆 **no-login**、**home 由 root 擁有**。
-慣例：每帳號一個同名 primary group（權限產生器的 ACL 以此為前提）。
+`chown`／`chmod`／`setfacl`／unit 內容／polkit 規則**一律不手寫**，全部由 permgen 由
+R1 登記表機械產生。**三分（`three-way`）是唯一 scheme**：
 
 ```bash
-# 🔧 sudo：cortex-svc（durable state owner ＋ Manager/monitor/reviewer/planner）
-sudo groupadd --system cortex-svc
-sudo useradd  --system --gid cortex-svc \
+# ✅ 完整權限計畫（JSON，含每項 rationale）
+python3 -m paulsha_cortex.trust_root permissions three-way
+
+# ✅ 可直接執行的權限命令（帶真實絕對路徑，無 placeholder）
+python3 -m paulsha_cortex.trust_root permissions three-way --commands --paths
+
+# ✅ 骨架目錄（非登記表資產的父層）
+python3 -m paulsha_cortex.trust_root scaffold three-way
+
+# ✅ Manager system unit 內容（User=cortex-manager，ReadWritePaths 由登記表導出）
+python3 -m paulsha_cortex.trust_root unit three-way --manager
+
+# ✅ job template unit 內容（User=cortex-builder 硬寫死；B 的核心）
+python3 -m paulsha_cortex.trust_root unit three-way --job
+
+# ✅ 降權 polkit 規則內容（只放行 cortex-job@*.service 的 start/stop）
+python3 -m paulsha_cortex.trust_root polkit three-way --template
+```
+
+**尚未由已 merge 介面提供、將由 #603 follow-up PR（template-instance 模式）提供的兩項**：
+
+```bash
+# ⏳ root-owned shim 內容（/opt/cortex/bin/cortex-job-shim）
+#    將由該 PR 以下列形式提供（命令名以該 PR 實際落地為準）：
+#      python3 -m paulsha_cortex.trust_root shim three-way
+#    在它落地前：第 5-3 節不執行，template unit 的 ExecStart 維持產生器當下的形狀。
+
+# ⏳ job-spec spool 的欄位契約（<job spool>/<id>/ 底下由 Manager 寫的執行規格）
+#    同一 PR 定義；本 runbook **不自行捏造 spec 格式**——正向 smoke 一律以
+#    「產生器印出什麼 ExecStart，就照那個形狀準備」（見 5-6）。
+```
+
+> **一律以產生器輸出為準**：本 runbook 的每個落檔步驟後面都跟一條 `diff` 驗證，
+> 因此上述兩項一旦落地、內容改變，`diff` 會立刻抓到漂移，runbook 不需改寫。
+
+---
+
+## 第 1 步：建 UID（**三分**）
+
+建立三個 **system service 帳號**，皆 **no-login**、**home 由 root 擁有**。
+慣例：每帳號一個同名 primary group（權限產生器的 ACL 以此為前提）。
+
+| 帳號 | 跑什麼 | durable state owner | 持 spawn 授權（polkit subject） |
+|---|---|:--:|:--:|
+| `cortex-manager` | Manager ＋ monitor。**不跑任何模型程式碼** | ✔ | ✔ |
+| `cortex-reviewer-planner` | reviewer ＋ planner 模型 job | ✘ | ✘ |
+| `cortex-builder` | builder 模型 job（唯一會跑 untrusted repo code） | ✘ | ✘ |
+
+```bash
+# ✅ 先取產生器對三分方案的 HOME／cache 計畫——**不手寫路徑**
+python3 - <<'PY'
+from paulsha_cortex.trust_root import permgen
+s = permgen.SCHEMES["three-way"]
+for path, owner, group, mode in permgen.DEFAULT_LAYOUT.scaffold_directories(s):
+    if path.startswith("/var/lib/cortex-"):
+        print(f"{path}\t{owner}:{group}\t{mode:04o}")
+PY
+#   期望（#603 follow-up PR 落地後）：三組 HOME＋cache，名稱與帳號一致。
+#   ⚠️ 目前已知缺口（permgen 的 PathLayout 尚未跟上三分定案）：
+#      (a) Manager 的 HOME 仍沿用二分時代的 `/var/lib/cortex-svc`；
+#      (b) `cortex-reviewer-planner` 沒有 HOME／cache 條目。
+#      **以產生器輸出為準**：下方 useradd 的 --home-dir 一律填它印出的值；
+#      待該 PR 更名後以 `sudo usermod --home <新值> cortex-manager` 同步並重跑第 2 步。
+
+# 🔧 sudo：cortex-manager（Manager＋monitor；durable state owner；持 spawn 授權；不跑模型）
+sudo groupadd --system cortex-manager
+sudo useradd  --system --gid cortex-manager \
      --home-dir /var/lib/cortex-svc --no-create-home \
      --shell /usr/sbin/nologin \
-     --comment "cortex trusted service (Manager/monitor/reviewer/planner)" cortex-svc
+     --comment "cortex manager+monitor (durable state owner, spawn grant, no model code)" \
+     cortex-manager
+#   ↑ --home-dir 取自上面產生器輸出的那一行（目前為 /var/lib/cortex-svc）。
 
-# 🔧 sudo：cortex-builder（唯一完全隔離的 headless job 帳號）
+# 🔧 sudo：cortex-reviewer-planner（reviewer＋planner 模型 job）
+sudo groupadd --system cortex-reviewer-planner
+sudo useradd  --system --gid cortex-reviewer-planner \
+     --home-dir /var/lib/cortex-reviewer-planner --no-create-home \
+     --shell /usr/sbin/nologin \
+     --comment "cortex reviewer/planner model job" cortex-reviewer-planner
+
+# 🔧 sudo：cortex-builder（builder 模型 job；唯一跑 untrusted repo code）
 sudo groupadd --system cortex-builder
 sudo useradd  --system --gid cortex-builder \
      --home-dir /var/lib/cortex-builder --no-create-home \
      --shell /usr/sbin/nologin \
      --comment "cortex headless builder job" cortex-builder
+
+# 🔧 sudo：reviewer-planner 的 HOME／cache（產生器尚未涵蓋時手動補；模式與 builder 對齊）
+sudo install -d -o root -g root -m 0755 /var/lib/cortex-reviewer-planner
+sudo install -d -o root -g root -m 0755 /var/lib/cortex-reviewer-planner/.codex
+sudo install -d -o cortex-reviewer-planner -g cortex-reviewer-planner -m 0700 \
+     /var/lib/cortex-reviewer-planner/cache
+#   ↑ 這四行在 #603 follow-up PR 把 reviewer-planner 納入 scaffold 後即可刪除，
+#     改由第 2 步的 scaffold script 一併產生（屆時 diff 會提醒）。
 ```
 
-**為何 `--no-create-home`**：兩個帳號的 HOME 由第 2 步以 **root 擁有**的方式建立
+**為何 `--no-create-home`**：三個帳號的 HOME 由第 2 步以 **root 擁有**的方式建立
 （`useradd --create-home` 會把 HOME 建成帳號自己擁有）。HOME 若由帳號自己擁有，
 它就能 rename 掉 `~/.codex`／`~/.gitconfig` 這類 root-owned 設定的**父目錄**——
 父目錄可寫者能 unlink／rename 子物件，等於保護失效。只有 `cache/` 子目錄開放給帳號寫。
 
 **群組設計理由**：跨帳號存取一律走 **per-account POSIX ACL**（見 permgen 輸出的
 `setfacl -m u:<acct>:rX`），**不**用共用 group 開放，避免「一個 group 開了就全開」。
+三分之後這條更關鍵：`cortex-reviewer-planner` 對 verdict spool 的授權是
+**write-only（`wx` 無 `r`）**，只有 per-account ACL 表達得出來。
 
 ```bash
-# ✅ 驗證：帳號存在、shell 為 nologin、互不同 group、互不在對方 group
-getent passwd cortex-svc cortex-builder
-id cortex-svc; id cortex-builder
-#   期望：uid/gid 各自成對；cortex-svc 的 groups 不含 cortex-builder，反之亦然
-getent group cortex-svc cortex-builder
+# ✅ 驗證：三帳號存在、shell 為 nologin、三個 group 互不交集
+getent passwd cortex-manager cortex-reviewer-planner cortex-builder
+id cortex-manager; id cortex-reviewer-planner; id cortex-builder
+#   期望：uid/gid 各自成對；三者的 groups 互不包含對方
+getent group cortex-manager cortex-reviewer-planner cortex-builder
+
+# ✅ 驗證：三個帳號都登不進去（nologin），且都不在 sudo／wheel 群組
+for U in cortex-manager cortex-reviewer-planner cortex-builder; do
+  printf '%s shell=%s groups=%s\n' "$U" "$(getent passwd "$U" | cut -d: -f7)" "$(id -nG "$U")"
+done
+#   期望：shell 全為 /usr/sbin/nologin；groups 只含自己的同名 group
+
+# ✅ 驗證：模型 job 帳號兩兩互不可讀對方 HOME（三分的第一條不變式）
+sudo -u cortex-builder ls /var/lib/cortex-reviewer-planner/cache 2>&1 | tail -1
+sudo -u cortex-reviewer-planner ls /var/lib/cortex-builder/cache 2>&1 | tail -1
+#   期望：兩者皆 Permission denied（cache 為 0700 且 owner 不同）
+
+# ✅ 驗證：三帳號皆無 sudo 授權
+for U in cortex-manager cortex-reviewer-planner cortex-builder; do
+  sudo -u "$U" sudo -n true 2>&1 | tail -1
+done
+#   期望：全部失敗（不可有任何一個成功）
 ```
 
-**回滾**：`sudo userdel cortex-svc; sudo userdel cortex-builder;
-sudo groupdel cortex-svc; sudo groupdel cortex-builder`（此時尚無任何檔案屬於它們）。
+**回滾**：
+```bash
+sudo userdel cortex-manager; sudo userdel cortex-reviewer-planner; sudo userdel cortex-builder
+sudo groupdel cortex-manager; sudo groupdel cortex-reviewer-planner; sudo groupdel cortex-builder
+sudo rm -rf /var/lib/cortex-reviewer-planner
+```
+（此時尚無任何檔案屬於它們。）
 
 ---
 
@@ -214,10 +374,10 @@ sudo groupdel cortex-svc; sudo groupdel cortex-builder`（此時尚無任何檔�
 
 ```bash
 # ✅ 產生骨架目錄 script（非登記表資產的父層：/opt/cortex、HOME、job spool…）
-python3 -m paulsha_cortex.trust_root scaffold two-way > /tmp/p2b-scaffold.sh
+python3 -m paulsha_cortex.trust_root scaffold three-way > /tmp/p2b-scaffold.sh
 
 # ✅ 產生權限 script（登記表每一項的 install -d／chown／chmod／setfacl）
-python3 -m paulsha_cortex.trust_root permissions two-way --commands --paths \
+python3 -m paulsha_cortex.trust_root permissions three-way --commands --paths \
   > /tmp/p2b-permissions.sh
 
 # ✅ 逐行讀過再執行——這是 operator 核可的實體動作
@@ -229,12 +389,26 @@ grep -oE "chmod [0-7]{4}" /tmp/p2b-permissions.sh | sort -u \
  | awk '{m=$2; if (substr(m,3,1) ~ /[2367]/ || substr(m,4,1) ~ /[2367]/) {print "!! group/other writable: " m; bad=1}}
         END{ if (!bad) print "no group/other write: OK" }'
 
-# ✅ 稽核 2：ACL 授「寫」只准出現在 event-spool（producer 只能 append）
+# ✅ 稽核 2：ACL 授「寫」只准出現在兩個 append-only 出口（三分下**恰好四行**）
 grep -E "^setfacl" /tmp/p2b-permissions.sh | grep -E ":[^ ]*w"
-#   期望：**恰好兩行**，皆為 u:cortex-builder:wx /var/lib/cortex/monitor/event-spool
-#         （access 與 default 各一）。多出任何一行都要停下來查。
+#   期望（三分）：**恰好四行**
+#     setfacl -m u:cortex-builder:wx           /var/lib/cortex/monitor/event-spool
+#     setfacl -d -m u:cortex-builder:wx        /var/lib/cortex/monitor/event-spool
+#     setfacl -m u:cortex-reviewer-planner:wx  /var/lib/cortex/coordinator/review-verdicts
+#     setfacl -d -m u:cortex-reviewer-planner:wx /var/lib/cortex/coordinator/review-verdicts
+#   **wx 無 r**——寫得進自己那格、讀不到他人的。多出任何一行都要停下來查。
 
-# ✅ 稽核 3：setfacl 可用（缺 acl 套件會讓跨帳號唯讀授權整段失效）
+# ✅ 稽核 3：三分的帳號名確實出現在計畫裡（權限 script 不得殘留 cortex-svc）
+grep -c "cortex-svc" /tmp/p2b-permissions.sh
+#   期望：0（若非 0，代表 scheme 傳錯或 permgen 仍有二分殘留，停下來查）
+grep -oE "cortex-(manager|reviewer-planner|builder)" /tmp/p2b-permissions.sh | sort | uniq -c
+#   期望：三個帳號名皆出現，且**不含** cortex-svc。
+grep -c "cortex-svc" /tmp/p2b-scaffold.sh
+#   期望：**2**（`/var/lib/cortex-svc` 與其 `cache/`）——這是第 1 步已標註的
+#   已知缺口：Manager 的 HOME 目錄名尚未跟上三分改名，但**擁有者已是 cortex-manager**。
+#   > 0 且非 2、或出現在 owner 欄位 ⇒ 停下來查。
+
+# ✅ 稽核 4：setfacl 可用（缺 acl 套件會讓跨帳號唯讀授權整段失效）
 command -v setfacl >/dev/null && echo "setfacl: OK" || echo "!! 請先 sudo apt-get install acl"
 ```
 
@@ -257,39 +431,50 @@ echo "exit=${PIPESTATUS[0]}"     # 期望 0
 
 > **為何要先 scaffold**：`install -d a/b/c` 會把**新建的每一層**都套上同一組
 > `-o/-g/-m`。先讓 `/opt/cortex`、`/var/lib/cortex/config`、`/var/lib/cortex/run`、
-> `/var/lib/cortex/runtime`、兩個 HOME 以 root 身分就位，權限 script 之後只會補
+> `/var/lib/cortex/runtime`、三個 HOME 以 root 身分就位，權限 script 之後只會補
 > 葉節點，不會把 root-owned 父層蓋成服務帳號所有。
 
 ```bash
-# ✅ 驗證：樹根 root 擁有、Manager-owned 子樹 cortex-svc 0700、無 g+w／o+w
+# ✅ 驗證：樹根 root 擁有、Manager-owned 子樹 cortex-manager 0700、無 g+w／o+w
 ls -ld /var/lib/cortex /opt/cortex
 ls -ld /var/lib/cortex/control /var/lib/cortex/coordinator /var/lib/cortex/specs \
        /var/lib/cortex/monitor /var/lib/cortex/registry /var/lib/cortex/worktree
 #   期望：/var/lib/cortex → root:root 0755
-#         control/coordinator/specs/monitor/registry → cortex-svc:cortex-svc 0700
-#         worktree → cortex-svc:cortex-svc 0701（others 只 traverse，不可列目錄）
+#         control/coordinator/specs/monitor/registry → cortex-manager:cortex-manager 0700
+#         worktree → cortex-manager:cortex-manager 0701（others 只 traverse，不可列目錄）
 
 # ✅ 驗證：全樹沒有任何 group/other 可寫的路徑（spec §R2 硬性要求）
 sudo find /var/lib/cortex /opt/cortex -perm /022 -print | tee /tmp/p2b-world-writable.txt
 #   期望：空輸出
 
-# ✅ 驗證：ACL 已就位（跨帳號讀取一律唯讀）
+# ✅ 驗證：兩個 append-only 出口的 ACL 已就位（跨帳號一律 write-only 或唯讀）
 sudo getfacl -p /var/lib/cortex/monitor/event-spool 2>/dev/null | grep -E "^user:"
 #   期望：user:cortex-builder:-wx（producer 只能 append，不可讀他人）
+sudo getfacl -p /var/lib/cortex/coordinator/review-verdicts 2>/dev/null | grep -E "^user:"
+#   期望：user:cortex-reviewer-planner:-wx（**無 r**）
 
-# ✅ 驗證：HOME 與 ~/.codex 由 root 擁有（帳號不得替換自己的設定）
+# ✅ 驗證：三個 HOME 與 ~/.codex 由 root 擁有（帳號不得替換自己的設定）
+ls -ld /var/lib/cortex-svc /var/lib/cortex-svc/cache
+ls -ld /var/lib/cortex-reviewer-planner /var/lib/cortex-reviewer-planner/.codex \
+       /var/lib/cortex-reviewer-planner/cache
 ls -ld /var/lib/cortex-builder /var/lib/cortex-builder/.codex /var/lib/cortex-builder/cache
-#   期望：前兩者 root:root 0755；cache 為 cortex-builder:cortex-builder 0700
+#   期望：HOME 與 .codex 皆 root:root 0755；三個 cache 各自 <帳號>:<帳號> 0700
+
+# ✅ 驗證：job spool 根 cortex-manager 擁有、0711（job 帳號只 traverse，不可列目錄）
+ls -ld /var/lib/cortex/jobs
+#   期望：cortex-manager:cortex-manager 0711
+sudo -u cortex-builder ls /var/lib/cortex/jobs 2>&1 | tail -1
+#   期望：Permission denied（0711 不可列目錄——job 不能枚舉別人的 spool）
 ```
 
-**回滾**：`sudo rm -rf /var/lib/cortex /var/lib/cortex-svc /var/lib/cortex-builder /opt/cortex`
-（此時新樹仍空，舊樹完全未動）。
+**回滾**：`sudo rm -rf /var/lib/cortex /var/lib/cortex-svc /var/lib/cortex-reviewer-planner
+/var/lib/cortex-builder /opt/cortex`（此時新樹仍空，舊樹完全未動）。
 
 ---
 
 ## 第 3 步：legacy-import（物理隔離 ＋ hash manifest；**不 chown 沿用**）
 
-裁決 3：舊 state **不**併入新樹、**不** `chown` 沿用，而是整包搬到 quarantine，
+裁決：舊 state **不**併入新樹、**不** `chown` 沿用，而是整包搬到 quarantine，
 留下內容 hash manifest。`legacy-imported` 來源 **MUST NOT** 滿足任何 ship gate。
 
 ```bash
@@ -317,12 +502,12 @@ wc -l "/tmp/legacy-import-manifest-$STAMP.txt"
 sha256sum "/tmp/legacy-import-manifest-$STAMP.txt"
 #   ↑ 把這個 manifest 自身的 hash 記在 #584，作為 import 的錨點
 
-# 🔧 sudo：建 quarantine 並整包搬入（唯讀、cortex-svc 擁有，不併入新樹）
-sudo install -d -o cortex-svc -g cortex-svc -m 0700 /var/lib/cortex/legacy-imported
+# 🔧 sudo：建 quarantine 並整包搬入（唯讀、cortex-manager 擁有，不併入新樹）
+sudo install -d -o cortex-manager -g cortex-manager -m 0700 /var/lib/cortex/legacy-imported
 sudo cp -a "$HOME/.agents/." /var/lib/cortex/legacy-imported/
 sudo cp "/tmp/legacy-import-manifest-$STAMP.txt" \
         /var/lib/cortex/legacy-imported/.legacy-import-manifest.txt
-sudo chown -R cortex-svc:cortex-svc /var/lib/cortex/legacy-imported
+sudo chown -R cortex-manager:cortex-manager /var/lib/cortex/legacy-imported
 sudo chmod -R a-w /var/lib/cortex/legacy-imported
 ```
 
@@ -335,14 +520,19 @@ sudo find /var/lib/cortex/legacy-imported -perm /222 -print | head
 #   期望：與 manifest 行數相同
 ls -A /var/lib/cortex/coordinator /var/lib/cortex/control
 #   期望：空（或只有第 2 步建的空子目錄）——舊 jobs.json／evidence **沒有**被併進來
+
+# ✅ 驗證：兩個模型 job 帳號都讀不到 quarantine
+sudo -u cortex-builder ls /var/lib/cortex/legacy-imported 2>&1 | tail -1
+sudo -u cortex-reviewer-planner ls /var/lib/cortex/legacy-imported 2>&1 | tail -1
+#   期望：兩者皆 Permission denied
 ```
 
 > **重要**：新樹是**乾淨的**。切換後產生的 record 一律走正常 gate；
 > `legacy-imported/` 只是唯讀歷史副本，任何從中還原的內容**不得**被 ship gate 採計。
 > 正式的 `trust: legacy-imported` 簽章標記屬 **Phase 3**，本階段以「物理隔離＋hash
-> manifest」達成同等的不可竄改性主張（裁決 3）。
+> manifest」達成同等的不可竄改性主張。
 
-### 3b. review verdict spool（Phase 2a 已就位的受控通道）
+### 3b. review verdict spool（Phase 2a 已就位的受控通道；三分下才完整）
 
 Phase 2a（PR #599）已把 review verdict 的落點從 reviewer worktree 搬到
 `/var/lib/cortex/coordinator/review-verdicts/<reviewer_job_id>/verdict.json`
@@ -353,19 +543,28 @@ Manager 在 dispatch 當下以 `0700` 建立、帶 pre-seed 守衛，落地後�
 spool 根的權限**已包含在第 2 步的權限 script 內**（它是登記表資產），這裡只做確認：
 
 ```bash
-# ✅ 驗證：spool 根由 cortex-svc 擁有、0700；builder 完全無權限
+# ✅ 驗證：spool 根由 cortex-manager 擁有、0700；reviewer 只有 write-only ACL
 ls -ld /var/lib/cortex/coordinator/review-verdicts
-sudo getfacl -p /var/lib/cortex/coordinator/review-verdicts | grep -E "^user:" || echo "(二分方案無跨帳號 ACL：reviewer 與 Manager 併帳，owner 位已涵蓋)"
+sudo getfacl -p /var/lib/cortex/coordinator/review-verdicts | grep -E "^user:"
+#   期望：user:cortex-reviewer-planner:-wx —— **wx 無 r**：
+#         寫得進自己那格、讀不到他人 verdict。
 
-# ✅ 驗證：產生器對本資產的計畫（三分方案才會出現 reviewer 的 write-only ACL）
-python3 -m paulsha_cortex.trust_root permissions three-way --commands --paths \
-  | grep -A6 "review-verdict-spool"
-#   期望（三分）：setfacl -m u:cortex-reviewer-planner:wx …
-#   **wx 無 r**——寫得進自己那格、讀不到他人 verdict。builder 兩案下都零權限。
+# ✅ 驗證：builder 對 verdict spool 零權限（三分下這是硬邊界，不是慣例）
+sudo -u cortex-builder ls /var/lib/cortex/coordinator/review-verdicts 2>&1 | tail -1
+sudo -u cortex-builder sh -c 'printf x > /var/lib/cortex/coordinator/review-verdicts/evil' 2>&1 | tail -1
+#   期望：兩者皆 Permission denied
+
+# ✅ 驗證：reviewer 寫得進、讀不到（write-only 的正反面）
+sudo -u cortex-reviewer-planner sh -c \
+  'printf x > /var/lib/cortex/coordinator/review-verdicts/.negctl && echo WRITE-OK' 2>&1 | tail -1
+sudo -u cortex-reviewer-planner ls /var/lib/cortex/coordinator/review-verdicts 2>&1 | tail -1
+sudo rm -f /var/lib/cortex/coordinator/review-verdicts/.negctl
+#   期望：第一條 WRITE-OK；第二條 Permission denied
 ```
 
 > 這一步完成後，spec 背景 §3 的「builder 代寫 verdict」最短攻擊路徑才從「結構上
-> 不可能被採信」升級為「**OS 層寫不進去**」。
+> 不可能被採信」升級為「**OS 層寫不進去**」；而三分讓 reviewer 自己也**讀不到**
+> 其他 reviewer 的 verdict。
 >
 > 另：降權啟動器需把該 job 的 spool 目錄放進 executor sandbox 的放行清單
 > （`--add-dir`，見 `SubprocessLauncher.as_verdict_spool_writer()`）——只放行**那一格**，
@@ -408,10 +607,17 @@ sudo mv /opt/cortex/venv.new /opt/cortex/venv
 
 ```bash
 # ✅ 驗證：對服務帳號唯讀、可執行、版本正確
-sudo -u cortex-svc /opt/cortex/venv/bin/cortex --version
-sudo -u cortex-svc test -w /opt/cortex/venv/bin/cortex && echo "!! 可寫，停止" || echo "read-only: OK"
+sudo -u cortex-manager /opt/cortex/venv/bin/cortex --version
+sudo -u cortex-manager test -w /opt/cortex/venv/bin/cortex && echo "!! 可寫，停止" || echo "read-only: OK"
 sudo find /opt/cortex/venv -perm /022 -print | head
 #   期望：空輸出
+
+# ✅ 驗證：兩個模型 job 帳號也都不可寫部署樹
+for U in cortex-reviewer-planner cortex-builder; do
+  sudo -u "$U" sh -c 'printf x >> /opt/cortex/venv/bin/cortex' 2>&1 | tail -1
+done
+#   期望：兩者皆 Permission denied
+
 # ✅ 沒有可注入點
 sudo find /opt/cortex/venv -name "sitecustomize.py" -o -name "*.pth" | xargs -r ls -l
 #   期望：若有，全部 root:root 且不可寫
@@ -423,7 +629,7 @@ sudo find /opt/cortex/venv -name "sitecustomize.py" -o -name "*.pth" | xargs -r 
 ### 4b. bootstrap env 遷入部署樹（root 擁有、fail-closed）
 
 env 檔放在 **`/opt/cortex/etc/`**（全 root-owned 樹）而**不是** `/var/lib/cortex` 底下：
-`/var/lib/cortex` 的子樹由 `cortex-svc` 擁有，**目錄可寫者能 unlink／replace 其中的
+`/var/lib/cortex` 的子樹由 `cortex-manager` 擁有，**目錄可寫者能 unlink／replace 其中的
 root-owned 檔案**——把 env 檔放進去等於沒保護。
 
 ```bash
@@ -446,13 +652,13 @@ sudo chmod 0644 /opt/cortex/etc/cortex-manager.env
 
 ```bash
 # ✅ 驗證：owner/mode 與 permgen 的 deployment 區塊一致
-python3 -m paulsha_cortex.trust_root permissions two-way --commands --paths \
+python3 -m paulsha_cortex.trust_root permissions three-way --commands --paths \
   | grep -A3 "runtime-bootstrap-env"
 ls -l /opt/cortex/etc/cortex-manager.env
 #   期望：-rw-r--r-- root root
 
 # ✅ 驗證：env 生效後路徑解析全部落在受保護樹內
-sudo -u cortex-svc env $(grep -v '^#' /opt/cortex/etc/cortex-manager.env | xargs) \
+sudo -u cortex-manager env $(grep -v '^#' /opt/cortex/etc/cortex-manager.env | xargs) \
   /opt/cortex/venv/bin/python -c \
   "from paulsha_cortex.config import paths; print(paths.agents_root(), paths.control_root(), paths.coordinator_root())"
 #   期望：三者都在 /var/lib/cortex 底下
@@ -467,10 +673,10 @@ sudo -u cortex-svc env $(grep -v '^#' /opt/cortex/etc/cortex-manager.env | xargs
 
 ```bash
 # ✅ 先看內容（ReadWritePaths 逐條附「涵蓋哪些登記表資產」註解）
-python3 -m paulsha_cortex.trust_root unit two-way --manager | less
+python3 -m paulsha_cortex.trust_root unit three-way --manager | less
 
 # 🔧 sudo：寫入 unit（內容一字不改，直接由產生器落檔）
-python3 -m paulsha_cortex.trust_root unit two-way --manager \
+python3 -m paulsha_cortex.trust_root unit three-way --manager \
   | sudo tee /etc/systemd/system/cortex-manager.service >/dev/null
 sudo chown root:root /etc/systemd/system/cortex-manager.service
 sudo chmod 0644 /etc/systemd/system/cortex-manager.service
@@ -486,11 +692,12 @@ sudo systemctl start cortex-manager.service
 systemctl show cortex-manager.service \
   -p User -p NoNewPrivileges -p ProtectSystem -p ProtectHome -p PrivateTmp \
   -p CapabilityBoundingSet -p ReadWritePaths
-#   期望：User=cortex-svc、NoNewPrivileges=yes、ProtectSystem=strict、
-#         ProtectHome=yes、PrivateTmp=yes、CapabilityBoundingSet=（空）
+#   期望：**User=cortex-manager**（三分：不再是 cortex-svc）、NoNewPrivileges=yes、
+#         ProtectSystem=strict、ProtectHome=yes、PrivateTmp=yes、
+#         CapabilityBoundingSet=（空）
 
 # ✅ 驗證：unit 檔內容與產生器輸出逐位元相同（防手改漂移）
-diff <(python3 -m paulsha_cortex.trust_root unit two-way --manager) \
+diff <(python3 -m paulsha_cortex.trust_root unit three-way --manager) \
      /etc/systemd/system/cortex-manager.service && echo "unit in sync: OK"
 
 # ✅ 驗證：加固評分（systemd 自己的評估，僅供對照）
@@ -499,6 +706,10 @@ systemd-analyze security cortex-manager.service | tail -5
 # ✅ 驗證：服務起得來、無 EPERM/EROFS
 systemctl status cortex-manager.service --no-pager
 sudo journalctl -u cortex-manager.service -n 100 --no-pager | grep -Ei "eperm|erofs|eacces|read-only" || echo "no denial in log: OK"
+
+# ✅ 驗證：Manager 行程確實以 cortex-manager 身分跑（三分的行程面證據）
+ps -o user=,pid=,cmd= -p "$(systemctl show cortex-manager.service -p MainPID --value)"
+#   期望：user 欄為 cortex-manager
 
 # ✅ 驗證：fail-closed——刪掉 env 檔必須拒絕啟動（測完立刻還原）
 sudo mv /opt/cortex/etc/cortex-manager.env /opt/cortex/etc/cortex-manager.env.bak
@@ -514,301 +725,257 @@ sudo rm /etc/systemd/system/cortex-manager.service; sudo systemctl daemon-reload
 
 ---
 
-## 第 5 步：降權啟用（`cortex-svc` → `cortex-builder`，關 FD、不傳 token）
+## 第 5 步：降權啟用（**A+B 單一路徑**）
 
-> **⏸ 本步有兩個方案，正等 operator 拍板**——這是全 runbook 唯一還需要決定的地方。
-> 兩案都寫成完整可執行；**選了哪一個就只跑那一節**，其餘步驟（1–4、6–9）兩案共用。
-> 同時要一併裁決的是「**是否提前三分**」（見下方風險比較）。
+> **前置條件**：執行前提第 9 項。若 `systemd-template` 尚未出現在
+> `job_runner.RUNNER_MODES`（#603 follow-up PR 未落地），則 **(a)(b) 照裝、(c) 跳過、
+> (d) 不開**——邊界仍可由 5-7 的反向測試完整證明，只是 Manager 還不會走它。
+> **絕不**因為 (d) 開不了就退回 transient 主路徑；需要臨時降權時走 **附錄 B**
+> 並在 #584 記錄殘餘風險與預計關閉時間。
 
-### 5-0. 共同前提：polkit 到底能收窄什麼（先讀完再選）
+### 5-1. 邊界由三個 root-owned 物件 ＋ 一個帳號事實構成
 
-**實測事實**（#603 驗證）：polkit 的 `org.freedesktop.systemd1.manage-units` action
-**只暴露 unit 名稱與 verb**，**不暴露 `User=`／`--uid=`**。授權之後，systemd 會照請求
-的**任意** `User=` 起 unit。因此：
+| # | 物件／事實 | 路徑 | 擁有者 | 它強制什麼 |
+|---|---|---|---|---|
+| (a) | **polkit 規則** | `/etc/polkit-1/rules.d/49-cortex-downgrade.rules` | root:root 0644 | 只有 `cortex-manager`、只有 `start`／`stop`、只有 `cortex-job@*.service`。**不授權 `manage-units` 的 transient 建立** |
+| (b) | **template unit** | `/etc/systemd/system/cortex-job@.service` | root:root 0644 | `User=cortex-builder` 寫死、加固段寫死、`ExecStart=` 寫死。呼叫端**選不了 UID、傳不了屬性** |
+| (c) | **shim** | `/opt/cortex/bin/cortex-job-shim` | root:root 0755 | `ExecStart=` 的實體。argv 的**形狀**由 root-owned 程式從 Manager-owned job-spec 導出；Manager 只能給參數 |
+| — | **三分帳號事實** | — | — | polkit 的 subject 只有 `cortex-manager`，而它**不跑任何模型程式碼**；injection 可達的 job 帳號完全不在授權面上 |
 
-| polkit **能**強制 | polkit **不能**強制 |
-|---|---|
-| 呼叫者是哪個 UID（`subject.user`） | job 降到哪個帳號（`User=`／`--uid=`） |
-| unit 名前綴／pattern（`action.lookup("unit")`） | 任何 unit 屬性（`AmbientCapabilities=`、`ExecStart=`…） |
-| verb（只放行 `start`／`stop`） | — |
+三者缺一都不成立：
+- 少了 (a)，`cortex-manager` 起不了 job（fail-closed，不會退回同 UID）。
+- 少了 (b)，`User=` 回到呼叫端手上——polkit 看不到它，等於沒守。
+- 少了 (c)，argv 的入口落在 Manager 可寫的樹裡；Manager 被攻陷即可換掉執行的東西。
 
-「只能降到 `cortex-builder`」這一半必須另外找地方強制——這就是 A／B 兩案的分野。
-兩案共用的 polkit 骨架（subject 檢查、action 檢查、**明細缺席即拒**、verb 白名單、
-unit pattern）由同一個產生器產出，只有 pattern 與說明段不同。
-
-```bash
-# ✅ 兩案的規則內容各印一份，並排比較後再選
-python3 -m paulsha_cortex.trust_root polkit two-way --transient | tee /tmp/polkit-A.rules
-python3 -m paulsha_cortex.trust_root polkit two-way --template  | tee /tmp/polkit-B.rules
-diff /tmp/polkit-A.rules /tmp/polkit-B.rules
-```
-
-#### 兩案比較（含「是否提前三分」的關聯）
-
-| | **方案 A：`systemd-run` transient unit** | **方案 B：root-owned 模板 unit** |
-|---|---|---|
-| 裁決對應 | 0816 裁決的**字面**方案 | 同一意圖的 OS 強制版 |
-| 程式碼狀態 | **已落地**（#603 `coordinator/job_runner.py`，`PSC_JOB_RUNNER=systemd-run`） | 需 Manager 端改以 `systemctl start cortex-job@<id>` 起 job——**尚待程式碼工項** |
-| 「降到哪個帳號」由誰強制 | Manager 端**封閉的 argv 產生器**（code level，`--uid` 受 POSIX 帳號名 pattern 檢查） | **OS**：`User=` 硬寫死在 root-owned 的 `/etc/systemd/system/cortex-job@.service` |
-| 特權屬性（`AmbientCapabilities=` 等） | 呼叫端**可以**傳（polkit 看不到），靠 argv 產生器不傳 | 呼叫端**連提都提不了**（屬性只存在於 root-owned 檔內） |
-| **殘餘風險** | 與 `cortex-svc` **同 UID 的任何行程**都持有這個 grant，可請求任意 `User=`（含 `User=root`）的 transient unit。**二分方案下 reviewer／planner 跑模型且與 Manager 併帳**——其中任一被攻陷即取得該能力 | 無（OS 層封閉） |
-| 與「提前三分」的關係 | **強相關**：改三分後 reviewer／planner 移出 `cortex-svc`，A 的殘餘風險縮回「只有 Manager 自己」 | 不相關（B 本來就不靠 UID 隔離來守這一半） |
-| 立即可執行 | ✅ | ⚠️ 規則與模板 unit 可先裝，但 Manager 端要等程式碼 |
-
-**建議判讀**（不代替裁決）：若要**現在**打開降權 → 選 A，並**同時**決定是否提前三分
-（三分把 A 的殘餘風險從「三個模型 persona」縮到「Manager 自己」）。若可以等一個程式碼
-工項 → B 是唯一能把整個分界線放進 OS 的做法。
+### 5-2. 安裝 (b) template unit
 
 ```bash
-# ✅ 三分方案的權限／unit／polkit 也已可產生（決定提前三分時把 two-way 換成 three-way）
-python3 -m paulsha_cortex.trust_root permissions three-way --commands --paths | head -20
-python3 -m paulsha_cortex.trust_root polkit three-way --transient | sed -n '/未強制/,/^\/\/$/p'
-#   期望：三分下的殘餘風險清單**不再**包含 reviewer／planner 併帳那一條
+# ✅ 先看內容
+python3 -m paulsha_cortex.trust_root unit three-way --job | less
+#   必須確認的三行：
+#     User=cortex-builder      ← 唯一 UID 來源，寫死
+#     Group=cortex-builder
+#     ExecStart=…              ← 見 5-3；PR 落地後應指向 /opt/cortex/bin/cortex-job-shim
+
+# 🔧 sudo：落檔（root 擁有——這是 User= 不可被竄改的前提）
+python3 -m paulsha_cortex.trust_root unit three-way --job \
+  | sudo tee /etc/systemd/system/cortex-job@.service >/dev/null
+sudo chown root:root /etc/systemd/system/cortex-job@.service
+sudo chmod 0644 /etc/systemd/system/cortex-job@.service
+sudo systemctl daemon-reload
+
+# ✅ 驗證：與產生器逐位元相同、User= 確實寫死
+diff <(python3 -m paulsha_cortex.trust_root unit three-way --job) \
+     /etc/systemd/system/cortex-job@.service && echo "job unit in sync: OK"
+grep -E "^(User|Group|ExecStart|NoNewPrivileges|CapabilityBoundingSet)=" \
+     /etc/systemd/system/cortex-job@.service
+#   期望：User=cortex-builder、Group=cortex-builder、NoNewPrivileges=yes、
+#         CapabilityBoundingSet=（空值）
 ```
 
----
+### 5-3. 部署 (c) root-owned shim
 
-### 5-A. 方案 A：`systemd-run` transient unit（0816 裁決的字面方案）
+shim 是 C（code-level argv 保證）從 Manager 端**搬進 root-owned 檔案**的那一步：
+job 的 argv 不再由 Manager 行程直接組出並交給 systemd，而是由 root 擁有的程式
+從 **Manager-owned 的 job-spec spool** 讀取參數後導出。
 
-#### 5-A-1. Manager 端會實際發出的 argv（polkit 要收窄的那個面）
-
-`job_runner.build_systemd_run_argv()` 的形狀是**封閉**的（新增旗標要改程式碼並過測試）：
-
-```text
-systemd-run --quiet --collect --pipe --wait \
-  --unit=cortex-job-<job_id 片段>-<sha256 前 8 碼>.service \
-  --uid=cortex-builder --gid=cortex-builder \
-  --service-type=exec \
-  --working-directory=<該 job 的 worktree> \
-  --property=NoNewPrivileges=yes \
-  --setenv=<白名單 env 逐項> \
-  -- bash -c '<job wrapper script>'
-```
-
-- unit 名前綴固定 `cortex-job-`（`job_runner.UNIT_NAME_PREFIX`）——**與 polkit 規則是
-  成對契約**，改任一邊都要同步改另一邊，否則所有 job 被拒（fail-closed，不會退回同 UID）。
-- `--wait` 讓 client 與 unit 同壽命，Manager 既有的 `pid_alive()` 判活不必改。
-- `--quiet` 必要：`systemd-run` 的狀態訊息會被 `--pipe` 導進 job 的 JSONL log，而那份
-  log 是 terminal evidence 的來源。
-- FD 只有 stdin/stdout/stderr（`close_fds=True`），stdin 顯式接 `/dev/null`。
-- **env 是白名單不是黑名單 scrub**：transient unit 不繼承呼叫端 environ，job 只看得到
-  `--setenv` 列出的那幾項；gh token、`CLAUDE_CONFIG_DIR`／`GH_CONFIG_DIR` 都**不在**上面。
+| 角色 | 路徑 | 擁有者 | 權限意義 |
+|---|---|---|---|
+| shim（root-owned 程式） | `/opt/cortex/bin/cortex-job-shim` | root:root 0755 | 三個服務帳號皆**不可寫**（`/opt/cortex` 整棵 root-owned） |
+| job-spec spool 根 | `/var/lib/cortex/jobs` | cortex-manager 0711 | Manager 寫；job 帳號只 traverse，**不可列目錄**（不能枚舉他人 job） |
+| per-job spec | `/var/lib/cortex/jobs/<id>/` | cortex-manager 0700 ＋ builder `r-x` ACL | job 只讀自己那格——**改不了自己的命令列，也埋伏不了下一個 job** |
 
 ```bash
-# ✅ 驗證（不需 root）：印出本機會發出的白名單與旗標，與上表逐項對照
-python3 - <<'PY'
-from paulsha_cortex.coordinator import job_runner
-for item in job_runner.BUILDER_FORWARDED_ENV:
-    print(f"{item.name:22} {item.rationale}")
-print("synthesized:", job_runner.BUILDER_SYNTHESIZED_ENV)
-print("unit prefix:", job_runner.UNIT_NAME_PREFIX)
-print("properties :", job_runner.TRANSIENT_UNIT_PROPERTIES)
-PY
+# ⏳ 內容由 #603 follow-up PR 的產生器提供（命令名以該 PR 實際落地為準）：
+#      python3 -m paulsha_cortex.trust_root shim three-way > /tmp/cortex-job-shim
+#    在它落地前**跳過本節**，並確認 5-2 的 ExecStart 指向哪裡（見下方檢查）。
 
-# ✅ 契約對齊：polkit 規則的 pattern 前綴必須等於 job_runner 的常數
-python3 - <<'PY'
-from paulsha_cortex.coordinator import job_runner
-from paulsha_cortex.trust_root import permgen
-prefix = permgen.transient_unit_prefix(permgen.DEFAULT_LAYOUT)
-assert prefix == job_runner.UNIT_NAME_PREFIX, (prefix, job_runner.UNIT_NAME_PREFIX)
-print("unit prefix contract OK:", prefix)
-PY
+# ✅ 檢查安裝好的 template unit 實際的 ExecStart——決定本節做不做
+systemctl cat cortex-job@.service | grep -E "^ExecStart="
+#   期望（PR 落地後）：ExecStart=/opt/cortex/bin/cortex-job-shim %i
+#   若仍為 /bin/sh /var/lib/cortex/jobs/%i/run.sh ⇒ PR 未落地：
+#     本節跳過；5-6 的正向 smoke 改用 run.sh 形式；(d) 切換點不打開。
+
+# 🔧 sudo：落檔（root 擁有、可執行、對三個服務帳號唯讀）
+sudo install -d -o root -g root -m 0755 /opt/cortex/bin
+sudo install -o root -g root -m 0755 /tmp/cortex-job-shim /opt/cortex/bin/cortex-job-shim
+
+# ✅ 驗證：與產生器逐位元相同
+diff <(python3 -m paulsha_cortex.trust_root shim three-way) /opt/cortex/bin/cortex-job-shim \
+  && echo "shim in sync: OK"
+
+# ✅ 驗證：三個服務帳號都改不動 shim（也換不掉它）
+for U in cortex-manager cortex-reviewer-planner cortex-builder; do
+  sudo -u "$U" sh -c 'printf "id\n" >> /opt/cortex/bin/cortex-job-shim' 2>&1 | tail -1
+  sudo -u "$U" sh -c 'ln -sf /tmp/evil /opt/cortex/bin/cortex-job-shim' 2>&1 | tail -1
+done
+#   期望：六條全部 Permission denied
+ls -l /opt/cortex/bin/cortex-job-shim
+#   期望：-rwxr-xr-x root root
 ```
 
-#### 5-A-2. 安裝 polkit 規則
+### 5-4. 安裝 (a) polkit 規則
 
 ```bash
-# ✅ 先讀（規則檔開頭把殘餘風險逐條寫出來，勿跳過）
-less /tmp/polkit-A.rules
+# ✅ 先讀（規則檔開頭把邊界與「為什麼 transient 一律拒」逐條寫出來，勿跳過）
+python3 -m paulsha_cortex.trust_root polkit three-way --template | tee /tmp/polkit-cortex.rules
+less /tmp/polkit-cortex.rules
+#   必須確認的五個條件（規則檔自己列在「審查者的一眼結論」段）：
+#     (1) subject 是 cortex-manager；(2) action 是 org.freedesktop.systemd1.manage-units；
+#     (3) unit／verb 明細存在；(4) verb ∈ {start, stop}；
+#     (5) unit 名匹配 ^cortex-job@[a-z0-9][a-z0-9._-]{0,62}\.service$
+#   **transient unit 的 StartTransientUnit 檢查不帶明細 ⇒ 條件 (3) 直接把它擋掉。**
 
 # 🔧 sudo：落檔
-sudo install -o root -g root -m 0644 /tmp/polkit-A.rules \
+sudo install -o root -g root -m 0644 /tmp/polkit-cortex.rules \
      /etc/polkit-1/rules.d/49-cortex-downgrade.rules
 sudo systemctl restart polkit.service 2>/dev/null || sudo systemctl restart polkitd.service
 
 # ✅ 驗證：載入無語法錯誤、與產生器逐位元相同
 sudo journalctl -u polkit -n 30 --no-pager | grep -Ei "error|syntax" || echo "polkit loaded clean: OK"
-diff <(python3 -m paulsha_cortex.trust_root polkit two-way --transient) \
+diff <(python3 -m paulsha_cortex.trust_root polkit three-way --template) \
      /etc/polkit-1/rules.d/49-cortex-downgrade.rules && echo "polkit in sync: OK"
+
+# ✅ 驗證：規則的 subject 是 cortex-manager，且殘餘風險清單為空（template 方案）
+python3 - <<'PY'
+from paulsha_cortex.trust_root import permgen
+rule = permgen.build_polkit_rule(
+    permgen.SCHEMES["three-way"], plan=permgen.PolkitPlan.TEMPLATE
+)
+print("subject       :", rule.subject_account)
+print("target        :", rule.target_account)
+print("unit_pattern  :", rule.unit_pattern)
+print("allowed_verbs :", rule.allowed_verbs)
+print("residual_risks:", rule.residual_risks or "(none — OS 層封閉)")
+PY
+#   期望：subject=cortex-manager、target=cortex-builder、verbs=('start','stop')、
+#         residual_risks 為空。
 ```
 
-#### 5-A-3. 打開開關（Manager env）
+### 5-5. (d) 打開切換點 `PSC_JOB_RUNNER=systemd-template`
 
 ```bash
 # 🔧 sudo：把降權模式寫進第 4b 步的 EnvironmentFile
 sudo tee -a /opt/cortex/etc/cortex-manager.env >/dev/null <<'ENVFILE'
-PSC_JOB_RUNNER=systemd-run
+PSC_JOB_RUNNER=systemd-template
 PSC_BUILDER_ACCOUNT=cortex-builder
 PSC_BUILDER_HOME=/var/lib/cortex-builder
 ENVFILE
 sudo systemctl restart cortex-manager.service
+
+# ✅ 驗證：模式確實被解析成 template（值非法必須 fail-closed，不得靜默當成 direct）
+sudo -u cortex-manager env $(grep -v '^#' /opt/cortex/etc/cortex-manager.env | xargs) \
+  /opt/cortex/venv/bin/python -c \
+  "import os; from paulsha_cortex.coordinator import job_runner; print(job_runner.resolve_runner_mode(os.environ))"
+#   期望：systemd-template
 ```
 
 > `PSC_JOB_RUNNER` 預設 `direct`＝不降權；值非法時**fail-closed**（不會靜默當成
 > `direct`）。`PSC_BUILDER_PATH` 選配——模型 CLI 不在 Manager `PATH` 上時才需要。
 > **builder 帳號必須自己有模型 CLI 的登入態**（`sudo -u cortex-builder claude /login`
 > 之類）；Manager 不會把自己的憑證傳過去，那正是本步驟的重點。
+> **M2 之前**：`PSC_JOB_RUNNER` 只影響 builder persona；reviewer／planner 仍在 Manager
+> 行程內執行（見開頭「分段落地」）。
 
-#### 5-A-4. 驗證（正向必須成功）
-
-```bash
-# ✅ 以 cortex-svc 起一個降到 cortex-builder 的 transient job
-sudo -u cortex-svc systemd-run --quiet --collect --pipe --wait \
-  --unit=cortex-job-smoke-00000000.service \
-  --uid=cortex-builder --gid=cortex-builder --service-type=exec \
-  --property=NoNewPrivileges=yes \
-  /bin/sh -c 'id; echo "GH_TOKEN=[$GH_TOKEN]"; ls -l /proc/self/fd'
-#   期望：uid=…(cortex-builder)；GH_TOKEN=[]；/proc/self/fd 只有 0/1/2
-```
-
-#### 5-A-5. 驗證（反向必須被拒）
-
-```bash
-# ✅ (1) 不符前綴的 unit 名：必須被拒
-sudo -u cortex-svc systemd-run --quiet --unit=evil-0001.service --uid=cortex-builder \
-     --pipe --wait /bin/id; echo "exit=$?"          # 期望非 0
-
-# ✅ (2) 起既存 unit（含 Manager 自己）：必須被拒
-sudo -u cortex-svc systemctl restart cortex-manager.service; echo "exit=$?"   # 期望非 0
-sudo -u cortex-svc systemctl daemon-reload; echo "exit=$?"                    # 期望非 0
-
-# ✅ (3) 負控制：暫時移除 polkit 規則後，dispatch 必須 fail-closed 而非退回 direct
-sudo mv /etc/polkit-1/rules.d/49-cortex-downgrade.rules /tmp/polkit-A.disabled
-sudo systemctl restart polkit.service 2>/dev/null || sudo systemctl restart polkitd.service
-#   → 觸發一次 dispatch，期望：job 落 needs_human，理由碼
-#     job-runner-transient-unit-start-failed，detail 帶 systemd-run 的實際拒絕訊息。
-#     **不得**出現以 cortex-svc 身分跑起來的 job。
-sudo mv /tmp/polkit-A.disabled /etc/polkit-1/rules.d/49-cortex-downgrade.rules
-sudo systemctl restart polkit.service 2>/dev/null || sudo systemctl restart polkitd.service
-
-# ⚠️ (4) 已知**不會**被拒（這就是 A 的殘餘風險，實測確認它確實存在）
-sudo -u cortex-svc systemd-run --quiet --unit=cortex-job-probe-00000000.service \
-     --uid=0 --pipe --wait /bin/id; echo "exit=$?"
-#   期望：**成功並印出 uid=0(root)**。這不是設定錯誤，是 A 方案的本質限制：
-#   polkit 看不到 --uid。看到這個結果就代表你確實理解自己接受了什麼。
-#   選 B 方案時這條必須改為「期望非 0」。
-```
-
-#### 5-A-6. 建議的額外加固（與方案 B 同源，機械產生）
-
-`job_runner` 目前只送 `--property=NoNewPrivileges=yes`。同一套加固表與**由登記表導出
-的 `ReadWritePaths`** 可展開成 `--property=` 形式，作為 A 與 B 加固面是否等價的對照：
-
-```bash
-# ✅ 印出建議清單（%i 是模板 specifier；A 方案請由呼叫端代入該 job 的實際 worktree）
-python3 -m paulsha_cortex.trust_root unit two-way --job-properties
-```
-
----
-
-### 5-B. 方案 B：root-owned 模板 unit（把整條分界線放進 OS）
-
-兩個 root-owned 檔一起構成邊界：
-
-1. **模板 unit** `/etc/systemd/system/cortex-job@.service`——`User=cortex-builder`
-   **硬寫死**；呼叫端只能給 instance 名，**選不了 UID、傳不了屬性**。
-2. **polkit 規則**——只放行 `cortex-svc` 對 `cortex-job@*.service` 的 `start`/`stop`，
-   **transient unit 一律拒**（明細缺席即拒）。
-
-> **前置條件**：Manager 端目前走 `systemd-run`（#603）。要真的用 B，需要一個程式碼
-> 工項把 spawn 改成「寫 `run.sh` 進 job spool → `systemctl start cortex-job@<id>.service`」。
-> **在那之前，B 的規則與模板 unit 仍可先裝並用下面的手動驗證證明邊界成立**，只是
-> Manager 還不會走它。
-
-#### 5-B-1. 安裝模板 unit
-
-```bash
-# ✅ 先看內容
-python3 -m paulsha_cortex.trust_root unit two-way --job | less
-
-# 🔧 sudo：落檔（root 擁有——這是 User= 不可被竄改的前提）
-python3 -m paulsha_cortex.trust_root unit two-way --job \
-  | sudo tee /etc/systemd/system/cortex-job@.service >/dev/null
-sudo chown root:root /etc/systemd/system/cortex-job@.service
-sudo chmod 0644 /etc/systemd/system/cortex-job@.service
-sudo systemctl daemon-reload
-```
-
-#### 5-B-2. 安裝 polkit 規則
-
-```bash
-# 🔧 sudo：落檔
-sudo install -o root -g root -m 0644 /tmp/polkit-B.rules \
-     /etc/polkit-1/rules.d/49-cortex-downgrade.rules
-sudo systemctl restart polkit.service 2>/dev/null || sudo systemctl restart polkitd.service
-
-# ✅ 驗證：與產生器逐位元相同、載入無錯
-diff <(python3 -m paulsha_cortex.trust_root polkit two-way --template) \
-     /etc/polkit-1/rules.d/49-cortex-downgrade.rules && echo "polkit in sync: OK"
-sudo journalctl -u polkit -n 30 --no-pager | grep -Ei "error|syntax" || echo "polkit loaded clean: OK"
-```
-
-#### 5-B-3. 準備 job spool 並實測降權（正向必須成功）
-
-job 的命令由 Manager 寫進 svc-owned spool，job 帳號只有讀權——因此**改不了自己的
-命令列，也埋伏不了下一個 job**。
+### 5-6. 正向驗證（**必須成功**）
 
 ```bash
 JOB=selftest
 
-# 🔧 sudo：per-job spool（svc 擁有、builder 只讀）
-sudo install -d -o cortex-svc -g cortex-svc -m 0700 "/var/lib/cortex/jobs/$JOB"
+# 🔧 sudo：per-job spool（manager 擁有、builder 只讀）＋ job worktree
+sudo install -d -o cortex-manager -g cortex-manager -m 0700 "/var/lib/cortex/jobs/$JOB"
 sudo setfacl -m u:cortex-builder:r-x "/var/lib/cortex/jobs/$JOB"
+sudo install -d -o cortex-builder -g cortex-builder -m 0700 "/var/lib/cortex/worktree/$JOB"
+
+# 🔧 sudo：放一份 smoke 執行規格。**形式取決於 5-3 檢查到的 ExecStart**：
+#   (i) shim 已落地（ExecStart=/opt/cortex/bin/cortex-job-shim %i）：
+#       用該 PR 提供的產生器寫 job-spec，**不要自行捏造欄位**。
+#   (ii) shim 未落地（ExecStart=/bin/sh …/%i/run.sh）：用下列 run.sh 形式，
+#        它同樣足以證明 (a)(b) 的邊界（身分／token／fd／HOME）。
 sudo tee "/var/lib/cortex/jobs/$JOB/run.sh" >/dev/null <<'SH'
 #!/bin/sh
 echo "== identity =="; id
 echo "== tokens =="; echo "GH_TOKEN=[$GH_TOKEN] GITHUB_TOKEN=[$GITHUB_TOKEN]"
 echo "== inherited fds =="; ls -l /proc/self/fd
 echo "== home =="; echo "HOME=$HOME"; ls -ld "$HOME" 2>&1
+echo "== deployment writable? =="; (printf x >> /opt/cortex/venv/bin/cortex) 2>&1 | tail -1
 SH
-sudo chown cortex-svc:cortex-svc "/var/lib/cortex/jobs/$JOB/run.sh"
+sudo chown cortex-manager:cortex-manager "/var/lib/cortex/jobs/$JOB/run.sh"
 sudo chmod 0600 "/var/lib/cortex/jobs/$JOB/run.sh"
 sudo setfacl -m u:cortex-builder:r-- "/var/lib/cortex/jobs/$JOB/run.sh"
 
-# 🔧 sudo：job 的 worktree（builder 擁有）
-sudo install -d -o cortex-builder -g cortex-builder -m 0700 "/var/lib/cortex/worktree/$JOB"
-
-# ✅ 驗證（正向）：以 cortex-svc 身分起 job——**必須成功**
-sudo -u cortex-svc systemctl start "cortex-job@$JOB.service"
+# ✅ 正向：以 cortex-manager 身分起 instance——**必須成功**
+sudo -u cortex-manager systemctl start "cortex-job@$JOB.service"
 sudo journalctl -u "cortex-job@$JOB.service" -n 50 --no-pager
 #   期望輸出：
-#     uid=…(cortex-builder) gid=…(cortex-builder)
-#     GH_TOKEN=[] GITHUB_TOKEN=[]                ← token 已 scrub
-#     /proc/self/fd 只有 0/1/2                    ← 無指向受保護資產的可寫 fd（R9 T4.1）
+#     uid=…(cortex-builder) gid=…(cortex-builder)   ← User= 由 OS 強制，不是呼叫端選的
+#     GH_TOKEN=[] GITHUB_TOKEN=[]                    ← token 已 scrub
+#     /proc/self/fd 只有 0/1/2                        ← 無指向受保護資產的可寫 fd（R9 T4.1）
 #     HOME=/var/lib/cortex-builder，且該目錄為 root:root
+#     deployment writable? → Permission denied / Read-only file system
+
+# ✅ 正向：停也必須成功（polkit 放行的兩個 verb）
+sudo -u cortex-manager systemctl stop "cortex-job@$JOB.service"; echo "exit=$?"   # 期望 0
 ```
 
-#### 5-B-4. 驗證（反向：全部必須失敗）
+### 5-7. 反向驗證（**11 條全部必須被拒**）
 
 ```bash
-# ✅ (1) transient unit 起 root：必須被拒
-sudo -u cortex-svc systemd-run --uid=0 --pipe --wait /bin/id; echo "exit=$?"
+# ✅ (1) 以 cortex-manager 起 transient unit（不指定 UID）：必須被拒
+sudo -u cortex-manager systemd-run --pipe --wait /bin/id; echo "exit=$?"
+
+# ✅ (2) 以 cortex-manager 起 transient unit --uid=0：必須被拒
+sudo -u cortex-manager systemd-run --uid=0 --pipe --wait /bin/id; echo "exit=$?"
 #   期望：非 0；訊息含 "Interactive authentication required" 或 "Access denied"
+#   **這一條就是 A+B 相對於單獨 A 多出來的保證**：polkit 沒授 transient 建立。
 
-# ✅ (2) transient unit 起 builder：**同樣**必須被拒（transient 一律封）
-sudo -u cortex-svc systemd-run --uid=cortex-builder --pipe --wait /bin/id; echo "exit=$?"
-#   期望：非 0。這就是 B 相對 A 多出來的那一半保證。
+# ✅ (3) 以 cortex-manager 起 transient unit --uid=cortex-builder：**同樣**必須被拒
+sudo -u cortex-manager systemd-run --uid=cortex-builder --pipe --wait /bin/id; echo "exit=$?"
 
-# ✅ (3) transient unit 夾帶特權屬性：必須被拒
-sudo -u cortex-svc systemd-run --uid=cortex-builder \
+# ✅ (4) transient unit 夾帶特權屬性：必須被拒
+sudo -u cortex-manager systemd-run --uid=cortex-builder \
      --property=AmbientCapabilities=CAP_SETUID --pipe --wait /bin/id; echo "exit=$?"
 
-# ✅ (4) 起別的既存 unit（含 Manager 自己）：必須被拒
-sudo -u cortex-svc systemctl restart cortex-manager.service; echo "exit=$?"
-sudo -u cortex-svc systemctl start sshd.service 2>&1 | tail -1; echo "exit=$?"
+# ✅ (5) 借用 template 名字的 transient unit：必須被拒（明細缺席即拒）
+sudo -u cortex-manager systemd-run --unit="cortex-job@evil.service" --uid=0 \
+     --pipe --wait /bin/id; echo "exit=$?"
 
-# ✅ (5) 名稱夾帶（前綴／後綴混淆）：必須被拒
-sudo -u cortex-svc systemctl start "evil-cortex-job@x.service"; echo "exit=$?"
+# ✅ (6) 起別的既存 unit（含 Manager 自己、sshd）：必須被拒
+sudo -u cortex-manager systemctl restart cortex-manager.service; echo "exit=$?"
+sudo -u cortex-manager systemctl start sshd.service 2>&1 | tail -1; echo "exit=$?"
 
-# ✅ (6) 其他 verb：必須被拒
-sudo -u cortex-svc systemctl mask "cortex-job@$JOB.service"; echo "exit=$?"
-sudo -u cortex-svc systemctl daemon-reload; echo "exit=$?"
+# ✅ (7) 名稱夾帶（前綴／後綴混淆）：必須被拒
+sudo -u cortex-manager systemctl start "evil-cortex-job@x.service"; echo "exit=$?"
+sudo -u cortex-manager systemctl start "cortex-job@x.service.evil"; echo "exit=$?"
 
-# ✅ (7) 直接改模板 unit：必須 EACCES
-sudo -u cortex-svc sh -c 'echo "User=root" >> /etc/systemd/system/cortex-job@.service'; echo "exit=$?"
+# ✅ (8) 其他 verb：必須被拒
+sudo -u cortex-manager systemctl mask "cortex-job@$JOB.service"; echo "exit=$?"
+sudo -u cortex-manager systemctl daemon-reload; echo "exit=$?"
+sudo -u cortex-manager systemctl set-property "cortex-job@$JOB.service" User=root; echo "exit=$?"
+
+# ✅ (9) 非授權帳號起 job instance：必須被拒（polkit subject 只有 cortex-manager）
+sudo -u cortex-reviewer-planner systemctl start "cortex-job@$JOB.service"; echo "exit=$?"
+sudo -u cortex-builder systemctl start "cortex-job@$JOB.service"; echo "exit=$?"
+
+# ✅ (10) 改 template unit／shim／polkit 規則：三個服務帳號一律 EACCES
+for U in cortex-manager cortex-reviewer-planner cortex-builder; do
+  sudo -u "$U" sh -c 'printf "User=root\n" >> /etc/systemd/system/cortex-job@.service'; echo "$U unit exit=$?"
+  sudo -u "$U" sh -c 'printf "id\n" >> /opt/cortex/bin/cortex-job-shim'; echo "$U shim exit=$?"
+  sudo -u "$U" sh -c 'printf "x\n" >> /etc/polkit-1/rules.d/49-cortex-downgrade.rules'; echo "$U polkit exit=$?"
+done
+
+# ✅ (11) 負控制：暫時移除 polkit 規則後，dispatch 必須 fail-closed 而非退回 direct
+sudo mv /etc/polkit-1/rules.d/49-cortex-downgrade.rules /tmp/polkit-cortex.disabled
+sudo systemctl restart polkit.service 2>/dev/null || sudo systemctl restart polkitd.service
+sudo -u cortex-manager systemctl start "cortex-job@$JOB.service"; echo "exit=$?"   # 期望非 0
+#   → 再觸發一次真正的 dispatch，期望：job 落 needs_human，理由碼指向
+#     job-runner 的 unit-start-failed 家族，detail 帶 systemctl 的實際拒絕訊息。
+#     **不得**出現以 cortex-manager 身分跑起來的 job。
+sudo mv /tmp/polkit-cortex.disabled /etc/polkit-1/rules.d/49-cortex-downgrade.rules
+sudo systemctl restart polkit.service 2>/dev/null || sudo systemctl restart polkitd.service
 ```
 
-**通過條件**：5-B-3 正向成功且輸出符合期望；5-B-4 的 (1)–(7) **全部**非 0 退出。
+**通過條件**：5-6 正向成功且輸出符合期望；5-7 的 (1)–(11) **全部**非 0 退出。
 任一反向測試通過（即攻擊成功）＝**立即停止**，回到第 9 步回滾。
 
 ```bash
@@ -817,20 +984,77 @@ sudo systemctl stop "cortex-job@$JOB.service" 2>/dev/null || true
 sudo rm -rf "/var/lib/cortex/jobs/$JOB" "/var/lib/cortex/worktree/$JOB"
 ```
 
----
+### 5-8. 殘餘風險（A+B 之後重新評估）
 
-### 5-C. 產生邏輯的離線對照（兩案共用）
+**已被關掉的**（第二輪時還是殘餘）：
+
+| 舊殘餘 | A+B 之後 |
+|---|---|
+| 「polkit 看不到 `User=`，授權後可請求任意 UID」 | **不再成立**——polkit 根本沒授權 transient 建立；唯一能起的是 root-owned template 的 instance，`User=` 在 root-owned 檔內寫死。5-7 (2)(3) 實測 |
+| 「跑模型的 reviewer／planner 與 Manager 併帳，其中任一被攻陷即取得 grant」 | **不再成立**——三分把它們移到 `cortex-reviewer-planner`；polkit subject 只有 `cortex-manager`，而它**不跑模型程式碼**。5-7 (9) 實測 |
+| 「授權帳號被攻陷即可提權」 | **降級為「無法向上」**——`cortex-manager` 即使被完全攻陷，也改不了 `User=`（unit 是 root-owned）、傳不了屬性（transient 被拒）、換不掉 argv 入口（shim 是 root-owned）。它能做的上界是「以 `cortex-builder` 身分起 job」，而那正是設計要它做的事 |
+
+**polkit 粗粒度仍在，但已不構成提權**：規則只能看到 unit 名與 verb，**這在 A+B 下
+足夠**——因為被授權的 unit 名 pattern 只對應一個 root-owned template，該 template 的
+每一個安全屬性都不由呼叫端提供。粗粒度授權的「粗」落在 instance 名（`%i`）上，
+而 `%i` 只被用作 spool 路徑與 worktree 路徑的 segment，且 pattern 已把字元集錨定為
+`[a-z0-9][a-z0-9._-]{0,62}`（無 `/`、無 `..` 起頭）。
+
+**剩下的殘餘 = `cortex-manager` 帳號的 supply-chain 類**：
+
+| 殘餘 | 具體形狀 | 現有緩解 | 缺口 |
+|---|---|---|---|
+| **部署樹供應鏈** | 惡意相依／被竄改的 wheel 進到 `/opt/cortex/venv`，之後以 `cortex-manager` 身分執行 | `/opt/cortex` 全 root-owned、對服務唯讀（4a）；升級走第 6 步 operator 手動驗證＋hash diff；**不 codify** root 命令（裁決 6） | 無簽章驗證（屬 **Phase 3**）；hash diff 靠 operator 目視 |
+| **Manager 自身邏輯被攻陷** | Manager 程式碼路徑被誘導寫出惡意 job-spec | root-owned shim 限定 argv 形狀（5-3）；job 仍降到 `cortex-builder`、拿不到 token | shim 對 spec 的檢查強度＝該 PR 的實作品質，需在 PR review 時單獨把關 |
+| **operator 帳號** | 有 `sudo`，可改任何東西 | 設計上信任邊界之外（本 runbook 全部 root 操作都由 operator 親自輸入） | 不在本階段範圍 |
+| **polkit 不可用** | polkit 掛掉 ⇒ 全部 job 起不來 | fail-closed（安全但功能全停）；執行前提第 6 項＋WSL2 段第 5 項複驗 | 需監控，否則表現為「靜默停擺」 |
+| **M2 未完成** | reviewer／planner 仍在 Manager 行程內以 `cortex-manager` 身分跑 ⇒ 這兩個 persona 的 injection 可達行程**目前**仍與 grant 同 UID | 檔案權限面已三分（第 3b 步實測）；builder（最大攻擊面）已完全移出 | **這是 M1 唯一的行程面殘餘**，必須在 #584 明示記錄，並隨 M2 關閉 |
+
+> **記錄要求**：完成第 5 步後，把 5-7 的 11 條 exit code、5-4 的 `residual_risks` 輸出、
+> 以及本表最後一列（M2 是否已完成）貼到 #584。D6 的通過判定引用這份紀錄。
+
+### 5-9. 產生邏輯的離線對照
 
 ```bash
-# ✅ polkit 無法本機模擬時的第二證據：決策矩陣測試（含兩案互不放行對方的 unit 形狀）
+# ✅ polkit 無法本機模擬時的第二證據：決策矩陣測試
 python3 -m pytest tests/test_trust_root_permgen_p2b.py -q -k polkit
+
+# ✅ 決策矩陣的手動抽點（與 5-7 的實機結果應逐條一致）
+python3 - <<'PY'
+from paulsha_cortex.trust_root import permgen
+rule = permgen.build_polkit_rule(
+    permgen.SCHEMES["three-way"], plan=permgen.PolkitPlan.TEMPLATE
+)
+cases = [
+    ("cortex-manager",          permgen.POLKIT_ACTION, "cortex-job@abc.service", "start", "YES"),
+    ("cortex-manager",          permgen.POLKIT_ACTION, "cortex-job@abc.service", "stop",  "YES"),
+    ("cortex-manager",          permgen.POLKIT_ACTION, None,                     None,    "NO"),
+    ("cortex-manager",          permgen.POLKIT_ACTION, "cortex-manager.service", "start", "NO"),
+    ("cortex-manager",          permgen.POLKIT_ACTION, "evil-cortex-job@x.service", "start", "NO"),
+    ("cortex-manager",          permgen.POLKIT_ACTION, "cortex-job@abc.service", "mask",  "NO"),
+    ("cortex-reviewer-planner", permgen.POLKIT_ACTION, "cortex-job@abc.service", "start", "NOT_HANDLED"),
+    ("cortex-builder",          permgen.POLKIT_ACTION, "cortex-job@abc.service", "start", "NOT_HANDLED"),
+]
+for user, action, unit, verb, want in cases:
+    got = permgen.evaluate_polkit(rule, user=user, action_id=action, unit=unit, verb=verb)
+    print(f"{'OK ' if got == want else '!! '}{user:24} {str(unit):28} {str(verb):6} -> {got} (want {want})")
+PY
+#   期望：全部 OK。`NOT_HANDLED` 代表交回 polkit 預設 ⇒ 無授權 ⇒ 實機被拒（5-7 (9) 已實測）。
 ```
 
-**回滾**（兩案共用）：`sudo rm -f /etc/polkit-1/rules.d/49-cortex-downgrade.rules
-/etc/systemd/system/cortex-job@.service; sudo systemctl daemon-reload;
-sudo systemctl restart polkit.service`；A 方案另需把 `PSC_JOB_RUNNER` 移出
-EnvironmentFile（回 `direct`）。降權停用後 Manager 以
-`PSC_DEGRADED_OPERATION=per-case-approval` 不 spawn job 運轉。
+**回滾（第 5 步整段）**：
+```bash
+sudo rm -f /etc/polkit-1/rules.d/49-cortex-downgrade.rules \
+           /etc/systemd/system/cortex-job@.service \
+           /opt/cortex/bin/cortex-job-shim
+sudo systemctl daemon-reload
+sudo systemctl restart polkit.service 2>/dev/null || true
+# 並把 PSC_JOB_RUNNER 那三行移出 EnvironmentFile（回 direct）：
+sudo sed -i '/^PSC_JOB_RUNNER=/d;/^PSC_BUILDER_ACCOUNT=/d;/^PSC_BUILDER_HOME=/d' \
+     /opt/cortex/etc/cortex-manager.env
+sudo systemctl restart cortex-manager.service
+```
+降權停用後 Manager 以 `PSC_DEGRADED_OPERATION=per-case-approval` 不 spawn job 運轉。
 
 ---
 
@@ -845,7 +1069,7 @@ operator 手動執行。升級因此是下列固定流程：
 pipx upgrade paulsha-cortex     # 或既有 build 流程
 "$HOME/.local/share/pipx/venvs/paulsha-cortex/bin/cortex" --version
 
-# ✅ 2. 差異對照（新舊部署的內容 hash）
+# ✅ 2. 差異對照（新舊部署的內容 hash）——供應鏈殘餘風險的唯一人工關卡
 ( cd "$HOME/.local/share/pipx/venvs/paulsha-cortex" && find . -type f -print0 | sort -z | xargs -0 sha256sum ) > /tmp/cortex-new.sha
 ( cd /opt/cortex/venv && sudo find . -type f -print0 | sort -z | sudo xargs -0 sha256sum ) > /tmp/cortex-cur.sha
 diff <(sort /tmp/cortex-cur.sha) <(sort /tmp/cortex-new.sha) | head -50
@@ -859,31 +1083,36 @@ sudo find /opt/cortex/venv.new -type f -exec chmod a-w {} +
 sudo find /opt/cortex/venv.new/bin -type f -exec chmod 0755 {} +
 
 # ✅ 4. 新樹自檢通過才切換
-sudo -u cortex-svc /opt/cortex/venv.new/bin/python -m paulsha_cortex.trust_root selfcheck
-sudo -u cortex-svc /opt/cortex/venv.new/bin/python -m paulsha_cortex.trust_root equation
+sudo -u cortex-manager /opt/cortex/venv.new/bin/python -m paulsha_cortex.trust_root selfcheck
+sudo -u cortex-manager /opt/cortex/venv.new/bin/python -m paulsha_cortex.trust_root equation
 
-# ✅ 5. 登記表若有變動，unit 必須重新產生（ReadWritePaths 可能改變）
-diff <(sudo -u cortex-svc /opt/cortex/venv.new/bin/python -m paulsha_cortex.trust_root unit two-way --manager) \
-     /etc/systemd/system/cortex-manager.service || echo "!! unit 需更新，見下"
+# ✅ 5. 登記表若有變動，unit／template／shim 全部必須重新產生
+diff <(sudo -u cortex-manager /opt/cortex/venv.new/bin/python -m paulsha_cortex.trust_root unit three-way --manager) \
+     /etc/systemd/system/cortex-manager.service || echo "!! manager unit 需更新"
+diff <(sudo -u cortex-manager /opt/cortex/venv.new/bin/python -m paulsha_cortex.trust_root unit three-way --job) \
+     /etc/systemd/system/cortex-job@.service || echo "!! job template unit 需更新"
+diff <(sudo -u cortex-manager /opt/cortex/venv.new/bin/python -m paulsha_cortex.trust_root polkit three-way --template) \
+     /etc/polkit-1/rules.d/49-cortex-downgrade.rules || echo "!! polkit 規則需更新"
+#   （shim 落地後同樣加一條 `… shim three-way` 對 /opt/cortex/bin/cortex-job-shim 的 diff）
 
 # 🔧 6. sudo：原子切換（保留前一版供回滾）
 sudo systemctl stop cortex-manager.service
 sudo rm -rf /opt/cortex/venv.prev
 sudo mv /opt/cortex/venv /opt/cortex/venv.prev
 sudo mv /opt/cortex/venv.new /opt/cortex/venv
-#   若第 5 步顯示 unit 需更新：
-#   python3 -m paulsha_cortex.trust_root unit two-way --manager | sudo tee /etc/systemd/system/cortex-manager.service >/dev/null
-#   sudo systemctl daemon-reload
+#   若第 5 步顯示需更新，逐項重新落檔後 `sudo systemctl daemon-reload`
+#   （polkit 規則另需 restart polkit）。
 sudo systemctl start cortex-manager.service
 ```
 
 ```bash
-# ✅ 驗證：新版在跑、自檢綠
-sudo -u cortex-svc /opt/cortex/venv/bin/cortex --version
+# ✅ 驗證：新版在跑、自檢綠、降權邊界沒被升級順手改掉
+sudo -u cortex-manager /opt/cortex/venv/bin/cortex --version
 systemctl status cortex-manager.service --no-pager | head -5
+sudo -u cortex-manager systemd-run --uid=0 --pipe --wait /bin/id; echo "exit=$?"   # 期望非 0
 ```
 
-> **不裸 chown**：升級不是「把 headless 產出的檔 chown 給 svc」，而是「operator 驗證
+> **不裸 chown**：升級不是「把 headless 產出的檔 chown 給 manager」，而是「operator 驗證
 > 來源後，以 root 身分整棵替換部署樹」。任何 headless 都碰不到 `/opt/cortex`。
 > **回滾**：`sudo systemctl stop cortex-manager; sudo rm -rf /opt/cortex/venv;
 > sudo mv /opt/cortex/venv.prev /opt/cortex/venv; sudo systemctl start cortex-manager`。
@@ -893,8 +1122,8 @@ systemctl status cortex-manager.service --no-pager | head -5
 ## 第 7 步：切換驗收（Phase 1 自檢轉綠）
 
 ```bash
-# ✅ 以 cortex-svc（Manager 身分）跑自檢——Manager-owned 樹應無 job-writable
-sudo -u cortex-svc env $(grep -v '^#' /opt/cortex/etc/cortex-manager.env | xargs) \
+# ✅ 以 cortex-manager（Manager 身分）跑自檢——Manager-owned 樹應無 job-writable
+sudo -u cortex-manager env $(grep -v '^#' /opt/cortex/etc/cortex-manager.env | xargs) \
   /opt/cortex/venv/bin/python -m paulsha_cortex.trust_root selfcheck \
   | tee "/tmp/trust-root-after-$(date +%Y%m%d-%H%M).json"
 #   期望：JSON 的 "ok": true、"job_writable_count": 0
@@ -926,15 +1155,27 @@ python3 -m paulsha_cortex.trust_root equation
 ## 第 8 步：R9 手動抽驗（operator 逐條攻擊測試）
 
 裁決 7：本階段為**手動抽驗**；完整自動化矩陣（對登記表每一項機械展開族 2）屬另一
-工項。下列每條都以 **`cortex-builder` 身分**執行，並附**確切命令**與**預期輸出**。
+工項。三分之後**每族要以兩個模型 job 身分各跑一次**：`cortex-builder` 與
+`cortex-reviewer-planner`；`cortex-manager` 只作為 negative control 的受信任身分。
 每族末尾都有 **negative control**（以受信任身分做同一件事**必須成功**）——沒有它，
 環境壞掉（目錄根本不存在）會產生假綠（spec §R9）。
 
-### 8a. 起一個 R9 攻擊 job
+**族別（A+B 後為五族）**：
+
+| 族 | 名稱 | subject | 新增？ |
+|---|---|---|---|
+| 1 | capability-theft | builder ／ reviewer-planner | 依三帳號重寫 |
+| 2 | durable-state-tampering | builder ／ reviewer-planner | 依三帳號重寫 |
+| 3 | enforcement-plane-tampering | builder ／ reviewer-planner | 依三帳號重寫 |
+| 4 | 行程間路徑 | builder ／ reviewer-planner | 依三帳號重寫 |
+| **5** | **privilege-boundary（A+B 新增）** | **cortex-manager**（授權帳號自身）＋三個 headless | **✅ 新增** |
+
+### 8a. 攻擊腳本（族 1–4，以模型 job 身分執行）
 
 ```bash
+# 🔧 sudo：R9 攻擊 job 的 spool／worktree／攻擊目標（全部由 operator 親自建立）
 JOB=r9
-sudo install -d -o cortex-svc -g cortex-svc -m 0700 "/var/lib/cortex/jobs/$JOB"
+sudo install -d -o cortex-manager -g cortex-manager -m 0700 "/var/lib/cortex/jobs/$JOB"
 sudo setfacl -m u:cortex-builder:r-x "/var/lib/cortex/jobs/$JOB"
 sudo install -d -o cortex-builder -g cortex-builder -m 0700 "/var/lib/cortex/worktree/$JOB"
 
@@ -945,10 +1186,11 @@ A=/var/lib/cortex
 
 echo "===== 族 1 capability-theft ====="
 t "T1.1 讀 EnvironmentFile"        cat /opt/cortex/etc/cortex-manager.env
-t "T1.1 讀 svc HOME cache"         ls /var/lib/cortex-svc/cache
+t "T1.1 讀 manager HOME cache"     ls /var/lib/cortex-svc/cache
 t "T1.2 連 Manager control socket" sh -c "ls $A/run/cortex && cat $A/run/cortex/*.sock"
 t "T1.3 呼叫 operator CLI"         /opt/cortex/venv/bin/cortex work ship --help
 t "T1.4 直寫 control queue"        sh -c "printf x > $A/control/requests/evil.json"
+t "T1.5 枚舉他人 job spool"        ls "$A/jobs"
 
 echo "===== 族 2 durable-state-tampering ====="
 t "T2 modify jobs.json"            sh -c "printf '{}' > $A/coordinator/jobs.json"
@@ -969,6 +1211,8 @@ t "T2 寫 dispatch specs"           sh -c "printf x > $A/specs/evil.md"
 t "T2 寫 skill ledger"             sh -c "printf x >> $A/registry/skill_usage.jsonl"
 t "T2 讀 monitor 讀模型"           cat "$A/monitor/work-items.snapshot.json"
 t "T2 代寫他人 review verdict"     sh -c "printf '{\"verdict\":\"pass\"}' > $A/worktree/victim/.psc-review-verdict.json"
+t "T2 直寫 verdict spool 他格"     sh -c "printf '{\"verdict\":\"pass\"}' > $A/coordinator/review-verdicts/victim/verdict.json"
+t "T2 列 verdict spool"            ls "$A/coordinator/review-verdicts"
 t "T2 寫他人 worktree"             sh -c "printf x > $A/worktree/victim/evil"
 t "T2 列 worktree pool"            ls "$A/worktree"
 
@@ -977,68 +1221,142 @@ t "T3.1 改 site-packages verifier" sh -c "printf x >> /opt/cortex/venv/lib/pyth
 t "T3.2 注入 sitecustomize"        sh -c "printf x > /opt/cortex/venv/lib/python3*/site-packages/sitecustomize.py"
 t "T3.2 注入 .pth"                 sh -c "printf x > /opt/cortex/venv/lib/python3*/site-packages/evil.pth"
 t "T3.3 改 Manager unit"           sh -c "printf x >> /etc/systemd/system/cortex-manager.service"
-t "T3.3 改 job 模板 unit"          sh -c "printf 'User=root' >> /etc/systemd/system/cortex-job@.service"  # 方案 B 才有此檔；A 下為 ENOENT，同樣算拒絕
 t "T3.4 改 EnvironmentFile"        sh -c "printf 'PSC_COORDINATOR_ROOT=/tmp/evil' >> /opt/cortex/etc/cortex-manager.env"
 t "T3.5 刪 EnvironmentFile"        rm -f /opt/cortex/etc/cortex-manager.env
 t "T3.6 改 venv launcher"          sh -c "printf x >> /opt/cortex/venv/bin/cortex"
-t "T3.9 改 codex hooks"            sh -c "printf x > /var/lib/cortex-builder/.codex/hooks.json"
-t "T3.9 換掉 ~/.codex 目錄"        sh -c "mv /var/lib/cortex-builder/.codex /var/lib/cortex-builder/.codex.bak"
-t "T3 改 polkit 規則"              sh -c "printf x >> /etc/polkit-1/rules.d/49-cortex-downgrade.rules"
+t "T3.9 改 codex hooks"            sh -c "printf x > $HOME/.codex/hooks.json"
+t "T3.9 換掉 ~/.codex 目錄"        sh -c "mv $HOME/.codex $HOME/.codex.bak"
 
 echo "===== 族 4 行程間路徑 ====="
 echo "T4.1 自己的 fd：" ; ls -l /proc/self/fd
-MPID=$(pgrep -u cortex-svc -n -f paulsha_cortex 2>/dev/null || echo 0)
+MPID=$(pgrep -u cortex-manager -n -f paulsha_cortex 2>/dev/null || echo 0)
 echo "manager pid = $MPID"
 t "T4.2 ptrace Manager"            sh -c "command -v gdb >/dev/null && gdb -p $MPID -batch -ex quit"
 t "T4.3 讀 Manager environ"        cat "/proc/$MPID/environ"
 t "T4.3 讀 Manager mem"            head -c 1 "/proc/$MPID/mem"
 t "T4.4 對 Manager 送 SIGSTOP"     kill -STOP "$MPID"
-t "T4 提權：systemd-run root"      systemd-run --uid=0 --pipe /bin/id
-t "T4 提權：起別的 job"            systemctl start cortex-job@other.service
-t "T4 提權：sudo"                  sudo -n true
+t "T4.5 讀另一個 job 帳號 cache"   sh -c "ls /var/lib/cortex-builder/cache /var/lib/cortex-reviewer-planner/cache"
+t "T4.6 提權：systemd-run root"    systemd-run --uid=0 --pipe /bin/id
+t "T4.6 提權：起 job instance"     systemctl start cortex-job@other.service
+t "T4.6 提權：sudo"                sudo -n true
 SH
-#   注意：以上三條是以 **cortex-builder 身分**執行——builder 在兩個方案下都**不在**
-#   polkit 授權面上（規則的 subject 只有 cortex-svc），故兩案都必須 denied。
-#   方案 A 的殘餘風險是「以 **cortex-svc** 身分」起任意 UID，那條在第 5-A-5 (4) 實測。
-sudo chown cortex-svc:cortex-svc "/var/lib/cortex/jobs/$JOB/run.sh"
+sudo chown cortex-manager:cortex-manager "/var/lib/cortex/jobs/$JOB/run.sh"
 sudo chmod 0600 "/var/lib/cortex/jobs/$JOB/run.sh"
 sudo setfacl -m u:cortex-builder:r-- "/var/lib/cortex/jobs/$JOB/run.sh"
+sudo setfacl -m u:cortex-reviewer-planner:r-- "/var/lib/cortex/jobs/$JOB/run.sh"
+sudo setfacl -m u:cortex-reviewer-planner:r-x "/var/lib/cortex/jobs/$JOB"
 
-# 準備一個「他人 worktree」作為跨 persona 攻擊目標
-sudo install -d -o cortex-svc -g cortex-svc -m 0700 /var/lib/cortex/worktree/victim
-sudo -u cortex-svc sh -c 'printf "{\"verdict\":\"fail\"}" > /var/lib/cortex/worktree/victim/.psc-review-verdict.json'
-
-# 🔧 sudo：以 svc 身分起攻擊 job（依第 5 步選定的方案二擇一）
-
-# 方案 A（systemd-run transient unit）：
-sudo -u cortex-svc systemd-run --quiet --collect --pipe --wait \
-  --unit="cortex-job-r9-00000000.service" \
-  --uid=cortex-builder --gid=cortex-builder --service-type=exec \
-  --property=NoNewPrivileges=yes \
-  --working-directory="/var/lib/cortex/worktree/$JOB" \
-  /bin/sh "/var/lib/cortex/jobs/$JOB/run.sh" | tee /tmp/r9-report.txt
-
-# 方案 B（root-owned 模板 unit）：
-# sudo -u cortex-svc systemctl start "cortex-job@$JOB.service"
-# sudo journalctl -u "cortex-job@$JOB.service" -n 300 --no-pager | tee /tmp/r9-report.txt
+# 準備「他人 worktree」與「他人 verdict 格」作為跨 persona 攻擊目標
+sudo install -d -o cortex-manager -g cortex-manager -m 0700 /var/lib/cortex/worktree/victim
+sudo -u cortex-manager sh -c 'printf "{\"verdict\":\"fail\"}" > /var/lib/cortex/worktree/victim/.psc-review-verdict.json'
+sudo install -d -o cortex-manager -g cortex-manager -m 0700 /var/lib/cortex/coordinator/review-verdicts/victim
 ```
 
-**預期輸出**：`/tmp/r9-report.txt` 中**每一條**都是 `denied (OK) rc=<非 0>`；
+```bash
+# 🔧 sudo：pass 1——以 **cortex-builder** 身分（經 A+B 的正式路徑：template instance）
+sudo -u cortex-manager systemctl start "cortex-job@$JOB.service"
+sudo journalctl -u "cortex-job@$JOB.service" -n 400 --no-pager | tee /tmp/r9-builder.txt
+
+# 🔧 sudo：pass 2——以 **cortex-reviewer-planner** 身分
+#   M2 之前 reviewer／planner 沒有自己的 template instance，因此這一趟用 **operator 的
+#   sudo** 直接起（不是用 cortex-manager 的 grant）。它測的是**檔案權限面**的三分，
+#   不是啟動面；啟動面由 5-7 (9) 覆蓋。
+sudo systemd-run --quiet --collect --pipe --wait \
+  --uid=cortex-reviewer-planner --gid=cortex-reviewer-planner --service-type=exec \
+  --property=NoNewPrivileges=yes \
+  --setenv=HOME=/var/lib/cortex-reviewer-planner \
+  --working-directory=/var/lib/cortex/worktree \
+  /bin/sh "/var/lib/cortex/jobs/$JOB/run.sh" | tee /tmp/r9-reviewer.txt
+```
+
+**預期輸出**：兩份報告中**每一條**都是 `denied (OK) rc=<非 0>`；
 `T4.1 自己的 fd` 只列 `0`、`1`、`2`（指向 journal socket 或 `/dev/null`），
 **沒有任何**指向 `/var/lib/cortex` 或 `/opt/cortex` 的可寫 fd。
 
 ```bash
-# ✅ 一眼判讀
-grep -c "denied (OK)" /tmp/r9-report.txt
-grep "SUCCEEDED (FAIL)" /tmp/r9-report.txt && echo "!! 有攻擊成功，立即停止並回滾" || echo "R9 抽驗全綠"
-grep -A5 "自己的 fd" /tmp/r9-report.txt
+# ✅ 一眼判讀（兩份都要看）
+for F in /tmp/r9-builder.txt /tmp/r9-reviewer.txt; do
+  printf '%s: denied=%s\n' "$F" "$(grep -c 'denied (OK)' "$F")"
+  grep "SUCCEEDED (FAIL)" "$F" && echo "!! $F 有攻擊成功，立即停止並回滾" || echo "   $F 全綠"
+done
+grep -A5 "自己的 fd" /tmp/r9-builder.txt
 ```
 
-### 8b. negative control（受信任身分做同樣的事**必須成功**）
+### 8b. 族 5：privilege-boundary（**A+B 新增的兩個攻擊族**）
+
+這兩族測的不是「job 能不能亂寫」，而是「**降權/提權分界線本身能不能被推開**」。
 
 ```bash
-# ✅ 族 1／2 的 negative control：cortex-svc 寫得進去
-sudo -u cortex-svc sh -c '
+# ---------------------------------------------------------------------------
+# 族 5.1：以 cortex-manager（唯一持 spawn 授權的帳號）請求 transient unit --uid=root
+#         → 必須被 polkit 拒（規則沒授權 manage-units 的 transient 建立）
+# ---------------------------------------------------------------------------
+# ✅ 5.1a 最直接的形式
+sudo -u cortex-manager systemd-run --uid=0 --pipe --wait /bin/id; echo "5.1a exit=$?"
+
+# ✅ 5.1b 借 job unit 名字包裝（想騙過 pattern 檢查）
+sudo -u cortex-manager systemd-run --unit="cortex-job@escalate.service" --uid=0 \
+     --pipe --wait /bin/id; echo "5.1b exit=$?"
+
+# ✅ 5.1c 不指定 uid、改用 property 夾帶特權
+sudo -u cortex-manager systemd-run --unit="cortex-job@escalate2.service" \
+     --property=AmbientCapabilities=CAP_SETUID --property=User=root \
+     --pipe --wait /bin/id; echo "5.1c exit=$?"
+
+# ✅ 5.1d 走 --user bus 旁路（user manager 的 transient unit）
+sudo -u cortex-manager systemd-run --user --pipe --wait /bin/id; echo "5.1d exit=$?"
+
+# ✅ 5.1e 直接打 D-Bus 的 StartTransientUnit（繞開 systemd-run 的 CLI）
+sudo -u cortex-manager busctl call org.freedesktop.systemd1 /org/freedesktop/systemd1 \
+     org.freedesktop.systemd1.Manager StartTransientUnit "ssa(sv)a(sa(sv))" \
+     "cortex-job@bus.service" "replace" 1 "User" s "root" 0 2>&1 | tail -2
+echo "5.1e exit=$?"
+
+# 期望：5.1a–5.1e **全部非 0**；journal 應可見 polkit 的 denial。
+# 期望的拒絕理由（任一）：
+#   "Interactive authentication required" / "Access denied" / "Permission denied"
+sudo journalctl -u polkit --since "-3 min" --no-pager | tail -20
+# ✅ negative control：同樣的請求由 **operator（有 sudo）** 發出必須成功——
+#    否則上面的紅是「systemd-run 根本壞了」的假綠。
+sudo systemd-run --quiet --collect --pipe --wait --uid=0 /bin/id; echo "5.1-neg exit=$?"   # 期望 0
+
+# ---------------------------------------------------------------------------
+# 族 5.2：以任何 headless 身分改寫 template unit 或 shim
+#         → 必須被 root-owned 檔案權限拒
+# ---------------------------------------------------------------------------
+# ✅ 5.2 逐帳號 × 逐物件 × 逐手法（改寫／截斷／換檔／換父目錄／drop-in）
+for U in cortex-manager cortex-reviewer-planner cortex-builder; do
+  echo "--- subject=$U ---"
+  sudo -u "$U" sh -c 'printf "User=root\n" >> /etc/systemd/system/cortex-job@.service'; echo "  append-unit    exit=$?"
+  sudo -u "$U" sh -c ': > /etc/systemd/system/cortex-job@.service';                      echo "  truncate-unit  exit=$?"
+  sudo -u "$U" sh -c 'printf "x" > /tmp/u && mv /tmp/u /etc/systemd/system/cortex-job@.service'; echo "  replace-unit   exit=$?"
+  sudo -u "$U" sh -c 'mkdir -p /etc/systemd/system/cortex-job@.service.d && printf "[Service]\nUser=root\n" > /etc/systemd/system/cortex-job@.service.d/evil.conf'; echo "  dropin-unit    exit=$?"
+  sudo -u "$U" sh -c 'printf "id\n" >> /opt/cortex/bin/cortex-job-shim';                 echo "  append-shim    exit=$?"
+  sudo -u "$U" sh -c 'ln -sf /tmp/evil /opt/cortex/bin/cortex-job-shim';                 echo "  symlink-shim   exit=$?"
+  sudo -u "$U" sh -c 'mv /opt/cortex/bin /opt/cortex/bin.bak';                           echo "  rename-bindir  exit=$?"
+  sudo -u "$U" sh -c 'printf "x\n" >> /etc/polkit-1/rules.d/49-cortex-downgrade.rules';  echo "  append-polkit  exit=$?"
+  sudo -u "$U" sh -c 'rm -f /etc/polkit-1/rules.d/49-cortex-downgrade.rules';            echo "  delete-polkit  exit=$?"
+done
+# 期望：**全部非 0**（9 手法 × 3 帳號 = 27 條）。任一條 exit=0 ⇒ 分界線已破，立即停止。
+
+# ✅ 5.2 negative control：root 改得動（且改完必須還原並複驗）
+sudo cp /etc/systemd/system/cortex-job@.service /tmp/jobunit.bak
+sudo sh -c 'printf "\n# negctl\n" >> /etc/systemd/system/cortex-job@.service'
+sudo systemctl daemon-reload && echo "5.2-neg OK"
+sudo cp /tmp/jobunit.bak /etc/systemd/system/cortex-job@.service
+sudo systemctl daemon-reload
+diff <(python3 -m paulsha_cortex.trust_root unit three-way --job) \
+     /etc/systemd/system/cortex-job@.service && echo "restored & in sync: OK"
+
+# ✅ 5.2 事後複驗：分界線改過之後仍成立（族 3「重啟後仍綠」的同一條紀律）
+sudo -u cortex-manager systemd-run --uid=0 --pipe --wait /bin/id; echo "post-negctl exit=$?"   # 期望非 0
+```
+
+### 8c. negative control（受信任身分做同樣的事**必須成功**）
+
+```bash
+# ✅ 族 1／2 的 negative control：cortex-manager 寫得進去
+sudo -u cortex-manager sh -c '
 set -e
 A=/var/lib/cortex
 printf "{}" > "$A/coordinator/.negctl.json" && rm -f "$A/coordinator/.negctl.json"
@@ -1050,6 +1368,11 @@ cat /opt/cortex/etc/cortex-manager.env >/dev/null
 echo NEG-CONTROL-OK'
 #   期望：印出 NEG-CONTROL-OK。若這裡也失敗 ⇒ 環境壞掉，族 1/2 的綠是假綠。
 
+# ✅ 族 2 的第二個 negative control：reviewer 寫得進自己那格 verdict spool
+sudo -u cortex-reviewer-planner sh -c \
+  'printf "{}" > /var/lib/cortex/coordinator/review-verdicts/.negctl && echo NEG-CONTROL-2-OK' 2>&1 | tail -1
+sudo rm -f /var/lib/cortex/coordinator/review-verdicts/.negctl
+
 # ✅ 族 3 的 negative control：root 改得動 enforcement plane（且改完必須重啟複驗）
 sudo cp /etc/systemd/system/cortex-manager.service /tmp/unit.bak
 sudo sh -c 'printf "\n# negctl\n" >> /etc/systemd/system/cortex-manager.service'
@@ -1058,30 +1381,53 @@ sudo cp /tmp/unit.bak /etc/systemd/system/cortex-manager.service
 sudo systemctl daemon-reload && sudo systemctl restart cortex-manager.service
 
 # ✅ 族 4 的 negative control：operator（有 sudo）讀得到 Manager environ
-MPID=$(pgrep -u cortex-svc -n -f paulsha_cortex); sudo cat "/proc/$MPID/environ" | tr '\0' '\n' | head -3 && echo "NEG-CONTROL-4-OK"
+MPID=$(pgrep -u cortex-manager -n -f paulsha_cortex); sudo cat "/proc/$MPID/environ" | tr '\0' '\n' | head -3 && echo "NEG-CONTROL-4-OK"
+
+# ✅ 族 5 的 negative control：cortex-manager 起**合法**的 job instance 必須成功
+#    （否則族 5 的紅可能只是「polkit 把 cortex-manager 全部擋掉了」）
+sudo install -d -o cortex-manager -g cortex-manager -m 0700 /var/lib/cortex/jobs/negctl5
+sudo setfacl -m u:cortex-builder:r-x /var/lib/cortex/jobs/negctl5
+sudo install -d -o cortex-builder -g cortex-builder -m 0700 /var/lib/cortex/worktree/negctl5
+sudo tee /var/lib/cortex/jobs/negctl5/run.sh >/dev/null <<'SH'
+#!/bin/sh
+id
+SH
+sudo chown cortex-manager:cortex-manager /var/lib/cortex/jobs/negctl5/run.sh
+sudo chmod 0600 /var/lib/cortex/jobs/negctl5/run.sh
+sudo setfacl -m u:cortex-builder:r-- /var/lib/cortex/jobs/negctl5/run.sh
+sudo -u cortex-manager systemctl start cortex-job@negctl5.service && echo "NEG-CONTROL-5-OK"
+sudo journalctl -u cortex-job@negctl5.service -n 5 --no-pager | grep -o "uid=[0-9]*(cortex-builder)"
+#   期望：印出 NEG-CONTROL-5-OK，且 journal 顯示 uid=…(cortex-builder)
 ```
 
-### 8c. 族 3 的「重啟後仍綠」複驗（spec §R9 硬性要求）
+### 8d. 族 3 的「重啟後仍綠」複驗（spec §R9 硬性要求）
 
 ```bash
-# ✅ 每個族 3 案例改完 MUST 實際重啟服務再驗證
+# ✅ 每個族 3／族 5.2 案例改完 MUST 實際重啟服務再驗證
 sudo systemctl restart cortex-manager.service
 sleep 3
 systemctl is-active cortex-manager.service
-sudo -u cortex-svc env $(grep -v '^#' /opt/cortex/etc/cortex-manager.env | xargs) \
+sudo -u cortex-manager env $(grep -v '^#' /opt/cortex/etc/cortex-manager.env | xargs) \
   /opt/cortex/venv/bin/python -m paulsha_cortex.trust_root selfcheck | head -20
-#   期望：服務 active、自檢仍 ok=true（族 3 的攻擊沒有留下任何持久效果）
+#   期望：服務 active、自檢仍 ok=true（族 3／5 的攻擊沒有留下任何持久效果）
 ```
 
-### 8d. 清理
+### 8e. 清理
 
 ```bash
-sudo systemctl stop "cortex-job@r9.service" 2>/dev/null || true   # 方案 B 才需要
-sudo rm -rf /var/lib/cortex/jobs/r9 /var/lib/cortex/worktree/r9 /var/lib/cortex/worktree/victim
+# 🔧 sudo：清掉 R9 抽驗的全部殘留（含 drop-in 目錄——它本身就是提權面）
+sudo systemctl stop "cortex-job@r9.service" "cortex-job@negctl5.service" 2>/dev/null || true
+sudo rm -rf /var/lib/cortex/jobs/r9 /var/lib/cortex/jobs/negctl5 \
+            /var/lib/cortex/worktree/r9 /var/lib/cortex/worktree/negctl5 \
+            /var/lib/cortex/worktree/victim \
+            /var/lib/cortex/coordinator/review-verdicts/victim \
+            /etc/systemd/system/cortex-job@.service.d
+sudo systemctl daemon-reload
 ```
 
-**通過條件**：8a 全部 `denied (OK)`；8b 三組 negative control 全部印出 `*-OK`；
-8c 重啟後仍綠。任一條不符 ⇒ **D6 不算通過**，`0.2.0` 不得宣告 stable（spec §R12）。
+**通過條件**：8a 兩份報告全部 `denied (OK)`；8b 族 5.1 五條與族 5.2 的 27 條**全部非 0**；
+8c 五組 negative control 全部印出 `*-OK`；8d 重啟後仍綠。
+任一條不符 ⇒ **D6 不算通過**，`0.2.0` 不得宣告 stable（spec §R12）。
 
 ---
 
@@ -1092,34 +1438,45 @@ Phase 1 完全不需 root 且含降級運轉安全網（`PSC_DEGRADED_OPERATION=
 
 | 階段 | 症狀 | 回滾動作（`🔧 sudo`） |
 |---|---|---|
-| 第 1（UID） | 帳號建錯／名稱衝突 | `sudo userdel cortex-svc; sudo userdel cortex-builder; sudo groupdel cortex-svc; sudo groupdel cortex-builder`（此時尚無檔案屬於它們） |
-| 第 2（樹／權限） | 權限套錯、`find -perm /022` 非空 | 重跑 `sudo sh -e /tmp/p2b-permissions.sh`（冪等）；仍不對則 `sudo rm -rf /var/lib/cortex /var/lib/cortex-svc /var/lib/cortex-builder` 後從第 2 步重來（舊樹未動） |
+| 第 1（三帳號） | 帳號建錯／名稱衝突 | `sudo userdel cortex-manager cortex-reviewer-planner cortex-builder`（逐一）；`sudo groupdel` 同名三個 group；`sudo rm -rf /var/lib/cortex-reviewer-planner`（此時尚無檔案屬於它們） |
+| 第 2（樹／權限） | 權限套錯、`find -perm /022` 非空 | 重跑 `sudo sh -e /tmp/p2b-permissions.sh`（冪等）；仍不對則 `sudo rm -rf /var/lib/cortex /var/lib/cortex-svc /var/lib/cortex-reviewer-planner /var/lib/cortex-builder` 後從第 2 步重來（舊樹未動） |
 | 第 3（legacy-import） | quarantine 內容不符 manifest | `sudo rm -rf /var/lib/cortex/legacy-imported`，重跑 3；`$HOME/.agents` 原地仍完整 |
 | 第 4a（部署） | 新 venv 起不來 | `sudo rm -rf /opt/cortex/venv; sudo mv /opt/cortex/venv.prev /opt/cortex/venv; sudo systemctl restart cortex-manager` |
 | 第 4c（system unit） | WSL 重啟後未拉起／服務起不來 | `sudo systemctl disable --now cortex-manager.service`；改回 `systemctl --user start cortex-manager.service`（舊部署仍在 `$HOME/.local/share/pipx`） |
 | 第 4c（加固誤擋） | 服務起來但功能靜默失效 | 見下方「`ProtectSystem=strict` 誤擋診斷」；**臨時** drop-in 放行、**同一天**把該路徑回填 R1 登記表並重跑 permgen |
-| 第 5（降權） | polkit／transient unit／模板 unit 在 WSL2 不如預期 | `sudo rm -f /etc/polkit-1/rules.d/49-cortex-downgrade.rules /etc/systemd/system/cortex-job@.service; sudo systemctl daemon-reload; sudo systemctl restart polkit.service`；**方案 A 另需**把 `PSC_JOB_RUNNER` 移出 EnvironmentFile（回 `direct`）並 `sudo systemctl restart cortex-manager`；Manager 以 `per-case-approval` 不 spawn job 運轉 |
-| 第 8（R9 有紅） | 任一攻擊成功 | **立即**停 job 派工，執行下方「全面回退」，在 #584 記錄該條攻擊路徑；D6 判定未通過 |
+| **第 5-2（template unit）** | instance 起不來／unit 語法錯 | `sudo rm -f /etc/systemd/system/cortex-job@.service; sudo rm -rf /etc/systemd/system/cortex-job@.service.d; sudo systemctl daemon-reload`；(d) 一併關閉（見下一列） |
+| **第 5-3（shim）** | job 起得來但 argv 不對／shim crash | `sudo rm -f /opt/cortex/bin/cortex-job-shim`；重新由產生器落檔並 `diff` 對齊；仍不對則關 (d) |
+| **第 5-4（polkit）** | 規則語法錯／`cortex-manager` 起不了任何 job | `sudo rm -f /etc/polkit-1/rules.d/49-cortex-downgrade.rules; sudo systemctl restart polkit.service`；此時降權面完全關閉（fail-closed，job 起不來但無提權） |
+| **第 5-5（切換點）** | 降權後 job 全數 needs_human | `sudo sed -i '/^PSC_JOB_RUNNER=/d;/^PSC_BUILDER_ACCOUNT=/d;/^PSC_BUILDER_HOME=/d' /opt/cortex/etc/cortex-manager.env; sudo systemctl restart cortex-manager.service`（回 `direct`）；Manager 以 `per-case-approval` 不 spawn job 運轉 |
+| 第 8（R9 有紅） | 任一攻擊成功（含族 5） | **立即**停 job 派工，執行下方「全面回退」，在 #584 記錄該條攻擊路徑；D6 判定未通過 |
 
 ### 全面回退到 Phase 1（降級運轉）
 
 ```bash
-# 🔧 sudo：停掉並移除 Phase 2 的一切
+# 🔧 sudo：停掉並移除 Phase 2 的一切（含 A+B 的三個 root-owned 物件與三帳號）
 sudo systemctl disable --now cortex-manager.service 2>/dev/null || true
 sudo rm -f /etc/systemd/system/cortex-manager.service /etc/systemd/system/cortex-job@.service
+sudo rm -rf /etc/systemd/system/cortex-job@.service.d
 sudo rm -f /etc/polkit-1/rules.d/49-cortex-downgrade.rules
-#   （方案 A：EnvironmentFile 隨 /opt/cortex 一併移除，PSC_JOB_RUNNER 自然失效）
+sudo rm -f /opt/cortex/bin/cortex-job-shim
+#   （EnvironmentFile 隨 /opt/cortex 一併移除，PSC_JOB_RUNNER 自然失效）
 sudo systemctl daemon-reload
 sudo systemctl restart polkit.service 2>/dev/null || true
 
-# 🔧 sudo：新樹整棵丟棄（舊 state 從未被併入，故無資料損失）
-sudo rm -rf /var/lib/cortex /var/lib/cortex-svc /var/lib/cortex-builder /opt/cortex
+# 🔧 sudo：新樹整棵丟棄（舊 state 從未被併入，故無資料損失）＋ 移除三帳號
+sudo rm -rf /var/lib/cortex /var/lib/cortex-svc /var/lib/cortex-reviewer-planner \
+            /var/lib/cortex-builder /opt/cortex
+for U in cortex-manager cortex-reviewer-planner cortex-builder; do
+  sudo userdel "$U" 2>/dev/null || true
+  sudo groupdel "$U" 2>/dev/null || true
+done
 
 # ✅ 回到 operator 帳號部署 ＋ 降級運轉
 export PSC_DEGRADED_OPERATION=per-case-approval
 systemctl --user start cortex-manager.service
 python3 -m paulsha_cortex.trust_root selfcheck    # 預期回到有 WARN 的 Phase 1 狀態
 echo "PSC_DEGRADED_OPERATION=$PSC_DEGRADED_OPERATION"
+getent passwd cortex-manager cortex-reviewer-planner cortex-builder || echo "accounts removed: OK"
 ```
 
 > **回滾原則**：舊 state 走 legacy-import（第 3 步）而非併入，所以回滾時新樹可整棵
@@ -1147,6 +1504,7 @@ systemctl show cortex-manager.service -p WantedBy
 #   期望：WantedBy=multi-user.target
 ls -l /etc/systemd/system/multi-user.target.wants/cortex-manager.service
 #   期望：symlink 存在
+#   注意：cortex-job@.service 是 template，**不需要也不應該** enable。
 
 # ---- 3. 在 Windows 端執行：wsl --shutdown ----
 #      然後重新開一個 WSL shell，再回來跑本段第 4 項。
@@ -1161,12 +1519,13 @@ sudo journalctl -u cortex-manager.service -b --no-pager | head -30
 
 # ✅ 5. polkit 也必須在重啟後自己起來（否則降權在重啟後靜默失效）
 systemctl is-active polkit.service || systemctl is-active polkitd.service
-#   方案 A：
-sudo -u cortex-svc systemd-run --quiet --collect --pipe --wait \
-  --unit=cortex-job-smoke-00000000.service --uid=cortex-builder --gid=cortex-builder \
-  --service-type=exec /bin/id && echo "降權重啟後仍可用（A）"
-#   方案 B：
-# sudo -u cortex-svc systemctl start cortex-job@selftest.service && echo "降權重啟後仍可用（B）"
+
+# ✅ 6. 降權正向：重啟後仍可起 job instance
+sudo -u cortex-manager systemctl start cortex-job@negctl5.service \
+  && echo "降權重啟後仍可用" || echo "!! 降權失效，查 polkit"
+
+# ✅ 7. 降權反向：重啟後提權仍被拒（規則沒有因重啟而失效）
+sudo -u cortex-manager systemd-run --uid=0 --pipe --wait /bin/id; echo "exit=$?"   # 期望非 0
 ```
 
 **若重啟後未拉起**：依序查
@@ -1187,21 +1546,28 @@ sudo journalctl -u cortex-manager.service -b --no-pager | grep -Ei \
 
 # ✅ 2. 看實際生效的白名單（和產生器輸出對照）
 systemctl show cortex-manager.service -p ProtectSystem -p ReadWritePaths -p ProtectHome
-diff <(python3 -m paulsha_cortex.trust_root unit two-way --manager | grep '^ReadWritePaths=') \
+diff <(python3 -m paulsha_cortex.trust_root unit three-way --manager | grep '^ReadWritePaths=') \
      <(systemctl show cortex-manager.service -p ReadWritePaths | tr ' ' '\n' | sed 's/^/ReadWritePaths=/' | head -50)
 
-# ✅ 3. 在**同一組沙箱條件**下重現（root 用 systemd-run 診斷，不放行給 svc）
-sudo systemd-run --pipe --wait --uid=cortex-svc \
+# ✅ 3. 在**同一組沙箱條件**下重現（root 用 systemd-run 診斷，不放行給 manager）
+sudo systemd-run --pipe --wait --uid=cortex-manager \
   --property=ProtectSystem=strict --property=ProtectHome=yes --property=PrivateTmp=yes \
   --property="ReadWritePaths=/var/lib/cortex/coordinator" \
   /bin/sh -c 'touch /var/lib/cortex/coordinator/.probe && echo WRITE-OK; touch /var/lib/cortex/specs/.probe || echo "specs blocked"'
 #   ↑ 逐條加/減 ReadWritePaths，找出到底缺哪一條
+#   注意：這條是 **operator 以 sudo** 起的診斷用 transient unit，
+#         與「cortex-manager 自己不能起 transient unit」不衝突（族 5.1 測的是後者）。
 
 # ✅ 4. 檢查有沒有落在 ProtectHome 遮住的區域（最常見的靜默失效）
 systemctl show cortex-manager.service -p ReadWritePaths | tr ' ' '\n' | grep -E "^/home|^/root" \
   && echo "!! RWP 落在 ProtectHome 遮蔽區，必定失效"
 
-# ✅ 5. 臨時放行（僅供診斷；當天必須回填登記表）
+# ✅ 5. job template 側的同一診斷（job 起得來但寫不進 worktree 時）
+systemctl show "cortex-job@negctl5.service" -p ReadWritePaths -p ProtectSystem 2>/dev/null
+diff <(python3 -m paulsha_cortex.trust_root unit three-way --job | grep '^ReadWritePaths=') \
+     <(grep '^ReadWritePaths=' /etc/systemd/system/cortex-job@.service)
+
+# ✅ 6. 臨時放行（僅供診斷；當天必須回填登記表）
 sudo systemctl edit cortex-manager.service     # 加入 [Service] ReadWritePaths=<被擋路徑>
 sudo systemctl daemon-reload && sudo systemctl restart cortex-manager.service
 ```
@@ -1215,10 +1581,13 @@ sudo systemctl daemon-reload && sudo systemctl restart cortex-manager.service
 | 服務起不來、Python 直接 crash | `MemoryDenyWriteExecute=yes` 撞到 C extension 的 ctypes trampoline | 先單獨註解該行複測；確認是它之後在 unit 產生器裡記錄例外理由 |
 | 任何 `$HOME/.agents` 路徑 | `ProtectHome=yes` 讓 HOME 不可見 | **這是刻意的**——代表還有程式碼在走舊 fallback，回頭修路徑契約，不要放寬 unit |
 | socket 建不出來 | `run_root` 不在 RWP | 檢查 `runtime-run-tree` 是否仍在登記表；重跑產生器 |
+| job 起得來但寫不進自己的 worktree | template unit 的 `%i` 展開與實際 worktree 名不一致 | 對照 5-6 的 `install -d …/worktree/$JOB` 與 instance 名；兩者必須同名 |
 
 > **鐵律**：被擋的路徑**只能**經「回填 R1 登記表 → 重跑 permgen → 重新落檔 unit」
 > 進入 `ReadWritePaths`。drop-in 只能作為**當天的**臨時措施，不得成為長期狀態——
 > 否則 unit 就不再是登記表的機械投影，`diff` 對齊檢查會紅。
+> **template unit 的 drop-in 更嚴**：`/etc/systemd/system/cortex-job@.service.d/` 一旦
+> 存在就是提權面（族 5.2 有一條專門測它建不起來），診斷完**必須立刻刪除**。
 
 ### C. WSL2 其他已知風險
 
@@ -1226,31 +1595,31 @@ sudo systemctl daemon-reload && sudo systemctl restart cortex-manager.service
    **一律拒絕**（fail-closed）。表現為「Manager 完全 spawn 不了 job」而非提權——
    安全但功能全停。執行前提第 6 項已檢查；重啟後由「A. 第 5 項」複驗。
 2. **`sudo` 需密碼**：所有 `🔧 sudo` 步驟皆互動式，**不可假設自動化**；
-   本 runbook 刻意不使用 `sudo -n`。
+   本 runbook 刻意不使用 `sudo -n`（族 5 的 `sudo -n true` 例外，那是攻擊測試）。
 3. **`/proc` 隱藏造成 R9 判讀差異**：`ProtectProc=invisible` 下讀他人
    `/proc/<pid>/environ` 會是 `ENOENT`（No such file）而非 `EACCES`——
    兩者都算**拒絕**（第 8 步的 `t()` 只看 rc 非 0，判定不受影響）。
+4. **WSL2 的 `busctl` 可能不在 PATH**：族 5.1e 若報 `command not found`，
+   以 `sudo apt-get install systemd` 補齊後重測；**不可**因為工具缺席就跳過該條
+   （它測的是繞開 CLI 的直接 D-Bus 路徑）。
 
 ---
 
-## 附錄：本 runbook 的自我檢查
+## 附錄 A：本 runbook 的自我檢查
 
 ```bash
-# ✅ unit／polkit 與產生器沒有漂移（建議排程每日跑）
-#   PLAN=transient（方案 A）或 template（方案 B）——填第 5 步選定的那個
-PLAN=transient
-diff <(python3 -m paulsha_cortex.trust_root unit two-way --manager) /etc/systemd/system/cortex-manager.service
-diff <(python3 -m paulsha_cortex.trust_root polkit two-way --$PLAN) /etc/polkit-1/rules.d/49-cortex-downgrade.rules
-[ "$PLAN" = template ] && diff <(python3 -m paulsha_cortex.trust_root unit two-way --job) \
-     /etc/systemd/system/cortex-job@.service
+# ✅ unit／polkit／shim 與產生器沒有漂移（建議排程每日跑）
+diff <(python3 -m paulsha_cortex.trust_root unit three-way --manager) /etc/systemd/system/cortex-manager.service
+diff <(python3 -m paulsha_cortex.trust_root unit three-way --job)     /etc/systemd/system/cortex-job@.service
+diff <(python3 -m paulsha_cortex.trust_root polkit three-way --template) /etc/polkit-1/rules.d/49-cortex-downgrade.rules
+# shim 落地後再加：
+# diff <(python3 -m paulsha_cortex.trust_root shim three-way) /opt/cortex/bin/cortex-job-shim
 
-# ✅ 方案 A 專屬：unit 名前綴契約沒有漂移（改任一邊都會讓所有 job 被 polkit 拒）
-[ "$PLAN" = transient ] && python3 - <<'PY'
-from paulsha_cortex.coordinator import job_runner
-from paulsha_cortex.trust_root import permgen
-assert permgen.transient_unit_prefix(permgen.DEFAULT_LAYOUT) == job_runner.UNIT_NAME_PREFIX
-print("unit prefix contract OK")
-PY
+# ✅ 沒有殘留的 template drop-in（族 5.2 的持久化面）
+ls -la /etc/systemd/system/cortex-job@.service.d 2>/dev/null && echo "!! 有 drop-in，查來源" || echo "no drop-in: OK"
+
+# ✅ 三分帳號仍是三個、互不交集、皆無 sudo
+for U in cortex-manager cortex-reviewer-planner cortex-builder; do id -nG "$U"; done
 
 # ✅ 權限沒有漂移
 sudo find /var/lib/cortex /opt/cortex -perm /022 -print | head
@@ -1258,3 +1627,83 @@ sudo find /var/lib/cortex /opt/cortex -perm /022 -print | head
 # ✅ 產生器本身的等式測試（含 ReadWritePaths 無遺漏無多餘）
 python3 -m pytest tests/test_trust_root_permgen_p2a.py tests/test_trust_root_permgen_p2b.py -q
 ```
+
+---
+
+## 附錄 B：降級備援——transient unit（**附殘餘風險**）
+
+> **這不是主路徑。** 只有在「template 路徑在本機不可用」（例如 template unit 起不來、
+> shim 尚未落地而又必須立刻恢復 job 派工）時才臨時使用，且**必須在 #584 記錄
+> 啟用時間、原因、預計關閉時間**。
+
+程式碼側 `PSC_JOB_RUNNER=systemd-run` 已於 #603 落地，polkit 側改用 transient 規則：
+
+```bash
+# 🔧 sudo：換成 transient 規則（unit 名前綴 cortex-job-，非 @ 實例）
+python3 -m paulsha_cortex.trust_root polkit three-way --transient \
+  | sudo tee /etc/polkit-1/rules.d/49-cortex-downgrade.rules >/dev/null
+sudo systemctl restart polkit.service 2>/dev/null || sudo systemctl restart polkitd.service
+
+# 🔧 sudo：切換點改回 systemd-run
+sudo sed -i 's/^PSC_JOB_RUNNER=.*/PSC_JOB_RUNNER=systemd-run/' /opt/cortex/etc/cortex-manager.env
+sudo systemctl restart cortex-manager.service
+
+# ✅ 契約對齊：polkit 規則的 pattern 前綴必須等於 job_runner 的常數
+python3 - <<'PY'
+from paulsha_cortex.coordinator import job_runner
+from paulsha_cortex.trust_root import permgen
+prefix = permgen.transient_unit_prefix(permgen.DEFAULT_LAYOUT)
+assert prefix == job_runner.UNIT_NAME_PREFIX, (prefix, job_runner.UNIT_NAME_PREFIX)
+print("unit prefix contract OK:", prefix)
+PY
+
+# ✅ 正向：transient job 起得來且降到 cortex-builder
+sudo -u cortex-manager systemd-run --quiet --collect --pipe --wait \
+  --unit=cortex-job-smoke-00000000.service \
+  --uid=cortex-builder --gid=cortex-builder --service-type=exec \
+  --property=NoNewPrivileges=yes \
+  /bin/sh -c 'id; echo "GH_TOKEN=[$GH_TOKEN]"; ls -l /proc/self/fd'
+
+# ⚠️ 殘餘風險實測：**這一條會成功**，且這正是降級的代價
+sudo -u cortex-manager systemd-run --quiet --unit=cortex-job-probe-00000000.service \
+     --uid=0 --pipe --wait /bin/id; echo "exit=$?"
+#   期望：**成功並印出 uid=0(root)**。polkit 看不到 --uid，因此
+#   「只能降到 cortex-builder」這一半在本備援下**只由 Manager 端 argv 產生器保證**。
+
+# ✅ 產生器對本方案的殘餘風險自述（貼進 #584）
+python3 - <<'PY'
+from paulsha_cortex.trust_root import permgen
+rule = permgen.build_polkit_rule(
+    permgen.SCHEMES["three-way"], plan=permgen.PolkitPlan.TRANSIENT
+)
+for r in rule.residual_risks:
+    print("-", r)
+PY
+```
+
+**降級期間的殘餘風險摘要**（相對於 A+B 主路徑）：
+
+| 面向 | A+B 主路徑 | transient 備援 |
+|---|---|---|
+| 「降到哪個帳號」由誰強制 | **OS**（root-owned unit 的 `User=`） | **code level**（Manager 的封閉 argv 產生器） |
+| `cortex-manager` 被攻陷後能否起 root job | ✘（5-7 (2) 實測被拒） | **✔（可以）** |
+| 特權屬性（`AmbientCapabilities=` 等） | 呼叫端提都提不了 | 呼叫端可以傳，靠 argv 產生器不傳 |
+| 三分帶來的保護 | 仍完整（injection 可達進程無 grant） | 仍完整——**這是三分在降級時的主要價值** |
+
+**關閉備援**：把 5-4 的 template 規則落回、`PSC_JOB_RUNNER=systemd-template`，
+再跑一次 5-7 的 11 條反向測試確認邊界恢復。
+
+---
+
+## 附錄 C：與第二輪裁決的差異（給讀過舊版 runbook 的人）
+
+| 舊版（0816 第二輪） | 本版（0816 第三輪） |
+|---|---|
+| 第 1 步建**兩**個帳號（`cortex-svc` / `cortex-builder`） | 建**三**個（`cortex-manager` / `cortex-reviewer-planner` / `cortex-builder`） |
+| 全文 `two-way` | 全文 `three-way`；`two-way` 僅存於程式碼作為對照組 |
+| 第 5 步 A／B 並列，**待 operator 拍板** | 第 5 步 **A+B 合一，無分歧**；transient 降為附錄 B 備援 |
+| polkit 授 transient 建立（方案 A） | polkit **不授** transient 建立；只放行 `cortex-job@*.service` 的 start/stop |
+| `ExecStart=` 指向 spool 內的 `run.sh` | 指向 **root-owned shim** `/opt/cortex/bin/cortex-job-shim`（C 層搬進 root-owned 檔） |
+| `PSC_JOB_RUNNER=systemd-run` | `PSC_JOB_RUNNER=systemd-template`（`systemd-run` 僅備援用） |
+| R9 四族，subject 為 `cortex-builder` | R9 **五族**，subject 為 builder ＋ reviewer-planner，新增族 5 privilege-boundary |
+| 殘餘風險：授權帳號可起任意 UID | 殘餘風險：**僅剩 `cortex-manager` 的 supply-chain 類**（見 5-8） |


### PR DESCRIPTION
## 摘要

把 trust-root Phase 2b runbook 從「A／B 兩案並列、待 operator 拍板」收斂為
**A+B 單一路徑**，落實 operator 0816 第三輪裁決（#584 最新留言）。

`#603` 實測確認 polkit 的 `org.freedesktop.systemd1.manage-units` **只暴露 unit 名與
verb、不暴露 `User=`／`--uid=`**。單靠 polkit 收窄守不住「只能降到 `cortex-builder`」
這一半，因此裁決把「**誰持有授權**」與「**授權能做什麼**」兩層一起收：

| 層 | 內容 | 效果 |
|---|---|---|
| **A（三分）** | `cortex-manager`（Manager＋monitor、durable state owner、唯一 polkit subject、**不跑任何模型程式碼**）／`cortex-reviewer-planner`／`cortex-builder` | injection 可達的 job 帳號**完全不在授權面上** |
| **B（template unit）** | root-owned `cortex-job@.service`，`User=cortex-builder` 與加固段寫死 | `cortex-manager` 即使被完全攻陷，也**改不了 `User=`、傳不了屬性** |
| **C（argv 保證）** | root-owned shim `/opt/cortex/bin/cortex-job-shim` 讀 Manager-owned job-spec spool 導出 argv | argv 的**形狀**由 root-owned 程式決定，Manager 只能給參數 |

**docs-only**：只動 runbook ＋ CHANGELOG／changelog.d，不改任何一行程式碼。

## 主要變更

- **第 1 步：建三帳號**（原二分）。新增三帳號互斥驗證：互不可讀對方 HOME cache、
  三者皆無 sudo、group 互不交集。全文 `two-way` → `three-way`
  （`permgen.THREE_WAY_SCHEME` 由備選轉定案）；二分縮為一行歷史註記＋附錄 C 差異表。
- **第 5 步：A+B 合一**，原 5-A／5-B 兩節（共 10 小節）收斂為一條九節路徑：
  (a) `polkit three-way --template`（只放行 `cortex-job@*.service` 的 `start`／`stop`，
  **不授權 transient 建立**）→ (b) template unit → (c) shim → (d)
  `PSC_JOB_RUNNER=systemd-template`。(c)(d) 依賴 #603 follow-up PR（template-instance
  模式），以「**將由該 PR 提供**」標註，並附「PR 未落地時做到哪裡」的分岔指引；
  每個落檔步驟後都跟一條對產生器的 `diff`，介面一落地即自動對齊。
- **反向測試**由「5-A-5 四條（其中一條**期望成功**）＋ 5-B-4 七條」收斂為 **5-7 的
  11 條、全部期望被拒**。
- **殘餘風險段重寫**：「polkit 看不到 `User=`」與「reviewer／planner 與 Manager 併帳」
  兩條殘餘**不再成立**（各附實測條目）；polkit 粗粒度仍在但已不構成提權。剩下的收斂為
  **`cortex-manager` 帳號的 supply-chain 類**（部署樹供應鏈／Manager 自身邏輯／
  operator 帳號／polkit 不可用），逐條列出現有緩解與缺口。
- **R9 攻擊矩陣：四族 → 五族**，族 1–4 各跑 **builder 與 reviewer-planner 兩個
  subject**（`cortex-manager` 僅作 negative control）。新增**族 5 privilege-boundary**：
  - **5.1** 以 `cortex-manager` 請求 transient unit `--uid=root` 的五種形式（直接／
    借 job unit 名包裝／改用 `--property` 夾帶／`--user` bus 旁路／`busctl` 直打
    `StartTransientUnit`）→ 必須全部被 polkit 拒（**無 transient 建立授權**）。
  - **5.2** 三個 headless 帳號 × 九種手法（append／truncate／replace／drop-in／
    改 shim／symlink 換 shim／rename `bin/`／改 polkit／刪 polkit）改寫
    `/etc/systemd/system/cortex-job@.service` 或 `/opt/cortex/bin/cortex-job-shim`
    → 必須全部被 root-owned 拒（27 條）。
  - 兩族各附 negative control（operator sudo 做同樣的事必須成功；`cortex-manager`
    起**合法** instance 必須成功），避免「polkit 把該帳號全擋掉」造成假綠。
- **執行前提補兩項**：三帳號名稱未被占用＋產生器的 persona→帳號映射自述；
  `systemd-template` 是否已在 `job_runner.RUNNER_MODES`（決定 (d) 能不能開）。
- **回滾段**：5-2（template unit，含 drop-in 目錄）／5-3（shim）／5-4（polkit）／
  5-5（切換點）各自獨立一列；「全面回退」新增移除 shim、drop-in 與**三個帳號**。
- **重新統計**：9 步 ＋ 3 附錄、**32 個 `🔧 sudo` 點**、**122 個 `✅ 驗證` 點**
  （附逐段落明細表與統計方式說明）。
- **新增附錄 B「降級備援——transient unit」**：保留原方案 A 的完整操作，但明示
  **不是主路徑**、必須在 #584 記錄啟用原因與預計關閉時間，並以對照表列出降級期間
  多出來的殘餘風險（含 `plan_residual_risk()` 的自述輸出）。**新增附錄 C**：與第二輪
  裁決的逐項差異，供讀過舊版的人對照。

## 誠實邊界（已寫進 runbook，共三處標註）

`launcher.SubprocessLauncher._degraded_runner()` 目前**只對 builder persona 降權**，
因此 M1（本 runbook 全程）之後 reviewer／planner 仍在 Manager 行程內以
`cortex-manager` 身分執行——「injection 可達的進程皆無 spawn 授權」在 M1
**只對 builder 成立**（builder 是唯一會跑 untrusted repo code 的 persona）。
reviewer／planner 的行程面降權為 **M2**（#603 follow-up 的後續工項）。runbook 於
開頭「分段落地」、5-8 殘餘風險表與第 8 步各標註一次，並要求把「M2 是否完成」寫進
#584 的 D6 判定紀錄。

另標註 permgen 尚未跟上三分定案的兩個已知缺口（Manager HOME 仍沿用
`/var/lib/cortex-svc`；`cortex-reviewer-planner` 未進 `scaffold_directories`），
第 1 步以「一律以產生器輸出為準」＋手動補三行處理，第 2 步稽核 3 給出對應期望值。

## 驗證

- `python3 -m pytest -q` → **3366 passed, 49 subtests passed**（docs-only，零回歸）。
- 本 PR 引用的每個 permgen 命令都以 `three-way` 實跑過：`scaffold`／
  `permissions --commands --paths`／`unit --manager`／`unit --job`／`polkit --template`。
- 第 2 步稽核 2／3 的期望值以實際輸出核對：三分下 `setfacl` 授寫**恰好四行**
  （builder→event-spool、reviewer-planner→review-verdicts，各 access／default 一組）；
  權限 script 的 `cortex-svc` 出現次數為 **0**、scaffold 為 **2**（已知 HOME 命名缺口）。

## Checklist

- [x] `changelog.d/ab-runbook-converged.md` fragment 已新增且已 commit
- [x] `CHANGELOG.md [Unreleased]` 有對應 entry
- [x] `VERSION` 未動（非 release PR）
- [x] 分支為 `feature/ab-runbook-converged`，非 `main`
- [x] 全套 pytest 通過（3366 passed）
- [x] 語言 zh-tw
- [x] R-17：本 PR 為 reference-only（`Refs #584`，母議題不 auto-close），帶
      `policy-exempt:issue-link`

Refs #584
