### PR TITLE
fix(paths): repo root 解析 fail-closed，移除 cwd fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,6 +137,30 @@
   （自檢 `job_writable_count` **5 → 0**、R9 denied 條數等）。規模統計
   35 → **43** 個 sudo 點、133 → **156** 個驗證點。
   詳見 `changelog.d/phase2b-runbook-realign.md`。
+- **#612：repo root 的 cwd fallback 是危險預設——相對路徑輸入使 production 動作
+  （`git fetch` 等）落在真實 checkout**——`paths.repo_root()` 舊實作未宣告
+  `PSC_REPO_ROOT` 時退回 `Path.cwd()`，而 manager daemon 的 `WorkingDirectory` 正是
+  operator 的真實 cortex checkout；`autonomy._infer_repo_root` 對**相對** spec 路徑
+  的 `Path.resolve()` 也接到同一個 cwd。於是「解析不出目標 repo」不是失敗，而是
+  **靜默打在錯的樹上**。清點出九條這樣的呼叫路徑，其中三條有**寫入**語意
+  （`worktree_reclaim` 的 `git worktree remove --force`／`prune`、
+  `ScriptWorktreeCreator` 的 worktree 建立、`installer.render_units` 把錯的
+  `WorkingDirectory=` 持久化進 systemd unit），另有一條會把錯 repo 的 `rev-parse`
+  結果寫成 candidate SHA 進 handoff manifest。#565／#607 收掉的是 `/tmp` 那半，
+  本次收 cwd 這半。改法為 fail-closed 取代 silent fallback：`paths.repo_root()` 未
+  宣告即拋 `RepoRootUnresolvedError`（新增 `configured_repo_root()` 讓「有沒有宣告」
+  可被分辨，cwd 語意改由 `allow_cwd=True` 在 operator 手動 CLI 上顯式表態）；
+  `_infer_repo_root` 拒收相對 spec 路徑、推不出 repo 根時帶 `DiagnosticReason`
+  fail-closed（`spec-path-not-absolute`／`repo-root-unresolved`），不再回
+  `spec.parent`——那條退路會讓 `git` 自己向上走回被 #565 搜尋上界／`~/.agents` 名稱
+  規則刻意排除掉的 repo。與 #623 的 Phase 2b 佈局相容：repo 源碼樹遷入 Manager-owned
+  樹之後，唯一的目標來源就是顯式的 `PSC_REPO_ROOT` 或顯式的絕對 spec 路徑。新增
+  `tests/test_repo_root_fail_closed_612.py`（13 個不變式測試，每個都把 cwd 設成真
+  repo 並斷言零 git 打向它）。連帶修掉四處**非 hermetic** 測試：`conftest` 的
+  `_clear_runtime_env` 從未涵蓋 `PSC_REPO_ROOT`（全套測試的 manager 目標 repo 一直是
+  跑 pytest 的當下目錄，比照 #303 改指 per-test 暫存路徑）、兩個 recover-pre-candidate
+  測試實際在真 checkout 上跑 `git worktree list`、`init-sample` 測試讀的是真 checkout
+  的 `.project-policy.yml`。詳見 `changelog.d/repo-root-fail-closed.md`。
 - **#618 / trust-root Phase 2b：補上 `cortex service run`——permgen 的 manager unit
   `ExecStart` 指向一個不存在的 verb**——產生的 system unit 寫
   `ExecStart=<venv>/bin/cortex service run`，但 porcelain 只有 `install`／`start`／

--- a/README.md
+++ b/README.md
@@ -717,10 +717,15 @@ cortex skill restore <skill_id> --approved-by "$ACTOR"
 | monitor state root | `~/.agents/monitor` | `PSC_MONITOR_STATE_ROOT` |
 | config root | `~/.config/paulshaclaw` | `PSC_CONFIG_ROOT` |
 | project config root | `~/.agents/config/paulsha` | `PSC_PROJECT_CONFIG_ROOT` |
-| repo root | 指定 install 時的 git repo top-level（`--repo-root`） | `PSC_REPO_ROOT` |
-| worktree root | `<repo>-worktrees` sibling | `PSC_WORKTREE_ROOT` |
+| repo root | 指定 install 時的 git repo top-level（`--repo-root`）；**無 cwd 預設**，未宣告即 fail-closed（見下方說明） | `PSC_REPO_ROOT` |
+| worktree root | `<repo>-worktrees` sibling（由 repo root 推導，因此同樣 fail-closed） | `PSC_WORKTREE_ROOT` |
 
 Multi-issue workflow build 階段將以 `issue` 清單中最小號碼作為主 branch，並始終以 run repository 作為 `ScriptWorktreeCreator` 的 git來源，以確保 builder worktree 在對應 repo 池內建立。
+
+**repo root 是 fail-closed 的（issue #612）**：`paths.repo_root()` 舊實作在 `PSC_REPO_ROOT` 未宣告時退回 `Path.cwd()`，而 manager daemon 的 `WorkingDirectory` 正是 operator 的真實 checkout——於是任何解析不出目標 repo 的呼叫都不是失敗，而是**靜默落在錯的樹上**（實測形態：相對 spec 路徑使 `complete_tick` 對真實 repo 跑 `git fetch --no-tags origin main`；同一族還有 `worktree_reclaim` 的 `git worktree remove --force`／`prune` 這類寫入動作）。現行契約：
+
+- 未宣告 `PSC_REPO_ROOT` 時 `paths.repo_root()` 拋 `RepoRootUnresolvedError`，不猜 cwd；需要「以當下目錄為準」的 operator 手動 CLI（`cortex work gc`、`cortex deck compile`）在呼叫點顯式帶 `allow_cwd=True`，`--repo-root` 一律優先。
+- spec 路徑必須是**絕對路徑**才能推導 repo root（`autonomy._infer_repo_root`）；相對路徑與「向上找不到 git repo 根又未宣告 `PSC_REPO_ROOT`」皆 fail-closed 並帶 `DiagnosticReason`（`spec-path-not-absolute`／`repo-root-unresolved`）。`cortex install service` 會把 `PSC_REPO_ROOT` 寫進 unit 的 `EnvironmentFile`，正常部署不受影響。
 
 `cortex install service` 會把 `PSC_CONTROL_ROOT` 寫成 `<agents_root>/control/<instance>`（比照 `PSC_RUN_ROOT` 的 `run/<instance>` 模式），讓 `manager.lock` 天生 per-instance；`service-manager.sh` 透過 `cortex control lock-path`（與 daemon 同一套 `config/runtime.py` 解析鏈）取得 lock 路徑，不再自行硬寫預設值（issue #375）。`PSC_PROJECT_CONFIG_ROOT` 與 `PSC_CONTROL_ROOT` 皆屬 installer 的 managed path：每次 `cortex install service` 都會依目前 `PSC_AGENTS_ROOT`／instance 重新推導並覆寫，不會被既有值鎖住（issue #371）；`cortex doctor` 的 `managed-path-drift` probe 可在尚未重跑 install 前就偵測到殘留的舊值。`PSC_MANAGER_SPECS_DIR`／`PSC_COORDINATOR_ROOT`／`PSC_SPECS_ROOT` 目前仍未 instance 化、也不在 installer 的 managed_env 之列（evaluate 後決定留待後續 follow-up；多 instance 共用同一 `PSC_AGENTS_ROOT` 時這三者會共用同一份 specs/coordinator 狀態）。
 

