### PR TITLE
feat(coordinator): ship phase 的成果回收——archive commit 進來源樹，ancestry 檢查回到成立

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,50 @@
 ## [Unreleased]
 
 ### Added
+- **#649 / trust-root Phase 2b：ship phase 的成果回收——`openspec-archive` 的 commit
+  沒有進來源樹，`matches_candidate()` 的 ancestry 檢查因此是條死路**——票上的第一步是
+  查證，而查證結果改變了範圍。**(1) ship 卡不是降權派工的對象**：兩張 ship 卡的
+  persona 是 `manager`，而 `_dispatch_workflow_card()` 對 `current_phase == "ship"`
+  一律回 `None`——它們不經 launcher、不 spawn job，由 Manager 自己在 `work_bridge` 內
+  以 deterministic 身分執行。沒有 template unit、沒有 `ReadWritePaths=<pool>/%i`、
+  沒有 `226/NAMESPACE`；#649 票上「#648 的症狀在 ship phase 原封不動」這句不成立。
+  **(2) `matches_candidate()` 的 ancestry 檢查目前是壞的**：它只在 post-archive
+  repair 走到，並在 `run.workspace_root` 上跑 `merge-base --is-ancestor`；而 archive
+  commit 是 Manager 在**工作區**裡做的，#623 改成 per-job 完整 clone（各自的 object
+  store）之後來源樹沒有它 ⇒ git 回 **128**（`Not a valid commit name`，不是 1）⇒
+  該卡被濾掉 ⇒ ship audit fail-closed。既有測試綠著，是因為它的 fixture 把兩個 commit
+  都直接做在來源樹裡（#623 之前共用 object store 的形狀）。**(3) #651 讓同一個缺口多
+  長一個症狀**：build 卡改 per-job 之後 base ＝ `run.candidate_head`，post-archive 的
+  `retry-build` 因此拿 archive commit 當 base 去 provision，而 creator 的第一道守衛是
+  在來源樹 `rev-parse --verify <base>` ⇒ `git worktree base invalid`，重派連工作區都
+  建不起來。**回收模型選 (a)**（票上兩條路）：archive commit **就是**下一輪的
+  candidate（reset 之後 verify／review 對著它重跑、`_builder_binding()` 以它選工作區、
+  PR 推的也是它），把它排除在鏈外等於重寫整條 post-archive 語意，不是縮小範圍。沿用
+  #637 的 bundle ＋ append-only spool，但 **producer 換成 Manager 自己**——新增
+  `job_workspace.publish_commit_bundle()`（in-process 版的 `build_bundle_command()`），
+  consumer 那一半 `harvest_branch()` 一個位元組不變，「commit 進來源樹」全 repo 仍只有
+  一個實作；刻意不寫 `git -C <來源樹> fetch <那棵工作區>`，那正是 `job_workspace` 模組
+  docstring 已判定在三分下結構性不成立的形狀。順序是 `git commit` →
+  `reserve_job_id()` → 建 spool → 產 bundle → harvest → **回收後 branch head 必須恰等
+  於新 commit** → 才 `_record_manager_ship_job()` 與 `_manager_reset_workflow_after_archive()`；
+  `candidate_head` 一旦推進，整條鏈就開始假設來源樹有那個 commit，回收失敗必須擋在推進
+  之前。兩道附帶守衛：commit 必須在記錄的 branch 上（detached HEAD fail-closed）、
+  bundle 的排除點依來源樹有沒有那個 commit 決定（沒有就帶完整歷史，不讓缺
+  prerequisite 弄垮一次合法的回收）。**`matches_candidate()` 沒改**——修的是它的前提。
+  **範圍切分**：票上第 3 點「ship 卡的工作區改 per-job」**不做**，因為查證推翻了它的
+  動機（`%i` 不變式落不到 ship 卡上），並換上一個更大也更真的需求——ship 段全程在
+  **builder 的 clone** 裡動手（`git commit`／preflight／push／`_ship_action` 都在那裡），
+  而 #641 已把 Manager 對 job 工作樹的讀取授權全部收掉 ⇒ 降權模式下會在第一個
+  `git -C` 就 `Permission denied`。修法是把 ship 段搬進 Manager-owned 的樹（此時
+  per-job 目錄名才有意義），連帶處理 `_builder_binding()` 的來源與
+  `archive-applied-needs-commit` 重入路徑，已開後續票，且**必須**建立在本 PR 的回收
+  通道之上。新增 `tests/test_ship_phase_harvest_649.py`（9 條，全部跑正式路徑：真 git
+  repo、真 per-job clone、真 `ScriptWorktreeCreator`），含回收不變式、`rmtree` 後仍取
+  得成果、fail-closed 且不先推進、ancestry 正反兩向、`openspec-archive` →
+  `policy-commit` 接續、spool 定址、`direct` 零回歸；spool 封口對 producer 的強制力需要
+  不同 UID ＋ per-account ACL，單 UID 環境**明確 skip 並說明**（#638 的教訓），skip
+  之前先斷言可測的那一半。突變驗證：拿掉 harvest 之後 9 條轉紅 8 條。
+  詳見 `changelog.d/ship-phase-harvest.md`。
 - **#615 / trust-root Phase 2b M2：reviewer／planner 啟動面降權——三分的另外一半**——
   M1（#584／#603）之後三分只在**檔案權限層**成立：`cortex-reviewer-planner` 帳號、
   HOME、cache、verdict spool 的 `wx` 無 `r` ACL、gitconfig 全部到位，但

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@
   而 #641 已把 Manager 對 job 工作樹的讀取授權全部收掉 ⇒ 降權模式下會在第一個
   `git -C` 就 `Permission denied`。修法是把 ship 段搬進 Manager-owned 的樹（此時
   per-job 目錄名才有意義），連帶處理 `_builder_binding()` 的來源與
-  `archive-applied-needs-commit` 重入路徑，已開後續票，且**必須**建立在本 PR 的回收
+  `archive-applied-needs-commit` 重入路徑，已開後續票 #653，且**必須**建立在本 PR 的回收
   通道之上。新增 `tests/test_ship_phase_harvest_649.py`（9 條，全部跑正式路徑：真 git
   repo、真 per-job clone、真 `ScriptWorktreeCreator`），含回收不變式、`rmtree` 後仍取
   得成果、fail-closed 且不先推進、ancestry 正反兩向、`openspec-archive` →

--- a/changelog.d/ship-phase-harvest.md
+++ b/changelog.d/ship-phase-harvest.md
@@ -146,7 +146,7 @@ post-archive retry-build 的 clone base、下一張卡的 handoff base）就開�
   有意義），連帶要處理 `_builder_binding()` 的來源、`archive-applied-needs-commit`
   這條重入路徑、preflight／push／`_ship_action` 的 repo_root。那是獨立一票的體量，
   且**必須**建立在本 PR 的回收通道之上（沒有回收，換了樹之後 candidate 更是回不來）。
-  已開後續票追。
+  已開後續票 #653 追。
 
 本 PR 因此是「能獨立驗證的第一段」：它自己就修好三個現行缺陷（ancestry 死路、
 #651 的 post-archive retry-build 回歸、成果只存在於某棵工作區的磁碟上），

