### PR TITLE
feat(coordinator): 成果回收改為 git bundle ＋ append-only spool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -261,6 +261,32 @@
   `mock.patch.object` 打不到，測試實際驗到的是「本機有沒有那個帳號」而非它宣稱的分支。
 
 ### Changed
+- **#623 / trust-root Phase 2b：成果回收由「Manager 伸手進 builder 的 clone fetch」
+  改為 git bundle ＋ append-only spool**——#634 的回收做法
+  `git -C <來源樹> fetch <builder 的 clone>` 在三分下**行不通**（operator 0817 實機
+  驗證）：clone 是 builder-owned `0700`，Manager 直接 `cannot change to '…':
+  Permission denied`；而「對每個 job 的 clone 補 `safe.directory`」也不可行——實測
+  git 2.43 **不吃路徑 glob**，只認逐字相等或字面 `*`。改成 builder 在自己的 clone
+  產 bundle → 寫進 Manager-owned 的 append-only spool
+  （`<coordinator_root>/commit-spool/<job-id>/commits.bundle`，形態比照
+  `review-verdict-spool`：容器 `0700 cortex-manager`、producer 只獲 `wx` 無 `r` 的
+  per-account ACL、dispatch 當下 pre-seed、落地後 seal）→ Manager 從**那個檔案**
+  fetch。關鍵在 Manager 讀的是一個普通檔而不是一個 repo，dubious-ownership 與父鏈
+  traverse 兩個問題同時消失，回收全程**不存取 builder 的樹**（不變式測試以
+  `chmod 000` 釘住，並已做突變驗證）。bundle 在 wrapper 的模型 argv 之後、**exit
+  sentinel 之前**產生（sentinel 一出現 Manager 隨時可能開始回收），並以
+  `exit "$rc"` 還原模型的 exit code（降權模式下 unit 的 exit code 就是它，#604）。
+  `^<base>` 取自 provisioning 在 clone 內 pin 的 `refs/cortex/base`＝來源 repo 自己
+  `rev-parse --verify` 出來的 `exact_base`，因此「來源樹一定有 prerequisite」由單一
+  推導點對每條 lane 成立。bundle 缺席／prerequisite 缺席／帶錯 branch／非
+  fast-forward 四類全部 fail-closed 且訊息可操作（git 原文＋該怎麼辦）。bundle 成功
+  回收後保留並封存，取代 `refs/cortex/reclaimed/**` 對 clone 形狀的證據角色（該機制
+  本身也要 `git -C <clone>`，三分下同樣不可行）。`direct` 模式沿用 #634「以形狀判斷、
+  不依 `PSC_JOB_RUNNER` 分支」的原則，`commit_bundle=None` 時 wrapper 輸出逐字不變。
+  登記表資產與 OS 權限由 #636（已 merge）在 `trust_root/` 定義，路徑契約的權威
+  resolver 是 `config/paths.py:commit_spool_root()`；本次只做 coordinator 側。
+  新增 `tests/test_bundle_commit_harvest_623.py`（30 測試）。
+  詳見 `changelog.d/bundle-harvest.md`。
 - **#623 / trust-root Phase 2b：job 工作區模型由 `git worktree` 改為 per-job 完整
   clone——provisioning、成果回收與回收層**——M1（#584）之後 builder 以
   `cortex-builder`、Manager 以 `cortex-manager` 執行，實測顯示 `git worktree` 在三分

--- a/changelog.d/bundle-harvest.md
+++ b/changelog.d/bundle-harvest.md
@@ -1,0 +1,101 @@
+### Changed
+- **#623 / trust-root Phase 2b：成果回收由「Manager 伸手進 builder 的 clone fetch」
+  改為 **git bundle ＋ append-only spool**（coordinator 側）**（Refs #623）
+
+  **為什麼非改不可**：#634 落地的回收做法是
+  `git -C <來源樹> fetch --no-tags <builder 的 clone> refs/heads/<b>:refs/heads/<b>`。
+  operator 0817 實機驗證它在三分下**行不通**，兩個獨立原因：
+
+  1. **Manager 走不進 builder 的樹**——job 的 clone 是 builder-owned `0700`，
+     `git -C <clone> …` 直接 `fatal: cannot change to '…': Permission denied`。
+  2. **per-job 路徑無法用一條設定涵蓋**——就算補了父鏈 traverse，Manager 對每個 job
+     的 clone 還需要跨擁有者的 `safe.directory`，而實測 git 2.43 **不吃路徑 glob**，
+     只認逐字相等或字面 `*`。
+
+  **改法**：builder 在自己的 clone 產出 bundle → 寫進 Manager-owned 的 append-only
+  spool → Manager 從**那個檔案** fetch。關鍵在 Manager 讀的是一個**普通檔**而不是一個
+  repo：dubious-ownership 與 traverse 兩個問題同時消失，且 Manager 全程不需要（也不
+  應該）存取 builder 的樹。operator 實機驗證：回收 `rc=0`、commit 與 diff 都正確落地，
+  期間 `ls <clone>` 仍 `Permission denied`；builder 也讀不到 spool 裡別人的東西。
+
+  **路徑契約**：`<coordinator_root>/commit-spool/<job-id>/commits.bundle`，形態完全
+  比照既有的 `review-verdict-spool`——容器 owner＝`cortex-manager` 0700、producer 以
+  **`wx` 無 `r`** 的 per-account ACL、per-job 目錄由 Manager 在 dispatch 當下建立
+  （`prepare_commit_spool`）、成果落地後轉唯讀（`seal_commit_spool` 把目錄收成
+  `0500`——bundle 是 builder-owned，Manager `chmod` 不了它，但它是目錄的 owner，
+  收掉 `w` 之後那一格就定版，POSIX ACL 的 mask 也一併收窄）。登記表資產與 OS 權限由
+  #636（已 merge）在 `trust_root/` 定義，路徑契約的權威 resolver 是
+  `config/paths.py:commit_spool_root()`；本 PR 只做 coordinator 側，
+  `job_workspace.commit_spool_root()` 逐字委派給它，只多接受一個**顯式**的
+  coordinator root（`manager` 與 `verification` 都有這個參數，一律回頭讀 env 會讓
+  同一個 job 的 dispatch 與 harvest 指到兩棵不同的樹）。
+
+  **bundle 不是證據，是搬運**：#628 把 gate ledger 與 exit sentinel 的作者收斂到
+  Manager，理由是「被驗方不得在自己的進程裡產生自己的驗收證據」。bundle 不適用那條
+  ——它不宣告任何結論，只把 commit 從一個 object store 搬到另一個。採信仍全由 Manager
+  判斷：canonical lane 的回收掛在 `_verify_build_candidate_transition` **之後**，且回收
+  後來源樹的 branch **必須恰等於已採信的 candidate**，對不上即 fail-closed（沿用 #540
+  的 acceptance chain）。bundle 內容由 builder 掌控因此不新增任何採信面，它能造成的
+  最壞情況就是讓回收失敗。
+
+  **bundle 在哪個時點產生**：Manager 組出的 wrapper script 裡，模型 argv 之後、**exit
+  sentinel 之前**（`launcher.build_wrapper_script` 的 `commit_bundle=`）。段序是
+  模型 → 存 `$?` → bundle → sentinel → gate → `exit "$rc"`。兩個理由：sentinel 一出現
+  Manager 隨時可能在下一個 tick 開始回收，bundle 必須先落地；而降權模式下 unit 的
+  exit code 就是這支 script 的 exit code（#604 的記帳 shell 記的正是它），多接一段
+  之後若不還原 `$?`，模型的成敗會被 bundle 步驟污染。bundle 段用 `git` 而不是像 gate
+  那樣呼叫 python module——降權模式下 builder 未必讀得到 Manager 的 repo root
+  （`ProtectHome=yes` 之後 `/home` 整個不可見），`PYTHONPATH=<repo>` 那條路在那裡不
+  成立。`.part` → `chmod 0644` → `mv` 三步以 `&&` 串接：spool 裡看得見的
+  `commits.bundle` 恆為完整檔，而 `chmod` 讓降權 unit 常見的 `UMask=0077` 不會產生一份
+  Manager 讀不到的成果。
+
+  **`^<base>` 怎麼推導**：provisioning（`seams.ScriptWorktreeCreator`）在 clone 內
+  `update-ref refs/cortex/base <exact_base>`，wrapper 以 `^refs/cortex/base` 收斂 bundle
+  範圍。`exact_base` 是**來源 repo 自己** `rev-parse --verify` 出來的 commit，因此
+  「來源樹一定有 bundle 的 prerequisite」這條性質由 provisioning 這個**單一推導點**對
+  每一條 lane 一致成立（lane 之間唯一的差別是傳給 `create()` 的 `base_sha`，而它在同
+  一個函式裡被同一次 `rev-parse --verify` 收斂）。base pin 放在 clone 內而不是寫死在
+  wrapper 裡，是因為產 bundle 的是 builder：它讀得到自己的 clone，卻讀不到 spool
+  （ACL 是 `wx` 無 `r`）也讀不到 Manager 的任何狀態。
+
+  **不完整 bundle 的處理**：`git fetch` 對缺 prerequisite 的 bundle 只吐
+  `error: Repository lacks these prerequisite commits:` 加一串裸 SHA，看不出下一步。
+  `harvest_branch()` 因此逐類包一層可操作說明——bundle 缺席（列出兩種成因與該去哪看
+  逐字原因）、prerequisite 缺席（指出處置是**重新 provision**，而不是放寬 refspec）、
+  bundle 帶的是別的 branch（指出用 `git bundle list-heads` 確認，不得改用其他 ref
+  回收）、非 fast-forward（訊息逐字保留）。四類全部 fail-closed，沒有任何一條退回讀
+  clone。
+
+  **bundle 的保留策略**：成功回收後**保留並封存**，不刪除。#634 加的
+  `refs/cortex/reclaimed/**` 封存機制是為了讓 `rmtree` 掉 clone 時不銷毀未回收的
+  commit，而它的實作本身要 `git -C <clone>` ——在三分下同樣不可行。bundle 正是那個
+  機制的替代品：它是那些 commit 在 Manager-owned 樹裡的副本，且取得它完全不需要碰
+  builder 的樹。`archive_workspace_head()` 因此原地保留給升級前既存的 linked
+  worktree，clone 形狀改以 bundle 為證據面。（把 `worktree_reclaim` 也改成優先讀
+  bundle 需要「工作區路徑 ↔ job id」的對應，目前不存在，列為後續票。）
+
+  **spool key 的推導只有一條規則**：`Path(job["log_path"]).stem` ——那正是
+  `launcher.launch()` 收到的 `slice_id`，同時決定 exit sentinel 與 gate ledger 的落點。
+  canonical lane 的 launch key 是 job_id、slice lane 的是 slice_id，兩條 lane 若各自
+  在回收端猜自己的 key，任何一邊改名都會退化成「找不到 spool → 靜默不回收」——最壞的
+  失敗形態。同理，「這個 job 要不要回收」的判準改為 **Manager-owned spool 那一格在
+  不在**，不再是「工作區是不是 clone」：後者要讀 `<clone>/.git/` 底下的標記檔，三分下
+  Manager 讀不到、判準恆為 False。`job_workspace` 的形狀判定同時收斂了
+  `PermissionError`（回 False 而不是讓一個 tick 整個掛掉）。
+
+  **`direct` 模式相容性**：沿用 #634「以工作區自己的形狀判斷、不依 `PSC_JOB_RUNNER`
+  分支」的原則——spool 授權在 dispatch 當下決定，兩種模式走完全相同的路徑。判準是
+  **persona**（reviewer／planner 不產生 commit，不給 spool），與 `_should_run_gates`／
+  `_downgraded_mode` 既有的 persona 分支對齊。`commit_bundle=None` 時
+  `build_wrapper_script` 的輸出**逐字**與改動前相同。
+
+  新增 `tests/test_bundle_commit_harvest_623.py`（30 測試，全部以真 git repo 驗證）：
+  base 錨點單一推導、bundle 產生→回收→內容正確、**不變式**（把 clone `chmod 000`
+  重現實機的 `Permission denied`，整條回收路徑照常完成——已做突變驗證：在回收路徑裡
+  加一次 clone 存取，這條當場紅）、四類 fail-closed 與訊息可操作、spool 的 pre-seed
+  與 seal、wrapper 段序與 exit code（真的跑一次 bash）、降權形狀、`direct` 零回歸。
+  另修正三個 trust-root launch 測試檔：它們以 `clear=True` 重建 environ、把 conftest
+  的 `PSC_AGENTS_ROOT` 保護一併清掉，因此顯式帶上 per-process 暫存根（否則 launch 會
+  在 operator 的真實 `$HOME` 底下建 spool——正是 conftest #303 註記要防的事）。全套
+  `python3 -m pytest tests/ -q`：3674 passed，零回歸。

--- a/paulsha_cortex/coordinator/job_workspace.py
+++ b/paulsha_cortex/coordinator/job_workspace.py
@@ -30,12 +30,47 @@ per-job 完整 clone 沒有這個問題：clone 有**自己的** object store，
 
 ## 方向性（D2「git 讀」）
 
-成果回收一律是 **Manager 拉**（`git -C <來源 repo> fetch <clone>`），**不是 builder
-推**。builder 永遠不 push 進 Manager 的樹；clone 完成後指向來源 repo 的暫時 remote
-會被移除（見 :data:`SOURCE_REMOTE`），工作區裡不留任何回寫路徑。
+成果回收一律是 **Manager 拉**，**不是 builder 推**。builder 永遠不 push 進 Manager
+的樹；clone 完成後指向來源 repo 的暫時 remote 會被移除（見 :data:`SOURCE_REMOTE`），
+工作區裡不留任何回寫路徑。
 
 fetch 的 refspec 刻意**不帶 `+`**：非 fast-forward 一律被 git 拒絕，Manager 不會靜默
 吸收被改寫過的歷史。
