### PR TITLE
fix(trust-root): permgen 對應表缺項讓抽象角色名當帳號印出 setfacl，未對應時改為 fail-closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,30 @@
   `tests/test_trust_root_job_template_ab.py`（80 測試）。
 
 ### Fixed
+- **#626 / trust-root：permgen 為不存在的 principal 產生 `setfacl`，`sh -e` 下中止整份
+  script 留下半套用的權限樹**——`permissions --commands --paths` 會印出
+  `setfacl -m u:operator:rX …` 與 `setfacl -m u:cortex-outbox:rX …`，但這兩個是
+  `registry.Principal` 的**抽象角色名**、不是真實帳號（`SCHEMES` 只把服務帳號那幾個
+  principal 對應到真實帳號——**對應表缺項，不是填錯**）。實機 `setfacl` 回
+  `Invalid argument near character 3`，而 runbook 第 2b 步是
+  `sudo sh -e /tmp/p2b-permissions.sh`：第一條就**中止整份 script**，權限樹停在半套用
+  狀態（前段已 chown/chmod、後段完全沒動），而且**看起來像裝好了**——錯誤訊息完全看不出
+  是「帳號不存在」。修法：`UidScheme` 新增 `operator_account`／`external_reader_account`
+  兩個**預設 `None`** 的欄位，由 `--operator-account`／`PSC_OPERATOR_ACCOUNT`（及
+  external reader 的對應旗標／env，旗標優先）於產生當下注入；值 `none` 是**明示**本部署
+  沒有這個角色的實體，該 principal 的授權整組略去。未指定時 `plan_to_commands()`
+  **fail-closed**：raise `UnresolvedPrincipalError`、**一行都不輸出**（CLI stdout 全空、
+  回傳碼 2，被重導的檔案是空檔而不是半套 script），訊息指出是哪個 principal、走哪個旗標／
+  env、以及「先 `getent passwd`」。另加一道輸出後自我檢查
+  `assert_output_accounts_known()`：每一行的 `u:<name>:` 與 `chown <owner>:<group>`
+  都必須落在方案宣告的帳號集合內（註解行一併檢查），擋的是**未來新增 principal 時再犯**。
+  `UidScheme.__post_init__` 拒絕把這幾個 principal 塞回 `account_of`（會被靜默忽略而形成
+  第二份真相，正是本 issue 的成因），帳號名另做 `^[a-z_][a-z0-9_-]*$` 形狀驗證（名字會被
+  逐字嵌進命令字串）。env 只在 CLI 這一層讀取，`permgen` 維持純函式。新增
+  `tests/test_trust_root_principal_account_mapping_626.py`（46 測試，兩 scheme 參數化，
+  含「輸出不得出現任何不在帳號集合內的字面值」這條擋復發的不變式）；runbook 第 2a 步補
+  稽核 6／6b（每個 ACL 帳號與 scaffold owner 都必須 `getent passwd` 得到）並明說 script
+  冪等、中止後直接重跑安全。詳見 `changelog.d/principal-account-mapping.md`。
 - **#608 / ledger gate 環境健壯性（#565、#586 同族第三例）：AF_UNIX socket 路徑不再
   吃 `TMPDIR` 長度，長暫存根無法再偽造出一筆 gate 失敗**——Linux 的 `sun_path` 只有
   108 bytes（含結尾 NUL，可用 107），而 pytest `tmp_path` 與 `tempfile.mkdtemp()` 都

--- a/changelog.d/principal-account-mapping.md
+++ b/changelog.d/principal-account-mapping.md
@@ -1,0 +1,74 @@
+# principal-account-mapping
+
+- **`#626`：permgen 為不存在的 principal 產生 `setfacl`，`sh -e` 下中止整份 script 留下
+  半套用的權限樹**——`permissions three-way --commands --paths` 會印出
+  `setfacl -m u:operator:rX …` 與 `setfacl -m u:cortex-outbox:rX …`。這兩個是
+  `registry.Principal` 的**抽象角色名**，不是真實帳號：`SCHEMES` 只把服務帳號那幾個
+  principal 對應到真實帳號，`Principal.OPERATOR` 與外部 reader 直接沿用字面值——**對應表
+  缺項，不是填錯**。實機上 `setfacl -m u:operator:rX` 回
+  `Invalid argument near character 3`，而 runbook 第 2b 步是
+  `sudo sh -e /tmp/p2b-permissions.sh`：`sh -e` 遇到第一條就**中止整份 script**，於是權限樹
+  處於**半套用**狀態（前段資產已 chown/chmod、後段完全沒動），而錯誤訊息完全看不出是
+  「帳號不存在」。最危險的是半套用的樹**看起來像裝好了**——目錄都在、前段權限正確，只有
+  後段仍是預設權限。#620 的 traverse ACL 上線後又多產了幾條同樣的 phantom ACL，這條因此更
+  嚴重。Phase 2b M1 沒踩到，只是因為 operator 執行前手動 `sed` 把兩個 principal 替換掉了，
+  而那個替換不在 runbook 也不在 spec 裡——換句話說**任何人照 runbook 做都會中止**。
+- **對應外部化**：`UidScheme` 新增 `operator_account` 與 `external_reader_account`，
+  **預設 `None`**，並從兩個 `SCHEMES` 的 `account_of` 移除 `Principal.OPERATOR`
+  （`external_reader` 的 `"cortex-outbox"` 預設值一併移除）。「operator 對應到誰」是
+  **部署決定**、不是程式能猜的：單人機器上就是那個人的登入帳號，多人／CI 部署可能是
+  專用帳號，而外部 outbox reader 在很多部署裡根本還沒有實體。新增
+  `PRINCIPAL_ACCOUNT_OPTIONS` 作為**唯一真相**——`UidScheme` 欄位名、CLI 旗標、env 變數名、
+  fail-closed 的錯誤訊息全部由它導出，將來多一個部署決定型 principal 只需加一列。
+  `UidScheme.__post_init__` 直接拒絕把 `OPERATOR`／`EXTERNAL`／`INSTALLER` 塞回
+  `account_of`：那會被靜默忽略而形成第二份真相，正是本 issue 的成因。
+- **三態，不是兩態**：`None`＝未指定（fail-closed）／`ABSENT_ACCOUNT`＝**明示**本部署沒有
+  這個角色的實體（該 principal 的授權整組略去，是被記錄下來的決定）／真實帳號名＝照常
+  產生 ACL。少了中間那態，「本機還沒有 outbox reader」就只能靠亂填一個帳號來繞過，
+  等於把不必要的讀取權授出去。
+- **fail-closed 在輸出前**：`plan_to_commands()` 先跑 `assert_principals_resolved()`，
+  有未對應的 principal 即 raise `UnresolvedPrincipalError`，**一行都不輸出**——CLI 因此
+  stdout 全空、回傳碼 2，被重導成 script 的檔案是**空檔**而不是一份跑到一半會中止的半套
+  script。訊息可操作：指出是哪個 principal、它是什麼角色、`--operator-account <帳號名>`
+  或 `PSC_OPERATOR_ACCOUNT=<帳號名>`、`none` 怎麼用，以及「指定前先 `getent passwd`」。
+  `generate_plan()` 刻意**不** raise（計畫是資料，看得見缺項反而有助診斷），未對應的
+  principal 改以 `PermissionPlan.unresolved_principals` 隨計畫一起出現，CLI 的 JSON 模式
+  把它放進 payload 並在 stderr 提醒一次——診斷模式不擋，但「少了誰的授權」必須看得見。
+- **產生器自我檢查（擋未來，不只擋這次）**：`assert_output_accounts_known()` 在輸出組完後
+  驗證每一行的 `u:<name>:` 與 `chown <owner>:<group>` 都落在
+  `UidScheme.declared_accounts()` 內，否則 raise `UnknownAccountInOutputError`。**註解行
+  一併檢查**——per-job 資產是以註解形式輸出的，phantom 躲在 `#   setfacl …` 裡照樣會被
+  複製貼上執行。這條擋的是「將來新增一個 principal 而忘了進對應表」：字面角色名一漏進
+  命令字串就 raise，不會再靜默產生一行 `sh -e` 下會炸掉的 `setfacl`。
+- **帳號名形狀驗證**：帳號名會被**逐字**嵌進 `setfacl`／`chown` 命令字串，因此只接受
+  `^[a-z_][a-z0-9_-]*\$?$`。`--operator-account "op; rm -rf /"` 在產生階段就被拒，
+  而不是等到 operator `sudo` 執行時。
+- **兩條注入管道，CLI 旗標優先於 env**：`--operator-account` / `PSC_OPERATOR_ACCOUNT`、
+  `--external-reader-account` / `PSC_EXTERNAL_READER_ACCOUNT`（值 `none`＝明示不存在）。
+  兩者並存的理由：runbook 是逐行 review 後手動執行的，旗標讓「這次產生用了哪個帳號」留在
+  可稽核的命令列上；env 則讓 CI／自動化不必改命令列。**env 只在 CLI 這一層讀取**——
+  `permgen` 維持純函式（不讀 env、不碰 IO），既有的
+  `test_permgen_never_touches_the_filesystem`／`test_permgen_module_does_not_import_subprocess`
+  兩條靜態不變式不受影響。
+- **`PermissionPlan` 帶著方案本體走**：新增 `scheme` 欄位（`compare=False`）。#626 之後
+  `SCHEMES[plan.scheme_id]` 反查到的是**未注入部署對應**的模組層方案，只憑 id 反查會把
+  注入過的對應整個丟掉、讓自我檢查誤判；`_scheme_for()` 統一「顯式參數 > 計畫自帶 >
+  `SCHEMES` 反查」的順序，`plan_to_commands()`／`directory_facts()`／
+  `derive_traverse_grants()`／`unreachable_hops()` 一律走它。
+- **測試**：新增 `tests/test_trust_root_principal_account_mapping_626.py`（46 測試，兩個
+  scheme 逐一參數化）——(a) 未指定時 fail-closed 且訊息含 principal 名／旗標／env／
+  `getent passwd`，只補一半也不放行；(b) 指定後每個 `u:<name>:` 都落在宣告帳號集合內，
+  且注入的帳號真的被用上；(c) **不變式**：輸出中不得出現任何不在帳號集合內的字面值，
+  含「偽造一行未來 principal 的輸出必須被攔下」與「註解行也檢查」與「`menu:x:` 不得被
+  誤判成 ACL 條目」；(d) `ABSENT_ACCOUNT` 只略去那個 principal 的 ACL、別人的一條都不少；
+  CLI 側涵蓋旗標／`=` 形式／env／旗標勝過 env／非法帳號名／懸空旗標／JSON 模式的
+  `unresolved_principals`；另有一條登記表側的不變式——需要部署決定的 principal **恰好**是
+  `operator` 與 `external`，多一個就代表對應表又缺了一項。既有 `_p2a`／`_p2b`／`_620`
+  三檔的命令輸出測試改用注入後的方案（它們原本驗到的正是帶 phantom 的輸出）。
+- **runbook**：`docs/superpowers/runbooks/trust-root-phase2b-setup.md` 第 2a 步——產生命令
+  補上兩個旗標與 `getent passwd` 前置確認、`exit=` 期望；新增**稽核 6／6b**（權限 script
+  的每個 ACL 帳號、骨架 script 的每個 owner 都必須 `getent passwd` 得到，出現任何 `!!`
+  就不要執行第 2b 步）；明說**兩份 script 都是冪等的、中止後直接重跑安全**，不需要先
+  回滾。另順修稽核 2 的假陽性：`grep -E ":[^ ]*w"` 會把
+  `u:cortex-reviewer-planner:--x` 撈進來（`reviewer` 自己帶一個 `w`），#620 的 traverse
+  節上線後這條就一直多報一行；pattern 改錨在 `u:<帳號>:` 之後。