--- a/changelog.d/ship-phase-harvest.md
+++ b/changelog.d/ship-phase-harvest.md
@@ -1,0 +1,201 @@
+# Issue #649：ship phase 的成果回收缺席——`openspec-archive` 的 commit 沒有進來源樹
+
+## 查證（本票的第一步，結論改變了範圍）
+
+### 1. ship 卡**不是**降權派工的對象——票上的前提不成立
+
+`openspec-archive`／`policy-commit` 兩張 ship 卡的 `persona_binding` 是 `manager`
+（`deck/data/cards.yaml`；`workflow.py` 的 manifest 也硬性要求 `"ship": "manager"`），
+而 `manager._dispatch_workflow_card()` 的第一道判準是
+
+```python
+if step is None or run.current_phase not in {"plan", "build", "verify", "review"}:
+    return None
+```
+
+**ship phase 永遠回 None**。這兩張卡不經任何 launcher、不 spawn 任何 job——它們由
+Manager 自己在 `work_bridge.py` 內以 deterministic 身分執行
+（`_commit_archive_and_require_reverification()` 直接 `git commit`，
+`_record_manager_ship_job()` 事後補一筆 `executor=cortex-manager` /
+`model_id=deterministic` 的稽核用 job 記錄）。
+
+因此：**沒有 template unit、沒有 `ReadWritePaths=<pool>/%i`、沒有 `226/NAMESPACE`。**
+`launcher._downgraded_mode()` 落不落在 manager persona 上是個假問題——那條路徑根本
+不會被走到。#649 票上「#648 的症狀在 ship phase 原封不動」這句是**錯的**，
+「ship 卡的工作區改 per-job」也因此失去它原本的動機（見「怎麼切的」）。
+
+> 附帶發現（不在本票範圍，另記）：`cards.yaml` 給這兩張卡宣告的
+> `runtime_capabilities: ["provider:github:…", "provider:executor"]`（#369／#442）
+> 掛在 `_runtime_preflight_gate` 上，而那也在 dispatch 路徑內——ship 卡不 dispatch，
+> 那兩條宣告在生產環境同樣無法生效。
+
+### 2. `matches_candidate()` 的 ancestry 檢查：**目前是壞的**（fail-closed）
+
+`manager._validated_ship_steps()` 內的 `matches_candidate()` 容許
+`openspec-archive` 的 `subject_head` 是 final candidate 的**祖先**，並在
+`run.workspace_root`（來源樹）上跑 `git merge-base --is-ancestor`。
+
+- **什麼時候會走到**：只有 post-archive repair——archive commit 之後 review 再度提出
+  阻擋性 findings、operator 下 `retry-build`、builder 在 archive commit 之上做出
+  descendant candidate。正常流程下 `subject_head == candidate` 精確相等，走第一個
+  分支，ancestry 那段碰不到。
+- **走到之後成不成立**：**不成立**。archive commit 是 Manager 在**工作區**裡做的，
+  而 #623 把工作區從 `git worktree`（與來源樹共用 object store）換成 per-job 完整
+  clone 之後，來源樹的 object store 裡**沒有那個 commit**。
+  `git merge-base --is-ancestor <來源樹沒有的 sha> <candidate>` 回 **128**
+  （`fatal: Not a valid commit name`），不是 1；`matches_candidate()` 因此回 False，
+  該卡被濾掉，`_validated_ship_steps()` 以
+  `workflow ship card audit missing or ambiguous: openspec-archive` 中止。
+
+  也就是說：這條檢查在 #623 之後就是一條**只會 fail-closed 的死路**。它是安全的
+  （不會誤放行），但 post-archive repair 這條路走不完。
+- **既有測試為什麼是綠的**：
+  `tests/test_workflow_production_wiring.py::test_ship_audit_accepts_manager_archive_ancestor_after_retry_build`
+  的 fixture 把 archive commit 與 repair commit **都直接做在 `run.workspace_root`
+  裡**——那正是 #623 之前共用 object store 的形狀。fixture 幫產品把前提補上了，
+  於是測試看不到 production 的斷點。
+
+### 3. #651 讓同一個缺口多長出一個症狀
+
+#651 之後 build 卡改成 per-job clone，中段／後續卡的 base 是
+`_workflow_build_handoff_base()` 給的 `run.candidate_head`。post-archive 的
+`retry-build` 因此會拿 **archive commit** 當 base 去 provision，而
+`ScriptWorktreeCreator.create()` 的第一道守衛是在**來源樹**上
+`rev-parse --verify <base>^{commit}`——找不到 ⇒ `git worktree base invalid`，
+重派連工作區都建不起來。（本 PR 的測試把 harvest 拿掉之後，重現的正是這句話。）
+
+## 回收模型：選路 (a)（bundle ＋ append-only spool），producer 換成 Manager
+
+票上兩條路擇一。選 (a)，推導如下：
+
+- **不能選 (b)（「ship 卡的 commit 不進 candidate 鏈」）**：archive commit **就是**
+  下一輪的 candidate——`_manager_reset_workflow_after_archive()` 把
+  `candidate_head` 推到它、verify／review 對著它重跑、`_builder_binding()` 以
+  `subject_head == candidate` 選工作區、`policy-commit` 精確綁 final candidate、
+  PR 推的也是它。把它排除在鏈外等於重寫整條 post-archive 語意，而
+  `matches_candidate()` 的 ancestry 檢查（＋ `governed-delivery-closure` spec 對它的
+  MUST）也得跟著拆——那不是縮小範圍，是換一套設計。
+- **選 (a) 但通道的 producer 是 Manager 自己**：#637 的 bundle ＋ spool 之所以存在，
+  是為了解兩個問題——builder 不能 push 進 Manager 的樹（D2 單向性），以及 Manager
+  走不進 builder 的樹（0700 ＋ `safe.directory` 不吃路徑 glob）。archive commit 由
+  Manager 親手做出來，沒有 wrapper script 可以掛
+  `job_workspace.build_bundle_command()` 那段 shell，但**consumer 那一半必須是同
+  一個**：`harvest_branch()` 是全 repo 唯一的「commit 進來源樹」實作，繞過它另寫一次
+  `git -C <來源樹> fetch <那棵工作區>` 會同時複製一份 fail-closed 分類，並且把
+  `job_workspace` 模組 docstring 明文否決的形狀寫回程式碼（那也正是下一段
+  「ship 工作區搬進 Manager-owned clone」之後必炸的形狀）。
+
+  因此只補 producer 那一半：新增 `job_workspace.publish_commit_bundle()`
+  （in-process 版的 `build_bundle_command()`），spool 那一格沿用
+  `prepare_commit_spool()` / `seal_commit_spool()`，key ＝ 這張 ship 卡的 job_id。
+- **票上「launcher 本來就已經幫 manager persona 建了 spool」這句也不成立**：ship 卡
+  不 launch，`prepare_commit_spool()` 從未為它跑過；`spool_key_for_job()` 由
+  `log_path` 推導，而 ship 卡的 job 記錄沒有 `log_path`。本 PR 因此在 Manager 側
+  顯式配 id、顯式建那一格。
+
+### 落地
+
+`work_bridge._commit_archive_and_require_reverification()` 在
+`git commit` 之後、`_record_manager_ship_job()` 與
+`_manager_reset_workflow_after_archive()` **之前**插入：
+
+```
+registry.reserve_job_id(_manager_ship_job_task(...))       # 先配 id
+  → job_workspace.prepare_commit_spool(spool_key=<那個 id>)
+  → job_workspace.publish_commit_bundle(工作區 → 那一格)
+  → job_workspace.harvest_branch(bundle → 來源樹的 refs/heads/<branch>)
+  → 回收後的 branch head 必須恰等於剛做的 commit，對不上即 fail-closed
+  → seal_commit_spool()
+```
+
+順序不能反過來：`candidate_head` 一旦推進，整條鏈（ship audit 的 ancestry、
+post-archive retry-build 的 clone base、下一張卡的 handoff base）就開始假設來源樹有
+那個 commit；回收失敗必須在推進**之前**擋下，而不是讓錯誤在很遠的地方以看不懂的訊息
+出現。
+
+另外兩道守衛：
+
+- **commit 必須在記錄的 branch 上**（`source_branch_head(worktree, branch) == new_head`）
+  ——回收的 refspec 是 `refs/heads/<branch>`，detached HEAD 或第三方動過 ref 時
+  bundle 帶的就是別的東西。與 `_harvest_build_candidate()` 的 head mismatch 同一條
+  判準。
+- **bundle 的排除點取決於來源樹有沒有那個 commit**（`commit_present()`）：正常情形是
+  `^<archive 之前的 candidate>`，只搬一個 commit；來源樹沒有它時（升級前既存的 run、
+  或從未走過 build harvest 的路徑）改為不排除、帶完整歷史——寧可多搬一點，也不要因為
+  缺 prerequisite 讓一次**合法**的回收失敗。
+
+`matches_candidate()` **一個位元組都沒改**：本 PR 修的是它的前提。archive commit
+回到來源樹之後，那條 ancestry 檢查就回到它原本設計成立的樣子。
+
+## 怎麼切的（範圍縮小，理由是查證結果而不是做不完）
+
+**本 PR 只做成果回收**。票上第 3 點「ship 卡的工作區改 per-job」不做，理由是查證
+推翻了它的動機、並換上一個**更大也更真**的需求：
+
+- **原動機消失**：ship 卡不 dispatch、不 launch，`%i` 不變式落不到它們身上
+  （見查證 1）。照票面把 `reserve_job_id() → creator.create()` 套上去，得到的是
+  一個沒有人會用 `%i` 定址的目錄——為了一個不存在的約束改動整條 ship 路徑。
+- **真正的阻擋物是別的**：ship 段全程在 `_builder_binding()` 交回來的
+  **builder 的 clone** 裡動手（`git diff`／`add`／`commit`／`rev-parse`／`push`、
+  `Path(worktree).resolve(strict=True)`、`_ship_action(repo_root=…)` 連測試都在那裡
+  跑）。Phase 2b 三分下那棵樹是 `cortex-builder` 0700，而 #641 已經把登記表裡
+  Manager 對 job 工作樹殘留的讀取授權**全部收掉**（runbook 第 2 步的稽核 5b 要求
+  `/var/lib/cortex/worktree/` 底下零 setfacl）。也就是說 ship phase 在降權模式下會
+  在**第一個 `git -C`** 就 `Permission denied`——不是 `226/NAMESPACE`。
+- 修法是把 ship 段的 git 工作搬進一棵 **Manager-owned** 的樹（此時 per-job 目錄名才
+  有意義），連帶要處理 `_builder_binding()` 的來源、`archive-applied-needs-commit`
+  這條重入路徑、preflight／push／`_ship_action` 的 repo_root。那是獨立一票的體量，
+  且**必須**建立在本 PR 的回收通道之上（沒有回收，換了樹之後 candidate 更是回不來）。
+  已開後續票追。
+
+本 PR 因此是「能獨立驗證的第一段」：它自己就修好三個現行缺陷（ancestry 死路、
+#651 的 post-archive retry-build 回歸、成果只存在於某棵工作區的磁碟上），
+且不依賴後續票。
+
+## 測試
+
+新增 `tests/test_ship_phase_harvest_649.py`（9 條，全部跑正式路徑：真 git repo、真
+per-job clone、真 `work_bridge._commit_archive_and_require_reverification()`、真
+`seams.ScriptWorktreeCreator`）：
+
+- **回收本身**：archive commit 進來源樹，且 `refs/heads/<branch>` == 新 candidate。
+- **交接不依賴磁碟殘留**：把做 commit 的那棵工作區整個 `rmtree` 掉，commit 與檔案內容
+  仍在來源樹裡讀得出來（#651 對 build 卡釘的是同一個形狀）。
+- **fail-closed 且不先推進**：commit 落在 detached HEAD 上時拒絕回收，且
+  `candidate_head`／`current_phase`／來源樹 branch 全部**原封不動**。
+- **`matches_candidate()` 的 ancestry（本票的查證題）**：正向——回收之後，以 archive
+  commit 為 base 用**真的** `ScriptWorktreeCreator` provision 出 repair clone、做出
+  descendant、harvest 回來，ship audit 兩張卡都 passed（這條同時是 #651
+  post-archive retry-build 的回歸守衛）；反向——archive commit 沒回收時 ship audit
+  fail-closed（＝本 PR 之前的實況）。
+- **`openspec-archive` → `policy-commit` 的接續**：archive 卡的 job 記錄（
+  `subject_head`／`branch`／`persona`／`executor`）就是 `_builder_binding()` 之後會
+  選到的那一筆；`policy-commit` 不產生 commit，來源樹 branch 一個位元組沒動。
+- **spool 定址**：spool key ＝ `reserve_job_id()` 配發的那個 job_id，task 由
+  `_manager_ship_job_task()` 單一推導（兩處字面值不再各寫一次）。
+- **`direct` 零回歸**：`PSC_JOB_RUNNER` 兩種值下走完全相同的路徑，結構性結果逐項
+  相等（#634 的「以形狀判斷，不依旗標分支」）。
+- **#638 的教訓**：spool 封口對 producer 的**強制力**需要 producer 與 consumer 是
+  不同 UID ＋ per-account POSIX ACL，單 UID 的開發機與 CI 都沒有，任何單 UID 模擬都
+  與真部署無關 ⇒ **明確 `pytest.skip` 並說明**，skip 之前先斷言可測的那一半（封口真的
+  發生）。
+
+**突變驗證**：把 harvest 那一行停掉之後，上述 9 條有 8 條轉紅（唯一仍綠的是那條反向
+的 fail-closed 測試，符合預期），其中 ancestry 那條紅在
+`git worktree base invalid: fatal: Needed a single revision`——正是 #651 的
+post-archive retry-build 回歸的逐字現場。
+
+既有測試的更新都是同一件事的直接後果：三個 fixture 把「工作區 ＝ 來源樹」改成
+#623 之後的真實形狀（來源樹持有 delivery branch 但不 checkout，工作區是另一棵
+checkout 在該 branch 上的 clone）。共用 helper `tests/git_fixtures.py:make_job_clone()`。
+沒有這一步，`git fetch` 會撞上「拒絕寫入正被 checkout 的 branch」——那是 fixture 的
+問題不是產品的。
+
+`python3 -m pytest tests/ -q`：**3900 passed, 7 skipped**。
+
+## 未做的實機驗證
+
+`PSC_JOB_RUNNER=systemd-template` 下跑完一個含 ship phase 的 run **尚未實機執行**
+——本機不是部署機，且依上面的查證，ship phase 在降權模式下還會卡在
+「Manager 讀不進 builder 的 clone」，那是後續票的範圍。本 PR 的不變式已由上述測試在
+真 git repo 上端到端覆蓋。

--- a/docs/superpowers/runbooks/trust-root-phase2b-setup.md
+++ b/docs/superpowers/runbooks/trust-root-phase2b-setup.md
@@ -1921,6 +1921,21 @@ systemctl cat cortex-job@.service | grep -E "^ReadWritePaths=/var/lib/cortex/wor
 #   實機稽核：一個多卡 run 跑完後，pool 底下該有**每張 build 卡各一個**目錄，
 #   且每個目錄名都能在 `systemctl list-units 'cortex-job*@*'` 的 instance 名裡找到。
 #     ls /var/lib/cortex/worktree
+#
+#   #649（範圍界線，避免誤查）：**ship phase 的兩張卡不在這條稽核裡**。
+#   `openspec-archive`／`policy-commit` 的 persona 是 `manager`，而
+#   `manager._dispatch_workflow_card()` 對 `current_phase == "ship"` 一律回 None
+#   ——它們不經 launcher、不 spawn job，因此 pool 底下**不會**、也不該出現 ship 卡的
+#   目錄，`systemctl list-units` 上也不會有它們的 instance。ship 卡由 Manager 自己
+#   在 `work_bridge` 內以 deterministic 身分執行，它的 commit 走的是 #649 補上的
+#   回收通道（bundle ＋ commit-spool → 來源樹的 `refs/heads/<branch>`）。
+#
+#   **ship phase 目前仍不可在降權模式下跑完**：它全程在 `_builder_binding()` 交回來的
+#   **builder 的 clone** 裡動手（`git commit`／preflight／push／`_ship_action`），而
+#   #641 已把登記表裡 Manager 對 job 工作樹的讀取授權全部收掉（見第 2 步的稽核 5b）
+#   ⇒ 三分下第一個 `git -C` 就會 `Permission denied`。症狀是**權限**不是
+#   `226/NAMESPACE`，別往 mount namespace 的方向查。修法（ship 段搬進 Manager-owned
+#   的樹）在後續票。
 
 # ✅ 檢查 unit 沒有被忽略的鍵（#645 附帶；#643 起兩份都要驗）
 sudo systemd-analyze verify /etc/systemd/system/cortex-job@.service \