+
+## 成果回收為什麼是 bundle ＋ append-only spool，而不是「對 clone fetch」
+
+`git -C <來源樹> fetch <builder 的 clone>` 在 Phase 2b 三分下**結構性不成立**，
+兩個獨立原因（operator 0817 實機驗證）：
+
+1. **Manager 走不進 builder 的樹**——clone 是 builder-owned `0700`，
+   `git -C <clone> …` 直接 `fatal: cannot change to '…': Permission denied`。
+2. **per-job 路徑無法用一條設定涵蓋**——就算補了 traverse，Manager 對每個 job 的
+   clone 還需要跨擁有者的 `safe.directory`，而實測 git 2.43 **不吃路徑 glob**，
+   只認逐字相等或字面 `*`。
+
+改成 builder 在自己的 clone 產出 bundle → 寫進 Manager-owned 的 append-only spool
+（:func:`commit_spool_root`）→ Manager 從**那個檔案** fetch：
+
+```
+# builder 身分（wrapper script，見 build_bundle_command）
+git -C <clone> bundle create <spool>/<key>/commits.bundle <branch> ^refs/cortex/base
+
+# Manager 身分
+git -C <來源樹> fetch --no-tags <spool>/<key>/commits.bundle <branch>:<branch>
+```
+
+關鍵在 Manager 讀的是一個**普通檔**而不是一個 repo——dubious-ownership 與 traverse
+兩個問題同時消失，且 Manager **全程不需要、也不應該**存取 builder 的樹。
+
+## bundle 不是證據，是搬運
+
+#628 已把 gate ledger 與 exit sentinel 的作者收斂到 Manager，理由是「被驗方不得在
+自己的進程裡產生自己的驗收證據」。bundle **不適用**那條：它不宣告任何結論，只把
+commit 從一個 object store 搬到另一個。採信與否仍全部由 Manager 判斷——canonical
+lane 在 `_verify_build_candidate_transition` 之後才回收，且回收後來源樹的 branch
+**必須恰等於已採信的 candidate**，對不上即 fail-closed（沿用 #540 的 acceptance
+chain：model 既不能自證成功、也不能自證失敗）。bundle 內容由 builder 掌控這件事
+因此不新增任何採信面：它能做到的最壞情況就是讓回收失敗。
 """
 
 from __future__ import annotations
@@ -43,11 +78,14 @@ from __future__ import annotations
 import json
 import os
 import re
+import shlex
 import shutil
 import subprocess
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, Mapping
+
+from paulsha_cortex.config import paths
 
 #: clone 工作區的識別標記檔名，寫在 clone 自己的 `.git/` 底下。
 #:
@@ -75,7 +113,32 @@ SOURCE_REMOTE = "cortex-source"
 #: 命名空間（不是 branch、不是 tag：不佔用 branch 名，`git push` 預設也不會帶出去）。
 ARCHIVE_REF_PREFIX = "refs/cortex/reclaimed"
 
+#: provision 當下寫進 clone 的 base pin，bundle 以 `^<此 ref>` 收斂範圍。
+#:
+#: 為什麼要一個 ref、而不是把 base 寫死在 wrapper 裡：**產 bundle 的是 builder**，
+#: 它讀得到自己的 clone，卻讀不到 spool（per-account ACL 是 `wx` 無 `r`），也讀不到
+#: Manager 的任何狀態。base 因此必須落在 clone 內部。它與標記檔的 `base` 欄同源
+#: （都取自 `seams` 解出的 `exact_base`），而 `exact_base` 是**來源 repo 自己**
+#: `rev-parse --verify` 出來的 commit——所以「來源樹一定有 bundle 的 prerequisite」
+#: 這條性質在**每一條 lane** 都由 provisioning 單一推導點保證。
+#:
+#: builder 動得了這個 ref（它是自己 clone 裡的一筆），但動了的後果只有一種：bundle
+#: 產不出來、或 prerequisite 對不上而 fetch 失敗——一律 fail-closed，見
+#: :func:`harvest_branch` 的錯誤分類。
+BASE_REF = "refs/cortex/base"
+
+#: per-job spool 裡那一份 bundle 的檔名。
+COMMIT_BUNDLE_FILENAME = "commits.bundle"
+
+#: builder 產 bundle 時的暫存名。先寫 `<name>.part`、`chmod` 後 `mv` 成正式名，
+#: 讓 spool 裡「存在」的那個檔恆為完整檔——中途被 kill 只會留下 `.part`。
+COMMIT_BUNDLE_PART_SUFFIX = ".part"
+
 _SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+
+#: spool 的 per-job 目錄名（與 `coordinator/review.py` 的 `SAFE_SPOOL_KEY_RE` 同形）。
+#: 這個字串會成為 Manager-owned 樹裡的一個目錄名，形狀守衛不得放寬。
+_SPOOL_KEY_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]{0,127}")
 
 
 class WorkspaceError(ValueError):
@@ -123,8 +186,22 @@ def is_job_clone(workspace: str | Path) -> bool:
     這種寬鬆判準（見 `worktree_reclaim` 的安全閘與 #478 現場）。
     """
 
-    marker = marker_path(workspace)
-    return marker.is_file() and not marker.is_symlink()
+    return _is_regular_file(marker_path(workspace))
+
+
+def _is_regular_file(path: Path) -> bool:
+    """`path` 是不是一個**可 stat 的普通檔**；不可讀（含整棵樹不可進入）時回 False。
+
+    三分部署下 Manager 對 builder-owned `0700` 的 clone 連 `stat` 都會拿到
+    `PermissionError`。那個例外必須在這裡收斂成 False，而不是往上炸——所有呼叫端
+    （`gc` 的掃描、`worktree_reclaim` 的安全閘）在「認不出這是什麼」時的正確行為
+    都是**不動它**，而不是讓一個 tick 整個掛掉。
+    """
+
+    try:
+        return path.is_file() and not path.is_symlink()
+    except OSError:
+        return False
 
 
 def is_linked_worktree(workspace: str | Path) -> bool:
@@ -134,13 +211,12 @@ def is_linked_worktree(workspace: str | Path) -> bool:
     回收——`gc` 與 `worktree_reclaim` 因此同時認得兩種形狀。
     """
 
-    marker = Path(workspace) / ".git"
-    return marker.is_file() and not marker.is_symlink()
+    return _is_regular_file(Path(workspace) / ".git")
 
 
 def read_marker(workspace: str | Path) -> dict[str, Any] | None:
     path = marker_path(workspace)
-    if not path.is_file() or path.is_symlink():
+    if not _is_regular_file(path):
         return None
     try:
         payload = json.loads(path.read_text(encoding="utf-8"))
@@ -206,32 +282,259 @@ def workspace_branch(workspace: str | Path) -> str | None:
 
 
 # ---------------------------------------------------------------------------
+# 成果 spool（Manager-owned、append-only、per-job 一格）
+# ---------------------------------------------------------------------------
+
+def commit_spool_root(coordinator_root: str | Path | None = None) -> Path:
+    """成果 bundle spool 的根：`<coordinator_root>/commit-spool/`。
+
+    路徑契約的權威是 `config/paths.py:commit_spool_root()`（登記表資產
+    `commit-spool`，#636）。本函式只多一件事：接受**顯式**的 coordinator root。
+    回收與 dispatch 兩端都可能拿到呼叫端傳下來的 root（`manager` 與
+    `verification` 都有這個參數），不能一律回頭讀 env——那會讓同一個 job 的
+    dispatch 與 harvest 指到兩個不同的樹。未指定時逐字委派給 `paths`。
+    """
+
+    if coordinator_root is None:
+        return paths.commit_spool_root()
+    return Path(coordinator_root) / paths.COMMIT_SPOOL_DIRNAME
+
+
+def commit_spool_dir(
+    *,
+    spool_key: str,
+    coordinator_root: str | Path | None = None,
+) -> Path:
+    """單一 job 的 spool 目錄（唯一定址點）。"""
+
+    if not isinstance(spool_key, str) or _SPOOL_KEY_RE.fullmatch(spool_key) is None:
+        raise WorkspaceError(f"unsafe commit spool key: {spool_key!r}")
+    return commit_spool_root(coordinator_root).resolve() / spool_key
+
+
+def commit_bundle_path(
+    *,
+    spool_key: str,
+    coordinator_root: str | Path | None = None,
+) -> Path:
+    """該 job 的 bundle 絕對路徑（builder 寫、Manager 讀的那一個檔）。"""
+
+    return (
+        commit_spool_dir(spool_key=spool_key, coordinator_root=coordinator_root)
+        / COMMIT_BUNDLE_FILENAME
+    )
+
+
+def spool_key_for_job(job: Mapping[str, object]) -> str | None:
+    """從 job 記錄推導出這個 job 在 dispatch 當下用的 spool key。
+
+    **推導規則只有一條**：`Path(job["log_path"]).stem`。理由是那正是
+    `launcher.launch()` 收到的 `slice_id`——它同時決定了 exit sentinel
+    （`<log_dir>/<slice_id>.exit`）與 gate ledger（`terminal_contract.
+    gate_ledger_path(log_path)`）的落點，本模組沿用同一條規則，spool 就不會與
+    那兩者漂移。
+
+    這件事必須是**單一規則**：canonical lane 的 launch key 是 job_id，slice lane
+    的是 slice_id，兩條 lane 若各自在回收端「猜」自己的 key，任何一邊改名都會退化成
+    「spool 找不到 → 靜默不回收」——那是最壞的失敗形態。改讀 `log_path` 之後兩條
+    lane 共用同一個推導，且該欄位由 `registry.attach_launch_handle` 在 launch 當下
+    寫入，與 spool 的建立點同源。
+
+    job 還沒 launch（沒有 `log_path`）時回 None——沒有 spool，也沒有東西可回收。
+    """
+
+    log_path = job.get("log_path")
+    if not isinstance(log_path, str) or not log_path.strip():
+        return None
+    stem = Path(log_path).stem
+    if _SPOOL_KEY_RE.fullmatch(stem) is None:
+        return None
+    return stem
+
+
+def commit_bundle_path_for_job(
+    job: Mapping[str, object],
+    *,
+    coordinator_root: str | Path | None = None,
+) -> Path | None:
+    """該 job 的 bundle 路徑；推導不出 spool key 時回 None。"""
+
+    key = spool_key_for_job(job)
+    if key is None:
+        return None
+    return commit_bundle_path(spool_key=key, coordinator_root=coordinator_root)
+
+
+def prepare_commit_spool(
+    *,
+    spool_key: str,
+    coordinator_root: str | Path | None = None,
+) -> Path:
+    """dispatch 當下建立 per-job 那一格，回傳 bundle 應該落地的路徑。
+
+    守衛與慣例：
+
+    - spool 目錄或 bundle 是 **symlink** → 一律移除／拒絕。Manager 之後會直接
+      `git fetch <那個檔案>`，讓它指向別處等於把回收路徑外包出去。
+    - 目錄以 `0700` 建立；**已存在時重新 `chmod 0700`**，把上一輪 harvest 之後的
+      封存（見 :func:`seal_commit_spool`）解開。同一個 key 會被重跑（retry 用同一個
+      slice_id／同一張卡重派），這與 `launcher.launch()` 對 exit sentinel 與 gate
+      ledger 的處置逐條一致。
+    - 殘留的 bundle（含 `.part`）在起跑前清掉。**這比「已存在即拒絕」更強**：預埋一份
+      bundle 的人得到的不是拒絕派工，而是自己的檔案被刪掉；而 Manager 是這一格的
+      owner，刪得掉 builder 寫的檔（目錄 `w`＋`x` 即可）。
+
+    真正的 owner／mode／ACL 由 Phase 2b 的 permgen 依 R1 登記表套用（資產由 #636
+    定義）；本函式只負責「這一格存在、而且是乾淨的」。
+    """
+
+    spool_dir = commit_spool_dir(spool_key=spool_key, coordinator_root=coordinator_root)
+    if spool_dir.is_symlink():
+        raise WorkspaceError(f"commit spool directory is a symlink: {spool_dir}")
+    spool_dir.parent.mkdir(parents=True, mode=0o700, exist_ok=True)
+    spool_dir.mkdir(mode=0o700, exist_ok=True)
+    if not spool_dir.is_dir():
+        raise WorkspaceError(f"commit spool directory unavailable: {spool_dir}")
+    try:
+        os.chmod(spool_dir, 0o700)
+    except OSError as exc:
+        raise WorkspaceError(f"commit spool directory not writable: {spool_dir}: {exc}") from exc
+    bundle = spool_dir / COMMIT_BUNDLE_FILENAME
+    for stale in (bundle, bundle.with_name(bundle.name + COMMIT_BUNDLE_PART_SUFFIX)):
+        if stale.is_symlink() or stale.exists():
+            stale.unlink(missing_ok=True)
+    return bundle
+
+
+def seal_commit_spool(bundle: str | Path) -> None:
+    """成果落地後把該 job 那一格轉唯讀（append-only spool 的封口）。
+
+    封的是**目錄**（`0500`）而不是檔案：bundle 由 builder 的 uid 建立，Manager 不是
+    它的 owner、`chmod` 不了它；但 Manager 是目錄的 owner，收掉目錄的 `w` 之後該格
+    就再也建不了、改不了名、刪不掉任何檔——而 POSIX ACL 的 mask 同時被 `chmod` 收窄，
+    producer 的 `wx` 授權一併失效。
+
+    best-effort：封存失敗不得讓一次**已經成功**的回收反而失敗（回收失敗才是
+    #478／#601 的生產事故）。權威副本此時已經在來源樹的 `refs/heads/<branch>` 裡。
+    """
+
+    target = Path(bundle)
+    try:
+        spool_dir = target.parent
+        if spool_dir.is_symlink() or not spool_dir.is_dir():
+            return
+        os.chmod(spool_dir, 0o500)
+    except OSError:
+        return
+
+
+def build_bundle_command(*, workspace: str | Path, bundle: str | Path) -> str:
+    """builder 在自己的 clone 產出 bundle 的那一段 shell（由 wrapper script 執行）。
+
+    形狀：
+
+    ```
+    git -C <clone> bundle create <bundle>.part "$(git -C <clone> symbolic-ref HEAD)" \
+        ^refs/cortex/base && chmod 0644 <bundle>.part && mv -f <bundle>.part <bundle>
+    ```
+
+    三個決定：
+
+    - **正向 ref 用 `symbolic-ref HEAD` 而不是寫死的 branch 名**——`launch()` 這一層
+      拿不到 branch（它只收 `slice_id`／`worktree`／`log_dir`），而 bundle 必須帶
+      **完整 ref 名**（`refs/heads/<branch>`），Manager 端才能用既有的
+      `refs/heads/<b>:refs/heads/<b>` refspec 取回。builder 若把 HEAD 弄成 detached，
+      這一步失敗、bundle 不存在 → 回收 fail-closed，正是想要的結果。
+    - **負向 ref 是 `^refs/cortex/base`**（provision 當下 pin 的來源樹 commit，見
+      :data:`BASE_REF`），讓 bundle 只帶這一輪的增量而不是整部歷史。
+    - **`.part` → `chmod` → `mv`**：spool 裡看得見的 `commits.bundle` 恆為完整檔；
+      `chmod 0644` 是因為檔由 builder 的 umask 建立（降權 unit 常帶 `UMask=0077`），
+      Manager 讀不到自己就沒東西可回收。放寬到 0644 不擴張暴露面——那一格的容器是
+      `0700 cortex-manager` ＋ per-account `wx`，別的帳號連 traverse 都進不來。
+
+    整段用 `&&` 串接：任何一步失敗都不會發表一個半成品 bundle。
+    """
+
+    workspace_arg = shlex.quote(str(workspace))
+    final = shlex.quote(str(bundle))
+    part = shlex.quote(str(bundle) + COMMIT_BUNDLE_PART_SUFFIX)
+    return (
+        f"git -C {workspace_arg} bundle create {part} "
+        f'"$(git -C {workspace_arg} symbolic-ref HEAD)" ^{shlex.quote(BASE_REF)} '
+        f"&& chmod 0644 {part} && mv -f {part} {final}"
+    )
+
+
+# ---------------------------------------------------------------------------
 # 成果回收（Manager 拉，builder 不推）
 # ---------------------------------------------------------------------------
+
+def source_branch_head(source_repo: str | Path, branch: str) -> str | None:
+    """來源樹上 `refs/heads/<branch>` 現在指到哪；不存在／不可讀時回 None。"""
+
+    if not branch:
+        return None
+    proc = _git(["-C", str(source_repo), "rev-parse", f"refs/heads/{branch}"])
+    if proc.returncode != 0:
+        return None
+    head = proc.stdout.strip().lower()
+    return head if _SHA_RE.fullmatch(head) else None
+
 
 def harvest_branch(
     *,
     source_repo: str | Path,
-    workspace: str | Path,
+    bundle: str | Path,
     branch: str,
 ) -> str:
-    """把 job clone 的 `branch` fetch 回來源 repo，回傳回收後的 branch head。
+    """從 **bundle 檔**把 `branch` fetch 回來源 repo，回傳回收後的 branch head。
 
-    這是 clone 模型下**成果離開 job 帳號的唯一路徑**：Manager 以自己的身分對
-    clone 執行 `git fetch`（單向讀），builder 永遠不 push 進 Manager 的樹。
+    這是三分模型下**成果離開 job 帳號的唯一路徑**。Manager 的 fetch 對象是一個
+    普通檔案，**不是** builder 的 clone——這正是本次變更的全部價值，見模組 docstring。
 
     refspec 刻意不帶 `+`——非 fast-forward 由 git 拒絕，Manager 不會靜默吸收被
     改寫過的歷史（等價於 worktree 模型下 `branch -f` 前的 ancestry 守衛）。
+
+    `git fetch` 對「bundle 不完整」的訊息（`error: Repository lacks these
+    prerequisite commits:` ＋ 一串裸 SHA）看不出該怎麼辦，因此這裡逐類包一層可操作
+    的說明。四類全部 fail-closed，沒有任何一條退回讀 clone。
     """
 
     source = Path(source_repo)
