### PR TITLE
fix(trust-root): worktree 目錄名改由 job id 導出，與模板 unit 的 %i 對齊

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,34 @@
   `tests/test_trust_root_job_template_ab.py`（80 測試）。
 
 ### Fixed
+- **#645 / trust-root：模板 unit 的 `%i` 與 worktree 目錄名永遠對不上——降權派工從未經
+  正式路徑成功啟動過任何 job**——`seams.ScriptWorktreeCreator.create()` 以 **branch
+  slug** 命名工作區（`feature/<slice_id>` → `<pool>/feature-<slice_id>`），而模板 unit 的
+  `ReadWritePaths=<pool>/%i` 期望的是 `job_runner.prepare_systemd_template()` 由 **job
+  id** 算出的 instance 名；兩者永遠差一個 `feature-` 前綴 ⇒ `ReadWritePaths` 指向不存在
+  的路徑 ⇒ systemd 建 mount namespace 直接失敗（`226/NAMESPACE`）。M1 的正向 smoke 用的
+  是**手工組的 job spec**（自然挑了與 instance 名相符的路徑），把這個 bug 繞過去了——
+  與 #584／#623 同一條方法論教訓：手工 spec 只能驗隔離，驗不了功能。
+  **修法（operator 裁決）改目錄名這一側，不改 instance 名**：模板 unit 只有 `%i` 可用、
+  推不出 branch slug，而「job 的工作區以 job id 定址」本來就與登記表既有的 per-job 模型
+  （spool／sentinel／gate ledger）一致。**branch 名完全不變**，只有磁碟上的目錄名改。
+  收斂為**單一推導點** `coordinator/job_workspace.py:job_segment(job_id)`——
+  `job_runner.template_instance_id()` 改為委派給它（形狀逐字不變，既有部署的 spec 檔名／
+  polkit pattern／unit 名皆不改變），`seams.create()` 加上**必填**的 `job_id` 關鍵字
+  （留預設值等於留一條「忘了傳就退回舊命名」的復發路徑）。新增
+  `tests/test_worktree_dir_naming_645.py` 直接比對兩個真實推導函式的輸出（不對常數斷言）、
+  一條突變守衛與一條接線測試；完整 `prepare_systemd_template()` 那一條需要 OS 層前置物，
+  單 UID 環境**明確 skip 並列出缺哪一項**（#638 的教訓）。
+  **既有殘留**：`gc`／`worktree_reclaim` 以**形狀**（標記檔／`.git` 檔）判斷、與名字無關，
+  舊目錄照樣回收得掉；真正會漏的 `recover-pre-candidate` 反推路徑（`manager` 與
+  `work_actions` 各一份）收斂到 `worktree_reclaim.reclaim_recorded_or_derived()`，
+  新舊兩種形狀都試，而形狀不明的目錄仍一律 fail-closed **不刪**。
+  **已知邊界**：canonical（workflow）lane 的工作區是 per-run 的（一個工作區對多個
+  job_id），「目錄名 ＝ 該 job 的 instance 名」在那裡結構上不可能成立；要在
+  `PSC_JOB_RUNNER=systemd-template` 下跑那條 lane，須先把工作區改成 per-job。
+  **附帶**：`permgen.build_job_unit()` 把 `CollectMode=inactive-or-failed` 由 `[Service]`
+  搬到 `[Unit]`——放錯段只被 systemd 忽略（`Unknown key name … ignoring.`），
+  「失敗的 instance 自動回收」的用意因此沒生效。
 - **#641 / trust-root：`repo-worktree` 仍授 Manager 唯讀 ACL——交換面已改 bundle，
   這條授權沒有消費者，卻讓 #637 的不變式在實機上不成立**——#637 把成果回收換成
   bundle ＋ append-only spool 並加了「Manager 全程不碰 builder 的 clone」不變式測試，

--- a/changelog.d/worktree-dir-naming.md
+++ b/changelog.d/worktree-dir-naming.md
@@ -1,0 +1,62 @@
+# worktree-dir-naming
+
+- **`#645`：模板 unit 的 `%i` 與 worktree 目錄名永遠對不上——降權派工從未經正式路徑
+  成功啟動過任何 job**——兩條命名鏈各自導出：`seams.ScriptWorktreeCreator.create()`
+  以 **branch slug** 命名工作區（`autonomy._branch_for_slice(slice_id)` →
+  `feature/<slice_id>` → 目錄 `<pool>/feature-<slice_id>`），而模板 unit 的
+  `ReadWritePaths=<pool>/%i`（permgen `with_job_segment("%i")`）期望的是
+  `job_runner.prepare_systemd_template(job_id=…)` 由 **job id** 算出的 instance 名。
+  兩者永遠差一個 `feature-` 前綴 ⇒ `ReadWritePaths` 指向不存在的路徑 ⇒ systemd 在建立
+  mount namespace 時就失敗（`Failed to set up mount namespacing: …: No such file or
+  directory`，`226/NAMESPACE`），job 連起都起不來。operator 0817 以**真實 dispatch
+  路徑**的功能 smoke 撞到；M1 的正向 smoke 用的是**手工組的 job spec**，而手工組時
+  自然會挑一個與 instance 名相符的 worktree 路徑，等於把這個 bug 繞過去（#584／#623
+  記錄的同一條方法論教訓：手工 spec 只能驗隔離，驗不了功能）。
+- **修法（operator 裁決）：改目錄名這一側，不改 instance 名**——模板 unit 只有 `%i`
+  可用、推不出 branch slug，所以要對齊只能讓目錄名讓步；而且「job 的工作區以 job id
+  定址」與登記表既有的 per-job 模型一致（spool、sentinel、gate ledger 全都以 job id
+  定址）。**branch 名完全不變**（仍是 `feature/<slice_id>`），只有磁碟上的目錄名改。
+- **單一推導點，不是「兩邊各自算、剛好相等」**——新增
+  `coordinator/job_workspace.py:job_segment(job_id)`，它是全 repo 唯一產生這個字串的
+  地方；`job_runner.template_instance_id()` 改為委派給它（形狀逐字不變，因此既有部署
+  的 spec spool 檔名、polkit pattern 與 unit 名都不改變），`job_runner.INSTANCE_NAME_RE`
+  改為別名到 `job_workspace.JOB_SEGMENT_RE`。`seams.ScriptWorktreeCreator.create()` 的
+  簽章加上**必填**的 `job_id` 關鍵字（`WorktreeCreator` 協定同步），目錄名一律由
+  `job_workspace.workspace_path()` 導出。留預設值等於留一條「忘了傳就退回舊命名」的
+  復發路徑，因此刻意不留。
+- **不變式測試**（本票的全部價值）：新增 `tests/test_worktree_dir_naming_645.py`——
+  直接比對**兩個真實推導函式**的輸出（真 git repo 上 provision 出來的目錄名 vs
+  `job_runner.template_instance_id()`），不對常數斷言；另加一條突變守衛（修法前的
+  branch-slug 目錄不得再出現）、一條接線測試（`autonomy._launcher_worktree()` 交給
+  provisioning 的 id，就是 `launch(slice_id=…)` 之後交給
+  `prepare_systemd_template(job_id=…)` 的那一個）。**完整 `prepare_systemd_template()`
+  的那一條**還會多跑一層 preflight（帳號／group／模板 unit／shim／spool），這些是 OS 層
+  前置物，單 UID 的開發機與 CI 沒有——比照 #638 的教訓**明確 skip 並列出缺哪一項**，
+  不靜默通過。
+- **既有部署的殘留（`feature-<slice_id>` 形狀的舊目錄）**：`gc.py` 與
+  `worktree_reclaim.py` 的判準本來就是**形狀**（`job_workspace` 標記檔／`.git` 檔）而不是
+  名字，兩者因此完全不受影響，舊目錄照樣掃得到、回收得掉。真正會漏的是
+  `manager.apply_slice_action` 與 `work_actions` 的 `recover-pre-candidate`：job／slice
+  記錄沒有 `worktree` 欄位時它們**由 branch slug 反推路徑**（第三、四個各自導出的來源）。
+  兩處收斂到新的 `worktree_reclaim.reclaim_recorded_or_derived()`——記錄有路徑就逐字用
+  它（行為與修法前相同），沒有才由 `job_workspace.reclaim_candidate_paths()` 反推，
+  **新舊兩種形狀都試**。少了這一步，升級當下磁碟上的舊殘留會被當成「不存在」而靜默
+  略過，下一次 provision 直接撞 `worktree target already exists`（#601 的生產現場）。
+  刪除仍完全走 `reclaim_worktree()` 的安全閘：**形狀不明的目錄一律 fail-closed，不刪**
+  （#478 的 `.project-policy.yml` 資料遺失回報）。
+- **canonical（workflow）lane 的已知邊界**：那條 lane 的工作區是 **per-run** 的——build
+  卡 provision 之後，同 run 後續的卡沿用 `builder_jobs[-1]["worktree"]`，一個工作區對
+  多個 job_id。因此「目錄名 ＝ 該 job 的 instance 名」在那裡**結構上不可能**成立，本次
+  只把它的目錄名同樣收進單一推導點（傳 run 層級的 build 身分），並在程式碼與 PR 上
+  明寫：canonical lane 要在 `PSC_JOB_RUNNER=systemd-template` 底下跑，得先把工作區從
+  per-run 改成 per-job。slice lane 沒有這個一對多，不變式在那裡成立且有測試守著。
+- **附帶（同一個 unit）**：`permgen.build_job_unit()` 把 `CollectMode=inactive-or-failed`
+  從 `[Service]` 搬到 `[Unit]`。實機 `systemd-analyze verify` 報
+  `Unknown key name 'CollectMode' in section 'Service', ignoring.`——語法不算錯，但
+  「失敗的 instance 自動回收」這個用意整個沒生效，失敗殘骸會一直掛在
+  `systemctl list-units --failed` 上、擋住同名 instance 的下一次 start。新增測試釘住
+  它落在 `[Unit]`、且同段的 `Restart=` 仍在 `[Service]`（確保不是整段被搬錯）。
+- **runbook**：`docs/superpowers/runbooks/trust-root-phase2b-setup.md` 第 5 步補兩條
+  `systemctl cat` / `systemd-analyze verify` 稽核（RWP 的 `%i` 與 `CollectMode`），並在
+  「5-6 正向驗證」前加上明確警語：那一段的 worktree 是 operator **手工**建在與 instance
+  名相符的路徑上，**通過不代表降權派工起得來**，必須另跑真實 dispatch 路徑的功能 smoke。

--- a/docs/superpowers/runbooks/trust-root-phase2b-setup.md
+++ b/docs/superpowers/runbooks/trust-root-phase2b-setup.md
@@ -1651,6 +1651,21 @@ systemctl cat cortex-job@.service | grep -E "^ExecStart="
 systemctl cat cortex-job@.service | grep -E "^Environment=PSC_JOB_SPEC_SPOOL="
 #   期望：Environment=PSC_JOB_SPEC_SPOOL=/var/lib/cortex/coordinator/job-specs
 
+# ✅ 檢查 job 工作區的 ReadWritePaths（#645）
+systemctl cat cortex-job@.service | grep -E "^ReadWritePaths=/var/lib/cortex/worktree/%i$"
+#   期望：命中。`%i` 這個 segment 與 provisioning 產生的**目錄名**是同一個推導點
+#   （`coordinator/job_workspace.py` 的 `job_segment(job_id)`，`job_runner`
+#   的 instance 名走的也是它）。#645 之前 provisioning 用的是 branch slug
+#   （`feature-<slice_id>`），與 `%i` 永遠差一個前綴 ⇒ ReadWritePaths 指向不存在
+#   的路徑 ⇒ `Failed to set up mount namespacing` / `226/NAMESPACE`，job 起不來。
+
+# ✅ 檢查 unit 沒有被忽略的鍵（#645 附帶）
+sudo systemd-analyze verify /etc/systemd/system/cortex-job@.service
+#   期望：**沒有** `Unknown key name 'CollectMode' in section 'Service', ignoring.`
+#   `CollectMode` 屬 `[Unit]`；放在 `[Service]` 只是被忽略（不影響行為），但
+#   「失敗的 instance 自動回收」這個用意不會生效，失敗殘骸會一直掛在
+#   `systemctl list-units --failed` 上、擋住同名 instance 的下一次 start。
+
 # 🔧 sudo：落檔（root 擁有、可執行、對三個服務帳號唯讀）
 sudo install -d -o root -g root -m 0755 /opt/cortex/bin
 sudo install -o root -g root -m 0755 /tmp/cortex-job-shim /opt/cortex/bin/cortex-job-shim