--- a/docs/superpowers/runbooks/trust-root-phase2b-setup.md
+++ b/docs/superpowers/runbooks/trust-root-phase2b-setup.md
@@ -1935,7 +1935,7 @@ systemctl cat cortex-job@.service | grep -E "^ReadWritePaths=/var/lib/cortex/wor
 #   #641 已把登記表裡 Manager 對 job 工作樹的讀取授權全部收掉（見第 2 步的稽核 5b）
 #   ⇒ 三分下第一個 `git -C` 就會 `Permission denied`。症狀是**權限**不是
 #   `226/NAMESPACE`，別往 mount namespace 的方向查。修法（ship 段搬進 Manager-owned
-#   的樹）在後續票。
+#   的樹）在 #653。
 
 # ✅ 檢查 unit 沒有被忽略的鍵（#645 附帶；#643 起兩份都要驗）
 sudo systemd-analyze verify /etc/systemd/system/cortex-job@.service \

--- a/paulsha_cortex/coordinator/job_workspace.py
+++ b/paulsha_cortex/coordinator/job_workspace.py
@@ -580,9 +580,82 @@ def build_bundle_command(*, workspace: str | Path, bundle: str | Path) -> str:
     )
 
 
+def publish_commit_bundle(
+    *,
+    workspace: str | Path,
+    bundle: str | Path,
+    branch: str,
+    exclude: str | None,
+) -> Path:
+    """#649：**in-process 版**的 :func:`build_bundle_command`——producer 是 Manager
+    自己，不是 wrapper script 驅動的 builder。
+
+    存在的理由：ship phase 的 `openspec-archive` commit 由 **Manager 親手**做出來
+    （`work_bridge._commit_archive_and_require_reverification` 直接 `git commit`），
+    不是任何 job 的模型產物，因此沒有 wrapper script 可以掛那段 shell。但**回收
+    通道必須是同一條**——`harvest_branch()` 是「commit 進來源樹」的唯一實作，繞過
+    它另寫一次 `git fetch <某棵樹>` 會同時複製一份 fail-closed 分類，而且會把
+    「Manager fetch 一棵 job 的樹」這個模組 docstring 明文否決的形狀寫回程式碼。
+
+    因此這裡只補 producer 那一半：把 bundle 產出來，交給既有的 consumer 那一半。
+
+    - **正向 ref 寫死 `refs/heads/<branch>`**（不是 `symbolic-ref HEAD`）：呼叫端
+      是 Manager，branch 是它自己記錄的權威值；用 HEAD 反而會在 detached 時發表
+      一個 ref 名對不上的 bundle。
+    - **負向 ref 由呼叫端決定**（`exclude`），而不是寫死 :data:`BASE_REF`：Manager
+      要排除的是「來源樹**已經有**的那個 commit」（＝已被採信的 candidate），而
+      `refs/cortex/base` 是那棵 clone 自己 provision 當下的 pin，兩者不同。
+      `exclude=None` ⇒ 不排除任何東西，bundle 帶完整歷史、無 prerequisite——留給
+      「來源樹沒有那個 commit」的情形（升級前的既有 run、沒有走過 build harvest
+      的測試路徑），否則 `harvest_branch()` 會因缺 prerequisite 而 fail-closed。
+    - `.part` → 放寬 → `mv`：與 wrapper 那條逐條相同，spool 裡看得見的
+      `commits.bundle` 恆為完整檔。
+
+    `git bundle create` 對「沒有任何 commit 可帶」會拒絕產出（空 bundle）——那在
+    這條路徑上是真的出事（Manager 剛做完一個 commit），因此一律 raise，不回 None。
+    """
+
+    if not branch:
+        raise WorkspaceError("commit bundle publication requires a branch name")
+    bundle_path = Path(bundle)
+    if bundle_path.is_symlink() or bundle_path.parent.is_symlink():
+        raise WorkspaceError(f"job workspace commit bundle is a symlink: {bundle_path}")
+    part = bundle_path.with_name(bundle_path.name + COMMIT_BUNDLE_PART_SUFFIX)
+    part.unlink(missing_ok=True)
+    argv = ["-C", str(workspace), "bundle", "create", str(part), f"refs/heads/{branch}"]
+    if exclude is not None:
+        if _SHA_RE.fullmatch(exclude.lower()) is None:
+            raise WorkspaceError(f"commit bundle exclusion is not a commit sha: {exclude!r}")
+        argv.append(f"^{exclude.lower()}")
+    proc = _git(argv)
+    if proc.returncode != 0 or not part.is_file():
+        part.unlink(missing_ok=True)
+        raise WorkspaceError(
+            f"commit bundle creation failed: {(proc.stderr or proc.stdout).strip()}"
+            f"；工作區 {workspace} 的 refs/heads/{branch} 產不出 bundle。"
+            "常見原因：branch 不存在於該工作區、或排除範圍已涵蓋全部 commit"
+            "（`git bundle create` 拒絕產生空 bundle）"
+        )
+    spool_slot.publish_file(part)
+    part.replace(bundle_path)
+    return bundle_path
+
+
 # ---------------------------------------------------------------------------
 # 成果回收（Manager 拉，builder 不推）
 # ---------------------------------------------------------------------------
+
+def commit_present(repo: str | Path, sha: str) -> bool:
+    """`repo` 的 object store 裡有沒有這個 commit（#649）。
+
+    用途只有一個：決定 :func:`publish_commit_bundle` 的 `exclude` 能不能用——
+    bundle 的 prerequisite 必須是**來源樹已經有**的 commit，否則 `harvest_branch()`
+    會在 fetch 那一步以「prerequisite 缺席」fail-closed。
+    """
+
+    if not isinstance(sha, str) or _SHA_RE.fullmatch(sha.lower()) is None:
+        return False
+    return _git(["-C", str(repo), "rev-parse", "--verify", "--quiet", f"{sha.lower()}^{{commit}}"]).returncode == 0
 
 def source_branch_head(source_repo: str | Path, branch: str) -> str | None:
     """來源樹上 `refs/heads/<branch>` 現在指到哪；不存在／不可讀時回 None。"""

--- a/paulsha_cortex/coordinator/work_bridge.py
+++ b/paulsha_cortex/coordinator/work_bridge.py
@@ -31,6 +31,7 @@ from paulsha_cortex.deck.schema import (
 )
 from paulsha_cortex.deck.task_types import load_task_types
 
+from . import job_workspace
 from . import verification
 from .claim import (
     WorkAuthority,
@@ -874,6 +875,103 @@ def _archive_path_allowed(path: str, *, change: str) -> bool:
     )
 
 
