### PR TITLE
feat(trust-root): per-job clone 的信任根層——來源樹、三份 gitconfig 與 commit spool 進登記表

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,29 @@
 ## [Unreleased]
 
 ### Added
+- **#623 / trust-root Phase 2b：per-job clone 的信任根層——`repo-source-tree` ＋ 兩份
+  root-owned `.gitconfig` 進登記表，內容由 permgen 產生**——M1 之後實機發現「這個部署
+  做不了真實工作」：`ProtectHome=yes` 讓 `/home` 完全不可見，而登記表**沒有定義 repo
+  源碼樹該放哪**；實測進一步證明 `git worktree` 在三分下結構性不成立（worktree 的
+  `.git` 指向**共用 object store**，builder 只要 `git add` 就必須能寫它，「builder 能
+  commit」與「三分隔離」互斥）。裁決改為 **per-job 完整 clone**（0.5 秒／35MB per job）。
+  本 PR 落地信任根層：新增登記表資產 `repo-source-tree`（`<agents_root>/repos`，
+  **working checkout**——monitor 要掃工作樹裡的檔案，bare 沒有工作樹；同一份 checkout
+  兼作掃描目標與 clone 來源）與 `builder-gitconfig`／`reviewer-planner-gitconfig`
+  （root-owned 0644，落在各自 job 帳號 HOME 下，比照既有的 `codex-hooks`）。
+  來源樹的 **writer 只有部署身分（root）**，owner_class 因此機械分到 `DEPLOYMENT`、
+  owner＝root 0755，**Manager／monitor／兩個 job 帳號一律唯讀**——ReadWritePaths 純由
+  「誰可寫」導出，owner＝`cortex-manager` 會讓 Manager unit 自動拿到寫入權，
+  「Manager 唯讀」與「owner＝Manager」互斥，取前者（攻擊面最小；代價是更新來源樹改為
+  operator 的 root 動作）。`.gitconfig` 的**內容**同樣由 permgen 產生
+  （`build_job_gitconfig()` ＋ CLI `trust_root gitconfig … --source-repo <slug>`），含
+  來源 repo 的 `safe.directory`——跨擁有者 clone 會被 git 的 dubious-ownership 保護擋
+  下，而 job 的 HOME 是 root-owned、它自己放不了這個檔；來源 repo 清單是部署決定
+  （比照 #626），未宣告即 fail-closed（git 的 `safe.directory` 只認逐字相等的路徑或
+  字面 `*`，實測 git 2.43 不吃 `<repos>/*`，而字面 `*` 等於整個關掉該保護）。三份 unit
+  的 `ReadWritePaths` 逐位元不變，monitor 對 Manager 的真子集不變式（#622）仍成立。
+  新增 `tests/test_trust_root_repo_source_tree_623.py`（45 測試）；runbook 補第 2c 步、
+  spec §R1 補裁決段。詳見 `changelog.d/repo-source-tree-assets.md`。
 - **#622 / trust-root Phase 2b：`trust_root unit three-way --monitor`——monitor 的
   system-level unit，同帳號、同加固段，可寫面嚴格窄於 Manager**——M1 之後 permgen
   只產生 Manager unit，實機切換後 instance **完全沒有 monitor**：舊 `--user` unit 以

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,29 +8,42 @@
 ## [Unreleased]
 
 ### Added
-- **#623 / trust-root Phase 2b：per-job clone 的信任根層——`repo-source-tree` ＋ 兩份
-  root-owned `.gitconfig` 進登記表，內容由 permgen 產生**——M1 之後實機發現「這個部署
-  做不了真實工作」：`ProtectHome=yes` 讓 `/home` 完全不可見，而登記表**沒有定義 repo
-  源碼樹該放哪**；實測進一步證明 `git worktree` 在三分下結構性不成立（worktree 的
-  `.git` 指向**共用 object store**，builder 只要 `git add` 就必須能寫它，「builder 能
-  commit」與「三分隔離」互斥）。裁決改為 **per-job 完整 clone**（0.5 秒／35MB per job）。
-  本 PR 落地信任根層：新增登記表資產 `repo-source-tree`（`<agents_root>/repos`，
-  **working checkout**——monitor 要掃工作樹裡的檔案，bare 沒有工作樹；同一份 checkout
-  兼作掃描目標與 clone 來源）與 `builder-gitconfig`／`reviewer-planner-gitconfig`
-  （root-owned 0644，落在各自 job 帳號 HOME 下，比照既有的 `codex-hooks`）。
-  來源樹的 **writer 只有部署身分（root）**，owner_class 因此機械分到 `DEPLOYMENT`、
-  owner＝root 0755，**Manager／monitor／兩個 job 帳號一律唯讀**——ReadWritePaths 純由
-  「誰可寫」導出，owner＝`cortex-manager` 會讓 Manager unit 自動拿到寫入權，
-  「Manager 唯讀」與「owner＝Manager」互斥，取前者（攻擊面最小；代價是更新來源樹改為
-  operator 的 root 動作）。`.gitconfig` 的**內容**同樣由 permgen 產生
-  （`build_job_gitconfig()` ＋ CLI `trust_root gitconfig … --source-repo <slug>`），含
-  來源 repo 的 `safe.directory`——跨擁有者 clone 會被 git 的 dubious-ownership 保護擋
-  下，而 job 的 HOME 是 root-owned、它自己放不了這個檔；來源 repo 清單是部署決定
-  （比照 #626），未宣告即 fail-closed（git 的 `safe.directory` 只認逐字相等的路徑或
-  字面 `*`，實測 git 2.43 不吃 `<repos>/*`，而字面 `*` 等於整個關掉該保護）。三份 unit
-  的 `ReadWritePaths` 逐位元不變，monitor 對 Manager 的真子集不變式（#622）仍成立。
-  新增 `tests/test_trust_root_repo_source_tree_623.py`（45 測試）；runbook 補第 2c 步、
-  spec §R1 補裁決段。詳見 `changelog.d/repo-source-tree-assets.md`。
+- **#623 / trust-root Phase 2b：per-job clone 的信任根層——`repo-source-tree`、三份
+  root-owned `.gitconfig` 與 `commit-spool` 進登記表，內容由 permgen 產生**——M1 之後
+  實機發現「這個部署做不了真實工作」：`ProtectHome=yes` 讓 `/home` 完全不可見，而登記表
+  **沒有定義 repo 源碼樹該放哪**；實測進一步證明 `git worktree` 在三分下結構性不成立
+  （worktree 的 `.git` 指向**共用 object store**，builder 只要 `git add` 就必須能寫它，
+  「builder 能 commit」與「三分隔離」互斥）。裁決改為 **per-job 完整 clone**
+  （0.5 秒／35MB per job）。本 PR 落地信任根層：
+  - `repo-source-tree`（`<agents_root>/repos`，**working checkout**——monitor 要掃工作樹
+    裡的檔案，bare 沒有工作樹；同一份 checkout 兼作掃描目標與 clone 來源）。**writer 是
+    Manager**（0817 裁決，推翻本票初版的 root-owned）：`git fetch` 必須把 `FETCH_HEAD`
+    寫進**目標 repo**，而成果回收正是「fetch 進來源樹」，實機在 root-owned 下實測
+    `error: cannot open '.git/FETCH_HEAD': Permission denied`——「Manager 唯讀」與
+    「Manager 回收成果」互斥，取後者。機械落點是 `owner_class=MANAGER_STATE`
+    （`cortex-manager` 0700），兩個 job 帳號各獲**唯讀** ACL（`rX`），monitor 靠 unit
+    的 persona 過濾（#622）仍寫不進去；隔離未變弱（不受信任的是 job 帳號，而 Manager
+    本來就擁有 gate ledger／evidence／`jobs.json`）。
+  - `builder-gitconfig`／`reviewer-planner-gitconfig`／`manager-gitconfig`（root-owned
+    0644，落在各自帳號 HOME 下，比照既有的 `codex-hooks`）。內容由 permgen 產生
+    （`build_account_gitconfig()` ＋ CLI `trust_root gitconfig [--builder|
+    --reviewer-planner|--manager] --source-repo <slug>`），每個來源 repo **兩條**
+    `safe.directory`（工作樹根 ＋ `<root>/.git`——實測從非 bare 來源 clone 時 git 檢查的
+    是後者）。Manager 那份是實機複驗補上的 blocking 缺口：來源樹是 root 建立後才 chown
+    過去的，owner 不相符的中途狀態會讓 Manager 的每一個 git 操作失敗。來源 repo 清單是
+    部署決定（比照 #626），未宣告即 fail-closed（`safe.directory` 只認逐字相等的路徑或
+    字面 `*`，實測 git 2.43 不吃 `<repos>/*`，而字面 `*` 等於整個關掉該保護）。
+  - `commit-spool`（`<coordinator_root>/commit-spool/<job-id>/`）＋ path resolver
+    `config.paths:commit_spool_root()`：成果回收改走 **bundle ＋ append-only spool**
+    （0817 裁決）——builder 在自己的 clone `git bundle create` 寫進 spool，Manager 從那個
+    **bundle 檔**（不是 repo）fetch，Manager 全程不碰 builder 的樹。形態逐條比照
+    `review-verdict-spool`：容器 `cortex-manager` 0700，producer 僅獲 **`wx` 無 `r`** 的
+    per-account ACL；**producer 只有 builder**（登記表裡唯一以 git commit 交付的 persona）。
+    本 PR 只定義資產與權限，bundle 的產生／消費在 coordinator 側，屬後續變更。
+
+  monitor 對 Manager 的**真子集**不變式（#622）仍成立。新增
+  `tests/test_trust_root_repo_source_tree_623.py`（68 測試）；runbook 補第 2c 步、
+  spec §R1 補兩段裁決。詳見 `changelog.d/repo-source-tree-assets.md`。
 - **#622 / trust-root Phase 2b：`trust_root unit three-way --monitor`——monitor 的
   system-level unit，同帳號、同加固段，可寫面嚴格窄於 Manager**——M1 之後 permgen
   只產生 Manager unit，實機切換後 instance **完全沒有 monitor**：舊 `--user` unit 以

--- a/changelog.d/repo-source-tree-assets.md
+++ b/changelog.d/repo-source-tree-assets.md
@@ -1,0 +1,38 @@
+### Added
+
+- **#623 / trust-root Phase 2b：per-job clone 的信任根層——`repo-source-tree` ＋ 兩份
+  root-owned `.gitconfig` 進登記表，內容由 permgen 產生**——Phase 2b M1 之後實機發現
+  「這個部署做不了真實工作」：`ProtectHome=yes` 讓 `/home` 完全不可見，而登記表
+  **沒有定義 repo 源碼樹該放哪**。實測進一步證明 `git worktree` 在三分下結構性不成立
+  ——worktree 的 `.git` 指向**共用 object store**，builder 只要 `git add` 就必須能寫
+  該 store，「builder 能 commit」與「三分隔離」互斥。裁決改為 **per-job 完整 clone**
+  （0.5 秒／35MB per job），本 PR 落地其信任根層：
+
+  - 登記表新增 **`repo-source-tree`**（`<agents_root>/repos`，Tier-0、MANAGER_OWNED）：
+    **working checkout**（不是 bare——monitor 掃的是工作樹裡的 `workstreams/*/todo.md`
+    等檔案），同一份 checkout 兼作 monitor 掃描目標與 job 的 clone 來源。**writer 只有
+    部署身分（root）**，因此 owner_class 機械分到 `DEPLOYMENT`、owner＝root 0755，
+    Manager／monitor／兩個 job 帳號**一律唯讀**——ReadWritePaths 純由「誰可寫」導出，
+    owner＝`cortex-manager` 會讓 Manager unit 自動拿到寫入權，「Manager 唯讀」與
+    「owner＝Manager」互斥，取前者（Manager 被攻陷也改不了每個 job clone 的來源；
+    代價是更新來源樹改為 operator 的 root 動作）。
+  - 登記表新增 **`builder-gitconfig`／`reviewer-planner-gitconfig`**（Tier-0、
+    root-owned 0644、落在各自 job 帳號 HOME 下）：比照既有的 `codex-hooks`。跨擁有者
+    clone 會被 git 的 dubious-ownership 保護擋下（`fatal: detected dubious ownership`），
+    唯一解是 `safe.directory`，而它**必須由 root 放進 job 的 HOME**——job 的 HOME 是
+    root-owned，它自己放不了這個檔。**內容**也由 permgen 產生（`build_job_gitconfig()`
+    ＋ CLI `trust_root gitconfig [--builder|--reviewer-planner] --source-repo <slug>`），
+    比照 shim／polkit，不手寫。來源 repo 清單是**部署決定**（比照 #626），未宣告即
+    fail-closed：git 的 `safe.directory` 只認**逐字相等**的路徑或字面 `*`（實測
+    git 2.43：`<repos>/*` 仍被拒），而字面 `*` 等於對該帳號整個關掉這個保護。
+  - **unit 產生器**：Manager／monitor unit 明寫來源樹在此唯讀（`ProtectSystem=strict`
+    下讀是預設允許，而 RWP 機械地不涵蓋它）；job 模板 unit 明寫 clone 來源唯讀、clone
+    落點 `<worktree>/%i` 已在 RWP 內。三份 unit 的 `ReadWritePaths` **逐位元不變**，
+    monitor 對 Manager 的真子集不變式（#622）仍成立。
+  - `PathLayout` 新增 `repo_source_root`／`gitconfig_of()`／`source_repo_slugs`
+    （＋`with_source_repo_slugs()` 的 slug 形狀驗證），`with_job_segment()` 改用
+    `dataclasses.replace`——逐欄位重建會讓每個新欄位靜默掉回預設值。
+
+  新增 `tests/test_trust_root_repo_source_tree_623.py`（45 測試：兩個 job 帳號零寫入、
+  Manager／monitor 唯讀、traverse 鏈完整（沿用 #624 的 `unreachable_hops()`）、
+  `.gitconfig` fail-closed 與 CLI 兩條注入管道）；runbook 補第 2c 步、spec §R1 補裁決段。

--- a/changelog.d/repo-source-tree-assets.md
+++ b/changelog.d/repo-source-tree-assets.md
@@ -1,38 +1,63 @@
 ### Added
 
-- **#623 / trust-root Phase 2b：per-job clone 的信任根層——`repo-source-tree` ＋ 兩份
-  root-owned `.gitconfig` 進登記表，內容由 permgen 產生**——Phase 2b M1 之後實機發現
-  「這個部署做不了真實工作」：`ProtectHome=yes` 讓 `/home` 完全不可見，而登記表
-  **沒有定義 repo 源碼樹該放哪**。實測進一步證明 `git worktree` 在三分下結構性不成立
-  ——worktree 的 `.git` 指向**共用 object store**，builder 只要 `git add` 就必須能寫
+- **#623 / trust-root Phase 2b：per-job clone 的信任根層——`repo-source-tree`、**三份**
+  root-owned `.gitconfig` 與 `commit-spool` 進登記表，內容由 permgen 產生**——Phase 2b
+  M1 之後實機發現「這個部署做不了真實工作」：`ProtectHome=yes` 讓 `/home` 完全不可見，
+  而登記表**沒有定義 repo 源碼樹該放哪**。實測進一步證明 `git worktree` 在三分下結構性
+  不成立——worktree 的 `.git` 指向**共用 object store**，builder 只要 `git add` 就必須能寫
   該 store，「builder 能 commit」與「三分隔離」互斥。裁決改為 **per-job 完整 clone**
   （0.5 秒／35MB per job），本 PR 落地其信任根層：
 
   - 登記表新增 **`repo-source-tree`**（`<agents_root>/repos`，Tier-0、MANAGER_OWNED）：
     **working checkout**（不是 bare——monitor 掃的是工作樹裡的 `workstreams/*/todo.md`
-    等檔案），同一份 checkout 兼作 monitor 掃描目標與 job 的 clone 來源。**writer 只有
-    部署身分（root）**，因此 owner_class 機械分到 `DEPLOYMENT`、owner＝root 0755，
-    Manager／monitor／兩個 job 帳號**一律唯讀**——ReadWritePaths 純由「誰可寫」導出，
-    owner＝`cortex-manager` 會讓 Manager unit 自動拿到寫入權，「Manager 唯讀」與
-    「owner＝Manager」互斥，取前者（Manager 被攻陷也改不了每個 job clone 的來源；
-    代價是更新來源樹改為 operator 的 root 動作）。
-  - 登記表新增 **`builder-gitconfig`／`reviewer-planner-gitconfig`**（Tier-0、
-    root-owned 0644、落在各自 job 帳號 HOME 下）：比照既有的 `codex-hooks`。跨擁有者
-    clone 會被 git 的 dubious-ownership 保護擋下（`fatal: detected dubious ownership`），
-    唯一解是 `safe.directory`，而它**必須由 root 放進 job 的 HOME**——job 的 HOME 是
-    root-owned，它自己放不了這個檔。**內容**也由 permgen 產生（`build_job_gitconfig()`
-    ＋ CLI `trust_root gitconfig [--builder|--reviewer-planner] --source-repo <slug>`），
-    比照 shim／polkit，不手寫。來源 repo 清單是**部署決定**（比照 #626），未宣告即
-    fail-closed：git 的 `safe.directory` 只認**逐字相等**的路徑或字面 `*`（實測
-    git 2.43：`<repos>/*` 仍被拒），而字面 `*` 等於對該帳號整個關掉這個保護。
-  - **unit 產生器**：Manager／monitor unit 明寫來源樹在此唯讀（`ProtectSystem=strict`
-    下讀是預設允許，而 RWP 機械地不涵蓋它）；job 模板 unit 明寫 clone 來源唯讀、clone
-    落點 `<worktree>/%i` 已在 RWP 內。三份 unit 的 `ReadWritePaths` **逐位元不變**，
-    monitor 對 Manager 的真子集不變式（#622）仍成立。
-  - `PathLayout` 新增 `repo_source_root`／`gitconfig_of()`／`source_repo_slugs`
+    等檔案），同一份 checkout 兼作 monitor 掃描目標與 job 的 clone 來源。**writer 是
+    Manager**（0817 裁決，推翻本票初版的 root-owned）：`git fetch` 必須把 `FETCH_HEAD`
+    寫進**目標 repo**，而 #634 的成果回收正是「fetch 進來源樹」，provisioning 那半邊的
+    `git branch -f` 同樣是對來源樹的寫入——實機在 root-owned 下實測
+    `error: cannot open '.git/FETCH_HEAD': Permission denied`，**「Manager 唯讀」與
+    「Manager 回收成果」互斥**，取後者。機械落點是 `owner_class=MANAGER_STATE`
+    （owner＝`cortex-manager` 0700），兩個 job 帳號各獲一條**唯讀** ACL（`rX`），
+    monitor 則靠 unit 的 persona 過濾（#622）仍寫不進去。隔離未變弱：不受信任的是 job
+    帳號，而 Manager 本來就擁有 gate ledger／evidence／`jobs.json`。
+  - 登記表新增 **`builder-gitconfig`／`reviewer-planner-gitconfig`／`manager-gitconfig`**
+    （Tier-0、root-owned 0644、落在各自帳號 HOME 下）：比照既有的 `codex-hooks`。跨擁有者
+    的 git 操作會被 dubious-ownership 保護擋下（`fatal: detected dubious ownership`），
+    唯一解是 `safe.directory`，而它**必須由 root 放進該帳號的 HOME**——那些 HOME 都是
+    root-owned，帳號自己放不了這個檔。**Manager 那份是實機複驗補上的 blocking 缺口**：
+    來源樹是 root 建立後才 chown 過去的，owner 不相符的中途狀態會讓 Manager 的每一個 git
+    操作失敗。**內容**也由 permgen 產生（`build_account_gitconfig()` ＋ CLI
+    `trust_root gitconfig [--builder|--reviewer-planner|--manager] --source-repo <slug>`），
+    比照 shim／polkit，不手寫；每個來源 repo 產生**兩條** `safe.directory`（工作樹根 ＋
+    `<root>/.git`）——實測從**非 bare** 來源 clone 時 git 檢查的是後者，`git -C <repo> …`
+    報的是前者，只給一條會讓另一半的操作在完全不同的時機才失敗。來源 repo 清單是**部署
+    決定**（比照 #626），未宣告即 fail-closed：git 的 `safe.directory` 只認**逐字相等**的
+    路徑或字面 `*`（實測 git 2.43：`<repos>/*` 仍被拒），而字面 `*` 等於對該帳號整個關掉
+    這個保護。
+  - 登記表新增 **`commit-spool`**（`<coordinator_root>/commit-spool/<job-id>/`，Tier-0、
+    JOB_VISIBLE、`INTERPROCESS`）＋ path resolver `config.paths:commit_spool_root()`：
+    成果回收改走 **bundle ＋ append-only spool**（0817 裁決）。#634 現行的「Manager 伸手
+    進 builder 的 clone `fetch`」需要 (a) traverse 進 builder-owned 的 `0700` 樹——實測
+    `Permission denied`；(b) 為**每個 job 路徑**加 `safe.directory`——而 git 2.43 不吃路徑
+    glob，等於把 Manager 的 Tier-0 gitconfig 變成執行期可變狀態。改走 bundle 後 builder 在
+    自己的 clone `git bundle create` 寫進本 spool，Manager 從那個 **bundle 檔**（不是 repo）
+    fetch：Manager 全程不碰 builder 的樹，dubious-ownership 與 traverse 兩個問題同時消失。
+    形態**逐條比照 `review-verdict-spool`**：容器 owner＝`cortex-manager` 0700，producer 僅
+    獲 **`wx` 無 `r`** 的 per-account ACL，per-job 目錄由 Manager 在 dispatch 當下建立、
+    落地後轉唯讀。**producer 只有 builder**——登記表裡唯一以 git commit 交付的 persona 就是
+    它（`repo-worktree` 的 writer 只有 BUILDER），reviewer 的交付通道是
+    `review-verdict-spool`、planner 的是 `dispatch-specs-tree`；多授一個 `wx` 給沒有 producer
+    的帳號只是多開一條無人消費的寫入面。本 PR **只定義資產與權限**，bundle 的產生／消費在
+    coordinator 側，屬後續變更。
+  - **unit 產生器**：Manager unit 明寫來源樹**可寫**並附裁決理由，monitor unit 明寫它在
+    monitor 這側仍唯讀（並點出這是 persona 過濾而非帳號差異）；job 模板 unit 明寫 clone
+    來源唯讀、clone 落點 `<worktree>/%i` 與 commit spool 在 RWP 內。monitor 對 Manager 的
+    **真子集**不變式（#622）仍成立——來源樹只進 Manager 那一側。
+  - `PathLayout` 新增 `repo_source_root`／`commit_spool_root`／`gitconfig_of()`／
+    `manager_account`／`source_repo_slugs`／`source_repo_safe_directories()`
     （＋`with_source_repo_slugs()` 的 slug 形狀驗證），`with_job_segment()` 改用
     `dataclasses.replace`——逐欄位重建會讓每個新欄位靜默掉回預設值。
 
-  新增 `tests/test_trust_root_repo_source_tree_623.py`（45 測試：兩個 job 帳號零寫入、
-  Manager／monitor 唯讀、traverse 鏈完整（沿用 #624 的 `unreachable_hops()`）、
-  `.gitconfig` fail-closed 與 CLI 兩條注入管道）；runbook 補第 2c 步、spec §R1 補裁決段。
+  新增 `tests/test_trust_root_repo_source_tree_623.py`（68 測試：兩個 job 帳號對來源樹零
+  寫入、Manager 可寫而 monitor 不可、commit spool 的 `wx` 無 `r` 與 producer 面、traverse
+  鏈完整（沿用 #624 的 `unreachable_hops()`）、三份 `.gitconfig` 的兩條 `safe.directory`、
+  fail-closed 與 CLI 兩條注入管道）；runbook 補第 2c 步、spec §R1 補兩段裁決。

--- a/docs/superpowers/runbooks/trust-root-phase2b-setup.md
+++ b/docs/superpowers/runbooks/trust-root-phase2b-setup.md
@@ -236,7 +236,7 @@ A/B 並列時同一件事要寫兩遍（5-A／5-B、第 8 步兩種起法、附�
 | 執行前提（含 G1／G2 兩個硬性 gate） | 0 | 11 |
 | 產生器＝單一真相 | 0 | 9 |
 | 第 1 步：建三帳號 | 3 | 5 |
-| 第 2 步：目標樹與權限（含 2c 來源樹） | 4 | 19 |
+| 第 2 步：目標樹與權限（含 2c 來源樹） | 4 | 21 |
 | 第 3 步：legacy-import（含 operator 設定搬遷） | 3 | 11 |
 | 第 4 步：Manager／monitor 部署與 unit | 12 | 24 |
 | **第 5 步：降權（A+B）** | **7** | **27** |
@@ -247,7 +247,7 @@ A/B 並列時同一件事要寫兩遍（5-A／5-B、第 8 步兩種起法、附�
 | WSL2 風險與診斷 | 2 | 12 |
 | 附錄 A：自我檢查 | 0 | 7 |
 | 附錄 B：降級備援 | 2 | 3 |
-| **合計** | **45** | **159** |
+| **合計** | **45** | **161** |
 
 （統計方式：全文 `🔧`／`✅` 標記出現次數，扣除說明性用法——「標記約定」的定義行、
 段落標題內的標記、以及表格裡當狀態記號用的那幾個。）
