### PR TITLE
fix(trust-root): spool 的 per-job 權限模型收斂成同一套 helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,29 @@
   `tests/test_trust_root_job_template_ab.py`（80 測試）。
 
 ### Fixed
+- **#638 / trust-root：兩個 spool 的 producer／consumer 權限模型在三分下三處失效——
+  verdict 通道（Phase 2a）實際從未成立過，`commit-spool` 繼承了同樣的缺陷**——三個
+  獨立缺陷全部有 operator 的實機證據：(1) per-job 目錄以明確 mode 建立會**重設 ACL
+  mask**，把 default ACL 繼承來的具名條目壓成 `#effective:---`，producer 連建檔都不行
+  （實機 `fatal: Unable to create '…/commits.bundle.part.lock': Permission denied`）；
+  (2) `wx` 無 `r` 的那一格上，producer 建的檔由 producer 擁有，**consumer 讀不到**；
+  (3)「落地後轉唯讀」實作成 `chmod` producer 擁有的**檔案**，而只有 owner 或 root
+  能 chmod，該處又刻意不 raise ⇒ **無聲失敗**，實測 reviewer 可以在 Manager 判讀之後
+  回頭覆寫自己的 verdict。修法：per-job 目錄**不傳明確 mode**（初始權限交給 default
+  ACL，事後只檢查並收窄 `other`；有 ACL 時 `group` 位就是 mask，刻意不動）；producer
+  寫完後自己 `chmod 0644`（verdict 那邊由 wrapper script 在模型結束後補一段，排在
+  exit sentinel 之前且不污染 `$?`）；seal 改封**目錄**（`0500`——consumer 是目錄的
+  owner，收掉 `w` 讓那一格定版，`chmod` 同時把 mask 收成 `---`，producer 具名條目的
+  traverse 一併失效）。兩個 spool 的 per-job 生命週期收斂到新的
+  `coordinator/spool_slot.py`——這個 bug 之所以有兩個實例，正是因為兩邊各自實作。
+  pre-seed 守衛語意與 operator 看到的錯誤字串一字未變。新增
+  `tests/test_spool_permission_model_638.py`：**自己建出帶 default ACL 的容器**並直接
+  斷言具名條目的 **effective 權限**（不是斷言 mode），同一組不變式參數化涵蓋
+  `review-verdict-spool` 與 `commit-spool`，另含一條把「修法前的形狀在同一個 fixture
+  下必須是紅的」釘住的突變驗證；跨 UID 的正反向功能驗收需要 root，拿不到時（以及檔案
+  系統不支援 ACL 時）**明確 skip 並說明理由**，不靜默通過。本票是 M2（#615）的前置：
+  verdict 通道目前只因 reviewer 仍以 Manager 帳號在行程內跑而看似正常，M2 一落地即
+  整條斷。（Closes #638）
 - **#626 / trust-root：permgen 為不存在的 principal 產生 `setfacl`，`sh -e` 下中止整份
   script 留下半套用的權限樹**——`permissions --commands --paths` 會印出
   `setfacl -m u:operator:rX …` 與 `setfacl -m u:cortex-outbox:rX …`，但這兩個是

--- a/changelog.d/spool-permission-model.md
+++ b/changelog.d/spool-permission-model.md
@@ -1,0 +1,85 @@
+### Fixed
+- **#638 / trust-root：兩個 spool 的 producer／consumer 權限模型在三分下三處失效——
+  verdict 通道（Phase 2a）實際從未成立過，`commit-spool` 繼承了同樣的缺陷**
+  （Closes #638）
+
+  operator 在為 #623 的 bundle 回收做端到端實測時撞到三個**獨立**缺陷，全部有實機
+  證據；#637 merge 之後降權模式下的成果回收整條不可用，卡在本票。三個缺陷影響既有的
+  `review-verdict-spool`（#599）與新的 `commit-spool`（#636／#637）——形態刻意相同，
+  所以缺陷也一起繼承。
+
+  **缺陷 1（blocking，已在產品程式碼上重現）**：per-job 目錄以明確 mode 建立會**重設
+  ACL mask**，把 default ACL 繼承來的具名條目壓成 `#effective:---`：
+
+  ```
+  $ getfacl /var/lib/cortex/coordinator/commit-spool/<key>   # prepare_commit_spool() 建的
+  user::rwx
+  user:cortex-builder:-wx    #effective:---     ← 繼承來的授權被 mask 遮掉
+  mask::---
+  ```
+
+  接著以 builder 身分執行 `build_bundle_command()` 逐字產生的命令：
+  `fatal: Unable to create '…/commits.bundle.part.lock': Permission denied`。
+  兩個實例（`review.py` 的 `spool_dir.mkdir(mode=0o700)` 與 `prepare_commit_spool()`
+  的「0700 建立／已存在時重新 chmod 0700」）是**同一個 bug**。
+
+  **修法**：per-job 目錄**不再傳明確 mode**，初始權限交給 default ACL；建立後只
+  **檢查**並收窄，而不是用 `chmod` 把 mask 一起壓掉。取捨寫在
+  `spool_slot.narrow_inherited_mode()`：`other` 位一律收掉（它與 mask 無關，收窄它
+  不影響任何具名條目，所以這一半的「不比 0700 更鬆」無條件保住）；`group` 位只在該
+  項**沒有** access ACL 時才收掉——有 ACL 時 group 位**就是 mask**，壓掉它正是缺陷 1
+  本身，此時它的值由 operator 的 `default:mask::` 決定，那是授權模型的一部分。因此
+  「不比 0700 更鬆」在無 ACL 的部署（含所有既有測試環境）下逐字成立，在有 ACL 的部署
+  下被**明確地**讓給 default ACL；那一格真正的邊界是它的容器（`0700 cortex-manager`，
+  別的帳號連 traverse 都進不來）＋ per-account 具名條目。若 mode 已經合規則完全不呼叫
+  `chmod`——`chmod` 本身就是會重設 mask 的那個動作。
+
+  **缺陷 2**：`wx` 無 `r` 的那一格上，producer 建的檔由 producer 擁有（又常帶降權
+  unit 的 `UMask=0077`），consumer 讀不到；容器 owner 的身分不給檔案內容的讀取權。
+  **修法**沿用 #637 已實機驗證的繞法並套到 `review-verdict-spool`：producer 寫完後
+  自己 `chmod 0644`。bundle 那邊 producer 是 Manager 組出的 `git` 命令（既有的
+  `.part` → `chmod` → `mv`）；verdict 那邊 producer 是**模型本身**，它不會自己
+  chmod，所以由 wrapper script 在模型結束後補一段
+  `{ [ -f <verdict> ] && chmod 0644 <verdict>; } 2>/dev/null || :`，排在 exit
+  sentinel **之前**（sentinel 一出現 Manager 隨時可能開始收割），且以存下來的模型
+  `$?` 收場（#604：降權模式下 unit 的 exit code 就是這支 script 的 exit code）。
+
+  **缺陷 3**：`seal_review_verdict_spool()` 的 `os.chmod(<verdict>, 0o444)` 由
+  Manager 執行，但檔案是 reviewer 擁有的——**只有 owner 或 root 能 chmod**，必然
+  `PermissionError`，而該處**刻意不 raise**，所以**無聲失敗**。實測後果：reviewer
+  可以在 Manager 判讀之後回頭 `printf TAMPERED > <verdict>`，spec §R2 要守的東西
+  從未成立。**修法**同樣沿用 #637：封的是**目錄**（`0500`）——Manager 是目錄的 owner，
+  收掉 `w` 讓那一格定版，而 `chmod` 同時把 ACL mask 收成 `---`，reviewer 具名條目的
+  `x`（traverse）一併失效，它連既有的 verdict 檔都再也打不開。**pre-seed 守衛語意
+  完全保留**（dispatch 前該格必須不存在合法 verdict）。
+
+  **收斂成一套 helper**：新增 `coordinator/spool_slot.py`，兩個 spool 的 per-job
+  生命週期（建立 → producer 寫 → consumer 讀 → seal）全部走它。這個 bug 之所以有
+  兩個實例，正是因為兩邊各自實作了這一段。`review.py` 與 `job_workspace.py` 只保留
+  各自的路徑推導、錯誤面翻譯與守衛訊息（operator 看到的錯誤字串一字未變）。解封
+  （`commit-spool` 的 retry：同一個 slice_id 重派）改為**整格重建**而不是 `chmod`
+  回去——seal 把 mask 收成 `---`，而正確的 mask 只有讓 default ACL 重新繼承一次才
+  拿得到；重建同時涵蓋了 #637 既有的「起跑前清掉殘留」。`review-verdict-spool` 每次
+  派工都是新的 reviewer job id，因此不需要、也不該有解封路徑。
+
+  **測試**：新增 `tests/test_spool_permission_model_638.py`。既有測試在單 UID 環境下
+  跑，那裡 ACL mask 不影響任何事，所以全綠卻不承載三分的語意——#637 的 CI 全綠卻在
+  實機第一步就斷掉正是這個形狀（同類前例：#630「綠靠 cwd 剛好是 repo」、#631「長
+  TMPDIR 下 36 個測試靜默 skip」）。因此新測試**自己建出帶 default ACL 的容器**，
+  直接斷言具名條目的 **effective 權限**（mask 套用後的結果）而不是斷言 mode；ACL 的
+  設定與讀取都走 `system.posix_acl_*` xattr（`setfacl`／`getfacl` 用的同一個核心
+  介面），不依賴 `acl` 套件裝了沒。同一組不變式**同時參數化涵蓋兩個 spool**：那一格
+  建立後具名條目不得被遮、`other` 位一律收掉、seal 之後 mask 與 effective 皆為
+  `---`、retry 解封後授權真的回來、pre-seed 守衛在 ACL 樹上仍然拒絕。另有一條**突變
+  驗證**測試把「修法前的形狀（`mkdir(mode=0o700)`）在同一個 fixture 下必須是紅的」
+  釘住，避免 fixture 哪天不再建出 ACL 樹而讓上面那些斷言退化成空過。跨 UID 的功能
+  驗收（producer 寫得進去／consumer 讀得到／seal 後 producer 改不動，正反各一）需要
+  root 才借得到兩個身分，拿不到時**明確 skip 並說明理由**（結構性的 effective-ACL
+  斷言在任何支援 ACL 的環境都會跑）；檔案系統不支援 ACL 時同樣明確 skip 並說明
+  ——不靜默通過。
+
+  **與 M2（#615）的關係**：本票是 M2 的前置。Phase 2a 的 verdict 通道在三分下從未
+  真正成立過，只因 reviewer 目前仍以 Manager 帳號在行程內跑、同 UID 所以一切都通。
+  M2 一旦落地（reviewer 有自己的降權啟動面），verdict 通道會立刻整條斷。
+
+  全套 `python3 -m pytest tests/ -q`：3761 passed，零回歸。

--- a/docs/superpowers/runbooks/trust-root-phase2b-setup.md
+++ b/docs/superpowers/runbooks/trust-root-phase2b-setup.md
@@ -805,6 +805,13 @@ sudo -u cortex-builder ls /var/lib/cortex/coordinator/commit-spool 2>&1 | tail -
 sudo -u cortex-reviewer-planner sh -c \
   "touch /var/lib/cortex/coordinator/commit-spool/probe" 2>&1 | tail -1
 #   期望：Permission denied（producer 只有 builder）
