### PR TITLE
feat(coordinator): ship 段搬出 builder 的 clone——改在 Manager-owned 的樹裡 commit／preflight／push

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,45 @@
 ## [Unreleased]
 
 ### Added
+- **#653 / trust-root Phase 2b：ship 段搬出 builder 的 clone——降權模式下 canonical lane
+  終於跑得完整個 run**——#654 查證出的形狀：`openspec-archive`／`policy-commit`
+  **不是降權派工的對象**（persona 是 `manager`，`_dispatch_workflow_card()` 對 ship phase
+  一律回 `None`），它們由 Manager 自己在 `work_bridge` 內以 `cortex-manager` 身分同步
+  執行；但**全程在 `_builder_binding()` 交回來的 builder 的 clone 裡動手**
+  （`resolve(strict=True)`、canonical report 清理、`openspec archive` 的 `cwd`、
+  `git diff/add/commit/rev-parse`、preflight、`ls-remote/push`、`_ship_action` 連測試），
+  而 #641 已把 Manager 對 job 工作樹的讀取授權全部收掉 ⇒ 三分下**第一個 `git -C` 就
+  `Permission denied`**。症狀是權限不是 `226/NAMESPACE`。**修法**：新增
+  `work_bridge._manager_ship_workspace()`，以 `run.candidate_head` 為 base、用
+  `seams.ScriptWorktreeCreator` 在來源樹上 provision 一棵 **Manager-owned 的完整 clone**
+  ——來源樹是 `cortex-manager` 擁有且可寫（0817 裁決），commit／preflight／push 全在自己的
+  樹裡發生，**不需要**任何指向 job 工作樹的 ACL（#644 的紅線：那條授權唯一的消費端本身
+  就是提權路徑，不得復活）。`_builder_binding()` 改為**只回 delivery branch**，選 job 的
+  採信鏈一個位元組沒改。工作區識別穩定於 **(run, candidate)**：同一個 candidate 的多次
+  tick 重用同一棵樹（ship phase 會 tick 很多次，每次 clone 35MB 是白燒），candidate 前進
+  則換一棵、前一棵原地留著——它正是 archive 卡 job 記錄上的 `worktree`，post-archive 的
+  verify／review 卡仍以它為 candidate 樹，回收交給 `cortex work gc`。
+  **`archive-applied-needs-commit` 重入路徑**（#653 明載）兩層處置：同一次 `validate()`
+  內套用與 commit 結構上就在同一棵樹；跨 tick 則在重用前 `checkout -f`／`reset --hard`／
+  `clean -ffdx` 打回 pristine 並以 `_require_pristine_ship_workspace()` 驗 branch／HEAD／
+  乾淨——取票上「在新樹裡重跑 archive」那條，讓「崩在中間」與「從沒跑過」收斂成同一個
+  狀態。`_remove_canonical_untracked_reports()` **移除**：它讀／刪的正是 builder 的 clone，
+  而 pristine clone 讓「report 弄髒 exact candidate」在結構上不再可能，改由開工前的不變式
+  承擔同一個保證；`manager._workflow_report_cleanup_allows_missing()` 保留為向後相容容忍面
+  並補上說明。**回收通道一個位元組沒改**——archive commit 仍走 #654 的 bundle ＋
+  append-only spool，consumer 仍是全 repo 唯一的 `harvest_branch()`；沒有 `--reference`／
+  `--shared`、沒有 `git -C <來源樹> fetch <job 的 clone>`。新增
+  `tests/test_ship_out_of_builder_clone_653.py`（7 條 ＋ 1 skip，全部跑正式路徑）：核心
+  不變式是把 builder 的 clone `chmod 000` 後 ship 段仍跑完（#637 範本），另含工作區身分、
+  重用＋pristine、重入路徑、archive→policy-commit 接續、`matches_candidate()` ancestry
+  守衛、`direct` 零回歸；OS 層語意（`0700 cortex-builder` vs `cortex-manager`、pool 零
+  `setfacl`）單 UID 測不出來，**明確 skip 並說明**，skip 前先斷言可測的那一半（#638 的
+  教訓）。突變驗證：把工作區改回 builder 的樹 ⇒ 8 條紅 7 條，chmod 那條逐字紅在
+  `PermissionError(13, 'Permission denied')`。runbook 的 `%i` 稽核段同步改寫（ship 段已可
+  在降權模式下跑完，並附上 ship 樹的實機稽核指令）。**附帶發現留給後續票**：兩張 ship 卡的
+  `runtime_capabilities`（#442）因為不 dispatch 在生產環境同樣無法生效；verify／review 卡
+  的 `workflow_repo_root` 仍是 builder 的 clone（#650）。
+  詳見 `changelog.d/ship-out-of-builder-clone.md`。
 - **#629 / gate 執行身分：第四個帳號 `cortex-gate`（`UidScheme` 三分 → 四分）**——
   `#604`／PR `#628` 把 gate ledger 與 exit sentinel 的**作者**收斂到 Manager，但刻意
   沒做執行面：operator 宣告的 gate 命令（`PSC_GATE_CMD_*`）在 **builder 完全掌控內容的

