### PR TITLE
fix(trust-root): gate ledger 與 exit sentinel 的作者收斂到 Manager (#604)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,31 @@
   `tests/test_trust_root_job_template_ab.py`（80 測試）。
 
 ### Fixed
+- **#604 / trust-root：gate ledger 與 exit sentinel 的作者收斂到 Manager——降權後
+  「被隔離的一方自寫驗收證據」的第一步修法**——登記表資產 `gate-ledger`（Manager 的
+  dispatch log 目錄，同時放 `<slice>.gates.json` 與 `<slice>.exit`）宣告
+  `writers=(MANAGER,)`，但兩個檔一直由 `launcher.build_wrapper_script` 的 wrapper
+  **在 job 進程內**寫。Phase 2b M1 實機上線（`PSC_JOB_RUNNER=systemd-template`，job
+  以 `uid=cortex-builder` 跑）之後這條路同時有兩個問題：**信任面**——sentinel 是
+  `poll_headless_done` 的第一判準、ledger 是 `authorize_terminal` 採信 `passed` 的唯一
+  背書，卻由被驗方自報（違反 #540 的「model 既不能自證成功、也不能自證失敗」）；
+  **可行性**——該目錄是 `0700 cortex-manager` 且不在 builder 模板 unit 的
+  `ReadWritePaths=` 內（`ProtectSystem=strict`），job 寫進去必然 EROFS，於是降權模式
+  下每個 builder job 都在「行程已死、無 sentinel」的分支被記成 failed。修法：(1) 新增
+  `job_runner.build_manager_exit_recorder_argv()`，把 `--wait` 的 client argv 包進一層
+  跑在 **Manager 身分**的 `bash -c` 由它寫 `$?`（**sentinel 路徑逐字不變**，harvest 端
+  零改動）；(2) `confirm_*_started()` 新增 `manager_authored_sentinel=` 旗標，判準改為
+  「確認窗內 client 以非零收場」（未傳＝既有語意，零回歸）；(3) `build_wrapper_script()`
+  新增 `write_sentinel=`，降權模式連同 gate 階段一併移出 job wrapper；(4) 新增
+  `terminal_contract.foreign_evidence_author()`，`read_gate_ledger()` 對非 Manager 產生
+  的 ledger 以新 reason `gate-ledger-foreign-author` fail closed、
+  `dispatcher._read_exit_sentinel()` 對非 Manager 產生／非普通檔的 sentinel 視同尚未
+  寫下。direct 模式下 job 與 Manager 同 uid，(4) 永遠不會命中，既有部署零影響。
+  **本票不含 gate 執行面的搬遷**：把 gate 重跑直接放進 Manager 進程會讓 builder 掌控的
+  `conftest.py`／pytest plugin 取得 `cortex-manager` 的任意程式碼執行，比要修的缺口更
+  嚴重；正確落點是一個既非 builder 也非 Manager 的 gate 執行身分（需動 permgen 的 UID
+  scheme 與 unit 產生器），在那之前降權模式不產生 ledger，build 卡照 `require_ledger`
+  fail closed。
 - **#620 / trust-root：permgen 機械導出父目錄 traverse ACL——三分下 builder／
   reviewer-planner 走不到自己的 spool，正向路徑全斷**——葉節點的跨帳號 ACL 完全正確
   （`u:cortex-builder:wx` 掛在 `<monitor>/event-spool` 上），但父目錄是

--- a/changelog.d/manager-authored-job-accounting.md
+++ b/changelog.d/manager-authored-job-accounting.md
@@ -1,0 +1,42 @@
+# manager-authored-job-accounting
+
+- **`#604` gate ledger 與 exit sentinel 的作者收斂到 Manager（降權後具名信任缺口的第一步）**——
+  登記表資產 `gate-ledger`（Manager 的 dispatch log 目錄，同時放 `<slice>.gates.json`
+  與 `<slice>.exit`）宣告 `writers=(MANAGER,)`，但兩個檔一直是由
+  `launcher.build_wrapper_script` 產生的 wrapper **在 job 進程內**寫。2026-08-17
+  Phase 2b M1 實機上線（`PSC_JOB_RUNNER=systemd-template`，builder job 真的以
+  `uid=cortex-builder` 跑）之後，這條路同時有信任面與可行性兩個問題：sentinel 是
+  `dispatcher.poll_headless_done` 的第一判準、ledger 是 `authorize_terminal` 採信
+  `passed` 的唯一背書，卻由被驗方自報（違反 `#540` 的「model 既不能自證成功、也不能
+  自證失敗」）；而那個目錄在 Phase 2b 是 `0700 cortex-manager`、且**不在** builder
+  模板 unit 的 `ReadWritePaths=` 內（`ProtectSystem=strict`），job 寫進去必然 EROFS
+  ——降權模式下每個 builder job 都會落到「行程已死、無 sentinel」的分支被記成 failed。
+  - **exit sentinel 改由 Manager 記帳**：新增
+    `job_runner.build_manager_exit_recorder_argv()`，把 `systemd-run --wait`／
+    `systemctl start --wait` 的 client argv 包進一層跑在 **Manager 身分**的
+    `bash -c`，由它寫下 client 的 `$?`。**sentinel 路徑逐字不變**（harvest 端零改動），
+    變的只有「誰是寫者」。`--wait` 的 client 本來就存活到 unit 結束，因此 pid 判活語意
+    也不變。
+  - **起動確認改判準**：記帳 shell 在 client 起不來時也會寫 sentinel，故
+    `confirm_transient_unit_started()`／`confirm_template_instance_started()` 新增
+    `manager_authored_sentinel=` 旗標——為真時判準改為「確認窗內 client 已結束且狀態
+    非 0」（`--wait` 的 client 不可能在 200ms 內走完一次真正的 unit 啟動；極端情況下
+    誤判的結果是**拒絕這次派工**，仍是 fail-closed）。未傳旗標＝既有語意，零回歸。
+  - **降權模式下 job 側 wrapper 不再寫這兩個檔**：`build_wrapper_script()` 新增
+    `write_sentinel=`，降權時連同 gate 階段一併移除（`_should_run_gates()` 對降權模式
+    回 `False`）。
+  - **採信端拒絕外來作者**：新增 `terminal_contract.foreign_evidence_author()`
+    （`lstat` 取 owner 與本行程 effective uid 比對）。`read_gate_ledger()` 對非
+    Manager 產生的 ledger 以新 reason `gate-ledger-foreign-author` fail closed；
+    `dispatcher._read_exit_sentinel()` 對非 Manager 產生／非普通檔的 sentinel 視同
+    尚未寫下（沿用既有 fail-closed 分支記成 failed）。direct 模式下 job 與 Manager
+    同 uid，這兩條永遠不會命中——**既有部署零影響**。
+  - **尚未處理（後續票）**：gate 的**執行面**仍未移出 builder。直接把 gate 重跑放進
+    Manager 進程會讓 builder 完全掌控的 worktree（`conftest.py`／pytest plugin）取得
+    `cortex-manager` 身分的任意程式碼執行，比本票要修的缺口更嚴重；正確落點是一個
+    既非 builder、也非 Manager 的 gate 執行身分，需要動 permgen 的 UID scheme 與 unit
+    產生器。在那之前降權模式不產生 ledger，build 卡照 `require_ledger` fail closed
+    ——沒有獨立證據就不採信，而不是採信一份 builder 自己寫的。
+  - 新增 `tests/test_manager_authored_job_accounting_604.py`：釘住「builder 對
+    `gate-ledger` 目錄零寫入權」的 permgen 結構事實、降權 wrapper 內不得出現 sentinel／
+    ledger 落點、外來作者的 ledger／sentinel 一律不採信、以及 direct 模式零回歸。

--- a/paulsha_cortex/coordinator/dispatcher.py
+++ b/paulsha_cortex/coordinator/dispatcher.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
 import os
+import stat
 import subprocess
 from pathlib import Path
 from typing import Callable
 
 from paulsha_cortex.config import paths
 
+from . import terminal_contract
 from .completion import classify_completion
 from .provider_outcome import classify_provider_failure, read_log_tail
 from .registry import JobRegistry
@@ -45,18 +47,43 @@ def exit_sentinel_path(log_path: str) -> Path:
 
     SubprocessLauncher 在子進程結束時把 `$?` 寫入此檔；poll_headless_done 跨進程讀回，
     故完成判定不再依賴 os.waitpid（只有 spawn 子進程的進程能 reap）。確定性、零 I/O。
+
+    #604：降權模式下寫者已改為 Manager 側的 exit 記帳 shell（見
+    `job_runner.build_manager_exit_recorder_argv`），**路徑推導完全不變**——變的
+    只有「誰是寫者」，因此 harvest 端與所有既有呼叫端零改動。
     """
     return Path(log_path).with_suffix(".exit")
 
 
 def _read_exit_sentinel(log_path: str | None) -> int | None:
-    """讀 exit sentinel；不存在/壞檔 → None（視為尚未寫下 exit code）。"""
+    """讀 exit sentinel；不存在／壞檔／**非 Manager 產生** → None。
+
+    #604：sentinel 是 `poll_headless_done` 的第一判準，等於「這個 job 的終局是
+    什麼」的權威來源。OS 隔離上線後 builder 是另一個 uid，一份由 job 帳號擁有的
+    sentinel 就是「被隔離的一方自報 exit code」——不得採信。
+
+    採「視同尚未寫下」而不是 raise：呼叫端 `poll_headless_done` 對「沒有 sentinel
+    且行程已死」本來就有 fail-closed 分支（記為 `exit_code=1` → failed），沿用它
+    比新增一條例外路徑安全，也不會讓一個被動過手腳的檔案把整個 tick 打斷。
+
+    同時要求它是**普通檔**（`lstat` 不跟隨 symlink）：symlink 換掉的 sentinel 即使
+    擁有者看起來對，指向的內容也不是 Manager 寫的。
+    """
     if not log_path:
         return None
     p = exit_sentinel_path(log_path)
-    if not p.is_file():
+    try:
+        stat_result = os.lstat(p)
+    except OSError:
         return None
-    text = p.read_text(encoding="utf-8").strip()
+    if not stat.S_ISREG(stat_result.st_mode):
+        return None
+    if terminal_contract.foreign_evidence_author(p) is not None:
+        return None
+    try:
+        text = p.read_text(encoding="utf-8").strip()
+    except (OSError, UnicodeDecodeError):
+        return None
     try:
         return int(text)
     except ValueError:

--- a/paulsha_cortex/coordinator/job_runner.py
+++ b/paulsha_cortex/coordinator/job_runner.py
@@ -73,8 +73,12 @@ stderr 併進 JSONL log（`stderr=STDOUT`）。不加 `--quiet` 就等於在 ter
 - `--wait` 讓 `systemctl` client 存活到 unit 結束（`systemctl(1)`：「For (re)start,
   wait until service stopped again」，systemd ≥ 232），因此
   `dispatcher.pid_alive()` 的 pid 判活不必改一行。
-- exit sentinel 仍由 wrapper script 在 job 內寫入，`poll_headless_done` 的第一判準
-  完全不變。
+- exit sentinel **不再由 job 進程自寫**（#604）：改由 Manager 側的 exit 記帳 shell
+  （:func:`build_manager_exit_recorder_argv`）包住 client argv，記下 client 的 `$?`。
+  `poll_headless_done` 讀的路徑逐字不變，變的只有「誰是寫者」——降權模式下 job 帳號
+  對那個目錄本來就無寫入權（`gate-ledger` 資產＝`0700 cortex-manager`，且不在 job
+  模板 unit 的 `ReadWritePaths=` 內），繼續要求 job 自寫等於要求它做一件必定 EROFS
+  的事，而在 direct 模式下它又等於讓被驗方自報 exit code。
 - log：`systemctl` **沒有** `--pipe`，且 unit 的 `StandardOutput=append:` 會由
   **root 在降權前**開檔（Manager 可寫的路徑上放 symlink 即成提權面），因此改由
   shim 在**已降權之後**依 spec 的 `log_path` 以 `O_NOFOLLOW` 接管 stdout/stderr。
@@ -94,6 +98,7 @@ import json
 import os
 import pwd
 import re
+import shlex
 import shutil
 import subprocess
 import tempfile
@@ -138,6 +143,7 @@ __all__ = [
     "UNIT_NAME_PREFIX",
     "build_builder_env",
     "build_job_spec",
+    "build_manager_exit_recorder_argv",
     "build_systemctl_start_argv",
     "build_systemd_run_argv",
     "confirm_template_instance_started",
@@ -766,6 +772,7 @@ def confirm_transient_unit_started(
     timeout_ms: int = DEFAULT_START_TIMEOUT_MS,
     monotonic: Callable[[], float] = time.monotonic,
     sleep: Callable[[float], None] = time.sleep,
+    manager_authored_sentinel: bool = False,
 ) -> None:
     """確認 transient unit 真的起來了；起不來就 fail-closed。
 
@@ -787,6 +794,7 @@ def confirm_transient_unit_started(
         timeout_ms=timeout_ms,
         monotonic=monotonic,
         sleep=sleep,
+        manager_authored_sentinel=manager_authored_sentinel,
     )
     if status is None:
         return
@@ -811,18 +819,32 @@ def _await_start(
     timeout_ms: int,
     monotonic: Callable[[], float],
     sleep: Callable[[float], None],
+    manager_authored_sentinel: bool = False,
 ) -> int | None:
     """起動確認的共用核心：回傳「起動失敗時的 client exit status」，成功回 None。
 
     判準對 `systemd-run --wait` 與 `systemctl start --wait` 完全一樣（兩者都是
     「client 存活到 unit 結束」的語意）：**client 已結束且 exit sentinel 不存在**
     才算起動失敗。真的跑完的極短命 job 必然留下 sentinel，因此不會誤判。
+
+    ``manager_authored_sentinel``（#604）：sentinel 改由 Manager 側的 exit 記帳
+    wrapper 寫入（:func:`build_manager_exit_recorder_argv`）之後，「sentinel 存在」
+    不再能區分兩件事——**那層 wrapper 在 client 起不來時也會寫**（它記的正是那個
+    非零狀態）。因此這條路徑改用單一判準：**確認窗內 client 已結束且狀態非 0**。
+    這在語意上成立，因為 `--wait` 的 client 只有在 unit 已經跑完之後才會返回，而
+    unit 啟動（systemd 排程 → 降權 → shim 讀 spec → exec 模型 CLI）不可能在預設
+    200ms 的窗內走完；反之 polkit 拒絕／模板未安裝是**立刻**回非 0。極端情況下若
+    真有一個 job 在窗內就以非零收場，結果是**拒絕這次派工**（fail-closed，可重派），
+    不是採信一個沒跑過的 job。
     """
 
     deadline = monotonic() + max(timeout_ms, 0) / 1000.0
     while True:
         status = process.poll()
         if status is not None:
+            if manager_authored_sentinel:
+                # Manager 記帳模式：sentinel 一定會被寫，故不能拿它當判準。
+                return status if status != 0 else None
             if Path(sentinel).exists():
                 # job 真的跑完了（且已寫下 exit sentinel）——不是起動失敗。
                 return None
@@ -1032,6 +1054,56 @@ def build_systemctl_start_argv(*, systemctl: str, unit: str) -> list[str]:
     return [systemctl, "start", "--wait", "--no-ask-password", unit]
 
 
+def build_manager_exit_recorder_argv(
+    *, client_argv: Sequence[str], sentinel: str
+) -> list[str]:
+    """把降權啟動器的 client argv 包進一層 **Manager 身分**的 exit 記帳 shell。
+
+    #604：exit sentinel 過去由 job 進程內的 wrapper script 寫（`launcher.
+    build_wrapper_script` 的第 2 段）。OS 隔離上線後這條路同時有兩個問題：
+
+    1. **信任面**：sentinel 是 `dispatcher.poll_headless_done` 的第一判準，卻由被
+       隔離的一方自報。builder 只要寫得進去就能宣告自己的 exit code。
+    2. **可行性**：登記表資產 `gate-ledger`（＝Manager 的 dispatch log 目錄）在
+       Phase 2b 是 `0700 cortex-manager`，且**不在** job 模板 unit 的
+       `ReadWritePaths=` 內（`ProtectSystem=strict` → EROFS）。job 根本寫不進去，
+       於是每個降權 job 都在 `poll_headless_done` 落到「行程已死、無 sentinel」的
+       fail-closed 分支，被記成 failed。
+
+    修法：`systemd-run --wait` 與 `systemctl start --wait` 的 client 本來就跑在
+    **Manager 這一側**（見 `launcher.launch()` 的 `popen_kwargs["env"]`），且會存活
+    到 unit 結束。把它包進一層 `bash -c`，由這層 shell 寫下 client 的 `$?`——寫者
+    因此是 Manager 的 uid，落點仍是 Manager-owned 的 log 目錄，job 側完全不參與。
+
+    `exit "$rc"`：把 client 的狀態原樣傳回給 `Popen` 物件，讓
+    :func:`_await_start` 仍拿得到「client 起不來時的 exit status」。
+
+    退出碼語意：`systemctl start --wait` 在 unit 成功結束時回 0、unit 失敗（或
+    根本起不來）時回非 0。`completion.classify_completion` 只分「0 / 非 0」，因此
+    這個粒度足夠；模型的逐字 exit code 本來就不是採信判準（採信走 gate ledger）。
+    """
+
+    if not client_argv or not all(isinstance(item, str) and item for item in client_argv):
+        raise _fail(
+            "job-runner-exit-recorder-invalid",
+            "exit 記帳 wrapper 需要非空的 client argv",
+            source="build_manager_exit_recorder_argv",
+        )
+    if not sentinel.startswith("/"):
+        raise _fail(
+            "job-runner-exit-recorder-invalid",
+            f"exit sentinel 必須是絕對路徑（Manager 的 log 目錄）: {sentinel!r}",
+            source="build_manager_exit_recorder_argv",
+            sentinel=sentinel,
+        )
+    script = (
+        f"{shlex.join(list(client_argv))}; rc=$?; "
+        f"printf %s \"$rc\" > {shlex.quote(sentinel)}; exit \"$rc\""
+    )
+    # `-c` 而非 `-lc`：這層 shell 是 Manager 的一部分，不該重新 source ~/.profile。
+    return ["bash", "-c", script]
+
+
 def preflight_systemd_template(
     *,
     account: str,
@@ -1200,12 +1272,15 @@ def confirm_template_instance_started(
     timeout_ms: int = DEFAULT_START_TIMEOUT_MS,
     monotonic: Callable[[], float] = time.monotonic,
     sleep: Callable[[float], None] = time.sleep,
+    manager_authored_sentinel: bool = False,
 ) -> None:
     """確認模板實例真的起來了；起不來就 fail-closed（**絕不**退回其他模式）。
 
     判準與 A 案共用 :func:`_await_start`：`systemctl start --wait` 與
     `systemd-run --wait` 都是「client 存活到 unit 結束」，因此「client 已結束且
     exit sentinel 不存在」在兩邊都恰好代表「job 從未真正執行」。
+    ``manager_authored_sentinel=True`` 時判準改為「確認窗內 client 以非零收場」
+    （#604，理由見 :func:`_await_start`）。
     """
 
     status = _await_start(
@@ -1214,6 +1289,7 @@ def confirm_template_instance_started(
         timeout_ms=timeout_ms,
         monotonic=monotonic,
         sleep=sleep,
+        manager_authored_sentinel=manager_authored_sentinel,
     )
     if status is None:
         return

--- a/paulsha_cortex/coordinator/launcher.py
+++ b/paulsha_cortex/coordinator/launcher.py
@@ -158,6 +158,7 @@ def build_wrapper_script(
     repo_root: str | None,
     run_gates: bool,
     stdin_prompt: str | None = None,
+    write_sentinel: bool = True,
 ) -> str:
     """組出 headless wrapper script（#261：模型結束後由 manager 產生 gate ledger）。
 
@@ -167,6 +168,17 @@ def build_wrapper_script(
     2. 把 ``$?`` 寫入 exit sentinel（跨進程 durable 完成判定，早於 gate 階段，
        確保 gate 執行時間不會被算進模型的 exit code）；
     3. 由 manager 掌控的 gate ledger writer。
+
+    ``write_sentinel=False`` / ``run_gates=False``（#604，降權模式）：這支 script
+    在降權模式下是以 **job 帳號**（`cortex-builder`）執行的，而 sentinel 與 ledger
+    的落點屬登記表資產 ``gate-ledger``（Manager 的 dispatch log 目錄，`0700
+    cortex-manager`，且不在 job 模板 unit 的 ``ReadWritePaths=`` 內）。讓 job 去寫
+    那兩個檔在信任面上是「被隔離的一方自證 exit code 與 gate 結果」，在可行性上則
+    是必定 EROFS。降權模式因此把兩段都拿掉：sentinel 改由 Manager 側的 exit 記帳
+    shell 寫（見 :func:`job_runner.build_manager_exit_recorder_argv`），gate 的重跑
+    與 ledger 產生留待 Manager 側的 gate 執行面（見本檔 :meth:`SubprocessLauncher.
+    _should_run_gates` 的說明），在那之前 ``require_ledger`` 會照既有規則 fail
+    closed——**不會**因為少了這一段而讓任何 build 卡靜默通過。
 
     gate 階段的 stdout/stderr 一律導向 /dev/null：JSONL log 是 terminal evidence 的
     來源，混入 gate 輸出會讓 ``_extract_terminal_json`` 讀到非 terminal 的內容。
@@ -189,7 +201,10 @@ def build_wrapper_script(
         command = (
             f"printf %s {shlex.quote(stdin_prompt)} | {shlex.join(inner_argv)} 2>/dev/null"
         )
-    script = f'{command}; printf %s "$?" > {shlex.quote(sentinel)}'
+    if write_sentinel:
+        script = f'{command}; printf %s "$?" > {shlex.quote(sentinel)}'
+    else:
+        script = command
     if not run_gates or not repo_root:
         return script
     gate_argv = [
@@ -1058,9 +1073,29 @@ class SubprocessLauncher:
         不應在它的 sandbox 內跑 gate；operator 未宣告任何 ``PSC_GATE_CMD_*`` 時仍會
         寫出一份 ``gates: []`` 的 ledger，讓 harvest 能區分「沒宣告 gate」與
         「wrapper 根本沒跑完」。
+
+        **#604：降權模式一律不在 job wrapper 內跑 gate。** 理由有兩層——
+
+        1. 信任面：wrapper 跑在 builder 的 uid 底下，ledger 因此是「被驗方在自己的
+           進程裡產生自己的驗收證據」。#540 的 gate acceptance chain 要求 model 既
+           不能自證成功、也不能自證失敗。
+        2. 可行性：ledger 的落點是登記表資產 ``gate-ledger``（`0700 cortex-manager`，
+           不在 job 模板 unit 的 ``ReadWritePaths=`` 內），job 寫進去必然 EROFS。
+
+        **為什麼不直接把 gate 搬進 Manager 進程**（＝本票只做到「不再由 job 自寫」
+        這一步的原因）：宣告出來的 gate 命令（`PSC_GATE_CMD_PYTEST` 之類）是在
+        **builder 完全掌控內容的 worktree** 裡執行的；`pytest` 會載入該 worktree 的
+        `conftest.py`／plugin，等於讓 builder 在 `cortex-manager` 身分下取得任意程式
+        碼執行——那比本票要修的缺口更嚴重。正確的落點是一個**既非 builder、也非
+        Manager** 的 gate 執行身分（Manager 起、以獨立降權帳號跑、產出直接落在
+        Manager-owned 樹），那需要動 permgen 的 UID scheme 與 unit 產生器，屬後續票。
+        在那之前，降權模式下的 build 卡會因 ``require_ledger`` 而 fail closed——這是
+        刻意的：沒有獨立證據就不採信，而不是採信一份 builder 自己寫的。
         """
 
         if self._review_only or self._read_only:
+            return False
+        if self._degraded_runner(os.environ):
             return False
         return env.get("PSC_REPO_ROOT") is not None
 
@@ -1267,6 +1302,9 @@ class SubprocessLauncher:
             repo_root=env.get("PSC_REPO_ROOT"),
             run_gates=self._should_run_gates(env),
             stdin_prompt=stdin_prompt,
+            # #604：降權模式下 sentinel 改由 Manager 側的 exit 記帳 shell 寫；
+            # job wrapper 內不得再出現任何指向 Manager log 目錄的寫入。
+            write_sentinel=not degraded,
         )
         # Reviewer 不使用 login shell，避免 ~/.profile 等在最小 env 建立後重新匯入 secrets。
         # 降權模式的 builder 同理（#588 第 2 點）：login shell 會在 transient unit 的
@@ -1287,6 +1325,10 @@ class SubprocessLauncher:
                 working_directory=worktree,
                 env=env,
                 command=argv,
+            )
+            # #604：client 跑在 Manager 這一側且存活到 unit 結束，由它記 exit code。
+            argv = job_runner.build_manager_exit_recorder_argv(
+                client_argv=argv, sentinel=sentinel
             )
             # systemd-run **client 自己**的環境。它不會流進 transient unit——unit 的
             # 環境只有 PID 1 的 manager environment 加上 `--setenv` 白名單（這正是
@@ -1315,6 +1357,10 @@ class SubprocessLauncher:
             job_runner.write_job_spec(template_plan.spec_path, spec)
             argv = job_runner.build_systemctl_start_argv(
                 systemctl=template_plan.binary, unit=template_plan.unit
+            )
+            # #604：同 A 案——sentinel 由 Manager 側這層 shell 寫，job 不參與。
+            argv = job_runner.build_manager_exit_recorder_argv(
+                client_argv=argv, sentinel=sentinel
             )
             # systemctl **client 自己**的環境（同 A 案的理由：polkit 授權可能要查
             # 呼叫端 session）。它不會流進 unit——unit 的環境來自 root-owned 模板檔，
@@ -1345,6 +1391,7 @@ class SubprocessLauncher:
                 account=template_plan.account,
                 log_path=log_path,
                 timeout_ms=job_runner.resolve_start_timeout_ms(os.environ),
+                manager_authored_sentinel=True,
             )
         if runner_plan is not None:
             # polkit 拒絕／unit 名衝突只在起動當下才知道；確認不到就 fail-closed，