@@ -265,9 +265,10 @@ A/B 並列時同一件事要寫兩遍（5-A／5-B、第 8 步兩種起法、附�
   注入並新增 T4.0 可見性測項、族 1 的 T1.1／T1.5 由「讀」改測「寫」並新增
   `d()`／`need()`／身分鎖三個判讀守衛。合計（#624／#625 落地後的 35／133 基礎上）
   → **43** 個 sudo 點、**156** 個驗證點。
-- **#623（per-job clone）新增**：第 2c 步「建立來源樹 ＋ 落兩份 root-owned
-  `.gitconfig`」——2 個 sudo 點、3 個驗證點（來源樹對 Manager／job 皆唯讀、job 真的
-  clone 得動、`.gitconfig` job 不可寫）→ **45** 個 sudo 點、**159** 個驗證點。
+- **#623（per-job clone）新增**：第 2c 步「建立來源樹 ＋ 落**三份** root-owned
+  `.gitconfig`」——2 個 sudo 點、5 個驗證點（來源樹 Manager 可寫／job 唯讀、job 真的
+  clone 得動、三份 `.gitconfig` 對應帳號不可寫、commit spool 的 `wx` 無 `r`）
+  → **45** 個 sudo 點、**161** 個驗證點。
 
 ---
 
@@ -335,10 +336,12 @@ python3 -m paulsha_cortex.trust_root polkit three-way --template
 # ✅ root-owned shim 內容（/opt/cortex/bin/cortex-job-shim）—— #616 已 merge
 python3 -m paulsha_cortex.trust_root shim three-way
 
-# ✅ job 帳號 HOME 下 root-owned 的 .gitconfig 內容（per-job clone 的來源樹 safe.directory）
+# ✅ 帳號 HOME 下 root-owned 的 .gitconfig 內容（來源樹的 safe.directory）
 #    <slug> ＝ 來源樹底下那一格的目錄名（見第 2c 步）；未給即 fail-closed。
+#    三份同構：兩個 job 帳號 ＋ Manager（Manager 也對來源樹跑 git，同樣會撞 dubious ownership）。
 python3 -m paulsha_cortex.trust_root gitconfig three-way --builder --source-repo <slug>
 python3 -m paulsha_cortex.trust_root gitconfig three-way --reviewer-planner --source-repo <slug>
+python3 -m paulsha_cortex.trust_root gitconfig three-way --manager --source-repo <slug>
 ```
 
 **job-spec 的欄位契約也已隨 #616 落地**——`coordinator/job_runner.py` 的
@@ -695,11 +698,11 @@ sudo -u cortex-reviewer-planner ls /var/lib/cortex/coordinator/job-specs 2>&1 | 
 #   期望：Permission denied（spool 只對 builder 開唯讀 ACL——三分在檔案層的證據）
 ```
 
-### 2c. 建立來源樹 ＋ 落兩份 root-owned `.gitconfig`（#623）
+### 2c. 建立來源樹 ＋ 落三份 root-owned `.gitconfig`（#623）
 
 第 2b 步已把 `/var/lib/cortex/repos`（登記表資產 `repo-source-tree`）建成
-**root:root 0755** 的空容器。本步把受治理的 repo 放進去，並讓兩個 job 帳號有辦法
-從它 clone。
+**`cortex-manager` 擁有、0700**、兩個 job 帳號各帶一條唯讀 ACL（`rX`）的空容器。
+本步把受治理的 repo 放進去，並讓 Manager 與兩個 job 帳號都有辦法對它跑 git。
 
 **為什麼是 per-job 完整 clone 而不是 `git worktree`**：#623 實測——worktree 的
 `.git` 是指向共用 object store 的指標，builder 要 `git add`／`git commit` 就必須能寫
@@ -711,73 +714,112 @@ sudo -u cortex-reviewer-planner ls /var/lib/cortex/coordinator/job-specs 2>&1 | 
 掃描目標與 job 的 clone 來源。
 
 ```bash
-# 🔧 sudo：把受治理的 repo 放進來源樹（**以 root 執行 ⇒ 整棵樹 root 擁有**）
+# 🔧 sudo：把受治理的 repo 放進來源樹，並交給 Manager 擁有
 SLUG=paulsha-cortex          # 目錄名；下面每個命令都用它
 sudo git clone <來源 remote 或 operator 的 checkout> /var/lib/cortex/repos/"$SLUG"
-sudo chown -R root:root /var/lib/cortex/repos/"$SLUG"
-sudo chmod -R a+rX,go-w /var/lib/cortex/repos/"$SLUG"
+sudo chown -R cortex-manager:cortex-manager /var/lib/cortex/repos/"$SLUG"
+# 兩個 job 帳號要讀得到整棵樹（容器的 default ACL 只涵蓋**之後**新建的物件，
+# 這一步是把 clone 當下已存在的那幾萬個檔一次補齊）。
+sudo setfacl -R -m u:cortex-builder:rX,u:cortex-reviewer-planner:rX \
+  /var/lib/cortex/repos/"$SLUG"
+sudo setfacl -R -d -m u:cortex-builder:rX,u:cortex-reviewer-planner:rX \
+  /var/lib/cortex/repos/"$SLUG"
 ```
 
-> **為什麼 root 擁有而不是 `cortex-manager` 擁有**：ReadWritePaths 由登記表**純由
-> 「誰可寫」機械導出**——只要來源樹的 owner 是 `cortex-manager`，Manager unit 就會
-> 自動拿到它的寫入權。「Manager 唯讀」與「owner＝Manager」在產生器裡互斥，裁決取
-> 前者：**來源樹由 operator 以 root 更新，Manager／monitor／兩個 job 帳號一律唯讀**。
-> 代價是 Manager 不能自己 `git fetch` 更新來源樹（見下方「更新來源樹」）；換到的是
-> 「Manager 被攻陷也改不了每個 job clone 的來源」。
+> **為什麼 `cortex-manager` 擁有而不是 root 擁有**（0817 裁決，推翻本 runbook 前一版）：
+> `git fetch` 必須把 `FETCH_HEAD` 寫進**目標 repo**，而成果回收正是「fetch 進來源樹」；
+> provisioning 那半邊的 `git branch -f <branch> <base>` 同樣是對來源樹的寫入。
+> root-owned 下實測：
+>
+> ```
+> error: cannot open '.git/FETCH_HEAD': Permission denied
+> ```
+>
+> **「Manager 唯讀」與「Manager 回收成果」互斥**，取後者。隔離不因此變弱：不受信任的
+> 是 **job 帳號**，它們對這棵樹只有 `rX`；Manager 本來就擁有 gate ledger／evidence／
+> `jobs.json`——多這一棵樹不改變攻擊面。monitor 雖與 Manager 同帳號，但它的 unit 少了
+> 那條 `ReadWritePaths`，因此仍寫不進去（#622 的 persona 過濾）。
 
 ```bash
-# 🔧 sudo：兩份 root-owned .gitconfig（內容由 permgen 產生，勿手寫）
-python3 -m paulsha_cortex.trust_root gitconfig three-way --builder --source-repo "$SLUG" \
-  | sudo tee /var/lib/cortex-builder/.gitconfig >/dev/null
-python3 -m paulsha_cortex.trust_root gitconfig three-way --reviewer-planner --source-repo "$SLUG" \
-  | sudo tee /var/lib/cortex-reviewer-planner/.gitconfig >/dev/null
-sudo chown root:root /var/lib/cortex-builder/.gitconfig /var/lib/cortex-reviewer-planner/.gitconfig
-sudo chmod 0644 /var/lib/cortex-builder/.gitconfig /var/lib/cortex-reviewer-planner/.gitconfig
+# 🔧 sudo：三份 root-owned .gitconfig（內容由 permgen 產生，勿手寫）
+# 旗標名與帳號後綴刻意同名：--<who> 的產物落在 /var/lib/cortex-<who>/.gitconfig。
+for who in builder reviewer-planner manager; do
+  python3 -m paulsha_cortex.trust_root gitconfig three-way --"$who" --source-repo "$SLUG" \
+    | sudo tee "/var/lib/cortex-$who/.gitconfig" >/dev/null
+done
+sudo chown root:root /var/lib/cortex-{builder,reviewer-planner,manager}/.gitconfig
+sudo chmod 0644 /var/lib/cortex-{builder,reviewer-planner,manager}/.gitconfig
 ```
 
-> **為什麼需要這兩個檔**：clone 來源不屬於 job 帳號，git 的 dubious-ownership 保護會
-> 讓 `git clone` 直接失敗；解法只有 `safe.directory`，而它**必須由 root 放進 job 的
-> HOME**——job 的 HOME 是 root-owned，它自己放不了這個檔。與既有的
-> `~/.codex/hooks.json` 同一個模式（登記表資產 `builder-gitconfig`／
-> `reviewer-planner-gitconfig`）。
+> **為什麼需要這三個檔**：來源樹與讀它的帳號不同 owner 時，git 的 dubious-ownership
+> 保護會擋下操作；解法只有 `safe.directory`，而它**必須由 root 放進該帳號的 HOME**
+> ——那些 HOME 都是 root-owned，帳號自己放不了這個檔。與既有的 `~/.codex/hooks.json`
+> 同一個模式（登記表資產 `builder-gitconfig`／`reviewer-planner-gitconfig`／
+> `manager-gitconfig`）。**Manager 那份不是冗餘**：來源樹是 root 建立後才 chown 過去的，
+> chown 前或任何 owner 不相符的中途狀態，Manager 的每一個 git 操作都會失敗
+> （`fatal: detected dubious ownership in repository at '<來源樹>/<slug>'`）。
+>
+> **為什麼每個 repo 是兩條 `safe.directory`**：實測從**非 bare** 來源 clone 時 git 檢查
+> 的是 `<repo>/.git`，而 `git -C <repo> …` 報的是工作樹根——兩個位置就是兩條逐字的值。
+> 產生器已自動出兩條，不必手加。
 >
 > **為什麼逐個列 repo 而不是萬用字元**：git 的 `safe.directory` 只認**逐字相等**的
 > 路徑或字面 `*`（實測 git 2.43：`<repos>/*` 仍被拒），而字面 `*` 等於對該帳號整個
 > 關掉這個保護。多一個受治理 repo 就多帶一次 `--source-repo`。
 
 ```bash
-# ✅ 驗證：來源樹 root 擁有、job 帳號讀得到但寫不進去
+# ✅ 驗證：來源樹由 Manager 擁有、Manager 寫得進去
 ls -ld /var/lib/cortex/repos /var/lib/cortex/repos/"$SLUG"
-#   期望：兩層皆 root:root 0755
+#   期望：容器 cortex-manager 0700；<slug> 亦 cortex-manager 擁有
+sudo -u cortex-manager git -C /var/lib/cortex/repos/"$SLUG" fetch --prune origin
+#   期望：rc=0。若出現 `cannot open '.git/FETCH_HEAD': Permission denied` ⇒ chown 沒做完；
+#         若出現 `fatal: detected dubious ownership` ⇒ manager 那份 .gitconfig 沒生效。
+
+# ✅ 驗證：兩個 job 帳號讀得到、但一個位元都寫不進去
 sudo -u cortex-builder git -C /var/lib/cortex/repos/"$SLUG" rev-parse --short HEAD
 #   期望：印出 commit（讀得到）
 sudo -u cortex-builder sh -c "touch /var/lib/cortex/repos/$SLUG/evil" 2>&1 | tail -1
 #   期望：Permission denied ← **這條才是邊界**
-sudo -u cortex-manager sh -c "touch /var/lib/cortex/repos/$SLUG/evil" 2>&1 | tail -1
-#   期望：Permission denied（Manager 亦唯讀——裁決如此）
+sudo -u cortex-reviewer-planner sh -c "touch /var/lib/cortex/repos/$SLUG/evil" 2>&1 | tail -1
+#   期望：Permission denied
 
 # ✅ 驗證：兩個 job 帳號真的 clone 得動（.gitconfig 生效）
 sudo -u cortex-builder git clone --no-hardlinks \
   /var/lib/cortex/repos/"$SLUG" /tmp/clone-probe-builder
 #   期望：成功。若出現 `fatal: detected dubious ownership` ⇒ .gitconfig 沒生效：
-#         先確認檔案 root:root 0644、且 job 的 HOME 與 unit 的 Environment=HOME 一致。
+#         先確認檔案 root:root 0644、且該帳號的 HOME 與 unit 的 Environment=HOME 一致，
+#         再確認 `[safe]` 段裡**同時**有工作樹根與 `<root>/.git` 兩條。
 sudo rm -rf /tmp/clone-probe-builder
 
-# ✅ 驗證：兩份 .gitconfig job 帳號不可寫
-sudo -u cortex-builder sh -c 'printf x >> /var/lib/cortex-builder/.gitconfig' 2>&1 | tail -1
-#   期望：Permission denied
+# ✅ 驗證：三份 .gitconfig 對應帳號皆不可寫
+for who in builder reviewer-planner manager; do
+  sudo -u "cortex-$who" sh -c "printf x >> /var/lib/cortex-$who/.gitconfig" 2>&1 | tail -1
+done
+#   期望：三行皆 Permission denied
+
+# ✅ 驗證：commit spool 是 `wx` 無 `r`（builder 寫得進、讀不到他人）
+getfacl -p /var/lib/cortex/coordinator/commit-spool 2>/dev/null | grep '^user:cortex-builder'
+#   期望：user:cortex-builder:-wx（**沒有 r**）
+sudo -u cortex-builder ls /var/lib/cortex/coordinator/commit-spool 2>&1 | tail -1
+#   期望：Permission denied（列不出別人的 bundle）
+sudo -u cortex-reviewer-planner sh -c \
+  "touch /var/lib/cortex/coordinator/commit-spool/probe" 2>&1 | tail -1
+#   期望：Permission denied（producer 只有 builder）
 ```
 
-**更新來源樹**（日常操作，operator 手動）：
+**更新來源樹**（日常操作）：Manager 現在是 owner，因此**服務自己就能** `fetch`；以
+operator 身分手動更新時記得別把 owner 換掉：
 
 ```bash
-sudo git -C /var/lib/cortex/repos/"$SLUG" fetch --prune
-sudo git -C /var/lib/cortex/repos/"$SLUG" merge --ff-only origin/main
-sudo chown -R root:root /var/lib/cortex/repos/"$SLUG"   # 保險：新物件仍歸 root
+sudo -u cortex-manager git -C /var/lib/cortex/repos/"$SLUG" fetch --prune
+sudo -u cortex-manager git -C /var/lib/cortex/repos/"$SLUG" merge --ff-only origin/main
+# 服務以 UMask=0077 建檔，新物件對 job 帳號預設不可讀；補一次遞迴 ACL 讓 clone 仍成立。
+sudo setfacl -R -m u:cortex-builder:rX,u:cortex-reviewer-planner:rX \
+  /var/lib/cortex/repos/"$SLUG"
 ```
 
-**回滾**：`sudo rm -rf /var/lib/cortex/repos /var/lib/cortex-builder/.gitconfig
-/var/lib/cortex-reviewer-planner/.gitconfig`。
+**回滾**：`sudo rm -rf /var/lib/cortex/repos
+/var/lib/cortex-{builder,reviewer-planner,manager}/.gitconfig`。
 
 ---
 

--- a/docs/superpowers/runbooks/trust-root-phase2b-setup.md
+++ b/docs/superpowers/runbooks/trust-root-phase2b-setup.md
@@ -236,7 +236,7 @@ A/B 並列時同一件事要寫兩遍（5-A／5-B、第 8 步兩種起法、附�
 | 執行前提（含 G1／G2 兩個硬性 gate） | 0 | 11 |
 | 產生器＝單一真相 | 0 | 9 |
 | 第 1 步：建三帳號 | 3 | 5 |
-| 第 2 步：目標樹與權限 | 2 | 16 |
+| 第 2 步：目標樹與權限（含 2c 來源樹） | 4 | 19 |
 | 第 3 步：legacy-import（含 operator 設定搬遷） | 3 | 11 |
 | 第 4 步：Manager／monitor 部署與 unit | 12 | 24 |
 | **第 5 步：降權（A+B）** | **7** | **27** |
@@ -247,7 +247,7 @@ A/B 並列時同一件事要寫兩遍（5-A／5-B、第 8 步兩種起法、附�
 | WSL2 風險與診斷 | 2 | 12 |
 | 附錄 A：自我檢查 | 0 | 7 |
 | 附錄 B：降級備援 | 2 | 3 |
-| **合計** | **43** | **156** |
+| **合計** | **45** | **159** |
 
 （統計方式：全文 `🔧`／`✅` 標記出現次數，扣除說明性用法——「標記約定」的定義行、
 段落標題內的標記、以及表格裡當狀態記號用的那幾個。）
@@ -265,6 +265,9 @@ A/B 並列時同一件事要寫兩遍（5-A／5-B、第 8 步兩種起法、附�
   注入並新增 T4.0 可見性測項、族 1 的 T1.1／T1.5 由「讀」改測「寫」並新增
   `d()`／`need()`／身分鎖三個判讀守衛。合計（#624／#625 落地後的 35／133 基礎上）
   → **43** 個 sudo 點、**156** 個驗證點。
+- **#623（per-job clone）新增**：第 2c 步「建立來源樹 ＋ 落兩份 root-owned
+  `.gitconfig`」——2 個 sudo 點、3 個驗證點（來源樹對 Manager／job 皆唯讀、job 真的
+  clone 得動、`.gitconfig` job 不可寫）→ **45** 個 sudo 點、**159** 個驗證點。
 
 ---
 
@@ -331,6 +334,11 @@ python3 -m paulsha_cortex.trust_root polkit three-way --template
 
 # ✅ root-owned shim 內容（/opt/cortex/bin/cortex-job-shim）—— #616 已 merge
 python3 -m paulsha_cortex.trust_root shim three-way
+
+# ✅ job 帳號 HOME 下 root-owned 的 .gitconfig 內容（per-job clone 的來源樹 safe.directory）
+#    <slug> ＝ 來源樹底下那一格的目錄名（見第 2c 步）；未給即 fail-closed。
+python3 -m paulsha_cortex.trust_root gitconfig three-way --builder --source-repo <slug>
+python3 -m paulsha_cortex.trust_root gitconfig three-way --reviewer-planner --source-repo <slug>
 ```
 
 **job-spec 的欄位契約也已隨 #616 落地**——`coordinator/job_runner.py` 的
@@ -687,7 +695,93 @@ sudo -u cortex-reviewer-planner ls /var/lib/cortex/coordinator/job-specs 2>&1 | 
 #   期望：Permission denied（spool 只對 builder 開唯讀 ACL——三分在檔案層的證據）
 ```
 
