### PR TITLE
fix(trust-root): gate／reviewer 讀不到自己的 job spec——spec spool 改為 per-principal，preflight 改驗 effective 權限

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -363,6 +363,24 @@
   `tests/test_trust_root_job_template_ab.py`（80 測試）。
 
 ### Fixed
+- **#657 / trust-root Phase 2b：gate（與 reviewer／planner）的 template unit 讀不到自己的
+  job spec——spec spool 改為 per-principal，preflight 改驗「那個身分讀得到」**——#629 落地
+  後實機每個 gate job 都以 `78/CONFIG` 收場：三份模板 unit 共用同一個
+  `Environment=PSC_JOB_SPEC_SPOOL=<coordinator>/job-specs`，而登記表只授 builder 唯讀 ACL；
+  shim 是 systemd 套完 `User=` **之後**才執行的，它以 job 身分讀 spec ⇒ 必然 `EACCES`。
+  reviewer／planner 同型（已查證，#652 未驗到這層）。裁決取 **per-principal spool**：
+  `<coordinator_root>/job-specs/{builder,reviewer,gate}`，各自只授自己；容器降為 owner-only
+  ＋ 機械導出的 `--x` traverse。「哪個身分讀哪個 spool」因此是 root-owned unit 上可逐字稽核
+  的一行，而不是共用目錄上多條 ACL 的交集，也不引入「跨 persona 互讀 spec」這個新性質。
+  三個資產／三條路徑／六份 unit 的 `Environment=` 全部由
+  `registry.DOWNGRADED_JOB_PRINCIPALS` 機械導出。`prepare_systemd_template()` 的 preflight
+  由「目錄存在」升級為「該 job 身分的 **effective** 權限」（`os.stat` ＋ POSIX ACL xattr，
+  含 mask 與整條 traverse 鏈），spec 落地後再就地複驗一次；失敗因此發生在派工之前、
+  訊息在 Manager 端。新增 `tests/test_per_principal_spec_spool_657.py`：**自建真實 ACL 樹**
+  並以 effective 權限斷言（與 `getfacl` 交叉核對），需要第二個 UID 的部分明確 skip 並寫出
+  理由。runbook 新增 §5-3a（含以各 job 身分實測讀得到的正反向步驟）。**需 operator 重跑
+  權限計畫並重落六份 unit，順序：先權限、後 unit。** 詳見
+  `changelog.d/per-principal-spec-spool.md`。
 - **權威 gate ledger 一律由 Manager 自己重寫，spool 內容以不受信任輸入對待（#629）**——
   讓 gate 直接寫 `gate-ledger` 會被 `#628` 的 `foreign_evidence_author()` 當場以
   `gate-ledger-foreign-author` 拒掉；而那個資產**同時**是 exit sentinel 的落點，開放

--- a/changelog.d/per-principal-spec-spool.md
+++ b/changelog.d/per-principal-spec-spool.md
@@ -1,0 +1,63 @@
+### Fixed
+- **#657 / trust-root Phase 2b：gate（與 reviewer／planner）的 template unit 讀不到自己的
+  job spec——spec spool 改為 per-principal，preflight 改驗「那個身分讀得到」**（Closes #657）
+
+  **實機病灶**：#629 的 gate 執行身分落地後，`sudo -u cortex-manager systemctl start
+  'cortex-gate-job@<inst>.service'` 一律以 `78/CONFIG` 收場，journal 只留
+  `cortex-job-shim: 讀不到 job spec …/job-specs/<inst>.json: [Errno 13] Permission denied`。
+  成因：三份模板 unit 共用同一個 `Environment=PSC_JOB_SPEC_SPOOL=<coordinator>/job-specs`，
+  而登記表資產 `job-spec-spool` 的 reader 面**只有 builder**。shim 是 systemd 套完
+  `User=` **之後**才執行的（`ExecStart=` 就是 shim），它以 job 身分讀 spec ⇒ 必然被拒。
+  **reviewer／planner 同型且已查證**：`cortex-reviewer-job@.service` 逐字指向同一個
+  spool，而 `cortex-reviewer-planner` 同樣不在 reader 面——#652（M2）落地時沒驗到這一層，
+  只是還沒有人在四分部署上派過 reviewer job。
+
+  **裁決＝方向 2（per-principal spool）**：每個降權 principal 一個 spool 根
+  （`<coordinator_root>/job-specs/{builder,reviewer,gate}`），各自只授自己
+  （`rX` access ＋ default ACL）。容器降為 owner-only、零跨帳號讀權，三個帳號在那一層
+  只拿到 `derive_traverse_grants()` 機械導出的 `--x`（走得進自己那格、列不出這台機器上
+  還有誰的 job）。理由是**可稽核性**：「哪個身分讀哪個 spool」因此是 root-owned unit 檔
+  上可逐字讀懂的一行，而不是一組共用目錄上多條 ACL 的交集；而且不必把「跨 persona 互讀
+  spec」這個新性質偷渡進來（方向 1 會）。方向 3（spec 檔 chown 給 job 帳號）不成立：
+  spec 是 Manager 寫的，chown 給別的 owner 需要 root，而「cortex 任何元件永不具 root」
+  是既有裁決。
+
+  **機械導出，不硬編清單**：`registry.DOWNGRADED_JOB_PRINCIPALS`（由 `permgen` 搬進登記表，
+  `permgen.DOWNGRADED_JOB_PRINCIPALS` 成為指向它的別名而非第二份）同時決定三個資產
+  （`job-spec-spool-<principal>`）、三條路徑（`config.paths.job_spec_spool_for()`／
+  `PathLayout.job_spec_spool_for()`）、六份 unit 的 `Environment=` 與容器上的 traverse ACL。
+  新增降權角色只需動那張表一行。`TrustRootAsset` 新增 `path_resolver_args`，讓一支帶參數的
+  resolver 服務一族資產（R1 雙向等式與 R3 自檢因此仍逐項解析得到真實路徑）。
+
+  **preflight 改為驗 effective 權限**（本票的第二半）：`prepare_systemd_template()` 原本只
+  `os.path.isdir(spool)`——那對 #657 完全無感（目錄存在、Manager 寫得進去，缺的只是那個
+  帳號的 ACL）。新增 `job_runner.effective_perms_for_account()`／
+  `inherited_perms_for_account()`：以 `os.stat` ＋ POSIX ACL xattr
+  （`system.posix_acl_access`／`system.posix_acl_default`）直接算 kernel 用的那條
+  POSIX.1e access check，**含 mask 收斂與整條 traverse 鏈**。Manager 不是那個身分、
+  `os.access()` 答不了這題，但那條判定本來就是對 inode 中繼資料的純計算。失敗因此變成派工
+  **之前**的 `job-runner-job-spec-spool-unreadable`；spec 落地後另有一次就地複驗
+  （`job-runner-job-spec-unreadable-by-job`），把 `write_job_spec()` 那段「`chmod 0640`
+  是為了讓繼承的 ACL mask 不被關掉」的推導從註解升級成斷言。誠實邊界（mount 選項、
+  mount namespace、LSM）寫進 docstring 與 runbook，由 `sudo -u` 實測步驟承接。
+
+  **mask 陷阱（修本票時在實機上量到）**：`/var/lib/cortex/coordinator/job-specs` 當時是
+  `mask::---` ＋ `user:cortex-builder:r-x #effective:---`——ACL 還在、`getfacl` 看得到，
+  實際權限卻是零（`chmod` 會重寫 ACL mask，因此「先 setfacl 再 chmod」會靜默失效）。
+  只看「有沒有那條 ACL」的檢查會說一切正常；新的 effective 判定當場抓到。
+
+  **測試**（`tests/test_per_principal_spec_spool_657.py`，23 條 ＋ 1 條明確 skip）：本族
+  （#630／#631／#638／#657）的 bug 全部是「單 UID 環境測不出 ACL 語意」，因此本檔**自己
+  建出一棵真實 ACL 樹**（`setfacl` 一個真的存在、uid 與本行程不同的第二個帳號），以
+  **effective 權限**斷言，並與系統 `getfacl` 的 `#effective:` 交叉核對；涵蓋「讀得到自己
+  的、讀不到別人的」「mask 打掉具名條目」「traverse 斷一層」「Manager 寫的 spec 該帳號讀
+  得到」「ACL 指名的是別人時不成立」。**真的以該 uid `open()` 需要第二個 UID／root，
+  明確 `pytest.skip` 並寫出理由與替代驗收位置，不靜默通過。** 另補派工路徑（每個角色寫進
+  自己那格、preflight 對「讀不到」fail-closed）與 `direct` 模式零回歸。
+  `tests/test_trust_root_permgen_traverse_620.py` 的正向路徑改為逐 principal，
+  reviewer 的那條鏈因此第一次被涵蓋。
+
+  **部署影響（需 operator 動作）**：spool 落點與六份 unit 的 `Environment=` 同時改變。
+  順序是**先權限、後 unit**——反過來會讓每個 job 以 78/CONFIG 收場。runbook 新增
+  §5-3a（per-principal spec spool），含落檔驗證、mask 判準，以及**以各 job 身分實測
+  讀得到自己的 spec／讀不到別人的**的正反向步驟。

--- a/docs/superpowers/runbooks/trust-root-phase2b-setup.md
+++ b/docs/superpowers/runbooks/trust-root-phase2b-setup.md
@@ -412,14 +412,16 @@ python3 -m paulsha_cortex.trust_root toolchain four-way
 #    **不自行捏造欄位**（手捏的 spec 會被 shim 的白名單 schema 拒絕）
 python3 - <<'PY'
 from paulsha_cortex.coordinator import job_runner
-print("spool 預設      :", job_runner.DEFAULT_JOB_SPEC_SPOOL)
-print("spec 路徑推導   :", job_runner.job_spec_path(job_runner.DEFAULT_JOB_SPEC_SPOOL, "<instance>"))
+for role in job_runner.JOB_ROLES:
+    s = job_runner.resolve_job_spec_spool({}, role=role)
+    print(f"spool[{role:<8}]:", s, "→", job_runner.job_spec_path(s, "<instance>"))
 print("spec_version    :", job_runner.JOB_SPEC_VERSION)
 print("必填欄位        :", job_runner.SPEC_REQUIRED_KEYS)
 print("禁用（身分）欄位:", sorted(job_runner.SPEC_FORBIDDEN_KEYS))
 PY
-#   期望：spool = /var/lib/cortex/coordinator/job-specs（**不是** /var/lib/cortex/jobs）；
-#         spec 路徑 = <spool>/<instance>.json（**一個檔，不是一個目錄**）；
+#   期望：spool = /var/lib/cortex/coordinator/job-specs/builder（#657：**per-principal**，
+#         `role=` 決定哪一格；**不是** /var/lib/cortex/jobs，也不是無尾段的 job-specs）；
+#         spec 路徑 = <該角色的 spool>/<instance>.json（**一個檔，不是一個目錄**）；
 #         禁用欄位含 user／uid／group／gid／properties／exec_start
 #         ——身分只有一個來源＝root-owned unit 檔的 `User=`，spec 連提都不准提。
 ```
@@ -790,22 +792,40 @@ ls -ld /var/lib/cortex-builder /var/lib/cortex-builder/.codex /var/lib/cortex-bu
 #   期望：HOME 與 .codex 皆 root:root 0755；三個 cache 各自 <帳號>:<帳號> 0700。
 #   （Manager 不跑模型，故無 `~/.codex` 這一條。）
 
-# ✅ 驗證：job-spec spool 根 cortex-manager 擁有、0700 ＋ builder 唯讀 ACL
-#   ⚠️ 路徑是 **<coordinator_root>/job-specs**，不是舊版寫的 /var/lib/cortex/jobs
-#      ——後者是 run.sh 時代的 per-job 目錄，**已不在登記表、也不會被建立**。
+# ✅ 驗證：job-spec spool 是 **per-principal** 的（#657）——容器 ＋ 三格
+#   ⚠️ 路徑是 **<coordinator_root>/job-specs/<principal>**。#657 之前三份模板 unit
+#      共用一個 `<coordinator_root>/job-specs`，而 ACL 只授 builder ⇒ reviewer／gate
+#      的**每一個** job 都在 shim 讀 spec 時 EACCES → 78/CONFIG。詳見 5-3a。
 ls -ld /var/lib/cortex/coordinator/job-specs
-#   期望：cortex-manager:cortex-manager 0700
-sudo getfacl -p /var/lib/cortex/coordinator/job-specs | grep -E "^(user|default:user):"
-#   期望：user:cortex-builder:r-x ＋ default:user:cortex-builder:r-x
-#   **builder 讀得到是設計**（見 5-3 表格下的說明）：template unit 的
-#   `User=cortex-builder` 由 systemd 在 `ExecStart` **之前**套用，shim 本身就是以
-#   builder 身分去讀 spec——讀不到就起不了 job。守的是**寫入面**（下一條）。
-sudo -u cortex-builder ls /var/lib/cortex/coordinator/job-specs >/dev/null \
-  && echo "builder 可列 spool（BY DESIGN）"
-sudo -u cortex-builder sh -c 'printf "{}" > /var/lib/cortex/coordinator/job-specs/probe.json' 2>&1 | tail -1
+#   期望：cortex-manager:cortex-manager 0700（容器本身**不授**任何 job 帳號讀權）
+sudo getfacl -p /var/lib/cortex/coordinator/job-specs | grep -E "^(user|mask):"
+#   期望：三條 `user:cortex-{builder,reviewer-planner,gate}:--x`（只給 traverse）
+#         ＋ `mask::--x`。**看 mask**：mask 收窄成 `---` 會讓上面三條全部
+#         `#effective:---`，ACL 還在但沒有作用（見 5-3a 的 mask 陷阱）。
+for P in builder reviewer gate; do
+  ls -ld "/var/lib/cortex/coordinator/job-specs/$P"
+  sudo getfacl -p "/var/lib/cortex/coordinator/job-specs/$P" \
+    | grep -E "^(user|default:user|mask|default:mask):"
+done
+#   期望（逐格）：cortex-manager:cortex-manager 0700，
+#         builder  格 → user:cortex-builder:r-x           ＋ default 同一條
+#         reviewer 格 → user:cortex-reviewer-planner:r-x  ＋ default 同一條
+#         gate     格 → user:cortex-gate:r-x              ＋ default 同一條
+#         且**沒有任何 `#effective:` 註記**（有就是被 mask 吃掉了）。
+#   **job 帳號讀得到自己那格是設計**（見 5-3 表格下的說明）：template unit 的
+#   `User=` 由 systemd 在 `ExecStart` **之前**套用，shim 本身就是以 job 身分去讀
+#   spec——讀不到就起不了 job。守的是**寫入面**（下面第二條）。
+sudo -u cortex-builder ls /var/lib/cortex/coordinator/job-specs/builder >/dev/null \
+  && echo "builder 可列自己那格（BY DESIGN）"
+sudo -u cortex-builder sh -c 'printf "{}" > /var/lib/cortex/coordinator/job-specs/builder/probe.json' 2>&1 | tail -1
 #   期望：Permission denied ← **這條才是邊界**（builder 改不了自己的命令列）
-sudo -u cortex-reviewer-planner ls /var/lib/cortex/coordinator/job-specs 2>&1 | tail -1
-#   期望：Permission denied（spool 只對 builder 開唯讀 ACL——三分在檔案層的證據）
+sudo -u cortex-builder ls /var/lib/cortex/coordinator/job-specs 2>&1 | tail -1
+#   期望：Permission denied（容器只給 traverse，不給列目錄——builder 因此連
+#         「這台機器上還有誰的 job」都看不到）
+sudo -u cortex-gate ls /var/lib/cortex/coordinator/job-specs/builder 2>&1 | tail -1
+sudo -u cortex-reviewer-planner ls /var/lib/cortex/coordinator/job-specs/gate 2>&1 | tail -1
+#   期望：兩行 Permission denied（跨 principal 讀不到彼此的 spec——#657 選
+#         per-principal 而非「擴大共用 spool 的 reader 面」買到的正是這一條）
 ```
 
 ### 2c. 建立來源樹 ＋ 落三份 root-owned `.gitconfig`（#623）
@@ -1683,6 +1703,18 @@ sudo -u cortex-builder sh -c \
 
 ### 5-2. 安裝 (b) template unit（**六份**＝3 角色 × 2 加固剖面）
 
+> **⚠️ 已部署過 #657 之前版本的機器：這一節與第 2 步都必須重跑，且有順序。**
+> #657 把 spec spool 從「一個共用根」改成「一個降權身分一格」，因此
+> **unit 的 `Environment=PSC_JOB_SPEC_SPOOL=` 與 spool 的落點同時改變**。
+> 順序是 **先權限、後 unit**：
+>
+> 1. 重跑第 2 步的權限 script（建出三格並套 ACL，見 5-3a 的第一個命令）；
+> 2. 重落這六份 unit ＋ `daemon-reload`；
+> 3. 跑 5-3a 的實測（**以各 job 身分**讀自己的 spec）。
+>
+> 反過來（先換 unit 後套權限）會讓每個 job 在 shim 讀 spec 時 `EACCES` →
+> `78/CONFIG`，而那正是 #657 的症狀，會白白花掉一輪診斷。
+
 > **為什麼是六份**：unit 檔裡寫死兩件事，兩件都不能靠參數傳——
 >
 > - **`User=`**（#615 M2、#629）：builder／reviewer-planner／gate 是三個不同的
@@ -2015,8 +2047,9 @@ job 的 argv 不再由 Manager 行程直接組出並交給 systemd，而是由 r
 | 角色 | 路徑 | 擁有者 | 權限意義 |
 |---|---|---|---|
 | shim（root-owned 程式） | `/opt/cortex/bin/cortex-job-shim` | root:root 0755 | 三個服務帳號皆**不可寫**（`/opt/cortex` 整棵 root-owned） |
-| job-spec spool 根 | `/var/lib/cortex/coordinator/job-specs` | cortex-manager 0700 ＋ builder `r-x` ACL | **只有 Manager 寫得進去**；builder 唯讀。spool 是登記表資產 `job-spec-spool`，權限由 permgen 機械產生 |
-| per-job spec | `<spool>/<instance>.json`（**一個檔，不是一個目錄**） | cortex-manager 0640 ＋ builder 唯讀 ACL | builder **改不了自己的命令列，也埋伏不了下一個 job**——見下方「守的是寫入面」 |
+| job-spec spool **容器** | `/var/lib/cortex/coordinator/job-specs` | cortex-manager 0700 ＋ 三條 `--x` traverse ACL | **零讀權**：job 走得進自己那格，列不出這台機器上還有誰的 job。登記表資產 `job-spec-spool` |
+| per-principal spool（#657） | `<容器>/{builder,reviewer,gate}` | cortex-manager 0700 ＋ **該帳號** `r-x` ACL（access ＋ default） | 一個降權身分一格。登記表資產 `job-spec-spool-<principal>`，由 `DOWNGRADED_JOB_PRINCIPALS` 機械導出 |
+| per-job spec | `<該角色的 spool>/<instance>.json`（**一個檔，不是一個目錄**） | cortex-manager 0640 ＋ 該帳號唯讀 ACL（default 繼承） | job **改不了自己的命令列，也埋伏不了下一個 job**——見下方「守的是寫入面」 |
 
 > **守的是寫入面，不是讀取面**（M1 實測校正，#584／#621）：
 > template unit 的 `User=cortex-builder` 由 systemd 在 `ExecStart` **之前**套用，
@@ -2025,10 +2058,13 @@ job 的 argv 不再由 Manager 行程直接組出並交給 systemd，而是由 r
 > builder 無法在 spool 內**建立**新 spec、**追加**自己的 spec、用 **symlink 換掉**、
 > 或**刪除**任何 spec。「改不了自己的命令列、埋伏不了下一個 job」就落在這四條上。
 >
-> **per-job 的讀隔離不在本方案範圍**：所有 builder job 共用**同一個 UID**，
+> **per-job 的讀隔離不在本方案範圍**：同一個 persona 的所有 job 共用**同一個 UID**，
 > 因此彼此的 spec 本來就互讀得到——這在威脅模型內（同 persona 的 job 之間不設界）。
 > 要做到 per-job 讀隔離必須 **per-job UID**（動態 UID／`DynamicUser=` 一類），
 > 那是另一個方案，**Phase 2b 不宣稱**。舊版此表寫「job 只讀自己那格」並不精確。
+>
+> **但 per-persona 的讀隔離在 #657 之後成立**：三個降權身分各有自己的 spool 根，
+> 跨 persona 讀不到彼此的 spec（實測步驟在 5-3a）。
 >
 > `User=` 完全不在 spec 內（`build_job_spec()` 對 `user`／`uid`／`group`／`gid`／
 > `properties`／`exec_start` 主動 fail-closed，shim 讀端再驗一次），
@@ -2045,8 +2081,19 @@ systemctl cat cortex-job@.service | grep -E "^ExecStart="
 #   （那是 run.sh 時代的形狀，spool 路徑也還是舊的）——先升級部署樹再繼續。
 
 # ✅ 檢查 spec 從哪裡讀（unit 用 Environment= 寫死，呼叫端改不了）
-systemctl cat cortex-job@.service | grep -E "^Environment=PSC_JOB_SPEC_SPOOL="
-#   期望：Environment=PSC_JOB_SPEC_SPOOL=/var/lib/cortex/coordinator/job-specs
+#   #657：**六份 unit 各指自己那格**，三條路徑必須互不相同。
+for U in cortex-job cortex-job-jit \
+         cortex-reviewer-job cortex-reviewer-job-jit \
+         cortex-gate-job cortex-gate-job-jit; do
+  printf '%-28s ' "$U"
+  systemctl cat "$U@.service" | grep -E "^Environment=PSC_JOB_SPEC_SPOOL="
+done
+#   期望：
+#     cortex-job / cortex-job-jit                   → …/job-specs/builder
+#     cortex-reviewer-job / cortex-reviewer-job-jit → …/job-specs/reviewer
+#     cortex-gate-job / cortex-gate-job-jit         → …/job-specs/gate
+#   任一份仍指向容器 `…/job-specs`（沒有尾段）⇒ 那是 #657 之前的 unit，
+#   該角色的每一個 job 都會以 78/CONFIG 收場。重跑 5-2 的落檔步驟。
 
 # ✅ 檢查 job 工作區的 ReadWritePaths（#645）
 systemctl cat cortex-job@.service | grep -E "^ReadWritePaths=/var/lib/cortex/worktree/%i$"
@@ -2116,6 +2163,91 @@ done
 ls -l /opt/cortex/bin/cortex-job-shim
 #   期望：-rwxr-xr-x root root
 ```