--- a/docs/superpowers/runbooks/trust-root-phase2b-setup.md
+++ b/docs/superpowers/runbooks/trust-root-phase2b-setup.md
@@ -485,9 +485,24 @@ sudo groupdel cortex-manager; sudo groupdel cortex-reviewer-planner; sudo groupd
 # ✅ 產生骨架目錄 script（非登記表資產的父層：/opt/cortex、HOME、job spool…）
 python3 -m paulsha_cortex.trust_root scaffold three-way > /tmp/p2b-scaffold.sh
 
+# ✅ operator 與外部 outbox reader 是**抽象角色名**，不是帳號——對應到誰是**部署決定**，
+#    必須在產生當下指定（#626）。未指定時產生器 fail-closed：stdout 一行都不輸出、
+#    回傳碼 2，stderr 指出是哪個 principal 與怎麼指定。
+OPERATOR_ACCOUNT="$(id -un)"   # 單人機器＝現在這個登入帳號；多人／CI 部署請改成專用帳號
+getent passwd "$OPERATOR_ACCOUNT" >/dev/null \
+  && echo "operator account OK: $OPERATOR_ACCOUNT" \
+  || echo "!! $OPERATOR_ACCOUNT 不存在，先建帳號或改指定"
+
 # ✅ 產生權限 script（登記表每一項的 install -d／chown／chmod／setfacl）
+#    `--external-reader-account none`＝**明示**本部署沒有外送管線 reader 的實體，
+#    該角色的 ACL 整組略去（是一個被記錄下來的決定，不是漏掉）。之後真的有了
+#    再改成它的帳號名重跑即可。旗標也可改用 env：PSC_OPERATOR_ACCOUNT／
+#    PSC_EXTERNAL_READER_ACCOUNT（旗標優先）。
 python3 -m paulsha_cortex.trust_root permissions three-way --commands --paths \
+  --operator-account "$OPERATOR_ACCOUNT" \
+  --external-reader-account none \
   > /tmp/p2b-permissions.sh
+echo "exit=$?"   # 期望 0；2＝有 principal 沒對應到真實帳號（stderr 已指出是哪個）
 
 # ✅ 逐行讀過再執行——這是 operator 核可的實體動作
 less /tmp/p2b-scaffold.sh
@@ -499,7 +514,10 @@ grep -oE "chmod [0-7]{4}" /tmp/p2b-permissions.sh | sort -u \
         END{ if (!bad) print "no group/other write: OK" }'
 
 # ✅ 稽核 2：ACL 授「寫」只准出現在兩個 append-only 出口（三分下**恰好四行**）
-grep -E "^setfacl" /tmp/p2b-permissions.sh | grep -E ":[^ ]*w"
+grep -E "^setfacl" /tmp/p2b-permissions.sh | grep -E "u:[^:]+:[^ ]*w"
+#   注意 pattern 必須錨在 `u:<帳號>:` 之後才找 `w`——裸的 `:[^ ]*w` 會把
+#   `u:cortex-reviewer-planner:--x` 也撈進來（`reviewer` 自己帶一個 w），
+#   #620 的 traverse 節上線後這條稽核就一直多出一行假陽性。
 #   期望（三分）：**恰好四行**
 #     setfacl -m u:cortex-builder:wx           /var/lib/cortex/monitor/event-spool
 #     setfacl -d -m u:cortex-builder:wx        /var/lib/cortex/monitor/event-spool
@@ -529,7 +547,8 @@ grep -E "^setfacl -m u:[^ ]+:--x " /tmp/p2b-permissions.sh
 #     setfacl -m u:cortex-builder:--x           /var/lib/cortex/monitor
 #     setfacl -m u:cortex-builder:--x           /var/lib/cortex/coordinator
 #     setfacl -m u:cortex-reviewer-planner:--x  /var/lib/cortex/coordinator
-#   （另有 cortex-outbox／operator 的對應條目，同樣由葉節點 ACL 機械導出）
+#   （另有 `--operator-account` 指定的那個帳號的對應條目，同樣由葉節點 ACL 機械
+#     導出；外部 reader 明示 `none` 時，它那一組條目整組不出現）
 grep -E "^setfacl .*:r-x " /tmp/p2b-permissions.sh
 #   期望：空輸出。traverse 一律 `--x` 而非 `r-x`：走得到自己那格，但**列不出**
 #   coordinator/ 底下還有哪些 Manager 資產。
@@ -542,21 +561,39 @@ tail -n 20 /tmp/p2b-permissions.sh | grep -c ":--x "
 #   不會報錯）。因此也**不要**在執行完 permissions 之後再重跑 scaffold。
 
 # ✅ 稽核 6：script 裡出現的每個帳號名都**真的存在**（#626）
-#   `setfacl` 對解析不到的使用者名直接失敗，而 2b 是 `sh -e`——一條錯就**中止整份
-#   script**，留下**半套權限的樹**（前半已套、後半沒套，包括尾端的 traverse 節）。
+#   `setfacl` 對解析不到的使用者名直接失敗（`Invalid argument near character 3`），
+#   而 2b 是 `sh -e`——一條錯就**中止整份 script**，留下**半套權限的樹**（前半已套、
+#   後半沒套，包括尾端的 traverse 節），而錯誤訊息完全看不出是「帳號不存在」。
 #   實測命中的是 permgen 為 `operator`／`cortex-outbox` 這兩個「登記表上有 principal、
-#   本機卻沒有對應帳號」的名字產出的條目。
+#   本機卻沒有對應帳號」的名字產出的條目。#626 已在**產生器側**擋掉——未對應的
+#   principal 一律 fail-closed、一行都不輸出（見上方產生命令的 `exit=`）；本稽核是
+#   **實機側的第二道**：對應到的帳號**這台機器上真的有嗎**。
 for U in $(grep -oE "u:[A-Za-z0-9._-]+:" /tmp/p2b-permissions.sh | cut -d: -f2 | sort -u); do
   getent passwd "$U" >/dev/null && echo "OK      $U" || echo "!! 不存在 $U"
 done
 #   期望：全部 OK。
 #   出現 `!! 不存在` 時的處置（**兩者擇一，不可硬跑**）：
-#     (a) 該 principal 在本機確實該有對應帳號 ⇒ 先建帳號（比照第 1 步的形態）；
-#     (b) 它是本部署形態下不存在的 principal ⇒ **等 #626 的產生器修正**，
-#         或在 operator 核可下由 script 中移除那幾行後再套用，並在 #584 記錄。
+#     (a) 該 principal 在本機確實該有對應帳號 ⇒ 先建帳號（比照第 1 步的形態），
+#         或以 `--operator-account <既有帳號>` 重新產生 script；
+#     (b) 它是本部署形態下不存在的 principal ⇒ 以 `--<principal>-account none`
+#         **明示**它不存在後重新產生——該角色的 ACL 會整組略去，不必再手改 script。
 #   **不要**改用 `sh`（去掉 `-e`）硬跑：那會把「中止」換成「靜默略過」，
 #   結果是一棵你以為套好、其實少了幾條授權的樹。