@@ -1754,6 +1769,15 @@ sudo -u cortex-manager env $(grep -v '^#' /opt/cortex/etc/cortex-manager.env | x
 > 行程內執行（見開頭「分段落地」）。
 
 ### 5-6. 正向驗證（**必須成功**）
+
+> **這一段只驗隔離，驗不了功能**（#645 的教訓）：底下的 worktree 是 operator
+> **手工**建在 `/var/lib/cortex/worktree/$JOB`——也就是刻意挑了一個與 instance 名
+> 相符的路徑。真實派工的工作區由 `seams.ScriptWorktreeCreator.create()` 產生，
+> instance 名由 `job_runner.prepare_systemd_template()` 產生；#645 之前這兩條鏈各自
+> 導出、永遠差一個 `feature-` 前綴，而手工組 spec 恰好把它繞過去。因此本步驟通過
+> **不代表**降權派工能起得來——請務必另跑一次**真實 dispatch 路徑**的功能 smoke。
+> 兩條鏈現已收斂到 `coordinator/job_workspace.py` 的 `job_segment()` 單一推導點，
+> 並由 `tests/test_worktree_dir_naming_645.py` 的不變式守著。
 
 ```bash
 JOB=selftest

--- a/paulsha_cortex/coordinator/autonomy.py
+++ b/paulsha_cortex/coordinator/autonomy.py
@@ -798,16 +798,25 @@ def _resolve_target_base_sha(
 
 
 def _launcher_worktree(dispatcher, slice_id: str, *, base_sha: str | None = None) -> str:
+    """provision 這條 slice 的 build 工作區。
+
+    #645：目錄名由 **slice_id** 導出（`job_workspace.job_segment()`），而
+    `launcher.launch(slice_id=…)` 又把同一個字串交給
+    `job_runner.prepare_systemd_template(job_id=…)` 產 instance 名——兩者因此是同一個
+    推導點的同一個輸出，模板 unit 的 `ReadWritePaths=<pool>/%i` 必然對得上。branch 名
+    仍是 `feature/<slice_id>`，只是不再決定目錄叫什麼。
+    """
+
     worktree_creator = getattr(dispatcher, "_worktree_creator", None)
     if worktree_creator is None:
         return str(Path.cwd())
     branch = _branch_for_slice(slice_id)
     if base_sha is None:
-        return worktree_creator.create(branch)
+        return worktree_creator.create(branch, job_id=slice_id)
     try:
-        return worktree_creator.create(branch, base_sha=base_sha)
+        return worktree_creator.create(branch, job_id=slice_id, base_sha=base_sha)
     except TypeError:
-        return worktree_creator.create(branch)
+        return worktree_creator.create(branch, job_id=slice_id)
 
 
 def _record_launching_job(

--- a/paulsha_cortex/coordinator/dispatcher.py
+++ b/paulsha_cortex/coordinator/dispatcher.py
@@ -145,10 +145,12 @@ class Dispatcher:
     ) -> dict[str, object]:
         branch = _branch_for_task(task)
         # (1) 先建 worktree；失敗則 raise（不送命令、不記 job — fail-closed）
+        #     #645：工作區目錄名由 job id 導出（本 lane 的 job id ＝ task），不再是
+        #     branch slug；`job_id` 為必填，因此 TypeError 退路也必須帶著它。
         try:
-            worktree = self._worktree_creator.create(branch, base_sha=base_sha)
+            worktree = self._worktree_creator.create(branch, job_id=task, base_sha=base_sha)
         except TypeError:
-            worktree = self._worktree_creator.create(branch)
+            worktree = self._worktree_creator.create(branch, job_id=task)
         # (2) 忠實轉送呼叫者給的完整 command（本 change 不組裝 copilot 指令）
         self._pane_sender.send(pane_id, command)
         # (3) 取 dispatch 當下的 branch head（baseline）；取不到記 None。

--- a/paulsha_cortex/coordinator/job_runner.py
+++ b/paulsha_cortex/coordinator/job_runner.py
@@ -107,6 +107,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable, Mapping, Sequence
 
+from . import job_workspace
 from .diagnostics import DiagnosticReason, diagnostic_reason
 
 __all__ = [
@@ -263,8 +264,10 @@ SPEC_FORBIDDEN_KEYS: frozenset[str] = frozenset(
 )
 
 #: systemd unit 實例名允許的字元。systemd 本身還允許更多（`/` 需 escape），這裡
-#: 刻意更窄：instance 名會被 polkit 的 unit pattern 比對，也會被拼成 spec 檔名。
-INSTANCE_NAME_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9_.-]{0,62}")
+#: 刻意更窄：instance 名會被 polkit 的 unit pattern 比對、被拼成 spec 檔名，**也是
+#: job 工作區在 pool 底下的目錄名**（#645）。因此形狀的真相在 `job_workspace`，
+#: 本模組只別名過來——兩份 pattern 就是兩個會漂移的來源。
+INSTANCE_NAME_RE = job_workspace.JOB_SEGMENT_RE
 
 
 # ---------------------------------------------------------------------------
@@ -862,37 +865,30 @@ def _await_start(
 def instance_name_valid(name: str) -> bool:
     """instance 名是否符合 :data:`INSTANCE_NAME_RE`（shim 端共用同一條判準）。"""
 
-    return bool(name) and INSTANCE_NAME_RE.fullmatch(name) is not None
+    return job_workspace.job_segment_valid(name)
 
 
 def template_instance_id(job_id: str) -> str:
     """job_id → systemd 模板實例名（`cortex-job@<這個>.service`）。
 
-    與 :func:`transient_unit_name` 同一套「可追蹤 ＋ 唯一」的推導，差別只在這裡
-    產出的是**實例名**而不是完整 unit 名：消毒後的可讀片段 ＋ job_id 的 sha256
-    前 8 碼（消毒後相同也不會撞名）。
+    **推導本身不在這裡**：唯一推導點是 :func:`job_workspace.job_segment`，因為同一個
+    字串同時是 job 工作區在 pool 底下的目錄名——模板 unit 只有 `%i` 可用，
+    `ReadWritePaths=<pool>/%i` 因此把「instance 名」與「目錄名」綁成同一個東西
+    （#645）。本函式只負責把那裡的錯誤翻成 `job_runner` 的診斷契約。
+
+    與 :func:`transient_unit_name` 同一套「可追蹤 ＋ 唯一」的形狀（消毒後的可讀片段
+    ＋ job_id 的 sha256 前 8 碼），差別只在這裡產出的是**實例名**而不是完整 unit 名。
     """
 
-    raw = str(job_id).strip()
-    if not raw:
+    try:
+        return job_workspace.job_segment(job_id)
+    except job_workspace.WorkspaceError as exc:
         raise _fail(
             "job-runner-instance-name-invalid",
-            "job_id 為空，無法組出可追蹤的模板實例名",
+            f"無法由 job_id 導出模板實例名: {exc}",
             source="template_instance_id",
-        )
-    slug = re.sub(r"[^A-Za-z0-9_.-]", "-", raw).strip("-")[:48]
-    digest = hashlib.sha256(raw.encode("utf-8")).hexdigest()[:8]
-    if not slug or not slug[0].isalnum():
-        slug = f"job{slug}" if slug else "job"
-    instance = f"{slug}-{digest}"
-    if not instance_name_valid(instance):
-        raise _fail(
-            "job-runner-instance-name-invalid",
-            f"推導出的模板實例名不合法: {instance!r}（job_id={raw!r}）",
-            source="template_instance_id",
-            job_id=raw,
-        )
-    return instance
+            job_id=str(job_id).strip(),
+        ) from exc
 
 
 def template_unit_name(instance: str, *, template: str = DEFAULT_TEMPLATE_UNIT) -> str:

--- a/paulsha_cortex/coordinator/job_workspace.py
+++ b/paulsha_cortex/coordinator/job_workspace.py
@@ -75,6 +75,7 @@ chain：model 既不能自證成功、也不能自證失敗）。bundle 內容�
 
 from __future__ import annotations
 
+import hashlib
 import json
 import re
 import shlex
@@ -143,8 +144,120 @@ _SHA_RE = re.compile(r"^[0-9a-f]{40}$")
 _SPOOL_KEY_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]{0,127}")
 
 
+#: per-job **具名片段**允許的字元。systemd unit 的 instance 名本身還允許更多
+#: （`/` 需 escape），這裡刻意更窄：同一個字串會被 polkit 的 unit pattern 比對、
+#: 被拼成 spec 檔名，也會成為 worktree pool 底下的一個目錄名。
+JOB_SEGMENT_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9_.-]{0,62}")
+
+
 class WorkspaceError(ValueError):
     """工作區 provision／回收的可操作錯誤。"""
+
+
+# ---------------------------------------------------------------------------
+# per-job 具名片段（#645：工作區目錄名 ＝ systemd 模板 instance 名，單一推導點）
+# ---------------------------------------------------------------------------
+
+def job_segment_valid(name: str) -> bool:
+    """`name` 是否符合 :data:`JOB_SEGMENT_RE`（shim 端共用同一條判準）。"""
+
+    return bool(name) and JOB_SEGMENT_RE.fullmatch(name) is not None
+
+
+def job_segment(job_id: str) -> str:
+    """job_id → 這個 job 的**具名片段**。全 repo 唯一的推導點。
+
+    這一個字串同時是三個東西，而它們必須**逐字相等**：
+
+    ==================================  ==========================================
+    用途                                 由誰讀
+    ==================================  ==========================================
+    工作區目錄名 `<pool>/<segment>`      `seams.ScriptWorktreeCreator.create()`
+    systemd 模板 instance 名             `job_runner.template_instance_id()`
+    模板 unit 的 `%i`                    `permgen.build_job_unit()` 產的
+                                        `ReadWritePaths=<pool>/%i`
+    ==================================  ==========================================
+
+    #645 的生產事故正是這三者曾經**各自推導**：provisioning 走 branch slug
+    （`feature/<slice_id>` → `feature-<slice_id>`）、instance 走 job_id，兩者永遠差一個
+    `feature-` 前綴，於是模板 unit 的 `ReadWritePaths` 指向一個不存在的路徑，systemd
+    連 mount namespace 都建不起來（`226/NAMESPACE`）——降權派工因此從未經正式路徑
+    成功啟動過任何 job。修法是把推導收斂成本函式；**呼叫端一律傳 job_id，不得自己
+    拼名字**（兩邊各自算、剛好相等，撐不過下一次改名）。
+
+    形狀：消毒後的可讀片段（保留可追蹤性）＋ job_id 的 sha256 前 8 碼（消毒後撞形
+    也不會撞名）。與 #616 起既有的 instance 名推導**逐字相同**，因此既有部署的
+    spec spool 檔名、polkit pattern 與 unit 名都不因本次變更而改變。
+    """
+
+    raw = str(job_id).strip()
+    if not raw:
+        raise WorkspaceError("job_id 為空，無法組出可追蹤的 per-job 片段")
+    slug = re.sub(r"[^A-Za-z0-9_.-]", "-", raw).strip("-")[:48]
+    digest = hashlib.sha256(raw.encode("utf-8")).hexdigest()[:8]
+    if not slug or not slug[0].isalnum():
+        slug = f"job{slug}" if slug else "job"
+    segment = f"{slug}-{digest}"
+    if not job_segment_valid(segment):
+        raise WorkspaceError(
+            f"推導出的 per-job 片段不合法: {segment!r}（job_id={raw!r}）"
+        )
+    return segment
+
+
+def workspace_path(pool_root: str | Path, job_id: str) -> Path:
+    """這個 job 的工作區絕對路徑：`<pool_root>/<job_segment(job_id)>`。"""
+
+    return Path(pool_root) / job_segment(job_id)
+
+
+def legacy_branch_slug(branch: str) -> str:
+    """#645 **之前**的工作區目錄名：`branch.replace("/", "-")`。
+
+    只給**回收／診斷**路徑用，provisioning 一律不得再產生這個形狀。既有部署的磁碟上
+    仍可能留著這種目錄（升級前 provision 的、或失敗殘留的），回收端必須認得它——
+    但認得不等於刪得掉：實際刪除仍走 `worktree_reclaim`／`gc` 的形狀判準
+    （標記檔或 `.git` 檔），認不出來的目錄一律 fail-closed，不刪。
+    """
+
+    return str(branch).replace("/", "-")
+
+
+def reclaim_candidate_paths(
+    pool_root: str | Path,
+    *,
+    job_id: str | None = None,
+    branch: str | None = None,
+) -> list[Path]:
+    """某個 job 的工作區**可能**落在哪些路徑（新形狀優先、保序去重）。
+
+    job／slice 記錄沒有 `worktree` 欄位時（舊列、或 provision 途中就炸掉），回收端只能
+    由 id／branch 反推。#645 換名之後「反推」必須同時涵蓋兩種形狀，否則升級當下磁碟上
+    的 `feature-<id>` 殘留會被回收端當成「不存在」而靜默略過，下一次 provision 就撞
+    `worktree target already exists`（#601 的生產現場）。
+
+    只回傳**候選路徑**，不做任何刪除判斷：呼叫端把每一條交給
+    `worktree_reclaim.reclaim_worktree()`，那裡的安全閘負責「不認得就不刪」。
+    """
+
+    root = Path(pool_root)
+    candidates: list[Path] = []
+    if job_id:
+        try:
+            candidates.append(workspace_path(root, job_id))
+        except WorkspaceError:
+            pass
+    if branch:
+        candidates.append(root / legacy_branch_slug(branch))
+    seen: set[str] = set()
+    unique: list[Path] = []
+    for path in candidates:
+        key = str(path)
+        if key in seen:
+            continue
+        seen.add(key)
+        unique.append(path)
+    return unique
 
 
 # ---------------------------------------------------------------------------
@@ -643,6 +756,7 @@ __all__ = [
     "BASE_REF",
     "COMMIT_BUNDLE_FILENAME",
     "COMMIT_BUNDLE_PART_SUFFIX",
+    "JOB_SEGMENT_RE",
     "MARKER_NAME",
     "MARKER_SCHEMA_VERSION",
     "SOURCE_REMOTE",
@@ -658,14 +772,19 @@ __all__ = [
     "harvest_if_spooled",
     "is_job_clone",
     "is_linked_worktree",
+    "job_segment",
+    "job_segment_valid",
+    "legacy_branch_slug",
     "list_clone_workspaces",
     "marker_path",
     "prepare_commit_spool",
     "read_marker",
+    "reclaim_candidate_paths",
     "remove_clone",
     "seal_commit_spool",
     "source_branch_head",
     "spool_key_for_job",
     "workspace_branch",
+    "workspace_path",
     "write_marker",
 ]

--- a/paulsha_cortex/coordinator/manager.py
+++ b/paulsha_cortex/coordinator/manager.py
@@ -1673,9 +1673,6 @@ def apply_slice_action(
                 pass
         if not wt_path:
             wt_path = slice_row.get("worktree")
-        if not wt_path and isinstance(slice_row.get("branch"), str):
-            slug = slice_row["branch"].replace("/", "-")
-            wt_path = str(Path(paths.worktree_root()) / slug)
 
         # #478：舊碼在 `runner is None`（生產 dispatcher 的合法狀態）時整段跳過
         # git 清理只 rmtree 目錄，registry 記錄留下來讓下一 tick 的
@@ -1683,18 +1680,31 @@ def apply_slice_action(
         # 「目錄已消失、registry 殘留」壞狀態永遠自癒不了。改走單一回收函式：
         # 預設 runner 由 `worktree_reclaim` 自行 fallback，後置條件（目錄不存在
         # ＋ registry 無該筆）驗證不過就 fail closed，不再回報 ok。
-        reclaim = None
-        if wt_path and isinstance(wt_path, (str, Path)):
-            reclaim = worktree_reclaim.reclaim_worktree(
-                wt_path,
-                git_runner=runner,
-                preserve_root=_reclaim_preserve_root(registry),
+        # #645：記錄沒有 worktree 時的反推改走共用 helper，新舊兩種目錄形狀都試。
+        # pool root **只在真的要反推時才解析**——`paths.worktree_root()` 在
+        # `PSC_REPO_ROOT` 未宣告時是 fail-closed 的（#612），記錄已有路徑卻因此炸掉
+        # 會讓回收比 #645 之前更脆弱。
+        recorded = wt_path if isinstance(wt_path, (str, Path)) and wt_path else None
+        pool_root = None
+        if recorded is None:
+            try:
+                pool_root = paths.worktree_root()
+            except Exception:
+                pool_root = None
+        branch_hint = slice_row.get("branch")
+        reclaim = worktree_reclaim.reclaim_recorded_or_derived(
+            recorded_path=recorded,
+            pool_root=pool_root,
+            job_id=slice_id,
+            branch=branch_hint if isinstance(branch_hint, str) else None,
+            git_runner=runner,
+            preserve_root=_reclaim_preserve_root(registry),
+        )
+        if reclaim is not None and not reclaim.ok:
+            raise RuntimeError(
+                "recover-pre-candidate worktree reclaim failed: "
+                f"{reclaim.detail or reclaim.status} ({reclaim.path})"
             )
-            if not reclaim.ok:
-                raise RuntimeError(
-                    "recover-pre-candidate worktree reclaim failed: "
-                    f"{reclaim.detail or reclaim.status} ({reclaim.path})"
-                )
 
         consumed_at = clock()
         registry.record_action(
@@ -8504,25 +8514,38 @@ def _dispatch_workflow_card(
             if (match := re.fullmatch(rf"{re.escape(run.repo)}#([1-9][0-9]*)", ref))
         ]
         primary_issue = min(issue_numbers) if issue_numbers else None
-        builder_branch = (
-            f"feature/{primary_issue}-{run.work_id}"
-            if primary_issue is not None
-            else f"feature/{run.work_id}"
+        builder_work_id = (
+            f"{primary_issue}-{run.work_id}" if primary_issue is not None else run.work_id
         )
-        # #208 收口 wiring 5（#211 閉環）：凍結集存在時 worktree 必須以
-        # frozen_readiness["base_sha"] 為基底，不得讓 dispatch 自行重新推導
-        # 一個可能更新鮮（或更陳舊）的 base（hippo #18 #2／#41 v2 的 stale-base
-        # 缺陷）。無凍結集時完全不傳 base_sha 引數，維持現行為（呼叫端保有舊
-        # WorktreeCreator 實作 without base_sha 亦不受影響）。
+        builder_branch = f"feature/{builder_work_id}"
+        # #645：工作區目錄名改由 id 導出（不再是 branch slug）。canonical lane 傳的是
+        # **run 層級的 build 身分**而不是某一個 job_id——這條 lane 的工作區是
+        # per-run 的：build 卡 provision 之後，同一個 run 後續的卡直接沿用
+        # `builder_jobs[-1]["worktree"]`（見本函式上方）。因此這裡的目錄名恆等於
+        # 「第一張 build 卡的 run 身分」，而 `job_runner.template_instance_id()` 算的是
+        # **每一個 job 自己的** id——兩者在 canonical lane 結構上就不可能逐字相等
+        # （一個工作區對多個 job）。slice lane（`autonomy._launcher_worktree`）沒有這個
+        # 一對多，因此 #645 的不變式在那裡成立且有測試守著。canonical lane 要在
+        # `PSC_JOB_RUNNER=systemd-template` 底下跑，需要先把「工作區 per-run」改成
+        # 「per-job」——那是另一票的事，本次不動。
         frozen_base_sha = None
         if isinstance(run.frozen_readiness, dict):
             candidate_base_sha = run.frozen_readiness.get("base_sha")
             if isinstance(candidate_base_sha, str) and candidate_base_sha:
                 frozen_base_sha = candidate_base_sha
+        # #208 收口 wiring 5（#211 閉環）：凍結集存在時 worktree 必須以
+        # frozen_readiness["base_sha"] 為基底，不得讓 dispatch 自行重新推導
+        # 一個可能更新鮮（或更陳舊）的 base（hippo #18 #2／#41 v2 的 stale-base
+        # 缺陷）。無凍結集時完全不傳 base_sha 引數，維持現行為（呼叫端保有舊
+        # WorktreeCreator 實作 without base_sha 亦不受影響）。
         if frozen_base_sha is not None:
-            worktree = str(creator.create(builder_branch, base_sha=frozen_base_sha))
+            worktree = str(
+                creator.create(
+                    builder_branch, job_id=builder_work_id, base_sha=frozen_base_sha
+                )
+            )
         else:
-            worktree = str(creator.create(builder_branch))
+            worktree = str(creator.create(builder_branch, job_id=builder_work_id))
     else:
         worktree = run.workspace_root
     effective_repo_root = Path(worktree).resolve()

--- a/paulsha_cortex/coordinator/seams.py
+++ b/paulsha_cortex/coordinator/seams.py
@@ -18,15 +18,20 @@ class PaneSender(Protocol):
 
 @runtime_checkable
 class WorktreeCreator(Protocol):
-    """為某分支建立 per-job git 工作區、回傳其路徑的 seam。
+    """為某 job 建立 per-job git 工作區、回傳其路徑的 seam。
 
     協定名沿用 ``WorktreeCreator``（以及 job 記錄的 ``worktree`` 欄位）：#623 之後
     實作已改為 per-job 完整 clone，但這兩個名字是**已持久化的契約**——job registry
     的既有列、以及注入 fake 的大量既有測試都靠它。改名不會讓任何東西更正確，只會
     製造一次不必要的資料遷移。實際的工作區模型見 `coordinator/job_workspace.py`。
+
+    ``job_id`` 是**必填**（#645）：目錄名由它經 `job_workspace.job_segment()` 導出，
+    而那同時是 systemd 模板的 instance 名。留一個預設值等於留一條「忘了傳就退回舊
+    命名」的路，那正是 #645 的復發面。``branch`` 仍是 branch——它決定 clone 出來
+    checkout 哪一條，**不再**決定目錄叫什麼。
     """
 
-    def create(self, branch: str, *, base_sha: str | None = None) -> str: ...
+    def create(self, branch: str, *, job_id: str, base_sha: str | None = None) -> str: ...
 
 
 class TmuxPaneSender:
@@ -89,6 +94,11 @@ class ScriptWorktreeCreator:
     任何一步失敗都會把**已做的變更全部還原**（部分 clone 目錄刪除、branch 回到
     provision 前的位置或刪除）——殘留正是 #601／#613 的生產現場。
 
+    **目錄名（#645）**：`<worktree_root>/<job_workspace.job_segment(job_id)>`。
+    #645 之前是 `<worktree_root>/<branch.replace("/", "-")>`，與模板 unit 期望的
+    `<worktree_root>/%i` 永遠差一個 `feature-` 前綴，systemd 建 mount namespace 直接
+    失敗（`226/NAMESPACE`）。branch 名不變，只有磁碟上的目錄名改。
+
     單元測試 MUST 注入 fake，不實體化此類。
     """
 
@@ -114,9 +124,13 @@ class ScriptWorktreeCreator:
     def _source(self, args: list[str]) -> subprocess.CompletedProcess[str]:
         return self._run(["-C", str(self._repo), *args])
 
-    def create(self, branch: str, *, base_sha: str | None = None) -> str:
-        slug = branch.replace("/", "-")
-        target = self._wt_root / slug
+    def create(self, branch: str, *, job_id: str, base_sha: str | None = None) -> str:
+        #: #645：目錄名由 **job id** 導出，不再是 branch slug。降權派工的模板 unit
+        #: 只有 `%i` 可用（`ReadWritePaths=<pool>/%i`），推不出 branch slug，因此
+        #: 兩個名字要對齊，只能讓目錄名這一側讓步。推導點只有
+        #: `job_workspace.job_segment()` 一個——`job_runner.template_instance_id()`
+        #: 走的是同一個函式，兩者因此不是「剛好相等」而是**同一個字串**。
+        target = job_workspace.workspace_path(self._wt_root, job_id)
         self._wt_root.mkdir(parents=True, exist_ok=True)
         base = base_sha or self._base
         #: provision 前的 branch 位置：None＝當時不存在。失敗時據此還原。

--- a/paulsha_cortex/coordinator/work_actions.py
+++ b/paulsha_cortex/coordinator/work_actions.py
@@ -3743,25 +3743,33 @@ def _recover_pre_candidate_action(
             pass
     if not wt_path:
         wt_path = target_slice.get("worktree")
-    if not wt_path and isinstance(target_slice.get("branch"), str):
-        slug = target_slice["branch"].replace("/", "-")
-        wt_path = str(Path(paths.worktree_root()) / slug)
 
     # #478：舊碼用裸 `subprocess.run(["git", "worktree", ...])`（無 `-C <repo>`，
     # 實際跑在 manager 進程的 cwd 上）、`check=False` 吞錯，且只在目錄還在時
     # 觸發——registry 殘留與「目錄已消失但 registry 還在」都清不掉。統一改走
     # `worktree_reclaim`，後置條件不成立即 fail closed。
-    reclaim = None
-    if wt_path and isinstance(wt_path, (str, Path)):
-        reclaim = worktree_reclaim.reclaim_worktree(
-            wt_path,
-            preserve_root=state_path.resolve().parent / "evidence",
+    # #645：記錄沒有 worktree 時的反推走共用 helper（與 `manager.apply_slice_action`
+    # 同一份），新舊兩種目錄形狀都試；pool root 只在真的要反推時才解析（#612）。
+    recorded = wt_path if isinstance(wt_path, (str, Path)) and wt_path else None
+    pool_root = None
+    if recorded is None:
+        try:
+            pool_root = paths.worktree_root()
+        except Exception:
+            pool_root = None
+    branch_hint = target_slice.get("branch")
+    reclaim = worktree_reclaim.reclaim_recorded_or_derived(
+        recorded_path=recorded,
+        pool_root=pool_root,
+        job_id=slice_id,
+        branch=branch_hint if isinstance(branch_hint, str) else None,
+        preserve_root=state_path.resolve().parent / "evidence",
+    )
+    if reclaim is not None and not reclaim.ok:
+        raise RuntimeError(
+            "recover-pre-candidate worktree reclaim failed: "
+            f"{reclaim.detail or reclaim.status} ({reclaim.path})"
         )
-        if not reclaim.ok:
-            raise RuntimeError(
-                "recover-pre-candidate worktree reclaim failed: "
-                f"{reclaim.detail or reclaim.status} ({reclaim.path})"
-            )
 
     actor = args.get("actor") or requested_by
     workflow_registry.record_action(

--- a/paulsha_cortex/coordinator/worktree_reclaim.py
+++ b/paulsha_cortex/coordinator/worktree_reclaim.py
@@ -478,6 +478,60 @@ def reclaim_worktree(
     )
 
 
+def reclaim_recorded_or_derived(
+    *,
+    recorded_path: str | Path | None = None,
+    pool_root: str | Path | None = None,
+    job_id: str | None = None,
+    branch: str | None = None,
+    git_runner: GitRunner | None = None,
+    repo_root: str | Path | None = None,
+    preserve_root: str | Path | None = None,
+) -> WorktreeReclaim | None:
+    """回收某個 slice 的 build 工作區——記錄有路徑就用它，沒有才反推。
+
+    `recover-pre-candidate` 有兩處實作（`manager.apply_slice_action` 與
+    `work_actions`），兩處都得回答同一個問題：「這條 slice 的工作區在哪」。收斂成
+    本函式，兩邊就不會在 #645 換名之後各自更新一半。
+
+    - **記錄有 `worktree`** → 逐字回收那一條，行為與 #645 之前完全相同。
+    - **記錄沒有** → 由 `job_workspace.reclaim_candidate_paths()` 反推候選：#645 之後
+      的 `<pool>/<job_segment(job_id)>` 與 #645 之前的 `<pool>/<branch slug>`。
+      **兩種形狀都要試**，否則升級當下磁碟上的舊目錄會被當成「不存在」而略過，
+      下一次 provision 直接撞 `worktree target already exists`（#601 的現場）。
+
+    回傳挑選規則：任一筆 `failed` → 回那一筆（呼叫端據此 fail closed）；否則有
+    實際回收到的 → 回那一筆；否則回第一筆（`absent`）；完全沒有候選 → None。
+    **不認得的目錄一律由 `reclaim_worktree()` 的安全閘擋下（回 failed），本函式不
+    會、也不得靜默刪除任何形狀不明的目錄。**
+    """
+
+    targets: list[Path] = []
+    if recorded_path and isinstance(recorded_path, (str, Path)):
+        targets = [Path(recorded_path)]
+    elif pool_root is not None:
+        targets = job_workspace.reclaim_candidate_paths(
+            pool_root, job_id=job_id, branch=branch
+        )
+    if not targets:
+        return None
+    results = reclaim_worktrees(
+        list(targets),
+        git_runner=git_runner,
+        repo_root=repo_root,
+        preserve_root=preserve_root,
+    )
+    if not results:
+        return None
+    for result in results:
+        if result.status == RECLAIM_FAILED:
+            return result
+    for result in results:
+        if result.status == RECLAIM_RECLAIMED:
+            return result
+    return results[0]
+
+
 def reclaim_worktrees(
     worktrees: list[str | Path],
     *,

--- a/paulsha_cortex/trust_root/permgen.py
+++ b/paulsha_cortex/trust_root/permgen.py
@@ -2334,6 +2334,12 @@ def build_job_unit(
         "[Unit]",
         "Description=cortex headless job %i (downgraded, trust-root Phase 2b)",
         f"After={layout.instance}-manager.service",
+        "# job 為一次性：結束即回收 unit 狀態，不留可被重用的殘骸。",
+        "# `CollectMode` 是 **[Unit] 的鍵**，不是 [Service] 的（#645 附帶修正）——放錯段",
+        "# systemd 只會 `Unknown key name 'CollectMode' in section 'Service', ignoring.`，",
+        "# 於是「失敗的 instance 自動回收」這個用意整個沒生效，失敗殘骸會一直掛在",
+        "# `systemctl list-units --failed` 上、擋住同名 instance 的下一次 start。",
+        "CollectMode=inactive-or-failed",
         "",
         "[Service]",
         "Type=exec",
@@ -2403,8 +2409,7 @@ def build_job_unit(
     body += _rwp_lines(owners)
     body += [
         "",
-        "# job 為一次性：結束即回收 unit 狀態，不留可被重用的殘骸。",
-        "CollectMode=inactive-or-failed",
+        "# job 為一次性，不自動重啟（`CollectMode` 在上方 [Unit] 段）。",
         "Restart=no",
         "# 刻意**不**用 StandardOutput=append:<log>——那個檔由 PID 1（root）在降權前開啟，",
         "# 路徑中只要有一段由 Manager 帳號掌控就成了 root-follows-symlink 的提權面。",

--- a/tests/test_bundle_commit_harvest_623.py
+++ b/tests/test_bundle_commit_harvest_623.py
@@ -26,6 +26,8 @@ from paulsha_cortex.coordinator import job_workspace, launcher, manager, verific
 from paulsha_cortex.coordinator.seams import ScriptWorktreeCreator
 
 _BRANCH = "feature/623-bundle-harvest"
+#: #645：工作區目錄名由 job id 導出（branch 名不變）。
+_JOB_ID = "623-bundle-harvest"
 _KEY = "job-623-0001"
 
 
@@ -58,7 +60,11 @@ def _source_repo(tmp_path: Path) -> Path:
 
 
 def _workspace(repo: Path, pool: Path) -> Path:
-    return Path(ScriptWorktreeCreator(repo=repo, wt_root=pool, base="main").create(_BRANCH))
+    return Path(
+        ScriptWorktreeCreator(repo=repo, wt_root=pool, base="main").create(
+            _BRANCH, job_id=_JOB_ID
+        )
+    )
 
 
 def _builder_commit(workspace: Path, name: str = "builder.txt") -> str:
@@ -140,7 +146,7 @@ def test_provision_pins_the_base_at_the_requested_base_sha(tmp_path: Path) -> No
 
     workspace = Path(
         ScriptWorktreeCreator(repo=repo, wt_root=tmp_path / "pool", base="main").create(
-            _BRANCH, base_sha=pinned_at
+            _BRANCH, job_id=_JOB_ID, base_sha=pinned_at
         )
     )
 

--- a/tests/test_coordinator_dependency_ancestry.py
+++ b/tests/test_coordinator_dependency_ancestry.py
@@ -162,7 +162,7 @@ class _RecordingWorktreeCreator:
     def __init__(self) -> None:
         self.calls: list[tuple[str, str | None]] = []
 
-    def create(self, branch: str, *, base_sha: str | None = None) -> str:
+    def create(self, branch: str, *, job_id: str | None = None, base_sha: str | None = None) -> str:
         self.calls.append((branch, base_sha))
         return f"/fake/wt/{branch.replace('/', '-')}"
 

--- a/tests/test_coordinator_dispatch_discipline_e2e.py
+++ b/tests/test_coordinator_dispatch_discipline_e2e.py
@@ -293,7 +293,7 @@ class _RecordingWorktreeCreator:
     def __init__(self) -> None:
         self.calls: list[tuple[str, str | None]] = []
 
-    def create(self, branch: str, *, base_sha: str | None = None) -> str:
+    def create(self, branch: str, *, job_id: str | None = None, base_sha: str | None = None) -> str:
         self.calls.append((branch, base_sha))
         return f"/fake/wt/{branch.replace('/', '-')}"
 

--- a/tests/test_coordinator_manager_daemon.py
+++ b/tests/test_coordinator_manager_daemon.py
@@ -212,7 +212,7 @@ class FakeWorktreeCreator:
         self._base_dir = base_dir
         self.calls: list[str] = []
 
-    def create(self, branch: str) -> str:
+    def create(self, branch: str, *, job_id: str | None = None) -> str:
         self.calls.append(branch)
         return str(self._base_dir / branch.replace("/", "__"))
 

--- a/tests/test_coordinator_operator_actions.py
+++ b/tests/test_coordinator_operator_actions.py
@@ -22,7 +22,7 @@ class _WorktreeCreator:
         self._base_dir = base_dir
         self.calls: list[tuple[str, str | None]] = []
 
-    def create(self, branch: str, base_sha: str | None = None) -> str:
+    def create(self, branch: str, base_sha: str | None = None, *, job_id: str | None = None) -> str:
         self.calls.append((branch, base_sha))
         worktree = self._base_dir / branch.replace("/", "__")
         worktree.mkdir(parents=True, exist_ok=True)

--- a/tests/test_coordinator_seams.py
+++ b/tests/test_coordinator_seams.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import pytest
 
+from paulsha_cortex.coordinator import job_workspace
 from paulsha_cortex.coordinator.seams import ScriptWorktreeCreator
 
 
@@ -38,13 +39,16 @@ def test_worktree_creator_reuses_existing_branch_only_when_it_is_base_ancestor(
 ) -> None:
     repo = _repo(tmp_path)
     branch = "feature/31-terminal-lifecycle-canary"
+    job_id = "31-terminal-lifecycle-canary"
     _git(repo, "branch", branch)
     (repo / "tracked.txt").write_text("two\n", encoding="utf-8")
     _git(repo, "commit", "-am", "main advances")
     expected = _git(repo, "rev-parse", "main")
 
     target = Path(
-        ScriptWorktreeCreator(repo=repo, wt_root=tmp_path / "worktrees").create(branch)
+        ScriptWorktreeCreator(repo=repo, wt_root=tmp_path / "worktrees").create(
+            branch, job_id=job_id
+        )
     )
 
     assert _git(repo, "rev-parse", branch) == expected
@@ -57,6 +61,7 @@ def test_worktree_creator_rejects_diverged_existing_branch_without_moving_it(
 ) -> None:
     repo = _repo(tmp_path)
     branch = "feature/31-terminal-lifecycle-canary"
+    job_id = "31-terminal-lifecycle-canary"
     _git(repo, "switch", "-c", branch)
     (repo / "feature.txt").write_text("feature\n", encoding="utf-8")
     _git(repo, "add", "feature.txt")
@@ -68,7 +73,11 @@ def test_worktree_creator_rejects_diverged_existing_branch_without_moving_it(
     _git(repo, "commit", "-m", "main only")
 
     with pytest.raises(ValueError, match="commits outside requested base"):
-        ScriptWorktreeCreator(repo=repo, wt_root=tmp_path / "worktrees").create(branch)
+        ScriptWorktreeCreator(repo=repo, wt_root=tmp_path / "worktrees").create(
+            branch, job_id=job_id
+        )
 
     assert _git(repo, "rev-parse", branch) == branch_head
+    # #645：目錄名由 job id 導出；舊的 branch-slug 形狀也不得留下殘留。
+    assert not (tmp_path / "worktrees" / job_workspace.job_segment(job_id)).exists()
     assert not (tmp_path / "worktrees" / "feature-31-terminal-lifecycle-canary").exists()

--- a/tests/test_multi_issue_worktree.py
+++ b/tests/test_multi_issue_worktree.py
@@ -4,7 +4,7 @@ import subprocess
 from pathlib import Path
 from typing import Any
 
-from paulsha_cortex.coordinator import manager, work_bridge
+from paulsha_cortex.coordinator import job_workspace, manager, work_bridge
 from paulsha_cortex.coordinator.launcher import LaunchHandle
 from paulsha_cortex.coordinator.model_identities import IdentityRegistry
 from paulsha_cortex.coordinator.registry import JobRegistry
@@ -44,7 +44,7 @@ class _RecordingCreator:
         self.repo_root = repo_root
         self.calls: list[str] = []
 
-    def create(self, branch: str, *, base_sha: str | None = None) -> str:
+    def create(self, branch: str, *, job_id: str | None = None, base_sha: str | None = None) -> str:
         self.calls.append(branch)
         return str(self.repo_root)
 
@@ -207,11 +207,15 @@ def test_build_worktree_uses_run_workspace_root_not_manager_repo(
     persisted = registry.get_job(job["job_id"])
 
     expected_pool = worktree_root_for(run_workspace)
-    expected_worktree = expected_pool / "feature-34-multi-issue-worktree"
+    # #645：目錄名由 build 身分（＝branch 去掉 `feature/`）經 job_workspace 導出，
+    # 不再是 branch slug；branch 名本身不變。
+    segment = job_workspace.job_segment("34-multi-issue-worktree")
+    expected_worktree = expected_pool / segment
     assert persisted["worktree"] == str(expected_worktree)
     assert expected_worktree.is_dir()
+    assert persisted["branch"] == "feature/34-multi-issue-worktree"
     # Manager-anchored pool must NOT receive the build worktree.
-    assert not (manager_pool / "feature-34-multi-issue-worktree").exists()
+    assert not (manager_pool / segment).exists()
 
 
 def test_pr_metadata_closes_all_mapped_issues(tmp_path: Path) -> None:

--- a/tests/test_per_job_clone_provisioning_623.py
+++ b/tests/test_per_job_clone_provisioning_623.py
@@ -22,6 +22,9 @@ from paulsha_cortex.coordinator import gc, job_workspace, manager, verification,
 from paulsha_cortex.coordinator.seams import ScriptWorktreeCreator
 
 _BRANCH = "feature/623-per-job-clone"
+_JOB_ID = "623-per-job-clone"
+#: #645：工作區目錄名由 job id 導出（不再是 branch slug）。
+_SEGMENT = job_workspace.job_segment(_JOB_ID)
 
 
 def _git(cwd: Path, *args: str) -> str:
@@ -109,7 +112,7 @@ def test_provisioned_workspace_is_a_standalone_clone_not_a_linked_worktree(
     """
 
     repo = _source_repo(tmp_path)
-    workspace = Path(_creator(repo, tmp_path / "pool").create(_BRANCH))
+    workspace = Path(_creator(repo, tmp_path / "pool").create(_BRANCH, job_id=_JOB_ID))
 
     assert (workspace / ".git").is_dir()
     assert not (workspace / ".git").is_file()
@@ -130,7 +133,7 @@ def test_provision_reuses_existing_branch_only_when_it_is_base_ancestor(
     _git(repo, "commit", "-qam", "main advances")
     expected = _git(repo, "rev-parse", "main")
 
-    workspace = Path(_creator(repo, tmp_path / "pool").create(_BRANCH))
+    workspace = Path(_creator(repo, tmp_path / "pool").create(_BRANCH, job_id=_JOB_ID))
 
     assert _git(repo, "rev-parse", _BRANCH) == expected
     assert _git(workspace, "rev-parse", "HEAD") == expected
@@ -154,10 +157,10 @@ def test_provision_rejects_diverged_existing_branch_without_moving_it(
     _git(repo, "commit", "-qm", "main only")
 
     with pytest.raises(ValueError, match="commits outside requested base"):
-        _creator(repo, tmp_path / "pool").create(_BRANCH)
+        _creator(repo, tmp_path / "pool").create(_BRANCH, job_id=_JOB_ID)
 
     assert _git(repo, "rev-parse", _BRANCH) == branch_head
-    assert not (tmp_path / "pool" / _BRANCH.replace("/", "-")).exists()
+    assert not (tmp_path / "pool" / _SEGMENT).exists()
 
 
 def test_provision_fails_closed_on_existing_target_without_deleting_it(
@@ -171,12 +174,12 @@ def test_provision_fails_closed_on_existing_target_without_deleting_it(
 
     repo = _source_repo(tmp_path)
     pool = tmp_path / "pool"
-    stale = pool / _BRANCH.replace("/", "-")
+    stale = pool / _SEGMENT
     stale.mkdir(parents=True)
     (stale / "precious.json").write_text("{}", encoding="utf-8")
 
     with pytest.raises(ValueError, match="worktree target already exists"):
-        _creator(repo, pool).create(_BRANCH)
+        _creator(repo, pool).create(_BRANCH, job_id=_JOB_ID)
 
     assert (stale / "precious.json").is_file()
 
@@ -190,10 +193,10 @@ def test_provision_rolls_back_the_branch_when_the_base_is_invalid(
     pool = tmp_path / "pool"
 
     with pytest.raises(ValueError, match="git worktree base invalid"):
-        ScriptWorktreeCreator(repo=repo, wt_root=pool, base="no-such-base").create(_BRANCH)
+        ScriptWorktreeCreator(repo=repo, wt_root=pool, base="no-such-base").create(_BRANCH, job_id=_JOB_ID)
 
     assert _try_git(repo, "show-ref", "--verify", "--quiet", f"refs/heads/{_BRANCH}").returncode == 1
-    assert not (pool / _BRANCH.replace("/", "-")).exists()
+    assert not (pool / _SEGMENT).exists()
 
 
 def test_provision_creates_the_branch_in_the_source_repo(tmp_path: Path) -> None:
@@ -202,7 +205,7 @@ def test_provision_creates_the_branch_in_the_source_repo(tmp_path: Path) -> None
     repo = _source_repo(tmp_path)
     base = _git(repo, "rev-parse", "main")
 
-    _creator(repo, tmp_path / "pool").create(_BRANCH)
+    _creator(repo, tmp_path / "pool").create(_BRANCH, job_id=_JOB_ID)
 
     assert _git(repo, "rev-parse", f"refs/heads/{_BRANCH}") == base
 
@@ -215,7 +218,7 @@ def test_provisioned_workspace_matches_the_worktree_model_git_environment(
     repo = _source_repo(tmp_path)
     upstream = _git(repo, "remote", "get-url", "origin")
 
-    workspace = Path(_creator(repo, tmp_path / "pool").create(_BRANCH))
+    workspace = Path(_creator(repo, tmp_path / "pool").create(_BRANCH, job_id=_JOB_ID))
 
     # `origin` 是**真正的上游**，不是來源 repo——否則 delivery 的
     # `git -C <工作區> push origin` 會把 candidate 推進 Manager 的樹。
@@ -232,7 +235,7 @@ def test_provision_works_without_an_upstream_remote(tmp_path: Path) -> None:
     """來源 repo 沒有 `origin`（測試環境常見）時工作區同樣沒有——與 worktree 等價。"""
 
     repo = _source_repo(tmp_path, with_upstream=False)
-    workspace = Path(_creator(repo, tmp_path / "pool").create(_BRANCH))
+    workspace = Path(_creator(repo, tmp_path / "pool").create(_BRANCH, job_id=_JOB_ID))
 
     assert _git(workspace, "remote") == ""
     assert _builder_commit(workspace)
@@ -250,7 +253,7 @@ def test_workspace_has_no_git_path_back_into_the_source_repo(tmp_path: Path) -> 
     """
 
     repo = _source_repo(tmp_path)
-    workspace = Path(_creator(repo, tmp_path / "pool").create(_BRANCH))
+    workspace = Path(_creator(repo, tmp_path / "pool").create(_BRANCH, job_id=_JOB_ID))
 
     remotes = _git(workspace, "remote").splitlines()
     assert job_workspace.SOURCE_REMOTE not in remotes
@@ -268,7 +271,7 @@ def test_builder_commits_do_not_reach_the_source_repo_before_harvest(
 
     repo = _source_repo(tmp_path)
     base = _git(repo, "rev-parse", "main")
-    workspace = Path(_creator(repo, tmp_path / "pool").create(_BRANCH))
+    workspace = Path(_creator(repo, tmp_path / "pool").create(_BRANCH, job_id=_JOB_ID))
 
     candidate = _builder_commit(workspace)
 
@@ -284,7 +287,7 @@ def test_manager_harvests_the_candidate_out_of_the_builder_clone(
     tmp_path: Path,
 ) -> None:
     repo = _source_repo(tmp_path)
-    workspace = Path(_creator(repo, tmp_path / "pool").create(_BRANCH))
+    workspace = Path(_creator(repo, tmp_path / "pool").create(_BRANCH, job_id=_JOB_ID))
     candidate = _builder_commit(workspace)
 
     harvested = _harvest(repo, workspace, tmp_path / "coordinator")
@@ -301,7 +304,7 @@ def test_harvest_rejects_a_rewritten_history_instead_of_absorbing_it(
     """refspec 刻意不帶 `+`：Manager 不會靜默吸收被改寫過的歷史。"""
 
     repo = _source_repo(tmp_path)
-    workspace = Path(_creator(repo, tmp_path / "pool").create(_BRANCH))
+    workspace = Path(_creator(repo, tmp_path / "pool").create(_BRANCH, job_id=_JOB_ID))
     first = _builder_commit(workspace)
     _harvest(repo, workspace, tmp_path / "coordinator")
 
@@ -351,7 +354,7 @@ def test_reclaim_removes_a_job_clone_and_leaves_no_residue(tmp_path: Path) -> No
     """#601／#613 關心的正是殘留：目錄與 registry 都不得留下任何一筆。"""
 
     repo = _source_repo(tmp_path)
-    workspace = Path(_creator(repo, tmp_path / "pool").create(_BRANCH))
+    workspace = Path(_creator(repo, tmp_path / "pool").create(_BRANCH, job_id=_JOB_ID))
     _builder_commit(workspace)
     _harvest(repo, workspace, tmp_path / "coordinator")
 
@@ -375,7 +378,7 @@ def test_reclaim_archives_unharvested_commits_before_deleting_the_clone(
     """
 
     repo = _source_repo(tmp_path)
-    workspace = Path(_creator(repo, tmp_path / "pool").create(_BRANCH))
+    workspace = Path(_creator(repo, tmp_path / "pool").create(_BRANCH, job_id=_JOB_ID))
     orphan = _builder_commit(workspace)
 
     result = worktree_reclaim.reclaim_worktree(workspace, repo_root=repo)
@@ -394,7 +397,7 @@ def test_reclaim_derives_the_source_repo_from_the_workspace_marker(
     """既有呼叫端都不傳 `repo_root`——封存必須靠標記檔自己找得到來源 repo。"""
 
     repo = _source_repo(tmp_path)
-    workspace = Path(_creator(repo, tmp_path / "pool").create(_BRANCH))
+    workspace = Path(_creator(repo, tmp_path / "pool").create(_BRANCH, job_id=_JOB_ID))
     orphan = _builder_commit(workspace)
 
     result = worktree_reclaim.reclaim_worktree(
@@ -416,7 +419,7 @@ def test_reclaim_preserves_dirty_content_inside_a_job_clone(tmp_path: Path) -> N
     """
 
     repo = _source_repo(tmp_path)
-    workspace = Path(_creator(repo, tmp_path / "pool").create(_BRANCH))
+    workspace = Path(_creator(repo, tmp_path / "pool").create(_BRANCH, job_id=_JOB_ID))
     (workspace / "uncommitted.txt").write_text("work in progress\n", encoding="utf-8")
     preserve_root = tmp_path / "evidence"
 
@@ -460,7 +463,7 @@ def test_reclaim_still_refuses_a_main_checkout_under_the_clone_model(
 def test_gc_scan_sees_job_clones_that_git_worktree_list_cannot(tmp_path: Path) -> None:
     repo = _source_repo(tmp_path)
     pool = tmp_path / "pool"
-    workspace = Path(_creator(repo, pool).create(_BRANCH))
+    workspace = Path(_creator(repo, pool).create(_BRANCH, job_id=_JOB_ID))
 
     artifacts = gc.scan(repo, worktree_root=pool)
     rows = {
@@ -479,7 +482,7 @@ def test_gc_apply_reclaims_a_merged_job_clone_by_directory_removal(
 
     repo = _source_repo(tmp_path)
     pool = tmp_path / "pool"
-    workspace = Path(_creator(repo, pool).create(_BRANCH))
+    workspace = Path(_creator(repo, pool).create(_BRANCH, job_id=_JOB_ID))
 
     artifacts = gc.scan(repo, worktree_root=pool)
     applied = gc.apply_gc(repo, artifacts, default_branch="main")
@@ -503,7 +506,7 @@ def test_gc_protects_the_branch_of_a_live_job_clone(tmp_path: Path) -> None:
 
     repo = _source_repo(tmp_path)
     pool = tmp_path / "pool"
-    workspace = Path(_creator(repo, pool).create(_BRANCH))
+    workspace = Path(_creator(repo, pool).create(_BRANCH, job_id=_JOB_ID))
     _builder_commit(workspace)
     _harvest(repo, workspace, tmp_path / "coordinator")
 
@@ -549,7 +552,7 @@ def test_workflow_lane_harvests_the_candidate_when_the_card_is_accepted(
     """
 
     repo = _source_repo(tmp_path)
-    workspace = Path(_creator(repo, tmp_path / "pool").create(_BRANCH))
+    workspace = Path(_creator(repo, tmp_path / "pool").create(_BRANCH, job_id=_JOB_ID))
     candidate = _builder_commit(workspace)
     coordinator_root = tmp_path / "coordinator"
     bundle = _produce_bundle(workspace, coordinator_root)
@@ -597,7 +600,7 @@ def test_workflow_lane_harvest_fails_closed_when_the_head_does_not_match(
     tmp_path: Path,
 ) -> None:
     repo = _source_repo(tmp_path)
-    workspace = Path(_creator(repo, tmp_path / "pool").create(_BRANCH))
+    workspace = Path(_creator(repo, tmp_path / "pool").create(_BRANCH, job_id=_JOB_ID))
     _builder_commit(workspace)
     coordinator_root = tmp_path / "coordinator"
     bundle = _produce_bundle(workspace, coordinator_root)
@@ -625,7 +628,7 @@ def test_slice_lane_verification_harvests_before_reading_the_branch(
 
     repo = _source_repo(tmp_path)
     base = _git(repo, "rev-parse", "main")
-    workspace = Path(_creator(repo, tmp_path / "pool").create(_BRANCH))
+    workspace = Path(_creator(repo, tmp_path / "pool").create(_BRANCH, job_id=_JOB_ID))
     candidate = _builder_commit(workspace)
     bundle = _produce_bundle(workspace, tmp_path / "coordinator")
     contract = {
@@ -666,7 +669,7 @@ def test_end_to_end_provision_commit_harvest_reclaim(tmp_path: Path) -> None:
 
     repo = _source_repo(tmp_path)
     pool = tmp_path / "pool"
-    workspace = Path(_creator(repo, pool).create(_BRANCH))
+    workspace = Path(_creator(repo, pool).create(_BRANCH, job_id=_JOB_ID))
 
     candidate = _builder_commit(workspace)
     # builder 寫不到來源 repo 的 ref（此處以「來源 repo 沒有這條路徑」驗證方向性；

--- a/tests/test_persona_phase2_coordinator_cli.py
+++ b/tests/test_persona_phase2_coordinator_cli.py
@@ -21,13 +21,13 @@ class FakeWorktreeCreator:
         self.root = root
         self.created: list[str] = []
 
-    def create(self, branch: str) -> str:
+    def create(self, branch: str, *, job_id: str | None = None) -> str:
         self.created.append(branch)
         return f"{self.root}/{branch.replace('/', '-')}"
 
 
 class _RaisingWorktreeCreator:
-    def create(self, branch: str) -> str:
+    def create(self, branch: str, *, job_id: str | None = None) -> str:
         raise ValueError("boom: worktree add failed")
 
 

--- a/tests/test_persona_phase4_fanout_autonomy.py
+++ b/tests/test_persona_phase4_fanout_autonomy.py
@@ -692,7 +692,7 @@ class FanoutTests(unittest.TestCase):
             def __init__(self):
                 self.created = []
 
-            def create(self, branch):
+            def create(self, branch, *, job_id=None):
                 self.created.append(branch)
                 return f"/fake/wt/{branch.replace('/', '-')}"
 
@@ -739,7 +739,7 @@ class FanoutTests(unittest.TestCase):
                 raise AssertionError("launcher path must not send to pane")
 
         class _FakeWt:
-            def create(self, branch):
+            def create(self, branch, *, job_id=None):
                 return f"/fake/wt/{branch.replace('/', '-')}"
 
         class _FakeLauncher:
@@ -783,7 +783,7 @@ class FanoutTests(unittest.TestCase):
                 raise AssertionError("launcher path must not send to pane")
 
         class _FakeWt:
-            def create(self, branch):
+            def create(self, branch, *, job_id=None):
                 return f"/fake/wt/{branch.replace('/', '-')}"
 
         class _FailFirstLauncher:
@@ -835,7 +835,7 @@ class FanoutTests(unittest.TestCase):
                 raise AssertionError("launcher path must not send to pane")
 
         class _FakeWt:
-            def create(self, branch):
+            def create(self, branch, *, job_id=None):
                 return f"/fake/wt/{branch.replace('/', '-')}"
 
         class _OrderLauncher:
@@ -907,7 +907,7 @@ class FanoutTests(unittest.TestCase):
                 self.sent.append((pane_id, text))
 
         class _FakeWt:
-            def create(self, branch):
+            def create(self, branch, *, job_id=None):
                 return f"/fake/wt/{branch.replace('/', '-')}"
 
         class _FakeLauncher:
@@ -1065,7 +1065,7 @@ class CliTests(unittest.TestCase):
                 self.sent.append((pane_id, text))
 
         class _FakeWt:
-            def create(self, branch):
+            def create(self, branch, *, job_id=None):
                 return f"/fake/wt/{branch.replace('/', '-')}"
 
         with tempfile.TemporaryDirectory() as d:
@@ -1104,7 +1104,7 @@ class CliTests(unittest.TestCase):
                 self.sent.append((pane_id, text))
 
         class _FakeWt:
-            def create(self, branch):
+            def create(self, branch, *, job_id=None):
                 return f"/fake/wt/{branch.replace('/', '-')}"
 
         with tempfile.TemporaryDirectory() as d:

--- a/tests/test_provider_failure_recovery.py
+++ b/tests/test_provider_failure_recovery.py
@@ -145,7 +145,7 @@ class _FakeWorktreeCreator:
     def __init__(self, path: Path):
         self._path = path
 
-    def create(self, branch: str, base_sha: str | None = None) -> Path:
+    def create(self, branch: str, base_sha: str | None = None, *, job_id: str | None = None) -> Path:
         return self._path
 
 

--- a/tests/test_repair_commit_recovery.py
+++ b/tests/test_repair_commit_recovery.py
@@ -574,7 +574,7 @@ class _FakeWorktreeCreator:
     def __init__(self, path: Path) -> None:
         self._path = path
 
-    def create(self, branch: str, base_sha: str | None = None) -> Path:
+    def create(self, branch: str, base_sha: str | None = None, *, job_id: str | None = None) -> Path:
         return self._path
 
 

--- a/tests/test_slice_executor_model.py
+++ b/tests/test_slice_executor_model.py
@@ -286,7 +286,7 @@ class FakeWorktreeCreator:
         self._base_dir = base_dir
         self.calls: list[tuple[str, str | None]] = []
 
-    def create(self, branch: str, base_sha: str | None = None) -> str:
+    def create(self, branch: str, base_sha: str | None = None, *, job_id: str | None = None) -> str:
         self.calls.append((branch, base_sha))
         return str(self._base_dir / branch.replace("/", "__"))
 

--- a/tests/test_work_bridge.py
+++ b/tests/test_work_bridge.py
@@ -972,7 +972,7 @@ identities:
     branches: list[str] = []
 
     class WorktreeCreator:
-        def create(self, branch, base_sha=None):
+        def create(self, branch, base_sha=None, *, job_id=None):
             branches.append(branch)
             return str(repo)
 

--- a/tests/test_workflow_production_wiring.py
+++ b/tests/test_workflow_production_wiring.py
@@ -2990,7 +2990,7 @@ def test_control_queue_manager_executes_heterogeneous_brainstorm_before_plan(tmp
     created_branches: list[str] = []
 
     class WorktreeCreator:
-        def create(self, branch, base_sha=None):
+        def create(self, branch, base_sha=None, *, job_id=None):
             created_branches.append(branch)
             return str(tmp_path)
 

--- a/tests/test_worktree_dir_naming_645.py
+++ b/tests/test_worktree_dir_naming_645.py
@@ -1,0 +1,397 @@
+"""issue #645：job 工作區目錄名 ＝ systemd 模板 instance 名（單一推導點）。
+
+#645 的生產現場：`seams.ScriptWorktreeCreator.create()` 以 **branch slug**
+（`feature/<slice_id>` → `feature-<slice_id>`）命名工作區，而模板 unit 的
+`ReadWritePaths=<pool>/%i` 期望的是 `job_runner` 由 **job id** 算出的 instance 名。
+兩條命名鏈各自導出、永遠差一個 `feature-` 前綴，於是 `ReadWritePaths` 指向不存在的
+路徑，systemd 建 mount namespace 直接失敗（`226/NAMESPACE`）——降權派工從未經正式
+路徑成功啟動過任何 job。
+
+本檔的核心是**一條不變式**：兩個**真實**推導函式的輸出必須逐字相等。刻意不對常數
+斷言——「兩邊各自算、剛好等於同一個字面量」正是 #645 復發的形狀。
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from paulsha_cortex.coordinator import (
+    autonomy,
+    job_runner,
+    job_workspace,
+    worktree_reclaim,
+)
+from paulsha_cortex.coordinator.seams import ScriptWorktreeCreator
+from paulsha_cortex.trust_root import permgen
+
+
+#: 涵蓋幾種真實會出現的 slice/job id 形狀：純 slug、帶 issue 號、帶需要消毒的
+#: 分隔字元（`/` 在目錄名裡必須被消掉，在 branch 名裡則是合法的一層）。
+_JOB_IDS = (
+    "dispatch1",
+    "645-worktree-dir-naming",
+    "645/sub-slice",
+)
+
+
+def _git(cwd: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", "-C", str(cwd), *args], check=True, capture_output=True, text=True
+    ).stdout.strip()
+
+
+def _source_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repos" / "paulsha-cortex"
+    repo.mkdir(parents=True)
+    subprocess.run(["git", "-C", str(repo), "init", "-q", "-b", "main"], check=True)
+    _git(repo, "config", "user.email", "manager@example.invalid")
+    _git(repo, "config", "user.name", "Cortex Manager")
+    (repo / "tracked.txt").write_text("one\n", encoding="utf-8")
+    _git(repo, "add", "tracked.txt")
+    _git(repo, "commit", "-qm", "initial")
+    return repo
+
+
+# ---------------------------------------------------------------------------
+# 本票的全部價值：兩個真實推導函式的輸出必須相等
+# ---------------------------------------------------------------------------
+
+def test_provisioned_directory_name_equals_the_template_instance_name(
+    tmp_path: Path,
+) -> None:
+    """`seams.create()` 產生的目錄名 == `job_runner` 算出的 instance 名。
+
+    兩側都跑**真實**推導：左邊是真的在真 git repo 上 provision 出來的目錄，右邊是
+    `prepare_systemd_template()` 內部逐字使用的 `template_instance_id()`。任何一側
+    再度分岔（例如有人把目錄名改回 branch slug），這條就紅。
+    """
+
+    repo = _source_repo(tmp_path)
+    pool = tmp_path / "pool"
+
+    for job_id in _JOB_IDS:
+        branch = autonomy._branch_for_slice(job_id)
+        workspace = Path(
+            ScriptWorktreeCreator(repo=repo, wt_root=pool, base="main").create(
+                branch, job_id=job_id
+            )
+        )
+        instance = job_runner.template_instance_id(job_id)
+
+        assert workspace.name == instance, (
+            f"job_id={job_id!r}：工作區目錄名 {workspace.name!r} 與模板 instance 名 "
+            f"{instance!r} 不相等——模板 unit 的 ReadWritePaths=<pool>/%i 會指向不存在"
+            "的路徑（#645 的 226/NAMESPACE）"
+        )
+        # unit 的 RWP 是 `<pool>/%i`：目錄的父層也必須就是 pool 本身。
+        assert workspace.parent == pool
+        assert workspace.is_dir()
+
+
+def test_provisioning_never_produces_the_pre_645_branch_slug_directory(
+    tmp_path: Path,
+) -> None:
+    """突變守衛：修法前的目錄名（branch slug）**不得**再出現在 pool 裡。
+
+    沒有這一條，上面那條不變式有可能因為「兩個名字剛好都被改成 branch slug」而
+    假通過——那正是 #645 的原狀。
+    """
+
+    repo = _source_repo(tmp_path)
+    pool = tmp_path / "pool"
+    job_id = "dispatch1"
+    branch = autonomy._branch_for_slice(job_id)
+
+    ScriptWorktreeCreator(repo=repo, wt_root=pool, base="main").create(
+        branch, job_id=job_id
+    )
+
+    legacy = pool / job_workspace.legacy_branch_slug(branch)
+    assert legacy.name == "feature-dispatch1", "legacy 形狀的定義本身漂移了"
+    assert not legacy.exists()
+    assert sorted(p.name for p in pool.iterdir()) == [
+        job_runner.template_instance_id(job_id)
+    ]
+
+
+def test_prepare_systemd_template_agrees_with_provisioning(tmp_path: Path) -> None:
+    """完整的 `prepare_systemd_template()` 與 provisioning 對齊（需 Phase 2b 部署）。
+
+    上面那條不變式跑的是 `template_instance_id()`——它正是
+    `prepare_systemd_template()` 內部唯一的 instance 來源，因此在任何機器上都測得到。
+    這一條再往外包一層，連 preflight（帳號／unit 檔／shim／spool）一起跑，證明
+    **正式派工路徑**上算出來的 instance 名也是同一個。
+
+    這些前置物是 OS 層的（真的存在 `cortex-builder` 帳號、真的裝了模板 unit），
+    單 UID 的開發機與 CI 都沒有。比照 #638 的教訓：**明確 skip 並說明理由**，
+    不得靜默通過。
+    """
+
+    missing: list[str] = []
+    account = job_runner.resolve_builder_account({})
+    group = job_runner.resolve_builder_group({})
+    template = job_runner.resolve_template_unit({})
+    shim = job_runner.resolve_job_shim({})
+    spool = job_runner.resolve_job_spec_spool({})
+    if shutil.which("systemctl") is None:
+        missing.append("PATH 上沒有 systemctl")
+    if not job_runner._systemd_booted():
+        missing.append("/run/systemd/system 不存在（本機未以 systemd 開機）")
+    if not job_runner._account_exists(account):
+        missing.append(f"builder 帳號 {account} 不存在")
+    if not job_runner._group_exists(group):
+        missing.append(f"builder group {group} 不存在")
+    if not job_runner._unit_file_installed(template):
+        missing.append(f"模板 unit {template} 未安裝")
+    if not job_runner._is_executable(shim):
+        missing.append(f"降權 shim {shim} 不存在或不可執行")
+    if not Path(spool).is_dir():
+        missing.append(f"job spec spool {spool} 不存在")
+    if missing:
+        pytest.skip(
+            "本機沒有 trust-root Phase 2b 的降權前置物（"
+            + "；".join(missing)
+            + "）。#645 的不變式在 `template_instance_id()` 那條測試裡已被完整覆蓋，"
+            "本條只多驗 preflight 這一層——刻意 skip 而非空過"
+        )
+
+    repo = _source_repo(tmp_path)
+    pool = tmp_path / "pool"
+    job_id = "dispatch1"
+    workspace = Path(
+        ScriptWorktreeCreator(repo=repo, wt_root=pool, base="main").create(
+            autonomy._branch_for_slice(job_id), job_id=job_id
+        )
+    )
+    plan = job_runner.prepare_systemd_template(
+        {}, job_id=job_id, unit_active=lambda _binary, _unit: False
+    )
+
+    assert workspace.name == plan.instance
+    assert plan.unit == f"cortex-job@{workspace.name}.service"
+
+
+def test_slice_lane_passes_the_same_id_to_provisioning_and_to_launch(
+    tmp_path: Path,
+) -> None:
+    """接線層：`autonomy._launcher_worktree()` 給 provisioning 的 id，就是
+    `launcher.launch(slice_id=…)` 之後交給 `prepare_systemd_template(job_id=…)` 的
+    那一個。
+
+    不變式成立的前提是「兩邊拿到同一個 id」，這條就守在那個接縫上——只驗推導函式
+    而不驗接線，一次傳錯參數就能讓 #645 原封不動地回來。
+    """
+
+    repo = _source_repo(tmp_path)
+    pool = tmp_path / "pool"
+    slice_id = "645-wiring"
+
+    class _RecordingDispatcher:
+        def __init__(self) -> None:
+            self._worktree_creator = _RecordingCreator()
+
+    class _RecordingCreator:
+        def __init__(self) -> None:
+            self.seen: list[tuple[str, str]] = []
+            self._real = ScriptWorktreeCreator(repo=repo, wt_root=pool, base="main")
+
+        def create(self, branch: str, *, job_id: str, base_sha: str | None = None) -> str:
+            self.seen.append((branch, job_id))
+            return self._real.create(branch, job_id=job_id, base_sha=base_sha)
+
+    dispatcher = _RecordingDispatcher()
+    worktree = autonomy._launcher_worktree(dispatcher, slice_id)
+
+    assert dispatcher._worktree_creator.seen == [
+        (autonomy._branch_for_slice(slice_id), slice_id)
+    ]
+    # `launcher.launch(slice_id=slice_id)` → `prepare_systemd_template(job_id=slice_id)`
+    assert Path(worktree).name == job_runner.template_instance_id(slice_id)
+
+
+# ---------------------------------------------------------------------------
+# direct 模式零回歸：branch 名不變，成果回收面不受影響
+# ---------------------------------------------------------------------------
+
+def test_branch_naming_and_harvest_surface_are_unchanged(tmp_path: Path) -> None:
+    """只有磁碟上的目錄名改，**branch 名一律不變**。
+
+    direct 模式（與 `gc`／harvest）完全不看目錄名：它們讀來源 repo 的
+    `refs/heads/<branch>`、讀工作區自己 checked-out 的 branch、以及 `log_path` 推導的
+    spool key。這條把那三個面一次釘住。
+    """
+
+    repo = _source_repo(tmp_path)
+    pool = tmp_path / "pool"
+    slice_id = "645-direct-lane"
+    branch = autonomy._branch_for_slice(slice_id)
+    assert branch == "feature/645-direct-lane"
+
+    workspace = Path(
+        ScriptWorktreeCreator(repo=repo, wt_root=pool, base="main").create(
+            branch, job_id=slice_id
+        )
+    )
+
+    # 1. 來源 repo 的 branch 仍在原本的位置（dispatch baseline／gc 都直接讀它）
+    assert _git(repo, "rev-parse", f"refs/heads/{branch}") == _git(repo, "rev-parse", "main")
+    assert job_workspace.source_branch_head(repo, branch) is not None
+    # 2. 工作區 checked-out 的仍是同一條 branch（gc 由此取 branch，不看目錄名）
+    assert job_workspace.workspace_branch(workspace) == branch
+    assert _git(workspace, "branch", "--show-current") == branch
+    # 3. 標記檔記的 branch 不變
+    marker = job_workspace.read_marker(workspace) or {}
+    assert marker.get("branch") == branch
+    # 4. spool key 仍由 log_path 推導，與目錄名無關（#637）
+    job = {"log_path": f"/var/log/cortex/{slice_id}.jsonl"}
+    assert job_workspace.spool_key_for_job(job) == slice_id
+
+
+# ---------------------------------------------------------------------------
+# 既有部署的殘留：兩種目錄形狀都要回收得掉，認不得的一律不刪
+# ---------------------------------------------------------------------------
+
+def test_reclaim_candidates_cover_both_directory_shapes() -> None:
+    """反推候選必須同時涵蓋 #645 前後兩種形狀，且新形狀優先。"""
+
+    pool = Path("/var/lib/cortex/worktree")
+    candidates = job_workspace.reclaim_candidate_paths(
+        pool, job_id="dispatch1", branch="feature/dispatch1"
+    )
+
+    assert candidates == [
+        pool / job_workspace.job_segment("dispatch1"),
+        pool / "feature-dispatch1",
+    ]
+
+
+def test_reclaim_collects_a_legacy_branch_slug_workspace(tmp_path: Path) -> None:
+    """升級前 provision 的 `feature-<id>` 目錄仍必須被回收得掉。
+
+    回收端若只認新形狀，磁碟上的舊殘留會被當成「不存在」而靜默略過，下一次
+    provision 直接撞 `worktree target already exists`（#601 的生產現場）。
+    """
+
+    repo = _source_repo(tmp_path)
+    pool = tmp_path / "pool"
+    slice_id = "645-legacy"
+    branch = autonomy._branch_for_slice(slice_id)
+    provisioned = Path(
+        ScriptWorktreeCreator(repo=repo, wt_root=pool, base="main").create(
+            branch, job_id=slice_id
+        )
+    )
+    # 搬成 #645 之前的形狀：per-job clone 是自足的，改目錄名即等價於舊部署的殘留。
+    legacy = pool / job_workspace.legacy_branch_slug(branch)
+    shutil.move(str(provisioned), str(legacy))
+    assert job_workspace.is_job_clone(legacy)
+
+    result = worktree_reclaim.reclaim_recorded_or_derived(
+        recorded_path=None,
+        pool_root=pool,
+        job_id=slice_id,
+        branch=branch,
+        repo_root=repo,
+        preserve_root=tmp_path / "evidence",
+    )
+
+    assert result is not None
+    assert result.ok, result.detail
+    assert result.status == worktree_reclaim.RECLAIM_RECLAIMED
+    assert Path(result.path) == legacy
+    assert not legacy.exists()
+
+
+def test_reclaim_refuses_to_delete_an_unrecognised_directory(tmp_path: Path) -> None:
+    """認不得的目錄一律 fail-closed——回收器不得變成「看到就刪」。
+
+    pool 底下同名的目錄未必是 build 工作區（operator 的暫存、掛載點、別的專案）。
+    #478 的安全閘在這條反推路徑上必須同樣生效。
+    """
+
+    repo = _source_repo(tmp_path)
+    pool = tmp_path / "pool"
+    slice_id = "645-not-a-workspace"
+    branch = autonomy._branch_for_slice(slice_id)
+    stranger = pool / job_workspace.legacy_branch_slug(branch)
+    stranger.mkdir(parents=True)
+    (stranger / "precious.json").write_text("{}", encoding="utf-8")
+
+    result = worktree_reclaim.reclaim_recorded_or_derived(
+        recorded_path=None,
+        pool_root=pool,
+        job_id=slice_id,
+        branch=branch,
+        repo_root=repo,
+        preserve_root=tmp_path / "evidence",
+    )
+
+    assert result is not None
+    assert not result.ok
+    assert result.detail == "worktree-path-not-a-worktree"
+    assert (stranger / "precious.json").is_file()
+
+
+def test_reclaim_uses_the_recorded_path_verbatim_when_present(tmp_path: Path) -> None:
+    """記錄有 `worktree` 時逐字回收那一條——與 #645 之前完全相同，不多掃 pool。"""
+
+    repo = _source_repo(tmp_path)
+    pool = tmp_path / "pool"
+    slice_id = "645-recorded"
+    branch = autonomy._branch_for_slice(slice_id)
+    provisioned = Path(
+        ScriptWorktreeCreator(repo=repo, wt_root=pool, base="main").create(
+            branch, job_id=slice_id
+        )
+    )
+    stranger = pool / job_workspace.legacy_branch_slug(branch)
+    stranger.mkdir(parents=True)
+
+    result = worktree_reclaim.reclaim_recorded_or_derived(
+        recorded_path=provisioned,
+        pool_root=pool,
+        job_id=slice_id,
+        branch=branch,
+        repo_root=repo,
+        preserve_root=tmp_path / "evidence",
+    )
+
+    assert result is not None and result.ok
+    assert not provisioned.exists()
+    # 反推不該被觸發：那個形狀不明的目錄一個位元組都不動。
+    assert stranger.is_dir()
+
+
+# ---------------------------------------------------------------------------
+# 附帶：`CollectMode` 屬 [Unit]，放在 [Service] 會被 systemd 靜默忽略
+# ---------------------------------------------------------------------------
+
+def _section_of(content: str, key: str) -> str | None:
+    section: str | None = None
+    for raw in content.splitlines():
+        line = raw.strip()
+        if line.startswith("[") and line.endswith("]"):
+            section = line[1:-1]
+        elif line.startswith(f"{key}="):
+            return section
+    return None
+
+
+def test_collect_mode_is_declared_in_the_unit_section() -> None:
+    """`CollectMode` 是 `[Unit]` 的鍵。
+
+    放在 `[Service]` 時 systemd 只印
+    `Unknown key name 'CollectMode' in section 'Service', ignoring.` 就繼續跑——
+    語法不算錯，但「失敗的 instance 自動回收」這個用意整個沒生效。
+    """
+
+    unit = permgen.build_job_unit(permgen.DEFAULT_SCHEME, permgen.DEFAULT_LAYOUT)
+
+    assert "CollectMode=inactive-or-failed" in unit.content
+    assert _section_of(unit.content, "CollectMode") == "Unit"
+    # 同段的 `Restart=` 仍屬 [Service]——這條確保上面不是整段被搬錯。
+    assert _section_of(unit.content, "Restart") == "Service"

--- a/tests/test_worktree_registry_reclaim_478.py
+++ b/tests/test_worktree_registry_reclaim_478.py
@@ -14,7 +14,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from paulsha_cortex.coordinator import manager, work_actions, worktree_reclaim
+from paulsha_cortex.coordinator import job_workspace, manager, work_actions, worktree_reclaim
 from paulsha_cortex.coordinator.dispatcher import Dispatcher
 from paulsha_cortex.coordinator.registry import JobRegistry
 from paulsha_cortex.coordinator.seams import ScriptWorktreeCreator
@@ -278,10 +278,11 @@ def test_recover_pre_candidate_clears_registry_and_allows_redispatch(
     assert str(worktree) not in _registered_worktrees(repo)
     assert registry.get_slice("slice-e")["state"] == "pending"
     # 下一 tick 的實際動作：dispatch 會呼叫 ScriptWorktreeCreator.create()。
+    # #645：目錄名改由 job id 導出（branch 名不變），因此重建的位置是新形狀那一個。
     recreated = ScriptWorktreeCreator(repo=repo, wt_root=pool, base="main").create(
-        "feature/slice-e"
+        "feature/slice-e", job_id="slice-e"
     )
-    assert Path(recreated) == worktree
+    assert Path(recreated) == pool / job_workspace.job_segment("slice-e")
 
 
 def test_recover_pre_candidate_self_heals_orphan_registry_entry(
@@ -316,7 +317,9 @@ def test_recover_pre_candidate_self_heals_orphan_registry_entry(
 
     assert result["result"] == "ok"
     assert str(worktree) not in _registered_worktrees(repo)
-    ScriptWorktreeCreator(repo=repo, wt_root=pool, base="main").create("feature/slice-f")
+    ScriptWorktreeCreator(repo=repo, wt_root=pool, base="main").create(
+        "feature/slice-f", job_id="slice-f"
+    )
 
 
 def test_recover_pre_candidate_fails_closed_when_reclaim_fails(


### PR DESCRIPTION
Closes #645

## 問題

兩條命名鏈各自導出，永不相等：

| 來源 | 導出 | 結果 |
|---|---|---|
| `autonomy._branch_for_slice(slice_id)` | `feature/<slice_id>` | branch 名 |
| `seams.ScriptWorktreeCreator.create()` | `branch.replace("/","-")` | 工作區＝`<pool>/feature-<slice_id>` |
| `job_runner.prepare_systemd_template(job_id=…)` | `template_instance_id(job_id)` | instance |
| 模板 unit（permgen `with_job_segment("%i")`） | `ReadWritePaths=<pool>/%i` | 期望＝`<pool>/<instance>` |

`feature-<slice_id>` ≠ `<instance>` ⇒ `ReadWritePaths` 指向不存在的路徑 ⇒ systemd 建
mount namespace 時就失敗（`Failed to set up mount namespacing … 226/NAMESPACE`）。
**降權派工從未經正式路徑成功啟動過任何 job。**

M1 的正向 smoke 用的是**手工組的 job spec**（自然挑了與 instance 名相符的 worktree
路徑），把這個 bug 繞過去了——與 #584／#623 同一條方法論教訓。

## 裁決與作法

operator 裁決：**改目錄名這一側，不改 instance 名**。模板 unit 只有 `%i` 可用、推不出
branch slug；而「job 的工作區以 job id 定址」本來就與登記表既有的 per-job 模型
（spool／sentinel／gate ledger）一致。**branch 名完全不變**，只有磁碟上的目錄名改。

### 怎麼讓兩個名稱單一推導

不是「兩邊各自算、剛好相等」，而是**同一個函式的同一個輸出**：

- 新增 `coordinator/job_workspace.py:job_segment(job_id)`——全 repo 唯一產生這個字串的
  地方（形狀與 #616 起既有的 instance 名推導**逐字相同**，因此既有部署的 spec spool
  檔名、polkit pattern 與 unit 名都不改變）。
- `job_runner.template_instance_id()` 改為**委派**給它；`job_runner.INSTANCE_NAME_RE`
  改為別名到 `job_workspace.JOB_SEGMENT_RE`（兩份 pattern 就是兩個會漂移的來源）。
- `seams.ScriptWorktreeCreator.create()` 的簽章加上**必填**的 `job_id` 關鍵字
  （`WorktreeCreator` 協定同步），目錄名一律由 `job_workspace.workspace_path()` 導出。
  刻意**不給預設值**：留預設等於留一條「忘了傳就退回舊命名」的復發路徑。

## gc／reclaim 受什麼影響

- **`gc.py`：無關（不必改）**。它的掃描判準是**形狀**——`job_workspace` 標記檔（clone）
  或 `.git` 檔（升級前的 linked worktree）；branch 取工作區自己 `symbolic-ref HEAD`。
  全程不看目錄名，因此新舊兩種形狀都照樣掃得到、分類得出、回收得掉。
- **`worktree_reclaim.reclaim_worktree()`：無關（不必改）**。它收的是呼叫端給的
  **路徑**，安全閘同樣是形狀判準（`_looks_like_job_workspace`）。
- **#601（retry-card 不回收 provision 卡的殘留 worktree）：不受影響、也未被解掉**。
  它要接的就是這支 reclaim helper；本 PR 讓那支 helper 多認得一種目錄形狀，只會讓
  #601 未來接上時更穩，不縮小也不擴大它的範圍。
- **#613（abandon 不回收 build branch）：完全無關**。本 PR 一個 branch 名都沒改。
- **真正會漏的是 `recover-pre-candidate` 的反推路徑**（`manager.apply_slice_action` 與
  `work_actions._recover_pre_candidate_action` 各一份）：job／slice 記錄沒有 `worktree`
  欄位時，舊碼**由 branch slug 反推**（第三、四個各自導出的來源）。兩處收斂到新的
  `worktree_reclaim.reclaim_recorded_or_derived()`。

## 舊目錄怎麼處理

**不做自動遷移，也不寫會刪掉不認得目錄的清理器。**

- 記錄有 `worktree` → 逐字回收那一條（與修法前完全相同，不多掃 pool）。
- 記錄沒有 → `job_workspace.reclaim_candidate_paths()` 反推，**新舊兩種形狀都試**
  （`<pool>/<job_segment(job_id)>` 與 `<pool>/<branch slug>`）。少了這一步，升級當下
  磁碟上的舊殘留會被當成「不存在」而靜默略過，下一次 provision 直接撞
  `worktree target already exists`（#601 的生產現場）。
- 刪除仍完全走 `reclaim_worktree()` 的安全閘：**形狀不明的目錄一律 `failed`、一個位元組
  都不刪**（#478 的 `.project-policy.yml` 資料遺失回報），有測試釘住。
- 已 merge 的舊工作區另有 `cortex work gc` 這條既有路徑，同樣不看名字。

## 已知邊界（不在本票範圍）

**canonical（workflow）lane 的工作區是 per-run 的**：build 卡 provision 之後，同 run
後續的卡沿用 `builder_jobs[-1]["worktree"]`，一個工作區對多個 `job_id`。因此
「目錄名 ＝ 該 job 的 instance 名」在那條 lane **結構上不可能**成立。本 PR 只把它的目錄
名同樣收進單一推導點（傳 run 層級的 build 身分），並在程式碼裡明寫這條邊界。要在
`PSC_JOB_RUNNER=systemd-template` 底下跑 canonical lane，得先把工作區從 per-run 改成
per-job——那是另一票。slice lane 沒有這個一對多，不變式在那裡成立且有測試守著。

## 附帶：`CollectMode`

`permgen.build_job_unit()` 把 `CollectMode=inactive-or-failed` 由 `[Service]` 搬到
`[Unit]`。實機 `systemd-analyze verify` 報
`Unknown key name 'CollectMode' in section 'Service', ignoring.`——語法不算錯，但
「失敗的 instance 自動回收」的用意整個沒生效。新增測試釘住它落在 `[Unit]`、且同段的
`Restart=` 仍在 `[Service]`。

## 測試

新增 `tests/test_worktree_dir_naming_645.py`（10 條）：

- **不變式（本票的全部價值）**：`ScriptWorktreeCreator.create()` 在真 git repo 上產生的
  **目錄名** == `job_runner.template_instance_id()` 的輸出。兩側都是真實推導函式，
  **不對常數斷言**（三種 id 形狀參數化）。
- **突變守衛**：修法前的 branch-slug 目錄不得再出現在 pool 裡（否則上一條可能因為
  「兩個名字都被改成 branch slug」而假通過）。
- **接線**：`autonomy._launcher_worktree()` 交給 provisioning 的 id，就是
  `launch(slice_id=…)` 之後交給 `prepare_systemd_template(job_id=…)` 的那一個。
- **完整 `prepare_systemd_template()`**（多驗一層 preflight）：需要 OS 層前置物
  （`cortex-builder` 帳號／group、模板 unit、shim、spec spool）。單 UID 的開發機與 CI
  沒有 ⇒ 比照 **#638 的教訓明確 `pytest.skip` 並逐項列出缺哪一個**，不靜默通過。
  （operator 的部署機上這一條**實際會跑**並通過——本機驗證過。）
- **direct 模式零回歸**：branch 名、來源 repo 的 `refs/heads/<branch>`、工作區
  `symbolic-ref HEAD`、標記檔的 `branch`、以及 `spool_key_for_job()`（由 `log_path` 推導）
  全部不變。
- **回收**：legacy `feature-<id>` 形狀收得掉／形狀不明的目錄一律不刪且回 `failed`／
  記錄有路徑時逐字使用不多掃 pool。

`python3 -m pytest tests/ -q`：**3844 passed, 4 skipped**（本機為部署機，故上述
Phase 2b 那條有跑；CI 上會 skip 並印出理由）。

## 並行注意（給 merge 排序）

- 本 PR 動到 `permgen.build_job_unit()`（**只有 `CollectMode` 搬段**）與 `job_runner`
  （**只有 `template_instance_id` / `instance_name_valid` / `INSTANCE_NAME_RE` 改為委派
  給 `job_workspace`，外加一行 import**）。**完全沒有**碰 job_runner 的剖面選擇、polkit
  產生器、或 unit 的加固段。
- #643（per-executor 加固剖面）會動同一個 `build_job_unit()` 與 polkit／剖面選擇。
  兩邊的接觸面不重疊，但落在同一個函式裡；建議 **#643 後於本 PR merge**，衝突只會在
  `build_job_unit()` 的 body 清單上，且是相鄰行。

## Checklist

- [x] 分支不是 `main`（`feature/645-worktree-dir-naming`）
- [x] `changelog.d/worktree-dir-naming.md` fragment 已新增且已 commit
- [x] `CHANGELOG.md [Unreleased]` 有對應 entry
- [x] `VERSION` 未改（非 release PR）
- [x] `python3 -m pytest tests/ -q` 全綠
- [x] `policy_check` 帶 PR 上下文跑，fail: 0
- [x] 文件與 PR 一律 zh-tw
- [x] docs 同步（Phase 2b runbook 補兩條稽核 ＋ 「手工 spec 驗不了功能」警語）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E7w9kaUxAzCCEk7piD5hfK