+
+# ✅ 驗證（#638）：dispatch 之後那**一格**的具名條目沒有被 mask 遮掉
+getfacl -p /var/lib/cortex/coordinator/commit-spool/<job-id> 2>/dev/null \
+  | grep -E '^(user:cortex-builder|mask)'
+#   期望：user:cortex-builder:-wx（**不得**帶 `#effective:---`）、mask::-wx 或更寬
+#   出現 `mask::---` ⇒ 那一格是以明確 mode 建立的（#638 缺陷 1 復發），
+#         builder 會在 `commits.bundle.part.lock` 這一步就 Permission denied。
 ```
 
 **更新來源樹**（日常操作）：Manager 現在是 owner，因此**服務自己就能** `fetch`；以
@@ -967,8 +974,27 @@ sudo -u cortex-manager env $(grep -v '^#' /opt/cortex/etc/cortex-manager.env | x
 Phase 2a（PR #599）已把 review verdict 的落點從 reviewer worktree 搬到
 `/var/lib/cortex/coordinator/review-verdicts/<reviewer_job_id>/verdict.json`
 （登記表 `review-verdict-spool`，spec §R2）。**程式碼側已完成**：per-job 目錄由
-Manager 在 dispatch 當下以 `0700` 建立、帶 pre-seed 守衛，落地後轉 `0444`；reviewer
-身分由 Manager job registry 推導，verdict payload 的自述綁定欄位一律忽略。
+Manager 在 dispatch 當下建立、帶 pre-seed 守衛，落地後把**那一格目錄**轉唯讀
+（`0500`）；reviewer 身分由 Manager job registry 推導，verdict payload 的自述綁定
+欄位一律忽略。
+
+> **#638 修正的三件事**（三分下才看得見，單 UID 環境全部無感）：
+>
+> 1. per-job 目錄**不再以明確 mode 建立**——明確 mode 會把 default ACL 繼承來的
+>    具名條目連同 **mask** 一起重設成 `#effective:---`，reviewer 因此連 verdict
+>    都寫不出來（`commit-spool` 的同一個 bug 讓 builder 連 `.part.lock` 都建不了）。
+> 2. verdict 由 **reviewer 自己在寫完後 `chmod 0644`**（wrapper script 的發表段）
+>    ——否則檔由 reviewer 擁有、又常帶 `UMask=0077`，Manager 讀不到。
+> 3. seal 從「`chmod 0444` verdict 檔」改成「封**目錄**」——只有 owner 或 root 能
+>    `chmod`，Manager 不是 verdict 的 owner，舊做法必定 `PermissionError` 且刻意
+>    不 raise ⇒ **無聲失敗**，reviewer 可以在 Manager 判讀之後回頭覆寫自己的 verdict。
+>
+> 驗證（三分主機上，spool 那一格建立之後）：
+>
+> ```bash
+> # 期望：具名條目沒有 #effective:--- ，mask 不是 ---
+> sudo getfacl -p /var/lib/cortex/coordinator/review-verdicts/<reviewer_job_id>
+> ```
 
 spool 根的權限**已包含在第 2 步的權限 script 內**（它是登記表資產），這裡只做確認：
 

--- a/docs/superpowers/specs/trust-root-isolation-spec.md
+++ b/docs/superpowers/specs/trust-root-isolation-spec.md
@@ -434,6 +434,24 @@ repo」。裁決前先排除了一條看似最省事的路：**`git worktree` �
   `durable_state_owner`、mode 0700，producer 僅獲 **`wx` 無 `r`** 的 per-account ACL，
   per-job 目錄由 Manager 在 dispatch 當下建立、落地後轉唯讀。
 
+##### 兩個 spool 的 per-job 生命週期（#638）
+
+`review-verdict-spool` 與 `commit-spool` 的那一格 SHALL 走**同一套**實作
+（`coordinator/spool_slot.py`）——形態相同而各自實作，缺陷就會有兩個實例，#638 的
+三個缺陷正是這樣出現的。三條規則：
+
+- **per-job 目錄 MUST NOT 以明確 mode 建立。** 在帶 default ACL 的容器下，明確
+  mode 會連 **ACL mask** 一起重設，把繼承來的具名條目壓成 `#effective:---`，
+  producer 因此連建檔都不行。初始權限交給 default ACL，事後只**檢查**並收窄
+  `other` 位；`group` 位在有 ACL 時**就是 mask**，MUST NOT 被收窄。
+- **producer SHALL 在寫完後自行把成果放寬到 consumer 讀得到**（0644）。`wx` 無
+  `r` 的那一格上檔案由 producer 擁有，容器 owner 的身分不給檔案內容的讀取權。
+  放寬不擴張暴露面——容器是 `0700 <durable_state_owner>`，別的帳號連 traverse
+  都進不來。
+- **seal SHALL 封目錄，MUST NOT 只 `chmod` 成果檔。** 只有檔案 owner 或 root 能
+  `chmod`，而成果是 producer 擁有的；封目錄則是 consumer 對自己**擁有**的那一項
+  操作，且 `chmod` 同時把 mask 收成 `---`，producer 具名條目的 traverse 一併失效。
+
 ##### `repo-source-tree` 的 owner：從 root 改為 Manager（0817 裁決）
 
 本節初版（PR #636 第一版）把 writer 定為部署身分，理由是「Manager 被攻陷也改不了每個

--- a/paulsha_cortex/coordinator/job_workspace.py
+++ b/paulsha_cortex/coordinator/job_workspace.py
@@ -76,7 +76,6 @@ chain：model 既不能自證成功、也不能自證失敗）。bundle 內容�
 from __future__ import annotations
 
 import json
-import os
 import re
 import shlex
 import shutil
@@ -86,6 +85,8 @@ from pathlib import Path
 from typing import Any, Mapping
 
 from paulsha_cortex.config import paths
+
+from . import spool_slot
 
 #: clone 工作區的識別標記檔名，寫在 clone 自己的 `.git/` 底下。
 #:
@@ -127,8 +128,9 @@ ARCHIVE_REF_PREFIX = "refs/cortex/reclaimed"
 #: :func:`harvest_branch` 的錯誤分類。
 BASE_REF = "refs/cortex/base"
 
-#: per-job spool 裡那一份 bundle 的檔名。
-COMMIT_BUNDLE_FILENAME = "commits.bundle"
+#: per-job spool 裡那一份 bundle 的檔名（權威定義在 `spool_slot`，與
+#: `review-verdict-spool` 的成果檔名並列在同一處）。
+COMMIT_BUNDLE_FILENAME = spool_slot.COMMIT_BUNDLE_FILENAME
 
 #: builder 產 bundle 時的暫存名。先寫 `<name>.part`、`chmod` 後 `mv` 成正式名，
 #: 讓 spool 裡「存在」的那個檔恆為完整檔——中途被 kill 只會留下 `.part`。
@@ -372,60 +374,57 @@ def prepare_commit_spool(
 ) -> Path:
     """dispatch 當下建立 per-job 那一格，回傳 bundle 應該落地的路徑。
 
+    生命週期本身走 :mod:`spool_slot`（與 `review-verdict-spool` 共用同一份實作，
+    #638）；本函式只負責 commit-spool 專屬的部分：路徑推導、symlink 守衛，以及把
+    共用層的錯誤翻成 :class:`WorkspaceError`。
+
     守衛與慣例：
 
-    - spool 目錄或 bundle 是 **symlink** → 一律移除／拒絕。Manager 之後會直接
+    - spool 目錄或 bundle 是 **symlink** → 一律拒絕。Manager 之後會直接
       `git fetch <那個檔案>`，讓它指向別處等於把回收路徑外包出去。
-    - 目錄以 `0700` 建立；**已存在時重新 `chmod 0700`**，把上一輪 harvest 之後的
-      封存（見 :func:`seal_commit_spool`）解開。同一個 key 會被重跑（retry 用同一個
-      slice_id／同一張卡重派），這與 `launcher.launch()` 對 exit sentinel 與 gate
-      ledger 的處置逐條一致。
-    - 殘留的 bundle（含 `.part`）在起跑前清掉。**這比「已存在即拒絕」更強**：預埋一份
-      bundle 的人得到的不是拒絕派工，而是自己的檔案被刪掉；而 Manager 是這一格的
-      owner，刪得掉 builder 寫的檔（目錄 `w`＋`x` 即可）。
+    - 那一格以 `reset=True` 建立：同一個 key 會被重跑（retry 用同一個 slice_id／
+      同一張卡重派），上一輪 harvest 之後的封存（見 :func:`seal_commit_spool`）
+      必須重新開封。這與 `launcher.launch()` 對 exit sentinel 與 gate ledger 的
+      處置逐條一致。`spool_slot.create_slot()` 的解封做法是**整格重建**而不是
+      `chmod` 回去——理由見該函式（`chmod` 只能猜一個 mask，正確的 mask 由
+      default ACL 重新繼承才拿得到，#638 缺陷 1）。
+    - 重建同時涵蓋了「殘留的 bundle（含 `.part`）在起跑前清掉」。**這比「已存在
+      即拒絕」更強**：預埋一份 bundle 的人得到的不是拒絕派工，而是自己的檔案被
+      刪掉；而 Manager 是這一格的 owner，刪得掉 builder 寫的檔。
 
-    真正的 owner／mode／ACL 由 Phase 2b 的 permgen 依 R1 登記表套用（資產由 #636
+    **不再傳明確 mode**（#638 缺陷 1）：在帶 default ACL 的樹上，`mkdir(mode=…)`
+    會把 mask 一起重設，把 builder 繼承來的具名條目壓成 `#effective:---`，實機
+    後果是 builder 連 `commits.bundle.part.lock` 都建不出來。初始權限交給 default
+    ACL，事後只**檢查**並收窄 `other`（見 `spool_slot.narrow_inherited_mode()`）。
+
+    真正的 owner／ACL 由 Phase 2b 的 permgen 依 R1 登記表套用（資產由 #636
     定義）；本函式只負責「這一格存在、而且是乾淨的」。
     """
 
     spool_dir = commit_spool_dir(spool_key=spool_key, coordinator_root=coordinator_root)
-    if spool_dir.is_symlink():
-        raise WorkspaceError(f"commit spool directory is a symlink: {spool_dir}")
-    spool_dir.parent.mkdir(parents=True, mode=0o700, exist_ok=True)
-    spool_dir.mkdir(mode=0o700, exist_ok=True)
-    if not spool_dir.is_dir():
-        raise WorkspaceError(f"commit spool directory unavailable: {spool_dir}")
     try:
-        os.chmod(spool_dir, 0o700)
-    except OSError as exc:
-        raise WorkspaceError(f"commit spool directory not writable: {spool_dir}: {exc}") from exc
-    bundle = spool_dir / COMMIT_BUNDLE_FILENAME
-    for stale in (bundle, bundle.with_name(bundle.name + COMMIT_BUNDLE_PART_SUFFIX)):
-        if stale.is_symlink() or stale.exists():
-            stale.unlink(missing_ok=True)
-    return bundle
+        spool_slot.create_slot(spool_dir, reset=True)
+    except spool_slot.SpoolSlotError as exc:
+        if exc.kind == "symlink":
+            raise WorkspaceError(f"commit spool directory is a symlink: {spool_dir}") from exc
+        raise WorkspaceError(f"commit spool directory unavailable: {spool_dir}: {exc}") from exc
+    return spool_dir / COMMIT_BUNDLE_FILENAME
 
 
 def seal_commit_spool(bundle: str | Path) -> None:
     """成果落地後把該 job 那一格轉唯讀（append-only spool 的封口）。
 
-    封的是**目錄**（`0500`）而不是檔案：bundle 由 builder 的 uid 建立，Manager 不是
-    它的 owner、`chmod` 不了它；但 Manager 是目錄的 owner，收掉目錄的 `w` 之後該格
-    就再也建不了、改不了名、刪不掉任何檔——而 POSIX ACL 的 mask 同時被 `chmod` 收窄，
-    producer 的 `wx` 授權一併失效。
+    封的是**目錄**而不是檔案：bundle 由 builder 的 uid 建立，Manager 不是它的
+    owner、`chmod` 不了它（#638 缺陷 3）；但 Manager 是目錄的 owner，收掉目錄的
+    `w` 之後該格就再也建不了、改不了名、刪不掉任何檔——而 POSIX ACL 的 mask 同時
+    被 `chmod` 收窄，producer 具名條目的 `wx` 授權一併失效。實作與
+    `review-verdict-spool` 共用 `spool_slot.seal_slot()`。
 
     best-effort：封存失敗不得讓一次**已經成功**的回收反而失敗（回收失敗才是
     #478／#601 的生產事故）。權威副本此時已經在來源樹的 `refs/heads/<branch>` 裡。
     """
 
-    target = Path(bundle)
-    try:
-        spool_dir = target.parent
-        if spool_dir.is_symlink() or not spool_dir.is_dir():
-            return
-        os.chmod(spool_dir, 0o500)
-    except OSError:
-        return
+    spool_slot.seal_slot(Path(bundle).parent)
 
 
 def build_bundle_command(*, workspace: str | Path, bundle: str | Path) -> str:
@@ -448,9 +447,12 @@ def build_bundle_command(*, workspace: str | Path, bundle: str | Path) -> str:
     - **負向 ref 是 `^refs/cortex/base`**（provision 當下 pin 的來源樹 commit，見
       :data:`BASE_REF`），讓 bundle 只帶這一輪的增量而不是整部歷史。
     - **`.part` → `chmod` → `mv`**：spool 裡看得見的 `commits.bundle` 恆為完整檔；
