### PR TITLE
fix(trust-root): per-executor 加固剖面——MDWE 與 node 型 executor 的互斥

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,45 @@
 ## [Unreleased]
 
 ### Added
+- **#643 / trust-root Phase 2b：per-executor 加固剖面——`MemoryDenyWriteExecute` 與
+  node 型 executor 的互斥，只讓需要的那一類付代價**——#640／#642 落地後做實機驗證時
+  測出來的：**加固面本身與 toolchain 相衝**，不是安裝沒裝好。以 `cortex-builder` 身分
+  在真實加固面下逐項隔離（`systemd-run` 一次只加一個 property）：無加固時 `node` 正常、
+  `+MemoryDenyWriteExecute=yes` 時 V8 直接崩在 `v8::internal::Runtime_CompileLazy`，
+  其餘每一項（`ProtectSystem=strict`／`PrivateTmp`／`RestrictNamespaces`／
+  `SystemCallFilter=@system-service` ＋ `SystemCallErrorNumber=EPERM`）單獨加上去
+  `node` 都正常——**唯一的阻斷點就是它**（V8 的 JIT 必須有 W+X 記憶體）。影響面是四個
+  executor 掛掉兩個（`codex` node script、`copilot` shell → node 皆空輸出；`claude`／
+  `agy` 原生 ELF 正常），而預設的 `PSC_MANAGER_EXECUTOR=codex` 正是掛掉那一個。
+  operator 裁決走**方向 2（per-executor 剖面）**：
+  - **兩份 job 模板 unit，共用同一張 `_HARDENING` 表**：`cortex-job@.service`
+    （`strict`，完整 27 項，給原生 ELF）與 `cortex-job-jit@.service`（`jit`，給 node
+    型）。兩份**不是**複製貼上的兩段加固——`permgen.HARDENING_PROFILES` 只帶
+    `overrides`，`_hardening_lines()` 現場套用，日後往加固表加一項時兩份自動同時拿到。
+    分岔面由 `permgen.PROFILE_DIVERGENCE_KEYS`（目前＝`{MemoryDenyWriteExecute}`）框住，
+    覆寫不存在的鍵或白名單以外的鍵在 **import 時**即 `ValueError`。
+  - **剖面由 executor 決定，且 job 選不到**（做不到就退化成「全域移除 MDWE」）。四道
+    守法：對應表由既有的 `permgen.EXECUTOR_TOOLS` 的 `needs_node` **機械導出**（不另立
+    第二張清單）；唯一輸入是 `executor`，而它是 Manager 的 dispatch 決定，
+    `prepare_systemd_template()` 的 `executor` 參數**必填無預設**；job spec 結構性禁止
+    攜帶剖面欄位（`hardening_profile`／`profile`／`template`／`template_unit`／
+    `unit_suffix`／`MemoryDenyWriteExecute` 全進 `SPEC_FORBIDDEN_KEYS`，與「身分欄位
+    不入 spec」同一條原則，寫端與讀端各掃一次且掃的是同一支 `forbidden_spec_keys()`）；
+    `PSC_JOB_TEMPLATE_UNIT` 只接受**基底**模板名，帶剖面後綴的值一律拒。
+  - **未知 executor fail-closed**：`resolve_hardening_profile()` 不回傳任何剖面——不是
+    「不確定就給嚴格的」（那會讓未盤點的 node 型 CLI 靜默起不來，症狀是空輸出，
+    #643 本身就是這樣被埋掉的），更不是「不確定就給寬鬆的」（那等於沒做）。
+  - **polkit 維持一條規則、一個 YES 出口**：unit pattern 的字幹段改為列舉的交替
+    （`^(?:cortex-job|cortex-job-jit)@[a-z0-9][a-z0-9._-]{0,62}\.service$`），由
+    `HARDENING_PROFILES` 機械導出。放行面從「一個具名模板」變成「兩個具名模板」，
+    **不是**「任意 unit」；5-7 的反向測試（transient 五形式、名稱前後綴混淆）對新字幹
+    逐條同樣成立，另補圍繞 `-jit` 的十種混淆形式。
+  新增 `tests/test_trust_root_hardening_profile_643.py`（40 測試，其中 2 條在無 root／
+  無 systemd 的環境明確 skip 並附理由）。詳見
+  `changelog.d/per-executor-hardening.md`。
+- **`trust_root unit --job --profile strict|jit` CLI 旗標**：剖面只對 job 模板有意義，
+  用在 `--manager`／`--monitor` 上直接拒絕（靜默忽略會產出與旗標不符的內容）。
+  `trust_root toolchain` 的輸出也逐支列出該 executor 的剖面與對應 unit 名。
 - **#640 / trust-root Phase 2b：真實 dispatch 的最後一哩——executor toolchain 與
   per-account 憑證進登記表**——#623 那一族的第五個缺口，且比前四個都靠後：前四個解完
   之後，dispatch 會一路走到**呼叫模型**那一步才失敗。job unit 帶 `ProtectHome=yes`，
@@ -147,7 +186,9 @@
   `PSC_JOB_RUNNER=systemd-template` 下跑那條 lane，須先把工作區改成 per-job。
   **附帶**：`permgen.build_job_unit()` 把 `CollectMode=inactive-or-failed` 由 `[Service]`
   搬到 `[Unit]`——放錯段只被 systemd 忽略（`Unknown key name … ignoring.`），
-  「失敗的 instance 自動回收」的用意因此沒生效。
+  「失敗的 instance 自動回收」的用意因此沒生效。（#643 在 runbook 第 5-2 步補上落檔後的
+  `systemd-analyze verify | grep -i "unknown key"` 檢查與 `reset-failed` 清理，讓舊部署
+  的殘骸被看見；產生器側的修正已由本條完成，#643 不重複。）
 - **#641 / trust-root：`repo-worktree` 仍授 Manager 唯讀 ACL——交換面已改 bundle，
   這條授權沒有消費者，卻讓 #637 的不變式在實機上不成立**——#637 把成果回收換成
   bundle ＋ append-only spool 並加了「Manager 全程不碰 builder 的 clone」不變式測試，
@@ -366,6 +407,31 @@
   `mock.patch.object` 打不到，測試實際驗到的是「本機有沒有那個帳號」而非它宣稱的分支。
 
 ### Changed
+- **#643 / `permgen.EXECUTOR_TOOLS` 的 `copilot.needs_node` 由 `False` 改為 `True`**
+  ——#640 落表時只知道它是 shell script、還沒查它內部 exec 什麼（表上的 note 當時就
+  寫著「安裝時務必 `head -n 20` 查一次」）。#643 在真實加固面下量到 `copilot
+  --version` 在 `MemoryDenyWriteExecute=yes` 下**空輸出**、拿掉即正常，與 `codex` 的
+  症狀逐字相同——它內部 exec 的就是 node。因此「系統層 node 的版本風險只涵蓋 `codex`
+  一個」在 spec／runbook／表註解三處同步改為**涵蓋 `codex` 與 `copilot` 兩個**。把量
+  到的事實回填既有那張表，而不是為剖面另開一張。
+- **#643 / spec §R3 新增「per-executor 加固剖面」段並明載誠實的取捨**：走 `jit` 剖面
+  的 job **失去 `MemoryDenyWriteExecute` 這一層**（取得任意程式碼執行的攻擊者可在該
+  job 自己的位址空間內配置 W+X 記憶體，JIT 型 shellcode 在此可行）。**沒有失去的部分
+  同樣寫明**：其餘 26 項逐項不變，`User=` 一樣寫死在 root-owned unit 檔裡——W+X 只讓
+  攻擊者在自己這個 UID 內執行程式碼，跨 UID／跨檔案系統／提權那幾層完全沒有鬆動，而
+  §R2／§R3 保護的 Tier-0／Tier-1 資產靠的正是後者。**換到的是**保住 `codex`／
+  `copilot` 兩個 provider，即 §R5／§R8 的 `independence_domain` 仍有可選空間。spec 因此
+  **明文禁止**把本系統敘述成「所有 job 都有完整加固」，準確敘述是「原生 ELF executor
+  的 job 有 27 項；node 型的有 26 項，少的那一項是 `MemoryDenyWriteExecute`」，風險表
+  補兩列（被讀成完整加固／剖面被改成可由呼叫端選擇），並明載退出條件（node 型能在無
+  W+X 下執行時 `jit` 剖面 SHALL 被移除，而非長期保留）。
+- **#643 / Phase 2b runbook**：第 5-2 步改為落**兩份** unit（含「兩份差異必須恰好
+  兩行」的落檔前 gate 與 `systemd-analyze verify` 未知鍵檢查），新增第 5-2b 步「在
+  **真實加固面下**驗證兩種剖面」——形態比照 #640 第 4e 步且**含負向對照**（node 型
+  executor 在 `strict` 剖面下**必須失敗**；只驗寬鬆環境的 `--version` 會整個溜過去，
+  只驗 `jit` 成功也證明不了剖面分岔是必要的）。5-7 新增第 12 條（config 選不了剖面／
+  未知 executor fail-closed／spec 帶剖面欄位被讀端拒），並讓 (5)(7)(8)(9)(10) 對兩個
+  字幹各跑一次 → 合計 **50** 個 sudo 點、**184** 個驗證點。
 - **#640 / job 的 `PATH` 沿用既有的 `PSC_BUILDER_PATH`，並由「選配」改為「必填」**
   ——`PathLayout.job_path_value()` 給出正規值（`<toolchain>/bin` **排最前面**，尾段是
   系統層，不含任何 `sbin`）。**刻意不在模板 unit 裡寫 `Environment=PATH=`**：模板

--- a/changelog.d/per-executor-hardening.md
+++ b/changelog.d/per-executor-hardening.md
@@ -1,0 +1,85 @@
+### Added
+- **#643 / trust-root Phase 2b：per-executor 加固剖面——`MemoryDenyWriteExecute` 與
+  node 型 executor 的互斥，只讓需要的那一類付代價**——#640／#642 落地後做實機驗證時
+  測出來的：**加固面本身與 toolchain 相衝**。以 `cortex-builder` 身分在真實加固面下
+  逐項隔離（`systemd-run` 一次只加一個 property），結果是無加固時 `node` 正常、
+  `+MemoryDenyWriteExecute=yes` 時 V8 直接崩在 `v8::internal::Runtime_CompileLazy`，
+  其餘每一項（`ProtectSystem=strict`／`PrivateTmp`／`RestrictNamespaces`／
+  `SystemCallFilter=@system-service` ＋ `SystemCallErrorNumber=EPERM`）單獨加上去
+  `node` 都正常——**唯一的阻斷點就是它**，V8 的 JIT 必須有 W+X 記憶體。影響面是四個
+  executor 掛掉兩個（`codex` node script、`copilot` shell → node 皆空輸出；`claude`／
+  `agy` 原生 ELF 正常），而預設的 `PSC_MANAGER_EXECUTOR=codex` 正是掛掉那一個。
+  operator 裁決走**方向 2（per-executor 剖面）**：
+  - **兩份 job 模板 unit，共用同一張 `_HARDENING` 表**——`cortex-job@.service`
+    （`strict`，完整 27 項，給原生 ELF）與 `cortex-job-jit@.service`（`jit`，給 node
+    型）。兩份**不是**兩段複製貼上的加固段：`permgen.HARDENING_PROFILES` 只帶
+    `overrides`，`_hardening_lines()` 現場套用，因此日後往加固表加一項時兩份自動同時
+    拿到。分岔面由 `permgen.PROFILE_DIVERGENCE_KEYS`（目前＝`{MemoryDenyWriteExecute}`）
+    結構性框住，覆寫一個不存在的鍵、或覆寫白名單以外的鍵，在 **import 時**就是
+    `ValueError`——「一個看起來有效、實際毫無作用的覆寫」不可能悄悄存在。
+  - **剖面由 executor 決定，且 job 選不到**（這是本設計全部的價值，做不到就退化成
+    「全域移除 MDWE」）。四道守法：(1) 對應表由既有的 `permgen.EXECUTOR_TOOLS` 的
+    `needs_node` **機械導出**，不另立第二張清單；(2) 唯一的輸入是 `executor`，而它是
+    Manager 的 dispatch 決定（`SubprocessLauncher(executor=...)`，在任何 per-job 產物
+    之前就固定），`prepare_systemd_template()` 的 `executor` 參數**必填無預設**；
+    (3) job spec **結構性禁止**攜帶剖面欄位（`hardening_profile`／`profile`／`template`
+    ／`template_unit`／`unit_suffix`／`MemoryDenyWriteExecute` 全進
+    `SPEC_FORBIDDEN_KEYS`，與「身分欄位不入 spec」同一條原則，寫端與讀端各掃一次、
+    且掃的是新抽出的**同一支** `forbidden_spec_keys()`）；(4) 部署 config
+    `PSC_JOB_TEMPLATE_UNIT` 只接受**基底**模板名，帶剖面後綴的值一律拒——否則一行
+    config 就能把所有 job 推到寬鬆剖面。
+  - **未知 executor fail-closed**：`resolve_hardening_profile()` 不回傳任何剖面。方向
+    刻意不是「不確定就給嚴格的」——那會讓一個未被盤點過的 node 型 CLI 在真實加固面下
+    靜默起不來（症狀是空輸出，離原因很遠，#643 本身就是這樣被埋掉的）；也絕不是
+    「不確定就給寬鬆的」（那等於沒做）。唯一正確的行為是要求它先進 `EXECUTOR_TOOLS`。
+  - **polkit 用同一條規則、同一個 YES 出口**：unit pattern 的字幹段改為**列舉的交替**
+    （`^(?:cortex-job|cortex-job-jit)@[a-z0-9][a-z0-9._-]{0,62}\.service$`），由
+    `HARDENING_PROFILES` 機械導出。放行面從「一個具名模板」變成「兩個具名模板」，
+    **不是**「任意 unit」：前後仍錨定、instance 段字元類一字未改。5-7 的反向測試
+    （transient 五形式、名稱前後綴混淆）對新字幹逐條同樣成立，並新增圍繞 `-jit` 的
+    十種混淆形式。
+- **`trust_root unit --job --profile strict|jit` CLI 旗標**：剖面只對 job 模板有意義，
+  用在 `--manager`／`--monitor` 上會直接拒絕（靜默忽略會產出一份與旗標不符的內容）。
+  `trust_root toolchain` 的輸出也逐支列出該 executor 的剖面與對應 unit 名。
+
+### Fixed
+- **`CollectMode` 放錯 section 的落檔後檢查**——產生器側的修正（由 `[Service]` 搬到
+  `[Unit]`）已由 **#645 附帶完成**，本 PR 不重複；#643 補的是它缺的另外兩半：
+  (a) runbook 第 5-2 步新增 `systemd-analyze verify | grep -i "unknown key"` 的落檔後
+  檢查與 `systemctl reset-failed` 清理——**舊部署落檔的 unit 不會因為產生器修好就自己
+  更新**，殘骸仍掛在 `systemctl list-units --failed` 上擋住同名 instance 的下一次
+  start；(b) 測試把這條守衛擴到**兩份**剖面（新增的 `cortex-job-jit@.service` 若是複製
+  貼上來的就可能複製到舊的放法），並改以「真正的指令行」判段而非字串 split——產生出來
+  的註解本身就含有 `[Unit]`／`[Service]` 字樣（在解釋這個坑），naive split 會切錯。
+
+### Changed
+- **`permgen.EXECUTOR_TOOLS` 的 `copilot.needs_node` 由 `False` 改為 `True`**——#640
+  落表時只知道它是 shell script、還沒查它內部 exec 什麼（表上的 note 當時就寫著
+  「安裝時務必 `head -n 20` 查一次它實際 exec 什麼」）。#643 在真實加固面下量到
+  `copilot --version` 在 `MemoryDenyWriteExecute=yes` 下**空輸出**、拿掉即正常，與
+  `codex` 的症狀逐字相同——它內部 exec 的就是 node。因此「系統層 node 的版本風險只
+  涵蓋 `codex` 一個」這句話在 spec／runbook／表註解三處同步改為**涵蓋 `codex` 與
+  `copilot` 兩個**。把量到的事實回填既有那張表，而不是為剖面另開一張。
+- **spec §R3 新增「per-executor 加固剖面」段，並明載誠實的取捨**：走 `jit` 剖面的 job
+  **失去 `MemoryDenyWriteExecute` 這一層**——取得任意程式碼執行的攻擊者可在該 job 自己
+  的位址空間內配置 W+X 記憶體，JIT 型 shellcode 在此可行。**沒有失去的部分同樣寫明**：
+  其餘 26 項逐項不變（`NoNewPrivileges`／`CapabilityBoundingSet` 空／
+  `ProtectSystem=strict`／`RestrictNamespaces`／`SystemCallFilter`…），`User=` 一樣寫死
+  在 root-owned unit 檔裡——W+X 只讓攻擊者在**自己這個 UID** 內執行程式碼，跨 UID／
+  跨檔案系統／提權那幾層完全沒有鬆動，而 §R2／§R3 保護的 Tier-0／Tier-1 資產靠的正是
+  後者。**換到的是**保住 `codex`／`copilot` 兩個 provider，即 §R5／§R8 的
+  `independence_domain` 仍有可選空間（方向 3「只用原生 ELF」會讓 build 域可選空間當場
+  減半；方向 1「全域移除」則讓不需要放寬的 `claude`／`agy` 一起失去該層）。spec 因此
+  **明文禁止**把本系統敘述成「所有 job 都有完整加固」，準確敘述是「原生 ELF executor
+  的 job 有 27 項；node 型的有 26 項，少的那一項是 `MemoryDenyWriteExecute`」，並在
+  風險表補兩列（被讀成完整加固／剖面被改成可由呼叫端選擇）。同時明載退出條件：若某天
+  node 型 executor 能在無 W+X 下執行（V8 jitless、或 CLI 改原生編譯），`jit` 剖面
+  SHALL 被移除而非長期保留。
+- **Phase 2b runbook 第 5-2 步改為落兩份 unit ＋ 新增第 5-2b 步**「在**真實加固面下**
+  驗證兩種剖面」——形態比照 #640 的第 4e 步，且**含負向對照**：node 型 executor 在
+  `strict` 剖面下**必須失敗**。只驗寬鬆環境的 `--version` 會整個溜過去（四支在
+  `sudo -u` 下全部 rc=0、版本全部相符，而其中兩支在真實加固面下是空輸出）；只驗 `jit`
+  剖面成功也證明不了剖面分岔是必要的。5-2 另加一條「兩份 unit 的差異必須恰好兩行」的
+  落檔前 gate，5-7 新增第 12 條（config 選不了剖面／未知 executor fail-closed／spec 帶
+  剖面欄位被讀端拒），並讓 (5)(7)(8)(9)(10) 對兩個字幹各跑一次
+  → 合計 **50** 個 sudo 點、**184** 個驗證點。

--- a/docs/superpowers/runbooks/trust-root-phase2b-setup.md
+++ b/docs/superpowers/runbooks/trust-root-phase2b-setup.md
@@ -31,7 +31,7 @@ OS** 的手動流程。
 
 | 未決點 | 定案（0816 第三輪，#584 留言） | 落在本 runbook |
 |---|---|---|
-| **降權機制** | **A+B 並行，單一路徑**。A＝UID **三分提前**；B＝**root-owned template unit**（`cortex-job@.service`，`User=` 寫死）。C（code-level argv 保證）自動保留為第三層，由 **root-owned shim** 承接 | 第 1、5 步 |
+| **降權機制** | **A+B 並行，單一路徑**。A＝UID **三分提前**；B＝**root-owned template unit**（`cortex-job@.service`；#643 起 node 型 executor 另有同源的 `cortex-job-jit@.service`，`User=` 兩份都寫死）。C（code-level argv 保證）自動保留為第三層，由 **root-owned shim** 承接 | 第 1、5 步 |
 | **UID 方案** | **三分為唯一路徑**：`cortex-manager`（Manager＋monitor，durable state owner，持 spawn 授權，**不跑任何模型程式碼**）／`cortex-reviewer-planner`（reviewer＋planner 模型 job）／`cortex-builder`（builder 模型 job）。`permgen.THREE_WAY_SCHEME` 由備選轉為**定案方案** | 第 1 步 |
 | durable state 路徑 | **`/var/lib/cortex`**；worktree pool＝**`/var/lib/cortex/worktree`** | 第 2 步 |
 | legacy-import | **物理隔離 ＋ hash manifest**（無簽章；簽章屬 Phase 3）。切換前 in-flight job **手動收尾** | 執行前提、第 3 步 |
@@ -78,7 +78,7 @@ OS** 的手動流程。
 
 | 里程碑 | 內容 | 本 runbook |
 |---|---|---|
-| **M1** | 三帳號建立、**檔案權限面完整三分**、builder job 經 `cortex-job@.service` 降權、polkit 只授 `cortex-manager` 對 `cortex-job@*` | ✅ 本 runbook 全程 |
+| **M1** | 三帳號建立、**檔案權限面完整三分**、builder job 經 `cortex-job@.service`／`cortex-job-jit@.service` 降權、polkit 只授 `cortex-manager` 對這**兩個具名模板** | ✅ 本 runbook 全程 |
 | **M2** | reviewer／planner job 也改經 template instance（`User=cortex-reviewer-planner`）落到自己的帳號 | ⏳ 程式碼工項 **#615**（範圍以該 PR 實際落地為準）。M1 已於 2026-08-17 完成，**M2 未做**——D6 的「三分已生效」全稱在 #615 之前 **BLOCKING** |
 
 **M1 下的誠實邊界**：`launcher.SubprocessLauncher._degraded_runner()` 目前只對 **builder
@@ -239,7 +239,7 @@ A/B 並列時同一件事要寫兩遍（5-A／5-B、第 8 步兩種起法、附�
 | 第 2 步：目標樹與權限（含 2c 來源樹） | 4 | 21 |
 | 第 3 步：legacy-import（含 operator 設定搬遷） | 3 | 11 |
 | 第 4 步：Manager／monitor 部署與 unit（含 4e toolchain／憑證） | 16 | 33 |
-| **第 5 步：降權（A+B）** | **7** | **28** |
+| **第 5 步：降權（A+B ＋ #643 per-executor 剖面）** | **8** | **38** |
 | 第 6 步：升級流程 | 5 | 6 |
 | 第 7 步：切換驗收（含功能面檢查） | 0 | 5 |
 | 第 8 步：R9 抽驗（五族） | 5 | 19 |
@@ -247,15 +247,18 @@ A/B 並列時同一件事要寫兩遍（5-A／5-B、第 8 步兩種起法、附�
 | WSL2 風險與診斷 | 2 | 12 |
 | 附錄 A：自我檢查 | 0 | 9 |
 | 附錄 B：降級備援 | 2 | 3 |
-| **合計** | **49** | **174** |
+| **合計** | **50** | **184** |
 
 （統計方式：全文 `🔧`／`✅` 標記出現次數，扣除說明性用法——「標記約定」的定義行、
 段落標題內的標記、以及表格裡當狀態記號用的那幾個。）
 
 - **步驟數**：9 步（未變）＋ 3 個附錄；第 5 步由「兩個並列方案（5-A 六節／5-B 四節，
-  共 10 節）」收斂為**一條九節路徑**（5-1…5-9）。
+  共 10 節）」收斂為**一條九節路徑**（5-1…5-9），#643 於其中插入 5-2b（真實加固面下
+  的雙剖面驗證）。
 - **反向測試**：原本分散在 5-A-5（4 條，其中 1 條「已知不會被拒」）與 5-B-4（7 條），
   收斂後集中在 5-7（**11 條**），且**全部期望為「被拒」**——不再有任何一條期望成功。
+  #643 再補第 12 條（三小條，期望為「拒絕確實發生」），並讓 (5)(7)(8)(9)(10) 對
+  **兩個**模板字幹各跑一次。
 - **R9 族數**：4 → **5**（新增族 5 privilege-boundary），且族 1–4 各跑**兩個 subject**
   （builder ／ reviewer-planner），實測條數約為舊版的兩倍。
 - **#621（M1 對照後的修正）新增**：執行前提兩個硬性 gate（`acl`／sudoers 萬用規則）、
@@ -275,6 +278,13 @@ A/B 並列時同一件事要寫兩遍（5-A／5-B、第 8 步兩種起法、附�
   憑證「檔 job-owned／目錄 root-owned」的三條反向不變式），另在「產生器＝單一真相」
   與 5-5 各補一條 ✅、附錄 A 補兩條漂移自我檢查（版本分岔／憑證 owner）
   → **49** 個 sudo 點、**174** 個驗證點。
+- **#643（per-executor 加固剖面）新增**：第 5-2 步改為落**兩份** template unit
+  （strict／jit，差異必須只有 `MemoryDenyWriteExecute` 一項）、新增第 5-2b 步「在
+  真實加固面下驗證兩種剖面」（**含負向對照**：node 型 executor 在 strict 剖面下必須
+  失敗——只驗 jit 成功等於什麼都沒驗）、5-7 補第 12 條（Manager 選不了剖面）與
+  兩字幹複跑（含 `systemd-analyze verify` 的未知鍵落檔後檢查——#645 修的是產生器，
+  已落檔的 unit 不會自己更新），4e 的 executor 形態表回填「`copilot` 也需要 node」
+  → **50** 個 sudo 點、**184** 個驗證點。
 
 ---
 
@@ -291,7 +301,9 @@ A/B 並列時同一件事要寫兩遍（5-A／5-B、第 8 步兩種起法、附�
 | 登記表雙向等式 | 執行前提 4／第 7 步 | `ok: true`（切換前後皆是） |
 | legacy-import manifest | 第 3 步 | 78,674 檔；全量複驗 78,674/78,674 `OK` |
 | 5-6 正向 smoke | 第 5 步 | 成功；`uid=…(cortex-builder)`、token 已 scrub、fd 僅 0/1/2、`HOME=/var/lib/cortex-builder`（root-owned）、部署樹不可寫 |
-| 5-7 反向 11 條 | 第 5 步 | **全數非 0** |
+| 5-2b 雙剖面（#643） | 第 5 步 | 正向四段皆 rc=0 且版本相符；**負向對照**：`codex`／`copilot` 在 strict 剖面下**空輸出** |
+| 5-7 反向 11 條 | 第 5 步 | **全數非 0**（(5)(7)(8)(9)(10) 對兩個字幹各一次） |
+| 5-7 (12) 剖面不可選（#643） | 第 5 步 | 三小條**全部 0**（＝拒絕確實發生） |
 | 5-7 (11) fail-closed | 第 5 步 | 移除 polkit 規則後起 job **失敗**、還原後**成功**（證明是規則在守，不是全紅假綠） |
 | 8a 族 1–4（builder） | 第 8 步 | 46 `denied` ／ 3 條 `SUCCEEDED` 標記 → 三條**全部判定為非破口**，且**三條的成因就是本 runbook 這次修掉的 #621 第 7／8／9 條**（期望寫反、測錯面、`rm -f` 假陽性）。按修正後的腳本重跑應為**全數 denied** |
 | 8a 族 1–4（reviewer-planner） | 第 8 步 | 47 `denied` ／ 2 條標記；**T1.5 對它是拒絕的** ← 三分在檔案層生效的直接證據 |
@@ -334,9 +346,13 @@ python3 -m paulsha_cortex.trust_root unit three-way --manager
 python3 -m paulsha_cortex.trust_root unit three-way --monitor
 
 # ✅ job template unit 內容（User=cortex-builder 硬寫死；B 的核心）
+#    #643：**兩份**——strict（預設）與 jit（node 型 executor），差異只有
+#    MemoryDenyWriteExecute 一項；剖面對應表由 permgen.EXECUTOR_TOOLS 機械導出。
 python3 -m paulsha_cortex.trust_root unit three-way --job
+python3 -m paulsha_cortex.trust_root unit three-way --job --profile jit
 
-# ✅ 降權 polkit 規則內容（只放行 cortex-job@*.service 的 start/stop）
+# ✅ 降權 polkit 規則內容
+#    （只放行 cortex-job@*.service 與 cortex-job-jit@*.service 的 start/stop）
 python3 -m paulsha_cortex.trust_root polkit three-way --template
 
 # ✅ root-owned shim 內容（/opt/cortex/bin/cortex-job-shim）—— #616 已 merge
@@ -1411,15 +1427,21 @@ job／服務帳號唯讀＋可執行）。理由是「job 跑的是哪個版本�
 
 **四個 CLI 的實體形態不同，搬移方式不能一概而論**（表在 `permgen.EXECUTOR_TOOLS`）：
 
-| executor | 形態 | 需要 node | 搬移方式 |
-|---|---|:--:|---|
-| `codex` | Node.js script（`.js` ＋ `#!/usr/bin/env node`） | ✅ | **整包** npm 套件樹，`bin/` 放進入點 symlink |
-| `claude` | 原生 ELF 執行檔 | — | 單檔複製 |
-| `copilot` | bash script | — | 單檔複製；**先 `head -n 20` 查它內部再叫什麼** |
-| `agy` | 原生 ELF 執行檔 | — | 單檔複製 |
+| executor | 形態 | 需要 node | 加固剖面（#643） | 搬移方式 |
+|---|---|:--:|---|---|
+| `codex` | Node.js script（`.js` ＋ `#!/usr/bin/env node`） | ✅ | `jit` | **整包** npm 套件樹，`bin/` 放進入點 symlink |
+| `claude` | 原生 ELF 執行檔 | — | `strict` | 單檔複製 |
+| `copilot` | bash script → **內部 exec node** | ✅ | `jit` | 單檔複製；**先 `head -n 20` 查它內部再叫什麼** |
+| `agy` | 原生 ELF 執行檔 | — | `strict` | 單檔複製 |
 
 > `claude`／`agy` 自帶原生執行檔，**不會因為 node 版本而行為改變**——因此系統層 node
