### PR TITLE
feat(trust-root): 三分 UID 定案並補 job_runner 的 template-instance 降權模式

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,41 @@
 
 ## [Unreleased]
 
+### Added
+- **#584 / trust-root Phase 2b：0816 第三輪裁決 A+B 的程式碼側——三分 UID 定案 ＋
+  `job_runner` 的 template-instance 模式**——**A**：`permgen.DEFAULT_SCHEME`
+  改為 `THREE_WAY_SCHEME`（`cortex-manager`／`cortex-reviewer-planner`／
+  `cortex-builder`），`trust_root` CLI 未指定 scheme 時一律出三分、`two-way` 需顯式
+  打出（打錯字不會靜默退回較寬鬆的方案）；polkit 產生器預設方案同步改為 **B**
+  （`PolkitPlan.TEMPLATE`，subject＝`cortex-manager`、verb ∈ {start, stop}、pattern＝
+  `^cortex-job@…\.service$`，且**不放行任何 transient unit 形狀**）。**B**：
+  `coordinator/job_runner.py` 新增第三模式 `PSC_JOB_RUNNER=systemd-template`——把
+  per-job spec（command／worktree／白名單 env／log 路徑，**無任何身分欄位**）原子寫進
+  Manager-owned spool `<coordinator_root>/job-specs/<instance>.json`（新登記表資產
+  `job-spec-spool`，builder 唯讀），再
+  `systemctl start --wait --no-ask-password cortex-job@<instance>.service`；`User=` 與
+  `ExecStart=` 皆硬寫死在 root-owned 模板 unit 裡，Manager 帳號選不了 UID、也給不了
+  命令列。模板的固定 `ExecStart=` 是新的 root-owned shim
+  （`permgen.build_job_shim()` 產 stub，邏輯在 `coordinator/job_shim.py`：`O_NOFOLLOW`
+  讀 spec → 白名單 schema 驗證 → 接管 log → chdir → `execvpe`）；新增 CLI
+  `python3 -m paulsha_cortex.trust_root shim`。判活與 log 沿用既有機制（`--wait` 保住
+  pid 判活、exit sentinel 不變、harvest 的 log 路徑逐字不變）。fail-fast 涵蓋模板／
+  shim／spool 未安裝、同名 instance 已在跑、spec 寫入失敗，一律 `DiagnosticReason`
+  fail-closed 且**不退回其他模式**。`direct` 與 `systemd-run` 逐字不變。
+  **誠實邊界**：`PSC_JOB_RUNNER` 預設仍是 `direct`，template 模式生效需 Phase 2b 安裝。
+  詳見 `changelog.d/ab-template-job-runner.md`。新增
+  `tests/test_trust_root_job_template_ab.py`（80 測試）。
+
+### Fixed
+- **#584 順修（#614 runbook 實測發現的兩個 permgen 缺口）**——(a) 帳號 HOME／cache
+  改由帳號名機械導出（`PathLayout.home_of()`／`cache_of()`），不再是二分時代的字面量
+  `/var/lib/cortex-svc`：三分下 Manager 的 `Environment=HOME=` 原本會指向一個沒人擁有
+  的目錄；(b) `scaffold_directories()` 改由 `scheme.headless_accounts()` 導出帳號清單，
+  `cortex-reviewer-planner` 的 HOME／cache／`~/.codex` 因此自動入列（原本靠列舉，漏了
+  三分才出現的第三個帳號）。runbook 的手動補行 workaround 可移除。另修
+  `preflight_systemd_run()` 的 `which` seam：預設值原本在 def 時就綁定 `shutil.which`，
+  `mock.patch.object` 打不到，測試實際驗到的是「本機有沒有那個帳號」而非它宣稱的分支。
+
 ### Changed
 - **#584 / trust-root Phase 2b runbook：A／B 兩案並列收斂為 A+B 單一路徑（docs-only）**
   ——落實 operator 0816 第三輪裁決。polkit 的 `manage-units` 只暴露 unit 名與 verb、

--- a/changelog.d/ab-template-job-runner.md
+++ b/changelog.d/ab-template-job-runner.md
@@ -1,0 +1,60 @@
+### Added
+- **R0.5 D6 / trust-root Phase 2b：operator 0816 第三輪裁決 A+B 的程式碼側——三分 UID
+  定案 ＋ `job_runner` 的 template-instance 模式**（Refs #584）
+
+  **A（三分定案）**：`permgen.DEFAULT_SCHEME = THREE_WAY_SCHEME`
+  （`cortex-manager`／`cortex-reviewer-planner`／`cortex-builder`），`trust_root` CLI
+  未指定 scheme 時一律出三分，`two-way` 保留為需**顯式**打出的向後相容選項（打錯字
+  不會靜默退回較寬鬆的方案）。判準是「injection 可達的任何進程都不持有 spawn 授權」：
+  二分下 reviewer／planner 與 Manager 併帳，任一被攻陷即取得 polkit 的 start grant。
+  既有不變式測試本來就對兩案參數化跑，因此三分無需新增任何 policy 分支。
+  polkit 產生器的預設方案同步改為 **B（`PolkitPlan.TEMPLATE`）**：subject＝
+  `cortex-manager`、action＝`manage-units`、verb ∈ {start, stop}、unit pattern＝
+  `^cortex-job@…\.service$`，且 `plan_residual_risk()` 對 B 回傳空 tuple。
+
+  **B（root-owned 模板 unit）**：`coordinator/job_runner.py` 新增第三模式
+  `PSC_JOB_RUNNER=systemd-template`。builder job 改為 (a) 把 per-job spec
+  （command／worktree／白名單 env／log 路徑）**原子**寫進 Manager-owned spool
+  `<coordinator_root>/job-specs/<instance>.json`；(b)
+  `systemctl start --wait --no-ask-password cortex-job@<instance>.service`。
+  spec **不含任何身分欄位**（`SPEC_FORBIDDEN_KEYS` 在寫端與讀端各擋一次）——`User=`
+  只存在於 root-owned 的模板 unit 檔，Manager 帳號**選不了 UID、也給不了命令列**。
+
+  **新資產**：`config.paths.job_spec_spool_root()` ＋ R1 登記表 `job-spec-spool`
+  （Manager-owned，writer 只有 Manager、builder 在 reader 面）。permgen 因此機械產出
+  owner-only（0700）＋ builder 唯讀 ACL（`rX`），並讓 Manager 的 `ReadWritePaths` 少
+  一條「額外可寫路徑」例外（原本的 `<agents_root>/jobs` run.sh spool 由本資產取代）。
+
+  **shim**：模板 unit 的 `ExecStart=` 固定為 `<deploy_root>/bin/cortex-job-shim %i`。
+  permgen 的 `build_job_shim()` 產出 root-owned 的啟動 stub（以部署 venv 的絕對路徑
+  interpreter exec `paulsha_cortex.coordinator.job_shim`，**不**走 `/usr/bin/env`），
+  shim 邏輯本體是 repo 內的可測模組：驗 instance 名 → `O_NOFOLLOW` 讀 spec → 白名單
+  schema 驗證（含身分欄位與憑證 env 守衛）→ 接管 log → chdir → `execvpe`。
+  新增 CLI：`python3 -m paulsha_cortex.trust_root shim [three-way|two-way]`。
+
+  **判活與 log 沿用既有機制**：`--wait` 讓 `systemctl` client 存活到 unit 結束
+  （`systemctl(1)`，systemd ≥ 232），`dispatcher.pid_alive()` 的 pid 判活與 exit
+  sentinel 皆零改動；harvest 讀的 log 路徑逐字不變（`<log_dir>/<slice_id>.jsonl`）。
+  log 導引刻意**不用** `StandardOutput=append:`——那個檔由 PID 1（root）在降權**之前**
+  開啟，路徑上任何一段由 Manager 掌控就成了 root-follows-symlink 的提權面；改由 shim
+  在已降權之後以 `O_NOFOLLOW` 接管。
+
+  **fail-fast**（一律 `DiagnosticReason` fail-closed，**絕不**退回其他模式）：
+  `systemctl` 缺席／未以 systemd 開機／帳號或 group 不存在／模板 unit 未安裝／shim
+  未安裝或不可執行／spec spool 缺席／**同名 instance 已在跑**（`systemctl start` 對
+  active unit 會靜默回 0）／spec 寫入失敗。
+
+  **零回歸**：`direct` 與 `systemd-run` 兩模式逐字不變，既有 63 個 job_runner 測試零
+  改動。新增 `tests/test_trust_root_job_template_ab.py`（71 測試）。全套
+  `python3 -m pytest -q` → **3437 passed, 49 subtests**（main 基準 3366＋71，零回歸）。
+
+### Fixed
+- **`preflight_systemd_run()` 的 `which` seam 改為 lazy 解析**——原本 `which=shutil.which`
+  在 **def 時**就把函式物件綁進預設值，`mock.patch.object(job_runner.shutil, "which", …)`
+  因此打不到它：`test_preflight_failure_propagates` 實際是靠「本機沒有 `cortex-builder`
+  帳號」而不是它想驗的分支通過的（在有該帳號的主機上會紅）。改為 `which or shutil.which`
+  後行為完全相同，但測試驗到的是它宣稱要驗的東西。
+
+### Changed
+- **誠實邊界**：`PSC_JOB_RUNNER` 預設仍是 `direct`；template 模式要生效需 Phase 2b
+  安裝（三帳號＋模板 unit＋polkit 規則＋shim），屬部署期動作，不在本次變更範圍。

--- a/paulsha_cortex/config/paths.py
+++ b/paulsha_cortex/config/paths.py
@@ -64,6 +64,28 @@ def review_verdict_spool_root() -> Path:
     return coordinator_root() / REVIEW_VERDICT_SPOOL_DIRNAME
 
 
+#: `job_spec_spool_root()` 在 `coordinator_root()` 底下的目錄名。獨立成常數是為了讓
+#: `coordinator/job_runner.py` 的 per-job 定址、`trust_root/permgen.py` 的 layout 與本
+#: resolver 共用同一個字面量（R1 登記表的「重複路徑推導」Scenario 要求單一真相）。
+JOB_SPEC_SPOOL_DIRNAME = "job-specs"
+
+
+def job_spec_spool_root() -> Path:
+    """trust-root Phase 2b 方案 B：降權 job 的 per-job 執行規格 spool 根。
+
+    operator 0816 第三輪裁決 **A+B**：builder job 改經 root-owned 的
+    `cortex-job@.service` 模板實例起跑。模板 unit 的 `ExecStart=` 是**固定的**
+    （`<deploy_root>/bin/cortex-job-shim %i`），因此「這個 job 要跑什麼命令、在哪個
+    worktree、帶哪些 env、log 寫去哪」必須由一個**帶外通道**傳遞——就是本 spool：
+    `<此根>/<unit-instance-id>.json`，Manager 原子寫入，job 帳號**唯讀**（permgen 依
+    R1 登記表產出 owner＝durable_state_owner、mode 0700 ＋ per-account 唯讀 ACL）。
+
+    這是「即使持 spawn 授權的帳號被攻陷也無法向上」的另一半：unit 檔 root-owned 改不了、
+    spec 檔 job 帳號寫不了，因此 job **既不能選 UID、也不能改寫自己的命令列**。
+    """
+    return coordinator_root() / JOB_SPEC_SPOOL_DIRNAME
+
+
 def specs_root() -> Path:
     return resolve_runtime_root("PSC_SPECS_ROOT")
 

--- a/paulsha_cortex/coordinator/job_runner.py
+++ b/paulsha_cortex/coordinator/job_runner.py
@@ -50,16 +50,53 @@ Python `Popen` 預設 `close_fds=True`，且 launcher 在降權模式顯式把 s
 stderr 併進 JSONL log（`stderr=STDOUT`）。不加 `--quiet` 就等於在 terminal evidence 的
 來源檔裡插入非 JSON 行。
 
-本模組只組字串與做唯讀探測，**不執行任何 root 操作、不建帳號、不寫 polkit**。
+## 第三種模式：`systemd-template`（operator 0816 **第三輪**裁決 A+B 的 B 半）
+
+#603 的實測結論是：`org.freedesktop.systemd1.manage-units` 這個 polkit action
+**只暴露 unit 名稱**，不暴露 `User=`／`--uid=`。因此 `systemd-run` 模式裡「只能
+降到 builder」這一半在 OS 層是**沒有強制的**——持授權的帳號被攻陷即可請求
+`--uid=root`。裁決把它換成 root-owned 的**模板 unit**：
+
+    systemctl start --wait cortex-job@<instance>.service
+
+- `User=` 與 `ExecStart=` 都寫死在 root 擁有的 `cortex-job@.service` 裡，Manager
+  帳號**選不了 UID、也給不了命令列**（unit 檔它改不動）。
+- 命令列既然給不了，per-job 參數改走**帶外通道**：一份 spec JSON 原子寫進
+  Manager-owned spool（登記表資產 `job-spec-spool`，job 帳號唯讀），
+  `ExecStart=` 的 root-owned shim 讀完才 exec 真正的 job
+  （見 :mod:`paulsha_cortex.coordinator.job_shim`）。
+- spec **不含** `User`／`uid` 這類欄位（:data:`SPEC_FORBIDDEN_KEYS` 在寫端與讀端
+  各擋一次），也不含任何 token（沿用同一份 env 白名單）。
+
+**判活與 log 與 systemd-run 模式同一條路**：
+
+- `--wait` 讓 `systemctl` client 存活到 unit 結束（`systemctl(1)`：「For (re)start,
+  wait until service stopped again」，systemd ≥ 232），因此
+  `dispatcher.pid_alive()` 的 pid 判活不必改一行。
+- exit sentinel 仍由 wrapper script 在 job 內寫入，`poll_headless_done` 的第一判準
+  完全不變。
+- log：`systemctl` **沒有** `--pipe`，且 unit 的 `StandardOutput=append:` 會由
+  **root 在降權前**開檔（Manager 可寫的路徑上放 symlink 即成提權面），因此改由
+  shim 在**已降權之後**依 spec 的 `log_path` 以 `O_NOFOLLOW` 接管 stdout/stderr。
+  **harvest 讀的 log 路徑因此逐字不變**（`<log_dir>/<slice_id>.jsonl`）。
+
+fail-fast 三案（任一命中即 `DiagnosticReason` fail-closed，**絕不**退回其他模式）：
+模板 unit／shim 未安裝、同名 instance 已在跑、spec 寫入失敗。
+
+本模組只組字串、做唯讀探測、與寫入 Manager 自己的 spec spool，**不執行任何 root
+操作、不建帳號、不寫 polkit、不安裝任何 unit**。
 """
 from __future__ import annotations
 
 import grp
 import hashlib
+import json
 import os
 import pwd
 import re
 import shutil
+import subprocess
+import tempfile
 import time
 from dataclasses import dataclass
 from pathlib import Path
@@ -76,27 +113,46 @@ __all__ = [
     "BUILDER_SYNTHESIZED_ENV",
     "CREDENTIAL_ENV_RE",
     "DEFAULT_BUILDER_ACCOUNT",
+    "DEFAULT_JOB_SHIM",
+    "DEFAULT_JOB_SPEC_SPOOL",
     "DEFAULT_START_TIMEOUT_MS",
+    "DEFAULT_TEMPLATE_UNIT",
     "ForwardedEnvVar",
     "JOB_RUNNER_ENV",
+    "JOB_SHIM_ENV",
+    "JOB_SPEC_SPOOL_ENV",
+    "JOB_SPEC_VERSION",
     "JobRunnerError",
     "RUNNER_DIRECT",
     "RUNNER_MODES",
     "RUNNER_SYSTEMD_RUN",
+    "RUNNER_SYSTEMD_TEMPLATE",
+    "SPEC_FORBIDDEN_KEYS",
+    "SPEC_REQUIRED_KEYS",
     "START_TIMEOUT_ENV",
     "SystemdRunPlan",
+    "SystemdTemplatePlan",
+    "TEMPLATE_UNIT_ENV",
+    "TEMPLATE_UNIT_PREFIX",
     "TRANSIENT_UNIT_PROPERTIES",
     "UNIT_NAME_PREFIX",
     "build_builder_env",
+    "build_job_spec",
+    "build_systemctl_start_argv",
     "build_systemd_run_argv",
+    "confirm_template_instance_started",
     "confirm_transient_unit_started",
+    "instance_name_valid",
+    "job_spec_path",
     "preflight_systemd_run",
+    "preflight_systemd_template",
     "prepare_systemd_run",
-    "resolve_builder_account",
-    "resolve_builder_group",
-    "resolve_runner_mode",
-    "resolve_start_timeout_ms",
+    "prepare_systemd_template",
+    "reject_unsafe_env",
+    "template_instance_id",
+    "template_unit_name",
     "transient_unit_name",
+    "write_job_spec",
 ]
 
 
@@ -132,7 +188,9 @@ DEFAULT_START_TIMEOUT_MS = 200
 
 RUNNER_DIRECT = "direct"
 RUNNER_SYSTEMD_RUN = "systemd-run"
-RUNNER_MODES = (RUNNER_DIRECT, RUNNER_SYSTEMD_RUN)
+#: 0816 第三輪裁決 B：root-owned 模板 unit。見本檔「模板實例模式」段。
+RUNNER_SYSTEMD_TEMPLATE = "systemd-template"
+RUNNER_MODES = (RUNNER_DIRECT, RUNNER_SYSTEMD_RUN, RUNNER_SYSTEMD_TEMPLATE)
 
 #: transient unit 名前綴。polkit 規則以 `action.lookup("unit")` 收窄授權面時，比對的
 #: 就是這個前綴（見 Phase 2b runbook 第 5 步）——因此它是**契約**，不可隨手改。
@@ -146,6 +204,61 @@ UNIT_NAME_PREFIX = "cortex-job-"
 #:   `trust_root.permgen` 機械產生並寫進 unit／runbook（operator 未決 5 的裁決），
 #:   在啟動器裡手寫會變成第二份真相。
 TRANSIENT_UNIT_PROPERTIES = ("NoNewPrivileges=yes",)
+
+
+# ---------------------------------------------------------------------------
+# 模板實例模式（0816 第三輪裁決 B）的 config
+#
+# 下面四個預設值與 `trust_root.permgen.DEFAULT_LAYOUT` 是**成對契約**（同一份路徑
+# 裁決的兩個落點）。刻意不在此 import permgen——`job_runner` 至今只依賴 stdlib ＋
+# `diagnostics`，讓派工熱路徑不必拖進整個 trust_root 子套件；改以
+# `tests/test_trust_root_job_template_ab.py` 的契約測試釘住兩邊逐字相等，任一邊
+# 漂移都會當場紅。
+# ---------------------------------------------------------------------------
+
+#: 模板 unit 名。polkit 規則（`permgen.build_polkit_rule(plan=TEMPLATE)`）比對的
+#: 就是它的實例形狀 `cortex-job@<id>.service`，因此是契約，不可隨手改。
+TEMPLATE_UNIT_ENV = "PSC_JOB_TEMPLATE_UNIT"
+TEMPLATE_UNIT_PREFIX = "cortex-job@"
+TEMPLATE_UNIT_SUFFIX = ".service"
+DEFAULT_TEMPLATE_UNIT = f"{TEMPLATE_UNIT_PREFIX}{TEMPLATE_UNIT_SUFFIX}"
+
+#: Manager-owned 的 per-job spec spool（登記表資產 `job-spec-spool`）。
+JOB_SPEC_SPOOL_ENV = "PSC_JOB_SPEC_SPOOL"
+DEFAULT_JOB_SPEC_SPOOL = "/var/lib/cortex/coordinator/job-specs"
+
+#: root-owned shim（模板 unit 的固定 `ExecStart=`）。preflight 只檢查它存在且可執行。
+JOB_SHIM_ENV = "PSC_JOB_SHIM"
+DEFAULT_JOB_SHIM = "/opt/cortex/bin/cortex-job-shim"
+
+#: 模板 unit 檔的安裝位置（preflight 檢查「template 未安裝」用）。
+DEFAULT_TEMPLATE_UNIT_DIR = "/etc/systemd/system"
+
+#: spec schema 版本。shim 讀到不符的版本一律拒絕執行——「舊 Manager ＋ 新 shim」
+#: 或反之都不該靠猜。
+JOB_SPEC_VERSION = 1
+
+#: spec 的必要欄位（shim 端逐項檢查；缺一即 fail-closed）。
+SPEC_REQUIRED_KEYS: tuple[str, ...] = (
+    "spec_version",
+    "instance",
+    "job_id",
+    "unit",
+    "command",
+    "working_directory",
+    "log_path",
+    "env",
+)
+
+#: spec **絕不可**出現的欄位——身分只有一個來源：root-owned unit 檔的 `User=`。
+#: 這是 B 案全部價值的所在，因此在寫端與讀端各擋一次。
+SPEC_FORBIDDEN_KEYS: frozenset[str] = frozenset(
+    {"user", "group", "uid", "gid", "User", "Group", "properties", "exec_start"}
+)
+
+#: systemd unit 實例名允許的字元。systemd 本身還允許更多（`/` 需 escape），這裡
+#: 刻意更窄：instance 名會被 polkit 的 unit pattern 比對，也會被拼成 spec 檔名。
+INSTANCE_NAME_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9_.-]{0,62}")
 
 
 # ---------------------------------------------------------------------------
@@ -413,6 +526,16 @@ EXCLUDED_ENV_RATIONALE: Mapping[str, str] = {
 }
 
 
+def reject_unsafe_env(env: Mapping[str, str], *, source: str) -> None:
+    """公開別名——讓 shim 端（`job_shim`）用**同一條**守衛驗它讀到的 spec env。
+
+    寫端與讀端共用一份判準，是為了讓「白名單被改壞」在兩邊都會炸；只在寫端自律，
+    等於相信一個 Manager 帳號可寫的檔案沒被動過手腳。
+    """
+
+    _reject_unsafe(env, source=source)
+
+
 def _reject_unsafe(env: Mapping[str, str], *, source: str) -> None:
     """最後一道守衛：白名單即使被改壞，憑證形狀與注入孔仍然出不去。
 
