### PR TITLE
feat(trust-root): executor toolchain 與 per-account 憑證進登記表（#640）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,38 @@
 ## [Unreleased]
 
 ### Added
+- **#640 / trust-root Phase 2b：真實 dispatch 的最後一哩——executor toolchain 與
+  per-account 憑證進登記表**——#623 那一族的第五個缺口，且比前四個都靠後：前四個解完
+  之後，dispatch 會一路走到**呼叫模型**那一步才失敗。job unit 帶 `ProtectHome=yes`，
+  而四個 executor 原本全在 operator 的 HOME 底下，實測
+  `sudo -u cortex-builder env HOME=<job HOME> codex exec --help` →
+  `/usr/bin/env: ‘node’: No such file or directory`（rc=127）；登記表對 toolchain 與
+  job 帳號憑證**都沒有預留資產**，permgen 因此也不會產生它們的權限。0817 裁決落地為
+  兩個新資產：
+  - `executor-toolchain`（`<deploy_root>/toolchain`，root-owned 0755，全部 job／服務
+    帳號**唯讀＋可執行**）：`node` 走**系統層**（通用 runtime）；四個模型 CLI 落進
+    部署樹，因為「job 跑的是哪個版本的模型 CLI」**會**影響產出——那必須是可稽核的部署
+    決定，而不是跟著 operator 的環境漂移。實機盤點在同一台機器上就有兩份 `codex`
+    （系統層 0.42.0 vs operator 實際在用的 0.147.0），因此安裝來源一律取 operator
+    實際在用的那一份，不另外 `npm install -g`。四者形態不同（`codex` 是 node script、
+    **唯一硬需要 node** 且要整包搬 npm 套件樹；`claude`／`agy` 自帶原生執行檔；
+    `copilot` 是 shell script），固化為 `permgen.EXECUTOR_TOOLS`——**系統層 node 的版本
+    風險因此只涵蓋 `codex` 一個**。`ProtectSystem=strict` 下 `/opt` 唯讀只擋寫入不擋
+    執行，故本資產機械地不出現在任何 unit 的 `ReadWritePaths` 上。
+  - `builder-executor-credential`（預設 `<job HOME>/.codex/auth.json`）：**檔案由 job
+    帳號擁有**（0600，能自行 refresh 過期 token），**放它的目錄維持 root-owned**
+    （0755）——job 因此改得了自己那份憑證的內容，卻**建不了新檔、刪不掉、也換不掉**
+    同目錄下的 root-owned `codex-hooks`（增／刪／換要的是目錄的寫入權）。
+    `ReadWritePaths` 只掛憑證**檔本身**而非父目錄（新的
+    `permgen.IN_PLACE_CONTENT_WRITE_ASSETS` 例外），使「目錄 root-owned」在檔案系統與
+    systemd mount 兩層同時成立。已知限制（裁決刻意接受）：以「暫存檔 ＋ rename」
+    refresh 的 CLI 會失敗。落點由新的部署決定欄位
+    `PathLayout.executor_credential_relpath` 導出，骨架的 root-owned 保護跟著它走；
+    `scaffold_directories()` 已為每一個 job 帳號建出該父目錄，登記表只掛
+    `cortex-builder` 一份（與 `codex-hooks` 逐條同構）。
+- **`trust_root toolchain` CLI verb ＋ `permgen.build_toolchain_plan()`**：toolchain 的
+  落位步驟由產生器出（逐支 CLI 的形態／搬移方式／來源判準／統一收權／
+  `PSC_BUILDER_PATH` 正規值），runbook 不手寫；與 `shim`／`gitconfig` 同一個定位。
 - **#623 / trust-root Phase 2b：per-job clone 的信任根層——`repo-source-tree`、三份
   root-owned `.gitconfig` 與 `commit-spool` 進登記表，內容由 permgen 產生**——M1 之後
   實機發現「這個部署做不了真實工作」：`ProtectHome=yes` 讓 `/home` 完全不可見，而登記表
@@ -284,6 +316,28 @@
   `mock.patch.object` 打不到，測試實際驗到的是「本機有沒有那個帳號」而非它宣稱的分支。
 
 ### Changed
+- **#640 / job 的 `PATH` 沿用既有的 `PSC_BUILDER_PATH`，並由「選配」改為「必填」**
+  ——`PathLayout.job_path_value()` 給出正規值（`<toolchain>/bin` **排最前面**，尾段是
+  系統層，不含任何 `sbin`）。**刻意不在模板 unit 裡寫 `Environment=PATH=`**：模板
+  unit 的 `ExecStart` 是 root-owned shim，shim 以 `execvpe(argv[0], argv, spec['env'])`
+  整份換掉環境，job 解析命令用的 `PATH` 來自 **spec 的 env**——寫在 unit 上只會是一個
+  看起來承載作用、實際被 shim 丟掉的設定。toolchain 排最前面是必要的：否則系統層那份
+  舊版會蓋掉它，症狀是「跑得起來但版本不是預期的那個」。取捨連同理由寫進產生出來的
+  job unit 註解裡。
+- **#640 / spec §R1 明載一個誠實限制**：把 operator 的憑證複製給 job 帳號，代表 job
+  用的是**同一個 provider 帳號**。三分買到的是**檔案系統層**的隔離（job 偷不到
+  Manager 的 token、改不了 Manager 的 state、讀不到另一個 job 帳號的憑證），**不是**
+  provider 層的獨立——與 `independence_domain`（§R5／§R8 的 anti-collusion 控制）不是
+  同一件事，兩者不得互相當作證據。真正的 provider 層獨立需要每個 job 帳號各自的
+  provider 帳號，屬未來選項。
+- **#640 / Phase 2b runbook 新增第 4e 步**「executor toolchain 落位 ＋ per-account
+  憑證」（4 個 sudo 點、9 個驗證點）：系統層 node（版本本身是部署決定）、逐支 CLI 的
+  搬移方式、**以 job 帳號實跑一次 `--help` 期望 rc=0**、**版本與 operator 側逐字相同**
+  （只驗 rc=0 不夠——系統層那份舊的一樣 rc=0）、在真實加固面下以 `systemd-run` 複跑
+  （`MemoryDenyWriteExecute=yes` 對 node 的 V8 是第一嫌疑），以及憑證「能改內容／
+  建不了新檔／刪不掉／換不掉鄰居」的反向不變式。5-5 的 `PSC_BUILDER_PATH` 與
+  「builder 自己 `login`」兩段一併改寫，附錄 A 補兩條漂移自我檢查 → 合計 **49** 個
+  sudo 點、**174** 個驗證點。
 - **#623 / trust-root Phase 2b：成果回收由「Manager 伸手進 builder 的 clone fetch」
   改為 git bundle ＋ append-only spool**——#634 的回收做法
   `git -C <來源樹> fetch <builder 的 clone>` 在三分下**行不通**（operator 0817 實機

--- a/changelog.d/executor-toolchain.md
+++ b/changelog.d/executor-toolchain.md
@@ -1,0 +1,64 @@
+### Added
+- **#640 / trust-root Phase 2b：真實 dispatch 的最後一哩——executor toolchain 與
+  per-account 憑證進登記表**——#623 那一族的第五個缺口，比前四個都靠後：前四個解完之後，
+  dispatch 會一路走到**呼叫模型**那一步才失敗。job unit 帶 `ProtectHome=yes`，而四個
+  executor 原本全在 operator 的 HOME 底下（nvm 樹與 `~/.local/bin`），實測
+  `sudo -u cortex-builder env HOME=<job HOME> codex exec --help` →
+  `/usr/bin/env: ‘node’: No such file or directory`，rc=127；系統層完全沒有 node，
+  而登記表對 toolchain 與 job 帳號憑證**都沒有預留資產**，因此 permgen 也不會產生它們
+  的權限。0817 裁決落地為兩個新資產：
+  - **`executor-toolchain`**（`<deploy_root>/toolchain`，root-owned 0755，全部 job／
+    服務帳號**唯讀＋可執行**）——`node` 走**系統層**（通用 runtime，換版本幾乎不影響
+    產出）；四個模型 CLI（`codex`／`claude`／`copilot`／`agy`）落進部署樹，因為「job
+    跑的是哪個版本的模型 CLI」**會**影響產出，那必須是**可稽核的部署決定**而不是跟著
+    operator 的環境漂移。這不是假設——實機盤點在同一台機器上就有兩份 `codex`（系統層
+    0.42.0 vs operator 實際在用的 0.147.0，差 100 個以上小版本），因此安裝來源一律取
+    operator 實際在用的那一份，**不**另外 `npm install -g`。四者的實體形態不同、搬移
+    方式不能一概而論，固化為 `permgen.EXECUTOR_TOOLS`：`codex` 是 node script（**唯一
+    硬需要 node**，且必須整包搬 npm 套件樹）、`claude`／`agy` 自帶原生執行檔、`copilot`
+    是 shell script——**因此系統層 node 的版本風險只涵蓋 `codex` 一個**。機械落點是
+    `owner_class=DEPLOYMENT`，`ProtectSystem=strict` 下 `/opt` 唯讀只擋寫入不擋執行，
+    故本資產機械地不出現在任何 unit 的 `ReadWritePaths` 上。
+  - **`builder-executor-credential`**（預設 `<job HOME>/.codex/auth.json`，**檔案由 job
+    帳號擁有** 0600、**放它的目錄維持 root-owned** 0755）——job 因此能就地改寫自己那份
+    憑證的內容（refresh 過期 token），卻**建不了新檔、刪不掉、也換不掉**同目錄下的其他
+    root-owned 檔（`codex-hooks` 就住在同一層）：增／刪／換要的是**目錄**的寫入權。
+    `ReadWritePaths` 因此只掛**憑證檔本身**而非父目錄（新的
+    `permgen.IN_PLACE_CONTENT_WRITE_ASSETS` 例外），讓「目錄 root-owned」在檔案系統與
+    systemd mount 兩層同時成立。已知限制（裁決刻意接受）：以「暫存檔 ＋ rename 原子
+    替換」refresh 的 CLI 會失敗，只有就地覆寫走得通。落點由新的部署決定欄位
+    `PathLayout.executor_credential_relpath` 導出（形狀在建構當下即驗），骨架目錄的
+    root-owned 保護因此**跟著它走**而不是寫死 `.codex`；`scaffold_directories()` 已為
+    **每一個** job 帳號建出該父目錄，機制是 per-account 的，登記表只掛 `cortex-builder`
+    一份（與 `codex-hooks` 逐條同構——它是兩個 scheme 都相同、且目前唯一真的以模板 unit
+    降權起 job 的帳號；登記第二份會讓 Manager unit 的 `ReadWritePaths` 出現一條二分
+    部署裡不存在的 HOME 路徑而使 unit 起不來）。
+- **`trust_root toolchain` CLI verb ＋ `permgen.build_toolchain_plan()`**——toolchain 的
+  **落位**步驟（逐支 CLI 的形態、搬移方式、來源判準、統一收權、`PSC_BUILDER_PATH` 的
+  正規值）由產生器出，runbook 不手寫；與 `shim`／`gitconfig` 同一個定位（權限那一半
+  仍由登記表經 `plan_to_commands()` 產出）。
+
+### Changed
+- **job 的 `PATH` 沿用既有的 `PSC_BUILDER_PATH`，並由 runbook 從「選配」改為「必填」**
+  ——`PathLayout.job_path_value()` 給出正規值（`<toolchain>/bin` **排最前面**，尾段是
+  系統層 `/usr/local/bin:/usr/bin:/bin`，不含任何 `sbin`）。**刻意不在模板 unit 裡寫
+  `Environment=PATH=`**：模板 unit 的 `ExecStart` 是 root-owned shim，shim 以
+  `execvpe(argv[0], argv, spec['env'])` 整份換掉環境，job 解析命令用的 `PATH` 來自
+  **spec 的 env**（即 Manager 端這個變數）——寫在 unit 上只會是一個看起來承載作用、
+  實際被 shim 丟掉的設定。toolchain 必須排最前面，否則系統層那份舊版會蓋掉它，而症狀是
+  「跑得起來但版本不是預期的那個」，比 `command not found` 難查得多。取捨連同理由寫進
+  產生出來的 job unit 註解裡。
+- **spec §R1 明載一個誠實限制**：把 operator 的憑證複製給 job 帳號，代表 job 用的是
+  **同一個 provider 帳號**。三分買到的是**檔案系統層**的隔離（job 偷不到 Manager 的
+  token、改不了 Manager 的 state、讀不到另一個 job 帳號的憑證），**不是** provider 層
+  的獨立——與 `independence_domain`（§R5／§R8 的 anti-collusion 控制，由 Manager 派工時
+  決定並寫入 registry）**不是同一件事**，兩者 MUST NOT 互相當作證據。真正的 provider
+  層獨立需要每個 job 帳號各自的 provider 帳號，屬未來選項。
+- **Phase 2b runbook 新增第 4e 步**「executor toolchain 落位 ＋ per-account 憑證」
+  （4 個 sudo 點、9 個驗證點）：系統層 node（版本本身是部署決定，某個 CLI 提高下限時要
+  一併升）、逐支 CLI 的搬移方式、**以 job 帳號實跑一次 `--help` 期望 rc=0**、
+  **版本與 operator 側逐字相同**（只驗 rc=0 不夠——系統層那份舊的一樣 rc=0）、在真實
+  加固面下以 `systemd-run` 複跑一次（`MemoryDenyWriteExecute=yes` 對 node 的 V8 是第一
+  嫌疑），以及憑證「能改內容／建不了新檔／刪不掉／換不掉鄰居」的反向不變式。5-5 的
+  `PSC_BUILDER_PATH` 與「builder 自己 `login`」兩段一併改寫，附錄 A 補兩條漂移自我檢查
+  → 合計 **49** 個 sudo 點、**174** 個驗證點。

--- a/docs/superpowers/runbooks/trust-root-phase2b-setup.md
+++ b/docs/superpowers/runbooks/trust-root-phase2b-setup.md
@@ -234,20 +234,20 @@ A/B 並列時同一件事要寫兩遍（5-A／5-B、第 8 步兩種起法、附�
 | 段落 | 🔧 sudo 點 | ✅ 驗證點 |
 |---|---:|---:|
 | 執行前提（含 G1／G2 兩個硬性 gate） | 0 | 11 |
-| 產生器＝單一真相 | 0 | 9 |
+| 產生器＝單一真相 | 0 | 10 |
 | 第 1 步：建三帳號 | 3 | 5 |
 | 第 2 步：目標樹與權限（含 2c 來源樹） | 4 | 21 |
 | 第 3 步：legacy-import（含 operator 設定搬遷） | 3 | 11 |
-| 第 4 步：Manager／monitor 部署與 unit | 12 | 24 |
-| **第 5 步：降權（A+B）** | **7** | **27** |
+| 第 4 步：Manager／monitor 部署與 unit（含 4e toolchain／憑證） | 16 | 33 |
+| **第 5 步：降權（A+B）** | **7** | **28** |
 | 第 6 步：升級流程 | 5 | 6 |
 | 第 7 步：切換驗收（含功能面檢查） | 0 | 5 |
 | 第 8 步：R9 抽驗（五族） | 5 | 19 |
 | 第 9 步：回滾 | 2 | 1 |
 | WSL2 風險與診斷 | 2 | 12 |
-| 附錄 A：自我檢查 | 0 | 7 |
+| 附錄 A：自我檢查 | 0 | 9 |
 | 附錄 B：降級備援 | 2 | 3 |