-> 的版本風險只涵蓋 `codex` 一個。
+> 的版本風險只涵蓋 `codex`／`copilot` 兩個。
+>
+> **`copilot` 的「需要 node」是 #643 回填的**：#640 落表時只知道它是 shell script、
+> 還沒查它內部 exec 什麼（上表當時就寫著「先 `head -n 20` 查」）。#643 在真實加固面
+> 下量到它與 `codex` 的症狀逐字相同（`MemoryDenyWriteExecute=yes` 下空輸出、拿掉即
+> 正常）——那就是 node。**這一欄同時決定加固剖面**（`permgen.EXECUTOR_TOOLS` 的
+> `needs_node` 是唯一真相來源，剖面由它機械導出，見第 5-2 步）。
 
 ```bash
 # ✅ 先讀落位步驟（含每支 CLI 的形態與搬移方式；產生器＝單一真相）
@@ -1487,10 +1509,16 @@ sudo systemd-run --pipe --wait --collect \
   --setenv=HOME=/var/lib/cortex-builder \
   --setenv=PATH=/opt/cortex/toolchain/bin:/usr/local/bin:/usr/bin:/bin \
   /opt/cortex/toolchain/bin/codex --version
-#   期望：與上一條同一個版本、rc=0。
-#   ⚠️ 若這條失敗而 `sudo -u` 那條成功，**第一嫌疑是 `MemoryDenyWriteExecute=yes`**
-#      （node 的 V8 需要 W→X 轉換）。單獨拿掉該 property 複測即可確認；確認後
-#      屬 unit 加固面的裁決，記進 #584 而不是在這裡自行放寬。
+#   期望（`codex` 這一支）：**空輸出**。
+#   ✅ 這不是失敗，是 #643 已經定案的事實：`MemoryDenyWriteExecute=yes` 與 V8 的 JIT
+#      天生互斥（node 崩在 `v8::internal::Runtime_CompileLazy`）。上面這條刻意保留
+#      **完整**加固面，是為了讓執行者親眼看到「為什麼需要第二份剖面」。
+#   ✅ 把 `--property=MemoryDenyWriteExecute=yes` 改成 `=no` 複跑，應印出與 operator
+#      側逐字相同的版本——那正是 `cortex-job-jit@.service`（jit 剖面）的加固面。
+#   ⚠️ 若**兩種**都失敗，那就不是 MDWE，回到上一條查 PATH／toolchain 可達性。
+#   ⚠️ `claude`／`agy` 在**兩種**下都應該 rc=0；若它們在完整加固面下也失敗，代表
+#      這台機器上還有第三個阻斷點——**停下來查清楚**，不要順手再放寬一項。
+#   完整的雙剖面驗證（含負向對照）在第 5-2b 步；這裡只是提早看見那條分岔。
 ```
 
 **per-account 憑證（0817 裁決 (b)）**：憑證**檔**由 job 帳號擁有（才 refresh 得了
@@ -1573,40 +1601,153 @@ sudo -u cortex-builder sh -c \
 
 | # | 物件／事實 | 路徑 | 擁有者 | 它強制什麼 |
 |---|---|---|---|---|
-| (a) | **polkit 規則** | `/etc/polkit-1/rules.d/49-cortex-downgrade.rules` | root:root 0644 | 只有 `cortex-manager`、只有 `start`／`stop`、只有 `cortex-job@*.service`。**不授權 `manage-units` 的 transient 建立** |
-| (b) | **template unit** | `/etc/systemd/system/cortex-job@.service` | root:root 0644 | `User=cortex-builder` 寫死、加固段寫死、`ExecStart=` 寫死。呼叫端**選不了 UID、傳不了屬性** |
+| (a) | **polkit 規則** | `/etc/polkit-1/rules.d/49-cortex-downgrade.rules` | root:root 0644 | 只有 `cortex-manager`、只有 `start`／`stop`、只有 `cortex-job@*.service` 與 `cortex-job-jit@*.service` 兩個**具名**模板。**不授權 `manage-units` 的 transient 建立** |
+| (b) | **template unit ×2** | `/etc/systemd/system/cortex-job@.service`（strict）<br>`/etc/systemd/system/cortex-job-jit@.service`（jit，#643） | root:root 0644 | `User=cortex-builder` 寫死、加固段寫死、`ExecStart=` 寫死。呼叫端**選不了 UID、傳不了屬性**。兩份的差異**只有** `MemoryDenyWriteExecute`（見 5-2 的剖面說明） |
 | (c) | **shim** | `/opt/cortex/bin/cortex-job-shim` | root:root 0755 | `ExecStart=` 的實體。argv 的**形狀**由 root-owned 程式從 Manager-owned job-spec 導出；Manager 只能給參數 |
 | — | **三分帳號事實** | — | — | polkit 的 subject 只有 `cortex-manager`，而它**不跑任何模型程式碼**；injection 可達的 job 帳號完全不在授權面上 |
 
 三者缺一都不成立：
 - 少了 (a)，`cortex-manager` 起不了 job（fail-closed，不會退回同 UID）。
 - 少了 (b)，`User=` 回到呼叫端手上——polkit 看不到它，等於沒守。
+  **只裝一份也不成立**：漏裝 `cortex-job-jit@.service` 時，走 node 型 executor
+  （`codex`／`copilot`）的派工會在 `prepare_systemd_template()` 的 preflight
+  fail-closed（`job-runner-job-template-missing`），不會靜默退回 strict 那份。
 - 少了 (c)，argv 的入口落在 Manager 可寫的樹裡；Manager 被攻陷即可換掉執行的東西。
 
-### 5-2. 安裝 (b) template unit
+### 5-2. 安裝 (b) template unit（**兩份**，#643 per-executor 加固剖面）
+
+> **為什麼是兩份**：`MemoryDenyWriteExecute=yes` 擋的是 JIT 型 shellcode，而 V8 的
+> JIT **必須**有 W+X 記憶體——這一項與 JS runtime 天生互斥。實機逐項隔離的結果是
+> 「唯一的阻斷點就是它」：`+MemoryDenyWriteExecute=yes` 下 `node` 直接崩在
+> `v8::internal::Runtime_CompileLazy`，其餘每一項（`ProtectSystem=strict`／
+> `PrivateTmp`／`RestrictNamespaces`／`SystemCallFilter=@system-service` ＋
+> `SystemCallErrorNumber=EPERM`）單獨加上去 `node` 都正常。
+>
+> 因此 operator 裁決走 **per-executor 剖面**：node 型 executor（`codex`／`copilot`）
+> 走 `cortex-job-jit@.service`，原生 ELF（`claude`／`agy`）維持嚴格的
+> `cortex-job@.service`。**兩份由同一張加固表產生**，只在 `MemoryDenyWriteExecute`
+> 這一項分岔（測試以集合比對釘住，見 `tests/test_trust_root_hardening_profile_643.py`）。
+>
+> **剖面選不到寬鬆那份**（這是本設計全部的價值）：對應表由
+> `permgen.EXECUTOR_TOOLS` 的 `needs_node` 機械導出，唯一的輸入是 **executor**，而
+> executor 是 Manager 的 dispatch 決定；job spec 結構性禁止攜帶任何剖面欄位
+> （`job_runner.SPEC_FORBIDDEN_KEYS`，寫端與讀端各擋一次），未知 executor
+> **fail-closed**（不落到寬鬆那份），`PSC_JOB_TEMPLATE_UNIT` 也不接受已帶剖面
+> 後綴的值（否則 operator 可以一鍵把所有 job 推到寬鬆剖面）。
+>
+> **代價**：走 jit 剖面的 job **失去 MDWE 這層防護**。這是為了保留 provider 多樣性
+> （`independence_domain` 的可選空間）付的代價，不是沒有代價——完整說明見 spec
+> §R3「per-executor 加固剖面」段，產生出來的 unit 檔頭也逐條寫著。
 
 ```bash
-# ✅ 先看內容
+# ✅ 先看兩份內容（剖面在檔頭以「=== 加固剖面 ===」段標明，含它接受的代價）
 python3 -m paulsha_cortex.trust_root unit three-way --job | less
-#   必須確認的三行：
+python3 -m paulsha_cortex.trust_root unit three-way --job --profile jit | less
+#   兩份都必須確認的三行：
 #     User=cortex-builder      ← 唯一 UID 來源，寫死
 #     Group=cortex-builder
 #     ExecStart=…              ← 見 5-3；PR 落地後應指向 /opt/cortex/bin/cortex-job-shim
 
+# ✅ 兩份的差異必須**只有一項**（這條先跑；不成立就不要落檔）
+diff <(python3 -m paulsha_cortex.trust_root unit three-way --job) \
+     <(python3 -m paulsha_cortex.trust_root unit three-way --job --profile jit) \
+  | grep -E "^[<>] [A-Za-z]" | sort
+#   期望恰好兩行（同一個鍵的兩個值）：
+#     < MemoryDenyWriteExecute=yes
+#     > MemoryDenyWriteExecute=no
+#   ⚠️ 出現任何第三行 ⇒ 兩份剖面在加固表以外也分岔了，**停下來**：
+#      那代表產生器被改成兩段各自維護，本步驟的前提不再成立。
+
 # 🔧 sudo：落檔（root 擁有——這是 User= 不可被竄改的前提）
-python3 -m paulsha_cortex.trust_root unit three-way --job \
-  | sudo tee /etc/systemd/system/cortex-job@.service >/dev/null
-sudo chown root:root /etc/systemd/system/cortex-job@.service
-sudo chmod 0644 /etc/systemd/system/cortex-job@.service
+for P in "" "--profile jit"; do
+  U=$(python3 -m paulsha_cortex.trust_root unit three-way --job $P \
+        | sed -n '1s|^# /etc/systemd/system/||p')
+  python3 -m paulsha_cortex.trust_root unit three-way --job $P \
+    | sudo tee "/etc/systemd/system/$U" >/dev/null
+  sudo chown root:root "/etc/systemd/system/$U"
+  sudo chmod 0644 "/etc/systemd/system/$U"
+  echo "installed: $U"
+done
 sudo systemctl daemon-reload
+#   期望印出兩行：cortex-job@.service、cortex-job-jit@.service
 
 # ✅ 驗證：與產生器逐位元相同、User= 確實寫死
 diff <(python3 -m paulsha_cortex.trust_root unit three-way --job) \
-     /etc/systemd/system/cortex-job@.service && echo "job unit in sync: OK"
-grep -E "^(User|Group|ExecStart|NoNewPrivileges|CapabilityBoundingSet)=" \
-     /etc/systemd/system/cortex-job@.service
-#   期望：User=cortex-builder、Group=cortex-builder、NoNewPrivileges=yes、
-#         CapabilityBoundingSet=（空值）
+     /etc/systemd/system/cortex-job@.service && echo "job unit (strict) in sync: OK"
+diff <(python3 -m paulsha_cortex.trust_root unit three-way --job --profile jit) \
+     /etc/systemd/system/cortex-job-jit@.service && echo "job unit (jit) in sync: OK"
+for U in cortex-job cortex-job-jit; do
+  echo "--- $U"
+  grep -E "^(User|Group|ExecStart|NoNewPrivileges|CapabilityBoundingSet|MemoryDenyWriteExecute)=" \
+       "/etc/systemd/system/$U@.service"
+done
+#   期望：兩份皆 User=cortex-builder、Group=cortex-builder、NoNewPrivileges=yes、
+#         CapabilityBoundingSet=（空值）；MemoryDenyWriteExecute 一份 yes 一份 no。
+
+# ✅ 驗證：systemd 解析兩份都無「未知鍵」（#645 修的 CollectMode 就是這一族）
+sudo systemd-analyze verify /etc/systemd/system/cortex-job@.service \
+                            /etc/systemd/system/cortex-job-jit@.service 2>&1 \
+  | grep -i "unknown key" && echo "❌ 有未知鍵，停下來" || echo "no unknown keys: OK"
+#   ⚠️ 舊版落檔的 unit 會在這裡報
+#      `Unknown key name 'CollectMode' in section 'Service', ignoring.`
+#      ——那表示「失敗的 instance 自動回收」從來沒有生效過（#645 已把它移回 [Unit]；
+#      **產生器修好不代表已落檔的 unit 跟著更新**，所以這條檢查在落檔後跑）。
+#      重新落檔即修好；順便清一次殘骸：
+#        systemctl list-units --failed 'cortex-job*'
+#        sudo systemctl reset-failed 'cortex-job@*' 'cortex-job-jit@*'
+```
+
+### 5-2b. 在**真實加固面下**驗證兩種剖面（#643 的核心驗收）
+
+**只驗寬鬆環境的 `--version` 會整個溜過去**——四支 executor 在 `sudo -u` 下全部
+rc=0、版本全部相符，而其中兩支在真實加固面下是空輸出。這一步的形狀比照第 4e 步：
+用 `systemd-run` 把**真的加固指令**帶上去跑，且**必須有負向對照**（strict 剖面下
+node 型 executor 應該失敗；只驗 jit 成功等於什麼都沒驗）。
+
+```bash
+# ✅ 直接從已落檔的 unit 取出加固面，組成 systemd-run 的 --property 清單
+#    （不要手打——手打的清單與 unit 漂移時，這一步驗的就不是 unit 了）
+props() {
+  sudo grep -E "^(NoNewPrivileges|CapabilityBoundingSet|AmbientCapabilities|ProtectSystem|ProtectHome|PrivateTmp|PrivateDevices|ProtectProc|ProcSubset|ProtectControlGroups|ProtectKernelModules|ProtectKernelTunables|ProtectKernelLogs|ProtectClock|ProtectHostname|RestrictSUIDSGID|RestrictNamespaces|RestrictRealtime|RestrictAddressFamilies|LockPersonality|MemoryDenyWriteExecute|SystemCallArchitectures|SystemCallFilter|SystemCallErrorNumber|RemoveIPC|KeyringMode|UMask)=" \
+    "/etc/systemd/system/$1@.service" | sed 's/^/--property=/'
+}
+run_under() {   # run_under <unit-stem> <cli>
+  sudo systemd-run --pipe --wait --collect --quiet \
+    --uid=cortex-builder --gid=cortex-builder \
+    $(props "$1") \
+    --setenv=HOME=/var/lib/cortex-builder \
+    --setenv=PATH=/opt/cortex/toolchain/bin:/usr/local/bin:/usr/bin:/bin \
+    "/opt/cortex/toolchain/bin/$2" --version
+}
+
+# ✅ (1) 正向：每個 executor 在**它自己的**剖面下必須跑得出版本
+for cli in claude agy; do echo "== $cli @strict"; run_under cortex-job     "$cli"; echo "rc=$?"; done
+for cli in codex copilot; do echo "== $cli @jit"; run_under cortex-job-jit "$cli"; echo "rc=$?"; done
+#   期望：四段皆印出版本字串且 rc=0，且版本與 operator 側逐字相同（第 4e 步那條）。
+
+# ✅ (2) **負向對照（不可省略）**：node 型 executor 在 strict 剖面下必須**失敗**
+for cli in codex copilot; do echo "== $cli @strict（期望空輸出／非 0）"; run_under cortex-job "$cli"; echo "rc=$?"; done
+#   期望：**空輸出**（V8 崩在 Runtime_CompileLazy）。
+#   ⚠️ 若這兩段也印出版本 ⇒ strict 那份 unit 的 MemoryDenyWriteExecute 沒生效
+#      （落檔錯／被 drop-in 覆蓋／props() 沒抓到那一行）。此時 (1) 的綠是假的，
+#      因為它證明不了「jit 剖面是必要的」，也證明不了「strict 剖面真的在守」。
+
+# ✅ (3) 對照：原生 ELF 在 jit 剖面下也會動（證明差異只在 node 型身上）
+run_under cortex-job-jit claude; echo "rc=$?"
+#   期望：rc=0。這條不是驗收條件，是在 (2) 失敗時區分「MDWE 沒生效」與
+#   「toolchain 根本不可達」的分流點。
+
+# ✅ (4) 剖面對應表：確認程式碼看到的分類與上面實測一致
+python3 - <<'PY'
+from paulsha_cortex.trust_root import permgen
+for tool in permgen.EXECUTOR_TOOLS:
+    p = permgen.executor_hardening_profile(tool.name)
+    print(f"{tool.name:8s} needs_node={str(tool.needs_node):5s} "
+          f"profile={p.profile_id:6s} unit={permgen.job_unit_stem(profile=p)}@.service")
+PY
+#   期望：codex/copilot → jit（cortex-job-jit@.service）；claude/agy → strict。
+#   ⚠️ 若實測 (1)(2) 與這張表對不上，**以實測為準**並回填 permgen.EXECUTOR_TOOLS
+#      的 needs_node（那張表是唯一真相來源），不要在 runbook 裡各記一份。
 ```
 
 ### 5-3. 部署 (c) root-owned shim
@@ -1659,8 +1800,9 @@ systemctl cat cortex-job@.service | grep -E "^ReadWritePaths=/var/lib/cortex/wor
 #   （`feature-<slice_id>`），與 `%i` 永遠差一個前綴 ⇒ ReadWritePaths 指向不存在
 #   的路徑 ⇒ `Failed to set up mount namespacing` / `226/NAMESPACE`，job 起不來。
 
-# ✅ 檢查 unit 沒有被忽略的鍵（#645 附帶）
-sudo systemd-analyze verify /etc/systemd/system/cortex-job@.service
+# ✅ 檢查 unit 沒有被忽略的鍵（#645 附帶；#643 起兩份都要驗）
+sudo systemd-analyze verify /etc/systemd/system/cortex-job@.service \
+                            /etc/systemd/system/cortex-job-jit@.service
 #   期望：**沒有** `Unknown key name 'CollectMode' in section 'Service', ignoring.`
 #   `CollectMode` 屬 `[Unit]`；放在 `[Service]` 只是被忽略（不影響行為），但
 #   「失敗的 instance 自動回收」這個用意不會生效，失敗殘骸會一直掛在
@@ -1693,8 +1835,12 @@ less /tmp/polkit-cortex.rules
 #   必須確認的五個條件（規則檔自己列在「審查者的一眼結論」段）：
 #     (1) subject 是 cortex-manager；(2) action 是 org.freedesktop.systemd1.manage-units；
 #     (3) unit／verb 明細存在；(4) verb ∈ {start, stop}；
-#     (5) unit 名匹配 ^cortex-job@[a-z0-9][a-z0-9._-]{0,62}\.service$
+#     (5) unit 名匹配 ^(?:cortex-job|cortex-job-jit)@[a-z0-9][a-z0-9._-]{0,62}\.service$
 #   **transient unit 的 StartTransientUnit 檢查不帶明細 ⇒ 條件 (3) 直接把它擋掉。**
+#   ⚠️ 條件 (5) 的字幹段是**列舉的交替**（#643：一個加固剖面一份 root-owned 模板檔
+#      ⇒ 兩個名字），**不是**萬用字元：前後仍然錨定、instance 段的字元類一字未改。
+#      仍然是**一條規則、一個 YES 出口**——放行面從「一個具名模板」變成「兩個具名
+#      模板」，沒有變成「任意 unit」。看到 `.*`／`[^`／`\w` 出現在字幹段就是被改壞了。
 
 # 🔧 sudo：落檔
 sudo install -o root -g root -m 0644 /tmp/polkit-cortex.rules \
@@ -1849,9 +1995,18 @@ sudo journalctl -u "cortex-job@$JOB.service" -n 20 --no-pager
 sudo -u cortex-manager systemctl stop "cortex-job@$JOB.service"; echo "exit=$?"   # 期望 0
 ```
 
-### 5-7. 反向驗證（**11 條全部必須被拒**）
+### 5-7. 反向驗證（**11 條全部必須被拒**，＋#643 的第 12 條）
+
+> **#643 起每一條都要對「兩個」字幹跑一次**：加固剖面讓 `cortex-job-jit@` 成為第二個
+> 被 polkit 放行的模板名。放行面從「一個具名模板」變成「兩個具名模板」——**不是**
+> 變成「任意 unit」——因此原本 11 條的每一條在新字幹上必須有**完全相同**的結果。
+> 下面在 (5)(7)(8)(9)(10) 逐條補上 `-jit` 版本，(7) 增加圍繞新字幹的混淆形式，
+> 並新增 (12)「Manager 選不了剖面」三小條。
 
 ```bash