+
+# ✅ 稽核 6b：骨架 script 的 owner 欄位同樣逐一 getent
+grep -oE "install -d -o [a-z_][a-z0-9_-]*" /tmp/p2b-scaffold.sh | awk '{print $4}' \
+ | sort -u | while read -r acct; do
+     getent passwd "$acct" >/dev/null \
+       && echo "scaffold owner OK: $acct" \
+       || echo "!! scaffold owner 不存在: $acct"
+   done
 ```
+
+> **中止後直接重跑是安全的**：兩份 script 都只由 `install -d`／`chown`／`chmod`／
+> `setfacl -m` 組成，全部是**冪等**操作。因此上面任何一條稽核紅了，修好成因（改
+> `--operator-account`／建帳號／明示 `none`）後**重新產生、整份重跑**即可，不需要
+> 先回滾、也不必只挑沒跑到的那幾行。順序要求仍在：先 scaffold、後 permissions
+> （`chmod` 會重寫 ACL mask，見稽核 5）。
 
 ### 2b. 執行（順序固定：先骨架、後權限）
 

--- a/paulsha_cortex/trust_root/__main__.py
+++ b/paulsha_cortex/trust_root/__main__.py
@@ -8,6 +8,8 @@ Phase 1 不改 `cortex` CLI（避免動到 R-16 help 對齊面）；operator／C
     python -m paulsha_cortex.trust_root registry    # R1 登記表摘要（JSON）
     python -m paulsha_cortex.trust_root equation     # R1 雙向等式結果
     python -m paulsha_cortex.trust_root permissions [three-way|two-way] [--commands] [--paths]
+                                        [--operator-account <帳號名|none>]
+                                        [--external-reader-account <帳號名|none>]
                                                     # Phase 2a 權限計畫（JSON 或命令序列）
     python -m paulsha_cortex.trust_root unit [three-way|two-way]
                                         [--manager|--monitor|--job|--job-properties]
@@ -36,14 +38,78 @@ UID 方案未指定時一律用 **`three-way`**（operator 0816 第三輪裁決 
 **絕不執行**任何 root 操作、不寫任何系統路徑——命令供 operator 在 Phase 2b runbook
 中手動 sudo 執行。`--paths` 讓 `--commands` 以 `permgen.DEFAULT_LAYOUT` 的真實絕對
 路徑輸出（0816 裁決：/var/lib/cortex ＋ /opt/cortex），不再帶 placeholder。
+
+## 部署決定型 principal 的對應（#626）
+
+`operator` 與 `external`（outbox 下游 reader）是**抽象角色**，不是帳號名——對應到誰是
+部署決定。兩條注入管道，**CLI 旗標優先於 env**：
+
+    --operator-account <帳號名>          PSC_OPERATOR_ACCOUNT=<帳號名>
+    --external-reader-account <帳號名>   PSC_EXTERNAL_READER_ACCOUNT=<帳號名>
+
+值為 `none` 表示「本部署沒有這個角色的實體」，該 principal 的授權整組略去。
+兩者皆未給時 `--commands` **fail-closed**：印出可操作的錯誤訊息到 stderr、stdout 一行
+都不輸出、回傳碼 2。因為 runbook 第 2b 步以 `sudo sh -e` 執行整份 script，一行
+`setfacl -m u:<不存在的帳號>:rX` 就會中止它並留下半套用的權限樹。
+
+env 只在本 CLI 這一層讀取——`permgen` 維持純函式（不讀 env、不碰 IO）。
 """
 from __future__ import annotations
 
 import json
+import os
 import sys
 from typing import Sequence
 
 from . import permgen, registry, selfcheck
+from .registry import Principal
+
+
+#: `--<principal>-account none` 的字面值——明示本部署沒有這個角色的實體。
+ABSENT_TOKEN = "none"
+
+
+def _account_overrides(
+    rest: list[str],
+    env: "dict[str, str] | None" = None,
+) -> "tuple[list[str], dict[Principal, str], str | None]":
+    """抽出部署決定型 principal 的對應（CLI 旗標優先於 env）。
+
+    回傳 `(剩餘 token, principal→帳號, 錯誤訊息)`。旗標與 env 變數名都由
+    `permgen.PRINCIPAL_ACCOUNT_OPTIONS` 導出——新增一個 principal 不必改本函式。
+    """
+    environ = os.environ if env is None else env
+    overrides: dict[Principal, str] = {}
+    for opt in permgen.PRINCIPAL_ACCOUNT_OPTIONS:
+        value = environ.get(opt.env_var)
+        if value:
+            overrides[opt.principal] = value
+
+    by_flag = {opt.cli_flag: opt for opt in permgen.PRINCIPAL_ACCOUNT_OPTIONS}
+    remaining: list[str] = []
+    pending = None
+    for token in rest:
+        if pending is not None:
+            overrides[pending.principal] = token
+            pending = None
+            continue
+        flag, sep, inline = token.partition("=")
+        opt = by_flag.get(flag)
+        if opt is None:
+            remaining.append(token)
+            continue
+        if sep:
+            if not inline:
+                return remaining, overrides, f"{opt.cli_flag} 需要一個帳號名（或 `none`）"
+            overrides[opt.principal] = inline
+        else:
+            pending = opt
+    if pending is not None:
+        return remaining, overrides, f"{pending.cli_flag} 需要一個帳號名（或 `none`）"
+    return remaining, {
+        p: (permgen.ABSENT_ACCOUNT if v == ABSENT_TOKEN else v)
+        for p, v in overrides.items()
+    }, None
 
 
 def _registry_summary() -> dict[str, object]:
@@ -99,7 +165,10 @@ def main(argv: Sequence[str] | None = None) -> int:
         ))
         return 0 if result.ok else 1
     if command == "permissions":
-        rest = args[1:]
+        rest, overrides, err = _account_overrides(args[1:])
+        if err is not None:
+            print(err, file=sys.stderr)
+            return 2
         scheme_id = permgen.DEFAULT_SCHEME_ID
         want_commands = False
         want_paths = False
@@ -113,13 +182,35 @@ def main(argv: Sequence[str] | None = None) -> int:
             else:
                 print(f"unknown permissions arg: {token}", file=sys.stderr)
                 return 2
-        plan = permgen.generate_plan(permgen.SCHEMES[scheme_id])
+        try:
+            scheme = permgen.SCHEMES[scheme_id].with_principal_accounts(overrides)
+        except ValueError as exc:
+            print(str(exc), file=sys.stderr)
+            return 2
+        plan = permgen.generate_plan(scheme)
         if want_commands:
             path_of = permgen.asset_paths() if want_paths else None
-            for line in permgen.plan_to_commands(plan, path_of=path_of):
+            try:
+                # fail-closed：未解析的 principal 一律在**輸出前**攔下——stdout 保持
+                # 空的，被重導成 script 的檔案因此是空檔，而不是一份跑到一半會中止
+                # 的半套 script（#626）。
+                lines = permgen.plan_to_commands(plan, path_of=path_of)
+            except (permgen.UnresolvedPrincipalError,
+                    permgen.UnknownAccountInOutputError) as exc:
+                print(str(exc), file=sys.stderr)
+                return 2
+            for line in lines:
                 print(line)
         else:
+            # JSON 是診斷模式：不 fail-closed，但未對應的 principal 必須看得見——
+            # 既在 payload 裡（`unresolved_principals`），也在 stderr 提醒一次。
             print(json.dumps(plan.to_dict(), ensure_ascii=False, indent=2))
+            unresolved = plan.unresolved_principals
+            if unresolved:
+                print(
+                    permgen.unresolved_principal_message(unresolved, scheme_id),
+                    file=sys.stderr,
+                )
         return 0
     if command == "unit":
         rest = args[1:]

--- a/paulsha_cortex/trust_root/permgen.py
+++ b/paulsha_cortex/trust_root/permgen.py
@@ -39,11 +39,39 @@ job-visible 樹由對應 job 帳號寫、跨 persona 互不可寫。全部既有
   start／stop。per-job 參數走 Manager-owned spec spool（登記表資產 `job-spec-spool`），
   由 `build_job_shim()` 產出的 root-owned shim 讀取後 exec。
 - C（Manager 端封閉 argv 產生器）自動保留為第三層，見 `coordinator/job_runner.py`。
+
+## 部署決定型 principal 的對應（#626，fail-closed）
+
+`registry.Principal` 有兩個成員是**抽象角色**、不是服務帳號：`OPERATOR`（人類操作者）
+與 `EXTERNAL`（digest／engineering-outcome outbox 的下游 reader）。它們對應到哪個 OS
+帳號是**部署決定**，產生器猜不到——單人機器上 operator 就是那個人的登入帳號，多人／CI
+部署可能是專用帳號，而外部 reader 在很多部署裡**根本還不存在**。
+
+因此這兩個 principal **不放進 `account_of`**（放進去等於在程式碼裡寫死一個部署決定），
+而是 `UidScheme` 上兩個預設 `None` 的欄位（見 :data:`PRINCIPAL_ACCOUNT_OPTIONS`），由
+CLI 參數或 env 於**產生當下**注入。三種狀態嚴格區分：
+
+- `None`＝**未指定** → `plan_to_commands()` raise :class:`UnresolvedPrincipalError`，
+  **一行命令都不輸出**；
+- :data:`ABSENT_ACCOUNT`＝**明示本部署沒有這個角色的實體** → 該 principal 的授權整組
+  略去（是一個被記錄下來的決定，不是遺漏）；
+- 真實帳號名 → 照常產生 ACL。
+
+為什麼必須 fail-closed 而不是「印出來讓 operator 自己看」：runbook 第 2b 步以
+`sudo sh -e` 執行整份權限 script，而 `setfacl -m u:<不存在的帳號>:rX` 會回
+`Invalid argument near character 3` 並讓 `sh -e` **中止整份 script**，留下一棵
+**半套用**的權限樹——前段資產已 chown/chmod、後段完全沒動，而錯誤訊息完全看不出
+是「帳號不存在」（#626）。少印一行安全，多印一行會炸掉部署。
+
+輸出前另有一道自我檢查（:func:`assert_output_accounts_known`）：每一行命令裡出現的
+`u:<name>:` 與 `chown <owner>:<group>` 都必須落在**本方案宣告的帳號集合**
+（:meth:`UidScheme.declared_accounts`）內，否則 raise。這條擋的是「未來新增
+principal 時再犯同一個錯」——新 principal 只要沒進對應表，字面角色名一漏出即 raise。
 """
 from __future__ import annotations
 
 import re
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from enum import Enum
 from typing import Mapping
 
@@ -59,6 +87,135 @@ from .registry import (
 
 
 # ---------------------------------------------------------------------------
+# 部署決定型 principal 的對應（#626）
+# ---------------------------------------------------------------------------
+
+#: 明示「本部署沒有這個角色的實體」的 sentinel。與「未指定」（`None`）**嚴格區分**：
+#: `None` 會讓產生器 fail-closed，本 sentinel 則是一個被記錄下來的決定——該 principal
+#: 的授權整組略去，輸出裡一行都不會出現。
+ABSENT_ACCOUNT: str = "<absent>"
+
+#: OS 帳號名的合法形狀（POSIX portable：小寫開頭、可含數字／底線／減號）。
+#: 這同時是**注入防線**：帳號名會被逐字嵌進 `setfacl`／`chown` 命令字串，帶空白或
+#: shell metacharacter 的值必須在產生階段就被拒絕，而不是等到 operator `sudo` 執行時。
+_ACCOUNT_NAME_RE = re.compile(r"^[a-z_][a-z0-9_-]*\$?$")
+
+
+@dataclass(frozen=True)
+class PrincipalAccountOption:
+    """一個「必須由部署提供對應」的 principal 及其注入管道。
+
+    這張表是唯一真相：`UidScheme` 的欄位、CLI 旗標、env 變數名、fail-closed 的錯誤
+    訊息全部由它導出。將來多一個部署決定型 principal，只需在
+    :data:`PRINCIPAL_ACCOUNT_OPTIONS` 加一列 ＋ `UidScheme` 加一個欄位。
+    """
+
+    principal: Principal
+    #: `UidScheme` 上對應的欄位名。
+    field_name: str
+    #: CLI 旗標（`python -m paulsha_cortex.trust_root permissions …`）。
+    cli_flag: str
+    #: env 變數名（CLI 未給時的來源；CLI 優先）。
+    env_var: str
+    #: 這個角色是什麼——進錯誤訊息，讓 operator 知道自己在決定什麼。
+    description: str
+
+
+PRINCIPAL_ACCOUNT_OPTIONS: tuple[PrincipalAccountOption, ...] = (
+    PrincipalAccountOption(
+        principal=Principal.OPERATOR,
+        field_name="operator_account",
+        cli_flag="--operator-account",
+        env_var="PSC_OPERATOR_ACCOUNT",
+        description=(
+            "人類操作者的登入帳號——單人機器＝那個人的帳號，多人／CI 部署可能是專用帳號"
+        ),
+    ),
+    PrincipalAccountOption(
+        principal=Principal.EXTERNAL,
+        field_name="external_reader_account",
+        cli_flag="--external-reader-account",
+        env_var="PSC_EXTERNAL_READER_ACCOUNT",
+        description=(
+            "外送管線／外部學習系統的唯讀 reader"
+            "——digest outbox 與 engineering-outcome outbox 的下游"
+        ),
+    ),
+)
+
+#: principal → 注入管道，供錯誤訊息與 CLI 反查。
+PRINCIPAL_ACCOUNT_OPTION_BY_PRINCIPAL: Mapping[Principal, PrincipalAccountOption] = {
+    opt.principal: opt for opt in PRINCIPAL_ACCOUNT_OPTIONS
+}
+
+
+class UnresolvedPrincipalError(ValueError):
+    """方案未把某個部署決定型 principal 對應到真實帳號（#626 的 fail-closed 出口）。
+
+    raise 的時機是**輸出前**：一行命令都還沒印出去。這是刻意的——runbook 以
+    `sudo sh -e` 跑整份 script，印出去一行指向不存在帳號的 `setfacl` 就足以中止
+    整份 script 並留下半套用的權限樹。
+    """
+
+    def __init__(self, unresolved: tuple[Principal, ...], scheme_id: str) -> None:
+        self.unresolved = tuple(unresolved)
+        self.scheme_id = scheme_id
+        super().__init__(unresolved_principal_message(self.unresolved, scheme_id))
+
+
+class UnknownAccountInOutputError(ValueError):
+    """輸出裡出現了不在本方案宣告帳號集合內的名字（自我檢查的最後一道）。"""
+
+    def __init__(self, unknown: tuple[str, ...], scheme_id: str, declared: frozenset[str]) -> None:
+        self.unknown = tuple(unknown)
+        self.scheme_id = scheme_id
+        self.declared = frozenset(declared)
+        super().__init__(
+            "permgen 自我檢查失敗：輸出含未宣告的帳號 "
+            f"{list(self.unknown)}（scheme={scheme_id}）。\n"
+            f"本方案宣告的帳號集合：{sorted(self.declared)}。\n"
+            "這代表某個 principal 的對應仍是**字面角色名**而不是真實 OS 帳號——"
+            "在 `sudo sh -e` 下會 `Invalid argument` 中止整份 script 並留下半套用的"
+            "權限樹（#626）。請把該 principal 補進對應表，或明示它在本部署不存在。"
+        )
+
+
+def unresolved_principal_message(
+    unresolved: tuple[Principal, ...],
+    scheme_id: str,
+) -> str:
+    """fail-closed 的可操作訊息：指出是哪個 principal、以及怎麼指定。"""
+    lines = [
+        f"permgen 拒絕輸出命令：scheme={scheme_id} 有 {len(unresolved)} 個 principal "
+        "未對應到真實 OS 帳號。",
+        "",
+    ]
+    for principal in unresolved:
+        opt = PRINCIPAL_ACCOUNT_OPTION_BY_PRINCIPAL.get(principal)
+        if opt is None:
+            lines.append(
+                f"  - principal `{principal.value}`：`UidScheme.account_of` 缺這一項，"
+                "請補上對應的 OS 帳號名。"
+            )
+            continue
+        lines += [
+            f"  - principal `{principal.value}`（{opt.description}）未對應到真實帳號。",
+            f"      指定：{opt.cli_flag} <帳號名>   或   env {opt.env_var}=<帳號名>",
+            f"      本部署沒有這個角色時，明示：{opt.cli_flag} none"
+            f"（等同 {opt.env_var}=none）——該 principal 的授權整組略去。",
+        ]
+    lines += [
+        "",
+        "為何不先印出來讓人自己看：runbook 第 2b 步以 `sudo sh -e` 執行整份權限 script，",
+        "而 `setfacl -m u:<不存在的帳號>:rX` 會回 `Invalid argument near character 3`",
+        "並**中止整份 script**，留下一棵半套用的權限樹（前段已 chown/chmod、後段完全沒動），",
+        "錯誤訊息還完全看不出是「帳號不存在」（#626）。",
+        "指定前請先確認帳號存在：`getent passwd <帳號名>`。",
+    ]
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
 # UID 方案 config（參數化——二分為預設，同一資料結構可表達三分）
 # ---------------------------------------------------------------------------
 
@@ -66,9 +223,14 @@ from .registry import (
 class UidScheme:
     """persona→OS 帳號的映射方案。
 
-    `account_of` 必須涵蓋登記表出現過的所有非 `ANY_SAME_UID` principal
+    `account_of` 必須涵蓋登記表出現過的所有**服務／job** principal
     （`ANY_SAME_UID` 是「現況同 UID 任意行程」的標記，正是 Phase 2 要移除的對象，
     故**不**映射到任何目標帳號）。
+
+    `INSTALLER`／`OPERATOR`／`EXTERNAL` 三者**不得**放進 `account_of`：前者永遠是
+    `deploy_account`，後兩者是部署決定，走各自的欄位（見
+    :data:`PRINCIPAL_ACCOUNT_OPTIONS`）。放進 `account_of` 會被靜默忽略，因此
+    `__post_init__` 直接拒絕——「兩份真相」正是 #626 的成因。
     """
 
     scheme_id: str
@@ -77,17 +239,49 @@ class UidScheme:
     durable_state_owner: str
     #: enforcement plane（unit／venv／launcher／env／codex hooks）的擁有者。
     deploy_account: str = "root"
-    #: 外部唯讀消費者（digest／engineering-outcome outbox 的下游）帳號。
-    external_reader: str = "cortex-outbox"
+    #: 人類操作者的登入帳號。**部署決定**：`None`＝未指定（產生器 fail-closed），
+    #: :data:`ABSENT_ACCOUNT`＝本部署沒有這個角色。
+    operator_account: str | None = None
+    #: 外部唯讀消費者（digest／engineering-outcome outbox 的下游）帳號。同上三態。
+    external_reader_account: str | None = None
+
+    def __post_init__(self) -> None:
+        managed = {opt.principal for opt in PRINCIPAL_ACCOUNT_OPTIONS} | {
+            Principal.INSTALLER, Principal.ANY_SAME_UID,
+        }
+        overlap = sorted(p.value for p in self.account_of if p in managed)
+        if overlap:
+            raise ValueError(
+                f"UidScheme(scheme_id={self.scheme_id!r})：{overlap} 不得出現在 "
+                "`account_of`——它們由專屬欄位決定（deploy_account／"
+                + "／".join(opt.field_name for opt in PRINCIPAL_ACCOUNT_OPTIONS)
+                + "），寫在 `account_of` 會被靜默忽略而形成第二份真相（#626）。"
+            )
+        for name in list(self.account_of.values()) + [
+            self.durable_state_owner, self.deploy_account,
+        ]:
+            _validate_account_name(name)
+        for opt in PRINCIPAL_ACCOUNT_OPTIONS:
+            value = getattr(self, opt.field_name)
+            if value is None or value == ABSENT_ACCOUNT:
+                continue
+            _validate_account_name(value, flag=opt.cli_flag)
 
     def resolve(self, principal: Principal) -> str | None:
-        """回傳 principal 的目標帳號；`ANY_SAME_UID` 與未映射者回傳 None。"""
+        """回傳 principal 的目標帳號；`ANY_SAME_UID`、未指定與明示不存在者回傳 None。
+
+        **回傳 None 不代表沒問題**：呼叫端要區分「本來就不該有帳號」
+        （`ANY_SAME_UID`／`ABSENT_ACCOUNT`）與「對應表缺項」——後者由
+        :meth:`unresolved_principals` 抓出來並讓產生器 fail-closed。
+        """
         if principal is Principal.ANY_SAME_UID:
             return None
         if principal is Principal.INSTALLER:
             return self.deploy_account
-        if principal is Principal.EXTERNAL:
-            return self.external_reader
+        opt = PRINCIPAL_ACCOUNT_OPTION_BY_PRINCIPAL.get(principal)
+        if opt is not None:
+            value = getattr(self, opt.field_name)
+            return None if value in (None, ABSENT_ACCOUNT) else value
         return self.account_of.get(principal)
 
     def group_of(self, account: str) -> str:
@@ -107,6 +301,74 @@ class UidScheme:
                 accts.add(a)
         return frozenset(accts)
 
+    def declared_accounts(self) -> frozenset[str]:
+        """本方案宣告過的**全部**帳號名——輸出自我檢查的比對基準。
+
+        任何出現在產生命令裡的帳號名都必須落在這個集合內；落在集合外就代表某處把
+        抽象角色名當帳號印出去了（#626）。
+        """
+        accts = set(self.account_of.values())
+        accts.add(self.durable_state_owner)
+        accts.add(self.deploy_account)
+        for opt in PRINCIPAL_ACCOUNT_OPTIONS:
+            value = getattr(self, opt.field_name)
+            if value is not None and value != ABSENT_ACCOUNT:
+                accts.add(value)
+        return frozenset(accts)
+
+    def unresolved_principals(
+        self,
+        assets: tuple[TrustRootAsset, ...] = registry.ASSET_REGISTRY,
+    ) -> tuple[Principal, ...]:
+        """登記表用到、但本方案**沒有**對應到帳號也沒明示不存在的 principal。
+
+        `ANY_SAME_UID` 不算（它本來就不該有帳號）；明示 :data:`ABSENT_ACCOUNT` 的
+        也不算（那是決定，不是遺漏）。回傳依 principal 值排序，確保訊息決定性。
+        """
+        missing: set[Principal] = set()
+        for asset in assets:
+            for principal in tuple(asset.writers) + tuple(asset.readers):
+                if principal is Principal.ANY_SAME_UID:
+                    continue
+                opt = PRINCIPAL_ACCOUNT_OPTION_BY_PRINCIPAL.get(principal)
+                if opt is not None:
+                    if getattr(self, opt.field_name) is None:
+                        missing.add(principal)
+                    continue
+                if self.resolve(principal) is None:
+                    missing.add(principal)
+        return tuple(sorted(missing, key=lambda p: p.value))
+
+    def with_principal_accounts(
+        self,
+        accounts: Mapping[Principal, str],
+    ) -> "UidScheme":
+        """回傳帶上部署決定型 principal 對應的新方案（本體 frozen，不就地改）。
+
+        CLI／env 注入的唯一入口。未列出的 principal 沿用原值。
+        """
+        overrides: dict[str, str] = {}
+        for principal, account in accounts.items():
+            opt = PRINCIPAL_ACCOUNT_OPTION_BY_PRINCIPAL.get(principal)
+            if opt is None:
+                raise ValueError(
+                    f"principal `{principal.value}` 不是部署決定型的對應項；"
+                    f"可指定的只有 {[o.principal.value for o in PRINCIPAL_ACCOUNT_OPTIONS]}。"
+                )
+            overrides[opt.field_name] = account
+        return replace(self, **overrides)
+
+
+def _validate_account_name(name: str, flag: str | None = None) -> None:
+    """帳號名必須是合法 POSIX 帳號形狀——名字會被逐字嵌進命令字串。"""
+    if not isinstance(name, str) or not _ACCOUNT_NAME_RE.match(name):
+        where = f"（{flag}）" if flag else ""
+        raise ValueError(
+            f"不是合法的 OS 帳號名{where}：{name!r}。"
+            "帳號名會被逐字嵌進 setfacl／chown 命令字串，只接受 "
+            "`^[a-z_][a-z0-9_-]*\\$?$`。"
+        )
+
 
 #: 二分（**向後相容選項**，非預設）：builder 一個帳號，其餘 headless／Manager／
 #: monitor 共用 cortex-svc。0816 第三輪裁決前的方案；已按此裝好的部署可續用，
@@ -120,10 +382,11 @@ TWO_WAY_SCHEME = UidScheme(
         Principal.PLANNER: "cortex-svc",
         Principal.BUILDER: "cortex-builder",
         Principal.HEADLESS_HOOK: "cortex-builder",
-        Principal.OPERATOR: "operator",
     },
     durable_state_owner="cortex-svc",
     deploy_account="root",
+    # operator_account／external_reader_account 刻意留 None：它們是部署決定，
+    # 由 CLI／env 於產生當下注入（#626）。寫死在這裡就是把部署決定編進程式碼。
 )
 
 #: 三分（**定案**）：把 cortex-svc 拆成 cortex-manager（durable state owner，持 spawn
@@ -138,10 +401,10 @@ THREE_WAY_SCHEME = UidScheme(
         Principal.PLANNER: "cortex-reviewer-planner",
         Principal.BUILDER: "cortex-builder",
         Principal.HEADLESS_HOOK: "cortex-builder",
-        Principal.OPERATOR: "operator",
     },
     durable_state_owner="cortex-manager",
     deploy_account="root",
+    # 同二分：operator／external reader 是部署決定，不寫死（#626）。
 )
 
 SCHEMES: dict[str, UidScheme] = {
@@ -493,6 +756,19 @@ class PermissionPlan:
     #: writers／readers，故把輸入資產一併帶著走。手工組出的 plan 留空 tuple，
     #: 此時 `required_write_targets` 退回 `registry.ASSET_REGISTRY` 查表。
     assets: tuple[TrustRootAsset, ...] = ()
+    #: 產生本計畫的方案**本體**。`scheme_id` 只是名字，查 `SCHEMES` 拿回來的是
+    #: 模組層那個**未注入部署對應**的方案（#626 之後 operator／external reader 是
+    #: 產生當下才注入的）——只憑 id 反查會把注入過的對應整個丟掉，自我檢查因此會
+    #: 誤判。故一律把方案本身帶著走；`compare=False` 讓兩份同方案計畫仍然相等。
+    scheme: "UidScheme | None" = field(default=None, compare=False, repr=False)
+
+    @property
+    def unresolved_principals(self) -> tuple[Principal, ...]:
+        """本計畫用到、但方案沒有對應到帳號的 principal（空 tuple＝可安全輸出）。"""
+        scheme = self.scheme or SCHEMES.get(self.scheme_id)
+        if scheme is None:
+            return ()
+        return scheme.unresolved_principals(self.assets or registry.ASSET_REGISTRY)
 
     def by_id(self, asset_id: str) -> PermissionEntry:
         for e in self.entries:
@@ -512,6 +788,9 @@ class PermissionPlan:
         return {
             "scheme_id": self.scheme_id,
             "asset_count": len(self.entries),
+            # 未對應的 principal 一律隨計畫一起出現：JSON 模式不會 raise（它是診斷
+            # 用途），但**必須**看得出「這份計畫少了誰的授權」，否則就是靜默漏授。
+            "unresolved_principals": [p.value for p in self.unresolved_principals],
             "entries": [e.to_dict() for e in self.entries],
         }
 
@@ -520,9 +799,74 @@ def generate_plan(
     scheme: UidScheme,
     assets: tuple[TrustRootAsset, ...] = registry.ASSET_REGISTRY,
 ) -> PermissionPlan:
-    """對登記表每一項機械產生權限，回傳完整計畫（涵蓋無遺漏）。"""
+    """對登記表每一項機械產生權限，回傳完整計畫（涵蓋無遺漏）。
+
+    **本函式不 fail-closed**：計畫是資料，看得到未對應的 principal 反而有助診斷
+    （`PermissionPlan.unresolved_principals`）。fail-closed 發生在
+    :func:`plan_to_commands`——也就是「要輸出會被 `sh -e` 執行的命令」的那一刻。
+    """
     entries = tuple(build_entry(a, scheme) for a in assets)
-    return PermissionPlan(scheme_id=scheme.scheme_id, entries=entries, assets=tuple(assets))
+    return PermissionPlan(
+        scheme_id=scheme.scheme_id,
+        entries=entries,
+        assets=tuple(assets),
+        scheme=scheme,
+    )
+
+
+def _scheme_for(plan: PermissionPlan, scheme: UidScheme | None) -> UidScheme:
+    """取本計畫該用的方案：顯式參數 > 計畫自帶 > `SCHEMES` 反查 > 預設。
+
+    順序不能反：`SCHEMES[plan.scheme_id]` 拿到的是**未注入部署對應**的模組層方案。
+    """
+    if scheme is not None:
+        return scheme
+    if plan.scheme is not None:
+        return plan.scheme
+    return SCHEMES.get(plan.scheme_id, DEFAULT_SCHEME)
+
+
+def assert_principals_resolved(plan: PermissionPlan, scheme: UidScheme) -> None:
+    """輸出前的 fail-closed 閘：有任何未對應的 principal 即 raise，一行都不輸出。"""
+    unresolved = scheme.unresolved_principals(plan.assets or registry.ASSET_REGISTRY)
+    if unresolved:
+        raise UnresolvedPrincipalError(unresolved, scheme.scheme_id)
+
+
+#: 命令字串裡的 ACL 帳號（`setfacl … u:<name>:<perms> …`）。前置的 `(?<![\w-])`
+#: 防止把 `menu:x:` 這種尾字為 `u` 的名字誤切成 `u:` 條目。
+_ACL_ACCOUNT_RE = re.compile(r"(?<![\w-])u:([^:\s]+):")
+#: `chown <owner>:<group> <path>`——owner／group 同樣必須是宣告過的帳號。
+_CHOWN_ACCOUNT_RE = re.compile(r"(?<![\w-])chown\s+([^:\s]+):([^:\s]+)\s")
+
+
+def unknown_accounts_in(lines: "list[str]", scheme: UidScheme) -> tuple[str, ...]:
+    """輸出行裡出現、卻不在方案宣告帳號集合內的名字（空 tuple＝乾淨）。
+
+    註解行**一併檢查**：per-job 資產是以註解形式輸出的，一個 phantom 帳號躲在
+    `#   setfacl …` 裡照樣會被人複製貼上去執行。
+    """
+    declared = scheme.declared_accounts()
+    seen: set[str] = set()
+    for line in lines:
+        for match in _ACL_ACCOUNT_RE.finditer(line):
+            seen.add(match.group(1))
+        for match in _CHOWN_ACCOUNT_RE.finditer(line):
+            seen.update(match.groups())
+    return tuple(sorted(seen - declared))
+
+
+def assert_output_accounts_known(lines: "list[str]", scheme: UidScheme) -> None:
+    """自我檢查：輸出裡每個帳號名都必須是本方案宣告過的，否則 raise。
+
+    這條擋的是**未來**——新增一個 principal 而忘了進對應表時，字面角色名一漏進
+    命令字串就 raise，不會再靜默產生一行 `sh -e` 下會炸掉的 `setfacl`（#626）。
+    """
+    unknown = unknown_accounts_in(lines, scheme)
+    if unknown:
+        raise UnknownAccountInOutputError(
+            unknown, scheme.scheme_id, scheme.declared_accounts()
+        )
 
 
 def _placeholder_path(entry: PermissionEntry) -> str:
@@ -552,7 +896,14 @@ def plan_to_commands(
     traverse ACL（`derive_traverse_grants`，#620）——沒有它，葉節點 ACL 全部正確
     但路徑走不通。`layout`／`scheme` 只影響那一節（骨架目錄的 owner／mode 是判斷
     「這層是否已可 traverse」的輸入），未給時取 `DEFAULT_LAYOUT` 與 plan 的 scheme。
+
+    **fail-closed（#626）**：方案裡有任何 principal 沒對應到真實 OS 帳號時，本函式
+    raise :class:`UnresolvedPrincipalError` 而**不輸出任何一行**；輸出組完後再過一道
+    :func:`assert_output_accounts_known` 自我檢查。理由見模組 docstring——半套用的
+    權限樹比「產生器拒絕產出」危險得多。
     """