-      `chmod 0644` 是因為檔由 builder 的 umask 建立（降權 unit 常帶 `UMask=0077`），
-      Manager 讀不到自己就沒東西可回收。放寬到 0644 不擴張暴露面——那一格的容器是
-      `0700 cortex-manager` ＋ per-account `wx`，別的帳號連 traverse 都進不來。
+      `chmod` 到 `spool_slot.PUBLISHED_FILE_MODE` 是 #638 缺陷 2 的修法（producer
+      自己放寬給 consumer）——檔由 builder 的 umask 建立（降權 unit 常帶
+      `UMask=0077`），Manager 讀不到自己就沒東西可回收。放寬不擴張暴露面：那一格的
+      容器是 `0700 cortex-manager` ＋ per-account `wx`，別的帳號連 traverse 都進不來。
+      `review-verdict-spool` 走同一個常數（那邊的 producer 是模型，因此改由 wrapper
+      script 的 `spool_slot.publish_file_command()` 段執行）。
 
     整段用 `&&` 串接：任何一步失敗都不會發表一個半成品 bundle。
     """
@@ -461,7 +463,7 @@ def build_bundle_command(*, workspace: str | Path, bundle: str | Path) -> str:
     return (
         f"git -C {workspace_arg} bundle create {part} "
         f'"$(git -C {workspace_arg} symbolic-ref HEAD)" ^{shlex.quote(BASE_REF)} '
-        f"&& chmod 0644 {part} && mv -f {part} {final}"
+        f"&& chmod {spool_slot.PUBLISHED_FILE_MODE:04o} {part} && mv -f {part} {final}"
     )
 
 

--- a/paulsha_cortex/coordinator/launcher.py
+++ b/paulsha_cortex/coordinator/launcher.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Mapping, Protocol, Sequence, runtime_checkable
 
-from . import gate_ledger, job_runner, job_workspace, terminal_contract
+from . import gate_ledger, job_runner, job_workspace, spool_slot, terminal_contract
 
 
 _GIT_REPOSITORY_ENV_KEYS = frozenset(
@@ -160,6 +160,7 @@ def build_wrapper_script(
     stdin_prompt: str | None = None,
     write_sentinel: bool = True,
     commit_bundle: str | None = None,
+    verdict_file: str | None = None,
 ) -> str:
     """組出 headless wrapper script（#261：模型結束後由 manager 產生 gate ledger）。
 