@@ -1356,6 +1403,7 @@ class SubprocessLauncher:
                 account=runner_plan.account,
                 log_path=log_path,
                 timeout_ms=job_runner.resolve_start_timeout_ms(os.environ),
+                manager_authored_sentinel=True,
             )
         return LaunchHandle(
             executor=self._executor,

--- a/paulsha_cortex/coordinator/terminal_contract.py
+++ b/paulsha_cortex/coordinator/terminal_contract.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Iterable, Mapping
@@ -494,6 +495,41 @@ def gate_ledger_path(log_path: str | Path) -> Path:
     return path.with_name(path.stem + ".gates.json")
 
 
+def _effective_uid() -> int | None:
+    """本行程的 effective uid；平台沒有 uid 概念（Windows）時回 ``None``。"""
+
+    geteuid = getattr(os, "geteuid", None)
+    return None if geteuid is None else int(geteuid())
+
+
+def foreign_evidence_author(path: str | Path) -> int | None:
+    """回傳「這份證據檔的擁有者 uid，若它不是 Manager 自己」；否則 ``None``。
+
+    #604：``gate-ledger`` 這個登記表資產（Manager 的 dispatch log 目錄，含 gate
+    ledger 與 exit sentinel）宣告的 writer 只有 Manager。Phase 2b OS 隔離上線前，
+    這份宣告靠的是「job 與 Manager 同 UID，所以誰寫都一樣」；上線之後 builder 是
+    另一個 uid，「誰寫的」第一次變成一個**可以在檔案系統上直接問出來的事實**。
+
+    這支函式就是把那個事實接進採信路徑：以 ``lstat``（不跟隨 symlink）取得擁有者，
+    與本行程的 effective uid 比對。回 ``None`` 的三種情況都代表「沒有偵測到外來
+    作者」：檔案不存在／stat 不到、擁有者就是自己、平台無 uid 概念。
+
+    刻意用 uid 而不是別的（簽章、hash chain）：這一層要擋的是「被隔離的一方自己
+    寫下自己的驗收證據」，而 OS 已經替我們記了作者；再疊一層應用層密碼學在
+    Phase 2b 的威脅模型裡不會多擋任何東西（Phase 3 才處理簽章）。
+    """
+
+    euid = _effective_uid()
+    if euid is None:
+        return None
+    try:
+        stat_result = os.lstat(path)
+    except OSError:
+        return None
+    owner = int(stat_result.st_uid)
+    return None if owner == euid else owner
+
+
 def gate_ledger_digest(payload: Mapping[str, Any]) -> str:
     """gate ledger 的 canonical digest；重驗以「讀檔＋比 hash」為主（D2）。"""
 
@@ -515,6 +551,19 @@ def read_gate_ledger(ledger_path: str | Path) -> tuple[dict[str, Any], str] | No
         )
     if not path.is_file():
         return None
