### PR TITLE
feat(coordinator): verify／review 卡的 candidate 樹搬出 builder 的 clone——改用 Manager 自己 clone 的 per-(run, candidate) 樹

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,36 @@
 ## [Unreleased]
 
 ### Added
+- **#650：verify／review 卡的 candidate 樹搬出 builder 的 clone——解開擋住「卡被採信後
+  即時回收」的最後一條引用**——`_dispatch_workflow_card()` 的 reviewer 分支以
+  `builder_jobs[-1]["worktree"]` 為 candidate 樹，六個用途全掛在它身上；#648 之後一個 run
+  會累積 N 棵這種樹（每棵約 35MB），而 `_harvest_build_candidate()` 落地後**被採信的卡的
+  工作區已無任何獨佔資訊**（bundle 已封存、commit 已在來源樹），唯一還讓它回收不掉的就是
+  這條引用。**六個用途逐個查證**後只有 `_create_reviewer_sandbox()` 是「只需要 candidate
+  這個 commit」（來源樹就夠）；其餘五個都要一棵**真的 checkout 在 candidate 上、且 Manager
+  可寫**的樹——`_authority_map_with_checkbox_tolerance()` 要比對 builder 勾過的 `tasks.md`
+  實檔（#310），`_workflow_input_snapshot()` 會往樹裡 seed 缺席的 planning authority 檔，
+  `_workflow_output_baseline()` 必須與 canonical report 的發佈根同源，`_tree_snapshot()`
+  的逃逸偵測對象必須活過 sandbox 拆除，而 job 記錄的 `workflow_repo_root` 還是**卡與卡的
+  交接載體**（`adversarial-review.requires` 就是 `code-review.produces` 發佈進去的那份未
+  追蹤 report）。因此**票上的 A／B 皆不成立**（per-job clone 與 sandbox 都留不住上一張卡
+  的 report），C 是把耦合固化成回收特例；改採 **A′：per-(run, candidate) 的 Manager-owned
+  clone**，形狀完全沿用 #653 的 `_manager_ship_workspace()`——新增
+  `manager._reviewer_candidate_workspace_id()`（唯一推導點，
+  `wf-<run 摘要>-review-<candidate 前綴>`）、`_require_reviewer_candidate_workspace()`
+  （branch／HEAD＝candidate／**追蹤檔**無漂移；未追蹤的 canonical report 刻意放行，那是
+  交接載體不是殘留）與 `_reviewer_candidate_workspace()`（在來源樹上 clone，重用**不**打回
+  pristine）。票上點名的順序問題（input snapshot 是 sandbox 的輸入、算它時 sandbox 還不
+  存在）在 A′ 下**不存在**：借 #653 的「同一次派工內結構性共用同一個 provisioning」，
+  candidate 樹在 reviewer 分支之前建好一次，五個用途拿到同一棵樹。順帶收掉一個 #641 同型
+  缺口——舊模型下 Manager 對 builder 的 `0700` clone 做的不只是讀（seed 檔案、遞迴
+  snapshot），降權部署下必然 `Permission denied`。`_is_exact_reviewer_terminal_recovery()`
+  的 candidate 樹定錨改為唯一推導點，舊形狀保留為升級當下的容忍面。**即時回收拆後續票**：
+  `worktree_reclaim` 的「不銷毀證據」需要讀進 builder 的 `0700` clone，三分下必然失敗，
+  「誰以什麼身分回收、abandon／retry 的重入」自成一票（**#658**）。紅線全數遵守（沒有加回 job 工作樹
+  的 ACL、沒有 `--reference`／`--shared`、回收通道一個位元組沒改）。新增
+  `tests/test_reviewer_candidate_tree_650.py`（10 條 ＋ 1 條 skip，全部跑正式路徑；突變驗證 7 條轉紅，
+  `chmod 000` 那條逐字重現 `PermissionError: [Errno 13] Permission denied`）。
 - **#653 / trust-root Phase 2b：ship 段搬出 builder 的 clone——降權模式下 canonical lane
   終於跑得完整個 run**——#654 查證出的形狀：`openspec-archive`／`policy-commit`
   **不是降權派工的對象**（persona 是 `manager`，`_dispatch_workflow_card()` 對 ship phase

--- a/changelog.d/reviewer-candidate-tree.md
+++ b/changelog.d/reviewer-candidate-tree.md
@@ -1,0 +1,88 @@
+# Issue #650：verify／review 卡的 candidate 樹仍讀前一張 build 卡的工作區——擋住「卡被採信後即時回收」
+
+## 問題
+
+`manager._dispatch_workflow_card()` 的 reviewer 分支以 `builder_jobs[-1]["worktree"]`
+（前一張 build 卡的工作區）為 candidate 樹，六個用途全掛在它身上。#648 把 build phase
+的工作區改成 per-job 之後，一個 run 會累積 N 棵這種樹（每棵約 35MB），而
+`_harvest_build_candidate()` 落地之後**被採信的卡的工作區已經沒有任何獨佔資訊**
+——bundle 已封存、commit 已在來源樹裡。唯一還讓它回收不掉的就是這條引用。
+
+reviewer 卡不是降權派工的對象（`launcher._downgraded_mode()` 對 `review_only` 回
+`None`），所以 #648 的 `ReadWritePaths=<pool>/%i` 不變式不落在它們身上——**這不是
+blocking，是耦合**。
+
+## 六個用途各自真正需要什麼（票上要求先查證）
+
+| # | 用途 | 真正需要的是 | 來源樹（不 checkout）夠不夠 |
+|---|---|---|:--:|
+| 1 | `_authority_map_with_checkbox_tolerance(candidate_root=…)` | **candidate 內容的檔案系統視圖**——#310 的 checkbox 容忍要比對 builder 勾過的 `tasks.md` 實檔 | ✗（來源樹的工作目錄停在 `main`，是未勾的版本） |
+| 2 | `_workflow_input_snapshot(repo_root=…)` | **可寫**的 candidate 內容視圖：它會 glob 宣告輸入，並把缺席的 planning authority 檔 `mkdir`＋`mkstemp`＋`os.replace` **seed 進去** | ✗（同上，且不得往共用來源樹寫） |
+| 3 | `_workflow_output_baseline(…)` | **canonical report 將被發佈的那棵樹**——baseline 與 `_canonical_workflow_artifacts()` 的校驗必須同根 | ✗ |
+| 4 | `_create_reviewer_sandbox(candidate_root=…)` | 只要 **object store 裡有 candidate 這個 commit**（`git clone` ＋ `checkout --detach`） | ✓ |
+| 5 | `planning_runtime._tree_snapshot(…)` → `workflow_sandbox_hash` | 一棵 **reviewer 不該碰的樹**（逃逸偵測的觀測對象），且必須活過 sandbox 拆除 | ✗ |
+| 6 | job 記錄的 `workflow_repo_root` | 一棵 **HEAD 恰為 candidate、可寫、跨卡穩定**的樹：`_verify_exact_candidate()` 驗 `rev-parse HEAD == candidate`；`_WorkflowReportPublicationTransaction` 往它發佈 report；**下一張 review 卡的宣告輸入就是上一張發佈進去的那份 report**（`adversarial-review.requires == code-review.produces`） | ✗ |
+
+只有第 4 個用途「來源樹就夠」。其餘五個都要一棵**真的 checkout 在 candidate 上、且
+Manager 可寫**的樹。
+
+## 選的方向：A′（per-(run, candidate) 的 Manager-owned clone），不是票上的 A／B／C
+
+- **B 不成立**：把「其餘四個判讀改讀 `reviewer_checkout`」套到用途 3／6 會壞兩件事——
+  (a) `_discard_reviewer_sandbox()` 在 report 發佈**之前**就把 sandbox `rmtree` 掉，
+  發佈目標不能在 sandbox 裡；(b) sandbox 是 per-card 的，`code-review` 發佈的 report
+  無法傳給 `adversarial-review`（`workflow declared input missing`）。
+- **A（per-job clone）也不成立**：同一個 (b)。per-job ⇒ 每張 review 卡一棵乾淨的樹
+  ⇒ 上一張卡的 report 不在裡面。
+- **C 最差**（票上已判）：把耦合固化成回收邏輯裡的特例。
+- **A′**：識別穩定於 **(run, candidate)**，形狀完全沿用 #653 的
+  `work_bridge._manager_ship_workspace()`。六個用途語意逐條不變，只是換成一棵 Manager
+  自己的樹；candidate 前進就換一棵（新 candidate 的 review phase 本來就該從頭跑）。
+
+## 順序問題怎麼解
+
+票上點名「input snapshot 是 sandbox 的輸入，算它時 sandbox 還不存在」。A′ 下這個問題
+**不存在**：借 #653 對 `archive-applied-needs-commit` 的處置——「同一次派工內結構性共用
+同一個 provisioning」。candidate 樹在 reviewer 分支之前建好一次，authority map／input
+snapshot／output baseline／sandbox clone 源／tree snapshot 全部拿到同一棵樹。
+
+## 改法
+
+- 新增 `manager._reviewer_candidate_workspace_id()`（唯一推導點，
+  `wf-<run 摘要>-review-<candidate 前綴>`）、`_require_reviewer_candidate_workspace()`
+  （branch／HEAD＝candidate／**追蹤檔**無漂移三條；未追蹤檔刻意放行——canonical report
+  就是未追蹤檔，也正是卡與卡的交接載體，ship 段那條「完全乾淨」在這裡會讓第二張 review
+  卡永遠開不了工）、`_reviewer_candidate_workspace()`（在來源樹上 clone，重用不打回
+  pristine）。
+- `_dispatch_workflow_card()` 的 reviewer 分支改用它；`builder_jobs[-1]["worktree"]`
+  在該分支**完全消失**。
+- `_is_exact_reviewer_terminal_recovery()` 的 candidate 樹定錨從「等於 builder job 的
+  `worktree`」換成「等於唯一推導點算出來的那一棵」，舊形狀保留為升級當下的容忍面。
+
+## 順帶收掉的一個 #641 同型缺口
+
+舊模型下 Manager 在 reviewer 派工當下對 builder 的 clone 做的**不只是讀**（見上表用途
+2／5）。三分部署下那棵樹是 `0700 cortex-builder`、且 #641 已收掉 Manager 的唯讀 ACL
+⇒ 兩步都是 `Permission denied`。突變驗證逐字重現了這句話。
+
+## 紅線遵守
+
+- **沒有**把 Manager 對 job 工作樹的 ACL 加回來（#641／#644）——candidate 樹是 Manager
+  自己 clone 的，`getfacl` 下不該有任何具名條目，稽核 5b 的「零 `setfacl`」仍成立。
+- **沒有** `--reference`／`--shared`／任何把 object store 接回共用的優化（#623）。
+- **沒有** `git -C <來源樹> fetch <某棵 job 的 clone>`；回收通道一個位元組沒改。
+
+## 即時回收：拆後續票，不在本 PR
+
+解耦之後回收**不是一行的事**：`worktree_reclaim.reclaim_worktree()` 的契約含「不銷毀
+證據」（先把未提交／未追蹤內容複製到 preserve 封存再刪），而三分下 Manager **讀不進**
+builder 的 `0700` clone ⇒ 那一步在降權部署下必然失敗。「誰以什麼身分回收、abandon／
+retry 的重入怎麼算」自成一票 ⇒ **#658**。#650 的驗收第 3 條因此移到那裡。
+
+## 測試
+
+新增 `tests/test_reviewer_candidate_tree_650.py`（10 條 ＋ 1 條 skip，全部跑正式路徑：真 git repo、
+真 `ScriptWorktreeCreator` 的 per-job clone、真 `dispatch_workflow_card()`、真 #637
+bundle ＋ spool 交接、真 `retry-build` 重置、真 `_WorkflowReportPublicationTransaction`）。
+突變驗證（把 reviewer 分支改回 `builder_jobs[-1]["worktree"]`）7 條轉紅，其中
+`chmod 000` 那條逐字重現生產訊息 `PermissionError: [Errno 13] Permission denied`。