--- a/changelog.d/repo-root-fail-closed.md
+++ b/changelog.d/repo-root-fail-closed.md
@@ -1,0 +1,67 @@
+# repo-root-fail-closed
+
+- **`#612` repo root 的 cwd fallback 是危險預設：相對路徑輸入使 production 動作落在真實
+  checkout**——`paths.repo_root()` 舊實作是
+  `_resolve_root("PSC_REPO_ROOT", Path.cwd())`，而 manager daemon 的
+  `WorkingDirectory` 正是 operator 的真實 cortex checkout。於是「解析不出目標 repo」
+  不是失敗，而是**靜默落在錯的樹上**：`autonomy._infer_repo_root` 對**相對** spec 路徑
+  的 `Path.resolve()` 接到 cwd，`paths.repo_root()` 的 cwd 預設又讓第一段
+  `relative_to(configured)` 早退命中同一個 checkout。#565／#607 收掉了 `/tmp` 那半，
+  cwd 這半留到本次。
+
+  **完整危險呼叫路徑清單**（皆以 `_infer_repo_root` 或 `paths.repo_root()` 推出的
+  `repo_root` 為 `git -C` 目標）：
+
+  | 路徑 | 動作 | 語意 |
+  | --- | --- | --- |
+  | `manager.complete_tick → _completion_candidate_ref` | `git fetch --no-tags <remote> <branch>`、`rev-parse`、`merge-base --is-ancestor` | 讀（#610 實測打到真實 github.com） |
+  | `autonomy.dispatch_ready → _resolve_target_base_sha` | 同上 fetch ＋ 相依 candidate 的 `merge-base` | 讀，且結果被 pin 進 job 的 `dispatch_base` |
+  | `manager._resolve_ancestry_status` | `rev-parse` ＋ `merge-base --is-ancestor` | 讀，結果決定 slice 是否算 merged |
+  | `manager.complete_tick → _candidate_for_evidence`（slice row 缺席時） | `git rev-parse <branch>` | 讀，**錯的 SHA 會被寫成 candidate 進 handoff manifest** |
+  | `manager.apply_slice_action(recover-pre-candidate) → worktree_reclaim` | `git worktree list --porcelain` → `git worktree remove --force` → `git worktree prune` | **寫**——issue 預測的「同路徑家族若有寫入動作就是事故」實例 |
+  | `seams.ScriptWorktreeCreator()`（`repo=None`） | `git worktree add`／`branch` 建立 | **寫** |
+  | `manager` retry-verify／retry-review、`complete_tick` 的 dirty-worktree 重驗 | verification／review runner 的整組 git 操作 | 讀寫混合 |
+  | `work_bridge.resolve_trusted_repo_root` | owner/name → repo 根解析把 cwd 收進候選 | 決定後續所有 lane 動作的目標 |
+  | `deploy.installer.render_units` | 把 `<repo_root>` 寫進 systemd unit 的 `WorkingDirectory=` | 錯的目標會被**持久化**進 unit |
+
+  **修法：fail-closed 取代 silent fallback。**
+
+  - `config/paths.py`：新增 `RepoRootUnresolvedError` 與 `configured_repo_root()`
+    （只回宣告值，未宣告回 `None`——讓「有沒有宣告」可被呼叫端分辨）。`repo_root()`
+    改為 `repo_root(*, allow_cwd=False)`，未宣告 `PSC_REPO_ROOT` 時直接拋例外；
+    `worktree_root()` 同步透傳。cwd 語意仍可用，但必須由呼叫端**顯式**表態——目前
+    只有兩個 operator 手動 CLI 帶 `allow_cwd=True`：`cortex work gc`（`--repo-root`
+    仍優先）與 `cortex deck compile`。
+  - `coordinator/autonomy.py`：新增 `RepoRootResolutionError`（繼承 `ValueError`，
+    沿用既有處置面），攜帶 #570／#527 的 `DiagnosticReason`。`_infer_repo_root`
+    **拒收相對 spec 路徑**（`spec-path-not-absolute`），改讀 `configured_repo_root()`
+    因此 cwd 不再經由「configured 預設值」偷渡，且向上找不到 git repo 根又未宣告
+    `PSC_REPO_ROOT` 時 fail-closed（`repo-root-unresolved`）而非回 `spec.parent`——
+    後者會被 `git` 自己向上走回一個被搜尋上界（`/tmp`）或名稱規則（`~/.agents`）
+    刻意排除掉的 repo，等於繞過 #565 的保護。`parse_spec_frontmatter` 把該例外落成
+    `parse_error`，掃描不中斷但該 spec 永遠停在 `hold`。
+  - `coordinator/manager.py`：新增 `_repo_root_for_slice_row()` 單一推導點，移除三處
+    `Path.cwd().resolve()` 退路；`_resolve_ancestry_status` 改回既有的
+    `repo-unresolved` 狀態；`_repo_root_for_slice`（相依判定）推不出時回 `None`。
+  - `coordinator/work_bridge.py`：候選只收顯式宣告的 repo 根。
+
+  **不變式測試**：新增 `tests/test_repo_root_fail_closed_612.py`（13 測試）。每個測試
+  都把 cwd 設成一個**真的** git repo（重演 daemon 在 operator checkout 裡跑的形狀），
+  斷言 production 動作拒絕執行**且沒有任何 git 指令打向那個 cwd repo**——含
+  `complete_tick` 對 #610 事故路徑的直接回歸（相對 spec path → 零 git 呼叫、零
+  manifest、錯誤進 `errors`），以及三組對照組確認正常流程未被誤殺。
+
+  **測試套件暴露出的非 hermetic 問題**（皆為「測試實際上在 operator 的真 repo 上動作」）：
+
+  - `tests/conftest.py` 的 `_clear_runtime_env` 從未涵蓋 `PSC_REPO_ROOT`，於是全套
+    3400+ 測試的 manager 目標 repo 一直是**跑 pytest 的當下目錄**。比照 #303 既有的
+    `PSC_AGENTS_ROOT` 處理，改指向 per-test 暫存路徑。
+  - `test_pre_candidate_recovery.py::test_recover_pre_candidate_supersedes_stale_handoff_manifest`
+    與 `test_record_action_atomic_382.py::…test_recover_pre_candidate_cleanly_resets_failed_failed_slice`
+    在真 checkout 上跑 `git worktree list --porcelain`（同函式再走一步就是
+    `worktree remove --force`／`prune`）→ 改自備 tmp repo 並顯式宣告。
+  - `test_porcelain_init_sample.py::test_init_sample_routes_before_coordinator_and_prints_hold_checklist`
+    讀的是 operator 真 checkout 的 `.project-policy.yml`（測試綠不綠取決於在哪個目錄
+    跑 pytest）→ 改自備最小 policy fixture。
+  - `test_paths.py` 與 `test_fix_dispatch_spec_path.py` 的 cwd fallback 斷言改為
+    fail-closed 斷言。

--- a/docs/superpowers/specs/fix-dispatch-spec-path-design.md
+++ b/docs/superpowers/specs/fix-dispatch-spec-path-design.md
@@ -13,7 +13,14 @@ work_item: fix-dispatch-spec-path
 
 ### D2 向後相容
 
-`PSC_REPO_ROOT` 未設定時 `paths.repo_root()` 回退到 cwd 解析，行為與既有一致。不改動 `paths.repo_root()` 本身。
+~~`PSC_REPO_ROOT` 未設定時 `paths.repo_root()` 回退到 cwd 解析，行為與既有一致。不改動 `paths.repo_root()` 本身。~~
+
+> **issue #612 推翻**：這條「向後相容」正是後來的事故面。cwd 就是 manager daemon 的
+> `WorkingDirectory`＝ operator 的真實 checkout，於是相對 spec 路徑會讓 production
+> 動作（`git fetch`／`rev-parse`／`merge-base`／`worktree remove`）落在錯的 repo 上並
+> 「成功」。現行契約：`paths.repo_root()` 未宣告即 `RepoRootUnresolvedError`；
+> `_infer_repo_root` 只收絕對 spec 路徑，推不出 repo 根時帶 `DiagnosticReason`
+> fail-closed。詳見 README 路徑契約段與 `tests/test_repo_root_fail_closed_612.py`。
 
 ### 風險與 mitigation
 

--- a/docs/superpowers/specs/fix-git-runner-cwd-spec.md
+++ b/docs/superpowers/specs/fix-git-runner-cwd-spec.md
@@ -11,7 +11,9 @@ work_item: fix-git-runner-cwd
 
 ### R1 git runner 顯式指定 repo root
 
-`paulsha_cortex/coordinator/dispatcher.py::_default_git_runner` MUST 以 `git -C <repo_root> <args>` 執行，`<repo_root>` 取自 `paulsha_cortex.config.paths.repo_root()`（`PSC_REPO_ROOT` 或 cwd 解析）。MUST NOT 依賴行程 cwd。既有 `GitRunner` 簽名（`Callable[[list[str]], str]`）保持不變；相對路徑參數在 `-C repo_root` 下解析行為與「cwd==repo_root」一致。
+`paulsha_cortex/coordinator/dispatcher.py::_default_git_runner` MUST 以 `git -C <repo_root> <args>` 執行，`<repo_root>` 取自 `paulsha_cortex.config.paths.repo_root()`。MUST NOT 依賴行程 cwd。既有 `GitRunner` 簽名（`Callable[[list[str]], str]`）保持不變；相對路徑參數在 `-C repo_root` 下解析行為與「cwd==repo_root」一致。
+
+> **issue #612 更新**：本節原文寫的是「`PSC_REPO_ROOT` 或 cwd 解析」。那條 cwd 退路已移除——`repo_root()` 未宣告 `PSC_REPO_ROOT` 時改拋 `RepoRootUnresolvedError`（見 README 路徑契約段）。R1 的意圖（git 執行與行程 cwd 無關）因此更強：不只不依賴 cwd，連「解析不出來時偷偷用 cwd」也不允許。
 
 ### R2 installer 模板含 WorkingDirectory
 

--- a/paulsha_cortex/config/paths.py
+++ b/paulsha_cortex/config/paths.py
@@ -163,8 +163,51 @@ def project_config_root() -> Path:
     return resolve_project_config_root()
 
 
-def repo_root() -> Path:
-    return _resolve_root("PSC_REPO_ROOT", Path.cwd())
+class RepoRootUnresolvedError(RuntimeError):
+    """`PSC_REPO_ROOT` 未宣告，且呼叫端沒有顯式表態要用 cwd（#612）。
+
+    刻意繼承 `RuntimeError` 而非 `ValueError`：daemon 的 tick isolation（#246）
+    攔的是 `(ValueError, RuntimeError, OSError)`，兩者都在其中，但 `RuntimeError`
+    可與 registry 那族「契約驗證失敗」的 `ValueError` 區分開來——這條不是資料不
+    合法，是**執行環境沒有宣告目標 repo**。
+    """
+
+
+def configured_repo_root() -> Path | None:
+    """只回 `PSC_REPO_ROOT` 顯式宣告的值；未宣告回 `None`（**不猜**）。
+
+    #612：`repo_root()` 舊實作的預設值是 `Path.cwd()`，於是「沒有宣告」與「宣告
+    成當下工作目錄」在型別上無從分辨，呼叫端也就無從 fail-closed。把「有沒有宣告」
+    這個資訊獨立出來，讓需要判斷的呼叫端（`autonomy._infer_repo_root`）能先問
+    「宣告了嗎」再決定要不要走推斷。
+    """
+    return _env_path("PSC_REPO_ROOT")
+
+
+def repo_root(*, allow_cwd: bool = False) -> Path:
+    """本 instance 治理的目標 repo 根。
+
+    #612：**預設 fail-closed**。舊實作 `_resolve_root("PSC_REPO_ROOT", Path.cwd())`
+    在未宣告時靜默退回 `Path.cwd()`，而 daemon 的 `WorkingDirectory` 正是 operator
+    的真實 checkout——於是任何解析不出目標的呼叫（相對 spec 路徑、缺 env 的
+    unit）都不是失敗，而是**打在錯的樹上**：`git fetch`／`rev-parse`／
+    `merge-base`／worktree 建立全部落到 operator 的工作區。#623 之後 repo 源碼樹
+    會搬進 Manager-owned 樹，「猜 cwd」只會更錯。
+
+    需要 cwd 語意的呼叫端（operator 手動 CLI）必須顯式傳 `allow_cwd=True`——意圖
+    寫在呼叫點上，不再由預設值默默生效。
+    """
+    explicit = configured_repo_root()
+    if explicit is not None:
+        return explicit
+    if allow_cwd:
+        return Path.cwd()
+    raise RepoRootUnresolvedError(
+        "PSC_REPO_ROOT 未宣告，拒絕退回 cwd（#612）："
+        "production 動作必須有顯式的目標 repo 才能執行。"
+        "請設定 PSC_REPO_ROOT，或由呼叫端顯式傳入 repo root；"
+        "operator 手動 CLI 若確實要以當下工作目錄為準，請顯式 allow_cwd=True。"
+    )
 
 
 def _canonical_repo_root(repo: Path) -> Path:
@@ -182,6 +225,10 @@ def worktree_root_for(repo: Path) -> Path:
     return repo.parent / f"{repo.name}-worktrees"
 
 
-def worktree_root() -> Path:
-    """coordinator 派工 worktree pool 的預設路徑。"""
-    return worktree_root_for(repo_root())
+def worktree_root(*, allow_cwd: bool = False) -> Path:
+    """coordinator 派工 worktree pool 的預設路徑。
+
+    `allow_cwd` 原樣傳給 `repo_root()`——worktree pool 是從 repo 根推導的，repo 根
+    猜錯，pool 就跟著建在錯的地方（#612）。
+    """
+    return worktree_root_for(repo_root(allow_cwd=allow_cwd))

--- a/paulsha_cortex/coordinator/autonomy.py
+++ b/paulsha_cortex/coordinator/autonomy.py
@@ -10,6 +10,7 @@ from paulsha_cortex.config import paths
 from .._yaml import YAMLError, safe_load
 from . import completion
 from .contract_command import build_dispatch_prompt
+from .diagnostics import DiagnosticReason, diagnostic_reason
 from .dispatcher import _default_git_runner
 from .launcher import AgentLauncher, LaunchHandle
 from .model_identities import load_model_identities
@@ -118,6 +119,18 @@ def parse_spec_frontmatter(path) -> dict:
         meta["model_id"] = data.get("model_id") if isinstance(data.get("model_id"), str) else None
         meta["repo"] = data.get("repo") if isinstance(data.get("repo"), str) else None
         meta["parse_error"] = exc.as_payload()
+        return meta
+    except RepoRootResolutionError as exc:
+        # #612：spec 路徑推不出 repo 根（相對路徑／無 git 根且未宣告
+        # PSC_REPO_ROOT）。掃描不該因此炸掉整輪，但這份 spec 也**不得**被派工——
+        # 落成 parse_error，`dispatch` 就永遠停在 hold，理由則由 DiagnosticReason
+        # 帶著走。
+        meta["slice_id"] = data.get("slice_id") if isinstance(data.get("slice_id"), str) else None
+        meta["parse_error"] = {
+            "code": exc.diagnostic.reason,
+            "field": "path",
+            "message": exc.diagnostic.detail,
+        }
         return meta
 
 
@@ -283,14 +296,65 @@ def _repo_search_boundaries() -> frozenset[Path]:
     return frozenset(roots)
 
 
+class RepoRootResolutionError(ValueError):
+    """spec 路徑推不出 repo 根，且拒絕退回 cwd（#612）。
+
+    繼承 `ValueError` 是為了沿用既有的處置面：`complete_tick` 的 per-job
+    `except Exception`、`work` action 的 `ValueError` 出口、daemon 的 tick
+    isolation（#246）都已經接得住，因此本例外只改變「打在錯的樹上」這件事，
+    不改變任何呼叫端原本的錯誤處置形狀。
+
+    `diagnostic` 是 #570／#527 的 :class:`DiagnosticReason`：呼叫端要落 evidence
+    或推 `needs_human` 時直接取用，不必從字串反推理由。
+    """
+
+    def __init__(self, diagnostic: DiagnosticReason) -> None:
+        self.diagnostic = diagnostic
+        super().__init__(f"{diagnostic.reason}: {diagnostic.detail}")
+
+
 def _infer_repo_root(spec_path: Path) -> Path:
-    configured = paths.repo_root().resolve()
+    """從 spec 路徑解析它所屬的 repo 根——**推不出來就失敗，絕不退回 cwd**（#612）。
+
+    舊實作有兩條靜默的 cwd 通道，兩條都會讓 production 動作打在錯的樹上：
+
+    1. `spec_path.resolve()` 對**相對**路徑是相對 cwd 解析的。daemon 的
+       `WorkingDirectory` 正是 operator 的真實 checkout，因此任何從 slice
+       spec／config／payload 滲入的相對路徑，都會把 repo 根解析成那個 checkout；
+    2. `paths.repo_root()` 未設 `PSC_REPO_ROOT` 時預設 `Path.cwd()`，於是連
+       第一段的 `relative_to(configured)` 早退也會命中同一個 checkout。
+
+    #610 實測的後果：`manager.complete_tick → _completion_candidate_ref` 對
+    operator 的真實 repo 跑 `git fetch --no-tags origin main`（連帶打真實
+    github.com）。fetch 本身良性，但同一條路徑家族還有 `_resolve_target_base_sha`
+    的 fetch、`_candidate_ancestry_summary` 的 `rev-parse`／`merge-base`、
+    verification／review 的 worktree 操作——只要其中一個有寫入語意就是事故。
+
+    #623 的 Phase 2b 佈局讓這條更緊：Manager unit 帶 `ProtectHome=yes`，repo 源碼
+    樹要搬進 Manager-owned 樹，任何「落回 cwd 或 operator checkout」的解析都是
+    **無聲的錯誤目標**。因此路徑正規化一律在進件邊界完成：進來的 spec 路徑必須
+    是絕對路徑，推不出 repo 根時 fail-closed 並帶 :class:`DiagnosticReason`。
+    """
+    if not spec_path.is_absolute():
+        raise RepoRootResolutionError(
+            diagnostic_reason(
+                "spec-path-not-absolute",
+                "spec 路徑為相對路徑，解析 repo 根會落在當下工作目錄（#612）；"
+                "spec 路徑必須在進件邊界正規化成絕對路徑後才能推斷 repo 根",
+                source="autonomy._infer_repo_root:relative-spec-path",
+                spec_path=str(spec_path),
+            )
+        )
+
+    configured_raw = paths.configured_repo_root()
+    configured = configured_raw.resolve() if configured_raw is not None else None
     resolved_spec = spec_path.resolve()
-    try:
-        resolved_spec.relative_to(configured)
-        return configured
-    except ValueError:
-        pass
+    if configured is not None:
+        try:
+            resolved_spec.relative_to(configured)
+            return configured
+        except ValueError:
+            pass
 
     agents_dir = Path.home() / ".agents"
     boundaries = _repo_search_boundaries()
@@ -302,9 +366,17 @@ def _infer_repo_root(spec_path: Path) -> Path:
                 continue
             return parent
 
-    if os.getenv("PSC_REPO_ROOT"):
+    if configured is not None:
         return configured
-    return resolved_spec.parent
+    raise RepoRootResolutionError(
+        diagnostic_reason(
+            "repo-root-unresolved",
+            "spec 路徑向上找不到 git repo 根，且未宣告 PSC_REPO_ROOT（#612）；"
+            "拒絕退回 spec 所在目錄／cwd——production 動作必須有顯式的目標 repo",
+            source="autonomy._infer_repo_root:unresolved",
+            spec_path=str(resolved_spec),
+        )
+    )
 
 
 def _resolve_contract_path(path_value: str | None, repo_root: Path) -> Path | None:

