### PR TITLE
feat(coordinator): build 卡被採信後即時回收其工作區——回收身分＝採信身分，preserve 契約拆成兩個具名模型

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,39 @@
 ## [Unreleased]
 
 ### Added
+- **#658：build 卡被採信之後即時回收其工作區——回收身分 ＝ 採信身分，preserve 契約拆成
+  兩個具名模型**——#648 之後一個 run 會累積 N 棵約 35MB 的 per-job clone，而 #649／#653
+  （ship 段自己的樹）與 #650／#659（verify／review 的 candidate 樹）落地後**被採信的
+  build 卡的工作區已無任何下游消費端**。票上的核心難點是「誰以什麼身分回收」：三分部署下
+  Manager 讀不進 builder 的 `0700` clone。**查證結論改變了選路**——抵達回收必須先走完
+  `_verify_exact_candidate()`，而它已經以 Manager 身分對**同一棵樹**跑過 `git -C … rev-parse
+  HEAD`，因此「Manager 進得去那棵樹」**本來就是「這張卡被採信」的必要條件**，回收不需要比
+  採信更大的授權面 ⇒ **不新增任何身分、不新增任何授權**。票上四個候選逐一否掉：job 自刪
+  違反 #540 且不知道自己有沒有被採信（會銷毀 #601 重派要用的殘留）；#629 的 `GATE` 只有
+  `rX` 無 `w`，授 `w` 等於讓跑不受信任程式碼的帳號能改尚未 harvest 的交付樹；
+  `ExecStopPost=` 的時機是 job 退出不是被採信，且 `+` 前綴＝root 執行，與「cortex 永不具
+  root」相斥；依 `PSC_JOB_RUNNER` 分支是 #634 反模式（決定回收成不成立的是磁碟上的 owner，
+  不是旗標）。改以**能力判定**：前置條件不成立就具名 skip、收不掉就 `failed`＋診斷，
+  **兩者都不擋採信**。另修正票上一處前提：preserve 讀不到時是記 warning 後繼續（真正
+  fail-closed 的是 `rmtree`）；且 #641 之後降權部署的 `_verify_exact_candidate()` 就已經先
+  fail-closed（`blocked on #629`）⇒ **那裡今天不存在「被採信卻沒回收的工作區」**，#629 落地
+  時回收身分必須與 candidate 驗證身分一起重新裁決。**契約改動**：`worktree_reclaim` 的
+  「不銷毀證據」拆成 `EVIDENCE_PRESERVE`（預設，#478 語意逐字不變，未採信路徑一律走它）與
+  `EVIDENCE_HARVESTED`（採信路徑；逐條盤點後未提交／未追蹤殘渣在採信面上地位為零——commit
+  在來源樹、bundle 在 spool、ledger／sentinel 由 Manager 寫、log 在 Manager-owned 樹、
+  outputs 已 hash 進 immutable evidence、canonical report 在 reviewer 的樹；把它複製進
+  `evidence/` 等於把不受信任內容搬進受信任的樹，且只是把要回收的位元組換個目錄）；未知值
+  一律 `raise`，`archive_workspace_head()` **兩種模型下都照跑**作為模型選錯時的安全網。
+  新增 `manager._trusted_build_workspace_target()`（六條 fail-closed 前置條件，核心安全閘是
+  「目錄名 ＝ `job_segment(job_id)`」這個 #645 單一推導點，結構性擋掉 #549 的
+  `worktree == workspace_root` 地雷）與 `_reclaim_trusted_build_workspace()`（永不 raise，
+  三種結果各一行結構化 log）。呼叫點刻意在狀態落盤**之後**——掛在 harvest 旁邊會留下
+  「工作區已刪、卡仍 pending」的死路。重入：#601 的未採信殘留完全不動、retry-card 的 base
+  走來源樹、abandon 的回收得到 `absent`（成功）、#613 的 branch 一個位元組沒碰且 `gc` 的
+  「未 merge ⇒ keep」仍頂得住。新增 `tests/test_immediate_worktree_reclaim_658.py`
+  （15 條 ＋ 1 條 skip，全部跑正式路徑；突變驗證停掉回收 6 條轉紅、拿掉兩道安全閘 3 條轉紅；
+  跨帳號擁有權語意單一 pytest 進程結構性測不到 ⇒ 明確 skip，可測的那一半另有 `chmod 000`
+  一條並在 docstring 講明它證得了什麼）。
 - **#650：verify／review 卡的 candidate 樹搬出 builder 的 clone——解開擋住「卡被採信後
   即時回收」的最後一條引用**——`_dispatch_workflow_card()` 的 reviewer 分支以
   `builder_jobs[-1]["worktree"]` 為 candidate 樹，六個用途全掛在它身上；#648 之後一個 run

--- a/changelog.d/immediate-worktree-reclaim.md
+++ b/changelog.d/immediate-worktree-reclaim.md
@@ -1,0 +1,169 @@
+# Issue #658：build 卡被採信之後即時回收其工作區——解耦已完成，卡在「誰以什麼身分回收」
+
+## 問題
+
+#648 把 canonical lane 的工作區改成 per-job，一個 run 因此會累積 N 棵約 35MB 的 clone
+（N ＝ build 卡數）。#649／#653（ship 段自己的 Manager-owned 樹）與 #650／#659
+（verify／review 的 candidate 樹改由 Manager 自己 clone）落地之後，**一張 build 卡被
+採信、`_harvest_build_candidate()` 走完之後，它的工作區已經沒有任何下游消費端**——
+candidate 已在來源樹的 `refs/heads/<branch>`、bundle 已封存進 Manager-owned spool、
+後續卡不再讀它。#650 驗收第 3 條「卡被採信之後即時回收該卡工作區」因此落到本票。
+
+票上點名它不是一行：`worktree_reclaim.reclaim_worktree()` 的模組契約含**不銷毀證據**
+（未提交／未追蹤內容要先複製到 `preserve_root` 封存），而三分部署下 Manager 讀不進
+builder 的 `0700` clone。三個問題要一次講清楚：**誰以什麼身分回收**、**封存還剩什麼
+要保**、**abandon（#613）＋ retry-card（#601）的重入**。
+
+---
+
+## 問題 1：誰以什麼身分回收 ⇒ **Manager，且不新增任何身分、不新增任何授權**
+
+答案由一條**既有的**不變式決定，不是新的設計裁決：
+
+> 抵達即時回收必須先走完 `_verify_build_candidate_transition()`，而它的第一件事是
+> `_verify_exact_candidate()`——以 **Manager 身分**對**同一棵樹**跑
+> `git -C <worktree> cat-file` 與 `rev-parse HEAD`。
+
+也就是說 **「Manager 進得去那棵樹」本來就是「這張卡被採信」的必要條件**。回收要的權限
+是採信路徑已經在用的那一份，**回收不需要比採信更大的授權面**。
+
+票上四個候選逐一被否掉：
+
+| 候選 | 為什麼不選 |
+|---|---|
+| (a) job wrapper 在自己退出前自刪 | 紅線（model 自證的變形）；更根本的是 job **不知道自己有沒有被採信**（採信在它退出之後由 Manager 判定），自刪必然把**未採信**路徑的殘留一起銷毀——那正是 #601 重派要用的東西 |
+| (b) #629 的第三執行身分（`cortex-gate`） | 登記表給 `GATE` 對 `repo-worktree` 的是 `rX` **無 `w`**。授它 `w` 等於讓一個專門跑不受信任程式碼的帳號能改 builder **尚未 harvest** 的交付樹，與 #629 自己的論證方向相反 |
+| (c) systemd `ExecStopPost=`／`RuntimeDirectory` | 時機錯：unit 停止是 **job 退出**不是**被採信**，失敗形態同 (a)；且要讓它跑得動 `rm -rf` 需要 `+` 前綴（root 執行），與「cortex 任何元件永不具 root」這條既有裁決相斥 |
+| (d) 只在 `direct` 模式即時回收，降權模式交給 `cortex work gc` | #634 的反模式（依 `PSC_JOB_RUNNER` 分支）。真正決定回收成不成立的是**磁碟上的 owner**，不是旗標——以旗標分支會在「旗標說降權、磁碟其實還是 Manager-owned」與其反面各錯一次 |
+
+改採**能力判定**：前置條件不成立就具名 skip，收不掉就 `failed` ＋ 診斷，**兩者都不擋
+採信**。
+
+### 三分／四分部署的誠實邊界（票上前提的一處修正）
+
+票上說「preserve 那一步在降權部署下必然失敗」。實際查證：`_dirty_entries()` 讀不到時
+是**記 warning 後繼續**（不是 `failed`），真正 fail-closed 的是後面的 `rmtree`——結論
+（Manager 收不掉那棵樹）不變，但失敗點不在票上寫的那一步。
+
+更關鍵的一點票上沒提：**#641 收掉 ACL 之後，降權部署下 `_verify_exact_candidate()`
+就已經先 fail-closed 了**（訊息明文 `blocked on #629`）⇒ 那個部署形態下**今天根本
+不存在「被採信卻沒回收的工作區」**，本函式連跑都跑不到。因此本票不必、也不得為它發明
+新的執行身分。等 #629 把 candidate 驗證搬到 gate 執行身分之後，「誰讀得到那棵樹」會
+跟著改變——**屆時回收身分必須與 candidate 驗證身分一起重新裁決**，這條依賴明文寫進
+`_reclaim_trusted_build_workspace()` 的 docstring 與 runbook 稽核 5c。
+
+---
+
+## 問題 2：封存還剩什麼要保 ⇒ **契約改了**：preserve 拆成兩個具名模型
+
+`worktree_reclaim` 的「不銷毀證據」從一種做法拆成兩個**具名**模型，呼叫端必須明講
+（未知值一律 `raise`，**不靜默退回預設**）：
+
+- `EVIDENCE_PRESERVE`（**預設，語意與 #478 逐字不變**）：所有**未採信**路徑——
+  `recover-pre-candidate`、`abandon` 的回收、#601 的殘留。這些路徑的共同性質是
+  **成果沒有被 harvest 過**，工作區裡的 commit 只存在於它自己的 object store。
+- `EVIDENCE_HARVESTED`（新增）：呼叫端必須先證明「每一樣受治理的東西都已經有第二份
+  副本，且那份副本在 Manager-owned 的樹裡」。
+
+### 為什麼 `harvested` 底下可以放棄 preserve（逐條盤點，不是省略）
+
+| 工作區裡的東西 | 第二份副本 |
+|---|---|
+| 被採信的 commit | 來源樹的 `refs/heads/<branch>`（#637 bundle ＋ spool；`_harvest_build_candidate()` 強制 branch head 恰等於 candidate） |
+| bundle 本身 | Manager-owned 的 `commit-spool`（封口後仍在） |
+| gate ledger | `gate-ledger-spool` → Manager 重寫的 `gate-ledger`（#628／#629） |
+| exit sentinel | Manager 自己寫（#604／#628） |
+| JSONL log | `log_dir`（Manager-owned），本來就不在工作區裡 |
+| 宣告的 outputs | 採信當下已由 `_read_job_workflow_evidence()` 逐檔 hash 進 immutable canonical evidence |
+| canonical report | #650／#659 之後發佈在 reviewer 的 candidate 樹，不在 build 卡的工作區 |
+
+**剩下的只有「模型做了、但既沒 commit、也沒宣告為 output」的未追蹤殘渣。** 它在採信面
+上的地位是零（#540 採信的是 candidate commit；#628 明講被驗方不得產生自己的驗收證據），
+而把它複製進 Manager-owned 的 `evidence/` 樹實際效果是**把不受信任的內容搬進受信任的
+樹**，並且把要回收的位元組原地搬個家（一張卡可能是 512 檔 × 4MB）——與本票要解的問題
+是同一個換個目錄。
+
+**#478 的現場不適用**：那次遺失的是 operator 自己 worktree 裡的真實工作，發生在**未
+採信**路徑上。那條路徑仍然、也必須走 `EVIDENCE_PRESERVE`。
+
+**放棄了什麼、保留了什麼**：放棄的是「採信路徑上的 preserve 封存」。**`archive_workspace_head()`
+兩種模型下都照跑**——它是模型選錯時的安全網（commit 沒進來源樹時把它救回封存命名
+空間），不是可有可無的加分項。
+
+---
+
+## 問題 3：abandon（#613）＋ retry-card（#601）的重入
+
+- **retry-card／未採信路徑**：即時回收**只在採信之後跑**，失敗的 job 從來沒有被採信過
+  ⇒ 它的工作區一個位元組都不動，#601 的重派前殘留仍在原地（有測試釘住，含未追蹤檔的
+  內容）。#601 的範圍與處置**完全不變**。
+- **retry-card 的重派**：`_manager_reset_workflow_for_retry_card()` 不動 `candidate_head`，
+  重派的 base 走 `_workflow_build_handoff_base()`＝來源樹上被採信的 candidate，**不讀任何
+  工作區**（#648 已釘）⇒ 即時回收不產生新的死路。
+- **abandon**：`work_actions._reclaim_abandoned_build_worktrees()` 掃 run 名下每一列 job
+  的 `worktree`；已被即時回收的路徑判定為 `absent`（**成功**，不是 `failed`），還活著的
+  那一棵照樣收得掉。有測試走真的掛點。
+- **#613 的 branch 回收**：即時回收**一個 branch 名都沒碰**，仍是 #613 的範圍。另補一條
+  測試：所有 build 工作區被回收之後 `gc` 的 `protected_branches` 這條保護被抽掉了，但
+  「未 merge ⇒ keep」仍頂得住，run 中途的 `gc --apply` 不會刪掉交付 branch。
+
+---
+
+## 落地
+
+`paulsha_cortex/coordinator/worktree_reclaim.py`
+
+- 新增 `EVIDENCE_PRESERVE`／`EVIDENCE_HARVESTED` 與 `reclaim_worktree(..., evidence_model=)`
+  （`reclaim_worktrees`／`reclaim_recorded_or_derived` 一併透傳）；未知值 `raise`。
+- `WorktreeReclaim` 增 `evidence_model` 欄並帶進 `to_dict()`——operator 看得到某一次回收
+  **為什麼**沒有 preserve 封存。
+- 模組 docstring 改寫「不銷毀證據」那一條為兩個模型 ＋ 完整論證。
+
+`paulsha_cortex/coordinator/manager.py`
+
+- 新增 `_trusted_build_workspace_target()`：六條前置條件，前四條防「刪到不該刪的東西」、
+  後兩條防「刪到還沒有第二份副本的東西」。安全閘的核心是**目錄名必須恰好是這個 job_id
+  經 `job_workspace.job_segment()` 導出的片段**（#645 的單一推導點）——#549 的資料語意
+  地雷（`job.worktree` 等於 run 的 `workspace_root`）在這裡結構性被擋掉。刻意**不**拿
+  `paths.worktree_root_for()` 當判準：那是 config 解析出來的位置，會與磁碟上真正
+  provision 到哪裡漂開（#634「以形狀判斷，不依環境推導」）。另外三條：標記檔存在
+  （#646「認不得就不刪」）、標記檔的 `branch`／`source_repo` 對得上、以及**當場對來源樹
+  複驗** `commit_present()` 與 `source_branch_head() == candidate`。
+- 新增 `_reclaim_trusted_build_workspace()`：**永不 raise**，三種結果各寫一行結構化 log
+  （`workflow-build-workspace-reclaim-{reclaimed,skipped,failed}`）。
+- 呼叫點在 `apply_workflow_action("advance")` 的 build 分支、**`_manager_update_workflow_run()`
+  之後**。位置是刻意的：掛在 `_harvest_build_candidate()` 旁邊的話，中間任何一條 raise
+  都會留下「工作區已刪、卡仍 pending」，下一個 tick 的 `_verify_exact_candidate()` 會以
+  `git -C <已刪的路徑>` 收場——一條**由清理製造出來的死路**。落盤之後再收，重入撞到的是
+  既有的 `workflow card evidence replay rejected`（已採信的卡不再讀工作區）。
+
+`docs/superpowers/runbooks/trust-root-phase2b-setup.md`：新增稽核 5c（回收沒有偷偷把
+#641 收掉的 ACL 加回來；運轉期以 journal 事件與 pool 佔用對照）。
+
+## 紅線遵守
+
+- **沒有**加回 Manager 對 job 工作樹的 ACL（#641／#644）——回收用的是採信路徑既有的
+  那一份權限，稽核 5b 的「零 `setfacl`」逐字仍然成立。
+- **沒有**讓 job 自己決定何時回收自己（回收由 Manager 在採信之後觸發）。
+- **沒有**寫會把不認得的目錄直接刪掉的清理器（#646）——六條前置條件全部 fail-closed。
+- `direct` 模式零回歸：本次沒有引入任何依 `PSC_JOB_RUNNER` 的分支，也沒碰
+  `job_runner`／`launcher`／`permgen`／`trust_root/`。
+
+## 測試
+
+新增 `tests/test_immediate_worktree_reclaim_658.py`（15 條 ＋ 1 條 skip），全部跑正式
+路徑：真 git repo、真 `ScriptWorktreeCreator` 的 per-job clone、真
+`dispatch_workflow_card()`、真 bundle ＋ append-only spool 交接、真
+`terminalize_workflow_job()`、真 `apply_workflow_action(action="advance")`、真
+`_manager_reset_workflow_for_retry_card()`、真 `gc.scan()`。
+
+**突變驗證**：停掉即時回收呼叫 ⇒ **6 條轉紅**；拿掉「目錄名 ＝ job_segment」與「來源樹
+複驗」兩道安全閘 ⇒ **3 條轉紅**。
+
+**#638／#657 的教訓**：跨帳號擁有權語意（`0700 cortex-builder` 的樹由 `cortex-manager`
+回收）需要 root 建置 ＋ 以另一個 UID 執行回收，**單一 pytest 進程結構性做不到** ⇒ 明確
+`pytest.skip` 並在 reason 印出本機實況。可測的那一半（讀不進去時得到具名拒絕理由、
+不做注定失敗的 `rmtree`）另有一條 `chmod 000` 的測試，並在 docstring 明講它證得了什麼、
+證不了什麼。
+
+`python3 -m pytest tests/ -q`：**4063 passed, 19 skipped**。