@@ -551,7 +674,10 @@ def preflight_systemd_run(
     *,
     account: str,
     group: str,
-    which: Callable[[str], str | None] = shutil.which,
+    # 預設值刻意是 None 而不是 `shutil.which`：後者會在 **def 時**就把函式物件綁進
+    # 預設值，`mock.patch.object(job_runner.shutil, "which", …)` 因此打不到它——
+    # 測試會靜默地驗到「真實主機上有沒有 systemd-run」而不是它想驗的分支。
+    which: Callable[[str], str | None] | None = None,
     account_exists: Callable[[str], bool] | None = None,
     group_exists: Callable[[str], bool] | None = None,
     systemd_booted: Callable[[], bool] | None = None,
@@ -565,7 +691,7 @@ def preflight_systemd_run(
     :func:`confirm_transient_unit_started` 在起動階段補上。
     """
 
-    resolved = which("systemd-run")
+    resolved = (which or shutil.which)("systemd-run")
     if not resolved:
         raise _fail(
             "job-runner-systemd-run-missing",
@@ -655,29 +781,489 @@ def confirm_transient_unit_started(
     時間收斂，代價是每次 builder 派工多 200ms，相對於一次 headless job 可忽略。
     """
 
+    status = _await_start(
+        process=process,
+        sentinel=sentinel,
+        timeout_ms=timeout_ms,
+        monotonic=monotonic,
+        sleep=sleep,
+    )
+    if status is None:
+        return
+    raise _fail(
+        "job-runner-transient-unit-start-failed",
+        (
+            f"transient unit {unit} 未能以 {account} 起動"
+            f"（systemd-run exit={status}；常見原因：polkit 拒絕、"
+            f"unit 名衝突、帳號無法切換）{_log_tail(log_path)}"
+        ),
+        source="confirm_transient_unit_started",
+        unit=unit,
+        account=account,
+        exit_status=status,
+    )
+
+
+def _await_start(
+    *,
+    process,
+    sentinel: str,
+    timeout_ms: int,
+    monotonic: Callable[[], float],
+    sleep: Callable[[float], None],
+) -> int | None:
+    """起動確認的共用核心：回傳「起動失敗時的 client exit status」，成功回 None。
+
+    判準對 `systemd-run --wait` 與 `systemctl start --wait` 完全一樣（兩者都是
+    「client 存活到 unit 結束」的語意）：**client 已結束且 exit sentinel 不存在**
+    才算起動失敗。真的跑完的極短命 job 必然留下 sentinel，因此不會誤判。
+    """
+
     deadline = monotonic() + max(timeout_ms, 0) / 1000.0
     while True:
         status = process.poll()
         if status is not None:
             if Path(sentinel).exists():
                 # job 真的跑完了（且已寫下 exit sentinel）——不是起動失敗。
-                return
-            raise _fail(
-                "job-runner-transient-unit-start-failed",
-                (
-                    f"transient unit {unit} 未能以 {account} 起動"
-                    f"（systemd-run exit={status}；常見原因：polkit 拒絕、"
-                    f"unit 名衝突、帳號無法切換）{_log_tail(log_path)}"
-                ),
-                source="confirm_transient_unit_started",
-                unit=unit,
-                account=account,
-                exit_status=status,
-            )
+                return None
+            return status
         remaining = deadline - monotonic()
         if remaining <= 0:
-            return
+            return None
         sleep(min(0.01, remaining))
+
+
+# ---------------------------------------------------------------------------
+# 模板實例模式（B 案）
+# ---------------------------------------------------------------------------
+
+def instance_name_valid(name: str) -> bool:
+    """instance 名是否符合 :data:`INSTANCE_NAME_RE`（shim 端共用同一條判準）。"""
+
+    return bool(name) and INSTANCE_NAME_RE.fullmatch(name) is not None
+
+
+def template_instance_id(job_id: str) -> str:
+    """job_id → systemd 模板實例名（`cortex-job@<這個>.service`）。
+
+    與 :func:`transient_unit_name` 同一套「可追蹤 ＋ 唯一」的推導，差別只在這裡
+    產出的是**實例名**而不是完整 unit 名：消毒後的可讀片段 ＋ job_id 的 sha256
+    前 8 碼（消毒後相同也不會撞名）。
+    """
+
+    raw = str(job_id).strip()
+    if not raw:
+        raise _fail(
+            "job-runner-instance-name-invalid",
+            "job_id 為空，無法組出可追蹤的模板實例名",
+            source="template_instance_id",
+        )
+    slug = re.sub(r"[^A-Za-z0-9_.-]", "-", raw).strip("-")[:48]
+    digest = hashlib.sha256(raw.encode("utf-8")).hexdigest()[:8]
+    if not slug or not slug[0].isalnum():
+        slug = f"job{slug}" if slug else "job"
+    instance = f"{slug}-{digest}"
+    if not instance_name_valid(instance):
+        raise _fail(
+            "job-runner-instance-name-invalid",
+            f"推導出的模板實例名不合法: {instance!r}（job_id={raw!r}）",
+            source="template_instance_id",
+            job_id=raw,
+        )
+    return instance
+
+
+def template_unit_name(instance: str, *, template: str = DEFAULT_TEMPLATE_UNIT) -> str:
+    """`cortex-job@.service` ＋ instance → `cortex-job@<instance>.service`。
+
+    模板名從 config 來（`PSC_JOB_TEMPLATE_UNIT`），因此必須現場驗形狀：值只要不是
+    `<前綴>@.service` 就 fail-closed——一個打錯的模板名會讓 polkit 全數拒絕，那時
+    的錯誤訊息（「Access denied」）完全指不出真正的原因。
+    """
+
+    if not template.endswith(f"@{TEMPLATE_UNIT_SUFFIX}"):
+        raise _fail(
+            "job-runner-template-unit-invalid",
+            f"{TEMPLATE_UNIT_ENV} 必須是 `<name>@{TEMPLATE_UNIT_SUFFIX}` 形狀，收到 {template!r}",
+            source="template_unit_name",
+            requested=template,
+        )
+    if not instance_name_valid(instance):
+        raise _fail(
+            "job-runner-instance-name-invalid",
+            f"模板實例名不合法（只允許 [A-Za-z0-9_.-]，首字元須為英數）: {instance!r}",
+            source="template_unit_name",
+            requested=instance,
+        )
+    stem = template[: -len(TEMPLATE_UNIT_SUFFIX)]  # `cortex-job@`
+    return f"{stem}{instance}{TEMPLATE_UNIT_SUFFIX}"
+
+
+def resolve_template_unit(env: Mapping[str, str]) -> str:
+    return (env.get(TEMPLATE_UNIT_ENV) or "").strip() or DEFAULT_TEMPLATE_UNIT
+
+
+def resolve_job_spec_spool(env: Mapping[str, str]) -> str:
+    return (env.get(JOB_SPEC_SPOOL_ENV) or "").strip() or DEFAULT_JOB_SPEC_SPOOL
+
+
+def resolve_job_shim(env: Mapping[str, str]) -> str:
+    return (env.get(JOB_SHIM_ENV) or "").strip() or DEFAULT_JOB_SHIM
+
+
+def job_spec_path(spool_dir: str, instance: str) -> str:
+    """`<spool>/<instance>.json`——與 `job_shim.resolve_spec_path()` 同一條推導。"""
+
+    return f"{spool_dir.rstrip('/')}/{instance}.json"
+
+
+def build_job_spec(
+    *,
+    job_id: str,
+    instance: str,
+    unit: str,
+    command: Sequence[str],
+    working_directory: str,
+    log_path: str,
+    env: Mapping[str, str],
+) -> dict[str, object]:
+    """組出 per-job spec（**不含任何身分欄位**）。純資料，無 IO。
+
+    「User 不在 spec 裡」是本模式全部的價值：身分只有一個來源＝root-owned unit
+    檔的 `User=`。因此這裡除了不放，還在寫端主動掃一次 forbidden key（未來有人
+    往 spec 加欄位時測試會紅），讀端（shim）再掃一次。
+    """
+
+    argv = [str(item) for item in command]
+    if not argv or not all(argv):
+        raise _fail(
+            "job-runner-job-spec-invalid",
+            "spec 的 command 不得為空、且每個元素都必須是非空字串",
+            source="build_job_spec",
+            instance=instance,
+        )
+    for label, value in (("working_directory", working_directory), ("log_path", log_path)):
+        if not str(value).startswith("/"):
+            raise _fail(
+                "job-runner-job-spec-invalid",
+                f"spec 的 {label} 必須是絕對路徑，收到 {value!r}",
+                source="build_job_spec",
+                instance=instance,
+            )
+    # env 走與 systemd-run 模式**同一條**守衛：模式換了，token 不得出去這件事不換。
+    _reject_unsafe(env, source="build_job_spec")
+    spec: dict[str, object] = {
+        "spec_version": JOB_SPEC_VERSION,
+        "instance": instance,
+        "job_id": str(job_id),
+        "unit": unit,
+        "command": argv,
+        "working_directory": str(working_directory),
+        "log_path": str(log_path),
+        "env": {str(k): str(v) for k, v in sorted(env.items())},
+    }
+    leaked = sorted(SPEC_FORBIDDEN_KEYS & set(spec))
+    if leaked:
+        raise _fail(
+            "job-runner-job-spec-invalid",
+            f"spec 不得攜帶身分／特權欄位 {leaked}——身分只由 root-owned unit 的 User= 決定",
+            source="build_job_spec",
+            instance=instance,
+        )
+    return spec
+
+
+def write_job_spec(spec_path: str, spec: Mapping[str, object]) -> str:
+    """把 spec **原子**寫進 Manager-owned spool；失敗即 fail-closed。
+
+    原子性（同目錄 temp ＋ `os.replace`）不是潔癖：spec 是 job 的命令列，一個被
+    讀到一半的檔會變成「執行了半條命令」。`os.replace` 在同一個檔案系統上是
+    rename(2)，讀端只會看到舊的或新的完整內容。
+
+    mode 明確設 `0o640` 而不是靠 umask：Manager unit 的 `UMask=0077` 會讓新檔出生
+    即 `0600`，而 group 位全關會**連帶把繼承下來的 ACL mask 也關掉**，job 帳號的
+    唯讀 ACL 因此形同虛設（讀 spec 會 EACCES）。group 仍是 Manager 自己的 group，
+    所以放寬 group-read 不會讓第三方讀到。
+    """
+
+    directory = os.path.dirname(spec_path) or "."
+    payload = json.dumps(spec, ensure_ascii=False, sort_keys=True, indent=2) + "\n"
+    tmp_path: str | None = None
+    try:
+        fd, tmp_path = tempfile.mkstemp(prefix=".job-spec-", suffix=".tmp", dir=directory)
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(payload)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.chmod(tmp_path, 0o640)
+        os.replace(tmp_path, spec_path)
+        tmp_path = None
+    except OSError as exc:
+        if tmp_path is not None:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+        raise _fail(
+            "job-runner-job-spec-write-failed",
+            f"寫不進 job spec {spec_path}: {exc}（spool 是否已由 Phase 2b 建立？）",
+            source="write_job_spec",
+            spec_path=spec_path,
+        ) from exc
+    return spec_path
+
+
+def build_systemctl_start_argv(*, systemctl: str, unit: str) -> list[str]:
+    """組出模板實例的啟動 argv。**封閉：除了 unit 名沒有任何可變輸入。**
+
+    逐項理由：
+
+    - `start`：polkit 規則只放行 `start`／`stop` 兩個 verb。
+    - `--wait`：client 存活到 unit 結束（`systemctl(1)`「For (re)start, wait until
+      service stopped again」，systemd ≥ 232），`dispatcher.pid_alive()` 的 pid 判活
+      因此與 direct／systemd-run 模式同語意，dispatcher 零改動。
+    - `--no-ask-password`：headless daemon 沒有 tty；缺這個旗標時 polkit 若要互動
+      認證，`systemctl` 會**卡住**而不是失敗——fail-closed 的前提是會失敗。
+    - `--no-block` **刻意不用**：那會讓 client 在 job 排入佇列後立刻返回，pid 判活
+      當場失效。
+    - **沒有** `--property=`／`--uid=`：本模式的整個重點就是這些東西給不了。
+    """
+
+    return [systemctl, "start", "--wait", "--no-ask-password", unit]
+
+
+def preflight_systemd_template(
+    *,
+    account: str,
+    group: str,
+    template_unit: str,
+    shim: str,
+    spool_dir: str,
+    which: Callable[[str], str | None] | None = None,
+    account_exists: Callable[[str], bool] | None = None,
+    group_exists: Callable[[str], bool] | None = None,
+    systemd_booted: Callable[[], bool] | None = None,
+    unit_file_installed: Callable[[str], bool] | None = None,
+    executable: Callable[[str], bool] | None = None,
+    directory_exists: Callable[[str], bool] | None = None,
+) -> str:
+    """模板模式的靜態檢查；任一項不成立即 fail-closed，回傳 systemctl 絕對路徑。
+
+    比 A 案多三條，對應「本模式生效需要 Phase 2b 安裝」的三個前置物：模板 unit 檔、
+    root-owned shim、Manager-owned spec spool。**任何一條都不會退回其他模式**——
+    「以為降權生效但其實沒有」正是這整條票要消除的失效模式。
+
+    polkit 拒絕仍然沒有可靠的唯讀探測面，由
+    :func:`confirm_template_instance_started` 在起動階段補上。
+    """
+
+    resolved = (which or shutil.which)("systemctl")
+    if not resolved:
+        raise _fail(
+            "job-runner-systemctl-missing",
+            "PATH 上找不到 systemctl；模板實例模式無法執行",
+            source="preflight_systemd_template",
+        )
+    booted = systemd_booted or _systemd_booted
+    if not booted():
+        raise _fail(
+            "job-runner-systemd-unavailable",
+            "/run/systemd/system 不存在——本機未以 systemd 開機，模板 unit 不可用",
+            source="preflight_systemd_template",
+        )
+    exists_account = account_exists or _account_exists
+    if not exists_account(account):
+        raise _fail(
+            "job-runner-builder-account-missing",
+            f"builder 帳號不存在: {account}（Phase 2b runbook 第 1 步尚未執行？）",
+            source="preflight_systemd_template",
+            account=account,
+        )
+    exists_group = group_exists or _group_exists
+    if not exists_group(group):
+        raise _fail(
+            "job-runner-builder-group-missing",
+            f"builder group 不存在: {group}",
+            source="preflight_systemd_template",
+            group=group,
+        )
+    installed = unit_file_installed or _unit_file_installed
+    if not installed(template_unit):
+        raise _fail(
+            "job-runner-job-template-missing",
+            (
+                f"模板 unit {template_unit} 未安裝於 {DEFAULT_TEMPLATE_UNIT_DIR}"
+                "（Phase 2b：`trust_root unit --job` 的輸出尚未落地？）"
+            ),
+            source="preflight_systemd_template",
+            unit=template_unit,
+        )
+    is_executable = executable or _is_executable
+    if not is_executable(shim):
+        raise _fail(
+            "job-runner-job-shim-missing",
+            (
+                f"降權 shim 不存在或不可執行: {shim}"
+                "（Phase 2b：`trust_root shim` 的輸出尚未落地？）"
+            ),
+            source="preflight_systemd_template",
+            shim=shim,
+        )
+    has_dir = directory_exists or os.path.isdir
+    if not has_dir(spool_dir):
+        raise _fail(
+            "job-runner-job-spec-spool-missing",
+            f"job spec spool 目錄不存在: {spool_dir}（Phase 2b 權限套用尚未執行？）",
+            source="preflight_systemd_template",
+            spool_dir=spool_dir,
+        )
+    return resolved
+
+
+@dataclass(frozen=True)
+class SystemdTemplatePlan:
+    """一次模板派工要用到的、**已驗證過**的身分／unit／路徑資訊。"""
+
+    binary: str
+    template_unit: str
+    instance: str
+    unit: str
+    account: str
+    group: str
+    shim: str
+    spool_dir: str
+    spec_path: str
+
+
+def prepare_systemd_template(
+    env: Mapping[str, str],
+    *,
+    job_id: str,
+    unit_active: Callable[[str, str], bool] | None = None,
+) -> SystemdTemplatePlan:
+    """模板派工的前置：解析 config、靜態 preflight、算 instance／unit／spec 路徑，
+    並確認**同名 instance 沒有正在跑**。
+
+    最後一條特別重要：`systemctl start` 對一個**已經 active** 的 unit 會直接回 0，
+    什麼都不做。少了這個檢查，Manager 會以為自己起了一個 job，實際上是掛在別人的
+    unit 上等——而且 `--wait` 會一路等到那個別人的 job 結束。
+
+    **在任何副作用之前呼叫**：這裡每一個 raise 都代表本次派工不該發生。
+    """
+
+    account = resolve_builder_account(env)
+    group = resolve_builder_group(env)
+    template = resolve_template_unit(env)
+    shim = resolve_job_shim(env)
+    spool_dir = resolve_job_spec_spool(env)
+    binary = preflight_systemd_template(
+        account=account,
+        group=group,
+        template_unit=template,
+        shim=shim,
+        spool_dir=spool_dir,
+    )
+    instance = template_instance_id(job_id)
+    unit = template_unit_name(instance, template=template)
+    is_active = unit_active or _unit_is_active
+    if is_active(binary, unit):
+        raise _fail(
+            "job-runner-template-instance-busy",
+            (
+                f"模板實例 {unit} 已在執行中——`systemctl start` 會靜默成功卻不起新 job。"
+                "同一個 job_id 是否已有未回收的派工？"
+            ),
+            source="prepare_systemd_template",
+            unit=unit,
+            account=account,
+        )
+    return SystemdTemplatePlan(
+        binary=binary,
+        template_unit=template,
+        instance=instance,
+        unit=unit,
+        account=account,
+        group=group,
+        shim=shim,
+        spool_dir=spool_dir,
+        spec_path=job_spec_path(spool_dir, instance),
+    )
+
+
+def confirm_template_instance_started(
+    *,
+    process,
+    sentinel: str,
+    unit: str,
+    account: str,
+    log_path: str | None = None,
+    timeout_ms: int = DEFAULT_START_TIMEOUT_MS,
+    monotonic: Callable[[], float] = time.monotonic,
+    sleep: Callable[[float], None] = time.sleep,
+) -> None:
+    """確認模板實例真的起來了；起不來就 fail-closed（**絕不**退回其他模式）。
+
+    判準與 A 案共用 :func:`_await_start`：`systemctl start --wait` 與
+    `systemd-run --wait` 都是「client 存活到 unit 結束」，因此「client 已結束且
+    exit sentinel 不存在」在兩邊都恰好代表「job 從未真正執行」。
+    """
+
+    status = _await_start(
+        process=process,
+        sentinel=sentinel,
+        timeout_ms=timeout_ms,
+        monotonic=monotonic,
+        sleep=sleep,
+    )
+    if status is None:
+        return
+    raise _fail(
+        "job-runner-template-instance-start-failed",
+        (
+            f"模板實例 {unit} 未能起動（systemctl exit={status}；常見原因：polkit 拒絕、"
+            f"模板 unit 未安裝、shim 讀 spec 失敗——後者的逐字原因在 journal："
+            f"`journalctl -u {unit}`）{_log_tail(log_path)}"
+        ),
+        source="confirm_template_instance_started",
+        unit=unit,
+        account=account,
+        exit_status=status,
+    )
+
+
+def _unit_file_installed(unit_name: str) -> bool:
+    """模板 unit 檔是否已落地。刻意用檔案存在判定而不是 `systemctl cat`：
+
+    後者要開一次 D-Bus、也可能因為 polkit 而失敗，把「未安裝」與「無授權」混成
+    同一個錯誤；前者是一次 stat，且答案就是 operator 在 runbook 第 5 步做的事。
+    """
+
+    return os.path.isfile(os.path.join(DEFAULT_TEMPLATE_UNIT_DIR, unit_name))
+
+
+def _is_executable(path: str) -> bool:
+    return os.path.isfile(path) and os.access(path, os.X_OK)
+
+
+def _unit_is_active(systemctl: str, unit: str) -> bool:
+    """`systemctl is-active --quiet <unit>` 的唯讀查詢（seam，測試一律 mock）。
+
+    查詢面不需要 polkit 授權（`is-active` 是唯讀 D-Bus 呼叫）。查不動時回 False
+    ——「查不到狀態」不該擋掉一次合法派工，真正起不來的情況由
+    :func:`confirm_template_instance_started` fail-closed。
+    """
+
+    try:
+        completed = subprocess.run(
+            [systemctl, "is-active", "--quiet", unit],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=10,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+    return completed.returncode == 0
 
 
 def _log_tail(log_path: str | None, *, limit: int = 200) -> str:

--- a/paulsha_cortex/coordinator/job_shim.py
+++ b/paulsha_cortex/coordinator/job_shim.py
@@ -1,0 +1,243 @@
+"""降權 job shim——root-owned 模板 unit（`cortex-job@.service`）的固定 `ExecStart=`。
+
+operator 0816 第三輪裁決 **A+B** 的 B 半：builder job 不再由 Manager 用
+`systemd-run` 起 transient unit（polkit 對 transient unit 看不到 `User=`，#603
+實測），改成 `systemctl start cortex-job@<instance>.service`——unit 檔 root 擁有、
+`User=` 與 `ExecStart=` 都硬寫死，Manager 帳號**選不了 UID、也給不了命令列**。
+
+命令列既然給不了，per-job 的參數就得走一條**帶外通道**：Manager 把一份 spec
+原子寫進 Manager-owned spool（登記表資產 `job-spec-spool`，job 帳號唯讀），
+systemd 起 unit、unit exec 本模組、本模組讀 spec 後 exec 真正的 job。
+
+## 這支程式在信任鏈上的位置
+
+執行本模組時**降權已經完成**（systemd 依 unit 的 `User=` 切好身分）。因此它
+**不是**特權邊界，它是「已經是 builder 的行程，去把自己變成那個 job」的一段
+接線。它能做的事 builder 本來就能做；它的價值在於**收斂**：
+
+- spec 檔只從固定的 spool 根、以 `<instance>.json` 推導，**不接受任何路徑參數**；
+- 開 spec 與開 log 一律 `O_NOFOLLOW`——即使有人在 spool／log 目錄埋 symlink，
+  也只會失敗，不會沿著連結走到別處；
+- schema 驗證是**白名單**：spec 裡出現 `user`／`uid`／`group`／`gid` 這類身分欄位
+  一律拒絕。身分只有一個來源＝root-owned 的 unit 檔，spec 連提都不准提；
+- env 走與 `job_runner` **同一條** `CREDENTIAL_ENV_RE`／`DENIED_ENV_NAMES` 守衛，
+  spec 被塞進 token 或 `LD_PRELOAD` 時 fail-closed，而不是照單 exec。
+
+## 為什麼 log 由這裡接管，而不是 unit 的 `StandardOutput=append:`
+
+`file:`／`append:` 的目標檔由 **PID 1（root）在降權之前**開啟。log 路徑必然含有
+Manager 帳號可寫的段落（`<log_dir>/<slice>.jsonl`），把它交給 root 開啟等於允許
+Manager 用一個 symlink 讓 root 對任意檔案 append——那會把「cortex 任何元件永不
+具 root」這條裁決賣掉。改由本模組在**已降權之後**用 `O_NOFOLLOW` 開同一個檔，
+最壞情況只是一個 builder 權限的寫入，而 harvest 讀的 log 路徑**完全不變**。
+
+錯誤處理分兩段（這是刻意的可觀測性設計）：
+
+1. **接管 log 之前**的失敗（instance 名非法、spec 缺席／是 symlink／schema 不合）
+   寫 stderr → 進 journal。此時 Manager 那邊的 log 檔會是空的，但 `systemctl start
+   --wait` 會以非零收場，Manager 的 `confirm_template_instance_started()` 因此
+   fail-closed，operator 從 journal 拿得到逐字原因。
+2. **接管之後**的失敗與 job 自身的輸出全部進那份 JSONL log，與 direct／
+   systemd-run 模式逐字同路徑。
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from typing import Mapping, Sequence
+
+from .job_runner import (
+    JOB_SPEC_SPOOL_ENV,
+    JOB_SPEC_VERSION,
+    SPEC_FORBIDDEN_KEYS,
+    SPEC_REQUIRED_KEYS,
+    instance_name_valid,
+    reject_unsafe_env,
+)
+
+__all__ = [
+    "EXIT_SPEC_ERROR",
+    "ShimError",
+    "load_spec",
+    "main",
+    "resolve_spec_path",
+]
+
+#: `EX_CONFIG`（sysexits.h）。刻意不用 1：1 是「job 自己失敗」的正常出口，
+#: 78 讓 operator 一眼分辨「job 跑了但失敗」與「job 根本沒起來」。
+EXIT_SPEC_ERROR = 78
+
+#: spec 檔大小上限。spec 帶的是 wrapper script（含 prompt），可以不小，但也不該
+#: 無界——讀進一個被灌爆的檔只會讓 job 帳號自己 OOM。
+SPEC_MAX_BYTES = 4 * 1024 * 1024
+
+
+class ShimError(RuntimeError):
+    """shim 在 exec 之前判定本次啟動不該發生。一律 fail-closed，絕不猜。"""
+
+
+def resolve_spec_path(instance: str, spool_root: str) -> str:
+    """`<spool_root>/<instance>.json`。**instance 是唯一輸入，且先被驗過形狀。**
+
+    不接受呼叫端給整條路徑：模板 unit 只傳 `%i`，路徑必須由固定的 spool 根推導，
+    否則「spec 一定落在 Manager-owned 樹裡」這條性質就不成立了。
+    """
+
+    if not instance_name_valid(instance):
+        raise ShimError(f"instance 名不合法（只允許 [A-Za-z0-9_.-]）: {instance!r}")
+    if not spool_root.startswith("/"):
+        raise ShimError(f"spec spool 根必須是絕對路徑: {spool_root!r}")
+    return f"{spool_root.rstrip('/')}/{instance}.json"
+
+
+def _read_regular_file(path: str) -> bytes:
+    """以 `O_NOFOLLOW` 讀檔，並要求它是**普通檔**。
+
+    `O_NOFOLLOW` 只擋最後一段是 symlink 的情況；中間目錄仍可能被替換，但那些
+    目錄全在 Manager-owned 樹裡（permgen 產出 owner-only ＋ 唯讀 ACL），能改的
+    身分本來就能改 spec 內容，沒有額外的提權面。
+    """
+
+    try:
+        fd = os.open(path, os.O_RDONLY | os.O_NOFOLLOW | getattr(os, "O_CLOEXEC", 0))
+    except OSError as exc:
+        raise ShimError(f"讀不到 job spec {path}: {exc}") from exc
+    try:
+        stat_result = os.fstat(fd)
+        if not os_path_isreg(stat_result.st_mode):
+            raise ShimError(f"job spec 不是普通檔（symlink／fifo／目錄？）: {path}")
+        if stat_result.st_size > SPEC_MAX_BYTES:
+            raise ShimError(
+                f"job spec 超過上限 {SPEC_MAX_BYTES} bytes: {path}（{stat_result.st_size}）"
+            )
+        return os.read(fd, SPEC_MAX_BYTES)
+    finally:
+        os.close(fd)
+
+
+def os_path_isreg(mode: int) -> bool:
+    """`stat.S_ISREG` 的等價判定（避免為了一個位元再拉一個 import）。"""
+
+    return (mode & 0o170000) == 0o100000
+
+
+def load_spec(instance: str, spool_root: str) -> dict[str, object]:
+    """讀出並**完整驗證**該 instance 的 spec。任何一項不合即 `ShimError`。"""
+
+    path = resolve_spec_path(instance, spool_root)
+    raw = _read_regular_file(path)
+    try:
+        spec = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, ValueError) as exc:
+        raise ShimError(f"job spec 不是合法 UTF-8 JSON: {path}: {exc}") from exc
+    if not isinstance(spec, dict):
+        raise ShimError(f"job spec 必須是 JSON object: {path}")
+
+    version = spec.get("spec_version")
+    if version != JOB_SPEC_VERSION:
+        raise ShimError(
+            f"job spec 版本不符（期望 {JOB_SPEC_VERSION}，收到 {version!r}）: {path}"
+        )
+    missing = [key for key in SPEC_REQUIRED_KEYS if key not in spec]
+    if missing:
+        raise ShimError(f"job spec 缺少必要欄位 {missing}: {path}")
+    # 身分欄位是**結構性禁止**，不是「忽略」：spec 一旦被容忍帶 user/uid，日後
+    # 有人「順手支援一下」就會把 B 案的整個保證還回去。
+    present_forbidden = sorted(k for k in SPEC_FORBIDDEN_KEYS if k in spec)
+    if present_forbidden:
+        raise ShimError(
+            f"job spec 不得攜帶身分欄位 {present_forbidden}（身分只由 root-owned "
+            f"unit 的 User= 決定）: {path}"
+        )
+    if spec.get("instance") != instance:
+        raise ShimError(
+            f"job spec 的 instance 與 unit 實例名不符（{spec.get('instance')!r} != "
+            f"{instance!r}）: {path}"
+        )
+
+    command = spec.get("command")
+    if (
+        not isinstance(command, list)
+        or not command
+        or not all(isinstance(item, str) and item for item in command)
+    ):
+        raise ShimError(f"job spec 的 command 必須是非空的字串陣列: {path}")
+    for key in ("working_directory", "log_path"):
+        value = spec.get(key)
+        if not isinstance(value, str) or not value.startswith("/"):
+            raise ShimError(f"job spec 的 {key} 必須是絕對路徑: {path}（{value!r}）")
+    env = spec.get("env")
+    if not isinstance(env, dict) or not all(
+        isinstance(k, str) and isinstance(v, str) for k, v in env.items()
+    ):
+        raise ShimError(f"job spec 的 env 必須是 str→str 的 object: {path}")
+    # 與 Manager 端寫入時**同一條**守衛：兩邊共用 job_runner 的 pattern／名單，
+    # 因此「白名單被改壞」在讀端也一樣會炸，不會只靠寫端自律。
+    try:
+        reject_unsafe_env(env, source="job_shim.load_spec")
+    except ValueError as exc:
+        raise ShimError(f"job spec 的 env 命中憑證／注入形狀守衛: {path}: {exc}") from exc
+    return spec
+
+
+def _take_over_stdio(log_path: str) -> None:
+    """把 stdout／stderr 接到 spec 指定的 JSONL log（append、`O_NOFOLLOW`）。
+
+    append 而非 truncate：Manager 在 spawn 前已經把該檔清空並可能寫入
+    `systemctl` client 自己的輸出，這裡再截一次會把那段診斷抹掉。
+    """
+
+    flags = os.O_WRONLY | os.O_CREAT | os.O_APPEND | os.O_NOFOLLOW
+    try:
+        fd = os.open(log_path, flags, 0o600)
+    except OSError as exc:
+        raise ShimError(f"開不了 job log {log_path}: {exc}") from exc
+    try:
+        os.dup2(fd, 1)
+        os.dup2(fd, 2)
+    finally:
+        if fd > 2:
+            os.close(fd)
+
+
+def main(argv: Sequence[str] | None = None, environ: Mapping[str, str] | None = None) -> int:
+    """模板 unit 的進入點：讀 spec → 接管 log → chdir → exec。**成功時不返回。**"""
+
+    args = list(sys.argv[1:] if argv is None else argv)
+    env = os.environ if environ is None else environ
+    try:
+        if len(args) != 1:
+            raise ShimError(
+                f"用法：cortex-job-shim <instance>（unit 應傳 %i）；收到 {args!r}"
+            )
+        spool_root = (env.get(JOB_SPEC_SPOOL_ENV) or "").strip()
+        if not spool_root:
+            raise ShimError(
+                f"{JOB_SPEC_SPOOL_ENV} 未設定——模板 unit 應以 Environment= 宣告 spec "
+                f"spool 根（root-owned unit 檔是這個值唯一的合法來源）"
+            )
+        spec = load_spec(args[0], spool_root)
+        _take_over_stdio(str(spec["log_path"]))
+        os.chdir(str(spec["working_directory"]))
+    except ShimError as exc:
+        print(f"cortex-job-shim: {exc}", file=sys.stderr, flush=True)
+        return EXIT_SPEC_ERROR
+    except OSError as exc:
+        print(f"cortex-job-shim: {exc}", file=sys.stderr, flush=True)
+        return EXIT_SPEC_ERROR
+
+    command = [str(item) for item in spec["command"]]  # type: ignore[index]
+    job_env = {str(k): str(v) for k, v in dict(spec["env"]).items()}  # type: ignore[index]
+    try:
+        # execvpe：同一個 pid 直接變成 job，unit 的 MAINPID 因此就是 job 本身
+        # （`systemctl start --wait` 的等待語意與 exit sentinel 都建立在這點上）。
+        os.execvpe(command[0], command, job_env)
+    except OSError as exc:  # pragma: no cover - exec 成功時不返回
+        print(f"cortex-job-shim: exec {command[0]} 失敗: {exc}", file=sys.stderr, flush=True)
+        return EXIT_SPEC_ERROR
+    return EXIT_SPEC_ERROR  # pragma: no cover - 不可達
+
+
+if __name__ == "__main__":  # pragma: no cover - 由模板 unit 執行
+    raise SystemExit(main())

--- a/paulsha_cortex/coordinator/launcher.py
+++ b/paulsha_cortex/coordinator/launcher.py
@@ -1064,25 +1064,40 @@ class SubprocessLauncher:
             return False
         return env.get("PSC_REPO_ROOT") is not None
 
-    def _degraded_runner(self, env: Mapping[str, str]) -> bool:
-        """本次 launch 是否要走 Phase 2a 的降權啟動器（`systemd-run` transient unit）。
+    def _downgraded_mode(self, env: Mapping[str, str]) -> str | None:
+        """本次 launch 要走哪一種降權啟動器（皆非時回 None＝direct，行為不變）。
 
         兩個條件同時成立才降權：
 
-        1. `PSC_JOB_RUNNER=systemd-run`（部署期設定；預設 `direct`＝現行行為不變）。
+        1. `PSC_JOB_RUNNER` ∈ {`systemd-run`, `systemd-template`}（部署期設定；
+           預設 `direct`＝現行行為不變）。
         2. **這是 builder persona**——判定點與本檔既有的 persona 分支完全對齊
            （`_should_run_gates`／`launch()` 的 env 分支用的是同一組條件）：
            `review_only`＝reviewer、`read_only`＝planner，兩者皆非才是 builder。
 
-        operator 0816 裁決的二分 UID 方案裡，reviewer 與 planner 和 Manager 同帳號
-        （`cortex-svc`），因此**不經降權**；只有 builder 落到 `cortex-builder`。
+        `systemd-run`（A 案）與 `systemd-template`（B 案，0816 第三輪裁決）在
+        launcher 這一層共用**完全相同**的 env 白名單與 `bash -c` 決定，差別只在
+        「怎麼把這條命令交給 systemd」——A 案經 `systemd-run` 的 argv，B 案經
+        Manager-owned spec 檔 ＋ root-owned 模板 unit。
+
         `PSC_JOB_RUNNER` 的值即使非法，也在這裡 fail-closed（見
         `job_runner.resolve_runner_mode`），不會被靜默當成 direct。
         """
 
-        if job_runner.resolve_runner_mode(env) != job_runner.RUNNER_SYSTEMD_RUN:
-            return False
-        return not self._review_only and not self._read_only
+        mode = job_runner.resolve_runner_mode(env)
+        if mode not in (job_runner.RUNNER_SYSTEMD_RUN, job_runner.RUNNER_SYSTEMD_TEMPLATE):
+            return None
+        if self._review_only or self._read_only:
+            # 三分 UID 方案下 reviewer／planner 有自己的帳號（`cortex-reviewer-planner`），
+            # 但它們的降權是**部署面**的事（Manager 自己的 unit 不會 spawn 它們到
+            # builder 帳號）；本啟動器只負責 builder job，維持 #603 的既有判定。
+            return None
+        return mode
+
+    def _degraded_runner(self, env: Mapping[str, str]) -> bool:
+        """是否走任一種降權啟動器（`executor_environment` 的 env 分支用）。"""
+
+        return self._downgraded_mode(env) is not None
 
     def executor_environment(self, *, slice_id: str = "preflight"):
         """#262 D2：回報正式 job 會實際看到的 executor 環境。
@@ -1141,9 +1156,15 @@ class SubprocessLauncher:
         # 非法或 builder 帳號不存在時，本次派工必須在還沒改動任何狀態前就 fail-closed，
         # 而不是先做一半再退回 direct。
         runner_plan: job_runner.SystemdRunPlan | None = None
-        if self._degraded_runner(os.environ):
+        template_plan: job_runner.SystemdTemplatePlan | None = None
+        runner_mode = self._downgraded_mode(os.environ)
+        if runner_mode == job_runner.RUNNER_SYSTEMD_RUN:
             runner_plan = job_runner.prepare_systemd_run(os.environ, job_id=slice_id)
-        degraded = runner_plan is not None
+        elif runner_mode == job_runner.RUNNER_SYSTEMD_TEMPLATE:
+            # B 案（0816 第三輪裁決）：模板 unit／shim／spec spool 三個前置物任一
+            # 缺席都在這裡 fail-closed，且**在寫任何 spec 之前**。
+            template_plan = job_runner.prepare_systemd_template(os.environ, job_id=slice_id)
+        degraded = runner_mode is not None
         resolved_worktree = Path(worktree).resolve(strict=True)
         if not resolved_worktree.is_dir():
             raise ValueError("launcher worktree must be a directory")
@@ -1277,9 +1298,54 @@ class SubprocessLauncher:
             # stdin 顯式接 /dev/null（direct 模式今天仍把 daemon 的 stdin 交給 job，
             # 降權模式在這點上比 direct 更緊）。
             popen_kwargs["stdin"] = subprocess.DEVNULL
-        with open(log_path, "wb") as logf:
+        log_mode = "wb"
+        if template_plan is not None:
+            # B 案：per-job 參數走 Manager-owned spec 檔（job 帳號唯讀），不走 argv
+            # ——模板 unit 的 ExecStart= 是固定的，Manager 給不了命令列。
+            # `User=` 刻意**不在** spec 內：身分只有 root-owned unit 檔一個來源。
+            spec = job_runner.build_job_spec(
+                job_id=slice_id,
+                instance=template_plan.instance,
+                unit=template_plan.unit,
+                command=argv,
+                working_directory=worktree,
+                log_path=log_path,
+                env=env,
+            )
+            job_runner.write_job_spec(template_plan.spec_path, spec)
+            argv = job_runner.build_systemctl_start_argv(
+                systemctl=template_plan.binary, unit=template_plan.unit
+            )
+            # systemctl **client 自己**的環境（同 A 案的理由：polkit 授權可能要查
+            # 呼叫端 session）。它不會流進 unit——unit 的環境來自 root-owned 模板檔，
+            # job 的環境則來自 spec，由 shim 在 exec 時直接指定。
+            popen_kwargs["env"] = _git_scope_env()
+            # systemctl client 不進 worktree：job 的 cwd 由 shim 依 spec 的
+            # working_directory 設定。三分方案下 per-job worktree 已 chown 給 job
+            # 帳號，Manager 未必進得去，硬把 client 的 cwd 指過去只會多一個
+            # PermissionError 失敗面。
+            popen_kwargs["cwd"] = None
+            popen_kwargs["stdin"] = subprocess.DEVNULL
+            # log 由 shim 在降權後以 O_APPEND 接管（unit 沒有 --pipe、也刻意不用
+            # StandardOutput=append:，理由見 job_runner 模組 docstring）。這裡先把
+            # 上一輪殘留截掉，再以 append 開檔——否則 systemctl client 的非 O_APPEND
+            # fd 會在 shim 已經寫了幾 KB 之後從 offset 0 覆蓋回去。
+            Path(log_path).write_bytes(b"")
+            log_mode = "ab"
+        with open(log_path, log_mode) as logf:
             popen_kwargs["stdout"] = logf
             proc = subprocess.Popen(argv, **popen_kwargs)
+        if template_plan is not None:
+            # polkit 拒絕／模板未安裝／shim 讀 spec 失敗只在起動當下才知道；
+            # 確認不到就 fail-closed，**絕不**退回其他模式。
+            job_runner.confirm_template_instance_started(
+                process=proc,
+                sentinel=sentinel,
+                unit=template_plan.unit,
+                account=template_plan.account,
+                log_path=log_path,
+                timeout_ms=job_runner.resolve_start_timeout_ms(os.environ),
+            )
         if runner_plan is not None:
             # polkit 拒絕／unit 名衝突只在起動當下才知道；確認不到就 fail-closed，
             # **絕不**退回 direct（見 job_runner.confirm_transient_unit_started）。

--- a/paulsha_cortex/trust_root/__main__.py
+++ b/paulsha_cortex/trust_root/__main__.py
@@ -7,24 +7,31 @@ Phase 1 不改 `cortex` CLI（避免動到 R-16 help 對齊面）；operator／C
     python -m paulsha_cortex.trust_root selfcheck   # R3 自檢診斷（JSON）
     python -m paulsha_cortex.trust_root registry    # R1 登記表摘要（JSON）
     python -m paulsha_cortex.trust_root equation     # R1 雙向等式結果
-    python -m paulsha_cortex.trust_root permissions [two-way|three-way] [--commands] [--paths]
+    python -m paulsha_cortex.trust_root permissions [three-way|two-way] [--commands] [--paths]
                                                     # Phase 2a 權限計畫（JSON 或命令序列）
-    python -m paulsha_cortex.trust_root unit [two-way|three-way]
+    python -m paulsha_cortex.trust_root unit [three-way|two-way]
                                         [--manager|--job|--job-properties]
                                                     # Phase 2b systemd unit 內容
                                                     # （--job-properties＝方案 A 的
                                                     #   systemd-run --property= 清單）
-    python -m paulsha_cortex.trust_root polkit [two-way|three-way] [--transient|--template]
+    python -m paulsha_cortex.trust_root shim [three-way|two-way]
+                                                    # Phase 2b 方案 B 的降權 shim 內容
+                                                    # （模板 unit 的固定 ExecStart=）
+    python -m paulsha_cortex.trust_root polkit [three-way|two-way] [--template|--transient]
                                                     # Phase 2b 降權 polkit 規則內容
-                                                    # （--transient＝方案 A，預設；
-                                                    #   --template＝方案 B）
-    python -m paulsha_cortex.trust_root scaffold [two-way|three-way]
+                                                    # （--template＝方案 B，**預設**；
+                                                    #   --transient＝方案 A，對照用）
+    python -m paulsha_cortex.trust_root scaffold [three-way|two-way]
                                                     # Phase 2b 骨架目錄的 install -d 命令
 
-`permissions`／`unit`／`polkit`／`scaffold` 只**產生**計畫與內容字串，**絕不執行**
-任何 root 操作、不寫任何系統路徑——命令供 operator 在 Phase 2b runbook 中手動
-sudo 執行。`--paths` 讓 `--commands` 以 `permgen.DEFAULT_LAYOUT` 的真實絕對路徑
-輸出（0816 裁決：/var/lib/cortex ＋ /opt/cortex），不再帶 placeholder。
+UID 方案未指定時一律用 **`three-way`**（operator 0816 第三輪裁決 A 的定案：
+`cortex-manager`／`cortex-reviewer-planner`／`cortex-builder`）。`two-way` 保留為
+向後相容選項，需**顯式**打出——打錯字不會靜默退回較寬鬆的方案。
+
+`permissions`／`unit`／`shim`／`polkit`／`scaffold` 只**產生**計畫與內容字串，
+**絕不執行**任何 root 操作、不寫任何系統路徑——命令供 operator 在 Phase 2b runbook
+中手動 sudo 執行。`--paths` 讓 `--commands` 以 `permgen.DEFAULT_LAYOUT` 的真實絕對
+路徑輸出（0816 裁決：/var/lib/cortex ＋ /opt/cortex），不再帶 placeholder。
 """
 from __future__ import annotations
 
@@ -89,7 +96,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         return 0 if result.ok else 1
     if command == "permissions":
         rest = args[1:]
-        scheme_id = "two-way"
+        scheme_id = permgen.DEFAULT_SCHEME_ID
         want_commands = False
         want_paths = False
         for token in rest:
@@ -112,7 +119,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         return 0
     if command == "unit":
         rest = args[1:]
-        scheme_id = "two-way"
+        scheme_id = permgen.DEFAULT_SCHEME_ID
         which = "manager"
         for token in rest:
             if token == "--manager":
@@ -142,10 +149,23 @@ def main(argv: Sequence[str] | None = None) -> int:
         )
         print(unit.content, end="")
         return 0
+    if command == "shim":
+        rest = args[1:]
+        scheme_id = permgen.DEFAULT_SCHEME_ID
+        for token in rest:
+            if token in permgen.SCHEMES:
+                scheme_id = token
+            else:
+                print(f"unknown shim arg: {token}", file=sys.stderr)
+                return 2
+        shim = permgen.build_job_shim(permgen.SCHEMES[scheme_id])
+        print(shim.content, end="")
+        return 0
     if command == "polkit":
         rest = args[1:]
-        scheme_id = "two-way"
-        plan = permgen.PolkitPlan.TRANSIENT
+        scheme_id = permgen.DEFAULT_SCHEME_ID
+        # 0816 第三輪裁決：方案 B（root-owned 模板 unit）定案，故為預設。
+        plan = permgen.PolkitPlan.TEMPLATE
         for token in rest:
             if token == "--transient":
                 plan = permgen.PolkitPlan.TRANSIENT
@@ -161,7 +181,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         return 0
     if command == "scaffold":
         rest = args[1:]
-        scheme_id = "two-way"
+        scheme_id = permgen.DEFAULT_SCHEME_ID
         for token in rest:
             if token in permgen.SCHEMES:
                 scheme_id = token

--- a/paulsha_cortex/trust_root/permgen.py
+++ b/paulsha_cortex/trust_root/permgen.py
@@ -9,26 +9,36 @@ spec §R10 Phase 2 第 2 條要求「目錄 owner／mode **由 R1 登記表產�
 **本模組純為產生器：只回傳資料與字串，絕不執行任何 root 操作、不 chown、不 chmod、
 不建 UID。** 命令字串供 operator 在 runbook 中手動 `sudo` 執行。
 
-## UID 方案的參數化（operator 0816 裁決：路線 A、Manager 專屬 UID、現階段先二分、
-## 但保留「二往三分」彈性）
+## UID 方案的參數化（operator 0816 **第三輪**裁決：三分定案，二分保留為向後相容選項）
 
 `UidScheme` 把每個 `Principal` 映射到具體 OS 帳號名，並指定：
 - `durable_state_owner`：擁有 Manager-owned durable state 樹的帳號；
 - `deploy_account`：enforcement plane（部署面）的擁有者（root／部署帳號）。
 
-**二分**（預設，`TWO_WAY_SCHEME`）：只有兩個 headless-相關帳號——
-`cortex-builder`（builder）與 `cortex-svc`（Manager＋reviewer＋planner＋monitor
-共用，且即 durable state owner）。reviewer 與 builder 因此落在互不可寫的不同帳號
-（滿足 spec §R2 對 independence 的最低要求）。
+**三分**（**定案**，`THREE_WAY_SCHEME`＝:data:`DEFAULT_SCHEME`）：三個帳號——
+`cortex-manager`（Manager＋monitor，durable state owner，**持 spawn 授權但不跑任何
+模型程式碼**）／`cortex-reviewer-planner`（reviewer＋planner 的模型 job）／
+`cortex-builder`（builder 的模型 job）。裁決的判準是 **「injection 可達的任何進程都
+不得持有 spawn 授權」**：二分下 reviewer／planner 與 Manager 併帳，任一被 prompt
+injection 攻陷即取得 polkit 的 start 授權；三分把模型執行面整個移出授權帳號。
 
-**三分**（`THREE_WAY_SCHEME`）：把 `cortex-svc` 拆為 `cortex-manager`（僅 Manager／
-monitor，且為 durable state owner）與 `cortex-reviewer-planner`（reviewer＋planner
-的 job 帳號，**不**擁有 durable state）。這實現裁決要保留的「未來把 Manager 拆成
-第三個 UID」彈性——**只換 config，不改本模組任何一行程式碼**。
+**二分**（`TWO_WAY_SCHEME`，向後相容）：`cortex-builder`＋`cortex-svc`（Manager＋
+reviewer＋planner＋monitor 共用）。保留是為了讓已按二分裝好的部署不必一次到位，
+**不是**新部署的建議值。
 
 兩個方案套用**同一套 policy 函式**，因此都能對登記表每一項產出一致（滿足同一組
 不變式）的權限集合：Manager-owned／deployment 樹對任何 headless 帳號皆不可寫，
-job-visible 樹由對應 job 帳號寫、跨 persona 互不可寫。
+job-visible 樹由對應 job 帳號寫、跨 persona 互不可寫。全部既有不變式測試對兩案
+逐一參數化跑（`tests/test_trust_root_permgen_p2a.py`／`_p2b.py` 的 `ALL_SCHEMES`）。
+
+## 降權機制（0816 第三輪裁決 A+B）
+
+- **A**＝上述三分。
+- **B**＝root-owned 模板 unit：`build_job_unit()` 產出 `cortex-job@.service`，
+  `User=` 硬寫死；`build_polkit_rule(plan=TEMPLATE)`（**預設**）只放行該模板實例的
+  start／stop。per-job 參數走 Manager-owned spec spool（登記表資產 `job-spec-spool`），
+  由 `build_job_shim()` 產出的 root-owned shim 讀取後 exec。
+- C（Manager 端封閉 argv 產生器）自動保留為第三層，見 `coordinator/job_runner.py`。
 """
 from __future__ import annotations
 
@@ -98,7 +108,9 @@ class UidScheme:
         return frozenset(accts)
 
 
-#: 二分（預設）：builder 一個帳號，其餘 headless／Manager／monitor 共用 cortex-svc。
+#: 二分（**向後相容選項**，非預設）：builder 一個帳號，其餘 headless／Manager／
+#: monitor 共用 cortex-svc。0816 第三輪裁決前的方案；已按此裝好的部署可續用，
+#: 但新部署一律走 :data:`DEFAULT_SCHEME`（三分）。
 TWO_WAY_SCHEME = UidScheme(
     scheme_id="two-way",
     account_of={
@@ -114,9 +126,9 @@ TWO_WAY_SCHEME = UidScheme(
     deploy_account="root",
 )
 
-#: 三分：把 cortex-svc 拆成 cortex-manager（durable state owner）與
-#: cortex-reviewer-planner（reviewer＋planner 的 job 帳號，不持有 durable state）。
-#: **與二分共用同一套 policy，僅換 config。**
+#: 三分（**定案**）：把 cortex-svc 拆成 cortex-manager（durable state owner，持 spawn
+#: 授權、不跑模型）與 cortex-reviewer-planner（reviewer＋planner 的模型 job 帳號，
+#: 不持有 durable state、不持 spawn 授權）。**與二分共用同一套 policy，僅換 config。**
 THREE_WAY_SCHEME = UidScheme(
     scheme_id="three-way",
     account_of={
@@ -136,6 +148,12 @@ SCHEMES: dict[str, UidScheme] = {
     TWO_WAY_SCHEME.scheme_id: TWO_WAY_SCHEME,
     THREE_WAY_SCHEME.scheme_id: THREE_WAY_SCHEME,
 }
+
+#: **定案方案**（0816 第三輪裁決 A）。CLI／產生器未指定 scheme 時一律用這個——
+#: 「預設就是最安全的那一個」是刻意的：要退回二分必須顯式打出 `two-way`，
+#: 打錯字不會靜默退回較寬鬆的方案（`SCHEMES` 查無即拒）。
+DEFAULT_SCHEME: UidScheme = THREE_WAY_SCHEME
+DEFAULT_SCHEME_ID: str = DEFAULT_SCHEME.scheme_id
 
 
 # ---------------------------------------------------------------------------
@@ -586,8 +604,15 @@ class PathLayout:
     worktree_root: str = "/var/lib/cortex/worktree"
     deploy_root: str = "/opt/cortex"
     instance: str = "cortex"
-    svc_home: str = "/var/lib/cortex-svc"
-    builder_home: str = "/var/lib/cortex-builder"
+    #: 服務／job 帳號 HOME 的父目錄。**每個帳號的 HOME 由帳號名機械導出**
+    #: （`home_of()`），不再是寫死的字面量——寫死會在換 scheme 時漂移：三分的
+    #: Manager 帳號是 `cortex-manager`，HOME 卻還指著二分時代的 `/var/lib/cortex-svc`，
+    #: unit 的 `Environment=HOME=` 與 scaffold 因此指向一個沒人擁有的目錄。
+    home_root: str = "/var/lib"
+    #: builder 的帳號名。只給 `asset_paths()` 用（`codex-hooks` 掛在 builder HOME 下），
+    #: 因為 `asset_paths()` 刻意不吃 scheme——兩個 scheme 對 BUILDER 的映射相同。
+    #: 其餘所有帳號相關路徑一律由 scheme 現場導出。
+    builder_account: str = "cortex-builder"
     #: per-job 路徑的 segment；system unit 模板用 `%i`（systemd instance 名）。
     job_segment: str = PER_JOB_SEGMENT
 
@@ -627,9 +652,24 @@ class PathLayout:
         return f"{self.agents_root}/runtime/dispatch"
 
     @property
-    def job_spool_root(self) -> str:
-        """Manager 寫、job 只讀的 per-job 執行規格（`<id>/run.sh`）。"""
-        return f"{self.agents_root}/jobs"
+    def job_spec_spool_root(self) -> str:
+        """Manager 寫、job 只讀的 per-job 執行規格（`<unit-instance-id>.json`）。
+
+        路徑與 `config.paths.job_spec_spool_root()` 是**成對契約**（登記表資產
+        `job-spec-spool`），由 `asset_paths()` 而非本 property 供給權限計畫；本
+        property 只是給 unit／shim 產生器引用的同一份字面量。
+        """
+        return f"{self.coordinator_root}/job-specs"
+
+    @property
+    def bin_root(self) -> str:
+        """部署樹的可執行檔目錄（root-owned）——降權 shim 住這裡。"""
+        return f"{self.deploy_root}/bin"
+
+    @property
+    def job_shim(self) -> str:
+        """降權 job 模板 unit 的固定 `ExecStart=`（root-owned，內容由 permgen 產）。"""
+        return f"{self.bin_root}/cortex-job-shim"
 
     @property
     def venv_root(self) -> str:
@@ -643,13 +683,26 @@ class PathLayout:
     def env_file(self) -> str:
         return f"{self.deploy_root}/etc/{self.instance}-manager.env"
 
+    # -- 帳號→HOME／cache（由帳號名機械導出，換 scheme 不會漂移）-------------
+    def home_of(self, account: str) -> str:
+        """該帳號的 HOME。HOME 本身 root-owned（見 `scaffold_directories`）。"""
+        return f"{self.home_root}/{account}"
+
+    def cache_of(self, account: str) -> str:
+        """該帳號 HOME 底下唯一可寫的那一層（git／gh／uv 的 cache）。"""
+        return f"{self.home_of(account)}/cache"
+
+    def codex_hooks_dir_of(self, account: str) -> str:
+        """該帳號的 `~/.codex`。root-owned——job 不得替換自己的 hooks。"""
+        return f"{self.home_of(account)}/.codex"
+
     @property
-    def svc_cache(self) -> str:
-        return f"{self.svc_home}/cache"
+    def builder_home(self) -> str:
+        return self.home_of(self.builder_account)
 
     @property
     def builder_cache(self) -> str:
-        return f"{self.builder_home}/cache"
+        return self.cache_of(self.builder_account)
 
     def with_job_segment(self, segment: str) -> "PathLayout":
         """換掉 per-job segment（system unit 模板用 `%i`）。"""
@@ -658,8 +711,8 @@ class PathLayout:
             worktree_root=self.worktree_root,
             deploy_root=self.deploy_root,
             instance=self.instance,
-            svc_home=self.svc_home,
-            builder_home=self.builder_home,
+            home_root=self.home_root,
+            builder_account=self.builder_account,
             job_segment=segment,
         )
 
@@ -699,6 +752,8 @@ class PathLayout:
             "review-verdict": f"{job}/.psc-review-verdict.json",
             # Phase 2a 受控通道（PR #599）：<coordinator>/review-verdicts/<reviewer_job_id>/
             "review-verdict-spool": f"{c}/review-verdicts",
+            # Phase 2b 方案 B（0816 第三輪 A+B）：模板 unit 的 per-job 執行規格。
+            "job-spec-spool": self.job_spec_spool_root,
             "verification-evidence": f"{c}/evidence/verification",
             "maintainer-attestation": f"{c}/evidence/maintainer-review",
             "completion-record": f"{c}/evidence/completion",
@@ -727,13 +782,29 @@ class PathLayout:
         rename 子物件，因此把 root-owned 檔放進 svc-owned 目錄等於沒保護。
         """
         svc = scheme.durable_state_owner
-        builder = scheme.resolve(Principal.BUILDER) or "cortex-builder"
         root = scheme.deploy_account
         g = scheme.group_of
+        # 每個 scheme 解析得到的帳號都要有 HOME／cache——**由 scheme 導出，不是列舉**。
+        # 二分下這是 {cortex-svc, cortex-builder}（與改動前逐字相同）；三分下自動多出
+        # `cortex-reviewer-planner`，不必在這裡補一行（補一行正是上一版漏掉它的原因）。
+        service_accounts = [svc] + sorted(scheme.headless_accounts() - {svc})
+        # 跑模型的 job 帳號還要一個 root-owned 的 ~/.codex（hooks 不得被 job 替換）。
+        job_accounts = sorted(scheme.headless_accounts() - {svc})
+        account_dirs: list[tuple[str, str, str, int]] = []
+        for account in service_accounts:
+            account_dirs.append((self.home_of(account), root, g(root), 0o755))
+            if account in job_accounts:
+                account_dirs.append(
+                    (self.codex_hooks_dir_of(account), root, g(root), 0o755)
+                )
+            account_dirs.append((self.cache_of(account), account, g(account), 0o700))
         return (
             # 部署樹（enforcement plane）：全 root，對 svc／builder 唯讀。
             (self.deploy_root, root, g(root), 0o755),
             (f"{self.deploy_root}/etc", root, g(root), 0o755),
+            # 降權 shim 的家：root-owned、對 svc／job 唯讀。模板 unit 的 ExecStart=
+            # 指向這裡，因此持 spawn 授權的帳號也改不了 job 實際執行的第一支程式。
+            (self.bin_root, root, g(root), 0o755),
             (self.venv_root, root, g(root), 0o755),
             # durable state 樹的 root-owned 骨架（svc 不得 relink 這幾層）。
             (f"{self.agents_root}/config", root, g(root), 0o755),
@@ -742,34 +813,33 @@ class PathLayout:
             # svc 自己建得出來、但先建好可讓權限一次到位的中間層。
             (f"{self.coordinator_root}/evidence", svc, g(svc), 0o700),
             (f"{self.coordinator_root}/digest", svc, g(svc), 0o700),
-            # job spool：svc 寫 run.sh，job 帳號只 traverse＋讀（0711 不可列目錄）。
-            (self.job_spool_root, svc, g(svc), 0o711),
-            # 服務帳號 HOME：root 擁有（job 不得替換自己的 ~/.codex），只開 cache 子目錄。
-            (self.svc_home, root, g(root), 0o755),
-            (self.svc_cache, svc, g(svc), 0o700),
-            (self.builder_home, root, g(root), 0o755),
-            (f"{self.builder_home}/.codex", root, g(root), 0o755),
-            (self.builder_cache, builder, g(builder), 0o700),
+            # job spec spool 不在此列：它已是登記表資產（`job-spec-spool`），權限由
+            # `plan_to_commands()` 依登記表機械產出（owner-only ＋ job 帳號唯讀 ACL），
+            # 在骨架再寫一次會變成第二份真相。
+            # 服務／job 帳號 HOME：root 擁有（job 不得替換自己的 ~/.codex），只開
+            # cache 子目錄。清單由 scheme 導出，見上方 `account_dirs`。
+            *account_dirs,
         )
 
     # -- 額外可寫路徑（非登記表資產，須附理由）------------------------------
-    def manager_extra_write_paths(self) -> tuple[ExtraWritePath, ...]:
+    def manager_extra_write_paths(self, account: str) -> tuple[ExtraWritePath, ...]:
+        # 註：job spec spool 曾經是這裡的一條 extra（`<agents_root>/jobs/<id>/run.sh`）。
+        # 0816 第三輪 A+B 把它升格為登記表資產 `job-spec-spool`，因此改由
+        # `required_write_targets()` 機械導出——例外通道少一條，等式多涵蓋一項。
         return (
             ExtraWritePath(
-                self.job_spool_root,
-                "Manager 寫 per-job 執行規格（<id>/run.sh）供降權 job 讀取；job 帳號唯讀。",
-            ),
-            ExtraWritePath(
-                self.svc_cache,
-                "服務帳號 HOME 快取（git/gh/uv）；HOME 本身 root-owned，只開這一層。",
+                self.cache_of(account),
+                f"服務帳號 {account} 的 HOME 快取（git/gh/uv）；HOME 本身 root-owned，只開這一層。",
             ),
         )
 
-    def job_extra_write_paths(self) -> tuple[ExtraWritePath, ...]:
+    def job_extra_write_paths(self, account: str) -> tuple[ExtraWritePath, ...]:
+        # 帳號由呼叫端（`build_job_unit` 的 principal）給：M2 要為 reviewer/planner
+        # 開第二個模板 unit 時，這裡不必改一行——換 principal 即換帳號。
         return (
             ExtraWritePath(
-                self.builder_cache,
-                "job 帳號 HOME 快取（git/gh/uv）；HOME 與 ~/.codex 皆 root-owned 不可替換。",
+                self.cache_of(account),
+                f"job 帳號 {account} 的 HOME 快取（git/gh/uv）；HOME 與 ~/.codex 皆 root-owned 不可替換。",
             ),
         )
 
@@ -910,6 +980,25 @@ _HARDENING: tuple[tuple[str, str, str], ...] = (
 )
 
 
+def job_unit_stem(
+    layout: "PathLayout" = None,  # type: ignore[assignment]
+    principal: Principal = Principal.BUILDER,
+) -> str:
+    """降權 job 模板 unit 的字幹（不含 `@.service`）。
+
+    **M2（#615，reviewer/planner 啟動面降權）的擴充點就是這裡。** 現階段只有
+    builder 走模板，字幹是 `cortex-job`（與 `coordinator/job_runner`
+    的 `TEMPLATE_UNIT_PREFIX` ＋ polkit pattern 成對契約）。要開第二個模板實例時
+    只需傳入另一個 `principal`：unit 名、`User=`、`Environment=HOME=`／
+    `XDG_CACHE_HOME=`、`ReadWritePaths=` 全部跟著 scheme 導出，`build_job_unit()`／
+    `build_polkit_rule()`／`build_job_shim()` 三支產生器**一行都不必改**。
+    """
+    layout = layout if layout is not None else DEFAULT_LAYOUT
+    if principal is Principal.BUILDER:
+        return f"{layout.instance}-job"
+    return f"{layout.instance}-{principal.value}-job"
+
+
 @dataclass(frozen=True)
 class SystemdUnit:
     """產生出來的 unit：**只有內容字串與結構化欄位，沒有任何寫檔／執行**。"""
@@ -964,7 +1053,7 @@ def build_manager_unit(
     plan = plan or generate_plan(scheme)
     account = scheme.durable_state_owner
     group = scheme.group_of(account)
-    extras = layout.manager_extra_write_paths()
+    extras = layout.manager_extra_write_paths(account)
     owners = read_write_path_owners(plan, layout, account, extras)
     unit_name = f"{layout.instance}-manager.service"
 
@@ -995,8 +1084,9 @@ def build_manager_unit(
         "# MUST NOT 靜默落回 $HOME/.agents 預設（spec §R3 Scenario「刪除 EnvironmentFile」）。",
         f"EnvironmentFile={layout.env_file}",
         "# HOME 由 unit 指定；HOME 本身 root-owned，只有 cache 子目錄可寫。",
-        f"Environment=HOME={layout.svc_home}",
-        f"Environment=XDG_CACHE_HOME={layout.svc_cache}",
+        "# 路徑由帳號名導出（`layout.home_of`）——換 scheme 時不會停在舊帳號的樹上。",
+        f"Environment=HOME={layout.home_of(account)}",
+        f"Environment=XDG_CACHE_HOME={layout.cache_of(account)}",
         "",
         "# --- 加固（spec §R3；逐項附理由供審查）---",
     ]
@@ -1033,6 +1123,19 @@ def build_job_unit(
     這是降權/提權分界線的另一半：`User=` 在 root-owned 的 unit 檔裡**硬寫死**，
     呼叫端（Manager）只能給 instance 名，**無法選擇 UID、無法夾帶任何屬性**。
     polkit 規則只放行這個模板的實例（見 `build_polkit_rule`）。
+
+    `ExecStart=` 同樣固定：永遠是 root-owned 的 shim（`build_job_shim()` 產出），
+    per-job 的命令／worktree／env／log 路徑改由 Manager-owned 的 spec spool
+    （登記表資產 `job-spec-spool`）傳遞，shim 讀完才 exec。
+
+    **為什麼不用 `StandardOutput=append:<log>`**：`file:`／`append:` 的目標檔是由
+    **PID 1（root）** 在降權之前開啟的；路徑裡只要有任何一段由 Manager 帳號掌控
+    （spec spool 或 log 目錄都是），Manager 就能在該位置放一個 symlink 讓 root 對
+    任意檔案 append——那是把「Manager 不具 root」這條裁決整個賣掉。模板是**單一
+    靜態檔**、per-job 的 log 路徑又必須維持 harvest 既有的
+    `<log_dir>/<slice>.jsonl`（`%i` 推不出來），兩者無法同時成立。因此 log 導引改由
+    **shim 在已降權之後**依 spec 的 `log_path` 自行接管（見 `coordinator/job_shim.py`），
+    unit 這層只留 journal 給 shim 讀 spec 失敗時的診斷。
     """
     plan = plan or generate_plan(scheme)
     account = scheme.resolve(principal)
@@ -1041,9 +1144,9 @@ def build_job_unit(
     group = scheme.group_of(account)
     # per-job 路徑在模板 unit 中以 systemd 的 %i 表示。
     job_layout = layout.with_job_segment("%i")
-    extras = job_layout.job_extra_write_paths()
+    extras = job_layout.job_extra_write_paths(account)
     owners = read_write_path_owners(plan, job_layout, account, extras)
-    unit_name = f"{layout.instance}-job@.service"
+    unit_name = f"{job_unit_stem(layout, principal)}@.service"
 
     body = [
         f"# {'/etc/systemd/system/' + unit_name}",
@@ -1063,15 +1166,24 @@ def build_job_unit(
         f"User={account}",
         f"Group={group}",
         "",
-        "# 執行規格由 Manager 寫入 job spool（svc-owned，job 帳號唯讀）：",
+        "# ExecStart 也是固定的：永遠是 root-owned 的 shim，呼叫端連命令列都給不了。",
+        "# per-job 執行規格由 Manager 原子寫入 spec spool（Manager-owned，job 帳號唯讀）：",
+        f"#   {job_layout.job_spec_spool_root}/%i.json",
         "# job 因此無法改寫自己的命令列，也無法為下一個 job 埋伏。",
-        f"ExecStart=/bin/sh {job_layout.job_spool_root}/%i/run.sh",
-        f"WorkingDirectory={job_layout.worktree_root}/%i",
+        f"ExecStart={job_layout.job_shim} %i",
+        "# 工作目錄：shim 會依 spec 的 working_directory 再 chdir 到該 job 的 worktree；",
+        "# 這裡只給恆存在的 pool 根（0701＝可 traverse、不可列目錄），避免 unit 因",
+        "# per-job 目錄尚未建立而在 exec 前就失敗（那會讓 log 裡沒有任何線索）。",
+        f"WorkingDirectory={job_layout.worktree_root}",
+        "# shim 讀 spec 的唯一合法來源：這一行在 root-owned 的 unit 檔裡，",
+        "# 因此持 spawn 授權的帳號也改不掉 spec 要從哪個目錄讀。shim 對未設此",
+        "# 變數的情況 fail-closed（不猜、不落回 $HOME 推導的預設）。",
+        f"Environment=PSC_JOB_SPEC_SPOOL={job_layout.job_spec_spool_root}",
         "# job 永不取得 gh token：GitHub 寫入由 Manager 代理（D1 outbox）。",
         "Environment=GH_TOKEN=",
         "Environment=GITHUB_TOKEN=",
-        f"Environment=HOME={job_layout.builder_home}",
-        f"Environment=XDG_CACHE_HOME={job_layout.builder_cache}",
+        f"Environment=HOME={job_layout.home_of(account)}",
+        f"Environment=XDG_CACHE_HOME={job_layout.cache_of(account)}",
         "",
         "# --- 加固（與 Manager 同一套；job 這側只多不少）---",
     ]
@@ -1083,6 +1195,10 @@ def build_job_unit(
         "# job 為一次性：結束即回收 unit 狀態，不留可被重用的殘骸。",
         "CollectMode=inactive-or-failed",
         "Restart=no",
+        "# 刻意**不**用 StandardOutput=append:<log>——那個檔由 PID 1（root）在降權前開啟，",
+        "# 路徑中只要有一段由 Manager 帳號掌控就成了 root-follows-symlink 的提權面。",
+        "# job 的 JSONL log 由 shim 在**已降權之後**依 spec 的 log_path 自行接管；",
+        "# 這裡的 journal 只承接 shim 讀 spec 失敗（尚未接管前）的診斷輸出。",
         "StandardOutput=journal",
         "StandardError=journal",
     ]
@@ -1090,9 +1206,97 @@ def build_job_unit(
         unit_name=unit_name,
         install_path=f"/etc/systemd/system/{unit_name}",
         account=account,
-        exec_start=f"/bin/sh {job_layout.job_spool_root}/%i/run.sh",
+        exec_start=f"{job_layout.job_shim} %i",
         environment_file=None,
         read_write_paths=tuple(owners.keys()),
+        content="\n".join(body) + "\n",
+    )
+
+
+# ---------------------------------------------------------------------------
+# 降權 shim（root-owned，模板 unit 的固定 ExecStart）
+# ---------------------------------------------------------------------------
+
+#: shim 真正的實作模組。**刻意不是 heredoc 產出的一大段程式碼**：shim 要做的事
+#: （驗 instance 名／驗 spec 檔不是 symlink／驗 schema／接管 log／chdir／execve）
+#: 每一條都是可測的邏輯，塞進字串就只剩「字串比對」這種驗收方式。把邏輯放進
+#: repo 內的模組，它跟其他程式碼一樣被單元測試、被 lint、被 review；permgen 只
+#: 產出那支 3 行的 root-owned 啟動 stub。兩者都落在 root-owned 的部署樹裡，
+#: 「job 改不了自己執行的第一支程式」這條性質完全不變。
+JOB_SHIM_MODULE = "paulsha_cortex.coordinator.job_shim"
+
+
+@dataclass(frozen=True)
+class ShimScript:
+    """產生出來的 shim stub：**只有內容字串**，本模組不寫任何系統路徑。"""
+
+    install_path: str
+    interpreter: str
+    module: str
+    mode: int
+    owner: str
+    group: str
+    content: str
+
+    @property
+    def mode_str(self) -> str:
+        return format(self.mode, "04o")
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "install_path": self.install_path,
+            "interpreter": self.interpreter,
+            "module": self.module,
+            "mode": self.mode_str,
+            "owner": self.owner,
+            "group": self.group,
+            "content": self.content,
+        }
+
+    def commands(self) -> list[str]:
+        """安裝命令字串（**只回傳字串，不執行**）。"""
+        return [
+            f"chown {self.owner}:{self.group} {self.install_path}",
+            f"chmod {self.mode_str} {self.install_path}",
+        ]
+
+
+def build_job_shim(
+    scheme: UidScheme = DEFAULT_SCHEME,
+    layout: PathLayout = DEFAULT_LAYOUT,
+) -> ShimScript:
+    """產生 `<deploy_root>/bin/cortex-job-shim` 的內容（root-owned 啟動 stub）。
+
+    stub 只做一件事：以部署 venv 的 interpreter 執行 :data:`JOB_SHIM_MODULE`，把
+    模板 unit 傳進來的 `%i`（instance 名）原封不動交過去。**不解析參數、不組命令、
+    不碰 spec 檔**——所有判斷都在那個模組裡，這裡沒有可被注入的表面。
+
+    interpreter 寫成部署 venv 的絕對路徑而不是 `/usr/bin/env python3`：後者會走
+    job 帳號的 `PATH`，等於讓 job 決定用哪個 interpreter 執行 root-owned 的 shim。
+    """
+    account = scheme.deploy_account
+    interpreter = f"{layout.venv_root}/bin/python3"
+    body = [
+        "#!/bin/sh",
+        f"# {layout.job_shim}",
+        f"# 由 permgen 機械產生（scheme={scheme.scheme_id}）——勿手改；重跑：",
+        f"#   python3 -m paulsha_cortex.trust_root shim {scheme.scheme_id}",
+        "#",
+        "# root-owned、mode 0755：Manager 與 job 帳號皆唯讀。這是模板 unit 固定的",
+        f"# ExecStart=，因此持 spawn 授權的帳號也換不掉 job 執行的第一支程式。",
+        "#",
+        f"# $1 ＝ systemd 模板實例名（%i）。spec 由此推導：",
+        f"#   {layout.job_spec_spool_root}/$1.json（Manager 寫、job 唯讀）",
+        "set -eu",
+        f'exec "{interpreter}" -m {JOB_SHIM_MODULE} "$@"',
+    ]
+    return ShimScript(
+        install_path=layout.job_shim,
+        interpreter=interpreter,
+        module=JOB_SHIM_MODULE,
+        mode=0o755,
+        owner=account,
+        group=scheme.group_of(account),
         content="\n".join(body) + "\n",
     )
 
@@ -1108,17 +1312,18 @@ POLKIT_ALLOWED_VERBS: tuple[str, ...] = ("start", "stop")
 
 
 class PolkitPlan(Enum):
-    """降權的兩個方案（operator 待拍板；兩案都完整產出，選了即可執行）。
+    """降權的兩個方案。**0816 第三輪裁決：B 定案**（`TEMPLATE` 為預設）。
 
-    - `TRANSIENT`（A）：Manager 以 `systemd-run` 起 transient unit（#603 的
-      `coordinator/job_runner.py` 已落地，`PSC_JOB_RUNNER=systemd-run` 開啟）。
-      polkit 能收窄的**只有**呼叫者 UID ＋ unit 名前綴；`User=`／`--uid=` **不在**
-      polkit detail 內，故「只能降到 job 帳號」這一半由 Manager 端封閉的 argv
-      產生器在 code level 保證，OS 層未強制（殘餘風險見 `plan_residual_risk`）。
-    - `TEMPLATE`（B）：root-owned 模板 unit（`<instance>-job@.service`）把 `User=`
-      硬寫死，polkit 只放行該模板的實例。**「降到哪個帳號」因此由 OS 強制**；
-      代價是 Manager 端要從 `systemd-run` 改成 `systemctl start <instance>-job@<id>`，
-      屬程式碼後續工項。
+    - `TEMPLATE`（B，**定案／預設**）：root-owned 模板 unit（`<instance>-job@.service`）
+      把 `User=` 與 `ExecStart=` 都硬寫死，polkit 只放行該模板的實例。**「降到哪個
+      帳號」「執行哪支程式」因此都由 OS 強制**，`plan_residual_risk()` 回傳空 tuple。
+      Manager 端對應的啟動器模式是 `PSC_JOB_RUNNER=systemd-template`
+      （`coordinator/job_runner.py`）。
+    - `TRANSIENT`（A，保留為對照／過渡）：Manager 以 `systemd-run` 起 transient unit
+      （`PSC_JOB_RUNNER=systemd-run`）。polkit 能收窄的**只有**呼叫者 UID ＋ unit 名
+      前綴；`User=`／`--uid=` **不在** polkit detail 內（#603 實測），故「只能降到 job
+      帳號」這一半只能由 Manager 端封閉的 argv 產生器在 code level 保證——那正是本次
+      改採 B 案的原因，殘餘風險見 `plan_residual_risk`。
     """
 
     TRANSIENT = "transient"
@@ -1173,12 +1378,14 @@ def transient_unit_prefix(layout: "PathLayout") -> str:
 def job_unit_pattern(
     layout: "PathLayout" = None,  # type: ignore[assignment]
     plan: PolkitPlan = PolkitPlan.TEMPLATE,
+    principal: Principal = Principal.BUILDER,
 ) -> str:
-    """被授權的 unit 名 regex（錨定）。"""
+    """被授權的 unit 名 regex（錨定）。`principal` 是 M2 的第二實例化擴充點。"""
     layout = layout if layout is not None else DEFAULT_LAYOUT
     if plan is PolkitPlan.TRANSIENT:
         return r"^" + layout.instance + r"-job-[a-z0-9][a-z0-9._-]{0,62}\.service$"
-    return r"^" + layout.instance + r"-job@[a-z0-9][a-z0-9._-]{0,62}\.service$"
+    stem = job_unit_stem(layout, principal)
+    return r"^" + stem + r"@[a-z0-9][a-z0-9._-]{0,62}\.service$"
 
 
 def plan_residual_risk(plan: PolkitPlan, scheme: UidScheme) -> tuple[str, ...]:
@@ -1212,7 +1419,7 @@ def plan_residual_risk(plan: PolkitPlan, scheme: UidScheme) -> tuple[str, ...]:
 def build_polkit_rule(
     scheme: UidScheme,
     layout: "PathLayout" = None,  # type: ignore[assignment]
-    plan: PolkitPlan = PolkitPlan.TRANSIENT,
+    plan: PolkitPlan = PolkitPlan.TEMPLATE,
     principal: Principal = Principal.BUILDER,
 ) -> PolkitRule:
     """產生降權授權的 polkit 規則內容（A／B 兩方案共用同一套產生邏輯）。
@@ -1225,7 +1432,7 @@ def build_polkit_rule(
     target = scheme.resolve(principal)
     if target is None:
         raise ValueError(f"principal 未映射到帳號: {principal}")
-    pattern = job_unit_pattern(layout, plan)
+    pattern = job_unit_pattern(layout, plan, principal)
     verbs = POLKIT_ALLOWED_VERBS
     verb_check = " && ".join(f'verb !== "{v}"' for v in verbs)
     residual = plan_residual_risk(plan, scheme)
@@ -1246,9 +1453,12 @@ def build_polkit_rule(
     else:
         headline = (
             f"// 方案 B（root-owned 模板 unit）：{svc} 只能 start/stop\n"
-            f"//   {layout.instance}-job@<id>.service 的實例。\n"
-            f"// 模板檔 /etc/systemd/system/{layout.instance}-job@.service 由 root 擁有，\n"
-            f"// 內容硬寫死 User={target}、NoNewPrivileges=yes、CapabilityBoundingSet=（空）。\n"
+            f"//   {job_unit_stem(layout, principal)}@<id>.service 的實例。\n"
+            f"// 模板檔 /etc/systemd/system/{job_unit_stem(layout, principal)}@.service 由 root 擁有，\n"
+            f"// 內容硬寫死 User={target}、NoNewPrivileges=yes、CapabilityBoundingSet=（空），\n"
+            f"// 以及固定的 ExecStart={layout.job_shim} %i（root-owned shim）。\n"
+            f"// per-job 參數走 Manager-owned spec spool（{layout.job_spec_spool_root}/<id>.json，\n"
+            f"// job 帳號唯讀）——{svc} 給得出參數，但給不出 UID、也給不出命令列。\n"
             f"// 因此 {svc} **無法選擇 job 的 UID**，也**無法夾帶任何特權屬性**：\n"
             + "\n".join(f"//     - {p}" for p in POLKIT_FORBIDDEN_PROPERTIES)
             + "\n"
@@ -1331,7 +1541,7 @@ def transient_unit_properties(
     job_layout = layout.with_job_segment("%i")
     props = [f"--property={key}={value}" for key, value, _why in _HARDENING]
     for rwp in read_write_paths(
-        plan, job_layout, account, job_layout.job_extra_write_paths()
+        plan, job_layout, account, job_layout.job_extra_write_paths(account)
     ):
         props.append(f"--property=ReadWritePaths={rwp}")
     return tuple(props)

--- a/paulsha_cortex/trust_root/registry.py
+++ b/paulsha_cortex/trust_root/registry.py
@@ -301,6 +301,25 @@ ASSET_REGISTRY: tuple[TrustRootAsset, ...] = (
         ),
     ),
     TrustRootAsset(
+        "job-spec-spool", _T0, _MO,
+        "paulsha_cortex.config.paths:job_spec_spool_root",
+        (Principal.MANAGER,), (Principal.MANAGER, Principal.BUILDER),
+        IngressKind.MANAGER_INTERNAL,
+        derived_in=(
+            "config/paths.py:job_spec_spool_root",
+            "coordinator/job_runner.py:job_spec_path",
+            "coordinator/job_shim.py:load_spec",
+        ),
+        note=(
+            "0816 第三輪裁決 A+B 的帶外通道：`<coordinator_root>/job-specs/"
+            "<unit-instance-id>.json`。root-owned 的 `cortex-job@.service` 模板 unit 的 "
+            "`ExecStart=` 固定為 shim，per-job 的命令／worktree／白名單 env／log 路徑改由"
+            "本 spool 傳遞。**writer 只有 Manager**——builder 在 reader 面（唯讀 ACL），"
+            "因此改不了自己的命令列；`User=` 完全不在本檔內（它硬寫死在 root-owned 的 "
+            "unit 檔裡），spool 被竄改也無法選 UID。"
+        ),
+    ),
+    TrustRootAsset(
         "verification-evidence", _T0, _MO, None,
         (Principal.MANAGER,), (Principal.MANAGER,), IngressKind.MANAGER_INTERNAL,
         derived_in=("coordinator/verification.py:305-316",),

--- a/tests/test_trust_root_job_template_ab.py
+++ b/tests/test_trust_root_job_template_ab.py
@@ -1,0 +1,1253 @@
+"""operator 0816 第三輪裁決 **A+B** 的程式碼側驗收（#584）。
+
+A＝三分 UID 定案（`permgen.DEFAULT_SCHEME`）；B＝root-owned 模板 unit ＋
+Manager-owned spec spool ＋ root-owned shim（`PSC_JOB_RUNNER=systemd-template`）。
+
+覆蓋面：
+
+1. **三分定案**——`DEFAULT_SCHEME` 是三分、CLI 未指定時出三分、二分仍可顯式取得。
+2. **模板模式 argv／spec**——argv 封閉（只有 unit 名可變）、spec **不含身分欄位**、
+   spec 的 env **不含任何 token 類**、spec 原子落地且 mode 讓 job 讀得到。
+3. **spool 資產入登記表**——`job-spec-spool` 在 R1 登記表、writer 只有 Manager、
+   builder 零寫入（permgen 不變式）、layout 對得上 `config.paths`。
+4. **fail-fast 三案**——模板未安裝／shim 未安裝／spool 缺席、instance 已在跑、
+   spec 寫入失敗，一律 `DiagnosticReason` fail-closed，且**不退回其他模式**。
+5. **direct／systemd-run 零回歸**——第三種模式存在不改前兩種的任何一個位元組。
+6. **shim**——stub 內容由 permgen 產生；shim 邏輯模組對 symlink／schema／身分欄位／
+   憑證 env 逐條 fail-closed，成功路徑接管 log、chdir、exec。
+
+全程不跑 systemctl、不建帳號、不碰 polkit、不安裝任何 unit。
+"""
+from __future__ import annotations
+
+import json
+import os
+import stat
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import paulsha_cortex.coordinator.job_runner as job_runner
+import paulsha_cortex.coordinator.job_shim as job_shim
+import paulsha_cortex.coordinator.launcher as launcher_module
+from paulsha_cortex.config import paths as config_paths
+from paulsha_cortex.coordinator.job_runner import JobRunnerError
+from paulsha_cortex.coordinator.launcher import SubprocessLauncher
+from paulsha_cortex.trust_root import permgen, registry
+from paulsha_cortex.trust_root.registry import Principal
+
+_BASE_ENV = {
+    "PATH": "/usr/local/bin:/usr/bin:/bin",
+    "HOME": "/var/lib/cortex-manager",
+    "LANG": "en_US.UTF-8",
+}
+
+_SECRET_ENV = {
+    "GH_TOKEN": "gh-secret",
+    "GITHUB_TOKEN": "github-secret",
+    "COPILOT_GITHUB_TOKEN": "copilot-secret",
+    "ANTHROPIC_API_KEY": "anthropic-secret",
+    "OPENAI_API_KEY": "openai-secret",
+    "AWS_SECRET_ACCESS_KEY": "aws-secret",
+    "CLAUDE_CONFIG_DIR": "/var/lib/cortex-manager/.claude",
+    "GH_CONFIG_DIR": "/var/lib/cortex-manager/.config/gh",
+    "BASH_ENV": "/tmp/credential-exporter",
+    "NODE_OPTIONS": "--require /tmp/inject.js",
+    "PGPASSWORD": "postgres-secret",
+}
+
+
+class _FakeProc:
+    def __init__(self, *, pid: int = 5150, exit_status: int | None = None) -> None:
+        self.pid = pid
+        self._exit_status = exit_status
+
+    def poll(self) -> int | None:
+        return self._exit_status
+
+
+class _RecordingPopen:
+    def __init__(self, *, proc: _FakeProc | None = None) -> None:
+        self.calls: list[dict] = []
+        self._proc = proc or _FakeProc()
+
+    def __call__(self, argv, **kwargs):
+        self.calls.append({"argv": argv, **kwargs})
+        return self._proc
+
+    @property
+    def call(self) -> dict:
+        return self.calls[0]
+
+
+class _nested:
+    def __init__(self, managers) -> None:
+        self._managers = list(managers)
+
+    def __enter__(self):
+        self._entered = [m.__enter__() for m in self._managers]
+        return self._entered
+
+    def __exit__(self, *exc_info):
+        for manager in reversed(self._managers):
+            manager.__exit__(*exc_info)
+        return False
+
+
+def _template_env(spool: str, **overrides: str) -> dict[str, str]:
+    env = {
+        **_BASE_ENV,
+        **_SECRET_ENV,
+        job_runner.JOB_RUNNER_ENV: job_runner.RUNNER_SYSTEMD_TEMPLATE,
+        job_runner.JOB_SPEC_SPOOL_ENV: spool,
+    }
+    env.update(overrides)
+    return env
+
+
+def _preflight_patches(*, unit_active: bool = False, **overrides):
+    defaults = {
+        "which": mock.patch.object(
+            job_runner.shutil, "which", return_value="/usr/bin/systemctl"
+        ),
+        "booted": mock.patch.object(job_runner, "_systemd_booted", return_value=True),
+        "account": mock.patch.object(job_runner, "_account_exists", return_value=True),
+        "group": mock.patch.object(job_runner, "_group_exists", return_value=True),
+        "unit_file": mock.patch.object(
+            job_runner, "_unit_file_installed", return_value=True
+        ),
+        "shim": mock.patch.object(job_runner, "_is_executable", return_value=True),
+        "active": mock.patch.object(
+            job_runner, "_unit_is_active", return_value=unit_active
+        ),
+    }
+    defaults.update(overrides)
+    return list(defaults.values())
+
+
+def _launch_template(
+    launcher: SubprocessLauncher,
+    *,
+    popen: _RecordingPopen,
+    slice_id: str = "psc-0042-template",
+    spool: str | None = None,
+    env_overrides: dict[str, str] | None = None,
+    patches=None,
+    workdir: str | None = None,
+) -> dict[str, str]:
+    """在完全受控的 seam 下跑一次 template 模式 launch，回傳現場路徑。"""
+
+    original = launcher_module.subprocess.Popen
+    launcher_module.subprocess.Popen = popen
+    created = tempfile.TemporaryDirectory() if workdir is None else None
+    root = workdir or created.name  # type: ignore[union-attr]
+    try:
+        spool_dir = spool if spool is not None else str(Path(root) / "job-specs")
+        Path(spool_dir).mkdir(parents=True, exist_ok=True)
+        env = _template_env(spool_dir, **(env_overrides or {}))
+        log_dir = str(Path(root) / "logs")
+        with mock.patch.dict(os.environ, env, clear=True):
+            with _nested(_preflight_patches() if patches is None else patches):
+                launcher.launch(
+                    slice_id=slice_id,
+                    prompt="PROMPT",
+                    worktree=root,
+                    log_dir=log_dir,
+                )
+        return {
+            "root": root,
+            "spool": spool_dir,
+            "log_dir": log_dir,
+            "log_path": str(Path(log_dir) / f"{slice_id}.jsonl"),
+        }
+    finally:
+        launcher_module.subprocess.Popen = original
+        if created is not None:
+            created.cleanup()
+
+
+def _only_spec(spool: str) -> dict:
+    files = sorted(Path(spool).glob("*.json"))
+    assert len(files) == 1, files
+    return json.loads(files[0].read_text(encoding="utf-8"))
+
+
+# ---------------------------------------------------------------------------
+# A：三分 UID 定案
+# ---------------------------------------------------------------------------
+
+class ThreeWaySchemeIsTheDecisionTests(unittest.TestCase):
+    def test_default_scheme_is_three_way(self) -> None:
+        self.assertIs(permgen.DEFAULT_SCHEME, permgen.THREE_WAY_SCHEME)
+        self.assertEqual(permgen.DEFAULT_SCHEME_ID, "three-way")
+
+    def test_three_way_splits_the_model_personas_off_the_spawn_authority(self) -> None:
+        """裁決的判準：持 spawn 授權的帳號不得跑任何模型程式碼。"""
+        scheme = permgen.DEFAULT_SCHEME
+        manager = scheme.durable_state_owner
+        self.assertEqual(manager, "cortex-manager")
+        # polkit 的 subject（＝持 start 授權者）就是 durable_state_owner。
+        rule = permgen.build_polkit_rule(scheme)
+        self.assertEqual(rule.subject_account, manager)
+        # 三個跑模型的 persona 全部落在其他帳號。
+        for persona in (Principal.BUILDER, Principal.REVIEWER, Principal.PLANNER):
+            self.assertNotEqual(scheme.resolve(persona), manager, persona)
+
+    def test_two_way_remains_available_for_backwards_compatibility(self) -> None:
+        self.assertIn("two-way", permgen.SCHEMES)
+        self.assertEqual(permgen.SCHEMES["two-way"], permgen.TWO_WAY_SCHEME)
+
+    def test_cli_defaults_to_three_way_and_two_way_needs_an_explicit_token(self) -> None:
+        from paulsha_cortex.trust_root.__main__ import main
+
+        for argv, expected in (
+            (["unit", "--job"], "cortex-builder"),
+            (["unit", "--manager"], "cortex-manager"),
+            (["unit", "two-way", "--manager"], "cortex-svc"),
+        ):
+            with mock.patch("sys.stdout") as out:
+                self.assertEqual(main(argv), 0)
+            printed = "".join(
+                str(call.args[0]) for call in out.write.call_args_list if call.args
+            )
+            self.assertIn(f"User={expected}", printed, argv)
+
+    def test_cli_polkit_defaults_to_plan_b(self) -> None:
+        from paulsha_cortex.trust_root.__main__ import main
+
+        with mock.patch("sys.stdout") as out:
+            self.assertEqual(main(["polkit"]), 0)
+        printed = "".join(
+            str(call.args[0]) for call in out.write.call_args_list if call.args
+        )
+        self.assertIn("方案 B", printed)
+        self.assertIn("cortex-job@", printed)
+
+    def test_every_permgen_invariant_runs_on_three_way(self) -> None:
+        """三分下同一套 policy 仍成立：headless 帳號對 Manager-owned 樹零寫入。"""
+        scheme = permgen.DEFAULT_SCHEME
+        plan = permgen.generate_plan(scheme)
+        headless = scheme.headless_accounts()
+        self.assertEqual(len(plan.entries), len(registry.ASSET_REGISTRY))
+        for entry in plan.entries:
+            if entry.owner_class is not permgen.OwnerClass.MANAGER_STATE:
+                continue
+            self.assertFalse(
+                plan.all_writable_accounts(entry) & headless,
+                (entry.asset_id, plan.all_writable_accounts(entry)),
+            )
+
+
+class PolkitPlanBTests(unittest.TestCase):
+    """B 案的 polkit 輸出：subject／action／verb／unit pattern 全部收窄。"""
+
+    def _rule(self):
+        return permgen.build_polkit_rule(
+            permgen.DEFAULT_SCHEME, permgen.DEFAULT_LAYOUT, plan=permgen.PolkitPlan.TEMPLATE
+        )
+
+    def test_subject_is_cortex_manager(self) -> None:
+        rule = self._rule()
+        self.assertEqual(rule.subject_account, "cortex-manager")
+        self.assertIn('subject.user !== "cortex-manager"', rule.content)
+
+    def test_action_and_verbs(self) -> None:
+        rule = self._rule()
+        self.assertEqual(rule.allowed_verbs, ("start", "stop"))
+        self.assertIn(
+            'action.id !== "org.freedesktop.systemd1.manage-units"', rule.content
+        )
+        for verb in ("reload", "mask", "set-property", "restart"):
+            self.assertEqual(
+                permgen.evaluate_polkit(
+                    rule,
+                    user="cortex-manager",
+                    action_id=permgen.POLKIT_ACTION,
+                    unit="cortex-job@x.service",
+                    verb=verb,
+                ),
+                "NO",
+                verb,
+            )
+
+    def test_unit_pattern_is_the_template_instance_shape(self) -> None:
+        rule = self._rule()
+        self.assertTrue(rule.unit_pattern.startswith("^cortex-job@"))
+        self.assertEqual(
+            permgen.evaluate_polkit(
+                rule,
+                user="cortex-manager",
+                action_id=permgen.POLKIT_ACTION,
+                unit="cortex-job@psc-0042-deadbeef.service",
+                verb="start",
+            ),
+            "YES",
+        )
+
+    def test_transient_units_are_never_authorised(self) -> None:
+        """B 案的重點：manage-units 對 transient unit 一律不放行。
+
+        transient 有兩種形狀會出現在 `action.lookup("unit")`：A 案自己命名的
+        `cortex-job-<id>.service`，以及 systemd 對匿名 transient 自動生成的
+        `run-uNNNN.service`。兩者都必須是 NO，否則「不能傳 User=root」就破功了。
+        """
+        rule = self._rule()
+        for unit in (
+            "cortex-job-psc-0042-deadbeef.service",
+            "run-u1234.service",
+            "run-r9c0ffee.service",
+            "cortex-job.service",
+        ):
+            self.assertEqual(
+                permgen.evaluate_polkit(
+                    rule,
+                    user="cortex-manager",
+                    action_id=permgen.POLKIT_ACTION,
+                    unit=unit,
+                    verb="start",
+                ),
+                "NO",
+                unit,
+            )
+        # 明細缺席（StartTransientUnit 的 polkit 檢查不帶 unit 明細）→ 拒。
+        self.assertEqual(
+            permgen.evaluate_polkit(
+                rule, user="cortex-manager", action_id=permgen.POLKIT_ACTION,
+                unit=None, verb=None,
+            ),
+            "NO",
+        )
+
+    def test_plan_b_has_no_residual_os_level_risk(self) -> None:
+        self.assertEqual(self._rule().residual_risks, ())
+
+
+class SchemeDerivedHomeTests(unittest.TestCase):
+    """三分定案暴露的兩個既有缺口（#614 runbook 實測）——HOME 與 scaffold。
+
+    兩者的根是同一條：帳號相關路徑被寫成二分時代的字面量，換 scheme 就漂移。
+    修法也是同一條：由 `scheme` 現場導出，不列舉。
+    """
+
+    def test_manager_home_follows_the_scheme_account(self) -> None:
+        layout = permgen.DEFAULT_LAYOUT
+        two = permgen.build_manager_unit(permgen.TWO_WAY_SCHEME, layout)
+        three = permgen.build_manager_unit(permgen.THREE_WAY_SCHEME, layout)
+        self.assertIn("Environment=HOME=/var/lib/cortex-svc\n", two.content)
+        self.assertIn("Environment=HOME=/var/lib/cortex-manager\n", three.content)
+        self.assertIn("Environment=XDG_CACHE_HOME=/var/lib/cortex-manager/cache\n", three.content)
+        # 三分下絕不可再出現二分時代的帳號樹。
+        self.assertNotIn("cortex-svc", three.content)
+
+    def test_job_home_follows_the_resolved_job_account(self) -> None:
+        layout = permgen.DEFAULT_LAYOUT
+        unit = permgen.build_job_unit(permgen.THREE_WAY_SCHEME, layout)
+        self.assertIn("Environment=HOME=/var/lib/cortex-builder\n", unit.content)
+        self.assertIn(
+            "Environment=XDG_CACHE_HOME=/var/lib/cortex-builder/cache\n", unit.content
+        )
+
+    def test_scaffold_covers_every_account_the_scheme_resolves(self) -> None:
+        for scheme, expected in (
+            (permgen.TWO_WAY_SCHEME, {"cortex-svc", "cortex-builder"}),
+            (
+                permgen.THREE_WAY_SCHEME,
+                {"cortex-manager", "cortex-reviewer-planner", "cortex-builder"},
+            ),
+        ):
+            dirs = permgen.DEFAULT_LAYOUT.scaffold_directories(scheme)
+            by_path = {path: (owner, mode) for path, owner, _g, mode in dirs}
+            for account in expected:
+                home = permgen.DEFAULT_LAYOUT.home_of(account)
+                cache = permgen.DEFAULT_LAYOUT.cache_of(account)
+                self.assertIn(home, by_path, (scheme.scheme_id, account))
+                self.assertEqual(by_path[home], ("root", 0o755), (scheme.scheme_id, account))
+                self.assertEqual(by_path[cache], (account, 0o700), (scheme.scheme_id, account))
+            # 無多餘：不得殘留任何非本 scheme 帳號的 HOME。
+            homes = {
+                p for p in by_path if p.startswith(permgen.DEFAULT_LAYOUT.home_root + "/cortex-")
+            }
+            resolved = {
+                permgen.DEFAULT_LAYOUT.home_of(a) for a in expected
+            } | {
+                permgen.DEFAULT_LAYOUT.cache_of(a) for a in expected
+            } | {
+                permgen.DEFAULT_LAYOUT.codex_hooks_dir_of(a) for a in expected
+            }
+            self.assertTrue(homes <= resolved, (scheme.scheme_id, homes - resolved))
+
+    def test_every_model_job_account_gets_a_root_owned_codex_dir(self) -> None:
+        """跑模型的帳號都不得替換自己的 `~/.codex`（hooks 是 Tier-0 資產）。"""
+        scheme = permgen.THREE_WAY_SCHEME
+        by_path = {
+            path: owner
+            for path, owner, _g, _m in permgen.DEFAULT_LAYOUT.scaffold_directories(scheme)
+        }
+        for account in ("cortex-builder", "cortex-reviewer-planner"):
+            self.assertEqual(
+                by_path[permgen.DEFAULT_LAYOUT.codex_hooks_dir_of(account)], "root", account
+            )
+
+    def test_custom_home_root_needs_no_code_change(self) -> None:
+        alt = permgen.PathLayout(home_root="/srv/homes")
+        self.assertEqual(alt.home_of("cortex-manager"), "/srv/homes/cortex-manager")
+        unit = permgen.build_manager_unit(permgen.THREE_WAY_SCHEME, alt)
+        self.assertIn("Environment=HOME=/srv/homes/cortex-manager\n", unit.content)
+
+
+class M2ExtensionPointTests(unittest.TestCase):
+    """#615（M2：reviewer/planner 啟動面降權）的第二實例化必須是換參數，不是改核心。
+
+    本 PR **不**實作 M2——這裡只釘住「擴充點存在且真的通」，避免 M2 開工時才發現
+    要動 `build_job_unit`／`build_polkit_rule` 的內部。
+    """
+
+    def test_a_second_template_instance_is_a_parameter_change(self) -> None:
+        scheme = permgen.DEFAULT_SCHEME
+        layout = permgen.DEFAULT_LAYOUT
+        unit = permgen.build_job_unit(scheme, layout, principal=Principal.REVIEWER)
+        self.assertEqual(unit.unit_name, "cortex-reviewer-job@.service")
+        self.assertEqual(unit.account, "cortex-reviewer-planner")
+        self.assertIn("User=cortex-reviewer-planner\n", unit.content)
+        self.assertIn("Environment=HOME=/var/lib/cortex-reviewer-planner\n", unit.content)
+        # 與 builder 的模板互不重疊（unit 名不同 ⇒ polkit 授權面不會被順帶擴大）。
+        builder_unit = permgen.build_job_unit(scheme, layout)
+        self.assertNotEqual(unit.unit_name, builder_unit.unit_name)
+
+    def test_a_second_polkit_grant_is_a_parameter_change(self) -> None:
+        scheme = permgen.DEFAULT_SCHEME
+        rule = permgen.build_polkit_rule(
+            scheme, plan=permgen.PolkitPlan.TEMPLATE, principal=Principal.REVIEWER
+        )
+        self.assertTrue(rule.unit_pattern.startswith("^cortex-reviewer-job@"))
+        self.assertEqual(rule.target_account, "cortex-reviewer-planner")
+        # builder 的規則不放行 reviewer 的模板實例，反之亦然。
+        builder_rule = permgen.build_polkit_rule(scheme, plan=permgen.PolkitPlan.TEMPLATE)
+        self.assertEqual(
+            permgen.evaluate_polkit(
+                builder_rule,
+                user=builder_rule.subject_account,
+                action_id=permgen.POLKIT_ACTION,
+                unit="cortex-reviewer-job@x.service",
+                verb="start",
+            ),
+            "NO",
+        )
+
+    def test_builder_stem_is_unchanged_by_the_extension_point(self) -> None:
+        self.assertEqual(
+            permgen.job_unit_stem(permgen.DEFAULT_LAYOUT, Principal.BUILDER), "cortex-job"
+        )
+        self.assertEqual(
+            job_runner.DEFAULT_TEMPLATE_UNIT,
+            f"{permgen.job_unit_stem(permgen.DEFAULT_LAYOUT)}@.service",
+        )
+
+    def test_runner_side_second_instance_is_pure_config(self) -> None:
+        """啟動器側的第二實例化＝三個 env，不動一行程式碼。"""
+        env = {
+            job_runner.TEMPLATE_UNIT_ENV: "cortex-reviewer-job@.service",
+            job_runner.BUILDER_ACCOUNT_ENV: "cortex-reviewer-planner",
+        }
+        self.assertEqual(
+            job_runner.resolve_template_unit(env), "cortex-reviewer-job@.service"
+        )
+        self.assertEqual(
+            job_runner.resolve_builder_account(env), "cortex-reviewer-planner"
+        )
+        self.assertEqual(
+            job_runner.template_unit_name(
+                "demo-deadbeef", template=job_runner.resolve_template_unit(env)
+            ),
+            "cortex-reviewer-job@demo-deadbeef.service",
+        )
+
+
+# ---------------------------------------------------------------------------
+# B：spool 資產入登記表
+# ---------------------------------------------------------------------------
+
+class JobSpecSpoolAssetTests(unittest.TestCase):
+    def test_asset_is_registered_and_manager_owned(self) -> None:
+        asset = registry.asset_by_id("job-spec-spool")
+        self.assertIs(asset.tree, registry.TrustTree.MANAGER_OWNED)
+        self.assertEqual(asset.writers, (Principal.MANAGER,))
+        self.assertIn(Principal.BUILDER, asset.readers)
+        self.assertEqual(
+            asset.path_resolver, "paulsha_cortex.config.paths:job_spec_spool_root"
+        )
+
+    def test_registry_equation_still_holds(self) -> None:
+        result = registry.check_registry_equation()
+        self.assertTrue(result.ok, result.failure_summary())
+
+    def test_builder_has_zero_write_on_the_spool(self) -> None:
+        """permgen 不變式：builder 只讀得到 spec，改不了自己的命令列。"""
+        for scheme in (permgen.DEFAULT_SCHEME, permgen.TWO_WAY_SCHEME):
+            plan = permgen.generate_plan(scheme)
+            entry = plan.by_id("job-spec-spool")
+            builder = scheme.resolve(Principal.BUILDER)
+            writable = plan.all_writable_accounts(entry)
+            self.assertEqual(writable, frozenset({scheme.durable_state_owner}), scheme.scheme_id)
+            self.assertNotIn(builder, writable, scheme.scheme_id)
+            # 讀得到：owner-only mode ＋ per-account 唯讀 ACL。
+            self.assertEqual(entry.mode, 0o700, scheme.scheme_id)
+            acl = {a.account: a.perms for a in entry.acls}
+            self.assertEqual(acl.get(builder), "rX", scheme.scheme_id)
+            self.assertFalse(any(a.writable for a in entry.acls), scheme.scheme_id)
+
+    def test_layout_path_matches_the_path_contract(self) -> None:
+        expected_dirname = config_paths.JOB_SPEC_SPOOL_DIRNAME
+        self.assertTrue(
+            permgen.DEFAULT_LAYOUT.job_spec_spool_root.endswith("/" + expected_dirname)
+        )
+        self.assertEqual(
+            permgen.DEFAULT_LAYOUT.asset_paths()["job-spec-spool"],
+            permgen.DEFAULT_LAYOUT.job_spec_spool_root,
+        )
+
+    def test_spool_is_not_writable_from_the_job_unit(self) -> None:
+        unit = permgen.build_job_unit(permgen.DEFAULT_SCHEME, permgen.DEFAULT_LAYOUT)
+        for rwp in unit.read_write_paths:
+            self.assertFalse(
+                permgen.DEFAULT_LAYOUT.job_spec_spool_root.startswith(rwp.rstrip("/") + "/")
+                or permgen.DEFAULT_LAYOUT.job_spec_spool_root == rwp,
+                rwp,
+            )
+
+
+class JobRunnerPermgenContractTests(unittest.TestCase):
+    """`job_runner` 的模板常數與 permgen layout 是成對契約（不得漂移）。"""
+
+    def test_defaults_match_the_layout(self) -> None:
+        layout = permgen.DEFAULT_LAYOUT
+        self.assertEqual(job_runner.DEFAULT_JOB_SPEC_SPOOL, layout.job_spec_spool_root)
+        self.assertEqual(job_runner.DEFAULT_JOB_SHIM, layout.job_shim)
+        self.assertEqual(
+            job_runner.DEFAULT_TEMPLATE_UNIT,
+            permgen.build_job_unit(permgen.DEFAULT_SCHEME, layout).unit_name,
+        )
+
+    def test_generated_instance_matches_the_polkit_pattern(self) -> None:
+        rule = permgen.build_polkit_rule(
+            permgen.DEFAULT_SCHEME, plan=permgen.PolkitPlan.TEMPLATE
+        )
+        for job_id in ("psc-0042-template", "workflow/abc def", "9-leading-digit"):
+            instance = job_runner.template_instance_id(job_id)
+            unit = job_runner.template_unit_name(instance)
+            self.assertEqual(
+                permgen.evaluate_polkit(
+                    rule,
+                    user=rule.subject_account,
+                    action_id=permgen.POLKIT_ACTION,
+                    unit=unit,
+                    verb="start",
+                ),
+                "YES",
+                (job_id, unit),
+            )
+
+    def test_builder_account_default_matches_three_way(self) -> None:
+        self.assertEqual(
+            job_runner.resolve_builder_account({}),
+            permgen.DEFAULT_SCHEME.resolve(Principal.BUILDER),
+        )
+
+
+# ---------------------------------------------------------------------------
+# B：instance 名與 argv
+# ---------------------------------------------------------------------------
+
+class TemplateInstanceNameTests(unittest.TestCase):
+    def test_instance_is_traceable_and_unique(self) -> None:
+        a = job_runner.template_instance_id("psc-0042-template")
+        b = job_runner.template_instance_id("psc/0042 template")
+        self.assertIn("psc-0042-template", a)
+        self.assertNotEqual(a, b, "消毒後撞形也不得撞名（sha8 後綴）")
+        self.assertTrue(job_runner.instance_name_valid(a))
+        self.assertTrue(job_runner.instance_name_valid(b))
+
+    def test_empty_job_id_is_fail_closed(self) -> None:
+        with self.assertRaises(JobRunnerError) as ctx:
+            job_runner.template_instance_id("   ")
+        self.assertEqual(
+            ctx.exception.diagnostic.reason, "job-runner-instance-name-invalid"
+        )
+
+    def test_instance_never_carries_shell_or_unit_metacharacters(self) -> None:
+        instance = job_runner.template_instance_id("a b;rm -rf /@x$(id)`id`")
+        self.assertNotIn("@", instance)
+        self.assertNotIn(";", instance)
+        self.assertNotIn("$", instance)
+        self.assertNotIn("/", instance)
+
+    def test_template_unit_name_composition(self) -> None:
+        self.assertEqual(
+            job_runner.template_unit_name("demo-deadbeef"),
+            "cortex-job@demo-deadbeef.service",
+        )
+
+    def test_malformed_template_config_is_fail_closed(self) -> None:
+        with self.assertRaises(JobRunnerError) as ctx:
+            job_runner.template_unit_name("demo", template="cortex-job.service")
+        self.assertEqual(
+            ctx.exception.diagnostic.reason, "job-runner-template-unit-invalid"
+        )
+
+    def test_injected_instance_is_rejected(self) -> None:
+        with self.assertRaises(JobRunnerError) as ctx:
+            job_runner.template_unit_name("evil@other")
+        self.assertEqual(
+            ctx.exception.diagnostic.reason, "job-runner-instance-name-invalid"
+        )
+
+
+class SystemctlArgvTests(unittest.TestCase):
+    def test_argv_is_closed(self) -> None:
+        argv = job_runner.build_systemctl_start_argv(
+            systemctl="/usr/bin/systemctl", unit="cortex-job@demo.service"
+        )
+        self.assertEqual(
+            argv,
+            [
+                "/usr/bin/systemctl",
+                "start",
+                "--wait",
+                "--no-ask-password",
+                "cortex-job@demo.service",
+            ],
+        )
+
+    def test_argv_never_carries_identity_or_properties(self) -> None:
+        argv = job_runner.build_systemctl_start_argv(
+            systemctl="/usr/bin/systemctl", unit="cortex-job@demo.service"
+        )
+        joined = " ".join(argv)
+        for forbidden in ("--uid", "--gid", "--property", "--setenv", "-p ", "--no-block"):
+            self.assertNotIn(forbidden, joined, forbidden)
+
+
+# ---------------------------------------------------------------------------
+# B：spec 內容
+# ---------------------------------------------------------------------------
+
+class JobSpecContentTests(unittest.TestCase):
+    def test_launch_writes_one_spec_and_starts_the_instance(self) -> None:
+        popen = _RecordingPopen()
+        ctx = _launch_template(SubprocessLauncher("codex"), popen=popen)
+        argv = popen.call["argv"]
+        self.assertEqual(argv[:4], ["/usr/bin/systemctl", "start", "--wait", "--no-ask-password"])
+        self.assertTrue(argv[4].startswith("cortex-job@"))
+        self.assertTrue(argv[4].endswith(".service"))
+        self.assertEqual(popen.call["cwd"], None)
+        self.assertEqual(popen.call["stdin"], subprocess.DEVNULL)
+
+    def test_spec_never_carries_identity(self) -> None:
+        """User 不在 spec 裡——它在 root-owned 的 unit 檔。"""
+        with tempfile.TemporaryDirectory() as d:
+            _launch_template(SubprocessLauncher("codex"), popen=_RecordingPopen(), workdir=d)
+            spec = _only_spec(str(Path(d) / "job-specs"))
+        for key in job_runner.SPEC_FORBIDDEN_KEYS:
+            self.assertNotIn(key, spec, key)
+        blob = json.dumps(spec, ensure_ascii=False)
+        for token in ("cortex-builder", "User=", "--uid"):
+            self.assertNotIn(token, blob, token)
+
+    def test_spec_env_has_no_credentials(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            _launch_template(SubprocessLauncher("copilot"), popen=_RecordingPopen(), workdir=d)
+            spec = _only_spec(str(Path(d) / "job-specs"))
+        env = spec["env"]
+        for name in _SECRET_ENV:
+            self.assertNotIn(name, env, name)
+        blob = json.dumps(spec, ensure_ascii=False)
+        for value in _SECRET_ENV.values():
+            self.assertNotIn(value, blob, value)
+
+    def test_spec_carries_command_worktree_log_and_whitelisted_env(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            ctx = _launch_template(
+                SubprocessLauncher("codex"), popen=_RecordingPopen(), workdir=d
+            )
+            spec = _only_spec(str(Path(d) / "job-specs"))
+        self.assertEqual(spec["spec_version"], job_runner.JOB_SPEC_VERSION)
+        self.assertEqual(spec["command"][:2], ["bash", "-c"])
+        self.assertEqual(spec["working_directory"], ctx["root"])
+        self.assertEqual(spec["log_path"], ctx["log_path"])
+        self.assertEqual(spec["env"]["PATH"], _BASE_ENV["PATH"])
+        self.assertEqual(spec["env"]["PSC_JOB_ID"], "psc-0042-template")
+        self.assertEqual(spec["unit"], job_runner.template_unit_name(spec["instance"]))
+
+    def test_spec_uses_bash_c_not_login_shell(self) -> None:
+        """#588 第 2 點：降權模式一律 `bash -c`（login shell 會重新匯入 ~/.profile）。"""
+        with tempfile.TemporaryDirectory() as d:
+            _launch_template(SubprocessLauncher("codex"), popen=_RecordingPopen(), workdir=d)
+            spec = _only_spec(str(Path(d) / "job-specs"))
+        self.assertEqual(spec["command"][1], "-c")
+        self.assertNotEqual(spec["command"][1], "-lc")
+
+    def test_spec_file_is_readable_by_the_job_account(self) -> None:
+        """mode 必須留下 group-read 位，否則繼承的唯讀 ACL 會被 mask 掉。"""
+        with tempfile.TemporaryDirectory() as d:
+            _launch_template(SubprocessLauncher("codex"), popen=_RecordingPopen(), workdir=d)
+            spec_file = sorted(Path(d, "job-specs").glob("*.json"))[0]
+            mode = stat.S_IMODE(spec_file.stat().st_mode)
+        self.assertEqual(mode, 0o640)
+
+    def test_spec_write_is_atomic_and_leaves_no_temp_file(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            _launch_template(SubprocessLauncher("codex"), popen=_RecordingPopen(), workdir=d)
+            leftovers = [p.name for p in Path(d, "job-specs").iterdir()]
+        self.assertEqual(len(leftovers), 1, leftovers)
+        self.assertTrue(leftovers[0].endswith(".json"), leftovers)
+
+    def test_build_job_spec_rejects_relative_paths_and_empty_command(self) -> None:
+        base = {
+            "job_id": "j",
+            "instance": "j-deadbeef",
+            "unit": "cortex-job@j-deadbeef.service",
+            "command": ["bash", "-c", "true"],
+            "working_directory": "/wt",
+            "log_path": "/logs/j.jsonl",
+            "env": {"PATH": "/usr/bin"},
+        }
+        for override in (
+            {"command": []},
+            {"command": ["bash", ""]},
+            {"working_directory": "relative/wt"},
+            {"log_path": "relative.jsonl"},
+        ):
+            with self.assertRaises(JobRunnerError) as ctx:
+                job_runner.build_job_spec(**{**base, **override})
+            self.assertEqual(
+                ctx.exception.diagnostic.reason, "job-runner-job-spec-invalid", override
+            )
+
+    def test_build_job_spec_rejects_credential_env(self) -> None:
+        with self.assertRaises(JobRunnerError) as ctx:
+            job_runner.build_job_spec(
+                job_id="j",
+                instance="j-deadbeef",
+                unit="cortex-job@j-deadbeef.service",
+                command=["bash", "-c", "true"],
+                working_directory="/wt",
+                log_path="/logs/j.jsonl",
+                env={"PATH": "/usr/bin", "GH_TOKEN": "leak"},
+            )
+        self.assertEqual(
+            ctx.exception.diagnostic.reason, "job-runner-credential-env-leak"
+        )
+
+
+# ---------------------------------------------------------------------------
+# B：fail-fast 三案
+# ---------------------------------------------------------------------------
+
+class TemplateFailFastTests(unittest.TestCase):
+    def _expect_fail(self, *, reason: str, patches, spool: str | None = None) -> None:
+        popen = _RecordingPopen()
+        with self.assertRaises(JobRunnerError) as ctx:
+            _launch_template(
+                SubprocessLauncher("codex"), popen=popen, patches=patches, spool=spool
+            )
+        self.assertEqual(ctx.exception.diagnostic.reason, reason)
+        self.assertEqual(popen.calls, [], "fail-closed：一個 job 都不得被 spawn")
+
+    def test_template_unit_not_installed(self) -> None:
+        self._expect_fail(
+            reason="job-runner-job-template-missing",
+            patches=_preflight_patches(
+                unit_file=mock.patch.object(
+                    job_runner, "_unit_file_installed", return_value=False
+                )
+            ),
+        )
+
+    def test_shim_not_installed(self) -> None:
+        self._expect_fail(
+            reason="job-runner-job-shim-missing",
+            patches=_preflight_patches(
+                shim=mock.patch.object(job_runner, "_is_executable", return_value=False)
+            ),
+        )
+
+    def test_instance_already_running(self) -> None:
+        self._expect_fail(
+            reason="job-runner-template-instance-busy",
+            patches=_preflight_patches(unit_active=True),
+        )
+
+    def test_spec_spool_missing(self) -> None:
+        popen = _RecordingPopen()
+        with tempfile.TemporaryDirectory() as d:
+            missing = str(Path(d) / "no-such-spool")
+            with self.assertRaises(JobRunnerError) as ctx:
+                _launch_template(
+                    SubprocessLauncher("codex"),
+                    popen=popen,
+                    patches=_preflight_patches(),
+                    env_overrides={job_runner.JOB_SPEC_SPOOL_ENV: missing},
+                    workdir=d,
+                )
+        self.assertEqual(
+            ctx.exception.diagnostic.reason, "job-runner-job-spec-spool-missing"
+        )
+        self.assertEqual(popen.calls, [])
+
+    def test_spec_write_failure_is_fail_closed(self) -> None:
+        popen = _RecordingPopen()
+        boom = mock.patch.object(
+            job_runner.os, "replace", side_effect=OSError("read-only file system")
+        )
+        with self.assertRaises(JobRunnerError) as ctx:
+            _launch_template(
+                SubprocessLauncher("codex"),
+                popen=popen,
+                patches=_preflight_patches() + [boom],
+            )
+        self.assertEqual(
+            ctx.exception.diagnostic.reason, "job-runner-job-spec-write-failed"
+        )
+        self.assertEqual(popen.calls, [], "spec 寫不進去就不得 spawn")
+
+    def test_systemctl_missing_is_fail_closed(self) -> None:
+        self._expect_fail(
+            reason="job-runner-systemctl-missing",
+            patches=_preflight_patches(
+                which=mock.patch.object(job_runner.shutil, "which", return_value=None)
+            ),
+        )
+
+    def test_never_falls_back_to_another_mode(self) -> None:
+        """fail-closed 的定義：不是「換一種方式跑」，是「不跑」。"""
+        src = Path(job_runner.__file__).read_text(encoding="utf-8")
+        for fallback in ("RUNNER_DIRECT\n        return", "except JobRunnerError"):
+            self.assertNotIn(fallback, src, fallback)
+
+    def test_start_confirmation_is_fail_closed_without_sentinel(self) -> None:
+        with self.assertRaises(JobRunnerError) as ctx:
+            job_runner.confirm_template_instance_started(
+                process=_FakeProc(exit_status=1),
+                sentinel="/nonexistent/sentinel",
+                unit="cortex-job@demo.service",
+                account="cortex-builder",
+                timeout_ms=0,
+                monotonic=lambda: 0.0,
+                sleep=lambda _s: None,
+            )
+        diagnostic = ctx.exception.diagnostic
+        self.assertEqual(
+            diagnostic.reason, "job-runner-template-instance-start-failed"
+        )
+        self.assertEqual(diagnostic.context["unit"], "cortex-job@demo.service")
+        self.assertIn("journalctl", diagnostic.detail)
+
+    def test_polkit_denial_text_reaches_the_diagnostic(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            log_path = Path(d) / "job.jsonl"
+            log_path.write_text(
+                "Failed to start cortex-job@x.service: Access denied\n", encoding="utf-8"
+            )
+            with self.assertRaises(JobRunnerError) as ctx:
+                job_runner.confirm_template_instance_started(
+                    process=_FakeProc(exit_status=1),
+                    sentinel=str(Path(d) / "missing.exit"),
+                    unit="cortex-job@x.service",
+                    account="cortex-builder",
+                    log_path=str(log_path),
+                    timeout_ms=0,
+                    monotonic=lambda: 0.0,
+                    sleep=lambda _s: None,
+                )
+        self.assertIn("Access denied", ctx.exception.diagnostic.detail)
+
+    def test_fast_job_with_sentinel_is_not_a_failure(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            sentinel = Path(d) / "job.exit"
+            sentinel.write_text("0", encoding="utf-8")
+            job_runner.confirm_template_instance_started(
+                process=_FakeProc(exit_status=0),
+                sentinel=str(sentinel),
+                unit="cortex-job@x.service",
+                account="cortex-builder",
+                timeout_ms=200,
+                monotonic=lambda: 0.0,
+                sleep=lambda _s: None,
+            )
+
+
+# ---------------------------------------------------------------------------
+# harvest 相容：log／sentinel 路徑不變
+# ---------------------------------------------------------------------------
+
+class HarvestCompatibilityTests(unittest.TestCase):
+    def test_log_and_sentinel_paths_are_unchanged(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            ctx = _launch_template(
+                SubprocessLauncher("codex"), popen=_RecordingPopen(), workdir=d
+            )
+            spec = _only_spec(ctx["spool"])
+        # harvest（`dispatcher.poll_headless_done` → `_read_exit_sentinel`）讀的是
+        # `<log_dir>/<slice>.jsonl` 與同名 `.exit`——兩者都必須與 direct 模式一致。
+        self.assertEqual(spec["log_path"], str(Path(ctx["log_dir"]) / "psc-0042-template.jsonl"))
+        self.assertIn(
+            str(Path(ctx["log_dir"]) / "psc-0042-template.exit"),
+            spec["command"][2],
+        )
+
+    def test_log_file_is_truncated_then_appended(self) -> None:
+        """systemctl client 用 append fd，避免蓋掉 shim 已經寫進去的內容。"""
+        with tempfile.TemporaryDirectory() as d:
+            log_dir = Path(d) / "logs"
+            log_dir.mkdir(parents=True)
+            stale = log_dir / "psc-0042-template.jsonl"
+            stale.write_text("STALE FROM LAST ROUND\n", encoding="utf-8")
+            _launch_template(SubprocessLauncher("codex"), popen=_RecordingPopen(), workdir=d)
+            self.assertEqual(stale.read_text(encoding="utf-8"), "")
+
+
+# ---------------------------------------------------------------------------
+# 零回歸：direct 與 systemd-run
+# ---------------------------------------------------------------------------
+
+class NoRegressionTests(unittest.TestCase):
+    def test_mode_table_extends_without_reordering(self) -> None:
+        self.assertEqual(job_runner.RUNNER_MODES[0], job_runner.RUNNER_DIRECT)
+        self.assertEqual(job_runner.RUNNER_MODES[1], job_runner.RUNNER_SYSTEMD_RUN)
+        self.assertEqual(job_runner.RUNNER_MODES[2], job_runner.RUNNER_SYSTEMD_TEMPLATE)
+        self.assertEqual(job_runner.resolve_runner_mode({}), job_runner.RUNNER_DIRECT)
+
+    def test_default_is_still_direct_with_login_shell(self) -> None:
+        popen = _RecordingPopen()
+        original = launcher_module.subprocess.Popen
+        launcher_module.subprocess.Popen = popen
+        try:
+            with tempfile.TemporaryDirectory() as d, mock.patch.dict(
+                os.environ, dict(_BASE_ENV), clear=True
+            ):
+                SubprocessLauncher("codex").launch(
+                    slice_id="psc-0001-demo",
+                    prompt="PROMPT",
+                    worktree=d,
+                    log_dir=str(Path(d) / "logs"),
+                )
+        finally:
+            launcher_module.subprocess.Popen = original
+        self.assertEqual(popen.call["argv"][:2], ["bash", "-lc"])
+        self.assertNotIn("stdin", popen.call)
+
+    def test_template_mode_string_is_the_only_new_trigger(self) -> None:
+        for value in ("systemd_template", "template", "systemd-templates"):
+            with self.assertRaises(JobRunnerError):
+                job_runner.resolve_runner_mode({job_runner.JOB_RUNNER_ENV: value})
+        self.assertEqual(
+            job_runner.resolve_runner_mode(
+                {job_runner.JOB_RUNNER_ENV: "SYSTEMD-TEMPLATE"}
+            ),
+            job_runner.RUNNER_SYSTEMD_TEMPLATE,
+        )
+
+    def test_systemd_run_mode_still_produces_the_transient_argv(self) -> None:
+        popen = _RecordingPopen()
+        original = launcher_module.subprocess.Popen
+        launcher_module.subprocess.Popen = popen
+        env = {
+            **_BASE_ENV,
+            **_SECRET_ENV,
+            job_runner.JOB_RUNNER_ENV: job_runner.RUNNER_SYSTEMD_RUN,
+        }
+        patches = [
+            mock.patch.object(
+                job_runner.shutil, "which", return_value="/usr/bin/systemd-run"
+            ),
+            mock.patch.object(job_runner, "_systemd_booted", return_value=True),
+            mock.patch.object(job_runner, "_account_exists", return_value=True),
+            mock.patch.object(job_runner, "_group_exists", return_value=True),
+        ]
+        try:
+            with tempfile.TemporaryDirectory() as d, mock.patch.dict(
+                os.environ, env, clear=True
+            ):
+                with _nested(patches):
+                    SubprocessLauncher("codex").launch(
+                        slice_id="psc-0001-demo",
+                        prompt="PROMPT",
+                        worktree=d,
+                        log_dir=str(Path(d) / "logs"),
+                    )
+        finally:
+            launcher_module.subprocess.Popen = original
+        argv = popen.call["argv"]
+        self.assertEqual(argv[0], "/usr/bin/systemd-run")
+        for flag in ("--pipe", "--wait", "--collect", "--uid=cortex-builder"):
+            self.assertIn(flag, argv)
+        self.assertEqual(popen.call["cwd"], os.path.realpath(popen.call["cwd"]))
+
+    def test_reviewer_and_planner_never_take_the_template_path(self) -> None:
+        for kwargs in (
+            {"review_only": True, "review_terminal_kind": "workflow-review-result"},
+            {"read_only": True},
+        ):
+            popen = _RecordingPopen()
+            launcher = SubprocessLauncher("codex", **kwargs)
+            original = launcher_module.subprocess.Popen
+            launcher_module.subprocess.Popen = popen
+            try:
+                with tempfile.TemporaryDirectory() as d, mock.patch.dict(
+                    os.environ,
+                    _template_env(str(Path(d) / "job-specs")),
+                    clear=True,
+                ):
+                    Path(d, "job-specs").mkdir(parents=True, exist_ok=True)
+                    launcher.launch(
+                        slice_id="psc-0002-review",
+                        prompt="PROMPT",
+                        worktree=d,
+                        log_dir=str(Path(d) / "logs"),
+                    )
+                    self.assertEqual(
+                        sorted(Path(d, "job-specs").iterdir()), [], kwargs
+                    )
+            finally:
+                launcher_module.subprocess.Popen = original
+            self.assertEqual(popen.call["argv"][0], "bash", kwargs)
+
+
+# ---------------------------------------------------------------------------
+# shim：stub 產生 ＋ 邏輯模組
+# ---------------------------------------------------------------------------
+
+class ShimStubTests(unittest.TestCase):
+    def test_stub_execs_the_shim_module_with_the_deploy_interpreter(self) -> None:
+        shim = permgen.build_job_shim(permgen.DEFAULT_SCHEME, permgen.DEFAULT_LAYOUT)
+        self.assertEqual(shim.install_path, "/opt/cortex/bin/cortex-job-shim")
+        self.assertEqual(shim.interpreter, "/opt/cortex/venv/bin/python3")
+        self.assertEqual(shim.module, "paulsha_cortex.coordinator.job_shim")
+        self.assertTrue(shim.content.startswith("#!/bin/sh\n"))
+        self.assertIn(
+            'exec "/opt/cortex/venv/bin/python3" -m paulsha_cortex.coordinator.job_shim "$@"',
+            shim.content,
+        )
+        # interpreter 絕不從 PATH 解析：那等於讓 job 決定用哪個 python 跑 root-owned shim。
+        self.assertNotIn("/usr/bin/env", shim.content)
+
+    def test_stub_is_root_owned_and_world_readable_only(self) -> None:
+        shim = permgen.build_job_shim(permgen.DEFAULT_SCHEME)
+        self.assertEqual(shim.owner, "root")
+        self.assertEqual(shim.mode, 0o755)
+        self.assertEqual(
+            shim.commands(),
+            [
+                "chown root:root /opt/cortex/bin/cortex-job-shim",
+                "chmod 0755 /opt/cortex/bin/cortex-job-shim",
+            ],
+        )
+
+    def test_stub_matches_the_template_unit_exec_start(self) -> None:
+        unit = permgen.build_job_unit(permgen.DEFAULT_SCHEME, permgen.DEFAULT_LAYOUT)
+        shim = permgen.build_job_shim(permgen.DEFAULT_SCHEME, permgen.DEFAULT_LAYOUT)
+        self.assertEqual(unit.exec_start, f"{shim.install_path} %i")
+
+    def test_shim_lives_in_a_root_owned_scaffold_directory(self) -> None:
+        dirs = {
+            path: (owner, mode)
+            for path, owner, _group, mode in permgen.DEFAULT_LAYOUT.scaffold_directories(
+                permgen.DEFAULT_SCHEME
+            )
+        }
+        self.assertEqual(dirs[permgen.DEFAULT_LAYOUT.bin_root], ("root", 0o755))
+
+    def test_generator_is_deterministic_and_string_only(self) -> None:
+        a = permgen.build_job_shim(permgen.DEFAULT_SCHEME)
+        b = permgen.build_job_shim(permgen.DEFAULT_SCHEME)
+        self.assertEqual(a.content, b.content)
+        self.assertEqual(a.to_dict(), b.to_dict())
+        self.assertIsInstance(a.content, str)
+
+
+class ShimLogicTests(unittest.TestCase):
+    def _spec(self, root: Path, **overrides) -> dict:
+        spec = {
+            "spec_version": job_runner.JOB_SPEC_VERSION,
+            "instance": "demo-deadbeef",
+            "job_id": "demo",
+            "unit": "cortex-job@demo-deadbeef.service",
+            "command": ["/bin/true"],
+            "working_directory": str(root),
+            "log_path": str(root / "job.jsonl"),
+            "env": {"PATH": "/usr/bin"},
+        }
+        spec.update(overrides)
+        return spec
+
+    def _write(self, spool: Path, spec: dict, name: str = "demo-deadbeef") -> None:
+        spool.mkdir(parents=True, exist_ok=True)
+        (spool / f"{name}.json").write_text(
+            json.dumps(spec, ensure_ascii=False), encoding="utf-8"
+        )
+
+    def test_load_spec_round_trips_a_manager_written_spec(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            root = Path(d)
+            spool = root / "job-specs"
+            spec = self._spec(root)
+            self._write(spool, spec)
+            loaded = job_shim.load_spec("demo-deadbeef", str(spool))
+        self.assertEqual(loaded["command"], ["/bin/true"])
+
+    def test_spec_path_is_derived_never_supplied(self) -> None:
+        self.assertEqual(
+            job_shim.resolve_spec_path("demo-deadbeef", "/var/lib/cortex/coordinator/job-specs"),
+            "/var/lib/cortex/coordinator/job-specs/demo-deadbeef.json",
+        )
+        for evil in ("../../etc/shadow", "a/b", "", "x" * 200):
+            with self.assertRaises(job_shim.ShimError, msg=evil):
+                job_shim.resolve_spec_path(evil, "/spool")
+
+    def test_symlinked_spec_is_refused(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            root = Path(d)
+            spool = root / "job-specs"
+            spool.mkdir(parents=True)
+            real = root / "elsewhere.json"
+            real.write_text(json.dumps(self._spec(root)), encoding="utf-8")
+            (spool / "demo-deadbeef.json").symlink_to(real)
+            with self.assertRaises(job_shim.ShimError):
+                job_shim.load_spec("demo-deadbeef", str(spool))
+
+    def test_identity_fields_in_spec_are_refused(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            root = Path(d)
+            spool = root / "job-specs"
+            for key in ("user", "uid", "group", "gid", "exec_start"):
+                self._write(spool, self._spec(root, **{key: "root"}))
+                with self.assertRaises(job_shim.ShimError, msg=key) as ctx:
+                    job_shim.load_spec("demo-deadbeef", str(spool))
+                self.assertIn("身分", str(ctx.exception), key)
+
+    def test_credential_env_in_spec_is_refused(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            root = Path(d)
+            spool = root / "job-specs"
+            self._write(
+                spool, self._spec(root, env={"PATH": "/usr/bin", "GH_TOKEN": "leak"})
+            )
+            with self.assertRaises(job_shim.ShimError):
+                job_shim.load_spec("demo-deadbeef", str(spool))
+
+    def test_schema_violations_are_refused(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            root = Path(d)
+            spool = root / "job-specs"
+            for override in (
+                {"spec_version": 99},
+                {"command": []},
+                {"command": "bash -c true"},
+                {"working_directory": "relative"},
+                {"log_path": "relative.jsonl"},
+                {"env": ["PATH=/usr/bin"]},
+                {"instance": "someone-elses-job"},
+            ):
+                self._write(spool, self._spec(root, **override))
+                with self.assertRaises(job_shim.ShimError, msg=str(override)):
+                    job_shim.load_spec("demo-deadbeef", str(spool))
+
+    def test_missing_required_key_is_refused(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            root = Path(d)
+            spool = root / "job-specs"
+            for key in job_runner.SPEC_REQUIRED_KEYS:
+                spec = self._spec(root)
+                spec.pop(key)
+                self._write(spool, spec)
+                with self.assertRaises(job_shim.ShimError, msg=key):
+                    job_shim.load_spec("demo-deadbeef", str(spool))
+
+    def test_absent_spool_env_is_fail_closed(self) -> None:
+        self.assertEqual(
+            job_shim.main(["demo-deadbeef"], environ={}), job_shim.EXIT_SPEC_ERROR
+        )
+
+    def test_wrong_argument_count_is_fail_closed(self) -> None:
+        for args in ([], ["a", "b"]):
+            self.assertEqual(
+                job_shim.main(args, environ={job_runner.JOB_SPEC_SPOOL_ENV: "/spool"}),
+                job_shim.EXIT_SPEC_ERROR,
+            )
+
+    def test_main_takes_over_the_log_then_execs(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            root = Path(d)
+            spool = root / "job-specs"
+            log = root / "job.jsonl"
+            log.write_text("MANAGER PREAMBLE\n", encoding="utf-8")
+            self._write(spool, self._spec(root))
+            recorded: dict = {}
+
+            def fake_exec(file, argv, env):
+                recorded["file"] = file
+                recorded["argv"] = list(argv)
+                recorded["env"] = dict(env)
+                recorded["cwd"] = os.getcwd()
+                # 走到這裡代表 log 已被接管：往 stdout 寫一行來證明它落在 log 檔。
+                os.write(1, b"FROM JOB\n")
+                raise OSError("exec stub")
+
+            saved_out, saved_err = os.dup(1), os.dup(2)
+            cwd = os.getcwd()
+            try:
+                with mock.patch.object(job_shim.os, "execvpe", fake_exec):
+                    rc = job_shim.main(
+                        ["demo-deadbeef"],
+                        environ={job_runner.JOB_SPEC_SPOOL_ENV: str(spool)},
+                    )
+            finally:
+                os.dup2(saved_out, 1)
+                os.dup2(saved_err, 2)
+                os.close(saved_out)
+                os.close(saved_err)
+                os.chdir(cwd)
+            self.assertEqual(rc, job_shim.EXIT_SPEC_ERROR)
+            self.assertEqual(recorded["file"], "/bin/true")
+            self.assertEqual(recorded["argv"], ["/bin/true"])
+            self.assertEqual(recorded["env"], {"PATH": "/usr/bin"})
+            self.assertEqual(Path(recorded["cwd"]).resolve(), root.resolve())
+            contents = log.read_text(encoding="utf-8")
+            self.assertIn("MANAGER PREAMBLE", contents, "append，不得截掉 Manager 的前導輸出")
+            self.assertIn("FROM JOB", contents)
+
+    def test_symlinked_log_is_refused(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            root = Path(d)
+            spool = root / "job-specs"
+            victim = root / "victim.txt"
+            victim.write_text("do not append here\n", encoding="utf-8")
+            (root / "job.jsonl").symlink_to(victim)
+            self._write(spool, self._spec(root))
+            rc = job_shim.main(
+                ["demo-deadbeef"], environ={job_runner.JOB_SPEC_SPOOL_ENV: str(spool)}
+            )
+        self.assertEqual(rc, job_shim.EXIT_SPEC_ERROR)
+
+    def test_shim_and_runner_share_one_schema(self) -> None:
+        """讀端與寫端的 schema 常數必須是同一份，不得各抄一遍。"""
+        self.assertIs(job_shim.JOB_SPEC_VERSION, job_runner.JOB_SPEC_VERSION)
+        self.assertIs(job_shim.SPEC_REQUIRED_KEYS, job_runner.SPEC_REQUIRED_KEYS)
+        self.assertIs(job_shim.SPEC_FORBIDDEN_KEYS, job_runner.SPEC_FORBIDDEN_KEYS)
+
+    def test_manager_written_spec_is_accepted_by_the_shim(self) -> None:
+        """端到端契約：`job_runner` 寫出的 spec，`job_shim` 必須讀得動。"""
+        with tempfile.TemporaryDirectory() as d:
+            ctx = _launch_template(
+                SubprocessLauncher("codex"), popen=_RecordingPopen(), workdir=d
+            )
+            instance = sorted(Path(ctx["spool"]).glob("*.json"))[0].stem
+            loaded = job_shim.load_spec(instance, ctx["spool"])
+        self.assertEqual(loaded["instance"], instance)
+        self.assertEqual(loaded["command"][:2], ["bash", "-c"])
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/tests/test_trust_root_permgen_p2b.py
+++ b/tests/test_trust_root_permgen_p2b.py
@@ -110,7 +110,10 @@ def test_manager_read_write_paths_have_no_redundant_entry(scheme) -> None:
     plan = generate_plan(scheme)
     unit = build_manager_unit(scheme, DEFAULT_LAYOUT)
     targets = required_write_targets(plan, DEFAULT_LAYOUT, scheme.durable_state_owner)
-    extras = {e.path for e in DEFAULT_LAYOUT.manager_extra_write_paths()}
+    extras = {
+        e.path
+        for e in DEFAULT_LAYOUT.manager_extra_write_paths(scheme.durable_state_owner)
+    }
 
     for rwp in unit.read_write_paths:
         if rwp in extras:
@@ -162,7 +165,11 @@ def test_read_write_paths_are_consistent_with_protect_home(scheme) -> None:
 
 @pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
 def test_extra_write_paths_all_carry_a_reason(scheme) -> None:
-    for extra in DEFAULT_LAYOUT.manager_extra_write_paths() + DEFAULT_LAYOUT.job_extra_write_paths():
+    builder = scheme.resolve(Principal.BUILDER)
+    assert builder is not None
+    for extra in DEFAULT_LAYOUT.manager_extra_write_paths(
+        scheme.durable_state_owner
+    ) + DEFAULT_LAYOUT.job_extra_write_paths(builder):
         assert extra.path.startswith("/")
         assert extra.reason.strip(), extra.path
 
@@ -198,7 +205,7 @@ def test_job_unit_read_write_paths_match_builder_writable_assets(scheme) -> None
     assert targets
     for asset_id, target in targets.items():
         assert any(_within(target, rwp) for rwp in unit.read_write_paths), (asset_id, target)
-    extras = {e.path for e in job_layout.job_extra_write_paths()}
+    extras = {e.path for e in job_layout.job_extra_write_paths(builder)}
     for rwp in unit.read_write_paths:
         if rwp in extras:
             continue
@@ -284,13 +291,22 @@ def test_job_unit_scrubs_github_token(scheme) -> None:
 
 
 @pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
-def test_job_unit_command_comes_from_manager_owned_spool(scheme) -> None:
-    """job 不得改寫自己的命令列：run.sh 落在 svc-owned spool，job 只讀。"""
+def test_job_unit_command_comes_from_root_owned_shim_and_manager_owned_spec(scheme) -> None:
+    """job 不得改寫自己的命令列。
+
+    0816 第三輪 A+B 之後這條的形狀變了（比原本更緊）：`ExecStart=` 不再是 spool 裡
+    的 `run.sh`，而是**固定**指向 root-owned 部署樹的 shim——連 Manager 都換不掉
+    job 執行的第一支程式。per-job 參數改走 Manager-owned 的 spec spool，job 帳號
+    對兩者皆零寫入。
+    """
     unit = build_job_unit(scheme, DEFAULT_LAYOUT)
-    assert DEFAULT_LAYOUT.job_spool_root in unit.exec_start
-    assert not any(
-        _within(DEFAULT_LAYOUT.job_spool_root, rwp) for rwp in unit.read_write_paths
-    )
+    assert unit.exec_start.startswith(DEFAULT_LAYOUT.job_shim + " ")
+    assert unit.exec_start.startswith(DEFAULT_LAYOUT.deploy_root + "/")
+    assert f"ExecStart={unit.exec_start}" in unit.content
+    # spec spool 的位置由 root-owned unit 檔宣告給 shim，且 job 側不可寫。
+    assert f"Environment=PSC_JOB_SPEC_SPOOL={DEFAULT_LAYOUT.job_spec_spool_root}" in unit.content
+    for protected in (DEFAULT_LAYOUT.job_spec_spool_root, DEFAULT_LAYOUT.deploy_root):
+        assert not any(_within(protected, rwp) for rwp in unit.read_write_paths), protected
 
 
 def test_units_are_deterministic() -> None:
@@ -500,7 +516,7 @@ def test_scaffold_directories_are_command_strings_only() -> None:
     by_path = {p: (o, m) for p, o, _g, m in dirs}
     assert by_path[DEFAULT_LAYOUT.builder_home][0] == "root"
     assert by_path[f"{DEFAULT_LAYOUT.builder_home}/.codex"][0] == "root"
-    assert by_path[DEFAULT_LAYOUT.svc_home][0] == "root"
+    assert by_path[DEFAULT_LAYOUT.home_of(TWO_WAY_SCHEME.durable_state_owner)][0] == "root"
     assert by_path[DEFAULT_LAYOUT.deploy_root][0] == "root"
 
 


### PR DESCRIPTION
## 摘要

operator 在 #584 **0816 第三輪**把降權機制裁決為 **A+B 並行**（C 自動保留為第三層）。
本 PR 是那條裁決的**程式碼側**：**A＝三分 UID 定案**、**B＝`job_runner` 的
template-instance 模式**。runbook 側由 #614（已 merge）負責，本 PR **不動 runbook**。

## ⚠️ 誠實邊界（請先讀這段）

**本 PR 是機制，不是生效。** `PSC_JOB_RUNNER` **預設仍是 `direct`**＝現行行為逐字不變，
merge 後不會有任何 job 被降權。template 模式要真的生效，需要 **Phase 2b 安裝**四樣東西
（全部是部署期動作，步驟見 #614 的 runbook）：

1. **三個帳號**：`cortex-manager`／`cortex-reviewer-planner`／`cortex-builder`；
2. **模板 unit**：`/etc/systemd/system/cortex-job@.service`（root-owned）；
3. **polkit 規則**：B 案（`--template`），授權 `cortex-manager` start/stop 該模板實例；
4. **shim**：`/opt/cortex/bin/cortex-job-shim`（root-owned, 0755）。

四樣缺任何一樣，本模式都會在**寫任何 spec 之前** fail-closed（見下方 fail-fast），
**不會**退回 `direct` 或 `systemd-run`。此外 builder 帳號仍需自己的模型 CLI 登入態
（#603 的三點誠實邊界原封不動，本 PR 未改變其中任何一條）。

## A：三分 UID 定案

`permgen.DEFAULT_SCHEME = THREE_WAY_SCHEME`。裁決的判準是**「injection 可達的任何進程
都不得持有 spawn 授權」**：

| | 二分（舊） | 三分（定案） |
|---|---|---|
| Manager／monitor | `cortex-svc` | `cortex-manager`（**持 spawn 授權，不跑任何模型程式碼**） |
| reviewer／planner | `cortex-svc` ← **與授權帳號併帳** | `cortex-reviewer-planner` |
| builder | `cortex-builder` | `cortex-builder` |

二分下 reviewer／planner 與 Manager 同帳號，任一被 prompt injection 攻陷即取得 polkit 的
`start` grant；三分把整個模型執行面移出授權帳號。

變更面：

- `DEFAULT_SCHEME`／`DEFAULT_SCHEME_ID` 新增，`trust_root` CLI 四個子命令未指定 scheme
  時一律出 `three-way`；`two-way` 保留為**需顯式打出**的向後相容選項——打錯字會落在
  `SCHEMES` 查無而拒絕，不會靜默退回較寬鬆的方案。
- **policy 一行都沒改**：兩案本來就共用同一套 `build_entry()`，既有不變式測試
  （`test_trust_root_permgen_p2a.py`／`_p2b.py` 的 `ALL_SCHEMES`）本來就對兩案逐一
  參數化跑，因此「三分照跑」是既有事實，本 PR 另加一條顯式斷言釘住它。
- polkit 產生器的**預設方案改為 B**（`PolkitPlan.TEMPLATE`），subject 隨 scheme 收斂為
  `cortex-manager`。`plan_residual_risk()` 對 B 回傳空 tuple（OS 層無殘餘）。

## B：template-instance 模式設計

### 啟動流程

```
Manager (cortex-manager)                    systemd (root)          job (cortex-builder)
──────────────────────────                  ──────────────          ────────────────────
prepare_systemd_template()   ← fail-fast，在任何副作用之前
  ├ preflight：systemctl／booted／帳號／group／模板 unit／shim／spool
  └ 同名 instance 未在跑（systemctl is-active）
build_job_spec() + write_job_spec()  原子寫入 Manager-owned spool
  <coordinator_root>/job-specs/<instance>.json   (0640, builder 唯讀 ACL)
systemctl start --wait --no-ask-password cortex-job@<instance>.service
                                          →  讀 root-owned 模板 unit
                                             User=cortex-builder   ← 硬寫死
                                             ExecStart=<shim> %i   ← 硬寫死
                                                                  →  shim 讀 spec
                                                                     接管 log／chdir
                                                                     execvpe(command)
confirm_template_instance_started()   ← client 已結束且無 sentinel ⇒ fail-closed
```

### spec spool（帶外通道）

模板 unit 的 `ExecStart=` 是**固定**的，Manager 給不了命令列，所以 per-job 參數必須走
帶外通道。spec 是**新的 R1 登記表資產** `job-spec-spool`：

- 路徑：`<coordinator_root>/job-specs/<unit-instance-id>.json`
  （`config.paths.job_spec_spool_root()`，`JOB_SPEC_SPOOL_DIRNAME = "job-specs"`）
- writer＝**只有** `Principal.MANAGER`；reader＝`MANAGER` ＋ `BUILDER`
- permgen 因此機械產出：owner＝`cortex-manager`、**mode 0700**、`u:cortex-builder:rX`
  的**唯讀** ACL、`builder` 零寫入（測試逐條斷言）
- spec 檔本身寫成 **0640**（不是靠 umask）：Manager unit 的 `UMask=0077` 會讓新檔出生即
  0600，而 group 位全關會**連帶把繼承下來的 ACL mask 也關掉**，builder 的唯讀 ACL 會變成
  形同虛設（讀 spec 直接 EACCES）。group 仍是 Manager 自己的 group，放寬 group-read 不會
  讓第三方讀到。
- 寫入是**原子**的（同目錄 `mkstemp` → `fsync` → `chmod` → `os.replace`）：spec 是 job 的
  命令列，一個被讀到一半的檔會變成「執行了半條命令」。

**spec 欄位（完整清單，`SPEC_REQUIRED_KEYS`）**：

| 欄位 | 內容 |
|---|---|
| `spec_version` | `1`（`JOB_SPEC_VERSION`；不符即拒，不靠猜相容） |
| `instance` | systemd 模板實例名；shim 會與 `%i` 比對，不符即拒 |
| `job_id` | 原始 slice/job id（可追蹤） |
| `unit` | `cortex-job@<instance>.service` |
| `command` | `["bash", "-c", <wrapper script>]`（非空 str 陣列） |
| `working_directory` | 該 job 的 worktree 絕對路徑 |
| `log_path` | `<log_dir>/<slice_id>.jsonl`——**與 direct 模式同一條路徑** |
| `env` | builder env 白名單（與 `systemd-run` 模式**同一份**，經同一條 `CREDENTIAL_ENV_RE` 守衛） |

**`SPEC_FORBIDDEN_KEYS`（結構性禁止）**：`user`／`group`／`uid`／`gid`／`User`／`Group`／
`properties`／`exec_start`。**`User=` 不在 spec 裡——它在 root-owned 的 unit 檔。** 這是 B 案
全部的價值，因此在**寫端**（`build_job_spec`）與**讀端**（`job_shim.load_spec`）各擋一次：
只在寫端自律，等於相信一個 Manager 帳號可寫的檔案沒被動過手腳。

### shim

- **stub**（permgen 產生，root-owned）：`/opt/cortex/bin/cortex-job-shim`, mode `0755`
  ```sh
  #!/bin/sh
  set -eu
  exec "/opt/cortex/venv/bin/python3" -m paulsha_cortex.coordinator.job_shim "$@"
  ```
  interpreter 寫成部署 venv 的**絕對路徑**而不是 `/usr/bin/env python3`：後者會走 job 帳號
  的 `PATH`，等於讓 job 決定用哪個 interpreter 執行 root-owned 的 shim。
- **邏輯本體**：`paulsha_cortex/coordinator/job_shim.py`（repo 內的可測模組，不是 heredoc
  字串——塞進字串就只剩「字串比對」這種驗收方式）。兩者都落在 root-owned 的部署樹裡，
  「job 改不了自己執行的第一支程式」這條性質完全不變。
- 步驟：驗 instance 名 → **`O_NOFOLLOW`** 讀 spec（且必須是普通檔、有大小上限）→ 白名單
  schema 驗證（含身分欄位與憑證 env 守衛）→ 接管 log → `chdir` → `execvpe`。
- spec 路徑**只從固定 spool 根推導**，不接受任何路徑參數；spool 根由 root-owned unit 的
  `Environment=PSC_JOB_SPEC_SPOOL=` 宣告（唯一合法來源，未設即 fail-closed，不落回
  `$HOME` 推導的預設）。

### log 導引：為什麼不是 `StandardOutput=append:`

裁決文字建議用模板的 `StandardOutput=append:` 指向 Manager 開的 log 檔。實作時發現這條會
**開一個提權面**，因此改用 shim 接管，並在 unit 檔內逐行寫明理由：

1. `file:`／`append:` 的目標檔是由 **PID 1（root）在降權之前**開啟的（`O_CREAT|O_APPEND`，
   會跟隨 symlink）。log 路徑必然含有 Manager 帳號可寫的段落，因此 Manager 只要在該位置放
   一個 symlink，就能讓 **root 對任意檔案 append**——那會把「cortex 任何元件永不具 root」
   這條裁決整個賣掉。
2. 模板是**單一靜態檔**，`append:` 只能寫死或用 `%i` 推導；而驗收要求 **harvest 讀的 log
   路徑不變**（`<log_dir>/<slice_id>.jsonl`，`log_dir` 是 launch 的參數）。兩者無法同時成立。

改法：shim 在**已降權之後**用 `O_NOFOLLOW` + `O_APPEND` 開同一個檔並 `dup2` 到 1/2。最壞
情況只是一個 builder 權限的寫入，而 harvest 路徑逐字不變。unit 這層留 `journal`，承接
shim 讀 spec 失敗（尚未接管 log 前）的診斷——`journalctl -u cortex-job@<id>.service`，
這條指令已寫進 fail-fast 的 `DiagnosticReason.detail`。

Manager 端配合：template 分支先把 log 截空、再以 **`ab`** 開檔給 systemctl client
（非 O_APPEND 的 fd 會在 shim 已寫入幾 KB 之後從 offset 0 覆蓋回去）。`direct`／
`systemd-run` 兩條路徑仍是 `wb`，逐字不變。

### 等待／判活：沿用既有機制，dispatcher 零改動

- **`--wait`**：`systemctl(1)` 明載 “For (re)start, wait until service stopped again”
  （systemd ≥ 232；本機 systemd 255 實測 `systemctl --help` 有此旗標）。client 因此存活到
  unit 結束，`dispatcher.pid_alive()` 的 `os.kill(pid, 0)` 判活與 `systemd-run --wait`
  **同語意**。
  > 裁決文字寫「template 模式沒有 `--wait --pipe`」——`--pipe` 確實沒有（已如上處理），
  > 但 `--wait` 是 `systemctl` 的真實旗標。若不用它，client 會在 unit 起動後立刻返回，
  > `poll_headless_done` 會看到「pid 已死 + 無 sentinel」而把還在跑的 job 判成 failed。
- **exit sentinel**：仍由 wrapper script 在 job 內寫入（`build_wrapper_script` 逐字未動），
  `poll_headless_done` 的第一判準完全不變。
- `confirm_template_instance_started()` 與 A 案共用 `_await_start()`：判準是「client 已結束
  **且** exit sentinel 不存在」——真的跑完的極短命 job 必然留下 sentinel，不會誤判。

### fail-fast（一律 `DiagnosticReason` fail-closed，**絕不**退回其他模式）

| 情境 | `reason` |
|---|---|
| 模板 unit 未安裝 | `job-runner-job-template-missing` |
| shim 不存在／不可執行 | `job-runner-job-shim-missing` |
| spec spool 目錄缺席 | `job-runner-job-spec-spool-missing` |
| **同名 instance 已在跑** | `job-runner-template-instance-busy` |
| spec 寫入失敗 | `job-runner-job-spec-write-failed` |
| `systemctl` 不在 PATH／未以 systemd 開機／帳號或 group 不存在 | `job-runner-systemctl-missing`／`-systemd-unavailable`／`-builder-account-missing`／`-builder-group-missing` |
| 起動失敗（polkit 拒絕、shim 讀 spec 失敗） | `job-runner-template-instance-start-failed`（帶 log tail ＋ `journalctl` 提示） |

「instance 已在跑」這條特別重要：`systemctl start` 對一個**已 active** 的 unit 會直接回 0
什麼都不做，而 `--wait` 會一路等到**那個別人的 job** 結束。少了這個檢查，Manager 會以為
自己起了一個 job。前六條全部在**寫任何 spec 之前**求值（測試斷言 `popen.calls == []`）。

## 產生器（新增／變更的 CLI）

```bash
python3 -m paulsha_cortex.trust_root permissions [three-way|two-way] [--commands] [--paths]
python3 -m paulsha_cortex.trust_root unit        [three-way|two-way] [--manager|--job|--job-properties]
python3 -m paulsha_cortex.trust_root shim        [three-way|two-way]   # ← 新增（B 案 shim stub）
python3 -m paulsha_cortex.trust_root polkit      [three-way|two-way] [--template|--transient]
python3 -m paulsha_cortex.trust_root scaffold    [three-way|two-way]
```

- **未指定 scheme 一律出 `three-way`**（原本是 `two-way`）。
- **`polkit` 未指定方案一律出 `--template`**（B 案；原本是 `--transient`）。
- 新增 `shim` 子命令 → `permgen.build_job_shim()`（回傳 `ShimScript`，含 `install_path`／
  `interpreter`／`module`／`mode`／`owner`／`commands()`）。
- 全部仍**只產生字串**，不執行任何 root 操作（`test_permgen_never_touches_the_filesystem`
  維持通過）。

## 順修：#614 runbook 實測發現的兩個 permgen 缺口

兩者的根是同一條——**帳號相關路徑被寫成二分時代的字面量，換 scheme 就漂移**；修法也是
同一條：**由 scheme 現場導出，不列舉**。

1. **帳號 HOME／cache**：`PathLayout.svc_home = "/var/lib/cortex-svc"` 是寫死的，三分下
   Manager 帳號是 `cortex-manager`，unit 的 `Environment=HOME=` 卻還指著 `/var/lib/cortex-svc`
   ——一個沒人擁有的目錄。改為 `home_of(account)`／`cache_of(account)`／
   `codex_hooks_dir_of(account)`（`home_root` 可 config）。
2. **`scaffold_directories()` 漏掉 `cortex-reviewer-planner`**：原本是列舉 svc＋builder 兩個
   帳號。改為由 `scheme.headless_accounts()` 導出——二分下輸出**與改動前逐字相同**
   （`{cortex-svc, cortex-builder}`），三分下 `cortex-reviewer-planner` 的 HOME／cache／
   root-owned `~/.codex` 自動入列。

> runbook 目前的手動補行 workaround（註明「等 PR 收掉後可刪」）可以移除了。

另修一個**測試 seam 的假綠**：`preflight_systemd_run(which=shutil.which, …)` 的預設值在
**def 時**就綁定了函式物件，`mock.patch.object(job_runner.shutil, "which", …)` 打不到它
——`test_preflight_failure_propagates` 實際是靠「本機沒有 `cortex-builder` 帳號」通過的
（在有該帳號的主機上會紅）。改為 `(which or shutil.which)(…)`，行為完全相同，但測試驗到的
是它宣稱要驗的東西。

## M2（#615：reviewer/planner 啟動面降權）的擴充點

本 PR **不實作 M2**，但已確保第二實例化是**換參數**而不是改核心，並用測試釘住：

| 面 | 擴充點 | M2 要做的事 |
|---|---|---|
| unit 名 | `permgen.job_unit_stem(layout, principal)` | 傳 `principal=REVIEWER` → `cortex-reviewer-job@.service` |
| unit 內容 | `build_job_unit(scheme, layout, principal=…)` | `User=`／`HOME`／`XDG_CACHE_HOME`／`ReadWritePaths` 全跟著 scheme 導出 |
| polkit | `build_polkit_rule(scheme, plan=TEMPLATE, principal=…)` | pattern 自動變 `^cortex-reviewer-job@…`；與 builder 的規則互不放行 |
| 額外可寫路徑 | `job_extra_write_paths(account)` | 帳號由呼叫端給 |
| 啟動器 | `PSC_JOB_TEMPLATE_UNIT`／`PSC_BUILDER_ACCOUNT`／`PSC_BUILDER_GROUP`／`PSC_JOB_SHIM`／`PSC_JOB_SPEC_SPOOL` | 純 config |
| 唯一需要動的程式碼 | `launcher._downgraded_mode()` 目前對 `review_only`／`read_only` 回 `None` | 那一行就是 M2 的入口 |

`build_job_shim()` 與 `job_shim.py` 對 M2 完全不必改（spec 已帶 `working_directory`／
`log_path`／`env`，身分由各自的模板 unit 決定）。

## 測試

新增 `tests/test_trust_root_job_template_ab.py`（**80 測試**）：

- **A 定案**：`DEFAULT_SCHEME` 是三分、模型 persona 全部脫離 spawn 授權帳號、CLI 未指定
  出三分／`two-way` 需顯式、三分下全部 permgen 不變式照跑。
- **polkit B 案**：subject＝`cortex-manager`、action＝`manage-units`、verb ∈ {start, stop}、
  pattern＝`^cortex-job@…\.service$`；**明確斷言不放行 transient**——A 案自己命名的
  `cortex-job-<id>.service`、systemd 匿名 transient 的 `run-uNNNN.service`／`run-rXXXX.service`、
  以及「明細缺席」（`StartTransientUnit` 的 polkit 檢查不帶 unit 明細）全部是 `NO`。
- **spool 資產**：入 R1 登記表、writer 只有 Manager、builder 零寫入且拿到 `rX` 唯讀 ACL、
  mode 0700、layout 與 `config.paths` 對得上、registry 雙向等式仍成立、job unit 的 RWP 不涵蓋它。
- **spec 內容**：`User` 不在 spec（逐條掃 `SPEC_FORBIDDEN_KEYS`，並在整份 JSON 上做值層面
  兜底）、env 不含任何 token 類（11 個 secret 名稱與**值**逐一斷言不存在）、`bash -c` 非
  `-lc`、log/worktree 正確、檔案 mode 0640、原子寫入不留 temp。
- **fail-fast**：上表七條，每條都斷言 `popen.calls == []`。
- **harvest 相容**：log／sentinel 路徑與 direct 模式一致；log 先截空再 append（不會蓋掉
  shim 已寫入的內容）。
- **零回歸**：模式表只增不改序、預設仍 direct＋`bash -lc`、`systemd-run` 仍產 transient
  argv、reviewer/planner 不走 template 路徑（且不產生任何 spec）。
- **shim**：stub 內容／owner／mode／與模板 `ExecStart=` 對齊；邏輯模組對 symlink spec、
  symlink log、身分欄位、憑證 env、schema 違規、缺欄位、缺 spool env、參數個數逐條
  fail-closed；成功路徑實測「接管 log → chdir → execvpe」；以及 **Manager 寫出的 spec
  `job_shim` 讀得動**的端到端契約。
- **順修與 M2**：HOME 隨 scheme、scaffold 涵蓋三帳號且無多餘、`~/.codex` 對每個 job 帳號
  皆 root-owned、`home_root` 可 config；M2 的四個擴充點各一條。

既有 `tests/test_trust_root_job_runner_p2a.py`（63 測試）**零改動**。
`tests/test_trust_root_permgen_p2b.py` 有 4 處呼叫面更新（`manager_extra_write_paths`／
`job_extra_write_paths` 現在吃 account、`svc_home` → `home_of()`），另 1 條
`test_job_unit_command_comes_from_manager_owned_spool` 改寫為
`..._from_root_owned_shim_and_manager_owned_spec`——同一條不變式的**更緊**形狀
（`ExecStart=` 從「spool 裡的 run.sh」變成「root-owned 部署樹的 shim」，連 Manager 都換不掉）。

**全套結果**：

| | passed | subtests |
|---|---|---|
| `origin/main` 基準 | 3366 | 49 |
| 本 PR | **3446** | 49 |

3446 − 3366 = **80**＝新增測試檔的全部，**既有測試零減少、零紅**。

## Checklist

- [x] `changelog.d/ab-template-job-runner.md` fragment 已新增且已 commit
- [x] `CHANGELOG.md [Unreleased]` 有對應 entry（Added／Fixed）
- [x] `VERSION` 未變更（非 release PR）
- [x] 全套測試綠（3446 passed，對 main 基準零回歸）
- [x] `policy_check` 帶 PR 上下文跑
- [x] 不動 systemd／不建帳號／不寫 polkit／不安裝任何 unit（本 PR 純程式碼＋測試）
- [x] 不動 runbook（#614 已 merge，由該 PR 負責）

Refs #584