--- a/paulsha_cortex/coordinator/gc.py
+++ b/paulsha_cortex/coordinator/gc.py
@@ -487,7 +487,12 @@ def _build_parser() -> argparse.ArgumentParser:
         description="proposal-first 回收殘留 build worktree 與已 merge local branch",
     )
     parser.add_argument(
-        "--repo-root", default=None, help="被治理的目標 git repo 根目錄（預設：cortex 路徑契約 repo_root()）"
+        "--repo-root",
+        default=None,
+        help=(
+            "被治理的目標 git repo 根目錄"
+            "（預設：cortex 路徑契約 repo_root()；未設 PSC_REPO_ROOT 時退回當下工作目錄）"
+        ),
     )
     parser.add_argument(
         "--apply", action="store_true",
@@ -500,7 +505,12 @@ def _build_parser() -> argparse.ArgumentParser:
 def main(argv: Sequence[str] | None = None) -> int:
     parser = _build_parser()
     args = parser.parse_args(list(argv) if argv is not None else None)
-    repo_root = Path(args.repo_root).resolve() if args.repo_root else default_repo_root()
+    # #612：`cortex work gc` 是 operator 手動 CLI，「在哪個 repo 裡跑就治理哪個」
+    # 是它本來的語意，因此 cwd 退路在這裡**顯式**表態（`allow_cwd=True`），而不是
+    # 靠 `repo_root()` 的預設值默默生效。daemon 側的呼叫端一律不帶這個旗標。
+    repo_root = (
+        Path(args.repo_root).resolve() if args.repo_root else default_repo_root(allow_cwd=True)
+    )
 
     report = run_gc(
         repo_root, apply=args.apply, pr_status_provider=default_pr_status_provider

--- a/paulsha_cortex/coordinator/manager.py
+++ b/paulsha_cortex/coordinator/manager.py
@@ -248,6 +248,31 @@ def _slice_for_reviewer_job(registry, slice_id: str, job_id: str) -> dict | None
     return slice_row
 
 
+def _repo_root_for_slice_row(slice_row: Mapping | None) -> Path:
+    """從 slice row 解析目標 repo 根——**沒有就 fail-closed**（#612）。
+
+    舊實作在 `slice_row is None`（或推斷丟例外）時退回 `Path.cwd().resolve()`。
+    daemon 的 `WorkingDirectory` 正是 operator 的真實 checkout，於是那條退路把
+    「不知道目標」變成「打在 operator 的樹上」：`complete_tick` 的
+    `_candidate_for_evidence`（`git rev-parse`）、`_completion_candidate_ref`
+    （`git fetch --no-tags origin main`）、verification／review runner 全部跟著
+    落在錯的 repo，而且一路「成功」。
+
+    沒有 slice row 時退回 `paths.repo_root()`——它自 #612 起也是 fail-closed 的
+    （`PSC_REPO_ROOT` 未宣告即拋 `RepoRootUnresolvedError`），因此這裡要嘛拿到
+    operator 顯式宣告的目標，要嘛拋例外由呼叫端的錯誤通道記錄，不會再有第三種
+    「靜默猜一個」的結局。
+    """
+    spec_path = None
+    if isinstance(slice_row, Mapping):
+        spec = slice_row.get("spec")
+        if isinstance(spec, Mapping):
+            spec_path = spec.get("path")
+    if isinstance(spec_path, str) and spec_path:
+        return autonomy._infer_repo_root(Path(spec_path))
+    return paths.repo_root().resolve()
+
+
 def _pinned_input_mismatches(slice_row: dict) -> list[str]:
     repo_root = autonomy._infer_repo_root(Path(slice_row["spec"]["path"]))
     mismatches: list[str] = []
@@ -572,7 +597,14 @@ def _resolve_ancestry_status(slice_row: dict, *, git_runner) -> dict[str, Any]:
         summary["status"] = "repo-unresolved"
         return summary
     runner = git_runner or verification._default_git_runner
-    repo_root = autonomy._infer_repo_root(Path(spec_path))
+    try:
+        repo_root = autonomy._infer_repo_root(Path(spec_path))
+    except autonomy.RepoRootResolutionError:
+        # #612：推不出目標 repo 就不跑 git——舊實作會落到 cwd（daemon 的
+        # WorkingDirectory ＝ operator 的真實 checkout），ancestry 於是對錯的樹
+        # 作答，而且答得「成功」。
+        summary["status"] = "repo-unresolved"
+        return summary
     target_head = verification._run_git(["-C", str(repo_root), "rev-parse", target_ref], runner)
     target_sha = target_head["stdout"].strip().lower()
     if target_head["status"] != "ok" or verification.SAFE_SHA_RE.fullmatch(target_sha) is None:
@@ -1924,7 +1956,13 @@ def complete_tick(
                 spec_path = None
         if not isinstance(spec_path, str) or not spec_path:
             return None
-        return autonomy._infer_repo_root(Path(spec_path))
+        try:
+            return autonomy._infer_repo_root(Path(spec_path))
+        except autonomy.RepoRootResolutionError:
+            # #612：推不出目標 repo → 與「沒有 spec 路徑」同義（`None`），
+            # `default_is_satisfied` 因此走它既有的「無 repo 可查」分支，
+            # 而不是拿 cwd 當 repo 去問 handoff／ancestry。
+            return None
 
     def _ready_ids() -> set[str]:
         return {
@@ -1962,14 +2000,12 @@ def complete_tick(
                     try:
                         b_job = registry.get_job(builder_job_id)
                         if b_job.get("status") in TERMINAL_STATUSES:
-                            try:
-                                r_root = (
-                                    autonomy._infer_repo_root(Path(slice_item["spec"]["path"]))
-                                    if isinstance(slice_item.get("spec"), dict) and slice_item["spec"].get("path")
-                                    else Path.cwd().resolve()
-                                )
-                            except Exception:
-                                r_root = Path.cwd().resolve()
+                            # #612：舊實作在「slice 沒有 spec 路徑」與「推斷丟例外」
+                            # 兩種情況都退回 `Path.cwd().resolve()`，於是 dirty
+                            # worktree 的重驗會對 operator 的真實 checkout 跑
+                            # verification（含 git 操作）。改成 fail-closed：解析
+                            # 不出目標 repo 就不重驗，由底下的 except 收掉這一輪。
+                            r_root = _repo_root_for_slice_row(slice_item)
                             st_path = getattr(registry, "_state_path", None)
                             coord_root = Path(st_path).parent if st_path is not None else None
                             re_ev = verification_runner(
@@ -2023,11 +2059,7 @@ def complete_tick(
                 slice_row = _slice_for_job(registry, slice_id, job_id)
                 if slice_row is not None and slice_row.get("reviewer_job_id"):
                     continue
-            repo_root = (
-                autonomy._infer_repo_root(Path(slice_row["spec"]["path"]))
-                if slice_row is not None
-                else Path.cwd().resolve()
-            )
+            repo_root = _repo_root_for_slice_row(slice_row)
             state_path = getattr(registry, "_state_path", None)
             coordinator_root = Path(state_path).parent if state_path is not None else None
             evidence = None

--- a/paulsha_cortex/coordinator/work_bridge.py
+++ b/paulsha_cortex/coordinator/work_bridge.py
@@ -128,7 +128,14 @@ def resolve_trusted_repo_root(repo: str, *, explicit: object = None) -> Path:
                 "explicit repo root must be the canonical git top-level and its remote must match owner/name"
             )
         return root
-    candidates.append(paths.repo_root())
+    # #612：候選只收「顯式宣告的」repo 根。舊實作用 `paths.repo_root()`，未宣告
+    # `PSC_REPO_ROOT` 時它會退回 cwd——daemon 的 cwd 就是 operator 的真實
+    # checkout，於是 owner/name 會被「解析」到一個沒人指定過的樹。改讀
+    # `configured_repo_root()`：沒宣告就不進候選，最後由下方「必須恰好命中一個」
+    # 的檢查 fail-closed。
+    configured = paths.configured_repo_root()
+    if configured is not None:
+        candidates.append(configured)
     try:
         from paulsha_cortex.monitor.config import load_config
 

--- a/paulsha_cortex/deck/compile.py
+++ b/paulsha_cortex/deck/compile.py
@@ -601,7 +601,12 @@ def compile_combo(
     band: str | None = None,
     repo_root: str | Path | None = None,
 ) -> CompileResult:
-    effective_repo_root = Path(repo_root) if repo_root is not None else paths.repo_root()
+    # #612：`cortex deck compile` 是 operator 手動 CLI，未帶 `repo_root` 時「以當下
+    # 工作目錄為準」是它本來的語意（只讀 `.project-policy.yml` 產 verification
+    # skeleton，不做任何 git mutation），因此 cwd 退路在這裡**顯式**表態。
+    effective_repo_root = (
+        Path(repo_root) if repo_root is not None else paths.repo_root(allow_cwd=True)
+    )
     slug = slugify_task(task)
     if change is not None:
         change = _validate_change_name(change)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -95,6 +95,16 @@ def _clear_runtime_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
         if name.startswith("PSC_") or name == "PAULSHACLAW_CONFIG":
             monkeypatch.delenv(name, raising=False)
     unset_root = tmp_path / "unset-psc-root-guard"
+    # #612：`PSC_REPO_ROOT` 與 `PSC_AGENTS_ROOT` 是同一類洩漏，只是洩漏的目標不同。
+    # `paths.repo_root()` 舊實作未宣告時退回 `Path.cwd()`，而跑測試的 cwd 就是
+    # operator 的**真實 cortex checkout**，於是任何忘了指定目標 repo 的測試都在真
+    # repo 上跑 git——#610 的實網事故（`git -C <真 checkout> fetch origin main`
+    # 打到 github.com）就是這樣來的，`worktree_reclaim` 的
+    # `git worktree remove --force`／`prune` 更是**寫入**動作。production 側自
+    # #612 起 fail-closed（未宣告即 `RepoRootUnresolvedError`），測試側則比照
+    # `PSC_AGENTS_ROOT` 指向 per-test 暫存路徑：需要真 repo 的測試自行 setenv／
+    # 建 fixture repo 覆寫，需要驗「未宣告」行為的測試自行 delenv。
+    monkeypatch.setenv("PSC_REPO_ROOT", str(unset_root / "repo"))
     monkeypatch.setenv("PSC_AGENTS_ROOT", str(unset_root / "agents"))
     monkeypatch.setenv("PSC_CONFIG_ROOT", str(unset_root / "config"))
     # #506：auto-claim scan 的 GitHub 節流在生產預設 1000ms／請求。測試不打真的

--- a/tests/test_fix_dispatch_spec_path.py
+++ b/tests/test_fix_dispatch_spec_path.py
@@ -11,6 +11,12 @@ hermetic 手法有二，兩者都用：
    不再只 `mkdir` 一個空 `.git`——空目錄現在依契約就不是 repo 根；
 2. 污染由測試**自備**（`make_empty_git_dir()` / monkeypatch 搜尋上界），
    host `/tmp` 有沒有 `.git` 都不影響結果。
+
+#612 起再加一條：推斷**不得**有任何 cwd 通道。舊實作有兩條——相對 spec 路徑的
+`Path.resolve()`，以及 `paths.repo_root()` 未宣告時的 `Path.cwd()` 預設——兩條都
+會把 repo 根解析成 daemon 的工作目錄（＝ operator 的真實 checkout）。因此本檔的
+測試一律以**絕對** spec 路徑餵入，並在需要驗「未宣告」行為時顯式
+`delenv("PSC_REPO_ROOT")`（conftest 預設把它指向 per-test 暫存路徑）。
 """
 
 from pathlib import Path
@@ -19,15 +25,15 @@ import pytest
 
 from git_fixtures import make_empty_git_dir, make_fake_repo
 from paulsha_cortex.coordinator import autonomy
-from paulsha_cortex.coordinator.autonomy import _infer_repo_root
+from paulsha_cortex.coordinator.autonomy import RepoRootResolutionError, _infer_repo_root
 
 
 def _isolated_cwd(tmp_path: Path) -> Path:
-    """未設 `PSC_REPO_ROOT` 時 `paths.repo_root()` 退回 `Path.cwd()`。
+    """驗「向上搜尋」分支時用的無關 cwd。
 
-    要驗「向上搜尋」的分支，cwd 就不能是 spec 的祖先——否則第一段
-    `relative_to(configured)` 早退，根本走不到搜尋迴圈。給一個與受測路徑無
-    祖孫關係的空目錄當 cwd。
+    #612 後 cwd 已不參與推斷，這個 helper 因此不再是必要條件，而是**反向**斷言的
+    載體：把 cwd 換到一個與受測路徑無祖孫關係的空目錄，若哪天推斷又偷偷讀了 cwd，
+    結果就會與斷言不符。
     """
     cwd = tmp_path / "unrelated-cwd"
     cwd.mkdir(exist_ok=True)
@@ -59,7 +65,13 @@ def test_infer_repo_root_keeps_in_repo_path_for_repo_relative_spec(monkeypatch, 
     assert _infer_repo_root(spec_path) == repo_root
 
 
-def test_infer_repo_root_fallback_unchanged_without_configured_repo_root(monkeypatch, tmp_path):
+def test_infer_repo_root_never_falls_back_to_cwd_repo(monkeypatch, tmp_path):
+    """#612：spec 在任何 repo 之外、又沒宣告 `PSC_REPO_ROOT` → fail-closed。
+
+    舊實作回 `spec_path.parent`，而 `paths.repo_root()` 的 cwd 預設更會讓「spec
+    剛好在 cwd 底下」直接回 cwd。這裡把 cwd 設成一個**真的** repo（重演 daemon
+    在 operator checkout 裡跑的形狀）並斷言推斷**不會**採用它。
+    """
     repo_root = make_fake_repo(tmp_path / "repo")
     spec_path = tmp_path / "outside" / "specs" / "foo-spec.md"
     spec_path.parent.mkdir(parents=True)
@@ -68,7 +80,9 @@ def test_infer_repo_root_fallback_unchanged_without_configured_repo_root(monkeyp
     monkeypatch.delenv("PSC_REPO_ROOT", raising=False)
     monkeypatch.chdir(repo_root)
 
-    assert _infer_repo_root(spec_path) == spec_path.parent
+    with pytest.raises(RepoRootResolutionError) as excinfo:
+        _infer_repo_root(spec_path)
+    assert excinfo.value.diagnostic.reason == "repo-root-unresolved"
 
 
 # --- #565 回歸：空 .git 目錄不得被當 repo 根 ---------------------------------
@@ -94,7 +108,11 @@ def test_empty_git_dir_on_path_chain_is_not_a_repo_root(monkeypatch, tmp_path):
 
 
 def test_empty_git_dir_alone_does_not_anchor_repo_root(monkeypatch, tmp_path):
-    """鏈上**只有**空 `.git`（沒有任何真 repo）時，落到既有 fallback 而非污染點。"""
+    """鏈上**只有**空 `.git`（沒有任何真 repo）時，不得落錨在污染點。
+
+    #565 的原斷言是「落到既有 fallback（`spec.parent`）」；#612 之後那條 fallback
+    本身也不存在了，所以斷言改成 fail-closed——重點不變：**污染點不是 repo 根**。
+    """
     polluted = tmp_path / "polluted"
     make_empty_git_dir(polluted)
     spec_path = polluted / "nested" / "specs" / "foo-spec.md"
@@ -104,7 +122,9 @@ def test_empty_git_dir_alone_does_not_anchor_repo_root(monkeypatch, tmp_path):
     monkeypatch.delenv("PSC_REPO_ROOT", raising=False)
     monkeypatch.chdir(_isolated_cwd(tmp_path))
 
-    assert _infer_repo_root(spec_path) == spec_path.parent
+    with pytest.raises(RepoRootResolutionError) as excinfo:
+        _infer_repo_root(spec_path)
+    assert excinfo.value.diagnostic.reason == "repo-root-unresolved"
 
 
 def test_worktree_git_file_still_counts_as_repo_root(monkeypatch, tmp_path):
@@ -152,7 +172,9 @@ def test_search_stops_at_shared_temp_root(monkeypatch, tmp_path):
     monkeypatch.delenv("PSC_REPO_ROOT", raising=False)
     monkeypatch.chdir(_isolated_cwd(tmp_path))
 
-    assert _infer_repo_root(spec_path) == spec_path.parent
+    with pytest.raises(RepoRootResolutionError) as excinfo:
+        _infer_repo_root(spec_path)
+    assert excinfo.value.diagnostic.reason == "repo-root-unresolved"
 
 
 def test_repo_below_shared_temp_root_still_resolves(monkeypatch, tmp_path):

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -24,11 +24,47 @@ def test_env_override_wins(monkeypatch, tmp_path):
     assert paths.control_root() == tmp_path / "ctl"
 
 
-def test_repo_root_env_then_cwd(monkeypatch, tmp_path):
+def test_repo_root_uses_env_and_fails_closed_without_it(monkeypatch, tmp_path):
+    """#612：`PSC_REPO_ROOT` 未宣告時**不得**退回 cwd，必須 fail-closed。
+
+    舊契約是 `repo_root() == Path.cwd()`。daemon 的 `WorkingDirectory` 正是
+    operator 的真實 checkout，所以那個預設值等同「解析不出目標就打在 operator
+    的樹上」——不是失敗，是靜默落在錯的 repo。
+    """
     monkeypatch.setenv("PSC_REPO_ROOT", str(tmp_path))
     assert paths.repo_root() == tmp_path
+
     monkeypatch.delenv("PSC_REPO_ROOT")
-    assert paths.repo_root() == Path.cwd()
+    with pytest.raises(paths.RepoRootUnresolvedError):
+        paths.repo_root()
+
+
+def test_repo_root_cwd_requires_explicit_opt_in(monkeypatch, tmp_path):
+    """#612：cwd 語意仍可用，但必須由呼叫端**顯式**表態（operator 手動 CLI）。"""
+    monkeypatch.delenv("PSC_REPO_ROOT", raising=False)
+    monkeypatch.chdir(tmp_path)
+    assert paths.repo_root(allow_cwd=True) == Path.cwd()
+
+    # 顯式宣告永遠優先於 cwd——`allow_cwd` 只是「沒宣告時可以用 cwd」。
+    monkeypatch.setenv("PSC_REPO_ROOT", str(tmp_path / "declared"))
+    assert paths.repo_root(allow_cwd=True) == tmp_path / "declared"
+
+
+def test_configured_repo_root_reports_absence_instead_of_guessing(monkeypatch, tmp_path):
+    """#612：「有沒有宣告」必須可被呼叫端分辨，才有辦法 fail-closed。"""
+    monkeypatch.delenv("PSC_REPO_ROOT", raising=False)
+    assert paths.configured_repo_root() is None
+
+    monkeypatch.setenv("PSC_REPO_ROOT", str(tmp_path / "declared"))
+    assert paths.configured_repo_root() == tmp_path / "declared"
+
+
+def test_worktree_root_fails_closed_without_repo_root(monkeypatch):
+    """#612：worktree pool 是從 repo 根推導的——repo 根猜錯，pool 就建在錯的地方。"""
+    monkeypatch.delenv("PSC_WORKTREE_ROOT", raising=False)
+    monkeypatch.delenv("PSC_REPO_ROOT", raising=False)
+    with pytest.raises(paths.RepoRootUnresolvedError):
+        paths.worktree_root()
 
 
 def test_worktree_root_is_repo_sibling(monkeypatch, tmp_path):

--- a/tests/test_porcelain_init_sample.py
+++ b/tests/test_porcelain_init_sample.py
@@ -41,6 +41,34 @@ def specs_root(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
     return root
 
 
+@pytest.fixture
+def policy_repo_root(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    """#612：`init-sample` 的 verification 骨架來自 `<repo_root>/.project-policy.yml`。
+
+    以前 `paths.repo_root()` 未宣告時退回 `Path.cwd()`，於是這個測試讀的是
+    **operator 真實 checkout** 的 `.project-policy.yml`——測試綠不綠取決於在哪個
+    目錄跑 pytest。改成自備一份最小 policy 並顯式宣告 `PSC_REPO_ROOT`。
+    """
+    repo = tmp_path / "policy-repo"
+    repo.mkdir(parents=True, exist_ok=True)
+    (repo / ".project-policy.yml").write_text(
+        "policy_version: 1.0.17\n"
+        "preflight:\n"
+        "  steps:\n"
+        "    - name: policy\n"
+        "      kind: validation\n"
+        '      argv: ["python3", "-m", "policy_check", "--repo", "."]\n'
+        "      timeout_seconds: 300\n"
+        "    - name: tests\n"
+        "      kind: tests\n"
+        '      argv: ["python3", "-m", "pytest", "tests/", "-q"]\n'
+        "      timeout_seconds: 1800\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("PSC_REPO_ROOT", str(repo))
+    return repo
+
+
 def _seed_emitted_spec(specs_root: Path, *, change: str) -> Path:
     path = specs_root / f"{change}-build.md"
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -74,6 +102,7 @@ def _seed_non_hold_spec(specs_root: Path, *, change: str) -> Path:
 def test_init_sample_routes_before_coordinator_and_prints_hold_checklist(
     monkeypatch: pytest.MonkeyPatch,
     specs_root: Path,
+    policy_repo_root: Path,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     emitted = _seed_emitted_spec(specs_root, change="demo-change")

--- a/tests/test_pre_candidate_recovery.py
+++ b/tests/test_pre_candidate_recovery.py
@@ -46,6 +46,27 @@ def _git(repo: Path, *args: str) -> None:
     assert proc.returncode == 0, f"git {' '.join(args)} failed: {proc.stderr}"
 
 
+def _seed_repo(tmp_path: Path) -> Path:
+    """建一個有一次 commit 的本機 repo，回傳其根。
+
+    `recover-pre-candidate` 會走 `worktree_reclaim`，而它的預設 git runner 是
+    `paths.repo_root()`——#612 之前那個預設是 `Path.cwd()`，也就是 operator 的
+    **真實 checkout**，於是這些測試實際上在真 repo 上跑
+    `git worktree list --porcelain`（同函式再走一步就是
+    `git worktree remove --force` / `git worktree prune` 這種**寫入**動作）。
+    測試必須自備目標 repo 並顯式 `PSC_REPO_ROOT`。
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q", "-b", "main")
+    _git(repo, "config", "user.email", "recover@example.invalid")
+    _git(repo, "config", "user.name", "recover-test")
+    (repo / "README.md").write_text("seed\n", encoding="utf-8")
+    _git(repo, "add", "README.md")
+    _git(repo, "commit", "-qm", "init")
+    return repo
+
+
 def test_recover_pre_candidate_removes_worktree_and_resets_slice(
     tmp_path: Path, monkeypatch
 ) -> None:
@@ -115,11 +136,13 @@ def test_recover_pre_candidate_removes_worktree_and_resets_slice(
     assert latest_slice["gate_state"] == "pending"
 
 
-def test_recover_pre_candidate_supersedes_stale_handoff_manifest(tmp_path: Path) -> None:
+def test_recover_pre_candidate_supersedes_stale_handoff_manifest(tmp_path: Path, monkeypatch) -> None:
     # issue #383：recover-pre-candidate 撥回 pending 之後，殘留的舊終局 handoff
     # manifest 應被標記 superseded（稽核可見性）——run_tick 的放行判定本身已改成
     # 跟 registry 現況對帳（不依賴這個標記，見 dispatch_gate_scan/
     # _manifest_still_blocks_fanout），這裡單獨驗證標記本身確實落地。
+    # #612：目標 repo 顯式指定（見 `_seed_repo`），不再靠 `repo_root()` 的 cwd 預設。
+    monkeypatch.setenv("PSC_REPO_ROOT", str(_seed_repo(tmp_path)))
     state_path = tmp_path / "jobs.json"
     reg = JobRegistry(state_path=state_path)
     builder_job = reg.create_job(

--- a/tests/test_record_action_atomic_382.py
+++ b/tests/test_record_action_atomic_382.py
@@ -320,11 +320,21 @@ class TestRecoverPreCandidateOnFreshFailure:
     必須乾淨地一次到位（state/gate_state 同步回 pending），不留半復原中間態。"""
 
     def test_recover_pre_candidate_cleanly_resets_failed_failed_slice(
-        self, tmp_path: Path
+        self, tmp_path: Path, monkeypatch
     ) -> None:
+        import subprocess
         from unittest.mock import MagicMock
 
         from paulsha_cortex.coordinator.dispatcher import Dispatcher
+
+        # #612：`recover-pre-candidate` 會走 `worktree_reclaim`，其預設 git runner
+        # 打的是 `paths.repo_root()`。舊實作未宣告 `PSC_REPO_ROOT` 時退回
+        # `Path.cwd()`＝ operator 的真實 checkout，因此這個測試以前是在**真 repo**
+        # 上跑 `git worktree list --porcelain`。改成自備一個空 repo 並顯式宣告。
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        subprocess.run(["git", "-C", str(repo), "init", "-q", "-b", "main"], check=True)
+        monkeypatch.setenv("PSC_REPO_ROOT", str(repo))
 
         state_path = tmp_path / "jobs.json"
         reg = JobRegistry(state_path=state_path)

--- a/tests/test_repo_root_fail_closed_612.py
+++ b/tests/test_repo_root_fail_closed_612.py
@@ -1,0 +1,334 @@
+"""#612 不變式：repo 根解析不出來時，production 動作必須**拒絕執行**而非落到 cwd。
+
+背景（#610 → #611 → #612）：`paths.repo_root()` 舊實作未宣告 `PSC_REPO_ROOT` 時
+退回 `Path.cwd()`，而 manager daemon 的 `WorkingDirectory` 正是 operator 的真實
+cortex checkout。任何從 slice spec／config／payload 滲入的**相對**路徑，經
+`autonomy._infer_repo_root` 的 `Path.resolve()` 之後都會把 repo 根解析成那個
+checkout，於是 production 動作在錯的樹上「成功」執行——#610 實測到的形態是
+`manager.complete_tick → _completion_candidate_ref` 對真實 repo 跑
+`git fetch --no-tags origin main`（連帶打真實 github.com）。#611 只修了測試層，
+production 面的預設值留到本檔對應的修復。
+
+#623 讓這條更緊：trust-root Phase 2b 的 Manager unit 帶 `ProtectHome=yes`，repo
+源碼樹要遷入 Manager-owned 樹，任何「落回 cwd 或 operator checkout」的解析都是
+**無聲的錯誤目標**——不是失敗，是打在錯的樹上。
+
+本檔的每個測試都遵循同一個形狀：
+1. 把 cwd 設成一個**真的** git repo（重演 daemon 在 operator checkout 裡跑的形狀）；
+2. 餵入相對路徑／不宣告 `PSC_REPO_ROOT`；
+3. 斷言 production 動作 **fail-closed**，且**沒有任何 git 指令打向那個 cwd repo**。
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from git_fixtures import make_fake_repo
+from paulsha_cortex.config import paths
+from paulsha_cortex.coordinator import autonomy, manager, seams
+from paulsha_cortex.coordinator import dispatcher as dispatcher_mod
+from paulsha_cortex.coordinator.autonomy import RepoRootResolutionError
+from paulsha_cortex.coordinator.dispatcher import Dispatcher
+from paulsha_cortex.coordinator.registry import JobRegistry
+
+
+class RecordingGitRunner:
+    """記下每一條 git argv；永遠回成功，好讓「有沒有被呼叫」成為唯一的觀測點。"""
+
+    def __init__(self) -> None:
+        self.calls: list[list[str]] = []
+
+    def __call__(self, args: list[str]) -> SimpleNamespace:
+        self.calls.append(list(args))
+        return SimpleNamespace(returncode=0, stdout="a" * 40, stderr="")
+
+    def targets(self) -> list[str]:
+        """所有 `-C <path>` 的目標。"""
+        return [
+            argv[index + 1]
+            for argv in self.calls
+            for index, token in enumerate(argv)
+            if token == "-C" and index + 1 < len(argv)
+        ]
+
+
+@pytest.fixture
+def cwd_repo(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    """把 cwd 換成一個真 repo，並清掉 `PSC_REPO_ROOT`。
+
+    這正是事故現場的形狀：daemon 的工作目錄是 operator 的 checkout，而目標 repo
+    沒有被顯式宣告。任何「落回 cwd」的實作都會在這個 fixture 底下被抓到。
+    """
+    repo = make_fake_repo(tmp_path / "operator-checkout")
+    monkeypatch.delenv("PSC_REPO_ROOT", raising=False)
+    monkeypatch.chdir(repo)
+    return repo
+
+
+# --------------------------------------------------------------------------- #
+# 1) 路徑推斷層：相對路徑一律 fail-closed
+# --------------------------------------------------------------------------- #
+def test_infer_repo_root_rejects_relative_spec_path(cwd_repo: Path) -> None:
+    """相對 spec 路徑不得被 `resolve()` 接到 cwd 上。"""
+    with pytest.raises(RepoRootResolutionError) as excinfo:
+        autonomy._infer_repo_root(Path("specs/slice-relative.md"))
+    diagnostic = excinfo.value.diagnostic
+    assert diagnostic.reason == "spec-path-not-absolute"
+    assert diagnostic.source.startswith("autonomy._infer_repo_root")
+    # 診斷必須帶得走：source ＋ context 讓 operator 不必反推是哪條路徑寫的。
+    assert diagnostic.context["spec_path"] == "specs/slice-relative.md"
+
+
+def test_infer_repo_root_rejects_relative_spec_even_with_configured_root(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """有宣告 `PSC_REPO_ROOT` 也不放行相對路徑。
+
+    宣告了目標 repo 並不代表相對路徑就該相對它解析——`Path.resolve()` 相對的
+    始終是 cwd，不是 `PSC_REPO_ROOT`。正規化必須在進件邊界完成。
+    """
+    declared = make_fake_repo(tmp_path / "declared-repo")
+    monkeypatch.setenv("PSC_REPO_ROOT", str(declared))
+    monkeypatch.chdir(make_fake_repo(tmp_path / "operator-checkout"))
+
+    with pytest.raises(RepoRootResolutionError) as excinfo:
+        autonomy._infer_repo_root(Path("specs/slice-relative.md"))
+    assert excinfo.value.diagnostic.reason == "spec-path-not-absolute"
+
+
+def test_parse_spec_frontmatter_holds_spec_with_unresolvable_repo_root(
+    cwd_repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """掃描不炸，但這份 spec 永遠停在 `hold`＋帶 `parse_error`。
+
+    `dispatch: auto` 的 spec 只要 repo 根推不出來就不得被派工——但整輪 scan 也
+    不該因為一份壞 spec 而中斷，因此理由落成 `parse_error`。
+    """
+    spec = cwd_repo / "specs" / "slice-relative.md"
+    spec.parent.mkdir(parents=True, exist_ok=True)
+    spec.write_text(
+        "---\ndispatch: auto\nslice_id: slice-relative\nplan: docs/plan.md\n"
+        "target_branch: main\n---\n\nbody\n",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(cwd_repo)
+
+    meta = autonomy.parse_spec_frontmatter("specs/slice-relative.md")
+
+    assert meta["dispatch"] == "hold"
+    assert meta["parse_error"]["code"] == "spec-path-not-absolute"
+    assert meta["parse_error"]["field"] == "path"
+
+
+# --------------------------------------------------------------------------- #
+# 2) production 動作層：拒絕執行，且不得對 cwd repo 下任何 git 指令
+# --------------------------------------------------------------------------- #
+def test_resolve_target_base_sha_refuses_relative_spec_without_fetching(cwd_repo: Path) -> None:
+    """派工前的 `git fetch --no-tags <remote> <branch>` 必須先解析出目標 repo。"""
+    runner = RecordingGitRunner()
+    pinned_inputs = {
+        "spec_path": "specs/slice-relative.md",
+        "target_branch": "main",
+        "target_remote": "origin",
+    }
+
+    with pytest.raises(RepoRootResolutionError):
+        autonomy._resolve_target_base_sha(
+            meta={"depends_on": []},
+            pinned_inputs=pinned_inputs,
+            handoff_dir=str(cwd_repo / "handoff"),
+            git_runner=runner,
+        )
+
+    assert runner.calls == [], "解析不出 repo 根就不得執行任何 git 指令"
+
+
+def test_pin_dispatch_inputs_refuses_relative_spec_path(cwd_repo: Path) -> None:
+    """派工 pin 也走同一條推斷，同樣不得落到 cwd。"""
+    with pytest.raises(RepoRootResolutionError):
+        autonomy.pin_dispatch_inputs(
+            {
+                "slice_id": "slice-relative",
+                "path": "specs/slice-relative.md",
+                "plan": "docs/plan.md",
+                "verification": None,
+            }
+        )
+
+
+def test_ancestry_status_reports_repo_unresolved_without_touching_cwd_repo(
+    cwd_repo: Path,
+) -> None:
+    """`rev-parse` / `merge-base --is-ancestor` 這條 ancestry 判準也一併 fail-closed。"""
+    runner = RecordingGitRunner()
+    slice_row = {
+        "slice_id": "slice-relative",
+        "candidate": "b" * 40,
+        "target_branch": "main",
+        "target_remote": "origin",
+        "spec": {"path": "specs/slice-relative.md"},
+    }
+
+    summary = manager._resolve_ancestry_status(slice_row, git_runner=runner)
+
+    assert summary["status"] == "repo-unresolved"
+    assert runner.calls == []
+
+
+def test_complete_tick_relative_spec_never_fetches_from_cwd_repo(
+    cwd_repo: Path, tmp_path: Path
+) -> None:
+    """#610 事故路徑的直接回歸：相對 spec path 不得讓 tick 對 cwd repo 跑 fetch。
+
+    舊行為：`_infer_repo_root("specs/slice-x.md")` → cwd（＝ operator 的真實
+    checkout）→ `_completion_candidate_ref` 對它跑
+    `git -C <真實 checkout> fetch --no-tags origin main`，而該 repo 的 origin
+    是真的 github.com。
+    """
+    runner = RecordingGitRunner()
+    registry = JobRegistry(state_path=tmp_path / "jobs.json")
+    builder_job = registry.create_job(
+        task="slice-relative",
+        persona="builder",
+        branch="feature/slice-relative",
+        pane="",
+        worktree=str(tmp_path / "wt" / "feature-slice-relative"),
+    )
+    registry.update_headless_result(builder_job["job_id"], status="exited", exit_code=0)
+    registry.create_slice(
+        slice_id="slice-relative",
+        spec_path="specs/slice-relative.md",  # ← 相對路徑：事故的進件形狀
+        spec_hash="0" * 64,
+        plan_path="plans/slice-relative.md",
+        plan_hash="1" * 64,
+        target_branch="main",
+        builder_job_id=builder_job["job_id"],
+        reviewer_job_id=None,
+        candidate=None,
+    )
+
+    handoff_dir = tmp_path / "handoff"
+    dispatcher = Dispatcher(registry, pane_sender=MagicMock(), worktree_creator=MagicMock())
+
+    summary = manager.complete_tick(
+        dispatcher,
+        handoff_dir=str(handoff_dir),
+        git_runner=runner,
+        clock=lambda: "T0",
+    )
+
+    # 一條 git 都不該打出去，更不可能打到 cwd 的 repo。
+    assert str(cwd_repo) not in runner.targets()
+    assert all("fetch" not in argv for argv in runner.calls)
+    # 理由要留在 tick 的錯誤通道上，而不是靜默完成。
+    assert summary["errors"], "repo 根解析失敗必須進 errors，而不是靜默略過"
+    assert any("spec-path-not-absolute" in str(entry) for entry in summary["errors"])
+    # 也不得寫出任何終局 manifest——那份 manifest 的內容會是對錯 repo 的觀測。
+    assert not (handoff_dir / "slice-relative.json").exists()
+
+
+# --------------------------------------------------------------------------- #
+# 3) 路徑契約層：未宣告 `PSC_REPO_ROOT` 時，git seam 與 worktree 建立都 fail-closed
+# --------------------------------------------------------------------------- #
+def test_default_git_runner_fails_closed_without_declared_repo_root(cwd_repo: Path) -> None:
+    """dispatcher 的預設 git seam 是 `git -C paths.repo_root() ...`。
+
+    未宣告目標 repo 時它以前會在 cwd 上執行——這裡釘死它必須拒絕。
+    """
+    with pytest.raises(paths.RepoRootUnresolvedError):
+        dispatcher_mod._default_git_runner(["rev-parse", "HEAD"])
+
+
+def test_worktree_creator_fails_closed_without_declared_repo_root(cwd_repo: Path) -> None:
+    """worktree 建立是**寫入**動作，落在錯的 repo 就是事故而不只是誤讀。"""
+    with pytest.raises(paths.RepoRootUnresolvedError):
+        seams.ScriptWorktreeCreator()
+
+
+def test_trusted_repo_root_resolution_does_not_fall_back_to_cwd(cwd_repo: Path) -> None:
+    """`work` lane 的 owner/name → repo 根解析同樣不得把 cwd 當候選。"""
+    from paulsha_cortex.coordinator import work_bridge
+
+    with pytest.raises(ValueError, match="trusted repo registry"):
+        work_bridge.resolve_trusted_repo_root("example/acme")
+
+
+# --------------------------------------------------------------------------- #
+# 4) 顯式路徑仍照常運作（fail-closed 不得誤殺正常流程）
+# --------------------------------------------------------------------------- #
+def test_absolute_spec_inside_declared_repo_still_resolves(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    declared = make_fake_repo(tmp_path / "declared-repo")
+    spec = declared / "specs" / "slice-ok.md"
+    spec.parent.mkdir(parents=True, exist_ok=True)
+    spec.write_text("# ok\n", encoding="utf-8")
+    monkeypatch.setenv("PSC_REPO_ROOT", str(declared))
+    monkeypatch.chdir(make_fake_repo(tmp_path / "operator-checkout"))
+
+    assert autonomy._infer_repo_root(spec) == declared
+
+
+def test_absolute_spec_in_foreign_repo_resolves_to_that_repo(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """跨 repo 派工（#469）不受影響：spec 所屬的 repo 仍優先於宣告值。"""
+    foreign = make_fake_repo(tmp_path / "foreign-repo")
+    spec = foreign / "specs" / "slice-foreign.md"
+    spec.parent.mkdir(parents=True, exist_ok=True)
+    spec.write_text("# foreign\n", encoding="utf-8")
+    monkeypatch.setenv("PSC_REPO_ROOT", str(make_fake_repo(tmp_path / "declared-repo")))
+    monkeypatch.chdir(make_fake_repo(tmp_path / "operator-checkout"))
+
+    assert autonomy._infer_repo_root(spec) == foreign
+
+
+def test_complete_tick_with_absolute_spec_still_writes_manifest(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """對照組：同一條 tick，spec 路徑改成絕對就照常走完並落 manifest。"""
+    repo = make_fake_repo(tmp_path / "declared-repo")
+    monkeypatch.setenv("PSC_REPO_ROOT", str(repo))
+    runner = RecordingGitRunner()
+    registry = JobRegistry(state_path=tmp_path / "jobs.json")
+    builder_job = registry.create_job(
+        task="slice-abs",
+        persona="builder",
+        branch="feature/slice-abs",
+        pane="",
+        worktree=str(tmp_path / "wt" / "feature-slice-abs"),
+    )
+    registry.update_headless_result(builder_job["job_id"], status="failed", exit_code=1)
+    registry.create_slice(
+        slice_id="slice-abs",
+        spec_path=str(repo / "specs" / "slice-abs.md"),
+        spec_hash="0" * 64,
+        plan_path=str(repo / "plans" / "slice-abs.md"),
+        plan_hash="1" * 64,
+        target_branch="main",
+        builder_job_id=builder_job["job_id"],
+        reviewer_job_id=None,
+        candidate=None,
+    )
+
+    handoff_dir = tmp_path / "handoff"
+    dispatcher = Dispatcher(registry, pane_sender=MagicMock(), worktree_creator=MagicMock())
+
+    summary = manager.complete_tick(
+        dispatcher,
+        handoff_dir=str(handoff_dir),
+        git_runner=runner,
+        clock=lambda: "T0",
+    )
+
+    assert summary["errors"] == []
+    manifest = json.loads((handoff_dir / "slice-abs.json").read_text(encoding="utf-8"))
+    assert manifest["slice_id"] == "slice-abs"
+    # 任何 git 目標都必須是宣告的 repo（或 job 自己的 worktree），不得是 cwd。
+    for target in runner.targets():
+        assert target.startswith(str(tmp_path)), target


### PR DESCRIPTION
Closes #612

## 問題

`paths.repo_root()` 舊實作是 `_resolve_root("PSC_REPO_ROOT", Path.cwd())`，而 manager daemon 的 `WorkingDirectory` 正是 operator 的真實 cortex checkout。於是「解析不出目標 repo」在這個系統裡**不是失敗，是靜默打在錯的樹上**：

- `autonomy._infer_repo_root` 對**相對** spec 路徑做 `Path.resolve()`，相對的永遠是 cwd；
- 就算走不到那裡，`paths.repo_root()` 的 cwd 預設也讓第一段 `resolved_spec.relative_to(configured)` 早退命中同一個 checkout。

#565／#607 收掉了 `/tmp` 那半，cwd 這半留到本 PR。#610 實測到的形態是 `manager.complete_tick → _completion_candidate_ref` 對 operator 的真實 repo 跑 `git fetch --no-tags origin main`（因此打到真實 github.com）；#611 只修了測試層，明確保留 production 面。

#623 讓這條更緊：trust-root Phase 2b 的 Manager unit 帶 `ProtectHome=yes`，repo 源碼樹將遷入 Manager-owned 樹，任何「落回 cwd 或 operator checkout」的解析都會變成**無聲的錯誤目標**。本 PR 的修法與該方向相容——唯一的目標來源只剩顯式的 `PSC_REPO_ROOT` 或顯式的絕對 spec 路徑，樹搬到哪裡都不影響。

## 完整危險呼叫路徑清單

issue 只點名了 `git fetch`。實際清點出九條，其中**三條有寫入語意**：

| 路徑 | 動作 | 語意 |
| --- | --- | --- |
| `manager.complete_tick → _completion_candidate_ref` | `git fetch --no-tags <remote> <branch>`、`rev-parse`、`merge-base --is-ancestor` | 讀（#610 實測打到真實 github.com） |
| `autonomy.dispatch_ready → _resolve_target_base_sha` | 同上 fetch ＋ 相依 candidate 的 `merge-base` | 讀，結果被 pin 進 job 的 `dispatch_base` |
| `manager._resolve_ancestry_status` | `rev-parse` ＋ `merge-base --is-ancestor` | 讀，決定 slice 是否算 merged |
| `manager.complete_tick → _candidate_for_evidence`（slice row 缺席時） | `git rev-parse <branch>` | 讀，**錯的 SHA 會被寫成 candidate 進 handoff manifest** |
| `manager.apply_slice_action(recover-pre-candidate) → worktree_reclaim` | `git worktree list --porcelain` → `git worktree remove --force` → `git worktree prune` | **寫** |
| `seams.ScriptWorktreeCreator()`（`repo=None`） | `git worktree add`／branch 建立 | **寫** |
| `deploy.installer.render_units()` | 把 `<repo_root>` 代進 systemd unit 的 `WorkingDirectory=` | **寫**（錯的目標被持久化進 unit） |
| `manager` retry-verify／retry-review、`complete_tick` 的 dirty-worktree 重驗 | verification／review runner 的整組 git 操作 | 讀寫混合 |
| `work_bridge.resolve_trusted_repo_root` | owner/name → repo 根解析把 cwd 收進候選 | 決定後續所有 lane 動作的目標 |

issue 說「fetch 是良性的，但同路徑家族若有寫入動作就是事故」——`worktree_reclaim` 就是那個實例，而且它是 operator 按 `recover-pre-candidate` 就會走到的路徑。

## 修法：fail-closed 取代 silent fallback

**`config/paths.py`**
- 新增 `RepoRootUnresolvedError`。
- 新增 `configured_repo_root() -> Path | None`：只回宣告值，未宣告回 `None`。舊介面把「沒宣告」與「宣告成當下目錄」壓成同一個 `Path`，呼叫端因此無從 fail-closed；把這個資訊獨立出來是整個修法的前提。
- `repo_root()` → `repo_root(*, allow_cwd: bool = False)`：未宣告 `PSC_REPO_ROOT` 即拋例外。`worktree_root()` 同步透傳。
- cwd 語意**仍然可用，但必須顯式**：只有兩個 operator 手動 CLI 帶 `allow_cwd=True`——`cortex work gc`（`--repo-root` 仍優先）與 `cortex deck compile`（只讀 `.project-policy.yml` 產 verification skeleton，無 git mutation）。daemon 側一律不帶。

**`coordinator/autonomy.py`**
- 新增 `RepoRootResolutionError`（繼承 `ValueError` 以沿用既有處置面：`complete_tick` 的 per-job `except`、work action 的 `ValueError` 出口、daemon 的 tick isolation #246），攜帶 #570／#527 的 `DiagnosticReason`。
- `_infer_repo_root` **拒收相對 spec 路徑**（`spec-path-not-absolute`）——路徑正規化該在進件邊界完成，這是 issue 傾向的方案 (a)。
- 改讀 `configured_repo_root()`，cwd 不再經由「configured 的預設值」偷渡。
- 向上找不到 git repo 根、又未宣告 `PSC_REPO_ROOT` 時 fail-closed（`repo-root-unresolved`），**不再回 `spec.parent`**。理由不只是「那是猜的」：`git -C <spec.parent>` 會自己向上走，於是它會走回一個被 #565 的搜尋上界（`/tmp`）或名稱規則（`~/.agents`）**刻意排除掉**的 repo——那條 fallback 等於繞過 #565 的保護。
- `parse_spec_frontmatter` 把該例外落成 `parse_error`：掃描不中斷（一份壞 spec 不該炸掉整輪），但該 spec 的 `dispatch` 永遠停在 `hold`，理由由 `DiagnosticReason` 帶著走。

**`coordinator/manager.py`**
- 新增 `_repo_root_for_slice_row()` 作為單一推導點，移除三處 `Path.cwd().resolve()` 退路（slice row 缺席、dirty-worktree 重驗、以及該處的 `except Exception` 退路）。沒有 slice row 時退回 `paths.repo_root()`——它本身已 fail-closed，因此結局只有「顯式宣告的目標」或「例外」，沒有第三種。
- `_resolve_ancestry_status` 改回既有的 `repo-unresolved` 狀態；`_repo_root_for_slice`（相依判定）推不出時回 `None`，走既有的「無 repo 可查」分支。

**`coordinator/work_bridge.py`**：`resolve_trusted_repo_root` 的候選只收顯式宣告的 repo 根；沒宣告就不進候選，由既有的「必須恰好命中一個」檢查 fail-closed。

## 不變式測試

新增 `tests/test_repo_root_fail_closed_612.py`（13 測試）。每個測試都把 **cwd 設成一個真的 git repo**（重演 daemon 在 operator checkout 裡跑的形狀），然後斷言 production 動作拒絕執行**且沒有任何 git 指令打向那個 cwd repo**：

- `_infer_repo_root` 對相對路徑 fail-closed（含「有宣告 `PSC_REPO_ROOT` 也不放行」——`resolve()` 相對的始終是 cwd，不是宣告值）；
- `parse_spec_frontmatter` 讓該 spec 停在 `hold` ＋ `parse_error`；
- `_resolve_target_base_sha`／`pin_dispatch_inputs`／`_resolve_ancestry_status` 拒絕執行且**零 git 呼叫**；
- **`complete_tick` 對 #610 事故路徑的直接回歸**：相對 spec path → 零 git 呼叫、零 handoff manifest、理由進 `summary["errors"]`；
- `dispatcher._default_git_runner`／`ScriptWorktreeCreator()`／`resolve_trusted_repo_root` 在未宣告時 fail-closed；
- 三組**對照組**確認 fail-closed 沒有誤殺正常流程（宣告 repo 內的絕對 spec、跨 repo 的絕對 spec、以及同一條 tick 改用絕對路徑後照常落 manifest）。

反向驗證：把 cwd 通道暫時塞回 production 程式後重跑本檔，7 個測試轉紅，其中旗艦那條逐字顯示 `git -C <cwd repo>` 真的被打出去。

## 測試套件暴露出的非 hermetic 問題

修完 production 側後全套 100 個測試轉紅。逐一查證，**沒有一個是誤殺**——它們全都是「測試實際上在 operator 的真 repo 上動作」：

1. **`tests/conftest.py` 的 `_clear_runtime_env` 從未涵蓋 `PSC_REPO_ROOT`。** 那個 fixture 的存在理由（#303）逐字就是「不讓忘了隔離的測試碰 operator 的真實狀態」，但它只處理了 `PSC_AGENTS_ROOT` 家族與 `PSC_CONFIG_ROOT`；`PSC_REPO_ROOT` 漏掉，於是全套 3400+ 測試的 manager 目標 repo 一直是**跑 pytest 的當下目錄**。這正是 #610 那起實網事故的結構性成因。比照既有處理改指向 per-test 暫存路徑後，90 個轉綠——也就是說它們原本的綠**完全是靠 cwd 剛好是一個 repo**。
2. `test_pre_candidate_recovery.py::test_recover_pre_candidate_supersedes_stale_handoff_manifest` 與 `test_record_action_atomic_382.py::…test_recover_pre_candidate_cleanly_resets_failed_failed_slice`：實際在 operator 的真 checkout 上跑 `git worktree list --porcelain`（同函式再走一步就是 `worktree remove --force`／`prune`）。改成自備 tmp repo 並顯式宣告。
3. `test_porcelain_init_sample.py::test_init_sample_routes_before_coordinator_and_prints_hold_checklist`：讀的是 operator 真 checkout 的 `.project-policy.yml`，測試綠不綠取決於在哪個目錄跑 pytest。改成自備最小 policy fixture。
4. `test_paths.py::test_repo_root_env_then_cwd` 與 `test_fix_dispatch_spec_path.py` 的三個 fallback 斷言：直接斷言舊的危險預設，改寫成 fail-closed 斷言（`#565` 那三條的**意圖**（污染點不是 repo 根）逐字保留，只是結局從「落到 fallback」變成「拒絕」）。

**沒有為了讓測試綠而保留任何危險預設**：production 側零 cwd 通道，測試側的 `PSC_REPO_ROOT` 指向 per-test 暫存路徑（不是 cwd、不是真 repo），需要驗「未宣告」行為的測試一律顯式 `delenv`。

## 驗證

- `python3 -m pytest tests/ -q` → **3467 passed, 49 subtests passed**，零回歸。
- `python3 -m policy_check --repo . --pr-title … --pr-body … --pr-base-ref main --pr-head-ref feature/612-repo-root-fail-closed` → **fail: 0**。

## 避開的並行工作

未觸碰 `paulsha_cortex/trust_root/permgen.py`（#620／#622）、`docs/superpowers/runbooks/trust-root-phase2b-setup.md`（#621），也未觸碰 gate ledger／exit sentinel 相關的 coordinator 程式（#604）。`coordinator/manager.py` 的變動集中在 repo root 推導（`_repo_root_for_slice_row`／`_resolve_ancestry_status`／`_repo_root_for_slice`），與 #604 的 job accounting 無重疊。

## Checklist

- [x] 從 `main` 開 `feature/612-repo-root-fail-closed` 分支
- [x] `changelog.d/repo-root-fail-closed.md` fragment 已新增且已 commit
- [x] `CHANGELOG.md [Unreleased]` 已補對應 entry
- [x] 文件與 PR 一律 zh-tw
- [x] `python3 -m pytest tests/ -q` 全綠、零回歸
- [x] `python3 -m policy_check` 帶 PR 上下文跑，fail: 0
- [x] docs 同步（README 路徑契約段補 fail-closed 語意；兩份既有 spec/design 的過時 cwd 敘述加註更正）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E7w9kaUxAzCCEk7piD5hfK