-**回滾**：`sudo rm -rf /var/lib/cortex /var/lib/cortex-manager /var/lib/cortex-reviewer-planner
+### 2c. 建立來源樹 ＋ 落兩份 root-owned `.gitconfig`（#623）
+
+第 2b 步已把 `/var/lib/cortex/repos`（登記表資產 `repo-source-tree`）建成
+**root:root 0755** 的空容器。本步把受治理的 repo 放進去，並讓兩個 job 帳號有辦法
+從它 clone。
+
+**為什麼是 per-job 完整 clone 而不是 `git worktree`**：#623 實測——worktree 的
+`.git` 是指向共用 object store 的指標，builder 要 `git add`／`git commit` 就必須能寫
+那個 store，而 store 在 `0700 cortex-manager` 底下。**「builder 能 commit」與「三分
+隔離」互斥**，不是權限沒調好。per-job clone 實測 0.5 秒／35MB，來源對 job 唯讀。
+
+**為什麼是 working checkout 而不是 bare mirror**：monitor 掃的是工作樹裡的檔案
+（`workstreams/*/todo.md` …），bare 沒有工作樹。同一份 checkout 因此兼作 monitor 的
+掃描目標與 job 的 clone 來源。
+
+```bash
+# 🔧 sudo：把受治理的 repo 放進來源樹（**以 root 執行 ⇒ 整棵樹 root 擁有**）
+SLUG=paulsha-cortex          # 目錄名；下面每個命令都用它
+sudo git clone <來源 remote 或 operator 的 checkout> /var/lib/cortex/repos/"$SLUG"
+sudo chown -R root:root /var/lib/cortex/repos/"$SLUG"
+sudo chmod -R a+rX,go-w /var/lib/cortex/repos/"$SLUG"
+```
+
+> **為什麼 root 擁有而不是 `cortex-manager` 擁有**：ReadWritePaths 由登記表**純由
+> 「誰可寫」機械導出**——只要來源樹的 owner 是 `cortex-manager`，Manager unit 就會
+> 自動拿到它的寫入權。「Manager 唯讀」與「owner＝Manager」在產生器裡互斥，裁決取
+> 前者：**來源樹由 operator 以 root 更新，Manager／monitor／兩個 job 帳號一律唯讀**。
+> 代價是 Manager 不能自己 `git fetch` 更新來源樹（見下方「更新來源樹」）；換到的是
+> 「Manager 被攻陷也改不了每個 job clone 的來源」。
+
+```bash
+# 🔧 sudo：兩份 root-owned .gitconfig（內容由 permgen 產生，勿手寫）
+python3 -m paulsha_cortex.trust_root gitconfig three-way --builder --source-repo "$SLUG" \
+  | sudo tee /var/lib/cortex-builder/.gitconfig >/dev/null
+python3 -m paulsha_cortex.trust_root gitconfig three-way --reviewer-planner --source-repo "$SLUG" \
+  | sudo tee /var/lib/cortex-reviewer-planner/.gitconfig >/dev/null
+sudo chown root:root /var/lib/cortex-builder/.gitconfig /var/lib/cortex-reviewer-planner/.gitconfig
+sudo chmod 0644 /var/lib/cortex-builder/.gitconfig /var/lib/cortex-reviewer-planner/.gitconfig
+```
+
+> **為什麼需要這兩個檔**：clone 來源不屬於 job 帳號，git 的 dubious-ownership 保護會
+> 讓 `git clone` 直接失敗；解法只有 `safe.directory`，而它**必須由 root 放進 job 的
+> HOME**——job 的 HOME 是 root-owned，它自己放不了這個檔。與既有的
+> `~/.codex/hooks.json` 同一個模式（登記表資產 `builder-gitconfig`／
+> `reviewer-planner-gitconfig`）。
+>
+> **為什麼逐個列 repo 而不是萬用字元**：git 的 `safe.directory` 只認**逐字相等**的
+> 路徑或字面 `*`（實測 git 2.43：`<repos>/*` 仍被拒），而字面 `*` 等於對該帳號整個
+> 關掉這個保護。多一個受治理 repo 就多帶一次 `--source-repo`。
+
+```bash
+# ✅ 驗證：來源樹 root 擁有、job 帳號讀得到但寫不進去
+ls -ld /var/lib/cortex/repos /var/lib/cortex/repos/"$SLUG"
+#   期望：兩層皆 root:root 0755
+sudo -u cortex-builder git -C /var/lib/cortex/repos/"$SLUG" rev-parse --short HEAD
+#   期望：印出 commit（讀得到）
+sudo -u cortex-builder sh -c "touch /var/lib/cortex/repos/$SLUG/evil" 2>&1 | tail -1
+#   期望：Permission denied ← **這條才是邊界**
+sudo -u cortex-manager sh -c "touch /var/lib/cortex/repos/$SLUG/evil" 2>&1 | tail -1
+#   期望：Permission denied（Manager 亦唯讀——裁決如此）
+
+# ✅ 驗證：兩個 job 帳號真的 clone 得動（.gitconfig 生效）
+sudo -u cortex-builder git clone --no-hardlinks \
+  /var/lib/cortex/repos/"$SLUG" /tmp/clone-probe-builder
+#   期望：成功。若出現 `fatal: detected dubious ownership` ⇒ .gitconfig 沒生效：
+#         先確認檔案 root:root 0644、且 job 的 HOME 與 unit 的 Environment=HOME 一致。
+sudo rm -rf /tmp/clone-probe-builder
+
+# ✅ 驗證：兩份 .gitconfig job 帳號不可寫
+sudo -u cortex-builder sh -c 'printf x >> /var/lib/cortex-builder/.gitconfig' 2>&1 | tail -1
+#   期望：Permission denied
+```
+
+**更新來源樹**（日常操作，operator 手動）：
+
+```bash
+sudo git -C /var/lib/cortex/repos/"$SLUG" fetch --prune
+sudo git -C /var/lib/cortex/repos/"$SLUG" merge --ff-only origin/main
+sudo chown -R root:root /var/lib/cortex/repos/"$SLUG"   # 保險：新物件仍歸 root
+```
+
+**回滾**：`sudo rm -rf /var/lib/cortex/repos /var/lib/cortex-builder/.gitconfig
+/var/lib/cortex-reviewer-planner/.gitconfig`。
+
+---
+
+**回滾（第 2 步整體）**：`sudo rm -rf /var/lib/cortex /var/lib/cortex-manager /var/lib/cortex-reviewer-planner
 /var/lib/cortex-builder /opt/cortex`（此時新樹仍空，舊樹完全未動）。
 
 ---

--- a/docs/superpowers/specs/trust-root-isolation-spec.md
+++ b/docs/superpowers/specs/trust-root-isolation-spec.md
@@ -420,16 +420,53 @@ repo」。裁決前先排除了一條看似最省事的路：**`git worktree` �
 
 - `repo-source-tree`：`<agents_root>/repos/<slug>`，**working checkout**（不是 bare——
   monitor 掃的是工作樹裡的檔案）。同時是 monitor 的掃描目標與每個 job 的 clone 來源。
-  **writer 只有部署身分（root）**：來源樹由 operator 以 root 更新，Manager／monitor／
-  兩個 job 帳號**一律唯讀**。這條不是風格選擇——ReadWritePaths 由登記表純以「誰可寫」
-  機械導出，owner＝Manager 會讓 Manager unit 自動取得寫入權，「Manager 唯讀」與
-  「owner＝Manager」在產生器裡互斥，取前者（攻擊面最小：Manager 被攻陷也改不了每個
-  job clone 的來源）。
-- `builder-gitconfig`／`reviewer-planner-gitconfig`：job 帳號 HOME 下的 **root-owned**
-  `.gitconfig`（0644），內容含來源 repo 的 `safe.directory`。跨擁有者 clone 會被 git 的
-  dubious-ownership 保護擋下，而 job 的 HOME 是 root-owned、它自己放不了這個檔——與
-  既有的 `codex-hooks`（root-owned、在 job 帳號 HOME 下）同一個模式，不是新概念。
-  內容 SHALL 由權限產生器產生（比照 shim／polkit），MUST NOT 手寫。
+  **writer 是 Manager**（0817 裁決）：`owner_class=MANAGER_STATE`、owner＝
+  `durable_state_owner`、mode 0700，兩個 job 帳號各獲一條**唯讀** ACL（`rX`）。
+- `builder-gitconfig`／`reviewer-planner-gitconfig`／`manager-gitconfig`：對應帳號 HOME
+  下的 **root-owned** `.gitconfig`（0644），內容含來源 repo 的 `safe.directory`。跨擁有者
+  的 git 操作會被 dubious-ownership 保護擋下，而那些 HOME 都是 root-owned、帳號自己放不了
+  這個檔——與既有的 `codex-hooks`（root-owned、在帳號 HOME 下）同一個模式，不是新概念。
+  內容 SHALL 由權限產生器產生（比照 shim／polkit），MUST NOT 手寫；每個來源 repo SHALL
+  產生**兩條** `safe.directory`（工作樹根 ＋ `<root>/.git`）——實測從**非 bare** 來源
+  clone 時 git 檢查的是後者，而 `git -C <repo> …` 報的是前者。
+- `commit-spool`：`<coordinator_root>/commit-spool/<job-id>/`，builder 成果回收的
+  **bundle spool**。形態 SHALL 逐條比照 `review-verdict-spool`：容器 owner＝
+  `durable_state_owner`、mode 0700，producer 僅獲 **`wx` 無 `r`** 的 per-account ACL，
+  per-job 目錄由 Manager 在 dispatch 當下建立、落地後轉唯讀。
+
+##### `repo-source-tree` 的 owner：從 root 改為 Manager（0817 裁決）
+
+本節初版（PR #636 第一版）把 writer 定為部署身分，理由是「Manager 被攻陷也改不了每個
+job clone 的來源」。實機複驗後**推翻**：
+
+```
+$ sudo -u cortex-manager git -C /var/lib/cortex/repos/<slug> fetch <bundle> …
+error: cannot open '.git/FETCH_HEAD': Permission denied
+```
+
+`git fetch` MUST 把 `FETCH_HEAD` 寫進**目標 repo**，而成果回收正是「fetch 進來源樹」；
+provisioning 那半邊的 `git branch -f <branch> <base>`（`coordinator/seams.py`）同樣是對
+來源樹的寫入。**「Manager 唯讀」與「Manager 回收成果」互斥**，裁決取後者。
+
+隔離不因此變弱：威脅模型裡不受信任的是 **job 帳號**，它們對來源樹只有唯讀 ACL；而
+Manager 本來就擁有 gate ledger、evidence 樹與 `jobs.json`——Manager 被攻陷的話那些全都
+完了，多這一棵樹不改變攻擊面。root-owned 買到的是一條**供應鏈**保護（Manager 被攻陷後
+仍污染不了下一輪 job 的原始碼），但它讓回收整個不成立，因此取回收。
+
+monitor 仍**不得**寫這棵樹：monitor 與 Manager 同帳號，檔案層權限相同，差別由 monitor
+unit 的 persona 過濾（§R3／#622）產生——`ReadWritePaths` 只由 monitor persona 在登記表上
+的 writer／spool-consumer 面導出，來源樹因此機械地不會出現在那份 unit 上。
+
+##### 成果回收走 bundle spool，而不是 Manager 伸手進 job 的 clone（0817 裁決）
+
+#634 現行的回收是 `git -C <來源樹> fetch <builder 的 clone> …`。那條路要求 Manager
+(a) traverse 進 builder-owned 的 `0700` 樹——實測 `Permission denied`；(b) 為**每個 job
+路徑**加 `safe.directory`——而 git 2.43 實測不吃路徑 glob，等於把 Manager 的 Tier-0
+gitconfig 變成執行期可變狀態。
+
+改走 bundle：builder 在**自己的** clone `git bundle create <spool>/<job-id>/<name>.bundle`，
+Manager 從那個 **bundle 檔**（不是 repo）fetch。Manager 全程不碰 builder 的樹，讀的又是
+一個普通檔案，dubious-ownership 與 traverse 兩個問題同時消失。
 
 ### R2 所有 Tier-0／Tier-1 durable state 與 mutation ingress MUST 位於不受信任 headless persona 不可寫的 OS 邊界內
 

--- a/docs/superpowers/specs/trust-root-isolation-spec.md
+++ b/docs/superpowers/specs/trust-root-isolation-spec.md
@@ -407,6 +407,30 @@ state，證明清單漂移速度快於人工複核週期。
 - **WHEN** 同一個 durable 資產在兩處以字面量重複推導路徑
 - **THEN** 登記表一致性測試 MUST FAIL
 
+#### repo 源碼樹的放置（#623 裁決；登記表資產 `repo-source-tree`）
+
+Phase 2b 的登記表原本定義了 durable state 樹與部署樹，**沒有定義 repo 源碼樹該放
+哪**——實機因此撞到「`ProtectHome=yes` 讓 `/home` 完全不可見 ⇒ Manager 看不到自己的
+repo」。裁決前先排除了一條看似最省事的路：**`git worktree` 在三分下不成立**。實測
+（#623）：worktree 的 `.git` 是指向**共用 object store** 的指標，builder 只要 `git add`
+就必須能寫該 store，而 store 在 Manager-owned 樹內——「builder 能 commit」與「三分
+隔離」互斥，不是權限沒調好。
+
+因此裁決為 **per-job 完整 clone**（實測 0.5 秒／35MB per job），登記表新增：
+
+- `repo-source-tree`：`<agents_root>/repos/<slug>`，**working checkout**（不是 bare——
+  monitor 掃的是工作樹裡的檔案）。同時是 monitor 的掃描目標與每個 job 的 clone 來源。
+  **writer 只有部署身分（root）**：來源樹由 operator 以 root 更新，Manager／monitor／
+  兩個 job 帳號**一律唯讀**。這條不是風格選擇——ReadWritePaths 由登記表純以「誰可寫」
+  機械導出，owner＝Manager 會讓 Manager unit 自動取得寫入權，「Manager 唯讀」與
+  「owner＝Manager」在產生器裡互斥，取前者（攻擊面最小：Manager 被攻陷也改不了每個
+  job clone 的來源）。
+- `builder-gitconfig`／`reviewer-planner-gitconfig`：job 帳號 HOME 下的 **root-owned**
+  `.gitconfig`（0644），內容含來源 repo 的 `safe.directory`。跨擁有者 clone 會被 git 的
+  dubious-ownership 保護擋下，而 job 的 HOME 是 root-owned、它自己放不了這個檔——與
+  既有的 `codex-hooks`（root-owned、在 job 帳號 HOME 下）同一個模式，不是新概念。
+  內容 SHALL 由權限產生器產生（比照 shim／polkit），MUST NOT 手寫。
+
 ### R2 所有 Tier-0／Tier-1 durable state 與 mutation ingress MUST 位於不受信任 headless persona 不可寫的 OS 邊界內
 
 系統 SHALL 使 builder／reviewer／planner 對登記表中 tier 0 與 1 的全部路徑

--- a/paulsha_cortex/config/paths.py
+++ b/paulsha_cortex/config/paths.py
@@ -64,6 +64,45 @@ def review_verdict_spool_root() -> Path:
     return coordinator_root() / REVIEW_VERDICT_SPOOL_DIRNAME
 
 
+#: `commit_spool_root()` 在 `coordinator_root()` 底下的目錄名。獨立成常數的理由與
+#: `REVIEW_VERDICT_SPOOL_DIRNAME` 逐字相同：coordinator 側的 per-job 定址與本
+#: resolver 必須共用同一個字面量（R1 登記表的「重複路徑推導」Scenario）。
+COMMIT_SPOOL_DIRNAME = "commit-spool"
+
+
+def commit_spool_root() -> Path:
+    """#623／#634：builder 成果回收的 **bundle spool** 根（append-only，per-job 一格）。
+
+    ## 為什麼成果回收要走 spool 而不是「Manager 直接 fetch builder 的 clone」
+
+    per-job clone 模型下 builder 的整棵 clone 由 `cortex-builder` 擁有、mode `0700`。
+    Manager 要 `git -C <來源樹> fetch <clone> …` 就必須：
+
+    1. **traverse 進 builder 的樹**——實測 `cannot change to '…': Permission denied`；
+    2. 為 `<clone>` 加 `safe.directory`——而 clone 路徑是 **per-job** 的，git 2.43 實測
+       **不吃路徑 glob**（只認逐字相等或字面 `*`），因此每起一個 job 就要動一次
+       Manager 的 gitconfig，把一個 Tier-0 檔案變成執行期可變狀態。
+
+    operator 裁決改走 **bundle ＋ append-only spool**：builder 在**自己的** clone 裡
+    `git bundle create <此根>/<job-id>/<name>.bundle …`，Manager 再從那個 **bundle 檔**
+    `fetch`。Manager 全程不碰 builder 的樹（實測 `ls` 仍 `Permission denied`），而且
+    Manager 讀的是一個**普通檔案**、不是 repo——dubious-ownership 與 traverse 兩個問題
+    同時消失。
+
+    ## 權限形態（與 `review_verdict_spool_root()` 逐條相同）
+
+    掛在 `coordinator_root()` 底下的 Manager-owned 樹；Phase 2b 的 chown／ACL 由
+    `trust_root/permgen.py` 依 R1 登記表資產 `commit-spool` 機械產生：容器
+    owner＝durable_state_owner、mode 0700，producer（builder）只獲 **write-only** ACL
+    （`wx`，無 `r`——寫得進自己那格、讀不到別人的 bundle），Manager 擁有並消費。
+    per-job 目錄由 Manager 在 dispatch 當下建立、落地後轉唯讀（pre-seed／seal，與
+    review verdict 通道同一套語意）。
+
+    **本 resolver 只定義路徑**；bundle 的產生與消費在 coordinator 側，屬後續變更。
+    """
+    return coordinator_root() / COMMIT_SPOOL_DIRNAME
+
+
 #: `job_spec_spool_root()` 在 `coordinator_root()` 底下的目錄名。獨立成常數是為了讓
 #: `coordinator/job_runner.py` 的 per-job 定址、`trust_root/permgen.py` 的 layout 與本
 #: resolver 共用同一個字面量（R1 登記表的「重複路徑推導」Scenario 要求單一真相）。

--- a/paulsha_cortex/trust_root/__main__.py
+++ b/paulsha_cortex/trust_root/__main__.py
@@ -24,11 +24,14 @@ Phase 1 不改 `cortex` CLI（避免動到 R-16 help 對齊面）；operator／C
                                                     # Phase 2b 方案 B 的降權 shim 內容
                                                     # （模板 unit 的固定 ExecStart=）
     python -m paulsha_cortex.trust_root gitconfig [three-way|two-way]
-                                        [--builder|--reviewer-planner]
+                                        [--builder|--reviewer-planner|--manager]
                                         --source-repo <slug> [--source-repo <slug>…]
-                                                    # #623：job 帳號 HOME 下 root-owned
-                                                    # 的 .gitconfig 內容（per-job clone
-                                                    # 的來源樹 safe.directory）
+                                                    # #623：帳號 HOME 下 root-owned 的
+                                                    # .gitconfig 內容（來源樹的
+                                                    # safe.directory）。三份同構：兩個
+                                                    # job 帳號 ＋ Manager（Manager 也要
+                                                    # 對來源樹跑 git，同樣會撞 dubious
+                                                    # ownership）
     python -m paulsha_cortex.trust_root polkit [three-way|two-way] [--template|--transient]
                                                     # Phase 2b 降權 polkit 規則內容
                                                     # （--template＝方案 B，**預設**；
@@ -320,11 +323,13 @@ def main(argv: Sequence[str] | None = None) -> int:
             return 2
         scheme_id = permgen.DEFAULT_SCHEME_ID
         principal = Principal.BUILDER
+        # 旗標→persona 由 permgen 那張表導出：新增一份 .gitconfig 不必改本函式。
+        by_flag = {
+            flag: p for p, flag in permgen.ACCOUNT_GITCONFIG_FLAGS.items()
+        }
         for token in rest:
-            if token == "--builder":
-                principal = Principal.BUILDER
-            elif token == "--reviewer-planner":
-                principal = Principal.REVIEWER
+            if token in by_flag:
+                principal = by_flag[token]
             elif token in permgen.SCHEMES:
                 scheme_id = token
             else:
@@ -332,9 +337,9 @@ def main(argv: Sequence[str] | None = None) -> int:
                 return 2
         try:
             layout = permgen.DEFAULT_LAYOUT.with_source_repo_slugs(slugs)
-            # fail-closed 與 `--commands` 同一個理由：一份「裝得起來但每個 job 都會在
-            # git clone 失敗」的 .gitconfig，比產生器拒絕產出危險得多（#623）。
-            blob = permgen.build_job_gitconfig(
+            # fail-closed 與 `--commands` 同一個理由：一份「裝得起來但每一次 git 操作
+            # 都會失敗」的 .gitconfig，比產生器拒絕產出危險得多（#623）。
+            blob = permgen.build_account_gitconfig(
                 permgen.SCHEMES[scheme_id], layout, principal
             )
         except (permgen.UnresolvedSourceRepoError, ValueError) as exc:

--- a/paulsha_cortex/trust_root/__main__.py
+++ b/paulsha_cortex/trust_root/__main__.py
@@ -23,6 +23,12 @@ Phase 1 不改 `cortex` CLI（避免動到 R-16 help 對齊面）；operator／C
     python -m paulsha_cortex.trust_root shim [three-way|two-way]
                                                     # Phase 2b 方案 B 的降權 shim 內容
                                                     # （模板 unit 的固定 ExecStart=）
+    python -m paulsha_cortex.trust_root gitconfig [three-way|two-way]
+                                        [--builder|--reviewer-planner]
+                                        --source-repo <slug> [--source-repo <slug>…]
+                                                    # #623：job 帳號 HOME 下 root-owned
+                                                    # 的 .gitconfig 內容（per-job clone
+                                                    # 的來源樹 safe.directory）
     python -m paulsha_cortex.trust_root polkit [three-way|two-way] [--template|--transient]
                                                     # Phase 2b 降權 polkit 規則內容
                                                     # （--template＝方案 B，**預設**；
@@ -52,6 +58,16 @@ UID 方案未指定時一律用 **`three-way`**（operator 0816 第三輪裁決 
 都不輸出、回傳碼 2。因為 runbook 第 2b 步以 `sudo sh -e` 執行整份 script，一行
 `setfacl -m u:<不存在的帳號>:rX` 就會中止它並留下半套用的權限樹。
 
+## 來源 repo 的宣告（#623，同樣是部署決定）
+
+`gitconfig` 需要**逐字**的 `safe.directory` 路徑（git 不吃目錄萬用字元），而
+「本 instance 治理哪些 repo」是部署決定。兩條注入管道，**CLI 旗標優先於 env**：
+
+    --source-repo <slug>（可重複）      PSC_SOURCE_REPO_SLUGS=<slug>[,<slug>…]
+
+未給時 fail-closed（stdout 一行都不輸出、回傳碼 2）：空的 `[safe]` 段裝得起來、
+服務也起得來，然後**每個 job 在第一次 `git clone` 才失敗**——症狀離原因很遠。
+
 env 只在本 CLI 這一層讀取——`permgen` 維持純函式（不讀 env、不碰 IO）。
 """
 from __future__ import annotations
@@ -67,6 +83,45 @@ from .registry import Principal
 
 #: `--<principal>-account none` 的字面值——明示本部署沒有這個角色的實體。
 ABSENT_TOKEN = "none"
+
+#: 來源 repo slug 的 CLI 旗標與 env 變數（#623；旗標可重複，優先於 env）。
+SOURCE_REPO_FLAG = "--source-repo"
+SOURCE_REPO_ENV = "PSC_SOURCE_REPO_SLUGS"
+
+
+def _source_repo_slugs(
+    rest: list[str],
+    env: "dict[str, str] | None" = None,
+) -> "tuple[list[str], list[str], str | None]":
+    """抽出 `--source-repo <slug>`（可重複）；未給旗標時退回 env。
+
+    回傳 `(剩餘 token, slug 清單, 錯誤訊息)`。env 值以逗號／空白分隔。
+    """
+    environ = os.environ if env is None else env
+    remaining: list[str] = []
+    slugs: list[str] = []
+    pending = False
+    for token in rest:
+        if pending:
+            slugs.append(token)
+            pending = False
+            continue
+        flag, sep, inline = token.partition("=")
+        if flag != SOURCE_REPO_FLAG:
+            remaining.append(token)
+            continue
+        if sep:
+            if not inline:
+                return remaining, slugs, f"{SOURCE_REPO_FLAG} 需要一個 slug"
+            slugs.append(inline)
+        else:
+            pending = True
+    if pending:
+        return remaining, slugs, f"{SOURCE_REPO_FLAG} 需要一個 slug"
+    if not slugs:
+        raw = (environ.get(SOURCE_REPO_ENV) or "").replace(",", " ")
+        slugs = [part for part in raw.split() if part]
+    return remaining, slugs, None
 
 
 def _account_overrides(
@@ -257,6 +312,35 @@ def main(argv: Sequence[str] | None = None) -> int:
                 return 2
         shim = permgen.build_job_shim(permgen.SCHEMES[scheme_id])
         print(shim.content, end="")
+        return 0
+    if command == "gitconfig":
+        rest, slugs, err = _source_repo_slugs(args[1:])
+        if err is not None:
+            print(err, file=sys.stderr)
+            return 2
+        scheme_id = permgen.DEFAULT_SCHEME_ID
+        principal = Principal.BUILDER
+        for token in rest:
+            if token == "--builder":
+                principal = Principal.BUILDER
+            elif token == "--reviewer-planner":
+                principal = Principal.REVIEWER
+            elif token in permgen.SCHEMES:
+                scheme_id = token
+            else:
+                print(f"unknown gitconfig arg: {token}", file=sys.stderr)
+                return 2
+        try:
+            layout = permgen.DEFAULT_LAYOUT.with_source_repo_slugs(slugs)
+            # fail-closed 與 `--commands` 同一個理由：一份「裝得起來但每個 job 都會在
+            # git clone 失敗」的 .gitconfig，比產生器拒絕產出危險得多（#623）。
+            blob = permgen.build_job_gitconfig(
+                permgen.SCHEMES[scheme_id], layout, principal
+            )
+        except (permgen.UnresolvedSourceRepoError, ValueError) as exc:
+            print(str(exc), file=sys.stderr)
+            return 2
+        print(blob.content, end="")
         return 0
     if command == "polkit":
         rest = args[1:]

--- a/paulsha_cortex/trust_root/permgen.py
+++ b/paulsha_cortex/trust_root/permgen.py
@@ -370,6 +370,20 @@ def _validate_account_name(name: str, flag: str | None = None) -> None:
         )
 
 
+#: repo slug 的合法形狀。slug 會被逐字嵌進 root 產生的 `.gitconfig`，且會被接成
+#: `<repo_source_root>/<slug>`——不得含 `/`、空白、shell metacharacter，也不得以 `.`
+#: 開頭（擋掉 `..` 這類往上跳的相對段）。
+_REPO_SLUG_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+
+
+def _validate_repo_slug(slug: str) -> None:
+    if not isinstance(slug, str) or not _REPO_SLUG_RE.match(slug):
+        raise ValueError(
+            f"不是合法的 repo slug：{slug!r}。slug 會被接成 <repo_source_root>/<slug> "
+            "並逐字寫進 root-owned 的 .gitconfig，只接受 `^[A-Za-z0-9][A-Za-z0-9._-]*$`。"
+        )
+
+
 #: 二分（**向後相容選項**，非預設）：builder 一個帳號，其餘 headless／Manager／
 #: monitor 共用 cortex-svc。0816 第三輪裁決前的方案；已按此裝好的部署可續用，
 #: 但新部署一律走 :data:`DEFAULT_SCHEME`（三分）。
@@ -629,6 +643,10 @@ def build_entry(asset: TrustRootAsset, scheme: UidScheme) -> PermissionEntry:
             "整棵樹；對全部 headless 唯讀，現況裸寫／group-writable 於此收斂。"
             "0816 裁決已定案路徑：部署樹＝/opt/cortex、bootstrap env 落 /opt/cortex/etc/、"
             "codex hooks 落 job 帳號 HOME 下的 root-owned .codex/（值見 PathLayout，勿手寫）。"
+            "**凡 writer 只有部署身分的資產皆歸此類**，因此 #623 的 per-job clone 來源樹"
+            "與 job 帳號 HOME 下的 root-owned .gitconfig 也在其中：owner＝root 即代表"
+            "**全部服務帳號（含 Manager）唯讀**——ReadWritePaths 純由「誰可寫」導出，"
+            "這條分類就是「來源樹由 operator 以 root 更新、Manager 唯讀」裁決的機械落點。"
         )
 
     elif owner_class is OwnerClass.MANAGER_STATE:
@@ -978,10 +996,21 @@ class PathLayout:
     #: Manager 帳號是 `cortex-manager`，HOME 卻還指著二分時代的 `/var/lib/cortex-svc`，
     #: unit 的 `Environment=HOME=` 與 scaffold 因此指向一個沒人擁有的目錄。
     home_root: str = "/var/lib"
-    #: builder 的帳號名。只給 `asset_paths()` 用（`codex-hooks` 掛在 builder HOME 下），
-    #: 因為 `asset_paths()` 刻意不吃 scheme——兩個 scheme 對 BUILDER 的映射相同。
-    #: 其餘所有帳號相關路徑一律由 scheme 現場導出。
+    #: builder 的帳號名。只給 `asset_paths()` 用（`codex-hooks`／`builder-gitconfig` 掛在
+    #: builder HOME 下），因為 `asset_paths()` 刻意不吃 scheme——兩個 scheme 對 BUILDER
+    #: 的映射相同。其餘所有帳號相關路徑一律由 scheme 現場導出。
     builder_account: str = "cortex-builder"
+    #: reviewer＋planner 的 job 帳號名（`reviewer-planner-gitconfig` 掛在它的 HOME 下）。
+    #: 與 `builder_account` 同一個理由存在，但**多一個前提**：兩個 scheme 對 REVIEWER／
+    #: PLANNER 的映射**不同**——這裡取的是**定案的三分**。二分是向後相容選項，其
+    #: reviewer／planner 與 Manager 併帳（`cortex-svc`）、且尚未經模板 unit 降權起 job，
+    #: 因此那個部署形態下本資產不適用（產生的命令帶 `[ ! -e ] ||` 守衛，會直接跳過）。
+    reviewer_planner_account: str = "cortex-reviewer-planner"
+    #: 本 instance 治理的來源 repo slug（`<repo_source_root>/<slug>`）。**部署決定**，
+    #: 刻意留空：job 帳號的 `.gitconfig` 需要**逐字**的 `safe.directory` 路徑（git 不吃
+    #: 目錄萬用字元，見 `build_job_gitconfig`），猜不到就只能猜錯。未指定時
+    #: `build_job_gitconfig()` fail-closed，比照 #626 的部署決定型 principal。
+    source_repo_slugs: tuple[str, ...] = ()
     #: per-job 路徑的 segment；system unit 模板用 `%i`（systemd instance 名）。
     job_segment: str = PER_JOB_SEGMENT
 
@@ -1009,6 +1038,24 @@ class PathLayout:
     @property
     def skill_registry_root(self) -> str:
         return f"{self.agents_root}/registry"
+
+    @property
+    def repo_source_root(self) -> str:
+        """per-job clone 的**來源樹容器**（登記表資產 `repo-source-tree`，#623）。
+
+        每個受治理 repo 一格：`<此根>/<slug>`，是 **working checkout**（不是 bare）——
+        monitor 要掃工作樹裡的 `workstreams/*/todo.md`，bare 沒有工作樹；同一份 checkout
+        因此兼作 monitor 的掃描目標與 job 的 clone 來源。
+
+        掛在 `agents_root` 底下而不是部署樹（`/opt/cortex`）：它是**每個 instance 一份的
+        資料**（隨 instance 治理的 repo 走），不是隨版本走的部署產物；換 layout 時它跟著
+        durable state 樹搬，而不是跟著 venv 搬。
+        """
+        return f"{self.agents_root}/repos"
+
+    def source_repo_paths(self) -> tuple[str, ...]:
+        """已宣告的來源 repo 絕對路徑（`<repo_source_root>/<slug>`；未宣告即空）。"""
+        return tuple(f"{self.repo_source_root}/{slug}" for slug in self.source_repo_slugs)
 
     @property
     def run_root(self) -> str:
@@ -1075,6 +1122,14 @@ class PathLayout:
         """該帳號的 `~/.codex`。root-owned——job 不得替換自己的 hooks。"""
         return f"{self.home_of(account)}/.codex"
 
+    def gitconfig_of(self, account: str) -> str:
+        """該帳號的 `~/.gitconfig`。root-owned——job 不得替換自己的 git 設定（#623）。
+
+        git 只在 `$HOME/.gitconfig`（global scope，屬 git 的 *protected configuration*）
+        認 `safe.directory`，因此位置由帳號的 HOME 決定，與 `~/.codex` 同一個模式。
+        """
+        return f"{self.home_of(account)}/.gitconfig"
+
     @property
     def builder_home(self) -> str:
         return self.home_of(self.builder_account)
@@ -1084,16 +1139,23 @@ class PathLayout:
         return self.cache_of(self.builder_account)
 
     def with_job_segment(self, segment: str) -> "PathLayout":
-        """換掉 per-job segment（system unit 模板用 `%i`）。"""
-        return PathLayout(
-            agents_root=self.agents_root,
-            worktree_root=self.worktree_root,
-            deploy_root=self.deploy_root,
-            instance=self.instance,
-            home_root=self.home_root,
-            builder_account=self.builder_account,
-            job_segment=segment,
-        )
+        """換掉 per-job segment（system unit 模板用 `%i`）。
+
+        以 `dataclasses.replace` 而非逐欄位重建：欄位表只有一份，新增欄位不會在這裡
+        被靜默重設回預設值（那會讓 job layout 與 setup layout 指向不同的樹）。
+        """
+        return replace(self, job_segment=segment)
+
+    def with_source_repo_slugs(self, slugs: "tuple[str, ...] | list[str]") -> "PathLayout":
+        """回傳帶上來源 repo 宣告的新 layout（本體 frozen，不就地改）。
+
+        slug 會被逐字嵌進 root 產生的 `.gitconfig`，因此在**產生階段**就驗形狀，
+        不等到 operator 落檔（比照帳號名的 `_validate_account_name`）。
+        """
+        checked = tuple(str(s) for s in slugs)
+        for slug in checked:
+            _validate_repo_slug(slug)
+        return replace(self, source_repo_slugs=checked)
 
     # -- 資產→路徑 ----------------------------------------------------------
     def asset_paths(self) -> dict[str, str]:
@@ -1125,6 +1187,10 @@ class PathLayout:
             "control-done-queue": f"{ctl}/done",
             "control-status": f"{ctl}/status.json",
             "control-daemon-lock": f"{ctl}/manager.lock",
+            # #623：per-job clone 的來源樹（容器；每個受治理 repo 一格 <此根>/<slug>）。
+            "repo-source-tree": self.repo_source_root,
+            "builder-gitconfig": self.gitconfig_of(self.builder_account),
+            "reviewer-planner-gitconfig": self.gitconfig_of(self.reviewer_planner_account),
             "repo-worktree": job,
             "dispatch-worktree-pool": wt,
             "jobs-registry": f"{c}/jobs.json",
@@ -1777,6 +1843,15 @@ def build_manager_unit(
         "# 相對 log_dir（runtime/dispatch/<slice>）由此解析，必須落在 ReadWritePaths 內。",
         f"WorkingDirectory={layout.agents_root}",
         "",
+        "# --- per-job clone 的來源樹（登記表 repo-source-tree，#623）：本服務**唯讀** ---",
+        f"#   {layout.repo_source_root}/<slug>（root 擁有 0755，PSC_REPO_ROOT 指向它）。",
+        "# ProtectSystem=strict 下「唯讀」是預設，因此讀不需要任何額外指令；而下方",
+        "# ReadWritePaths **不含**它——來源樹的 writer 只有部署身分（root），更新來源樹是",
+        "# operator 的 root 動作。取捨：Manager 因此不能自己 `git fetch` 更新來源樹，換到的",
+        "# 是「Manager 被攻陷也改不了每個 job clone 的來源」——攻擊面最小的那一邊。",
+        "# 要改成 Manager 可更新，唯一的正當作法是把它登記為 Manager 的 writer 並重跑",
+        "# 產生器（RWP 會跟著出現），不是在這裡手加一條。",
+        "",
         "# EnvironmentFile 無 '-' 前綴＝fail-closed：檔案缺席即拒絕啟動，",
         "# MUST NOT 靜默落回 $HOME/.agents 預設（spec §R3 Scenario「刪除 EnvironmentFile」）。",
         f"EnvironmentFile={layout.env_file}",
@@ -1901,6 +1976,12 @@ def build_monitor_unit(
         "# 由 config 指定絕對路徑，這裡只要一個必然存在、不隨 operator HOME 漂移的 cwd。",
         f"WorkingDirectory={layout.agents_root}",
         "",
+        "# --- monitor 的掃描目標（登記表 repo-source-tree，#623）：**唯讀** ---",
+        f"#   {layout.repo_source_root}/<slug>——**working checkout**（不是 bare），因為",
+        "# monitor 掃的是工作樹裡的檔案（workstreams/*/todo.md…），bare 沒有工作樹。",
+        "# ProtectSystem=strict 下讀是預設允許的，故不需要任何指令；而下方 ReadWritePaths",
+        "# **不含**它——monitor 在登記表上不是它的 writer，掃描本來就只需要讀。",
+        "",
         "# EnvironmentFile 無 '-' 前綴＝fail-closed：檔案缺席即拒絕啟動，",
         "# MUST NOT 靜默落回 $HOME/.agents 預設。這正是 #622 的核心——舊 --user monitor",
         "# 的 PSC_MONITOR_STATE_ROOT 指著舊樹，起回來只會雙寫。與 Manager 共用同一份",
@@ -1998,6 +2079,13 @@ def build_job_unit(
         "# 這裡只給恆存在的 pool 根（0701＝可 traverse、不可列目錄），避免 unit 因",
         "# per-job 目錄尚未建立而在 exec 前就失敗（那會讓 log 裡沒有任何線索）。",
         f"WorkingDirectory={job_layout.worktree_root}",
+        "# --- clone 來源（登記表 repo-source-tree，#623）：對 job **唯讀** ---",
+        f"#   {job_layout.repo_source_root}/<slug> → `git clone --no-hardlinks` 到",
+        f"#   {job_layout.worktree_root}/%i（整個 clone 由本 job 帳號擁有，已在下方 RWP 內）。",
+        "# 來源樹**不在** ReadWritePaths：job 讀得到、寫不進去，共用 object store 那條",
+        "# 「builder 能寫 Manager 的樹」的路因此在 git 這一層就不存在。",
+        f"# 跨擁有者 clone 由 {job_layout.gitconfig_of(account)} 的 safe.directory 放行",
+        "# （root-owned、本帳號唯讀；登記表資產，內容同樣由 permgen 產生）。",
         "# shim 讀 spec 的唯一合法來源：這一行在 root-owned 的 unit 檔裡，",
         "# 因此持 spawn 授權的帳號也改不掉 spec 要從哪個目錄讀。shim 對未設此",
         "# 變數的情況 fail-closed（不猜、不落回 $HOME 推導的預設）。",
@@ -2120,6 +2208,151 @@ def build_job_shim(
         mode=0o755,
         owner=account,
         group=scheme.group_of(account),
+        content="\n".join(body) + "\n",
+    )
+
+
+# ---------------------------------------------------------------------------
+# job 帳號的 root-owned `.gitconfig`（per-job clone 的必要條件，#623）
+# ---------------------------------------------------------------------------
+
+#: 需要一份 root-owned `.gitconfig` 的 job persona → 登記表 asset_id。
+#: reviewer 與 planner 共用同一個帳號（三分定案），故共用同一份檔，由 REVIEWER 代表。
+JOB_GITCONFIG_ASSETS: Mapping[Principal, str] = {
+    Principal.BUILDER: "builder-gitconfig",
+    Principal.REVIEWER: "reviewer-planner-gitconfig",
+}
+
+#: `.gitconfig` 的 mode。**0644 而非 0600**：檔案 root 擁有、job 帳號要讀得到，
+#: 與 `codex-hooks`（同樣 root-owned、同樣落在 job HOME 下）逐位元相同。
+JOB_GITCONFIG_MODE = 0o644
+
+
+class UnresolvedSourceRepoError(ValueError):
+    """layout 沒宣告任何來源 repo——`.gitconfig` 產不出有用的 `safe.directory`（#623）。
+
+    fail-closed 而不是輸出一份空的 `[safe]` 段：空的檔案照樣裝得起來、服務照樣起得來，
+    然後**每一個 job 在第一次 `git clone` 時失敗**（`fatal: detected dubious ownership`），
+    而症狀出現的位置離原因很遠——正是 #623 要消滅的那一類缺口。
+    """
+
+    def __init__(self, layout_hint: str) -> None:
+        super().__init__(
+            "permgen 拒絕產生 .gitconfig：layout 未宣告任何來源 repo slug。\n"
+            f"來源樹容器：{layout_hint}\n"
+            "  指定：--source-repo <slug>（可重複）  或  env PSC_SOURCE_REPO_SLUGS=<slug>[,<slug>…]\n"
+            "\n"
+            "為何不能省略、也不能用萬用字元：git 的 `safe.directory` 只認**逐字相等**的\n"
+            "路徑或字面 `*`（實測 git 2.43：`<repos>/*` 仍被拒），而字面 `*` 等於對這個\n"
+            "帳號整個關掉 dubious-ownership 保護——那是 opt-out，不是授權。\n"
+            "slug 即來源樹底下的目錄名：`<repo_source_root>/<slug>`（例如 repo 的名字）。"
+        )
+
+
+@dataclass(frozen=True)
+class GitConfigFile:
+    """產生出來的 `.gitconfig`：**只有內容字串與結構化欄位**，本模組不寫任何路徑。"""
+
+    install_path: str
+    #: 讀這個檔的 job 帳號（`$HOME` 就是它的 HOME）。
+    account: str
+    owner: str
+    group: str
+    mode: int
+    #: 被授信的來源 repo 絕對路徑（逐字寫進 `safe.directory`）。
+    safe_directories: tuple[str, ...]
+    content: str
+
+    @property
+    def mode_str(self) -> str:
+        return format(self.mode, "04o")
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "install_path": self.install_path,
+            "account": self.account,
+            "owner": self.owner,
+            "group": self.group,
+            "mode": self.mode_str,
+            "safe_directories": list(self.safe_directories),
+            "content": self.content,
+        }
+
+    def commands(self) -> list[str]:
+        """安裝命令字串（**只回傳字串，不執行**）。"""
+        return [
+            f"chown {self.owner}:{self.group} {self.install_path}",
+            f"chmod {self.mode_str} {self.install_path}",
+        ]
+
+
+def build_job_gitconfig(
+    scheme: UidScheme = DEFAULT_SCHEME,
+    layout: PathLayout = DEFAULT_LAYOUT,
+    principal: Principal = Principal.BUILDER,
+) -> GitConfigFile:
+    """產生 job 帳號 HOME 下那份 root-owned `.gitconfig` 的內容（#623）。
+
+    ## 為什麼這個檔是必要的
+
+    #623 裁決把 job 工作區從 `git worktree` 改成 **per-job 完整 clone**（實測：共用
+    git object store 與三分隔離互斥——builder 要 commit 就得能寫 object store）。
+    clone 的來源樹屬 root（登記表資產 `repo-source-tree`），job 帳號跨擁有者 clone 會
+    被 git 的 dubious-ownership 保護擋下：
+
+        fatal: detected dubious ownership in repository at '<來源樹>/<slug>'
+
+    唯一的解是 `safe.directory`，而它**必須由 root 放進 job 的 HOME**——job 的 HOME 是
+    root-owned，它自己放不了這個檔。這正是登記表既有的 `codex-hooks`
+    （root-owned、在 job 帳號 HOME 下）同一個模式，不需要新概念。
+
+    ## 為什麼逐個列出來源 repo，而不是 `<repos>/*` 或 `*`
+
+    - git 的 `safe.directory` **不支援目錄萬用字元**（實測 git 2.43：值寫成
+      `<repos>/*` 時 clone 仍被拒），只認逐字相等的路徑或字面 `*`；
+    - 字面 `*` 等於對這個帳號整個關掉該保護——那是 opt-out，不是授權，且會讓「這個
+      帳號被授信的來源有哪些」這件事在檔案裡完全看不出來。
+
+    因此來源 repo 清單是**部署決定**，由 `layout.source_repo_slugs` 於產生當下注入
+    （比照 #626 的部署決定型 principal），未宣告即 :class:`UnresolvedSourceRepoError`。
+    """
+    account = scheme.resolve(principal)
+    if account is None:
+        raise ValueError(f"principal 未映射到帳號: {principal}")
+    safe_dirs = layout.source_repo_paths()
+    if not safe_dirs:
+        raise UnresolvedSourceRepoError(layout.repo_source_root)
+    install_path = layout.gitconfig_of(account)
+    asset_id = JOB_GITCONFIG_ASSETS.get(principal, "builder-gitconfig")
+    flag = "--builder" if principal is Principal.BUILDER else "--reviewer-planner"
+    slug_args = " ".join(f"--source-repo {slug}" for slug in layout.source_repo_slugs)
+    body = [
+        f"# {install_path}",
+        f"# 由 permgen 機械產生（scheme={scheme.scheme_id}）——勿手改；重跑：",
+        f"#   python3 -m paulsha_cortex.trust_root gitconfig {scheme.scheme_id} "
+        f"{flag} {slug_args}",
+        "#",
+        f"# 登記表資產 `{asset_id}`：root 擁有、mode "
+        f"{format(JOB_GITCONFIG_MODE, '04o')}、{account} **唯讀**。",
+        "# HOME 本身也是 root-owned，因此 job 既改不了這個檔，也放不了自己的版本。",
+        "#",
+        "# 為什麼需要它：#623 把 job 工作區從 git worktree 改為 per-job 完整 clone；",
+        "# 來源樹屬 root，跨擁有者 clone 會被 git 的 dubious-ownership 保護擋下",
+        "# （fatal: detected dubious ownership in repository at ...）。",
+        "#",
+        "# 為什麼逐個列出而不是萬用字元：git 的 safe.directory 只認逐字相等的路徑或",
+        "# 字面 `*`（實測 git 2.43：`<repos>/*` 仍被拒），而字面 `*` 等於對這個帳號",
+        "# 整個關掉該保護——那是 opt-out，不是授權。",
+        "[safe]",
+    ]
+    body += [f"\tdirectory = {path}" for path in safe_dirs]
+    return GitConfigFile(
+        install_path=install_path,
+        account=account,
+        owner=scheme.deploy_account,
+        group=scheme.group_of(scheme.deploy_account),
+        mode=JOB_GITCONFIG_MODE,
+        safe_directories=safe_dirs,
         content="\n".join(body) + "\n",
     )
 

--- a/paulsha_cortex/trust_root/permgen.py
+++ b/paulsha_cortex/trust_root/permgen.py
@@ -553,6 +553,7 @@ _DIR_ASSET_IDS = frozenset({
     "engineering-outcome-outbox",   # <coordinator>/engineering-outcomes/<repo>.jsonl 的容器
     "gate-ledger",                  # <agents_root>/runtime/dispatch/（manager log_dir）
     "review-verdict-spool",         # <coordinator>/review-verdicts/<reviewer_job_id>/
+    "commit-spool",                 # <coordinator>/commit-spool/<job-id>/
 })
 _FILE_ASSET_IDS = frozenset({
     "control-daemon-lock",
@@ -643,10 +644,12 @@ def build_entry(asset: TrustRootAsset, scheme: UidScheme) -> PermissionEntry:
             "整棵樹；對全部 headless 唯讀，現況裸寫／group-writable 於此收斂。"
             "0816 裁決已定案路徑：部署樹＝/opt/cortex、bootstrap env 落 /opt/cortex/etc/、"
             "codex hooks 落 job 帳號 HOME 下的 root-owned .codex/（值見 PathLayout，勿手寫）。"
-            "**凡 writer 只有部署身分的資產皆歸此類**，因此 #623 的 per-job clone 來源樹"
-            "與 job 帳號 HOME 下的 root-owned .gitconfig 也在其中：owner＝root 即代表"
-            "**全部服務帳號（含 Manager）唯讀**——ReadWritePaths 純由「誰可寫」導出，"
-            "這條分類就是「來源樹由 operator 以 root 更新、Manager 唯讀」裁決的機械落點。"
+            "**凡 writer 只有部署身分的資產皆歸此類**，因此 #623 的三份 root-owned "
+            ".gitconfig（builder／reviewer-planner／manager）也在其中：owner＝root 即代表"
+            "**全部服務帳號（含 Manager）對這些檔唯讀**——ReadWritePaths 純由「誰可寫」"
+            "導出，服務因此改不了自己的 git 設定（.gitconfig 可指定 core.fsmonitor／"
+            "alias.* 這類會執行外部命令的鍵）。注意來源樹本身**不**歸此類：0817 裁決把"
+            "它的 writer 改為 Manager（回收成果必須寫得進去），見 `repo-source-tree`。"
         )
 
     elif owner_class is OwnerClass.MANAGER_STATE:
@@ -1006,10 +1009,14 @@ class PathLayout:
     #: reviewer／planner 與 Manager 併帳（`cortex-svc`）、且尚未經模板 unit 降權起 job，
     #: 因此那個部署形態下本資產不適用（產生的命令帶 `[ ! -e ] ||` 守衛，會直接跳過）。
     reviewer_planner_account: str = "cortex-reviewer-planner"
+    #: Manager＋monitor 的服務帳號名（`manager-gitconfig` 掛在它的 HOME 下）。與上面
+    #: 兩個同一個理由：`asset_paths()` 刻意不吃 scheme，而兩個 scheme 對 MANAGER 的映射
+    #: **不同**（二分是 `cortex-svc`）——這裡同樣取**定案的三分**，二分下該資產不適用。
+    manager_account: str = "cortex-manager"
     #: 本 instance 治理的來源 repo slug（`<repo_source_root>/<slug>`）。**部署決定**，
-    #: 刻意留空：job 帳號的 `.gitconfig` 需要**逐字**的 `safe.directory` 路徑（git 不吃
-    #: 目錄萬用字元，見 `build_job_gitconfig`），猜不到就只能猜錯。未指定時
-    #: `build_job_gitconfig()` fail-closed，比照 #626 的部署決定型 principal。
+    #: 刻意留空：`.gitconfig` 需要**逐字**的 `safe.directory` 路徑（git 不吃目錄萬用
+    #: 字元，見 `build_account_gitconfig`），猜不到就只能猜錯。未指定時
+    #: `build_account_gitconfig()` fail-closed，比照 #626 的部署決定型 principal。
     source_repo_slugs: tuple[str, ...] = ()
     #: per-job 路徑的 segment；system unit 模板用 `%i`（systemd instance 名）。
     job_segment: str = PER_JOB_SEGMENT
@@ -1057,6 +1064,29 @@ class PathLayout:
         """已宣告的來源 repo 絕對路徑（`<repo_source_root>/<slug>`；未宣告即空）。"""
         return tuple(f"{self.repo_source_root}/{slug}" for slug in self.source_repo_slugs)
 
+    def source_repo_safe_directories(self) -> tuple[str, ...]:
+        """每個來源 repo 需要的 `safe.directory` 值——**工作樹根 ＋ `<root>/.git` 兩條**。
+
+        實測（#623 複驗）：從**非 bare** 的來源 clone 時，git 檢查的是 `<repo>/.git`
+        而**不是**工作樹根——
+
+            fatal: detected dubious ownership in repository at
+                   '/var/lib/cortex/repos/paulsha-cortex/.git'
+
+        而 `git -C <repo> rev-parse`／`fetch` 這類對工作樹本身的操作，報的又是工作樹根：
+
+            fatal: detected dubious ownership in repository at
+                   '/var/lib/cortex/repos/paulsha-cortex'
+
+        `safe.directory` 只認**逐字相等**的路徑（見 `build_account_gitconfig` 的說明），
+        兩個位置就是兩條值，只給其中一條會讓另一半的操作在完全不同的時機才失敗。
+        """
+        entries: list[str] = []
+        for path in self.source_repo_paths():
+            entries.append(path)
+            entries.append(f"{path}/.git")
+        return tuple(entries)
+
     @property
     def run_root(self) -> str:
         return f"{self.agents_root}/run/{self.instance}"
@@ -1066,6 +1096,16 @@ class PathLayout:
         """Manager 的 job log_dir（`autonomy.py` 以相對 `runtime/dispatch/<slice>`
         推導，故由 unit 的 `WorkingDirectory` 決定落點）。gate ledger 住在這裡。"""
         return f"{self.agents_root}/runtime/dispatch"
+
+    @property
+    def commit_spool_root(self) -> str:
+        """builder 成果回收的 bundle spool 根（登記表資產 `commit-spool`，#623／#634）。
+
+        路徑與 `config.paths.commit_spool_root()` 是**成對契約**，由 `asset_paths()`
+        供給權限計畫；本 property 只是給 unit 產生器引用的同一份字面量（比照
+        `job_spec_spool_root`）。
+        """
+        return f"{self.coordinator_root}/commit-spool"
 
     @property
     def job_spec_spool_root(self) -> str:
@@ -1191,12 +1231,15 @@ class PathLayout:
             "repo-source-tree": self.repo_source_root,
             "builder-gitconfig": self.gitconfig_of(self.builder_account),
             "reviewer-planner-gitconfig": self.gitconfig_of(self.reviewer_planner_account),
+            "manager-gitconfig": self.gitconfig_of(self.manager_account),
             "repo-worktree": job,
             "dispatch-worktree-pool": wt,
             "jobs-registry": f"{c}/jobs.json",
             "review-verdict": f"{job}/.psc-review-verdict.json",
             # Phase 2a 受控通道（PR #599）：<coordinator>/review-verdicts/<reviewer_job_id>/
             "review-verdict-spool": f"{c}/review-verdicts",
+            # #623／#634 成果回收的 bundle spool：<coordinator>/commit-spool/<job-id>/
+            "commit-spool": self.commit_spool_root,
             # Phase 2b 方案 B（0816 第三輪 A+B）：模板 unit 的 per-job 執行規格。
             "job-spec-spool": self.job_spec_spool_root,
             "verification-evidence": f"{c}/evidence/verification",
@@ -1843,14 +1886,16 @@ def build_manager_unit(
         "# 相對 log_dir（runtime/dispatch/<slice>）由此解析，必須落在 ReadWritePaths 內。",
         f"WorkingDirectory={layout.agents_root}",
         "",
-        "# --- per-job clone 的來源樹（登記表 repo-source-tree，#623）：本服務**唯讀** ---",
-        f"#   {layout.repo_source_root}/<slug>（root 擁有 0755，PSC_REPO_ROOT 指向它）。",
-        "# ProtectSystem=strict 下「唯讀」是預設，因此讀不需要任何額外指令；而下方",
-        "# ReadWritePaths **不含**它——來源樹的 writer 只有部署身分（root），更新來源樹是",
-        "# operator 的 root 動作。取捨：Manager 因此不能自己 `git fetch` 更新來源樹，換到的",
-        "# 是「Manager 被攻陷也改不了每個 job clone 的來源」——攻擊面最小的那一邊。",
-        "# 要改成 Manager 可更新，唯一的正當作法是把它登記為 Manager 的 writer 並重跑",
-        "# 產生器（RWP 會跟著出現），不是在這裡手加一條。",
+        "# --- per-job clone 的來源樹（登記表 repo-source-tree，#623）：本服務**可寫** ---",
+        f"#   {layout.repo_source_root}/<slug>"
+        f"（{account} 擁有 0700，PSC_REPO_ROOT 指向它）。",
+        "# 0817 裁決推翻了本票初版的 root-owned：`git fetch` 必須把 FETCH_HEAD 寫進**目標",
+        "# repo**，而 #634 的成果回收正是 fetch 進來源樹；provision 那半邊的 `git branch -f`",
+        "# 也是對來源樹的寫入。「Manager 唯讀」與「Manager 回收成果」互斥，取後者。",
+        "# 隔離沒有變弱：不受信任的是 job 帳號，它們對這棵樹只有唯讀 ACL；而 Manager 本來",
+        "# 就擁有 gate ledger／evidence／jobs.json——多這一棵樹不改變攻擊面。",
+        f"# 跨擁有者的 git 操作由 {layout.gitconfig_of(account)} 的 safe.directory 放行",
+        "# （root-owned、本帳號唯讀；登記表資產 manager-gitconfig，內容同樣由 permgen 產）。",
         "",
         "# EnvironmentFile 無 '-' 前綴＝fail-closed：檔案缺席即拒絕啟動，",
         "# MUST NOT 靜默落回 $HOME/.agents 預設（spec §R3 Scenario「刪除 EnvironmentFile」）。",
@@ -1981,6 +2026,9 @@ def build_monitor_unit(
         "# monitor 掃的是工作樹裡的檔案（workstreams/*/todo.md…），bare 沒有工作樹。",
         "# ProtectSystem=strict 下讀是預設允許的，故不需要任何指令；而下方 ReadWritePaths",
         "# **不含**它——monitor 在登記表上不是它的 writer，掃描本來就只需要讀。",