+
+### 5-3a. per-principal spec spool（#657）——**以各 job 身分實測讀得到**
+
+> **本節不是「檔案在不在」的檢查。** #657 的實機病灶是：spool 目錄存在、Manager
+> 寫得進去、`getfacl` 上也看得到唯讀 ACL——而 gate／reviewer 的每一個 job 仍以
+> `78/CONFIG` 死掉，因為 shim 是 systemd 套完 `User=` **之後**才執行的，它以 job
+> 身分讀 spec。因此本節的每一條驗收都要**變成那個身分**去做，或至少讀 `getfacl`
+> 的 **`#effective:`**，而不是「有沒有那條 ACL」。
+
+**mask 陷阱（實機量到過，務必看這一條）**：`chmod` 會重寫 ACL 的 mask，因此
+「先 `setfacl` 再 `chmod`」會讓具名條目靜默失效——`getfacl` 仍列出
+`user:cortex-builder:r-x`，後面卻跟著 `#effective:---`，實際權限是零。產生器輸出的
+命令順序（`chown` → `chmod` → `setfacl`，父層 traverse 一律殿後）已經避開它；
+**手動補過 ACL 之後又 `chmod` 過的機器會踩到**。判準一律看 `mask::` 與
+`#effective:`。
+
+```bash
+# 🔧 sudo：重跑權限計畫（#657 之後 spool 從一格變四格，必須重跑）
+python3 -m paulsha_cortex.trust_root permissions four-way --commands --paths \
+  --operator-account "$(id -un)" --external-reader-account none > /tmp/perm-657.sh
+less /tmp/perm-657.sh          # 先讀過，這份會以 `sh -e` 整份執行
+sudo sh -e /tmp/perm-657.sh
+
+# ✅ 落檔：容器 ＋ 三格
+ls -ld /var/lib/cortex/coordinator/job-specs \
+       /var/lib/cortex/coordinator/job-specs/{builder,reviewer,gate}
+#   期望：四行都是 cortex-manager:cortex-manager 0700
+
+# ✅ effective（不是「有沒有 ACL」）——容器只給 traverse
+sudo getfacl -p /var/lib/cortex/coordinator/job-specs | grep -E "^(user:|mask::)"
+#   期望：三條 user:cortex-*:--x ＋ mask::--x，且**沒有任何 `#effective:` 註記**
+
+# ✅ effective——每格只授自己
+for PAIR in builder:cortex-builder reviewer:cortex-reviewer-planner gate:cortex-gate; do
+  P="${PAIR%%:*}"; A="${PAIR##*:}"
+  echo "--- $P"
+  sudo getfacl -p "/var/lib/cortex/coordinator/job-specs/$P" \
+    | grep -E "^(user:|default:user:|mask::|default:mask::)"
+done
+#   期望（逐格）：`user:<自己>:r-x` ＋ `default:user:<自己>:r-x` ＋
+#         `mask::r-x` ＋ `default:mask::r-x`，**無 `#effective:` 註記**、
+#         **無其他 principal 的條目**。
+#   看到 `#effective:---` ⇒ mask 被 chmod 打掉了，重跑上面那份 script。
+
+# ✅✅ **正向實測：每個身分讀得到自己的 spec**（本節的核心，不可以只驗檔案存在）
+for PAIR in builder:cortex-builder reviewer:cortex-reviewer-planner gate:cortex-gate; do
+  P="${PAIR%%:*}"; A="${PAIR##*:}"
+  S="/var/lib/cortex/coordinator/job-specs/$P/probe-657.json"
+  # Manager 寫（＝正式路徑的寫端：原子寫入 ＋ chmod 0640，讓繼承的 ACL mask 不被關掉）
+  sudo -u cortex-manager sh -c "printf '{\"probe\":1}' > $S && chmod 0640 $S"
+  # 那個身分讀（＝shim 在 systemd 套完 User= 之後做的事）
+  sudo -u "$A" cat "$S" >/dev/null \
+    && echo "$A 讀得到自己的 spec：OK" \
+    || echo "$A 讀不到自己的 spec：**FAIL（這就是 #657）**"
+done
+
+# ✅✅ **反向實測：跨 principal 讀不到彼此的 spec**
+sudo -u cortex-gate cat /var/lib/cortex/coordinator/job-specs/builder/probe-657.json 2>&1 | tail -1
+sudo -u cortex-builder cat /var/lib/cortex/coordinator/job-specs/gate/probe-657.json 2>&1 | tail -1
+sudo -u cortex-reviewer-planner cat /var/lib/cortex/coordinator/job-specs/gate/probe-657.json 2>&1 | tail -1
+#   期望：三行 Permission denied
+
+# ✅ 寫入面仍全拒（M1 起的不變式，本票不得放寬）
+for PAIR in builder:cortex-builder reviewer:cortex-reviewer-planner gate:cortex-gate; do
+  P="${PAIR%%:*}"; A="${PAIR##*:}"
+  sudo -u "$A" sh -c "printf x > /var/lib/cortex/coordinator/job-specs/$P/evil.json" 2>&1 | tail -1
+  sudo -u "$A" sh -c "printf x >> /var/lib/cortex/coordinator/job-specs/$P/probe-657.json" 2>&1 | tail -1
+  sudo -u "$A" rm -f "/var/lib/cortex/coordinator/job-specs/$P/probe-657.json" 2>&1 | tail -1
+done
+#   期望：九行全部 Permission denied（job 建不了、改不了、刪不掉自己的命令列）
+
+# 🧹 清理
+sudo rm -f /var/lib/cortex/coordinator/job-specs/{builder,reviewer,gate}/probe-657.json
+```
+
+> **Manager 端還有一道同語意的閘**：`prepare_systemd_template()` 的 preflight 在
+> #657 之後檢查的是「該 job 身分的 **effective** 權限」而不是「目錄存在」——它以
+> `os.stat` ＋ POSIX ACL xattr 直接算 kernel 用的那條 access check（含 mask 與
+> 整條 traverse 鏈），因此上面任何一條 FAIL 都會在**派工之前**變成
+> `job-runner-job-spec-spool-unreadable`，而不是 journal 裡的一行 78/CONFIG。
+> spec 落地後另有一次就地複驗（`job-runner-job-spec-unreadable-by-job`）。
+>
+> 那道閘**算不到**的三件事，正是本節 `sudo -u` 步驟不可省略的理由：mount 選項
+> （唯讀掛載）、mount namespace（unit 的 `ProtectSystem=strict` 等）、LSM
+> （SELinux／AppArmor）。
 
 ### 5-4. 安裝 (a) polkit 規則
 
@@ -2300,7 +2432,9 @@ import sys
 from paulsha_cortex.coordinator import job_runner
 
 instance = sys.argv[1]
-spool = job_runner.DEFAULT_JOB_SPEC_SPOOL
+# #657：spool 是 per-principal 的——`role=` 決定寫進哪一格。
+spool = job_runner.resolve_job_spec_spool({}, role=job_runner.JOB_ROLE_BUILDER)
+account = "cortex-builder"
 smoke = (
     'echo "== identity =="; id; '
     'echo "== tokens =="; echo "GH_TOKEN=[$GH_TOKEN] GITHUB_TOKEN=[$GITHUB_TOKEN]"; '
@@ -2308,7 +2442,7 @@ smoke = (
     'echo "== home =="; echo "HOME=$HOME"; ls -ld "$HOME"; '
     'echo "== deployment writable? =="; (printf x >> /opt/cortex/venv/bin/cortex) 2>&1 | tail -1; '
     'echo "== spec spool writable? =="; '
-    '(printf x > /var/lib/cortex/coordinator/job-specs/evil.json) 2>&1 | tail -1'
+    '(printf x > /var/lib/cortex/coordinator/job-specs/builder/evil.json) 2>&1 | tail -1'
 )
 spec = job_runner.build_job_spec(
     job_id=f"{instance}-smoke",
@@ -2322,7 +2456,10 @@ spec = job_runner.build_job_spec(
     #    而 token 類的名字 build_job_spec() 直接拒收（見下方註）。
     env={"HOME": "/var/lib/cortex-builder", "PATH": "/usr/local/bin:/usr/bin:/bin"},
 )
-print("wrote:", job_runner.write_job_spec(job_runner.job_spec_path(spool, instance), spec))
+# `account=` 讓寫端在落地後就地複驗「那個身分讀得到這個檔」（#657）——
+# 失敗會是一個 Manager 端的清楚錯誤，而不是 journal 裡的 78/CONFIG。
+print("wrote:", job_runner.write_job_spec(
+    job_runner.job_spec_path(spool, instance), spec, account=account))
 PY
 #   ↑ 以 **cortex-manager 身分**寫——spool 是 Manager-owned，這一步本身就在證明
 #     「writer 只有 Manager」；若這裡就 Permission denied，代表第 2 步權限沒套好。
@@ -2372,7 +2509,9 @@ import sys
 from paulsha_cortex.coordinator import job_runner
 
 instance = sys.argv[1]
-spool = job_runner.DEFAULT_JOB_SPEC_SPOOL
+# #657：spool 是 per-principal 的——`role=` 決定寫進哪一格。
+spool = job_runner.resolve_job_spec_spool({}, role=job_runner.JOB_ROLE_BUILDER)
+account = "cortex-builder"
 smoke = (
     'echo "== identity =="; id; '
     'echo "== tokens =="; echo "GH_TOKEN=[$GH_TOKEN] GITHUB_TOKEN=[$GITHUB_TOKEN]"; '
@@ -2404,7 +2543,10 @@ spec = job_runner.build_job_spec(
         "PATH": "/usr/local/bin:/usr/bin:/bin",
     },
 )
-print("wrote:", job_runner.write_job_spec(job_runner.job_spec_path(spool, instance), spec))
+# `account=` 讓寫端在落地後就地複驗「那個身分讀得到這個檔」（#657）——
+# 失敗會是一個 Manager 端的清楚錯誤，而不是 journal 裡的 78/CONFIG。
+print("wrote:", job_runner.write_job_spec(
+    job_runner.job_spec_path(spool, instance), spec, account=account))
 PY
 
 # ✅ 正向：以 cortex-manager 身分起 reviewer instance——**必須成功**
@@ -2429,7 +2571,7 @@ sudo cat "/var/lib/cortex-reviewer-planner/cache/$RJOB.log"
 # 🔧 清理
 sudo -u cortex-manager systemctl stop "cortex-reviewer-job@$RJOB.service" 2>/dev/null
 sudo rm -rf /var/lib/cortex/coordinator/review-verdicts/probe
-sudo rm -f "/var/lib/cortex/coordinator/job-specs/$RJOB.json" \
+sudo rm -f "/var/lib/cortex/coordinator/job-specs/reviewer/$RJOB.json" \
            "/var/lib/cortex-reviewer-planner/cache/$RJOB.log"
 ```
 
@@ -2587,7 +2729,7 @@ sys.exit(1)
 sudo -u cortex-manager /opt/cortex/venv/bin/python -c '
 import json, sys
 from paulsha_cortex.coordinator import job_shim