--- a/changelog.d/ship-out-of-builder-clone.md
+++ b/changelog.d/ship-out-of-builder-clone.md
@@ -1,0 +1,181 @@
+# Issue #653：ship 段全程在 builder 的 clone 裡動手——#641 收掉讀取授權後，降權模式下第一個 `git -C` 就 `Permission denied`
+
+## 問題（#654 已查證，與 #649 票面上的假設不同）
+
+`openspec-archive`／`policy-commit` **不是降權派工的對象**：兩張卡的 persona 是
+`manager`，而 `manager._dispatch_workflow_card()` 對 `current_phase == "ship"` 一律回
+`None`——它們不經 launcher、不 spawn job，由 Manager 自己在 `work_bridge.py` 內以
+`cortex-manager` 身分同步執行。因此**沒有 template unit、沒有 `ReadWritePaths=<pool>/%i`、
+沒有 `226/NAMESPACE`**。
+
+真正的阻擋物是**權限**：ship 段全程在 `_builder_binding()` 交回來的 **builder 的
+clone** 裡動手——
+
+| 位置 | 動作 |
+|---|---|
+| `_builder_binding()` | `Path(worktree).resolve(strict=True)` |
+| `_remove_canonical_untracked_reports()` | 讀／刪工作區內的 canonical report |
+| `work_actions._validate_local_archive_inputs()` ＋ `openspec archive` | `cwd=<那棵樹>` |
+| `_commit_archive_and_require_reverification()` | `git -C <那棵樹> diff/add/commit/rev-parse` |
+| `_run_exact_candidate_preflight()` | preflight 在那棵樹跑 |
+| `_push_exact_candidate()` | `git -C <那棵樹> ls-remote/push` |
+| `work_actions._ship_action(repo_root=…)` | 連測試都在那棵樹跑 |
+
+Phase 2b 三分下那棵樹是 `cortex-builder` 擁有的 `0700` clone，而 **#641 已把登記表裡
+Manager 對 job 工作樹殘留的讀取授權全部收掉**（runbook 第 2 步的稽核 5b 要求
+`/var/lib/cortex/worktree/` 底下零 `setfacl`）⇒ 降權模式下 ship phase 會在**第一個
+`git -C`** 就 `Permission denied`。本 PR 的突變驗證逐字重現了這句話（見「測試」）。
+
+**不得把那條 ACL 加回來**：#644 的論證是那條授權唯一的消費端（在 builder 掌控的樹裡
+執行命令）本身就是一條提權路徑；加回來等於把它復活。
+
+## 修法：ship 段 provision 一棵自己的 Manager-owned clone
+
+`work_bridge._manager_ship_workspace()`：以 `run.candidate_head` 為 base，用
+`seams.ScriptWorktreeCreator` 在**來源樹**上 clone 一份。來源樹
+`/var/lib/cortex/repos/<slug>` 是 `cortex-manager` 擁有且可寫（0817 裁決），Manager 對
+自己 clone 出來的樹自然是 owner——commit／preflight／push 全部沒有權限問題，也**不需要**
+任何指向 job 工作樹的 ACL。creator 的兩道既有守衛在這條 lane 上剛好就是要的：
+
+- `rev-parse --verify <candidate>^{commit}`：來源樹必須已經有這個 commit——那正是
+  #654 的回收通道所保證的不變式。回收沒走完就 provision 不起來，而不是在很遠的地方
+  以看不懂的訊息炸開。
+- `merge-base --is-ancestor <branch> <candidate>`：delivery branch 不得帶著 candidate
+  以外的 commit。
+
+`_builder_binding()` **只回 delivery branch**，不再回（也不再 `resolve()`）那個 job 的
+工作區：它真正不可取代的職責是**採信鏈**——foreign review 指名的那一個 builder（或
+post-archive 的 manager archive）job 必須是 `subject_head == candidate` 的那一筆。選 job
+的那一段**一個位元組沒改**。
+
+### 工作區的識別與生命週期
+
+識別 `_ship_workspace_id()` 穩定於 **(run, candidate)**（形如
+`wf-<run 摘要>-ship-<candidate 前綴>`，目錄名仍由唯一推導點 `job_workspace.job_segment()`
+導出）。兩個直接後果：
+
+- **同一個 candidate 的多次 tick 共用同一棵樹**。ship phase 會被 tick 很多次（等
+  preflight、等 PR、等 copilot、等 merge），每次都 clone 一份 35MB 是白燒。
+- **candidate 前進就換一棵**，前一棵原地留著——它正是 `_record_manager_ship_job()` 記在
+  archive 卡上的 `worktree`，post-archive 的 verify／review 卡仍以
+  `builder_jobs[-1]["worktree"]` 當 candidate 樹（`manager._dispatch_workflow_card()`）。
+  **ship 段因此不自己刪樹**，回收交給 `cortex work gc`，與 build 卡的 clone 同一套。
+
+### `archive-applied-needs-commit` 的重入路徑（#653 明載必須一併處理）
+
+`_ship_action()` 可能在工作區裡把 archive 套用完但沒 commit，`work_bridge` 才回頭呼叫
+`_commit_archive_and_require_reverification()`。票上點出：若那時才另開一棵乾淨的 clone，
+已套用但未 commit 的異動會不見 ⇒ `changed` 為空 ⇒
+`archive diff escaped strict OpenSpec/docs/changelog allowlist`。
+
+處置分兩層，取的是票上兩個選項中的「**在新樹裡重跑 archive**」：
+
+1. **同一次 `validate()` 內**兩件事本來就在同一棵樹——工作區在 `validate()` 開頭
+   provision 一次，`_ship_action()` 與後續的 commit 拿到的是同一個 `worktree`。這是
+   結構性的，不靠約定。
+2. **跨 tick**（上一次崩在中間）：`_manager_ship_workspace()` 重用既有樹之前一律
+   `checkout -f`／`reset --hard <candidate>`／`clean -ffdx` 打回 pristine，再以
+   `_require_pristine_ship_workspace()` 驗證 branch／HEAD／乾淨三條。套用 archive 對同一
+   個 candidate 是完全可重現的確定性動作，重跑一次比帶著來歷不明的 dirty 檔往下走安全
+   得多——而且讓「崩在中間」與「從沒跑過」收斂成同一個狀態。已 commit 但**還沒回收**的
+   archive commit 同樣被丟掉：回收是採信發生的唯一時點，沒回收就沒有任何下游依賴它。
+
+### `_remove_canonical_untracked_reports()` 移除
+
+那個函式的用意是「reviewer 發佈在 candidate 樹裡的未追蹤 report 不得弄髒要 commit 的
+exact candidate」。它讀／刪的正是 **builder 的 clone**——本票要消滅的東西。新模型下 ship
+段拿到的是一棵 pristine clone，未追蹤檔根本不會被 clone 過去，「候選樹被 report 弄髒」
+在**結構上**不再可能發生。因此改為由開工前的
+`_require_pristine_ship_workspace()`（branch 對、HEAD ＝ candidate、`status --porcelain`
+為空）承擔同一個保證，原函式與它的 `report-cleanup` evidence 產生路徑一併移除。
+
+`manager._workflow_report_cleanup_allows_missing()` **保留**為向後相容的容忍面（升級當下
+正在進行、已寫過該 evidence 的 run 仍要走得完），並補上 docstring 說明它已無產生端；沒有
+那份 evidence 時仍一律 fail-closed。副作用是 report 從此留在 verify／review 卡自己的
+`workflow_repo_root` 裡，`_read_job_workflow_evidence()` 的 artifact 校驗因此**不再**需要
+走容忍路徑——比刪掉它更不脆弱。
+
+## 紅線遵守
+
+- **沒有**把 Manager 對 job 工作樹的 ACL 加回來（#644）；ship 的樹是 Manager 自己 clone
+  的，`getfacl` 下不該有任何具名條目，稽核 5b 的「零 `setfacl`」仍然成立。
+- **沒有** `--reference`／`--shared`／任何把 object store 接回共用的優化（#623 判定共用
+  object store 與三分隔離互斥）。
+- **沒有** `git -C <來源樹> fetch <某棵 job 的 clone>`。archive commit 回到來源樹走的是
+  #654 的 bundle ＋ append-only spool，consumer 仍是全 repo 唯一的
+  `job_workspace.harvest_branch()`——本 PR 對回收通道**一個位元組都沒改**。
+
+## 測試
+
+新增 `tests/test_ship_out_of_builder_clone_653.py`（7 條 ＋ 1 條 skip，全部跑正式路徑：
+真 git repo、真 per-job clone、真 `build_production_ship_validator()`、真
+`ScriptWorktreeCreator`、真 `_run_exact_candidate_preflight()`）。harness 取自
+`test_preflight_closeout_order`——repo 內唯一一份真的把 production ship validator 端到端
+跑起來的 fixture，複製一份只會讓兩邊漂移。
+
+- **本票的全部價值**：把 builder 的 clone `chmod 000`（＝實機上 `0700 cortex-builder` 對
+  Manager 的樣子），ship 段仍完整跑完 local closeout、archive commit 回收進來源樹，而那
+  棵 clone 的 active change 與 HEAD 一個位元組沒動。形狀沿用 #637 的
+  `test_manager_never_touches_the_builder_clone_while_harvesting`。
+- **工作區身分**：pool 底下、`is_job_clone()` 為真、標記檔的 `branch`／`base` 對得上、
+  `.git` 是目錄（不得退回 linked worktree），且 `openspec archive` 只在那棵樹裡被套用過
+  （假 runner 改成以呼叫端給的 `cwd` 為準，那才是真 `openspec archive` 的行為）。
+- **重用 ＋ pristine**：同一個 candidate 連續兩次進入拿到同一棵樹（標記檔的
+  `created_at` 沒變 ⇒ 沒有重新 clone），而上一輪留下的「已套用未 commit 的 archive ＋
+  雜物」被打回原狀。
+- **`archive-applied-needs-commit` 重入**：把 run 推到「archive 已宣告完成、PR 已綁定」
+  ——那是 `_ship_action()` 回這個 action 的唯一入口——驗證 archive 套用與 commit 落在
+  **同一棵** Manager-owned 樹裡，回收成立，且 builder 的 clone 全程沒動。
+- **`openspec-archive` → `policy-commit` 接續**：archive 卡的 job 記錄就是後續會綁到的
+  那一筆，其 `worktree` 是 ship 樹且**仍在磁碟上**（post-archive 的 verify／review 卡要
+  用），ship audit 兩張卡皆 passed。範本為 #654 的同名測試，改走 validator 的正式路徑。
+- **`matches_candidate()` 的 ancestry 別弄壞**：archive 之後以 archive commit 為 base 用
+  真的 `ScriptWorktreeCreator` provision repair clone（#651 post-archive `retry-build` 的
+  回歸守衛）、做 descendant、經 bundle 回收，祖先關係在來源樹上驗得出來，ship audit 走
+  得通。
+- **`direct` 零回歸**：`PSC_JOB_RUNNER` 兩種值下走完全相同的路徑，七項結構性事實逐項
+  相等（#634 的「以形狀判斷，不依旗標分支」；本 PR 沒有引入任何依該旗標的分支）。
+- **#638 的教訓**：真正要驗的是 OS 層語意——builder 的 clone 為 `0700 cortex-builder`、
+  ship 段以 `cortex-manager` 執行、pool 底下零 `setfacl`。單 UID 的開發機與 CI 三者皆無
+  （同 UID 下 owner 隨時 `chmod` 回去，root 更完全不受限）⇒ **明確 `pytest.skip` 並說明
+  理由**，skip 之前先斷言可測的那一半（工作區是這個行程 clone 的、獨立 object store、
+  不是 linked worktree）。權限面的端到端驗證屬 runbook 的實機稽核。
+
+**突變驗證**（兩次）：
+
+1. 把 `validate()` 的工作區改回「builder job 記錄的那棵樹」⇒ 8 條紅 7 條，其中 chmod
+   那條紅在 **`PermissionError(13, 'Permission denied')`**——本票要修的生產症狀逐字現場；
+   另外三條紅在 `archive diff escaped strict OpenSpec/docs/changelog allowlist`
+   （report 弄髒 candidate）與 `repo_root origin remote must match requested repo`。
+2. 拿掉重用前的 pristine reset ⇒ 重用那條紅在殘留的 `leftover.txt` 還在。
+
+既有測試的更新都是同一件事的直接後果：三個假 runner 原本寫死「archive／push／preflight
+發生在哪棵樹」，改成以呼叫端實際給的 `cwd`／`-C`／`repo_root` 為準——那本來就是真指令的
+行為，寫死一棵樹測到的是 fixture 自己的形狀。`test_delivery_report_cleanup_rejects_hash_drift_without_deleting`
+隨被移除的函式一併刪除。
+
+`python3 -m pytest tests/ -q`：**4017 passed, 14 skipped**（已 rebase 到含 #655／#629
+四分帳號的 main）。#655 改的是 gate **執行身分**（`gate_runner.run_declared_gates()`、
+`gate-ledger-spool`、`gate-worktree`），落在 build／verify 的 terminal 採信路徑上；
+ship 段不讀 gate ledger（`work_bridge` 內零 `ledger` 引用），兩者不相交，rebase 後
+全套與兩個相關檔案（`test_gate_execution_identity_629.py`／本檔）皆綠。
+
+## 未做的實機驗證
+
+`PSC_JOB_RUNNER=systemd-template` 下跑完一個含 ship phase 的 run **尚未實機執行**——本機
+不是部署機。runbook 的 `%i` 稽核段已補上 ship 樹的實機稽核指令（owner ＝
+`cortex-manager`、`getfacl` 具名條目數為 0）。
+
+## 附帶發現：留給後續票
+
+`deck/data/cards.yaml` 給兩張 ship 卡宣告的
+`runtime_capabilities: ["provider:github:…", "provider:executor"]`（#369／#442）掛在
+`_runtime_preflight_gate` 上，而那在 dispatch 路徑內——ship 卡不 dispatch，那兩條宣告在
+生產環境**無法生效**，#442 的「先在 ship-phase 兩張卡觀測」因此觀測不到任何東西。本 PR
+不處理：讓它生效需要決定「不 dispatch 的卡怎麼套 capability gate」，那是 capability 模型
+的設計題，不是工作區歸屬問題。
+
+另一個相鄰缺口（同樣不在本票範圍）：verify／review 卡的 `workflow_repo_root` 仍是
+**builder 的 clone**（`manager._dispatch_workflow_card()` 的
+`builder_jobs[-1]["worktree"]`），因此那條路徑在降權模式下仍會撞上同一堵牆——那是 #650
+的範圍，兩票的收斂點是同一個「candidate 樹從哪來」。

--- a/docs/superpowers/plans/fix-preflight-closeout-order.md
+++ b/docs/superpowers/plans/fix-preflight-closeout-order.md
@@ -27,7 +27,11 @@ work_item: fix-preflight-closeout-order
 
 ### 3. ship validator 三段重排（local closeout 前移）
 
-- [ ] `paulsha_cortex/coordinator/work_bridge.py`：`build_production_ship_validator` 的 `validate`（line 1378）重排——在 `_builder_binding`／`_remove_canonical_untracked_reports`（line 1403-1415）之後、`_pr_metadata`（line 1416）之前插入 local closeout 段：builder worktree 的 `openspec/changes/<change>` 目錄存在時，呼叫 `work_actions._validate_local_archive_inputs`（`work_actions.py:108`）→ 執行官方 archive argv → `_commit_archive_and_require_reverification`（line 783）→ 回傳 `candidate-reverification-required` trusted 結果。change slug 取自 `load_work_authority` 的 `mapped_openspec`（validate 內已有 authority，line 1395-1399），不依賴 `_ship_binding` 的 `pr_number`。
+- [ ] `paulsha_cortex/coordinator/work_bridge.py`：`build_production_ship_validator` 的 `validate`（line 1378）重排——在 `_builder_binding` 與 canonical report 清理（line 1403-1415）之後、`_pr_metadata`（line 1416）之前插入 local closeout 段：工作區的 `openspec/changes/<change>` 目錄存在時，呼叫 `work_actions._validate_local_archive_inputs`（`work_actions.py:108`）→ 執行官方 archive argv → `_commit_archive_and_require_reverification`（line 783）→ 回傳 `candidate-reverification-required` trusted 結果。change slug 取自 `load_work_authority` 的 `mapped_openspec`（validate 內已有 authority，line 1395-1399），不依賴 `_ship_binding` 的 `pr_number`。
+  > 事後註記（#653）：ship 段已改為在 **Manager-owned 的 pristine clone** 裡動手，
+  > 那棵樹不可能帶著 reviewer 發佈的未追蹤 report，上述「canonical report 清理」
+  > 那一步因此連同它的實作一併移除，改由 `_require_pristine_ship_workspace()` 這條
+  > 開工前不變式承擔同一個保證。本行的行號與函式清單保留當時的現場記錄。
 - [ ] `_pr_metadata`（line 1416）、初次 preflight（line 1427-1437）、push（line 1438）、PR 建立（line 1449）、既有 PR preflight＋push（line 1487-1524）與 `_ship_action`（line 1567）全部保持在 local closeout 段之後執行；`_ship_action` 內的 archive 段（`work_actions.py:2904-2924`）與 remote archive 檢查（`work_actions.py:2955-2956`）原樣保留。
 - [ ] 驗收：task 1 的 `test_ship_validate_completes_local_archive_closeout_without_pr_binding` 與 `test_stage_order_closeout_then_preflight_then_ship` 全綠。
 

--- a/docs/superpowers/runbooks/trust-root-phase2b-setup.md
+++ b/docs/superpowers/runbooks/trust-root-phase2b-setup.md
@@ -2072,12 +2072,24 @@ systemctl cat cortex-job@.service | grep -E "^ReadWritePaths=/var/lib/cortex/wor
 #   在 `work_bridge` 內以 deterministic 身分執行，它的 commit 走的是 #649 補上的
 #   回收通道（bundle ＋ commit-spool → 來源樹的 `refs/heads/<branch>`）。
 #
-#   **ship phase 目前仍不可在降權模式下跑完**：它全程在 `_builder_binding()` 交回來的
-#   **builder 的 clone** 裡動手（`git commit`／preflight／push／`_ship_action`），而
-#   #641 已把登記表裡 Manager 對 job 工作樹的讀取授權全部收掉（見第 2 步的稽核 5b）
-#   ⇒ 三分下第一個 `git -C` 就會 `Permission denied`。症狀是**權限**不是
-#   `226/NAMESPACE`，別往 mount namespace 的方向查。修法（ship 段搬進 Manager-owned
-#   的樹）在 #653。
+#   #653（已修）：ship 段在此之前全程在 `_builder_binding()` 交回來的 **builder 的
+#   clone** 裡動手（`git commit`／preflight／push／`_ship_action`），而 #641 已把
+#   登記表裡 Manager 對 job 工作樹的讀取授權全部收掉（見第 2 步的稽核 5b）⇒ 降權部署
+#   下（三分／四分皆然）第一個 `git -C` 就會 `Permission denied`。症狀是**權限**不是
+#   `226/NAMESPACE`，別往 mount namespace 的方向查。現在 ship 段以 `run.candidate_head`
+#   為 base，在
+#   來源樹上 provision 一棵**自己的 Manager-owned clone**（目錄名同樣由
+#   `job_workspace.job_segment()` 導出，形如 `wf-<run 摘要>-ship-<candidate 前綴>-…`），
+#   commit／preflight／push 全在那裡發生，**不需要**任何指向 job 工作樹的授權。
+#
+#   實機稽核：ship phase 跑過之後，pool 底下會多出 ship 卡自己的目錄，且
+#     stat -c '%U %a' /var/lib/cortex/worktree/wf-*-ship-*
+#   期望：`cortex-manager 700`（Manager 自己 clone 的，不是 job 帳號的）。
+#     getfacl -p /var/lib/cortex/worktree/wf-*-ship-* | grep -c '^user:'
+#   期望：`0`——ship 的樹不需要任何具名 ACL 條目；稽核 5b 的「零 `setfacl`」因此
+#   仍然成立。這些目錄與 build 卡的 clone 走同一套回收（`cortex work gc`，branch
+#   merge 後才回收），不由 ship 段自己刪：archive 卡的 job 記錄指著它，
+#   post-archive 的 verify／review 卡仍以它為 candidate 樹。
 
 # ✅ 檢查 unit 沒有被忽略的鍵（#645 附帶；#643 起兩份都要驗）
 sudo systemd-analyze verify /etc/systemd/system/cortex-job@.service \