-| **合計** | **45** | **161** |
+| **合計** | **49** | **174** |
 
 （統計方式：全文 `🔧`／`✅` 標記出現次數，扣除說明性用法——「標記約定」的定義行、
 段落標題內的標記、以及表格裡當狀態記號用的那幾個。）
@@ -269,6 +269,12 @@ A/B 並列時同一件事要寫兩遍（5-A／5-B、第 8 步兩種起法、附�
   `.gitconfig`」——2 個 sudo 點、5 個驗證點（來源樹 Manager 可寫／job 唯讀、job 真的
   clone 得動、三份 `.gitconfig` 對應帳號不可寫、commit spool 的 `wx` 無 `r`）
   → **45** 個 sudo 點、**161** 個驗證點。
+- **#640（executor 執行面）新增**：第 4e 步「executor toolchain 落位 ＋ per-account
+  憑證」——4 個 sudo 點、9 個驗證點（toolchain 對 job 唯讀、以 job 帳號實跑
+  `--help` 期望 rc=0、**版本與 operator 側逐字相同**、在真實加固面下複跑一次、
+  憑證「檔 job-owned／目錄 root-owned」的三條反向不變式），另在「產生器＝單一真相」
+  與 5-5 各補一條 ✅、附錄 A 補兩條漂移自我檢查（版本分岔／憑證 owner）
+  → **49** 個 sudo 點、**174** 個驗證點。
 
 ---
 
@@ -342,6 +348,10 @@ python3 -m paulsha_cortex.trust_root shim three-way
 python3 -m paulsha_cortex.trust_root gitconfig three-way --builder --source-repo <slug>
 python3 -m paulsha_cortex.trust_root gitconfig three-way --reviewer-planner --source-repo <slug>
 python3 -m paulsha_cortex.trust_root gitconfig three-way --manager --source-repo <slug>
+
+# ✅ executor toolchain 的落位步驟（#640；四個模型 CLI 進 /opt/cortex/toolchain、
+#    node 走系統層、job 的 PSC_BUILDER_PATH 值）——見第 4e 步
+python3 -m paulsha_cortex.trust_root toolchain three-way
 ```
 
 **job-spec 的欄位契約也已隨 #616 落地**——`coordinator/job_runner.py` 的
@@ -1361,6 +1371,176 @@ sudo rm /etc/systemd/system/cortex-monitor.service; sudo systemctl daemon-reload
 **注意**：回滾後 monitor 會重新寫舊的 `~/.agents/monitor` 樹，與 system-level Manager
 的 `/var/lib/cortex/monitor` 形成雙寫——僅可作為短時間的救急手段。
 
+### 4e. executor toolchain 落位 ＋ per-account 憑證（#640）
+
+**沒有這一步，前面全部做完 dispatch 仍會在「呼叫模型」那一步失敗。** job unit 帶
+`ProtectHome=yes`，而四個 executor 原本全在 operator 的 HOME 底下：
+
+```
+$ sudo -u cortex-builder env HOME=/var/lib/cortex-builder codex exec --help
+/usr/bin/env: ‘node’: No such file or directory        rc=127
+```
+
+**0817 裁決 (a)**：`node` 走**系統層**（通用 runtime，換版本幾乎不影響產出）；四個
+模型 CLI 落進 `/opt/cortex/toolchain`（登記表資產 `executor-toolchain`，root-owned、
+job／服務帳號唯讀＋可執行）。理由是「job 跑的是哪個版本的模型 CLI」**會**影響產出，
+那必須是一個可稽核的部署決定。
+
+> **為什麼不是「系統層有什麼就用什麼」**：這台機器上實測有**兩份** `codex`——系統層
+> `/usr/lib/node_modules/@openai/codex` 是 **0.42.0**，operator 實際在用的 nvm 那份是
+> **0.147.0**，差 100 個以上小版本。裁決要防的漂移在這裡**已經是現況**，不是假設。
+> 所以來源一律取 operator 實際在用的那一份（`command -v` 解出來的），**不要**另外
+> `npm install -g` 裝一份。
+
+**四個 CLI 的實體形態不同，搬移方式不能一概而論**（表在 `permgen.EXECUTOR_TOOLS`）：
+
+| executor | 形態 | 需要 node | 搬移方式 |
+|---|---|:--:|---|
+| `codex` | Node.js script（`.js` ＋ `#!/usr/bin/env node`） | ✅ | **整包** npm 套件樹，`bin/` 放進入點 symlink |
+| `claude` | 原生 ELF 執行檔 | — | 單檔複製 |
+| `copilot` | bash script | — | 單檔複製；**先 `head -n 20` 查它內部再叫什麼** |
+| `agy` | 原生 ELF 執行檔 | — | 單檔複製 |
+
+> `claude`／`agy` 自帶原生執行檔，**不會因為 node 版本而行為改變**——因此系統層 node
+> 的版本風險只涵蓋 `codex` 一個。
+
+```bash
+# ✅ 先讀落位步驟（含每支 CLI 的形態與搬移方式；產生器＝單一真相）
+python3 -m paulsha_cortex.trust_root toolchain three-way | less
+
+# 🔧 sudo：系統層 node（apt；nodesource repo 已設定時候選為 20.x）
+sudo apt-get install -y nodejs
+node --version
+#   期望：v20 以上。codex 0.147.0 宣告 `node >=16`，故 20 可用。
+#   ⚠️ node 版本是**部署決定**：某個 CLI 哪天提高下限時要一併升，
+#      否則它會變成下一個無聲漂移點。
+
+# 🔧 sudo：建骨架並把四個 CLI 從 operator 實際在用的那一份複製進來
+#   （逐支的來源與方式照 `trust_root toolchain` 的輸出；以下為 codex 的形狀）
+sudo install -d -o root -g root -m 0755 /opt/cortex/toolchain{,/bin,/lib}
+SRC="$(readlink -f "$(command -v codex)")"
+PKG="$(cd "$(dirname "$SRC")/.." && pwd)"     # npm 套件根（單搬 .js 會缺 node_modules）
+sudo cp -a "$PKG" /opt/cortex/toolchain/lib/codex
+sudo ln -sfn "/opt/cortex/toolchain/lib/codex/$(basename "$SRC")" \
+  /opt/cortex/toolchain/bin/codex
+for cli in claude copilot agy; do
+  sudo cp -a "$(readlink -f "$(command -v "$cli")")" "/opt/cortex/toolchain/bin/$cli"
+done
+
+# 🔧 sudo：統一收權（root 擁有、全部 job／服務帳號唯讀＋可執行）
+sudo chown -R root:root /opt/cortex/toolchain
+sudo chmod -R u=rwX,go=rX /opt/cortex/toolchain
+```
+
+```bash
+# ✅ 驗證：權限與登記表產生的計畫逐位元一致
+python3 -m paulsha_cortex.trust_root permissions three-way --commands --paths \
+  --operator-account "$USER" --external-reader-account none \
+  | grep -A3 "executor-toolchain"
+ls -ld /opt/cortex/toolchain
+#   期望：drwxr-xr-x root root（**一個 group／other 的 w 都不得有**）
+
+# ✅ 驗證：job 帳號寫不進去（這條才是邊界）
+sudo -u cortex-builder sh -c "touch /opt/cortex/toolchain/bin/evil" 2>&1 | tail -1
+#   期望：Permission denied
+
+# ✅ 功能驗證（本票的核心驗收）：以 job 帳號實跑一次 `--help`，期望 rc=0
+for cli in codex claude copilot agy; do
+  sudo -u cortex-builder env HOME=/var/lib/cortex-builder \
+    PATH=/opt/cortex/toolchain/bin:/usr/local/bin:/usr/bin:/bin \
+    "$cli" --help >/dev/null 2>&1; echo "$cli rc=$?"
+done
+#   期望：四行皆 rc=0。**rc=127 ＝ #640 的原症狀**（CLI 或它的 runtime 不可達）：
+#     先 `sudo -u cortex-builder ... command -v <cli>` 看解到哪裡，
+#     再 `head -n 1 /opt/cortex/toolchain/bin/codex` 確認 shebang 解得開（node 在系統層）。
+
+# ✅ 驗證（**裁決 (a) 真正要守的那條**）：job 帳號跑出來的版本 == operator 側的版本
+sudo -u cortex-builder env HOME=/var/lib/cortex-builder \
+  PATH=/opt/cortex/toolchain/bin:/usr/local/bin:/usr/bin:/bin codex --version
+codex --version
+#   期望：**兩行逐字相同**。只驗 rc=0 是不夠的——系統層那份 0.42.0 一樣會 rc=0，
+#   而 job 跑的就變成 operator 從未判讀過的版本（症狀是「結果對不上」，不是報錯）。
+#   不同 ⇒ PATH 順序錯（toolchain 沒排最前面），或複製到的是系統那份。
+
+# ✅ 驗證（**在真實加固面下**跑一次）：`sudo -u` 沒有 unit 的加固，兩者可能不同結果
+sudo systemd-run --pipe --wait --collect \
+  --uid=cortex-builder --gid=cortex-builder \
+  --property=NoNewPrivileges=yes --property=ProtectSystem=strict \
+  --property=ProtectHome=yes --property=MemoryDenyWriteExecute=yes \
+  --setenv=HOME=/var/lib/cortex-builder \
+  --setenv=PATH=/opt/cortex/toolchain/bin:/usr/local/bin:/usr/bin:/bin \
+  /opt/cortex/toolchain/bin/codex --version
+#   期望：與上一條同一個版本、rc=0。
+#   ⚠️ 若這條失敗而 `sudo -u` 那條成功，**第一嫌疑是 `MemoryDenyWriteExecute=yes`**
+#      （node 的 V8 需要 W→X 轉換）。單獨拿掉該 property 複測即可確認；確認後
+#      屬 unit 加固面的裁決，記進 #584 而不是在這裡自行放寬。
+```
+
+**per-account 憑證（0817 裁決 (b)）**：憑證**檔**由 job 帳號擁有（才 refresh 得了
+過期 token），**放它的目錄維持 root-owned**。
+
+> **這個組合的安全性質**：job **能**就地改寫自己那份憑證的內容；但**建不了新檔、
+> 刪不掉、也換不掉**同目錄下的其他 root-owned 檔（例如 `codex-hooks` 的
+> `hooks.json`）——建立／unlink／rename 需要的是**目錄**的寫入權，而目錄對 job 只有
+> `r-x`。
+>
+> **已知限制**：因此「暫存檔 ＋ rename 原子替換」形式的 refresh 會失敗（它要在同目錄
+> 建檔），只有就地覆寫的 refresh 走得通。這是裁決刻意接受的代價。
+>
+> **這買到的是什麼**：把 operator 的憑證複製給 job 帳號，代表 job 用的是**同一個
+> provider 帳號**。三分買到的是**檔案系統層**的隔離（job 偷不到 Manager 的 token、
+> 改不了 Manager 的 state、也讀不到另一個 job 帳號的憑證），**不是** provider 層的
+> 獨立——與 `independence_domain` 不是同一件事（見 spec §R1）。
+
+```bash
+# 🔧 sudo：把 operator 那份憑證複製給兩個 job 帳號，owner 給該帳號、目錄維持 root 的
+for who in builder reviewer-planner; do
+  sudo install -o "cortex-$who" -g "cortex-$who" -m 0600 \
+    "$HOME/.codex/auth.json" "/var/lib/cortex-$who/.codex/auth.json"
+done
+#   ↑ `.codex/` 目錄本身由第 2b 步的骨架建成 root:root 0755，這裡**不要**動它。
+#   其他 executor 的憑證檔位置不同（`claude` 等各有自己的落點，本票未實測）：
+#   落位規則完全一樣——先確認該 CLI 實際寫哪個檔，再以同一條 install 命令落位；
+#   若該檔的父目錄還不存在，用 `sudo install -d -o root -g root -m 0755 <dir>` 補。
+```
+
+```bash
+# ✅ 驗證：檔案 owner 是 job 帳號、**目錄** owner 是 root
+ls -ld /var/lib/cortex-builder/.codex
+ls -l  /var/lib/cortex-builder/.codex/auth.json
+#   期望：目錄 drwxr-xr-x root root；檔案 -rw------- cortex-builder cortex-builder
+
+# ✅ 驗證：與登記表產生的計畫一致
+python3 -m paulsha_cortex.trust_root permissions three-way --commands --paths \
+  --operator-account "$USER" --external-reader-account none \
+  | grep "executor-credential"
+#   期望：chown cortex-builder:cortex-builder … ＋ chmod 0600 …（帶 `[ ! -e ] ||` 守衛）
+
+# ✅ 驗證（**不變式：能改內容、不能增刪換**）
+sudo -u cortex-builder sh -c \
+  "printf '{}' > /var/lib/cortex-builder/.codex/auth.json" && echo "改內容: OK"
+#   期望：OK（refresh 走得通）——測完記得把真的憑證放回去
+sudo -u cortex-builder sh -c \
+  "touch /var/lib/cortex-builder/.codex/newfile" 2>&1 | tail -1
+#   期望：Permission denied ← **建不了新檔**
+sudo -u cortex-builder sh -c \
+  "rm -f /var/lib/cortex-builder/.codex/auth.json" 2>&1 | tail -1
+#   期望：Permission denied ← **刪不掉**
+sudo -u cortex-builder sh -c \
+  "mv /var/lib/cortex-builder/.codex/auth.json /var/lib/cortex-builder/.codex/hooks.json" \
+  2>&1 | tail -1
+#   期望：Permission denied ← **換不掉同目錄下的 root-owned 檔**
+```
+
+> **job unit 會因為憑證缺席而起不來**：模板 unit 的 `ReadWritePaths` 直接掛在憑證
+> **檔**上（不是它的父目錄），而 systemd 對不存在的 `ReadWritePaths` 目標會讓 unit
+> 起不來。那是刻意的 fail-closed——沒有登入態的 job 本來就做不了事，在 exec 前失敗
+> 比走到呼叫模型那一步才 rc=127 好查得多。journal 若出現
+> `Failed to set up mount namespacing … No such file or directory`，先回頭看這一步。
+
+**回滾**：`sudo rm -rf /opt/cortex/toolchain
+/var/lib/cortex-{builder,reviewer-planner}/.codex/auth.json`。
+
 ---
 
 ## 第 5 步：降權啟用（**A+B 單一路徑**）
@@ -1513,11 +1693,16 @@ PY
 ### 5-5. (d) 打開切換點 `PSC_JOB_RUNNER=systemd-template`
 
 ```bash
+# ✅ 先取 PSC_BUILDER_PATH 的正規值（產生器＝單一真相，**不要手打**）
+python3 -m paulsha_cortex.trust_root unit three-way --job | grep PSC_BUILDER_PATH
+#   期望：PSC_BUILDER_PATH=/opt/cortex/toolchain/bin:/usr/local/bin:/usr/bin:/bin
+
 # 🔧 sudo：把降權模式寫進第 4b 步的 EnvironmentFile
 sudo tee -a /opt/cortex/etc/cortex-manager.env >/dev/null <<'ENVFILE'
 PSC_JOB_RUNNER=systemd-template
 PSC_BUILDER_ACCOUNT=cortex-builder
 PSC_BUILDER_HOME=/var/lib/cortex-builder
+PSC_BUILDER_PATH=/opt/cortex/toolchain/bin:/usr/local/bin:/usr/bin:/bin
 ENVFILE
 sudo systemctl restart cortex-manager.service
 
@@ -1529,9 +1714,25 @@ sudo -u cortex-manager env $(grep -v '^#' /opt/cortex/etc/cortex-manager.env | x
 ```
 
 > `PSC_JOB_RUNNER` 預設 `direct`＝不降權；值非法時**fail-closed**（不會靜默當成
