### PR TITLE
fix(trust-root): 收掉 Manager 對 job 工作樹的唯讀 ACL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,28 @@
   `tests/test_trust_root_job_template_ab.py`（80 測試）。
 
 ### Fixed
+- **#641 / trust-root：`repo-worktree` 仍授 Manager 唯讀 ACL——交換面已改 bundle，
+  這條授權沒有消費者，卻讓 #637 的不變式在實機上不成立**——#637 把成果回收換成
+  bundle ＋ append-only spool 並加了「Manager 全程不碰 builder 的 clone」不變式測試，
+  但登記表 rationale 仍停在 worktree 時代（「交換面沿用 D2 git 讀」），permgen 因此
+  照樣產出 `setfacl -m u:cortex-manager:rX /var/lib/cortex/worktree/<job-id>`；operator
+  實機複驗：沒有 ACL 時 Manager `ls` 得到 Permission denied（不變式成立），套上登記表
+  那條之後就讀得到（同一條不變式在實機上不成立）。**三條同型授權一起收**——
+  `repo-worktree` 的 `rX`、`review-verdict` 與 `work-items-yaml` 的 `r`，逐條論證過
+  各自的消費者都已移到 spool 或來源樹；必須一起收是因為 traverse ACL 由跨帳號 ACL
+  機械導出（#620），留任何一條 job 樹的 `--x` 就會自己長回來。收掉它同時**移除一條
+  提權路徑的成立條件**：那條 `rX` 唯一還在使用的消費端 `verification.py` 是以
+  `cwd=<builder 完全掌控內容的樹>` 執行宣告的 check／test／full-suite，`pytest` 會載入
+  該樹的 `conftest.py`／plugin ⇒ builder 在 `cortex-manager` 身分下取得任意程式碼執行
+  （與 #629 同一條路徑）。那組讀工作樹的檢查改為**明確 fail-closed 並指向 #629**：
+  權限造成的失敗改回專屬理由碼 `candidate-worktree-unreadable-pending-gate-identity`，
+  evidence 帶 `blocked_on: "#629"` 與可操作處置——不靜默略過、不改讀 bundle（同源會讓
+  檢查退化）、不採信 builder 自報工作樹乾淨（#540／#628）。reviewer 側同型殘留已一併
+  確認並處理；`dispatch-worktree-pool` 容器層（`0701`）複驗零 `setfacl`。新增
+  `tests/test_manager_worktree_acl_641.py`（31 測試，含需要 root 的 OS 層不變式——
+  非 root 時**明確 skip 並附理由**，不靜默通過），四組突變驗證全部實跑；理由碼的
+  判定字串以 git 2.43.0 對真實的跨 uid `0700` repo 實測取得。詳見
+  `changelog.d/drop-manager-worktree-acl.md`。
 - **#638 / trust-root：兩個 spool 的 producer／consumer 權限模型在三分下三處失效——
   verdict 通道（Phase 2a）實際從未成立過，`commit-spool` 繼承了同樣的缺陷**——三個
   獨立缺陷全部有 operator 的實機證據：(1) per-job 目錄以明確 mode 建立會**重設 ACL

--- a/changelog.d/drop-manager-worktree-acl.md
+++ b/changelog.d/drop-manager-worktree-acl.md
@@ -1,0 +1,100 @@
+### Fixed
+- **#641 / trust-root：`repo-worktree` 仍授 Manager 唯讀 ACL——交換面已改 bundle，
+  這條授權沒有消費者，卻讓 #637 的不變式在實機上不成立**（Closes #641）
+
+  #637 把成果回收整條換成 **bundle ＋ append-only spool**（builder 在自己的 clone
+  產 bundle → 寫進 Manager-owned 的 `commit-spool` → Manager 從**那個檔案** fetch），
+  並為此加了不變式測試 `test_manager_never_touches_the_builder_clone_while_harvesting`
+  （把 clone `chmod 000` 仍能完成回收）。但登記表 `repo-worktree` 的 rationale 仍停在
+  worktree 時代——「trusted reader（Manager）以唯讀 ACL 讀取（交換面沿用 D2 git 讀）」
+  ——permgen 因此機械產出 `setfacl -m u:cortex-manager:rX /var/lib/cortex/worktree/<job-id>`。
+  operator 0817 實機複驗：
+
+  ```
+  只有 0700、無 ACL          → Manager `ls` 得到 Permission denied（#637 的不變式成立）
+  套上登記表要求的那條 ACL    → Manager 讀得到（同一條不變式在實機上不成立）
+  ```
+
+  也就是**測試裡成立的不變式，在照登記表部署的機器上不成立**，因為登記表主動授了
+  那條已無消費者的讀取權。
+
+  **三條一起收，不是只收一條。** job 樹底下原本有**三條**同型授權，全部出自 permgen
+  「單一 job writer」分支那一句共用 rationale：`repo-worktree` 的 `rX`、
+  `review-verdict`（reviewer 工作樹內的 legacy verdict 檔）的 `r`、以及
+  `work-items-yaml`（`<job 樹>/.cortex/work-items.yaml`）的 `r`。後兩條逐條論證過
+  沒有消費者：verdict 的權威通道自 Phase 2a 起是 `review-verdict-spool`，而
+  `_review_verdict_source()` 對帶 `review_verdict_channel == "spool"` 標記的 job
+  **只**認 spool、明確不回退讀 worktree——Phase 2b 部署派出的每個 reviewer job 都帶
+  那個標記，legacy 分支只對 Phase 2a 之前派工的 in-flight job 成立，而那批 job 不可能
+  出現在一台已經套了三分 ACL 的機器上；`work-items.yaml` 則是 monitor 讀**來源樹**
+  那一份（`correlation.load_work_item_overrides()` 與 `work_actions` 都以 Manager 自己的
+  `PSC_REPO_ROOT` 為根，也就是 `repo-source-tree`），builder 的修改是 git-tracked，
+  循 bundle 以 commit 旅行、不以跨帳號檔案讀取旅行。**必須一起收**的機械理由：
+  traverse ACL 是由跨帳號 ACL 導出的（#620），留任何一條，`<job 樹>`（乃至
+  `<job 樹>/.cortex`）的 `--x` 就會自己長回來。
+
+  **這不只是最小權限，也是一條提權路徑的成立條件。** 那條 `rX` 唯一還在使用的消費端
+  是 `coordinator/verification.py`——它不只讀 HEAD／dirty 狀態，還以
+  `cwd=<job 樹>` **執行**宣告出來的 check／test／full-suite（`_resolve_worktree_cwd`）。
+  `pytest` 會載入該樹的 `conftest.py`／plugin，等於 builder 在 `cortex-manager` 身分下
+  取得任意程式碼執行——與 #629 在 gate 執行面描述的是同一條路徑（同一段論證早已寫在
+  `gate-ledger` 的 note 與 `launcher._should_run_gates` 的 docstring）。收掉這條讀取權
+  之後，那些命令在三分下連 spawn 都不會成功。
+
+  **verification 那組讀工作樹的檢查改為明確 fail-closed 並指向 #629**（方向 1，不是
+  靜默略過、也不是整組刪掉）。`candidate-worktree-unreadable`／`-status-error`／
+  `-moved-after-verification` 三個既有理由碼保留給「那棵樹壞了」；讀取失敗**是權限
+  造成的**時改回專屬理由碼 `candidate-worktree-unreadable-pending-gate-identity`，
+  evidence 的 `details.candidate_worktree_blocked` 帶 `blocked_on: "#629"` 與可操作
+  處置（等 #629 的第三執行身分，或在 `PSC_JOB_RUNNER=direct` 下重跑）。canonical lane
+  的 `_verify_exact_candidate`／`_verify_build_candidate_transition` 得到同一處理：
+  處置一格未變（照樣 raise），只是訊息從那個部署形態下毫無意義的「candidate does not
+  exist」換成指得出下一步的字串。三條 **MUST NOT** 逐字寫進 `verification.py` 的
+  模組註解以免日後被「順手修好」：不得靜默略過；不得改讀 bundle 替代（bundle 同樣
+  由 builder 產生，兩邊同源會讓檢查退化成「builder 說什麼就是什麼」）；不得讓 builder
+  自報工作樹乾淨（違反 #540 的 acceptance chain 與 #628 的證據作者歸屬）。
+
+  **不是回歸**：三分部署下 build 卡本來就因 `require_ledger` 而
+  `gate-ledger-missing` fail-closed（#629 記錄的現況），這條 lane 早已卡在同一票；
+  `direct` 模式與所有既有測試環境下 Manager 就是工作樹的 owner，一位元都沒變。
+
+  **reviewer 側同型殘留已一併確認**：除上述 `review-verdict` 之外沒有其他殘留——
+  `_verify_exact_candidate` 對 reviewer persona 取的是 `workflow_repo_root`
+  （`repo-source-tree`，Manager-owned）而不是 reviewer 的工作樹，verdict 走 spool，
+  reviewer 的工作樹從頭到尾沒有被 Manager 讀過。`dispatch-worktree-pool` 容器層
+  （`0701`，owner＝Manager）也複驗過：產生器對它只出 `install -d`／`chown`／`chmod`，
+  零 `setfacl`，沒有任何為「Manager 讀 job 樹」而設的授權。
+
+  **測試**：新增 `tests/test_manager_worktree_acl_641.py`（31 測試）。結構性那一組
+  （權限計畫零跨帳號 ACL、產生的 script 含**註解掉的 per-job 段**都沒有指向 job 樹的
+  `setfacl`、rationale 不再宣稱 Manager 讀取、兩個 scheme 各驗一次）在任何環境都跑；
+  **OS 層那一組**（照登記表建出 `0700 <job uid>` 的樹，另一個 uid `listdir`／`open`
+  必須被拒，而 job 帳號自己讀得到）需要 root 才借得到兩個身分，非 root 時**明確 skip
+  並附理由**——這正是 #638 點名的「單 UID 環境測不出來的 OS 語意」，不靜默通過。
+  **突變驗證**四組全部實跑過：把 `repo-worktree` 的 reader 改回 Manager → 7 條紅；
+  只把 `work-items-yaml` 改回去 → 6 條紅（含 `test_no_traverse_grant_reaches_into_a_
+  job_worktree`，證明 traverse 真的會自己長回來）；拿掉 `worktree_read_blocked()` 的
+  偵測 → 6 條紅；OS 層把修法前那條 `u:<manager>:rX` 以 xattr 套回去 → 讀取從被拒轉為
+  成功（證明該 fixture 分辨得出兩種形狀，不是因為建錯東西才紅）。
+  `tests/test_trust_root_permgen_traverse_620.py::test_unknown_intermediate_directory_
+  is_fail_closed` 改以**合成資產**驗被驗的性質——它原本綁在 `work-items-yaml` 這個
+  登記表資料上，那個耦合正是它會隨無關變更一起紅掉的原因。
+
+  docs 同步：spec §R1 新增「job 工作樹對 Manager 完全不可讀（#641）」一節、修正
+  §背景資產表與 Phase 2 roadmap 第 6 條的「沿用 D2 git 讀」；runbook 第 2b 步新增
+  稽核 5b（`grep setfacl … /var/lib/cortex/worktree/` 期望空輸出）。
+
+  理由碼的判定字串是**實測**來的：以 git 2.43.0 對一個 `0700`、屬於別的 uid 的
+  真實 repo 跑 `rev-parse HEAD`／`status --porcelain`／`merge-base --is-ancestor`，
+  三者逐字都是 `fatal: cannot change to '<dir>': Permission denied`、rc 皆為 128。
+
+  已 rebase 到 #642（executor toolchain ＋ per-account 憑證）之上：它新增的兩個資產
+  都不在 job 工作樹底下（`<deploy_root>/toolchain` 與 builder HOME 下的憑證檔），
+  本票的不變式因此不受影響——而且是**機械性**地不受影響（那條斷言掃的是「落點在
+  job 樹底下的每一項」，不是一份硬編碼的 asset_id 清單）。
+
+  全套 `python3 -m pytest tests/ -q`：**3834 passed, 4 skipped**（零回歸；4 skipped
+  ＝#638 既有 2 條 ＋ 本次新增的 2 條 root-only 不變式）。那 2 條已另以 root 實跑：
+  `sudo python3 -m pytest tests/test_manager_worktree_acl_641.py -q` → **31 passed**，
+  含跨 UID 的正向（job 帳號讀得到）、反向（Manager 被拒）與突變對照（套回舊 ACL 就
+  讀得到）。

--- a/docs/superpowers/runbooks/trust-root-phase2b-setup.md
+++ b/docs/superpowers/runbooks/trust-root-phase2b-setup.md
@@ -581,6 +581,23 @@ tail -n 20 /tmp/p2b-permissions.sh | grep -c ":--x "
 #   ACL **mask**，先 setfacl 再 chmod 會讓具名條目的有效權限被 mask 成空（靜默失效，
 #   不會報錯）。因此也**不要**在執行完 permissions 之後再重跑 scaffold。
 