--- a/docs/superpowers/runbooks/trust-root-phase2b-setup.md
+++ b/docs/superpowers/runbooks/trust-root-phase2b-setup.md
@@ -683,6 +683,27 @@ grep -E "setfacl" /tmp/p2b-permissions.sh | grep -E "/var/lib/cortex/worktree/"
 #   它是 `0701 cortex-manager`，Manager 是 owner、別的帳號只能 traverse，
 #   產生器對它只出 `install -d`／`chown`／`chmod`，本來就沒有 setfacl。
 
+# ✅ 稽核 5c：**即時回收沒有偷偷把那條 ACL 加回來**（#658）
+#   #658 讓 build 卡被採信之後即時回收它的工作區。回收身分是 **Manager 自己**，
+#   而且**刻意不新增任何授權**——推導是：抵達回收必須先走完
+#   `manager._verify_exact_candidate()`，那裡已經以 Manager 身分對**同一棵樹**跑過
+#   `git -C <worktree> rev-parse HEAD`。因此「Manager 進得去那棵樹」是**採信本身
+#   既有的前提**，不是 #658 新增的假設；稽核 5b 的「零 setfacl」因此仍然成立，
+#   上面那條 grep 就是本項的稽核（不需要另一條命令）。
+#   **降權部署下今天的實況**：#641 收掉 ACL 之後 `_verify_exact_candidate()` 會先
+#   fail-closed（訊息含 `blocked on #629`），所以那裡根本不會出現「被採信卻沒回收
+#   的工作區」。等 #629 把 candidate 驗證搬到 gate 執行身分之後，「誰讀得到那棵樹」
+#   會跟著改變——**屆時回收身分必須與 candidate 驗證身分一起重新裁決**，不得單獨
+#   為回收開一條授權。
+#   **運轉期稽核**（run 跑過之後看得到）：
+#     journalctl -u cortex-manager | grep workflow-build-workspace-reclaim
+#   期望：每張被採信的 build 卡各一行 `-reclaimed`。
+#     `-skipped reason=<code>` ⇒ 前置條件不成立（刻意不收），reason 逐字說明是哪一條；
+#     `-failed` ⇒ 試了但後置條件不成立，**採信不受影響**，殘留由 `cortex work gc` 收。
+#   pool 佔用的對照：一個進行中的 run 在 build phase 應只有**一個** build 工作區
+#   （正在跑的那一張卡）：
+#     sudo ls -1 /var/lib/cortex/worktree | grep -v -- '-review-' | wc -l
+
 # ✅ 稽核 6：script 裡出現的每個帳號名都**真的存在**（#626）
 #   `setfacl` 對解析不到的使用者名直接失敗（`Invalid argument near character 3`），
 #   而 2b 是 `sh -e`——一條錯就**中止整份 script**，留下**半套權限的樹**（前半已套、