-> `direct`）。`PSC_BUILDER_PATH` 選配——模型 CLI 不在 Manager `PATH` 上時才需要。
-> **builder 帳號必須自己有模型 CLI 的登入態**（`sudo -u cortex-builder claude /login`
-> 之類）；Manager 不會把自己的憑證傳過去，那正是本步驟的重點。
+> `direct`）。
+>
+> **`PSC_BUILDER_PATH` 是必填，不再是選配（#640 改）**：未設時 job 會拿到 Manager
+> 轉發的 `PATH`，而 Manager 以 system unit 跑、拿到的是 systemd 的預設 `PATH`
+> （`/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin`）——裡面**沒有**
+> `/opt/cortex/toolchain/bin`。toolchain 必須排在最前面：系統層可能另有一份同名但舊
+> 很多的 CLI（本機實測兩份 `codex` 差 100 個以上小版本），排後面的症狀是「跑得起來
+> 但版本不是預期的那個」。
+>
+> **為什麼是 `PSC_BUILDER_PATH` 而不是模板 unit 的 `Environment=PATH=`**：模板 unit
+> 的 `ExecStart` 是 root-owned shim，shim 以 `execvpe(argv[0], argv, spec['env'])`
+> **整份換掉**環境——job 解析命令用的 `PATH` 來自 **spec 的 env**（即 Manager 端這個
+> 變數），不是 unit 的 `Environment=`。寫在 unit 上只會是一個看起來承載作用、實際被
+> shim 丟掉的設定。產生的 job unit 內有一段註解把這個取捨寫在產物本身。
+>
+> **憑證**：見第 4e 步——由 root 複製進 job 帳號 HOME、chown 給該帳號（0600），
+> **不是**讓 builder 自己 `login`（toolchain 未落位前 `login` 這個動作本身就跑不起來，
+> 而且 job 的 HOME 是 root-owned，CLI 也建不了 `auth.json`）。Manager 不會在執行期把
+> 自己的憑證傳過去——job 的登入態是一次性的部署動作。
 > **M2 之前**：`PSC_JOB_RUNNER` 只影響 builder persona；reviewer／planner 仍在 Manager
 > 行程內執行（見開頭「分段落地」）。
 
@@ -2573,6 +2774,16 @@ for U in cortex-manager cortex-reviewer-planner cortex-builder; do id -nG "$U"; 
 
 # ✅ 權限沒有漂移
 sudo find /var/lib/cortex /opt/cortex -perm /022 -print | head
+
+# ✅ executor toolchain 仍可用，且版本沒有跟 operator 側分岔（#640）
+sudo -u cortex-builder env HOME=/var/lib/cortex-builder \
+  PATH=/opt/cortex/toolchain/bin:/usr/local/bin:/usr/bin:/bin codex --version
+codex --version
+#   期望：兩行逐字相同。分岔＝某一側被升級了而另一側沒有——那正是裁決 (a) 要防的漂移。
+
+# ✅ 憑證仍是「檔 job-owned／目錄 root-owned」（#640 裁決 (b)）
+stat -c '%n %U:%G %a' /var/lib/cortex-builder/.codex /var/lib/cortex-builder/.codex/auth.json
+#   期望：目錄 root:root 755、檔案 cortex-builder:cortex-builder 600
 
 # ✅ 產生器本身的等式測試（含 ReadWritePaths 無遺漏無多餘）
 python3 -m pytest tests/test_trust_root_permgen_p2a.py tests/test_trust_root_permgen_p2b.py -q

--- a/docs/superpowers/specs/trust-root-isolation-spec.md
+++ b/docs/superpowers/specs/trust-root-isolation-spec.md
@@ -486,6 +486,82 @@ gitconfig 變成執行期可變狀態。
 Manager 從那個 **bundle 檔**（不是 repo）fetch。Manager 全程不碰 builder 的樹，讀的又是
 一個普通檔案，dubious-ownership 與 traverse 兩個問題同時消失。
 
+#### executor 執行面：toolchain 與 per-account 憑證（#640 裁決；登記表資產 `executor-toolchain`／`builder-executor-credential`）
+
+`ProtectHome=yes` 讓 job 帳號看不到 `/home`，而四個模型 executor（`codex`／`claude`／
+`copilot`／`agy`）原本**全部**落在 operator 的 HOME 底下（nvm 樹與 `~/.local/bin`）。
+實測：
+
+```
+$ sudo -u cortex-builder env HOME=<job HOME> codex exec --help
+/usr/bin/env: ‘node’: No such file or directory        rc=127
+```
+
+登記表對 toolchain 與 job 帳號憑證**都沒有預留資產**，因此 permgen 也不會產生它們的
+權限——這是「provisioning → clone → bundle → harvest 全通、但 dispatch 走到呼叫模型
+那一步才失敗」的最後一哩。
+
+##### (a) toolchain：node 走系統層、模型 CLI 進部署樹
+
+- `node` SHALL 由**系統層**提供（apt）。它是通用 runtime，換版本幾乎不影響產出；
+  但版本本身仍是**部署決定**，某個 CLI 提高下限時 SHALL 一併升，否則它會變成下一個
+  無聲漂移點。
+- 四個模型 CLI SHALL 落進 `<deploy_root>/toolchain`（登記表資產 `executor-toolchain`）：
+  `owner_class=DEPLOYMENT`、owner＝root、mode `0755`——**全部 job／服務帳號唯讀＋
+  可執行**，一個 `w` 都沒有。`ProtectSystem=strict` 下 `/opt` 唯讀只擋寫入，讀取與
+  執行不受影響，因此本資產 MUST NOT 出現在任何 unit 的 `ReadWritePaths` 上。
+- 安裝來源 SHALL 是 **operator 實際在用的那一份**（`command -v` 解得到的），
+  MUST NOT 另外 `npm install -g` 裝一份系統的。理由不是假設：實機盤點在同一台機器上
+  就有兩份 `codex`——系統層 0.42.0、operator 實際在用的 0.147.0（差 100 個以上小版本）。
+  「job 跑的是哪個版本的模型 CLI」**會**影響產出，因此它必須是一個可稽核的部署決定，
+  而不是跟著 operator 的環境漂移。
+- 四者的實體形態不同，搬移方式不能一概而論（表固化於
+  `permgen.EXECUTOR_TOOLS`）：`codex` 是 `#!/usr/bin/env node` 的 node script（**唯一
+  硬需要 node**，且必須整包搬 npm 套件樹）；`claude`／`agy` 自帶原生執行檔；`copilot`
+  是 shell script（腳本內部可能再叫別的程式，安裝時 SHALL 查一次）。**因此系統層 node
+  的版本風險只涵蓋 `codex` 一個。**
+- job 的 `PATH` SHALL 由 Manager 端既有的 `PSC_BUILDER_PATH` 注入，且 toolchain
+  SHALL 排在**最前面**——系統層可能另有一份同名但舊很多的 CLI，排在後面的症狀是
+  「跑得起來但版本不是預期的那個」，比 `command not found` 難查得多。**MUST NOT**
+  改以模板 unit 的 `Environment=PATH=` 提供：模板 unit 的 `ExecStart` 是 root-owned
+  shim，shim 以 `execvpe(argv[0], argv, spec['env'])` 整份換掉環境，job 解析命令用的
+  `PATH` 來自 **spec 的 env**——寫在 unit 上只會是一個看起來承載作用、實際被丟掉的設定。
+
+##### (b) 憑證：檔案 job-owned、目錄 root-owned
+
+憑證**檔**（預設 `<job HOME>/.codex/auth.json`，＝本部署 `PSC_MANAGER_EXECUTOR` 的那
+一個）SHALL 由該 job 帳號擁有、mode `0600`；**放它的目錄** SHALL 維持 root-owned
+`0755`（既有的 `<job HOME>/.codex/` 就是這個形態，`codex-hooks` 住在同一層）。
+淨效果：
+
+- job **能**就地改寫自己那份憑證的內容（過期 token 可自行 refresh）；
+- job **建不了新檔、刪不掉、也換不掉**同目錄下的其他 root-owned 檔——建立／unlink／
+  rename 需要的是**目錄**的寫入權，而目錄對它只有 `r-x`。
+
+`ReadWritePaths` SHALL 只掛**憑證檔本身**而非其父目錄（`permgen`
+的 `IN_PLACE_CONTENT_WRITE_ASSETS`；一般規則把檔案折算成父目錄，這一族是明示例外），
+使「目錄 root-owned」在**檔案系統**與 **systemd mount** 兩層同時成立。
+
+**已知限制（裁決刻意接受）**：以「暫存檔 ＋ rename 原子替換」形式 refresh 的 CLI 會
+失敗，因為那需要在同目錄建檔；只有就地 `O_TRUNC` 覆寫的 refresh 走得通。
+
+##### 這買到的是檔案系統層的隔離，**不是** provider 層的獨立
+
+把 operator 的憑證複製給 job 帳號，代表 job 用的是**同一個 provider 帳號**。三分買到
+的是**檔案系統層**的隔離——job 偷不到 Manager 的 token、改不了 Manager 的 state、也讀
+不到另一個 job 帳號的憑證（HOME 互不可讀）。它**不是** provider 層的獨立：同一個
+provider 帳號下的兩個 job 在 provider 眼中是同一個主體，配額、速率限制、稽核紀錄與
+帳號層的封鎖全部共用。
+
+這與 `independence_domain`（§R5／§R8）想表達的**不是同一件事**。`independence_domain`
+是 anti-collusion 控制，講的是「審的人與被審的人不得是同一個模型身分」；它由 Manager
+在派工時決定並寫入 registry，與 OS 帳號、與憑證檔在哪一個 HOME 全無關係。本節的檔案
+系統隔離既不蘊含它、也不被它蘊含——**兩者 MUST NOT 互相當作證據**，spec 在此明載是為
+了避免把「三分 ＋ 各自的憑證檔」讀成比實際更強的保證。
+
+真正的 provider 層獨立需要**每個 job 帳號各自的 provider 帳號**，成本最高（帳號、
+計費、配額各自管理），屬**未來選項**，不在本票範圍。
+
 ### R2 所有 Tier-0／Tier-1 durable state 與 mutation ingress MUST 位於不受信任 headless persona 不可寫的 OS 邊界內
 
 系統 SHALL 使 builder／reviewer／planner 對登記表中 tier 0 與 1 的全部路徑

--- a/paulsha_cortex/trust_root/__main__.py
+++ b/paulsha_cortex/trust_root/__main__.py
@@ -32,6 +32,11 @@ Phase 1 不改 `cortex` CLI（避免動到 R-16 help 對齊面）；operator／C
                                                     # job 帳號 ＋ Manager（Manager 也要
                                                     # 對來源樹跑 git，同樣會撞 dubious
                                                     # ownership）
+    python -m paulsha_cortex.trust_root toolchain [three-way|two-way]
+                                                    # #640：executor toolchain 的落位
+                                                    # 步驟（四個模型 CLI 進
+                                                    # <deploy_root>/toolchain、node 走
+                                                    # 系統層、job 的 PSC_BUILDER_PATH）
     python -m paulsha_cortex.trust_root polkit [three-way|two-way] [--template|--transient]
                                                     # Phase 2b 降權 polkit 規則內容
                                                     # （--template＝方案 B，**預設**；
@@ -43,7 +48,7 @@ UID 方案未指定時一律用 **`three-way`**（operator 0816 第三輪裁決 
 `cortex-manager`／`cortex-reviewer-planner`／`cortex-builder`）。`two-way` 保留為
 向後相容選項，需**顯式**打出——打錯字不會靜默退回較寬鬆的方案。
 
-`permissions`／`unit`／`shim`／`polkit`／`scaffold` 只**產生**計畫與內容字串，
+`permissions`／`unit`／`shim`／`gitconfig`／`toolchain`／`polkit`／`scaffold` 只**產生**計畫與內容字串，
 **絕不執行**任何 root 操作、不寫任何系統路徑——命令供 operator 在 Phase 2b runbook
 中手動 sudo 執行。`--paths` 讓 `--commands` 以 `permgen.DEFAULT_LAYOUT` 的真實絕對
 路徑輸出（0816 裁決：/var/lib/cortex ＋ /opt/cortex），不再帶 placeholder。
@@ -346,6 +351,18 @@ def main(argv: Sequence[str] | None = None) -> int:
             print(str(exc), file=sys.stderr)
             return 2
         print(blob.content, end="")
+        return 0
+    if command == "toolchain":
+        rest = args[1:]
+        scheme_id = permgen.DEFAULT_SCHEME_ID
+        for token in rest:
+            if token in permgen.SCHEMES:
+                scheme_id = token
+            else:
+                print(f"unknown toolchain arg: {token}", file=sys.stderr)
+                return 2
+        for line in permgen.build_toolchain_plan(permgen.SCHEMES[scheme_id]):
+            print(line)
         return 0
     if command == "polkit":
         rest = args[1:]

--- a/paulsha_cortex/trust_root/permgen.py
+++ b/paulsha_cortex/trust_root/permgen.py
@@ -384,6 +384,96 @@ def _validate_repo_slug(slug: str) -> None:
         )
 
 
