### PR TITLE
feat(coordinator): canonical lane 的工作區改為 per-job，與模板 unit 的 %i 對齊

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,44 @@
 ## [Unreleased]
 
 ### Added
+- **#648 / trust-root Phase 2b：canonical（workflow）lane 的工作區改為 per-job——
+  per-run 工作區使 `%i` 不變式結構上不成立，該 lane 在降權模式下不可用**——
+  canonical lane 的工作區是 per-run 的（build 卡 provision 之後，同 run 後續的卡沿用
+  `builder_jobs[-1]["worktree"]`，**一個工作區對多個 `job_id`**），而模板 unit 是
+  per-job 定址（`ReadWritePaths=<pool>/%i`）。一個工作區不可能同時等於多個 job id ⇒
+  `PSC_JOB_RUNNER=systemd-template` 下必然拿到指向不存在路徑的 RWP ⇒ `226/NAMESPACE`。
+  #645／#646 只把命名收斂成單一推導點，並在程式碼裡**明文把 canonical lane 排除在
+  不變式外**；本次把那個排除拿掉。**改法**：build phase 的每一張卡自己 clone 一份，
+  目錄名沿用唯一推導點 `job_workspace.job_segment(job_id)`（＝
+  `job_runner.template_instance_id()` 的同一個輸出）。目錄名由 job_id 導出、而
+  `create_job()` 的 input snapshot 又要從工作區算，順序只能是「先配 id → 建工作區 →
+  建 job」⇒ 新增 `JobRegistry.reserve_job_id(task)`（**配發即消耗**，不是預測；與
+  `create_job()` 共用同一個私有配發器，`f"{task}-{seq}"` 全 repo 仍只有一份）。
+  **卡與卡的交接顯式化**：沿用 #637 的 bundle ＋ append-only spool——前一張卡的成果
+  harvest 回來源樹的 `refs/heads/<branch>`（`_harvest_build_candidate()` 已強制它恰
+  等於被採信的 candidate），下一張卡以 `run.candidate_head` 為 base 從**來源樹**
+  clone，完全不讀前一張卡的工作區。**base 推導**：首張卡＝凍結集 base（#208／#211）、
+  後續／中段卡＝最後一張被採信的 candidate；`retry-card`（#545）不動 `candidate_head`，
+  因此中段卡重派拿到的仍是那個 candidate，而不是 run 的原始 base，也不是失敗那次留在
+  磁碟上的東西。推不出合法 SHA 一律 **raise**——退回 creator 預設（`main`）等於
+  `branch -f` 把整個 run 已採信的 commit 抹掉。**成本**：每張 build 卡一次 clone
+  （0.5 秒／35MB），`feature-oneshot` 三張 build 卡 ⇒ 約 1.5 秒／105MB；**刻意不用
+  `--reference`／`--shared`**——那會把 object store 接回共用，正是 #623 判定與三分隔離
+  互斥的東西。**`gc`／`worktree_reclaim` 不必改**：兩者都以形狀與呼叫端給的路徑為準，
+  沒有「一個 run 一個工作區」的假設；per-job 反而消滅了「回收一張卡把兄弟卡的樹一起
+  刪掉」的隱患，而 #601 的 `worktree target already exists` 在這條 lane 上結構性消失
+  （殘留回收仍屬 #601）。**`direct` 模式零回歸**：branch 名／來源樹 ref／標記檔／
+  spool key 推導／`dispatch_head`（仍是 run 層級）全部逐字不變，且本次沒有引入任何依
+  `PSC_JOB_RUNNER` 的分支。**範圍切分**：ship phase 的 manager 卡與 verify／review 卡
+  仍沿用前一張 build 卡的工作區——前者要先補「ship phase 成果回收」才動得了，後者不是
+  降權對象（`%i` 不變式不落在它們身上），各切成後續票。新增
+  `tests/test_canonical_per_job_workspace_648.py`（10 條，全部跑正式 dispatch 路徑：
+  真 creator、真 git repo、真 bundle ＋ spool 交接），含「把前一張卡的工作區刪掉、
+  後續卡仍拿得到 base」的不變式、突變守衛、fail-closed、中段卡重派與 gc／reclaim；
+  完整 `prepare_systemd_template()` 那一條需要 OS 層前置物，單 UID 環境**明確 skip 並
+  逐項列出缺哪一個**（#638 的教訓）。**bootstrap**：`cortex work intake` 走的正是這條
+  lane，本票讓它的 build phase 在降權下可用，cortex 自我託管的第一段因此打通。
+  詳見 `changelog.d/canonical-per-job-workspace.md`。
 - **#643 / trust-root Phase 2b：per-executor 加固剖面——`MemoryDenyWriteExecute` 與
   node 型 executor 的互斥，只讓需要的那一類付代價**——#640／#642 落地後做實機驗證時
   測出來的：**加固面本身與 toolchain 相衝**，不是安裝沒裝好。以 `cortex-builder` 身分
@@ -184,6 +222,8 @@
   **已知邊界**：canonical（workflow）lane 的工作區是 per-run 的（一個工作區對多個
   job_id），「目錄名 ＝ 該 job 的 instance 名」在那裡結構上不可能成立；要在
   `PSC_JOB_RUNNER=systemd-template` 下跑那條 lane，須先把工作區改成 per-job。
+  （**已由 #648 解掉**：build phase 的工作區已改 per-job，不變式在那裡成立且有測試
+  守著；ship／verify／review 卡的工作區另有後續票。）
   **附帶**：`permgen.build_job_unit()` 把 `CollectMode=inactive-or-failed` 由 `[Service]`
   搬到 `[Unit]`——放錯段只被 systemd 忽略（`Unknown key name … ignoring.`），
   「失敗的 instance 自動回收」的用意因此沒生效。（#643 在 runbook 第 5-2 步補上落檔後的

--- a/changelog.d/canonical-per-job-workspace.md
+++ b/changelog.d/canonical-per-job-workspace.md
@@ -1,0 +1,153 @@
+# canonical lane 的工作區改為 per-job（#648）
+
+## 問題
+
+canonical（workflow）lane 的工作區是 **per-run** 的：build 卡 provision 之後，同一個
+run 的後續卡直接沿用 `builder_jobs[-1]["worktree"]`——**一個工作區對多個 `job_id`**。
+
+trust-root Phase 2b 的 template unit 是 per-job 定址的（`ReadWritePaths=<pool>/%i`，
+`%i` ＝ systemd instance ＝ job id）。一個工作區不可能同時等於多個 job id，所以在
+`PSC_JOB_RUNNER=systemd-template` 下 canonical lane 的卡必然拿到指向不存在路徑的
+`ReadWritePaths` → `Failed to set up mount namespacing` → `226/NAMESPACE` → 起不來。
+#645／#646 只把命名收斂成單一推導點，**沒有解決 per-run 對 per-job 的結構落差**，
+並在程式碼裡明文把 canonical lane 排除在不變式之外。本次把那個排除拿掉。
+
+## 改法
+
+### 1. 工作區 per-job，目錄名沿用唯一推導點
+
+`manager._dispatch_workflow_card()` 的 build phase 一律 provision **自己的** clone，
+目錄名 ＝ `job_workspace.job_segment(job_id)`——與 `job_runner.template_instance_id()`
+是同一個函式的同一個輸出（不是「兩邊各自算、剛好相等」，那正是 #645 的形狀）。
+slice lane 的推導點一個位元組都沒動。
+
+### 2. job_id 必須在 provision 之前定案 → `registry.reserve_job_id()`
+
+目錄名由 job_id 導出，而 `create_job()` 的 `workflow_input_snapshot` /
+`workflow_output_baseline` 都是從**工作區裡的檔案**算出來的——順序只能是
+「先配 id → 建工作區 → 建 job」。因此新增 `JobRegistry.reserve_job_id(task)`：
+配發即消耗（`_seq` 前進並落盤），呼叫端把拿到的 id 原樣交回
+`create_job(job_id=…)`，那裡驗證它確實屬於同一個 `task`、未被使用、且已配發。
+**不是「預測下一個 id」**——預測會在任何一次插入之後漂掉。
+`create_job()` 與 `reserve_job_id()` 共用同一個私有配發器 `_allocate_job_id()`，
+`f"{task}-{seq}"` 這條公式全 repo 仍然只有一份。
+
+### 3. 卡與卡的交接顯式化：bundle ＋ append-only spool（沿用 #637）
+
+per-run 工作區隱含「前一張卡的產出留在磁碟上給下一張用」。per-job 之後那條交接
+改走 #637 已落地的通道：
+
+```
+builder 在自己的 clone 產 bundle → Manager-owned append-only spool
+  → Manager 從那個檔案 fetch 進來源樹的 refs/heads/<branch>
+    → 下一張卡從**來源樹** clone
+```
+
+`_harvest_build_candidate()` 已經強制「回收後來源樹的 branch head 恰等於被採信的
+candidate，對不上即 fail-closed」，因此
+
+    來源樹的 refs/heads/<branch> == run.candidate_head
+
+在每一張 build 卡被採信之後成立。新增的 `manager._workflow_build_handoff_base()`
+就以 `run.candidate_head` 作為後續卡的 clone base——**完全不讀前一張卡的工作區**。
+測試把「前一張卡的工作區整個刪掉，後續卡仍拿得到正確 base」釘成不變式。
+
+### 4. base 推導（含中段卡重派）
+
+| 情形 | base |
+|---|---|
+| 首張 build 卡 | `frozen_readiness["base_sha"]`（#208／#211），無凍結集則不傳 |
+| 後續／中段 build 卡 | `run.candidate_head`（最後一張**被採信**的卡的 candidate） |
+| `candidate_head` 尚未錨定（首張卡的 terminal 壞掉正在重派） | 同首張卡 |
+
+`retry-card`（#545）刻意不動 `candidate_head`，因此重派的中段卡拿到的 base 仍是
+最後一張被採信的 candidate——不是 run 的原始 base（會丟掉前面幾張卡的成果），也不是
+那次失敗嘗試留在磁碟上的東西（那是另一個 job_id、另一個目錄）。
+
+推不出合法 SHA 時 **raise**，不得退回 creator 的預設 base（那是 `main`，
+`branch -f` 會把整個 run 已採信的 commit 從 branch 上抹掉）。base 與來源樹實況對不上
+時由 `ScriptWorktreeCreator.create()` 既有的兩道守衛擋下：`rev-parse --verify <base>`
+找不到 ⇒ 交接沒走完；`merge-base --is-ancestor <branch> <base>` ⇒ branch 上有 base
+以外的 commit（#613 的形狀）。兩條都 fail-closed，訊息逐字沿用。
+
+## 成本
+
+每張 build 卡一次 clone（實測 0.5 秒／35MB）。`feature-oneshot` 的 build phase 是
+三張卡（`worktree-isolation` / `tdd-red` / `subagent-build`）⇒ 約 **1.5 秒／105MB**，
+相對於一張卡動輒數分鐘的模型執行時間可忽略。
+
+**刻意不做 `--reference`／`--shared` 之類的優化**：那會把 object store 接回共用，而
+#623 已判定「共用 object store」與「三分隔離」**互斥**（builder 要 commit 就必須能寫
+object store）。要優化只能走不共用 object store 的路（例如 shallow／partial clone），
+不在本票範圍。
+
+## `gc` / `worktree_reclaim` 受什麼影響
+
+- **`gc.py`：不必改**。判準是**形狀**（`job_workspace` 標記檔／`.git` 檔）與 branch
+  的 merge 狀態，不看目錄名、也沒有「一個 run 一個工作區」的假設。同一條 branch 上
+  掛著 N 個工作區時 N 個都掃得到；只要還有任何一個被 keep，那條 branch 就受保護
+  （`protected_branches`），不會在 job 還活著時被刪掉。新增測試釘住。
+- **`worktree_reclaim.py`：不必改，而且變得更安全**。它收的是呼叫端給的**路徑**。
+  per-job 之後每一列 job 記錄的 `worktree` 都是自己那一個，回收一張卡不會波及同 run
+  的其他卡——per-run 時代那是同一條路徑，回收任一張卡等於把兄弟卡的樹一起刪掉。
+- **#601（retry-card 不回收 provision 卡的殘留 worktree）：症狀消失，票不關**。
+  #601 的生產現場是重派撞 `worktree target already exists`；per-job 命名之後兩次嘗試
+  的目錄名不同，那個撞名在 canonical lane 上**結構性消失**。但殘留目錄仍留在磁碟上，
+  「回收」那一半仍是 #601 的範圍。
+- **#613（abandon 不回收 build branch）：完全無關**。本次一個 branch 名都沒改。
+- **新增的成本面**：一個 run 現在會累積 N 個工作區（以前 1 個）。canonical lane 的
+  abandon 目前本來就不回收工作區（那是 #595／#613／#558 那一族），既有的掃除路徑
+  `cortex work gc` 不看名字、N 個一起收得掉。**卡被採信之後即時回收**現在是安全的
+  （成果已在來源樹、bundle 已封存），列為後續票。
+
+## `direct` 模式零回歸
+
+branch 名、來源樹的 `refs/heads/<branch>`、工作區自己 checked-out 的 branch、標記檔的
+`branch` 欄、`spool_key_for_job()`（由 `log_path` 推導）、`dispatch_head`（仍是 **run
+層級**的 base，persona scope diff 的比較基準）全部逐字不變，各有測試釘住。
+`direct` 與 `systemd-template` 走**完全相同**的 provisioning 路徑（本次沒有引入任何
+依 `PSC_JOB_RUNNER` 的分支）。
+
+## 不在本票範圍（已切成後續票）
+
+- **ship phase 的 manager 卡**（`openspec-archive` / `policy-commit`）仍沿用
+  `builder_jobs[-1]["worktree"]`。它們是降權派工的對象（manager persona 既非
+  `read_only` 也非 `review_only`），因此 `%i` 不變式同樣落在它們身上——但它們的成果
+  目前**沒有 harvest 通道**（`_harvest_build_candidate()` 只在 `current_phase ==
+  "build"` 時跑），先改 per-job 會讓第二張 ship 卡看不到第一張的 commit。要先補
+  「ship phase 成果回收」才動得了。
+- **verify / review 卡的 candidate 樹**仍讀前一張 build 卡的工作區。這兩種卡不是降權
+  對象（reviewer 走 `as_review_only()`），實際工作樹是 reviewer sandbox，因此 `%i`
+  不變式不落在它們身上；但它們確實還依賴前一張卡的磁碟殘留，這是「即時回收」的前置。
+
+## 測試
+
+新增 `tests/test_canonical_per_job_workspace_648.py`（10 條，全部跑**正式** dispatch
+路徑：真的 `ScriptWorktreeCreator`、真的 git repo、真的 bundle ＋ spool 交接）：
+
+- **不變式（本票的全部價值）**：canonical lane **每一張** build 卡的工作區目錄名 ==
+  `job_runner.template_instance_id(launch(slice_id=…) 收到的那個 id)`。兩側都是真實
+  推導函式，**不對常數斷言**。
+- **突變守衛**：#648 之前的 per-run 目錄名（`job_segment("<issue>-<work_id>")`）與
+  #645 之前的 branch slug 都不得再出現在 pool 裡。
+- **交接不依賴磁碟殘留**：把前一張卡的工作區 `rmtree` 掉，後續卡仍 clone 出帶著它
+  成果的樹（`HEAD == candidate`、檔案在、`refs/cortex/base` 也錨在 candidate 上）。
+- **fail-closed**：candidate 沒回到來源樹時拒絕 provision，不退回 run 的原始 base。
+- **中段卡重派**：走真的 `_manager_reset_workflow_for_retry_card()`，新目錄、新
+  instance 名、base 仍是最後一張被採信的 candidate；失敗那次的殘留一個位元組沒動。
+- **`dispatch_head` 仍是 run 層級**：per-job 只改工作區，不改記帳基準。
+- **`direct` 模式零回歸** ＋ **`reserve_job_id()` 的三條守衛**。
+- **gc／reclaim**：同一條 branch 上多個工作區都掃得到、branch 受保護、回收一張卡不
+  波及兄弟卡。
+- **完整 `prepare_systemd_template()`**：需要 OS 層前置物（`cortex-builder` 帳號／
+  group、兩份模板 unit、shim、spec spool）。單 UID 的開發機與 CI 沒有，且任何單 UID
+  的模擬都測不出 mount namespace 的語意 ⇒ 比照 **#638 的教訓明確 `pytest.skip` 並逐項
+  列出缺哪一個**，不靜默通過。
+
+`python3 -m pytest tests/ -q`：**3892 passed, 6 skipped**。
+
+## bootstrap
+
+`cortex work intake` 走的正是 canonical lane。本票之前，canonical lane 在降權模式下
+build phase 起不來，cortex 因此無法在降權模式下自己修自己。本票讓 build phase 可用，
+自我託管的第一段因此打通（ship phase 待後續票）。

