### PR TITLE
fix(trust-root): 補上 `cortex service run`——permgen manager unit 的 ExecStart 指向不存在的 verb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,17 @@
   `tests/test_trust_root_job_template_ab.py`（80 測試）。
 
 ### Fixed
+- **#618 / trust-root Phase 2b：補上 `cortex service run`——permgen 的 manager unit
+  `ExecStart` 指向一個不存在的 verb**——產生的 system unit 寫
+  `ExecStart=<venv>/bin/cortex service run`，但 porcelain 只有 `install`／`start`／
+  `stop`／`restart`／`status`／`logs`／`uninstall`，unit 一 start 即
+  `unsupported service command`，Phase 2b 第 4c 步 blocking。加一個薄轉發 verb：
+  `run` 之後的 argv（含 `--help`）在 parse 前攔截並原樣交給
+  `coordinator.manager_daemon.main()`。**不沿用 `scripts/service-manager.sh`**：它會
+  `mkdir -p "$HOME/.agents/log"` 導 daemon 輸出，而 Phase 2b 的 `HOME` 為 root-owned
+  且 unit 帶 `ProtectHome=yes`——system-level 的正確形態是前景跑、log 進 journald。
+  新增 `tests/test_service_run_verb.py` 五條，含一條把「產生器 ExecStart」與
+  「CLI 實際 verb」綁在一起的迴歸鎖。
 - **#584 順修（#614 runbook 實測發現的兩個 permgen 缺口）**——(a) 帳號 HOME／cache
   改由帳號名機械導出（`PathLayout.home_of()`／`cache_of()`），不再是二分時代的字面量
   `/var/lib/cortex-svc`：三分下 Manager 的 `Environment=HOME=` 原本會指向一個沒人擁有

--- a/changelog.d/service-run-verb.md
+++ b/changelog.d/service-run-verb.md
@@ -1,0 +1,16 @@
+### Fixed
+- **#618 / trust-root Phase 2b：補上 `cortex service run`——permgen 的 manager unit
+  `ExecStart` 指向一個不存在的 verb**——`permgen` 產生的 system-level unit 寫的是
+  `ExecStart=<venv>/bin/cortex service run`，但 `porcelain/service.py` 只有
+  `install`／`start`／`stop`／`restart`／`status`／`logs`／`uninstall`，unit 一 start
+  就以 `unsupported service command` 失敗；Phase 2b 第 4c 步（Manager 遷 system-level）
+  因此 blocking。修法是加一個薄轉發 verb：`cortex service run` 之後的 argv（含
+  `--help`）在 parse 前就攔截並原樣交給 `coordinator.manager_daemon.main()`，
+  不在 porcelain 端複製一份會與 daemon parser 漂移的參數宣告。
+  **不沿用 `scripts/service-manager.sh` 當 `ExecStart` 的理由**：該 wrapper 會
+  `mkdir -p "$HOME/.agents/log"` 並把 daemon 輸出導進去，而 Phase 2b 的
+  `HOME=/var/lib/cortex-manager` 為 root-owned（只有 `cache/` 可寫）且 unit 帶
+  `ProtectHome=yes`——system-level 的正確形態是 daemon 前景跑、log 交給 journald，
+  重啟語意由 `Restart=on-failure` 負責。新增 `tests/test_service_run_verb.py`
+  五條，含一條把「產生器的 ExecStart」與「CLI 實際提供的 verb」綁在一起的迴歸鎖，
+  避免同一條契約再度單邊漂移。

--- a/paulsha_cortex/porcelain/service.py
+++ b/paulsha_cortex/porcelain/service.py
@@ -57,6 +57,13 @@ def _build_parser() -> argparse.ArgumentParser:
     uninstall.add_argument("--instance", default=os.environ.get("PSC_INSTANCE", "cortex"))
     uninstall.add_argument("--purge", action="store_true", help="一併移除 bootstrap env")
     uninstall.add_argument("--json", action="store_true", help="輸出 cortex-porcelain/service/v1 JSON")