--- a/docs/superpowers/runbooks/trust-root-phase2b-setup.md
+++ b/docs/superpowers/runbooks/trust-root-phase2b-setup.md
@@ -2088,8 +2088,23 @@ systemctl cat cortex-job@.service | grep -E "^ReadWritePaths=/var/lib/cortex/wor
 #     getfacl -p /var/lib/cortex/worktree/wf-*-ship-* | grep -c '^user:'
 #   期望：`0`——ship 的樹不需要任何具名 ACL 條目；稽核 5b 的「零 `setfacl`」因此
 #   仍然成立。這些目錄與 build 卡的 clone 走同一套回收（`cortex work gc`，branch
-#   merge 後才回收），不由 ship 段自己刪：archive 卡的 job 記錄指著它，
-#   post-archive 的 verify／review 卡仍以它為 candidate 樹。
+#   merge 後才回收），不由 ship 段自己刪：archive 卡的 job 記錄指著它。
+#
+#   #650（已修）：verify／review 卡在此之前以 `builder_jobs[-1]["worktree"]`（前一張
+#   build 卡的工作區）為 candidate 樹，而 Manager 在那棵樹上做的**不只是讀**——
+#   `_workflow_input_snapshot()` 會往裡面 seed 缺席的 planning authority 檔、
+#   `planning_runtime._tree_snapshot()` 會遞迴走完整棵樹 ⇒ 收掉唯讀 ACL 之後這條 lane
+#   同樣是 `Permission denied`（與 ship 段同型，症狀一樣是**權限**）。現在 verify／
+#   review 卡也在來源樹上 provision 一棵自己的 Manager-owned clone，識別穩定於
+#   **(run, candidate)**（形如 `wf-<run 摘要>-review-<candidate 前綴>-…`）。
+#
+#   實機稽核：verify／review phase 跑過之後
+#     stat -c '%U %a' /var/lib/cortex/worktree/wf-*-review-*
+#   期望：`cortex-manager 700`。
+#     getfacl -p /var/lib/cortex/worktree/wf-*-review-* | grep -c '^user:'
+#   期望：`0`（同上，稽核 5b 的「零 `setfacl`」仍然成立）。
+#   注意這棵樹裡會有**未追蹤**的 canonical report（`reports/verify|review/*.md`）
+#   ——那是 `code-review` → `adversarial-review` 的宣告輸入，不是殘留，不要手動清。
 
 # ✅ 檢查 unit 沒有被忽略的鍵（#645 附帶；#643 起兩份都要驗）
 sudo systemd-analyze verify /etc/systemd/system/cortex-job@.service \

--- a/paulsha_cortex/coordinator/manager.py
+++ b/paulsha_cortex/coordinator/manager.py
@@ -3204,8 +3204,10 @@ def _raise_if_worktree_read_blocked(result: object, *, what: str) -> None:
 
 def _verify_exact_candidate(job: Mapping[str, object], *, git_runner=None) -> str:
     candidate = job.get("subject_head")