--- a/docs/superpowers/runbooks/trust-root-phase2b-setup.md
+++ b/docs/superpowers/runbooks/trust-root-phase2b-setup.md
@@ -1799,6 +1799,14 @@ systemctl cat cortex-job@.service | grep -E "^ReadWritePaths=/var/lib/cortex/wor
 #   的 instance 名走的也是它）。#645 之前 provisioning 用的是 branch slug
 #   （`feature-<slice_id>`），與 `%i` 永遠差一個前綴 ⇒ ReadWritePaths 指向不存在
 #   的路徑 ⇒ `Failed to set up mount namespacing` / `226/NAMESPACE`，job 起不來。
+#
+#   #648：canonical（workflow）lane 的工作區在 #646 之前是 **per-run** 的（build 卡
+#   provision 之後，同一個 run 後續的卡沿用同一棵樹），一個工作區對多個 job_id ⇒
+#   同一個症狀在那條 lane 上對「第二張卡起」必然重現。已改為 per-job：每一張 build
+#   卡自己 clone 一份，卡與卡之間的交接走 bundle ＋ append-only spool（#637）。
+#   實機稽核：一個多卡 run 跑完後，pool 底下該有**每張 build 卡各一個**目錄，
+#   且每個目錄名都能在 `systemctl list-units 'cortex-job*@*'` 的 instance 名裡找到。
+#     ls /var/lib/cortex/worktree
 
 # ✅ 檢查 unit 沒有被忽略的鍵（#645 附帶；#643 起兩份都要驗）
 sudo systemd-analyze verify /etc/systemd/system/cortex-job@.service \

