### PR TITLE
feat(trust-root): monitor 的 system-level unit——同帳號、同加固段，可寫面嚴格窄於 Manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,25 @@
 ## [Unreleased]
 
 ### Added
+- **#622 / trust-root Phase 2b：`trust_root unit three-way --monitor`——monitor 的
+  system-level unit，同帳號、同加固段，可寫面嚴格窄於 Manager**——M1 之後 permgen
+  只產生 Manager unit，實機切換後 instance **完全沒有 monitor**：舊 `--user` unit 以
+  操作者身分跑、指向舊 `~/.agents/monitor`，起回來只會雙寫，且寫不進 `0700
+  cortex-manager` 的新樹；`monitor-event-spool` 因此只有 builder 的 `wx` 生產端、
+  沒有消費端。新增 `permgen.build_monitor_unit()` 與 CLI 旗標 `--monitor`：`User=`
+  取 `durable_state_owner`（UID 方案表即「`cortex-manager`＝Manager ＋ monitor」）、
+  加固段與 fail-closed 的 `EnvironmentFile` 與 Manager unit 同源、`HOME`／
+  `XDG_CACHE_HOME` 走 `layout.home_of()`／`cache_of()`。`ReadWritePaths` 多一層
+  **persona 過濾**（`permgen.principal_needs_write()`，規則只有兩條且都直接讀登記表：
+  persona 是 `writers` 之一，或是 `INTERPROCESS` 單向 spool 的 reader——消費＝unlink，
+  需要容器寫入權），因此 monitor 只拿到 `/var/lib/cortex/monitor`、
+  `/var/lib/cortex/run/cortex` 與服務帳號 HOME 快取三條，是 Manager 十一條的真子集；
+  `principals=None` 維持既有行為，Manager 與 job 模板 unit 的輸出**逐位元不變**。
+  `ExecStart` 形態比照 #618／PR #619 用 `<venv>/bin/cortex monitor`（既有 CLI verb，
+  不帶 `--once` 即長駐），不用 `python -m` 以免在部署樹裡開第二種進入點形態。
+  新增 `tests/test_trust_root_monitor_unit_622.py`（40 測試，含 ExecStart 契約鎖與
+  加固欄位對 Manager 的集合等式）；runbook 補第 4d 步。
+  詳見 `changelog.d/monitor-system-unit.md`。
 - **#584 / trust-root Phase 2b：0816 第三輪裁決 A+B 的程式碼側——三分 UID 定案 ＋
   `job_runner` 的 template-instance 模式**——**A**：`permgen.DEFAULT_SCHEME`
   改為 `THREE_WAY_SCHEME`（`cortex-manager`／`cortex-reviewer-planner`／

--- a/changelog.d/monitor-system-unit.md
+++ b/changelog.d/monitor-system-unit.md
@@ -1,0 +1,37 @@
+### Added
+- **#622 / trust-root Phase 2b：`trust_root unit three-way --monitor`——monitor 的
+  system-level unit（同帳號、同加固段，可寫面嚴格窄於 Manager）**——Phase 2b M1
+  之後 `permgen` 只產生 Manager unit，實機切換後 cortex instance **完全沒有
+  monitor**：舊的 `--user` unit 以操作者身分跑、`PSC_MONITOR_STATE_ROOT` 指著舊的
+  `~/.agents/monitor`，起回來只會讓 `monitor-state-tree`／
+  `monitor-work-items-snapshot`／`monitor-github-sync-cursor` 出現雙寫來源，而且它
+  寫不進 `0700 cortex-manager` 的 `/var/lib/cortex/monitor`；`monitor-event-spool`
+  因此只有 builder 的 `wx` 生產端、沒有消費端，spool 只增不減。
+  新增 `permgen.build_monitor_unit()` 與 CLI 旗標 `--monitor`：`User=` 取
+  `durable_state_owner`（UID 方案表寫的就是「`cortex-manager`＝Manager ＋ monitor」，
+  也唯有同帳號才寫得進自己的 `0700` state 樹）、加固段與 `EnvironmentFile`
+  （無 `-` 前綴＝fail-closed）與 Manager unit 共用同一份來源、`HOME`／
+  `XDG_CACHE_HOME` 走 `layout.home_of()`／`cache_of()` 而非字面量。
+- **`ReadWritePaths` 的 persona 過濾（`permgen.principal_needs_write()`）**——同帳號
+  **不代表**同可寫面：只按帳號導出時 monitor 會拿到 Manager 的全集
+  （`coordinator/`、`specs/`、`control/`、`worktree/`…），等於把 monitor 的任何 bug
+  或被餵入的惡意 GitHub 內容變成對整棵 durable state 的寫入面。因此
+  `required_write_targets()`／`read_write_paths()`／`read_write_path_owners()` 多一個
+  `principals=` 參數（`None`＝維持既有帳號全集行為，Manager 與 job 模板 unit 的輸出
+  **逐位元不變**），導出規則只有兩條、且兩條都直接讀登記表欄位：persona 是
+  `writers` 之一，或是 `IngressKind.INTERPROCESS` 單向 spool 的 reader（消費＝讀完
+  unlink，需要容器目錄的寫入權）。monitor unit 因此只拿到三條：
+  `/var/lib/cortex/monitor`（`monitor-state-tree`＋兩個葉檔＋`monitor-event-spool`
+  的消費端）、`/var/lib/cortex/run/cortex`（`runtime-run-tree`，monitor 的 unix
+  socket）、以及明示 extra 的服務帳號 HOME 快取——是 Manager 十一條的**真子集**。
+- **`ExecStart` 形態與 #618／PR #619 對齊**——用部署 venv 的 console script ＋ 既有
+  CLI verb（`<venv>/bin/cortex monitor` → `paulsha_cortex.monitor.__main__:main`，
+  不帶 `--once` 即長駐 `ProjectMonitorService.run_forever()`，符合 `Type=simple`），
+  而**不是** `python -m paulsha_cortex.monitor`：後者會在部署樹裡開第二種進入點形態，
+  與 `cortex service run` 各自漂移，而 R-16 的 CLI help 對齊面只看得到前者。
+  新增 `tests/test_trust_root_monitor_unit_622.py`（40 測試），含比照
+  `tests/test_service_run_verb.py` 的**契約鎖**——真的走一次 `cli.main`，確認
+  `ExecStart` 指名的 verb 會抵達 monitor 進入點；另有加固欄位與 Manager 的**集合
+  等式**（任一邊加減一項即紅，杜絕單邊漂移）與「RWP 是 Manager 真子集」的斷言。
+  runbook 補第 4d 步（落檔、身分／加固／RWP 驗證、新樹確有寫入、spool 被消費、
+  fail-closed 複驗、回滾）。

--- a/docs/superpowers/runbooks/trust-root-phase2b-setup.md
+++ b/docs/superpowers/runbooks/trust-root-phase2b-setup.md
@@ -36,7 +36,7 @@ OS** 的手動流程。
 | durable state 路徑 | **`/var/lib/cortex`**；worktree pool＝**`/var/lib/cortex/worktree`** | 第 2 步 |
 | legacy-import | **物理隔離 ＋ hash manifest**（無簽章；簽章屬 Phase 3）。切換前 in-flight job **手動收尾** | 執行前提、第 3 步 |
 | Manager 部署 | **`/opt/cortex`**（root 擁有，對服務唯讀）；system-level unit，`User=cortex-manager` | 第 4 步 |
-| `ReadWritePaths` | **由 R1 登記表經 permgen 機械產生**，不手寫 | 第 4c 步 |
+| `ReadWritePaths` | **由 R1 登記表經 permgen 機械產生**，不手寫；monitor 再多一層 persona 過濾，嚴格窄於 Manager | 第 4c／4d 步 |
 | root 命令 codify | **不 codify**——不提供 `cortex install trust-root --system`；cortex 只產生命令字串 | 第 6 步 |
 | R9 | **手動抽驗**（五族；完整自動化矩陣屬另一工項） | 第 8 步 |
 
@@ -191,11 +191,11 @@ A/B 並列時同一件事要寫兩遍（5-A／5-B、第 8 步兩種起法、附�
 | 段落 | 🔧 sudo 點 | ✅ 驗證點 |
 |---|---:|---:|
 | 執行前提 | 0 | 9 |
-| 產生器＝單一真相 | 0 | 6 |
+| 產生器＝單一真相 | 0 | 7 |
 | 第 1 步：建三帳號 | 4 | 5 |
 | 第 2 步：目標樹與權限 | 2 | 12 |
 | 第 3 步：legacy-import | 2 | 8 |
-| 第 4 步：Manager 部署與 unit | 5 | 12 |
+| 第 4 步：Manager／monitor 部署與 unit | 8 | 22 |
 | **第 5 步：降權（A+B）** | **7** | **24** |
 | 第 6 步：升級流程 | 2 | 5 |
 | 第 7 步：切換驗收 | 0 | 3 |
@@ -204,7 +204,7 @@ A/B 並列時同一件事要寫兩遍（5-A／5-B、第 8 步兩種起法、附�
 | WSL2 風險與診斷 | 1 | 12 |
 | 附錄 A：自我檢查 | 0 | 5 |
 | 附錄 B：降級備援 | 2 | 3 |
