### PR TITLE
fix(trust-root): permgen 機械導出父目錄 traverse ACL——修好三分下 builder／reviewer-planner 走不到自己 spool 的正向路徑

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,23 @@
   `tests/test_trust_root_job_template_ab.py`（80 測試）。
 
 ### Fixed
+- **#620 / trust-root：permgen 機械導出父目錄 traverse ACL——三分下 builder／
+  reviewer-planner 走不到自己的 spool，正向路徑全斷**——葉節點的跨帳號 ACL 完全正確
+  （`u:cortex-builder:wx` 掛在 `<monitor>/event-spool` 上），但父目錄是
+  `0700 cortex-manager`；POSIX 要求路徑上**每一層**都帶 `x`（search）位，於是 Phase 2b
+  實機兩條 append-only 正向路徑同時 `Permission denied`，且錯誤訊息指的是**父目錄**、
+  與真正缺的授權不在同一層。`permgen` 新增 `derive_traverse_grants()`：對每個授了跨帳號
+  ACL 的資產沿路徑往上走到管理樹根，逐層以 `can_traverse()` 判斷該帳號是否已經走得過去
+  （owner 位相符／others 帶 x／既有 ACL 已含 x），只為真正缺的那幾層產生一條 `--x`；
+  中間層的目標狀態由登記表 `PermissionEntry` ＋ `scaffold_directories()` 兩個既有真相
+  合出（`directory_facts()`），沒有第二份手寫清單。**`--x` 而非 `r-x`、且一律不設
+  default ACL**：前者讓 job 帳號走得到自己那格卻列不出 `coordinator/` 底下還有哪些
+  Manager 資產，後者避免一條 traverse 被子物件繼承成整棵子樹的授權。命令排在輸出**尾端**
+  ——`chmod` 會重寫 ACL mask，順序反了會靜默失效。另新增 `account_can_reach()`／
+  `unreachable_hops()` 讓「鏈是否完整」成為可測的純函式判定。新增
+  `tests/test_trust_root_permgen_traverse_620.py`（26 測試，兩 scheme 參數化，含
+  「拿掉導出授權即重現 issue 斷法」的反向對照）；runbook 補稽核 5 與正／負向驗證。
+  詳見 `changelog.d/permgen-parent-traverse-acl.md`。
 - **#618 / trust-root Phase 2b：補上 `cortex service run`——permgen 的 manager unit
   `ExecStart` 指向一個不存在的 verb**——產生的 system unit 寫
   `ExecStart=<venv>/bin/cortex service run`，但 porcelain 只有 `install`／`start`／

--- a/changelog.d/permgen-parent-traverse-acl.md
+++ b/changelog.d/permgen-parent-traverse-acl.md
@@ -1,0 +1,43 @@
+# permgen-parent-traverse-acl
+
+- **`#620`：permgen 沒產生父目錄 traverse ACL——三分下 builder／reviewer-planner 走不到
+  自己的 spool，正向路徑全斷**——產生器對**葉節點**授的跨帳號 ACL 完全正確
+  （`setfacl -m u:cortex-builder:wx <monitor>/event-spool`、
+  `setfacl -m u:cortex-reviewer-planner:wx <coordinator>/review-verdicts`），但父目錄是
+  `0700 cortex-manager:cortex-manager`。POSIX 要求路徑上**每一層**都帶 `x`（search）位
+  才走得到葉節點，於是 Phase 2b 實機兩條 append-only 正向路徑同時 `Permission denied`
+  ——而且錯誤訊息指的是**父目錄**，與真正缺的那條授權不在同一層，極難診斷（實機是靠
+  operator 手補三條 `setfacl … :--x` 解封的）。
+  修法：`permgen` 新增一組純函式，把 traverse 權**與葉節點 ACL 同源機械導出**——
+  `derive_traverse_grants()` 對每個授了跨帳號 ACL 的資產沿路徑往上走到管理樹根
+  （`managed_roots()`，再往上是發行版標準的 root-owned 0755，不歸本產生器管），
+  逐層以 `can_traverse()` 判斷該帳號是否**已經**走得過去（owner 位相符／others 帶 x
+  ／既有 ACL 已含 x），只為真正缺的那幾層產生一條 `--x`。中間層的目標狀態由
+  `directory_facts()` 從登記表資產的 `PermissionEntry` ＋ `scaffold_directories()`
+  兩個既有真相合出來，**沒有第二份手寫清單**；未被任一方描述的中間層（例如 job 自建的
+  `<worktree>/<job-id>/.cortex`）保守視為不可 traverse，寧可多產一條也不漏。
+- **`--x` 而非 `r-x`，且一律不設 default ACL**——這是安全要求不是風格：`r-x` 會讓 job
+  帳號列得出 `coordinator/` 底下還有哪些 Manager 資產；default ACL 則會讓該目錄底下
+  **新建的每個物件**都繼承這條授權，等於把一條 traverse 放大成整棵子樹的授權。兩者都有
+  測試釘住。三分下實際導出七條（含 issue 手補的那三條，另加 `cortex-outbox` 對
+  `coordinator`／`coordinator/digest`、`operator` 對 `coordinator`，以及 per-job 的
+  `<worktree>/<job-id>/.cortex`），二分下 reviewer 與 owner 併帳故自動少一條——**同一套
+  policy，只換 config**。
+- **順序**：traverse 節排在 `plan_to_commands()` 輸出的**最尾端**。`chmod` 在帶 ACL 的
+  物件上會把 group 位寫進 ACL **mask**，先 `setfacl` 再 `chmod 0700` 會讓所有具名條目的
+  有效權限被 mask 成空——順序反了不會報錯，只會靜默失效。測試釘住「traverse 行全部晚於
+  最後一個 `chmod`／`install -d`，且是連續的一節」。
+- **可驗收的鏈完整性**：新增 `account_can_reach()`／`unreachable_hops()`——套完產生器輸出
+  後，某帳號到某資產的路徑上**是否每一層都可 search**，成為可測的純函式判定（也是
+  runbook 之外第二個檢查點）。`plan_to_commands()` 新增選擇性的 `layout`／`scheme` 參數
+  （只影響 traverse 節；未給時取 `DEFAULT_LAYOUT` 與 plan 的 scheme），既有呼叫端逐字不變。
+- **測試**：新增 `tests/test_trust_root_permgen_traverse_620.py`（26 測試，兩個 scheme 逐一
+  參數化）——實機手補的三條逐字出現在可執行行裡；**每一個**跨帳號 ACL 的鏈都完整（不只
+  那三條）；反向對照（拿掉導出的授權就重現 issue 的斷法，證明測的不是「本來就通」）；
+  `--x` 不含 `r`／`w`、無 default ACL、job 帳號仍列不出 coordinator；已可 traverse 的三種
+  情形（root-owned 0755／0701 others-x／既有 `rX` ACL）不重複產生；同一 `(path, account)`
+  去重且輸出決定性；換 `PathLayout` 不必改產生器一行程式碼。
+- **runbook**：`docs/superpowers/runbooks/trust-root-phase2b-setup.md` 第 2 步補「稽核 5」
+  （traverse ACL 存在、不得是 `r-x`、不得有 default、必須留在 script 尾端）與套用後的
+  正／負向驗證（builder 寫 event-spool、reviewer-planner 寫 verdict spool 皆成功；
+  `ls /var/lib/cortex/coordinator` 對 job 帳號仍 Permission denied）。