+# ✅ 稽核 5b：**job 工作樹底下不得有任何 setfacl**（#641）
+#   註解掉的 per-job 行也算數——那些是降權啟動器逐案要套的，因此連 `#` 開頭的行
+#   一起看：
+grep -E "setfacl" /tmp/p2b-permissions.sh | grep -E "/var/lib/cortex/worktree/"
+#   期望：**空輸出**。
+#   #637 把成果交付整條換成 bundle spool（builder 產 bundle → commit-spool →
+#   Manager 從**檔案** fetch），reviewer 的 verdict 走 review-verdict-spool。
+#   Manager 因此沒有任何理由讀 job 的樹；#641 把登記表裡殘留的三條讀取授權
+#   （`repo-worktree` 的 `rX`、`review-verdict` 與 `work-items-yaml` 的 `r`）
+#   一起收掉。
+#   **非空輸出 ⇒ 部署樹比 #641 舊，先升級再繼續**——照舊值套用會讓
+#   #637 的不變式（Manager 全程不碰 builder 的 clone）在實機上不成立，而測試
+#   仍是綠的。
+#   注意 `/var/lib/cortex/worktree`（pool 容器本身，無 `/` 結尾）**不在**此列：
+#   它是 `0701 cortex-manager`，Manager 是 owner、別的帳號只能 traverse，
+#   產生器對它只出 `install -d`／`chown`／`chmod`，本來就沒有 setfacl。
+
 # ✅ 稽核 6：script 裡出現的每個帳號名都**真的存在**（#626）
 #   `setfacl` 對解析不到的使用者名直接失敗（`Invalid argument near character 3`），
 #   而 2b 是 `sh -e`——一條錯就**中止整份 script**，留下**半套權限的樹**（前半已套、

--- a/docs/superpowers/specs/trust-root-isolation-spec.md
+++ b/docs/superpowers/specs/trust-root-isolation-spec.md
@@ -260,7 +260,7 @@ install 的殘留），可見這條路徑契約在實機上已經漂移。
 | skill ledger／park／proposal | `skill_ledger.py:141-183`、`skill_janitor.py:312-387`（皆無 chmod） | Manager、operator | 僅 Manager UID | operator 唯讀 |
 | runtime bootstrap env | `installer.py:162`（裸寫、無 mode） | 每個 Manager／Monitor 行程啟動 | root 或 Manager UID | 全部行程唯讀 |
 | unit／launcher／executable／site-packages／codex hooks | `installer.py:298`、`hooks.py:53-60`、pipx | systemd、Python import、codex | root（部署身分） | 全部行程唯讀 |
-| worktree（派工工作區） | 對應 headless job | Manager（改走 git 讀，D2） | 對應 headless UID | Manager 唯讀／git 讀 |
+| worktree（派工工作區） | 對應 headless job | **無跨帳號 reader**（成果走 bundle spool，#637／#641） | 對應 headless UID | owner-only，Manager **不讀** |
 
 **三個 headless persona 必須分別處理**，不能只封 builder：
 
@@ -451,6 +451,40 @@ repo」。裁決前先排除了一條看似最省事的路：**`git worktree` �
 - **seal SHALL 封目錄，MUST NOT 只 `chmod` 成果檔。** 只有檔案 owner 或 root 能
   `chmod`，而成果是 producer 擁有的；封目錄則是 consumer 對自己**擁有**的那一項
   操作，且 `chmod` 同時把 mask 收成 `---`，producer 具名條目的 traverse 一併失效。
+
+##### job 工作樹對 Manager 完全不可讀（#641，0817 裁決）
+
+交換面改成 bundle spool 之後，登記表裡「Manager 讀 job 樹」那一族授權**全部沒有
+消費者**。實機複驗（operator，0817）證實它讓 #637 建立的不變式在部署上不成立：
+
+```
+只有 0700、無 ACL          → Manager `ls` 得到 Permission denied（#637 的不變式成立）
+套上登記表要求的那條 ACL    → Manager 讀得到（同一條不變式在實機上不成立）
+```
+
+因此 job 工作樹底下的每一項資產 SHALL 是 **owner-only、零跨帳號 ACL**。三項一起
+收，不得只收其中一條——traverse ACL 是由跨帳號 ACL **機械導出**的（#620），留任何
+一條，`<job 樹>` 乃至其子目錄的 `--x` 就會自己長回來：
+
+| 資產 | 落點 | 原授權 | 真正的消費者 |
+|---|---|---|---|
+| `repo-worktree` | `<job 樹>` | `u:<manager>:rX` | 成果改走 `commit-spool` 的 bundle（#637） |
+| `review-verdict` | `<job 樹>/.psc-review-verdict.json` | `u:<manager>:r` | 權威通道是 `review-verdict-spool`（#599／#639）；legacy fallback 只對 Phase 2a 之前派工的 job 生效，而那批 job 不可能出現在套了 Phase 2b ACL 的機器上 |
+| `work-items-yaml` | `<job 樹>/.cortex/work-items.yaml` | `u:<manager>:r` | monitor 讀的是**來源樹**那一份（`repo-source-tree`）；builder 的修改是 git-tracked，循 bundle 以 commit 旅行 |
+
+**這不只是最小權限，也是一條提權路徑的成立條件。** `coordinator/verification.py`
+以 `cwd=<job 樹>` **執行**宣告出來的 check／test／full-suite；`pytest` 會載入該樹的
+`conftest.py`／plugin，等於 builder 在 Manager 身分下取得任意程式碼執行——與 #629
+在 gate 執行面描述的是同一條路徑。收掉這條讀取權之後，那些命令在三分下連 spawn
+都不會成功。
+
+**verification 那組讀工作樹的檢查** SHALL 搬到 #629 的第三執行身分（既非 builder
+也非 Manager，在受控 checkout 判讀）。在那之前它 SHALL **明確 fail-closed**，理由碼
+`candidate-worktree-unreadable-pending-gate-identity`、evidence 帶 `blocked_on:
+"#629"` 與可操作處置。三條 MUST NOT：**不得**靜默略過；**不得**改以 bundle 內容替代
+（bundle 同樣由 builder 產生，兩邊同源會讓檢查退化成「builder 說什麼就是什麼」）；
+**不得**採信 builder 自報的工作樹狀態（違反 §R5 acceptance chain 與 #628 的證據
+作者歸屬）。
 
 ##### `repo-source-tree` 的 owner：從 root 改為 Manager（0817 裁決）
 
@@ -960,7 +994,10 @@ skill ledger、runtime bootstrap env。
    受保護樹；unit 加固指令切實生效。
 5. 降權啟動器：Manager 以降權方式 spawn headless job，明確關閉 FD 傳遞、
    不傳遞 gh token。
-6. 交換面：headless 產出改由 Manager 以 candidate SHA 走 git 讀（沿用 D2）；
+6. 交換面：headless 產出改走 **append-only spool**——builder 的 commit 以 git
+   bundle 交付（`commit-spool`，#637）、reviewer 的 verdict 走
+   `review-verdict-spool`（#599）；Manager 讀的一律是 Manager-owned 樹裡的一個
+   **檔案**，**不**伸手進 job 的工作樹（#641 把登記表殘留的讀取 ACL 收掉）。
    planning artifact 走 staging→publish 兩段，publish 只由 Manager 執行。
 7. R3 自檢切 fail-closed。
 8. R9 四族測試矩陣全綠。

