### PR TITLE
feat(trust-root): gate 執行身分——第四個帳號 cortex-gate (#629)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,40 @@
 ## [Unreleased]
 
 ### Added
+- **#629 / gate 執行身分：第四個帳號 `cortex-gate`（`UidScheme` 三分 → 四分）**——
+  `#604`／PR `#628` 把 gate ledger 與 exit sentinel 的**作者**收斂到 Manager，但刻意
+  沒做執行面：operator 宣告的 gate 命令（`PSC_GATE_CMD_*`）在 **builder 完全掌控內容的
+  工作樹**上執行，`pytest` 會載入該樹的 `conftest.py` 與 plugin ⇒ **執行者取得任意程式碼
+  執行**。後果是 `PSC_JOB_RUNNER=systemd-template` 下 build 卡恆因 `require_ledger` 而
+  `gate-ledger-missing` fail closed——安全，但不能用。本次把缺的那一半補上：
+  - **`permgen.FOUR_WAY_SCHEME` 成為定案方案**（`DEFAULT_SCHEME`）。既有三個帳號逐一
+    皆不可承接 gate：`cortex-builder`＝模型自證（違反 `#540` 的 acceptance chain）、
+    `cortex-manager`＝把任意程式碼執行引到持 spawn 授權、擁有全部 durable state 的
+    帳號（`#629` 本文的整段論證）、`cortex-reviewer-planner`＝它是寫 verdict 的那一個
+    （等於把 `#638`／`#639` 剛關掉的通道重新打開）。唯一認真的無新帳號候選
+    `DynamicUser=yes` **結構性不成立**：本方案兩端都靠具名 POSIX ACL 授權，而
+    `setfacl -m u:<名>:…` 在產生權限的當下就要解析得到那個帳號。
+  - **`account_of` 支援 `ABSENT_ACCOUNT`**（語意與 `#626` 的部署決定型欄位逐字相同）：
+    `three-way`／`two-way` 明示「本方案沒有 gate 角色」，因此不產生 gate 的帳號／unit／
+    ACL／polkit 字幹，而**不是**讓整個產生器拒絕輸出。缺鍵（既非帳號也非明示不存在）
+    仍然 fail-closed 並在訊息裡逐條列出「為什麼不能併到既有帳號」。
+  - **`coordinator/gate_runner.py`（新模組）**：Manager 起 `cortex-gate-job@<id>.service`
+    執行宣告的 gate，產出經 spool 回到 Manager 手上。它是**單一進入點**——自動路徑
+    （`manager.terminalize_workflow_job`，排在 `_assert_terminal_gate_consistency` 正
+    前方）與 operator 明著要求的 `regenerate-gates` 走同一支。
+  - **登記表兩個新資產**：`gate-ledger-spool`（`<coordinator>/gate-ledger-spool/<job>/`，
+    Tier-0，gate 只獲 **`wx` 無 `r`**，per-job 生命週期整條走 `#639` 的
+    `coordinator/spool_slot.py`，不另寫一份）與 `gate-worktree-pool`
+    （`<agents_root>/gate-worktree/`，gate-owned `0700`）。`repo-worktree` 的 readers
+    補一個 `GATE`（**`rX`，沒有 `w`**）。
+  - **`job_runner` 第三個 job 角色 `gate`**：沿用 `#615` 的 `JOB_ROLE_CONFIG` 表，沒有
+    任何 `if role == …` 分支。`prepare_systemd_template()` 對 gate 角色**要求
+    `executor=None`**（gate 不跑模型 CLI，剖面不得跟著 `PSC_MANAGER_EXECUTOR` 漂移），
+    對模型角色仍**要求 `executor` 非 None**（`#643` 的既有紀律）。
+  - **polkit 沿用 `#643`／`#615` 的單一交替 pattern 擴字幹**：`3 角色 × 2 剖面 ＝ 六個
+    具名模板`，**不加第二條 `addRule`**，全檔仍只有一個 `return polkit.Result.YES`；
+    pattern 的字幹來源改為「**本方案實際落檔**的角色」（`downgraded_job_principals()`），
+    因此 `three-way`／`two-way` 產出的規則不會提一份那台機器上不存在的 unit。
 - **#649 / trust-root Phase 2b：ship phase 的成果回收——`openspec-archive` 的 commit
   沒有進來源樹，`matches_candidate()` 的 ancestry 檢查因此是條死路**——票上的第一步是
   查證，而查證結果改變了範圍。**(1) ship 卡不是降權派工的對象**：兩張 ship 卡的
@@ -290,6 +324,29 @@
   `tests/test_trust_root_job_template_ab.py`（80 測試）。
 
 ### Fixed
+- **權威 gate ledger 一律由 Manager 自己重寫，spool 內容以不受信任輸入對待（#629）**——
+  讓 gate 直接寫 `gate-ledger` 會被 `#628` 的 `foreign_evidence_author()` 當場以
+  `gate-ledger-foreign-author` 拒掉；而那個資產**同時**是 exit sentinel 的落點，開放
+  寫入面等於讓一個跑 untrusted code 的帳號能偽造**任何** job 的完成狀態。Manager 讀
+  spool 時逐項驗形狀、gate 名稱必須落在 operator 的宣告集合內、payload 有界、`status`
+  由 `exit_code` 重算（與採信端 `_ledger_outcomes()` 同一條紀律）。
+- **產生的 job unit 檔頭不再固定寫 `--job`**：`JOB_UNIT_CLI_FLAG` 讓「重跑用哪一行」
+  跟著角色走。原本 reviewer／gate 的 unit 檔頭都寫著 `unit <scheme> --job`，operator
+  照抄會拿到 builder 的 unit **覆蓋掉**這一份。檔頭裡的 `Manager（cortex-svc）` 也改為
+  由 scheme 導出（二分時代的字面量殘留）。
+- **spec §R3 新增「誠實的取捨：gate 執行身分買到的是圍堵，不是不可偽造」**——第四帳號
+  **不**使 gate 結果不可偽造：取得任意程式碼執行的 builder 依然能影響**自己那一份**
+  ledger 的內容，那是「執行對方交出來的測試碼」這件事本身的性質，換誰執行都一樣。
+  買到的是那個執行**碰不到**：Manager 的 durable state（含 exit sentinel）、builder 的
+  工作樹（只有 `rX`）、verdict／commit 通道、他人在 gate spool 的那一格（`wx` 無 `r`）、
+  以及任何 polkit grant。任何引用本 spec 的稽核或 PR 描述 MUST NOT 把它敘述成
+  「gate ledger 不可被 builder 影響」。
+- **spec §R9 新增族 5「gate 執行身分」**（T5.1–T5.10，含 negative control）；runbook
+  對應第 8b-3 步（族 7）。runbook 另新增第 1 步的第四個帳號、5-2c／5-2d（兩份 gate
+  模板 ＋ **真實加固面下**的驗證，含「拿掉 ACL 之後 build 卡必須 fail closed」的負向
+  對照）、5-5 的 `PSC_GATE_*` 設定，並把全文 scheme token 由 `three-way` 改為
+  `four-way`（附三分機器的升級路徑：只需建帳號、重跑權限 script、落兩份 unit ＋ 重跑
+  polkit，第 3／4 步完全不動）。
 - **#615：slice lane 的 foreign reviewer 差一點被以 `cortex-builder` 起跑**——實作 M2
   時發現的真缺口。foreign reviewer 走 `manager._spool_writable_launcher()` →
   `SubprocessLauncher.as_verdict_spool_writer()`，而那支工廠產出的 launcher
@@ -563,6 +620,25 @@
   `mock.patch.object` 打不到，測試實際驗到的是「本機有沒有那個帳號」而非它宣稱的分支。
 
 ### Changed
+- **`work_actions._regenerate_gates_action` 的執行面收斂到 gate 執行身分（#629）**——
+  它原本在 **Manager 進程內**直接呼叫 `gate_ledger.write_gate_ledger()`，等於以
+  `cortex-manager` 的身分在 builder 完全掌控的工作樹上跑 `pytest`。`direct` 模式下
+  builder 與 Manager 同 UID，這件事本來就沒有邊界可言；OS 隔離上線後它是一條**真的**
+  提權路徑，而且是最容易被忽略的那一種（不在派工熱路徑上，只在 operator 手動救援時
+  才走到）。改為與自動路徑共用 `gate_runner.run_declared_gates()`，因此不會出現「自動的
+  那條降權了、手動的那條還在 Manager 進程裡跑」。降權模式下 gate 起不來時**不退回
+  Manager 進程內執行**，診斷碼原樣回報。
+- **`gate_ledger` 新增 `--snapshot-from`／`--publish`**：gate 命令一律在**拋棄式副本**
+  上執行。唯讀不可行（`pytest` 要寫 `.pytest_cache`／`__pycache__`，`npm test`／`make`
+  更是必寫，掛成唯讀只會讓每個真實 gate 以 EROFS 收場＝#629 要修掉的「安全但不能用」）；
+  副本另外買到「gate 的寫入不污染 builder 交付的樹」與「快照在單一時點取得，builder
+  留下的背景行程改不了跑到一半的樹」。symlink **原樣複製、絕不跟隨**（跟隨會把樹外
+  內容複製進 gate 的可寫區，或走進無界遞迴）。
+- **`UidScheme.headless_accounts()` 的來源改為 `registry.UNTRUSTED_EXECUTION_PRINCIPALS`**
+  （headless persona ＋ headless hook ＋ **gate**），因此「Manager-owned／deployment 樹
+  對這些帳號零寫入」這條核心不變式自動涵蓋 gate。同時新增
+  `model_job_accounts()`——只有**跑模型 CLI** 的帳號需要 root-owned `~/.codex` 與
+  executor 憑證骨架，gate 兩者都不要。
 - **#643 / `permgen.EXECUTOR_TOOLS` 的 `copilot.needs_node` 由 `False` 改為 `True`**
   ——#640 落表時只知道它是 shell script、還沒查它內部 exec 什麼（表上的 note 當時就
   寫著「安裝時務必 `head -n 20` 查一次」）。#643 在真實加固面下量到 `copilot

--- a/changelog.d/gate-execution-identity.md
+++ b/changelog.d/gate-execution-identity.md
@@ -1,0 +1,83 @@
+### Added
+- **#629 / gate 執行身分：第四個帳號 `cortex-gate`（`UidScheme` 三分 → 四分）**——
+  `#604`／PR `#628` 把 gate ledger 與 exit sentinel 的**作者**收斂到 Manager，但刻意
+  沒做執行面：operator 宣告的 gate 命令（`PSC_GATE_CMD_*`）在 **builder 完全掌控內容的
+  工作樹**上執行，`pytest` 會載入該樹的 `conftest.py` 與 plugin ⇒ **執行者取得任意程式碼
+  執行**。後果是 `PSC_JOB_RUNNER=systemd-template` 下 build 卡恆因 `require_ledger` 而
+  `gate-ledger-missing` fail closed——安全，但不能用。本次把缺的那一半補上：
+  - **`permgen.FOUR_WAY_SCHEME` 成為定案方案**（`DEFAULT_SCHEME`）。既有三個帳號逐一
+    皆不可承接 gate：`cortex-builder`＝模型自證（違反 `#540` 的 acceptance chain）、
+    `cortex-manager`＝把任意程式碼執行引到持 spawn 授權、擁有全部 durable state 的
+    帳號（`#629` 本文的整段論證）、`cortex-reviewer-planner`＝它是寫 verdict 的那一個
+    （等於把 `#638`／`#639` 剛關掉的通道重新打開）。唯一認真的無新帳號候選
+    `DynamicUser=yes` **結構性不成立**：本方案兩端都靠具名 POSIX ACL 授權，而
+    `setfacl -m u:<名>:…` 在產生權限的當下就要解析得到那個帳號。
+  - **`account_of` 支援 `ABSENT_ACCOUNT`**（語意與 `#626` 的部署決定型欄位逐字相同）：
+    `three-way`／`two-way` 明示「本方案沒有 gate 角色」，因此不產生 gate 的帳號／unit／
+    ACL／polkit 字幹，而**不是**讓整個產生器拒絕輸出。缺鍵（既非帳號也非明示不存在）
+    仍然 fail-closed 並在訊息裡逐條列出「為什麼不能併到既有帳號」。
+  - **`coordinator/gate_runner.py`（新模組）**：Manager 起 `cortex-gate-job@<id>.service`
+    執行宣告的 gate，產出經 spool 回到 Manager 手上。它是**單一進入點**——自動路徑
+    （`manager.terminalize_workflow_job`，排在 `_assert_terminal_gate_consistency` 正
+    前方）與 operator 明著要求的 `regenerate-gates` 走同一支。
+  - **登記表兩個新資產**：`gate-ledger-spool`（`<coordinator>/gate-ledger-spool/<job>/`，
+    Tier-0，gate 只獲 **`wx` 無 `r`**，per-job 生命週期整條走 `#639` 的
+    `coordinator/spool_slot.py`，不另寫一份）與 `gate-worktree-pool`
+    （`<agents_root>/gate-worktree/`，gate-owned `0700`）。`repo-worktree` 的 readers
+    補一個 `GATE`（**`rX`，沒有 `w`**）。
+  - **`job_runner` 第三個 job 角色 `gate`**：沿用 `#615` 的 `JOB_ROLE_CONFIG` 表，沒有
+    任何 `if role == …` 分支。`prepare_systemd_template()` 對 gate 角色**要求
+    `executor=None`**（gate 不跑模型 CLI，剖面不得跟著 `PSC_MANAGER_EXECUTOR` 漂移），
+    對模型角色仍**要求 `executor` 非 None**（`#643` 的既有紀律）。
+  - **polkit 沿用 `#643`／`#615` 的單一交替 pattern 擴字幹**：`3 角色 × 2 剖面 ＝ 六個
+    具名模板`，**不加第二條 `addRule`**，全檔仍只有一個 `return polkit.Result.YES`；
+    pattern 的字幹來源改為「**本方案實際落檔**的角色」（`downgraded_job_principals()`），
+    因此 `three-way`／`two-way` 產出的規則不會提一份那台機器上不存在的 unit。
+
+### Changed
+- **`work_actions._regenerate_gates_action` 的執行面收斂到 gate 執行身分（#629）**——
+  它原本在 **Manager 進程內**直接呼叫 `gate_ledger.write_gate_ledger()`，等於以
+  `cortex-manager` 的身分在 builder 完全掌控的工作樹上跑 `pytest`。`direct` 模式下
+  builder 與 Manager 同 UID，這件事本來就沒有邊界可言；OS 隔離上線後它是一條**真的**
+  提權路徑，而且是最容易被忽略的那一種（不在派工熱路徑上，只在 operator 手動救援時
+  才走到）。改為與自動路徑共用 `gate_runner.run_declared_gates()`，因此不會出現「自動的
+  那條降權了、手動的那條還在 Manager 進程裡跑」。降權模式下 gate 起不來時**不退回
+  Manager 進程內執行**，診斷碼原樣回報。
+- **`gate_ledger` 新增 `--snapshot-from`／`--publish`**：gate 命令一律在**拋棄式副本**
+  上執行。唯讀不可行（`pytest` 要寫 `.pytest_cache`／`__pycache__`，`npm test`／`make`
+  更是必寫，掛成唯讀只會讓每個真實 gate 以 EROFS 收場＝#629 要修掉的「安全但不能用」）；
+  副本另外買到「gate 的寫入不污染 builder 交付的樹」與「快照在單一時點取得，builder
+  留下的背景行程改不了跑到一半的樹」。symlink **原樣複製、絕不跟隨**（跟隨會把樹外
+  內容複製進 gate 的可寫區，或走進無界遞迴）。
+- **`UidScheme.headless_accounts()` 的來源改為 `registry.UNTRUSTED_EXECUTION_PRINCIPALS`**
+  （headless persona ＋ headless hook ＋ **gate**），因此「Manager-owned／deployment 樹
+  對這些帳號零寫入」這條核心不變式自動涵蓋 gate。同時新增
+  `model_job_accounts()`——只有**跑模型 CLI** 的帳號需要 root-owned `~/.codex` 與
+  executor 憑證骨架，gate 兩者都不要。
+
+### Fixed
+- **權威 gate ledger 一律由 Manager 自己重寫，spool 內容以不受信任輸入對待（#629）**——
+  讓 gate 直接寫 `gate-ledger` 會被 `#628` 的 `foreign_evidence_author()` 當場以
+  `gate-ledger-foreign-author` 拒掉；而那個資產**同時**是 exit sentinel 的落點，開放
+  寫入面等於讓一個跑 untrusted code 的帳號能偽造**任何** job 的完成狀態。Manager 讀
+  spool 時逐項驗形狀、gate 名稱必須落在 operator 的宣告集合內、payload 有界、`status`
+  由 `exit_code` 重算（與採信端 `_ledger_outcomes()` 同一條紀律）。
+- **產生的 job unit 檔頭不再固定寫 `--job`**：`JOB_UNIT_CLI_FLAG` 讓「重跑用哪一行」
+  跟著角色走。原本 reviewer／gate 的 unit 檔頭都寫著 `unit <scheme> --job`，operator
+  照抄會拿到 builder 的 unit **覆蓋掉**這一份。檔頭裡的 `Manager（cortex-svc）` 也改為
+  由 scheme 導出（二分時代的字面量殘留）。
+
+### Security
+- **spec §R3 新增「誠實的取捨：gate 執行身分買到的是圍堵，不是不可偽造」**——第四帳號
+  **不**使 gate 結果不可偽造：取得任意程式碼執行的 builder 依然能影響**自己那一份**
+  ledger 的內容，那是「執行對方交出來的測試碼」這件事本身的性質，換誰執行都一樣。
+  買到的是那個執行**碰不到**：Manager 的 durable state（含 exit sentinel）、builder 的
+  工作樹（只有 `rX`）、verdict／commit 通道、他人在 gate spool 的那一格（`wx` 無 `r`）、
+  以及任何 polkit grant。任何引用本 spec 的稽核或 PR 描述 MUST NOT 把它敘述成
+  「gate ledger 不可被 builder 影響」。
+- **spec §R9 新增族 5「gate 執行身分」**（T5.1–T5.10，含 negative control）；runbook
+  對應第 8b-3 步（族 7）。runbook 另新增第 1 步的第四個帳號、5-2c／5-2d（兩份 gate
+  模板 ＋ **真實加固面下**的驗證，含「拿掉 ACL 之後 build 卡必須 fail closed」的負向
+  對照）、5-5 的 `PSC_GATE_*` 設定，並把全文 scheme token 由 `three-way` 改為
+  `four-way`（附三分機器的升級路徑：只需建帳號、重跑權限 script、落兩份 unit ＋ 重跑
+  polkit，第 3／4 步完全不動）。

--- a/docs/superpowers/runbooks/trust-root-phase2b-setup.md
+++ b/docs/superpowers/runbooks/trust-root-phase2b-setup.md
@@ -38,11 +38,11 @@ OS** 的手動流程。
 | Manager 部署 | **`/opt/cortex`**（root 擁有，對服務唯讀）；system-level unit，`User=cortex-manager` | 第 4 步 |
 | `ReadWritePaths` | **由 R1 登記表經 permgen 機械產生**，不手寫；monitor 再多一層 persona 過濾，嚴格窄於 Manager | 第 4c／4d 步 |
 | root 命令 codify | **不 codify**——不提供 `cortex install trust-root --system`；cortex 只產生命令字串 | 第 6 步 |
-| R9 | **手動抽驗**（五族；完整自動化矩陣屬另一工項） | 第 8 步 |
+| R9 | **手動抽驗**（#629 起共**七族**：runbook 族 1–4 ＋ 族 5 privilege-boundary ＋ 族 6 verdict 通道 ＋ 族 7 gate 執行身分。完整自動化矩陣屬另一工項） | 第 8 步 |
 
 > **歷史註記（二分）**：0816 第二輪曾以二分（`cortex-svc` / `cortex-builder`）先行、
 > 三分為保留彈性；第三輪裁決後二分（`permgen.TWO_WAY_SCHEME`）**不再是可選路徑**，
-> 僅保留在程式碼中作為方案參數化的對照組，本 runbook 全文一律 `three-way`。
+> 僅保留在程式碼中作為方案參數化的對照組，本 runbook 全文一律 `four-way`。
 
 ### 為什麼是 A+B（而不是二選一）
 
@@ -188,7 +188,7 @@ getent passwd cortex-manager cortex-reviewer-planner cortex-builder \
 python3 - <<'PY'
 from paulsha_cortex.trust_root import permgen
 from paulsha_cortex.trust_root.registry import Principal
-s = permgen.SCHEMES["three-way"]
+s = permgen.SCHEMES["four-way"]
 print("scheme_id          :", s.scheme_id)
 print("manager            :", s.resolve(Principal.MANAGER))
 print("monitor            :", s.resolve(Principal.MONITOR))
@@ -353,52 +353,55 @@ A/B 並列時同一件事要寫兩遍（5-A／5-B、第 8 步兩種起法、附�
 ## 產生器＝權限／unit／polkit／shim 的單一真相
 
 `chown`／`chmod`／`setfacl`／unit 內容／polkit 規則**一律不手寫**，全部由 permgen 由
-R1 登記表機械產生。**三分（`three-way`）是唯一 scheme**：
+R1 登記表機械產生。**三分（`four-way`）是唯一 scheme**：
 
 ```bash
 # ✅ 完整權限計畫（JSON，含每項 rationale）
-python3 -m paulsha_cortex.trust_root permissions three-way
+python3 -m paulsha_cortex.trust_root permissions four-way
 
 # ✅ 可直接執行的權限命令（帶真實絕對路徑，無 placeholder）
-python3 -m paulsha_cortex.trust_root permissions three-way --commands --paths
+python3 -m paulsha_cortex.trust_root permissions four-way --commands --paths
 
 # ✅ 骨架目錄（非登記表資產的父層）
-python3 -m paulsha_cortex.trust_root scaffold three-way
+python3 -m paulsha_cortex.trust_root scaffold four-way
 
 # ✅ Manager system unit 內容（User=cortex-manager，ReadWritePaths 由登記表導出）
-python3 -m paulsha_cortex.trust_root unit three-way --manager
+python3 -m paulsha_cortex.trust_root unit four-way --manager
 
 # ✅ monitor system unit 內容（同帳號、同加固段，ReadWritePaths 嚴格窄於 Manager）
-python3 -m paulsha_cortex.trust_root unit three-way --monitor
+python3 -m paulsha_cortex.trust_root unit four-way --monitor
 
 # ✅ job template unit 內容（`User=` 硬寫死；B 的核心）——**四份**
 #    #643（加固剖面）：strict（預設）與 jit（node 型 executor），差異只有
 #      MemoryDenyWriteExecute 一項；對應表由 permgen.EXECUTOR_TOOLS 機械導出。
 #    #615（job 角色）：--job＝builder；--review-job＝reviewer＋planner
 #      （同帳號同模板）。兩個角色的差異全部由帳號帶出來。
-python3 -m paulsha_cortex.trust_root unit three-way --job
-python3 -m paulsha_cortex.trust_root unit three-way --job --profile jit
-python3 -m paulsha_cortex.trust_root unit three-way --review-job
-python3 -m paulsha_cortex.trust_root unit three-way --review-job --profile jit
+python3 -m paulsha_cortex.trust_root unit four-way --job
+python3 -m paulsha_cortex.trust_root unit four-way --job --profile jit
+python3 -m paulsha_cortex.trust_root unit four-way --review-job
+python3 -m paulsha_cortex.trust_root unit four-way --review-job --profile jit
+# ✅ #629：gate 執行身分的兩份模板（User=cortex-gate；只有 four-way 有這個帳號）
+python3 -m paulsha_cortex.trust_root unit four-way --gate-job
+python3 -m paulsha_cortex.trust_root unit four-way --gate-job --profile jit
 
 # ✅ 降權 polkit 規則內容（**單一檔、單一 addRule、單一 return YES**）
 #    放行的是四個具名模板的 start/stop：cortex-job@ / cortex-job-jit@ /
 #    cortex-reviewer-job@ / cortex-reviewer-job-jit@（皆 *.service）
-python3 -m paulsha_cortex.trust_root polkit three-way --template
+python3 -m paulsha_cortex.trust_root polkit four-way --template
 
 # ✅ root-owned shim 內容（/opt/cortex/bin/cortex-job-shim）—— #616 已 merge
-python3 -m paulsha_cortex.trust_root shim three-way
+python3 -m paulsha_cortex.trust_root shim four-way
 
 # ✅ 帳號 HOME 下 root-owned 的 .gitconfig 內容（來源樹的 safe.directory）
 #    <slug> ＝ 來源樹底下那一格的目錄名（見第 2c 步）；未給即 fail-closed。
 #    三份同構：兩個 job 帳號 ＋ Manager（Manager 也對來源樹跑 git，同樣會撞 dubious ownership）。
-python3 -m paulsha_cortex.trust_root gitconfig three-way --builder --source-repo <slug>
-python3 -m paulsha_cortex.trust_root gitconfig three-way --reviewer-planner --source-repo <slug>
-python3 -m paulsha_cortex.trust_root gitconfig three-way --manager --source-repo <slug>
+python3 -m paulsha_cortex.trust_root gitconfig four-way --builder --source-repo <slug>
+python3 -m paulsha_cortex.trust_root gitconfig four-way --reviewer-planner --source-repo <slug>
+python3 -m paulsha_cortex.trust_root gitconfig four-way --manager --source-repo <slug>
 
 # ✅ executor toolchain 的落位步驟（#640；四個模型 CLI 進 /opt/cortex/toolchain、
 #    node 走系統層、job 的 PSC_BUILDER_PATH 值）——見第 4e 步
-python3 -m paulsha_cortex.trust_root toolchain three-way
+python3 -m paulsha_cortex.trust_root toolchain four-way
 ```
 
 **job-spec 的欄位契約也已隨 #616 落地**——`coordinator/job_runner.py` 的
@@ -426,22 +429,36 @@ PY
 
 ---
 
-## 第 1 步：建 UID（**三分**）
+## 第 1 步：建 UID（**四分**）
 
-建立三個 **system service 帳號**，皆 **no-login**、**home 由 root 擁有**。
+建立四個 **system service 帳號**，皆 **no-login**、**home 由 root 擁有**。
 慣例：每帳號一個同名 primary group（權限產生器的 ACL 以此為前提）。
 
 | 帳號 | 跑什麼 | durable state owner | 持 spawn 授權（polkit subject） |
 |---|---|:--:|:--:|
 | `cortex-manager` | Manager ＋ monitor。**不跑任何模型程式碼** | ✔ | ✔ |
 | `cortex-reviewer-planner` | reviewer ＋ planner 模型 job | ✘ | ✘ |
-| `cortex-builder` | builder 模型 job（唯一會跑 untrusted repo code） | ✘ | ✘ |
+| `cortex-builder` | builder 模型 job（會跑 untrusted repo code） | ✘ | ✘ |
+| **`cortex-gate`**（#629） | operator 宣告的 gate 命令（`PSC_GATE_CMD_*`）。**不跑模型**，但跑 builder 工作樹裡的 `conftest.py`／plugin ⇒ 同樣是 untrusted 執行 | ✘ | ✘ |
+
+> **為什麼一定要第四個帳號**（#629；完整論證見 spec §R3「誠實的取捨：gate 執行身分」）：
+> gate 命令必然在 builder 完全掌控內容的樹上執行，`pytest` 會載入該樹的 `conftest.py`
+> ⇒ **執行者取得任意程式碼執行**。既有三個逐一皆不可承接——`cortex-builder`＝模型自證
+> （違反 #540 的 acceptance chain）、`cortex-manager`＝把那個執行引到持 spawn 授權、
+> 擁有全部 durable state 的帳號、`cortex-reviewer-planner`＝它是寫 verdict 的那一個
+> （等於把 #638／#639 剛關掉的通道重新打開）。
+>
+> **不能用 `DynamicUser=yes` 省掉這個帳號**：本方案兩端都靠**具名 POSIX ACL**
+> 授權（gate 對 `gate-ledger-spool` 是 `wx` 無 `r`、對 builder 工作樹是 `rX`），
+> 而 `setfacl -m u:<名>:…` 在**產生權限的當下**就要解析得到那個帳號；DynamicUser
+> 的 UID 在 unit 起動前不存在、每次還不同。`User=nobody` 更糟——那是與系統上其他
+> 服務共用的帳號，授它 Tier-0 spool 的寫入權等於開給所有 `nobody` 行程。
 
 ```bash
 # ✅ 先取產生器對三分方案的 HOME／cache 計畫——**不手寫路徑**
 python3 - <<'PY'
 from paulsha_cortex.trust_root import permgen
-s = permgen.SCHEMES["three-way"]
+s = permgen.SCHEMES["four-way"]
 for path, owner, group, mode in permgen.DEFAULT_LAYOUT.scaffold_directories(s):
     if path.startswith("/var/lib/cortex-"):
         print(f"{path}\t{owner}:{group}\t{mode:04o}")
@@ -476,13 +493,26 @@ sudo useradd  --system --gid cortex-reviewer-planner \
      --shell /usr/sbin/nologin \
      --comment "cortex reviewer/planner model job" cortex-reviewer-planner
 
-# 🔧 sudo：cortex-builder（builder 模型 job；唯一跑 untrusted repo code）
+# 🔧 sudo：cortex-builder（builder 模型 job；跑 untrusted repo code）
 sudo groupadd --system cortex-builder
 sudo useradd  --system --gid cortex-builder \
      --home-dir /var/lib/cortex-builder --no-create-home \
      --shell /usr/sbin/nologin \
      --comment "cortex headless builder job" cortex-builder
+
+# 🔧 sudo：cortex-gate（#629；operator 宣告的 gate 命令，不跑模型）
+sudo groupadd --system cortex-gate
+sudo useradd  --system --gid cortex-gate \
+     --home-dir /var/lib/cortex-gate --no-create-home \
+     --shell /usr/sbin/nologin \
+     --comment "cortex gate execution identity (declared gate commands, no model)" \
+     cortex-gate
 ```
+
+> **gate 帳號沒有 `~/.codex`、也沒有 executor 憑證**——它不跑模型 CLI。這件事由
+> `scaffold_directories()` 機械保證（來源是 `scheme.model_job_accounts()`，不是
+> `headless_accounts()`）。若第 2 步的 scaffold script 裡出現
+> `/var/lib/cortex-gate/.codex` ⇒ 停下來，部署樹比 #629 舊。
 
 > **不需要手動補目錄**：舊版此處有四行 `install -d` 替 `cortex-reviewer-planner`
 > 補 HOME／`.codex`／`cache`——#616 讓 `scaffold_directories()` 改由
@@ -492,7 +522,7 @@ sudo useradd  --system --gid cortex-builder \
 > script 內容，不是磁碟現況）。若上一輪已手建過，第 2 步的 scaffold 冪等重跑
 > 會把 owner／mode 拉回計畫值，不必先刪。
 
-**為何 `--no-create-home`**：三個帳號的 HOME 由第 2 步以 **root 擁有**的方式建立
+**為何 `--no-create-home`**：四個帳號的 HOME 由第 2 步以 **root 擁有**的方式建立
 （`useradd --create-home` 會把 HOME 建成帳號自己擁有）。HOME 若由帳號自己擁有，
 它就能 rename 掉 `~/.codex`／`~/.gitconfig` 這類 root-owned 設定的**父目錄**——
 父目錄可寫者能 unlink／rename 子物件，等於保護失效。只有 `cache/` 子目錄開放給帳號寫。
@@ -500,28 +530,32 @@ sudo useradd  --system --gid cortex-builder \
 **群組設計理由**：跨帳號存取一律走 **per-account POSIX ACL**（見 permgen 輸出的
 `setfacl -m u:<acct>:rX`），**不**用共用 group 開放，避免「一個 group 開了就全開」。
 三分之後這條更關鍵：`cortex-reviewer-planner` 對 verdict spool 的授權是
-**write-only（`wx` 無 `r`）**，只有 per-account ACL 表達得出來。
+**write-only（`wx` 無 `r`）**，只有 per-account ACL 表達得出來；#629 的 `cortex-gate`
+再加兩條同樣只有 ACL 表達得出來的授權——對 `gate-ledger-spool` 的 `wx` 無 `r`，
+以及對 builder per-job 工作樹的 `rX`（**讀得到、寫不進**）。
 
 ```bash
-# ✅ 驗證：三帳號存在、shell 為 nologin、三個 group 互不交集
-getent passwd cortex-manager cortex-reviewer-planner cortex-builder
-id cortex-manager; id cortex-reviewer-planner; id cortex-builder
-#   期望：uid/gid 各自成對；三者的 groups 互不包含對方
-getent group cortex-manager cortex-reviewer-planner cortex-builder
+# ✅ 驗證：四帳號存在、shell 為 nologin、四個 group 互不交集
+getent passwd cortex-manager cortex-reviewer-planner cortex-builder cortex-gate
+id cortex-manager; id cortex-reviewer-planner; id cortex-builder; id cortex-gate
+#   期望：uid/gid 各自成對；四者的 groups 互不包含對方
+getent group cortex-manager cortex-reviewer-planner cortex-builder cortex-gate
 
-# ✅ 驗證：三個帳號都登不進去（nologin），且都不在 sudo／wheel 群組
-for U in cortex-manager cortex-reviewer-planner cortex-builder; do
+# ✅ 驗證：四個帳號都登不進去（nologin），且都不在 sudo／wheel 群組
+for U in cortex-manager cortex-reviewer-planner cortex-builder cortex-gate; do
   printf '%s shell=%s groups=%s\n' "$U" "$(getent passwd "$U" | cut -d: -f7)" "$(id -nG "$U")"
 done
 #   期望：shell 全為 /usr/sbin/nologin；groups 只含自己的同名 group
 
-# ✅ 驗證：模型 job 帳號兩兩互不可讀對方 HOME（三分的第一條不變式）
+# ✅ 驗證：job 帳號兩兩互不可讀對方 HOME（分帳的第一條不變式）
 sudo -u cortex-builder ls /var/lib/cortex-reviewer-planner/cache 2>&1 | tail -1
 sudo -u cortex-reviewer-planner ls /var/lib/cortex-builder/cache 2>&1 | tail -1
-#   期望：兩者皆 Permission denied（cache 為 0700 且 owner 不同）
+sudo -u cortex-gate ls /var/lib/cortex-builder/cache 2>&1 | tail -1
+sudo -u cortex-builder ls /var/lib/cortex-gate/cache 2>&1 | tail -1
+#   期望：四者皆 Permission denied（cache 為 0700 且 owner 不同）
 
-# ✅ 驗證：三帳號皆無 sudo 授權（**與執行前提 G2 成對**——這是 G2 的事後複驗）
-for U in cortex-manager cortex-reviewer-planner cortex-builder; do
+# ✅ 驗證：四帳號皆無 sudo 授權（**與執行前提 G2 成對**——這是 G2 的事後複驗）
+for U in cortex-manager cortex-reviewer-planner cortex-builder cortex-gate; do
   printf '=== %s ===\n' "$U"
   sudo -l -U "$U" 2>&1 | tail -2
   sudo -u "$U" sudo -n true 2>&1 | tail -1
@@ -535,8 +569,10 @@ done
 
 **回滾**：
 ```bash
-sudo userdel cortex-manager; sudo userdel cortex-reviewer-planner; sudo userdel cortex-builder
-sudo groupdel cortex-manager; sudo groupdel cortex-reviewer-planner; sudo groupdel cortex-builder
+sudo userdel cortex-manager; sudo userdel cortex-reviewer-planner
+sudo userdel cortex-builder; sudo userdel cortex-gate
+sudo groupdel cortex-manager; sudo groupdel cortex-reviewer-planner
+sudo groupdel cortex-builder; sudo groupdel cortex-gate
 ```
 （此時尚無任何檔案或目錄屬於它們——HOME／cache 由第 2 步的 scaffold 建立。）
 
@@ -551,7 +587,7 @@ sudo groupdel cortex-manager; sudo groupdel cortex-reviewer-planner; sudo groupd
 
 ```bash
 # ✅ 產生骨架目錄 script（非登記表資產的父層：/opt/cortex、HOME、job spool…）
-python3 -m paulsha_cortex.trust_root scaffold three-way > /tmp/p2b-scaffold.sh
+python3 -m paulsha_cortex.trust_root scaffold four-way > /tmp/p2b-scaffold.sh
 
 # ✅ operator 與外部 outbox reader 是**抽象角色名**，不是帳號——對應到誰是**部署決定**，
 #    必須在產生當下指定（#626）。未指定時產生器 fail-closed：stdout 一行都不輸出、
@@ -566,7 +602,7 @@ getent passwd "$OPERATOR_ACCOUNT" >/dev/null \
 #    該角色的 ACL 整組略去（是一個被記錄下來的決定，不是漏掉）。之後真的有了
 #    再改成它的帳號名重跑即可。旗標也可改用 env：PSC_OPERATOR_ACCOUNT／
 #    PSC_EXTERNAL_READER_ACCOUNT（旗標優先）。
-python3 -m paulsha_cortex.trust_root permissions three-way --commands --paths \
+python3 -m paulsha_cortex.trust_root permissions four-way --commands --paths \
   --operator-account "$OPERATOR_ACCOUNT" \
   --external-reader-account none \
   > /tmp/p2b-permissions.sh
@@ -818,7 +854,7 @@ sudo setfacl -R -d -m u:cortex-builder:rX,u:cortex-reviewer-planner:rX \
 # 🔧 sudo：三份 root-owned .gitconfig（內容由 permgen 產生，勿手寫）
 # 旗標名與帳號後綴刻意同名：--<who> 的產物落在 /var/lib/cortex-<who>/.gitconfig。
 for who in builder reviewer-planner manager; do
-  python3 -m paulsha_cortex.trust_root gitconfig three-way --"$who" --source-repo "$SLUG" \
+  python3 -m paulsha_cortex.trust_root gitconfig four-way --"$who" --source-repo "$SLUG" \
     | sudo tee "/var/lib/cortex-$who/.gitconfig" >/dev/null
 done
 sudo chown root:root /var/lib/cortex-{builder,reviewer-planner,manager}/.gitconfig
@@ -1231,7 +1267,7 @@ sudo chmod 0644 /opt/cortex/etc/cortex-manager.env
 
 ```bash
 # ✅ 驗證：owner/mode 與 permgen 的 deployment 區塊一致
-python3 -m paulsha_cortex.trust_root permissions three-way --commands --paths \
+python3 -m paulsha_cortex.trust_root permissions four-way --commands --paths \
   | grep -A3 "runtime-bootstrap-env"
 ls -l /opt/cortex/etc/cortex-manager.env
 #   期望：-rw-r--r-- root root
@@ -1252,10 +1288,10 @@ sudo -u cortex-manager env $(grep -v '^#' /opt/cortex/etc/cortex-manager.env | x
 
 ```bash
 # ✅ 先看內容（ReadWritePaths 逐條附「涵蓋哪些登記表資產」註解）
-python3 -m paulsha_cortex.trust_root unit three-way --manager | less
+python3 -m paulsha_cortex.trust_root unit four-way --manager | less
 
 # 🔧 sudo：寫入 unit（內容一字不改，直接由產生器落檔）
-python3 -m paulsha_cortex.trust_root unit three-way --manager \
+python3 -m paulsha_cortex.trust_root unit four-way --manager \
   | sudo tee /etc/systemd/system/cortex-manager.service >/dev/null
 sudo chown root:root /etc/systemd/system/cortex-manager.service
 sudo chmod 0644 /etc/systemd/system/cortex-manager.service
@@ -1276,7 +1312,7 @@ systemctl show cortex-manager.service \
 #         CapabilityBoundingSet=（空）
 
 # ✅ 驗證：unit 檔內容與產生器輸出逐位元相同（防手改漂移）
-diff <(python3 -m paulsha_cortex.trust_root unit three-way --manager) \
+diff <(python3 -m paulsha_cortex.trust_root unit four-way --manager) \
      /etc/systemd/system/cortex-manager.service && echo "unit in sync: OK"
 
 # ✅ 驗證：加固評分（systemd 自己的評估，僅供對照）
@@ -1346,15 +1382,15 @@ writer／spool-consumer 面導出。
 
 ```bash
 # ✅ 先看內容（ReadWritePaths 逐條附「涵蓋哪些登記表資產」註解）
-python3 -m paulsha_cortex.trust_root unit three-way --monitor | less
+python3 -m paulsha_cortex.trust_root unit four-way --monitor | less
 
 # ✅ 先驗「窄」這件事本身：monitor 的 RWP 必須是 Manager 的真子集
-diff <(python3 -m paulsha_cortex.trust_root unit three-way --monitor | grep ^ReadWritePaths=) \
-     <(python3 -m paulsha_cortex.trust_root unit three-way --manager | grep ^ReadWritePaths=)
+diff <(python3 -m paulsha_cortex.trust_root unit four-way --monitor | grep ^ReadWritePaths=) \
+     <(python3 -m paulsha_cortex.trust_root unit four-way --manager | grep ^ReadWritePaths=)
 #   期望：只有 `<` 那側缺行（monitor 少），**不得**出現 `>` 獨有的 monitor 條目
 
 # 🔧 sudo：寫入 unit（內容一字不改，直接由產生器落檔）
-python3 -m paulsha_cortex.trust_root unit three-way --monitor \
+python3 -m paulsha_cortex.trust_root unit four-way --monitor \
   | sudo tee /etc/systemd/system/cortex-monitor.service >/dev/null
 sudo chown root:root /etc/systemd/system/cortex-monitor.service
 sudo chmod 0644 /etc/systemd/system/cortex-monitor.service
@@ -1382,7 +1418,7 @@ sudo systemctl start cortex-monitor.service
 
 ```bash
 # ✅ 驗證：unit 檔內容與產生器輸出逐位元相同（防手改漂移）
-diff <(python3 -m paulsha_cortex.trust_root unit three-way --monitor) \
+diff <(python3 -m paulsha_cortex.trust_root unit four-way --monitor) \
      /etc/systemd/system/cortex-monitor.service && echo "monitor unit in sync: OK"
 
 # ✅ 驗證：身分與加固段（應與 cortex-manager.service 逐項相同）
@@ -1476,7 +1512,7 @@ job／服務帳號唯讀＋可執行）。理由是「job 跑的是哪個版本�
 
 ```bash
 # ✅ 先讀落位步驟（含每支 CLI 的形態與搬移方式；產生器＝單一真相）
-python3 -m paulsha_cortex.trust_root toolchain three-way | less
+python3 -m paulsha_cortex.trust_root toolchain four-way | less
 
 # 🔧 sudo：系統層 node（apt；nodesource repo 已設定時候選為 20.x）
 sudo apt-get install -y nodejs
@@ -1504,7 +1540,7 @@ sudo chmod -R u=rwX,go=rX /opt/cortex/toolchain
 
 ```bash
 # ✅ 驗證：權限與登記表產生的計畫逐位元一致
-python3 -m paulsha_cortex.trust_root permissions three-way --commands --paths \
+python3 -m paulsha_cortex.trust_root permissions four-way --commands --paths \
   --operator-account "$USER" --external-reader-account none \
   | grep -A3 "executor-toolchain"
 ls -ld /opt/cortex/toolchain
@@ -1587,7 +1623,7 @@ ls -l  /var/lib/cortex-builder/.codex/auth.json
 #   期望：目錄 drwxr-xr-x root root；檔案 -rw------- cortex-builder cortex-builder
 
 # ✅ 驗證：與登記表產生的計畫一致
-python3 -m paulsha_cortex.trust_root permissions three-way --commands --paths \
+python3 -m paulsha_cortex.trust_root permissions four-way --commands --paths \
   --operator-account "$USER" --external-reader-account none \
   | grep "executor-credential"
 #   期望：chown cortex-builder:cortex-builder … ＋ chmod 0600 …（帶 `[ ! -e ] ||` 守衛）
@@ -1645,19 +1681,20 @@ sudo -u cortex-builder sh -c \
   fail-closed（`job-runner-job-template-missing`），不會靜默退回 strict 那份。
 - 少了 (c)，argv 的入口落在 Manager 可寫的樹裡；Manager 被攻陷即可換掉執行的東西。
 
-### 5-2. 安裝 (b) template unit（**四份**＝2 角色 × 2 加固剖面）
+### 5-2. 安裝 (b) template unit（**六份**＝3 角色 × 2 加固剖面）
 
-> **為什麼是四份**：unit 檔裡寫死兩件事，兩件都不能靠參數傳——
+> **為什麼是六份**：unit 檔裡寫死兩件事，兩件都不能靠參數傳——
 >
-> - **`User=`**（#615 M2）：builder 與 reviewer／planner 是不同的 OS 帳號
->   ⇒ 不同的檔、不同的名字。planner **不另開第三份**：三分方案把它與 reviewer 映到
+> - **`User=`**（#615 M2、#629）：builder／reviewer-planner／gate 是三個不同的
+>   OS 帳號 ⇒ 三組檔、三個名字。planner **不另開一份**：方案把它與 reviewer 映到
 >   同一個帳號（`cortex-reviewer-planner`），同帳號 ⇒ 同 unit。
 > - **加固指令**（#643）：一個模板只有一份加固段 ⇒ 兩種剖面必然是兩個檔。
 >
-> 四份**共用同一張 `_HARDENING` 表與同一條 `ReadWritePaths` 導出規則**：角色之間的
+> 六份**共用同一張 `_HARDENING` 表與同一條 `ReadWritePaths` 導出規則**：角色之間的
 > 全部差異都是「帳號」帶出來的（`User=`／`Group=`／HOME／cache／登記表上該帳號的
 > 可寫面），產生器裡沒有任何一行 `if principal is …`。測試以**集合比對**釘住
-> （`tests/test_reviewer_planner_downgrade_615.py::HardeningParityTests`）。
+> （`tests/test_reviewer_planner_downgrade_615.py::HardeningParityTests` 與
+> `tests/test_gate_execution_identity_629.py::GateHardeningParityTests`）。
 
 | unit | `User=` | 給誰 |
 |---|---|---|
@@ -1665,12 +1702,20 @@ sudo -u cortex-builder sh -c \
 | `cortex-job-jit@.service` | `cortex-builder` | builder，node 型 executor（`codex`／`copilot`） |
 | `cortex-reviewer-job@.service` | `cortex-reviewer-planner` | reviewer＋planner，原生 ELF executor |
 | `cortex-reviewer-job-jit@.service` | `cortex-reviewer-planner` | reviewer＋planner，node 型 executor |
+| `cortex-gate-job@.service` | **`cortex-gate`** | #629 gate 執行身分，**預設**剖面 |
+| `cortex-gate-job-jit@.service` | **`cortex-gate`** | #629 gate 執行身分，宣告了 node 型 gate（`npm test`）時才用 |
+
+> **gate 的剖面由誰選**：不是 executor（gate 不跑模型），而是 **operator** 的
+> `PSC_GATE_HARDENING_PROFILE`（預設 `strict`）。這與 #643「剖面不由呼叫端選」
+> **不衝突**：#643 擋的是「job 能影響自己的剖面」，而 gate 的命令本身就是 operator
+> 宣告的——宣告命令卻不能宣告它需要哪份剖面才是不一致的。值不合法時 fail-closed
+> （不落回預設：一個打錯的 `jti` 落回 strict 會讓 node 型 gate 全崩而設定看起來是對的）。
 
 ```bash
 # ✅ 先看 reviewer 那兩份（與 builder 的差異必須**只有帳號帶出來的那幾行**）
-python3 -m paulsha_cortex.trust_root unit three-way --review-job | less
-diff <(python3 -m paulsha_cortex.trust_root unit three-way --job) \
-     <(python3 -m paulsha_cortex.trust_root unit three-way --review-job) \
+python3 -m paulsha_cortex.trust_root unit four-way --review-job | less
+diff <(python3 -m paulsha_cortex.trust_root unit four-way --job) \
+     <(python3 -m paulsha_cortex.trust_root unit four-way --review-job) \
   | grep -E "^[<>] [A-Za-z]" | sort
 #   期望只出現這幾類指令行的差異（其餘逐字相同）：
 #     User= / Group=                      ← 帳號
@@ -1680,7 +1725,7 @@ diff <(python3 -m paulsha_cortex.trust_root unit three-way --job) \
 #      分岔了，**停下來**：本步驟的前提（四份共用同一張表）不再成立。
 
 # ✅ reviewer 的 ReadWritePaths 必須**恰好兩條**，且不含 builder 的任何面
-python3 -m paulsha_cortex.trust_root unit three-way --review-job | grep '^ReadWritePaths='
+python3 -m paulsha_cortex.trust_root unit four-way --review-job | grep '^ReadWritePaths='
 #   期望恰好兩行：
 #     ReadWritePaths=/var/lib/cortex-reviewer-planner/cache
 #     ReadWritePaths=/var/lib/cortex/coordinator/review-verdicts
@@ -1717,16 +1762,16 @@ python3 -m paulsha_cortex.trust_root unit three-way --review-job | grep '^ReadWr
 
 ```bash
 # ✅ 先看兩份內容（剖面在檔頭以「=== 加固剖面 ===」段標明，含它接受的代價）
-python3 -m paulsha_cortex.trust_root unit three-way --job | less
-python3 -m paulsha_cortex.trust_root unit three-way --job --profile jit | less
+python3 -m paulsha_cortex.trust_root unit four-way --job | less
+python3 -m paulsha_cortex.trust_root unit four-way --job --profile jit | less
 #   兩份都必須確認的三行：
 #     User=cortex-builder      ← 唯一 UID 來源，寫死
 #     Group=cortex-builder
 #     ExecStart=…              ← 見 5-3；PR 落地後應指向 /opt/cortex/bin/cortex-job-shim
 
 # ✅ 兩份的差異必須**只有一項**（這條先跑；不成立就不要落檔）
-diff <(python3 -m paulsha_cortex.trust_root unit three-way --job) \
-     <(python3 -m paulsha_cortex.trust_root unit three-way --job --profile jit) \
+diff <(python3 -m paulsha_cortex.trust_root unit four-way --job) \
+     <(python3 -m paulsha_cortex.trust_root unit four-way --job --profile jit) \
   | grep -E "^[<>] [A-Za-z]" | sort
 #   期望恰好兩行（同一個鍵的兩個值）：
 #     < MemoryDenyWriteExecute=yes
@@ -1737,9 +1782,9 @@ diff <(python3 -m paulsha_cortex.trust_root unit three-way --job) \
 # 🔧 sudo：落檔**四份**（root 擁有——這是 User= 不可被竄改的前提）
 for W in --job --review-job; do
   for P in "" "--profile jit"; do
-    U=$(python3 -m paulsha_cortex.trust_root unit three-way $W $P \
+    U=$(python3 -m paulsha_cortex.trust_root unit four-way $W $P \
           | sed -n '1s|^# /etc/systemd/system/||p')
-    python3 -m paulsha_cortex.trust_root unit three-way $W $P \
+    python3 -m paulsha_cortex.trust_root unit four-way $W $P \
       | sudo tee "/etc/systemd/system/$U" >/dev/null
     sudo chown root:root "/etc/systemd/system/$U"
     sudo chmod 0644 "/etc/systemd/system/$U"
@@ -1751,13 +1796,13 @@ sudo systemctl daemon-reload
 #                 cortex-reviewer-job@ / cortex-reviewer-job-jit@（.service）
 
 # ✅ 驗證：與產生器逐位元相同、User= 確實寫死
-diff <(python3 -m paulsha_cortex.trust_root unit three-way --job) \
+diff <(python3 -m paulsha_cortex.trust_root unit four-way --job) \
      /etc/systemd/system/cortex-job@.service && echo "job unit (strict) in sync: OK"
-diff <(python3 -m paulsha_cortex.trust_root unit three-way --job --profile jit) \
+diff <(python3 -m paulsha_cortex.trust_root unit four-way --job --profile jit) \
      /etc/systemd/system/cortex-job-jit@.service && echo "job unit (jit) in sync: OK"
-diff <(python3 -m paulsha_cortex.trust_root unit three-way --review-job) \
+diff <(python3 -m paulsha_cortex.trust_root unit four-way --review-job) \
      /etc/systemd/system/cortex-reviewer-job@.service && echo "review unit (strict) in sync: OK"
-diff <(python3 -m paulsha_cortex.trust_root unit three-way --review-job --profile jit) \
+diff <(python3 -m paulsha_cortex.trust_root unit four-way --review-job --profile jit) \
      /etc/systemd/system/cortex-reviewer-job-jit@.service && echo "review unit (jit) in sync: OK"
 for U in cortex-job cortex-job-jit cortex-reviewer-job cortex-reviewer-job-jit; do
   echo "--- $U"
@@ -1864,6 +1909,103 @@ PY
 #      的 needs_node（那張表是唯一真相來源），不要在 runbook 裡各記一份。
 ```
 
+### 5-2c. 兩份 gate 模板（#629 gate 執行身分）
+
+```bash
+# ✅ 先看內容，並確認與 builder 的差異**只有帳號帶出來的那幾行**
+python3 -m paulsha_cortex.trust_root unit four-way --gate-job | less
+diff <(python3 -m paulsha_cortex.trust_root unit four-way --job) \
+     <(python3 -m paulsha_cortex.trust_root unit four-way --gate-job) \
+  | grep -E "^[<>] [A-Za-z]" | sort
+#   期望只出現這幾類指令行的差異（其餘逐字相同）：
+#     User= / Group=                      ← 帳號
+#     Environment=HOME= / XDG_CACHE_HOME= ← 帳號的 HOME
+#     ReadWritePaths=                     ← 登記表上該帳號的可寫面
+#   ⚠️ 若任何加固鍵出現在差異裡 ⇒ 停下來：本步驟的前提（六份共用同一張表）不成立。
+
+# ✅ gate 的 ReadWritePaths 必須**恰好三條**，且不含 builder／Manager 的任何面
+python3 -m paulsha_cortex.trust_root unit four-way --gate-job | grep '^ReadWritePaths='
+#   期望恰好三行：
+#     ReadWritePaths=/var/lib/cortex-gate/cache
+#     ReadWritePaths=/var/lib/cortex/coordinator/gate-ledger-spool
+#     ReadWritePaths=/var/lib/cortex/gate-worktree
+#   ⚠️ 出現 /var/lib/cortex/runtime/dispatch ⇒ **立即停止**：那是 gate ledger 與
+#      exit sentinel 的落點，gate 寫得進去等於它能偽造任何 job 的完成狀態（#628 失效）。
+#   ⚠️ 出現 /var/lib/cortex/worktree/%i ⇒ 停下來：gate 只該**讀**被驗的樹（rX ACL），
+#      命令一律跑在它自己 pool 底下的拋棄式副本上。
+#   ⚠️ 出現 review-verdicts 或 commit-spool ⇒ 停下來：#638／#639 的通道被重新打開。
+
+# 🔧 sudo：落檔（兩份）
+sudo install -o root -g root -m 0644 /dev/stdin /etc/systemd/system/cortex-gate-job@.service \
+  < <(python3 -m paulsha_cortex.trust_root unit four-way --gate-job)
+sudo install -o root -g root -m 0644 /dev/stdin /etc/systemd/system/cortex-gate-job-jit@.service \
+  < <(python3 -m paulsha_cortex.trust_root unit four-way --gate-job --profile jit)
+sudo systemctl daemon-reload
+
+# ✅ 落檔後檢查（產生器修好 ≠ 已落檔的 unit 跟著更新，#643 的教訓）
+sudo systemd-analyze verify cortex-gate-job@.service 2>&1 | grep -i "unknown key" && \
+  echo "⚠️ 有未知鍵——停下來" || echo "OK：無未知鍵"
+systemctl cat cortex-gate-job@.service | grep -E "^(User|Group|ExecStart)="
+#   期望：User=cortex-gate / Group=cortex-gate / ExecStart=/opt/cortex/bin/cortex-job-shim %i
+```
+
+### 5-2d. 在**真實加固面下**驗證 gate 身分（#629 的核心驗收）
+
+> **只驗寬鬆環境會整個溜過去**（#642 第 4e 步／#643 第 5-2b 步的同一個教訓）：
+> 下面每一條的結論都來自「已落檔的 unit ＋ 真實 ACL ＋ 真實 UID」，在單 UID 的
+> 開發機或 CI 容器裡跑同樣的命令一律會綠，而那個綠不代表任何事。
+
+```bash
+# ✅ (1) gate 真的以 cortex-gate 執行，而且 dispatch log 目錄對它是唯讀的
+sudo systemd-run --uid=cortex-gate --gid=cortex-gate --pipe --wait \
+  -p ProtectSystem=strict \
+  -p ReadWritePaths=/var/lib/cortex/coordinator/gate-ledger-spool \
+  -p ReadWritePaths=/var/lib/cortex/gate-worktree \
+  /bin/sh -c 'id -un; : > /var/lib/cortex/runtime/dispatch/probe.$$ && echo "BAD: wrote" || echo "OK: EROFS/EACCES"'
+#   期望：第一行 cortex-gate；第二行 OK。
+#   ⚠️ 出現 BAD ⇒ 立即停止：#628 的作者歸屬在檔案層失效。
+
+# ✅ (2) gate 讀得到 builder 的工作樹，但寫不進去（rX，沒有 w）
+#     先取一個真實存在的 per-job 工作區（沒有就先派一張 build 卡）
+JOBDIR=$(sudo ls -1d /var/lib/cortex/worktree/*/ 2>/dev/null | head -1)
+sudo -u cortex-gate ls "$JOBDIR" >/dev/null 2>&1 && echo "OK: readable" || echo "BAD: not readable"
+sudo -u cortex-gate touch "$JOBDIR/psc-gate-probe" 2>&1 | tail -1
+#   期望：第一行 OK；第二行 Permission denied。
+#   ⚠️ 「not readable」⇒ gate 跑不了任何 gate（快照會失敗）：檢查
+#      `setfacl -m u:cortex-gate:rX` 是否套到該 job 目錄，以及**容器層的 default ACL**
+#      （per-job 目錄是 job 帳號在 dispatch 當下建的，繼承的是容器的 default ACL）。
+#   ⚠️ 「touch 成功」⇒ 立即停止：gate 能污染 harvest 的來源。
+
+# ✅ (3) gate 寫得進自己那一格 spool，但讀不到別人的（wx 無 r）
+sudo install -d -o cortex-manager -g cortex-manager -m 0700 \
+  /var/lib/cortex/coordinator/gate-ledger-spool/probe-a \
+  /var/lib/cortex/coordinator/gate-ledger-spool/probe-b
+sudo setfacl -m u:cortex-gate:wx /var/lib/cortex/coordinator/gate-ledger-spool/probe-a
+sudo -u cortex-gate sh -c 'echo x > /var/lib/cortex/coordinator/gate-ledger-spool/probe-a/ledger.json' \
+  && echo "OK: wrote own slot" || echo "BAD: cannot write own slot"
+sudo -u cortex-gate ls /var/lib/cortex/coordinator/gate-ledger-spool/probe-a 2>&1 | tail -1
+#   期望：第一行 OK；第二行 Permission denied（有 wx 沒有 r ⇒ 寫得進、列不出來）。
+sudo -u cortex-gate ls /var/lib/cortex/coordinator/gate-ledger-spool/probe-b 2>&1 | tail -1
+#   期望：Permission denied（連 traverse 都沒有）。
+sudo rm -rf /var/lib/cortex/coordinator/gate-ledger-spool/probe-a \
+            /var/lib/cortex/coordinator/gate-ledger-spool/probe-b
+
+# ✅ (4) 端到端：派一張 build 卡，確認 ledger 由 **Manager** 擁有
+#     （gate 交付的那一份留在 spool 裡並已封口）
+sudo ls -l /var/lib/cortex/runtime/dispatch/*.gates.json | tail -3
+#   期望：owner 為 cortex-manager。
+#   ⚠️ owner 是 cortex-gate ⇒ 停下來：採信端會以 gate-ledger-foreign-author 拒掉，
+#      而且代表權威 ledger 的落地路徑被繞過了。
+sudo ls -ld /var/lib/cortex/coordinator/gate-ledger-spool/*/ | tail -3
+#   期望：mode 為 dr-x------（0500，已封口）。
+
+# ✅ (5) 負向對照：把 gate 帳號的 ACL 拿掉之後，build 卡必須 **fail closed**
+#     （不是靜默通過，也不是退回 Manager 進程內執行）
+#   做法：`setfacl -x u:cortex-gate <spool>`，重派一張 build 卡，
+#   期望 run 停在 needs_human 且理由指向 gate 執行面（gate-spool-* 診斷碼），
+#   **絕不**出現「卡過了」。驗完記得把 ACL 加回去（或重跑第 2 步的權限 script）。
+```
+
 ### 5-3. 部署 (c) root-owned shim
 
 shim 是 C（code-level argv 保證）從 Manager 端**搬進 root-owned 檔案**的那一步：
@@ -1894,7 +2036,7 @@ job 的 argv 不再由 Manager 行程直接組出並交給 systemd，而是由 r
 
 ```bash
 # ✅ 產生 shim 內容（#616 已 merge；產生器是唯一真相）
-python3 -m paulsha_cortex.trust_root shim three-way > /tmp/cortex-job-shim
+python3 -m paulsha_cortex.trust_root shim four-way > /tmp/cortex-job-shim
 
 # ✅ 檢查安裝好的 template unit 實際的 ExecStart
 systemctl cat cortex-job@.service | grep -E "^ExecStart="
@@ -1950,7 +2092,7 @@ sudo install -d -o root -g root -m 0755 /opt/cortex/bin
 sudo install -o root -g root -m 0755 /tmp/cortex-job-shim /opt/cortex/bin/cortex-job-shim
 
 # ✅ 驗證：與產生器逐位元相同
-diff <(python3 -m paulsha_cortex.trust_root shim three-way) /opt/cortex/bin/cortex-job-shim \
+diff <(python3 -m paulsha_cortex.trust_root shim four-way) /opt/cortex/bin/cortex-job-shim \
   && echo "shim in sync: OK"
 
 # ✅ 驗證：三個服務帳號都改不動 shim（也換不掉它）
@@ -1967,22 +2109,27 @@ ls -l /opt/cortex/bin/cortex-job-shim
 
 ```bash
 # ✅ 先讀（規則檔開頭把邊界與「為什麼 transient 一律拒」逐條寫出來，勿跳過）
-python3 -m paulsha_cortex.trust_root polkit three-way --template | tee /tmp/polkit-cortex.rules
+python3 -m paulsha_cortex.trust_root polkit four-way --template | tee /tmp/polkit-cortex.rules
 less /tmp/polkit-cortex.rules
 #   必須確認的五個條件（規則檔自己列在「審查者的一眼結論」段）：
 #     (1) subject 是 cortex-manager；(2) action 是 org.freedesktop.systemd1.manage-units；
 #     (3) unit／verb 明細存在；(4) verb ∈ {start, stop}；
-#     (5) unit 名匹配 ^(?:cortex-job|cortex-job-jit)@[a-z0-9][a-z0-9._-]{0,62}\.service$
+#     (5) unit 名匹配（六個具名字幹的交替；逐字以產生器輸出為準）
+#         ^(?:cortex-job|cortex-job-jit|cortex-reviewer-job|cortex-reviewer-job-jit
+#           |cortex-gate-job|cortex-gate-job-jit)@[a-z0-9][a-z0-9._-]{0,62}\.service$
 #   **transient unit 的 StartTransientUnit 檢查不帶明細 ⇒ 條件 (3) 直接把它擋掉。**
 #   ⚠️ 條件 (5) 的字幹段是**列舉的交替**，而且是**兩層**列舉，**不是**萬用字元：
 #        (a) 加固剖面（#643）：一份剖面一個 root-owned 模板檔 ⇒ 兩個後綴；
-#        (b) job 角色（#615 M2）：builder 與 reviewer/planner 是不同的 UID，而
-#            User= 同樣寫死在檔裡 ⇒ 兩個字幹頭。
-#      2 × 2 ＝ 四個具名模板。前後仍然錨定、instance 段的字元類一字未改，仍然是
-#      **一條規則、一個 YES 出口**——放行面是「四個具名模板」，不是「任意 unit」。
+#        (b) job 角色（#615 M2／#629）：builder、reviewer/planner、gate 是三個不同的
+#            UID，而 User= 同樣寫死在檔裡 ⇒ 三個字幹頭。
+#      3 × 2 ＝ 六個具名模板。前後仍然錨定、instance 段的字元類一字未改，仍然是
+#      **一條規則、一個 YES 出口**——放行面是「六個具名模板」，不是「任意 unit」。
 #      看到 `.*`／`[^`／`\w` 出現在字幹段就是被改壞了。
-#      四份模板的 User= 全部是無 sudo、無 root、彼此互不可寫的降權服務帳號，
+#      六份模板的 User= 全部是無 sudo、無 root、彼此互不可寫的降權服務帳號，
 #      因此「多一個字幹」擴大的是**降權目標的選擇**，不是提權面。
+#   ⚠️ 若字幹段**沒有** cortex-gate-job ⇒ 你用的是 three-way／two-way 產出的規則，
+#      或部署樹比 #629 舊。那份規則裝上去之後 gate unit 一律被 polkit 拒，
+#      症狀是每張 build 卡都停在 gate 執行面的診斷碼上。
 
 # 🔧 sudo：落檔
 sudo install -o root -g root -m 0644 /tmp/polkit-cortex.rules \
@@ -1991,14 +2138,14 @@ sudo systemctl restart polkit.service 2>/dev/null || sudo systemctl restart polk
 
 # ✅ 驗證：載入無語法錯誤、與產生器逐位元相同
 sudo journalctl -u polkit -n 30 --no-pager | grep -Ei "error|syntax" || echo "polkit loaded clean: OK"
-diff <(python3 -m paulsha_cortex.trust_root polkit three-way --template) \
+diff <(python3 -m paulsha_cortex.trust_root polkit four-way --template) \
      /etc/polkit-1/rules.d/49-cortex-downgrade.rules && echo "polkit in sync: OK"
 
 # ✅ 驗證：規則的 subject 是 cortex-manager，且殘餘風險清單為空（template 方案）
 python3 - <<'PY'
 from paulsha_cortex.trust_root import permgen
 rule = permgen.build_polkit_rule(
-    permgen.SCHEMES["three-way"], plan=permgen.PolkitPlan.TEMPLATE
+    permgen.SCHEMES["four-way"], plan=permgen.PolkitPlan.TEMPLATE
 )
 print("subject       :", rule.subject_account)
 print("targets       :", rule.target_accounts)
@@ -2019,12 +2166,17 @@ PY
 
 ```bash
 # ✅ 先取 PSC_BUILDER_PATH 的正規值（產生器＝單一真相，**不要手打**）
-python3 -m paulsha_cortex.trust_root unit three-way --job | grep PSC_BUILDER_PATH
+python3 -m paulsha_cortex.trust_root unit four-way --job | grep PSC_BUILDER_PATH
 #   期望：PSC_BUILDER_PATH=/opt/cortex/toolchain/bin:/usr/local/bin:/usr/bin:/bin
 
 # ✅ #615：reviewer／planner 那一組（**與 builder 不共用**，見下方說明）
-python3 -m paulsha_cortex.trust_root unit three-way --review-job | grep PSC_REVIEWER_PATH
+python3 -m paulsha_cortex.trust_root unit four-way --review-job | grep PSC_REVIEWER_PATH
 #   期望：PSC_REVIEWER_PATH=/opt/cortex/toolchain/bin:/usr/local/bin:/usr/bin:/bin
+
+# ✅ #629：gate 執行身分那一組。**PATH 刻意不含 toolchain**——gate 不跑任何模型 CLI，
+#    它跑的是 operator 宣告的 gate 命令（pytest／make／npm…）。把 toolchain 排進去
+#    只會多開一條「gate 也能起模型」的面，換不到任何東西。
+python3 -m paulsha_cortex.trust_root unit four-way --gate-job | grep PSC_GATE_PATH
 
 # 🔧 sudo：把降權模式寫進第 4b 步的 EnvironmentFile
 sudo tee -a /opt/cortex/etc/cortex-manager.env >/dev/null <<'ENVFILE'
@@ -2035,6 +2187,16 @@ PSC_BUILDER_PATH=/opt/cortex/toolchain/bin:/usr/local/bin:/usr/bin:/bin
 PSC_REVIEWER_ACCOUNT=cortex-reviewer-planner
 PSC_REVIEWER_HOME=/var/lib/cortex-reviewer-planner
 PSC_REVIEWER_PATH=/opt/cortex/toolchain/bin:/usr/local/bin:/usr/bin:/bin
+# --- #629 gate 執行身分 ---
+PSC_GATE_ACCOUNT=cortex-gate
+PSC_GATE_HOME=/var/lib/cortex-gate
+PSC_GATE_PATH=/usr/local/bin:/usr/bin:/bin
+# gate 用來跑 ledger writer 的直譯器。必須是**絕對路徑且 gate 讀得到**——
+# Manager 的 repo root 在 /home 底下，而 job unit 帶 ProtectHome=yes，
+# `PYTHONPATH=<repo>` 那條路在那裡不成立（#623 缺口 1 的同一件事）。
+PSC_GATE_PYTHON=/opt/cortex/venv/bin/python3
+# gate 的加固剖面（operator 平面的決定）。宣告了 node 型 gate（npm test）才改 jit。
+PSC_GATE_HARDENING_PROFILE=strict
 ENVFILE
 sudo systemctl restart cortex-manager.service
 
@@ -2050,8 +2212,17 @@ PY
 #   期望：
 #     builder  account=cortex-builder           template=cortex-job@.service
 #     review   account=cortex-reviewer-planner  template=cortex-reviewer-job@.service
+#     gate     account=cortex-gate              template=cortex-gate-job@.service
 #   ⚠️ review 那行若是 cortex-builder ⇒ 停下來：reviewer 會以 builder 身分起跑，
 #      而 reviewer 正是寫 verdict 的那一個——那等於把 verdict 通道交還給 builder。
+#   ⚠️ gate 那行若與其他兩行**任一個相同** ⇒ 立即停止（#629）：三種併法各自對應
+#      一條已知提權路徑（模型自證／授權線內側／verdict 通道），而且都看起來是成功的。
+
+# ✅ 驗證（#629）：gate 的直譯器對 gate 帳號真的可執行
+sudo -u cortex-gate /opt/cortex/venv/bin/python3 -c \
+  "import paulsha_cortex.coordinator.gate_ledger as g; print('gate ledger writer OK')"
+#   ⚠️ ImportError／Permission denied ⇒ 停下來：gate 起得來但跑不了 ledger writer，
+#      症狀會是每張 build 卡都停在 gate-spool-empty（空輸出型失敗，最難查）。
 
 # ✅ 驗證：模式確實被解析成 template（值非法必須 fail-closed，不得靜默當成 direct）
 sudo -u cortex-manager env $(grep -v '^#' /opt/cortex/etc/cortex-manager.env | xargs) \
@@ -2474,7 +2645,7 @@ python3 -m pytest tests/test_trust_root_permgen_p2b.py -q -k polkit
 python3 - <<'PY'
 from paulsha_cortex.trust_root import permgen
 rule = permgen.build_polkit_rule(
-    permgen.SCHEMES["three-way"], plan=permgen.PolkitPlan.TEMPLATE
+    permgen.SCHEMES["four-way"], plan=permgen.PolkitPlan.TEMPLATE
 )
 cases = [
     ("cortex-manager",          permgen.POLKIT_ACTION, "cortex-job@abc.service", "start", "YES"),
@@ -2580,15 +2751,15 @@ sudo -u cortex-manager /opt/cortex/venv.new/bin/python -m paulsha_cortex.trust_r
 sudo -u cortex-manager /opt/cortex/venv.new/bin/python -m paulsha_cortex.trust_root equation
 
 # ✅ 5. 登記表若有變動，unit／template／shim 全部必須重新產生
-diff <(sudo -u cortex-manager /opt/cortex/venv.new/bin/python -m paulsha_cortex.trust_root unit three-way --manager) \
+diff <(sudo -u cortex-manager /opt/cortex/venv.new/bin/python -m paulsha_cortex.trust_root unit four-way --manager) \
      /etc/systemd/system/cortex-manager.service || echo "!! manager unit 需更新"
-diff <(sudo -u cortex-manager /opt/cortex/venv.new/bin/python -m paulsha_cortex.trust_root unit three-way --job) \
+diff <(sudo -u cortex-manager /opt/cortex/venv.new/bin/python -m paulsha_cortex.trust_root unit four-way --job) \
      /etc/systemd/system/cortex-job@.service || echo "!! job template unit (strict) 需更新"
-diff <(python3 -m paulsha_cortex.trust_root unit three-way --job --profile jit) \
+diff <(python3 -m paulsha_cortex.trust_root unit four-way --job --profile jit) \
      /etc/systemd/system/cortex-job-jit@.service || echo "!! job template unit (jit) 需更新"
-diff <(sudo -u cortex-manager /opt/cortex/venv.new/bin/python -m paulsha_cortex.trust_root polkit three-way --template) \
+diff <(sudo -u cortex-manager /opt/cortex/venv.new/bin/python -m paulsha_cortex.trust_root polkit four-way --template) \
      /etc/polkit-1/rules.d/49-cortex-downgrade.rules || echo "!! polkit 規則需更新"
-diff <(sudo -u cortex-manager /opt/cortex/venv.new/bin/python -m paulsha_cortex.trust_root shim three-way) \
+diff <(sudo -u cortex-manager /opt/cortex/venv.new/bin/python -m paulsha_cortex.trust_root shim four-way) \
      /opt/cortex/bin/cortex-job-shim || echo "!! shim 需更新"
 
 # 🔧 6. sudo：原子切換（保留前一版供回滾）
@@ -3028,7 +3199,7 @@ sudo sh -c 'printf "\n# negctl\n" >> /etc/systemd/system/cortex-job@.service'
 sudo systemctl daemon-reload && echo "5.2-neg OK"
 sudo cp /tmp/jobunit.bak /etc/systemd/system/cortex-job@.service
 sudo systemctl daemon-reload
-diff <(python3 -m paulsha_cortex.trust_root unit three-way --job) \
+diff <(python3 -m paulsha_cortex.trust_root unit four-way --job) \
      /etc/systemd/system/cortex-job@.service && echo "restored & in sync: OK"
 
 # ✅ 5.2 事後複驗：分界線改過之後仍成立（族 3「重啟後仍綠」的同一條紀律）
@@ -3147,9 +3318,87 @@ sudo rm -f "/var/lib/cortex/coordinator/job-specs/$VJOB.json" \
            "/var/lib/cortex-reviewer-planner/cache/$VJOB.log"
 ```
 
+### 8b-3. 族 7：gate 執行身分（**#629**；＝spec §R9 的**族 5**）
+
+> **編號對照**：spec §R9 只列四族，本 runbook 另有 A+B 新增的族 5（privilege-boundary）
+> 與 #615 M2 的族 6（verdict 通道端到端），因此 #629 這一族在 runbook 裡排到**族 7**，
+> 在 spec 裡是**族 5**。兩邊的內容逐條相同（T5.1–T5.10）。
+
+> **本族的前提與其他族不同**：這裡假設 builder **已經**在自己的工作樹裡取得任意
+> 程式碼執行——那正是宣告出來的 gate 命令必然給它的東西（`pytest` 會載入該樹的
+> `conftest.py`）。要驗的不是「那個執行不會發生」，而是**它被關在哪裡**。
+>
+> spec §R3 的誠實邊界：第四帳號買到的是**圍堵**，**不是**「ledger 不可偽造」。
+> 取得 ACE 的 builder 依然能影響自己那一份 ledger 的內容；下面每一條驗的是它
+> **影響不到別的東西**。
+
+```bash
+# 以 gate 執行身分執行（模擬「gate 命令內的 conftest.py 拿到 shell」）
+sudo -u cortex-gate sh -s <<'SH'
+A=/var/lib/cortex
+ok(){ printf '%-58s %s\n' "$1" "$2"; }
+try(){ if eval "$2" >/dev/null 2>&1; then ok "$1" "❌ BAD: 成功了"; else ok "$1" "✅ 被拒"; fi; }
+
+# T5.1 寫 gate ledger／exit sentinel 的落點
+try "T5.1 write dispatch log dir"      ": > $A/runtime/dispatch/psc-probe"
+# T5.2 寫其他 Tier-0 Manager-owned 資產
+try "T5.2 write jobs registry"         ": > $A/coordinator/jobs.json.probe"
+try "T5.2 write evidence tree"         ": > $A/coordinator/evidence/.probe"
+try "T5.2 write job-spec spool"        ": > $A/coordinator/job-specs/.probe"
+try "T5.2 write repo source tree"      ": > $A/repos/.probe"
+# T5.3 寫 builder 的工作樹（讀得到，但不可寫）
+for d in $A/worktree/*/; do try "T5.3 write builder worktree" ": > ${d}psc-probe"; break; done
+# T5.4 碰 verdict／commit 通道
+try "T5.4 read verdict spool"          "ls $A/coordinator/review-verdicts"
+try "T5.4 write verdict spool"         ": > $A/coordinator/review-verdicts/.probe"
+try "T5.4 read commit spool"           "ls $A/coordinator/commit-spool"
+# T5.5 讀 gate spool 容器（自己那格是 wx 無 r ⇒ 列不出來）
+try "T5.5 list gate ledger spool"      "ls $A/coordinator/gate-ledger-spool"
+# T5.6 起任何 unit（gate 完全沒有 polkit grant）
+try "T5.6 systemctl start any unit"    "systemctl start cortex-gate-job@probe.service"
+try "T5.6 systemctl start builder unit" "systemctl start cortex-job@probe.service"
+SH
+#   期望：**每一行都是 ✅ 被拒**。任何一個 ❌ 都要停下來——那一條就是 #629 沒守住的地方。
+
+# T5.7 gate 不污染被驗的樹：跑完一張 build 卡之後，工作樹裡不得有 gate 的產物
+JOBDIR=$(sudo ls -1d /var/lib/cortex/worktree/*/ 2>/dev/null | head -1)
+sudo find "$JOBDIR" -user cortex-gate -print | head
+#   期望：**沒有任何輸出**（副本在 /var/lib/cortex/gate-worktree/，不在這裡）。
+
+# T5.8 builder 預先佔位 ledger 落點
+sudo -u cortex-builder sh -c '
+  mkdir -p /var/lib/cortex/coordinator/gate-ledger-spool/preseed 2>&1 | tail -1
+' 
+#   期望：Permission denied（容器 0700 cortex-manager，builder 連 traverse 都沒有）。
+
+# T5.9 builder 竄改 conftest.py 影響不了 Manager 身分
+#   做法：在一張 build 卡的工作樹放一個會寫 Manager durable state 的 conftest.py，
+#   派卡，然後確認：
+sudo find /var/lib/cortex/coordinator /var/lib/cortex/runtime -user cortex-gate | head
+#   期望：**沒有任何輸出**（除了 gate 自己那一格 spool，而那一格在收割後已封口）。
+sudo ls -l /var/lib/cortex/runtime/dispatch/*.gates.json | tail -3
+#   期望：owner 全部是 cortex-manager。
+
+# T5.10 gate 直接寫權威 ledger
+sudo -u cortex-gate sh -c 'printf "{}" > /var/lib/cortex/runtime/dispatch/x.gates.json' 2>&1 | tail -1
+#   期望：Permission denied。即使以特權植入，採信端也會以 gate-ledger-foreign-author 拒。
+```
+
 ### 8c. negative control（受信任身分做同樣的事**必須成功**）
 
 ```bash
+# ✅ 族 7（#629）的 negative control：**該成功的必須成功**
+#    (a) cortex-manager 寫得進 gate ledger 的落點；(b) cortex-gate 寫得進自己那格。
+sudo -u cortex-manager sh -c ': > /var/lib/cortex/runtime/dispatch/.negctl && \
+  rm -f /var/lib/cortex/runtime/dispatch/.negctl' && echo "negctl manager→dispatch: OK"
+sudo install -d -o cortex-manager -g cortex-manager -m 0700 \
+  /var/lib/cortex/coordinator/gate-ledger-spool/negctl
+sudo setfacl -m u:cortex-gate:wx /var/lib/cortex/coordinator/gate-ledger-spool/negctl
+sudo -u cortex-gate sh -c 'printf "{}" > /var/lib/cortex/coordinator/gate-ledger-spool/negctl/ledger.json' \
+  && echo "negctl gate→own slot: OK" || echo "❌ 測試環境無效：族 7 結果不算數"
+sudo rm -rf /var/lib/cortex/coordinator/gate-ledger-spool/negctl
+#   ⚠️ 這兩條**任一條失敗**都代表帳號或 ACL 沒套上，族 7 的「全部被拒」是假綠。
+
 # ✅ 族 1／2 的 negative control：cortex-manager 寫得進去
 sudo -u cortex-manager sh -c '
 set -e
@@ -3388,7 +3637,7 @@ sudo journalctl -u cortex-manager.service -b --no-pager | grep -Ei \
 
 # ✅ 2. 看實際生效的白名單（和產生器輸出對照）
 systemctl show cortex-manager.service -p ProtectSystem -p ReadWritePaths -p ProtectHome
-diff <(python3 -m paulsha_cortex.trust_root unit three-way --manager | grep '^ReadWritePaths=') \
+diff <(python3 -m paulsha_cortex.trust_root unit four-way --manager | grep '^ReadWritePaths=') \
      <(systemctl show cortex-manager.service -p ReadWritePaths | tr ' ' '\n' | sed 's/^/ReadWritePaths=/' | head -50)
 
 # ✅ 3. 在**同一組沙箱條件**下重現（root 用 systemd-run 診斷，不放行給 manager）
@@ -3406,7 +3655,7 @@ systemctl show cortex-manager.service -p ReadWritePaths | tr ' ' '\n' | grep -E 
 
 # ✅ 5. job template 側的同一診斷（job 起得來但寫不進 worktree 時）
 systemctl show "cortex-job@negctl5.service" -p ReadWritePaths -p ProtectSystem 2>/dev/null
-diff <(python3 -m paulsha_cortex.trust_root unit three-way --job | grep '^ReadWritePaths=') \
+diff <(python3 -m paulsha_cortex.trust_root unit four-way --job | grep '^ReadWritePaths=') \
      <(grep '^ReadWritePaths=' /etc/systemd/system/cortex-job@.service)
 
 # ✅ 6. 臨時放行（僅供診斷；當天必須回填登記表）
@@ -3461,11 +3710,11 @@ sudo systemctl daemon-reload && sudo systemctl restart cortex-manager.service
 
 ```bash
 # ✅ unit／polkit／shim 與產生器沒有漂移（建議排程每日跑）
-diff <(python3 -m paulsha_cortex.trust_root unit three-way --manager) /etc/systemd/system/cortex-manager.service
-diff <(python3 -m paulsha_cortex.trust_root unit three-way --job)     /etc/systemd/system/cortex-job@.service
-diff <(python3 -m paulsha_cortex.trust_root unit three-way --job --profile jit) /etc/systemd/system/cortex-job-jit@.service
-diff <(python3 -m paulsha_cortex.trust_root polkit three-way --template) /etc/polkit-1/rules.d/49-cortex-downgrade.rules
-diff <(python3 -m paulsha_cortex.trust_root shim three-way)            /opt/cortex/bin/cortex-job-shim
+diff <(python3 -m paulsha_cortex.trust_root unit four-way --manager) /etc/systemd/system/cortex-manager.service
+diff <(python3 -m paulsha_cortex.trust_root unit four-way --job)     /etc/systemd/system/cortex-job@.service
+diff <(python3 -m paulsha_cortex.trust_root unit four-way --job --profile jit) /etc/systemd/system/cortex-job-jit@.service
+diff <(python3 -m paulsha_cortex.trust_root polkit four-way --template) /etc/polkit-1/rules.d/49-cortex-downgrade.rules
+diff <(python3 -m paulsha_cortex.trust_root shim four-way)            /opt/cortex/bin/cortex-job-shim
 
 # ✅ 部署樹沒有被 pipx 殘留污染（第 4a／第 6 步的兩個必補步驟）
 sudo grep -rIl -- "/.local/share/pipx" /opt/cortex/venv | head    # 期望：空輸出
@@ -3526,7 +3775,7 @@ python3 -m pytest tests/test_trust_root_permgen_p2a.py tests/test_trust_root_per
 
 ```bash
 # 🔧 sudo：換成 transient 規則（unit 名前綴 cortex-job-，非 @ 實例）
-python3 -m paulsha_cortex.trust_root polkit three-way --transient \
+python3 -m paulsha_cortex.trust_root polkit four-way --transient \
   | sudo tee /etc/polkit-1/rules.d/49-cortex-downgrade.rules >/dev/null
 sudo systemctl restart polkit.service 2>/dev/null || sudo systemctl restart polkitd.service
 
@@ -3560,7 +3809,7 @@ sudo -u cortex-manager systemd-run --quiet --unit=cortex-job-probe-00000000.serv
 python3 - <<'PY'
 from paulsha_cortex.trust_root import permgen
 rule = permgen.build_polkit_rule(
-    permgen.SCHEMES["three-way"], plan=permgen.PolkitPlan.TRANSIENT
+    permgen.SCHEMES["four-way"], plan=permgen.PolkitPlan.TRANSIENT
 )
 for r in rule.residual_risks:
     print("-", r)
@@ -3586,7 +3835,7 @@ PY
 | 舊版（0816 第二輪） | 本版（0816 第三輪） |
 |---|---|
 | 第 1 步建**兩**個帳號（`cortex-svc` / `cortex-builder`） | 建**三**個（`cortex-manager` / `cortex-reviewer-planner` / `cortex-builder`） |
-| 全文 `two-way` | 全文 `three-way`；`two-way` 僅存於程式碼作為對照組 |
+| 全文 `two-way` | 全文 `four-way`；`two-way` 僅存於程式碼作為對照組 |
 | 第 5 步 A／B 並列，**待 operator 拍板** | 第 5 步 **A+B 合一，無分歧**；transient 降為附錄 B 備援 |
 | polkit 授 transient 建立（方案 A） | polkit **不授** transient 建立；只放行四個具名模板的 start/stop：`cortex-job@` / `cortex-job-jit@`（#643 加固剖面）/ `cortex-reviewer-job@` / `cortex-reviewer-job-jit@`（#615 job 角色），皆 `*.service`——**四個具名模板，不是任意 unit** |
 | `ExecStart=` 指向 spool 內的 `run.sh` | 指向 **root-owned shim** `/opt/cortex/bin/cortex-job-shim`（C 層搬進 root-owned 檔） |

--- a/docs/superpowers/specs/trust-root-isolation-spec.md
+++ b/docs/superpowers/specs/trust-root-isolation-spec.md
@@ -749,6 +749,58 @@ SHALL 用這句話，MUST NOT 簡化成「job 已完整加固」。
 （V8 的 jitless 模式、或 CLI 改為原生編譯），`jit` 剖面 SHALL 被移除而不是長期保留；
 移除的判準就是上表「完整加固面」欄全部變 ✅。
 
+##### 誠實的取捨：gate 執行身分買到的是圍堵，不是不可偽造（`#629`）
+
+operator 宣告的 gate 命令（`PSC_GATE_CMD_*`）在 **builder 完全掌控內容的工作樹**上
+執行，而 `pytest` 會載入該樹的 `conftest.py` 與 plugin。**「執行 gate」與「執行被驗
+方交出來的程式碼」在信任面上是同一件事**，這一點沒有任何工程手段能移除——唯一的
+替代是不跑 gate，而那等於放棄 §R2 的獨立重驗。
+
+因此系統 SHALL 把該執行關進一個**第四個**降權帳號（`cortex-gate`），而 **MUST NOT**
+掛在任何既有身分上。三個候選逐一皆不可用：
+
+| 候選 | 為什麼不行 |
+|---|---|
+| `cortex-builder` | 模型自證自己的驗收證據，違反 `#540` 的 acceptance chain |
+| `cortex-manager` | 持 spawn 授權、擁有全部 Manager-owned durable state，是授權線的**內側** |
+| `cortex-reviewer-planner` | 它是寫 verdict 的那一個；掛上去等於把 builder 對 verdict 通道的影響力重新打開（抵銷 `#638`／`#639`） |
+
+**沒有買到的**（必須明載，否則會被讀成比實際更強）：取得任意程式碼執行的 builder
+**依然能影響自己那一份 ledger 的內容**——它可以讓宣告的 gate 命令回 0 並在
+`detail` 裡寫任何東西。第四帳號**不**使 gate 結果不可偽造。
+
+**買到的**：那個執行
+
+1. 寫不進 `gate-ledger`（含 exit sentinel）與任何其他 Manager-owned Tier-0 資產；
+2. 寫不進 builder 的工作樹（只有 `rX`），因此污染不了 harvest 的來源；
+3. 碰不到 `review-verdict-spool`／`commit-spool`，讀不到他人在 `gate-ledger-spool`
+   的那一格（`wx` 無 `r`）；
+4. 沒有任何 polkit grant，起不了任何 unit；
+5. 影響範圍**限於它自己那一個 job 的 ledger**——不能跨 job、不能跨 persona。
+
+**因此 spec 明載**：準確的敘述是——**gate ledger 是「operator 宣告的命令，在一個
+除了自己那一格 spool 與自己的拋棄式副本之外什麼都碰不到的身分下，跑過一次」的
+記錄**；它 MUST NOT 被敘述成「不可被 builder 影響」。權威副本由 Manager 依 spool
+內容自行重寫，因此 `#628` 的作者歸屬（`foreign_evidence_author()`）逐字不變，而
+spool 內容一律以**不受信任輸入**驗證（schema 嚴格、gate 名稱 MUST ⊆ operator 的
+宣告集合、payload 有界）。
+
+**未來選項（不在本票範圍）**：要讓 gate 結果真正不可偽造，需要的是「在不執行被驗
+方程式碼的前提下判定它」——那不是身分問題，而是 Phase 3 的簽章／可重現建置範疇。
+
+#### Scenario: gate 執行身分寫 Manager 的證據樹
+
+- **WHEN** gate 執行身分試圖寫 `gate-ledger`（ledger 或 exit sentinel）
+- **THEN** 檔案層 MUST 拒絕（該資產不在它的 `ReadWritePaths=` 內）；即使以特權植入，
+  採信端 MUST 以 `gate-ledger-foreign-author` 拒絕非 Manager 擁有的 ledger
+
+#### Scenario: gate 命令在被驗的工作樹上就地執行
+
+- **WHEN** 系統把 gate 命令的 cwd 設成 builder 的工作樹本身
+- **THEN** 該設計 MUST 被拒絕：gate 需要可寫暫存（`.pytest_cache`／`__pycache__`／
+  build 產物），就地執行不是「唯讀因此安全」，而是「gate 的寫入污染了 harvest 的
+  來源」。命令 SHALL 在**拋棄式副本**上執行，來源對 gate 唯讀
+
 #### Scenario: node 型 executor 在嚴格剖面下起不來
 
 - **WHEN** 以 `codex`／`copilot` 為 executor 的 job 被派到 `cortex-job@.service`
@@ -1040,6 +1092,27 @@ skill ledger、runtime bootstrap env。
 | T4.3 | 讀 `/proc/<manager_pid>/mem`、`environ` | `EACCES` |
 | T4.4 | 對 Manager 送 signal（`SIGSTOP`／`SIGKILL`） | `EPERM` |
 
+**族 5：gate 執行身分（`#629`）**——前提改成「builder 在自己的工作樹裡取得任意
+程式碼執行」，因為那正是宣告出來的 gate 命令必然給它的東西（`pytest` 會載入該樹的
+`conftest.py` 與 plugin）。本族驗的不是「那個執行不會發生」，而是**它被關在哪裡**。
+
+| ID | 動作（以 gate 執行身分 `cortex-gate` 進行） | 期望 |
+|---|---|---|
+| T5.1 | 寫 `gate-ledger`（Manager dispatch log 目錄，含 exit sentinel） | `EACCES`／`EROFS` |
+| T5.2 | 寫任何其他 Tier-0 Manager-owned 資產（jobs registry、verification evidence、delivery journal…） | `EACCES`／`EROFS` |
+| T5.3 | 寫 builder 的 per-job 工作樹（`repo-worktree`） | `EACCES`——ACL 只授 `rX` |
+| T5.4 | 讀／寫 `review-verdict-spool` 或 `commit-spool` | `EACCES`——gate 不在兩者的 writer／reader 面 |
+| T5.5 | 讀他人在 `gate-ledger-spool` 的那一格 | `EACCES`——`wx` 無 `r` |
+| T5.6 | `systemctl start` 任何非 `cortex-gate-job@*` 的 unit | polkit 拒絕（subject 是 Manager，不是 gate；gate 自己完全沒有 grant） |
+| T5.7 | 在被驗的工作樹留下檔案（污染 harvest 的來源） | 不可能——命令跑在拋棄式副本上，來源對它唯讀 |
+| T5.8 | builder 預先在 `gate-ledger-spool` 佔位一份「全過」的 ledger | 該檔在起 gate 前被 Manager 刪除（pre-seed 守衛）；且 builder 連容器都 traverse 不進來 |
+| T5.9 | builder 竄改工作樹內的 `conftest.py` 以影響 **Manager** 身分 | 不可能——gate 命令不在 `cortex-manager` 下執行，Manager 只讀 spool 的 JSON |
+| T5.10 | gate 直接把權威 ledger 寫進 `gate-ledger` 讓採信端讀 | 採信端 `gate-ledger-foreign-author` 拒（#628），且 T5.1 已先擋在檔案層 |
+
+**族 5 的 negative control**：以 `cortex-manager` 執行 T5.1／T5.2 MUST 成功；以
+`cortex-gate` 執行「寫自己那一格 spool」MUST 成功。兩者皆失敗即代表帳號或 ACL 沒
+套上，該族結果 MUST 視為未通過。
+
 **negative control（必要）**：每一族 MUST 附一組以受信任身分執行相同動作且
 **必須成功**的對照案例。無 negative control 的測試會在環境壞掉（例如目錄根本
 不存在）時假綠。
@@ -1055,6 +1128,18 @@ skill ledger、runtime bootstrap env。
 
 - **WHEN** 以受信任身分執行族 2 的寫入動作
 - **THEN** MUST 成功——若同樣失敗，表示測試環境無效，該族結果 MUST 視為未通過
+
+#### Scenario: gate 執行身分不得與任何既有身分合併
+
+- **WHEN** UID 方案把 `gate` 映到 `builder`／`manager`／`reviewer-planner` 任一帳號
+- **THEN** 該方案 MUST 被視為未滿足 R9 族 5——三者分別對應「模型自證」「把任意程式碼
+  執行引到持 spawn 授權的帳號」「把 builder 對 verdict 通道的影響力重新打開」
+
+#### Scenario: 沒有 gate 執行身分的部署
+
+- **WHEN** UID 方案明示「本部署沒有 gate 角色」（`ABSENT_ACCOUNT`）
+- **THEN** 系統 MUST NOT 以任何其他身分代跑 gate；`require_ledger` 的卡照既有規則
+  fail closed，MUST NOT 靜默通過
 
 ### R10 落地 MUST 分三階段交付，Phase 1 MUST 可在不需 root 的前提下先行
 
@@ -1189,6 +1274,8 @@ MUST NOT 標記為 stable；本項 MUST NOT 引用計畫「貫穿工項」第 7 
 | 資產盤點漏項 | 漏保護的 state 成為新破口 | R1 的雙向等式測試把漏項變成 CI FAIL；同時收斂六處重複的 journal 路徑推導 |
 | **per-executor 加固剖面（#643）被讀成「所有 job 都有完整加固」** | 稽核／報告高估實際保護面，日後出事時對不上 | §R3 的「誠實的取捨」段明載準確敘述（原生 ELF 27 項／node 型 26 項，少的是 `MemoryDenyWriteExecute`）；產生出來的 unit 檔頭逐條寫著它接受的代價；runbook 第 5-2 步要求執行者先讀那一段 |
 | **剖面被改成可由呼叫端選擇**（config、spec、或新增一個「方便」的參數） | 退化成「全域移除 MDWE」——`claude`／`agy` 一起失去該層，方向 2 的價值歸零 | 剖面族進 `SPEC_FORBIDDEN_KEYS`（寫端＋讀端各掃一次）；`PSC_JOB_TEMPLATE_UNIT` 拒絕帶剖面後綴的值；未知 executor fail-closed；polkit pattern 只列舉具名字幹。四條都有對應測試 |
+| **`#629` 的第四帳號被讀成「gate ledger 因此不可偽造」** | 稽核高估實際保護面；真正出事時對不上 | §R3 的「誠實的取捨」段明載準確敘述：第四帳號買到的是**圍堵**（那個執行碰不到 Manager durable state、verdict 通道、他人工作樹，也沒有 spawn 授權），不是「取得 ACE 的 builder 影響不了自己那一份 ledger」——後者是「執行對方交出來的測試碼」這件事本身的性質，換誰執行都一樣 |
+| **gate 執行被「順手」掛回既有帳號**（省一個帳號、或圖 `regenerate-gates` 好寫） | 三種掛法各自對應一條已知提權路徑，且都看起來是成功的 | `UidScheme` 上 gate 是獨立 principal；`permgen` 對未對應的 gate fail-closed 並在訊息裡逐條列出為什麼不能併；`work_actions._regenerate_gates_action` 與自動路徑共用**同一個**進入點，測試以原始碼比對釘住它不得回頭直呼 `write_gate_ledger()` |
 | Phase 3 簽章方案被誤當成可替代 Phase 2 | 投入密碼學工程卻仍可被繞過 | 「路線比較與裁決建議」段已論證 B 的三個前提都依賴 A；R6(c) 明載單調計數器必須在 OS 邊界內 |
 | reviewer 與 builder 分離推高資源與複雜度 | Phase 2 工期拉長 | independence 是 `#484` 與 D6 的共同要求，不可省；可先以兩個 UID（builder／非 builder）起步，planner 併入非 builder 域，待驗證後再細分 |
 | 降級運轉期間 fleet 產能下降 | 交付變慢 | 降級只涵蓋 acceptance／outbox mutation／ship 三條路徑，define／plan／build／verify 不受影響 |

--- a/paulsha_cortex/config/paths.py
+++ b/paulsha_cortex/config/paths.py
@@ -103,6 +103,52 @@ def commit_spool_root() -> Path:
     return coordinator_root() / COMMIT_SPOOL_DIRNAME
 
 
+#: `gate_ledger_spool_root()` 在 `coordinator_root()` 底下的目錄名。獨立成常數的理由
+#: 與 `COMMIT_SPOOL_DIRNAME` 逐字相同（R1 登記表的「重複路徑推導」Scenario）。
+GATE_LEDGER_SPOOL_DIRNAME = "gate-ledger-spool"
+
+
+def gate_ledger_spool_root() -> Path:
+    """#629：gate 執行身分交付 ledger 的 **per-job 單向 spool** 根。
+
+    `#604`／PR `#628` 把 gate ledger 的**作者**收斂到 Manager，但執行面留在原地：
+    operator 宣告的 gate 命令（`PSC_GATE_CMD_*`）跑在 builder 完全掌控內容的工作樹
+    上，`pytest` 會載入該樹的 `conftest.py`／plugin——誰執行 gate，誰就對 builder 開
+    放一條任意程式碼執行。因此執行身分既不能是 builder（模型自證，違反 #540 的
+    acceptance chain）、也不能是 Manager 或 reviewer／planner（兩者都在授權線內側：
+    前者持 spawn 授權，後者寫 verdict）。#629 的答案是**第四個帳號** `cortex-gate`。
+
+    本函式即它的交付通道根：每個 job 在 `<此根>/<job-id>/ledger.json` 有且只有自己
+    那一格。掛在 `coordinator_root()` 底下的 Manager-owned 樹；Phase 2b 的 chown／ACL
+    由 `trust_root/permgen.py` 依 R1 登記表資產 `gate-ledger-spool` 機械產生：容器
+    owner＝durable_state_owner、mode 0700，gate 只獲 **write-only** ACL（`wx` 無
+    `r`），Manager 擁有並消費。
+
+    **為什麼要多一跳而不讓 gate 直接寫 `gate-ledger`**：#628 的採信端以
+    `terminal_contract.foreign_evidence_author()` 檢查檔案擁有者，非 Manager 產生的
+    ledger 一律不採信；而那個目錄同時是 exit sentinel 的落點。權威 ledger 因此一律
+    由 Manager 依本 spool 的內容**自己重寫一份**（`coordinator/gate_runner.py`）。
+    """
+    return coordinator_root() / GATE_LEDGER_SPOOL_DIRNAME
+
+
+def gate_worktree_root() -> Path:
+    """#629：gate 執行身分的**拋棄式工作區** pool 根（`<agents_root>/gate-worktree`）。
+
+    gate 命令一律在**副本**上跑，不在 builder 交付的那棵樹上跑：
+
+    - **唯讀不可行**——`pytest` 要寫 `.pytest_cache`／`__pycache__`，`npm test`／
+      `cargo test`／`make` 更是必寫。把工作樹掛成唯讀只會讓每個真實 gate 以 EROFS
+      收場，那正是 #629 要修掉的「安全但不能用」。
+    - 副本另外買到：gate 的寫入不污染 builder 交付的樹（harvest 讀到的仍是 builder
+      自己的成果），且快照在單一時點取得，builder 留下的背景行程改不了跑到一半的樹。
+
+    複製由 **gate 自己**執行（它是唯一同時讀得到來源、寫得進目的地的身分）；#641 之後
+    Manager 讀不到 builder 的樹，那條刻意不回頭放寬。
+    """
+    return agents_root() / "gate-worktree"
+
+
 #: `job_spec_spool_root()` 在 `coordinator_root()` 底下的目錄名。獨立成常數是為了讓
 #: `coordinator/job_runner.py` 的 per-job 定址、`trust_root/permgen.py` 的 layout 與本
 #: resolver 共用同一個字面量（R1 登記表的「重複路徑推導」Scenario 要求單一真相）。

--- a/paulsha_cortex/coordinator/gate_ledger.py
+++ b/paulsha_cortex/coordinator/gate_ledger.py
@@ -24,12 +24,14 @@ import argparse
 import json
 import os
 import shlex
+import shutil
 import subprocess
+import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable, Mapping, Sequence
 
-from . import terminal_contract
+from . import spool_slot, terminal_contract
 
 
 # operator 宣告 gate 的環境變數前綴；``PSC_GATE_CMD_PYTEST`` → gate ``pytest``。
@@ -262,6 +264,54 @@ def run_gates(
     return rows
 
 
+class SnapshotError(OSError):
+    """拋棄式副本無法建立（#629）。**不寫 ledger**，讓採信端照 `require_ledger` 拒。"""
+
+
+def snapshot_worktree(source: str | Path, destination: str | Path) -> Path:
+    """把被驗的工作樹複製成一份**拋棄式副本**，回傳副本路徑（#629）。
+
+    ## 為什麼是副本而不是「工作樹對 gate 唯讀」
+
+    - **唯讀不可行**：`pytest` 要寫 `.pytest_cache`／`__pycache__`，operator 宣告的
+      `npm test`／`cargo test`／`make` 更是必寫。把工作樹掛成唯讀只會讓每個真實
+      gate 以 EROFS 收場——那正是 #629 要修掉的「安全但不能用」。
+    - **副本另外買到兩件事**：(a) gate 的寫入不會污染 builder 交付的那棵樹，harvest
+      讀到的仍是 builder 自己的成果；(b) 快照在單一時點取得，builder 留下的背景
+      行程改不了 gate 跑到一半的樹（TOCTOU）。
+
+    ## 兩條刻意的取捨
+
+    `symlinks=True`——symlink **原樣複製成 symlink，絕不跟隨**。跟隨的後果有兩個：
+    指向樹外的絕對 symlink 會把外部內容**複製進**副本（gate 於是在自己的可寫區內
+    得到一份 `/etc` 的複本），而指向上層目錄的 symlink 會讓 `copytree` 走進無界的
+    遞迴。不跟隨之後，副本裡的 symlink 仍然是 symlink，解析它們是 gate 命令自己的
+    事，而 gate 的 unit 已經把可寫面收斂到自己那兩個目錄。
+
+    目的地**先整個移除再重建**：留下上一輪的殘留等於讓前一次 gate 的產物（甚至前一
+    次被攻陷的 gate 留下的東西）參與這一次的判定。與 `spool_slot.create_slot(
+    reset=True)` 同一條理由——重建比「就地清理」少一個要窮舉的清單。
+    """
+
+    src = Path(source)
+    dst = Path(destination)
+    if src.is_symlink() or not src.is_dir():
+        raise SnapshotError(f"gate snapshot source is not a directory: {src}")
+    if dst == src or src in dst.parents:
+        # 副本落在來源樹**裡面**會遞迴複製自己；落在同一個路徑則直接毀掉來源。
+        raise SnapshotError(f"gate snapshot destination overlaps its source: {dst}")
+    try:
+        if dst.is_symlink() or dst.is_file():
+            dst.unlink()
+        elif dst.is_dir():
+            shutil.rmtree(dst)
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copytree(src, dst, symlinks=True, ignore_dangling_symlinks=True)
+    except OSError as exc:
+        raise SnapshotError(f"gate snapshot failed: {src} -> {dst}: {exc}") from exc
+    return dst
+
+
 def build_ledger(
     gates: Sequence[Mapping[str, object]],
     *,
@@ -298,24 +348,69 @@ def write_gate_ledger(
         runner=runner,
     )
     payload = build_ledger(gates, slice_id=source.get("PSC_SLICE_ID"))
+    write_ledger_payload(ledger_path, payload)
+    return payload
+
+
+def encode_ledger(payload: Mapping[str, object]) -> str:
+    """ledger 的 canonical JSON 編碼（與 `terminal_contract.gate_ledger_digest` 同形）。"""
+
+    return json.dumps(payload, ensure_ascii=True, sort_keys=True, separators=(",", ":"))
+
+
+def write_ledger_payload(
+    ledger_path: str | Path, payload: Mapping[str, object]
+) -> Path:
+    """把 ledger payload **原子**寫到指定路徑，回傳該路徑。
+
+    抽出來是為了讓 **Manager 自己重寫權威 ledger** 這條路徑（#629 的
+    `coordinator/gate_runner.py`）與本模組共用同一份編碼與同一套原子寫入——兩邊
+    若各寫一次，`terminal_contract.gate_ledger_digest()` 算出來的 digest 就可能因為
+    一個空白而不同，而那個 digest 是要進 evidence 的。
+    """
+
     target = Path(ledger_path)
     target.parent.mkdir(parents=True, exist_ok=True)
     tmp = target.with_name(target.name + ".tmp")
-    tmp.write_text(
-        json.dumps(payload, ensure_ascii=True, sort_keys=True, separators=(",", ":")),
-        encoding="utf-8",
-    )
+    tmp.write_text(encode_ledger(payload), encoding="utf-8")
     os.replace(tmp, target)
-    return payload
+    return target
 
 
 def main(argv: Sequence[str] | None = None) -> int:
     parser = argparse.ArgumentParser(prog="paulsha-cortex-gate-ledger")
     parser.add_argument("--out", required=True, help="gate ledger 輸出路徑")
     parser.add_argument("--worktree", required=True, help="執行 gate 的工作目錄")
+    parser.add_argument(
+        "--snapshot-from",
+        default=None,
+        help=(
+            "#629：先把這棵樹複製成 --worktree 的拋棄式副本，再在副本上跑 gate。"
+            "gate 執行身分（cortex-gate）對來源只有唯讀 ACL，寫入一律落在副本。"
+        ),
+    )
+    parser.add_argument(
+        "--publish",
+        action="store_true",
+        help=(
+            "寫完 ledger 後放寬到 0644，讓 spool 的 consumer（Manager）讀得到"
+            "（#638 缺陷 2 的同一個修法；`wx` 無 `r` 的那一格上，檔由 producer 擁有）。"
+        ),
+    )
     args = parser.parse_args(list(argv) if argv is not None else None)
+    if args.snapshot_from is not None:
+        try:
+            snapshot_worktree(args.snapshot_from, args.worktree)
+        except SnapshotError as exc:
+            # **刻意不寫任何 ledger**：快照失敗代表我們根本沒有可判定的樹，寫一份
+            # 「全部 failed」會把「沒驗到」偽裝成「驗過但沒過」。採信端看到 ledger
+            # 不存在，照 `require_ledger` fail closed，理由在本行程的 stderr 上。
+            print(str(exc), file=sys.stderr)
+            return 74
     try:
         write_gate_ledger(ledger_path=args.out, worktree=args.worktree)
+        if args.publish:
+            spool_slot.publish_file(args.out)
     except GateSpecError:
         # operator 宣告錯誤：仍寫出一份「沒有任何 gate 通過」的 ledger，讓 harvest
         # fail closed 且訊息可追溯，而不是留下空目錄讓人以為 gate 沒被要求。
@@ -339,6 +434,10 @@ def main(argv: Sequence[str] | None = None) -> int:
             ),
             encoding="utf-8",
         )
+        if args.publish:
+            # 宣告壞掉時**同樣要放寬**：那份「gate-spec failed」的 ledger 就是這一輪
+            # 的結論，consumer 讀不到它等於把「設定錯誤」退化成「什麼都沒發生」。
+            spool_slot.publish_file(args.out)
         return 78
     return 0
 

--- a/paulsha_cortex/coordinator/gate_runner.py
+++ b/paulsha_cortex/coordinator/gate_runner.py
@@ -1,0 +1,582 @@
+"""#629：以**第四個帳號**執行 operator 宣告的 gate，並由 Manager 落地權威 ledger。
+
+`#604`／PR `#628` 把 gate ledger 與 exit sentinel 的**作者**收斂到 Manager，但刻意
+沒做執行面。理由寫在 `launcher._should_run_gates` 的 docstring 裡：operator 宣告的
+gate 命令（`PSC_GATE_CMD_*`）是在 **builder 完全掌控內容的工作樹**上執行的，`pytest`
+會載入該樹的 `conftest.py` 與 plugin ⇒ **執行者取得任意程式碼執行**。
+
+後果是 `PSC_JOB_RUNNER=systemd-template` 下 build 卡恆因 `require_ledger` 而
+`gate-ledger-missing` fail closed——安全，但不能用。本模組補上那一半。
+
+## 執行身分：為什麼是第四個帳號
+
+既有三個帳號逐一檢查，沒有一個能承接（完整論證見
+`trust_root.permgen.FOUR_WAY_SCHEME`）：
+
+- `cortex-builder`：模型自證自己的驗收證據，違反 #540 的 acceptance chain；
+- `cortex-manager`：持 spawn 授權、擁有全部 Manager-owned durable state，是授權線的
+  **內側**；
+- `cortex-reviewer-planner`：它是寫 verdict 的那一個——把 gate 掛上去，被攻陷的
+  builder 就能經由 gate 執行影響 reviewer 的帳號，等於把 #638／#639 剛關掉的通道
+  重新打開。
+
+「不開帳號」的唯一認真候選是 `DynamicUser=yes`，它**結構性地**不成立：本方案兩端
+都靠具名 POSIX ACL 授權（`gate-ledger-spool` 給 gate `wx` 無 `r`、`repo-worktree`
+給 gate `rX`），而 `setfacl -m u:<名>:…` 在產生權限的當下就要解析得到那個名字；
+DynamicUser 的 UID 在 unit 起動前不存在、每次還不同。
+
+## 工作樹：拋棄式副本，不是唯讀
+
+唯讀在可行性上不成立（`pytest` 要寫 `.pytest_cache`／`__pycache__`，`npm test`／
+`make` 更是必寫），而副本另外買到「gate 的寫入不污染 builder 交付的樹」與「快照在
+單一時點取得，builder 的背景行程改不了跑到一半的樹」。複製由 **gate 自己**執行
+（`gate_ledger.snapshot_worktree`）——它是唯一同時讀得到來源（`rX` ACL）、寫得進
+目的地（自己的 pool）的身分；Manager 在 #641 之後讀不到 builder 的樹，那條刻意不
+回頭放寬。
+
+## 產出落點：spool，不是直接寫 `gate-ledger`
+
+#628 的採信端以 `terminal_contract.foreign_evidence_author()` 檢查檔案擁有者，**非
+Manager 產生的 ledger 一律不採信**；而 `gate-ledger` 這個資產同時是 exit sentinel
+的落點，開放寫入面等於讓一個跑 untrusted code 的帳號能偽造任何 job 的完成狀態。
+
+因此 gate 寫的是 `gate-ledger-spool` 的自己那一格（`wx` 無 `r`，per-job，pre-seed
+守衛與封口共用 `spool_slot`，不另寫一份），Manager 讀它、**以不受信任輸入驗證**
+（schema 嚴格、gate 名稱必須落在 operator 的宣告集合內），然後**自己重寫一份**權威
+ledger 到 `gate-ledger`。作者歸屬與 #628 逐字不變。
+
+## 誠實邊界
+
+本模組買到的是**圍堵**，不是「ledger 不可偽造」。取得任意程式碼執行的 builder 依然
+能影響**自己那一份** ledger 的內容——那是「執行對方交出來的測試碼」這件事本身的
+性質，換誰執行都一樣，唯一的替代是不跑 gate。它買到的是：那個執行碰不到 Manager 的
+durable state、碰不到 verdict 通道、碰不到別的 job 的工作樹、也沒有 spawn 授權。
+spec §R3 有對應的風險段落。
+
+## `direct` 模式零回歸
+
+`PSC_JOB_RUNNER=direct`（現行預設）下 builder 與 Manager 同 UID，「第四個身分」沒有
+任何邊界可言。本模組因此在 direct 模式下**逐字沿用既有行為**：就地呼叫
+`gate_ledger.write_gate_ledger()`，與 `work_actions._regenerate_gates_action` 改動前
+做的事完全相同。兩種模式共用**同一個進入點**（:func:`run_declared_gates`），差別
+只在那一個分支——這正是 #629 要求「`_regenerate_gates_action` 一併收斂」的形狀。
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+from typing import Any, Mapping
+
+from ..config import paths
+from . import gate_ledger, job_runner, spool_slot, terminal_contract
+
+
+#: gate 執行身分用來跑 `gate_ledger` 的直譯器。降權模式下 Manager 的 repo root 在
+#: `/home` 底下，而 job unit 帶 `ProtectHome=yes`——`PYTHONPATH=<repo>` 那條路在那裡
+#: 不成立（#623 缺口 1 的同一件事）。可行的是**部署樹裡的 venv**：`/opt/cortex`
+#: root-owned `0755`，對每個 job 帳號唯讀＋可執行，`ProtectSystem=strict` 讓它唯讀
+#: 但讀得到。
+GATE_PYTHON_ENV = "PSC_GATE_PYTHON"
+DEFAULT_GATE_PYTHON = "/opt/cortex/venv/bin/python3"
+
+#: gate 那一格裡的 ledger 檔名（目錄本身以 spool key 定址）。
+GATE_LEDGER_FILENAME = "ledger.json"
+
+#: gate unit 的 stdout／stderr 落點（同一格內）。**診斷用，不是證據**：權威結論在
+#: ledger 裡，每個 gate 的輸出尾段由 `gate_ledger.run_gates()` 放進 `detail`。
+GATE_LOG_FILENAME = "gate.log"
+
+#: ledger 每一列 `detail` 的上限（與 `gate_ledger.run_gates` 的 `[-2000:]` 同數量級）。
+#: spool 內容是**不受信任輸入**：一個被攻陷的 gate 可以塞進數百 MB 的 detail，而那
+#: 份 payload 會進 Manager 的 durable evidence 樹。
+MAX_DETAIL_CHARS = 2000
+
+#: 一份 ledger 最多幾列。同上：宣告了 N 個 gate 就只該有 N 列（外加宣告失敗那一
+#: 列），多出來的一律是 spool 被塞了東西。
+MAX_LEDGER_ROWS = 64
+
+
+class GateRunnerError(RuntimeError):
+    """gate 執行面失敗。`reason` 是機器可讀的診斷碼，與採信端的錯誤碼同一套風格。"""
+
+    def __init__(self, reason: str, message: str, **context: object) -> None:
+        super().__init__(message)
+        self.reason = reason
+        self.context = dict(context)
+
+
+# ---------------------------------------------------------------------------
+# 路徑（與 R1 登記表的 path 契約成對）
+# ---------------------------------------------------------------------------
+
+def gate_ledger_spool_root(coordinator_root: str | Path | None = None) -> Path:
+    """`<coordinator_root>/gate-ledger-spool/`（登記表資產 `gate-ledger-spool`）。
+
+    接受顯式 root 的理由與 `job_workspace.commit_spool_root()` 逐字相同：起 gate 與
+    消費 spool 兩端都可能拿到呼叫端傳下來的 root，一律回頭讀 env 會讓同一個 job 的
+    兩端指到不同的樹。
+    """
+
+    if coordinator_root is None:
+        return paths.gate_ledger_spool_root()
+    return Path(coordinator_root) / paths.GATE_LEDGER_SPOOL_DIRNAME
+
+
+def gate_ledger_spool_dir(
+    *, spool_key: str, coordinator_root: str | Path | None = None
+) -> Path:
+    """單一 job 的 gate spool 目錄（唯一定址點）。"""
+
+    _validate_spool_key(spool_key)
+    return gate_ledger_spool_root(coordinator_root).resolve() / spool_key
+
+
+def gate_spool_ledger_path(
+    *, spool_key: str, coordinator_root: str | Path | None = None
+) -> Path:
+    """gate 寫、Manager 讀的那一個檔。"""
+
+    return (
+        gate_ledger_spool_dir(spool_key=spool_key, coordinator_root=coordinator_root)
+        / GATE_LEDGER_FILENAME
+    )
+
+
+def gate_worktree_dir(
+    *, spool_key: str, gate_worktree_root: str | Path | None = None
+) -> Path:
+    """gate 的拋棄式副本落點（登記表資產 `gate-worktree-pool` 底下一格）。"""
+
+    _validate_spool_key(spool_key)
+    root = (
+        paths.gate_worktree_root()
+        if gate_worktree_root is None
+        else Path(gate_worktree_root)
+    )
+    return root / spool_key
+
+
+def _validate_spool_key(spool_key: str) -> None:
+    """key 會被接成絕對路徑並嵌進 spec，形狀在**組路徑之前**就驗。
+
+    判準刻意複用 `job_workspace.job_segment_valid()`：gate 的 spool key 與 builder
+    的 spool key／worktree 目錄名是**同一個字串**（`Path(log_path).stem`），兩邊用
+    不同的判準就會出現「builder 那格建得起來、gate 這格建不起來」的錯位。
+    """
+
+    from . import job_workspace
+
+    if not isinstance(spool_key, str) or not job_workspace.job_segment_valid(spool_key):
+        raise GateRunnerError(
+            "gate-spool-key-invalid",
+            f"unsafe gate spool key: {spool_key!r}",
+            spool_key=str(spool_key),
+        )
+
+
+def spool_key_for_job(job: Mapping[str, object]) -> str | None:
+    """該 job 的 gate spool key。**推導規則只有一條**，且與 commit spool 共用。
+
+    `job_workspace.spool_key_for_job()` 是那一條規則的唯一實作（`Path(log_path).stem`
+    ＝ `launcher.launch()` 收到的 `slice_id`，也就是 exit sentinel 與 gate ledger 的
+    定址基準）。這裡直接委派而不是重寫，理由與該函式 docstring 的「必須是單一規則」
+    逐字相同——各自猜 key 的失敗形態是「找不到 → 靜默不回收」。
+    """
+
+    from . import job_workspace
+
+    return job_workspace.spool_key_for_job(job)
+
+
+# ---------------------------------------------------------------------------
+# gate 執行
+# ---------------------------------------------------------------------------
+
+def resolve_gate_python(env: Mapping[str, str]) -> str:
+    """gate unit 用來跑 `gate_ledger` 的直譯器絕對路徑。"""
+
+    raw = str(env.get(GATE_PYTHON_ENV, "") or "").strip() or DEFAULT_GATE_PYTHON
+    if not raw.startswith("/"):
+        raise GateRunnerError(
+            "gate-python-not-absolute",
+            f"{GATE_PYTHON_ENV} 必須是絕對路徑（gate unit 沒有 Manager 的 PATH），收到 {raw!r}",
+            requested=raw,
+        )
+    return raw
+
+
+def build_gate_argv(
+    *,
+    python: str,
+    ledger_out: str | Path,
+    snapshot: str | Path,
+    source_worktree: str | Path,
+) -> list[str]:
+    """gate unit 實際執行的 argv。**封閉：沒有任何來自 job 的可變輸入。**
+
+    要跑哪些命令**不在這條 argv 上**——它們由 operator 的 `PSC_GATE_CMD_*` 宣告，
+    經 `job_runner.gate_declaration_env()` 進到 unit 的環境，再由
+    `gate_ledger.load_gate_specs()` 解析。這是刻意的：讓 Manager 把命令展開到 argv
+    上會產生第二份真實來源，而 `gate_evidence_name_hint()`／`gate_scope_honesty_hint()`
+    給 builder 看的 prompt 用的是第一份。
+
+    `--publish`：那一格是 `wx` 無 `r`，檔由 gate 的 uid 建立、unit 帶 `UMask=0077`，
+    Manager 是**目錄**的 owner 但那不給檔案內容的讀取權（#638 缺陷 2）。
+    """
+
+    return [
+        str(python),
+        "-m",
+        "paulsha_cortex.coordinator.gate_ledger",
+        "--out",
+        str(ledger_out),
+        "--worktree",
+        str(snapshot),
+        "--snapshot-from",
+        str(source_worktree),
+        "--publish",
+    ]
+
+
+def prepare_gate_spool(
+    *, spool_key: str, coordinator_root: str | Path | None = None
+) -> Path:
+    """起 gate 之前建立那一格，回傳 ledger 應該落地的路徑。
+
+    生命週期整條走 :mod:`spool_slot`（#639 已有這套語意，本模組不另寫一份）：
+
+    - **`reset=True`**：同一個 key 會被重跑（retry 用同一個 slice_id、
+      `regenerate-gates` 更是明著重跑），上一輪封存過的那一格必須重新開封，而
+      `spool_slot.create_slot()` 的解封做法是**整格重建**而不是 `chmod` 回去。
+    - **pre-seed 守衛**：重建同時把任何預埋的 `ledger.json` 刪掉。**這比「已存在
+      即拒絕」更強**——預埋的人得到的不是拒絕，而是自己的檔案被刪掉；而 Manager 是
+      這一格的 owner，刪得掉 gate（或任何人）寫的檔。builder 更是連容器都
+      traverse 不進來（`0700 cortex-manager` ＋ 只給 gate 一條 `wx` 具名條目）。
+    - **不傳明確 mode**：在帶 default ACL 的樹上 `mkdir(mode=…)` 會把 mask 一起
+      重設，把 gate 繼承來的具名條目壓成 `#effective:---`（#638 缺陷 1）。
+    """
+
+    spool_dir = gate_ledger_spool_dir(
+        spool_key=spool_key, coordinator_root=coordinator_root
+    )
+    try:
+        spool_slot.create_slot(spool_dir, reset=True)
+    except spool_slot.SpoolSlotError as exc:
+        raise GateRunnerError(
+            "gate-spool-unavailable",
+            f"gate ledger spool slot unavailable: {spool_dir}: {exc}",
+            spool_dir=str(spool_dir),
+        ) from exc
+    return spool_dir / GATE_LEDGER_FILENAME
+
+
+def seal_gate_spool(ledger_file: str | Path) -> None:
+    """消費完成後把那一格封口（best-effort，與兩個既有 spool 同一支實作）。
+
+    封的是**目錄**：ledger 由 gate 的 uid 建立，Manager `chmod` 不了它（#638 缺陷
+    3）；但 Manager 是目錄的 owner，收掉目錄的 `w` 之後那一格再也建不了、改不了名、
+    刪不掉任何檔，`chmod` 同時把 ACL mask 收成 `---`，gate 具名條目的授權一併失效。
+
+    失敗不得讓一次**已經成功**的消費反而失敗：權威副本此時已經落在 `gate-ledger`。
+    """
+
+    spool_slot.seal_slot(Path(ledger_file).parent)
+
+
+def read_gate_spool(ledger_file: str | Path, *, env: Mapping[str, str]) -> dict[str, Any]:
+    """讀回 gate 交付的 ledger 並**以不受信任輸入驗證**，回傳正規化後的 payload。
+
+    寫這份檔的身分正在執行 builder 交出來的程式碼；它可以被攻陷。因此這裡逐項驗
+    形狀，並把 gate 名稱收斂到 operator 的宣告集合內——一個被攻陷的 gate 可以把
+    `status` 全填 `passed`（那是圍堵買不到的東西，見模組 docstring 的誠實邊界），
+    但**不能**發明一個 operator 沒宣告過的 gate 名混進 ledger、不能塞進無界的
+    payload、也不能讓 ledger 的 `slice_id` 指到別的 job。
+    """
+
+    path = Path(ledger_file)
+    if path.is_symlink():
+        raise GateRunnerError(
+            "gate-spool-unsafe", f"gate spool ledger is a symlink: {path}", path=str(path)
+        )
+    if not path.is_file():
+        raise GateRunnerError(
+            "gate-spool-empty",
+            f"gate 執行結束但沒有交付 ledger：{path}"
+            "（快照失敗／直譯器不存在／unit 起不來時皆為此形狀，"
+            "診斷見 `journalctl -u <gate unit>` 與同一格的 gate.log）",
+            path=str(path),
+        )
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as exc:
+        raise GateRunnerError(
+            "gate-spool-unreadable", f"gate spool ledger unreadable: {path}: {exc}",
+            path=str(path),
+        ) from exc
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise GateRunnerError(
+            "gate-spool-invalid", f"gate spool ledger 不是合法 JSON: {exc}", path=str(path)
+        ) from exc
+    if (
+        not isinstance(payload, Mapping)
+        or payload.get("kind") != terminal_contract.GATE_LEDGER_KIND
+        or type(payload.get("schema_version")) is not int
+        or not isinstance(payload.get("gates"), list)
+    ):
+        raise GateRunnerError(
+            "gate-spool-invalid", f"gate spool ledger 形狀非法: {path}", path=str(path)
+        )
+    rows = payload["gates"]
+    if len(rows) > MAX_LEDGER_ROWS:
+        raise GateRunnerError(
+            "gate-spool-invalid",
+            f"gate spool ledger 有 {len(rows)} 列，超過上限 {MAX_LEDGER_ROWS}",
+            path=str(path),
+        )
+    allowed = set(gate_ledger.ledger_gate_names(env)) | {gate_ledger.GATE_SPEC_FAILURE_NAME}
+    normalized: list[dict[str, object]] = []
+    for row in rows:
+        if not isinstance(row, Mapping):
+            raise GateRunnerError(
+                "gate-spool-invalid", "gate spool ledger gates 項目必須為物件", path=str(path)
+            )
+        name = row.get("name")
+        if not isinstance(name, str) or name not in allowed:
+            raise GateRunnerError(
+                "gate-spool-unknown-gate",
+                f"gate spool ledger 出現未宣告的 gate 名稱 {name!r}"
+                f"（operator 宣告的是 {sorted(allowed)}）",
+                path=str(path),
+                name=str(name),
+            )
+        exit_code = row.get("exit_code")
+        if type(exit_code) is not int:
+            raise GateRunnerError(
+                "gate-spool-invalid",
+                f"gate {name!r} 的 exit_code 必須是整數", path=str(path),
+            )
+        detail = row.get("detail")
+        normalized.append(
+            {
+                "name": name,
+                "command": str(row.get("command", ""))[:MAX_DETAIL_CHARS],
+                "exit_code": exit_code,
+                # **status 由 exit_code 重算，不採信 spool 自報的那一欄。** 這與
+                # `terminal_contract._ledger_outcomes()` 是同一條紀律（ledger 自身
+                # 矛盾＝記了非 0 卻標 passed，一律不採信），只是往上游多做一次：
+                # 這樣 Manager 落地的權威 ledger 本身就沒有那種矛盾可言。
+                "status": "passed" if exit_code == 0 else "failed",
+                "detail": (detail if isinstance(detail, str) else "")[-MAX_DETAIL_CHARS:],
+            }
+        )
+    return gate_ledger.build_ledger(normalized, slice_id=str(env.get("PSC_SLICE_ID", "")))
+
+
+def run_declared_gates(
+    *,
+    job_id: str,
+    spool_key: str,
+    ledger_path: str | Path,
+    worktree: str | Path,
+    env: Mapping[str, str] | None = None,
+    coordinator_root: str | Path | None = None,
+    runner: Any | None = None,
+) -> dict[str, Any]:
+    """執行 operator 宣告的 gate 並讓 **Manager** 落地權威 ledger，回傳 payload。
+
+    這是 #629 的**單一進入點**：自動路徑（`manager.terminalize_workflow_job`）與
+    operator 明著要求的 `regenerate-gates` 走的是同一支，因此不會出現「自動的那條
+    降權了、手動的那條還在 Manager 進程裡跑」這種半套狀態——那正是 #629 本文點名
+    `work_actions._regenerate_gates_action` 要一併收斂的原因。
+
+    模式分支只有一個，而且在最上面：
+
+    - `direct`（現行預設）：builder 與 Manager 同 UID，第四個身分沒有任何邊界可言。
+      逐字沿用既有行為（就地 `write_gate_ledger`），**零回歸**。
+    - `systemd-run`／`systemd-template`：以 `cortex-gate` 起一份 root-owned 模板
+      unit 執行，產出經 spool 回到 Manager 手上。
+    """
+
+    source = dict(os.environ if env is None else env)
+    mode = job_runner.resolve_runner_mode(source)
+    if mode == job_runner.RUNNER_DIRECT:
+        return gate_ledger.write_gate_ledger(
+            ledger_path=ledger_path, worktree=worktree, env=source
+        )
+    return _run_as_gate_identity(
+        job_id=job_id,
+        spool_key=spool_key,
+        ledger_path=ledger_path,
+        worktree=worktree,
+        env=source,
+        coordinator_root=coordinator_root,
+        runner=runner,
+    )
+
+
+def _run_as_gate_identity(
+    *,
+    job_id: str,
+    spool_key: str,
+    ledger_path: str | Path,
+    worktree: str | Path,
+    env: Mapping[str, str],
+    coordinator_root: str | Path | None,
+    runner: Any | None,
+) -> dict[str, Any]:
+    """降權模式的實作：起 `cortex-gate-job@<instance>.service`，消費 spool，落地。"""
+
+    resolved_worktree = Path(worktree)
+    if not resolved_worktree.is_dir():
+        raise GateRunnerError(
+            "gate-worktree-missing",
+            f"被驗的工作樹不存在：{resolved_worktree}",
+            worktree=str(resolved_worktree),
+        )
+    # 前置物（模板 unit／shim／spec spool／帳號）任一缺席都在**任何副作用之前**
+    # fail-closed；`executor=None` 是 gate 角色的契約（剖面由 operator 平面決定）。
+    plan = job_runner.prepare_systemd_template(
+        env, job_id=job_id, executor=None, role=job_runner.JOB_ROLE_GATE
+    )
+    spool_ledger = prepare_gate_spool(
+        spool_key=spool_key, coordinator_root=coordinator_root
+    )
+    snapshot = gate_worktree_dir(spool_key=spool_key)
+    gate_env = job_runner.build_job_env(
+        manager_env=env,
+        job_id=job_id,
+        slice_id=str(env.get("PSC_SLICE_ID") or spool_key),
+        repo_root=str(env.get("PSC_REPO_ROOT") or "/opt/cortex"),
+        role=job_runner.JOB_ROLE_GATE,
+    )
+    argv = build_gate_argv(
+        python=resolve_gate_python(env),
+        ledger_out=spool_ledger,
+        snapshot=snapshot,
+        source_worktree=resolved_worktree,
+    )
+    spec = job_runner.build_job_spec(
+        job_id=job_id,
+        instance=plan.instance,
+        unit=plan.unit,
+        command=argv,
+        # cwd 是 gate 自己的 pool 根，不是被驗的樹：那棵樹對 gate 只有 `rX`，而
+        # 副本在 unit 起動的當下還不存在（是 gate 的第一個動作才建的）。
+        working_directory=str(paths.gate_worktree_root()),
+        log_path=str(spool_ledger.parent / GATE_LOG_FILENAME),
+        env=gate_env,
+    )
+    job_runner.write_job_spec(plan.spec_path, spec)
+    start = job_runner.build_systemctl_start_argv(
+        systemctl=plan.binary, unit=plan.unit
+    )
+    execute = subprocess.run if runner is None else runner
+    completed = execute(start, capture_output=True, text=True, check=False)
+    returncode = int(getattr(completed, "returncode", 1))
+    try:
+        payload = read_gate_spool(spool_ledger, env=env)
+    except GateRunnerError as exc:
+        # unit 起不來（polkit 拒絕、模板未安裝、shim 讀不到 spec）與「跑了但沒交付」
+        # 在 spool 端是同一個形狀，因此把 client 的 exit code 與 stderr 帶進錯誤裡
+        # ——少了它，operator 看到的只有「沒有 ledger」，指不出真正的原因（#643 的
+        # 教訓：症狀是空輸出的失敗最難查）。
+        raise GateRunnerError(
+            exc.reason,
+            f"{exc}\n"
+            f"gate unit={plan.unit} account={plan.account} "
+            f"profile={plan.hardening_profile} systemctl_exit={returncode}\n"
+            f"{(getattr(completed, 'stderr', '') or '').strip()[-2000:]}",
+            **{**exc.context, "unit": plan.unit, "systemctl_exit": returncode},
+        ) from exc
+    # **權威 ledger 由 Manager 自己寫**——#628 的 `foreign_evidence_author()` 檢查的
+    # 就是這個檔的擁有者。gate 交付的那一份留在 spool 裡封起來，不進採信路徑。
+    gate_ledger.write_ledger_payload(ledger_path, payload)
+    seal_gate_spool(spool_ledger)
+    return payload
+
+
+# ---------------------------------------------------------------------------
+# 自動路徑：terminalize 之前補上缺席的 ledger
+# ---------------------------------------------------------------------------
+
+def ensure_gate_ledger(
+    job: Mapping[str, object],
+    *,
+    phases: frozenset[str],
+    env: Mapping[str, str] | None = None,
+    coordinator_root: str | Path | None = None,
+    runner: Any | None = None,
+) -> dict[str, Any] | None:
+    """降權模式下，在採信之前把缺席的 gate ledger 補上；回傳 payload 或 `None`。
+
+    `None` 代表「這一輪不該由本模組動手」，四種情況：
+
+    1. **`direct` 模式**——ledger 由 job wrapper 在模型結束後寫，本模組不介入。
+       這條是「零回歸」的來源：direct 下的行為與 #629 之前逐字相同。
+    2. **phase 不在 `phases` 內**——`plan`／`review` 不跑 gate（planner 與 reviewer
+       都不改 candidate），判準由呼叫端給，本模組不自己發明一份。
+    3. **ledger 已經存在**——重跑會覆蓋一份已經被採信路徑讀過的證據。要重跑是
+       operator 的明示決定，走 `regenerate-gates`。
+    4. **推導不出 spool key／工作樹已不在**——沒有可驗的東西，維持 `require_ledger`
+       的既有 fail-closed（缺 ledger ⇒ 拒），而不是產生一份空的假裝驗過。
+
+    **失敗一律往上拋**（`GateRunnerError`／`JobRunnerError`）：gate 跑不起來時最壞的
+    行為是靜默略過——那會讓 `require_ledger` 看到「沒有 ledger」而以一個指不出原因
+    的錯誤收場。呼叫端負責把它翻成可操作的診斷。
+    """
+
+    source = dict(os.environ if env is None else env)
+    if job_runner.resolve_runner_mode(source) == job_runner.RUNNER_DIRECT:
+        return None
+    if job.get("workflow_phase") not in phases:
+        return None
+    log_path = job.get("log_path")
+    if not isinstance(log_path, str) or not log_path:
+        return None
+    ledger_path = terminal_contract.gate_ledger_path(log_path)
+    if Path(ledger_path).exists():
+        return None
+    spool_key = spool_key_for_job(job)
+    if spool_key is None:
+        return None
+    worktree = job.get("worktree")
+    if not isinstance(worktree, str) or not Path(worktree).is_dir():
+        return None
+    job_id = str(job.get("job_id") or spool_key)
+    return run_declared_gates(
+        job_id=job_id,
+        spool_key=spool_key,
+        ledger_path=ledger_path,
+        worktree=worktree,
+        env=source,
+        coordinator_root=coordinator_root,
+        runner=runner,
+    )
+
+
+__all__ = [
+    "DEFAULT_GATE_PYTHON",
+    "GATE_LEDGER_FILENAME",
+    "GATE_LOG_FILENAME",
+    "GATE_PYTHON_ENV",
+    "GateRunnerError",
+    "MAX_DETAIL_CHARS",
+    "MAX_LEDGER_ROWS",
+    "build_gate_argv",
+    "ensure_gate_ledger",
+    "gate_ledger_spool_dir",
+    "gate_ledger_spool_root",
+    "gate_spool_ledger_path",
+    "gate_worktree_dir",
+    "prepare_gate_spool",
+    "read_gate_spool",
+    "resolve_gate_python",
+    "run_declared_gates",
+    "seal_gate_spool",
+    "spool_key_for_job",
+]

--- a/paulsha_cortex/coordinator/job_runner.py
+++ b/paulsha_cortex/coordinator/job_runner.py
@@ -120,6 +120,8 @@ __all__ = [
     "BUILDER_SYNTHESIZED_ENV",
     "CREDENTIAL_ENV_RE",
     "DEFAULT_BUILDER_ACCOUNT",
+    "DEFAULT_GATE_ACCOUNT",
+    "DEFAULT_GATE_TEMPLATE_UNIT",
     "DEFAULT_JOB_SHIM",
     "DEFAULT_JOB_SPEC_SPOOL",
     "DEFAULT_REVIEWER_ACCOUNT",
@@ -128,11 +130,17 @@ __all__ = [
     "DEFAULT_TEMPLATE_UNIT",
     "EXECUTOR_HARDENING_PROFILE",
     "ForwardedEnvVar",
+    "GATE_ACCOUNT_ENV",
+    "GATE_GROUP_ENV",
+    "GATE_HOME_ENV",
+    "GATE_PATH_ENV",
+    "GATE_TEMPLATE_UNIT_ENV",
     "HARDENING_PROFILE_JIT",
     "HARDENING_PROFILE_STRICT",
     "JOB_ROLES",
     "JOB_ROLE_BUILDER",
     "JOB_ROLE_CONFIG",
+    "JOB_ROLE_GATE",
     "JOB_ROLE_REVIEW",
     "JOB_RUNNER_ENV",
     "JOB_SHIM_ENV",
@@ -221,6 +229,18 @@ REVIEWER_GROUP_ENV = "PSC_REVIEWER_GROUP"
 REVIEWER_HOME_ENV = "PSC_REVIEWER_HOME"
 REVIEWER_PATH_ENV = "PSC_REVIEWER_PATH"
 
+#: gate 執行身分的 OS 帳號名（#629）。**第四個帳號**，與 builder／reviewer-planner／
+#: manager 三者皆不同——理由見 `trust_root.permgen.FOUR_WAY_SCHEME` 的說明。
+GATE_ACCOUNT_ENV = "PSC_GATE_ACCOUNT"
+DEFAULT_GATE_ACCOUNT = "cortex-gate"
+GATE_GROUP_ENV = "PSC_GATE_GROUP"
+GATE_HOME_ENV = "PSC_GATE_HOME"
+GATE_PATH_ENV = "PSC_GATE_PATH"
+
+#: gate 的模板 unit 名（與 `permgen.job_unit_stem(…, GATE)` 成對契約）。
+GATE_TEMPLATE_UNIT_ENV = "PSC_GATE_JOB_TEMPLATE_UNIT"
+DEFAULT_GATE_TEMPLATE_UNIT = "cortex-gate-job@.service"
+
 #: reviewer／planner 的模板 unit 名（與 `permgen.job_unit_stem(…, REVIEWER)` 成對契約）。
 REVIEW_TEMPLATE_UNIT_ENV = "PSC_REVIEW_JOB_TEMPLATE_UNIT"
 DEFAULT_REVIEW_TEMPLATE_UNIT = "cortex-reviewer-job@.service"
@@ -291,7 +311,10 @@ DEFAULT_TEMPLATE_UNIT = f"{TEMPLATE_UNIT_PREFIX}{TEMPLATE_UNIT_SUFFIX}"
 JOB_ROLE_BUILDER = "builder"
 #: reviewer ＋ planner（同一個 OS 帳號、同一份模板 unit）。
 JOB_ROLE_REVIEW = "review"
-JOB_ROLES = (JOB_ROLE_BUILDER, JOB_ROLE_REVIEW)
+#: operator 宣告的 gate 命令（#629）。**不跑模型**，但跑的是 builder 工作樹裡的
+#: `conftest.py`／plugin，因此與前兩者同級地必須被關進盒子——只是**不同的**盒子。
+JOB_ROLE_GATE = "gate"
+JOB_ROLES = (JOB_ROLE_BUILDER, JOB_ROLE_REVIEW, JOB_ROLE_GATE)
 
 
 @dataclass(frozen=True)
@@ -339,6 +362,23 @@ JOB_ROLE_CONFIG: Mapping[str, JobRoleConfig] = MappingProxyType(
                 "reviewer ＋ planner persona（三分方案下同一個 OS 帳號）。M2（#615）："
                 "在此之前它們仍在 Manager 行程內以 Manager 帳號執行，"
                 "「injection 可達的進程皆無 spawn 授權」因此只對 builder 成立。"
+            ),
+        ),
+        JOB_ROLE_GATE: JobRoleConfig(
+            role_id=JOB_ROLE_GATE,
+            account_env=GATE_ACCOUNT_ENV,
+            default_account=DEFAULT_GATE_ACCOUNT,
+            group_env=GATE_GROUP_ENV,
+            home_env=GATE_HOME_ENV,
+            path_env=GATE_PATH_ENV,
+            template_env=GATE_TEMPLATE_UNIT_ENV,
+            default_template=DEFAULT_GATE_TEMPLATE_UNIT,
+            rationale=(
+                "gate 執行身分（#629）——operator 宣告的 `PSC_GATE_CMD_*` 在這裡執行。"
+                "它不跑模型，但那些命令載入的是 builder 完全掌控的工作樹裡的 "
+                "`conftest.py`／plugin，等於一條任意程式碼執行；既有三個帳號逐一皆不可"
+                "承接（builder＝模型自證、manager＝授權線內側、reviewer-planner＝寫 "
+                "verdict 的那一個），故必須是第四個帳號。"
             ),
         ),
     }
@@ -830,8 +870,38 @@ def build_job_env(
     env["PSC_REPO_ROOT"] = repo_root
     if relay_target is not None:
         env["PSC_RELAY_TARGET"] = relay_target
+    if config.role_id == JOB_ROLE_GATE:
+        env.update(gate_declaration_env(manager_env))
     _reject_unsafe(env, source="build_job_env")
     return env
+
+
+#: gate 角色**額外**轉發的變數（#629）：operator 的 gate 宣告本身。
+#:
+#: 它們不在 `BUILDER_FORWARDED_ENV` 裡，因為對模型 job 而言那是純多餘的暴露面
+#: （builder 不該知道自己等一下會被哪些命令驗——#606 的 scope 紀律靠 prompt 給，
+#: 不靠 env）。對 gate 而言它們**就是工作內容**：`gate_ledger.load_gate_specs()`
+#: 只認 `PSC_GATE_CMD_*`，讓 Manager 改用 argv 傳命令會多出第二份真實來源。
+GATE_DECLARATION_ENV_PREFIX = "PSC_GATE_CMD_"
+GATE_DECLARATION_ENV_NAMES = ("PSC_GATE_TIMEOUT",)
+
+
+def gate_declaration_env(manager_env: Mapping[str, str]) -> dict[str, str]:
+    """從 Manager env 取出要轉發給 gate 的宣告（`PSC_GATE_CMD_*` ＋ 逾時）。
+
+    刻意只認**前綴 ＋ 具名白名單**，不認任何 `PSC_GATE_*`：`PSC_GATE_ACCOUNT`／
+    `PSC_GATE_HARDENING_PROFILE`／`PSC_GATE_JOB_TEMPLATE_UNIT` 都是**身分與加固**
+    的設定，轉發進 job 的環境等於把「這個 job 該以什麼形態跑」放進它自己看得到、
+    未來也可能被誰讀去用的地方。gate 需要知道的只有「要跑哪些命令、逾時多久」。
+    """
+
+    forwarded: dict[str, str] = {}
+    for name in sorted(manager_env):
+        if name.startswith(GATE_DECLARATION_ENV_PREFIX) or name in GATE_DECLARATION_ENV_NAMES:
+            value = manager_env.get(name)
+            if value:
+                forwarded[name] = str(value)
+    return forwarded
 
 
 def build_builder_env(
@@ -1205,6 +1275,46 @@ def resolve_hardening_profile(executor: str) -> str:
     return profile
 
 
+#: gate 角色的加固剖面覆寫（#629）。**operator 平面的決定**，不是 job 平面的。
+#:
+#: #643 對模型 job 立下的紀律是「剖面由 executor 決定，config 選不了」——因為那裡
+#: 存在一個 job 碰不到、又能唯一決定剖面的輸入（Manager 選的 executor）。gate 沒有
+#: 那個輸入：它跑的是 operator 用 `PSC_GATE_CMD_*` **自己宣告**的命令，因此「這些
+#: 命令需要哪一份剖面」與「這些命令是什麼」是同一個人在同一個平面上的決定，宣告
+#: 命令卻不能宣告剖面才是不一致的。
+#:
+#: 預設 `strict`：多數宣告的 gate 是 `pytest`／`make`／原生 ELF，它們在
+#: `MemoryDenyWriteExecute=yes` 下正常。宣告 node 型 gate（`npm test`）的部署必須
+#: 顯式打出 `jit`——**不顯式就會壞掉，而且壞得看得見**（V8 直接崩，見 #643），
+#: 這比「不確定就給寬鬆的」正確：後者等於所有部署都少一層加固。
+GATE_HARDENING_PROFILE_ENV = "PSC_GATE_HARDENING_PROFILE"
+DEFAULT_GATE_HARDENING_PROFILE = HARDENING_PROFILE_STRICT
+
+
+def resolve_gate_hardening_profile(env: Mapping[str, str]) -> str:
+    """gate 角色的加固剖面 id；未設＝`strict`，值不合法即 fail-closed。
+
+    不合法時**不落回預設**：一個打錯的剖面名（`jti`）落回 strict 會讓 operator
+    以為自己開了 jit 卻沒有，症狀是 node 型 gate 全崩而設定看起來是對的（#643
+    本身就是這樣被埋掉的）。
+    """
+
+    raw = str(env.get(GATE_HARDENING_PROFILE_ENV, "") or "").strip()
+    if not raw:
+        return DEFAULT_GATE_HARDENING_PROFILE
+    if raw not in TEMPLATE_UNIT_SUFFIX_BY_PROFILE:
+        raise _fail(
+            "job-runner-hardening-profile-unknown",
+            (
+                f"{GATE_HARDENING_PROFILE_ENV} 只接受 "
+                f"{sorted(TEMPLATE_UNIT_SUFFIX_BY_PROFILE)}，收到 {raw!r}"
+            ),
+            source="resolve_gate_hardening_profile",
+            requested=raw,
+        )
+    return raw
+
+
 def template_unit_for_profile(template: str, profile: str) -> str:
     """基底模板名 ＋ 剖面 → 該剖面的模板名（`cortex-job@.service` → `cortex-job-jit@.service`）。
 
@@ -1554,11 +1664,47 @@ class SystemdTemplatePlan:
     role: str = JOB_ROLE_BUILDER
 
 
+def _resolve_profile_for_role(
+    env: Mapping[str, str], *, role: str, executor: str | None
+) -> str:
+    """該角色的加固剖面 id。**兩個角色族、兩條來源，互斥且皆 fail-closed。**
+
+    - 模型 job（builder／review）：唯一輸入是 `executor`（#643），`None` 即拒。
+    - gate（#629）：沒有 executor 可言，唯一輸入是 operator 的
+      `PSC_GATE_HARDENING_PROFILE`；傳了 executor 即拒。
+    """
+
+    if role == JOB_ROLE_GATE:
+        if executor:
+            raise _fail(
+                "job-runner-gate-executor-not-applicable",
+                (
+                    f"gate 角色不得帶 executor（收到 {executor!r}）——它不跑模型 CLI，"
+                    f"剖面由 {GATE_HARDENING_PROFILE_ENV} 決定，不隨 Manager 的 "
+                    "executor 漂移（#629）"
+                ),
+                source="_resolve_profile_for_role",
+                requested=str(executor),
+            )
+        return resolve_gate_hardening_profile(env)
+    if executor is None:
+        raise _fail(
+            "job-runner-executor-missing",
+            (
+                f"角色 {role!r} 的加固剖面唯一輸入是 executor，不得為 None"
+                "（#643：忘了說是哪個 executor 就不該派得出去）"
+            ),
+            source="_resolve_profile_for_role",
+            requested=role,
+        )
+    return resolve_hardening_profile(executor)
+
+
 def prepare_systemd_template(
     env: Mapping[str, str],
     *,
     job_id: str,
-    executor: str,
+    executor: str | None,
     role: str = JOB_ROLE_BUILDER,
     unit_active: Callable[[str, str], bool] | None = None,
 ) -> SystemdTemplatePlan:
@@ -1580,6 +1726,13 @@ def prepare_systemd_template(
     不是提權；而忘了傳 `executor` 的後果是「拿到一份不該給它的加固剖面」。前者由
     `launcher` 的單一決定點 ＋ 不變式測試守住，後者必須在型別層擋。
 
+    **`role=gate`（#629）時 `executor` 必須是 `None`**，而且是雙向強制：gate 不跑
+    任何模型 CLI，所以「哪個 executor」對它沒有意義，剖面改由
+    :func:`resolve_gate_hardening_profile` 從 operator 平面取得。傳了 executor 就是
+    呼叫端把 gate 當成模型 job 在派——那會讓剖面跟著 `PSC_MANAGER_EXECUTOR` 漂移，
+    而 gate 跑什麼命令與 Manager 用哪個模型完全無關。反過來，模型 job 傳 `None`
+    也一樣 fail-closed（那正是 #643 要擋的「忘了說是哪個 executor」）。
+
     **在任何副作用之前呼叫**：這裡每一個 raise 都代表本次派工不該發生。
     """
 
@@ -1587,7 +1740,7 @@ def prepare_systemd_template(
     account = resolve_job_account(env, role=role)
     group = resolve_job_group(env, role=role)
     base_template = resolve_template_unit(env, role=role)
-    profile = resolve_hardening_profile(executor)
+    profile = _resolve_profile_for_role(env, role=role, executor=executor)
     template = template_unit_for_profile(base_template, profile)
     shim = resolve_job_shim(env)
     spool_dir = resolve_job_spec_spool(env)

--- a/paulsha_cortex/coordinator/manager.py
+++ b/paulsha_cortex/coordinator/manager.py
@@ -27,6 +27,7 @@ from . import autonomy
 from . import completion
 from . import coverage
 from . import gate_ledger
+from . import job_runner
 from . import job_workspace
 from . import planning_runtime
 from . import provider_backoff
@@ -3635,6 +3636,14 @@ def _terminal_parse_diagnostics(
 # deterministic verification report 管線（schema／binding／report 重驗）。
 GATE_LEDGER_REQUIRED_PHASES = frozenset({"build"})
 
+# #629：降權模式下由**第四個帳號**（`cortex-gate`）重跑 gate 的 phase。
+#
+# 與 `GATE_LEDGER_REQUIRED_PHASES` **刻意是同一個集合**，而不是「所有會寫 candidate
+# 的 phase」：跑 gate 的唯一理由就是有人要求那份 ledger，而要求它的只有上面那一條
+# 規則。兩者若分家，就會出現「跑了 gate、產出的 ledger 沒有任何採信端會讀」的空轉，
+# 或者反過來「要求 ledger 的 phase 沒人替它跑」——後者正是 #629 之前的現況。
+GATE_EXECUTION_PHASES = GATE_LEDGER_REQUIRED_PHASES
+
 
 def _workflow_step_test_policy(registry, job: Mapping[str, object]) -> str | None:
     """#307：從 job 綁定的 :class:`WorkflowRun` 撈出目前 card 的 ``execution.test_policy``。
@@ -3694,6 +3703,30 @@ def _workflow_acceptance_definition_drifted(
     if pinned is None:
         return False
     return pinned != fresh_test_policy
+
+
+def _run_gate_execution_identity(job: Mapping[str, object]) -> None:
+    """#629：降權模式下補上缺席的 gate ledger（`direct` 模式為 no-op）。
+
+    **失敗一律翻成 `TerminalContractError` 並 fail closed**，不吞、不降級。gate 跑
+    不起來（polkit 拒絕、模板未安裝、快照失敗、spool 被塞了不合法內容）與「gate 沒
+    通過」在**授權**這件事上是同一個結論：沒有獨立證據就不採信。差別只在訊息——
+    這裡把 `GateRunnerError` 的診斷碼與 systemctl 的 exit code 原樣帶出來，否則
+    operator 看到的只會是後面那個 `gate-ledger-missing`，指不出真正的原因（#643 的
+    教訓：症狀是空輸出的失敗最難查）。
+    """
+
+    from . import gate_runner
+
+    try:
+        gate_runner.ensure_gate_ledger(job, phases=GATE_EXECUTION_PHASES)
+    except (gate_runner.GateRunnerError, job_runner.JobRunnerError) as exc:
+        reason = getattr(exc, "reason", None) or "gate-execution-failed"
+        raise terminal_contract.TerminalContractError(
+            f"gate 執行身分未能產生 ledger（{reason}）：{exc}",
+            reason=str(reason),
+            validation_path="$.gate_evidence",
+        ) from exc
 
 
 def _assert_terminal_gate_consistency(
@@ -5446,6 +5479,15 @@ def terminalize_workflow_job(
     if phase not in {"plan", "build", "verify", "review"}:
         raise ValueError("workflow job phase is not terminalizable")
     raw = _extract_terminal_json(job.get("log_path"))
+    # #629：降權模式下 job wrapper 不跑 gate（跑了就是模型自證，見
+    # `launcher._should_run_gates`），ledger 因此在這一刻還不存在。這裡以**第四個
+    # 帳號**（`cortex-gate`）重跑 operator 宣告的命令，產出經 spool 回到 Manager
+    # 手上、由 Manager 自己落地——`direct` 模式下本呼叫是 no-op（ledger 已由
+    # wrapper 寫好），行為與 #629 之前逐字相同。
+    #
+    # 位置在 `_assert_terminal_gate_consistency` **正前方**：那裡是唯一會讀 ledger
+    # 的採信點，證據必須在被讀之前就已經落地，且**不得**在採信開始之後才產生。
+    _run_gate_execution_identity(job)
     # #261 R2／D3：矛盾偵測排在任何狀態採信之前。放在 per-phase schema 驗證之前，
     # 是為了避免「先按 passed 走一段流程、後面才發現不對」造成的部分副作用。
     # #307：帶入 registry 讓 red-required 卡的測試 gate 語意反轉生效。

--- a/paulsha_cortex/coordinator/work_actions.py
+++ b/paulsha_cortex/coordinator/work_actions.py
@@ -3451,9 +3451,21 @@ def _regenerate_gates_action(
     fail closed 條件：exact WorkflowRun CAS、run 必須在 needs_human、且必須真的
     找得到一個 gate-ledger 相關 phase、已終止、log 與 worktree 都還在的 job。
     任一條不成立即拒絕，不做任何 side effect。
+
+    **#629：執行面收斂到 gate 執行身分。** 本動作原本在 **Manager 進程內**直接呼叫
+    `gate_ledger.write_gate_ledger()`——那等於以 `cortex-manager` 的身分，在 builder
+    完全掌控內容的工作樹上跑 `pytest`，而 `pytest` 會載入該樹的 `conftest.py` 與
+    plugin。direct 模式下 builder 與 Manager 同 UID，這件事本來就沒有邊界可言；OS
+    隔離上線後它是一條**真的**提權路徑，而且是最容易被忽略的那一種——它不在派工的
+    熱路徑上，只在 operator 手動救援時才走到。
+
+    改法不是在這裡另寫一套降權，而是改呼叫 `gate_runner.run_declared_gates()`：自動
+    路徑（`manager.terminalize_workflow_job`）與本動作因此走**同一支**，不會出現
+    「自動的那條降權了、手動的那條還在 Manager 進程裡跑」。direct 模式下該函式逐字
+    沿用既有行為（就地 `write_gate_ledger`），本動作的產出與訊息面零變化。
     """
 
-    from . import gate_ledger, terminal_contract
+    from . import gate_ledger, gate_runner, terminal_contract
     from .manager import GATE_LEDGER_REQUIRED_PHASES
 
     extras = set(args) - {
@@ -3510,14 +3522,26 @@ def _regenerate_gates_action(
         raise RuntimeError("regenerate-gates requires the builder worktree to still exist")
 
     ledger_path = terminal_contract.gate_ledger_path(job["log_path"])
+    spool_key = gate_runner.spool_key_for_job(job)
+    if spool_key is None:
+        raise RuntimeError("regenerate-gates requires a resolvable gate spool key")
     try:
-        payload = gate_ledger.write_gate_ledger(
+        payload = gate_runner.run_declared_gates(
+            job_id=str(job.get("job_id") or spool_key),
+            spool_key=spool_key,
             ledger_path=ledger_path,
             worktree=worktree,
         )
     except gate_ledger.GateSpecError as exc:
         # operator 宣告仍不合法：不寫出任何東西，把設定錯誤原樣回報。
         raise RuntimeError(f"regenerate-gates gate declaration invalid: {exc}") from exc
+    except gate_runner.GateRunnerError as exc:
+        # 降權模式下 gate 執行身分起不來／沒交付 ledger。**不退回 Manager 進程內
+        # 執行**——那正是本動作要移除的那條提權路徑；診斷碼原樣帶出來讓 operator
+        # 修部署，而不是靜默換一個更寬的身分把它跑起來。
+        raise RuntimeError(
+            f"regenerate-gates gate execution failed ({exc.reason}): {exc}"
+        ) from exc
     gates = [
         {"name": row.get("name"), "status": row.get("status"), "exit_code": row.get("exit_code")}
         for row in payload.get("gates", [])

--- a/paulsha_cortex/trust_root/__main__.py
+++ b/paulsha_cortex/trust_root/__main__.py
@@ -7,12 +7,13 @@ Phase 1 不改 `cortex` CLI（避免動到 R-16 help 對齊面）；operator／C
     python -m paulsha_cortex.trust_root selfcheck   # R3 自檢診斷（JSON）
     python -m paulsha_cortex.trust_root registry    # R1 登記表摘要（JSON）
     python -m paulsha_cortex.trust_root equation     # R1 雙向等式結果
-    python -m paulsha_cortex.trust_root permissions [three-way|two-way] [--commands] [--paths]
+    python -m paulsha_cortex.trust_root permissions [four-way|three-way|two-way]
+                                        [--commands] [--paths]
                                         [--operator-account <帳號名|none>]
                                         [--external-reader-account <帳號名|none>]
                                                     # Phase 2a 權限計畫（JSON 或命令序列）
-    python -m paulsha_cortex.trust_root unit [three-way|two-way]
-                                        [--manager|--monitor|--job|--review-job
+    python -m paulsha_cortex.trust_root unit [four-way|three-way|two-way]
+                                        [--manager|--monitor|--job|--review-job|--gate-job
                                          |--job-properties]
                                         [--profile strict|jit]
                                                     # Phase 2b systemd unit 內容
@@ -25,19 +26,24 @@ Phase 1 不改 `cortex` CLI（避免動到 R-16 help 對齊面）；operator／C
                                                     #   ＋planner 模板 unit（同帳號，
                                                     #   User=cortex-reviewer-planner，
                                                     #   unit 名 cortex-reviewer-job@.service）；
+                                                    #   --gate-job＝#629 的 gate 執行身分
+                                                    #   模板 unit（User=cortex-gate，
+                                                    #   unit 名 cortex-gate-job@.service；
+                                                    #   只有 four-way 有這個帳號）；
                                                     #   --job-properties＝方案 A 的
                                                     #   systemd-run --property= 清單；
                                                     #   --profile＝#643 的 per-executor
                                                     #   加固剖面，只對 --job／--review-job／
-                                                    #   --job-properties 有意義。預設
+                                                    #   --gate-job／--job-properties 有意義。
+                                                    #   預設
                                                     #   strict＝完整加固表；jit 只放寬
                                                     #   MemoryDenyWriteExecute，給 node 型
                                                     #   executor（codex／copilot）用，
                                                     #   unit 名尾綴 -jit）
-    python -m paulsha_cortex.trust_root shim [three-way|two-way]
+    python -m paulsha_cortex.trust_root shim [four-way|three-way|two-way]
                                                     # Phase 2b 方案 B 的降權 shim 內容
                                                     # （模板 unit 的固定 ExecStart=）
-    python -m paulsha_cortex.trust_root gitconfig [three-way|two-way]
+    python -m paulsha_cortex.trust_root gitconfig [four-way|three-way|two-way]
                                         [--builder|--reviewer-planner|--manager]
                                         --source-repo <slug> [--source-repo <slug>…]
                                                     # #623：帳號 HOME 下 root-owned 的
@@ -46,26 +52,32 @@ Phase 1 不改 `cortex` CLI（避免動到 R-16 help 對齊面）；operator／C
                                                     # job 帳號 ＋ Manager（Manager 也要
                                                     # 對來源樹跑 git，同樣會撞 dubious
                                                     # ownership）
-    python -m paulsha_cortex.trust_root toolchain [three-way|two-way]
+    python -m paulsha_cortex.trust_root toolchain [four-way|three-way|two-way]
                                                     # #640：executor toolchain 的落位
                                                     # 步驟（四個模型 CLI 進
                                                     # <deploy_root>/toolchain、node 走
                                                     # 系統層、job 的 PSC_BUILDER_PATH）
-    python -m paulsha_cortex.trust_root polkit [three-way|two-way] [--template|--transient]
+    python -m paulsha_cortex.trust_root polkit [four-way|three-way|two-way]
+                                        [--template|--transient]
                                                     # Phase 2b 降權 polkit 規則內容
                                                     # （--template＝方案 B，**預設**；
                                                     #   --transient＝方案 A，對照用）
-                                                    # 內容涵蓋**全部**降權 job 角色的
-                                                    # 具名模板（#615 M2 起＝builder ＋
-                                                    # reviewer/planner，各兩個加固剖面
-                                                    # ＝四個字幹），仍是**單一** addRule、
-                                                    # 單一 return YES
-    python -m paulsha_cortex.trust_root scaffold [three-way|two-way]
+                                                    # 內容涵蓋**該方案實際落檔**的全部
+                                                    # 降權 job 角色具名模板（#629 起，
+                                                    # four-way＝builder ＋ reviewer/planner
+                                                    # ＋ gate，各兩個加固剖面＝六個字幹；
+                                                    # three-way／two-way 沒有 gate 帳號，
+                                                    # 因此不含 gate 字幹），仍是**單一**
+                                                    # addRule、單一 return YES
+    python -m paulsha_cortex.trust_root scaffold [four-way|three-way|two-way]
                                                     # Phase 2b 骨架目錄的 install -d 命令
 
-UID 方案未指定時一律用 **`three-way`**（operator 0816 第三輪裁決 A 的定案：
-`cortex-manager`／`cortex-reviewer-planner`／`cortex-builder`）。`two-way` 保留為
-向後相容選項，需**顯式**打出——打錯字不會靜默退回較寬鬆的方案。
+UID 方案未指定時一律用 **`four-way`**（#629 的定案：`cortex-manager`／
+`cortex-reviewer-planner`／`cortex-builder`／**`cortex-gate`**）。`three-way`
+（0816 第三輪裁決 A）與 `two-way` 保留為向後相容選項，需**顯式**打出——打錯字不會
+靜默退回較寬鬆的方案。那兩個方案對 `GATE` 明示「本部署沒有這個角色」，因此不產生
+gate 的 unit／ACL／polkit 字幹，降權模式下 build 卡照 `require_ledger` fail closed
+（＝#629 之前的現況）。
 
 `permissions`／`unit`／`shim`／`gitconfig`／`toolchain`／`polkit`／`scaffold` 只**產生**計畫與內容字串，
 **絕不執行**任何 root 操作、不寫任何系統路徑——命令供 operator 在 Phase 2b runbook
@@ -319,6 +331,8 @@ def main(argv: Sequence[str] | None = None) -> int:
                 which = "job"
             elif token == "--review-job":
                 which = "review-job"
+            elif token == "--gate-job":
+                which = "gate-job"
             elif token == "--job-properties":
                 which = "job-properties"
             elif token == "--profile":
@@ -355,11 +369,22 @@ def main(argv: Sequence[str] | None = None) -> int:
         if which == "job":
             print(permgen.build_job_unit(scheme, profile=profile).content, end="")
             return 0
-        if which == "review-job":
+        if which in ("review-job", "gate-job"):
             # #615 M2：reviewer＋planner 的模板（同一份，兩者同帳號）。
+            # #629：gate 執行身分的模板（第四個帳號，不代表任何 persona）。
+            principal = (
+                Principal.REVIEWER if which == "review-job" else Principal.GATE
+            )
+            if scheme.resolve(principal) is None:
+                print(
+                    f"scheme={scheme.scheme_id} 沒有 `{principal.value}` 帳號，"
+                    f"因此沒有這份模板 unit（#629：改用 --scheme four-way）",
+                    file=sys.stderr,
+                )
+                return 2
             print(
                 permgen.build_job_unit(
-                    scheme, principal=Principal.REVIEWER, profile=profile
+                    scheme, principal=principal, profile=profile
                 ).content,
                 end="",
             )
@@ -367,7 +392,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         if profile_id != permgen.DEFAULT_HARDENING_PROFILE.profile_id:
             # 剖面只對 job 模板 unit 有意義；靜默忽略會產出一份與旗標不符的內容。
             print(
-                f"--profile 只適用於 --job／--review-job／--job-properties（收到 {which}）",
+                "--profile 只適用於 --job／--review-job／--gate-job／--job-properties"
+                f"（收到 {which}）",
                 file=sys.stderr,
             )
             return 2

--- a/paulsha_cortex/trust_root/permgen.py
+++ b/paulsha_cortex/trust_root/permgen.py
@@ -80,6 +80,7 @@ from typing import Mapping, Sequence
 from . import registry
 from .registry import (
     HEADLESS_PERSONAS,
+    UNTRUSTED_EXECUTION_PRINCIPALS,
     AssetTier,
     IngressKind,
     Principal,
@@ -199,6 +200,15 @@ def unresolved_principal_message(
                 f"  - principal `{principal.value}`：`UidScheme.account_of` 缺這一項，"
                 "請補上對應的 OS 帳號名。"
             )
+            if principal is Principal.GATE:
+                lines += [
+                    "      這是 #629 新增的 **gate 執行身分**。它不能併到任何既有帳號：",
+                    "      併到 builder＝模型自證（#540）、併到 manager＝把任意程式碼執行",
+                    "      引到持 spawn 授權的帳號、併到 reviewer-planner＝把 builder 對",
+                    "      verdict 通道的影響力重新打開（#638／#639）。",
+                    "      改用四分方案：`--scheme four-way`（預設值），並先建立帳號：",
+                    "      `sudo useradd --system --no-create-home --shell /usr/sbin/nologin cortex-gate`",
+                ]
             continue
         lines += [
             f"  - principal `{principal.value}`（{opt.description}）未對應到真實帳號。",
@@ -233,6 +243,14 @@ class UidScheme:
     `deploy_account`，後兩者是部署決定，走各自的欄位（見
     :data:`PRINCIPAL_ACCOUNT_OPTIONS`）。放進 `account_of` 會被靜默忽略，因此
     `__post_init__` 直接拒絕——「兩份真相」正是 #626 的成因。
+
+    `account_of` 的值可以是 :data:`ABSENT_ACCOUNT`（#629），語意與部署決定型欄位
+    的那個 sentinel **逐字相同**：「本方案明示沒有這個角色的實體」。它與「沒有這個
+    鍵」嚴格區分——後者讓產生器 fail-closed（`unresolved_principals()` 會指名它），
+    前者是一個**被記錄下來的決定**，該 principal 的授權整組略去、輸出裡一行都不會
+    出現。二分／三分對 `GATE` 用的就是它：那兩個方案沒有第四個帳號，因此沒有 gate
+    執行面，build 卡照 `require_ledger` fail closed（＝#629 之前的現況），但方案的
+    其餘部分仍然完整可產出——不會為了一個它們本來就沒有的角色而整份拒絕輸出。
     """
 
     scheme_id: str
@@ -262,6 +280,10 @@ class UidScheme:
         for name in list(self.account_of.values()) + [
             self.durable_state_owner, self.deploy_account,
         ]:
+            # `ABSENT_ACCOUNT`（#629）不是帳號名，是「本方案沒有這個角色」的 sentinel；
+            # 它永遠不會被印進任何命令，因此不受 `_ACCOUNT_NAME_RE` 約束。
+            if name == ABSENT_ACCOUNT:
+                continue
             _validate_account_name(name)
         for opt in PRINCIPAL_ACCOUNT_OPTIONS:
             value = getattr(self, opt.field_name)
@@ -284,20 +306,47 @@ class UidScheme:
         if opt is not None:
             value = getattr(self, opt.field_name)
             return None if value in (None, ABSENT_ACCOUNT) else value
-        return self.account_of.get(principal)
+        mapped = self.account_of.get(principal)
+        # `ABSENT_ACCOUNT`（#629）與缺鍵在這裡故意收斂成同一個回傳值：兩者都代表
+        # 「沒有帳號可用」。**分辨兩者是 `unresolved_principals()` 的職責**——它才是
+        # 決定「這是決定還是遺漏」的地方。
+        return None if mapped == ABSENT_ACCOUNT else mapped
 
     def group_of(self, account: str) -> str:
         """帳號的 primary group（慣例：每帳號一個同名 group）。"""
         return account
 
     def headless_accounts(self) -> frozenset[str]:
-        """全部 headless persona（含 headless hook）解析到的帳號集合。
+        """全部**執行不受信任程式碼**的身分解析到的帳號集合。
 
         Manager-owned／deployment 樹對這些帳號**必須**零寫入權——這是本產生器的
         核心不變式。
+
+        #629 起來源是 :data:`registry.UNTRUSTED_EXECUTION_PRINCIPALS`（headless
+        persona ＋ headless hook ＋ **gate**），而不是只有 `HEADLESS_PERSONAS`：
+        gate 執行的是 operator 宣告的命令，但那些命令跑在 builder 完全掌控內容的
+        工作樹上，載入的是該樹的 `conftest.py`／plugin——在「Manager-owned 樹對它
+        必須零寫入權」這件事上，它與跑模型的三個 persona 完全同級。方法名維持
+        `headless_accounts` 是刻意的：它的**語意**（不受信任的執行帳號集合）沒有
+        改變，改名只會讓十幾個呼叫端跟著動而換不到任何東西。
         """
         accts: set[str] = set()
-        for p in list(HEADLESS_PERSONAS) + [Principal.HEADLESS_HOOK]:
+        for p in sorted(UNTRUSTED_EXECUTION_PRINCIPALS, key=lambda x: x.value):
+            a = self.resolve(p)
+            if a is not None:
+                accts.add(a)
+        return frozenset(accts)
+
+    def model_job_accounts(self) -> frozenset[str]:
+        """**跑模型 CLI** 的 job 帳號集合（`HEADLESS_PERSONAS` 解析結果）。
+
+        與 :meth:`headless_accounts` 的差別只有一項——`cortex-gate` 不在其中——但那
+        一項決定了「要不要幫這個帳號準備 root-owned 的 `~/.codex` 與 executor 憑證
+        檔」。gate 不跑模型，因此那兩個前置物對它是純多餘：多兩個沒有消費者的
+        root-owned 目錄，還會讓「無多餘」那組等式測試被迫放寬。
+        """
+        accts: set[str] = set()
+        for p in sorted(HEADLESS_PERSONAS, key=lambda x: x.value):
             a = self.resolve(p)
             if a is not None:
                 accts.add(a)
@@ -309,7 +358,7 @@ class UidScheme:
         任何出現在產生命令裡的帳號名都必須落在這個集合內；落在集合外就代表某處把
         抽象角色名當帳號印出去了（#626）。
         """
-        accts = set(self.account_of.values())
+        accts = {a for a in self.account_of.values() if a != ABSENT_ACCOUNT}
         accts.add(self.durable_state_owner)
         accts.add(self.deploy_account)
         for opt in PRINCIPAL_ACCOUNT_OPTIONS:
@@ -336,6 +385,10 @@ class UidScheme:
                 if opt is not None:
                     if getattr(self, opt.field_name) is None:
                         missing.add(principal)
+                    continue
+                # #629：`ABSENT_ACCOUNT` 是決定、缺鍵才是遺漏。兩者 `resolve()` 都回
+                # None，因此這裡要直接看原始對應表，不能只看解析結果。
+                if self.account_of.get(principal) == ABSENT_ACCOUNT:
                     continue
                 if self.resolve(principal) is None:
                     missing.add(principal)
@@ -501,6 +554,12 @@ TWO_WAY_SCHEME = UidScheme(
         Principal.PLANNER: "cortex-svc",
         Principal.BUILDER: "cortex-builder",
         Principal.HEADLESS_HOOK: "cortex-builder",
+        # #629：本方案沒有 gate 執行身分（明示，不是遺漏）。二分把 Manager／monitor／
+        # reviewer／planner 全併在 `cortex-svc`，若把 gate 也併進去就等於讓 builder
+        # 交出來的 `conftest.py` 在 durable state owner 的身分下執行——比 #629 要修的
+        # 缺口更嚴重。因此二分**不提供 gate 執行面**：降權模式下 build 卡照
+        # `require_ledger` fail closed（＝#629 之前的現況）。要用 gate 就升四分。
+        Principal.GATE: ABSENT_ACCOUNT,
     },
     durable_state_owner="cortex-svc",
     deploy_account="root",
@@ -520,21 +579,79 @@ THREE_WAY_SCHEME = UidScheme(
         Principal.PLANNER: "cortex-reviewer-planner",
         Principal.BUILDER: "cortex-builder",
         Principal.HEADLESS_HOOK: "cortex-builder",
+        # #629：同二分——三分也沒有第四個帳號可以承接 gate。三個候選逐一皆不可用
+        # （見 `FOUR_WAY_SCHEME` 的說明），因此明示「本方案沒有這個角色」而不是併帳。
+        Principal.GATE: ABSENT_ACCOUNT,
     },
     durable_state_owner="cortex-manager",
     deploy_account="root",
     # 同二分：operator／external reader 是部署決定，不寫死（#626）。
 )
 
+#: 四分（**#629 定案**）：三分再拆出 `cortex-gate`——operator 宣告的 gate 命令的執行
+#: 身分。**與二分／三分共用同一套 policy，僅換 config。**
+#:
+#: ## 為什麼一定要是第四個帳號
+#:
+#: gate 命令跑在 **builder 完全掌控內容的工作樹**上，`pytest` 會載入該樹的
+#: `conftest.py` 與 plugin ⇒ **執行 gate 的身分等於對 builder 開放任意程式碼執行**。
+#: 既有的三個帳號逐一檢查，沒有一個能承接：
+#:
+#: - `cortex-builder`：模型自證自己的驗收證據，違反 #540 的 acceptance chain；
+#: - `cortex-manager`：持 spawn 授權、擁有全部 Manager-owned durable state，是三分
+#:   授權線的**內側**——這是 issue #629 本文的整段論證；
+#: - `cortex-reviewer-planner`：它是寫 verdict 的那一個。把 gate 掛上去，被攻陷的
+#:   builder 就能經由 gate 執行影響 reviewer 的帳號，等於把 #638／#639 剛關掉的
+#:   「builder 對 verdict 通道的影響力」重新打開。
+#:
+#: ## 為什麼不能「不開帳號」
+#:
+#: 唯一認真的無新帳號候選是 systemd 的 `DynamicUser=yes`（每次起 unit 配一個暫時
+#: UID，不必建帳號）。它**結構性地**不成立，理由不是偏好而是機制：本方案兩端都靠
+#: **具名 POSIX ACL** 授權——`gate-ledger-spool` 那一格要給 gate `wx` 無 `r`，
+#: `repo-worktree` 要給 gate `rX`——而 `setfacl -m u:<名>:…` 在**產生權限的當下**就
+#: 要解析得到那個帳號；DynamicUser 的 UID 在 unit 起動前不存在、每次還不同，根本
+#: 沒有可寫進 ACL 的名字。退而求其次的 `User=nobody` 更糟：那是一個與系統上任何
+#: 其他服務共用的帳號，授它 Tier-0 spool 的寫入權等於把那條通道開給所有 `nobody`
+#: 行程。
+#:
+#: ## 誠實邊界（spec §R3 有對應段落）
+#:
+#: 第四帳號買到的是**圍堵**，不是「ledger 不可偽造」。取得 ACE 的 builder 依然能
+#: 影響**自己那一份** ledger 的內容——那是「執行對方交出來的測試碼」這件事本身的
+#: 性質，換誰執行都一樣。它買到的是：那個 ACE 碰不到 Manager 的 durable state、
+#: 碰不到 verdict 通道、碰不到別的 job 的工作樹、也沒有 spawn 授權。
+FOUR_WAY_SCHEME = UidScheme(
+    scheme_id="four-way",
+    account_of={
+        Principal.MANAGER: "cortex-manager",
+        Principal.MONITOR: "cortex-manager",
+        Principal.REVIEWER: "cortex-reviewer-planner",
+        Principal.PLANNER: "cortex-reviewer-planner",
+        Principal.BUILDER: "cortex-builder",
+        Principal.HEADLESS_HOOK: "cortex-builder",
+        Principal.GATE: "cortex-gate",
+    },
+    durable_state_owner="cortex-manager",
+    deploy_account="root",
+    # 同二分／三分：operator／external reader 是部署決定，不寫死（#626）。
+)
+
 SCHEMES: dict[str, UidScheme] = {
     TWO_WAY_SCHEME.scheme_id: TWO_WAY_SCHEME,
     THREE_WAY_SCHEME.scheme_id: THREE_WAY_SCHEME,
+    FOUR_WAY_SCHEME.scheme_id: FOUR_WAY_SCHEME,
 }
 
-#: **定案方案**（0816 第三輪裁決 A）。CLI／產生器未指定 scheme 時一律用這個——
-#: 「預設就是最安全的那一個」是刻意的：要退回二分必須顯式打出 `two-way`，
-#: 打錯字不會靜默退回較寬鬆的方案（`SCHEMES` 查無即拒）。
-DEFAULT_SCHEME: UidScheme = THREE_WAY_SCHEME
+#: **定案方案**（#629；在此之前是 0816 第三輪裁決 A 的三分）。CLI／產生器未指定
+#: scheme 時一律用這個——「預設就是最安全的那一個」是刻意的：要退回三分／二分必須
+#: 顯式打出 `three-way`／`two-way`，打錯字不會靜默退回較寬鬆的方案（`SCHEMES` 查無即拒）。
+#:
+#: **三分／二分在 #629 之後會 fail-closed**，而且是刻意的：登記表已有兩個資產把
+#: `GATE` 列為 writer，那兩個方案對它沒有帳號對應，`unresolved_principals()` 因此
+#: 會指名它並讓 `plan_to_commands()` 一行都不輸出（#626 的既有出口）。這比「靜默把
+#: gate 併到某個既有帳號」正確得多——併進去的每一種選法都是上面剛否決掉的那三條。
+DEFAULT_SCHEME: UidScheme = FOUR_WAY_SCHEME
 DEFAULT_SCHEME_ID: str = DEFAULT_SCHEME.scheme_id
 
 
@@ -786,12 +903,17 @@ def build_entry(asset: TrustRootAsset, scheme: UidScheme) -> PermissionEntry:
         writer_accounts = frozenset(writer_accounts)
 
     else:  # JOB
+        # 「哪些 writer 算 untrusted producer」＝ `UNTRUSTED_EXECUTION_PRINCIPALS`
+        # （#629 起含 `GATE`）。用它而不是逐項列舉，是為了讓「新增一個執行不受信任
+        # 程式碼的身分」只需要改登記表那一個集合——漏改這裡的後果是**靜默 fail-open**
+        # 的相反面：該身分的 `wx` ACL 不會被產生，它連自己那格 spool 都寫不進去，
+        # 而症狀出現在部署當天而不是產生器。
         job_writers = frozenset(
             a
             for a in (
                 scheme.resolve(w)
                 for w in asset.writers
-                if w in HEADLESS_PERSONAS or w is Principal.HEADLESS_HOOK
+                if w in UNTRUSTED_EXECUTION_PRINCIPALS
             )
             if a is not None
         )
@@ -1278,6 +1400,27 @@ class PathLayout:
         return f"{self.coordinator_root}/review-verdicts"
 
     @property
+    def gate_ledger_spool_root(self) -> str:
+        """gate 寫、Manager 讀的 per-job ledger spool 根（登記表資產
+        `gate-ledger-spool`，#629）。
+
+        路徑與 `config.paths.gate_ledger_spool_root()` 是**成對契約**，由
+        `asset_paths()` 而非本 property 供給權限計畫；本 property 只是給 unit
+        產生器引用的同一份字面量（比照 `commit_spool_root`）。
+        """
+        return f"{self.coordinator_root}/gate-ledger-spool"
+
+    @property
+    def gate_worktree_root(self) -> str:
+        """gate 執行身分的拋棄式工作區 pool 根（登記表資產 `gate-worktree-pool`，#629）。
+
+        與 `config.paths.gate_worktree_root()` 成對契約。掛在 `agents_root` 底下而不是
+        `worktree_root`：那個 pool 的容器已為 job persona 的三個帳號套好 ACL，把一個
+        **不同帳號**的樹混進同一棵容器只會讓「誰進得了哪一格」變成要逐格推敲的事。
+        """
+        return f"{self.agents_root}/gate-worktree"
+
+    @property
     def job_spec_spool_root(self) -> str:
         """Manager 寫、job 只讀的 per-job 執行規格（`<unit-instance-id>.json`）。
 
@@ -1462,6 +1605,13 @@ class PathLayout:
             "commit-spool": self.commit_spool_root,
             # Phase 2b 方案 B（0816 第三輪 A+B）：模板 unit 的 per-job 執行規格。
             "job-spec-spool": self.job_spec_spool_root,
+            # #629 gate 執行身分：拋棄式工作區 pool ＋ ledger 單向 spool。
+            # 工作區 pool 登記的是**容器**（不帶 per-job segment）：它只有一個 writer
+            # ＝`cortex-gate`，因此容器本身就 owner-only 0700，per-job 那一格由 gate
+            # 自己建、自己重建——不像 `dispatch-worktree-pool` 要 Manager 逐案 chown 給
+            # 三個不同帳號。少一個 runtime-managed 的環節就少一個會漏掉的環節。
+            "gate-worktree-pool": self.gate_worktree_root,
+            "gate-ledger-spool": self.gate_ledger_spool_root,
             "verification-evidence": f"{c}/evidence/verification",
             "maintainer-attestation": f"{c}/evidence/maintainer-review",
             "completion-record": f"{c}/evidence/completion",
@@ -1497,7 +1647,10 @@ class PathLayout:
         # `cortex-reviewer-planner`，不必在這裡補一行（補一行正是上一版漏掉它的原因）。
         service_accounts = [svc] + sorted(scheme.headless_accounts() - {svc})
         # 跑模型的 job 帳號還要一個 root-owned 的 ~/.codex（hooks 不得被 job 替換）。
-        job_accounts = sorted(scheme.headless_accounts() - {svc})
+        # **來源是 `model_job_accounts()` 而不是 `headless_accounts()`**（#629）：
+        # `cortex-gate` 也是不受信任的執行帳號、也要 HOME／cache，但它不跑模型 CLI，
+        # 給它 `~/.codex` 與一份 executor 憑證只會多兩個沒有消費者的 root-owned 目錄。
+        job_accounts = sorted(scheme.model_job_accounts() - {svc})
         account_dirs: list[tuple[str, str, str, int]] = []
         for account in service_accounts:
             account_dirs.append((self.home_of(account), root, g(root), 0o755))
@@ -2244,9 +2397,18 @@ def executor_hardening_profile(executor: str) -> HardeningProfile:
 #: 一個字幹），卻換不到任何隔離。`REVIEWER` 在這裡是**那個帳號的代表 principal**，
 #: 由 :data:`JOB_PRINCIPAL_PERSONAS` 明載它代表誰。
 #:
+#: - `GATE`（#629）：`cortex-gate-job@.service`／`cortex-gate-job-jit@.service`，
+#:   `User=cortex-gate`。它不跑模型，跑的是 operator 宣告的 gate 命令——但那些命令
+#:   載入的是 builder 工作樹裡的 `conftest.py`／plugin，所以在「必須被關進盒子」這件
+#:   事上與前兩者同級。
+#:
 #: 這張表同時是 polkit unit pattern 的字幹來源（見 :func:`job_unit_pattern`）：
 #: 放行面 = 這張表 × :data:`HARDENING_PROFILES`，兩者都是列舉，沒有萬用字元。
-DOWNGRADED_JOB_PRINCIPALS: tuple[Principal, ...] = (Principal.BUILDER, Principal.REVIEWER)
+DOWNGRADED_JOB_PRINCIPALS: tuple[Principal, ...] = (
+    Principal.BUILDER,
+    Principal.REVIEWER,
+    Principal.GATE,
+)
 
 #: 每個 job 角色的 `PATH` 覆寫變數名。與 `coordinator/job_runner.JOB_ROLE_CONFIG`
 #: 的 `path_env` 是**成對契約**（同 `DEFAULT_TEMPLATE_UNIT` 的既有模式：permgen 與
@@ -2257,18 +2419,51 @@ JOB_PATH_ENV_BY_PRINCIPAL: Mapping[Principal, str] = MappingProxyType(
     {
         Principal.BUILDER: "PSC_BUILDER_PATH",
         Principal.REVIEWER: "PSC_REVIEWER_PATH",
+        Principal.GATE: "PSC_GATE_PATH",
     }
 )
 
 #: 每份模板 unit 服務的 persona 家族（代表 principal → 實際會以該 unit 起跑的 persona）。
 #: 記錄在這裡而不是散在註解裡：`cortex-reviewer-job@.service` 同時是 planner 的 unit，
 #: 這件事必須是機器可讀的，否則「planner 的降權在哪」只能靠讀 commit 訊息回答。
+#: 產生每份模板 unit 的 CLI 旗標（`python -m paulsha_cortex.trust_root unit …`）。
+#: 產出的 unit 檔頭會印出「重跑用哪一行」，那一行必須跟著角色走——寫死 `--job` 會讓
+#: operator 照抄之後拿到 builder 的 unit 覆蓋掉 reviewer／gate 的那一份。
+JOB_UNIT_CLI_FLAG: Mapping[Principal, str] = MappingProxyType(
+    {
+        Principal.BUILDER: "--job",
+        Principal.REVIEWER: "--review-job",
+        Principal.GATE: "--gate-job",
+    }
+)
+
 JOB_PRINCIPAL_PERSONAS: Mapping[Principal, frozenset[Principal]] = MappingProxyType(
     {
         Principal.BUILDER: frozenset({Principal.BUILDER, Principal.HEADLESS_HOOK}),
         Principal.REVIEWER: frozenset({Principal.REVIEWER, Principal.PLANNER}),
+        # #629：gate 不代表任何 persona——它就是它自己。這一格不是佔位符，是斷言：
+        # 「有沒有哪個 persona 其實是以 gate 帳號起跑的」必須是機器可讀的 **否**。
+        Principal.GATE: frozenset({Principal.GATE}),
     }
 )
+
+
+def downgraded_job_principals(scheme: UidScheme) -> tuple[Principal, ...]:
+    """本方案**真的會落檔**的那一組降權 job principal（依表順序）。
+
+    :data:`DOWNGRADED_JOB_PRINCIPALS` 是「本系統支援哪些降權角色」；本函式是「這個
+    部署有哪些」。兩者在四分方案下相同，在二分／三分下差一項——那兩個方案對
+    `GATE` 明示 :data:`ABSENT_ACCOUNT`（#629），因此不會有 `cortex-gate-job@.service`
+    這份 unit 檔。
+
+    **為什麼 polkit pattern 必須用這一支而不是那張表**：pattern 是放行面。放行一個
+    在本機**不存在**的 unit 名不會讓任何 job 起得來（unit 檔不在就是不在），但它會
+    讓「這條規則授權了什麼」與「這台機器上實際有什麼」對不起來——而那條規則的全部
+    價值就在於它可以被逐字讀懂。同理 `build_job_unit()` 對未映射的 principal 直接
+    raise：產生一份 `User=` 空白的 unit 比不產生危險得多。
+    """
+
+    return tuple(p for p in DOWNGRADED_JOB_PRINCIPALS if scheme.resolve(p) is not None)
 
 
 def _as_principals(
@@ -2302,6 +2497,9 @@ def job_unit_stem(
     `profile` 是 **#643 的第二個擴充點**：加固剖面不同 ⇒ 必須是不同的 unit 檔
     （加固指令寫在檔案裡，一個模板只有一份），因此字幹尾端掛剖面後綴。嚴格剖面的
     後綴是空字串，`cortex-job@.service` 這個既有名字逐字不變。
+
+    **#629 由同一個擴充點再加一個角色**：`Principal.GATE` → `cortex-gate-job`
+    （`User=cortex-gate`）。產生器同樣一行都沒有改。
     """
     layout = layout if layout is not None else DEFAULT_LAYOUT
     if principal is Principal.BUILDER:
@@ -2669,26 +2867,43 @@ def build_job_unit(
         for name, profile_id in EXECUTOR_HARDENING_PROFILE.items()
         if profile_id == profile.profile_id
     )
+    # 產生本檔的旗標必須跟著角色走：註解裡寫著「重跑用 --job」卻產出 reviewer／gate
+    # 的 unit，會讓 operator 照抄之後拿到**另一份** unit 覆蓋掉這一份。
+    unit_flag = JOB_UNIT_CLI_FLAG[principal]
 
     body = [
         f"# {'/etc/systemd/system/' + unit_name}",
         f"# 由 permgen 機械產生（scheme={scheme.scheme_id}, profile={profile.profile_id}）",
         "# ——勿手改；重跑：",
-        f"#   python3 -m paulsha_cortex.trust_root unit {scheme.scheme_id} --job"
+        f"#   python3 -m paulsha_cortex.trust_root unit {scheme.scheme_id} {unit_flag}"
         + (f" --profile {profile.profile_id}" if profile is not DEFAULT_HARDENING_PROFILE else ""),
         "#",
-        "# 降權/提權分界線：User= 在本 root-owned 檔內硬寫死。Manager（cortex-svc）",
+        "# 降權/提權分界線：User= 在本 root-owned 檔內硬寫死。Manager"
+        f"（{scheme.durable_state_owner}）",
         f"# 只能 `systemctl start {stem}@<id>.service`，**不能**選 UID、不能傳屬性。",
         "#",
         f"# === 加固剖面：{profile.profile_id}（#643 per-executor 剖面）===",
-        f"# 適用 executor：{'、'.join(profile_users) if profile_users else '（無）'}",
     ]
+    if principal is Principal.GATE:
+        # gate 不跑任何模型 CLI，列 executor 名單只會誤導（讀的人會以為這份 unit 是
+        # 給 `agy`／`claude` 用的）。剖面來源也不同：operator 平面，不是 executor。
+        body += _wrap_comment(
+            "適用對象：gate 執行身分（#629）——它不跑模型 CLI，因此沒有「適用 "
+            "executor」可言。剖面由 operator 的 PSC_GATE_HARDENING_PROFILE 決定"
+            "（宣告 gate 命令與宣告它需要哪份剖面是同一個人、同一個平面的決定）；"
+            "宣告 node 型 gate（npm test）時必須顯式打出 jit，否則 V8 會直接崩。"
+        )
+    else:
+        body += [
+            f"# 適用 executor：{'、'.join(profile_users) if profile_users else '（無）'}",
+        ]
     body += _wrap_comment(f"理由：{profile.rationale}")
     for loss in profile.accepted_loss:
         body += _wrap_comment(f"⚠ 本剖面接受的代價：{loss}")
     body += [
-        "# 剖面**不由 job 決定**：對應表由 permgen.EXECUTOR_TOOLS 的 needs_node 機械",
-        "# 導出，executor 則是 Manager 的 dispatch 決定；job spec 結構性禁止攜帶任何",
+        "# 剖面**不由 job 決定**：模型 job 的對應表由 permgen.EXECUTOR_TOOLS 的",
+        "# needs_node 機械導出，executor 則是 Manager 的 dispatch 決定；gate 的剖面",
+        "# 由 operator 平面決定（#629）。兩者共同點是 job spec 結構性禁止攜帶任何",
         "# 剖面欄位（job_runner.SPEC_FORBIDDEN_KEYS，寫端與讀端各擋一次）。",
         "",
         "[Unit]",
@@ -3327,7 +3542,7 @@ def build_polkit_rule(
     scheme: UidScheme,
     layout: "PathLayout" = None,  # type: ignore[assignment]
     plan: PolkitPlan = PolkitPlan.TEMPLATE,
-    principals: "Principal | Sequence[Principal]" = DOWNGRADED_JOB_PRINCIPALS,
+    principals: "Principal | Sequence[Principal] | None" = None,
 ) -> PolkitRule:
     """產生降權授權的 polkit 規則內容（A／B 兩方案共用同一套產生邏輯）。
 
@@ -3342,7 +3557,11 @@ def build_polkit_rule(
     """
     layout = layout if layout is not None else DEFAULT_LAYOUT
     svc = scheme.durable_state_owner
-    ordered = _as_principals(principals)
+    # `None`＝依本方案導出（#629）。預設不再是那張**支援表**，而是「這個部署真的會有
+    # 哪幾份 unit」——二分／三分沒有 gate 帳號，規則就不該提 `cortex-gate-job@`。
+    ordered = _as_principals(
+        downgraded_job_principals(scheme) if principals is None else principals
+    )
     targets: list[str] = []
     for principal in ordered:
         target = scheme.resolve(principal)

--- a/paulsha_cortex/trust_root/registry.py
+++ b/paulsha_cortex/trust_root/registry.py
@@ -50,14 +50,34 @@ class Principal(Enum):
     BUILDER = "builder"              # headless
     REVIEWER = "reviewer"            # headless
     PLANNER = "planner"              # headless
+    GATE = "gate"                    # #629：operator 宣告的 gate 命令的執行身分
     HEADLESS_HOOK = "headless-hook"  # D5 headless 事件 hook（寫 event-spool）
     EXTERNAL = "external"            # 外送管線／外部學習系統（唯讀）
     ANY_SAME_UID = "any-same-uid"    # 現況：同 UID 任何行程皆可寫（含全部 headless persona）
 
 
 #: 三個不受信任 headless persona；spec §R1 要求盤點必須分別涵蓋，不能只封 builder。
+#:
+#: **判準是「這個 principal 會執行一個模型 CLI」**，因此 #629 的 :data:`Principal.GATE`
+#: 不在其中：gate 不跑模型，它跑的是 operator 宣告的命令。兩者在「不受信任」這件事上
+#: 完全同級（見 :data:`UNTRUSTED_EXECUTION_PRINCIPALS`），差別只在**需要哪些前置物**
+#: ——模型 job 帳號要有 root-owned 的 `~/.codex` 與 executor 憑證檔，gate 一個都不要。
 HEADLESS_PERSONAS: frozenset[Principal] = frozenset(
     {Principal.BUILDER, Principal.REVIEWER, Principal.PLANNER}
+)
+
+#: **全部「執行不受信任程式碼」的身分**——Manager-owned／deployment 樹對這些帳號必須
+#: 零寫入權（`permgen.UidScheme.headless_accounts()` 的來源，也是產生器的核心不變式）。
+#:
+#: #629 起它比 :data:`HEADLESS_PERSONAS` 多兩項：
+#:
+#: - `HEADLESS_HOOK`（D5 事件 hook，與 builder 同帳號）；
+#: - `GATE`——operator 宣告的 gate 命令是在 **builder 完全掌控內容的工作樹**上跑的，
+#:   `pytest` 會載入該樹的 `conftest.py`／plugin，所以「執行 gate」與「執行模型交出來
+#:   的程式碼」在信任面上是同一件事。它必須被關進與 builder 同級的盒子，只是**不同的
+#:   那一個**盒子（同一個盒子＝模型自證，見 issue #540 的 acceptance chain）。
+UNTRUSTED_EXECUTION_PRINCIPALS: frozenset[Principal] = (
+    HEADLESS_PERSONAS | {Principal.HEADLESS_HOOK, Principal.GATE}
 )
 
 
@@ -413,7 +433,7 @@ ASSET_REGISTRY: tuple[TrustRootAsset, ...] = (
     # ---- job-visible worktree 族 -------------------------------------------
     TrustRootAsset(
         "repo-worktree", _T1, _JV, "paulsha_cortex.config.paths:repo_root",
-        (Principal.BUILDER,), (Principal.BUILDER,),
+        (Principal.BUILDER,), (Principal.BUILDER, Principal.GATE),
         IngressKind.STAGING_SPOOL,
         note=(
             "builder write_paths:['**']，可寫工作區內任何路徑（含 .cortex/.github）。"
@@ -440,7 +460,71 @@ ASSET_REGISTRY: tuple[TrustRootAsset, ...] = (
             "`candidate-worktree-unreadable-pending-gate-identity`（理由碼與 evidence 的 "
             "`blocked_on` 欄逐字指向 #629），**不得**靜默略過、**不得**改讀 bundle "
             "（bundle 也是 builder 產的，兩邊同源會讓那道檢查退化）、更**不得**讓 builder "
-            "自報「我的工作樹是乾淨的」（違反 #540 的 acceptance chain 與 #628 的作者歸屬）。"
+            "自報「我的工作樹是乾淨的」（違反 #540 的 acceptance chain 與 #628 的作者歸屬）。\n"
+            "**#629：`readers` 補回一個帳號，但不是 Manager——是 `GATE`。** gate 執行身分"
+            "要重跑 operator 宣告的命令，就必須讀得到被驗的那棵樹；而它讀完做的第一件事是"
+            "**複製到自己的拋棄式工作區**（`gate-worktree-pool`），命令一律在副本上跑。"
+            "授的是 `rX`（讀＋traverse），**沒有 `w`**——gate 改不了 builder 的樹，因此"
+            "後續 harvest 拿到的仍是 builder 自己交付的那份成果。這條與 #641 收掉的那條"
+            "**形狀相同、方向相反**：`cortex-manager` 的 `rX` 是把 ACE 引到授權線內側，"
+            "`cortex-gate` 的 `rX` 是把同一個 ACE 引到一個**除了自己的副本與自己那格 "
+            "spool 以外什麼都碰不到**的帳號上。"
+        ),
+    ),
+    # ---- #629：gate 執行身分的兩個資產 --------------------------------------
+    TrustRootAsset(
+        "gate-worktree-pool", _T1, _JV,
+        "paulsha_cortex.config.paths:gate_worktree_root",
+        (Principal.GATE,), (Principal.GATE,),
+        IngressKind.STAGING_SPOOL,
+        derived_in=(
+            "config/paths.py:gate_worktree_root",
+            "trust_root/permgen.py:PathLayout.gate_worktree_root",
+            "coordinator/gate_runner.py:gate_worktree_dir",
+        ),
+        note=(
+            "gate 執行身分的**拋棄式工作區** pool：`<agents_root>/gate-worktree/<job-id>/`。"
+            "形態逐條比照 `dispatch-worktree-pool`（容器 owner＝Manager、per-job 一格、"
+            "格內由該身分擁有）。\n"
+            "**為什麼是拋棄式副本而不是「工作樹對 gate 唯讀」**：唯讀在可行性上不成立"
+            "——`pytest` 要寫 `.pytest_cache`／`__pycache__`，`npm test`／`cargo test`／"
+            "`make` 更是必寫；把工作樹掛成唯讀只會讓每一個真實 gate 以 EROFS 收場，那正是"
+            "#629 要修掉的「安全但不能用」。副本另外買到兩件事：(a) gate 的寫入**不會**"
+            "污染 builder 交付的那棵樹（harvest 讀到的仍是 builder 自己的成果）；(b) 快照"
+            "在單一時點取得，builder 留下的背景行程改不了 gate 跑到一半的樹（TOCTOU）。\n"
+            "**誰複製**：gate 自己（它是唯一同時讀得到來源、寫得進目的地的身分）。Manager "
+            "不複製——它在 #641 之後**讀不到** builder 的樹，這條刻意不回頭放寬。\n"
+            "**回收**：每次 gate 執行前整格重建（`spool_slot.create_slot(reset=True)`），"
+            "因此殘留副本不會累積，也不會被下一輪採信。"
+        ),
+    ),
+    TrustRootAsset(
+        "gate-ledger-spool", _T0, _JV,
+        "paulsha_cortex.config.paths:gate_ledger_spool_root",
+        (Principal.MANAGER, Principal.GATE), (Principal.MANAGER,),
+        IngressKind.INTERPROCESS,
+        derived_in=(
+            "config/paths.py:gate_ledger_spool_root",
+            "trust_root/permgen.py:PathLayout.gate_ledger_spool_root",
+            "coordinator/gate_runner.py:gate_ledger_spool_dir",
+        ),
+        note=(
+            "#629 gate 執行結果的**單向 spool**：`<coordinator_root>/gate-ledger-spool/"
+            "<job-id>/ledger.json`。形態**逐條比照 `commit-spool`**——tree 分類 job-visible"
+            "（單向 spool 一律如此），permgen 產出的實質是 Manager-owned：容器 owner＝"
+            "durable_state_owner、mode 0700，producer（gate）僅獲 **`wx` 無 `r`** 的 "
+            "per-account ACL；per-job 目錄由 Manager 在起 gate 當下建立（pre-seed 守衛與 "
+            "seal 共用 `coordinator/spool_slot.py`，不另寫一份），消費後封口。\n"
+            "**為什麼 gate 不直接寫 `gate-ledger`**：#628 已把採信端改成 "
+            "`terminal_contract.foreign_evidence_author()`——**非 Manager 擁有的 ledger 一律"
+            "不採信**。讓 gate 直接寫那個目錄，寫出來的檔 owner 是 `cortex-gate`，採信端會"
+            "當場 `gate-ledger-foreign-author` 拒掉；要讓它被採信就得放寬那條檢查，等於把 "
+            "#628 拆掉。而且 `gate-ledger` 這個資產**同時**是 exit sentinel 的落點，開放"
+            "寫入面等於讓一個跑 untrusted code 的帳號能偽造**任何** job 的完成狀態。\n"
+            "因此權威 ledger 一律由 **Manager 自己**依本 spool 的內容重寫一份到 "
+            "`gate-ledger`（`coordinator/gate_runner.py`），作者歸屬與 #628 逐字不變；"
+            "spool 內容一律以**不受信任輸入**對待（schema 嚴格驗證 ＋ gate 名稱必須落在 "
+            "operator 的 `PSC_GATE_CMD_*` 宣告集合內）。"
         ),
     ),
     TrustRootAsset(

--- a/tests/test_gate_execution_identity_629.py
+++ b/tests/test_gate_execution_identity_629.py
@@ -1,0 +1,1024 @@
+"""#629：gate 執行身分——第四個帳號 `cortex-gate`。
+
+`#604`／PR `#628` 把 gate ledger 與 exit sentinel 的**作者**收斂到 Manager，但刻意
+沒做執行面：operator 宣告的 gate 命令跑在 builder 完全掌控內容的工作樹上，`pytest`
+會載入該樹的 `conftest.py`／plugin ⇒ 執行者取得任意程式碼執行。後果是
+`PSC_JOB_RUNNER=systemd-template` 下 build 卡恆因 `require_ledger` fail closed。
+
+本檔守七組性質：
+
+1. gate 確實以**第四個身分**執行（不變式），且該身分與既有三個逐一不同；
+2. 該身分**不能**寫 Manager durable state、**不能**寫 builder 工作區、**不能**碰
+   verdict spool；
+3. builder 無法預先佔位 ledger 落點（pre-seed 守衛，沿用 #639 的 `spool_slot`）；
+4. polkit 新字幹的正向放行與反向拒絕（含名稱混淆，比照 #647 的十種）；
+5. 各份模板 unit 的加固表除剖面差異外逐項相同（**集合比對，不硬編**）；
+6. spool 內容一律以**不受信任輸入**對待；
+7. `direct` 模式零回歸。
+
+## #638 的教訓（本檔的 skip 紀律）
+
+有幾條語意在單 UID／寬鬆環境裡**測不出來**——不是難測，是「測了也永遠綠」：跨 UID
+的 `wx` 無 `r` ACL 是否真的擋住讀取、polkit 是否真的拒絕、seal 之後 producer 是否
+真的進不去、`cortex-gate` 對 builder 工作樹的 `rX` 是否真的成立。那些一律**明確
+skip 並說明理由**，不用 `sudo -u`／裸跑當替身（那只會產生一個永遠綠、什麼都沒驗到
+的測試）。真實驗證在 runbook 第 5-2b／5-7／9b 步；具備條件的機器可設
+`PSC_TEST_REAL_HARDENING=1` 啟用。
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import stat
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from paulsha_cortex.config import paths
+from paulsha_cortex.coordinator import (
+    gate_ledger,
+    gate_runner,
+    job_runner,
+    spool_slot,
+    terminal_contract,
+)
+from paulsha_cortex.coordinator.launcher import SubprocessLauncher
+from paulsha_cortex.trust_root import permgen, registry
+from paulsha_cortex.trust_root.registry import Principal
+
+REAL_HARDENING = os.environ.get("PSC_TEST_REAL_HARDENING") == "1"
+
+SCHEME = permgen.DEFAULT_SCHEME
+LAYOUT = permgen.DEFAULT_LAYOUT
+JOB_LAYOUT = LAYOUT.with_job_segment("%i")
+
+GATE_ACCOUNT = "cortex-gate"
+BUILDER_ACCOUNT = "cortex-builder"
+REVIEW_ACCOUNT = "cortex-reviewer-planner"
+MANAGER_ACCOUNT = "cortex-manager"
+
+_BASE_ENV = {
+    "PATH": "/usr/local/bin:/usr/bin:/bin",
+    "HOME": "/var/lib/cortex-manager",
+    "LANG": "en_US.UTF-8",
+    "PSC_REPO_ROOT": "/opt/cortex",
+    "PSC_SLICE_ID": "psc-0629-build",
+}
+
+
+class _FakeCompleted:
+    def __init__(self, returncode: int = 0, stderr: str = "") -> None:
+        self.returncode = returncode
+        self.stdout = ""
+        self.stderr = stderr
+
+
+class _RecordingRunner:
+    """假的 `subprocess.run`：記下 argv，並可選擇性地把 gate 的產出寫進 spool。"""
+
+    def __init__(self, *, returncode: int = 0, payload: object | None = None) -> None:
+        self.calls: list[list[str]] = []
+        self.returncode = returncode
+        self.payload = payload
+
+    def __call__(self, argv, **kwargs):
+        self.calls.append(list(argv))
+        if self.payload is not None:
+            # 真實部署裡這一段是 gate unit 內的 `gate_ledger` 做的；測試在這裡
+            # 模擬「它交付了什麼」，好讓 Manager 端的驗證邏輯被真正走到。
+            Path(self._out).write_text(
+                json.dumps(self.payload), encoding="utf-8"
+            )
+        return _FakeCompleted(self.returncode)
+
+    def expect_output(self, path: str | Path) -> "_RecordingRunner":
+        self._out = str(path)
+        return self
+
+
+def _nested(patches):
+    class _Ctx:
+        def __enter__(self):
+            for p in patches:
+                p.start()
+            return self
+
+        def __exit__(self, *exc):
+            for p in reversed(patches):
+                p.stop()
+            return False
+
+    return _Ctx()
+
+
+def _preflight_patches(binary: str = "/usr/bin/systemctl"):
+    return [
+        mock.patch.object(job_runner.shutil, "which", return_value=binary),
+        mock.patch.object(job_runner, "_systemd_booted", return_value=True),
+        mock.patch.object(job_runner, "_account_exists", return_value=True),
+        mock.patch.object(job_runner, "_group_exists", return_value=True),
+        mock.patch.object(job_runner, "_unit_file_installed", return_value=True),
+        mock.patch.object(job_runner, "_is_executable", return_value=True),
+        mock.patch.object(job_runner, "_unit_is_active", return_value=False),
+    ]
+
+
+def _ok_payload(*, slice_id: str = "psc-0629-build", exit_code: int = 0) -> dict:
+    return {
+        "schema_version": terminal_contract.GATE_LEDGER_SCHEMA_VERSION,
+        "kind": terminal_contract.GATE_LEDGER_KIND,
+        "slice_id": slice_id,
+        "gates": [
+            {
+                "name": "pytest",
+                "command": "python3 -m pytest -q",
+                "exit_code": exit_code,
+                "status": "passed" if exit_code == 0 else "failed",
+                "detail": "",
+            }
+        ],
+    }
+
+
+# ---------------------------------------------------------------------------
+# 1. 執行身分：第四個帳號，且與既有三個逐一不同
+# ---------------------------------------------------------------------------
+
+class GateIdentityTests(unittest.TestCase):
+    """#629 的核心不變式：gate 既非 builder、非 Manager，也非 reviewer／planner。"""
+
+    def test_the_gate_principal_maps_to_a_distinct_fourth_account(self) -> None:
+        gate = SCHEME.resolve(Principal.GATE)
+        self.assertEqual(gate, GATE_ACCOUNT)
+        for other in (
+            Principal.BUILDER,
+            Principal.REVIEWER,
+            Principal.PLANNER,
+            Principal.MANAGER,
+            Principal.MONITOR,
+            Principal.HEADLESS_HOOK,
+        ):
+            self.assertNotEqual(gate, SCHEME.resolve(other), other)
+        self.assertNotEqual(gate, SCHEME.durable_state_owner)
+        self.assertNotEqual(gate, SCHEME.deploy_account)
+        self.assertEqual(len(SCHEME.declared_accounts()), 5)  # 四個服務帳號 ＋ root
+
+    def test_gate_is_an_untrusted_execution_principal_but_not_a_model_persona(self) -> None:
+        """它必須落在「Manager-owned 樹零寫入」的那個集合裡，但不需要模型的前置物。"""
+        self.assertIn(Principal.GATE, registry.UNTRUSTED_EXECUTION_PRINCIPALS)
+        self.assertNotIn(Principal.GATE, registry.HEADLESS_PERSONAS)
+        self.assertIn(GATE_ACCOUNT, SCHEME.headless_accounts())
+        self.assertNotIn(GATE_ACCOUNT, SCHEME.model_job_accounts())
+        # 不跑模型 ⇒ 不該有 root-owned 的 ~/.codex 與 executor 憑證骨架。
+        scaffold = {path for path, *_rest in LAYOUT.scaffold_directories(SCHEME)}
+        self.assertIn(LAYOUT.cache_of(GATE_ACCOUNT), scaffold)
+        self.assertIn(LAYOUT.home_of(GATE_ACCOUNT), scaffold)
+        self.assertNotIn(LAYOUT.codex_hooks_dir_of(GATE_ACCOUNT), scaffold)
+        self.assertNotIn(LAYOUT.executor_credential_dir_of(GATE_ACCOUNT), scaffold)
+
+    def test_the_gate_unit_hardcodes_the_gate_account(self) -> None:
+        unit = permgen.build_job_unit(SCHEME, principal=Principal.GATE)
+        self.assertEqual(unit.unit_name, "cortex-gate-job@.service")
+        self.assertEqual(unit.account, GATE_ACCOUNT)
+        self.assertIn(f"User={GATE_ACCOUNT}\n", unit.content)
+        self.assertIn(f"Group={GATE_ACCOUNT}\n", unit.content)
+        # 身分只有 root-owned unit 檔一個來源——ExecStart 同樣寫死成 shim。
+        self.assertEqual(unit.exec_start, f"{LAYOUT.job_shim} %i")
+
+    def test_job_runner_role_table_and_permgen_agree_on_the_gate_account(self) -> None:
+        """兩邊刻意不互相 import，由本測項釘住逐字相等（沿用 #615 的成對契約模式）。"""
+        self.assertEqual(job_runner.DEFAULT_GATE_ACCOUNT, SCHEME.resolve(Principal.GATE))
+        self.assertEqual(
+            job_runner.DEFAULT_GATE_TEMPLATE_UNIT,
+            f"{permgen.job_unit_stem(LAYOUT, Principal.GATE)}@.service",
+        )
+        self.assertEqual(
+            permgen.JOB_PATH_ENV_BY_PRINCIPAL[Principal.GATE],
+            job_runner.JOB_ROLE_CONFIG[job_runner.JOB_ROLE_GATE].path_env,
+        )
+        self.assertIn(Principal.GATE, permgen.DOWNGRADED_JOB_PRINCIPALS)
+        self.assertEqual(
+            len(permgen.DOWNGRADED_JOB_PRINCIPALS), len(job_runner.JOB_ROLES)
+        )
+
+    def test_gate_unit_serves_no_model_persona(self) -> None:
+        """`JOB_PRINCIPAL_PERSONAS` 必須機器可讀地說「沒有任何 persona 以 gate 起跑」。"""
+        served = permgen.JOB_PRINCIPAL_PERSONAS[Principal.GATE]
+        self.assertEqual(served, frozenset({Principal.GATE}))
+        self.assertEqual(served & registry.HEADLESS_PERSONAS, frozenset())
+
+    def test_the_launcher_never_routes_a_model_job_to_the_gate_role(self) -> None:
+        """三個 persona 的 `_job_role()` 都不得是 gate——gate 不跑模型。"""
+        for label, launcher in (
+            ("builder", SubprocessLauncher("claude")),
+            ("reviewer", SubprocessLauncher("claude").as_review_only(
+                terminal_kind="workflow-review-result")),
+            ("planner", SubprocessLauncher("claude").as_read_only()),
+        ):
+            self.assertNotEqual(launcher._job_role(), job_runner.JOB_ROLE_GATE, label)
+
+
+# ---------------------------------------------------------------------------
+# 2. gate 身分的可寫面：三條「不能碰」
+# ---------------------------------------------------------------------------
+
+def _write_face(principal: Principal) -> tuple[str, ...]:
+    return permgen.build_job_unit(SCHEME, principal=principal).read_write_paths
+
+
+def _covers(granted: str, target: str) -> bool:
+    g = granted.rstrip("/")
+    return target == g or target.startswith(g + "/")
+
+
+class GateWriteFaceTests(unittest.TestCase):
+    """gate 的 `ReadWritePaths=` 由登記表機械導出——本組釘住它導出來的是什麼。"""
+
+    def setUp(self) -> None:
+        self.granted = _write_face(Principal.GATE)
+
+    def test_gate_can_write_exactly_its_own_two_trees_plus_cache(self) -> None:
+        self.assertEqual(
+            set(self.granted),
+            {
+                LAYOUT.cache_of(GATE_ACCOUNT),
+                JOB_LAYOUT.gate_ledger_spool_root,
+                JOB_LAYOUT.gate_worktree_root,
+            },
+        )
+
+    def test_gate_cannot_write_manager_durable_state(self) -> None:
+        """含 gate ledger／exit sentinel 的落點——這一條若破，#628 當場失效。"""
+        for target in (
+            LAYOUT.dispatch_log_root,       # gate-ledger（ledger ＋ exit sentinel）
+            LAYOUT.coordinator_root,        # Manager 的 durable state 樹
+            LAYOUT.repo_source_root,        # per-job clone 的來源樹
+            LAYOUT.job_spec_spool_root,     # job spec（誰的命令列）
+            LAYOUT.control_root,
+            LAYOUT.monitor_state_root,
+        ):
+            for granted in self.granted:
+                self.assertFalse(_covers(granted, target), (granted, target))
+
+    def test_gate_cannot_write_the_builder_workspace(self) -> None:
+        """gate 讀得到被驗的樹（`rX`），但**寫不進去**——副本才是它的可寫面。"""
+        for granted in self.granted:
+            self.assertFalse(_covers(granted, JOB_LAYOUT.asset_paths()["repo-worktree"]))
+            self.assertFalse(_covers(granted, LAYOUT.worktree_root))
+        entry = next(
+            e for e in permgen.generate_plan(SCHEME).entries
+            if e.asset_id == "repo-worktree"
+        )
+        self.assertEqual(entry.owner, BUILDER_ACCOUNT)
+        gate_acls = [a for a in entry.acls if a.account == GATE_ACCOUNT]
+        self.assertEqual(len(gate_acls), 1, entry.acls)
+        self.assertEqual(gate_acls[0].perms, "rX")   # 讀＋traverse，**沒有 w**
+        self.assertNotIn("w", gate_acls[0].perms)
+
+    def test_gate_cannot_touch_the_verdict_spool(self) -> None:
+        """#639 剛關掉的通道不得因為多一個帳號而重新打開。"""
+        for granted in self.granted:
+            self.assertFalse(_covers(granted, JOB_LAYOUT.review_verdict_spool_root))
+            self.assertFalse(_covers(granted, JOB_LAYOUT.commit_spool_root))
+        for asset_id in ("review-verdict-spool", "review-verdict", "commit-spool"):
+            entry = next(
+                e for e in permgen.generate_plan(SCHEME).entries if e.asset_id == asset_id
+            )
+            self.assertNotIn(
+                GATE_ACCOUNT, {a.account for a in entry.acls}, asset_id
+            )
+            self.assertNotIn(GATE_ACCOUNT, entry.writer_accounts, asset_id)
+
+    def test_no_other_role_gains_a_write_face_on_the_gate_trees(self) -> None:
+        """反向：builder／reviewer 都不得寫得進 gate 的 spool 或工作區。"""
+        for principal in (Principal.BUILDER, Principal.REVIEWER):
+            for granted in _write_face(principal):
+                for target in (
+                    JOB_LAYOUT.gate_ledger_spool_root,
+                    JOB_LAYOUT.gate_worktree_root,
+                ):
+                    self.assertFalse(_covers(granted, target), (principal, granted))
+
+    def test_the_gate_ledger_asset_still_has_manager_as_its_only_writer(self) -> None:
+        """權威 ledger 的作者歸屬與 #628 逐字不變（gate 只寫 spool）。"""
+        asset = registry.asset_by_id("gate-ledger")
+        self.assertEqual(asset.writers, (Principal.MANAGER,))
+        entry = next(
+            e for e in permgen.generate_plan(SCHEME).entries if e.asset_id == "gate-ledger"
+        )
+        self.assertEqual(entry.owner, MANAGER_ACCOUNT)
+        self.assertEqual(entry.acls, ())
+
+    def test_the_spool_grants_gate_write_only_no_read(self) -> None:
+        """`wx` 無 `r`：寫得進自己那格、讀不到別人的（與兩個既有 spool 同形）。"""
+        entry = next(
+            e for e in permgen.generate_plan(SCHEME).entries
+            if e.asset_id == "gate-ledger-spool"
+        )
+        self.assertEqual(entry.owner, MANAGER_ACCOUNT)
+        self.assertEqual(entry.mode, 0o700)
+        acls = [a for a in entry.acls if a.account == GATE_ACCOUNT]
+        self.assertEqual([a.perms for a in acls], ["wx"])
+        self.assertNotIn("r", acls[0].perms)
+
+
+# ---------------------------------------------------------------------------
+# 3. pre-seed 守衛：沿用 #639 的 spool_slot，不另寫一份
+# ---------------------------------------------------------------------------
+
+class PreSeedGuardTests(unittest.TestCase):
+    def test_prepare_gate_spool_uses_the_shared_slot_lifecycle(self) -> None:
+        """守衛必須是 `spool_slot.create_slot(reset=True)`，不是本模組自己的實作。"""
+        with tempfile.TemporaryDirectory() as root:
+            with mock.patch.object(
+                spool_slot, "create_slot", wraps=spool_slot.create_slot
+            ) as spy:
+                gate_runner.prepare_gate_spool(spool_key="job-1", coordinator_root=root)
+            self.assertEqual(spy.call_count, 1)
+            self.assertIs(spy.call_args.kwargs.get("reset"), True)
+
+    def test_a_preseeded_ledger_is_destroyed_not_consumed(self) -> None:
+        """builder 預埋一份「全過」的 ledger，得到的是自己的檔案被刪掉。"""
+        with tempfile.TemporaryDirectory() as root:
+            slot = gate_runner.gate_ledger_spool_dir(
+                spool_key="job-1", coordinator_root=root
+            )
+            slot.mkdir(parents=True)
+            planted = slot / gate_runner.GATE_LEDGER_FILENAME
+            planted.write_text(json.dumps(_ok_payload()), encoding="utf-8")
+            (slot / "extra-junk").write_text("x", encoding="utf-8")
+
+            out = gate_runner.prepare_gate_spool(
+                spool_key="job-1", coordinator_root=root
+            )
+            self.assertEqual(out, planted)
+            self.assertFalse(planted.exists())
+            self.assertFalse((slot / "extra-junk").exists())
+            self.assertTrue(slot.is_dir())
+
+    def test_a_preseeded_symlink_slot_is_refused(self) -> None:
+        """把那一格換成 symlink 等於把落點外包出去——拒絕，不是接受後跟隨。"""
+        with tempfile.TemporaryDirectory() as root:
+            slot = gate_runner.gate_ledger_spool_dir(
+                spool_key="job-1", coordinator_root=root
+            )
+            slot.parent.mkdir(parents=True, exist_ok=True)
+            elsewhere = Path(root) / "elsewhere"
+            elsewhere.mkdir()
+            slot.symlink_to(elsewhere)
+            with self.assertRaises(gate_runner.GateRunnerError) as ctx:
+                gate_runner.prepare_gate_spool(spool_key="job-1", coordinator_root=root)
+            self.assertEqual(ctx.exception.reason, "gate-spool-unavailable")
+
+    def test_the_slot_is_sealed_after_consumption(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            out = gate_runner.prepare_gate_spool(
+                spool_key="job-1", coordinator_root=root
+            )
+            out.write_text(json.dumps(_ok_payload()), encoding="utf-8")
+            gate_runner.seal_gate_spool(out)
+            self.assertEqual(
+                stat.S_IMODE(out.parent.stat().st_mode), spool_slot.SEALED_SLOT_MODE
+            )
+
+    def test_unsafe_spool_keys_are_refused_before_any_path_is_built(self) -> None:
+        for bad in ("../escape", "/abs", "", "a/b", ".hidden"):
+            with self.assertRaises(gate_runner.GateRunnerError) as ctx:
+                gate_runner.gate_ledger_spool_dir(spool_key=bad, coordinator_root="/tmp")
+            self.assertEqual(ctx.exception.reason, "gate-spool-key-invalid", bad)
+
+    def test_spool_key_derivation_is_shared_with_the_commit_spool(self) -> None:
+        """兩個 spool 的 key 必須是**同一個字串**，否則會出現 builder 那格建得起來、
+        gate 這格建不起來的錯位。"""
+        from paulsha_cortex.coordinator import job_workspace
+
+        job = {"log_path": "/var/lib/cortex/runtime/dispatch/psc-0629-build.jsonl"}
+        self.assertEqual(
+            gate_runner.spool_key_for_job(job), job_workspace.spool_key_for_job(job)
+        )
+        self.assertEqual(gate_runner.spool_key_for_job(job), "psc-0629-build")
+
+
+# ---------------------------------------------------------------------------
+# 4. polkit：新字幹的正向放行與反向拒絕（比照 #647 的十種名稱混淆）
+# ---------------------------------------------------------------------------
+
+class PolkitGateStemTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.rule = permgen.build_polkit_rule(SCHEME, plan=permgen.PolkitPlan.TEMPLATE)
+
+    def _decide(self, unit: str | None, verb: str | None = "start") -> str:
+        return permgen.evaluate_polkit(
+            self.rule,
+            user=self.rule.subject_account,
+            action_id=permgen.POLKIT_ACTION,
+            unit=unit,
+            verb=verb,
+        )
+
+    def test_still_exactly_one_rule_and_one_grant(self) -> None:
+        """#647 立下的可審查性性質：全檔只有一個 `return YES`、一條 `addRule`。
+
+        #629 擴的是**字幹段**，不是規則數——第二條 `addRule` 會把 subject／action／
+        verb／明細缺席四個檢查複製一份，變成兩個要同步維護的放行出口。
+        """
+        self.assertEqual(self.rule.content.count("polkit.Result.YES"), 1)
+        self.assertEqual(self.rule.content.count("polkit.addRule("), 1)
+
+    def test_every_gate_stem_is_authorised(self) -> None:
+        for profile in permgen.HARDENING_PROFILES:
+            stem = permgen.job_unit_stem(LAYOUT, Principal.GATE, profile)
+            self.assertEqual(self._decide(f"{stem}@psc-0629-build.service"), "YES", stem)
+
+    def test_stem_segment_stays_a_closed_enumeration(self) -> None:
+        tail = r"@[a-z0-9][a-z0-9._-]{0,62}\.service$"
+        pattern = self.rule.unit_pattern
+        self.assertTrue(pattern.startswith("^"))
+        self.assertTrue(pattern.endswith(tail))
+        head = pattern[1 : -len(tail)]
+        stems = permgen.job_unit_stems(LAYOUT, permgen.DOWNGRADED_JOB_PRINCIPALS)
+        self.assertEqual(head, "(?:" + "|".join(stems) + ")")
+        self.assertEqual(
+            len(stems),
+            len(permgen.DOWNGRADED_JOB_PRINCIPALS) * len(permgen.HARDENING_PROFILES),
+        )
+        bare = head.replace("(?:", "").replace(")", "")
+        for wildcard in (".*", "[^", "\\w", "+", "?", "|.", ".|"):
+            self.assertNotIn(wildcard, bare, wildcard)
+
+    def test_ten_gate_name_confusions_are_refused(self) -> None:
+        """比照 #647 對 `-jit` 做的十種——名稱混淆一條都不得放行。"""
+        for unit in (
+            "cortex-gate-jobx@a.service",       # 字幹後多字元
+            "cortex-gate-jo@a.service",         # 字幹被截短
+            "cortex-job-gate@a.service",        # 段序對調
+            "cortex-gate-job@.service",         # `@` 後空 instance
+            "Cortex-gate-job@a.service",        # 首字大寫
+            "cortex-gate-job@a.socket",         # 換 unit 型別
+            "cortex-gate-job@a.service.bak",    # 尾綴混淆
+            "cortex-gate-job@a.service\ncortex-gate-job@b.service",  # 換行注入
+            "cortex-gate-job@" + "a" * 64 + ".service",              # instance 超長
+            "xcortex-gate-job@a.service",       # 字幹前多字元
+        ):
+            self.assertEqual(self._decide(unit), "NO", unit)
+
+    def test_transient_shapes_are_refused_for_the_gate_stem(self) -> None:
+        for unit in (
+            "cortex-gate-job-psc-0629-deadbeef.service",
+            "cortex-gate-job-jit-psc-0629-deadbeef.service",
+            "run-u1234.service",
+        ):
+            self.assertEqual(self._decide(unit), "NO", unit)
+
+    def test_other_verbs_and_other_subjects_are_refused(self) -> None:
+        for verb in ("reload", "mask", "set-property", "restart", "kill", "enable"):
+            self.assertEqual(self._decide("cortex-gate-job@a.service", verb), "NO", verb)
+        for user in ("nobody", BUILDER_ACCOUNT, REVIEW_ACCOUNT, GATE_ACCOUNT, "root"):
+            self.assertEqual(
+                permgen.evaluate_polkit(
+                    self.rule,
+                    user=user,
+                    action_id=permgen.POLKIT_ACTION,
+                    unit="cortex-gate-job@a.service",
+                    verb="start",
+                ),
+                "NOT_HANDLED",
+                user,
+            )
+
+    def test_legacy_schemes_do_not_name_a_gate_unit(self) -> None:
+        """二分／三分沒有 gate 帳號 ⇒ 規則不該提一份那台機器上不存在的 unit。"""
+        for scheme_id in ("two-way", "three-way"):
+            scheme = permgen.SCHEMES[scheme_id].with_principal_accounts(
+                {Principal.OPERATOR: "ops", Principal.EXTERNAL: "outbox"}
+            )
+            rule = permgen.build_polkit_rule(scheme)
+            self.assertNotIn("cortex-gate-job", rule.unit_pattern, scheme_id)
+            self.assertNotIn(GATE_ACCOUNT, rule.target_accounts, scheme_id)
+            self.assertEqual(
+                permgen.evaluate_polkit(
+                    rule,
+                    user=rule.subject_account,
+                    action_id=permgen.POLKIT_ACTION,
+                    unit="cortex-gate-job@a.service",
+                    verb="start",
+                ),
+                "NO",
+                scheme_id,
+            )
+
+    def test_the_pattern_is_a_valid_anchored_regex(self) -> None:
+        compiled = re.compile(self.rule.unit_pattern)
+        self.assertIsNotNone(compiled.search("cortex-gate-job@a.service"))
+        self.assertIsNone(compiled.search("prefix-cortex-gate-job@a.service"))
+
+    @unittest.skipUnless(
+        REAL_HARDENING,
+        "polkit 是否真的拒絕，只有在已落檔規則 ＋ 真實 D-Bus 上才驗得到；本機以 "
+        "Python 鏡像測的是**產生邏輯**，不是 polkit 的實際決策。真實驗證在 runbook "
+        "第 5-7 步（含移除規則後必須失敗的 fail-closed 對照）。",
+    )
+    def test_real_polkit_decision_for_the_gate_stem(self) -> None:  # pragma: no cover
+        raise AssertionError("此測項只在已落檔 polkit 規則的實機上執行（runbook 5-7）。")
+
+
+# ---------------------------------------------------------------------------
+# 5. 加固表：各份 unit 除剖面差異外逐項相同（集合比對，不硬編）
+# ---------------------------------------------------------------------------
+
+def _hardening_table(content: str) -> dict[str, str]:
+    """從產出的 unit 抽出實際生效的加固指令（只看真正的指令行，不看註解）。"""
+    table: dict[str, str] = {}
+    section = None
+    for line in content.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if stripped.startswith("[") and stripped.endswith("]"):
+            section = stripped
+            continue
+        if section != "[Service]" or "=" not in stripped:
+            continue
+        key, _, value = stripped.partition("=")
+        if key in {k for k, _v, _w in permgen._HARDENING}:
+            table[key] = value
+    return table
+
+
+class GateHardeningParityTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.units = {
+            (principal, profile.profile_id): permgen.build_job_unit(
+                SCHEME, principal=principal, profile=profile
+            )
+            for principal in permgen.DOWNGRADED_JOB_PRINCIPALS
+            for profile in permgen.HARDENING_PROFILES
+        }
+
+    def test_key_set_is_identical_across_every_template(self) -> None:
+        expected = {key for key, _value, _why in permgen._HARDENING}
+        for label, unit in self.units.items():
+            self.assertEqual(set(_hardening_table(unit.content)), expected, label)
+
+    def test_the_gate_template_matches_the_builder_template_item_by_item(self) -> None:
+        """新增一個角色不得順手放寬任何一項加固——**集合比對，不硬編值**。"""
+        for profile in permgen.HARDENING_PROFILES:
+            builder = _hardening_table(
+                self.units[(Principal.BUILDER, profile.profile_id)].content
+            )
+            gate = _hardening_table(
+                self.units[(Principal.GATE, profile.profile_id)].content
+            )
+            self.assertEqual(gate, builder, profile.profile_id)
+
+    def test_profile_divergence_is_bounded_for_the_gate_role(self) -> None:
+        strict = _hardening_table(self.units[(Principal.GATE, "strict")].content)
+        jit = _hardening_table(self.units[(Principal.GATE, "jit")].content)
+        diff = {k for k in strict if strict[k] != jit[k]}
+        self.assertEqual(diff, permgen.PROFILE_DIVERGENCE_KEYS)
+
+    def test_read_write_paths_are_the_only_thing_that_differs_between_roles(self) -> None:
+        """角色之間的全部差異都必須是「帳號」帶出來的，加固表一項都不能動。"""
+        tables = {
+            principal: _hardening_table(self.units[(principal, "strict")].content)
+            for principal in permgen.DOWNGRADED_JOB_PRINCIPALS
+        }
+        self.assertEqual(len({tuple(sorted(t.items())) for t in tables.values()}), 1)
+
+
+# ---------------------------------------------------------------------------
+# 6. 執行面：spec 形狀、spool 消費、不受信任輸入
+# ---------------------------------------------------------------------------
+
+class GateExecutionTests(unittest.TestCase):
+    def _run(self, *, root: str, payload: object, returncode: int = 0, env_extra=None):
+        spool_dir = str(Path(root) / "job-specs")
+        Path(spool_dir).mkdir(parents=True)
+        coordinator_root = str(Path(root) / "coordinator")
+        worktree = Path(root) / "worktree"
+        worktree.mkdir()
+        ledger_path = Path(root) / "dispatch" / "psc-0629-build.gates.json"
+        env = {
+            **_BASE_ENV,
+            job_runner.JOB_RUNNER_ENV: job_runner.RUNNER_SYSTEMD_TEMPLATE,
+            job_runner.JOB_SPEC_SPOOL_ENV: spool_dir,
+            "PSC_GATE_CMD_PYTEST": "python3 -m pytest -q",
+            **(env_extra or {}),
+        }
+        runner = _RecordingRunner(returncode=returncode, payload=payload)
+        runner.expect_output(
+            gate_runner.gate_spool_ledger_path(
+                spool_key="psc-0629-build", coordinator_root=coordinator_root
+            )
+        )
+        with mock.patch.dict(os.environ, env, clear=True), _nested(_preflight_patches()):
+            result = gate_runner.run_declared_gates(
+                job_id="psc-0629-build",
+                spool_key="psc-0629-build",
+                ledger_path=ledger_path,
+                worktree=worktree,
+                coordinator_root=coordinator_root,
+                runner=runner,
+            )
+        specs = sorted(Path(spool_dir).iterdir())
+        return {
+            "result": result,
+            "spec": json.loads(specs[0].read_text(encoding="utf-8")) if specs else None,
+            "runner": runner,
+            "ledger_path": ledger_path,
+        }
+
+    def test_the_gate_runs_under_the_gate_template_unit(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            out = self._run(root=root, payload=_ok_payload())
+            # instance 名走與 builder 完全相同的推導（`job_workspace.job_segment`），
+            # 因此 unit 名可追蹤且唯一；本測項釘的是**模板字幹**是 gate 的那一份。
+            instance = job_runner.template_instance_id("psc-0629-build")
+            expected_unit = f"cortex-gate-job@{instance}.service"
+            self.assertEqual(out["spec"]["unit"], expected_unit)
+            self.assertEqual(out["spec"]["instance"], instance)
+            # 起動 argv 是封閉的：沒有 `--property=`／`--uid=`，unit 名是唯一輸入。
+            self.assertEqual(
+                out["runner"].calls[0],
+                [
+                    "/usr/bin/systemctl", "start", "--wait", "--no-ask-password",
+                    expected_unit,
+                ],
+            )
+
+    def test_the_spec_carries_no_identity_or_profile_field(self) -> None:
+        """身分只由 root-owned unit 的 `User=` 決定（#643／0816 裁決 B 的核心）。"""
+        with tempfile.TemporaryDirectory() as root:
+            spec = self._run(root=root, payload=_ok_payload())["spec"]
+            self.assertEqual(job_runner.forbidden_spec_keys(spec), [])
+            for banned in ("User", "user", "account", "uid", "hardening_profile"):
+                self.assertNotIn(banned, spec)
+
+    def test_the_gate_command_snapshots_instead_of_running_in_place(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            spec = self._run(root=root, payload=_ok_payload())["spec"]
+            argv = spec["command"]
+            self.assertIn("--snapshot-from", argv)
+            source = argv[argv.index("--snapshot-from") + 1]
+            snapshot = argv[argv.index("--worktree") + 1]
+            self.assertTrue(source.endswith("/worktree"), source)
+            self.assertNotEqual(source, snapshot)
+            # 副本落在 gate 自己的 pool，不在被驗的樹裡面。
+            self.assertIn("/gate-worktree/", snapshot)
+            self.assertTrue(snapshot.endswith("/psc-0629-build"), snapshot)
+            self.assertFalse(snapshot.startswith(source))
+
+    def test_the_gate_env_carries_the_declaration_but_not_the_identity_config(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            env = self._run(
+                root=root,
+                payload=_ok_payload(),
+                env_extra={
+                    "PSC_GATE_ACCOUNT": "cortex-gate",
+                    "PSC_GATE_HARDENING_PROFILE": "strict",
+                    "GITHUB_TOKEN": "ghp_secret",
+                },
+            )["spec"]["env"]
+            self.assertEqual(env["PSC_GATE_CMD_PYTEST"], "python3 -m pytest -q")
+            for leaked in (
+                "PSC_GATE_ACCOUNT", "PSC_GATE_HARDENING_PROFILE",
+                "PSC_GATE_JOB_TEMPLATE_UNIT", "GITHUB_TOKEN",
+            ):
+                self.assertNotIn(leaked, env, leaked)
+
+    def test_the_manager_rewrites_the_authoritative_ledger_itself(self) -> None:
+        """#628 的作者歸屬：權威 ledger 由 Manager 寫，gate 的那一份留在 spool。"""
+        with tempfile.TemporaryDirectory() as root:
+            out = self._run(root=root, payload=_ok_payload())
+            written = Path(out["ledger_path"])
+            self.assertTrue(written.is_file())
+            self.assertIsNone(terminal_contract.foreign_evidence_author(written))
+            found = terminal_contract.read_gate_ledger(written)
+            self.assertIsNotNone(found)
+            self.assertEqual([g["name"] for g in found[0]["gates"]], ["pytest"])
+
+    def test_a_missing_spool_ledger_fails_closed_with_the_unit_diagnostics(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            with self.assertRaises(gate_runner.GateRunnerError) as ctx:
+                self._run(root=root, payload=None, returncode=4)
+            self.assertEqual(ctx.exception.reason, "gate-spool-empty")
+            instance = job_runner.template_instance_id("psc-0629-build")
+            self.assertIn(f"cortex-gate-job@{instance}.service", str(ctx.exception))
+            self.assertIn("systemctl_exit=4", str(ctx.exception))
+            self.assertIn(GATE_ACCOUNT, str(ctx.exception))
+
+    def test_an_undeclared_gate_name_in_the_spool_is_refused(self) -> None:
+        """spool 是不受信任輸入：被攻陷的 gate 不得發明 operator 沒宣告過的 gate 名。"""
+        payload = _ok_payload()
+        payload["gates"].append(
+            {"name": "totally-made-up", "command": "", "exit_code": 0,
+             "status": "passed", "detail": ""}
+        )
+        with tempfile.TemporaryDirectory() as root:
+            with self.assertRaises(gate_runner.GateRunnerError) as ctx:
+                self._run(root=root, payload=payload)
+            self.assertEqual(ctx.exception.reason, "gate-spool-unknown-gate")
+
+    def test_exit_code_overrides_the_self_reported_status(self) -> None:
+        """記了非 0 exit code 卻標 passed ⇒ 以 exit code 為準（與採信端同一條紀律）。"""
+        payload = _ok_payload()
+        payload["gates"][0]["exit_code"] = 1
+        payload["gates"][0]["status"] = "passed"
+        with tempfile.TemporaryDirectory() as root:
+            result = self._run(root=root, payload=payload)["result"]
+            self.assertEqual(result["gates"][0]["status"], "failed")
+
+    def test_an_oversized_spool_payload_is_refused_or_truncated(self) -> None:
+        payload = _ok_payload()
+        payload["gates"][0]["detail"] = "x" * 100_000
+        with tempfile.TemporaryDirectory() as root:
+            result = self._run(root=root, payload=payload)["result"]
+            self.assertLessEqual(
+                len(result["gates"][0]["detail"]), gate_runner.MAX_DETAIL_CHARS
+            )
+        flooded = _ok_payload()
+        flooded["gates"] = flooded["gates"] * (gate_runner.MAX_LEDGER_ROWS + 1)
+        with tempfile.TemporaryDirectory() as root:
+            with self.assertRaises(gate_runner.GateRunnerError) as ctx:
+                self._run(root=root, payload=flooded)
+            self.assertEqual(ctx.exception.reason, "gate-spool-invalid")
+
+    def test_a_malformed_spool_payload_is_refused(self) -> None:
+        for payload in ({"kind": "nope"}, {"gates": "not-a-list"}, []):
+            with tempfile.TemporaryDirectory() as root:
+                with self.assertRaises(gate_runner.GateRunnerError) as ctx:
+                    self._run(root=root, payload=payload)
+                self.assertEqual(ctx.exception.reason, "gate-spool-invalid", payload)
+
+    def test_the_gate_role_refuses_an_executor(self) -> None:
+        """gate 不跑模型 ⇒ 剖面不得跟著 `PSC_MANAGER_EXECUTOR` 漂移。"""
+        with mock.patch.dict(os.environ, {}, clear=True), _nested(_preflight_patches()):
+            with self.assertRaises(job_runner.JobRunnerError):
+                job_runner.prepare_systemd_template(
+                    {job_runner.JOB_SPEC_SPOOL_ENV: "/tmp"},
+                    job_id="j", executor="codex", role=job_runner.JOB_ROLE_GATE,
+                )
+
+    def test_model_roles_still_require_an_executor(self) -> None:
+        with mock.patch.dict(os.environ, {}, clear=True), _nested(_preflight_patches()):
+            with self.assertRaises(job_runner.JobRunnerError):
+                job_runner.prepare_systemd_template(
+                    {job_runner.JOB_SPEC_SPOOL_ENV: "/tmp"},
+                    job_id="j", executor=None, role=job_runner.JOB_ROLE_BUILDER,
+                )
+
+    def test_the_gate_profile_is_an_operator_decision_and_fails_closed(self) -> None:
+        self.assertEqual(job_runner.resolve_gate_hardening_profile({}), "strict")
+        self.assertEqual(
+            job_runner.resolve_gate_hardening_profile(
+                {job_runner.GATE_HARDENING_PROFILE_ENV: "jit"}
+            ),
+            "jit",
+        )
+        with self.assertRaises(job_runner.JobRunnerError):
+            job_runner.resolve_gate_hardening_profile(
+                {job_runner.GATE_HARDENING_PROFILE_ENV: "jti"}
+            )
+
+    def test_the_interpreter_must_be_absolute(self) -> None:
+        self.assertEqual(
+            gate_runner.resolve_gate_python({}), gate_runner.DEFAULT_GATE_PYTHON
+        )
+        with self.assertRaises(gate_runner.GateRunnerError):
+            gate_runner.resolve_gate_python({gate_runner.GATE_PYTHON_ENV: "python3"})
+
+
+# ---------------------------------------------------------------------------
+# 7. 拋棄式副本
+# ---------------------------------------------------------------------------
+
+class SnapshotTests(unittest.TestCase):
+    def test_the_snapshot_is_a_real_copy_and_the_source_is_untouched(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            src = Path(root) / "src"
+            (src / "pkg").mkdir(parents=True)
+            (src / "pkg" / "conftest.py").write_text("x = 1\n", encoding="utf-8")
+            dst = Path(root) / "snap"
+            gate_runner_out = gate_ledger.snapshot_worktree(src, dst)
+            self.assertEqual(gate_runner_out, dst)
+            self.assertEqual(
+                (dst / "pkg" / "conftest.py").read_text(encoding="utf-8"), "x = 1\n"
+            )
+            # gate 在副本上寫入（`.pytest_cache` 等）不影響來源。
+            (dst / ".pytest_cache").mkdir()
+            self.assertFalse((src / ".pytest_cache").exists())
+
+    def test_symlinks_are_copied_as_symlinks_never_followed(self) -> None:
+        """跟隨 symlink 會把樹外內容複製進 gate 的可寫區，或走進無界遞迴。"""
+        with tempfile.TemporaryDirectory() as root:
+            outside = Path(root) / "outside"
+            outside.mkdir()
+            (outside / "secret").write_text("s3cret", encoding="utf-8")
+            src = Path(root) / "src"
+            src.mkdir()
+            (src / "escape").symlink_to(outside)
+            (src / "self").symlink_to(src)
+            dst = Path(root) / "snap"
+            gate_ledger.snapshot_worktree(src, dst)
+            self.assertTrue((dst / "escape").is_symlink())
+            self.assertTrue((dst / "self").is_symlink())
+            self.assertFalse((dst / "escape").joinpath("secret").is_file()
+                             and not (dst / "escape").is_symlink())
+
+    def test_a_stale_snapshot_is_rebuilt_not_merged(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            src = Path(root) / "src"
+            src.mkdir()
+            (src / "new.txt").write_text("new", encoding="utf-8")
+            dst = Path(root) / "snap"
+            dst.mkdir()
+            (dst / "leftover.txt").write_text("old", encoding="utf-8")
+            gate_ledger.snapshot_worktree(src, dst)
+            self.assertFalse((dst / "leftover.txt").exists())
+            self.assertTrue((dst / "new.txt").is_file())
+
+    def test_overlapping_destinations_are_refused(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            src = Path(root) / "src"
+            src.mkdir()
+            for dst in (src, src / "inner"):
+                with self.assertRaises(gate_ledger.SnapshotError):
+                    gate_ledger.snapshot_worktree(src, dst)
+
+    def test_a_missing_source_fails_closed_without_writing_a_ledger(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            out = Path(root) / "ledger.json"
+            rc = gate_ledger.main(
+                [
+                    "--out", str(out),
+                    "--worktree", str(Path(root) / "snap"),
+                    "--snapshot-from", str(Path(root) / "does-not-exist"),
+                ]
+            )
+            self.assertEqual(rc, 74)
+            # **一份 ledger 都不寫**：寫「全部 failed」會把「沒驗到」偽裝成「驗過沒過」。
+            self.assertFalse(out.exists())
+
+
+# ---------------------------------------------------------------------------
+# 8. direct 模式零回歸
+# ---------------------------------------------------------------------------
+
+class DirectModeParityTests(unittest.TestCase):
+    """`direct` 下 builder 與 Manager 同 UID，第四個身分沒有邊界可言——行為不變。"""
+
+    def test_direct_mode_writes_the_ledger_in_process_exactly_as_before(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            worktree = Path(root) / "wt"
+            worktree.mkdir()
+            ledger = Path(root) / "out.gates.json"
+            env = {"PSC_SLICE_ID": "s1", job_runner.JOB_RUNNER_ENV: "direct"}
+            with mock.patch.object(
+                gate_ledger, "write_gate_ledger", wraps=gate_ledger.write_gate_ledger
+            ) as spy:
+                payload = gate_runner.run_declared_gates(
+                    job_id="j", spool_key="s1", ledger_path=ledger,
+                    worktree=worktree, env=env,
+                )
+            self.assertEqual(spy.call_count, 1)
+            self.assertEqual(payload["gates"], [])
+            self.assertTrue(ledger.is_file())
+
+    def test_direct_mode_never_creates_a_gate_spool_or_snapshot(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            worktree = Path(root) / "wt"
+            worktree.mkdir()
+            coordinator_root = Path(root) / "coordinator"
+            with mock.patch.object(gate_runner, "prepare_gate_spool") as spy:
+                gate_runner.run_declared_gates(
+                    job_id="j", spool_key="s1",
+                    ledger_path=Path(root) / "out.gates.json",
+                    worktree=worktree,
+                    env={job_runner.JOB_RUNNER_ENV: "direct"},
+                    coordinator_root=coordinator_root,
+                )
+            spy.assert_not_called()
+            self.assertFalse(coordinator_root.exists())
+
+    def test_ensure_gate_ledger_is_a_no_op_in_direct_mode(self) -> None:
+        job = {
+            "workflow_phase": "build",
+            "log_path": "/tmp/psc-0629-build.jsonl",
+            "worktree": "/tmp",
+        }
+        self.assertIsNone(
+            gate_runner.ensure_gate_ledger(
+                job, phases=frozenset({"build"}),
+                env={job_runner.JOB_RUNNER_ENV: "direct"},
+            )
+        )
+
+    def test_ensure_gate_ledger_skips_the_phases_that_never_ran_gates(self) -> None:
+        env = {job_runner.JOB_RUNNER_ENV: job_runner.RUNNER_SYSTEMD_TEMPLATE}
+        for phase in ("plan", "review", "verify"):
+            job = {"workflow_phase": phase, "log_path": "/tmp/a.jsonl", "worktree": "/tmp"}
+            self.assertIsNone(
+                gate_runner.ensure_gate_ledger(
+                    job, phases=frozenset({"build"}), env=env
+                ),
+                phase,
+            )
+
+    def test_ensure_gate_ledger_never_overwrites_an_existing_ledger(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            log_path = Path(root) / "psc-0629-build.jsonl"
+            log_path.write_text("", encoding="utf-8")
+            terminal_contract.gate_ledger_path(log_path).write_text("{}", encoding="utf-8")
+            job = {
+                "workflow_phase": "build",
+                "log_path": str(log_path),
+                "worktree": root,
+            }
+            self.assertIsNone(
+                gate_runner.ensure_gate_ledger(
+                    job,
+                    phases=frozenset({"build"}),
+                    env={job_runner.JOB_RUNNER_ENV: job_runner.RUNNER_SYSTEMD_TEMPLATE},
+                )
+            )
+
+
+# ---------------------------------------------------------------------------
+# 9. `_regenerate_gates_action` 走同一條執行面
+# ---------------------------------------------------------------------------
+
+class RegenerateGatesConvergenceTests(unittest.TestCase):
+    """#629：手動救援不得留在 Manager 進程內跑 builder 交出來的 `conftest.py`。"""
+
+    def test_the_action_calls_the_shared_entry_point_not_write_gate_ledger(self) -> None:
+        import inspect
+
+        from paulsha_cortex.coordinator import work_actions
+
+        source = inspect.getsource(work_actions._regenerate_gates_action)
+        # docstring 會提到舊寫法（那是它為什麼改的說明），因此只看**程式碼本體**。
+        body = source.replace(work_actions._regenerate_gates_action.__doc__ or "", "")
+        self.assertIn("gate_runner.run_declared_gates(", body)
+        self.assertNotIn("gate_ledger.write_gate_ledger(", body)
+
+    def test_the_manager_runs_the_gate_before_the_acceptance_read(self) -> None:
+        """證據必須在被讀之前落地，且**不得**在採信開始之後才產生。"""
+        import inspect
+
+        from paulsha_cortex.coordinator import manager
+
+        source = inspect.getsource(manager.terminalize_workflow_job)
+        run_at = source.index("_run_gate_execution_identity(job)")
+        read_at = source.index("_assert_terminal_gate_consistency(raw")
+        self.assertLess(run_at, read_at)
+
+    def test_gate_execution_phases_match_the_phases_that_require_a_ledger(self) -> None:
+        from paulsha_cortex.coordinator import manager
+
+        self.assertEqual(
+            manager.GATE_EXECUTION_PHASES, manager.GATE_LEDGER_REQUIRED_PHASES
+        )
+
+
+# ---------------------------------------------------------------------------
+# 10. 單 UID 下測不出來的：明確 skip（#638 的教訓）
+# ---------------------------------------------------------------------------
+
+class RealIsolationTests(unittest.TestCase):
+    """本組每一項都需要 root ＋ 四個真實帳號 ＋ 已套 ACL 的樹。
+
+    在 CI 容器裡跑出來的「綠」不代表任何事——單 UID 下 `wx` 無 `r` 的 ACL 根本不會
+    被評估，`sudo -u` 也不可得。因此一律 skip 並指向 runbook 的實機步驟，**不**用
+    裸跑當替身（那只會產生一個永遠綠、什麼都沒驗到的測試）。
+    """
+
+    @unittest.skipUnless(
+        REAL_HARDENING,
+        "需要 root ＋ `cortex-gate` 帳號：驗 gate 對 builder 工作樹的 `rX` 真的成立"
+        "（讀得到、寫不進）。runbook 第 9b 步。",
+    )
+    def test_real_gate_can_read_but_not_write_the_builder_worktree(self) -> None:  # pragma: no cover
+        raise AssertionError("實機測項（runbook 9b）。")
+
+    @unittest.skipUnless(
+        REAL_HARDENING,
+        "需要已套 ACL 的 spool：驗 gate 寫得進自己那格、**讀不到**別人那格"
+        "（`wx` 無 `r`），以及 seal 之後連自己那格都進不去。runbook 第 9c 步。",
+    )
+    def test_real_spool_is_write_only_for_the_gate_account(self) -> None:  # pragma: no cover
+        raise AssertionError("實機測項（runbook 9c）。")
+
+    @unittest.skipUnless(
+        REAL_HARDENING,
+        "需要真實 systemd：驗 gate unit 真的以 `uid=cortex-gate` 執行，且對 "
+        "Manager 的 dispatch log 目錄寫入為 EROFS。runbook 第 9a 步。",
+    )
+    def test_real_gate_unit_runs_as_the_gate_uid(self) -> None:  # pragma: no cover
+        raise AssertionError("實機測項（runbook 9a）。")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/tests/test_gate_execution_identity_629.py
+++ b/tests/test_gate_execution_identity_629.py
@@ -28,11 +28,14 @@ skip 並說明理由**，不用 `sudo -u`／裸跑當替身（那只會產生一
 
 from __future__ import annotations
 
+import ast
+import inspect
 import json
 import os
 import re
 import stat
 import tempfile
+import textwrap
 import unittest
 from pathlib import Path
 from unittest import mock
@@ -97,6 +100,26 @@ class _RecordingRunner:
     def expect_output(self, path: str | Path) -> "_RecordingRunner":
         self._out = str(path)
         return self
+
+
+def _function_body_source(func) -> str:
+    """函式的**程式碼本體**（剝掉 docstring，且不含註解）。
+
+    `ast.unparse` 一併丟掉註解是刻意的：本檔用它來斷言「這段程式碼不再呼叫某個
+    函式」，而註解與 docstring 裡提到那個名字是合理的（它們正在解釋為什麼不再呼叫）。
+    """
+
+    src = textwrap.dedent(inspect.getsource(func))
+    node = ast.parse(src).body[0]
+    body = getattr(node, "body", [])
+    if (
+        body
+        and isinstance(body[0], ast.Expr)
+        and isinstance(body[0].value, ast.Constant)
+        and isinstance(body[0].value.value, str)
+    ):
+        node.body = body[1:]
+    return ast.unparse(node)
 
 
 def _nested(patches):
@@ -954,13 +977,13 @@ class RegenerateGatesConvergenceTests(unittest.TestCase):
     """#629：手動救援不得留在 Manager 進程內跑 builder 交出來的 `conftest.py`。"""
 
     def test_the_action_calls_the_shared_entry_point_not_write_gate_ledger(self) -> None:
-        import inspect
-
         from paulsha_cortex.coordinator import work_actions
 
-        source = inspect.getsource(work_actions._regenerate_gates_action)
         # docstring 會提到舊寫法（那是它為什麼改的說明），因此只看**程式碼本體**。
-        body = source.replace(work_actions._regenerate_gates_action.__doc__ or "", "")
+        # 用 `ast` 剝掉 docstring 而不是 `source.replace(fn.__doc__, "")`：後者在
+        # Python 3.13 會失效——3.13 起 `__doc__` 的共同前置縮排在編譯期就被移除，
+        # 與原始碼裡的字串不再逐字相等（3.10–3.12 相等，因此那個寫法只在部分版本綠）。
+        body = _function_body_source(work_actions._regenerate_gates_action)
         self.assertIn("gate_runner.run_declared_gates(", body)
         self.assertNotIn("gate_ledger.write_gate_ledger(", body)
 

--- a/tests/test_reviewer_planner_downgrade_615.py
+++ b/tests/test_reviewer_planner_downgrade_615.py
@@ -43,7 +43,11 @@ from paulsha_cortex.trust_root.registry import Principal
 
 REAL_HARDENING = os.environ.get("PSC_TEST_REAL_HARDENING") == "1"
 
-SCHEME = permgen.THREE_WAY_SCHEME
+# #629 把定案方案推進到四分（多一個 `cortex-gate`）。本檔測的是 M2 的不變式，而
+# M2 的不變式在四分下逐條仍然成立——改綁 `DEFAULT_SCHEME` 是為了讓「產生器產出的
+# 那一組 unit／polkit 字幹」與部署現實同步，否則這裡測到的是一份沒人會裝的規則。
+SCHEME = permgen.DEFAULT_SCHEME
+GATE_ACCOUNT = "cortex-gate"
 LAYOUT = permgen.DEFAULT_LAYOUT
 JOB_LAYOUT = LAYOUT.with_job_segment("%i")
 REVIEW_ACCOUNT = "cortex-reviewer-planner"
@@ -678,7 +682,7 @@ class PolkitReviewStemTests(unittest.TestCase):
                 stem = permgen.job_unit_stem(LAYOUT, principal, profile)
                 self.assertIn(f"{stem}@<id>.service", self.rule.content, stem)
         self.assertEqual(
-            self.rule.target_accounts, (BUILDER_ACCOUNT, REVIEW_ACCOUNT)
+            self.rule.target_accounts, (BUILDER_ACCOUNT, REVIEW_ACCOUNT, GATE_ACCOUNT)
         )
         self.assertEqual(self.rule.residual_risks, ())
 
@@ -723,17 +727,30 @@ class HardeningParityTests(unittest.TestCase):
             for profile in permgen.HARDENING_PROFILES
         }
 
-    def test_there_are_exactly_four_templates(self) -> None:
+    def test_template_count_is_roles_times_profiles(self) -> None:
+        """份數＝角色 × 剖面，**機械導出不硬編**（#629 加第三個角色時這裡自動跟上）。"""
         names = {unit.unit_name for unit in self.units.values()}
-        self.assertEqual(len(names), 4, names)
+        self.assertEqual(
+            len(names),
+            len(permgen.DOWNGRADED_JOB_PRINCIPALS) * len(permgen.HARDENING_PROFILES),
+            names,
+        )
         self.assertEqual(
             names,
             {
-                "cortex-job@.service",
-                "cortex-job-jit@.service",
-                "cortex-reviewer-job@.service",
-                "cortex-reviewer-job-jit@.service",
+                f"{permgen.job_unit_stem(LAYOUT, principal, profile)}@.service"
+                for principal in permgen.DOWNGRADED_JOB_PRINCIPALS
+                for profile in permgen.HARDENING_PROFILES
             },
+        )
+        # M2 的兩份與 #629 的第三份都必須在裡面——名字逐字釘死，避免字幹被悄悄改掉。
+        self.assertLessEqual(
+            {
+                "cortex-job@.service",
+                "cortex-reviewer-job@.service",
+                "cortex-gate-job@.service",
+            },
+            names,
         )
 
     def test_key_set_is_identical_across_every_template(self) -> None:
@@ -744,13 +761,15 @@ class HardeningParityTests(unittest.TestCase):
     def test_same_profile_across_roles_is_value_identical(self) -> None:
         """角色不改變任何一項加固——差異只能來自剖面。"""
         for profile in permgen.HARDENING_PROFILES:
-            builder = _hardening_table(
-                self.units[(Principal.BUILDER, profile.profile_id)].content
-            )
-            review = _hardening_table(
-                self.units[(Principal.REVIEWER, profile.profile_id)].content
-            )
-            self.assertEqual(builder, review, profile.profile_id)
+            tables = {
+                principal: _hardening_table(
+                    self.units[(principal, profile.profile_id)].content
+                )
+                for principal in permgen.DOWNGRADED_JOB_PRINCIPALS
+            }
+            reference = tables[Principal.BUILDER]
+            for principal, table in tables.items():
+                self.assertEqual(table, reference, (principal, profile.profile_id))
 
     def test_profile_divergence_is_bounded_for_every_role(self) -> None:
         for principal in permgen.DOWNGRADED_JOB_PRINCIPALS:
@@ -766,15 +785,14 @@ class HardeningParityTests(unittest.TestCase):
             self.assertIn(f"Group={account}\n", unit.content, (principal, profile_id))
             self.assertEqual(unit.exec_start, f"{LAYOUT.job_shim} %i")
 
-    def test_the_two_roles_never_share_a_home_or_cache(self) -> None:
-        homes = {
-            SCHEME.resolve(p): LAYOUT.home_of(SCHEME.resolve(p))
-            for p in permgen.DOWNGRADED_JOB_PRINCIPALS
-        }
-        self.assertEqual(len(set(homes.values())), 2, homes)
-        self.assertNotEqual(
-            LAYOUT.cache_of(BUILDER_ACCOUNT), LAYOUT.cache_of(REVIEW_ACCOUNT)
-        )
+    def test_no_two_roles_share_a_home_or_cache(self) -> None:
+        """每個角色一個帳號、一個 HOME、一個 cache——**共用即等於沒有隔離**。"""
+        accounts = [SCHEME.resolve(p) for p in permgen.DOWNGRADED_JOB_PRINCIPALS]
+        self.assertEqual(len(set(accounts)), len(accounts), accounts)
+        homes = {LAYOUT.home_of(a) for a in accounts}
+        caches = {LAYOUT.cache_of(a) for a in accounts}
+        self.assertEqual(len(homes), len(accounts), homes)
+        self.assertEqual(len(caches), len(accounts), caches)
 
 
 # ---------------------------------------------------------------------------
@@ -805,12 +823,13 @@ class PairedContractTests(unittest.TestCase):
         )
 
     def test_path_env_names_match(self) -> None:
+        roles = {
+            Principal.BUILDER: job_runner.JOB_ROLE_BUILDER,
+            Principal.REVIEWER: job_runner.JOB_ROLE_REVIEW,
+            Principal.GATE: job_runner.JOB_ROLE_GATE,
+        }
         for principal in permgen.DOWNGRADED_JOB_PRINCIPALS:
-            role = (
-                job_runner.JOB_ROLE_BUILDER
-                if principal is Principal.BUILDER
-                else job_runner.JOB_ROLE_REVIEW
-            )
+            role = roles[principal]
             self.assertEqual(
                 permgen.JOB_PATH_ENV_BY_PRINCIPAL[principal],
                 job_runner.JOB_ROLE_CONFIG[role].path_env,
@@ -879,13 +898,26 @@ class GateExecutionBoundaryTests(unittest.TestCase):
             REVIEW_ACCOUNT, {a.account for a in entry.acls}
         )
 
-    def test_only_two_roles_exist_no_gate_role_was_smuggled_in(self) -> None:
-        """第四個帳號（gate 執行身分）屬 #629，本票不得順手建立。"""
-        self.assertEqual(set(job_runner.JOB_ROLES), {"builder", "review"})
+    def test_the_gate_role_is_a_fourth_account_not_the_reviewer(self) -> None:
+        """#629 已落地：gate 執行身分存在，而且**不是** reviewer／builder／Manager。
+
+        本測項是 M2 那條「不得把 gate 掛到 reviewer 上」邊界的**接續**，不是它的
+        廢止：#615 當時斷言「還沒有第四個角色」，#629 把它換成「有第四個角色，而且
+        它與前三個逐一不同」。把 gate 併到既有任一帳號都會讓這裡當場紅。
+        """
+        self.assertEqual(
+            set(job_runner.JOB_ROLES), {"builder", "review", "gate"}
+        )
         self.assertEqual(
             set(SCHEME.account_of.values()),
-            {MANAGER_ACCOUNT, REVIEW_ACCOUNT, BUILDER_ACCOUNT},
+            {MANAGER_ACCOUNT, REVIEW_ACCOUNT, BUILDER_ACCOUNT, GATE_ACCOUNT},
         )
+        gate = SCHEME.resolve(Principal.GATE)
+        self.assertEqual(gate, GATE_ACCOUNT)
+        for other in (Principal.BUILDER, Principal.REVIEWER, Principal.PLANNER,
+                      Principal.MANAGER, Principal.MONITOR):
+            self.assertNotEqual(gate, SCHEME.resolve(other), other)
+        self.assertNotEqual(gate, SCHEME.durable_state_owner)
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/tests/test_trust_root_job_template_ab.py
+++ b/tests/test_trust_root_job_template_ab.py
@@ -188,9 +188,34 @@ def _only_spec(spool: str) -> dict:
 # ---------------------------------------------------------------------------
 
 class ThreeWaySchemeIsTheDecisionTests(unittest.TestCase):
-    def test_default_scheme_is_three_way(self) -> None:
-        self.assertIs(permgen.DEFAULT_SCHEME, permgen.THREE_WAY_SCHEME)
-        self.assertEqual(permgen.DEFAULT_SCHEME_ID, "three-way")
+    def test_default_scheme_is_the_widest_split_available(self) -> None:
+        """預設永遠是**分得最細**的那一個方案（#629 起＝四分）。
+
+        0816 第三輪裁決 A 的性質是「預設就是最安全的那一個，要退回較寬鬆的方案必須
+        顯式打出來」。#629 把定案往前推一格（多出 `cortex-gate`），因此這裡斷言的
+        是那個**性質**而不是某個字面 id：預設方案的帳號數必須 ≥ 其餘每一個方案，
+        且三分／二分都仍在表上、都要顯式指定才拿得到。
+        """
+        self.assertIs(permgen.DEFAULT_SCHEME, permgen.FOUR_WAY_SCHEME)
+        self.assertEqual(permgen.DEFAULT_SCHEME_ID, "four-way")
+        widest = max(
+            len(s.declared_accounts()) for s in permgen.SCHEMES.values()
+        )
+        self.assertEqual(len(permgen.DEFAULT_SCHEME.declared_accounts()), widest)
+        for legacy_id in ("two-way", "three-way"):
+            self.assertIn(legacy_id, permgen.SCHEMES)
+            self.assertIsNot(permgen.SCHEMES[legacy_id], permgen.DEFAULT_SCHEME)
+
+    def test_three_way_remains_available_and_declares_no_gate_identity(self) -> None:
+        """三分沒有第四個帳號——而且那是**明示的決定**，不是遺漏（#629）。"""
+        three = permgen.THREE_WAY_SCHEME
+        self.assertEqual(
+            three.account_of[Principal.GATE], permgen.ABSENT_ACCOUNT
+        )
+        self.assertIsNone(three.resolve(Principal.GATE))
+        # 明示不存在 ⇒ 不算未對應，產生器照樣輸出得了三分的其餘部分。
+        self.assertNotIn(Principal.GATE, three.unresolved_principals())
+        self.assertNotIn("cortex-gate", three.declared_accounts())
 
     def test_three_way_splits_the_model_personas_off_the_spawn_authority(self) -> None:
         """裁決的判準：持 spawn 授權的帳號不得跑任何模型程式碼。"""
@@ -448,7 +473,8 @@ class M2ExtensionPointTests(unittest.TestCase):
                     stem,
                 )
         self.assertEqual(
-            rule.target_accounts, ("cortex-builder", "cortex-reviewer-planner")
+            rule.target_accounts,
+            ("cortex-builder", "cortex-reviewer-planner", "cortex-gate"),
         )
         # 仍然只有一個放行出口。
         self.assertEqual(rule.content.count("polkit.Result.YES"), 1)

--- a/tests/test_trust_root_principal_account_mapping_626.py
+++ b/tests/test_trust_root_principal_account_mapping_626.py
@@ -372,10 +372,49 @@ def test_registry_needs_exactly_the_two_deployment_decisions() -> None:
         used.update(asset.writers)
         used.update(asset.readers)
     covered = {opt.principal for opt in PRINCIPAL_ACCOUNT_OPTIONS}
-    fully_mapped = _resolved(THREE_WAY_SCHEME)
+    # **判準是「定案方案」**，不是某個字面 id：#629 把定案推進到四分（多一個
+    # `cortex-gate`），三分對 `GATE` 明示 `ABSENT_ACCOUNT`，因此那個方案下 `GATE`
+    # 永遠 resolve 不到帳號——那是決定，不是 #626 要擋的那種遺漏。
+    fully_mapped = _resolved(permgen.DEFAULT_SCHEME)
     unmapped = {
         p for p in used
         if p is not Principal.ANY_SAME_UID and fully_mapped.resolve(p) is None
     }
     assert unmapped == set(), sorted(p.value for p in unmapped)
     assert covered <= used
+
+
+def test_absent_in_account_of_is_a_decision_not_an_omission() -> None:
+    """#629：`account_of` 也吃 `ABSENT_ACCOUNT`，語意與部署決定型欄位逐字相同。
+
+    三個狀態必須可分辨：缺鍵＝遺漏（fail-closed 並指名）、`ABSENT_ACCOUNT`＝
+    「本方案沒有這個角色」（略去、不 fail）、帳號名＝有。少了中間那一態，
+    「二分／三分沒有 gate 執行面」就只能靠讓整個產生器拒絕輸出來表達。
+    """
+    three = _resolved(THREE_WAY_SCHEME)
+    four = _resolved(permgen.FOUR_WAY_SCHEME)
+
+    assert three.account_of[Principal.GATE] == permgen.ABSENT_ACCOUNT
+    assert three.resolve(Principal.GATE) is None
+    assert Principal.GATE not in three.unresolved_principals()
+    assert permgen.ABSENT_ACCOUNT not in three.declared_accounts()
+
+    assert four.resolve(Principal.GATE) == "cortex-gate"
+    assert "cortex-gate" in four.declared_accounts()
+
+    # 缺鍵（既不是帳號也不是明示不存在）仍然 fail-closed 並指名。
+    missing = permgen.UidScheme(
+        scheme_id="gate-omitted",
+        account_of={
+            p: a for p, a in four.account_of.items() if p is not Principal.GATE
+        },
+        durable_state_owner=four.durable_state_owner,
+        operator_account=four.operator_account,
+        external_reader_account=four.external_reader_account,
+    )
+    assert Principal.GATE in missing.unresolved_principals()
+    message = permgen.unresolved_principal_message(
+        (Principal.GATE,), missing.scheme_id
+    )
+    assert "four-way" in message
+    assert "cortex-gate" in message


### PR DESCRIPTION
Closes #629

## 為什麼現在做

`#615`（M2）已 merge，D6 判定的兩個 blocking 前提只剩這一個。

`#604`／PR `#628` 把 gate ledger 與 exit sentinel 的**作者**收斂到 Manager，但刻意
沒做執行面。理由寫在 `launcher._should_run_gates` 的 docstring 裡：operator 宣告的
gate 命令（`PSC_GATE_CMD_*`）是在 **builder 完全掌控內容的工作樹**上執行的，`pytest`
會載入該樹的 `conftest.py` 與 plugin ⇒ **執行者取得任意程式碼執行**。

現況後果：`PSC_JOB_RUNNER=systemd-template` 下 build 卡**恆**因 `require_ledger` 而
`gate-ledger-missing` fail closed。安全，但不能用。

## 第四帳號的判斷與推導（本票最大的一塊）

**結論：需要第四個帳號 `cortex-gate`，`UidScheme` 三分 → 四分。**

### 為什麼沒有「不需要新帳號的乾淨解」

先確認問題不可迴避：gate 的工作**就是**執行 builder 交出來的東西。任何「換個方式跑」
都改不了這一點——

- 改在 harvest 後的 commit 上跑？commit 裡就有 builder 寫的 `conftest.py`，內容同源；
- 改在 Manager 的來源樹上跑？那只是換了 checkout 的路徑，程式碼還是那份；
- 不跑 gate？那是放棄 §R2 的獨立重驗，也就是現況。

⇒ **ACE 一定會發生，唯一能決定的是它發生在誰的身分下。** 既有三個帳號逐一檢查：

| 候選 | 為什麼不行 |
|---|---|
| `cortex-builder` | 模型自證自己的驗收證據，違反 `#540` 的 acceptance chain |
| `cortex-manager` | 持 spawn 授權、擁有全部 Manager-owned durable state，是三分授權線的**內側**（`#629` 本文的整段論證） |
| `cortex-reviewer-planner` | 它是寫 verdict 的那一個；掛上去等於把 builder 對 verdict 通道的影響力重新打開，抵銷 `#639` |

### 認真評估過的「無新帳號」候選，以及它為什麼不成立

**`DynamicUser=yes`**（systemd 每次起 unit 配一個暫時 UID，不必建帳號）——這是唯一
值得認真看的一條，而它是**結構性**不成立，不是偏好問題：

本方案兩端都靠**具名 POSIX ACL** 授權——`gate-ledger-spool` 那一格要給 gate `wx` 無
`r`，`repo-worktree` 要給 gate `rX`——而 `setfacl -m u:<名>:…` 在**產生權限的當下**
（runbook 第 2 步，`sudo sh -e` 跑整份 script）就要解析得到那個帳號。DynamicUser 的
UID 在 unit 起動前不存在、每次還不同，根本沒有可以寫進 ACL 的名字。

退而求其次的 `User=nobody` 更糟：那是一個與系統上任何其他服務共用的帳號，授它 Tier-0
spool 的寫入權等於把那條通道開給所有 `nobody` 行程。

這段推導固化在 `permgen.FOUR_WAY_SCHEME` 的 docstring 與 spec §R3。

### 三分／二分怎麼辦（不讓它們變成不能用）

`account_of` 支援 `ABSENT_ACCOUNT`（語意與 `#626` 的部署決定型欄位**逐字相同**）：
`three-way`／`two-way` 明示「本方案沒有 gate 角色」⇒ 不產生 gate 的帳號／unit／ACL／
polkit 字幹，降權模式下 build 卡照 `require_ledger` fail closed（＝#629 之前的現況），
但方案的其餘部分**仍然完整可產出**——不會為了一個它們本來就沒有的角色而整份拒絕。

三態必須可分辨，因此**缺鍵**（既非帳號也非明示不存在）仍然 fail-closed，且錯誤訊息
逐條列出「為什麼不能併到既有帳號」＋ 建帳號的那一行命令。

## worktree：拋棄式副本（不是唯讀）

**選拋棄式副本。** 唯讀在可行性上不成立——`pytest` 要寫 `.pytest_cache`／
`__pycache__`，operator 宣告的 `npm test`／`cargo test`／`make` 更是必寫。把工作樹掛
成唯讀只會讓每個真實 gate 以 EROFS 收場，那正是本票要修掉的「安全但不能用」。

副本另外買到兩件事：

1. **gate 的寫入不污染 builder 交付的樹**——harvest 讀到的仍是 builder 自己的成果；
2. **快照在單一時點取得**——builder 留下的背景行程改不了 gate 跑到一半的樹（TOCTOU）。

**複製由 gate 自己執行**（`gate_ledger.snapshot_worktree`）：它是唯一同時讀得到來源
（`rX` ACL）、寫得進目的地（自己的 pool）的身分。Manager 在 `#641` 之後**讀不到**
builder 的樹，那條刻意不回頭放寬。symlink **原樣複製成 symlink、絕不跟隨**——跟隨會
把樹外內容複製進 gate 的可寫區，或走進無界遞迴。

## ledger 落點：`wx` 無 `r` 的 spool（不是直接寫 `gate-ledger`）

**選 spool。** 直接寫在兩個層面上都不成立：

1. **採信端會拒**——`#628` 的 `terminal_contract.foreign_evidence_author()` 檢查檔案
   擁有者，gate 寫出來的檔 owner 是 `cortex-gate`，會當場 `gate-ledger-foreign-author`
   被拒。要讓它被採信就得把 `#628` 拆掉。
2. **`gate-ledger` 同時是 exit sentinel 的落點**——開放寫入面等於讓一個跑 untrusted
   code 的帳號能偽造**任何** job 的完成狀態。

因此：gate 寫 `gate-ledger-spool` 的自己那一格 → Manager 讀它、**以不受信任輸入驗證**
→ Manager **自己重寫**一份權威 ledger 到 `gate-ledger`。作者歸屬與 `#628` 逐字不變。

**pre-seed 守衛沿用 `#639` 的 `coordinator/spool_slot.py`，不另寫一份**：
`create_slot(reset=True)`（整格重建＝預埋的人得到的是自己的檔案被刪掉，比「已存在即
拒絕」更強）、`publish_file`（`wx` 無 `r` 那一格上 consumer 讀不到 producer 建的檔）、
`seal_slot`（封的是**目錄**，因為 Manager `chmod` 不了 producer 擁有的檔）。

**Manager 對 spool 的驗證**：schema 嚴格、gate 名稱 MUST ⊆ operator 的 `PSC_GATE_CMD_*`
宣告集合、列數與 `detail` 長度有界、`status` 由 `exit_code` 重算（與採信端
`_ledger_outcomes()` 同一條紀律，只是往上游多做一次）。

## `_regenerate_gates_action` 怎麼收斂

它原本在 **Manager 進程內**直接呼叫 `gate_ledger.write_gate_ledger()`——等於以
`cortex-manager` 的身分在 builder 完全掌控的工作樹上跑 `pytest`。`direct` 下沒有邊界
可言，OS 隔離上線後它是一條**真的**提權路徑，而且是最容易被忽略的那一種：不在派工
熱路徑上，只在 operator 手動救援時才走到。

**改法不是在那裡另寫一套降權**，而是改呼叫 `gate_runner.run_declared_gates()`——自動
路徑（`manager.terminalize_workflow_job`）與它走**同一支**，因此不會出現「自動的那條
降權了、手動的那條還在 Manager 進程裡跑」。降權模式下 gate 起不來時**不退回 Manager
進程內執行**（那正是要移除的東西），診斷碼原樣回報讓 operator 修部署。

測試以原始碼比對釘死這件事（`RegenerateGatesConvergenceTests`）。

## permgen／polkit（沿用既有機制，沒有複製）

- **共用加固表**：`build_job_unit()` **一行都沒有為本票改**。`DOWNGRADED_JOB_PRINCIPALS`
  加一項 → `3 角色 × 2 剖面 ＝ 六份` unit，全部走同一張 `_HARDENING` 表與同一條
  `ReadWritePaths` 導出規則。測試以**字典比對**釘住（`GateHardeningParityTests`）。
- **polkit 單一交替 pattern**：字幹段由 `3 × 2` 機械導出，**不加第二條 `addRule`**，
  全檔仍只有一個 `return polkit.Result.YES`。字幹來源改為「**本方案實際落檔**的角色」
  （`downgraded_job_principals(scheme)`），因此 `three-way`／`two-way` 產出的規則不會
  提一份那台機器上不存在的 unit。
- **gate 的剖面由 operator 決定**（`PSC_GATE_HARDENING_PROFILE`，預設 `strict`，值不
  合法 fail-closed 不落回預設）。這與 `#643`「剖面不由呼叫端選」**不衝突**：`#643` 擋
  的是「job 能影響自己的剖面」，而 gate 沒有 executor 可導出——它跑的是 operator 自己
  宣告的命令，宣告命令卻不能宣告剖面才是不一致的。`prepare_systemd_template()` 因此
  **雙向強制**：gate 角色傳 executor 即拒、模型角色傳 `None` 即拒。

## 誠實邊界（spec §R3 新增段落）

**第四帳號買到的是圍堵，不是「ledger 不可偽造」。** 取得任意程式碼執行的 builder
依然能影響**自己那一份** ledger 的內容——那是「執行對方交出來的測試碼」這件事本身的
性質，換誰執行都一樣。

買到的是那個執行**碰不到**：Manager 的 durable state（含 exit sentinel）、builder 的
工作樹（只有 `rX`）、verdict／commit 通道、他人在 gate spool 的那一格（`wx` 無 `r`）、
以及任何 polkit grant；影響範圍限於它自己那一個 job 的 ledger。

spec 明載任何稽核或 PR 描述 **MUST NOT** 把它敘述成「gate ledger 不可被 builder
影響」。要做到那個需要「在不執行被驗方程式碼的前提下判定它」——那是 Phase 3 範疇。

## 測試

新增 `tests/test_gate_execution_identity_629.py`（58 測試，4 skipped）：

- **執行身分不變式**：gate 與既有三個帳號逐一不同；`JOB_PRINCIPAL_PERSONAS[GATE]` 機器
  可讀地斷言「沒有任何 persona 以 gate 起跑」；三個 launcher persona 的 `_job_role()`
  都不得是 gate。
- **三條「不能碰」**：`ReadWritePaths` 集合恆等於 `{cache, gate spool, gate worktree}`；
  逐條反證 Manager durable state／builder 工作區／verdict spool；反向驗 builder 與
  reviewer 也寫不進 gate 的兩棵樹。
- **pre-seed 守衛**：`create_slot(reset=True)` 是唯一實作（以 spy 釘住）；預埋的
  ledger 與雜物被刪掉；symlink 那一格被拒；封口後 mode 為 `0500`；spool key 與
  commit spool **同一個推導**。
- **polkit**：正向兩個字幹放行；**十種名稱混淆**（比照 `#647`）＋ transient 五形式 ＋
  其他 verb／subject 全拒；字幹段是封閉列舉（斷言不含 `.*`／`[^`／`\w`／`+`）；
  legacy scheme 不提 gate unit。
- **加固表**：六份 unit 鍵集合恆等於 `_HARDENING`；gate 與 builder **逐項字典相等**；
  剖面差異恆等於 `PROFILE_DIVERGENCE_KEYS`。
- **不受信任輸入**：未宣告的 gate 名／超量列數／畸形 payload 全拒；`exit_code` 覆寫
  自報 `status`；`detail` 截斷。
- **`direct` 零回歸**：走 in-process `write_gate_ledger`（以 spy 釘住）、不建任何 spool
  或副本、`ensure_gate_ledger` 為 no-op；非 build phase 與已存在的 ledger 一律不動。

**`#638` 的教訓**：四條在單 UID／寬鬆環境測不出來的語意**明確 skip 並說明理由**——
gate 對 builder 工作樹的 `rX` 是否真的成立、spool 的 `wx` 無 `r` 是否真的擋住讀取、
polkit 是否真的拒絕、gate unit 是否真的以 `uid=cortex-gate` 執行。不用 `sudo -u`／
裸跑當替身（那只會產生一個永遠綠、什麼都沒驗到的測試）。真實驗證在 runbook 第
5-2d／5-7／8b-3 步；具備條件的機器可設 `PSC_TEST_REAL_HARDENING=1`。

`python3 -m pytest tests/ -q` → **4003 passed, 12 skipped**。

## runbook（真實加固面下的驗證）

比照 `#642` 第 4e 步／`#643` 第 5-2b 步——**只驗寬鬆環境會整個溜過去**：

- 第 1 步：第四個帳號（含「為什麼不能用 `DynamicUser`」）、四帳號互不可讀的複驗；
- **5-2c**：兩份 gate 模板落檔 ＋ `diff` 對照 builder（差異必須只有帳號帶出來的那幾行）
  ＋ `ReadWritePaths` 恰好三條的逐條停損條件；
- **5-2d**：真實加固面下五條——(1) 真的以 `cortex-gate` 執行且 dispatch log 目錄 EROFS；
  (2) 讀得到 builder 工作樹但 `touch` 失敗；(3) 寫得進自己那格但 `ls` 失敗、別人那格
  連 traverse 都沒有；(4) 端到端後 ledger owner 必須是 `cortex-manager`、spool 已封口
  `0500`；(5) **負向對照**——拿掉 gate 的 ACL 之後 build 卡必須 fail closed；
- 5-4：polkit 六字幹的審查條件（含「沒有 `cortex-gate-job` ⇒ 你用的是舊 scheme」）；
- 5-5：`PSC_GATE_*` 設定 ＋ 「gate 的直譯器對 gate 帳號真的可執行」的複驗；
- **8b-3（族 7＝spec §R9 族 5）**：T5.1–T5.10 攻擊矩陣 ＋ 專屬 negative control；
- 全文 scheme token `three-way` → `four-way`，並附**三分機器的升級路徑**（只需建帳號、
  重跑權限 script、落兩份 unit ＋ 重跑 polkit；第 3／4 步完全不動）。

## 與 #615 的關係

**已 rebase 到 #652 merge 後的 main**，零衝突。本票沿用 M2 建立的三個機制而沒有複製
任何一段：`JOB_ROLE_CONFIG`（加第三列）、`DOWNGRADED_JOB_PRINCIPALS`（加第三項）、
`job_unit_stems`／`job_unit_pattern` 的多 principal 交替。

必要地動了三個既有測試：`test_reviewer_planner_downgrade_615.py`（M2 的
`test_only_two_roles_exist_no_gate_role_was_smuggled_in` 是**為本票留的守衛**，換成
「有第四個角色，而且它與前三個逐一不同」；計數斷言改為機械導出）、
`test_trust_root_job_template_ab.py`（預設方案的斷言改為「永遠是分得最細的那一個」
這個**性質**，另補三分明示無 gate 的測項）、
`test_trust_root_principal_account_mapping_626.py`（判準改綁 `DEFAULT_SCHEME`，另補
`ABSENT_ACCOUNT` 三態可分辨的測項）。

## 拆分

**沒有拆。** 曾考慮把「第四帳號的引入」獨立成一票，結論是不該拆：只有帳號沒有執行
路徑，等於在部署上多一個沒有任何消費者的帳號與兩棵空樹，而 build 卡仍然 fail closed
——`#629` 一個字都沒有被關掉；只有執行路徑沒有帳號則根本無法強制。兩者是同一個不變式
的兩半，分開 merge 的中間狀態沒有任何一個是可用的。

範圍上唯一刻意留在票外的是 `coordinator/verification.py` 的那組 check／test／
full-suite 命令（`repo-worktree` 的 note 記著它們「搬到 #629 的第三執行身分」）：它們
今天已由 `#641` 明確 fail-closed 成 `candidate-worktree-unreadable-pending-gate-identity`，
是**另一條**呼叫路徑、另一組判準，且不影響本票要解的 `require_ledger` 死結。

## Checklist

- [x] 分支不是 `main`（`feature/629-gate-execution-identity`）
- [x] `changelog.d/gate-execution-identity.md` fragment 已新增且已 commit
- [x] `CHANGELOG.md [Unreleased]` 有對應 entry（Added／Changed／Fixed／Security 四段）
- [x] 文件與 PR 一律 zh-tw
- [x] `python3 -m pytest tests/ -q` 全綠（4003 passed, 12 skipped）
- [x] `policy_check` 帶 PR 上下文跑，fail: 0
- [x] spec（`docs/superpowers/specs/trust-root-isolation-spec.md`）與 runbook
      （`docs/superpowers/runbooks/trust-root-phase2b-setup.md`）已同步
- [x] `VERSION` 未動（非 release PR）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E7w9kaUxAzCCEk7piD5hfK