+
+    # issue #618：trust-root Phase 2b 的 system-level unit 以此為 ExecStart
+    # （permgen.ManagerUnit 產生 `<venv>/bin/cortex service run`）。與 start/stop
+    # 不同——它不是 systemctl 包裝，而是 daemon 迴圈本身。
+    # 參數不在此宣告：`main` 會在 parse 前攔截 run，把其餘 argv（含 --help）
+    # 原樣交給 daemon，避免在這裡複製一份會與 daemon parser 漂移的宣告。
+    sub.add_parser("run", help="前景執行 manager daemon（system unit 的 ExecStart）")
     return parser
 
 
@@ -586,9 +593,27 @@ def _run_uninstall(*, instance: str, purge: bool, json_output: bool) -> int:
     return 0
 
 
+def _run_foreground(daemon_argv: Sequence[str]) -> int:
+    """前景跑 manager daemon（issue #618）。
+
+    stdout/stderr 一律交給呼叫端（system unit 下即 journald），不自建 log 檔——
+    Phase 2b 的 `HOME` 為 root-owned 且 unit 帶 `ProtectHome=yes`，
+    `scripts/service-manager.sh` 那套 `$HOME/.agents/log` 導向在該佈局下寫不進去。
+    daemon 迴圈本身即阻塞並回傳 0/1，符合 `Type=simple` 的期待。
+    """
+    # 延後匯入：daemon 會拉進整個 coordinator 相依圖，不該在每次 `cortex` 呼叫
+    # 註冊 porcelain 命令時就付這個成本。
+    from paulsha_cortex.coordinator import manager_daemon
+
+    return manager_daemon.main(list(daemon_argv))
+
+
 def main(argv: Sequence[str]) -> int:
+    items = _normalize_argv(argv)
+    if items and items[0] == "run":
+        return _run_foreground(items[1:])
     parser = _build_parser()
-    args = parser.parse_args(_normalize_argv(argv))
+    args = parser.parse_args(items)
     try:
         instance = installer._validate_instance(getattr(args, "instance", "cortex"))
         if args.command == "install":