-| **合計** | **32** | **122** |
+| **合計** | **35** | **133** |
 
 （統計方式：全文 `🔧`／`✅` 標記出現次數，扣除說明性用法——「標記約定」的定義行、
 段落標題內的標記、以及表格裡當狀態記號用的那幾個。）
@@ -235,6 +235,9 @@ python3 -m paulsha_cortex.trust_root scaffold three-way
 
 # ✅ Manager system unit 內容（User=cortex-manager，ReadWritePaths 由登記表導出）
 python3 -m paulsha_cortex.trust_root unit three-way --manager
+
+# ✅ monitor system unit 內容（同帳號、同加固段，ReadWritePaths 嚴格窄於 Manager）
+python3 -m paulsha_cortex.trust_root unit three-way --monitor
 
 # ✅ job template unit 內容（User=cortex-builder 硬寫死；B 的核心）
 python3 -m paulsha_cortex.trust_root unit three-way --job
@@ -624,7 +627,7 @@ find "$HOME/.agents" -perm /022 -print | head
 
 ---
 
-## 第 4 步：Manager 遷 root-owned 部署 ＋ system-level unit
+## 第 4 步：Manager／monitor 遷 root-owned 部署 ＋ system-level unit
 
 ### 4a. venv 遷入 `/opt/cortex`
 
@@ -760,6 +763,105 @@ sudo systemctl restart cortex-manager.service && echo "restored: OK"
 **回滾**：`sudo systemctl disable --now cortex-manager.service;
 sudo rm /etc/systemd/system/cortex-manager.service; sudo systemctl daemon-reload`，
 再以 `systemctl --user start cortex-manager.service` 回到舊部署（見第 9 步）。
+
+### 4d. Monitor system-level unit（內容由 permgen 產生）
+
+> **不可省略**（issue #622）。舊的 `cortex-monitor.service` 是 `--user` unit、以
+> operator 身分跑、`PSC_MONITOR_STATE_ROOT` 指著舊的 `~/.agents/monitor`。第 4 步之後
+> 把它起回來只會**雙寫**——`monitor-state-tree`／`monitor-work-items-snapshot`／
+> `monitor-github-sync-cursor` 出現兩個來源，正是 Phase 2b 要收斂掉的狀態；而且它
+> 寫不進 `0700 cortex-manager` 的 `/var/lib/cortex/monitor`，只會靜默地繼續寫舊樹。
+> **跳過本步＝instance 沒有 monitor**：GitHub issue sync／work-items 快照停擺，
+> `monitor-event-spool` 只有 builder 的 `wx` 生產端、沒有消費端，spool 只增不減。
+
+monitor 與 Manager **同帳號**（UID 方案表：`cortex-manager`＝Manager ＋ monitor——
+唯有同帳號才寫得進自己的 `0700` state 樹），加固段與 EnvironmentFile 也是同一份；
+但 `ReadWritePaths` **嚴格更窄**：產生器只從 monitor persona 在 R1 登記表上的
+writer／spool-consumer 面導出。
+
+| `ReadWritePaths` | 涵蓋的登記表資產 |
+|---|---|
+| `/var/lib/cortex/monitor` | `monitor-state-tree`、`monitor-work-items-snapshot`、`monitor-github-sync-cursor`、`monitor-event-spool`（消費＝讀完 unlink，需要容器目錄的寫入權） |
+| `/var/lib/cortex/run/cortex` | `runtime-run-tree`（monitor 的 unix socket） |
+| `/var/lib/cortex-manager/cache` | 明示 extra：服務帳號 HOME 快取（git／gh／uv），與 Manager 是同一條、不是第二條 |
+
+`coordinator/`、`specs/`、`control/`、`worktree/`、`registry/`、`config/` 一律**不在**
+其中：monitor 在登記表上既不是它們的 writer、也不是它們的 spool consumer。要讓某條
+回來，唯一的辦法是改登記表再重跑產生器——unit 沒有手擴的入口。
+
+```bash
+# ✅ 先看內容（ReadWritePaths 逐條附「涵蓋哪些登記表資產」註解）
+python3 -m paulsha_cortex.trust_root unit three-way --monitor | less
+
+# ✅ 先驗「窄」這件事本身：monitor 的 RWP 必須是 Manager 的真子集
+diff <(python3 -m paulsha_cortex.trust_root unit three-way --monitor | grep ^ReadWritePaths=) \
+     <(python3 -m paulsha_cortex.trust_root unit three-way --manager | grep ^ReadWritePaths=)
+#   期望：只有 `<` 那側缺行（monitor 少），**不得**出現 `>` 獨有的 monitor 條目
+
+# 🔧 sudo：寫入 unit（內容一字不改，直接由產生器落檔）
+python3 -m paulsha_cortex.trust_root unit three-way --monitor \
+  | sudo tee /etc/systemd/system/cortex-monitor.service >/dev/null
+sudo chown root:root /etc/systemd/system/cortex-monitor.service
+sudo chmod 0644 /etc/systemd/system/cortex-monitor.service
+
+# 🔧 sudo：確認舊的 --user monitor 已停用且不會被 lingering 拉回來
+systemctl --user disable --now cortex-monitor.service 2>/dev/null || true
+
+# 🔧 sudo：載入並啟用（system-level，非 --user）
+sudo systemctl daemon-reload
+sudo systemctl enable cortex-monitor.service
+sudo systemctl start cortex-monitor.service
+```
+
+```bash
+# ✅ 驗證：unit 檔內容與產生器輸出逐位元相同（防手改漂移）
+diff <(python3 -m paulsha_cortex.trust_root unit three-way --monitor) \
+     /etc/systemd/system/cortex-monitor.service && echo "monitor unit in sync: OK"
+
+# ✅ 驗證：身分與加固段（應與 cortex-manager.service 逐項相同）
+systemctl show cortex-monitor.service \
+  -p User -p NoNewPrivileges -p ProtectSystem -p ProtectHome -p ProtectProc \
+  -p CapabilityBoundingSet -p MemoryDenyWriteExecute -p ReadWritePaths
+#   期望：**User=cortex-manager**、NoNewPrivileges=yes、ProtectSystem=strict、
+#         ProtectHome=yes、ProtectProc=invisible、CapabilityBoundingSet=（空）、
+#         MemoryDenyWriteExecute=yes；ReadWritePaths 僅上表三條
+
+# ✅ 驗證：monitor 行程確實以 cortex-manager 身分跑
+ps -o user=,pid=,cmd= -p "$(systemctl show cortex-monitor.service -p MainPID --value)"
+#   期望：user 欄為 cortex-manager，cmd 為 /opt/cortex/venv/bin/cortex monitor
+
+# ✅ 驗證：起得來、無 EPERM/EROFS（加固誤擋的第一現場）
+systemctl status cortex-monitor.service --no-pager
+sudo journalctl -u cortex-monitor.service -n 100 --no-pager \
+  | grep -Ei "eperm|erofs|eacces|read-only" || echo "no denial in log: OK"
+
+# ✅ 驗證：新樹確實有寫入（不是還在寫舊的 ~/.agents/monitor）
+sudo ls -la /var/lib/cortex/monitor
+sudo find /var/lib/cortex/monitor -maxdepth 1 -newermt '-5 minutes' -print
+#   期望：work-items.snapshot.json／github-issue-sync.json 於近幾分鐘內被更新
+ls -la "$HOME/.agents/monitor" 2>/dev/null && echo "⚠️ 舊樹仍在——確認其 mtime 未再前進"
+
+# ✅ 驗證：event-spool 真的被消費（#622 的契約面：有生產端也要有消費端）
+sudo ls /var/lib/cortex/monitor/event-spool | head
+#   期望：空的、或項目數會隨時間下降；持續單調增加代表消費端沒在跑
+
+# ✅ 驗證：monitor socket 落在 run root、由 cortex-manager 擁有
+sudo ls -la /var/lib/cortex/run/cortex/project-monitor.sock
+#   期望：owner cortex-manager、mode 0600
+
+# ✅ 驗證：fail-closed——刪掉 env 檔必須拒絕啟動（測完立刻還原）
+sudo mv /opt/cortex/etc/cortex-manager.env /opt/cortex/etc/cortex-manager.env.bak
+sudo systemctl restart cortex-monitor.service; echo "exit=$?"
+#   期望：restart 失敗（非 0），status 顯示 EnvironmentFile 缺檔
+sudo mv /opt/cortex/etc/cortex-manager.env.bak /opt/cortex/etc/cortex-manager.env
+sudo systemctl restart cortex-monitor.service && echo "restored: OK"
+```
+
+**回滾**：`sudo systemctl disable --now cortex-monitor.service;
+sudo rm /etc/systemd/system/cortex-monitor.service; sudo systemctl daemon-reload`，
+再以 `systemctl --user start cortex-monitor.service` 回到舊部署（見第 9 步）。
+**注意**：回滾後 monitor 會重新寫舊的 `~/.agents/monitor` 樹，與 system-level Manager
+的 `/var/lib/cortex/monitor` 形成雙寫——僅可作為短時間的救急手段。
 
 ---
 