+    scheme = _scheme_for(plan, scheme)
+    assert_principals_resolved(plan, scheme)
     lines: list[str] = [
         f"# trust-root Phase 2b 權限套用命令（scheme={plan.scheme_id}）",
         "# 由 permgen 機械產生；operator 逐項 review 後手動 sudo 執行。",
@@ -590,6 +941,7 @@ def plan_to_commands(
     lines += traverse_commands(
         derive_traverse_grants(plan, layout, scheme, path_of=path_of or {})
     )
+    assert_output_accounts_known(lines, scheme)
     return lines
 
 
@@ -1048,7 +1400,7 @@ def directory_facts(
 ) -> dict[str, DirectoryFacts]:
     """路徑→目標狀態（骨架目錄先鋪底，登記表資產覆蓋其上）。純函式、無 IO。"""
     layout = layout if layout is not None else DEFAULT_LAYOUT
-    scheme = scheme if scheme is not None else SCHEMES.get(plan.scheme_id, DEFAULT_SCHEME)
+    scheme = _scheme_for(plan, scheme)
     paths = dict(path_of) if path_of is not None else layout.asset_paths()
     facts: dict[str, DirectoryFacts] = {}
     for path, owner, group, mode in layout.scaffold_directories(scheme):
@@ -1159,7 +1511,7 @@ def derive_traverse_grants(
     一律跳過——不重複產生。回傳依 `(path, account)` 排序，確保輸出決定性。
     """
     layout = layout if layout is not None else DEFAULT_LAYOUT
-    scheme = scheme if scheme is not None else SCHEMES.get(plan.scheme_id, DEFAULT_SCHEME)
+    scheme = _scheme_for(plan, scheme)
     paths = dict(path_of) if path_of is not None else layout.asset_paths()
     facts = directory_facts(plan, layout, scheme, paths)
     roots = managed_roots(facts)
@@ -1198,7 +1550,7 @@ def unreachable_hops(
     這就是 #620 的驗收條件本身：葉節點 ACL 正確 **≠** 路徑走得通。
     """
     layout = layout if layout is not None else DEFAULT_LAYOUT
-    scheme = scheme if scheme is not None else SCHEMES.get(plan.scheme_id, DEFAULT_SCHEME)
+    scheme = _scheme_for(plan, scheme)
     paths = dict(path_of) if path_of is not None else layout.asset_paths()
     facts = directory_facts(plan, layout, scheme, paths)
     if grants is None:

--- a/tests/test_trust_root_permgen_p2a.py
+++ b/tests/test_trust_root_permgen_p2a.py
@@ -24,6 +24,19 @@ from paulsha_cortex.trust_root.registry import ASSET_REGISTRY, Principal
 
 ALL_SCHEMES = [TWO_WAY_SCHEME, THREE_WAY_SCHEME]
 
+#: #626：`operator` 與 `external` 是部署決定，模組層方案刻意留 `None`——未注入時
+#: `plan_to_commands()` 一律 fail-closed（由
+#: `tests/test_trust_root_principal_account_mapping_626.py` 專門釘住）。本檔要驗
+#: 命令輸出的測試先注入一組示範對應。
+DEPLOYMENT_ACCOUNTS = {
+    Principal.OPERATOR: "cortex-ops",
+    Principal.EXTERNAL: "cortex-outbox",
+}
+
+
+def _resolved(scheme):
+    return scheme.with_principal_accounts(DEPLOYMENT_ACCOUNTS)
+
 
 def _plan(scheme) -> PermissionPlan:
     return generate_plan(scheme)
@@ -191,9 +204,11 @@ def test_custom_scheme_needs_no_code_change() -> None:
             Principal.PLANNER: "cortex-planner",
             Principal.BUILDER: "cortex-builder",
             Principal.HEADLESS_HOOK: "cortex-builder",
-            Principal.OPERATOR: "operator",
         },
         durable_state_owner="cortex-manager",
+        # #626：部署決定型 principal 走專屬欄位，不得混進 `account_of`。
+        operator_account="cortex-ops",
+        external_reader_account="cortex-outbox",
     )
     plan = generate_plan(four_way)
     assert len(plan.entries) == len(ASSET_REGISTRY)
@@ -220,7 +235,7 @@ def test_plan_is_json_serializable(scheme) -> None:
 def test_commands_are_strings_only_and_never_execute(scheme) -> None:
     """產出只能是 install -d／chown／chmod／setfacl（可帶 `[ ! -e ] ||` 存在性守衛）
     字串——絕不執行任何 root 操作。"""
-    plan = _plan(scheme)
+    plan = _plan(_resolved(scheme))
     lines = permgen.plan_to_commands(plan)
     allowed = ("install -d ", "chown ", "chmod ", "setfacl ", "[ ! -e ")
     for line in lines:
@@ -236,7 +251,7 @@ def test_commands_are_strings_only_and_never_execute(scheme) -> None:
 
 def test_commands_honour_supplied_paths() -> None:
     """runbook 帶入真實路徑時，命令引用該路徑；未帶入者以 placeholder。"""
-    plan = _plan(TWO_WAY_SCHEME)
+    plan = _plan(_resolved(TWO_WAY_SCHEME))
     lines = permgen.plan_to_commands(plan, path_of={"jobs-registry": "/srv/agents/coordinator/jobs.json"})
     joined = "\n".join(lines)
     assert "/srv/agents/coordinator/jobs.json" in joined

--- a/tests/test_trust_root_permgen_p2b.py
+++ b/tests/test_trust_root_permgen_p2b.py
@@ -522,7 +522,11 @@ def test_scaffold_directories_are_command_strings_only() -> None:
 
 def test_commands_with_real_layout_have_no_placeholder_left() -> None:
     """runbook 引用形式：帶 layout 後輸出不再有 <PATH:...> placeholder。"""
-    plan = generate_plan(TWO_WAY_SCHEME)
+    # #626：命令輸出前必須先把部署決定型 principal 對應到真實帳號，否則 fail-closed。
+    plan = generate_plan(TWO_WAY_SCHEME.with_principal_accounts({
+        Principal.OPERATOR: "cortex-ops",
+        Principal.EXTERNAL: "cortex-outbox",
+    }))
     lines = permgen.plan_to_commands(plan, path_of=permgen.asset_paths())
     commands = [ln for ln in lines if ln.strip() and not ln.lstrip().startswith("#")]
     assert commands

--- a/tests/test_trust_root_permgen_traverse_620.py
+++ b/tests/test_trust_root_permgen_traverse_620.py
@@ -20,9 +20,7 @@ import pytest
 from paulsha_cortex.trust_root import permgen
 from paulsha_cortex.trust_root.permgen import (
     DEFAULT_LAYOUT,
-    THREE_WAY_SCHEME,
     TRAVERSE_PERMS,
-    TWO_WAY_SCHEME,
     PathLayout,
     account_can_reach,
     can_traverse,
@@ -31,7 +29,21 @@ from paulsha_cortex.trust_root.permgen import (
     generate_plan,
     unreachable_hops,
 )
+from paulsha_cortex.trust_root.permgen import THREE_WAY_SCHEME as _THREE_WAY_BASE
+from paulsha_cortex.trust_root.permgen import TWO_WAY_SCHEME as _TWO_WAY_BASE
 from paulsha_cortex.trust_root.registry import Principal
+
+#: #626：`operator` 與 `external` 是**部署決定**，模組層方案刻意留 `None`，未注入時
+#: 產生器 fail-closed。traverse 推導的驗收本來就涵蓋這兩個帳號的中間層授權
+#: （`cortex-outbox` 對 `coordinator`／`coordinator/digest`、operator 對 `coordinator`），
+#: 故本檔一律用**注入後**的方案；fail-closed 本身由
+#: `tests/test_trust_root_principal_account_mapping_626.py` 專門釘住。
+DEPLOYMENT_ACCOUNTS = {
+    Principal.OPERATOR: "cortex-ops",
+    Principal.EXTERNAL: "cortex-outbox",
+}
+TWO_WAY_SCHEME = _TWO_WAY_BASE.with_principal_accounts(DEPLOYMENT_ACCOUNTS)
+THREE_WAY_SCHEME = _THREE_WAY_BASE.with_principal_accounts(DEPLOYMENT_ACCOUNTS)
 
 ALL_SCHEMES = [TWO_WAY_SCHEME, THREE_WAY_SCHEME]
 

--- a/tests/test_trust_root_principal_account_mapping_626.py
+++ b/tests/test_trust_root_principal_account_mapping_626.py
@@ -1,0 +1,381 @@
+"""#626：principal→真實 OS 帳號的對應外部化 ＋ 未對應時 fail-closed。
+
+Phase 2b 實機症狀：`permissions three-way --commands --paths` 為 `operator` 與
+`cortex-outbox` 兩個**抽象角色名**印出 `setfacl -m u:operator:rX …`。它們不是真實
+帳號，`setfacl` 回 `Invalid argument near character 3`，而 runbook 第 2b 步是
+`sudo sh -e /tmp/p2b-permissions.sh`——`sh -e` 遇到第一條就**中止整份 script**，留下
+一棵半套用的權限樹（前段已 chown/chmod、後段完全沒動），錯誤訊息還看不出是
+「帳號不存在」。#624 的 traverse ACL 讓這條更嚴重（多產了幾條同樣的 phantom ACL）。
+
+驗收（對應 issue 的四條）：
+- (a) 未指定對應時 fail-closed，且訊息含 principal 名與指定方式；
+- (b) 指定後輸出的每個 `u:<name>:` 都可解析（都在方案宣告的帳號集合內）；
+- (c) **不變式**：輸出中不得出現任何不在帳號集合內的字面值——這條要能擋住未來
+      新增 principal 時再犯同一個錯；
+- (d) 兩個 scheme 都測。
+"""
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from paulsha_cortex.trust_root import permgen
+from paulsha_cortex.trust_root.__main__ import main
+from paulsha_cortex.trust_root.permgen import (
+    ABSENT_ACCOUNT,
+    PRINCIPAL_ACCOUNT_OPTIONS,
+    THREE_WAY_SCHEME,
+    TWO_WAY_SCHEME,
+    UidScheme,
+    UnknownAccountInOutputError,
+    UnresolvedPrincipalError,
+    generate_plan,
+)
+from paulsha_cortex.trust_root.registry import ASSET_REGISTRY, Principal
+
+ALL_SCHEMES = [TWO_WAY_SCHEME, THREE_WAY_SCHEME]
+
+#: issue 已確認的 phantom 集合——登記表裡沒有第三個。這兩個字面值是**角色名**，
+#: 實機上不存在對應帳號，任何一個漏進輸出都會讓 `sh -e` 中止整份 script。
+PHANTOM_LITERALS = ("cortex-outbox", "operator")
+
+DEPLOYMENT_ACCOUNTS = {
+    Principal.OPERATOR: "cortex-ops",
+    Principal.EXTERNAL: "cortex-outbox-reader",
+}
+
+#: 命令字串裡的 ACL 帳號（與產生器自我檢查同一條 regex 的行為）。
+ACL_ACCOUNT_RE = re.compile(r"(?<![\w-])u:([^:\s]+):")
+
+
+def _resolved(scheme: UidScheme) -> UidScheme:
+    return scheme.with_principal_accounts(DEPLOYMENT_ACCOUNTS)
+
+
+def _commands(scheme: UidScheme) -> list[str]:
+    return permgen.plan_to_commands(generate_plan(scheme), path_of=permgen.asset_paths())
+
+
+# ---------------------------------------------------------------------------
+# 根因：對應表缺項，不是填錯——模組層方案不得把角色名當帳號
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
+def test_shipped_schemes_do_not_hardcode_a_deployment_decision(scheme) -> None:
+    """`operator` 對應到誰是部署決定，程式碼裡不得有預設值（#626 的根因）。"""
+    for opt in PRINCIPAL_ACCOUNT_OPTIONS:
+        assert getattr(scheme, opt.field_name) is None, opt.field_name
+        assert scheme.resolve(opt.principal) is None, opt.principal
+
+
+@pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
+def test_phantom_literals_are_not_declared_accounts(scheme) -> None:
+    """兩個角色名都不在方案宣告的帳號集合內——它們從來就不是帳號。"""
+    declared = scheme.declared_accounts()
+    for literal in PHANTOM_LITERALS:
+        assert literal not in declared, literal
+
+
+def test_deployment_principals_may_not_hide_in_account_of() -> None:
+    """把 `operator` 塞回 `account_of` 會被靜默忽略——第二份真相正是 #626 的成因，
+    因此直接拒絕建構。"""
+    with pytest.raises(ValueError) as exc:
+        UidScheme(
+            scheme_id="bad",
+            account_of={
+                Principal.MANAGER: "cortex-manager",
+                Principal.OPERATOR: "operator",
+            },
+            durable_state_owner="cortex-manager",
+        )
+    assert "operator" in str(exc.value)
+    assert "account_of" in str(exc.value)
+
+
+# ---------------------------------------------------------------------------
+# (a) 未指定對應時 fail-closed，訊息可操作
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
+def test_unresolved_principals_are_reported_before_any_output(scheme) -> None:
+    unresolved = scheme.unresolved_principals()
+    assert {p.value for p in unresolved} == {"external", "operator"}
+    assert generate_plan(scheme).unresolved_principals == unresolved
+
+
+@pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
+def test_commands_fail_closed_when_mapping_is_missing(scheme) -> None:
+    """未指定對應時**一行都不輸出**——半套用的權限樹比「產生器拒絕產出」危險得多。"""
+    with pytest.raises(UnresolvedPrincipalError) as exc:
+        _commands(scheme)
+    assert {p.value for p in exc.value.unresolved} == {"external", "operator"}
+
+
+@pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
+def test_fail_closed_message_names_the_principal_and_how_to_specify_it(scheme) -> None:
+    """訊息必須可操作：是哪個 principal、走哪個旗標／env、以及怎麼確認帳號存在。"""
+    with pytest.raises(UnresolvedPrincipalError) as exc:
+        _commands(scheme)
+    message = str(exc.value)
+    assert scheme.scheme_id in message
+    for opt in PRINCIPAL_ACCOUNT_OPTIONS:
+        assert f"`{opt.principal.value}`" in message, opt.principal
+        assert opt.cli_flag in message, opt.cli_flag
+        assert opt.env_var in message, opt.env_var
+    assert "getent passwd" in message
+
+
+@pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
+def test_partial_mapping_still_fails_closed(scheme) -> None:
+    """只補一半也不放行——剩下那個仍會印出 phantom ACL。"""
+    half = scheme.with_principal_accounts({Principal.OPERATOR: "cortex-ops"})
+    with pytest.raises(UnresolvedPrincipalError) as exc:
+        _commands(half)
+    assert {p.value for p in exc.value.unresolved} == {"external"}
+
+
+# ---------------------------------------------------------------------------
+# (b) 指定後輸出的每個 u:<name>: 都可解析
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
+def test_every_acl_account_resolves_after_mapping_is_supplied(scheme) -> None:
+    lines = _commands(_resolved(scheme))
+    declared = _resolved(scheme).declared_accounts()
+    found = {m.group(1) for line in lines for m in ACL_ACCOUNT_RE.finditer(line)}
+    assert found, "應該要有跨帳號 ACL"
+    assert found <= declared, sorted(found - declared)
+
+
+@pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
+def test_supplied_accounts_actually_appear_in_the_output(scheme) -> None:
+    """注入的帳號要真的被用上——否則「指定了」與「有效」是兩回事。"""
+    joined = "\n".join(_commands(_resolved(scheme)))
+    for account in DEPLOYMENT_ACCOUNTS.values():
+        assert f"u:{account}:" in joined, account
+
+
+@pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
+def test_phantom_role_names_never_appear_after_the_fix(scheme) -> None:
+    """issue 貼出的那幾行，逐字不得再出現。"""
+    joined = "\n".join(_commands(_resolved(scheme)))
+    for literal in PHANTOM_LITERALS:
+        assert f"u:{literal}:" not in joined, literal
+    assert "setfacl -m u:operator:rX" not in joined
+
+
+# ---------------------------------------------------------------------------
+# (c) 不變式：輸出不得出現任何不在帳號集合內的字面值
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
+def test_output_contains_no_account_outside_the_declared_set(scheme) -> None:
+    """`u:<name>:` 與 `chown <owner>:<group>` 的每個名字都必須是宣告過的帳號。
+
+    這是**擋未來**的那條：新增 principal 而忘了進對應表時，字面角色名一漏進命令
+    字串就會被抓出來。
+    """
+    resolved = _resolved(scheme)
+    lines = _commands(resolved)
+    assert permgen.unknown_accounts_in(lines, resolved) == ()
+    permgen.assert_output_accounts_known(lines, resolved)
+
+
+def test_self_check_catches_a_future_principal_that_slips_through() -> None:
+    """模擬「未來新增一個 principal 卻沒進對應表」：自我檢查必須攔下。
+
+    直接偽造一行帶未知帳號的輸出——不依賴任何未來才存在的 principal，因此這條
+    不會因為登記表變動而失效。
+    """
+    resolved = _resolved(THREE_WAY_SCHEME)
+    lines = _commands(resolved) + ["setfacl -m u:future-role:rX /var/lib/cortex/x"]
+    assert permgen.unknown_accounts_in(lines, resolved) == ("future-role",)
+    with pytest.raises(UnknownAccountInOutputError) as exc:
+        permgen.assert_output_accounts_known(lines, resolved)
+    assert "future-role" in str(exc.value)
+
+
+def test_self_check_also_covers_commented_out_per_job_lines() -> None:
+    """per-job 資產以註解形式輸出——phantom 躲在 `#   setfacl …` 裡照樣會被複製執行。"""
+    resolved = _resolved(THREE_WAY_SCHEME)
+    lines = ["#   setfacl -m u:operator:rX /var/lib/cortex/worktree/<job-id>"]
+    assert permgen.unknown_accounts_in(lines, resolved) == ("operator",)
+
+
+def test_self_check_does_not_false_positive_on_names_ending_in_u() -> None:
+    """`menu:x:` 不是 `u:` 條目——regex 不得把尾字為 `u` 的名字誤切。"""
+    scheme = _resolved(THREE_WAY_SCHEME)
+    assert permgen.unknown_accounts_in(["chown menu:menu /tmp/x"], scheme) == ("menu",)
+    assert permgen.unknown_accounts_in(["# 說明：menu:x: 不是 ACL"], scheme) == ()
+
+
+def test_chown_owner_is_checked_too() -> None:
+    """ACL 之外，`chown` 的 owner／group 同樣必須是宣告過的帳號。"""
+    scheme = _resolved(TWO_WAY_SCHEME)
+    lines = ["chown operator:operator /var/lib/cortex/control "]
+    assert permgen.unknown_accounts_in(lines, scheme) == ("operator",)
+
+
+# ---------------------------------------------------------------------------
+# 明示「本部署沒有這個角色」——與「忘了指定」嚴格區分
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
+def test_absent_account_is_a_decision_not_an_omission(scheme) -> None:
+    """本機還沒有 outbox reader 的實體時，明示 absent：授權整組略去、不 fail。"""
+    declared_absent = scheme.with_principal_accounts({
+        Principal.OPERATOR: "cortex-ops",
+        Principal.EXTERNAL: ABSENT_ACCOUNT,
+    })
+    assert declared_absent.unresolved_principals() == ()
+    assert declared_absent.resolve(Principal.EXTERNAL) is None
+    assert ABSENT_ACCOUNT not in declared_absent.declared_accounts()
+    joined = "\n".join(_commands(declared_absent))
+    assert ABSENT_ACCOUNT not in joined
+    assert "u:cortex-ops:" in joined
+
+
+def test_absent_external_reader_drops_exactly_that_principals_acls() -> None:
+    """略去的只有那個 principal 的授權——別人的 ACL 一條都不能少。"""
+    scheme = THREE_WAY_SCHEME.with_principal_accounts({
+        Principal.OPERATOR: "cortex-ops",
+        Principal.EXTERNAL: "cortex-outbox-reader",
+    })
+    absent = scheme.with_principal_accounts({Principal.EXTERNAL: ABSENT_ACCOUNT})
+    def _executable(scheme_: UidScheme) -> set[str]:
+        return {
+            ln for ln in _commands(scheme_)
+            if ln.strip() and not ln.lstrip().startswith("#")
+        }
+
+    full_lines = _executable(scheme)
+    absent_lines = _executable(absent)
+    dropped = full_lines - absent_lines
+    assert dropped, "略去 external reader 應該少掉幾條 ACL"
+    assert all("cortex-outbox-reader" in line for line in dropped), sorted(dropped)
+    assert absent_lines - full_lines == set(), "不得因此**多**出任何命令"
+
+
+# ---------------------------------------------------------------------------
+# 帳號名的形狀（命令字串是逐字嵌入的，注入必須在產生階段就被擋下）
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("bad", ["x y", "op;rm -rf /", "$(id -u)", "Operator", ""])
+def test_account_names_must_look_like_posix_accounts(bad) -> None:
+    with pytest.raises(ValueError):
+        THREE_WAY_SCHEME.with_principal_accounts({Principal.OPERATOR: bad})
+
+
+def test_with_principal_accounts_rejects_non_deployment_principals() -> None:
+    with pytest.raises(ValueError):
+        THREE_WAY_SCHEME.with_principal_accounts({Principal.BUILDER: "cortex-builder"})
+
+
+def test_with_principal_accounts_does_not_mutate_the_shipped_scheme() -> None:
+    _resolved(THREE_WAY_SCHEME)
+    assert THREE_WAY_SCHEME.operator_account is None
+    assert THREE_WAY_SCHEME.external_reader_account is None
+
+
+# ---------------------------------------------------------------------------
+# (d) CLI：旗標與 env 兩條注入管道，未給時 stdout 全空
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("scheme_id", ["two-way", "three-way"])
+def test_cli_fail_closed_prints_nothing_to_stdout(scheme_id, capsys) -> None:
+    """重導成 script 時，檔案必須是**空的**，而不是一份跑到一半會中止的半套 script。"""
+    assert main([
+        "permissions", scheme_id, "--commands", "--paths",
+    ]) == 2
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "--operator-account" in captured.err
+    assert "operator" in captured.err
+
+
+@pytest.mark.parametrize("scheme_id", ["two-way", "three-way"])
+def test_cli_flag_supplies_the_mapping(scheme_id, capsys) -> None:
+    assert main([
+        "permissions", scheme_id, "--commands", "--paths",
+        "--operator-account", "cortex-ops",
+        "--external-reader-account", "cortex-outbox-reader",
+    ]) == 0
+    out = capsys.readouterr().out
+    assert "u:cortex-ops:" in out
+    assert "u:operator:" not in out
+    assert "u:cortex-outbox:" not in out
+
+
+def test_cli_flag_accepts_equals_form(capsys) -> None:
+    assert main([
+        "permissions", "--commands", "--paths",
+        "--operator-account=cortex-ops", "--external-reader-account=none",
+    ]) == 0
+    assert "u:cortex-ops:" in capsys.readouterr().out
+
+
+def test_cli_env_supplies_the_mapping(monkeypatch, capsys) -> None:
+    monkeypatch.setenv("PSC_OPERATOR_ACCOUNT", "cortex-ops")
+    monkeypatch.setenv("PSC_EXTERNAL_READER_ACCOUNT", "none")
+    assert main(["permissions", "--commands", "--paths"]) == 0
+    out = capsys.readouterr().out
+    assert "u:cortex-ops:" in out
+    assert "u:operator:" not in out
+
+
+def test_cli_flag_wins_over_env(monkeypatch, capsys) -> None:
+    monkeypatch.setenv("PSC_OPERATOR_ACCOUNT", "from-env")
+    monkeypatch.setenv("PSC_EXTERNAL_READER_ACCOUNT", "none")
+    assert main([
+        "permissions", "--commands", "--paths", "--operator-account", "from-flag",
+    ]) == 0
+    out = capsys.readouterr().out
+    assert "u:from-flag:" in out
+    assert "from-env" not in out
+
+
+def test_cli_rejects_an_illegal_account_name(capsys) -> None:
+    assert main([
+        "permissions", "--commands", "--paths",
+        "--operator-account", "op; rm -rf /",
+        "--external-reader-account", "none",
+    ]) == 2
+    assert capsys.readouterr().out == ""
+
+
+def test_cli_rejects_a_dangling_account_flag(capsys) -> None:
+    assert main(["permissions", "--commands", "--operator-account"]) == 2
+    assert capsys.readouterr().out == ""
+
+
+def test_cli_json_mode_surfaces_unresolved_principals(capsys) -> None:
+    """JSON 是診斷模式：不 fail-closed，但「少了誰的授權」必須看得見。"""
+    assert main(["permissions", "three-way"]) == 0
+    captured = capsys.readouterr()
+    assert '"unresolved_principals"' in captured.out
+    assert '"operator"' in captured.out
+    assert "--operator-account" in captured.err
+
+
+# ---------------------------------------------------------------------------
+# 登記表側：phantom 集合恰好是這兩個，沒有第三個
+# ---------------------------------------------------------------------------
+
+def test_registry_needs_exactly_the_two_deployment_decisions() -> None:
+    """登記表用到的 principal 中，需要部署決定的恰好是 operator 與 external。
+
+    多一個就代表對應表又缺了一項，這條會直接紅——正是 #626 想擋住的復發路徑。
+    """
+    used: set[Principal] = set()
+    for asset in ASSET_REGISTRY:
+        used.update(asset.writers)
+        used.update(asset.readers)
+    covered = {opt.principal for opt in PRINCIPAL_ACCOUNT_OPTIONS}
+    fully_mapped = _resolved(THREE_WAY_SCHEME)
+    unmapped = {
+        p for p in used
+        if p is not Principal.ANY_SAME_UID and fully_mapped.resolve(p) is None
+    }
+    assert unmapped == set(), sorted(p.value for p in unmapped)
+    assert covered <= used


### PR DESCRIPTION
## 問題

`permissions three-way --commands --paths` 會印出這幾行：

```
setfacl -m u:operator:rX      /var/lib/cortex/control
setfacl -m u:cortex-outbox:rX /var/lib/cortex/coordinator/digest/outbox
setfacl -m u:operator:--x     /var/lib/cortex/coordinator      ← #620 之後又多幾條
```

`operator` 與 `cortex-outbox` 是 `registry.Principal` 的**抽象角色名**，不是真實帳號。
實機：

```
$ sudo setfacl -m u:operator:rX /tmp
setfacl: Option -m: Invalid argument near character 3
```

runbook 第 2b 步是 `sudo sh -e /tmp/p2b-permissions.sh`——`sh -e` 遇到第一條就**中止整份
script**，權限樹停在**半套用**狀態（前段已 chown/chmod、後段完全沒動），而且**看起來像是
裝好了**：目錄都在、前段權限正確，只有後段仍是預設權限。錯誤訊息還完全看不出是「帳號
不存在」。

根因是 `SCHEMES` 只把服務帳號那幾個 principal 對應到真實帳號名，`Principal.OPERATOR` 與
external reader 直接沿用字面值——**對應表缺項，不是填錯**。

## 修法

1. **對應外部化**：`UidScheme` 新增 `operator_account` / `external_reader_account`
   （**預設 `None`**），並從兩個 `SCHEMES` 的 `account_of` 移除 `Principal.OPERATOR`、
   移除 `external_reader` 的 `"cortex-outbox"` 預設值。新增 `PRINCIPAL_ACCOUNT_OPTIONS`
   作為**唯一真相**：欄位名、CLI 旗標、env 變數名、fail-closed 訊息全部由它導出，將來多
   一個部署決定型 principal 只需加一列。`__post_init__` 拒絕把這幾個 principal 塞回
   `account_of`（會被靜默忽略而形成第二份真相，正是本 issue 的成因）。
2. **三態，不是兩態**：`None`＝未指定（fail-closed）／`ABSENT_ACCOUNT`＝**明示**本部署沒有
   這個角色的實體（授權整組略去，是被記錄下來的決定）／真實帳號名＝照常產生 ACL。
   少了中間那態，「本機還沒有 outbox reader」就只能靠亂填一個帳號繞過，等於把不必要的
   讀取權授出去。
3. **fail-closed 在輸出前**：`plan_to_commands()` 先跑 `assert_principals_resolved()`，
   有未對應的 principal 即 raise `UnresolvedPrincipalError`，**一行都不輸出**。CLI 因此
   stdout 全空、回傳碼 2——被重導成 script 的檔案是**空檔**，而不是一份跑到一半會中止的
   半套 script。`generate_plan()` 刻意**不** raise（計畫是資料），改以
   `PermissionPlan.unresolved_principals` 曝光，CLI 的 JSON 診斷模式放進 payload 並在
   stderr 提醒一次。
4. **產生器自我檢查（擋未來）**：`assert_output_accounts_known()` 在輸出組完後驗證每一行的
   `u:<name>:` 與 `chown <owner>:<group>` 都落在 `declared_accounts()` 內，否則 raise
   `UnknownAccountInOutputError`。**註解行一併檢查**——per-job 資產以註解形式輸出，phantom
   躲在 `#   setfacl …` 裡照樣會被複製貼上執行。
5. **帳號名形狀驗證**：名字會被**逐字**嵌進命令字串，只接受 `^[a-z_][a-z0-9_-]*$?$`；
   `--operator-account "op; rm -rf /"` 在產生階段就被拒。

## 對應機制：CLI 旗標 **與** env 兩條，旗標優先

```
--operator-account <帳號名|none>          PSC_OPERATOR_ACCOUNT=<帳號名|none>
--external-reader-account <帳號名|none>   PSC_EXTERNAL_READER_ACCOUNT=<帳號名|none>
```

兩者並存的理由：runbook 是**逐行 review 後手動 sudo 執行**的，旗標讓「這次產生用了哪個
帳號」留在可稽核的命令列上（也留在 shell history 與 runbook 貼文裡）；env 則讓 CI／
自動化不必改命令列。**env 只在 CLI 這一層讀取**——`permgen` 維持純函式（不讀 env、不碰
IO），既有的 `test_permgen_never_touches_the_filesystem` /
`test_permgen_module_does_not_import_subprocess` 兩條靜態不變式不受影響。

## fail-closed 的錯誤訊息

```
$ python3 -m paulsha_cortex.trust_root permissions three-way --commands --paths
# stdout: （空）
# 回傳碼: 2
# stderr:
permgen 拒絕輸出命令：scheme=three-way 有 2 個 principal 未對應到真實 OS 帳號。

  - principal `external`（外送管線／外部學習系統的唯讀 reader——digest outbox 與 engineering-outcome outbox 的下游）未對應到真實帳號。
      指定：--external-reader-account <帳號名>   或   env PSC_EXTERNAL_READER_ACCOUNT=<帳號名>
      本部署沒有這個角色時，明示：--external-reader-account none（等同 PSC_EXTERNAL_READER_ACCOUNT=none）——該 principal 的授權整組略去。
  - principal `operator`（人類操作者的登入帳號——單人機器＝那個人的帳號，多人／CI 部署可能是專用帳號）未對應到真實帳號。
      指定：--operator-account <帳號名>   或   env PSC_OPERATOR_ACCOUNT=<帳號名>
      本部署沒有這個角色時，明示：--operator-account none（等同 PSC_OPERATOR_ACCOUNT=none）——該 principal 的授權整組略去。

為何不先印出來讓人自己看：runbook 第 2b 步以 `sudo sh -e` 執行整份權限 script，
而 `setfacl -m u:<不存在的帳號>:rX` 會回 `Invalid argument near character 3`
並**中止整份 script**，留下一棵半套用的權限樹（前段已 chown/chmod、後段完全沒動），
錯誤訊息還完全看不出是「帳號不存在」（#626）。
指定前請先確認帳號存在：`getent passwd <帳號名>`。
```

指定後的輸出（三分 ＋ `--operator-account cortex-ops --external-reader-account none`）：

```
$ ... | grep -oE "u:[a-z_-]+:" | sort -u
u:cortex-builder:
u:cortex-manager:
u:cortex-ops:
u:cortex-reviewer-planner:
```

## 測試

新增 `tests/test_trust_root_principal_account_mapping_626.py`（**46 測試**，兩個 scheme
逐一參數化）：

- (a) 未指定時 fail-closed，訊息含 principal 名／旗標／env／`getent passwd`；只補一半也
  不放行；CLI stdout 必須是空的。
- (b) 指定後每個 `u:<name>:` 都落在宣告帳號集合內，且注入的帳號真的被用上。
- (c) **不變式**：輸出中不得出現任何不在帳號集合內的字面值——含「偽造一行未來 principal
  的輸出必須被攔下」「註解行也檢查」「`menu:x:` 不得被誤判成 ACL 條目」「`chown` 的
  owner/group 同樣檢查」。另有一條登記表側的不變式：需要部署決定的 principal **恰好**是
  `operator` 與 `external`，多一個就代表對應表又缺了一項。
- (d) 兩個 scheme 全參數化；另涵蓋 `ABSENT_ACCOUNT` 只略去那個 principal 的 ACL、CLI 的
  旗標／`=` 形式／env／旗標勝過 env／非法帳號名／懸空旗標／JSON 模式。

既有 `_p2a` / `_p2b` / `_620` 三檔的**命令輸出**測試改用注入後的方案——它們原本驗到的正是
帶 phantom 的輸出。全套 `python3 -m pytest tests/ -q`：**3563 passed, 49 subtests passed**，
零回歸（含 #624 剛加的 `test_trust_root_permgen_traverse_620.py` 26 條）。

## runbook 改動（**已 rebase 到 #621／PR #627 之後，衝突已就地解掉**）

本 PR 原本基於 #625，期間 #621（PR #627）先 merge 並大改了同一份 runbook。已 rebase 到
`origin/main`（`0cf3606`）並逐處解掉衝突，改動**全部集中在第 2a 步那一個 code block**：

1. 產生命令補上 `--operator-account "$OPERATOR_ACCOUNT"` / `--external-reader-account none`
   （`OPERATOR_ACCOUNT="$(id -un)"` ＋ 前置 `getent passwd` 確認）與 `exit=` 期望。
2. **稽核 6**（#621 已加的那條 getent 檢查）就地更新：原文寫「(b) 它是本部署形態下不存在的
   principal ⇒ **等 #626 的產生器修正**，或在 operator 核可下由 script 中移除那幾行」——本 PR
   就是那個修正，處置改為「以 `--<principal>-account none` **明示**它不存在後重新產生，
   該角色的 ACL 整組略去，不必再手改 script」。另補一句：產生器側已 fail-closed，本稽核是
   **實機側的第二道**（帳號真的存在嗎）。
3. **新增稽核 6b**：骨架 script 的每個 `install -d -o` owner 也逐一 `getent passwd`。
4. 2a 尾端補一段「中止後直接重跑是安全的」——與 #621 在 2b 已寫的冪等說明呼應，不重複，
   只補「修好成因後**重新產生**再整份重跑」這一步。

另**順修一個既有假陽性**（發現於驗證稽核輸出時，非本 issue 範圍但同在 2a 這一塊）：稽核 2
的 `grep -E ":[^ ]*w"` 會把 `u:cortex-reviewer-planner:--x` 撈進來（`reviewer` 自己帶一個
`w`），#620 的 traverse 節上線後這條稽核就一直比「期望恰好四行」多報一行。pattern 改錨在
`u:<帳號>:` 之後。

## Checklist

- [x] 分支非 `main`（`feature/626-principal-account-mapping`）
- [x] 新增並 commit `changelog.d/principal-account-mapping.md` fragment
- [x] `CHANGELOG.md [Unreleased] ### Fixed` 補對應 entry
- [x] `python3 -m pytest tests/ -q` 全綠（3563 passed，零回歸）
- [x] `openspec validate --specs` 16 passed / 0 failed
- [x] 本機 `policy_check` 帶 PR 上下文跑，`fail: 0`（**以 GitHub CI 判定為準**）
- [x] permgen 仍不含任何執行面／IO（兩條既有靜態不變式測試通過）
- [x] 文件與 PR 一律 zh-tw

Closes #626

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E7w9kaUxAzCCEk7piD5hfK