--- a/paulsha_cortex/coordinator/manager.py
+++ b/paulsha_cortex/coordinator/manager.py
@@ -5902,6 +5902,15 @@ def _workflow_report_cleanup_allows_missing(
     ref: str,
     expected_hash: str,
 ) -> bool:
+    """已發佈的 canonical report 不在 `repo_root` 時，是否有 Manager 的刪除意圖佐證。
+
+    #653 之後**產生**這種 evidence 的路徑已經沒有了：ship 段改在自己的 pristine
+    clone 裡動手，不再需要（也不再有權）到 job 的工作樹裡刪 report，因此「報告缺席」
+    不再是交付流程製造出來的正常狀態。本函式保留為**向後相容的容忍面**——升級當下
+    正在進行、已經寫過 `report-cleanup` evidence 的 run 仍要走得完。沒有那份 evidence
+    時一律回 False（缺席 ＝ artifact drift，fail-closed），語意與過去逐條相同。
+    """
+
     directory = coordinator_root / "evidence" / "report-cleanup"
     if directory.is_symlink() or not directory.is_dir():
         return False

--- a/paulsha_cortex/coordinator/work_bridge.py
+++ b/paulsha_cortex/coordinator/work_bridge.py
@@ -685,12 +685,34 @@ def _builder_binding(
     *,
     state_root: Path,
     foreign_ref,
-) -> tuple[Path, str]:
+) -> str:
     """Use the foreign-review edge to select the exact builder job.
 
     A feature workflow legitimately has several build cards, so counting all
     successful build jobs is ambiguous. The terminal review evidence names the
     one builder job whose candidate it actually reviewed.
+
+    #653：回傳的是 **delivery branch**，不是那個 job 的工作區。
+
+    這個函式原本回 `(Path(row["worktree"]).resolve(strict=True), branch)`，而
+    ship 段接著就在那棵樹裡 `git diff`／`add`／`commit`／`rev-parse`／`push`、跑
+    preflight、跑 `_ship_action` 的測試。Phase 2b 三分下那棵樹是 `cortex-builder`
+    擁有的 `0700` clone，而 **#641 已把登記表裡 Manager 對 job 工作樹殘留的讀取
+    授權全部收掉**（runbook 稽核 5b 要求 `/var/lib/cortex/worktree/` 底下零
+    `setfacl`）⇒ 降權模式下 ship phase 會在**第一個 `git -C`** 就
+    `Permission denied`。
+
+    **不得把那條 ACL 加回來**：#644 的論證是那條授權唯一的消費端（在 builder
+    掌控的樹裡執行命令）本身就是一條提權路徑。因此改成「ship 段自己 provision
+    一棵 Manager-owned 的樹」（:func:`_manager_ship_workspace`），而這個函式只保留
+    它真正不可取代的職責——**採信鏈**：foreign review 指名的那一個 builder（或
+    post-archive 的 manager archive）job，必須是 `subject_head == candidate` 的
+    那一筆，delivery branch 由它決定。
+
+    `row["worktree"]` 因此**刻意不再被讀**：ship 段不需要它，而讀它就等於重新
+    宣告一次「Manager 進得去 job 的樹」這個已被撤銷的前提。連
+    `Path(...).resolve(strict=True)` 都不做——那會讓一棵已被 `cortex work gc`
+    回收的工作區把一條合法的交付卡死。
     """
 
     from . import review
@@ -734,12 +756,200 @@ def _builder_binding(
         or row.get("subject_head") != candidate
     ):
         raise RuntimeError("delivery requires the reviewed exact-candidate builder job")
-    worktree = row.get("worktree")
     branch = row.get("branch")
-    if not isinstance(worktree, str) or not isinstance(branch, str) or not branch:
+    if not isinstance(branch, str) or not branch:
         raise RuntimeError("builder delivery binding malformed")
-    root = Path(worktree).resolve(strict=True)
-    return root, branch
+    return branch
+
+
+def _ship_workspace_id(run, candidate: str) -> str:
+    """ship 段那棵 Manager-owned 工作區的識別（#653）——**唯一推導點**。
+
+    形狀與 `_manager_ship_job_task()` 對齊（`wf-<run 摘要>-…`），但多帶
+    candidate 的前綴：ship 段的工作區是綁在 **(run, 這個 candidate)** 上的，而
+    `openspec-archive` 一旦回收成功，`candidate_head` 就會前進到 archive commit
+    ——下一輪 ship 因此拿到**另一個**識別、另一棵樹，前一棵原地留著（它正是
+    `_record_manager_ship_job()` 記在 archive 卡上的 `worktree`，post-archive 的
+    verify／review 卡仍以它為 candidate 樹，見
+    `manager._dispatch_workflow_card()` 的 `builder_jobs[-1]["worktree"]`）。
+
+    反過來說，**同一個 candidate 的每一次 ship tick 共用同一棵樹**：ship phase 會
+    被 tick 很多次（等 preflight、等 PR、等 copilot、等 merge），每次都 clone 一
+    份 35MB 是白燒；而識別穩定之後「這棵樹是不是我的」就有一條可驗證的判準
+    （工作區標記檔的 `branch`／`base`），不必靠猜。
+    """
+
+    if verification.SAFE_SHA_RE.fullmatch(candidate) is None:
+        raise ValueError("ship workspace candidate is invalid")
+    digest = hashlib.sha256(run.run_id.encode()).hexdigest()[:10]
+    return f"wf-{digest}-ship-{candidate[:12]}"
+
+
+def _require_pristine_ship_workspace(worktree: Path, *, branch: str, candidate: str) -> None:
+    """ship 段開工前的三條不變式：branch 對、HEAD ＝ candidate、工作區乾淨。
+
+    這三條是 ship 段其餘每一步的前提，集中在這裡驗一次而不是散在各處：
+
+    - **branch**：`_push_exact_candidate()` 推的是 `HEAD:refs/heads/<branch>`，而
+      `_harvest_manager_ship_commit()` 的回收 refspec 也是 `refs/heads/<branch>`
+      ——detached HEAD 或 checkout 在別條 branch 上時兩者都會搬錯東西。
+    - **HEAD ＝ candidate**：archive commit 必須恰好長在被採信的 candidate 上。
+    - **乾淨**：archive 的 allowlist 判準是 `git diff HEAD` ＋
+      `ls-files --others`，任何開工前就存在的殘留都會被算進那個集合。這條同時
+      取代了舊模型裡 `_remove_canonical_untracked_reports()` 的角色——那時 ship
+      段借用 builder 的 clone，reviewer 發佈在裡面的 canonical report 是**未追蹤
+      檔**，必須先刪掉才不會弄髒 exact candidate；現在 ship 段有自己的 pristine
+      clone，「候選樹被 report 弄髒」在結構上不再可能發生。
+    """
+
+    for argv, expected, failure in (
+        (["symbolic-ref", "--quiet", "--short", "HEAD"], branch, "branch"),
+        (["rev-parse", "HEAD"], candidate, "head"),
+    ):
+        probe = subprocess.run(
+            ["git", "-C", str(worktree), *argv],
+            shell=False,
+            capture_output=True,
+            text=True,
+        )
+        if probe.returncode != 0 or probe.stdout.strip().lower() != expected.lower():
+            raise RuntimeError(f"manager ship workspace {failure} mismatch")
+    status = subprocess.run(
+        ["git", "-C", str(worktree), "status", "--porcelain"],
+        shell=False,
+        capture_output=True,
+        text=True,
+    )
+    if status.returncode != 0 or status.stdout.strip():
+        raise RuntimeError("manager ship workspace is not pristine")
+
+
+def _reset_ship_workspace(worktree: Path, *, branch: str, candidate: str) -> bool:
+    """把一棵**既有的** ship 工作區打回 `candidate` 的原狀；做不到就回 False。
+
+    ship 段的每一次進入都要求 pristine（見
+    :func:`_require_pristine_ship_workspace`）。前一次 tick 可能在裡面套用了
+    `openspec archive` 卻在 commit 之前掛掉——#653 明載的
+    `archive-applied-needs-commit` 重入路徑就是這條。**新模型的處置是「在新樹裡
+    重跑 archive」**（票上給的兩個選項之一）：套用 archive 是一個對同一個
+    candidate 完全可重現的確定性動作，把樹打回原狀再跑一次，比帶著一堆來歷不明
+    的 dirty 檔往下走安全得多，也讓「崩在中間」與「從沒跑過」收斂成同一個狀態。
+
+    已經 commit、但**還沒回收**的 archive commit 同樣被丟掉——那是對的：回收
+    （`_harvest_manager_ship_commit()`）是採信這件事發生的唯一時點，沒回收就代表
+    沒有任何下游依賴它，重做一次得到的是等價的 commit。回收**成功**之後
+    `candidate_head` 才前進，那時識別已經換了一個（見 :func:`_ship_workspace_id`），
+    根本走不到這裡。
+
+    best-effort：任何一步失敗都回 False，由呼叫端整棵重建，不在這裡 raise。
+    """
+
+    for argv in (
+        ["checkout", "--quiet", "--force", "-B", branch, candidate],
+        ["reset", "--quiet", "--hard", candidate],
+        ["clean", "-qffdx"],
+    ):
+        done = subprocess.run(
+            ["git", "-C", str(worktree), *argv],
+            shell=False,
+            capture_output=True,
+            text=True,
+        )
+        if done.returncode != 0:
+            return False
+    try:
+        _require_pristine_ship_workspace(worktree, branch=branch, candidate=candidate)
+    except RuntimeError:
+        return False
+    return True
+
+
+def _manager_ship_workspace(
+    *,
+    run,
+    branch: str,
+    candidate: str,
+    creator=None,
+) -> Path:
+    """#653：ship 段動手的那棵樹——**Manager-owned**，不是 builder 的 clone。
+
+    ## 為什麼一定要換一棵樹
+
+    ship 段（`openspec-archive`／`policy-commit`／preflight／push／`_ship_action`）
+    不是降權派工的對象：`manager._dispatch_workflow_card()` 對 ship phase 一律回
+    `None`，這兩張卡由 Manager 自己在本模組內以 `cortex-manager` 身分同步執行
+    （查證見 #654）。但它們原本全程在 `_builder_binding()` 交回來的 **builder 的
+    clone** 裡動手，而 #641 已把 Manager 對 job 工作樹的讀取授權全部收掉 ⇒ 降權
+    模式下第一個 `git -C` 就 `Permission denied`。**症狀是權限，不是 mount
+    namespace。**
+
+    ## 形狀
+
+    以 `run.candidate_head`（＝這一輪被採信的 candidate）為 base、用
+    `seams.ScriptWorktreeCreator` 在**來源樹**上 provision 一份自己的完整 clone。
+    來源樹 `/var/lib/cortex/repos/<slug>` 是 `cortex-manager` 擁有且可寫（0817
+    裁決），Manager 對自己 clone 出來的樹自然是 owner——commit／preflight／push
+    全部沒有權限問題，也**不需要**任何指向 job 工作樹的 ACL。
+
+    creator 的兩道既有守衛在這條 lane 上剛好就是我們要的：
+
+    - `rev-parse --verify <candidate>^{commit}`：來源樹必須已經有這個 commit
+      ——那正是 #654 的 build／ship 回收通道所保證的不變式。回收沒走完就 provision
+      不起來，而不是在很遠的地方以看不懂的訊息炸開。
+    - `merge-base --is-ancestor <branch> <candidate>`：來源樹的 delivery branch
+      不得帶著 candidate 以外的 commit。
+
+    ## 生命週期
+
+    識別由 :func:`_ship_workspace_id` 決定（穩定於 (run, candidate)）：同一個
+    candidate 的多次 tick 重用同一棵樹（重用前一律打回 pristine，見
+    :func:`_reset_ship_workspace`），candidate 前進時換一棵新的。**不在這裡刪**
+    ——archive 卡的 job 記錄指著這棵樹，post-archive 的 verify／review 卡仍以
+    `builder_jobs[-1]["worktree"]` 當 candidate 樹；回收交給 `cortex work gc`，
+    與 build 卡的 clone 同一套。
+
+    ## 紅線
+
+    沒有 `--reference`／`--shared`／任何把 object store 接回共用的優化（#623 判定
+    共用 object store 與三分隔離互斥），也沒有「Manager fetch 一棵 job 的 clone」
+    （`job_workspace` 模組 docstring 已判定該形狀在三分下結構性不成立）。archive
+    commit 回到來源樹走的是 #654 的 bundle ＋ append-only spool，consumer 仍是全
+    repo 唯一的 `job_workspace.harvest_branch()`。
+    """
+
+    from . import seams
+
+    source_repo = getattr(run, "workspace_root", None)
+    if not isinstance(source_repo, str) or not source_repo:
+        raise RuntimeError("manager ship workspace source repo missing")
+    source = Path(source_repo)
+    pool = paths.worktree_root_for(source)
+    workspace_id = _ship_workspace_id(run, candidate)
+    target = job_workspace.workspace_path(pool, workspace_id)
+    if target.is_symlink() or (target.exists() and not target.is_dir()):
+        raise RuntimeError("manager ship workspace path is not a directory")
+    if target.is_dir():
+        marker = job_workspace.read_marker(target)
+        reusable = (
+            job_workspace.is_job_clone(target)
+            and isinstance(marker, dict)
+            and marker.get("branch") == branch
+            and str(marker.get("base", "")).lower() == candidate.lower()
+        )
+        if reusable and _reset_ship_workspace(
+            target, branch=branch, candidate=candidate
+        ):
+            return target
+        if not job_workspace.is_job_clone(target):
+            # 認不出這是什麼就**不刪**（#478 的爆炸半徑教訓）。這條路徑只該在
+            # operator 手動放了東西進 pool 時走到。
+            raise RuntimeError("manager ship workspace path is occupied")
+        job_workspace.remove_clone(target)
+    if creator is None:
+        creator = seams.ScriptWorktreeCreator(repo=source, wt_root=pool, base="main")
+    created = Path(creator.create(branch, job_id=workspace_id, base_sha=candidate))
+    _require_pristine_ship_workspace(created, branch=branch, candidate=candidate)
+    return created
 
 
 def _manager_archive_applied(run) -> bool:
@@ -1294,132 +1504,6 @@ def _workflow_evidence_payload(
     return payload, job
 
 
-def _remove_canonical_untracked_reports(
-    *,
-    registry,
-    state_root: Path,
-    run,
-    worktree: Path,
-) -> None:
-    """Remove only exact, canonical report publications before delivery.
-
-    Reviewer reports are Manager-owned evidence material rather than Candidate
-    tree content.  They are needed while subsequent review cards snapshot their
-    inputs, but must not make the exact committed Candidate dirty at delivery.
-    Unknown, tracked, symlinked, stale, or hash-drifted paths remain a hard stop.
-    A hash-addressed cleanup intent makes a Manager-completed deletion replayable.
-    """
-
-    trusted: dict[str, str] = {}
-    for job in registry.list_jobs():
-        phase = job.get("workflow_phase")
-        locator = job.get("workflow_evidence")
-        if (
-            job.get("workflow_run_id") != run.run_id
-            or phase not in {"verify", "review"}
-            or job.get("subject_head") != run.candidate_head
-            or job.get("status") != "exited"
-            or job.get("exit_code") != 0
-            or not isinstance(locator, dict)
-            or not isinstance(locator.get("path"), str)
-            or not isinstance(locator.get("hash"), str)
-        ):
-            continue
-        evidence_ref = state_root / str(locator["path"])
-        envelope, _validated_job = _workflow_evidence_envelope(
-            registry=registry,
-            state_root=state_root,
-            run=run,
-            phase=str(phase),
-            expected_ref=str(evidence_ref),
-            expected_hash=str(locator["hash"]),
-        )
-        phase_root = f"reports/{'verify' if phase == 'verify' else 'review'}/"
-        for artifact in envelope["artifacts"]:
-            if (
-                not isinstance(artifact, dict)
-                or set(artifact) != {"path", "sha256", "baseline_sha256"}
-                or not isinstance(artifact.get("path"), str)
-                or not artifact["path"].startswith(phase_root)
-                or not isinstance(artifact.get("sha256"), str)
-                or re.fullmatch(r"[0-9a-f]{64}", str(artifact["sha256"])) is None
-                or artifact.get("baseline_sha256") is not None
-                and (
-                    not isinstance(artifact.get("baseline_sha256"), str)
-                    or re.fullmatch(
-                        r"[0-9a-f]{64}", str(artifact["baseline_sha256"])
-                    ) is None
-                )
-            ):
-                raise RuntimeError("canonical workflow report artifact malformed")
-            relative = Path(str(artifact["path"]))
-            if relative.is_absolute() or ".." in relative.parts:
-                raise RuntimeError("canonical workflow report path escapes repo")
-            # JobRegistry is append-ordered; a retry publication supersedes the
-            # prior canonical body at the same report path.
-            trusted[relative.as_posix()] = str(artifact["sha256"])
-
-    cleanup_payload = {
-        "schema": "cortex-workflow-report-cleanup/v1",
-        "run_id": run.run_id,
-        "candidate": run.candidate_head,
-        "reports": [
-            {"path": path, "sha256": sha256}
-            for path, sha256 in sorted(trusted.items())
-        ],
-    }
-    cleanup_digest = verification.canonical_json_hash(cleanup_payload)
-    cleanup_path = (
-        state_root.resolve() / "evidence" / "report-cleanup" / f"{cleanup_digest}.json"
-    )
-    cleanup_started = cleanup_path.exists() or cleanup_path.is_symlink()
-    if cleanup_started and (
-        cleanup_path.is_symlink()
-        or not cleanup_path.is_file()
-        or cleanup_path.stat().st_mode & 0o222
-    ):
-        raise RuntimeError("workflow report cleanup evidence is not immutable")
-
-    removals: list[Path] = []
-    for relative, expected_hash in sorted(trusted.items()):
-        path = worktree / relative
-        if not path.exists() and not path.is_symlink():
-            if cleanup_started:
-                continue
-            raise RuntimeError("canonical workflow report is missing before cleanup")
-        if path.is_symlink() or not path.is_file():
-            raise RuntimeError("canonical workflow report path is not a regular file")
-        resolved = path.resolve(strict=True)
-        try:
-            resolved.relative_to(worktree)
-        except ValueError as exc:
-            raise RuntimeError("canonical workflow report path escapes worktree") from exc
-        actual = hashlib.sha256(resolved.read_bytes()).hexdigest()
-        if actual != expected_hash:
-            raise RuntimeError("canonical workflow report hash drift")
-        tracked = subprocess.run(
-            ["git", "-C", str(worktree), "ls-files", "--error-unmatch", "--", relative],
-            shell=False,
-            capture_output=True,
-            text=True,
-        )
-        if tracked.returncode == 0:
-            raise RuntimeError("canonical workflow report unexpectedly tracked")
-        if tracked.returncode != 1:
-            raise RuntimeError("canonical workflow report tracking state unavailable")
-        removals.append(resolved)
-
-    if trusted:
-        _write_json_evidence(state_root, "report-cleanup", cleanup_payload)
-    for path in removals:
-        path.unlink()
-        directory_fd = os.open(path.parent, os.O_RDONLY | os.O_DIRECTORY)
-        try:
-            os.fsync(directory_fd)
-        finally:
-            os.close(directory_fd)
-
-
 def _run_exact_candidate_preflight(
     *,
     worktree: Path,
@@ -1675,8 +1759,15 @@ def build_production_ship_validator(
     runner: Callable[..., object] = subprocess.run,
     now: Callable[[], float] = time.time,
     snapshot_path: str | Path | None = None,
+    workspace_creator=None,
 ):
-    """Bind review completion to the authenticated, resumable delivery state machine."""
+    """Bind review completion to the authenticated, resumable delivery state machine.
+
+    `workspace_creator` 是 ship 段那棵 Manager-owned 工作區的 provisioning seam
+    （#653）。留 `None` 時由 `_manager_ship_workspace()` 依 `run.workspace_root`
+    自行組一個 `seams.ScriptWorktreeCreator`——生產路徑不必也不應該由呼叫端指定
+    工作區從哪來。
+    """
 
     state_root = Path(coordinator_root).resolve()
 
@@ -1705,18 +1796,21 @@ def build_production_ship_validator(
         expected_issues = tuple(f"{run.repo}#{number}" for number in authority.mapped_issues)
         if run.issue_refs != expected_issues or run.openspec_refs != authority.mapped_openspec:
             raise RuntimeError("WorkflowRun refs differ from current WorkAuthority")
-        worktree, branch = _builder_binding(
+        branch = _builder_binding(
             registry,
             run,
             candidate,
             state_root=state_root,
             foreign_ref=foreign[0],
         )
-        _remove_canonical_untracked_reports(
-            registry=registry,
-            state_root=state_root,
+        # #653：ship 段從這一行起全部在 **Manager-owned** 的樹裡動手。以下每一段
+        # （archive 套用／commit／回收、preflight、push、`_ship_action` 連測試）
+        # 拿到的都是這棵樹，**沒有任何一處**再指向 builder 的 clone。
+        worktree = _manager_ship_workspace(
             run=run,
-            worktree=worktree,
+            branch=branch,
+            candidate=candidate,
+            creator=workspace_creator,
         )
         change = authority.mapped_openspec[0] if len(authority.mapped_openspec) == 1 else None
         active_change = worktree / "openspec" / "changes" / str(change) if change else None

--- a/tests/test_preflight_closeout_order.py
+++ b/tests/test_preflight_closeout_order.py
@@ -71,6 +71,8 @@ class SpyRunner:
     ) -> None:
         self.repo = repo
         self.calls: list[list[str]] = []
+        #: #653：`openspec archive` 實際被套用在哪幾棵樹上（不變式測試用）。
+        self.archived_in: list[Path] = []
         self.remote_head: str | None = None
         self.metadata_preflight_returncode = metadata_preflight_returncode
         self.pr_preflight_returncode = pr_preflight_returncode
@@ -83,7 +85,11 @@ class SpyRunner:
         if command[:2] == ["openspec", "validate"]:
             return RunnerResult(0)
         if command[:2] == ["openspec", "archive"]:
-            self._apply_archive(command[-1])
+            #: #653：archive 的效果落在**呼叫端指定的 `cwd`** 上，不是 fixture 記
+            #: 住的某一棵樹。ship 段搬進 Manager-owned 工作區之後，那個 cwd 才是
+            #: 真的會被 commit 的樹；假 runner 若仍寫死一棵樹，測到的是 fixture
+            #: 自己的形狀而不是產品的。
+            self._apply_archive(command[-1], cwd=kwargs.get("cwd"))
             return RunnerResult(0)
         if command[:2] == ["git", "-C"] and "ls-remote" in command:
             if self.remote_head is None:
@@ -118,9 +124,11 @@ class SpyRunner:
                 )
         return subprocess.run(command, **kwargs)
 
-    def _apply_archive(self, change: str) -> None:
-        active = self.repo / "openspec" / "changes" / change
-        archived = self.repo / "openspec" / "changes" / "archive" / change
+    def _apply_archive(self, change: str, *, cwd: str | None = None) -> None:
+        root = Path(cwd) if cwd else self.repo
+        self.archived_in.append(root)
+        active = root / "openspec" / "changes" / change
+        archived = root / "openspec" / "changes" / "archive" / change
         if active.exists():
             archived.parent.mkdir(parents=True, exist_ok=True)
             shutil.move(str(active), str(archived))
@@ -604,7 +612,13 @@ def test_ship_validate_completes_local_archive_closeout_without_pr_binding(
     assert updated.current_phase == "verify"
     assert updated.candidate_head is not None and updated.candidate_head != harness.candidate
     assert updated.pr_refs == ()
-    assert not (harness.worktree / "openspec" / "changes" / "work").exists()
+    # #653：archive 套用在 **Manager-owned 的 ship 工作區**裡，builder 的 clone
+    # 一個位元組沒動——那正是 #641 收掉讀取授權之後唯一可行的形狀。
+    assert (harness.worktree / "openspec" / "changes" / "work").is_dir()
+    assert harness.runner.archived_in and all(
+        root != harness.worktree and root != harness.repo
+        for root in harness.runner.archived_in
+    )
     # #649：archive commit 已回收進來源樹的 delivery branch。
     assert (
         job_workspace.source_branch_head(harness.repo, "feature/14-work")

--- a/tests/test_ship_out_of_builder_clone_653.py
+++ b/tests/test_ship_out_of_builder_clone_653.py
@@ -1,0 +1,565 @@
+"""#653：ship 段從 builder 的 clone 搬進 Manager-owned 的樹。
+
+本檔全部跑**正式路徑**：真 git repo、真 per-job clone、真
+`work_bridge.build_production_ship_validator()`、真 `seams.ScriptWorktreeCreator`、
+真 `_run_exact_candidate_preflight()`。不手動 `git push`、不自己捏工作區。
+
+問題（#654 查證出來的）：ship 段不是降權派工的對象——兩張 ship 卡由 Manager 自己
+在 `work_bridge` 內以 `cortex-manager` 身分同步執行；但它們全程在
+`_builder_binding()` 交回來的 **builder 的 clone** 裡動手，而 #641 已把 Manager 對
+job 工作樹的讀取授權全部收掉 ⇒ 降權模式下 ship phase 會在**第一個 `git -C`** 就
+`Permission denied`。**症狀是權限，不是 mount namespace。**
+
+本檔的第一條測試就是這件事的機械形式：把 builder 的 clone `chmod 000`（＝實機上
+`0700 cortex-builder` 對 Manager 的樣子），ship 段仍必須完整跑完。形狀沿用 #637 的
+`test_manager_never_touches_the_builder_clone_while_harvesting`。
+
+共用 harness 取自 `test_preflight_closeout_order`——那是 repo 內唯一一份「真的把
+production ship validator 端到端跑起來」的 fixture，複製一份只會讓兩邊漂移。
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from paulsha_cortex.config.paths import worktree_root_for
+from paulsha_cortex.coordinator import (
+    job_workspace,
+    manager,
+    seams,
+    work_actions,
+    work_bridge,
+)
+from paulsha_cortex.coordinator.claim import load_work_authority
+
+from test_preflight_closeout_order import (  # noqa: E402
+    ShipHarness,
+    _capture,
+    _ship_harness,
+)
+
+
+def _git(repo: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", "-C", str(repo), *args], check=True, capture_output=True, text=True
+    ).stdout.strip()
+
+
+def _with_real_ship_cards(harness: ShipHarness):
+    """把共用 harness 的佔位 `ship-card` 換成真的兩張 ship 卡。
+
+    `_manager_archive_applied()` 與 `_validated_ship_steps()` 都以 **card id** 定址
+    （`openspec-archive`／`policy-commit`），佔位卡在那兩處等於「這個 run 沒有
+    ship 卡」。需要走 archive 宣告或 ship audit 的測試必須先補上。
+    """
+
+    from paulsha_cortex.coordinator.workflow import WorkflowStep
+
+    run = harness.registry.get_workflow_run(harness.run_id)
+    return harness.registry._manager_update_workflow_run(
+        run.run_id,
+        steps=tuple(step for step in run.steps if step.phase != "ship")
+        + (
+            WorkflowStep("ship", "manager", "openspec-archive", None, None, None, (), ()),
+            WorkflowStep("ship", "manager", "policy-commit", None, None, None, (), ()),
+        ),
+    )
+
+
+def _ship_workspace(harness: ShipHarness, candidate: str) -> Path:
+    """這一輪 ship 段實際使用的 Manager-owned 工作區（由產品的推導點算出來）。"""
+
+    return job_workspace.workspace_path(
+        worktree_root_for(harness.repo),
+        work_bridge._ship_workspace_id(harness.run, candidate),
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. 本票的全部價值：ship 段不碰 builder 的樹
+# ---------------------------------------------------------------------------
+
+@pytest.mark.skipif(os.geteuid() == 0, reason="root 不受目錄權限限制，這條不變式驗不到")
+def test_ship_phase_completes_while_the_builder_clone_is_unreadable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """把 builder 的 clone `chmod 000`，ship 段仍要跑完 local closeout。
+
+    以 `chmod 000` 重現 operator 實機看到的形狀（clone 為 `0700 cortex-builder`，
+    Manager 連 `ls` 都 `Permission denied`）。本票之前這裡必炸——ship 段的第一個
+    動作就是對那棵樹 `resolve(strict=True)` 然後一路 `git -C` 下去。
+    """
+
+    harness = _ship_harness(
+        tmp_path, monkeypatch, active_change=True, archived_change=False
+    )
+    os.chmod(harness.worktree, 0o000)
+    try:
+        # 前提成立：這棵樹現在真的進不去（等同實機的 Permission denied）。
+        assert (
+            subprocess.run(
+                ["git", "-C", str(harness.worktree), "status"],
+                capture_output=True,
+            ).returncode
+            != 0
+        )
+        outcome = _capture(
+            harness.validator, run=harness.run, candidate=harness.candidate
+        )
+    finally:
+        os.chmod(harness.worktree, 0o700)
+
+    updated = harness.registry.get_workflow_run(harness.run_id)
+
+    assert outcome.exception is None
+    assert isinstance(outcome.result, dict)
+    assert outcome.result["reason"] == "archive-commit-invalidated-candidate-evidence"
+    assert updated.current_phase == "verify"
+    assert updated.candidate_head not in (None, harness.candidate)
+    # archive commit 走 #654 的 bundle ＋ spool 回到來源樹（consumer 仍是
+    # `harvest_branch()`，全 repo 唯一實作）。
+    assert (
+        job_workspace.source_branch_head(harness.repo, "feature/14-work")
+        == updated.candidate_head
+    )
+    # builder 的 clone 原封不動：active change 還在，也沒有多出任何 commit。
+    assert (harness.worktree / "openspec" / "changes" / "work").is_dir()
+    assert _git(harness.worktree, "rev-parse", "HEAD") == harness.candidate
+
+
+def test_ship_workspace_is_a_manager_owned_clone_bound_to_run_and_candidate(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """ship 段的樹是 pool 裡一棵 Manager-owned 的 per-job clone，不是 builder 的。
+
+    同時釘住 `openspec archive` 實際落在哪棵樹上——那是「搬家」有沒有真的發生的
+    唯一直接證據（`_ship_action`／`_commit_archive_and_require_reverification`
+    都拿同一個 `worktree`）。
+    """
+
+    harness = _ship_harness(
+        tmp_path, monkeypatch, active_change=True, archived_change=False
+    )
+    workspace = _ship_workspace(harness, harness.candidate)
+
+    outcome = _capture(harness.validator, run=harness.run, candidate=harness.candidate)
+
+    assert outcome.exception is None
+    assert workspace.is_dir()
+    assert workspace != harness.worktree
+    assert workspace.parent == worktree_root_for(harness.repo).resolve()
+    # 形狀是 per-job clone（自己的 object store ＋ 工作區標記檔），不是 linked
+    # worktree、也不是來源樹本身。
+    assert job_workspace.is_job_clone(workspace)
+    assert (workspace / ".git").is_dir()
+    marker = job_workspace.read_marker(workspace)
+    assert marker is not None
+    assert marker["branch"] == "feature/14-work"
+    assert marker["base"] == harness.candidate
+    # archive 只在那棵樹裡被套用過。
+    assert harness.runner.archived_in == [workspace]
+    assert not (workspace / "openspec" / "changes" / "work").exists()
+
+
+def test_ship_workspace_is_reused_across_ticks_and_reset_to_pristine(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """同一個 candidate 的多次 tick 共用同一棵樹，且每次進入都是 pristine。
+
+    ship phase 會被 tick 很多次（等 preflight、等 PR、等 copilot、等 merge）。
+    識別穩定於 (run, candidate) 因此不會每 tick 燒一份 clone；而**開工前一律打回
+    原狀**，讓「上一次崩在中間」與「從沒跑過」收斂成同一個狀態——這正是
+    `archive-applied-needs-commit` 重入路徑在新模型下的處置方式（票上兩個選項中的
+    「在新樹裡重跑 archive」）。
+    """
+
+    harness = _ship_harness(
+        tmp_path, monkeypatch, active_change=True, archived_change=False
+    )
+    expected = _ship_workspace(harness, harness.candidate)
+
+    first = work_bridge._manager_ship_workspace(
+        run=harness.run, branch="feature/14-work", candidate=harness.candidate
+    )
+    assert first == expected
+    marker_created_at = job_workspace.read_marker(first)["created_at"]
+
+    # 模擬「上一個 tick 崩在中間」：工作區留下已套用但未 commit 的 archive 異動
+    # ＋ 一份雜物；下一次進入必須看不到它們。
+    archived = first / "openspec" / "changes" / "archive"
+    archived.mkdir(parents=True, exist_ok=True)
+    (first / "openspec" / "changes" / "work").rename(archived / "work")
+    (first / "leftover.txt").write_text("junk\n", encoding="utf-8")
+    assert _git(first, "status", "--porcelain") != ""
+
+    second = work_bridge._manager_ship_workspace(
+        run=harness.run, branch="feature/14-work", candidate=harness.candidate
+    )
+
+    assert second == first
+    # 同一棵樹（沒有重新 clone——標記檔還是第一次寫的那一份）。
+    assert job_workspace.read_marker(second)["created_at"] == marker_created_at
+    # 但已被打回 candidate 的原狀。
+    assert not (second / "leftover.txt").exists()
+    assert (second / "openspec" / "changes" / "work").is_dir()
+    assert _git(second, "rev-parse", "HEAD") == harness.candidate
+    assert _git(second, "status", "--porcelain") == ""
+    assert _git(second, "symbolic-ref", "--short", "HEAD") == "feature/14-work"
+
+
+# ---------------------------------------------------------------------------
+# 2. `archive-applied-needs-commit` 重入路徑
+# ---------------------------------------------------------------------------
+
+def _bind_pr_and_mark_archive_applied(harness: ShipHarness):
+    """把 run 推到「archive 已宣告完成、PR 已綁定」的狀態。
+
+    這正是 `_ship_action()` 回 `archive-applied-needs-commit` 的**唯一**入口：
+    `validate()` 的早期 local-closeout 段以 `_manager_archive_applied(run)` 為守衛，
+    該值為真時就會跳過那一段，改由 `_ship_action()` 在 PR 段裡發現工作區仍有
+    active change、套用 archive、然後把球丟回 `work_bridge`。
+
+    順帶把 authority／journal 一起推到 PR 已建立之後的形狀（PR 是前一個 tick 建的，
+    delivery journal 那一筆因此已經存在），否則 push 段會先在
+    `delivery push journal missing canonical run` 上停下來，測不到重入路徑。
+    """
+
+    from dataclasses import replace
+
+    from paulsha_cortex.coordinator.claim import work_authority_digest
+
+    from test_preflight_closeout_order import _snapshot
+
+    _snapshot(harness.snapshot, mapped_prs=(17,))
+    authority = work_bridge._authority_with_manager_pr(
+        load_work_authority(
+            repo="acme/demo", work_id="work", snapshot_path=harness.snapshot
+        ),
+        17,
+    )
+    run = _with_real_ship_cards(harness)
+    run = harness.registry._manager_update_workflow_run(
+        run.run_id,
+        pr_refs=("acme/demo#17",),
+        source_revision=work_authority_digest(authority),
+        steps=tuple(
+            replace(
+                step,
+                executor="cortex-manager",
+                model="deterministic",
+                domain="cortex",
+                gate_result="passed",
+            )
+            if step.phase == "ship" and step.card == "openspec-archive"
+            else step
+            for step in run.steps
+        ),
+    )
+    work_actions._load_work_run(
+        state_path=harness.state_root / "delivery-journal.json",
+        workflow_registry=harness.registry,
+        authority=authority,
+    )
+    return run
+
+
+def test_archive_applied_needs_commit_reentry_commits_in_the_manager_tree(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """重入路徑：`_ship_action()` 在工作區套用 archive → 同一棵樹裡被 commit。
+
+    #653 明載這條必須一起處理：套用與 commit 若不在同一棵樹，
+    `_commit_archive_and_require_reverification()` 會看到一個乾淨的樹（`changed`
+    為空）而落到 `archive diff escaped strict OpenSpec/docs/changelog allowlist`。
+    新模型下兩者都拿 `validate()` 開頭那一次 provisioning 的結果，因此結構上就是
+    同一棵——本測試把它釘住。
+    """
+
+    harness = _ship_harness(
+        tmp_path, monkeypatch, active_change=True, archived_change=False
+    )
+    _bind_pr_and_mark_archive_applied(harness)
+    workspace = _ship_workspace(harness, harness.candidate)
+
+    outcome = _capture(
+        harness.validator, run=harness.run, candidate=harness.candidate
+    )
+    updated = harness.registry.get_workflow_run(harness.run_id)
+
+    assert outcome.exception is None
+    assert isinstance(outcome.result, dict)
+    assert outcome.result["reason"] == "archive-commit-invalidated-candidate-evidence"
+    # 走的是 `_ship_action()` 的重入路徑：PR 段已經跑過（push 與 gh 都發生了），
+    # 而不是 `validate()` 開頭那一段 local closeout。
+    assert harness.runner.saw_push()
+    # archive 套用在 ship 的工作區裡，commit 也在那裡——同一棵樹。
+    assert harness.runner.archived_in == [workspace]
+    assert updated.candidate_head not in (None, harness.candidate)
+    assert _git(workspace, "rev-parse", "HEAD") == updated.candidate_head
+    # 且已回收：來源樹的 delivery branch 就是新 candidate。
+    assert (
+        job_workspace.source_branch_head(harness.repo, "feature/14-work")
+        == updated.candidate_head
+    )
+    # builder 的 clone 全程沒動。
+    assert (harness.worktree / "openspec" / "changes" / "work").is_dir()
+    assert _git(harness.worktree, "rev-parse", "HEAD") == harness.candidate
+
+
+# ---------------------------------------------------------------------------
+# 3. archive → policy-commit 的接續，與 `matches_candidate()` 的 ancestry 前提
+# ---------------------------------------------------------------------------
+
+def test_archive_to_policy_commit_handoff_binds_the_archive_job(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """archive 卡的 job 記錄就是後續 ship 段會綁到的那一筆。
+
+    `_builder_binding()` 現在只回 branch，但**選 job 的那一段一個位元組沒改**
+    ——archive 之後被指名的就是 archive 卡自己。這條是本票最容易回歸的一條
+    （範本為 #654 的同名測試，改成走 validator 的正式路徑）。
+    """
+
+    harness = _ship_harness(
+        tmp_path, monkeypatch, active_change=True, archived_change=False
+    )
+    _with_real_ship_cards(harness)
+    workspace = _ship_workspace(harness, harness.candidate)
+
+    assert _capture(
+        harness.validator, run=harness.run, candidate=harness.candidate
+    ).exception is None
+    updated = harness.registry.get_workflow_run(harness.run_id)
+    archive_head = str(updated.candidate_head)
+
+    archive_jobs = [
+        job
+        for job in harness.registry.list_jobs()
+        if job.get("workflow_run_id") == harness.run_id
+        and job.get("workflow_phase") == "ship"
+        and job.get("workflow_card") == "openspec-archive"
+    ]
+    assert len(archive_jobs) == 1
+    archive_job = archive_jobs[0]
+    assert archive_job["subject_head"] == archive_head
+    assert archive_job["branch"] == "feature/14-work"
+    assert archive_job["persona"] == "manager"
+    assert archive_job["executor"] == "cortex-manager"
+    # #653：記在 archive 卡上的工作區是 **Manager-owned 的 ship 樹**，不是
+    # builder 的 clone。post-archive 的 verify／review 卡以
+    # `builder_jobs[-1]["worktree"]` 當 candidate 樹，因此這棵樹不得在 ship 段
+    # 結束時被刪掉（回收交給 `cortex work gc`，與 build 卡的 clone 同一套）。
+    assert archive_job["worktree"] == str(workspace)
+    assert workspace.is_dir()
+    assert workspace != harness.worktree
+
+    # policy-commit 記在同一棵樹、同一個 candidate 上，且 ship audit 兩張卡皆 passed。
+    run = harness.registry._manager_update_workflow_run(
+        updated.run_id, current_phase="review", verified_head=archive_head
+    )
+    work_bridge._record_manager_ship_job(
+        registry=harness.registry,
+        state_root=harness.state_root,
+        run=run,
+        worktree=workspace,
+        branch="feature/14-work",
+        card="policy-commit",
+        old_head=archive_head,
+        new_head=archive_head,
+    )
+    audited = manager._validated_ship_steps(
+        harness.registry,
+        run=run,
+        candidate=archive_head,
+        coordinator_root=harness.state_root,
+    )
+    assert all(step.gate_result == "passed" for step in audited if step.phase == "ship")
+
+
+def test_post_archive_repair_still_provisions_and_passes_ship_audit(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`matches_candidate()` 的 ancestry 分支在搬家之後仍然成立。
+
+    #654 剛把這條檢查的**前提**修好（archive commit 進來源樹）。本票換掉的是
+    archive commit 是在哪棵樹裡做出來的，回收通道一個位元組沒改——這條因此是
+    「別弄壞它」的守衛：以 archive commit 當 base 還能 provision（#651 的
+    post-archive `retry-build`），且 final candidate 對 archive commit 的祖先關係
+    在**來源樹**上驗得出來，ship audit 走得通。
+    """
+
+    harness = _ship_harness(
+        tmp_path, monkeypatch, active_change=True, archived_change=False
+    )
+    _with_real_ship_cards(harness)
+    assert _capture(
+        harness.validator, run=harness.run, candidate=harness.candidate
+    ).exception is None
+    archive_head = str(harness.registry.get_workflow_run(harness.run_id).candidate_head)
+
+    # post-archive repair：以 archive commit 為 base 重新 provision（creator 的第一
+    # 道守衛就是在來源樹 `rev-parse --verify <base>`），做出 descendant 並回收。
+    creator = seams.ScriptWorktreeCreator(
+        repo=harness.repo, wt_root=tmp_path / "repair-pool", base="main"
+    )
+    repair = Path(
+        creator.create("feature/14-work", job_id="wf-repair-1", base_sha=archive_head)
+    )
+    (repair / "repair.txt").write_text("repair\n", encoding="utf-8")
+    _git(repair, "add", "repair.txt")
+    _git(repair, "commit", "-qm", "fix review finding")
+    final = _git(repair, "rev-parse", "HEAD")
+    bundle = job_workspace.prepare_commit_spool(
+        spool_key="wf-repair-1", coordinator_root=harness.state_root
+    )
+    job_workspace.publish_commit_bundle(
+        workspace=repair, bundle=bundle, branch="feature/14-work", exclude=archive_head
+    )
+    assert (
+        job_workspace.harvest_branch(
+            source_repo=str(harness.repo), bundle=bundle, branch="feature/14-work"
+        )
+        == final
+    )
+    assert (
+        subprocess.run(
+            [
+                "git", "-C", str(harness.repo), "merge-base", "--is-ancestor",
+                archive_head, final,
+            ],
+            capture_output=True,
+        ).returncode
+        == 0
+    )
+
+    run = harness.registry._manager_update_workflow_run(
+        harness.run_id,
+        current_phase="review",
+        candidate_head=final,
+        verified_head=final,
+    )
+    work_bridge._record_manager_ship_job(
+        registry=harness.registry,
+        state_root=harness.state_root,
+        run=run,
+        worktree=repair,
+        branch="feature/14-work",
+        card="policy-commit",
+        old_head=final,
+        new_head=final,
+    )
+
+    audited = manager._validated_ship_steps(
+        harness.registry,
+        run=run,
+        candidate=final,
+        coordinator_root=harness.state_root,
+    )
+    assert all(step.gate_result == "passed" for step in audited if step.phase == "ship")
+
+
+# ---------------------------------------------------------------------------
+# 4. direct 零回歸 ／ 單 UID 測不到的那一半
+# ---------------------------------------------------------------------------
+
+def test_ship_workspace_has_no_runner_mode_branch(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`direct` 零回歸：本票沒有引入任何依 `PSC_JOB_RUNNER` 的分支。
+
+    #634 的原則——以形狀判斷，不依旗標分支。兩種 runner mode 下走的是同一條路徑，
+    結構性結果逐項相等（commit 的 SHA 兩邊本來就不同：不同的 tmp repo、不同的
+    時間戳，因此比的是事實而不是字面值）。
+    """
+
+    observed = {}
+    for index, mode in enumerate(("direct", "systemd-template")):
+        monkeypatch.setenv("PSC_JOB_RUNNER", mode)
+        (tmp_path / f"case-{index}").mkdir()
+        harness = _ship_harness(
+            tmp_path / f"case-{index}",
+            monkeypatch,
+            active_change=True,
+            archived_change=False,
+        )
+        workspace = _ship_workspace(harness, harness.candidate)
+        outcome = _capture(
+            harness.validator, run=harness.run, candidate=harness.candidate
+        )
+        updated = harness.registry.get_workflow_run(harness.run_id)
+        observed[mode] = {
+            "raised": outcome.exception is not None,
+            "phase": updated.current_phase,
+            "advanced": updated.candidate_head != harness.candidate,
+            "harvested": job_workspace.source_branch_head(
+                harness.repo, "feature/14-work"
+            )
+            == updated.candidate_head,
+            "manager_owned_workspace": job_workspace.is_job_clone(workspace),
+            "archived_in_ship_tree": harness.runner.archived_in == [workspace],
+            "builder_clone_untouched": (
+                harness.worktree / "openspec" / "changes" / "work"
+            ).is_dir(),
+        }
+
+    assert observed["direct"] == observed["systemd-template"]
+    assert observed["direct"] == {
+        "raised": False,
+        "phase": "verify",
+        "advanced": True,
+        "harvested": True,
+        "manager_owned_workspace": True,
+        "archived_in_ship_tree": True,
+        "builder_clone_untouched": True,
+    }
+
+
+def test_builder_clone_ownership_boundary_is_not_single_uid_testable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """真正的邊界是 **OS 層**的，單 UID 測不出來——明確 skip（#638 的教訓）。
+
+    生產上 builder 的 clone 是 `0700 cortex-builder`、ship 段以 `cortex-manager`
+    執行，兩者是不同 UID；`chmod 000` 只是那個形狀的**近似**（同 UID 下 owner 隨時
+    `chmod` 回去就繞過了，而且 root 完全不受限）。同理，「Manager 對 job 工作樹零
+    `setfacl`」（#641 runbook 稽核 5b）是登記表與檔案系統 ACL 的性質，本機與 CI
+    都沒有那些帳號，任何模擬與真部署無關。
+
+    skip 之前先斷言**可測的那一半**：ship 段拿到的工作區在來源樹自己的 pool 底下、
+    是 Manager 這個行程 clone 出來的，與 builder 的樹是兩個獨立的 object store
+    ——那是「不需要任何指向 job 工作樹的授權」這件事在單 UID 下唯一驗得到的形式。
+    """
+
+    harness = _ship_harness(
+        tmp_path, monkeypatch, active_change=False, archived_change=True
+    )
+    workspace = _ship_workspace(harness, harness.candidate)
+    assert _capture(
+        harness.validator, run=harness.run, candidate=harness.candidate
+    ).exception is None
+
+    assert workspace.is_dir() and workspace != harness.worktree
+    assert workspace.stat().st_uid == os.geteuid(), "ship 工作區不是這個行程建的"
+    assert (workspace / ".git" / "objects").is_dir(), "不是獨立 object store"
+    assert not (workspace / ".git").is_file(), "不得退回 linked worktree（#623）"
+
+    pytest.skip(
+        "真正要驗的是 OS 層語意：builder 的 clone 為 `0700 cortex-builder`、ship 段"
+        "以 `cortex-manager` 執行，且 `/var/lib/cortex/worktree/` 底下零 `setfacl`"
+        "（#641 runbook 稽核 5b）。單 UID 的開發機與 CI 兩者皆無——此處 ship 段與"
+        "builder 的樹同屬一個 uid，`chmod` 回去就繞過了，模擬出來的結果與真部署無關。"
+        "可測的那一半（工作區是 Manager 自己 clone 的獨立 object store）已在 skip "
+        "之前斷言；權限面的端到端驗證屬 runbook 的實機稽核"
+    )

--- a/tests/test_work_bridge.py
+++ b/tests/test_work_bridge.py
@@ -10,6 +10,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from paulsha_cortex.config import paths
 from paulsha_cortex.control.contract import build_request
 from paulsha_cortex.coordinator import (
     completion,
@@ -457,20 +458,24 @@ def test_ship_adapter_creates_pr_after_metadata_preflight_and_binds_same_run(
     assert updated.pr_refs == ("acme/demo#17",)
     assert updated.source_revision != run.source_revision
     assert updated.planning_source_revision == initial_source_revision
-    assert not report.exists()
-    assert plan.is_file()
-    assert subprocess.run(
-        ["git", "-C", str(repo), "branch", "--list", "feature/preflight-*"],
-        check=True,
-        capture_output=True,
-        text=True,
-    ).stdout == ""
-    work_bridge._remove_canonical_untracked_reports(
-        registry=registry,
-        state_root=tmp_path / "state",
-        run=run,
-        worktree=repo,
+    # #653：ship 段在自己的 Manager-owned clone 裡動手，builder 記錄的樹（本
+    # fixture 就是來源樹）一個位元組沒動——canonical report 原地留著。舊模型是在
+    # 那棵樹裡把它刪掉，才不會弄髒要 commit 的 exact candidate；新模型的 ship
+    # 工作區是 pristine clone，未追蹤檔根本不會被 clone 過去。
+    assert report.is_file()
+    ship_workspace = job_workspace.workspace_path(
+        paths.worktree_root_for(repo), work_bridge._ship_workspace_id(run, candidate)
     )
+    assert ship_workspace.is_dir()
+    assert not (ship_workspace / "reports").exists()
+    assert plan.is_file()
+    for tree in (repo, ship_workspace):
+        assert subprocess.run(
+            ["git", "-C", str(tree), "branch", "--list", "feature/preflight-*"],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout == ""
     journal = json.loads(
         (tmp_path / "state" / "delivery-journal.json").read_text(encoding="utf-8")
     )
@@ -497,126 +502,6 @@ def test_ship_adapter_creates_pr_after_metadata_preflight_and_binds_same_run(
     assert remote_head == candidate
     assert push_count == 2
     assert preflight_requests[-1].pr_number == 17
-
-
-def test_delivery_report_cleanup_rejects_hash_drift_without_deleting(
-    tmp_path: Path,
-) -> None:
-    repo, candidate = _repo(tmp_path / "repo")
-    state_root = tmp_path / "state"
-    report_ref = "reports/review/work-review.md"
-    report = repo / report_ref
-    report.parent.mkdir(parents=True)
-    canonical = b"# Historical canonical review\n"
-    latest = b"# Latest canonical review\n"
-    report.write_bytes(canonical)
-    run = SimpleNamespace(run_id="workflow-run", candidate_head=candidate)
-    job = {
-        "job_id": "review-job",
-        "workflow_run_id": run.run_id,
-        "workflow_claim_key": "claim:v1:" + "1" * 64,
-        "workflow_repo": "acme/demo",
-        "workflow_card": "review-card",
-        "workflow_phase": "review",
-        "workflow_inputs": [],
-        "workflow_outputs": [report_ref],
-        "workflow_output_baseline": [],
-        "source_revision": "source-revision",
-        "subject_head": candidate,
-        "status": "exited",
-        "exit_code": 0,
-    }
-    envelope = {
-        "schema_version": 1,
-        "kind": "review",
-        "job": {
-            "job_id": job["job_id"],
-            "run_id": run.run_id,
-            "claim_key": job["workflow_claim_key"],
-            "repo": job["workflow_repo"],
-            "source_revision": job["source_revision"],
-            "card_id": job["workflow_card"],
-            "phase": "review",
-            "inputs": [],
-            "outputs": [report_ref],
-            "output_baseline": [],
-        },
-        "payload": {},
-        "artifacts": [
-            {
-                "path": report_ref,
-                "sha256": hashlib.sha256(canonical).hexdigest(),
-                "baseline_sha256": None,
-            }
-        ],
-    }
-    content = json.dumps(envelope, sort_keys=True, separators=(",", ":")).encode() + b"\n"
-    evidence = state_root / "evidence" / "workflow" / "review.json"
-    evidence.parent.mkdir(parents=True)
-    evidence.write_bytes(content)
-    job["workflow_evidence"] = {
-        "kind": "review",
-        "path": "evidence/workflow/review.json",
-        "hash": hashlib.sha256(content).hexdigest(),
-    }
-    latest_job = {
-        **job,
-        "job_id": "review-job-2",
-        "workflow_card": "adversarial-review-card",
-        "workflow_output_baseline": [
-            {"path": report_ref, "sha256": hashlib.sha256(canonical).hexdigest()}
-        ],
-    }
-    latest_envelope = {
-        **envelope,
-        "job": {
-            **envelope["job"],
-            "job_id": latest_job["job_id"],
-            "card_id": latest_job["workflow_card"],
-            "output_baseline": latest_job["workflow_output_baseline"],
-        },
-        "artifacts": [
-            {
-                "path": report_ref,
-                "sha256": hashlib.sha256(latest).hexdigest(),
-                "baseline_sha256": hashlib.sha256(canonical).hexdigest(),
-            }
-        ],
-    }
-    latest_content = (
-        json.dumps(latest_envelope, sort_keys=True, separators=(",", ":")).encode()
-        + b"\n"
-    )
-    latest_evidence = state_root / "evidence" / "workflow" / "review-2.json"
-    latest_evidence.write_bytes(latest_content)
-    latest_job["workflow_evidence"] = {
-        "kind": "review",
-        "path": "evidence/workflow/review-2.json",
-        "hash": hashlib.sha256(latest_content).hexdigest(),
-    }
-
-    class Registry:
-        @staticmethod
-        def list_jobs():
-            return [job, latest_job]
-
-    with pytest.raises(RuntimeError, match="report hash drift"):
-        work_bridge._remove_canonical_untracked_reports(
-            registry=Registry(),
-            state_root=state_root,
-            run=run,
-            worktree=repo,
-        )
-
-    assert report.read_bytes() == canonical
-    report.unlink()
-    with pytest.raises(RuntimeError, match="missing before cleanup"):
-        work_bridge._remove_canonical_untracked_reports(
-            registry=Registry(),
-            state_root=state_root,
-            run=run,
-            worktree=repo,
-        )
 
 
 def test_archive_commit_invalidates_old_gates_without_pushing(
@@ -1123,8 +1008,11 @@ identities:
 
     def fake_preflight(**kwargs):
         preflight_requests.append(kwargs["request"])
+        #: #653：preflight 回報的 head 是**它實際跑的那棵樹**的 head。ship 段搬進
+        #: Manager-owned 工作區之後，archive commit 不再落在 build 卡的 clone 裡，
+        #: 假 preflight 若仍去讀那棵樹會回報一個過期的 candidate。
         head = subprocess.run(
-            ["git", "-C", str(job_worktrees[0]), "rev-parse", "HEAD"],
+            ["git", "-C", str(kwargs["repo_root"]), "rev-parse", "HEAD"],
             check=True,
             capture_output=True,
             text=True,
@@ -1188,8 +1076,10 @@ identities:
             )
         if "push" in argv:
             assert argv[-3:] == ["push", "origin", "HEAD:refs/heads/feature/14-work"]
+            #: #653：推的是 `git -C <ship 工作區> push …`，遠端因此收到那棵樹的
+            #: HEAD。假 remote 從 argv 的 `-C` 讀，不再寫死 build 卡的 clone。
             pushed_head = subprocess.run(
-                ["git", "-C", str(job_worktrees[0]), "rev-parse", "HEAD"],
+                ["git", "-C", argv[2], "rev-parse", "HEAD"],
                 check=True,
                 capture_output=True,
                 text=True,


### PR DESCRIPTION
Closes #653

## 問題（#654 已查證，與 #649 票面上的假設不同）

`openspec-archive`／`policy-commit` **不是降權派工的對象**：兩張卡的 persona 是
`manager`，而 `manager._dispatch_workflow_card()` 對 `current_phase == "ship"` 一律回
`None`——它們不經 launcher、不 spawn job，由 Manager 自己在 `work_bridge.py` 內以
`cortex-manager` 身分同步執行。**沒有 template unit、沒有 `ReadWritePaths=<pool>/%i`、
沒有 `226/NAMESPACE`。**

真正的阻擋物是**權限**：ship 段全程在 `_builder_binding()` 交回來的 **builder 的
clone** 裡動手——

| 位置 | 動作 |
|---|---|
| `_builder_binding()` | `Path(worktree).resolve(strict=True)` |
| `_remove_canonical_untracked_reports()` | 讀／刪工作區內的 canonical report |
| `work_actions._validate_local_archive_inputs()` ＋ `openspec archive` | `cwd=<那棵樹>` |
| `_commit_archive_and_require_reverification()` | `git -C <那棵樹> diff/add/commit/rev-parse` |
| `_run_exact_candidate_preflight()` | preflight 在那棵樹跑 |
| `_push_exact_candidate()` | `git -C <那棵樹> ls-remote/push` |
| `work_actions._ship_action(repo_root=…)` | 連測試都在那棵樹跑 |

Phase 2b 三分下那棵樹是 `cortex-builder` 擁有的 `0700` clone，而 **#641 已把登記表裡
Manager 對 job 工作樹殘留的讀取授權全部收掉**（runbook 稽核 5b 要求
`/var/lib/cortex/worktree/` 底下零 `setfacl`）⇒ 降權模式下 ship phase 會在**第一個
`git -C`** 就 `Permission denied`。本 PR 的突變驗證逐字重現了這句話（見「測試」）。

## 修法：ship 段 provision 一棵自己的 Manager-owned clone

新增 `work_bridge._manager_ship_workspace()`：以 `run.candidate_head` 為 base，用
`seams.ScriptWorktreeCreator` 在**來源樹**上 clone 一份。來源樹
`/var/lib/cortex/repos/<slug>` 是 `cortex-manager` 擁有且可寫（0817 裁決），Manager 對
自己 clone 出來的樹自然是 owner——commit／preflight／push 全部沒有權限問題，也**不需要**
任何指向 job 工作樹的 ACL。creator 的兩道既有守衛在這條 lane 上剛好就是要的：

- `rev-parse --verify <candidate>^{commit}`：來源樹必須已經有這個 commit——那正是
  **#654 的回收通道**所保證的不變式。回收沒走完就 provision 不起來，而不是在很遠的地方
  以看不懂的訊息炸開。
- `merge-base --is-ancestor <branch> <candidate>`：delivery branch 不得帶著 candidate
  以外的 commit。

`_builder_binding()` 改為**只回 delivery branch**，不再回（也不再 `resolve()`）那個 job
的工作區。它真正不可取代的職責是**採信鏈**——foreign review 指名的那一個 builder（或
post-archive 的 manager archive）job 必須是 `subject_head == candidate` 的那一筆；**選 job
的那一段一個位元組沒改**。順帶消掉一個既有脆弱點：工作區被 `cortex work gc` 回收之後，
`resolve(strict=True)` 會把一條合法的交付卡死。

### 工作區的識別與生命週期

`_ship_workspace_id()` 穩定於 **(run, candidate)**（形如
`wf-<run 摘要>-ship-<candidate 前綴>`，目錄名仍由唯一推導點 `job_workspace.job_segment()`
導出）。兩個直接後果：

- **同一個 candidate 的多次 tick 共用同一棵樹**：ship phase 會被 tick 很多次（等
  preflight、等 PR、等 copilot、等 merge），每次都 clone 一份 35MB 是白燒。
- **candidate 前進就換一棵，前一棵原地留著**——它正是 `_record_manager_ship_job()` 記在
  archive 卡上的 `worktree`，而 post-archive 的 verify／review 卡仍以
  `builder_jobs[-1]["worktree"]` 當 candidate 樹（`manager._dispatch_workflow_card()`）。
  **ship 段因此不自己刪樹**，回收交給 `cortex work gc`，與 build 卡的 clone 同一套。

### `archive-applied-needs-commit` 的重入路徑（#653 明載必須一併處理）

票上點出：`_ship_action()` 可能在工作區裡把 archive 套用完但沒 commit，若那時才另開一棵
乾淨的 clone，已套用未 commit 的異動會不見 ⇒ `changed` 為空 ⇒
`archive diff escaped strict OpenSpec/docs/changelog allowlist`。處置分兩層，取的是票上
兩個選項中的「**在新樹裡重跑 archive**」：

1. **同一次 `validate()` 內**兩件事本來就在同一棵樹——工作區在 `validate()` 開頭
   provision 一次，`_ship_action()` 與後續的 commit 拿到同一個 `worktree`。結構性的，
   不靠約定。
2. **跨 tick**（上一次崩在中間）：重用既有樹之前一律 `checkout -f`／
   `reset --hard <candidate>`／`clean -ffdx` 打回 pristine，再以
   `_require_pristine_ship_workspace()` 驗 branch／HEAD／乾淨三條。套用 archive 對同一個
   candidate 是完全可重現的確定性動作，重跑一次比帶著來歷不明的 dirty 檔往下走安全得多
   ——而且讓「崩在中間」與「從沒跑過」收斂成同一個狀態。已 commit 但**還沒回收**的
   archive commit 同樣被丟掉：回收是採信發生的唯一時點，沒回收就沒有任何下游依賴它。

### `_remove_canonical_untracked_reports()` 移除

它的用意是「reviewer 發佈在 candidate 樹裡的未追蹤 report 不得弄髒要 commit 的 exact
candidate」，而它讀／刪的正是 **builder 的 clone**——本票要消滅的東西。新模型下 ship 段
拿到的是 pristine clone，未追蹤檔根本不會被 clone 過去，「候選樹被 report 弄髒」在**結構
上**不再可能發生。改由開工前的 `_require_pristine_ship_workspace()` 承擔同一個保證，原
函式與它的 `report-cleanup` evidence 產生路徑一併移除。

`manager._workflow_report_cleanup_allows_missing()` **保留**為向後相容的容忍面（升級當下
正在進行、已寫過該 evidence 的 run 仍要走得完），並補上 docstring 說明它已無產生端；沒有
那份 evidence 時仍一律 fail-closed。副作用是 report 從此留在 verify／review 卡自己的
`workflow_repo_root` 裡，artifact 校驗因此**不再**需要走容忍路徑——比刪掉它更不脆弱。

## 紅線遵守

- **沒有**把 Manager 對 job 工作樹的 ACL 加回來（#644：那條授權唯一的消費端——在 builder
  掌控的樹裡執行命令——本身就是提權路徑）。ship 的樹是 Manager 自己 clone 的，`getfacl`
  下不該有任何具名條目，稽核 5b 的「零 `setfacl`」仍然成立。
- **沒有** `--reference`／`--shared`／任何把 object store 接回共用的優化（#623）。
- **沒有** `git -C <來源樹> fetch <某棵 job 的 clone>`。archive commit 回到來源樹走的仍是
  #654 的 bundle ＋ append-only spool，consumer 仍是全 repo 唯一的
  `job_workspace.harvest_branch()`——**回收通道一個位元組都沒改**。

## 測試

新增 `tests/test_ship_out_of_builder_clone_653.py`（7 條 ＋ 1 條 skip，全部跑正式路徑：
真 git repo、真 per-job clone、真 `build_production_ship_validator()`、真
`ScriptWorktreeCreator`、真 `_run_exact_candidate_preflight()`）。harness 取自
`test_preflight_closeout_order`——repo 內唯一一份真的把 production ship validator 端到端
跑起來的 fixture，複製一份只會讓兩邊漂移。

- **本票的全部價值**：把 builder 的 clone `chmod 000`（＝實機上 `0700 cortex-builder` 對
  Manager 的樣子），ship 段仍完整跑完 local closeout、archive commit 回收進來源樹，而那棵
  clone 的 active change 與 HEAD 一個位元組沒動。形狀沿用 #637 的
  `test_manager_never_touches_the_builder_clone_while_harvesting`。
- **工作區身分**：pool 底下、`is_job_clone()` 為真、標記檔的 `branch`／`base` 對得上、
  `.git` 是目錄（不得退回 linked worktree），且 `openspec archive` 只在那棵樹裡被套用過。
- **重用 ＋ pristine**：同一個 candidate 連續兩次進入拿到同一棵樹（標記檔 `created_at`
  沒變 ⇒ 沒有重新 clone），而上一輪留下的「已套用未 commit 的 archive ＋ 雜物」被打回原狀。
- **`archive-applied-needs-commit` 重入**：把 run 推到「archive 已宣告完成、PR 已綁定」
  ——那是 `_ship_action()` 回這個 action 的唯一入口——驗證 archive 套用與 commit 落在
  **同一棵** Manager-owned 樹裡，回收成立，且 builder 的 clone 全程沒動。
- **`openspec-archive` → `policy-commit` 接續**：archive 卡的 job 記錄就是後續會綁到的
  那一筆，其 `worktree` 是 ship 樹且**仍在磁碟上**（post-archive 的 verify／review 卡要
  用），ship audit 兩張卡皆 passed。範本為 #654 的同名測試，改走 validator 的正式路徑。
- **`matches_candidate()` 的 ancestry 別弄壞**：archive 之後以 archive commit 為 base 用
  真的 `ScriptWorktreeCreator` provision repair clone（#651 post-archive `retry-build` 的
  回歸守衛）、做 descendant、經 bundle 回收，祖先關係在來源樹上驗得出來，ship audit 走得通。
- **`direct` 零回歸**：`PSC_JOB_RUNNER` 兩種值下走完全相同的路徑，七項結構性事實逐項相等
  （#634 的「以形狀判斷，不依旗標分支」；本 PR 沒有引入任何依該旗標的分支）。
- **#638 的教訓**：真正要驗的是 OS 層語意——builder 的 clone 為 `0700 cortex-builder`、
  ship 段以 `cortex-manager` 執行、pool 底下零 `setfacl`。單 UID 的開發機與 CI 三者皆無
  （同 UID 下 owner 隨時 `chmod` 回去，root 更完全不受限）⇒ **明確 `pytest.skip` 並說明
  理由**，skip 之前先斷言可測的那一半（工作區是這個行程 clone 的、獨立 object store、不是
  linked worktree）。權限面的端到端驗證屬 runbook 的實機稽核。

**突變驗證**（兩次）：

1. 把 `validate()` 的工作區改回「builder job 記錄的那棵樹」⇒ 8 條紅 7 條，其中 chmod 那條
   紅在 **`PermissionError(13, 'Permission denied')`**——本票要修的生產症狀逐字現場；另外
   三條紅在 `archive diff escaped strict OpenSpec/docs/changelog allowlist`（report 弄髒
   candidate）與 `repo_root origin remote must match requested repo`。
2. 拿掉重用前的 pristine reset ⇒ 重用那條紅在殘留的 `leftover.txt` 還在。

既有測試的更新都是同一件事的直接後果：三個假 runner 原本寫死「archive／push／preflight
發生在哪棵樹」，改成以呼叫端實際給的 `cwd`／`-C`／`repo_root` 為準——那本來就是真指令的
行為，寫死一棵樹測到的是 fixture 自己的形狀而不是產品的。
`test_delivery_report_cleanup_rejects_hash_drift_without_deleting` 隨被移除的函式一併刪除。

`python3 -m pytest tests/ -q`：**4017 passed, 14 skipped**（已 rebase 到含 **#655／#629**
四分帳號的 main）。

## 未做的實機驗證

`PSC_JOB_RUNNER=systemd-template` 下跑完一個含 ship phase 的 run **尚未實機執行**——本機
不是部署機。runbook 的 `%i` 稽核段已改寫（ship 段已可在降權模式下跑完，並附上 ship 樹的
實機稽核指令：owner ＝ `cortex-manager`、`getfacl` 具名條目數為 0）。

## 附帶發現：留給後續票（範圍外）

- **兩張 ship 卡的 `runtime_capabilities`（#369／#442）在生產環境無法生效**：那兩條宣告掛
  在 `_runtime_preflight_gate` 上，而它在 dispatch 路徑內；ship 卡不 dispatch，因此 #442
  的「先在 ship-phase 兩張卡觀測」觀測不到任何東西。**本 PR 不處理**：讓它生效需要決定
  「不 dispatch 的卡怎麼套 capability gate」，那是 capability 模型的設計題，不是工作區歸屬
  問題，硬塞進來會讓這張票同時改兩套語意。
- **verify／review 卡的 `workflow_repo_root` 仍是 builder 的 clone**
  （`builder_jobs[-1]["worktree"]`），那條路徑在降權模式下仍會撞上同一堵牆——**#650** 的
  範圍，兩票的收斂點是同一個「candidate 樹從哪來」。

## 沒有拆票

#653 的驗收面（工作區為 Manager-owned、不再讀任何 job 的 clone；重入路徑正確；
archive→policy-commit 不依賴磁碟殘留；`direct` 零回歸）在本 PR 內全部落地，**沒有再拆**。
上面兩條附帶發現本來就是票面上標明「可另開」與「與本票有交集的別票」的部分。

## 並行注意：與 #655（#629 四分帳號）的關係

**已 rebase 到 `29b4849`（#655 merge 之後的 main）**。衝突只有 `CHANGELOG.md` 一處
（雙方都在 `[Unreleased] / ### Added` 開頭插入 entry），照既有慣例（新的在上）保留兩段；
runbook 與 `manager.py` 自動合併，另把本 PR 在 runbook 新增那段的「三分下」改為
「降權部署下（三分／四分皆然）」以配合 `UidScheme` 已成四分。

**兩者不相交，且已實際跑過確認**：#655 改的是 gate 的**執行身分**
（`gate_runner.run_declared_gates()`／`gate-ledger-spool`／`gate-worktree`／
`_regenerate_gates_action`），掛在 `manager` 的 terminal 採信點正前方，作用於
`GATE_LEDGER_REQUIRED_PHASES`（build／verify）。ship 段**不讀 gate ledger**——
`work_bridge.py` 內零 `ledger` 引用，`_validated_ship_steps()` 只讀 job 的 workflow
evidence——因此「ledger 的產生者換成 Manager 重寫」對本 PR 是 no-op。`gate_worktree_root()`
是 `<agents_root>/gate-worktree`，與 ship 工作區的 pool（`worktree_root_for(來源樹)`）
不同根；`worktree_root_for()` 本身 #655 沒動。rebase 後全套綠，
`test_gate_execution_identity_629.py` 與 `test_ship_out_of_builder_clone_653.py` 一起跑
也綠（203 passed, 6 skipped）。

**本 PR 完全沒有碰 `launcher.py`／`trust_root/permgen.py`／polkit／`job_runner.py`／
`job_shim.py`／`gate_runner.py`／`gate_ledger.py`**（查證 1 說明了為什麼不必碰——ship 卡
根本不走 launcher）。實際變動的檔案：

- `paulsha_cortex/coordinator/work_bridge.py`（主體）
- `paulsha_cortex/coordinator/manager.py`（只加一段 docstring）
- `docs/superpowers/runbooks/trust-root-phase2b-setup.md`、
  `docs/superpowers/plans/fix-preflight-closeout-order.md`
- `tests/test_ship_out_of_builder_clone_653.py`（新）、`tests/test_work_bridge.py`、
  `tests/test_preflight_closeout_order.py`
- `CHANGELOG.md`、`changelog.d/ship-out-of-builder-clone.md`

## Checklist

- [x] 分支不是 `main`（`feature/653-ship-out-of-builder-clone`）
- [x] `changelog.d/ship-out-of-builder-clone.md` fragment 已新增且已 commit
- [x] `CHANGELOG.md [Unreleased]` 有對應 entry
- [x] `VERSION` 未改（非 release PR）
- [x] `python3 -m pytest tests/ -q` 全綠（rebase 後 4017 passed, 14 skipped）
- [x] `policy_check` 帶 PR 上下文跑，fail: 0
- [x] 文件與 PR 一律 zh-tw
- [x] docs 同步（Phase 2b runbook 的 `%i` 稽核段改寫並補上 ship 樹的實機稽核；
      fix-preflight-closeout-order 計畫加註 `_remove_canonical_untracked_reports` 的移除）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E7w9kaUxAzCCEk7piD5hfK