### PR TITLE
feat(coordinator): job 工作區由 git worktree 改為 per-job 完整 clone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -225,6 +225,33 @@
   `mock.patch.object` 打不到，測試實際驗到的是「本機有沒有那個帳號」而非它宣稱的分支。
 
 ### Changed
+- **#623 / trust-root Phase 2b：job 工作區模型由 `git worktree` 改為 per-job 完整
+  clone——provisioning、成果回收與回收層**——M1（#584）之後 builder 以
+  `cortex-builder`、Manager 以 `cortex-manager` 執行，實測顯示 `git worktree` 在三分
+  下**結構性不成立**：linked worktree 的 `.git` 是指向 Manager-owned 樹的指標檔，把
+  gitdir 也 chown 給 builder 之後 `git status` 過了但 `git add` 仍失敗——寫 object
+  需要寫**共用** object store，而能寫共用 object store，隔離邊界就在 git 這一層漏掉。
+  新增 `coordinator/job_workspace.py` 作為工作區模型的單一真相（標記／識別／列舉／
+  刪除／成果回收／封存）；`coordinator/seams.py` 的 provisioning 改為
+  `git clone --no-hardlinks`，四條守衛（target 已存在、base 必須是既有 commit、既有
+  branch 必須位於 base ancestry、fast-forward 後重掛）與錯誤訊息逐條等價，且失敗會把
+  已做的變更全部還原；工作區的 `origin` 指向**真正的上游**、指向來源 repo 的暫時
+  remote 一律移除、`refs/remotes/origin/*` 與本地 git identity 一併複製過去，因此
+  delivery 的 `git -C <工作區> push origin` 行為不變。新增成果回收
+  `job_workspace.harvest_branch()`——Manager 以 `git -C <來源 repo> fetch <clone>`
+  單向拉回（沿用 D2「git 讀」的方向，builder 永遠不 push 進 Manager 的樹；refspec 不帶
+  `+`，非 fast-forward fail-closed），掛在 canonical lane 的
+  `_verify_build_candidate_transition` 之後與 slice lane 的
+  `verification.run_result_verification` 讀 branch head 之前。`coordinator/gc.py` 的掃描
+  與 `--apply` 同時涵蓋 per-job clone 與升級前既存的 linked worktree，依工作區**自己的
+  形狀**分派回收方式；`coordinator/worktree_reclaim.py` 的安全閘擴充為認得兩種形狀，
+  並在刪除 clone 前把工作區 HEAD 封存進 `refs/cortex/reclaimed/**`（clone 的 `rmtree`
+  會連 object store 一起刪掉，與該模組「不銷毀證據」的契約相牴觸）。clone 模型對
+  `direct` 與降權模式走同一條 code path，所有新行為都以工作區標記檔為前置條件，既有
+  部署與測試裡的假路徑完全不觸發。新增
+  `tests/test_per_job_clone_provisioning_623.py`（27 測試，全部以真 git repo 驗證）；
+  全套 `python3 -m pytest tests/ -q`：3644 passed，零回歸。
+  詳見 `changelog.d/per-job-clone-provisioning.md`。
 - **#584 / trust-root Phase 2b runbook：A／B 兩案並列收斂為 A+B 單一路徑（docs-only）**
   ——落實 operator 0816 第三輪裁決。polkit 的 `manage-units` 只暴露 unit 名與 verb、
   不暴露 `User=`（#603 實測），因此「誰持有授權」與「授權能做什麼」兩層一起收：

--- a/changelog.d/per-job-clone-provisioning.md
+++ b/changelog.d/per-job-clone-provisioning.md
@@ -1,0 +1,73 @@
+### Changed
+- **#623 / trust-root Phase 2b：job 工作區模型由 `git worktree` 改為 per-job 完整
+  clone——provisioning、成果回收與回收層**（Refs #623）
+
+  **為什麼非改不可**：M1（#584）之後 builder 以 `cortex-builder` 執行、Manager 以
+  `cortex-manager`，durable state 樹是 `0700 cortex-manager`。實測顯示 `git worktree`
+  在這個模型下**結構性不成立**——linked worktree 的 `.git` 是指向
+  `<來源 repo>/.git/worktrees/<name>` 的指標檔（在 Manager-owned 樹裡），只 chown
+  worktree 目錄 `git status` 就 `fatal: not a git repository`；把 gitdir 那一格也
+  chown 給 builder 之後 `git status` 過了，但 `git add` 仍失敗，因為寫 object 需要寫
+  **共用** object store。推論是一條互斥：*只要 builder 要能 commit，它就必須能寫
+  object store；而能寫 object store，「builder 不可竄改 Manager state」這條邊界就在
+  git 這一層漏掉。* per-job clone 有自己的 object store，整個目錄由該 job 帳號擁有，
+  來源 repo 對它唯讀（operator 實測 0.5 秒／35MB per job）。
+
+  **新模組 `coordinator/job_workspace.py`**：工作區「是什麼」的單一真相——標記、識別、
+  列舉、刪除、成果回收、回收前封存。三個呼叫端（`seams`／`gc`／`worktree_reclaim`）
+  共用，避免同一個判準在三處各自演化。工作區的識別判準是寫在 clone `.git/` 底下的
+  標記檔，**不是**「`.git` 是目錄」——後者對任何主 checkout 都成立，一筆陳舊的
+  `job.worktree` 就足以讓遞迴刪除掃掉整個來源 repo（#478 現場記錄過 `job.worktree`
+  等於 run 的 `workspace_root`）。標記放在 `.git/` 而非工作樹根，是因為工作樹根的任何
+  檔案都會讓工作區一出生就是 dirty，而 dirty 是 `verification` 與 `gc` 的 fail-closed
+  條件。
+
+  **provisioning（`coordinator/seams.py`）**：`git worktree add` → `git clone
+  --no-hardlinks`。四條守衛與 worktree 模型**逐條等價**且錯誤訊息逐字保留（既有診斷
+  與 #527／#601 的測試不因實作換代而失效）：target 已存在、base 必須是既有 commit、
+  既有 branch 必須完全位於 base ancestry（#613 的 fail-closed）、既有 branch
+  fast-forward 後重掛。branch 仍錨定在**來源 repo**——`gc` 與 dispatch baseline 都直接
+  讀它，ancestry 守衛也需要一個跨世代穩定的比較對象。clone 完成後的工作區狀態與
+  worktree 模型逐字相同：`origin` 指向**真正的上游**（來源 repo 的 `origin` URL，
+  delivery 的 `git -C <工作區> push origin` 因此行為不變）、指向來源 repo 的暫時 remote
+  一律移除（不在 builder 的工作區裡留回寫把手）、branch 無 upstream、來源 repo 的
+  `refs/remotes/origin/*` 與本地 `user.name`／`user.email` 一併複製過去（clone 不繼承
+  來源的 local config，少了 identity builder 的 `git commit` 會直接失敗）。任何一步
+  失敗都會把已做的變更**全部還原**（部分 clone 目錄、branch 位置），但 `target already
+  exists` 這條路徑上一個位元組都不動——回滾不得擴張成「刪掉別人的工作區再說」。
+
+  **成果回收**：clone 有自己的 object store，builder 的 commit 在回收前**來源 repo
+  看不到**。新增 `job_workspace.harvest_branch()`：Manager 以 `git -C <來源 repo>
+  fetch <clone> refs/heads/<branch>:refs/heads/<branch>` 單向拉回，沿用 D2「git 讀」的
+  方向——builder 永遠不 push 進 Manager 的樹。refspec 刻意不帶 `+`，非 fast-forward 由
+  git 拒絕，Manager 不會靜默吸收被改寫過的歷史。掛在兩個 lane 的採信點：canonical
+  lane 在 `manager.apply_workflow_action` 的 build phase、`_verify_build_candidate_
+  transition` 之後（candidate 已被確認是工作區 HEAD 且單調延伸自基線，回收只負責搬運，
+  不新增採信路徑；回收後來源 repo 的 branch 必須恰好等於該 candidate，對不上即
+  fail-closed）；slice lane 在 `verification.run_result_verification` 讀 branch head
+  之前（該函式以來源 repo 為根判讀 candidate／ancestry／required-artifact diff／persona
+  scope diff，少了回收整段會以 `candidate-unreadable` 收場）。工作區不是 per-job clone
+  時兩處都是 no-op。
+
+  **回收層（`coordinator/gc.py`、`coordinator/worktree_reclaim.py`）**：`gc` 的掃描同時
+  涵蓋 per-job clone（走檔案系統，`git worktree list` 看不到它們）與升級前既存的 linked
+  worktree；`--apply` 依工作區**自己的形狀**分派回收方式（clone＝目錄刪除、linked
+  worktree＝`git worktree remove`），不依部署模式旗標——旗標會與磁碟上的實況漂移，形狀
+  不會。少了 clone 掃描這一步，正在跑的 job 的 branch 會因為「沒掛在任何 worktree 上」
+  被誤判為可回收。`worktree_reclaim` 的安全閘擴充為認得兩種形狀，並在刪除 clone 前把
+  工作區 HEAD 封存進來源 repo 的 `refs/cortex/reclaimed/**`（來源 repo 已有該 commit
+  時不重複封存）——worktree 模型下回收工作區不銷毀任何 commit，clone 模型下 `rmtree`
+  會連 object store 一起刪掉，而該模組契約明文「不銷毀證據」。來源 repo 取自呼叫端或
+  標記檔（既有呼叫端都不傳 `repo_root`）。
+
+  **既有部署零回歸**：clone 模型對 `direct` 與降權模式走**同一條** code path，不依
+  `PSC_JOB_RUNNER` 分支；所有新行為（回收、clone 回收路徑）都以標記檔為前置條件，
+  worktree 模型與測試裡的假路徑完全不觸發。`launcher._linked_worktree_git_write_dirs`
+  無需改動——它對 `.git` 為目錄的工作區本來就回空集合，而 clone 的 `.git` 在工作區內、
+  已被 sandbox 的工作區授權涵蓋。
+
+  新增 `tests/test_per_job_clone_provisioning_623.py`（27 測試，全部以真 git repo 驗證：
+  provision 守衛等價與失敗回滾、工作區無回寫路徑、未回收前來源 repo 不受影響、成果
+  回收與非 fast-forward fail-closed、兩個 lane 的回收掛點、clone 與 linked worktree 的
+  回收、dirty 內容封存、gc 對在用 branch 的保護、端到端）。全套
+  `python3 -m pytest tests/ -q`：3644 passed，零回歸。

--- a/docs/superpowers/specs/feat-work-gc-v2-spec.md
+++ b/docs/superpowers/specs/feat-work-gc-v2-spec.md
@@ -61,9 +61,16 @@ default branch MUST 依 `origin/HEAD` 解析，無法解析時退回 `main`；GC
 
 ### R4 回收範圍與報告
 
-候選範圍 SHALL 為：worktree pool（repo 同層 `<repo>-worktrees`，`PSC_WORKTREE_ROOT` 可覆寫）內的殘留 build worktree，與 repo 的 local branch。
+候選範圍 SHALL 為：worktree pool（repo 同層 `<repo>-worktrees`，`PSC_WORKTREE_ROOT` 可覆寫）內的殘留 build 工作區，與 repo 的 local branch。
 