--- a/paulsha_cortex/coordinator/manager.py
+++ b/paulsha_cortex/coordinator/manager.py
@@ -3285,6 +3285,56 @@ def _verify_build_candidate_transition(
     return candidate
 
 
+def _workflow_build_handoff_base(run, *, builder_jobs, card: str) -> str:
+    """#648：中段／後續 build 卡的 clone base——**卡與卡交接的顯式通道**。
+
+    canonical lane 的工作區改成 per-job 之後，「前一張卡的產出留在磁碟上給下一張
+    用」這個隱含交接必須換成一個明講的通道。既有的那一條就是 #637 的 **bundle ＋
+    append-only spool**：前一張卡的 commit 由 builder 產成 bundle → 寫進
+    Manager-owned spool → `_harvest_build_candidate()` 把它 fetch 進來源樹的
+    `refs/heads/<branch>`，且**強制**回收後的 branch head 恰等於被採信的 candidate
+    （對不上即 fail-closed）。因此：
+
+        來源樹的 `refs/heads/<branch>` == `run.candidate_head`
+
+    在每一張 build 卡被採信之後成立，下一張卡只要以 `run.candidate_head` 為 base
+    去 clone，拿到的就是前一張卡的成果——**完全不必讀前一張卡的工作區**。
+
+    為什麼是 `run.candidate_head` 而不是「去讀來源樹的 branch tip」：candidate 是
+    Manager 採信鏈（#540）的產物，branch tip 只是磁碟現況。以採信值為準，兩者一旦
+    不一致就會在 `ScriptWorktreeCreator.create()` 的既有守衛上炸出來
+    （`rev-parse --verify` 找不到 ⇒ harvest 沒完成；`merge-base --is-ancestor`
+    失敗 ⇒ branch 上有 candidate 以外的 commit），而不是靜默沿用一個沒被採信的 tip。
+
+    **中段卡重派（#545 retry-card）**：`_manager_reset_workflow_for_retry_card()`
+    不動 `candidate_head`，只把那一張卡打回 pending。因此重派的中段卡在這裡拿到的
+    base 仍是「最後一張**被採信**的 build 卡」的 candidate——不是 run 的原始 base，
+    也不是那次失敗嘗試留在磁碟上的東西。失敗那次的工作區是另一個 job_id、另一個
+    目錄，既不會撞名（#601 的 `worktree target already exists` 在這條 lane 結構上
+    消失），也不會被下一次 provision 讀到。
+
+    **`candidate_head` 尚未錨定時不走這條路**：那代表 run 還沒採信過任何 build
+    成果（首張卡、或首張卡的 terminal 壞掉正在重派），呼叫端會退回「首張 build 卡」
+    的凍結 base。判準寫在呼叫端而不是這裡，因為那是「有沒有東西要交接」的問題。
+
+    推不出合法 SHA 時 raise：**不得**退回 creator 的預設 base（那是 `main`，等於把
+    整個 run 已採信的成果 reset 掉）。
+    """
+
+    for value in (
+        getattr(run, "candidate_head", None),
+        builder_jobs[-1].get("subject_head") if builder_jobs else None,
+    ):
+        if isinstance(value, str) and verification.SAFE_SHA_RE.fullmatch(value) is not None:
+            return value.lower()
+    raise ValueError(
+        "workflow build handoff base is unavailable: "
+        f"card={card}；run 已有被採信的 build 卡，卻推不出可 clone 的 candidate。"
+        "這代表上一張卡的成果回收（#637 bundle ＋ spool）沒有走完——不得以 run 的原始 "
+        "base 重新 provision，那會丟掉已採信的 commit"
+    )
+
+
 def _harvest_build_candidate(
     job: Mapping[str, object],
     *,
@@ -8460,6 +8510,15 @@ def _dispatch_workflow_card(
     builder_job_id = str(builder_jobs[-1]["job_id"]) if builder_jobs else None
     if step.persona == "reviewer" and builder_job_id is None:
         raise ValueError("workflow reviewer builder job unavailable")
+    task = f"wf-{hashlib.sha256(run.run_id.encode()).hexdigest()[:10]}-{step.card}"
+    # #648：job_id 必須在 **provision 之前**就定案——per-job 工作區的目錄名就是
+    # `job_workspace.job_segment(job_id)`，而 `launcher.launch(slice_id=job_id)`
+    # 之後交給 `job_runner.prepare_systemd_template(job_id=…)` 算 instance 名的也是
+    # 同一個字串。順序不能反過來：`create_job()` 的 `workflow_input_snapshot` /
+    # `workflow_output_baseline` 都是從工作區的檔案算出來的。
+    # 配發即消耗（見 `registry.reserve_job_id`），因此 provision 失敗只是燒掉一個
+    # 序號，不會有兩個 job 共用同一個 id、進而共用同一個目錄。
+    reserved_job_id = registry.reserve_job_id(task)
     planner_sandbox: Path | None = None
     reviewer_sandbox: Path | None = None
     sandbox_hash: str | None = None
@@ -8483,8 +8542,6 @@ def _dispatch_workflow_card(
         planning_runtime._copy_planning_sandbox(Path(run.workspace_root), planner_sandbox)
         sandbox_hash = planning_runtime._tree_snapshot(planner_sandbox)
         worktree = str(planner_sandbox)
-    elif builder_jobs:
-        worktree = str(builder_jobs[-1]["worktree"])
     elif step.phase == "build":
         creator = getattr(dispatcher, "_worktree_creator", None)
         workspace_root = Path(run.workspace_root)
@@ -8518,34 +8575,65 @@ def _dispatch_workflow_card(
             f"{primary_issue}-{run.work_id}" if primary_issue is not None else run.work_id
         )
         builder_branch = f"feature/{builder_work_id}"
-        # #645：工作區目錄名改由 id 導出（不再是 branch slug）。canonical lane 傳的是
-        # **run 層級的 build 身分**而不是某一個 job_id——這條 lane 的工作區是
-        # per-run 的：build 卡 provision 之後，同一個 run 後續的卡直接沿用
-        # `builder_jobs[-1]["worktree"]`（見本函式上方）。因此這裡的目錄名恆等於
-        # 「第一張 build 卡的 run 身分」，而 `job_runner.template_instance_id()` 算的是
-        # **每一個 job 自己的** id——兩者在 canonical lane 結構上就不可能逐字相等
-        # （一個工作區對多個 job）。slice lane（`autonomy._launcher_worktree`）沒有這個
-        # 一對多，因此 #645 的不變式在那裡成立且有測試守著。canonical lane 要在
-        # `PSC_JOB_RUNNER=systemd-template` 底下跑，需要先把「工作區 per-run」改成
-        # 「per-job」——那是另一票的事，本次不動。
-        frozen_base_sha = None
-        if isinstance(run.frozen_readiness, dict):
-            candidate_base_sha = run.frozen_readiness.get("base_sha")
-            if isinstance(candidate_base_sha, str) and candidate_base_sha:
-                frozen_base_sha = candidate_base_sha
-        # #208 收口 wiring 5（#211 閉環）：凍結集存在時 worktree 必須以
-        # frozen_readiness["base_sha"] 為基底，不得讓 dispatch 自行重新推導
-        # 一個可能更新鮮（或更陳舊）的 base（hippo #18 #2／#41 v2 的 stale-base
-        # 缺陷）。無凍結集時完全不傳 base_sha 引數，維持現行為（呼叫端保有舊
+        # #648：canonical lane 的工作區改為 **per-job**——每一張 build 卡自己 clone
+        # 一份，目錄名 ＝ 這張卡的 job_id 經 `job_workspace.job_segment()` 導出的
+        # 片段，也就是 `job_runner.template_instance_id()` 算出來的 instance 名。
+        # #645／#646 之後 canonical lane 傳的是 run 層級的 build 身分，一個工作區
+        # 對多個 job_id，`ReadWritePaths=<pool>/%i` 對第二張卡起必然指向不存在的
+        # 路徑（`226/NAMESPACE`）；改 per-job 之後那個一對多消失，不變式成立。
+        # 這裡刻意與 slice lane（`autonomy._launcher_worktree`）用**同一個推導點**。
+        build_branch = (
+            str(builder_jobs[-1]["branch"])
+            if builder_jobs and isinstance(builder_jobs[-1].get("branch"), str)
+            else builder_branch
+        )
+        accepted_candidate = (
+            run.candidate_head
+            if isinstance(run.candidate_head, str)
+            and verification.SAFE_SHA_RE.fullmatch(run.candidate_head) is not None
+            else None
+        )
+        if builder_jobs and accepted_candidate is not None:
+            # 中段／後續 build 卡：base 是**來源樹上這條 branch 現在的位置**，也就是
+            # 前一張卡 harvest 回來（#637 bundle ＋ append-only spool）之後被採信的
+            # candidate。交接因此完全走 Manager 自己的 object store，不依賴前一張卡的
+            # 工作區還留在磁碟上——那個目錄可以已經被回收掉。
+            # `run.candidate_head` 是 Manager 採信的權威值；推不出時 fail-closed，
+            # **絕不**讓 base 落回 creator 的預設（那會是 `main`，等於把整個 run 的
+            # 成果 reset 掉）。base 對不上來源樹的實況時，creator 既有的兩道守衛會擋：
+            # `rev-parse --verify <base>` 找不到 commit ⇒ harvest 沒完成；
+            # `merge-base --is-ancestor <branch> <base>` ⇒ branch 上有 base 以外的
+            # commit（#613 的形狀），一律拒絕 provision。
+            build_base_sha = _workflow_build_handoff_base(
+                run, builder_jobs=builder_jobs, card=step.card
+            )
+        else:
+            # 首張 build 卡：#208 收口 wiring 5（#211 閉環）——凍結集存在時必須以
+            # frozen_readiness["base_sha"] 為基底，不得讓 dispatch 自行重新推導一個
+            # 可能更新鮮（或更陳舊）的 base（hippo #18 #2／#41 v2 的 stale-base 缺陷）。
+            build_base_sha = None
+            if isinstance(run.frozen_readiness, dict):
+                candidate_base_sha = run.frozen_readiness.get("base_sha")
+                if isinstance(candidate_base_sha, str) and candidate_base_sha:
+                    build_base_sha = candidate_base_sha
+        # 無凍結集且為首張卡時完全不傳 base_sha 引數，維持現行為（呼叫端保有舊
         # WorktreeCreator 實作 without base_sha 亦不受影響）。
-        if frozen_base_sha is not None:
+        if build_base_sha is not None:
             worktree = str(
                 creator.create(
-                    builder_branch, job_id=builder_work_id, base_sha=frozen_base_sha
+                    build_branch, job_id=reserved_job_id, base_sha=build_base_sha
                 )
             )
         else:
-            worktree = str(creator.create(builder_branch, job_id=builder_work_id))
+            worktree = str(creator.create(build_branch, job_id=reserved_job_id))
+    elif builder_jobs:
+        # verify／review／ship 卡：仍以**前一張 build 卡的工作區**為 candidate 樹。
+        # 這三種卡不是降權派工的對象（reviewer 走 `as_review_only()`，其實際
+        # 工作樹是 reviewer sandbox；ship 卡的成果目前沒有 harvest 通道），因此
+        # #648 的 `%i` 不變式不落在它們身上。把它們也搬到 per-job clone 需要先補
+        # 「ship phase 的成果回收」與「reviewer candidate 樹的來源」兩件事——見
+        # 後續票，本 PR 不動它們一個位元組。
+        worktree = str(builder_jobs[-1]["worktree"])
     else:
         worktree = run.workspace_root
     effective_repo_root = Path(worktree).resolve()
@@ -8620,14 +8708,13 @@ def _dispatch_workflow_card(
             ):
                 raise ValueError("workflow build phase base is unavailable")
             dispatch_base = base_value
-    task = f"wf-{hashlib.sha256(run.run_id.encode()).hexdigest()[:10]}-{step.card}"
     try:
         branch = (
-            (
-                str(builder_jobs[-1]["branch"])
-                if builder_jobs and isinstance(builder_jobs[-1].get("branch"), str)
-                else builder_branch
-            )
+            # #648：build 卡的 branch 已在 provisioning 當下定案（`build_branch`
+            # 就是傳給 `creator.create()` 的那一個）。在這裡重算一次等於再開一個
+            # 會漂移的來源——job 記錄的 branch 與工作區實際 checkout 的 branch 對不
+            # 上，harvest 的 refspec 就會指到別條 ref。
+            build_branch
             if step.phase == "build"
             else (
                 str(builder_jobs[-1]["branch"])
@@ -8637,6 +8724,7 @@ def _dispatch_workflow_card(
         )
         job = registry.create_job(
             task=task,
+            job_id=reserved_job_id,
             persona=step.persona,
             kind="review" if step.persona == "reviewer" else "build",
             branch=branch,

--- a/paulsha_cortex/coordinator/registry.py
+++ b/paulsha_cortex/coordinator/registry.py
@@ -830,6 +830,40 @@ class JobRegistry:
         except KeyError as exc:
             raise ValueError(f"{field} 指向不存在 job: {job_id}") from exc
 
+    def _allocate_job_id(self, task: str) -> str:
+        """配發下一個 job_id。**全 repo 唯一**的 job_id 產生點。
+
+        `create_job()` 與 `reserve_job_id()` 都走這裡：兩邊各自拼一次
+        `f"{task}-{seq}"` 就是兩個會漂移的來源，而那正是 #645 的形狀。
+        """
+
+        self._seq += 1
+        return f"{task}-{self._seq}"
+
+    def reserve_job_id(self, task: str) -> str:
+        """先把 job_id 配發出來（並持久化水位），稍後再以它建立 job（#648）。
+
+        存在的理由只有一個：**per-job 工作區的目錄名就是 job_id**
+        （`job_workspace.job_segment()`），而工作區必須在 `create_job()`
+        **之前**存在——canonical lane 的 `workflow_input_snapshot` /
+        `workflow_output_baseline` 都是從工作區的檔案算出來的，是 `create_job()`
+        的必填參數。順序因此只能是「先配 id → 建工作區 → 建 job」。
+
+        配發即消耗：`self._seq` 前進並落盤，因此即使後續 provision 失敗、這個 id
+        永遠不會被第二個 job 取用（只是燒掉一個序號，無害）。呼叫端必須把拿到的
+        id 原樣交回 `create_job(job_id=…)`；那裡會驗證它確實屬於同一個 `task`、
+        且尚未被使用。
+
+        **不是**「預測下一個 id」——預測會在任何一次插入之後漂掉。這裡是真的把
+        序號取走。
+        """
+
+        if not isinstance(task, str) or not task:
+            raise ValueError("reserve_job_id 需要非空 task")
+        job_id = self._allocate_job_id(task)
+        self._persist()
+        return job_id
+
     def create_job(
         self,
         *,
@@ -838,6 +872,7 @@ class JobRegistry:
         branch: str,
         pane: str,
         worktree: str,
+        job_id: str | None = None,
         dispatch_head: str | None = None,
         executor: str | None = None,
         session_name: str | None = None,
@@ -879,9 +914,21 @@ class JobRegistry:
         if kind not in {"build", "review"}:
             raise ValueError(f"非法 kind: {kind!r}")
         self._validate_existing_job_ref("workflow_builder_job_id", workflow_builder_job_id)
-        self._seq += 1
+        if job_id is None:
+            allocated = self._allocate_job_id(task)
+        else:
+            # #648：只接受**本 registry 配發過**的 id。放寬成「任意字串」等於讓
+            # 呼叫端自己造 job_id，那既繞過序號單調性，也讓工作區目錄名與 registry
+            # 身分脫鉤（#645 的復發面）。
+            prefix = f"{task}-"
+            suffix = job_id[len(prefix):] if job_id.startswith(prefix) else ""
+            if not suffix.isdigit() or int(suffix) > self._seq:
+                raise ValueError(f"create_job 收到未經配發的 job_id: {job_id!r}（task={task!r}）")
+            if any(existing.get("job_id") == job_id for existing in self._jobs):
+                raise ValueError(f"create_job 收到已被使用的 job_id: {job_id!r}")
+            allocated = job_id
         job: dict[str, Any] = {
-            "job_id": f"{task}-{self._seq}",
+            "job_id": allocated,
             "task": task,
             "persona": persona,
             "kind": kind,

--- a/tests/git_fixtures.py
+++ b/tests/git_fixtures.py
@@ -33,3 +33,25 @@ def make_empty_git_dir(root: Path) -> Path:
     git_dir = root / ".git"
     git_dir.mkdir(parents=True, exist_ok=True)
     return git_dir
+
+
+class StubWorktreeCreator:
+    """#648：canonical lane 的 build 卡改為 **per-job** provisioning 之後，每一次
+    build dispatch 都會呼叫 `WorktreeCreator`（以前只有一個 run 的第一張 build 卡
+    會呼叫，後續卡沿用 `builder_jobs[-1]["worktree"]`）。
+
+    不在意工作區本身、只在意 job 生命週期的測試，注入這個 stub 即可；不注入時
+    `manager._dispatch_workflow_card` 會自行建構真的 `ScriptWorktreeCreator`，而那
+    要求 `run.workspace_root` 是一棵真的 git repo。
+
+    `calls` 逐筆記下 `(branch, job_id, base_sha)`，讓需要驗「每張卡拿到自己的
+    job_id」的測試不必再自己包一層。
+    """
+
+    def __init__(self, root: Path) -> None:
+        self._root = str(root)
+        self.calls: list[tuple[str, str, str | None]] = []
+
+    def create(self, branch: str, *, job_id: str, base_sha: str | None = None) -> str:
+        self.calls.append((branch, job_id, base_sha))
+        return self._root

--- a/tests/test_canonical_per_job_workspace_648.py
+++ b/tests/test_canonical_per_job_workspace_648.py
@@ -1,0 +1,780 @@
+"""issue #648：canonical（workflow）lane 的工作區改為 **per-job**。
+
+#645／#646 把「工作區目錄名 ＝ systemd 模板 instance 名」收斂成單一推導點
+（`job_workspace.job_segment()`），但同時發現 canonical lane **結構上**滿足不了它：
+那條 lane 的工作區是 per-run 的（build 卡 provision 之後，同一個 run 後續的卡沿用
+`builder_jobs[-1]["worktree"]`），一個工作區對多個 `job_id`。模板 unit 的
+`ReadWritePaths=<pool>/%i` 因此對第二張卡起必然指向不存在的路徑 → `226/NAMESPACE`
+→ 起不來。#646 的程式碼裡明文寫著這條邊界，本票把它拿掉。
+
+本檔的核心是三條不變式：
+
+1. **命名**：canonical lane 每一張 build 卡的工作區目錄名 == 該卡的
+   `job_runner.template_instance_id(job_id)`（兩側都跑真實推導函式，不對常數斷言）。
+2. **交接**：卡與卡之間的交接走 #637 的 bundle ＋ append-only spool，**不依賴磁碟
+   殘留**——把前一張卡的工作區整個刪掉，後續卡仍能拿到正確的 base。
+3. **零回歸**：branch 名、spool key 推導、`direct` 模式的既有行為逐字不變。
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from paulsha_cortex.coordinator import job_runner, job_workspace, manager, seams
+from paulsha_cortex.coordinator.launcher import LaunchHandle
+from paulsha_cortex.coordinator.model_identities import IdentityRegistry
+from paulsha_cortex.coordinator.registry import JobRegistry
+from paulsha_cortex.coordinator.workflow import WorkflowStep
+
+from diagnostic_fixtures import fixture_needs_human_reason
+
+
+_REPO = "hamanpaul/paulsha-cortex"
+_WORK_ID = "648-canonical-per-job-workspace"
+
+
+# ---------------------------------------------------------------------------
+# fixtures
+# ---------------------------------------------------------------------------
+
+
+def _git(cwd: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", "-C", str(cwd), *args], check=True, capture_output=True, text=True
+    ).stdout.strip()
+
+
+def _source_repo(root: Path) -> Path:
+    root.mkdir(parents=True, exist_ok=True)
+    subprocess.run(["git", "-C", str(root), "init", "-q", "-b", "main"], check=True)
+    _git(root, "config", "user.email", "manager@example.invalid")
+    _git(root, "config", "user.name", "Cortex Manager")
+    (root / "README.md").write_text("source\n", encoding="utf-8")
+    _git(root, "add", "README.md")
+    _git(root, "commit", "-qm", "init")
+    return root
+
+
+def _build_step(card: str, *, gate_result: str = "pending") -> WorkflowStep:
+    return WorkflowStep(
+        phase="build",
+        persona="builder",
+        card=card,
+        executor="copilot" if gate_result == "passed" else None,
+        model="gpt" if gate_result == "passed" else None,
+        domain="openai" if gate_result == "passed" else None,
+        inputs=(),
+        outputs=(),
+        commit_policy="required",
+        test_policy="focused",
+        gate_result=gate_result,
+    )
+
+
+def _identities() -> IdentityRegistry:
+    return IdentityRegistry.from_rows(
+        [{
+            "executor": "copilot",
+            "model_id": "gpt",
+            "independence_domain": "openai",
+            "capabilities": ["build"],
+        }]
+    )
+
+
+class _RecordingLauncher:
+    """記下每次 launch 的 `slice_id`／`worktree`——不變式要驗的正是這兩個的關係。"""
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, str]] = []
+
+    def as_commit_required(self) -> "_RecordingLauncher":
+        return self
+
+    def launch(self, *, slice_id: str, prompt: str, worktree: str, log_dir: str) -> LaunchHandle:
+        self.calls.append({"slice_id": slice_id, "worktree": worktree})
+        return LaunchHandle(
+            executor="copilot",
+            model_id="gpt",
+            session_name=slice_id,
+            pid=100,
+            log_path=f"{log_dir}/{slice_id}.jsonl",
+        )
+
+
+def _run_with_cards(
+    registry: JobRegistry,
+    *,
+    workspace: Path,
+    cards: tuple[str, ...],
+) -> Any:
+    return registry._manager_create_workflow_run(
+        work_id=_WORK_ID,
+        repo=_REPO,
+        claim_key="claim:v1:" + "1" * 64,
+        source_revision="2" * 64,
+        workspace_root=str(workspace),
+        combo="feature-oneshot",
+        current_phase="build",
+        steps=tuple(_build_step(card) for card in cards),
+        issue_refs=(f"{_REPO}#648",),
+        openspec_refs=(),
+        pr_refs=(),
+        attempts={"build": 1},
+        gate_status="running",
+    )
+
+
+def _dispatch(
+    registry: JobRegistry,
+    *,
+    run,
+    workspace: Path,
+    pool: Path,
+    coordinator_root: Path,
+    force_new_card: bool = False,
+) -> tuple[dict[str, object], _RecordingLauncher]:
+    """跑**正式** dispatch 路徑：真的 `ScriptWorktreeCreator`、真的 git repo。"""
+
+    creator = seams.ScriptWorktreeCreator(repo=workspace, wt_root=pool, base="main")
+    dispatcher = type(
+        "D",
+        (),
+        {"_registry": registry, "_worktree_creator": creator, "_git_runner": None},
+    )()
+    launcher = _RecordingLauncher()
+    dispatched = manager.dispatch_workflow_card(
+        dispatcher,
+        run=run,
+        identities=_identities(),
+        launcher_factory=lambda _identity: launcher,
+        coordinator_root=coordinator_root,
+        force_new_card=force_new_card,
+    )
+    assert dispatched is not None
+    return registry.get_job(str(dispatched["job_id"])), launcher
+
+
+def _accept_card(
+    registry: JobRegistry,
+    *,
+    run,
+    job: dict[str, object],
+    card: str,
+    candidate: str,
+):
+    """把「這張卡已被採信」這件事寫進 registry（harvest 之後的狀態）。
+
+    `subject_head` 由 `bind_workflow_evidence()` 寫入——那正是正式路徑（見
+    `manager._read_job_workflow_evidence`），而 `builder_jobs` 的過濾條件就是
+    `subject_head == run.candidate_head`。手動塞 `subject_head` 會繞過那條綁定。
+    """
+
+    registry.update_headless_result(str(job["job_id"]), status="exited", exit_code=0)
+    registry.bind_workflow_evidence(
+        str(job["job_id"]),
+        locator={"kind": "build", "path": "evidence/workflow/fake.json", "hash": "a" * 64},
+        subject_head=candidate,
+    )
+    steps = tuple(
+        _build_step(step.card, gate_result="passed") if step.card == card else step
+        for step in run.steps
+    )
+    return registry._manager_update_workflow_run(
+        run.run_id, steps=steps, candidate_head=candidate
+    )
+
+
+def _harvest_through_the_spool(
+    *,
+    workspace: Path,
+    clone: Path,
+    branch: str,
+    spool_key: str,
+    coordinator_root: Path,
+) -> str:
+    """完整跑一次 #637 的交接：builder 產 bundle → Manager 從那個檔 fetch。
+
+    刻意**不**手動 `git push`／`fetch <clone>`：本票的整個論點就是「交接走一條顯式
+    通道」，測試若自己抄捷徑把 commit 搬過去，被驗的就不是那條通道。
+    """
+
+    bundle = job_workspace.prepare_commit_spool(
+        spool_key=spool_key, coordinator_root=coordinator_root
+    )
+    command = job_workspace.build_bundle_command(workspace=clone, bundle=bundle)
+    produced = subprocess.run(["bash", "-c", command], capture_output=True, text=True)
+    assert produced.returncode == 0, produced.stderr
+    return job_workspace.harvest_branch(
+        source_repo=workspace, bundle=bundle, branch=branch
+    )
+
+
+def _commit_in(clone: Path, *, filename: str) -> str:
+    (clone / filename).write_text("candidate\n", encoding="utf-8")
+    _git(clone, "add", filename)
+    _git(clone, "commit", "-qm", f"add {filename}")
+    return _git(clone, "rev-parse", "HEAD").lower()
+
+
+# ---------------------------------------------------------------------------
+# 不變式 1：目錄名 ＝ instance 名（#646 明文排除 canonical lane，本票拿掉那個排除）
+# ---------------------------------------------------------------------------
+
+
+def test_every_canonical_build_card_workspace_name_equals_its_instance_name(
+    tmp_path: Path,
+) -> None:
+    """canonical lane 的**每一張** build 卡，工作區目錄名 == 該卡的 instance 名。
+
+    左邊是真的在真 git repo 上 provision 出來的目錄，右邊是
+    `job_runner.template_instance_id()`（`prepare_systemd_template()` 內部唯一的
+    instance 來源）對 `launcher.launch(slice_id=…)` 收到的那個 id 的輸出。#646 之前
+    canonical lane 傳的是 run 層級的 build 身分，第一張卡就對不上，第二張卡起更是
+    「一個目錄對多個 instance」——結構上不可能相等。
+    """
+
+    workspace = _source_repo(tmp_path / "source")
+    pool = tmp_path / "pool"
+    coordinator_root = tmp_path / "coordinator"
+    registry = JobRegistry(state_path=tmp_path / "jobs.json")
+    run = _run_with_cards(
+        registry, workspace=workspace, cards=("worktree-isolation", "tdd-red")
+    )
+
+    job_one, launcher_one = _dispatch(
+        registry, run=run, workspace=workspace, pool=pool,
+        coordinator_root=coordinator_root,
+    )
+    first_clone = Path(str(job_one["worktree"]))
+    candidate = _commit_in(first_clone, filename="one.txt")
+    _harvest_through_the_spool(
+        workspace=workspace,
+        clone=first_clone,
+        branch=str(job_one["branch"]),
+        spool_key=str(job_one["job_id"]),
+        coordinator_root=coordinator_root,
+    )
+    run = _accept_card(
+        registry, run=run, job=job_one, card="worktree-isolation", candidate=candidate
+    )
+    job_two, launcher_two = _dispatch(
+        registry, run=run, workspace=workspace, pool=pool,
+        coordinator_root=coordinator_root,
+    )
+    second_clone = Path(str(job_two["worktree"]))
+
+    for job, launcher, clone in (
+        (job_one, launcher_one, first_clone),
+        (job_two, launcher_two, second_clone),
+    ):
+        launched_id = launcher.calls[0]["slice_id"]
+        # 接線：交給 provisioning 的 id，就是 `launch(slice_id=…)` 之後交給
+        # `prepare_systemd_template(job_id=…)` 的那一個。
+        assert launched_id == str(job["job_id"])
+        assert launcher.calls[0]["worktree"] == str(clone)
+        assert clone.name == job_runner.template_instance_id(launched_id), (
+            f"card={job['workflow_card']}：工作區目錄名 {clone.name!r} 與模板 instance 名 "
+            f"{job_runner.template_instance_id(launched_id)!r} 不相等——模板 unit 的 "
+            "ReadWritePaths=<pool>/%i 會指向不存在的路徑（#645 的 226/NAMESPACE）"
+        )
+        # unit 的 RWP 是 `<pool>/%i`：目錄的父層也必須就是 pool 本身。
+        assert clone.parent == pool
+        assert clone.is_dir()
+
+    # 兩張卡不得共用同一個工作區——那正是 #648 要消滅的一對多。
+    assert first_clone != second_clone
+
+
+def test_canonical_lane_never_produces_the_pre_648_per_run_directory(
+    tmp_path: Path,
+) -> None:
+    """突變守衛：#648 之前的目錄名（run 層級的 build 身分）不得再出現在 pool 裡。
+
+    沒有這一條，上面的不變式可能因為「兩個名字剛好都被改成 run 身分」而假通過。
+    """
+
+    workspace = _source_repo(tmp_path / "source")
+    pool = tmp_path / "pool"
+    registry = JobRegistry(state_path=tmp_path / "jobs.json")
+    run = _run_with_cards(registry, workspace=workspace, cards=("worktree-isolation",))
+
+    job, _launcher = _dispatch(
+        registry, run=run, workspace=workspace, pool=pool,
+        coordinator_root=tmp_path / "coordinator",
+    )
+
+    # #646 的形狀：`job_segment("<issue>-<work_id>")`（run 層級，全 run 一份）
+    legacy = pool / job_workspace.job_segment(f"648-{_WORK_ID}")
+    assert not legacy.exists()
+    # #645 之前的形狀：branch slug
+    assert not (pool / job_workspace.legacy_branch_slug(str(job["branch"]))).exists()
+    assert sorted(path.name for path in pool.iterdir()) == [
+        job_runner.template_instance_id(str(job["job_id"]))
+    ]
+
+
+# ---------------------------------------------------------------------------
+# 不變式 2：交接顯式化——不依賴磁碟殘留
+# ---------------------------------------------------------------------------
+
+
+def test_next_card_gets_its_base_after_the_previous_workspace_is_deleted(
+    tmp_path: Path,
+) -> None:
+    """把前一張卡的工作區**整個刪掉**，後續卡仍拿得到它需要的 base。
+
+    這是本票的全部價值：per-run 工作區隱含「前一張卡的產出留在磁碟上給下一張用」，
+    per-job 之後那個交接必須走一條顯式通道。這裡跑的就是 #637 落地的那一條——
+    builder 在自己的 clone 產出 bundle → 寫進 Manager-owned 的 append-only spool →
+    Manager 從**那個檔案** fetch 進來源樹的 `refs/heads/<branch>`。下一張卡從來源樹
+    clone，因此前一張卡的目錄可以在它派工之前就被回收掉。
+    """
+
+    workspace = _source_repo(tmp_path / "source")
+    pool = tmp_path / "pool"
+    coordinator_root = tmp_path / "coordinator"
+    registry = JobRegistry(state_path=tmp_path / "jobs.json")
+    run = _run_with_cards(
+        registry, workspace=workspace, cards=("worktree-isolation", "tdd-red")
+    )
+
+    job_one, _ = _dispatch(
+        registry, run=run, workspace=workspace, pool=pool,
+        coordinator_root=coordinator_root,
+    )
+    first_clone = Path(str(job_one["worktree"]))
+    branch = str(job_one["branch"])
+    candidate = _commit_in(first_clone, filename="one.txt")
+    harvested = _harvest_through_the_spool(
+        workspace=workspace, clone=first_clone, branch=branch,
+        spool_key=str(job_one["job_id"]), coordinator_root=coordinator_root,
+    )
+    assert harvested == candidate
+    run = _accept_card(
+        registry, run=run, job=job_one, card="worktree-isolation", candidate=candidate
+    )
+
+    # 前一張卡的工作區被回收：磁碟上再也沒有那棵樹。
+    shutil.rmtree(first_clone)
+    assert not first_clone.exists()
+
+    job_two, _ = _dispatch(
+        registry, run=run, workspace=workspace, pool=pool,
+        coordinator_root=coordinator_root,
+    )
+    second_clone = Path(str(job_two["worktree"]))
+
+    # 後續卡的工作區確實帶著前一張卡的成果。
+    assert _git(second_clone, "rev-parse", "HEAD").lower() == candidate
+    assert (second_clone / "one.txt").is_file()
+    assert _git(second_clone, "branch", "--show-current") == branch
+    # base pin 也錨在被採信的 candidate 上——下一輪 bundle 因此只帶這張卡的增量。
+    assert _git(second_clone, "rev-parse", job_workspace.BASE_REF).lower() == candidate
+
+
+def test_build_handoff_fails_closed_when_the_candidate_never_reached_the_source_tree(
+    tmp_path: Path,
+) -> None:
+    """交接沒走完時 fail-closed，**不得**退回 run 的原始 base 重新 provision。
+
+    退回原始 base 的後果不是「跑得比較慢」，而是 `branch -f` 把整個 run 已採信的
+    commit 從 branch 上抹掉——成果只剩在已被回收的 clone 裡。
+    """
+
+    workspace = _source_repo(tmp_path / "source")
+    pool = tmp_path / "pool"
+    coordinator_root = tmp_path / "coordinator"
+    registry = JobRegistry(state_path=tmp_path / "jobs.json")
+    run = _run_with_cards(
+        registry, workspace=workspace, cards=("worktree-isolation", "tdd-red")
+    )
+
+    job_one, _ = _dispatch(
+        registry, run=run, workspace=workspace, pool=pool,
+        coordinator_root=coordinator_root,
+    )
+    first_clone = Path(str(job_one["worktree"]))
+    candidate = _commit_in(first_clone, filename="one.txt")
+    # 刻意**不** harvest：candidate 只存在於 builder 的 clone 裡。
+    run = _accept_card(
+        registry, run=run, job=job_one, card="worktree-isolation", candidate=candidate
+    )
+
+    with pytest.raises(ValueError, match="git worktree base invalid"):
+        _dispatch(
+            registry, run=run, workspace=workspace, pool=pool,
+            coordinator_root=coordinator_root,
+        )
+
+
+# ---------------------------------------------------------------------------
+# 不變式 3：多卡 run 的 base 推導，含中段卡重派（#545）
+# ---------------------------------------------------------------------------
+
+
+def test_midchain_card_redispatch_starts_from_the_accepted_candidate(
+    tmp_path: Path,
+) -> None:
+    """中段卡重派：新工作區、新目錄，base 仍是**最後一張被採信**的 candidate。
+
+    `_manager_reset_workflow_for_retry_card()`（#545）不動 `candidate_head`，只把那
+    一張卡打回 pending。因此重派拿到的 base 不是 run 的原始 base（會丟掉前面幾張卡
+    的成果），也不是那次失敗嘗試留在磁碟上的東西（那是另一個 job_id、另一個目錄）。
+
+    附帶：#601 的生產現場是「重派撞 `worktree target already exists`」。per-job 命名
+    之後兩次嘗試的目錄名不同，那個撞名在這條 lane 上**結構性消失**——殘留目錄的
+    回收仍是 #601 的範圍，但它不再擋住重派。
+    """
+
+    workspace = _source_repo(tmp_path / "source")
+    pool = tmp_path / "pool"
+    coordinator_root = tmp_path / "coordinator"
+    registry = JobRegistry(state_path=tmp_path / "jobs.json")
+    run = _run_with_cards(
+        registry, workspace=workspace, cards=("worktree-isolation", "tdd-red")
+    )
+
+    # 卡 1 成功並交接回來源樹。
+    job_one, _ = _dispatch(
+        registry, run=run, workspace=workspace, pool=pool,
+        coordinator_root=coordinator_root,
+    )
+    first_clone = Path(str(job_one["worktree"]))
+    candidate = _commit_in(first_clone, filename="one.txt")
+    _harvest_through_the_spool(
+        workspace=workspace, clone=first_clone, branch=str(job_one["branch"]),
+        spool_key=str(job_one["job_id"]), coordinator_root=coordinator_root,
+    )
+    run = _accept_card(
+        registry, run=run, job=job_one, card="worktree-isolation", candidate=candidate
+    )
+
+    # 卡 2 首派：失敗（terminal 壞掉、evidence 綁不上），工作區留在磁碟上。
+    job_two, _ = _dispatch(
+        registry, run=run, workspace=workspace, pool=pool,
+        coordinator_root=coordinator_root,
+    )
+    failed_clone = Path(str(job_two["worktree"]))
+    registry.update_headless_result(str(job_two["job_id"]), status="exited", exit_code=1)
+    assert failed_clone.is_dir()
+
+    # 卡 2 重派：走**真的** `retry-card` 原子重置——它刻意不動 candidate_head。
+    registry._manager_update_workflow_run(
+        run.run_id,
+        facets=("needs_human",),
+        gate_status="running",
+        needs_human_reason=fixture_needs_human_reason(),
+    )
+    run = registry._manager_reset_workflow_for_retry_card(
+        run.run_id, expected_run_id=run.run_id, card="tdd-red"
+    )
+    assert run.candidate_head == candidate, "retry-card 不得動 candidate_head"
+    job_retry, _ = _dispatch(
+        registry, run=run, workspace=workspace, pool=pool,
+        coordinator_root=coordinator_root, force_new_card=True,
+    )
+    retry_clone = Path(str(job_retry["worktree"]))
+
+    assert job_retry["job_id"] != job_two["job_id"]
+    assert retry_clone != failed_clone, "#601：重派必須拿到自己的目錄，不得撞名"
+    assert retry_clone.name == job_runner.template_instance_id(str(job_retry["job_id"]))
+    # base 是最後一張**被採信**的 candidate，不是 run 的原始 base。
+    assert _git(retry_clone, "rev-parse", "HEAD").lower() == candidate
+    assert (retry_clone / "one.txt").is_file()
+    # 失敗那次的殘留一個位元組都沒被動過（回收是 #601 的範圍，不是 provision 的）。
+    assert failed_clone.is_dir()
+
+
+def test_dispatch_head_stays_run_level_across_the_card_chain(tmp_path: Path) -> None:
+    """`dispatch_head` 仍是 **run 層級**的 base——per-job 只改工作區，不改記帳基準。
+
+    `dispatch_head` 是 persona scope diff／required-artifact diff 的比較基準
+    （`verification`），語意是「這個 run 從哪裡長出來」。把它改成「上一張卡的
+    candidate」會讓 scope 檢查只看得到最後一張卡的 diff。
+    """
+
+    workspace = _source_repo(tmp_path / "source")
+    pool = tmp_path / "pool"
+    coordinator_root = tmp_path / "coordinator"
+    registry = JobRegistry(state_path=tmp_path / "jobs.json")
+    run = _run_with_cards(
+        registry, workspace=workspace, cards=("worktree-isolation", "tdd-red")
+    )
+    run_base = _git(workspace, "rev-parse", "HEAD").lower()
+
+    job_one, _ = _dispatch(
+        registry, run=run, workspace=workspace, pool=pool,
+        coordinator_root=coordinator_root,
+    )
+    first_clone = Path(str(job_one["worktree"]))
+    candidate = _commit_in(first_clone, filename="one.txt")
+    _harvest_through_the_spool(
+        workspace=workspace, clone=first_clone, branch=str(job_one["branch"]),
+        spool_key=str(job_one["job_id"]), coordinator_root=coordinator_root,
+    )
+    run = _accept_card(
+        registry, run=run, job=job_one, card="worktree-isolation", candidate=candidate
+    )
+    job_two, _ = _dispatch(
+        registry, run=run, workspace=workspace, pool=pool,
+        coordinator_root=coordinator_root,
+    )
+
+    assert job_one["dispatch_head"] == run_base
+    assert job_two["dispatch_head"] == run_base != candidate
+
+
+# ---------------------------------------------------------------------------
+# direct 模式零回歸
+# ---------------------------------------------------------------------------
+
+
+def test_direct_mode_branch_and_spool_surfaces_are_unchanged(tmp_path: Path) -> None:
+    """只有磁碟上的目錄名改：branch 名、來源樹的 ref、spool key 推導全部不變。
+
+    `direct` 模式（與 `gc`／harvest）完全不看目錄名——它們讀來源 repo 的
+    `refs/heads/<branch>`、讀工作區自己 checked-out 的 branch、以及 `log_path` 推導
+    的 spool key。這條把那三個面一次釘住。
+    """
+
+    workspace = _source_repo(tmp_path / "source")
+    pool = tmp_path / "pool"
+    coordinator_root = tmp_path / "coordinator"
+    registry = JobRegistry(state_path=tmp_path / "jobs.json")
+    run = _run_with_cards(
+        registry, workspace=workspace, cards=("worktree-isolation", "tdd-red")
+    )
+    base = _git(workspace, "rev-parse", "HEAD").lower()
+
+    job_one, launcher_one = _dispatch(
+        registry, run=run, workspace=workspace, pool=pool,
+        coordinator_root=coordinator_root,
+    )
+    branch = str(job_one["branch"])
+    clone = Path(str(job_one["worktree"]))
+
+    # 1. branch 名由 run 的 primary issue ＋ work_id 導出，與 #648 之前逐字相同。
+    assert branch == f"feature/648-{_WORK_ID}"
+    # 2. 來源 repo 的 branch 錨在 dispatch base（gc／dispatch baseline 都直接讀它）
+    assert job_workspace.source_branch_head(workspace, branch) == base
+    # 3. 工作區 checked-out 的仍是同一條 branch（gc 由此取 branch，不看目錄名）
+    assert job_workspace.workspace_branch(clone) == branch
+    assert (job_workspace.read_marker(clone) or {}).get("branch") == branch
+    # 4. spool key 仍由 log_path 推導（#637），與目錄名無關
+    assert job_workspace.spool_key_for_job(job_one) == str(job_one["job_id"])
+    assert job_workspace.spool_key_for_job(job_one) == launcher_one.calls[0]["slice_id"]
+
+    # 後續卡同樣不改 branch——per-job 的是工作區，不是 branch。
+    candidate = _commit_in(clone, filename="one.txt")
+    _harvest_through_the_spool(
+        workspace=workspace, clone=clone, branch=branch,
+        spool_key=str(job_one["job_id"]), coordinator_root=coordinator_root,
+    )
+    run = _accept_card(
+        registry, run=run, job=job_one, card="worktree-isolation", candidate=candidate
+    )
+    job_two, _ = _dispatch(
+        registry, run=run, workspace=workspace, pool=pool,
+        coordinator_root=coordinator_root,
+    )
+    assert job_two["branch"] == branch
+    assert job_workspace.source_branch_head(workspace, branch) == candidate
+
+
+def test_reserved_job_id_is_the_id_the_job_actually_gets(tmp_path: Path) -> None:
+    """`reserve_job_id()` 配發的 id 就是 `create_job()` 寫進 registry 的那一個。
+
+    per-job 工作區的目錄名由這個 id 導出，而它必須在 `create_job()` **之前**就定案
+    （工作區要先存在，`workflow_input_snapshot` 才算得出來）。配發與寫入若各自產生
+    一次 id，目錄名與 registry 身分就會漂開——那正是 #645 的形狀。
+    """
+
+    registry = JobRegistry(state_path=tmp_path / "jobs.json")
+    reserved = registry.reserve_job_id("wf-abc-tdd-red")
+    job = registry.create_job(
+        task="wf-abc-tdd-red",
+        job_id=reserved,
+        persona="builder",
+        branch="feature/x",
+        pane="",
+        worktree=str(tmp_path),
+    )
+    # 讓它離開 active 狀態，底下兩條才驗得到 job_id 守衛本身（而不是先撞上
+    # 「同一個 task 已有 active builder」那條既有守衛）。
+    registry.update_headless_result(reserved, status="exited", exit_code=0)
+
+    assert job["job_id"] == reserved
+    # 配發即消耗：同一個 id 不可能被第二個 job 拿到。
+    assert registry.reserve_job_id("wf-abc-tdd-red") != reserved
+    with pytest.raises(ValueError, match="已被使用"):
+        registry.create_job(
+            task="wf-abc-tdd-red",
+            job_id=reserved,
+            persona="builder",
+            branch="feature/x",
+            pane="",
+            worktree=str(tmp_path),
+        )
+    # 未經配發的 id 一律拒絕——放寬等於讓呼叫端自己造 registry 身分。
+    with pytest.raises(ValueError, match="未經配發"):
+        registry.create_job(
+            task="wf-abc-tdd-red",
+            job_id="wf-abc-tdd-red-9999",
+            persona="builder",
+            branch="feature/x",
+            pane="",
+            worktree=str(tmp_path),
+        )
+
+
+# ---------------------------------------------------------------------------
+# 回收：gc／worktree_reclaim 對「一個 run 一個工作區」的假設
+# ---------------------------------------------------------------------------
+
+
+def test_gc_and_reclaim_handle_several_workspaces_on_one_branch(tmp_path: Path) -> None:
+    """同一條 branch 上有多個 per-job 工作區時，`gc` 與 `worktree_reclaim` 都要正確。
+
+    #648 之前 canonical lane 一個 run 只有一個工作區，因此「工作區 ↔ branch」是
+    一對一。改 per-job 之後同一條 branch 上會同時掛著 N 個工作區——這條把兩件事
+    釘住：
+
+    - `gc.scan()` 的判準是**形狀**（標記檔／`.git` 檔）與 branch 的 merge 狀態，
+      不看目錄名也不假設一對一，因此 N 個都掃得到；只要還有任何一個沒被回收，
+      那條 branch 就仍受保護（不會在 job 還活著時被刪掉）。
+    - `worktree_reclaim` 收的是**呼叫端給的路徑**。per-job 之後每一列 job 記錄的
+      `worktree` 都是自己那一個，回收一張卡不會波及同 run 的其他卡——per-run 時代
+      那是同一條路徑，回收任一張卡等於把兄弟卡的樹一起刪掉。
+    """
+
+    from paulsha_cortex.coordinator import gc, worktree_reclaim
+
+    workspace = _source_repo(tmp_path / "source")
+    pool = tmp_path / "pool"
+    coordinator_root = tmp_path / "coordinator"
+    registry = JobRegistry(state_path=tmp_path / "jobs.json")
+    run = _run_with_cards(
+        registry, workspace=workspace, cards=("worktree-isolation", "tdd-red")
+    )
+
+    job_one, _ = _dispatch(
+        registry, run=run, workspace=workspace, pool=pool,
+        coordinator_root=coordinator_root,
+    )
+    first_clone = Path(str(job_one["worktree"]))
+    branch = str(job_one["branch"])
+    candidate = _commit_in(first_clone, filename="one.txt")
+    _harvest_through_the_spool(
+        workspace=workspace, clone=first_clone, branch=branch,
+        spool_key=str(job_one["job_id"]), coordinator_root=coordinator_root,
+    )
+    run = _accept_card(
+        registry, run=run, job=job_one, card="worktree-isolation", candidate=candidate
+    )
+    job_two, _ = _dispatch(
+        registry, run=run, workspace=workspace, pool=pool,
+        coordinator_root=coordinator_root,
+    )
+    second_clone = Path(str(job_two["worktree"]))
+
+    artifacts = gc.scan(workspace, worktree_root=pool)
+    scanned = {
+        item.identifier for item in artifacts if item.kind == "worktree"
+    }
+    assert scanned == {str(first_clone.resolve()), str(second_clone.resolve())}
+    # branch 未 merge ⇒ 兩個工作區都 keep，branch 因此受保護。
+    branch_rows = [
+        item for item in artifacts if item.kind == "branch" and item.branch == branch
+    ]
+    assert branch_rows and all(item.action == gc.ACTION_KEEP for item in branch_rows)
+
+    # 回收第一張卡的工作區，不得波及第二張卡的。
+    result = worktree_reclaim.reclaim_recorded_or_derived(
+        recorded_path=first_clone,
+        pool_root=pool,
+        job_id=str(job_one["job_id"]),
+        branch=branch,
+        repo_root=workspace,
+        preserve_root=tmp_path / "evidence",
+    )
+    assert result is not None and result.ok, result.detail if result else None
+    assert not first_clone.exists()
+    assert second_clone.is_dir()
+    assert _git(second_clone, "rev-parse", "HEAD").lower() == candidate
+
+
+# ---------------------------------------------------------------------------
+# 完整 preflight（需 Phase 2b 部署；單 UID 的開發機／CI 明確 skip，見 #638）
+# ---------------------------------------------------------------------------
+
+
+def test_prepare_systemd_template_agrees_with_canonical_provisioning(
+    tmp_path: Path,
+) -> None:
+    """canonical lane 的完整 `prepare_systemd_template()` 與 provisioning 對齊。
+
+    上面的不變式跑的是 `template_instance_id()`——它正是
+    `prepare_systemd_template()` 內部唯一的 instance 來源，因此在任何機器上都測得到。
+    這一條再往外包一層，連 preflight（帳號／unit 檔／shim／spec spool）一起跑，證明
+    **正式派工路徑**上算出來的 instance 名也是同一個。
+
+    這些前置物是 OS 層的（真的存在 `cortex-builder` 帳號、真的裝了模板 unit），
+    單 UID 的開發機與 CI 都沒有，任何單 UID 的模擬都測不出 mount namespace 的語意。
+    比照 #638 的教訓：**明確 skip 並逐項說明缺什麼**，不得靜默通過。
+    """
+
+    missing: list[str] = []
+    account = job_runner.resolve_builder_account({})
+    group = job_runner.resolve_builder_group({})
+    template = job_runner.resolve_template_unit({})
+    shim = job_runner.resolve_job_shim({})
+    spool = job_runner.resolve_job_spec_spool({})
+    if shutil.which("systemctl") is None:
+        missing.append("PATH 上沒有 systemctl")
+    if not job_runner._systemd_booted():
+        missing.append("/run/systemd/system 不存在（本機未以 systemd 開機）")
+    if not job_runner._account_exists(account):
+        missing.append(f"builder 帳號 {account} 不存在")
+    if not job_runner._group_exists(group):
+        missing.append(f"builder group {group} 不存在")
+    for profile in sorted(job_runner.TEMPLATE_UNIT_SUFFIX_BY_PROFILE):
+        unit = job_runner.template_unit_for_profile(template, profile)
+        if not job_runner._unit_file_installed(unit):
+            missing.append(f"模板 unit {unit}（剖面 {profile}）未安裝")
+    if not job_runner._is_executable(shim):
+        missing.append(f"降權 shim {shim} 不存在或不可執行")
+    if not Path(spool).is_dir():
+        missing.append(f"job spec spool {spool} 不存在")
+    if missing:
+        pytest.skip(
+            "本機沒有 trust-root Phase 2b 的降權前置物（"
+            + "；".join(missing)
+            + "）。#648 的不變式在 `template_instance_id()` 那條測試裡已被完整覆蓋，"
+            "本條只多驗 preflight 這一層——刻意 skip 而非空過"
+        )
+
+    workspace = _source_repo(tmp_path / "source")
+    pool = tmp_path / "pool"
+    registry = JobRegistry(state_path=tmp_path / "jobs.json")
+    run = _run_with_cards(registry, workspace=workspace, cards=("worktree-isolation",))
+    job, _launcher = _dispatch(
+        registry, run=run, workspace=workspace, pool=pool,
+        coordinator_root=tmp_path / "coordinator",
+    )
+    clone = Path(str(job["worktree"]))
+
+    for executor, stem in (("claude", "cortex-job"), ("codex", "cortex-job-jit")):
+        plan = job_runner.prepare_systemd_template(
+            {},
+            job_id=str(job["job_id"]),
+            executor=executor,
+            unit_active=lambda _binary, _unit: False,
+        )
+        assert clone.name == plan.instance, executor
+        assert plan.unit == f"{stem}@{clone.name}.service", executor

--- a/tests/test_midchain_builder_retry_545.py
+++ b/tests/test_midchain_builder_retry_545.py
@@ -46,6 +46,7 @@ from paulsha_cortex.deck.schema import (
 from paulsha_cortex.porcelain import recover as porcelain_recover
 
 from diagnostic_fixtures import fixture_needs_human_reason
+from git_fixtures import StubWorktreeCreator
 
 
 HEAD = "d" * 40
@@ -468,7 +469,16 @@ def test_forced_retry_dispatches_a_new_job_for_the_midchain_card(
     prompts: list[str] = []
 
     replacement = manager.dispatch_workflow_card(
-        type("D", (), {"_registry": registry, "_git_runner": None})(),
+        # #648：build 卡改為 per-job provisioning，重派會走 creator。
+        type(
+            "D",
+            (),
+            {
+                "_registry": registry,
+                "_git_runner": None,
+                "_worktree_creator": StubWorktreeCreator(tmp_path),
+            },
+        )(),
         run=registry.get_workflow_run(run.run_id),
         identities=_identities(),
         launcher_factory=lambda _: _Launcher(prompts),
@@ -571,7 +581,16 @@ def test_retry_card_reset_refuses_the_final_card_after_state_drift(tmp_path: Pat
 
 
 def _daemon_executor(tmp_path: Path, registry: JobRegistry, run, **kwargs):
-    dispatcher = type("D", (), {"_registry": registry, "_git_runner": None})()
+    dispatcher = type(
+        "D",
+        (),
+        {
+            "_registry": registry,
+            "_git_runner": None,
+            # #648：build 卡改為 per-job provisioning，重派會走 creator。
+            "_worktree_creator": StubWorktreeCreator(tmp_path),
+        },
+    )()
     return manager_daemon.build_request_executor(
         dispatcher=dispatcher,
         specs_dir=str(tmp_path / "specs"),

--- a/tests/test_multi_issue_worktree.py
+++ b/tests/test_multi_issue_worktree.py
@@ -207,9 +207,10 @@ def test_build_worktree_uses_run_workspace_root_not_manager_repo(
     persisted = registry.get_job(job["job_id"])
 
     expected_pool = worktree_root_for(run_workspace)
-    # #645：目錄名由 build 身分（＝branch 去掉 `feature/`）經 job_workspace 導出，
-    # 不再是 branch slug；branch 名本身不變。
-    segment = job_workspace.job_segment("34-multi-issue-worktree")
+    # #645：目錄名由 id 經 job_workspace 導出，不再是 branch slug；branch 名本身不變。
+    # #648：那個 id 改為**這張卡自己的 job_id**（per-job 工作區），不再是 run 層級的
+    # build 身分——目錄名因此逐字等於這個 job 的 systemd 模板 instance 名。
+    segment = job_workspace.job_segment(str(persisted["job_id"]))
     expected_worktree = expected_pool / segment
     assert persisted["worktree"] == str(expected_worktree)
     assert expected_worktree.is_dir()

--- a/tests/test_retry_feedback_context_606.py
+++ b/tests/test_retry_feedback_context_606.py
@@ -40,6 +40,7 @@ from paulsha_cortex.coordinator.registry import JobRegistry
 from paulsha_cortex.coordinator.workflow import WorkflowStep
 
 from diagnostic_fixtures import fixture_needs_human_reason
+from git_fixtures import StubWorktreeCreator
 
 
 HEAD = "d" * 40
@@ -568,7 +569,16 @@ def test_forced_redispatch_prompt_carries_the_evidence(
     prompts: list[str] = []
 
     replacement = manager.dispatch_workflow_card(
-        type("D", (), {"_registry": registry, "_git_runner": None})(),
+        # #648：build 卡改為 per-job provisioning，每次派工都會走 creator。
+        type(
+            "D",
+            (),
+            {
+                "_registry": registry,
+                "_git_runner": None,
+                "_worktree_creator": StubWorktreeCreator(tmp_path),
+            },
+        )(),
         run=registry.get_workflow_run(run.run_id),
         identities=_identities(),
         launcher_factory=lambda _: _Launcher(prompts),
@@ -615,7 +625,16 @@ def test_first_dispatch_through_the_real_path_has_no_retry_context(
     prompts: list[str] = []
 
     manager.dispatch_workflow_card(
-        type("D", (), {"_registry": registry, "_git_runner": None})(),
+        # #648：build 卡改為 per-job provisioning，每次派工都會走 creator。
+        type(
+            "D",
+            (),
+            {
+                "_registry": registry,
+                "_git_runner": None,
+                "_worktree_creator": StubWorktreeCreator(tmp_path),
+            },
+        )(),
         run=registry.get_workflow_run(run.run_id),
         identities=_identities(),
         launcher_factory=lambda _: _Launcher(prompts),

--- a/tests/test_terminal_result_contract.py
+++ b/tests/test_terminal_result_contract.py
@@ -14,6 +14,8 @@ import pytest
 
 from paulsha_cortex.coordinator import terminal_contract as tc
 
+from git_fixtures import StubWorktreeCreator
+
 
 CANONICAL_CARD = {
     "schema_version": 2,
@@ -580,6 +582,8 @@ def test_resume_bounds_schema_mismatch_retry_with_observable_counter(tmp_path: P
     class ResumeDispatcher:
         _registry = registry
         _git_runner = None
+        # #648：build 卡改為 per-job provisioning，resume 重派會走 creator。
+        _worktree_creator = StubWorktreeCreator(tmp_path)
 
         def poll_headless_done(self, job_id):
             return registry.get_job(job_id)

--- a/tests/test_work_bridge.py
+++ b/tests/test_work_bridge.py
@@ -970,10 +970,14 @@ identities:
 
     registry = JobRegistry()
     branches: list[str] = []
+    #: #648：canonical lane 的工作區改為 per-job，provisioning 由「一個 run 一次」
+    #: 變成「每張 build 卡一次」；branch 名一條不變，只是被要求得更多次。
+    provisioned_job_ids: list[str | None] = []
 
     class WorktreeCreator:
         def create(self, branch, base_sha=None, *, job_id=None):
             branches.append(branch)
+            provisioned_job_ids.append(job_id)
             return str(repo)
 
     dispatcher = Dispatcher(
@@ -1203,7 +1207,16 @@ identities:
     run = registry.get_workflow_run(run_id)
     assert run.current_phase == "review"
     assert run.pr_refs == ("acme/demo#17",)
-    assert branches == ["feature/14-work"]
+    build_job_ids = [
+        job["job_id"]
+        for job in registry.list_jobs()
+        if job.get("workflow_run_id") == run_id and job.get("workflow_phase") == "build"
+    ]
+    assert set(branches) == {"feature/14-work"}
+    # #648：每張 build 卡 provision 一次，且帶的是**那張卡自己的 job_id**——
+    # 目錄名（`job_workspace.job_segment(job_id)`）因此逐字等於該 job 的 systemd
+    # 模板 instance 名。
+    assert provisioned_job_ids == build_job_ids
     assert preflight_requests[0].metadata_path is not None
     assert preflight_requests[0].pr_number is None
     assert created[0]["branch"] == "feature/14-work"

--- a/tests/test_workflow_production_wiring.py
+++ b/tests/test_workflow_production_wiring.py
@@ -37,6 +37,7 @@ from paulsha_cortex.deck.compile import compile_combo, emit
 from paulsha_cortex.deck.schema import DEFAULT_CARDS_PATH, DEFAULT_COMBOS_DIR, load_cards, load_combo
 
 from diagnostic_fixtures import fixture_needs_human_reason
+from git_fixtures import StubWorktreeCreator as _StubWorktreeCreator
 
 
 def _gate_ledger_passed(log_path, *, gates: list[dict[str, object]] | None = None) -> None:
@@ -917,7 +918,16 @@ def test_forced_retry_build_dispatches_new_job_after_prior_success(
             )
 
     replacement = manager.dispatch_workflow_card(
-        type("D", (), {"_registry": registry, "_git_runner": None})(),
+        # #648：build 卡改為 per-job provisioning，重派會走 creator。
+        type(
+            "D",
+            (),
+            {
+                "_registry": registry,
+                "_git_runner": None,
+                "_worktree_creator": _StubWorktreeCreator(tmp_path),
+            },
+        )(),
         run=run,
         identities=IdentityRegistry.from_rows(
             [{
@@ -1591,6 +1601,8 @@ def test_operator_resume_retries_bound_needs_human_terminal_without_rewriting_ol
     class ResumeDispatcher:
         _registry = registry
         _git_runner = None
+        # #648：build 卡改為 per-job provisioning，resume 重派會走 creator。
+        _worktree_creator = _StubWorktreeCreator(tmp_path)
 
         def poll_headless_done(self, job_id):
             return registry.get_job(job_id)
@@ -1867,6 +1879,8 @@ def test_operator_resume_retries_malformed_build_terminal_without_advancing(
     class ResumeDispatcher:
         _registry = registry
         _git_runner = None
+        # #648：build 卡改為 per-job provisioning，resume 重派會走 creator。
+        _worktree_creator = _StubWorktreeCreator(tmp_path)
 
         def poll_headless_done(self, job_id):
             return registry.get_job(job_id)
@@ -2988,10 +3002,14 @@ def test_control_queue_manager_executes_heterogeneous_brainstorm_before_plan(tmp
         raise AssertionError(argv)
 
     created_branches: list[str] = []
+    #: #648：canonical lane 的工作區改為 per-job，因此 provisioning 由「一個 run
+    #: 一次」變成「每張 build 卡一次」，且每次帶的是**那張卡自己的 job_id**。
+    created_job_ids: list[str | None] = []
 
     class WorktreeCreator:
         def create(self, branch, base_sha=None, *, job_id=None):
             created_branches.append(branch)
+            created_job_ids.append(job_id)
             return str(tmp_path)
 
     dispatcher = Dispatcher(
@@ -3414,7 +3432,11 @@ def test_control_queue_manager_executes_heterogeneous_brainstorm_before_plan(tmp
         for job in workflow_jobs
         if job.get("workflow_phase") == "ship"
     } == {"openspec-archive", "policy-commit"}
-    assert created_branches == ["feature/production-wiring"]
+    # #648：branch 名一條不變（每張 build 卡都在同一條 branch 上接力），但工作區
+    # 改為 per-job——provisioning 次數 ＝ build 卡數，且帶的 job_id 逐一對應。
+    build_jobs = [job for job in workflow_jobs if job.get("workflow_phase") == "build"]
+    assert set(created_branches) == {"feature/production-wiring"}
+    assert created_job_ids == [job["job_id"] for job in build_jobs]
     assert all(job.get("workflow_evidence") for job in workflow_jobs)
     assert all(job.get("workflow_claim_key") == run.claim_key for job in workflow_jobs)
     assert all(isinstance(job.get("workflow_inputs"), list) for job in workflow_jobs)


### PR DESCRIPTION
Closes #648

## 問題

canonical（workflow）lane 的工作區是 **per-run** 的：build 卡 provision 之後，同一個 run
的後續卡直接沿用 `builder_jobs[-1]["worktree"]`——**一個工作區對多個 `job_id`**。

trust-root Phase 2b 的模板 unit 是 per-job 定址（`ReadWritePaths=<worktree_root>/%i`，
`%i` ＝ systemd instance ＝ job id）。一個工作區不可能同時等於多個 job id，所以在
`PSC_JOB_RUNNER=systemd-template` 下這條 lane 的卡必然拿到指向不存在路徑的
`ReadWritePaths` → `Failed to set up mount namespacing` → `226/NAMESPACE` → 起不來。

#645／#646 只把命名收斂成單一推導點，並在 `manager._dispatch_workflow_card()` 裡**明文
把 canonical lane 排除在不變式外**。本 PR 拿掉那個排除。

| lane | `direct` | `systemd-template` |
|---|:--:|:--:|
| slice | ✅ | ✅（已實機端到端驗證） |
| canonical，build phase | ✅ | ✅ **本 PR** |
| canonical，ship phase | ✅ | ⛔ #649 |

## 改法

### 1. 工作區 per-job，目錄名沿用唯一推導點

build phase 的每一張卡 provision **自己的** clone，目錄名 ＝
`job_workspace.job_segment(job_id)`——與 `job_runner.template_instance_id()` 是同一個
函式的同一個輸出（不是「兩邊各自算、剛好相等」，那正是 #645 的形狀）。slice lane 的
推導點一個位元組沒動。

### 2. `registry.reserve_job_id()`：job_id 必須在 provision 之前定案

目錄名由 job_id 導出，而 `create_job()` 的 `workflow_input_snapshot` /
`workflow_output_baseline` 都是從**工作區裡的檔案**算出來的——順序只能是
「先配 id → 建工作區 → 建 job」。

因此新增 `JobRegistry.reserve_job_id(task)`：**配發即消耗**（`_seq` 前進並落盤），
呼叫端把拿到的 id 原樣交回 `create_job(job_id=…)`，那裡驗證它確實屬於同一個 `task`、
已配發、且未被使用。**不是「預測下一個 id」**——預測會在任何一次插入之後漂掉。
`create_job()` 與 `reserve_job_id()` 共用同一個私有配發器 `_allocate_job_id()`，
`f"{task}-{seq}"` 這條公式全 repo 仍然只有一份。

provision 失敗只是燒掉一個序號（無害），不會有兩個 job 共用同一個 id、進而共用同一個目錄。
dispatch 的冪等早退（`if matching and not retryable_latest: return matching[-1]`）在
配發之前，因此重複 tick 不會燒號。

### 3. 卡與卡的交接顯式化：bundle ＋ append-only spool（沿用 #637）

per-run 工作區隱含「前一張卡的產出留在磁碟上給下一張用」。per-job 之後那條交接改走
#637 已落地的通道：

```
builder 在自己的 clone 產 bundle → Manager-owned append-only spool
  → Manager 從那個檔案 fetch 進來源樹的 refs/heads/<branch>
    → 下一張卡從**來源樹** clone
```

`_harvest_build_candidate()` 早已強制「回收後來源樹的 branch head 恰等於被採信的
candidate，對不上即 fail-closed」，因此

```
來源樹的 refs/heads/<branch> == run.candidate_head
```

在每一張 build 卡被採信之後成立。新增的 `manager._workflow_build_handoff_base()` 就以
`run.candidate_head` 作為後續卡的 clone base——**完全不讀前一張卡的工作區**。測試把
「前一張卡的工作區整個 `rmtree` 掉，後續卡仍拿得到正確 base」釘成不變式。

**為什麼是 `run.candidate_head` 而不是去讀來源樹的 branch tip**：candidate 是 Manager
採信鏈（#540）的產物，branch tip 只是磁碟現況。以採信值為準，兩者一旦不一致就會在
`ScriptWorktreeCreator.create()` 的既有守衛上炸出來，而不是靜默沿用一個沒被採信的 tip。

### 4. base 推導（含中段卡重派）

| 情形 | base |
|---|---|
| 首張 build 卡 | `frozen_readiness["base_sha"]`（#208／#211），無凍結集則不傳 |
| 後續／中段 build 卡 | `run.candidate_head`（最後一張**被採信**的卡的 candidate） |
| `candidate_head` 尚未錨定（首張卡 terminal 壞掉正在重派） | 同首張卡 |

`retry-card`（#545）刻意不動 `candidate_head`，因此**中段卡重派**拿到的 base 仍是最後
一張被採信的 candidate——不是 run 的原始 base（會丟掉前面幾張卡的成果），也不是那次
失敗嘗試留在磁碟上的東西（那是另一個 job_id、另一個目錄）。測試走**真的**
`_manager_reset_workflow_for_retry_card()`，不自己捏狀態。

推不出合法 SHA 時 **raise**，**不得**退回 creator 的預設 base（那是 `main`，
`branch -f` 會把整個 run 已採信的 commit 從 branch 上抹掉）。base 與來源樹實況對不上時
由 creator 既有的兩道守衛擋下，訊息逐字沿用：

- `rev-parse --verify <base>` 找不到 ⇒ 交接沒走完（harvest 沒跑或失敗）
- `merge-base --is-ancestor <branch> <base>` ⇒ branch 上有 base 以外的 commit（#613 的形狀）

`dispatch_head` **仍是 run 層級**的 base（persona scope diff／required-artifact diff 的
比較基準）——per-job 改的是工作區，不是記帳基準。有測試釘住。

## 成本

每張 build 卡一次 clone（實測 0.5 秒／35MB）。`feature-oneshot` 的 build phase 是三張卡
（`worktree-isolation` / `tdd-red` / `subagent-build`）⇒ 約 **1.5 秒／105MB**，相對於一張
卡動輒數分鐘的模型執行時間可忽略。

**刻意不用 `--reference`／`--shared` 之類的優化**：那會把 object store 接回共用，而 #623
已判定「共用 object store」與「三分隔離」**互斥**（builder 要 commit 就必須能寫 object
store）。要優化只能走不共用 object store 的路（shallow／partial clone），不在本票範圍。

## `gc`／`worktree_reclaim` 受什麼影響

- **`gc.py`：不必改**。判準是**形狀**（`job_workspace` 標記檔／`.git` 檔）與 branch 的
  merge 狀態，不看目錄名、也沒有「一個 run 一個工作區」的假設。同一條 branch 上掛著 N 個
  工作區時 N 個都掃得到；只要還有任何一個被 keep，那條 branch 就受保護
  （`protected_branches`），不會在 job 還活著時被刪掉。**新增測試釘住**。
- **`worktree_reclaim.py`：不必改，而且變得更安全**。它收的是呼叫端給的**路徑**。per-job
  之後每一列 job 記錄的 `worktree` 都是自己那一個，回收一張卡不會波及同 run 的其他卡——
  per-run 時代那是同一條路徑，回收任一張卡等於把兄弟卡的樹一起刪掉。
- **#601（retry-card 不回收 provision 卡的殘留 worktree）：症狀消失，票不關**。#601 的
  生產現場是重派撞 `worktree target already exists`；per-job 命名之後兩次嘗試的目錄名
  不同，那個撞名在 canonical lane 上**結構性消失**（有測試）。但殘留目錄仍在磁碟上，
  「回收」那一半仍是 #601 的範圍。
- **#613（abandon 不回收 build branch）：完全無關**。本 PR 一個 branch 名都沒改。
- **新增的成本面**：一個 run 現在會累積 N 個工作區（以前 1 個）。canonical lane 的 abandon
  目前本來就不回收工作區（#595／#613／#558 那一族），既有的掃除路徑 `cortex work gc`
  不看名字、N 個一起收得掉。**卡被採信之後即時回收**現在是安全的（成果已在來源樹、
  bundle 已封存），列為 #650。

## `direct` 模式零回歸

branch 名、來源樹的 `refs/heads/<branch>`、工作區自己 checked-out 的 branch、標記檔的
`branch` 欄、`spool_key_for_job()`（由 `log_path` 推導）、`dispatch_head`（run 層級）
全部逐字不變，各有測試釘住。本 PR **沒有引入任何依 `PSC_JOB_RUNNER` 的分支**——`direct`
與 `systemd-template` 走完全相同的 provisioning 路徑（#634 的「以形狀判斷，不依旗標分支」）。

## 怎麼切的（範圍不是收乾淨，是刻意切開）

本 PR 只動 **build phase**。兩塊切成後續票，理由不是「做不完」而是「先做會造成回歸」：

- **#649：ship phase 的成果回收**。ship 卡（`openspec-archive`／`policy-commit`）**是**
  降權對象（manager persona 既非 `read_only` 也非 `review_only`），`%i` 不變式同樣落在
  它們身上——但它們的成果**沒有 harvest 通道**（`_harvest_build_candidate()` 只在
  `current_phase == "build"` 時跑）。先改 per-job 會讓 `policy-commit` clone 到一棵沒有
  `openspec-archive` commit 的樹。必須先補回收通道。
- **#650：verify／review 卡的 candidate 樹**。這兩種卡不是降權對象（reviewer 走
  `as_review_only()`，實際工作樹是 reviewer sandbox 而非 pool 內的工作區），`%i` 不變式
  不落在它們身上——但它們確實還讀前一張 build 卡的工作區，那是「卡被採信後即時回收」的
  前置。

## bootstrap

`cortex work intake` 走的正是 canonical lane。本 PR 之前，canonical lane 在降權模式下
build phase 起不來，**cortex 因此無法在降權模式下自己修自己**。本 PR 讓 build phase
可用，自我託管的第一段因此打通（ship phase 待 #649）。

## 測試

新增 `tests/test_canonical_per_job_workspace_648.py`（10 條，全部跑**正式** dispatch
路徑：真的 `ScriptWorktreeCreator`、真的 git repo、真的 bundle ＋ spool 交接，不手動
`git push`／`fetch <clone>` 抄捷徑）：

- **不變式（本票的全部價值）**：canonical lane **每一張** build 卡的工作區目錄名 ==
  `job_runner.template_instance_id(launch(slice_id=…) 收到的那個 id)`。兩側都是真實推導
  函式，**不對常數斷言**；同時驗接線（交給 provisioning 的 id ＝ 交給 launch 的 id）。
- **突變守衛**：#648 之前的 per-run 目錄名（`job_segment("<issue>-<work_id>")`）與 #645
  之前的 branch slug 都不得再出現在 pool 裡。
- **交接不依賴磁碟殘留**：把前一張卡的工作區 `rmtree` 掉，後續卡仍 clone 出帶著它成果的
  樹（`HEAD == candidate`、檔案在、`refs/cortex/base` 也錨在 candidate 上）。
- **fail-closed**：candidate 沒回到來源樹時拒絕 provision，不退回 run 的原始 base。
- **中段卡重派**：走真的 `_manager_reset_workflow_for_retry_card()`，新目錄、新 instance
  名、base 仍是最後一張被採信的 candidate；失敗那次的殘留一個位元組沒動。
- **`dispatch_head` 仍是 run 層級**。
- **`direct` 模式零回歸** ＋ **`reserve_job_id()` 的三條守衛**。
- **gc／reclaim**：同一條 branch 上多個工作區都掃得到、branch 受保護、回收一張卡不波及
  兄弟卡。
- **完整 `prepare_systemd_template()`**：需要 OS 層前置物（`cortex-builder` 帳號／group、
  兩份模板 unit、shim、spec spool）。單 UID 的開發機與 CI 沒有，且任何單 UID 的模擬都測
  不出 mount namespace 的語意 ⇒ 比照 **#638 的教訓明確 `pytest.skip` 並逐項列出缺哪一個**，
  不靜默通過。

既有測試的更新都是「per-job 之後 provisioning 由『一個 run 一次』變成『每張 build 卡
一次』」的直接後果：`created_branches` 類斷言改為驗「provision 次數 ＝ build 卡數、且帶的
job_id 逐一對應 build job」（比原斷言更強）；四個只在意 job 生命週期的測試注入共用的
`tests/git_fixtures.py:StubWorktreeCreator`。

`python3 -m pytest tests/ -q`：**3892 passed, 6 skipped**（本機非部署機，Phase 2b 那條
skip 並印出缺哪一項）。

## 未做的實機驗證

`PSC_JOB_RUNNER=systemd-template` 下跑完一個多卡 canonical run **尚未實機執行**——本機
不是部署機。#648 驗收的那一條需要 operator 在部署機上跑；程式碼側的不變式與交接已由上述
測試在真 git repo 上端到端覆蓋。

## Checklist

- [x] 分支不是 `main`（`feature/648-canonical-per-job-workspace`）
- [x] `changelog.d/canonical-per-job-workspace.md` fragment 已新增且已 commit
- [x] `CHANGELOG.md [Unreleased]` 有對應 entry
- [x] `VERSION` 未改（非 release PR）
- [x] `python3 -m pytest tests/ -q` 全綠
- [x] `policy_check` 帶 PR 上下文跑，fail: 0
- [x] 文件與 PR 一律 zh-tw
- [x] docs 同步（Phase 2b runbook 的 `%i` 稽核段補上 canonical lane 的 per-job 說明與實機稽核）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E7w9kaUxAzCCEk7piD5hfK
