### PR TITLE
docs(trust-root): Phase 2b runbook 與 M1 實機對齊——十三處逐條修正 (#621)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,49 @@
   `tests/test_trust_root_permgen_traverse_620.py`（26 測試，兩 scheme 參數化，含
   「拿掉導出授權即重現 issue 斷法」的反向對照）；runbook 補稽核 5 與正／負向驗證。
   詳見 `changelog.d/permgen-parent-traverse-acl.md`。
+- **#621 / trust-root Phase 2b runbook 與 M1 實機對齊：十三處逐條修正（docs-only）**
+  ——#584 M1（2026-08-17 實機）逐步對照後累積的落差，**沒有一條是安全破口**，
+  但每一條都會讓下一個執行者卡住或誤判。**(A) 舊佈局殘留**：`--home-dir`
+  `/var/lib/cortex-svc` → `/var/lib/cortex-manager`、刪掉已由 #616 涵蓋的四行手動
+  `install -d`、稽核 3 的 `grep -c cortex-svc` 期望 2 → **0**、驗證路徑同步改名。
+  **(B) job-spec spool 改版**：`/var/lib/cortex/jobs/<id>/run.sh` →
+  `<coordinator_root>/job-specs/<instance>.json`，且一律用
+  `job_runner.build_job_spec()` 產生；連帶修正「輸出在 spec 的 `log_path` 而非
+  journal」「job env 完全等於 spec 的 `env`、不繼承 unit 的 `Environment=`」兩個
+  會讓 smoke 直接看不到東西的誤導；刪掉不存在的 `/var/lib/cortex/jobs` 驗證。
+  **(C) R9 三條假期望**：T1.1 由「讀 EnvironmentFile 期望 denied」改為**測寫入四式**
+  （登記表 rationale 明寫「對全部 headless 唯讀」，可讀是設計）；T1.5 同理改測
+  spool 的寫入四式，讀取期望改為依 subject 而異，並在 5-3 表格註明
+  **per-job 讀隔離需 per-job UID、不在本方案範圍**；T2 delete 的 `rm -f` 改 `rm`
+  並補 `need()` 前置守衛（`-f` 對不存在的檔回 0＝必然假陽性）。
+  **(D) 族 4 假綠**：`pgrep` 在 `ProtectProc=invisible` 下必回空，測到的是
+  「pid 不存在」而非「權限被拒」——改由 operator 以
+  `systemctl show … -p MainPID --value` 取得後注入，並新增 `test -d /proc/<pid>`
+  直接證明 pid 不可見；8c 的 negative control 同步改用 `MainPID`。
+  **(E) 第 4a／第 6 步 pipx 遷移缺步**：`cp -a` 後 venv 仍有兩處指回 operator 樹
+  （`bin/*` shebang、`site-packages/pipx_shared.pth`），補上重寫 shebang 與移除
+  `.pth` 兩步（須在 `chmod a-w` 之前）＋總驗收，並說明這同時是**安全條件**。
+  **(F) 執行前提兩個硬性 gate**：`acl` 套件（缺它時跨帳號授權整段無聲 no-op）、
+  `/etc/sudoers.d/` 萬用 `ALL ALL=NOPASSWD: ALL`（三個服務帳號一建立就是無密碼
+  root）。**另補（issue 未列，實機對照時發現）**：R9 攻擊腳本加**身分鎖**
+  （腳本會真的 truncate／`rm`／`mv "$HOME/.codex"`，在沙箱外跑會弄壞 operator
+  自己的環境，而那些「成功」會被誤讀成邊界失守）；**第 3-0／3a-2**——裁決
+  「legacy-imported 不得滿足任何 ship gate」針對的是**模型產出的 state／evidence**，
+  `config/**`／`specs/**` 是 **operator 撰寫**的、不是 gate 的受檢對象，原本兩類
+  一起 quarantine 而沒有任何一步搬內容，實測導致 `cortex monitor --once` 直接
+  `錯誤: 無 project 設定`，新增分類表與明示逐檔複製段；**第 4d 的「裝好但不得啟動」
+  gate（#623）**——`PSC_DEGRADED_OPERATION=per-case-approval` **不會**阻止派工
+  （只 gate 四個敏感動作），monitor 一起來就會派出必然失敗的 builder job，
+  4d 驗證因此拆成安裝面／執行面兩段、正確終態為 `disabled`；**第 7b 功能面檢查**
+  ——M1 的驗收全是結構性的，這正是部署通過 M1 卻做不了實際工作的原因，新增
+  F1（`cortex monitor --once` 載得到設定）／F2（`cortex status`／`jobs`）／
+  F3（真實 intake 跑到 terminal，⛔ #623 前不得執行）；**第 2a 稽核 6（#626）**
+  ——permgen 為本機不存在的 principal 產出 `setfacl`，`sh -e` 下會中止整份 script
+  留下半套的樹，稽核在套用前攔下並禁止「拿掉 `-e` 硬跑」。另隨 PR #624 落地移除
+  #620 的手動繞過段、M2 追蹤 issue 更正為 #615、新增「M1 實機基準值」對照表
+  （自檢 `job_writable_count` **5 → 0**、R9 denied 條數等）。規模統計
+  35 → **43** 個 sudo 點、133 → **156** 個驗證點。
+  詳見 `changelog.d/phase2b-runbook-realign.md`。
 - **#618 / trust-root Phase 2b：補上 `cortex service run`——permgen 的 manager unit
   `ExecStart` 指向一個不存在的 verb**——產生的 system unit 寫
   `ExecStart=<venv>/bin/cortex service run`，但 porcelain 只有 `install`／`start`／

--- a/changelog.d/phase2b-runbook-realign.md
+++ b/changelog.d/phase2b-runbook-realign.md
@@ -1,0 +1,153 @@
+# phase2b-runbook-realign
+
+- **trust-root Phase 2b runbook 與 M1 實機對齊：十三處逐條修正（docs-only，
+  不改任何一行程式碼、不動部署）**——來源是 #584 M1（2026-08-17 實機執行）
+  逐步對照 `docs/superpowers/runbooks/trust-root-phase2b-setup.md` 累積的落差。
+  **沒有一條是安全破口**，但每一條都會讓下一個執行者卡住或誤判。
+
+  - **A. 舊佈局殘留（#616 已修 permgen，runbook 文字沒跟上）**
+    - 第 1 步 `useradd --home-dir` 由 `/var/lib/cortex-svc` 改為
+      `/var/lib/cortex-manager`；「⚠️ 目前已知缺口 (a)(b)」整段刪除，改列
+      `scaffold_directories()` 的實際八行期望值（HOME 由 `PathLayout.home_of()`
+      機械導出，不再有二分時代的字面量）。
+    - 第 1 步的四行手動 `install -d`（替 `cortex-reviewer-planner` 補
+      HOME／`.codex`／`cache`）**整段刪除**——#616 後 scaffold 已自動涵蓋第三個
+      帳號；改為一段「不得再手動建目錄」的說明。
+    - 第 2 步稽核 3 的 `grep -c "cortex-svc" p2b-scaffold.sh` 期望由 **2** 改為
+      **0**，並新增一條「三個 HOME 路徑與帳號名逐字對應」的正向稽核。
+    - 第 2 步驗證的 `ls -ld /var/lib/cortex-svc` 改為 `/var/lib/cortex-manager`；
+      第 2／9 步回滾命令中的 `cortex-svc` 一併改名。
+
+  - **B. job-spec spool 路徑改版（runbook 仍停在 `run.sh` 時代）**
+    - 5-3 表格／5-6 正向 smoke／8a 攻擊腳本／8c NC5 的
+      `/var/lib/cortex/jobs/<id>/run.sh` 全部改為登記表資產 `job-spec-spool` 的
+      實際契約 `<coordinator_root>/job-specs/<instance>.json`，且**一律用
+      `job_runner.build_job_spec()`／`write_job_spec()` 產生**（手捏欄位會被 shim
+      的白名單 schema 擋掉）。連帶修正三件原本會誤導執行者的事：job 的輸出在
+      **spec 的 `log_path`** 而非 journal（shim 在已降權之後接管 stdout/stderr）；
+      job 的 env **完全等於** spec 的 `env`、不繼承 unit 的 `Environment=`
+      （`PATH`／`HOME` 必須在 spec 內給）；token 的保證是「名字根本進不了 spec」
+      （寫入端 `CREDENTIAL_ENV_RE`／`DENIED_ENV_NAMES` 直接 raise）而非執行時 scrub。
+    - 第 2 步的 `ls -ld /var/lib/cortex/jobs`（期望 `0711`）刪除——該資產不在
+      登記表、目錄不會被建立；改為驗 spool 的 `0700 cortex-manager` ＋ builder
+      唯讀 ACL，並把「builder 讀得到／寫不進去」拆成兩條分別驗。
+    - 「產生器＝單一真相」段的兩項 `⏳ 待 #603 follow-up` 改為已落地
+      （`trust_root shim three-way`、`build_job_spec()` 契約），並補上 spec 必填／
+      禁用欄位的自檢；第 6 步升級流程補回 shim 的 `diff` 對齊。
+
+  - **C. R9 的三條期望與實際設計矛盾（會讓執行者把設計誤判為破口）**
+    - **T1.1 由「讀 EnvironmentFile 期望 denied」改為測寫入面**（追加／截斷／
+      symlink 換掉／刪除四式）。登記表 `runtime-bootstrap-env` 的 rationale 明寫
+      「對全部 headless **唯讀**」、mode 就是 `0644`——**可讀是設計**；該守的是
+      「改不了 `PSC_*` 就重導不了整棵 durable state」。原本的讀取測項改由新增的
+      `d()` 助手記為 `readable (BY DESIGN)`，讓設計契約也有實測背書。
+    - **T1.5 由「枚舉 job-spec spool 期望 denied」改為測寫入四式**（建立／追加／
+      symlink 換掉／刪除）。template unit 的 `User=cortex-builder` 由 systemd 在
+      `ExecStart` **之前**套用，shim 本身即以 builder 身分讀 spec，**讀不到就起不了
+      job**。讀取面的期望改為**依 subject 而異**（builder 讀得到；
+      reviewer-planner 被拒——三分在檔案層生效的直接證據）。5-3 表格同步改寫：
+      刪掉不精確的「job 只讀自己那格」，改為「守的是寫入面」，並明確註記
+      **per-job 讀隔離需 per-job UID，不在本方案範圍**。
+    - **T2 delete jobs.json 的 `rm -f` 改為 `rm`**（`-f` 對不存在的檔回 0，在乾淨
+      新樹上是必然的假陽性），並新增 `need()` 前置守衛與一段 operator 預建目標檔的
+      步驟——「刪不掉」必須是「權限被拒」，不能是「檔不存在」。
+
+  - **D. 族 4 的假綠**
+    - `MPID=$(pgrep -u cortex-manager -n -f paulsha_cortex)` **刪除**。job unit 帶
+      `ProtectProc=invisible` ＋ `ProcSubset=pid`，job 眼中的 `/proc` 只有自己，
+      `pgrep` 必回空 → 後續每一條變成對 `/proc//…` 操作，因「路徑不存在」失敗而被
+      記成 denied。**測到的是 pid 不存在，不是權限被拒。** 改由 operator 從外部取
+      `systemctl show cortex-manager.service -p MainPID --value`，經 spec 的 `env`
+      （pass 1）或 `--setenv`（pass 2）注入；另新增 **T4.0 `test -d /proc/<pid>`**
+      直接把「pid 不可見」本身測出來，不讓它偽裝成其他測項的 denial。
+      8c 族 4 的 negative control 同樣改用 `MainPID`（原本的 `pgrep -f
+      paulsha_cortex` 連 operator 都匹配不到 `cortex service run`，是假紅）；
+      pass 2 補上 `ProtectProc=invisible`／`ProcSubset=pid`，兩趟的 `/proc` 語意
+      才可比。WSL2 風險段第 3 條同步改寫。
+
+  - **E. 第 4a／第 6 步：pipx venv 遷 `/opt/cortex` 後不可執行**
+    - `cp -a` ＋ `chown` ＋ `chmod` 之後 venv 仍有**兩處指回 operator 樹**，M1 實測
+      `sudo -u cortex-manager /opt/cortex/venv/bin/cortex --version` 直接
+      `Permission denied`：`bin/*` 的 shebang 仍是 pipx 樹的 python、
+      `site-packages/pipx_shared.pth` 指向 operator 的 pipx shared site-packages。
+      補上**重寫 shebang 前綴**與**移除 `pipx_shared.pth`**兩步（必須在
+      `chmod a-w` 硬化**之前**），並說明這同時是**安全條件**——留著等於部署樹的
+      第一支被執行的程式與 import path 仍受 operator 可寫目錄影響。另加一條
+      涵蓋所有形式的總驗收（`grep -rIl` ＋ symlink 檢查）。第 6 步升級流程的
+      `cp -a` 有同樣問題，逐字補上同三步；升級的 hash diff 另附「哪兩類差異是
+      這兩步造成的、不是供應鏈訊號」的過濾。
+
+  - **F. 執行前提補兩個硬性 gate**
+    - **G1 `acl` 套件**：原本只在第 2 步「稽核 4」提示且失敗不中止；缺 acl 時
+      `setfacl` 全數失效、跨帳號授權整段成為**無聲 no-op**，而權限 script 仍以
+      exit 0 收場。上移為執行前提的硬性 gate，第 2 步保留一次複驗。
+    - **G2 `/etc/sudoers.d/` 萬用 NOPASSWD 規則**：M1 本機原有
+      `ALL ALL=NOPASSWD: ALL`，第 1 步新建的三個服務帳號**一建立就自動取得無密碼
+      root**，整個降權設計歸零。新增 gate（`grep` sudoers ＋ `sudo -l -U`）與
+      「先收斂到具名帳號再建帳號」的順序要求；第 1 步的「三帳號皆無 sudo 授權」
+      驗證升級為 `sudo -l -U` 複驗並與 G2 成對。
+
+  - **另補（issue 未列、對照時發現）**
+    - **R9 攻擊腳本加身分鎖**：腳本會真的執行破壞性動作
+      （truncate、`rm`、`mv "$HOME/.codex"`、覆寫 hooks.json），在沙箱外跑會弄壞
+      operator 自己的環境，而且那些「成功」會被誤讀成邊界失守。新增
+      `id -un` 白名單（只允許 `cortex-builder`／`cortex-reviewer-planner`），
+      並加一條「以 operator 身分跑必須被拒」的驗證。腳本位置一併改為
+      root-owned 的 `/var/lib/cortex/r9-attack.sh`（`PrivateTmp=yes` 讓 `/tmp`
+      不可用；builder-owned worktree 則 reviewer-planner 讀不到）。
+    - **WSL2 段「重啟後仍可起 job」補上重建 spec 的步驟**——8e 已清掉 negctl5 的
+      spec 與 worktree，原文直接 `systemctl start` 會因「spec 缺席」而失敗，
+      診斷會指向錯誤的層。
+    - **#620 的手動繞過收進第 2 步**：permgen 尚未產生父目錄 traverse ACL，
+      `coordinator/`／`monitor/` 是 `0700`，POSIX 要求路徑每層都要 `x`，兩條
+      append-only 正向路徑與 spool 唯讀路徑因此全斷。補上 M1 實測的三條
+      `setfacl -m u:<acct>:--x`（只 traverse、不可列目錄）與驗證，並標明
+      **#620 落地後整段刪除**。
+    - **M2 的追蹤 issue 由 #603 follow-up 更正為 #615**。
+    - **第 4d：monitor unit「裝好但不得啟動」的 gate（#623）**——4d 的安裝與驗證
+      全部照做，但 `enable --now` 必須等 #623 關閉。`PSC_DEGRADED_OPERATION=
+      per-case-approval` **不會**阻止派工（它只 gate `headless-acceptance`／
+      `outbox-mutation`／`ship`／`merge` 四個動作，見 `trust_root/capability.py`），
+      因此 monitor 一起來就會真的派 builder job，而那些 job 現在必然失敗
+      （`ProtectHome=yes` 讓 repo 不可達、EnvironmentFile 缺八個操作變數），
+      後果是燒模型額度、needs_human 噪音、半死的 run 狀態——且**沒有任何一條結構性
+      驗收會因此變紅**。4d 的驗證因此拆成「安裝面（不需服務在跑）」與
+      「執行面（⛔ #623 關閉後才適用）」兩段，正確終態是 `disabled`／`inactive`。
+    - **第 3 步分成兩類處理（3-0／3a-2）**——裁決「legacy-imported 不得滿足任何
+      ship gate」針對的是**模型產出的 state／evidence**（`coordinator/**`／
+      `monitor/**`／`registry/**`／`runtime/**`）；`config/**`／`specs/**` 是
+      **operator 撰寫**的、不是任何 gate 的受檢對象。原本兩類一起關進 quarantine，
+      而第 2 步只建 `config/paulsha` **目錄**、沒有任何一步搬**內容**，實測導致
+      `cortex monitor --once` 直接 `錯誤: 無 project 設定：…皆不存在`。新增 3-0 的
+      分類表與 3a-2 的「明示逐檔複製 ＋ 逐份審閱 ＋ 功能面驗證」段（刻意用白名單而
+      非 `cp -r`：要搬什麼是 operator 的決定）。
+    - **第 7b 功能面檢查**——M1 的每一條驗收都是結構性的（誰擁有什麼、誰被拒、
+      攻擊有沒有失敗），**沒有一條是功能性的**，這正是部署能通過 M1 卻做不了任何
+      實際工作的原因。新增三級：F1 `cortex monitor --once` 載得到設定（兩秒鐘，
+      是上一條缺口的最短偵測路徑）、F2 `cortex status`／`jobs` 在新樹上答得出話、
+      F3 真實 intake 一案跑到 terminal（⛔ #623 關閉前不得執行）。通過條件改為
+      「結構面 ＋ F1／F2」，並明訂 F3 通過前不得宣稱「Phase 2b 可用」。
+    - **第 2a 稽核 6：script 裡的每個帳號名都要 `getent passwd` 得到（#626）**
+      ——permgen 會為本機不存在的 principal（`operator`／`cortex-outbox`）產出
+      `setfacl` 條目，而 2b 是 `sh -e`：一條錯就中止整份 script，留下**半套權限的
+      樹**（含尾端整個 traverse 節沒套）。稽核 6 在套用前就攔下來，並給出兩條合法
+      處置（建帳號／等 #626 修產生器），明確禁止「拿掉 `-e` 硬跑」——那會把中止
+      換成靜默略過。2b 另補一段：exit 非 0 時樹是半套的、不要往下驗證，
+      且整份重跑是安全的（每條命令皆冪等）。
+    - **#620 的手動繞過段落刪除**——PR #624 已把父目錄 traverse ACL 進產生器，
+      第 2 步改由 main 的稽核 5 與正／負向驗證守門；「M1 實機基準值」下的註記
+      同步改寫為「已收編」，並新增「M1 之後才發現、目前仍未關的兩條」（#626／#623）
+      指向各自的步驟標注。
+    - **新增「M1 實機基準值」對照表**（自檢 `job_writable_count` 5→0、登記表等式、
+      legacy-import manifest 檔數、5-7 十一條全非 0、8a 兩個 subject 的 denied 條數、
+      8c 五組 negative control、8d 重啟複驗），讓下一個執行者有數字基準；並在第 8 步
+      補一段「判讀紀律」——`SUCCEEDED` 要先確認測項測的是不是該守的那一面，
+      `denied` 也可能是假綠。
+    - 規模統計同步更新：**32 → 38 個 `🔧 sudo` 點、122 → 134 個 `✅ 驗證`點**。
+
+  相關 issue：#621（本票）、#584（M1）、#616（三分＋template 落地）、
+  #620／PR #624（父層 traverse ACL，已落地，本 PR 移除對應的手動繞過段）、
+  #622／PR #625（monitor unit，本 PR 加上「裝好但不得啟動」的 gate）、
+  #623（monitor 啟動前提＋operator 設定搬遷＋功能面驗收，本 PR 只在 runbook 標注，
+  程式與部署面的修正屬該票）、#626（phantom principal 的 `setfacl` 條目，本 PR 只加
+  第 2a 稽核 6 這道 operator 側的攔截，產生器修正屬該票）、#615（M2）。

--- a/docs/superpowers/runbooks/trust-root-phase2b-setup.md
+++ b/docs/superpowers/runbooks/trust-root-phase2b-setup.md
@@ -79,7 +79,7 @@ OS** 的手動流程。
 | 里程碑 | 內容 | 本 runbook |
 |---|---|---|
 | **M1** | 三帳號建立、**檔案權限面完整三分**、builder job 經 `cortex-job@.service` 降權、polkit 只授 `cortex-manager` 對 `cortex-job@*` | ✅ 本 runbook 全程 |
-| **M2** | reviewer／planner job 也改經 template instance（`User=cortex-reviewer-planner`）落到自己的帳號 | ⏳ 程式碼工項（#603 follow-up；範圍以該 PR 實際落地為準） |
+| **M2** | reviewer／planner job 也改經 template instance（`User=cortex-reviewer-planner`）落到自己的帳號 | ⏳ 程式碼工項 **#615**（範圍以該 PR 實際落地為準）。M1 已於 2026-08-17 完成，**M2 未做**——D6 的「三分已生效」全稱在 #615 之前 **BLOCKING** |
 
 **M1 下的誠實邊界**：`launcher.SubprocessLauncher._degraded_runner()` 目前只對 **builder
 persona** 降權（`review_only`＝reviewer、`read_only`＝planner 兩者皆非才降權）；因此在
@@ -91,6 +91,44 @@ reviewer／planner 的三分只在**檔案權限層**成立（第 8 步族 2 會
 ---
 
 ## 執行前提（開工前逐項確認，全部 `✅ 驗證`）
+
+### 兩個硬性 gate——不通過就**不要開工**
+
+這兩條是 M1 實機（2026-08-17）踩到的**部署環境**前提，不是 cortex 的缺陷；
+但任一條沒守住，底下九項全部驗綠也沒有意義——整個降權設計會靜默歸零。
+**它們是 gate，不是提示**：不符合就停下來處理，處理完再回到這裡。
+
+```bash
+# ✅ G1（硬性 gate）：`acl` 套件必須已安裝
+#    缺 acl 時 setfacl 全數失效，跨帳號授權整段變成**無聲 no-op**——append-only
+#    出口與 job-spec spool 的唯讀 ACL 全部不存在，而權限 script 仍會以 exit 0
+#    收場（第 2 步看起來全綠）。這就是它從第 2 步的「稽核 4」上移成 gate 的理由。
+command -v setfacl && command -v getfacl && setfacl --version | head -1
+#   期望：三行都印得出來。
+#   若缺：`sudo apt-get install -y acl`，裝完重跑本條。**未通過不得往下做。**
+
+# ✅ G2（硬性 gate）：`/etc/sudoers.d/` 不得有萬用 NOPASSWD 規則
+#    M1 本機原有 `ALL ALL=NOPASSWD: ALL`，第 1 步新建的三個服務帳號
+#    **一建立就自動取得無密碼 root**（`sudo -l -U cortex-builder`
+#    → `(root) NOPASSWD: ALL`）。整個降權設計因此歸零——builder 不必攻擊任何
+#    邊界，直接 `sudo` 就好；第 1 步「三帳號皆無 sudo 授權」那條驗證會是紅的。
+sudo grep -rnE '^[[:space:]]*ALL[[:space:]]+ALL[[:space:]]*=' /etc/sudoers /etc/sudoers.d/
+#   期望：**空輸出**（grep 找不到時 exit 1，屬正常）。
+sudo -l -U nobody 2>&1 | tail -3
+#   期望：`not allowed to run sudo` 之類。**若印出 `(root) NOPASSWD: ALL`**，
+#   代表規則對「任何」使用者成立，新帳號一建立就吃得到。
+#
+#   若命中：**先把規則收斂到具名帳號，再建帳號**——把
+#   `ALL ALL=(ALL) NOPASSWD: ALL` 改成 `<operator 帳號> ALL=(ALL) NOPASSWD: ALL`
+#   （M1 即如此收斂，三帳號複驗為 `is not allowed to run sudo`）。
+#   **順序不可調換**：先建帳號再收斂規則，中間那段時間三個服務帳號就是 root。
+```
+
+**G1／G2 判定**：任一不通過 ⇒ 停止並處理，不得「先做下去之後再補」。
+第 1 步末尾有一條複驗（`sudo -l -U` 對三帳號），與 G2 成對——G2 過了但複驗紅，
+代表建帳號的過程中又引入了新規則。
+
+### 其餘九項
 
 ```bash
 # ✅ 1. in-flight job 手動收尾（裁決：切換期間不得有半途 job）
@@ -110,6 +148,8 @@ pgrep -a -f "paulsha_cortex" || echo "no cortex process"
 python3 -m paulsha_cortex.trust_root selfcheck \
   | tee "/tmp/trust-root-baseline-$(date +%Y%m%d-%H%M).json" >/dev/null
 echo "baseline saved"
+#   M1 實測參考值：baseline `job_writable_count` = **5**、`ok: false`。
+#   這是預期的紅——第 7 步應收斂為 0（見「M1 實機基準值」表）。
 
 # ✅ 4. 登記表雙向等式必須綠（紅＝盤點已漂移，先修 Phase 1 再繼續）
 python3 -m paulsha_cortex.trust_root equation
@@ -153,13 +193,16 @@ modes = getattr(job_runner, "RUNNER_MODES", ())
 print("RUNNER_MODES =", modes)
 print("systemd-template available:", "systemd-template" in modes)
 PY
-#   期望（#603 follow-up PR 落地後）：True。
-#   若 False：第 5 步的 (a)(b)(c) 仍可全部安裝並用 5-7 的反向測試證明邊界，
-#   只有 (d) 切換點暫不打開（Manager 維持 per-case-approval 不 spawn job）。
+#   期望：`RUNNER_MODES = ('direct', 'systemd-run', 'systemd-template')`、True。
+#   （#616 已 merge，template 模式與 root-owned shim 皆已在主線落地。）
+#   若 False（部署的 wheel 比 #616 舊）：第 5 步的 (a)(b)(c) 仍可全部安裝並用 5-7
+#   的反向測試證明邊界，只有 (d) 切換點暫不打開（Manager 維持 per-case-approval
+#   不 spawn job）——但正確處置是先把部署樹升到含 #616 的版本。
 ```
 
-**通過條件**：1–8 全部符合期望；`equation` 回傳 `ok: true`；baseline JSON 已存檔；
-第 9 項無論真假都**記錄**在 #584（決定本次是否走到 (d)）。
+**通過條件**：**G1／G2 皆通過**（缺一即停）；1–8 全部符合期望；`equation` 回傳
+`ok: true`；baseline JSON 已存檔；第 9 項無論真假都**記錄**在 #584
+（決定本次是否走到 (d)）。
 Phase 1 自檢此時**預期為紅**（有 `job-writable` finding）——那正是本 runbook 要收斂的
 清單，切換完成後（第 7 步）應轉綠。
 
@@ -190,21 +233,21 @@ A/B 並列時同一件事要寫兩遍（5-A／5-B、第 8 步兩種起法、附�
 
 | 段落 | 🔧 sudo 點 | ✅ 驗證點 |
 |---|---:|---:|
-| 執行前提 | 0 | 9 |
-| 產生器＝單一真相 | 0 | 7 |
-| 第 1 步：建三帳號 | 4 | 5 |
-| 第 2 步：目標樹與權限 | 2 | 12 |
-| 第 3 步：legacy-import | 2 | 8 |
-| 第 4 步：Manager／monitor 部署與 unit | 8 | 22 |
-| **第 5 步：降權（A+B）** | **7** | **24** |
-| 第 6 步：升級流程 | 2 | 5 |
-| 第 7 步：切換驗收 | 0 | 3 |
-| 第 8 步：R9 抽驗（五族） | 4 | 17 |
-| 第 9 步：回滾 | 3 | 1 |
-| WSL2 風險與診斷 | 1 | 12 |
-| 附錄 A：自我檢查 | 0 | 5 |
+| 執行前提（含 G1／G2 兩個硬性 gate） | 0 | 11 |
+| 產生器＝單一真相 | 0 | 9 |
+| 第 1 步：建三帳號 | 3 | 5 |
+| 第 2 步：目標樹與權限 | 2 | 16 |
+| 第 3 步：legacy-import（含 operator 設定搬遷） | 3 | 11 |
+| 第 4 步：Manager／monitor 部署與 unit | 12 | 24 |
+| **第 5 步：降權（A+B）** | **7** | **27** |
+| 第 6 步：升級流程 | 5 | 6 |
+| 第 7 步：切換驗收（含功能面檢查） | 0 | 5 |
+| 第 8 步：R9 抽驗（五族） | 5 | 19 |
+| 第 9 步：回滾 | 2 | 1 |
+| WSL2 風險與診斷 | 2 | 12 |
+| 附錄 A：自我檢查 | 0 | 7 |
 | 附錄 B：降級備援 | 2 | 3 |
-| **合計** | **35** | **133** |
+| **合計** | **43** | **156** |
 
 （統計方式：全文 `🔧`／`✅` 標記出現次數，扣除說明性用法——「標記約定」的定義行、
 段落標題內的標記、以及表格裡當狀態記號用的那幾個。）
@@ -215,6 +258,47 @@ A/B 並列時同一件事要寫兩遍（5-A／5-B、第 8 步兩種起法、附�
   收斂後集中在 5-7（**11 條**），且**全部期望為「被拒」**——不再有任何一條期望成功。
 - **R9 族數**：4 → **5**（新增族 5 privilege-boundary），且族 1–4 各跑**兩個 subject**
   （builder ／ reviewer-planner），實測條數約為舊版的兩倍。
+- **#621（M1 對照後的修正）新增**：執行前提兩個硬性 gate（`acl`／sudoers 萬用規則）、
+  第 2a 稽核 6（#626 的帳號存在性）、第 3-0／3a-2（operator 設定的分類與搬遷）、
+  第 4a 與第 6 步各補三個 pipx 遷移必要步驟（shebang／`pipx_shared.pth`／總驗收）、
+  第 4d 的「裝好但不得啟動」gate（#623）、第 7b 功能面檢查、族 4 的 pid 改由 operator
+  注入並新增 T4.0 可見性測項、族 1 的 T1.1／T1.5 由「讀」改測「寫」並新增
+  `d()`／`need()`／身分鎖三個判讀守衛。合計（#624／#625 落地後的 35／133 基礎上）
+  → **43** 個 sudo 點、**156** 個驗證點。
+
+---
+
+## M1 實機基準值（2026-08-17，#584 M1 留言）
+
+下表是 **M1 在 9900X／WSL2 上實跑出來的值**，供下一個執行者當**對照基準**：
+數字對不上不一定是錯，但**必須查清楚差在哪**才能繼續。
+（檔數這類與本機資料量相關的值只作量級參考；`ok` / 條數這類是硬期望。）
+
+| 關卡 | 本 runbook 位置 | M1 實測值 |
+|---|---|---|
+| Phase 1 自檢 baseline | 執行前提 3 | `ok: false`、`job_writable_count` = **5** |
+| Phase 1 自檢（切換後） | 第 7 步 | `ok: true`、`job_writable_count` = **0**、`remaining` 為空 |
+| 登記表雙向等式 | 執行前提 4／第 7 步 | `ok: true`（切換前後皆是） |
+| legacy-import manifest | 第 3 步 | 78,674 檔；全量複驗 78,674/78,674 `OK` |
+| 5-6 正向 smoke | 第 5 步 | 成功；`uid=…(cortex-builder)`、token 已 scrub、fd 僅 0/1/2、`HOME=/var/lib/cortex-builder`（root-owned）、部署樹不可寫 |
+| 5-7 反向 11 條 | 第 5 步 | **全數非 0** |
+| 5-7 (11) fail-closed | 第 5 步 | 移除 polkit 規則後起 job **失敗**、還原後**成功**（證明是規則在守，不是全紅假綠） |
+| 8a 族 1–4（builder） | 第 8 步 | 46 `denied` ／ 3 條 `SUCCEEDED` 標記 → 三條**全部判定為非破口**，且**三條的成因就是本 runbook 這次修掉的 #621 第 7／8／9 條**（期望寫反、測錯面、`rm -f` 假陽性）。按修正後的腳本重跑應為**全數 denied** |
+| 8a 族 1–4（reviewer-planner） | 第 8 步 | 47 `denied` ／ 2 條標記；**T1.5 對它是拒絕的** ← 三分在檔案層生效的直接證據 |
+| 8c negative control ×5 | 第 8 步 | 全部 `*-OK`（含 NC5：manager 起合法 instance 成功且 `uid=…(cortex-builder)`） |
+| 8d 重啟複驗 | 第 8 步 | 服務 `active`、自檢仍 `ok=true`、`NRestarts=0` |
+
+> **M1 期間手動繞過、之後已收編的一條**：permgen 當時沒產生**父目錄 traverse ACL**
+> ——葉節點 ACL 正確，但 `coordinator/`／`monitor/` 是 `0700 cortex-manager`，
+> POSIX 要求路徑**每一層**都要 `x`，兩條 append-only 正向路徑因此全斷。
+> M1 以三條手動 `setfacl --x` 解封；**#620 已由 PR #624 進產生器**，第 2 步的
+> 稽核 5 與正／負向驗證即是它的守門條款，**不需要再手補**。
+>
+> **M1 之後才發現、目前仍未關的兩條**（下一個執行者會撞到，見各步的標注）：
+> **#626**——permgen 為本機不存在的 principal（`operator`／`cortex-outbox`）產出
+> `setfacl` 條目，`sh -e` 下會中止整份權限 script、留下半套的樹（第 2a 稽核 6）；
+> **#623**——monitor unit 起得來但 job 跑不完（`ProtectHome=yes` 讓 repo 不可達、
+> EnvironmentFile 缺八個操作變數），因此 **4d 裝好但不得啟動**（見第 4d 步）。
 
 ---
 
@@ -244,23 +328,33 @@ python3 -m paulsha_cortex.trust_root unit three-way --job
 
 # ✅ 降權 polkit 規則內容（只放行 cortex-job@*.service 的 start/stop）
 python3 -m paulsha_cortex.trust_root polkit three-way --template
+
+# ✅ root-owned shim 內容（/opt/cortex/bin/cortex-job-shim）—— #616 已 merge
+python3 -m paulsha_cortex.trust_root shim three-way
 ```
 
-**尚未由已 merge 介面提供、將由 #603 follow-up PR（template-instance 模式）提供的兩項**：
+**job-spec 的欄位契約也已隨 #616 落地**——`coordinator/job_runner.py` 的
+`build_job_spec()` 是**唯一**的產生入口，`coordinator/job_shim.py` 是唯一的讀取端：
 
 ```bash
-# ⏳ root-owned shim 內容（/opt/cortex/bin/cortex-job-shim）
-#    將由該 PR 以下列形式提供（命令名以該 PR 實際落地為準）：
-#      python3 -m paulsha_cortex.trust_root shim three-way
-#    在它落地前：第 5-3 節不執行，template unit 的 ExecStart 維持產生器當下的形狀。
-
-# ⏳ job-spec spool 的欄位契約（<job spool>/<id>/ 底下由 Manager 寫的執行規格）
-#    同一 PR 定義；本 runbook **不自行捏造 spec 格式**——正向 smoke 一律以
-#    「產生器印出什麼 ExecStart，就照那個形狀準備」（見 5-6）。
+# ✅ spec 契約（路徑推導 ＋ 必填／禁用欄位）——本 runbook 一律用它產 spec，
+#    **不自行捏造欄位**（手捏的 spec 會被 shim 的白名單 schema 拒絕）
+python3 - <<'PY'
+from paulsha_cortex.coordinator import job_runner
+print("spool 預設      :", job_runner.DEFAULT_JOB_SPEC_SPOOL)
+print("spec 路徑推導   :", job_runner.job_spec_path(job_runner.DEFAULT_JOB_SPEC_SPOOL, "<instance>"))
+print("spec_version    :", job_runner.JOB_SPEC_VERSION)
+print("必填欄位        :", job_runner.SPEC_REQUIRED_KEYS)
+print("禁用（身分）欄位:", sorted(job_runner.SPEC_FORBIDDEN_KEYS))
+PY
+#   期望：spool = /var/lib/cortex/coordinator/job-specs（**不是** /var/lib/cortex/jobs）；
+#         spec 路徑 = <spool>/<instance>.json（**一個檔，不是一個目錄**）；
+#         禁用欄位含 user／uid／group／gid／properties／exec_start
+#         ——身分只有一個來源＝root-owned unit 檔的 `User=`，spec 連提都不准提。
 ```
 
 > **一律以產生器輸出為準**：本 runbook 的每個落檔步驟後面都跟一條 `diff` 驗證，
-> 因此上述兩項一旦落地、內容改變，`diff` 會立刻抓到漂移，runbook 不需改寫。
+> 上述任一項內容改變，`diff` 會立刻抓到漂移，runbook 不需改寫。
 
 ---
 
@@ -284,21 +378,28 @@ for path, owner, group, mode in permgen.DEFAULT_LAYOUT.scaffold_directories(s):
     if path.startswith("/var/lib/cortex-"):
         print(f"{path}\t{owner}:{group}\t{mode:04o}")
 PY
-#   期望（#603 follow-up PR 落地後）：三組 HOME＋cache，名稱與帳號一致。
-#   ⚠️ 目前已知缺口（permgen 的 PathLayout 尚未跟上三分定案）：
-#      (a) Manager 的 HOME 仍沿用二分時代的 `/var/lib/cortex-svc`；
-#      (b) `cortex-reviewer-planner` 沒有 HOME／cache 條目。
-#      **以產生器輸出為準**：下方 useradd 的 --home-dir 一律填它印出的值；
-#      待該 PR 更名後以 `sudo usermod --home <新值> cortex-manager` 同步並重跑第 2 步。
+#   期望（#616 已 merge）：**三組 HOME＋cache，目錄名與帳號名逐字一致**——
+#     /var/lib/cortex-manager            root:root  0755
+#     /var/lib/cortex-manager/cache      cortex-manager:cortex-manager 0700
+#     /var/lib/cortex-builder            root:root  0755
+#     /var/lib/cortex-builder/.codex     root:root  0755
+#     /var/lib/cortex-builder/cache      cortex-builder:cortex-builder 0700
+#     /var/lib/cortex-reviewer-planner   root:root  0755
+#     /var/lib/cortex-reviewer-planner/.codex  root:root 0755
+#     /var/lib/cortex-reviewer-planner/cache   cortex-reviewer-planner:… 0700
+#   **不得**再出現 `/var/lib/cortex-svc`（二分時代的字面量；#616 已改為由帳號名
+#   機械導出 `PathLayout.home_of()`／`cache_of()`）。若仍出現 ⇒ 部署樹比 #616 舊，
+#   先升級再繼續，**不要**照舊值建帳號。
+#   註：只有跑模型的兩個 job 帳號有 root-owned `~/.codex`；Manager 不跑模型故無此條。
 
 # 🔧 sudo：cortex-manager（Manager＋monitor；durable state owner；持 spawn 授權；不跑模型）
 sudo groupadd --system cortex-manager
 sudo useradd  --system --gid cortex-manager \
-     --home-dir /var/lib/cortex-svc --no-create-home \
+     --home-dir /var/lib/cortex-manager --no-create-home \
      --shell /usr/sbin/nologin \
      --comment "cortex manager+monitor (durable state owner, spawn grant, no model code)" \
      cortex-manager
-#   ↑ --home-dir 取自上面產生器輸出的那一行（目前為 /var/lib/cortex-svc）。
+#   ↑ --home-dir 取自上面產生器輸出的那一行。
 
 # 🔧 sudo：cortex-reviewer-planner（reviewer＋planner 模型 job）
 sudo groupadd --system cortex-reviewer-planner
@@ -313,15 +414,15 @@ sudo useradd  --system --gid cortex-builder \
      --home-dir /var/lib/cortex-builder --no-create-home \
      --shell /usr/sbin/nologin \
      --comment "cortex headless builder job" cortex-builder
-
-# 🔧 sudo：reviewer-planner 的 HOME／cache（產生器尚未涵蓋時手動補；模式與 builder 對齊）
-sudo install -d -o root -g root -m 0755 /var/lib/cortex-reviewer-planner
-sudo install -d -o root -g root -m 0755 /var/lib/cortex-reviewer-planner/.codex
-sudo install -d -o cortex-reviewer-planner -g cortex-reviewer-planner -m 0700 \
-     /var/lib/cortex-reviewer-planner/cache
-#   ↑ 這四行在 #603 follow-up PR 把 reviewer-planner 納入 scaffold 後即可刪除，
-#     改由第 2 步的 scaffold script 一併產生（屆時 diff 會提醒）。
 ```
+
+> **不需要手動補目錄**：舊版此處有四行 `install -d` 替 `cortex-reviewer-planner`
+> 補 HOME／`.codex`／`cache`——#616 讓 `scaffold_directories()` 改由
+> `scheme.headless_accounts()` 導出帳號清單後，第三個帳號**自動入列**，
+> 由第 2 步的 scaffold script 一併產生。**此處不得再手動建任何目錄**——
+> 手建會繞過產生器這個單一真相，也讓第 2 步的稽核失去意義（稽核比對的是
+> script 內容，不是磁碟現況）。若上一輪已手建過，第 2 步的 scaffold 冪等重跑
+> 會把 owner／mode 拉回計畫值，不必先刪。
 
 **為何 `--no-create-home`**：三個帳號的 HOME 由第 2 步以 **root 擁有**的方式建立
 （`useradd --create-home` 會把 HOME 建成帳號自己擁有）。HOME 若由帳號自己擁有，
@@ -351,20 +452,25 @@ sudo -u cortex-builder ls /var/lib/cortex-reviewer-planner/cache 2>&1 | tail -1
 sudo -u cortex-reviewer-planner ls /var/lib/cortex-builder/cache 2>&1 | tail -1
 #   期望：兩者皆 Permission denied（cache 為 0700 且 owner 不同）
 
-# ✅ 驗證：三帳號皆無 sudo 授權
+# ✅ 驗證：三帳號皆無 sudo 授權（**與執行前提 G2 成對**——這是 G2 的事後複驗）
 for U in cortex-manager cortex-reviewer-planner cortex-builder; do
+  printf '=== %s ===\n' "$U"
+  sudo -l -U "$U" 2>&1 | tail -2
   sudo -u "$U" sudo -n true 2>&1 | tail -1
 done
-#   期望：全部失敗（不可有任何一個成功）
+#   期望：`sudo -l -U` 三個都印 `is not allowed to run sudo`（M1 收斂萬用規則後的
+#   實測字串）；`sudo -n true` 全部失敗（不可有任何一個成功）。
+#   ⚠️ 若出現 `(root) NOPASSWD: ALL` ⇒ `/etc/sudoers.d/` 有萬用規則（G2 沒守住或
+#   被重新引入）。**立即停止**：這三個帳號現在就是無密碼 root，後面的降權全部無效。
+#   處置：先收斂規則到具名 operator 帳號，再重跑本條複驗，綠了才往下做。
 ```
 
 **回滾**：
 ```bash
 sudo userdel cortex-manager; sudo userdel cortex-reviewer-planner; sudo userdel cortex-builder
 sudo groupdel cortex-manager; sudo groupdel cortex-reviewer-planner; sudo groupdel cortex-builder
-sudo rm -rf /var/lib/cortex-reviewer-planner
 ```
-（此時尚無任何檔案屬於它們。）
+（此時尚無任何檔案或目錄屬於它們——HOME／cache 由第 2 步的 scaffold 建立。）
 
 ---
 
@@ -401,18 +507,21 @@ grep -E "^setfacl" /tmp/p2b-permissions.sh | grep -E ":[^ ]*w"
 #     setfacl -d -m u:cortex-reviewer-planner:wx /var/lib/cortex/coordinator/review-verdicts
 #   **wx 無 r**——寫得進自己那格、讀不到他人的。多出任何一行都要停下來查。
 
-# ✅ 稽核 3：三分的帳號名確實出現在計畫裡（權限 script 不得殘留 cortex-svc）
+# ✅ 稽核 3：三分的帳號名確實出現在計畫裡（兩份 script 都不得殘留 cortex-svc）
 grep -c "cortex-svc" /tmp/p2b-permissions.sh
-#   期望：0（若非 0，代表 scheme 傳錯或 permgen 仍有二分殘留，停下來查）
+#   期望：**0**（若非 0，代表 scheme 傳錯或 permgen 仍有二分殘留，停下來查）
 grep -oE "cortex-(manager|reviewer-planner|builder)" /tmp/p2b-permissions.sh | sort | uniq -c
 #   期望：三個帳號名皆出現，且**不含** cortex-svc。
 grep -c "cortex-svc" /tmp/p2b-scaffold.sh
-#   期望：**2**（`/var/lib/cortex-svc` 與其 `cache/`）——這是第 1 步已標註的
-#   已知缺口：Manager 的 HOME 目錄名尚未跟上三分改名，但**擁有者已是 cortex-manager**。
-#   > 0 且非 2、或出現在 owner 欄位 ⇒ 停下來查。
+#   期望：**0**。#616 之前 scaffold 會殘留 2 筆（`/var/lib/cortex-svc` 與其
+#   `cache/`）——那是二分時代寫死的字面量，現已改由帳號名機械導出。
+#   **非 0 ⇒ 部署樹比 #616 舊，先升級再繼續**，不要照舊值建目錄。
+grep -oE "/var/lib/cortex-(manager|reviewer-planner|builder)" /tmp/p2b-scaffold.sh | sort -u
+#   期望：三行，與三個帳號名逐字對應（HOME 由帳號名導出，不會再漂移）。
 
-# ✅ 稽核 4：setfacl 可用（缺 acl 套件會讓跨帳號唯讀授權整段失效）
-command -v setfacl >/dev/null && echo "setfacl: OK" || echo "!! 請先 sudo apt-get install acl"
+# ✅ 稽核 4：setfacl 可用 —— 已上移為**執行前提 G1（硬性 gate）**
+#   此處僅複驗一次（script 產生後、套用前的最後一道），失敗即停止：
+command -v setfacl >/dev/null || echo "!! acl 缺席——回到執行前提 G1，不得套用權限"
 
 # ✅ 稽核 5：父目錄 traverse ACL 已由產生器導出（#620）
 grep -E "^setfacl -m u:[^ ]+:--x " /tmp/p2b-permissions.sh
@@ -431,6 +540,22 @@ tail -n 20 /tmp/p2b-permissions.sh | grep -c ":--x "
 #   期望：> 0。traverse 節**必須留在 script 尾端**：`chmod` 在帶 ACL 的物件上會重寫
 #   ACL **mask**，先 setfacl 再 chmod 會讓具名條目的有效權限被 mask 成空（靜默失效，
 #   不會報錯）。因此也**不要**在執行完 permissions 之後再重跑 scaffold。
+
+# ✅ 稽核 6：script 裡出現的每個帳號名都**真的存在**（#626）
+#   `setfacl` 對解析不到的使用者名直接失敗，而 2b 是 `sh -e`——一條錯就**中止整份
+#   script**，留下**半套權限的樹**（前半已套、後半沒套，包括尾端的 traverse 節）。
+#   實測命中的是 permgen 為 `operator`／`cortex-outbox` 這兩個「登記表上有 principal、
+#   本機卻沒有對應帳號」的名字產出的條目。
+for U in $(grep -oE "u:[A-Za-z0-9._-]+:" /tmp/p2b-permissions.sh | cut -d: -f2 | sort -u); do
+  getent passwd "$U" >/dev/null && echo "OK      $U" || echo "!! 不存在 $U"
+done
+#   期望：全部 OK。
+#   出現 `!! 不存在` 時的處置（**兩者擇一，不可硬跑**）：
+#     (a) 該 principal 在本機確實該有對應帳號 ⇒ 先建帳號（比照第 1 步的形態）；
+#     (b) 它是本部署形態下不存在的 principal ⇒ **等 #626 的產生器修正**，
+#         或在 operator 核可下由 script 中移除那幾行後再套用，並在 #584 記錄。
+#   **不要**改用 `sh`（去掉 `-e`）硬跑：那會把「中止」換成「靜默略過」，
+#   結果是一棵你以為套好、其實少了幾條授權的樹。
 ```
 
 ### 2b. 執行（順序固定：先骨架、後權限）
@@ -442,6 +567,11 @@ sudo sh -e /tmp/p2b-scaffold.sh && echo "scaffold applied"
 # 🔧 sudo：登記表每一項的目標權限（冪等，可重複執行）
 sudo sh -e /tmp/p2b-permissions.sh 2>&1 | tee /tmp/p2b-permissions.log
 echo "exit=${PIPESTATUS[0]}"     # 期望 0
+#   **非 0 ⇒ 樹是半套的**（`sh -e` 在第一個錯誤就停，後面的條目——包括尾端的
+#   traverse 節——完全沒套）。此時**不要**繼續往下做驗證：先看 log 最後一行是哪一條
+#   命令失敗、修掉成因（最常見是稽核 6 的帳號不存在），再**整份重跑**。
+#   重跑是安全的：每條命令都是冪等的（`install -d`／`chown`／`chmod`／`setfacl -m`
+#   對已是目標狀態的物件皆為 no-op），沒有「已套過的部分會被套壞」這回事。
 ```
 
 > **葉檔守衛**：尚未建立的葉檔（`jobs.json`、`status.json`、ledger…）由產生器包上
@@ -495,20 +625,32 @@ sudo -u cortex-builder ls /var/lib/cortex/coordinator/evidence 2>&1 | tail -1
 #   期望：Permission denied（走得到 job-specs，仍看不到別的 Manager 資產）
 
 # ✅ 驗證：三個 HOME 與 ~/.codex 由 root 擁有（帳號不得替換自己的設定）
-ls -ld /var/lib/cortex-svc /var/lib/cortex-svc/cache
+ls -ld /var/lib/cortex-manager /var/lib/cortex-manager/cache
 ls -ld /var/lib/cortex-reviewer-planner /var/lib/cortex-reviewer-planner/.codex \
        /var/lib/cortex-reviewer-planner/cache
 ls -ld /var/lib/cortex-builder /var/lib/cortex-builder/.codex /var/lib/cortex-builder/cache
-#   期望：HOME 與 .codex 皆 root:root 0755；三個 cache 各自 <帳號>:<帳號> 0700
+#   期望：HOME 與 .codex 皆 root:root 0755；三個 cache 各自 <帳號>:<帳號> 0700。
+#   （Manager 不跑模型，故無 `~/.codex` 這一條。）
 
-# ✅ 驗證：job spool 根 cortex-manager 擁有、0711（job 帳號只 traverse，不可列目錄）
-ls -ld /var/lib/cortex/jobs
-#   期望：cortex-manager:cortex-manager 0711
-sudo -u cortex-builder ls /var/lib/cortex/jobs 2>&1 | tail -1
-#   期望：Permission denied（0711 不可列目錄——job 不能枚舉別人的 spool）
+# ✅ 驗證：job-spec spool 根 cortex-manager 擁有、0700 ＋ builder 唯讀 ACL
+#   ⚠️ 路徑是 **<coordinator_root>/job-specs**，不是舊版寫的 /var/lib/cortex/jobs
+#      ——後者是 run.sh 時代的 per-job 目錄，**已不在登記表、也不會被建立**。
+ls -ld /var/lib/cortex/coordinator/job-specs
+#   期望：cortex-manager:cortex-manager 0700
+sudo getfacl -p /var/lib/cortex/coordinator/job-specs | grep -E "^(user|default:user):"
+#   期望：user:cortex-builder:r-x ＋ default:user:cortex-builder:r-x
+#   **builder 讀得到是設計**（見 5-3 表格下的說明）：template unit 的
+#   `User=cortex-builder` 由 systemd 在 `ExecStart` **之前**套用，shim 本身就是以
+#   builder 身分去讀 spec——讀不到就起不了 job。守的是**寫入面**（下一條）。
+sudo -u cortex-builder ls /var/lib/cortex/coordinator/job-specs >/dev/null \
+  && echo "builder 可列 spool（BY DESIGN）"
+sudo -u cortex-builder sh -c 'printf "{}" > /var/lib/cortex/coordinator/job-specs/probe.json' 2>&1 | tail -1
+#   期望：Permission denied ← **這條才是邊界**（builder 改不了自己的命令列）
+sudo -u cortex-reviewer-planner ls /var/lib/cortex/coordinator/job-specs 2>&1 | tail -1
+#   期望：Permission denied（spool 只對 builder 開唯讀 ACL——三分在檔案層的證據）
 ```
 
-**回滾**：`sudo rm -rf /var/lib/cortex /var/lib/cortex-svc /var/lib/cortex-reviewer-planner
+**回滾**：`sudo rm -rf /var/lib/cortex /var/lib/cortex-manager /var/lib/cortex-reviewer-planner
 /var/lib/cortex-builder /opt/cortex`（此時新樹仍空，舊樹完全未動）。
 
 ---
@@ -517,6 +659,29 @@ sudo -u cortex-builder ls /var/lib/cortex/jobs 2>&1 | tail -1
 
 裁決：舊 state **不**併入新樹、**不** `chown` 沿用，而是整包搬到 quarantine，
 留下內容 hash manifest。`legacy-imported` 來源 **MUST NOT** 滿足任何 ship gate。
+
+### 3-0. 先分清楚兩類東西——裁決只針對其中一類
+
+`$HOME/.agents` 底下**不是同質的**。裁決「legacy-imported 不得滿足任何 ship gate」
+針對的是**模型產出的 state／evidence**；把 operator 親手寫的設定一起關進 quarantine，
+等於要求 operator 憑記憶把自己的設定重打一次——而且**沒有任何一步負責搬**。
+
+| 類別 | 內容 | 為什麼 | 本步怎麼處理 |
+|---|---|---|---|
+| **模型產出的 state／evidence** | `coordinator/**`、`monitor/**`、`registry/**`、`runtime/**` | 是 gate 的**受檢對象**；來源不可信正是裁決要隔離的東西 | **整包 quarantine，不併入新樹**（3a） |
+| **operator 撰寫的設定** | `config/**`（`project-cortex.yaml`、`projects.yaml`、`model-identities.yaml`…）、`specs/**` | **不是模型輸出**，也不是任何 gate 的受檢對象；它是 operator 的意圖宣告 | **明示複製 ＋ 逐份審閱後放進新樹**（3a-2） |
+
+**漏掉 3a-2 的症狀**（M1 實測）：第 2 步只建了 `config/paulsha` 這個**目錄**並套權限，
+沒有任何一步搬**內容**；於是新樹拿不到設定，`cortex monitor --once` 直接：
+
+```text
+錯誤: 無 project 設定：manual（project-cortex.yaml / legacy）與 project-hippo.yaml 皆不存在
+```
+
+而這條**不會**被第 7 步的結構性自檢抓到——它結構全綠、功能全死。
+第 7 步因此另加了功能面檢查（見該步）。
+
+### 3a. 模型產出的 state／evidence → quarantine
 
 ```bash
 # ✅ 1. 先確認 in-flight 已收尾（執行前提第 1 項；此處再確認一次，直接讀舊 jobs.json）
@@ -568,10 +733,61 @@ sudo -u cortex-reviewer-planner ls /var/lib/cortex/legacy-imported 2>&1 | tail -
 #   期望：兩者皆 Permission denied
 ```
 
-> **重要**：新樹是**乾淨的**。切換後產生的 record 一律走正常 gate；
-> `legacy-imported/` 只是唯讀歷史副本，任何從中還原的內容**不得**被 ship gate 採計。
-> 正式的 `trust: legacy-imported` 簽章標記屬 **Phase 3**，本階段以「物理隔離＋hash
-> manifest」達成同等的不可竄改性主張。
+> **重要**：新樹的 **state／evidence 面**是乾淨的。切換後產生的 record 一律走正常
+> gate；`legacy-imported/` 只是唯讀歷史副本，任何從中還原的 **state／evidence**
+> **不得**被 ship gate 採計。正式的 `trust: legacy-imported` 簽章標記屬 **Phase 3**，
+> 本階段以「物理隔離＋hash manifest」達成同等的不可竄改性主張。
+> 下一節搬的 `config/**`／`specs/**` **不在這個限制內**——它們不是 gate 的受檢對象。
+
+### 3a-2. operator 撰寫的設定 → 明示複製進新樹（**不可略過**）
+
+quarantine 是唯讀副本，因此以它為來源複製是安全的（內容已被 3a 的 manifest 錨定）。
+**逐份看過再放**——這是 operator 對「新樹該照什麼設定跑」的重新確認，不是機械搬運。
+
+```bash
+# ✅ 1. 先看 quarantine 裡有哪些 operator 設定（不是全部都要搬）
+sudo find /var/lib/cortex/legacy-imported/config /var/lib/cortex/legacy-imported/specs \
+     -type f 2>/dev/null | sort
+#   M1 實機出現的三份：config/paulsha/project-cortex.yaml、projects.yaml、
+#   model-identities.yaml。**逐份 `sudo less` 看過**——舊路徑（`~/.agents/...`）
+#   若被寫死在設定裡，要改成新樹路徑，否則搬過去也是指回舊樹。
+
+# 🔧 sudo：以 cortex-manager 身分複製（owner 直接就對，不必事後 chown）
+sudo -u cortex-manager sh -c '
+set -e
+SRC=/var/lib/cortex/legacy-imported/config/paulsha
+DST=/var/lib/cortex/config/paulsha
+for f in project-cortex.yaml projects.yaml model-identities.yaml; do
+  [ -f "$SRC/$f" ] || { echo "skip（來源沒有）: $f"; continue; }
+  [ -e "$DST/$f" ] && { echo "skip（新樹已有，不覆蓋）: $f"; continue; }
+  cp "$SRC/$f" "$DST/$f" && echo "copied: $f"
+done'
+sudo chmod 0600 /var/lib/cortex/config/paulsha/*.yaml
+#   ↑ 清單刻意寫死而不是 `cp -r`：**要搬什麼是 operator 的決定**。
+#     `specs/**` 同理——有需要就以同樣形態補一段，沒有就不動。
+
+# ✅ 驗證：新樹讀得到設定，且內容與 quarantine 一致
+ls -l /var/lib/cortex/config/paulsha/
+sudo -u cortex-manager cat /var/lib/cortex/config/paulsha/project-cortex.yaml | head -20
+for f in /var/lib/cortex/config/paulsha/*.yaml; do
+  b=$(basename "$f")
+  sudo cmp -s "$f" "/var/lib/cortex/legacy-imported/config/paulsha/$b" \
+    && echo "same as quarantine: $b" || echo "!! 與 quarantine 不同（若是刻意改路徑則正常）: $b"
+done
+
+# ✅ 驗證（功能面）：設定真的被載入——這條是 3a-2 的**存在理由**
+sudo -u cortex-manager env $(grep -v '^#' /opt/cortex/etc/cortex-manager.env | xargs) \
+  /opt/cortex/venv/bin/cortex monitor --once 2>&1 | head -20
+#   期望：**不得**出現
+#     `錯誤: 無 project 設定：manual（project-cortex.yaml / legacy）與 project-hippo.yaml 皆不存在`
+#   出現這行 ⇒ 設定沒搬到／檔名不符／路徑被寫死指回舊樹，回上面重做。
+#   註：本步在第 4b（EnvironmentFile）之後才跑得起來；若此時尚未到第 4b，
+#       把這條記在待辦，第 7 步的功能面檢查會再驗一次。
+```
+
+> **為什麼不是 `cp -a` 整棵 `config/`**：`config/` 底下未來可能混進非 operator 撰寫的
+> 快取或衍生檔；整棵搬會把「哪些是 operator 的意圖」這條界線再度模糊掉。逐檔白名單
+> 讓每一份設定進新樹都是一個**明示決定**，也讓 diff 在下次升級時看得懂。
 
 ### 3b. review verdict spool（Phase 2a 已就位的受控通道；三分下才完整）
 
@@ -631,14 +847,59 @@ find "$HOME/.agents" -perm /022 -print | head
 
 ### 4a. venv 遷入 `/opt/cortex`
 
+> **⚠️ `cp -a` 之後 venv 還沒好**：pipx 的 venv 有**兩處硬編碼**指回 operator 樹，
+> 光靠 `cp -a` ＋ `chown` ＋ `chmod` 搬不掉。M1 實測直接
+> `sudo -u cortex-manager /opt/cortex/venv/bin/cortex --version` → `Permission denied`：
+>
+> | 殘留 | 內容 | 為什麼是**安全條件**而不只是「跑不起來」 |
+> |---|---|---|
+> | `bin/*` 的 shebang | `#!$HOME/.local/share/pipx/venvs/paulsha-cortex/bin/python` | 部署樹的**第一支被執行的程式**其實住在 operator 可寫的目錄裡 |
+> | `lib/python3.*/site-packages/pipx_shared.pth` | 指向 operator 的 pipx shared site-packages | 部署樹的 **import path** 仍受 operator 可寫目錄影響——`.pth` 是背景 §5 那條「注入 `.pth`」攻擊面的同一個機制 |
+>
+> 兩者都必須在硬化（`chmod a-w`）**之前**清掉，否則 `/opt/cortex` 全 root-owned
+> 這件事只是表面的：真正決定執行什麼的兩個指標仍在信任邊界外。
+
 ```bash
 # 🔧 sudo：複製（不是原地 chown）到 root-owned 部署路徑
 sudo rm -rf /opt/cortex/venv.new
 sudo cp -a "$HOME/.local/share/pipx/venvs/paulsha-cortex" /opt/cortex/venv.new
+
+# 🔧 sudo：(1) 重寫 bin/* 的 shebang 前綴 —— 指回部署樹自己的 python
+#   只改「第一行確實是舊前綴」的檔案，二進位檔與 symlink 一律不碰。
+#   注意寫的是最終路徑 /opt/cortex/venv（不是 venv.new）——下面就會 mv 過去。
+sudo env OLD_PREFIX="$HOME/.local/share/pipx/venvs/paulsha-cortex" sh -s <<'SH'
+set -eu
+for f in /opt/cortex/venv.new/bin/*; do
+  [ -f "$f" ] || continue            # 跳過 symlink／目錄
+  IFS= read -r first < "$f" || continue
+  case "$first" in
+    "#!$OLD_PREFIX/bin/"*) ;;
+    *) continue ;;
+  esac
+  interp=${first#"#!$OLD_PREFIX/bin/"}
+  sed -i "1s|.*|#!/opt/cortex/venv/bin/$interp|" "$f"
+  echo "shebang rewritten: $f -> /opt/cortex/venv/bin/$interp"
+done
+SH
+
+# 🔧 sudo：(2) 移除 pipx_shared.pth —— 部署樹不得再 import operator 的 shared 樹
+sudo find /opt/cortex/venv.new -name "pipx_shared.pth" -print -delete
+#   註：pipx shared 樹裡是 pip／setuptools／wheel，runtime 不需要；部署樹本來就
+#   不該在裡面裝東西（升級走第 6 步整棵替換）。
+
+# 🔧 sudo：硬化（順序不可調換——上面兩步要在 a-w 之前做完）
 sudo chown -R root:root /opt/cortex/venv.new
 sudo find /opt/cortex/venv.new -type d -exec chmod 0755 {} +
 sudo find /opt/cortex/venv.new -type f -exec chmod a-w {} +
 sudo find /opt/cortex/venv.new/bin -type f -exec chmod 0755 {} +
+
+# ✅ 驗證（切換前）：部署樹裡不得殘留任何指回 operator 樹的路徑
+#   這是上面兩步的**總驗收**——它同時涵蓋 shebang、.pth、pyvenv.cfg、
+#   console-script 內嵌路徑等一切形式，比逐項檢查更難漏。
+sudo grep -rIl -- "$HOME/.local/share/pipx" /opt/cortex/venv.new | head
+#   期望：空輸出
+sudo find /opt/cortex/venv.new -type l -lname "*/.local/share/pipx/*" | head
+#   期望：空輸出（symlink 也不得指回 operator 樹）
 
 # 🔧 sudo：切成 active（venv 目錄本身即 ExecStart 的目標；保留舊的供回滾）
 sudo rm -rf /opt/cortex/venv.prev
@@ -649,6 +910,10 @@ sudo mv /opt/cortex/venv.new /opt/cortex/venv
 ```bash
 # ✅ 驗證：對服務帳號唯讀、可執行、版本正確
 sudo -u cortex-manager /opt/cortex/venv/bin/cortex --version
+#   期望：印出版本。**若是 `Permission denied`** ⇒ shebang 仍指回 operator 樹
+#   （`head -1 /opt/cortex/venv/bin/cortex` 即可確認），回上面的 (1) 重做。
+sudo -u cortex-manager /opt/cortex/venv/bin/python -c "import paulsha_cortex, sys; print(sys.prefix)"
+#   期望：/opt/cortex/venv —— 確認 import path 沒有經由 .pth 逃回 operator 樹
 sudo -u cortex-manager test -w /opt/cortex/venv/bin/cortex && echo "!! 可寫，停止" || echo "read-only: OK"
 sudo find /opt/cortex/venv -perm /022 -print | head
 #   期望：空輸出
@@ -774,6 +1039,23 @@ sudo rm /etc/systemd/system/cortex-manager.service; sudo systemctl daemon-reload
 > **跳過本步＝instance 沒有 monitor**：GitHub issue sync／work-items 快照停擺，
 > `monitor-event-spool` 只有 builder 的 `wx` 生產端、沒有消費端，spool 只增不減。
 
+> **⛔ 但**：**現在只安裝，不要 `enable --now`**（issue #623，實機驗證）。
+> 「裝好」與「啟動」是兩件事——本步的**安裝與驗證全部照做**，
+> **唯獨最後的 `enable`／`start` 要等 #623 的三個缺口全解**。
+>
+> 為什麼不能先起來擋著：`PSC_DEGRADED_OPERATION=per-case-approval` **不會**阻止
+> 派工。它只 gate 四個敏感動作（`headless-acceptance`／`outbox-mutation`／`ship`／
+> `merge`，見 `trust_root/capability.py`），**job spawn 不在其中**。
+> 因此 monitor 一起來，intake 就會開始運作並真的派 builder job 出去，而那些 job
+> **現在不可能成功**——#623 記錄的兩個成因：unit 的 `ProtectHome=yes` 讓 repo
+> 路徑不可達；EnvironmentFile 缺八個操作變數（含 `PSC_GATE_CMD_PYTEST`）。
+> 後果是**燒模型額度、產生 needs_human 噪音、留下半死的 run 狀態**——
+> 全部發生在「看起來裝好了」之後，而且沒有任何一條 M1 的結構性驗收會變紅。
+>
+> **本步的正確終態**：unit 已落檔、與產生器逐位元相同、`systemctl show` 的身分與
+> 加固段全部驗過，而服務保持 **`disabled` ／ `inactive`**。
+> #623 關閉後再回來執行「啟動」那一小段，並補跑第 7 步的功能面檢查。
+
 monitor 與 Manager **同帳號**（UID 方案表：`cortex-manager`＝Manager ＋ monitor——
 唯有同帳號才寫得進自己的 `0700` state 樹），加固段與 EnvironmentFile 也是同一份；
 但 `ReadWritePaths` **嚴格更窄**：產生器只從 monitor persona 在 R1 登記表上的
@@ -807,11 +1089,23 @@ sudo chmod 0644 /etc/systemd/system/cortex-monitor.service
 # 🔧 sudo：確認舊的 --user monitor 已停用且不會被 lingering 拉回來
 systemctl --user disable --now cortex-monitor.service 2>/dev/null || true
 
-# 🔧 sudo：載入並啟用（system-level，非 --user）
+# 🔧 sudo：只 daemon-reload，**先不要 enable／start**（見上方 #623 的 ⛔）
 sudo systemctl daemon-reload
+
+# ✅ 驗證：本步的正確終態就是「裝好但沒跑」
+systemctl is-enabled cortex-monitor.service; systemctl is-active cortex-monitor.service
+#   期望：`disabled` ／ `inactive`（`is-enabled` 對未 enable 的 unit 回非 0，屬正常）
+```
+
+**#623 關閉後**才執行下面這一小段，並在 #584 記錄啟動時間：
+
+```bash
+# 🔧 sudo：啟用（system-level，非 --user）—— **#623 三個缺口全解之後才做**
 sudo systemctl enable cortex-monitor.service
 sudo systemctl start cortex-monitor.service
 ```
+
+**安裝面驗證（不需要服務在跑，#623 未關也照做）**：
 
 ```bash
 # ✅ 驗證：unit 檔內容與產生器輸出逐位元相同（防手改漂移）
@@ -819,13 +1113,18 @@ diff <(python3 -m paulsha_cortex.trust_root unit three-way --monitor) \
      /etc/systemd/system/cortex-monitor.service && echo "monitor unit in sync: OK"
 
 # ✅ 驗證：身分與加固段（應與 cortex-manager.service 逐項相同）
+#   `systemctl show` 讀的是 unit 定義，服務沒在跑也答得出來。
 systemctl show cortex-monitor.service \
   -p User -p NoNewPrivileges -p ProtectSystem -p ProtectHome -p ProtectProc \
   -p CapabilityBoundingSet -p MemoryDenyWriteExecute -p ReadWritePaths
 #   期望：**User=cortex-manager**、NoNewPrivileges=yes、ProtectSystem=strict、
 #         ProtectHome=yes、ProtectProc=invisible、CapabilityBoundingSet=（空）、
 #         MemoryDenyWriteExecute=yes；ReadWritePaths 僅上表三條
+```
 
+**執行面驗證（⛔ 只在 #623 關閉、服務已啟動後才適用）**：
+
+```bash
 # ✅ 驗證：monitor 行程確實以 cortex-manager 身分跑
 ps -o user=,pid=,cmd= -p "$(systemctl show cortex-monitor.service -p MainPID --value)"
 #   期望：user 欄為 cortex-manager，cmd 為 /opt/cortex/venv/bin/cortex monitor
@@ -868,8 +1167,9 @@ sudo rm /etc/systemd/system/cortex-monitor.service; sudo systemctl daemon-reload
 ## 第 5 步：降權啟用（**A+B 單一路徑**）
 
 > **前置條件**：執行前提第 9 項。若 `systemd-template` 尚未出現在
-> `job_runner.RUNNER_MODES`（#603 follow-up PR 未落地），則 **(a)(b) 照裝、(c) 跳過、
-> (d) 不開**——邊界仍可由 5-7 的反向測試完整證明，只是 Manager 還不會走它。
+> `job_runner.RUNNER_MODES`（部署樹比 #616 舊），則 **(a)(b) 照裝、(c) 跳過、
+> (d) 不開**——邊界仍可由 5-7 的反向測試完整證明，只是 Manager 還不會走它；
+> 但正確處置是先把部署樹升級到含 #616 的版本，而不是長期停在這個狀態。
 > **絕不**因為 (d) 開不了就退回 transient 主路徑；需要臨時降權時走 **附錄 B**
 > 並在 #584 記錄殘餘風險與預計關閉時間。
 
@@ -922,19 +1222,38 @@ job 的 argv 不再由 Manager 行程直接組出並交給 systemd，而是由 r
 | 角色 | 路徑 | 擁有者 | 權限意義 |
 |---|---|---|---|
 | shim（root-owned 程式） | `/opt/cortex/bin/cortex-job-shim` | root:root 0755 | 三個服務帳號皆**不可寫**（`/opt/cortex` 整棵 root-owned） |
-| job-spec spool 根 | `/var/lib/cortex/jobs` | cortex-manager 0711 | Manager 寫；job 帳號只 traverse，**不可列目錄**（不能枚舉他人 job） |
-| per-job spec | `/var/lib/cortex/jobs/<id>/` | cortex-manager 0700 ＋ builder `r-x` ACL | job 只讀自己那格——**改不了自己的命令列，也埋伏不了下一個 job** |
+| job-spec spool 根 | `/var/lib/cortex/coordinator/job-specs` | cortex-manager 0700 ＋ builder `r-x` ACL | **只有 Manager 寫得進去**；builder 唯讀。spool 是登記表資產 `job-spec-spool`，權限由 permgen 機械產生 |
+| per-job spec | `<spool>/<instance>.json`（**一個檔，不是一個目錄**） | cortex-manager 0640 ＋ builder 唯讀 ACL | builder **改不了自己的命令列，也埋伏不了下一個 job**——見下方「守的是寫入面」 |
+
+> **守的是寫入面，不是讀取面**（M1 實測校正，#584／#621）：
+> template unit 的 `User=cortex-builder` 由 systemd 在 `ExecStart` **之前**套用，
+> 所以 shim 本身就是以 builder 身分執行的——**它必須讀得到 spec，否則 job 起不來**。
+> 「builder 讀得到 spool」因此是設計，不是破口。真正載重的是四個**寫入**面實測全拒：
+> builder 無法在 spool 內**建立**新 spec、**追加**自己的 spec、用 **symlink 換掉**、
+> 或**刪除**任何 spec。「改不了自己的命令列、埋伏不了下一個 job」就落在這四條上。
+>
+> **per-job 的讀隔離不在本方案範圍**：所有 builder job 共用**同一個 UID**，
+> 因此彼此的 spec 本來就互讀得到——這在威脅模型內（同 persona 的 job 之間不設界）。
+> 要做到 per-job 讀隔離必須 **per-job UID**（動態 UID／`DynamicUser=` 一類），
+> 那是另一個方案，**Phase 2b 不宣稱**。舊版此表寫「job 只讀自己那格」並不精確。
+>
+> `User=` 完全不在 spec 內（`build_job_spec()` 對 `user`／`uid`／`group`／`gid`／
+> `properties`／`exec_start` 主動 fail-closed，shim 讀端再驗一次），
+> 因此 spool 即使被竄改也選不了 UID。
 
 ```bash
-# ⏳ 內容由 #603 follow-up PR 的產生器提供（命令名以該 PR 實際落地為準）：
-#      python3 -m paulsha_cortex.trust_root shim three-way > /tmp/cortex-job-shim
-#    在它落地前**跳過本節**，並確認 5-2 的 ExecStart 指向哪裡（見下方檢查）。
+# ✅ 產生 shim 內容（#616 已 merge；產生器是唯一真相）
+python3 -m paulsha_cortex.trust_root shim three-way > /tmp/cortex-job-shim
 
-# ✅ 檢查安裝好的 template unit 實際的 ExecStart——決定本節做不做
+# ✅ 檢查安裝好的 template unit 實際的 ExecStart
 systemctl cat cortex-job@.service | grep -E "^ExecStart="
-#   期望（PR 落地後）：ExecStart=/opt/cortex/bin/cortex-job-shim %i
-#   若仍為 /bin/sh /var/lib/cortex/jobs/%i/run.sh ⇒ PR 未落地：
-#     本節跳過；5-6 的正向 smoke 改用 run.sh 形式；(d) 切換點不打開。
+#   期望：ExecStart=/opt/cortex/bin/cortex-job-shim %i
+#   若仍為 /bin/sh /var/lib/cortex/jobs/%i/run.sh ⇒ 部署樹比 #616 舊
+#   （那是 run.sh 時代的形狀，spool 路徑也還是舊的）——先升級部署樹再繼續。
+
+# ✅ 檢查 spec 從哪裡讀（unit 用 Environment= 寫死，呼叫端改不了）
+systemctl cat cortex-job@.service | grep -E "^Environment=PSC_JOB_SPEC_SPOOL="
+#   期望：Environment=PSC_JOB_SPEC_SPOOL=/var/lib/cortex/coordinator/job-specs
 
 # 🔧 sudo：落檔（root 擁有、可執行、對三個服務帳號唯讀）
 sudo install -d -o root -g root -m 0755 /opt/cortex/bin
@@ -1022,37 +1341,68 @@ sudo -u cortex-manager env $(grep -v '^#' /opt/cortex/etc/cortex-manager.env | x
 ```bash
 JOB=selftest
 
-# 🔧 sudo：per-job spool（manager 擁有、builder 只讀）＋ job worktree
-sudo install -d -o cortex-manager -g cortex-manager -m 0700 "/var/lib/cortex/jobs/$JOB"
-sudo setfacl -m u:cortex-builder:r-x "/var/lib/cortex/jobs/$JOB"
+# 🔧 sudo：job worktree（builder 擁有——job 的 log 與工作區都落在這裡）
 sudo install -d -o cortex-builder -g cortex-builder -m 0700 "/var/lib/cortex/worktree/$JOB"
 
-# 🔧 sudo：放一份 smoke 執行規格。**形式取決於 5-3 檢查到的 ExecStart**：
-#   (i) shim 已落地（ExecStart=/opt/cortex/bin/cortex-job-shim %i）：
-#       用該 PR 提供的產生器寫 job-spec，**不要自行捏造欄位**。
-#   (ii) shim 未落地（ExecStart=/bin/sh …/%i/run.sh）：用下列 run.sh 形式，
-#        它同樣足以證明 (a)(b) 的邊界（身分／token／fd／HOME）。
-sudo tee "/var/lib/cortex/jobs/$JOB/run.sh" >/dev/null <<'SH'
-#!/bin/sh
-echo "== identity =="; id
-echo "== tokens =="; echo "GH_TOKEN=[$GH_TOKEN] GITHUB_TOKEN=[$GITHUB_TOKEN]"
-echo "== inherited fds =="; ls -l /proc/self/fd
-echo "== home =="; echo "HOME=$HOME"; ls -ld "$HOME" 2>&1
-echo "== deployment writable? =="; (printf x >> /opt/cortex/venv/bin/cortex) 2>&1 | tail -1
-SH
-sudo chown cortex-manager:cortex-manager "/var/lib/cortex/jobs/$JOB/run.sh"
-sudo chmod 0600 "/var/lib/cortex/jobs/$JOB/run.sh"
-sudo setfacl -m u:cortex-builder:r-- "/var/lib/cortex/jobs/$JOB/run.sh"
+# 🔧 sudo：寫 job-spec —— **一律用 build_job_spec()／write_job_spec() 產生**，
+#   不要自行捏造欄位（手捏的 spec 會被 shim 的白名單 schema 擋掉，而且
+#   `spec_version` 一旦對不上就直接 fail-closed）。
+#   spec 路徑＝<spool>/<instance>.json，由 job_spec_path() 推導，不手寫。
+sudo -u cortex-manager /opt/cortex/venv/bin/python - "$JOB" <<'PY'
+import sys
+from paulsha_cortex.coordinator import job_runner
+
+instance = sys.argv[1]
+spool = job_runner.DEFAULT_JOB_SPEC_SPOOL
+smoke = (
+    'echo "== identity =="; id; '
+    'echo "== tokens =="; echo "GH_TOKEN=[$GH_TOKEN] GITHUB_TOKEN=[$GITHUB_TOKEN]"; '
+    'echo "== inherited fds =="; ls -l /proc/self/fd; '
+    'echo "== home =="; echo "HOME=$HOME"; ls -ld "$HOME"; '
+    'echo "== deployment writable? =="; (printf x >> /opt/cortex/venv/bin/cortex) 2>&1 | tail -1; '
+    'echo "== spec spool writable? =="; '
+    '(printf x > /var/lib/cortex/coordinator/job-specs/evil.json) 2>&1 | tail -1'
+)
+spec = job_runner.build_job_spec(
+    job_id=f"{instance}-smoke",
+    instance=instance,
+    unit=f"cortex-job@{instance}.service",
+    command=["/bin/sh", "-c", smoke],
+    working_directory=f"/var/lib/cortex/worktree/{instance}",
+    log_path=f"/var/lib/cortex/worktree/{instance}/{instance}.log",
+    # ⚠️ job 的 env **就是**這一份，不繼承 unit 的 Environment=——shim 是
+    #    `execvpe(command, spec["env"])`。因此 PATH／HOME 要在這裡給，
+    #    而 token 類的名字 build_job_spec() 直接拒收（見下方註）。
+    env={"HOME": "/var/lib/cortex-builder", "PATH": "/usr/local/bin:/usr/bin:/bin"},
+)
+print("wrote:", job_runner.write_job_spec(job_runner.job_spec_path(spool, instance), spec))
+PY
+#   ↑ 以 **cortex-manager 身分**寫——spool 是 Manager-owned，這一步本身就在證明
+#     「writer 只有 Manager」；若這裡就 Permission denied，代表第 2 步權限沒套好。
+#
+#   ▸ **token 的保證比「scrub」更強**：job 的 env 完全等於 spec 的 `env` 欄位，
+#     而 `build_job_spec()` 對 `*TOKEN*`／`*SECRET*`／`*API_KEY*` 這類名字
+#     （`CREDENTIAL_ENV_RE`）與 `LD_PRELOAD`／`PYTHONPATH` 這類名字
+#     （`DENIED_ENV_NAMES`）**在寫入端就 raise**——不是執行時清掉，是根本進不了 spec。
+#     可以當場驗一次這條守衛（期望：拋 DiagnosticReason，spec 不會被寫出）：
+#       … build_job_spec(..., env={"GH_TOKEN": "x"})
 
 # ✅ 正向：以 cortex-manager 身分起 instance——**必須成功**
 sudo -u cortex-manager systemctl start "cortex-job@$JOB.service"
-sudo journalctl -u "cortex-job@$JOB.service" -n 50 --no-pager
+
+# ✅ job 的輸出在 **spec 的 log_path**，不在 journal
+#   （shim 在**已降權之後**用 O_NOFOLLOW 接管 stdout/stderr；journal 只承接
+#    「接管之前」的 shim 診斷，例如 spec 缺席／schema 不合。）
+sudo cat "/var/lib/cortex/worktree/$JOB/$JOB.log"
 #   期望輸出：
 #     uid=…(cortex-builder) gid=…(cortex-builder)   ← User= 由 OS 強制，不是呼叫端選的
-#     GH_TOKEN=[] GITHUB_TOKEN=[]                    ← token 已 scrub
+#     GH_TOKEN=[] GITHUB_TOKEN=[]                    ← 兩個名字根本進不了 spec
 #     /proc/self/fd 只有 0/1/2                        ← 無指向受保護資產的可寫 fd（R9 T4.1）
 #     HOME=/var/lib/cortex-builder，且該目錄為 root:root
 #     deployment writable? → Permission denied / Read-only file system
+#     spec spool writable? → Permission denied      ← builder 改不了自己的命令列
+sudo journalctl -u "cortex-job@$JOB.service" -n 20 --no-pager
+#   期望：**沒有** shim 的錯誤（`job spec …` 開頭的訊息代表 spec 有問題）。
 
 # ✅ 正向：停也必須成功（polkit 放行的兩個 verb）
 sudo -u cortex-manager systemctl stop "cortex-job@$JOB.service"; echo "exit=$?"   # 期望 0
@@ -1119,9 +1469,10 @@ sudo systemctl restart polkit.service 2>/dev/null || sudo systemctl restart polk
 任一反向測試通過（即攻擊成功）＝**立即停止**，回到第 9 步回滾。
 
 ```bash
-# 🔧 sudo：清掉 selftest 殘留
+# 🔧 sudo：清掉 selftest 殘留（spec 是一個檔，worktree 是一個目錄）
 sudo systemctl stop "cortex-job@$JOB.service" 2>/dev/null || true
-sudo rm -rf "/var/lib/cortex/jobs/$JOB" "/var/lib/cortex/worktree/$JOB"
+sudo rm -f "/var/lib/cortex/coordinator/job-specs/$JOB.json"
+sudo rm -rf "/var/lib/cortex/worktree/$JOB"
 ```
 
 ### 5-8. 殘餘風險（A+B 之後重新評估）
@@ -1145,7 +1496,7 @@ sudo rm -rf "/var/lib/cortex/jobs/$JOB" "/var/lib/cortex/worktree/$JOB"
 | 殘餘 | 具體形狀 | 現有緩解 | 缺口 |
 |---|---|---|---|
 | **部署樹供應鏈** | 惡意相依／被竄改的 wheel 進到 `/opt/cortex/venv`，之後以 `cortex-manager` 身分執行 | `/opt/cortex` 全 root-owned、對服務唯讀（4a）；升級走第 6 步 operator 手動驗證＋hash diff；**不 codify** root 命令（裁決 6） | 無簽章驗證（屬 **Phase 3**）；hash diff 靠 operator 目視 |
-| **Manager 自身邏輯被攻陷** | Manager 程式碼路徑被誘導寫出惡意 job-spec | root-owned shim 限定 argv 形狀（5-3）；job 仍降到 `cortex-builder`、拿不到 token | shim 對 spec 的檢查強度＝該 PR 的實作品質，需在 PR review 時單獨把關 |
+| **Manager 自身邏輯被攻陷** | Manager 程式碼路徑被誘導寫出惡意 job-spec | root-owned shim 限定 argv 形狀（5-3）；spec 的 schema 是**白名單**且身分欄位 fail-closed（寫端 `build_job_spec()`、讀端 `job_shim.load_spec()` 各驗一次）；job 仍降到 `cortex-builder`、拿不到 token | shim 只能保證「身分／入口不可選」，**不**保證 command 內容良性——惡意 spec 仍可讓 builder 跑任意命令（上界＝builder 權限）。這條要靠 Manager 端的派工邏輯與 R9 族 2 的檔案邊界共同壓住 |
 | **operator 帳號** | 有 `sudo`，可改任何東西 | 設計上信任邊界之外（本 runbook 全部 root 操作都由 operator 親自輸入） | 不在本階段範圍 |
 | **polkit 不可用** | polkit 掛掉 ⇒ 全部 job 起不來 | fail-closed（安全但功能全停）；執行前提第 6 項＋WSL2 段第 5 項複驗 | 需監控，否則表現為「靜默停擺」 |
 | **M2 未完成** | reviewer／planner 仍在 Manager 行程內以 `cortex-manager` 身分跑 ⇒ 這兩個 persona 的 injection 可達行程**目前**仍與 grant 同 UID | 檔案權限面已三分（第 3b 步實測）；builder（最大攻擊面）已完全移出 | **這是 M1 唯一的行程面殘餘**，必須在 #584 明示記錄，並隨 M2 關閉 |
@@ -1213,14 +1564,50 @@ pipx upgrade paulsha-cortex     # 或既有 build 流程
 ( cd "$HOME/.local/share/pipx/venvs/paulsha-cortex" && find . -type f -print0 | sort -z | xargs -0 sha256sum ) > /tmp/cortex-new.sha
 ( cd /opt/cortex/venv && sudo find . -type f -print0 | sort -z | sudo xargs -0 sha256sum ) > /tmp/cortex-cur.sha
 diff <(sort /tmp/cortex-cur.sha) <(sort /tmp/cortex-new.sha) | head -50
+#   ⚠️ 預期會有**兩類與版本無關的固定差異**（第 4a／本步 3a-3b 造成的，不是供應鏈訊號）：
+#     (a) `./bin/*` —— 現行部署的 shebang 已改寫成 /opt/cortex/venv/bin/…
+#     (b) `./lib/python3.*/site-packages/pipx_shared.pth` —— 只存在於 pipx 樹
+#   人工關卡要看的是**扣掉這兩類之後**還有什麼變動：
+diff <(sort /tmp/cortex-cur.sha) <(sort /tmp/cortex-new.sha) \
+  | grep -vE "^[<>] [0-9a-f]{64}  \./(bin/|lib/python3\.[0-9]+/site-packages/pipx_shared\.pth)" \
+  | head -50
 
 # 🔧 3. sudo：旁建新樹（不覆蓋現行）
+#   ⚠️ 與第 4a 步**完全相同**的兩個 pipx 殘留必須在硬化前清掉——升級用的是同一條
+#   `cp -a`，因此同樣會把 operator 樹的 shebang 與 pipx_shared.pth 帶進來。
+#   漏掉的症狀：升級後服務起不來（`Permission denied`），或更糟——起得來但
+#   import path 仍受 operator 可寫目錄影響（見 4a 的表）。
 sudo rm -rf /opt/cortex/venv.new
 sudo cp -a "$HOME/.local/share/pipx/venvs/paulsha-cortex" /opt/cortex/venv.new
+
+# 🔧 3a. sudo：重寫 bin/* 的 shebang 前綴（與 4a 逐字相同）
+sudo env OLD_PREFIX="$HOME/.local/share/pipx/venvs/paulsha-cortex" sh -s <<'SH'
+set -eu
+for f in /opt/cortex/venv.new/bin/*; do
+  [ -f "$f" ] || continue
+  IFS= read -r first < "$f" || continue
+  case "$first" in
+    "#!$OLD_PREFIX/bin/"*) ;;
+    *) continue ;;
+  esac
+  interp=${first#"#!$OLD_PREFIX/bin/"}
+  sed -i "1s|.*|#!/opt/cortex/venv/bin/$interp|" "$f"
+  echo "shebang rewritten: $f -> /opt/cortex/venv/bin/$interp"
+done
+SH
+
+# 🔧 3b. sudo：移除 pipx_shared.pth
+sudo find /opt/cortex/venv.new -name "pipx_shared.pth" -print -delete
+
+# 🔧 3c. sudo：硬化（順序不可調換）
 sudo chown -R root:root /opt/cortex/venv.new
 sudo find /opt/cortex/venv.new -type d -exec chmod 0755 {} +
 sudo find /opt/cortex/venv.new -type f -exec chmod a-w {} +
 sudo find /opt/cortex/venv.new/bin -type f -exec chmod 0755 {} +
+
+# ✅ 3d. 總驗收：新樹裡不得殘留任何指回 operator 樹的路徑
+sudo grep -rIl -- "$HOME/.local/share/pipx" /opt/cortex/venv.new | head    # 期望：空輸出
+sudo find /opt/cortex/venv.new -type l -lname "*/.local/share/pipx/*" | head  # 期望：空輸出
 
 # ✅ 4. 新樹自檢通過才切換
 sudo -u cortex-manager /opt/cortex/venv.new/bin/python -m paulsha_cortex.trust_root selfcheck
@@ -1233,7 +1620,8 @@ diff <(sudo -u cortex-manager /opt/cortex/venv.new/bin/python -m paulsha_cortex.
      /etc/systemd/system/cortex-job@.service || echo "!! job template unit 需更新"
 diff <(sudo -u cortex-manager /opt/cortex/venv.new/bin/python -m paulsha_cortex.trust_root polkit three-way --template) \
      /etc/polkit-1/rules.d/49-cortex-downgrade.rules || echo "!! polkit 規則需更新"
-#   （shim 落地後同樣加一條 `… shim three-way` 對 /opt/cortex/bin/cortex-job-shim 的 diff）
+diff <(sudo -u cortex-manager /opt/cortex/venv.new/bin/python -m paulsha_cortex.trust_root shim three-way) \
+     /opt/cortex/bin/cortex-job-shim || echo "!! shim 需更新"
 
 # 🔧 6. sudo：原子切換（保留前一版供回滾）
 sudo systemctl stop cortex-manager.service
@@ -1267,6 +1655,7 @@ sudo -u cortex-manager env $(grep -v '^#' /opt/cortex/etc/cortex-manager.env | x
   /opt/cortex/venv/bin/python -m paulsha_cortex.trust_root selfcheck \
   | tee "/tmp/trust-root-after-$(date +%Y%m%d-%H%M).json"
 #   期望：JSON 的 "ok": true、"job_writable_count": 0
+#   M1 實測：`job_writable_count` 由 baseline 的 **5** 收斂為 **0**、`remaining` 為空。
 
 # ✅ 與執行前提的 baseline 逐項對照（哪些 job-writable finding 被關掉了）
 python3 - <<'PY'
@@ -1288,7 +1677,43 @@ PY
 python3 -m paulsha_cortex.trust_root equation
 ```
 
-**通過條件**：自檢 `ok=true`、`remaining` 為空、`equation` 為 `ok: true`。
+### 7b. 功能面檢查（**結構全綠不等於做得了事**）
+
+> **這一節存在的理由**：上面每一條、以及 M1 的全部驗收，都是**結構性**的——
+> 誰擁有什麼、誰被拒、攻擊有沒有失敗。**沒有一條是功能性的**。
+> 這正是為什麼 M1 全數通過，而部署其實**做不了任何實際工作**：
+> 設定沒搬（第 3a-2）、job 跑不完（#623）。結構性驗收看不到這兩件事。
+> 從最便宜的一條開始，逐級加重。
+
+```bash
+# ✅ F1（最便宜）：monitor 載得到自己的設定——第 3a-2 的守門條款
+sudo -u cortex-manager env $(grep -v '^#' /opt/cortex/etc/cortex-manager.env | xargs) \
+  /opt/cortex/venv/bin/cortex monitor --once 2>&1 | head -20
+#   期望：正常跑完一輪。
+#   ⛔ 出現 `錯誤: 無 project 設定：…皆不存在` ⇒ 第 3a-2 沒做或做錯，回去補。
+#   這條**兩秒鐘**，卻是 M1 唯一漏掉的那一類缺口的最短偵測路徑。
+
+# ✅ F2：Manager 的 porcelain 在新樹上答得出話（路徑契約真的解析得到）
+sudo -u cortex-manager env $(grep -v '^#' /opt/cortex/etc/cortex-manager.env | xargs) \
+  /opt/cortex/venv/bin/cortex status 2>&1 | head -20
+sudo -u cortex-manager env $(grep -v '^#' /opt/cortex/etc/cortex-manager.env | xargs) \
+  /opt/cortex/venv/bin/cortex jobs 2>&1 | head -10
+#   期望：兩者都正常輸出（新樹為空是合理的，**報錯不是**）。
+
+# ⏳ F3（最重，但這才是「能用」的定義）：真實 intake 一案並跑到 terminal
+#   ⛔ **#623 關閉前不要做**——job 現在必然失敗（ProtectHome 讓 repo 不可達、
+#      EnvironmentFile 缺八個操作變數），只會燒額度並留下半死的 run 狀態。
+#   #623 關閉後：以 operator 觸發一次真實派工，追到 terminal 狀態，並確認
+#     (a) job 以 uid=…(cortex-builder) 執行；
+#     (b) evidence 落在 /var/lib/cortex/coordinator/evidence 底下；
+#     (c) 全程沒有任何一步回頭寫 $HOME/.agents。
+#   結果貼進 #584。**在 F3 通過之前，本部署只能宣稱「隔離已就位」，
+#   不得宣稱「Phase 2b 可用」。**
+```
+
+**通過條件**：自檢 `ok=true`、`remaining` 為空、`equation` 為 `ok: true`
+（結構面）**且** F1／F2 通過（功能面）。F3 屬 #623 關閉後的驗收，
+未做時必須在 #584 明示記錄「功能面僅到 F2」。
 
 ---
 
@@ -1313,29 +1738,88 @@ python3 -m paulsha_cortex.trust_root equation
 ### 8a. 攻擊腳本（族 1–4，以模型 job 身分執行）
 
 ```bash
-# 🔧 sudo：R9 攻擊 job 的 spool／worktree／攻擊目標（全部由 operator 親自建立）
+# 🔧 sudo：R9 攻擊 job 的 worktree ＋ 攻擊腳本（全部由 operator 親自建立）
 JOB=r9
-sudo install -d -o cortex-manager -g cortex-manager -m 0700 "/var/lib/cortex/jobs/$JOB"
-sudo setfacl -m u:cortex-builder:r-x "/var/lib/cortex/jobs/$JOB"
 sudo install -d -o cortex-builder -g cortex-builder -m 0700 "/var/lib/cortex/worktree/$JOB"
 
-sudo tee "/var/lib/cortex/jobs/$JOB/run.sh" >/dev/null <<'SH'
+# 攻擊腳本放在**兩個 subject 都讀得到**的 root-owned 位置。
+#   ・不能放 /tmp：template unit 帶 PrivateTmp=yes，operator 寫的 /tmp 檔 job 看不到。
+#   ・不能放 worktree/$JOB：那是 builder-owned 0700，reviewer-planner 讀不到。
+#   ・/var/lib/cortex 樹根是 root:root 0755，放這裡 root 擁有、全體唯讀，8e 一併清掉。
+sudo tee /var/lib/cortex/r9-attack.sh >/dev/null <<'SH'
 #!/bin/sh
+# t() = 期望**被拒**的攻擊。rc 非 0 ⇒ denied (OK)。
 t() { printf '%s :: ' "$1"; shift; if "$@" >/dev/null 2>&1; then echo "!! SUCCEEDED (FAIL)"; else echo "denied (OK) rc=$?"; fi; }
+# d() = 設計上**應該成功**的讀取。把它們列出來，是為了讓「可讀是設計、
+#       不可寫才是守的東西」有實測背書，而不是靠註解宣稱。
+d() { printf '%s :: ' "$1"; shift; if "$@" >/dev/null 2>&1; then echo "readable (BY DESIGN)"; else echo "!! 讀不到——與登記表 rationale 不符，查"; fi; }
+# need() = 目標檔必須先存在，否則「刪不掉／讀不到」測的是「檔不存在」而非「被拒」。
+need() { [ -e "$1" ] || printf '!! 前置缺失：%s 不存在——對它的刪除／截斷／讀取測項會是假綠，請先由 operator 以 cortex-manager 身分預建\n' "$1"; }
 A=/var/lib/cortex
+SPOOL=$A/coordinator/job-specs
+
+# ⛔ 身分鎖（**不可移除**）：本腳本會真的執行破壞性動作——truncate、`rm`、
+#    `mv "$HOME/.codex"`、覆寫 hooks.json。在沙箱外（例如 operator 帳號）
+#    直接跑會弄壞自己的機器，而且那些「成功」還會被誤讀成邊界失守。
+#    只允許以兩個 headless 帳號執行；其他身分一律拒跑。
+SELF=$(id -un 2>/dev/null || echo unknown)
+case "$SELF" in
+  cortex-builder|cortex-reviewer-planner) ;;
+  *) echo "⛔ 拒絕執行：本腳本只能以 cortex-builder／cortex-reviewer-planner 身分執行（目前是 $SELF）。"
+     echo "   若要在沙箱外檢查腳本內容，請用 less／cat，不要執行它。"
+     exit 2 ;;
+esac
+
+: "${R9_SUBJECT:?R9_SUBJECT 必須由 operator 注入（builder / reviewer-planner）}"
+: "${R9_INSTANCE:?R9_INSTANCE 必須由 operator 注入（本次 job 的 instance 名）}"
+: "${MANAGER_PID:?MANAGER_PID 必須由 operator 從外部注入——見族 4 說明}"
+echo "subject=$R9_SUBJECT instance=$R9_INSTANCE manager_pid=$MANAGER_PID"
+
+echo "===== 前置：族 2 的目標檔是否存在（不存在 ⇒ 該測項假綠）====="
+need "$A/coordinator/jobs.json"
+need "$A/monitor/work-items.snapshot.json"
 
 echo "===== 族 1 capability-theft ====="
-t "T1.1 讀 EnvironmentFile"        cat /opt/cortex/etc/cortex-manager.env
-t "T1.1 讀 manager HOME cache"     ls /var/lib/cortex-svc/cache
+# ⚠️ T1.1 測的是**寫入**，不是讀取。登記表資產 `runtime-bootstrap-env` 的 rationale
+#    明寫「對全部 headless **唯讀**」、mode 就是 0644——**可讀是設計**。
+#    守的是「改不了 PSC_* 就重導不了整棵 durable state」。
+t "T1.1 寫 EnvironmentFile"        sh -c "printf 'PSC_COORDINATOR_ROOT=/tmp/evil\n' >> /opt/cortex/etc/cortex-manager.env"
+t "T1.1 截斷 EnvironmentFile"      sh -c ": > /opt/cortex/etc/cortex-manager.env"
+t "T1.1 symlink 換掉 EnvironmentFile" sh -c "ln -sf /tmp/evil /opt/cortex/etc/cortex-manager.env"
+t "T1.1 刪 EnvironmentFile"        rm /opt/cortex/etc/cortex-manager.env
+d "T1.1 讀 EnvironmentFile（設計為唯讀）" cat /opt/cortex/etc/cortex-manager.env
+t "T1.1 讀 manager HOME cache"     ls /var/lib/cortex-manager/cache
 t "T1.2 連 Manager control socket" sh -c "ls $A/run/cortex && cat $A/run/cortex/*.sock"
 t "T1.3 呼叫 operator CLI"         /opt/cortex/venv/bin/cortex work ship --help
 t "T1.4 直寫 control queue"        sh -c "printf x > $A/control/requests/evil.json"
-t "T1.5 枚舉他人 job spool"        ls "$A/jobs"
+
+# ⚠️ T1.5：job-spec spool 的載重同樣在**寫入面**。
+#    template unit 的 User=cortex-builder 由 systemd 在 ExecStart **之前**套用，
+#    shim 本身即以 builder 身分讀 spec——**讀得到是必要條件**，不是破口。
+#    所有 builder job 共用同一個 UID，互讀本來就在威脅模型內
+#    （per-job 讀隔離需 per-job UID，不在本方案範圍，見 5-3）。
+t "T1.5 spool 建立新 spec"         sh -c "printf '{}' > $SPOOL/evil.json"
+t "T1.5 spool 追加自己的 spec"     sh -c "printf 'x' >> $SPOOL/$R9_INSTANCE.json"
+t "T1.5 spool symlink 換掉 spec"   sh -c "ln -sf /tmp/evil $SPOOL/$R9_INSTANCE.json"
+t "T1.5 spool 刪除 spec"           rm "$SPOOL/$R9_INSTANCE.json"
+#    讀取面的期望**依 subject 而異**——這正是三分在檔案層生效的直接證據：
+case "$R9_SUBJECT" in
+  builder)
+    d "T1.5 讀自己的 spec"          cat "$SPOOL/$R9_INSTANCE.json"
+    d "T1.5 列 spool"               ls "$SPOOL"
+    ;;
+  *)
+    t "T1.5 讀 spec（非 builder 應被拒）" cat "$SPOOL/$R9_INSTANCE.json"
+    t "T1.5 列 spool（非 builder 應被拒）" ls "$SPOOL"
+    ;;
+esac
 
 echo "===== 族 2 durable-state-tampering ====="
 t "T2 modify jobs.json"            sh -c "printf '{}' > $A/coordinator/jobs.json"
 t "T2 truncate jobs.json"          sh -c ": > $A/coordinator/jobs.json"
-t "T2 delete jobs.json"            rm -f "$A/coordinator/jobs.json"
+# ⚠️ 不可用 `rm -f`：`-f` 對**不存在**的檔回 0，在乾淨新樹上會變成必然的假陽性
+#    （測到的是「檔不存在」而不是「權限被拒」）。上面的 need() 是它的配套。
+t "T2 delete jobs.json"            rm "$A/coordinator/jobs.json"
 t "T2 replace jobs.json"           sh -c "printf '{}' > /tmp/j && mv /tmp/j $A/coordinator/jobs.json"
 t "T2 symlink-swap jobs.json"      sh -c "ln -sf /tmp/evil $A/coordinator/jobs.json"
 t "T2 寫 verification evidence"    sh -c "printf x > $A/coordinator/evidence/verification/evil.json"
@@ -1369,22 +1853,42 @@ t "T3.9 換掉 ~/.codex 目錄"        sh -c "mv $HOME/.codex $HOME/.codex.bak"
 
 echo "===== 族 4 行程間路徑 ====="
 echo "T4.1 自己的 fd：" ; ls -l /proc/self/fd
-MPID=$(pgrep -u cortex-manager -n -f paulsha_cortex 2>/dev/null || echo 0)
-echo "manager pid = $MPID"
-t "T4.2 ptrace Manager"            sh -c "command -v gdb >/dev/null && gdb -p $MPID -batch -ex quit"
-t "T4.3 讀 Manager environ"        cat "/proc/$MPID/environ"
-t "T4.3 讀 Manager mem"            head -c 1 "/proc/$MPID/mem"
-t "T4.4 對 Manager 送 SIGSTOP"     kill -STOP "$MPID"
+# ⚠️ **不可**在這裡用 `pgrep` 取 Manager 的 pid。job unit 帶 ProtectProc=invisible
+#    ＋ ProcSubset=pid，job 眼中的 /proc **只看得到自己**——`pgrep` 必回空，
+#    後面每一條就變成對 `/proc//…` 操作，因「路徑不存在」而失敗、被記成 denied。
+#    那是**假綠**：測到的是 pid 不存在，不是權限被拒。pid 一律由 operator 從外部
+#    以 `systemctl show cortex-manager.service -p MainPID --value` 取得後注入。
+#    （順帶一提：Manager 的 ExecStart 是 `cortex service run`，
+#     `pgrep -f paulsha_cortex` 連在 operator 身上都不一定匹配得到。）
+t "T4.0 Manager /proc 可見性（denied＝不可見，正是 ProtectProc 生效）" \
+                                   test -d "/proc/$MANAGER_PID"
+t "T4.2 ptrace Manager"            sh -c "command -v gdb >/dev/null && gdb -p $MANAGER_PID -batch -ex quit"
+t "T4.3 讀 Manager environ"        cat "/proc/$MANAGER_PID/environ"
+t "T4.3 讀 Manager mem"            head -c 1 "/proc/$MANAGER_PID/mem"
+t "T4.4 對 Manager 送 SIGSTOP"     kill -STOP "$MANAGER_PID"
 t "T4.5 讀另一個 job 帳號 cache"   sh -c "ls /var/lib/cortex-builder/cache /var/lib/cortex-reviewer-planner/cache"
 t "T4.6 提權：systemd-run root"    systemd-run --uid=0 --pipe /bin/id
 t "T4.6 提權：起 job instance"     systemctl start cortex-job@other.service
 t "T4.6 提權：sudo"                sudo -n true
 SH
-sudo chown cortex-manager:cortex-manager "/var/lib/cortex/jobs/$JOB/run.sh"
-sudo chmod 0600 "/var/lib/cortex/jobs/$JOB/run.sh"
-sudo setfacl -m u:cortex-builder:r-- "/var/lib/cortex/jobs/$JOB/run.sh"
-sudo setfacl -m u:cortex-reviewer-planner:r-- "/var/lib/cortex/jobs/$JOB/run.sh"
-sudo setfacl -m u:cortex-reviewer-planner:r-x "/var/lib/cortex/jobs/$JOB"
+sudo chown root:root /var/lib/cortex/r9-attack.sh
+sudo chmod 0755 /var/lib/cortex/r9-attack.sh
+#   ↑ root 擁有：攻擊腳本本身不得被受測 subject 改寫（否則測的是自己寫的東西）。
+
+# ✅ 驗證：身分鎖有效——以 operator 身分直接跑必須被拒（**不要為了「先看看」而繞過它**）
+sh /var/lib/cortex/r9-attack.sh; echo "guard exit=$?"
+#   期望：印出 `⛔ 拒絕執行…`、exit=2。
+#   這條不是形式主義：腳本裡的 T3.9 會 `mv "$HOME/.codex" "$HOME/.codex.bak"`、
+#   T1.1／T2 會 truncate 檔案——在 operator 帳號跑一次就會弄壞自己的環境，
+#   而且那些「成功」是身分錯了，不是邊界破了。
+
+# 🔧 sudo：族 2 的目標檔必須先存在——否則「刪不掉／讀不到」是「檔不存在」的假綠
+sudo -u cortex-manager sh -c '
+  A=/var/lib/cortex
+  [ -e "$A/coordinator/jobs.json" ] || printf "{\"jobs\": []}" > "$A/coordinator/jobs.json"
+  [ -e "$A/monitor/work-items.snapshot.json" ] || printf "{}" > "$A/monitor/work-items.snapshot.json"
+  ls -l "$A/coordinator/jobs.json" "$A/monitor/work-items.snapshot.json"'
+#   （這兩個檔本來就會由 Manager 首次寫入時建立；乾淨新樹上要手動預建一次。）
 
 # 準備「他人 worktree」與「他人 verdict 格」作為跨 persona 攻擊目標
 sudo install -d -o cortex-manager -g cortex-manager -m 0700 /var/lib/cortex/worktree/victim
@@ -1393,30 +1897,80 @@ sudo install -d -o cortex-manager -g cortex-manager -m 0700 /var/lib/cortex/coor
 ```
 
 ```bash
+# ✅ 由 **operator 從外部**取 Manager 的 pid（族 4 唯一正確的取得方式）
+MANAGER_PID="$(systemctl show cortex-manager.service -p MainPID --value)"
+echo "MANAGER_PID=$MANAGER_PID"
+#   期望：非 0 的 pid。若是 0 ⇒ 服務沒在跑，族 4 整族無效，先把服務起起來。
+ps -o user=,pid=,cmd= -p "$MANAGER_PID"     # 期望：user 欄為 cortex-manager
+
 # 🔧 sudo：pass 1——以 **cortex-builder** 身分（經 A+B 的正式路徑：template instance）
+#   攻擊腳本走 job-spec 的 command；R9_* 與 MANAGER_PID 走 spec 的 env
+#   （job 的 env **完全等於** spec 的 env，不繼承 unit 的 Environment=）。
+sudo -u cortex-manager /opt/cortex/venv/bin/python - "$JOB" "$MANAGER_PID" <<'PY'
+import sys
+from paulsha_cortex.coordinator import job_runner
+
+instance, manager_pid = sys.argv[1], sys.argv[2]
+spool = job_runner.DEFAULT_JOB_SPEC_SPOOL
+spec = job_runner.build_job_spec(
+    job_id=f"{instance}-attack",
+    instance=instance,
+    unit=f"cortex-job@{instance}.service",
+    command=["/bin/sh", "/var/lib/cortex/r9-attack.sh"],
+    working_directory=f"/var/lib/cortex/worktree/{instance}",
+    log_path=f"/var/lib/cortex/worktree/{instance}/{instance}.log",
+    env={
+        "HOME": "/var/lib/cortex-builder",
+        "PATH": "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin",
+        "R9_SUBJECT": "builder",
+        "R9_INSTANCE": instance,
+        "MANAGER_PID": manager_pid,
+    },
+)
+print("wrote:", job_runner.write_job_spec(job_runner.job_spec_path(spool, instance), spec))
+PY
 sudo -u cortex-manager systemctl start "cortex-job@$JOB.service"
-sudo journalctl -u "cortex-job@$JOB.service" -n 400 --no-pager | tee /tmp/r9-builder.txt
+# ⚠️ 報告在 **spec 的 log_path**，不在 journal——shim 在已降權之後接管 stdout/stderr。
+sudo cat "/var/lib/cortex/worktree/$JOB/$JOB.log" | tee /tmp/r9-builder.txt
+sudo journalctl -u "cortex-job@$JOB.service" -n 30 --no-pager
+#   期望：journal 只有 systemd 的起停紀錄，**沒有** `cortex-job-shim: …` 錯誤。
 
 # 🔧 sudo：pass 2——以 **cortex-reviewer-planner** 身分
 #   M2 之前 reviewer／planner 沒有自己的 template instance，因此這一趟用 **operator 的
 #   sudo** 直接起（不是用 cortex-manager 的 grant）。它測的是**檔案權限面**的三分，
 #   不是啟動面；啟動面由 5-7 (9) 覆蓋。
+#   ⚠️ 必須帶上 ProtectProc／ProcSubset：否則 pass 2 的 /proc 語意與 template unit
+#      不同，族 4 兩趟的結果不可比（T4.0 會在 pass 2 「成功」而被誤記為破口）。
 sudo systemd-run --quiet --collect --pipe --wait \
   --uid=cortex-reviewer-planner --gid=cortex-reviewer-planner --service-type=exec \
   --property=NoNewPrivileges=yes \
+  --property=ProtectProc=invisible --property=ProcSubset=pid \
   --setenv=HOME=/var/lib/cortex-reviewer-planner \
+  --setenv=R9_SUBJECT=reviewer-planner \
+  --setenv="R9_INSTANCE=$JOB" \
+  --setenv="MANAGER_PID=$MANAGER_PID" \
   --working-directory=/var/lib/cortex/worktree \
-  /bin/sh "/var/lib/cortex/jobs/$JOB/run.sh" | tee /tmp/r9-reviewer.txt
+  /bin/sh /var/lib/cortex/r9-attack.sh | tee /tmp/r9-reviewer.txt
 ```
 
-**預期輸出**：兩份報告中**每一條**都是 `denied (OK) rc=<非 0>`；
-`T4.1 自己的 fd` 只列 `0`、`1`、`2`（指向 journal socket 或 `/dev/null`），
+**預期輸出**：兩份報告中**每一條 `t()` 測項**都是 `denied (OK) rc=<非 0>`；
+`d()` 測項印 `readable (BY DESIGN)`（那是登記表 rationale 的實測背書，不是破口）；
+`need()` 不得印出任何 `!! 前置缺失`；
+`T4.1 自己的 fd` 只列 `0`、`1`、`2`（shim 接管後指向 spec 的 log／`/dev/null`），
 **沒有任何**指向 `/var/lib/cortex` 或 `/opt/cortex` 的可寫 fd。
+
+> **M1 對照**：修正前的腳本在 builder 上是 46 `denied` ／ 3 條 `SUCCEEDED`，
+> 三條分別是 T1.1（期望寫反）、T1.5（測錯面）、T2 delete（`rm -f` 假陽性）——
+> 三條**全部判定為非破口**，而且成因就是本節這次修掉的三處。
+> 按本節修正後的腳本重跑，兩份報告都應是**全數 denied**。
 
 ```bash
 # ✅ 一眼判讀（兩份都要看）
 for F in /tmp/r9-builder.txt /tmp/r9-reviewer.txt; do
-  printf '%s: denied=%s\n' "$F" "$(grep -c 'denied (OK)' "$F")"
+  printf '%s: denied=%s by-design-readable=%s\n' "$F" \
+    "$(grep -c 'denied (OK)' "$F")" "$(grep -c 'BY DESIGN' "$F")"
+  grep "!! 前置缺失" "$F" && echo "!! $F 有測項是假綠（目標檔不存在），補建後重跑"
+  grep "!! 讀不到" "$F" && echo "!! $F 的 by-design 讀取失敗，與登記表 rationale 不符，查"
   grep "SUCCEEDED (FAIL)" "$F" && echo "!! $F 有攻擊成功，立即停止並回滾" || echo "   $F 全綠"
 done
 grep -A5 "自己的 fd" /tmp/r9-builder.txt
@@ -1521,23 +2075,31 @@ sudo cp /tmp/unit.bak /etc/systemd/system/cortex-manager.service
 sudo systemctl daemon-reload && sudo systemctl restart cortex-manager.service
 
 # ✅ 族 4 的 negative control：operator（有 sudo）讀得到 Manager environ
-MPID=$(pgrep -u cortex-manager -n -f paulsha_cortex); sudo cat "/proc/$MPID/environ" | tr '\0' '\n' | head -3 && echo "NEG-CONTROL-4-OK"
+#    ⚠️ 同樣**不要用 pgrep**：Manager 的 ExecStart 是 `cortex service run`，
+#       `pgrep -f paulsha_cortex` 匹配不到；空 pid 會讓這條 negative control
+#       自己變成假紅。一律從 systemd 拿權威 pid。
+MANAGER_PID="$(systemctl show cortex-manager.service -p MainPID --value)"
+sudo cat "/proc/$MANAGER_PID/environ" | tr '\0' '\n' | head -3 && echo "NEG-CONTROL-4-OK"
 
 # ✅ 族 5 的 negative control：cortex-manager 起**合法**的 job instance 必須成功
 #    （否則族 5 的紅可能只是「polkit 把 cortex-manager 全部擋掉了」）
-sudo install -d -o cortex-manager -g cortex-manager -m 0700 /var/lib/cortex/jobs/negctl5
-sudo setfacl -m u:cortex-builder:r-x /var/lib/cortex/jobs/negctl5
 sudo install -d -o cortex-builder -g cortex-builder -m 0700 /var/lib/cortex/worktree/negctl5
-sudo tee /var/lib/cortex/jobs/negctl5/run.sh >/dev/null <<'SH'
-#!/bin/sh
-id
-SH
-sudo chown cortex-manager:cortex-manager /var/lib/cortex/jobs/negctl5/run.sh
-sudo chmod 0600 /var/lib/cortex/jobs/negctl5/run.sh
-sudo setfacl -m u:cortex-builder:r-- /var/lib/cortex/jobs/negctl5/run.sh
+sudo -u cortex-manager /opt/cortex/venv/bin/python - <<'PY'
+from paulsha_cortex.coordinator import job_runner
+instance = "negctl5"
+spec = job_runner.build_job_spec(
+    job_id="negctl5", instance=instance, unit=f"cortex-job@{instance}.service",
+    command=["/bin/sh", "-c", "id"],
+    working_directory=f"/var/lib/cortex/worktree/{instance}",
+    log_path=f"/var/lib/cortex/worktree/{instance}/{instance}.log",
+    env={"HOME": "/var/lib/cortex-builder", "PATH": "/usr/bin:/bin"},
+)
+print("wrote:", job_runner.write_job_spec(
+    job_runner.job_spec_path(job_runner.DEFAULT_JOB_SPEC_SPOOL, instance), spec))
+PY
 sudo -u cortex-manager systemctl start cortex-job@negctl5.service && echo "NEG-CONTROL-5-OK"
-sudo journalctl -u cortex-job@negctl5.service -n 5 --no-pager | grep -o "uid=[0-9]*(cortex-builder)"
-#   期望：印出 NEG-CONTROL-5-OK，且 journal 顯示 uid=…(cortex-builder)
+sudo grep -o "uid=[0-9]*(cortex-builder)" /var/lib/cortex/worktree/negctl5/negctl5.log
+#   期望：印出 NEG-CONTROL-5-OK，且 job 的 log（**不是 journal**）顯示 uid=…(cortex-builder)
 ```
 
 ### 8d. 族 3 的「重啟後仍綠」複驗（spec §R9 硬性要求）
@@ -1557,17 +2119,30 @@ sudo -u cortex-manager env $(grep -v '^#' /opt/cortex/etc/cortex-manager.env | x
 ```bash
 # 🔧 sudo：清掉 R9 抽驗的全部殘留（含 drop-in 目錄——它本身就是提權面）
 sudo systemctl stop "cortex-job@r9.service" "cortex-job@negctl5.service" 2>/dev/null || true
-sudo rm -rf /var/lib/cortex/jobs/r9 /var/lib/cortex/jobs/negctl5 \
-            /var/lib/cortex/worktree/r9 /var/lib/cortex/worktree/negctl5 \
+sudo rm -f /var/lib/cortex/coordinator/job-specs/r9.json \
+           /var/lib/cortex/coordinator/job-specs/negctl5.json \
+           /var/lib/cortex/r9-attack.sh
+sudo rm -rf /var/lib/cortex/worktree/r9 /var/lib/cortex/worktree/negctl5 \
             /var/lib/cortex/worktree/victim \
             /var/lib/cortex/coordinator/review-verdicts/victim \
             /etc/systemd/system/cortex-job@.service.d
 sudo systemctl daemon-reload
+
+# ✅ 驗證：spool 內不得殘留任何抽驗用的 spec（它們是 job 的命令列）
+sudo ls -l /var/lib/cortex/coordinator/job-specs
+#   期望：不含 r9.json／negctl5.json／selftest.json／evil.json
 ```
 
-**通過條件**：8a 兩份報告全部 `denied (OK)`；8b 族 5.1 五條與族 5.2 的 27 條**全部非 0**；
-8c 五組 negative control 全部印出 `*-OK`；8d 重啟後仍綠。
+**通過條件**：8a 兩份報告的 `t()` 測項**全部** `denied (OK)`、`d()` 測項全部
+`readable (BY DESIGN)`、**沒有任何** `!! 前置缺失`；8b 族 5.1 五條與族 5.2 的
+27 條**全部非 0**；8c 五組 negative control 全部印出 `*-OK`；8d 重啟後仍綠。
 任一條不符 ⇒ **D6 不算通過**，`0.2.0` 不得宣告 stable（spec §R12）。
+
+> **判讀紀律（M1 教訓）**：`SUCCEEDED (FAIL)` 出現時，**先確認測項本身測的是不是
+> 該守的那一面**，再判定是不是破口。M1 的三條 `SUCCEEDED` 全部是測項寫錯
+> （期望寫反／測讀取而非寫入／`rm -f` 對不存在的檔回 0），不是邊界失守——
+> 反過來，一條「denied」也可能是假綠（例如 pid 根本不存在）。
+> 兩個方向的誤判都要靠 negative control 與 `need()` 前置檢查擋住。
 
 ---
 
@@ -1579,7 +2154,7 @@ Phase 1 完全不需 root 且含降級運轉安全網（`PSC_DEGRADED_OPERATION=
 | 階段 | 症狀 | 回滾動作（`🔧 sudo`） |
 |---|---|---|
 | 第 1（三帳號） | 帳號建錯／名稱衝突 | `sudo userdel cortex-manager cortex-reviewer-planner cortex-builder`（逐一）；`sudo groupdel` 同名三個 group；`sudo rm -rf /var/lib/cortex-reviewer-planner`（此時尚無檔案屬於它們） |
-| 第 2（樹／權限） | 權限套錯、`find -perm /022` 非空 | 重跑 `sudo sh -e /tmp/p2b-permissions.sh`（冪等）；仍不對則 `sudo rm -rf /var/lib/cortex /var/lib/cortex-svc /var/lib/cortex-reviewer-planner /var/lib/cortex-builder` 後從第 2 步重來（舊樹未動） |
+| 第 2（樹／權限） | 權限套錯、`find -perm /022` 非空 | 重跑 `sudo sh -e /tmp/p2b-permissions.sh`（冪等）；仍不對則 `sudo rm -rf /var/lib/cortex /var/lib/cortex-manager /var/lib/cortex-reviewer-planner /var/lib/cortex-builder` 後從第 2 步重來（舊樹未動） |
 | 第 3（legacy-import） | quarantine 內容不符 manifest | `sudo rm -rf /var/lib/cortex/legacy-imported`，重跑 3；`$HOME/.agents` 原地仍完整 |
 | 第 4a（部署） | 新 venv 起不來 | `sudo rm -rf /opt/cortex/venv; sudo mv /opt/cortex/venv.prev /opt/cortex/venv; sudo systemctl restart cortex-manager` |
 | 第 4c（system unit） | WSL 重啟後未拉起／服務起不來 | `sudo systemctl disable --now cortex-manager.service`；改回 `systemctl --user start cortex-manager.service`（舊部署仍在 `$HOME/.local/share/pipx`） |
@@ -1605,7 +2180,7 @@ sudo systemctl daemon-reload
 sudo systemctl restart polkit.service 2>/dev/null || true
 
 # 🔧 sudo：新樹整棵丟棄（舊 state 從未被併入，故無資料損失）＋ 移除三帳號
-sudo rm -rf /var/lib/cortex /var/lib/cortex-svc /var/lib/cortex-reviewer-planner \
+sudo rm -rf /var/lib/cortex /var/lib/cortex-manager /var/lib/cortex-reviewer-planner \
             /var/lib/cortex-builder /opt/cortex
 for U in cortex-manager cortex-reviewer-planner cortex-builder; do
   sudo userdel "$U" 2>/dev/null || true
@@ -1662,8 +2237,28 @@ sudo journalctl -u cortex-manager.service -b --no-pager | head -30
 systemctl is-active polkit.service || systemctl is-active polkitd.service
 
 # ✅ 6. 降權正向：重啟後仍可起 job instance
+#    ⚠️ 8e 已清掉 negctl5 的 spec 與 worktree，這裡必須**先重新備好**再起——
+#       否則失敗的原因會是「spec 缺席」而不是「降權失效」，診斷指向錯誤的層。
+sudo install -d -o cortex-builder -g cortex-builder -m 0700 /var/lib/cortex/worktree/negctl5
+sudo -u cortex-manager /opt/cortex/venv/bin/python - <<'PY'
+from paulsha_cortex.coordinator import job_runner
+instance = "negctl5"
+spec = job_runner.build_job_spec(
+    job_id="negctl5", instance=instance, unit=f"cortex-job@{instance}.service",
+    command=["/bin/sh", "-c", "id"],
+    working_directory=f"/var/lib/cortex/worktree/{instance}",
+    log_path=f"/var/lib/cortex/worktree/{instance}/{instance}.log",
+    env={"HOME": "/var/lib/cortex-builder", "PATH": "/usr/bin:/bin"},
+)
+print("wrote:", job_runner.write_job_spec(
+    job_runner.job_spec_path(job_runner.DEFAULT_JOB_SPEC_SPOOL, instance), spec))
+PY
 sudo -u cortex-manager systemctl start cortex-job@negctl5.service \
   && echo "降權重啟後仍可用" || echo "!! 降權失效，查 polkit"
+sudo grep -o "uid=[0-9]*(cortex-builder)" /var/lib/cortex/worktree/negctl5/negctl5.log
+# 🔧 sudo：驗完立刻清掉（spec 是 job 的命令列，不留過夜）
+sudo rm -f /var/lib/cortex/coordinator/job-specs/negctl5.json
+sudo rm -rf /var/lib/cortex/worktree/negctl5
 
 # ✅ 7. 降權反向：重啟後提權仍被拒（規則沒有因重啟而失效）
 sudo -u cortex-manager systemd-run --uid=0 --pipe --wait /bin/id; echo "exit=$?"   # 期望非 0
@@ -1737,9 +2332,18 @@ sudo systemctl daemon-reload && sudo systemctl restart cortex-manager.service
    安全但功能全停。執行前提第 6 項已檢查；重啟後由「A. 第 5 項」複驗。
 2. **`sudo` 需密碼**：所有 `🔧 sudo` 步驟皆互動式，**不可假設自動化**；
    本 runbook 刻意不使用 `sudo -n`（族 5 的 `sudo -n true` 例外，那是攻擊測試）。
-3. **`/proc` 隱藏造成 R9 判讀差異**：`ProtectProc=invisible` 下讀他人
-   `/proc/<pid>/environ` 會是 `ENOENT`（No such file）而非 `EACCES`——
-   兩者都算**拒絕**（第 8 步的 `t()` 只看 rc 非 0，判定不受影響）。
+3. **`/proc` 隱藏會製造族 4 的假綠**：unit 帶 `ProtectProc=invisible` ＋
+   `ProcSubset=pid`，**job 眼中的 `/proc` 只有自己**。因此
+   (a) 在 job 內跑 `pgrep -u cortex-manager …` **必回空**，用它取得的 pid 是空字串，
+   後續每一條都變成對 `/proc//…` 操作，因「路徑不存在」而失敗、被 `t()` 記成
+   `denied`——**那是假綠**：測到的是 pid 不存在，不是權限被拒。
+   (b) 正確作法：由 **operator 從外部**取
+   `systemctl show cortex-manager.service -p MainPID --value`，以 spec 的 `env`
+   （pass 1）或 `--setenv`（pass 2）注入，讓攻擊真的打在活著的 pid 上；並另加一條
+   `test -d /proc/<pid>`（第 8 步的 T4.0）**直接把「pid 不可見」這件事本身測出來**，
+   而不是讓它偽裝成其他測項的 denial。
+   (c) 打在活 pid 上之後，讀他人 `/proc/<pid>/environ` 仍可能是 `ENOENT` 或
+   `EACCES`——**兩者都算拒絕**（`t()` 只看 rc 非 0），但此時「拒絕」是真的。
 4. **WSL2 的 `busctl` 可能不在 PATH**：族 5.1e 若報 `command not found`，
    以 `sudo apt-get install systemd` 補齊後重測；**不可**因為工具缺席就跳過該條
    （它測的是繞開 CLI 的直接 D-Bus 路徑）。
@@ -1753,8 +2357,14 @@ sudo systemctl daemon-reload && sudo systemctl restart cortex-manager.service
 diff <(python3 -m paulsha_cortex.trust_root unit three-way --manager) /etc/systemd/system/cortex-manager.service
 diff <(python3 -m paulsha_cortex.trust_root unit three-way --job)     /etc/systemd/system/cortex-job@.service
 diff <(python3 -m paulsha_cortex.trust_root polkit three-way --template) /etc/polkit-1/rules.d/49-cortex-downgrade.rules
-# shim 落地後再加：
-# diff <(python3 -m paulsha_cortex.trust_root shim three-way) /opt/cortex/bin/cortex-job-shim
+diff <(python3 -m paulsha_cortex.trust_root shim three-way)            /opt/cortex/bin/cortex-job-shim
+
+# ✅ 部署樹沒有被 pipx 殘留污染（第 4a／第 6 步的兩個必補步驟）
+sudo grep -rIl -- "/.local/share/pipx" /opt/cortex/venv | head    # 期望：空輸出
+sudo find /opt/cortex/venv -name "pipx_shared.pth" | head          # 期望：空輸出
+
+# ✅ job-spec spool 沒有留下過夜的 spec（每一份都是某個 job 的命令列）
+sudo ls -l /var/lib/cortex/coordinator/job-specs
 
 # ✅ 沒有殘留的 template drop-in（族 5.2 的持久化面）
 ls -la /etc/systemd/system/cortex-job@.service.d 2>/dev/null && echo "!! 有 drop-in，查來源" || echo "no drop-in: OK"


### PR DESCRIPTION
## 摘要

Closes #621

#584 M1（2026-08-17 實機執行）逐步對照
`docs/superpowers/runbooks/trust-root-phase2b-setup.md` 後累積的十三處落差，逐條修進
runbook。**沒有一條是安全破口**，但每一條都會讓下一個執行者卡住或誤判。
本 PR **docs-only**，不改任何一行程式碼、不動部署。

## 逐條對應

### A. 舊佈局殘留（#616 已修 permgen，runbook 文字沒跟上）

1. 第 1 步 `useradd --home-dir /var/lib/cortex-svc` → `/var/lib/cortex-manager`；
   「⚠️ 目前已知缺口 (a)(b)」整段刪除，改列 `scaffold_directories()` 的實際八行期望值。
2. 第 1 步四行手動 `install -d`（補 `cortex-reviewer-planner` 的 HOME／`.codex`／
   `cache`）**整段刪除**——#616 後 scaffold 已自動涵蓋第三個帳號。
3. 第 2 步稽核 3 `grep -c "cortex-svc" p2b-scaffold.sh` 期望 **2 → 0**，
   另加一條「三個 HOME 路徑與帳號名逐字對應」的正向稽核。
4. 第 2 步驗證 `ls -ld /var/lib/cortex-svc` → `/var/lib/cortex-manager`
   （第 2／9 步回滾命令中的 `cortex-svc` 一併改名）。

### B. job-spec spool 路徑已改，runbook 仍停在 `run.sh` 時代

5. 5-3 表格／5-6／8a／8c 的 `/var/lib/cortex/jobs/<id>/run.sh` 全部改為
   `<coordinator_root>/job-specs/<instance>.json`，且**一律用
   `job_runner.build_job_spec()`／`write_job_spec()` 產生**。連帶修正三件原本會讓
   執行者「照做卻看不到東西」的事：job 輸出在 **spec 的 `log_path`** 而非 journal
   （shim 在已降權之後接管 stdout/stderr）；job 的 env **完全等於** spec 的 `env`、
   不繼承 unit 的 `Environment=`（`PATH`／`HOME` 必須在 spec 內給）；token 的保證是
   「名字根本進不了 spec」（寫入端直接 raise）而非執行時 scrub。
6. 第 2 步 `ls -ld /var/lib/cortex/jobs`（期望 `0711`）刪除——該資產不在登記表、
   目錄不會被建立；改為驗 spool 的 `0700 cortex-manager` ＋ builder 唯讀 ACL，
   並把「builder 讀得到／寫不進去」拆成兩條分別驗。

### C. R9 的三條期望與實際設計矛盾

7. **T1.1 不只是把期望由 denied 改成 allowed，而是把測項本身從「讀」改成「寫」**。
   登記表 `runtime-bootstrap-env` 的契約是「對全部 headless **唯讀**」、mode `0644`
   ——可讀是設計；該守的是寫入面，因此改測**追加／截斷／symlink 換掉／刪除**四式。
   原本的讀取測項改由新增的 `d()` 助手記為 `readable (BY DESIGN)`，讓設計契約
   也有實測背書，而不是被靜靜刪掉。
8. **T1.5 同理改測 spool 的寫入四式**（建立／追加／symlink 換掉／刪除）。
   template unit 的 `User=cortex-builder` 由 systemd 在 `ExecStart` **之前**套用，
   shim 本身即以 builder 身分讀 spec，**讀不到就起不了 job**。讀取面的期望改為
   **依 subject 而異**（builder 讀得到；reviewer-planner 被拒——三分在檔案層生效的
   直接證據）。5-3 表格刪掉不精確的「job 只讀自己那格」，改為「守的是寫入面」，
   並明確註明 **per-job 讀隔離需 per-job UID，不在本方案範圍**（不假裝現在做得到）。
9. T2 delete 的 `rm -f` 改為 `rm`，並新增 `need()` 前置守衛與 operator 預建目標檔的
   步驟——「刪不掉」必須是「權限被拒」，不能是「檔不存在」。

### D. 族 4 的假綠

10. `MPID=$(pgrep …)` **刪除**。job unit 帶 `ProtectProc=invisible` ＋
    `ProcSubset=pid`，job 眼中的 `/proc` 只有自己，`pgrep` 必回空 → 後續每一條變成
    對 `/proc//…` 操作，因「路徑不存在」失敗而被記成 denied：**測到的是 pid 不存在，
    不是權限被拒**。改由 operator 從外部取
    `systemctl show cortex-manager.service -p MainPID --value`，經 spec 的 `env`
    （pass 1）或 `--setenv`（pass 2）注入；另加 **T4.0 `test -d /proc/<pid>`**
    直接證明 pid 不可見。8c 族 4 的 negative control 同樣改用 `MainPID`
    （原本的 `pgrep -f paulsha_cortex` 連 operator 都匹配不到 `cortex service run`，
    是假紅）；pass 2 補上 `ProtectProc`／`ProcSubset`，兩趟的 `/proc` 語意才可比。

### E. 第 4a 缺步

11. 補上**重寫 shebang 前綴**與**移除 `pipx_shared.pth`**兩步（必須在 `chmod a-w`
    硬化**之前**），並說明這同時是**安全條件**——留著等於部署樹的第一支被執行的程式
    與 import path 仍受 operator 可寫目錄影響。另加一條涵蓋所有形式的總驗收。
    第 6 步升級流程的 `cp -a` 逐字補上同三步，並附「哪兩類 hash diff 是這兩步造成的、
    不是供應鏈訊號」的過濾。

### F. 執行前提

12. `acl` 硬性 gate（G1）——原本只在第 2 步提示且失敗不中止；缺 acl 時 `setfacl`
    全數失效、跨帳號授權整段成為**無聲 no-op**，而權限 script 仍以 exit 0 收場。
13. `/etc/sudoers.d/` 萬用 NOPASSWD 規則的硬性 gate（G2）——M1 本機原有
    `ALL ALL=NOPASSWD: ALL`，三個服務帳號**一建立就自動取得無密碼 root**。
    含「先收斂到具名帳號再建帳號」的順序要求；第 1 步的驗證升級為 `sudo -l -U`
    複驗並與 G2 成對。

## Issue 未列、對照時另外發現的落差

- **R9 攻擊腳本沒有身分鎖**（我在驗證腳本語法時實際踩到）：腳本會真的執行破壞性
  動作（truncate、`rm`、`mv "$HOME/.codex"`、覆寫 `hooks.json`），在沙箱外跑會弄壞
  operator 自己的環境，而且那些「成功」會被誤讀成邊界失守。新增 `id -un` 白名單
  （只允許 `cortex-builder`／`cortex-reviewer-planner`）＋一條「以 operator 身分跑
  必須被拒」的驗證。腳本位置一併改為 root-owned 的 `/var/lib/cortex/r9-attack.sh`
  （`PrivateTmp=yes` 讓 `/tmp` 不可用；builder-owned worktree 則 reviewer-planner
  讀不到）。
- **WSL2 段「重啟後仍可起 job」缺重建 spec 的步驟**——8e 已清掉 negctl5 的 spec 與
  worktree，原文直接 `systemctl start` 會因「spec 缺席」失敗，診斷指向錯誤的層。
- **「產生器＝單一真相」段的兩項 `⏳ 待 #603 follow-up`** 早已隨 #616 落地
  （`trust_root shim three-way`、`build_job_spec()` 契約），改為已落地並補上 spec
  必填／禁用欄位自檢；第 6 步升級流程補回 shim 的 `diff` 對齊。
- **M2 的追蹤 issue 由「#603 follow-up」更正為 #615**。
- 規模統計同步更新：**32 → 38** 個 `🔧 sudo` 點、**122 → 134** 個 `✅ 驗證` 點
  （以 runbook 原本的統計方式重算，確認舊值 32／122 可完全重現）。

## 依賴其他 issue 的一條（未自行改程式）

- **#620（permgen 父層 traverse ACL）**：葉節點 ACL 正確，但 `coordinator/`／
  `monitor/` 是 `0700 cortex-manager`，POSIX 要求路徑每層都要 `x`，兩條 append-only
  正向路徑與 spool 唯讀路徑因此全斷。本 PR **不改 `permgen.py`**（#620／#622 由其他
  PR 進行），改為在第 2 步以 blockquote 標注 M1 實測的三條
  `setfacl -m u:<acct>:--x` 手動繞過與驗證，並明寫 **#620 落地後整段刪除**、
  屆時 2a 稽核 2 的條數敘述需一併複核。

## M1 實測值已寫進 runbook

新增「M1 實機基準值（2026-08-17）」對照表：自檢 `job_writable_count` **5 → 0**、
登記表等式 `ok: true`、legacy-import manifest 78,674 檔全量複驗 OK、5-7 反向十一條
全數非 0、8a 兩個 subject 的 denied 條數（46/3 與 47/2，三條 `SUCCEEDED` 全部是本 PR
修掉的測項寫法問題）、8c 五組 negative control 全 `*-OK`、8d 重啟複驗。第 8 步另補
一段「判讀紀律」：`SUCCEEDED` 要先確認測項測的是不是該守的那一面，`denied` 也可能是
假綠。

## Coordinator 實機回報後追加的四項（rebase 到 68fafbf 之後）

`#624`／`#625` 在本 PR 進行期間 merge 且都動了同一份 runbook，已 rebase 到
`origin/main`（68fafbf）並解掉三處衝突。四項追加全部收下：

1. **第 4d：monitor unit「裝好但不得啟動」的 gate（#623）**。4d 的安裝與驗證照做，
   但 `enable --now` 必須等 #623 關閉。理由寫進 runbook：
   `PSC_DEGRADED_OPERATION=per-case-approval` **不會**阻止派工——它只 gate
   `headless-acceptance`／`outbox-mutation`／`ship`／`merge` 四個動作
   （`trust_root/capability.py`），job spawn 不在其中。monitor 一起來就會真的派
   builder job，而那些 job 現在必然失敗（`ProtectHome=yes` 讓 repo 不可達、
   EnvironmentFile 缺八個操作變數含 `PSC_GATE_CMD_PYTEST`），後果是燒額度、
   needs_human 噪音、半死的 run 狀態，**而且沒有任何一條結構性驗收會因此變紅**。
   4d 的驗證拆成「安裝面（不需服務在跑）」與「執行面（⛔ #623 後才適用）」兩段，
   正確終態明訂為 `disabled`／`inactive`。
2. **第 3-0／3a-2：legacy-import 分成兩類**。裁決「legacy-imported 不得滿足任何
   ship gate」針對的是**模型產出的 state／evidence**（`coordinator/**`／`monitor/**`／
   `registry/**`／`runtime/**`）；`config/**`／`specs/**` 是 **operator 撰寫**的，
   不是任何 gate 的受檢對象。原本兩類一起 quarantine，而第 2 步只建
   `config/paulsha` **目錄**、沒有任何一步搬**內容**——實測 `cortex monitor --once`
   直接 `錯誤: 無 project 設定：…皆不存在`。新增 3-0 的分類表與 3a-2 的
   「明示逐檔複製 ＋ 逐份審閱 ＋ 功能面驗證」段（刻意用白名單而非 `cp -r`：
   要搬什麼是 operator 的決定）。
3. **第 7b：功能面檢查**。M1 的每一條驗收都是結構性的，這正是部署通過 M1 卻做不了
   任何實際工作的原因。新增三級：**F1** `cortex monitor --once` 載得到設定
   （兩秒鐘，是上一條缺口的最短偵測路徑）、**F2** `cortex status`／`jobs` 在新樹上
   答得出話、**F3** 真實 intake 一案跑到 terminal（⛔ #623 關閉前不得執行）。
   通過條件改為「結構面 ＋ F1／F2」，並明訂 **F3 通過前不得宣稱「Phase 2b 可用」**。
4. **第 2a 稽核 6（#626）**：script 裡每個 `u:<name>:` 都必須 `getent passwd` 得到。
   permgen 為本機不存在的 principal（`operator`／`cortex-outbox`）產出 `setfacl`
   條目，而 2b 是 `sh -e`——一條錯就中止整份 script，留下**半套權限的樹**
   （含尾端整個 traverse 節沒套）。稽核給出兩條合法處置（建帳號／等 #626 修產生器），
   並明確禁止「拿掉 `-e` 硬跑」——那會把中止換成靜默略過。2b 另補：exit 非 0 時
   樹是半套的、不要往下驗證，且整份重跑是安全的（每條命令皆冪等）。
   **#626 的產生器修正不在本 PR**（只加 operator 側的攔截）。

另隨 **PR #624** 落地：第 2 步的 **#620 手動繞過段整段刪除**（改由 main 的稽核 5 與
正／負向驗證守門），「M1 實機基準值」下的註記改寫為「已收編」，並新增
「M1 之後才發現、目前仍未關的兩條」（#626／#623）指向各自步驟。

規模統計以 #624／#625 落地後的 35／133 為基礎重算 → **43** 個 sudo 點、
**156** 個驗證點。

## 驗證

- `bash -n` 逐一檢查全部 **50** 個 `bash` 區塊，**0 失敗**；code fence 收支平衡。
- shebang 重寫迴圈以假 venv 樹實跑：僅改寫 shebang 檔、二進位與 symlink 不動。
- `build_job_spec()`／`write_job_spec()` 片段實跑通過；憑證守衛實測會 raise
  （`job-runner-credential-env-leak`）。
- R9 腳本 `sh -n` 通過，且身分鎖以 operator 身分實測回 `exit=2`。
- `python3 -m policy_check --repo . --pr-title … --pr-body … --pr-base-ref main
  --pr-head-ref feature/621-phase2b-runbook-realign` → **fail: 0**。

## Checklist

- [x] 分支自 `main` 開出，命名 `feature/621-phase2b-runbook-realign`
- [x] `changelog.d/phase2b-runbook-realign.md` fragment 已新增且**已 commit**
- [x] `CHANGELOG.md [Unreleased]` 的 `### Fixed` 已補對應 entry
- [x] `VERSION` 未動（非 release PR）
- [x] 文件與 PR 全 zh-tw
- [x] policy_check 帶 PR 上下文跑過，`fail: 0`
- [x] 未觸碰 `paulsha_cortex/trust_root/permgen.py`（#620／#622 由其他 PR 進行）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E7w9kaUxAzCCEk7piD5hfK
