### PR TITLE
fix(tests): AF_UNIX socket 路徑改掛短固定根，長 TMPDIR 不再偽造 gate 失敗

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,25 @@
   `tests/test_trust_root_job_template_ab.py`（80 測試）。
 
 ### Fixed
+- **#608 / ledger gate 環境健壯性（#565、#586 同族第三例）：AF_UNIX socket 路徑不再
+  吃 `TMPDIR` 長度，長暫存根無法再偽造出一筆 gate 失敗**——Linux 的 `sun_path` 只有
+  108 bytes（含結尾 NUL，可用 107），而 pytest `tmp_path` 與 `tempfile.mkdtemp()` 都
+  掛在 `TMPDIR` 下，socket 路徑長度因此由環境決定。實測 `origin/main`：`len(TMPDIR)`
+  ＝47 時全套 **4 failed**、66 時 **18 failed**、91 時全綠但 AF_UNIX 家族 **36 測
+  靜默 skip**（#586 探針自己也建在 `TMPDIR` 下，先超限 → `bind()` 失敗 → 被誤判成
+  「sandbox 禁止 bind」，覆蓋消失而套件是綠的）。Manager gate ledger 對 candidate
+  重跑全套 pytest 是採信的硬 gate（#540），那些 `failed` 進 ledger 後與「交付真的
+  沒過」無法區分，合格 candidate 會被 `GateContradictionError` 拒掉。主修法比照 #565
+  的 `tests/git_fixtures.py`：新增 `tests/socket_fixtures.py`（短固定根 ＋ per-uid
+  `0700` 容器 ＋ 短亂數名目錄，與 `TMPDIR` 無關）與 conftest 的 `socket_dir` fixture，
+  五個測試檔的 bind／connect 路徑改用它，工作區與快照仍留在 `tmp_path`。次修法：新增
+  `paulsha_cortex/monitor/socket_path.py` 收攏 107／108 常數與 byte 級判定，
+  `MonitorServer.serve_forever()`／`MonitorSocketClient.request()` 超限時 fail closed
+  在 `SocketPathTooLongError`（`ValueError` 子類，刻意不繼承 `OSError` 以免被
+  「transport 出事」的處理吸收），另補 `MonitorServer.startup_error` 與 `cortex doctor`
+  在 live probe 前的長度診斷。刻意不改用抽象命名空間——它沒有權限位、會打開現行
+  `chmod 0o600` 的 socket，且仍吃同一條 108 bytes 上限。
+  詳見 `changelog.d/afunix-sunpath-hermetic.md`。
 - **#604 / trust-root：gate ledger 與 exit sentinel 的作者收斂到 Manager——降權後
   「被隔離的一方自寫驗收證據」的第一步修法**——登記表資產 `gate-ledger`（Manager 的
   dispatch log 目錄，同時放 `<slice>.gates.json` 與 `<slice>.exit`）宣告

--- a/README.md
+++ b/README.md
@@ -767,6 +767,20 @@ export PSC_DIGEST_DELIVERY_CMD='/path/to/relay-script --channel ops'
   需要 remote 的測試一律用本機 fixture（`git_origin` 造 tmp bare origin，或注入假
   provider／runner）。本機除錯要放行整場用 `PSC_TEST_ALLOW_NETWORK=1`；本質上需要網路的
   整合測試標 `@pytest.mark.network`（預設排除於全套，`--run-network` 才跑）。
+- **AF_UNIX socket 路徑不得掛在 `TMPDIR` 下（#608）**：Linux 的 `sun_path` 只有 108
+  bytes（含結尾 NUL，可用 107），而 `tmp_path`／`tempfile.mkdtemp()` 的長度由環境給。
+  凡是要 `bind()`／`connect()` 的路徑一律取自 `tests/socket_fixtures.py` 的短固定根
+  （pytest 用 conftest 的 `socket_dir` fixture，`unittest.TestCase` 用
+  `make_short_socket_dir()`）；工作區、設定檔、快照沒有長度上限，照舊留在 `tmp_path`。
+  production 端由 `paulsha_cortex/monitor/socket_path.py` 統一判定，超限時 fail closed
+  在 `SocketPathTooLongError` 並附 byte 數，不退化成「服務沒起來」或「socket 沒在聽」。
+- **ledger gate 環境健壯性（#565 / #586 / #608 / #610 同族，一律 P1）**：Manager 的 gate
+  ledger 對 candidate 重跑全套 pytest 是採信的硬 gate（#540），因此凡是「全套 pytest 的
+  結果會隨 host 環境形狀改變」的測試，污染的都是**採信判斷**——環境噪音會被讀成「這次
+  交付真的沒過」，讓合格 candidate 撞上 `GateContradictionError`。發現這類測試一律比照
+  上述四例 hermetic 化：污染／環境條件由測試自備，且必須附**負控制**（同一條路徑上真正的
+  失敗仍然要被記成失敗），否則「修好了」與「什麼都判成通過」無法區分。靜默 skip 同樣算
+  失敗——覆蓋消失而套件是綠的，比紅掉更難發現。
 
 ## Version
 

--- a/changelog.d/afunix-sunpath-hermetic.md
+++ b/changelog.d/afunix-sunpath-hermetic.md
@@ -1,0 +1,57 @@
+# afunix-sunpath-hermetic
+
+- **`#608` AF_UNIX socket 路徑不再吃 `TMPDIR` 長度，長暫存根無法再偽造出一筆 gate
+  失敗**——Linux 的 `struct sockaddr_un.sun_path` 只有 108 bytes（含結尾 NUL，可用
+  107）。pytest 的 `tmp_path` 與 `tempfile.mkdtemp()` 都掛在 `TMPDIR` 底下，socket
+  路徑的長度因此是**環境給的**；CI／sandbox 給一個長暫存根就整批撞牆。實測
+  （0817，`origin/main`）：
+
+  | `len(TMPDIR)` | 全套 pytest |
+  | --- | --- |
+  | 4（`/tmp`） | 全綠 |
+  | 47 | **4 failed**（`test_monitor_work_api` 三測 ＋ `test_doctor` 一測） |
+  | 66 | **18 failed**（再加 `test_stage9_project_monitor_service` 十四測） |
+  | 91 | 全綠，但 AF_UNIX 家族 **36 測靜默 skip** |
+
+  這是 P1，理由與 #565／#586 同族：Manager gate ledger 對 candidate 重跑全套 pytest
+  是採信的硬 gate（#540），上表的 `failed` 進 ledger 之後與「這次交付真的沒過」
+  **長得一模一樣**，合格 candidate 會被 `GateContradictionError` 拒掉。最後一列更
+  陰險——#586 的 `af_unix_bind_available()` 探針自己也建在 `TMPDIR` 下，探針路徑先
+  超限，`bind()` 失敗被判成「sandbox 禁止 bind」，整個 AF_UNIX 家族帶著**不成立的
+  理由**靜默 skip：套件綠、ledger 綠、覆蓋卻是空的。
+
+  **測試 hermetic 化（主修法，比照 #565 的 `tests/git_fixtures.py`）**：新增
+  `tests/socket_fixtures.py`——`short_socket_root()` 選一個短且與 `TMPDIR` 無關的
+  固定根（`/tmp` → `/var/tmp` → `/run/user/<uid>`，各自加 per-uid 的 `0700` 容器
+  目錄），`make_short_socket_dir()`／`short_socket_dir()` 在其下開短亂數名目錄，
+  `assert_socket_path_fits()` 讓 fixture 自己壞掉時炸在「fixture 壞了」而不是某個
+  看起來像產品缺陷的 `bind()` 失敗上。conftest 另出 `socket_dir` fixture。五個測試
+  檔改用它：`sandbox_support`（#586 探針）、`test_sandbox_afunix_skip_586`（ground
+  truth）、`test_monitor_work_api`、`test_doctor`、
+  `test_stage9_project_monitor_service`。**只有要 bind／connect 的路徑搬家**；
+  工作區、設定檔、快照沒有長度上限，照舊留在 `tmp_path`。
+
+  **production fail-closed（次修法）**：新增
+  `paulsha_cortex/monitor/socket_path.py` 收攏 107／108 這兩個常數與判定
+  （`socket_path_length()` 以 **byte** 計，非字元——中文目錄名下用字元數會低估）。
+  `MonitorServer.serve_forever()`、`MonitorSocketClient.request()` 在碰檔案系統前
+  先驗，超限時 raise `SocketPathTooLongError`（附實際 byte 數、上限、超出量、路徑
+  與該調哪個環境旋鈕），取代一句沒有出處的 `OSError: AF_UNIX path too long`；該
+  例外刻意繼承 `ValueError` 而**非** `OSError`，否則會被呼叫端既有的「transport
+  出事」處理吸收，重新變回無法區分的症狀。`MonitorServer.startup_error` 讓 threaded
+  呼叫端不再只看到 `wait_until_ready()` 的空 `False`。`cortex doctor` 的
+  `monitor-socket` probe 在 live probe **之前**先量長度，直接說出「超過 sun_path
+  上限」而不是「socket is not listening」。
+
+  **不改用抽象命名空間**（`\0` 前綴）：抽象 socket 沒有權限位，會把現行
+  `chmod 0o600` 的 monitor socket 對整個 network namespace 打開；`server` 的
+  stale-socket 回收、`live monitor already listening` 偵測與 teardown identity 比對
+  也全建立在「socket 是一個檔案」上；而且它**仍然**吃 108 bytes 上限，只是換個地方
+  踩。
+
+  新增 `tests/test_afunix_sun_path_608.py`（16 測）四層釘死：常數與 byte 計算契約、
+  fixture 對敵意 `TMPDIR` 免疫、production 超限時 fail closed 且說得出原因、以及
+  **核心不變式**——以敵意長 `TMPDIR` 走 production 的 `gate_ledger.write_gate_ledger()`
+  重跑那四個原本必紅的測試，ledger 必須記成 `passed`；並附**負控制**：同一條 ledger
+  路徑上真正失敗的 gate 仍然記成 `failed`，證明「環境失敗與交付失敗可區分」不是靠
+  「什麼都記成 passed」作弊得來的。

--- a/paulsha_cortex/doctor.py
+++ b/paulsha_cortex/doctor.py
@@ -16,6 +16,7 @@ from urllib.parse import quote
 from unittest.mock import patch
 
 from .github_rate_limit import is_rate_limit_signal
+from .monitor.socket_path import socket_path_fits, socket_path_limit_detail
 
 DOCTOR_SCHEMA = "cortex-doctor/v1"
 AUTO_LABEL = "cortex:auto-on-going"