+        "# 注意這一條是 **persona 過濾**的成果，不是帳號的：0817 裁決後 Manager 是這棵樹的",
+        "# writer，而 monitor 與 Manager 同帳號——檔案層兩者權限相同，是這份 unit 少了那條",
+        "# ReadWritePaths 才讓 monitor 真的寫不進去。要拿回來只能改登記表，沒有手擴的入口。",
         "",
         "# EnvironmentFile 無 '-' 前綴＝fail-closed：檔案缺席即拒絕啟動，",
         "# MUST NOT 靜默落回 $HOME/.agents 預設。這正是 #622 的核心——舊 --user monitor",
@@ -2082,10 +2130,16 @@ def build_job_unit(
         "# --- clone 來源（登記表 repo-source-tree，#623）：對 job **唯讀** ---",
         f"#   {job_layout.repo_source_root}/<slug> → `git clone --no-hardlinks` 到",
         f"#   {job_layout.worktree_root}/%i（整個 clone 由本 job 帳號擁有，已在下方 RWP 內）。",
-        "# 來源樹**不在** ReadWritePaths：job 讀得到、寫不進去，共用 object store 那條",
-        "# 「builder 能寫 Manager 的樹」的路因此在 git 這一層就不存在。",
+        "# 來源樹的 owner 是 Manager（0817 裁決），job 帳號只拿到唯讀 ACL：讀得到、",
+        "# 寫不進去，共用 object store 那條「builder 能寫 Manager 的樹」的路因此在 git",
+        "# 這一層就不存在；下方 ReadWritePaths **不含**來源樹。",
         f"# 跨擁有者 clone 由 {job_layout.gitconfig_of(account)} 的 safe.directory 放行",
         "# （root-owned、本帳號唯讀；登記表資產，內容同樣由 permgen 產生）。",
+        "# --- 成果回收（登記表 commit-spool，#623／#634）---",
+        f"#   {job_layout.commit_spool_root}/%i/：job 在**自己的** clone `git bundle create`",
+        "# 寫進這一格，Manager 再從那個 bundle **檔案** fetch——Manager 全程不碰 job 的樹。",
+        "# 權限是 `wx` 無 `r`：寫得進自己那格、讀不到別人的 bundle。producer 只有 builder，",
+        "# 因此這條只會出現在 builder 的模板 unit（RWP 由登記表機械導出，不是寫死的）。",
         "# shim 讀 spec 的唯一合法來源：這一行在 root-owned 的 unit 檔裡，",
         "# 因此持 spawn 授權的帳號也改不掉 spec 要從哪個目錄讀。shim 對未設此",
         "# 變數的情況 fail-closed（不猜、不落回 $HOME 推導的預設）。",
@@ -2213,19 +2267,29 @@ def build_job_shim(
 
 
 # ---------------------------------------------------------------------------
-# job 帳號的 root-owned `.gitconfig`（per-job clone 的必要條件，#623）
+# 服務／job 帳號的 root-owned `.gitconfig`（per-job clone 的必要條件，#623）
 # ---------------------------------------------------------------------------
 
-#: 需要一份 root-owned `.gitconfig` 的 job persona → 登記表 asset_id。
-#: reviewer 與 planner 共用同一個帳號（三分定案），故共用同一份檔，由 REVIEWER 代表。
-JOB_GITCONFIG_ASSETS: Mapping[Principal, str] = {
+#: 需要一份 root-owned `.gitconfig` 的 persona → 登記表 asset_id。
+#: reviewer 與 planner 共用同一個帳號（三分定案），故共用同一份檔，由 REVIEWER 代表；
+#: Manager 與 monitor 同樣共用一個帳號與 HOME，由 MANAGER 代表。
+ACCOUNT_GITCONFIG_ASSETS: Mapping[Principal, str] = {
     Principal.BUILDER: "builder-gitconfig",
     Principal.REVIEWER: "reviewer-planner-gitconfig",
+    Principal.MANAGER: "manager-gitconfig",
 }
 
-#: `.gitconfig` 的 mode。**0644 而非 0600**：檔案 root 擁有、job 帳號要讀得到，
-#: 與 `codex-hooks`（同樣 root-owned、同樣落在 job HOME 下）逐位元相同。
-JOB_GITCONFIG_MODE = 0o644
+#: 各 persona 對應的 CLI 旗標（`trust_root gitconfig … <flag>`）。與
+#: :data:`ACCOUNT_GITCONFIG_ASSETS` 同一張表導出，產出的「重跑這行」註解因此不會漂移。
+ACCOUNT_GITCONFIG_FLAGS: Mapping[Principal, str] = {
+    Principal.BUILDER: "--builder",
+    Principal.REVIEWER: "--reviewer-planner",
+    Principal.MANAGER: "--manager",
+}
+
+#: `.gitconfig` 的 mode。**0644 而非 0600**：檔案 root 擁有、讀取的帳號要讀得到，
+#: 與 `codex-hooks`（同樣 root-owned、同樣落在帳號 HOME 下）逐位元相同。
+ACCOUNT_GITCONFIG_MODE = 0o644
 
 
 class UnresolvedSourceRepoError(ValueError):
@@ -2254,7 +2318,7 @@ class GitConfigFile:
     """產生出來的 `.gitconfig`：**只有內容字串與結構化欄位**，本模組不寫任何路徑。"""
 
     install_path: str
-    #: 讀這個檔的 job 帳號（`$HOME` 就是它的 HOME）。
+    #: 讀這個檔的帳號（`$HOME` 就是它的 HOME）。
     account: str
     owner: str
     group: str
@@ -2286,25 +2350,35 @@ class GitConfigFile:
         ]
 
 
-def build_job_gitconfig(
+def build_account_gitconfig(
     scheme: UidScheme = DEFAULT_SCHEME,
     layout: PathLayout = DEFAULT_LAYOUT,
     principal: Principal = Principal.BUILDER,
 ) -> GitConfigFile:
-    """產生 job 帳號 HOME 下那份 root-owned `.gitconfig` 的內容（#623）。
+    """產生某個帳號 HOME 下那份 root-owned `.gitconfig` 的內容（#623）。
+
+    三份同構的產物共用本函式（見 :data:`ACCOUNT_GITCONFIG_ASSETS`）：兩個 job 帳號
+    各一份，**Manager 帳號一份**。Manager 那份不是「順手也給一個」——它與 job 那兩份
+    是同一條必要性，只是操作方向相反（見下）。
 
     ## 為什麼這個檔是必要的
 
     #623 裁決把 job 工作區從 `git worktree` 改成 **per-job 完整 clone**（實測：共用
     git object store 與三分隔離互斥——builder 要 commit 就得能寫 object store）。
-    clone 的來源樹屬 root（登記表資產 `repo-source-tree`），job 帳號跨擁有者 clone 會
-    被 git 的 dubious-ownership 保護擋下：
+    來源樹（登記表資產 `repo-source-tree`）與讀它的帳號**不同 owner**時，git 的
+    dubious-ownership 保護會直接擋下操作：
 
         fatal: detected dubious ownership in repository at '<來源樹>/<slug>'
 
-    唯一的解是 `safe.directory`，而它**必須由 root 放進 job 的 HOME**——job 的 HOME 是
-    root-owned，它自己放不了這個檔。這正是登記表既有的 `codex-hooks`
-    （root-owned、在 job 帳號 HOME 下）同一個模式，不需要新概念。
+    唯一的解是 `safe.directory`，而它**必須由 root 放進該帳號的 HOME**——那些 HOME
+    都是 root-owned，帳號自己放不了這個檔。這正是登記表既有的 `codex-hooks`
+    （root-owned、在帳號 HOME 下）同一個模式，不需要新概念。
+
+    ## 為什麼每個 repo 是**兩條**值
+
+    實測：從**非 bare** 的來源 clone 時 git 檢查的是 `<repo>/.git`，而 `git -C <repo>`
+    這類對工作樹本身的操作報的是工作樹根。只給一條會讓另一半的操作在完全不同的時機
+    才失敗。兩條的推導在 `PathLayout.source_repo_safe_directories()`。
 
     ## 為什麼逐個列出來源 repo，而不是 `<repos>/*` 或 `*`
 
@@ -2319,12 +2393,12 @@ def build_job_gitconfig(
     account = scheme.resolve(principal)
     if account is None:
         raise ValueError(f"principal 未映射到帳號: {principal}")
-    safe_dirs = layout.source_repo_paths()
-    if not safe_dirs:
+    if not layout.source_repo_paths():
         raise UnresolvedSourceRepoError(layout.repo_source_root)
+    safe_dirs = layout.source_repo_safe_directories()
     install_path = layout.gitconfig_of(account)
-    asset_id = JOB_GITCONFIG_ASSETS.get(principal, "builder-gitconfig")
-    flag = "--builder" if principal is Principal.BUILDER else "--reviewer-planner"
+    asset_id = ACCOUNT_GITCONFIG_ASSETS.get(principal, "builder-gitconfig")
+    flag = ACCOUNT_GITCONFIG_FLAGS.get(principal, "--builder")
     slug_args = " ".join(f"--source-repo {slug}" for slug in layout.source_repo_slugs)
     body = [
         f"# {install_path}",
@@ -2333,12 +2407,16 @@ def build_job_gitconfig(
         f"{flag} {slug_args}",
         "#",
         f"# 登記表資產 `{asset_id}`：root 擁有、mode "
-        f"{format(JOB_GITCONFIG_MODE, '04o')}、{account} **唯讀**。",
-        "# HOME 本身也是 root-owned，因此 job 既改不了這個檔，也放不了自己的版本。",
+        f"{format(ACCOUNT_GITCONFIG_MODE, '04o')}、{account} **唯讀**。",
+        "# HOME 本身也是 root-owned，因此該帳號既改不了這個檔，也放不了自己的版本",
+        "# ——.gitconfig 可指定 core.fsmonitor／alias.* 這類會執行外部命令的鍵。",
         "#",
         "# 為什麼需要它：#623 把 job 工作區從 git worktree 改為 per-job 完整 clone；",
-        "# 來源樹屬 root，跨擁有者 clone 會被 git 的 dubious-ownership 保護擋下",
+        "# 來源樹與讀它的帳號不同 owner 時，git 的 dubious-ownership 保護會擋下操作",
         "# （fatal: detected dubious ownership in repository at ...）。",
+        "#",
+        "# 為什麼每個 repo 兩條：從**非 bare** 來源 clone 時 git 檢查的是 <repo>/.git，",
+        "# 而 `git -C <repo> …` 報的是工作樹根——兩個位置就是兩條逐字的值。",
         "#",
         "# 為什麼逐個列出而不是萬用字元：git 的 safe.directory 只認逐字相等的路徑或",
         "# 字面 `*`（實測 git 2.43：`<repos>/*` 仍被拒），而字面 `*` 等於對這個帳號",
@@ -2351,7 +2429,7 @@ def build_job_gitconfig(
         account=account,
         owner=scheme.deploy_account,
         group=scheme.group_of(scheme.deploy_account),
-        mode=JOB_GITCONFIG_MODE,
+        mode=ACCOUNT_GITCONFIG_MODE,
         safe_directories=safe_dirs,
         content="\n".join(body) + "\n",
     )

--- a/paulsha_cortex/trust_root/registry.py
+++ b/paulsha_cortex/trust_root/registry.py
@@ -245,12 +245,71 @@ ASSET_REGISTRY: tuple[TrustRootAsset, ...] = (
         IngressKind.MANAGER_INTERNAL,
         note="lock 檔實測 0o644；owner 可 unlink 後重建。",
     ),
+    # ---- per-job clone 的來源樹（#623）--------------------------------------
+    TrustRootAsset(
+        "repo-source-tree", _T0, _MO, None,
+        (Principal.INSTALLER,),
+        (
+            Principal.MANAGER, Principal.MONITOR,
+            Principal.BUILDER, Principal.REVIEWER, Principal.PLANNER,
+        ),
+        IngressKind.DEPLOYMENT_WRITE,
+        derived_in=("trust_root/permgen.py:PathLayout.repo_source_root",),
+        note=(
+            "`<agents_root>/repos/<slug>`——**Manager-owned 樹內的 working checkout**，"
+            "同時是 monitor 的掃描目標（`workstreams/*/todo.md` 等要有工作樹，bare 沒有）"
+            "與每個 job 的 **clone 來源**。#623 實測：共用 git object store 與三分隔離"
+            "**互斥**（builder 要 commit 就得能寫 object store，能寫就等於邊界在 git 這層"
+            "漏掉），因此 job 工作區由 `git worktree` 改為 **per-job 完整 clone**"
+            "（0.5 秒／35MB）。\n"
+            "**writer 只有部署身分（root）**：來源樹由 operator 以 root 更新，"
+            "**全部服務帳號（含 Manager）唯讀**——owner_class 因此機械分到 DEPLOYMENT"
+            "而非 MANAGER_STATE（permgen 的 ReadWritePaths 純由「誰可寫」導出，"
+            "owner＝cortex-manager 會讓 Manager unit 自動拿到寫入權）。tree 仍是 "
+            "MANAGER_OWNED（headless 零寫入），與 `runtime-agents-tree` 同形。\n"
+            "**無 path_resolver**：程式碼解析的是**單一** repo（`PSC_REPO_ROOT` → "
+            "`<此樹>/<slug>`，見 `config/paths.py:repo_root`），本資產是**容器**，"
+            "沒有任何函式回傳它。"
+        ),
+    ),
+    TrustRootAsset(
+        "builder-gitconfig", _T0, _MO, None,
+        (Principal.INSTALLER,), (Principal.BUILDER,),
+        IngressKind.DEPLOYMENT_WRITE,
+        derived_in=("trust_root/permgen.py:build_job_gitconfig",),
+        note=(
+            "builder 帳號 HOME 下的 root-owned `.gitconfig`（0644），內容含來源 repo 的 "
+            "`safe.directory`——比照既有的 `codex-hooks`（root-owned、在 job 帳號 HOME 下），"
+            "不是新概念。**為何必須存在**：per-job clone 的來源樹不屬於 job 帳號，git 的 "
+            "dubious ownership 保護會讓 `git clone` 直接失敗；而 job 的 HOME 是 root-owned，"
+            "它自己放不了這個檔。**為何是 Tier-0**：gitconfig 可指定 `core.fsmonitor`／"
+            "`core.pager`／`alias.*` 等會執行外部命令的鍵，可寫者等於對該 job 帳號取得"
+            "任意程式碼執行——與 `codex-hooks` 同一條性質。內容由 permgen 產生"
+            "（`build_job_gitconfig()`），不手寫。"
+        ),
+    ),
+    TrustRootAsset(
+        "reviewer-planner-gitconfig", _T0, _MO, None,
+        (Principal.INSTALLER,), (Principal.REVIEWER, Principal.PLANNER),
+        IngressKind.DEPLOYMENT_WRITE,
+        derived_in=("trust_root/permgen.py:build_job_gitconfig",),
+        note=(
+            "同 `builder-gitconfig`，落在 reviewer＋planner 的 job 帳號 HOME 下"
+            "（三分定案的 `cortex-reviewer-planner`）。兩個 job 帳號各一份是必要的："
+            "`.gitconfig` 讀取端是 `$HOME`，而三分的硬性要求就是 reviewer 與 builder "
+            "互不可寫、HOME 互不相同。"
+        ),
+    ),
     # ---- job-visible worktree 族 -------------------------------------------
     TrustRootAsset(
         "repo-worktree", _T1, _JV, "paulsha_cortex.config.paths:repo_root",
         (Principal.BUILDER,), (Principal.MANAGER,),
         IngressKind.STAGING_SPOOL,
-        note="builder write_paths:['**']，可寫 worktree 內任何路徑（含 .cortex/.github）。",
+        note=(
+            "builder write_paths:['**']，可寫工作區內任何路徑（含 .cortex/.github）。"
+            "#623 之後這個工作區是從 `repo-source-tree` 拉出來的 **per-job 完整 clone**"
+            "（整個 clone 由該 job 帳號擁有），不再是共用 object store 的 git worktree。"
+        ),
     ),
     TrustRootAsset(
         "dispatch-worktree-pool", _T1, _JV, "paulsha_cortex.config.paths:worktree_root",
@@ -492,7 +551,9 @@ MUTATION_INGRESS: tuple[MutationIngress, ...] = (
     MutationIngress("config-overlay", IngressKind.CONFIG_OVERLAY, False, True,
                     "model-identity／combo／persona tool_allowlist_additions（只加不減、無上限）。"),
     MutationIngress("deployment-write", IngressKind.DEPLOYMENT_WRITE, False, True,
-                    "unit／venv／launcher／sitecustomize／.pth／PATH／~/.codex/hooks.json。"),
+                    "unit／venv／launcher／sitecustomize／.pth／PATH／~/.codex/hooks.json；"
+                    "#623 起另含 per-job clone 的來源樹與 job 帳號 HOME 下的 root-owned "
+                    "`.gitconfig`——同一條性質：writer 只有部署身分，服務帳號一律唯讀。"),
     MutationIngress("interprocess", IngressKind.INTERPROCESS, False, True,
                     "inherited FD／ptrace／/proc/<pid>/mem／signal。"),
 )

--- a/paulsha_cortex/trust_root/registry.py
+++ b/paulsha_cortex/trust_root/registry.py
@@ -248,12 +248,12 @@ ASSET_REGISTRY: tuple[TrustRootAsset, ...] = (
     # ---- per-job clone 的來源樹（#623）--------------------------------------
     TrustRootAsset(
         "repo-source-tree", _T0, _MO, None,
-        (Principal.INSTALLER,),
+        (Principal.MANAGER,),
         (
             Principal.MANAGER, Principal.MONITOR,
             Principal.BUILDER, Principal.REVIEWER, Principal.PLANNER,
         ),
-        IngressKind.DEPLOYMENT_WRITE,
+        IngressKind.MANAGER_INTERNAL,
         derived_in=("trust_root/permgen.py:PathLayout.repo_source_root",),
         note=(
             "`<agents_root>/repos/<slug>`——**Manager-owned 樹內的 working checkout**，"
@@ -262,11 +262,21 @@ ASSET_REGISTRY: tuple[TrustRootAsset, ...] = (
             "**互斥**（builder 要 commit 就得能寫 object store，能寫就等於邊界在 git 這層"
             "漏掉），因此 job 工作區由 `git worktree` 改為 **per-job 完整 clone**"
             "（0.5 秒／35MB）。\n"
-            "**writer 只有部署身分（root）**：來源樹由 operator 以 root 更新，"
-            "**全部服務帳號（含 Manager）唯讀**——owner_class 因此機械分到 DEPLOYMENT"
-            "而非 MANAGER_STATE（permgen 的 ReadWritePaths 純由「誰可寫」導出，"
-            "owner＝cortex-manager 會讓 Manager unit 自動拿到寫入權）。tree 仍是 "
-            "MANAGER_OWNED（headless 零寫入），與 `runtime-agents-tree` 同形。\n"
+            "**writer＝Manager（0817 裁決，推翻本票初版的 root-owned）**。初版把 writer "
+            "定成只有部署身分，機械分到 `owner_class=DEPLOYMENT`（root 0755）；實測那條"
+            "**走不通**：\n"
+            "    $ sudo -u cortex-manager git -C <來源樹> fetch <bundle> …\n"
+            "    error: cannot open '.git/FETCH_HEAD': Permission denied\n"
+            "`git fetch` 必須把 `FETCH_HEAD` 寫進**目標 repo**，而 #634 的成果回收正是"
+            "「fetch 進來源樹」；provisioning 那半邊也一樣要寫（`seams.py` 的 "
+            "`git branch -f <branch> <base>` 是對來源樹的寫入）。「Manager 唯讀」與"
+            "「Manager 回收成果」互斥，取後者。\n"
+            "**為何隔離沒有變弱**：威脅模型裡不受信任的是 **job 帳號**，而 Manager 本來"
+            "就擁有 gate ledger、evidence 樹與 jobs.json——Manager 被攻陷的話那些全都完了，"
+            "多這一棵樹不改變攻擊面。root-owned 買到的是「Manager 被攻陷後仍污染不了下一輪"
+            "job 的原始碼」這條供應鏈保護，但它讓成果回收整個不成立，因此取回收。改成 "
+            "Manager 可寫後實測整條通（`fetch` 真實 rc=0），而兩個 job 帳號對來源樹**仍"
+            "只有唯讀 ACL**（`rX`，一個 `w` 都沒有）——這條才是本資產真正在守的邊界。\n"
             "**無 path_resolver**：程式碼解析的是**單一** repo（`PSC_REPO_ROOT` → "
             "`<此樹>/<slug>`，見 `config/paths.py:repo_root`），本資產是**容器**，"
             "沒有任何函式回傳它。"
@@ -276,7 +286,7 @@ ASSET_REGISTRY: tuple[TrustRootAsset, ...] = (
         "builder-gitconfig", _T0, _MO, None,
         (Principal.INSTALLER,), (Principal.BUILDER,),
         IngressKind.DEPLOYMENT_WRITE,
-        derived_in=("trust_root/permgen.py:build_job_gitconfig",),
+        derived_in=("trust_root/permgen.py:build_account_gitconfig",),
         note=(
             "builder 帳號 HOME 下的 root-owned `.gitconfig`（0644），內容含來源 repo 的 "
             "`safe.directory`——比照既有的 `codex-hooks`（root-owned、在 job 帳號 HOME 下），"
@@ -285,19 +295,41 @@ ASSET_REGISTRY: tuple[TrustRootAsset, ...] = (
             "它自己放不了這個檔。**為何是 Tier-0**：gitconfig 可指定 `core.fsmonitor`／"
             "`core.pager`／`alias.*` 等會執行外部命令的鍵，可寫者等於對該 job 帳號取得"
             "任意程式碼執行——與 `codex-hooks` 同一條性質。內容由 permgen 產生"
-            "（`build_job_gitconfig()`），不手寫。"
+            "（`build_account_gitconfig()`），不手寫；每個來源 repo **兩條** "
+            "`safe.directory`（工作樹根 ＋ `<root>/.git`），理由見該函式。"
         ),
     ),
     TrustRootAsset(
         "reviewer-planner-gitconfig", _T0, _MO, None,
         (Principal.INSTALLER,), (Principal.REVIEWER, Principal.PLANNER),
         IngressKind.DEPLOYMENT_WRITE,
-        derived_in=("trust_root/permgen.py:build_job_gitconfig",),
+        derived_in=("trust_root/permgen.py:build_account_gitconfig",),
         note=(
             "同 `builder-gitconfig`，落在 reviewer＋planner 的 job 帳號 HOME 下"
             "（三分定案的 `cortex-reviewer-planner`）。兩個 job 帳號各一份是必要的："
             "`.gitconfig` 讀取端是 `$HOME`，而三分的硬性要求就是 reviewer 與 builder "
             "互不可寫、HOME 互不相同。"
+        ),
+    ),
+    TrustRootAsset(
+        "manager-gitconfig", _T0, _MO, None,
+        (Principal.INSTALLER,), (Principal.MANAGER, Principal.MONITOR),
+        IngressKind.DEPLOYMENT_WRITE,
+        derived_in=("trust_root/permgen.py:build_account_gitconfig",),
+        note=(
+            "與上面兩份**同構**（root-owned 0644、落在帳號 HOME 下、內容由 permgen 產），"
+            "但讀者是 `cortex-manager`（Manager ＋ monitor 同帳號、同 HOME）。\n"
+            "**為何必須存在**：Manager 也要對來源樹跑 git（provision 的 "
+            "`git branch -f`、成果回收的 `git fetch`、dispatch baseline 的 `rev-parse`），"
+            "而來源樹是由 root 建立、再 chown 給 `cortex-manager` 的——**chown 之前**或"
+            "任何 owner 不相符的中途狀態，git 一樣擋：\n"
+            "    fatal: detected dubious ownership in repository at '<來源樹>/<slug>'\n"
+            "owner 相符時這個檔是無害的冗餘；owner 不相符時它是「服務起得來但每一次 git "
+            "都失敗」與「正常運轉」的差別。缺這一份正是本票初版被實機複驗抓到的 blocking "
+            "缺口。\n"
+            "**writer 仍只有部署身分**：Manager 可寫的是**來源樹**，不是自己的 gitconfig"
+            "——`.gitconfig` 可指定 `core.fsmonitor`／`alias.*` 這類會執行外部命令的鍵，"
+            "讓 Manager 能改自己的 git 設定等於把 Tier-0 的執行面交還給它。"
         ),
     ),
     # ---- job-visible worktree 族 -------------------------------------------
@@ -357,6 +389,37 @@ ASSET_REGISTRY: tuple[TrustRootAsset, ...] = (
             "durable_state_owner、mode 0700，reviewer 僅獲 write-only ACL（寫得進自己"
             "那格、讀不到他人 verdict），**builder 不在 writer 面故零寫入**。dispatch 前"
             "該格必須不存在（pre-seed 守衛），Manager 落地後轉唯讀。"
+        ),
+    ),
+    TrustRootAsset(
+        "commit-spool", _T0, _JV,
+        "paulsha_cortex.config.paths:commit_spool_root",
+        (Principal.MANAGER, Principal.BUILDER), (Principal.MANAGER,),
+        IngressKind.INTERPROCESS,
+        derived_in=(
+            "config/paths.py:commit_spool_root",
+            "trust_root/permgen.py:PathLayout.commit_spool_root",
+        ),
+        note=(
+            "#623／#634 成果回收的 **bundle spool**：`<coordinator_root>/commit-spool/"
+            "<job-id>/`。形態**逐條比照 `review-verdict-spool`**——tree 分類 job-visible"
+            "（單向 spool 一律如此），permgen 產出的實質是 Manager-owned：容器 owner＝"
+            "durable_state_owner、mode 0700，producer 僅獲 **`wx` 無 `r`** 的 per-account "
+            "ACL（寫得進自己那格、讀不到他人的 bundle）；per-job 目錄由 Manager 在 dispatch "
+            "當下建立、落地後轉唯讀（pre-seed／seal 同一套語意）。\n"
+            "**為何需要這條通道**：#634 現行的回收是「Manager 伸手進 builder 的 clone "
+            "`fetch`」，那需要 (a) traverse 進 builder-owned 的 `0700` 樹——實測 "
+            "`Permission denied`；(b) 為**每個 job 路徑**加 `safe.directory`——而 git 2.43 "
+            "實測不吃路徑 glob，等於把 Manager 的 Tier-0 gitconfig 變成執行期可變狀態。"
+            "改走 bundle 之後 builder 在自己的 clone `git bundle create` 寫進本 spool，"
+            "Manager 從那個 **bundle 檔** fetch：Manager 全程不碰 builder 的樹，讀的是一個"
+            "**檔案**而非 repo，dubious-ownership 與 traverse 兩個問題同時消失。\n"
+            "**producer 只有 builder**：登記表裡唯一以 git commit 交付的 persona 就是它"
+            "（`repo-worktree` 的 writer 只有 BUILDER）；reviewer 的交付通道是 "
+            "`review-verdict-spool`、planner 的是 `dispatch-specs-tree`。多授一個 `wx` "
+            "ACL 給沒有 producer 的帳號，只是多開一條無人消費的寫入面。要納入時改登記表"
+            "並重跑產生器，不在此預留。\n"
+            "**本項只定義資產與權限**；bundle 的產生與消費在 coordinator 側，屬後續變更。"
         ),
     ),
     TrustRootAsset(
@@ -552,8 +615,10 @@ MUTATION_INGRESS: tuple[MutationIngress, ...] = (
                     "model-identity／combo／persona tool_allowlist_additions（只加不減、無上限）。"),
     MutationIngress("deployment-write", IngressKind.DEPLOYMENT_WRITE, False, True,
                     "unit／venv／launcher／sitecustomize／.pth／PATH／~/.codex/hooks.json；"
-                    "#623 起另含 per-job clone 的來源樹與 job 帳號 HOME 下的 root-owned "
-                    "`.gitconfig`——同一條性質：writer 只有部署身分，服務帳號一律唯讀。"),
+                    "#623 起另含**三份**帳號 HOME 下的 root-owned `.gitconfig`"
+                    "（builder／reviewer-planner／manager）——同一條性質：writer 只有部署"
+                    "身分，服務帳號對這些檔一律唯讀。來源樹本身**不在**此類（0817 裁決把"
+                    "它的 writer 改為 Manager，見 `repo-source-tree`）。"),
     MutationIngress("interprocess", IngressKind.INTERPROCESS, False, True,
                     "inherited FD／ptrace／/proc/<pid>/mem／signal。"),
 )

--- a/tests/test_trust_root_repo_source_tree_623.py
+++ b/tests/test_trust_root_repo_source_tree_623.py
@@ -1,0 +1,464 @@
+"""#623：per-job clone 的信任根層——來源樹資產 ＋ job 帳號的 root-owned `.gitconfig`。
+
+背景（#623 實測，已由 operator 裁決）：`git worktree` 的**共用 object store** 與三分
+隔離互斥——builder 要 commit 就得能寫 object store，能寫就等於邊界在 git 這一層漏掉。
+因此 job 工作區改為 **per-job 完整 clone**（0.5 秒／35MB），來源是一份 Manager-owned
+樹內的 **working checkout**（monitor 要掃工作樹裡的檔案，bare 沒有工作樹）。
+
+本檔釘住信任根層的四件事：
+
+1. `repo-source-tree` 在登記表裡，且**兩個 job 帳號唯讀**——計畫一個 `w` 都不給；
+2. 同一條唯讀也套在 **Manager／monitor** 身上（裁決：來源樹由 operator 以 root 更新，
+   攻擊面最小）——機械落點是 owner_class＝DEPLOYMENT，因此 unit 的 ReadWritePaths
+   （純由「誰可寫」導出）不會涵蓋它；
+3. traverse 鏈完整（沿用 #624 的 `unreachable_hops()`）——葉節點權限對 ≠ 路徑走得通；
+4. `.gitconfig` 是 root-owned、job 不可寫，且**內容**由 permgen 產生（比照 shim／
+   polkit），未宣告來源 repo 時 fail-closed。
+"""
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+from paulsha_cortex.trust_root import permgen, registry
+from paulsha_cortex.trust_root.__main__ import main
+from paulsha_cortex.trust_root.permgen import (
+    DEFAULT_LAYOUT,
+    OwnerClass,
+    PathLayout,
+    UnresolvedSourceRepoError,
+    account_can_reach,
+    build_job_gitconfig,
+    build_job_unit,
+    build_manager_unit,
+    build_monitor_unit,
+    generate_plan,
+    unreachable_hops,
+)
+from paulsha_cortex.trust_root.permgen import THREE_WAY_SCHEME as _THREE_WAY_BASE
+from paulsha_cortex.trust_root.permgen import TWO_WAY_SCHEME as _TWO_WAY_BASE
+from paulsha_cortex.trust_root.registry import (
+    AssetTier,
+    IngressKind,
+    Principal,
+    TrustTree,
+)
+
+#: #626：`operator`／`external` 是部署決定，模組層方案刻意留 `None`。要驗命令輸出的
+#: 測試一律用注入後的方案（fail-closed 本身由 #626 的專屬檔釘住）。
+DEPLOYMENT_ACCOUNTS = {
+    Principal.OPERATOR: "cortex-ops",
+    Principal.EXTERNAL: "cortex-outbox-reader",
+}
+TWO_WAY_SCHEME = _TWO_WAY_BASE.with_principal_accounts(DEPLOYMENT_ACCOUNTS)
+THREE_WAY_SCHEME = _THREE_WAY_BASE.with_principal_accounts(DEPLOYMENT_ACCOUNTS)
+ALL_SCHEMES = [TWO_WAY_SCHEME, THREE_WAY_SCHEME]
+
+SOURCE_SLUG = "paulsha-cortex"
+LAYOUT = DEFAULT_LAYOUT.with_source_repo_slugs((SOURCE_SLUG,))
+
+#: 跑模型的兩個 job persona——「兩個 job 帳號對來源樹唯讀」的驗收對象。
+JOB_PRINCIPALS = (Principal.BUILDER, Principal.REVIEWER, Principal.PLANNER)
+
+
+def _within(child: str, parent: str) -> bool:
+    return child == parent or child.startswith(parent.rstrip("/") + "/")
+
+
+# ---------------------------------------------------------------------------
+# 登記表：三項新資產的分類
+# ---------------------------------------------------------------------------
+
+def test_source_tree_is_registered_and_fully_classified() -> None:
+    asset = registry.asset_by_id("repo-source-tree")
+    assert asset.tier is AssetTier.TIER_0
+    assert asset.tree is TrustTree.MANAGER_OWNED
+    assert asset.ingress_kind is IngressKind.DEPLOYMENT_WRITE
+    # writer 只有部署身分：來源樹由 operator 以 root 更新（裁決）。
+    assert asset.writers == (Principal.INSTALLER,)
+    # reader 面要涵蓋 Manager（fetch／解析）、monitor（掃描）與三個 headless persona
+    # （clone 來源）——#624 的 traverse 鏈就是由 reader 宣告機械補出來的。
+    assert set(asset.readers) >= {Principal.MANAGER, Principal.MONITOR, *JOB_PRINCIPALS}
+    # 容器沒有 path_resolver：程式碼解析的是單一 repo（PSC_REPO_ROOT → <此樹>/<slug>）。
+    assert asset.path_resolver is None
+
+
+@pytest.mark.parametrize(
+    "asset_id, readers",
+    [
+        ("builder-gitconfig", {Principal.BUILDER}),
+        ("reviewer-planner-gitconfig", {Principal.REVIEWER, Principal.PLANNER}),
+    ],
+)
+def test_gitconfig_assets_mirror_the_codex_hooks_shape(asset_id, readers) -> None:
+    """比照既有的 `codex-hooks`：root-owned、落在 job 帳號 HOME 下、enforcement plane。"""
+    asset = registry.asset_by_id(asset_id)
+    hooks = registry.asset_by_id("codex-hooks")
+    assert asset.tier is hooks.tier is AssetTier.TIER_0
+    assert asset.tree is hooks.tree is TrustTree.MANAGER_OWNED
+    assert asset.ingress_kind is hooks.ingress_kind is IngressKind.DEPLOYMENT_WRITE
+    assert asset.writers == (Principal.INSTALLER,)
+    assert set(asset.readers) == readers
+
+
+def test_new_assets_introduce_no_new_deployment_decision() -> None:
+    """#626 的 fail-closed 面：新資產只用得到已可解析的 principal。
+
+    多一個沒對應的 principal 就會讓整個 `--commands` fail-closed；這條在登記表側先擋。
+    """
+    used: set[Principal] = set()
+    for asset_id in ("repo-source-tree", "builder-gitconfig", "reviewer-planner-gitconfig"):
+        asset = registry.asset_by_id(asset_id)
+        used.update(asset.writers)
+        used.update(asset.readers)
+    for principal in used:
+        assert THREE_WAY_SCHEME.resolve(principal) is not None, principal
+    assert THREE_WAY_SCHEME.unresolved_principals() == ()
+
+
+def test_layout_places_the_source_tree_in_the_durable_state_tree() -> None:
+    paths = DEFAULT_LAYOUT.asset_paths()
+    assert paths["repo-source-tree"] == "/var/lib/cortex/repos"
+    assert DEFAULT_LAYOUT.repo_source_root == "/var/lib/cortex/repos"
+    # 每個受治理 repo 一格；slug 是部署決定（見 gitconfig 那節）。
+    assert LAYOUT.source_repo_paths() == ("/var/lib/cortex/repos/paulsha-cortex",)
+    # `.gitconfig` 落在各自 HOME 下，與 `~/.codex` 同一層。
+    assert paths["builder-gitconfig"] == "/var/lib/cortex-builder/.gitconfig"
+    assert paths["reviewer-planner-gitconfig"] == (
+        "/var/lib/cortex-reviewer-planner/.gitconfig"
+    )
+
+
+def test_source_tree_paths_follow_a_relocated_layout() -> None:
+    """路徑由 `agents_root` 導出，不得寫死——換部署位置不必改產生器一行程式碼。"""
+    alt = PathLayout(agents_root="/srv/cx", worktree_root="/srv/cx/wt",
+                     deploy_root="/srv/deploy", instance="cx", home_root="/srv/accounts")
+    paths = alt.asset_paths()
+    assert paths["repo-source-tree"] == "/srv/cx/repos"
+    assert paths["builder-gitconfig"] == "/srv/accounts/cortex-builder/.gitconfig"
+    assert alt.with_source_repo_slugs(("x",)).source_repo_paths() == ("/srv/cx/repos/x",)
+
+
+def test_with_job_segment_preserves_the_new_layout_fields() -> None:
+    """job layout 是由 setup layout 換 segment 得來的——欄位不得在中途被重設。
+
+    逐欄位重建的舊寫法會讓每個新欄位都靜默掉回預設值，job unit 因此指到另一棵樹。
+    """
+    job_layout = LAYOUT.with_job_segment("%i")
+    assert job_layout.source_repo_slugs == LAYOUT.source_repo_slugs
+    assert job_layout.reviewer_planner_account == LAYOUT.reviewer_planner_account
+    assert job_layout.repo_source_root == LAYOUT.repo_source_root
+    assert job_layout.job_segment == "%i"
+
+
+# ---------------------------------------------------------------------------
+# 來源樹：兩個 job 帳號唯讀（本 PR 的核心驗收）
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
+def test_job_accounts_get_no_write_on_the_source_tree(scheme) -> None:
+    """驗收：產生的計畫不得給兩個 job 帳號 `w`——一個位元都不行。"""
+    plan = generate_plan(scheme)
+    entry = plan.by_id("repo-source-tree")
+    writable = plan.all_writable_accounts(entry)
+    for principal in JOB_PRINCIPALS:
+        account = scheme.resolve(principal)
+        assert account not in writable, (scheme.scheme_id, principal, sorted(writable))
+    # ACL 面也不得有任何授寫條目（跨帳號授權在此類一律唯讀）。
+    assert not [a for a in entry.acls if a.writable]
+    # group／other 無寫入位（spec §R2）。
+    assert not entry.mode & 0o022, entry.mode_str
+
+
+@pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
+def test_source_tree_is_root_owned_so_every_service_account_is_read_only(scheme) -> None:
+    """裁決：來源樹由 operator 以 root 更新、Manager 唯讀。
+
+    機械落點就是 owner_class＝DEPLOYMENT：ReadWritePaths 純由「誰可寫」導出，若 owner
+    是 `cortex-manager`，Manager unit 會**自動**拿到這棵樹的寫入權——「Manager 唯讀」
+    與「owner＝Manager」在本產生器裡互斥，取前者。
+    """
+    plan = generate_plan(scheme)
+    entry = plan.by_id("repo-source-tree")
+    assert entry.owner_class is OwnerClass.DEPLOYMENT
+    assert entry.owner == scheme.deploy_account == "root"
+    assert plan.all_writable_accounts(entry) == {"root"}
+    assert scheme.durable_state_owner not in plan.all_writable_accounts(entry)
+    assert entry.is_directory is True
+    assert entry.mode == 0o755
+
+
+@pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
+def test_manager_and_monitor_units_can_read_but_never_write_the_source_tree(scheme) -> None:
+    """`ProtectSystem=strict` 下唯讀是預設，因此「讀得到」不需要任何指令；
+
+    「寫不進去」則要求 ReadWritePaths **不涵蓋**它——這條就是取捨的可驗證形式。
+    """
+    source = DEFAULT_LAYOUT.asset_paths()["repo-source-tree"]
+    for unit in (build_manager_unit(scheme, DEFAULT_LAYOUT),
+                 build_monitor_unit(scheme, DEFAULT_LAYOUT)):
+        assert not any(_within(source, rwp) for rwp in unit.read_write_paths), (
+            scheme.scheme_id, unit.unit_name, unit.read_write_paths,
+        )
+        # 但兩份 unit 都必須說明「這棵樹在這裡是唯讀的」，否則下一個人會手加一條 RWP。
+        assert source in unit.content, unit.unit_name
+
+
+@pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
+def test_monitor_read_write_paths_stay_strictly_narrower_than_manager(scheme) -> None:
+    """#622 的不變式不得被本 PR 動到（新資產對兩者都不可寫 ⇒ 兩邊都不變）。"""
+    manager = set(build_manager_unit(scheme, DEFAULT_LAYOUT).read_write_paths)
+    monitor = set(build_monitor_unit(scheme, DEFAULT_LAYOUT).read_write_paths)
+    assert monitor < manager, (sorted(monitor), sorted(manager))
+
+
+@pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
+def test_job_template_unit_excludes_the_source_tree_but_keeps_its_own_clone(scheme) -> None:
+    """job 側：來源樹唯讀（不在 RWP），clone 落點 `<worktree>/%i` 在 RWP 內。"""
+    job_layout = DEFAULT_LAYOUT.with_job_segment("%i")
+    unit = build_job_unit(scheme, DEFAULT_LAYOUT)
+    source = job_layout.asset_paths()["repo-source-tree"]
+    clone = job_layout.asset_paths()["repo-worktree"]
+    assert not any(_within(source, rwp) for rwp in unit.read_write_paths), (
+        scheme.scheme_id, unit.read_write_paths,
+    )
+    assert any(_within(clone, rwp) for rwp in unit.read_write_paths), unit.read_write_paths
+    # 兩個 root-owned 設定檔（hooks／gitconfig）同樣不可寫。
+    for protected in (job_layout.gitconfig_of(unit.account),
+                      job_layout.codex_hooks_dir_of(unit.account)):
+        assert not any(_within(protected, rwp) for rwp in unit.read_write_paths), protected
+
+
+# ---------------------------------------------------------------------------
+# traverse 鏈（#624 的檢查沿用）
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
+def test_every_reader_can_actually_reach_the_source_tree(scheme) -> None:
+    """葉節點權限正確 ≠ 路徑走得通——每個 reader 的整條鏈都要通（#620／#624）。"""
+    plan = generate_plan(scheme)
+    readers = registry.asset_by_id("repo-source-tree").readers
+    accounts = {scheme.resolve(p) for p in readers} - {None}
+    assert accounts
+    for account in sorted(accounts):
+        blocked = unreachable_hops(
+            plan, scheme=scheme, account=account, asset_id="repo-source-tree"
+        )
+        assert blocked == (), (scheme.scheme_id, account, blocked)
+        assert account_can_reach(
+            plan, scheme=scheme, account=account, asset_id="repo-source-tree"
+        )
+
+
+@pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
+def test_source_tree_needs_no_traverse_acl_of_its_own(scheme) -> None:
+    """鏈通得靠 root-owned 0755，不是靠 ACL——因此不得產生任何指向來源樹的 ACL。
+
+    多產一條 `setfacl` 不會壞掉部署，但會讓「這棵樹是誰授權給誰」多一份真相。
+    """
+    plan = generate_plan(scheme)
+    source = DEFAULT_LAYOUT.asset_paths()["repo-source-tree"]
+    grants = permgen.derive_traverse_grants(plan, scheme=scheme)
+    assert source not in {g.path for g in grants}
+    assert plan.by_id("repo-source-tree").acls == ()
+
+
+@pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
+def test_job_accounts_can_reach_their_own_gitconfig(scheme) -> None:
+    plan = generate_plan(scheme)
+    for asset_id, principal in (
+        ("builder-gitconfig", Principal.BUILDER),
+        ("reviewer-planner-gitconfig", Principal.REVIEWER),
+    ):
+        entry = plan.by_id(asset_id)
+        assert entry.owner_class is OwnerClass.DEPLOYMENT
+        assert entry.owner == "root"
+        assert entry.is_directory is False
+        assert entry.mode == permgen.JOB_GITCONFIG_MODE == 0o644
+        assert plan.all_writable_accounts(entry) == {"root"}
+        assert scheme.resolve(principal) not in plan.all_writable_accounts(entry)
+
+
+def test_permission_commands_cover_the_new_assets() -> None:
+    """runbook 引用形式：三項新資產都出現在命令輸出，且輸出仍只有字串命令。"""
+    lines = permgen.plan_to_commands(
+        generate_plan(THREE_WAY_SCHEME), path_of=permgen.asset_paths(),
+        scheme=THREE_WAY_SCHEME,
+    )
+    joined = "\n".join(lines)
+    for asset_id in ("repo-source-tree", "builder-gitconfig", "reviewer-planner-gitconfig"):
+        assert asset_id in joined, asset_id
+    executable = [ln for ln in lines if ln.strip() and not ln.lstrip().startswith("#")]
+    assert "install -d /var/lib/cortex/repos" in executable
+    assert "chown root:root /var/lib/cortex/repos" in executable
+    assert "chmod 0755 /var/lib/cortex/repos" in executable
+    # 葉檔守衛：`.gitconfig` 在 setup 當下多半還沒落檔，不得讓 `sh -e` 中止整份 script。
+    assert (
+        "[ ! -e /var/lib/cortex-builder/.gitconfig ] || "
+        "chown root:root /var/lib/cortex-builder/.gitconfig"
+    ) in executable
+    # 自我檢查：輸出裡沒有任何未宣告的帳號名（#626 的不變式）。
+    assert permgen.unknown_accounts_in(lines, THREE_WAY_SCHEME) == ()
+
+
+# ---------------------------------------------------------------------------
+# `.gitconfig` 的內容產生（比照 shim／polkit：內容也由 permgen 出）
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "principal, asset_id",
+    [
+        (Principal.BUILDER, "builder-gitconfig"),
+        (Principal.REVIEWER, "reviewer-planner-gitconfig"),
+    ],
+)
+def test_gitconfig_content_is_generated_and_lands_on_the_registry_path(
+    principal, asset_id,
+) -> None:
+    """內容由產生器出，落點與登記表資產逐字對齊（三分＝定案方案）。"""
+    blob = build_job_gitconfig(THREE_WAY_SCHEME, LAYOUT, principal)
+    assert blob.install_path == LAYOUT.asset_paths()[asset_id]
+    assert blob.account == THREE_WAY_SCHEME.resolve(principal)
+    assert blob.owner == "root" and blob.group == "root"
+    assert blob.mode == 0o644
+    assert permgen.JOB_GITCONFIG_ASSETS[principal] == asset_id
+    # 內容：逐字的 safe.directory，指向來源樹底下那一格。
+    assert blob.safe_directories == ("/var/lib/cortex/repos/paulsha-cortex",)
+    assert "[safe]" in blob.content
+    assert "\tdirectory = /var/lib/cortex/repos/paulsha-cortex\n" in blob.content
+    # 安裝命令仍只是字串。
+    assert blob.commands() == [
+        f"chown root:root {blob.install_path}",
+        f"chmod 0644 {blob.install_path}",
+    ]
+
+
+def test_gitconfig_uses_literal_paths_not_a_wildcard() -> None:
+    """git 的 safe.directory 不吃目錄萬用字元（實測 git 2.43），字面 `*` 又等於
+
+    對該帳號整個關掉 dubious-ownership 保護——兩者都不得出現在產出裡。
+    """
+    content = build_job_gitconfig(THREE_WAY_SCHEME, LAYOUT).content
+    directives = [
+        ln.strip() for ln in content.splitlines()
+        if ln.strip().startswith("directory")
+    ]
+    assert directives == ["directory = /var/lib/cortex/repos/paulsha-cortex"]
+    for value in directives:
+        assert not value.endswith("*"), value
+
+
+def test_gitconfig_fails_closed_without_a_declared_source_repo() -> None:
+    """未宣告來源 repo 時一行都不產：空的 `[safe]` 段會讓每個 job 在 clone 才失敗。"""
+    with pytest.raises(UnresolvedSourceRepoError) as exc:
+        build_job_gitconfig(THREE_WAY_SCHEME, DEFAULT_LAYOUT)
+    message = str(exc.value)
+    assert "--source-repo" in message
+    assert "PSC_SOURCE_REPO_SLUGS" in message
+    assert DEFAULT_LAYOUT.repo_source_root in message
+
+
+@pytest.mark.parametrize("bad", ["../etc", "a b", "x;rm -rf /", "$(id -u)", ".hidden", ""])
+def test_source_repo_slugs_must_look_like_a_path_segment(bad) -> None:
+    """slug 會被逐字寫進 root 產生的檔案——形狀在產生階段就驗，不等到落檔。"""
+    with pytest.raises(ValueError):
+        DEFAULT_LAYOUT.with_source_repo_slugs((bad,))
+
+
+def test_multiple_source_repos_are_all_declared() -> None:
+    layout = DEFAULT_LAYOUT.with_source_repo_slugs(("alpha", "beta"))
+    blob = build_job_gitconfig(THREE_WAY_SCHEME, layout)
+    assert blob.safe_directories == (
+        "/var/lib/cortex/repos/alpha", "/var/lib/cortex/repos/beta",
+    )
+    assert blob.content.count("directory = ") == 2
+
+
+def test_gitconfig_is_deterministic_and_strings_only() -> None:
+    a = build_job_gitconfig(THREE_WAY_SCHEME, LAYOUT)
+    b = build_job_gitconfig(THREE_WAY_SCHEME, LAYOUT)
+    assert a.content == b.content
+    assert a.to_dict() == b.to_dict()
+    assert isinstance(a.content, str) and a.content
+
+
+def test_two_way_scheme_moves_the_gitconfig_off_the_registry_path() -> None:
+    """已記錄的不對稱：二分把 reviewer／planner 併進 Manager 帳號。
+
+    `asset_paths()` 刻意不吃 scheme（既有設計），取的是**定案的三分**帳號；二分是向後
+    相容選項，其 reviewer／planner 尚未經模板 unit 降權起 job，本資產不適用於那個形態。
+    builder 兩案相同，因此不受影響。
+    """
+    assert build_job_gitconfig(
+        TWO_WAY_SCHEME, LAYOUT, Principal.BUILDER
+    ).install_path == LAYOUT.asset_paths()["builder-gitconfig"]
+    two_way_rp = build_job_gitconfig(TWO_WAY_SCHEME, LAYOUT, Principal.REVIEWER)
+    assert two_way_rp.account == TWO_WAY_SCHEME.durable_state_owner
+    assert two_way_rp.install_path != LAYOUT.asset_paths()["reviewer-planner-gitconfig"]
+
+
+def test_generators_still_touch_no_filesystem() -> None:
+    """靜態保證：新增的 gitconfig 產生器仍不含任何 IO 或執行面。"""
+    src = inspect.getsource(permgen)
+    for forbidden in ("subprocess", "os.system", "os.chown", "os.chmod",
+                      "open(", "write_text", "shutil"):
+        assert forbidden not in src, forbidden
+
+
+# ---------------------------------------------------------------------------
+# CLI（runbook 的落檔來源）
+# ---------------------------------------------------------------------------
+
+def test_cli_emits_the_gitconfig(capsys: pytest.CaptureFixture[str]) -> None:
+    assert main(["gitconfig", "three-way", "--builder", "--source-repo", SOURCE_SLUG]) == 0
+    out = capsys.readouterr().out
+    assert out == build_job_gitconfig(
+        permgen.THREE_WAY_SCHEME, LAYOUT, Principal.BUILDER
+    ).content
+    assert "/var/lib/cortex-builder/.gitconfig" in out
+
+    assert main([
+        "gitconfig", "--reviewer-planner", f"--source-repo={SOURCE_SLUG}",
+    ]) == 0
+    assert "/var/lib/cortex-reviewer-planner/.gitconfig" in capsys.readouterr().out
+
+
+def test_cli_reads_slugs_from_env_when_no_flag_is_given(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("PSC_SOURCE_REPO_SLUGS", "alpha,beta")
+    assert main(["gitconfig", "three-way", "--builder"]) == 0
+    out = capsys.readouterr().out
+    assert "directory = /var/lib/cortex/repos/alpha" in out
+    assert "directory = /var/lib/cortex/repos/beta" in out
+
+
+def test_cli_flag_wins_over_env(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv("PSC_SOURCE_REPO_SLUGS", "from-env")
+    assert main(["gitconfig", "--source-repo", "from-flag"]) == 0
+    out = capsys.readouterr().out
+    assert "from-flag" in out
+    assert "from-env" not in out
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["gitconfig", "three-way", "--builder"],            # 未宣告來源 repo
+        ["gitconfig", "--source-repo"],                     # 旗標缺值
+        ["gitconfig", "--source-repo", "../etc"],           # slug 形狀不合法
+        ["gitconfig", "--nope"],                            # 未知旗標
+    ],
+)
+def test_cli_fail_closed_prints_nothing_to_stdout(
+    argv, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str],
+) -> None:
+    """重導成檔案時必須是**空檔**，而不是一份看起來裝好、實際擋掉所有 job 的設定。"""
+    monkeypatch.delenv("PSC_SOURCE_REPO_SLUGS", raising=False)
+    assert main(argv) == 2
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err.strip()

--- a/tests/test_trust_root_repo_source_tree_623.py
+++ b/tests/test_trust_root_repo_source_tree_623.py
@@ -1,19 +1,23 @@
-"""#623：per-job clone 的信任根層——來源樹資產 ＋ job 帳號的 root-owned `.gitconfig`。
+"""#623：per-job clone 的信任根層——來源樹、三份 root-owned `.gitconfig`、commit spool。
 
 背景（#623 實測，已由 operator 裁決）：`git worktree` 的**共用 object store** 與三分
 隔離互斥——builder 要 commit 就得能寫 object store，能寫就等於邊界在 git 這一層漏掉。
 因此 job 工作區改為 **per-job 完整 clone**（0.5 秒／35MB），來源是一份 Manager-owned
 樹內的 **working checkout**（monitor 要掃工作樹裡的檔案，bare 沒有工作樹）。
 
-本檔釘住信任根層的四件事：
+本檔釘住信任根層的五件事：
 
 1. `repo-source-tree` 在登記表裡，且**兩個 job 帳號唯讀**——計畫一個 `w` 都不給；
-2. 同一條唯讀也套在 **Manager／monitor** 身上（裁決：來源樹由 operator 以 root 更新，
-   攻擊面最小）——機械落點是 owner_class＝DEPLOYMENT，因此 unit 的 ReadWritePaths
-   （純由「誰可寫」導出）不會涵蓋它；
+2. 來源樹的 owner 是 **Manager**（0817 裁決推翻本票初版的 root-owned）：`git fetch`
+   必須把 `FETCH_HEAD` 寫進目標 repo，而成果回收正是 fetch 進來源樹——「Manager 唯讀」
+   與「Manager 回收成果」互斥。機械落點是 `owner_class=MANAGER_STATE`，因此 Manager
+   unit 的 ReadWritePaths 涵蓋它、monitor unit **不**涵蓋（persona 過濾，#622 不變式）；
 3. traverse 鏈完整（沿用 #624 的 `unreachable_hops()`）——葉節點權限對 ≠ 路徑走得通；
-4. `.gitconfig` 是 root-owned、job 不可寫，且**內容**由 permgen 產生（比照 shim／
-   polkit），未宣告來源 repo 時 fail-closed。
+4. **三份** `.gitconfig`（builder／reviewer-planner／**manager**）皆 root-owned、對應
+   帳號不可寫，內容由 permgen 產生，且每個來源 repo **兩條** `safe.directory`
+   （工作樹根 ＋ `<root>/.git`）——實測從非 bare 來源 clone 時 git 檢查的是後者；
+5. `commit-spool`（bundle 回收通道）形態逐條比照 `review-verdict-spool`：容器
+   Manager-owned 0700，producer 只拿 `wx` 無 `r` 的 ACL。
 """
 from __future__ import annotations
 
@@ -29,7 +33,7 @@ from paulsha_cortex.trust_root.permgen import (
     PathLayout,
     UnresolvedSourceRepoError,
     account_can_reach,
-    build_job_gitconfig,
+    build_account_gitconfig,
     build_job_unit,
     build_manager_unit,
     build_monitor_unit,
@@ -61,27 +65,46 @@ LAYOUT = DEFAULT_LAYOUT.with_source_repo_slugs((SOURCE_SLUG,))
 #: 跑模型的兩個 job persona——「兩個 job 帳號對來源樹唯讀」的驗收對象。
 JOB_PRINCIPALS = (Principal.BUILDER, Principal.REVIEWER, Principal.PLANNER)
 
+#: 本票落地的全部新資產（`test_new_assets_introduce_no_new_deployment_decision` 等共用）。
+NEW_ASSET_IDS = (
+    "repo-source-tree",
+    "builder-gitconfig",
+    "reviewer-planner-gitconfig",
+    "manager-gitconfig",
+    "commit-spool",
+)
+
+#: persona → 該 persona 那份 `.gitconfig` 的登記表 asset_id。
+GITCONFIG_CASES = (
+    (Principal.BUILDER, "builder-gitconfig"),
+    (Principal.REVIEWER, "reviewer-planner-gitconfig"),
+    (Principal.MANAGER, "manager-gitconfig"),
+)
+
 
 def _within(child: str, parent: str) -> bool:
     return child == parent or child.startswith(parent.rstrip("/") + "/")
 
 
 # ---------------------------------------------------------------------------
-# 登記表：三項新資產的分類
+# 登記表：新資產的分類
 # ---------------------------------------------------------------------------
 
 def test_source_tree_is_registered_and_fully_classified() -> None:
     asset = registry.asset_by_id("repo-source-tree")
     assert asset.tier is AssetTier.TIER_0
     assert asset.tree is TrustTree.MANAGER_OWNED
-    assert asset.ingress_kind is IngressKind.DEPLOYMENT_WRITE
-    # writer 只有部署身分：來源樹由 operator 以 root 更新（裁決）。
-    assert asset.writers == (Principal.INSTALLER,)
+    # 0817 裁決：writer 是 Manager（成果回收要 fetch 進來，fetch 必寫 FETCH_HEAD），
+    # 不再是部署身分——因此 ingress 也從 DEPLOYMENT_WRITE 改為 MANAGER_INTERNAL。
+    assert asset.ingress_kind is IngressKind.MANAGER_INTERNAL
+    assert asset.writers == (Principal.MANAGER,)
     # reader 面要涵蓋 Manager（fetch／解析）、monitor（掃描）與三個 headless persona
     # （clone 來源）——#624 的 traverse 鏈就是由 reader 宣告機械補出來的。
     assert set(asset.readers) >= {Principal.MANAGER, Principal.MONITOR, *JOB_PRINCIPALS}
     # 容器沒有 path_resolver：程式碼解析的是單一 repo（PSC_REPO_ROOT → <此樹>/<slug>）。
     assert asset.path_resolver is None
+    # headless 一律不在 writer 面——這條不因 owner 換人而鬆動。
+    assert not asset.headless_writable()
 
 
 @pytest.mark.parametrize(
@@ -89,10 +112,15 @@ def test_source_tree_is_registered_and_fully_classified() -> None:
     [
         ("builder-gitconfig", {Principal.BUILDER}),
         ("reviewer-planner-gitconfig", {Principal.REVIEWER, Principal.PLANNER}),
+        ("manager-gitconfig", {Principal.MANAGER, Principal.MONITOR}),
     ],
 )
 def test_gitconfig_assets_mirror_the_codex_hooks_shape(asset_id, readers) -> None:
-    """比照既有的 `codex-hooks`：root-owned、落在 job 帳號 HOME 下、enforcement plane。"""
+    """比照既有的 `codex-hooks`：root-owned、落在帳號 HOME 下、enforcement plane。
+
+    Manager 那份也在其中：Manager 可寫的是**來源樹**，不是自己的 git 設定——
+    `.gitconfig` 可指定 `core.fsmonitor`／`alias.*` 這類會執行外部命令的鍵。
+    """
     asset = registry.asset_by_id(asset_id)
     hooks = registry.asset_by_id("codex-hooks")
     assert asset.tier is hooks.tier is AssetTier.TIER_0
@@ -102,13 +130,44 @@ def test_gitconfig_assets_mirror_the_codex_hooks_shape(asset_id, readers) -> Non
     assert set(asset.readers) == readers
 
 
+def test_commit_spool_mirrors_the_review_verdict_spool_shape() -> None:
+    """bundle 回收通道與既有 verdict 通道**同構**——同一條政策，換一個 producer。"""
+    spool = registry.asset_by_id("commit-spool")
+    verdict = registry.asset_by_id("review-verdict-spool")
+    assert spool.tier is verdict.tier is AssetTier.TIER_0
+    assert spool.tree is verdict.tree is TrustTree.JOB_VISIBLE
+    assert spool.ingress_kind is verdict.ingress_kind is IngressKind.INTERPROCESS
+    assert spool.path_resolver == "paulsha_cortex.config.paths:commit_spool_root"
+    # producer 是 builder（下面那條測試論證為何不含 reviewer／planner）；consumer 是 Manager。
+    assert set(spool.writers) == {Principal.MANAGER, Principal.BUILDER}
+    assert set(spool.readers) == {Principal.MANAGER}
+    assert Principal.ANY_SAME_UID not in spool.writers
+
+
+def test_commit_spool_producer_is_exactly_the_committing_persona() -> None:
+    """producer 面由登記表導出，不是憑印象選的。
+
+    唯一以 git commit 交付的 persona 是 builder（`repo-worktree` 的 writer 只有它）；
+    reviewer 的交付通道是 `review-verdict-spool`、planner 的是 `dispatch-specs-tree`。
+    多授一個 `wx` 給沒有 producer 的帳號＝多開一條無人消費的寫入面。
+    """
+    spool = registry.asset_by_id("commit-spool")
+    worktree_writers = set(registry.asset_by_id("repo-worktree").writers)
+    assert worktree_writers == {Principal.BUILDER}
+    headless_producers = set(spool.writers) & registry.HEADLESS_PERSONAS
+    assert headless_producers == worktree_writers
+    # reviewer／planner 的交付通道各自存在，因此不需要（也不該）出現在本 spool。
+    assert Principal.REVIEWER in registry.asset_by_id("review-verdict-spool").writers
+    assert Principal.PLANNER in registry.asset_by_id("dispatch-specs-tree").writers
+
+
 def test_new_assets_introduce_no_new_deployment_decision() -> None:
     """#626 的 fail-closed 面：新資產只用得到已可解析的 principal。
 
     多一個沒對應的 principal 就會讓整個 `--commands` fail-closed；這條在登記表側先擋。
     """
     used: set[Principal] = set()
-    for asset_id in ("repo-source-tree", "builder-gitconfig", "reviewer-planner-gitconfig"):
+    for asset_id in NEW_ASSET_IDS:
         asset = registry.asset_by_id(asset_id)
         used.update(asset.writers)
         used.update(asset.readers)
@@ -123,11 +182,26 @@ def test_layout_places_the_source_tree_in_the_durable_state_tree() -> None:
     assert DEFAULT_LAYOUT.repo_source_root == "/var/lib/cortex/repos"
     # 每個受治理 repo 一格；slug 是部署決定（見 gitconfig 那節）。
     assert LAYOUT.source_repo_paths() == ("/var/lib/cortex/repos/paulsha-cortex",)
-    # `.gitconfig` 落在各自 HOME 下，與 `~/.codex` 同一層。
+    # 三份 `.gitconfig` 各落在自己帳號的 HOME 下，與 `~/.codex` 同一層。
     assert paths["builder-gitconfig"] == "/var/lib/cortex-builder/.gitconfig"
     assert paths["reviewer-planner-gitconfig"] == (
         "/var/lib/cortex-reviewer-planner/.gitconfig"
     )
+    assert paths["manager-gitconfig"] == "/var/lib/cortex-manager/.gitconfig"
+    # commit spool 與 verdict spool 同層（都掛在 coordinator 樹底下）。
+    assert paths["commit-spool"] == "/var/lib/cortex/coordinator/commit-spool"
+    assert DEFAULT_LAYOUT.commit_spool_root == paths["commit-spool"]
+
+
+def test_commit_spool_layout_matches_the_path_contract() -> None:
+    """`PathLayout` 與 `config.paths` 是成對契約——目錄名只有一份字面量。"""
+    from paulsha_cortex.config import paths as path_contract
+
+    assert path_contract.COMMIT_SPOOL_DIRNAME == "commit-spool"
+    assert DEFAULT_LAYOUT.commit_spool_root.endswith(
+        f"/{path_contract.COMMIT_SPOOL_DIRNAME}"
+    )
+    assert DEFAULT_LAYOUT.commit_spool_root.startswith(DEFAULT_LAYOUT.coordinator_root)
 
 
 def test_source_tree_paths_follow_a_relocated_layout() -> None:
@@ -137,6 +211,8 @@ def test_source_tree_paths_follow_a_relocated_layout() -> None:
     paths = alt.asset_paths()
     assert paths["repo-source-tree"] == "/srv/cx/repos"
     assert paths["builder-gitconfig"] == "/srv/accounts/cortex-builder/.gitconfig"
+    assert paths["manager-gitconfig"] == "/srv/accounts/cortex-manager/.gitconfig"
+    assert paths["commit-spool"] == "/srv/cx/coordinator/commit-spool"
     assert alt.with_source_repo_slugs(("x",)).source_repo_paths() == ("/srv/cx/repos/x",)
 
 
@@ -148,7 +224,9 @@ def test_with_job_segment_preserves_the_new_layout_fields() -> None:
     job_layout = LAYOUT.with_job_segment("%i")
     assert job_layout.source_repo_slugs == LAYOUT.source_repo_slugs
     assert job_layout.reviewer_planner_account == LAYOUT.reviewer_planner_account
+    assert job_layout.manager_account == LAYOUT.manager_account
     assert job_layout.repo_source_root == LAYOUT.repo_source_root
+    assert job_layout.commit_spool_root == LAYOUT.commit_spool_root
     assert job_layout.job_segment == "%i"
 
 
@@ -157,57 +235,97 @@ def test_with_job_segment_preserves_the_new_layout_fields() -> None:
 # ---------------------------------------------------------------------------
 
 @pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
-def test_job_accounts_get_no_write_on_the_source_tree(scheme) -> None:
-    """驗收：產生的計畫不得給兩個 job 帳號 `w`——一個位元都不行。"""
+def test_source_tree_grants_no_write_beyond_its_owner(scheme) -> None:
+    """驗收：可寫面**只有** owner——沒有任何授寫 ACL、group／other 零寫入位。
+
+    二分下 reviewer／planner 與 Manager 併帳（`cortex-svc`），因此那個方案裡「job 帳號
+    對來源樹唯讀」本來就不成立——這正是三分定案的理由之一，逐帳號的驗收放在下一條。
+    """
     plan = generate_plan(scheme)
     entry = plan.by_id("repo-source-tree")
-    writable = plan.all_writable_accounts(entry)
-    for principal in JOB_PRINCIPALS:
-        account = scheme.resolve(principal)
-        assert account not in writable, (scheme.scheme_id, principal, sorted(writable))
-    # ACL 面也不得有任何授寫條目（跨帳號授權在此類一律唯讀）。
+    assert plan.all_writable_accounts(entry) == {entry.owner}
+    # ACL 面不得有任何授寫條目（跨帳號授權在此類一律唯讀）。
     assert not [a for a in entry.acls if a.writable]
     # group／other 無寫入位（spec §R2）。
     assert not entry.mode & 0o022, entry.mode_str
 
 
-@pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
-def test_source_tree_is_root_owned_so_every_service_account_is_read_only(scheme) -> None:
-    """裁決：來源樹由 operator 以 root 更新、Manager 唯讀。
+def test_three_way_keeps_both_job_accounts_off_the_source_tree_write_face() -> None:
+    """定案方案的核心驗收：兩個 job 帳號對來源樹一個 `w` 都拿不到。"""
+    plan = generate_plan(THREE_WAY_SCHEME)
+    entry = plan.by_id("repo-source-tree")
+    writable = plan.all_writable_accounts(entry)
+    job_accounts = {THREE_WAY_SCHEME.resolve(p) for p in JOB_PRINCIPALS}
+    assert job_accounts == {"cortex-builder", "cortex-reviewer-planner"}
+    assert not (job_accounts & writable), (sorted(job_accounts), sorted(writable))
 
-    機械落點就是 owner_class＝DEPLOYMENT：ReadWritePaths 純由「誰可寫」導出，若 owner
-    是 `cortex-manager`，Manager unit 會**自動**拿到這棵樹的寫入權——「Manager 唯讀」
-    與「owner＝Manager」在本產生器裡互斥，取前者。
+
+@pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
+def test_source_tree_is_manager_owned_so_harvest_can_write_it(scheme) -> None:
+    """0817 裁決：來源樹的 owner 是 Manager，不是 root。
+
+    理由是實測——`git fetch` 必須把 `FETCH_HEAD` 寫進**目標 repo**，而成果回收正是
+    「fetch 進來源樹」；provision 那半邊的 `git branch -f` 也是對來源樹的寫入：
+
+        error: cannot open '.git/FETCH_HEAD': Permission denied
+
+    「Manager 唯讀」與「Manager 回收成果」互斥，取後者。機械落點就是
+    `owner_class=MANAGER_STATE`——ReadWritePaths 純由「誰可寫」導出，owner 換人的
+    同一刻 Manager unit 就拿到這棵樹的寫入權。
     """
     plan = generate_plan(scheme)
     entry = plan.by_id("repo-source-tree")
-    assert entry.owner_class is OwnerClass.DEPLOYMENT
-    assert entry.owner == scheme.deploy_account == "root"
-    assert plan.all_writable_accounts(entry) == {"root"}
-    assert scheme.durable_state_owner not in plan.all_writable_accounts(entry)
+    assert entry.owner_class is OwnerClass.MANAGER_STATE
+    assert entry.owner == scheme.durable_state_owner
+    assert plan.all_writable_accounts(entry) == {scheme.durable_state_owner}
     assert entry.is_directory is True
-    assert entry.mode == 0o755
+    # Manager-owned durable state 的基準：owner-only，跨帳號一律走精確唯讀 ACL。
+    assert entry.mode == 0o700
+    # deploy 帳號（root）不在可寫面裡——它在 OS 層本來就無所不能，登記表不為它發權限。
+    assert scheme.deploy_account not in plan.all_writable_accounts(entry) or (
+        scheme.deploy_account == scheme.durable_state_owner
+    )
 
 
 @pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
-def test_manager_and_monitor_units_can_read_but_never_write_the_source_tree(scheme) -> None:
-    """`ProtectSystem=strict` 下唯讀是預設，因此「讀得到」不需要任何指令；
+def test_job_accounts_get_read_only_acls_on_the_source_tree(scheme) -> None:
+    """兩個 job 帳號拿到的是 `rX`——讀得到 clone 來源，一個 `w` 都沒有。"""
+    plan = generate_plan(scheme)
+    entry = plan.by_id("repo-source-tree")
+    acl_by_account = {a.account: a.perms for a in entry.acls if not a.default}
+    for principal in JOB_PRINCIPALS:
+        account = scheme.resolve(principal)
+        if account == entry.owner:
+            continue  # 二分：reviewer／planner 與 Manager 併帳，owner 位已涵蓋
+        assert acl_by_account.get(account) == "rX", (scheme.scheme_id, account)
+    assert all("w" not in perms for perms in acl_by_account.values())
 
-    「寫不進去」則要求 ReadWritePaths **不涵蓋**它——這條就是取捨的可驗證形式。
+
+@pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
+def test_manager_unit_can_write_the_source_tree_but_monitor_cannot(scheme) -> None:
+    """Manager 需要寫（回收／provision）；monitor 只掃描，因此**不得**拿到寫入權。
+
+    兩者同帳號（`cortex-manager`），檔案層權限相同——差別完全由 monitor unit 的
+    persona 過濾產生（#622 建立的機制）。這條是那個機制第一次被「同一資產、兩種
+    persona 結論不同」直接驗到。
     """
     source = DEFAULT_LAYOUT.asset_paths()["repo-source-tree"]
-    for unit in (build_manager_unit(scheme, DEFAULT_LAYOUT),
-                 build_monitor_unit(scheme, DEFAULT_LAYOUT)):
-        assert not any(_within(source, rwp) for rwp in unit.read_write_paths), (
-            scheme.scheme_id, unit.unit_name, unit.read_write_paths,
-        )
-        # 但兩份 unit 都必須說明「這棵樹在這裡是唯讀的」，否則下一個人會手加一條 RWP。
+    manager = build_manager_unit(scheme, DEFAULT_LAYOUT)
+    monitor = build_monitor_unit(scheme, DEFAULT_LAYOUT)
+    assert any(_within(source, rwp) for rwp in manager.read_write_paths), (
+        scheme.scheme_id, manager.read_write_paths,
+    )
+    assert not any(_within(source, rwp) for rwp in monitor.read_write_paths), (
+        scheme.scheme_id, monitor.read_write_paths,
+    )
+    # 兩份 unit 都必須說明這棵樹在自己這側是什麼待遇，否則下一個人會手加一條 RWP。
+    for unit in (manager, monitor):
         assert source in unit.content, unit.unit_name
 
 
 @pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
 def test_monitor_read_write_paths_stay_strictly_narrower_than_manager(scheme) -> None:
-    """#622 的不變式不得被本 PR 動到（新資產對兩者都不可寫 ⇒ 兩邊都不變）。"""
+    """#622 的不變式不得被本 PR 動到——來源樹只進 Manager 那一側。"""
     manager = set(build_manager_unit(scheme, DEFAULT_LAYOUT).read_write_paths)
     monitor = set(build_monitor_unit(scheme, DEFAULT_LAYOUT).read_write_paths)
     assert monitor < manager, (sorted(monitor), sorted(manager))
@@ -228,6 +346,67 @@ def test_job_template_unit_excludes_the_source_tree_but_keeps_its_own_clone(sche
     for protected in (job_layout.gitconfig_of(unit.account),
                       job_layout.codex_hooks_dir_of(unit.account)):
         assert not any(_within(protected, rwp) for rwp in unit.read_write_paths), protected
+
+
+# ---------------------------------------------------------------------------
+# commit spool：`wx` 無 `r`（比照 review-verdict-spool 的既有測試）
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
+def test_commit_spool_container_is_manager_owned_and_owner_only(scheme) -> None:
+    plan = generate_plan(scheme)
+    entry = plan.by_id("commit-spool")
+    verdict = plan.by_id("review-verdict-spool")
+    assert entry.owner == verdict.owner == scheme.durable_state_owner
+    assert entry.owner_class is verdict.owner_class is OwnerClass.JOB
+    assert entry.mode == verdict.mode == 0o700
+    assert entry.is_directory is True
+
+
+@pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
+def test_commit_spool_grants_producer_write_only_never_read(scheme) -> None:
+    """單向語意：builder 寫得進自己那格，但讀不到別人的 bundle。"""
+    plan = generate_plan(scheme)
+    entry = plan.by_id("commit-spool")
+    builder = scheme.resolve(Principal.BUILDER)
+    assert builder in plan.all_writable_accounts(entry)
+    for acl in entry.acls:
+        assert "r" not in acl.perms, (scheme.scheme_id, acl.account, acl.perms)
+        assert acl.perms == "wx", (scheme.scheme_id, acl.account, acl.perms)
+
+
+def test_commit_spool_excludes_the_non_producing_personas() -> None:
+    """三分下 reviewer／planner 帳號在本 spool 上完全沒有權限。"""
+    plan = generate_plan(THREE_WAY_SCHEME)
+    entry = plan.by_id("commit-spool")
+    reviewer_planner = THREE_WAY_SCHEME.resolve(Principal.REVIEWER)
+    assert reviewer_planner not in plan.all_writable_accounts(entry)
+    assert reviewer_planner not in {a.account for a in entry.acls}
+
+
+@pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
+def test_builder_can_reach_the_commit_spool(scheme) -> None:
+    """葉節點 ACL 正確 ≠ 路徑走得通：整條鏈都要有 `--x`（#620／#624）。"""
+    plan = generate_plan(scheme)
+    builder = scheme.resolve(Principal.BUILDER)
+    assert unreachable_hops(
+        plan, scheme=scheme, account=builder, asset_id="commit-spool"
+    ) == ()
+    # 反向對照：拿掉導出的授權，coordinator 那一層就是斷的。
+    assert unreachable_hops(
+        plan, scheme=scheme, account=builder, asset_id="commit-spool", grants=()
+    ) == (DEFAULT_LAYOUT.coordinator_root,)
+
+
+@pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
+def test_builder_job_unit_can_write_the_commit_spool(scheme) -> None:
+    """回收通道要成立，builder 的模板 unit 必須寫得進 spool（RWP 機械導出）。"""
+    unit = build_job_unit(scheme, DEFAULT_LAYOUT)
+    spool = DEFAULT_LAYOUT.asset_paths()["commit-spool"]
+    assert any(_within(spool, rwp) for rwp in unit.read_write_paths), (
+        scheme.scheme_id, unit.read_write_paths,
+    )
+    assert spool in unit.content
 
 
 # ---------------------------------------------------------------------------
@@ -253,7 +432,7 @@ def test_every_reader_can_actually_reach_the_source_tree(scheme) -> None:
 
 @pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
 def test_source_tree_needs_no_traverse_acl_of_its_own(scheme) -> None:
-    """鏈通得靠 root-owned 0755，不是靠 ACL——因此不得產生任何指向來源樹的 ACL。
+    """父層是 root-owned 0755，因此不得產生任何指向來源樹**本身**的 traverse ACL。
 
     多產一條 `setfacl` 不會壞掉部署，但會讓「這棵樹是誰授權給誰」多一份真相。
     """
@@ -261,43 +440,54 @@ def test_source_tree_needs_no_traverse_acl_of_its_own(scheme) -> None:
     source = DEFAULT_LAYOUT.asset_paths()["repo-source-tree"]
     grants = permgen.derive_traverse_grants(plan, scheme=scheme)
     assert source not in {g.path for g in grants}
-    assert plan.by_id("repo-source-tree").acls == ()
 
 
 @pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
-def test_job_accounts_can_reach_their_own_gitconfig(scheme) -> None:
+def test_accounts_can_reach_their_own_gitconfig(scheme) -> None:
     plan = generate_plan(scheme)
-    for asset_id, principal in (
-        ("builder-gitconfig", Principal.BUILDER),
-        ("reviewer-planner-gitconfig", Principal.REVIEWER),
-    ):
+    for principal, asset_id in GITCONFIG_CASES:
         entry = plan.by_id(asset_id)
         assert entry.owner_class is OwnerClass.DEPLOYMENT
         assert entry.owner == "root"
         assert entry.is_directory is False
-        assert entry.mode == permgen.JOB_GITCONFIG_MODE == 0o644
+        assert entry.mode == permgen.ACCOUNT_GITCONFIG_MODE == 0o644
         assert plan.all_writable_accounts(entry) == {"root"}
         assert scheme.resolve(principal) not in plan.all_writable_accounts(entry)
 
 
 def test_permission_commands_cover_the_new_assets() -> None:
-    """runbook 引用形式：三項新資產都出現在命令輸出，且輸出仍只有字串命令。"""
+    """runbook 引用形式：新資產都出現在命令輸出，且輸出仍只有字串命令。"""
     lines = permgen.plan_to_commands(
         generate_plan(THREE_WAY_SCHEME), path_of=permgen.asset_paths(),
         scheme=THREE_WAY_SCHEME,
     )
     joined = "\n".join(lines)
-    for asset_id in ("repo-source-tree", "builder-gitconfig", "reviewer-planner-gitconfig"):
+    for asset_id in NEW_ASSET_IDS:
         assert asset_id in joined, asset_id
     executable = [ln for ln in lines if ln.strip() and not ln.lstrip().startswith("#")]
+    # 來源樹：Manager 擁有、owner-only，兩個 job 帳號各一條唯讀 ACL。
     assert "install -d /var/lib/cortex/repos" in executable
-    assert "chown root:root /var/lib/cortex/repos" in executable
-    assert "chmod 0755 /var/lib/cortex/repos" in executable
-    # 葉檔守衛：`.gitconfig` 在 setup 當下多半還沒落檔，不得讓 `sh -e` 中止整份 script。
+    assert "chown cortex-manager:cortex-manager /var/lib/cortex/repos" in executable
+    assert "chmod 0700 /var/lib/cortex/repos" in executable
+    assert "setfacl -m u:cortex-builder:rX /var/lib/cortex/repos" in executable
     assert (
-        "[ ! -e /var/lib/cortex-builder/.gitconfig ] || "
-        "chown root:root /var/lib/cortex-builder/.gitconfig"
-    ) in executable
+        "setfacl -m u:cortex-reviewer-planner:rX /var/lib/cortex/repos" in executable
+    )
+    # commit spool：`wx` 無 `r`，且只給 builder。
+    assert (
+        "setfacl -m u:cortex-builder:wx /var/lib/cortex/coordinator/commit-spool"
+        in executable
+    )
+    assert not [
+        ln for ln in executable
+        if "commit-spool" in ln and "cortex-reviewer-planner" in ln
+    ]
+    # 葉檔守衛：`.gitconfig` 在 setup 當下多半還沒落檔，不得讓 `sh -e` 中止整份 script。
+    for home in ("cortex-builder", "cortex-reviewer-planner", "cortex-manager"):
+        assert (
+            f"[ ! -e /var/lib/{home}/.gitconfig ] || "
+            f"chown root:root /var/lib/{home}/.gitconfig"
+        ) in executable
     # 自我檢查：輸出裡沒有任何未宣告的帳號名（#626 的不變式）。
     assert permgen.unknown_accounts_in(lines, THREE_WAY_SCHEME) == ()
 
@@ -306,27 +496,25 @@ def test_permission_commands_cover_the_new_assets() -> None:
 # `.gitconfig` 的內容產生（比照 shim／polkit：內容也由 permgen 出）
 # ---------------------------------------------------------------------------
 
-@pytest.mark.parametrize(
-    "principal, asset_id",
-    [
-        (Principal.BUILDER, "builder-gitconfig"),
-        (Principal.REVIEWER, "reviewer-planner-gitconfig"),
-    ],
-)
+@pytest.mark.parametrize("principal, asset_id", GITCONFIG_CASES)
 def test_gitconfig_content_is_generated_and_lands_on_the_registry_path(
     principal, asset_id,
 ) -> None:
     """內容由產生器出，落點與登記表資產逐字對齊（三分＝定案方案）。"""
-    blob = build_job_gitconfig(THREE_WAY_SCHEME, LAYOUT, principal)
+    blob = build_account_gitconfig(THREE_WAY_SCHEME, LAYOUT, principal)
     assert blob.install_path == LAYOUT.asset_paths()[asset_id]
     assert blob.account == THREE_WAY_SCHEME.resolve(principal)
     assert blob.owner == "root" and blob.group == "root"
     assert blob.mode == 0o644
-    assert permgen.JOB_GITCONFIG_ASSETS[principal] == asset_id
-    # 內容：逐字的 safe.directory，指向來源樹底下那一格。
-    assert blob.safe_directories == ("/var/lib/cortex/repos/paulsha-cortex",)
+    assert permgen.ACCOUNT_GITCONFIG_ASSETS[principal] == asset_id
+    # 內容：逐字的 safe.directory，**工作樹根 ＋ `<root>/.git` 兩條**。
+    assert blob.safe_directories == (
+        "/var/lib/cortex/repos/paulsha-cortex",
+        "/var/lib/cortex/repos/paulsha-cortex/.git",
+    )
     assert "[safe]" in blob.content
     assert "\tdirectory = /var/lib/cortex/repos/paulsha-cortex\n" in blob.content
+    assert "\tdirectory = /var/lib/cortex/repos/paulsha-cortex/.git\n" in blob.content
     # 安裝命令仍只是字串。
     assert blob.commands() == [
         f"chown root:root {blob.install_path}",
@@ -334,25 +522,61 @@ def test_gitconfig_content_is_generated_and_lands_on_the_registry_path(
     ]
 
 
+@pytest.mark.parametrize("principal, _asset_id", GITCONFIG_CASES)
+def test_gitconfig_covers_both_the_worktree_root_and_its_dot_git(
+    principal, _asset_id,
+) -> None:
+    """實測：從**非 bare** 來源 clone 時，git 檢查的是 `<repo>/.git` 而不是工作樹根。
+
+        fatal: detected dubious ownership in repository at
+               '/var/lib/cortex/repos/paulsha-cortex/.git'
+
+    而 `git -C <repo> rev-parse`／`fetch` 報的又是工作樹根。`safe.directory` 只認逐字
+    相等的值，因此兩個位置就是兩條——只給一條會讓另一半的操作在完全不同的時機才失敗。
+    """
+    blob = build_account_gitconfig(THREE_WAY_SCHEME, LAYOUT, principal)
+    values = [
+        ln.split("=", 1)[1].strip()
+        for ln in blob.content.splitlines()
+        if ln.strip().startswith("directory")
+    ]
+    for root in LAYOUT.source_repo_paths():
+        assert root in values, (principal, root, values)
+        assert f"{root}/.git" in values, (principal, root, values)
+    assert len(values) == 2 * len(LAYOUT.source_repo_paths())
+
+
+def test_layout_derives_both_safe_directory_entries() -> None:
+    """兩條值的推導在 layout，而不是散在三個產生器裡。"""
+    assert LAYOUT.source_repo_safe_directories() == (
+        "/var/lib/cortex/repos/paulsha-cortex",
+        "/var/lib/cortex/repos/paulsha-cortex/.git",
+    )
+    assert DEFAULT_LAYOUT.source_repo_safe_directories() == ()
+
+
 def test_gitconfig_uses_literal_paths_not_a_wildcard() -> None:
     """git 的 safe.directory 不吃目錄萬用字元（實測 git 2.43），字面 `*` 又等於
 
     對該帳號整個關掉 dubious-ownership 保護——兩者都不得出現在產出裡。
     """
-    content = build_job_gitconfig(THREE_WAY_SCHEME, LAYOUT).content
+    content = build_account_gitconfig(THREE_WAY_SCHEME, LAYOUT).content
     directives = [
         ln.strip() for ln in content.splitlines()
         if ln.strip().startswith("directory")
     ]
-    assert directives == ["directory = /var/lib/cortex/repos/paulsha-cortex"]
+    assert directives == [
+        "directory = /var/lib/cortex/repos/paulsha-cortex",
+        "directory = /var/lib/cortex/repos/paulsha-cortex/.git",
+    ]
     for value in directives:
         assert not value.endswith("*"), value
 
 
 def test_gitconfig_fails_closed_without_a_declared_source_repo() -> None:
-    """未宣告來源 repo 時一行都不產：空的 `[safe]` 段會讓每個 job 在 clone 才失敗。"""
+    """未宣告來源 repo 時一行都不產：空的 `[safe]` 段會讓每次 git 操作才失敗。"""
     with pytest.raises(UnresolvedSourceRepoError) as exc:
-        build_job_gitconfig(THREE_WAY_SCHEME, DEFAULT_LAYOUT)
+        build_account_gitconfig(THREE_WAY_SCHEME, DEFAULT_LAYOUT)
     message = str(exc.value)
     assert "--source-repo" in message
     assert "PSC_SOURCE_REPO_SLUGS" in message
@@ -368,34 +592,39 @@ def test_source_repo_slugs_must_look_like_a_path_segment(bad) -> None:
 
 def test_multiple_source_repos_are_all_declared() -> None:
     layout = DEFAULT_LAYOUT.with_source_repo_slugs(("alpha", "beta"))
-    blob = build_job_gitconfig(THREE_WAY_SCHEME, layout)
+    blob = build_account_gitconfig(THREE_WAY_SCHEME, layout)
     assert blob.safe_directories == (
-        "/var/lib/cortex/repos/alpha", "/var/lib/cortex/repos/beta",
+        "/var/lib/cortex/repos/alpha", "/var/lib/cortex/repos/alpha/.git",
+        "/var/lib/cortex/repos/beta", "/var/lib/cortex/repos/beta/.git",
     )
-    assert blob.content.count("directory = ") == 2
+    assert blob.content.count("directory = ") == 4
 
 
 def test_gitconfig_is_deterministic_and_strings_only() -> None:
-    a = build_job_gitconfig(THREE_WAY_SCHEME, LAYOUT)
-    b = build_job_gitconfig(THREE_WAY_SCHEME, LAYOUT)
+    a = build_account_gitconfig(THREE_WAY_SCHEME, LAYOUT)
+    b = build_account_gitconfig(THREE_WAY_SCHEME, LAYOUT)
     assert a.content == b.content
     assert a.to_dict() == b.to_dict()
     assert isinstance(a.content, str) and a.content
 
 
 def test_two_way_scheme_moves_the_gitconfig_off_the_registry_path() -> None:
-    """已記錄的不對稱：二分把 reviewer／planner 併進 Manager 帳號。
+    """已記錄的不對稱：二分把 reviewer／planner／Manager 併成同一個 `cortex-svc`。
 
     `asset_paths()` 刻意不吃 scheme（既有設計），取的是**定案的三分**帳號；二分是向後
     相容選項，其 reviewer／planner 尚未經模板 unit 降權起 job，本資產不適用於那個形態。
     builder 兩案相同，因此不受影響。
     """
-    assert build_job_gitconfig(
+    assert build_account_gitconfig(
         TWO_WAY_SCHEME, LAYOUT, Principal.BUILDER
     ).install_path == LAYOUT.asset_paths()["builder-gitconfig"]
-    two_way_rp = build_job_gitconfig(TWO_WAY_SCHEME, LAYOUT, Principal.REVIEWER)
-    assert two_way_rp.account == TWO_WAY_SCHEME.durable_state_owner
-    assert two_way_rp.install_path != LAYOUT.asset_paths()["reviewer-planner-gitconfig"]
+    for principal, asset_id in (
+        (Principal.REVIEWER, "reviewer-planner-gitconfig"),
+        (Principal.MANAGER, "manager-gitconfig"),
+    ):
+        two_way = build_account_gitconfig(TWO_WAY_SCHEME, LAYOUT, principal)
+        assert two_way.account == TWO_WAY_SCHEME.durable_state_owner
+        assert two_way.install_path != LAYOUT.asset_paths()[asset_id]
 
 
 def test_generators_still_touch_no_filesystem() -> None:
@@ -413,7 +642,7 @@ def test_generators_still_touch_no_filesystem() -> None:
 def test_cli_emits_the_gitconfig(capsys: pytest.CaptureFixture[str]) -> None:
     assert main(["gitconfig", "three-way", "--builder", "--source-repo", SOURCE_SLUG]) == 0
     out = capsys.readouterr().out
-    assert out == build_job_gitconfig(
+    assert out == build_account_gitconfig(
         permgen.THREE_WAY_SCHEME, LAYOUT, Principal.BUILDER
     ).content
     assert "/var/lib/cortex-builder/.gitconfig" in out
@@ -422,6 +651,17 @@ def test_cli_emits_the_gitconfig(capsys: pytest.CaptureFixture[str]) -> None:
         "gitconfig", "--reviewer-planner", f"--source-repo={SOURCE_SLUG}",
     ]) == 0
     assert "/var/lib/cortex-reviewer-planner/.gitconfig" in capsys.readouterr().out
+
+
+def test_cli_emits_the_manager_gitconfig(capsys: pytest.CaptureFixture[str]) -> None:
+    """本票初版缺的就是這一份——實機複驗時 Manager 的每一個 git 操作全部失效。"""
+    assert main(["gitconfig", "three-way", "--manager", "--source-repo", SOURCE_SLUG]) == 0
+    out = capsys.readouterr().out
+    assert out == build_account_gitconfig(
+        permgen.THREE_WAY_SCHEME, LAYOUT, Principal.MANAGER
+    ).content
+    assert "/var/lib/cortex-manager/.gitconfig" in out
+    assert out.count("directory = ") == 2
 
 
 def test_cli_reads_slugs_from_env_when_no_flag_is_given(
@@ -448,6 +688,7 @@ def test_cli_flag_wins_over_env(
     "argv",
     [
         ["gitconfig", "three-way", "--builder"],            # 未宣告來源 repo
+        ["gitconfig", "three-way", "--manager"],            # 同上，Manager 那份
         ["gitconfig", "--source-repo"],                     # 旗標缺值
         ["gitconfig", "--source-repo", "../etc"],           # slug 形狀不合法
         ["gitconfig", "--nope"],                            # 未知旗標
@@ -456,7 +697,7 @@ def test_cli_flag_wins_over_env(
 def test_cli_fail_closed_prints_nothing_to_stdout(
     argv, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str],
 ) -> None:
-    """重導成檔案時必須是**空檔**，而不是一份看起來裝好、實際擋掉所有 job 的設定。"""
+    """重導成檔案時必須是**空檔**，而不是一份看起來裝好、實際擋掉所有操作的設定。"""
     monkeypatch.delenv("PSC_SOURCE_REPO_SLUGS", raising=False)
     assert main(argv) == 2
     captured = capsys.readouterr()


### PR DESCRIPTION
#623 已由 operator 裁決把 job 工作區從 `git worktree` 改為 **per-job 完整 clone**（實測：共用 git object store 與三分隔離互斥——builder 要 commit 就得能寫 object store，而能寫就等於邊界在 git 這層漏掉）。#634 落地了 provisioning 層，本 PR 落地**信任根層**。

實機複驗（@paulc-arc 的 review）抓到初版三個缺口，operator 已就前兩項下裁決；本 PR 已全數處理。

## 1. `repo-source-tree` 的 owner：root → `cortex-manager`（**裁決已下**）

初版把 writer 定為只有 `Principal.INSTALLER`，機械分到 `owner_class=DEPLOYMENT`、`owner=root 0755`。這條**實測走不通**：

```
$ sudo -u cortex-manager git -C /var/lib/cortex/repos/paulsha-cortex fetch <bundle> …
error: cannot open '.git/FETCH_HEAD': Permission denied
```

`git fetch` 必須把 `FETCH_HEAD` 寫進**目標 repo**，而 #634 的成果回收正是「fetch 進來源樹」；provisioning 那半邊的 `git branch -f <branch> <base>`（`coordinator/seams.py`）同樣是對來源樹的寫入。**「Manager 唯讀」與「Manager 回收成果」互斥**，取後者。

改成 Manager 可寫後實測整條通（`fetch` 真實 rc=0），而**隔離沒有變弱**——兩個 job 帳號對來源樹仍 `Permission denied`（只有唯讀 ACL）。

**裁決理由**（已寫進資產 note、spec 與 changelog）：威脅模型裡不受信任的是 **job 帳號**；Manager 本來就擁有 gate ledger、evidence 樹與 `jobs.json`，Manager 被攻陷的話那些全都完了，多這一棵樹不改變攻擊面。root-owned 買到的是「防 Manager 被攻陷後污染下一輪 job 的原始碼」這條供應鏈保護，但它讓回收整個不成立——取回收。

機械落點：`writers=(MANAGER,)`、`ingress_kind=MANAGER_INTERNAL` → `owner_class=MANAGER_STATE`（`cortex-manager` 0700）＋兩個 job 帳號各一條 `rX` ACL。Manager unit 的 `ReadWritePaths` 因此**自動**多出 `/var/lib/cortex/repos`；monitor unit **沒有**（persona 過濾，#622），兩者同帳號但可寫面不同——這是 #622 那個機制第一次被「同一資產、兩種 persona 結論不同」直接驗到。

## 2. 新增 `manager-gitconfig` ＋ 三份 gitconfig 皆補第二條 `safe.directory`

Manager 也要對來源樹跑 git，同樣會撞 dubious ownership（實測 `fatal: detected dubious ownership`）。新增一份 root-owned 0644、落在 Manager HOME 下的 `.gitconfig`，與既有兩份**同構**（同一個產生器、同一條 `codex-hooks` 模式）。writer 仍只有部署身分：Manager 可寫的是**來源樹**，不是自己的 git 設定——`.gitconfig` 可指定 `core.fsmonitor`／`alias.*` 這類會執行外部命令的鍵。

**另一個實測細節**：從**非 bare** 來源 clone 時，git 檢查的是 `<repo>/.git` 而**不是**工作樹根——

```
fatal: detected dubious ownership in repository at '/var/lib/cortex/repos/paulsha-cortex/.git'
```

而 `git -C <repo> rev-parse`／`fetch` 報的又是工作樹根。`safe.directory` 只認逐字相等的值，因此每個來源 repo 必須有**兩條**。推導收在 `PathLayout.source_repo_safe_directories()`，三份 gitconfig 共用，並有測試釘住。

`build_job_gitconfig` 隨之更名 **`build_account_gitconfig`**（Manager 不是 job），CLI 新增 `--manager`；旗標→persona 由 `ACCOUNT_GITCONFIG_FLAGS` 一張表導出，之後再多一份不必改 CLI。

## 3. 新增 `commit-spool`（bundle 回收，**裁決已下**）

成果回收改走 **bundle ＋ append-only spool**，取代 #634 現行的「Manager 伸手進 builder 的 clone fetch」。後者需要 Manager (a) traverse 進 builder-owned 的 `0700` 樹——實測 `Permission denied`；(b) 為**每個 job 路徑**加 `safe.directory`——而 git 2.43 不吃路徑 glob，等於把 Manager 的 Tier-0 gitconfig 變成執行期可變狀態。

bundle 形態已整條實測過：builder 在自己的 clone `git bundle create` 寫進 Manager-owned spool → Manager 從那個 **bundle 檔** fetch。Manager 全程沒碰 builder 的樹（`ls` 仍 `Permission denied`），builder 也讀不到 spool 裡別人的東西。關鍵是 Manager 讀的是一個**檔案**而非 repo，dubious-ownership 與 traverse 兩個問題同時消失。

新資產 `commit-spool` 形態**完全比照 `review-verdict-spool`**：路徑 `<coordinator_root>/commit-spool/<job-id>/`、容器 owner=`cortex-manager` 0700、producer 以 **`wx` 無 `r`** 的 per-account ACL 授權、per-job 目錄由 Manager 在 dispatch 當下建立、落地後轉唯讀。另加 path resolver `config.paths:commit_spool_root()`（與 `review_verdict_spool_root()` 對稱，並讓登記表雙向等式維持綠）。

### producer 為何**不含** reviewer／planner

依登記表判斷：唯一以 git commit 交付的 persona 是 **builder**——`repo-worktree` 的 `writers` 只有 `BUILDER`。reviewer 的交付通道是 `review-verdict-spool`（它是那項的 writer），planner 的是 `dispatch-specs-tree`（同）。多授一個 `wx` ACL 給沒有 producer 的帳號，只是多開一條無人消費的寫入面。要納入時改登記表並重跑產生器，不在此預留。有測試把這條論證釘成不變式（`test_commit_spool_producer_is_exactly_the_committing_persona`）。

**本 PR 只定義資產與權限**；bundle 的產生／消費在 coordinator 側，屬後續變更（未動 `coordinator/`）。

## 驗證

- `trust_root equation`：**綠**（新增的 `commit_spool_root()` 已登記）
- 兩個 job 帳號對來源樹**唯讀**：計畫的可寫面只有 owner，ACL 面零授寫（`rX`）
- traverse 鏈完整（沿用 #624 的 `unreachable_hops()`）：來源樹每個 reader、以及 builder→`commit-spool` 皆 `()`；並有反向對照（拿掉導出授權即斷在 `coordinator/`）
- 三份 gitconfig 皆 root-owned 0644、對應帳號不可寫、內容含**兩條** `safe.directory`
- `commit-spool` 的 ACL 是 `wx` 無 `r`（比照 `review-verdict-spool` 的既有測試）
- monitor 的 RWP 仍**嚴格窄於** Manager（`monitor < manager`，#622 不變式）
- `permgen` 仍為純函式（`test_permgen_never_touches_the_filesystem`／`test_permgen_module_does_not_import_subprocess`／本檔的 `test_generators_still_touch_no_filesystem`）
- 全套 `pytest tests/ -q`：**3712 passed, 49 subtests**，零回歸
- 本機 `policy_check` 帶 PR 上下文（帶 `policy-exempt:issue-link`）

## 文件

- spec §R1 補兩段裁決（來源樹 owner 從 root 改為 Manager；回收走 bundle spool）
- runbook 第 2c 步改寫：來源樹 chown 給 `cortex-manager`、三份 `.gitconfig`、新增「Manager 寫得進去」與「commit spool `wx` 無 `r`」兩個驗證點（第 2 步 4 sudo／21 驗證，合計 45／161）

## 為何是 `Refs` 而非 `Closes`

#623 尚有其他缺口未解（`PSC_PREFLIGHT_CMD` 的落點未定、#629 的 gate 執行第三身分），本 PR 只關掉工作區模型這一塊。依白名單上 `policy-exempt:issue-link`。

Refs #623

## Checklist
- [x] `changelog.d/repo-source-tree-assets.md` fragment 已新增且已 commit
- [x] `CHANGELOG.md [Unreleased]` 有對應 entry
- [x] `VERSION` 與意圖一致（非 release PR，未動）
- [x] 測試通過（3712 passed）
- [x] `policy_check` 帶 PR 上下文跑過

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E7w9kaUxAzCCEk7piD5hfK