+# ✅ (0) 兩個字幹的變數化（下面的條目共用；**不要只跑其中一個**）
+STEMS="cortex-job cortex-job-jit"
+
 # ✅ (1) 以 cortex-manager 起 transient unit（不指定 UID）：必須被拒
 sudo -u cortex-manager systemd-run --pipe --wait /bin/id; echo "exit=$?"
 
@@ -1868,29 +2023,51 @@ sudo -u cortex-manager systemd-run --uid=cortex-builder \
      --property=AmbientCapabilities=CAP_SETUID --pipe --wait /bin/id; echo "exit=$?"
 
 # ✅ (5) 借用 template 名字的 transient unit：必須被拒（明細缺席即拒）
-sudo -u cortex-manager systemd-run --unit="cortex-job@evil.service" --uid=0 \
-     --pipe --wait /bin/id; echo "exit=$?"
+for S in $STEMS; do
+  sudo -u cortex-manager systemd-run --unit="$S@evil.service" --uid=0 \
+       --pipe --wait /bin/id; echo "(5) $S exit=$?"
+done
 
 # ✅ (6) 起別的既存 unit（含 Manager 自己、sshd）：必須被拒
 sudo -u cortex-manager systemctl restart cortex-manager.service; echo "exit=$?"
 sudo -u cortex-manager systemctl start sshd.service 2>&1 | tail -1; echo "exit=$?"
 
 # ✅ (7) 名稱夾帶（前綴／後綴混淆）：必須被拒
-sudo -u cortex-manager systemctl start "evil-cortex-job@x.service"; echo "exit=$?"
-sudo -u cortex-manager systemctl start "cortex-job@x.service.evil"; echo "exit=$?"
+#     前兩條是原本的；其餘八條是 #643 新字幹周邊的混淆面
+#     （**新增一個字幹，最容易被鑽的就是這裡**）
+for BAD in \
+    "evil-cortex-job@x.service" \
+    "cortex-job@x.service.evil" \
+    "evil-cortex-job-jit@x.service" \
+    "cortex-job-jit@x.service.evil" \
+    "cortex-job-jitx@x.service" \
+    "cortex-job-ji@x.service" \
+    "cortex-job-jit-evil@x.service" \
+    "cortex-jit-job@x.service" \
+    "cortex-job-jit@.service" \
+    "cortex-job-jit@X.service"; do
+  sudo -u cortex-manager systemctl start "$BAD" 2>/dev/null; echo "(7) $BAD exit=$?"
+done
 
 # ✅ (8) 其他 verb：必須被拒
-sudo -u cortex-manager systemctl mask "cortex-job@$JOB.service"; echo "exit=$?"
-sudo -u cortex-manager systemctl daemon-reload; echo "exit=$?"
-sudo -u cortex-manager systemctl set-property "cortex-job@$JOB.service" User=root; echo "exit=$?"
+for S in $STEMS; do
+  sudo -u cortex-manager systemctl mask "$S@$JOB.service"; echo "(8) $S mask exit=$?"
+  sudo -u cortex-manager systemctl set-property "$S@$JOB.service" User=root
+  echo "(8) $S set-property exit=$?"
+done
+sudo -u cortex-manager systemctl daemon-reload; echo "(8) daemon-reload exit=$?"
 
 # ✅ (9) 非授權帳號起 job instance：必須被拒（polkit subject 只有 cortex-manager）
-sudo -u cortex-reviewer-planner systemctl start "cortex-job@$JOB.service"; echo "exit=$?"
-sudo -u cortex-builder systemctl start "cortex-job@$JOB.service"; echo "exit=$?"
+for S in $STEMS; do
+  sudo -u cortex-reviewer-planner systemctl start "$S@$JOB.service"; echo "(9) $S rp exit=$?"
+  sudo -u cortex-builder systemctl start "$S@$JOB.service"; echo "(9) $S builder exit=$?"
+done
 
 # ✅ (10) 改 template unit／shim／polkit 規則：三個服務帳號一律 EACCES
 for U in cortex-manager cortex-reviewer-planner cortex-builder; do
-  sudo -u "$U" sh -c 'printf "User=root\n" >> /etc/systemd/system/cortex-job@.service'; echo "$U unit exit=$?"
+  sudo -u "$U" sh -c 'printf "User=root\n" >> /etc/systemd/system/cortex-job@.service'; echo "$U unit(strict) exit=$?"
+  sudo -u "$U" sh -c 'printf "MemoryDenyWriteExecute=no\n" >> /etc/systemd/system/cortex-job@.service'; echo "$U mdwe(strict) exit=$?"
+  sudo -u "$U" sh -c 'printf "User=root\n" >> /etc/systemd/system/cortex-job-jit@.service'; echo "$U unit(jit) exit=$?"
   sudo -u "$U" sh -c 'printf "id\n" >> /opt/cortex/bin/cortex-job-shim'; echo "$U shim exit=$?"
   sudo -u "$U" sh -c 'printf "x\n" >> /etc/polkit-1/rules.d/49-cortex-downgrade.rules'; echo "$U polkit exit=$?"
 done
@@ -1904,9 +2081,61 @@ sudo -u cortex-manager systemctl start "cortex-job@$JOB.service"; echo "exit=$?"
 #     **不得**出現以 cortex-manager 身分跑起來的 job。
 sudo mv /tmp/polkit-cortex.disabled /etc/polkit-1/rules.d/49-cortex-downgrade.rules
 sudo systemctl restart polkit.service 2>/dev/null || sudo systemctl restart polkitd.service
+
+# ✅ (12) #643：Manager **選不了**加固剖面——剖面只跟著 executor 走
+#     這三條守的是「per-executor 剖面」不退化成「全域移除 MDWE」。
+#     ⚠️ 與其他反向條目相反：這三條**期望 exit=0**（0 代表「拒絕確實發生」）。
+
+#     (12a) PSC_JOB_TEMPLATE_UNIT 不接受已帶剖面後綴的值
+#           （接受的話，operator 一行 config 就能把**所有** job 推到寬鬆剖面）
+sudo -u cortex-manager env $(grep -v '^#' /opt/cortex/etc/cortex-manager.env | xargs) \
+  PSC_JOB_TEMPLATE_UNIT=cortex-job-jit@.service \
+  /opt/cortex/venv/bin/python -c '
+import os, sys
+from paulsha_cortex.coordinator import job_runner as j
+try:
+    j.prepare_systemd_template(os.environ, job_id="probe", executor="claude")
+except j.JobRunnerError as exc:
+    print("refused:", exc.diagnostic.reason); sys.exit(0)
+sys.exit(1)
+'; echo "(12a) exit=$?"
+#   期望：exit=0，印出 refused: job-runner-template-unit-invalid
+
+#     (12b) 未登記的 executor fail-closed
+#           （**不得**落到寬鬆那份；也不得默默給嚴格那份而讓問題再埋一次）
+sudo -u cortex-manager /opt/cortex/venv/bin/python -c '
+import sys
+from paulsha_cortex.coordinator import job_runner as j
+try:
+    j.resolve_hardening_profile("mystery")
+except j.JobRunnerError as exc:
+    print("refused:", exc.diagnostic.reason); sys.exit(0)
+sys.exit(1)
+'; echo "(12b) exit=$?"
+#   期望：exit=0，印出 refused: job-runner-hardening-profile-unknown
+
+#     (12c) job spec 帶剖面欄位 ⇒ shim 讀端拒絕執行（寫端已在單元測試覆蓋）
+sudo -u cortex-manager /opt/cortex/venv/bin/python -c '
+import json, sys
+from paulsha_cortex.coordinator import job_shim
+spool = "/var/lib/cortex/coordinator/job-specs"
+spec = {"spec_version": 1, "instance": "profile-probe", "job_id": "profile-probe",
+        "unit": "cortex-job@profile-probe.service", "command": ["/bin/true"],
+        "working_directory": "/tmp", "log_path": "/tmp/probe.jsonl",
+        "env": {"PATH": "/usr/bin"}, "hardening_profile": "jit"}
+open(spool + "/profile-probe.json", "w").write(json.dumps(spec))
+try:
+    job_shim.load_spec("profile-probe", spool)
+except job_shim.ShimError as exc:
+    print("refused:", exc); sys.exit(0)
+sys.exit(1)
+'; echo "(12c) exit=$?"
+sudo rm -f /var/lib/cortex/coordinator/job-specs/profile-probe.json
+#   期望：exit=0，印出 refused: ... hardening_profile ...
 ```
 
-**通過條件**：5-6 正向成功且輸出符合期望；5-7 的 (1)–(11) **全部**非 0 退出。
+**通過條件**：5-6 正向成功且輸出符合期望；**5-2b 的 (1) 正向與 (2) 負向對照皆符合
+期望**；5-7 的 (1)–(11) **全部**非 0 退出、(12a)(12b)(12c) **全部** 0 退出。
 任一反向測試通過（即攻擊成功）＝**立即停止**，回到第 9 步回滾。
 
 ```bash
@@ -1914,6 +2143,7 @@ sudo systemctl restart polkit.service 2>/dev/null || sudo systemctl restart polk
 sudo systemctl stop "cortex-job@$JOB.service" 2>/dev/null || true
 sudo rm -f "/var/lib/cortex/coordinator/job-specs/$JOB.json"
 sudo rm -rf "/var/lib/cortex/worktree/$JOB"
+sudo systemctl reset-failed "cortex-job@*" "cortex-job-jit@*" 2>/dev/null || true
 ```
 
 ### 5-8. 殘餘風險（A+B 之後重新評估）
@@ -1964,6 +2194,11 @@ cases = [
     ("cortex-manager",          permgen.POLKIT_ACTION, "cortex-manager.service", "start", "NO"),
     ("cortex-manager",          permgen.POLKIT_ACTION, "evil-cortex-job@x.service", "start", "NO"),
     ("cortex-manager",          permgen.POLKIT_ACTION, "cortex-job@abc.service", "mask",  "NO"),
+    # #643：第二個加固剖面的模板同樣放行；圍繞它的混淆同樣拒。
+    ("cortex-manager",          permgen.POLKIT_ACTION, "cortex-job-jit@abc.service", "start", "YES"),
+    ("cortex-manager",          permgen.POLKIT_ACTION, "cortex-job-jitx@abc.service", "start", "NO"),
+    ("cortex-manager",          permgen.POLKIT_ACTION, "cortex-job-ji@abc.service", "start", "NO"),
+    ("cortex-manager",          permgen.POLKIT_ACTION, "cortex-job-jit-abc.service", "start", "NO"),
     ("cortex-reviewer-planner", permgen.POLKIT_ACTION, "cortex-job@abc.service", "start", "NOT_HANDLED"),
     ("cortex-builder",          permgen.POLKIT_ACTION, "cortex-job@abc.service", "start", "NOT_HANDLED"),
 ]
@@ -1978,6 +2213,7 @@ PY
 ```bash
 sudo rm -f /etc/polkit-1/rules.d/49-cortex-downgrade.rules \
            /etc/systemd/system/cortex-job@.service \
+           /etc/systemd/system/cortex-job-jit@.service \
            /opt/cortex/bin/cortex-job-shim
 sudo systemctl daemon-reload
 sudo systemctl restart polkit.service 2>/dev/null || true
@@ -2058,7 +2294,9 @@ sudo -u cortex-manager /opt/cortex/venv.new/bin/python -m paulsha_cortex.trust_r
 diff <(sudo -u cortex-manager /opt/cortex/venv.new/bin/python -m paulsha_cortex.trust_root unit three-way --manager) \
      /etc/systemd/system/cortex-manager.service || echo "!! manager unit 需更新"
 diff <(sudo -u cortex-manager /opt/cortex/venv.new/bin/python -m paulsha_cortex.trust_root unit three-way --job) \
-     /etc/systemd/system/cortex-job@.service || echo "!! job template unit 需更新"
+     /etc/systemd/system/cortex-job@.service || echo "!! job template unit (strict) 需更新"
+diff <(python3 -m paulsha_cortex.trust_root unit three-way --job --profile jit) \
+     /etc/systemd/system/cortex-job-jit@.service || echo "!! job template unit (jit) 需更新"
 diff <(sudo -u cortex-manager /opt/cortex/venv.new/bin/python -m paulsha_cortex.trust_root polkit three-way --template) \
      /etc/polkit-1/rules.d/49-cortex-downgrade.rules || echo "!! polkit 規則需更新"
 diff <(sudo -u cortex-manager /opt/cortex/venv.new/bin/python -m paulsha_cortex.trust_root shim three-way) \
@@ -2566,7 +2804,8 @@ sudo rm -f /var/lib/cortex/coordinator/job-specs/r9.json \
 sudo rm -rf /var/lib/cortex/worktree/r9 /var/lib/cortex/worktree/negctl5 \
             /var/lib/cortex/worktree/victim \
             /var/lib/cortex/coordinator/review-verdicts/victim \
-            /etc/systemd/system/cortex-job@.service.d
+            /etc/systemd/system/cortex-job@.service.d \
+            /etc/systemd/system/cortex-job-jit@.service.d
 sudo systemctl daemon-reload
 
 # ✅ 驗證：spool 內不得殘留任何抽驗用的 spec（它們是 job 的命令列）
@@ -2601,7 +2840,7 @@ Phase 1 完全不需 root 且含降級運轉安全網（`PSC_DEGRADED_OPERATION=
 | 第 4c（system unit） | WSL 重啟後未拉起／服務起不來 | `sudo systemctl disable --now cortex-manager.service`；改回 `systemctl --user start cortex-manager.service`（舊部署仍在 `$HOME/.local/share/pipx`） |
 | 第 4c（加固誤擋） | 服務起來但功能靜默失效 | 見下方「`ProtectSystem=strict` 誤擋診斷」；**臨時** drop-in 放行、**同一天**把該路徑回填 R1 登記表並重跑 permgen |
 | 第 4d（monitor unit） | monitor 起不來／新樹無寫入 | `sudo systemctl disable --now cortex-monitor.service`；改回 `systemctl --user start cortex-monitor.service`（**會與 system-level Manager 雙寫**，僅救急） |
-| **第 5-2（template unit）** | instance 起不來／unit 語法錯 | `sudo rm -f /etc/systemd/system/cortex-job@.service; sudo rm -rf /etc/systemd/system/cortex-job@.service.d; sudo systemctl daemon-reload`；(d) 一併關閉（見下一列） |
+| **第 5-2（template unit ×2）** | instance 起不來／unit 語法錯 | `sudo rm -f /etc/systemd/system/cortex-job@.service /etc/systemd/system/cortex-job-jit@.service; sudo rm -rf /etc/systemd/system/cortex-job@.service.d /etc/systemd/system/cortex-job-jit@.service.d; sudo systemctl daemon-reload`；(d) 一併關閉（見下一列）。**兩份要一起收**——只留一份會讓一半的 executor 在 preflight fail-closed |
 | **第 5-3（shim）** | job 起得來但 argv 不對／shim crash | `sudo rm -f /opt/cortex/bin/cortex-job-shim`；重新由產生器落檔並 `diff` 對齊；仍不對則關 (d) |
 | **第 5-4（polkit）** | 規則語法錯／`cortex-manager` 起不了任何 job | `sudo rm -f /etc/polkit-1/rules.d/49-cortex-downgrade.rules; sudo systemctl restart polkit.service`；此時降權面完全關閉（fail-closed，job 起不來但無提權） |
 | **第 5-5（切換點）** | 降權後 job 全數 needs_human | `sudo sed -i '/^PSC_JOB_RUNNER=/d;/^PSC_BUILDER_ACCOUNT=/d;/^PSC_BUILDER_HOME=/d' /opt/cortex/etc/cortex-manager.env; sudo systemctl restart cortex-manager.service`（回 `direct`）；Manager 以 `per-case-approval` 不 spawn job 運轉 |
@@ -2612,8 +2851,11 @@ Phase 1 完全不需 root 且含降級運轉安全網（`PSC_DEGRADED_OPERATION=
 ```bash
 # 🔧 sudo：停掉並移除 Phase 2 的一切（含 A+B 的三個 root-owned 物件與三帳號）
 sudo systemctl disable --now cortex-manager.service 2>/dev/null || true
-sudo rm -f /etc/systemd/system/cortex-manager.service /etc/systemd/system/cortex-job@.service
-sudo rm -rf /etc/systemd/system/cortex-job@.service.d
+sudo rm -f /etc/systemd/system/cortex-manager.service \
+           /etc/systemd/system/cortex-job@.service \
+           /etc/systemd/system/cortex-job-jit@.service
+sudo rm -rf /etc/systemd/system/cortex-job@.service.d \
+            /etc/systemd/system/cortex-job-jit@.service.d
 sudo rm -f /etc/polkit-1/rules.d/49-cortex-downgrade.rules
 sudo rm -f /opt/cortex/bin/cortex-job-shim
 #   （EnvironmentFile 隨 /opt/cortex 一併移除，PSC_JOB_RUNNER 自然失效）
@@ -2661,7 +2903,8 @@ systemctl show cortex-manager.service -p WantedBy
 #   期望：WantedBy=multi-user.target
 ls -l /etc/systemd/system/multi-user.target.wants/cortex-manager.service
 #   期望：symlink 存在
-#   注意：cortex-job@.service 是 template，**不需要也不應該** enable。
+#   注意：cortex-job@.service／cortex-job-jit@.service 都是 template，
+#         **不需要也不應該** enable。
 
 # ---- 3. 在 Windows 端執行：wsl --shutdown ----
 #      然後重新開一個 WSL shell，再回來跑本段第 4 項。
@@ -2763,7 +3006,8 @@ sudo systemctl daemon-reload && sudo systemctl restart cortex-manager.service
 > **鐵律**：被擋的路徑**只能**經「回填 R1 登記表 → 重跑 permgen → 重新落檔 unit」
 > 進入 `ReadWritePaths`。drop-in 只能作為**當天的**臨時措施，不得成為長期狀態——
 > 否則 unit 就不再是登記表的機械投影，`diff` 對齊檢查會紅。
-> **template unit 的 drop-in 更嚴**：`/etc/systemd/system/cortex-job@.service.d/` 一旦
+> **template unit 的 drop-in 更嚴**：`/etc/systemd/system/cortex-job@.service.d/`
+> 與 `cortex-job-jit@.service.d/`（#643）一旦
 > 存在就是提權面（族 5.2 有一條專門測它建不起來），診斷完**必須立刻刪除**。
 
 ### C. WSL2 其他已知風險
@@ -2797,6 +3041,7 @@ sudo systemctl daemon-reload && sudo systemctl restart cortex-manager.service
 # ✅ unit／polkit／shim 與產生器沒有漂移（建議排程每日跑）
 diff <(python3 -m paulsha_cortex.trust_root unit three-way --manager) /etc/systemd/system/cortex-manager.service
 diff <(python3 -m paulsha_cortex.trust_root unit three-way --job)     /etc/systemd/system/cortex-job@.service
+diff <(python3 -m paulsha_cortex.trust_root unit three-way --job --profile jit) /etc/systemd/system/cortex-job-jit@.service
 diff <(python3 -m paulsha_cortex.trust_root polkit three-way --template) /etc/polkit-1/rules.d/49-cortex-downgrade.rules
 diff <(python3 -m paulsha_cortex.trust_root shim three-way)            /opt/cortex/bin/cortex-job-shim
 
@@ -2808,7 +3053,14 @@ sudo find /opt/cortex/venv -name "pipx_shared.pth" | head          # 期望：�
 sudo ls -l /var/lib/cortex/coordinator/job-specs
 
 # ✅ 沒有殘留的 template drop-in（族 5.2 的持久化面）
-ls -la /etc/systemd/system/cortex-job@.service.d 2>/dev/null && echo "!! 有 drop-in，查來源" || echo "no drop-in: OK"
+ls -la /etc/systemd/system/cortex-job@.service.d /etc/systemd/system/cortex-job-jit@.service.d \
+  2>/dev/null && echo "!! 有 drop-in，查來源" || echo "no drop-in: OK"
+# ✅ #643：兩份 job unit 的加固差異必須**只有** MemoryDenyWriteExecute 一項
+diff <(grep -E "^[A-Z][A-Za-z]*=" /etc/systemd/system/cortex-job@.service) \
+     <(grep -E "^[A-Z][A-Za-z]*=" /etc/systemd/system/cortex-job-jit@.service) \
+  | grep -E "^[<>]" | sort
+#   期望恰好兩行：`< MemoryDenyWriteExecute=yes` 與 `> MemoryDenyWriteExecute=no`。
+#   出現第三行 ⇒ 兩份剖面在加固表以外分岔了，回第 5-2 步重新落檔。
 
 # ✅ 三分帳號仍是三個、互不交集、皆無 sudo
 for U in cortex-manager cortex-reviewer-planner cortex-builder; do id -nG "$U"; done
@@ -2904,7 +3156,7 @@ PY
 | 第 1 步建**兩**個帳號（`cortex-svc` / `cortex-builder`） | 建**三**個（`cortex-manager` / `cortex-reviewer-planner` / `cortex-builder`） |
 | 全文 `two-way` | 全文 `three-way`；`two-way` 僅存於程式碼作為對照組 |
 | 第 5 步 A／B 並列，**待 operator 拍板** | 第 5 步 **A+B 合一，無分歧**；transient 降為附錄 B 備援 |
-| polkit 授 transient 建立（方案 A） | polkit **不授** transient 建立；只放行 `cortex-job@*.service` 的 start/stop |
+| polkit 授 transient 建立（方案 A） | polkit **不授** transient 建立；只放行 `cortex-job@*.service` 與 `cortex-job-jit@*.service`（#643 加固剖面）的 start/stop——**兩個具名模板，不是任意 unit** |
 | `ExecStart=` 指向 spool 內的 `run.sh` | 指向 **root-owned shim** `/opt/cortex/bin/cortex-job-shim`（C 層搬進 root-owned 檔） |
 | `PSC_JOB_RUNNER=systemd-run` | `PSC_JOB_RUNNER=systemd-template`（`systemd-run` 僅備援用） |
 | R9 四族，subject 為 `cortex-builder` | R9 **五族**，subject 為 builder ＋ reviewer-planner，新增族 5 privilege-boundary |

--- a/docs/superpowers/specs/trust-root-isolation-spec.md
+++ b/docs/superpowers/specs/trust-root-isolation-spec.md
@@ -550,10 +550,12 @@ $ sudo -u cortex-builder env HOME=<job HOME> codex exec --help
   「job 跑的是哪個版本的模型 CLI」**會**影響產出，因此它必須是一個可稽核的部署決定，
   而不是跟著 operator 的環境漂移。
 - 四者的實體形態不同，搬移方式不能一概而論（表固化於
-  `permgen.EXECUTOR_TOOLS`）：`codex` 是 `#!/usr/bin/env node` 的 node script（**唯一
-  硬需要 node**，且必須整包搬 npm 套件樹）；`claude`／`agy` 自帶原生執行檔；`copilot`
-  是 shell script（腳本內部可能再叫別的程式，安裝時 SHALL 查一次）。**因此系統層 node
-  的版本風險只涵蓋 `codex` 一個。**
+  `permgen.EXECUTOR_TOOLS`）：`codex` 是 `#!/usr/bin/env node` 的 node script（必須整包
+  搬 npm 套件樹）；`claude`／`agy` 自帶原生執行檔；`copilot` 是 shell script，而它**內部
+  再 exec node**（#640 落表時尚未查證，#643 在真實加固面下量到與 `codex` 逐字相同的
+  症狀後回填）。**因此系統層 node 的版本風險涵蓋 `codex` 與 `copilot` 兩個。**
+  同一個 `needs_node` 欄位也是 §R3 per-executor 加固剖面的分類來源——**一張表，兩個
+  用途**，不另立第二份清單。
 - job 的 `PATH` SHALL 由 Manager 端既有的 `PSC_BUILDER_PATH` 注入，且 toolchain
   SHALL 排在**最前面**——系統層可能另有一份同名但舊很多的 CLI，排在後面的症狀是
   「跑得起來但版本不是預期的那個」，比 `command not found` 難查得多。**MUST NOT**
@@ -658,7 +660,8 @@ provider 帳號下的兩個 job 在 provider 眼中是同一個主體，配額�
 
 - systemd unit SHALL 加上加固指令（至少 `NoNewPrivileges=yes`、
   `ProtectSystem=strict`、`ProtectHome` 與明列的 `ReadWritePaths`、`PrivateTmp=yes`）。
-  現況三個 unit **一項都沒有**。
+  現況三個 unit **一項都沒有**。加固表固化於 `permgen._HARDENING`（27 項，逐項附
+  「為何」註解）；job 模板 unit 的加固面另受 **per-executor 剖面**約束，見下節。
 - `EnvironmentFile=-` 的缺檔靜默容忍 SHALL 改為 fail-closed（缺檔即拒絕啟動），
   否則刪檔即是一條無聲的重導路徑。
 - `PSC_MANAGER_INSTALLER`、`PSC_REPLY_BRIDGE`、`PSC_DIGEST_DELIVERY_CMD` 三個