@@ -1482,6 +1584,7 @@ Phase 1 完全不需 root 且含降級運轉安全網（`PSC_DEGRADED_OPERATION=
 | 第 4a（部署） | 新 venv 起不來 | `sudo rm -rf /opt/cortex/venv; sudo mv /opt/cortex/venv.prev /opt/cortex/venv; sudo systemctl restart cortex-manager` |
 | 第 4c（system unit） | WSL 重啟後未拉起／服務起不來 | `sudo systemctl disable --now cortex-manager.service`；改回 `systemctl --user start cortex-manager.service`（舊部署仍在 `$HOME/.local/share/pipx`） |
 | 第 4c（加固誤擋） | 服務起來但功能靜默失效 | 見下方「`ProtectSystem=strict` 誤擋診斷」；**臨時** drop-in 放行、**同一天**把該路徑回填 R1 登記表並重跑 permgen |
+| 第 4d（monitor unit） | monitor 起不來／新樹無寫入 | `sudo systemctl disable --now cortex-monitor.service`；改回 `systemctl --user start cortex-monitor.service`（**會與 system-level Manager 雙寫**，僅救急） |
 | **第 5-2（template unit）** | instance 起不來／unit 語法錯 | `sudo rm -f /etc/systemd/system/cortex-job@.service; sudo rm -rf /etc/systemd/system/cortex-job@.service.d; sudo systemctl daemon-reload`；(d) 一併關閉（見下一列） |
 | **第 5-3（shim）** | job 起得來但 argv 不對／shim crash | `sudo rm -f /opt/cortex/bin/cortex-job-shim`；重新由產生器落檔並 `diff` 對齊；仍不對則關 (d) |
 | **第 5-4（polkit）** | 規則語法錯／`cortex-manager` 起不了任何 job | `sudo rm -f /etc/polkit-1/rules.d/49-cortex-downgrade.rules; sudo systemctl restart polkit.service`；此時降權面完全關閉（fail-closed，job 起不來但無提權） |

--- a/paulsha_cortex/trust_root/__main__.py
+++ b/paulsha_cortex/trust_root/__main__.py
@@ -10,9 +10,13 @@ Phase 1 不改 `cortex` CLI（避免動到 R-16 help 對齊面）；operator／C
     python -m paulsha_cortex.trust_root permissions [three-way|two-way] [--commands] [--paths]
                                                     # Phase 2a 權限計畫（JSON 或命令序列）
     python -m paulsha_cortex.trust_root unit [three-way|two-way]
-                                        [--manager|--job|--job-properties]
+                                        [--manager|--monitor|--job|--job-properties]
                                                     # Phase 2b systemd unit 內容
-                                                    # （--job-properties＝方案 A 的
+                                                    # （--monitor＝monitor 的 system-level
+                                                    #   unit：與 manager 同帳號、同加固段，
+                                                    #   但 ReadWritePaths 只由 monitor
+                                                    #   persona 的登記表面導出，嚴格更窄；
+                                                    #   --job-properties＝方案 A 的
                                                     #   systemd-run --property= 清單）
     python -m paulsha_cortex.trust_root shim [three-way|two-way]
                                                     # Phase 2b 方案 B 的降權 shim 內容
@@ -124,6 +128,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         for token in rest:
             if token == "--manager":
                 which = "manager"
+            elif token == "--monitor":
+                which = "monitor"
             elif token == "--job":
                 which = "job"
             elif token == "--job-properties":
@@ -142,12 +148,12 @@ def main(argv: Sequence[str] | None = None) -> int:
             for prop in permgen.transient_unit_properties(scheme):
                 print(prop)
             return 0
-        unit = (
-            permgen.build_manager_unit(scheme)
-            if which == "manager"
-            else permgen.build_job_unit(scheme)
-        )
-        print(unit.content, end="")
+        builders = {
+            "manager": permgen.build_manager_unit,
+            "monitor": permgen.build_monitor_unit,
+            "job": permgen.build_job_unit,
+        }
+        print(builders[which](scheme).content, end="")
         return 0
     if command == "shim":
         rest = args[1:]

--- a/paulsha_cortex/trust_root/permgen.py
+++ b/paulsha_cortex/trust_root/permgen.py
@@ -488,6 +488,11 @@ class PermissionPlan:
 
     scheme_id: str
     entries: tuple[PermissionEntry, ...]
+    #: 產生本計畫的登記表切片。`PermissionEntry` 只留權限結論、不留 persona 面，
+    #: 但 per-persona 的 ReadWritePaths 導出（`principals=` 過濾）需要回頭看
+    #: writers／readers，故把輸入資產一併帶著走。手工組出的 plan 留空 tuple，
+    #: 此時 `required_write_targets` 退回 `registry.ASSET_REGISTRY` 查表。
+    assets: tuple[TrustRootAsset, ...] = ()
 
     def by_id(self, asset_id: str) -> PermissionEntry:
         for e in self.entries:
@@ -517,7 +522,7 @@ def generate_plan(
 ) -> PermissionPlan:
     """對登記表每一項機械產生權限，回傳完整計畫（涵蓋無遺漏）。"""
     entries = tuple(build_entry(a, scheme) for a in assets)
-    return PermissionPlan(scheme_id=scheme.scheme_id, entries=entries)
+    return PermissionPlan(scheme_id=scheme.scheme_id, entries=entries, assets=tuple(assets))
 
 
 def _placeholder_path(entry: PermissionEntry) -> str:
@@ -692,6 +697,16 @@ class PathLayout:
         return f"{self.venv_root}/bin/cortex service run"
 
     @property
+    def monitor_exec_start(self) -> str:
+        """monitor 的 `ExecStart=`。
+
+        形態刻意與 Manager 同一種：**部署 venv 裡的 `cortex` console script ＋ 一個
+        既有的 CLI verb**，而不是 `python -m paulsha_cortex.monitor`。理由見
+        `build_monitor_unit()` 的 docstring 與 unit 內註解。
+        """
+        return f"{self.venv_root}/bin/cortex monitor"
+
+    @property
     def env_file(self) -> str:
         return f"{self.deploy_root}/etc/{self.instance}-manager.env"
 
@@ -845,6 +860,16 @@ class PathLayout:
             ),
         )
 
+    def monitor_extra_write_paths(self, account: str) -> tuple[ExtraWritePath, ...]:
+        """monitor unit 的額外可寫路徑。
+
+        三分 UID 方案表寫的是「`cortex-manager`：Manager ＋ **monitor**」——同一個
+        帳號、同一個 HOME，因此這裡**刻意複用** `manager_extra_write_paths()` 而不
+        另開一條例外：monitor 的 `git`／`gh`／`uv` 快取就是 Manager 的那一個
+        `XDG_CACHE_HOME`，寫成兩條會讓「例外通道」看起來比實際多一條。
+        """
+        return self.manager_extra_write_paths(account)
+
     def job_extra_write_paths(self, account: str) -> tuple[ExtraWritePath, ...]:
         # 帳號由呼叫端（`build_job_unit` 的 principal）給：M2 要為 reviewer/planner
         # 開第二個模板 unit 時，這裡不必改一行——換 principal 即換帳號。
@@ -887,22 +912,59 @@ def _minimize(paths: set[str]) -> tuple[str, ...]:
     return tuple(sorted(set(kept)))
 
 
+def principal_needs_write(
+    asset: TrustRootAsset,
+    principals: frozenset[Principal],
+) -> bool:
+    """該組 persona 是否需要對此資產可寫——**只看登記表，沒有第二條規則**。
+
+    兩種「需要寫」，都直接讀自登記表欄位：
+
+    1. **直接 writer**：persona 出現在 `asset.writers`。
+    2. **單向 spool 的 trusted consumer**：`IngressKind.INTERPROCESS` 的 reader。
+       消費＝讀完即 unlink（`monitor-event-spool` 的 note 就是這麼寫的：「別的
+       行程寫入、monitor 消費即消失」），而 unlink 需要對**容器目錄**的寫入權。
+       少了這條，monitor unit 會拿到一個「讀得到卻刪不掉」的 spool——事件會被
+       重複消費，spool 只增不減，正是 #622 描述的那個沒有消費端的狀態。
+
+    這條規則是**帳號過濾之外的第二層**：三分方案把 Manager 與 monitor 映到同一個
+    `cortex-manager` 帳號，單看帳號兩者的可寫面完全相同；要讓 monitor unit 真的
+    比 Manager 窄，必須回到 persona 這一層來切。
+    """
+    if any(p in principals for p in asset.writers):
+        return True
+    if asset.ingress_kind is IngressKind.INTERPROCESS:
+        return any(p in principals for p in asset.readers)
+    return False
+
+
 def required_write_targets(
     plan: PermissionPlan,
     layout: PathLayout,
     account: str,
+    principals: frozenset[Principal] | None = None,
 ) -> dict[str, str]:
     """`asset_id → 該帳號必須可寫的目標路徑`（檔案取其父目錄）。
 
     ProtectSystem=strict 下整個檔案系統唯讀；要**建立／取代**一個檔，必須對其
     父目錄可寫，故檔案資產一律折算成父目錄。這就是「ReadWritePaths 由登記表機械
     導出」的全部規則——沒有第二條。
+
+    `principals` 給定時再套一層 persona 過濾（見 `principal_needs_write`）：同一
+    帳號上跑多個 persona 時（三分的 `cortex-manager`＝Manager＋monitor），每個
+    unit 只拿自己那一份，而不是帳號的全集。`None`＝不過濾（帳號全集，Manager
+    unit 與 job 模板 unit 的既有行為）。
     """
     targets: dict[str, str] = {}
     paths = layout.asset_paths()
+    index = {a.asset_id: a for a in (plan.assets or registry.ASSET_REGISTRY)}
     for entry in plan.entries:
         if account not in plan.all_writable_accounts(entry):
             continue
+        if principals is not None:
+            asset = index.get(entry.asset_id)
+            if asset is None or not principal_needs_write(asset, principals):
+                continue
         path = paths[entry.asset_id]
         targets[entry.asset_id] = path if entry.is_directory else _parent_dir(path)
     return targets
@@ -913,9 +975,10 @@ def read_write_paths(
     layout: PathLayout,
     account: str,
     extras: tuple[ExtraWritePath, ...] = (),
+    principals: frozenset[Principal] | None = None,
 ) -> tuple[str, ...]:
     """該帳號 unit 的 `ReadWritePaths=` 最小覆蓋集合（登記表導出 ∪ 明示 extras）。"""
-    wanted = set(required_write_targets(plan, layout, account).values())
+    wanted = set(required_write_targets(plan, layout, account, principals).values())
     wanted |= {e.path for e in extras}
     return _minimize(wanted)
 
@@ -925,11 +988,12 @@ def read_write_path_owners(
     layout: PathLayout,
     account: str,
     extras: tuple[ExtraWritePath, ...] = (),
+    principals: frozenset[Principal] | None = None,
 ) -> dict[str, tuple[str, ...]]:
     """每條 ReadWritePaths → 它涵蓋的 asset_id（或 `extra:<reason>`），供逐條註解。"""
-    targets = required_write_targets(plan, layout, account)
+    targets = required_write_targets(plan, layout, account, principals)
     result: dict[str, tuple[str, ...]] = {}
-    for rwp in read_write_paths(plan, layout, account, extras):
+    for rwp in read_write_paths(plan, layout, account, extras, principals):
         covered = sorted(aid for aid, t in targets.items() if _is_within(t, rwp))
         covered += [f"extra:{e.reason}" for e in extras if _is_within(e.path, rwp)]
         result[rwp] = tuple(covered)
@@ -1203,7 +1267,10 @@ def traverse_commands(grants: tuple[TraverseGrant, ...]) -> list[str]:
 
 
 # ---------------------------------------------------------------------------
-# systemd unit 產生（Manager system unit ＋ 降權 job 模板 unit）
+# systemd unit 產生（Manager／monitor system unit ＋ 降權 job 模板 unit）
+#
+# 三份 unit 共用同一份加固表（`_HARDENING`）與同一套 ReadWritePaths 導出
+# （`read_write_path_owners`）；差別只在 `User=`／`ExecStart=`／persona 過濾。
 # ---------------------------------------------------------------------------
 
 #: 加固指令 →（值, 為何）。逐項附註解是 spec §R3 的可審查性要求。
@@ -1384,6 +1451,132 @@ def build_manager_unit(
         install_path=f"/etc/systemd/system/{unit_name}",
         account=account,
         exec_start=layout.exec_start,
+        environment_file=layout.env_file,
+        read_write_paths=tuple(owners.keys()),
+        content="\n".join(body) + "\n",
+    )
+
+
+#: monitor unit 的 persona 過濾集合。ReadWritePaths 只從這組 persona 在登記表上的
+#: writer／spool-consumer 面導出——**這是 monitor unit 比 Manager unit 窄的機制**。
+MONITOR_PRINCIPALS: frozenset[Principal] = frozenset({Principal.MONITOR})
+
+
+def build_monitor_unit(
+    scheme: UidScheme,
+    layout: PathLayout = DEFAULT_LAYOUT,
+    plan: PermissionPlan | None = None,
+) -> SystemdUnit:
+    """monitor 的 system-level unit（`User=<durable_state_owner>`，與 Manager 同帳號）。
+
+    ## 為什麼 `User=` 與 Manager 同一個帳號
+
+    三分方案的 UID 表寫的就是「`cortex-manager`：Manager ＋ monitor」（見
+    :data:`THREE_WAY_SCHEME`）。裁決的判準是「injection 可達的任何進程都不得持有
+    spawn 授權」——monitor **不跑任何模型程式碼**，與 Manager 同屬那條線的內側；
+    而 `/var/lib/cortex/monitor` 是 `0700 cortex-manager`，monitor 若以別的身分跑
+    就根本寫不進自己的 state 樹（#622 的實機症狀正是如此：舊 `--user` monitor 以
+    操作者身分跑，只能靜默地繼續寫舊的 `~/.agents` 樹）。
+
+    ## 為什麼 ReadWritePaths 必須比 Manager 窄
+
+    同帳號**不代表**同可寫面。`required_write_targets()` 只按帳號過濾時，monitor
+    會拿到 Manager 的全集（`coordinator/`、`specs/`、`control/`、`worktree/`…），
+    等於把 monitor 的任何 bug／被餵入的惡意 GitHub 內容，變成對整棵 durable state
+    的寫入面。因此這裡多帶一層 persona 過濾（:data:`MONITOR_PRINCIPALS`），讓
+    ReadWritePaths 只由 **monitor 這個 persona 在登記表上的資產**導出：
+
+    - `monitor-state-tree`／`monitor-work-items-snapshot`／`monitor-github-sync-cursor`
+      （`writers=(MONITOR,)`）
+    - `monitor-event-spool`（`INTERPROCESS` spool 的 trusted consumer——消費＝unlink，
+      需要容器目錄的寫入權；#622 的「有生產端沒消費端」就是這一格）
+    - `runtime-run-tree`（`writers=(MANAGER, MONITOR)`——monitor 的 unix socket）
+
+    其餘全部落在 monitor 的 persona 面之外，因此**機械地**不會出現在這份 unit 上。
+    要讓某條回來，唯一的辦法是改登記表把 monitor 登記成該資產的 writer／consumer，
+    然後重跑產生器——沒有手擴的入口。
+
+    ## ExecStart 的形態（#618／PR #619 對齊）
+
+    與 Manager 同形：`<venv>/bin/cortex <verb>`，這裡的 verb 是**既有**的
+    `cortex monitor`（`cli.py` 轉發到 `paulsha_cortex.monitor.__main__:main`，不帶
+    `--once` 即長駐 `ProjectMonitorService.run_forever()`，符合 `Type=simple`）。
+    #618 的教訓是「ExecStart 契約只存在於產生器端、CLI 沒跟上」，因此本 PR 一併加了
+    契約鎖測試把兩端綁住；差別在 Manager 那次必須**補**一個 verb，monitor 這次
+    verb 早就在（`cortex monitor` 是 README 與 `cli.py` 的公開介面），所以只補鎖。
+
+    刻意**不用** `<venv>/bin/python -m paulsha_cortex.monitor`：那條路繞過 console
+    script，等於在部署樹裡開第二種進入點形態——`cortex service run` 與
+    `python -m ...` 之後會各自漂移，而 R-16 的 CLI help 對齊面只看得到前者。
+    """
+    plan = plan or generate_plan(scheme)
+    account = scheme.durable_state_owner
+    group = scheme.group_of(account)
+    extras = layout.monitor_extra_write_paths(account)
+    owners = read_write_path_owners(
+        plan, layout, account, extras, principals=MONITOR_PRINCIPALS
+    )
+    unit_name = f"{layout.instance}-monitor.service"
+
+    body = [
+        f"# {'/etc/systemd/system/' + unit_name}",
+        f"# 由 permgen 機械產生（scheme={scheme.scheme_id}）——勿手改；改登記表後重跑：",
+        f"#   python3 -m paulsha_cortex.trust_root unit {scheme.scheme_id} --monitor",
+        "#",
+        "# monitor 與 Manager 同帳號（UID 方案表：cortex-manager＝Manager ＋ monitor），",
+        "# 但**可寫面不同**：下方 ReadWritePaths 只由 monitor persona 在 R1 登記表上的",
+        "# writer／spool-consumer 面導出，是 Manager unit 的真子集。",
+        "",
+        "[Unit]",
+        "Description=cortex Monitor (trust-root Phase 2b, system-level)",
+        "Documentation=file://docs/superpowers/runbooks/trust-root-phase2b-setup.md",
+        "After=network-online.target",
+        "Wants=network-online.target",
+        "",
+        "[Service]",
+        "Type=simple",
+        "# 受信任服務身分。monitor 不跑任何模型程式碼，故與 Manager 同屬授權線內側；",
+        f"# 也唯有同帳號才寫得進 0700 {account} 的 {layout.monitor_state_root}。",
+        f"User={account}",
+        f"Group={group}",
+        "",
+        "# 與 Manager 同形態的進入點：部署 venv 的 console script ＋ 既有 CLI verb",
+        "# （`cortex monitor` → paulsha_cortex.monitor.__main__:main；不帶 --once 即長駐）。",
+        "# 不寫 `python -m paulsha_cortex.monitor`——那會在部署樹裡開第二種進入點形態，",
+        "# 與 `cortex service run` 各自漂移（#618 就是產生器與 CLI 單邊漂移的後果）。",
+        f"ExecStart={layout.monitor_exec_start}",
+        "# 落在 durable state 樹根（root-owned、對本服務唯讀）——monitor 的掃描目標一律",
+        "# 由 config 指定絕對路徑，這裡只要一個必然存在、不隨 operator HOME 漂移的 cwd。",
+        f"WorkingDirectory={layout.agents_root}",
+        "",
+        "# EnvironmentFile 無 '-' 前綴＝fail-closed：檔案缺席即拒絕啟動，",
+        "# MUST NOT 靜默落回 $HOME/.agents 預設。這正是 #622 的核心——舊 --user monitor",
+        "# 的 PSC_MONITOR_STATE_ROOT 指著舊樹，起回來只會雙寫。與 Manager 共用同一份",
+        "# instance-scoped env，兩個服務因此不可能解析到不同的 durable state 樹。",
+        f"EnvironmentFile={layout.env_file}",
+        "# HOME 由 unit 指定；HOME 本身 root-owned，只有 cache 子目錄可寫。",
+        "# 路徑由帳號名導出（`layout.home_of`）——換 scheme 時不會停在舊帳號的樹上。",
+        f"Environment=HOME={layout.home_of(account)}",
+        f"Environment=XDG_CACHE_HOME={layout.cache_of(account)}",
+        "",
+        "# --- 加固（與 Manager unit 逐項同一份表；集合比對有測試守著，不得單邊漂移）---",
+    ]
+    body += _hardening_lines()
+    body += [""]
+    body += _rwp_lines(owners)
+    body += [
+        "",
+        "Restart=on-failure",
+        "RestartSec=10s",
+        "",
+        "[Install]",
+        "WantedBy=multi-user.target",
+    ]
+    return SystemdUnit(
+        unit_name=unit_name,
+        install_path=f"/etc/systemd/system/{unit_name}",
+        account=account,
+        exec_start=layout.monitor_exec_start,
         environment_file=layout.env_file,
         read_write_paths=tuple(owners.keys()),
         content="\n".join(body) + "\n",

--- a/tests/test_trust_root_monitor_unit_622.py
+++ b/tests/test_trust_root_monitor_unit_622.py
@@ -1,0 +1,412 @@
+"""issue #622：monitor 的 system-level unit（`trust_root unit three-way --monitor`）。
+
+Phase 2b M1 之後 permgen 只產生 Manager unit，實機切換後 cortex instance **完全沒有
+monitor**：舊的 `--user` monitor 以操作者身分跑、指向舊 `~/.agents`，起回來只會雙寫
+且寫不進 `0700 cortex-manager` 的新樹；`monitor-event-spool` 因此只有生產端
+（builder 的 `wx` ACL）沒有消費端。
+
+本檔釘住四條，讓那個狀態不可能再出現，也不可能單邊漂移回去：
+
+1. `User=` 是 durable_state_owner（UID 方案表：`cortex-manager`＝Manager ＋ monitor）；
+2. 加固欄位與 Manager unit **集合相等**（任一邊加減一項就紅）；
+3. `ReadWritePaths` 是 Manager 的**真子集**，且內容恰為 monitor persona 的登記表面；
+4. `ExecStart` 指向的 CLI verb 真的存在（比照 `tests/test_service_run_verb.py`——
+   #618 就是這條契約只存在於產生器端而斷掉）。
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from paulsha_cortex import cli
+from paulsha_cortex.trust_root import permgen
+from paulsha_cortex.trust_root.permgen import (
+    DEFAULT_LAYOUT,
+    THREE_WAY_SCHEME,
+    TWO_WAY_SCHEME,
+    build_manager_unit,
+    build_monitor_unit,
+    generate_plan,
+)
+from paulsha_cortex.trust_root.registry import (
+    ASSET_REGISTRY,
+    IngressKind,
+    Principal,
+)
+
+ALL_SCHEMES = [TWO_WAY_SCHEME, THREE_WAY_SCHEME]
+
+
+def _within(child: str, parent: str) -> bool:
+    return child == parent or child.startswith(parent.rstrip("/") + "/")
+
+
+def _directives(content: str) -> dict[str, str]:
+    """unit 內容 → `{key: value}`（略過註解與 section 標頭；重複 key 取最後一筆）。"""
+    result: dict[str, str] = {}
+    for line in content.splitlines():
+        if not line or line.startswith("#") or line.startswith("["):
+            continue
+        key, _, value = line.partition("=")
+        result[key] = value
+    return result
+
+
+# ---------------------------------------------------------------------------
+# 身分：與 Manager 同帳號，且永不是 root
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
+def test_monitor_unit_runs_as_the_durable_state_owner(scheme) -> None:
+    """UID 方案表：`cortex-manager`＝Manager ＋ monitor。
+
+    同帳號不是巧合而是必要條件——`/var/lib/cortex/monitor` 是 `0700
+    durable_state_owner`，monitor 以任何其他身分跑都寫不進自己的 state 樹。
+    """
+    unit = build_monitor_unit(scheme, DEFAULT_LAYOUT)
+    assert unit.account == scheme.durable_state_owner
+    assert f"User={scheme.durable_state_owner}" in unit.content
+    assert f"Group={scheme.group_of(scheme.durable_state_owner)}" in unit.content
+    assert "User=root" not in unit.content
+    assert unit.unit_name == "cortex-monitor.service"
+    assert unit.install_path == "/etc/systemd/system/cortex-monitor.service"
+
+
+@pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
+def test_monitor_and_manager_share_the_service_account(scheme) -> None:
+    manager = build_manager_unit(scheme, DEFAULT_LAYOUT)
+    monitor = build_monitor_unit(scheme, DEFAULT_LAYOUT)
+    assert monitor.account == manager.account
+
+
+def test_three_way_scheme_moves_the_monitor_account_too() -> None:
+    """換 scheme 只換 config：monitor unit 的身分與 HOME 跟著走，程式碼零改動。"""
+    assert build_monitor_unit(TWO_WAY_SCHEME, DEFAULT_LAYOUT).account == "cortex-svc"
+    three = build_monitor_unit(THREE_WAY_SCHEME, DEFAULT_LAYOUT)
+    assert three.account == "cortex-manager"
+    assert "Environment=HOME=/var/lib/cortex-manager\n" in three.content
+    assert "Environment=XDG_CACHE_HOME=/var/lib/cortex-manager/cache\n" in three.content
+
+
+# ---------------------------------------------------------------------------
+# 加固段：與 Manager unit 集合相等（不得單邊漂移）
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
+def test_monitor_hardening_is_set_equal_to_manager(scheme) -> None:
+    """集合比對而非逐項列舉：日後往 `_HARDENING` 加一項，兩邊必須同時拿到。
+
+    只驗「monitor ⊇ manager」會漏掉 monitor 多開一項的情況，反之亦然，故取等式。
+    """
+    manager = _directives(build_manager_unit(scheme, DEFAULT_LAYOUT).content)
+    monitor = _directives(build_monitor_unit(scheme, DEFAULT_LAYOUT).content)
+    keys = {key for key, _value, _why in permgen._HARDENING}
+    assert {k: v for k, v in monitor.items() if k in keys} == {
+        k: v for k, v in manager.items() if k in keys
+    }
+    # 加固表本身也要完整落地（避免兩邊「一致地都缺」）。
+    assert keys <= set(monitor)
+
+
+@pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
+def test_monitor_unit_carries_every_hardening_directive_with_a_comment(scheme) -> None:
+    """每項加固都要帶「為何」的註解——可審查性要求，與 Manager unit 同標準。"""
+    lines = build_monitor_unit(scheme, DEFAULT_LAYOUT).content.splitlines()
+    for key, value, why in permgen._HARDENING:
+        directive = f"{key}={value}"
+        assert directive in lines, directive
+        index = lines.index(directive)
+        assert lines[index - 1].startswith("# "), directive
+        assert why.split("：")[0][:6] in lines[index - 1], directive
+
+
+# ---------------------------------------------------------------------------
+# ReadWritePaths：由登記表機械導出，且嚴格窄於 Manager
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
+def test_monitor_read_write_paths_are_strictly_narrower_than_manager(scheme) -> None:
+    """核心驗收：真子集（是子集**且不相等**）。
+
+    同帳號意味著單看帳號兩者可寫面相同；這條測試就是「persona 過濾真的有作用」
+    的機械證據——拿掉 `principals=` 過濾即紅。
+    """
+    manager = set(build_manager_unit(scheme, DEFAULT_LAYOUT).read_write_paths)
+    monitor = set(build_monitor_unit(scheme, DEFAULT_LAYOUT).read_write_paths)
+    assert monitor < manager, (sorted(monitor), sorted(manager))
+
+
+@pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
+def test_monitor_read_write_paths_exclude_the_manager_only_trees(scheme) -> None:
+    """monitor 不擁有也不消費的樹一律不得出現（列舉 issue 點名的那幾棵）。"""
+    unit = build_monitor_unit(scheme, DEFAULT_LAYOUT)
+    for forbidden in (
+        DEFAULT_LAYOUT.coordinator_root,
+        DEFAULT_LAYOUT.specs_root,
+        DEFAULT_LAYOUT.worktree_root,
+        DEFAULT_LAYOUT.control_root,
+        DEFAULT_LAYOUT.skill_registry_root,
+        DEFAULT_LAYOUT.project_config_root,
+        DEFAULT_LAYOUT.dispatch_log_root,
+        DEFAULT_LAYOUT.deploy_root,
+    ):
+        assert not any(_within(forbidden, rwp) for rwp in unit.read_write_paths), (
+            scheme.scheme_id, forbidden, unit.read_write_paths,
+        )
+
+
+@pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
+def test_monitor_read_write_paths_cover_every_monitor_asset(scheme) -> None:
+    """無遺漏：登記表中每一項 monitor persona 需寫的資產都被某條 RWP 覆蓋。"""
+    plan = generate_plan(scheme)
+    unit = build_monitor_unit(scheme, DEFAULT_LAYOUT)
+    targets = permgen.required_write_targets(
+        plan, DEFAULT_LAYOUT, scheme.durable_state_owner,
+        principals=permgen.MONITOR_PRINCIPALS,
+    )
+    assert set(targets) == {
+        "runtime-run-tree",
+        "monitor-state-tree",
+        "monitor-work-items-snapshot",
+        "monitor-github-sync-cursor",
+        "monitor-event-spool",
+    }, sorted(targets)
+    for asset_id, target in targets.items():
+        assert any(_within(target, rwp) for rwp in unit.read_write_paths), (asset_id, target)
+
+
+@pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
+def test_monitor_read_write_paths_have_no_redundant_entry(scheme) -> None:
+    """無多餘：拿掉任何一條登記表導出的條目就會有資產失去覆蓋。
+
+    明示宣告的 extras（HOME cache）是唯一例外，且必須附理由。
+    """
+    plan = generate_plan(scheme)
+    account = scheme.durable_state_owner
+    unit = build_monitor_unit(scheme, DEFAULT_LAYOUT)
+    targets = permgen.required_write_targets(
+        plan, DEFAULT_LAYOUT, account, principals=permgen.MONITOR_PRINCIPALS
+    )
+    extras = {e.path for e in DEFAULT_LAYOUT.monitor_extra_write_paths(account)}
+    assert all(e.reason for e in DEFAULT_LAYOUT.monitor_extra_write_paths(account))
+
+    for rwp in unit.read_write_paths:
+        if rwp in extras:
+            continue
+        remaining = [p for p in unit.read_write_paths if p != rwp]
+        uncovered = [
+            asset_id
+            for asset_id, target in targets.items()
+            if not any(_within(target, other) for other in remaining)
+        ]
+        assert uncovered, (scheme.scheme_id, f"{rwp} 是多餘條目——移除後無資產失去覆蓋")
+
+
+@pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
+def test_monitor_can_consume_the_event_spool(scheme) -> None:
+    """#622 的契約面：spool 有 builder 的 `wx` 生產端，也必須有可 unlink 的消費端。
+
+    消費＝讀完 unlink，unlink 需要**容器目錄**的寫入權；ProtectSystem=strict 下
+    沒有涵蓋它的 RWP 就等於只累積不消費。
+    """
+    spool = DEFAULT_LAYOUT.asset_paths()["monitor-event-spool"]
+    unit = build_monitor_unit(scheme, DEFAULT_LAYOUT)
+    assert any(_within(spool, rwp) for rwp in unit.read_write_paths), unit.read_write_paths
+
+
+@pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
+def test_monitor_read_write_paths_carry_the_registry_provenance_comment(scheme) -> None:
+    """每條 RWP 上方保留「涵蓋哪些登記表資產」的註解（比照 Manager unit）。"""
+    lines = build_monitor_unit(scheme, DEFAULT_LAYOUT).content.splitlines()
+    for index, line in enumerate(lines):
+        if not line.startswith("ReadWritePaths="):
+            continue
+        assert lines[index - 1].startswith("#   涵蓋："), line
+        assert lines[index - 1].removeprefix("#   涵蓋：").strip() not in ("", "（無）"), line
+
+
+def test_read_write_paths_shift_when_the_monitor_registry_face_shrinks() -> None:
+    """機械性反證：把 monitor 需寫的一項從登記表拿掉，導出的 RWP 必須跟著變。
+
+    取 `runtime-run-tree`（monitor 的 unix socket）而非 monitor state 族——後者四項
+    共用同一個容器目錄，拿掉一項不會讓那條 RWP 消失，證不出機械性。
+    """
+    def _paths(assets) -> tuple[str, ...]:
+        return permgen.read_write_paths(
+            generate_plan(THREE_WAY_SCHEME, assets), DEFAULT_LAYOUT,
+            THREE_WAY_SCHEME.durable_state_owner,
+            principals=permgen.MONITOR_PRINCIPALS,
+        )
+
+    trimmed = tuple(a for a in ASSET_REGISTRY if a.asset_id != "runtime-run-tree")
+    assert DEFAULT_LAYOUT.run_root in _paths(ASSET_REGISTRY)
+    assert DEFAULT_LAYOUT.run_root not in _paths(trimmed)
+    # 其餘 monitor 面不受影響（spool 的消費端不因此消失）。
+    spool = DEFAULT_LAYOUT.asset_paths()["monitor-event-spool"]
+    assert any(_within(spool, rwp) for rwp in _paths(trimmed)), _paths(trimmed)
+
+
+def test_principal_filter_is_derived_from_the_registry_only() -> None:
+    """導出規則只有兩條，且兩條都直接讀登記表欄位——沒有硬編碼的 asset_id 清單。"""
+    monitor = permgen.MONITOR_PRINCIPALS
+    for asset in ASSET_REGISTRY:
+        expected = any(p in monitor for p in asset.writers) or (
+            asset.ingress_kind is IngressKind.INTERPROCESS
+            and any(p in monitor for p in asset.readers)
+        )
+        assert permgen.principal_needs_write(asset, monitor) is expected, asset.asset_id
+
+
+def test_unfiltered_derivation_keeps_the_manager_behaviour() -> None:
+    """`principals=None`＝帳號全集：Manager unit 的既有導出行為一位元都沒變。"""
+    plan = generate_plan(THREE_WAY_SCHEME)
+    account = THREE_WAY_SCHEME.durable_state_owner
+    unfiltered = permgen.required_write_targets(plan, DEFAULT_LAYOUT, account)
+    filtered = permgen.required_write_targets(
+        plan, DEFAULT_LAYOUT, account, principals=permgen.MONITOR_PRINCIPALS
+    )
+    assert set(filtered) < set(unfiltered)
+    assert set(unfiltered) > {"coordinator-root-tree", "dispatch-specs-tree"}
+
+
+# ---------------------------------------------------------------------------
+# ExecStart 契約鎖（比照 tests/test_service_run_verb.py）
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
+def test_monitor_execstart_lives_in_the_root_owned_deploy_tree(scheme) -> None:
+    unit = build_monitor_unit(scheme, DEFAULT_LAYOUT)
+    assert unit.exec_start.startswith(DEFAULT_LAYOUT.deploy_root + "/")
+    assert unit.exec_start == f"{DEFAULT_LAYOUT.venv_root}/bin/cortex monitor"
+    assert f"ExecStart={unit.exec_start}" in unit.content
+    assert f"WorkingDirectory={DEFAULT_LAYOUT.agents_root}" in unit.content
+
+
+def test_monitor_execstart_shares_the_manager_entry_point_shape() -> None:
+    """與 #618／PR #619 定下的形態一致：`<venv>/bin/cortex <verb>`，不是 `python -m`。"""
+    manager = build_manager_unit(THREE_WAY_SCHEME, DEFAULT_LAYOUT)
+    monitor = build_monitor_unit(THREE_WAY_SCHEME, DEFAULT_LAYOUT)
+    prefix = f"{DEFAULT_LAYOUT.venv_root}/bin/cortex "
+    assert manager.exec_start.startswith(prefix)
+    assert monitor.exec_start.startswith(prefix)
+    assert "python" not in monitor.exec_start
+    assert " -m " not in monitor.exec_start
+
+
+def test_monitor_execstart_verb_is_actually_routed_by_the_cli(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """契約鎖：產生器的 ExecStart 與 CLI 實際提供的 verb 必須同步。
+
+    #618 就是這條斷掉——unit 一 start 就以 `unsupported service command` 失敗。
+    這裡不比字串常數，而是**真的走一次 `cli.main`**，確認該 verb 會抵達 monitor
+    的進入點。
+    """
+    unit = build_monitor_unit(THREE_WAY_SCHEME, DEFAULT_LAYOUT)
+    verb = unit.exec_start.split("/bin/cortex ", 1)[1].split()
+    assert verb == ["monitor"]
+
+    seen: dict[str, object] = {}
+
+    def fake_main(argv: list[str] | None = None) -> int:
+        seen["argv"] = list(argv or [])
+        return 0
+
+    monkeypatch.setattr(
+        "paulsha_cortex.monitor.__main__.main", fake_main, raising=True
+    )
+    assert cli.main([*verb, "--once"]) == 0
+    assert seen["argv"] == ["--once"]
+
+
+def test_monitor_entry_point_module_exists_and_is_long_running_by_default() -> None:
+    """進入點真的存在，且**不帶旗標時**是長駐服務（`Type=simple` 的前提）。"""
+    from paulsha_cortex.monitor.__main__ import build_parser, main
+
+    assert callable(main)
+    parser = build_parser()
+    assert parser.prog == "cortex monitor"
+    # `--once` 才是單次掃描；unit 不帶它，因此走 `ProjectMonitorService.run_forever()`。
+    assert parser.parse_args([]).once is False
+    assert parser.parse_args(["--once"]).once is True
+
+
+# ---------------------------------------------------------------------------
+# env／fail-closed／產生器純度
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
+def test_monitor_environment_file_is_fail_closed(scheme) -> None:
+    """無 `-` 前綴＝缺檔即拒絕啟動，不得靜默落回 `$HOME/.agents`（#622 的雙寫根因）。"""
+    unit = build_monitor_unit(scheme, DEFAULT_LAYOUT)
+    assert unit.environment_file == DEFAULT_LAYOUT.env_file
+    assert f"EnvironmentFile={DEFAULT_LAYOUT.env_file}" in unit.content
+    assert "EnvironmentFile=-" not in unit.content
+
+
+@pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
+def test_monitor_shares_the_manager_environment_file(scheme) -> None:
+    """同一份 instance-scoped env——兩個服務不可能解析到不同的 durable state 樹。"""
+    assert (
+        build_monitor_unit(scheme, DEFAULT_LAYOUT).environment_file
+        == build_manager_unit(scheme, DEFAULT_LAYOUT).environment_file
+    )
+
+
+@pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
+def test_monitor_home_paths_come_from_the_layout_not_literals(scheme) -> None:
+    """HOME／cache 由 `layout.home_of()`／`cache_of()` 導出，不得寫死字面量。"""
+    account = scheme.durable_state_owner
+    content = build_monitor_unit(scheme, DEFAULT_LAYOUT).content
+    assert f"Environment=HOME={DEFAULT_LAYOUT.home_of(account)}\n" in content
+    assert f"Environment=XDG_CACHE_HOME={DEFAULT_LAYOUT.cache_of(account)}\n" in content
+    assert "/home/" not in content
+
+
+def test_monitor_unit_is_deterministic() -> None:
+    a = build_monitor_unit(THREE_WAY_SCHEME, DEFAULT_LAYOUT)
+    b = build_monitor_unit(THREE_WAY_SCHEME, DEFAULT_LAYOUT)
+    assert a.content == b.content
+    assert a.to_dict() == b.to_dict()
+
+
+def test_monitor_unit_needs_no_code_change_for_a_custom_layout() -> None:
+    """換 layout 只換 config：unit 全面跟著走，產生器零改動。"""
+    layout = permgen.PathLayout(
+        agents_root="/srv/cx", worktree_root="/srv/cx/wt",
+        deploy_root="/srv/deploy", instance="cx", home_root="/srv/home",
+    )
+    unit = build_monitor_unit(THREE_WAY_SCHEME, layout)
+    assert unit.unit_name == "cx-monitor.service"
+    assert unit.exec_start == "/srv/deploy/venv/bin/cortex monitor"
+    assert unit.environment_file == "/srv/deploy/etc/cx-manager.env"
+    assert "/srv/cx/monitor" in unit.read_write_paths
+    assert "/var/lib" not in unit.content
+
+
+def test_monitor_generator_is_strings_only() -> None:
+    """產生器只回傳字串／結構化欄位——不得執行任何特權操作。"""
+    unit = build_monitor_unit(THREE_WAY_SCHEME, DEFAULT_LAYOUT)
+    assert isinstance(unit.content, str)
+    assert all(isinstance(p, str) for p in unit.read_write_paths)
+    assert all(isinstance(v, (str, list, type(None))) for v in unit.to_dict().values())
+
+
+def test_cli_exposes_the_monitor_unit(capsys: pytest.CaptureFixture[str]) -> None:
+    """`trust_root unit three-way --monitor` 是 runbook 引用的落檔來源。"""
+    from paulsha_cortex.trust_root.__main__ import main
+
+    assert main(["unit", "three-way", "--monitor"]) == 0
+    out = capsys.readouterr().out
+    assert out == build_monitor_unit(THREE_WAY_SCHEME, DEFAULT_LAYOUT).content
+    assert "User=cortex-manager" in out
+    # 預設仍是 manager（不打旗標不會意外拿到 monitor unit）。
+    assert main(["unit", "three-way"]) == 0
+    assert capsys.readouterr().out == build_manager_unit(
+        THREE_WAY_SCHEME, DEFAULT_LAYOUT
+    ).content
+
+
+def test_monitor_principals_is_the_registry_persona_not_an_account() -> None:
+    """過濾用的是 persona（`Principal.MONITOR`），不是帳號字串——換 scheme 不受影響。"""
+    assert permgen.MONITOR_PRINCIPALS == frozenset({Principal.MONITOR})


### PR DESCRIPTION
## 問題

Phase 2b M1 實機完成後，`permgen` 只產生 **Manager** 的 system-level unit，沒有 monitor 的對應物。實機切換後：

- `cortex-manager.service`（system-level、`User=cortex-manager`）✅ 運轉中
- `cortex-monitor.service`（`--user`、操作者身分、指向舊 `~/.agents`）⛔ 已停，**沒有替代品**

也就是 cortex instance 目前**沒有 monitor**。

舊 `--user` monitor 不能直接起回來：它的 `PSC_MONITOR_STATE_ROOT` 指著舊樹，而 Manager 已在 `/var/lib/cortex/monitor` 上工作——`monitor-state-tree`／`monitor-work-items-snapshot`／`monitor-github-sync-cursor` 會出現雙寫來源。更關鍵的是身分：`/var/lib/cortex/monitor` 是 `0700 cortex-manager`，舊 monitor **寫不進去**，只會靜默地繼續寫舊樹。結果是 `monitor-event-spool` 有生產端（builder 的 `wx` ACL）卻**沒有消費端**，spool 只增不減。

## 修法

### 1. `permgen.build_monitor_unit()` ＋ CLI `unit <scheme> --monitor`

- `User=` 取 `durable_state_owner`——UID 方案表寫的就是「`cortex-manager`：Manager ＋ **monitor**」。同帳號不是巧合而是必要條件：唯有同帳號才寫得進自己那棵 `0700` 的 state 樹。
- 加固段直接吃同一份 `_HARDENING`（`NoNewPrivileges`／`ProtectSystem=strict`／`ProtectHome=yes`／`CapabilityBoundingSet=` 空／`ProtectProc=invisible`／`MemoryDenyWriteExecute` …），與 Manager unit 逐項相同。
- `EnvironmentFile=/opt/cortex/etc/cortex-manager.env`，**無 `-` 前綴**＝fail-closed。與 Manager 共用同一份 instance-scoped env，兩個服務因此不可能解析到不同的 durable state 樹。
- `Environment=HOME=` / `XDG_CACHE_HOME=` 走 `layout.home_of()` / `cache_of()`，無字面量（有測試斷言 unit 內容不含 `/home/`，且換 layout 後不殘留 `/var/lib`）。

### 2. `ReadWritePaths` 的 persona 過濾——這是「窄」的機制

同帳號**不代表**同可寫面。`required_write_targets()` 只按帳號過濾時，monitor 會拿到 Manager 的全集（`coordinator/`、`specs/`、`control/`、`worktree/`…），等於把 monitor 的任何 bug、或它從 GitHub 讀進來的任何惡意內容，變成對整棵 durable state 的寫入面。

因此三支導出函式（`required_write_targets` / `read_write_paths` / `read_write_path_owners`）多一個 `principals=` 參數，規則抽成 `principal_needs_write()`，**只有兩條、且兩條都直接讀登記表欄位**：

1. persona ∈ `asset.writers`；
2. persona ∈ `asset.readers` 且 `ingress_kind is INTERPROCESS`——單向 spool 的 trusted consumer。消費＝讀完 unlink，unlink 需要**容器目錄**的寫入權。少了這條，monitor 會拿到一個「讀得到卻刪不掉」的 spool，事件重複消費、spool 只增不減，正是本 issue 描述的狀態。

`principals=None`＝不過濾（帳號全集）。Manager unit 與 job 模板 unit 因此**逐位元不變**（已用 `diff` 對 main 的產生器輸出驗證）。

### 3. 導出結果：3 條（Manager 是 11 條）

| `ReadWritePaths` | 涵蓋的登記表資產 |
|---|---|
| `/var/lib/cortex/monitor` | `monitor-state-tree`、`monitor-work-items-snapshot`、`monitor-github-sync-cursor`（三者 `writers=(MONITOR,)`）＋ `monitor-event-spool`（`INTERPROCESS` spool 的 consumer） |
| `/var/lib/cortex/run/cortex` | `runtime-run-tree`（`writers=(MANAGER, MONITOR)`——monitor 的 unix socket） |
| `/var/lib/cortex-manager/cache` | 明示 extra：服務帳號 HOME 快取（git／gh／uv）。與 Manager 是**同一條**、不是第二條例外——同帳號同 HOME |

**monitor 為何不需要其他的**（全部是登記表事實，不是判斷）：

- `coordinator/`、`specs/`、`control/`、`registry/`、`config/`、`runtime/dispatch`：monitor 在登記表上既不是 writer、也不是這些資產的 spool consumer。它讀 `jobs-registry` 之類是**唯讀**，而 `ProtectSystem=strict` 只是讓檔案系統唯讀，不影響讀取。
- `worktree/`：`repo-worktree`／`dispatch-worktree-pool`／`handoff-manifest` 的 writer 是 headless persona；monitor 對 `work-items-yaml` 只在 reader 面（`writers=(OPERATOR, BUILDER, ANY_SAME_UID)`——`correlation.py` 的寫入路徑是 operator 觸發的 work-action，不在 monitor run loop 上）。
- `review-verdict-spool`：也是 `INTERPROCESS`，但 monitor 不在它的 reader 面（reader 是 Manager），所以第 2 條規則不會把它帶進來——這是 persona 過濾**沒有過度概化**的證據。
- `/opt/cortex` 部署樹、`runtime-bootstrap-env`、`codex-hooks`：enforcement plane，對所有服務唯讀。

要讓某條回來，唯一的辦法是改登記表把 monitor 登記成該資產的 writer／consumer 後重跑產生器——unit 沒有手擴的入口。

### 4. `ExecStart` 的取捨

**採用**：`ExecStart=/opt/cortex/venv/bin/cortex monitor`（與 Manager 同形：部署 venv 的 console script ＋ CLI verb）。

**取捨理由**：

- #618／PR #619 定下的形態是 `<venv>/bin/cortex <verb>`。差別在 Manager 那次必須**補**一個 verb（`service run` 當時不存在，unit 一 start 就 `unsupported service command`），而 `cortex monitor` **早就在**——它是 `cli.py` 的既有分派、README 的公開介面，`build_parser().prog` 就是 `"cortex monitor"`（`tests/test_cli_help_alignment.py` 已經釘住），不帶 `--once` 即長駐 `ProjectMonitorService.run_forever()`，符合 `Type=simple`。所以本 PR **不需要新增 verb，只補契約鎖**。
- **不用** `<venv>/bin/python -m paulsha_cortex.monitor`：那條路繞過 console script，等於在同一棵部署樹裡開第二種進入點形態。`cortex service run` 與 `python -m …` 之後會各自漂移，而 R-16 的 CLI help 對齊面只看得到前者——#618 的教訓正是「契約只存在於單邊」。維持一種形態，兩個 unit 才會被同一組檢查覆蓋。
- **不沿用** `scripts/service-manager.sh` 型的 wrapper：理由與 PR #619 相同（會 `mkdir -p "$HOME/.agents/log"`，而 Phase 2b 的 HOME 是 root-owned ＋ `ProtectHome=yes`）。

## 測試

新增 `tests/test_trust_root_monitor_unit_622.py`（**40 測試**，兩個 scheme 逐一參數化）：

- `User=` 是 `durable_state_owner`，且與 Manager unit 同帳號、永不是 root。
- **加固欄位與 Manager 的集合等式**——不是逐項列舉，而是 `{k: v for k in _HARDENING}` 兩邊相等：日後往加固表加一項，兩邊必須同時拿到；任一邊多開或少開一項即紅。另有「每項都帶為何的註解」一條。
- **`ReadWritePaths` 嚴格窄於 Manager**：`set(monitor) < set(manager)`（真子集，是子集且不相等）；另有「不得涵蓋 `coordinator/`／`specs/`／`worktree/`／`control/`／`registry/`／`config/`／`runtime/dispatch`／`/opt/cortex`」的點名列舉、「無遺漏」（恰為那五個 asset_id）、「無多餘」（拿掉任一條就有資產失去覆蓋）、以及把 spool 拿掉會讓對應 RWP 消失的機械性反證。
- **`ExecStart` 契約鎖**（比照 `tests/test_service_run_verb.py`）：不比字串常數，而是**真的走一次 `cli.main`**，確認 `ExecStart` 指名的 verb 會抵達 `paulsha_cortex.monitor.__main__:main`；另驗進入點模組存在、`prog == "cortex monitor"`、且不帶旗標時 `once is False`（`Type=simple` 的前提）。
- **`EnvironmentFile` 無 `-` 前綴**，且與 Manager 是同一份。
- persona 過濾規則本身也被反推驗證（對登記表全項逐一比對兩條規則，證明沒有硬編碼的 asset_id 清單）；`principals=None` 仍是帳號全集。

回歸：

- `python3 -m pytest tests/ -q -k "trust_root or permgen or monitor"` → **726 passed**
- `diff` 驗證：`unit three-way --manager` 與 `--job` 的輸出與 main **逐位元相同**
- `policy_check` 帶 PR 上下文：**fail: 0**

permgen 仍只產生命令／檔案字串，未新增任何 `subprocess`／`os.chown`／`os.chmod`——既有靜態純度測試照跑。

## 文件

runbook 補**第 4d 步**：為何不能把舊 `--user` monitor 起回來、三條 RWP 的登記表出處表、落檔命令、以及驗證（unit 與產生器逐位元相同／身分與加固欄位／行程 user 欄／新樹確有寫入而非還在寫 `~/.agents`／`event-spool` 真的被消費／socket owner 與 mode／fail-closed 刪 env 複驗）、回滾與其雙寫代價。同步更新規模統計表與「產生器＝單一真相」清單。

## 未涵蓋（誠實邊界）

issue 驗收第 3 項「實機：monitor 以 system-level 起、新樹有寫入、spool 被消費」需要 operator 在目標主機執行第 4d 步——本 PR 提供產生器、驗證命令與測試，不代跑實機。

## 與 #626（幽靈帳號的 `setfacl`）的關係——**無交集**

#626：`permgen` 對 `operator`／`cortex-outbox` 這兩個不存在的 OS 帳號發 `setfacl`，
命令會被拒（`Invalid argument near character 3`），在 runbook 的 `sh -e` 下會中斷整份
權限腳本、留下半套用的樹。本 PR **不修** #626（不想把這個 PR 撐大），也**沒有動到
principal→account 的映射**：

- 未改 `UidScheme.resolve()`／`account_of`／`external_reader`，未改 `build_entry()`
  ——ACL 產生面（`AclEntry` 從 `reader_accounts` 推出來的那段）一行都沒碰。
- 本 PR 新增的 `principals=` 過濾走的是**登記表 persona 層**（`asset.writers`／
  `asset.readers`／`ingress_kind`），發生在帳號解析**之外**；`ReadWritePaths` 的
  帳號側判準仍然只是「`cortex-manager` 是否在該資產的可寫帳號集合內」，幽靈帳號
  在不在那個集合裡都不影響結論。

實測（模擬 #626 最可能的修法——讓 `OPERATOR`／`EXTERNAL` 解析為 `None`）：
`unit three-way --monitor` 的輸出**逐位元相同**，`ReadWritePaths` 三條不變，
「嚴格窄於 Manager」仍成立。因此 #626 可以排在本 PR 之前或之後，兩邊不需要互等。

## Rebase 紀錄

本分支已 rebase 到 `origin/main`（fc263a6＝#624 的 squash merge）。衝突一處、且**純為
註解**：#624 把它的 traverse-ACL 整段插在 `# systemd unit 產生（…）` 這行 banner 之前，
而本 PR 改寫了同一行 banner（`Manager system unit` → `Manager／monitor system unit`，
另加兩行說明三份 unit 共用同一份加固表）。解法是保留 #624 整段、banner 取本 PR 版本，
**兩邊的程式碼都沒有被動到**。