--- a/docs/superpowers/runbooks/trust-root-phase2b-setup.md
+++ b/docs/superpowers/runbooks/trust-root-phase2b-setup.md
@@ -410,6 +410,24 @@ grep -c "cortex-svc" /tmp/p2b-scaffold.sh
 
 # ✅ 稽核 4：setfacl 可用（缺 acl 套件會讓跨帳號唯讀授權整段失效）
 command -v setfacl >/dev/null && echo "setfacl: OK" || echo "!! 請先 sudo apt-get install acl"
+
+# ✅ 稽核 5：父目錄 traverse ACL 已由產生器導出（#620）
+grep -E "^setfacl -m u:[^ ]+:--x " /tmp/p2b-permissions.sh
+#   期望（三分）：**至少**含下列三行——它們是兩條正向路徑成立的**必要條件**
+#     setfacl -m u:cortex-builder:--x           /var/lib/cortex/monitor
+#     setfacl -m u:cortex-builder:--x           /var/lib/cortex/coordinator
+#     setfacl -m u:cortex-reviewer-planner:--x  /var/lib/cortex/coordinator
+#   （另有 cortex-outbox／operator 的對應條目，同樣由葉節點 ACL 機械導出）
+grep -E "^setfacl .*:r-x " /tmp/p2b-permissions.sh
+#   期望：空輸出。traverse 一律 `--x` 而非 `r-x`：走得到自己那格，但**列不出**
+#   coordinator/ 底下還有哪些 Manager 資產。
+grep -E "^setfacl -d -m u:[^ ]+:--x " /tmp/p2b-permissions.sh
+#   期望：空輸出。traverse 只設 access ACL、不設 default——default 會讓該目錄底下
+#   新建的每個物件都繼承這條授權，等於把一條 traverse 放大成整棵子樹的授權。
+tail -n 20 /tmp/p2b-permissions.sh | grep -c ":--x "
+#   期望：> 0。traverse 節**必須留在 script 尾端**：`chmod` 在帶 ACL 的物件上會重寫
+#   ACL **mask**，先 setfacl 再 chmod 會讓具名條目的有效權限被 mask 成空（靜默失效，
+#   不會報錯）。因此也**不要**在執行完 permissions 之後再重跑 scaffold。
 ```
 
 ### 2b. 執行（順序固定：先骨架、後權限）
@@ -452,6 +470,26 @@ sudo getfacl -p /var/lib/cortex/monitor/event-spool 2>/dev/null | grep -E "^user
 #   期望：user:cortex-builder:-wx（producer 只能 append，不可讀他人）
 sudo getfacl -p /var/lib/cortex/coordinator/review-verdicts 2>/dev/null | grep -E "^user:"
 #   期望：user:cortex-reviewer-planner:-wx（**無 r**）
+
+# ✅ 驗證：父目錄 traverse 已就位——**正向路徑真的走得通**（#620）
+sudo getfacl -p /var/lib/cortex/monitor 2>/dev/null | grep -E "^user:"
+#   期望：user:cortex-builder:--x（**無 r**）
+sudo getfacl -p /var/lib/cortex/coordinator 2>/dev/null | grep -E "^user:"
+#   期望：user:cortex-builder:--x、user:cortex-reviewer-planner:--x（皆**無 r**）
+sudo -u cortex-builder sh -c 'echo x > /var/lib/cortex/monitor/event-spool/probe.json' \
+  && sudo rm -f /var/lib/cortex/monitor/event-spool/probe.json \
+  && echo "builder → event-spool: OK"
+sudo -u cortex-reviewer-planner mkdir /var/lib/cortex/coordinator/review-verdicts/probe \
+  && sudo rmdir /var/lib/cortex/coordinator/review-verdicts/probe \
+  && echo "reviewer-planner → review-verdicts: OK"
+#   期望：兩行 OK。任一 `Permission denied` 就停下來查——先看它抱怨的是**哪一層**，
+#   父目錄的錯與葉節點的錯訊息長得很像但缺的授權不同層。
+
+# ✅ 驗證（負向）：traverse 沒有連帶開放列目錄
+sudo -u cortex-builder ls /var/lib/cortex/coordinator 2>&1 | tail -1
+#   期望：Permission denied（--x 只給 search，不給 read）
+sudo -u cortex-builder ls /var/lib/cortex/coordinator/evidence 2>&1 | tail -1
+#   期望：Permission denied（走得到 job-specs，仍看不到別的 Manager 資產）
 
 # ✅ 驗證：三個 HOME 與 ~/.codex 由 root 擁有（帳號不得替換自己的設定）
 ls -ld /var/lib/cortex-svc /var/lib/cortex-svc/cache

--- a/paulsha_cortex/trust_root/permgen.py
+++ b/paulsha_cortex/trust_root/permgen.py
@@ -533,6 +533,8 @@ PER_JOB_SEGMENT = "<job-id>"
 def plan_to_commands(
     plan: PermissionPlan,
     path_of: Mapping[str, str] | None = None,
+    layout: "PathLayout" = None,  # type: ignore[assignment]
+    scheme: UidScheme | None = None,
 ) -> list[str]:
     """把計畫轉成 runbook 可引用的命令序列（**只產生字串，絕不執行**）。
 
@@ -540,6 +542,11 @@ def plan_to_commands(
     shell 變數替換（`PathLayout.asset_paths()` 可一次提供全部真實路徑）。輸出含
     分節註解，方便 operator 對照登記表逐項核可；目錄資產會先出 `install -d`，
     使整份輸出成為一份可直接執行的 setup script。
+
+    帶 `path_of`（真實路徑）時，輸出**尾端**另附一節由跨帳號 ACL 機械導出的父目錄
+    traverse ACL（`derive_traverse_grants`，#620）——沒有它，葉節點 ACL 全部正確
+    但路徑走不通。`layout`／`scheme` 只影響那一節（骨架目錄的 owner／mode 是判斷
+    「這層是否已可 traverse」的輸入），未給時取 `DEFAULT_LAYOUT` 與 plan 的 scheme。
     """
     lines: list[str] = [
         f"# trust-root Phase 2b 權限套用命令（scheme={plan.scheme_id}）",
@@ -573,6 +580,11 @@ def plan_to_commands(
             cmds = [f"[ ! -e {path} ] || {cmd}" for cmd in cmds]
         for cmd in cmds:
             lines.append(f"#   {cmd}" if per_job else cmd)
+    # 父層 traverse ACL 一律殿後——見 `traverse_commands` 的順序說明（chmod 會重寫
+    # ACL mask）。placeholder 模式（未給 path_of）沒有真實路徑階層可推，故不出這節。
+    lines += traverse_commands(
+        derive_traverse_grants(plan, layout, scheme, path_of=path_of or {})
+    )
     return lines
 
 
@@ -922,6 +934,272 @@ def read_write_path_owners(
         covered += [f"extra:{e.reason}" for e in extras if _is_within(e.path, rwp)]
         result[rwp] = tuple(covered)
     return result
+
+
+# ---------------------------------------------------------------------------
+# 父目錄 traverse ACL 的機械導出（#620）
+#
+# POSIX 要求路徑上**每一層**都帶 `x`（search）位才走得到葉節點。葉節點的跨帳號 ACL
+# 再精確，只要中間任何一層是 `0700 <別人>`，實際結果就是 `Permission denied`——而且
+# 錯誤訊息指的是那個父目錄，與真正缺的那條授權**不在同一層**，極難診斷（Phase 2b
+# 實機兩條正向路徑同時全斷即為此）。
+#
+# 因此 traverse 權**必須與葉節點 ACL 同源機械導出**，不能留給 runbook 手補：它是
+# 「正向路徑成立」的必要條件，漏掉會讓整套降權部署看起來「裝好了但 job 全部失敗」。
+# ---------------------------------------------------------------------------
+
+#: 父層 traverse ACL 的 perms。**必須是 `--x` 而不是 `r-x`**：只給 search，不給
+#: 列目錄。builder 因此走得到 `<monitor>/event-spool`，卻列不出 `coordinator/`
+#: 底下還有哪些 Manager 資產——「能走到自己那格」與「看得見別人有哪些格」是兩件事，
+#: 這裡只授前者。
+TRAVERSE_PERMS = "--x"
+
+
+@dataclass(frozen=True)
+class DirectoryFacts:
+    """某目錄在**目標狀態**下的 owner／group／mode／具名 ACL（推導 traverse 用）。
+
+    來源有二，合起來就是本產生器對「路徑上每一層長什麼樣」的全部知識：
+    登記表資產的 `PermissionEntry`（目錄型）與 `PathLayout.scaffold_directories()`。
+    不在其中的目錄一律保守視為**不可 traverse**（fail-closed：寧可多產一條 `--x`，
+    也不要漏掉一條而讓正向路徑靜默斷掉）。
+    """
+
+    path: str
+    owner: str
+    group: str
+    mode: int
+    #: account → ACL perms。只收 access ACL；default ACL 決定的是**子物件**的初值，
+    #: 不影響「能不能走過這個目錄本身」。
+    acl_perms: Mapping[str, str] = field(default_factory=dict)
+    #: `asset:<asset_id>` 或 `scaffold`——供診斷時指出這層是誰定的。
+    source: str = ""
+
+
+def directory_facts(
+    plan: PermissionPlan,
+    layout: "PathLayout" = None,  # type: ignore[assignment]
+    scheme: UidScheme | None = None,
+    path_of: Mapping[str, str] | None = None,
+) -> dict[str, DirectoryFacts]:
+    """路徑→目標狀態（骨架目錄先鋪底，登記表資產覆蓋其上）。純函式、無 IO。"""
+    layout = layout if layout is not None else DEFAULT_LAYOUT
+    scheme = scheme if scheme is not None else SCHEMES.get(plan.scheme_id, DEFAULT_SCHEME)
+    paths = dict(path_of) if path_of is not None else layout.asset_paths()
+    facts: dict[str, DirectoryFacts] = {}
+    for path, owner, group, mode in layout.scaffold_directories(scheme):
+        facts[path] = DirectoryFacts(
+            path=path, owner=owner, group=group, mode=mode, source="scaffold"
+        )
+    for entry in plan.entries:
+        if not entry.is_directory:
+            continue
+        path = paths.get(entry.asset_id)
+        if not path:
+            continue
+        facts[path] = DirectoryFacts(
+            path=path,
+            owner=entry.owner,
+            group=entry.group,
+            mode=entry.mode,
+            acl_perms={a.account: a.perms for a in entry.acls if not a.default},
+            source=f"asset:{entry.asset_id}",
+        )
+    return facts
+
+
+def can_traverse(
+    facts: DirectoryFacts | None,
+    account: str,
+    scheme: UidScheme,
+) -> bool:
+    """該帳號在目標狀態下能否 search 進這個目錄。
+
+    依 POSIX ACL 的判定順序：owner 條目優先；具名 user 條目一旦存在就**取代**
+    group／other 位（不是疊加——`r--` 的具名條目會擋掉 other 的 x）；都沒有才看
+    group、最後看 other。未知目錄回 `False`（fail-closed）。
+    """
+    if facts is None:
+        return False
+    if facts.owner == account:
+        return bool(facts.mode & 0o100)
+    perms = facts.acl_perms.get(account)
+    if perms is not None:
+        # setfacl 的 `X` ＝「目錄才給 x」；本函式的對象都是目錄，故等同 x。
+        return "x" in perms or "X" in perms
+    if facts.group == scheme.group_of(account):
+        return bool(facts.mode & 0o010)
+    return bool(facts.mode & 0o001)
+
+
+def managed_roots(facts: Mapping[str, DirectoryFacts]) -> tuple[str, ...]:
+    """本 layout 管理的樹根（沒有其他已知目錄是其祖先者）。
+
+    traverse 推導往上走到這裡為止。再往上（`/var/lib`、`/var`、`/`）是發行版標準的
+    root-owned 0755，不歸本產生器管——對那幾層下 `setfacl` 是越權，也毫無必要。
+    """
+    return _minimize(set(facts))
+
+
+def _ancestors_within(path: str, roots: tuple[str, ...]) -> tuple[str, ...]:
+    """`path` 由內而外的祖先目錄，只取仍落在管理樹內者。"""
+    chain: list[str] = []
+    current = _parent_dir(path)
+    while any(_is_within(current, r) for r in roots):
+        chain.append(current)
+        parent = _parent_dir(current)
+        if parent == current:
+            break
+        current = parent
+    return tuple(chain)
+
+
+@dataclass(frozen=True)
+class TraverseGrant:
+    """單條父層 traverse ACL：`setfacl -m u:<account>:--x <path>`。"""
+
+    path: str
+    account: str
+    #: 需要這條才走得到的葉資產（一個中間目錄常同時服務多個葉）。
+    required_by: tuple[str, ...] = ()
+
+    @property
+    def acl(self) -> AclEntry:
+        """對應的 ACL 條目。**永遠 access-only**（`default=False`）：default ACL 會讓
+        該目錄底下**新建的每個物件**都繼承這條授權，等於把一條 traverse 洩漏成整棵
+        子樹的授權——與「不可列目錄、不可讀他人資產」的目的正好相反。"""
+        return AclEntry(self.account, TRAVERSE_PERMS)
+
+    def render(self) -> str:
+        return self.acl.render(self.path)
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "path": self.path,
+            "account": self.account,
+            "perms": TRAVERSE_PERMS,
+            "required_by": list(self.required_by),
+        }
+
+
+def derive_traverse_grants(
+    plan: PermissionPlan,
+    layout: "PathLayout" = None,  # type: ignore[assignment]
+    scheme: UidScheme | None = None,
+    path_of: Mapping[str, str] | None = None,
+) -> tuple[TraverseGrant, ...]:
+    """對每個授了跨帳號 ACL 的資產，沿路徑往上補齊該帳號的 traverse 權。
+
+    規則只有一條，沒有第二條：**葉節點被授權的帳號，其路徑上每一層都必須可 search**。
+    已經允許該帳號 traverse 的中間層（owner 相符、other 帶 x、或既有 ACL 已帶 x）
+    一律跳過——不重複產生。回傳依 `(path, account)` 排序，確保輸出決定性。
+    """
+    layout = layout if layout is not None else DEFAULT_LAYOUT
+    scheme = scheme if scheme is not None else SCHEMES.get(plan.scheme_id, DEFAULT_SCHEME)
+    paths = dict(path_of) if path_of is not None else layout.asset_paths()
+    facts = directory_facts(plan, layout, scheme, paths)
+    roots = managed_roots(facts)
+
+    needed: dict[tuple[str, str], set[str]] = {}
+    for entry in plan.entries:
+        path = paths.get(entry.asset_id)
+        if not path:
+            continue
+        for acl in entry.acls:
+            # default ACL 只決定子物件初值；owner 自己不需要 ACL。
+            if acl.default or acl.account == entry.owner:
+                continue
+            for ancestor in _ancestors_within(path, roots):
+                if can_traverse(facts.get(ancestor), acl.account, scheme):
+                    continue
+                needed.setdefault((ancestor, acl.account), set()).add(entry.asset_id)
+    return tuple(
+        TraverseGrant(path=p, account=a, required_by=tuple(sorted(ids)))
+        for (p, a), ids in sorted(needed.items())
+    )
+
+
+def unreachable_hops(
+    plan: PermissionPlan,
+    layout: "PathLayout" = None,  # type: ignore[assignment]
+    scheme: UidScheme | None = None,
+    *,
+    account: str,
+    asset_id: str,
+    path_of: Mapping[str, str] | None = None,
+    grants: tuple[TraverseGrant, ...] | None = None,
+) -> tuple[str, ...]:
+    """套用導出的 traverse 授權後，該帳號**仍**走不過去的中間層（空 tuple＝整條通）。
+
+    這就是 #620 的驗收條件本身：葉節點 ACL 正確 **≠** 路徑走得通。
+    """
+    layout = layout if layout is not None else DEFAULT_LAYOUT
+    scheme = scheme if scheme is not None else SCHEMES.get(plan.scheme_id, DEFAULT_SCHEME)
+    paths = dict(path_of) if path_of is not None else layout.asset_paths()
+    facts = directory_facts(plan, layout, scheme, paths)
+    if grants is None:
+        grants = derive_traverse_grants(plan, layout, scheme, paths)
+    granted: dict[str, set[str]] = {}
+    for grant in grants:
+        granted.setdefault(grant.path, set()).add(grant.account)
+
+    blocked: list[str] = []
+    for ancestor in _ancestors_within(paths[asset_id], managed_roots(facts)):
+        if account in granted.get(ancestor, set()):
+            continue
+        if can_traverse(facts.get(ancestor), account, scheme):
+            continue
+        blocked.append(ancestor)
+    return tuple(blocked)
+
+
+def account_can_reach(
+    plan: PermissionPlan,
+    layout: "PathLayout" = None,  # type: ignore[assignment]
+    scheme: UidScheme | None = None,
+    *,
+    account: str,
+    asset_id: str,
+    path_of: Mapping[str, str] | None = None,
+    grants: tuple[TraverseGrant, ...] | None = None,
+) -> bool:
+    """該帳號套完產生器輸出後是否走得到這個資產（整條路徑鏈皆可 search）。"""
+    return not unreachable_hops(
+        plan, layout, scheme,
+        account=account, asset_id=asset_id, path_of=path_of, grants=grants,
+    )
+
+
+def traverse_commands(grants: tuple[TraverseGrant, ...]) -> list[str]:
+    """把 traverse 授權轉成命令序列（**只產生字串，絕不執行**）。
+
+    這一節必須排在整份 script 的**最後**：`chmod` 在有 ACL 的物件上會把 group 位
+    寫進 ACL **mask**，先 `setfacl` 再 `chmod 0700` 會讓所有具名條目的有效權限被
+    mask 成空——順序反了不會報錯，只會靜默失效。
+    """
+    if not grants:
+        return []
+    lines = [
+        "",
+        "# ===== 父目錄 traverse ACL（由上方跨帳號 ACL 機械導出，#620）=====",
+        "# POSIX 要求路徑上每一層都有 x（search）位；葉節點 ACL 再精確，中間只要有一層",
+        "# 是 0700 <別人>，整條就走不通，而錯誤訊息還指在父目錄（與缺的授權不同層）。",
+        f"# perms 固定為 {TRAVERSE_PERMS}：**只給 traverse、不給列目錄**——帳號走得到自己",
+        "# 那格，卻列不出該目錄底下還有哪些別人的資產。",
+        "# 一律只設 access ACL、**不設 default ACL**：default 會讓底下新建的每個物件都",
+        "# 繼承這條授權，等於把一條 traverse 放大成整棵子樹的授權。",
+        "# 本節排在最後是必要的：chmod 會重寫 ACL mask，先 setfacl 再 chmod 會讓具名",
+        "# 條目被 mask 成空（靜默失效，不會報錯）。",
+    ]
+    for grant in grants:
+        per_job = PER_JOB_SEGMENT in grant.path
+        lines.append(f"#   走得到：{', '.join(grant.required_by)}")
+        if per_job:
+            lines.append("#   per-job：由降權啟動器在 spawn 時套用，setup 階段不執行。")
+            lines.append(f"#   {grant.render()}")
+        else:
+            lines.append(grant.render())
+    return lines
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_trust_root_permgen_traverse_620.py
+++ b/tests/test_trust_root_permgen_traverse_620.py
@@ -1,0 +1,336 @@
+"""#620：父目錄 traverse ACL 的機械導出。
+
+Phase 2b 實機症狀：葉節點的跨帳號 ACL 全部正確（`u:cortex-builder:wx` 掛在
+`<monitor>/event-spool` 上），但父目錄是 `0700 cortex-manager`，POSIX 要求路徑上
+**每一層**都有 `x`（search）位，於是 builder 寫 event-spool、reviewer-planner 寫
+review-verdicts 兩條正向路徑全部 `Permission denied`——而錯誤訊息指的是父目錄，
+與真正缺的那條授權不在同一層。
+
+驗收（對應 issue 的四條）：
+- (a) 產生器輸出包含必要的父層 traverse ACL（實機手補的那三條逐字出現）；
+- (b) 產生的是 `--x` 不是 `r-x`——只給 traverse，列目錄仍須被拒；
+- (c) 已允許該帳號 traverse 的中間層不重複產生；
+- (d) 三分方案下 builder→event-spool、reviewer-planner→review-verdicts、
+      builder→job-specs 三條路徑的**完整鏈**每一層都有授權。
+"""
+from __future__ import annotations
+
+import pytest
+
+from paulsha_cortex.trust_root import permgen
+from paulsha_cortex.trust_root.permgen import (
+    DEFAULT_LAYOUT,
+    THREE_WAY_SCHEME,
+    TRAVERSE_PERMS,
+    TWO_WAY_SCHEME,
+    PathLayout,
+    account_can_reach,
+    can_traverse,
+    derive_traverse_grants,
+    directory_facts,
+    generate_plan,
+    unreachable_hops,
+)
+from paulsha_cortex.trust_root.registry import Principal
+
+ALL_SCHEMES = [TWO_WAY_SCHEME, THREE_WAY_SCHEME]
+
+#: 三分下的三條正向路徑：(persona, 葉資產)。issue 驗收的核心就是這三條走得通。
+FORWARD_PATHS = (
+    (Principal.BUILDER, "monitor-event-spool"),
+    (Principal.REVIEWER, "review-verdict-spool"),
+    (Principal.BUILDER, "job-spec-spool"),
+)
+
+
+def _commands(scheme=THREE_WAY_SCHEME) -> list[str]:
+    return permgen.plan_to_commands(
+        generate_plan(scheme), path_of=permgen.asset_paths(), scheme=scheme
+    )
+
+
+def _executable(lines: list[str]) -> list[str]:
+    return [ln for ln in lines if ln.strip() and not ln.lstrip().startswith("#")]
+
+
+# ---------------------------------------------------------------------------
+# (a) 產生器輸出包含必要的父層 traverse ACL
+# ---------------------------------------------------------------------------
+
+def test_generator_emits_the_three_manually_patched_acls() -> None:
+    """Phase 2b 實機用來解封的那三條，必須由產生器導出、逐字出現在可執行行裡。"""
+    emitted = _executable(_commands())
+    for expected in (
+        "setfacl -m u:cortex-builder:--x /var/lib/cortex/monitor",
+        "setfacl -m u:cortex-builder:--x /var/lib/cortex/coordinator",
+        "setfacl -m u:cortex-reviewer-planner:--x /var/lib/cortex/coordinator",
+    ):
+        assert expected in emitted, expected
+
+
+@pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
+def test_every_cross_account_acl_gets_its_traverse_chain(scheme) -> None:
+    """涵蓋等式：**每一個**授了跨帳號 ACL 的資產，該帳號都走得到（不只那三條）。"""
+    plan = generate_plan(scheme)
+    for entry in plan.entries:
+        for acl in entry.acls:
+            if acl.default or acl.account == entry.owner:
+                continue
+            blocked = unreachable_hops(
+                plan, scheme=scheme, account=acl.account, asset_id=entry.asset_id
+            )
+            assert not blocked, (entry.asset_id, acl.account, blocked)
+
+
+@pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
+def test_without_the_derived_grants_the_paths_are_broken(scheme) -> None:
+    """反向對照：拿掉導出的授權，實機那兩條正向路徑就是 issue 描述的斷法。
+
+    沒有這條，(d) 可能只是在測「本來就通」的東西。
+    """
+    plan = generate_plan(scheme)
+    builder = scheme.resolve(Principal.BUILDER)
+    blocked = unreachable_hops(
+        plan, scheme=scheme, account=builder, asset_id="monitor-event-spool", grants=()
+    )
+    assert blocked == (f"{DEFAULT_LAYOUT.monitor_state_root}",)
+    blocked = unreachable_hops(
+        plan, scheme=scheme, account=builder, asset_id="job-spec-spool", grants=()
+    )
+    assert blocked == (f"{DEFAULT_LAYOUT.coordinator_root}",)
+
+
+# ---------------------------------------------------------------------------
+# (b) `--x` 不是 `r-x`：只給 traverse，不給列目錄
+# ---------------------------------------------------------------------------
+
+def test_traverse_perms_are_search_only() -> None:
+    assert TRAVERSE_PERMS == "--x"
+    assert "r" not in TRAVERSE_PERMS
+
+
+@pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
+def test_no_traverse_grant_confers_read(scheme) -> None:
+    """每條導出的授權都是 `--x`——`r-x` 會讓 job 帳號列得出 coordinator/ 底下有哪些
+    Manager 資產，那是 issue 明確要求不得發生的事。"""
+    for grant in derive_traverse_grants(generate_plan(scheme), scheme=scheme):
+        assert grant.acl.perms == TRAVERSE_PERMS
+        assert "r" not in grant.acl.perms and "w" not in grant.acl.perms
+        assert not grant.acl.writable
+        assert grant.render().startswith(f"setfacl -m u:{grant.account}:{TRAVERSE_PERMS} ")
+
+
+@pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
+def test_job_accounts_still_cannot_list_the_coordinator_tree(scheme) -> None:
+    """`ls /var/lib/cortex/coordinator` 對 job 帳號仍須是 Permission denied：
+    coordinator 自身 mode 不給 other 讀，且 job 帳號在其上只有 `--x`。"""
+    plan = generate_plan(scheme)
+    facts = directory_facts(plan, scheme=scheme)[DEFAULT_LAYOUT.coordinator_root]
+    assert facts.mode & 0o007 == 0, "coordinator 不得對 other 開任何位"
+    assert facts.owner == scheme.durable_state_owner
+    job_accounts = scheme.headless_accounts() - {facts.owner}
+    assert job_accounts
+    grants = {
+        (g.path, g.account): g
+        for g in derive_traverse_grants(plan, scheme=scheme)
+    }
+    for account in job_accounts:
+        # 目錄本身沒給該帳號任何讀取條目……
+        assert account not in facts.acl_perms
+        # ……導出的授權也只有 traverse，沒有 r。
+        grant = grants.get((DEFAULT_LAYOUT.coordinator_root, account))
+        if grant is not None:
+            assert "r" not in grant.acl.perms
+        assert not can_traverse(
+            permgen.DirectoryFacts(
+                path=facts.path, owner=facts.owner, group=facts.group,
+                mode=facts.mode & 0o770,  # 只留 owner/group，模擬「沒有 ACL」
+            ),
+            account,
+            scheme,
+        )
+
+
+@pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
+def test_traverse_grants_never_emit_a_default_acl(scheme) -> None:
+    """default ACL 會讓該目錄底下**新建的每個物件**繼承這條授權，等於把一條
+    traverse 放大成整棵子樹的授權——與目的正好相反，故一條都不能有。"""
+    for grant in derive_traverse_grants(generate_plan(scheme), scheme=scheme):
+        assert grant.acl.default is False
+        assert " -d " not in grant.render()
+    section = _commands(scheme)
+    tail = section[section.index([
+        ln for ln in section if "父目錄 traverse ACL" in ln
+    ][0]):]
+    assert not any("setfacl -d" in ln for ln in tail), "traverse 節不得出現 default ACL"
+
+
+# ---------------------------------------------------------------------------
+# (c) 已允許 traverse 的目錄不重複產生
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
+def test_already_traversable_directories_are_skipped(scheme) -> None:
+    """三種「本來就走得過去」的情形都不得重複產生：
+    root-owned 0755、others 帶 x（worktree pool 0701）、以及既有 ACL 已含 x。"""
+    grants = derive_traverse_grants(generate_plan(scheme), scheme=scheme)
+    paths = {g.path for g in grants}
+    # root-owned 0755（樹根與骨架中間層）。
+    assert DEFAULT_LAYOUT.agents_root not in paths
+    assert f"{DEFAULT_LAYOUT.agents_root}/run" not in paths
+    assert f"{DEFAULT_LAYOUT.agents_root}/config" not in paths
+    # 0701：others 只 traverse、不可列目錄——已足夠，不必再補。
+    assert DEFAULT_LAYOUT.worktree_root not in paths
+    # 既有 `rX` ACL 已含 traverse（operator 讀 registry／control 底下的葉檔）。
+    operator = scheme.resolve(Principal.OPERATOR)
+    assert (DEFAULT_LAYOUT.skill_registry_root, operator) not in {
+        (g.path, g.account) for g in grants
+    }
+    assert (DEFAULT_LAYOUT.control_root, operator) not in {
+        (g.path, g.account) for g in grants
+    }
+
+
+@pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
+def test_grants_are_deduplicated_and_deterministic(scheme) -> None:
+    """同一個中間層服務多個葉時只產生一條（reason 合併），且順序決定性。"""
+    plan = generate_plan(scheme)
+    grants = derive_traverse_grants(plan, scheme=scheme)
+    keys = [(g.path, g.account) for g in grants]
+    assert len(keys) == len(set(keys)), "同一 (path, account) 不得重複產生"
+    assert keys == sorted(keys)
+    assert grants == derive_traverse_grants(plan, scheme=scheme)
+    # coordinator 上的 cortex-outbox 一條同時服務 digest 與 engineering-outcome。
+    merged = [
+        g for g in grants
+        if g.path == DEFAULT_LAYOUT.coordinator_root and len(g.required_by) > 1
+    ]
+    assert merged and all(len(set(g.required_by)) == len(g.required_by) for g in merged)
+
+
+def test_owner_of_the_leaf_never_gets_a_redundant_grant() -> None:
+    """二分把 reviewer 併進 durable-state owner——此時 verdict spool 的 traverse
+    本來就由 owner 位提供，不得再產生一條。這條同時證明推導是 config 驅動的。"""
+    two = derive_traverse_grants(generate_plan(TWO_WAY_SCHEME), scheme=TWO_WAY_SCHEME)
+    three = derive_traverse_grants(
+        generate_plan(THREE_WAY_SCHEME), scheme=THREE_WAY_SCHEME
+    )
+    reviewer_two = TWO_WAY_SCHEME.resolve(Principal.REVIEWER)
+    assert reviewer_two == TWO_WAY_SCHEME.durable_state_owner
+    assert not [
+        g for g in two
+        if g.account == reviewer_two and g.path == DEFAULT_LAYOUT.coordinator_root
+    ], "coordinator 由 cortex-svc 自己擁有，二分下不需要任何 traverse ACL"
+    assert [
+        g for g in three
+        if g.account == THREE_WAY_SCHEME.resolve(Principal.REVIEWER)
+        and g.path == DEFAULT_LAYOUT.coordinator_root
+    ]
+
+
+def test_unknown_intermediate_directory_is_fail_closed() -> None:
+    """登記表／骨架都沒描述的中間層（job 自建的 `<worktree>/.cortex`）保守視為
+    不可 traverse——寧可多產一條 `--x`，也不要漏掉而讓正向路徑靜默斷掉。"""
+    assert can_traverse(None, "cortex-builder", THREE_WAY_SCHEME) is False
+    grants = derive_traverse_grants(
+        generate_plan(THREE_WAY_SCHEME), scheme=THREE_WAY_SCHEME
+    )
+    hidden = [g for g in grants if g.path.endswith("/.cortex")]
+    assert hidden, "work-items.yaml 的 .cortex 中間層必須被推導出來"
+    assert hidden[0].account == THREE_WAY_SCHEME.durable_state_owner
+
+
+# ---------------------------------------------------------------------------
+# (d) 三條正向路徑的完整鏈
+# ---------------------------------------------------------------------------
+
+def test_three_way_forward_paths_have_a_complete_chain() -> None:
+    """三分下三條正向路徑：從樹根到葉，每一層都可 search。"""
+    plan = generate_plan(THREE_WAY_SCHEME)
+    paths = permgen.asset_paths()
+    facts = directory_facts(plan, scheme=THREE_WAY_SCHEME)
+    grants = derive_traverse_grants(plan, scheme=THREE_WAY_SCHEME)
+    granted = {(g.path, g.account) for g in grants}
+    for principal, asset_id in FORWARD_PATHS:
+        account = THREE_WAY_SCHEME.resolve(principal)
+        assert account_can_reach(plan, account=account, asset_id=asset_id), (
+            account, asset_id
+        )
+        # 逐層列出鏈，證明「每一層」都被覆蓋，而不是只有葉節點對。
+        chain = permgen._ancestors_within(
+            paths[asset_id], permgen.managed_roots(facts)
+        )
+        assert chain, asset_id
+        for hop in chain:
+            assert (
+                (hop, account) in granted
+                or can_traverse(facts.get(hop), account, THREE_WAY_SCHEME)
+            ), (asset_id, account, hop)
+        # 葉節點本身的權限沒被改掉（wx／rX 照舊，traverse 是**額外**的一層）。
+        leaf = plan.by_id(asset_id)
+        assert any(a.account == account and "x" in a.perms.lower() for a in leaf.acls)
+
+
+def test_forward_paths_survive_a_relocated_layout() -> None:
+    """推導是純 config 驅動：換部署位置不必改產生器一行程式碼。"""
+    alt = PathLayout(
+        agents_root="/srv/cortex",
+        worktree_root="/srv/cortex/wt",
+        deploy_root="/usr/local/cortex",
+        instance="alpha",
+    )
+    plan = generate_plan(THREE_WAY_SCHEME)
+    grants = derive_traverse_grants(plan, alt, THREE_WAY_SCHEME)
+    assert grants
+    assert all(g.path.startswith(("/srv/cortex", "/usr/local/cortex")) for g in grants)
+    for principal, asset_id in FORWARD_PATHS:
+        assert account_can_reach(
+            plan, alt, THREE_WAY_SCHEME,
+            account=THREE_WAY_SCHEME.resolve(principal), asset_id=asset_id,
+        )
+
+
+# ---------------------------------------------------------------------------
+# 命令序列：位置、形狀、非執行保證
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
+def test_traverse_section_comes_after_every_chmod(scheme) -> None:
+    """順序是正確性的一部分：`chmod` 在帶 ACL 的物件上會重寫 ACL **mask**，
+    先 setfacl 再 chmod 會讓具名條目的有效權限被 mask 成空（靜默失效）。"""
+    lines = _commands(scheme)
+    executable = _executable(lines)
+    traverse_at = [
+        i for i, ln in enumerate(executable)
+        if ln.startswith("setfacl") and f":{TRAVERSE_PERMS} " in ln
+    ]
+    assert traverse_at
+    last_chmod = max(
+        i for i, ln in enumerate(executable)
+        if ln.startswith("chmod ") or ln.startswith("install -d ")
+    )
+    assert min(traverse_at) > last_chmod
+    # 而且是連續的一節（不散落在各資產之間）。
+    assert traverse_at == list(range(min(traverse_at), max(traverse_at) + 1))
+
+
+@pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
+def test_traverse_commands_are_strings_only(scheme) -> None:
+    """維持 permgen 的非執行不變式：本節仍只有 setfacl 字串。"""
+    lines = _commands(scheme)
+    for line in _executable(lines):
+        assert line.startswith(("install -d ", "chown ", "chmod ", "setfacl ", "[ ! -e "))
+    assert not any("<PATH:" in ln for ln in _executable(lines))
+
+
+def test_per_job_traverse_grants_are_commented_out() -> None:
+    """含 per-job segment 的路徑由降權啟動器逐案套用，setup 階段不得執行。"""
+    for line in _commands():
+        if permgen.PER_JOB_SEGMENT in line:
+            assert line.lstrip().startswith("#"), line
+
+
+def test_placeholder_mode_emits_no_traverse_section() -> None:
+    """未帶真實路徑時沒有路徑階層可推——不得憑空產生指向真實絕對路徑的命令。"""
+    lines = permgen.plan_to_commands(generate_plan(THREE_WAY_SCHEME))
+    assert not any(f":{TRAVERSE_PERMS} " in ln for ln in lines)


### PR DESCRIPTION
Closes #620

## 症狀

Phase 2b 實機套完 `permissions three-way --commands --paths` 後，**兩條 append-only 正向路徑全部走不通**：

```
$ sudo -u cortex-builder sh -c 'echo x > /var/lib/cortex/monitor/event-spool/probe.json'
sh: 1: cannot create /var/lib/cortex/monitor/event-spool/probe.json: Permission denied