@@ -674,6 +677,96 @@ provider 帳號下的兩個 job 在 provider 眼中是同一個主體，配額�
 或把 `<instance>-manager.env` 的 `PSC_COORDINATOR_ROOT` 指到自己的目錄，再重啟
 服務，即可整套繞過。這是計畫第七輪 critical 修正的核心，也是路線 B 單獨無法解決
 的一族。
+
+#### per-executor 加固剖面（#643 裁決；`permgen.HARDENING_PROFILES`）
+
+**`MemoryDenyWriteExecute=yes` 與 JS runtime 天生互斥。** 實機逐項隔離（以
+`cortex-builder` 身分、`systemd-run` 帶單一 property）的結果是：無加固時 `node` 正常；
+`+MemoryDenyWriteExecute=yes` 時 V8 直接崩在 `v8::internal::Runtime_CompileLazy`；其餘
+每一項（`ProtectSystem=strict`／`PrivateTmp`／`RestrictNamespaces`／
+`SystemCallFilter=@system-service` ＋ `SystemCallErrorNumber=EPERM`）單獨加上去 `node`
+都正常。**唯一的阻斷點就是它**——V8 的 JIT 必須有 W+X 記憶體。
+
+四個 executor 因此分成兩類（分類來源＝`permgen.EXECUTOR_TOOLS` 的 `needs_node`，
+與 §R1 executor 執行面那張表**同一張**，不另立清單）：
+
+| executor | 形態 | 完整加固面 | 加固剖面 | 模板 unit |
+|---|---|:--:|---|---|
+| `claude` | 原生 ELF | ✅ | `strict` | `cortex-job@.service` |
+| `agy` | 原生 ELF | ✅ | `strict` | `cortex-job@.service` |
+| `codex` | node script | ⛔ 空輸出 | `jit` | `cortex-job-jit@.service` |
+| `copilot` | shell → node | ⛔ 空輸出 | `jit` | `cortex-job-jit@.service` |
+
+**規範**：
+
+- job 模板 unit SHALL 有且僅有 `permgen.HARDENING_PROFILES` 列舉的那幾份，且**全部由
+  同一張 `_HARDENING` 表產生**；剖面之間的差異 SHALL 侷限於
+  `permgen.PROFILE_DIVERGENCE_KEYS`（目前是 `{MemoryDenyWriteExecute}` 這一項）。
+  複製兩段各自維護的加固表 MUST NOT 出現——那會讓「日後改一份忘另一份」變成必然。
+- 剖面 SHALL 由 **executor** 決定，而 executor SHALL 是 Manager 的 dispatch 決定
+  （`SubprocessLauncher(executor=...)`，在任何 per-job 產物之前就固定）。
+- job spec **MUST NOT** 攜帶任何決定剖面的欄位（`job_runner.SPEC_FORBIDDEN_KEYS` 的
+  剖面族），且 SHALL 在寫端（`build_job_spec`）與讀端（`job_shim.load_spec`）各掃一次
+  ——**這與「身分欄位不入 spec」是同一條原則**：身分只有一個來源（root-owned unit 的
+  `User=`），剖面也只有一個來源（executor）。
+- 未登記的 executor SHALL **fail-closed**，MUST NOT 預設落到放寬的那一份剖面。
+  （也刻意不預設落到嚴格那份：一個未被盤點過的 node 型 CLI 會在真實加固面下靜默
+  起不來，症狀是空輸出，離原因很遠——#643 本身就是這樣被埋掉的。）
+- 部署 config（`PSC_JOB_TEMPLATE_UNIT`）SHALL 只接受**基底**模板名；帶剖面後綴的值
+  MUST 被拒——否則一行 config 就能把**所有** job 推到寬鬆剖面，per-executor 設計當場
+  退化成「全域移除 MDWE」。
+- polkit 規則的 unit pattern SHALL **列舉**這些模板字幹（錨定的交替），MUST NOT 放寬
+  成萬用字元；`instance` 段的字元類 SHALL 維持不變。
+
+##### 誠實的取捨：哪一類 job 有哪一種保護
+
+**走 `jit` 剖面的 job（`codex`／`copilot`）失去 `MemoryDenyWriteExecute` 這一層。**
+具體代價：取得任意程式碼執行的攻擊者可在**該 job 自己的位址空間內**配置 W+X 記憶體，
+JIT 型 shellcode（不落地、不經 `exec`、因此不觸發任何依賴檔案或 exec 的偵測）在此可行。
+這是真的少了一層，不是換個寫法的等價物。
+
+**沒有失去的部分**（同樣要寫清楚，否則會被讀成比實際更弱）：其餘 26 項加固在 `jit`
+剖面下**逐項不變**——`NoNewPrivileges=yes`、`CapabilityBoundingSet=`（空）、
+`ProtectSystem=strict`、`ProtectHome=yes`、`RestrictNamespaces=yes`、
+`SystemCallFilter=@system-service`、`RestrictSUIDSGID=yes`… 全部照舊，`User=` 一樣寫死在
+root-owned 的 unit 檔裡。W+X 讓攻擊者能在**自己這個 UID** 內執行程式碼；**跨 UID、
+跨檔案系統、提權**那幾層完全沒有鬆動。換句話說：`jit` 剖面守不住的是「job 內部的
+程式碼完整性」，守得住的仍然是「job 出不了自己那個 UID 的邊界」——而 §R2／§R3 保護的
+Tier-0／Tier-1 資產靠的是後者。
+
+**換到什麼**：保住 `codex`／`copilot` 兩個 provider。若採方向 3（只用原生 ELF
+executor），build 域只剩 `claude`／`agy`，§R5／§R8 的 `independence_domain`
+（reviewer 不得與 builder 同 domain）可選空間當場減半。方向 1（全域移除 MDWE）則會讓
+**不需要**放寬的 `claude`／`agy` 一起失去這層——方向 2 的全部價值就在於「只讓需要的
+那一類付這個代價」。
+
+**因此 spec 明載**：本系統**不宣稱**「所有 job 都有完整加固」。準確的敘述是——
+**原生 ELF executor 的 job 有完整 27 項加固；node 型 executor 的 job 有 26 項，
+少的那一項是 `MemoryDenyWriteExecute`。** 任何引用本 spec 的稽核、報告或 PR 描述
+SHALL 用這句話，MUST NOT 簡化成「job 已完整加固」。
+
+**未來選項（不在本票範圍）**：若某天 node 型 executor 有辦法在無 W+X 下執行
+（V8 的 jitless 模式、或 CLI 改為原生編譯），`jit` 剖面 SHALL 被移除而不是長期保留；
+移除的判準就是上表「完整加固面」欄全部變 ✅。
+
+#### Scenario: node 型 executor 在嚴格剖面下起不來
+
+- **WHEN** 以 `codex`／`copilot` 為 executor 的 job 被派到 `cortex-job@.service`
+  （strict 剖面）
+- **THEN** 它 MUST 失敗（V8 崩在 `Runtime_CompileLazy`），MUST NOT 被視為可接受狀態；
+  驗收 SHALL 包含這條**負向對照**——只驗 `jit` 剖面成功無法證明剖面分岔是必要的
+
+#### Scenario: job 試圖選擇加固剖面
+
+- **WHEN** job spec（或任何 job 可影響的輸入）攜帶 `hardening_profile`／`profile`／
+  `template_unit` 等欄位
+- **THEN** 寫端與讀端 MUST 各自 fail-closed 拒絕執行，MUST NOT 忽略該欄位後照常執行
+
+#### Scenario: 未登記的 executor
+
+- **WHEN** dispatch 使用一個不在 `permgen.EXECUTOR_TOOLS` 內的 executor 名
+- **THEN** 降權啟動器 MUST fail-closed，MUST NOT 落到任一剖面（放寬的那份會讓設計退化，
+  嚴格的那份會讓問題再被埋一次）
 
 #### Scenario: 竄改 EnvironmentFile 重導 state 根
 
@@ -1094,6 +1187,8 @@ MUST NOT 標記為 stable；本項 MUST NOT 引用計畫「貫穿工項」第 7 
 | 路徑分樹破壞既有 `PSC_*` 契約，導致既有 instance 無法啟動 | fleet 停擺 | 分樹以登記表產生、保留舊路徑為唯讀相容層一個 release；`doctor` 增加分樹健檢；實測已發現部署中的 env 缺 `PSC_CONTROL_ROOT`，遷移前須先對帳 |
 | headless 失去 gh token 後功能退化 | headless 無法自行推 PR | 由 Manager 代理 GitHub 寫入（D1 outbox 記帳已是此方向）；Phase 2 前先量測哪些 headless 動作真的需要 token |
 | 資產盤點漏項 | 漏保護的 state 成為新破口 | R1 的雙向等式測試把漏項變成 CI FAIL；同時收斂六處重複的 journal 路徑推導 |
+| **per-executor 加固剖面（#643）被讀成「所有 job 都有完整加固」** | 稽核／報告高估實際保護面，日後出事時對不上 | §R3 的「誠實的取捨」段明載準確敘述（原生 ELF 27 項／node 型 26 項，少的是 `MemoryDenyWriteExecute`）；產生出來的 unit 檔頭逐條寫著它接受的代價；runbook 第 5-2 步要求執行者先讀那一段 |
+| **剖面被改成可由呼叫端選擇**（config、spec、或新增一個「方便」的參數） | 退化成「全域移除 MDWE」——`claude`／`agy` 一起失去該層，方向 2 的價值歸零 | 剖面族進 `SPEC_FORBIDDEN_KEYS`（寫端＋讀端各掃一次）；`PSC_JOB_TEMPLATE_UNIT` 拒絕帶剖面後綴的值；未知 executor fail-closed；polkit pattern 只列舉具名字幹。四條都有對應測試 |
 | Phase 3 簽章方案被誤當成可替代 Phase 2 | 投入密碼學工程卻仍可被繞過 | 「路線比較與裁決建議」段已論證 B 的三個前提都依賴 A；R6(c) 明載單調計數器必須在 OS 邊界內 |
 | reviewer 與 builder 分離推高資源與複雜度 | Phase 2 工期拉長 | independence 是 `#484` 與 D6 的共同要求，不可省；可先以兩個 UID（builder／非 builder）起步，planner 併入非 builder 域，待驗證後再細分 |
 | 降級運轉期間 fleet 產能下降 | 交付變慢 | 降級只涵蓋 acceptance／outbox mutation／ship 三條路徑，define／plan／build／verify 不受影響 |

--- a/paulsha_cortex/coordinator/job_runner.py
+++ b/paulsha_cortex/coordinator/job_runner.py
@@ -105,6 +105,7 @@ import tempfile
 import time
 from dataclasses import dataclass
 from pathlib import Path
+from types import MappingProxyType
 from typing import Callable, Mapping, Sequence
 
 from . import job_workspace