-`--apply` 對 clean 且 merged 的 worktree MUST 以 `git worktree remove` 移除；對通過 R2 驗證鏈的 merged branch MUST 於刪除前重新驗證一次，再以 `git branch -D` 刪除。
+工作區有兩種形狀，掃描 MUST 同時涵蓋（#623）：
+
+- **per-job clone**（現行模型）：獨立 repo，`git worktree list` 看不到它們，掃描 SHALL 走檔案系統並以 `coordinator/job_workspace.py` 的標記檔為判準。
+- **linked worktree**（#623 升級前既存）：由 `git worktree list --porcelain` 列出。
+
+`--apply` 對 clean 且 merged 的工作區 MUST 依其形狀回收——per-job clone 為目錄刪除（無 worktree registry 可清），linked worktree 為 `git worktree remove`；對通過 R2 驗證鏈的 merged branch MUST 於刪除前重新驗證一次，再以 `git branch -D` 刪除。
+
+工作區仍在使用（未 merge）時其 branch MUST 落在 `keep`——clone 沒有 worktree registry，少了 clone 掃描這一步，正在跑的 job 的 branch 會被誤判為可回收。
 
 報告 MUST 逐項列出 artifact、判定與 reason；`--json` MUST 輸出 versioned schema（`cortex-work-gc/v1`），含 dry-run／apply 模式標記與逐項結果。
 

--- a/paulsha_cortex/coordinator/gc.py
+++ b/paulsha_cortex/coordinator/gc.py
@@ -25,7 +25,7 @@ from typing import Any, Callable, Sequence
 from paulsha_cortex.config.paths import repo_root as default_repo_root
 from paulsha_cortex.config.paths import worktree_root_for
 
-from . import verification
+from . import job_workspace, verification
 
 GC_SCHEMA = "cortex-work-gc/v1"
 
@@ -173,6 +173,24 @@ def list_worktrees(repo_root: Path, git_runner: GitRunner | None = None) -> list
     return entries
 
 