+    foreign_uid = foreign_evidence_author(path)
+    if foreign_uid is not None:
+        # #604：ledger 不是 Manager 寫的。降權模式下這代表 builder（或任何其他
+        # 非 Manager 身分）在 Manager-owned 的證據樹裡放了一份自證檔案——它既不是
+        # 「manager 獨立產生的 evidence」，也不能被降級成 hint 後照樣採信，一律
+        # fail closed。direct 模式下 job 與 Manager 同 uid，這條永遠不會命中，
+        # 因此對既有部署零影響。
+        raise TerminalContractError(
+            f"gate ledger 非 Manager 產生（owner uid={foreign_uid}）；"
+            "model 不得自證 gate 結果",
+            reason="gate-ledger-foreign-author",
+            validation_path="$.gate_evidence",
+        )
     try:
         payload = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:

--- a/paulsha_cortex/trust_root/registry.py
+++ b/paulsha_cortex/trust_root/registry.py
@@ -354,8 +354,22 @@ ASSET_REGISTRY: tuple[TrustRootAsset, ...] = (
     TrustRootAsset(
         "gate-ledger", _T0, _MO, None,
         (Principal.MANAGER,), (Principal.MANAGER,), IngressKind.MANAGER_INTERNAL,
-        derived_in=("coordinator/terminal_contract.py:488-494",),
-        note="刻意放在 manager log_dir（模型 cwd 拿不到）——D6 要系統化的正面前例。",
+        derived_in=(
+            "coordinator/terminal_contract.py:gate_ledger_path",
+            "coordinator/dispatcher.py:exit_sentinel_path",
+        ),
+        note=(
+            "manager 的 dispatch log 目錄，**同時**是 gate ledger（`<slice>.gates.json`）"
+            "與 exit sentinel（`<slice>.exit`）的落點——兩者共用同一個資產，因為它們"
+            "共用同一個目錄與同一條信任性質。刻意放在 manager log_dir（模型 cwd 拿不到）"
+            "——D6 要系統化的正面前例。**#604**：`writers=(MANAGER,)` 這條宣告在 Phase 2b "
+            "之前只是同 UID 的巧合（wrapper script 是在 job 進程內寫這兩個檔的）；現在由"
+            "程式碼強制——sentinel 改由 Manager 側的 exit 記帳 shell 寫，且採信端一律以 "
+            "`terminal_contract.foreign_evidence_author()` 檢查檔案擁有者，非 Manager 產生"
+            "的 ledger/sentinel 不採信。gate **執行面**尚未移出 builder（見 issue #604 的"
+            "後續：需要一個既非 builder 也非 Manager 的 gate 執行身分），在那之前降權模式"
+            "不產生 ledger，build 卡照 `require_ledger` fail closed。"
+        ),
     ),
     TrustRootAsset(
         "delivery-journal", _T0, _MO, None,

--- a/tests/test_manager_authored_job_accounting_604.py
+++ b/tests/test_manager_authored_job_accounting_604.py
@@ -1,0 +1,535 @@
+"""#604：gate ledger 與 exit sentinel 的**作者**必須是 Manager，不是被隔離的 job。
+
+## 這張票在修什麼
+
+登記表資產 `gate-ledger`（＝Manager 的 dispatch log 目錄，同時放 `<slice>.gates.json`
+與 `<slice>.exit`）宣告 `writers=(MANAGER,)`。Phase 2b 之前這條宣告只是**同 UID 的
+巧合**——兩個檔實際上都由 `launcher.build_wrapper_script` 產生的 wrapper 在 **job 進程
+內**寫。2026-08-17 OS 隔離實機上線（`PSC_JOB_RUNNER=systemd-template`，job 真的以
+`uid=cortex-builder` 跑）之後，同一段程式碼同時有兩個問題：
+
+- **信任面**：exit sentinel 是 `dispatcher.poll_headless_done` 的第一判準、gate ledger
+  是 `terminal_contract.authorize_terminal` 採信 `passed` 的唯一背書，兩者卻由被驗方
+  自己的進程寫。#540 的 gate acceptance chain 要求 model 既不能自證成功、也不能自證
+  失敗。
+- **可行性**：那個目錄在 Phase 2b 是 `0700 cortex-manager`，且**不在** builder 模板
+  unit 的 `ReadWritePaths=` 內（`ProtectSystem=strict`）。job 寫進去必然 EROFS。
+
+本檔把修法的三條性質釘成不變式：
+
+1. **結構事實**（`StructuralAuthorshipTests`）——permgen 導出的權限與 job unit 的
+   `ReadWritePaths=` 證明 builder 對該目錄零寫入權。這是「job 不可能是合法作者」的
+   機械證據，也是下面兩條的前提。
+2. **降權模式下 job 不再被要求寫**（`DegradedWrapperTests`）——job 側 wrapper 內不得
+   再出現 sentinel 重導向或 gate ledger writer；sentinel 改由 Manager 側的 exit 記帳
+   shell 寫（`job_runner.build_manager_exit_recorder_argv`）。
+3. **採信端拒絕外來作者**（`ForeignAuthorRejectionTests`）——即使檔案真的出現在該
+   位置，只要擁有者不是 Manager，ledger 一律 fail closed、sentinel 一律不採信。
+
+`direct` 模式（同 UID）的行為逐字不變，由 `DirectModeZeroRegressionTests` 釘住。
+
+全程不跑 systemd、不建帳號、不 chown（測試進程不具 root）；「外來作者」以替換
+`terminal_contract._effective_uid` 模擬——被比對的一端是檔案系統上真實的 `st_uid`。
+"""
+from __future__ import annotations
+
+import json
+import os
+import shlex
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import paulsha_cortex.coordinator.job_runner as job_runner
+import paulsha_cortex.coordinator.launcher as launcher_module
+from paulsha_cortex.coordinator import dispatcher, terminal_contract
+from paulsha_cortex.coordinator.job_runner import JobRunnerError
+from paulsha_cortex.coordinator.launcher import SubprocessLauncher
+from paulsha_cortex.trust_root import permgen
+from paulsha_cortex.trust_root.registry import Principal, asset_by_id
+
+_BASE_ENV = {
+    "PATH": "/usr/local/bin:/usr/bin:/bin",
+    "HOME": "/var/lib/cortex-manager",
+    "LANG": "en_US.UTF-8",
+    "PSC_REPO_ROOT": "/opt/cortex/venv/lib/python3/site-packages",
+}
+
+
+# ---------------------------------------------------------------------------
+# 1：結構事實——builder 對 gate-ledger 目錄零寫入權
+# ---------------------------------------------------------------------------
+
+class StructuralAuthorshipTests(unittest.TestCase):
+    """登記表宣告 ⟷ permgen 產出 ⟷ job unit 三者一致：job 不可能是合法作者。"""
+
+    def setUp(self) -> None:
+        self.scheme = permgen.DEFAULT_SCHEME
+        self.plan = permgen.generate_plan(self.scheme)
+        self.entry = self.plan.by_id("gate-ledger")
+
+    def test_registry_declares_manager_as_the_only_writer(self) -> None:
+        asset = asset_by_id("gate-ledger")
+        self.assertEqual(asset.writers, (Principal.MANAGER,))
+        self.assertFalse(asset.headless_writable())
+
+    def test_permgen_gives_no_job_account_any_write_access(self) -> None:
+        writable = self.plan.all_writable_accounts(self.entry)
+        self.assertEqual(writable, {self.scheme.durable_state_owner})
+        for principal in (Principal.BUILDER, Principal.REVIEWER, Principal.PLANNER):
+            account = self.scheme.resolve(principal)
+            if account == self.scheme.durable_state_owner:
+                continue
+            self.assertNotIn(account, writable, principal)
+        # group/other 一個寫入位都沒有——連「同 group 就寫得到」這條路都不存在。
+        self.assertEqual(self.entry.mode & 0o077, 0)
+
+    def test_builder_job_unit_read_write_paths_never_cover_the_ledger_dir(self) -> None:
+        """`ProtectSystem=strict` 下，沒被 RWP 涵蓋＝唯讀掛載＝EROFS。
+
+        這條是本票診斷的核心證據：job 側的 wrapper 就算照舊執行那兩行寫入，在實機上
+        也只會失敗。要求 job 去寫一個它結構上寫不到的檔，得到的不是「安全」而是
+        「每個 job 都因為沒有 sentinel 被判 failed」。
+        """
+
+        unit = permgen.build_job_unit(self.scheme, principal=Principal.BUILDER)
+        ledger_dir = permgen.asset_paths()["gate-ledger"]
+        for rwp in unit.read_write_paths:
+            self.assertFalse(
+                permgen._is_within(ledger_dir, rwp),
+                f"job unit 不該對 gate-ledger 目錄可寫: {rwp}",
+            )
+
+    def test_exit_sentinel_and_gate_ledger_share_the_same_asset(self) -> None:
+        """兩個檔同目錄、同性質，因此同一個登記表資產必須同時涵蓋它們。"""
+
+        log_path = f"{permgen.asset_paths()['gate-ledger']}/psc-1/psc-1.jsonl"
+        sentinel = str(dispatcher.exit_sentinel_path(log_path))
+        ledger = str(terminal_contract.gate_ledger_path(log_path))
+        ledger_dir = permgen.asset_paths()["gate-ledger"]
+        self.assertTrue(permgen._is_within(sentinel, ledger_dir), sentinel)
+        self.assertTrue(permgen._is_within(ledger, ledger_dir), ledger)
+        derived = asset_by_id("gate-ledger").derived_in
+        self.assertTrue(
+            any("exit_sentinel_path" in item for item in derived),
+            f"sentinel 的推導點必須登記在 gate-ledger 資產上: {derived}",
+        )
+
+
+# ---------------------------------------------------------------------------
+# 2：降權模式下 job 側 wrapper 不再寫 sentinel／ledger
+# ---------------------------------------------------------------------------
+
+class _FakeProc:
+    def __init__(self, *, pid: int = 6060, exit_status: int | None = None) -> None:
+        self.pid = pid
+        self._exit_status = exit_status
+
+    def poll(self) -> int | None:
+        return self._exit_status
+
+
+class _RecordingPopen:
+    def __init__(self, *, proc: _FakeProc | None = None) -> None:
+        self.calls: list[dict] = []
+        self._proc = proc or _FakeProc()
+
+    def __call__(self, argv, **kwargs):
+        self.calls.append({"argv": argv, **kwargs})
+        return self._proc
+
+    @property
+    def call(self) -> dict:
+        return self.calls[0]
+
+
+class _nested:
+    def __init__(self, managers) -> None:
+        self._managers = list(managers)
+
+    def __enter__(self):
+        self._entered = [m.__enter__() for m in self._managers]
+        return self._entered
+
+    def __exit__(self, *exc_info):
+        for manager in reversed(self._managers):
+            manager.__exit__(*exc_info)
+        return False
+
+
+def _seams(*, template: bool):
+    patches = [
+        mock.patch.object(
+            job_runner.shutil,
+            "which",
+            return_value="/usr/bin/systemctl" if template else "/usr/bin/systemd-run",
+        ),
+        mock.patch.object(job_runner, "_systemd_booted", return_value=True),
+        mock.patch.object(job_runner, "_account_exists", return_value=True),
+        mock.patch.object(job_runner, "_group_exists", return_value=True),
+    ]
+    if template:
+        patches += [
+            mock.patch.object(job_runner, "_unit_file_installed", return_value=True),
+            mock.patch.object(job_runner, "_is_executable", return_value=True),
+            mock.patch.object(job_runner, "_unit_is_active", return_value=False),
+        ]
+    return patches
+
+
+def _launch(
+    *,
+    mode: str,
+    popen: _RecordingPopen,
+    slice_id: str = "psc-0604-demo",
+    extra_env: dict[str, str] | None = None,
+) -> dict[str, str]:
+    """在受控 seam 下跑一次 launch，回傳現場路徑。"""
+
+    original = launcher_module.subprocess.Popen
+    launcher_module.subprocess.Popen = popen
+    try:
+        with tempfile.TemporaryDirectory() as root:
+            spool = str(Path(root) / "job-specs")
+            Path(spool).mkdir(parents=True, exist_ok=True)
+            env = {
+                **_BASE_ENV,
+                job_runner.JOB_RUNNER_ENV: mode,
+                job_runner.JOB_SPEC_SPOOL_ENV: spool,
+                **(extra_env or {}),
+            }
+            log_dir = str(Path(root) / "logs")
+            template = mode == job_runner.RUNNER_SYSTEMD_TEMPLATE
+            with mock.patch.dict(os.environ, env, clear=True):
+                with _nested(_seams(template=template)):
+                    SubprocessLauncher("codex").launch(
+                        slice_id=slice_id,
+                        prompt="PROMPT",
+                        worktree=root,
+                        log_dir=log_dir,
+                    )
+            specs = sorted(Path(spool).glob("*.json"))
+            return {
+                "log_dir": str(Path(log_dir).resolve()),
+                "sentinel": str(Path(log_dir).resolve() / f"{slice_id}.exit"),
+                "ledger": str(Path(log_dir).resolve() / f"{slice_id}.gates.json"),
+                "spec": specs[0].read_text(encoding="utf-8") if specs else "",
+            }
+    finally:
+        launcher_module.subprocess.Popen = original
+
+
+def _recorder_parts(argv: list[str]) -> tuple[list[str], str]:
+    """`(client argv, sentinel)`——同時釘住 Manager 側 exit 記帳 shell 的形狀。"""
+
+    assert argv[:2] == ["bash", "-c"], argv
+    head, sep, tail = argv[2].partition("; rc=$?; ")
+    assert sep, argv[2]
+    assert tail.startswith('printf %s "$rc" > '), tail
+    assert tail.endswith('; exit "$rc"'), tail
+    written = tail[len('printf %s "$rc" > ') : -len('; exit "$rc"')]
+    return shlex.split(head), shlex.split(written)[0]
+
+
+class DegradedWrapperTests(unittest.TestCase):
+    """降權模式：job 側寫入面歸零，sentinel 的寫者換成 Manager。"""
+
+    def test_template_mode_job_command_never_touches_the_manager_log_dir(self) -> None:
+        popen = _RecordingPopen()
+        paths = _launch(mode=job_runner.RUNNER_SYSTEMD_TEMPLATE, popen=popen)
+        spec = json.loads(paths["spec"])
+        job_script = " ".join(str(item) for item in spec["command"])
+        # job 真正會執行的命令列裡，不得出現這兩個**證據**落點。
+        self.assertNotIn(paths["sentinel"], job_script)
+        self.assertNotIn(paths["ledger"], job_script)
+        self.assertNotIn('printf %s "$?"', job_script)
+        self.assertNotIn("paulsha_cortex.coordinator.gate_ledger", job_script)
+        # 註：codex 的 `-o <log_dir>/last.json`（`launcher.build_codex_argv`）仍指向
+        # 同一個目錄。它**不是**證據面（沒有任何採信路徑讀它，見 `grep last.json`：
+        # 只有 planning_runtime 的暫存目錄版本被讀），因此不在本票範圍內；但它在
+        # Phase 2b 同樣會 EROFS，屬 executor argv 面的獨立缺口，另票處理。
+
+    def test_template_mode_sentinel_is_written_by_the_manager_side_shell(self) -> None:
+        popen = _RecordingPopen()
+        paths = _launch(mode=job_runner.RUNNER_SYSTEMD_TEMPLATE, popen=popen)
+        client, sentinel = _recorder_parts(popen.call["argv"])
+        self.assertEqual(sentinel, paths["sentinel"])
+        self.assertEqual(client[0], "/usr/bin/systemctl")
+        # 那層 shell 用的是 Manager 自己的 env（polkit 可能要查呼叫端 session），
+        # 因此它跑在 Manager 的 uid 下——這正是「作者是 Manager」的來源。
+        self.assertIn("PATH", popen.call["env"])
+
+    def test_systemd_run_mode_gets_the_same_treatment(self) -> None:
+        popen = _RecordingPopen()
+        paths = _launch(mode=job_runner.RUNNER_SYSTEMD_RUN, popen=popen)
+        client, sentinel = _recorder_parts(popen.call["argv"])
+        self.assertEqual(sentinel, paths["sentinel"])
+        self.assertEqual(client[0], "/usr/bin/systemd-run")
+        job_script = client[client.index("--") + 1 :][2]
+        self.assertNotIn(paths["sentinel"], job_script)
+        self.assertNotIn("paulsha_cortex.coordinator.gate_ledger", job_script)
+
+    def test_degraded_launch_never_asks_the_job_to_run_gates(self) -> None:
+        """gate 執行面尚未搬走，但**絕不**留在 builder 進程裡自證。
+
+        後續票要把 gate 重跑放到一個既非 builder、也非 Manager 的執行身分下
+        （直接放進 Manager 進程會讓 builder 掌控的 `conftest.py` 取得
+        `cortex-manager` 的任意程式碼執行）。在那之前降權模式不產生 ledger，
+        build 卡照 `require_ledger` fail closed。
+        """
+
+        launcher = SubprocessLauncher("codex")
+        degraded = {
+            **_BASE_ENV,
+            job_runner.JOB_RUNNER_ENV: job_runner.RUNNER_SYSTEMD_TEMPLATE,
+        }
+        with mock.patch.dict(os.environ, degraded, clear=True):
+            self.assertFalse(launcher._should_run_gates(dict(_BASE_ENV)))
+
+    def test_manager_exit_recorder_rejects_relative_sentinel(self) -> None:
+        with self.assertRaises(JobRunnerError) as ctx:
+            job_runner.build_manager_exit_recorder_argv(
+                client_argv=["systemctl", "start"], sentinel="logs/x.exit"
+            )
+        self.assertEqual(ctx.exception.diagnostic.reason, "job-runner-exit-recorder-invalid")
+
+    def test_manager_exit_recorder_really_records_the_client_status(self) -> None:
+        """不是比對字串——真的跑一次 bash，確認寫下的就是 client 的 exit code。"""
+
+        import subprocess
+
+        with tempfile.TemporaryDirectory() as d:
+            sentinel = str(Path(d) / "s.exit")
+            argv = job_runner.build_manager_exit_recorder_argv(
+                client_argv=["sh", "-c", "exit 3"], sentinel=sentinel
+            )
+            proc = subprocess.run(argv, capture_output=True)
+            self.assertEqual(proc.returncode, 3)
+            self.assertEqual(Path(sentinel).read_text(encoding="utf-8"), "3")
+
+
+class ManagerAuthoredStartConfirmationTests(unittest.TestCase):
+    """記帳 shell 一定會寫 sentinel，因此起動確認不能再拿它當判準。"""
+
+    def test_start_failure_is_still_detected_when_the_sentinel_exists(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            sentinel = str(Path(d) / "s.exit")
+            Path(sentinel).write_text("1", encoding="utf-8")  # 記帳 shell 已寫下
+            with self.assertRaises(JobRunnerError) as ctx:
+                job_runner.confirm_template_instance_started(
+                    process=_FakeProc(exit_status=1),
+                    sentinel=sentinel,
+                    unit="cortex-job@demo.service",
+                    account="cortex-builder",
+                    timeout_ms=0,
+                    manager_authored_sentinel=True,
+                )
+        self.assertEqual(
+            ctx.exception.diagnostic.reason, "job-runner-template-instance-start-failed"
+        )
+
+    def test_successful_short_lived_job_is_not_a_start_failure(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            sentinel = str(Path(d) / "s.exit")
+            Path(sentinel).write_text("0", encoding="utf-8")
+            job_runner.confirm_template_instance_started(
+                process=_FakeProc(exit_status=0),
+                sentinel=sentinel,
+                unit="cortex-job@demo.service",
+                account="cortex-builder",
+                timeout_ms=0,
+                manager_authored_sentinel=True,
+            )
+
+    def test_legacy_job_authored_semantics_are_untouched(self) -> None:
+        """未傳旗標時＝既有語意（sentinel 存在即視為真的跑過），零回歸。"""
+
+        with tempfile.TemporaryDirectory() as d:
+            sentinel = str(Path(d) / "s.exit")
+            Path(sentinel).write_text("1", encoding="utf-8")
+            job_runner.confirm_transient_unit_started(
+                process=_FakeProc(exit_status=1),
+                sentinel=sentinel,
+                unit="cortex-job-demo.service",
+                account="cortex-builder",
+                timeout_ms=0,
+            )
+
+
+# ---------------------------------------------------------------------------
+# 3：採信端拒絕外來作者
+# ---------------------------------------------------------------------------
+
+def _as_foreign_reader():
+    """讓本行程「看起來」是另一個 uid——測試檔案的 st_uid 因此變成外來作者。
+
+    刻意不 chown（測試不具 root）：被比對的一端仍是檔案系統上真實的 owner，
+    只有比對基準被換掉，判定路徑本身逐字是生產路徑。
+    """
+
+    return mock.patch.object(
+        terminal_contract, "_effective_uid", return_value=os.getuid() + 4242
+    )
+
+
+def _passing_ledger(path: Path) -> None:
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": terminal_contract.GATE_LEDGER_SCHEMA_VERSION,
+                "kind": terminal_contract.GATE_LEDGER_KIND,
+                "slice_id": "psc-0604",
+                "gates": [
+                    {
+                        "name": "pytest",
+                        "command": "python3 -m pytest",
+                        "exit_code": 0,
+                        "status": "passed",
+                        "detail": "",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def _passing_envelope() -> terminal_contract.TerminalEnvelope:
+    return terminal_contract.validate_envelope(
+        {
+            "schema_version": terminal_contract.TERMINAL_SCHEMA_VERSION,
+            "kind": "workflow-card",
+            "status": "passed",
+            "payload": {},
+            "gate_evidence": [{"name": "pytest", "status": "passed"}],
+        }
+    )
+
+
+class ForeignAuthorRejectionTests(unittest.TestCase):
+    def test_foreign_authored_ledger_is_refused_even_when_it_says_everything_passed(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            ledger = Path(d) / "psc-0604.gates.json"
+            _passing_ledger(ledger)
+            with _as_foreign_reader():
+                with self.assertRaises(terminal_contract.TerminalContractError) as ctx:
+                    terminal_contract.read_gate_ledger(ledger)
+        self.assertEqual(ctx.exception.reason, "gate-ledger-foreign-author")
+
+    def test_foreign_authored_ledger_fails_the_whole_acceptance_chain(self) -> None:
+        """#540 的鏈條：ledger 不可信 → `passed` 拿不到授權，且不得靜默降級。"""
+
+        with tempfile.TemporaryDirectory() as d:
+            ledger = Path(d) / "psc-0604.gates.json"
+            _passing_ledger(ledger)
+            with _as_foreign_reader():
+                with self.assertRaises(terminal_contract.TerminalContractError) as ctx:
+                    terminal_contract.authorize_terminal(
+                        _passing_envelope(),
+                        ledger_path=ledger,
+                        require_ledger=True,
+                        expected_gate_names={"pytest"},
+                    )
+        self.assertEqual(ctx.exception.reason, "gate-ledger-foreign-author")
+
+    def test_manager_authored_ledger_is_accepted(self) -> None:
+        """零回歸：direct 模式（同 UID）下這條檢查永遠不會命中。"""
+
+        with tempfile.TemporaryDirectory() as d:
+            ledger = Path(d) / "psc-0604.gates.json"
+            _passing_ledger(ledger)
+            payload, digest = terminal_contract.read_gate_ledger(ledger)
+            self.assertEqual(payload["kind"], terminal_contract.GATE_LEDGER_KIND)
+            self.assertEqual(len(digest), 64)
+            authorization = terminal_contract.authorize_terminal(
+                _passing_envelope(),
+                ledger_path=ledger,
+                require_ledger=True,
+                expected_gate_names={"pytest"},
+            )
+            self.assertEqual(authorization.status, "passed")
+
+    def test_foreign_authored_exit_sentinel_is_not_believed(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            log_path = str(Path(d) / "psc-0604.jsonl")
+            Path(log_path).write_text("", encoding="utf-8")
+            sentinel = dispatcher.exit_sentinel_path(log_path)
+            sentinel.write_text("0", encoding="utf-8")  # builder 自報「我成功了」
+            self.assertEqual(dispatcher._read_exit_sentinel(log_path), 0)
+            with _as_foreign_reader():
+                self.assertIsNone(dispatcher._read_exit_sentinel(log_path))
+
+    def test_symlinked_sentinel_is_not_believed(self) -> None:
+        """擁有者看起來對，但內容來自別處——同樣不採信。"""
+
+        with tempfile.TemporaryDirectory() as d:
+            real = Path(d) / "elsewhere"
+            real.write_text("0", encoding="utf-8")
+            log_path = str(Path(d) / "psc-0604.jsonl")
+            Path(log_path).write_text("", encoding="utf-8")
+            sentinel = dispatcher.exit_sentinel_path(log_path)
+            sentinel.symlink_to(real)
+            self.assertIsNone(dispatcher._read_exit_sentinel(log_path))
+
+    def test_poll_headless_done_fails_closed_on_a_foreign_sentinel(self) -> None:
+        """整條 harvest 路徑：不採信 ≠ 卡住，而是 fail-closed 記成 failed。"""
+
+        class _Registry:
+            def __init__(self, job: dict) -> None:
+                self.job = job
+                self.finalized: dict | None = None
+
+            def get_job(self, job_id: str) -> dict:
+                return self.job
+
+            def update_headless_result(self, job_id, *, status, exit_code, provider_outcome):
+                self.finalized = {"status": status, "exit_code": exit_code}
+                return self.finalized
+
+        with tempfile.TemporaryDirectory() as d:
+            log_path = str(Path(d) / "psc-0604.jsonl")
+            Path(log_path).write_text("", encoding="utf-8")
+            dispatcher.exit_sentinel_path(log_path).write_text("0", encoding="utf-8")
+            registry = _Registry({"job_id": "j1", "pid": 4242, "log_path": log_path})
+            disp = dispatcher.Dispatcher(registry, None, None)
+            with _as_foreign_reader():
+                result = disp.poll_headless_done("j1", pid_alive=lambda pid: False)
+        self.assertEqual(result["status"], "failed")
+        self.assertEqual(result["exit_code"], 1)
+
+
+# ---------------------------------------------------------------------------
+# 4：direct 模式零回歸
+# ---------------------------------------------------------------------------
+
+class DirectModeZeroRegressionTests(unittest.TestCase):
+    def test_direct_wrapper_still_writes_sentinel_and_gate_ledger(self) -> None:
+        script = launcher_module.build_wrapper_script(
+            inner_argv=["codex", "exec"],
+            sentinel="/tmp/s.exit",
+            ledger="/tmp/s.gates.json",
+            worktree="/tmp/wt",
+            repo_root="/repo",
+            run_gates=True,
+        )
+        self.assertIn('printf %s "$?" > /tmp/s.exit', script)
+        self.assertIn("paulsha_cortex.coordinator.gate_ledger", script)
+
+    def test_write_sentinel_false_removes_only_that_segment(self) -> None:
+        without = launcher_module.build_wrapper_script(
+            inner_argv=["codex", "exec"],
+            sentinel="/tmp/s.exit",
+            ledger="/tmp/s.gates.json",
+            worktree="/tmp/wt",
+            repo_root="/repo",
+            run_gates=False,
+            write_sentinel=False,
+        )
+        self.assertEqual(without, "codex exec")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/tests/test_trust_root_job_runner_p2a.py
+++ b/tests/test_trust_root_job_runner_p2a.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import os
+import shlex
 import subprocess
 import tempfile
 import unittest
@@ -134,6 +135,30 @@ class _nested:
         for manager in reversed(self._managers):
             manager.__exit__(*exc_info)
         return False
+
+
+def _unwrap_exit_recorder(argv: list[str]) -> list[str]:
+    """剝掉 #604 的 Manager 側 exit 記帳 shell，取回真正的 systemd client argv。
+
+    降權啟動的最外層現在恆為 `bash -c '<client…>; rc=$?; printf … > <sentinel>;
+    exit "$rc"'`（寫者＝Manager 的 uid，不是 job）。本 helper 同時**釘住那層的形狀**：
+    形狀變了就整批降權測試立刻紅，而不是靜默退回檢查外層 argv 的空集合。
+    """
+
+    assert argv[:2] == ["bash", "-c"], argv
+    head, sep, tail = argv[2].partition("; rc=$?; ")
+    assert sep, argv[2]
+    assert tail.startswith('printf %s "$rc" > '), tail
+    assert tail.endswith('; exit "$rc"'), tail
+    return shlex.split(head)
+
+
+def _recorded_sentinel(argv: list[str]) -> str:
+    """從 exit 記帳 shell 取出它會寫的 sentinel 路徑。"""
+
+    _, _, tail = argv[2].partition("; rc=$?; ")
+    written = tail[len('printf %s "$rc" > ') : -len('; exit "$rc"')]
+    return shlex.split(written)[0]
 
 
 def _setenv_map(argv: list[str]) -> dict[str, str]:
@@ -612,8 +637,27 @@ class DegradedLaunchTests(unittest.TestCase):
         )
         return popen
 
+    def _client_argv(self, *, env=None, executor: str = "codex") -> list[str]:
+        """降權啟動的 systemd client argv（已剝掉 #604 的 exit 記帳外層）。"""
+
+        return _unwrap_exit_recorder(
+            self._launch_builder(env=env, executor=executor).call["argv"]
+        )
+
+    def test_exit_sentinel_is_written_by_the_manager_side_recorder(self) -> None:
+        # #604：sentinel 的寫者必須在 Manager 這一側。外層 shell 由 Manager 的
+        # environ／uid 執行（見 `test_client_env_is_not_the_unit_env`），job 側的
+        # wrapper 內不得再出現任何 sentinel 重導向。
+        call = self._launch_builder().call
+        sentinel = _recorded_sentinel(call["argv"])
+        self.assertTrue(sentinel.endswith(".exit"), sentinel)
+        inner = _unwrap_exit_recorder(call["argv"])
+        job_script = inner[inner.index("--") + 1 :][2]
+        self.assertNotIn(sentinel, job_script)
+        self.assertNotIn('printf %s "$?"', job_script)
+
     def test_builder_is_wrapped_in_systemd_run(self) -> None:
-        argv = self._launch_builder().call["argv"]
+        argv = self._client_argv()
         self.assertEqual(argv[0], "/usr/bin/systemd-run")
         self.assertIn("--uid=cortex-builder", argv)
         self.assertIn("--gid=cortex-builder", argv)
@@ -621,20 +665,20 @@ class DegradedLaunchTests(unittest.TestCase):
         self.assertIn("--pipe", argv)
 
     def test_unit_name_carries_the_job_id(self) -> None:
-        argv = self._launch_builder().call["argv"]
+        argv = self._client_argv()
         unit = next(item for item in argv if item.startswith("--unit="))
         self.assertTrue(unit.startswith(f"--unit={job_runner.UNIT_NAME_PREFIX}"))
         self.assertIn("psc-0001-demo", unit)
 
     def test_inner_shell_is_non_login(self) -> None:
         # #588 第 2 點：login shell 會讓 ~/.profile 在白名單 env 之後重新匯入。
-        argv = self._launch_builder().call["argv"]
+        argv = self._client_argv()
         tail = argv[argv.index("--") + 1 :]
         self.assertEqual(tail[:2], ["bash", "-c"])
         self.assertNotIn("-lc", argv)
 
     def test_unit_env_never_contains_tokens(self) -> None:
-        argv = self._launch_builder().call["argv"]
+        argv = self._client_argv()
         unit_env = _setenv_map(argv)
         for name in _SECRET_ENV:
             self.assertNotIn(name, unit_env)
@@ -648,11 +692,11 @@ class DegradedLaunchTests(unittest.TestCase):
     def test_copilot_token_normalization_is_inert_under_degraded_runner(self) -> None:
         # direct 模式會把 GH_TOKEN 正規化成 COPILOT_GITHUB_TOKEN 送進 job；
         # 降權模式下 env 白名單裡沒有任何 token 候選，因此那條路徑自然變成 no-op。
-        argv = self._launch_builder(executor="copilot").call["argv"]
+        argv = self._client_argv(executor="copilot")
         self.assertNotIn("COPILOT_GITHUB_TOKEN", _setenv_map(argv))
 
     def test_unit_env_carries_job_markers(self) -> None:
-        unit_env = _setenv_map(self._launch_builder().call["argv"])
+        unit_env = _setenv_map(self._client_argv())
         self.assertEqual(unit_env["PSC_JOB_ID"], "psc-0001-demo")
         self.assertEqual(unit_env["PSC_SLICE_ID"], "psc-0001-demo")
         self.assertIn("PSC_REPO_ROOT", unit_env)
@@ -662,18 +706,20 @@ class DegradedLaunchTests(unittest.TestCase):
         call = self._launch_builder().call
         self.assertEqual(call["stdin"], subprocess.DEVNULL)
         worktree = call["cwd"]
-        self.assertIn(f"--working-directory={worktree}", call["argv"])
+        self.assertIn(
+            f"--working-directory={worktree}", _unwrap_exit_recorder(call["argv"])
+        )
 
     def test_client_env_is_not_the_unit_env(self) -> None:
         # systemd-run client 保留完整 env（polkit 可能要查 session），但那份 env
         # 不會進到 unit——unit 只看得到 `--setenv` 白名單。
         call = self._launch_builder().call
         self.assertIn("GH_TOKEN", call["env"])
-        self.assertNotIn("GH_TOKEN", _setenv_map(call["argv"]))
+        self.assertNotIn("GH_TOKEN", _setenv_map(_unwrap_exit_recorder(call["argv"])))
 
     def test_builder_account_override_flows_into_argv(self) -> None:
         env = _degraded_env(**{job_runner.BUILDER_ACCOUNT_ENV: "cortex-worker"})
-        argv = self._launch_builder(env=env).call["argv"]
+        argv = self._client_argv(env=env)
         self.assertIn("--uid=cortex-worker", argv)
         self.assertNotIn("--uid=cortex-builder", argv)
 

--- a/tests/test_trust_root_job_template_ab.py
+++ b/tests/test_trust_root_job_template_ab.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import json
 import os
+import shlex
 import stat
 import subprocess
 import tempfile
@@ -604,6 +605,16 @@ class TemplateInstanceNameTests(unittest.TestCase):
         )
 
 
+def _unwrap_exit_recorder(argv: list[str]) -> list[str]:
+    """剝掉 #604 的 Manager 側 exit 記帳 shell，取回封閉的 systemctl client argv。"""
+
+    assert argv[:2] == ["bash", "-c"], argv
+    head, sep, tail = argv[2].partition("; rc=$?; ")
+    assert sep, argv[2]
+    assert tail.startswith('printf %s "$rc" > '), tail
+    return shlex.split(head)
+
+
 class SystemctlArgvTests(unittest.TestCase):
     def test_argv_is_closed(self) -> None:
         argv = job_runner.build_systemctl_start_argv(
@@ -637,7 +648,9 @@ class JobSpecContentTests(unittest.TestCase):
     def test_launch_writes_one_spec_and_starts_the_instance(self) -> None:
         popen = _RecordingPopen()
         ctx = _launch_template(SubprocessLauncher("codex"), popen=popen)
-        argv = popen.call["argv"]
+        # #604：最外層是 Manager 側的 exit 記帳 shell（sentinel 的寫者不再是 job）；
+        # 它包住的才是那條封閉的 systemctl client argv。
+        argv = _unwrap_exit_recorder(popen.call["argv"])
         self.assertEqual(argv[:4], ["/usr/bin/systemctl", "start", "--wait", "--no-ask-password"])
         self.assertTrue(argv[4].startswith("cortex-job@"))
         self.assertTrue(argv[4].endswith(".service"))
@@ -884,18 +897,19 @@ class TemplateFailFastTests(unittest.TestCase):
 
 class HarvestCompatibilityTests(unittest.TestCase):
     def test_log_and_sentinel_paths_are_unchanged(self) -> None:
+        popen = _RecordingPopen()
         with tempfile.TemporaryDirectory() as d:
-            ctx = _launch_template(
-                SubprocessLauncher("codex"), popen=_RecordingPopen(), workdir=d
-            )
+            ctx = _launch_template(SubprocessLauncher("codex"), popen=popen, workdir=d)
             spec = _only_spec(ctx["spool"])
         # harvest（`dispatcher.poll_headless_done` → `_read_exit_sentinel`）讀的是
         # `<log_dir>/<slice>.jsonl` 與同名 `.exit`——兩者都必須與 direct 模式一致。
+        sentinel = str(Path(ctx["log_dir"]) / "psc-0042-template.exit")
         self.assertEqual(spec["log_path"], str(Path(ctx["log_dir"]) / "psc-0042-template.jsonl"))
-        self.assertIn(
-            str(Path(ctx["log_dir"]) / "psc-0042-template.exit"),
-            spec["command"][2],
-        )
+        # #604：**路徑不變，作者改變**。sentinel 現在由 Manager 側的 exit 記帳 shell
+        # 寫（`popen` 的 argv），job spec 的 command 內不得再出現它——那個目錄是
+        # `0700 cortex-manager`，job 寫進去只會 EROFS，而且那本來就是自報。
+        self.assertIn(sentinel, popen.call["argv"][2])
+        self.assertNotIn(sentinel, spec["command"][2])
 
     def test_log_file_is_truncated_then_appended(self) -> None:
         """systemctl client 用 append fd，避免蓋掉 shim 已經寫進去的內容。"""
@@ -979,7 +993,8 @@ class NoRegressionTests(unittest.TestCase):
                     )
         finally:
             launcher_module.subprocess.Popen = original
-        argv = popen.call["argv"]
+        # #604：A 案與 B 案一樣，最外層是 Manager 側的 exit 記帳 shell。
+        argv = _unwrap_exit_recorder(popen.call["argv"])
         self.assertEqual(argv[0], "/usr/bin/systemd-run")
         for flag in ("--pipe", "--wait", "--collect", "--uid=cortex-builder"):
             self.assertIn(flag, argv)


### PR DESCRIPTION
## 為什麼現在做

`#584` Phase 2b **M1 於 2026-08-17 實機完成**，`PSC_JOB_RUNNER=systemd-template` 上線，builder job 真的以 `uid=cortex-builder` 執行。`#604` 因此從「理論缺口」變成**現行部署上具名的信任缺口**：我們剛建立「builder 不能竄改 durable state」這條 OS 層保證，gate ledger 與 exit sentinel 卻仍由 builder 自己的進程寫。

## 診斷（先做診斷，再談修法）

### 誰在寫

`launcher.build_wrapper_script()` 組出的 job wrapper：

```
<模型 argv>; printf %s "$?" > <sentinel>; PYTHONPATH=… python3 -m …gate_ledger --out <ledger> …
```

三段全在 **job 進程內**。`systemd-template` 模式下這個 `bash` 是 shim `execvpe` 出來的，unit 的 `User=cortex-builder` 已生效 → **兩個檔的寫者都是 `uid=cortex-builder`**。

### 落點與權限現況

兩個檔同屬登記表資產 **`gate-ledger`**（`PathLayout.dispatch_log_root` ＝ `/var/lib/cortex/runtime/dispatch`）：

| | 值 |
|---|---|
| 資產宣告 | `tier=TIER_0`、`tree=manager-owned`、`writers=(MANAGER,)`、`readers=(MANAGER,)` |
| permgen 產出（三分） | `owner=cortex-manager`、`mode=0700`、**無任何 ACL** |
| builder 模板 unit 的 `ReadWritePaths=` | `/var/lib/cortex-builder/cache`、`/var/lib/cortex/monitor/event-spool`、`/var/lib/cortex/worktree/%i` ← **不含 dispatch log 目錄** |

### 能不能偽造

分兩個部署模式，結論不同，而且**兩個都是壞的**：

- **`direct`（現行預設）**：job 與 Manager 同 UID，兩個檔完全可寫、可在 wrapper 跑完後被背景進程覆寫。`writers=(MANAGER,)` 這條登記表宣告在這裡只是**同 UID 的巧合**，沒有任何強制。
- **`systemd-template`（M1 實機）**：`0700 cortex-manager` ＋ `ProtectSystem=strict` 且未列入 RWP ⇒ 寫入 **EROFS**。builder 偽造不了——但**合法的寫入也不存在**。後果是：
  - 沒有 sentinel → `dispatcher.poll_headless_done` 落到「行程已死、無 sentinel」分支 → **每個 builder job 都被記成 `failed`**（fail-closed，但與實際結果無關）；
  - 沒有 ledger → `require_ledger` 的 build 卡恆 `gate-ledger-missing`。

  runbook 的 R9 攻擊矩陣本身就把「builder 寫 gate ledger」列為**必須被拒**的一條（`trust-root-phase2b-setup.md:1205`），M1 的 8a 也確實判它 denied——**與 launcher 實際要求 builder 做的事直接矛盾**。這條矛盾之所以沒在 M1 被發現，是因為 5-6 正向 smoke 走的是手動 `systemctl start`，沒有跑過真正的 builder 派工路徑。

### 偽造/失效會影響哪些驗收判斷

| 檔 | 讀者 | 影響 |
|---|---|---|
| `<slice>.exit` | `dispatcher._read_exit_sentinel` → `poll_headless_done` → `classify_completion` | job 的終局（exited/failed）與 provider 失敗分類 |
| `<slice>.gates.json` | `terminal_contract.read_gate_ledger` → `authorize_terminal` | `passed` 的**唯一**獨立背書；`#307` red-required 語意反轉、`#379` expected gate names、`#308` 空/局部 ledger 判定全部建立在它上面 |

## 本 PR 的修法（四項）

1. **exit sentinel 改由 Manager 記帳**——新增 `job_runner.build_manager_exit_recorder_argv()`，把 `systemd-run --wait` / `systemctl start --wait` 的 client argv 包進一層跑在 **Manager 身分**的 `bash -c`，由它寫下 client 的 `$?`。client 本來就存活到 unit 結束（`--wait`），**sentinel 路徑逐字不變**，harvest 端零改動；變的只有「誰是寫者」。
2. **起動確認改判準**——記帳 shell 在 client 起不來時也會寫 sentinel，故 `confirm_transient_unit_started()` / `confirm_template_instance_started()` 新增 `manager_authored_sentinel=`：為真時判準改為「確認窗內 client 已結束且狀態非 0」。`--wait` 的 client 不可能在 200 ms 內走完一次真正的 unit 啟動；極端情況下誤判的結果是**拒絕這次派工**，仍是 fail-closed。未傳旗標＝既有語意，零回歸。
3. **降權模式下 job 側 wrapper 不再寫這兩個檔**——`build_wrapper_script()` 新增 `write_sentinel=`；`_should_run_gates()` 對降權模式回 `False`，gate 階段一併移出。
4. **採信端拒絕外來作者**——新增 `terminal_contract.foreign_evidence_author()`（`lstat` 取 owner 與本行程 effective uid 比對）：
   - `read_gate_ledger()` 對非 Manager 產生的 ledger 以新 reason **`gate-ledger-foreign-author`** fail closed；
   - `dispatcher._read_exit_sentinel()` 對非 Manager 產生／非普通檔（symlink）的 sentinel 視同尚未寫下，沿用既有 fail-closed 分支記成 failed。

   `direct` 模式下 job 與 Manager 同 uid，這條永遠不會命中——**既有部署零影響**。這也讓登記表 `writers=(MANAGER,)` 第一次成為**被程式碼強制的性質**，而不只是同 UID 的巧合。

## 為什麼拆，剩下什麼

**本 PR 刻意不含 gate 的執行面搬遷。** issue 提的方向是「由 Manager 以 svc 身分在受控 checkout 重跑 gate」——但宣告出來的 gate 命令（`PSC_GATE_CMD_PYTEST` 等）是在 **builder 完全掌控內容的 worktree** 裡執行的，`pytest` 會載入該 worktree 的 `conftest.py` 與 plugin。把它放進 Manager 進程等於讓 builder 在 `cortex-manager` 身分下取得**任意程式碼執行**——比本票要修的缺口嚴重得多。

正確落點是一個**既非 builder、也非 Manager 的 gate 執行身分**（Manager 起、以獨立降權帳號跑、產出直接落在 Manager-owned 樹），那需要動 `permgen` 的 UID scheme 與 unit 產生器，屬獨立一票。硬塞進本 PR 會同時撞上 `#620`／`#622` 正在改的 permgen。

在那之前，降權模式下 build 卡會因 `require_ledger` 而 fail closed——**這是刻意的**：沒有獨立證據就不採信，而不是採信一份 builder 自己寫的。相對於現況（同樣沒有 ledger，但外加每個 job 都被誤判 failed）是嚴格改善。

其餘尚未處理、`#604` 本文提到的項目：
- `#603` 的兩個小項（copilot builder 降權模式缺登入態 preflight；同 job_id retry 撞 unit 名時 `transient-unit-start-failed` 診斷碼誤導）。
- 診斷過程另發現：`launcher.build_codex_argv()` 的 `-o <log_dir>/last.json` 也指向同一個 Manager-owned 目錄，在 Phase 2b 同樣會 EROFS。它**不是**證據面（沒有任何採信路徑讀它），故不在本票範圍，另票處理。

## 依賴與衝突面

- 基於 `main` @ `fc263a6`（`#624` / `#620` 父目錄 traverse ACL 已 merge）。
- **不改 `paulsha_cortex/trust_root/permgen.py`**，避免與 `#620`／`#622` 的並行 PR 衝突。`trust_root/registry.py` 只改 `gate-ledger` 一項的 `derived_in` 與 `note`（把 exit sentinel 的推導點登記進來，並記下作者性現在由程式碼強制），不新增資產、不改 writer/reader 面，因此 permgen 產出的權限計畫**逐位元不變**。

## 測試

新增 `tests/test_manager_authored_job_accounting_604.py`（21 條）：

- `StructuralAuthorshipTests`——登記表宣告、permgen 產出、builder job unit 的 `ReadWritePaths=` 三者一致，機械證明 builder 對該目錄零寫入權；sentinel 與 ledger 同屬一個資產。
- `DegradedWrapperTests`——`systemd-template` / `systemd-run` 兩種降權模式下，job spec 的 command 內不得出現 sentinel／ledger 落點或 gate writer；記帳 shell 真的跑一次 `bash` 驗證它寫下的就是 client 的 exit code。
- `ManagerAuthoredStartConfirmationTests`——sentinel 已存在時仍能偵測起動失敗；短命成功 job 不被誤判；未傳旗標的既有語意不變。
- `ForeignAuthorRejectionTests`——**核心不變式**：即使 ledger 內容宣稱全部 gate 通過，只要作者不是 Manager 就 `gate-ledger-foreign-author` fail closed（整條 `authorize_terminal` 鏈一起紅）；builder 自寫的 sentinel 不被採信，`poll_headless_done` fail-closed 記成 failed；symlink sentinel 同樣不採信。
- `DirectModeZeroRegressionTests`——direct 模式的 wrapper 仍照舊寫 sentinel ＋ gate ledger。

不變式已做突變驗證：把 `foreign_evidence_author()` 改成恆回 `None`，`ForeignAuthorRejectionTests` 的 4 條當場紅。

```
python3 -m pytest tests/ -q
3499 passed, 49 subtests passed
python3 -m pytest tests/ -q -k "job_runner or job_shim or gate or ledger"
293 passed
```

## Checklist

- [x] 分支從 `main` 開，命名 `feature/604-manager-authored-job-accounting`
- [x] `changelog.d/manager-authored-job-accounting.md` fragment 已新增且已 commit
- [x] `CHANGELOG.md [Unreleased] → Fixed` 有對應 entry
- [x] `VERSION` 未動（非 release PR）
- [x] 全套測試通過（3499 passed），無回歸
- [x] 針對「builder 自寫 ledger/sentinel 不被採信」新增不變式測試
- [x] `python3 -m policy_check` 帶完整 PR 上下文跑過
- [x] 文件與 PR 內文為 zh-tw
- [x] 部分修法，故用 `Refs #604` 並在上方說明剩下什麼、為什麼這樣切（`policy-exempt:issue-link`）

Refs #604
Refs #584 #540 #603

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E7w9kaUxAzCCEk7piD5hfK