--- a/tests/test_service_run_verb.py
+++ b/tests/test_service_run_verb.py
@@ -1,0 +1,71 @@
+"""issue #618：`cortex service run` 是 trust-root Phase 2b system unit 的 ExecStart。
+
+permgen 產生的 `ExecStart=<venv>/bin/cortex service run` 必須真的可執行——
+這條契約在 #618 之前只存在於產生器端，CLI 沒有對應 verb，unit 一 start 就
+以 `unsupported service command` 失敗。
+"""
+
+from __future__ import annotations
+
+import argparse
+
+import pytest
+
+from paulsha_cortex.porcelain import service
+from paulsha_cortex.trust_root import permgen
+
+
+def test_run_verb_listed_in_service_help() -> None:
+    parser = service._build_parser()
+    action = next(a for a in parser._actions if isinstance(a, argparse._SubParsersAction))
+    assert "run" in action.choices
+
+
+def test_run_forwards_argv_to_manager_daemon(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: dict[str, object] = {}
+
+    def fake_main(argv: list[str]) -> int:
+        seen["argv"] = list(argv)
+        return 0
+
+    monkeypatch.setattr(
+        "paulsha_cortex.coordinator.manager_daemon.main", fake_main, raising=True
+    )
+    rc = service.main(["run", "--max-rounds", "1", "--no-require-idle"])
+
+    assert rc == 0
+    assert seen["argv"] == ["--max-rounds", "1", "--no-require-idle"]
+
+
+def test_run_forwards_help_instead_of_consuming_it(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`--help` 也要原樣下放——service parser 不得攔截成自己的用法說明，
+    否則 operator 看不到 daemon 的真實參數面。"""
+    seen: dict[str, object] = {}
+
+    def fake_main(argv: list[str]) -> int:
+        seen["argv"] = list(argv)
+        return 0
+
+    monkeypatch.setattr(
+        "paulsha_cortex.coordinator.manager_daemon.main", fake_main, raising=True
+    )
+    assert service.main(["run", "--help"]) == 0
+    assert seen["argv"] == ["--help"]
+
+
+def test_run_propagates_daemon_exit_code(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "paulsha_cortex.coordinator.manager_daemon.main", lambda argv: 1, raising=True
+    )
+    assert service.main(["run"]) == 1
+
+
+def test_manager_unit_execstart_matches_the_verb_cli_exposes() -> None:
+    """產生器的 ExecStart 與 CLI 實際提供的 verb 必須同步——#618 就是這條斷掉。"""
+    unit = permgen.build_manager_unit(permgen.SCHEMES["three-way"])
+    verb = unit.exec_start.split("/bin/cortex ", 1)[1].split()
+
+    parser = service._build_parser()
+    action = next(a for a in parser._actions if isinstance(a, argparse._SubParsersAction))
+    assert verb[0] == "service"
+    assert verb[1] in action.choices


### PR DESCRIPTION
## 問題

Phase 2b 實機執行到第 4c 步（Manager 遷 system-level unit）卡住。`permgen` 產生的 unit 寫：

```
ExecStart=/opt/cortex/venv/bin/cortex service run
```

但 CLI 沒有這個 verb：

```
$ cortex service --help
usage: cortex service [-h] {install,start,stop,restart,status,logs,uninstall} ...
```

unit 一 `start` 就以 `unsupported service command` 失敗。ExecStart 契約只存在於產生器端，CLI 沒跟上。

## 為什麼不是改指向 `scripts/service-manager.sh`

現行 `--user` unit 跑的是那支 wrapper，但它在 Phase 2b 佈局下**結構性不可用**：

- `mkdir -p "$HOME/.agents/log"`，並把 daemon stdout/stderr 導到 `$HOME/.agents/log/manager.log`
- 而 Phase 2b 的 `HOME=/var/lib/cortex-manager` 是 **root-owned**（只有 `cache/` 可寫），unit 又帶 `ProtectHome=yes`

system-level 的正確形態是 **daemon 前景跑、log 交給 journald**——重啟語意由 `Restart=on-failure` 負責，不需要 background + `wait` 的 shell 包裝。

## 修法

`porcelain/service.py` 加 `run` verb，在 parse 前攔截並把其餘 argv 原樣轉發給 `coordinator.manager_daemon.main()`：

- `manager_daemon.main()` 本身即前景阻塞（`run_loop`）、回傳 0/1，符合 `Type=simple`
- **含 `--help` 一併下放**——operator 看到的是 daemon 的真實參數面，而不是 porcelain 自己編的一份
- 不在 porcelain 端複製參數宣告，因此不會與 daemon parser 漂移
- daemon 匯入延後到函式內，避免每次 `cortex` 呼叫都付 coordinator 相依圖的成本
- `--specs-dir` 未給時走 `default_specs_dir()` → `paths.specs_root()`，與 unit 的 `EnvironmentFile` 中 `PSC_SPECS_ROOT` 一致

## 測試

新增 `tests/test_service_run_verb.py` 五條，其中一條是**契約鎖**：把「產生器輸出的 ExecStart」與「CLI 實際提供的 verb」綁在一起斷言，讓同一條契約不能再單邊漂移（#618 就是這條斷掉）。

- 既有相關套件（porcelain routing／install service／inspect／service install overwrite）52 綠
- `trust_root`／`permgen`／`job_runner` 285 綠
- `policy_check` 帶 PR 上下文：**fail: 0**（R-18／R-22 warn 為陳年 README 懸空引用，非本 PR 造成）

## 實機驗收

```
$ cortex service run --max-rounds 1 --no-require-idle
exit=0
```

merge 後回 Phase 2b 第 4c 步，續驗 `MainPID` 的 user 欄為 `cortex-manager`。

Closes #618

## Checklist
- [x] `changelog.d/service-run-verb.md` fragment 已新增且已 commit
- [x] `CHANGELOG.md [Unreleased]` 有對應 entry
- [x] `VERSION` 與意圖一致（非 release PR，未動）
- [x] 測試通過
- [x] `policy_check` 帶 PR 上下文跑過，fail: 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E7w9kaUxAzCCEk7piD5hfK