+def _manager_ship_job_task(*, run, card: str) -> str:
+    """ship 卡那一筆 job 記錄的 `task`——**唯一推導點**（#649）。
+
+    `reserve_job_id()` 與 `create_job()` 必須拿到逐字相同的 task（registry 會驗
+    「這個 id 確實屬於同一個 task」），因此不再讓兩處各自組一次字串。與
+    `manager._dispatch_workflow_card()` 的 build／verify／review 卡同一個公式。
+    """
+
+    return f"wf-{hashlib.sha256(run.run_id.encode()).hexdigest()[:10]}-{card}"
+
+
+def _harvest_manager_ship_commit(
+    *,
+    state_root: Path,
+    run,
+    worktree: Path,
+    branch: str,
+    spool_key: str,
+    baseline: str,
+    new_head: str,
+) -> str:
+    """#649：把 ship phase 的 Manager commit 收進**來源樹**的 `refs/heads/<branch>`。
+
+    ## 為什麼 ship phase 需要這條通道
+
+    build phase 的每一張卡在被採信之後都會走 `manager._harvest_build_candidate()`，
+    因此
+
+        來源樹的 `refs/heads/<branch>` == `run.candidate_head`
+
+    在每一張 build 卡之後成立。`openspec-archive` 是**唯一會產生 commit 的 ship
+    卡**（`policy-commit` 的 `new_head == old_head`，不 commit），而它做完 commit 之後
+    `_manager_reset_workflow_after_archive()` 會把 `candidate_head` 推進到那個新
+    commit——**但那個 commit 只存在於做 commit 的那棵工作樹裡**。#623 把工作區從
+    `git worktree`（共用 object store）換成 per-job 完整 clone 之後，「順便就在來源樹
+    裡」這件事不再成立，上面那條不變式因此在 ship phase 斷掉。三個已知後果：
+
+    1. `manager._validated_ship_steps()` 的 `matches_candidate()` 對 post-archive
+       repair 允許 `openspec-archive` 的 `subject_head` 是 final candidate 的祖先，
+       而那條 ancestry 檢查跑在 `run.workspace_root` 上——來源樹沒有 archive commit
+       時 `git merge-base --is-ancestor` 回 128（`Not a valid commit name`），
+       `matches_candidate()` 回 False，整個 ship audit fail-closed。
+    2. #651 之後 build 卡改成 per-job clone，base ＝ `run.candidate_head`。
+       post-archive 的 `retry-build` 因此會拿 archive commit 當 base 去 provision，
+       而 `ScriptWorktreeCreator.create()` 的 `rev-parse --verify <base>` 在來源樹
+       上找不到它 ⇒ `git worktree base invalid`，重派直接起不來。
+    3. 「成果只在磁碟上的某一棵工作區裡」本身就是 #637／#651 要消除的形狀——
+       那棵樹被回收（`cortex work gc`）之後 commit 就沒了。
+
+    ## 通道形狀：沿用 #637 的 bundle ＋ append-only spool
+
+    producer 換成 Manager 自己（見 `job_workspace.publish_commit_bundle()`），
+    consumer 那一半（`harvest_branch()`）一個位元組不變：**「commit 進來源樹」全
+    repo 仍然只有一個實作**，fail-closed 分類、非 fast-forward 拒絕、prerequisite
+    診斷全部沿用。刻意不走 `git -C <來源樹> fetch <那棵工作區>`——`job_workspace`
+    模組 docstring 已判定那個形狀在三分部署下結構性不成立（Manager 走不進 job 的樹、
+    `safe.directory` 不吃路徑 glob），寫回來等於預先埋一顆下一階段必炸的雷。
+
+    ## 回收後的不變式
+
+    來源樹的 `refs/heads/<branch>` 必須**恰等於**剛做出來的 commit，對不上即
+    fail-closed——與 `_harvest_build_candidate()` 逐條相同的判準。呼叫端在這之後
+    才推進 `candidate_head`，因此「採信值」與「來源樹實況」不會分岔。
+
+    `baseline` 是 bundle 的排除點（＝ archive 之前那個已被採信的 candidate）。
+    來源樹沒有它時（升級前既存的 run、或沒走過 build harvest 的路徑）改為不排除，
+    bundle 帶完整歷史——寧可多搬一點，也不要因為缺 prerequisite 而讓一次**合法**的
+    回收失敗。
+    """
+
+    source_repo = getattr(run, "workspace_root", None)
+    if not isinstance(source_repo, str) or not source_repo:
+        raise RuntimeError("manager ship commit harvest source repo missing")
+    # 回收的 refspec 是 `refs/heads/<branch>`——commit 若不在那條 ref 上（detached
+    # HEAD、或第三方在 commit 之後動過 ref），bundle 帶的就是別的東西。與
+    # `_harvest_build_candidate()` 的 head mismatch 同一條判準，先擋在這裡讓訊息說
+    # 得出成因，而不是讓 `git bundle create` 丟一句 `ambiguous argument`。
+    if job_workspace.source_branch_head(worktree, branch) != new_head.lower():
+        raise RuntimeError("manager ship commit is not on the recorded branch")
+    bundle = job_workspace.prepare_commit_spool(
+        spool_key=spool_key, coordinator_root=state_root
+    )
+    job_workspace.publish_commit_bundle(
+        workspace=worktree,
+        bundle=bundle,
+        branch=branch,
+        exclude=baseline if job_workspace.commit_present(source_repo, baseline) else None,
+    )
+    harvested = job_workspace.harvest_branch(
+        source_repo=source_repo, bundle=bundle, branch=branch
+    )
+    if harvested.lower() != new_head.lower():
+        raise RuntimeError("manager ship commit harvest head mismatch")
+    job_workspace.seal_commit_spool(bundle)
+    return harvested
+
+
 def _record_manager_ship_job(
     *,
     registry,
@@ -884,6 +982,7 @@ def _record_manager_ship_job(
     card: str,
     old_head: str,
     new_head: str,
+    job_id: str | None = None,
 ):
     existing = [
         job
@@ -901,7 +1000,11 @@ def _record_manager_ship_job(
     if existing:
         raise RuntimeError("manager ship card audit is ambiguous")
     job = registry.create_job(
-        task=f"wf-{hashlib.sha256(run.run_id.encode()).hexdigest()[:10]}-{card}",
+        task=_manager_ship_job_task(run=run, card=card),
+        # #649：job_id 由呼叫端先 `reserve_job_id()` 取得——回收那一格的 spool key
+        # 就是它，而 spool 必須在 job 之前建立（bundle 得先落地才 harvest 得動）。
+        # 順序與 #648 的 build 卡逐條相同：先配 id → 用它定址 → 再建 job。
+        job_id=job_id,
         persona="manager",
         kind="build",
         branch=branch,
@@ -1032,6 +1135,23 @@ def _commit_archive_and_require_reverification(
     new_head = head.stdout.strip().lower()
     if head.returncode != 0 or verification.SAFE_SHA_RE.fullmatch(new_head) is None or new_head == candidate:
         raise RuntimeError("archive commit did not produce a new exact Candidate")
+    # #649：ship phase 的**成果回收**。這一步排在 `_record_manager_ship_job()` 與
+    # `_manager_reset_workflow_after_archive()` **之前**：candidate_head 一旦推進到
+    # archive commit，整條鏈（ship audit 的 ancestry、post-archive retry-build 的
+    # clone base、下一張卡的 handoff base）就會假設來源樹有它。回收失敗時必須在推
+    # 進之前 fail-closed，而不是先推進再讓後面某一段以看不懂的訊息炸開。
+    job_id = registry.reserve_job_id(
+        _manager_ship_job_task(run=run, card="openspec-archive")
+    )
+    _harvest_manager_ship_commit(
+        state_root=state_root,
+        run=run,
+        worktree=worktree,
+        branch=branch,
+        spool_key=job_id,
+        baseline=candidate,
+        new_head=new_head,
+    )
     _record_manager_ship_job(
         registry=registry,
         state_root=state_root,
@@ -1041,6 +1161,7 @@ def _commit_archive_and_require_reverification(
         card="openspec-archive",
         old_head=candidate,
         new_head=new_head,
+        job_id=job_id,
     )
     return registry._manager_reset_workflow_after_archive(
         run.run_id,

--- a/tests/git_fixtures.py
+++ b/tests/git_fixtures.py
@@ -13,7 +13,29 @@
 
 from __future__ import annotations
 
+import subprocess
 from pathlib import Path
+
+
+def make_job_clone(source: Path, target: Path, *, branch: str) -> Path:
+    """#649：造出一棵**真的** per-job clone（#623 之後工作區的實際形狀）。
+
+    來源樹與工作區是兩個獨立的 object store，工作區 checkout 在 `<branch>` 上，
+    來源樹留在自己的預設 branch——那正是成果回收（`job_workspace.harvest_branch()`）
+    能成立的前提：`git fetch` **拒絕**寫入一條正被 checkout 的 branch。
+
+    測試若把工作區與來源樹寫成同一個目錄（#623 之前 `git worktree` 共用 object
+    store 時的殘留寫法），回收路徑會撞上那條拒絕，而那是 fixture 的問題不是產品的。
+    """
+
+    subprocess.run(
+        ["git", "clone", "-q", "--branch", branch, str(source), str(target)], check=True
+    )
+    subprocess.run(
+        ["git", "-C", str(target), "config", "user.email", "test@example.com"], check=True
+    )
+    subprocess.run(["git", "-C", str(target), "config", "user.name", "Test"], check=True)
+    return target
 
 
 def make_fake_repo(root: Path, *, branch: str = "main") -> Path:

--- a/tests/test_preflight_closeout_order.py
+++ b/tests/test_preflight_closeout_order.py
@@ -11,7 +11,13 @@ from types import SimpleNamespace
 
 import pytest
 
-from paulsha_cortex.coordinator import manager, review, work_actions, work_bridge
+from paulsha_cortex.coordinator import (
+    job_workspace,
+    manager,
+    review,
+    work_actions,
+    work_bridge,
+)
 from paulsha_cortex.coordinator.claim import load_work_authority, work_authority_digest
 from paulsha_cortex.coordinator.model_identities import IdentityRegistry
 from paulsha_cortex.coordinator.registry import JobRegistry
@@ -20,6 +26,8 @@ from paulsha_cortex.coordinator.workflow import (
     PlanningArtifactAuthority,
     WorkflowStep,
 )
+
+from git_fixtures import make_job_clone
 
 
 @dataclass
@@ -38,6 +46,8 @@ class RunnerResult:
 @dataclass
 class ShipHarness:
     repo: Path
+    #: #649：ship 段實際操作的工作區（per-job clone），與來源樹 `repo` 是兩棵樹。
+    worktree: Path
     candidate: str
     snapshot: Path
     state_root: Path
@@ -207,6 +217,10 @@ def _repo(root: Path, *, active_change: bool, archived_change: bool) -> tuple[Pa
         (target / "tasks.md").write_text("- [x] ready\n", encoding="utf-8")
     subprocess.run(["git", "-C", str(root), "add", "."], check=True)
     subprocess.run(["git", "-C", str(root), "commit", "-qm", "init"], check=True)
+    # #649：來源樹持有 delivery branch 但**不 checkout** 它——ship 卡的成果回收是
+    # `git fetch <bundle> refs/heads/<b>:refs/heads/<b>`，git 拒絕寫入正被 checkout
+    # 的 branch。production 的來源樹本來就停在預設 branch。
+    subprocess.run(["git", "-C", str(root), "branch", "feature/14-work"], check=True)
     head = subprocess.run(
         ["git", "-C", str(root), "rev-parse", "HEAD"],
         check=True,
@@ -285,14 +299,25 @@ def _steps(*, review_passed: bool) -> tuple[WorkflowStep, ...]:
     return tuple(steps)
 
 
-def _seed_foreign_review(*, registry: JobRegistry, run, repo: Path, candidate: str, state_root: Path) -> None:
+def _seed_foreign_review(
+    *,
+    registry: JobRegistry,
+    run,
+    repo: Path,
+    candidate: str,
+    state_root: Path,
+    worktree: Path | None = None,
+) -> None:
+    #: #649：builder job 記錄的 `worktree` 就是 ship 段會拿到的工作區
+    #: （`work_bridge._builder_binding`），預設仍是來源樹本身以維持既有呼叫端。
+    worktree = repo if worktree is None else worktree
     builder = registry.create_job(
         task="wf-build",
         persona="builder",
         kind="build",
         branch="feature/14-work",
         pane="",
-        worktree=str(repo),
+        worktree=str(worktree),
         executor="codex",
         model_id="gpt",
         independence_domain="openai",
@@ -302,7 +327,7 @@ def _seed_foreign_review(*, registry: JobRegistry, run, repo: Path, candidate: s
         workflow_repo=run.repo,
         workflow_card="build-card",
         workflow_phase="build",
-        workflow_repo_root=str(repo),
+        workflow_repo_root=str(worktree),
         source_revision=run.source_revision,
     )
     registry.update_headless_result(builder["job_id"], status="exited", exit_code=0)
@@ -313,7 +338,7 @@ def _seed_foreign_review(*, registry: JobRegistry, run, repo: Path, candidate: s
         kind="review",
         branch="feature/14-work",
         pane="",
-        worktree=str(repo),
+        worktree=str(worktree),
         executor="claude",
         model_id="sonnet",
         independence_domain="anthropic",
@@ -323,7 +348,7 @@ def _seed_foreign_review(*, registry: JobRegistry, run, repo: Path, candidate: s
         workflow_repo=run.repo,
         workflow_card="review-card",
         workflow_phase="review",
-        workflow_repo_root=str(repo),
+        workflow_repo_root=str(worktree),
         workflow_outputs=(report_ref,),
         workflow_output_baseline=(),
         source_revision=run.source_revision,
@@ -349,7 +374,9 @@ def _seed_foreign_review(*, registry: JobRegistry, run, repo: Path, candidate: s
             },
         },
     )
-    report = repo / report_ref
+    # #649：canonical report 發表在 candidate 樹（＝工作區），delivery 的清理段
+    # 也在那裡找它。
+    report = worktree / report_ref
     report.parent.mkdir(parents=True, exist_ok=True)
     report.write_text("# Canonical review\n", encoding="utf-8")
     report_hash = hashlib.sha256(report.read_bytes()).hexdigest()
@@ -430,15 +457,17 @@ def _ship_harness(
         verified_head=candidate,
         gate_status="running",
     )
+    worktree = make_job_clone(repo, tmp_path / "job-worktree", branch="feature/14-work")
     _seed_foreign_review(
         registry=registry,
         run=run,
         repo=repo,
         candidate=candidate,
         state_root=state_root,
+        worktree=worktree,
     )
     runner = SpyRunner(
-        repo=repo,
+        repo=worktree,
         metadata_preflight_returncode=metadata_preflight_returncode,
     )
     monkeypatch.setattr(work_bridge, "load_preflight_command", lambda: ("preflight",))
@@ -451,6 +480,7 @@ def _ship_harness(
     )
     return ShipHarness(
         repo=repo,
+        worktree=worktree,
         candidate=candidate,
         snapshot=snapshot,
         state_root=state_root,
@@ -574,7 +604,12 @@ def test_ship_validate_completes_local_archive_closeout_without_pr_binding(
     assert updated.current_phase == "verify"
     assert updated.candidate_head is not None and updated.candidate_head != harness.candidate
     assert updated.pr_refs == ()
-    assert not (harness.repo / "openspec" / "changes" / "work").exists()
+    assert not (harness.worktree / "openspec" / "changes" / "work").exists()
+    # #649：archive commit 已回收進來源樹的 delivery branch。
+    assert (
+        job_workspace.source_branch_head(harness.repo, "feature/14-work")
+        == updated.candidate_head
+    )
     assert not harness.runner.saw_push()
     assert not harness.runner.saw_gh()
 
@@ -682,8 +717,10 @@ def test_pr_created_automatically_after_closeout_and_preflight_pass(
 
 def test_archive_commit_does_not_push(tmp_path: Path) -> None:
     repo, _initial = _repo(tmp_path / "archive-repo", active_change=True, archived_change=False)
-    active = repo / "openspec" / "changes" / "work"
-    archived = repo / "openspec" / "changes" / "archive" / "work"
+    # #649：archive 的檔案異動落在工作區（per-job clone），不是來源樹。
+    worktree = make_job_clone(repo, tmp_path / "archive-worktree", branch="feature/14-work")
+    active = worktree / "openspec" / "changes" / "work"
+    archived = worktree / "openspec" / "changes" / "archive" / "work"
     archived.parent.mkdir(parents=True, exist_ok=True)
     shutil.move(str(active), str(archived))
     candidate = subprocess.run(
@@ -719,14 +756,14 @@ def test_archive_commit_does_not_push(tmp_path: Path) -> None:
         verified_head=candidate,
         gate_status="running",
     )
-    runner = SpyRunner(repo=repo)
+    runner = SpyRunner(repo=worktree)
 
     reset = work_bridge._commit_archive_and_require_reverification(
         registry=registry,
         state_root=state_root,
         run=run,
         authority=authority,
-        worktree=repo,
+        worktree=worktree,
         branch="feature/14-work",
         candidate=candidate,
         runner=runner,
@@ -735,6 +772,10 @@ def test_archive_commit_does_not_push(tmp_path: Path) -> None:
     assert reset.current_phase == "verify"
     assert reset.candidate_head != candidate
     assert not runner.saw_push()
+    # #649：不 push，但**要**回收——來源樹的 delivery branch 必須就是新 candidate。
+    assert (
+        job_workspace.source_branch_head(repo, "feature/14-work") == reset.candidate_head
+    )
 
 
 def test_reviewer_dispatch_fail_closed_on_frozen_hash_drift(tmp_path: Path) -> None:

--- a/tests/test_ship_phase_harvest_649.py
+++ b/tests/test_ship_phase_harvest_649.py
@@ -1,0 +1,595 @@
+"""#649：ship phase 的成果回收——`openspec-archive` 的 commit 必須進來源樹。
+
+本檔全部跑**正式路徑**：真的 git repo、真的 per-job clone、真的
+`work_bridge._commit_archive_and_require_reverification()`、真的
+`seams.ScriptWorktreeCreator`。不手動 `git push`／不自己捏 registry 狀態。
+
+查證結論（見 PR body）：`manager._validated_ship_steps()` 的 `matches_candidate()`
+容許 `openspec-archive` 的 `subject_head` 是 final candidate 的**祖先**，而那條
+ancestry 檢查跑在 `run.workspace_root`（來源樹）上。#623 把工作區從 `git worktree`
+（共用 object store）換成 per-job 完整 clone 之後，archive commit 只存在於做 commit
+的那棵 clone 裡，來源樹沒有它 ⇒ `git merge-base --is-ancestor` 回 **128**
+（`Not a valid commit name`）⇒ `matches_candidate()` 回 False ⇒ 整個 ship audit
+fail-closed。既有測試看不到這件事，是因為它的 fixture 把兩個 commit 都直接做在來源樹
+裡（#623 之前的形狀）。本檔的 `test_ship_audit_ancestry_needs_harvested_archive_commit`
+與 `..._fails_closed_without_harvest` 一正一反把它釘住。
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from dataclasses import replace
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from paulsha_cortex.coordinator import (
+    job_workspace,
+    manager,
+    seams,
+    work_bridge,
+)
+from paulsha_cortex.coordinator.claim import load_work_authority, work_authority_digest
+from paulsha_cortex.coordinator.registry import JobRegistry
+from paulsha_cortex.coordinator.workflow import GateEvidenceRef, WorkflowStep
+
+from git_fixtures import make_job_clone
+
+BRANCH = "feature/14-ship-harvest"
+
+
+def _git(repo: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", "-C", str(repo), *args], check=True, capture_output=True, text=True
+    ).stdout.strip()
+
+
+def _source_repo(root: Path) -> tuple[Path, str]:
+    """來源樹：預設 branch 上有一個 commit，delivery branch 指向它但**不 checkout**。
+
+    這是 build harvest 跑完之後來源樹的實況——`refs/heads/<branch>` ==
+    `run.candidate_head`，而 Manager 自己停在預設 branch。
+    """
+
+    root.mkdir(parents=True)
+    subprocess.run(["git", "init", "-q", str(root)], check=True)
+    _git(root, "config", "user.email", "test@example.com")
+    _git(root, "config", "user.name", "Test")
+    _git(root, "remote", "add", "origin", "git@github.com:acme/demo.git")
+    (root / "README.md").write_text("demo\n", encoding="utf-8")
+    (root / "CHANGELOG.md").write_text("## [Unreleased]\n\n- work\n", encoding="utf-8")
+    change = root / "openspec" / "changes" / "work"
+    change.mkdir(parents=True)
+    (change / "proposal.md").write_text("# Proposal\n", encoding="utf-8")
+    (change / "tasks.md").write_text("- [x] ready\n", encoding="utf-8")
+    todo = root / "docs" / "todo.md"
+    todo.parent.mkdir(parents=True)
+    todo.write_text("- [x] ready\n", encoding="utf-8")
+    _git(root, "add", ".")
+    _git(root, "commit", "-qm", "init")
+    _git(root, "branch", BRANCH)
+    return root, _git(root, "rev-parse", "HEAD")
+
+
+def _snapshot(path: Path) -> Path:
+    path.write_text(
+        json.dumps(
+            {
+                "schema": "work-items-snapshot/v1",
+                "providers": {
+                    "github": {
+                        "provider_id": "github",
+                        "revision": "gh-1",
+                        "last_success_epoch": 100,
+                        "degraded": False,
+                    }
+                },
+                "work_items": [
+                    {
+                        "repo": "acme/demo",
+                        "work_id": "work",
+                        "mapped_issues": [14],
+                        "mapped_prs": [],
+                        "mapped_openspec": ["work"],
+                        "mapped_todo_paths": ["docs/todo.md"],
+                        "confirmed_todo": True,
+                        "auto_label": False,
+                        "source_revisions": [
+                            "github_issue:acme/demo#14@issue-open",
+                            "openspec:acme/demo:work@spec-1",
+                            "todo:acme/demo:docs/todo.md@todo-1",
+                        ],
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _steps() -> tuple[WorkflowStep, ...]:
+    personas = {
+        "claim": "manager",
+        "define": "planner",
+        "plan": "planner",
+        "build": "builder",
+        "verify": "reviewer",
+        "review": "reviewer",
+    }
+    steps = [
+        WorkflowStep(
+            phase=phase,
+            persona=persona,
+            card=f"{phase}-card",
+            executor="codex" if phase == "build" else "claude",
+            model="gpt" if phase == "build" else "sonnet",
+            domain="openai" if phase == "build" else "anthropic",
+            inputs=(),
+            outputs=(),
+            gate_result="passed",
+        )
+        for phase, persona in personas.items()
+    ]
+    steps.append(
+        WorkflowStep("ship", "manager", "openspec-archive", None, None, None, (), ())
+    )
+    steps.append(
+        WorkflowStep("ship", "manager", "policy-commit", None, None, None, (), ())
+    )
+    return tuple(steps)
+
+
+def _run(registry: JobRegistry, *, repo: Path, candidate: str, authority):
+    return registry._manager_create_workflow_run(
+        work_id="work",
+        repo="acme/demo",
+        claim_key="claim:v1:" + "1" * 64,
+        source_revision=work_authority_digest(authority),
+        workspace_root=str(repo),
+        combo="feature-oneshot",
+        current_phase="review",
+        steps=_steps(),
+        issue_refs=("acme/demo#14",),
+        openspec_refs=("work",),
+        pr_refs=(),
+        attempts={"verify": 1, "review": 1},
+        gate_refs=(GateEvidenceRef("foreign-review", "review.json", "1" * 64),),
+        candidate_head=candidate,
+        verified_head=candidate,
+        gate_status="running",
+    )
+
+
+def _apply_archive(worktree: Path) -> None:
+    """把 `openspec archive` 的檔案效果做出來（allowlist 內的異動）。"""
+
+    archived = worktree / "openspec" / "changes" / "archive"
+    archived.mkdir(parents=True, exist_ok=True)
+    (worktree / "openspec" / "changes" / "work").rename(archived / "work")
+    with (worktree / "CHANGELOG.md").open("a", encoding="utf-8") as handle:
+        handle.write("- Archive work.\n")
+
+
+def _archive_fixture(tmp_path: Path) -> SimpleNamespace:
+    """跑到「archive commit 已回收」為止的共用場景。"""
+
+    repo, candidate = _source_repo(tmp_path / "repo")
+    worktree = make_job_clone(repo, tmp_path / "job-worktree", branch=BRANCH)
+    authority = load_work_authority(
+        repo="acme/demo", work_id="work", snapshot_path=_snapshot(tmp_path / "snap.json")
+    )
+    state_root = tmp_path / "state"
+    registry = JobRegistry(state_path=state_root / "jobs.json")
+    run = _run(registry, repo=repo, candidate=candidate, authority=authority)
+    _apply_archive(worktree)
+    reset = work_bridge._commit_archive_and_require_reverification(
+        registry=registry,
+        state_root=state_root,
+        run=run,
+        authority=authority,
+        worktree=worktree,
+        branch=BRANCH,
+        candidate=candidate,
+        runner=lambda *a, **k: SimpleNamespace(returncode=0, stdout="", stderr=""),
+    )
+    return SimpleNamespace(
+        repo=repo,
+        worktree=worktree,
+        authority=authority,
+        state_root=state_root,
+        registry=registry,
+        candidate=candidate,
+        reset=reset,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. 回收本身
+# ---------------------------------------------------------------------------
+
+def test_archive_commit_is_harvested_into_source_tree(tmp_path: Path) -> None:
+    """archive commit 進來源樹，且 `refs/heads/<branch>` == 新 candidate。
+
+    這正是 build phase 在 `_harvest_build_candidate()` 之後成立、而 ship phase 在
+    本票之前不成立的那條不變式。
+    """
+
+    fixture = _archive_fixture(tmp_path)
+    archive_head = fixture.reset.candidate_head
+
+    assert archive_head is not None and archive_head != fixture.candidate
+    assert job_workspace.commit_present(fixture.repo, archive_head)
+    assert job_workspace.source_branch_head(fixture.repo, BRANCH) == archive_head
+    # 採信值與來源樹實況同步：#651 的 `_workflow_build_handoff_base()` 以
+    # `run.candidate_head` 當 clone base，兩者一分岔就會在 creator 的守衛上炸開。
+    assert _git(fixture.repo, "rev-parse", f"refs/heads/{BRANCH}") == archive_head
+
+
+def test_archive_handoff_survives_worktree_removal(tmp_path: Path) -> None:
+    """交接不依賴磁碟殘留：把做 commit 的那棵工作區整個刪掉，成果仍在。
+
+    #651 對 build 卡釘的是同一個形狀；ship 卡在本票之前做不到——archive commit
+    只存在於那棵 clone 的 object store 裡，`rmtree` 一下就沒了。
+    """
+
+    fixture = _archive_fixture(tmp_path)
+    archive_head = fixture.reset.candidate_head
+    shutil.rmtree(fixture.worktree)
+
+    assert not fixture.worktree.exists()
+    assert job_workspace.commit_present(fixture.repo, archive_head)
+    # 成果也真的還讀得出來（不只是 object 還在）。
+    assert "archive/work" in _git(
+        fixture.repo, "ls-tree", "-r", "--name-only", str(archive_head)
+    )
+
+
+def test_archive_harvest_runs_before_candidate_head_advances(tmp_path: Path) -> None:
+    """回收失敗時 fail-closed，且 `candidate_head` **不得**先被推進。
+
+    推進之後才發現來源樹沒有那個 commit，錯誤會在很遠的地方（下一次 provision、
+    或 ship audit）以看不懂的訊息出現——那正是本票要消除的失敗形態。
+    """
+
+    repo, candidate = _source_repo(tmp_path / "repo")
+    worktree = make_job_clone(repo, tmp_path / "job-worktree", branch=BRANCH)
+    authority = load_work_authority(
+        repo="acme/demo", work_id="work", snapshot_path=_snapshot(tmp_path / "snap.json")
+    )
+    state_root = tmp_path / "state"
+    registry = JobRegistry(state_path=state_root / "jobs.json")
+    run = _run(registry, repo=repo, candidate=candidate, authority=authority)
+    _apply_archive(worktree)
+    # 工作區把 commit 做在 detached HEAD 上（branch 不動）——回收的 refspec 是
+    # `refs/heads/<branch>`，此時 bundle 帶的就不是那個 commit。
+    _git(worktree, "checkout", "-q", "--detach")
+
+    with pytest.raises(RuntimeError, match="not on the recorded branch"):
+        work_bridge._commit_archive_and_require_reverification(
+            registry=registry,
+            state_root=state_root,
+            run=run,
+            authority=authority,
+            worktree=worktree,
+            branch=BRANCH,
+            candidate=candidate,
+            runner=lambda *a, **k: SimpleNamespace(returncode=0, stdout="", stderr=""),
+        )
+
+    unchanged = registry.get_workflow_run(run.run_id)
+    assert unchanged.candidate_head == candidate
+    assert unchanged.current_phase == "review"
+    assert job_workspace.source_branch_head(repo, BRANCH) == candidate
+
+
+# ---------------------------------------------------------------------------
+# 2. `matches_candidate()` 的 ancestry 檢查（本票的查證題）
+# ---------------------------------------------------------------------------
+
+def _repair_descendant(fixture: SimpleNamespace, pool: Path) -> str:
+    """post-archive repair：以 archive commit 為 base 重新 provision 並產 descendant。
+
+    這一段同時是 **#651 的回歸守衛**：`_workflow_build_handoff_base()` 會把
+    `run.candidate_head`（＝ archive commit）交給 `ScriptWorktreeCreator.create()`
+    當 base，而它的第一道守衛就是在**來源樹**上 `rev-parse --verify <base>`。回收
+    沒做的話這裡就是 `git worktree base invalid`，post-archive 的 `retry-build`
+    直接起不來。
+    """
+
+    creator = seams.ScriptWorktreeCreator(repo=fixture.repo, wt_root=pool, base="main")
+    repair = Path(
+        creator.create(
+            BRANCH, job_id="wf-repair-1", base_sha=str(fixture.reset.candidate_head)
+        )
+    )
+    (repair / "repair.txt").write_text("repair\n", encoding="utf-8")
+    _git(repair, "add", "repair.txt")
+    _git(repair, "commit", "-qm", "fix review finding")
+    final = _git(repair, "rev-parse", "HEAD")
+    bundle = job_workspace.prepare_commit_spool(
+        spool_key="wf-repair-1", coordinator_root=fixture.state_root
+    )
+    job_workspace.publish_commit_bundle(
+        workspace=repair,
+        bundle=bundle,
+        branch=BRANCH,
+        exclude=str(fixture.reset.candidate_head),
+    )
+    assert (
+        job_workspace.harvest_branch(
+            source_repo=str(fixture.repo), bundle=bundle, branch=BRANCH
+        )
+        == final
+    )
+    return final
+
+
+def _record_policy_commit(fixture: SimpleNamespace, *, run, candidate: str) -> None:
+    work_bridge._record_manager_ship_job(
+        registry=fixture.registry,
+        state_root=fixture.state_root,
+        run=run,
+        worktree=fixture.worktree,
+        branch=BRANCH,
+        card="policy-commit",
+        old_head=candidate,
+        new_head=candidate,
+    )
+
+
+def test_ship_audit_ancestry_needs_harvested_archive_commit(tmp_path: Path) -> None:
+    """回收之後，post-archive repair 的 ship audit 走得通（ancestry 分支成立）。
+
+    這條同時證明兩件事：`ScriptWorktreeCreator` 拿 archive commit 當 base 能
+    provision（#651 的 post-archive retry-build），以及 final candidate 是 archive
+    commit 的真祖先關係在**來源樹**上驗得出來。
+    """
+
+    fixture = _archive_fixture(tmp_path)
+    archive_head = str(fixture.reset.candidate_head)
+    final = _repair_descendant(fixture, tmp_path / "pool")
+
+    assert final != archive_head
+    assert (
+        subprocess.run(
+            [
+                "git", "-C", str(fixture.repo), "merge-base", "--is-ancestor",
+                archive_head, final,
+            ],
+            capture_output=True,
+        ).returncode
+        == 0
+    )
+
+    run = fixture.registry._manager_update_workflow_run(
+        fixture.reset.run_id, candidate_head=final, verified_head=final
+    )
+    _record_policy_commit(fixture, run=run, candidate=final)
+
+    audited = manager._validated_ship_steps(
+        fixture.registry,
+        run=run,
+        candidate=final,
+        coordinator_root=fixture.state_root,
+    )
+    assert all(step.gate_result == "passed" for step in audited if step.phase == "ship")
+
+
+def test_ship_audit_ancestry_fails_closed_without_harvest(tmp_path: Path) -> None:
+    """突變守衛：archive commit 沒進來源樹時，ancestry 檢查 fail-closed。
+
+    這就是 #623 之後、本票之前的實況——`merge-base --is-ancestor` 對來源樹沒有的
+    commit 回 128，`matches_candidate()` 回 False，整張卡被濾掉。**刻意不對錯誤
+    訊息以外的行為做斷言**：重點是「它不會靜默放行」。
+    """
+
+    repo, candidate = _source_repo(tmp_path / "repo")
+    worktree = make_job_clone(repo, tmp_path / "job-worktree", branch=BRANCH)
+    authority = load_work_authority(
+        repo="acme/demo", work_id="work", snapshot_path=_snapshot(tmp_path / "snap.json")
+    )
+    state_root = tmp_path / "state"
+    registry = JobRegistry(state_path=state_root / "jobs.json")
+    run = _run(registry, repo=repo, candidate=candidate, authority=authority)
+
+    # 只在 clone 裡做 archive commit（不回收）——本票之前的形狀。
+    _apply_archive(worktree)
+    _git(worktree, "add", "-A")
+    _git(worktree, "commit", "-qm", "chore(openspec): archive work")
+    orphan_archive = _git(worktree, "rev-parse", "HEAD")
+    (worktree / "repair.txt").write_text("repair\n", encoding="utf-8")
+    _git(worktree, "add", "repair.txt")
+    _git(worktree, "commit", "-qm", "fix")
+    final = _git(worktree, "rev-parse", "HEAD")
+    assert not job_workspace.commit_present(repo, orphan_archive)
+
+    work_bridge._record_manager_ship_job(
+        registry=registry,
+        state_root=state_root,
+        run=run,
+        worktree=worktree,
+        branch=BRANCH,
+        card="openspec-archive",
+        old_head=candidate,
+        new_head=orphan_archive,
+    )
+    run = registry._manager_update_workflow_run(
+        run.run_id,
+        candidate_head=final,
+        verified_head=final,
+        steps=tuple(
+            replace(
+                step,
+                executor="cortex-manager",
+                model="deterministic",
+                domain="cortex",
+                gate_result="passed",
+            )
+            if step.phase == "ship" and step.card == "openspec-archive"
+            else step
+            for step in run.steps
+        ),
+    )
+    work_bridge._record_manager_ship_job(
+        registry=registry,
+        state_root=state_root,
+        run=run,
+        worktree=worktree,
+        branch=BRANCH,
+        card="policy-commit",
+        old_head=final,
+        new_head=final,
+    )
+
+    with pytest.raises(ValueError, match="openspec-archive"):
+        manager._validated_ship_steps(
+            registry, run=run, candidate=final, coordinator_root=state_root
+        )
+
+
+# ---------------------------------------------------------------------------
+# 3. `openspec-archive` → `policy-commit` 的接續
+# ---------------------------------------------------------------------------
+
+def test_archive_to_policy_commit_handoff_binds_the_archive_job(tmp_path: Path) -> None:
+    """archive 之後的每一段都指向同一棵樹與同一個 candidate。
+
+    `_builder_binding()` 以「`subject_head == candidate` 的 job」決定 ship 段後續
+    要用哪個工作區與 branch；archive 之後那個 job 就是 archive 卡自己。這條把
+    「archive 卡的記錄 → 後續 ship 段」這條接線釘住，也是本票最容易回歸的一條。
+    """
+
+    fixture = _archive_fixture(tmp_path)
+    archive_head = str(fixture.reset.candidate_head)
+    run = fixture.registry.get_workflow_run(fixture.reset.run_id)
+
+    archive_jobs = [
+        job
+        for job in fixture.registry.list_jobs()
+        if job.get("workflow_run_id") == run.run_id
+        and job.get("workflow_phase") == "ship"
+        and job.get("workflow_card") == "openspec-archive"
+    ]
+    assert len(archive_jobs) == 1
+    archive_job = archive_jobs[0]
+    assert archive_job["subject_head"] == archive_head
+    assert archive_job["branch"] == BRANCH
+    assert archive_job["persona"] == "manager"
+    assert archive_job["executor"] == "cortex-manager"
+
+    # `_builder_binding()` 會挑到它，且拿到的 worktree／branch 就是 archive 卡的。
+    run = fixture.registry._manager_update_workflow_run(
+        run.run_id, verified_head=archive_head
+    )
+    _record_policy_commit(fixture, run=run, candidate=archive_head)
+    audited = manager._validated_ship_steps(
+        fixture.registry,
+        run=run,
+        candidate=archive_head,
+        coordinator_root=fixture.state_root,
+    )
+    assert all(step.gate_result == "passed" for step in audited if step.phase == "ship")
+
+    # `policy-commit` 不產生 commit：來源樹的 branch 一個位元組沒動。
+    assert job_workspace.source_branch_head(fixture.repo, BRANCH) == archive_head
+
+
+def test_ship_job_id_is_reserved_and_addresses_its_own_spool(tmp_path: Path) -> None:
+    """spool key ＝ 那張卡的 job_id（`reserve_job_id()` 配發的那一個）。
+
+    與 #651 的 build 卡同一條順序：先配 id → 用它定址 → 再建 job。兩處的 task 字串
+    由 `_manager_ship_job_task()` 單一推導，registry 因此驗得過。
+    """
+
+    fixture = _archive_fixture(tmp_path)
+    run = fixture.registry.get_workflow_run(fixture.reset.run_id)
+    archive_job = next(
+        job
+        for job in fixture.registry.list_jobs()
+        if job.get("workflow_card") == "openspec-archive"
+    )
+    expected_task = work_bridge._manager_ship_job_task(run=run, card="openspec-archive")
+
+    assert archive_job["task"] == expected_task
+    assert str(archive_job["job_id"]).startswith(f"{expected_task}-")
+    slot = job_workspace.commit_spool_dir(
+        spool_key=str(archive_job["job_id"]), coordinator_root=fixture.state_root
+    )
+    assert slot.is_dir()
+    assert (slot / job_workspace.COMMIT_BUNDLE_FILENAME).is_file()
+
+
+def test_ship_harvest_has_no_runner_mode_branch(tmp_path: Path, monkeypatch) -> None:
+    """`direct` 零回歸：本 PR 沒有引入任何依 `PSC_JOB_RUNNER` 的分支。
+
+    #634 的原則——以形狀判斷，不依旗標分支。兩種 runner mode 下走的是同一條路徑，
+    結果逐字相同。
+    """
+
+    observed = {}
+    for index, mode in enumerate(("direct", "systemd-template")):
+        monkeypatch.setenv("PSC_JOB_RUNNER", mode)
+        fixture = _archive_fixture(tmp_path / f"case-{index}")
+        archive_head = str(fixture.reset.candidate_head)
+        observed[mode] = {
+            # commit 的 SHA 兩邊本來就不同（不同的 tmp repo、不同的時間戳），
+            # 因此比的是**結構性事實**而不是字面值。
+            "harvested": job_workspace.source_branch_head(fixture.repo, BRANCH)
+            == archive_head,
+            "advanced": archive_head != fixture.candidate,
+            "phase": fixture.reset.current_phase,
+            "spool_sealed": job_workspace.commit_spool_dir(
+                spool_key=str(
+                    next(
+                        job
+                        for job in fixture.registry.list_jobs()
+                        if job.get("workflow_card") == "openspec-archive"
+                    )["job_id"]
+                ),
+                coordinator_root=fixture.state_root,
+            ).stat().st_mode
+            & 0o200
+            == 0,
+        }
+
+    assert observed["direct"] == observed["systemd-template"]
+    assert observed["direct"] == {
+        "harvested": True,
+        "advanced": True,
+        "phase": "verify",
+        "spool_sealed": True,
+    }
+
+
+def test_commit_spool_seal_enforcement_is_not_single_uid_testable(tmp_path: Path) -> None:
+    """封口的**強制力**單 UID 測不出來——明確 skip，不靜默通過（#638 的教訓）。
+
+    `seal_commit_spool()` 收掉那一格目錄的 `w`，同時把 POSIX ACL 的 mask 收成
+    `---`，producer 具名條目的授權因此一併失效。但 producer 進不去那一格的前提是
+    「唯一路徑是具名 ACL 條目」——同 UID 下 producer 就是目錄 owner，`chmod` 回去
+    即可，任何單 UID 的模擬都測不到真正的語意（`spool_slot` 模組 docstring 的
+    「誠實邊界」段已寫明）。這裡只驗**可測的那一半**：封口確實發生。
+    """
+
+    fixture = _archive_fixture(tmp_path)
+    archive_job = next(
+        job
+        for job in fixture.registry.list_jobs()
+        if job.get("workflow_card") == "openspec-archive"
+    )
+    slot = job_workspace.commit_spool_dir(
+        spool_key=str(archive_job["job_id"]), coordinator_root=fixture.state_root
+    )
+    assert slot.stat().st_mode & 0o200 == 0, "封口沒發生：那一格仍可寫"
+
+    pytest.skip(
+        "封口對 producer 的**強制力**需要 producer 與 consumer 是不同 UID"
+        "（三分部署的 `cortex-builder` / `cortex-manager`），且那一格帶 per-account "
+        "POSIX ACL。單 UID 的開發機與 CI 兩者皆無：此處 Manager 同時是 producer 與 "
+        "目錄 owner，`chmod` 回去就繞過了，模擬出來的結果與真部署無關。"
+        "可測的那一半（封口真的發生）已在 skip 之前斷言"
+    )

--- a/tests/test_work_bridge.py
+++ b/tests/test_work_bridge.py
@@ -13,6 +13,7 @@ import pytest
 from paulsha_cortex.control.contract import build_request
 from paulsha_cortex.coordinator import (
     completion,
+    job_workspace,
     manager,
     manager_daemon,
     review,
@@ -31,6 +32,8 @@ from paulsha_cortex.coordinator.workflow import (
     PlanningArtifactAuthority,
     WorkflowStep,
 )
+
+from git_fixtures import make_job_clone
 
 
 def _repo(root: Path) -> tuple[Path, str]:
@@ -626,6 +629,12 @@ def test_archive_commit_invalidates_old_gates_without_pushing(
     (repo / "CHANGELOG.md").write_text("# Changelog\n", encoding="utf-8")
     subprocess.run(["git", "-C", str(repo), "add", "."], check=True)
     subprocess.run(["git", "-C", str(repo), "commit", "-qm", "add change"], check=True)
+    # #649：ship 卡的 commit 現在要被回收進**來源樹**的 `refs/heads/<branch>`，
+    # 因此 fixture 必須是 #623 之後的真實形狀：來源樹上有那條 branch（build harvest
+    # 之後它就等於 candidate）但停在預設 branch，工作區是另一棵 checkout 在該 branch
+    # 上的 clone。原本工作區與來源樹是同一個目錄，那是 `git worktree` 共用 object
+    # store 時代的殘留。
+    subprocess.run(["git", "-C", str(repo), "branch", "feature/14-work"], check=True)
     candidate = subprocess.run(
         ["git", "-C", str(repo), "rev-parse", "HEAD"],
         check=True,
@@ -661,10 +670,11 @@ def test_archive_commit_invalidates_old_gates_without_pushing(
         gate_status="running",
     )
 
-    archive = repo / "openspec" / "changes" / "archive"
+    worktree = make_job_clone(repo, tmp_path / "ship-worktree", branch="feature/14-work")
+    archive = worktree / "openspec" / "changes" / "archive"
     archive.mkdir(parents=True)
-    active.rename(archive / "work")
-    with (repo / "CHANGELOG.md").open("a", encoding="utf-8") as handle:
+    (worktree / "openspec" / "changes" / "work").rename(archive / "work")
+    with (worktree / "CHANGELOG.md").open("a", encoding="utf-8") as handle:
         handle.write("- Archive work.\n")
 
     remote_head: str | None = None
@@ -694,7 +704,7 @@ def test_archive_commit_invalidates_old_gates_without_pushing(
         state_root=state_root,
         run=run,
         authority=authority,
-        worktree=repo,
+        worktree=worktree,
         branch="feature/14-work",
         candidate=candidate,
         runner=delivery_runner,
@@ -702,6 +712,12 @@ def test_archive_commit_invalidates_old_gates_without_pushing(
 
     assert reset.current_phase == "verify"
     assert remote_head is None
+    # #649：archive commit 已被回收進來源樹——`candidate_head` 推進到它的同時，
+    # 來源樹的 `refs/heads/<branch>` 必須恰好也在那裡（ship audit 的 ancestry
+    # 檢查、post-archive retry-build 的 clone base 都以此為前提）。
+    assert (
+        job_workspace.source_branch_head(repo, "feature/14-work") == reset.candidate_head
+    )
     assert reset.candidate_head is not None
     assert reset.candidate_head != candidate
     assert reset.verified_head is None
@@ -895,6 +911,9 @@ def test_installed_defaults_start_to_ship_handoff_remains_monitor_ongoing(
         target.write_text(body, encoding="utf-8")
     subprocess.run(["git", "-C", str(repo), "add", "."], check=True)
     subprocess.run(["git", "-C", str(repo), "commit", "-qm", "add planning"], check=True)
+    # #649：同上——工作區是一棵 checkout 在 `feature/14-work` 上的獨立 clone，
+    # 來源樹留在預設 branch 並持有同名 branch（build harvest 之後的形狀）。
+    subprocess.run(["git", "-C", str(repo), "branch", "feature/14-work"], check=True)
     candidate = subprocess.run(
         ["git", "-C", str(repo), "rev-parse", "HEAD"],
         check=True,
@@ -974,11 +993,20 @@ identities:
     #: 變成「每張 build 卡一次」；branch 名一條不變，只是被要求得更多次。
     provisioned_job_ids: list[str | None] = []
 
+    #: #649：工作區是**獨立 clone**，不是來源樹本身——ship 卡的成果回收
+    #: （`git fetch <bundle> refs/heads/<b>:refs/heads/<b>`）會被 git 拒絕寫入一條
+    #: 正被 checkout 的 branch，而那正是「工作區 ≠ 來源樹」在 #623 之後的實況。
+    job_worktrees: list[Path] = []
+
     class WorktreeCreator:
         def create(self, branch, base_sha=None, *, job_id=None):
             branches.append(branch)
             provisioned_job_ids.append(job_id)
-            return str(repo)
+            if not job_worktrees:
+                job_worktrees.append(
+                    make_job_clone(repo, tmp_path / "job-worktree", branch=branch)
+                )
+            return str(job_worktrees[0])
 
     dispatcher = Dispatcher(
         registry,
@@ -1096,7 +1124,7 @@ identities:
     def fake_preflight(**kwargs):
         preflight_requests.append(kwargs["request"])
         head = subprocess.run(
-            ["git", "-C", str(repo), "rev-parse", "HEAD"],
+            ["git", "-C", str(job_worktrees[0]), "rev-parse", "HEAD"],
             check=True,
             capture_output=True,
             text=True,
@@ -1139,8 +1167,11 @@ identities:
         if argv[:3] == ["python3", "-m", "policy_check"]:
             return SimpleNamespace(returncode=0, stdout="", stderr="")
         if argv[:2] == ["openspec", "archive"]:
-            active = repo / "openspec" / "changes" / "work"
-            archived = repo / "openspec" / "changes" / "archive" / "2026-08-06-work"
+            # #649：archive 落在**呼叫端指定的工作區**，不是來源樹——真正的
+            # `openspec archive` 也是以 `cwd` 為準。
+            cwd = Path(kwargs["cwd"])
+            active = cwd / "openspec" / "changes" / "work"
+            archived = cwd / "openspec" / "changes" / "archive" / "2026-08-06-work"
             archived.parent.mkdir(parents=True, exist_ok=True)
             if active.exists():
                 shutil.move(str(active), str(archived))
@@ -1158,7 +1189,7 @@ identities:
         if "push" in argv:
             assert argv[-3:] == ["push", "origin", "HEAD:refs/heads/feature/14-work"]
             pushed_head = subprocess.run(
-                ["git", "-C", str(repo), "rev-parse", "HEAD"],
+                ["git", "-C", str(job_worktrees[0]), "rev-parse", "HEAD"],
                 check=True,
                 capture_output=True,
                 text=True,


### PR DESCRIPTION
Closes #649

## 查證（票上第一步，結論改變了範圍）

### 1. ship 卡**不是**降權派工的對象——票上的前提不成立

`openspec-archive`／`policy-commit` 的 `persona_binding` 是 `manager`
（`deck/data/cards.yaml`；`workflow.py` 的 manifest 也硬性要求 `"ship": "manager"`），
而 `manager._dispatch_workflow_card()` 的第一道判準是

```python
if step is None or run.current_phase not in {"plan", "build", "verify", "review"}:
    return None
```

**ship phase 永遠回 None**。這兩張卡不經任何 launcher、不 spawn 任何 job——它們由
Manager 自己在 `work_bridge.py` 內以 deterministic 身分執行
（`_commit_archive_and_require_reverification()` 直接 `git commit`；
`_record_manager_ship_job()` 事後補一筆 `executor=cortex-manager` /
`model_id=deterministic` 的稽核用 job 記錄）。

因此：**沒有 template unit、沒有 `ReadWritePaths=<pool>/%i`、沒有 `226/NAMESPACE`。**
`launcher._downgraded_mode()` 落不落在 manager persona 上是個假問題——那條路徑根本不會
被走到（**因此本 PR 一個位元組都沒碰 `launcher`／`permgen`／polkit，與 #615 零重疊**）。
票上「#648 的症狀在 ship phase 原封不動」這句是錯的。

> 附帶發現（另記，不在本 PR 範圍）：`cards.yaml` 給這兩張卡宣告的
> `runtime_capabilities: ["provider:github:…", "provider:executor"]`（#369／#442）掛在
> `_runtime_preflight_gate` 上，而那也在 dispatch 路徑內——ship 卡不 dispatch，那兩條
> 宣告在生產環境同樣無法生效。#442「先在 ship-phase 兩張卡觀測」因此觀測不到東西。

### 2. `matches_candidate()` 的 ancestry 檢查：**目前是壞的**（fail-closed 的死路）

- **什麼時候會走到**：只有 post-archive repair——archive commit 之後 review 再度提出
  阻擋性 findings、operator 下 `retry-build`、builder 在 archive commit 之上做出
  descendant candidate。正常流程 `subject_head == candidate` 精確相等，走第一個分支，
  ancestry 那段碰不到。
- **走到之後成不成立**：**不成立**。archive commit 是 Manager 在**工作區**裡做的，而
  #623 把工作區從 `git worktree`（與來源樹共用 object store）換成 per-job 完整 clone
  之後，`run.workspace_root` 的 object store 裡**沒有那個 commit**。
  `git merge-base --is-ancestor <來源樹沒有的 sha> <candidate>` 回 **128**
  （`fatal: Not a valid commit name`），**不是 1** ⇒ `matches_candidate()` 回 False ⇒
  該卡被濾掉 ⇒ `_validated_ship_steps()` 以
  `workflow ship card audit missing or ambiguous: openspec-archive` 中止。

  也就是說：這條檢查在 #623 之後就是一條**只會 fail-closed 的死路**。安全（不會誤放行），
  但 post-archive repair 走不完。
- **既有測試為什麼是綠的**：
  `tests/test_workflow_production_wiring.py::test_ship_audit_accepts_manager_archive_ancestor_after_retry_build`
  的 fixture 把 archive commit 與 repair commit **都直接做在 `run.workspace_root` 裡**
  ——那正是 #623 之前共用 object store 的形狀。fixture 幫產品把前提補上了，於是測試看不到
  production 的斷點。

### 3. #651 讓同一個缺口多長出一個症狀

#651 之後 build 卡改 per-job clone，中段／後續卡的 base 是
`_workflow_build_handoff_base()` 給的 `run.candidate_head`。post-archive 的
`retry-build` 因此會拿 **archive commit** 當 base 去 provision，而
`ScriptWorktreeCreator.create()` 的第一道守衛是在**來源樹**上
`rev-parse --verify <base>^{commit}` ⇒ 找不到 ⇒ `git worktree base invalid`，重派連
工作區都建不起來。（本 PR 的突變驗證重現的正是這句話，見「測試」。）

## 回收模型：選路 (a)（bundle ＋ append-only spool），producer 換成 Manager

票上兩條路擇一，選 (a)：

- **不能選 (b)（「ship 卡的 commit 不進 candidate 鏈」）**：archive commit **就是**下一輪
  的 candidate——`_manager_reset_workflow_after_archive()` 把 `candidate_head` 推到它、
  verify／review 對著它重跑、`_builder_binding()` 以 `subject_head == candidate` 選工作區、
  `policy-commit` 精確綁 final candidate、PR 推的也是它。把它排除在鏈外等於重寫整條
  post-archive 語意，而 `matches_candidate()` 的 ancestry 檢查（＋
  `governed-delivery-closure` spec 對它的 MUST）也得跟著拆——那不是縮小範圍，是換一套設計。
- **選 (a)，但通道的 producer 是 Manager 自己**：#637 的 bundle ＋ spool 之所以存在，是為了
  解兩個問題——builder 不能 push 進 Manager 的樹（D2 單向性），以及 Manager 走不進 builder
  的樹（0700 ＋ `safe.directory` 不吃路徑 glob）。archive commit 由 Manager 親手做出來，
  沒有 wrapper script 可以掛 `job_workspace.build_bundle_command()` 那段 shell；但
  **consumer 那一半必須是同一個**：`harvest_branch()` 是全 repo 唯一的「commit 進來源樹」
  實作，繞過它另寫一次 `git -C <來源樹> fetch <那棵工作區>` 會同時複製一份 fail-closed 分類，
  並且把 `job_workspace` 模組 docstring **明文否決**的形狀寫回程式碼（那也正是 #653 之後
  必炸的形狀）。因此只補 producer 那一半：新增 `job_workspace.publish_commit_bundle()`
  （in-process 版的 `build_bundle_command()`）。
- **票上「launcher 對 manager persona 本來就已經建了 spool」這句也不成立**：ship 卡不
  launch，`prepare_commit_spool()` 從未為它跑過；`spool_key_for_job()` 由 `log_path` 推導，
  而 ship 卡的 job 記錄沒有 `log_path`。本 PR 因此在 Manager 側顯式配 id、顯式建那一格。

### 落地

`_commit_archive_and_require_reverification()` 在 `git commit` 之後、
`_record_manager_ship_job()` 與 `_manager_reset_workflow_after_archive()` **之前**插入：

```
registry.reserve_job_id(_manager_ship_job_task(...))          # 先配 id（與 #648 同一條順序）
  → job_workspace.prepare_commit_spool(spool_key=<那個 id>)
  → job_workspace.publish_commit_bundle(工作區 → 那一格)
  → job_workspace.harvest_branch(bundle → 來源樹的 refs/heads/<branch>)
  → 回收後 branch head 必須恰等於剛做的 commit，對不上即 fail-closed
  → seal_commit_spool()
```

順序不能反過來：`candidate_head` 一旦推進，整條鏈（ship audit 的 ancestry、post-archive
retry-build 的 clone base、下一張卡的 handoff base）就開始假設來源樹有那個 commit；
回收失敗必須擋在推進**之前**，而不是讓錯誤在很遠的地方以看不懂的訊息出現。

另外兩道守衛：

- **commit 必須在記錄的 branch 上**（`source_branch_head(worktree, branch) == new_head`）
  ——回收的 refspec 是 `refs/heads/<branch>`，detached HEAD 或第三方動過 ref 時 bundle 帶的
  就是別的東西。與 `_harvest_build_candidate()` 的 head mismatch 同一條判準。
- **bundle 的排除點依來源樹有沒有那個 commit 決定**（`commit_present()`）：正常情形是
  `^<archive 之前的 candidate>`，只搬一個 commit；來源樹沒有它時（升級前既存的 run、或從未
  走過 build harvest 的路徑）改為不排除、帶完整歷史——寧可多搬一點，也不要因為缺
  prerequisite 讓一次**合法**的回收失敗。

`matches_candidate()` **一個位元組都沒改**：本 PR 修的是它的前提。archive commit 回到來源樹
之後，那條 ancestry 檢查就回到它原本設計成立的樣子。

**#623 的紅線遵守**：沒有 `--reference`／`--shared`／任何把 object store 接回共用的優化，
也沒有「Manager fetch 一棵 job 的 clone」。

## 怎麼切的（範圍縮小，理由是查證結果，不是做不完）

**本 PR 只做成果回收**。票上第 3 點「ship 卡的工作區改 per-job」**不做**：

- **原動機消失**：ship 卡不 dispatch、不 launch，`%i` 不變式落不到它們身上（查證 1）。
  照票面把 `reserve_job_id() → creator.create()` 套上去，得到的是一個沒有人會用 `%i`
  定址的目錄——為了一個不存在的約束改動整條 ship 路徑。
- **真正的阻擋物是別的**：ship 段全程在 `_builder_binding()` 交回來的 **builder 的 clone**
  裡動手（`git diff`／`add`／`commit`／`rev-parse`／`push`、`resolve(strict=True)`、
  `_ship_action(repo_root=…)` 連測試都在那裡跑）。Phase 2b 三分下那棵樹是 `cortex-builder`
  0700，而 **#641 已把登記表裡 Manager 對 job 工作樹殘留的讀取授權全部收掉**（runbook 第 2
  步的稽核 5b 要求 `/var/lib/cortex/worktree/` 底下**零 setfacl**）⇒ ship phase 在降權模式
  下會在**第一個 `git -C`** 就 `Permission denied`。症狀是**權限**，不是 `226/NAMESPACE`。
- 修法是把 ship 段搬進一棵 **Manager-owned** 的樹（此時 per-job 目錄名才有意義），連帶處理
  `_builder_binding()` 的來源、`archive-applied-needs-commit` 這條重入路徑、preflight／push／
  `_ship_action` 的 repo_root。獨立一票的體量，且**必須**建立在本 PR 的回收通道之上
  ——已開 **#653**。

本 PR 因此是「能獨立驗證的第一段」：自己就修好三個現行缺陷（ancestry 死路、#651 的
post-archive retry-build 回歸、成果只存在於某棵工作區的磁碟上），不依賴後續票。

| | 回收通道 | 降權模式可用 |
|---|:--:|:--:|
| canonical，build phase | ✅ #637／#651 | ✅ #651 |
| canonical，ship phase | ✅ **本 PR** | ⛔ #653（Manager 讀不進 builder 的 clone） |

## 測試

新增 `tests/test_ship_phase_harvest_649.py`（9 條，全部跑正式路徑：真 git repo、真 per-job
clone、真 `_commit_archive_and_require_reverification()`、真 `seams.ScriptWorktreeCreator`，
不手動 `git push`／不自己捏 registry 狀態）：

- **回收本身**：archive commit 進來源樹，且 `refs/heads/<branch>` == 新 candidate。
- **交接不依賴磁碟殘留**：把做 commit 的那棵工作區整個 `rmtree` 掉，commit 與檔案內容仍在
  來源樹裡讀得出來（#651 對 build 卡釘的是同一個形狀）。
- **fail-closed 且不先推進**：commit 落在 detached HEAD 上時拒絕回收，且
  `candidate_head`／`current_phase`／來源樹 branch 全部**原封不動**。
- **`matches_candidate()` 的 ancestry（本票的查證題）**：正向——回收之後，以 archive commit
  為 base 用**真的** `ScriptWorktreeCreator` provision 出 repair clone、做 descendant、
  harvest 回來，ship audit 兩張卡都 passed（**這條同時是 #651 post-archive retry-build 的
  回歸守衛**）；反向——archive commit 沒回收時 ship audit fail-closed（＝本 PR 之前的實況）。
- **`openspec-archive` → `policy-commit` 的接續**（最容易回歸的一條）：archive 卡的 job 記錄
  （`subject_head`／`branch`／`persona`／`executor`）就是 `_builder_binding()` 之後會選到的
  那一筆，且 `_validated_ship_steps()` 對兩張卡都 passed；`policy-commit` 不產生 commit，
  來源樹 branch 一個位元組沒動。
- **spool 定址**：spool key ＝ `reserve_job_id()` 配發的那個 job_id，task 由
  `_manager_ship_job_task()` 單一推導（兩處字面值不再各寫一次）。
- **`direct` 零回歸**：`PSC_JOB_RUNNER` 兩種值下走完全相同的路徑，結構性結果逐項相等
  （#634 的「以形狀判斷，不依旗標分支」；本 PR 沒有引入任何依該旗標的分支）。
- **#638 的教訓**：spool 封口對 producer 的**強制力**需要 producer 與 consumer 是不同 UID
  ＋ per-account POSIX ACL，單 UID 的開發機與 CI 都沒有，任何單 UID 模擬都與真部署無關 ⇒
  **明確 `pytest.skip` 並說明理由**，skip 之前先斷言可測的那一半（封口真的發生）。

**突變驗證**：把 harvest 那一行停掉之後，9 條轉紅 8 條（唯一仍綠的是那條反向的 fail-closed
測試，符合預期），其中 ancestry 那條紅在
`git worktree base invalid: fatal: Needed a single revision`——正是 #651 post-archive
retry-build 回歸的逐字現場。

既有測試的更新都是同一件事的直接後果：三個 fixture 把「工作區 ＝ 來源樹」改成 #623 之後的
真實形狀（來源樹持有 delivery branch 但**不 checkout**，工作區是另一棵 checkout 在該 branch
上的 clone），共用 helper `tests/git_fixtures.py:make_job_clone()`。沒有這一步，`git fetch`
會撞上「拒絕寫入正被 checkout 的 branch」——那是 fixture 的問題不是產品的。

`python3 -m pytest tests/ -q`：**3951 passed, 9 skipped**（已 rebase 到含 #652／#615 的 main）。

## 並行注意

另一個 agent 在做 #615（reviewer/planner 啟動面降權），動 `launcher`／`permgen`／polkit。
**本 PR 完全沒有碰這三個檔案**（查證 1 說明了為什麼不必碰 `launcher._downgraded_mode()`），
重疊為零。

## 未做的實機驗證

`PSC_JOB_RUNNER=systemd-template` 下跑完一個含 ship phase 的 run **尚未實機執行**——本機不是
部署機，且依查證，ship phase 在降權模式下還會卡在「Manager 讀不進 builder 的 clone」，那是
#653 的範圍。本 PR 的不變式已由上述測試在真 git repo 上端到端覆蓋。

## Checklist

- [x] 分支不是 `main`（`feature/649-ship-phase-harvest`）
- [x] `changelog.d/ship-phase-harvest.md` fragment 已新增且已 commit
- [x] `CHANGELOG.md [Unreleased]` 有對應 entry
- [x] `VERSION` 未改（非 release PR）
- [x] `python3 -m pytest tests/ -q` 全綠（3951 passed, 9 skipped）；GitHub CI 全綠（pytest 3.10–3.13／policy／persona-scope／smoke-install）
- [x] `policy_check` 帶 PR 上下文跑，fail: 0
- [x] 文件與 PR 一律 zh-tw
- [x] docs 同步（Phase 2b runbook 的 `%i` 稽核段補上「ship 卡不在這條稽核裡」與降權下真正的
      症狀是權限而非 `226/NAMESPACE`）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E7w9kaUxAzCCEk7piD5hfK