-spool = "/var/lib/cortex/coordinator/job-specs"
+spool = "/var/lib/cortex/coordinator/job-specs/builder"
 spec = {"spec_version": 1, "instance": "profile-probe", "job_id": "profile-probe",
         "unit": "cortex-job@profile-probe.service", "command": ["/bin/true"],
         "working_directory": "/tmp", "log_path": "/tmp/probe.jsonl",
@@ -2599,7 +2741,7 @@ except job_shim.ShimError as exc:
     print("refused:", exc); sys.exit(0)
 sys.exit(1)
 '; echo "(12c) exit=$?"
-sudo rm -f /var/lib/cortex/coordinator/job-specs/profile-probe.json
+sudo rm -f /var/lib/cortex/coordinator/job-specs/builder/profile-probe.json
 #   期望：exit=0，印出 refused: ... hardening_profile ...
 ```
 
@@ -2610,7 +2752,7 @@ sudo rm -f /var/lib/cortex/coordinator/job-specs/profile-probe.json
 ```bash
 # 🔧 sudo：清掉 selftest 殘留（spec 是一個檔，worktree 是一個目錄）
 sudo systemctl stop "cortex-job@$JOB.service" 2>/dev/null || true
-sudo rm -f "/var/lib/cortex/coordinator/job-specs/$JOB.json"
+sudo rm -f "/var/lib/cortex/coordinator/job-specs/builder/$JOB.json"
 sudo rm -rf "/var/lib/cortex/worktree/$JOB"
 sudo systemctl reset-failed "cortex-job@*" "cortex-job-jit@*" 2>/dev/null || true
 ```
@@ -2907,7 +3049,8 @@ d() { printf '%s :: ' "$1"; shift; if "$@" >/dev/null 2>&1; then echo "readable 
 # need() = 目標檔必須先存在，否則「刪不掉／讀不到」測的是「檔不存在」而非「被拒」。
 need() { [ -e "$1" ] || printf '!! 前置缺失：%s 不存在——對它的刪除／截斷／讀取測項會是假綠，請先由 operator 以 cortex-manager 身分預建\n' "$1"; }
 A=/var/lib/cortex
-SPOOL=$A/coordinator/job-specs
+# #657：spool 是 per-principal 的；R9 攻擊腳本以模型 job 身分執行，看的是自己那格。
+SPOOL=$A/coordinator/job-specs/builder
 
 # ⛔ 身分鎖（**不可移除**）：本腳本會真的執行破壞性動作——truncate、`rm`、
 #    `mv "$HOME/.codex"`、覆寫 hooks.json。在沙箱外（例如 operator 帳號）
@@ -3062,7 +3205,9 @@ import sys
 from paulsha_cortex.coordinator import job_runner
 
 instance, manager_pid = sys.argv[1], sys.argv[2]
-spool = job_runner.DEFAULT_JOB_SPEC_SPOOL
+# #657：spool 是 per-principal 的——`role=` 決定寫進哪一格。
+spool = job_runner.resolve_job_spec_spool({}, role=job_runner.JOB_ROLE_BUILDER)
+account = "cortex-builder"
 spec = job_runner.build_job_spec(
     job_id=f"{instance}-attack",
     instance=instance,
@@ -3078,7 +3223,10 @@ spec = job_runner.build_job_spec(
         "MANAGER_PID": manager_pid,
     },
 )
-print("wrote:", job_runner.write_job_spec(job_runner.job_spec_path(spool, instance), spec))
+# `account=` 讓寫端在落地後就地複驗「那個身分讀得到這個檔」（#657）——
+# 失敗會是一個 Manager 端的清楚錯誤，而不是 journal 裡的 78/CONFIG。
+print("wrote:", job_runner.write_job_spec(
+    job_runner.job_spec_path(spool, instance), spec, account=account))
 PY
 sudo -u cortex-manager systemctl start "cortex-job@$JOB.service"
 # ⚠️ 報告在 **spec 的 log_path**，不在 journal——shim 在已降權之後接管 stdout/stderr。
@@ -3098,7 +3246,9 @@ import sys
 from paulsha_cortex.coordinator import job_runner
 
 instance, manager_pid = sys.argv[1], sys.argv[2]
-spool = job_runner.DEFAULT_JOB_SPEC_SPOOL
+# #657：spool 是 per-principal 的——`role=` 決定寫進哪一格。
+spool = job_runner.resolve_job_spec_spool({}, role=job_runner.JOB_ROLE_REVIEW)
+account = "cortex-reviewer-planner"
 spec = job_runner.build_job_spec(
     job_id=f"{instance}-r9",
     instance=instance,
@@ -3114,7 +3264,10 @@ spec = job_runner.build_job_spec(
         "MANAGER_PID": manager_pid,
     },
 )
-print("wrote:", job_runner.write_job_spec(job_runner.job_spec_path(spool, instance), spec))
+# `account=` 讓寫端在落地後就地複驗「那個身分讀得到這個檔」（#657）——
+# 失敗會是一個 Manager 端的清楚錯誤，而不是 journal 裡的 78/CONFIG。
+print("wrote:", job_runner.write_job_spec(
+    job_runner.job_spec_path(spool, instance), spec, account=account))
 PY
 sudo -u cortex-manager systemctl start "cortex-reviewer-job@$RJOB.service"
 sudo cat "/var/lib/cortex-reviewer-planner/cache/$RJOB.log" | tee /tmp/r9-reviewer.txt
@@ -3326,7 +3479,7 @@ PY
 
 # 🔧 清理
 sudo rm -rf "$SPOOLDIR" /var/lib/cortex/coordinator/review-verdicts/negctl
-sudo rm -f "/var/lib/cortex/coordinator/job-specs/$VJOB.json" \
+sudo rm -f "/var/lib/cortex/coordinator/job-specs/reviewer/$VJOB.json" \
            "/var/lib/cortex-reviewer-planner/cache/$VJOB.log"
 ```
 
@@ -3356,7 +3509,9 @@ try "T5.1 write dispatch log dir"      ": > $A/runtime/dispatch/psc-probe"
 # T5.2 寫其他 Tier-0 Manager-owned 資產
 try "T5.2 write jobs registry"         ": > $A/coordinator/jobs.json.probe"
 try "T5.2 write evidence tree"         ": > $A/coordinator/evidence/.probe"
-try "T5.2 write job-spec spool"        ": > $A/coordinator/job-specs/.probe"
+try "T5.2 write job-spec spool"        ": > $A/coordinator/job-specs/gate/.probe"
+try "T5.2 read another persona spool"  "ls $A/coordinator/job-specs/builder"
+try "T5.2 list the spool container"    "ls $A/coordinator/job-specs"
 try "T5.2 write repo source tree"      ": > $A/repos/.probe"
 # T5.3 寫 builder 的工作樹（讀得到，但不可寫）
 for d in $A/worktree/*/; do try "T5.3 write builder worktree" ": > ${d}psc-probe"; break; done
@@ -3481,8 +3636,8 @@ sudo -u cortex-manager env $(grep -v '^#' /opt/cortex/etc/cortex-manager.env | x
 ```bash
 # 🔧 sudo：清掉 R9 抽驗的全部殘留（含 drop-in 目錄——它本身就是提權面）
 sudo systemctl stop "cortex-job@r9.service" "cortex-job@negctl5.service" 2>/dev/null || true
-sudo rm -f /var/lib/cortex/coordinator/job-specs/r9.json \
-           /var/lib/cortex/coordinator/job-specs/negctl5.json \
+sudo rm -f /var/lib/cortex/coordinator/job-specs/builder/r9.json \
+           /var/lib/cortex/coordinator/job-specs/builder/negctl5.json \
            /var/lib/cortex/r9-attack.sh
 sudo rm -rf /var/lib/cortex/worktree/r9 /var/lib/cortex/worktree/negctl5 \
             /var/lib/cortex/worktree/victim \
@@ -3491,8 +3646,8 @@ sudo rm -rf /var/lib/cortex/worktree/r9 /var/lib/cortex/worktree/negctl5 \
             /etc/systemd/system/cortex-job-jit@.service.d
 sudo systemctl daemon-reload
 
-# ✅ 驗證：spool 內不得殘留任何抽驗用的 spec（它們是 job 的命令列）
-sudo ls -l /var/lib/cortex/coordinator/job-specs
+# ✅ 驗證：spool 內不得殘留任何抽驗用的 spec（它們是 job 的命令列）——**逐格看**
+sudo ls -l /var/lib/cortex/coordinator/job-specs/{builder,reviewer,gate}
 #   期望：不含 r9.json／negctl5.json／selftest.json／evil.json
 ```
 
@@ -3624,7 +3779,7 @@ sudo -u cortex-manager systemctl start cortex-job@negctl5.service \
   && echo "降權重啟後仍可用" || echo "!! 降權失效，查 polkit"
 sudo grep -o "uid=[0-9]*(cortex-builder)" /var/lib/cortex/worktree/negctl5/negctl5.log
 # 🔧 sudo：驗完立刻清掉（spec 是 job 的命令列，不留過夜）
-sudo rm -f /var/lib/cortex/coordinator/job-specs/negctl5.json
+sudo rm -f /var/lib/cortex/coordinator/job-specs/builder/negctl5.json
 sudo rm -rf /var/lib/cortex/worktree/negctl5
 
 # ✅ 7. 降權反向：重啟後提權仍被拒（規則沒有因重啟而失效）
@@ -3732,8 +3887,13 @@ diff <(python3 -m paulsha_cortex.trust_root shim four-way)            /opt/corte
 sudo grep -rIl -- "/.local/share/pipx" /opt/cortex/venv | head    # 期望：空輸出
 sudo find /opt/cortex/venv -name "pipx_shared.pth" | head          # 期望：空輸出
 
-# ✅ job-spec spool 沒有留下過夜的 spec（每一份都是某個 job 的命令列）
-sudo ls -l /var/lib/cortex/coordinator/job-specs
+# ✅ job-spec spool 沒有留下過夜的 spec（每一份都是某個 job 的命令列）——**逐格看**
+sudo ls -l /var/lib/cortex/coordinator/job-specs/{builder,reviewer,gate}
+# ✅ #657：六份 unit 各指自己那格（共用一條＝該角色每個 job 必以 78/CONFIG 收場）
+for U in cortex-job cortex-job-jit cortex-reviewer-job cortex-reviewer-job-jit \
+         cortex-gate-job cortex-gate-job-jit; do
+  systemctl cat "$U@.service" | grep -E "^Environment=PSC_JOB_SPEC_SPOOL="
+done | sort -u | wc -l          # 期望：3
 
 # ✅ 沒有殘留的 template drop-in（族 5.2 的持久化面）——**四份都要看**
 for S in cortex-job cortex-job-jit cortex-reviewer-job cortex-reviewer-job-jit; do

--- a/paulsha_cortex/config/paths.py
+++ b/paulsha_cortex/config/paths.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import os
+import re
 from pathlib import Path
 
 from .runtime import resolve_project_config_root, resolve_run_root, resolve_runtime_root
@@ -156,19 +157,60 @@ JOB_SPEC_SPOOL_DIRNAME = "job-specs"
 
 
 def job_spec_spool_root() -> Path:
-    """trust-root Phase 2b 方案 B：降權 job 的 per-job 執行規格 spool 根。
+    """trust-root Phase 2b 方案 B：降權 job 的 per-job 執行規格 spool **容器**。
 
     operator 0816 第三輪裁決 **A+B**：builder job 改經 root-owned 的
     `cortex-job@.service` 模板實例起跑。模板 unit 的 `ExecStart=` 是**固定的**
     （`<deploy_root>/bin/cortex-job-shim %i`），因此「這個 job 要跑什麼命令、在哪個
-    worktree、帶哪些 env、log 寫去哪」必須由一個**帶外通道**傳遞——就是本 spool：
-    `<此根>/<unit-instance-id>.json`，Manager 原子寫入，job 帳號**唯讀**（permgen 依
-    R1 登記表產出 owner＝durable_state_owner、mode 0700 ＋ per-account 唯讀 ACL）。
+    worktree、帶哪些 env、log 寫去哪」必須由一個**帶外通道**傳遞——就是本 spool。
+
+    **#657 起本函式回傳的是容器，不是任何 job 讀得到的目錄。** 實際的 spec 落在
+    per-principal 的子 spool（:func:`job_spec_spool_for`），容器本身維持
+    owner-only 0700、對每個降權帳號只有機械導出的 `--x` traverse——因此沒有任何
+    job 帳號列得出「這台機器上還有誰的 job」。
 
     這是「即使持 spawn 授權的帳號被攻陷也無法向上」的另一半：unit 檔 root-owned 改不了、
     spec 檔 job 帳號寫不了，因此 job **既不能選 UID、也不能改寫自己的命令列**。
     """
     return coordinator_root() / JOB_SPEC_SPOOL_DIRNAME
+
+
+#: per-principal spool 的目錄名形狀。只允許小寫字母／數字／`-`，且必須以字母開頭
+#: ——這個字串會被接進絕對路徑並寫進 root-owned unit 的 `Environment=`，容忍
+#: `..`／`/` 等於把「spec 一定落在 Manager-owned 樹裡」這條性質交給呼叫端自律。
+_SPOOL_PRINCIPAL_RE = re.compile(r"^[a-z][a-z0-9-]*$")
+
+
+def job_spec_spool_for(principal_id: str) -> Path:
+    """#657：**該降權 principal 專屬**的 spec spool（`<容器>/<principal>`）。
+
+    ## 為什麼不是一個共用 spool
+
+    #629 的 gate 執行身分落地後，實機上每個 gate job 都以 `78/CONFIG` 收場：
+    `cortex-gate-job@.service` 與 builder 的模板 unit 指向**同一個** spool，而登記表
+    只授 builder 唯讀 ACL。shim 是 systemd 套完 `User=` **之後**才跑的，因此它以 job
+    身分讀 spec ⇒ 必然 `EACCES`。reviewer／planner 是同一型（#652 未驗到這層）。
+
+    修法有兩個候選：把共用 spool 的 reader 面擴成「全部降權 principal」，或每個
+    principal 一個 spool 根。取後者，理由是**可稽核性**：這樣「哪個身分讀哪個 spool」
+    是 root-owned unit 檔上可以逐字讀懂的一行（`Environment=PSC_JOB_SPEC_SPOOL=`），
+    而不是一組共用目錄上三條 ACL 的交集；而且它不必新開「跨 persona 互讀 spec」這個
+    性質——那在共用 spool 下是無法避免的副作用（spec 內容是命令列與白名單 env）。
+
+    第三個候選（spec 檔由 root 預先 chown 給該 job 帳號）不成立：spec 是 Manager 寫的，
+    chown 給別的 owner 需要 root，而「cortex 任何元件永不具 root」是既有裁決。
+
+    `principal_id` 是 `trust_root.registry.Principal` 的 `value`（`builder`／
+    `reviewer`／`gate`），由登記表機械導出；本模組不 import trust_root（path 契約
+    對治理平面零依賴），故以字串傳入並在此驗形狀。
+    """
+
+    name = str(principal_id or "").strip()
+    if not _SPOOL_PRINCIPAL_RE.match(name):
+        raise ValueError(
+            f"principal id 不合法（只允許 ^[a-z][a-z0-9-]*$）: {principal_id!r}"
+        )
+    return job_spec_spool_root() / name
 
 
 def specs_root() -> Path:

--- a/paulsha_cortex/coordinator/gate_runner.py
+++ b/paulsha_cortex/coordinator/gate_runner.py
@@ -471,7 +471,7 @@ def _run_as_gate_identity(
         log_path=str(spool_ledger.parent / GATE_LOG_FILENAME),
         env=gate_env,
     )
-    job_runner.write_job_spec(plan.spec_path, spec)
+    job_runner.write_job_spec(plan.spec_path, spec, account=plan.account)
     start = job_runner.build_systemctl_start_argv(
         systemctl=plan.binary, unit=plan.unit
     )

--- a/paulsha_cortex/coordinator/job_runner.py
+++ b/paulsha_cortex/coordinator/job_runner.py
@@ -62,9 +62,9 @@ stderr 併進 JSONL log（`stderr=STDOUT`）。不加 `--quiet` 就等於在 ter
 - `User=` 與 `ExecStart=` 都寫死在 root 擁有的 `cortex-job@.service` 裡，Manager
   帳號**選不了 UID、也給不了命令列**（unit 檔它改不動）。
 - 命令列既然給不了，per-job 參數改走**帶外通道**：一份 spec JSON 原子寫進
-  Manager-owned spool（登記表資產 `job-spec-spool`，job 帳號唯讀），
-  `ExecStart=` 的 root-owned shim 讀完才 exec 真正的 job
-  （見 :mod:`paulsha_cortex.coordinator.job_shim`）。
+  Manager-owned spool（登記表資產 `job-spec-spool-<principal>`，**該** job 帳號
+  唯讀；#657 起一個降權身分一格），`ExecStart=` 的 root-owned shim 讀完才 exec
+  真正的 job（見 :mod:`paulsha_cortex.coordinator.job_shim`）。
 - spec **不含** `User`／`uid` 這類欄位（:data:`SPEC_FORBIDDEN_KEYS` 在寫端與讀端
   各擋一次），也不含任何 token（沿用同一份 env 白名單）。
 
@@ -124,6 +124,8 @@ __all__ = [
     "DEFAULT_GATE_TEMPLATE_UNIT",
     "DEFAULT_JOB_SHIM",
     "DEFAULT_JOB_SPEC_SPOOL",
+    "DEFAULT_GATE_JOB_SPEC_SPOOL",
+    "DEFAULT_REVIEW_JOB_SPEC_SPOOL",
     "DEFAULT_REVIEWER_ACCOUNT",
     "DEFAULT_REVIEW_TEMPLATE_UNIT",
     "DEFAULT_START_TIMEOUT_MS",
@@ -145,6 +147,10 @@ __all__ = [
     "JOB_RUNNER_ENV",
     "JOB_SHIM_ENV",
     "JOB_SPEC_SPOOL_ENV",
+    "GATE_JOB_SPEC_SPOOL_ENV",
+    "REVIEW_JOB_SPEC_SPOOL_ENV",
+    "POSIX_ACL_ACCESS_XATTR",
+    "POSIX_ACL_DEFAULT_XATTR",
     "JOB_SPEC_VERSION",
     "JobRoleConfig",
     "JobRunnerError",
@@ -175,7 +181,9 @@ __all__ = [
     "build_systemd_run_argv",
     "confirm_template_instance_started",
     "confirm_transient_unit_started",
+    "effective_perms_for_account",
     "forbidden_spec_keys",
+    "inherited_perms_for_account",
     "instance_name_valid",
     "job_spec_path",
     "preflight_systemd_run",
@@ -186,6 +194,7 @@ __all__ = [
     "resolve_hardening_profile",
     "resolve_job_account",
     "resolve_job_group",
+    "resolve_job_spec_spool",
     "resolve_job_role",
     "template_instance_id",
     "template_unit_for_profile",
@@ -289,6 +298,32 @@ TEMPLATE_UNIT_PREFIX = "cortex-job@"
 TEMPLATE_UNIT_SUFFIX = ".service"
 DEFAULT_TEMPLATE_UNIT = f"{TEMPLATE_UNIT_PREFIX}{TEMPLATE_UNIT_SUFFIX}"
 
+# ---------------------------------------------------------------------------
+# per-principal spec spool（#657）
+#
+# 在此之前三份模板 unit 共用同一個 spool 根，而登記表只授 builder 唯讀 ACL——shim 是
+# systemd 套完 `User=` **之後**才執行的，因此 reviewer／gate 的每一個 job 都在讀 spec
+# 時 `EACCES` → `78/CONFIG`（實機實測）。現在每個角色有自己的 spool（登記表資產
+# `job-spec-spool-<principal>`），路徑由 root-owned 的模板 unit 以
+# `Environment=PSC_JOB_SPEC_SPOOL=` 宣告——**shim 端因此一行都不必改**，它讀的永遠是
+# 「這份 unit 說的那一個」，而那一行是可稽核的。
+#
+# 下面三組預設值與 `trust_root.permgen.PathLayout.job_spec_spool_for()` 是**成對契約**
+# （與 `DEFAULT_TEMPLATE_UNIT` 同一個既有模式：job_runner 刻意不 import permgen，改由
+# `tests/test_per_principal_spec_spool_657.py` 釘住兩邊逐字相等）。
+#
+# **per-role 的變數名是刻意的**：共用一個 `PSC_JOB_SPEC_SPOOL` 會讓「Manager 的環境裡
+# 剛好有這個變數」把三個角色一起導回同一個目錄——那正好是本票要修掉的那個狀態，而且
+# 會靜默生效。
+# ---------------------------------------------------------------------------
+
+JOB_SPEC_SPOOL_ENV = "PSC_JOB_SPEC_SPOOL"
+DEFAULT_JOB_SPEC_SPOOL = "/var/lib/cortex/coordinator/job-specs/builder"
+REVIEW_JOB_SPEC_SPOOL_ENV = "PSC_REVIEW_JOB_SPEC_SPOOL"
+DEFAULT_REVIEW_JOB_SPEC_SPOOL = "/var/lib/cortex/coordinator/job-specs/reviewer"
+GATE_JOB_SPEC_SPOOL_ENV = "PSC_GATE_JOB_SPEC_SPOOL"
+DEFAULT_GATE_JOB_SPEC_SPOOL = "/var/lib/cortex/coordinator/job-specs/gate"
+
 
 # ---------------------------------------------------------------------------
 # job 角色（#615 M2：reviewer／planner 啟動面降權）
@@ -329,6 +364,11 @@ class JobRoleConfig:
     path_env: str
     template_env: str
     default_template: str
+    #: #657：**本角色專屬**的 spec spool。與模板 unit 的
+    #: `Environment=PSC_JOB_SPEC_SPOOL=` 是同一條路徑的兩個落點（Manager 寫端／
+    #: shim 讀端），由 `trust_root.permgen` 機械產出。
+    spec_spool_env: str
+    default_spec_spool: str
     #: 這個角色是誰、為什麼要獨立一份（進錯誤訊息與產物註解）。
     rationale: str
 
@@ -344,6 +384,8 @@ JOB_ROLE_CONFIG: Mapping[str, JobRoleConfig] = MappingProxyType(
             path_env=BUILDER_PATH_ENV,
             template_env=TEMPLATE_UNIT_ENV,
             default_template=DEFAULT_TEMPLATE_UNIT,
+            spec_spool_env=JOB_SPEC_SPOOL_ENV,
+            default_spec_spool=DEFAULT_JOB_SPEC_SPOOL,
             rationale=(
                 "builder persona——唯一會在自己完全掌控的工作區裡跑 untrusted repo "
                 "code 的角色，攻擊面最大。M1（#603／#584）已落地。"
@@ -358,6 +400,8 @@ JOB_ROLE_CONFIG: Mapping[str, JobRoleConfig] = MappingProxyType(
             path_env=REVIEWER_PATH_ENV,
             template_env=REVIEW_TEMPLATE_UNIT_ENV,
             default_template=DEFAULT_REVIEW_TEMPLATE_UNIT,
+            spec_spool_env=REVIEW_JOB_SPEC_SPOOL_ENV,
+            default_spec_spool=DEFAULT_REVIEW_JOB_SPEC_SPOOL,
             rationale=(
                 "reviewer ＋ planner persona（三分方案下同一個 OS 帳號）。M2（#615）："
                 "在此之前它們仍在 Manager 行程內以 Manager 帳號執行，"
@@ -373,6 +417,8 @@ JOB_ROLE_CONFIG: Mapping[str, JobRoleConfig] = MappingProxyType(
             path_env=GATE_PATH_ENV,
             template_env=GATE_TEMPLATE_UNIT_ENV,
             default_template=DEFAULT_GATE_TEMPLATE_UNIT,
+            spec_spool_env=GATE_JOB_SPEC_SPOOL_ENV,
+            default_spec_spool=DEFAULT_GATE_JOB_SPEC_SPOOL,
             rationale=(
                 "gate 執行身分（#629）——operator 宣告的 `PSC_GATE_CMD_*` 在這裡執行。"
                 "它不跑模型，但那些命令載入的是 builder 完全掌控的工作樹裡的 "
@@ -455,10 +501,6 @@ EXECUTOR_HARDENING_PROFILE: Mapping[str, str] = MappingProxyType(
         "agy": HARDENING_PROFILE_STRICT,
     }
 )
-
-#: Manager-owned 的 per-job spec spool（登記表資產 `job-spec-spool`）。
-JOB_SPEC_SPOOL_ENV = "PSC_JOB_SPEC_SPOOL"
-DEFAULT_JOB_SPEC_SPOOL = "/var/lib/cortex/coordinator/job-specs"
 
 #: root-owned shim（模板 unit 的固定 `ExecStart=`）。preflight 只檢查它存在且可執行。
 JOB_SHIM_ENV = "PSC_JOB_SHIM"
@@ -1361,8 +1403,18 @@ def resolve_template_unit(env: Mapping[str, str], *, role: str = JOB_ROLE_BUILDE
     return (env.get(config.template_env) or "").strip() or config.default_template
 
 
-def resolve_job_spec_spool(env: Mapping[str, str]) -> str:
-    return (env.get(JOB_SPEC_SPOOL_ENV) or "").strip() or DEFAULT_JOB_SPEC_SPOOL
+def resolve_job_spec_spool(env: Mapping[str, str], *, role: str = JOB_ROLE_BUILDER) -> str:
+    """該角色**自己的** spec spool（#657；由 :data:`JOB_ROLE_CONFIG` 查表）。
+
+    `role` 的預設值是 builder，與 :func:`resolve_job_account` 等同族函式一致——理由也
+    一樣：忘了傳 `role` 的後果是「reviewer 的 spec 被寫進 builder 的 spool」，那個 job
+    起不來（它的 unit 讀的是 reviewer 的 spool），而**起不來是安全的失敗方向**；反過來
+    若讓寫端落回一個共用目錄，才會回到 #657 那個「看起來成功、實際上每個 job 78/CONFIG」
+    的狀態。
+    """
+
+    config = resolve_job_role(role)
+    return (env.get(config.spec_spool_env) or "").strip() or config.default_spec_spool
 
 
 def resolve_job_shim(env: Mapping[str, str]) -> str:
@@ -1444,7 +1496,9 @@ def build_job_spec(
     return spec
 
 
-def write_job_spec(spec_path: str, spec: Mapping[str, object]) -> str:
+def write_job_spec(
+    spec_path: str, spec: Mapping[str, object], *, account: str | None = None
+) -> str:
     """把 spec **原子**寫進 Manager-owned spool；失敗即 fail-closed。
 
     原子性（同目錄 temp ＋ `os.replace`）不是潔癖：spec 是 job 的命令列，一個被
@@ -1455,6 +1509,13 @@ def write_job_spec(spec_path: str, spec: Mapping[str, object]) -> str:
     即 `0600`，而 group 位全關會**連帶把繼承下來的 ACL mask 也關掉**，job 帳號的
     唯讀 ACL 因此形同虛設（讀 spec 會 EACCES）。group 仍是 Manager 自己的 group，
     所以放寬 group-read 不會讓第三方讀到。
+
+    **`account`（#657）**：落地之後就地複驗「那個身分讀得到這個檔」。preflight 算的
+    是 spool 目錄的 default ACL（spec 當時還不存在，那是唯一能算的東西）；這裡算的是
+    **真的那個 inode**，把上面那段 `chmod 0640` ⟷ ACL mask 的推導從註解升級成斷言。
+    `account=None` 或帳號不在 passwd 時略過——那兩種情形在正式派工路徑上不可達
+    （`prepare_systemd_template()` 已對帳號 fail-closed），只出現在直接呼叫本函式的
+    測試裡。
     """
 
     directory = os.path.dirname(spec_path) or "."
@@ -1481,6 +1542,20 @@ def write_job_spec(spec_path: str, spec: Mapping[str, object]) -> str:
             source="write_job_spec",
             spec_path=spec_path,
         ) from exc
+    if account:
+        ok, why = _spec_readable_by(spec_path, account)
+        if not ok:
+            raise _fail(
+                "job-runner-job-spec-unreadable-by-job",
+                (
+                    f"spec 已落地但 {account} 讀不到它: {why}。shim 會在 systemd 套完 "
+                    "User= 之後以該身分讀這個檔，因此本次派工必定以 78/CONFIG 收場"
+                    "——在這裡擋掉，而不是讓它變成 journal 裡的一行（#657）。"
+                ),
+                source="write_job_spec",
+                spec_path=spec_path,
+                account=account,
+            )
     return spec_path
 
 
@@ -1567,12 +1642,20 @@ def preflight_systemd_template(
     unit_file_installed: Callable[[str], bool] | None = None,
     executable: Callable[[str], bool] | None = None,
     directory_exists: Callable[[str], bool] | None = None,
+    spool_readable: Callable[[str, str], tuple[bool, str]] | None = None,
 ) -> str:
     """模板模式的靜態檢查；任一項不成立即 fail-closed，回傳 systemctl 絕對路徑。
 
     比 A 案多三條，對應「本模式生效需要 Phase 2b 安裝」的三個前置物：模板 unit 檔、
     root-owned shim、Manager-owned spec spool。**任何一條都不會退回其他模式**——
     「以為降權生效但其實沒有」正是這整條票要消除的失效模式。
+
+    **spool 那一條在 #657 之後檢查的是「`account` 讀得到」而不是「目錄存在」。**
+    舊的 `os.path.isdir()` 對 #657 完全無感：那台實機上 spool 目錄存在、Manager 也
+    寫得進去，缺的只是 `cortex-gate` 的 ACL——於是 preflight 綠、`systemctl start`
+    回 0、job 在 shim 讀 spec 時才以 `78/CONFIG` 死掉，逐字原因只在 journal 裡。
+    現在改以 :func:`_spool_readable_by` 算該帳號的 **effective** 權限（見該函式的
+    誠實邊界），失敗點因此回到「派工之前、Manager 自己的錯誤訊息裡」。
 
     polkit 拒絕仍然沒有可靠的唯讀探測面，由
     :func:`confirm_template_instance_started` 在起動階段補上。
@@ -1634,9 +1717,28 @@ def preflight_systemd_template(
     if not has_dir(spool_dir):
         raise _fail(
             "job-runner-job-spec-spool-missing",
-            f"job spec spool 目錄不存在: {spool_dir}（Phase 2b 權限套用尚未執行？）",
+            (
+                f"job spec spool 目錄不存在: {spool_dir}（#657 起每個降權角色一格；"
+                "Phase 2b 權限套用尚未重跑？）"
+            ),
             source="preflight_systemd_template",
             spool_dir=spool_dir,
+        )
+    readable = spool_readable or _spool_readable_by
+    ok, why = readable(spool_dir, account)
+    if not ok:
+        raise _fail(
+            "job-runner-job-spec-spool-unreadable",
+            (
+                f"job 身分 {account} 讀不到自己的 spec spool: {why}。"
+                "（#657：spool 存在不等於那個身分讀得到——shim 是 systemd 套完 "
+                "`User=` **之後**才執行的，它以 job 身分讀 spec。重跑 "
+                "`python3 -m paulsha_cortex.trust_root permissions --commands --paths` "
+                "並套用，或見 runbook 的 per-principal spool 段。）"
+            ),
+            source="preflight_systemd_template",
+            spool_dir=spool_dir,
+            account=account,
         )
     return resolved
 
@@ -1743,7 +1845,7 @@ def prepare_systemd_template(
     profile = _resolve_profile_for_role(env, role=role, executor=executor)
     template = template_unit_for_profile(base_template, profile)
     shim = resolve_job_shim(env)
-    spool_dir = resolve_job_spec_spool(env)
+    spool_dir = resolve_job_spec_spool(env, role=role)
     binary = preflight_systemd_template(
         account=account,
         group=group,
@@ -1900,3 +2002,303 @@ def _group_exists(name: str) -> bool:
     except KeyError:
         return False
     return True
+
+
+# ---------------------------------------------------------------------------
+# 「**那個身分**讀得到嗎」——effective 權限判定（#657）
+#
+# 本族 bug（#638／#657）全部是同一個形狀：測試與 preflight 檢查的是「檔案／目錄
+# 存在」，而實機失敗的是「**該 job 身分**讀不到它」。兩者在單 UID 環境下無法區分，
+# 於是 CI 綠、實機每個 job 以 78/CONFIG 收場。
+#
+# Manager 不是那個身分，`os.access()` 問的是「**我**讀不讀得到」，因此答不了這題。
+# 但核心的判定並不需要變成那個身分：POSIX.1e 的 access check 是**對 inode 的中繼資料
+# 做的一次純計算**（owner／group／mode ＋ ACL），而那些中繼資料 Manager 讀得到。
+# 下面就是那個計算——不是近似，是 kernel 用的同一條規則。
+#
+# 它**不**涵蓋的（誠實邊界，見 runbook 的實測步驟）：
+#   - mount 選項（`noexec`／唯讀掛載）與 LSM（SELinux／AppArmor）；
+#   - mount namespace（模板 unit 的 `ProtectSystem=strict` 等）；
+#   - root 對 DAC 的豁免（本族評的都是非 root 的 job 帳號，不適用）。
+# 那三項只有「真的以該身分開一次檔」才驗得到，所以 runbook 保留 `sudo -u <帳號>`
+# 的實測步驟，而測試對「需要第二個 UID 才驗得到」的部分**明確 skip 並說明理由**。
+# ---------------------------------------------------------------------------
+
+#: POSIX.1e access ACL 的 xattr 名（Linux）。`getfacl` 讀的就是這個。
+POSIX_ACL_ACCESS_XATTR = "system.posix_acl_access"
+#: 目錄的 default ACL——決定**底下新建的檔**會繼承到哪些具名條目。spec 檔在 preflight
+#: 當下還不存在（它是 preflight 通過之後才寫的），因此「job 讀不讀得到自己的 spec」
+#: 在這個時點只能、也**足以**由這一份決定（另一半是 `write_job_spec()` 的 0640）。
+POSIX_ACL_DEFAULT_XATTR = "system.posix_acl_default"
+
+_ACL_TAG_USER_OBJ = 0x01
+_ACL_TAG_USER = 0x02
+_ACL_TAG_GROUP_OBJ = 0x04
+_ACL_TAG_GROUP = 0x08
+_ACL_TAG_MASK = 0x10
+_ACL_TAG_OTHER = 0x20
+_ACL_XATTR_VERSION = 2
+_ACL_UNDEFINED_ID = 0xFFFFFFFF
+
+_PERM_R = 0o4
+_PERM_W = 0o2
+_PERM_X = 0o1
+
+
+def _perm_str(bits: int) -> str:
+    """`0o5` → `"r-x"`。錯誤訊息裡的可讀形狀（與 `getfacl` 同一種寫法）。"""
+
+    return "".join(
+        letter if bits & bit else "-"
+        for letter, bit in (("r", _PERM_R), ("w", _PERM_W), ("x", _PERM_X))
+    )
+
+
+def _parse_acl_xattr(blob: bytes) -> list[tuple[int, int, int]]:
+    """POSIX.1e ACL xattr → `[(tag, perms, id), …]`。格式不認得即空 list。
+
+    佈局（`<linux/posix_acl_xattr.h>`）：4-byte little-endian version，其後每 8 bytes
+    一條：`u16 tag`、`u16 perm`、`u32 id`。
+    """
+
+    if len(blob) < 4 or (len(blob) - 4) % 8:
+        return []
+    if int.from_bytes(blob[:4], "little") != _ACL_XATTR_VERSION:
+        return []
+    entries: list[tuple[int, int, int]] = []
+    for offset in range(4, len(blob), 8):
+        tag = int.from_bytes(blob[offset:offset + 2], "little")
+        perm = int.from_bytes(blob[offset + 2:offset + 4], "little")
+        ident = int.from_bytes(blob[offset + 4:offset + 8], "little")
+        entries.append((tag, perm, ident))
+    return entries
+
+
+def _read_acl(path: str, xattr_name: str) -> list[tuple[int, int, int]]:
+    """讀一份 ACL；沒有 ACL／不支援 xattr／非 Linux 一律回空 list。
+
+    空 list **不是** fail-open：呼叫端在那種情形下退回傳統 mode 位判定，而那正是
+    「這個檔系統上沒有 ACL 時 kernel 用的規則」。
+    """
+
+    getxattr = getattr(os, "getxattr", None)
+    if getxattr is None:  # pragma: no cover - 非 Linux
+        return []
+    try:
+        return _parse_acl_xattr(getxattr(path, xattr_name))
+    except OSError:
+        return []
+
+
+def _account_ids(account: str) -> tuple[int, frozenset[int]] | None:
+    """帳號 → `(uid, 全部 gid)`；passwd 查不到即 None（呼叫端須 fail-closed）。"""
+
+    try:
+        entry = pwd.getpwnam(account)
+    except KeyError:
+        return None
+    try:
+        gids = frozenset(os.getgrouplist(entry.pw_name, entry.pw_gid))
+    except (OSError, AttributeError):  # pragma: no cover - 平台差異
+        gids = frozenset({entry.pw_gid})
+    return entry.pw_uid, gids
+
+
+def effective_perms_for_account(path: str, account: str) -> int | None:
+    """`account` 對 `path` 的 **effective** 權限位（`0o7` 之內）；無法判定即 None。
+
+    這是 POSIX.1e §Access Check Algorithm 的直譯：owner 位優先、其次具名 user 條目
+    （**經 mask 收斂**）、其次 group 類條目的聯集（同樣經 mask）、最後 other 位。
+
+    **mask 那一段是本族 bug 的核心**：`setfacl -m u:x:rX` 之後再 `chmod 0700` 會把
+    mask 打成 `---`，具名條目於是靜默失效——ACL 還在（`getfacl` 看得到），有效權限
+    卻是零。只看「有沒有那條 ACL」的檢查會漏掉它；本函式看的是 kernel 實際會算出
+    的那個值。
+    """
+
+    ids = _account_ids(account)
+    if ids is None:
+        return None
+    uid, gids = ids
+    try:
+        stat_result = os.stat(path)
+    except OSError:
+        return None
+
+    mode = stat_result.st_mode
+    entries = _read_acl(path, POSIX_ACL_ACCESS_XATTR)
+    if not entries:
+        # 沒有 ACL：傳統三段式。
+        if uid == stat_result.st_uid:
+            return (mode >> 6) & 0o7
+        if stat_result.st_gid in gids:
+            return (mode >> 3) & 0o7
+        return mode & 0o7
+
+    mask = 0o7
+    has_mask = False
+    for tag, perm, _ident in entries:
+        if tag == _ACL_TAG_MASK:
+            mask = perm & 0o7
+            has_mask = True
+
+    if uid == stat_result.st_uid:
+        for tag, perm, _ident in entries:
+            if tag == _ACL_TAG_USER_OBJ:
+                return perm & 0o7  # owner 位不過 mask
+        return (mode >> 6) & 0o7
+    for tag, perm, ident in entries:
+        if tag == _ACL_TAG_USER and ident == uid:
+            return perm & mask if has_mask else perm & 0o7
+    group_bits = 0
+    matched_group = False
+    for tag, perm, ident in entries:
+        if tag == _ACL_TAG_GROUP_OBJ and stat_result.st_gid in gids:
+            matched_group = True
+            group_bits |= perm & 0o7
+        elif tag == _ACL_TAG_GROUP and ident in gids:
+            matched_group = True
+            group_bits |= perm & 0o7
+    if matched_group:
+        return group_bits & mask if has_mask else group_bits
+    for tag, perm, _ident in entries:
+        if tag == _ACL_TAG_OTHER:
+            return perm & 0o7
+    return mode & 0o7
+
+
+def inherited_perms_for_account(directory: str, account: str) -> int | None:
+    """新建於 `directory` 的**檔**會讓 `account` 拿到的權限位；無法判定即 None。
+
+    來源是目錄的 default ACL。`write_job_spec()` 在 `os.replace` 前 `chmod 0640`，
+    因此新檔的 ACL mask 會被重算成 `r--`——這一段與本函式相加，就是「job 讀不讀得到
+    自己的 spec」的完整答案，而且**在 spec 還沒寫出來之前就答得出來**。
+    """
+
+    ids = _account_ids(account)
+    if ids is None:
+        return None
+    uid, gids = ids
+    entries = _read_acl(directory, POSIX_ACL_DEFAULT_XATTR)
+    if not entries:
+        # 沒有 default ACL：新檔只帶傳統 mode 位，而 `write_job_spec()` 給的是 0640
+        # （owner rw、group r、other 0）。非 owner 的 job 帳號因此只可能經由 group
+        # 拿到讀權——那要它與 Manager 同 group，是部署決定，不是本函式能假設的。
+        try:
+            owner_uid = os.stat(directory).st_uid
+        except OSError:
+            return None
+        return 0o6 if uid == owner_uid else 0
+    mask = 0o7
+    has_mask = False
+    for tag, perm, _ident in entries:
+        if tag == _ACL_TAG_MASK:
+            mask = perm & 0o7
+            has_mask = True
+    for tag, perm, ident in entries:
+        if tag == _ACL_TAG_USER and ident == uid:
+            return perm & mask if has_mask else perm & 0o7
+    group_bits = 0
+    matched_group = False
+    for tag, perm, ident in entries:
+        if tag == _ACL_TAG_GROUP and ident in gids:
+            matched_group = True
+            group_bits |= perm & 0o7
+    if matched_group:
+        return group_bits & mask if has_mask else group_bits
+    try:
+        owner_uid = os.stat(directory).st_uid
+    except OSError:
+        return None
+    if uid == owner_uid:
+        for tag, perm, _ident in entries:
+            if tag == _ACL_TAG_USER_OBJ:
+                return perm & 0o7
+        return 0o6
+    return 0
+
+
+def _managed_ancestors(path: str) -> list[str]:
+    """`path` 由淺至深的祖先目錄（含 `/`，不含 `path` 自己）。
+
+    traverse 權要整條都成立才有意義：葉節點 ACL 再精確，中間有一層走不過去，
+    `open()` 就是 `EACCES`——而錯誤訊息指的是那一層，與缺的授權不同層（#620）。
+    """
+
+    parts = os.path.normpath(path).split("/")
+    ancestors: list[str] = ["/"]
+    current = ""
+    for segment in parts[1:-1]:
+        current = f"{current}/{segment}"
+        ancestors.append(current)
+    return ancestors
+
+
+def _spool_readable_by(spool_dir: str, account: str) -> tuple[bool, str]:
+    """`account` 是否**真的**讀得到將寫進 `spool_dir` 的 spec。`(ok, 原因)`。
+
+    三段，缺一即不成立：
+
+    1. 路徑上每一層都要有 `x`（traverse）——`derive_traverse_grants()` 產的 `--x`；
+    2. spool 目錄本身要有 `x`（shim 以固定檔名開檔，不需要 `r`；只要求 `x` 是刻意
+       的——要求 `r` 會讓一個「只給 traverse、能正常運作」的更嚴部署被誤判為壞掉）；
+    3. spool 目錄的 **default ACL** 要讓該帳號在新建檔上拿得到 `r`——這一條就是
+       #657 的正面判準，而它在 spec 檔還不存在時就答得出來。
+    """
+
+    if _account_ids(account) is None:
+        return False, (
+            f"帳號 {account} 在 passwd 裡查不到，無法判定它讀不讀得到 spec"
+            "（前一項帳號存在檢查若被 stub 掉，這裡就是唯一會發現的地方）"
+        )
+    for ancestor in _managed_ancestors(spool_dir):
+        bits = effective_perms_for_account(ancestor, account)
+        if bits is None:
+            return False, f"{ancestor}：無法判定 {account} 的 effective 權限（stat 失敗？）"
+        if not bits & _PERM_X:
+            return False, (
+                f"{ancestor}：{account} 沒有 traverse（x）權，effective="
+                f"{_perm_str(bits)}——整條路徑因此走不通"
+                f"（Phase 2b 權限計畫的父目錄 traverse ACL 尚未套用？）"
+            )
+    bits = effective_perms_for_account(spool_dir, account)
+    if bits is None:
+        return False, f"{spool_dir}：無法判定 {account} 的 effective 權限"
+    if not bits & _PERM_X:
+        return False, (
+            f"{spool_dir}：{account} 進不去自己的 spool，effective={_perm_str(bits)}"
+        )
+    inherited = inherited_perms_for_account(spool_dir, account)
+    if inherited is None:
+        return False, f"{spool_dir}：無法判定新建 spec 檔會給 {account} 什麼權限"
+    if not inherited & _PERM_R:
+        return False, (
+            f"{spool_dir}：新建的 spec 檔不會讓 {account} 讀得到"
+            f"（default ACL 推得的 effective={_perm_str(inherited)}）——"
+            f"這正是 #657 的形狀：spool 存在、Manager 寫得進去，而 shim 在 systemd "
+            f"套完 User={account} 之後讀它會 EACCES 並以 78/CONFIG 收場"
+        )
+    return True, ""
+
+
+def _spec_readable_by(spec_path: str, account: str) -> tuple[bool, str]:
+    """spec **落地之後**就地複驗「那個身分讀得到這個 inode」。`(ok, 原因)`。
+
+    與 :func:`_spool_readable_by` 的分工：那一支在**寫之前**算目錄的 default ACL
+    （spec 當時還不存在），這一支在**寫之後**算真的那個檔。兩支合起來把
+    `write_job_spec()` 那段「`chmod 0640` 是為了讓繼承下來的 ACL mask 不被關掉」的
+    推導從註解升級成斷言——那段推導錯了的話，症狀就是 #657 的 78/CONFIG。
+
+    帳號不在 passwd 時回 `(True, …)`：那在正式派工路徑上不可達
+    （`prepare_systemd_template()` 已對帳號 fail-closed），只會出現在直接呼叫
+    `write_job_spec()` 的測試裡；在這裡 fail-closed 只會把測試的 seam 變成產線行為。
+    """
+
+    if _account_ids(account) is None:
+        return True, f"帳號 {account} 不在 passwd（本機無此身分，略過就地複驗）"
+    bits = effective_perms_for_account(spec_path, account)
+    if bits is None:
+        return False, f"{spec_path}：無法判定 {account} 的 effective 權限"
+    if not bits & _PERM_R:
+        return False, f"{spec_path}：effective={_perm_str(bits)}（缺 r）"
+    return True, ""

--- a/paulsha_cortex/coordinator/job_shim.py
+++ b/paulsha_cortex/coordinator/job_shim.py
@@ -6,8 +6,13 @@ operator 0816 第三輪裁決 **A+B** 的 B 半：builder job 不再由 Manager 
 `User=` 與 `ExecStart=` 都硬寫死，Manager 帳號**選不了 UID、也給不了命令列**。
 
 命令列既然給不了，per-job 的參數就得走一條**帶外通道**：Manager 把一份 spec
-原子寫進 Manager-owned spool（登記表資產 `job-spec-spool`，job 帳號唯讀），
-systemd 起 unit、unit exec 本模組、本模組讀 spec 後 exec 真正的 job。
+原子寫進 Manager-owned spool（登記表資產 `job-spec-spool-<principal>`，該 job 帳號
+唯讀），systemd 起 unit、unit exec 本模組、本模組讀 spec 後 exec 真正的 job。
+
+**#657：spool 是 per-principal 的，而本模組因此一行都沒改。** spool 根的唯一來源
+是模板 unit 的 `Environment=PSC_JOB_SPEC_SPOOL=`（root-owned，本模組對未設此變數
+fail-closed、不猜、不落回預設）——「哪個身分讀哪個 spool」是那份 unit 檔上可逐字
+稽核的一行，不是本模組的推導。
 
 ## 這支程式在信任鏈上的位置
 

--- a/paulsha_cortex/coordinator/launcher.py
+++ b/paulsha_cortex/coordinator/launcher.py
@@ -1544,7 +1544,9 @@ class SubprocessLauncher:
                 log_path=log_path,
                 env=env,
             )
-            job_runner.write_job_spec(template_plan.spec_path, spec)
+            job_runner.write_job_spec(
+                template_plan.spec_path, spec, account=template_plan.account
+            )
             argv = job_runner.build_systemctl_start_argv(
                 systemctl=template_plan.binary, unit=template_plan.unit
             )

--- a/paulsha_cortex/trust_root/permgen.py
+++ b/paulsha_cortex/trust_root/permgen.py
@@ -1422,13 +1422,27 @@ class PathLayout:
 
     @property
     def job_spec_spool_root(self) -> str:
-        """Manager 寫、job 只讀的 per-job 執行規格（`<unit-instance-id>.json`）。
+        """per-principal spec spool 的**容器**（登記表資產 `job-spec-spool`）。
 
-        路徑與 `config.paths.job_spec_spool_root()` 是**成對契約**（登記表資產
-        `job-spec-spool`），由 `asset_paths()` 而非本 property 供給權限計畫；本
-        property 只是給 unit／shim 產生器引用的同一份字面量。
+        路徑與 `config.paths.job_spec_spool_root()` 是**成對契約**，由 `asset_paths()`
+        而非本 property 供給權限計畫；本 property 只是給 unit／shim 產生器引用的同一份
+        字面量。
+
+        **#657 起沒有任何 job 讀得到這一層**：它 owner-only 0700、零跨帳號 ACL，
+        降權帳號只會拿到機械導出的 `--x` traverse。spec 落在
+        :meth:`job_spec_spool_for` 的子 spool。
         """
         return f"{self.coordinator_root}/job-specs"
+
+    def job_spec_spool_for(self, principal: Principal) -> str:
+        """#657：**該降權 principal 專屬**的 spec spool（`<容器>/<principal>`）。
+
+        與 `config.paths.job_spec_spool_for()` 是**成對契約**（登記表資產
+        `job-spec-spool-<principal>`）。模板 unit 的
+        `Environment=PSC_JOB_SPEC_SPOOL=` 用的就是本函式——「哪個身分讀哪個 spool」
+        因此是 root-owned unit 檔上可逐字稽核的一行。
+        """
+        return f"{self.job_spec_spool_root}/{principal.value}"
 
     @property
     def bin_root(self) -> str:
@@ -1604,7 +1618,16 @@ class PathLayout:
             # #623／#634 成果回收的 bundle spool：<coordinator>/commit-spool/<job-id>/
             "commit-spool": self.commit_spool_root,
             # Phase 2b 方案 B（0816 第三輪 A+B）：模板 unit 的 per-job 執行規格。
+            # #657：容器 ＋ per-principal 子 spool。子項由登記表的同一張
+            # `DOWNGRADED_JOB_PRINCIPALS` 導出，不逐項寫死——asset_paths() 漏一項的
+            # 症狀是 `plan_to_commands()` 對該資產用 placeholder 路徑，等於漏授。
             "job-spec-spool": self.job_spec_spool_root,
+            **{
+                registry.job_spec_spool_asset_id(principal): self.job_spec_spool_for(
+                    principal
+                )
+                for principal in registry.DOWNGRADED_JOB_PRINCIPALS
+            },
             # #629 gate 執行身分：拋棄式工作區 pool ＋ ledger 單向 spool。
             # 工作區 pool 登記的是**容器**（不帶 per-job segment）：它只有一個 writer
             # ＝`cortex-gate`，因此容器本身就 owner-only 0700，per-job 那一格由 gate
@@ -2404,11 +2427,12 @@ def executor_hardening_profile(executor: str) -> HardeningProfile:
 #:
 #: 這張表同時是 polkit unit pattern 的字幹來源（見 :func:`job_unit_pattern`）：
 #: 放行面 = 這張表 × :data:`HARDENING_PROFILES`，兩者都是列舉，沒有萬用字元。
-DOWNGRADED_JOB_PRINCIPALS: tuple[Principal, ...] = (
-    Principal.BUILDER,
-    Principal.REVIEWER,
-    Principal.GATE,
-)
+#:
+#: **#657：真相搬進 `registry`，本名只是別名。** 這張表同時決定「登記表有哪些
+#: per-principal spec spool 資產」（`registry.job_spec_spool_asset_id`），而
+#: `permgen` import `registry`（反向不成立）——留在這裡會讓登記表得從產生器 import
+#: 回來。搬過去之後兩邊仍是**同一個 tuple 物件**，不是兩份會漂移的清單。
+DOWNGRADED_JOB_PRINCIPALS: tuple[Principal, ...] = registry.DOWNGRADED_JOB_PRINCIPALS
 
 #: 每個 job 角色的 `PATH` 覆寫變數名。與 `coordinator/job_runner.JOB_ROLE_CONFIG`
 #: 的 `path_env` 是**成對契約**（同 `DEFAULT_TEMPLATE_UNIT` 的既有模式：permgen 與
@@ -2925,7 +2949,11 @@ def build_job_unit(
         "",
         "# ExecStart 也是固定的：永遠是 root-owned 的 shim，呼叫端連命令列都給不了。",
         "# per-job 執行規格由 Manager 原子寫入 spec spool（Manager-owned，job 帳號唯讀）：",
-        f"#   {job_layout.job_spec_spool_root}/%i.json",
+        f"#   {job_layout.job_spec_spool_for(principal)}/%i.json",
+        "# **本 principal 專屬的 spool**（#657）：容器 <…>/job-specs/ 對本帳號只有",
+        "# traverse（--x），讀得到的只有自己這一格。shim 是 systemd 套完上面的 User=",
+        "# **之後**才執行的，它以 job 身分讀 spec——所以「這個身分讀得到哪個 spool」",
+        "# 必須是這份 root-owned unit 上可逐字稽核的一行，不是一組共用目錄的 ACL 交集。",
         "# job 因此無法改寫自己的命令列，也無法為下一個 job 埋伏。",
         f"ExecStart={job_layout.job_shim} %i",
         "# 工作目錄：shim 會依 spec 的 working_directory 再 chdir 到該 job 的 worktree；",
@@ -2976,7 +3004,7 @@ def build_job_unit(
         "# shim 讀 spec 的唯一合法來源：這一行在 root-owned 的 unit 檔裡，",
         "# 因此持 spawn 授權的帳號也改不掉 spec 要從哪個目錄讀。shim 對未設此",
         "# 變數的情況 fail-closed（不猜、不落回 $HOME 推導的預設）。",
-        f"Environment=PSC_JOB_SPEC_SPOOL={job_layout.job_spec_spool_root}",
+        f"Environment=PSC_JOB_SPEC_SPOOL={job_layout.job_spec_spool_for(principal)}",
         "# job 永不取得 gh token：GitHub 寫入由 Manager 代理（D1 outbox）。",
         "Environment=GH_TOKEN=",
         "Environment=GITHUB_TOKEN=",
@@ -3086,7 +3114,10 @@ def build_job_shim(
         f"# ExecStart=，因此持 spawn 授權的帳號也換不掉 job 執行的第一支程式。",
         "#",
         f"# $1 ＝ systemd 模板實例名（%i）。spec 由此推導：",
-        f"#   {layout.job_spec_spool_root}/$1.json（Manager 寫、job 唯讀）",
+        f"#   $PSC_JOB_SPEC_SPOOL/$1.json（Manager 寫、job 唯讀）",
+        "# spool 根**只**來自模板 unit 的 Environment=PSC_JOB_SPEC_SPOOL=，而那是",
+        f"#   {layout.job_spec_spool_root}/<principal>（#657：一個降權身分一格）。",
+        "# 本 shim 對三個角色逐字相同——身分與 spool 都由 root-owned 的 unit 決定。",
         "set -eu",
         f'exec "{interpreter}" -m {JOB_SHIM_MODULE} "$@"',
     ]
@@ -3603,7 +3634,7 @@ def build_polkit_rule(
             f"// 內容硬寫死 User={'／'.join(targets)}、NoNewPrivileges=yes、"
             f"CapabilityBoundingSet=（空），\n"
             f"// 以及固定的 ExecStart={layout.job_shim} %i（root-owned shim）。\n"
-            f"// per-job 參數走 Manager-owned spec spool（{layout.job_spec_spool_root}/<id>.json，\n"
+            f"// per-job 參數走 Manager-owned spec spool（{layout.job_spec_spool_root}/<principal>/<id>.json，\n"
             f"// job 帳號唯讀）——{svc} 給得出參數，但給不出 UID、也給不出命令列。\n"
             f"// 因此 {svc} **無法選擇 job 的 UID**，也**無法夾帶任何特權屬性**：\n"
             + "\n".join(f"//     - {p}" for p in POLKIT_FORBIDDEN_PROPERTIES)

--- a/paulsha_cortex/trust_root/registry.py
+++ b/paulsha_cortex/trust_root/registry.py
@@ -80,6 +80,42 @@ UNTRUSTED_EXECUTION_PRINCIPALS: frozenset[Principal] = (
     HEADLESS_PERSONAS | {Principal.HEADLESS_HOOK, Principal.GATE}
 )
 
+#: **具備啟動面降權的 job principal**——各有一組 root-owned 模板 unit，因此各有一個
+#: **自己的** spec spool（#657）。這張表是那一族的唯一清單：登記表資產
+#: （:func:`job_spec_spool_asset_id`）、路徑（`config.paths.job_spec_spool_for`）、
+#: unit 的 `Environment=PSC_JOB_SPEC_SPOOL=`、polkit 的 unit 字幹全部由它導出。
+#:
+#: - `BUILDER`（M1，#603／#584）：`cortex-job@.service`／`cortex-job-jit@.service`。
+#: - `REVIEWER`（M2，#615）：`cortex-reviewer-job@.service`／`-jit`，
+#:   `User=cortex-reviewer-planner`。
+#: - `GATE`（#629）：`cortex-gate-job@.service`／`-jit`，`User=cortex-gate`。
+#:
+#: **`PLANNER` 刻意不在表內，而且不是遺漏**：三分／四分方案把 reviewer 與 planner
+#: 映到**同一個帳號**，而 unit 與 spool 的全部內容差異都由帳號決定。為 planner 再
+#: 產一份逐字相同、只是名字不同的 unit 與 spool，等於多一個要同步維護的放行面，
+#: 卻換不到任何隔離。`REVIEWER` 在這裡是**那個帳號的代表 principal**，由
+#: `permgen.JOB_PRINCIPAL_PERSONAS` 明載它代表誰。
+#:
+#: 定義在登記表而非 `permgen`：permgen import registry（反向不成立），而本清單同時
+#: 要決定**登記表有哪些資產**。放在 permgen 會讓資產清單得從產生器 import 回來。
+#: `permgen.DOWNGRADED_JOB_PRINCIPALS` 是指向本項的別名，不是第二份。
+DOWNGRADED_JOB_PRINCIPALS: tuple[Principal, ...] = (
+    Principal.BUILDER,
+    Principal.REVIEWER,
+    Principal.GATE,
+)
+
+
+def job_spec_spool_asset_id(principal: Principal) -> str:
+    """該降權 principal 的 per-principal spec spool 資產 id（#657）。
+
+    容器（`job-spec-spool`）與子 spool（`job-spec-spool-<principal>`）是**兩種不同
+    的東西**：容器 owner-only、對 job 只有機械導出的 `--x` traverse（走得進去、列不
+    出來）；子 spool 才帶該帳號的唯讀 ACL。
+    """
+
+    return f"job-spec-spool-{principal.value}"
+
 
 class IngressKind(Enum):
     """spec §C mutation ingress 盤點的種類。"""
@@ -111,6 +147,15 @@ class TrustRootAsset:
     writers: tuple[Principal, ...]
     readers: tuple[Principal, ...]
     ingress_kind: IngressKind
+    #: 呼叫 `path_resolver` 時要帶的引數（#657）。同一支 resolver 可以服務**一族**
+    #: 資產（per-principal spool：`job_spec_spool_for("gate")`），此時 asset 之間的
+    #: 差別就是這一組引數。空 tuple＝零引數 resolver（絕大多數）。
+    #:
+    #: 為什麼不是「一族三支零引數函式」：那會把「哪些 principal 有自己的 spool」
+    #: 複製成第二份清單，而那份清單漏一項的症狀正是本票要修的東西（漏授＝該身分
+    #: 每個 job 以 78/CONFIG 收場）。resolver 帶引數之後，這族資產與它們的路徑同樣
+    #: **由單一 principal 清單機械導出**。
+    path_resolver_args: tuple[str, ...] = ()
     #: 現況路徑推導位置（`檔案:行號`），供 Phase 2 收斂與交叉複驗；spec §R1 要求
     #: 把重複推導收斂到登記表，故一律登記全部已知推導點。
     derived_in: tuple[str, ...] = ()
@@ -138,6 +183,54 @@ _T0 = AssetTier.TIER_0
 _T1 = AssetTier.TIER_1
 _MO = TrustTree.MANAGER_OWNED
 _JV = TrustTree.JOB_VISIBLE
+
+
+def _job_spec_spool_assets() -> tuple[TrustRootAsset, ...]:
+    """per-principal spec spool 的登記表項（#657）——由
+    :data:`DOWNGRADED_JOB_PRINCIPALS` **機械導出**，不逐項手寫。
+
+    手寫三項的代價不是打字量，是**漏一項的失效模式**：漏掉的那個 principal 不會有
+    任何 ACL，於是它的每一個 job 都在 shim 讀 spec 時 `EACCES` → `78/CONFIG`，而
+    產生器、CI、單 UID 的測試全部是綠的（那正是 #657 的病史）。導出之後，新增一個
+    降權角色只要動那張表一行，資產／路徑／unit env／traverse ACL 一起跟上。
+
+    每一項的 reader 面**只有它自己**（＋Manager，它是 writer 兼消費者）：跨 principal
+    互讀 spec 在本設計下不成立，而那正是選 per-principal 而非「共用 spool 擴大 reader
+    面」的理由之一。
+    """
+
+    return tuple(
+        TrustRootAsset(
+            job_spec_spool_asset_id(principal), _T0, _MO,
+            "paulsha_cortex.config.paths:job_spec_spool_for",
+            (Principal.MANAGER,), (Principal.MANAGER, principal),
+            IngressKind.MANAGER_INTERNAL,
+            path_resolver_args=(principal.value,),
+            derived_in=(
+                "config/paths.py:job_spec_spool_for",
+                "trust_root/permgen.py:PathLayout.job_spec_spool_for",
+                "coordinator/job_runner.py:JOB_ROLE_CONFIG",
+                "coordinator/job_runner.py:job_spec_path",
+                "coordinator/job_shim.py:load_spec",
+            ),
+            note=(
+                f"#657：`{principal.value}` **專屬**的 per-job 執行規格 spool"
+                f"（`<coordinator_root>/job-specs/{principal.value}/"
+                "<unit-instance-id>.json`）。root-owned 模板 unit 的 `ExecStart=` 固定"
+                "為 shim，per-job 的命令／worktree／白名單 env／log 路徑由本 spool 傳遞；"
+                "**writer 只有 Manager**，該 job 帳號在 reader 面（唯讀 ACL），因此改不了"
+                "自己的命令列，`User=` 也完全不在本檔內（硬寫死在 root-owned unit 檔裡）。\n"
+                "**為什麼一個 principal 一個 spool**：shim 是 systemd 套完 `User=` 之後才"
+                "執行的，它以 job 身分讀 spec；共用一個 spool 時「哪個身分讀得到」變成一組"
+                "共用目錄上多條 ACL 的交集，漏授的症狀是該身分每個 job 以 78/CONFIG 收場"
+                "（#657 實機）。拆開之後這件事是 root-owned unit 上可逐字稽核的一行"
+                "`Environment=PSC_JOB_SPEC_SPOOL=`，而且不必新開「跨 persona 互讀 spec」"
+                "這個性質。"
+            ),
+        )
+        for principal in DOWNGRADED_JOB_PRINCIPALS
+    )
+
 
 ASSET_REGISTRY: tuple[TrustRootAsset, ...] = (
     # ---- resolver-backed 容器樹 --------------------------------------------
@@ -627,22 +720,21 @@ ASSET_REGISTRY: tuple[TrustRootAsset, ...] = (
     TrustRootAsset(
         "job-spec-spool", _T0, _MO,
         "paulsha_cortex.config.paths:job_spec_spool_root",
-        (Principal.MANAGER,), (Principal.MANAGER, Principal.BUILDER),
+        (Principal.MANAGER,), (Principal.MANAGER,),
         IngressKind.MANAGER_INTERNAL,
         derived_in=(
             "config/paths.py:job_spec_spool_root",
-            "coordinator/job_runner.py:job_spec_path",
-            "coordinator/job_shim.py:load_spec",
+            "trust_root/permgen.py:PathLayout.job_spec_spool_root",
         ),
         note=(
-            "0816 第三輪裁決 A+B 的帶外通道：`<coordinator_root>/job-specs/"
-            "<unit-instance-id>.json`。root-owned 的 `cortex-job@.service` 模板 unit 的 "
-            "`ExecStart=` 固定為 shim，per-job 的命令／worktree／白名單 env／log 路徑改由"
-            "本 spool 傳遞。**writer 只有 Manager**——builder 在 reader 面（唯讀 ACL），"
-            "因此改不了自己的命令列；`User=` 完全不在本檔內（它硬寫死在 root-owned 的 "
-            "unit 檔裡），spool 被竄改也無法選 UID。"
+            "0816 第三輪裁決 A+B 的帶外通道**容器**：`<coordinator_root>/job-specs/`。"
+            "**#657 起它本身不再是任何 job 讀得到的目錄**——reader 只有 Manager，"
+            "mode 0700、零跨帳號 ACL；降權帳號在這一層只會拿到 `derive_traverse_grants()` "
+            "機械導出的 `--x`（走得進自己那格、列不出這台機器上還有誰的 job）。"
+            "實際的 spec 落在 per-principal 子 spool（`job-spec-spool-<principal>`）。"
         ),
     ),
+    *_job_spec_spool_assets(),
     TrustRootAsset(
         "verification-evidence", _T0, _MO, None,
         (Principal.MANAGER,), (Principal.MANAGER,), IngressKind.MANAGER_INTERNAL,

--- a/paulsha_cortex/trust_root/selfcheck.py
+++ b/paulsha_cortex/trust_root/selfcheck.py
@@ -150,7 +150,9 @@ def _resolve_asset_path(asset: TrustRootAsset) -> Path | None:
 
         mod = importlib.import_module(modname)
         func = getattr(mod, funcname)
-        result = func()
+        # #657：一支 resolver 可以服務一族資產（per-principal spool），此時
+        # asset 之間的差別就是 `path_resolver_args`。零引數是絕大多數的情形。
+        result = func(*asset.path_resolver_args)
     except Exception:  # noqa: BLE001 — 唯讀自檢永不 raise
         return None
     return result if isinstance(result, Path) else None

--- a/tests/test_canonical_per_job_workspace_648.py
+++ b/tests/test_canonical_per_job_workspace_648.py
@@ -18,6 +18,7 @@
 
 from __future__ import annotations
 
+import os
 import shutil
 import subprocess
 from pathlib import Path
@@ -749,8 +750,17 @@ def test_prepare_systemd_template_agrees_with_canonical_provisioning(
             missing.append(f"模板 unit {unit}（剖面 {profile}）未安裝")
     if not job_runner._is_executable(shim):
         missing.append(f"降權 shim {shim} 不存在或不可執行")
-    if not Path(spool).is_dir():
-        missing.append(f"job spec spool {spool} 不存在")
+    # #657：`Path.is_dir()` 在 EACCES 時**會 raise**（只吞 ENOENT／ENOTDIR 一類），
+    # 而 spool 的父層對非 Manager 帳號本來就是 0700——用 `os.path.isdir()`（吞掉所有
+    # OSError）才是這個 skip 判斷該有的語意。
+    if not os.path.isdir(spool):
+        missing.append(f"job spec spool {spool} 不存在（#657 起每個角色一格）")
+    else:
+        # 「存在」不等於「那個身分讀得到」——那正是 #657。前置物清單一併涵蓋它，
+        # 否則本條會在一台 spool 存在但 ACL 未套用的機器上以真實派工失敗收場。
+        ok, why = job_runner._spool_readable_by(spool, account)
+        if not ok:
+            missing.append(f"builder 讀不到自己的 spec spool（{why}）")
     if missing:
         pytest.skip(
             "本機沒有 trust-root Phase 2b 的降權前置物（"

--- a/tests/test_gate_execution_identity_629.py
+++ b/tests/test_gate_execution_identity_629.py
@@ -146,6 +146,11 @@ def _preflight_patches(binary: str = "/usr/bin/systemctl"):
         mock.patch.object(job_runner, "_unit_file_installed", return_value=True),
         mock.patch.object(job_runner, "_is_executable", return_value=True),
         mock.patch.object(job_runner, "_unit_is_active", return_value=False),
+        # #657：preflight 現在會算「該 job 身分讀不讀得到自己的 spool」的 effective
+        # 權限；本檔宣稱的帳號在單 UID 的開發機／CI 上不存在，故同一條 seam 一併
+        # stub。真正驗這條語意的是 `tests/test_per_principal_spec_spool_657.py`。
+        mock.patch.object(job_runner, "_spool_readable_by", return_value=(True, "")),
+        mock.patch.object(job_runner, "_spec_readable_by", return_value=(True, "")),
     ]
 
 
@@ -627,7 +632,9 @@ class GateExecutionTests(unittest.TestCase):
         env = {
             **_BASE_ENV,
             job_runner.JOB_RUNNER_ENV: job_runner.RUNNER_SYSTEMD_TEMPLATE,
+            # #657：gate 讀的是**自己的** spool 變數。
             job_runner.JOB_SPEC_SPOOL_ENV: spool_dir,
+            job_runner.GATE_JOB_SPEC_SPOOL_ENV: spool_dir,
             "PSC_GATE_CMD_PYTEST": "python3 -m pytest -q",
             **(env_extra or {}),
         }
@@ -781,7 +788,10 @@ class GateExecutionTests(unittest.TestCase):
         with mock.patch.dict(os.environ, {}, clear=True), _nested(_preflight_patches()):
             with self.assertRaises(job_runner.JobRunnerError):
                 job_runner.prepare_systemd_template(
-                    {job_runner.JOB_SPEC_SPOOL_ENV: "/tmp"},
+                    {
+                        job_runner.JOB_SPEC_SPOOL_ENV: "/tmp",
+                        job_runner.GATE_JOB_SPEC_SPOOL_ENV: "/tmp",
+                    },
                     job_id="j", executor="codex", role=job_runner.JOB_ROLE_GATE,
                 )
 
@@ -789,7 +799,10 @@ class GateExecutionTests(unittest.TestCase):
         with mock.patch.dict(os.environ, {}, clear=True), _nested(_preflight_patches()):
             with self.assertRaises(job_runner.JobRunnerError):
                 job_runner.prepare_systemd_template(
-                    {job_runner.JOB_SPEC_SPOOL_ENV: "/tmp"},
+                    {
+                        job_runner.JOB_SPEC_SPOOL_ENV: "/tmp",
+                        job_runner.GATE_JOB_SPEC_SPOOL_ENV: "/tmp",
+                    },
                     job_id="j", executor=None, role=job_runner.JOB_ROLE_BUILDER,
                 )
 

--- a/tests/test_manager_authored_job_accounting_604.py
+++ b/tests/test_manager_authored_job_accounting_604.py
@@ -182,6 +182,11 @@ def _seams(*, template: bool):
             mock.patch.object(job_runner, "_unit_file_installed", return_value=True),
             mock.patch.object(job_runner, "_is_executable", return_value=True),
             mock.patch.object(job_runner, "_unit_is_active", return_value=False),
+            # #657：preflight／落地複驗現在算的是「該 job 身分的 effective 權限」，
+            # 而本檔宣稱的帳號在單 UID 環境不存在。真正驗那條語意的是
+            # `tests/test_per_principal_spec_spool_657.py`（自建真實 ACL 樹）。
+            mock.patch.object(job_runner, "_spool_readable_by", return_value=(True, "")),
+            mock.patch.object(job_runner, "_spec_readable_by", return_value=(True, "")),
         ]
     return patches
 
@@ -204,7 +209,10 @@ def _launch(
             env = {
                 **_BASE_ENV,
                 job_runner.JOB_RUNNER_ENV: mode,
+                # #657：spool per-principal；本檔只跑 builder，其餘一併指同一格。
                 job_runner.JOB_SPEC_SPOOL_ENV: spool,
+                job_runner.REVIEW_JOB_SPEC_SPOOL_ENV: spool,
+                job_runner.GATE_JOB_SPEC_SPOOL_ENV: spool,
                 **(extra_env or {}),
             }
             log_dir = str(Path(root) / "logs")

--- a/tests/test_per_principal_spec_spool_657.py
+++ b/tests/test_per_principal_spec_spool_657.py
@@ -1,0 +1,639 @@
+"""#657：per-principal spec spool ——「那個身分讀得到自己的 spec 嗎」。
+
+## 這一票在測什麼
+
+#629 的 gate 執行身分落地後，實機上**每個** gate job 都以 `78/CONFIG` 收場：
+三份模板 unit（builder／reviewer-planner／gate）指向**同一個** spec spool，而登記表
+只授 builder 唯讀 ACL。shim 是 systemd 套完 `User=` **之後**才執行的，因此它以 job
+身分讀 spec ⇒ 必然 `EACCES`。reviewer／planner 是同一型（#652 沒驗到這一層）。
+
+## 為什麼 CI 當時是綠的（本檔存在的理由）
+
+這一族（#630／#631／#638／#657）的 bug 全部同一個形狀：**單 UID 環境測不出 ACL
+語意**。測試建了目錄、Manager 寫得進去、檔案存在——於是綠；而實機缺的是「另一個
+UID 對這個 inode 的 **effective** 權限」，那在單 UID 下不會表現出來。
+
+本檔因此不測「目錄在不在」。它**自己建出一棵真實的 ACL 樹**（`setfacl` 一個真的
+存在、uid 與本行程不同的第二個帳號），並以 **effective 權限**斷言——而且與系統的
+`getfacl` 交叉核對，證明判定不是自說自話。
+
+**需要第二個 UID 才驗得到的那一半明確 skip**：真的 `seteuid()` 過去開一次檔需要
+root 或第二個可登入身分，CI 兩者都沒有。那一段由 runbook 的 `sudo -u <帳號>` 實測
+步驟承接，本檔以 `pytest.skip` ＋ 逐字理由留下缺口位置，**不靜默通過**。
+"""
+from __future__ import annotations
+
+import json
+import os
+import pwd
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from paulsha_cortex.config import paths as config_paths
+from paulsha_cortex.coordinator import job_runner
+from paulsha_cortex.trust_root import permgen, registry
+from paulsha_cortex.trust_root.registry import Principal
+
+LAYOUT = permgen.DEFAULT_LAYOUT
+SCHEME = permgen.DEFAULT_SCHEME
+
+#: job_runner 的角色 id ⟷ 登記表 principal。兩個模組刻意不互相 import（既有裁決：
+#: 派工熱路徑不拖進 trust_root），因此這張對照表是本檔釘住兩邊的那一條線。
+ROLE_TO_PRINCIPAL = {
+    job_runner.JOB_ROLE_BUILDER: Principal.BUILDER,
+    job_runner.JOB_ROLE_REVIEW: Principal.REVIEWER,
+    job_runner.JOB_ROLE_GATE: Principal.GATE,
+}
+
+
+# ---------------------------------------------------------------------------
+# 1. 登記表／產生器：一個降權身分一格，且由單一清單導出
+# ---------------------------------------------------------------------------
+
+class RegistryDerivationTests(unittest.TestCase):
+    def test_one_asset_per_downgraded_principal(self) -> None:
+        """三個資產由 `DOWNGRADED_JOB_PRINCIPALS` 導出，不是手寫清單。"""
+        expected = {
+            registry.job_spec_spool_asset_id(p)
+            for p in registry.DOWNGRADED_JOB_PRINCIPALS
+        }
+        actual = {
+            a.asset_id
+            for a in registry.ASSET_REGISTRY
+            if a.asset_id.startswith("job-spec-spool-")
+        }
+        self.assertEqual(actual, expected)
+        self.assertEqual(len(expected), 3)
+
+    def test_permgen_reuses_the_registry_list_verbatim(self) -> None:
+        """permgen 的那個名字是別名，不是第二份會漂移的清單。"""
+        self.assertIs(
+            permgen.DOWNGRADED_JOB_PRINCIPALS, registry.DOWNGRADED_JOB_PRINCIPALS
+        )
+
+    def test_each_spool_is_readable_only_by_its_own_principal(self) -> None:
+        """跨 principal 讀不到彼此的 spec——這是選 per-principal 而非擴大共用 spool
+        reader 面的核心差異，因此必須是斷言而不是說明。"""
+        plan = permgen.generate_plan(SCHEME)
+        accounts = {
+            p: SCHEME.resolve(p) for p in registry.DOWNGRADED_JOB_PRINCIPALS
+        }
+        for principal, account in accounts.items():
+            entry = plan.by_id(registry.job_spec_spool_asset_id(principal))
+            granted = {a.account for a in entry.acls}
+            self.assertEqual(granted, {account}, principal)
+            self.assertEqual(entry.mode, 0o700, principal)
+            self.assertEqual(entry.owner, SCHEME.durable_state_owner, principal)
+            # 唯讀：job 改不了自己的命令列（M1 起的不變式，本票不得放寬）。
+            self.assertFalse(any(a.writable for a in entry.acls), principal)
+            self.assertEqual(
+                plan.all_writable_accounts(entry),
+                frozenset({SCHEME.durable_state_owner}),
+                principal,
+            )
+            for other, other_account in accounts.items():
+                if other is principal:
+                    continue
+                self.assertNotIn(other_account, granted, (principal, other))
+
+    def test_the_container_grants_no_job_account_anything_but_traverse(self) -> None:
+        """容器只是一個 0700 的殼：job 走得進自己那格，列不出這台機器上還有誰。"""
+        plan = permgen.generate_plan(SCHEME)
+        entry = plan.by_id("job-spec-spool")
+        self.assertEqual(entry.acls, ())
+        self.assertEqual(entry.mode, 0o700)
+
+        grants = permgen.derive_traverse_grants(
+            plan, LAYOUT, SCHEME, path_of=LAYOUT.asset_paths()
+        )
+        on_container = {
+            g.account for g in grants if g.path == LAYOUT.job_spec_spool_root
+        }
+        for principal in registry.DOWNGRADED_JOB_PRINCIPALS:
+            self.assertIn(SCHEME.resolve(principal), on_container, principal)
+        self.assertEqual(permgen.TRAVERSE_PERMS, "--x")
+
+    def test_every_template_unit_names_its_own_spool(self) -> None:
+        """「哪個身分讀哪個 spool」是 root-owned unit 上可逐字稽核的一行。"""
+        seen: dict[str, str] = {}
+        for principal in registry.DOWNGRADED_JOB_PRINCIPALS:
+            for profile in permgen.HARDENING_PROFILES:
+                unit = permgen.build_job_unit(
+                    SCHEME, LAYOUT, principal=principal, profile=profile
+                )
+                expected = LAYOUT.job_spec_spool_for(principal)
+                self.assertIn(
+                    f"Environment=PSC_JOB_SPEC_SPOOL={expected}\n",
+                    unit.content + "\n",
+                    (principal, profile.profile_id),
+                )
+                self.assertIn(f"User={SCHEME.resolve(principal)}\n", unit.content)
+                seen.setdefault(expected, unit.unit_name)
+        # 三個角色三條不同的路徑——共用一條正是 #657 的狀態。
+        self.assertEqual(len(seen), 3, seen)
+
+    def test_the_spool_is_still_not_writable_from_any_job_unit(self) -> None:
+        for principal in registry.DOWNGRADED_JOB_PRINCIPALS:
+            unit = permgen.build_job_unit(SCHEME, LAYOUT, principal=principal)
+            spool = LAYOUT.job_spec_spool_for(principal)
+            for rwp in unit.read_write_paths:
+                self.assertFalse(
+                    spool == rwp or spool.startswith(rwp.rstrip("/") + "/"),
+                    (principal, rwp),
+                )
+
+    def test_generated_commands_cover_all_three_spools(self) -> None:
+        """`sh -e` 真的會跑到的那份 script 必須逐格出現，否則就是漏授。"""
+        # operator／external 是部署決定（#626），未注入時產生器整份 fail-closed。
+        scheme = SCHEME.with_principal_accounts(
+            {Principal.OPERATOR: "cortex-ops", Principal.EXTERNAL: "cortex-ops"}
+        )
+        lines = permgen.plan_to_commands(
+            permgen.generate_plan(scheme),
+            path_of=LAYOUT.asset_paths(),
+            scheme=scheme,
+        )
+        executable = [ln for ln in lines if ln.strip() and not ln.lstrip().startswith("#")]
+        for principal in registry.DOWNGRADED_JOB_PRINCIPALS:
+            spool = LAYOUT.job_spec_spool_for(principal)
+            account = SCHEME.resolve(principal)
+            self.assertIn(f"chmod 0700 {spool}", executable, principal)
+            self.assertIn(f"setfacl -m u:{account}:rX {spool}", executable, principal)
+            self.assertIn(
+                f"setfacl -d -m u:{account}:rX {spool}", executable, principal
+            )
+            self.assertIn(
+                f"setfacl -m u:{account}:--x {LAYOUT.job_spec_spool_root}",
+                executable,
+                principal,
+            )
+
+    def test_path_contract_and_layout_agree(self) -> None:
+        for principal in registry.DOWNGRADED_JOB_PRINCIPALS:
+            self.assertTrue(
+                LAYOUT.job_spec_spool_for(principal).endswith(
+                    f"/{config_paths.JOB_SPEC_SPOOL_DIRNAME}/{principal.value}"
+                ),
+                principal,
+            )
+
+    def test_path_contract_rejects_a_traversal_shaped_principal(self) -> None:
+        for bad in ("../manager", "a/b", "", "Builder", "/abs"):
+            with self.assertRaises(ValueError, msg=bad):
+                config_paths.job_spec_spool_for(bad)
+
+
+class JobRunnerPermgenSpoolContractTests(unittest.TestCase):
+    """`job_runner` 的三組預設值 ⟷ permgen layout（兩邊刻意不互相 import）。"""
+
+    def test_defaults_match_the_layout_per_role(self) -> None:
+        for role, principal in ROLE_TO_PRINCIPAL.items():
+            self.assertEqual(
+                job_runner.resolve_job_spec_spool({}, role=role),
+                LAYOUT.job_spec_spool_for(principal),
+                role,
+            )
+
+    def test_each_role_has_its_own_env_variable(self) -> None:
+        """共用一個變數會讓「Manager 環境裡剛好有它」把三個角色導回同一格。"""
+        names = {
+            job_runner.resolve_job_role(role).spec_spool_env
+            for role in ROLE_TO_PRINCIPAL
+        }
+        self.assertEqual(len(names), 3, names)
+        for role in ROLE_TO_PRINCIPAL:
+            config = job_runner.resolve_job_role(role)
+            self.assertEqual(
+                job_runner.resolve_job_spec_spool(
+                    {config.spec_spool_env: "/tmp/override"}, role=role
+                ),
+                "/tmp/override",
+                role,
+            )
+            # 別的角色的變數影響不到本角色。
+            others = {
+                job_runner.resolve_job_role(r).spec_spool_env: "/tmp/wrong"
+                for r in ROLE_TO_PRINCIPAL
+                if r != role
+            }
+            self.assertEqual(
+                job_runner.resolve_job_spec_spool(others, role=role),
+                config.default_spec_spool,
+                role,
+            )
+
+    def test_unknown_role_fails_closed(self) -> None:
+        with self.assertRaises(job_runner.JobRunnerError):
+            job_runner.resolve_job_spec_spool({}, role="not-a-role")
+
+
+# ---------------------------------------------------------------------------
+# 2. 真實 ACL 樹上的 effective 語意（本票核心）
+# ---------------------------------------------------------------------------
+
+def _second_accounts(limit: int = 2) -> list[str]:
+    """本機上 uid 與本行程不同、且非 root 的真實帳號（優先 `nobody`）。
+
+    非 root：root 對 DAC 有豁免，拿它當樣本會讓斷言測到的是「root 什麼都讀得到」。
+    """
+
+    me = os.getuid()
+    found: list[str] = []
+    try:
+        entries = pwd.getpwall()
+    except Exception:  # pragma: no cover - 平台差異
+        return []
+    entries.sort(key=lambda e: (e.pw_name != "nobody", e.pw_uid))
+    for entry in entries:
+        if entry.pw_uid in (0, me) or entry.pw_name in [n for n in found]:
+            continue
+        found.append(entry.pw_name)
+        if len(found) >= limit:
+            break
+    return found
+
+
+def _acl_supported(directory: Path, account: str) -> bool:
+    if shutil.which("setfacl") is None or shutil.which("getfacl") is None:
+        return False
+    probe = directory / ".acl-probe"
+    probe.mkdir()
+    rc = subprocess.run(
+        ["setfacl", "-m", f"u:{account}:rx", str(probe)],
+        capture_output=True,
+        text=True,
+    )
+    ok = rc.returncode == 0 and bool(
+        job_runner._read_acl(str(probe), job_runner.POSIX_ACL_ACCESS_XATTR)
+    )
+    shutil.rmtree(probe)
+    return ok
+
+
+def _getfacl_effective(path: Path, account: str) -> str | None:
+    """`getfacl` 眼中該具名帳號的 **effective** 權限（`"r-x"`），無此條目即 None。
+
+    交叉核對用：本檔的斷言若只跟自己的實作比，等於沒有外部真相。
+    """
+
+    out = subprocess.run(
+        ["getfacl", "-p", "--absolute-names", str(path)],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    for line in out.splitlines():
+        line = line.strip()
+        if not line.startswith(f"user:{account}:"):
+            continue
+        body, _, comment = line.partition("#effective:")
+        if comment:
+            return comment.strip()
+        return body.split(":")[2].strip()
+    return None
+
+
+@pytest.fixture()
+def acl_tree():
+    """一棵**真的**四分 spool 樹：容器 ＋ 三格，權限逐字照產生器的輸出套。
+
+    回傳 `(container, spools, owner_account, foreign_accounts)`；其中
+    `spools[Principal.…]` 是那一格的路徑，`owner_account` 是被授權的第二個帳號
+    （扮演該 principal 的 job 帳號），`foreign_accounts` 是其餘可用的帳號。
+
+    **不用 `tmp_path`**：pytest 的 `/tmp/pytest-of-<user>/` 是 0700，第二個帳號連
+    `/tmp` 底下第一層都 traverse 不過去，於是每一條正向斷言都會在「與本票無關的
+    那一層」失敗。這裡自建一個 `0711` 的樹根（＝真實部署上 `/var/lib` 那幾層的
+    形狀：可 traverse、不可列目錄），讓被測的斷點只可能落在 spool 樹自己身上。
+    """
+
+    accounts = _second_accounts()
+    if not accounts:
+        pytest.skip(
+            "本機找不到第二個非 root 帳號——ACL 語意需要一個 uid 與本行程不同的"
+            "真實帳號才建得出來（`setfacl -m u:<名>:…` 在產生的當下就要解析得到 uid）。"
+            "刻意 skip 而非以自己的 uid 假裝：那樣測到的是 owner 位，不是具名 ACL。"
+        )
+    root = Path(tempfile.mkdtemp(prefix="psc-657-"))
+    try:
+        os.chmod(root, 0o711)
+        if not _acl_supported(root, accounts[0]):
+            pytest.skip(
+                "本機的暫存檔系統不支援 POSIX ACL（或缺 setfacl／getfacl）——"
+                "本檔的每一條斷言都建立在真實 ACL 上，沒有它就不是在測 #657 的語意。"
+                "刻意 skip 而非退回 mode 位模擬。"
+            )
+        container = root / "job-specs"
+        container.mkdir()
+        os.chmod(container, 0o700)
+        spools: dict[Principal, Path] = {}
+        for principal in registry.DOWNGRADED_JOB_PRINCIPALS:
+            spool = container / principal.value
+            spool.mkdir()
+            os.chmod(spool, 0o700)
+            spools[principal] = spool
+        # 只有第一格拿到那個帳號的 ACL——另外兩格扮演「別人的 spool」。
+        own = spools[registry.DOWNGRADED_JOB_PRINCIPALS[0]]
+        subprocess.run(["setfacl", "-m", f"u:{accounts[0]}:rX", str(own)], check=True)
+        subprocess.run(
+            ["setfacl", "-d", "-m", f"u:{accounts[0]}:rX", str(own)], check=True
+        )
+        # 容器的 traverse：`--x`，且**排在 chmod 之後**——順序反過來會被 mask 吃掉，
+        # 那正是 `test_a_masked_out_acl_is_caught` 在驗的東西。全部可用帳號都給，
+        # 這樣「讀不到別人的」就只可能來自 spool 那一格自己的權限，而不是 traverse。
+        for account in accounts:
+            subprocess.run(
+                ["setfacl", "-m", f"u:{account}:--x", str(container)], check=True
+            )
+        yield container, spools, accounts[0], accounts[1:]
+    finally:
+        shutil.rmtree(root, ignore_errors=True)
+
+
+def test_own_spool_is_readable_and_foreign_spools_are_not(acl_tree) -> None:
+    """驗收第 1／2 條：讀得到**自己的**、讀不到**別人的**——以 effective 權限斷言。"""
+    container, spools, account, _ = acl_tree
+    own_principal = registry.DOWNGRADED_JOB_PRINCIPALS[0]
+
+    ok, why = job_runner._spool_readable_by(str(spools[own_principal]), account)
+    assert ok, why
+
+    for principal, spool in spools.items():
+        if principal is own_principal:
+            continue
+        ok, why = job_runner._spool_readable_by(str(spool), account)
+        assert not ok, (principal, spool)
+        assert account in why
+        bits = job_runner.effective_perms_for_account(str(spool), account)
+        assert bits == 0, (principal, bits)
+
+
+def test_our_effective_computation_agrees_with_getfacl(acl_tree) -> None:
+    """外部真相交叉核對：本檔的判定與系統 `getfacl` 對同一棵樹的結論一致。"""
+    container, spools, account, _ = acl_tree
+    own = spools[registry.DOWNGRADED_JOB_PRINCIPALS[0]]
+    for path, expected in ((own, "r-x"), (container, "--x")):
+        assert _getfacl_effective(path, account) == expected, path
+        bits = job_runner.effective_perms_for_account(str(path), account)
+        assert job_runner._perm_str(bits) == expected, path
+
+
+def test_a_masked_out_acl_is_caught(acl_tree) -> None:
+    """**本族最陰的一種**：ACL 還在（`getfacl` 看得到），mask 卻把它打成空。
+
+    `chmod` 會重寫 ACL mask，因此「先 setfacl 再 chmod」會讓具名條目靜默失效——
+    這不是假想：修本票時在實機上量到 `/var/lib/cortex/coordinator/job-specs` 正是
+    `mask::---` ＋ `user:cortex-builder:r-x #effective:---`。只看「有沒有那條 ACL」
+    的檢查會說一切正常。
+    """
+
+    container, spools, account, _ = acl_tree
+    own = spools[registry.DOWNGRADED_JOB_PRINCIPALS[0]]
+    ok, _ = job_runner._spool_readable_by(str(own), account)
+    assert ok
+
+    os.chmod(own, 0o700)  # ← 這一行就是那個 bug
+
+    assert _getfacl_effective(own, account) == "---"
+    assert job_runner.effective_perms_for_account(str(own), account) == 0
+    ok, why = job_runner._spool_readable_by(str(own), account)
+    assert not ok
+    assert "---" in why
+
+
+def test_a_broken_traverse_chain_is_caught(acl_tree) -> None:
+    """葉節點 ACL 再精確，中間有一層走不過去，`open()` 就是 EACCES（#620 同族）。"""
+    container, spools, account, _ = acl_tree
+    own = spools[registry.DOWNGRADED_JOB_PRINCIPALS[0]]
+    subprocess.run(["setfacl", "-x", f"u:{account}", str(container)], check=True)
+    ok, why = job_runner._spool_readable_by(str(own), account)
+    assert not ok
+    assert str(container) in why
+    assert "traverse" in why
+
+
+def test_a_spec_written_by_the_manager_is_readable_by_the_job_account(
+    acl_tree,
+) -> None:
+    """`write_job_spec()` 的 `chmod 0640` ⟷ ACL mask 那段推導，從註解升級成斷言。
+
+    這是「每個降權 principal 讀得到自己的 spec」在單 UID 環境下驗得到的**全部**：
+    真的那個 inode 上，那個帳號的 effective 權限含 `r`。真的以該 uid `open()` 需要
+    第二個 UID（見本檔最後一條）。
+    """
+
+    _container, spools, account, _ = acl_tree
+    own = spools[registry.DOWNGRADED_JOB_PRINCIPALS[0]]
+    spec = job_runner.build_job_spec(
+        job_id="psc-0657",
+        instance="psc-0657-deadbeef",
+        unit="cortex-gate-job@psc-0657-deadbeef.service",
+        command=["/bin/true"],
+        working_directory="/tmp",
+        log_path="/tmp/psc-0657.jsonl",
+        env={"PATH": "/usr/bin"},
+    )
+    spec_path = job_runner.job_spec_path(str(own), "psc-0657-deadbeef")
+    job_runner.write_job_spec(spec_path, spec, account=account)
+
+    assert json.loads(Path(spec_path).read_text(encoding="utf-8"))["job_id"] == "psc-0657"
+    assert _getfacl_effective(Path(spec_path), account) == "r--"
+    bits = job_runner.effective_perms_for_account(spec_path, account)
+    assert bits is not None and bits & 0o4, job_runner._perm_str(bits or 0)
+
+
+def test_write_job_spec_refuses_to_leave_an_unreadable_spec(acl_tree) -> None:
+    """落地複驗會擋下來——失敗因此在 Manager 的錯誤訊息裡，不是 journal 裡的一行。"""
+    _container, spools, account, _ = acl_tree
+    foreign = spools[registry.DOWNGRADED_JOB_PRINCIPALS[1]]
+    spec = job_runner.build_job_spec(
+        job_id="psc-0657",
+        instance="psc-0657-deadbeef",
+        unit="cortex-gate-job@psc-0657-deadbeef.service",
+        command=["/bin/true"],
+        working_directory="/tmp",
+        log_path="/tmp/psc-0657.jsonl",
+        env={"PATH": "/usr/bin"},
+    )
+    spec_path = job_runner.job_spec_path(str(foreign), "psc-0657-deadbeef")
+    with pytest.raises(job_runner.JobRunnerError) as excinfo:
+        job_runner.write_job_spec(spec_path, spec, account=account)
+    assert excinfo.value.diagnostic.reason == "job-runner-job-spec-unreadable-by-job"
+
+
+def test_a_named_acl_for_someone_else_does_not_help(acl_tree) -> None:
+    """#657 的**逐字重現**：spool 存在、Manager 寫得進去、上面也有一條唯讀 ACL
+    ——只是那條給的是**另一個**帳號。這正是實機上 gate 撞到的形狀。"""
+
+    _container, spools, account, others = acl_tree
+    if not others:
+        pytest.skip(
+            "本機只找得到一個非 root 的第二帳號，無法建出「ACL 指名的是別人」這個"
+            "形狀（需要兩個不同的 uid 同時出現在同一棵樹上）。此形狀的否定面已由"
+            "`test_own_spool_is_readable_and_foreign_spools_are_not` 涵蓋（無 ACL 的"
+            "那兩格）；刻意 skip 而非以同一個帳號假裝。"
+        )
+    foreign = spools[registry.DOWNGRADED_JOB_PRINCIPALS[1]]
+    subprocess.run(["setfacl", "-m", f"u:{others[0]}:rX", str(foreign)], check=True)
+    subprocess.run(["setfacl", "-d", "-m", f"u:{others[0]}:rX", str(foreign)], check=True)
+
+    assert _getfacl_effective(foreign, others[0]) == "r-x"
+    ok, why = job_runner._spool_readable_by(str(foreign), account)
+    assert not ok, why
+    ok, _ = job_runner._spool_readable_by(str(foreign), others[0])
+    assert ok
+
+
+def test_actually_opening_the_spec_as_the_job_uid_needs_a_second_uid(acl_tree) -> None:
+    """**明確的缺口位置**：以該 uid 真的 `open()` 一次。
+
+    本檔其餘每一條算的都是 kernel 用的同一條 POSIX.1e 規則，但那是**中繼資料層**的
+    推導；mount 選項（唯讀掛載）、mount namespace（模板 unit 的
+    `ProtectSystem=strict`）與 LSM（SELinux／AppArmor）都不在其中。要涵蓋那三項只有
+    真的變成那個身分開一次檔，而那需要 root（`seteuid`）或第二個可登入身分。
+
+    因此本條**永遠 skip**，並把驗收位置指回 runbook 的
+    `sudo -u <帳號> cat <spool>/<instance>.json` 步驟——留一個看得見的缺口，比讓
+    「四分部署上真的讀得到」這句話沒有任何測試對應要好（#638／#657 的教訓）。
+    """
+
+    _container, spools, account, _ = acl_tree
+    if os.getuid() != 0:
+        pytest.skip(
+            f"以 {account} 的 uid 實際 open() 需要 root（seteuid）或第二個可登入身分；"
+            "本行程兩者皆非。中繼資料層的 effective 判定已由本檔其餘條目涵蓋，"
+            "mount／namespace／LSM 那一層由 runbook 的 `sudo -u` 步驟承接。"
+        )
+    raise AssertionError(  # pragma: no cover - 只有以 root 跑測試才會到這裡
+        "以 root 跑測試套件不在支援範圍：root 對 DAC 有豁免，"
+        "任何以它做的讀取斷言都不承載本票的語意"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 3. 派工路徑：角色決定 spool，preflight 驗的是「讀得到」
+# ---------------------------------------------------------------------------
+
+def _preflight_patches(*, spool_readable=(True, "")):
+    return [
+        mock.patch.object(
+            job_runner.shutil, "which", return_value="/usr/bin/systemctl"
+        ),
+        mock.patch.object(job_runner, "_systemd_booted", return_value=True),
+        mock.patch.object(job_runner, "_account_exists", return_value=True),
+        mock.patch.object(job_runner, "_group_exists", return_value=True),
+        mock.patch.object(job_runner, "_unit_file_installed", return_value=True),
+        mock.patch.object(job_runner, "_is_executable", return_value=True),
+        mock.patch.object(job_runner, "_unit_is_active", return_value=False),
+        mock.patch.object(
+            job_runner, "_spool_readable_by", return_value=spool_readable
+        ),
+    ]
+
+
+class _nested:
+    def __init__(self, managers) -> None:
+        self._managers = list(managers)
+
+    def __enter__(self):
+        return [m.__enter__() for m in self._managers]
+
+    def __exit__(self, *exc_info):
+        for manager in reversed(self._managers):
+            manager.__exit__(*exc_info)
+        return False
+
+
+class DispatchUsesTheRoleSpoolTests(unittest.TestCase):
+    def test_each_role_plans_into_its_own_spool(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            env: dict[str, str] = {}
+            expected: dict[str, str] = {}
+            for role in ROLE_TO_PRINCIPAL:
+                spool = str(Path(root) / role)
+                Path(spool).mkdir()
+                env[job_runner.resolve_job_role(role).spec_spool_env] = spool
+                expected[role] = spool
+            for role in ROLE_TO_PRINCIPAL:
+                executor = None if role == job_runner.JOB_ROLE_GATE else "claude"
+                with _nested(_preflight_patches()):
+                    plan = job_runner.prepare_systemd_template(
+                        env, job_id="psc-0657", executor=executor, role=role
+                    )
+                self.assertEqual(plan.spool_dir, expected[role], role)
+                self.assertTrue(
+                    plan.spec_path.startswith(expected[role] + "/"), plan.spec_path
+                )
+                self.assertEqual(
+                    plan.spec_path, f"{expected[role]}/{plan.instance}.json", role
+                )
+
+    def test_preflight_fails_closed_when_the_job_identity_cannot_read(self) -> None:
+        """#657 的迴歸閘：spool 存在、Manager 寫得進去，但那個身分讀不到 ⇒ 派不出去。
+
+        在此之前這裡檢查的是 `os.path.isdir()`，對 #657 完全無感。
+        """
+
+        with tempfile.TemporaryDirectory() as root:
+            spool = str(Path(root) / "gate")
+            Path(spool).mkdir()
+            env = {job_runner.GATE_JOB_SPEC_SPOOL_ENV: spool}
+            with _nested(
+                _preflight_patches(
+                    spool_readable=(False, "cortex-gate 沒有 traverse（x）權")
+                )
+            ):
+                with self.assertRaises(job_runner.JobRunnerError) as ctx:
+                    job_runner.prepare_systemd_template(
+                        env,
+                        job_id="psc-0657",
+                        executor=None,
+                        role=job_runner.JOB_ROLE_GATE,
+                    )
+        self.assertEqual(
+            ctx.exception.diagnostic.reason, "job-runner-job-spec-spool-unreadable"
+        )
+        self.assertIn("cortex-gate", str(ctx.exception))
+
+    def test_a_missing_spool_still_reports_the_missing_reason(self) -> None:
+        env = {job_runner.GATE_JOB_SPEC_SPOOL_ENV: "/nonexistent-657"}
+        with _nested(_preflight_patches()):
+            with self.assertRaises(job_runner.JobRunnerError) as ctx:
+                job_runner.prepare_systemd_template(
+                    env,
+                    job_id="psc-0657",
+                    executor=None,
+                    role=job_runner.JOB_ROLE_GATE,
+                )
+        self.assertEqual(
+            ctx.exception.diagnostic.reason, "job-runner-job-spec-spool-missing"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 4. direct 模式零回歸
+# ---------------------------------------------------------------------------
+
+def test_direct_mode_never_touches_the_spool(tmp_path: Path) -> None:
+    """`direct` 是預設模式，本票一行都不該碰到它。
+
+    判準是結構性的：整條 spool／preflight 只由 `prepare_systemd_template()` 進入，
+    而那一支只在 `PSC_JOB_RUNNER=systemd-template` 時被呼叫。這裡直接證明
+    `direct` 下 `_downgraded_mode()` 回 None，且 spool 目錄零產出。
+    """
+
+    from paulsha_cortex.coordinator.launcher import SubprocessLauncher
+
+    launcher = SubprocessLauncher("codex")
+    for env in ({}, {job_runner.JOB_RUNNER_ENV: job_runner.RUNNER_DIRECT}):
+        assert launcher._downgraded_mode(env) is None, env
+
+    spool = tmp_path / "job-specs"
+    spool.mkdir()
+    assert list(spool.iterdir()) == []

--- a/tests/test_reviewer_planner_downgrade_615.py
+++ b/tests/test_reviewer_planner_downgrade_615.py
@@ -117,6 +117,11 @@ def _preflight_patches(binary: str = "/usr/bin/systemctl"):
         mock.patch.object(job_runner, "_unit_file_installed", return_value=True),
         mock.patch.object(job_runner, "_is_executable", return_value=True),
         mock.patch.object(job_runner, "_unit_is_active", return_value=False),
+        # #657：preflight 現在會算「該 job 身分讀不讀得到自己的 spool」的 effective
+        # 權限；本檔宣稱的帳號在單 UID 的開發機／CI 上不存在，故同一條 seam 一併
+        # stub。真正驗這條語意的是 `tests/test_per_principal_spec_spool_657.py`。
+        mock.patch.object(job_runner, "_spool_readable_by", return_value=(True, "")),
+        mock.patch.object(job_runner, "_spec_readable_by", return_value=(True, "")),
     ]
 
 
@@ -125,7 +130,12 @@ def _template_env(spool: str, **overrides: str) -> dict[str, str]:
         **_BASE_ENV,
         **_SECRET_ENV,
         job_runner.JOB_RUNNER_ENV: job_runner.RUNNER_SYSTEMD_TEMPLATE,
+        # #657：spool 是 per-principal 的（builder／review／gate 各一個變數）。
+        # 測試把三個都指向同一個暫存目錄——這裡驗的是「spec 內容與起動形狀」，
+        # 不是隔離；隔離由 `tests/test_per_principal_spec_spool_657.py` 驗。
         job_runner.JOB_SPEC_SPOOL_ENV: spool,
+        job_runner.REVIEW_JOB_SPEC_SPOOL_ENV: spool,
+        job_runner.GATE_JOB_SPEC_SPOOL_ENV: spool,
     }
     env.update(overrides)
     return env

--- a/tests/test_trust_root_job_template_ab.py
+++ b/tests/test_trust_root_job_template_ab.py
@@ -110,7 +110,12 @@ def _template_env(spool: str, **overrides: str) -> dict[str, str]:
         **_BASE_ENV,
         **_SECRET_ENV,
         job_runner.JOB_RUNNER_ENV: job_runner.RUNNER_SYSTEMD_TEMPLATE,
+        # #657：spool 是 per-principal 的（builder／review／gate 各一個變數）。
+        # 測試把三個都指向同一個暫存目錄——這裡驗的是「spec 內容與起動形狀」，
+        # 不是隔離；隔離由 `tests/test_per_principal_spec_spool_657.py` 驗。
         job_runner.JOB_SPEC_SPOOL_ENV: spool,
+        job_runner.REVIEW_JOB_SPEC_SPOOL_ENV: spool,
+        job_runner.GATE_JOB_SPEC_SPOOL_ENV: spool,
     }
     env.update(overrides)
     return env
@@ -130,6 +135,16 @@ def _preflight_patches(*, unit_active: bool = False, **overrides):
         "shim": mock.patch.object(job_runner, "_is_executable", return_value=True),
         "active": mock.patch.object(
             job_runner, "_unit_is_active", return_value=unit_active
+        ),
+        # #657：preflight 現在會算「該 job 身分讀不讀得到自己的 spool」的
+        # **effective** 權限。上面那些 seam 宣稱的帳號（cortex-builder…）在單 UID
+        # 的開發機／CI 上並不存在，因此這裡把同一條 seam 一併 stub 掉——真正驗這條
+        # 語意的是 `tests/test_per_principal_spec_spool_657.py`（自建真實 ACL 樹）。
+        "spool_readable": mock.patch.object(
+            job_runner, "_spool_readable_by", return_value=(True, "")
+        ),
+        "spec_readable": mock.patch.object(
+            job_runner, "_spec_readable_by", return_value=(True, "")
         ),
     }
     defaults.update(overrides)
@@ -518,13 +533,26 @@ class M2ExtensionPointTests(unittest.TestCase):
 
 class JobSpecSpoolAssetTests(unittest.TestCase):
     def test_asset_is_registered_and_manager_owned(self) -> None:
-        asset = registry.asset_by_id("job-spec-spool")
+        """容器（#657 之後 reader 只有 Manager）與 builder 那一格。"""
+        container = registry.asset_by_id("job-spec-spool")
+        self.assertIs(container.tree, registry.TrustTree.MANAGER_OWNED)
+        self.assertEqual(container.writers, (Principal.MANAGER,))
+        # #657：容器本身不再授任何 job 帳號——它只是一個 0700 的殼，job 在這一層
+        # 只會拿到機械導出的 `--x`（走得進自己那格、列不出別人的）。
+        self.assertNotIn(Principal.BUILDER, container.readers)
+        self.assertEqual(
+            container.path_resolver, "paulsha_cortex.config.paths:job_spec_spool_root"
+        )
+        asset = registry.asset_by_id(
+            registry.job_spec_spool_asset_id(Principal.BUILDER)
+        )
         self.assertIs(asset.tree, registry.TrustTree.MANAGER_OWNED)
         self.assertEqual(asset.writers, (Principal.MANAGER,))
         self.assertIn(Principal.BUILDER, asset.readers)
         self.assertEqual(
-            asset.path_resolver, "paulsha_cortex.config.paths:job_spec_spool_root"
+            asset.path_resolver, "paulsha_cortex.config.paths:job_spec_spool_for"
         )
+        self.assertEqual(asset.path_resolver_args, ("builder",))
 
     def test_registry_equation_still_holds(self) -> None:
         result = registry.check_registry_equation()
@@ -534,7 +562,7 @@ class JobSpecSpoolAssetTests(unittest.TestCase):
         """permgen 不變式：builder 只讀得到 spec，改不了自己的命令列。"""
         for scheme in (permgen.DEFAULT_SCHEME, permgen.TWO_WAY_SCHEME):
             plan = permgen.generate_plan(scheme)
-            entry = plan.by_id("job-spec-spool")
+            entry = plan.by_id(registry.job_spec_spool_asset_id(Principal.BUILDER))
             builder = scheme.resolve(Principal.BUILDER)
             writable = plan.all_writable_accounts(entry)
             self.assertEqual(writable, frozenset({scheme.durable_state_owner}), scheme.scheme_id)
@@ -554,6 +582,16 @@ class JobSpecSpoolAssetTests(unittest.TestCase):
             permgen.DEFAULT_LAYOUT.asset_paths()["job-spec-spool"],
             permgen.DEFAULT_LAYOUT.job_spec_spool_root,
         )
+        # #657：per-principal 那一族同樣要落在 asset_paths()——漏一項的症狀是
+        # `plan_to_commands()` 對它用 placeholder 路徑（＝該身分零授權）。
+        for principal in registry.DOWNGRADED_JOB_PRINCIPALS:
+            self.assertEqual(
+                permgen.DEFAULT_LAYOUT.asset_paths()[
+                    registry.job_spec_spool_asset_id(principal)
+                ],
+                f"{permgen.DEFAULT_LAYOUT.job_spec_spool_root}/{principal.value}",
+                principal,
+            )
 
     def test_spool_is_not_writable_from_the_job_unit(self) -> None:
         unit = permgen.build_job_unit(permgen.DEFAULT_SCHEME, permgen.DEFAULT_LAYOUT)
@@ -570,7 +608,11 @@ class JobRunnerPermgenContractTests(unittest.TestCase):
 
     def test_defaults_match_the_layout(self) -> None:
         layout = permgen.DEFAULT_LAYOUT
-        self.assertEqual(job_runner.DEFAULT_JOB_SPEC_SPOOL, layout.job_spec_spool_root)
+        # #657：預設值是 builder **自己那一格**，不是容器。
+        self.assertEqual(
+            job_runner.DEFAULT_JOB_SPEC_SPOOL,
+            layout.job_spec_spool_for(Principal.BUILDER),
+        )
         self.assertEqual(job_runner.DEFAULT_JOB_SHIM, layout.job_shim)
         self.assertEqual(
             job_runner.DEFAULT_TEMPLATE_UNIT,

--- a/tests/test_trust_root_permgen_traverse_620.py
+++ b/tests/test_trust_root_permgen_traverse_620.py
@@ -11,7 +11,7 @@ review-verdicts 兩條正向路徑全部 `Permission denied`——而錯誤訊�
 - (b) 產生的是 `--x` 不是 `r-x`——只給 traverse，列目錄仍須被拒；
 - (c) 已允許該帳號 traverse 的中間層不重複產生；
 - (d) 三分方案下 builder→event-spool、reviewer-planner→review-verdicts、
-      builder→job-specs 三條路徑的**完整鏈**每一層都有授權。
+      builder→自己的 job-specs 三條路徑的**完整鏈**每一層都有授權。
 """
 from __future__ import annotations
 
@@ -58,7 +58,11 @@ ALL_SCHEMES = [TWO_WAY_SCHEME, THREE_WAY_SCHEME]
 FORWARD_PATHS = (
     (Principal.BUILDER, "monitor-event-spool"),
     (Principal.REVIEWER, "review-verdict-spool"),
-    (Principal.BUILDER, "job-spec-spool"),
+    # #657：spec spool 是 per-principal 的，因此正向路徑也是逐個 principal 的
+    # ——這正好把「reviewer／gate 的鏈有沒有補齊」納入本檔的覆蓋面（在 #657 之前
+    # 這裡只驗 builder，而那條共用路徑對 reviewer／gate 從來沒成立過）。
+    (Principal.BUILDER, "job-spec-spool-builder"),
+    (Principal.REVIEWER, "job-spec-spool-reviewer"),
 )
 
 
@@ -114,9 +118,15 @@ def test_without_the_derived_grants_the_paths_are_broken(scheme) -> None:
     )
     assert blocked == (f"{DEFAULT_LAYOUT.monitor_state_root}",)
     blocked = unreachable_hops(
-        plan, scheme=scheme, account=builder, asset_id="job-spec-spool", grants=()
+        plan, scheme=scheme, account=builder,
+        asset_id="job-spec-spool-builder", grants=(),
     )
-    assert blocked == (f"{DEFAULT_LAYOUT.coordinator_root}",)
+    # #657：多一跳——容器 <coordinator>/job-specs 對 job 帳號同樣是 0700 別人的，
+    # 因此少了導出的 traverse，斷點是**兩層**而不是一層。
+    assert blocked == (
+        DEFAULT_LAYOUT.job_spec_spool_root,
+        f"{DEFAULT_LAYOUT.coordinator_root}",
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_worktree_dir_naming_645.py
+++ b/tests/test_worktree_dir_naming_645.py
@@ -13,6 +13,7 @@
 
 from __future__ import annotations
 
+import os
 import shutil
 import subprocess
 from pathlib import Path
@@ -152,8 +153,17 @@ def test_prepare_systemd_template_agrees_with_provisioning(tmp_path: Path) -> No
             missing.append(f"模板 unit {unit}（剖面 {profile}）未安裝")
     if not job_runner._is_executable(shim):
         missing.append(f"降權 shim {shim} 不存在或不可執行")
-    if not Path(spool).is_dir():
-        missing.append(f"job spec spool {spool} 不存在")
+    # #657：`Path.is_dir()` 在 EACCES 時**會 raise**（只吞 ENOENT／ENOTDIR 一類），
+    # 而 spool 的父層對非 Manager 帳號本來就是 0700——用 `os.path.isdir()`（吞掉所有
+    # OSError）才是這個 skip 判斷該有的語意。
+    if not os.path.isdir(spool):
+        missing.append(f"job spec spool {spool} 不存在（#657 起每個角色一格）")
+    else:
+        # 「存在」不等於「那個身分讀得到」——那正是 #657。前置物清單一併涵蓋它，
+        # 否則本條會在一台 spool 存在但 ACL 未套用的機器上以真實派工失敗收場。
+        ok, why = job_runner._spool_readable_by(spool, account)
+        if not ok:
+            missing.append(f"builder 讀不到自己的 spec spool（{why}）")
     if missing:
         pytest.skip(
             "本機沒有 trust-root Phase 2b 的降權前置物（"


### PR DESCRIPTION
Closes #657

## 問題（實機證據）

#629 的 gate 執行身分落地後，四分部署上**每個** gate job 都以 `78/CONFIG` 收場：

```
cortex-job-shim: 讀不到 job spec …/job-specs/<inst>.json: [Errno 13] Permission denied
Main process exited, code=exited, status=78/CONFIG
```

成因：三份模板 unit 共用同一個 `Environment=PSC_JOB_SPEC_SPOOL=<coordinator>/job-specs`，
而登記表資產 `job-spec-spool` 的 reader 面**只有 builder**。shim 是 systemd 套完
`User=` **之後**才執行的（`ExecStart=` 就是 shim），它以 job 身分讀 spec ⇒ 必然被拒。

## reviewer／planner 同型——已查證

以產生器逐字複驗（`trust_root unit four-way --review-job`）：

```
User=cortex-reviewer-planner
Environment=PSC_JOB_SPEC_SPOOL=/var/lib/cortex/coordinator/job-specs   ← 與 builder 同一條
```

而 `cortex-reviewer-planner` 不在 `job-spec-spool` 的 reader 面。**同型成立**，只是還沒有
人在四分部署上派過 reviewer job。#652（M2）落地時沒驗到這一層。

## 另一個實機發現（順帶）

修本票時在部署機上量到 `/var/lib/cortex/coordinator/job-specs` 是：

```
user:cortex-builder:r-x	#effective:---
mask::---
```

`chmod` 會重寫 ACL mask，因此「先 `setfacl` 再 `chmod`」會讓具名條目**靜默失效**——ACL
還在、`getfacl` 看得到，實際權限卻是零。也就是說**那台機器上 builder 的 spool 同樣是
壞的**，只是症狀還沒被觸發。只看「有沒有那條 ACL」的檢查會說一切正常；本 PR 新的
effective 判定當場抓到（見下）。runbook 已把 mask 判準寫進驗收步驟。

## 裁決：方向 2（per-principal spool）

每個降權 principal 一個 spool 根，各自只授自己：

| | 路徑 | owner／mode | ACL |
|---|---|---|---|
| 容器 | `<coordinator>/job-specs` | `cortex-manager` 0700 | 三條 `--x`（機械導出的 traverse，**零讀權**） |
| builder | `<容器>/builder` | `cortex-manager` 0700 | `u:cortex-builder:rX` ＋ default |
| reviewer | `<容器>/reviewer` | `cortex-manager` 0700 | `u:cortex-reviewer-planner:rX` ＋ default |
| gate | `<容器>/gate` | `cortex-manager` 0700 | `u:cortex-gate:rX` ＋ default |

**推導**：這讓「哪個身分讀哪個 spool」變成 root-owned unit 檔上可逐字讀懂的一行
（`Environment=PSC_JOB_SPEC_SPOOL=`），而不是一組共用目錄上多條 ACL 的交集；而且不必把
「跨 persona 互讀 spec」這個新性質偷渡進來。容器維持 owner-only 之後另外買到一條：job
帳號連「這台機器上還有誰的 job」都列不出來。

**方向 1（擴大共用 spool 的 reader 面）不取**：它把跨 persona 互讀 spec 變成設計的一部分。
**方向 3（spec 檔 chown 給 job 帳號）不成立**：spec 是 Manager 寫的，chown 給別的 owner
需要 root，而「cortex 任何元件永不具 root」是既有裁決——票裡的判斷正確，本 PR 只是排除它。

**沒有結構性阻礙**：`spool_key_for_job()` 與 spool 路徑無關（它算的是 log 檔的 stem，
`job_workspace` 那一支才是唯一實作）；`prepare_systemd_template()` 也沒有「單一 spool」的
假設——它本來就已經 per-role 查表拿帳號／模板，spool 只是第四個查表項。

**機械導出，不硬編清單**：`DOWNGRADED_JOB_PRINCIPALS` 由 `permgen` 搬進 `registry`
（`permgen` 那個名字成為指向它的**別名**，不是第二份），它同時決定三個資產、三條路徑、
六份 unit 的 `Environment=` 與容器上的 traverse ACL。新增降權角色只要動那張表一行。
`TrustRootAsset` 新增 `path_resolver_args`，讓一支帶參數的 resolver 服務一族資產——R1 雙向
等式與 R3 自檢因此仍逐項解析得到真實路徑，而不是退回 `path_resolver=None`。

## preflight 怎麼改

原本是 `os.path.isdir(spool_dir)`——對 #657 完全無感（目錄存在、Manager 寫得進去，缺的
只是那個帳號的 ACL）。

Manager 不是那個身分，`os.access()` 問的是「**我**讀不讀得到」，答不了這題。**但那條判定
不需要變成那個身分**：POSIX.1e 的 access check 是對 inode 中繼資料的一次純計算，而那些
中繼資料 Manager 讀得到。新增 `effective_perms_for_account()`／
`inherited_perms_for_account()`：`os.stat` ＋ POSIX ACL xattr
（`system.posix_acl_access`／`system.posix_acl_default`）直接算 kernel 用的那條規則，
**含 mask 收斂**與**整條 traverse 鏈**。

preflight 因此檢查三件事：路徑上每一層對該帳號有 `x`；spool 本身有 `x`；spool 的
**default ACL** 讓該帳號在新建檔上拿得到 `r`（spec 當時還不存在，這是唯一能算、也**足以**
決定答案的東西——另一半是 `write_job_spec()` 的 `chmod 0640`）。失敗＝
`job-runner-job-spec-spool-unreadable`，發生在**任何副作用之前**。

spec 落地後再就地複驗一次真的那個 inode（`job-runner-job-spec-unreadable-by-job`），把
`write_job_spec()` 那段「`chmod 0640` 是為了讓繼承的 ACL mask 不被關掉」的推導從註解升級
成斷言。

**誠實邊界**（寫進 docstring 與 runbook）：算不到 mount 選項、mount namespace
（`ProtectSystem=strict`）與 LSM。那三項只有真的以該身分開一次檔才驗得到，由 runbook 的
`sudo -u` 步驟承接。

## 跨 UID 語意的測試怎麼寫

`tests/test_per_principal_spec_spool_657.py`（23 條 ＋ **1 條明確 skip**）。

本族（#630／#631／#638／#657）的 bug 全部是「單 UID 環境測不出 ACL 語意」，所以本檔不測
「目錄在不在」。它**自己建出一棵真實 ACL 樹**：`setfacl` 一個真的存在、uid 與本行程不同
且**非 root** 的第二個帳號（非 root 是必要的——root 對 DAC 有豁免），然後以 **effective
權限**斷言，並與系統 `getfacl` 的 `#effective:` **交叉核對**（不跟自己的實作比）。

涵蓋：讀得到自己那格／讀不到另外兩格；`chmod` 打掉 mask 之後具名條目失效（＝實機上量到的
那個形狀）；traverse 斷一層；Manager 用正式寫端寫出的 spec 該帳號讀得到；「ACL 指名的是
別人」時不成立。樹根用自建的 `0711`（而非 `tmp_path`，那是 `0700`）——否則每條斷言都會在
與本票無關的那一層失敗。

**明確 skip 的那一條**：真的 `seteuid()` 過去 `open()` 一次需要 root 或第二個可登入身分，
CI 兩者都沒有。該測試逐字寫出理由、指回 runbook 的 `sudo -u` 驗收步驟，**永遠 skip 而不
靜默通過**。ACL 不支援／找不到第二帳號時同樣是帶理由的 skip。

另補：派工路徑（每個角色寫進自己那格、preflight 對「讀不到」fail-closed）、`direct` 模式
零回歸。`tests/test_trust_root_permgen_traverse_620.py` 的正向路徑改為逐 principal，
reviewer 那條鏈因此第一次被涵蓋。

## 部署影響（需 operator 動作）

spool 落點與六份 unit 的 `Environment=` 同時改變。**順序是先權限、後 unit**——反過來會讓
每個 job 以 78/CONFIG 收場。runbook 新增 §5-3a（per-principal spec spool），含落檔驗證、
mask 判準，以及**以各 job 身分實測讀得到自己的 spec／讀不到別人的**正反向步驟。

## 驗收

- [x] 每個降權 principal 都讀得到**自己的** spec（真實 ACL 樹 ＋ effective 斷言；以該 uid
      實際 `open()` 的那一層明確 skip 並指回 runbook 的 `sudo -u` 步驟）
- [x] 跨 principal 讀不到彼此的 spec
- [x] `prepare_systemd_template()` 的 preflight 改為驗「該 job 身分讀得到」而非只驗存在
- [x] reviewer/planner 的同型問題已查證並一併修
- [x] `direct` 模式零回歸
- [x] `python3 -m pytest tests/ -q` 全綠（4038 passed, 17 skipped）
- [x] `changelog.d/per-principal-spec-spool.md` 已新增且 commit
- [x] `CHANGELOG.md [Unreleased]` 已補
- [x] runbook 已更新（含以各 job 身分實測的驗證步驟）
- [x] `policy_check` 帶 PR 上下文跑，fail: 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E7w9kaUxAzCCEk7piD5hfK