--- a/paulsha_cortex/coordinator/manager.py
+++ b/paulsha_cortex/coordinator/manager.py
@@ -3395,6 +3395,188 @@ def _harvest_build_candidate(
     return harvested
 
 
+#: #658：即時回收的結構化 log 事件名。operator 的稽核面就是這一行——
+#: `journalctl -u cortex-manager | grep workflow-build-workspace-reclaim`。
+#: 三種結果各一個字尾：`-reclaimed`（真的收掉）／`-skipped`（前置條件不成立，
+#: 刻意不收）／`-failed`（試了但後置條件不成立，殘留交給 `cortex work gc`）。
+WORKFLOW_BUILD_WORKSPACE_RECLAIM_EVENT = "workflow-build-workspace-reclaim"
+
+
+def _trusted_build_workspace_target(
+    job: Mapping[str, object], *, run, candidate: str
+) -> tuple[Path | None, str | None]:
+    """這張已被採信的 build 卡的工作區可不可以現在就回收？回 (路徑, 拒絕理由)。
+
+    恰有一個非 None。**任何一條不成立都回拒絕理由，不 raise、不猜、不回收**——
+    回收是清理，採信已經完成（#658 驗收：回收失敗不得擋住採信）。
+
+    六條前置條件，前四條防「刪到不該刪的東西」，後兩條防「刪到還沒有第二份副本
+    的東西」：
+
+    1. **記錄真的有一條絕對路徑**，且是目錄、不是 symlink。
+    2. **目錄名恰好是這個 job_id 經 `job_workspace.job_segment()` 導出的片段**。
+       這是 #645 的單一推導點，也是本函式最重要的一條安全閘：它把「回收哪一棵樹」
+       綁在 provisioning 的同一個推導上，而不是綁在一條可能陳舊的字串。#549 的
+       資料語意地雷（實測 `job.worktree` 會等於 run 的 `workspace_root`，那是
+       Manager 的 durable state）在這裡就被擋掉——來源樹的目錄名永遠不會是某個
+       job_id 的片段。刻意**不**拿 `paths.worktree_root_for()` 當判準：那是
+       config 解析出來的位置，會與磁碟上真正 provision 到哪裡漂開（注入 creator
+       的呼叫端就是），而「以形狀判斷，不依環境推導」正是 #634 的原則。
+    3. **它帶 `job_workspace` 的標記檔**（`is_job_clone`）。#646 的紅線：認不得的
+       目錄一律不刪。三分部署下 Manager 讀不進 `0700` 的 clone，這條會回 False
+       ⇒ 得到一個具名的 skip 理由，而不是一次注定失敗的 `rmtree`。
+    4. **標記檔的 `branch` 與 `source_repo` 都對得上**——分別對 job 記錄的 branch
+       與 run 的 `workspace_root`。標記檔是 provisioning 當下寫的，因此這一條驗的
+       是「這棵樹真的是本 run、這條交付線 provision 出來的」，不只是路徑長得像。
+    5. **來源樹裡真的有這顆 candidate**（`commit_present`）。
+    6. **來源樹的 `refs/heads/<branch>` 恰等於 candidate**。
+
+    5／6 是 `_harvest_build_candidate()` 的後置條件，這裡**當場對來源樹重驗一次**
+    而不是依賴呼叫順序：`EVIDENCE_HARVESTED` 這個 evidence 模型（見
+    `worktree_reclaim` 模組 docstring）的全部正當性就建立在這兩條上，而「呼叫端
+    在正確的位置呼叫」是一條會隨重構漂掉的約定，不是不變式。
+    """
+
+    worktree = job.get("worktree")
+    if not isinstance(worktree, str) or not worktree:
+        return None, "workspace-path-missing"
+    source_repo = getattr(run, "workspace_root", None)
+    if not isinstance(source_repo, str) or not source_repo:
+        return None, "source-repo-missing"
+    branch = job.get("branch")
+    if not isinstance(branch, str) or not branch:
+        return None, "branch-missing"
+    job_id = job.get("job_id")
+    if not isinstance(job_id, str) or not job_id:
+        return None, "job-id-missing"
+    if verification.SAFE_SHA_RE.fullmatch(candidate) is None:
+        return None, "candidate-invalid"
+
+    target = Path(worktree)
+    if not target.is_absolute() or target.is_symlink() or not target.is_dir():
+        return None, "workspace-path-not-a-directory"
+    try:
+        expected = job_workspace.workspace_path(target.parent, job_id)
+    except job_workspace.WorkspaceError:
+        return None, "job-id-not-a-workspace-segment"
+    if target != expected:
+        # #549：`job.worktree` 指到 run 的 `workspace_root`（主 checkout）時走到
+        # 這裡。那是 Manager 的 durable state，遞迴刪除的爆炸半徑不可接受。
+        return None, "workspace-name-not-derived-from-job-id"
+    if not job_workspace.is_job_clone(target):
+        return None, "workspace-not-a-job-clone"
+    marker = job_workspace.read_marker(target) or {}
+    if marker.get("branch") != branch:
+        return None, "workspace-branch-mismatch"
+    recorded_source = marker.get("source_repo")
+    if not isinstance(recorded_source, str) or Path(recorded_source) != Path(source_repo):
+        return None, "workspace-source-repo-mismatch"
+
+    if not job_workspace.commit_present(source_repo, candidate):
+        return None, "candidate-not-in-source-repo"
+    if job_workspace.source_branch_head(source_repo, branch) != candidate.lower():
+        return None, "source-branch-head-mismatch"
+    return target, None
+
+
+def _reclaim_trusted_build_workspace(
+    job: Mapping[str, object], *, run, candidate: str
+):
+    """#658：build 卡被採信之後即時回收它的工作區。回傳 `WorktreeReclaim | None`。
+
+    ## 為什麼現在可以收
+
+    #648（後續 build 卡的 base 走 `run.candidate_head`，不讀前一張卡的工作區）、
+    #649／#653（ship 段有自己的 Manager-owned 樹）、#650／#659（verify／review 的
+    candidate 樹是 Manager 自己 clone 的）三票落地之後，**一張 build 卡被採信、
+    `_harvest_build_candidate()` 走完之後，它的工作區已經沒有任何下游消費端**。
+    per-job（#648）之後一個 run 會累積 N 棵這種樹（每棵約 35MB），即時回收因此是
+    自然的下一步——#650 驗收第 3 條移到本票。
+
+    ## 誰以什麼身分回收：**Manager，且不新增任何身分、不新增任何授權**
+
+    這是 #658 的核心問題，答案由一條既有的不變式決定：**「Manager 進得去那棵樹」
+    本來就是「這張卡被採信」的必要條件**。抵達本函式必須先走完
+    `_verify_build_candidate_transition()`，而它的第一件事就是以 Manager 身分對
+    **同一棵樹**跑 `git -C <worktree> cat-file` 與 `rev-parse HEAD`
+    （`_verify_exact_candidate()`）。因此回收不需要比採信更大的授權面——它要的權限
+    是採信路徑已經在用的那一份。
+
+    四個候選身分各自為什麼不選（票上列的那四個）：
+
+    - **(a) job wrapper 自刪**：被回收的對象自己決定回收，與 #540 的 acceptance
+      chain 方向相反；更根本的是 job **不知道自己有沒有被採信**（採信發生在它退出
+      之後、由 Manager 判定），自刪必然把未採信路徑的殘留一起銷毀——那正是 #601
+      重派要用的東西。
+    - **(b) #629 的 gate 執行身分**：登記表給 `GATE` 對 `repo-worktree` 的是 `rX`
+      **無 `w`**。授它 `w` 等於讓一個專門用來跑不受信任程式碼的帳號能改 builder
+      尚未 harvest 的交付樹，方向與 #629 自己的論證相反。
+    - **(c) `ExecStopPost=`／`RuntimeDirectory`**：時機錯——unit 停止是 **job 退出**
+      不是**被採信**，同 (a) 的失敗形態；而讓它跑得動 `rm -rf` 需要 `+` 前綴
+      （root 執行），與「cortex 任何元件永不具 root」這條既有裁決相斥。
+    - **(d) 依 `PSC_JOB_RUNNER` 分支（只在 `direct` 即時收）**：#634 的反模式。
+      真正決定回收成不成立的是**磁碟上的 owner**，不是旗標；以旗標分支會在
+      「旗標說降權、磁碟其實還是 Manager-owned」與其反面各錯一次。本函式改以
+      **能力判定**：前置條件不成立就具名 skip，收不掉就回 `failed` ＋ 診斷。
+
+    **三分／四分部署的誠實邊界**：#641 收掉 Manager 對 job 工作樹的 ACL 之後，
+    `_verify_exact_candidate()` 在那些部署上會先 fail-closed（訊息明文
+    `blocked on #629`）⇒ **那裡今天根本不存在「被採信卻沒回收的工作區」**，本函式
+    連跑都不會跑到。等 #629 把 candidate 驗證搬到第三執行身分之後，「誰讀得到那棵
+    樹」會跟著改變——屆時**回收身分必須與 candidate 驗證身分同進退**，這條依賴是
+    刻意寫在這裡的，不是留給下一個人重新推導。
+
+    ## 回收失敗不擋採信
+
+    採信在呼叫本函式之前就已經 durable（`_manager_update_workflow_run()` 已落盤）。
+    因此本函式**永不 raise**：失敗只留下 :data:`WORKFLOW_BUILD_WORKSPACE_RECLAIM_EVENT`
+    的結構化 log，殘留由既有的 `cortex work gc` 掃除。
+
+    ## evidence 模型
+
+    走 `worktree_reclaim.EVIDENCE_HARVESTED`——完整論證在該模組的 docstring，前提由
+    `_trusted_build_workspace_target()` 的第 5／6 條**當場對來源樹複驗**。
+    """
+
+    job_id = job.get("job_id")
+    run_id = getattr(run, "run_id", None)
+    card = job.get("workflow_card")
+    target, refusal = _trusted_build_workspace_target(job, run=run, candidate=candidate)
+    if target is None:
+        logger.info(
+            "%s-skipped run_id=%s job_id=%s card=%s reason=%s",
+            WORKFLOW_BUILD_WORKSPACE_RECLAIM_EVENT, run_id, job_id, card, refusal,
+        )
+        return None
+    try:
+        result = worktree_reclaim.reclaim_worktree(
+            target,
+            repo_root=str(getattr(run, "workspace_root", "")) or None,
+            evidence_model=worktree_reclaim.EVIDENCE_HARVESTED,
+        )
+    except Exception as exc:  # noqa: BLE001 - 清理不得讓已完成的採信反悔
+        logger.warning(
+            "%s-failed run_id=%s job_id=%s card=%s path=%s error=%s: %s",
+            WORKFLOW_BUILD_WORKSPACE_RECLAIM_EVENT, run_id, job_id, card, target,
+            type(exc).__name__, str(exc)[:200],
+        )
+        return None
+    if result.ok:
+        logger.info(
+            "%s-reclaimed run_id=%s job_id=%s card=%s path=%s status=%s",
+            WORKFLOW_BUILD_WORKSPACE_RECLAIM_EVENT, run_id, job_id, card,
+            result.path, result.status,
+        )
+    else:
+        logger.warning(
+            "%s-failed run_id=%s job_id=%s card=%s path=%s detail=%s"
+            "；採信不受影響，殘留工作區交給 `cortex work gc`",
+            WORKFLOW_BUILD_WORKSPACE_RECLAIM_EVENT, run_id, job_id, card,
+            result.path, result.detail,
+        )
+    return result
+
+
 def _review_builder_job_binding(
     registry,
     *,
@@ -10391,6 +10573,17 @@ def apply_workflow_action(
                 else None
             ),
         )
+        if current.current_phase == "build":
+            # #658：這張卡的採信此刻已經 durable（上面那次 `_manager_update_workflow_run`
+            # 已落盤），它的工作區從此沒有任何下游消費端 ⇒ 即時回收。
+            #
+            # **位置刻意在狀態更新之後**：若掛在 `_harvest_build_candidate()` 旁邊，
+            # 中間任何一條 raise（宣告了 outputs 卻沒有 artifact、`_audit_phase_steps`、
+            # phase transition 驗證……）都會讓 run 停在「工作區已刪、卡仍 pending」，
+            # 下一個 tick 的 `_verify_exact_candidate()` 會以 `git -C <已刪的路徑>`
+            # 失敗收場——一條由清理製造出來的死路。狀態落盤之後再收，重入的是
+            # `workflow card evidence replay rejected`（已採信的卡不再讀工作區）。
+            _reclaim_trusted_build_workspace(job, run=updated, candidate=str(candidate))
         reason = (
             "ship-validator-unavailable"
             if current.current_phase == "review" and phase_done and requested_phase == "ship" and ship_validator is None

--- a/paulsha_cortex/coordinator/worktree_reclaim.py
+++ b/paulsha_cortex/coordinator/worktree_reclaim.py
@@ -14,9 +14,67 @@ at ...` 失敗，slice 被打回 `needs_human`。
   否則回收判定為 ``failed``——呼叫端據此 fail closed，不得回報成功。
 - **自癒**：既存壞狀態（目錄已不存在、registry 殘留）也要能收乾淨；因此
   registry 探測先於目錄探測，不以目錄存在與否作為要不要清 registry 的條件。
-- **不銷毀證據**：目錄若帶未提交／未追蹤內容，先複製到 ``preserve_root`` 底下
-  的 reclaim 封存再刪；封存失敗即 ``failed``，一個位元組都不刪（#478 的
-  `.project-policy.yml` 資料遺失回報）。
+- **不銷毀證據**：見下節。回收永遠不得讓「還沒有第二份副本的東西」消失。
+
+## 「不銷毀證據」的兩種模型（#658）
+
+原始契約只有一種做法：目錄若帶未提交／未追蹤內容，先複製到 ``preserve_root``
+底下的 reclaim 封存再刪；封存失敗即 ``failed``，一個位元組都不刪（#478 的
+`.project-policy.yml` 資料遺失回報）。#658 把它拆成**兩個具名模型**，呼叫端必須
+明講自己屬於哪一種——**不是靜默跳過**：
+
+:data:`EVIDENCE_PRESERVE`（預設，語意與 #478 逐字相同）
+    「這棵樹裡可能有還沒有第二份副本的東西」。所有**未採信**路徑一律走這條：
+    `recover-pre-candidate`（#478／#547）、`abandon` 的回收（#527）、#601 的
+    retry 前殘留。這些路徑的共同性質是**成果沒有被 harvest 過**——工作區裡的
+    commit 只存在於它自己的 object store，未提交內容更是沒有任何其他副本。
+
+:data:`EVIDENCE_HARVESTED`（#658 新增）
+    「這棵樹裡的每一樣**受治理**的東西都已經有第二份副本，且那份副本在
+    Manager-owned 的樹裡」。呼叫端 MUST 在傳入這個值之前證明該前提；本模組
+    **不**代為證明（它只拿得到一個路徑）。目前唯一的合法呼叫端是
+    `manager._reclaim_trusted_build_workspace()`——它在
+    `_harvest_build_candidate()` 之後、且**當場對來源樹複驗** candidate 已經
+    在裡面、`refs/heads/<branch>` 恰等於它，才會用這個模型。
+
+### 為什麼 `harvested` 底下可以不做 preserve（#658 的論證，不是省略）
+
+被回收的是 canonical lane 一張**已被採信**的 build 卡的工作區。逐條盤點它當下
+還持有什麼，以及那樣東西的第二份副本在哪：
+
+===============================  ===================================================
+工作區裡的東西                    第二份副本
+===============================  ===================================================
+被採信的 commit                   來源樹的 ``refs/heads/<branch>``（#637 bundle ＋
+                                 append-only spool；`_harvest_build_candidate()`
+                                 強制「回收後 branch head 恰等於 candidate」）
+bundle 本身                       Manager-owned 的 `commit-spool`（封口後仍在）
+gate ledger                       `gate-ledger-spool` → Manager 重寫的 `gate-ledger`
+                                 （#628／#629，作者一律是 Manager）
+exit sentinel                     Manager 自己寫（#604／#628）
+JSONL log                         `log_dir`（Manager-owned），本來就不在工作區裡
+宣告的 outputs                    採信當下已由 `_read_job_workflow_evidence()` 逐檔
+                                 hash 進 immutable canonical evidence
+canonical report                  #650／#659 之後發佈在 reviewer 的 candidate 樹，
+                                 不在 build 卡的工作區
+===============================  ===================================================
+
+**剩下的就只有「模型做了、但既沒 commit、也沒宣告為 output」的未追蹤殘渣。**
+它在採信面上的地位是零——#540 的 acceptance chain 採信的是 candidate commit，
+未提交內容從定義上就不在採信面內；#628 更明講「被驗方不得在自己的進程裡產生
+自己的驗收證據」，而這些檔案正是 builder 完全掌控的內容。把它們複製進
+Manager-owned 的 ``evidence/`` 樹，實際效果是**把不受信任的內容搬進受信任的
+樹**，並且把本次要回收的位元組原地搬個家（一張卡就可能是 512 檔 × 4MB）——
+那與 #658 要解的「工作區佔用隨 build 卡數線性成長」是同一個問題換個目錄。
+
+**#478 的現場不適用**：那次遺失的是 operator 自己 worktree 裡的真實工作，
+發生在**未採信**路徑上。那條路徑仍然、也必須走 :data:`EVIDENCE_PRESERVE`。
+
+**兩個模型共用的保險絲**：`job_workspace.archive_workspace_head()` 在**兩種模型
+下都跑**。它把工作區 HEAD 拉進來源樹的封存命名空間，且「commit 已在來源樹裡」
+時直接回 None。因此在 `harvested` 模型下它正常是 no-op；一旦呼叫端的前提其實
+不成立（commit 沒進來源樹），它就會把那顆 commit 救回來——這是模型選錯時的
+安全網，不是可有可無的加分項。
 
 git_runner seam 沿用 `dispatcher.GitRunner` 契約：收 **git 子命令參數**（不含
 前導 ``git``、不含 ``-C``），對 repo root 執行，失敗時 raise。#478 驗收條款
@@ -57,6 +115,12 @@ PRESERVE_FILE_MAX_BYTES = 4 * 1024 * 1024
 # 封存檔數上限，理由同上。
 PRESERVE_FILE_MAX_COUNT = 512
 
+# 「不銷毀證據」的兩種模型（完整論證見模組 docstring）。**預設一律是
+# `EVIDENCE_PRESERVE`**：新呼叫端忘了表態時得到的是保守的那一個。
+EVIDENCE_PRESERVE = "preserve"
+EVIDENCE_HARVESTED = "harvested"
+_EVIDENCE_MODELS = frozenset({EVIDENCE_PRESERVE, EVIDENCE_HARVESTED})
+
 
 @dataclass(frozen=True)
 class WorktreeReclaim:
@@ -73,6 +137,9 @@ class WorktreeReclaim:
     #: （`job_workspace.ARCHIVE_REF_PREFIX` 底下）。worktree 模型、或 commit 已在
     #: 來源 repo 裡（成果已回收）時為 None。
     archived_ref: str | None = None
+    #: #658：本次回收採用的「不銷毀證據」模型（見模組 docstring）。帶進 action
+    #: record／診斷是刻意的——operator 看得到某一次回收**為什麼**沒有 preserve 封存。
+    evidence_model: str = EVIDENCE_PRESERVE
     detail: str | None = None
 
     @property
@@ -86,6 +153,7 @@ class WorktreeReclaim:
             "registry_entry_found": self.registry_entry_found,
             "registry_removed": self.registry_removed,
             "directory_removed": self.directory_removed,
+            "evidence_model": self.evidence_model,
         }
         if self.preserved_ref is not None:
             payload["preserved_ref"] = self.preserved_ref
@@ -305,6 +373,7 @@ def reclaim_worktree(
     git_runner: GitRunner | None = None,
     repo_root: str | Path | None = None,
     preserve_root: str | Path | None = None,
+    evidence_model: str = EVIDENCE_PRESERVE,
 ) -> WorktreeReclaim:
     """原子回收單一 build worktree（目錄 ＋ registry），並驗證後置條件。
 
@@ -315,8 +384,14 @@ def reclaim_worktree(
 
     任一條無法證實（含 registry 清單本身讀不到）一律回 ``failed``；呼叫端
     MUST NOT 在 ``failed`` 上回報 recovery 成功——這正是 #478 的核心缺陷。
+
+    ``evidence_model``（#658）決定「不銷毀證據」怎麼落實，兩個合法值的語意與
+    適用條件見模組 docstring。**不接受未知值**：那代表呼叫端沒有真的表態，而
+    靜默退回預設會讓一次本該 preserve 的回收看起來像是刻意跳過。
     """
 
+    if evidence_model not in _EVIDENCE_MODELS:
+        raise ValueError(f"unknown worktree reclaim evidence model: {evidence_model!r}")
     runner = resolve_git_runner(git_runner, repo_root=repo_root)
     target = Path(path)
     text = str(target)
@@ -324,12 +399,15 @@ def reclaim_worktree(
     registered, list_error = _registry_contains(runner, target)
     if list_error is not None:
         return WorktreeReclaim(
-            RECLAIM_FAILED, text, detail=f"worktree-registry-unreadable: {list_error}"
+            RECLAIM_FAILED,
+            text,
+            evidence_model=evidence_model,
+            detail=f"worktree-registry-unreadable: {list_error}",
         )
 
     exists = target.exists() or target.is_symlink()
     if not registered and not exists:
-        return WorktreeReclaim(RECLAIM_ABSENT, text)
+        return WorktreeReclaim(RECLAIM_ABSENT, text, evidence_model=evidence_model)
 
     # 安全閘（先於任何寫入／掃描）：registry 沒這筆、目錄本身也沒有
     # linked-worktree 標記，代表這個路徑不是（也不曾是）build worktree——
@@ -344,13 +422,22 @@ def reclaim_worktree(
         and target.is_dir()
         and not _looks_like_job_workspace(target)
     ):
-        return WorktreeReclaim(RECLAIM_FAILED, text, detail="worktree-path-not-a-worktree")
+        return WorktreeReclaim(
+            RECLAIM_FAILED,
+            text,
+            evidence_model=evidence_model,
+            detail="worktree-path-not-a-worktree",
+        )
 
     # #623：clone 模型下 `rmtree` 會連 object store 一起刪掉——worktree 模型下這些
     # commit 在共用 store 裡、branch 也還在主 repo，回收不銷毀任何東西。為了維持本
     # 模組契約的「不銷毀證據」，刪除前先把工作區 HEAD 拉進來源 repo 的封存命名空間
     # （已在來源 repo 裡的 commit 不重複封存）。封存本身是加分項，失敗不阻斷回收
     # ——回收失敗才是 #478／#601 的生產事故。
+    #
+    # #658：這一段在**兩種 evidence 模型下都跑**。`harvested` 模型下它正常是 no-op
+    # （commit 已在來源樹裡 ⇒ 直接回 None），但呼叫端的前提萬一不成立，它就是把那顆
+    # commit 救回來的安全網——正因為如此，`harvested` 略過的只有 preserve 那一段。
     archived_ref: str | None = None
     if exists and not target.is_symlink() and job_workspace.is_job_clone(target):
         # 來源 repo 優先取呼叫端給的值；沒給時取標記檔記錄的 provision 來源
@@ -371,7 +458,12 @@ def reclaim_worktree(
 
     preserved_ref: str | None = None
     preserved_files = 0
-    if exists and not target.is_symlink() and target.is_dir():
+    if (
+        evidence_model == EVIDENCE_PRESERVE
+        and exists
+        and not target.is_symlink()
+        and target.is_dir()
+    ):
         entries, dirty_error = _dirty_entries(runner, target)
         if dirty_error is not None:
             # gitdir 已壞（正是 #478 的殘留態）時 status 讀不到；此時目錄要嘛
@@ -396,6 +488,7 @@ def reclaim_worktree(
                     RECLAIM_FAILED,
                     text,
                     registry_entry_found=registered,
+                    evidence_model=evidence_model,
                     detail=(
                         "worktree-dirty-preserve-failed: "
                         f"{type(exc).__name__}: {str(exc)[:200]}"
@@ -419,6 +512,7 @@ def reclaim_worktree(
                 registry_entry_found=True,
                 preserved_ref=preserved_ref,
                 preserved_files=preserved_files,
+                evidence_model=evidence_model,
                 detail=f"worktree-registry-unreadable: {list_error}",
             )
         if still_registered:
@@ -428,6 +522,7 @@ def reclaim_worktree(
                 registry_entry_found=True,
                 preserved_ref=preserved_ref,
                 preserved_files=preserved_files,
+                evidence_model=evidence_model,
                 detail=(
                     "worktree-registry-entry-remains: "
                     f"{remove_error or 'git worktree remove reported success'}"
@@ -451,6 +546,7 @@ def reclaim_worktree(
                 registry_removed=registry_removed,
                 preserved_ref=preserved_ref,
                 preserved_files=preserved_files,
+                evidence_model=evidence_model,
                 detail=f"worktree-directory-remove-failed: {type(exc).__name__}: {str(exc)[:200]}",
             )
         directory_removed = True
@@ -463,6 +559,7 @@ def reclaim_worktree(
             registry_removed=registry_removed,
             preserved_ref=preserved_ref,
             preserved_files=preserved_files,
+            evidence_model=evidence_model,
             detail="worktree-directory-remains",
         )
 
@@ -475,6 +572,7 @@ def reclaim_worktree(
         preserved_ref=preserved_ref,
         preserved_files=preserved_files,
         archived_ref=archived_ref,
+        evidence_model=evidence_model,
     )
 
 
@@ -487,6 +585,7 @@ def reclaim_recorded_or_derived(
     git_runner: GitRunner | None = None,
     repo_root: str | Path | None = None,
     preserve_root: str | Path | None = None,
+    evidence_model: str = EVIDENCE_PRESERVE,
 ) -> WorktreeReclaim | None:
     """回收某個 slice 的 build 工作區——記錄有路徑就用它，沒有才反推。
 
@@ -520,6 +619,7 @@ def reclaim_recorded_or_derived(
         git_runner=git_runner,
         repo_root=repo_root,
         preserve_root=preserve_root,
+        evidence_model=evidence_model,
     )
     if not results:
         return None
@@ -538,6 +638,7 @@ def reclaim_worktrees(
     git_runner: GitRunner | None = None,
     repo_root: str | Path | None = None,
     preserve_root: str | Path | None = None,
+    evidence_model: str = EVIDENCE_PRESERVE,
 ) -> list[WorktreeReclaim]:
     """對多個 worktree 逐一回收（去重、保序）；不因單筆失敗而中止。"""
 
@@ -554,6 +655,7 @@ def reclaim_worktrees(
                 git_runner=git_runner,
                 repo_root=repo_root,
                 preserve_root=preserve_root,
+                evidence_model=evidence_model,
             )
         )
     return results

--- a/tests/test_immediate_worktree_reclaim_658.py
+++ b/tests/test_immediate_worktree_reclaim_658.py
@@ -1,0 +1,920 @@
+"""issue #658：build 卡被採信之後即時回收它的工作區。
+
+#648 把 canonical lane 的工作區改成 per-job，一個 run 因此會累積 N 棵約 35MB 的
+clone；#649／#653（ship 段自己的樹）與 #650／#659（verify／review 的 candidate 樹）
+把最後兩個下游消費端也搬走之後，**一張 build 卡被採信、`_harvest_build_candidate()`
+走完之後，它的工作區已經沒有任何獨佔資訊**。本檔把「即時回收」釘成四組不變式：
+
+1. **回收確實發生，且 run 仍走得完**：被採信的卡的工作區消失，後續卡照樣拿得到
+   base 與內容（交接走的是 #637 的 bundle ＋ spool，不是磁碟殘留）。
+2. **佔用不隨卡數線性成長**：任一時刻 pool 裡最多一棵 build 工作區。
+3. **fail-closed**：未被採信的工作區、pool 以外的路徑、認不出形狀的目錄、成果沒
+   回到來源樹的情形，一律**不回收**，且各自有具名理由。
+4. **重入**：`retry-card`（#601／#545）與 `abandon`（#613／#527）在新模型下不產生
+   新的死路。
+
+外加一組契約測試：`worktree_reclaim` 的兩種 evidence 模型——`preserve`（預設，
+#478 的語意逐字不變）與 `harvested`（#658 新增，只有已 harvest 的採信路徑能用）。
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from paulsha_cortex.coordinator import (
+    gc,
+    job_runner,
+    job_workspace,
+    manager,
+    seams,
+    terminal_contract,
+    work_actions,
+    worktree_reclaim,
+)
+from paulsha_cortex.coordinator.launcher import LaunchHandle
+from paulsha_cortex.coordinator.model_identities import IdentityRegistry
+from paulsha_cortex.coordinator.registry import JobRegistry
+from paulsha_cortex.coordinator.workflow import WorkflowStep
+
+from diagnostic_fixtures import fixture_needs_human_reason
+
+
+_REPO = "hamanpaul/paulsha-cortex"
+_WORK_ID = "658-immediate-reclaim"
+
+
+# ---------------------------------------------------------------------------
+# fixtures（形狀沿用 tests/test_canonical_per_job_workspace_648.py：真 git repo、
+# 真 `ScriptWorktreeCreator`、真 dispatch、真 bundle ＋ spool 交接）
+# ---------------------------------------------------------------------------
+
+
+def _git(cwd: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", "-C", str(cwd), *args], check=True, capture_output=True, text=True
+    ).stdout.strip()
+
+
+def _source_repo(root: Path) -> Path:
+    root.mkdir(parents=True, exist_ok=True)
+    subprocess.run(["git", "-C", str(root), "init", "-q", "-b", "main"], check=True)
+    _git(root, "config", "user.email", "manager@example.invalid")
+    _git(root, "config", "user.name", "Cortex Manager")
+    (root / "README.md").write_text("source\n", encoding="utf-8")
+    _git(root, "add", "README.md")
+    _git(root, "commit", "-qm", "init")
+    return root
+
+
+def _build_step(card: str, *, gate_result: str = "pending") -> WorkflowStep:
+    return WorkflowStep(
+        phase="build",
+        persona="builder",
+        card=card,
+        executor="copilot" if gate_result == "passed" else None,
+        model="gpt" if gate_result == "passed" else None,
+        domain="openai" if gate_result == "passed" else None,
+        inputs=(),
+        outputs=(),
+        commit_policy="required",
+        # `test_policy="none"` ⇒ `expected_gate_names_for_test_policy()` 是空集合，
+        # 空 ledger 即合法（#308）。本檔要驗的是回收，不是 gate 語意。
+        test_policy="none",
+        gate_result=gate_result,
+    )
+
+
+def _identities() -> IdentityRegistry:
+    return IdentityRegistry.from_rows(
+        [{
+            "executor": "copilot",
+            "model_id": "gpt",
+            "independence_domain": "openai",
+            "capabilities": ["build"],
+        }]
+    )
+
+
+class _RecordingLauncher:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, str]] = []
+
+    def as_commit_required(self) -> "_RecordingLauncher":
+        return self
+
+    def launch(self, *, slice_id: str, prompt: str, worktree: str, log_dir: str) -> LaunchHandle:
+        Path(log_dir).mkdir(parents=True, exist_ok=True)
+        self.calls.append({"slice_id": slice_id, "worktree": worktree})
+        return LaunchHandle(
+            executor="copilot",
+            model_id="gpt",
+            session_name=slice_id,
+            pid=100,
+            log_path=f"{log_dir}/{slice_id}.jsonl",
+        )
+
+
+def _run_with_cards(
+    registry: JobRegistry, *, workspace: Path, cards: tuple[str, ...]
+) -> Any:
+    return registry._manager_create_workflow_run(
+        work_id=_WORK_ID,
+        repo=_REPO,
+        claim_key="claim:v1:" + "1" * 64,
+        source_revision="2" * 64,
+        workspace_root=str(workspace),
+        combo="feature-oneshot",
+        current_phase="build",
+        steps=tuple(_build_step(card) for card in cards),
+        issue_refs=(f"{_REPO}#658",),
+        openspec_refs=(),
+        pr_refs=(),
+        attempts={"build": 1},
+        gate_status="running",
+    )
+
+
+def _dispatch(
+    registry: JobRegistry,
+    *,
+    run,
+    workspace: Path,
+    pool: Path,
+    coordinator_root: Path,
+    force_new_card: bool = False,
+) -> dict[str, object]:
+    creator = seams.ScriptWorktreeCreator(repo=workspace, wt_root=pool, base="main")
+    dispatcher = type(
+        "D",
+        (),
+        {"_registry": registry, "_worktree_creator": creator, "_git_runner": None},
+    )()
+    dispatched = manager.dispatch_workflow_card(
+        dispatcher,
+        run=run,
+        identities=_identities(),
+        launcher_factory=lambda _identity: _RecordingLauncher(),
+        coordinator_root=coordinator_root,
+        force_new_card=force_new_card,
+    )
+    assert dispatched is not None
+    return registry.get_job(str(dispatched["job_id"]))
+
+
+def _commit_in(clone: Path, *, filename: str) -> str:
+    (clone / filename).write_text("candidate\n", encoding="utf-8")
+    _git(clone, "add", filename)
+    _git(clone, "commit", "-qm", f"add {filename}")
+    return _git(clone, "rev-parse", "HEAD").lower()
+
+
+def _harvest_through_the_spool(
+    *, workspace: Path, clone: Path, branch: str, spool_key: str, coordinator_root: Path
+) -> str:
+    """完整跑一次 #637 的交接：builder 產 bundle → Manager 從那個檔 fetch。"""
+
+    bundle = job_workspace.prepare_commit_spool(
+        spool_key=spool_key, coordinator_root=coordinator_root
+    )
+    command = job_workspace.build_bundle_command(workspace=clone, bundle=bundle)
+    produced = subprocess.run(["bash", "-c", command], capture_output=True, text=True)
+    assert produced.returncode == 0, produced.stderr
+    return job_workspace.harvest_branch(
+        source_repo=workspace, bundle=bundle, branch=branch
+    )
+
+
+def _write_terminal(job: dict[str, object], *, run, candidate: str) -> None:
+    """寫 job 的終局 JSONL ＋ 空 gate ledger（`test_policy="none"` 的合法形狀）。"""
+
+    log = Path(str(job["log_path"]))
+    log.parent.mkdir(parents=True, exist_ok=True)
+    log.write_text(
+        json.dumps({
+            "schema_version": 1,
+            "kind": "workflow-card",
+            "status": "passed",
+            "run_id": run.run_id,
+            "card_id": job["workflow_card"],
+            "candidate": candidate,
+            "outputs": [],
+        }) + "\n",
+        encoding="utf-8",
+    )
+    ledger = terminal_contract.gate_ledger_path(log)
+    ledger.parent.mkdir(parents=True, exist_ok=True)
+    ledger.write_text(
+        json.dumps({
+            "schema_version": terminal_contract.GATE_LEDGER_SCHEMA_VERSION,
+            "kind": "workflow-gate-ledger",
+            "slice_id": log.stem,
+            "gates": [],
+        }),
+        encoding="utf-8",
+    )
+
+
+def _finish_card(
+    registry: JobRegistry,
+    *,
+    run,
+    job: dict[str, object],
+    workspace: Path,
+    coordinator_root: Path,
+    filename: str,
+    harvest: bool = True,
+) -> tuple[Any, str, Path]:
+    """跑完一張 build 卡的**正式**採信路徑，回傳 (run, candidate, 工作區路徑)。
+
+    真的 commit、真的 bundle ＋ spool 交接、真的 `terminalize_workflow_job()`、真的
+    `apply_workflow_action(action="advance")`——即時回收就掛在最後那一支裡面，測試
+    因此驗的是生產路徑，不是直接呼叫回收函式。
+    """
+
+    clone = Path(str(job["worktree"]))
+    candidate = _commit_in(clone, filename=filename)
+    if harvest:
+        _harvest_through_the_spool(
+            workspace=workspace,
+            clone=clone,
+            branch=str(job["branch"]),
+            spool_key=str(job["job_id"]),
+            coordinator_root=coordinator_root,
+        )
+    _write_terminal(job, run=run, candidate=candidate)
+    registry.update_headless_result(str(job["job_id"]), status="exited", exit_code=0)
+    terminal = manager.terminalize_workflow_job(
+        registry, job_id=str(job["job_id"]), coordinator_root=coordinator_root
+    )
+    manager.apply_workflow_action(
+        registry,
+        args={
+            "action": "advance",
+            "run_id": run.run_id,
+            "card_id": str(job["workflow_card"]),
+            "job_id": terminal["job_id"],
+            "current_phase": "build",
+        },
+        identity_registry=_identities(),
+        coordinator_root=coordinator_root,
+        trusted_terminal=True,
+    )
+    return registry.get_workflow_run(run.run_id), candidate, clone
+
+
+def _build_workspaces(pool: Path) -> list[Path]:
+    return sorted(job_workspace.list_clone_workspaces(pool))
+
+
+# ---------------------------------------------------------------------------
+# 不變式 1／2：回收確實發生、run 仍走得完、佔用不隨卡數成長
+# ---------------------------------------------------------------------------
+
+
+def test_trusted_build_card_workspace_is_reclaimed_and_the_run_keeps_going(
+    tmp_path: Path,
+) -> None:
+    """被採信的 build 卡的工作區當場消失，而後續卡照樣拿得到它的成果。
+
+    這是本票的全部價值。**兩件事必須同時成立**：回收真的發生（不是「總有一天由
+    `cortex work gc` 收」），以及回收之後這個 run 一個位元組都沒少——後續卡的 base
+    來自來源樹的 `refs/heads/<branch>`（#637 的 bundle ＋ append-only spool 交接），
+    與那棵被刪掉的樹無關。
+    """
+
+    workspace = _source_repo(tmp_path / "source")
+    pool = tmp_path / "pool"
+    coordinator_root = tmp_path / "coordinator"
+    registry = JobRegistry(state_path=tmp_path / "jobs.json")
+    run = _run_with_cards(
+        registry, workspace=workspace, cards=("worktree-isolation", "tdd-red")
+    )
+
+    job_one = _dispatch(
+        registry, run=run, workspace=workspace, pool=pool,
+        coordinator_root=coordinator_root,
+    )
+    branch = str(job_one["branch"])
+    run, candidate, first_clone = _finish_card(
+        registry, run=run, job=job_one, workspace=workspace,
+        coordinator_root=coordinator_root, filename="one.txt",
+    )
+
+    # 回收：目錄不在了，registry 也沒有殘留（clone 模型下本來就沒有 registry 記錄）。
+    assert not first_clone.exists(), "被採信的 build 卡的工作區應該當場被回收"
+    assert _build_workspaces(pool) == []
+    # 成果完好：來源樹的 branch 就是被採信的 candidate。
+    assert run.candidate_head == candidate
+    assert job_workspace.source_branch_head(workspace, branch) == candidate
+
+    # 後續卡照樣派得出去，且拿到的是帶著前一張卡成果的樹。
+    job_two = _dispatch(
+        registry, run=run, workspace=workspace, pool=pool,
+        coordinator_root=coordinator_root,
+    )
+    second_clone = Path(str(job_two["worktree"]))
+    assert second_clone != first_clone
+    assert _git(second_clone, "rev-parse", "HEAD").lower() == candidate
+    assert (second_clone / "one.txt").is_file()
+    assert _git(second_clone, "rev-parse", job_workspace.BASE_REF).lower() == candidate
+
+
+def test_workspace_footprint_does_not_grow_with_the_number_of_build_cards(
+    tmp_path: Path,
+) -> None:
+    """三張 build 卡跑完，pool 裡任一時刻最多一棵工作區、結束時零棵。
+
+    #648 之前 canonical lane 一個 run 一棵樹；per-job 之後是 N 棵（每棵約 35MB），
+    #658 的驗收條款要求佔用**不隨 build 卡數線性成長**。這條用真的 per-job clone
+    量測，不是對常數斷言。
+    """
+
+    workspace = _source_repo(tmp_path / "source")
+    pool = tmp_path / "pool"
+    coordinator_root = tmp_path / "coordinator"
+    registry = JobRegistry(state_path=tmp_path / "jobs.json")
+    cards = ("worktree-isolation", "tdd-red", "subagent-build")
+    run = _run_with_cards(registry, workspace=workspace, cards=cards)
+
+    seen: list[Path] = []
+    high_water = 0
+    for index, card in enumerate(cards):
+        job = _dispatch(
+            registry, run=run, workspace=workspace, pool=pool,
+            coordinator_root=coordinator_root,
+        )
+        assert job["workflow_card"] == card
+        high_water = max(high_water, len(_build_workspaces(pool)))
+        run, _candidate, clone = _finish_card(
+            registry, run=run, job=job, workspace=workspace,
+            coordinator_root=coordinator_root, filename=f"card-{index}.txt",
+        )
+        seen.append(clone)
+
+    assert high_water == 1, "同時只該有一棵 build 工作區（正在跑的那一張卡）"
+    assert len(set(seen)) == len(cards), "每張卡仍各自 provision 自己的樹（#648）"
+    assert _build_workspaces(pool) == [], "最後一張卡被採信後 pool 應該是空的"
+    # 三張卡的成果全都在來源樹裡（回收沒有銷毀任何被採信的東西）。
+    assert run.candidate_head is not None
+    tree = _git(workspace, "ls-tree", "--name-only", str(run.candidate_head))
+    assert {f"card-{index}.txt" for index in range(len(cards))} <= set(tree.splitlines())
+
+
+# ---------------------------------------------------------------------------
+# 不變式 3：fail-closed——不該收的一律不收，且各有具名理由
+# ---------------------------------------------------------------------------
+
+
+def test_untrusted_build_workspace_is_never_reclaimed(tmp_path: Path) -> None:
+    """卡沒被採信 ⇒ 工作區一個位元組都不動；`retry-card` 重派之後殘留仍在。
+
+    #601 的生產現場是「重派需要前一次失敗嘗試的殘留被回收」。即時回收**刻意不碰**
+    那條路徑：它只在採信之後跑，而失敗的 job 從來沒有被採信過。把這條釘住，是為了
+    讓「即時回收」不會偷偷變成「job 退出就收」——那正是 #658 紅線點名的形狀（被回收
+    的對象自己決定回收），而且會把 #601 重派要用的東西銷毀掉。
+    """
+
+    workspace = _source_repo(tmp_path / "source")
+    pool = tmp_path / "pool"
+    coordinator_root = tmp_path / "coordinator"
+    registry = JobRegistry(state_path=tmp_path / "jobs.json")
+    run = _run_with_cards(
+        registry, workspace=workspace, cards=("worktree-isolation", "tdd-red")
+    )
+
+    job_one = _dispatch(
+        registry, run=run, workspace=workspace, pool=pool,
+        coordinator_root=coordinator_root,
+    )
+    run, _candidate, first_clone = _finish_card(
+        registry, run=run, job=job_one, workspace=workspace,
+        coordinator_root=coordinator_root, filename="one.txt",
+    )
+    assert not first_clone.exists()
+
+    # 卡 2 首派失敗：exit_code=1，evidence 綁不上 ⇒ 從未被採信。
+    job_two = _dispatch(
+        registry, run=run, workspace=workspace, pool=pool,
+        coordinator_root=coordinator_root,
+    )
+    failed_clone = Path(str(job_two["worktree"]))
+    (failed_clone / "scratch.txt").write_text("half-done\n", encoding="utf-8")
+    registry.update_headless_result(str(job_two["job_id"]), status="exited", exit_code=1)
+    assert failed_clone.is_dir()
+    assert (failed_clone / "scratch.txt").is_file()
+
+    # `retry-card` 走真的原子重置 ＋ 真的重派。
+    registry._manager_update_workflow_run(
+        run.run_id,
+        facets=("needs_human",),
+        gate_status="running",
+        needs_human_reason=fixture_needs_human_reason(),
+    )
+    run = registry._manager_reset_workflow_for_retry_card(
+        run.run_id, expected_run_id=run.run_id, card="tdd-red"
+    )
+    job_retry = _dispatch(
+        registry, run=run, workspace=workspace, pool=pool,
+        coordinator_root=coordinator_root, force_new_card=True,
+    )
+    retry_clone = Path(str(job_retry["worktree"]))
+
+    assert retry_clone != failed_clone, "#601：重派拿到自己的目錄（per-job 之後撞名消失）"
+    assert failed_clone.is_dir(), "未採信的工作區不得被即時回收"
+    assert (failed_clone / "scratch.txt").read_text(encoding="utf-8") == "half-done\n"
+    # 重派的樹仍以最後一張**被採信**的 candidate 為 base。
+    assert _git(retry_clone, "rev-parse", "HEAD").lower() == run.candidate_head
+
+
+def test_reclaim_refuses_a_workspace_whose_name_is_not_the_job_segment(tmp_path: Path) -> None:
+    """`job.worktree` 指到來源樹（#549 的資料語意地雷）時**拒絕回收**。
+
+    #549 實測 `job.worktree` 會等於 run 的 `workspace_root`——那是 Manager 的
+    durable state，遞迴刪除的爆炸半徑不可接受。判準刻意是「pool 的直接子項」而不是
+    黑名單：provisioning 的唯一推導點 `job_workspace.workspace_path()` 產出的就是這
+    個形狀，來源樹永遠不可能滿足它。
+    """
+
+    workspace = _source_repo(tmp_path / "source")
+    registry = JobRegistry(state_path=tmp_path / "jobs.json")
+    run = _run_with_cards(registry, workspace=workspace, cards=("worktree-isolation",))
+    candidate = _git(workspace, "rev-parse", "HEAD").lower()
+    job = {
+        "job_id": "wf-x-1",
+        "workflow_card": "worktree-isolation",
+        "branch": "feature/658",
+        "worktree": str(workspace),
+    }
+
+    target, refusal = manager._trusted_build_workspace_target(
+        job, run=run, candidate=candidate
+    )
+
+    assert target is None
+    assert refusal == "workspace-name-not-derived-from-job-id"
+    assert manager._reclaim_trusted_build_workspace(
+        job, run=run, candidate=candidate
+    ) is None
+    assert (workspace / "README.md").is_file(), "來源樹一個位元組都不得被動到"
+
+
+def test_reclaim_refuses_when_the_candidate_never_reached_the_source_tree(
+    tmp_path: Path,
+) -> None:
+    """成果沒回到來源樹 ⇒ 不回收（`harvested` evidence 模型的前提當場複驗）。
+
+    `EVIDENCE_HARVESTED` 之所以可以不做 preserve 封存，全部的正當性就在「每一樣受
+    治理的東西都已經有第二份副本」。這裡把交接刻意跳過，回收必須拒絕——否則那顆
+    commit 會隨 clone 的 object store 一起消失，正是 #478 契約要防的事。
+    """
+
+    workspace = _source_repo(tmp_path / "source")
+    pool = tmp_path / "pool"
+    coordinator_root = tmp_path / "coordinator"
+    registry = JobRegistry(state_path=tmp_path / "jobs.json")
+    run = _run_with_cards(registry, workspace=workspace, cards=("worktree-isolation",))
+
+    job = _dispatch(
+        registry, run=run, workspace=workspace, pool=pool,
+        coordinator_root=coordinator_root,
+    )
+    clone = Path(str(job["worktree"]))
+    candidate = _commit_in(clone, filename="one.txt")  # 刻意不 harvest
+
+    target, refusal = manager._trusted_build_workspace_target(
+        job, run=run, candidate=candidate
+    )
+
+    assert target is None
+    assert refusal == "candidate-not-in-source-repo"
+    assert clone.is_dir()
+    assert _git(clone, "rev-parse", "HEAD").lower() == candidate
+
+
+def test_reclaim_refuses_a_directory_without_the_job_workspace_marker(
+    tmp_path: Path,
+) -> None:
+    """pool 底下但認不出形狀的目錄一律不刪（#646 的紅線）。
+
+    三分部署下 Manager 讀不進 `0700` 的 clone，`is_job_clone()` 因此回 False——這條
+    同時是那個部署形態的行為規格：得到一個具名的 skip 理由，而不是一次注定失敗的
+    `rmtree`。
+    """
+
+    workspace = _source_repo(tmp_path / "source")
+    pool = tmp_path / "pool"
+    registry = JobRegistry(state_path=tmp_path / "jobs.json")
+    run = _run_with_cards(registry, workspace=workspace, cards=("worktree-isolation",))
+    # 目錄名刻意就是那個 job_id 的片段——這樣通過第 2 條之後，擋下它的必然是
+    # 標記檔那一條（#646 的紅線），而不是名字。
+    stranger = job_workspace.workspace_path(pool, "wf-x-1")
+    stranger.mkdir(parents=True)
+    (stranger / "keep-me.txt").write_text("not ours\n", encoding="utf-8")
+
+    target, refusal = manager._trusted_build_workspace_target(
+        {
+            "job_id": "wf-x-1",
+            "workflow_card": "worktree-isolation",
+            "branch": "feature/658",
+            "worktree": str(stranger),
+        },
+        run=run,
+        candidate=_git(workspace, "rev-parse", "HEAD").lower(),
+    )
+
+    assert target is None
+    assert refusal == "workspace-not-a-job-clone"
+    assert (stranger / "keep-me.txt").is_file()
+
+
+def test_reclaim_failure_does_not_block_acceptance(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """回收失敗時採信照樣成立，且留下可操作的診斷。
+
+    採信在回收之前就已經 durable。#658 驗收條款：「回收失敗**不得**擋住採信——但
+    必須留下可操作的診斷」。
+    """
+
+    workspace = _source_repo(tmp_path / "source")
+    pool = tmp_path / "pool"
+    coordinator_root = tmp_path / "coordinator"
+    registry = JobRegistry(state_path=tmp_path / "jobs.json")
+    run = _run_with_cards(registry, workspace=workspace, cards=("worktree-isolation",))
+
+    job = _dispatch(
+        registry, run=run, workspace=workspace, pool=pool,
+        coordinator_root=coordinator_root,
+    )
+    clone = Path(str(job["worktree"]))
+
+    def _explode(*_args: object, **_kwargs: object):
+        raise OSError("simulated reclaim failure")
+
+    monkeypatch.setattr(worktree_reclaim, "reclaim_worktree", _explode)
+
+    run, candidate, _clone = _finish_card(
+        registry, run=run, job=job, workspace=workspace,
+        coordinator_root=coordinator_root, filename="one.txt",
+    )
+
+    assert run.candidate_head == candidate
+    assert next(
+        step for step in run.steps if step.card == "worktree-isolation"
+    ).gate_result == "passed"
+    assert "needs_human" not in run.facets
+    assert clone.is_dir(), "回收失敗時工作區留著（交給 `cortex work gc`），不是半刪"
+
+
+def test_reclaim_outcome_reaches_the_operator_log(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """成功與拒絕都寫進結構化 log——那是 operator 唯一的稽核面。"""
+
+    workspace = _source_repo(tmp_path / "source")
+    pool = tmp_path / "pool"
+    coordinator_root = tmp_path / "coordinator"
+    registry = JobRegistry(state_path=tmp_path / "jobs.json")
+    run = _run_with_cards(registry, workspace=workspace, cards=("worktree-isolation",))
+    job = _dispatch(
+        registry, run=run, workspace=workspace, pool=pool,
+        coordinator_root=coordinator_root,
+    )
+
+    with caplog.at_level("INFO", logger="paulsha_cortex.coordinator.manager"):
+        run, _candidate, _clone = _finish_card(
+            registry, run=run, job=job, workspace=workspace,
+            coordinator_root=coordinator_root, filename="one.txt",
+        )
+        text = caplog.text
+    assert f"{manager.WORKFLOW_BUILD_WORKSPACE_RECLAIM_EVENT}-reclaimed" in text
+
+    caplog.clear()
+    with caplog.at_level("INFO", logger="paulsha_cortex.coordinator.manager"):
+        manager._reclaim_trusted_build_workspace(
+            {"job_id": "x", "workflow_card": "c", "branch": "b", "worktree": str(workspace)},
+            run=run,
+            candidate=str(run.candidate_head),
+        )
+        text = caplog.text
+    assert f"{manager.WORKFLOW_BUILD_WORKSPACE_RECLAIM_EVENT}-skipped" in text
+    assert "workspace-name-not-derived-from-job-id" in text
+
+
+# ---------------------------------------------------------------------------
+# 不變式 4：abandon（#613／#527）的重入
+# ---------------------------------------------------------------------------
+
+
+def test_abandon_reclaim_is_a_no_op_after_immediate_reclaim(tmp_path: Path) -> None:
+    """abandon 的工作區回收在即時回收之後回 `absent`——不是 `failed`。
+
+    `work_actions._reclaim_abandoned_build_worktrees()` 掃的是這個 run 名下每一列
+    job 記錄的 `worktree`。即時回收之後那些路徑已經不存在，`reclaim_worktree()` 的
+    「registry 沒這筆、目錄也不在」判定為 `absent`（成功），因此 abandon 不會因為
+    「東西已經被收掉了」而落一堆 failed 診斷——那正是 #658 要避免的新死路。
+
+    **branch 仍留在來源樹上**：那是 #613 的範圍，即時回收一個 branch 名都沒碰。
+    """
+
+    workspace = _source_repo(tmp_path / "source")
+    pool = tmp_path / "pool"
+    coordinator_root = tmp_path / "coordinator"
+    state_path = tmp_path / "jobs.json"
+    registry = JobRegistry(state_path=state_path)
+    run = _run_with_cards(
+        registry, workspace=workspace, cards=("worktree-isolation", "tdd-red")
+    )
+
+    job_one = _dispatch(
+        registry, run=run, workspace=workspace, pool=pool,
+        coordinator_root=coordinator_root,
+    )
+    branch = str(job_one["branch"])
+    run, candidate, first_clone = _finish_card(
+        registry, run=run, job=job_one, workspace=workspace,
+        coordinator_root=coordinator_root, filename="one.txt",
+    )
+    job_two = _dispatch(
+        registry, run=run, workspace=workspace, pool=pool,
+        coordinator_root=coordinator_root,
+    )
+    live_clone = Path(str(job_two["worktree"]))
+    assert not first_clone.exists() and live_clone.is_dir()
+
+    targets = [
+        str(row["worktree"])
+        for row in registry.list_jobs()
+        if row.get("workflow_run_id") == run.run_id and row.get("worktree")
+    ]
+    results = worktree_reclaim.reclaim_worktrees(
+        targets, repo_root=workspace, preserve_root=tmp_path / "evidence"
+    )
+
+    by_path = {result.path: result for result in results}
+    assert by_path[str(first_clone)].status == worktree_reclaim.RECLAIM_ABSENT
+    assert all(result.ok for result in results), [r.detail for r in results if not r.ok]
+    assert not live_clone.exists(), "abandon 仍要收掉還活著的那一棵"
+    # 走完整條 abandon 掛點也不得拋（best-effort 契約）。
+    work_actions._reclaim_abandoned_build_worktrees(
+        run, registry, state_path=state_path
+    )
+    # #613：branch 與它承載的 commit 原封不動——回收 branch 不在本票範圍。
+    assert job_workspace.source_branch_head(workspace, branch) == candidate
+
+
+def test_gc_still_protects_the_delivery_branch_when_no_workspace_is_left(
+    tmp_path: Path,
+) -> None:
+    """所有 build 工作區被即時回收之後，`cortex work gc` 仍不會刪掉交付 branch。
+
+    `gc` 的 branch 保護有兩條來源：掛在 keep worktree 上（`protected_branches`），
+    以及 merge 判定。即時回收把第一條抽掉了——這條確認第二條仍然頂得住：run 還在飛，
+    branch 未 merge 進 default branch ⇒ `keep`。少了它，一次不巧的 `gc --apply`
+    會在 run 中途刪掉整條交付線。
+    """
+
+    workspace = _source_repo(tmp_path / "source")
+    pool = tmp_path / "pool"
+    coordinator_root = tmp_path / "coordinator"
+    registry = JobRegistry(state_path=tmp_path / "jobs.json")
+    run = _run_with_cards(registry, workspace=workspace, cards=("worktree-isolation",))
+
+    job = _dispatch(
+        registry, run=run, workspace=workspace, pool=pool,
+        coordinator_root=coordinator_root,
+    )
+    branch = str(job["branch"])
+    run, candidate, clone = _finish_card(
+        registry, run=run, job=job, workspace=workspace,
+        coordinator_root=coordinator_root, filename="one.txt",
+    )
+    assert not clone.exists()
+
+    artifacts = gc.scan(workspace, worktree_root=pool)
+
+    assert [item for item in artifacts if item.kind == "worktree"] == []
+    rows = [item for item in artifacts if item.kind == "branch" and item.branch == branch]
+    assert rows and all(item.action == gc.ACTION_KEEP for item in rows), rows
+    assert all(item.reason == gc.REASON_UNMERGED_CONTENT for item in rows), rows
+    assert job_workspace.source_branch_head(workspace, branch) == candidate
+
+
+# ---------------------------------------------------------------------------
+# `worktree_reclaim` 的 evidence 模型契約（#658 改的那一條）
+# ---------------------------------------------------------------------------
+
+
+def _standalone_clone(tmp_path: Path) -> tuple[Path, Path]:
+    """一棵真的 per-job clone（走 provisioning 的唯一推導點），回傳 (來源樹, clone)。"""
+
+    workspace = _source_repo(tmp_path / "source")
+    pool = tmp_path / "pool"
+    creator = seams.ScriptWorktreeCreator(repo=workspace, wt_root=pool, base="main")
+    clone = Path(creator.create("feature/658-x", job_id="wf-abc-card-1"))
+    return workspace, clone
+
+
+def test_preserve_model_is_unchanged_for_untrusted_reclaim(tmp_path: Path) -> None:
+    """預設模型仍逐字是 #478 的語意：未提交／未追蹤內容先封存再刪。
+
+    #658 只**新增**一個具名模型，不改預設。`recover-pre-candidate`／`abandon`／
+    #601 的殘留回收全部沿用預設，因此 #478 的資料遺失回報仍受同一條保護。
+    """
+
+    workspace, clone = _standalone_clone(tmp_path)
+    (clone / "untracked.txt").write_text("operator work\n", encoding="utf-8")
+    preserve_root = tmp_path / "evidence"
+
+    result = worktree_reclaim.reclaim_worktree(
+        clone, repo_root=workspace, preserve_root=preserve_root
+    )
+
+    assert result.status == worktree_reclaim.RECLAIM_RECLAIMED
+    assert result.evidence_model == worktree_reclaim.EVIDENCE_PRESERVE
+    assert result.preserved_ref is not None and result.preserved_files == 1
+    preserved = Path(result.preserved_ref) / "untracked.txt"
+    assert preserved.read_text(encoding="utf-8") == "operator work\n"
+    assert not clone.exists()
+    assert result.to_dict()["evidence_model"] == worktree_reclaim.EVIDENCE_PRESERVE
+
+
+def test_harvested_model_skips_preserve_but_keeps_the_head_archive_fuse(
+    tmp_path: Path,
+) -> None:
+    """`harvested` 模型不做 preserve 封存，但 HEAD 封存**照樣跑**。
+
+    這是 #658 對契約的實際改動與它的安全網：preserve 被放棄（論證見
+    `worktree_reclaim` 模組 docstring），而 `archive_workspace_head()` 兩種模型下
+    都跑——呼叫端的前提萬一不成立（commit 沒進來源樹），那顆 commit 仍救得回來。
+    這裡刻意**不** harvest，就是為了讓保險絲真的動作一次。
+    """
+
+    workspace, clone = _standalone_clone(tmp_path)
+    (clone / "scratch.txt").write_text("model scratch\n", encoding="utf-8")
+    _git(clone, "add", "scratch.txt")
+    _git(clone, "commit", "-qm", "scratch")
+    head = _git(clone, "rev-parse", "HEAD").lower()
+    (clone / "untracked.txt").write_text("untracked\n", encoding="utf-8")
+    preserve_root = tmp_path / "evidence"
+
+    result = worktree_reclaim.reclaim_worktree(
+        clone,
+        repo_root=workspace,
+        preserve_root=preserve_root,
+        evidence_model=worktree_reclaim.EVIDENCE_HARVESTED,
+    )
+
+    assert result.status == worktree_reclaim.RECLAIM_RECLAIMED
+    assert result.evidence_model == worktree_reclaim.EVIDENCE_HARVESTED
+    assert result.preserved_ref is None and result.preserved_files == 0
+    assert not (preserve_root / "worktree-reclaim").exists()
+    assert not clone.exists()
+    # 保險絲：commit 不在來源樹時被拉進封存命名空間，沒有被 `rmtree` 一起銷毀。
+    assert result.archived_ref is not None
+    assert result.archived_ref.startswith(job_workspace.ARCHIVE_REF_PREFIX)
+    assert _git(workspace, "rev-parse", result.archived_ref).lower() == head
+
+
+def test_unknown_evidence_model_is_rejected(tmp_path: Path) -> None:
+    """未知的 evidence 模型一律 raise——靜默退回預設會掩蓋「呼叫端沒表態」。"""
+
+    workspace, clone = _standalone_clone(tmp_path)
+
+    with pytest.raises(ValueError, match="unknown worktree reclaim evidence model"):
+        worktree_reclaim.reclaim_worktree(
+            clone, repo_root=workspace, evidence_model="best-effort"
+        )
+    assert clone.is_dir(), "被拒絕的呼叫不得有任何 side effect"
+
+
+# ---------------------------------------------------------------------------
+# 突變驗證的對照面：把回收拿掉，上面兩條不變式必須轉紅
+# ---------------------------------------------------------------------------
+
+
+def test_without_the_reclaim_call_the_pool_grows_with_every_card(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """把即時回收停掉（模擬 #658 之前），pool 就會隨卡數成長。
+
+    這條是上面兩條不變式的**對照**：沒有它，那兩條有可能因為「工作區從來沒被建出
+    來」之類的原因假通過。
+    """
+
+    monkeypatch.setattr(
+        manager, "_reclaim_trusted_build_workspace", lambda *_a, **_k: None
+    )
+    workspace = _source_repo(tmp_path / "source")
+    pool = tmp_path / "pool"
+    coordinator_root = tmp_path / "coordinator"
+    registry = JobRegistry(state_path=tmp_path / "jobs.json")
+    cards = ("worktree-isolation", "tdd-red")
+    run = _run_with_cards(registry, workspace=workspace, cards=cards)
+
+    for index, _card in enumerate(cards):
+        job = _dispatch(
+            registry, run=run, workspace=workspace, pool=pool,
+            coordinator_root=coordinator_root,
+        )
+        run, _candidate, _clone = _finish_card(
+            registry, run=run, job=job, workspace=workspace,
+            coordinator_root=coordinator_root, filename=f"card-{index}.txt",
+        )
+
+    assert len(_build_workspaces(pool)) == len(cards)
+
+
+# ---------------------------------------------------------------------------
+# OS 層語意：單 UID 測不到，明確 skip（#638／#657 的教訓）
+# ---------------------------------------------------------------------------
+
+
+def test_unreadable_workspace_yields_a_named_refusal_not_a_doomed_rmtree(
+    tmp_path: Path,
+) -> None:
+    """工作區讀不進去時得到具名的拒絕理由，而不是一次注定失敗的 `rmtree`。
+
+    這是三分部署的**可測代理**：那裡的 clone 是 `0700 <job 帳號>`，Manager 連
+    `stat` 標記檔都會拿到 `PermissionError`。`chmod 000` 在同一個 UID 上重現的正是
+    「進不去這棵樹」這個形狀（#653／#659 的不變式測試用的是同一招）。
+
+    **它證得了什麼、證不了什麼**：證得了本函式在讀不進去時的**處置**（不刪、具名
+    理由、採信不受影響）；證不了「別的帳號擁有的 `0700` 樹刪不掉」——那條見下一條
+    測試的 skip 理由。
+    """
+
+    if os.geteuid() == 0:
+        pytest.skip("以 root 執行時 DAC 不生效，`chmod 000` 攔不住任何東西")
+
+    workspace = _source_repo(tmp_path / "source")
+    pool = tmp_path / "pool"
+    coordinator_root = tmp_path / "coordinator"
+    registry = JobRegistry(state_path=tmp_path / "jobs.json")
+    run = _run_with_cards(registry, workspace=workspace, cards=("worktree-isolation",))
+    job = _dispatch(
+        registry, run=run, workspace=workspace, pool=pool,
+        coordinator_root=coordinator_root,
+    )
+    clone = Path(str(job["worktree"]))
+    candidate = _commit_in(clone, filename="one.txt")
+    _harvest_through_the_spool(
+        workspace=workspace, clone=clone, branch=str(job["branch"]),
+        spool_key=str(job["job_id"]), coordinator_root=coordinator_root,
+    )
+
+    clone.chmod(0o000)
+    try:
+        target, refusal = manager._trusted_build_workspace_target(
+            job, run=run, candidate=candidate
+        )
+        assert manager._reclaim_trusted_build_workspace(
+            job, run=run, candidate=candidate
+        ) is None
+    finally:
+        clone.chmod(0o700)
+
+    assert target is None
+    assert refusal == "workspace-not-a-job-clone"
+    assert clone.is_dir(), "讀不進去就不動它——半刪比留著更糟"
+
+
+def test_multi_uid_ownership_semantics_are_not_reachable_from_a_test_process() -> None:
+    """三分／四分部署下「誰回收得掉那棵樹」——**任何**測試進程都驗不到，明確 skip。
+
+    #658 的核心答案是：**回收身分 ＝ 採信身分，不新增任何身分**。抵達即時回收必須
+    先走完 `_verify_exact_candidate()`，而它以 Manager 身分對**同一棵樹**跑
+    `git -C <worktree> rev-parse HEAD`；因此回收要的授權面是採信路徑已經在用的
+    那一份，本票沒有、也不需要擴張任何 ACL。
+
+    要在測試裡驗證這條，必須同時成立三件事：
+
+    1. 真的存在 `cortex-manager` 與 `cortex-builder` 兩個帳號；
+    2. 工作區真的是 `0700 cortex-builder`（要 `chown` 給別的 owner 需要 root，
+       而「cortex 任何元件永不具 root」是既有裁決 ⇒ 產品程式碼永遠做不到這一步）；
+    3. 執行回收的進程真的是 `cortex-manager`（＝**不是**跑測試的這個 UID）。
+
+    第 2、3 條在單一測試進程裡結構性不可能：pytest 只有一個 UID，而它若真的是
+    root，第 (1)(2) 條的斷言又全部失去意義（DAC 對 root 不生效）。任何「用
+    `chmod 000` 模擬」的寫法驗到的是 owner 的例外語意，不是跨帳號語意——上一條
+    測試明講了它證得了什麼、證不了什麼。
+
+    比照 #638／#657 的教訓：**明確 skip 並說清楚缺什麼**，不寫一條看起來綠、
+    實際上與目標部署無關的斷言。實機稽核步驟寫在
+    `docs/superpowers/runbooks/trust-root-phase2b-setup.md`（第 2 步稽核 5c）。
+    """
+
+    pytest.skip(
+        "跨帳號擁有權語意需要 root 建置 ＋ 以另一個 UID 執行回收，"
+        "單一 pytest 進程結構性做不到（見本函式 docstring 的三條）；"
+        f"本機 euid={os.geteuid()}、"
+        f"cortex-builder 存在={job_runner._account_exists('cortex-builder')}、"
+        f"cortex-manager 存在={job_runner._account_exists('cortex-manager')}。"
+        "回收邏輯本身已由本檔其餘測試在真 git repo ＋ 真 per-job clone 上端到端覆蓋"
+    )


### PR DESCRIPTION
Closes #658

## 查證（票上第一步；結論修正了票上兩處前提）

### 修正 1：preserve 那一步在降權下**不是**失敗點

票上寫「Manager 讀不進 builder 的 `0700` clone ⇒ 封存那一步必然失敗」。實際查證
`reclaim_worktree()`：`_dirty_entries()` 讀不到時是**記 warning 後繼續**（`elif entries:`
不成立 ⇒ 不封存），真正 fail-closed 的是後面的 `rmtree`。結論（Manager 收不掉那棵樹）
不變，但失敗點不在票上寫的那一步——這件事直接影響修法（要改的是**要不要 preserve**，
不是**preserve 會不會炸**）。

### 修正 2：降權部署下今天**不存在**「被採信卻沒回收的工作區」

`_verify_build_candidate_transition()` → `_verify_exact_candidate()` 對 build job 跑的是
`git -C <job 的工作區> cat-file` 與 `rev-parse HEAD`。#641 收掉 `repo-worktree` 的 `rX`
之後，三分部署下這一步**先** fail-closed（`_raise_if_worktree_read_blocked()`，訊息明文
`blocked on #629`）。**沒有被採信的 build 卡，就沒有要回收的工作區** ⇒ 那個部署形態下
本票的程式碼連跑都跑不到，因此**不必、也不得為它發明新的執行身分**。

---

## 問題 1：誰以什麼身分回收 ⇒ **Manager，且不新增任何身分、不新增任何授權**

上面的修正 2 反過來就是答案：

> 抵達即時回收的**必要條件**是 `_verify_exact_candidate()` 已經以 Manager 身分對
> **同一棵樹**成功跑過 `git -C`。

⇒ **「Manager 進得去那棵樹」不是本票新增的假設，而是採信本身既有的前提**；回收要的權限
就是採信路徑已經在用的那一份。稽核 5b 的「job 工作樹底下零 `setfacl`」逐字仍然成立。

票上四個候選逐一被否掉：

| 候選 | 為什麼不選 |
|---|---|
| **(a) job wrapper 自刪** | 紅線（model 自證的變形）。更根本的是 job **不知道自己有沒有被採信**——採信在它退出之後由 Manager 判定；自刪必然把**未採信**路徑的殘留一起銷毀，而那正是 #601 重派要用的東西 |
| **(b) #629 的第三執行身分（`cortex-gate`）** | 登記表給 `GATE` 對 `repo-worktree` 的是 `rX` **無 `w`**。授它 `w` ＝ 讓一個專門跑不受信任程式碼的帳號能改 builder **尚未 harvest** 的交付樹，與 #629 自己的論證方向相反 |
| **(c) `ExecStopPost=`／`RuntimeDirectory`** | 時機錯：unit 停止是 **job 退出**、不是**被採信**（失敗形態同 (a)）；且要跑得動 `rm -rf` 需要 `+` 前綴＝**root 執行**，與「cortex 任何元件永不具 root」這條既有裁決相斥 |
| **(d) 只在 `direct` 即時收，降權交給 `cortex work gc`** | #634 的反模式（依 `PSC_JOB_RUNNER` 分支）。真正決定回收成不成立的是**磁碟上的 owner**，不是旗標——旗標分支會在「旗標說降權、磁碟其實還是 Manager-owned」與其反面各錯一次 |

改採**能力判定**：前置條件不成立 ⇒ 具名 skip；試了收不掉 ⇒ `failed` ＋ 診斷。**兩者都
不擋採信**（採信在呼叫回收之前就已 durable）。

**寫死的依賴**：#629 把 candidate 驗證搬到 gate 執行身分之後，「誰讀得到那棵樹」會跟著
改變 ⇒ **回收身分必須與 candidate 驗證身分一起重新裁決，不得單獨為回收開一條授權**。
這句話寫在 `_reclaim_trusted_build_workspace()` 的 docstring 與 runbook 稽核 5c，不是留給
下一個人重新推導。

---

## 問題 2：封存還剩什麼要保 ⇒ **契約改了**（票上要求「明確論證並改契約，不是默默跳過」）

`worktree_reclaim` 的「不銷毀證據」從一種做法拆成**兩個具名模型**，呼叫端必須表態
（未知值一律 `raise`，**不靜默退回預設**）：

- **`EVIDENCE_PRESERVE`（預設，#478 語意逐字不變）**——所有**未採信**路徑：
  `recover-pre-candidate`、`abandon` 的回收、#601 的殘留。共同性質是**成果沒有被
  harvest 過**，工作區裡的 commit 只存在於它自己的 object store。
- **`EVIDENCE_HARVESTED`（新增）**——呼叫端必須先證明「每一樣受治理的東西都已經有第二份
  副本，且那份副本在 Manager-owned 的樹裡」。

### 逐條盤點（放棄 preserve 的論證）

| 工作區裡的東西 | 第二份副本 |
|---|---|
| 被採信的 commit | 來源樹的 `refs/heads/<branch>`（#637 bundle ＋ spool；`_harvest_build_candidate()` 強制 branch head 恰等於 candidate） |
| bundle 本身 | Manager-owned 的 `commit-spool`（封口後仍在） |
| gate ledger | `gate-ledger-spool` → Manager 重寫的 `gate-ledger`（#628／#629） |
| exit sentinel | Manager 自己寫（#604／#628） |
| JSONL log | `log_dir`（Manager-owned），本來就不在工作區裡 |
| 宣告的 outputs | 採信當下已由 `_read_job_workflow_evidence()` 逐檔 hash 進 immutable canonical evidence |
| canonical report | #650／#659 之後發佈在 reviewer 的 candidate 樹，不在 build 卡的工作區 |

**剩下的只有「模型做了、但既沒 commit、也沒宣告為 output」的未追蹤殘渣。** 它在採信面上
的地位是**零**——#540 採信的是 candidate commit，未提交內容從定義上不在採信面內；#628
更明講被驗方不得產生自己的驗收證據，而這些檔案正是 builder 完全掌控的內容。把它們複製
進 Manager-owned 的 `evidence/`，實際效果是**把不受信任的內容搬進受信任的樹**，並且把
本次要回收的位元組原地搬個家（一張卡可能是 512 檔 × 4MB）——與本票要解的問題是同一個
換個目錄。

**#478 的現場不適用**：那次遺失的是 operator 自己 worktree 裡的真實工作，發生在**未採信**
路徑上。那條路徑仍然、也必須走 `EVIDENCE_PRESERVE`（有回歸測試）。

### 放棄了什麼、保留了什麼

- **放棄**：採信路徑上的 preserve 封存。
- **保留**：`archive_workspace_head()` **兩種模型下都照跑**。它在 `harvested` 下正常是
  no-op（commit 已在來源樹 ⇒ 回 None）；一旦呼叫端的前提其實不成立，它就把那顆 commit
  救回封存命名空間——**模型選錯時的安全網，不是可有可無的加分項**（有測試專門讓它動作
  一次）。

---

## 問題 3：abandon（#613）＋ retry-card（#601）的重入

- **未採信路徑完全不動**：即時回收只在採信之後跑，失敗的 job 從來沒有被採信過 ⇒ 它的
  工作區一個位元組都不動（測試連未追蹤檔的內容一起釘）。**#601 的範圍與處置不變。**
- **retry-card 重派**：`_manager_reset_workflow_for_retry_card()` 不動 `candidate_head`，
  重派 base 走 `_workflow_build_handoff_base()` ＝ 來源樹上被採信的 candidate，**不讀任何
  工作區**（#648 已釘）⇒ 不產生新的死路。
- **abandon**：`work_actions._reclaim_abandoned_build_worktrees()` 掃 run 名下每一列 job 的
  `worktree`；已被即時回收的路徑判為 `absent`（**成功**，不是 `failed`），還活著的那一棵
  照樣收得掉。測試走真的掛點。
- **#613 的 branch 回收**：即時回收**一個 branch 名都沒碰**，仍是 #613 的範圍。另補一條
  測試：所有 build 工作區被回收之後，`gc` 的 `protected_branches` 這條保護被抽掉了，但
  「未 merge ⇒ keep」仍頂得住 ⇒ run 中途的 `gc --apply` 不會刪掉整條交付線。

---

## 落地

**`worktree_reclaim.py`**：新增 `EVIDENCE_PRESERVE`／`EVIDENCE_HARVESTED` ＋
`evidence_model=` 參數（`reclaim_worktrees`／`reclaim_recorded_or_derived` 一併透傳），
`WorktreeReclaim` 增 `evidence_model` 欄並帶進 `to_dict()`（operator 看得到某一次回收
**為什麼**沒有 preserve 封存），模組 docstring 改寫為兩個模型 ＋ 完整論證。

**`manager.py`**：

- `_trusted_build_workspace_target()`——六條 fail-closed 前置條件。核心安全閘是**目錄名
  必須恰好是這個 job_id 經 `job_workspace.job_segment()` 導出的片段**（#645 的單一推導
  點），#549 的資料語意地雷（`job.worktree` ＝ run 的 `workspace_root`）因此**結構性**被
  擋掉。刻意**不**拿 `paths.worktree_root_for()` 當判準：那是 config 解析出來的位置，會
  與磁碟上真正 provision 到哪裡漂開（#634「以形狀判斷，不依環境推導」）。另外：標記檔
  存在（#646「認不得就不刪」；三分下讀不到 ⇒ 具名 skip 而不是注定失敗的 `rmtree`）、
  標記檔的 `branch`／`source_repo` 對得上、**當場對來源樹複驗** `commit_present()` 與
  `source_branch_head() == candidate`（不依賴「呼叫端在正確位置呼叫」這種會隨重構漂掉的
  約定）。
- `_reclaim_trusted_build_workspace()`——**永不 raise**，三種結果各一行結構化 log
  （`workflow-build-workspace-reclaim-{reclaimed,skipped,failed}`）。
- 呼叫點在 `apply_workflow_action("advance")` 的 build 分支、**`_manager_update_workflow_run()`
  之後**。位置是刻意的：掛在 `_harvest_build_candidate()` 旁邊的話，中間任何一條 raise
  （宣告 outputs 卻無 artifact／`_audit_phase_steps`／phase transition 驗證……）都會留下
  「工作區已刪、卡仍 pending」，下一個 tick 的 `_verify_exact_candidate()` 以
  `git -C <已刪的路徑>` 收場——**一條由清理製造出來的死路**。落盤之後再收，重入撞到的是
  既有的 `workflow card evidence replay rejected`（已採信的卡不再讀工作區）。

**已知的相鄰交互（不在本票修，明講）**：`regenerate-gates` 取 `candidates[-1]`（最新的
build job），若那張卡已被採信則它的工作區現在不在了 ⇒ 該動作以
`regenerate-gates requires the builder worktree to still exist` 拒絕。這**不損失任何可達
的救援**：對已採信的卡重新產 ledger 之後 `resume` 一律撞
`workflow card evidence replay rejected`，本來就走不通。目標選取的修法是 #557（補
`--card`），刻意不在本票擴張那個動作的語意。

## 紅線遵守

- **沒有**加回 Manager 對 job 工作樹的 ACL（#641／#644：那條授權唯一的消費端本身就是提權
  路徑）——回收用的是採信路徑既有的權限，稽核 5b 的「零 `setfacl`」逐字仍然成立。
- **沒有**讓 job 自己決定何時回收自己。
- **沒有**寫會把不認得的目錄直接刪掉的清理器（#646）——六條前置條件全部 fail-closed，
  且每一條各有具名理由與測試。
- **`direct` 模式零回歸**：沒有引入任何依 `PSC_JOB_RUNNER` 的分支；`job_runner`／
  `launcher`／`permgen`／`trust_root/` 一個位元組都沒碰。

## 測試

新增 `tests/test_immediate_worktree_reclaim_658.py`（15 條 ＋ 1 條 skip），全部跑**正式
路徑**：真 git repo、真 `ScriptWorktreeCreator` 的 per-job clone、真
`dispatch_workflow_card()`、真 #637 bundle ＋ append-only spool 交接、真
`terminalize_workflow_job()`、真 `apply_workflow_action(action="advance")`、真
`_manager_reset_workflow_for_retry_card()`、真 `gc.scan()`。不手動 `git push`、不自己捏
registry 狀態、不直接呼叫回收函式當作「驗過了」。

- **回收發生且 run 走得完**：被採信的卡的工作區當場消失；後續卡拿到 `HEAD == candidate`、
  檔案在、`refs/cortex/base` 也錨在 candidate 上。
- **佔用不隨卡數成長**：三張 build 卡跑完，pool 的 high-water 是 **1**、結束時 **0**，且
  三張卡的產物全在來源樹的 candidate 裡。
- **fail-closed**：未採信的工作區不動（含 retry-card 重派之後）／目錄名不是 job_segment
  （#549）／沒有標記檔（#646）／成果沒回到來源樹 —— 四條各自具名。
- **回收失敗不擋採信**：注入 `OSError`，卡仍 `passed`、`candidate_head` 仍前進、
  `needs_human` 不觸發、工作區留著（不是半刪）。
- **診斷**：`-reclaimed`／`-skipped reason=…` 都出現在 log。
- **重入**：abandon 的回收得到 `absent`＋全 `ok`、走真掛點不拋；`gc` 對交付 branch 仍
  `keep`（`unmerged-content`）。
- **契約**：預設模型仍逐字 preserve（#478 回歸護欄）；`harvested` 不 preserve 但 HEAD
  封存照跑；未知模型 `raise` 且零 side effect。
- **突變驗證**：停掉即時回收呼叫 ⇒ **6 條轉紅**；拿掉「目錄名 ＝ job_segment」與「來源樹
  複驗」兩道安全閘 ⇒ **3 條轉紅**。

**#638／#657 的教訓**：跨帳號擁有權語意（`0700 cortex-builder` 的樹由 `cortex-manager`
回收）需要 root 建置 ＋ 以**另一個 UID** 執行回收——單一 pytest 進程**結構性做不到**（若
以 root 跑，DAC 對 root 不生效，斷言又全部失去意義）⇒ **明確 `pytest.skip` 並在 reason
印出本機實況**。可測的那一半（讀不進去時得到具名拒絕理由、不做注定失敗的 `rmtree`）另有
一條 `chmod 000` 測試，並在 docstring 明講**它證得了什麼、證不了什麼**。

`python3 -m pytest tests/ -q`：**4063 passed, 19 skipped**。

## 未做的實機驗證

`PSC_JOB_RUNNER=systemd-template` 下的實機驗證**尚未執行**——本機不是部署機，而且依查證
修正 2，那個部署形態下 build 卡的採信今天就先卡在 #629。runbook 已補稽核 5c（含運轉期的
journal 事件與 pool 佔用對照）供 operator 在部署機上執行。

## 碰了哪些檔案（與 #633 的並行邊界）

| 檔案 | 動了什麼 |
|---|---|
| `paulsha_cortex/coordinator/worktree_reclaim.py` | evidence 模型（常數／參數／欄位／docstring） |
| `paulsha_cortex/coordinator/manager.py` | 新增兩個函式 ＋ 一處呼叫點 |
| `docs/superpowers/runbooks/trust-root-phase2b-setup.md` | 只新增「稽核 5c」一段（第 2 步稽核區） |
| `tests/test_immediate_worktree_reclaim_658.py` | 新增 |
| `CHANGELOG.md` / `changelog.d/immediate-worktree-reclaim.md` | 依 repo 規範 |

**一個位元組都沒碰** `seams.py`、`gc.py`、`job_workspace.py`、`job_runner`／`launcher`／
`permgen`／`trust_root/` ⇒ 與 #633（`ScriptWorktreeCreator` lazy 解析 ＋ runbook 的 env
慣用法）在 `seams.py` 上零重疊；runbook 只多一段獨立的稽核區塊。

## Checklist

- [x] 三個問題（回收身分／封存語意／abandon＋retry 重入）各自論證並寫進 PR body
- [x] 回收身分與封存語意定案並寫進 `worktree_reclaim` 模組 docstring
- [x] build 卡被採信之後其工作區即時回收（有測試，走正式 `advance` 路徑）
- [x] 一個 run 的工作區佔用不隨 build 卡數線性成長（真 per-job clone 量測）
- [x] 回收失敗不擋採信，且留下可操作的診斷
- [x] 未被採信的工作區不得被回收（fail-closed，四條具名理由）
- [x] `abandon`／`retry-card` 的重入不因即時回收產生新的死路
- [x] `direct` 模式零回歸（無 `PSC_JOB_RUNNER` 分支；未碰 `job_runner`／`launcher`／`permgen`）
- [x] 紅線：沒有加回 Manager 對 job 工作樹的 ACL
- [x] 紅線：沒有讓 job 自己決定何時回收自己
- [x] 紅線：沒有會刪掉不認得目錄的清理器
- [x] OS 層／單 UID 測不到的部分明確 skip 並說明理由（#638／#657）
- [x] `changelog.d/immediate-worktree-reclaim.md` 已新增且已 commit
- [x] `CHANGELOG.md [Unreleased]` 已補 entry
- [x] `VERSION` 未改（非 release PR）
- [x] `python3 -m pytest tests/ -q` 全綠
- [x] `policy_check` 帶 PR 上下文跑，fail: 0
- [x] 文件與 PR 一律 zh-tw
- [x] docs 同步（runbook 稽核 5c）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E7w9kaUxAzCCEk7piD5hfK