+def list_clone_workspaces(
+    pool_root: Path, git_runner: GitRunner | None = None
+) -> list[_WorktreeEntry]:
+    """#623：列出 pool 底下的 per-job clone 工作區。
+
+    clone 沒有 `git worktree` registry——`git -C <repo> worktree list` 看不到它們，
+    因此掃描改由檔案系統負責（判準是 `job_workspace` 的標記檔，見該模組）。branch
+    取工作區自己 checked-out 的那條；detached 時為 None，與 worktree 的表示法一致。
+    """
+
+    entries: list[_WorktreeEntry] = []
+    for path in job_workspace.list_clone_workspaces(pool_root):
+        branch_result = _git(path, ["symbolic-ref", "--short", "HEAD"], git_runner)
+        branch = branch_result["stdout"].strip() if branch_result["status"] == "ok" else ""
+        entries.append(_WorktreeEntry(path=path, branch=branch or None))
+    return entries
+
+
 def list_local_branches(repo_root: Path, git_runner: GitRunner | None = None) -> list[str]:
     result = _git(
         repo_root, ["for-each-ref", "--format=%(refname:short)", "refs/heads/"], git_runner
@@ -294,13 +312,25 @@ def scan(
     artifacts: list[Artifact] = []
     protected_branches: set[str] = set()
 
-    for entry in list_worktrees(repo_root, git_runner):
+    #: 兩種形狀都要掃：#623 之後新工作區是 per-job clone（`git worktree list` 看
+    #: 不到），升級前既存的 linked worktree 仍須能被回收。以解析後的路徑去重——
+    #: 同一路徑不可能同時是兩者，但去重讓「掃描來源多一個」不會變成報表出現兩列。
+    seen_paths: set[str] = set()
+    pool_entries = [
+        *list_worktrees(repo_root, git_runner),
+        *list_clone_workspaces(pool_root, git_runner),
+    ]
+
+    for entry in pool_entries:
         try:
             resolved = entry.path.resolve()
         except OSError:
             continue
         if not _is_under(resolved, pool_root):
             continue
+        if str(resolved) in seen_paths:
+            continue
+        seen_paths.add(str(resolved))
         artifact = _classify_worktree(
             entry,
             repo_root=repo_root,
@@ -354,9 +384,21 @@ def _apply_worktree(
     merged, reason = _classify_merge(repo_root, default_branch, ref, git_runner)
     if not merged:
         return _keep_apply_error(artifact, "worktree no longer verified merged")
-    removal = _git(repo_root, ["worktree", "remove", str(path)], git_runner)
-    if removal["status"] != "ok":
-        return _keep_apply_error(artifact, f"git worktree remove failed: {removal['stderr']}")
+    # #623：per-job clone 沒有 `git worktree` registry，回收退化成單純的目錄刪除；
+    # 升級前既存的 linked worktree 仍走 `git worktree remove`（它同時要清 registry，
+    # 少了那一步就是 #478 的殘留態）。判準是工作區自己的形狀，不是部署模式旗標
+    # ——旗標會與磁碟上的實況漂移，形狀不會。
+    if job_workspace.is_job_clone(path):
+        try:
+            job_workspace.remove_clone(path)
+        except Exception as exc:  # noqa: BLE001 - 刪除失敗一律降為 keep，不誤報回收
+            return _keep_apply_error(
+                artifact, f"job workspace remove failed: {type(exc).__name__}: {str(exc)[:200]}"
+            )
+    else:
+        removal = _git(repo_root, ["worktree", "remove", str(path)], git_runner)
+        if removal["status"] != "ok":
+            return _keep_apply_error(artifact, f"git worktree remove failed: {removal['stderr']}")
     return Artifact(
         artifact.kind, artifact.identifier, ACTION_RECLAIM, reason,
         branch=artifact.branch, detail="removed",

--- a/paulsha_cortex/coordinator/job_workspace.py
+++ b/paulsha_cortex/coordinator/job_workspace.py
@@ -1,0 +1,339 @@
+"""#623：per-job **完整 clone** 的工作區模型（取代 `git worktree`）。
+
+## 為什麼不是 `git worktree`
+
+trust-root Phase 2b M1（#584）之後 builder job 以 `cortex-builder` 執行、Manager 以
+`cortex-manager`，durable state 樹是 `0700 cortex-manager`。在這個模型下 `git worktree`
+**結構性不成立**（#623 實測）：
+
+1. linked worktree 的 `.git` 是一個指標檔，指向 `<來源 repo>/.git/worktrees/<name>`
+   ——那在 Manager-owned 的樹裡。只把 worktree 目錄 chown 給 builder，`git status`
+   直接 `fatal: not a git repository`。
+2. 連 `.git/worktrees/<name>/` 一起 chown、父鏈補 `--x` 之後 `git status` 過了，但
+   **`git add` 仍失敗**——寫 object 需要寫**共用 object store**。
+
+推論：*只要 builder 要能 commit，它就必須能寫 object store；而能寫 object store，
+「builder 不可竄改 Manager state」這條邊界就在 git 這一層漏掉。*共用 object store 與
+三分隔離互斥。
+
+per-job 完整 clone 沒有這個問題：clone 有**自己的** object store，整個目錄由該 job
+帳號擁有，來源 repo 對它唯讀（實測 0.5 秒／35MB per job）。
+
+## 本模組的職責
+
+工作區「是什麼」的單一真相——標記、識別、列舉、刪除，以及**成果回收**
+（Manager 從 job 的 clone `fetch` 回自己的樹）。三個呼叫端共用：
+
+- `coordinator/seams.py`：provision（建 clone）
+- `coordinator/gc.py`：`cortex work gc` 的掃描與回收
+- `coordinator/worktree_reclaim.py`：#478／#544 的原子回收 helper
+
+## 方向性（D2「git 讀」）
+
+成果回收一律是 **Manager 拉**（`git -C <來源 repo> fetch <clone>`），**不是 builder
+推**。builder 永遠不 push 進 Manager 的樹；clone 完成後指向來源 repo 的暫時 remote
+會被移除（見 :data:`SOURCE_REMOTE`），工作區裡不留任何回寫路徑。
+
+fetch 的 refspec 刻意**不帶 `+`**：非 fast-forward 一律被 git 拒絕，Manager 不會靜默
+吸收被改寫過的歷史。
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+#: clone 工作區的識別標記檔名，寫在 clone 自己的 `.git/` 底下。
+#:
+#: 放在 `.git/` 而非工作樹根，是因為工作樹根的任何檔案都會出現在
+#: `git status --porcelain --untracked-files=all` 裡——那會讓每一個新工作區一出生就
+#: 是 dirty，而 dirty 是 `verification` 與 `gc` 的 fail-closed 條件。
+MARKER_NAME = "cortex-job-workspace.json"
+
+MARKER_SCHEMA_VERSION = 1
+
+#: 標記檔的 `model` 欄位值。將來若再換工作區模型，這個字面量就是分辨依據。
+WORKSPACE_MODEL = "per-job-clone"
+
+#: `git clone` 期間指向來源 repo 的 remote 名。clone 完成後**必定移除**——留著它
+#: 等於在 builder 的工作區裡放一條可 push 回 Manager 樹的路徑（`git push
+#: cortex-source`），與 D2 的單向性直接衝突。工作區最終看到的 `origin` 是**真正的
+#: 上游**（來源 repo 的 `origin` URL），與 worktree 模型下逐字相同。
+SOURCE_REMOTE = "cortex-source"
+
+#: 回收 clone 前，把工作區 HEAD 封存到來源 repo 的這個 ref 命名空間。
+#:
+#: worktree 模型下「回收工作區」不會銷毀 commit——object 在共用 store 裡、branch 還在
+#: 主 repo。clone 模型下 `rmtree` 會把**尚未回收的 commit 一併刪掉**，那與
+#: `worktree_reclaim` 模組契約的「不銷毀證據」相牴觸。因此回收前先把 HEAD 拉進這個
+#: 命名空間（不是 branch、不是 tag：不佔用 branch 名，`git push` 預設也不會帶出去）。
+ARCHIVE_REF_PREFIX = "refs/cortex/reclaimed"
+
+_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+
+
+class WorkspaceError(ValueError):
+    """工作區 provision／回收的可操作錯誤。"""
+
+
+# ---------------------------------------------------------------------------
+# git 執行（本模組刻意直接用 subprocess）
+# ---------------------------------------------------------------------------
+
+def _git(args: list[str]) -> subprocess.CompletedProcess[str]:
+    """執行 `git <args>`；不 check，由呼叫端判讀。
+
+    不引入 runner seam：本模組的行為**就是** git 的行為，注入假 runner 的測試只會
+    驗到自己寫的 stub。相關測試一律開真 git repo（與 `tests/test_coordinator_seams.py`
+    既有作法一致）。
+    """
+
+    try:
+        return subprocess.run(["git", *args], capture_output=True, text=True, check=False)
+    except FileNotFoundError as exc:  # pragma: no cover - 環境無 git
+        raise WorkspaceError("git not found") from exc
+
+
+def _git_ok(args: list[str], *, failure: str) -> str:
+    proc = _git(args)
+    if proc.returncode != 0:
+        raise WorkspaceError(f"{failure}: {(proc.stderr or proc.stdout).strip()}")
+    return proc.stdout.strip()
+
+
+# ---------------------------------------------------------------------------
+# 標記與識別
+# ---------------------------------------------------------------------------
+
+def marker_path(workspace: str | Path) -> Path:
+    return Path(workspace) / ".git" / MARKER_NAME
+
+
+def is_job_clone(workspace: str | Path) -> bool:
+    """這個路徑是不是 cortex provision 出來的 per-job clone。
+
+    判準是標記檔存在，**不是**「`.git` 是目錄」——後者對任何主 checkout 都成立，
+    包含 run 的 `workspace_root`（來源 repo 本身）。遞迴刪除的爆炸半徑不允許用
+    這種寬鬆判準（見 `worktree_reclaim` 的安全閘與 #478 現場）。
+    """
+
+    marker = marker_path(workspace)
+    return marker.is_file() and not marker.is_symlink()
+
+
+def is_linked_worktree(workspace: str | Path) -> bool:
+    """linked worktree 的根目錄帶的是 `.git` **檔案**（內容 `gitdir: ...`）。
+
+    clone 模型上線後新工作區不會再是這個形狀，但升級前既存的 worktree 仍須能被
+    回收——`gc` 與 `worktree_reclaim` 因此同時認得兩種形狀。
+    """
+
+    marker = Path(workspace) / ".git"
+    return marker.is_file() and not marker.is_symlink()
+
+
+def read_marker(workspace: str | Path) -> dict[str, Any] | None:
+    path = marker_path(workspace)
+    if not path.is_file() or path.is_symlink():
+        return None
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def write_marker(
+    workspace: str | Path,
+    *,
+    branch: str,
+    base: str,
+    source_repo: str | Path,
+) -> Path:
+    path = marker_path(workspace)
+    payload = {
+        "schema_version": MARKER_SCHEMA_VERSION,
+        "model": WORKSPACE_MODEL,
+        "branch": branch,
+        "base": base,
+        "source_repo": str(source_repo),
+        "created_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, ensure_ascii=False, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    return path
+
+
+def list_clone_workspaces(pool_root: str | Path) -> list[Path]:
+    """列出 pool 底下的 per-job clone（只掃**直接子項**，不遞迴）。
+
+    不遞迴是刻意的：pool 的契約是 `<PSC_WORKTREE_ROOT>/<工作區名>`，遞迴只會把
+    clone 內部的巢狀 repo（例如模型自己 clone 的第三方 repo）也掃進回收清單。
+    """
+
+    root = Path(pool_root)
+    if not root.is_dir():
+        return []
+    found: list[Path] = []
+    try:
+        entries = sorted(root.iterdir())
+    except OSError:
+        return []
+    for entry in entries:
+        if entry.is_symlink() or not entry.is_dir():
+            continue
+        if is_job_clone(entry):
+            found.append(entry)
+    return found
+
+
+def workspace_branch(workspace: str | Path) -> str | None:
+    """工作區目前 checked-out 的 branch；detached 或不可讀時回 None。"""
+
+    proc = _git(["-C", str(workspace), "symbolic-ref", "--short", "HEAD"])
+    if proc.returncode != 0:
+        return None
+    value = proc.stdout.strip()
+    return value or None
+
+
+# ---------------------------------------------------------------------------
+# 成果回收（Manager 拉，builder 不推）
+# ---------------------------------------------------------------------------
+
+def harvest_branch(
+    *,
+    source_repo: str | Path,
+    workspace: str | Path,
+    branch: str,
+) -> str:
+    """把 job clone 的 `branch` fetch 回來源 repo，回傳回收後的 branch head。
+
+    這是 clone 模型下**成果離開 job 帳號的唯一路徑**：Manager 以自己的身分對
+    clone 執行 `git fetch`（單向讀），builder 永遠不 push 進 Manager 的樹。
+
+    refspec 刻意不帶 `+`——非 fast-forward 由 git 拒絕，Manager 不會靜默吸收被
+    改寫過的歷史（等價於 worktree 模型下 `branch -f` 前的 ancestry 守衛）。
+    """
+
+    source = Path(source_repo)
+    target = Path(workspace)
+    if not branch:
+        raise WorkspaceError("harvest requires a branch name")
+    refspec = f"refs/heads/{branch}:refs/heads/{branch}"
+    proc = _git(["-C", str(source), "fetch", "--no-tags", str(target), refspec])
+    if proc.returncode != 0:
+        detail = (proc.stderr or proc.stdout).strip()
+        if "non-fast-forward" in detail or "rejected" in detail:
+            raise WorkspaceError(
+                f"job workspace branch is not a fast-forward of {branch}: {detail}"
+            )
+        raise WorkspaceError(f"job workspace harvest failed: {detail}")
+    head = _git_ok(
+        ["-C", str(source), "rev-parse", f"refs/heads/{branch}"],
+        failure="job workspace harvest head unreadable",
+    )
+    if _SHA_RE.fullmatch(head) is None:
+        raise WorkspaceError(f"job workspace harvest head invalid: {head}")
+    return head
+
+
+def harvest_if_job_clone(
+    *,
+    source_repo: str | Path,
+    workspace: str | Path,
+    branch: str,
+) -> str | None:
+    """工作區是 per-job clone 時做成果回收；否則回 None。
+
+    worktree 模型下 branch 與 object 本來就在來源 repo 裡，沒有東西要 fetch；
+    升級前既存的 worktree、以及測試用的假路徑因此**完全不受影響**——這是本次
+    變更「既有部署零回歸」的掛點。
+    """
+
+    if not is_job_clone(workspace):
+        return None
+    return harvest_branch(source_repo=source_repo, workspace=workspace, branch=branch)
+
+
+def archive_workspace_head(
+    *,
+    source_repo: str | Path,
+    workspace: str | Path,
+) -> str | None:
+    """回收前把工作區 HEAD 封存進來源 repo 的 :data:`ARCHIVE_REF_PREFIX` 命名空間。
+
+    回傳封存後的 ref 名；工作區沒有可讀 HEAD、或 commit 已在來源 repo 裡（沒有東西
+    會被銷毀）時回 None。任何失敗都回 None——封存是**加分項**，不得讓回收本身失敗
+    （回收失敗才是 #478／#601 的生產事故）。
+    """
+
+    source = Path(source_repo)
+    target = Path(workspace)
+    head_proc = _git(["-C", str(target), "rev-parse", "HEAD"])
+    if head_proc.returncode != 0:
+        return None
+    head = head_proc.stdout.strip().lower()
+    if _SHA_RE.fullmatch(head) is None:
+        return None
+    if _git(["-C", str(source), "cat-file", "-e", f"{head}^{{commit}}"]).returncode == 0:
+        # commit 已在 Manager 的 object store 裡（多半剛做過成果回收），
+        # 刪掉工作區不會銷毀任何東西。
+        return None
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    ref = f"{ARCHIVE_REF_PREFIX}/{target.name}/{stamp}-{head[:12]}"
+    fetched = _git(["-C", str(source), "fetch", "--no-tags", str(target), f"{head}:{ref}"])
+    if fetched.returncode != 0:
+        return None
+    return ref
+
+
+# ---------------------------------------------------------------------------
+# 刪除
+# ---------------------------------------------------------------------------
+
+def remove_clone(workspace: str | Path) -> None:
+    """刪除 per-job clone 目錄，並驗證後置條件。
+
+    clone 沒有 `git worktree` registry，回收因此退化成單純的目錄刪除——但後置條件
+    仍必須被**驗證**（#478 的教訓：清理失敗被吞掉，下一個 tick 才炸）。
+    """
+
+    target = Path(workspace)
+    if target.is_symlink():
+        target.unlink()
+        return
+    if not target.exists():
+        return
+    shutil.rmtree(target, ignore_errors=False)
+    if target.exists() or target.is_symlink():  # pragma: no cover - rmtree 失敗會先拋
+        raise WorkspaceError(f"job workspace removal incomplete: {target}")
+
+
+__all__ = [
+    "ARCHIVE_REF_PREFIX",
+    "MARKER_NAME",
+    "MARKER_SCHEMA_VERSION",
+    "SOURCE_REMOTE",
+    "WORKSPACE_MODEL",
+    "WorkspaceError",
+    "archive_workspace_head",
+    "harvest_branch",
+    "harvest_if_job_clone",
+    "is_job_clone",
+    "is_linked_worktree",
+    "list_clone_workspaces",
+    "marker_path",
+    "read_marker",
+    "remove_clone",
+    "workspace_branch",
+    "write_marker",
+]

--- a/paulsha_cortex/coordinator/manager.py
+++ b/paulsha_cortex/coordinator/manager.py
@@ -27,6 +27,7 @@ from . import autonomy
 from . import completion
 from . import coverage
 from . import gate_ledger
+from . import job_workspace
 from . import planning_runtime
 from . import provider_backoff
 from . import outcome_taxonomy
@@ -3243,6 +3244,48 @@ def _verify_build_candidate_transition(
     if returncode != 0:
         raise ValueError("workflow build candidate ancestry unavailable")
     return candidate
+
+
+def _harvest_build_candidate(job: Mapping[str, object], *, run, candidate: str) -> str | None:
+    """#623：把 build card 的 candidate 從 job 的 per-job clone 取回 Manager 的樹。
+
+    clone 模型下 builder 的 commit 只存在於 clone 自己的 object store。後續每一段
+    都需要它在**來源 repo** 裡：review 卡的 `git worktree add --detach <candidate>`
+    （`coordinator/review.py`）、`_completion_candidate_ref` 的 merge-base、
+    `cortex work gc` 的 branch 分類，以及最基本的一件事——工作區被回收之後 commit
+    還在不在。
+
+    方向是 Manager **拉**（`git -C <來源 repo> fetch <clone>`），沿用 D2「git 讀」
+    的單向性；builder 永遠不 push 進 Manager 的樹。
+
+    掛在 candidate 驗證**之後**：`_verify_build_candidate_transition` 已確認
+    candidate 就是工作區的 HEAD 且單調延伸自基線，此處只負責把那個已被採信的
+    commit 搬進來，不引入新的採信路徑。
+
+    工作區不是 per-job clone（worktree 模型、或測試裡的假路徑）時回 None，不做任何
+    事——既有部署零回歸的掛點。
+    """
+
+    worktree = job.get("worktree")
+    branch = job.get("branch")
+    if not isinstance(worktree, str) or not worktree:
+        return None
+    if not isinstance(branch, str) or not branch:
+        return None
+    if not job_workspace.is_job_clone(worktree):
+        return None
+    source_repo = getattr(run, "workspace_root", None)
+    if not isinstance(source_repo, str) or not source_repo:
+        raise ValueError("workflow build candidate harvest source repo missing")
+    harvested = job_workspace.harvest_branch(
+        source_repo=source_repo, workspace=worktree, branch=branch
+    )
+    if harvested.lower() != candidate.lower():
+        # 回收後來源 repo 的 branch 必須恰好是被採信的 candidate。對不上代表
+        # 工作區的 branch tip 與 HEAD 不同（模型在 detached HEAD 上 commit，
+        # 或 provision 後有第三方動過 ref）——fail-closed，不得繼續。
+        raise ValueError("workflow build candidate harvest head mismatch")
+    return harvested
 
 
 def _review_builder_job_binding(
@@ -9685,6 +9728,7 @@ def apply_workflow_action(
                 previous_candidate=candidate,
                 git_runner=git_runner,
             )
+            _harvest_build_candidate(job, run=current, candidate=candidate)
         elif current.current_phase in {"verify", "review"}:
             job_candidate = _verify_exact_candidate(job, git_runner=git_runner)
             if candidate != job_candidate:

--- a/paulsha_cortex/coordinator/seams.py
+++ b/paulsha_cortex/coordinator/seams.py
@@ -6,6 +6,8 @@ from typing import Protocol, runtime_checkable
 
 from paulsha_cortex.config import paths
 
+from . import job_workspace
+
 
 @runtime_checkable
 class PaneSender(Protocol):
@@ -16,7 +18,13 @@ class PaneSender(Protocol):
 
 @runtime_checkable
 class WorktreeCreator(Protocol):
-    """為某分支建立 git worktree、回傳其路徑的 seam。"""
+    """為某分支建立 per-job git 工作區、回傳其路徑的 seam。
+
+    協定名沿用 ``WorktreeCreator``（以及 job 記錄的 ``worktree`` 欄位）：#623 之後
+    實作已改為 per-job 完整 clone，但這兩個名字是**已持久化的契約**——job registry
+    的既有列、以及注入 fake 的大量既有測試都靠它。改名不會讓任何東西更正確，只會
+    製造一次不必要的資料遷移。實際的工作區模型見 `coordinator/job_workspace.py`。
+    """
 
     def create(self, branch: str, *, base_sha: str | None = None) -> str: ...
 
@@ -46,11 +54,42 @@ class TmuxPaneSender:
 
 
 class ScriptWorktreeCreator:
-    """真實作：鏡射 scripts/using-git-worktrees.sh 的新分支路徑。
+    """真實作：per-job **完整 clone** 的工作區 provisioning（#623）。
 
-    新 branch 使用 `git worktree add -b`；既有 branch 僅在它完全位於 base
-    ancestry 時 fast-forward 後重掛。回傳 target 路徑。單元測試 MUST 注入
-    fake，不實體化此類。
+    #623 之前這裡是 `git worktree add`。trust-root Phase 2b 三分 UID 上線後那個模型
+    結構性不成立——builder 要 commit 就必須寫**共用** object store，而能寫共用
+    object store，隔離邊界就在 git 這一層漏掉（完整推導見
+    `coordinator/job_workspace.py` 模組 docstring）。改為每個 job 一份自己的 clone。
+
+    **守衛與 worktree 模型逐條等價**（錯誤訊息刻意逐字保留，既有診斷／測試不因
+    實作換代而失效）：
+
+    ================================  ==========================================
+    守衛                              clone 模型下的作法
+    ================================  ==========================================
+    target 已存在                     同——先探測後 fail-closed
+    base 必須是既有 commit            同——`rev-parse --verify <base>^{commit}`
+    既有 branch 必須位於 base          同——`merge-base --is-ancestor`，非祖先即拒
+      ancestry
+    既有 branch fast-forward 後重掛    在**來源 repo** `branch -f` 後 clone 出來
+    新 branch                         在**來源 repo** 建 branch 後 clone 出來
+    ================================  ==========================================
+
+    branch 仍錨定在來源 repo（而非只存在於 clone 裡）的理由有三：`gc` 與
+    `dispatcher`／`autonomy` 的 dispatch baseline 都直接讀來源 repo 的
+    `refs/heads/<branch>`；ancestry 守衛需要一個跨世代穩定的比較對象（#613）；而
+    成果回收本來就會把 branch fetch 回同一個位置。
+
+    clone 完成後的工作區狀態，與 worktree 模型下逐字相同：`origin` 指向**真正的
+    上游**（來源 repo 的 `origin` URL），指向來源 repo 的暫時 remote 一律移除，
+    `<branch>` 沒有 upstream（`worktree add -b` 也不設），來源 repo 的
+    `refs/remotes/origin/*` 與本地 `user.name`／`user.email` 一併複製過去
+    （clone 不繼承來源的 local config，少了它 builder 的 `git commit` 會直接失敗）。
+
+    任何一步失敗都會把**已做的變更全部還原**（部分 clone 目錄刪除、branch 回到
+    provision 前的位置或刪除）——殘留正是 #601／#613 的生產現場。
+
+    單元測試 MUST 注入 fake，不實體化此類。
     """
 
     def __init__(
@@ -67,69 +106,173 @@ class ScriptWorktreeCreator:
     def repo_root(self) -> Path:
         return self._repo
 
+    # -- git 小工具（皆對來源 repo 或工作區執行，回傳 CompletedProcess） ---------
+
+    def _run(self, args: list[str]) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(["git", *args], check=False, capture_output=True, text=True)
+
+    def _source(self, args: list[str]) -> subprocess.CompletedProcess[str]:
+        return self._run(["-C", str(self._repo), *args])
+
     def create(self, branch: str, *, base_sha: str | None = None) -> str:
         slug = branch.replace("/", "-")
         target = self._wt_root / slug
         self._wt_root.mkdir(parents=True, exist_ok=True)
         base = base_sha or self._base
+        #: provision 前的 branch 位置：None＝當時不存在。失敗時據此還原。
+        previous_branch_sha: str | None = None
+        branch_touched = False
+        #: 只有**本次呼叫親手建立**的 target 才可以在還原時刪除。撞到既有目錄時
+        #: 這個旗標必為 False——否則 "target already exists" 這條守衛會從
+        #: fail-closed 變成「刪掉別人的工作區再說」。
+        target_created = False
         try:
             if target.exists() or target.is_symlink():
                 raise ValueError("worktree target already exists")
-            base_probe = subprocess.run(
-                ["git", "-C", str(self._repo), "rev-parse", "--verify", f"{base}^{{commit}}"],
-                check=False,
-                capture_output=True,
-            )
+            base_probe = self._source(["rev-parse", "--verify", f"{base}^{{commit}}"])
             if base_probe.returncode != 0:
-                raise ValueError(
-                    f"git worktree base invalid: {base_probe.stderr.decode().strip()}"
-                )
-            exact_base = base_probe.stdout.decode().strip()
-            branch_probe = subprocess.run(
-                [
-                    "git", "-C", str(self._repo), "show-ref", "--verify", "--quiet",
-                    f"refs/heads/{branch}",
-                ],
-                check=False,
-                capture_output=True,
+                raise ValueError(f"git worktree base invalid: {base_probe.stderr.strip()}")
+            exact_base = base_probe.stdout.strip()
+            branch_probe = self._source(
+                ["show-ref", "--verify", "--quiet", f"refs/heads/{branch}"]
             )
             if branch_probe.returncode not in {0, 1}:
-                raise ValueError(
-                    f"git branch probe failed: {branch_probe.stderr.decode().strip()}"
-                )
+                raise ValueError(f"git branch probe failed: {branch_probe.stderr.strip()}")
             if branch_probe.returncode == 0:
-                ancestor = subprocess.run(
-                    [
-                        "git", "-C", str(self._repo), "merge-base", "--is-ancestor",
-                        branch, exact_base,
-                    ],
-                    check=False,
-                    capture_output=True,
+                ancestor = self._source(
+                    ["merge-base", "--is-ancestor", branch, exact_base]
                 )
                 if ancestor.returncode == 1:
                     raise ValueError("existing worktree branch has commits outside requested base")
                 if ancestor.returncode != 0:
                     raise ValueError(
-                        f"git branch ancestry check failed: {ancestor.stderr.decode().strip()}"
+                        f"git branch ancestry check failed: {ancestor.stderr.strip()}"
                     )
-                subprocess.run(
-                    ["git", "-C", str(self._repo), "branch", "-f", branch, exact_base],
-                    check=True,
-                    capture_output=True,
-                )
-                argv = [
-                    "git", "-C", str(self._repo), "worktree", "add", str(target), branch,
-                ]
-            else:
-                argv = [
-                    "git", "-C", str(self._repo), "worktree", "add", "-b", branch,
-                    str(target), exact_base,
-                ]
-            subprocess.run(argv, check=True, capture_output=True)
+                previous_branch_sha = self._source(
+                    ["rev-parse", f"refs/heads/{branch}"]
+                ).stdout.strip() or None
+            branch_touched = True
+            moved = self._source(["branch", "-f", branch, exact_base])
+            if moved.returncode != 0:
+                branch_touched = False
+                raise ValueError(f"git worktree add failed: {moved.stderr.strip()}")
+            target_created = True
+            self._clone(branch=branch, target=target, exact_base=exact_base)
         except ValueError:
+            self._rollback(
+                branch=branch,
+                target=target,
+                previous_branch_sha=previous_branch_sha,
+                branch_touched=branch_touched,
+                target_created=target_created,
+            )
             raise
-        except subprocess.CalledProcessError as exc:
-            raise ValueError(f"git worktree add failed: {exc.stderr.decode().strip()}") from exc
         except FileNotFoundError as exc:
+            self._rollback(
+                branch=branch,
+                target=target,
+                previous_branch_sha=previous_branch_sha,
+                branch_touched=branch_touched,
+                target_created=target_created,
+            )
             raise ValueError("git not found") from exc
         return str(target)
+
+    # -- clone 與善後 -----------------------------------------------------------
+
+    def _clone(self, *, branch: str, target: Path, exact_base: str) -> None:
+        cloned = self._run(
+            [
+                "clone",
+                "--quiet",
+                # hardlink 會讓 clone 的 object 與來源 repo 共用 inode——那正是本次
+                # 變更要消滅的共用面（也是 operator 實測採用的旗標）。
+                "--no-hardlinks",
+                "--origin",
+                job_workspace.SOURCE_REMOTE,
+                "--branch",
+                branch,
+                "--",
+                str(self._repo),
+                str(target),
+            ]
+        )
+        if cloned.returncode != 0:
+            raise ValueError(f"git worktree add failed: {cloned.stderr.strip()}")
+
+        origin_url = self._source(["remote", "get-url", "origin"])
+        upstream = origin_url.stdout.strip() if origin_url.returncode == 0 else ""
+
+        if upstream:
+            # 來源 repo 的 remote-tracking refs 一併鏡射過去：worktree 模型下
+            # `git -C <工作區> rev-parse origin/main` 是共用 ref，直接可讀；clone
+            # 只會拿到 `refs/heads/*`，少了這一步模型端的 `git log origin/main..`
+            # 之類命令會突然失效。
+            mirrored = self._run(
+                [
+                    "-C",
+                    str(target),
+                    "fetch",
+                    "--no-tags",
+                    job_workspace.SOURCE_REMOTE,
+                    "+refs/remotes/origin/*:refs/remotes/origin/*",
+                ]
+            )
+            if mirrored.returncode != 0:
+                raise ValueError(
+                    f"git worktree add failed: {mirrored.stderr.strip()}"
+                )
+
+        removed = self._run(["-C", str(target), "remote", "remove", job_workspace.SOURCE_REMOTE])
+        if removed.returncode != 0:
+            raise ValueError(f"git worktree add failed: {removed.stderr.strip()}")
+
+        if upstream:
+            added = self._run(["-C", str(target), "remote", "add", "origin", upstream])
+            if added.returncode != 0:
+                raise ValueError(f"git worktree add failed: {added.stderr.strip()}")
+
+        # `--branch` 會把 upstream 設到暫時 remote 上；`remote remove` 之後那組
+        # config 可能仍在。worktree 模型下 `worktree add -b` 不設 upstream，這裡
+        # 清掉以維持等價（unset 不存在的 key 回 5，非錯誤）。
+        for key in (f"branch.{branch}.remote", f"branch.{branch}.merge"):
+            self._run(["-C", str(target), "config", "--unset-all", key])
+
+        # clone **不繼承**來源 repo 的 local config。identity 缺席時 builder 的
+        # `git commit` 會直接失敗，而 worktree 模型下它是共用的——複製過去。
+        for key in ("user.name", "user.email"):
+            probe = self._source(["config", "--local", "--get", key])
+            value = probe.stdout.strip() if probe.returncode == 0 else ""
+            if value:
+                self._run(["-C", str(target), "config", key, value])
+
+        job_workspace.write_marker(
+            target, branch=branch, base=exact_base, source_repo=self._repo
+        )
+
+    def _rollback(
+        self,
+        *,
+        branch: str,
+        target: Path,
+        previous_branch_sha: str | None,
+        branch_touched: bool,
+        target_created: bool,
+    ) -> None:
+        """把 provision 途中已做的變更全部還原（best-effort，不覆蓋原始錯誤）。"""
+
+        if target_created:
+            try:
+                if target.is_dir() and not target.is_symlink():
+                    job_workspace.remove_clone(target)
+            except Exception:  # noqa: BLE001 - 還原失敗不得蓋掉原始 provision 錯誤
+                pass
+        if not branch_touched:
+            return
+        try:
+            if previous_branch_sha:
+                self._source(["branch", "-f", branch, previous_branch_sha])
+            else:
+                self._source(["branch", "-D", branch])
+        except Exception:  # noqa: BLE001 - 同上
+            pass

--- a/paulsha_cortex/coordinator/verification.py
+++ b/paulsha_cortex/coordinator/verification.py
@@ -13,6 +13,7 @@ from uuid import uuid4
 
 from paulsha_cortex.config import paths
 
+from . import job_workspace
 from .._yaml import YAMLError, safe_load
 from ..persona import gate
 from ..persona.contract import PersonaContract, validate_persona_schema
@@ -694,6 +695,20 @@ def run_result_verification(
     except ContractValidationError as exc:
         details["contract_error"] = exc.as_payload()
         return _finish("needs_human", "verification-contract-invalid")
+
+    # #623：工作區是 per-job clone 時，builder 的 commit 只存在於 clone 自己的
+    # object store 裡——底下所有以 `resolved_repo_root` 為根的判讀（candidate、
+    # ancestry、required-artifact diff、persona scope diff）都會看不到它。先由
+    # Manager 單向 fetch 回自己的樹，才有東西可讀。worktree 模型（以及測試裡的
+    # 假路徑）沒有標記檔，這一步是 no-op，既有行為逐字不變。
+    if branch:
+        try:
+            job_workspace.harvest_if_job_clone(
+                source_repo=resolved_repo_root, workspace=worktree, branch=branch
+            )
+        except job_workspace.WorkspaceError as exc:
+            details["candidate_harvest_error"] = str(exc)
+            return _finish("needs_human", "candidate-harvest-failed")
 
     branch_result = _run_git(["-C", str(resolved_repo_root), "rev-parse", branch], git_runner)
     branch_stdout = branch_result["stdout"].strip()

--- a/paulsha_cortex/coordinator/worktree_reclaim.py
+++ b/paulsha_cortex/coordinator/worktree_reclaim.py
@@ -38,6 +38,7 @@ from uuid import uuid4
 
 from paulsha_cortex.config import paths
 
+from . import job_workspace
 from .dispatcher import _default_git_runner
 
 logger = logging.getLogger(__name__)
@@ -68,6 +69,10 @@ class WorktreeReclaim:
     directory_removed: bool = False
     preserved_ref: str | None = None
     preserved_files: int = 0
+    #: #623：per-job clone 被刪除前，其 HEAD 被封存到來源 repo 的哪一條 ref
+    #: （`job_workspace.ARCHIVE_REF_PREFIX` 底下）。worktree 模型、或 commit 已在
+    #: 來源 repo 裡（成果已回收）時為 None。
+    archived_ref: str | None = None
     detail: str | None = None
 
     @property
@@ -85,6 +90,8 @@ class WorktreeReclaim:
         if self.preserved_ref is not None:
             payload["preserved_ref"] = self.preserved_ref
             payload["preserved_files"] = self.preserved_files
+        if self.archived_ref is not None:
+            payload["archived_ref"] = self.archived_ref
         if self.detail is not None:
             payload["detail"] = self.detail
         return payload
@@ -192,12 +199,26 @@ def _registry_contains(runner: GitRunner, target: Path) -> tuple[bool, str | Non
     return False, None
 
 
-def _looks_like_linked_worktree(target: Path) -> bool:
-    """linked worktree 的根目錄帶的是 `.git` **檔案**（內容 `gitdir: ...`）。
+def _looks_like_job_workspace(target: Path) -> bool:
+    """這個路徑是不是「本模組該遞迴刪除的 build 工作區」。
 
-    `.git` 是**目錄**代表那是一個主 checkout（獨立 repo，例如 run 的
-    `workspace_root`）——那絕不是本模組該遞迴刪除的東西，一律回 False。
+    兩種形狀都算：
+
+    - **per-job clone**（#623 之後的模型）：`.git` 是目錄，但帶
+      `job_workspace` 的標記檔。
+    - **linked worktree**（升級前既存）：`.git` 是**檔案**（內容 `gitdir: ...`）。
+
+    `.git` 是目錄且**沒有**標記檔，代表那是一個主 checkout（獨立 repo，例如 run 的
+    `workspace_root`）——那絕不是本模組該遞迴刪除的東西，一律回 False。標記檔而非
+    「`.git` 是目錄」當判準，正是為了守住這條邊界：clone 模型下若改用寬鬆判準，
+    一筆陳舊的 `job.worktree` 就足以刪掉整個來源 repo。
     """
+
+    return job_workspace.is_job_clone(target) or _looks_like_linked_worktree(target)
+
+
+def _looks_like_linked_worktree(target: Path) -> bool:
+    """linked worktree 的根目錄帶的是 `.git` **檔案**（內容 `gitdir: ...`）。"""
 
     marker = target / ".git"
     return marker.is_file() and not marker.is_symlink()
@@ -321,9 +342,32 @@ def reclaim_worktree(
         and not registered
         and not target.is_symlink()
         and target.is_dir()
-        and not _looks_like_linked_worktree(target)
+        and not _looks_like_job_workspace(target)
     ):
         return WorktreeReclaim(RECLAIM_FAILED, text, detail="worktree-path-not-a-worktree")
+
+    # #623：clone 模型下 `rmtree` 會連 object store 一起刪掉——worktree 模型下這些
+    # commit 在共用 store 裡、branch 也還在主 repo，回收不銷毀任何東西。為了維持本
+    # 模組契約的「不銷毀證據」，刪除前先把工作區 HEAD 拉進來源 repo 的封存命名空間
+    # （已在來源 repo 裡的 commit 不重複封存）。封存本身是加分項，失敗不阻斷回收
+    # ——回收失敗才是 #478／#601 的生產事故。
+    archived_ref: str | None = None
+    if exists and not target.is_symlink() and job_workspace.is_job_clone(target):
+        # 來源 repo 優先取呼叫端給的值；沒給時取標記檔記錄的 provision 來源
+        # ——既有呼叫端（`manager.apply_slice_action` 的 recover-pre-candidate、
+        # `work_actions` 的 abandon 回收）都不傳 `repo_root`，硬要求它會讓封存
+        # 在生產路徑上永遠不觸發。
+        marker = job_workspace.read_marker(target) or {}
+        source = repo_root or marker.get("source_repo")
+        if isinstance(source, (str, Path)) and str(source):
+            try:
+                archived_ref = job_workspace.archive_workspace_head(
+                    source_repo=source, workspace=target
+                )
+            except Exception as exc:  # noqa: BLE001 - 封存失敗只記錄，不阻斷回收
+                logger.warning(
+                    "worktree-reclaim-archive-unavailable path=%s error=%s", text, exc
+                )
 
     preserved_ref: str | None = None
     preserved_files = 0
@@ -430,6 +474,7 @@ def reclaim_worktree(
         directory_removed=directory_removed,
         preserved_ref=preserved_ref,
         preserved_files=preserved_files,
+        archived_ref=archived_ref,
     )
 
 

--- a/tests/test_per_job_clone_provisioning_623.py
+++ b/tests/test_per_job_clone_provisioning_623.py
@@ -1,0 +1,635 @@
+"""#623：工作區模型由 `git worktree` 改為 per-job 完整 clone。
+
+覆蓋四段，皆以**真 git repo** 驗證（注入假 runner 只會驗到 stub 自己）：
+
+1. provision——守衛與 worktree 模型逐條等價，且失敗不留殘留
+2. 隔離——工作區裡沒有任何回寫來源 repo 的路徑；未回收前來源 repo 不受影響
+3. 成果回收——Manager 單向 fetch 回自己的樹，非 fast-forward fail-closed
+4. 回收——clone 走目錄刪除、封存 HEAD；linked worktree（升級前既存）仍走
+   `git worktree remove`；主 checkout 一律拒絕
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from paulsha_cortex.coordinator import gc, job_workspace, manager, verification, worktree_reclaim
+from paulsha_cortex.coordinator.seams import ScriptWorktreeCreator
+
+_BRANCH = "feature/623-per-job-clone"
+
+
+def _git(cwd: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", "-C", str(cwd), *args], check=True, capture_output=True, text=True
+    ).stdout.strip()
+
+
+def _try_git(cwd: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", "-C", str(cwd), *args], check=False, capture_output=True, text=True
+    )
+
+
+def _source_repo(tmp_path: Path, *, with_upstream: bool = True) -> Path:
+    """Manager-owned 的來源 working checkout（不是 bare——monitor 要掃工作樹）。"""
+
+    repo = tmp_path / "repos" / "paulsha-cortex"
+    repo.mkdir(parents=True)
+    subprocess.run(["git", "-C", str(repo), "init", "-q", "-b", "main"], check=True)
+    _git(repo, "config", "user.email", "manager@example.invalid")
+    _git(repo, "config", "user.name", "Cortex Manager")
+    (repo / "tracked.txt").write_text("one\n", encoding="utf-8")
+    _git(repo, "add", "tracked.txt")
+    _git(repo, "commit", "-qm", "initial")
+    if with_upstream:
+        upstream = tmp_path / "upstream.git"
+        subprocess.run(
+            ["git", "init", "-q", "-b", "main", "--bare", str(upstream)], check=True
+        )
+        _git(repo, "remote", "add", "origin", str(upstream))
+        _git(repo, "push", "-q", "origin", "main")
+        _git(repo, "fetch", "-q", "origin")
+    return repo
+
+
+def _creator(repo: Path, pool: Path) -> ScriptWorktreeCreator:
+    return ScriptWorktreeCreator(repo=repo, wt_root=pool, base="main")
+
+
+def _builder_commit(workspace: Path, name: str = "builder.txt") -> str:
+    """模擬 builder 在自己的 clone 裡做一次交付。"""
+
+    (workspace / name).write_text("builder work\n", encoding="utf-8")
+    _git(workspace, "add", name)
+    _git(workspace, "commit", "-qm", f"builder: {name}")
+    return _git(workspace, "rev-parse", "HEAD")
+
+
+# ---------------------------------------------------------------------------
+# 1. provision
+# ---------------------------------------------------------------------------
+
+def test_provisioned_workspace_is_a_standalone_clone_not_a_linked_worktree(
+    tmp_path: Path,
+) -> None:
+    """核心行為變更：工作區有**自己的** object store。
+
+    linked worktree 的 `.git` 是指標檔、object store 共用——那正是 #623 證明與三分
+    隔離互斥的結構。clone 之後 `.git` 是目錄，且來源 repo 的 worktree registry 裡
+    完全沒有這一筆。
+    """
+
+    repo = _source_repo(tmp_path)
+    workspace = Path(_creator(repo, tmp_path / "pool").create(_BRANCH))
+
+    assert (workspace / ".git").is_dir()
+    assert not (workspace / ".git").is_file()
+    assert job_workspace.is_job_clone(workspace)
+    assert str(workspace) not in _git(repo, "worktree", "list", "--porcelain")
+    # 工作區一出生就必須是 clean——標記檔刻意放在 `.git/` 底下，不進工作樹。
+    assert _git(workspace, "status", "--porcelain", "--untracked-files=all") == ""
+
+
+def test_provision_reuses_existing_branch_only_when_it_is_base_ancestor(
+    tmp_path: Path,
+) -> None:
+    """既有 branch 完全位於 base ancestry 時 fast-forward——與 worktree 模型等價。"""
+
+    repo = _source_repo(tmp_path)
+    _git(repo, "branch", _BRANCH)
+    (repo / "tracked.txt").write_text("two\n", encoding="utf-8")
+    _git(repo, "commit", "-qam", "main advances")
+    expected = _git(repo, "rev-parse", "main")
+
+    workspace = Path(_creator(repo, tmp_path / "pool").create(_BRANCH))
+
+    assert _git(repo, "rev-parse", _BRANCH) == expected
+    assert _git(workspace, "rev-parse", "HEAD") == expected
+    assert _git(workspace, "branch", "--show-current") == _BRANCH
+
+
+def test_provision_rejects_diverged_existing_branch_without_moving_it(
+    tmp_path: Path,
+) -> None:
+    """#613 的守衛在 clone 模型下必須逐字保留：不得靜默吸收前代的 commits。"""
+
+    repo = _source_repo(tmp_path)
+    _git(repo, "switch", "-qc", _BRANCH)
+    (repo / "feature.txt").write_text("feature\n", encoding="utf-8")
+    _git(repo, "add", "feature.txt")
+    _git(repo, "commit", "-qm", "feature only")
+    branch_head = _git(repo, "rev-parse", "HEAD")
+    _git(repo, "switch", "-q", "main")
+    (repo / "main.txt").write_text("main\n", encoding="utf-8")
+    _git(repo, "add", "main.txt")
+    _git(repo, "commit", "-qm", "main only")
+
+    with pytest.raises(ValueError, match="commits outside requested base"):
+        _creator(repo, tmp_path / "pool").create(_BRANCH)
+
+    assert _git(repo, "rev-parse", _BRANCH) == branch_head
+    assert not (tmp_path / "pool" / _BRANCH.replace("/", "-")).exists()
+
+
+def test_provision_fails_closed_on_existing_target_without_deleting_it(
+    tmp_path: Path,
+) -> None:
+    """#601／#527 的守衛：撞到既有 target 一律拒絕。
+
+    clone 模型新增了「失敗時回滾」的能力，這條測的正是回滾**不得**擴張成
+    「刪掉別人的工作區再說」——`target already exists` 的路徑上一個位元組都不動。
+    """
+
+    repo = _source_repo(tmp_path)
+    pool = tmp_path / "pool"
+    stale = pool / _BRANCH.replace("/", "-")
+    stale.mkdir(parents=True)
+    (stale / "precious.json").write_text("{}", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="worktree target already exists"):
+        _creator(repo, pool).create(_BRANCH)
+
+    assert (stale / "precious.json").is_file()
+
+
+def test_provision_rolls_back_the_branch_when_the_base_is_invalid(
+    tmp_path: Path,
+) -> None:
+    """base 無效時不得留下半套狀態：branch 不被建立、目錄不存在。"""
+
+    repo = _source_repo(tmp_path)
+    pool = tmp_path / "pool"
+
+    with pytest.raises(ValueError, match="git worktree base invalid"):
+        ScriptWorktreeCreator(repo=repo, wt_root=pool, base="no-such-base").create(_BRANCH)
+
+    assert _try_git(repo, "show-ref", "--verify", "--quiet", f"refs/heads/{_BRANCH}").returncode == 1
+    assert not (pool / _BRANCH.replace("/", "-")).exists()
+
+
+def test_provision_creates_the_branch_in_the_source_repo(tmp_path: Path) -> None:
+    """branch 仍錨定在來源 repo：dispatch baseline 與 gc 都直接讀它。"""
+
+    repo = _source_repo(tmp_path)
+    base = _git(repo, "rev-parse", "main")
+
+    _creator(repo, tmp_path / "pool").create(_BRANCH)
+
+    assert _git(repo, "rev-parse", f"refs/heads/{_BRANCH}") == base
+
+
+def test_provisioned_workspace_matches_the_worktree_model_git_environment(
+    tmp_path: Path,
+) -> None:
+    """clone 不繼承來源 repo 的 local config，逐項補回才能與 worktree 模型等價。"""
+
+    repo = _source_repo(tmp_path)
+    upstream = _git(repo, "remote", "get-url", "origin")
+
+    workspace = Path(_creator(repo, tmp_path / "pool").create(_BRANCH))
+
+    # `origin` 是**真正的上游**，不是來源 repo——否則 delivery 的
+    # `git -C <工作區> push origin` 會把 candidate 推進 Manager 的樹。
+    assert _git(workspace, "remote", "get-url", "origin") == upstream
+    # 來源 repo 的 remote-tracking refs 有鏡射過來（模型常跑 `git log origin/main..`）
+    assert _git(workspace, "rev-parse", "origin/main") == _git(repo, "rev-parse", "origin/main")
+    # `worktree add -b` 不設 upstream，clone 也不得留下 `--branch` 帶進來的那組
+    assert _try_git(workspace, "rev-parse", "--abbrev-ref", "@{u}").returncode != 0
+    # identity 缺席時 builder 的 `git commit` 會直接失敗
+    assert _git(workspace, "config", "user.email") == "manager@example.invalid"
+
+
+def test_provision_works_without_an_upstream_remote(tmp_path: Path) -> None:
+    """來源 repo 沒有 `origin`（測試環境常見）時工作區同樣沒有——與 worktree 等價。"""
+
+    repo = _source_repo(tmp_path, with_upstream=False)
+    workspace = Path(_creator(repo, tmp_path / "pool").create(_BRANCH))
+
+    assert _git(workspace, "remote") == ""
+    assert _builder_commit(workspace)
+
+
+# ---------------------------------------------------------------------------
+# 2. 隔離
+# ---------------------------------------------------------------------------
+
+def test_workspace_has_no_git_path_back_into_the_source_repo(tmp_path: Path) -> None:
+    """D2 方向性：builder 永遠不 push 進 Manager 的樹。
+
+    clone 期間的來源 remote 必須被移除——留著它，`git push cortex-source` 就是一條
+    現成的回寫路徑（權限層擋得住，但不該在工作區裡放這個把手）。
+    """
+
+    repo = _source_repo(tmp_path)
+    workspace = Path(_creator(repo, tmp_path / "pool").create(_BRANCH))
+
+    remotes = _git(workspace, "remote").splitlines()
+    assert job_workspace.SOURCE_REMOTE not in remotes
+    urls = [_git(workspace, "remote", "get-url", name) for name in remotes if name]
+    assert all(str(repo) != url for url in urls)
+
+
+def test_builder_commits_do_not_reach_the_source_repo_before_harvest(
+    tmp_path: Path,
+) -> None:
+    """clone 有自己的 object store：未回收前來源 repo 看不到 builder 的 commit。
+
+    這正是與 worktree 模型的實質差異，也是「必須有回收這一段」的理由。
+    """
+
+    repo = _source_repo(tmp_path)
+    base = _git(repo, "rev-parse", "main")
+    workspace = Path(_creator(repo, tmp_path / "pool").create(_BRANCH))
+
+    candidate = _builder_commit(workspace)
+
+    assert _git(repo, "rev-parse", f"refs/heads/{_BRANCH}") == base
+    assert _try_git(repo, "cat-file", "-e", f"{candidate}^{{commit}}").returncode != 0
+
+
+# ---------------------------------------------------------------------------
+# 3. 成果回收
+# ---------------------------------------------------------------------------
+
+def test_manager_harvests_the_candidate_out_of_the_builder_clone(
+    tmp_path: Path,
+) -> None:
+    repo = _source_repo(tmp_path)
+    workspace = Path(_creator(repo, tmp_path / "pool").create(_BRANCH))
+    candidate = _builder_commit(workspace)
+
+    harvested = job_workspace.harvest_if_job_clone(
+        source_repo=repo, workspace=workspace, branch=_BRANCH
+    )
+
+    assert harvested == candidate
+    assert _git(repo, "rev-parse", f"refs/heads/{_BRANCH}") == candidate
+    # object 也真的進來了——review 卡的 `worktree add --detach <candidate>` 靠這個
+    assert _try_git(repo, "cat-file", "-e", f"{candidate}^{{commit}}").returncode == 0
+
+
+def test_harvest_rejects_a_rewritten_history_instead_of_absorbing_it(
+    tmp_path: Path,
+) -> None:
+    """refspec 刻意不帶 `+`：Manager 不會靜默吸收被改寫過的歷史。"""
+
+    repo = _source_repo(tmp_path)
+    workspace = Path(_creator(repo, tmp_path / "pool").create(_BRANCH))
+    first = _builder_commit(workspace)
+    job_workspace.harvest_branch(source_repo=repo, workspace=workspace, branch=_BRANCH)
+
+    _git(workspace, "reset", "-q", "--hard", "HEAD~1")
+    _builder_commit(workspace, "rewritten.txt")
+
+    with pytest.raises(job_workspace.WorkspaceError, match="not a fast-forward"):
+        job_workspace.harvest_branch(source_repo=repo, workspace=workspace, branch=_BRANCH)
+
+    assert _git(repo, "rev-parse", f"refs/heads/{_BRANCH}") == first
+
+
+def test_harvest_is_a_noop_for_a_workspace_that_is_not_a_job_clone(
+    tmp_path: Path,
+) -> None:
+    """零回歸掛點：worktree 模型與測試裡的假路徑完全不受影響。"""
+
+    repo = _source_repo(tmp_path)
+    legacy = tmp_path / "legacy-worktree"
+    _git(repo, "worktree", "add", "-q", "-b", "feature/legacy", str(legacy), "main")
+
+    assert (
+        job_workspace.harvest_if_job_clone(
+            source_repo=repo, workspace=legacy, branch="feature/legacy"
+        )
+        is None
+    )
+    assert (
+        job_workspace.harvest_if_job_clone(
+            source_repo=repo, workspace=tmp_path / "does-not-exist", branch="feature/x"
+        )
+        is None
+    )
+
+
+# ---------------------------------------------------------------------------
+# 4. 回收
+# ---------------------------------------------------------------------------
+
+def test_reclaim_removes_a_job_clone_and_leaves_no_residue(tmp_path: Path) -> None:
+    """#601／#613 關心的正是殘留：目錄與 registry 都不得留下任何一筆。"""
+
+    repo = _source_repo(tmp_path)
+    workspace = Path(_creator(repo, tmp_path / "pool").create(_BRANCH))
+    _builder_commit(workspace)
+    job_workspace.harvest_branch(source_repo=repo, workspace=workspace, branch=_BRANCH)
+
+    result = worktree_reclaim.reclaim_worktree(workspace, repo_root=repo)
+
+    assert result.status == worktree_reclaim.RECLAIM_RECLAIMED
+    assert result.ok
+    assert not workspace.exists()
+    assert str(workspace) not in _git(repo, "worktree", "list", "--porcelain")
+    # 成果已回收 → 沒有東西會被銷毀 → 不重複封存
+    assert result.archived_ref is None
+
+
+def test_reclaim_archives_unharvested_commits_before_deleting_the_clone(
+    tmp_path: Path,
+) -> None:
+    """clone 模型下 `rmtree` 會連 object store 一起刪掉。
+
+    worktree 模型回收工作區不銷毀任何 commit（object 在共用 store、branch 還在），
+    本模組契約也明文「不銷毀證據」。未回收的 commit 因此必須先進封存命名空間。
+    """
+
+    repo = _source_repo(tmp_path)
+    workspace = Path(_creator(repo, tmp_path / "pool").create(_BRANCH))
+    orphan = _builder_commit(workspace)
+
+    result = worktree_reclaim.reclaim_worktree(workspace, repo_root=repo)
+
+    assert result.status == worktree_reclaim.RECLAIM_RECLAIMED
+    assert not workspace.exists()
+    assert result.archived_ref is not None
+    assert result.archived_ref.startswith(job_workspace.ARCHIVE_REF_PREFIX)
+    assert _git(repo, "rev-parse", result.archived_ref) == orphan
+    assert result.to_dict()["archived_ref"] == result.archived_ref
+
+
+def test_reclaim_derives_the_source_repo_from_the_workspace_marker(
+    tmp_path: Path,
+) -> None:
+    """既有呼叫端都不傳 `repo_root`——封存必須靠標記檔自己找得到來源 repo。"""
+
+    repo = _source_repo(tmp_path)
+    workspace = Path(_creator(repo, tmp_path / "pool").create(_BRANCH))
+    orphan = _builder_commit(workspace)
+
+    result = worktree_reclaim.reclaim_worktree(
+        workspace, git_runner=lambda args: subprocess.run(
+            ["git", "-C", str(repo), *args], check=False, capture_output=True, text=True
+        )
+    )
+
+    assert result.status == worktree_reclaim.RECLAIM_RECLAIMED
+    assert result.archived_ref is not None
+    assert _git(repo, "rev-parse", result.archived_ref) == orphan
+
+
+def test_reclaim_preserves_dirty_content_inside_a_job_clone(tmp_path: Path) -> None:
+    """#478 的 `.project-policy.yml` 資料遺失回報：未提交內容先封存再刪。
+
+    `_dirty_entries` 走的是 repo-pinned runner 再疊一層 `-C <工作區>`；clone 是獨立
+    repo（不是共用 gitdir 的 linked worktree），這條路徑必須照樣掃得到 dirty 內容。
+    """
+
+    repo = _source_repo(tmp_path)
+    workspace = Path(_creator(repo, tmp_path / "pool").create(_BRANCH))
+    (workspace / "uncommitted.txt").write_text("work in progress\n", encoding="utf-8")
+    preserve_root = tmp_path / "evidence"
+
+    result = worktree_reclaim.reclaim_worktree(
+        workspace, repo_root=repo, preserve_root=preserve_root
+    )
+
+    assert result.status == worktree_reclaim.RECLAIM_RECLAIMED
+    assert result.preserved_files == 1
+    assert result.preserved_ref is not None
+    assert (Path(result.preserved_ref) / "uncommitted.txt").read_text(
+        encoding="utf-8"
+    ) == "work in progress\n"
+    assert not workspace.exists()
+
+
+def test_reclaim_still_refuses_a_main_checkout_under_the_clone_model(
+    tmp_path: Path,
+) -> None:
+    """判準是標記檔，不是「`.git` 是目錄」——否則陳舊的 job 記錄能刪掉整個 repo。"""
+
+    repo = _source_repo(tmp_path)
+    other = _source_repo(tmp_path / "elsewhere")
+
+    result = worktree_reclaim.reclaim_worktree(
+        other,
+        git_runner=lambda args: subprocess.run(
+            ["git", "-C", str(repo), *args], check=False, capture_output=True, text=True
+        ),
+    )
+
+    assert result.status == worktree_reclaim.RECLAIM_FAILED
+    assert result.detail == "worktree-path-not-a-worktree"
+    assert (other / "tracked.txt").is_file()
+
+
+# ---------------------------------------------------------------------------
+# 5. `cortex work gc`
+# ---------------------------------------------------------------------------
+
+def test_gc_scan_sees_job_clones_that_git_worktree_list_cannot(tmp_path: Path) -> None:
+    repo = _source_repo(tmp_path)
+    pool = tmp_path / "pool"
+    workspace = Path(_creator(repo, pool).create(_BRANCH))
+
+    artifacts = gc.scan(repo, worktree_root=pool)
+    rows = {
+        (item.kind, item.identifier): item
+        for item in artifacts
+        if item.kind == "worktree"
+    }
+
+    assert ("worktree", str(workspace.resolve())) in rows
+
+
+def test_gc_apply_reclaims_a_merged_job_clone_by_directory_removal(
+    tmp_path: Path,
+) -> None:
+    """clone 沒有 worktree registry，`git worktree remove` 對它必然失敗。"""
+
+    repo = _source_repo(tmp_path)
+    pool = tmp_path / "pool"
+    workspace = Path(_creator(repo, pool).create(_BRANCH))
+
+    artifacts = gc.scan(repo, worktree_root=pool)
+    applied = gc.apply_gc(repo, artifacts, default_branch="main")
+    reclaimed = [
+        item
+        for item in applied
+        if item.kind == "worktree" and item.action == gc.ACTION_RECLAIM
+    ]
+
+    assert [item.identifier for item in reclaimed] == [str(workspace.resolve())]
+    assert reclaimed[0].detail == "removed"
+    assert not workspace.exists()
+
+
+def test_gc_protects_the_branch_of_a_live_job_clone(tmp_path: Path) -> None:
+    """未 merge 的工作區仍在用時，它的 branch 不得被歸類為可回收。
+
+    worktree 模型靠 `git worktree list` 找出「還掛著」的 branch；clone 沒有那份
+    registry，少了 clone 掃描這一步 gc 會在 job 還在跑的時候把 branch 刪掉。
+    """
+
+    repo = _source_repo(tmp_path)
+    pool = tmp_path / "pool"
+    workspace = Path(_creator(repo, pool).create(_BRANCH))
+    _builder_commit(workspace)
+    job_workspace.harvest_branch(source_repo=repo, workspace=workspace, branch=_BRANCH)
+
+    artifacts = gc.scan(repo, worktree_root=pool)
+    branch_rows = [item for item in artifacts if item.kind == "branch" and item.branch == _BRANCH]
+
+    assert branch_rows and all(item.action == gc.ACTION_KEEP for item in branch_rows)
+
+
+def test_gc_still_reclaims_a_pre_upgrade_linked_worktree(tmp_path: Path) -> None:
+    """既有部署零回歸：升級前建立的 linked worktree 仍走 `git worktree remove`。"""
+
+    repo = _source_repo(tmp_path)
+    pool = tmp_path / "pool"
+    pool.mkdir()
+    legacy = pool / "feature-legacy"
+    _git(repo, "worktree", "add", "-q", "-b", "feature/legacy", str(legacy), "main")
+
+    artifacts = gc.scan(repo, worktree_root=pool)
+    applied = gc.apply_gc(repo, artifacts, default_branch="main")
+    reclaimed = [
+        item
+        for item in applied
+        if item.kind == "worktree" and item.action == gc.ACTION_RECLAIM
+    ]
+
+    assert [item.identifier for item in reclaimed] == [str(legacy.resolve())]
+    assert not legacy.exists()
+    assert str(legacy) not in _git(repo, "worktree", "list", "--porcelain")
+
+
+# ---------------------------------------------------------------------------
+# 6. 端到端
+# ---------------------------------------------------------------------------
+
+def test_workflow_lane_harvests_the_candidate_when_the_card_is_accepted(
+    tmp_path: Path,
+) -> None:
+    """canonical lane 的掛點：build card 的 candidate 被採信後立刻取回 Manager 的樹。
+
+    掛在 `_verify_build_candidate_transition` **之後**——那一步已確認 candidate 就是
+    工作區的 HEAD 且單調延伸自基線，回收只負責搬運，不新增採信路徑。
+    """
+
+    repo = _source_repo(tmp_path)
+    workspace = Path(_creator(repo, tmp_path / "pool").create(_BRANCH))
+    candidate = _builder_commit(workspace)
+    job = {"worktree": str(workspace), "branch": _BRANCH}
+    run = SimpleNamespace(workspace_root=str(repo))
+
+    harvested = manager._harvest_build_candidate(job, run=run, candidate=candidate)
+
+    assert harvested == candidate
+    assert _git(repo, "rev-parse", f"refs/heads/{_BRANCH}") == candidate
+
+
+def test_workflow_lane_harvest_is_a_noop_outside_the_clone_model(
+    tmp_path: Path,
+) -> None:
+    """既有部署零回歸：worktree 模型與測試裡的假 worktree 路徑完全不觸發回收。"""
+
+    repo = _source_repo(tmp_path)
+    run = SimpleNamespace(workspace_root=str(repo))
+
+    assert (
+        manager._harvest_build_candidate(
+            {"worktree": str(repo), "branch": "main"}, run=run, candidate="0" * 40
+        )
+        is None
+    )
+    assert (
+        manager._harvest_build_candidate(
+            {"worktree": "", "branch": _BRANCH}, run=run, candidate="0" * 40
+        )
+        is None
+    )
+
+
+def test_workflow_lane_harvest_fails_closed_when_the_head_does_not_match(
+    tmp_path: Path,
+) -> None:
+    repo = _source_repo(tmp_path)
+    workspace = Path(_creator(repo, tmp_path / "pool").create(_BRANCH))
+    _builder_commit(workspace)
+    job = {"worktree": str(workspace), "branch": _BRANCH}
+    run = SimpleNamespace(workspace_root=str(repo))
+
+    with pytest.raises(ValueError, match="harvest head mismatch"):
+        manager._harvest_build_candidate(job, run=run, candidate="0" * 40)
+
+
+def test_slice_lane_verification_harvests_before_reading_the_branch(
+    tmp_path: Path,
+) -> None:
+    """`verification` 以來源 repo 為根判讀 candidate／ancestry／diff。
+
+    clone 模型下那些 commit 只在工作區裡——少了回收這一步，整段會以
+    `candidate-unreadable` 或 `candidate-worktree-mismatch` 收場。
+    """
+
+    repo = _source_repo(tmp_path)
+    base = _git(repo, "rev-parse", "main")
+    workspace = Path(_creator(repo, tmp_path / "pool").create(_BRANCH))
+    candidate = _builder_commit(workspace)
+    contract = {
+        "docs_class": "trivial",
+        "review_policy": "not-required",
+        "required_artifacts": [],
+        "checks": [],
+        "tests": [],
+        "full_suite": {
+            "argv": ["true"],
+            "cwd": ".",
+            "timeout_seconds": 5,
+            "baseline": "no-regression",
+        },
+    }
+
+    verification.run_result_verification(
+        slice_row={
+            "slice_id": "clone-623",
+            "dispatch_base": base,
+            "verification": {"contract": contract},
+        },
+        job={"task": "clone-623", "branch": _BRANCH, "worktree": str(workspace)},
+        repo_root=repo,
+        coordinator_root=tmp_path / "coordinator",
+    )
+
+    assert _git(repo, "rev-parse", f"refs/heads/{_BRANCH}") == candidate
+
+
+def test_end_to_end_provision_commit_harvest_reclaim(tmp_path: Path) -> None:
+    """一整條：provision → builder commit → Manager 回收成果 → 回收工作區。"""
+
+    repo = _source_repo(tmp_path)
+    pool = tmp_path / "pool"
+    workspace = Path(_creator(repo, pool).create(_BRANCH))
+
+    candidate = _builder_commit(workspace)
+    # builder 寫不到來源 repo 的 ref（此處以「來源 repo 沒有這條路徑」驗證方向性；
+    # 檔案權限那一半屬 trust-root 的 chown／ACL，不在本層）
+    assert job_workspace.SOURCE_REMOTE not in _git(workspace, "remote").splitlines()
+
+    harvested = job_workspace.harvest_branch(
+        source_repo=repo, workspace=workspace, branch=_BRANCH
+    )
+    assert harvested == candidate
+    assert _git(repo, "rev-parse", f"refs/heads/{_BRANCH}") == candidate
+
+    result = worktree_reclaim.reclaim_worktree(workspace, repo_root=repo)
+
+    assert result.ok
+    assert not workspace.exists()
+    # 成果留在 Manager 的樹裡，工作區消失也不會遺失
+    assert _git(repo, "rev-parse", f"refs/heads/{_BRANCH}") == candidate
+    assert _try_git(repo, "cat-file", "-e", f"{candidate}^{{commit}}").returncode == 0


### PR DESCRIPTION
## 摘要

`git worktree` → **per-job 完整 clone**。operator 0817 已裁決（#623 第一則實測留言）。
本 PR 只做 **provisioning、成果回收與回收層**，不動 `paulsha_cortex/trust_root/`。

## 為什麼非改不可

trust-root Phase 2b M1（#584）之後 builder 以 `cortex-builder` 執行、Manager 以
`cortex-manager`，durable state 樹是 `0700 cortex-manager`。operator 實測（#623）：

- linked worktree 的 `.git` 是指標檔，指向 `<來源 repo>/.git/worktrees/<name>`——那在
  Manager-owned 樹裡。只 chown worktree 目錄 → `git status: fatal: not a git repository`
- 連 gitdir 那一格也 chown、父鏈補 `--x` → `git status` OK，但 **`git add` 仍失敗**：
  寫 object 需要寫**共用** object store

推論是一條互斥：**只要 builder 要能 commit，它就必須能寫 object store；而能寫 object
store，「builder 不可竄改 Manager state」這條邊界就在 git 這一層漏掉。** per-job clone
有自己的 object store（實測 0.5 秒／35MB per job）。

## 變更

### 新模組 `coordinator/job_workspace.py`

工作區「是什麼」的單一真相——標記、識別、列舉、刪除、成果回收、回收前封存。三個呼叫端
（`seams`／`gc`／`worktree_reclaim`）共用，避免同一判準在三處各自演化。

識別判準是寫在 clone `.git/` 底下的標記檔，**不是**「`.git` 是目錄」——後者對任何主
checkout 都成立，一筆陳舊的 `job.worktree` 就足以讓遞迴刪除掃掉整個來源 repo（#478
現場記錄過 `job.worktree` 等於 run 的 `workspace_root`）。標記放在 `.git/` 而非工作樹
根，是因為工作樹根的任何檔案都會讓工作區一出生就是 dirty，而 dirty 是 `verification`
與 `gc` 的 fail-closed 條件。

### provisioning（`coordinator/seams.py`）

`git worktree add` → `git clone --no-hardlinks`。**守衛逐條等價，錯誤訊息逐字保留**
（既有診斷與 #527／#601 的測試不因實作換代而失效）：

| 守衛 | clone 模型下的作法 |
|---|---|
| target 已存在 | 同——先探測後 fail-closed |
| base 必須是既有 commit | 同——`rev-parse --verify <base>^{commit}` |
| 既有 branch 必須位於 base ancestry | 同——`merge-base --is-ancestor`，非祖先即拒（#613 的守衛） |
| 既有 branch fast-forward 後重掛 | 在**來源 repo** `branch -f` 後 clone 出來 |
| 新 branch | 在**來源 repo** 建 branch 後 clone 出來 |

branch 仍錨定在來源 repo（而非只存在於 clone 裡）的理由有三：`gc` 與 `dispatcher`／
`autonomy` 的 dispatch baseline 都直接讀來源 repo 的 `refs/heads/<branch>`；ancestry
守衛需要一個跨世代穩定的比較對象；成果回收本來就會把 branch fetch 回同一個位置。

clone 完成後的工作區狀態與 worktree 模型**逐字相同**：

- `origin` 指向**真正的上游**（來源 repo 的 `origin` URL）——delivery 的
  `git -C <工作區> push origin HEAD:refs/heads/<branch>`（`work_bridge`）因此行為不變。
  若讓 `origin` 留在來源 repo，那條 push 會直接把 candidate 推進 Manager 的樹。
- 指向來源 repo 的暫時 remote（clone 用的）**一律移除**——不在 builder 的工作區裡留
  一個現成的回寫把手。
- branch 沒有 upstream（`worktree add -b` 也不設）。
- 來源 repo 的 `refs/remotes/origin/*` 鏡射過去（模型常跑 `git log origin/main..`）。
- 來源 repo 的 local `user.name`／`user.email` 複製過去——clone **不繼承**來源的 local
  config，少了 identity builder 的 `git commit` 會直接失敗。

任何一步失敗都把已做的變更**全部還原**（部分 clone 目錄、branch 位置），但
`target already exists` 這條路徑上一個位元組都不動——回滾不得擴張成「刪掉別人的工作區
再說」。

### 成果回收

clone 有自己的 object store，builder 的 commit 在回收前**來源 repo 看不到**。
`job_workspace.harvest_branch()`：

```
git -C <來源 repo> fetch --no-tags <clone> refs/heads/<branch>:refs/heads/<branch>
```

Manager **拉**，沿用 D2「git 讀」的方向——builder 永遠不 push 進 Manager 的樹。refspec
刻意不帶 `+`：非 fast-forward 由 git 拒絕，Manager 不會靜默吸收被改寫過的歷史。

掛在兩個 lane 的採信點：

- **canonical lane**：`manager.apply_workflow_action` 的 build phase，
  `_verify_build_candidate_transition` **之後**——那一步已確認 candidate 就是工作區的
  HEAD 且單調延伸自基線，回收只負責搬運，不新增採信路徑。回收後來源 repo 的 branch
  必須恰好等於該 candidate，對不上即 fail-closed。
- **slice lane**：`verification.run_result_verification` 讀 branch head **之前**——該
  函式以來源 repo 為根判讀 candidate／ancestry／required-artifact diff／persona scope
  diff，少了回收整段會以 `candidate-unreadable` 收場。

工作區不是 per-job clone 時兩處都是 no-op。

### 回收層（`gc.py` / `worktree_reclaim.py`）

- `gc.scan` 同時涵蓋 per-job clone（走檔案系統，`git worktree list` 看不到它們）與
  升級前既存的 linked worktree；`--apply` 依工作區**自己的形狀**分派回收方式
  （clone＝目錄刪除、linked worktree＝`git worktree remove`），**不依部署模式旗標**
  ——旗標會與磁碟上的實況漂移，形狀不會。少了 clone 掃描這一步，正在跑的 job 的
  branch 會因為「沒掛在任何 worktree 上」被誤判為可回收。
- `worktree_reclaim` 的安全閘擴充為認得兩種形狀（主 checkout 仍被拒），並在刪除 clone
  前把工作區 HEAD 封存進來源 repo 的 `refs/cortex/reclaimed/**`（來源 repo 已有該
  commit 時不重複封存）——worktree 模型下回收工作區不銷毀任何 commit，clone 模型下
  `rmtree` 會連 object store 一起刪掉，而該模組契約明文「不銷毀證據」。來源 repo 取自
  呼叫端或標記檔（既有呼叫端都不傳 `repo_root`）。

## 與 #601／#613 的關係

**#613（abandon 不回收 build branch，換代 provision 撞 existing branch）**：clone 模型
讓這個現場**大幅收斂但不消失**。gen1 若在 candidate 錨定前失敗，它的 commit 只在 clone
裡、來源 repo 的 branch 仍停在 base，gen2 的 ancestry 守衛因此**自然通過**——#613 的
主要觸發路徑消失。但 gen1 若已成功回收過成果，branch 就帶著 gen1 的 commits，守衛照舊
會擋（這是正確的 fail-closed）。因此 **#613 的修法（abandon 終態化時 tag 歸檔再刪
branch）仍然需要，範圍縮小到「已回收過成果的世代」**。本 PR 的封存機制（
`refs/cortex/reclaimed/**`）處理的是另一半——**未**回收的 commit 在 clone 被刪時的
可達性，那是 clone 模型新引入的風險，worktree 模型下不存在。

**#601（retry-card 對 provision 卡不回收殘留 worktree）**：診斷不變、修法不變（retry-card
的 provision 卡路徑要接上 `worktree_reclaim` 的原子 helper），但本 PR 讓那條路徑**在
clone 模型下可用**——`worktree_reclaim` 原本的安全閘會對 clone 回
`worktree-path-not-a-worktree` 而**整條回收失效**，本 PR 修掉了這一點。另外
provisioning 新增的失敗回滾會減少（不能消除）殘留的產生。

兩票都不因本 PR 失效，也都不需要改寫；#613 的範圍可以縮小，建議在該票補一則說明。

## `direct` 模式相容性：取捨與理由

**選擇：clone 模型對兩種模式走同一條 code path**，不依 `PSC_JOB_RUNNER` 分支。

- **為什麼不分支**：依 runner mode 分支等於讓「磁碟上的工作區是什麼形狀」取決於一個
  執行期旗標。旗標與實況一漂移（升級中途改設定、舊工作區殘留），`gc` 與
  `worktree_reclaim` 就會用錯的方式回收。改以**工作區自己的形狀**（標記檔）判斷，
  兩種形狀在同一棵樹裡並存也不會錯配。
- **代價**：`direct` 模式也開始付 clone 的成本（實測 0.5 秒／35MB per job）。對本 repo
  規模可接受。
- **零回歸怎麼保證**：所有新行為（成果回收、clone 回收路徑、封存）都以標記檔為前置
  條件；worktree 模型與測試裡的假 worktree 路徑完全不觸發。`gc` 與 `worktree_reclaim`
  都保留了 linked worktree 的完整處理路徑，升級前既存的工作區仍可被正常回收（有專門
  的測試）。全套 3644 passed、零回歸。
- **`launcher` 無需改動**：`_linked_worktree_git_write_dirs` 對 `.git` 為目錄的工作區
  本來就回空集合，而 clone 的 `.git` 在工作區內、已被 sandbox 的工作區授權涵蓋。

## 與 #612／PR #630 的相容性

未新增任何靜默 fallback。`job_workspace` 完全不解析路徑根（來源 repo 一律由呼叫端或
標記檔明確給定）；`seams` 的 `paths.repo_root()` 用法未改（PR #630 修好之後直接受益）。

## 已知缺口（本 PR 不收，建議後續票）

1. **`dispatcher.poll_done` 的 slice-lane baseline** 以來源 repo 的 branch head 判定
   「builder 有沒有 commit」。它目前**無任何 production 呼叫端**（只有 CLI 原語），
   故未接上回收；若將來重新啟用需補。
2. **ship／delivery 由 Manager 在 builder-owned 工作區內執行 git**
   （`work_bridge._push_exact_candidate`、`_commit_archive_and_require_reverification`
   等五處）。clone 模型下那些是 builder 擁有的目錄，Manager 未必寫得進去。本 PR 的成果
   回收落地後這些動作已可改由 Manager 在**自己的**來源 repo 上做——已開 **#635** 追蹤
   （上面第 1 點的 `poll_done` 也併在該票的附帶段）。
3. **登記表資產**（`repo-source-tree`、builder `.gitconfig`、permgen 的 RWP／ACL 導出、
   unit 產生器）由另一 agent 於 #632 落地後處理；本 PR 只**假設**那些路徑存在並照契約
   使用。

## 測試

新增 `tests/test_per_job_clone_provisioning_623.py`（27 測試，**全部以真 git repo
驗證**——注入假 runner 只會驗到 stub 自己）：

- provision：獨立 object store／守衛逐條等價／既有 target 不被刪／base 無效時回滾／
  git 環境與 worktree 模型等價／無上游 remote 時亦可用
- 隔離：工作區沒有回寫來源 repo 的路徑；未回收前來源 repo 看不到 builder 的 commit
- 成果回收：candidate 正確回收、非 fast-forward fail-closed、非 clone 為 no-op、
  兩個 lane 的掛點各有測試（含 head mismatch 的 fail-closed）
- 回收：clone 目錄與 branch 無殘留、未回收 commit 先封存、來源 repo 由標記檔推得、
  主 checkout 仍被拒、dirty 內容封存
- `gc`：掃得到 clone、以目錄刪除回收、在用工作區的 branch 受保護、**升級前既存的
  linked worktree 仍走 `git worktree remove`**
- 端到端：provision → builder commit → Manager 回收成果 → 回收工作區，成果留存

`python3 -m pytest tests/ -q`：**3644 passed, 49 subtests passed**，零回歸。
`python3 -m policy_check --repo . --pr-*`：**fail: 0**。

## Checklist

- [x] 分支非 `main`（`feature/623-per-job-clone-provisioning`）
- [x] `changelog.d/per-job-clone-provisioning.md` fragment 已新增且已 commit
- [x] `CHANGELOG.md [Unreleased]` 有對應 entry
- [x] `VERSION` 未動（非 release PR）
- [x] 全套測試通過（3644 passed，零回歸）
- [x] 本機 policy_check 帶 PR 上下文跑過（含 `policy-exempt:issue-link`），fail: 0
- [x] 文件與 PR 內文為 zh-tw
- [x] docs 同步（`docs/superpowers/specs/feat-work-gc-v2-spec.md` 的 R4 回收範圍）

Refs #623（**不用 `Closes`**：#623 還有缺口 2「EnvironmentFile 漏八個運轉變數」與
缺口 3「operator-authored config 未搬」未解，本 PR 只收工作區模型這一段。因此帶
`policy-exempt:issue-link` 豁免 R-17——引用不關閉。）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E7w9kaUxAzCCEk7piD5hfK