--- a/paulsha_cortex/coordinator/manager.py
+++ b/paulsha_cortex/coordinator/manager.py
@@ -3167,8 +3167,34 @@ def _job_for_workflow_card(
     return job, identity
 
 
+def _raise_if_worktree_read_blocked(result: object, *, what: str) -> None:
+    """#641：這次 `git -C <job 樹>` 失敗若是「Manager 沒有讀取權」，換一個指得出下一步的錯誤。
+
+    canonical lane 的 candidate 驗證與 slice lane 的 `verification` 是同一個問題的
+    兩個實例：兩邊都以 Manager 身分伸手進 builder 的樹。#641 收掉 `repo-worktree`
+    的唯讀 ACL 之後，三分部署下這裡必然 `Permission denied`。**照樣 fail-closed**
+    （處置一格未變，仍然 raise），本函式只負責讓錯誤訊息指向 #629 的第三執行身分，
+    而不是留下一句在那個部署形態下毫無意義的「candidate does not exist」。
+    """
+
+    if isinstance(result, str) or result is None:
+        return
+    stderr = getattr(result, "stderr", "")
+    if not isinstance(stderr, str):
+        return
+    if not verification.worktree_read_blocked({"status": "non-zero", "stderr": stderr}):
+        return
+    raise ValueError(
+        f"workflow candidate worktree unreadable by manager ({what}); "
+        f"blocked on {verification.WORKTREE_READ_BLOCKED_ISSUE}: "
+        f"{verification.WORKTREE_READ_BLOCKED_DETAIL}"
+    )
+
+
 def _verify_exact_candidate(job: Mapping[str, object], *, git_runner=None) -> str:
     candidate = job.get("subject_head")
+    # reviewer 走 `workflow_repo_root`（Manager 自己的來源樹），不讀 reviewer 的
+    # 工作樹——#641 的同型問題在這條 lane 上本來就不存在。
     worktree = (
         job.get("workflow_repo_root")
         if job.get("persona") == "reviewer"
@@ -3195,6 +3221,7 @@ def _verify_exact_candidate(job: Mapping[str, object], *, git_runner=None) -> st
     else:
         exists_ok = getattr(exists, "returncode", 1) == 0
     if not exists_ok:
+        _raise_if_worktree_read_blocked(exists, what="cat-file")
         raise ValueError("workflow candidate does not exist")
     head = run_git(["git", "-C", worktree, "rev-parse", "HEAD"])
     if isinstance(head, str):
@@ -3204,6 +3231,7 @@ def _verify_exact_candidate(job: Mapping[str, object], *, git_runner=None) -> st
         head_ok = getattr(head, "returncode", 1) == 0
         head_text = getattr(head, "stdout", "")
     if not head_ok or not isinstance(head_text, str) or head_text.strip().lower() != candidate:
+        _raise_if_worktree_read_blocked(head, what="rev-parse HEAD")
         raise ValueError("workflow candidate is not exact worktree HEAD")
     return candidate
 
@@ -3242,6 +3270,7 @@ def _verify_build_candidate_transition(
     if returncode == 1:
         raise ValueError("workflow build candidate is not a descendant")
     if returncode != 0:
+        _raise_if_worktree_read_blocked(ancestry, what="merge-base --is-ancestor")
         raise ValueError("workflow build candidate ancestry unavailable")
     return candidate
 

--- a/paulsha_cortex/coordinator/verification.py
+++ b/paulsha_cortex/coordinator/verification.py
@@ -476,6 +476,94 @@ def _run_git(args: list[str], git_runner: GitRunner | None) -> dict[str, Any]:
     }
 
 
+# ---------------------------------------------------------------------------
+# #641：Manager 對 job 工作樹沒有讀取權時的 fail-closed 面
+# ---------------------------------------------------------------------------
+#
+# 三分（trust-root Phase 2b）部署下，job 的工作樹是 `0700 <job 帳號>`，而登記表
+# 資產 `repo-worktree` 在 #641 之後**不再**授 Manager 唯讀 ACL——成果交付整條走
+# bundle spool（#637），Manager 沒有理由走進 builder 的樹。
+#
+# 但本模組底下這一組檢查（worktree HEAD == candidate、工作樹乾淨、以及以
+# `cwd=<job 樹>` 執行宣告出來的 check／test／full-suite）**確實**在讀那棵樹。
+# 它們在三分下會全部拿到 `Permission denied`。正確的落點是 #629 的第三執行身分
+# （既非 builder 也非 Manager，在受控 checkout 判讀）——理由不只是權限：以
+# `cwd=<builder 完全掌控內容的樹>` 跑 `pytest` 會載入該樹的 `conftest.py`／plugin，
+# 等於 builder 在 `cortex-manager` 身分下取得任意程式碼執行（同一段論證見
+# `trust_root/registry.py` 的 `gate-ledger` note 與 `launcher._should_run_gates`）。
+#
+# 在 #629 落地之前，這裡的行為只有一種是對的：**明確 fail-closed，且理由碼指得出
+# 下一步**。三條不得走的路，逐條寫在這裡以免日後被「順手修好」：
+#
+#   1. **不得靜默略過**——略過等於一張 build 卡沒有任何人檢查過工作樹狀態就往下走。
+#   2. **不得改讀 bundle 取代這組檢查**——bundle 的內容同樣由 builder 產生，兩邊
+#      同源，那道檢查會退化成「builder 說什麼就是什麼」（#637 PR body 已列此結論）。
+#   3. **不得讓 builder 自報「我的工作樹是乾淨的」**——違反 #540 的 acceptance chain
+#      （model 既不能自證成功、也不能自證失敗）與 #628 收斂好的證據作者歸屬。
+
+#: 讀不到 job 工作樹時的專屬 summary。與泛用的 `candidate-worktree-unreadable`
+#: 分開：後者是「那棵樹壞了」，前者是「Manager 本來就不該讀得到，等 #629」。
+WORKTREE_READ_BLOCKED_SUMMARY = "candidate-worktree-unreadable-pending-gate-identity"
+
+#: 阻擋原因所指向的票號——evidence 內逐字帶出，operator 不必回頭讀原始碼。
+WORKTREE_READ_BLOCKED_ISSUE = "#629"
+
+WORKTREE_READ_BLOCKED_DETAIL = (
+    "Manager 讀不到這個 job 的工作樹。trust-root 三分部署下工作樹是 "
+    "`0700 <job 帳號>`，而登記表資產 `repo-worktree` 自 #641 起不再授 Manager "
+    "唯讀 ACL（成果交付走 commit-spool 的 bundle，見 #637）。本組檢查"
+    "（worktree HEAD == candidate、工作樹乾淨、以及以 cwd=<job 樹> 執行宣告的 "
+    "check／test／full-suite）必須改由 #629 的第三執行身分在受控 checkout 執行；"
+    "在那之前一律 fail-closed。處置：等 #629，或在 `PSC_JOB_RUNNER=direct` "
+    "（Manager 與 job 同 UID）下重跑這張卡。**不得**放寬 `repo-worktree` 的權限、"
+    "**不得**改以 bundle 內容替代（同源，檢查會退化）、**不得**採信 builder "
+    "自報的工作樹狀態（#540／#628）。"
+)
+
+#: git／OS 在「走不進那棵樹」時吐出來的字串。逐條比對而不是只看 returncode——
+#: 非零 returncode 也可能是「這不是一個 repo」，那是完全不同的處置。
+#:
+#: 第一條是**實測**來的，不是猜的：以 git 2.43.0 對一個 `0700` 且屬於**別的 uid**
+#: 的真實 repo 跑本模組會用到的三種形狀，三者逐字相同、rc 皆為 128——
+#:
+#:     $ setpriv --reuid=<manager> git -C <job 樹> rev-parse HEAD
+#:     $ setpriv --reuid=<manager> git -C <job 樹> status --porcelain --untracked-files=all
+#:     $ setpriv --reuid=<manager> git -C <job 樹> merge-base --is-ancestor HEAD HEAD
+#:     fatal: cannot change to '<job 樹>': Permission denied
+#:
+#: 其餘幾條涵蓋非 git 的讀取面（`Path.exists()` 一類的 `PermissionError`、
+#: coreutils 的 `cannot access`）與 EPERM 形態。
+_WORKTREE_READ_BLOCKED_MARKERS = (
+    "permission denied",
+    "cannot change to",
+    "operation not permitted",
+    "cannot access",
+)
+
+
+def worktree_read_blocked(result: Mapping[str, Any]) -> bool:
+    """這次對 job 工作樹的讀取是不是「Manager 沒有權限」造成的？
+
+    `_run_git` 的回傳形狀；`status == "ok"` 一律不算（讀到了就是讀到了）。
+    """
+
+    if result.get("status") == "ok":
+        return False
+    stderr = str(result.get("stderr") or "").lower()
+    return any(marker in stderr for marker in _WORKTREE_READ_BLOCKED_MARKERS)
+
+
+def worktree_read_blocked_payload(result: Mapping[str, Any]) -> dict[str, Any]:
+    """寫進 verification evidence 的結構化阻擋原因（理由碼指向 #629）。"""
+
+    return {
+        "blocked_on": WORKTREE_READ_BLOCKED_ISSUE,
+        "reason": WORKTREE_READ_BLOCKED_SUMMARY,
+        "detail": WORKTREE_READ_BLOCKED_DETAIL,
+        "git": dict(result),
+    }
+
+
 def _load_catalog_from_text(text: str) -> dict[str, PersonaContract]:
     try:
         raw = safe_load(text)
@@ -722,10 +810,17 @@ def run_result_verification(
     candidate = branch_stdout.lower()
     details["candidate"] = candidate
 
+    # #641：以下每一次對 `worktree` 的存取都是 Manager 伸手進 builder 的樹。三分下
+    # 這裡是整個 verification **第一個**碰到那棵樹的點——排在 harvest 之後、任何
+    # `cwd=<job 樹>` 的命令執行之前，因此讀不到時不會有任何 builder 掌控的程式碼被
+    # 以 Manager 身分執行。完整推導見本檔 `WORKTREE_READ_BLOCKED_DETAIL`。
     worktree_head = _run_git(["-C", str(worktree), "rev-parse", "HEAD"], git_runner)
     worktree_head_stdout = worktree_head["stdout"].strip()
     if worktree_head["status"] != "ok" or SAFE_SHA_RE.fullmatch(worktree_head_stdout) is None:
         details["candidate_worktree_error"] = worktree_head
+        if worktree_read_blocked(worktree_head):
+            details["candidate_worktree_blocked"] = worktree_read_blocked_payload(worktree_head)
+            return _finish("needs_human", WORKTREE_READ_BLOCKED_SUMMARY)
         return _finish("needs_human", "candidate-worktree-unreadable")
     details["candidate_worktree_head"] = worktree_head_stdout.lower()
     if worktree_head_stdout.lower() != candidate:
@@ -740,6 +835,9 @@ def run_result_verification(
         "stderr": worktree_status["stderr"],
     }
     if worktree_status["status"] != "ok":
+        if worktree_read_blocked(worktree_status):
+            details["candidate_worktree_blocked"] = worktree_read_blocked_payload(worktree_status)
+            return _finish("needs_human", WORKTREE_READ_BLOCKED_SUMMARY)
         return _finish("needs_human", "candidate-worktree-status-error")
     if worktree_status["stdout"].strip():
         return _finish("needs_human", "candidate-worktree-dirty")
@@ -1021,6 +1119,12 @@ def run_result_verification(
         "stderr": worktree_status_after["stderr"],
     }
     if worktree_status_after["status"] != "ok":
+        # #641：與前一組同一條規則——讀不到就指名 #629，不與「那棵樹壞了」混為一談。
+        if worktree_read_blocked(worktree_status_after):
+            details["candidate_worktree_blocked"] = worktree_read_blocked_payload(
+                worktree_status_after
+            )
+            return _finish("needs_human", WORKTREE_READ_BLOCKED_SUMMARY)
         return _finish("needs_human", "candidate-worktree-status-error")
     if worktree_status_after["stdout"].strip():
         return _finish("needs_human", "candidate-worktree-dirty-after-verification")
@@ -1028,6 +1132,11 @@ def run_result_verification(
     details["candidate_worktree_head_after"] = final_worktree_head["stdout"].strip().lower()
     if final_worktree_head["status"] != "ok" or final_worktree_head["stdout"].strip().lower() != candidate:
         details["candidate_worktree_head_after_error"] = final_worktree_head
+        if worktree_read_blocked(final_worktree_head):
+            details["candidate_worktree_blocked"] = worktree_read_blocked_payload(
+                final_worktree_head
+            )
+            return _finish("needs_human", WORKTREE_READ_BLOCKED_SUMMARY)
         return _finish("needs_human", "candidate-worktree-moved-after-verification")
 
     final_branch = _run_git(["-C", str(resolved_repo_root), "rev-parse", branch], git_runner)

--- a/paulsha_cortex/trust_root/permgen.py
+++ b/paulsha_cortex/trust_root/permgen.py
@@ -820,7 +820,16 @@ def build_entry(asset: TrustRootAsset, scheme: UidScheme) -> PermissionEntry:
                 "本表只定容器層權限。"
             )
         else:
-            # 單一 job writer：owner＝該 job 帳號，Manager 以唯讀 ACL 讀取產出（D2 走 git）。
+            # 單一 job writer：owner＝該 job 帳號，owner-only。
+            #
+            # #641：本分支原本無條件補一條「trusted reader（Manager）唯讀 ACL」，
+            # 理由寫的是「交換面沿用 D2 git 讀」。那個交換面在 #637 之後已經不存在
+            # ——builder 的成果走 bundle → `commit-spool` → Manager 從**檔案** fetch，
+            # reviewer 的 verdict 走 `review-verdict-spool`。跨帳號讀取因此**只**在
+            # 登記表真的宣告了非 owner 的 reader 時才產生；本族三項（`repo-worktree`
+            # ／`review-verdict`／`work-items-yaml`）在 #641 之後都沒有，產出即為
+            # owner-only、零 ACL。rationale 也跟著條件化——operator review 的是這一行，
+            # 它不能在「這一項其實沒有任何跨帳號授權」時還宣稱有。
             owner = next(iter(job_writers), trusted_owner)
             mode = _dir_file_mode(is_dir, 0o7 if is_dir else 0o6, 0, 0)
             for racct in sorted(reader_accounts):
@@ -829,9 +838,20 @@ def build_entry(asset: TrustRootAsset, scheme: UidScheme) -> PermissionEntry:
                 acls.append(AclEntry(racct, "rX" if is_dir else "r"))
             writer_accounts = frozenset({owner})
             rationale = (
-                "job-visible 單一 writer：owner＝對應 job 帳號可寫；trusted reader "
-                "（Manager）以唯讀 ACL 讀取（交換面沿用 D2 git 讀）。"
+                "job-visible 單一 writer：owner＝對應 job 帳號可寫。"
             )
+            if acls:
+                rationale += (
+                    "登記表宣告了非 owner 的 reader，故以 per-account 唯讀 ACL 精確授予"
+                    "（每一條都必須在該資產的 note 指名真正的消費者——#641：成果交付"
+                    "一律走 spool，「Manager 讀 job 的樹」不是合法理由）。"
+                )
+            else:
+                rationale += (
+                    "**owner-only、零跨帳號 ACL**：成果交付走 spool（builder→"
+                    "`commit-spool` 的 bundle、reviewer→`review-verdict-spool` 的 "
+                    "verdict），Manager 不讀 job 的樹（#637／#641）。"
+                )
 
     # 安全網：group/other 一律不得帶 write 位（spec §R2「group 寫入權 MUST 移除」）。
     group_bits = _mask_write((mode >> 3) & 0o7)

--- a/paulsha_cortex/trust_root/registry.py
+++ b/paulsha_cortex/trust_root/registry.py
@@ -413,19 +413,49 @@ ASSET_REGISTRY: tuple[TrustRootAsset, ...] = (
     # ---- job-visible worktree 族 -------------------------------------------
     TrustRootAsset(
         "repo-worktree", _T1, _JV, "paulsha_cortex.config.paths:repo_root",
-        (Principal.BUILDER,), (Principal.MANAGER,),
+        (Principal.BUILDER,), (Principal.BUILDER,),
         IngressKind.STAGING_SPOOL,
         note=(
             "builder write_paths:['**']，可寫工作區內任何路徑（含 .cortex/.github）。"
             "#623 之後這個工作區是從 `repo-source-tree` 拉出來的 **per-job 完整 clone**"
-            "（整個 clone 由該 job 帳號擁有），不再是共用 object store 的 git worktree。"
+            "（整個 clone 由該 job 帳號擁有），不再是共用 object store 的 git worktree。\n"
+            "**#641：reader 只剩 job 帳號自己，Manager 不在其中。** 本項原宣告 "
+            "`readers=(MANAGER,)`，permgen 因此產出 `setfacl -m u:cortex-manager:rX "
+            "<job 樹>`，理由是「交換面沿用 D2 git 讀」。#637 已把交換面整條換掉："
+            "builder 在自己的 clone `git bundle create` → 寫進 Manager-owned 的 "
+            "`commit-spool` → Manager 從**那個檔案** fetch。Manager 全程不需要、也不應該"
+            "走進 builder 的樹（#637 的不變式測試 `test_manager_never_touches_the_builder_"
+            "clone_while_harvesting` 就是釘這件事），而登記表卻主動授了那條讀取權——"
+            "**測試裡成立的不變式在照登記表部署的實機上不成立**，operator 0817 實測複驗過。\n"
+            "**為什麼不是「留著也沒差」**：那條 `rX` 不只是一條沒有消費者的讀取權。它"
+            "唯一還在使用的消費端是 `coordinator/verification.py`——那裡不但讀 HEAD／"
+            "dirty 狀態，還以 `cwd=<job 樹>` **執行**宣告出來的 check／test／full-suite "
+            "命令（`_resolve_worktree_cwd`）。`pytest` 會載入該樹的 `conftest.py`／plugin，"
+            "等於 builder 在 `cortex-manager` 身分下取得任意程式碼執行——正是 #629 要解的"
+            "那條提權路徑（同一段論證已寫在 `gate-ledger` 的 note 與 `launcher."
+            "_should_run_gates` 的 docstring）。收掉這條 ACL 因此不是「拿掉一個沒用的東西」，"
+            "而是**移除該提權路徑的成立條件**：沒有它，那些命令在三分下連 spawn 都不會成功。\n"
+            "**那組檢查怎麼辦**：搬到 #629 的第三執行身分（既非 builder 也非 Manager）。"
+            "在那之前 `verification` 讀不到工作樹時**明確 fail-closed** 並回 "
+            "`candidate-worktree-unreadable-pending-gate-identity`（理由碼與 evidence 的 "
+            "`blocked_on` 欄逐字指向 #629），**不得**靜默略過、**不得**改讀 bundle "
+            "（bundle 也是 builder 產的，兩邊同源會讓那道檢查退化）、更**不得**讓 builder "
+            "自報「我的工作樹是乾淨的」（違反 #540 的 acceptance chain 與 #628 的作者歸屬）。"
         ),
     ),
     TrustRootAsset(
         "dispatch-worktree-pool", _T1, _JV, "paulsha_cortex.config.paths:worktree_root",
         (Principal.BUILDER, Principal.REVIEWER, Principal.PLANNER), (Principal.MANAGER,),
         IngressKind.STAGING_SPOOL,
-        note="派工 worktree pool；reviewer 與 builder 必須分屬互不可寫域（裁決 10-2）。",
+        note=(
+            "派工 worktree pool；reviewer 與 builder 必須分屬互不可寫域（裁決 10-2）。"
+            "**#641 複驗**：容器層 `0701`（owner＝Manager）給的是「別的帳號只能 traverse "
+            "進自己那格、列不出目錄」，**不是**「Manager 讀得進 job 的樹」——Manager 是容器"
+            "的 owner，本來就進得了容器，但每個 per-job 子目錄是 `0700 <job 帳號>`，收掉 "
+            "`repo-worktree` 的 `rX` 之後 Manager 就到此為止。容器層沒有任何為了「Manager "
+            "讀 job 樹」而設的額外授權（產生器對本項只出 `install -d`／`chown`／`chmod`，"
+            "零 `setfacl`）。"
+        ),
     ),
     # ---- path_resolver=None：在別處以字面量推導的 Tier-0／Tier-1 資產 --------
     TrustRootAsset(
@@ -440,7 +470,7 @@ ASSET_REGISTRY: tuple[TrustRootAsset, ...] = (
     ),
     TrustRootAsset(
         "review-verdict", _T0, _JV, None,
-        (Principal.REVIEWER, Principal.ANY_SAME_UID), (Principal.MANAGER,),
+        (Principal.REVIEWER, Principal.ANY_SAME_UID), (Principal.REVIEWER,),
         IngressKind.DIRECT_FILE_WRITE,
         derived_in=("coordinator/review.py:22-23,176-185",),
         note=(
@@ -448,7 +478,17 @@ ASSET_REGISTRY: tuple[TrustRootAsset, ...] = (
             ".psc-review-verdict.json。**Phase 2a 起已非權威來源**——權威通道改為 "
             "review-verdict-spool；本項僅保留為過渡期 legacy fallback（只對 Phase 2a "
             "之前派工、job row 無 review_verdict_channel 標記的 reviewer job 生效），"
-            "採信時記 WARN＋DiagnosticReason。過渡期結束即應除役。"
+            "採信時記 WARN＋DiagnosticReason。過渡期結束即應除役。\n"
+            "**#641：reader 不再含 Manager——這是 `repo-worktree` 的同型殘留。** 本項的"
+            "落點是 reviewer 工作樹內的 `.psc-review-verdict.json`，原宣告 "
+            "`readers=(MANAGER,)` 會產出 `setfacl -m u:cortex-manager:r <reviewer 樹>/"
+            ".psc-review-verdict.json`。但那條授權在**它會被套用的部署上永遠沒有消費者**："
+            "per-job ACL 只存在於 Phase 2b（三分）部署，而 `manager._review_verdict_source()`"
+            "對帶 `review_verdict_channel == \"spool\"` 標記的 job **只**認 spool 落點、"
+            "明確不回退讀 worktree；Phase 2b 部署派出的每個 reviewer job 都帶那個標記，"
+            "legacy 分支只對「Phase 2a 之前派工的 in-flight job」成立——那批 job 不可能"
+            "出現在一台已經套了三分 ACL 的機器上。留 `readers=(REVIEWER,)` 是誠實的：這個"
+            "檔今天唯一的讀者就是擁有它的那個 job 帳號自己。"
         ),
     ),
     TrustRootAsset(
@@ -639,10 +679,22 @@ ASSET_REGISTRY: tuple[TrustRootAsset, ...] = (
     ),
     TrustRootAsset(
         "work-items-yaml", _T1, _JV, None,
-        (Principal.OPERATOR, Principal.BUILDER, Principal.ANY_SAME_UID), (Principal.MONITOR,),
+        (Principal.OPERATOR, Principal.BUILDER, Principal.ANY_SAME_UID), (Principal.BUILDER,),
         IngressKind.DIRECT_FILE_WRITE,
         derived_in=("monitor/correlation.py:79-80,463-487",),
-        note="git-tracked correlation authority；builder ['**'] 可寫，即一次 correlation 變更。",
+        note=(
+            "git-tracked correlation authority；builder ['**'] 可寫，即一次 correlation 變更。"
+            "**#641：reader 不再含 Monitor——第三個同型殘留。** 本項在 `PathLayout` 的落點是"
+            "**job 工作樹裡的那一份**（`<job 樹>/.cortex/work-items.yaml`，因為那裡才有不受"
+            "信任的 writer），原宣告 `readers=(MONITOR,)` 會產出 `setfacl -m "
+            "u:cortex-manager:r` 加一條導出的 `--x` traverse（#620）打進 job 樹。但 monitor "
+            "讀的**不是那一份**：`correlation.load_work_item_overrides(repo_root)` 與 "
+            "`work_actions._work_override_action` 都以 **Manager 進程自己的 `PSC_REPO_ROOT`**"
+            "為根，也就是 `repo-source-tree`（Manager-owned，monitor 已列在該項的 readers "
+            "裡）。builder 對這個檔的修改是 git-tracked 的，因此循 #637 的 bundle 回到來源樹"
+            "——以 commit 旅行，不以跨帳號檔案讀取旅行。留 `readers=(BUILDER,)` 對應的正是"
+            "「job 樹裡那一份的讀者只有 job 帳號自己」。"
+        ),
     ),
 )
 

--- a/tests/test_manager_worktree_acl_641.py
+++ b/tests/test_manager_worktree_acl_641.py
@@ -1,0 +1,672 @@
+"""#641：收掉 Manager 對 job 工作樹的唯讀 ACL 之後的不變式。
+
+## 這一票在修什麼
+
+登記表資產 `repo-worktree` 原本宣告 `readers=(MANAGER,)`，permgen 因此機械產出
+
+    setfacl -m u:cortex-manager:rX /var/lib/cortex/worktree/<job-id>
+
+rationale 寫的是「交換面沿用 D2 git 讀」。**那個交換面在 #637 之後已經不存在**：
+builder 在自己的 clone 產 bundle → 寫進 Manager-owned 的 `commit-spool` → Manager
+從**那個檔案** fetch。#637 甚至為此加了不變式測試
+`test_manager_never_touches_the_builder_clone_while_harvesting`（把 clone `chmod 000`
+仍能完成回收）。
+
+operator 0817 的實機複驗因此抓到一個**測試與部署互相矛盾**的狀態：
+
+    只有 0700、無 ACL          → Manager `ls` 得到 Permission denied（#637 的不變式成立）
+    套上登記表要求的那條 ACL    → Manager 讀得到（#637 的不變式在實機上不成立）
+
+本檔釘住修正後的那一側：**照登記表部署，Manager 對 job 工作樹確實讀不到。**
+
+## 為什麼三個資產一起收
+
+job 樹底下原本有**三條**同型的跨帳號讀取授權，全部出自 permgen「單一 job writer」
+分支那一句「trusted reader（Manager）以唯讀 ACL 讀取」：
+
+| 資產 | 落點 | 原授權 | 真正的消費者 |
+|---|---|---|---|
+| `repo-worktree` | `<job 樹>` | `u:cortex-manager:rX` | 已改 bundle（#637）；殘留的讀取端見下 |
+| `review-verdict` | `<job 樹>/.psc-review-verdict.json` | `u:cortex-manager:r` | 已改 `review-verdict-spool`（#599／#639） |
+| `work-items-yaml` | `<job 樹>/.cortex/work-items.yaml` | `u:cortex-manager:r` | monitor 讀的是**來源樹**那一份（`repo-source-tree`） |
+
+而 traverse ACL 是**機械導出**的（#620）：只要 job 樹裡還留著任何一條跨帳號 ACL，
+`<job 樹>` 乃至其子目錄就會自動被補上 `--x`。只收 `repo-worktree` 一條，洞會從
+traverse 那一側自己長回來——`test_no_traverse_grant_reaches_into_a_job_worktree`
+（在 `test_trust_root_permgen_traverse_620.py`）釘的就是這件事。
+
+## verification 那一組檢查怎麼辦
+
+`coordinator/verification.py` 有一組**確實在讀 job 工作樹**的檢查（worktree HEAD ==
+candidate、工作樹乾淨），而且同一個 `worktree` 還被當成 `cwd` 去**執行**宣告出來的
+check／test／full-suite。收掉 ACL 之後這些在三分下全部 `Permission denied`。
+
+處置是**方向 1**：搬到 #629 的第三執行身分。在那之前 fail-closed，並以專屬理由碼
+`candidate-worktree-unreadable-pending-gate-identity` ＋ evidence 裡的
+`blocked_on: "#629"` 指出下一步——**不是**靜默略過、**不是**改讀 bundle（同源會讓
+檢查退化）、**不是**讓 builder 自報工作樹乾淨（#540／#628）。
+
+## 環境相依的那一組（#638 的教訓）
+
+「別的 uid 讀不到」是 **OS 層語意**，單 UID 環境根本測不出來——那正是 #637 CI 全綠
+卻在實機第一步就斷掉的形狀。因此跨 UID 那一組需要 root 才借得到兩個身分，拿不到時
+**明確 skip 並附理由**，絕不靜默通過；結構性的那一組（權限計畫與產生器輸出）在任何
+環境都會跑。
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import stat
+import struct
+import tempfile
+from dataclasses import replace
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from paulsha_cortex.coordinator import manager, spool_slot, verification
+from paulsha_cortex.trust_root import permgen
+from paulsha_cortex.trust_root.permgen import DEFAULT_LAYOUT, generate_plan
+from paulsha_cortex.trust_root.registry import ASSET_REGISTRY, Principal, asset_by_id
+
+
+#: #626：`operator`／`external` 是部署決定，模組層方案刻意留 None；本檔只關心 job
+#: 樹，但 `plan_to_commands` 會 fail-closed，故一律用注入後的方案。
+DEPLOYMENT_ACCOUNTS = {
+    Principal.OPERATOR: "cortex-ops",
+    Principal.EXTERNAL: "cortex-outbox",
+}
+THREE_WAY = permgen.THREE_WAY_SCHEME.with_principal_accounts(DEPLOYMENT_ACCOUNTS)
+TWO_WAY = permgen.TWO_WAY_SCHEME.with_principal_accounts(DEPLOYMENT_ACCOUNTS)
+ALL_SCHEMES = [TWO_WAY, THREE_WAY]
+SCHEME_IDS = [s.scheme_id for s in ALL_SCHEMES]
+
+
+# ---------------------------------------------------------------------------
+# 共用：把「job 樹底下的跨帳號授權」抽成一個可被突變驗證重複呼叫的函式
+# ---------------------------------------------------------------------------
+
+def _job_tree_root(paths: dict[str, str]) -> str:
+    """per-job 工作樹的落點（`<worktree pool>/<job-id>`）。"""
+
+    return paths["repo-worktree"]
+
+
+def _entries_inside_the_job_tree(plan, paths: dict[str, str]):
+    """權限計畫中，落點在 per-job 工作樹**之內**（含樹根自己）的每一項。
+
+    pool 容器（`dispatch-worktree-pool`）刻意不算：那一層是 Manager 擁有的容器，
+    Manager 進得去是設計本身（`0701`＝別的帳號只能 traverse、列不出目錄）。
+    """
+
+    root = _job_tree_root(paths)
+    return [
+        (entry, paths[entry.asset_id])
+        for entry in plan.entries
+        if paths.get(entry.asset_id) == root or paths.get(entry.asset_id, "").startswith(root + "/")
+    ]
+
+
+def cross_account_grants_into_the_job_tree(assets, scheme) -> list[tuple[str, str, str]]:
+    """job 樹底下所有「授給非 owner 帳號」的 ACL。空 list＝#641 的不變式成立。
+
+    回傳 `(asset_id, 帳號, perms)`，方便突變驗證時直接看見復發的是哪一條。
+    """
+
+    plan = generate_plan(scheme, tuple(assets))
+    paths = DEFAULT_LAYOUT.asset_paths()
+    found: list[tuple[str, str, str]] = []
+    for entry, _path in _entries_inside_the_job_tree(plan, paths):
+        for acl in entry.acls:
+            if acl.account != entry.owner:
+                found.append((entry.asset_id, acl.account, acl.perms))
+    return sorted(found)
+
+
+#: 修法前的形狀：三個 job 樹資產各自把 Manager／Monitor 宣告為 reader。突變驗證用。
+_PRE_641_READERS = {
+    "repo-worktree": (Principal.MANAGER,),
+    "review-verdict": (Principal.MANAGER,),
+    "work-items-yaml": (Principal.MONITOR,),
+}
+
+
+def _pre_641_registry() -> tuple:
+    return tuple(
+        replace(asset, readers=_PRE_641_READERS[asset.asset_id])
+        if asset.asset_id in _PRE_641_READERS
+        else asset
+        for asset in ASSET_REGISTRY
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. 登記表／權限計畫（結構性——任何環境都跑）
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=SCHEME_IDS)
+def test_no_cross_account_grant_anywhere_inside_a_job_worktree(scheme) -> None:
+    """#641 的驗收本身：job 樹底下不得有任何授給非 owner 的 ACL。"""
+
+    assert cross_account_grants_into_the_job_tree(ASSET_REGISTRY, scheme) == []
+
+
+@pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=SCHEME_IDS)
+def test_the_job_tree_invariant_actually_covers_something(scheme) -> None:
+    """守衛：上一條若因為「job 樹底下一項資產都沒有」而空過，就什麼也沒證明。"""
+
+    plan = generate_plan(scheme)
+    paths = DEFAULT_LAYOUT.asset_paths()
+    covered = {entry.asset_id for entry, _ in _entries_inside_the_job_tree(plan, paths)}
+    assert covered >= {"repo-worktree", "review-verdict", "work-items-yaml", "handoff-manifest"}
+
+
+def test_repo_worktree_is_owner_only_with_zero_acl() -> None:
+    """job 樹本身：owner＝該 job 帳號、`0700`、零 ACL。"""
+
+    entry = generate_plan(THREE_WAY).by_id("repo-worktree")
+    assert entry.owner == THREE_WAY.resolve(Principal.BUILDER)
+    assert entry.mode == 0o700
+    assert entry.acls == ()
+    assert entry.is_directory is True
+
+
+def test_registry_no_longer_declares_manager_as_a_reader_of_the_job_tree() -> None:
+    """宣告層（不是產生層）：三個資產的 readers 都不再含 Manager／Monitor。
+
+    產生器只是把登記表翻成命令；真正的單一真相是登記表這一欄。
+    """
+
+    for asset_id in _PRE_641_READERS:
+        readers = set(asset_by_id(asset_id).readers)
+        assert Principal.MANAGER not in readers, asset_id
+        assert Principal.MONITOR not in readers, asset_id
+        assert readers, f"{asset_id} 仍必須有 reader（登記表不允許無人消費的資產）"
+
+
+def test_dispatch_worktree_pool_grants_nothing_extra_for_manager_reads() -> None:
+    """容器層複驗：`0701` Manager-owned，零 ACL——沒有任何為「Manager 讀 job 樹」而設的授權。"""
+
+    entry = generate_plan(THREE_WAY).by_id("dispatch-worktree-pool")
+    assert entry.owner == THREE_WAY.durable_state_owner
+    assert entry.mode == 0o701
+    assert entry.acls == ()
+
+
+# ---------------------------------------------------------------------------
+# 2. 產生器輸出（operator 真正會執行的那些字串）
+# ---------------------------------------------------------------------------
+
+def _command_lines(scheme) -> list[str]:
+    """`plan_to_commands` 的輸出，逐行去掉註解前綴。
+
+    per-job 資產的命令是以 `#   ` 註解形式輸出的（由降權啟動器逐案套用，不在 setup
+    階段執行）——**那些也算數**，因此必須連註解一起檢查，不能只看未註解的行。
+    """
+
+    lines = permgen.plan_to_commands(
+        generate_plan(scheme), path_of=DEFAULT_LAYOUT.asset_paths(), scheme=scheme
+    )
+    return [line.lstrip("#").strip() for line in lines]
+
+
+@pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=SCHEME_IDS)
+def test_generated_commands_contain_no_setfacl_into_a_job_worktree(scheme) -> None:
+    """產生的權限 script（含註解掉的 per-job 段）沒有任何指向 job 樹的 setfacl。"""
+
+    root = _job_tree_root(DEFAULT_LAYOUT.asset_paths())
+    offenders = [
+        line
+        for line in _command_lines(scheme)
+        if line.startswith("setfacl") and (line.endswith(" " + root) or f" {root}/" in line)
+    ]
+    assert offenders == [], offenders
+
+
+@pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=SCHEME_IDS)
+def test_the_job_tree_section_still_sets_owner_and_mode(scheme) -> None:
+    """反向守衛：ACL 沒了，但 chown／chmod 這兩條**必須**還在（不是整段被刪掉）。"""
+
+    root = _job_tree_root(DEFAULT_LAYOUT.asset_paths())
+    lines = _command_lines(scheme)
+    assert any(line.startswith("chmod 0700 ") and line.endswith(root) for line in lines)
+    assert any(line.startswith("chown ") and line.endswith(root) for line in lines)
+
+
+def test_the_rationale_no_longer_claims_a_manager_read() -> None:
+    """operator review 的是 rationale 那一行——它不能還在宣稱「Manager 以唯讀 ACL 讀取」。"""
+
+    entry = generate_plan(THREE_WAY).by_id("repo-worktree")
+    assert "D2 git 讀" not in entry.rationale
+    assert "trusted reader" not in entry.rationale
+    assert "owner-only" in entry.rationale
+
+
+# ---------------------------------------------------------------------------
+# 3. 突變驗證：把修法前的形狀放回去，上面那些斷言必須當場紅
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=SCHEME_IDS)
+def test_the_pre_641_registry_shape_would_still_fail_this_fixture(scheme) -> None:
+    """沒有這一條，上面的斷言有可能哪天只是因為 fixture 不再涵蓋 job 樹而空過。"""
+
+    grants = cross_account_grants_into_the_job_tree(_pre_641_registry(), scheme)
+    if scheme is TWO_WAY:
+        # 二分下 reviewer／planner 與 Manager 併帳，`review-verdict` 的 owner 就是
+        # Manager 自己，那一條退化成 no-op；另外兩條照樣復發。
+        assert {asset_id for asset_id, _, _ in grants} == {"repo-worktree", "work-items-yaml"}
+        return
+    assert {asset_id for asset_id, _, _ in grants} == {
+        "repo-worktree",
+        "review-verdict",
+        "work-items-yaml",
+    }
+    assert all(account == THREE_WAY.durable_state_owner for _, account, _ in grants)
+
+
+def test_the_pre_641_shape_reopens_the_derived_traverse_into_the_job_tree() -> None:
+    """#620 的 traverse 是機械導出的：把讀取權放回去，job 樹裡的 `--x` 也跟著回來。
+
+    這正是「三條必須一起收」的理由——留任何一條，traverse 那一側就會自己長回來。
+    """
+
+    paths = DEFAULT_LAYOUT.asset_paths()
+    root = _job_tree_root(paths)
+    grants = permgen.derive_traverse_grants(
+        generate_plan(THREE_WAY, _pre_641_registry()), scheme=THREE_WAY, path_of=paths
+    )
+    reopened = [g for g in grants if g.path.startswith(root + "/") or g.path == root]
+    assert reopened, "突變後 traverse 沒有復發 ⇒ 這條測試證不出東西"
+
+
+# ---------------------------------------------------------------------------
+# 4. OS 層不變式：照登記表建出來的樹，別的 uid 真的讀不到
+#
+# 這一組是 #638 明說的那類「單 UID 環境測不出來」的東西：非 root 時**明確 skip**，
+# 不靜默通過。結構性的保證由上面第 1／2 節承擔。
+# ---------------------------------------------------------------------------
+
+_CROSS_UID_SKIP = (
+    "「Manager 讀不到 job 工作樹」是 OS 層語意，需要 root 才借得到 job／Manager 兩個 uid "
+    "實跑；單 UID 環境下 owner 就是自己，這條不變式在那裡沒有可驗的語意——"
+    "刻意 skip 而非空過（#638 的教訓）。結構性保證由本檔的權限計畫／產生器斷言承擔。"
+)
+
+_JOB_UID = 60011
+_MANAGER_UID = 60012
+
+_ACL_USER_OBJ, _ACL_USER, _ACL_GROUP_OBJ, _ACL_MASK, _ACL_OTHER = 0x01, 0x02, 0x04, 0x10, 0x20
+_ACL_UNDEFINED_ID = 0xFFFFFFFF
+_R, _W, _X = 4, 2, 1
+
+
+def _pre_641_read_acl(reader_uid: int) -> bytes:
+    """修法前那一條 `setfacl -m u:cortex-manager:rX <job 樹>` 的 xattr 形式。
+
+    走 `system.posix_acl_access`（`setfacl` 用的同一個核心介面），不依賴 `acl`
+    套件裝了沒。
+    """
+
+    payload = struct.pack("<I", 2)
+    for tag, perm, ident in (
+        (_ACL_USER_OBJ, _R | _W | _X, _ACL_UNDEFINED_ID),
+        (_ACL_USER, _R | _X, reader_uid),
+        (_ACL_GROUP_OBJ, 0, _ACL_UNDEFINED_ID),
+        (_ACL_MASK, _R | _W | _X, _ACL_UNDEFINED_ID),
+        (_ACL_OTHER, 0, _ACL_UNDEFINED_ID),
+    ):
+        payload += struct.pack("<HHI", tag, perm, ident)
+    return payload
+
+
+def _run_as(uid: int, fn) -> int:
+    """在 fork 出來的子進程裡以 `uid` 執行 `fn`。0＝成功、1＝被拒、2＝其他例外。"""
+
+    pid = os.fork()
+    if pid == 0:  # pragma: no cover - 子進程
+        code = 2
+        try:
+            os.setgroups([])
+            os.setgid(uid)
+            os.setuid(uid)
+            fn()
+            code = 0
+        except PermissionError:
+            code = 1
+        except OSError as exc:
+            code = 1 if exc.errno in {1, 13} else 2
+        except BaseException:
+            code = 2
+        os._exit(code)
+    _, status = os.waitpid(pid, 0)
+    return os.WEXITSTATUS(status)
+
+
+@pytest.fixture()
+def job_tree():
+    """照登記表把 `repo-worktree` 那一格建出來：`0700`、owner＝job 帳號、零 ACL。
+
+    刻意用 `tempfile.mkdtemp()` 而不是 `tmp_path`：借來的 uid 必須 traverse 得進來，
+    而 pytest 的 tmp 根鏈不保證是可穿越的（與 #638 同一個理由）。
+    """
+
+    root = Path(tempfile.mkdtemp(prefix="psc-641-"))
+    os.chmod(root, 0o755)
+    tree = root / "job-641-0001"
+    entry = generate_plan(THREE_WAY).by_id("repo-worktree")
+    tree.mkdir()
+    os.chmod(tree, entry.mode)
+    (tree / "committed.txt").write_text("builder-owned\n", encoding="utf-8")
+    os.chown(tree / "committed.txt", _JOB_UID, _JOB_UID)
+    os.chown(tree, _JOB_UID, _JOB_UID)
+    try:
+        yield tree
+    finally:
+        os.chmod(tree, 0o700)
+        shutil.rmtree(root, ignore_errors=True)
+
+
+@pytest.mark.skipif(os.geteuid() != 0, reason=_CROSS_UID_SKIP)
+def test_manager_cannot_read_a_job_worktree_built_to_the_registry(job_tree: Path) -> None:
+    """照登記表部署之後，Manager 對 job 工作樹**確實**讀不到（#637 的不變式在實機成立）。"""
+
+    assert stat.S_IMODE(os.stat(job_tree).st_mode) == 0o700
+    assert os.stat(job_tree).st_uid == _JOB_UID
+
+    def _list() -> None:
+        os.listdir(job_tree)
+
+    def _open() -> None:
+        (job_tree / "committed.txt").read_text(encoding="utf-8")
+
+    assert _run_as(_MANAGER_UID, _list) == 1, "Manager 列得出 job 樹的內容"
+    assert _run_as(_MANAGER_UID, _open) == 1, "Manager 讀得到 job 樹裡的檔案"
+    # 正向對照：job 帳號自己當然讀得到——不是把整棵樹鎖到誰都不能用。
+    assert _run_as(_JOB_UID, _list) == 0
+    assert _run_as(_JOB_UID, _open) == 0
+
+
+@pytest.mark.skipif(os.geteuid() != 0, reason=_CROSS_UID_SKIP)
+def test_the_pre_641_acl_would_have_made_this_fixture_pass_wrongly(job_tree: Path) -> None:
+    """突變驗證（OS 層）：把修法前那條 ACL 套回去，上一條的斷言必須反轉。
+
+    沒有這一條，上面那個 `Permission denied` 有可能只是因為 fixture 根本沒建對東西。
+    """
+
+    try:
+        os.setxattr(job_tree, spool_slot.ACCESS_ACL_XATTR, _pre_641_read_acl(_MANAGER_UID))
+    except OSError as exc:  # pragma: no cover - 取決於執行環境的檔案系統
+        pytest.skip(
+            f"此檔案系統不支援 POSIX ACL（設定 {spool_slot.ACCESS_ACL_XATTR} 失敗：{exc}）；"
+            "沒有 ACL 就重現不了修法前的形狀——刻意 skip 而非空過"
+        )
+
+    def _list() -> None:
+        os.listdir(job_tree)
+
+    assert _run_as(_MANAGER_UID, _list) == 0, (
+        "套上修法前的 `u:<manager>:rX` 之後 Manager 仍讀不到 ⇒ 這個 fixture 分辨不出"
+        "兩種形狀，前一條測試證不出東西"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 5. verification：讀不到工作樹時明確 fail-closed，理由碼指向 #629
+# ---------------------------------------------------------------------------
+
+#: git 2.43.0 對一個 `0700`、屬於別的 uid 的真實 repo 逐字吐出來的東西（實測，不是
+#: 猜的——`rev-parse HEAD`／`status --porcelain`／`merge-base --is-ancestor` 三種形狀
+#: 全部相同、rc 皆為 128）。理由碼的判定就靠這個字串，因此它必須是實測值。
+_DENIED_STDERR = (
+    "fatal: cannot change to '/var/lib/cortex/worktree/job-641-0001': Permission denied"
+)
+
+
+def _git_ok(stdout: str = "") -> SimpleNamespace:
+    return SimpleNamespace(returncode=0, stdout=stdout, stderr="")
+
+
+def _git_denied() -> SimpleNamespace:
+    return SimpleNamespace(returncode=128, stdout="", stderr=_DENIED_STDERR)
+
+
+def _contract() -> dict:
+    return {
+        "docs_class": "code",
+        "review_policy": "required",
+        "required_artifacts": [],
+        "checks": [
+            {"kind": "persona-scope"},
+            {
+                "kind": "command",
+                "name": "policy",
+                "argv": ["python3", "-m", "pytest", "-q", "tests/policy.py"],
+                "cwd": ".",
+                "timeout_seconds": 30,
+            },
+        ],
+        "tests": [],
+        "full_suite": {
+            "argv": ["python3", "-m", "pytest", "-q"],
+            "cwd": ".",
+            "timeout_seconds": 60,
+            "baseline": "no-regression",
+        },
+    }
+
+
+def _slice_row(contract: dict, *, dispatch_base: str, worktree: Path) -> dict:
+    return {
+        "slice_id": "slice-641",
+        "target_branch": "main",
+        "dispatch_base": dispatch_base,
+        "builder_job_id": "slice-641-1",
+        "state": "building",
+        "gate_state": "pending",
+        "worktree": str(worktree),
+        "verification": {
+            "hash": verification.canonical_json_hash(contract),
+            "contract": contract,
+        },
+    }
+
+
+def _job(worktree: Path) -> dict:
+    return {
+        "job_id": "slice-641-1",
+        "task": "slice-641",
+        "persona": "builder",
+        "branch": "feature/slice-641",
+        "worktree": str(worktree),
+        "status": "exited",
+        "exit_code": 0,
+    }
+
+
+class _WorktreeDenyingGitRunner:
+    """來源樹的 git 一切正常；凡是 `-C <job 樹>` 一律回實機那句 Permission denied。"""
+
+    def __init__(self, *, repo_root: Path, worktree: Path, candidate: str, deny: bool = True) -> None:
+        self._repo_root = str(repo_root)
+        self._worktree = str(worktree)
+        self._candidate = candidate
+        self._deny = deny
+        self.calls: list[list[str]] = []
+
+    def __call__(self, args: list[str]):
+        self.calls.append(list(args))
+        if len(args) >= 2 and args[0] == "-C" and args[1] == self._worktree:
+            if self._deny:
+                return _git_denied()
+            return SimpleNamespace(returncode=1, stdout="", stderr="fatal: not a git repository")
+        if args[:2] == ["-C", self._repo_root] and args[2:] == ["rev-parse", "feature/slice-641"]:
+            return _git_ok(self._candidate)
+        raise AssertionError(f"unexpected git call: {args!r}")
+
+
+class _ExplodingSubprocessRunner:
+    """verification 一旦以 `cwd=<job 樹>` 執行任何命令就當場失敗。"""
+
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    def __call__(self, argv, **kwargs):
+        self.calls.append({"argv": list(argv), **kwargs})
+        raise AssertionError(
+            f"Manager 在讀不到工作樹的情況下仍執行了命令：{argv!r} cwd={kwargs.get('cwd')!r}"
+        )
+
+
+def _run_verification(tmp_path: Path, *, deny: bool = True):
+    repo_root = tmp_path / "source"
+    repo_root.mkdir()
+    worktree = tmp_path / "worktree" / "job-641-0001"
+    worktree.mkdir(parents=True)
+    candidate = "b" * 40
+    git_runner = _WorktreeDenyingGitRunner(
+        repo_root=repo_root, worktree=worktree, candidate=candidate, deny=deny
+    )
+    proc_runner = _ExplodingSubprocessRunner()
+    evidence = verification.run_result_verification(
+        slice_row=_slice_row(_contract(), dispatch_base="a" * 40, worktree=worktree),
+        job=_job(worktree),
+        repo_root=repo_root,
+        coordinator_root=tmp_path / "coordinator",
+        git_runner=git_runner,
+        subprocess_runner=proc_runner,
+    )
+    return evidence["payload"], git_runner, proc_runner
+
+
+def test_verification_fails_closed_with_a_reason_pointing_at_629(tmp_path: Path) -> None:
+    """讀不到 job 工作樹 ⇒ needs_human ＋ 專屬理由碼 ＋ evidence 裡逐字帶出 #629。"""
+
+    payload, _git, proc = _run_verification(tmp_path)
+
+    assert payload["status"] == "needs_human"
+    assert payload["summary"] == verification.WORKTREE_READ_BLOCKED_SUMMARY
+    blocked = payload["details"]["candidate_worktree_blocked"]
+    assert blocked["blocked_on"] == "#629"
+    assert "#629" in blocked["detail"]
+    # 處置說明必須真的指得出下一步，不是只丟一個票號。
+    assert "第三執行身分" in blocked["detail"]
+    assert blocked["git"]["stderr"] == _DENIED_STDERR
+    # 而且**沒有**在讀不到的情況下執行任何 builder 掌控的程式碼。
+    assert proc.calls == []
+
+
+def test_verification_does_not_silently_pass_or_fall_back(tmp_path: Path) -> None:
+    """三條不得走的路：不靜默通過、不改讀 bundle、不採信 builder 自報。"""
+
+    payload, git, _proc = _run_verification(tmp_path)
+
+    assert payload["status"] not in {"verified", "reviewing"}
+    assert payload["details"]["checks"] == []
+    assert payload["details"]["tests"] == []
+    assert payload["details"]["full_suite"]["status"] == "skipped"
+    # 讀不到之後就停手：不會再有第二次對工作樹的嘗試（改用別的方式硬取）。
+    worktree_calls = [c for c in git.calls if c[:1] == ["-C"] and "worktree" in c[1]]
+    assert len(worktree_calls) == 1, worktree_calls
+
+
+def test_a_plain_broken_worktree_keeps_the_original_reason(tmp_path: Path) -> None:
+    """反向：不是權限問題時，理由碼**不得**被換成指向 #629 的那一個。
+
+    兩者的處置完全不同——一個是等 #629，一個是那棵樹壞了要人去看。
+    """
+
+    payload, _git, _proc = _run_verification(tmp_path, deny=False)
+
+    assert payload["summary"] == "candidate-worktree-unreadable"
+    assert "candidate_worktree_blocked" not in payload["details"]
+
+
+@pytest.mark.parametrize(
+    "stderr",
+    [
+        "fatal: cannot change to '/x': Permission denied",
+        "PermissionError: [Errno 13] Permission denied: '/x'",
+        "ls: cannot access '/x': Permission denied",
+        "mkdir: cannot create directory: Operation not permitted",
+    ],
+)
+def test_worktree_read_blocked_recognises_the_real_shapes(stderr: str) -> None:
+    assert verification.worktree_read_blocked({"status": "non-zero", "stderr": stderr}) is True
+
+
+@pytest.mark.parametrize(
+    "result",
+    [
+        {"status": "ok", "stderr": "Permission denied"},  # 讀到了就是讀到了
+        {"status": "non-zero", "stderr": "fatal: not a git repository"},
+        {"status": "non-zero", "stderr": ""},
+        {"status": "runner-error", "stderr": "boom"},
+    ],
+)
+def test_worktree_read_blocked_does_not_over_claim(result: dict) -> None:
+    assert verification.worktree_read_blocked(result) is False
+
+
+# ---------------------------------------------------------------------------
+# 6. canonical lane（`manager._verify_exact_candidate`）：同一條規則
+# ---------------------------------------------------------------------------
+
+def test_workflow_candidate_verification_points_at_629_when_denied() -> None:
+    """canonical lane 也是 Manager 伸手進 builder 的樹——照樣 fail-closed，訊息指向 #629。"""
+
+    job = {
+        "subject_head": "b" * 40,
+        "worktree": "/var/lib/cortex/worktree/job-641-0001",
+        "persona": "builder",
+    }
+
+    def git_runner(argv, **_kwargs):
+        return _git_denied()
+
+    with pytest.raises(ValueError) as excinfo:
+        manager._verify_exact_candidate(job, git_runner=git_runner)
+    assert "#629" in str(excinfo.value)
+    assert "unreadable by manager" in str(excinfo.value)
+
+
+def test_workflow_candidate_verification_keeps_the_original_message_otherwise() -> None:
+    """不是權限問題時訊息一字未變（既有處置與既有稽核字串不受影響）。"""
+
+    job = {
+        "subject_head": "b" * 40,
+        "worktree": "/tmp/does-not-matter",
+        "persona": "builder",
+    }
+
+    def git_runner(argv, **_kwargs):
+        return SimpleNamespace(returncode=1, stdout="", stderr="fatal: not a git repository")
+
+    with pytest.raises(ValueError, match="workflow candidate does not exist"):
+        manager._verify_exact_candidate(job, git_runner=git_runner)
+
+
+def test_reviewer_lane_never_reads_the_reviewer_worktree() -> None:
+    """reviewer 側同型殘留的複驗：candidate 驗證讀的是 Manager 自己的來源樹。
+
+    `_verify_exact_candidate` 對 reviewer persona 取 `workflow_repo_root`（
+    `repo-source-tree`，Manager-owned）而不是 `worktree`——因此 reviewer 的工作樹
+    從頭到尾沒有被 Manager 讀過，#641 的問題在這條 lane 上不存在。
+    """
+
+    seen: list[str] = []
+
+    def git_runner(argv, **_kwargs):
+        seen.append(argv[2])
+        return _git_ok("b" * 40)
+
+    job = {
+        "subject_head": "b" * 40,
+        "persona": "reviewer",
+        "workflow_repo_root": "/var/lib/cortex/repos/paulsha-cortex",
+        "worktree": "/var/lib/cortex/worktree/reviewer-job-0001",
+    }
+    assert manager._verify_exact_candidate(job, git_runner=git_runner) == "b" * 40
+    assert seen and all(path == "/var/lib/cortex/repos/paulsha-cortex" for path in seen)

--- a/tests/test_trust_root_permgen_traverse_620.py
+++ b/tests/test_trust_root_permgen_traverse_620.py
@@ -31,7 +31,14 @@ from paulsha_cortex.trust_root.permgen import (
 )
 from paulsha_cortex.trust_root.permgen import THREE_WAY_SCHEME as _THREE_WAY_BASE
 from paulsha_cortex.trust_root.permgen import TWO_WAY_SCHEME as _TWO_WAY_BASE
-from paulsha_cortex.trust_root.registry import Principal
+from paulsha_cortex.trust_root.registry import (
+    ASSET_REGISTRY,
+    AssetTier,
+    IngressKind,
+    Principal,
+    TrustRootAsset,
+    TrustTree,
+)
 
 #: #626：`operator` 與 `external` 是**部署決定**，模組層方案刻意留 `None`，未注入時
 #: 產生器 fail-closed。traverse 推導的驗收本來就涵蓋這兩個帳號的中間層授權
@@ -241,15 +248,48 @@ def test_owner_of_the_leaf_never_gets_a_redundant_grant() -> None:
 
 
 def test_unknown_intermediate_directory_is_fail_closed() -> None:
-    """登記表／骨架都沒描述的中間層（job 自建的 `<worktree>/.cortex`）保守視為
-    不可 traverse——寧可多產一條 `--x`，也不要漏掉而讓正向路徑靜默斷掉。"""
+    """登記表／骨架都沒描述的中間層保守視為不可 traverse——寧可多產一條 `--x`，
+    也不要漏掉而讓正向路徑靜默斷掉。
+
+    #641 之前這條以 `work-items-yaml`（落點 `<job 樹>/.cortex/work-items.yaml`）
+    當實例，因為它是當時登記表裡唯一「跨帳號 ACL 的路徑經過一個沒人描述的中間層」
+    的資產。#641 收掉 job 樹上全部三條跨帳號讀取 ACL 之後，登記表**剛好**沒有這種
+    資產了——但被驗的性質（`can_traverse(None, …) is False` ⇒ 導出一條 `--x`）完全
+    沒變。因此改以**合成資產**驗，不再綁在某一項登記表資料上：那個耦合正是這條測試
+    會隨無關變更一起紅掉的原因。
+    """
     assert can_traverse(None, "cortex-builder", THREE_WAY_SCHEME) is False
-    grants = derive_traverse_grants(
-        generate_plan(THREE_WAY_SCHEME), scheme=THREE_WAY_SCHEME
+
+    synthetic = TrustRootAsset(
+        "synthetic-nested-leaf", AssetTier.TIER_1, TrustTree.MANAGER_OWNED, None,
+        (Principal.MANAGER,), (Principal.MANAGER, Principal.BUILDER),
+        IngressKind.MANAGER_INTERNAL,
     )
-    hidden = [g for g in grants if g.path.endswith("/.cortex")]
-    assert hidden, "work-items.yaml 的 .cortex 中間層必須被推導出來"
-    assert hidden[0].account == THREE_WAY_SCHEME.durable_state_owner
+    nested = f"{DEFAULT_LAYOUT.coordinator_root}/undescribed/leaf.json"
+    plan = generate_plan(THREE_WAY_SCHEME, ASSET_REGISTRY + (synthetic,))
+    grants = derive_traverse_grants(
+        plan,
+        scheme=THREE_WAY_SCHEME,
+        path_of={**permgen.asset_paths(), "synthetic-nested-leaf": nested},
+    )
+    hidden = [g for g in grants if g.path.endswith("/undescribed")]
+    assert hidden, "沒人描述的中間層必須被推導出一條 traverse"
+    assert hidden[0].account == THREE_WAY_SCHEME.resolve(Principal.BUILDER)
+
+
+def test_no_traverse_grant_reaches_into_a_job_worktree() -> None:
+    """#641：job 的工作樹底下不得有任何導出的 traverse 授權。
+
+    traverse 是機械導出的（#620）——只要登記表在 job 樹裡留下**任何一條**跨帳號
+    ACL，`<job 樹>` 乃至其子目錄就會自動被補上 `--x`。因此「收掉 `repo-worktree`
+    的 `rX`」若沒有把 `review-verdict`／`work-items-yaml` 一起收掉，洞會從 traverse
+    這一側自己長回來。這條就是釘住那件事。
+    """
+    job_root = permgen.asset_paths()["repo-worktree"]
+    for scheme in ALL_SCHEMES:
+        grants = derive_traverse_grants(generate_plan(scheme), scheme=scheme)
+        intruders = [g for g in grants if g.path == job_root or g.path.startswith(job_root + "/")]
+        assert not intruders, (scheme.scheme_id, [(g.path, g.account, g.required_by) for g in intruders])
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## 摘要

登記表資產 `repo-worktree` 仍授 `setfacl -m u:cortex-manager:rX /var/lib/cortex/worktree/<job-id>`，
rationale 是「trusted reader（Manager）以唯讀 ACL 讀取（**交換面沿用 D2 git 讀**）」。
**#637 已經把那個交換面整條換掉**：builder 產 bundle → append-only `commit-spool` →
Manager 從**檔案** fetch，並為此加了不變式測試
`test_manager_never_touches_the_builder_clone_while_harvesting`。

operator 0817 實機複驗因此抓到一個測試與部署互相矛盾的狀態：

```
只有 0700、無 ACL          → Manager `ls` 得到 Permission denied（#637 的不變式成立）
套上登記表要求的那條 ACL    → Manager 讀得到（同一條不變式在實機上不成立）
```

本 PR 依 operator 裁決**收掉那條 ACL**，並逐條處理它牽動的兩個決定。

## 我選的方向：**1（搬到 #629 的第三執行身分）**，完整論證

### 為什麼不是方向 3（保留 ACL、改寫 rationale）

因為那條 ACL 唯一還在使用的消費端，是一個**不該以那種形式存在**的消費端。

`coordinator/verification.py` 對 job 工作樹做的**不只**是 `rev-parse HEAD` 與
`status --porcelain`。同一個 `worktree` 還被當成 `cwd` 去**執行**宣告出來的命令：

```python
check_cwd     = _resolve_worktree_cwd(worktree, check["cwd"])       # :892
test_cwd      = _resolve_worktree_cwd(worktree, test_spec["cwd"])   # :910
candidate_cwd = _resolve_worktree_cwd(worktree, contract["full_suite"]["cwd"])  # :949
```

`pytest` 會載入該樹的 `conftest.py`／plugin，而那棵樹的內容 builder 完全掌控
（`write_paths: ["**"]`）——**等於 builder 在 `cortex-manager` 身分下取得任意程式碼
執行**。這正是 #629 存在的理由，同一段論證早已寫在 `gate-ledger` 的 note 與
`launcher._should_run_gates` 的 docstring 裡，只是當時只點名 gate、沒點名
verification。

因此「保留 ACL 並把真正的消費者寫進 rationale」會變成：**把一條提權路徑的成立條件
寫成正式授權**。收掉它不是「拿掉一個沒用的東西」，而是**移除該路徑的成立條件**
——沒有那條 ACL，那些命令在三分下連 spawn 都不會成功。

### 為什麼不是方向 2（改由 bundle 側取得等價保證）

逐條看那組檢查在 bundle 模型下還剩什麼：

| 檢查 | 理由碼 | bundle 側有沒有等價保證 |
|---|---|---|
| worktree HEAD == candidate | `candidate-worktree-mismatch` | **形式上有、實質上退化**。bundle 是 `git bundle create <file> "$(git symbolic-ref HEAD)" ^refs/cortex/base` 產的，所以 branch tip 恆等於 builder 產 bundle 當下的 HEAD；`_harvest_build_candidate` 也已釘住「回收後來源樹的 branch 必須恰等於已採信的 candidate」。**但兩邊同源**——bundle 的內容也是 builder 產的，用它去驗「builder 的 HEAD 是什麼」等於讓 builder 自己回答。#637 的 PR body 已寫下同一個結論。 |
| 工作樹乾淨 | `candidate-worktree-dirty` | **沒有，而且不可能有**。bundle 只帶 commit；「工作樹裡有未提交的東西」正是 bundle 定義上會丟掉的資訊。這條守的是「跑 gate 的那棵樹 == 要交出去的那個 commit」——gate 是在工作樹上跑的（見上），工作樹髒就代表證據對應的不是那個 commit。這在 bundle 模型下**語意沒有變得冗餘，只是變得無法從 bundle 觀測**。 |
| verification 後的複驗（`:1014-1027`） | `-dirty-after-verification`／`-moved-after-verification` | **沒有**。它守的是「跑完 full-suite 之後那棵樹沒被動過」——一個**時間點**的性質，bundle 是更早的一張快照，證不了這件事。 |

三條裡有兩條在 bundle 模型下沒有等價替代品，第三條有也是退化的。所以**不能整組
搬到 bundle 側**，也不該逐條刪。

### 為什麼方向 1 成立、且代價是零

「在 builder 的工作區裡跑檢查，但不以 Manager 也不以 builder 身分」正是 #629 要解的
問題本身。那組檢查的正確落點就是它。

**在 #629 之前這條 lane 沒有回歸**：三分部署下 build 卡本來就因 `require_ledger`
而 `gate-ledger-missing` fail-closed（#629 issue 本文明載「`PSC_JOB_RUNNER=systemd-template`
下 build 卡恆 fail closed」），根本走不到 verification。`direct` 模式與所有既有
測試環境下 Manager 就是工作樹的 owner，一位元都沒變（全套測試零回歸）。

**絕對不做的那件事**：讓 builder 自報「我的工作樹是乾淨的」。這三條 MUST NOT 已
逐字寫進 `verification.py` 的模組註解，以免日後被「順手修好」：

1. 不得靜默略過——略過等於一張 build 卡沒有任何人檢查過工作樹狀態就往下走；
2. 不得改讀 bundle 替代——同源，檢查會退化成「builder 說什麼就是什麼」；
3. 不得讓 builder 自報——違反 #540 的 acceptance chain 與 #628 收斂好的作者歸屬。

## verification 那組檢查最後怎麼處理

**明確 fail-closed，理由碼指向 #629。** 既有的三個理由碼保留給「那棵樹壞了」；
失敗**是權限造成的**時改回專屬理由碼：

```
summary: candidate-worktree-unreadable-pending-gate-identity
details.candidate_worktree_blocked:
  blocked_on: "#629"
  detail: "…必須改由 #629 的第三執行身分在受控 checkout 執行；在那之前一律
           fail-closed。處置：等 #629，或在 PSC_JOB_RUNNER=direct 下重跑這張卡。
           不得放寬 repo-worktree 的權限、不得改以 bundle 內容替代、不得採信
           builder 自報的工作樹狀態。"
  git: { …逐字保留 git 的原始 stderr… }
```

四個讀取點全部走同一條規則：`:725`（HEAD）、`:733`（status）、`:1014`（複驗
status）、`:1027`（複驗 HEAD）。判定走 stderr 的字串比對而不是只看 returncode
——非零 returncode 也可能是「這不是一個 repo」，那是完全不同的處置（
`test_a_plain_broken_worktree_keeps_the_original_reason` 釘住這個分界）。

**掛點的位置是有意義的**：`:725` 是整個 `run_result_verification` **第一個**碰到
job 工作樹的動作——排在 harvest 之後、任何 `cwd=<job 樹>` 的命令執行之前。因此讀
不到時，**沒有任何 builder 掌控的程式碼被以 Manager 身分執行過**
（`test_verification_fails_closed_with_a_reason_pointing_at_629` 以一個「被呼叫就
`AssertionError`」的 subprocess runner 釘住這件事）。

**canonical lane 同一處理**：`manager._verify_exact_candidate` 與
`_verify_build_candidate_transition` 也是 Manager 伸手進 builder 的樹。處置**一格
未變**（照樣 raise、照樣 fail-closed），只是訊息從那個部署形態下毫無意義的
「workflow candidate does not exist」換成指得出下一步的字串。非權限失敗時訊息
一字未變。

## 一併確認的兩件事

### 1. `dispatch-worktree-pool`（容器層 `0701`）

**沒有其他為「Manager 讀 job 樹」而設的授權。** 產生器對它只出
`install -d`／`chown`／`chmod`，零 `setfacl`。`0701` 的語意是「別的帳號只能
traverse 進自己那格、列不出目錄」；Manager 是容器的 owner，本來就進得了容器，但
每個 per-job 子目錄是 `0700 <job 帳號>`——收掉 `repo-worktree` 的 `rX` 之後
Manager 就到此為止。已加測試釘住。

### 2. reviewer／planner 側同型殘留：**有，而且不只一條**

盤完整個登記表，job 樹底下原本有 **三條**同型授權，全部出自 permgen「單一 job
writer」分支那一句共用 rationale：

| 資產 | 落點 | 原授權 | 真正的消費者 | 結論 |
|---|---|---|---|---|
| `repo-worktree` | `<job 樹>` | `u:<manager>:rX` | 已改 bundle（#637）；殘留讀取端＝verification（見上） | **收掉** |
| `review-verdict` | `<job 樹>/.psc-review-verdict.json` | `u:<manager>:r` | 權威通道是 `review-verdict-spool`（#599／#639） | **收掉** |
| `work-items-yaml` | `<job 樹>/.cortex/work-items.yaml` | `u:<manager>:r` | monitor 讀的是**來源樹**那一份 | **收掉** |

**`review-verdict` 的論證**：它是 legacy fallback，只對「Phase 2a 之前派工、job row
無 `review_verdict_channel` 標記」的 reviewer job 生效——`_review_verdict_source()`
對帶 `spool` 標記的 job **只**認 spool、明確不回退讀 worktree。而 per-job ACL 只存在
於 Phase 2b（三分）部署，那台機器派出的每個 reviewer job 都帶標記。所以**那條授權
在它會被套用的部署上永遠沒有消費者**。改宣告 `readers=(REVIEWER,)`：這個檔今天唯一
的讀者就是擁有它的那個 job 帳號自己。

**`work-items-yaml` 的論證**：`PathLayout` 把它落在 job 樹裡（那裡才有不受信任的
writer），但 monitor 讀的**不是那一份**——`correlation.load_work_item_overrides(repo_root)`
與 `work_actions._work_override_action` 都以 **Manager 進程自己的 `PSC_REPO_ROOT`**
為根，也就是 `repo-source-tree`（Manager-owned，monitor 已列在該項的 readers 裡）。
builder 對這個檔的修改是 **git-tracked** 的，因此循 #637 的 bundle 回到來源樹——
以 commit 旅行，不以跨帳號檔案讀取旅行。

**為什麼三條必須一起收（機械理由，不是潔癖）**：traverse ACL 是由跨帳號 ACL
**機械導出**的（#620）。只收 `repo-worktree` 一條，剩下兩條會讓
`<job 樹>`／`<job 樹>/.cortex` 的 `--x` 自己長回來——洞從 traverse 那一側復原。
已加測試 `test_no_traverse_grant_reaches_into_a_job_worktree` 與突變驗證
`test_the_pre_641_shape_reopens_the_derived_traverse_into_the_job_tree` 釘住。

**其餘 reviewer 側複驗**：`_verify_exact_candidate` 對 reviewer persona 取的是
`workflow_repo_root`（`repo-source-tree`，Manager-owned）而不是 reviewer 的工作樹，
verdict 走 spool——reviewer 的工作樹從頭到尾沒有被 Manager 讀過。已加測試。

## 改動

**登記表（壓在 `repo-worktree` 那一項附近）**：三項的 `readers` 改為擁有它的 job
persona 自己，note 逐項補上完整論證。**沒有新增或刪除任何資產、沒有動 `PathLayout`、
沒有動 permgen 的 UID scheme 或 unit 產生器**——與 #640 的改動面不重疊（見下）。

**permgen**：「單一 job writer」分支的 rationale 條件化。原本無條件宣稱「trusted
reader（Manager）以唯讀 ACL 讀取（交換面沿用 D2 git 讀）」，現在依實際有沒有產生
ACL 分岔——operator review 的就是那一行，它不能在「這一項其實沒有任何跨帳號授權」
時還宣稱有。產生的權限 script 對 job 樹從 5 條命令降為 3 條：

```
# [TIER_1] repo-worktree (job) — job-visible 單一 writer：owner＝對應 job 帳號可寫。
#   **owner-only、零跨帳號 ACL**：成果交付走 spool（builder→`commit-spool` 的 bundle、
#   reviewer→`review-verdict-spool` 的 verdict），Manager 不讀 job 的樹（#637／#641）。
#   install -d /var/lib/cortex/worktree/<job-id>
#   chown cortex-builder:cortex-builder /var/lib/cortex/worktree/<job-id>
#   chmod 0700 /var/lib/cortex/worktree/<job-id>
```

**未動 `coordinator/job_workspace.py`**（#637／#639 的成果），未動
`config/paths.py`、未動 `trust_root/permgen.py` 的 layout／scheme／unit 產生器。

## 測試

新增 `tests/test_manager_worktree_acl_641.py`（31 測試）：

- **登記表／權限計畫**（任何環境都跑）——job 樹底下零跨帳號 ACL（兩個 scheme 各驗
  一次）、`repo-worktree` 是 owner-only `0700`、宣告層三項都不再含 Manager／Monitor、
  容器層 `0701` 零 ACL。另有一條**涵蓋守衛**（`test_the_job_tree_invariant_actually_covers_something`）
  ——上面那些若因為「job 樹底下一項資產都沒有」而空過，就什麼也沒證明。
- **產生器輸出**——連**註解掉的 per-job 段**一起檢查（那些是降權啟動器逐案要套的，
  不看就等於沒驗）；反向守衛釘住 `chown`／`chmod` 仍在（不是整段被刪掉）；
  rationale 不得再出現「D2 git 讀」／「trusted reader」。
- **OS 層不變式**——照登記表建出 `0700 <job uid>` 的樹，另一個 uid `listdir`／`open`
  **必須被拒**，而 job 帳號自己讀得到（不是把整棵樹鎖到誰都不能用）。
- **verification**——讀不到時 needs_human ＋ 專屬理由碼 ＋ `blocked_on: "#629"` ＋
  可操作處置文字，且 `subprocess_runner` 一次都沒被呼叫；不靜默通過（checks／tests
  全空、full_suite 仍是 skipped）；讀不到之後就停手不再嘗試第二次；非權限失敗時
  理由碼不得被換掉。
- **canonical lane**——`_verify_exact_candidate` 被拒時訊息帶 `#629`；非權限失敗時
  訊息一字未變；reviewer lane 讀的是來源樹。

### 注意 #638 的教訓：單 UID 測不出來的一律明確 skip

「Manager 讀不到 job 工作樹」是 **OS 層語意**——單 UID 環境下 owner 就是自己，這條
不變式在那裡**沒有可驗的語意**。那正是 #637 CI 全綠卻在實機第一步就斷掉的形狀。
因此跨 UID 那兩條需要 root 才借得到兩個身分，非 root 時 `skipif` **明確 skip 並附
理由**（理由字串逐字說明「刻意 skip 而非空過，結構性保證由權限計畫／產生器斷言
承擔」），絕不靜默通過。已以 root 實跑通過。

### 突變驗證（四組，全部實跑）

| 突變 | 結果 |
|---|---|
| `repo-worktree` 的 reader 改回 `MANAGER` | **7 條紅**（兩個 scheme 的 ACL 不變式、產生器輸出、宣告層、rationale） |
| 只把 `work-items-yaml` 改回 `MONITOR` | **6 條紅**，含 `test_no_traverse_grant_reaches_into_a_job_worktree`——證明 traverse 真的會自己長回來 |
| 拿掉 `worktree_read_blocked()` 的偵測 | **6 條紅**（理由碼退回泛用值、canonical lane 訊息不再帶 #629） |
| OS 層：把修法前那條 `u:<manager>:rX` 以 xattr 套回去 | 讀取從**被拒**轉為**成功**——證明該 fixture 分辨得出兩種形狀，不是因為建錯東西才紅 |

另修 `tests/test_trust_root_permgen_traverse_620.py::test_unknown_intermediate_directory_is_fail_closed`：
它原本以 `work-items-yaml` 當實例（當時登記表裡唯一「跨帳號 ACL 的路徑經過一個沒人
描述的中間層」的資產）。被驗的性質沒變，改以**合成資產**驗——那個對登記表資料的
耦合正是它會隨無關變更一起紅掉的原因。

```
python3 -m pytest tests/ -q
3834 passed, 4 skipped, 49 subtests passed      # rebase 到 #642 之上；零回歸
                                                # 4 skipped＝#638 既有 2 條 ＋ 本次 2 條 root-only

sudo python3 -m pytest tests/test_manager_worktree_acl_641.py -q
31 passed                                        # root 下跨 UID 那 2 條實跑通過
```

## docs

- spec §R1 新增「job 工作樹對 Manager 完全不可讀（#641，0817 裁決）」一節（三項的
  逐條論證 ＋ verification 的 SHALL／MUST NOT）；
- 修正 §背景資產盤點表的 worktree 那一列與 Phase 2 roadmap 第 6 條——兩處都還寫著
  「Manager 改走 git 讀（沿用 D2）」，那是被 #637 取代掉的交換面；
- runbook 第 2b 步新增**稽核 5b**：`grep setfacl … /var/lib/cortex/worktree/` 期望
  空輸出（連註解掉的 per-job 行一起看），並說明非空輸出＝部署樹比 #641 舊。

## 與 #642（#640）的關係：已 rebase，並逐條回應它帶進來的三件事

已 `git rebase origin/main`（`0c7fd48`）。**零衝突**：#642 新增的兩個資產
（`executor-toolchain` 在 `<deploy_root>/toolchain`、`builder-executor-credential`
在 builder HOME 下）都**不在** job 工作樹底下，本 PR 只改登記表三個既有項的 `readers`
欄與 note，加上 `permgen.build_entry()` 裡「單一 job writer」分支的 rationale 字串。

而且是**機械性**地不受影響：`test_no_cross_account_grant_anywhere_inside_a_job_worktree`
掃的是「落點在 job 樹底下的**每一項**」，不是一份硬編碼的 asset_id 清單——日後任何
新資產只要落進 job 樹並宣告跨帳號 reader，它就會紅。

### 1. `Environment=PATH=` 在 job unit 上無效（shim 的 `execvpe` 會整份換掉環境）

**不影響本 PR 的方向，因為本 PR 不新增任何執行面。** 方向 1 做的事情正好相反：它
讓 verification 在三分下**不執行**任何東西（讀不到工作樹就當場停手，`subprocess_runner`
一次都不會被呼叫——已有測試以「被呼叫就 `AssertionError`」的 runner 釘住）。

這條對 **#629** 是關鍵前提，值得先記下來：#629 的第三執行身分要真的跑起宣告的 gate
命令，它的 PATH 必須進到**傳給 `execvpe` 的那份 env**（比照 `PSC_BUILDER_PATH`
的做法），寫在 unit 的 `Environment=PATH=` 會是一個看起來承載作用、實際被丟掉的設定。
本 PR 的 fail-closed 訊息因此只指向 #629，不預設它會怎麼傳環境。

### 2. `IN_PLACE_CONTENT_WRITE_ASSETS`（RWP 掛檔案本身而非父目錄）

**本 PR 用不到，這是刻意的。** 那個模式解的是「要給某個帳號一小塊精確授權」；本 PR
的方向是**收窄**——三項的結論都是 owner-only、零跨帳號 ACL，沒有任何「要精確授予
一小塊」的需求。硬套它會變成「發明一條新的、更窄的讀取權」，而本票的整個論證是
**那個消費者根本不該存在於 Manager 身分底下**。

同樣值得留給 #629：若第三執行身分最後需要對 job 工作樹的某一小塊有精確授權，
`IN_PLACE_CONTENT_WRITE_ASSETS` 是既有模式，不必自創。

### 3. 「結論若依賴某個檢查在加固面下跑得起來，要在真實加固面驗過」

**本 PR 的結論不依賴那件事，依賴的是它的反面**——三分下 Manager **不該**在 job 的
樹裡跑任何東西。因此沒有「在寬鬆環境測 `--help` 就宣告可行」的等價風險。

需要實機語意的兩件事都已在**真實 OS 面**驗過，不是在假物件上驗的：

| 主張 | 怎麼驗的 |
|---|---|
| 照登記表建出來的樹，別的 uid 真的讀不到 | root ＋ 兩個真實 uid（60011／60012）在真實檔案系統上跑 `listdir`／`open`，正向反向各一，再加「把舊 ACL 以 `system.posix_acl_access` xattr 套回去就讀得到」的突變對照 |
| 理由碼的判定字串就是 git 實際吐的那句 | git 2.43.0，對一個 `0700`、屬於別的 uid 的**真實 repo** 跑 `rev-parse HEAD`／`status --porcelain`／`merge-base --is-ancestor`——三者逐字都是 `fatal: cannot change to '<dir>': Permission denied`，rc 皆 128 |

**誠實邊界**：本 PR 沒有、也不需要在 `MemoryDenyWriteExecute=yes` 那類 systemd 加固面
下複跑——它不啟動任何 unit。#642 第 4e 步那條風險（node 的 V8 JIT 可能被
`MemoryDenyWriteExecute=yes` 擋掉）屬 executor 的執行面，與本 PR 不相交；但它會落在
**#629** 頭上：第三執行身分若以模板 unit 起 `pytest`，同一條加固面風險必須在那裡實驗。

### merge 順序

本 PR 已 rebase 到 #642 之上，可直接 merge。後續任何再動登記表的 PR 請注意：
**新增的資產若落在 job 工作樹底下且宣告了跨帳號 reader，
`test_no_cross_account_grant_anywhere_inside_a_job_worktree` 會紅**——那是刻意的，
不是衝突。屆時請依本 PR 的規則逐條論證該 reader 的真實消費者，或把交付通道改走 spool。

## 已知邊界（本 PR 不收）

1. **`verification` 那組檢查仍未真正搬家**——本 PR 只讓它在三分下明確 fail-closed
   並指名 #629。真正的搬遷（獨立降權執行身分、受控 checkout、產出落 Manager-owned 樹）
   屬 #629。
2. **`work-items-yaml` 的 layout 落點**——它一個 asset id 對應兩個實體位置（來源樹
   那一份與 job 樹那一份），`PathLayout` 只能選一個。本 PR 維持既有選擇（job 樹，
   因為不受信任的 writer 在那裡），把「monitor 讀的是另一份」寫進 note；要不要把它
   拆成兩項屬後續票。
3. **`review-verdict` 的除役**——legacy fallback 分支本身仍在（`direct` 模式下的
   in-flight job 還可能用到）。本 PR 只收它在 Phase 2b 下的 ACL；分支除役屬過渡期
   結束後的另一票。

## Checklist

- [x] 分支從 `main` 開，命名 `feature/641-drop-manager-worktree-acl`
- [x] `changelog.d/drop-manager-worktree-acl.md` fragment 已新增且**已 commit**
- [x] `CHANGELOG.md [Unreleased] → Fixed` 有對應 entry
- [x] `VERSION` 未動（非 release PR）
- [x] 全套測試通過（rebase 到 #642 之上：3834 passed, 4 skipped），零回歸
- [x] 新增「照登記表部署後 Manager 對 job 工作樹確實讀不到」的不變式，與 #637 的測試對齊
- [x] 採方向 1：那組檢查讀不到時**明確 fail-closed**且理由碼指向 #629，不是靜默通過
- [x] 涉及 OS 層語意、單 UID 測不出的不變式**明確 skip 並說明理由**（#638 的教訓）
- [x] 四組突變驗證全部實跑並記錄結果
- [x] `dispatch-worktree-pool` 容器層已複驗（零 `setfacl`）
- [x] reviewer／planner 側同型殘留已盤點並處理（`review-verdict`）
- [x] `python3 -m policy_check` 帶完整 PR 上下文跑過，fail: 0
- [x] 文件與 PR 內文為 zh-tw
- [x] 未動 `coordinator/job_workspace.py`（#637／#639 的成果）、未動 `config/paths.py`
- [x] 已 rebase 到 #642（`0c7fd48`）之上，零衝突；它帶進來的三件事已逐條回應

Closes #641
Refs #637 #639 #629 #620 #628 #540

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E7w9kaUxAzCCEk7piD5hfK