+#: executor 憑證在帳號 HOME 下的相對路徑形狀（#640）。**必須至少含一個 `/`**：
+#: 裁決 (b) 的性質建立在「檔案 job-owned、放它的**目錄** root-owned」上，憑證直接
+#: 落在 HOME 根本身就沒有那一層目錄可保護。段名限縮成無 shell metacharacter，且
+#: 明確擋掉 `..`——這個值會被接成絕對路徑並嵌進 root 執行的 chown／chmod 命令。
+_CREDENTIAL_RELPATH_RE = re.compile(r"^[A-Za-z0-9._-]+(?:/[A-Za-z0-9._-]+)+$")
+
+
+def _validate_credential_relpath(relpath: str) -> None:
+    if (
+        not isinstance(relpath, str)
+        or not _CREDENTIAL_RELPATH_RE.match(relpath)
+        or any(seg == ".." for seg in relpath.split("/"))
+    ):
+        raise ValueError(
+            f"不是合法的憑證相對路徑：{relpath!r}。它會被接成 <帳號 HOME>/<relpath> "
+            "並嵌進 root 執行的 chown／chmod 命令，只接受 "
+            "`^[A-Za-z0-9._-]+(?:/[A-Za-z0-9._-]+)+$` 且不得含 `..`。"
+            "**必須至少含一層目錄**——裁決 (b) 的「目錄 root-owned、檔案 job-owned」"
+            "沒有那一層就不成立。"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 四個模型 executor 的實體形態（#640 實機盤點）
+#
+# 形態不同 ⇒ 搬進部署樹的方式不能一概而論，因此固化成一張表：runbook 的安裝步驟與
+# 測試都由它導出，新增／換掉一個 executor 只改這裡一列。
+# ---------------------------------------------------------------------------
+
+class ExecutorShape(Enum):
+    """executor 在檔案系統上的實體形態。"""
+
+    NODE_SCRIPT = "node-script"    # `#!/usr/bin/env node` ＋ JS 本體（需 node runtime）
+    NATIVE_ELF = "native-elf"      # 自帶原生執行檔（不依賴任何 runtime）
+    SHELL_SCRIPT = "shell-script"  # shell script（可能再叫別的程式，安裝時要查一次）
+
+
+@dataclass(frozen=True)
+class ExecutorTool:
+    """一個模型 CLI 的搬移契約。"""
+
+    name: str
+    shape: ExecutorShape
+    #: 需要**系統層** runtime 才跑得起來（目前只有 node）。
+    needs_node: bool
+    #: 必須連同整包目錄複製（npm 套件樹），而不是單一檔案。
+    copy_tree: bool
+    note: str
+
+
+#: 0817 實機盤點的四個 executor。`needs_node` 為真者只有 `codex`——這正是「系統層
+#: node 的版本風險只涵蓋一個 CLI」這句話的機器可讀形式。
+EXECUTOR_TOOLS: tuple[ExecutorTool, ...] = (
+    ExecutorTool(
+        "codex", ExecutorShape.NODE_SCRIPT, needs_node=True, copy_tree=True,
+        note=(
+            "唯一硬需要 node 的：本體是 JS，進入點的 shebang 是 `#!/usr/bin/env node`。"
+            "單搬那支 `.js` 會缺 `node_modules`，必須整包搬 npm 套件樹。"
+            "**版本漂移的實例就在它身上**：同一台機器上系統層是 0.42.0、operator 實際"
+            "在用的是 0.147.0，差 100 個以上小版本。"
+        ),
+    ),
+    ExecutorTool(
+        "claude", ExecutorShape.NATIVE_ELF, needs_node=False, copy_tree=False,
+        note="自帶原生執行檔，**不因 node 版本而行為改變**——node 的版本風險不涵蓋它。",
+    ),
+    ExecutorTool(
+        "copilot", ExecutorShape.SHELL_SCRIPT, needs_node=False, copy_tree=False,
+        note=(
+            "shell script。腳本內部**可能再叫別的程式**（另一支 CLI、另一個 runtime），"
+            "安裝時務必 `head -n 20` 查一次它實際 exec 什麼，該相依同樣要在 job 的 "
+            "PATH 上或一併搬進 toolchain。"
+        ),
+    ),
+    ExecutorTool(
+        "agy", ExecutorShape.NATIVE_ELF, needs_node=False, copy_tree=False,
+        note="自帶原生執行檔，同 `claude`：不受系統層 node 版本影響。",
+    ),
+)
+
+#: 走**系統層**的通用 runtime（裁決 (a) 的另一半）。node 換版本幾乎不影響模型輸出，
+#: 因此不進部署樹；但它仍是**部署決定**——某個 CLI 哪天提高下限（目前 codex 宣告
+#: `node >=16`，apt 候選 20.x 可用）時要一併升，否則它會變成下一個無聲漂移點。
+TOOLCHAIN_SYSTEM_RUNTIMES: tuple[str, ...] = ("node",)
+
+#: job `PATH` 的系統層尾段（toolchain 之後）。`node`（codex 的 runtime）、`git`、
+#: wrapper 內的 `python3` 都在這裡。刻意不含任何 `sbin`。
+JOB_PATH_SYSTEM_TAIL: tuple[str, ...] = ("/usr/local/bin", "/usr/bin", "/bin")
+
+
 #: 二分（**向後相容選項**，非預設）：builder 一個帳號，其餘 headless／Manager／
 #: monitor 共用 cortex-svc。0816 第三輪裁決前的方案；已按此裝好的部署可續用，
 #: 但新部署一律走 :data:`DEFAULT_SCHEME`（三分）。
@@ -554,10 +644,15 @@ _DIR_ASSET_IDS = frozenset({
     "gate-ledger",                  # <agents_root>/runtime/dispatch/（manager log_dir）
     "review-verdict-spool",         # <coordinator>/review-verdicts/<reviewer_job_id>/
     "commit-spool",                 # <coordinator>/commit-spool/<job-id>/
+    "executor-toolchain",           # <deploy_root>/toolchain/（四個模型 CLI 的落點）
 })
 _FILE_ASSET_IDS = frozenset({
     "control-daemon-lock",
     "control-status",
+    # #640：憑證是**單一檔**（`<HOME>/<relpath>`）。這條明列不是裝飾——file/dir 的
+    # 判定直接決定 permgen 會不會把一整個目錄 chown 給 job 帳號，而該目錄必須維持
+    # root-owned 才有「能改內容、不能增刪換」那條性質。
+    "builder-executor-credential",
 })
 
 
@@ -974,6 +1069,25 @@ def plan_to_commands(
 # 的機器可讀形式——runbook 不再手寫路徑，全部從這裡取。
 # ---------------------------------------------------------------------------
 
+def _dedupe_scaffold(
+    entries: tuple[tuple[str, str, str, int], ...],
+) -> tuple[tuple[str, str, str, int], ...]:
+    """同一個路徑只留第一次出現的那一筆（順序不變）。
+
+    骨架清單是由**多條獨立規則**疊出來的（`~/.codex` 來自 hooks、憑證父目錄來自
+    #640），預設 layout 下兩者指向同一層。去重讓 `install -d` 不會重複輸出，也讓
+    「無多餘」那類等式測試不必為一個純顯示層的重複而放寬。
+    """
+    seen: set[str] = set()
+    kept: list[tuple[str, str, str, int]] = []
+    for entry in entries:
+        if entry[0] in seen:
+            continue
+        seen.add(entry[0])
+        kept.append(entry)
+    return tuple(kept)
+
+
 @dataclass(frozen=True)
 class ExtraWritePath:
     """非登記表資產、但服務身分確實需要寫的路徑（每條必須附理由）。
@@ -1018,8 +1132,18 @@ class PathLayout:
     #: 字元，見 `build_account_gitconfig`），猜不到就只能猜錯。未指定時
     #: `build_account_gitconfig()` fail-closed，比照 #626 的部署決定型 principal。
     source_repo_slugs: tuple[str, ...] = ()
+    #: executor 憑證在帳號 HOME 下的相對路徑（登記表資產 `*-executor-credential`）。
+    #: **部署決定**：預設對齊本部署的 `PSC_MANAGER_EXECUTOR=codex`（`~/.codex/auth.json`，
+    #: 也就是 #640 實測的那一個）。換 executor 時只改這一個值——`asset_paths()`、
+    #: 骨架目錄（那一層 root-owned 的父目錄）與 unit 的 `ReadWritePaths` 全部跟著動。
+    executor_credential_relpath: str = ".codex/auth.json"
     #: per-job 路徑的 segment；system unit 模板用 `%i`（systemd instance 名）。
     job_segment: str = PER_JOB_SEGMENT
+
+    def __post_init__(self) -> None:
+        # 值會被接成絕對路徑並嵌進 root 執行的命令字串，因此在**建構**當下就驗形狀，
+        # 不等到 operator `sudo` 執行（比照 `_validate_account_name`／`_validate_repo_slug`）。
+        _validate_credential_relpath(self.executor_credential_relpath)
 
     # -- 衍生根 -------------------------------------------------------------
     @property
@@ -1123,6 +1247,38 @@ class PathLayout:
         return f"{self.deploy_root}/bin"
 
     @property
+    def toolchain_root(self) -> str:
+        """四個模型 executor 的部署樹落點（登記表資產 `executor-toolchain`，#640）。
+
+        掛在 `deploy_root` 而不是 `agents_root`：它是**隨版本走的部署產物**（哪一版的
+        模型 CLI），不是隨 instance 治理的資料——與 venv／shim 同一棵樹、同一個 owner
+        （root）、同一條升級路徑。
+        """
+        return f"{self.deploy_root}/toolchain"
+
+    @property
+    def toolchain_bin(self) -> str:
+        """job 的 `PATH` 上那一段——四個 executor 的進入點都在這裡。"""
+        return f"{self.toolchain_root}/bin"
+
+    @property
+    def toolchain_lib(self) -> str:
+        """需要整包搬的 CLI（npm 套件樹）的落點；`bin/` 內的進入點指進來。"""
+        return f"{self.toolchain_root}/lib"
+
+    def job_path_value(self) -> str:
+        """job 應該拿到的 `PATH`（＝ Manager 端 `PSC_BUILDER_PATH` 的值，#640）。
+
+        **toolchain 必須排在最前面**：系統層可能另有一份同名但舊很多的 CLI（實機盤點
+        到的兩份 `codex` 差 100 個以上小版本），排在後面就會被系統那份蓋掉，而症狀是
+        「跑得起來、但跑的不是你以為的版本」——比 `command not found` 難查得多。
+
+        尾段給的是系統層：`node`（codex 的 runtime）、`git`、`python3`（wrapper 內的
+        gate ledger writer）都在那裡。刻意**不含** `sbin`——job 不需要任何管理工具。
+        """
+        return ":".join((self.toolchain_bin,) + JOB_PATH_SYSTEM_TAIL)
+
+    @property
     def job_shim(self) -> str:
         """降權 job 模板 unit 的固定 `ExecStart=`（root-owned，內容由 permgen 產）。"""
         return f"{self.bin_root}/cortex-job-shim"
@@ -1161,6 +1317,19 @@ class PathLayout:
     def codex_hooks_dir_of(self, account: str) -> str:
         """該帳號的 `~/.codex`。root-owned——job 不得替換自己的 hooks。"""
         return f"{self.home_of(account)}/.codex"
+
+    def executor_credential_of(self, account: str) -> str:
+        """該帳號的 executor 憑證檔（#640 裁決 (b)）。**檔案由該帳號擁有**（0600）。
+
+        與 `codex_hooks_dir_of()` 刻意落在**同一層**目錄：那一層是 root-owned 的骨架
+        目錄，因此 job 能就地改寫自己這份憑證的內容（refresh），卻建不了新檔、刪不掉、
+        也換不掉同目錄下的 `hooks.json`——「增／刪／換」需要的是**目錄**的寫入權。
+        """
+        return f"{self.home_of(account)}/{self.executor_credential_relpath}"
+
+    def executor_credential_dir_of(self, account: str) -> str:
+        """憑證檔的父目錄。**必須 root-owned**——裁決 (b) 的性質全部落在這一層。"""
+        return _parent_dir(self.executor_credential_of(account))
 
     def gitconfig_of(self, account: str) -> str:
         """該帳號的 `~/.gitconfig`。root-owned——job 不得替換自己的 git 設定（#623）。
@@ -1232,6 +1401,11 @@ class PathLayout:
             "builder-gitconfig": self.gitconfig_of(self.builder_account),
             "reviewer-planner-gitconfig": self.gitconfig_of(self.reviewer_planner_account),
             "manager-gitconfig": self.gitconfig_of(self.manager_account),
+            # #640：四個模型 executor 的部署樹落點 ＋ 兩個 job 帳號各自的憑證。
+            "executor-toolchain": self.toolchain_root,
+            "builder-executor-credential": self.executor_credential_of(
+                self.builder_account
+            ),
             "repo-worktree": job,
             "dispatch-worktree-pool": wt,
             "jobs-registry": f"{c}/jobs.json",
@@ -1285,8 +1459,17 @@ class PathLayout:
                 account_dirs.append(
                     (self.codex_hooks_dir_of(account), root, g(root), 0o755)
                 )
+                # #640 裁決 (b)：憑證**檔**由 job 帳號擁有，放它的**目錄**維持
+                # root-owned——job 因此改得了自己那份憑證的內容，卻建不了新檔、
+                # 刪不掉、也換不掉同目錄下的 root-owned `hooks.json`。預設 relpath
+                # 下這一層就是上面那個 `~/.codex`，去重後不會重複出現；由
+                # `executor_credential_dir_of()` **導出**而非再寫死一次，換 relpath
+                # 時這條保護才會跟著走。
+                account_dirs.append(
+                    (self.executor_credential_dir_of(account), root, g(root), 0o755)
+                )
             account_dirs.append((self.cache_of(account), account, g(account), 0o700))
-        return (
+        return _dedupe_scaffold((
             # 部署樹（enforcement plane）：全 root，對 svc／builder 唯讀。
             (self.deploy_root, root, g(root), 0o755),
             (f"{self.deploy_root}/etc", root, g(root), 0o755),
@@ -1307,7 +1490,7 @@ class PathLayout:
             # 服務／job 帳號 HOME：root 擁有（job 不得替換自己的 ~/.codex），只開
             # cache 子目錄。清單由 scheme 導出，見上方 `account_dirs`。
             *account_dirs,
-        )
+        ))
 
     # -- 額外可寫路徑（非登記表資產，須附理由）------------------------------
     def manager_extra_write_paths(self, account: str) -> tuple[ExtraWritePath, ...]:
@@ -1399,6 +1582,22 @@ def principal_needs_write(
     return False
 
 
+#: 「只改內容、不增刪換」的葉檔資產（#640 裁決 (b)）。
+#:
+#: 一般規則把檔案資產折算成**父目錄**——因為要「建立／取代」一個檔，必須對父目錄可寫。
+#: 這一族刻意**不**具備建立／取代的能力：目錄維持 root-owned（`scaffold_directories`），
+#: job 只是把自己擁有的那一個檔就地改寫（`O_TRUNC` 覆寫，例如 token refresh）。因此
+#: `ReadWritePaths` 只掛在**檔案本身**，父目錄（同時放著 root-owned 的 `codex-hooks`）
+#: 連 mount 層都不開放可寫——「檔案 job-owned、目錄 root-owned」這條性質因此在
+#: **檔案系統**與 **systemd mount** 兩層同時成立，而不是只靠其中一層。
+#:
+#: 代價（裁決刻意接受）：以「暫存檔 ＋ rename 原子替換」形式 refresh 的 CLI 會失敗，
+#: 因為那需要在同目錄建檔。診斷方式見 Phase 2b runbook 第 4e 步。
+IN_PLACE_CONTENT_WRITE_ASSETS: frozenset[str] = frozenset({
+    "builder-executor-credential",
+})
+
+
 def required_write_targets(
     plan: PermissionPlan,
     layout: PathLayout,
@@ -1409,7 +1608,8 @@ def required_write_targets(
 
     ProtectSystem=strict 下整個檔案系統唯讀；要**建立／取代**一個檔，必須對其
     父目錄可寫，故檔案資產一律折算成父目錄。這就是「ReadWritePaths 由登記表機械
-    導出」的全部規則——沒有第二條。
+    導出」的全部規則——唯一的例外是 :data:`IN_PLACE_CONTENT_WRITE_ASSETS`
+    （只改內容、不增刪換的葉檔），它們掛在檔案本身而**不**折算成父目錄。
 
     `principals` 給定時再套一層 persona 過濾（見 `principal_needs_write`）：同一
     帳號上跑多個 persona 時（三分的 `cortex-manager`＝Manager＋monitor），每個
@@ -1427,7 +1627,10 @@ def required_write_targets(
             if asset is None or not principal_needs_write(asset, principals):
                 continue
         path = paths[entry.asset_id]
-        targets[entry.asset_id] = path if entry.is_directory else _parent_dir(path)
+        if entry.is_directory or entry.asset_id in IN_PLACE_CONTENT_WRITE_ASSETS:
+            targets[entry.asset_id] = path
+        else:
+            targets[entry.asset_id] = _parent_dir(path)
     return targets
 
 
@@ -2140,6 +2343,29 @@ def build_job_unit(
         "# 寫進這一格，Manager 再從那個 bundle **檔案** fetch——Manager 全程不碰 job 的樹。",
         "# 權限是 `wx` 無 `r`：寫得進自己那格、讀不到別人的 bundle。producer 只有 builder，",
         "# 因此這條只會出現在 builder 的模板 unit（RWP 由登記表機械導出，不是寫死的）。",
+        "# --- executor toolchain（登記表 executor-toolchain，#640）---",
+        f"#   {job_layout.toolchain_root}：四個模型 CLI 的落點，root-owned 0755——",
+        "# 本 job 帳號**唯讀＋可執行**。ProtectSystem=strict 讓 /opt 唯讀，但唯讀只擋",
+        "# 寫入，讀取與執行完全不受影響；下方 ReadWritePaths 因此機械地不含它",
+        "# （writer 只有部署身分）。",
+        "# **PATH 刻意不寫在這份 unit 上**：模板 unit 的 ExecStart 是 root-owned shim，",
+        "# 而 shim 以 `execvpe(argv[0], argv, spec['env'])` **整份換掉**環境——job 解析",
+        "# 命令用的 PATH 來自 **spec 的 env**，不是本 unit 的 Environment=。在這裡寫一行",
+        "# Environment=PATH= 只會產生一個看起來承載作用、實際被 shim 丟掉的設定。",
+        "# 真正的來源是 Manager 端 root-owned EnvironmentFile 裡的（job 改不了）：",
+        f"#   PSC_BUILDER_PATH={job_layout.job_path_value()}",
+        "# toolchain 排最前面是必要的：系統層可能另有一份同名但舊很多的 CLI（實機盤點",
+        "# 到兩份 codex 差 100 個以上小版本），排後面會被它蓋掉，而症狀是「跑得起來但",
+        "# 版本不是你以為的那個」。",
+        "# --- executor 憑證（登記表 *-executor-credential，#640 裁決 (b)）---",
+        f"#   {job_layout.executor_credential_of(account)}：**檔案**由本 job 帳號擁有",
+        "# （0600，token 過期可自行 refresh），**放它的目錄維持 root-owned**——因此",
+        "# 本帳號建不了新檔、刪不掉、也換不掉同目錄下的 root-owned hooks.json。",
+        "# 下方 ReadWritePaths 只掛**那一個檔**，不是它的父目錄（一般規則會折算成父",
+        "# 目錄，這一族是明示的例外，見 permgen.IN_PLACE_CONTENT_WRITE_ASSETS）。",
+        "# 憑證尚未落位時本 unit 會**起不來**（systemd 對不存在的 ReadWritePaths 目標",
+        "# 報錯）——那是刻意的 fail-closed：沒有登入態的 job 本來就做不了事，在 exec",
+        "# 前失敗比走到呼叫模型那一步才 rc=127 好查得多。",
         "# shim 讀 spec 的唯一合法來源：這一行在 root-owned 的 unit 檔裡，",
         "# 因此持 spawn 授權的帳號也改不掉 spec 要從哪個目錄讀。shim 對未設此",
         "# 變數的情況 fail-closed（不猜、不落回 $HOME 推導的預設）。",
@@ -2433,6 +2659,100 @@ def build_account_gitconfig(
         safe_directories=safe_dirs,
         content="\n".join(body) + "\n",
     )
+
+
+# ---------------------------------------------------------------------------
+# executor toolchain 的落位計畫（#640）
+# ---------------------------------------------------------------------------
+
+def build_toolchain_plan(
+    scheme: UidScheme = DEFAULT_SCHEME,
+    layout: PathLayout = DEFAULT_LAYOUT,
+) -> list[str]:
+    """產生 executor toolchain 的落位步驟（**只回傳字串，絕不執行**）。
+
+    分工：**權限**由登記表經 `plan_to_commands()` 產出（`executor-toolchain` 那一節），
+    本函式產的是**內容落位**——哪一支 CLI 用哪種方式搬進 `<deploy_root>/toolchain`，
+    比照 `build_job_shim()`／`build_account_gitconfig()` 的定位。
+
+    來源路徑刻意留成 shell 變數：那是 operator 機器上的位置（nvm 樹／`~/.local/bin`），
+    產生器猜不到也不該猜。但**來源的判準**是固定的，寫進輸出裡：一律取 operator
+    **實際在用的那一份**（`command -v` 解出來的），不是另外裝一份系統的。
+    """
+    tail = ", ".join(JOB_PATH_SYSTEM_TAIL)
+    lines = [
+        f"# {layout.toolchain_root} —— executor toolchain（登記表資產 executor-toolchain）",
+        f"# 由 permgen 機械產生（scheme={scheme.scheme_id}）——勿手改；重跑：",
+        f"#   python3 -m paulsha_cortex.trust_root toolchain {scheme.scheme_id}",
+        "#",
+        "# ===== 裁決 (a)（#640）=====",
+        "# node 走**系統層**（通用 runtime，換版本幾乎不影響產出）；四個模型 CLI 落進",
+        "# 部署樹，因為「job 跑的是哪個版本的模型 CLI」**會**影響產出——那必須是一個",
+        "# 可稽核的部署決定，而不是跟著 operator 自己的環境漂移。",
+        "#",
+        "# ===== 來源一律取 operator 實際在用的那一份 =====",
+        "# **不要** `npm install -g` 另裝一份系統的。實機盤點：同一台機器上系統層的",
+        "# codex 是 0.42.0、operator 實際在用的是 0.147.0（差 100 個以上小版本）——",
+        "# 照「系統層有什麼就用什麼」，job 會跑一份 operator 從未判讀過的版本，而",
+        "# 症狀是「跑得起來但結果對不上」，不是 `command not found`。",
+        "#",
+        "# ===== 系統層 runtime（apt，不進部署樹）=====",
+    ]
+    for runtime in TOOLCHAIN_SYSTEM_RUNTIMES:
+        lines.append(
+            f"#   {runtime}：版本本身仍是**部署決定**——某個 CLI 哪天提高下限時要一併升，"
+            "否則它會變成下一個無聲漂移點。"
+        )
+    lines += [
+        f"#   目前只有 `codex` 需要它；`claude`／`agy` 自帶原生執行檔、`copilot` 是 "
+        "shell script。",
+        "",
+        "# --- 目錄骨架（權限與登記表那一節逐位元相同）---",
+        f"install -d -o {scheme.deploy_account} -g {scheme.group_of(scheme.deploy_account)}"
+        f" -m 0755 {layout.toolchain_root}",
+        f"install -d -o {scheme.deploy_account} -g {scheme.group_of(scheme.deploy_account)}"
+        f" -m 0755 {layout.toolchain_bin}",
+        f"install -d -o {scheme.deploy_account} -g {scheme.group_of(scheme.deploy_account)}"
+        f" -m 0755 {layout.toolchain_lib}",
+    ]
+    for tool in EXECUTOR_TOOLS:
+        lines += [
+            "",
+            f"# --- {tool.name}（{tool.shape.value}"
+            + ("；**需要系統層 node**" if tool.needs_node else "")
+            + f"）---",
+            f"#   {tool.note}",
+            f'#   SRC="$(readlink -f "$(command -v {tool.name})")"   '
+            "# operator 實際在用的那一份",
+        ]
+        if tool.copy_tree:
+            lines += [
+                "#   整包搬（單搬進入點會缺 node_modules）：先找出套件根，再整棵複製——",
+                f'#     PKG="$(cd "$(dirname "$SRC")/.." && pwd)"',
+                f'#     cp -a "$PKG" {layout.toolchain_lib}/{tool.name}',
+                f"#     ln -sfn {layout.toolchain_lib}/{tool.name}/<套件內的進入點>"
+                f" {layout.toolchain_bin}/{tool.name}",
+                "#   落定後確認進入點的 shebang 解得開：`head -n 1` 應為 "
+                "`#!/usr/bin/env node`，且 `command -v node` 落在系統層。",
+            ]
+        else:
+            lines += [
+                f'#     cp -a "$SRC" {layout.toolchain_bin}/{tool.name}',
+            ]
+    lines += [
+        "",
+        "# --- 統一收權（root 擁有、全部 job／服務帳號唯讀＋可執行）---",
+        f"chown -R {scheme.deploy_account}:{scheme.group_of(scheme.deploy_account)}"
+        f" {layout.toolchain_root}",
+        f"chmod -R u=rwX,go=rX {layout.toolchain_root}",
+        "",
+        "# ===== job 的 PATH =====",
+        "# toolchain **必須排在最前面**：系統層可能另有一份同名但舊很多的 CLI，排後面",
+        "# 就會被它蓋掉。尾段給的是系統層（" + tail + "）——node／git／python3 在那裡；",
+        "# 刻意不含任何 sbin。值寫進 Manager 端 root-owned 的 EnvironmentFile：",
+        f"#   PSC_BUILDER_PATH={layout.job_path_value()}",
+    ]
+    return lines
 
 
 # ---------------------------------------------------------------------------

--- a/paulsha_cortex/trust_root/registry.py
+++ b/paulsha_cortex/trust_root/registry.py
@@ -332,6 +332,84 @@ ASSET_REGISTRY: tuple[TrustRootAsset, ...] = (
             "讓 Manager 能改自己的 git 設定等於把 Tier-0 的執行面交還給它。"
         ),
     ),
+    # ---- executor 執行面：toolchain ＋ per-account 憑證（#640）--------------
+    TrustRootAsset(
+        "executor-toolchain", _T0, _MO, None,
+        (Principal.INSTALLER,),
+        (
+            Principal.MANAGER, Principal.MONITOR,
+            Principal.BUILDER, Principal.REVIEWER, Principal.PLANNER,
+        ),
+        IngressKind.DEPLOYMENT_WRITE,
+        derived_in=("trust_root/permgen.py:PathLayout.toolchain_root",),
+        note=(
+            "`<deploy_root>/toolchain`——四個模型 executor（`codex`／`claude`／"
+            "`copilot`／`agy`）的**部署樹落點**。root-owned 0755：全部 job／服務帳號"
+            "**唯讀＋可執行**，一個 `w` 都沒有（機械結果：writer 只有部署身分 → "
+            "`owner_class=DEPLOYMENT`，與 `runtime-agents-tree`／venv 同一類）。\n"
+            "**為何必須存在（#640 實測）**：Phase 2b 的 job unit 帶 `ProtectHome=yes`，"
+            "而四個 executor 原本全在 operator 的 HOME 底下（nvm 樹與 `~/.local/bin`），"
+            "`/home` 整個不可見——\n"
+            "    $ sudo -u cortex-builder env HOME=<job HOME> codex exec --help\n"
+            "    /usr/bin/env: ‘node’: No such file or directory      rc=127\n"
+            "沒有任何一個 executor 可用，dispatch 會一路走到**呼叫模型**那一步才失敗。\n"
+            "**0817 裁決 (a)**：`node` 走**系統層**（它是通用 runtime，換版本幾乎不影響"
+            "產出），四個模型 CLI 則落進本資產。理由是「job 跑的是哪個版本的模型 CLI」"
+            "**會**影響產出，那必須是一個**可稽核的部署決定**，而不是跟著 operator 自己"
+            "的環境漂移。這不是假設——實機盤點在同一台機器上就有兩份 `codex`（系統層 "
+            "0.42.0 vs operator 實際在用的 0.147.0，差 100 個以上小版本）；照「系統層有"
+            "什麼就用什麼」的做法，job 會跑一份 operator 從未判讀過的版本。因此安裝步驟"
+            "是**從 operator 實際使用的那一份複製進來**，不是另外 `npm install -g` 裝一份。\n"
+            "**node 的版本風險只涵蓋 codex 一個**：`claude` 與 `agy` 自帶原生執行檔、"
+            "`copilot` 是 shell script，只有 `codex` 是 `#!/usr/bin/env node` 的 node "
+            "script。系統層 node 的版本本身仍是**部署決定**（某個 CLI 哪天提高下限時要"
+            "一併升），形態表見 `permgen.EXECUTOR_TOOLS`。\n"
+            "**ProtectSystem=strict 下 `/opt` 唯讀**：讀取與執行完全不受影響，被擋的只有"
+            "寫入——因此本資產機械地不會出現在任何 unit 的 `ReadWritePaths` 上。"
+        ),
+    ),
+    TrustRootAsset(
+        "builder-executor-credential", _T0, _JV, None,
+        (Principal.BUILDER,), (Principal.BUILDER,),
+        IngressKind.DIRECT_FILE_WRITE,
+        derived_in=("trust_root/permgen.py:PathLayout.executor_credential_of",),
+        note=(
+            "builder 帳號 HOME 下那份 executor 憑證（預設 `~/.codex/auth.json`，"
+            "＝本部署 `PSC_MANAGER_EXECUTOR` 的那一個；落點由 "
+            "`PathLayout.executor_credential_relpath` 這個**部署決定**導出）。\n"
+            "**0817 裁決 (b)：檔案由 job 帳號擁有（0600），放它的目錄維持 root-owned**"
+            "（`<HOME>/.codex` 已是既有的 root-owned 骨架目錄，`codex-hooks` 就住在裡面）。"
+            "淨效果——job **能就地改寫自己那份憑證的內容**（token 過期可自行 refresh），"
+            "但在該目錄**建不了新檔、刪不掉、也換不掉同目錄下的其他 root-owned 檔**"
+            "（例如 `codex-hooks`）：建立／unlink／rename 需要的是**目錄**的寫入權，"
+            "而目錄是 `root 0755`，job 落在 `other` 位（`r-x`）。\n"
+            "**已知限制**：因此「以暫存檔 ＋ rename 原子替換」形式做 refresh 的 CLI 會"
+            "失敗（它需要在同目錄建檔）；只有就地 `O_TRUNC` 覆寫的 refresh 走得通。"
+            "這是裁決 (b) 刻意接受的代價，不是漏掉的情況。\n"
+            "**為何 writer 不含部署身分**：root 當然放得進去（安裝時就是 root 放的），"
+            "但 `writers` 描述的是**執行期**的合法 mutator——寫成 INSTALLER 會讓機械分類"
+            "落到 `owner_class=DEPLOYMENT`（owner＝root），憑證就 refresh 不了，與裁決"
+            "相反。\n"
+            "**這買到的是什麼、不是什麼**：把 operator 的憑證複製給 job 帳號，代表 job "
+            "用的是**同一個 provider 帳號**。三分買到的是**檔案系統層**的隔離（job 偷不到"
+            "Manager 的 token、改不了 Manager 的 state），**不是** provider 層的獨立——與 "
+            "`model-identity-overlay` 的 `independence_domain` 想表達的不是同一件事。"
+            "真正的 provider 層獨立需要每個 job 帳號各自的 provider 帳號，屬未來選項"
+            "（spec §R1 有完整說明）。\n"
+            "**為何只登記 builder 這一份**（與 `codex-hooks` 逐條同構，不是遺漏）："
+            "登記表資產是 1:1 綁到一條絕對路徑的，而路徑要由帳號名推導；`cortex-builder` "
+            "是**兩個 scheme 都相同**的唯一 job 帳號，也是目前唯一真的以模板 unit 降權"
+            "起 job 的 persona。reviewer／planner 在二分下與 Manager 併帳"
+            "（`cortex-svc`），登記第二份會讓 Manager unit 的 `ReadWritePaths` 出現一條"
+            "**二分部署裡根本不存在**的 HOME 路徑——systemd 對不存在的 `ReadWritePaths` "
+            "目標直接讓 unit 起不來，等於用一個 M2 才需要的資產弄壞一個現存的部署形態。\n"
+            "**機制本身已經是 per-account 的**：`PathLayout.executor_credential_of()` 吃"
+            "任意帳號，`scaffold_directories()` 也已為**每一個** job 帳號建出 root-owned "
+            "的憑證父目錄（因此 `cortex-reviewer-planner` 那一份憑證照同一條規則落位、"
+            "同樣受保護）。M2（#615）把 reviewer／planner 移上模板 unit 時，登記表補第二"
+            "列即可，產生器一行都不必改。"
+        ),
+    ),
     # ---- job-visible worktree 族 -------------------------------------------
     TrustRootAsset(
         "repo-worktree", _T1, _JV, "paulsha_cortex.config.paths:repo_root",
@@ -618,7 +696,10 @@ MUTATION_INGRESS: tuple[MutationIngress, ...] = (
                     "#623 起另含**三份**帳號 HOME 下的 root-owned `.gitconfig`"
                     "（builder／reviewer-planner／manager）——同一條性質：writer 只有部署"
                     "身分，服務帳號對這些檔一律唯讀。來源樹本身**不在**此類（0817 裁決把"
-                    "它的 writer 改為 Manager，見 `repo-source-tree`）。"),
+                    "它的 writer 改為 Manager，見 `repo-source-tree`）；#640 起另含 "
+                    "`executor-toolchain`（四個模型 CLI 的部署樹落點，root-owned、"
+                    "全部 job／服務帳號唯讀＋可執行）。executor **憑證**同樣不在此類——"
+                    "檔案由 job 帳號擁有才 refresh 得了，見 `builder-executor-credential`。"),
     MutationIngress("interprocess", IngressKind.INTERPROCESS, False, True,
                     "inherited FD／ptrace／/proc/<pid>/mem／signal。"),
 )

--- a/tests/test_trust_root_executor_toolchain_640.py
+++ b/tests/test_trust_root_executor_toolchain_640.py
@@ -1,0 +1,542 @@
+"""#640：真實 dispatch 的最後一哩——executor toolchain ＋ per-account 憑證。
+
+背景（#640 實測）：Phase 2b 的 job unit 帶 `ProtectHome=yes`，而四個 executor 原本
+全在 operator 的 HOME 底下（nvm 樹與 `~/.local/bin`）——
+
+    $ sudo -u cortex-builder env HOME=<job HOME> codex exec --help
+    /usr/bin/env: ‘node’: No such file or directory      rc=127
+
+登記表對 toolchain 與 job 帳號的憑證**都沒有預留資產**，因此 permgen 也不會產生它們
+的權限。0817 裁決：
+
+- **(a) toolchain**：`node` 走系統層（通用 runtime）；四個模型 CLI 落進
+  `<deploy_root>/toolchain`（root-owned，job／服務帳號唯讀＋可執行）。理由是「job 跑
+  的是哪個版本的模型 CLI」會影響產出，那必須是**可稽核的部署決定**——實機盤點在同一
+  台機器上就有兩份 `codex`（系統層 0.42.0 vs operator 的 0.147.0）。
+- **(b) 憑證**：憑證**檔**由 job 帳號擁有（能自行 refresh 過期 token），**放它的目錄
+  維持 root-owned**。淨效果：job 改得了自己那份憑證的內容，卻**建不了新檔、刪不掉、
+  也換不掉**同目錄下的其他 root-owned 檔（例如 `codex-hooks`）。
+
+本檔釘住六件事：
+
+1. 兩個新資產都在登記表裡，且雙向等式仍綠；
+2. toolchain 對 job 帳號**唯讀**（計畫一個 `w` 都不給）**且可執行**；
+3. 憑證檔 owner 是 job 帳號、**父目錄** owner 是 root——並以**真的 OS 語意**驗
+   「能改內容、不能增刪換」（見 `TestInPlaceCredentialOsSemantics` 的說明，
+   單 UID 環境測得到，因為守的那條規則就是「目錄少了 `w` 位」）；
+4. traverse 鏈完整（沿用 #624 的 `unreachable_hops()`），且有反向對照；
+5. monitor 的 `ReadWritePaths` 仍**嚴格窄於** Manager（#622 不變式）；
+6. `permgen` 仍為純函式（靜態不變式）。
+"""
+from __future__ import annotations
+
+import inspect
+import os
+import stat
+from pathlib import Path
+
+import pytest
+
+from paulsha_cortex.trust_root import permgen, registry
+from paulsha_cortex.trust_root.__main__ import main
+from paulsha_cortex.trust_root.permgen import (
+    DEFAULT_LAYOUT,
+    EXECUTOR_TOOLS,
+    IN_PLACE_CONTENT_WRITE_ASSETS,
+    JOB_PATH_SYSTEM_TAIL,
+    TOOLCHAIN_SYSTEM_RUNTIMES,
+    ExecutorShape,
+    OwnerClass,
+    PathLayout,
+    account_can_reach,
+    build_job_unit,
+    build_manager_unit,
+    build_monitor_unit,
+    build_toolchain_plan,
+    generate_plan,
+    unreachable_hops,
+)
+from paulsha_cortex.trust_root.permgen import THREE_WAY_SCHEME as _THREE_WAY_BASE
+from paulsha_cortex.trust_root.permgen import TWO_WAY_SCHEME as _TWO_WAY_BASE
+from paulsha_cortex.trust_root.registry import (
+    AssetTier,
+    IngressKind,
+    Principal,
+    TrustTree,
+)
+
+#: #626：`operator`／`external` 是部署決定，模組層方案刻意留 `None`。
+DEPLOYMENT_ACCOUNTS = {
+    Principal.OPERATOR: "cortex-ops",
+    Principal.EXTERNAL: "cortex-outbox-reader",
+}
+TWO_WAY_SCHEME = _TWO_WAY_BASE.with_principal_accounts(DEPLOYMENT_ACCOUNTS)
+THREE_WAY_SCHEME = _THREE_WAY_BASE.with_principal_accounts(DEPLOYMENT_ACCOUNTS)
+ALL_SCHEMES = [TWO_WAY_SCHEME, THREE_WAY_SCHEME]
+
+TOOLCHAIN = "executor-toolchain"
+CREDENTIAL = "builder-executor-credential"
+NEW_ASSET_IDS = (TOOLCHAIN, CREDENTIAL)
+
+
+def _within(child: str, parent: str) -> bool:
+    return child == parent or child.startswith(parent.rstrip("/") + "/")
+
+
+# ---------------------------------------------------------------------------
+# 1. 登記表：兩個新資產存在，且雙向等式仍綠
+# ---------------------------------------------------------------------------
+
+def test_registry_equation_stays_green() -> None:
+    """兩個新資產都是 `path_resolver=None`（路徑在 permgen 的 layout），不影響等式；
+    但等式必須被實際跑一次——這是「新增 durable path 未登記」那條 gate 的守門人。"""
+    result = registry.check_registry_equation()
+    assert result.ok, result.failure_summary()
+
+
+@pytest.mark.parametrize("asset_id", NEW_ASSET_IDS)
+def test_new_assets_are_registered_and_fully_classified(asset_id: str) -> None:
+    asset = registry.asset_by_id(asset_id)
+    assert asset.tier is AssetTier.TIER_0, "兩者被竄改都直接等於對 job 帳號的任意程式碼執行"
+    assert asset.writers and asset.readers
+    assert asset.note.strip(), "裁決理由必須跟著資產走"
+    assert asset.derived_in, "路徑推導點必須指得出來"
+
+
+def test_toolchain_is_deployment_owned_and_job_accounts_are_not_writers() -> None:
+    asset = registry.asset_by_id(TOOLCHAIN)
+    assert asset.tree is TrustTree.MANAGER_OWNED
+    assert asset.ingress_kind is IngressKind.DEPLOYMENT_WRITE
+    assert asset.writers == (Principal.INSTALLER,), "只有部署身分可寫"
+    # 四個模型 executor 的讀者：兩個 job persona ＋ Manager／monitor。
+    for reader in (
+        Principal.BUILDER, Principal.REVIEWER, Principal.PLANNER,
+        Principal.MANAGER, Principal.MONITOR,
+    ):
+        assert reader in asset.readers, reader
+
+
+def test_credential_writer_is_the_job_persona_not_the_installer() -> None:
+    """裁決 (b) 的機械落點：writer 是 job persona，才會分到 `owner_class=JOB`。
+
+    寫成 `INSTALLER` 會讓 `classify_owner()` 落到 `DEPLOYMENT`（owner＝root），
+    憑證就 refresh 不了——與裁決正好相反。這條把那個反轉釘死。
+    """
+    asset = registry.asset_by_id(CREDENTIAL)
+    assert asset.writers == (Principal.BUILDER,)
+    assert Principal.INSTALLER not in asset.writers
+    assert asset.tree is TrustTree.JOB_VISIBLE
+    assert permgen.classify_owner(asset) is OwnerClass.JOB
+
+
+# ---------------------------------------------------------------------------
+# 2. toolchain：對 job 帳號唯讀 ＋ 可執行
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
+def test_toolchain_is_root_owned_and_no_account_can_write_it(scheme) -> None:
+    plan = generate_plan(scheme)
+    entry = plan.by_id(TOOLCHAIN)
+    assert entry.owner_class is OwnerClass.DEPLOYMENT
+    assert entry.owner == scheme.deploy_account == "root"
+    assert entry.is_directory, "toolchain 是一棵樹，不是單一檔"
+    # 可寫面只有 root——ACL 面也一條授寫都沒有。
+    assert plan.all_writable_accounts(entry) == frozenset({scheme.deploy_account})
+    assert not any(acl.writable for acl in entry.acls)
+    for account in sorted(scheme.declared_accounts() - {scheme.deploy_account}):
+        assert account not in plan.all_writable_accounts(entry), account
+
+
+@pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
+def test_toolchain_mode_is_readable_and_executable_but_never_writable(scheme) -> None:
+    """`0755`：group／other 都有 `r` 與 `x`、都沒有 `w`。
+
+    `x` 這一半和 `r` 一樣重要——少了它，job 走得到目錄卻 exec 不了裡面的 CLI，
+    症狀又是 rc=126／127，與 #640 原本那個 `node: No such file` 幾乎難以分辨。
+    """
+    entry = generate_plan(scheme).by_id(TOOLCHAIN)
+    assert entry.mode == 0o755, entry.mode_str
+    for shift in (3, 0):  # group, other
+        bits = (entry.mode >> shift) & 0o7
+        assert bits & 0o4, ("可讀", entry.mode_str, shift)
+        assert bits & 0o1, ("可執行", entry.mode_str, shift)
+        assert not bits & 0o2, ("不可寫", entry.mode_str, shift)
+
+
+@pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
+def test_toolchain_never_appears_in_any_unit_read_write_paths(scheme) -> None:
+    """ProtectSystem=strict 下 /opt 唯讀：讀與執行不受影響，因此**不需要**任何 RWP。
+
+    這不是靠寫死排除的——writer 只有部署身分，`required_write_targets()` 就機械地
+    不會把它算進任何帳號的可寫面。
+    """
+    toolchain = DEFAULT_LAYOUT.asset_paths()[TOOLCHAIN]
+    units = [
+        build_manager_unit(scheme, DEFAULT_LAYOUT),
+        build_monitor_unit(scheme, DEFAULT_LAYOUT),
+        build_job_unit(scheme, DEFAULT_LAYOUT),
+    ]
+    for unit in units:
+        assert not any(_within(toolchain, rwp) for rwp in unit.read_write_paths), (
+            unit.unit_name, unit.read_write_paths,
+        )
+
+
+def test_toolchain_lives_in_the_deployment_tree_not_the_state_tree() -> None:
+    """它是隨版本走的部署產物（跟 venv／shim 同一棵樹），不是隨 instance 走的資料。"""
+    assert DEFAULT_LAYOUT.toolchain_root == "/opt/cortex/toolchain"
+    assert _within(DEFAULT_LAYOUT.toolchain_root, DEFAULT_LAYOUT.deploy_root)
+    assert not _within(DEFAULT_LAYOUT.toolchain_root, DEFAULT_LAYOUT.agents_root)
+    assert DEFAULT_LAYOUT.asset_paths()[TOOLCHAIN] == DEFAULT_LAYOUT.toolchain_root
+
+
+# ---------------------------------------------------------------------------
+# 3. 憑證：檔 job-owned、目錄 root-owned
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
+def test_credential_file_is_owned_by_the_job_account(scheme) -> None:
+    entry = generate_plan(scheme).by_id(CREDENTIAL)
+    builder = scheme.resolve(Principal.BUILDER)
+    assert entry.owner == builder, scheme.scheme_id
+    assert entry.group == scheme.group_of(builder)
+    assert not entry.is_directory, "憑證是單一檔——目錄型會讓整層被 chown 給 job"
+    assert entry.mode == 0o600, entry.mode_str
+    # 跨帳號一條 ACL 都不給：Manager 沒有理由讀 job 的登入態。
+    assert entry.acls == ()
+    assert plan_writers(scheme, CREDENTIAL) == frozenset({builder})
+
+
+def plan_writers(scheme, asset_id: str) -> frozenset[str]:
+    plan = generate_plan(scheme)
+    return plan.all_writable_accounts(plan.by_id(asset_id))
+
+
+@pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
+def test_credential_parent_directory_stays_root_owned(scheme) -> None:
+    """裁決 (b) 的全部性質都落在這一層：目錄 root-owned ⇒ job 增／刪／換不了。"""
+    scaffold = {
+        path: (owner, mode)
+        for path, owner, _group, mode in DEFAULT_LAYOUT.scaffold_directories(scheme)
+    }
+    builder = scheme.resolve(Principal.BUILDER)
+    cred_dir = DEFAULT_LAYOUT.executor_credential_dir_of(DEFAULT_LAYOUT.builder_account)
+    assert cred_dir in scaffold, (scheme.scheme_id, sorted(scaffold))
+    owner, mode = scaffold[cred_dir]
+    assert owner == scheme.deploy_account == "root"
+    assert mode == 0o755
+    # 「目錄沒有 w 位給 job」就是那條不變式本身。
+    assert not mode & 0o020 and not mode & 0o002, format(mode, "04o")
+    # 憑證檔確實落在那一層底下，而不是別處。
+    cred = DEFAULT_LAYOUT.asset_paths()[CREDENTIAL]
+    assert cred == f"{cred_dir}/auth.json"
+    assert cred.startswith(DEFAULT_LAYOUT.home_of(DEFAULT_LAYOUT.builder_account) + "/")
+    assert builder  # scheme 一定解析得出 builder 帳號
+
+
+def test_credential_shares_its_directory_with_a_root_owned_tier0_file() -> None:
+    """同目錄下就放著 root-owned 的 `codex-hooks`——那正是「換不掉」要守的東西。"""
+    paths = DEFAULT_LAYOUT.asset_paths()
+    cred_dir = DEFAULT_LAYOUT.executor_credential_dir_of(DEFAULT_LAYOUT.builder_account)
+    assert _within(paths["codex-hooks"], cred_dir)
+    assert _within(paths[CREDENTIAL], cred_dir)
+    hooks = generate_plan(THREE_WAY_SCHEME).by_id("codex-hooks")
+    assert hooks.owner == "root", "同目錄的 hooks 仍是 root 的"
+
+
+@pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
+def test_credential_read_write_path_is_the_file_itself_not_its_parent(scheme) -> None:
+    """一般規則把檔案折算成父目錄；這一族是**明示**的例外。
+
+    折算成父目錄會讓 job unit 的 mount 層開放整個 `~/.codex`（裡面還有 root-owned 的
+    `hooks.json`）；掛在檔案本身則讓「目錄 root-owned」在**檔案系統**與 **systemd
+    mount** 兩層同時成立。#623 那條「兩個 root-owned 設定檔不可寫」的既有不變式因此
+    仍然逐字成立。
+    """
+    assert CREDENTIAL in IN_PLACE_CONTENT_WRITE_ASSETS
+    unit = build_job_unit(scheme, DEFAULT_LAYOUT)
+    cred = DEFAULT_LAYOUT.asset_paths()[CREDENTIAL]
+    cred_dir = DEFAULT_LAYOUT.executor_credential_dir_of(DEFAULT_LAYOUT.builder_account)
+    assert cred in unit.read_write_paths, unit.read_write_paths
+    assert cred_dir not in unit.read_write_paths, unit.read_write_paths
+    # 父目錄不得被任何一條 RWP 涵蓋（含更上層的 HOME）。
+    assert not any(_within(cred_dir, rwp) for rwp in unit.read_write_paths), (
+        unit.read_write_paths
+    )
+
+
+def test_credential_is_absent_from_the_manager_and_monitor_units() -> None:
+    """job 的登入態不屬於 Manager 的可寫面（兩個 scheme 皆然）。"""
+    cred = DEFAULT_LAYOUT.asset_paths()[CREDENTIAL]
+    for scheme in ALL_SCHEMES:
+        for unit in (
+            build_manager_unit(scheme, DEFAULT_LAYOUT),
+            build_monitor_unit(scheme, DEFAULT_LAYOUT),
+        ):
+            assert not any(_within(cred, rwp) for rwp in unit.read_write_paths), (
+                scheme.scheme_id, unit.unit_name, unit.read_write_paths,
+            )
+
+
+def test_credential_relpath_is_a_validated_deployment_decision() -> None:
+    """換 executor 只改一個值，且值的形狀在**建構當下**就驗（不等到 root 執行）。"""
+    alt = PathLayout(executor_credential_relpath=".claude/credentials.json")
+    account = alt.builder_account
+    assert alt.executor_credential_of(account).endswith("/.claude/credentials.json")
+    assert alt.executor_credential_dir_of(account).endswith("/.claude")
+    # 換了 relpath，骨架的那條 root-owned 保護必須**跟著走**（不是寫死 `.codex`）。
+    scaffold = {p: (o, m) for p, o, _g, m in alt.scaffold_directories(THREE_WAY_SCHEME)}
+    assert scaffold[alt.executor_credential_dir_of("cortex-builder")] == ("root", 0o755)
+    for bad in ("auth.json", "/etc/passwd", "../../etc/passwd", "..", ".codex/a b"):
+        with pytest.raises(ValueError):
+            PathLayout(executor_credential_relpath=bad)
+
+
+def test_scaffold_gives_every_model_job_account_a_root_owned_credential_dir() -> None:
+    """機制是 per-account 的：登記表只掛 builder 一份，保護面卻涵蓋全部 job 帳號。"""
+    scaffold = {
+        p: (o, m)
+        for p, o, _g, m in DEFAULT_LAYOUT.scaffold_directories(THREE_WAY_SCHEME)
+    }
+    for account in ("cortex-builder", "cortex-reviewer-planner"):
+        cred_dir = DEFAULT_LAYOUT.executor_credential_dir_of(account)
+        assert scaffold[cred_dir] == ("root", 0o755), account
+
+
+def test_scaffold_has_no_duplicate_paths() -> None:
+    """預設 relpath 下憑證父目錄與 `~/.codex` 是同一層——去重後只出現一次。"""
+    for scheme in ALL_SCHEMES:
+        dirs = DEFAULT_LAYOUT.scaffold_directories(scheme)
+        paths = [p for p, _o, _g, _m in dirs]
+        assert len(paths) == len(set(paths)), sorted(paths)
+
+
+# ---------------------------------------------------------------------------
+# 3b. 「能改內容、不能增刪換」——真的 OS 語意（#638 的教訓）
+# ---------------------------------------------------------------------------
+
+@pytest.mark.skipif(
+    os.geteuid() == 0,
+    reason=(
+        "root 不受 DAC 限制：以 root 跑時目錄少了 w 位照樣建得了檔，"
+        "本組驗的語意在 root 下不存在——刻意 skip 而非空過"
+    ),
+)
+class TestInPlaceCredentialOsSemantics:
+    """把裁決 (b) 的三條性質對**真的檔案系統**驗一次。
+
+    #638 的教訓是「涉及 OS 層語意的不變式，測試要能真的驗到那個語意」。這裡不需要
+    第二個 UID：裁決 (b) 守的規則是「**目錄沒有 `w` 位給這個行程**」——真實部署裡
+    job 帳號落在 root-owned `0755` 的 `other` 位（`r-x`），本測試以 owner 位為
+    `r-x`（`0555`）重現**同一條 kernel 檢查**（`inode_permission(dir, MAY_WRITE)`）。
+    兩者走的是同一段判定，只是命中的是不同那一組權限位。
+
+    真正需要第二個 UID 的只有「檔案 owner 不是本行程」那一半，而那一半由上面的
+    產生器測試（`entry.owner == builder`）釘住，不重複用一個要 root 才跑得起來的
+    測試去驗同一件事。
+    """
+
+    @pytest.fixture()
+    def tree(self, tmp_path: Path):
+        """`~/.codex` 的最小重現：目錄不可寫、憑證檔可寫、旁邊一個不可換的鄰居。"""
+        cred_dir = tmp_path / ".codex"
+        cred_dir.mkdir()
+        cred = cred_dir / "auth.json"
+        cred.write_text('{"token": "old"}\n', encoding="utf-8")
+        cred.chmod(0o600)
+        # 同目錄下的 root-owned 鄰居（真實部署裡是 `hooks.json`）。
+        neighbour = cred_dir / "hooks.json"
+        neighbour.write_text("{}\n", encoding="utf-8")
+        # 目錄：對本行程 `r-x`——重現 job 帳號在 root-owned 0755 目錄上的有效權限。
+        cred_dir.chmod(0o555)
+        try:
+            yield cred_dir, cred, neighbour
+        finally:
+            # 還原後 pytest 才收得掉這棵樹（不可寫的目錄 rmtree 會失敗）。
+            cred_dir.chmod(0o755)
+
+    def test_content_can_be_rewritten_in_place(self, tree) -> None:
+        """refresh 走得通：憑證檔是自己的，`O_TRUNC` 覆寫不需要目錄的寫入權。"""
+        _cred_dir, cred, _neighbour = tree
+        cred.write_text('{"token": "refreshed"}\n', encoding="utf-8")
+        assert "refreshed" in cred.read_text(encoding="utf-8")
+        assert stat.S_IMODE(cred.stat().st_mode) == 0o600
+
+    def test_new_files_cannot_be_created_in_the_directory(self, tree) -> None:
+        """「建不了新檔」——這同時封掉「暫存檔 ＋ rename」那條原子替換路徑。"""
+        cred_dir, _cred, _neighbour = tree
+        with pytest.raises(PermissionError):
+            (cred_dir / "auth.json.tmp").write_text("x", encoding="utf-8")
+
+    def test_the_credential_cannot_be_unlinked(self, tree) -> None:
+        """「刪不掉」——unlink 需要的是**目錄**的寫入權，不是檔案的。"""
+        _cred_dir, cred, _neighbour = tree
+        with pytest.raises(PermissionError):
+            cred.unlink()
+        assert cred.exists()
+
+    def test_the_root_owned_neighbour_cannot_be_replaced(self, tree) -> None:
+        """「換不掉同目錄下的其他 root-owned 檔」——rename 同樣要目錄的寫入權。"""
+        _cred_dir, cred, neighbour = tree
+        with pytest.raises(PermissionError):
+            os.replace(cred, neighbour)
+        assert neighbour.read_text(encoding="utf-8") == "{}\n"
+
+
+# ---------------------------------------------------------------------------
+# 4. traverse 鏈（#624 的 `unreachable_hops()`）
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
+@pytest.mark.parametrize("asset_id", NEW_ASSET_IDS)
+def test_the_job_account_can_actually_reach_the_new_assets(scheme, asset_id) -> None:
+    """葉節點權限對 **≠** 路徑走得通：整條鏈必須每一層都可 search。"""
+    plan = generate_plan(scheme)
+    builder = scheme.resolve(Principal.BUILDER)
+    blocked = unreachable_hops(
+        plan, DEFAULT_LAYOUT, scheme, account=builder, asset_id=asset_id
+    )
+    assert blocked == (), (scheme.scheme_id, asset_id, blocked)
+    assert account_can_reach(
+        plan, DEFAULT_LAYOUT, scheme, account=builder, asset_id=asset_id
+    )
+
+
+def test_reverse_control_a_closed_deployment_tree_breaks_the_toolchain_path() -> None:
+    """反向對照：把部署樹收成 owner-only，toolchain 立刻走不到（不是永遠回 `()`）。"""
+    scheme = THREE_WAY_SCHEME
+    plan = generate_plan(scheme)
+    builder = scheme.resolve(Principal.BUILDER)
+    deploy_root = DEFAULT_LAYOUT.deploy_root
+
+    class _ClosedDeployTree(PathLayout):
+        def scaffold_directories(self, scheme_):  # type: ignore[override]
+            return tuple(
+                (path, owner, group, 0o700 if path == deploy_root else mode)
+                for path, owner, group, mode in PathLayout.scaffold_directories(
+                    self, scheme_
+                )
+            )
+
+    closed = _ClosedDeployTree()
+    blocked = unreachable_hops(
+        plan, closed, scheme, account=builder, asset_id=TOOLCHAIN
+    )
+    assert deploy_root in blocked, blocked
+
+
+# ---------------------------------------------------------------------------
+# 5. #622 不變式：monitor 的可寫面仍嚴格窄於 Manager
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
+def test_monitor_read_write_paths_stay_strictly_narrower_than_manager(scheme) -> None:
+    manager = set(build_manager_unit(scheme, DEFAULT_LAYOUT).read_write_paths)
+    monitor = set(build_monitor_unit(scheme, DEFAULT_LAYOUT).read_write_paths)
+    assert monitor < manager, (scheme.scheme_id, sorted(monitor - manager))
+
+
+# ---------------------------------------------------------------------------
+# 6. executor 形態表 ＋ PATH 的取捨
+# ---------------------------------------------------------------------------
+
+def test_executor_table_covers_the_four_dispatched_executors() -> None:
+    names = [t.name for t in EXECUTOR_TOOLS]
+    assert names == ["codex", "claude", "copilot", "agy"]
+    assert len(set(names)) == len(names)
+    for tool in EXECUTOR_TOOLS:
+        assert isinstance(tool.shape, ExecutorShape)
+        assert tool.note.strip(), tool.name
+
+
+def test_only_the_node_script_executor_depends_on_the_system_runtime() -> None:
+    """「node 的版本風險只涵蓋 codex 一個」這句話的機器可讀形式。
+
+    `claude`／`agy` 自帶原生執行檔、`copilot` 是 shell script——它們不會因為系統層
+    node 換版本而行為改變。這條同時擋住「以後有人順手把某個 CLI 標成 needs_node」。
+    """
+    needs_node = {t.name for t in EXECUTOR_TOOLS if t.needs_node}
+    assert needs_node == {"codex"}
+    assert TOOLCHAIN_SYSTEM_RUNTIMES == ("node",)
+    by_name = {t.name: t for t in EXECUTOR_TOOLS}
+    assert by_name["codex"].shape is ExecutorShape.NODE_SCRIPT
+    assert by_name["codex"].copy_tree, "node 套件單搬進入點會缺 node_modules"
+    assert by_name["claude"].shape is ExecutorShape.NATIVE_ELF
+    assert by_name["agy"].shape is ExecutorShape.NATIVE_ELF
+    assert by_name["copilot"].shape is ExecutorShape.SHELL_SCRIPT
+
+
+def test_job_path_puts_the_toolchain_first() -> None:
+    """實機上系統層另有一份舊很多的同名 CLI——排在後面就會被它蓋掉。"""
+    value = DEFAULT_LAYOUT.job_path_value()
+    segments = value.split(":")
+    assert segments[0] == DEFAULT_LAYOUT.toolchain_bin
+    assert tuple(segments[1:]) == JOB_PATH_SYSTEM_TAIL
+    # node／git／python3 的所在必須在 PATH 上；管理工具（sbin）一律不在。
+    assert "/usr/bin" in segments
+    assert not any(seg.endswith("/sbin") for seg in segments)
+
+
+def test_job_unit_documents_where_path_actually_comes_from() -> None:
+    """取捨寫在產物本身：模板 unit 的 `Environment=PATH=` 會被 shim 丟掉。
+
+    shim 以 `execvpe(argv[0], argv, spec['env'])` 整份換掉環境，job 解析命令用的
+    PATH 因此來自 **spec 的 env**（Manager 端 `PSC_BUILDER_PATH`），不是 unit。
+    在 unit 裡寫一行 `Environment=PATH=` 只會是一個看起來承載作用、實際無效的設定。
+    """
+    unit = build_job_unit(THREE_WAY_SCHEME, DEFAULT_LAYOUT)
+    assert "\nEnvironment=PATH=" not in unit.content, "不得產生無效的 PATH 指令"
+    assert f"PSC_BUILDER_PATH={DEFAULT_LAYOUT.job_path_value()}" in unit.content
+    assert DEFAULT_LAYOUT.toolchain_root in unit.content
+    assert "execvpe" in unit.content, "取捨的理由必須留在產物裡"
+
+
+def test_builder_path_env_name_matches_the_job_runner_contract() -> None:
+    """`PSC_BUILDER_PATH` 是 Manager 端**既有**的注入點，不是本票新造的。"""
+    from paulsha_cortex.coordinator import job_runner
+
+    assert job_runner.BUILDER_PATH_ENV == "PSC_BUILDER_PATH"
+    assert f"{job_runner.BUILDER_PATH_ENV}=" in build_job_unit(
+        THREE_WAY_SCHEME, DEFAULT_LAYOUT
+    ).content
+
+
+# ---------------------------------------------------------------------------
+# 7. toolchain 落位計畫（產生器＝單一真相）＋ 純函式不變式
+# ---------------------------------------------------------------------------
+
+def test_toolchain_plan_is_deterministic_strings_only() -> None:
+    a = build_toolchain_plan(THREE_WAY_SCHEME, DEFAULT_LAYOUT)
+    b = build_toolchain_plan(THREE_WAY_SCHEME, DEFAULT_LAYOUT)
+    assert a == b
+    assert all(isinstance(line, str) for line in a)
+    allowed = ("install -d ", "chown ", "chmod ")
+    for line in a:
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        assert stripped.startswith(allowed), stripped
+
+
+def test_toolchain_plan_names_every_executor_and_the_version_pitfall() -> None:
+    text = "\n".join(build_toolchain_plan(THREE_WAY_SCHEME, DEFAULT_LAYOUT))
+    for tool in EXECUTOR_TOOLS:
+        assert f"--- {tool.name}（" in text, tool.name
+    # 來源判準：取 operator 實際在用的那一份，而不是另裝一份系統的。
+    assert "command -v" in text
+    assert "npm install -g" in text, "「不要另裝一份」這句必須寫在產物裡"
+    assert DEFAULT_LAYOUT.job_path_value() in text
+
+
+def test_toolchain_cli_verb_prints_the_plan(capsys) -> None:
+    assert main(["toolchain", "three-way"]) == 0
+    out = capsys.readouterr().out
+    assert DEFAULT_LAYOUT.toolchain_root in out
+    assert main(["toolchain", "--nope"]) == 2
+
+
+def test_generators_still_touch_no_filesystem() -> None:
+    """`permgen` 仍是純函式：沒有 subprocess、沒有 chown／chmod 的實作面。"""
+    src = inspect.getsource(permgen)
+    for forbidden in ("subprocess", "os.system", "os.chown", "os.chmod", "shutil."):
+        assert forbidden not in src, forbidden


### PR DESCRIPTION
#640：#623 那一族的**第五個**缺口，而且比前四個都靠後——前四個解完之後，dispatch 會
一路走到**呼叫模型**那一步才失敗。job unit 帶 `ProtectHome=yes`，而四個 executor 原本
全在 operator 的 HOME 底下：

```
$ sudo -u cortex-builder env HOME=<job HOME> codex exec --help
/usr/bin/env: ‘node’: No such file or directory        rc=127
```

`grep -niE "auth\.json|credential|憑證|login" trust_root/registry.py` → 無結果：登記表
對 toolchain 與 job 帳號憑證**都沒有預留資產**，permgen 因此也不會產生它們的權限。
本 PR 落地 operator 0817 的兩條裁決。

## 1. `executor-toolchain`（裁決 (a)）

`<deploy_root>/toolchain`，root-owned `0755`——**全部 job／服務帳號唯讀＋可執行**，
一個 `w` 都沒有。機械落點是 `owner_class=DEPLOYMENT`（writer 只有部署身分），與
`runtime-agents-tree`／venv 同一類；`ProtectSystem=strict` 下 `/opt` 唯讀只擋寫入，
讀取與執行完全不受影響，因此本資產**機械地**不出現在任何 unit 的 `ReadWritePaths` 上。

`node` 走**系統層**（通用 runtime，換版本幾乎不影響產出）；四個模型 CLI 進部署樹，
因為「job 跑的是哪個版本的模型 CLI」**會**影響產出——那必須是可稽核的部署決定。

**這不是假設，是現況**：實機盤點在同一台機器上就有兩份 `codex`——系統層
`/usr/lib/node_modules/@openai/codex` 是 **0.42.0**、operator 實際在用的 nvm 那份是
**0.147.0**（差 100 個以上小版本）。照「系統層有什麼就用什麼」，job 會跑一份 operator
從未判讀過的版本，而症狀是「結果對不上」而不是報錯。因此安裝來源一律取 operator
**實際在用的那一份**（`command -v` 解出來的），**不**另外 `npm install -g`。

四者的實體形態不同、搬移方式不能一概而論，固化為 `permgen.EXECUTOR_TOOLS`：

| executor | 形態 | 需要 node | 搬移 |
|---|---|:--:|---|
| `codex` | Node.js script（`#!/usr/bin/env node`） | ✅ | 整包 npm 套件樹 |
| `claude` | 原生 ELF | — | 單檔 |
| `copilot` | bash script | — | 單檔（先查它內部再叫什麼） |
| `agy` | 原生 ELF | — | 單檔 |

`claude`／`agy` 自帶原生執行檔、不因 node 版本而行為改變——**系統層 node 的版本風險
因此只涵蓋 `codex` 一個**（有測試把這條釘成不變式，擋住未來有人順手把別支標成
`needs_node`）。node 的版本本身仍是**部署決定**，runbook 有記一句：某個 CLI 哪天提高
下限時要一併升，否則它會變成下一個無聲漂移點。

## 2. `builder-executor-credential`（裁決 (b)）：目錄 root-owned、檔案 job-owned

檔案（預設 `<job HOME>/.codex/auth.json`）由 **job 帳號**擁有、`0600`；**放它的目錄
維持 root-owned `0755`**（`codex-hooks` 就住在同一層）。淨效果：

- job **能**就地改寫自己那份憑證的內容（refresh 過期 token）；
- job **建不了新檔、刪不掉、也換不掉**同目錄下的其他 root-owned 檔——增／刪／換要的是
  **目錄**的寫入權，而目錄對它只有 `r-x`。

**機械上怎麼落到 job-owned**：`writers=(BUILDER,)`（**不含** `INSTALLER`）。寫成
`INSTALLER` 會讓 `classify_owner()` 落到 `DEPLOYMENT`（owner＝root），憑證就 refresh
不了——與裁決正好相反，有測試把這個反轉釘死。

**`ReadWritePaths` 掛在檔案本身而不是父目錄**（新的
`permgen.IN_PLACE_CONTENT_WRITE_ASSETS`，是一般規則的**明示**例外）：一般規則把檔案
折算成父目錄（要建立／取代一個檔必須對父目錄可寫），但這一族刻意不具備那個能力。
折算成父目錄會讓 job unit 的 mount 層開放整個 `~/.codex`（裡面還有 root-owned 的
`hooks.json`）；掛在檔案本身則讓「目錄 root-owned」在**檔案系統**與 **systemd mount**
兩層同時成立，#623 那條「兩個 root-owned 設定檔不可寫」的既有不變式也因此**逐字**
仍然成立（那條測試沒有被改寫，是新設計讓它繼續綠）。

**已知限制（裁決刻意接受，寫進 note／spec／runbook）**：以「暫存檔 ＋ rename 原子
替換」形式 refresh 的 CLI 會失敗（它要在同目錄建檔），只有就地 `O_TRUNC` 覆寫走得通。

**副作用（fail-closed，刻意）**：憑證未落位時 job unit 會起不來（systemd 對不存在的
`ReadWritePaths` 目標報錯）。沒有登入態的 job 本來就做不了事，在 exec 前失敗比走到
呼叫模型那一步才 rc=127 好查得多；runbook 記了 journal 的確切症狀。

### 為什麼登記表只掛 builder 一份（與 `codex-hooks` 逐條同構，不是遺漏）

登記表資產是 1:1 綁到一條絕對路徑的，而路徑要由帳號名推導。`cortex-builder` 是**兩個
scheme 都相同**的唯一 job 帳號，也是目前唯一真的以模板 unit 降權起 job 的 persona。
**登記第二份會弄壞一個現存的部署形態**：二分下 reviewer／planner 與 Manager 併帳
（`cortex-svc`），那份憑證的 owner 會解析成 `cortex-svc`，於是 Manager unit 的
`ReadWritePaths` 多出一條**二分部署裡根本不存在**的 HOME 路徑 → unit 起不來。
（這是實作過程中真的撞到的，`test_custom_layout_needs_no_code_change` 紅了才發現。）

**機制本身已經是 per-account 的**：`PathLayout.executor_credential_of()` 吃任意帳號，
`scaffold_directories()` 也已為**每一個** job 帳號建出 root-owned 的憑證父目錄
（`cortex-reviewer-planner` 那份憑證照同一條規則落位、同樣受保護）。M2（#615）把
reviewer／planner 移上模板 unit 時，登記表補第二列即可，產生器一行都不必改。

## 3. PATH：沿用 `PSC_BUILDER_PATH`，**不**在 unit 裡寫 `Environment=PATH=`

**結論：沿用既有的 `PSC_BUILDER_PATH`**，並把 runbook 的「選配」改成「**必填**」。

- **`Environment=PATH=` 在模板 unit 上是無效的**。模板 unit 的 `ExecStart` 是
  root-owned shim，而 shim 以 `os.execvpe(command[0], command, job_env)` 執行——CPython
  的 `_execvpe` 解析 `command[0]` 時走的是 `get_exec_path(env)`，也就是**傳進去那份
  env 的 `PATH`**（＝ job spec 的 `env`），不是 shim 行程繼承來的 unit 環境。在 unit
  裡寫一行 `Environment=PATH=` 只會產生一個**看起來承載作用、實際被 shim 丟掉**的設定
  ——正是這個 repo 最不想要的那種東西。要改成 unit 提供，就得動 `coordinator/job_shim.py`
  讓它合併 unit 的 PATH，而本 PR 依指示不碰 `coordinator/`；即使能動，也只是把單一
  真相從 spec 搬到 unit，換不到新的性質。
- **`PSC_BUILDER_PATH` 已經是 root-owned 的**：它寫在 `/opt/cortex/etc/cortex-manager.env`
  裡（登記表資產 `runtime-bootstrap-env`，root 擁有、Manager 唯讀），job 改不了它，
  Manager 也改不了。「可稽核的部署決定」這條性質沒有因為走 env 而變弱。
- **為什麼從「選配」變「必填」**：未設時 job 拿到的是 Manager 轉發的 `PATH`，而
  Manager 以 system unit 跑、拿到的是 systemd 的預設 `PATH`——裡面**沒有**
  `/opt/cortex/toolchain/bin`。
- **值由產生器出**（`PathLayout.job_path_value()`）：`<toolchain>/bin` **排最前面**，
  尾段是系統層 `/usr/local/bin:/usr/bin:/bin`（node／git／python3 在那裡），**不含
  任何 `sbin``）。排最前面是必要的：系統層那份 0.42.0 排在前面就會蓋掉 toolchain，
  症狀是「跑得起來但版本不是預期的那個」，比 `command not found` 難查得多。

取捨連同理由寫進**產生出來的 job unit 註解**裡（測試斷言 `Environment=PATH=` 不得
出現、且 `PSC_BUILDER_PATH=<正規值>` 與 `execvpe` 的說明必須在），runbook 5-5 一併
改寫。

## 4. spec：一個誠實限制

§R1 新增「executor 執行面」小節，並明載：把 operator 的憑證複製給 job 帳號，代表 job
用的是**同一個 provider 帳號**。三分買到的是**檔案系統層**的隔離（job 偷不到 Manager
的 token、改不了 Manager 的 state、讀不到另一個 job 帳號的憑證），**不是** provider
層的獨立——同一個 provider 帳號下的兩個 job 在 provider 眼中是同一個主體，配額、速率
限制、稽核紀錄與帳號層封鎖全部共用。

這與 `independence_domain`（§R5／§R8 的 anti-collusion 控制，由 Manager 在派工時決定
並寫入 registry，與 OS 帳號／憑證檔位置**全無關係**）**不是同一件事**；spec 明寫
**兩者 MUST NOT 互相當作證據**，否則「三分 ＋ 各自的憑證檔」很容易被讀成比實際更強的
保證。真正的 provider 層獨立需要每個 job 帳號各自的 provider 帳號，屬未來選項。

## 5. runbook

新增**第 4e 步**「executor toolchain 落位 ＋ per-account 憑證」（4 個 sudo 點、9 個
驗證點），內容包含：

- 系統層 node（apt；並記下「版本是部署決定」這句）；
- 逐支 CLI 的搬移方式（`codex` 整包搬套件樹、其餘單檔；`copilot` 提醒先 `head -n 20`
  查它內部再叫什麼）；
- **功能驗證**：以 job 帳號實跑一次四支 `--help`，**期望 rc=0**（rc=127 就是 #640 的
  原症狀，附診斷路徑）；
- **版本驗證**：job 帳號跑出來的 `codex --version` 必須與 operator 側**逐字相同**
  ——只驗 rc=0 不夠，系統層那份 0.42.0 一樣 rc=0；
- **在真實加固面下複跑一次**（`systemd-run` 帶 unit 的關鍵 property）：`sudo -u` 沒有
  unit 的加固面，兩者可能不同結果；若只有這條失敗，**第一嫌疑是
  `MemoryDenyWriteExecute=yes`**（node 的 V8 需要 W→X），附確認方式並要求記回 #584
  而不是就地放寬；
- 憑證落位（`install -o <job 帳號> -m 0600`，**不動** `.codex/` 目錄本身）與
  「能改內容／建不了新檔／刪不掉／換不掉鄰居」四條反向驗證。

另：5-5 的 `PSC_BUILDER_PATH`（選配→必填，附取捨）與「builder 帳號必須自己
`login`」（改為 root 落位——toolchain 未落位前 `login` 這個動作本身就跑不起來，且 job
的 HOME 是 root-owned，CLI 建不了 `auth.json`）兩段改寫；附錄 A 補兩條漂移自我檢查
（版本分岔／憑證 owner）。合計 **49** 個 sudo 點、**174** 個驗證點。

`trust_root toolchain` 新 CLI verb ＋ `permgen.build_toolchain_plan()` 讓落位步驟由
產生器出、runbook 不手寫（與 `shim`／`gitconfig` 同一個定位；**權限**那一半仍由登記表
經 `plan_to_commands()` 產出，不是第二份真相）。

## 驗證

- **`trust_root equation`：綠**（兩個新資產都是 `path_resolver=None`，路徑在 layout；
  等式本身有測試實跑）
- **toolchain 對 job 帳號唯讀且可執行**：`mode == 0o755`、group／other 皆有 `r`＋`x`
  且**無** `w`；`all_writable_accounts()` 只有 `root`；ACL 面零授寫；三份 unit 的
  `ReadWritePaths` 皆不涵蓋它
- **憑證檔 owner 是 job 帳號、目錄 owner 是 root**：計畫 `owner == cortex-builder`／
  `0600`／零 ACL；骨架的父目錄 `("root", 0o755)` 且 group／other 無 `w`
- **不變式「job 帳號在該目錄建不了新檔」以真的 OS 語意驗**（#638 的教訓）：
  `TestInPlaceCredentialOsSemantics` 對真實檔案系統驗四條——就地改內容成功、建新檔
  `PermissionError`、`unlink` `PermissionError`、`os.replace` 蓋鄰居 `PermissionError`。
  **不需要第二個 UID**：裁決 (b) 守的規則是「目錄沒有 `w` 位給這個行程」，真實部署裡
  job 落在 root-owned `0755` 的 `other` 位（`r-x`），測試以 owner 位為 `r-x`（`0555`）
  重現**同一段 kernel 檢查**（`inode_permission(dir, MAY_WRITE)`），只是命中不同那組
  權限位。真正需要第二個 UID 的只有「檔案 owner 不是本行程」那一半，那一半由產生器
  測試（`entry.owner == builder`）釘住，不重複造一個要 root 才跑得起來的測試。
  以 root 執行時整組**明確 skip 並說明理由**（root 不受 DAC 限制，那個語意在 root 下
  不存在），不靜默通過。
- **traverse 鏈完整**（沿用 #624 的 `unreachable_hops()`）：兩個新資產對 job 帳號皆
  `()`；並有**反向對照**（把 `/opt/cortex` 收成 `0700`，toolchain 立刻回報該層被擋）
- **monitor RWP 仍嚴格窄於 manager**（#622 不變式）：兩個 scheme 皆 `monitor < manager`
- **`permgen` 仍為純函式**：`test_generators_still_touch_no_filesystem`（無
  `subprocess`／`os.system`／`os.chown`／`os.chmod`／`shutil.`）＋ 落位計畫只產生
  `install -d`／`chown`／`chmod` 字串
- 新測試檔 `tests/test_trust_root_executor_toolchain_640.py`：**43 passed**
- 全套 `python3 -m pytest tests/ -q`：**3804 passed, 2 skipped, 49 subtests**，零回歸
- 本機 `policy_check` 帶 PR 上下文跑

## 未動的部分

`coordinator/` 一行未動（依指示）。實機安裝由 operator 執行；本 PR 只出登記表／
產生器／runbook。

Closes #640

## Checklist
- [x] `changelog.d/executor-toolchain.md` fragment 已新增且已 commit
- [x] `CHANGELOG.md [Unreleased]` 有對應 entry（Added ＋ Changed）
- [x] `VERSION` 與意圖一致（非 release PR，未動）
- [x] 測試通過（3804 passed）
- [x] `policy_check` 帶 PR 上下文跑過

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E7w9kaUxAzCCEk7piD5hfK