rebase 後複驗：
- `pytest -k "trust_root or permgen or monitor"` → **752 passed**（本 PR 726 ＋ #624 的 26）
- `tests/test_trust_root_permgen_traverse_620.py` → 26 passed（本 PR 的 `principals=`
  參數不干擾 #624 的 traverse grant 導出）
- `unit three-way --monitor` 輸出 rebase 前後**逐位元相同**——兩者確實不互相作用：
  #624 的 traverse grant 是為了讓 builder／reviewer-planner 走得到自己的 spool，而
  monitor 以樹的 owner 身分跑，traverse 是天生就有的。

## Checklist
- [x] `changelog.d/monitor-system-unit.md` fragment 已新增且已 commit
- [x] `CHANGELOG.md [Unreleased]` 有對應 `### Added` entry
- [x] `VERSION` 與意圖一致（非 release PR，未動）
- [x] 分支自 `main` 開出，命名為 `feature/622-monitor-system-unit`
- [x] `python3 -m pytest tests/ -q -k "trust_root or permgen or monitor"` 零回歸（726 passed）
- [x] `policy_check` 帶 PR 上下文跑，fail: 0
- [x] 文件與 PR 內文為 zh-tw
- [x] Manager／job 模板 unit 輸出逐位元不變

Closes #622

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E7w9kaUxAzCCEk7piD5hfK