-    target = Path(workspace)
+    bundle_path = Path(bundle)
     if not branch:
         raise WorkspaceError("harvest requires a branch name")
+    if bundle_path.is_symlink():
+        raise WorkspaceError(f"job workspace commit bundle is a symlink: {bundle_path}")
+    if not bundle_path.is_file():
+        raise WorkspaceError(
+            f"job workspace commit bundle missing: {bundle_path}"
+            "；builder 沒有產出 bundle。常見原因：(1) 這一輪工作區內沒有任何新 commit"
+            f"（`git bundle create` 拒絕產生空 bundle）；(2) clone 內的 {BASE_REF} 被"
+            "動過或 HEAD 是 detached，產 bundle 那一步失敗。逐字原因在該 job 的 JSONL "
+            "log 末段（bundle 步驟與模型輸出寫同一份 log）"
+        )
     refspec = f"refs/heads/{branch}:refs/heads/{branch}"
-    proc = _git(["-C", str(source), "fetch", "--no-tags", str(target), refspec])
+    proc = _git(["-C", str(source), "fetch", "--no-tags", str(bundle_path), refspec])
     if proc.returncode != 0:
         detail = (proc.stderr or proc.stdout).strip()
+        if "prerequisite" in detail:
+            raise WorkspaceError(
+                f"job workspace commit bundle is incomplete: {bundle_path}: {detail}"
+                f"；bundle 以 `^{BASE_REF}` 收斂範圍，來源樹卻沒有那個 prerequisite "
+                "commit。這代表 provision 當下 pin 的 base 與來源樹已經對不上"
+                f"（工作區內的 {BASE_REF} 被改寫，或來源樹被 reset 掉了那段歷史）。"
+                "處置：不要放寬 refspec——重新 provision 這張卡的工作區，讓 base 重新"
+                "錨定在來源樹現有的 commit 上"
+            )
+        if "couldn't find remote ref" in detail or "find remote ref" in detail:
+            raise WorkspaceError(
+                f"job workspace commit bundle does not carry {branch}: {bundle_path}: {detail}"
+                "；bundle 帶的是工作區 `HEAD` 當下所指的 branch，與 Manager 記錄的 "
+                "branch 不同即代表 builder 換過 branch（或 HEAD detached 後另建）。"
+                "處置：以 `git bundle list-heads <bundle>` 確認實際帶的 ref，"
+                "不得改用其他 ref 回收"
+            )
         if "non-fast-forward" in detail or "rejected" in detail:
             raise WorkspaceError(
                 f"job workspace branch is not a fast-forward of {branch}: {detail}"
@@ -246,22 +549,37 @@ def harvest_branch(
     return head
 
 
-def harvest_if_job_clone(
+def harvest_if_spooled(
     *,
     source_repo: str | Path,
-    workspace: str | Path,
+    job: Mapping[str, object],
     branch: str,
+    coordinator_root: str | Path | None = None,
 ) -> str | None:
-    """工作區是 per-job clone 時做成果回收；否則回 None。
+    """這個 job 有 spool 授權時做成果回收；否則回 None。
 
-    worktree 模型下 branch 與 object 本來就在來源 repo 裡，沒有東西要 fetch；
-    升級前既存的 worktree、以及測試用的假路徑因此**完全不受影響**——這是本次
-    變更「既有部署零回歸」的掛點。
+    判準是 **Manager-owned 的 spool 那一格在不在**，不是「工作區是不是 clone」——
+    後者要讀 `<clone>/.git/` 底下的標記檔，而在三分部署下 Manager 讀不到，判準會
+    恆為 False，退化成**靜默不回收**（最壞的失敗形態：成果沒進來，錯誤訊息卻出現
+    在很遠的地方）。spool 那一格由 Manager 自己在 dispatch 當下建立，因此永遠讀得到。
+
+    這也維持了 #634 的原則：**以工作區自己的形狀判斷，不依 `PSC_JOB_RUNNER` 分支**。
+    spool 授權是 dispatch 當下就決定的形狀，`direct` 與降權模式走完全相同的路徑。
+
+    回 None 的兩種情形（都是零回歸掛點）：job 還沒 launch（無 `log_path`）、或這個
+    job 是升級前／測試用的假路徑（沒有 spool 那一格）。**spool 存在但 bundle 缺席
+    不在此列**——那是真的出事了，一律 raise。
     """
 
-    if not is_job_clone(workspace):
+    bundle = commit_bundle_path_for_job(job, coordinator_root=coordinator_root)
+    if bundle is None:
         return None
-    return harvest_branch(source_repo=source_repo, workspace=workspace, branch=branch)
+    spool_dir = bundle.parent
+    if spool_dir.is_symlink() or not spool_dir.is_dir():
+        return None
+    head = harvest_branch(source_repo=source_repo, bundle=bundle, branch=branch)
+    seal_commit_spool(bundle)
+    return head
 
 
 def archive_workspace_head(
@@ -320,20 +638,32 @@ def remove_clone(workspace: str | Path) -> None:
 
 __all__ = [
     "ARCHIVE_REF_PREFIX",
+    "BASE_REF",
+    "COMMIT_BUNDLE_FILENAME",
+    "COMMIT_BUNDLE_PART_SUFFIX",
     "MARKER_NAME",
     "MARKER_SCHEMA_VERSION",
     "SOURCE_REMOTE",
     "WORKSPACE_MODEL",
     "WorkspaceError",
     "archive_workspace_head",
+    "build_bundle_command",
+    "commit_bundle_path",
+    "commit_bundle_path_for_job",
+    "commit_spool_dir",
+    "commit_spool_root",
     "harvest_branch",
-    "harvest_if_job_clone",
+    "harvest_if_spooled",
     "is_job_clone",
     "is_linked_worktree",
     "list_clone_workspaces",
     "marker_path",
+    "prepare_commit_spool",
     "read_marker",
     "remove_clone",
+    "seal_commit_spool",
+    "source_branch_head",
+    "spool_key_for_job",
     "workspace_branch",
     "write_marker",
 ]

--- a/paulsha_cortex/coordinator/launcher.py
+++ b/paulsha_cortex/coordinator/launcher.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Mapping, Protocol, Sequence, runtime_checkable
 
-from . import gate_ledger, job_runner, terminal_contract
+from . import gate_ledger, job_runner, job_workspace, terminal_contract
 
 
 _GIT_REPOSITORY_ENV_KEYS = frozenset(
@@ -159,6 +159,7 @@ def build_wrapper_script(
     run_gates: bool,
     stdin_prompt: str | None = None,
     write_sentinel: bool = True,
+    commit_bundle: str | None = None,
 ) -> str:
     """組出 headless wrapper script（#261：模型結束後由 manager 產生 gate ledger）。
 
@@ -168,6 +169,21 @@ def build_wrapper_script(
     2. 把 ``$?`` 寫入 exit sentinel（跨進程 durable 完成判定，早於 gate 階段，
        確保 gate 執行時間不會被算進模型的 exit code）；
     3. 由 manager 掌控的 gate ledger writer。
+
+    ``commit_bundle``（#623）：成果 bundle 的落點。非 None 時 script 改成**先把
+    模型的 ``$?`` 存進 shell 變數**，接著產 bundle，最後才寫 sentinel／跑 gate，
+    並以存下來的值收場。兩個理由：
+
+    - **順序**——sentinel 一出現，Manager 隨時可能在下一個 tick 判定完成並開始
+      回收。bundle 必須在 sentinel **之前**落地，否則回收會撞上一個還沒寫完的 spool。
+      降權模式沒有 job 側 sentinel，但 Manager 側的記帳 shell 等的是整個 unit
+      （``systemctl start --wait``），bundle 同樣先完成。
+    - **exit code 不得被污染**——降權模式下 unit 的 exit code 就是這支 script 的
+      exit code，而 Manager 的記帳 shell 記的正是它（#604）。多接一段 bundle 之後
+      若不還原 ``$?``，模型明明失敗卻會被記成成功（或反過來）。
+
+    ``commit_bundle`` 為 None 時（reviewer／planner，以及所有既有測試路徑）script
+    **逐字**與改動前相同。
 
     ``write_sentinel=False`` / ``run_gates=False``（#604，降權模式）：這支 script
     在降權模式下是以 **job 帳號**（`cortex-builder`）執行的，而 sentinel 與 ledger
@@ -201,6 +217,17 @@ def build_wrapper_script(
         command = (
             f"printf %s {shlex.quote(stdin_prompt)} | {shlex.join(inner_argv)} 2>/dev/null"
         )
+    if commit_bundle is not None:
+        return _bundle_wrapper_script(
+            command=command,
+            sentinel=sentinel,
+            ledger=ledger,
+            worktree=worktree,
+            repo_root=repo_root,
+            run_gates=run_gates,
+            write_sentinel=write_sentinel,
+            commit_bundle=commit_bundle,
+        )
     if write_sentinel:
         script = f'{command}; printf %s "$?" > {shlex.quote(sentinel)}'
     else:
@@ -221,6 +248,56 @@ def build_wrapper_script(
         f"{script}; PYTHONPATH={shlex.quote(repo_root)} "
         f"{shlex.join(gate_argv)} >/dev/null 2>&1"
     )
+
+
+#: 存放模型 exit code 的 shell 變數名（#623 的 bundle 段用）。刻意帶 `__psc_` 前綴，
+#: 不與模型或 gate 階段可能設定的任何變數撞名。
+_RC_VAR = "__psc_rc"
+
+
+def _gate_segment(*, ledger: str, worktree: str, repo_root: str) -> str:
+    gate_argv = [
+        "python3",
+        "-m",
+        "paulsha_cortex.coordinator.gate_ledger",
+        "--out",
+        ledger,
+        "--worktree",
+        worktree,
+    ]
+    return (
+        f"PYTHONPATH={shlex.quote(repo_root)} {shlex.join(gate_argv)} >/dev/null 2>&1"
+    )
+
+
+def _bundle_wrapper_script(
+    *,
+    command: str,
+    sentinel: str,
+    ledger: str,
+    worktree: str,
+    repo_root: str | None,
+    run_gates: bool,
+    write_sentinel: bool,
+    commit_bundle: str,
+) -> str:
+    """#623：帶成果 bundle 的 wrapper。段序＝模型 → 存 `$?` → bundle → sentinel → gate → 還原 `$?`。
+
+    為什麼 bundle 段用 `git` 而不是像 gate 那樣呼叫一個 python module：降權模式下
+    builder 看到的是白名單 env、且它未必讀得到 Manager 的 repo root
+    （`ProtectHome=yes` 之後 `/home` 整個不可見，#623 缺口 1），`PYTHONPATH=<repo>`
+    這條路在那裡不成立。`git` 是 job 本來就必須有的工具。
+    """
+
+    segments = [command, f"{_RC_VAR}=$?", job_workspace.build_bundle_command(
+        workspace=worktree, bundle=commit_bundle
+    )]
+    if write_sentinel:
+        segments.append(f'printf %s "${_RC_VAR}" > {shlex.quote(sentinel)}')
+    if run_gates and repo_root:
+        segments.append(_gate_segment(ledger=ledger, worktree=worktree, repo_root=repo_root))
+    segments.append(f'exit "${_RC_VAR}"')
+    return "; ".join(segments)
 
 
 def _srt_runtime_root() -> Path | None:
@@ -1290,6 +1367,14 @@ class SubprocessLauncher:
         # #261：同理清掉上一輪的 gate ledger，避免 harvest 讀到前一次的 gate 結果。
         ledger = terminal_contract.gate_ledger_path(log_path)
         Path(ledger).unlink(missing_ok=True)
+        # #623：成果 bundle 的 per-job spool。`prepare_commit_spool()` 同樣負責清掉
+        # 上一輪殘留（與 sentinel／ledger 逐條一致），並把上一輪 harvest 之後的封存
+        # 解開。判準是 **persona**，不是 `PSC_JOB_RUNNER`：reviewer／planner 不產生
+        # commit，給它們一格 spool 只會多一個沒人寫的空目錄；builder 兩種模式走完全
+        # 相同的路徑（#634 的「以形狀判斷、不依旗標分支」原則）。
+        commit_bundle: str | None = None
+        if not (self._read_only or self._review_only):
+            commit_bundle = str(job_workspace.prepare_commit_spool(spool_key=slice_id))
         # cg（issue #442）走 stdin 傳 prompt，不是 argv 參數（見 build_cg_argv）：
         # 其餘 executor 維持既有「prompt 為 argv 一個元素」路徑，stdin_prompt=None
         # 時 build_wrapper_script 的行為與改動前逐字相同（零影響）。
@@ -1305,6 +1390,7 @@ class SubprocessLauncher:
             # #604：降權模式下 sentinel 改由 Manager 側的 exit 記帳 shell 寫；
             # job wrapper 內不得再出現任何指向 Manager log 目錄的寫入。
             write_sentinel=not degraded,
+            commit_bundle=commit_bundle,
         )
         # Reviewer 不使用 login shell，避免 ~/.profile 等在最小 env 建立後重新匯入 secrets。
         # 降權模式的 builder 同理（#588 第 2 點）：login shell 會在 transient unit 的

--- a/paulsha_cortex/coordinator/manager.py
+++ b/paulsha_cortex/coordinator/manager.py
@@ -3246,8 +3246,14 @@ def _verify_build_candidate_transition(
     return candidate
 
 
-def _harvest_build_candidate(job: Mapping[str, object], *, run, candidate: str) -> str | None:
-    """#623：把 build card 的 candidate 從 job 的 per-job clone 取回 Manager 的樹。
+def _harvest_build_candidate(
+    job: Mapping[str, object],
+    *,
+    run,
+    candidate: str,
+    coordinator_root: str | Path | None = None,
+) -> str | None:
+    """#623：把 build card 的 candidate 從 job 的成果 bundle 取回 Manager 的樹。
 
     clone 模型下 builder 的 commit 只存在於 clone 自己的 object store。後續每一段
     都需要它在**來源 repo** 裡：review 卡的 `git worktree add --detach <candidate>`
@@ -3255,36 +3261,45 @@ def _harvest_build_candidate(job: Mapping[str, object], *, run, candidate: str) 
     `cortex work gc` 的 branch 分類，以及最基本的一件事——工作區被回收之後 commit
     還在不在。
 
-    方向是 Manager **拉**（`git -C <來源 repo> fetch <clone>`），沿用 D2「git 讀」
-    的單向性；builder 永遠不 push 進 Manager 的樹。
+    搬運介面是 **Manager-owned spool 裡的一個 bundle 檔**，不是 builder 的 clone
+    ——三分部署下 Manager 走不進那棵樹（完整推導見 `job_workspace` 模組 docstring）。
+    這個函式因此**完全不觸碰工作區**：它只讀 job 記錄、spool 與來源 repo。
 
     掛在 candidate 驗證**之後**：`_verify_build_candidate_transition` 已確認
     candidate 就是工作區的 HEAD 且單調延伸自基線，此處只負責把那個已被採信的
     commit 搬進來，不引入新的採信路徑。
 
-    工作區不是 per-job clone（worktree 模型、或測試裡的假路徑）時回 None，不做任何
-    事——既有部署零回歸的掛點。
+    這個 job 沒有 spool 那一格（升級前既存的工作區、或測試裡的假 job 記錄）時回
+    None，不做任何事——既有部署零回歸的掛點。
     """
 
-    worktree = job.get("worktree")
     branch = job.get("branch")
-    if not isinstance(worktree, str) or not worktree:
-        return None
     if not isinstance(branch, str) or not branch:
         return None
-    if not job_workspace.is_job_clone(worktree):
+    bundle = job_workspace.commit_bundle_path_for_job(job, coordinator_root=coordinator_root)
+    if bundle is None or bundle.parent.is_symlink() or not bundle.parent.is_dir():
         return None
     source_repo = getattr(run, "workspace_root", None)
     if not isinstance(source_repo, str) or not source_repo:
         raise ValueError("workflow build candidate harvest source repo missing")
+    if not bundle.is_file():
+        # 這張卡沒有產生新 commit（`git bundle create` 拒絕產生空 bundle）。candidate
+        # 此時就是基線本身、來源樹早已有它——沒有東西要搬，也不該因此 fail。來源樹的
+        # branch 若**不是** candidate，就落到 `harvest_branch` 的「bundle 缺席」
+        # fail-closed，訊息會逐條列出成因。
+        existing = job_workspace.source_branch_head(source_repo, branch)
+        if existing is not None and existing == candidate.lower():
+            job_workspace.seal_commit_spool(bundle)
+            return candidate
     harvested = job_workspace.harvest_branch(
-        source_repo=source_repo, workspace=worktree, branch=branch
+        source_repo=source_repo, bundle=bundle, branch=branch
     )
     if harvested.lower() != candidate.lower():
         # 回收後來源 repo 的 branch 必須恰好是被採信的 candidate。對不上代表
         # 工作區的 branch tip 與 HEAD 不同（模型在 detached HEAD 上 commit，
         # 或 provision 後有第三方動過 ref）——fail-closed，不得繼續。
         raise ValueError("workflow build candidate harvest head mismatch")
+    job_workspace.seal_commit_spool(bundle)
     return harvested
 
 
@@ -9728,7 +9743,9 @@ def apply_workflow_action(
                 previous_candidate=candidate,
                 git_runner=git_runner,
             )
-            _harvest_build_candidate(job, run=current, candidate=candidate)
+            _harvest_build_candidate(
+                job, run=current, candidate=candidate, coordinator_root=coordinator_root
+            )
         elif current.current_phase in {"verify", "review"}:
             job_candidate = _verify_exact_candidate(job, git_runner=git_runner)
             if candidate != job_candidate:

--- a/paulsha_cortex/coordinator/seams.py
+++ b/paulsha_cortex/coordinator/seams.py
@@ -246,6 +246,18 @@ class ScriptWorktreeCreator:
             if value:
                 self._run(["-C", str(target), "config", key, value])
 
+        # 成果 bundle 的 `^<base>` 錨點。bundle 要能被來源樹 fetch，它的
+        # prerequisite 就必須是**來源樹已有**的 commit——`exact_base` 正是來源 repo
+        # 自己 `rev-parse --verify` 出來的，所以這條性質由 provisioning 這個單一
+        # 推導點對**每一條 lane** 一致成立。pin 成 clone 內的一個 ref 是因為產
+        # bundle 的是 builder：它讀得到自己的 clone，讀不到 spool 也讀不到 Manager
+        # 的任何狀態（見 `job_workspace.BASE_REF`）。
+        pinned = self._run(
+            ["-C", str(target), "update-ref", job_workspace.BASE_REF, exact_base]
+        )
+        if pinned.returncode != 0:
+            raise ValueError(f"git worktree add failed: {pinned.stderr.strip()}")
+
         job_workspace.write_marker(
             target, branch=branch, base=exact_base, source_repo=self._repo
         )

--- a/paulsha_cortex/coordinator/verification.py
+++ b/paulsha_cortex/coordinator/verification.py
@@ -699,12 +699,16 @@ def run_result_verification(
     # #623：工作區是 per-job clone 時，builder 的 commit 只存在於 clone 自己的
     # object store 裡——底下所有以 `resolved_repo_root` 為根的判讀（candidate、
     # ancestry、required-artifact diff、persona scope diff）都會看不到它。先由
-    # Manager 單向 fetch 回自己的樹，才有東西可讀。worktree 模型（以及測試裡的
-    # 假路徑）沒有標記檔，這一步是 no-op，既有行為逐字不變。
+    # Manager 從該 job 的成果 **bundle**（Manager-owned spool，不是 builder 的樹）
+    # 單向 fetch 回自己的樹，才有東西可讀。這個 job 沒有 spool 那一格（升級前既存
+    # 的工作區、測試裡的假 job 記錄）時是 no-op，既有行為逐字不變。
     if branch:
         try:
-            job_workspace.harvest_if_job_clone(
-                source_repo=resolved_repo_root, workspace=worktree, branch=branch
+            job_workspace.harvest_if_spooled(
+                source_repo=resolved_repo_root,
+                job=job,
+                branch=branch,
+                coordinator_root=coordinator_root,
             )
         except job_workspace.WorkspaceError as exc:
             details["candidate_harvest_error"] = str(exc)

--- a/tests/test_bundle_commit_harvest_623.py
+++ b/tests/test_bundle_commit_harvest_623.py
@@ -1,0 +1,817 @@
+"""#623：成果回收由「Manager 伸手進 builder 的 clone fetch」改為 **bundle ＋ append-only spool**。
+
+`git -C <來源樹> fetch <builder 的 clone>` 在 trust-root Phase 2b 三分下結構性不成立
+（operator 0817 實機驗證）：clone 是 builder-owned `0700`，Manager 進不去；而
+`safe.directory` 實測不吃路徑 glob，per-job 路徑無法用一條設定涵蓋。
+
+本檔覆蓋改法的五個面向，全部以**真 git repo**驗證（注入假 runner 只會驗到 stub 自己）：
+
+1. base 錨點——provision 單一推導點，bundle 的 prerequisite 恆為來源樹已有的 commit
+2. 產出與回收——builder 在自己的 clone 產 bundle，Manager 從那個**檔案** fetch
+3. **不變式**——回收全程不存取 builder 的 clone（本次變更的全部價值）
+4. fail-closed——bundle 缺席／不完整／帶錯 branch／非 fast-forward，訊息可操作
+5. wrapper 與 `direct` 模式零回歸——段序、exit code、無 bundle 時逐字不變
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from paulsha_cortex.coordinator import job_workspace, launcher, manager, verification
+from paulsha_cortex.coordinator.seams import ScriptWorktreeCreator
+
+_BRANCH = "feature/623-bundle-harvest"
+_KEY = "job-623-0001"
+
+
+# ---------------------------------------------------------------------------
+# fixture helpers
+# ---------------------------------------------------------------------------
+
+def _git(cwd: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", "-C", str(cwd), *args], check=True, capture_output=True, text=True
+    ).stdout.strip()
+
+
+def _try_git(cwd: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", "-C", str(cwd), *args], check=False, capture_output=True, text=True
+    )
+
+
+def _source_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repos" / "paulsha-cortex"
+    repo.mkdir(parents=True)
+    subprocess.run(["git", "-C", str(repo), "init", "-q", "-b", "main"], check=True)
+    _git(repo, "config", "user.email", "manager@example.invalid")
+    _git(repo, "config", "user.name", "Cortex Manager")
+    (repo / "tracked.txt").write_text("one\n", encoding="utf-8")
+    _git(repo, "add", "tracked.txt")
+    _git(repo, "commit", "-qm", "initial")
+    return repo
+
+
+def _workspace(repo: Path, pool: Path) -> Path:
+    return Path(ScriptWorktreeCreator(repo=repo, wt_root=pool, base="main").create(_BRANCH))
+
+
+def _builder_commit(workspace: Path, name: str = "builder.txt") -> str:
+    (workspace / name).write_text("builder work\n", encoding="utf-8")
+    _git(workspace, "add", name)
+    _git(workspace, "commit", "-qm", f"builder: {name}")
+    return _git(workspace, "rev-parse", "HEAD")
+
+
+def _run_bundle_step(workspace: Path, bundle: Path) -> subprocess.CompletedProcess[str]:
+    """以 **builder 身分**跑 wrapper 裡那一段真正的 bundle 命令。
+
+    刻意不在測試裡自己組 `git bundle create`：要驗的就是 production wrapper 送出去
+    的那一串字，另寫一份只會驗到測試自己。
+    """
+
+    return subprocess.run(
+        ["bash", "-c", job_workspace.build_bundle_command(workspace=workspace, bundle=bundle)],
+        cwd=str(workspace),
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _dispatch(tmp_path: Path, key: str = _KEY) -> Path:
+    """Manager 在 dispatch 當下建立該 job 那一格，回傳 bundle 應該落地的路徑。"""
+
+    return job_workspace.prepare_commit_spool(
+        spool_key=key, coordinator_root=tmp_path / "coordinator"
+    )
+
+
+def _job(bundle: Path, *, branch: str = _BRANCH, workspace: Path | None = None) -> dict[str, object]:
+    """一筆已 launch 的 job 記錄——spool key 由 `log_path` 的 stem 推導。"""
+
+    return {
+        "job_id": bundle.parent.name,
+        "branch": branch,
+        "worktree": str(workspace) if workspace is not None else "",
+        "log_path": f"/logs/workflow/{bundle.parent.name}.jsonl",
+    }
+
+
+# ---------------------------------------------------------------------------
+# 1. base 錨點
+# ---------------------------------------------------------------------------
+
+def test_provision_pins_the_bundle_base_inside_the_clone(tmp_path: Path) -> None:
+    """`^<base>` 的推導只有一個點：provision 解出的 `exact_base`。
+
+    bundle 要能被來源樹 fetch，它的 prerequisite 就必須是**來源樹已有**的 commit。
+    `exact_base` 正是來源 repo 自己 `rev-parse --verify` 出來的，所以這條性質對每一
+    條 lane 都成立——lane 之間唯一的差別是傳給 `create()` 的 `base_sha`，而那個值
+    在同一個函式裡被同一個 `rev-parse --verify` 收斂。
+    """
+
+    repo = _source_repo(tmp_path)
+    expected = _git(repo, "rev-parse", "main")
+
+    workspace = _workspace(repo, tmp_path / "pool")
+
+    assert _git(workspace, "rev-parse", job_workspace.BASE_REF) == expected
+    # 與標記檔同源——兩邊都取自同一個 `exact_base`
+    assert (job_workspace.read_marker(workspace) or {})["base"] == expected
+    # 來源樹一定有它 → bundle 的 prerequisite 必然滿足
+    assert _try_git(repo, "cat-file", "-e", f"{expected}^{{commit}}").returncode == 0
+    # base pin 不得讓工作區一出生就是 dirty（dirty 是 verification／gc 的 fail-closed 條件）
+    assert _git(workspace, "status", "--porcelain", "--untracked-files=all") == ""
+
+
+def test_provision_pins_the_base_at_the_requested_base_sha(tmp_path: Path) -> None:
+    """lane 指定 `base_sha` 時，pin 的是那一個 commit，不是 `main`。"""
+
+    repo = _source_repo(tmp_path)
+    pinned_at = _git(repo, "rev-parse", "main")
+    (repo / "tracked.txt").write_text("two\n", encoding="utf-8")
+    _git(repo, "commit", "-qam", "main advances")
+
+    workspace = Path(
+        ScriptWorktreeCreator(repo=repo, wt_root=tmp_path / "pool", base="main").create(
+            _BRANCH, base_sha=pinned_at
+        )
+    )
+
+    assert _git(workspace, "rev-parse", job_workspace.BASE_REF) == pinned_at
+
+
+# ---------------------------------------------------------------------------
+# 2. 產出與回收
+# ---------------------------------------------------------------------------
+
+def test_builder_bundle_round_trips_the_candidate_into_the_source_tree(
+    tmp_path: Path,
+) -> None:
+    """bundle 產生 → 回收 → branch 落在來源樹且**內容**正確。"""
+
+    repo = _source_repo(tmp_path)
+    workspace = _workspace(repo, tmp_path / "pool")
+    bundle = _dispatch(tmp_path)
+    candidate = _builder_commit(workspace)
+
+    assert _run_bundle_step(workspace, bundle).returncode == 0
+    assert bundle.is_file()
+
+    harvested = job_workspace.harvest_branch(
+        source_repo=repo, bundle=bundle, branch=_BRANCH
+    )
+
+    assert harvested == candidate
+    assert _git(repo, "rev-parse", f"refs/heads/{_BRANCH}") == candidate
+    # object 也真的進來了——review 卡的 `worktree add --detach <candidate>` 靠這個
+    assert _try_git(repo, "cat-file", "-e", f"{candidate}^{{commit}}").returncode == 0
+    # 內容而不只是 ref：diff 必須逐字落地
+    assert _git(repo, "show", f"{candidate}:builder.txt") == "builder work"
+
+
+def test_bundle_carries_only_this_generation_not_the_whole_history(
+    tmp_path: Path,
+) -> None:
+    """`^<base>` 真的收斂了範圍——bundle 只帶這一輪的 commit。"""
+
+    repo = _source_repo(tmp_path)
+    workspace = _workspace(repo, tmp_path / "pool")
+    bundle = _dispatch(tmp_path)
+    base = _git(workspace, "rev-parse", job_workspace.BASE_REF)
+    candidate = _builder_commit(workspace)
+
+    assert _run_bundle_step(workspace, bundle).returncode == 0
+
+    heads = subprocess.run(
+        ["git", "bundle", "list-heads", str(bundle)],
+        check=True, capture_output=True, text=True,
+    ).stdout
+    assert heads.strip() == f"{candidate} refs/heads/{_BRANCH}"
+    # base 是 prerequisite（bundle 不含它），不是 bundle 的一個 head
+    assert base not in heads
+
+
+def test_harvest_is_idempotent_across_repeated_ticks(tmp_path: Path) -> None:
+    """同一份 bundle 被回收兩次（Manager 的 tick 可能重跑）不得失敗。"""
+
+    repo = _source_repo(tmp_path)
+    workspace = _workspace(repo, tmp_path / "pool")
+    bundle = _dispatch(tmp_path)
+    candidate = _builder_commit(workspace)
+    _run_bundle_step(workspace, bundle)
+
+    first = job_workspace.harvest_branch(source_repo=repo, bundle=bundle, branch=_BRANCH)
+    job_workspace.seal_commit_spool(bundle)
+    second = job_workspace.harvest_branch(source_repo=repo, bundle=bundle, branch=_BRANCH)
+
+    assert first == second == candidate
+
+
+# ---------------------------------------------------------------------------
+# 3. 不變式：Manager 全程不碰 builder 的 clone
+# ---------------------------------------------------------------------------
+
+@pytest.mark.skipif(os.geteuid() == 0, reason="root 不受目錄權限限制，這條不變式驗不到")
+def test_manager_never_touches_the_builder_clone_while_harvesting(
+    tmp_path: Path,
+) -> None:
+    """**本次變更的全部價值**：回收路徑對 builder 的樹是零存取。
+
+    以 `chmod 000` 重現 operator 實機看到的形狀（clone 為 builder-owned `0700`，
+    Manager 連 `ls` 都 `Permission denied`）。舊做法在這裡必炸——它的第一個動作就是
+    `git -C <來源樹> fetch <clone>`；新做法讀的是 spool 裡的一個**普通檔**，因此
+    整條路徑（含 `manager._harvest_build_candidate`）照常完成。
+    """
+
+    repo = _source_repo(tmp_path)
+    workspace = _workspace(repo, tmp_path / "pool")
+    bundle = _dispatch(tmp_path)
+    candidate = _builder_commit(workspace)
+    assert _run_bundle_step(workspace, bundle).returncode == 0
+
+    os.chmod(workspace, 0o000)
+    try:
+        # 前提成立：這棵樹現在真的進不去（等同實機的 Permission denied）
+        assert _try_git(workspace, "status").returncode != 0
+        assert not job_workspace.is_job_clone(workspace)
+
+        harvested = job_workspace.harvest_branch(
+            source_repo=repo, bundle=bundle, branch=_BRANCH
+        )
+        lane = manager._harvest_build_candidate(
+            _job(bundle, workspace=workspace),
+            run=SimpleNamespace(workspace_root=str(repo)),
+            candidate=candidate,
+            coordinator_root=tmp_path / "coordinator",
+        )
+    finally:
+        os.chmod(workspace, 0o700)
+
+    assert harvested == candidate
+    assert lane == candidate
+    assert _git(repo, "rev-parse", f"refs/heads/{_BRANCH}") == candidate
+
+
+def test_manager_fetches_a_regular_file_never_a_repository(tmp_path: Path) -> None:
+    """回收的來源必須是一個檔案。
+
+    這是「Manager 不需要對 per-job 路徑設 `safe.directory`」那半個理由的機械形式：
+    只要 fetch 對象是普通檔，dubious-ownership 與父鏈 traverse 都不會被觸發。
+    """
+
+    repo = _source_repo(tmp_path)
+    workspace = _workspace(repo, tmp_path / "pool")
+    bundle = _dispatch(tmp_path)
+    _builder_commit(workspace)
+    _run_bundle_step(workspace, bundle)
+
+    assert bundle.is_file()
+    assert not bundle.is_dir()
+    assert not bundle.is_symlink()
+    assert not (bundle / ".git").exists()
+
+
+# ---------------------------------------------------------------------------
+# 4. fail-closed
+# ---------------------------------------------------------------------------
+
+def test_harvest_fails_closed_when_the_bundle_is_absent(tmp_path: Path) -> None:
+    """builder 沒有產出 bundle → 拒絕，且訊息說得出下一步。"""
+
+    repo = _source_repo(tmp_path)
+    bundle = _dispatch(tmp_path)
+
+    with pytest.raises(job_workspace.WorkspaceError) as excinfo:
+        job_workspace.harvest_branch(source_repo=repo, bundle=bundle, branch=_BRANCH)
+
+    message = str(excinfo.value)
+    assert "commit bundle missing" in message
+    assert str(bundle) in message
+    # 可操作：逐條列出成因，並指出逐字原因在哪裡看
+    assert job_workspace.BASE_REF in message
+    assert "log" in message
+
+
+def test_harvest_fails_closed_on_an_incomplete_bundle(tmp_path: Path) -> None:
+    """缺 base 的 bundle：`git fetch` 只吐一串裸 SHA，這裡必須包成可操作的說明。"""
+
+    repo = _source_repo(tmp_path)
+    workspace = _workspace(repo, tmp_path / "pool")
+    bundle = _dispatch(tmp_path)
+    _builder_commit(workspace, "first.txt")
+    # base pin 被推到 builder 自己造的 commit 上 → bundle 的 prerequisite 來源樹沒有
+    _git(workspace, "update-ref", job_workspace.BASE_REF, "HEAD")
+    _builder_commit(workspace, "second.txt")
+    assert _run_bundle_step(workspace, bundle).returncode == 0
+
+    with pytest.raises(job_workspace.WorkspaceError) as excinfo:
+        job_workspace.harvest_branch(source_repo=repo, bundle=bundle, branch=_BRANCH)
+
+    message = str(excinfo.value)
+    assert "commit bundle is incomplete" in message
+    # git 的原文（裸 SHA 清單）保留，另外補上「該怎麼辦」
+    assert "prerequisite" in message
+    assert "重新 provision" in message
+    # fail-closed：來源樹的 branch 沒有被動到
+    assert _git(repo, "rev-parse", f"refs/heads/{_BRANCH}") == _git(repo, "rev-parse", "main")
+
+
+def test_harvest_fails_closed_when_the_bundle_carries_another_branch(
+    tmp_path: Path,
+) -> None:
+    """builder 換了 branch：bundle 帶的 ref 與 Manager 記錄的對不上 → 拒絕。"""
+
+    repo = _source_repo(tmp_path)
+    workspace = _workspace(repo, tmp_path / "pool")
+    bundle = _dispatch(tmp_path)
+    _git(workspace, "checkout", "-q", "-b", "feature/elsewhere")
+    _builder_commit(workspace)
+    assert _run_bundle_step(workspace, bundle).returncode == 0
+
+    with pytest.raises(job_workspace.WorkspaceError, match="does not carry"):
+        job_workspace.harvest_branch(source_repo=repo, bundle=bundle, branch=_BRANCH)
+
+
+def test_harvest_rejects_a_rewritten_history_instead_of_absorbing_it(
+    tmp_path: Path,
+) -> None:
+    """refspec 刻意不帶 `+`：Manager 不會靜默吸收被改寫過的歷史。"""
+
+    repo = _source_repo(tmp_path)
+    workspace = _workspace(repo, tmp_path / "pool")
+    bundle = _dispatch(tmp_path)
+    first = _builder_commit(workspace)
+    _run_bundle_step(workspace, bundle)
+    job_workspace.harvest_branch(source_repo=repo, bundle=bundle, branch=_BRANCH)
+
+    _git(workspace, "reset", "-q", "--hard", "HEAD~1")
+    _builder_commit(workspace, "rewritten.txt")
+    rewritten = _dispatch(tmp_path, key="job-623-0002")
+    _run_bundle_step(workspace, rewritten)
+
+    with pytest.raises(job_workspace.WorkspaceError, match="not a fast-forward"):
+        job_workspace.harvest_branch(source_repo=repo, bundle=rewritten, branch=_BRANCH)
+
+    assert _git(repo, "rev-parse", f"refs/heads/{_BRANCH}") == first
+
+
+def test_harvest_refuses_a_symlinked_bundle(tmp_path: Path) -> None:
+    """spool 那一格裡的 bundle 若是 symlink，回收路徑等於被外包出去。"""
+
+    repo = _source_repo(tmp_path)
+    bundle = _dispatch(tmp_path)
+    elsewhere = tmp_path / "elsewhere.bundle"
+    elsewhere.write_bytes(b"")
+    bundle.symlink_to(elsewhere)
+
+    with pytest.raises(job_workspace.WorkspaceError, match="is a symlink"):
+        job_workspace.harvest_branch(source_repo=repo, bundle=bundle, branch=_BRANCH)
+
+
+# ---------------------------------------------------------------------------
+# 5. spool 的生命週期（pre-seed／seal）
+# ---------------------------------------------------------------------------
+
+def test_prepare_clears_a_preseeded_bundle_instead_of_inheriting_it(
+    tmp_path: Path,
+) -> None:
+    """預埋一份 bundle 的人得到的是「自己的檔案被刪掉」，不是被繼承。"""
+
+    bundle = _dispatch(tmp_path)
+    bundle.write_bytes(b"pre-seeded")
+    part = bundle.with_name(bundle.name + job_workspace.COMMIT_BUNDLE_PART_SUFFIX)
+    part.write_bytes(b"half written")
+
+    again = _dispatch(tmp_path)
+
+    assert again == bundle
+    assert not bundle.exists()
+    assert not part.exists()
+
+
+def test_prepare_reopens_a_sealed_spool_for_a_retry(tmp_path: Path) -> None:
+    """同一個 key 被重派（retry-card／forced retry）時那一格必須重新可寫。"""
+
+    bundle = _dispatch(tmp_path)
+    bundle.write_bytes(b"harvested")
+    job_workspace.seal_commit_spool(bundle)
+    assert (bundle.parent.stat().st_mode & 0o777) == 0o500
+
+    _dispatch(tmp_path)
+
+    assert (bundle.parent.stat().st_mode & 0o777) == 0o700
+    assert not bundle.exists()
+
+
+@pytest.mark.skipif(os.geteuid() == 0, reason="root 不受目錄權限限制")
+def test_seal_closes_the_spool_after_a_successful_harvest(tmp_path: Path) -> None:
+    """append-only 的封口：落地後那一格再也建不了、刪不掉任何檔。
+
+    封的是目錄不是檔案——bundle 由 builder 的 uid 建立，Manager `chmod` 不了它；
+    但 Manager 是目錄的 owner，收掉目錄的 `w` 就足以讓那一格定版。
+    """
+
+    repo = _source_repo(tmp_path)
+    workspace = _workspace(repo, tmp_path / "pool")
+    bundle = _dispatch(tmp_path)
+    _builder_commit(workspace)
+    _run_bundle_step(workspace, bundle)
+
+    job_workspace.harvest_if_spooled(
+        source_repo=repo,
+        job=_job(bundle),
+        branch=_BRANCH,
+        coordinator_root=tmp_path / "coordinator",
+    )
+
+    assert (bundle.parent.stat().st_mode & 0o777) == 0o500
+    with pytest.raises(PermissionError):
+        (bundle.parent / "smuggled").write_bytes(b"x")
+    # 但證據還讀得到——bundle 就是 clone 被 rmtree 之後那些 commit 的 Manager-owned 副本
+    assert bundle.read_bytes()[:4] == b"# v2"
+
+
+def test_spool_key_rejects_a_path_traversing_identifier(tmp_path: Path) -> None:
+    """key 會成為 Manager-owned 樹裡的一個目錄名，形狀守衛不得放寬。"""
+
+    for bad in ("../escape", "a/b", "", ".hidden"):
+        with pytest.raises(job_workspace.WorkspaceError, match="unsafe commit spool key"):
+            job_workspace.commit_spool_dir(
+                spool_key=bad, coordinator_root=tmp_path / "coordinator"
+            )
+
+
+def test_spool_key_is_derived_from_the_same_identifier_launch_used(
+    tmp_path: Path,
+) -> None:
+    """launch 端與回收端**同一條**推導規則：`Path(log_path).stem`。
+
+    canonical lane 的 launch key 是 job_id、slice lane 的是 slice_id；兩條 lane 若
+    各自在回收端猜自己的 key，任何一邊改名都會退化成「找不到 spool → 靜默不回收」。
+    """
+
+    log_dir = tmp_path / "logs"
+    for launch_key in ("job-abc123", "slice-2026-08-17-01"):
+        log_path = str(log_dir / f"{launch_key}.jsonl")
+        assert job_workspace.spool_key_for_job({"log_path": log_path}) == launch_key
+    assert job_workspace.spool_key_for_job({}) is None
+    assert job_workspace.spool_key_for_job({"log_path": ""}) is None
+
+
+def test_harvest_is_a_noop_for_a_job_without_a_spool_grant(tmp_path: Path) -> None:
+    """零回歸掛點：升級前既存的工作區與測試裡的假 job 記錄完全不受影響。"""
+
+    repo = _source_repo(tmp_path)
+    coordinator_root = tmp_path / "coordinator"
+
+    assert (
+        job_workspace.harvest_if_spooled(
+            source_repo=repo, job={}, branch=_BRANCH, coordinator_root=coordinator_root
+        )
+        is None
+    )
+    assert (
+        job_workspace.harvest_if_spooled(
+            source_repo=repo,
+            job={"log_path": str(tmp_path / "logs" / "never-dispatched.jsonl")},
+            branch=_BRANCH,
+            coordinator_root=coordinator_root,
+        )
+        is None
+    )
+
+
+# ---------------------------------------------------------------------------
+# 6. wrapper script（段序、exit code、`direct` 零回歸）
+# ---------------------------------------------------------------------------
+
+def _wrapper(**overrides: object) -> str:
+    kwargs: dict[str, object] = {
+        "inner_argv": ["true"],
+        "sentinel": "/tmp/psc-nonexistent/s.exit",
+        "ledger": "/tmp/psc-nonexistent/s.gates.json",
+        "worktree": "/tmp/psc-nonexistent/wt",
+        "repo_root": "/tmp/psc-nonexistent/repo",
+        "run_gates": True,
+    }
+    kwargs.update(overrides)
+    return launcher.build_wrapper_script(**kwargs)  # type: ignore[arg-type]
+
+
+def test_wrapper_without_a_bundle_is_byte_identical_to_the_previous_shape() -> None:
+    """`commit_bundle=None`（reviewer／planner）＝改動前逐字相同。"""
+
+    assert _wrapper() == (
+        "true; "
+        'printf %s "$?" > /tmp/psc-nonexistent/s.exit; '
+        "PYTHONPATH=/tmp/psc-nonexistent/repo python3 -m paulsha_cortex.coordinator.gate_ledger "
+        "--out /tmp/psc-nonexistent/s.gates.json --worktree /tmp/psc-nonexistent/wt "
+        ">/dev/null 2>&1"
+    )
+
+
+def test_wrapper_puts_the_bundle_before_the_sentinel() -> None:
+    """sentinel 一出現，Manager 隨時可能開始回收——bundle 必須先落地。"""
+
+    script = _wrapper(commit_bundle="/spool/k/commits.bundle")
+
+    assert script.index("bundle create") < script.index("s.exit")
+    # gate 排在 sentinel 之後（#261 的既有順序不變）
+    assert script.index("s.exit") < script.index("gate_ledger")
+
+
+def test_wrapper_preserves_the_model_exit_code_across_the_bundle_step(
+    tmp_path: Path,
+) -> None:
+    """真的跑一次：bundle 段不得污染模型的 `$?`（降權模式下 unit 的 exit code 就是它）。"""
+
+    repo = _source_repo(tmp_path)
+    workspace = _workspace(repo, tmp_path / "pool")
+    bundle = _dispatch(tmp_path)
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+    sentinel = log_dir / "job.exit"
+    # 「模型」：做一次 commit 然後以 3 收場
+    model = "git add -A && git commit -qm 'builder: model output' && exit 3"
+    (workspace / "model.txt").write_text("from the model\n", encoding="utf-8")
+
+    script = launcher.build_wrapper_script(
+        inner_argv=["bash", "-c", model],
+        sentinel=str(sentinel),
+        ledger=str(log_dir / "job.gates.json"),
+        worktree=str(workspace),
+        repo_root=None,
+        run_gates=False,
+        commit_bundle=str(bundle),
+    )
+    proc = subprocess.run(
+        ["bash", "-c", script], cwd=str(workspace), check=False, capture_output=True, text=True
+    )
+
+    assert proc.returncode == 3, proc.stderr
+    assert sentinel.read_text(encoding="utf-8") == "3"
+    # 失敗的模型也必須留下成果——採信與否由 Manager 判斷，不是由 exit code 決定搬不搬
+    assert bundle.is_file()
+    assert job_workspace.harvest_branch(
+        source_repo=repo, bundle=bundle, branch=_BRANCH
+    ) == _git(workspace, "rev-parse", "HEAD")
+
+
+def test_degraded_wrapper_has_no_sentinel_but_still_bundles_and_exits_with_the_model_code(
+    tmp_path: Path,
+) -> None:
+    """#604 的降權形狀：job 側不寫 sentinel／不跑 gate，但仍產 bundle。
+
+    exit code 由 `exit "$rc"` 還原——降權模式下 Manager 側的記帳 shell 記的正是
+    unit（＝這支 script）的 exit code。
+    """
+
+    repo = _source_repo(tmp_path)
+    workspace = _workspace(repo, tmp_path / "pool")
+    bundle = _dispatch(tmp_path)
+    (workspace / "model.txt").write_text("from the model\n", encoding="utf-8")
+
+    script = launcher.build_wrapper_script(
+        inner_argv=["bash", "-c", "git add -A && git commit -qm 'builder: x' && exit 7"],
+        sentinel="/tmp/psc-nonexistent/s.exit",
+        ledger="/tmp/psc-nonexistent/s.gates.json",
+        worktree=str(workspace),
+        repo_root=str(repo),
+        run_gates=False,
+        write_sentinel=False,
+        commit_bundle=str(bundle),
+    )
+    proc = subprocess.run(
+        ["bash", "-c", script], cwd=str(workspace), check=False, capture_output=True, text=True
+    )
+
+    assert "s.exit" not in script
+    assert "gate_ledger" not in script
+    assert proc.returncode == 7, proc.stderr
+    assert bundle.is_file()
+
+
+def test_bundle_step_leaves_no_partial_file_when_it_fails(tmp_path: Path) -> None:
+    """`.part` → `chmod` → `mv`：失敗時 spool 裡不得出現一個半成品 `commits.bundle`。"""
+
+    repo = _source_repo(tmp_path)
+    workspace = _workspace(repo, tmp_path / "pool")
+    bundle = _dispatch(tmp_path)
+    # 沒有任何新 commit → `git bundle create` 拒絕產生空 bundle
+    proc = _run_bundle_step(workspace, bundle)
+
+    assert proc.returncode != 0
+    assert not bundle.exists()
+
+
+def test_bundle_is_readable_by_the_manager_regardless_of_the_job_umask(
+    tmp_path: Path,
+) -> None:
+    """降權 unit 常帶 `UMask=0077`；bundle 若落成 0600 builder-owned，Manager 就沒東西可讀。"""
+
+    repo = _source_repo(tmp_path)
+    workspace = _workspace(repo, tmp_path / "pool")
+    bundle = _dispatch(tmp_path)
+    _builder_commit(workspace)
+
+    proc = subprocess.run(
+        [
+            "bash",
+            "-c",
+            "umask 0077; "
+            + job_workspace.build_bundle_command(workspace=workspace, bundle=bundle),
+        ],
+        cwd=str(workspace), check=False, capture_output=True, text=True,
+    )
+
+    assert proc.returncode == 0, proc.stderr
+    assert (bundle.stat().st_mode & 0o044) == 0o044
+
+
+# ---------------------------------------------------------------------------
+# 7. 兩條 lane 的掛點
+# ---------------------------------------------------------------------------
+
+def test_canonical_lane_harvests_the_accepted_candidate(tmp_path: Path) -> None:
+    """掛在 `_verify_build_candidate_transition` **之後**：只搬運已被採信的 commit。"""
+
+    repo = _source_repo(tmp_path)
+    workspace = _workspace(repo, tmp_path / "pool")
+    bundle = _dispatch(tmp_path)
+    candidate = _builder_commit(workspace)
+    _run_bundle_step(workspace, bundle)
+
+    harvested = manager._harvest_build_candidate(
+        _job(bundle, workspace=workspace),
+        run=SimpleNamespace(workspace_root=str(repo)),
+        candidate=candidate,
+        coordinator_root=tmp_path / "coordinator",
+    )
+
+    assert harvested == candidate
+    assert _git(repo, "rev-parse", f"refs/heads/{_BRANCH}") == candidate
+
+
+def test_canonical_lane_fails_closed_when_the_harvested_head_is_not_the_candidate(
+    tmp_path: Path,
+) -> None:
+    """回收後 branch 必須恰等於已採信的 candidate——這條守衛保留。"""
+
+    repo = _source_repo(tmp_path)
+    workspace = _workspace(repo, tmp_path / "pool")
+    bundle = _dispatch(tmp_path)
+    _builder_commit(workspace)
+    _run_bundle_step(workspace, bundle)
+
+    with pytest.raises(ValueError, match="harvest head mismatch"):
+        manager._harvest_build_candidate(
+            _job(bundle, workspace=workspace),
+            run=SimpleNamespace(workspace_root=str(repo)),
+            candidate="0" * 40,
+            coordinator_root=tmp_path / "coordinator",
+        )
+
+
+def test_canonical_lane_accepts_a_card_that_produced_no_commit(tmp_path: Path) -> None:
+    """沒有新 commit 就沒有 bundle（git 拒絕產空的）——candidate 早已在來源樹裡。"""
+
+    repo = _source_repo(tmp_path)
+    workspace = _workspace(repo, tmp_path / "pool")
+    bundle = _dispatch(tmp_path)
+    baseline = _git(repo, "rev-parse", f"refs/heads/{_BRANCH}")
+
+    harvested = manager._harvest_build_candidate(
+        _job(bundle, workspace=workspace),
+        run=SimpleNamespace(workspace_root=str(repo)),
+        candidate=baseline,
+        coordinator_root=tmp_path / "coordinator",
+    )
+
+    assert harvested == baseline
+    # 但 branch 與 candidate 對不上時仍是 fail-closed，不得靜默放過
+    with pytest.raises(job_workspace.WorkspaceError, match="commit bundle missing"):
+        manager._harvest_build_candidate(
+            _job(bundle, workspace=workspace),
+            run=SimpleNamespace(workspace_root=str(repo)),
+            candidate="0" * 40,
+            coordinator_root=tmp_path / "coordinator",
+        )
+
+
+def test_canonical_lane_is_a_noop_for_a_job_without_a_spool_grant(
+    tmp_path: Path,
+) -> None:
+    """既有部署零回歸：沒有 spool 那一格就完全不觸發回收。"""
+
+    repo = _source_repo(tmp_path)
+    run = SimpleNamespace(workspace_root=str(repo))
+
+    assert (
+        manager._harvest_build_candidate(
+            {"worktree": str(repo), "branch": "main"},
+            run=run, candidate="0" * 40, coordinator_root=tmp_path / "coordinator",
+        )
+        is None
+    )
+    assert (
+        manager._harvest_build_candidate(
+            {"branch": "", "log_path": "/logs/x.jsonl"},
+            run=run, candidate="0" * 40, coordinator_root=tmp_path / "coordinator",
+        )
+        is None
+    )
+
+
+def test_slice_lane_verification_harvests_from_the_bundle_before_reading_the_branch(
+    tmp_path: Path,
+) -> None:
+    """`verification` 以來源 repo 為根判讀；少了回收整段會以 `candidate-unreadable` 收場。"""
+
+    repo = _source_repo(tmp_path)
+    base = _git(repo, "rev-parse", "main")
+    workspace = _workspace(repo, tmp_path / "pool")
+    bundle = _dispatch(tmp_path)
+    candidate = _builder_commit(workspace)
+    _run_bundle_step(workspace, bundle)
+
+    result = verification.run_result_verification(
+        slice_row={
+            "slice_id": "bundle-623",
+            "dispatch_base": base,
+            "verification": {
+                "contract": {
+                    "docs_class": "trivial",
+                    "review_policy": "not-required",
+                    "required_artifacts": [],
+                    "checks": [],
+                    "tests": [],
+                    "full_suite": {
+                        "argv": ["true"], "cwd": ".", "timeout_seconds": 5,
+                        "baseline": "no-regression",
+                    },
+                }
+            },
+        },
+        job={
+            "task": "bundle-623",
+            "branch": _BRANCH,
+            "worktree": str(workspace),
+            "log_path": str(tmp_path / "logs" / f"{_KEY}.jsonl"),
+        },
+        repo_root=repo,
+        coordinator_root=tmp_path / "coordinator",
+    )
+
+    assert result["payload"]["candidate"] == candidate
+    assert _git(repo, "rev-parse", f"refs/heads/{_BRANCH}") == candidate
+
+
+def test_slice_lane_reports_candidate_harvest_failed_with_an_actionable_detail(
+    tmp_path: Path,
+) -> None:
+    """bundle 缺席時不得靜默略過——needs_human ＋ 逐字可操作的原因。"""
+
+    repo = _source_repo(tmp_path)
+    base = _git(repo, "rev-parse", "main")
+    workspace = _workspace(repo, tmp_path / "pool")
+    bundle = _dispatch(tmp_path)
+
+    result = verification.run_result_verification(
+        slice_row={
+            "slice_id": "bundle-623",
+            "dispatch_base": base,
+            "verification": {
+                "contract": {
+                    "docs_class": "trivial",
+                    "review_policy": "not-required",
+                    "required_artifacts": [],
+                    "checks": [],
+                    "tests": [],
+                    "full_suite": {
+                        "argv": ["true"], "cwd": ".", "timeout_seconds": 5,
+                        "baseline": "no-regression",
+                    },
+                }
+            },
+        },
+        job={
+            "task": "bundle-623",
+            "branch": _BRANCH,
+            "worktree": str(workspace),
+            "log_path": str(tmp_path / "logs" / f"{bundle.parent.name}.jsonl"),
+        },
+        repo_root=repo,
+        coordinator_root=tmp_path / "coordinator",
+    )
+
+    payload = result["payload"]
+    assert payload["status"] == "needs_human"
+    assert payload["summary"] == "candidate-harvest-failed"
+    assert "commit bundle missing" in payload["details"]["candidate_harvest_error"]

--- a/tests/test_coordinator_launcher.py
+++ b/tests/test_coordinator_launcher.py
@@ -1291,7 +1291,10 @@ class ArgvTests(unittest.TestCase):
         script = argv[2]
         sentinel = str(exit_sentinel_path(handle.log_path))
         self.assertIn(shlex.quote(sentinel), script)
-        self.assertIn('"$?"', script)
+        # #623：模型的 `$?` 先存進 shell 變數（bundle 段夾在中間，見
+        # `build_wrapper_script`），寫進 sentinel 的仍然是**模型**的 exit code。
+        self.assertIn("__psc_rc=$?", script)
+        self.assertIn(f'printf %s "$__psc_rc" > {shlex.quote(sentinel)}', script)
         # 內層 argv 經 shlex.join 安全嵌入；含 -p PROMPT
         inner = shlex.join(["copilot", "-p", "PROMPT"])
         self.assertIn(inner, script)

--- a/tests/test_manager_authored_job_accounting_604.py
+++ b/tests/test_manager_authored_job_accounting_604.py
@@ -49,9 +49,17 @@ from paulsha_cortex.coordinator.launcher import SubprocessLauncher
 from paulsha_cortex.trust_root import permgen
 from paulsha_cortex.trust_root.registry import Principal, asset_by_id
 
+_ISOLATED_AGENTS_ROOT = tempfile.mkdtemp(prefix="psc-agents-root-")
+
 _BASE_ENV = {
     "PATH": "/usr/local/bin:/usr/bin:/bin",
     "HOME": "/var/lib/cortex-manager",
+    # conftest 的 `_clear_runtime_env` 把 PSC_AGENTS_ROOT 指向 per-test 暫存目錄，
+    # 但本檔的 launch 測試以 `clear=True` 重建整份 environ（要驗的就是白名單本身），
+    # 那層保護因此被清掉。顯式帶上一個 per-process 暫存根：`launcher.launch()` 會在
+    # coordinator 樹底下建這個 job 的成果 bundle spool（#623），少了它會落到 operator
+    # 的真實 `$HOME`——正是 conftest #303 註記要防的事。
+    "PSC_AGENTS_ROOT": _ISOLATED_AGENTS_ROOT,
     "LANG": "en_US.UTF-8",
     "PSC_REPO_ROOT": "/opt/cortex/venv/lib/python3/site-packages",
 }

--- a/tests/test_per_job_clone_provisioning_623.py
+++ b/tests/test_per_job_clone_provisioning_623.py
@@ -4,7 +4,8 @@
 
 1. provision——守衛與 worktree 模型逐條等價，且失敗不留殘留
 2. 隔離——工作區裡沒有任何回寫來源 repo 的路徑；未回收前來源 repo 不受影響
-3. 成果回收——Manager 單向 fetch 回自己的樹，非 fast-forward fail-closed
+3. 成果回收——Manager 單向取回自己的樹（**搬運介面是 bundle**，見
+   `tests/test_bundle_commit_harvest_623.py`：Manager 不得存取 builder 的 clone）
 4. 回收——clone 走目錄刪除、封存 HEAD；linked worktree（升級前既存）仍走
    `git worktree remove`；主 checkout 一律拒絕
 """
@@ -68,6 +69,29 @@ def _builder_commit(workspace: Path, name: str = "builder.txt") -> str:
     _git(workspace, "add", name)
     _git(workspace, "commit", "-qm", f"builder: {name}")
     return _git(workspace, "rev-parse", "HEAD")
+
+
+def _produce_bundle(workspace: Path, spool_root: Path, *, key: str = "job-1") -> Path:
+    """以 **builder 身分**跑 production wrapper 裡那一段 bundle 命令，回傳落地的 bundle。
+
+    刻意不在測試裡自己組 `git bundle create`——另寫一份只會驗到測試自己。
+    """
+
+    bundle = job_workspace.prepare_commit_spool(spool_key=key, coordinator_root=spool_root)
+    subprocess.run(
+        ["bash", "-c", job_workspace.build_bundle_command(workspace=workspace, bundle=bundle)],
+        cwd=str(workspace), check=True, capture_output=True, text=True,
+    )
+    return bundle
+
+
+def _harvest(
+    repo: Path, workspace: Path, spool_root: Path, *, branch: str = _BRANCH, key: str = "job-1"
+) -> str:
+    """builder 產 bundle → Manager 從那個檔案回收（成果離開 job 帳號的唯一路徑）。"""
+
+    bundle = _produce_bundle(workspace, spool_root, key=key)
+    return job_workspace.harvest_branch(source_repo=repo, bundle=bundle, branch=branch)
 
 
 # ---------------------------------------------------------------------------
@@ -263,9 +287,7 @@ def test_manager_harvests_the_candidate_out_of_the_builder_clone(
     workspace = Path(_creator(repo, tmp_path / "pool").create(_BRANCH))
     candidate = _builder_commit(workspace)
 
-    harvested = job_workspace.harvest_if_job_clone(
-        source_repo=repo, workspace=workspace, branch=_BRANCH
-    )
+    harvested = _harvest(repo, workspace, tmp_path / "coordinator")
 
     assert harvested == candidate
     assert _git(repo, "rev-parse", f"refs/heads/{_BRANCH}") == candidate
@@ -281,35 +303,41 @@ def test_harvest_rejects_a_rewritten_history_instead_of_absorbing_it(
     repo = _source_repo(tmp_path)
     workspace = Path(_creator(repo, tmp_path / "pool").create(_BRANCH))
     first = _builder_commit(workspace)
-    job_workspace.harvest_branch(source_repo=repo, workspace=workspace, branch=_BRANCH)
+    _harvest(repo, workspace, tmp_path / "coordinator")
 
     _git(workspace, "reset", "-q", "--hard", "HEAD~1")
     _builder_commit(workspace, "rewritten.txt")
 
     with pytest.raises(job_workspace.WorkspaceError, match="not a fast-forward"):
-        job_workspace.harvest_branch(source_repo=repo, workspace=workspace, branch=_BRANCH)
+        _harvest(repo, workspace, tmp_path / "coordinator", key="job-2")
 
     assert _git(repo, "rev-parse", f"refs/heads/{_BRANCH}") == first
 
 
-def test_harvest_is_a_noop_for_a_workspace_that_is_not_a_job_clone(
+def test_harvest_is_a_noop_for_a_job_dispatched_before_the_spool_existed(
     tmp_path: Path,
 ) -> None:
-    """零回歸掛點：worktree 模型與測試裡的假路徑完全不受影響。"""
+    """零回歸掛點：worktree 模型與測試裡的假 job 記錄完全不受影響。"""
 
     repo = _source_repo(tmp_path)
     legacy = tmp_path / "legacy-worktree"
     _git(repo, "worktree", "add", "-q", "-b", "feature/legacy", str(legacy), "main")
 
     assert (
-        job_workspace.harvest_if_job_clone(
-            source_repo=repo, workspace=legacy, branch="feature/legacy"
+        job_workspace.harvest_if_spooled(
+            source_repo=repo,
+            job={"worktree": str(legacy), "log_path": str(tmp_path / "logs" / "legacy.jsonl")},
+            branch="feature/legacy",
+            coordinator_root=tmp_path / "coordinator",
         )
         is None
     )
     assert (
-        job_workspace.harvest_if_job_clone(
-            source_repo=repo, workspace=tmp_path / "does-not-exist", branch="feature/x"
+        job_workspace.harvest_if_spooled(
+            source_repo=repo,
+            job={"worktree": str(tmp_path / "does-not-exist")},
+            branch="feature/x",
+            coordinator_root=tmp_path / "coordinator",
         )
         is None
     )
@@ -325,7 +353,7 @@ def test_reclaim_removes_a_job_clone_and_leaves_no_residue(tmp_path: Path) -> No
     repo = _source_repo(tmp_path)
     workspace = Path(_creator(repo, tmp_path / "pool").create(_BRANCH))
     _builder_commit(workspace)
-    job_workspace.harvest_branch(source_repo=repo, workspace=workspace, branch=_BRANCH)
+    _harvest(repo, workspace, tmp_path / "coordinator")
 
     result = worktree_reclaim.reclaim_worktree(workspace, repo_root=repo)
 
@@ -477,7 +505,7 @@ def test_gc_protects_the_branch_of_a_live_job_clone(tmp_path: Path) -> None:
     pool = tmp_path / "pool"
     workspace = Path(_creator(repo, pool).create(_BRANCH))
     _builder_commit(workspace)
-    job_workspace.harvest_branch(source_repo=repo, workspace=workspace, branch=_BRANCH)
+    _harvest(repo, workspace, tmp_path / "coordinator")
 
     artifacts = gc.scan(repo, worktree_root=pool)
     branch_rows = [item for item in artifacts if item.kind == "branch" and item.branch == _BRANCH]
@@ -523,10 +551,18 @@ def test_workflow_lane_harvests_the_candidate_when_the_card_is_accepted(
     repo = _source_repo(tmp_path)
     workspace = Path(_creator(repo, tmp_path / "pool").create(_BRANCH))
     candidate = _builder_commit(workspace)
-    job = {"worktree": str(workspace), "branch": _BRANCH}
+    coordinator_root = tmp_path / "coordinator"
+    bundle = _produce_bundle(workspace, coordinator_root)
+    job = {
+        "worktree": str(workspace),
+        "branch": _BRANCH,
+        "log_path": str(tmp_path / "logs" / f"{bundle.parent.name}.jsonl"),
+    }
     run = SimpleNamespace(workspace_root=str(repo))
 
-    harvested = manager._harvest_build_candidate(job, run=run, candidate=candidate)
+    harvested = manager._harvest_build_candidate(
+        job, run=run, candidate=candidate, coordinator_root=coordinator_root
+    )
 
     assert harvested == candidate
     assert _git(repo, "rev-parse", f"refs/heads/{_BRANCH}") == candidate
@@ -535,20 +571,23 @@ def test_workflow_lane_harvests_the_candidate_when_the_card_is_accepted(
 def test_workflow_lane_harvest_is_a_noop_outside_the_clone_model(
     tmp_path: Path,
 ) -> None:
-    """既有部署零回歸：worktree 模型與測試裡的假 worktree 路徑完全不觸發回收。"""
+    """既有部署零回歸：worktree 模型與測試裡的假 job 記錄完全不觸發回收。"""
 
     repo = _source_repo(tmp_path)
     run = SimpleNamespace(workspace_root=str(repo))
+    coordinator_root = tmp_path / "coordinator"
 
     assert (
         manager._harvest_build_candidate(
-            {"worktree": str(repo), "branch": "main"}, run=run, candidate="0" * 40
+            {"worktree": str(repo), "branch": "main"},
+            run=run, candidate="0" * 40, coordinator_root=coordinator_root,
         )
         is None
     )
     assert (
         manager._harvest_build_candidate(
-            {"worktree": "", "branch": _BRANCH}, run=run, candidate="0" * 40
+            {"worktree": "", "branch": _BRANCH},
+            run=run, candidate="0" * 40, coordinator_root=coordinator_root,
         )
         is None
     )
@@ -560,11 +599,19 @@ def test_workflow_lane_harvest_fails_closed_when_the_head_does_not_match(
     repo = _source_repo(tmp_path)
     workspace = Path(_creator(repo, tmp_path / "pool").create(_BRANCH))
     _builder_commit(workspace)
-    job = {"worktree": str(workspace), "branch": _BRANCH}
+    coordinator_root = tmp_path / "coordinator"
+    bundle = _produce_bundle(workspace, coordinator_root)
+    job = {
+        "worktree": str(workspace),
+        "branch": _BRANCH,
+        "log_path": str(tmp_path / "logs" / f"{bundle.parent.name}.jsonl"),
+    }
     run = SimpleNamespace(workspace_root=str(repo))
 
     with pytest.raises(ValueError, match="harvest head mismatch"):
-        manager._harvest_build_candidate(job, run=run, candidate="0" * 40)
+        manager._harvest_build_candidate(
+            job, run=run, candidate="0" * 40, coordinator_root=coordinator_root
+        )
 
 
 def test_slice_lane_verification_harvests_before_reading_the_branch(
@@ -580,6 +627,7 @@ def test_slice_lane_verification_harvests_before_reading_the_branch(
     base = _git(repo, "rev-parse", "main")
     workspace = Path(_creator(repo, tmp_path / "pool").create(_BRANCH))
     candidate = _builder_commit(workspace)
+    bundle = _produce_bundle(workspace, tmp_path / "coordinator")
     contract = {
         "docs_class": "trivial",
         "review_policy": "not-required",
@@ -600,7 +648,12 @@ def test_slice_lane_verification_harvests_before_reading_the_branch(
             "dispatch_base": base,
             "verification": {"contract": contract},
         },
-        job={"task": "clone-623", "branch": _BRANCH, "worktree": str(workspace)},
+        job={
+            "task": "clone-623",
+            "branch": _BRANCH,
+            "worktree": str(workspace),
+            "log_path": str(tmp_path / "logs" / f"{bundle.parent.name}.jsonl"),
+        },
         repo_root=repo,
         coordinator_root=tmp_path / "coordinator",
     )
@@ -620,9 +673,7 @@ def test_end_to_end_provision_commit_harvest_reclaim(tmp_path: Path) -> None:
     # 檔案權限那一半屬 trust-root 的 chown／ACL，不在本層）
     assert job_workspace.SOURCE_REMOTE not in _git(workspace, "remote").splitlines()
 
-    harvested = job_workspace.harvest_branch(
-        source_repo=repo, workspace=workspace, branch=_BRANCH
-    )
+    harvested = _harvest(repo, workspace, tmp_path / "coordinator")
     assert harvested == candidate
     assert _git(repo, "rev-parse", f"refs/heads/{_BRANCH}") == candidate
 

--- a/tests/test_trust_root_job_runner_p2a.py
+++ b/tests/test_trust_root_job_runner_p2a.py
@@ -30,9 +30,17 @@ from paulsha_cortex.coordinator.launcher import SubprocessLauncher
 
 
 # 每一輪 launch 測試都在乾淨的 env 上疊加，避免 operator 自己的 shell 汙染判定。
+_ISOLATED_AGENTS_ROOT = tempfile.mkdtemp(prefix="psc-agents-root-")
+
 _BASE_ENV = {
     "PATH": "/usr/local/bin:/usr/bin:/bin",
     "HOME": "/var/lib/cortex-svc",
+    # conftest 的 `_clear_runtime_env` 把 PSC_AGENTS_ROOT 指向 per-test 暫存目錄，
+    # 但本檔的 launch 測試以 `clear=True` 重建整份 environ（要驗的就是白名單本身），
+    # 那層保護因此被清掉。顯式帶上一個 per-process 暫存根：`launcher.launch()` 會在
+    # coordinator 樹底下建這個 job 的成果 bundle spool（#623），少了它會落到 operator
+    # 的真實 `$HOME`——正是 conftest #303 註記要防的事。
+    "PSC_AGENTS_ROOT": _ISOLATED_AGENTS_ROOT,
     "LANG": "en_US.UTF-8",
 }
 

--- a/tests/test_trust_root_job_template_ab.py
+++ b/tests/test_trust_root_job_template_ab.py
@@ -39,9 +39,17 @@ from paulsha_cortex.coordinator.launcher import SubprocessLauncher
 from paulsha_cortex.trust_root import permgen, registry
 from paulsha_cortex.trust_root.registry import Principal
 
+_ISOLATED_AGENTS_ROOT = tempfile.mkdtemp(prefix="psc-agents-root-")
+
 _BASE_ENV = {
     "PATH": "/usr/local/bin:/usr/bin:/bin",
     "HOME": "/var/lib/cortex-manager",
+    # conftest 的 `_clear_runtime_env` 把 PSC_AGENTS_ROOT 指向 per-test 暫存目錄，
+    # 但本檔的 launch 測試以 `clear=True` 重建整份 environ（要驗的就是白名單本身），
+    # 那層保護因此被清掉。顯式帶上一個 per-process 暫存根：`launcher.launch()` 會在
+    # coordinator 樹底下建這個 job 的成果 bundle spool（#623），少了它會落到 operator
+    # 的真實 `$HOME`——正是 conftest #303 註記要防的事。
+    "PSC_AGENTS_ROOT": _ISOLATED_AGENTS_ROOT,
     "LANG": "en_US.UTF-8",
 }
 


### PR DESCRIPTION
## 摘要

成果回收由「Manager 伸手進 builder 的 clone fetch」改為 **git bundle ＋ append-only
spool**。operator 0817 已裁決。本 PR 只做 **coordinator 側**，不動
`paulsha_cortex/trust_root/`（登記表資產與 OS 權限由 #636 定義）。

## 為什麼非改不可

#634 落地的回收做法是：

```
git -C <來源樹> fetch --no-tags <builder 的 clone> refs/heads/<b>:refs/heads/<b>
```

operator 實機驗證它在 trust-root Phase 2b 三分下**行不通**，兩個獨立原因：

1. **Manager 走不進 builder 的樹**——job 的 clone 在 `<worktree>/<job-id>`，
   builder-owned `0700`。`git -C <clone> …` → `fatal: cannot change to '…':
   Permission denied`。
2. **per-job 路徑無法用一條設定涵蓋**——就算開了父鏈 traverse，Manager 還要對每個
   job 的 clone 路徑有跨擁有者的 `safe.directory`，而**實測 git 2.43 不吃路徑
   glob**，只認逐字相等或字面 `*`。

## 改法

builder 在自己的 clone 產出 bundle → 寫進 Manager-owned 的 append-only spool →
Manager 從**那個檔案** fetch：

```bash
# builder 身分（Manager 組出的 wrapper script）
git -C <clone> bundle create <spool>/<key>/commits.bundle "$(git -C <clone> symbolic-ref HEAD)" ^refs/cortex/base

# Manager 身分
git -C <來源樹> fetch --no-tags <spool>/<key>/commits.bundle refs/heads/<b>:refs/heads/<b>
```

關鍵在 Manager 讀的是一個**普通檔**而不是一個 repo——dubious-ownership 與 traverse
兩個問題同時消失，且 Manager **全程不需要、也不應該**存取 builder 的樹。

### 路徑契約

`<coordinator_root>/commit-spool/<job-id>/commits.bundle`，形態完全比照既有的
`review-verdict-spool`：容器 owner＝`cortex-manager` 0700、producer 以 **`wx` 無
`r`** 的 per-account ACL、per-job 目錄由 Manager 在 dispatch 當下建立
（`prepare_commit_spool`）、成果落地後轉唯讀（`seal_commit_spool`）。

seal 封的是**目錄**（`0500`）而不是檔案：bundle 由 builder 的 uid 建立，Manager
不是它的 owner、`chmod` 不了它；但 Manager 是目錄的 owner，收掉目錄的 `w` 之後那一格
就再也建不了、改不了名、刪不掉任何檔，而 POSIX ACL 的 mask 同時被收窄，producer 的
`wx` 授權一併失效。

**與 #636 的契約分工**：#636 已 merge，路徑契約的權威 resolver 是
`config/paths.py:commit_spool_root()`（登記表資產 `commit-spool`）。本 PR 已 rebase
到它上面，**未改動 `config/paths.py` 一個位元組**。`job_workspace.commit_spool_root()`
逐字委派給它，只多接受一個**顯式**的 coordinator root——`manager` 與 `verification`
都有這個參數，一律回頭讀 env 會讓同一個 job 的 dispatch 與 harvest 指到兩棵不同的樹。
**契約與 #636 宣告的完全一致**（`<coordinator_root>/commit-spool/<job-id>/`，容器
`0700 durable_state_owner` ＋ builder `wx` 無 `r`），bundle 檔名由本 PR 定為
`commits.bundle`（#636 的 spec 只寫 `<name>.bundle`，未 pin）。

### bundle 不是證據，是搬運

#628 已把 gate ledger 與 exit sentinel 的作者收斂到 Manager，理由是「被驗方不得在
自己的進程裡產生自己的驗收證據」。bundle **不適用**那一條：它不宣告任何結論，只把
commit 從一個 object store 搬到另一個。採信仍全部由 Manager 判斷——canonical lane 的
回收掛在 `_verify_build_candidate_transition` **之後**，且回收後來源樹的 branch
**必須恰等於已採信的 candidate**，對不上即 fail-closed（沿用 #540 的 acceptance
chain：model 既不能自證成功、也不能自證失敗）。bundle 內容由 builder 掌控因此不新增
任何採信面：它能造成的最壞情況就是讓回收失敗。

## bundle 在哪個時點產生

在 Manager 組出的 wrapper script 裡（`launcher.build_wrapper_script` 的
`commit_bundle=`），段序是：

```
<模型 argv>; __psc_rc=$?; <bundle>; [printf %s "$__psc_rc" > <sentinel>;] [<gate>;] exit "$__psc_rc"
```

三個決定：

- **bundle 排在 sentinel 之前**——sentinel 一出現，Manager 隨時可能在下一個 tick 判定
  完成並開始回收；bundle 必須先落地。降權模式沒有 job 側 sentinel，但 Manager 側的
  記帳 shell 等的是整個 unit（`systemctl start --wait`），bundle 同樣先完成。
- **`$?` 存進 shell 變數再還原**——降權模式下 unit 的 exit code 就是這支 script 的
  exit code，而 Manager 的記帳 shell 記的正是它（#604）。多接一段 bundle 之後若不
  還原，模型明明失敗卻會被記成成功（或反過來）。測試真的跑一次 bash 驗這件事。
- **bundle 段用 `git` 而不是像 gate 那樣呼叫 python module**——降權模式下 builder
  看到的是白名單 env，且未必讀得到 Manager 的 repo root（`ProtectHome=yes` 之後
  `/home` 整個不可見，#623 缺口 1），`PYTHONPATH=<repo>` 那條路在那裡不成立。`git`
  是 job 本來就必須有的工具。

`.part` → `chmod 0644` → `mv` 三步以 `&&` 串接：spool 裡看得見的 `commits.bundle`
恆為完整檔（中途被 kill 只留下 `.part`），而 `chmod` 讓降權 unit 常見的
`UMask=0077` 不會產生一份 Manager 讀不到的成果（不擴張暴露面——那一格的容器是
`0700 cortex-manager` ＋ per-account `wx`，別的帳號連 traverse 都進不來）。

## `^<base>` 怎麼推導

provisioning（`seams.ScriptWorktreeCreator._clone`）在 clone 內
`update-ref refs/cortex/base <exact_base>`，wrapper 以 `^refs/cortex/base` 收斂範圍。

**為什麼各條 lane 都正確**：`exact_base` 是**來源 repo 自己**
`rev-parse --verify <base>^{commit}` 解出來的 commit，所以「來源樹一定有 bundle 的
prerequisite」由 provisioning 這個**單一推導點**成立。lane 之間唯一的差別是傳給
`create()` 的 `base_sha`（canonical lane 給 dispatch base、slice lane 給
`base_sha or dispatch_head`、CLI 原語不給而落到 `self._base`），而那個值在同一個
函式裡被同一次 `rev-parse --verify` 收斂——不存在「某條 lane 的 base 不在來源樹裡」
的路徑。base pin 與標記檔的 `base` 欄同源，測試逐條釘住。

**為什麼 pin 在 clone 裡而不是寫死在 wrapper**：產 bundle 的是 builder，它讀得到
自己的 clone，卻讀不到 spool（ACL 是 `wx` 無 `r`）也讀不到 Manager 的任何狀態。
builder 動得了這個 ref，但動了的後果只有一種：bundle 產不出來、或 prerequisite 對
不上而 fetch 失敗——一律 fail-closed。

## 不完整 bundle 的處理

`git fetch` 對缺 prerequisite 的 bundle 只吐 `error: Repository lacks these
prerequisite commits:` 加一串裸 SHA，看不出下一步。`harvest_branch()` 因此逐類包一層：

| 情形 | git 原文 | 包上去的可操作說明 |
|---|---|---|
| bundle 缺席 | （檔案不存在） | 兩種成因（這一輪沒有新 commit／`refs/cortex/base` 被動過或 HEAD detached），並指出逐字原因在該 job 的 JSONL log 末段 |
| prerequisite 缺席 | `Repository lacks these prerequisite commits` | 指出處置是**重新 provision** 讓 base 重新錨定，**不得**放寬 refspec |
| bundle 帶的是別的 branch | `couldn't find remote ref` | 指出以 `git bundle list-heads` 確認實際帶的 ref，不得改用其他 ref 回收 |
| 非 fast-forward | `non-fast-forward` / `rejected` | 訊息逐字保留（#634 既有） |

四類全部 fail-closed，**沒有任何一條退回讀 clone**。

## bundle 檔的保留策略

**成功回收後保留並封存，不刪除。**

#634 加的 `refs/cortex/reclaimed/**` 封存機制存在的理由是：clone 模型下 `rmtree`
會把尚未回收的 commit 一併刪掉，而 `worktree_reclaim` 的模組契約明文「不銷毀證據」。
但它的實作本身要 `git -C <clone> rev-parse HEAD` ＋ `git fetch <clone>`——在三分下
**同樣不可行**。

bundle 正是那個機制的替代品：它是那些 commit 在 **Manager-owned 樹裡**的副本，
而且取得它完全不需要碰 builder 的樹。因此：

- **clone 形狀**：證據面改由 sealed bundle 承擔（保留、唯讀、可 `git bundle
  list-heads` 稽核）。
- **升級前既存的 linked worktree**：`archive_workspace_head()` 原地保留不動。

把 `worktree_reclaim` 也改成優先讀 bundle 需要「工作區路徑 ↔ job id」的對應，目前
不存在（工作區名是 branch slug、spool key 是 launch id），**列為後續票**，不塞進
本 PR。

## spool key 的推導只有一條規則

`Path(job["log_path"]).stem` ——那正是 `launcher.launch()` 收到的 `slice_id`，同時
決定 exit sentinel（`<log_dir>/<slice_id>.exit`）與 gate ledger
（`terminal_contract.gate_ledger_path(log_path)`）的落點。

這件事必須是**單一規則**：canonical lane 的 launch key 是 job_id、slice lane 的是
slice_id；兩條 lane 若各自在回收端「猜」自己的 key，任何一邊改名都會退化成
「找不到 spool → 靜默不回收」——最壞的失敗形態（成果沒進來，錯誤訊息卻出現在很遠的
地方）。

同理，「這個 job 要不要回收」的判準改為 **Manager-owned spool 那一格在不在**，不再
是「工作區是不是 clone」：後者要讀 `<clone>/.git/` 底下的標記檔，而三分下 Manager
讀不到，判準會恆為 False。`job_workspace` 的形狀判定同時收斂了 `PermissionError`
（回 False 而不是讓一個 tick 整個掛掉）——`gc` 與 `worktree_reclaim` 在「認不出這是
什麼」時的正確行為都是不動它。

## `direct` 模式相容性

沿用 #634「以工作區自己的形狀判斷、不依 `PSC_JOB_RUNNER` 分支」的原則：**spool 授權
是 dispatch 當下就決定的形狀**，`direct` 與兩種降權模式走完全相同的路徑。

- **判準是 persona**（`read_only`＝planner、`review_only`＝reviewer，兩者皆非才是
  builder），與 `_should_run_gates`／`_downgraded_mode` 既有的 persona 分支對齊。
  reviewer／planner 不產生 commit，給它們一格 spool 只會多一個沒人寫的空目錄。
- **`commit_bundle=None` 時 `build_wrapper_script` 的輸出逐字與改動前相同**（測試以
  完整字串比對釘住）。
- 同一個 key 重跑（retry-card／forced retry）時 `prepare_commit_spool` 清掉殘留並把
  上一輪的 seal 解開，與 `launch()` 對 sentinel／ledger 既有的「重跑先清殘留」慣例
  逐條一致。
- 全套 3674 passed，零回歸。

## 測試

新增 `tests/test_bundle_commit_harvest_623.py`（30 測試，全部以**真 git repo** 驗證）：

- **base 錨點**——單一推導點、與標記檔同源、指定 `base_sha` 時 pin 的是那一個、
  pin 不讓工作區一出生就 dirty。
- **產出與回收**——bundle 產生 → 回收 → branch 與 **diff 內容**都正確落地；
  `^<base>` 真的收斂了範圍（`list-heads` 只有這一輪）；重複 tick 冪等。
- **不變式（本次變更的全部價值）**——把 clone `chmod 000` 重現實機的
  `Permission denied`，整條回收路徑（含 `manager._harvest_build_candidate`）照常完成；
  另一條釘住「Manager 的 fetch 對象是普通檔，不是 repo」。**已做突變驗證**：在回收
  路徑裡加一次 clone 存取，這條當場紅。
- **fail-closed**——四類錯誤各一條，逐條檢查訊息帶得出下一步；symlink bundle 拒絕。
- **spool 生命週期**——pre-seed 殘留被清掉而不是被繼承、seal 之後那一格寫不進去但
  bundle 仍讀得到、retry 重新開封、key 形狀守衛（`../escape` 等）。
- **wrapper**——無 bundle 時逐字不變（完整字串比對）、bundle 排在 sentinel 之前、
  **真的跑一次 bash** 驗 exit code 不被污染（模型 exit 3 → sentinel 是 3 且 bundle
  仍產出）、降權形狀無 sentinel／無 gate 但 exit code 正確、失敗不留半成品、
  `umask 0077` 下 Manager 仍讀得到。
- **兩條 lane**——canonical lane 的採信點、head mismatch fail-closed、沒有新 commit
  的卡不誤判、slice lane 從 bundle 回收後 `verification` 讀得到 candidate、bundle
  缺席時 `candidate-harvest-failed` 帶可操作 detail。

另修正三個 trust-root launch 測試檔（`test_trust_root_job_runner_p2a.py`／
`test_trust_root_job_template_ab.py`／`test_manager_authored_job_accounting_604.py`）：
它們以 `mock.patch.dict(..., clear=True)` 重建整份 environ（要驗的就是白名單本身），
把 conftest 的 `PSC_AGENTS_ROOT` 保護一併清掉。顯式帶上 per-process 暫存根——否則
`launch()` 會在 operator 的**真實 `$HOME`** 底下建 spool，正是 conftest #303 註記要
防的事。

```
python3 -m pytest tests/ -q
3742 passed, 49 subtests passed   # rebase 到 #636 之上
```

## 已知缺口（本 PR 不收）

1. **`_verify_build_candidate_transition` 仍 `git -C <worktree>`**——candidate
   驗證（「宣稱的 candidate 是否就是工作區 HEAD」）與 `verification` 的
   dirty-tree 檢查都還會伸手進 builder 的樹，在三分下會失敗。這**不能**改成讀
   bundle：bundle 的內容也是 builder 產的，兩邊同源會讓那道檢查退化。正確解法是
   獨立的一票（例如由 gate 執行身分在受控 checkout 判讀）。本 PR 讓**回收**這一段
   先脫離對 clone 的依賴。
2. **`worktree_reclaim` 尚未改讀 bundle**——需要「工作區路徑 ↔ job id」對應，見上。
3. **spool 的 GC**——bundle 只帶單張卡的增量（很小），目前隨 coordinator 樹長存；
   要不要納入 `cortex work gc` 屬後續票。
4. **升級中途的 in-flight job**——本 PR 前派工的 job 沒有 spool 那一格，回收會
   no-op（fail-closed，不是靜默吸收）。#634 今天才 merge，建議切換前先讓在跑的 job
   收尾。

## Checklist

- [x] 分支從 `main` 開，命名 `feature/623-bundle-harvest`
- [x] `changelog.d/bundle-harvest.md` fragment 已新增且已 commit
- [x] `CHANGELOG.md [Unreleased] → Changed` 有對應 entry
- [x] `VERSION` 未動（非 release PR）
- [x] 全套測試通過（3674 passed），零回歸
- [x] 針對「Manager 不存取 builder 的 clone」新增不變式測試，並做過突變驗證
- [x] `python3 -m policy_check` 帶完整 PR 上下文跑過，fail: 0
- [x] 文件與 PR 內文為 zh-tw
- [x] 未動 `paulsha_cortex/trust_root/`，也未動 `config/paths.py`（已 rebase 到 #636 之上）
- [x] 部分修法（只做 coordinator 側），故用 `Refs #623` 並上 `policy-exempt:issue-link`

Refs #623
Refs #634 #636 #628 #540

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E7w9kaUxAzCCEk7piD5hfK