$ sudo -u cortex-reviewer-planner mkdir /var/lib/cortex/coordinator/review-verdicts/probe
mkdir: cannot create directory '/var/lib/cortex/coordinator': Permission denied
```

## 根因

產生器對**葉節點**授的 ACL 完全正確（`u:cortex-builder:wx` 掛在 `<monitor>/event-spool` 上），但父目錄是 `0700 cortex-manager:cortex-manager`。POSIX 要求路徑上**每一層**都帶 `x`（search）位才走得到葉節點——葉節點的 ACL 再精確，中間有一層走不過去就整條斷。

更麻煩的是**錯誤訊息指的是父目錄**，與真正缺的那條授權不在同一層：看起來像「裝好了但 job 全部失敗」。實機當時是靠 operator 手補三條 `setfacl … :--x` 解封的。

## 修法：與葉節點 ACL 同源機械導出，不留給 runbook 手補

`permgen` 新增一組純函式（仍**只產生字串**，無任何特權操作）：

- `derive_traverse_grants()`——對每個授了跨帳號 ACL 的資產，沿路徑往上走到管理樹根，逐層判斷該帳號是否**已經**走得過去，只為真正缺的那幾層產生一條 `--x`。
- `can_traverse()`——依 POSIX ACL 判定順序（owner 條目優先 → 具名 user 條目**取代** group／other 位 → group → other）決定某帳號能否 search 進某目錄。
- `directory_facts()`——中間層的目標狀態由**兩個既有真相**合出：登記表資產的 `PermissionEntry` ＋ `PathLayout.scaffold_directories()`。**沒有第二份手寫清單**；未被任一方描述的中間層（例如 job 自建的 `<worktree>/<job-id>/.cortex`）保守視為不可 traverse（fail-closed，寧可多產一條也不漏）。
- `managed_roots()`——往上走到管理樹根為止。再往上（`/var/lib`、`/var`、`/`）是發行版標準的 root-owned 0755，對那幾層下 `setfacl` 是越權也無必要。
- `account_can_reach()`／`unreachable_hops()`——「套完產生器輸出後，某帳號到某資產的鏈是否每一層都可 search」成為可測的純函式判定。

`plan_to_commands()` 新增選擇性的 `layout`／`scheme` 參數（只影響 traverse 節；未給時取 `DEFAULT_LAYOUT` 與 plan 的 scheme），既有呼叫端逐字不變。

### 三分下實際導出（issue 手補的三條逐字在內）

```
setfacl -m u:cortex-builder:--x           /var/lib/cortex/coordinator     # job-spec-spool
setfacl -m u:cortex-outbox:--x            /var/lib/cortex/coordinator     # digest / engineering-outcome
setfacl -m u:cortex-reviewer-planner:--x  /var/lib/cortex/coordinator     # review-verdict-spool
setfacl -m u:operator:--x                 /var/lib/cortex/coordinator     # coverage-shadow
setfacl -m u:cortex-outbox:--x            /var/lib/cortex/coordinator/digest
setfacl -m u:cortex-builder:--x           /var/lib/cortex/monitor         # event-spool
#   （per-job，由降權啟動器套用）u:cortex-manager:--x <worktree>/<job-id>/.cortex
```

二分下 reviewer 與 durable-state owner 併帳，該條自動消失——**同一套 policy，只換 config**。

### 三個刻意的設計點

1. **`--x` 而非 `r-x`**——安全要求，不是風格。`r-x` 會讓 builder 列得出 `coordinator/` 底下還有哪些 Manager 資產；`--x` 只讓它走到自己那格。測試釘住 `"r" not in perms`，runbook 也補了 `ls` 仍被拒的負向驗證。
2. **一律不設 default ACL**——default 會讓該目錄底下**新建的每個物件**都繼承這條授權，等於把一條 traverse 放大成整棵子樹的授權，與目的正好相反。
3. **traverse 節排在輸出尾端**——`chmod` 在帶 ACL 的物件上會把 group 位寫進 ACL **mask**，先 `setfacl` 再 `chmod 0700` 會讓所有具名條目的有效權限被 mask 成空。順序反了**不會報錯，只會靜默失效**。測試釘住「traverse 行全部晚於最後一個 `chmod`／`install -d`，且是連續的一節」。

## 驗收（對應 issue 四條）

| issue 驗收 | 對應測試 |
| --- | --- |
| (a) 輸出包含三條父層 `--x` | `test_generator_emits_the_three_manually_patched_acls`（逐字比對可執行行） |
| (b) 是 `--x` 不是 `r-x` | `test_traverse_perms_are_search_only`、`test_no_traverse_grant_confers_read`、`test_job_accounts_still_cannot_list_the_coordinator_tree` |
| (c) 已允許 traverse 者不重複產生 | `test_already_traversable_directories_are_skipped`（root-owned 0755／0701 others-x／既有 `rX` ACL 三種情形）、`test_grants_are_deduplicated_and_deterministic` |
| (d) 三條路徑完整鏈 | `test_three_way_forward_paths_have_a_complete_chain`（逐層走完並比對）、`test_every_cross_account_acl_gets_its_traverse_chain`（涵蓋等式：**每一個**跨帳號 ACL，不只那三條） |

另加 `test_without_the_derived_grants_the_paths_are_broken`：拿掉導出的授權就重現 issue 描述的斷法——證明 (d) 測的不是「本來就通」的東西。

`tests/test_trust_root_permgen_traverse_620.py` 共 26 測試，兩個 scheme 逐一參數化。

## 驗證

- `python3 -m pytest tests/ -q -k "trust_root or permgen"` → **311 passed**（原 285 ＋ 新增 26）
- `python3 -m pytest tests/ -q` → **3477 passed, 49 subtests passed**（零回歸）
- `python3 -m policy_check --repo . --pr-title … --pr-body … --pr-base-ref main --pr-head-ref feature/620-permgen-parent-traverse-acl` → **fail: 0**
- permgen 的非特權靜態不變式維持不變（`test_permgen_never_touches_the_filesystem`／`test_permgen_module_does_not_import_subprocess` 仍綠）——本 PR 沒有引入任何 `subprocess`／`os.chown`／`os.chmod`／IO。

## Checklist

- [x] 分支自 `main` 開出，命名為 `feature/620-permgen-parent-traverse-acl`
- [x] `changelog.d/permgen-parent-traverse-acl.md` fragment 已新增且已 commit
- [x] `CHANGELOG.md [Unreleased] ### Fixed` 有對應 entry
- [x] 文件與 PR 一律 zh-tw
- [x] 測試已補（新增 26 測試，兩 scheme 參數化）且全套零回歸
- [x] `policy_check` 帶 PR 上下文跑過，fail: 0
- [x] runbook（`docs/superpowers/runbooks/trust-root-phase2b-setup.md`）同步更新
- [x] PR body 含 `Closes #620`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E7w9kaUxAzCCEk7piD5hfK