@@ -182,8 +183,18 @@ def build_wrapper_script(
       exit code，而 Manager 的記帳 shell 記的正是它（#604）。多接一段 bundle 之後
       若不還原 ``$?``，模型明明失敗卻會被記成成功（或反過來）。
 
-    ``commit_bundle`` 為 None 時（reviewer／planner，以及所有既有測試路徑）script
-    **逐字**與改動前相同。
+    ``verdict_file``（#638 缺陷 2）：reviewer verdict spool 的落點。非 None 時在
+    模型之後追加一段 ``chmod``，把 reviewer 寫出來的 verdict 放寬到 Manager 讀得到
+    ——那個檔由 **reviewer 的 uid** 建立、又常帶降權 unit 的 ``UMask=0077``，
+    Manager 是**目錄**的 owner 但那不給檔案內容的讀取權，consumer 讀不到整條
+    verdict 通道就不成立。與 bundle 段的 ``chmod`` 是**同一個修法的兩個實例**
+    （共用 :data:`spool_slot.PUBLISHED_FILE_MODE`），差別只在 bundle 的 producer
+    是 Manager 組出來的 ``git`` 命令、verdict 的 producer 是模型本身——模型不會
+    自己 chmod，所以那一步必須由 wrapper 在它結束後補上。段序同樣排在 sentinel
+    **之前**，理由與 bundle 一致。
+
+    ``commit_bundle`` 與 ``verdict_file`` 皆為 None 時（planner，以及所有既有測試
+    路徑）script **逐字**與改動前相同。
 
     ``write_sentinel=False`` / ``run_gates=False``（#604，降權模式）：這支 script
     在降權模式下是以 **job 帳號**（`cortex-builder`）執行的，而 sentinel 與 ledger
@@ -217,8 +228,8 @@ def build_wrapper_script(
         command = (
             f"printf %s {shlex.quote(stdin_prompt)} | {shlex.join(inner_argv)} 2>/dev/null"
         )
-    if commit_bundle is not None:
-        return _bundle_wrapper_script(
+    if commit_bundle is not None or verdict_file is not None:
+        return _publishing_wrapper_script(
             command=command,
             sentinel=sentinel,
             ledger=ledger,
@@ -227,6 +238,7 @@ def build_wrapper_script(
             run_gates=run_gates,
             write_sentinel=write_sentinel,
             commit_bundle=commit_bundle,
+            verdict_file=verdict_file,
         )
     if write_sentinel:
         script = f'{command}; printf %s "$?" > {shlex.quote(sentinel)}'
@@ -270,7 +282,7 @@ def _gate_segment(*, ledger: str, worktree: str, repo_root: str) -> str:
     )
 
 
-def _bundle_wrapper_script(
+def _publishing_wrapper_script(
     *,
     command: str,
     sentinel: str,
@@ -279,19 +291,31 @@ def _bundle_wrapper_script(
     repo_root: str | None,
     run_gates: bool,
     write_sentinel: bool,
-    commit_bundle: str,
+    commit_bundle: str | None,
+    verdict_file: str | None,
 ) -> str:
-    """#623：帶成果 bundle 的 wrapper。段序＝模型 → 存 `$?` → bundle → sentinel → gate → 還原 `$?`。
+    """帶「成果發表」段的 wrapper。
+
+    段序＝模型 → 存 `$?` → bundle（#623）→ verdict 放寬（#638）→ sentinel →
+    gate → 還原 `$?`。
+
+    兩個發表段都排在 sentinel **之前**：sentinel 一出現，Manager 隨時可能在下一個
+    tick 判定完成並開始收割，成果必須先落地且已經是 consumer 讀得到的形狀。
 
     為什麼 bundle 段用 `git` 而不是像 gate 那樣呼叫一個 python module：降權模式下
     builder 看到的是白名單 env、且它未必讀得到 Manager 的 repo root
     （`ProtectHome=yes` 之後 `/home` 整個不可見，#623 缺口 1），`PYTHONPATH=<repo>`
-    這條路在那裡不成立。`git` 是 job 本來就必須有的工具。
+    這條路在那裡不成立。`git` 是 job 本來就必須有的工具；verdict 段只用 `chmod`，
+    同理。
     """
 
-    segments = [command, f"{_RC_VAR}=$?", job_workspace.build_bundle_command(
-        workspace=worktree, bundle=commit_bundle
-    )]
+    segments = [command, f"{_RC_VAR}=$?"]
+    if commit_bundle is not None:
+        segments.append(
+            job_workspace.build_bundle_command(workspace=worktree, bundle=commit_bundle)
+        )
+    if verdict_file is not None:
+        segments.append(spool_slot.publish_file_command(verdict_file))
     if write_sentinel:
         segments.append(f'printf %s "${_RC_VAR}" > {shlex.quote(sentinel)}')
     if run_gates and repo_root:
@@ -1375,6 +1399,16 @@ class SubprocessLauncher:
         commit_bundle: str | None = None
         if not (self._read_only or self._review_only):
             commit_bundle = str(job_workspace.prepare_commit_spool(spool_key=slice_id))
+        # #638 缺陷 2：reviewer 寫出來的 verdict 由 **reviewer 的 uid** 建立
+        # （降權 unit 常帶 `UMask=0077`），Manager 是那一格目錄的 owner 但那不給
+        # 檔案內容的讀取權——不補這一步，verdict 通道在三分下讀不到任何東西。
+        # 落點由 Manager 在 dispatch 當下決定（`as_verdict_spool_writer()` 帶進來
+        # 的就是那一格），因此這裡不需要、也不該讓模型自述路徑。
+        verdict_file: str | None = None
+        if self._verdict_spool_dir is not None:
+            verdict_file = str(
+                Path(self._verdict_spool_dir) / spool_slot.REVIEW_VERDICT_FILENAME
+            )
         # cg（issue #442）走 stdin 傳 prompt，不是 argv 參數（見 build_cg_argv）：
         # 其餘 executor 維持既有「prompt 為 argv 一個元素」路徑，stdin_prompt=None
         # 時 build_wrapper_script 的行為與改動前逐字相同（零影響）。
@@ -1391,6 +1425,7 @@ class SubprocessLauncher:
             # job wrapper 內不得再出現任何指向 Manager log 目錄的寫入。
             write_sentinel=not degraded,
             commit_bundle=commit_bundle,
+            verdict_file=verdict_file,
         )
         # Reviewer 不使用 login shell，避免 ~/.profile 等在最小 env 建立後重新匯入 secrets。
         # 降權模式的 builder 同理（#588 第 2 點）：login shell 會在 transient unit 的

--- a/paulsha_cortex/coordinator/review.py
+++ b/paulsha_cortex/coordinator/review.py
@@ -15,7 +15,7 @@ from paulsha_cortex.config import paths
 
 from ..persona import render
 from ..project_policy import ProjectPolicyError, resolve_project_policy
-from . import model_identities, verification
+from . import model_identities, spool_slot, verification
 
 MODEL_IDENTITY_SCHEMA_VERSION = model_identities.MODEL_IDENTITY_SCHEMA_VERSION
 REVIEW_SCHEMA_VERSION = 1
@@ -24,8 +24,9 @@ REVIEW_SCHEMA_VERSION = 1
 #: 之前派工、job row 無 `review_verdict_channel` 標記」的 reviewer job 保留讀取。
 REVIEW_VERDICT_FILENAME = ".psc-review-verdict.json"
 REVIEW_WORKTREE_DIRNAME = ".psc-review-worktrees"
-#: per-job verdict spool 內的檔名（目錄本身以 reviewer job id 定址）。
-REVIEW_VERDICT_SPOOL_FILENAME = "verdict.json"
+#: per-job verdict spool 內的檔名（目錄本身以 reviewer job id 定址）。權威定義在
+#: `spool_slot`——`launcher` 組 wrapper 的發表段時也要用同一個字串（#638 缺陷 2）。
+REVIEW_VERDICT_SPOOL_FILENAME = spool_slot.REVIEW_VERDICT_FILENAME
 #: reviewer job row 上的通道標記。有此標記 ⇒ 該 job 是經 spool 通道派工的，
 #: **不得**回退讀 worktree（否則 builder 只要刪掉 spool 再寫 worktree 就能洗白）。
 REVIEW_VERDICT_CHANNEL_SPOOL = "spool"
@@ -228,8 +229,14 @@ def review_verdict_path(worktree: str | Path) -> Path:
 #      ACL、builder 完全無權限。
 #   2. **job-addressed ＋ pre-seed 守衛**——dispatch 前該 job 的 spool 位置必須
 #      不存在（`prepare_review_verdict_spool()`）；已存在即拒絕派工。
-#   3. **落地後唯讀**——Manager 收割並落成 Tier-0 gate evaluation 後把 spool
-#      verdict 轉 0o444（`seal_review_verdict_spool()`）。
+#   3. **落地後封口**——Manager 收割並落成 Tier-0 gate evaluation 後把該 job 的
+#      **那一格目錄**轉唯讀（`seal_review_verdict_spool()`）。#638 之前這裡封的是
+#      verdict 檔本身（`chmod 0o444`），但檔案是 reviewer 擁有的、Manager `chmod`
+#      不了它，該處又刻意不 raise ⇒ 無聲失敗。封目錄才是 consumer 做得到的那一個。
+#
+# per-job 那一格的生命週期（建立 → producer 寫 → consumer 讀 → seal）與
+# `commit-spool` 共用 `coordinator/spool_slot.py`；#638 的三個缺陷之所以有兩個
+# 實例，正是因為兩邊原本各自實作了這一段。
 #
 # **誠實邊界**：Phase 2b（分 UID／chown）之前，同 UID 下 builder 技術上仍寫得進
 # coordinator_root（Phase 1 自檢已知並 WARN）。本階段交付的是**通道結構**——路徑、
@@ -268,26 +275,31 @@ def prepare_review_verdict_spool(
 ) -> Path:
     """建立 per-job spool 目錄並執行 pre-seed 守衛；回傳 verdict 檔路徑。
 
-    守衛（全部 fail-closed，任何一項成立即拒絕派工）：
+    守衛（全部 fail-closed，任何一項成立即拒絕派工，語意與修法前逐字相同）：
 
     - spool 目錄或 verdict 檔已存在／是 symlink → 有人預埋，拒絕；
     - 目錄建立競態（`FileExistsError`）→ 同樣視為預埋，拒絕。
 
     這是舊 `prepare_review_worktree()` 內那道「verdict 檔不得預先存在」守衛搬到
     新落點的版本；舊守衛保留為 defense-in-depth（legacy fallback 仍會讀它）。
+
+    生命週期本身走 :mod:`spool_slot`（與 `commit-spool` 共用同一份實作，#638）。
+    `reset=False` 就是上面那道 pre-seed 守衛：那一格必須不存在。commit-spool 用
+    `reset=True`（同一個 slice_id 會被 retry 重跑），而 reviewer job 每次派工都是
+    **新的 job id**，因此這裡不需要、也不該有解封路徑。
+
+    **不再傳明確 mode**（#638 缺陷 1）：在帶 default ACL 的樹上，`mkdir(mode=…)`
+    會把 ACL mask 一起重設，把 reviewer 繼承來的具名條目壓成 `#effective:---`，
+    實機後果是 reviewer 連 verdict 都寫不出來。初始權限交給 default ACL，事後只
+    **檢查**並收窄 `other`（見 `spool_slot.narrow_inherited_mode()`）。
     """
 
     spool_dir = review_verdict_spool_dir(
         reviewer_job_id=reviewer_job_id, coordinator_root=coordinator_root
     )
-    if spool_dir.is_symlink() or spool_dir.exists():
-        raise RuntimeError(f"preseeded review verdict spool detected: {spool_dir}")
-    # spool 根：owner-only。已存在時不 chmod——真正的 owner/mode 由 Phase 2b 的
-    # permgen 計畫套用（見 `trust_root/permgen.py` 的 `review-verdict-spool`）。
-    spool_dir.parent.mkdir(parents=True, mode=0o700, exist_ok=True)
     try:
-        spool_dir.mkdir(mode=0o700)
-    except FileExistsError as exc:
+        spool_slot.create_slot(spool_dir, reset=False)
+    except spool_slot.SpoolSlotError as exc:
         raise RuntimeError(f"preseeded review verdict spool detected: {spool_dir}") from exc
     verdict_path = spool_dir / REVIEW_VERDICT_SPOOL_FILENAME
     if verdict_path.exists() or verdict_path.is_symlink():
@@ -295,22 +307,53 @@ def prepare_review_verdict_spool(
     return verdict_path
 
 
+def publish_review_verdict(path: str | Path) -> bool:
+    """reviewer 寫完 verdict 後把它放寬給 Manager 讀（#638 缺陷 2）。
+
+    `wx` 無 `r` 的那一格上，verdict 由 **reviewer 的 uid** 建立、又常帶降權 unit
+    的 `UMask=0077`，Manager 是**目錄**的 owner 但那不給檔案內容的讀取權——
+    consumer 讀不到，verdict 通道整條不成立。
+
+    真正在生產路徑上執行這一步的是 wrapper script 裡的
+    `spool_slot.publish_file_command()` 段（producer 是模型，它不會自己 chmod）；
+    本函式是 in-process producer 的等價入口，兩者共用同一個 mode 常數。
+    """
+
+    return spool_slot.publish_file(path)
+
+
 def seal_review_verdict_spool(path: str | Path) -> None:
-    """Manager 落地後把 spool verdict 轉唯讀（0o444）。
+    """Manager 落地後把該 job 那一格封口。
+
+    **封的是目錄，不是 verdict 檔**（#638 缺陷 3）。修法前這裡是
+    `os.chmod(<verdict>, 0o444)`，但只有檔案 owner 或 root 能 `chmod`，而 verdict
+    是 **reviewer 擁有**的——三分下必定 `PermissionError`，而這裡刻意不 raise，
+    於是**無聲失敗**：operator 實機驗到 reviewer 可以在 Manager 判讀之後回頭
+    `printf TAMPERED > <verdict>`，spec §R2 要守的東西根本沒有成立過。
+
+    改成封目錄之後，consumer 封的是自己**擁有**的那一項：收掉目錄的 `w` 讓那一格
+    定版，而 `chmod` 同時把 ACL mask 收成 `---`，reviewer 具名條目的 `x`
+    （traverse）一併失效——它連既有的 verdict 檔都再也打不開。`spool_slot` 另對
+    目錄內既有檔做一次 best-effort `0444`，那一次只在同 UID（`direct` 模式）下會
+    成功，是額外一層、不是封口的效力來源。
 
     權威副本是已落地的 Tier-0 gate evaluation（immutable，見
-    `write_gate_evaluation()`）；封存 spool 只是讓「同一個 job 的 verdict 被事後
-    改寫」在檔案層留下痕跡。**在 Phase 2b 之前這不是強制**——同 UID 的 owner 可以
-    chmod 回去，故刻意不對失敗 raise（封存失敗不該讓一次合法的 review 反而卡住）。
+    `write_gate_evaluation()`）；封存只是讓「同一個 job 的 verdict 被事後改寫」在
+    檔案層留下痕跡，故仍刻意不對失敗 raise（封存失敗不該讓一次合法的 review
+    反而卡住）。
+
+    verdict 缺席（或是 symlink）時**完全不動**：既有的容忍語意一個位元組沒變，而
+    且封的既然是目錄，「路徑指到哪一格」這件事必須由一個真的落在那一格裡的成果
+    確認過，不能只憑呼叫端給的字串推導。
     """
 
     target = Path(path)
     try:
         if target.is_symlink() or not target.is_file():
             return
-        os.chmod(target, 0o444)
     except OSError:
         return
+    spool_slot.seal_slot(target.parent)
 
 
 # --- issue #482：pre-launch absent evaluation 的命名空間 ----------------------

--- a/paulsha_cortex/coordinator/spool_slot.py
+++ b/paulsha_cortex/coordinator/spool_slot.py
@@ -1,0 +1,292 @@
+"""兩個 spool 共用的 per-job 生命週期（建立 → producer 寫 → consumer 讀 → seal）。
+
+`review-verdict-spool`（Phase 2a／#599）與 `commit-spool`（#623／#636）是**同一種
+東西**：一個 Manager-owned 的容器，底下每個 job 一格；producer（reviewer／builder）
+以 per-account ACL 取得 `wx` 無 `r` 的授權往自己那一格寫，consumer（Manager）讀，
+落地後那一格封口。#638 的三個缺陷之所以有兩個實例，正是因為兩邊各自實作了這段
+生命週期——本模組把它收斂成單一份，兩個 spool 都只是它的呼叫端。
+
+三個缺陷與各自的修法（全部有 operator 的實機證據，見 #638）：
+
+**缺陷 1——`mkdir(mode=...)` 把繼承來的 ACL 重設掉。** 在帶 default ACL 的樹上，
+明確 mode 會連 **ACL mask** 一起寫掉，把繼承來的具名條目壓成 `#effective:---`：
+
+```
+user::rwx
+user:cortex-builder:-wx    #effective:---     ← mkdir(mode=0o700) 之後
+mask::---
+```
+
+producer 因此連建檔都不行（實機：``fatal: Unable to create
+'…/commits.bundle.part.lock': Permission denied``）。修法是
+:func:`create_slot` **不傳明確 mode**，讓 default ACL 決定初始權限，再由
+:func:`narrow_inherited_mode` 事後**檢查**而不是無條件 `chmod`——見該函式對
+「不比 0700 更鬆」與「不壓掉 mask」之間取捨的說明。
+
+**缺陷 2——`wx` 無 `r` 的那一格上，consumer 讀不到 producer 建的檔。** 檔由
+producer 擁有、又常帶降權 unit 的 `UMask=0077`，Manager 是**目錄**的 owner 但那
+不給檔案內容的讀取權。修法沿用 #637 已在實機驗證過的繞法：**producer 自己在寫完
+後把成果放寬到 0644**（:data:`PUBLISHED_FILE_MODE`），in-process 的 producer 用
+:func:`publish_file`、由 wrapper script 驅動的用 :func:`publish_file_command`。
+放寬不擴張暴露面——那一格的容器是 `0700 <manager>` ＋ per-account ACL，別的帳號
+連 traverse 都進不來。
+
+**缺陷 3——consumer `chmod` 不了 producer 擁有的檔。** 只有檔案 owner 或 root
+能 `chmod`，所以「落地後轉唯讀」若實作成 `os.chmod(<producer 的檔>, 0o444)`，在
+三分下必定 `PermissionError`；而該處刻意不 raise，於是**無聲失敗**（實機：
+reviewer 可以在 Manager 判讀之後回頭覆寫自己的 verdict）。修法同樣沿用 #637：
+:func:`seal_slot` 封的是**目錄**——Manager 是目錄的 owner，收掉目錄的 `w` 之後那
+一格再也建不了、改不了名、刪不掉任何檔，而 `chmod` 同時把 ACL mask 收成 `---`，
+producer 具名條目的 `x`（traverse）一併失效，連既有的檔都再也打不開。
+
+**誠實邊界**：seal 的強制力來自「producer 進得去那一格的**唯一**路徑是具名 ACL
+條目」。同 UID（Phase 2b 之前、或 `direct` 模式）下 producer 就是目錄 owner，本
+模組任何一段都攔不住它——那是已知且已記錄的邊界，不是本模組宣稱要守的東西。
+"""
+
+from __future__ import annotations
+
+import os
+import shlex
+import shutil
+import stat
+from pathlib import Path
+
+#: `review-verdict-spool` 那一格裡的成果檔名（目錄本身以 reviewer job id 定址）。
+#: 定義放在共用層是為了讓 `launcher` 組 wrapper 的發表段時不必回頭 import
+#: `coordinator.review`（那條路會把整個 verification 依賴鏈拉進 launcher）。
+REVIEW_VERDICT_FILENAME = "verdict.json"
+
+#: `commit-spool` 那一格裡的成果檔名（目錄本身以 spool key 定址）。
+COMMIT_BUNDLE_FILENAME = "commits.bundle"
+
+#: producer 寫完成果後放寬到的 mode（缺陷 2）。consumer 讀得到即可，不需要 `w`。
+PUBLISHED_FILE_MODE = 0o644
+
+#: seal 時對那一格內既有檔案的 best-effort 唯讀化。**只有在 consumer 恰好也是檔案
+#: owner 時才會成功**（同 UID／`direct` 模式）；三分下必然 `PermissionError`，屬
+#: 預期內，真正的封口是 :data:`SEALED_SLOT_MODE`。
+SEALED_FILE_MODE = 0o444
+
+#: seal 之後 per-job 目錄的 mode。收掉 `w` ⇒ 那一格定版；`chmod` 同時把 ACL mask
+#: 收成 `---` ⇒ producer 具名條目的授權一併失效。
+SEALED_SLOT_MODE = 0o500
+
+#: POSIX ACL 的 access ACL 落在這個 xattr。存在 ⇒ 這一項的 group 位是 **mask**，
+#: 不是「群組的實際權限」。
+ACCESS_ACL_XATTR = "system.posix_acl_access"
+
+
+class SpoolSlotError(Exception):
+    """per-job 那一格的生命週期錯誤。
+
+    `kind` 讓呼叫端把它翻成自己的錯誤型別與既有訊息（`review` 是 `RuntimeError`
+    ＋「preseeded …」、`job_workspace` 是 `WorkspaceError`）——兩個 spool 對
+    operator 的錯誤面不因為共用實作而改變。
+    """
+
+    def __init__(self, kind: str, message: str) -> None:
+        super().__init__(message)
+        self.kind = kind
+
+
+def has_posix_acl(path: str | Path) -> bool:
+    """這一項身上有沒有 access ACL（⇒ st_mode 的 group 位是 mask）。
+
+    以 xattr 直接判定而不是呼叫 `getfacl`：本模組跑在 dispatch 的熱路徑上，且
+    `getfacl` 不一定安裝。平台沒有 xattr（非 Linux）或檔案系統不支援時回 False，
+    退化成「純 mode 語意」，與修法前的行為一致。
+    """
+
+    try:
+        return ACCESS_ACL_XATTR in os.listxattr(path)
+    except (OSError, AttributeError, ValueError):
+        return False
+
+
+def narrow_inherited_mode(path: str | Path) -> int:
+    """把繼承來的初始權限收窄，但**不動 ACL mask**。回傳收窄後的 mode。
+
+    `mkdir(mode=0o700)` 的本意是「不比 0700 更鬆」，但在帶 default ACL 的樹上它的
+    實際效果是「把 producer 的授權關掉」（缺陷 1）。取捨如下：
+
+    - **`other` 位一律收掉。** 它在 ACL 語意下就是 `other::`，與 mask 無關，收窄
+      它不會影響任何具名條目——這一半的「不比 0700 更鬆」無條件保住。
+    - **`group` 位只在這一項**沒有** access ACL 時才收掉。** 有 ACL 時 group 位
+      **就是 mask**，把它壓成 0 正是缺陷 1 本身；此時 group 位的值由 operator 的
+      default ACL（`default:mask::`）決定，那是**授權模型的一部分**，不是本函式
+      該覆寫的東西。這一格的實際邊界是它的容器（`0700 <manager>`，別的帳號連
+      traverse 都進不來）＋ per-account 具名條目，不是這一格自己的 group 位。
+
+    因此「不比 0700 更鬆」在無 ACL 的部署下逐字成立（也就是所有既有測試環境），
+    在有 ACL 的部署下被**明確地**讓給 default ACL——那正是 operator 宣告授權的
+    地方。若 mode 已經合規則完全不呼叫 `chmod`（`chmod` 本身就是會重設 mask 的
+    那個動作，能不做就不做）。
+    """
+
+    mode = stat.S_IMODE(os.stat(path).st_mode)
+    target = mode & ~0o007
+    if not has_posix_acl(path):
+        target &= ~0o070
+    if target != mode:
+        os.chmod(path, target)
+    return target
+
+
+def ensure_container(container: str | Path) -> Path:
+    """建立 spool 的容器（根目錄）；已存在時**完全不動**它。
+
+    已存在時不 `chmod` 是刻意的：真正的 owner／mode／ACL 由 Phase 2b 的 permgen
+    依 R1 登記表套用，本函式若回頭 `chmod` 一次就會把 operator 套好的 mask 壓掉
+    ——那是缺陷 1 在容器層的同一個形狀。
+    """
+
+    path = Path(container)
+    try:
+        path.mkdir(parents=True)
+    except FileExistsError:
+        return path
+    narrow_inherited_mode(path)
+    return path
+
+
+def create_slot(slot: str | Path, *, reset: bool) -> Path:
+    """建立 per-job 那一格。
+
+    `reset=False`（`review-verdict-spool`）：那一格**必須不存在**——已存在（或是
+    symlink）即視為預埋，`SpoolSlotError` 往上丟由呼叫端翻成拒絕派工。這是既有的
+    pre-seed 守衛語意，一個位元組都沒放寬。
+
+    `reset=True`（`commit-spool`）：同一個 key 會被重跑（retry-card／forced
+    retry 用同一個 slice_id），那一格必須重新可寫。做法是**整個移除再重建**，而
+    不是 `chmod` 解封：seal 收掉目錄 `w` 的同時把 ACL mask 收成 `---`，而
+    `chmod` 回去只能把 mask 設成「某個我們自己猜的值」——正確的 mask 是 default
+    ACL 說了算的那一個，只有讓它重新繼承一次才拿得到。重建同時涵蓋了 #637 既有的
+    「起跑前清掉殘留」（預埋一份成果的人得到的是自己的檔案被刪掉）。
+
+    **不傳明確 mode** 是缺陷 1 的修法本身；初始權限交給 default ACL，事後才由
+    :func:`narrow_inherited_mode` 檢查並收窄。
+    """
+
+    path = Path(slot)
+    if path.is_symlink():
+        raise SpoolSlotError("symlink", f"spool slot is a symlink: {path}")
+    if path.exists():
+        if not reset:
+            raise SpoolSlotError("preseeded", f"spool slot already exists: {path}")
+        _remove_slot(path)
+    ensure_container(path.parent)
+    try:
+        path.mkdir()
+    except FileExistsError as exc:
+        raise SpoolSlotError("preseeded", f"spool slot already exists: {path}") from exc
+    except OSError as exc:
+        raise SpoolSlotError("unavailable", f"spool slot unavailable: {path}: {exc}") from exc
+    try:
+        narrow_inherited_mode(path)
+    except OSError as exc:
+        raise SpoolSlotError("unavailable", f"spool slot unavailable: {path}: {exc}") from exc
+    if not path.is_dir():
+        raise SpoolSlotError("unavailable", f"spool slot unavailable: {path}")
+    return path
+
+
+def _remove_slot(path: Path) -> None:
+    """移除上一輪那一格（含 seal 之後的 `0500`）。
+
+    先把 owner 位補回來：sealed 目錄沒有 `w`，`rmtree` 進不去。只動 owner 位
+    （`| 0o700`），group 位（＝mask）維持原樣——這裡不需要 mask，接下來整個目錄
+    就要被刪掉了。裡面的檔可能是 producer 擁有的，但刪除只需要目錄的 `wx`，
+    Manager 是目錄的 owner。
+    """
+
+    try:
+        if not path.is_dir():
+            path.unlink()
+            return
+        os.chmod(path, stat.S_IMODE(os.stat(path).st_mode) | 0o700)
+    except OSError as exc:
+        raise SpoolSlotError("unavailable", f"spool slot not reusable: {path}: {exc}") from exc
+    try:
+        shutil.rmtree(path)
+    except OSError as exc:
+        raise SpoolSlotError("unavailable", f"spool slot not reusable: {path}: {exc}") from exc
+
+
+def publish_file(path: str | Path) -> bool:
+    """producer 寫完後把成果放寬給 consumer（缺陷 2）；成功回 True。
+
+    best-effort：這一步失敗只代表 consumer 可能讀不到，不該讓 producer 這一輪的
+    工作反而失敗（而讀不到會在 consumer 端 fail-closed，不會被靜默吸收）。
+    """
+
+    return _chmod_regular_file(path, PUBLISHED_FILE_MODE)
+
+
+def publish_file_command(path: str | Path) -> str:
+    """由 wrapper script（producer 的身分）執行的 :func:`publish_file` 等價段。
+
+    `[ -f … ]` 先判存在：producer 沒產出成果是**多數失敗路徑**的常態，不該在
+    JSONL log 裡留下一行 chmod 錯誤。整段以 `|| :` 收尾，確保它永遠不會決定
+    script 的 exit code——exit code 的權威是 wrapper 存下來的模型 `$?`（#604）。
+    """
+
+    quoted = shlex.quote(str(path))
+    return f"{{ [ -f {quoted} ] && chmod {PUBLISHED_FILE_MODE:04o} {quoted}; }} 2>/dev/null || :"
+
+
+def seal_slot(slot: str | Path) -> bool:
+    """成果落地後把那一格封口（缺陷 3）；目錄真的被封起來才回 True。
+
+    封的是**目錄**：那是 consumer 唯一擁有 owner 權的東西。目錄內既有的檔另做一次
+    best-effort 唯讀化（:data:`SEALED_FILE_MODE`）——同 UID／`direct` 模式下
+    consumer 就是檔案 owner，那一次 `chmod` 會成功並多擋一層；三分下它必定失敗，
+    屬預期內，封口的效力全部來自目錄那一次。
+
+    best-effort：封存失敗不得讓一次**已經成功**的收割反而失敗。權威副本此時已經
+    落地（verdict → immutable gate evaluation；bundle → 來源樹的 `refs/heads/*`）。
+    """
+
+    path = Path(slot)
+    try:
+        if path.is_symlink() or not path.is_dir():
+            return False
+        entries = sorted(path.iterdir())
+    except OSError:
+        return False
+    for entry in entries:
+        _chmod_regular_file(entry, SEALED_FILE_MODE)
+    try:
+        os.chmod(path, SEALED_SLOT_MODE)
+    except OSError:
+        return False
+    return True
+
+
+def _chmod_regular_file(path: str | Path, mode: int) -> bool:
+    target = Path(path)
+    try:
+        if target.is_symlink() or not target.is_file():
+            return False
+        os.chmod(target, mode)
+    except OSError:
+        return False
+    return True
+
+
+__all__ = [
+    "ACCESS_ACL_XATTR",
+    "COMMIT_BUNDLE_FILENAME",
+    "PUBLISHED_FILE_MODE",
+    "REVIEW_VERDICT_FILENAME",
+    "SEALED_FILE_MODE",
+    "SEALED_SLOT_MODE",
+    "SpoolSlotError",
+    "create_slot",
+    "ensure_container",
+    "has_posix_acl",
+    "narrow_inherited_mode",
+    "publish_file",
+    "publish_file_command",
+    "seal_slot",
+]

--- a/tests/test_spool_permission_model_638.py
+++ b/tests/test_spool_permission_model_638.py
@@ -1,0 +1,601 @@
+"""#638：兩個 spool 的 producer／consumer 權限模型（**在真實 ACL 樹上**驗）。
+
+`review-verdict-spool`（Phase 2a／#599）與 `commit-spool`（#623／#636）在三分下有
+三個獨立缺陷，operator 全部有實機證據：
+
+1. per-job 目錄用明確 mode 建立會**重設 ACL mask**，把 default ACL 繼承來的具名
+   條目壓成 `#effective:---`，producer 因此連建檔都不行；
+2. `wx` 無 `r` 的那一格上，producer 建的檔由 producer 擁有，**consumer 讀不到**；
+3. 「落地後轉唯讀」若實作成 `chmod` producer 擁有的**檔案**，consumer 根本 chmod
+   不了它（只有 owner 或 root 能），而該處刻意不 raise ⇒ **無聲失敗**。
+
+**為什麼這一檔不能只驗 mode**：既有測試全部在單 UID 環境下跑，那裡 ACL mask 不
+影響任何事，於是 `mkdir(mode=0o700)` 看起來完全正常——#637 的 CI 全綠卻在實機第一
+步就斷掉，正是這個形狀（同類前例：#630 的「綠靠 cwd 剛好是 repo」、#631 的「長
+TMPDIR 下 36 個測試靜默 skip」）。本檔因此**自己建出帶 default ACL 的容器**，並
+直接斷言具名條目的 **effective 權限**（mask 套用後的結果），不是斷言 mode。
+
+ACL 的設定與讀取一律走 `system.posix_acl_*` xattr（`setfacl`／`getfacl` 用的是同一
+個核心介面）：不依賴 `acl` 套件有沒有裝，只依賴檔案系統支不支援 ACL。不支援時
+**明確 skip 並說明理由**（見 `_require_acl_support`），不靜默通過。
+
+`_CROSS_UID_SKIP` 那一組是真正的跨 UID 功能驗收（producer 寫得進去／consumer
+讀得到／seal 後 producer 改不動），需要 root 才能借到兩個身分；拿不到時同樣明確
+skip。結構性的那一組（effective 權限）在任何支援 ACL 的環境都會跑。
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import stat
+import struct
+import subprocess
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable
+
+import pytest
+
+from paulsha_cortex.config import paths
+from paulsha_cortex.coordinator import job_workspace, launcher, spool_slot
+from paulsha_cortex.coordinator import review as foreign_review
+
+# ---------------------------------------------------------------------------
+# POSIX ACL 的最小實作（設定與讀取都走 xattr，不依賴 setfacl/getfacl 二進位）
+# ---------------------------------------------------------------------------
+
+_ACL_USER_OBJ = 0x01
+_ACL_USER = 0x02
+_ACL_GROUP_OBJ = 0x04
+_ACL_MASK = 0x10
+_ACL_OTHER = 0x20
+_ACL_UNDEFINED_ID = 0xFFFFFFFF
+
+_ACL_DEFAULT_XATTR = "system.posix_acl_default"
+
+_R, _W, _X = 4, 2, 1
+
+#: 借給 producer／consumer 的兩個 uid。跨 UID 那一組只在 root 底下跑，此時 uid
+#: 不必真的存在於 `/etc/passwd`——核心的權限判定只看數字。
+_PRODUCER_UID = 60001
+_CONSUMER_UID = 60002
+
+_KEY = "job-638-0001"
+
+
+def _acl_blob(entries: list[tuple[int, int, int]]) -> bytes:
+    """組出 `system.posix_acl_*` 的 payload（version 2 ＋ 逐筆 tag/perm/id）。
+
+    條目順序必須是 USER_OBJ → USER* → GROUP_OBJ → GROUP* → MASK → OTHER，否則
+    核心會回 EINVAL。
+    """
+
+    payload = struct.pack("<I", 2)
+    for tag, perm, ident in entries:
+        payload += struct.pack("<HHI", tag, perm, ident)
+    return payload
+
+
+def _producer_acl(producer_uid: int) -> bytes:
+    """實機那一格的形狀：owner 全權、producer **`wx` 無 `r`**、group／other 全關。"""
+
+    return _acl_blob(
+        [
+            (_ACL_USER_OBJ, _R | _W | _X, _ACL_UNDEFINED_ID),
+            (_ACL_USER, _W | _X, producer_uid),
+            (_ACL_GROUP_OBJ, 0, _ACL_UNDEFINED_ID),
+            (_ACL_MASK, _R | _W | _X, _ACL_UNDEFINED_ID),
+            (_ACL_OTHER, 0, _ACL_UNDEFINED_ID),
+        ]
+    )
+
+
+@dataclass(frozen=True)
+class _AccessAcl:
+    """一份 access ACL 的解讀結果。`mask is None` ⇒ 這一項沒有具名條目。"""
+
+    mask: int | None
+    named_users: dict[int, int]
+
+    def effective(self, uid: int) -> int:
+        """具名條目經 mask 套用後**實際生效**的權限（`getfacl` 的 `#effective:`）。"""
+
+        granted = self.named_users.get(uid)
+        if granted is None:
+            return 0
+        if self.mask is None:
+            return granted
+        return granted & self.mask
+
+
+def _read_access_acl(path: Path) -> _AccessAcl:
+    raw = os.getxattr(path, spool_slot.ACCESS_ACL_XATTR)
+    named: dict[int, int] = {}
+    mask: int | None = None
+    for offset in range(4, len(raw), 8):
+        tag, perm, ident = struct.unpack("<HHI", raw[offset : offset + 8])
+        if tag == _ACL_USER:
+            named[ident] = perm
+        elif tag == _ACL_MASK:
+            mask = perm
+    return _AccessAcl(mask=mask, named_users=named)
+
+
+def _require_acl_support(root: Path) -> None:
+    """檔案系統不支援 POSIX ACL 時**明確** skip（附理由），不靜默通過。"""
+
+    probe = root / ".acl-probe"
+    probe.mkdir()
+    try:
+        os.setxattr(probe, _ACL_DEFAULT_XATTR, _producer_acl(_PRODUCER_UID))
+    except OSError as exc:  # pragma: no cover - 取決於執行環境的檔案系統
+        pytest.skip(
+            f"此檔案系統不支援 POSIX ACL（設定 {_ACL_DEFAULT_XATTR} 失敗：{exc}）；"
+            "#638 驗的是 ACL mask 的行為，沒有 ACL 就沒有可驗的語意——刻意 skip 而非空過"
+        )
+    child = probe / "inherit"
+    child.mkdir()
+    try:
+        os.getxattr(child, spool_slot.ACCESS_ACL_XATTR)
+    except OSError as exc:  # pragma: no cover - 取決於執行環境的檔案系統
+        pytest.skip(
+            f"此檔案系統不繼承 default ACL（讀取 {spool_slot.ACCESS_ACL_XATTR} 失敗：{exc}）；"
+            "#638 驗的正是繼承來的具名條目，沒有繼承就沒有可驗的語意——刻意 skip 而非空過"
+        )
+    shutil.rmtree(probe)
+
+
+# ---------------------------------------------------------------------------
+# 兩個 spool 的共用參數化（同一組不變式必須同時涵蓋兩邊）
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class _Spool:
+    name: str
+    container: str
+    #: coordinator_root → producer 應該寫出來的那個成果檔路徑（其 parent 即那一格）
+    prepare: Callable[[Path], Path]
+    #: 成果檔路徑 → None
+    seal: Callable[[Path], None]
+    artifact: str
+
+
+_VERDICT_SPOOL = _Spool(
+    name="review-verdict-spool",
+    container=paths.REVIEW_VERDICT_SPOOL_DIRNAME,
+    prepare=lambda root: foreign_review.prepare_review_verdict_spool(
+        reviewer_job_id=_KEY, coordinator_root=root
+    ),
+    seal=foreign_review.seal_review_verdict_spool,
+    artifact=spool_slot.REVIEW_VERDICT_FILENAME,
+)
+
+_COMMIT_SPOOL = _Spool(
+    name="commit-spool",
+    container=paths.COMMIT_SPOOL_DIRNAME,
+    prepare=lambda root: job_workspace.prepare_commit_spool(
+        spool_key=_KEY, coordinator_root=root
+    ),
+    seal=job_workspace.seal_commit_spool,
+    artifact=spool_slot.COMMIT_BUNDLE_FILENAME,
+)
+
+_SPOOLS = [_VERDICT_SPOOL, _COMMIT_SPOOL]
+_SPOOL_IDS = [spool.name for spool in _SPOOLS]
+
+
+@pytest.fixture()
+def acl_root(tmp_path: Path):
+    """一棵可用的暫存樹；不支援 ACL 時 skip。
+
+    刻意用 `tempfile.mkdtemp()` 而不是 `tmp_path` 本身：跨 UID 那一組需要借來的
+    uid **traverse 得進來**，而 pytest 的 tmp 根鏈不保證是可穿越的。
+    """
+
+    root = Path(tempfile.mkdtemp(prefix="psc-638-"))
+    os.chmod(root, 0o755)
+    try:
+        _require_acl_support(root)
+        yield root
+    finally:
+        _force_rmtree(root)
+
+
+def _force_rmtree(root: Path) -> None:
+    """清掉暫存樹，包含已經 seal 成 `0500` 的那些格。"""
+
+    for current, dirs, _files in os.walk(root):
+        for name in [current, *(str(Path(current) / d) for d in dirs)]:
+            try:
+                os.chmod(name, stat.S_IMODE(os.stat(name).st_mode) | 0o700)
+            except OSError:
+                pass
+    shutil.rmtree(root, ignore_errors=True)
+
+
+def _make_container(root: Path, spool: _Spool, *, owner_uid: int | None = None) -> Path:
+    """建出實機那一格的容器：`0700` owner-only ＋ producer 的 per-account ACL。
+
+    access ACL 讓 producer traverse 得進去，default ACL 讓**每一格**都繼承同一份
+    授權——這正是 permgen 依 R1 登記表在實機做的事（`review-verdict-spool` 與
+    `commit-spool` 兩個資產的形態刻意相同）。
+    """
+
+    container = root / spool.container
+    container.mkdir(parents=True)
+    acl = _producer_acl(_PRODUCER_UID)
+    os.setxattr(container, spool_slot.ACCESS_ACL_XATTR, acl)
+    os.setxattr(container, _ACL_DEFAULT_XATTR, acl)
+    if owner_uid is not None:
+        os.chown(container, owner_uid, -1)
+    return container
+
+
+# ---------------------------------------------------------------------------
+# 1. 缺陷 1：per-job 目錄建立不得遮掉繼承來的具名條目
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("spool", _SPOOLS, ids=_SPOOL_IDS)
+def test_per_job_slot_keeps_the_inherited_acl_effective(acl_root: Path, spool: _Spool) -> None:
+    """那一格建立之後，producer 的具名條目**不得**被 mask 遮掉。
+
+    斷言的是 **effective 權限**而不是 mode：mode 在單 UID 下看起來一直都是對的，
+    真正決定 producer 進不進得來的是 `mask & 具名條目`。
+    """
+
+    _make_container(acl_root, spool)
+
+    artifact = spool.prepare(acl_root)
+    slot = artifact.parent
+
+    acl = _read_access_acl(slot)
+    assert acl.named_users.get(_PRODUCER_UID) == _W | _X, "繼承來的具名條目不見了"
+    assert acl.mask != 0, f"mask 被壓成 --- ⇒ producer 的授權整條失效（{spool.name}）"
+    assert acl.effective(_PRODUCER_UID) == _W | _X, (
+        f"{spool.name}：具名條目被 mask 遮成 #effective:--- "
+        "（這就是實機 `Permission denied` 的成因）"
+    )
+
+
+@pytest.mark.parametrize("spool", _SPOOLS, ids=_SPOOL_IDS)
+def test_the_old_explicit_mode_shape_would_still_fail_this_fixture(
+    acl_root: Path, spool: _Spool
+) -> None:
+    """突變驗證：修法前的形狀（`mkdir(mode=0o700)`）在同一個 fixture 下必須是紅的。
+
+    沒有這一條，上面那條測試「綠」有可能只是因為 fixture 根本沒建出 ACL 樹——
+    #638 要修的三個缺陷全部是「測試環境測不出來」造成的，這裡先把測試環境本身
+    釘住。
+    """
+
+    container = _make_container(acl_root, spool)
+
+    legacy = container / "legacy-shape"
+    legacy.mkdir(mode=0o700)
+
+    acl = _read_access_acl(legacy)
+    assert acl.named_users.get(_PRODUCER_UID) == _W | _X
+    assert acl.mask == 0, "明確 mode 應該把 mask 壓成 ---；沒壓掉代表 fixture 沒建出 ACL 樹"
+    assert acl.effective(_PRODUCER_UID) == 0
+
+
+@pytest.mark.parametrize("spool", _SPOOLS, ids=_SPOOL_IDS)
+def test_per_job_slot_never_grants_other(acl_root: Path, spool: _Spool) -> None:
+    """「不比 0700 更鬆」保住的那一半：`other` 位一律收掉，即使 default ACL 給了它。
+
+    `other::` 與 mask 無關，收窄它不影響任何具名條目——所以這一半是無條件的。
+    `group` 位（＝有 ACL 時的 mask）刻意不動，理由見
+    `spool_slot.narrow_inherited_mode()`。
+    """
+
+    container = _make_container(acl_root, spool)
+    loose = _acl_blob(
+        [
+            (_ACL_USER_OBJ, _R | _W | _X, _ACL_UNDEFINED_ID),
+            (_ACL_USER, _W | _X, _PRODUCER_UID),
+            (_ACL_GROUP_OBJ, 0, _ACL_UNDEFINED_ID),
+            (_ACL_MASK, _R | _W | _X, _ACL_UNDEFINED_ID),
+            (_ACL_OTHER, _R | _X, _ACL_UNDEFINED_ID),
+        ]
+    )
+    os.setxattr(container, _ACL_DEFAULT_XATTR, loose)
+
+    slot = spool.prepare(acl_root).parent
+
+    assert stat.S_IMODE(os.stat(slot).st_mode) & 0o007 == 0
+    # 收窄 other **不得**連帶把 mask 壓掉——那正是缺陷 1。
+    assert _read_access_acl(slot).effective(_PRODUCER_UID) == _W | _X
+
+
+def test_slot_without_any_acl_is_exactly_owner_only(tmp_path: Path) -> None:
+    """無 ACL 的部署（含所有既有測試環境）下「不比 0700 更鬆」逐字成立。
+
+    `mkdir()` 不給 mode 之後初始權限由 umask 決定，因此這條同時釘住「結果與
+    operator 的 umask 無關」。
+    """
+
+    previous = os.umask(0o002)
+    try:
+        for spool in _SPOOLS:
+            root = tmp_path / spool.name
+            root.mkdir()
+            slot = spool.prepare(root).parent
+            assert stat.S_IMODE(os.stat(slot).st_mode) == 0o700, spool.name
+    finally:
+        os.umask(previous)
+
+
+def test_commit_spool_retry_reopens_the_slot_with_the_acl_restored(acl_root: Path) -> None:
+    """同一個 key 重跑：解封之後 producer 的具名條目必須**真的**回來。
+
+    `commit-spool` 是唯一有解封需求的那一個（retry 用同一個 slice_id）。做法是整格
+    重建而不是 `chmod` 回去——seal 把 mask 收成 `---`，而正確的 mask 只有讓 default
+    ACL 重新繼承一次才拿得到（`chmod` 只能猜一個值）。
+    """
+
+    _make_container(acl_root, _COMMIT_SPOOL)
+    bundle = _COMMIT_SPOOL.prepare(acl_root)
+    bundle.write_bytes(b"harvested")
+    _COMMIT_SPOOL.seal(bundle)
+    assert _read_access_acl(bundle.parent).effective(_PRODUCER_UID) == 0
+
+    again = _COMMIT_SPOOL.prepare(acl_root)
+
+    assert again == bundle
+    assert not bundle.exists(), "上一輪的殘留必須清掉"
+    assert _read_access_acl(again.parent).effective(_PRODUCER_UID) == _W | _X
+
+
+def test_review_verdict_slot_keeps_the_pre_seed_guard(acl_root: Path) -> None:
+    """ACL 樹上 pre-seed 守衛語意一個位元組沒變：那一格已存在即拒絕派工。"""
+
+    _make_container(acl_root, _VERDICT_SPOOL)
+    _VERDICT_SPOOL.prepare(acl_root)
+
+    with pytest.raises(RuntimeError, match="preseeded review verdict spool"):
+        _VERDICT_SPOOL.prepare(acl_root)
+
+
+# ---------------------------------------------------------------------------
+# 2. 缺陷 3：seal 封的是目錄，且真的收掉 producer 的授權
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("spool", _SPOOLS, ids=_SPOOL_IDS)
+def test_seal_revokes_the_named_acl_entry_for_both_spools(acl_root: Path, spool: _Spool) -> None:
+    """seal 之後 producer 的具名條目 effective 必須是 `---`。
+
+    這就是「seal 後 producer 改不動」的**機制本身**：producer 進得去那一格的唯一
+    路徑是具名條目（容器是 `0700 <consumer>`、`other::---`），mask 一收成 `---`
+    它連 traverse 都做不到，既有的檔也再打不開。修法前 seal 是
+    `chmod(<producer 擁有的檔>, 0o444)`，那一步在三分下必定 `PermissionError`
+    且刻意不 raise ⇒ 無聲失敗。
+    """
+
+    _make_container(acl_root, spool)
+    artifact = spool.prepare(acl_root)
+    artifact.write_bytes(b'{"schema_version": 1, "findings": []}')
+
+    spool.seal(artifact)
+
+    slot = artifact.parent
+    assert stat.S_IMODE(os.stat(slot).st_mode) == spool_slot.SEALED_SLOT_MODE
+    acl = _read_access_acl(slot)
+    assert acl.mask == 0
+    assert acl.effective(_PRODUCER_UID) == 0, f"{spool.name}：seal 沒有收掉 producer 的授權"
+    # 證據仍讀得到：consumer 是目錄 owner，`0500` 保留了 `r-x`。
+    assert artifact.read_bytes() != b""
+
+
+@pytest.mark.parametrize("spool", _SPOOLS, ids=_SPOOL_IDS)
+@pytest.mark.skipif(os.geteuid() == 0, reason="root 不受目錄權限限制，測不到封口")
+def test_seal_closes_the_slot_for_new_entries(tmp_path: Path, spool: _Spool) -> None:
+    """封口的可見後果：那一格再也建不了新檔（兩個 spool 同一組不變式）。"""
+
+    root = tmp_path / spool.name
+    root.mkdir()
+    artifact = spool.prepare(root)
+    artifact.write_bytes(b"x")
+
+    spool.seal(artifact)
+
+    with pytest.raises(PermissionError):
+        (artifact.parent / "smuggled").write_bytes(b"x")
+
+
+# ---------------------------------------------------------------------------
+# 3. 缺陷 2：producer 寫完自己放寬，consumer 才讀得到
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("spool", _SPOOLS, ids=_SPOOL_IDS)
+def test_producer_publishes_its_artifact_for_the_consumer(tmp_path: Path, spool: _Spool) -> None:
+    """降權 unit 常帶 `UMask=0077`；成果若停在 `0600` producer-owned，consumer 就讀不到。"""
+
+    root = tmp_path / spool.name
+    root.mkdir()
+    artifact = spool.prepare(root)
+    previous = os.umask(0o077)
+    try:
+        artifact.write_bytes(b"produced")
+    finally:
+        os.umask(previous)
+    assert stat.S_IMODE(os.stat(artifact).st_mode) & 0o044 == 0
+
+    assert spool_slot.publish_file(artifact) is True
+
+    assert stat.S_IMODE(os.stat(artifact).st_mode) == spool_slot.PUBLISHED_FILE_MODE
+
+
+def test_wrapper_publishes_the_verdict_after_the_model_and_before_the_sentinel(
+    tmp_path: Path,
+) -> None:
+    """verdict 的 producer 是模型本身——它不會自己 chmod，所以 wrapper 必須補上。
+
+    真的跑一次 `bash`：模型以 `UMask=0077` 寫出 verdict、exit 3，驗完成之後
+    verdict 是 consumer 讀得到的 `0644`，而 script 的 exit code 仍是模型的 3
+    （#604：降權模式下 unit 的 exit code 就是它，被污染會讓失敗記成成功）。
+    """
+
+    spool_dir = tmp_path / "review-verdicts" / _KEY
+    spool_dir.mkdir(parents=True)
+    verdict = spool_dir / spool_slot.REVIEW_VERDICT_FILENAME
+    sentinel = tmp_path / "r.exit"
+    script = launcher.build_wrapper_script(
+        inner_argv=["bash", "-c", f"umask 0077; printf '{{}}' > {verdict}; exit 3"],
+        sentinel=str(sentinel),
+        ledger=str(tmp_path / "r.ledger"),
+        worktree=str(tmp_path),
+        repo_root=None,
+        run_gates=False,
+        verdict_file=str(verdict),
+    )
+
+    assert script.index("chmod") < script.index(str(sentinel)), "發表段必須排在 sentinel 之前"
+
+    proc = subprocess.run(["bash", "-c", script], capture_output=True, text=True, check=False)
+
+    assert proc.returncode == 3, proc.stderr
+    assert sentinel.read_text() == "3"
+    assert stat.S_IMODE(os.stat(verdict).st_mode) == spool_slot.PUBLISHED_FILE_MODE
+
+
+def test_wrapper_verdict_segment_is_silent_when_the_reviewer_wrote_nothing(
+    tmp_path: Path,
+) -> None:
+    """reviewer 失敗、沒產出 verdict：發表段不得吵、也不得改變 exit code。"""
+
+    spool_dir = tmp_path / "review-verdicts" / _KEY
+    spool_dir.mkdir(parents=True)
+    verdict = spool_dir / spool_slot.REVIEW_VERDICT_FILENAME
+    script = launcher.build_wrapper_script(
+        inner_argv=["bash", "-c", "exit 9"],
+        sentinel=str(tmp_path / "r.exit"),
+        ledger=str(tmp_path / "r.ledger"),
+        worktree=str(tmp_path),
+        repo_root=None,
+        run_gates=False,
+        write_sentinel=False,
+        verdict_file=str(verdict),
+    )
+
+    proc = subprocess.run(["bash", "-c", script], capture_output=True, text=True, check=False)
+
+    assert proc.returncode == 9
+    assert proc.stderr == ""
+    assert not verdict.exists()
+
+
+def test_wrapper_is_byte_identical_when_neither_spool_is_in_play(tmp_path: Path) -> None:
+    """planner／既有測試路徑：沒有任何發表段時 script 逐字與改動前相同。"""
+
+    kwargs = dict(
+        inner_argv=["codex", "exec", "prompt"],
+        sentinel=str(tmp_path / "s.exit"),
+        ledger=str(tmp_path / "s.ledger"),
+        worktree=str(tmp_path),
+        repo_root=None,
+        run_gates=False,
+    )
+
+    assert launcher.build_wrapper_script(**kwargs) == (
+        f"codex exec prompt; printf %s \"$?\" > {tmp_path / 's.exit'}"
+    )
+
+
+def test_both_spools_publish_with_the_same_mode() -> None:
+    """兩個 spool 的發表 mode 必須同源——這正是 #638 要求收斂成一套 helper 的原因。"""
+
+    bundle_command = job_workspace.build_bundle_command(workspace="/w", bundle="/s/b")
+    verdict_command = spool_slot.publish_file_command("/s/verdict.json")
+    literal = f"{spool_slot.PUBLISHED_FILE_MODE:04o}"
+
+    assert f"chmod {literal} " in bundle_command
+    assert f"chmod {literal} " in verdict_command
+
+
+# ---------------------------------------------------------------------------
+# 4. 跨 UID 的功能驗收（正向＋反向）——需要 root 才借得到兩個身分
+# ---------------------------------------------------------------------------
+
+_CROSS_UID_SKIP = (
+    "跨 UID 驗收需要 root 才能以 producer／consumer 兩個身分實跑；"
+    "非 root 環境下同一組不變式由上面的 effective-ACL 斷言承擔（刻意 skip 而非空過）"
+)
+
+
+def _run_as(uid: int, fn: Callable[[], None]) -> int:
+    """在 fork 出來的子進程裡以 `uid` 執行 `fn`；回傳 exit code。
+
+    0＝成功、1＝`PermissionError`（預期內的拒絕）、2＝其他例外。
+    """
+
+    pid = os.fork()
+    if pid == 0:  # pragma: no cover - 子進程
+        code = 2
+        try:
+            os.setgroups([])
+            os.setgid(uid)
+            os.setuid(uid)
+            fn()
+            code = 0
+        except PermissionError:
+            code = 1
+        except OSError as exc:
+            code = 1 if exc.errno in {1, 13} else 2
+        except BaseException:
+            code = 2
+        os._exit(code)
+    _, status = os.waitpid(pid, 0)
+    return os.WEXITSTATUS(status)
+
+
+@pytest.mark.skipif(os.geteuid() != 0, reason=_CROSS_UID_SKIP)
+@pytest.mark.parametrize("spool", _SPOOLS, ids=_SPOOL_IDS)
+def test_cross_uid_lifecycle_for_both_spools(acl_root: Path, spool: _Spool) -> None:
+    """完整的一輪：consumer 建格 → producer 寫 → consumer 讀 → seal → producer 改不動。
+
+    容器由 **consumer** 擁有（實機的 `cortex-manager`），producer 只有 per-account
+    的 `wx` 無 `r`——與 permgen 依 R1 登記表產出的形狀相同。
+    """
+
+    _make_container(acl_root, spool, owner_uid=_CONSUMER_UID)
+    holder: dict[str, Path] = {}
+
+    def _prepare() -> None:
+        spool.prepare(acl_root)
+
+    assert _run_as(_CONSUMER_UID, _prepare) == 0, "consumer 建不出那一格"
+    artifact = acl_root / spool.container / _KEY / spool.artifact
+    holder["artifact"] = artifact
+
+    def _produce() -> None:
+        os.umask(0o077)
+        with open(artifact, "wb") as handle:
+            handle.write(b"produced-by-the-job")
+        assert spool_slot.publish_file(artifact) is True
+
+    # 正向 1：producer 寫得進去（缺陷 1 修好之前這一步就是實機的 `Permission denied`）
+    assert _run_as(_PRODUCER_UID, _produce) == 0, "producer 寫不進那一格（缺陷 1 復發）"
+
+    # 正向 2：consumer 讀得到 producer 寫的內容（缺陷 2）
+    def _consume() -> None:
+        assert artifact.read_bytes() == b"produced-by-the-job"
+
+    assert _run_as(_CONSUMER_UID, _consume) == 0, "consumer 讀不到 producer 的成果（缺陷 2 復發）"
+
+    # seal 由 consumer 執行——修法前它 chmod 的是 producer 擁有的檔，必定無聲失敗
+    def _seal() -> None:
+        spool.seal(artifact)
+
+    assert _run_as(_CONSUMER_UID, _seal) == 0
+
+    # 反向：seal 之後 producer 改不動自己剛寫的東西（缺陷 3）
+    def _tamper() -> None:
+        with open(artifact, "wb") as handle:
+            handle.write(b"TAMPERED")
+
+    assert _run_as(_PRODUCER_UID, _tamper) == 1, "seal 之後 producer 仍改得動（缺陷 3 復發）"
+
+    # consumer 讀到的仍是 producer 當初交付的那一份
+    assert holder["artifact"].read_bytes() == b"produced-by-the-job"


### PR DESCRIPTION
## 摘要

`review-verdict-spool`（Phase 2a／#599）與 `commit-spool`（#623／#636／#637）的
producer／consumer 權限模型在三分下有**三個獨立缺陷**，全部有 operator 的實機證據
（#638）。#637 merge 之後**降權模式下的成果回收整條不可用**，卡在本票。

本 PR 修掉三個缺陷，並把兩個 spool 的 per-job 生命週期（建立 → producer 寫 →
consumer 讀 → seal）收斂到**同一套 helper**（新增 `coordinator/spool_slot.py`）
——這個 bug 之所以有兩個實例，正是因為兩邊各自實作了這一段。

**不在範圍**：gate 執行身分（#629）、M2 本身（#615）、permgen 的 ACL 宣告。

## 缺陷 1：`mkdir(mode=…)` 把繼承來的 ACL mask 重設掉（blocking）

實機（以 #637 落地的產品 API `prepare_commit_spool()` 建出來的那一格）：

```
user::rwx
user:cortex-builder:-wx    #effective:---     ← 繼承來的授權被 mask 遮掉
mask::---
```

接著以 builder 身分執行 `build_bundle_command()` 逐字產生的命令：

```
fatal: Unable to create '…/commits.bundle.part.lock': Permission denied
```

`review.py:289` 的 `spool_dir.mkdir(mode=0o700)` 與 `prepare_commit_spool()` 的
「0700 建立／已存在時重新 chmod 0700」是**同一個 bug 的兩個實例**。

### 修法與取捨：在「不壓掉 mask」與「不比 0700 更鬆」之間

per-job 目錄**不再傳明確 mode**，初始權限交給 default ACL；建立後只**檢查**並
收窄，而不是用 `chmod` 把 mask 一起壓掉。逐條取捨寫在
`spool_slot.narrow_inherited_mode()`：

- **`other` 位一律收掉。** 它在 ACL 語意下就是 `other::`，與 mask 無關，收窄它
  不影響任何具名條目——這一半的「不比 0700 更鬆」**無條件保住**。
- **`group` 位只在該項「沒有」access ACL 時才收掉。** 有 ACL 時 group 位**就是
  mask**，把它壓成 0 正是缺陷 1 本身；此時它的值由 operator 的 `default:mask::`
  決定，那是**授權模型的一部分**，不是這個函式該覆寫的東西。有沒有 ACL 以
  `system.posix_acl_access` xattr 判定（`getfacl` 用的同一個核心介面，不依賴
  `acl` 套件裝了沒；平台／檔案系統不支援時退化成純 mode 語意，與修法前一致）。
- **mode 已經合規則完全不呼叫 `chmod`**——`chmod` 本身就是會重設 mask 的那個動作，
  能不做就不做。

因此「不比 0700 更鬆」在**無 ACL 的部署（含所有既有測試環境）下逐字成立**（測試
`test_slot_without_any_acl_is_exactly_owner_only` 在兩種 umask 下釘住 `0o700`），
在有 ACL 的部署下被**明確地**讓給 default ACL。那一格真正的邊界不是它自己的 group
位，而是**容器**（`0700 cortex-manager`，別的帳號連 traverse 都進不來）＋
per-account 具名條目。

## 缺陷 2：consumer 讀不到 producer 寫的檔

`wx` 無 `r` 的那一格上，成果由 producer 擁有（又常帶降權 unit 的 `UMask=0077`），
而「目錄 owner」不給檔案內容的讀取權。#637 已用「producer 自己 `chmod 0644` 再
`mv` 進位」在 commit-spool 這側繞開，**review-verdict spool 未處理**。

本 PR 把同一個繞法套過去。差別在 producer 是誰：

| spool | producer | 發表點 |
|---|---|---|
| `commit-spool` | Manager 組出的 `git` 命令 | 既有的 `.part` → `chmod` → `mv`（改用共用常數） |
| `review-verdict-spool` | **模型本身** | wrapper script 在模型結束後補一段 |

模型不會自己 chmod，所以 verdict 那一段必須由 wrapper 補：

```
<模型 argv>; __psc_rc=$?; { [ -f <verdict> ] && chmod 0644 <verdict>; } 2>/dev/null || :; \
  printf %s "$__psc_rc" > <sentinel>; exit "$__psc_rc"
```

三個決定：排在 **sentinel 之前**（sentinel 一出現 Manager 隨時可能在下一個 tick
開始收割）、`[ -f … ]` 先判存在（reviewer 沒產出 verdict 是多數失敗路徑的常態，
不該在 JSONL log 留下一行 chmod 錯誤）、以存下來的 `$?` 收場（#604：降權模式下
unit 的 exit code 就是這支 script 的 exit code）。`commit_bundle` 與 `verdict_file`
皆為 None 時 script **逐字**與改動前相同（測試以完整字串比對釘住）。

## 缺陷 3：seal 必然失敗且無聲

`review.py:311` 的 `os.chmod(target, 0o444)` 由 Manager 執行，但檔案是 reviewer
擁有的——**只有 owner 或 root 能 chmod**，必然 `PermissionError`，而該處刻意不
raise（`review.py:304` 的註解：「封存失敗不該讓一次合法的 review 反而卡住」）。
實測後果：`printf TAMPERED > <verdict>` 成功，spec §R2 要守的東西從未成立。

#637 已用「封**目錄**」在 commit-spool 這側繞開，本 PR 套到 verdict spool：Manager
是目錄的 owner，收掉 `w` 之後那一格再也建不了、改不了名、刪不掉任何檔，而 `chmod`
同時把 ACL mask 收成 `---`，**producer 具名條目的 `x`（traverse）一併失效——它連
既有的 verdict 檔都再也打不開**。這才是封口的效力來源（目錄的 `w` 只管
create/rename/unlink，管不到既有檔的 in-place 覆寫）。

`spool_slot.seal_slot()` 另對那一格內既有的檔做一次 best-effort `0444`：同 UID／
`direct` 模式下 consumer 就是檔案 owner，那一次會成功並多擋一層；三分下它必定失敗，
屬預期內，**不是**封口的效力來源。

**pre-seed 守衛語意完全保留**：dispatch 前該格必須不存在（`create_slot(reset=False)`
就是那道守衛），operator 看到的錯誤字串一字未變。

## 兩個 spool 真的收斂到同一套 helper

新增 `paulsha_cortex/coordinator/spool_slot.py`，per-job 那一格的整個生命週期只有
一份實作：

- `create_slot(slot, *, reset)` — 建立那一格（缺陷 1 的修法本身）。
  `reset=False` 就是 verdict spool 的 pre-seed 守衛；`reset=True` 是 commit-spool
  的 retry 解封。
- `narrow_inherited_mode(path)` — 上面那條取捨。
- `publish_file(path)` / `publish_file_command(path)` — 缺陷 2 的兩個 producer 形態。
- `seal_slot(slot)` — 缺陷 3。
- `PUBLISHED_FILE_MODE` / `SEALED_SLOT_MODE` / `REVIEW_VERDICT_FILENAME` /
  `COMMIT_BUNDLE_FILENAME` — 兩邊共用的契約常數。

`review.py` 與 `job_workspace.py` 各自只剩**路徑推導、symlink 守衛、錯誤面翻譯**
（`RuntimeError`「preseeded …」／`WorkspaceError` 逐字保留）。測試
`test_both_spools_publish_with_the_same_mode` 釘住兩邊的發表 mode 同源。

**解封改為整格重建**（`commit-spool` 的 retry：同一個 slice_id 重派）而不是 `chmod`
回去：seal 把 mask 收成 `---`，而 `chmod` 只能設成「某個我們自己猜的值」——正確的
mask 是 default ACL 說了算的那一個，只有讓它**重新繼承一次**才拿得到。重建同時涵蓋
了 #637 既有的「起跑前清掉殘留」。`review-verdict-spool` 每次派工都是新的 reviewer
job id，因此不需要、也不該有解封路徑。

## 測試：不能只驗 mode

既有測試在**單 UID 環境**下跑，那裡 ACL mask 不影響任何事，所以 `mkdir(mode=0o700)`
看起來完全正常——**#637 的 CI 全綠卻在實機第一步就斷掉，正是這個形狀**（同類前例：
#630 的「綠靠 cwd 剛好是 repo」、#631 的「長 TMPDIR 下 36 個測試靜默 skip」）。

新增 `tests/test_spool_permission_model_638.py`（21 測試），因此：

- **自己建出帶 default ACL 的容器**（`u::rwx` / `u:<producer>:wx` / `g::---` /
  `mask::rwx` / `o::---`，access ＋ default 兩份，與 permgen 在實機做的形態相同），
  再用**產品 API** 建那一格。
- **直接斷言具名條目的 `#effective` 權限**（`mask & 具名條目`），不是斷言 mode。
  ACL 的設定與讀取都走 `system.posix_acl_*` xattr——不依賴 `setfacl`／`getfacl`
  二進位裝了沒，只依賴檔案系統支不支援 ACL。
- **同一組不變式參數化涵蓋兩個 spool**：那一格建立後具名條目不得被遮、`other` 位
  一律收掉、seal 之後 `mask == ---` 且 effective `== ---`、retry 解封後授權真的
  回來、pre-seed 守衛在 ACL 樹上仍然拒絕、封口後那一格建不了新檔。
- **突變驗證**：`test_the_old_explicit_mode_shape_would_still_fail_this_fixture`
  把「修法前的形狀（`mkdir(mode=0o700)`）在同一個 fixture 下必須是紅的」釘住——
  沒有這一條，上面那些斷言有可能哪天只是因為 fixture 不再建出 ACL 樹而空過。
  實跑過的突變：把 `path.mkdir()` 改回 `mkdir(mode=0o700)` → 5 條紅（兩個 spool
  都紅）；把 seal 改回 `chmod(<檔>, 0o444)` → 2 條紅；拿掉 wrapper 的發表段 →
  1 條紅。
- **wrapper 真的跑一次 `bash`**：模型以 `UMask=0077` 寫出 verdict、exit 3 →
  verdict 是 `0644`、sentinel 是 `3`、script exit code 是 `3`；reviewer 什麼都沒寫
  時發表段不吵（stderr 空）也不改 exit code。

### 沒有 ACL 支援的環境怎麼處理

**明確 skip 並說明理由，絕不靜默通過**（#631 的教訓）：

- 檔案系統不支援 POSIX ACL（`os.setxattr(system.posix_acl_default)` 失敗）→
  skip，理由帶上 errno 與「#638 驗的是 ACL mask 的行為，沒有 ACL 就沒有可驗的
  語意——刻意 skip 而非空過」。
- 檔案系統不繼承 default ACL → 同樣 skip 並說明。
- **跨 UID 的功能驗收**（producer 寫得進去／consumer 讀得到／seal 後 producer
  改不動，正反各一）需要 root 才借得到兩個身分（60001／60002）；非 root 時 skip，
  理由明寫「同一組不變式由 effective-ACL 斷言承擔」。**結構性那一組在任何支援
  ACL 的環境都會跑**，不受 root 與否影響。

跨 UID 那一組已在本機以 root 實跑通過，並做過突變驗證：改回 `mkdir(mode=0o700)`
→ producer 寫入被拒（重現實機的 `Permission denied`）；把 seal 的目錄 chmod 拿掉
→ producer 覆寫成功（重現 `printf TAMPERED`）。

```
python3 -m pytest tests/ -q
3761 passed, 2 skipped, 49 subtests passed
```

## 與 M2（#615）的關係

本票是 **M2 的前置**。Phase 2a 的 verdict 通道（#599）在三分下**從未真正成立過**，
只因 reviewer 目前仍以 Manager 帳號在行程內跑、同 UID 所以一切都通——三個缺陷全部
被「producer 就是 consumer」這件事掩蓋。M2 一旦落地（reviewer 有自己的降權啟動面），
verdict 通道會**立刻整條斷**：缺陷 1 讓 reviewer 寫不出 verdict、缺陷 2 讓 Manager
讀不到、缺陷 3 讓封存無聲失效。本 PR 必須在 M2 之前落地。

## 誠實邊界

seal 的強制力來自「producer 進得去那一格的**唯一**路徑是具名 ACL 條目」。同 UID
（Phase 2b 之前、或 `direct` 模式）下 producer 就是目錄 owner，本 PR 任何一段都攔
不住它——那是已知且已記錄的邊界，不是本 PR 宣稱要守的東西。

## Checklist

- [x] 分支從 `main` 開，命名 `feature/638-spool-permission-model`
- [x] `changelog.d/spool-permission-model.md` fragment 已新增且已 commit
- [x] `CHANGELOG.md [Unreleased] → Fixed` 有對應 entry
- [x] `VERSION` 未動（非 release PR）
- [x] 全套測試通過（3761 passed），零回歸
- [x] 新測試在**真實 ACL 樹**上驗 effective 權限，並做過突變驗證（三個缺陷各一組）
- [x] ACL／root 不可用時**明確 skip 並附理由**，不靜默通過
- [x] 兩個 spool 的 per-job 生命週期收斂到單一 helper（`coordinator/spool_slot.py`）
- [x] pre-seed 守衛語意與 operator 可見的錯誤字串未變
- [x] docs 同步（spec §R1 資產段落 ＋ Phase 2b runbook §3b／commit-spool 驗證段）
- [x] `python3 -m policy_check` 帶完整 PR 上下文跑過，fail: 0
- [x] 文件與 PR 內文為 zh-tw
- [x] 未動 `paulsha_cortex/trust_root/`、未動 `config/paths.py`
- [x] 未觸及 gate 執行身分（#629）與 M2（#615）

Closes #638
Refs #599 #623 #636 #637 #615

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E7w9kaUxAzCCEk7piD5hfK