-    # reviewer 走 `workflow_repo_root`（Manager 自己的來源樹），不讀 reviewer 的
-    # 工作樹——#641 的同型問題在這條 lane 上本來就不存在。
+    # reviewer 走 `workflow_repo_root`，不讀 reviewer 的工作樹（那是 sandbox）。
+    # #650 之後那個欄位是 **Manager 自己從來源樹 clone 出來的 candidate 樹**
+    # （`_reviewer_candidate_workspace()`，HEAD 恰為 candidate），不再是前一張
+    # build 卡的工作區——因此 #641 的同型問題在這條 lane 上結構性不存在。
     worktree = (
         job.get("workflow_repo_root")
         if job.get("persona") == "reviewer"
@@ -4195,11 +4197,27 @@ def _is_exact_reviewer_terminal_recovery(
         )
     except ValueError:
         return False
+    # #650：candidate 樹的定錨從「等於 builder job 記錄的工作區」換成「等於本 run
+    # ＋本 candidate 的**唯一推導點**算出來的那一棵 Manager-owned clone」
+    # （`_reviewer_candidate_workspace_id`）。推導點比兄弟 job 的欄位穩定——後者正
+    # 是本票要拆掉的耦合，而且那個目錄在成果回收之後隨時可能被回收掉。
+    #
+    # 舊形狀（`workflow_repo_root` == 那張 build 卡的工作區）**保留為容忍面**：升級
+    # 當下正在進行、reviewer job 已派出去的 run 仍要走得完 operator recovery。兩者
+    # 都是「這個 repo_root 真的是本 run 的 candidate 樹」的定錨，容忍不放寬語意。
     builder_worktree = builder.get("worktree")
-    if (
-        not isinstance(builder_worktree, str)
-        or Path(repo_root_value).resolve() != Path(builder_worktree).resolve()
-    ):
+    recorded_root = Path(repo_root_value).resolve()
+    try:
+        expected_root = job_workspace.workspace_path(
+            worktree_root_for(Path(str(run.workspace_root))),
+            _reviewer_candidate_workspace_id(run, str(run.candidate_head).lower()),
+        ).resolve()
+    except (ValueError, OSError):
+        expected_root = None
+    legacy_root = (
+        Path(builder_worktree).resolve() if isinstance(builder_worktree, str) else None
+    )
+    if recorded_root not in {root for root in (expected_root, legacy_root) if root is not None}:
         return False
     expected = job.get("workflow_sandbox_hash")
     candidate_root = Path(repo_root_value)
@@ -5193,6 +5211,155 @@ def _discard_failed_planner_sandbox(
         shutil.rmtree(path)
     if path.exists() or path.is_symlink():
         raise ValueError("planner sandbox retry cleanup incomplete")
+
+
+def _reviewer_candidate_workspace_id(run, candidate: str) -> str:
+    """verify／review 卡那棵 candidate 樹的識別（#650）——**唯一推導點**。
+
+    形狀與 `work_bridge._ship_workspace_id()` 對齊（`wf-<run 摘要>-<段>-<candidate
+    前綴>`），只換中間那一段。穩定於 **(run, candidate)** 而**不是** per-job，這一點
+    是被產品契約逼出來的，不是省一次 clone 的優化：
+
+    `adversarial-review` 的 `requires` 是 `reports/review/*<task-slug>*.md`，也就是
+    前一張 `code-review` 卡的產出；而 canonical report 是 Manager 在
+    `terminalize_workflow_job()` 裡發佈到那張卡的 `workflow_repo_root` 的**未追蹤
+    檔**（#653 之後不再被 ship 段清掉）。同一個 candidate 的 verify／review 卡因此
+    必須共用同一棵樹，下一張卡的 `_workflow_input_snapshot()` 才 glob 得到它。
+    per-job 一棵樹會讓那個 glob 落空 ⇒ `workflow declared input missing`。
+
+    candidate 前進（retry-build、post-archive 重驗）就換一棵樹——那也正是對的：新
+    candidate 的 review phase 從頭跑起，舊 candidate 的 report 不該被它讀到。舊的
+    那一棵原地留著，回收交給 `cortex work gc`，與 build／ship 卡的 clone 同一套。
+    """
+
+    if verification.SAFE_SHA_RE.fullmatch(candidate) is None:
+        raise ValueError("workflow reviewer candidate invalid")
+    digest = hashlib.sha256(run.run_id.encode()).hexdigest()[:10]
+    return f"wf-{digest}-review-{candidate[:12]}"
+
+
+def _require_reviewer_candidate_workspace(
+    worktree: Path, *, branch: str, candidate: str
+) -> None:
+    """candidate 樹開工前的三條不變式：branch 對、HEAD ＝ candidate、追蹤檔無漂移。
+
+    - **branch**：job 記錄的 `branch` 與這棵樹實際 checkout 的 branch 必須一致
+      （與 `work_bridge._require_pristine_ship_workspace()` 同一條理由）。
+    - **HEAD ＝ candidate**：`_verify_exact_candidate()` 在採信時對 reviewer 的
+      `workflow_repo_root` 跑的正是 `rev-parse HEAD == candidate`；這裡先驗一次，
+      讓「樹不對」在派工當下就炸開，而不是等到一整個 session 跑完才發現。
+      `_authority_map_with_checkbox_tolerance()` 讀的 candidate 內容也以這條為前提。
+    - **追蹤檔無漂移**（`--untracked-files=no`）：**未追蹤檔刻意放行**——canonical
+      report 就是未追蹤檔，而它們正是 `code-review` → `adversarial-review` 的交接
+      載體（見 `_reviewer_candidate_workspace_id`）。這裡不能用 ship 段那條「完全
+      乾淨」，否則第二張 review 卡永遠開不了工。
+
+    這棵樹只有 Manager 寫（input seed ＋ canonical report 發佈），因此任何一條不成
+    立都代表有第三方動過它——fail-closed，不刪、不自癒。
+    """
+
+    for argv, expected, failure in (
+        (["symbolic-ref", "--quiet", "--short", "HEAD"], branch, "branch"),
+        (["rev-parse", "HEAD"], candidate, "head"),
+    ):
+        probe = subprocess.run(
+            ["git", "-C", str(worktree), *argv],
+            shell=False,
+            capture_output=True,
+            text=True,
+        )
+        if probe.returncode != 0 or probe.stdout.strip().lower() != expected.lower():
+            raise ValueError(f"workflow reviewer candidate workspace {failure} mismatch")
+    tracked = subprocess.run(
+        ["git", "-C", str(worktree), "status", "--porcelain", "--untracked-files=no"],
+        shell=False,
+        capture_output=True,
+        text=True,
+    )
+    if tracked.returncode != 0 or tracked.stdout.strip():
+        raise ValueError("workflow reviewer candidate workspace has tracked drift")
+
+
+def _reviewer_candidate_workspace(
+    *,
+    run,
+    branch: str,
+    candidate: str,
+    creator=None,
+) -> Path:
+    """#650：verify／review 卡的 candidate 樹——**Manager-owned**，不是 builder 的 clone。
+
+    ## 換掉的是什麼
+
+    在此之前 verify／review 卡以 `builder_jobs[-1]["worktree"]`（前一張 build 卡的
+    工作區）為 candidate 樹，六個用途全掛在它身上。#648 把 build phase 的工作區改成
+    per-job 之後，一個 run 會累積 N 棵這種樹（每棵約 35MB），而
+    `_harvest_build_candidate()` 落地之後**被採信的卡的工作區已經沒有任何獨佔資訊**
+    ——bundle 已封存、commit 已在來源樹裡。唯一還讓它回收不掉的就是這條引用。
+
+    ## 形狀（沿用 #653 的 `work_bridge._manager_ship_workspace()`）
+
+    以 `run.candidate_head` 為 base、用 `seams.ScriptWorktreeCreator` 在**來源樹**上
+    clone 一份。來源樹是 `cortex-manager` 擁有且可寫，Manager 對自己 clone 出來的樹
+    自然是 owner。creator 的兩道既有守衛在這條 lane 上剛好就是要的：
+
+    - `rev-parse --verify <candidate>^{commit}`：來源樹必須已經有這個 commit——那正是
+      `_harvest_build_candidate()`（#637 bundle ＋ append-only spool）保證的不變式
+      （build 卡）與 `work_bridge._harvest_manager_ship_commit()`（#649，archive
+      commit）保證的不變式。回收沒走完就 provision 不起來。
+    - `merge-base --is-ancestor <branch> <candidate>`：delivery branch 不得帶著
+      candidate 以外的 commit（#613 的形狀）。
+
+    ## 順帶收掉的一個 #641 同型缺口
+
+    舊模型下 Manager 在 reviewer 派工當下對 builder 的 clone 做的**不只是讀**：
+    `_workflow_input_snapshot()` 會把缺席的 planning authority 檔案 seed 進去
+    （`mkdir` ＋ `mkstemp` ＋ `os.replace`），`planning_runtime._tree_snapshot()` 會
+    遞迴走完整棵樹。三分部署下那棵樹是 `0700 cortex-builder`、且 #641 已收掉 Manager
+    的唯讀 ACL ⇒ 這兩步都是 `Permission denied`。換成 Manager 自己的樹之後，這條路徑
+    不需要任何指向 job 工作樹的授權。
+
+    ## 紅線
+
+    沒有 `--reference`／`--shared`／任何把 object store 接回共用的優化（#623 判定共用
+    object store 與三分隔離互斥），也沒有「Manager fetch 一棵 job 的 clone」。
+    """
+
+    source_repo = getattr(run, "workspace_root", None)
+    if not isinstance(source_repo, str) or not source_repo:
+        raise ValueError("workflow reviewer candidate workspace source repo missing")
+    source = Path(source_repo)
+    pool = worktree_root_for(source)
+    workspace_id = _reviewer_candidate_workspace_id(run, candidate)
+    target = job_workspace.workspace_path(pool, workspace_id)
+    if target.is_symlink() or (target.exists() and not target.is_dir()):
+        raise ValueError("workflow reviewer candidate workspace path is not a directory")
+    if target.is_dir():
+        marker = job_workspace.read_marker(target)
+        reusable = (
+            job_workspace.is_job_clone(target)
+            and isinstance(marker, dict)
+            and marker.get("branch") == branch
+            and str(marker.get("base", "")).lower() == candidate.lower()
+        )
+        if reusable:
+            # 重用**不打回 pristine**：未追蹤的 canonical report 是同一個 candidate
+            # 的下一張 review 卡的宣告輸入（見 `_reviewer_candidate_workspace_id`）。
+            # ship 段的 `_reset_ship_workspace()` 之所以能 `clean -ffdx`，是因為它
+            # 要 commit 一個 exact candidate；這裡的契約相反。
+            _require_reviewer_candidate_workspace(
+                target, branch=branch, candidate=candidate
+            )
+            return target
+        if not job_workspace.is_job_clone(target):
+            # 認不出這是什麼就**不刪**（#478 的爆炸半徑教訓）。
+            raise ValueError("workflow reviewer candidate workspace path is occupied")
+        job_workspace.remove_clone(target)
+    if creator is None:
+        creator = seams.ScriptWorktreeCreator(repo=source, wt_root=pool, base="main")
+    created = Path(creator.create(branch, job_id=workspace_id, base_sha=candidate))
+    _require_reviewer_candidate_workspace(created, branch=branch, candidate=candidate)
+    return created
 
 
 def _reviewer_sandbox_parent(
@@ -8677,13 +8844,40 @@ def _dispatch_workflow_card(
             )
         else:
             worktree = str(creator.create(build_branch, job_id=reserved_job_id))
+    elif step.persona == "reviewer":
+        # #650：verify／review 卡的 candidate 樹改為 **Manager 自己在來源樹上 clone
+        # 出來的一棵**，不再是 `builder_jobs[-1]["worktree"]`。
+        #
+        # 為什麼在這裡（而不是等到 reviewer 分支）provision：`_workflow_input_snapshot()`
+        # 是 `_create_reviewer_sandbox()` 的**輸入**，算它時 sandbox 還不存在——票上點名
+        # 的順序問題。解法沿用 #653 對 `archive-applied-needs-commit` 的處置：**同一次
+        # 派工內結構性共用同一個 provisioning**。candidate 樹在這裡建好一次，
+        # authority map／input snapshot／output baseline／sandbox clone 源／tree
+        # snapshot 五個用途全部拿到同一棵樹，順序問題因此不是被「解決」而是**不存在**。
+        #
+        # branch 與底下 job 記錄用的那一個是同一條推導（前一張 build 卡的 branch；
+        # post-archive 時是 `_record_manager_ship_job()` 記在 archive 卡上的那一條）。
+        reviewer_branch = (
+            str(builder_jobs[-1]["branch"])
+            if builder_jobs and isinstance(builder_jobs[-1].get("branch"), str)
+            else f"feature/{run.work_id}"
+        )
+        reviewer_candidate = run.candidate_head
+        if (
+            not isinstance(reviewer_candidate, str)
+            or verification.SAFE_SHA_RE.fullmatch(reviewer_candidate) is None
+        ):
+            # 與 `_create_reviewer_sandbox()` 逐字相同的訊息：candidate 推不出來時
+            # 這條 lane 本來就走不下去，只是現在擋在建樹之前。
+            raise ValueError("workflow reviewer candidate invalid")
+        worktree = str(
+            _reviewer_candidate_workspace(
+                run=run,
+                branch=reviewer_branch,
+                candidate=reviewer_candidate.lower(),
+            )
+        )
     elif builder_jobs:
-        # verify／review／ship 卡：仍以**前一張 build 卡的工作區**為 candidate 樹。
-        # 這三種卡不是降權派工的對象（reviewer 走 `as_review_only()`，其實際
-        # 工作樹是 reviewer sandbox；ship 卡的成果目前沒有 harvest 通道），因此
-        # #648 的 `%i` 不變式不落在它們身上。把它們也搬到 per-job clone 需要先補
-        # 「ship phase 的成果回收」與「reviewer candidate 樹的來源」兩件事——見
-        # 後續票，本 PR 不動它們一個位元組。
         worktree = str(builder_jobs[-1]["worktree"])
     else:
         worktree = run.workspace_root

--- a/paulsha_cortex/coordinator/work_bridge.py
+++ b/paulsha_cortex/coordinator/work_bridge.py
@@ -769,9 +769,11 @@ def _ship_workspace_id(run, candidate: str) -> str:
     candidate 的前綴：ship 段的工作區是綁在 **(run, 這個 candidate)** 上的，而
     `openspec-archive` 一旦回收成功，`candidate_head` 就會前進到 archive commit
     ——下一輪 ship 因此拿到**另一個**識別、另一棵樹，前一棵原地留著（它正是
-    `_record_manager_ship_job()` 記在 archive 卡上的 `worktree`，post-archive 的
-    verify／review 卡仍以它為 candidate 樹，見
-    `manager._dispatch_workflow_card()` 的 `builder_jobs[-1]["worktree"]`）。
+    `_record_manager_ship_job()` 記在 archive 卡上的 `worktree`，是那張卡的稽核
+    定錨）。#650 之後 post-archive 的 verify／review 卡**不再讀這棵樹**：它們自己
+    從來源樹 clone 一棵 `wf-<run 摘要>-review-<candidate 前綴>`（見
+    `manager._reviewer_candidate_workspace()`），archive commit 已由 #649 的回收
+    通道搬進來源樹。
 
     反過來說，**同一個 candidate 的每一次 ship tick 共用同一棵樹**：ship phase 會
     被 tick 很多次（等 preflight、等 PR、等 copilot、等 merge），每次都 clone 一
@@ -904,9 +906,9 @@ def _manager_ship_workspace(
     識別由 :func:`_ship_workspace_id` 決定（穩定於 (run, candidate)）：同一個
     candidate 的多次 tick 重用同一棵樹（重用前一律打回 pristine，見
     :func:`_reset_ship_workspace`），candidate 前進時換一棵新的。**不在這裡刪**
-    ——archive 卡的 job 記錄指著這棵樹，post-archive 的 verify／review 卡仍以
-    `builder_jobs[-1]["worktree"]` 當 candidate 樹；回收交給 `cortex work gc`，
-    與 build 卡的 clone 同一套。
+    ——archive 卡的 job 記錄指著這棵樹（`_record_manager_ship_job()` 的
+    `worktree`／`workflow_repo_root`）；回收交給 `cortex work gc`，與 build 卡的
+    clone 同一套。
 
     ## 紅線
 

--- a/tests/test_reviewer_candidate_tree_650.py
+++ b/tests/test_reviewer_candidate_tree_650.py
@@ -1,0 +1,741 @@
+"""#650：verify／review 卡的 candidate 樹搬出 builder 的 clone。
+
+在此之前 verify／review 卡以 `builder_jobs[-1]["worktree"]`（前一張 build 卡的工作
+區）為 candidate 樹，六個用途全掛在它身上。#648 把 build phase 的工作區改成 per-job
+之後，一個 run 會累積 N 棵這種樹（每棵約 35MB），而 `_harvest_build_candidate()` 落地
+之後**被採信的卡的工作區已經沒有任何獨佔資訊**——bundle 已封存、commit 已在來源樹
+裡。唯一還讓它回收不掉的就是這條引用。
+
+本檔全部跑**正式路徑**：真 git repo、真 `seams.ScriptWorktreeCreator` provision 的
+per-job clone、真 `manager.dispatch_workflow_card()`、真 #637 bundle ＋ append-only
+spool 交接、真 `_create_reviewer_sandbox()`、真
+`_WorkflowReportPublicationTransaction`。不手動 `git push`、不自己捏工作區。
+
+三條核心不變式：
+
+1. **解耦**：把前一張 build 卡的工作區刪掉（或 `chmod 000`），verify／review 卡仍
+   正確派得出去。形狀沿用 #653 的
+   `test_ship_phase_completes_while_the_builder_clone_is_unreadable`。
+2. **語意不變**：`workflow_sandbox_hash`／input snapshot（含 #310 checkbox 容忍）／
+   output baseline 在新模型下與舊模型逐位元相同——這三個進 evidence，改了會動到採信
+   判斷。
+3. **卡與卡的交接**：`code-review` 發佈在 candidate 樹裡的 canonical report 是
+   `adversarial-review` 的宣告輸入（`requires: reports/review/*<task-slug>*.md`）。
+   同一個 candidate 的 review 卡因此必須共用同一棵樹；candidate 前進才換一棵。
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from paulsha_cortex.config.paths import worktree_root_for
+from paulsha_cortex.coordinator import (
+    job_workspace,
+    manager,
+    planning_runtime,
+    seams,
+)
+from paulsha_cortex.coordinator.launcher import LaunchHandle
+from paulsha_cortex.coordinator.model_identities import IdentityRegistry
+from paulsha_cortex.coordinator.registry import JobRegistry
+from paulsha_cortex.coordinator.workflow import PlanningArtifactAuthority, WorkflowStep
+
+from diagnostic_fixtures import fixture_needs_human_reason
+
+
+_REPO = "hamanpaul/paulsha-cortex"
+_WORK_ID = "650-reviewer-candidate-tree"
+_BRANCH = "feature/650-650-reviewer-candidate-tree"
+
+TASKS_REF = "openspec/changes/demo-650/tasks.md"
+PROPOSAL_REF = "openspec/changes/demo-650/proposal.md"
+
+TASKS_BASELINE = """---
+status: accepted
+work_item: demo-650
+---
+
+# Tasks
+
+- [ ] 1.1 RED：新增測試。
+- [ ] 1.2 GREEN：實作。
+"""
+TASKS_TICKED = TASKS_BASELINE.replace("- [ ] 1.1", "- [x] 1.1")
+PROPOSAL_BASELINE = "# Proposal\n\n把 candidate 樹搬出 builder 的 clone。\n"
+
+REPORT_REF = "reports/review/demo-650.md"
+
+
+# ---------------------------------------------------------------------------
+# fixtures
+# ---------------------------------------------------------------------------
+
+
+def _git(cwd: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", "-C", str(cwd), *args], check=True, capture_output=True, text=True
+    ).stdout.strip()
+
+
+def _source_repo(root: Path) -> Path:
+    """來源樹（`run.workspace_root`）：Manager 擁有、可寫，停在 `main`。"""
+
+    root.mkdir(parents=True, exist_ok=True)
+    subprocess.run(["git", "-C", str(root), "init", "-q", "-b", "main"], check=True)
+    _git(root, "config", "user.email", "manager@example.invalid")
+    _git(root, "config", "user.name", "Cortex Manager")
+    (root / TASKS_REF).parent.mkdir(parents=True, exist_ok=True)
+    (root / TASKS_REF).write_text(TASKS_BASELINE, encoding="utf-8")
+    (root / PROPOSAL_REF).write_text(PROPOSAL_BASELINE, encoding="utf-8")
+    _git(root, "add", "-A")
+    _git(root, "commit", "-qm", "init")
+    return root
+
+
+def _planning_authority() -> tuple[PlanningArtifactAuthority, ...]:
+    return (
+        PlanningArtifactAuthority(
+            ref=TASKS_REF,
+            kind="plan",
+            work_id=_WORK_ID,
+            baseline_sha256=hashlib.sha256(TASKS_BASELINE.encode()).hexdigest(),
+        ),
+        PlanningArtifactAuthority(
+            ref=PROPOSAL_REF,
+            kind="spec",
+            work_id=_WORK_ID,
+            baseline_sha256=hashlib.sha256(PROPOSAL_BASELINE.encode()).hexdigest(),
+        ),
+    )
+
+
+def _steps(*, build_passed: bool, review_passed: tuple[str, ...] = ()) -> tuple[WorkflowStep, ...]:
+    """build 一張 ＋ review 兩張（`code-review` → `adversarial-review`）。
+
+    兩張 review 卡的 `inputs`／`outputs` 沿用 deck 的形狀：第二張的 `requires` 就是
+    第一張的 `produces`（見 `deck/data/cards.yaml`），那正是本票必須維持的交接。
+    """
+
+    return (
+        WorkflowStep(
+            phase="build",
+            persona="builder",
+            card="subagent-build",
+            executor="codex" if build_passed else None,
+            model="gpt-primary" if build_passed else None,
+            domain="openai" if build_passed else None,
+            inputs=(),
+            outputs=(),
+            commit_policy="required",
+            test_policy="focused",
+            gate_result="passed" if build_passed else "pending",
+        ),
+        WorkflowStep(
+            phase="review",
+            persona="reviewer",
+            card="code-review",
+            executor=None,
+            model=None,
+            domain=None,
+            inputs=(),
+            outputs=("reports/review/*.md",),
+            gate_result="passed" if "code-review" in review_passed else "pending",
+        ),
+        WorkflowStep(
+            phase="review",
+            persona="reviewer",
+            card="adversarial-review",
+            executor=None,
+            model=None,
+            domain=None,
+            inputs=("reports/review/*.md",),
+            outputs=("reports/review/*.md",),
+            gate_result="passed" if "adversarial-review" in review_passed else "pending",
+        ),
+    )
+
+
+def _identities() -> IdentityRegistry:
+    return IdentityRegistry.from_rows(
+        [
+            {
+                "executor": "codex",
+                "model_id": "gpt-primary",
+                "independence_domain": "openai",
+                "capabilities": ["build"],
+            },
+            {
+                "executor": "claude",
+                "model_id": "sonnet-primary",
+                "independence_domain": "anthropic",
+                "capabilities": ["build", "review"],
+            },
+        ]
+    )
+
+
+class _RecordingLauncher:
+    """記下每次 launch 的 `slice_id`／`worktree`（reviewer 的 worktree ＝ sandbox）。"""
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, str]] = []
+
+    def as_commit_required(self) -> "_RecordingLauncher":
+        return self
+
+    def as_review_only(self, *, terminal_kind: str) -> "_RecordingLauncher":
+        self.terminal_kind = terminal_kind
+        return self
+
+    def launch(self, *, slice_id: str, prompt: str, worktree: str, log_dir: str) -> LaunchHandle:
+        self.calls.append({"slice_id": slice_id, "worktree": worktree, "prompt": prompt})
+        return LaunchHandle(
+            executor="claude",
+            model_id="sonnet-primary",
+            session_name=slice_id,
+            pid=100,
+            log_path=f"{log_dir}/{slice_id}.jsonl",
+        )
+
+
+class _Harness:
+    def __init__(self, tmp_path: Path) -> None:
+        self.source = _source_repo(tmp_path / "source")
+        self.pool = worktree_root_for(self.source)
+        self.coordinator_root = tmp_path / "coordinator"
+        self.registry = JobRegistry(state_path=self.coordinator_root / "jobs.json")
+        self.run = self.registry._manager_create_workflow_run(
+            work_id=_WORK_ID,
+            repo=_REPO,
+            claim_key="claim:v1:" + "1" * 64,
+            source_revision="2" * 64,
+            workspace_root=str(self.source),
+            combo="feature-oneshot",
+            current_phase="build",
+            steps=_steps(build_passed=False),
+            issue_refs=(f"{_REPO}#650",),
+            openspec_refs=(),
+            pr_refs=(),
+            attempts={"build": 1},
+            gate_status="running",
+            planning_authority=_planning_authority(),
+        )
+        self.builder_clone: Path | None = None
+
+    # -- dispatch -----------------------------------------------------------
+
+    def dispatch(self, *, force_new_card: bool = False) -> tuple[dict[str, object], _RecordingLauncher]:
+        creator = seams.ScriptWorktreeCreator(
+            repo=self.source, wt_root=self.pool, base="main"
+        )
+        dispatcher = type(
+            "D",
+            (),
+            {"_registry": self.registry, "_worktree_creator": creator, "_git_runner": None},
+        )()
+        launcher = _RecordingLauncher()
+        dispatched = manager.dispatch_workflow_card(
+            dispatcher,
+            run=self.registry.get_workflow_run(self.run.run_id),
+            identities=_identities(),
+            launcher_factory=lambda _identity: launcher,
+            coordinator_root=self.coordinator_root,
+            force_new_card=force_new_card,
+        )
+        assert dispatched is not None
+        return self.registry.get_job(str(dispatched["job_id"])), launcher
+
+    # -- build phase --------------------------------------------------------
+
+    def land_a_candidate(
+        self, *, tasks_text: str = TASKS_TICKED, force_new_card: bool = False
+    ) -> str:
+        """跑完一張 build 卡：provision → commit → #637 交接 → 採信。"""
+
+        job, _launcher = self.dispatch(force_new_card=force_new_card)
+        clone = Path(str(job["worktree"]))
+        self.builder_clone = clone
+        (clone / TASKS_REF).write_text(tasks_text, encoding="utf-8")
+        _git(clone, "add", "-A")
+        _git(clone, "commit", "-qm", "build: tick a checkbox")
+        candidate = _git(clone, "rev-parse", "HEAD").lower()
+
+        spool_key = job_workspace.spool_key_for_job(job) or str(job["job_id"])
+        bundle = job_workspace.prepare_commit_spool(
+            spool_key=spool_key, coordinator_root=self.coordinator_root
+        )
+        produced = subprocess.run(
+            ["bash", "-c", job_workspace.build_bundle_command(workspace=clone, bundle=bundle)],
+            capture_output=True,
+            text=True,
+        )
+        assert produced.returncode == 0, produced.stderr
+        harvested = job_workspace.harvest_branch(
+            source_repo=self.source, bundle=bundle, branch=str(job["branch"])
+        )
+        assert harvested.lower() == candidate
+
+        self.registry.update_headless_result(
+            str(job["job_id"]), status="exited", exit_code=0
+        )
+        self.registry.bind_workflow_evidence(
+            str(job["job_id"]),
+            locator={"kind": "build", "path": "evidence/workflow/fake.json", "hash": "a" * 64},
+            subject_head=candidate,
+        )
+        self.run = self.registry._manager_update_workflow_run(
+            self.run.run_id,
+            steps=_steps(build_passed=True),
+            candidate_head=candidate,
+        )
+        return candidate
+
+    def advance_to_review(self) -> None:
+        """phase 只能一格一格往前（`validate_workflow_phase_transition`）。"""
+
+        for phase in ("verify", "review"):
+            self.run = self.registry._manager_update_workflow_run(
+                self.run.run_id, current_phase=phase
+            )
+
+    def reopen_build_for_retry(self, *, candidate: str) -> None:
+        """走**真的** `retry-build` 原子重置，把最後一張 build 卡打回 pending。"""
+
+        self.registry._manager_update_workflow_run(
+            self.run.run_id,
+            facets=("needs_human",),
+            gate_status="running",
+            needs_human_reason=fixture_needs_human_reason(),
+        )
+        self.run = self.registry._manager_reset_workflow_for_retry_build(
+            self.run.run_id,
+            expected_candidate=candidate,
+            repair_action="review 提出阻擋性 findings，重跑 build 卡",
+        )
+
+    # -- review phase -------------------------------------------------------
+
+    def accept_review_card(self, job: dict[str, object], card: str) -> None:
+        self.registry.update_headless_result(
+            str(job["job_id"]), status="exited", exit_code=0
+        )
+        self.run = self.registry._manager_update_workflow_run(
+            self.run.run_id, steps=_steps(build_passed=True, review_passed=(card,))
+        )
+
+    def publish_report(self, job: dict[str, object], *, body: str) -> str:
+        """走**正式**的 canonical report 發佈通道，把 report 落進 `workflow_repo_root`。
+
+        production 路徑是 `terminalize_workflow_job()` 在 evidence 綁定前後包一層這個
+        transaction；這裡直接用同一個 publisher，不另抄一份寫檔。
+        """
+
+        transaction = manager._WorkflowReportPublicationTransaction(
+            repo_root=Path(str(job["workflow_repo_root"])),
+            coordinator_root=self.coordinator_root,
+            job_id=str(job["job_id"]),
+        )
+        transaction.publish(
+            ((REPORT_REF, body),),
+            job=job,
+            candidate=str(job["subject_head"]),
+        )
+        transaction.commit()
+        return REPORT_REF
+
+    # -- derived paths ------------------------------------------------------
+
+    def candidate_tree(self, candidate: str) -> Path:
+        """這一輪 verify／review 實際使用的 candidate 樹（由產品的推導點算出來）。"""
+
+        return job_workspace.workspace_path(
+            self.pool,
+            manager._reviewer_candidate_workspace_id(
+                self.registry.get_workflow_run(self.run.run_id), candidate
+            ),
+        )
+
+
+# ---------------------------------------------------------------------------
+# 1. 本票的全部價值：verify／review 不再讀前一張 build 卡的工作區
+# ---------------------------------------------------------------------------
+
+
+def test_review_dispatch_works_after_the_builder_clone_is_deleted(tmp_path: Path) -> None:
+    """把前一張 build 卡的工作區整棵刪掉，review 卡仍派得出去。
+
+    這是「卡被採信之後即時回收它的工作區」的機械前提：只要 verify／review 還讀那棵樹，
+    就回收不掉。刪除版對任何 UID 都成立，因此是本檔的主測試。
+    """
+
+    harness = _Harness(tmp_path)
+    candidate = harness.land_a_candidate()
+    harness.advance_to_review()
+    assert harness.builder_clone is not None
+    shutil.rmtree(harness.builder_clone)
+    assert not harness.builder_clone.exists()
+
+    job, launcher = harness.dispatch()
+
+    assert job["persona"] == "reviewer"
+    assert job["workflow_card"] == "code-review"
+    assert job["subject_head"] == candidate
+    # candidate 樹是 Manager 自己 clone 的那一棵，不是（已不存在的）builder clone。
+    assert Path(str(job["workflow_repo_root"])) == harness.candidate_tree(candidate)
+    assert len(launcher.calls) == 1
+
+
+@pytest.mark.skipif(
+    os.geteuid() == 0, reason="root 不受目錄權限限制，`chmod 000` 這條不變式驗不到"
+)
+def test_review_dispatch_works_while_the_builder_clone_is_unreadable(
+    tmp_path: Path,
+) -> None:
+    """把 builder 的 clone `chmod 000`——實機上 `0700 cortex-builder` 對 Manager 的樣子。
+
+    本票之前這裡必炸，而且不只是「讀」：`_workflow_input_snapshot()` 會往那棵樹
+    `mkdir`＋`mkstemp` seed 缺席的 planning authority 檔，`planning_runtime._tree_snapshot()`
+    會遞迴走完整棵樹。#641 收掉 Manager 對 job 工作樹的唯讀 ACL 之後，兩步都是
+    `Permission denied`。形狀沿用 #653 的
+    `test_ship_phase_completes_while_the_builder_clone_is_unreadable`。
+    """
+
+    harness = _Harness(tmp_path)
+    candidate = harness.land_a_candidate()
+    harness.advance_to_review()
+    assert harness.builder_clone is not None
+    os.chmod(harness.builder_clone, 0o000)
+    try:
+        # 前提成立：這棵樹現在真的進不去。
+        assert (
+            subprocess.run(
+                ["git", "-C", str(harness.builder_clone), "status"], capture_output=True
+            ).returncode
+            != 0
+        )
+        job, _launcher = harness.dispatch()
+    finally:
+        os.chmod(harness.builder_clone, 0o700)
+
+    assert job["persona"] == "reviewer"
+    assert Path(str(job["workflow_repo_root"])) == harness.candidate_tree(candidate)
+    # 那棵 clone 的 HEAD 與工作區內容一個位元組沒被動過。
+    assert _git(harness.builder_clone, "rev-parse", "HEAD").lower() == candidate
+    assert _git(harness.builder_clone, "status", "--porcelain") == ""
+
+
+# ---------------------------------------------------------------------------
+# 2. candidate 樹的身分
+# ---------------------------------------------------------------------------
+
+
+def test_the_candidate_tree_is_a_manager_owned_clone_at_the_accepted_candidate(
+    tmp_path: Path,
+) -> None:
+    """身分：pool 底下、真 clone（`.git` 是目錄）、標記檔對得上、HEAD 恰為 candidate。"""
+
+    harness = _Harness(tmp_path)
+    candidate = harness.land_a_candidate()
+    harness.advance_to_review()
+    job, _launcher = harness.dispatch()
+
+    tree = Path(str(job["workflow_repo_root"]))
+    assert tree == harness.candidate_tree(candidate)
+    assert tree.parent == harness.pool
+    assert tree != harness.builder_clone
+    assert job_workspace.is_job_clone(tree)
+    # clone 模型（#623）：`.git` 是目錄，不得退回共用 object store 的 linked worktree。
+    assert (tree / ".git").is_dir()
+    assert not job_workspace.is_linked_worktree(tree)
+    marker = job_workspace.read_marker(tree)
+    assert isinstance(marker, dict)
+    assert marker["branch"] == str(job["branch"])
+    assert str(marker["base"]).lower() == candidate
+    assert _git(tree, "rev-parse", "HEAD").lower() == candidate
+    assert _git(tree, "symbolic-ref", "--short", "HEAD") == str(job["branch"])
+    # 來源樹沒有被 clone 弄髒，仍停在 main。
+    assert _git(harness.source, "symbolic-ref", "--short", "HEAD") == "main"
+
+
+def test_the_candidate_tree_is_not_the_job_worktree(tmp_path: Path) -> None:
+    """`direct` 零回歸 ＋ #648 邊界：reviewer job 的欄位形狀一格未改。
+
+    `worktree` 仍是 reviewer sandbox、`workflow_input_root` 仍是 sandbox 裡的
+    checkout、`workflow_repo_root` 仍是 candidate 樹。candidate 樹**不是** job 的
+    工作區，因此 #648 的 `ReadWritePaths=<pool>/%i` 不變式本來就不落在它身上——這條
+    是票上「不是 blocking，是耦合」那句話的機械形式。
+    """
+
+    harness = _Harness(tmp_path)
+    candidate = harness.land_a_candidate()
+    harness.advance_to_review()
+    job, launcher = harness.dispatch()
+
+    sandbox = Path(str(job["worktree"]))
+    checkout = Path(str(job["workflow_input_root"]))
+    tree = Path(str(job["workflow_repo_root"]))
+
+    assert launcher.calls[0]["worktree"] == str(sandbox)
+    assert sandbox.parent == harness.coordinator_root.resolve() / "review-sandboxes"
+    assert checkout == sandbox / "candidate"
+    assert _git(checkout, "rev-parse", "HEAD").lower() == candidate
+    assert tree not in {sandbox, checkout}
+    # 目錄名由 (run, candidate) 導出，**不是** job_id ⇒ 與模板 unit 的 `%i` 無關。
+    assert tree.name != job_workspace.job_segment(str(job["job_id"]))
+    workspace_id = manager._reviewer_candidate_workspace_id(
+        harness.registry.get_workflow_run(harness.run.run_id), candidate
+    )
+    assert workspace_id.endswith(f"-review-{candidate[:12]}")
+    assert tree.name == job_workspace.job_segment(workspace_id)
+
+
+def test_dispatch_fails_closed_when_the_candidate_never_reached_the_source_tree(
+    tmp_path: Path,
+) -> None:
+    """交接沒走完（來源樹沒有這個 commit）時 provision 不起來，而不是靜默走下去。
+
+    守衛用的是 `ScriptWorktreeCreator` 既有的 `rev-parse --verify <base>^{commit}`，
+    訊息逐字沿用——與 #648 的 build 交接同一條。
+    """
+
+    harness = _Harness(tmp_path)
+    job, _launcher = harness.dispatch()
+    clone = Path(str(job["worktree"]))
+    (clone / TASKS_REF).write_text(TASKS_TICKED, encoding="utf-8")
+    _git(clone, "add", "-A")
+    _git(clone, "commit", "-qm", "build: never harvested")
+    candidate = _git(clone, "rev-parse", "HEAD").lower()
+    harness.registry.update_headless_result(
+        str(job["job_id"]), status="exited", exit_code=0
+    )
+    harness.registry.bind_workflow_evidence(
+        str(job["job_id"]),
+        locator={"kind": "build", "path": "evidence/workflow/fake.json", "hash": "a" * 64},
+        subject_head=candidate,
+    )
+    harness.run = harness.registry._manager_update_workflow_run(
+        harness.run.run_id,
+        steps=_steps(build_passed=True),
+        candidate_head=candidate,
+    )
+    harness.advance_to_review()
+
+    with pytest.raises(ValueError, match="git worktree base invalid"):
+        harness.dispatch()
+
+
+# ---------------------------------------------------------------------------
+# 3. 語意不變（這三個進 evidence）
+# ---------------------------------------------------------------------------
+
+
+def test_sandbox_hash_input_snapshot_and_output_baseline_keep_their_meaning(
+    tmp_path: Path,
+) -> None:
+    """三個進 evidence 的量在新模型下與舊模型逐位元相同。
+
+    - `workflow_sandbox_hash`：舊模型是 `_tree_snapshot(builder 的 clone)`。兩棵樹是
+      **同一個 commit 的兩份乾淨 checkout**，`_tree_snapshot` 排除 `.git`，因此雜湊
+      必須相等——這條斷言就是「換了一棵樹但看到的內容一模一樣」的機械證明。
+    - **input snapshot**：#310 的 checkbox 容忍仍以**候選實際內容**為 pinned 期望值
+      （builder 勾過的 `tasks.md`），不是 claim 當下的 baseline。容忍若失效，
+      `foreign_review.verify_authority_in_input_snapshot()` 會在 dispatch 當場炸開。
+    - **output baseline**：candidate 樹上還沒有 review report ⇒ 空，與舊模型相同。
+    """
+
+    harness = _Harness(tmp_path)
+    candidate = harness.land_a_candidate()
+    harness.advance_to_review()
+    assert harness.builder_clone is not None
+    builder_snapshot = planning_runtime._tree_snapshot(harness.builder_clone)
+
+    job, _launcher = harness.dispatch()
+
+    assert job["workflow_sandbox_hash"] == builder_snapshot
+    assert job["workflow_sandbox_hash"] == planning_runtime._tree_snapshot(
+        Path(str(job["workflow_repo_root"]))
+    )
+
+    rows = {row["path"]: row for row in job["workflow_input_snapshot"]}
+    assert set(rows) == {TASKS_REF, PROPOSAL_REF}
+    # 勾過的 tasks.md：pinned 期望值 ＝ 候選的實際 hash（#310），不是 baseline。
+    assert rows[TASKS_REF]["sha256"] == hashlib.sha256(TASKS_TICKED.encode()).hexdigest()
+    assert rows[TASKS_REF]["sha256"] != hashlib.sha256(TASKS_BASELINE.encode()).hexdigest()
+    assert rows[TASKS_REF]["authority"] == "planning-authority"
+    # 沒被動過的 proposal.md：仍是 baseline。
+    assert rows[PROPOSAL_REF]["sha256"] == hashlib.sha256(PROPOSAL_BASELINE.encode()).hexdigest()
+
+    assert job["workflow_output_baseline"] == []
+
+    # 採信時 `_verify_exact_candidate()` 對 reviewer 讀的就是 `workflow_repo_root`。
+    assert manager._verify_exact_candidate(job) == candidate
+
+
+# ---------------------------------------------------------------------------
+# 4. 卡與卡的交接：canonical report 是下一張 review 卡的宣告輸入
+# ---------------------------------------------------------------------------
+
+
+def test_both_review_cards_of_one_candidate_share_the_tree_and_its_report(
+    tmp_path: Path,
+) -> None:
+    """`code-review` 發佈的 report 必須被 `adversarial-review` 的 input snapshot 看到。
+
+    這條是「candidate 樹的識別穩定於 (run, candidate) 而**不是** per-job」的理由：
+    `adversarial-review` 的 `requires` 就是 `code-review` 的 `produces`，而 canonical
+    report 是 Manager 發佈在 `workflow_repo_root` 裡的**未追蹤檔**（#653 之後不再被
+    ship 段清掉）。每張卡各自 clone 一棵乾淨的樹，那個 glob 會落空 ⇒
+    `workflow declared input missing`。
+    """
+
+    harness = _Harness(tmp_path)
+    candidate = harness.land_a_candidate()
+    harness.advance_to_review()
+
+    first, _ = harness.dispatch()
+    tree = Path(str(first["workflow_repo_root"]))
+    created_at = job_workspace.read_marker(tree)["created_at"]
+    body = "---\ncandidate: " + candidate + "\n---\n\n# Review\n\n找不到阻擋性問題。\n"
+    harness.publish_report(first, body=body)
+    assert (tree / REPORT_REF).is_file()
+    harness.accept_review_card(first, "code-review")
+
+    second, _ = harness.dispatch()
+
+    assert second["workflow_card"] == "adversarial-review"
+    # 同一棵樹（標記檔的 created_at 沒變 ⇒ 沒有重新 clone），report 原地還在。
+    assert Path(str(second["workflow_repo_root"])) == tree
+    assert job_workspace.read_marker(tree)["created_at"] == created_at
+    assert (tree / REPORT_REF).is_file()
+
+    rows = {row["path"]: row for row in second["workflow_input_snapshot"]}
+    assert REPORT_REF in rows
+    assert rows[REPORT_REF]["sha256"] == hashlib.sha256(
+        (tree / REPORT_REF).read_bytes()
+    ).hexdigest()
+    assert rows[REPORT_REF]["authority"] == "worktree"
+    # 前一張卡的產出也進了 output baseline，artifact 校驗因此看得到「本來就有的東西」。
+    baseline = {row["path"]: row["sha256"] for row in second["workflow_output_baseline"]}
+    assert baseline[REPORT_REF] == rows[REPORT_REF]["sha256"]
+    # reviewer 真的在 sandbox 裡看得到那份 report（seed 自 evidence store，不是 clone）。
+    assert (Path(str(second["workflow_input_root"])) / REPORT_REF).is_file()
+
+
+def test_a_new_candidate_gets_a_new_candidate_tree(tmp_path: Path) -> None:
+    """candidate 前進（retry-build／post-archive 重驗）就換一棵樹，前一棵原地留著。
+
+    這是對的：新 candidate 的 review phase 從頭跑起，舊 candidate 的 report 不該被它
+    讀到。舊那一棵交給 `cortex work gc`，與 build／ship 卡的 clone 同一套。
+    """
+
+    harness = _Harness(tmp_path)
+    first_candidate = harness.land_a_candidate()
+    harness.advance_to_review()
+    first, _ = harness.dispatch()
+    first_tree = Path(str(first["workflow_repo_root"]))
+    harness.publish_report(first, body="---\nx: 1\n---\n\n# Review\n")
+
+    # 走**真的** `retry-build`：review 提出阻擋性 findings → 最後一張 build 卡重開。
+    harness.registry.update_headless_result(
+        str(first["job_id"]), status="exited", exit_code=1
+    )
+    harness.reopen_build_for_retry(candidate=first_candidate)
+    second_candidate = harness.land_a_candidate(
+        tasks_text=TASKS_TICKED.replace("- [ ] 1.2", "- [x] 1.2"),
+        force_new_card=True,
+    )
+    assert second_candidate != first_candidate
+    harness.advance_to_review()
+
+    second, _ = harness.dispatch(force_new_card=True)
+    second_tree = Path(str(second["workflow_repo_root"]))
+
+    assert second_tree != first_tree
+    assert second_tree == harness.candidate_tree(second_candidate)
+    assert _git(second_tree, "rev-parse", "HEAD").lower() == second_candidate
+    # 前一棵原地留著（回收是 `cortex work gc` 的事），但新的那一棵沒有舊 report。
+    assert first_tree.is_dir()
+    assert (first_tree / REPORT_REF).is_file()
+    assert not (second_tree / REPORT_REF).exists()
+
+
+# ---------------------------------------------------------------------------
+# 5. 重用的守衛
+# ---------------------------------------------------------------------------
+
+
+def test_reusing_the_candidate_tree_fails_closed_when_its_head_moved(
+    tmp_path: Path,
+) -> None:
+    """這棵樹只有 Manager 寫。HEAD 被第三方動過就 fail-closed，不自癒、不刪。
+
+    自癒（整棵重建）會把前一張 review 卡的 report 一起丟掉，讓下一張卡以
+    `workflow declared input missing` 這種與成因無關的訊息失敗。
+    """
+
+    harness = _Harness(tmp_path)
+    harness.land_a_candidate()
+    harness.advance_to_review()
+    first, _ = harness.dispatch()
+    tree = Path(str(first["workflow_repo_root"]))
+    harness.accept_review_card(first, "code-review")
+    (tree / "intruder.txt").write_text("x\n", encoding="utf-8")
+    _git(tree, "add", "intruder.txt")
+    _git(tree, "commit", "-qm", "third party commit")
+
+    with pytest.raises(ValueError, match="candidate workspace head mismatch"):
+        harness.dispatch()
+
+
+@pytest.mark.skip(
+    reason="需要真的三分 UID：CI 以單一 UID 跑，`chown cortex-builder` 與 `getfacl` "
+    "的具名條目都造不出來，`chmod 000` 只是同一件事的近似。稽核步驟寫在 "
+    "docs/superpowers/runbooks/trust-root-phase2b-setup.md（`wf-*-review-*` 那段）"
+    "——#638／#657 的教訓：測不到就明確 skip 並說明，不得靜默通過。"
+)
+def test_candidate_tree_is_owned_by_cortex_manager_with_no_named_acl() -> None:
+    """實機稽核項（單 UID 驗不到）：
+
+        stat -c '%U %a' /var/lib/cortex/worktree/wf-*-review-*   → cortex-manager 700
+        getfacl -p /var/lib/cortex/worktree/wf-*-review-* | grep -c '^user:'  → 0
+
+    第二條是 #641／#644 的紅線在這條 lane 上的形式：candidate 樹是 Manager 自己
+    clone 的，不該有任何指向 job 工作樹的具名 ACL 條目，runbook 稽核 5b 的「零
+    `setfacl`」因此仍然成立。
+    """
+
+
+def test_untracked_reports_do_not_count_as_drift(tmp_path: Path) -> None:
+    """未追蹤檔刻意放行——canonical report 就是未追蹤檔，也正是交接的載體。
+
+    ship 段那條「完全乾淨」（`work_bridge._require_pristine_ship_workspace`）在這裡
+    會讓第二張 review 卡永遠開不了工，因此判準是 `--untracked-files=no`。
+    """
+
+    harness = _Harness(tmp_path)
+    candidate = harness.land_a_candidate()
+    harness.advance_to_review()
+    first, _ = harness.dispatch()
+    tree = Path(str(first["workflow_repo_root"]))
+
+    manager._require_reviewer_candidate_workspace(
+        tree, branch=str(first["branch"]), candidate=candidate
+    )
+    (tree / REPORT_REF).parent.mkdir(parents=True, exist_ok=True)
+    (tree / REPORT_REF).write_text("# untracked report\n", encoding="utf-8")
+    manager._require_reviewer_candidate_workspace(
+        tree, branch=str(first["branch"]), candidate=candidate
+    )
+
+    # 追蹤檔被改動則不放行。
+    (tree / TASKS_REF).write_text(TASKS_BASELINE, encoding="utf-8")
+    with pytest.raises(ValueError, match="candidate workspace has tracked drift"):
+        manager._require_reviewer_candidate_workspace(
+            tree, branch=str(first["branch"]), candidate=candidate
+        )

--- a/tests/test_reviewer_card_retry_569.py
+++ b/tests/test_reviewer_card_retry_569.py
@@ -125,7 +125,12 @@ def _steps_stopped_at(card: str):
 
 
 def _init_candidate_repo(repo: Path) -> str:
-    """真實 git repo：reviewer sandbox 是 `git clone` + `checkout <candidate>`。"""
+    """真實 git repo：reviewer sandbox 是 `git clone` + `checkout <candidate>`。
+
+    #650 之後這棵樹是 **run.workspace_root（來源樹）**，不再是 builder 的工作區：
+    candidate 由 `_harvest_build_candidate()` 搬進來源樹，verify／review 卡的
+    candidate 樹是 Manager 自己從那裡 clone 出來的。
+    """
 
     repo.mkdir(parents=True, exist_ok=True)
     subprocess.run(["git", "-C", str(repo), "init", "-q"], check=True)
@@ -178,14 +183,17 @@ def _stuck_reviewer_run(
     已有一顆乾淨終止（exit 0）但 log 無 JSON envelope、evidence 未綁定的 job。"""
 
     workspace = tmp_path / "workspace"
-    workspace.mkdir(parents=True, exist_ok=True)
-    (workspace / PLAN_REF).parent.mkdir(parents=True, exist_ok=True)
-    (workspace / PLAN_REF).write_text(PLAN_TEXT, encoding="utf-8")
     builder_worktree = tmp_path / "builder-worktree"
+    builder_worktree.mkdir(parents=True, exist_ok=True)
     if with_git:
-        candidate = _init_candidate_repo(builder_worktree)
+        # #650：candidate 在**來源樹**裡（harvest 之後的實況），reviewer 的 candidate
+        # 樹由 Manager 從這裡 clone。builder 的工作區留成一個普通目錄——本票的重點
+        # 就是 verify／review 派工不再讀它。
+        candidate = _init_candidate_repo(workspace)
     else:
-        builder_worktree.mkdir(parents=True, exist_ok=True)
+        workspace.mkdir(parents=True, exist_ok=True)
+        (workspace / PLAN_REF).parent.mkdir(parents=True, exist_ok=True)
+        (workspace / PLAN_REF).write_text(PLAN_TEXT, encoding="utf-8")
         candidate = "d" * 40
 
     snapshot = _snapshot(tmp_path / "snapshot.json")

--- a/tests/test_ship_out_of_builder_clone_653.py
+++ b/tests/test_ship_out_of_builder_clone_653.py
@@ -355,9 +355,9 @@ def test_archive_to_policy_commit_handoff_binds_the_archive_job(
     assert archive_job["persona"] == "manager"
     assert archive_job["executor"] == "cortex-manager"
     # #653：記在 archive 卡上的工作區是 **Manager-owned 的 ship 樹**，不是
-    # builder 的 clone。post-archive 的 verify／review 卡以
-    # `builder_jobs[-1]["worktree"]` 當 candidate 樹，因此這棵樹不得在 ship 段
-    # 結束時被刪掉（回收交給 `cortex work gc`，與 build 卡的 clone 同一套）。
+    # builder 的 clone。這棵樹是 archive 卡的稽核定錨，不得在 ship 段結束時被刪掉
+    # （回收交給 `cortex work gc`，與 build 卡的 clone 同一套）。#650 之後
+    # post-archive 的 verify／review 卡改用自己的 `-review-` 樹，不再讀這一棵。
     assert archive_job["worktree"] == str(workspace)
     assert workspace.is_dir()
     assert workspace != harness.worktree

--- a/tests/test_workflow_production_wiring.py
+++ b/tests/test_workflow_production_wiring.py
@@ -5130,27 +5130,33 @@ def test_reviewer_disposable_checkout_detects_candidate_mutation(tmp_path: Path)
 def test_operator_resume_replaces_exact_bound_reviewer_without_terminal_json(
     tmp_path: Path,
 ) -> None:
+    # #650：candidate 必須在**來源樹**（`run.workspace_root`）裡——那是
+    # `_harvest_build_candidate()` 之後的實況，也是 verify／review 卡的 candidate 樹
+    # 現在 clone 的來源。`repo` 留成 builder 那一份 clone（本票之後派工不再讀它，只
+    # 有既有 job 記錄還指著它）。
     workspace = tmp_path / "workspace"
     workspace.mkdir()
-    repo = tmp_path / "repo"
-    repo.mkdir()
-    subprocess.run(["git", "-C", str(repo), "init", "-q"], check=True)
+    subprocess.run(["git", "-C", str(workspace), "init", "-q"], check=True)
     subprocess.run(
-        ["git", "-C", str(repo), "config", "user.email", "canary@example.invalid"],
+        ["git", "-C", str(workspace), "config", "user.email", "canary@example.invalid"],
         check=True,
     )
     subprocess.run(
-        ["git", "-C", str(repo), "config", "user.name", "Canary"], check=True
+        ["git", "-C", str(workspace), "config", "user.name", "Canary"], check=True
     )
-    (repo / "README.md").write_text("candidate\n", encoding="utf-8")
-    subprocess.run(["git", "-C", str(repo), "add", "README.md"], check=True)
-    subprocess.run(["git", "-C", str(repo), "commit", "-qm", "base"], check=True)
+    (workspace / "README.md").write_text("candidate\n", encoding="utf-8")
+    subprocess.run(["git", "-C", str(workspace), "add", "README.md"], check=True)
+    subprocess.run(["git", "-C", str(workspace), "commit", "-qm", "base"], check=True)
     candidate = subprocess.run(
-        ["git", "-C", str(repo), "rev-parse", "HEAD"],
+        ["git", "-C", str(workspace), "rev-parse", "HEAD"],
         check=True,
         capture_output=True,
         text=True,
     ).stdout.strip()
+    repo = tmp_path / "repo"
+    subprocess.run(
+        ["git", "clone", "-q", "--no-hardlinks", str(workspace), str(repo)], check=True
+    )
     steps = tuple(
         WorkflowStep.from_dict(
             {


### PR DESCRIPTION
Closes #650

## 查證（票上第一步，結論改變了選路）

### 六個用途各自真正需要什麼

| # | 用途 | 真正需要的是 | 「來源樹就夠」？ |
|---|---|---|:--:|
| 1 | `_authority_map_with_checkbox_tolerance(candidate_root=…)` | **candidate 內容的檔案系統視圖**——#310 的 checkbox 容忍要拿 builder 勾過的 `tasks.md` 實檔當 pinned 期望值 | ✗ 來源樹的工作目錄停在 `main`（未勾版） |
| 2 | `_workflow_input_snapshot(repo_root=…)` | **可寫**的 candidate 內容視圖：它 glob 宣告輸入，並把缺席的 planning authority 檔 `mkdir`＋`mkstemp`＋`os.replace` **seed 進去** | ✗ 同上，且不得往共用來源樹寫 |
| 3 | `_workflow_output_baseline(…)` | **canonical report 將被發佈的那棵樹**——baseline 與 `_canonical_workflow_artifacts()` 的校驗必須同根 | ✗ |
| 4 | `_create_reviewer_sandbox(candidate_root=…)` | 只要 **object store 裡有 candidate 這個 commit**（`git clone` ＋ `checkout --detach`） | ✓ |
| 5 | `planning_runtime._tree_snapshot(…)` → `workflow_sandbox_hash` | 一棵 **reviewer 不該碰的樹**（逃逸偵測的觀測對象），且必須活過 sandbox 拆除 | ✗ |
| 6 | job 記錄的 `workflow_repo_root` | 一棵 **HEAD 恰為 candidate、可寫、跨卡穩定**的樹 | ✗ |

**只有第 4 個「來源樹就夠」。** 其餘五個都要一棵真的 checkout 在 candidate 上、且
Manager 可寫的樹。

用途 6 是最關鍵的一條，票上沒展開：`workflow_repo_root` 同時是三件事的根——
`_verify_exact_candidate()` 對 reviewer job 驗 `rev-parse HEAD == candidate`（採信路徑）、
`_WorkflowReportPublicationTransaction` 往它發佈 canonical report、而**下一張 review 卡的
宣告輸入就是上一張發佈進去的那份 report**：

```
deck/data/cards.yaml
  code-review          produces: ["reports/review/*<task-slug>*.md"]
  adversarial-review   requires: ["reports/review/*<task-slug>*.md"]   ← 同一個 glob
```

canonical report 是 Manager 發佈在那棵樹裡的**未追蹤檔**（#653 之後不再被 ship 段清掉），
`_workflow_input_snapshot()` 是用檔案系統 glob 找到它的。**candidate 樹因此是卡與卡的
交接載體，不只是「一份 candidate 的副本」。**

### `_is_exact_reviewer_terminal_recovery()` 是第七個消費端（票上沒列）

它另外硬性要求 `workflow_repo_root == builder job 的 worktree`，同樣得一起改。

## 選的方向：A′（per-(run, candidate) 的 Manager-owned clone）

推翻票上三個選項的推導：

- **B 不成立**（operator 傾向的那個）：把用途 1／2／5 改讀 `reviewer_checkout` 是可行的，
  但用途 3／6 不行——(a) `_discard_reviewer_sandbox()` 在 report 發佈**之前**就把 sandbox
  `rmtree` 掉，發佈目標不能在 sandbox 裡；(b) sandbox 是 per-card 的，`code-review` 發佈的
  report 傳不到 `adversarial-review` ⇒ `workflow declared input missing`。
  「其餘四個改讀 `reviewer_checkout`」這句在用途 3／6 上落不了地。
- **A（per-job clone）也不成立**：同一個 (b)。per-job ⇒ 每張 review 卡一棵乾淨的樹 ⇒
  上一張卡的 report 不在裡面。票上提到的「回收端要認得 `workflow_repo_root`」反而是小問題，
  真正的阻擋是交接。
- **C 最差**（票上已判，同意）：把耦合固化成回收邏輯裡的特例。
- **A′ ＝ 識別穩定於 (run, candidate) 的 Manager-owned clone**：形狀完全沿用 #653 的
  `work_bridge._manager_ship_workspace()`（operator 指名的範本）。六個用途**語意逐條不變**，
  只是換成一棵 Manager 自己的樹。B 的核心洞見（來源樹 harvest 之後就有 candidate）**被保留**
  ——這棵樹正是從來源樹 clone 的，`_create_reviewer_sandbox()` 也不必再碰 builder 的樹。

## 順序問題（`_workflow_input_snapshot()` vs `_create_reviewer_sandbox()`）

票上點名：input snapshot 是 sandbox 的輸入，算它時 sandbox 還不存在。

**A′ 下這個問題不存在，不是被解決。** 借的正是 #653 對 `archive-applied-needs-commit`
重入用的那條——「同一次 `validate()` 內結構性共用同一個 provisioning」。這裡是：candidate
樹在 reviewer 分支**之前**建好一次，authority map／input snapshot／output baseline／
sandbox clone 源／tree snapshot 五個用途拿到**同一棵樹**。結構性的，不靠約定。

（B 之所以有順序問題，是因為它把 snapshot 的根搬進 sandbox；A′ 沒有把兩者疊在一起。）

## 落地

新增三個函式（`manager.py`）：

- `_reviewer_candidate_workspace_id(run, candidate)`——**唯一推導點**，
  `wf-<run 摘要>-review-<candidate 前綴>`，與 `_ship_workspace_id()` 同形只換中段。
  穩定於 (run, candidate) 而**不是** per-job，理由是上面的交接契約，不是省一次 clone。
- `_require_reviewer_candidate_workspace()`——開工前三條不變式：branch 對、HEAD ＝
  candidate、**追蹤檔**無漂移（`--untracked-files=no`）。**未追蹤檔刻意放行**：canonical
  report 就是未追蹤檔，也正是交接載體；ship 段那條「完全乾淨」用在這裡會讓第二張 review
  卡永遠開不了工。這棵樹只有 Manager 寫，三條任一不成立即 fail-closed——**不自癒、不刪**
  （整棵重建會把上一張卡的 report 一起丟掉，讓下一張卡以與成因無關的訊息失敗）。
- `_reviewer_candidate_workspace()`——以 `run.candidate_head` 為 base、用
  `seams.ScriptWorktreeCreator` 在**來源樹**上 clone。creator 的兩道既有守衛在這條 lane 上
  剛好就是要的：`rev-parse --verify <candidate>^{commit}`（來源樹必須已有這個 commit——那正是
  #637／#649 回收通道保證的不變式）與 `merge-base --is-ancestor`（#613 的形狀）。

`_dispatch_workflow_card()` 的 reviewer 分支改用它。**`builder_jobs[-1]["worktree"]` 在該
分支完全消失**（`branch` 仍取自同一筆 job 記錄，那是採信鏈不是磁碟依賴）。

`_is_exact_reviewer_terminal_recovery()` 的 candidate 樹定錨換成唯一推導點；舊形狀
（== builder job 的 `worktree`）**保留為容忍面**，讓升級當下已派出 reviewer job 的 run 仍走
得完 operator recovery。兩者都是「這個 repo_root 真的是本 run 的 candidate 樹」的定錨，
容忍不放寬語意。

## 順帶收掉的一個 #641 同型缺口

舊模型下 Manager 在 reviewer 派工當下對 builder 的 clone 做的**不只是讀**：用途 2 會往裡面
`mkdir`＋`mkstemp`＋`os.replace` seed 檔案，用途 5 會遞迴走完整棵樹。三分部署下那棵樹是
`0700 cortex-builder`，而 #641／#644 已收掉 Manager 的唯讀 ACL ⇒ **兩步都是
`Permission denied`**。與 ship 段（#653）同型，症狀一樣是**權限**不是 `226/NAMESPACE`。
突變驗證逐字重現了這句話（見「測試」）。

## 紅線遵守

- **沒有**把 Manager 對 job 工作樹的 ACL 加回來（#641／#644：那條授權唯一的消費端本身就是
  提權路徑）。candidate 樹是 Manager 自己 clone 的，`getfacl` 下不該有任何具名條目，runbook
  稽核 5b 的「零 `setfacl`」仍然成立。
- **沒有** `--reference`／`--shared`／任何把 object store 接回共用的優化（#623）。
- **沒有** `git -C <來源樹> fetch <某棵 job 的 clone>`；**回收通道一個位元組沒改**。
- `direct` 模式零回歸（全套 4027 測試綠；本 PR 一個位元組都沒碰 `job_runner`／`launcher`／
  `permgen`）。

## 即時回收：拆後續票 #658

票說即時回收是這件事的動機。解耦之後它**仍然不是一行**：
`worktree_reclaim.reclaim_worktree()` 的模組契約含**不銷毀證據**（未提交／未追蹤內容要先複製
到 preserve 封存再刪，封存失敗即 `failed`、一個位元組都不刪——#478 的資料遺失現場），而三分
部署下 Manager **讀不進** builder 的 `0700` clone ⇒ 那一步必然失敗。「誰以什麼身分回收
（wrapper 自刪／#629 第三身分／`ExecStopPost=`／只在 `direct` 即時收）」「封存在成果已走
bundle＋spool 之後還剩什麼要保」「abandon（#613）／retry-card（#601）的重入」三件事需要一次
講清楚 ⇒ **#658**。#650 驗收第 3 條移到那裡，其餘三條在本 PR 落地。

## 測試

新增 `tests/test_reviewer_candidate_tree_650.py`（10 條 ＋ 1 條 skip）。全部跑**正式路徑**：
真 git repo、真 `ScriptWorktreeCreator` provision 的 per-job clone、真
`manager.dispatch_workflow_card()`、真 #637 bundle ＋ append-only spool 交接、真
`_manager_reset_workflow_for_retry_build()`、真 `_create_reviewer_sandbox()`、真
`_WorkflowReportPublicationTransaction`。不手動 `git push`、不自己捏工作區。

- **解耦不變式（本票的全部價值）**：把前一張 build 卡的工作區 `rmtree` 掉 / `chmod 000`
  （＝實機上 `0700 cortex-builder` 對 Manager 的樣子），review 卡仍正確派得出去，且那棵
  clone 的 HEAD 與工作區一個位元組沒動。形狀沿用 #653 的
  `test_ship_phase_completes_while_the_builder_clone_is_unreadable`。
- **語意不變**：`workflow_sandbox_hash` 與**舊模型逐位元相同**（兩棵樹是同一個 commit 的
  兩份乾淨 checkout，`_tree_snapshot` 排除 `.git`）；input snapshot 的 #310 checkbox 容忍
  仍以候選實際內容為 pinned 期望值（不是 claim baseline）；output baseline 語意不變；
  `_verify_exact_candidate()` 在新的 `workflow_repo_root` 上仍回 candidate。
- **交接**：`code-review` 發佈的 report 出現在 `adversarial-review` 的 input snapshot、
  output baseline 與 sandbox checkout 裡；同一個 candidate 的兩張卡共用同一棵樹（標記檔
  `created_at` 沒變 ⇒ 沒有重新 clone）；candidate 前進（真的 `retry-build`）換一棵新的，
  前一棵原地留著。
- **fail-closed**：交接沒走完（來源樹沒有那個 commit）⇒ `git worktree base invalid`；
  樹被第三方 commit 過 ⇒ `candidate workspace head mismatch`；追蹤檔漂移 ⇒
  `candidate workspace has tracked drift`；未追蹤 report 不算漂移。
- **突變驗證**：把 reviewer 分支改回 `builder_jobs[-1]["worktree"]`，**7 條轉紅**，其中
  `chmod 000` 那條逐字給出生產訊息 `PermissionError: [Errno 13] Permission denied`，
  `rmtree` 那條給出 `FileNotFoundError`。（另 3 條是語意保存的回歸護欄，兩個模型下都該綠。）
- **#638／#657 的教訓**：真三分 UID 的稽核（`stat` 期望 `cortex-manager 700`、`getfacl`
  期望零具名條目）單 UID 驗不到 ⇒ **明確 `pytest.mark.skip` 並在 reason 寫清楚**，稽核步驟
  同步寫進 `docs/superpowers/runbooks/trust-root-phase2b-setup.md`。

`python3 -m pytest tests/ -q`：**4027 passed, 15 skipped**（升級前 4017 passed / 14 skipped）。

## 碰了哪些檔案（與 #657 的並行邊界）

| 檔案 | 動了什麼 |
|---|---|
| `paulsha_cortex/coordinator/manager.py` | 新增三個函式；reviewer 分支；`_is_exact_reviewer_terminal_recovery()` 定錨；兩處註解校正 |
| `paulsha_cortex/coordinator/work_bridge.py` | **只有 docstring**（`_ship_workspace_id` / `_manager_ship_workspace` 對 post-archive verify／review 的描述已過時） |
| `docs/superpowers/runbooks/trust-root-phase2b-setup.md` | 新增 `wf-*-review-*` 的實機稽核段 |
| `tests/test_reviewer_candidate_tree_650.py` | 新增 |
| `tests/test_reviewer_card_retry_569.py` / `tests/test_workflow_production_wiring.py` | fixture 校正：candidate 改放在**來源樹**（harvest 之後的實況），builder 的樹不再是 candidate 樹 |
| `tests/test_ship_out_of_builder_clone_653.py` | 只有註解 |
| `CHANGELOG.md` / `changelog.d/reviewer-candidate-tree.md` | 依 repo 規範 |

**一個位元組都沒碰** `trust_root/`、unit 產生器、`job_runner`、`launcher`、`permgen`
⇒ 與 #657（per-principal job spec spool）零重疊。

## Checklist

- [x] 六個用途逐個查證並把結論寫進 PR body
- [x] 順序問題的處置寫進 PR body（借 #653 的結構性共用 provisioning）
- [x] verify／review 卡的 candidate 樹來源定案並落地（A′）
- [x] 不變式測試：前一張 build 卡的工作區刪掉／`chmod 000`，verify／review 卡仍正確運作
- [x] `workflow_sandbox_hash`／input snapshot／output baseline 語意不變（有測試）
- [x] `direct` 模式零回歸
- [x] 即時回收拆後續票 #658 並在 PR body 說明推導
- [x] 紅線：沒有加回 Manager 對 job 工作樹的 ACL
- [x] 紅線：沒有 `--reference`／`--shared`
- [x] OS 層／單 UID 測不到的部分明確 skip 並說明理由（#638／#657）
- [x] `changelog.d/reviewer-candidate-tree.md` 已新增且已 commit
- [x] `CHANGELOG.md [Unreleased]` 已補 entry
- [x] `python3 -m pytest tests/ -q` 全綠
- [x] `policy_check` 帶 PR 上下文跑，fail: 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E7w9kaUxAzCCEk7piD5hfK