@@ -993,6 +994,17 @@ def _monitor_path_probes(
     run_root = socket_path.parent
     if not socket_path.is_absolute():
         monitor_socket = ProbeResult("monitor-socket", "fail", "monitor socket root must be absolute", True)
+    elif not socket_path_fits(socket_path):
+        # #608：`sun_path` 只有 108 bytes。超限時 bind/connect 會失敗成一句
+        # 沒有數字的 `OSError`，在 live probe 下會被記成「socket 沒在聽」——
+        # 與「monitor 根本沒跑」無法區分。在 live probe 之前先量，讓 doctor
+        # 直接說出這是路徑長度的環境限制，附實際 byte 數。
+        monitor_socket = ProbeResult(
+            "monitor-socket",
+            "fail",
+            socket_path_limit_detail(socket_path, role="monitor socket"),
+            True,
+        )
     elif not _root_is_creatable(run_root):
         monitor_socket = ProbeResult("monitor-socket", "fail", "monitor socket root is not writable/creatable", True)
     elif not live:

--- a/paulsha_cortex/monitor/server.py
+++ b/paulsha_cortex/monitor/server.py
@@ -43,6 +43,7 @@ from pathlib import Path
 from typing import Iterable
 
 from .snapshot import ChangeEvent, SnapshotStore
+from .socket_path import SocketPathTooLongError, validate_socket_path
 from .work_api import (
     WORK_API_SCHEMA,
     AmbiguousWorkItemError,
@@ -111,8 +112,22 @@ class MonitorServer:
         self._connection_threads: list[threading.Thread] = []
         self._connection_threads_lock = threading.Lock()
         self._serve_thread: threading.Thread | None = None
+        self._startup_error: BaseException | None = None
 
     # --- lifecycle ---
+
+    @property
+    def startup_error(self) -> BaseException | None:
+        """`serve_forever` 為何沒能開始服務；還沒失敗過則為 ``None``。
+
+        #608：`serve_forever` 常被丟進背景 thread 跑，此時它 raise 的東西不會回到
+        呼叫端——呼叫端只看到 `wait_until_ready()` 回 ``False``，一個「沒起來」的
+        空結果。socket 路徑超過 `sun_path` 上限正是會走這條路的環境失敗，而
+        「環境不合格」與「服務有缺陷」在那個空結果上完全分不出來。把原因留在這裡，
+        threaded 的呼叫端就能指名道姓地說出是哪一種。
+        """
+
+        return self._startup_error
 
     def _prepare_socket_path(self) -> None:
         if not self._socket_path.exists():
@@ -149,6 +164,17 @@ class MonitorServer:
         # Atomic bind + permission tightening.
         if self._stop_event.is_set():
             return
+        # #608: check `sun_path` *before* touching the filesystem. `bind()` would
+        # otherwise raise a bare `OSError("AF_UNIX path too long")` — no byte
+        # count, no limit, no remediation — after having already created the run
+        # directory. Fail closed on a named error that says which environment
+        # knob is at fault, so an over-long PSC_RUN_ROOT can never be mistaken
+        # for a defect in the service.
+        try:
+            validate_socket_path(self._socket_path, role="monitor socket")
+        except SocketPathTooLongError as exc:
+            self._startup_error = exc
+            raise
         self._socket_path.parent.mkdir(parents=True, exist_ok=True)
         listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         bound = False

--- a/paulsha_cortex/monitor/socket_path.py
+++ b/paulsha_cortex/monitor/socket_path.py
@@ -1,0 +1,129 @@
+"""AF_UNIX socket 路徑長度契約（#608）。
+
+## 為什麼需要一個模組
+
+`struct sockaddr_un` 的 `sun_path` 在 Linux 上是 **108 bytes 的固定陣列**（見
+`sys/un.h`），其中最後一個 byte 必須留給結尾 NUL，因此**可用路徑上限是 107
+bytes**。超過時 `bind()` / `connect()` 直接失敗，CPython 把它翻成一句沒有數字、
+沒有路徑、也沒有出處的 ``OSError: AF_UNIX path too long``。
+
+這條上限是**環境形狀**（`TMPDIR`、`PSC_RUN_ROOT` 有多長）決定的，不是程式對錯
+決定的。而 manager 的 gate ledger 對 candidate 重跑全套 pytest 是採信的硬 gate
+（#540）——環境形狀一旦能讓 gate 紅掉，「這次交付真的沒過」與「這台機器的暫存
+根太長」在 ledger 上就長得一模一樣，合格 candidate 會被 `GateContradictionError`
+拒絕。#565（`/tmp/.git` 污染）、#586（sandbox 擋 `bind`）之後，這是同族第三例。
+
+## 兩條防線
+
+1. **測試不碰這條線**：測試用的 socket 一律建在短固定根下（見
+   `tests/socket_fixtures.py`），與 `TMPDIR` 長度無關。環境再怎麼長，全套 pytest
+   都不會因為 `sun_path` 紅掉，因此**不可能**產生一筆看起來像 gate 失敗的 ledger
+   記錄。這是本 issue 的主修法。
+2. **真的超限時 fail closed 且說得出原因**：operator 若把 `PSC_RUN_ROOT` 設成一個
+   過長的路徑，production 仍會失敗——但要失敗在一個**指名道姓**的
+   :class:`SocketPathTooLongError` 上（附實際 byte 數、上限、超出量與路徑），而
+   不是退化成「服務起不來」「socket 沒在聽」這種與缺陷混淆的症狀。
+
+## 為什麼不用 abstract namespace
+
+Linux 的抽象命名空間（`sun_path` 以 `\\0` 開頭）確實不吃檔案系統路徑長度，issue
+裡也點名了這個選項，但本 repo **刻意不採用**：
+
+* 抽象 socket 不是檔案系統物件，**沒有任何權限位**。monitor socket 現在是
+  `chmod 0o600`（見 `server.serve_forever`），改抽象等於把它對同 network
+  namespace 內的所有行程開放——這是安全退步，不是環境健壯化。
+* `server` 既有的 stale-socket 回收、`live monitor already listening` 偵測、
+  teardown 時的 identity 比對 unlink，全都建立在「socket 是一個檔案」上。
+* 抽象 socket **仍然**吃 108 bytes 的上限，只是不吃路徑長度；它並沒有真的移除
+  這條契約，只是換一個地方踩。
+
+因此本模組的角色是「把 108 這個常數與它的判定收在一處」，讓 production 與測試
+共用同一份真實來源，而不是各自寫死一個數字。
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+__all__ = [
+    "SUN_PATH_MAX_BYTES",
+    "SUN_PATH_MAX_USABLE_BYTES",
+    "SocketPathTooLongError",
+    "socket_path_length",
+    "socket_path_fits",
+    "socket_path_limit_detail",
+    "validate_socket_path",
+]
+
+#: `struct sockaddr_un.sun_path` 的固定長度（Linux；含結尾 NUL）。
+SUN_PATH_MAX_BYTES = 108
+
+#: 實際可用的路徑 byte 數——最後一個 byte 保留給結尾 NUL。
+SUN_PATH_MAX_USABLE_BYTES = SUN_PATH_MAX_BYTES - 1
+
+
+class SocketPathTooLongError(ValueError):
+    """AF_UNIX socket 路徑超過 `sun_path` 上限。
+
+    刻意**不**繼承 :class:`OSError`：呼叫端普遍用 ``except OSError`` 表示
+    「transport 出事了（沒在聽／連不上）」，而路徑過長是**設定／環境的前置條件
+    不成立**，兩者的處置完全不同。掛在 :class:`ValueError` 下，既有的 transport
+    錯誤處理就不會把它誤讀成「monitor 沒在跑」。
+    """
+
+
+def socket_path_length(path: str | os.PathLike[str]) -> int:
+    """回傳該路徑寫進 `sun_path` 時佔用的 **byte** 數（不含結尾 NUL）。
+
+    用 :func:`os.fsencode` 而非 ``len(str(path))``：kernel 收的是 bytes，非 ASCII
+    路徑（例如中文目錄名）一個字元可能佔 3 bytes，用字元數會低估。
+    """
+
+    return len(os.fsencode(os.fspath(path)))
+
+
+def socket_path_fits(path: str | os.PathLike[str]) -> bool:
+    """該路徑是否塞得進 `sun_path`（含結尾 NUL）。"""
+
+    return socket_path_length(path) <= SUN_PATH_MAX_USABLE_BYTES
+
+
+def socket_path_limit_detail(
+    path: str | os.PathLike[str],
+    *,
+    role: str = "AF_UNIX socket",
+) -> str:
+    """回傳一句可直接放進錯誤訊息／doctor detail 的診斷。
+
+    刻意把「實際幾 bytes、上限幾 bytes、超出幾 bytes、哪一段太長」全部寫出來：
+    讀到這句話的人（或 agent）不必再自己量一次，就能判斷這是環境問題而非缺陷。
+    """
+
+    actual = socket_path_length(path)
+    excess = actual - SUN_PATH_MAX_USABLE_BYTES
+    return (
+        f"{role} path exceeds the AF_UNIX sun_path limit: {actual} bytes > "
+        f"{SUN_PATH_MAX_USABLE_BYTES} usable bytes (sun_path is "
+        f"{SUN_PATH_MAX_BYTES} bytes including the trailing NUL); "
+        f"{excess} bytes too long. path={os.fspath(path)!s} "
+        "— this is an environment/configuration limit, not a defect in the "
+        "code under test; shorten the socket root (PSC_RUN_ROOT / TMPDIR). "
+        "See issue #608."
+    )
+
+
+def validate_socket_path(
+    path: str | os.PathLike[str],
+    *,
+    role: str = "AF_UNIX socket",
+) -> Path:
+    """路徑塞得下就原樣回傳，塞不下就 raise :class:`SocketPathTooLongError`。
+
+    fail closed 的理由見模組 docstring：超限時**不得**降級成「靜默不啟動」或
+    「連不上」，那正是會被誤記成交付失敗的形狀。
+    """
+
+    if not socket_path_fits(path):
+        raise SocketPathTooLongError(socket_path_limit_detail(path, role=role))
+    return Path(path)

--- a/paulsha_cortex/monitor/work_api.py
+++ b/paulsha_cortex/monitor/work_api.py
@@ -25,6 +25,7 @@ from .providers import (
     RepoWorkProvider,
     WorkflowRegistryProvider,
 )
+from .socket_path import validate_socket_path
 from ..coordinator.terminal_contract import MAX_SCHEMA_RETRIES as SCHEMA_RETRY_LIMIT
 from .work_models import ProviderSnapshot
 from .work_models import WorkItem
@@ -392,6 +393,13 @@ class MonitorSocketClient:
         self.timeout = timeout
 
     def request(self, payload: Mapping) -> dict:
+        # #608: an over-long socket path makes `connect()` raise a bare
+        # `OSError("AF_UNIX path too long")`, which every caller here treats as
+        # "the monitor is not listening" — a transport verdict for what is really
+        # an environment limit. Check first and fail closed on a named error
+        # (`SocketPathTooLongError`, a ValueError, deliberately *not* an OSError)
+        # so the two stay distinguishable.
+        validate_socket_path(self.socket_path, role="monitor socket")
         body = (json.dumps(dict(payload), ensure_ascii=False) + "\n").encode("utf-8")
         with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as client:
             client.settimeout(self.timeout)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Mapping
+from typing import Iterator, Mapping
 import os
 import shutil
 import subprocess
@@ -9,6 +9,25 @@ import subprocess
 import pytest
 
 import network_guard
+from socket_fixtures import short_socket_dir
+
+
+# --- #608：AF_UNIX socket 路徑不得吃 TMPDIR 長度 ------------------------------
+
+
+@pytest.fixture
+def socket_dir() -> "Iterator[Path]":
+    """短固定根底下的空目錄，專供要 `bind()` / `connect()` 的測試放 socket。
+
+    `tmp_path` 掛在 `TMPDIR` 下，長度由環境決定，超過 `sun_path` 的 107 bytes
+    就整批紅掉——而那種紅會被 manager 的 gate ledger 記成「交付沒過」。理由與
+    實測數據見 `tests/socket_fixtures.py` 的模組 docstring。
+
+    只把 **socket 本身**搬過來；工作區／設定檔／快照照舊留在 `tmp_path`。
+    """
+
+    with short_socket_dir(prefix="pytest") as path:
+        yield path
 
 
 # --- #610：測試不得出實網 ------------------------------------------------------

--- a/tests/sandbox_support.py
+++ b/tests/sandbox_support.py
@@ -22,6 +22,13 @@ run → pass）在源頭一致，消除 envelope/ledger 分歧。正常環境／
 
 安全邊界：本模組**只**改變測試在「無法 bind AF_UNIX」時的判定（run vs skip），
 不放寬任何 syscall、不打開網路、不允許 builder 連上 manager 既有 socket。
+
+#608：探針本身原本建在 `tempfile.TemporaryDirectory()`（＝`TMPDIR`）底下，於是
+`TMPDIR` 一長（實測 > 70 bytes），探針路徑先撞上 `sun_path` 的 107 bytes 上限，
+`bind()` 以 `ENAMETOOLONG` 失敗，被這裡判成「sandbox 禁止 bind」——整個 AF_UNIX
+家族帶著**錯誤的理由**靜默 skip，套件是綠的但覆蓋沒了。探針因此改建在
+`socket_fixtures.short_socket_root()` 的短固定根下：它量的必須是「能不能 bind」
+這件事本身，不能被環境的路徑長度污染。
 """
 
 from __future__ import annotations
@@ -29,10 +36,10 @@ from __future__ import annotations
 import errno
 import functools
 import socket
-import tempfile
-from pathlib import Path
 
 import pytest
+
+from socket_fixtures import assert_socket_path_fits, short_socket_dir
 
 AF_UNIX_SKIP_REASON = (
     "builder sandbox forbids binding an AF_UNIX socket (bind() -> EPERM); "
@@ -52,10 +59,21 @@ def af_unix_bind_available() -> bool:
     unexpected ``OSError`` is likewise treated as unavailable so a guarded test
     skips rather than erroring in a hostile environment; a normal host binds
     cleanly and returns ``True``.
+
+    #608: the probe path lives under a short fixed root, **not** ``TMPDIR`` —
+    otherwise a long ``TMPDIR`` makes the probe itself exceed ``sun_path`` and
+    this function answers "the sandbox forbids bind" when the truth is "the
+    path was too long", silently skipping the whole AF_UNIX family for a reason
+    that is not true. Over-length is therefore asserted *before* ``bind()``
+    rather than folded into ``False``: under a root this short it can only mean
+    the fixture itself is broken, and a broken fixture must be loud. (CPython
+    rejects an over-long ``sun_path`` before the syscall, raising a bare
+    ``OSError("AF_UNIX path too long")`` with ``errno is None`` — indistinguishable
+    from a sandbox denial by errno alone, hence the explicit check.)
     """
 
-    with tempfile.TemporaryDirectory(prefix="psc-afunix-probe-") as tmp:
-        sock_path = Path(tmp) / "probe.sock"
+    with short_socket_dir(prefix="afunix") as tmp:
+        sock_path = assert_socket_path_fits(tmp / "p.sock")
         try:
             sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         except (PermissionError, OSError):

--- a/tests/socket_fixtures.py
+++ b/tests/socket_fixtures.py
@@ -1,0 +1,177 @@
+"""測試用的 AF_UNIX socket 目錄 fixture（#608）。
+
+## 問題
+
+Linux 的 `sun_path` 只有 108 bytes（含結尾 NUL，可用 107，見
+`paulsha_cortex.monitor.socket_path`）。pytest 的 `tmp_path` 與
+`tempfile.mkdtemp()` 都掛在 `TMPDIR` 底下，路徑長度因此是**環境給的**：
+
+    <TMPDIR>/pytest-of-<user>/pytest-<N>/<test-name-30-chars><M>/monitor.sock
+    └──── 環境決定 ────┘└──────────── 固定約 75 bytes ────────────┘
+
+`TMPDIR` 是 `/tmp` 時總長 79 bytes，一切正常；CI／sandbox 給一個 40～70 bytes
+的暫存根時就直接撞牆。實測（0817，本 repo `origin/main`）：
+
+| `len(TMPDIR)` | 全套 pytest 結果 |
+| --- | --- |
+| 4（`/tmp`） | 全綠 |
+| 47 | **4 failed**（`test_monitor_work_api` 三測 ＋ `test_doctor` 一測） |
+| 66 | **17 failed**（再加上 `test_stage9_project_monitor_service` 十三測） |
+| 72 | 全綠，但 AF_UNIX 家族**全部靜默 skip**（見下） |
+
+## 為什麼這是 P1
+
+manager 的 gate ledger 對 candidate 重跑全套 pytest 是採信的硬 gate（#540）。
+上表的 `failed` 進 ledger 之後，與「這次交付真的沒過」**長得一模一樣**——合格
+candidate 會被 `GateContradictionError` 拒掉。#565（`/tmp/.git` 污染）、#586
+（sandbox 擋 `bind`）之後，這是同族第三例。
+
+`len(TMPDIR) > 70` 那一列更陰險：#586 的 `af_unix_bind_available()` 探針自己也建
+在 `TMPDIR` 底下，探針路徑先超限 → `bind()` 失敗 → 被判成「sandbox 禁止 bind」→
+整個 AF_UNIX 家族帶著**錯誤的理由**靜默 skip。套件是綠的，覆蓋卻沒了。
+
+## 修法
+
+socket 一律建在**短固定根**下，與 `TMPDIR` 無關（見 `short_socket_root()`）。
+需要 socket 的測試不再用 `tmp_path` / `mkdtemp()` 當 socket 的家，環境形狀因此
+無法再讓全套 pytest 紅掉或靜默 skip。
+
+不改用抽象命名空間（`\\0` 前綴）的理由見
+`paulsha_cortex.monitor.socket_path` 的模組 docstring——抽象 socket 沒有權限位，
+會把現行 `chmod 0o600` 的 monitor socket 對整個 network namespace 打開。
+
+只有**需要 bind／connect 的路徑**該搬到這裡。同一個測試的工作區、設定檔、快照
+等等照舊留在 `tmp_path`：那些沒有長度上限，搬過來只會失去 pytest 的保留與清理。
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import secrets
+import shutil
+import tempfile
+from pathlib import Path
+from typing import Iterator
+
+from paulsha_cortex.monitor.socket_path import (
+    SUN_PATH_MAX_USABLE_BYTES,
+    socket_path_fits,
+    socket_path_length,
+)
+
+__all__ = [
+    "SOCKET_NAME_HEADROOM_BYTES",
+    "assert_socket_path_fits",
+    "make_short_socket_dir",
+    "short_socket_dir",
+    "short_socket_root",
+]
+
+#: 目錄底下還要留給 socket 檔名（含中間層）的 byte 數。
+#: 本 repo 最長的實際檔名是 `run/project-monitor.sock`（24 bytes），取 40 留餘裕。
+SOCKET_NAME_HEADROOM_BYTES = 40
+
+#: 每個測試目錄的隨機字尾長度（hex 字元數）。短到不吃預算、長到不會撞名。
+_TOKEN_HEX_BYTES = 5  # -> 10 個 hex 字元
+
+#: 候選根，依「短且穩定」排序。`/tmp` 在 Linux 上一定存在且最短；`/run/user/<uid>`
+#: 是 systemd 的 per-user runtime dir（tmpfs，正是給 socket 用的）；最後才回頭問
+#: `tempfile.gettempdir()`——它會讀 `TMPDIR`，是本模組要避開的東西，只當保底。
+_STATIC_ROOT_CANDIDATES = ("/tmp", "/var/tmp")
+
+
+def _candidate_roots() -> tuple[Path, ...]:
+    candidates = [Path(item) for item in _STATIC_ROOT_CANDIDATES]
+    try:
+        candidates.append(Path("/run/user") / str(os.getuid()))
+    except AttributeError:  # pragma: no cover - 非 POSIX
+        pass
+    # 保底：連 /tmp 都不可寫的環境還是要有東西可用，即使它可能很長。
+    candidates.append(Path(tempfile.gettempdir()))
+    return tuple(candidates)
+
+
+def _usable(root: Path) -> bool:
+    if not root.is_dir() or not os.access(root, os.W_OK | os.X_OK):
+        return False
+    # 容器目錄 + token 目錄 + 檔名都要塞得下，否則這個根等於沒用。
+    container = root / _container_name()
+    probe = container / ("0" * (_TOKEN_HEX_BYTES * 2 + 4))
+    return socket_path_length(probe) + 1 + SOCKET_NAME_HEADROOM_BYTES <= SUN_PATH_MAX_USABLE_BYTES
+
+
+def _container_name() -> str:
+    # per-uid：共用主機上不同使用者不會撞到彼此的 0o700 目錄。
+    try:
+        return f"psc-sock-{os.getuid()}"
+    except AttributeError:  # pragma: no cover - 非 POSIX
+        return "psc-sock"
+
+
+def short_socket_root() -> Path:
+    """回傳一個**短且與 `TMPDIR` 無關**的 socket 根，必要時建立它。
+
+    刻意不快取：測試會 monkeypatch `TMPDIR` 來驗證「換了環境仍然短」，快取會讓
+    那個驗證變成只在量第一次的結果。這個函式只做幾次 `stat`，不值得快取。
+    """
+
+    for root in _candidate_roots():
+        if not _usable(root):
+            continue
+        container = root / _container_name()
+        try:
+            container.mkdir(mode=0o700, parents=True, exist_ok=True)
+        except OSError:
+            continue
+        # 容器可能是別人（別的 uid、別的 umask）留下的既有目錄；不可寫就換下一個
+        # 候選，而不是等到 `mkdir` 子目錄時才炸在一個看起來像產品缺陷的地方。
+        if not os.access(container, os.W_OK | os.X_OK):
+            continue
+        return container
+    raise RuntimeError(
+        "找不到任何可用且夠短的 AF_UNIX socket 根（試過 "
+        f"{', '.join(str(item) for item in _candidate_roots())}）；"
+        f"sun_path 可用上限為 {SUN_PATH_MAX_USABLE_BYTES} bytes。見 issue #608。"
+    )
+
+
+def make_short_socket_dir(*, prefix: str = "t") -> Path:
+    """在短根底下建一個空目錄並回傳；呼叫端負責清理。
+
+    給 `unittest.TestCase` 用（搭配 `addCleanup`）。pytest 風格的測試用
+    :func:`short_socket_dir` 或 conftest 的 `socket_dir` fixture。
+    """
+
+    root = short_socket_root()
+    # prefix 只為了 `ls /tmp` 時看得出是誰留下的；截短以免吃掉預算。
+    label = "".join(ch for ch in prefix if ch.isalnum() or ch in "-_")[:8]
+    path = root / f"{label}-{secrets.token_hex(_TOKEN_HEX_BYTES)}"
+    path.mkdir(mode=0o700, parents=False, exist_ok=False)
+    return path
+
+
+@contextlib.contextmanager
+def short_socket_dir(*, prefix: str = "t") -> Iterator[Path]:
+    """:func:`make_short_socket_dir` 的 context manager 版本（結束即刪除）。"""
+
+    path = make_short_socket_dir(prefix=prefix)
+    try:
+        yield path
+    finally:
+        shutil.rmtree(path, ignore_errors=True)
+
+
+def assert_socket_path_fits(path: Path) -> Path:
+    """路徑塞不進 `sun_path` 時當場 fail，並回傳原路徑。
+
+    給測試自我檢查用：fixture 的保證一旦被某次改動破壞，要炸在「fixture 壞了」
+    這句話上，而不是炸在某個看起來像產品缺陷的 `bind()` 失敗上。
+    """
+
+    if not socket_path_fits(path):
+        raise AssertionError(
+            f"socket fixture 產生的路徑超過 sun_path 上限："
+            f"{socket_path_length(path)} > {SUN_PATH_MAX_USABLE_BYTES} bytes：{path}"
+        )
+    return path

--- a/tests/test_afunix_sun_path_608.py
+++ b/tests/test_afunix_sun_path_608.py
@@ -58,12 +58,17 @@ _REPO_ROOT = Path(__file__).resolve().parents[1]
 #: `socket_fixtures` 模組 docstring 的表）。
 _HOSTILE_TMPDIR_NAME = "psc608-hostile-" + ("a" * 32)
 
-#: 修復前會因 `sun_path` 超限而紅掉的測試（#608 內文點名三個，實測還有第四個）。
+#: 修復前會因長 `TMPDIR` 紅掉的測試。前四個是 `sun_path` 超限（#608 內文點名三個，
+#: 實測還有 `test_doctor` 的第四個）；最後一個機制不同但屬同族——拒收訊息有 400
+#: 字元上限且 evidence 絕對路徑排在最後，`TMPDIR` 一長就被截掉，測試對「完整路徑
+#: 必須出現」的斷言隨之落空。列在同一組是刻意的：ledger 不變式要守的是「環境形狀
+#: 不得偽造出 gate 失敗」，不是「socket 不得超長」。
 _FRAGILE_NODE_IDS = (
     "tests/test_monitor_work_api.py::test_socket_work_item_read_apis_and_subscription_preserve_legacy",
     "tests/test_monitor_work_api.py::test_work_subscription_can_scope_duplicate_work_id_by_repo",
     "tests/test_monitor_work_api.py::test_old_server_teardown_does_not_unlink_replacement_socket",
     "tests/test_doctor.py::test_monitor_protocol_probe_rejects_transport_only_listener",
+    "tests/test_workflow_production_wiring.py::test_planning_artifact_rejection_records_full_content_evidence",
 )
 
 

--- a/tests/test_afunix_sun_path_608.py
+++ b/tests/test_afunix_sun_path_608.py
@@ -1,0 +1,364 @@
+"""issue #608：AF_UNIX `sun_path` 108-byte 上限的環境敏感性（ledger gate 家族第三例）。
+
+家族背景：manager 的 gate ledger 對 candidate 重跑全套 pytest 是採信的硬 gate
+（#540）。凡是「全套 pytest 的結果會隨 host 環境形狀改變」的測試都是 P1——它們
+污染的是**採信判斷**，一次環境噪音就會讓合格 candidate 撞上
+`GateContradictionError`。#565（`/tmp/.git` 污染）、#586（sandbox 擋 `bind`）之後
+這是第三例：`TMPDIR` 一長，pytest `tmp_path` 底下的 socket 路徑就超過
+`sun_path` 的 107 bytes 可用上限，`bind()` 失敗。
+
+本檔釘四層：
+
+1. **常數契約**——107／108 與 byte（非字元）計算。
+2. **fixture 的保證**——`socket_fixtures` 產生的路徑與 `TMPDIR` 長度無關。
+3. **production fail-closed**——真的超限時，錯誤是指名道姓的
+   `SocketPathTooLongError`（附 byte 數），不是一句沒有出處的 `OSError`，也不是
+   「服務沒起來」「socket 沒在聽」這種與缺陷混淆的空結果。
+4. **最重要的不變式**——長 `TMPDIR` 不得在 gate ledger 上產生一筆看起來像
+   「gate 失敗」的記錄。第 4 層附**負控制**：同一條路徑上，真正失敗的 gate 仍然
+   必須記成 `failed`。沒有負控制，第 4 層可以靠「什麼都記成 passed」作弊通過。
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import threading
+from pathlib import Path
+
+import pytest
+
+from socket_fixtures import (
+    SOCKET_NAME_HEADROOM_BYTES,
+    short_socket_dir,
+    short_socket_root,
+)
+
+from paulsha_cortex.coordinator import gate_ledger
+from paulsha_cortex.doctor import _monitor_path_probes
+from paulsha_cortex.monitor.config import MonitorConfig
+from paulsha_cortex.monitor.server import MonitorServer
+from paulsha_cortex.monitor.snapshot import SnapshotStore
+from paulsha_cortex.monitor.socket_path import (
+    SUN_PATH_MAX_BYTES,
+    SUN_PATH_MAX_USABLE_BYTES,
+    SocketPathTooLongError,
+    socket_path_fits,
+    socket_path_length,
+    validate_socket_path,
+)
+from paulsha_cortex.monitor.work_api import MonitorSocketClient
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+#: 一個「CI／sandbox 給了長暫存根」的忠實模擬。長度刻意落在實測會讓
+#: `test_monitor_work_api` 三測與 `test_doctor` 一測全紅的區間（見
+#: `socket_fixtures` 模組 docstring 的表）。
+_HOSTILE_TMPDIR_NAME = "psc608-hostile-" + ("a" * 32)
+
+#: 修復前會因 `sun_path` 超限而紅掉的測試（#608 內文點名三個，實測還有第四個）。
+_FRAGILE_NODE_IDS = (
+    "tests/test_monitor_work_api.py::test_socket_work_item_read_apis_and_subscription_preserve_legacy",
+    "tests/test_monitor_work_api.py::test_work_subscription_can_scope_duplicate_work_id_by_repo",
+    "tests/test_monitor_work_api.py::test_old_server_teardown_does_not_unlink_replacement_socket",
+    "tests/test_doctor.py::test_monitor_protocol_probe_rejects_transport_only_listener",
+)
+
+
+# --- 1. 常數與計算契約 --------------------------------------------------------
+
+
+def test_sun_path_limits_are_the_kernel_numbers() -> None:
+    """108 是 `struct sockaddr_un.sun_path` 的長度，可用的是 107（最後一 byte 是 NUL）。"""
+
+    assert SUN_PATH_MAX_BYTES == 108
+    assert SUN_PATH_MAX_USABLE_BYTES == 107
+
+
+def test_length_is_counted_in_bytes_not_characters() -> None:
+    """非 ASCII 路徑一個字元不只一個 byte；kernel 收的是 bytes。
+
+    用 `len(str(path))` 會低估，剛好在中文目錄名底下把超限的路徑判成合法——
+    那正是「量錯了所以 fail-closed 沒有生效」的形狀。
+    """
+
+    path = Path("/tmp/" + "目錄" * 20)  # 40 個字元，UTF-8 下 120 bytes
+    assert len(str(path)) < SUN_PATH_MAX_USABLE_BYTES
+    assert socket_path_length(path) > SUN_PATH_MAX_USABLE_BYTES
+    assert not socket_path_fits(path)
+
+
+def test_boundary_is_inclusive_at_107_and_rejects_108() -> None:
+    fits = Path("/" + "a" * (SUN_PATH_MAX_USABLE_BYTES - 1))
+    assert socket_path_length(fits) == SUN_PATH_MAX_USABLE_BYTES
+    assert socket_path_fits(fits)
+    assert validate_socket_path(fits) == fits
+
+    over = Path("/" + "a" * SUN_PATH_MAX_USABLE_BYTES)
+    assert socket_path_length(over) == SUN_PATH_MAX_BYTES
+    assert not socket_path_fits(over)
+    with pytest.raises(SocketPathTooLongError):
+        validate_socket_path(over)
+
+
+def test_too_long_error_is_not_an_oserror() -> None:
+    """`SocketPathTooLongError` 不得被 `except OSError` 撈走。
+
+    呼叫端普遍用 `except OSError` 表示「transport 出事（沒在聽／連不上）」。路徑
+    過長是環境前置條件不成立，兩者的處置完全不同；掛在 `OSError` 下就會被既有的
+    transport 錯誤處理吸收，重新變回無法區分的症狀。
+    """
+
+    assert not issubclass(SocketPathTooLongError, OSError)
+    assert issubclass(SocketPathTooLongError, ValueError)
+
+
+def test_diagnostic_names_the_numbers_and_the_environment_knob() -> None:
+    over = Path("/tmp/" + "a" * 200)
+    with pytest.raises(SocketPathTooLongError) as excinfo:
+        validate_socket_path(over, role="monitor socket")
+    message = str(excinfo.value)
+    assert "monitor socket" in message
+    assert str(SUN_PATH_MAX_USABLE_BYTES) in message
+    assert str(socket_path_length(over)) in message
+    # 讀到訊息的人要能當場判斷「這是環境，不是缺陷」，並知道該調哪個旋鈕。
+    assert "PSC_RUN_ROOT" in message and "TMPDIR" in message
+    assert "#608" in message
+
+
+# --- 2. fixture 對 TMPDIR 免疫 ------------------------------------------------
+
+
+def test_short_socket_root_ignores_a_hostile_tmpdir(monkeypatch, tmp_path: Path) -> None:
+    """`TMPDIR` 再長，fixture 給的 socket 目錄仍然短。"""
+
+    hostile = tmp_path / _HOSTILE_TMPDIR_NAME
+    hostile.mkdir(parents=True)
+    monkeypatch.setenv("TMPDIR", str(hostile))
+    monkeypatch.setattr("tempfile.tempdir", str(hostile))
+
+    root = short_socket_root()
+    assert str(hostile) not in str(root)
+
+    with short_socket_dir(prefix="probe") as directory:
+        socket_path = directory / "project-monitor.sock"
+        assert socket_path_fits(socket_path)
+        # 還要留得下更深一層（stage9 的 `run/project-monitor.sock`）。
+        assert (
+            socket_path_length(directory) + 1 + SOCKET_NAME_HEADROOM_BYTES
+            <= SUN_PATH_MAX_USABLE_BYTES
+        )
+
+
+def test_short_socket_dirs_are_unique_and_cleaned_up() -> None:
+    with short_socket_dir(prefix="a") as first, short_socket_dir(prefix="b") as second:
+        assert first != second
+        assert first.is_dir() and second.is_dir()
+        leaked = first
+    assert not leaked.exists()
+
+
+def test_a_real_bind_succeeds_under_a_hostile_tmpdir(monkeypatch, tmp_path: Path) -> None:
+    """端到端：`TMPDIR` 惡意加長時，透過 fixture 建的 socket 仍然 bind 得起來。"""
+
+    import socket as socket_module
+
+    hostile = tmp_path / _HOSTILE_TMPDIR_NAME
+    hostile.mkdir(parents=True)
+    monkeypatch.setenv("TMPDIR", str(hostile))
+    monkeypatch.setattr("tempfile.tempdir", str(hostile))
+
+    with short_socket_dir(prefix="bind") as directory:
+        sock = socket_module.socket(socket_module.AF_UNIX, socket_module.SOCK_STREAM)
+        try:
+            sock.bind(str(directory / "p.sock"))
+        finally:
+            sock.close()
+
+
+def test_negative_control_tmpdir_rooted_socket_would_have_failed(tmp_path: Path) -> None:
+    """負控制：證明模擬的敵意環境是忠實的。
+
+    同一個長 `TMPDIR` 下，**沿用舊寫法**（socket 掛在 `tmp_path` 底下）產生的路徑
+    確實超過 `sun_path` 上限。沒有這條，上面那些「修好了」的斷言可能只是因為模擬
+    的環境根本不夠長。
+    """
+
+    old_style = tmp_path / _HOSTILE_TMPDIR_NAME / "pytest-of-user" / "pytest-1" / "monitor.sock"
+    assert not socket_path_fits(old_style)
+
+
+# --- 3. production fail closed 且說得出原因 -----------------------------------
+
+
+def _over_long_socket_path() -> Path:
+    root = short_socket_root()
+    padding = "p" * (SUN_PATH_MAX_USABLE_BYTES - socket_path_length(root))
+    path = root / padding / "monitor.sock"
+    assert not socket_path_fits(path)
+    return path
+
+
+def test_server_refuses_an_over_long_socket_path_with_a_named_error() -> None:
+    """`serve_forever` 必須 fail closed 在 `SocketPathTooLongError` 上。
+
+    修復前是 `OSError: AF_UNIX path too long`——沒有 byte 數、沒有上限、沒有路徑，
+    而且在 threaded 呼叫端只表現為 `wait_until_ready()` 回 `False`。
+    """
+
+    server = MonitorServer(
+        store=SnapshotStore(config=MonitorConfig(workspaces=())),
+        socket_path=_over_long_socket_path(),
+    )
+    with pytest.raises(SocketPathTooLongError) as excinfo:
+        server.serve_forever()
+    assert str(SUN_PATH_MAX_USABLE_BYTES) in str(excinfo.value)
+
+
+# thread 內 raise 正是本測試要驗的行為，pytest 的 unhandled-thread 警告是預期噪音。
+@pytest.mark.filterwarnings("ignore::pytest.PytestUnhandledThreadExceptionWarning")
+def test_server_records_startup_error_for_threaded_callers() -> None:
+    """背景 thread 跑 `serve_forever` 時，原因不得就這樣消失。
+
+    `wait_until_ready()` 回 `False` 對「環境不合格」與「服務有缺陷」是同一個空
+    結果；`startup_error` 是讓兩者可區分的那條線。
+    """
+
+    server = MonitorServer(
+        store=SnapshotStore(config=MonitorConfig(workspaces=())),
+        socket_path=_over_long_socket_path(),
+    )
+    assert server.startup_error is None
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    thread.join(timeout=5.0)
+
+    assert not server.wait_until_ready(timeout=0.1)
+    assert isinstance(server.startup_error, SocketPathTooLongError)
+
+
+def test_socket_client_reports_length_rather_than_a_transport_error() -> None:
+    """client 端超限時不得退化成「monitor 沒在聽」。"""
+
+    client = MonitorSocketClient(socket_path=_over_long_socket_path(), timeout=0.1)
+    with pytest.raises(SocketPathTooLongError):
+        client.request({"kind": "list_work_items"})
+
+
+def test_doctor_names_the_sun_path_limit_instead_of_not_listening(tmp_path: Path) -> None:
+    """`cortex doctor` 要在 live probe 之前就說出「路徑太長」。
+
+    否則 bind／connect 的失敗會被記成 `monitor socket is not listening`——與
+    「monitor 根本沒在跑」無法區分，排障方向直接被帶偏。
+    """
+
+    _state, monitor_socket = _monitor_path_probes(
+        state_root=tmp_path / "state",
+        socket_path=_over_long_socket_path(),
+        live=True,
+    )
+    assert monitor_socket.status == "fail"
+    assert "sun_path" in monitor_socket.detail
+    assert "not listening" not in monitor_socket.detail
+
+
+# --- 4. ledger 不變式：環境形狀不得偽造出一筆 gate 失敗 -----------------------
+
+
+def _run_gate_under_hostile_tmpdir(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    argv: str,
+) -> dict[str, object]:
+    """以敵意長 `TMPDIR` 跑一個宣告出來的 gate，回傳 manager 寫出的 ledger。
+
+    走的是 production 的 `gate_ledger.write_gate_ledger`，不是自己模擬——要驗的
+    正是「manager 實際寫進 ledger 的那份東西」。
+    """
+
+    hostile = tmp_path / _HOSTILE_TMPDIR_NAME
+    hostile.mkdir(parents=True)
+    assert len(str(hostile)) > 40, "模擬的 TMPDIR 不夠長，測試會失去意義"
+
+    monkeypatch.setenv("TMPDIR", str(hostile))
+    ledger_path = tmp_path / "gate-ledger.json"
+    env = dict(os.environ)
+    env["PSC_GATE_CMD_PYTEST"] = argv
+    env["PSC_SLICE_ID"] = "slice-608"
+
+    gate_ledger.write_gate_ledger(
+        ledger_path=ledger_path,
+        worktree=_REPO_ROOT,
+        env=env,
+    )
+    return json.loads(ledger_path.read_text(encoding="utf-8"))
+
+
+def test_long_tmpdir_cannot_manufacture_a_failed_gate_ledger_row(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """**本 issue 的核心不變式。**
+
+    以敵意長 `TMPDIR` 讓 manager 重跑修復前必紅的那四個測試，ledger 必須記成
+    `passed`。若這裡出現 `failed`，manager 會把「這台機器的暫存根太長」讀成
+    「這次交付真的沒過」，合格 candidate 撞 `GateContradictionError`——正是
+    #565／#586／#608 這一族要根除的東西。
+    """
+
+    argv = " ".join(
+        [sys.executable, "-m", "pytest", "-q", "-p", "no:randomly", *_FRAGILE_NODE_IDS]
+    )
+    ledger = _run_gate_under_hostile_tmpdir(tmp_path, monkeypatch, argv=argv)
+
+    rows = {row["name"]: row for row in ledger["gates"]}
+    assert set(rows) == {"pytest"}
+    row = rows["pytest"]
+    assert row["status"] == "passed", (
+        "長 TMPDIR 在 gate ledger 上偽造出一筆 gate 失敗（#608）：" f"{row['detail']}"
+    )
+    assert row["exit_code"] == 0
+
+
+def test_fragile_tests_run_rather_than_skip_under_a_long_tmpdir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """靜默 skip 也是失敗的一種——覆蓋沒了，而理由還是假的。
+
+    #586 的 `af_unix_bind_available()` 探針原本自己也建在 `TMPDIR` 底下：`TMPDIR`
+    夠長時探針先超限，`bind()` 失敗被判成「sandbox 禁止 bind」，整個 AF_UNIX 家族
+    帶著**不成立的理由**靜默 skip。套件綠、ledger 綠、覆蓋卻是空的。
+    """
+
+    hostile = tmp_path / _HOSTILE_TMPDIR_NAME
+    hostile.mkdir(parents=True)
+    completed = subprocess.run(
+        [sys.executable, "-m", "pytest", "-q", "-p", "no:randomly", *_FRAGILE_NODE_IDS],
+        cwd=str(_REPO_ROOT),
+        env={**os.environ, "TMPDIR": str(hostile)},
+        capture_output=True,
+        text=True,
+        timeout=600,
+    )
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+    assert f"{len(_FRAGILE_NODE_IDS)} passed" in completed.stdout
+    assert "skipped" not in completed.stdout
+
+
+def test_negative_control_a_genuinely_failing_gate_is_still_recorded_failed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """負控制：上面那條不得靠「什麼都記成 passed」作弊。
+
+    同一條 ledger 路徑、同一個敵意 `TMPDIR`，真正失敗的 gate 仍然必須是 `failed`。
+    這條與上面兩條合起來才構成「環境失敗與交付失敗可區分」的證明。
+    """
+
+    argv = f'{sys.executable} -c "import sys; sys.exit(3)"'
+    ledger = _run_gate_under_hostile_tmpdir(tmp_path, monkeypatch, argv=argv)
+
+    row = {item["name"]: item for item in ledger["gates"]}["pytest"]
+    assert row["status"] == "failed"
+    assert row["exit_code"] == 3

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import shutil
 import socket
 import subprocess
 import sys
@@ -11,6 +12,7 @@ from pathlib import Path
 import pytest
 
 from sandbox_support import requires_af_unix_bind
+from socket_fixtures import make_short_socket_dir
 
 from paulsha_cortex import cli
 from paulsha_cortex.doctor import (
@@ -34,8 +36,29 @@ class Result:
         self.stderr = stderr
 
 
+#: #608：`_layout` 在短固定根下造出來的假 home，於本模組跑完後統一清掉。
+#: 用 module-scope fixture 而非改 `_layout` 的簽章：後者要動 15 個呼叫端，而這裡
+#: 真正要保證的只有「socket 的家夠短」與「跑完不留垃圾」兩件事。
+_SHORT_HOME_ROOTS: list[Path] = []
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _cleanup_short_home_roots():
+    yield
+    for path in _SHORT_HOME_ROOTS:
+        shutil.rmtree(path, ignore_errors=True)
+    _SHORT_HOME_ROOTS.clear()
+
+
 def _layout(tmp_path: Path) -> tuple[Path, dict[str, str]]:
-    home = tmp_path / "home"
+    # #608：這個假 home 底下住著 monitor 的 AF_UNIX socket
+    # （`<home>/.agents/run/cortex/project-monitor.sock`，光固定段就 39 bytes），
+    # 吃 `sun_path` 的 107 bytes 上限。`tmp_path` 掛在 `TMPDIR` 下、長度由環境
+    # 決定，實測連預設 `/tmp` 都已經因為測試名夠長而超限（doctor 過去不量長度，
+    # 所以沒人發現）。home 因此改掛短固定根；`preflight` 與 workspace 沒有長度
+    # 上限，照舊留在 `tmp_path`。
+    home = make_short_socket_dir(prefix="doctor") / "home"
+    _SHORT_HOME_ROOTS.append(home.parent)
     agents = home / ".agents"
     preflight = tmp_path / "preflight"
     preflight.write_text("#!/bin/sh\n", encoding="utf-8")
@@ -501,8 +524,12 @@ def test_monitor_live_probe_requires_connectable_unix_socket(tmp_path: Path) -> 
 
 
 @requires_af_unix_bind
-def test_monitor_protocol_probe_rejects_transport_only_listener(tmp_path: Path, monkeypatch) -> None:
-    socket_path = tmp_path / "run" / "project-monitor.sock"
+def test_monitor_protocol_probe_rejects_transport_only_listener(
+    tmp_path: Path, socket_dir: Path, monkeypatch
+) -> None:
+    # #608：socket 走短固定根（`tmp_path` 吃 TMPDIR 長度會撞 sun_path）；
+    # state root 不 bind，照舊留在 `tmp_path`。
+    socket_path = socket_dir / "run" / "project-monitor.sock"
     socket_path.parent.mkdir()
     listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
     listener.bind(str(socket_path))

--- a/tests/test_monitor_work_api.py
+++ b/tests/test_monitor_work_api.py
@@ -202,10 +202,10 @@ def test_recv_fails_fast_when_socket_closes_before_newline():
 
 
 @requires_af_unix_bind
-def test_socket_work_item_read_apis_and_subscription_preserve_legacy(tmp_path):
+def test_socket_work_item_read_apis_and_subscription_preserve_legacy(socket_dir):
     project_store = SnapshotStore(config=MonitorConfig(workspaces=()))
     work_store = WorkReadModelStore(_snapshot(_item("active", "ongoing")))
-    socket_path = tmp_path / "monitor.sock"
+    socket_path = socket_dir / "monitor.sock"
     server = MonitorServer(
         store=project_store, work_store=work_store, socket_path=socket_path
     )
@@ -258,7 +258,7 @@ def test_socket_work_item_read_apis_and_subscription_preserve_legacy(tmp_path):
 
 
 @requires_af_unix_bind
-def test_work_subscription_can_scope_duplicate_work_id_by_repo(tmp_path):
+def test_work_subscription_can_scope_duplicate_work_id_by_repo(socket_dir):
     healthy = ProviderSnapshot(
         provider_id="github:example/acme",
         status="ok",
@@ -284,7 +284,7 @@ def test_work_subscription_can_scope_duplicate_work_id_by_repo(tmp_path):
             providers={healthy.provider_id: healthy, degraded.provider_id: degraded},
         )
     )
-    socket_path = tmp_path / "monitor.sock"
+    socket_path = socket_dir / "monitor.sock"
     server = MonitorServer(
         store=SnapshotStore(config=MonitorConfig(workspaces=())),
         work_store=work_store,
@@ -333,10 +333,10 @@ def test_work_subscription_can_scope_duplicate_work_id_by_repo(tmp_path):
 
 
 @requires_af_unix_bind
-def test_server_stopped_before_start_never_signals_ready(tmp_path):
+def test_server_stopped_before_start_never_signals_ready(socket_dir):
     server = MonitorServer(
         store=SnapshotStore(config=MonitorConfig(workspaces=())),
-        socket_path=tmp_path / "monitor.sock",
+        socket_path=socket_dir / "monitor.sock",
     )
     server.stop()
 
@@ -355,8 +355,8 @@ def test_server_stopped_before_start_never_signals_ready(tmp_path):
 
 
 @requires_af_unix_bind
-def test_old_server_teardown_does_not_unlink_replacement_socket(tmp_path):
-    socket_path = tmp_path / "monitor.sock"
+def test_old_server_teardown_does_not_unlink_replacement_socket(socket_dir):
+    socket_path = socket_dir / "monitor.sock"
     store = SnapshotStore(config=MonitorConfig(workspaces=()))
     old_server = MonitorServer(store=store, socket_path=socket_path)
     old_thread = threading.Thread(target=old_server.serve_forever, daemon=True)
@@ -398,11 +398,11 @@ def test_old_server_teardown_does_not_unlink_replacement_socket(tmp_path):
 
 
 @requires_af_unix_bind
-def test_work_subscription_extension_preserves_legacy_queue_full_replacement(tmp_path):
+def test_work_subscription_extension_preserves_legacy_queue_full_replacement(socket_dir):
     server = MonitorServer(
         store=SnapshotStore(config=MonitorConfig(workspaces=())),
         work_store=WorkReadModelStore.empty(),
-        socket_path=tmp_path / "unused.sock",
+        socket_path=socket_dir / "unused.sock",
     )
     subscriber = _Subscriber(projects=None)
     for index in range(subscriber.queue.maxsize):

--- a/tests/test_sandbox_afunix_skip_586.py
+++ b/tests/test_sandbox_afunix_skip_586.py
@@ -27,21 +27,27 @@ from unittest import mock
 
 import sandbox_support
 from sandbox_support import af_unix_bind_available
+from socket_fixtures import short_socket_dir
 
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 _TESTS_DIR = Path(__file__).resolve().parent
 
 
 def _actual_bind_capability() -> bool:
-    """Ground truth：當場真的建立並 bind 一個 AF_UNIX socket。"""
+    """Ground truth：當場真的建立並 bind 一個 AF_UNIX socket。
 
-    with tempfile.TemporaryDirectory(prefix="psc-afunix-truth-") as tmp:
+    #608：路徑走短固定根而非 `TMPDIR`。ground truth 要量的是「這個 runtime 准不准
+    我 bind」，`TMPDIR` 一長，量到的會變成「這條路徑塞不塞得進 sun_path」——那是
+    另一件事，而且會讓這個測試與 probe 一起以錯誤的理由同時說謊。
+    """
+
+    with short_socket_dir(prefix="truth") as tmp:
         try:
             sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         except OSError:
             return False
         try:
-            sock.bind(str(Path(tmp) / "truth.sock"))
+            sock.bind(str(tmp / "t.sock"))
         except OSError:
             return False
         finally:

--- a/tests/test_stage9_project_monitor_service.py
+++ b/tests/test_stage9_project_monitor_service.py
@@ -41,6 +41,7 @@ from pathlib import Path
 from unittest import mock
 
 from sandbox_support import AF_UNIX_SKIP_REASON, af_unix_bind_available
+from socket_fixtures import make_short_socket_dir
 
 # Imports from the Phase 3 modules (do not exist yet — Red).
 try:
@@ -446,6 +447,9 @@ class Stage9ServerTests(unittest.TestCase):
     def setUp(self) -> None:
         _require_phase3(self)
         self.tmp = Path(tempfile.mkdtemp(prefix="stage9-server-"))
+        # #608：只有**要 bind 的 socket** 需要躲開 TMPDIR 長度（sun_path 上限
+        # 107 bytes）；workspace／snapshot 沒有長度上限，照舊留在 self.tmp。
+        self.sock_dir = make_short_socket_dir(prefix="stage9s")
         _mkdir_resilient(self.tmp / "ws")
         _make_workspace(self.tmp / "ws", "projA", DEFAULT_TODO)
         _make_workspace(self.tmp / "ws", "projB", DEFAULT_TODO)
@@ -455,7 +459,7 @@ class Stage9ServerTests(unittest.TestCase):
         )
         self.store = SnapshotStore(config=self.cfg)
         self.store.load()
-        self.socket_path = self.tmp / "monitor.sock"
+        self.socket_path = self.sock_dir / "monitor.sock"
         self.server = MonitorServer(store=self.store, socket_path=self.socket_path)
         self.server_thread = threading.Thread(
             target=self.server.serve_forever, daemon=True
@@ -480,6 +484,7 @@ class Stage9ServerTests(unittest.TestCase):
         import shutil
 
         shutil.rmtree(self.tmp, ignore_errors=True)
+        shutil.rmtree(self.sock_dir, ignore_errors=True)
 
     def _connect(self) -> socket.socket:
         deadline = time.time() + 1.0
@@ -576,7 +581,7 @@ class Stage9ServerTests(unittest.TestCase):
             release_chmod.wait(timeout=2.0)
             return real_chmod(path, mode, **kwargs)
 
-        other_socket_path = self.tmp / "chmod-race.sock"
+        other_socket_path = self.sock_dir / "chmod-race.sock"
         server = MonitorServer(store=self.store, socket_path=other_socket_path)
         thread = threading.Thread(target=server.serve_forever, daemon=True)
         try:
@@ -627,7 +632,7 @@ class Stage9ServerTests(unittest.TestCase):
         below and issue #425). Asserting `os.umask` is never called is the
         direct, non-timing-sensitive proof that the race class is gone.
         """
-        other_socket_path = self.tmp / "no-umask-call.sock"
+        other_socket_path = self.sock_dir / "no-umask-call.sock"
         server = MonitorServer(store=self.store, socket_path=other_socket_path)
         thread = threading.Thread(target=server.serve_forever, daemon=True)
         with mock.patch(
@@ -675,7 +680,7 @@ class Stage9ServerTests(unittest.TestCase):
             release_bind.wait(timeout=2.0)
             return real_bind(sock_self, address)
 
-        other_socket_path = self.tmp / "umask-race.sock"
+        other_socket_path = self.sock_dir / "umask-race.sock"
         server = MonitorServer(store=self.store, socket_path=other_socket_path)
         new_dir = self.tmp / "concurrent-race" / "nested" / "leaf"
         try:
@@ -793,7 +798,7 @@ class Stage9ServerTests(unittest.TestCase):
             contender_thread.join(timeout=2.0)
 
     def test_server_reclaims_stale_socket_file(self) -> None:
-        stale_path = self.tmp / "stale-monitor.sock"
+        stale_path = self.sock_dir / "stale-monitor.sock"
         stale = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         stale.bind(str(stale_path))
         stale.close()
@@ -830,7 +835,7 @@ class Stage9ServerTests(unittest.TestCase):
             reclaimed_thread.join(timeout=2.0)
 
     def test_server_refuses_to_delete_non_socket_path(self) -> None:
-        bad_path = self.tmp / "not-a-socket"
+        bad_path = self.sock_dir / "not-a-socket"
         bad_path.write_text("occupied", encoding="utf-8")
         contender = MonitorServer(store=self.store, socket_path=bad_path)
         with self.assertRaisesRegex(RuntimeError, "不是 Unix socket"):
@@ -838,7 +843,7 @@ class Stage9ServerTests(unittest.TestCase):
         self.assertTrue(bad_path.exists())
 
     def test_server_timeout_probe_treats_socket_as_live(self) -> None:
-        busy_path = self.tmp / "busy-monitor.sock"
+        busy_path = self.sock_dir / "busy-monitor.sock"
         busy = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         busy.bind(str(busy_path))
         busy.close()
@@ -874,6 +879,8 @@ class Stage9ServiceTests(unittest.TestCase):
     def setUp(self) -> None:
         _require_phase3(self)
         self.tmp = Path(tempfile.mkdtemp(prefix="stage9-svc-"))
+        # #608：run dir 底下要 bind socket，必須落在短固定根（見上）。
+        self.sock_dir = make_short_socket_dir(prefix="stage9v")
         _mkdir_resilient(self.tmp / "ws")
         self.project_dir = _make_workspace(self.tmp / "ws", "projA", DEFAULT_TODO)
         _mkdir_resilient(self.project_dir / ".git" / "refs" / "heads")
@@ -881,7 +888,7 @@ class Stage9ServiceTests(unittest.TestCase):
         (self.project_dir / ".git" / "refs" / "heads" / "main").write_text("deadbeef\n")
         _mkdir_resilient(self.project_dir / "node_modules" / "pkg")
         (self.project_dir / "node_modules" / "pkg" / "index.js").write_text("module.exports = 1;\n")
-        self.run_dir = self.tmp / "run"
+        self.run_dir = self.sock_dir / "run"
         self.socket_path = self.run_dir / "project-monitor.sock"
         self.cfg = MonitorConfig(
             workspaces=(WorkspaceConfig(path=self.tmp / "ws", name="ws"),),
@@ -915,6 +922,7 @@ class Stage9ServiceTests(unittest.TestCase):
         import shutil
 
         shutil.rmtree(self.tmp, ignore_errors=True)
+        shutil.rmtree(self.sock_dir, ignore_errors=True)
 
     def _connect(self) -> socket.socket:
         deadline = time.time() + 1.0
@@ -1017,7 +1025,7 @@ class Stage9ServiceTests(unittest.TestCase):
         cfg = MonitorConfig(
             workspaces=(WorkspaceConfig(path=self.tmp / "ws", name="ws"),),
             legacy_policy="list-only",
-            socket_path=self.tmp / "fallback.sock",
+            socket_path=self.sock_dir / "fallback.sock",
         )
         with mock.patch.object(service_module, "HAS_WATCHDOG", False):
             fallback_service = ProjectMonitorService(config=cfg)

--- a/tests/test_workflow_production_wiring.py
+++ b/tests/test_workflow_production_wiring.py
@@ -4024,7 +4024,26 @@ def test_planning_artifact_rejection_records_full_content_evidence(tmp_path: Pat
     # evidence 落在 coordinator_root 底下，不得污染被監控的 artifact worktree。
     assert not (artifact_root / "evidence").exists()
     # 錯誤訊息要指向該檔，operator 不必自己猜路徑。
-    assert f"evidence={evidence_paths[0]}" in str(excinfo.value)
+    #
+    # #608：這條原本斷言**完整絕對路徑**出現在訊息裡，但訊息有 400 字元上限，且
+    # `evidence` 刻意排在欄位順序最後（見 `_planning_artifact_rejection_message`
+    # 的註解：最短最關鍵的 reasons 先寫，被上游截斷時還看得到）。evidence 路徑
+    # 會不會被截掉，因此取決於 coordinator root 有多長——而那是 host `TMPDIR`
+    # 給的。實測 `len(TMPDIR)=92` 時本測必紅，是 ledger gate 環境敏感家族
+    # （#565／#586／#608／#610）的一員：Manager 重跑全套時，那筆紅與「交付真的
+    # 沒過」在 ledger 上無法區分。
+    #
+    # 修法是讓斷言只主張 production 真正保證的事：evidence 欄位存在，且它帶出的
+    # 字串是真實路徑的前綴。訊息沒被截斷時這等同原本的完整路徑比對（一般環境走
+    # 的就是這條），被截斷時仍然抓得到「指錯檔」的回歸——而結果不再隨 host 的
+    # 暫存根長度改變。
+    message = str(excinfo.value)
+    assert "evidence=" in message
+    # 未截斷時訊息以 `)` 收尾，截斷時以 `…` 收尾；兩種都剝掉才拿得到路徑本身。
+    emitted_ref = message.split("evidence=", 1)[1].removesuffix("…").removesuffix(")")
+    assert str(evidence_paths[0]).startswith(emitted_ref)
+    if not message.endswith("…"):
+        assert emitted_ref == str(evidence_paths[0])
 
 
 def test_planning_artifact_rejection_evidence_truncates_oversized_content(


### PR DESCRIPTION
## 問題

Linux 的 `struct sockaddr_un.sun_path` 是 **108 bytes 的固定陣列**（含結尾 NUL，
可用 **107**）。pytest 的 `tmp_path` 與 `tempfile.mkdtemp()` 都掛在 `TMPDIR` 底下，
socket 路徑的長度因此是**環境給的**：

```
<TMPDIR>/pytest-of-<user>/pytest-<N>/<test-name-30-chars><M>/monitor.sock
└─ 環境決定 ─┘└──────────────── 固定約 75 bytes ────────────────┘
```

`TMPDIR` 是 `/tmp` 時總長 79 bytes，一切正常；CI／sandbox 給一個 40～70 bytes 的
暫存根就直接撞牆。實測（0817，`origin/main`，乾淨環境）：

| `len(TMPDIR)` | 全套 `python3 -m pytest tests/ -q` |
| --- | --- |
| 4（`/tmp`） | 全綠 |
| 47 | **4 failed** |
| 66 | **18 failed** |
| 91 | 全綠，但 AF_UNIX 家族 **36 測靜默 skip**，另有 1 failed（見下） |

#608 內文點名三個（`test_monitor_work_api` 的
`test_socket_work_item_read_apis_and_subscription_preserve_legacy`、
`test_work_subscription_can_scope_duplicate_work_id_by_repo`、
`test_old_server_teardown_does_not_unlink_replacement_socket`）；實測還有第四個
（`test_doctor::test_monitor_protocol_probe_rejects_transport_only_listener`），
以及門檻更高的 `test_stage9_project_monitor_service` 十四測——不同寫法的路徑固定段
長度不同，各自有各自的臨界值，形成上表的階梯。

### 為什麼是 P1

Manager gate ledger 對 candidate 重跑全套 pytest 是採信的硬 gate（#540）。上表的
`failed` 進 ledger 之後，與「這次交付真的沒過」**長得一模一樣**——合格 candidate 會
被 `GateContradictionError` 拒掉。這是 #565（`/tmp/.git` 污染）、#586（sandbox 擋
`bind`）之後**同族第三例**。

`len(TMPDIR) > 70` 那一列更陰險：#586 的 `af_unix_bind_available()` 探針**自己也
建在 `TMPDIR` 底下**，探針路徑先超限 → `bind()` 失敗 → 被判成「sandbox 禁止
bind」→ 整個 AF_UNIX 家族帶著**不成立的理由**靜默 skip。套件是綠的、ledger 是綠的，
覆蓋卻沒了——比紅掉更難發現。

## 受影響的 socket 建立點（8 處）

**production（3）**：`monitor/server.py` 的 `listener.bind()` 與 stale-socket
`probe.connect()`、`monitor/work_api.py` 的 `MonitorSocketClient.request()`
`client.connect()`。路徑源自 `PSC_RUN_ROOT`，不吃 `TMPDIR`，但同樣吃 107 bytes 上限。

**測試（5 個檔）**：`sandbox_support.py`（#586 探針，**meta 的那一個**——它一壞，
整族的判定跟著壞）、`test_sandbox_afunix_skip_586.py`（ground truth bind）、
`test_monitor_work_api.py`、`test_doctor.py`、
`test_stage9_project_monitor_service.py`。

## 修法

### 1. 測試 hermetic 化（主修法，形態比照 #607／#565）

#607 的形態是「production 兩道判準 ＋ 新增 `tests/git_fixtures.py` 收攏污染形狀
＋ 回歸測試自備污染」。本 PR 沿用同一形態，只是把「污染」換成「路徑長度」。

新增 **`tests/socket_fixtures.py`**（對應 `git_fixtures.py`）：

* `short_socket_root()`——選一個**短且與 `TMPDIR` 無關**的固定根
  （`/tmp` → `/var/tmp` → `/run/user/<uid>`，保底才回頭問 `tempfile.gettempdir()`），
  各自加一層 per-uid 的 `0700` 容器目錄（共用主機上不同使用者不互踩）；
* `make_short_socket_dir()` / `short_socket_dir()`——在其下開短亂數名目錄
  （`unittest` 用前者搭 `addCleanup`，pytest 用後者或 conftest 的 `socket_dir` fixture）；
* `assert_socket_path_fits()`——fixture 的保證一旦被改壞，要炸在「fixture 壞了」
  這句話上，而不是炸在某個**看起來像產品缺陷**的 `bind()` 失敗上。

五個測試檔改用它。**只有需要 `bind()` / `connect()` 的路徑搬家**；同一個測試的
工作區、設定檔、快照沒有長度上限，照舊留在 `tmp_path`（搬過來只會失去 pytest 的
保留與清理）。

`test_doctor.py` 的 `_layout()` 改把整個假 home 掛在短根下——它底下住著
`<home>/.agents/run/cortex/project-monitor.sock`，光固定段就 39 bytes。**這條在
`origin/main` 上就已經超限了**，只是 doctor 從不量長度所以沒人發現。用 module-scope
fixture 統一清理，不動 `_layout()` 的簽章（否則要改 15 個呼叫端）。

### 2. production fail closed 且說得出原因

新增 **`paulsha_cortex/monitor/socket_path.py`**，把 107／108 與判定收在一處
（`socket_path_length()` 以 **byte** 計而非字元——中文目錄名下用字元數會低估，
剛好讓 fail-closed 失效）：

* `MonitorServer.serve_forever()` 與 `MonitorSocketClient.request()` 在**碰檔案系統
  之前**先驗，超限時 raise `SocketPathTooLongError`，訊息附**實際 byte 數、上限、
  超出量、路徑、該調哪個環境旋鈕**，取代一句沒有出處的
  `OSError: AF_UNIX path too long`；
* 該例外刻意繼承 `ValueError` 而**非** `OSError`——呼叫端普遍用 `except OSError`
  表示「transport 出事（沒在聽／連不上）」，掛在 `OSError` 下會被那些既有處理吸收，
  重新變回無法區分的症狀；
* 新增 `MonitorServer.startup_error`：`serve_forever` 常被丟進背景 thread 跑，
  raise 的東西不會回到呼叫端，呼叫端只看到 `wait_until_ready()` 回 `False`——
  一個對「環境不合格」與「服務有缺陷」完全相同的空結果；
* `cortex doctor` 的 `monitor-socket` probe 在 **live probe 之前**先量長度，直接說出
  「超過 sun_path 上限」而不是 `monitor socket is not listening`。

### 3. 為什麼不用 abstract namespace

issue 內文點名了 `\0` 前綴的抽象命名空間，本 PR **刻意不採用**：

* 抽象 socket 不是檔案系統物件，**沒有任何權限位**。monitor socket 現在是
  `chmod 0o600`，改抽象等於對同 network namespace 內所有行程開放——這是安全退步，
  不是環境健壯化；
* `server` 既有的 stale-socket 回收、`live monitor already listening` 偵測、teardown
  時的 identity 比對 unlink，全建立在「socket 是一個檔案」上；
* 它**仍然**吃 108 bytes 上限，只是不吃路徑長度——並沒有真的移除這條契約，只是換個
  地方踩。

## 核心不變式：環境失敗與交付失敗可區分

**現況會不會產生一筆看起來像 gate 失敗的 ledger 記錄？會。** `gate_ledger.run_gates()`
只記 `status: passed|failed` ＋ `detail`（pytest 輸出末 2000 字），沒有任何「環境
因素」的分類；長 `TMPDIR` 讓 pytest exit≠0，ledger 就寫下一筆 `failed`。

本 PR 從**源頭**消除它，而不是在 ledger 上加一層分類——後者是 #604 的地界，且
「先製造一筆失敗、再想辦法標註它是假的」比「讓它根本不發生」脆弱。修完之後，長
`TMPDIR` 不再能讓全套 pytest 紅（也不再靜默 skip），因此**不可能**產生那筆記錄。

`tests/test_afunix_sun_path_608.py`（16 測）把這件事釘死，四層：

1. **常數與計算契約**——107／108；byte 而非字元；邊界 107 收、108 拒；
   `SocketPathTooLongError` 不得是 `OSError`；訊息必須含數字與環境旋鈕名。
2. **fixture 對敵意 `TMPDIR` 免疫**——含一條**負控制**（同一個敵意環境下，沿用舊
   寫法產生的路徑確實超限），證明模擬的環境是忠實的、不是「因為根本不夠長才綠」。
3. **production fail closed**——`serve_forever` / `MonitorSocketClient` /
   `doctor` 三個面各一條，且 doctor 的 detail 明確**不含** `not listening`。
4. **ledger 不變式**——以敵意長 `TMPDIR` 走 production 的
   `gate_ledger.write_gate_ledger()` 重跑那些原本必紅的測試，ledger 必須是
   `passed`；另一條驗它們是**跑了**而不是 skip；再一條**負控制**：同一條 ledger
   路徑、同一個敵意 `TMPDIR`，真正失敗的 gate 仍然記成 `failed`（`exit_code=3`）。
   第 4 層沒有負控制的話，可以靠「什麼都記成 passed」作弊通過。

### 順手收掉的同族第五例（不同機制）

驗證掃描到 `len(TMPDIR)=91` 時發現 `test_workflow_production_wiring.py::
test_planning_artifact_rejection_records_full_content_evidence` 也必紅，機制與
socket 無關：拒收訊息有 400 字元上限，而 evidence 絕對路徑**刻意排在欄位順序最後**
（`_planning_artifact_rejection_message` 的設計就是讓最短最關鍵的 `reasons` 先寫），
`TMPDIR` 一長就被截掉，測試對「完整路徑必須出現」的斷言隨之落空。

production 的行為是**照設計正確的**，過度斷言的是測試。因此只改測試：斷言改成
主張 production 真正保證的事——`evidence=` 欄位存在，且它帶出的字串是真實路徑的
前綴；訊息沒被截斷時（一般環境走的就是這條）等同原本的完整路徑比對，被截斷時仍然
抓得到「指錯檔」的回歸，而結果不再隨 host 暫存根長度改變。該 nodeid 一併收進上述
第 4 層的 ledger 不變式測試——那條要守的是「環境形狀不得偽造出 gate 失敗」，不是
「socket 不得超長」。

## 驗證

本 PR 已 rebase 到含 #604（PR #628）與 #621（PR #627）的 `main`（`0cf3606`），
下表為 rebase 後實跑：


| 條件 | 結果 |
| --- | --- |
| 全套 pytest，`TMPDIR=/tmp`（len 4） | `3555 passed, 49 subtests passed` |
| 全套 pytest，`len(TMPDIR)=48` | `3555 passed, 49 subtests passed` |
| 全套 pytest，`len(TMPDIR)=67` | `3555 passed, 49 subtests passed` |
| 全套 pytest，`len(TMPDIR)=92` | `3555 passed, 49 subtests passed` |
| 全套 pytest，`len(TMPDIR)=106` | `3555 passed, 49 subtests passed` |
| 新增的 `tests/test_afunix_sun_path_608.py` | `16 passed` |
| **負控制**：修前 code，`len(TMPDIR)=48` | **4 failed** |
| **負控制**：修前 code，`len(TMPDIR)=67` | **18 failed** |
| **負控制**：修前 code，`len(TMPDIR)=92` | **1 failed ＋ 36 skipped**（skip 理由不成立） |

負控制證明四個 `TMPDIR` 長度區間都是忠實的：同一組環境在修前分別觸發紅、更多紅、
與靜默 skip，修後全部無感且零 skip。`len(TMPDIR)` 從 4 一路拉到 **106**（只差
1 byte 就吃滿整個 `sun_path`）結果完全相同，是「socket 路徑長度已與環境脫鉤」最
直接的證據。

## 與 #604 的分界

本 PR **完全沒有動 gate ledger 的寫入語意**——`coordinator/gate_ledger.py`、
`coordinator/terminal_contract.py`、exit sentinel 一行未改。`write_gate_ledger()`
只在新測試裡被**呼叫**（當作待驗的產品行為），不是被修改。改動全部集中在
**socket 路徑的產生**這一面（`monitor/socket_path.py`、`monitor/server.py` 的 bind
前置檢查、`monitor/work_api.py` 的 connect 前置檢查、`doctor.py` 的
`monitor-socket` probe，以及測試側的 fixture）。與 #620／#622
（`trust_root/permgen.py`）、#621（Phase 2b runbook）、#612（`_infer_repo_root`）
皆無檔案重疊。

## Checklist

- [x] 分支非 `main`（`feature/608-afunix-sunpath-hermetic`）
- [x] `changelog.d/afunix-sunpath-hermetic.md` fragment 已新增並 commit
- [x] `CHANGELOG.md [Unreleased] / Fixed` 有對應 entry
- [x] `VERSION` 未動（非 release PR）
- [x] 全套 pytest 綠（五個 `TMPDIR` 長度區間皆 `3555 passed`）
- [x] `README.md` 補「AF_UNIX socket 路徑不得掛在 `TMPDIR` 下」與「ledger gate
      環境健壯性」兩條開發慣例（R-18）
- [x] 語言 zh-tw

## 相鄰觀察（不在本 PR 範圍）

- `tests/test_stage9_project_monitor_service.py::Stage9WatchdogIntegrationTests` 掛著
  `@skipUnless(af_unix_bind_available())`，但該 class 完全不碰 socket——多餘的 gate，
  本 PR 不順手改以免混淆 diff。
- `MonitorServer._prepare_socket_path()` 的 `RuntimeError`（「已存在且不是 Unix
  socket」「live monitor already listening」）在 threaded 呼叫端同樣只表現為
  `wait_until_ready()` 回 `False`；本 PR 新增的 `startup_error` 目前只記錄
  `SocketPathTooLongError`，把其餘啟動失敗也納入是自然的下一步，但那會改到既有錯誤
  路徑的行為，留給後續。

Closes #608

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E7w9kaUxAzCCEk7piD5hfK