@@ -123,7 +124,10 @@ __all__ = [
     "DEFAULT_JOB_SPEC_SPOOL",
     "DEFAULT_START_TIMEOUT_MS",
     "DEFAULT_TEMPLATE_UNIT",
+    "EXECUTOR_HARDENING_PROFILE",
     "ForwardedEnvVar",
+    "HARDENING_PROFILE_JIT",
+    "HARDENING_PROFILE_STRICT",
     "JOB_RUNNER_ENV",
     "JOB_SHIM_ENV",
     "JOB_SPEC_SPOOL_ENV",
@@ -140,6 +144,7 @@ __all__ = [
     "SystemdTemplatePlan",
     "TEMPLATE_UNIT_ENV",
     "TEMPLATE_UNIT_PREFIX",
+    "TEMPLATE_UNIT_SUFFIX_BY_PROFILE",
     "TRANSIENT_UNIT_PROPERTIES",
     "UNIT_NAME_PREFIX",
     "build_builder_env",
@@ -149,6 +154,7 @@ __all__ = [
     "build_systemd_run_argv",
     "confirm_template_instance_started",
     "confirm_transient_unit_started",
+    "forbidden_spec_keys",
     "instance_name_valid",
     "job_spec_path",
     "preflight_systemd_run",
@@ -156,7 +162,9 @@ __all__ = [
     "prepare_systemd_run",
     "prepare_systemd_template",
     "reject_unsafe_env",
+    "resolve_hardening_profile",
     "template_instance_id",
+    "template_unit_for_profile",
     "template_unit_name",
     "transient_unit_name",
     "write_job_spec",
@@ -225,10 +233,59 @@ TRANSIENT_UNIT_PROPERTIES = ("NoNewPrivileges=yes",)
 
 #: 模板 unit 名。polkit 規則（`permgen.build_polkit_rule(plan=TEMPLATE)`）比對的
 #: 就是它的實例形狀 `cortex-job@<id>.service`，因此是契約，不可隨手改。
+#:
+#: **這是「基底」模板名**（＝strict 剖面）。#643 之後真正被起動的 unit 還要再過一次
+#: :func:`template_unit_for_profile`：node 型 executor 走 `cortex-job-jit@.service`。
 TEMPLATE_UNIT_ENV = "PSC_JOB_TEMPLATE_UNIT"
 TEMPLATE_UNIT_PREFIX = "cortex-job@"
 TEMPLATE_UNIT_SUFFIX = ".service"
 DEFAULT_TEMPLATE_UNIT = f"{TEMPLATE_UNIT_PREFIX}{TEMPLATE_UNIT_SUFFIX}"
+
+
+# ---------------------------------------------------------------------------
+# per-executor 加固剖面（#643，operator 裁決＝方向 2）
+#
+# `MemoryDenyWriteExecute=yes` 與 JS runtime 天生互斥（V8 的 JIT 必須 W+X），而預設
+# executor（`codex`）正是 node 型。裁決是「node 型走一份只放寬這一項的 root-owned
+# 模板 unit，原生執行檔型維持嚴格」。
+#
+# **剖面的選擇不可由 job 決定**，否則整個設計退化成「全域移除 MDWE」。守法：
+#
+#   1. 唯一的輸入是 **executor**，而 executor 是 Manager 的 dispatch 決定
+#      （`SubprocessLauncher(executor=...)`，在 job spec 產生之前就固定了）；
+#   2. 對應表在下方**列舉且封閉**，未知 executor **fail-closed**（不落到寬鬆那份）；
+#   3. job spec 結構性禁止攜帶任何剖面欄位（見 :data:`SPEC_FORBIDDEN_KEYS`，
+#      寫端 `build_job_spec()` 與讀端 `job_shim.load_spec()` 各掃一次）；
+#   4. 兩份 unit 都是 root-owned、`User=`／`ExecStart=` 寫死，polkit 的 unit pattern
+#      只列舉這兩個字幹——呼叫端選得了「哪一份模板」，但兩份都選不出 UID 或命令列。
+#
+# 下面三個常數與 `trust_root.permgen` 的 `HARDENING_PROFILES`／
+# `EXECUTOR_HARDENING_PROFILE` 是**成對契約**（與 `DEFAULT_TEMPLATE_UNIT` 同一個
+# 理由：job_runner 刻意不 import permgen，讓派工熱路徑不必拖進整個 trust_root
+# 子套件），由 `tests/test_trust_root_hardening_profile_643.py` 釘住兩邊逐字相等。
+# permgen 那一份才是真相來源：它由 `EXECUTOR_TOOLS.needs_node` 機械導出。
+# ---------------------------------------------------------------------------
+
+HARDENING_PROFILE_STRICT = "strict"
+HARDENING_PROFILE_JIT = "jit"
+
+#: 剖面 → 模板字幹後綴。strict 為空字串，因此 `cortex-job@.service` 逐字不變。
+TEMPLATE_UNIT_SUFFIX_BY_PROFILE: Mapping[str, str] = MappingProxyType(
+    {HARDENING_PROFILE_STRICT: "", HARDENING_PROFILE_JIT: "-jit"}
+)
+
+#: executor → 剖面。**封閉列舉**：這裡沒有 fallback、沒有預設值、沒有 `.get(x, jit)`。
+#: `cg` 刻意不在表內——它只支援 read-only／review-only，而降權啟動器只服務 builder
+#: persona（`launcher._downgraded_mode` 對 review_only／read_only 回 None），因此它
+#: 走不到這裡；真的走到了就代表有人改壞了 persona 分支，那時 fail-closed 才是對的。
+EXECUTOR_HARDENING_PROFILE: Mapping[str, str] = MappingProxyType(
+    {
+        "codex": HARDENING_PROFILE_JIT,
+        "copilot": HARDENING_PROFILE_JIT,
+        "claude": HARDENING_PROFILE_STRICT,
+        "agy": HARDENING_PROFILE_STRICT,
+    }
+)
 
 #: Manager-owned 的 per-job spec spool（登記表資產 `job-spec-spool`）。
 JOB_SPEC_SPOOL_ENV = "PSC_JOB_SPEC_SPOOL"
@@ -257,10 +314,29 @@ SPEC_REQUIRED_KEYS: tuple[str, ...] = (
     "env",
 )
 
-#: spec **絕不可**出現的欄位——身分只有一個來源：root-owned unit 檔的 `User=`。
-#: 這是 B 案全部價值的所在，因此在寫端與讀端各擋一次。
+#: spec **絕不可**出現的欄位。兩族，同一條原則：
+#:
+#: 1. **身分**（`user`／`uid`／…）——身分只有一個來源：root-owned unit 檔的 `User=`。
+#:    這是 B 案全部價值的所在。
+#: 2. **加固剖面**（`hardening_profile`／`template`／…，#643）——剖面只有一個來源：
+#:    executor（Manager 的 dispatch 決定）。spec 是 Manager→shim 的**參數**通道；
+#:    讓它承載剖面等於把「用哪一份 unit」變成一個可寫進 spec 的輸入，而那正是
+#:    「per-executor 剖面」退化成「全域移除 MDWE」的路徑。
+#:
+#: 兩族都在寫端（`build_job_spec`）與讀端（`job_shim.load_spec`）各擋一次。
+#:
+#: 註：`unit` 仍是必要欄位（`SPEC_REQUIRED_KEYS`），而它的值確實隱含剖面——但它是
+#: 決定的**紀錄**，不是決定的**輸入**：shim 執行時降權與加固都已由 systemd 套用完畢，
+#: shim 只拿它與自己的 instance 交叉核對，改它不會改變任何已生效的加固面。
 SPEC_FORBIDDEN_KEYS: frozenset[str] = frozenset(
-    {"user", "group", "uid", "gid", "User", "Group", "properties", "exec_start"}
+    {
+        # 身分族
+        "user", "group", "uid", "gid", "User", "Group", "properties", "exec_start",
+        # 剖面族（#643）
+        "hardening", "hardening_profile", "profile",
+        "template", "template_unit", "unit_suffix",
+        "MemoryDenyWriteExecute",
+    }
 )
 
 #: systemd unit 實例名允許的字元。systemd 本身還允許更多（`/` 需 escape），這裡
@@ -917,6 +993,78 @@ def template_unit_name(instance: str, *, template: str = DEFAULT_TEMPLATE_UNIT) 
     return f"{stem}{instance}{TEMPLATE_UNIT_SUFFIX}"
 
 
+def resolve_hardening_profile(executor: str) -> str:
+    """executor → 加固剖面 id。**未知 executor 一律 fail-closed。**
+
+    fail-closed 的方向是本函式的全部重點：這裡**不是**「不確定就給嚴格的」，而是
+    「不確定就拒絕」。
+
+    - 若預設落到**寬鬆**那份，整個 per-executor 設計當場退化成「全域移除 MDWE」——
+      任何未登記的名字都能拿到放寬的 unit。
+    - 若預設落到**嚴格**那份，一個未被盤點過的 node 型 CLI 會在真實加固面下靜默
+      起不來（症狀是空輸出，離原因很遠——#643 就是這樣被埋掉半個 milestone 的）。
+
+    因此唯一正確的行為是要求它先被登記進 `permgen.EXECUTOR_TOOLS`（並標明
+    `needs_node`），再同步到本檔的 :data:`EXECUTOR_HARDENING_PROFILE`。
+    """
+
+    name = str(executor or "").strip()
+    profile = EXECUTOR_HARDENING_PROFILE.get(name)
+    if profile is None:
+        raise _fail(
+            "job-runner-hardening-profile-unknown",
+            (
+                f"未知的 executor {executor!r}，無法決定加固剖面（已登記："
+                f"{sorted(EXECUTOR_HARDENING_PROFILE)}）。新增 executor 必須先進 "
+                "trust_root.permgen.EXECUTOR_TOOLS 標明 needs_node，再同步到 "
+                "job_runner.EXECUTOR_HARDENING_PROFILE——剖面不得靠猜，"
+                "更不得預設落到放寬的那一份。"
+            ),
+            source="resolve_hardening_profile",
+            executor=name,
+        )
+    return profile
+
+
+def template_unit_for_profile(template: str, profile: str) -> str:
+    """基底模板名 ＋ 剖面 → 該剖面的模板名（`cortex-job@.service` → `cortex-job-jit@.service`）。
+
+    `template` 必須是**基底**（strict）名。config（`PSC_JOB_TEMPLATE_UNIT`）若已經被
+    設成某個剖面的名字，這裡 fail-closed 而不是再疊一層後綴——`cortex-job-jit-jit@`
+    這種名字會被 polkit 拒掉，而那時的錯誤訊息（Access denied）指不出真正的原因。
+    """
+
+    if not template.endswith(f"@{TEMPLATE_UNIT_SUFFIX}"):
+        raise _fail(
+            "job-runner-template-unit-invalid",
+            f"{TEMPLATE_UNIT_ENV} 必須是 `<name>@{TEMPLATE_UNIT_SUFFIX}` 形狀，收到 {template!r}",
+            source="template_unit_for_profile",
+            requested=template,
+        )
+    suffix = TEMPLATE_UNIT_SUFFIX_BY_PROFILE.get(profile)
+    if suffix is None:
+        raise _fail(
+            "job-runner-hardening-profile-unknown",
+            f"未知的加固剖面 {profile!r}（已登記：{sorted(TEMPLATE_UNIT_SUFFIX_BY_PROFILE)}）",
+            source="template_unit_for_profile",
+            requested=str(profile),
+        )
+    stem = template[: -len(f"@{TEMPLATE_UNIT_SUFFIX}")]
+    for known in TEMPLATE_UNIT_SUFFIX_BY_PROFILE.values():
+        if known and stem.endswith(known):
+            raise _fail(
+                "job-runner-template-unit-invalid",
+                (
+                    f"{TEMPLATE_UNIT_ENV} 必須是**基底**模板名（strict 剖面），"
+                    f"收到已帶剖面後綴的 {template!r}；剖面由 executor 決定並在此處"
+                    "自動套用，不該由 config 預先寫死。"
+                ),
+                source="template_unit_for_profile",
+                requested=template,
+            )
+    return f"{stem}{suffix}@{TEMPLATE_UNIT_SUFFIX}"
+
+
 def resolve_template_unit(env: Mapping[str, str]) -> str:
     return (env.get(TEMPLATE_UNIT_ENV) or "").strip() or DEFAULT_TEMPLATE_UNIT
 
@@ -933,6 +1081,18 @@ def job_spec_path(spool_dir: str, instance: str) -> str:
     """`<spool>/<instance>.json`——與 `job_shim.resolve_spec_path()` 同一條推導。"""
 
     return f"{spool_dir.rstrip('/')}/{instance}.json"
+
+
+def forbidden_spec_keys(spec: Mapping[str, object]) -> list[str]:
+    """spec 內出現的 :data:`SPEC_FORBIDDEN_KEYS`（排序後）。空 list＝乾淨。
+
+    **寫端（`build_job_spec`）與讀端（`job_shim.load_spec`）呼叫的是這同一支**，
+    兩邊只在「raise 哪一種例外」上不同。抽出來不是為了少寫一行，而是為了讓「兩端
+    掃的是同一份判準」成為結構事實而非約定——這條在 #643 之後承載的東西更多了
+    （不只身分，還有加固剖面）。
+    """
+
+    return sorted(key for key in SPEC_FORBIDDEN_KEYS if key in spec)
 
 
 def build_job_spec(
@@ -980,11 +1140,12 @@ def build_job_spec(
         "log_path": str(log_path),
         "env": {str(k): str(v) for k, v in sorted(env.items())},
     }
-    leaked = sorted(SPEC_FORBIDDEN_KEYS & set(spec))
+    leaked = forbidden_spec_keys(spec)
     if leaked:
         raise _fail(
             "job-runner-job-spec-invalid",
-            f"spec 不得攜帶身分／特權欄位 {leaked}——身分只由 root-owned unit 的 User= 決定",
+            f"spec 不得攜帶身分／加固剖面欄位 {leaked}——身分只由 root-owned unit 的 "
+            "User= 決定，剖面只由 executor 決定（#643）",
             source="build_job_spec",
             instance=instance,
         )
@@ -1201,27 +1362,40 @@ class SystemdTemplatePlan:
     shim: str
     spool_dir: str
     spec_path: str
+    #: 生效的加固剖面 id（#643）。由 `executor` 決定，不由 job 決定。
+    hardening_profile: str = HARDENING_PROFILE_STRICT
+    #: 決定剖面的 executor（Manager 的 dispatch 決定）。留在 plan 上供診斷／稽核。
+    executor: str = ""
+    #: config 給的**基底**模板名（未套剖面後綴前）。
+    base_template_unit: str = DEFAULT_TEMPLATE_UNIT
 
 
 def prepare_systemd_template(
     env: Mapping[str, str],
     *,
     job_id: str,
+    executor: str,
     unit_active: Callable[[str, str], bool] | None = None,
 ) -> SystemdTemplatePlan:
-    """模板派工的前置：解析 config、靜態 preflight、算 instance／unit／spec 路徑，
-    並確認**同名 instance 沒有正在跑**。
+    """模板派工的前置：解析 config、決定加固剖面、靜態 preflight、算 instance／unit／
+    spec 路徑，並確認**同名 instance 沒有正在跑**。
 
     最後一條特別重要：`systemctl start` 對一個**已經 active** 的 unit 會直接回 0，
     什麼都不做。少了這個檢查，Manager 會以為自己起了一個 job，實際上是掛在別人的
     unit 上等——而且 `--wait` 會一路等到那個別人的 job 結束。
+
+    `executor` 是**必填且無預設**（#643）：剖面選擇的唯一輸入就是它，而它是 Manager
+    的 dispatch 決定。給預設值等於允許某條路徑「忘了說是哪個 executor」還能派出去，
+    那個預設值不論指向哪一份剖面都是錯的（見 :func:`resolve_hardening_profile`）。
 
     **在任何副作用之前呼叫**：這裡每一個 raise 都代表本次派工不該發生。
     """
 
     account = resolve_builder_account(env)
     group = resolve_builder_group(env)
-    template = resolve_template_unit(env)
+    base_template = resolve_template_unit(env)
+    profile = resolve_hardening_profile(executor)
+    template = template_unit_for_profile(base_template, profile)
     shim = resolve_job_shim(env)
     spool_dir = resolve_job_spec_spool(env)
     binary = preflight_systemd_template(
@@ -1255,6 +1429,9 @@ def prepare_systemd_template(
         shim=shim,
         spool_dir=spool_dir,
         spec_path=job_spec_path(spool_dir, instance),
+        hardening_profile=profile,
+        executor=str(executor or "").strip(),
+        base_template_unit=base_template,
     )
 
 

--- a/paulsha_cortex/coordinator/job_shim.py
+++ b/paulsha_cortex/coordinator/job_shim.py
@@ -52,6 +52,7 @@ from .job_runner import (
     JOB_SPEC_VERSION,
     SPEC_FORBIDDEN_KEYS,
     SPEC_REQUIRED_KEYS,
+    forbidden_spec_keys,
     instance_name_valid,
     reject_unsafe_env,
 )
@@ -59,6 +60,7 @@ from .job_runner import (
 __all__ = [
     "EXIT_SPEC_ERROR",
     "ShimError",
+    "forbidden_spec_keys",
     "load_spec",
     "main",
     "resolve_spec_path",
@@ -142,13 +144,14 @@ def load_spec(instance: str, spool_root: str) -> dict[str, object]:
     missing = [key for key in SPEC_REQUIRED_KEYS if key not in spec]
     if missing:
         raise ShimError(f"job spec 缺少必要欄位 {missing}: {path}")
-    # 身分欄位是**結構性禁止**，不是「忽略」：spec 一旦被容忍帶 user/uid，日後
-    # 有人「順手支援一下」就會把 B 案的整個保證還回去。
-    present_forbidden = sorted(k for k in SPEC_FORBIDDEN_KEYS if k in spec)
+    # 身分與加固剖面欄位是**結構性禁止**，不是「忽略」：spec 一旦被容忍帶 user/uid
+    # 或 hardening_profile，日後有人「順手支援一下」就會把 B 案／#643 的整個保證
+    # 還回去。掃的是與寫端**同一支** `forbidden_spec_keys()`。
+    present_forbidden = forbidden_spec_keys(spec)
     if present_forbidden:
         raise ShimError(
-            f"job spec 不得攜帶身分欄位 {present_forbidden}（身分只由 root-owned "
-            f"unit 的 User= 決定）: {path}"
+            f"job spec 不得攜帶身分／加固剖面欄位 {present_forbidden}（身分只由 "
+            f"root-owned unit 的 User= 決定，剖面只由 executor 決定）: {path}"
         )
     if spec.get("instance") != instance:
         raise ShimError(

--- a/paulsha_cortex/coordinator/launcher.py
+++ b/paulsha_cortex/coordinator/launcher.py
@@ -1299,7 +1299,16 @@ class SubprocessLauncher:
         elif runner_mode == job_runner.RUNNER_SYSTEMD_TEMPLATE:
             # B 案（0816 第三輪裁決）：模板 unit／shim／spec spool 三個前置物任一
             # 缺席都在這裡 fail-closed，且**在寫任何 spec 之前**。
-            template_plan = job_runner.prepare_systemd_template(os.environ, job_id=slice_id)
+            #
+            # #643：加固剖面在這裡定案。唯一的輸入是 `self._executor`——它由
+            # `SubprocessLauncher.__init__` 收下（Manager 的 dispatch 決定，且已對
+            # `_ARGV_BUILDERS` 驗過），此後 immutable。**job 影響不到它**：prompt、
+            # worktree 內容、spec 都在這行之後才產生，而 spec 連提剖面都不准
+            # （`job_runner.SPEC_FORBIDDEN_KEYS`）。未登記的 executor 在這裡
+            # fail-closed，不會落到放寬的那一份剖面。
+            template_plan = job_runner.prepare_systemd_template(
+                os.environ, job_id=slice_id, executor=self._executor
+            )
         degraded = runner_mode is not None
         resolved_worktree = Path(worktree).resolve(strict=True)
         if not resolved_worktree.is_dir():

--- a/paulsha_cortex/trust_root/__main__.py
+++ b/paulsha_cortex/trust_root/__main__.py
@@ -13,13 +13,21 @@ Phase 1 不改 `cortex` CLI（避免動到 R-16 help 對齊面）；operator／C
                                                     # Phase 2a 權限計畫（JSON 或命令序列）
     python -m paulsha_cortex.trust_root unit [three-way|two-way]
                                         [--manager|--monitor|--job|--job-properties]
+                                        [--profile strict|jit]
                                                     # Phase 2b systemd unit 內容
                                                     # （--monitor＝monitor 的 system-level
                                                     #   unit：與 manager 同帳號、同加固段，
                                                     #   但 ReadWritePaths 只由 monitor
                                                     #   persona 的登記表面導出，嚴格更窄；
                                                     #   --job-properties＝方案 A 的
-                                                    #   systemd-run --property= 清單）
+                                                    #   systemd-run --property= 清單；
+                                                    #   --profile＝#643 的 per-executor
+                                                    #   加固剖面，只對 --job／
+                                                    #   --job-properties 有意義。預設
+                                                    #   strict＝完整加固表；jit 只放寬
+                                                    #   MemoryDenyWriteExecute，給 node 型
+                                                    #   executor（codex／copilot）用，
+                                                    #   unit 名為 cortex-job-jit@.service）
     python -m paulsha_cortex.trust_root shim [three-way|two-way]
                                                     # Phase 2b 方案 B 的降權 shim 內容
                                                     # （模板 unit 的固定 ExecStart=）
@@ -279,8 +287,20 @@ def main(argv: Sequence[str] | None = None) -> int:
         rest = args[1:]
         scheme_id = permgen.DEFAULT_SCHEME_ID
         which = "manager"
+        profile_id = permgen.DEFAULT_HARDENING_PROFILE.profile_id
+        expect_profile = False
         for token in rest:
-            if token == "--manager":
+            if expect_profile:
+                if token not in permgen.HARDENING_PROFILES_BY_ID:
+                    print(
+                        f"unknown hardening profile: {token}"
+                        f"（可用：{sorted(permgen.HARDENING_PROFILES_BY_ID)}）",
+                        file=sys.stderr,
+                    )
+                    return 2
+                profile_id = token
+                expect_profile = False
+            elif token == "--manager":
                 which = "manager"
             elif token == "--monitor":
                 which = "monitor"
@@ -288,24 +308,50 @@ def main(argv: Sequence[str] | None = None) -> int:
                 which = "job"
             elif token == "--job-properties":
                 which = "job-properties"
+            elif token == "--profile":
+                expect_profile = True
+            elif token.startswith("--profile="):
+                candidate = token.split("=", 1)[1]
+                if candidate not in permgen.HARDENING_PROFILES_BY_ID:
+                    print(
+                        f"unknown hardening profile: {candidate}"
+                        f"（可用：{sorted(permgen.HARDENING_PROFILES_BY_ID)}）",
+                        file=sys.stderr,
+                    )
+                    return 2
+                profile_id = candidate
             elif token in permgen.SCHEMES:
                 scheme_id = token
             else:
                 print(f"unknown unit arg: {token}", file=sys.stderr)
                 return 2
+        if expect_profile:
+            print("--profile 需要一個剖面 id", file=sys.stderr)
+            return 2
         scheme = permgen.SCHEMES[scheme_id]
+        profile = permgen.HARDENING_PROFILES_BY_ID[profile_id]
         if which == "job-properties":
             print("# 方案 A（systemd-run transient unit）的 --property= 建議清單。")
             print("# 與方案 B 的模板 unit 同源（同一加固表 ＋ 同一份登記表導出的 RWP）。")
+            print(f"# 加固剖面：{profile_id}（--profile 可切換；預設為最嚴格的那一份）。")
             print("# 注意：%i 是 systemd 模板 specifier；A 方案（transient）請由呼叫端")
             print("#       代入該 job 的實際 worktree 路徑。")
-            for prop in permgen.transient_unit_properties(scheme):
+            for prop in permgen.transient_unit_properties(scheme, profile=profile):
                 print(prop)
             return 0
+        if which == "job":
+            print(permgen.build_job_unit(scheme, profile=profile).content, end="")
+            return 0
+        if profile_id != permgen.DEFAULT_HARDENING_PROFILE.profile_id:
+            # 剖面只對 job 模板 unit 有意義；靜默忽略會產出一份與旗標不符的內容。
+            print(
+                f"--profile 只適用於 --job／--job-properties（收到 {which}）",
+                file=sys.stderr,
+            )
+            return 2
         builders = {
             "manager": permgen.build_manager_unit,
             "monitor": permgen.build_monitor_unit,
-            "job": permgen.build_job_unit,
         }
         print(builders[which](scheme).content, end="")
         return 0

--- a/paulsha_cortex/trust_root/permgen.py
+++ b/paulsha_cortex/trust_root/permgen.py
@@ -71,8 +71,10 @@ principal 時再犯同一個錯」——新 principal 只要沒進對應表，�
 from __future__ import annotations
 
 import re
+import unicodedata
 from dataclasses import dataclass, field, replace
 from enum import Enum
+from types import MappingProxyType
 from typing import Mapping
 
 from . import registry
@@ -428,14 +430,25 @@ class ExecutorTool:
     name: str
     shape: ExecutorShape
     #: 需要**系統層** runtime 才跑得起來（目前只有 node）。
+    #:
+    #: **這個欄位同時是加固剖面的分類來源**（#643）：node ⇒ V8 ⇒ JIT ⇒ 需要 W+X
+    #: 記憶體 ⇒ `MemoryDenyWriteExecute=yes` 下起不來。剖面由
+    #: :func:`executor_hardening_profile` 機械導出，**不另立第二張清單**。
     needs_node: bool
     #: 必須連同整包目錄複製（npm 套件樹），而不是單一檔案。
     copy_tree: bool
     note: str
 
 
-#: 0817 實機盤點的四個 executor。`needs_node` 為真者只有 `codex`——這正是「系統層
-#: node 的版本風險只涵蓋一個 CLI」這句話的機器可讀形式。
+#: 0817 實機盤點的四個 executor。`needs_node` 為真者是 `codex` 與 `copilot`——
+#: 這是「系統層 node 的版本風險涵蓋哪幾個 CLI」與「哪幾個 job 必須走放寬 W+X 的
+#: 加固剖面」（#643）兩句話共同的機器可讀形式。
+#:
+#: **`copilot` 的 `needs_node` 於 #643 由 False 改為 True**：#640 落表時只知道它是
+#: shell script、還沒查它內部 exec 什麼（表上的 note 當時就寫著「安裝時務必
+#: `head -n 20` 查一次」）。#643 在真實加固面下逐項隔離量到 `copilot --version` 在
+#: `MemoryDenyWriteExecute=yes` 下**空輸出**、拿掉即正常，與 `codex` 的症狀逐字相同
+#: ——它內部 exec 的就是 node。把量到的事實回填到既有那張表，而不是為剖面另開一張。
 EXECUTOR_TOOLS: tuple[ExecutorTool, ...] = (
     ExecutorTool(
         "codex", ExecutorShape.NODE_SCRIPT, needs_node=True, copy_tree=True,
@@ -451,11 +464,13 @@ EXECUTOR_TOOLS: tuple[ExecutorTool, ...] = (
         note="自帶原生執行檔，**不因 node 版本而行為改變**——node 的版本風險不涵蓋它。",
     ),
     ExecutorTool(
-        "copilot", ExecutorShape.SHELL_SCRIPT, needs_node=False, copy_tree=False,
+        "copilot", ExecutorShape.SHELL_SCRIPT, needs_node=True, copy_tree=False,
         note=(
-            "shell script。腳本內部**可能再叫別的程式**（另一支 CLI、另一個 runtime），"
-            "安裝時務必 `head -n 20` 查一次它實際 exec 什麼，該相依同樣要在 job 的 "
-            "PATH 上或一併搬進 toolchain。"
+            "shell script，但**內部再 exec node**（#643 實機量測確認：完整加固面下 "
+            "`--version` 空輸出，單獨拿掉 `MemoryDenyWriteExecute` 即正常，與 codex "
+            "的症狀逐字相同）。因此它同樣吃系統層 node 的版本風險，加固剖面也與 "
+            "`codex` 同一份。安裝時仍應 `head -n 20` 查一次它實際 exec 什麼——它可能"
+            "再叫別的程式，該相依同樣要在 job 的 PATH 上或一併搬進 toolchain。"
         ),
     ),
     ExecutorTool(
@@ -1995,7 +2010,8 @@ _HARDENING: tuple[tuple[str, str, str], ...] = (
     ("LockPersonality", "yes", "鎖定執行域，禁止切換 personality 規避 seccomp。"),
     ("MemoryDenyWriteExecute", "yes",
      "禁 W+X 記憶體，封 JIT 型 shellcode。※ 若 Python C-extension（ctypes "
-     "trampoline）啟動失敗，這是第一嫌疑：先單獨註解本行複測。"),
+     "trampoline）或任何 JS runtime 啟動失敗，這是第一嫌疑：先單獨註解本行複測"
+     "（#643 實測 V8 的 Runtime_CompileLazy 會直接崩）。"),
     ("SystemCallArchitectures", "native",
      "只允許原生 ABI，封掉經 32-bit compat 介面規避 seccomp。"),
     ("SystemCallFilter", "@system-service",
@@ -2009,9 +2025,173 @@ _HARDENING: tuple[tuple[str, str, str], ...] = (
 )
 
 
+# ---------------------------------------------------------------------------
+# per-executor 加固剖面（#643，operator 裁決＝方向 2）
+#
+# 問題：`MemoryDenyWriteExecute=yes` 與 JS runtime 天生互斥（V8 的 JIT 必須 W+X），
+# 而預設 executor 正是 node 型的 `codex`。三個方向裡 operator 選了「per-executor 剖面」
+# ——node 型 job 走一份**只在這一項**放寬的 unit，原生執行檔型維持嚴格。
+#
+# 這個設計成立的前提只有一條：**剖面不可由 job 自選**。若 job 能選到寬鬆那份，
+# 它就退化成「全域移除 MDWE」。守法（三層，缺一即退化）：
+#
+#   1. 剖面由 **executor** 決定，而 executor 是 Manager 的 dispatch 決定
+#      （`SubprocessLauncher(executor=...)`，job spec 產生之前就固定了）；
+#   2. 對應表由 :data:`EXECUTOR_TOOLS` 的 `needs_node` **機械導出**，未知 executor
+#      fail-closed（見 :func:`executor_hardening_profile`）——不得預設落到寬鬆那份；
+#   3. 兩份 unit 都是 root-owned、`User=`／`ExecStart=` 寫死；呼叫端只能
+#      `systemctl start <那兩個名字之一>@<id>.service`，選不了執行的第一支程式，
+#      也塞不進任何屬性（polkit 規則的 unit pattern 只列舉這兩個字幹）。
+#
+# **兩份 unit 共用同一張 `_HARDENING` 表**，只以 `overrides` 分岔：日後往加固表加一
+# 項時兩份自動同時拿到，不存在「改一份忘另一份」。
+# ---------------------------------------------------------------------------
+
+#: 加固表中**唯一**允許被剖面分岔的鍵。寫成常數而非散在各處：想放寬第二項就必須改
+#: 這裡，而這裡同時是測試的比對基準——「順手多放寬一項」不會靜默通過。
+PROFILE_DIVERGENCE_KEYS: frozenset[str] = frozenset({"MemoryDenyWriteExecute"})
+
+
+class UnknownExecutorProfileError(ValueError):
+    """未知 executor 的剖面查詢——**fail-closed**，絕不落到寬鬆那份。"""
+
+
+@dataclass(frozen=True)
+class HardeningProfile:
+    """job 模板 unit 的加固剖面（`_HARDENING` ＋ 一組受限覆寫）。"""
+
+    profile_id: str
+    #: unit 字幹的後綴。strict＝空字串，因此既有的 `cortex-job@.service` 逐字不變。
+    unit_suffix: str
+    #: 對 `_HARDENING` 的覆寫。鍵必須同時屬於 `_HARDENING` 與 `PROFILE_DIVERGENCE_KEYS`
+    #: （import 時由 `_validate_hardening_profiles()` 強制，打錯字不會靜默變成 no-op）。
+    overrides: Mapping[str, str]
+    #: 這份剖面為誰而設、為什麼。
+    rationale: str
+    #: 這份剖面**放棄**的防護。誠實標註：產物、spec 與 runbook 都引用它。
+    accepted_loss: tuple[str, ...] = ()
+
+    def effective(self) -> dict[str, str]:
+        """本剖面實際生效的加固表（鍵集合與 `_HARDENING` 恆等）。"""
+
+        table = {key: value for key, value, _why in _HARDENING}
+        table.update(self.overrides)
+        return table
+
+
+#: 嚴格剖面（**預設**）：完整加固表，一項不減。原生執行檔型 executor
+#: （`claude`／`agy`）在此剖面下實測全部可用，因此它們沒有理由降級。
+STRICT_PROFILE = HardeningProfile(
+    profile_id="strict",
+    unit_suffix="",
+    overrides={},
+    rationale=(
+        "原生 ELF executor（不依賴 JS runtime）的 job。完整加固面，含 "
+        "MemoryDenyWriteExecute=yes。"
+    ),
+)
+
+#: 放寬剖面：**只**放寬 `MemoryDenyWriteExecute`，其餘 26 項逐字不變。
+JIT_PROFILE = HardeningProfile(
+    profile_id="jit",
+    unit_suffix="-jit",
+    overrides={"MemoryDenyWriteExecute": "no"},
+    rationale=(
+        "node 型 executor（`EXECUTOR_TOOLS` 的 `needs_node`）的 job。V8 的 JIT 必須有 "
+        "W+X 記憶體，MemoryDenyWriteExecute=yes 下 Runtime_CompileLazy 直接崩（#643 "
+        "實機量測）——這一項與 JS runtime 天生互斥，不是設定錯誤。"
+    ),
+    accepted_loss=(
+        "本剖面的 job **失去 MemoryDenyWriteExecute 這層防護**：取得任意程式碼執行的"
+        "攻擊者可在本 job 內配置 W+X 記憶體，JIT 型 shellcode（不落地、不經 exec、"
+        "因此也不觸發 NoNewPrivileges／SystemCallFilter 之外的任何一層）在此可行。",
+        "換來的是保住 codex／copilot 兩個 provider——即 §R5／§R8 的 independence_domain "
+        "仍有可選空間。這是**付了代價的取捨**，不是沒有代價。",
+        "其餘 26 項加固（NoNewPrivileges／CapabilityBoundingSet 空／ProtectSystem=strict"
+        "／SystemCallFilter 等）在本剖面下**逐項不變**：W+X 只讓攻擊者在自己這個 UID "
+        "的位址空間內執行程式碼，跨 UID／跨檔案系統／提權的那幾層完全沒有鬆動。",
+    ),
+)
+
+#: 全部剖面。polkit 的 unit pattern 與測試的比對基準都由這裡導出。
+HARDENING_PROFILES: tuple[HardeningProfile, ...] = (STRICT_PROFILE, JIT_PROFILE)
+HARDENING_PROFILES_BY_ID: Mapping[str, HardeningProfile] = MappingProxyType(
+    {profile.profile_id: profile for profile in HARDENING_PROFILES}
+)
+
+#: 未指定時一律用**嚴格**那份。「預設就是最安全的那一個」與 `DEFAULT_SCHEME` 同一條
+#: 原則：要放寬必須顯式打出來，打錯字不會靜默退回較寬鬆的剖面。
+DEFAULT_HARDENING_PROFILE: HardeningProfile = STRICT_PROFILE
+
+
+def _validate_hardening_profiles() -> None:
+    """import 時的結構檢查：覆寫鍵必須真的存在、且在允許分岔的白名單內。"""
+
+    known = {key for key, _value, _why in _HARDENING}
+    missing = sorted(PROFILE_DIVERGENCE_KEYS - known)
+    if missing:
+        raise ValueError(f"PROFILE_DIVERGENCE_KEYS 指到 _HARDENING 沒有的鍵: {missing}")
+    suffixes: set[str] = set()
+    for profile in HARDENING_PROFILES:
+        bad = sorted(set(profile.overrides) - known)
+        if bad:
+            raise ValueError(
+                f"剖面 {profile.profile_id} 覆寫了 _HARDENING 沒有的鍵 {bad}"
+                "——打錯字會變成一個看起來有效、實際毫無作用的覆寫。"
+            )
+        outside = sorted(set(profile.overrides) - PROFILE_DIVERGENCE_KEYS)
+        if outside:
+            raise ValueError(
+                f"剖面 {profile.profile_id} 覆寫了 PROFILE_DIVERGENCE_KEYS 以外的鍵 "
+                f"{outside}——擴大分岔面必須是顯式決定。"
+            )
+        if profile.unit_suffix and not re.fullmatch(r"-[a-z0-9]+", profile.unit_suffix):
+            # 字幹會被拼進 polkit 的 regex（原字串，不 escape），因此形狀必須受限。
+            raise ValueError(f"剖面 {profile.profile_id} 的 unit_suffix 形狀不合法")
+        if profile.unit_suffix in suffixes:
+            raise ValueError(f"剖面 unit_suffix 重複: {profile.unit_suffix!r}")
+        suffixes.add(profile.unit_suffix)
+
+
+_validate_hardening_profiles()
+
+
+#: executor → 剖面 id。**由 `EXECUTOR_TOOLS` 機械導出，不是第二張清單**：改 executor
+#: 的形態只改那張表一列，這裡跟著動。
+EXECUTOR_HARDENING_PROFILE: Mapping[str, str] = MappingProxyType(
+    {
+        tool.name: (JIT_PROFILE if tool.needs_node else STRICT_PROFILE).profile_id
+        for tool in EXECUTOR_TOOLS
+    }
+)
+
+
+def executor_hardening_profile(executor: str) -> HardeningProfile:
+    """executor 名 → 加固剖面。**未知 executor 一律拒絕，不回傳任何剖面。**
+
+    fail-closed 的方向很重要：這裡不是「不確定就給嚴格的」，而是「不確定就拒絕」。
+    給嚴格的表面上安全，實際會讓一個從未被盤點過的 node 型 CLI 在真實加固面下靜默
+    起不來（症狀是空輸出，離原因很遠——#643 就是這樣被埋掉的）；而如果反過來預設
+    給寬鬆的，整個 per-executor 設計當場退化成「全域移除 MDWE」。兩邊都不可接受，
+    因此唯一正確的行為是要求它先被登記進 :data:`EXECUTOR_TOOLS`。
+    """
+
+    name = str(executor or "").strip()
+    profile_id = EXECUTOR_HARDENING_PROFILE.get(name)
+    if profile_id is None:
+        raise UnknownExecutorProfileError(
+            f"未知的 executor {executor!r}，無法決定加固剖面"
+            f"（已登記：{sorted(EXECUTOR_HARDENING_PROFILE)}）。新增 executor 必須先進 "
+            "permgen.EXECUTOR_TOOLS 並標明 needs_node——剖面不得靠猜，也不得預設"
+            "落到放寬的那一份。"
+        )
+    return HARDENING_PROFILES_BY_ID[profile_id]
+
+
 def job_unit_stem(
     layout: "PathLayout" = None,  # type: ignore[assignment]
     principal: Principal = Principal.BUILDER,
+    profile: HardeningProfile = DEFAULT_HARDENING_PROFILE,
 ) -> str:
     """降權 job 模板 unit 的字幹（不含 `@.service`）。
 
@@ -2021,11 +2201,15 @@ def job_unit_stem(
     只需傳入另一個 `principal`：unit 名、`User=`、`Environment=HOME=`／
     `XDG_CACHE_HOME=`、`ReadWritePaths=` 全部跟著 scheme 導出，`build_job_unit()`／
     `build_polkit_rule()`／`build_job_shim()` 三支產生器**一行都不必改**。
+
+    `profile` 是 **#643 的第二個擴充點**：加固剖面不同 ⇒ 必須是不同的 unit 檔
+    （加固指令寫在檔案裡，一個模板只有一份），因此字幹尾端掛剖面後綴。嚴格剖面的
+    後綴是空字串，`cortex-job@.service` 這個既有名字逐字不變。
     """
     layout = layout if layout is not None else DEFAULT_LAYOUT
     if principal is Principal.BUILDER:
-        return f"{layout.instance}-job"
-    return f"{layout.instance}-{principal.value}-job"
+        return f"{layout.instance}-job{profile.unit_suffix}"
+    return f"{layout.instance}-{principal.value}-job{profile.unit_suffix}"
 
 
 @dataclass(frozen=True)
@@ -2039,6 +2223,8 @@ class SystemdUnit:
     environment_file: str | None
     read_write_paths: tuple[str, ...]
     content: str
+    #: 生效的加固剖面 id（#643）。Manager／monitor unit 恆為 `strict`。
+    hardening_profile: str = DEFAULT_HARDENING_PROFILE.profile_id
 
     def to_dict(self) -> dict[str, object]:
         return {
@@ -2048,16 +2234,58 @@ class SystemdUnit:
             "exec_start": self.exec_start,
             "environment_file": self.environment_file,
             "read_write_paths": list(self.read_write_paths),
+            "hardening_profile": self.hardening_profile,
             "content": self.content,
         }
 
 
-def _hardening_lines(overrides: Mapping[str, str] | None = None) -> list[str]:
+def _wrap_comment(text: str, prefix: str = "# ", width: int = 78) -> list[str]:
+    """把一段（可能很長的）中文說明折成多行註解。
+
+    `textwrap` 只在空白處斷行，對中文等於不折——產出的 unit 會出現數百字元的單行
+    註解，`systemctl cat` 讀起來完全失去可審查性。這裡改以顯示寬度計（CJK 算 2），
+    可在任意字元處斷行。
+    """
+
     lines: list[str] = []
-    over = dict(overrides or {})
+    current: list[str] = []
+    used = len(prefix)
+    for char in text:
+        size = 2 if unicodedata.east_asian_width(char) in ("W", "F") else 1
+        if used + size > width and current:
+            lines.append((prefix + "".join(current)).rstrip())
+            current = []
+            used = len(prefix)
+            if char == " ":
+                # 斷在空白處時不把它帶到下一行的行首。
+                continue
+        current.append(char)
+        used += size
+    if current:
+        lines.append((prefix + "".join(current)).rstrip())
+    return lines or [prefix.rstrip()]
+
+
+def _hardening_lines(
+    profile: HardeningProfile = DEFAULT_HARDENING_PROFILE,
+) -> list[str]:
+    """展開加固表。**所有 unit 都走這一支**，剖面只以 `overrides` 分岔。
+
+    刻意不接受任意 override mapping：唯一的合法覆寫來源是 :data:`HARDENING_PROFILES`
+    ——那張表已在 import 時驗過「鍵存在且在 `PROFILE_DIVERGENCE_KEYS` 內」。開一個
+    自由的 override 參數等於讓任何呼叫端就地放寬一項加固而不被任何檢查看到。
+    """
+
+    lines: list[str] = []
     for key, value, why in _HARDENING:
-        effective = over.get(key, value)
+        effective = profile.overrides.get(key, value)
         lines.append(f"# {why}")
+        if effective != value:
+            lines += _wrap_comment(
+                f"※ 剖面覆寫（profile={profile.profile_id}）：嚴格剖面為 "
+                f"{key}={value}，本剖面改為 {key}={effective}。**這是本檔與 "
+                f"strict 剖面唯一的差異**；理由與接受的代價見檔頭「加固剖面」段。"
+            )
         lines.append(f"{key}={effective}")
     return lines
 
@@ -2292,6 +2520,7 @@ def build_job_unit(
     layout: PathLayout = DEFAULT_LAYOUT,
     principal: Principal = Principal.BUILDER,
     plan: PermissionPlan | None = None,
+    profile: HardeningProfile = DEFAULT_HARDENING_PROFILE,
 ) -> SystemdUnit:
     """降權 job 的**模板** unit（`cortex-job@.service`）。
 
@@ -2311,6 +2540,12 @@ def build_job_unit(
     `<log_dir>/<slice>.jsonl`（`%i` 推不出來），兩者無法同時成立。因此 log 導引改由
     **shim 在已降權之後**依 spec 的 `log_path` 自行接管（見 `coordinator/job_shim.py`），
     unit 這層只留 journal 給 shim 讀 spec 失敗時的診斷。
+
+    **`profile`（#643）**：加固剖面。同一個 principal 會產出**兩份** unit——
+    `cortex-job@.service`（strict）與 `cortex-job-jit@.service`（jit）——兩份共用
+    同一張 `_HARDENING` 表，只在 `PROFILE_DIVERGENCE_KEYS` 那一項分岔。哪個 job 用
+    哪一份由 **executor** 決定（:func:`executor_hardening_profile`），而 executor 是
+    Manager 的 dispatch 決定；job 自己（spec 也好、worktree 內容也好）碰不到這個選擇。
     """
     plan = plan or generate_plan(scheme)
     account = scheme.resolve(principal)
@@ -2321,18 +2556,38 @@ def build_job_unit(
     job_layout = layout.with_job_segment("%i")
     extras = job_layout.job_extra_write_paths(account)
     owners = read_write_path_owners(plan, job_layout, account, extras)
-    unit_name = f"{job_unit_stem(layout, principal)}@.service"
+    stem = job_unit_stem(layout, principal, profile)
+    unit_name = f"{stem}@.service"
+    profile_users = sorted(
+        name
+        for name, profile_id in EXECUTOR_HARDENING_PROFILE.items()
+        if profile_id == profile.profile_id
+    )
 
     body = [
         f"# {'/etc/systemd/system/' + unit_name}",
-        f"# 由 permgen 機械產生（scheme={scheme.scheme_id}）——勿手改；重跑：",
-        f"#   python3 -m paulsha_cortex.trust_root unit {scheme.scheme_id} --job",
+        f"# 由 permgen 機械產生（scheme={scheme.scheme_id}, profile={profile.profile_id}）",
+        "# ——勿手改；重跑：",
+        f"#   python3 -m paulsha_cortex.trust_root unit {scheme.scheme_id} --job"
+        + (f" --profile {profile.profile_id}" if profile is not DEFAULT_HARDENING_PROFILE else ""),
         "#",
         "# 降權/提權分界線：User= 在本 root-owned 檔內硬寫死。Manager（cortex-svc）",
-        "# 只能 `systemctl start cortex-job@<id>.service`，**不能**選 UID、不能傳屬性。",
+        f"# 只能 `systemctl start {stem}@<id>.service`，**不能**選 UID、不能傳屬性。",
+        "#",
+        f"# === 加固剖面：{profile.profile_id}（#643 per-executor 剖面）===",
+        f"# 適用 executor：{'、'.join(profile_users) if profile_users else '（無）'}",
+    ]
+    body += _wrap_comment(f"理由：{profile.rationale}")
+    for loss in profile.accepted_loss:
+        body += _wrap_comment(f"⚠ 本剖面接受的代價：{loss}")
+    body += [
+        "# 剖面**不由 job 決定**：對應表由 permgen.EXECUTOR_TOOLS 的 needs_node 機械",
+        "# 導出，executor 則是 Manager 的 dispatch 決定；job spec 結構性禁止攜帶任何",
+        "# 剖面欄位（job_runner.SPEC_FORBIDDEN_KEYS，寫端與讀端各擋一次）。",
         "",
         "[Unit]",
-        "Description=cortex headless job %i (downgraded, trust-root Phase 2b)",
+        "Description=cortex headless job %i (downgraded, trust-root Phase 2b, "
+        f"hardening={profile.profile_id})",
         f"After={layout.instance}-manager.service",
         "# job 為一次性：結束即回收 unit 狀態，不留可被重用的殘骸。",
         "# `CollectMode` 是 **[Unit] 的鍵**，不是 [Service] 的（#645 附帶修正）——放錯段",
@@ -2402,9 +2657,11 @@ def build_job_unit(
         f"Environment=HOME={job_layout.home_of(account)}",
         f"Environment=XDG_CACHE_HOME={job_layout.cache_of(account)}",
         "",
-        "# --- 加固（與 Manager 同一套；job 這側只多不少）---",
+        f"# --- 加固（與 Manager 同一張 _HARDENING 表；剖面={profile.profile_id}）---",
+        "# 兩份 job unit 共用這張表，只在下方以 ※ 標出的那一項分岔；",
+        "# 日後往表裡加一項，兩份 unit 會自動同時拿到。",
     ]
-    body += _hardening_lines()
+    body += _hardening_lines(profile)
     body += [""]
     body += _rwp_lines(owners)
     body += [
@@ -2426,6 +2683,7 @@ def build_job_unit(
         environment_file=None,
         read_write_paths=tuple(owners.keys()),
         content="\n".join(body) + "\n",
+        hardening_profile=profile.profile_id,
     )
 
 
@@ -2741,11 +2999,14 @@ def build_toolchain_plan(
         f" -m 0755 {layout.toolchain_lib}",
     ]
     for tool in EXECUTOR_TOOLS:
+        profile = executor_hardening_profile(tool.name)
         lines += [
             "",
             f"# --- {tool.name}（{tool.shape.value}"
             + ("；**需要系統層 node**" if tool.needs_node else "")
             + f"）---",
+            f"#   加固剖面：{profile.profile_id} ⇒ "
+            f"{job_unit_stem(layout, Principal.BUILDER, profile)}@<id>.service（#643）",
             f"#   {tool.note}",
             f'#   SRC="$(readlink -f "$(command -v {tool.name})")"   '
             "# operator 實際在用的那一份",
@@ -2854,17 +3115,39 @@ def transient_unit_prefix(layout: "PathLayout") -> str:
     return f"{layout.instance}-job-"
 
 
+def job_unit_stems(
+    layout: "PathLayout" = None,  # type: ignore[assignment]
+    principal: Principal = Principal.BUILDER,
+) -> tuple[str, ...]:
+    """該 principal 的**全部**模板字幹（每個加固剖面一個），依剖面表順序。"""
+
+    layout = layout if layout is not None else DEFAULT_LAYOUT
+    return tuple(job_unit_stem(layout, principal, p) for p in HARDENING_PROFILES)
+
+
 def job_unit_pattern(
     layout: "PathLayout" = None,  # type: ignore[assignment]
     plan: PolkitPlan = PolkitPlan.TEMPLATE,
     principal: Principal = Principal.BUILDER,
 ) -> str:
-    """被授權的 unit 名 regex（錨定）。`principal` 是 M2 的第二實例化擴充點。"""
+    """被授權的 unit 名 regex（錨定）。`principal` 是 M2 的第二實例化擴充點。
+
+    **#643 起字幹是一個列舉的交替，不是萬用字元**：每個加固剖面各有一份 root-owned
+    模板檔，因此各有一個字幹（`cortex-job` / `cortex-job-jit`）。交替項由
+    :data:`HARDENING_PROFILES` 機械導出——新增剖面時 pattern 自動涵蓋它，而**放行面
+    仍然是「兩個具名的模板」，不是「任意 unit」**：前後都錨定，instance 段的字元類
+    未變，`^` 與 `@` 之間不允許任何未列舉的字幹。
+
+    刻意**不**用 `re.escape()`：產出的字串會原樣嵌進 polkit 的 JS regex 字面量，而
+    `re.escape` 會把 `-` escape 成 `\\-`（JS 的 unicode 模式視為錯誤）。字幹形狀改由
+    `_validate_hardening_profiles()` 與 `layout.instance` 的既有約束保證。
+    """
     layout = layout if layout is not None else DEFAULT_LAYOUT
     if plan is PolkitPlan.TRANSIENT:
         return r"^" + layout.instance + r"-job-[a-z0-9][a-z0-9._-]{0,62}\.service$"
-    stem = job_unit_stem(layout, principal)
-    return r"^" + stem + r"@[a-z0-9][a-z0-9._-]{0,62}\.service$"
+    stems = job_unit_stems(layout, principal)
+    alternation = stems[0] if len(stems) == 1 else "(?:" + "|".join(stems) + ")"
+    return r"^" + alternation + r"@[a-z0-9][a-z0-9._-]{0,62}\.service$"
 
 
 def plan_residual_risk(plan: PolkitPlan, scheme: UidScheme) -> tuple[str, ...]:
@@ -2930,10 +3213,16 @@ def build_polkit_rule(
             f"//   python3 -m paulsha_cortex.trust_root polkit {scheme.scheme_id} --template\n"
         )
     else:
+        stems = job_unit_stems(layout, principal)
+        profile_lines = "".join(
+            f"//     - {job_unit_stem(layout, principal, p)}@<id>.service"
+            f"（剖面 {p.profile_id}：{'完整加固表' if not p.overrides else '、'.join(f'{k}={v}' for k, v in sorted(p.overrides.items())) + '，其餘逐項同 strict'}）\n"
+            for p in HARDENING_PROFILES
+        )
         headline = (
-            f"// 方案 B（root-owned 模板 unit）：{svc} 只能 start/stop\n"
-            f"//   {job_unit_stem(layout, principal)}@<id>.service 的實例。\n"
-            f"// 模板檔 /etc/systemd/system/{job_unit_stem(layout, principal)}@.service 由 root 擁有，\n"
+            f"// 方案 B（root-owned 模板 unit）：{svc} 只能 start/stop 下列**具名模板**的實例：\n"
+            + profile_lines
+            + f"// 兩份模板檔都在 /etc/systemd/system/ 由 root 擁有，\n"
             f"// 內容硬寫死 User={target}、NoNewPrivileges=yes、CapabilityBoundingSet=（空），\n"
             f"// 以及固定的 ExecStart={layout.job_shim} %i（root-owned shim）。\n"
             f"// per-job 參數走 Manager-owned spec spool（{layout.job_spec_spool_root}/<id>.json，\n"
@@ -2942,6 +3231,16 @@ def build_polkit_rule(
             + "\n".join(f"//     - {p}" for p in POLKIT_FORBIDDEN_PROPERTIES)
             + "\n"
             f"// 這些屬性全部只存在於 root-owned 的模板檔裡，呼叫端連提都提不了。\n"
+            f"//\n"
+            f"// ===== 為什麼有兩個字幹（#643 per-executor 加固剖面）=====\n"
+            f"// 加固指令寫在 unit 檔裡，一個模板只有一份 ⇒ 兩種剖面必然是兩個檔、兩個名字。\n"
+            f"// 上面的 pattern 因此是**列舉的交替**（{'、'.join(stems)}），\n"
+            f"// 不是萬用字元：`^` 與 `@` 之間不允許任何未列舉的字幹，instance 段的字元類\n"
+            f"// 一字未改。{svc} 選得了「哪一份模板」，但兩份都是 root-owned、User= 都寫死，\n"
+            f"// 兩份都不含任何可由呼叫端注入的東西——能選的只是「多一項或少一項加固」，\n"
+            f"// 而那一項（MemoryDenyWriteExecute）擋的是**本 job 自己位址空間內**的 W+X，\n"
+            f"// 不是跨 UID 的邊界。真正決定用哪一份的是 executor（Manager 的 dispatch\n"
+            f"// 決定），job 側完全碰不到。\n"
             f"//\n"
             f"// ===== 為什麼 transient unit 在本方案下一律拒 =====\n"
             f"// StartTransientUnit 的 polkit 檢查**不帶 unit 屬性明細**（規則只看得到\n"
@@ -3005,6 +3304,7 @@ def transient_unit_properties(
     layout: "PathLayout" = None,  # type: ignore[assignment]
     principal: Principal = Principal.BUILDER,
     plan: PermissionPlan | None = None,
+    profile: HardeningProfile = DEFAULT_HARDENING_PROFILE,
 ) -> tuple[str, ...]:
     """A 方案的 `--property=` 建議清單（與 B 方案模板 unit 同源，機械產生）。
 
@@ -3018,7 +3318,8 @@ def transient_unit_properties(
     if account is None:
         raise ValueError(f"principal 未映射到帳號: {principal}")
     job_layout = layout.with_job_segment("%i")
-    props = [f"--property={key}={value}" for key, value, _why in _HARDENING]
+    effective = profile.effective()
+    props = [f"--property={key}={effective[key]}" for key, _value, _why in _HARDENING]
     for rwp in read_write_paths(
         plan, job_layout, account, job_layout.job_extra_write_paths(account)
     ):

--- a/tests/test_trust_root_executor_toolchain_640.py
+++ b/tests/test_trust_root_executor_toolchain_640.py
@@ -450,13 +450,20 @@ def test_executor_table_covers_the_four_dispatched_executors() -> None:
 
 
 def test_only_the_node_script_executor_depends_on_the_system_runtime() -> None:
-    """「node 的版本風險只涵蓋 codex 一個」這句話的機器可讀形式。
+    """「哪幾個 CLI 吃系統層 node 的版本風險」這句話的機器可讀形式。
 
-    `claude`／`agy` 自帶原生執行檔、`copilot` 是 shell script——它們不會因為系統層
-    node 換版本而行為改變。這條同時擋住「以後有人順手把某個 CLI 標成 needs_node」。
+    `claude`／`agy` 自帶原生執行檔，不會因為系統層 node 換版本而行為改變。
+    `codex`／`copilot` 會。
+
+    **#643 把 `copilot` 從 False 改為 True**：#640 落表時只知道它是 shell script、
+    還沒查它內部 exec 什麼（表上的 note 當時就寫著「安裝時務必 `head -n 20` 查一次」）。
+    #643 在真實加固面下量到 `copilot --version` 在 `MemoryDenyWriteExecute=yes` 下
+    空輸出、拿掉即正常，與 `codex` 的症狀逐字相同——它內部 exec 的就是 node。
+    這條同時是 #643 加固剖面的分類基準，因此改動它會連帶改動兩份 job unit 的對應
+    關係（見 `test_trust_root_hardening_profile_643.py`）。
     """
     needs_node = {t.name for t in EXECUTOR_TOOLS if t.needs_node}
-    assert needs_node == {"codex"}
+    assert needs_node == {"codex", "copilot"}
     assert TOOLCHAIN_SYSTEM_RUNTIMES == ("node",)
     by_name = {t.name: t for t in EXECUTOR_TOOLS}
     assert by_name["codex"].shape is ExecutorShape.NODE_SCRIPT

--- a/tests/test_trust_root_hardening_profile_643.py
+++ b/tests/test_trust_root_hardening_profile_643.py
@@ -1,0 +1,676 @@
+"""#643：per-executor 加固剖面（operator 裁決＝方向 2）。
+
+`MemoryDenyWriteExecute=yes` 與 JS runtime 天生互斥（V8 的 JIT 必須 W+X），而預設
+executor（`codex`）正是 node 型——四個 executor 在真實加固面下有兩個起不來。裁決是
+「node 型走一份只放寬這一項的 root-owned 模板 unit，原生執行檔型維持嚴格」。
+
+**這整份測試真正要守的只有一條：剖面選不到寬鬆那份。** 若 job 能選到，設計就退化成
+「全域移除 MDWE」，等於白做。因此下面的斷言分四層：
+
+1. **兩份 unit 的加固表除 `MemoryDenyWriteExecute` 外逐項相同**——用集合／字典比對而
+   非逐字硬編，日後往 `_HARDENING` 加一項時兩邊自動同步（漏改一邊會當場紅）。
+2. **未知 executor fail-closed**——三個入口（permgen／job_runner／template 名推導）都不
+   得回傳任何剖面，更不得預設落到寬鬆那份。
+3. **job spec 不得攜帶剖面欄位**——寫端與讀端各掃一次，且掃的是同一支函式。
+4. **polkit 對新 unit 名的正向放行與反向拒絕**——含 5-7 的 transient 五形式與名稱
+   前後綴混淆，對**兩個**字幹同樣成立。
+
+**測不到的部分明確 skip（#638 的教訓）**：MDWE 是否真的擋掉 V8、polkit 是否真的拒絕、
+`CollectMode` 是否真的回收 instance——這三條都需要 root ＋ systemd ＋ polkit ＋ 已落檔
+的 unit，在單 UID／寬鬆的 CI 容器裡跑出來的「綠」不代表任何事。它們由 runbook 第 5-2b
+步在真實加固面下驗，這裡只留 skip 與理由，不留假綠。
+"""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from paulsha_cortex.coordinator import job_runner, job_shim  # noqa: E402
+from paulsha_cortex.coordinator.launcher import SubprocessLauncher  # noqa: E402
+from paulsha_cortex.trust_root import permgen  # noqa: E402
+from paulsha_cortex.trust_root.permgen import Principal  # noqa: E402
+
+from test_trust_root_job_template_ab import (  # noqa: E402
+    _launch_template,
+    _only_spec,
+    _RecordingPopen,
+    _unwrap_exit_recorder,
+)
+
+_REAL_SURFACE = bool(os.environ.get("PSC_TEST_REAL_HARDENING"))
+
+
+def _directives(content: str) -> dict[str, str]:
+    """從 unit 內容抽出 `[Service]` 段的 `Key=Value`（忽略註解與空行）。"""
+
+    table: dict[str, str] = {}
+    section = ""
+    for line in content.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if stripped.startswith("[") and stripped.endswith("]"):
+            section = stripped
+            continue
+        if section != "[Service]" or "=" not in stripped:
+            continue
+        key, value = stripped.split("=", 1)
+        # ReadWritePaths／Environment 是可重複鍵，加固表的鍵不是；只取加固表的鍵。
+        if key in {k for k, _v, _w in permgen._HARDENING}:
+            table[key] = value
+    return table
+
+
+def _section_of(content: str, key: str) -> str:
+    """`key=` 這一行落在哪個 section。"""
+
+    section = ""
+    for line in content.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("[") and stripped.endswith("]"):
+            section = stripped
+        elif stripped.startswith(f"{key}="):
+            return section
+    return ""
+
+
+# ---------------------------------------------------------------------------
+# 1. 兩份 unit 共用同一張加固表，只在一項分岔
+# ---------------------------------------------------------------------------
+
+class SharedHardeningTableTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.scheme = permgen.DEFAULT_SCHEME
+        self.strict = permgen.build_job_unit(self.scheme, profile=permgen.STRICT_PROFILE)
+        self.jit = permgen.build_job_unit(self.scheme, profile=permgen.JIT_PROFILE)
+
+    def test_both_units_carry_every_directive_in_the_shared_table(self) -> None:
+        """鍵集合恆等於 `_HARDENING`——沒有任何一項在某個剖面下「消失」。"""
+        expected = {key for key, _value, _why in permgen._HARDENING}
+        self.assertEqual(set(_directives(self.strict.content)), expected)
+        self.assertEqual(set(_directives(self.jit.content)), expected)
+
+    def test_the_two_profiles_differ_in_exactly_the_declared_keys(self) -> None:
+        """除 `PROFILE_DIVERGENCE_KEYS` 外**逐項相同**。
+
+        用字典差集而不是逐字硬編：日後 `_HARDENING` 加一項時，只要有一邊漏了就會
+        出現在 `diff` 裡而當場紅——這正是「不要複製貼上兩份完整加固段」要買的東西。
+        """
+        strict = _directives(self.strict.content)
+        jit = _directives(self.jit.content)
+        diff = {key for key in strict if strict[key] != jit[key]}
+        self.assertEqual(diff, set(permgen.PROFILE_DIVERGENCE_KEYS))
+        self.assertEqual(diff, {"MemoryDenyWriteExecute"})
+        self.assertEqual(strict["MemoryDenyWriteExecute"], "yes")
+        self.assertEqual(jit["MemoryDenyWriteExecute"], "no")
+
+    def test_divergence_is_structurally_bounded(self) -> None:
+        """剖面只能覆寫 `_HARDENING` 既有的鍵，且只能覆寫白名單內的鍵。"""
+        known = {key for key, _value, _why in permgen._HARDENING}
+        self.assertTrue(permgen.PROFILE_DIVERGENCE_KEYS <= known)
+        for profile in permgen.HARDENING_PROFILES:
+            self.assertTrue(set(profile.overrides) <= known, profile.profile_id)
+            self.assertTrue(
+                set(profile.overrides) <= permgen.PROFILE_DIVERGENCE_KEYS,
+                profile.profile_id,
+            )
+
+    def test_a_typo_in_an_override_key_is_rejected_at_import_time(self) -> None:
+        """覆寫一個不存在的鍵＝一個看起來有效、實際毫無作用的設定，必須是錯誤。"""
+        bogus = permgen.HardeningProfile(
+            profile_id="bogus",
+            unit_suffix="-bogus",
+            overrides={"MemoryDenyWriteExecut": "no"},  # 少一個 e
+            rationale="typo",
+        )
+        original = permgen.HARDENING_PROFILES
+        permgen.HARDENING_PROFILES = original + (bogus,)
+        try:
+            with self.assertRaises(ValueError):
+                permgen._validate_hardening_profiles()
+        finally:
+            permgen.HARDENING_PROFILES = original
+        permgen._validate_hardening_profiles()  # 還原後仍成立
+
+    def test_strict_profile_is_the_default_everywhere(self) -> None:
+        """預設就是最嚴格的那一份；要放寬必須顯式打出來。"""
+        self.assertIs(permgen.DEFAULT_HARDENING_PROFILE, permgen.STRICT_PROFILE)
+        self.assertEqual(permgen.STRICT_PROFILE.overrides, {})
+        self.assertEqual(
+            permgen.build_job_unit(self.scheme).content, self.strict.content
+        )
+
+    def test_strict_unit_name_is_unchanged(self) -> None:
+        """既有部署的 `cortex-job@.service` 逐字不變（strict 後綴為空字串）。"""
+        self.assertEqual(self.strict.unit_name, "cortex-job@.service")
+        self.assertEqual(self.strict.install_path, "/etc/systemd/system/cortex-job@.service")
+        self.assertEqual(self.jit.unit_name, "cortex-job-jit@.service")
+        self.assertEqual(
+            self.jit.install_path, "/etc/systemd/system/cortex-job-jit@.service"
+        )
+
+    def test_everything_but_hardening_is_identical(self) -> None:
+        """身分、ExecStart、RWP、spec spool——兩份 unit 除加固外沒有第二處差異。"""
+        self.assertEqual(self.strict.account, self.jit.account)
+        self.assertEqual(self.strict.exec_start, self.jit.exec_start)
+        self.assertEqual(self.strict.read_write_paths, self.jit.read_write_paths)
+        for unit in (self.strict, self.jit):
+            self.assertIn(f"User={self.scheme.resolve(Principal.BUILDER)}\n", unit.content)
+            self.assertNotIn("User=root", unit.content)
+
+    def test_the_accepted_loss_is_written_into_the_artifact(self) -> None:
+        """誠實標註寫在**產物本身**，讀 unit 的人不必去翻 spec 才知道少了什麼。"""
+        self.assertTrue(permgen.JIT_PROFILE.accepted_loss)
+        self.assertEqual(permgen.STRICT_PROFILE.accepted_loss, ())
+        self.assertIn("失去 MemoryDenyWriteExecute", self.jit.content)
+        self.assertIn("JIT 型 shellcode", self.jit.content)
+        self.assertIn("※ 剖面覆寫（profile=jit）", self.jit.content)
+        self.assertNotIn("※ 剖面覆寫", self.strict.content)
+
+    def test_transient_property_list_follows_the_same_profile(self) -> None:
+        """A 案的 `--property=` 對照表同樣由剖面導出，不是第二份手抄。"""
+        for profile in permgen.HARDENING_PROFILES:
+            props = permgen.transient_unit_properties(self.scheme, profile=profile)
+            effective = profile.effective()
+            for key, _value, _why in permgen._HARDENING:
+                self.assertIn(f"--property={key}={effective[key]}", props, key)
+
+    def test_manager_and_monitor_units_stay_strict(self) -> None:
+        """剖面只對 job 模板有意義；Manager／monitor 不受影響。"""
+        for build in (permgen.build_manager_unit, permgen.build_monitor_unit):
+            unit = build(self.scheme)
+            self.assertEqual(unit.hardening_profile, "strict")
+            self.assertEqual(_directives(unit.content)["MemoryDenyWriteExecute"], "yes")
+
+
+# ---------------------------------------------------------------------------
+# 2. 剖面由 executor 決定；未知 executor fail-closed
+# ---------------------------------------------------------------------------
+
+class ProfileSelectionTests(unittest.TestCase):
+    def test_mapping_is_derived_from_the_existing_executor_table(self) -> None:
+        """#642 的 `EXECUTOR_TOOLS` 是分類來源，不另立第二張清單。"""
+        derived = {
+            tool.name: permgen.executor_hardening_profile(tool.name).profile_id
+            for tool in permgen.EXECUTOR_TOOLS
+        }
+        self.assertEqual(derived, dict(permgen.EXECUTOR_HARDENING_PROFILE))
+        self.assertEqual(
+            derived,
+            {"codex": "jit", "copilot": "jit", "claude": "strict", "agy": "strict"},
+        )
+        # 反向：needs_node 為真 ⟺ jit
+        for tool in permgen.EXECUTOR_TOOLS:
+            expected = "jit" if tool.needs_node else "strict"
+            self.assertEqual(derived[tool.name], expected, tool.name)
+
+    def test_job_runner_table_is_pinned_to_permgen(self) -> None:
+        """`job_runner` 刻意不 import permgen（派工熱路徑不拖 trust_root），兩份表
+        由本契約測試釘住逐字相等——與 `DEFAULT_TEMPLATE_UNIT` 同一個既有模式。"""
+        self.assertEqual(
+            dict(job_runner.EXECUTOR_HARDENING_PROFILE),
+            dict(permgen.EXECUTOR_HARDENING_PROFILE),
+        )
+        self.assertEqual(
+            dict(job_runner.TEMPLATE_UNIT_SUFFIX_BY_PROFILE),
+            {p.profile_id: p.unit_suffix for p in permgen.HARDENING_PROFILES},
+        )
+        self.assertEqual(
+            set(job_runner.EXECUTOR_HARDENING_PROFILE),
+            {tool.name for tool in permgen.EXECUTOR_TOOLS},
+        )
+
+    def test_template_unit_names_match_the_generated_units(self) -> None:
+        """啟動器算出來的 unit 名 == permgen 產出的模板檔名。"""
+        for profile in permgen.HARDENING_PROFILES:
+            unit = permgen.build_job_unit(permgen.DEFAULT_SCHEME, profile=profile)
+            self.assertEqual(
+                job_runner.template_unit_for_profile(
+                    job_runner.DEFAULT_TEMPLATE_UNIT, profile.profile_id
+                ),
+                unit.unit_name,
+                profile.profile_id,
+            )
+
+    def test_unknown_executor_is_fail_closed_in_permgen(self) -> None:
+        for name in ("mystery", "", "  ", "cg", "CODEX", "node"):
+            with self.assertRaises(permgen.UnknownExecutorProfileError, msg=name):
+                permgen.executor_hardening_profile(name)
+
+    def test_unknown_executor_is_fail_closed_in_job_runner(self) -> None:
+        """**不得預設落到寬鬆那份**——也不得默默給嚴格那份。一律拒。"""
+        for name in ("mystery", "", "cg", "node", "CODEX"):
+            with self.assertRaises(job_runner.JobRunnerError, msg=name) as ctx:
+                job_runner.resolve_hardening_profile(name)
+            self.assertEqual(
+                ctx.exception.diagnostic.reason, "job-runner-hardening-profile-unknown"
+            )
+
+    def test_unknown_profile_id_is_fail_closed(self) -> None:
+        with self.assertRaises(job_runner.JobRunnerError):
+            job_runner.template_unit_for_profile(job_runner.DEFAULT_TEMPLATE_UNIT, "lax")
+
+    def test_config_cannot_preselect_a_profile(self) -> None:
+        """`PSC_JOB_TEMPLATE_UNIT` 只能給**基底**名；帶剖面後綴一律拒。
+
+        少了這條，operator 可以把 config 直接指到 `cortex-job-jit@.service`，讓
+        **所有** job（含 claude／agy）都走寬鬆剖面——那正是「退化成全域移除 MDWE」。
+        """
+        with self.assertRaises(job_runner.JobRunnerError) as ctx:
+            job_runner.template_unit_for_profile(
+                "cortex-job-jit@.service", job_runner.HARDENING_PROFILE_STRICT
+            )
+        self.assertEqual(
+            ctx.exception.diagnostic.reason, "job-runner-template-unit-invalid"
+        )
+
+    def test_prepare_requires_an_explicit_executor(self) -> None:
+        """沒有預設值：任何呼叫端都必須說出是哪個 executor。"""
+        with self.assertRaises(TypeError):
+            job_runner.prepare_systemd_template({}, job_id="x")  # type: ignore[call-arg]
+
+    def test_plan_records_the_decision_for_audit(self) -> None:
+        from unittest import mock
+
+        from test_trust_root_job_template_ab import _preflight_patches, _nested, _template_env
+
+        with tempfile.TemporaryDirectory() as d:
+            spool = str(Path(d) / "job-specs")
+            Path(spool).mkdir(parents=True)
+            env = _template_env(spool)
+            with mock.patch.dict(os.environ, env, clear=True):
+                with _nested(_preflight_patches()):
+                    for executor, expected, stem in (
+                        ("codex", "jit", "cortex-job-jit@"),
+                        ("copilot", "jit", "cortex-job-jit@"),
+                        ("claude", "strict", "cortex-job@"),
+                        ("agy", "strict", "cortex-job@"),
+                    ):
+                        plan = job_runner.prepare_systemd_template(
+                            os.environ, job_id="psc-0643", executor=executor
+                        )
+                        self.assertEqual(plan.hardening_profile, expected, executor)
+                        self.assertEqual(plan.executor, executor)
+                        self.assertEqual(
+                            plan.base_template_unit, job_runner.DEFAULT_TEMPLATE_UNIT
+                        )
+                        self.assertTrue(plan.unit.startswith(stem), plan.unit)
+
+
+# ---------------------------------------------------------------------------
+# 3. job 選不到剖面：spec 結構性禁止攜帶剖面欄位（寫端＋讀端）
+# ---------------------------------------------------------------------------
+
+class SpecCannotCarryTheProfileTests(unittest.TestCase):
+    #: 任何一個都足以把「剖面由 executor 決定」變成「剖面由 spec 決定」。
+    PROFILE_KEYS = (
+        "hardening",
+        "hardening_profile",
+        "profile",
+        "template",
+        "template_unit",
+        "unit_suffix",
+        "MemoryDenyWriteExecute",
+    )
+
+    def test_the_forbidden_set_covers_the_profile_family(self) -> None:
+        for key in self.PROFILE_KEYS:
+            self.assertIn(key, job_runner.SPEC_FORBIDDEN_KEYS, key)
+        # 既有的身分族一項未減。
+        for key in ("user", "uid", "group", "gid", "properties", "exec_start"):
+            self.assertIn(key, job_runner.SPEC_FORBIDDEN_KEYS, key)
+
+    def test_write_and_read_side_run_the_same_scan(self) -> None:
+        """兩端掃的是**同一支函式**與**同一份判準**，不是兩份各自的抄本。"""
+        self.assertIs(job_shim.SPEC_FORBIDDEN_KEYS, job_runner.SPEC_FORBIDDEN_KEYS)
+        self.assertIs(job_shim.forbidden_spec_keys, job_runner.forbidden_spec_keys)
+        for key in self.PROFILE_KEYS:
+            self.assertEqual(job_runner.forbidden_spec_keys({key: "x"}), [key], key)
+        self.assertEqual(job_runner.forbidden_spec_keys({"command": ["x"]}), [])
+
+    def test_write_side_refuses_a_spec_carrying_a_profile_key(self) -> None:
+        """寫端：`build_job_spec` 的守衛掃過整份 spec。"""
+        base = dict(
+            job_id="psc-0643",
+            instance="demo-deadbeef",
+            unit="cortex-job@demo-deadbeef.service",
+            command=["bash", "-c", "true"],
+            working_directory="/tmp",
+            log_path="/tmp/x.jsonl",
+            env={"PATH": "/usr/bin"},
+        )
+        spec = job_runner.build_job_spec(**base)
+        self.assertEqual(job_runner.forbidden_spec_keys(spec), [])
+        # 守衛本身：一旦有人往 spec 塞剖面欄位，寫端立刻 fail-closed。
+        for key in self.PROFILE_KEYS:
+            leaked = dict(spec)
+            leaked[key] = "jit"
+            self.assertEqual(job_runner.forbidden_spec_keys(leaked), [key], key)
+
+    def test_read_side_refuses_a_spec_carrying_a_profile_key(self) -> None:
+        """讀端：即使 spool 被竄改（或未來有人「順手支援一下」），shim 也拒絕執行。"""
+        for key in self.PROFILE_KEYS:
+            with tempfile.TemporaryDirectory() as d:
+                spool = Path(d) / "job-specs"
+                spool.mkdir()
+                spec = {
+                    "spec_version": job_runner.JOB_SPEC_VERSION,
+                    "instance": "demo-deadbeef",
+                    "job_id": "psc-0643",
+                    "unit": "cortex-job-jit@demo-deadbeef.service",
+                    "command": ["/bin/true"],
+                    "working_directory": d,
+                    "log_path": str(Path(d) / "job.jsonl"),
+                    "env": {"PATH": "/usr/bin"},
+                    key: "jit",
+                }
+                (spool / "demo-deadbeef.json").write_text(
+                    json.dumps(spec), encoding="utf-8"
+                )
+                with self.assertRaises(job_shim.ShimError, msg=key) as ctx:
+                    job_shim.load_spec("demo-deadbeef", str(spool))
+                self.assertIn(key, str(ctx.exception))
+
+    def test_launched_spec_is_clean(self) -> None:
+        """實跑一次 template 派工：落地的 spec 一個剖面欄位都沒有。"""
+        with tempfile.TemporaryDirectory() as d:
+            _launch_template(
+                SubprocessLauncher("codex"), popen=_RecordingPopen(), workdir=d
+            )
+            spec = _only_spec(str(Path(d) / "job-specs"))
+        self.assertEqual(job_runner.forbidden_spec_keys(spec), [])
+        # 鍵集合是封閉的：spec 只有 `SPEC_REQUIRED_KEYS` 那幾個，多一個都沒有。
+        self.assertEqual(set(spec), set(job_runner.SPEC_REQUIRED_KEYS))
+        for key in job_runner.SPEC_FORBIDDEN_KEYS:
+            self.assertNotIn(key, spec, key)
+
+
+# ---------------------------------------------------------------------------
+# 4. 派工端：剖面跟著 executor 走，且在 spec 之前就定案
+# ---------------------------------------------------------------------------
+
+class DispatchSelectsTheProfileTests(unittest.TestCase):
+    def _unit_for(self, executor: str) -> str:
+        popen = _RecordingPopen()
+        with tempfile.TemporaryDirectory() as d:
+            _launch_template(SubprocessLauncher(executor), popen=popen, workdir=d)
+        return _unwrap_exit_recorder(popen.call["argv"])[4]
+
+    def test_node_executors_get_the_jit_template(self) -> None:
+        for executor in ("codex", "copilot"):
+            self.assertTrue(
+                self._unit_for(executor).startswith("cortex-job-jit@"), executor
+            )
+
+    def test_native_executors_stay_strict(self) -> None:
+        for executor in ("claude", "agy"):
+            unit = self._unit_for(executor)
+            self.assertTrue(unit.startswith("cortex-job@"), unit)
+            self.assertFalse(unit.startswith("cortex-job-jit@"), unit)
+
+    def test_the_start_argv_still_carries_nothing_but_the_unit_name(self) -> None:
+        """剖面是「換一個 root-owned unit 名」，**不是**多送一個屬性。"""
+        for executor in ("codex", "claude"):
+            popen = _RecordingPopen()
+            with tempfile.TemporaryDirectory() as d:
+                _launch_template(SubprocessLauncher(executor), popen=popen, workdir=d)
+            argv = _unwrap_exit_recorder(popen.call["argv"])
+            self.assertEqual(
+                argv[:4],
+                ["/usr/bin/systemctl", "start", "--wait", "--no-ask-password"],
+            )
+            self.assertEqual(len(argv), 5, argv)
+            joined = " ".join(argv)
+            for forbidden in ("--uid", "--gid", "--property", "--setenv", "-p "):
+                self.assertNotIn(forbidden, joined, forbidden)
+
+    def test_prompt_and_worktree_cannot_move_the_profile(self) -> None:
+        """job 側可控的兩個輸入（prompt 與 worktree 內容）換掉，剖面不動。
+
+        這是「job 選不到寬鬆剖面」在派工端的直接反證：`prepare_systemd_template()`
+        在 `launch()` 的**第一行**求值（任何 mkdir／spec 寫入／Popen 之前），它唯一的
+        剖面輸入是建構期就固定的 `self._executor`。
+        """
+        popen = _RecordingPopen()
+        with tempfile.TemporaryDirectory() as d:
+            evil = Path(d) / "hardening_profile"
+            evil.write_text("jit\n", encoding="utf-8")
+            _launch_template(
+                SubprocessLauncher("claude"),
+                popen=popen,
+                workdir=d,
+                slice_id="hardening-profile-jit",
+            )
+        unit = _unwrap_exit_recorder(popen.call["argv"])[4]
+        self.assertTrue(unit.startswith("cortex-job@"), unit)
+        self.assertFalse(unit.startswith("cortex-job-jit@"), unit)
+
+
+# ---------------------------------------------------------------------------
+# 5. polkit：兩個字幹都放行，混淆一律拒
+# ---------------------------------------------------------------------------
+
+class PolkitCoversBothProfilesTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.rule = permgen.build_polkit_rule(
+            permgen.DEFAULT_SCHEME, plan=permgen.PolkitPlan.TEMPLATE
+        )
+
+    def _decide(self, unit: str | None, verb: str | None = "start") -> str:
+        return permgen.evaluate_polkit(
+            self.rule,
+            user=self.rule.subject_account,
+            action_id=permgen.POLKIT_ACTION,
+            unit=unit,
+            verb=verb,
+        )
+
+    def test_one_rule_one_grant(self) -> None:
+        """新增剖面沒有增加放行出口：全檔仍只有一個 `return polkit.Result.YES`。"""
+        self.assertEqual(self.rule.content.count("polkit.Result.YES"), 1)
+        self.assertEqual(self.rule.content.count("polkit.addRule("), 1)
+
+    def test_both_stems_are_authorised(self) -> None:
+        for profile in permgen.HARDENING_PROFILES:
+            stem = permgen.job_unit_stem(
+                permgen.DEFAULT_LAYOUT, Principal.BUILDER, profile
+            )
+            self.assertEqual(self._decide(f"{stem}@psc-0643-deadbeef.service"), "YES", stem)
+
+    def test_pattern_enumerates_the_stems_instead_of_widening(self) -> None:
+        """pattern 仍然錨定、instance 段字元類一字未改、沒有任何萬用字元。"""
+        pattern = self.rule.unit_pattern
+        self.assertTrue(pattern.startswith("^"))
+        self.assertTrue(pattern.endswith(r"@[a-z0-9][a-z0-9._-]{0,62}\.service$"))
+        stems = permgen.job_unit_stems(permgen.DEFAULT_LAYOUT, Principal.BUILDER)
+        self.assertEqual(stems, ("cortex-job", "cortex-job-jit"))
+        head = pattern[1 : -len(r"@[a-z0-9][a-z0-9._-]{0,62}\.service$")]
+        self.assertEqual(head, "(?:" + "|".join(stems) + ")")
+        for wildcard in (".*", "[^", "\\w", "+"):
+            self.assertNotIn(wildcard, head, wildcard)
+
+    def test_transient_shapes_are_still_refused(self) -> None:
+        """5-7 的反向測試對新字幹同樣成立（transient 五形式）。"""
+        for unit in (
+            # A 案自己命名的 transient
+            "cortex-job-psc-0042-deadbeef.service",
+            "cortex-job-jit-psc-0042-deadbeef.service",
+            # systemd 對匿名 transient 自動生成的兩種
+            "run-u1234.service",
+            "run-r9c0ffee.service",
+            # 非實例形式
+            "cortex-job.service",
+        ):
+            self.assertEqual(self._decide(unit), "NO", unit)
+        # StartTransientUnit 的檢查不帶明細 → 缺席即拒。
+        self.assertEqual(self._decide(None, None), "NO")
+
+    def test_name_confusion_around_the_new_stem_is_refused(self) -> None:
+        """名稱前後綴混淆——新增一個字幹最容易被鑽的就是這裡。"""
+        for unit in (
+            "cortex-job-jitx@a.service",       # 後綴多一字
+            "cortex-job-ji@a.service",         # 後綴少一字
+            "xcortex-job-jit@a.service",       # 前綴多一字
+            "cortex-job-jit@.service",         # instance 為空
+            "cortex-job-jit@-a.service",       # instance 首字非英數
+            "cortex-job-jit@A.service",        # instance 首字大寫（字元類只收小寫）
+            "cortex-job-jit@a.socket",         # 非 .service
+            "cortex-job-jit@a.service.evil",   # 尾綴混淆
+            "evil-cortex-job-jit@a.service",
+            "cortex-job-jit-evil@a.service",
+            "cortex-jit-job@a.service",
+            "cortex-job@a.service\ncortex-job-jit@b.service",  # 換行注入
+            "cortex-job-jit@" + "a" * 64 + ".service",         # instance 超長
+        ):
+            self.assertEqual(self._decide(unit), "NO", unit)
+
+    def test_other_verbs_and_subjects_are_unchanged(self) -> None:
+        for verb in ("reload", "mask", "set-property", "restart", "kill"):
+            self.assertEqual(self._decide("cortex-job-jit@a.service", verb), "NO", verb)
+        self.assertEqual(
+            permgen.evaluate_polkit(
+                self.rule,
+                user="nobody",
+                action_id=permgen.POLKIT_ACTION,
+                unit="cortex-job-jit@a.service",
+                verb="start",
+            ),
+            "NOT_HANDLED",
+        )
+
+    def test_reviewer_extension_point_still_isolated(self) -> None:
+        """M2 的第二 principal 與剖面正交：builder 的規則不放行 reviewer 的任一剖面。"""
+        for profile in permgen.HARDENING_PROFILES:
+            stem = permgen.job_unit_stem(
+                permgen.DEFAULT_LAYOUT, Principal.REVIEWER, profile
+            )
+            self.assertEqual(self._decide(f"{stem}@a.service"), "NO", stem)
+
+    def test_rule_documents_both_templates(self) -> None:
+        for profile in permgen.HARDENING_PROFILES:
+            stem = permgen.job_unit_stem(
+                permgen.DEFAULT_LAYOUT, Principal.BUILDER, profile
+            )
+            self.assertIn(f"{stem}@<id>.service", self.rule.content, stem)
+        self.assertIn("MemoryDenyWriteExecute=no", self.rule.content)
+        self.assertEqual(self.rule.residual_risks, ())
+
+
+# ---------------------------------------------------------------------------
+# 6. 順帶：CollectMode 放錯 section
+# ---------------------------------------------------------------------------
+
+class CollectModeSectionTests(unittest.TestCase):
+    """`CollectMode` 屬 `[Unit]` 不屬 `[Service]`（產生器側已由 #645 修正）。
+
+    放錯段時 systemd 只記一行 `Unknown key name 'CollectMode' in section 'Service',
+    ignoring.` 然後忽略——unit 照樣起得來，但「失敗的 instance 自動回收」整個不生效，
+    失敗的 instance 會一直留在 `systemctl list-units --failed` 上，而下一次同名派工
+    會撞上 `prepare_systemd_template()` 的 busy 檢查。
+
+    #643 把這條守衛**擴到兩份剖面**：`cortex-job-jit@.service` 是本 PR 新增的第二份
+    unit，若它是複製貼上來的就可能複製到舊的放法。順帶驗「沒有任何未知鍵」。
+    """
+
+    def test_collect_mode_lives_in_the_unit_section(self) -> None:
+        for profile in permgen.HARDENING_PROFILES:
+            unit = permgen.build_job_unit(permgen.DEFAULT_SCHEME, profile=profile)
+            # 以「真正的指令行」判段，不是字串 split——產生出來的**註解**裡就含有
+            # `[Unit]`／`[Service]` 字樣（在解釋這個坑），naive split 會切錯地方。
+            directives = [
+                line.strip()
+                for line in unit.content.splitlines()
+                if line.strip().startswith("CollectMode=")
+            ]
+            self.assertEqual(len(directives), 1, profile.profile_id)
+            self.assertEqual(
+                _section_of(unit.content, "CollectMode"), "[Unit]", profile.profile_id
+            )
+
+    def test_systemd_analyze_accepts_the_generated_units(self) -> None:
+        """`systemd-analyze verify` 是唯一能證明「沒有 Unknown key name」的東西。
+
+        它不需要 root、也不需要真的起 unit，但需要機器上有 systemd；沒有就 skip
+        （#638 的教訓：在測不到的環境下讓它「綠」比紅更糟）。
+        """
+        analyze = shutil.which("systemd-analyze")
+        if analyze is None:
+            self.skipTest("本機無 systemd-analyze——`Unknown key name` 只有 systemd 判得出來")
+        for profile in permgen.HARDENING_PROFILES:
+            unit = permgen.build_job_unit(permgen.DEFAULT_SCHEME, profile=profile)
+            with tempfile.TemporaryDirectory() as d:
+                path = Path(d) / unit.unit_name
+                path.write_text(unit.content, encoding="utf-8")
+                proc = subprocess.run(
+                    [analyze, "verify", str(path)],
+                    capture_output=True, text=True, timeout=60,
+                )
+            self.assertNotIn("Unknown key name", proc.stderr, unit.unit_name)
+
+
+# ---------------------------------------------------------------------------
+# 7. 明確測不到的語意（#638 的教訓：不留假綠）
+# ---------------------------------------------------------------------------
+
+class RealHardeningSurfaceTests(unittest.TestCase):
+    """下面三條的語意**在單 UID／寬鬆環境下測不出來**，一律 skip 並說明理由。
+
+    #643 本身就是這條教訓的實例：四個 executor 在寬鬆環境下 `--version` 全部 rc=0、
+    版本全部相符，唯一能看見問題的是 `systemd-run` 帶上真實加固面那一條。因此這裡
+    **不**用 `sudo -u`／裸跑當替身——那只會產生一個永遠綠、卻什麼都沒驗到的測試。
+
+    要跑真的：runbook 第 5-2b 步（root ＋ systemd ＋ 已落檔的兩份 unit），或在具備
+    root 的機器上設 `PSC_TEST_REAL_HARDENING=1`。
+    """
+
+    def setUp(self) -> None:
+        if not _REAL_SURFACE:
+            self.skipTest(
+                "需要 root ＋ systemd ＋ 已落檔的兩份 job unit ＋ 已裝的 toolchain；"
+                "CI 容器是單 UID／無 systemd，跑出來的綠不代表任何事。"
+                "真實驗證見 runbook 第 5-2b 步（PSC_TEST_REAL_HARDENING=1 可在具備"
+                "條件的機器上啟用）。"
+            )
+
+    def test_mdwe_blocks_node_and_the_jit_profile_does_not(self) -> None:
+        """負向對照是重點：strict 剖面下 node **必須失敗**，jit 下必須成功。
+
+        只驗 jit 成功會整個溜過去——那正是 #642 差點漏掉這條的原因。
+        """
+        node = shutil.which("node")
+        if node is None:
+            self.skipTest("本機無 node")
+        base = [
+            "systemd-run", "--pipe", "--wait", "--collect", "--quiet",
+            "--property=NoNewPrivileges=yes",
+        ]
+        script = "console.log('node OK ' + process.version)"
+        strict = subprocess.run(
+            base + ["--property=MemoryDenyWriteExecute=yes", node, "-e", script],
+            capture_output=True, text=True, timeout=120,
+        )
+        lax = subprocess.run(
+            base + ["--property=MemoryDenyWriteExecute=no", node, "-e", script],
+            capture_output=True, text=True, timeout=120,
+        )
+        self.assertNotIn("node OK", strict.stdout, "strict 剖面下 V8 不該起得來")
+        self.assertIn("node OK", lax.stdout, "jit 剖面下 node 必須正常")
+
+    def test_polkit_refuses_the_jit_template_from_a_foreign_account(self) -> None:
+        self.skipTest(
+            "polkit 決策無法在本機純函式化驗證（規則跑在 polkitd 內，且 subject 必須"
+            "是真的 cortex-manager）。`evaluate_polkit` 是產生邏輯的鏡像，不是 polkitd。"
+            "真實反向測試見 runbook 第 5-7 步。"
+        )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/tests/test_trust_root_job_template_ab.py
+++ b/tests/test_trust_root_job_template_ab.py
@@ -283,7 +283,10 @@ class PolkitPlanBTests(unittest.TestCase):
 
     def test_unit_pattern_is_the_template_instance_shape(self) -> None:
         rule = self._rule()
-        self.assertTrue(rule.unit_pattern.startswith("^cortex-job@"))
+        # #643：pattern 改成「每個加固剖面一個字幹」的列舉交替，因此不再是單一
+        # 字面前綴；語意（放行 strict 模板的實例）逐字不變。
+        self.assertTrue(rule.unit_pattern.startswith("^"))
+        self.assertTrue(rule.unit_pattern.endswith(r"@[a-z0-9][a-z0-9._-]{0,62}\.service$"))
         self.assertEqual(
             permgen.evaluate_polkit(
                 rule,
@@ -430,7 +433,16 @@ class M2ExtensionPointTests(unittest.TestCase):
         rule = permgen.build_polkit_rule(
             scheme, plan=permgen.PolkitPlan.TEMPLATE, principal=Principal.REVIEWER
         )
-        self.assertTrue(rule.unit_pattern.startswith("^cortex-reviewer-job@"))
+        self.assertEqual(
+            permgen.evaluate_polkit(
+                rule,
+                user=rule.subject_account,
+                action_id=permgen.POLKIT_ACTION,
+                unit="cortex-reviewer-job@x.service",
+                verb="start",
+            ),
+            "YES",
+        )
         self.assertEqual(rule.target_account, "cortex-reviewer-planner")
         # builder 的規則不放行 reviewer 的模板實例，反之亦然。
         builder_rule = permgen.build_polkit_rule(scheme, plan=permgen.PolkitPlan.TEMPLATE)
@@ -660,7 +672,8 @@ class JobSpecContentTests(unittest.TestCase):
         # 它包住的才是那條封閉的 systemctl client argv。
         argv = _unwrap_exit_recorder(popen.call["argv"])
         self.assertEqual(argv[:4], ["/usr/bin/systemctl", "start", "--wait", "--no-ask-password"])
-        self.assertTrue(argv[4].startswith("cortex-job@"))
+        # #643：`codex` 是 node 型 ⇒ jit 剖面的模板（`cortex-job-jit@`）。
+        self.assertTrue(argv[4].startswith("cortex-job-jit@"), argv[4])
         self.assertTrue(argv[4].endswith(".service"))
         self.assertEqual(popen.call["cwd"], None)
         self.assertEqual(popen.call["stdin"], subprocess.DEVNULL)
@@ -699,7 +712,15 @@ class JobSpecContentTests(unittest.TestCase):
         self.assertEqual(spec["log_path"], ctx["log_path"])
         self.assertEqual(spec["env"]["PATH"], _BASE_ENV["PATH"])
         self.assertEqual(spec["env"]["PSC_JOB_ID"], "psc-0042-template")
-        self.assertEqual(spec["unit"], job_runner.template_unit_name(spec["instance"]))
+        self.assertEqual(
+            spec["unit"],
+            job_runner.template_unit_name(
+                spec["instance"],
+                template=job_runner.template_unit_for_profile(
+                    job_runner.DEFAULT_TEMPLATE_UNIT, job_runner.HARDENING_PROFILE_JIT
+                ),
+            ),
+        )
 
     def test_spec_uses_bash_c_not_login_shell(self) -> None:
         """#588 第 2 點：降權模式一律 `bash -c`（login shell 會重新匯入 ~/.profile）。"""

--- a/tests/test_trust_root_permgen_p2b.py
+++ b/tests/test_trust_root_permgen_p2b.py
@@ -345,7 +345,10 @@ def test_polkit_rule_binds_svc_to_job_units_only(scheme, plan) -> None:
     assert rule.target_account == scheme.resolve(Principal.BUILDER)
     assert rule.install_path == "/etc/polkit-1/rules.d/49-cortex-downgrade.rules"
     assert rule.allowed_verbs == ("start", "stop")
-    assert rule.unit_pattern.startswith("^cortex-job")
+    # 錨定兩端；字幹段在 TEMPLATE 下是「每個加固剖面一個」的列舉交替（#643），
+    # 因此只驗「以 cortex-job 這個字幹家族開頭」而不是單一字面前綴。
+    assert rule.unit_pattern.startswith("^")
+    assert "cortex-job" in rule.unit_pattern
     assert rule.unit_pattern.endswith("$")
 
 
@@ -358,15 +361,23 @@ def test_transient_plan_unit_prefix_is_the_job_runner_contract() -> None:
 
 
 def test_template_plan_matches_the_generated_template_unit() -> None:
-    """B 方案的 pattern 必須恰好認得 build_job_unit() 產出的模板實例。"""
+    """B 方案的 pattern 必須恰好認得 build_job_unit() 產出的**每一個**剖面的模板實例。
+
+    #643 之後每個加固剖面各有一份 root-owned 模板檔，因此各有一個字幹；pattern 是
+    這些字幹的列舉交替（不是萬用字元）。這裡改以「產生器產出的 unit 名 → pattern
+    必須放行」來驗，而不是比對 pattern 的字面前綴——後者在加第二個剖面時只會逼人
+    改斷言，驗不到任何語意。
+    """
     rule = build_polkit_rule(TWO_WAY_SCHEME, DEFAULT_LAYOUT, plan=PolkitPlan.TEMPLATE)
-    unit = build_job_unit(TWO_WAY_SCHEME, DEFAULT_LAYOUT)
-    assert unit.unit_name == "cortex-job@.service"
-    assert rule.unit_pattern.startswith("^cortex-job@")
-    assert evaluate_polkit(
-        rule, user=rule.subject_account, action_id=permgen.POLKIT_ACTION,
-        unit="cortex-job@abc.service", verb="start",
-    ) == "YES"
+    for profile in permgen.HARDENING_PROFILES:
+        unit = build_job_unit(TWO_WAY_SCHEME, DEFAULT_LAYOUT, profile=profile)
+        stem = unit.unit_name[: -len("@.service")]
+        assert unit.unit_name.endswith("@.service")
+        assert evaluate_polkit(
+            rule, user=rule.subject_account, action_id=permgen.POLKIT_ACTION,
+            unit=f"{stem}@abc.service", verb="start",
+        ) == "YES", unit.unit_name
+    assert build_job_unit(TWO_WAY_SCHEME, DEFAULT_LAYOUT).unit_name == "cortex-job@.service"
 
 
 @pytest.mark.parametrize("plan", ALL_PLANS, ids=lambda p: p.value)
@@ -551,5 +562,8 @@ def test_custom_layout_needs_no_code_change() -> None:
     assert all(p.startswith(("/srv/cortex", "/var/lib/cortex-svc")) for p in unit.read_write_paths)
     assert build_polkit_rule(TWO_WAY_SCHEME, alt, plan=PolkitPlan.TRANSIENT) \
         .unit_pattern.startswith("^alpha-job-")
-    assert build_polkit_rule(TWO_WAY_SCHEME, alt, plan=PolkitPlan.TEMPLATE) \
-        .unit_pattern.startswith("^alpha-job@")
+    assert evaluate_polkit(
+        build_polkit_rule(TWO_WAY_SCHEME, alt, plan=PolkitPlan.TEMPLATE),
+        user="cortex-svc", action_id=permgen.POLKIT_ACTION,
+        unit="alpha-job@abc.service", verb="start",
+    ) == "YES"

--- a/tests/test_worktree_dir_naming_645.py
+++ b/tests/test_worktree_dir_naming_645.py
@@ -145,8 +145,11 @@ def test_prepare_systemd_template_agrees_with_provisioning(tmp_path: Path) -> No
         missing.append(f"builder 帳號 {account} 不存在")
     if not job_runner._group_exists(group):
         missing.append(f"builder group {group} 不存在")
-    if not job_runner._unit_file_installed(template):
-        missing.append(f"模板 unit {template} 未安裝")
+    # #643：每個加固剖面各有一份模板 unit，下面兩個 executor 各用一份——兩份都要在。
+    for profile in sorted(job_runner.TEMPLATE_UNIT_SUFFIX_BY_PROFILE):
+        unit = job_runner.template_unit_for_profile(template, profile)
+        if not job_runner._unit_file_installed(unit):
+            missing.append(f"模板 unit {unit}（剖面 {profile}）未安裝")
     if not job_runner._is_executable(shim):
         missing.append(f"降權 shim {shim} 不存在或不可執行")
     if not Path(spool).is_dir():
@@ -167,12 +170,15 @@ def test_prepare_systemd_template_agrees_with_provisioning(tmp_path: Path) -> No
             autonomy._branch_for_slice(job_id), job_id=job_id
         )
     )
-    plan = job_runner.prepare_systemd_template(
-        {}, job_id=job_id, unit_active=lambda _binary, _unit: False
-    )
-
-    assert workspace.name == plan.instance
-    assert plan.unit == f"cortex-job@{workspace.name}.service"
+    # #643：`executor` 決定加固剖面（＝哪一份模板 unit），因此是必填。這裡刻意用
+    # 兩個剖面各跑一次——本票的不變式是「instance 名」，它必須與剖面無關。
+    for executor, stem in (("claude", "cortex-job"), ("codex", "cortex-job-jit")):
+        plan = job_runner.prepare_systemd_template(
+            {}, job_id=job_id, executor=executor,
+            unit_active=lambda _binary, _unit: False,
+        )
+        assert workspace.name == plan.instance, executor
+        assert plan.unit == f"{stem}@{workspace.name}.service", executor
 
 
 def test_slice_lane_passes_the_same_id_to_provisioning_and_to_launch(


### PR DESCRIPTION
Closes #643

## 摘要

`MemoryDenyWriteExecute=yes` 與 JS runtime 天生互斥（V8 的 JIT 必須 W+X 記憶體）。
以 `cortex-builder` 身分在真實加固面下逐項隔離：無加固時 `node` 正常、
`+MemoryDenyWriteExecute=yes` 時 V8 直接崩在 `v8::internal::Runtime_CompileLazy`，
其餘每一項（`ProtectSystem=strict`／`PrivateTmp`／`RestrictNamespaces`／
`SystemCallFilter=@system-service` ＋ `SystemCallErrorNumber=EPERM`）單獨加上去 `node`
都正常——**唯一的阻斷點就是它**。四個 executor 因此掛掉兩個（`codex`／`copilot`），
而預設的 `PSC_MANAGER_EXECUTOR=codex` 正是掛掉那一個。

operator 裁決＝**方向 2（per-executor 加固剖面）**。

## 剖面對應在哪固化

| 層 | 位置 | 內容 |
|---|---|---|
| 分類來源 | `permgen.EXECUTOR_TOOLS[*].needs_node` | #642 加的既有那張表，**不另立第二張清單** |
| 導出 | `permgen.EXECUTOR_HARDENING_PROFILE` / `executor_hardening_profile()` | 由 `needs_node` 機械導出（node ⇒ V8 ⇒ JIT ⇒ 需要 W+X） |
| 剖面表 | `permgen.HARDENING_PROFILES` | `strict`（後綴空字串）／`jit`（後綴 `-jit`） |
| 啟動器 | `job_runner.EXECUTOR_HARDENING_PROFILE` | 與 permgen 成對契約，由契約測試釘住逐字相等（沿用 `DEFAULT_TEMPLATE_UNIT` 的既有模式：`job_runner` 刻意不 import permgen） |
| 決定點 | `launcher.launch()` → `prepare_systemd_template(..., executor=self._executor)` | `executor` 由 `SubprocessLauncher.__init__` 收下＝Manager 的 dispatch 決定 |

`copilot.needs_node` 由 `False` 改為 `True`：#640 落表時只知道它是 shell script、還沒查
它內部 exec 什麼（表上的 note 當時就寫著「安裝時務必 `head -n 20` 查一次」）。#643 量到
它與 `codex` 的症狀逐字相同——把量到的事實回填既有那張表。

## 怎麼證明 job 選不到寬鬆剖面

1. **唯一輸入是 executor，且它在任何 per-job 產物之前就固定**——`prepare_systemd_template()`
   在 `launch()` 的第一行求值（任何 mkdir／spec 寫入／Popen 之前），`executor` 參數**必填
   無預設**（給預設值等於允許某條路徑「忘了說是哪個 executor」還能派出去）。
   測試：`DispatchSelectsTheProfileTests.test_prompt_and_worktree_cannot_move_the_profile`
   （換掉 job 側可控的 prompt 與 worktree 內容，剖面不動）。
2. **job spec 結構性禁止攜帶剖面欄位**——`hardening`／`hardening_profile`／`profile`／
   `template`／`template_unit`／`unit_suffix`／`MemoryDenyWriteExecute` 全進
   `SPEC_FORBIDDEN_KEYS`（與「身分欄位不入 spec」同一條原則）。寫端 `build_job_spec()`
   與讀端 `job_shim.load_spec()` 各掃一次，且掃的是新抽出的**同一支**
   `forbidden_spec_keys()`（`assertIs` 釘住兩端是同一個物件）。
3. **未知 executor fail-closed**——`resolve_hardening_profile()` 不回傳任何剖面。方向刻意
   不是「不確定就給嚴格的」（那會讓未盤點的 node 型 CLI 靜默起不來，症狀是空輸出——#643
   本身就是這樣被埋掉的），更不是「不確定就給寬鬆的」（那等於沒做）。
4. **config 也選不了**——`PSC_JOB_TEMPLATE_UNIT` 只接受**基底**模板名，帶剖面後綴的值
   一律拒。少了這條，operator 一行 config 就能把**所有** job 推到寬鬆剖面。
5. **shim 仍是 root-owned 且 `ExecStart` 寫死**——兩份 unit 的 `ExecStart` 都是
   `/opt/cortex/bin/cortex-job-shim %i`，`User=` 都硬寫死；呼叫端能選的只是「哪一份具名
   模板」，選不了執行的第一支程式，也塞不進任何屬性。

## polkit：同一條 pattern（列舉交替），不是第二條規則

`^(?:cortex-job|cortex-job-jit)@[a-z0-9][a-z0-9._-]{0,62}\.service$`，字幹段由
`HARDENING_PROFILES` 機械導出。

**為什麼不開第二條規則**：第二條 `polkit.addRule` 會把 subject／action／verb／明細缺席
四個檢查複製一份，變成兩個要同步維護的放行出口——那正是這份規則檔「全檔只有一個
`return polkit.Result.YES`」這個可審查性性質要避免的。列舉交替保留了單一出口，而放行面
從「一個具名模板」變成「兩個具名模板」，**不是**「任意 unit」：前後仍然錨定、instance 段
的字元類一字未改、`^` 與 `@` 之間不允許任何未列舉的字幹。測試明確斷言字幹段內不得出現
`.*`／`[^`／`\w`／`+`。

5-7 的反向測試（transient 五形式、名稱前後綴混淆）對新字幹逐條同樣成立，另補圍繞 `-jit`
的十種混淆（`cortex-job-jitx@`／`cortex-job-ji@`／`cortex-jit-job@`／`@` 後空 instance／
首字大寫／`.socket`／尾綴混淆／換行注入／instance 超長…）。

## spec 的誠實取捨（§R3 新增段）

明載**失去的**：走 `jit` 剖面的 job 失去 `MemoryDenyWriteExecute` 這一層——取得任意程式碼
執行的攻擊者可在該 job 自己的位址空間內配置 W+X 記憶體，JIT 型 shellcode 在此可行。

同樣明載**沒有失去的**（否則會被讀成比實際更弱）：其餘 26 項逐項不變，`User=` 一樣寫死在
root-owned unit 檔裡——W+X 只讓攻擊者在**自己這個 UID** 內執行程式碼，跨 UID／跨檔案系統／
提權那幾層完全沒有鬆動，而 §R2／§R3 保護的 Tier-0／Tier-1 資產靠的正是後者。

**換到的**：保住 `codex`／`copilot` 兩個 provider，即 §R5／§R8 的 `independence_domain`
仍有可選空間（方向 3「只用原生 ELF」會讓 build 域可選空間當場減半；方向 1「全域移除」
則讓不需要放寬的 `claude`／`agy` 一起失去該層——方向 2 的全部價值就在於「只讓需要的那一
類付這個代價」）。

spec 因此**明文禁止**把本系統敘述成「所有 job 都有完整加固」；準確敘述是「原生 ELF
executor 的 job 有 27 項；node 型的有 26 項，少的那一項是 `MemoryDenyWriteExecute`」。
風險表補兩列，並明載退出條件：node 型能在無 W+X 下執行時（V8 jitless、或 CLI 改原生
編譯），`jit` 剖面 SHALL 被移除而非長期保留。

## 順帶修：`CollectMode` 放錯 section

**產生器側的修正已由 #645 附帶完成**（rebase 後撞到，本 PR 不重複）。#643 補的是它缺的
另外兩半：

1. **落檔後檢查**——產生器修好不代表**已落檔**的 unit 跟著更新。runbook 第 5-2 步新增
   `systemd-analyze verify | grep -i "unknown key"` 與 `systemctl reset-failed` 清理；
   #645 在 5-3 加的那條也擴為兩份 unit 一起驗。
2. **測試擴到兩份剖面**——`cortex-job-jit@.service` 是本 PR 新增的第二份 unit，若是複製
   貼上來的就可能複製到舊的放法；並改以「真正的指令行」判段而非字串 split（產生出來的
   註解本身就含 `[Unit]`／`[Service]` 字樣在解釋這個坑，naive split 會切錯）。

## 測試

新增 `tests/test_trust_root_hardening_profile_643.py`（40 測試）：

- 兩份 unit 的加固表**用字典差集比對**（不逐字硬編）：`diff == PROFILE_DIVERGENCE_KEYS`，
  且鍵集合恆等於 `_HARDENING`——日後加一項時漏改一邊會當場紅。
- 覆寫不存在的鍵／白名單外的鍵在 import 時即 `ValueError`。
- 未知 executor 在 permgen／job_runner／template 名推導三個入口皆 fail-closed。
- spec 剖面欄位的寫端與讀端各一組，並 `assertIs` 釘住兩端是同一支函式。
- polkit 正向（兩字幹）＋ 反向（transient 五形式、十種名稱混淆、其他 verb、其他 subject、
  M2 reviewer 字幹）。
- `CollectMode` 落在 `[Unit]`，另有 `systemd-analyze verify` 的「無未知鍵」檢查（無
  `systemd-analyze` 時 skip）。

**#638 的教訓**：三條在單 UID／寬鬆環境測不出來的語意**明確 skip 並說明理由**——MDWE 是否
真的擋掉 V8（含負向對照）、polkit 是否真的拒絕、`CollectMode` 是否真的回收 instance。這三
條需要 root ＋ systemd ＋ polkit ＋ 已落檔的 unit；在 CI 容器裡跑出來的「綠」不代表任何
事，因此不用 `sudo -u`／裸跑當替身（那只會產生一個永遠綠、什麼都沒驗到的測試）。真實驗證
在 runbook 第 5-2b／5-7 步；具備條件的機器可設 `PSC_TEST_REAL_HARDENING=1` 啟用。

`python3 -m pytest tests/ -q` → **3872 passed, 6 skipped**。

## 與 #645 的關係（**已 rebase 到 #646 merge 後的 main**）

對 `job_runner` 的改動**壓在剖面選擇那一塊**：新增 `resolve_hardening_profile()`／
`template_unit_for_profile()`／`forbidden_spec_keys()`／剖面常數，並在
`prepare_systemd_template()` 加一個 `executor` 參數與三個 plan 欄位。未觸及 `seams.py`／
`gc.py`／`worktree_reclaim.py`，也未觸及 `template_instance_id()`／`%i` 與目錄名的推導。

rebase 撞到兩處，皆已解：

- `permgen.build_job_unit()` 的 `CollectMode`——**採 #645 的版本**（本 PR 不重複改）。
- `CHANGELOG.md` 的 `### Fixed`——保留 #645 的條目，本 PR 的重複條目移除，並在 #645 條目
  末補一句說明「產生器修好 ≠ 已落檔的 unit 跟著更新」由 #643 的 runbook 檢查補上。

另外**必要地**動了 `tests/test_worktree_dir_naming_645.py` 一處（22 行）：
`prepare_systemd_template()` 的 `executor` 變成必填，該測試要傳；且它的前置物檢查現在要
確認**兩份**模板 unit 都已安裝（在本機實測時 `cortex-job-jit@.service` 尚未落檔，該測試
如實 fail-closed 了——這正是設計要的行為）。順帶讓它對兩個剖面各跑一次，證明 #645 的
不變式（instance 名）與剖面無關。

## Checklist

- [x] 分支不是 `main`（`feature/643-per-executor-hardening`）
- [x] `changelog.d/per-executor-hardening.md` fragment 已新增且已 commit
- [x] `CHANGELOG.md [Unreleased]` 有對應 entry（Added／Fixed／Changed 三段）
- [x] 文件與 PR 一律 zh-tw
- [x] `python3 -m pytest tests/ -q` 全綠（3872 passed, 6 skipped）
- [x] `policy_check` 帶 PR 上下文跑，fail: 0
- [x] spec（`docs/superpowers/specs/trust-root-isolation-spec.md`）與 runbook
      （`docs/superpowers/runbooks/trust-root-phase2b-setup.md`）已同步
- [x] `VERSION` 未動（非 release PR）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E7w9kaUxAzCCEk7piD5hfK