### PR TITLE
fix(trust-root): pytest 與 gh 憑證進登記表，＋ 外部相依的窮舉盤點（#666）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,52 @@
 ## [Unreleased]
 
 ### Added
+- **#666：外部相依的窮舉盤點——判準從「這一類東西有哪些」改成「跑完一個 run 需要碰到
+  什麼」**——`#640`（executor toolchain ＋ job 憑證）、`#661`／`#664`（`srt`／`openspec`／
+  preflight backend）、#666（`pytest` ＋ Manager 的 gh 憑證）是同一族的第一到第五個成員，
+  每一次都是「症狀出現才補一項」，而症狀一次比一次遠（從 `rc=127`，到 doctor 一個看不出
+  原因的 FAIL，到「ledger 空 ⇒ 每張 build 卡在採信階段被拒」）。前面每張表本身都完整，
+  缺的是**沒有任何一處回答「一個 run 需要碰到的東西有哪些」**。新增
+  `permgen.RUN_EXTERNAL_DEPENDENCIES`（25 項，逐項標明 kind／哪些 principal／run 的哪一段
+  ／登記在哪），並**雙向封閉**：`uncovered_run_dependencies()`（盤點列到但表上查無）與
+  `unlisted_roster_entries()`（表上有但盤點沒列到）皆有測試釘住必須為空。**後者才是真正
+  買到的東西**——它讓「加一支相依」與「說明它在 run 的哪一段被誰碰到」變成同一件事，而不是
+  兩件可以只做一半的事。落位計畫（`trust_root toolchain`）把盤點逐段印出來，runbook 第 4h
+  步要求每次部署複核一次。
+- **#666：盤點補上三支一直在用、卻從來沒被寫下來的系統層程式**——`bash`（**每一支 job 的
+  `command[0]` 就是它**：wrapper 是 `bash -c <script>`，降權模式下 shim 的 `execvpe` 執行
+  的第一支程式即為它；Manager 側的 exit 記帳 shell 亦然）、`python3`（gate 宣告與
+  `review-sandbox` probe 都以 `PATH` 解析它 ⇒ **系統層那一支**；#661 曾以「它是部署 venv
+  自己的 interpreter」為由排除，查證後該前提不成立）、`systemctl`（B 案定案後 Manager
+  派工的第一個動作就是 exec 它，解不到就是「降權派工整條不可用」而非單一 job 失敗）。
+- **#666：第四種外部相依——python 發行版**（`permgen.SYSTEM_PYTHON_DISTRIBUTIONS`／
+  `DEPLOYMENT_PYTHON_DISTRIBUTIONS`）。`pytest`／`PyYAML`／`policy-check` 不是落在 `PATH`
+  上的可執行檔，`command -v` 對它們無解；塞進 `SYSTEM_PROGRAMS` 會讓「名冊上每一項都解析
+  得到執行檔」這條既有性質變成假的——與 #661「不得把 `srt` 併進 `EXECUTOR_TOOLS`」是同一條
+  論證：**盤點完整性不可以用「往別張表塞東西」來換**。兩張新表各自標明落在哪一個
+  interpreter、版本約束的唯一宣告來源、以及誰需要它；原本散落的
+  `PREFLIGHT_BACKEND_DISTRIBUTION` 也收進同一張表。
+- **#666：`permgen.GATE_COMMAND_DECLARATIONS` ／ `PathLayout.gate_command_env()`——產生器
+  出建議的 gate 宣告值**（定位同 `job_path_value()`／`preflight_command_value()`：產生器
+  出值、operator 落進 root-owned 的 EnvironmentFile，不是第二份執行期真相）。買到兩件既有
+  形態買不到的事：(i) **gate 宣告的每一段都可以被機械對照到某張表**——`python3` 必須在
+  `SYSTEM_PROGRAMS` 上、`-m <module>` 必須在 `SYSTEM_PYTHON_DISTRIBUTIONS` 上，而 #666 的
+  漂移正是這條不成立卻沒人看得見；(ii) **覆蓋率**——本表必須是 doctor `gate-declarations`
+  probe 由 packaged deck `test_policy` 導出那個集合的超集，否則照 runbook 裝出來的部署一
+  開機 doctor 就是紅的。另有契約測試釘住 `GATE_COMMAND_ENV_PREFIX ==
+  gate_ledger.GATE_ENV_PREFIX`（兩邊刻意不互相 import）。
+- **#666：`permgen.deferred_run_dependencies()`——盤點撞到、尚無歸宿的四項變成可列舉**
+  （比照 #661 的 `unresolved_node_execution_surfaces()`：**不做裁決、不放寬任何一面**，但
+  也不讓它靜默消失）。四項的共同形態是「per-account 的機制已就緒，登記表只登記了其中一
+  份」：(1) **reviewer／planner 的 executor 憑證**——#640 說「M2 落地時補第二列」，而 M2
+  （#615）已經落地，因此這條現在是**逾期未做**；實測 reviewer 模板 unit 的
+  `ReadWritePaths` 不含它 ⇒ `ProtectSystem=strict` 下讀得到、改不了 ⇒ token 過期那天
+  refresh 靜默失敗（有測試把這個**事實**釘住，補上第二列時該測試會紅，那正是提醒去刪掉它
+  與那筆 deferred）；(2) `cortex-gate` 沒有 `.gitconfig`（預防面，目前的 gate 宣告不碰
+  git）；(3) reviewer／planner 的 `codex-hooks`（`asset_paths()` 把它寫死在 builder HOME
+  下）；(4) **Manager 的 claude 登入態**——`planning_runtime` 是在 **Manager 行程內**直接
+  exec `claude` 的（不是派降權 job），它讀 `<HOME>/.claude/.credentials.json`，而
+  `executor_credential_relpath` 是**單一**部署決定、一個帳號只表達得了一份憑證。
 - **#661：`permgen.node_execution_surfaces()`／`unresolved_node_execution_surfaces()`
   ——#643 剖面推導的盲區變成可列舉、不會靜默消失的東西**——#643 由
   `EXECUTOR_TOOLS.needs_node` 機械導出加固剖面，而那條推導唯一的輸入是 **executor 名**：
@@ -441,6 +487,39 @@
   `tests/test_trust_root_job_template_ab.py`（80 測試）。
 
 ### Fixed
+- **#666：實機為啟用 monitor 手動補的兩項收斂回登記表——`pytest`（系統層 python 套件）與
+  Manager 的 `gh` 憑證**。兩項在實機都已生效，但**產生器的計畫產不出它們**：重跑
+  `permissions`／`toolchain` 不會有、換一台機器部署也不會有。
+
+  **漂移項 1：`pytest` 裝在 operator 的 user site-packages，gate 讀不到。**
+  `PSC_GATE_CMD_PYTEST="python3 -m pytest -q"` 是**相對名**，由 gate 的 `PSC_GATE_PATH`
+  解析 ⇒ `/usr/bin/python3`——**系統層那一支**。gate unit 自己的 `ExecStart` 用的是
+  `/opt/cortex/venv/bin/python3`，但那只涵蓋 ledger writer 本身，**operator 宣告的命令另外
+  解析一次**。`ProtectHome=yes` 之後 `~/.local/lib/python3.12/site-packages` 不可達 ⇒ 每張
+  build 卡的 gate ledger 為空 ⇒ 撞 #540 的 acceptance chain，而痕跡只有 `manager.log` 的
+  一行。修法：進 `SYSTEM_PYTHON_DISTRIBUTIONS`，連同 **`PyYAML`**——後者是**被測樹**的
+  runtime 相依而不是 pytest 的（gate 的 cwd 是被驗那棵樹的副本，pytest 把 rootdir 插進
+  `sys.path` ⇒ `import paulsha_cortex` 解到被驗的樹 ⇒ 它 `import yaml`；缺它的症狀是
+  pytest exit code `2`，collection error，不是「測試失敗」）。**版本是明示的部署決定**：
+  約束的唯一真相在 `pyproject.toml`（測試對著它比，改一邊沒改另一邊即紅），實機解出來的
+  版本由 runbook 第 4f 步記錄並與 operator 側比對。
+
+  **漂移項 2：Manager 沒有 gh 登入態，兩個 github provider `degraded`。** 新增登記表資產
+  `manager-gh-credential`（`<manager HOME>/.config/gh/hosts.yml`，服務帳號 owned `0600`、
+  列入 `IN_PLACE_CONTENT_WRITE_ASSETS`）與 `manager-gh-config`（`config.yml`，**root-owned
+  `0644`**），兩層目錄（`.config`、`.config/gh`）由 `scaffold_directories()` 產出
+  root-owned `0755`。**兩個檔的 owner 刻意不同**：`hosts.yml` 是 `gh` 唯一寫回 token 的檔
+  （`auth login`／`refresh` 就地覆寫，不歸該帳號就 refresh 不回來）；`config.yml` 不承載
+  憑證，但其 `aliases` 可宣告 `!` 開頭的 shell alias——讓服務帳號改得了它等於給 Manager
+  一條「把任意命令掛進每一次 `gh` 呼叫」的執行面，與三份 `.gitconfig` 維持 root-owned 是
+  **逐字相同**的理由。**與 #640 的 job 憑證形狀相同、洩漏面不同級**（spec／note／runbook
+  三處都明寫不得混為一談）：#640 那一份是 **job 帳號**的模型 provider 憑證，job unit 另有
+  `Environment=GH_TOKEN=`／`GITHUB_TOKEN=` 清空 GitHub token、成果走 `commit-spool` 由
+  Manager 代理推送；本份是給 **durable state owner** 的，這個 token 推得動 PR、關得掉
+  issue、改得了 label、merge 得了分支。job 帳號因此**刻意沒有** `~/.config/gh` 這一層目錄。
+  落點之所以是 `~/.config/gh`，是因為產生出來的 unit 設 `HOME=` 與 `XDG_CACHE_HOME=` 而
+  **刻意不設 `XDG_CONFIG_HOME=`**；日後補上它會讓憑證落點**無聲**搬走（症狀是「未登入」，
+  而檔案還在原處），這一條寫進 spec 與 runbook。
 - **#661 / trust-root Phase 2 收尾：實機四分部署 doctor 剩的兩個 FAIL，同一個成因
   （job／服務需要的外部程式不在登記表上）**——(1) `review-sandbox`：`srt` 被**單檔複製**
   而它是 npm 套件樹，`dist/cli.js` 的 ESM 相對 import 解到 `<toolchain>/bin/utils/…`
@@ -794,6 +873,28 @@
   `mock.patch.object` 打不到，測試實際驗到的是「本機有沒有那個帳號」而非它宣稱的分支。
 
 ### Changed
+- **#666：HOME-anchored 資產在不適用的方案下不再進入 `ReadWritePaths`**
+  （`permgen.inapplicable_home_anchored_assets()`）。幾個掛在帳號 HOME 下的資產由
+  `PathLayout` 的部署決定欄位導出路徑，而那些欄位取的是定案的三分／四分；二分把 Manager／
+  reviewer／planner 併進 `cortex-svc`，同一條路徑在二分部署裡不存在，而 systemd 對不存在的
+  `ReadWritePaths=` 目標會讓 unit **直接起不來**。登記表的 note 早就寫著「二分下該資產不
+  適用」、權限那一半也早就以 `[ ! -e ] || …` 守衛表達了它，缺的只有 RWP 那一半——#640 當時
+  的處置是「乾脆不登記第二份憑證」，#666 要登記 Manager 的 gh 憑證時同一個陷阱又出現一次，
+  因此改成一條**可列舉的機械規則**（靜默扣掉一條 RWP 與漏授一條在輸出上長得一樣，而後者的
+  症狀是 job 跑到一半 EROFS）。附帶效果：#640 當年那個「不要登記第二份」的阻礙已經拆掉。
+- **#666：`trust_root toolchain` 的輸出擴為三段**——系統層 python 發行版的落位與版本比對、
+  Manager gh 憑證的落位與**以該身分實測**的驗證、以及窮舉盤點與已知未決項。計畫仍是純字串
+  （非註解行只可能是 `install -d`／`chown`／`chmod`，有回歸測試）。驗收方式是**「重跑計畫
+  後零漂移」**：實機手動補過的東西若產生器出不出來，換一台機器部署就不會有它。
+- **#666：runbook 新增第 4f（系統層 python 套件）／4g（Manager gh 憑證）／4h（窮舉盤點
+  複核）三步**，驗證一律**以該身分實測**而不是只驗檔案存在：4f 有「gate 身分
+  `python3 -m pytest --version`」＋完整加固面下的 `systemd-run` 實跑（**CPython 不是 V8，
+  MDWE 對它沒有影響**，因此這條在完整加固面下就該過，失敗即為新發現、不得就地放寬）＋版本
+  比對；4g 有「Manager 身分 `gh auth status`」＋不變式四條（改得了內容／建不了新檔／刪不掉
+  root-owned 鄰居／改不了 `config.yml`）＋ RWP 只掛檔案不掛父目錄＋ job 側反向驗證。附錄 A
+  的漂移自我檢查同步補三條。spec §R1 新增 (b2)（Manager 傳輸層憑證：同形狀、不同級的洩漏
+  面）與 (c)（外部相依的盤點判準從 run 反推、雙向封閉、第四種相依、HOME-anchored 資產的
+  不適用規則）兩節。
 - **#661：登記表的外部程式盤點由「四個 executor」擴為完整名冊，但**刻意分成兩張表****
   ——`permgen` 新增 `SERVICE_TOOLS`（`srt`／`openspec`）與 `SYSTEM_PROGRAMS`
   （`node`／`git`／`gh`／`bwrap`／`socat`），落位計畫改由 `TOOLCHAIN_PROGRAMS`

--- a/changelog.d/external-deps-exhaustive.md
+++ b/changelog.d/external-deps-exhaustive.md
@@ -1,0 +1,119 @@
+### Fixed
+- **#666：實機為啟用 monitor 手動補的兩項收斂回登記表——`pytest`（系統層 python 套件）
+  與 Manager 的 `gh` 憑證**。兩項在實機都已生效，但**產生器的計畫產不出它們**：重跑
+  `permissions`／`toolchain` 不會有、換一台機器部署也不會有。
+
+  **漂移項 1：`pytest` 裝在 operator 的 user site-packages，gate 讀不到。**
+  `PSC_GATE_CMD_PYTEST="python3 -m pytest -q"` 是**相對名**，由 gate 的 `PSC_GATE_PATH`
+  解析 ⇒ `/usr/bin/python3`——**系統層那一支**。gate unit 自己的 `ExecStart` 用的是
+  `/opt/cortex/venv/bin/python3`，但那只涵蓋 ledger writer 本身，**operator 宣告的命令
+  另外解析一次**。`ProtectHome=yes` 之後 `~/.local/lib/python3.12/site-packages` 不可達
+  ⇒ 每張 build 卡的 gate ledger 為空 ⇒ 撞 #540 的 acceptance chain，而痕跡只有
+  `manager.log` 的一行。修法：新增 `permgen.SYSTEM_PYTHON_DISTRIBUTIONS`（`pytest` ＋
+  **`PyYAML`**——後者是**被測樹**的 runtime 相依，不是 pytest 的：gate 的 cwd 是被驗那棵
+  樹的副本，pytest 把 rootdir 插進 `sys.path` ⇒ `import paulsha_cortex` 解到被驗的樹
+  ⇒ 它 `import yaml`；缺它的症狀是 pytest exit code `2`（collection error），不是「測試
+  失敗」）。**版本是明示的部署決定**：約束的唯一真相在 `pyproject.toml`（測試對著它比，
+  改一邊沒改另一邊即紅），實機解出來的版本由 runbook 第 4f 步記錄並與 operator 側比對。
+
+  **漂移項 2：Manager 沒有 gh 登入態，兩個 github provider `degraded`。** 新增登記表資產
+  `manager-gh-credential`（`<manager HOME>/.config/gh/hosts.yml`，服務帳號 owned `0600`、
+  列入 `IN_PLACE_CONTENT_WRITE_ASSETS`）與 `manager-gh-config`（`config.yml`，
+  **root-owned `0644`**）。**兩個檔的 owner 刻意不同**：`hosts.yml` 是 `gh` 唯一寫回
+  token 的檔（不歸該帳號就 refresh 不回來）；`config.yml` 不承載憑證，但其 `aliases` 可
+  宣告 `!` 開頭的 shell alias——讓服務帳號改得了它等於給 Manager 一條「把任意命令掛進
+  每一次 `gh` 呼叫」的執行面，與三份 `.gitconfig` 維持 root-owned 是**逐字相同**的理由。
+  兩層目錄（`.config`、`.config/gh`）由 `scaffold_directories()` 產出 root-owned `0755`。
+  **與 #640 的 job 憑證形狀相同、洩漏面不同級，spec／note／runbook 三處都明寫不得混談**：
+  #640 那一份是 job 帳號的模型 provider 憑證（job unit 另有 `Environment=GH_TOKEN=` 清空
+  GitHub token，成果走 spool 由 Manager 代理推送）；本份是給 durable state owner 的，
+  這個 token 推得動 PR、關得掉 issue、merge 得了分支。job 帳號因此**刻意沒有**
+  `~/.config/gh` 這一層目錄。
+
+### Added
+- **#666：外部相依的窮舉盤點——判準從「這一類東西有哪些」改成「跑完一個 run 需要碰到
+  什麼」**。`#640`（executor toolchain ＋ job 憑證）、`#661`／`#664`（`srt`／`openspec`／
+  preflight backend）、本票（`pytest` ＋ gh 憑證）是同一族的第一到第五個成員，每次都是
+  「症狀出現才補一項」。前面每張表本身都完整，缺的是**沒有任何一處回答「一個 run 需要
+  碰到的東西有哪些」**。新增 `permgen.RUN_EXTERNAL_DEPENDENCIES`（25 項，逐項標明 kind／
+  哪些 principal／run 的哪一段／登記在哪），並**雙向封閉**：
+  `uncovered_run_dependencies()`（盤點列到但表上查無）與 `unlisted_roster_entries()`
+  （表上有但盤點沒列到）皆有測試釘住必須為空。**後者才是本票真正買到的東西**——它讓
+  「加一支相依」與「說明它在 run 的哪一段被誰碰到」變成同一件事，而不是兩件可以只做一半
+  的事。落位計畫（`trust_root toolchain`）把盤點逐段印出來，runbook 第 4h 步要求每次部署
+  複核一次。
+- **#666：盤點補上三支一直在用、卻從來沒被寫下來的系統層程式**——`bash`（**每一支 job 的
+  `command[0]` 就是它**：wrapper 是 `bash -c <script>`，降權模式下 shim 的 `execvpe` 執行
+  的第一支程式即為它；Manager 側的 exit 記帳 shell 亦然）、`python3`（gate 宣告與
+  `review-sandbox` probe 都以 `PATH` 解析它 ⇒ **系統層那一支**；#661 曾以「它是部署 venv
+  自己的 interpreter」為由排除，查證後該前提不成立）、`systemctl`（B 案定案後 Manager
+  派工的第一個動作就是 exec 它，解不到就是「降權派工整條不可用」）。
+- **#666：第四種外部相依——python 發行版**。`pytest`／`PyYAML`／`policy-check` 不是落在
+  `PATH` 上的可執行檔，`command -v` 對它們無解；塞進 `SYSTEM_PROGRAMS` 會讓「名冊上每一項
+  都解析得到執行檔」這條既有性質變成假的（與 #661「不得把 `srt` 併進 `EXECUTOR_TOOLS`」
+  是同一條論證：盤點完整性不可以用「往別張表塞東西」來換）。因此另立
+  `SYSTEM_PYTHON_DISTRIBUTIONS`／`DEPLOYMENT_PYTHON_DISTRIBUTIONS`，各自標明落在哪一個
+  interpreter、版本約束的唯一宣告來源、以及誰需要它；`PREFLIGHT_BACKEND_DISTRIBUTION`
+  這個原本散落的常數也收進同一張表。
+- **#666：`permgen.GATE_COMMAND_DECLARATIONS` ／ `PathLayout.gate_command_env()`
+  ——產生器出建議的 gate 宣告值**（定位同 `job_path_value()`／`preflight_command_value()`：
+  產生器出值、operator 落進 root-owned 的 EnvironmentFile，不是第二份執行期真相）。買到
+  兩件既有形態買不到的事：(i) **gate 宣告的每一段都可以被機械對照到某張表**——`python3`
+  必須在 `SYSTEM_PROGRAMS` 上、`-m <module>` 必須在 `SYSTEM_PYTHON_DISTRIBUTIONS` 上，
+  而 #666 的漂移正是這條不成立卻沒人看得見；(ii) **覆蓋率**——本表必須是 doctor
+  `gate-declarations` probe 由 packaged deck `test_policy` 導出的那個集合的超集，否則照
+  runbook 裝出來的部署一開機 doctor 就是紅的。另有契約測試釘住
+  `GATE_COMMAND_ENV_PREFIX == gate_ledger.GATE_ENV_PREFIX`（兩邊刻意不互相 import）。
+- **#666：`permgen.deferred_run_dependencies()`——盤點撞到、尚無歸宿的四項變成可列舉**
+  （比照 #661 的 `unresolved_node_execution_surfaces()`：**不做裁決、不放寬任何一面**，
+  但也不讓它靜默消失）。四項的共同形態是「per-account 的機制已就緒，登記表只登記了其中
+  一份」：(1) **reviewer／planner 的 executor 憑證**——#640 說「M2 落地時補第二列」，而 M2
+  （#615）已經落地，因此這條現在是**逾期未做**；實測 reviewer 模板 unit 的
+  `ReadWritePaths` 不含它 ⇒ `ProtectSystem=strict` 下讀得到、改不了 ⇒ token 過期那天
+  refresh 靜默失敗（有測試把這個**事實**釘住，補上第二列時該測試會紅，那正是提醒去刪掉
+  它與那筆 deferred）；(2) `cortex-gate` 沒有 `.gitconfig`（預防面，目前的 gate 宣告不碰
+  git）；(3) reviewer／planner 的 `codex-hooks`（`asset_paths()` 把它寫死在 builder HOME
+  下）；(4) **Manager 的 claude 登入態**——`planning_runtime` 是在 **Manager 行程內**直接
+  exec `claude` 的（不是派降權 job），它讀 `<HOME>/.claude/.credentials.json`，而
+  `executor_credential_relpath` 是**單一**部署決定、一個帳號只表達得了一份憑證。
+
+### Changed
+- **#666：HOME-anchored 資產在不適用的方案下不再進入 `ReadWritePaths`
+  （`permgen.inapplicable_home_anchored_assets()`）**。幾個掛在帳號 HOME 下的資產由
+  `PathLayout` 的部署決定欄位導出路徑，而那些欄位取的是定案的三分／四分；二分把
+  Manager／reviewer／planner 併進 `cortex-svc`，同一條路徑在二分部署裡不存在，而 systemd
+  對不存在的 `ReadWritePaths=` 目標會讓 unit **直接起不來**。登記表的 note 早就寫著
+  「二分下該資產不適用」、權限那一半也早就以 `[ ! -e ] || …` 守衛表達了它，缺的只有 RWP
+  那一半——#640 當時的處置是「乾脆不登記第二份憑證」，#666 要登記 Manager 的 gh 憑證時
+  同一個陷阱又出現一次，因此改成一條**可列舉的機械規則**（靜默扣掉一條 RWP 與漏授一條
+  在輸出上長得一樣，而後者的症狀是 job 跑到一半 EROFS）。附帶效果：#640 當年那個「不要
+  登記第二份」的阻礙已經被拆掉。
+- **#666：`trust_root toolchain` 的輸出擴為三段**——系統層 python 發行版的落位與版本比對、
+  Manager gh 憑證的落位與**以該身分實測**的驗證、以及窮舉盤點與已知未決項。計畫仍是純
+  字串（非註解行只可能是 `install -d`／`chown`／`chmod`，有回歸測試）。驗收方式是
+  **「重跑計畫後零漂移」**：實機手動補過的東西若產生器出不出來，換一台機器部署就不會有它。
+- **#666：runbook 新增第 4f（系統層 python 套件）／4g（Manager gh 憑證）／4h（窮舉盤點
+  複核）三步**，驗證一律**以該身分實測**而不是只驗檔案存在：4f 有「gate 身分 `python3 -m
+  pytest --version`」＋完整加固面下的 `systemd-run` 實跑（**CPython 不是 V8，MDWE 對它沒有
+  影響**，因此這一條在完整加固面下就該過，失敗即為新發現、不得就地放寬）＋版本比對；
+  4g 有「Manager 身分 `gh auth status`」＋不變式四條（改得了內容／建不了新檔／刪不掉
+  root-owned 鄰居／改不了 `config.yml`）＋ RWP 只掛檔案不掛父目錄＋ job 側反向驗證。
+  附錄 A 的漂移自我檢查同步補三條。
+- **#666：spec §R1 新增 (b2)（Manager 傳輸層憑證：同形狀、不同級的洩漏面）與 (c)（外部
+  相依的盤點判準從 run 反推、雙向封閉、第四種相依、HOME-anchored 資產的不適用規則）。**
+
+### 測試
+- 新測試檔 `tests/test_trust_root_external_deps_exhaustive_666.py`：**53 passed, 1 skipped**。
+  涵蓋兩個新資產的 owner／mode／目錄形態、`ReadWritePaths` 只掛檔案不掛父目錄、
+  traverse 鏈可達、#622 monitor 嚴格窄於 manager 仍成立、二分不得出現不存在帳號的路徑、
+  gate 宣告每一段可對照到某張表、盤點雙向封閉、以及落位計畫能重現實機那兩項。
+- **OS 層語意以真的檔案系統驗**（#638／#657 的教訓）：`TestGhCredentialOsSemantics` 對
+  真實檔案系統驗四條（就地改內容成功、建新檔 `PermissionError`、`unlink`
+  `PermissionError`、`os.replace` 蓋 root-owned 鄰居 `PermissionError`）。手法與 #642 的
+  `TestInPlaceCredentialOsSemantics` 相同：裁決守的是「**目錄沒有 `w` 位給這個行程**」，
+  以 owner 位 `0555` 重現**同一段 kernel 檢查**（`inode_permission(dir, MAY_WRITE)`），
+  不需要第二個 UID。**真正需要第二個 UID 的那一半明確 skip 並寫明理由**——「`config.yml`
+  由 root 擁有、服務帳號連內容都改不了」在單 UID 下重現不了（本行程就是 owner，chmod
+  回來即可改），那一半改由產生器測試（`entry.owner == deploy_account` 且 writer 不含服務
+  帳號）與 runbook 的實機驗證守；在這裡跑一次只會證明一件與待驗命題無關的事。
+- 全套 `python3 -m pytest tests/ -q`：**4163 passed, 21 skipped, 49 subtests**，零回歸。

--- a/docs/onboarding/troubleshooting.md
+++ b/docs/onboarding/troubleshooting.md
@@ -138,7 +138,9 @@ cortex inspect service --instance cortex --json
 之後系統層的 `python3` import 不到它。
 
 ```bash
-sudo -u cortex-gate env HOME=/var/lib/cortex-gate python3 -m pytest --version
+# HOME 由產生器導出，不要手寫絕對路徑（換 layout 時這裡會跟著動）
+GATE_HOME="$(python3 -c 'from paulsha_cortex.trust_root.permgen import DEFAULT_LAYOUT as L; print(L.home_of("cortex-gate"))')"
+sudo -u cortex-gate env HOME="$GATE_HOME" python3 -m pytest --version
 #   `No module named pytest` ⇒ 就是這一條
 ```
 
@@ -154,7 +156,8 @@ sudo -u cortex-gate env HOME=/var/lib/cortex-gate python3 -m pytest --version
 `~/.config/gh/` 不可見。
 
 ```bash
-sudo -u cortex-manager env HOME=/var/lib/cortex-manager gh auth status
+MANAGER_HOME="$(python3 -c 'from paulsha_cortex.trust_root.permgen import DEFAULT_LAYOUT as L; print(L.home_of(L.manager_account))')"
+sudo -u cortex-manager env HOME="$MANAGER_HOME" gh auth status
 #   `You are not logged into any GitHub hosts.` ⇒ 就是這一條
 ```
 

--- a/docs/onboarding/troubleshooting.md
+++ b/docs/onboarding/troubleshooting.md
@@ -25,6 +25,8 @@
 | `systemd` 不可用 | `cortex service status --json` | 在沒有 `systemd --user` 的環境操作，或 unit 未安裝 | 看 [systemd 不可用](#systemd-不可用) |
 | executor 未登入 | `cortex doctor --probe-live --repo owner/name --json` | `copilot`、`claude`、`codex` 尚未登入 | 看 [executor 未登入](#executor-未登入) |
 | F34 / stale `venv` | `cortex inspect service --json` | unit 指向已刪的安裝位置，或 service 還在跑舊碼 | 看 [stale venv 或 exec path drift](#stale-venv-或-exec-path-drift-f34) |
+| build 卡全數在採信階段被拒（`gate-ledger-missing-expected-gate`），但 gate 宣告看起來正常 | `sudo -u <gate 帳號> env HOME=<gate HOME> python3 -m pytest --version` | 降權部署下 gate 宣告的 `python3` 解析到**系統層** interpreter，而 `pytest` 只裝在 operator 的 user site-packages（`ProtectHome` 之後不可達） | 看 [降權部署下 gate ledger 為空](#降權部署下-gate-ledger-為空) |
+| monitor 起得來但兩個 github provider `degraded`；doctor 的 `gh-*` probe 全紅 | `sudo -u <manager 帳號> env HOME=<manager HOME> gh auth status` | 降權部署下 Manager 沒有自己的 `gh` 登入態（operator 的在 `/home` 底下，`ProtectHome` 之後不可達） | 看 [降權部署下 Manager 沒有 gh 登入態](#降權部署下-manager-沒有-gh-登入態) |
 
 ## delivery preflight 失敗
 
@@ -122,6 +124,44 @@ cortex inspect service --instance cortex --json
 2. 依 [Upgrade](upgrade.md) 或 [Rollback](rollback.md) 重裝。
 3. 重啟 `cortex service restart --instance cortex`。
 4. 重新執行 `cortex inspect service --json` 確認 drift 消失。
+
+## 降權部署下 gate ledger 為空
+
+**只發生在 Phase 2b 的降權部署（四分）**，症狀離原因很遠：dispatch 走得完、builder 交得
+出合格 candidate，但每張帶 `test_policy` 的卡都在 harvest 撞
+`gate-ledger-missing-expected-gate`，而唯一的痕跡是 `manager.log` 裡的一行。
+
+成因：`PSC_GATE_CMD_PYTEST="python3 -m pytest -q"` 用的是**相對名**，由 gate 的
+`PSC_GATE_PATH` 解析 ⇒ `/usr/bin/python3`（**系統層那一支**）。gate unit 自己的
+`ExecStart` 用的是部署 venv 的 interpreter，但那只涵蓋 ledger writer 本身——**operator
+宣告的命令另外解析一次**。`pytest` 只裝在 operator 的 `~/.local/...` 時，`ProtectHome=yes`
+之後系統層的 `python3` import 不到它。
+
+```bash
+sudo -u cortex-gate env HOME=/var/lib/cortex-gate python3 -m pytest --version
+#   `No module named pytest` ⇒ 就是這一條
+```
+
+`cortex doctor` 的 `gate-declarations` probe **驗不到這個**——它只驗宣告的 argv 形狀，不驗
+「那個模組 import 得到嗎」。處置見 Runbook 第 4f 步（`sudo pip install
+--break-system-packages 'pytest>=7' 'PyYAML>=6'`，並以 gate 身分＋完整加固面各實測一次）。
+`PyYAML` 也要裝：gate 的 cwd 是被驗那棵樹的副本，`import paulsha_cortex` 會解到那棵樹，
+而它 `import yaml`——缺它的症狀是 pytest exit code `2`（collection error）。
+
+## 降權部署下 Manager 沒有 gh 登入態
+
+同一族的另一個：Manager／monitor 的 system unit 帶 `ProtectHome=yes`，operator 的
+`~/.config/gh/` 不可見。
+
+```bash
+sudo -u cortex-manager env HOME=/var/lib/cortex-manager gh auth status
+#   `You are not logged into any GitHub hosts.` ⇒ 就是這一條
+```
+
+處置見 Runbook 第 4g 步。**兩個檔要分別落位、owner 刻意不同**：`hosts.yml` 由服務帳號擁有
+（`0600`，token 要 refresh 得回來），`config.yml` 維持 `root:root 0644`（它的 `aliases`
+可宣告 `!` shell alias，讓服務帳號改得了它等於多一條執行面）。若落位後仍顯示未登入，先確認
+沒有人設了 `XDG_CONFIG_HOME` 或 `GH_CONFIG_DIR`——那會讓 `gh` 去看別的目錄，而檔案還在原處。
 
 ## 什麼時候該直接走 Runbook
 

--- a/docs/superpowers/runbooks/trust-root-phase2b-setup.md
+++ b/docs/superpowers/runbooks/trust-root-phase2b-setup.md
@@ -415,8 +415,16 @@ python3 -m paulsha_cortex.trust_root gitconfig four-way --manager --source-repo 
 
 # ✅ executor toolchain 的落位步驟（#640；四個模型 CLI 進 /opt/cortex/toolchain、
 #    node 走系統層、job 的 PSC_BUILDER_PATH 值）——見第 4e 步
+#    #661 起同一份輸出另含：srt／openspec 的搬移、preflight backend 的 venv 落點；
+#    #666 起再含：系統層 python 套件（第 4f 步）、Manager 的 gh 憑證（第 4g 步），
+#    以及**窮舉盤點**與已知未決項（第 4h 步）。
 python3 -m paulsha_cortex.trust_root toolchain four-way
 ```
+
+> **「重跑計畫後零漂移」是本步的驗收方式**（#666）：實機手動補過的東西，如果產生器出
+> 不出來，換一台機器部署就不會有它。上面那一行 ＋ `permissions`／`scaffold` 三份輸出
+> 合起來必須涵蓋 `/opt/cortex/toolchain`、系統層 python 套件、以及每一個帳號 HOME 下的
+> 憑證／設定；**逐項對完仍為空差異**才算這一步做完。
 
 **job-spec 的欄位契約也已隨 #616 落地**——`coordinator/job_runner.py` 的
 `build_job_spec()` 是**唯一**的產生入口，`coordinator/job_shim.py` 是唯一的讀取端：
@@ -1979,6 +1987,242 @@ sudo -u cortex-builder sh -c \
 
 **回滾**：`sudo rm -rf /opt/cortex/toolchain
 /var/lib/cortex-{builder,reviewer-planner}/.codex/auth.json`。
+
+---
+
+### 4f. 系統層 python 套件（#666 漂移項 1：`pytest`）
+
+**沒有這一步，前面全部做完 dispatch 也走得完——但每張 build 卡都會在採信階段被拒。**
+症狀離原因最遠的一步就是這一個，因此它獨立成一節。
+
+`PSC_GATE_CMD_PYTEST="python3 -m pytest -q"` 是**相對名**，由 gate 的 `PSC_GATE_PATH`
+（`/opt/cortex/toolchain/bin:/usr/local/bin:/usr/bin:/bin`）解析 ⇒ `/usr/bin/python3`，
+**系統層那一支**。gate unit 自己的 `ExecStart` 用的是 `/opt/cortex/venv/bin/python3`，
+但那只涵蓋 ledger writer 本身——**operator 宣告的命令另外解析一次**。兩者是不同的
+interpreter，這是本節存在的唯一理由。
+
+```
+$ sudo -u cortex-gate env HOME=/var/lib/cortex-gate python3 -m pytest --version
+/usr/bin/python3: No module named pytest
+```
+
+> **後果不是「gate 失敗」**：wrapper 仍會寫出 ledger，只是每一項都記 `failed`／或
+> 整份為空 ⇒ 每張帶 `test_policy` 的 build 卡在 harvest 撞
+> `gate-ledger-missing-expected-gate`（#540 的 acceptance chain）⇒ **交付全部卡住**，
+> 而唯一的痕跡是 `manager.log` 裡的一行。`cortex doctor` 的 `gate-declarations` probe
+> 只驗宣告的 argv 形狀，**驗不到「那個模組 import 得到嗎」**——這一節補的正是那個缺口。
+
+**要裝哪些、為什麼是兩個**（清單由產生器出，不要手抄）：
+
+```bash
+# ✅ 清單與版本約束（含每一項的理由）
+python3 -m paulsha_cortex.trust_root toolchain four-way | sed -n '/系統層 python 發行版/,/完整加固面下/p'
+#   期望兩項：
+#     pytest —— gate 實際跑的 test runner；約束宣告在 pyproject.toml 的 test extra
+#     PyYAML —— **被測樹**的 runtime 相依（不是 pytest 的）：gate 的 cwd 是被驗那棵樹
+#                的副本，pytest 會把 rootdir 插進 sys.path ⇒ `import paulsha_cortex`
+#                解到被驗的樹 ⇒ 它 import yaml。缺它的症狀是 pytest exit code 2
+#                （collection error），不是「測試失敗」。
+```
+
+```bash
+# 🔧 sudo：裝到系統層（**不是** `pip install --user`——ProtectHome 之後讀不到）
+sudo pip install --break-system-packages 'pytest>=7' 'PyYAML>=6'
+```
+
+```bash
+# ✅ 驗證（1）：**以 gate 身分實測**，不是只驗檔案存在
+sudo -u cortex-gate env HOME=/var/lib/cortex-gate \
+  PATH=/opt/cortex/toolchain/bin:/usr/local/bin:/usr/bin:/bin \
+  python3 -m pytest --version
+#   期望：印出版本，rc=0（不是 `No module named pytest`）
+sudo -u cortex-gate env HOME=/var/lib/cortex-gate python3 -c 'import yaml; print(yaml.__version__)'
+#   期望：印出版本
+
+# ✅ 驗證（2）：**在完整加固面下**複跑（`sudo -u` 沒有 unit 的加固面）
+sudo install -d -o root -g root -m 0755 /tmp/psc-gate-probe
+printf 'def test_ok():\n    assert True\n' \
+  | sudo tee /tmp/psc-gate-probe/test_probe.py >/dev/null
+sudo systemd-run --pipe --wait --collect \
+  --uid=cortex-gate --gid=cortex-gate \
+  --property=NoNewPrivileges=yes --property=ProtectSystem=strict \
+  --property=ProtectHome=yes --property=MemoryDenyWriteExecute=yes \
+  --setenv=HOME=/var/lib/cortex-gate \
+  --setenv=PATH=/opt/cortex/toolchain/bin:/usr/local/bin:/usr/bin:/bin \
+  --working-directory=/tmp/psc-gate-probe \
+  /usr/bin/python3 -m pytest -q
+#   期望：`1 passed`，rc=0。
+#   ✅ **這一條在完整加固面下就應該過，不需要放寬任何一項**：CPython 不是 V8，
+#      `MemoryDenyWriteExecute=yes` 對它沒有影響（與 #643 的 node 型 executor 相反）。
+#   ⚠️ 若這一條失敗而拿掉 MDWE 才過，那是新發現——**停下來記回 issue**，不要就地放寬。
+sudo rm -rf /tmp/psc-gate-probe
+
+# ✅ 驗證（3）：**版本是明示的部署決定** —— 記下來並與 operator 側比對
+python3 -m pytest --version                                  # operator 側
+sudo -u cortex-gate env HOME=/var/lib/cortex-gate python3 -m pytest --version   # gate 側
+#   ⚠️ 兩者**可以**不同（兩個 interpreter 各有一份是常態），但**必須被記下來**：
+#      版本分岔的症狀是「gate 判定與本機跑不一樣」，不是報錯。把 gate 側那一版寫進
+#      本 runbook 的部署紀錄；哪天要升，升的是 gate 側那一份。
+
+# ✅ 驗證（4）：宣告本身
+sh -c 'set -a; . /opt/cortex/etc/cortex-manager.env; set +a; echo "[$PSC_GATE_CMD_PYTEST]"'
+#   期望：`[python3 -m pytest -q]`（產生器出的建議值；見 4b 步）
+python3 -m paulsha_cortex.trust_root toolchain four-way | grep 'PSC_GATE_CMD_'
+```
+
+> **為什麼不乾脆把宣告改成 `/opt/cortex/venv/bin/python3 -m pytest`？** 那是一個
+> **operator 可以做、但產生器不會替你做**的裁決：改了之後系統層這兩個套件的需求整個
+> 消失，但 gate 跑的 pytest 版本就與 cortex 自己的部署版本綁在一起（升 cortex 會連帶
+> 換掉 gate 的判準）。兩邊各有取捨。**若你改了宣告，這一節就不再適用**——同時要把
+> `permgen.SYSTEM_PYTHON_DISTRIBUTIONS` 一起改掉，測試會提醒你。
+
+**回滾**：`sudo pip uninstall --break-system-packages pytest`（`PyYAML` 通常是系統套件
+的相依，**不要**動它）。
+
+---
+
+### 4g. Manager 的 gh 憑證（#666 漂移項 2）
+
+**沒有這一步，monitor 起得來但兩個 github provider 一起 `degraded`**，且 doctor 的
+`gh-auth`／`gh-permissions`／`auto-label` 三個 required probe 全紅。
+
+```
+$ sudo -u cortex-manager env HOME=/var/lib/cortex-manager gh auth status
+You are not logged into any GitHub hosts.
+```
+
+operator 側的登入態在 `~/.config/gh/` 底下，`ProtectHome=yes` 之後 `/home` 整個不可見
+——與 #640／#661 的成因逐字相同，這是那一族的**第五個**成員。
+
+> **⚠️ 這一份與 4e 的 job 憑證形狀相同、洩漏面不同級，不要混為一談。**
+> 4e 那一份是給 **job 帳號**的模型 provider 憑證：被竊只換得到模型呼叫額度，而且 job
+> 模板 unit 另有 `Environment=GH_TOKEN=`／`GITHUB_TOKEN=` 把 GitHub token 清空，成果
+> 一律走 `commit-spool` 由 Manager 代理推送。
+> 本節這一份是給 **Manager** 的，而 Manager 是 durable state owner——這個 token
+> **推得動 PR、關得掉 issue、改得了 label、merge 得了分支**，洩漏的是治理平面對上游
+> repo 的寫入權。因此它只落在 Manager 的 HOME 下；**job 帳號刻意沒有 `~/.config/gh`
+> 這一層目錄**（`trust_root scaffold` 不會為它們建，建了就是多開一條被明確關掉的通道）。
+
+> **⚠️ 兩個檔的 owner 刻意不同，這不是疏漏**（下一個人最可能做錯的就是把兩個設成同一種）：
+>
+> | 檔 | owner / mode | 為什麼 |
+> |---|---|---|
+> | `.config/`、`.config/gh/` | `root:root 0755` | 增／刪／換需要**目錄**的寫入權；性質全部落在這一層 |
+> | `hosts.yml` | `cortex-manager:cortex-manager 0600` | `gh` **唯一寫回 token 的檔**（`auth login`／`refresh` 就地覆寫），不歸它就 refresh 不回來 |
+> | `config.yml` | `root:root 0644` | 非憑證；但 `aliases` 可宣告 `!` 開頭的 **shell alias** ⇒ 讓服務帳號改得了它等於給 Manager 一條「把任意命令掛進每一次 `gh` 呼叫」的執行面。與三份 `.gitconfig` 維持 root-owned 是**同一條理由**（`core.fsmonitor`／`alias.*`） |
+
+> **落點為什麼是 `~/.config/gh` 而不是別條**：`gh` 依序看 `$GH_CONFIG_DIR` →
+> `$XDG_CONFIG_HOME/gh` → `$HOME/.config/gh`，而產生出來的 unit 設 `HOME=` 與
+> `XDG_CACHE_HOME=`、**刻意不設 `XDG_CONFIG_HOME=`**。哪天有人在 unit 或
+> EnvironmentFile 補上 `XDG_CONFIG_HOME`，憑證的實際落點會跟著搬走而登記表不會知道
+> ——那是**無聲**的漂移：`gh auth status` 變成「未登入」，而檔案還好端端躺在原處。
+
+```bash
+# ✅ 先確認兩層目錄已由骨架建出（第 2b 步；這裡只驗，不建）
+python3 -m paulsha_cortex.trust_root scaffold four-way | grep '\.config'
+#   期望兩行：
+#     install -d -o root -g root -m 0755 /var/lib/cortex-manager/.config
+#     install -d -o root -g root -m 0755 /var/lib/cortex-manager/.config/gh
+ls -ld /var/lib/cortex-manager/.config /var/lib/cortex-manager/.config/gh
+#   期望：兩層皆 drwxr-xr-x root root
+```
+
+```bash
+# 🔧 sudo：把 operator 那份登入態複製過去（**兩個檔、兩種 owner**）
+sudo install -o cortex-manager -g cortex-manager -m 0600 \
+  "$HOME/.config/gh/hosts.yml" /var/lib/cortex-manager/.config/gh/hosts.yml
+sudo install -o root -g root -m 0644 \
+  "$HOME/.config/gh/config.yml" /var/lib/cortex-manager/.config/gh/config.yml
+#   ↑ `.config/gh/` 目錄本身**不要**動。
+#   落位步驟也由產生器出（含理由與驗證）：
+#     python3 -m paulsha_cortex.trust_root toolchain four-way | sed -n '/Manager 的 gh 憑證/,/Permission denied/p'
+```
+
+```bash
+# ✅ 驗證（1）：與登記表產生的計畫逐字一致
+python3 -m paulsha_cortex.trust_root permissions four-way --commands --paths \
+  --operator-account "$USER" --external-reader-account none | grep 'config/gh'
+#   期望四行（皆帶 `[ ! -e ] ||` 守衛）：
+#     chown cortex-manager:cortex-manager …/hosts.yml
+#     chmod 0600                            …/hosts.yml
+#     chown root:root                       …/config.yml
+#     chmod 0644                            …/config.yml
+ls -l /var/lib/cortex-manager/.config/gh/
+#   期望：-rw------- cortex-manager cortex-manager hosts.yml
+#         -rw-r--r-- root           root           config.yml
+
+# ✅ 驗證（2）：**以 Manager 身分實測**（不是只驗檔案存在）
+sudo -u cortex-manager env HOME=/var/lib/cortex-manager gh auth status
+#   期望：以 fleet 正式身分登入成功、`Token scopes` 列得出來。
+#   ⚠️ 若仍是 `You are not logged into any GitHub hosts.`：先看有沒有人設了
+#      `XDG_CONFIG_HOME`／`GH_CONFIG_DIR`（見上方那條無聲漂移的警告）。
+
+# ✅ 驗證（3）：**在完整加固面下**複跑（`sudo -u` 沒有 unit 的加固面）
+sudo systemd-run --pipe --wait --collect \
+  --uid=cortex-manager --gid=cortex-manager \
+  --property=NoNewPrivileges=yes --property=ProtectSystem=strict \
+  --property=ProtectHome=yes --property=MemoryDenyWriteExecute=yes \
+  --setenv=HOME=/var/lib/cortex-manager \
+  --setenv=PATH=/opt/cortex/toolchain/bin:/usr/local/bin:/usr/bin:/bin \
+  /usr/bin/gh auth status
+#   期望：同上。`gh` 是原生 ELF，MDWE 不影響它。
+
+# ✅ 驗證（4）：**不變式「改得了內容、建不了新檔」**（與 4e 的憑證逐條同構）
+sudo -u cortex-manager sh -c \
+  "cat /var/lib/cortex-manager/.config/gh/hosts.yml > /tmp/psc-hosts.bak && \
+   cat /tmp/psc-hosts.bak > /var/lib/cortex-manager/.config/gh/hosts.yml" && echo "改內容: OK"
+#   期望：OK（token refresh 走得通）
+sudo -u cortex-manager sh -c \
+  "touch /var/lib/cortex-manager/.config/gh/newfile" 2>&1 | tail -1
+#   期望：Permission denied ← **建不了新檔**（同時封掉「暫存檔＋rename」那條路）
+sudo -u cortex-manager sh -c \
+  "rm -f /var/lib/cortex-manager/.config/gh/config.yml" 2>&1 | tail -1
+#   期望：Permission denied ← **刪不掉 root-owned 的鄰居**
+sudo -u cortex-manager sh -c \
+  "printf 'aliases:\n  x: \"!id\"\n' > /var/lib/cortex-manager/.config/gh/config.yml" 2>&1 | tail -1
+#   期望：Permission denied ← **改不了 config.yml 的內容**（`!` shell alias 那條執行面關著）
+sudo rm -f /tmp/psc-hosts.bak
+
+# ✅ 驗證（5）：unit 的 ReadWritePaths 只掛**那一個檔**，不是父目錄
+python3 -m paulsha_cortex.trust_root unit four-way --manager | grep 'config/gh'
+python3 -m paulsha_cortex.trust_root unit four-way --monitor | grep 'config/gh'
+#   期望兩者都只有 `ReadWritePaths=/var/lib/cortex-manager/.config/gh/hosts.yml`
+#   （出現 `…/.config/gh` 這條目錄＝父目錄被開放，`config.yml` 會跟著可寫 ⇒ 錯）
+
+# ✅ 驗證（6）：job 側必須是**反向**的
+python3 -m paulsha_cortex.trust_root unit four-way --job | grep -c 'config/gh' || true
+#   期望：0
+python3 -m paulsha_cortex.trust_root unit four-way --job | grep 'GH_TOKEN'
+#   期望：`Environment=GH_TOKEN=`（空值）
+```
+
+**回滾**：`sudo rm -f /var/lib/cortex-manager/.config/gh/{hosts.yml,config.yml}`。
+
+---
+
+### 4h. 窮舉盤點的複核（#666）——**每次部署都跑一次**
+
+前面 4e／4f／4g 三節各自處理一族，但真正要防的是「下一個沒被盤到的相依」。把盤點印出來
+逐項對一次，比等症狀出現便宜得多。
+
+```bash
+# ✅ 完整盤點（判準：降權帳號在完整加固面下跑完一個 run 需要碰到的所有外部程式與憑證）
+python3 -m paulsha_cortex.trust_root toolchain four-way | sed -n '/窮舉盤點/,$p'
+#   逐段列出 dispatch／model-call／review／gate／ship／monitor 六段各需要什麼、
+#   由哪個 principal 碰到、登記在哪張表。
+
+# ✅ 雙向封閉（兩個都必須是空的；非空＝盤點已漂移，先修再往下裝）
+python3 -c "from paulsha_cortex.trust_root import permgen as p
+print('uncovered:', p.uncovered_run_dependencies())
+print('unlisted :', p.unlisted_roster_entries())"
+#   期望：兩行皆為 `()`。
+
+# ✅ 已知未決項（**不是**待辦清單，是「已經被看見的決定」）
+python3 -c "from paulsha_cortex.trust_root import permgen as p
+for d in p.deferred_run_dependencies(): print('-', d.name, '→', d.disposition)"
+#   目前四項；每一項的完整理由與症狀在 permgen.deferred_run_dependencies() 的 note 裡。
+#   ⚠️ 這幾項**尚未落地**，不要照著自己補——它們各自需要 operator 的部署面裁決。
+```
 
 ---
 
@@ -4326,8 +4570,32 @@ codex --version
 stat -c '%n %U:%G %a' /var/lib/cortex-builder/.codex /var/lib/cortex-builder/.codex/auth.json
 #   期望：目錄 root:root 755、檔案 cortex-builder:cortex-builder 600
 
+# ✅ Manager 的 gh 憑證仍是「兩個檔、兩種 owner」（#666；第 4g 步）
+stat -c '%n %U:%G %a' /var/lib/cortex-manager/.config/gh \
+  /var/lib/cortex-manager/.config/gh/hosts.yml \
+  /var/lib/cortex-manager/.config/gh/config.yml
+#   期望：目錄 root:root 755、hosts.yml cortex-manager:cortex-manager 600、
+#         config.yml root:root 644。
+#   ⚠️ 若 config.yml 變成 cortex-manager owned，`aliases` 的 `!` shell alias 執行面
+#      就打開了——那是最容易被「順手統一成同一種 owner」弄壞的一格。
+sudo -u cortex-manager env HOME=/var/lib/cortex-manager gh auth status >/dev/null \
+  && echo "manager gh: OK"
+
+# ✅ gate 跑得動 pytest，且版本沒有無聲換掉（#666；第 4f 步）
+sudo -u cortex-gate env HOME=/var/lib/cortex-gate \
+  PATH=/opt/cortex/toolchain/bin:/usr/local/bin:/usr/bin:/bin python3 -m pytest --version
+#   期望：與部署紀錄裡記下的那一版逐字相同。換掉了而沒人知道 ⇒ gate 判準已漂移。
+
+# ✅ 窮舉盤點仍雙向封閉（#666；第 4h 步）——非空即代表登記表已落後於程式碼
+python3 -c "from paulsha_cortex.trust_root import permgen as p
+assert p.uncovered_run_dependencies() == (), p.uncovered_run_dependencies()
+assert p.unlisted_roster_entries() == (), p.unlisted_roster_entries()
+print('inventory closed:', len(p.RUN_EXTERNAL_DEPENDENCIES), 'deps;',
+      len(p.deferred_run_dependencies()), 'deferred')"
+
 # ✅ 產生器本身的等式測試（含 ReadWritePaths 無遺漏無多餘）
-python3 -m pytest tests/test_trust_root_permgen_p2a.py tests/test_trust_root_permgen_p2b.py -q
+python3 -m pytest tests/test_trust_root_permgen_p2a.py tests/test_trust_root_permgen_p2b.py \
+  tests/test_trust_root_external_deps_exhaustive_666.py -q
 ```
 
 ---

--- a/docs/superpowers/runbooks/trust-root-phase2b-setup.md
+++ b/docs/superpowers/runbooks/trust-root-phase2b-setup.md
@@ -2040,7 +2040,9 @@ sudo -u cortex-gate env HOME=/var/lib/cortex-gate python3 -c 'import yaml; print
 #   期望：印出版本
 
 # ✅ 驗證（2）：**在完整加固面下**複跑（`sudo -u` 沒有 unit 的加固面）
-sudo install -d -o root -g root -m 0755 /tmp/psc-gate-probe
+#    探測目錄給 gate 帳號擁有——pytest 會在 rootdir 建 `.pytest_cache`，root-owned 的
+#    目錄會讓它印一段與待驗命題無關的 cache 警告，白白製造雜訊。
+sudo install -d -o cortex-gate -g cortex-gate -m 0755 /tmp/psc-gate-probe
 printf 'def test_ok():\n    assert True\n' \
   | sudo tee /tmp/psc-gate-probe/test_probe.py >/dev/null
 sudo systemd-run --pipe --wait --collect \

--- a/docs/superpowers/specs/trust-root-isolation-spec.md
+++ b/docs/superpowers/specs/trust-root-isolation-spec.md
@@ -643,6 +643,77 @@ provider 帳號下的兩個 job 在 provider 眼中是同一個主體，配額�
 真正的 provider 層獨立需要**每個 job 帳號各自的 provider 帳號**，成本最高（帳號、
 計費、配額各自管理），屬**未來選項**，不在本票範圍。
 
+##### (b2) Manager 的傳輸層憑證：同一個形狀，**不同級的洩漏面**（#666；登記表資產 `manager-gh-credential`／`manager-gh-config`）
+
+Manager／monitor 帳號在 `ProtectHome=yes` 之後同樣拿不到 operator 的 `gh` 登入態：
+
+```
+$ sudo -u cortex-manager env HOME=<manager HOME> gh auth status
+You are not logged into any GitHub hosts.
+```
+
+- `<manager HOME>/.config/gh/hosts.yml` SHALL 由 durable state owner 擁有、mode `0600`，
+  並比照 (b) 掛在 `IN_PLACE_CONTENT_WRITE_ASSETS`——它是 `gh` 唯一寫回 token 的檔
+  （`auth login`／`refresh` 就地覆寫），不歸該帳號就 refresh 不回來。
+- 放它的兩層目錄（`<HOME>/.config`、`<HOME>/.config/gh`）SHALL 維持 root-owned `0755`。
+  落點之所以是這一條，是因為產生出來的 unit 設 `HOME=` 與 `XDG_CACHE_HOME=` 而**刻意
+  不設 `XDG_CONFIG_HOME=`**；日後在 unit 或 EnvironmentFile 補上它會讓憑證的實際落點
+  **無聲**搬走（症狀是「未登入」，而檔案還在原處）。
+- `<manager HOME>/.config/gh/config.yml` SHALL **root-owned `0644`**——與 `hosts.yml`
+  **刻意不同 owner**。它不承載憑證，但其 `aliases` 可宣告 `!` 開頭的 shell alias；讓
+  服務帳號改得了它，等於給 Manager 一條「自己把任意命令掛進每一次 `gh` 呼叫」的執行面，
+  與三份 `.gitconfig` 維持 root-owned 的理由（`core.fsmonitor`／`alias.*`）逐字相同。
+- job 帳號 SHALL **NOT** 取得這一層目錄或這份憑證。job 模板 unit 已帶
+  `Environment=GH_TOKEN=`／`GITHUB_TOKEN=`，GitHub 寫入一律由 Manager 代理（D1 outbox）。
+
+**這一份與 (b) 的 job 憑證 MUST NOT 被當成同一件事。** 形狀相同（檔案帳號 owned、目錄
+root-owned），洩漏面不同級：(b) 是**job 帳號**的模型 provider 憑證，被竊只換得到模型
+呼叫額度，且 job 交出來的成果仍要經過 spool 與 Manager 的採信鏈；本節這一份是給
+**Manager** 的，而 Manager 是 durable state owner——這個 token 推得動 PR、關得掉 issue、
+改得了 label、merge 得了分支，也就是**治理平面對上游 repo 的寫入權**。因此它只掛在
+durable state owner 的 HOME 下，且不對任何 job 帳號開放。
+
+##### (c) 外部相依的盤點判準：**從一個 run 反推**，而不是逐類列舉（#666）
+
+`#640`（executor toolchain ＋ job 憑證）、`#661`（`srt`／`openspec`／preflight backend）、
+`#666`（`pytest`／Manager 的 gh 憑證）是同一族的第一到第五個成員，每一次都是「症狀出現
+才補一項」。前面各張表本身都完整，但它們回答的是「**這一類**東西有哪些」——沒有任何一處
+回答「跑完一個 run 需要碰到的東西有哪些」。
+
+- 登記表 SHALL 維護一份以「**降權帳號在完整加固面下跑完一個 run 需要碰到的所有外部程式
+  與憑證**」為判準的窮舉盤點（`permgen.RUN_EXTERNAL_DEPENDENCIES`），逐項標明 kind、
+  哪些 principal、run 的哪一段、以及**它登記在哪**。
+- 盤點 SHALL **雙向封閉**：`uncovered_run_dependencies()`（盤點列到但表上查無）與
+  `unlisted_roster_entries()`（表上有但盤點沒列到）皆 MUST 為空，且兩者皆有測試。後者
+  是關鍵——它讓「加一支相依」與「說明它在 run 的哪一段被誰碰到」變成同一件事。
+- 盤到但**尚無歸宿**者 MUST NOT 塞進主盤點充數，SHALL 由
+  `permgen.deferred_run_dependencies()` 列舉（比照 `unresolved_node_execution_surfaces()`
+  的先例：不裁決、不放寬、但不得靜默消失）。
+
+**新增的第四種相依：python 發行版。** `pytest`／`PyYAML`／`policy-check` 不是落在 `PATH`
+上的可執行檔，`command -v` 對它們一律無解；把它們塞進 `SYSTEM_PROGRAMS` 會讓「名冊上每一
+項都解析得到執行檔」這條既有性質變成假的（與「不得把 `srt` 併進 `EXECUTOR_TOOLS`」同一條
+論證）。因此另立 `permgen.SYSTEM_PYTHON_DISTRIBUTIONS`／`DEPLOYMENT_PYTHON_DISTRIBUTIONS`
+兩張表，各自標明落在哪一個 interpreter 與版本約束的**唯一宣告來源**。
+
+- operator 宣告的 gate 命令（`PSC_GATE_CMD_*`）若使用相對名 `python3`，它 SHALL 被理解為
+  由 gate 的 `PSC_GATE_PATH` 解析出來的**系統層** interpreter——gate unit 自己的
+  `ExecStart` 用部署 venv 的 interpreter，但那只涵蓋 ledger writer 本身，**宣告的命令另外
+  解析一次**。因此該命令所需的 python 套件 SHALL 裝在系統層，且版本 SHALL 是明示的部署
+  決定（約束宣告於 `pyproject.toml`，實際落定的版本記入 runbook 並與 operator 側比對）。
+- 產生器 SHALL 出一份建議的 gate 宣告（`permgen.GATE_COMMAND_DECLARATIONS` →
+  `PathLayout.gate_command_env()`），且該宣告 SHALL 覆蓋 packaged deck 依 `test_policy`
+  導出的每一個 gate 名——否則照 runbook 裝出來的部署一開機 doctor 的 `gate-declarations`
+  就是紅的，而症狀要到 builder 交出合格 candidate 之後才在採信階段現形（#540）。
+
+**HOME-anchored 資產在不適用的方案下 MUST NOT 進入 `ReadWritePaths`。** 幾個掛在帳號 HOME
+下的資產由 `PathLayout` 的部署決定欄位導出路徑，而那些欄位取的是定案的三分／四分；二分把
+Manager／reviewer／planner 併進 `cortex-svc`，同一條路徑在二分部署裡不存在，而 systemd 對
+不存在的 `ReadWritePaths=` 目標會讓 unit **直接起不來**。此前的處置是「乾脆不登記第二份」
+（#640 對 reviewer 憑證的決定）；#666 起改由機械規則
+`permgen.inapplicable_home_anchored_assets()` 表達，並**可列舉**——靜默扣掉一條 RWP 與漏授
+一條在輸出上長得一樣，後者的症狀是 job 跑到一半 EROFS。
+
 ### R2 所有 Tier-0／Tier-1 durable state 與 mutation ingress MUST 位於不受信任 headless persona 不可寫的 OS 邊界內
 
 系統 SHALL 使 builder／reviewer／planner 對登記表中 tier 0 與 1 的全部路徑

--- a/paulsha_cortex/trust_root/permgen.py
+++ b/paulsha_cortex/trust_root/permgen.py
@@ -4537,6 +4537,12 @@ def build_toolchain_plan(
 
 def _system_python_lines(layout: PathLayout) -> list[str]:
     """系統層 python 發行版的落位段（#666 漂移項 1）。"""
+    # 刻意先組成字串再放進 list：巢狀 f-string ＋ 同款引號是 PEP 701（3.12+）語法，
+    # 而本 repo 的 `requires-python` 從 3.10 起——CI 的 3.10／3.11 會直接 SyntaxError。
+    declarations = " / ".join(
+        '{}="{}"'.format(key, value)
+        for key, value in layout.gate_command_env().items()
+    )
     lines = [
         "",
         "# ===== 系統層 python 發行版（#666 漂移項 1：pytest）=====",
@@ -4544,7 +4550,7 @@ def _system_python_lines(layout: PathLayout) -> list[str]:
         "# 發行版，`import`／`-m` 得到才有意義，`command -v` 對它一律無解。",
         "#",
         "# **為什麼落在系統層而不是部署 venv**：operator 宣告的 gate 命令用的是相對名",
-        f"#   {' / '.join(f'{k}=\"{v}\"' for k, v in layout.gate_command_env().items())}",
+        f"#   {declarations}",
         "# 而 gate 的 PSC_GATE_PATH 尾段是系統層 ⇒ `python3` 解到 /usr/bin/python3。",
         "# gate unit 自己的 ExecStart 用的是部署 venv 的 interpreter，但那只涵蓋 ledger",
         "# writer 本身；**operator 宣告的命令另外解析一次**。兩者是不同的 interpreter。",

--- a/paulsha_cortex/trust_root/permgen.py
+++ b/paulsha_cortex/trust_root/permgen.py
@@ -75,7 +75,7 @@ import unicodedata
 from dataclasses import dataclass, field, replace
 from enum import Enum
 from types import MappingProxyType
-from typing import Mapping, Sequence
+from typing import Callable, Mapping, Sequence
 
 from . import registry
 from .registry import (
@@ -632,6 +632,13 @@ class SystemProgram:
 #: **#661 之前這裡只有 `node` 一列**，而那是不完整的盤點：`srt` 在 Linux 上實際會去
 #: exec `bwrap` 與 `socat`（doctor 的 `review-sandbox` probe 逐一跑它們的 `--version`），
 #: Manager 則需要 `git`／`gh`。缺任何一支的症狀都不是「設定錯」而是「跑到一半才失敗」。
+#:
+#: **#666 的窮舉盤點又補上三支**，而三支都是「一直在用、只是從來沒被寫下來」的那種：
+#: `bash`（每一支 job 的 `command[0]` 就是它——wrapper 是 `bash -c <script>`）、
+#: `python3`（gate 宣告 `python3 -m pytest` 時解析到的是**系統層**那一支，不是部署
+#: venv 的）、`systemctl`（B 案定案之後，Manager 派工的第一個動作就是 exec 它）。
+#: 判準沒有改變——它們仍是「版本換掉幾乎不影響治理產出」的通用工具；改變的只是
+#: 「盤點有沒有做完」。
 SYSTEM_PROGRAMS: tuple[SystemProgram, ...] = (
     SystemProgram(
         "node", "apt: nodejs", ("codex", "copilot", "srt", "openspec"),
@@ -666,6 +673,54 @@ SYSTEM_PROGRAMS: tuple[SystemProgram, ...] = (
             "`socat -V` 驗證。"
         ),
     ),
+    SystemProgram(
+        "bash", "apt: bash（base system）", ("builder", "reviewer-planner", "manager"),
+        note=(
+            "**每一支 job 的 `command[0]` 就是它**（#666 窮舉盤點補上）。"
+            "`launcher.build_wrapper_script()` 產的是一段 shell script，"
+            "`launcher` 交給 runner 的 argv 是 `bash -c <script>`（reviewer 與降權 "
+            "builder）或 `bash -lc <script>`（direct builder）；降權模式下 shim 的 "
+            "`os.execvpe(command[0], …)` 執行的第一支程式因此是 `bash`。Manager 側的 "
+            "exit 記帳 shell（`job_runner.build_manager_exit_recorder_argv`）同樣是 "
+            "`bash -c`。\n"
+            "**為什麼它一直沒被盤到**：它落在 `JOB_PATH_SYSTEM_TAIL` 的 `/bin` 裡、"
+            "而且從來沒缺過，所以「沒被登記」與「不需要」在實機上長得一樣。這正是本"
+            "族每一次的形態——把它寫下來的價值不在於它會缺，而在於它是 job 執行面的"
+            "**第一段**：`ProtectSystem=strict` 或 `NoExecPaths` 之類的加固項哪天涵蓋"
+            "到 `/bin`，症狀會是「每一個 job 都起不來且沒有輸出」。"
+        ),
+    ),
+    SystemProgram(
+        "python3", "apt: python3", ("gate", "srt", "manager"),
+        note=(
+            "**gate 宣告解析到的是這一支，不是部署 venv 的那一支**（#666）。"
+            "`PSC_GATE_CMD_PYTEST=\"python3 -m pytest -q\"` 是相對名，由 gate 的 "
+            "`PSC_GATE_PATH`（`<toolchain>/bin` ＋ `JOB_PATH_SYSTEM_TAIL`）解析 ⇒ "
+            "`/usr/bin/python3`。gate unit 自己的 `ExecStart` 用的是 "
+            "`gate_runner.DEFAULT_GATE_PYTHON`（`<venv>/bin/python3`），但那只涵蓋 "
+            "ledger writer 本身；**operator 宣告的 gate 命令另外解析一次**。\n"
+            "這是 #666 兩個漂移項之一的機械成因：pytest 裝在 operator 的 user "
+            "site-packages 時，系統層的 `python3` 在 `ProtectHome=yes` 之後 import "
+            "不到它 ⇒ 每張 build 卡的 ledger 為空 ⇒ 撞 #540 的 acceptance chain。"
+            "系統層需要哪些 python 套件見 :data:`SYSTEM_PYTHON_DISTRIBUTIONS`。\n"
+            "doctor 的 `review-sandbox` probe 也把它列進 "
+            "`REVIEW_SANDBOX_EXECUTABLES`（`srt` 的沙箱 smoke test 拿它當被關的程式），"
+            "同樣走 `PATH` 解析。"
+        ),
+    ),
+    SystemProgram(
+        "systemctl", "apt: systemd", ("manager",),
+        note=(
+            "**B 案（模板 unit，0816 第三輪定案）的派工 client**（#666）。"
+            "`job_runner.build_systemctl_start_argv()` ／ `gate_runner` 起 job 與 gate "
+            "的方式就是 `systemctl start --wait <模板實例>`，`is-active` 查狀態亦然；"
+            "polkit 規則放行的也正是這條路徑。Manager 以 system unit 跑，因此它必須"
+            "落在 Manager 自己的 `PATH` 上——`job_runner` 是以 `which(\"systemctl\")` "
+            "解的，解不到就是「降權派工整條不可用」而不是單一 job 失敗。\n"
+            "**`systemd-run` 不另立一列**：那是附錄 B 的降級備援（A 案 transient unit），"
+            "同一個 `systemd` 套件出的，升降級不會只有其中一支在場。"
+        ),
+    ),
 )
 
 #: 系統層程式的名字（既有名稱保留；值由 :data:`SYSTEM_PROGRAMS` 機械導出，避免兩份
@@ -691,6 +746,172 @@ PREFLIGHT_BACKEND_MODULE = "policy_check.preflight"
 #: 版本必須逐字等於 `.project-policy.yml` 的 `policy_version`（引擎自己會驗，對不上就
 #: fail-closed），因此「裝哪一版」與 R-23 的 workflow pin 是同一個部署決定。
 PREFLIGHT_BACKEND_DISTRIBUTION = "policy-check"
+
+
+# ---------------------------------------------------------------------------
+# python 發行版（#666）——**第四種**外部相依，前三張表都收不下它
+#
+# `TOOLCHAIN_PROGRAMS` 與 `SYSTEM_PROGRAMS` 的形狀都是「一個落在 `PATH` 上的可執行
+# 檔」，而這一族不是：`pytest`／`PyYAML`／`policy-check` 是 **python 發行版**，
+# `import` 或 `python3 -m` 得到才有意義，`command -v` 對它們一律無解。硬塞進
+# `SYSTEM_PROGRAMS` 會讓「`TOOLCHAIN_SYSTEM_RUNTIMES` 的每一項都應該 `which` 得到」
+# 這條既有性質變成假的——那是把盤點完整性拿去換掉一條真的不變式，正是 #661 對
+# 「不要把 `srt` 併進 `EXECUTOR_TOOLS`」的同一條論證。
+#
+# **落在哪一個 interpreter 是關鍵，而且兩個都有人用**：
+#
+# - **系統層**（`/usr/bin/python3`）：operator 宣告的 gate 命令 `PSC_GATE_CMD_PYTEST=
+#   "python3 -m pytest -q"` 是**相對名**，由 gate 的 `PSC_GATE_PATH` 解析，落在
+#   `JOB_PATH_SYSTEM_TAIL` 的 `/usr/bin`。#666 的實機症狀就是這一格：pytest 只裝在
+#   operator 的 user site-packages，`ProtectHome=yes` 之後系統層的 `python3` import
+#   不到 ⇒ ledger 空 ⇒ 撞 #540 的 acceptance chain。
+# - **部署 venv**（`<deploy_root>/venv`）：cortex 自己與 preflight backend 住的地方，
+#   既有的 root-owned 部署資產，不需要新增檔案系統資產（#661 已裁決）。
+# ---------------------------------------------------------------------------
+
+#: :class:`PythonDistribution.interpreter` 的兩個值。
+SYSTEM_INTERPRETER = "system"
+DEPLOYMENT_VENV_INTERPRETER = "deployment-venv"
+
+
+@dataclass(frozen=True)
+class PythonDistribution:
+    """一個 python 發行版的部署決定（#666）。不是可執行檔，因此不進前兩張表。"""
+
+    #: PyPI 發行版名（`pip install` 用的那個名字）。
+    name: str
+    #: `import` ／ `python3 -m` 用的模組名（與發行版名常常不同，例如 PyYAML→yaml）。
+    module: str
+    #: 落在哪一個 interpreter：:data:`SYSTEM_INTERPRETER` 或
+    #: :data:`DEPLOYMENT_VENV_INTERPRETER`。
+    interpreter: str
+    #: **版本要求本身**——這是「明示的部署決定」那一半。刻意寫成 requirement 字串而
+    #: 不是解析出來的版本號：產生器是純函式，讀不到實機裝了哪一版；它能負責的是
+    #: 「約束從哪裡來」，實際落定的版本由 runbook 的驗證步驟記錄並比對。
+    requirement: str
+    #: 上面那條約束的**宣告來源**（唯一真相在哪個檔）。
+    declared_in: str
+    #: 誰需要它（帳號／角色名，讓 runbook 知道要以哪個身分實跑驗證）。
+    required_by: tuple[str, ...]
+    note: str
+
+    @property
+    def module_invocation(self) -> tuple[str, ...]:
+        """以 `-m` 執行時的 argv 尾段（可執行的那一族才有意義）。"""
+        return ("-m", self.module)
+
+
+#: **系統層** python 發行版（#666）。判準與 :data:`SYSTEM_PROGRAMS` 同一條：它們是
+#: 通用工具，換版本不改變治理判準；但「gate 用哪一版 pytest 跑測試」仍必須是可稽核
+#: 的部署決定，而不是跟著 operator 的 `pip install --user` 漂移。
+#:
+#: **這張表的存在條件是 operator 的 gate 宣告用相對名 `python3`**（見
+#: :data:`GATE_COMMAND_DECLARATIONS`）。改宣告成部署 venv 的絕對路徑 interpreter，
+#: 系統層這一份需求就整個消失——那是 operator 平面的裁決，不是產生器能替它做的，
+#: 因此這裡記的是**目前這個部署決定的後果**，不是唯一可能的形態。
+SYSTEM_PYTHON_DISTRIBUTIONS: tuple[PythonDistribution, ...] = (
+    PythonDistribution(
+        "pytest", "pytest", SYSTEM_INTERPRETER,
+        requirement="pytest>=7",
+        declared_in="pyproject.toml [project.optional-dependencies] test",
+        required_by=("gate",),
+        note=(
+            "gate 執行身分實際跑的 test runner。#666 實機症狀：裝在 operator 的 "
+            "`~/.local/lib/python3.12/site-packages`，`ProtectHome=yes` 之後 gate 身分"
+            "讀不到——\n"
+            "    $ sudo -u cortex-gate env HOME=<gate HOME> python3 -m pytest --version\n"
+            "    /usr/bin/python3: No module named pytest\n"
+            "後果不是「gate 失敗」而是**每張 build 卡的 ledger 為空**，接著整條 #540 "
+            "的 acceptance chain 卡住，而錯誤只在 manager.log 裡。\n"
+            "**落系統層而不是部署樹**：它是通用 test runner，不是「換版本會改變治理"
+            "產出」的那一類（與 `node` 同一條理由，與模型 CLI 相反）。但**版本仍是"
+            "部署決定**：約束由 `pyproject.toml` 的 `test` extra 宣告，實機解出來的"
+            "版本必須記進 runbook 並與 operator 側比對——同一台機器上兩個 "
+            "interpreter 各有一份 pytest 是常態，而版本分岔的症狀是「gate 判定與"
+            "本機跑不一樣」，不是報錯。\n"
+            "**加固面已實測**：CPython 不是 V8，`MemoryDenyWriteExecute=yes` 不影響"
+            "它（與 #643 的 node 型 executor 相反），完整加固面下跑得完。"
+        ),
+    ),
+    PythonDistribution(
+        "PyYAML", "yaml", SYSTEM_INTERPRETER,
+        requirement="PyYAML>=6",
+        declared_in="pyproject.toml [project] dependencies",
+        required_by=("gate",),
+        note=(
+            "**不是 pytest 的相依，是被測樹的相依**（#666 窮舉盤點；票上只點名了 "
+            "pytest，但實機兩個是一起裝的，理由在這裡）。gate 命令的 cwd 是 gate "
+            "自己那份工作樹副本，pytest 會把 rootdir 插進 `sys.path`，於是 "
+            "`import paulsha_cortex` 解到**被驗的那棵樹**，而 cortex 的 runtime "
+            "相依裡有 PyYAML。系統層的 `python3` 沒有它，收集階段就 ImportError ⇒ "
+            "pytest exit code 落在 `2`（collection error）⇒ 依 #307 的判準**不會**被"
+            "當成合格 RED，而是照一般規則記 failed。\n"
+            "**這條的一般形式**：`PSC_GATE_CMD_*` 用系統 interpreter 時，"
+            "**被治理 repo 的整組 runtime 相依**都成了系統層的部署決定。目前受治理的"
+            "只有 cortex 自己（PyYAML 一項），治理面擴到別的 repo 時這一列要跟著長。"
+        ),
+    ),
+)
+
+#: **部署 venv** 裡的 python 發行版（#666 把既有的兩個散落常數收進同一張表）。
+#: 落點是既有的 root-owned 部署資產（`<deploy_root>/venv`），因此**不新增任何檔案
+#: 系統資產**——這與 #661 對 preflight backend 的裁決逐字相同。
+DEPLOYMENT_PYTHON_DISTRIBUTIONS: tuple[PythonDistribution, ...] = (
+    PythonDistribution(
+        PREFLIGHT_BACKEND_DISTRIBUTION, PREFLIGHT_BACKEND_MODULE.split(".")[0],
+        DEPLOYMENT_VENV_INTERPRETER,
+        requirement=f"{PREFLIGHT_BACKEND_DISTRIBUTION}==<policy_version>",
+        declared_in=".project-policy.yml policy_version（＋ R-23 的 workflow pin）",
+        required_by=("manager",),
+        note=(
+            "preflight adapter 的 backend（#661）。版本必須逐字等於 "
+            "`.project-policy.yml` 的 `policy_version`——引擎自己會驗，對不上 "
+            "fail-closed；CI 端 R-23 另外釘住 workflow pin ⟷ `policy_version`，"
+            "兩條遞移出「本機跑的引擎版本 == CI 跑的引擎版本」。"
+        ),
+    ),
+    PythonDistribution(
+        "PyYAML", "yaml", DEPLOYMENT_VENV_INTERPRETER,
+        requirement="PyYAML>=6",
+        declared_in="pyproject.toml [project] dependencies",
+        required_by=("manager", "monitor"),
+        note=(
+            "cortex 自己唯一的 runtime 相依（deck／persona／model-identities 全是 "
+            "YAML）。隨 `pip install paulsha-cortex` 進 venv，**與系統層那一份是兩個"
+            "不同 interpreter 下的兩份**——列在這裡是為了讓「同一個發行版在兩個落點"
+            "各有一份」這件事是明寫的，而不是靠讀者自己發現。"
+        ),
+    ),
+)
+
+#: 兩個落點的聯集——窮舉盤點的輸入之一。
+PYTHON_DISTRIBUTIONS: tuple[PythonDistribution, ...] = (
+    SYSTEM_PYTHON_DISTRIBUTIONS + DEPLOYMENT_PYTHON_DISTRIBUTIONS
+)
+
+
+#: operator 應該宣告的 gate 命令（`PSC_GATE_CMD_<NAME>` → typed argv，#666）。
+#:
+#: 與 `job_path_value()`／`preflight_command_value()` 同一個定位：**產生器出建議值、
+#: operator 落進 root-owned 的 EnvironmentFile**，不是第二份執行期真相（執行期真相
+#: 永遠是 `gate_ledger.load_gate_specs()` 讀到的那份 env）。
+#:
+#: 把它寫下來買到兩件既有形態買不到的事：
+#:
+#: 1. **gate 宣告的每一段都可以被機械對照到某張表**——`python3` 必須在
+#:    :data:`SYSTEM_PROGRAMS` 上、`-m <module>` 必須在
+#:    :data:`SYSTEM_PYTHON_DISTRIBUTIONS` 上。#666 的漂移正是這條不成立而沒人看得見。
+#: 2. **覆蓋率**：doctor 的 `gate-declarations` probe 以 packaged deck 每張卡的
+#:    `test_policy` 導出應驗 gate 集合，宣告沒涵蓋到就是 required fail。本表必須是
+#:    那個集合的**超集**，否則照 runbook 裝出來的部署一開機 doctor 就是紅的。
+GATE_COMMAND_DECLARATIONS: Mapping[str, tuple[str, ...]] = MappingProxyType({
+    "pytest": ("python3", "-m", "pytest", "-q"),
+})
+
+#: gate 宣告的環境變數前綴。**與 `coordinator.gate_ledger.GATE_ENV_PREFIX` 是成對
+#: 契約**（同 `DEFAULT_TEMPLATE_UNIT`／`JOB_PATH_ENV_BY_PRINCIPAL` 的既有模式：
+#: `permgen` 與 `coordinator` 刻意不互相 import，改由契約測試釘住兩邊逐字相等）。
+GATE_COMMAND_ENV_PREFIX = "PSC_GATE_CMD_"
 
 
 #: 二分（**向後相容選項**，非預設）：builder 一個帳號，其餘 headless／Manager／
@@ -936,6 +1157,10 @@ _FILE_ASSET_IDS = frozenset({
     # 判定直接決定 permgen 會不會把一整個目錄 chown 給 job 帳號，而該目錄必須維持
     # root-owned 才有「能改內容、不能增刪換」那條性質。
     "builder-executor-credential",
+    # #666：`~/.config/gh/` 底下的兩個檔，理由與上一條逐字相同——那一層目錄必須維持
+    # root-owned，`hosts.yml` 與 `config.yml` 才能是**不同 owner** 的兩個檔。
+    "manager-gh-credential",
+    "manager-gh-config",
 })
 
 
@@ -1650,6 +1875,30 @@ class PathLayout:
         """
         return f"{self.venv_root}/bin/python3 -m {PREFLIGHT_ADAPTER_MODULE}"
 
+    def gate_command_env(self) -> dict[str, str]:
+        """`PSC_GATE_CMD_<NAME>` 的建議值（#666）。
+
+        由 :data:`GATE_COMMAND_DECLARATIONS` 機械導出，**不接受第二份手寫清單**。
+        值刻意是相對名（`python3`）而不是絕對路徑，理由與 `preflight_command_value()`
+        **相反**，因此值得寫清楚：
+
+        - preflight 的 backend 是**部署產物**（隨 cortex 進同一個 venv），落點由部署
+          決定，寫絕對路徑才驗得到「缺件在 doctor 就看得見」；
+        - gate 命令跑的是**被驗那棵樹的測試**，用的是 gate 的 `PSC_GATE_PATH`
+          （`<toolchain>/bin` ＋ :data:`JOB_PATH_SYSTEM_TAIL`）解析出來的系統
+          interpreter。這條路徑上的 python 需要哪些套件，見
+          :data:`SYSTEM_PYTHON_DISTRIBUTIONS`。
+
+        **改成部署 venv 的絕對 interpreter 是一個 operator 可以做、但本產生器不會替
+        它做的裁決**：那會讓系統層那兩個 python 套件的需求整個消失，同時也讓 gate 跑
+        的 pytest 版本與 cortex 自己的部署版本綁在一起。兩邊各有取捨，因此這裡只出
+        「目前這個部署決定」的值。
+        """
+        return {
+            f"{GATE_COMMAND_ENV_PREFIX}{name.upper()}": " ".join(argv)
+            for name, argv in GATE_COMMAND_DECLARATIONS.items()
+        }
+
     @property
     def job_shim(self) -> str:
         """降權 job 模板 unit 的固定 `ExecStart=`（root-owned，內容由 permgen 產）。"""
@@ -1710,6 +1959,53 @@ class PathLayout:
         認 `safe.directory`，因此位置由帳號的 HOME 決定，與 `~/.codex` 同一個模式。
         """
         return f"{self.home_of(account)}/.gitconfig"
+
+    def declared_accounts(self) -> tuple[str, ...]:
+        """本 layout 以**部署決定欄位**寫死的帳號名（#666）。
+
+        `asset_paths()` 刻意不吃 scheme，因此幾個掛在帳號 HOME 下的資產只能由這三個
+        欄位導出路徑，而它們取的是**定案的三分／四分**。二分把 Manager／reviewer／
+        planner 併進 `cortex-svc`，於是這三條路徑在二分部署裡不存在——「哪些資產在
+        本方案不適用」因此要拿這張清單去對 `UidScheme.declared_accounts()`，見
+        :func:`inapplicable_home_anchored_assets`。
+        """
+        return (self.builder_account, self.reviewer_planner_account, self.manager_account)
+
+    def gh_config_dir_of(self, account: str) -> str:
+        """該帳號的 `gh` 設定目錄（`~/.config/gh`）。**必須 root-owned**（#666）。
+
+        **為什麼是這條路徑而不是別條**：`gh` 依序看 `$GH_CONFIG_DIR` →
+        `$XDG_CONFIG_HOME/gh` → `$HOME/.config/gh`。產生出來的 unit 設 `HOME=` 與
+        `XDG_CACHE_HOME=`，**刻意不設 `XDG_CONFIG_HOME=`**，因此解析結果就是這一條。
+        哪天有人在 unit 或 EnvironmentFile 補上 `XDG_CONFIG_HOME`，憑證的實際落點會
+        跟著搬走而登記表不會知道——那是**無聲**的漂移（`gh auth status` 會變成
+        「未登入」，兩個 github provider 一起 `degraded`，而檔案還好端端躺在原處）。
+
+        與 `codex_hooks_dir_of()`／`executor_credential_dir_of()` 同一個模式：目錄
+        root-owned，底下才放得下「檔案 job/服務-owned、目錄 root-owned」那組性質。
+        """
+        return f"{self.home_of(account)}/.config/gh"
+
+    def gh_credential_of(self, account: str) -> str:
+        """該帳號的 `gh` **憑證**檔（`~/.config/gh/hosts.yml`）。由該帳號擁有、0600。
+
+        `hosts.yml` 是 `gh` 唯一寫回 token 的檔（`gh auth login`／`refresh` 就地覆寫
+        它）。因此它與 #640 裁決 (b) 的 `auth.json` 同一族：**檔案**由使用它的帳號
+        擁有（token 過期要 refresh 得回來），**放它的目錄維持 root-owned**。
+        """
+        return f"{self.gh_config_dir_of(account)}/hosts.yml"
+
+    def gh_settings_of(self, account: str) -> str:
+        """該帳號的 `gh` **非憑證**設定（`~/.config/gh/config.yml`）。root-owned、0644。
+
+        它與 `hosts.yml` **刻意不同 owner**，而且不是疏漏：`config.yml` 放的是
+        editor／pager／aliases／`prompt` 這類偏好，其中 **`aliases` 可以宣告 `!`
+        開頭的 shell alias**——讓服務帳號改得了它，等於把一條「Manager 自己就能把
+        任意命令掛進每一次 `gh` 呼叫」的執行面交還給它，與 `.gitconfig` 維持
+        root-owned 的理由（`core.fsmonitor`／`alias.*`）**逐字相同**。它不承載 token、
+        也不需要被寫回，因此 root-owned、對服務帳號唯讀就夠。
+        """
+        return f"{self.gh_config_dir_of(account)}/config.yml"
 
     @property
     def builder_home(self) -> str:
@@ -1778,6 +2074,11 @@ class PathLayout:
             "builder-executor-credential": self.executor_credential_of(
                 self.builder_account
             ),
+            # #666：Manager 的 gh 登入態。**兩個檔刻意不同 owner**——`hosts.yml` 承載
+            # token（要 refresh ⇒ 服務帳號擁有），`config.yml` 是偏好設定（可宣告
+            # `!` shell alias ⇒ 必須 root-owned 唯讀）。
+            "manager-gh-credential": self.gh_credential_of(self.manager_account),
+            "manager-gh-config": self.gh_settings_of(self.manager_account),
             "repo-worktree": job,
             "dispatch-worktree-pool": wt,
             "jobs-registry": f"{c}/jobs.json",
@@ -1860,6 +2161,18 @@ class PathLayout:
                     (self.executor_credential_dir_of(account), root, g(root), 0o755)
                 )
             account_dirs.append((self.cache_of(account), account, g(account), 0o700))
+        # #666：**durable state owner 才需要** `~/.config/gh` 那兩層。`gh` 依序看
+        # `$GH_CONFIG_DIR` → `$XDG_CONFIG_HOME/gh` → `$HOME/.config/gh`，而產生出來的
+        # unit 只設 `HOME=` 與 `XDG_CACHE_HOME=`（**刻意不設 `XDG_CONFIG_HOME=`**），
+        # 因此落點就是這一條。兩層都 root-owned：底下要放得下「`hosts.yml` 服務帳號
+        # 擁有、`config.yml` root-owned」這組不同 owner 的檔，而那組性質全部建立在
+        # 「目錄沒有 `w` 位給服務帳號」上。
+        #
+        # **job 帳號刻意沒有這一層**：job unit 帶 `Environment=GH_TOKEN=`／
+        # `GITHUB_TOKEN=` 把 token 清空，GitHub 寫入一律由 Manager 代理（D1 outbox）。
+        # 為 job 建出 gh 設定目錄等於替一條被明確關掉的通道預留位置。
+        account_dirs.append((f"{self.home_of(svc)}/.config", root, g(root), 0o755))
+        account_dirs.append((self.gh_config_dir_of(svc), root, g(root), 0o755))
         return _dedupe_scaffold((
             # 部署樹（enforcement plane）：全 root，對 svc／builder 唯讀。
             (self.deploy_root, root, g(root), 0o755),
@@ -1986,6 +2299,14 @@ def principal_needs_write(
 #: 因為那需要在同目錄建檔。診斷方式見 Phase 2b runbook 第 4e 步。
 IN_PLACE_CONTENT_WRITE_ASSETS: frozenset[str] = frozenset({
     "builder-executor-credential",
+    # #666：Manager 的 gh token。與上一條同形，但**洩漏面不同級**，這點不得混談：
+    # #640 的憑證是給 **job 帳號**的，job unit 另有 `Environment=GH_TOKEN=` 把 token
+    # 清空、成果一律走 spool 由 Manager 代理推送；這一份是給 **Manager** 的，而
+    # Manager 是 durable state owner——它的 token 推得動 PR、關得掉 issue、改得了
+    # label。折算成父目錄會讓 Manager unit 的 mount 層開放整個 `~/.config/gh`，
+    # 連 root-owned 的 `config.yml`（可宣告 `!` shell alias）一起可寫，等於把「改不了
+    # 自己的 gh 設定」這條性質從兩層拆成零層。
+    "manager-gh-credential",
 })
 
 
@@ -2010,6 +2331,58 @@ IN_PLACE_CONTENT_WRITE_ASSETS: frozenset[str] = frozenset({
 RETIRED_JOB_WRITE_ASSETS: frozenset[str] = frozenset({
     "review-verdict",
 })
+
+
+def home_anchored_account(layout: PathLayout, path: str) -> str | None:
+    """`path` 掛在**哪一個 layout 帳號欄位**的 HOME 底下（否則回 `None`）。純字串。
+
+    比對來源刻意只有 :meth:`PathLayout.declared_accounts`（三個部署決定欄位），
+    **不是**「`home_root` 底下的第一段」——durable state 樹本身就住在
+    `<home_root>/cortex`，用字串切段會把整棵樹誤判成某個叫 `cortex` 的帳號的 HOME。
+    """
+    for account in layout.declared_accounts():
+        home = layout.home_of(account)
+        if path == home or path.startswith(home.rstrip("/") + "/"):
+            return account
+    return None
+
+
+def inapplicable_home_anchored_assets(
+    plan: PermissionPlan,
+    layout: PathLayout,
+) -> tuple[tuple[str, str], ...]:
+    """`(asset_id, path)`：掛在**本方案不存在的帳號** HOME 下的資產（#666）。
+
+    登記表資產是 1:1 綁到一條絕對路徑的，而幾個 HOME-anchored 資產的路徑由
+    :class:`PathLayout` 的**部署決定欄位**（`manager_account`／
+    `reviewer_planner_account`）導出，那幾個欄位取的是**定案的三分／四分**；二分
+    方案把 Manager／reviewer／planner 全併進 `cortex-svc`，於是同一條路徑在二分
+    部署裡**根本不存在**。這在登記表既有的 note 裡已經寫成「二分下該資產不適用」，
+    而權限那一半也早就以 `[ ! -e ] || …` 守衛表達了它。
+
+    **本函式補的是 `ReadWritePaths` 那一半**：systemd 對不存在的 `ReadWritePaths=`
+    目標會讓 unit **直接起不來**，因此「不適用」不能只在權限面成立。#642 當時的處置
+    是「乾脆不登記第二份憑證」（`builder-executor-credential` 的 note 有整段論證）；
+    #666 要登記 Manager 的 gh 憑證時同一個陷阱又出現一次，因此把「不適用」做成一條
+    **可列舉的機械規則**，而不是每次都用「不要登記」繞過去。
+
+    刻意做成可列舉而不是靜默過濾：靜默扣掉一條 RWP 與「漏授一條 RWP」在輸出上長得
+    一樣，而後者的症狀是 job 跑到一半 EROFS。要看它扣了什麼，呼叫這個函式。
+    """
+    scheme = plan.scheme or SCHEMES.get(plan.scheme_id)
+    if scheme is None:
+        return ()
+    declared = scheme.declared_accounts()
+    paths = layout.asset_paths()
+    found: list[tuple[str, str]] = []
+    for entry in plan.entries:
+        path = paths.get(entry.asset_id)
+        if path is None:
+            continue
+        anchor = home_anchored_account(layout, path)
+        if anchor is not None and anchor not in declared:
+            found.append((entry.asset_id, path))
+    return tuple(sorted(found))
 
 
 def required_write_targets(
@@ -2038,8 +2411,13 @@ def required_write_targets(
     targets: dict[str, str] = {}
     paths = layout.asset_paths()
     index = {a.asset_id: a for a in (plan.assets or registry.ASSET_REGISTRY)}
+    # #666：本方案不存在的帳號 HOME 底下的資產一律不進 RWP——systemd 對不存在的
+    # `ReadWritePaths=` 目標會讓 unit 起不來（見 `inapplicable_home_anchored_assets`）。
+    inapplicable = {aid for aid, _path in inapplicable_home_anchored_assets(plan, layout)}
     for entry in plan.entries:
         if account not in plan.all_writable_accounts(entry):
+            continue
+        if entry.asset_id in inapplicable:
             continue
         if retired is not None and entry.asset_id in retired:
             continue
@@ -2638,6 +3016,477 @@ def unresolved_node_execution_surfaces() -> tuple[NodeExecutionSurface, ...]:
     """`node_execution_surfaces()` 裡**執行面仍禁 W+X** 的那些（＝已知會失敗的組合）。"""
 
     return tuple(surface for surface in node_execution_surfaces() if not surface.allows_wx)
+
+
+# ---------------------------------------------------------------------------
+# 窮舉盤點（#666）：降權帳號在完整加固面下跑完一個 run 需要碰到的**全部**外部相依
+#
+# ## 為什麼要有這一節
+#
+# `#640`（executor toolchain ＋ job 憑證）、`#661`／`#664`（`srt`／`openspec`／
+# preflight backend）、`#666`（`pytest`／Manager 的 gh 憑證）——**同一族的第一到第五
+# 個成員**，每一次都是「症狀出現才補一項」。症狀還一次比一次遠：從 `rc=127`，到
+# doctor 一個看不出原因的 FAIL，到「ledger 空 ⇒ 每張 build 卡在採信階段被拒」。
+#
+# 前三張表（:data:`EXECUTOR_TOOLS`／:data:`SERVICE_TOOLS`／:data:`SYSTEM_PROGRAMS`）
+# 各自都是完整的——但它們回答的是「**這一類**東西有哪些」，沒有任何一個地方回答
+# 「跑完一個 run 需要碰到的東西有哪些」。這一節就是後者：**判準改成從 run 反推**，
+# 而不是等下一個症狀。
+#
+# ## 它怎麼防止自己過期
+#
+# 兩個方向都釘住，缺任一邊測試就紅：
+#
+# - :func:`uncovered_run_dependencies`：盤點列出的每一項都必須**真的**落在某張表或
+#   某個登記表資產上（不是字串相等，是回頭去那張表／`ASSET_REGISTRY` 裡查）；
+# - :func:`unlisted_roster_entries`：反過來，每張表上的每一項、以及每一個掛在帳號
+#   HOME 下的登記表資產，都必須被盤點列到。往 `SERVICE_TOOLS` 加一支程式而忘了說明
+#   它在 run 的哪一段被誰碰到，測試會紅。
+#
+# 已知**還沒有**歸宿的那些不塞進主表充數，改由 :func:`deferred_run_dependencies`
+# 列舉（比照 :func:`unresolved_node_execution_surfaces` 的先例：不做裁決、不放寬、
+# 但也不讓它靜默消失）。
+# ---------------------------------------------------------------------------
+
+class DependencyKind(Enum):
+    """外部相依的種類——決定它應該落在哪一張表。"""
+
+    #: 部署樹 `<toolchain>/bin`（版本會影響治理產出 ⇒ 可稽核的部署決定）。
+    TOOLCHAIN_PROGRAM = "toolchain-program"
+    #: 發行版套件（通用 runtime／傳輸層／基礎工具）。
+    SYSTEM_PROGRAM = "system-program"
+    #: python 發行版——**不是可執行檔**，`import`／`-m` 得到才有意義（#666 新增的
+    #: 第四類；前三張表的形狀都收不下它，見 :class:`PythonDistribution`）。
+    PYTHON_DISTRIBUTION = "python-distribution"
+    #: 帳號 HOME 下的**憑證**檔（登記表資產；檔案該帳號擁有、目錄 root-owned）。
+    CREDENTIAL = "credential"
+    #: 帳號 HOME 下的**非憑證**設定（登記表資產；一律 root-owned 唯讀）。
+    ACCOUNT_CONFIG = "account-config"
+
+
+class RunStage(Enum):
+    """一個 run 的各段——用來回答「這項相依是在哪一步被碰到的」。"""
+
+    DISPATCH = "dispatch"        # Manager 決定派工並起 job
+    MODEL_CALL = "model-call"    # job 帳號實際呼叫模型 CLI
+    REVIEW = "review"            # reviewer 在 sandbox 內覆核
+    GATE = "gate"                # gate 執行身分重跑 operator 宣告的命令
+    SHIP = "ship"                # preflight／archive／推送
+    MONITOR = "monitor"          # monitor 的輪詢與 provider
+
+
+@dataclass(frozen=True)
+class RunDependency:
+    """窮舉盤點的一列：**誰**在 run 的**哪一段**碰到**什麼**，以及它登記在哪。"""
+
+    name: str
+    kind: DependencyKind
+    #: 哪些 principal 在**完整加固面下**會碰到它（不是「誰理論上可能用到」）。
+    principals: tuple[Principal, ...]
+    stages: tuple[RunStage, ...]
+    #: 涵蓋它的那張表的名字，或登記表資產的 `asset_id`。**這個欄位會被真的拿去查**
+    #: （見 :func:`uncovered_run_dependencies`），寫錯字就是紅的。
+    covered_by: str
+    note: str
+
+    @property
+    def key(self) -> tuple[str, str]:
+        """盤點內的唯一鍵。**名字本身不夠**——同一個 python 發行版（PyYAML）在系統層
+        與部署 venv 各有一份，那是兩個不同的部署決定，不能被去重掉。"""
+        return (self.name, self.covered_by)
+
+
+#: **窮舉盤點的本體**（#666）。順序＝一個 run 走過的順序，方便對著 runbook 讀。
+RUN_EXTERNAL_DEPENDENCIES: tuple[RunDependency, ...] = (
+    # ---- DISPATCH：Manager 起 job -----------------------------------------
+    RunDependency(
+        "systemctl", DependencyKind.SYSTEM_PROGRAM,
+        (Principal.MANAGER,), (RunStage.DISPATCH,),
+        covered_by="SYSTEM_PROGRAMS",
+        note="B 案的派工 client：`systemctl start --wait <模板實例>`。#666 補進表。",
+    ),
+    RunDependency(
+        "manager-gitconfig", DependencyKind.ACCOUNT_CONFIG,
+        (Principal.MANAGER, Principal.MONITOR), (RunStage.DISPATCH, RunStage.SHIP),
+        covered_by="manager-gitconfig",
+        note=(
+            "來源樹的 `safe.directory`（#623）。Manager 對 root-owned 的來源樹跑 "
+            "`fetch`／`rev-parse`／`branch -f`，缺它就是每一次 git 都 dubious ownership。"
+        ),
+    ),
+    RunDependency(
+        "git", DependencyKind.SYSTEM_PROGRAM,
+        (Principal.MANAGER, Principal.MONITOR, Principal.BUILDER,
+         Principal.REVIEWER, Principal.PLANNER),
+        (RunStage.DISPATCH, RunStage.MODEL_CALL, RunStage.SHIP, RunStage.MONITOR),
+        covered_by="SYSTEM_PROGRAMS",
+        note=(
+            "per-job clone、bundle 產出與回收、monitor 的 mirror 掃描、ship 段的 "
+            "push／ls-remote 全靠它。**gate 刻意不在 principals 內**——那一格是未決的，"
+            "見 `deferred_run_dependencies()`。"
+        ),
+    ),
+    # ---- MODEL_CALL：job 帳號呼叫模型 --------------------------------------
+    RunDependency(
+        "bash", DependencyKind.SYSTEM_PROGRAM,
+        (Principal.MANAGER, Principal.BUILDER, Principal.REVIEWER, Principal.PLANNER),
+        (RunStage.DISPATCH, RunStage.MODEL_CALL),
+        covered_by="SYSTEM_PROGRAMS",
+        note=(
+            "**每一支 job 的 `command[0]`**（wrapper 是 `bash -c <script>`），"
+            "以及 Manager 側的 exit 記帳 shell。#666 補進表。"
+        ),
+    ),
+    RunDependency(
+        "codex", DependencyKind.TOOLCHAIN_PROGRAM,
+        (Principal.BUILDER, Principal.REVIEWER, Principal.PLANNER),
+        (RunStage.MODEL_CALL,),
+        covered_by="EXECUTOR_TOOLS",
+        note="dispatch 直接執行的模型 CLI；本部署的 `PSC_MANAGER_EXECUTOR` 預設值。",
+    ),
+    RunDependency(
+        "claude", DependencyKind.TOOLCHAIN_PROGRAM,
+        (Principal.BUILDER, Principal.REVIEWER, Principal.PLANNER, Principal.MANAGER),
+        (RunStage.MODEL_CALL, RunStage.REVIEW),
+        covered_by="EXECUTOR_TOOLS",
+        note=(
+            "**Manager 也在 principals 內，而且不是筆誤**：`planning_runtime` 的 JSON "
+            "呼叫是在 **Manager 行程內**直接 exec `claude` 的（不是派一個降權 job），"
+            "因此它跑在 Manager unit 的加固面上、讀的是 Manager HOME。那條路徑的登入態"
+            "目前沒有登記表資產，見 `deferred_run_dependencies()`。"
+        ),
+    ),
+    RunDependency(
+        "copilot", DependencyKind.TOOLCHAIN_PROGRAM,
+        (Principal.BUILDER,), (RunStage.MODEL_CALL,),
+        covered_by="EXECUTOR_TOOLS",
+        note="shell script，但內部再 exec node（#643 實機量測）⇒ 走 `jit` 剖面。",
+    ),
+    RunDependency(
+        "agy", DependencyKind.TOOLCHAIN_PROGRAM,
+        (Principal.PLANNER, Principal.MANAGER), (RunStage.MODEL_CALL, RunStage.DISPATCH),
+        covered_by="EXECUTOR_TOOLS",
+        note=(
+            "planning 的 canonical executor。Manager 另外會跑 `agy models`（"
+            "`model_identities` 的 live probe ＋ doctor 的 `agy` probe），因此它同樣"
+            "要在 Manager 的 `PATH` 上。"
+        ),
+    ),
+    RunDependency(
+        "node", DependencyKind.SYSTEM_PROGRAM,
+        (Principal.BUILDER, Principal.REVIEWER, Principal.PLANNER, Principal.MANAGER),
+        (RunStage.MODEL_CALL, RunStage.REVIEW, RunStage.SHIP),
+        covered_by="SYSTEM_PROGRAMS",
+        note="全部 `needs_node` 的 toolchain 程式共用的系統層 runtime。",
+    ),
+    RunDependency(
+        "builder-executor-credential", DependencyKind.CREDENTIAL,
+        (Principal.BUILDER,), (RunStage.MODEL_CALL,),
+        covered_by="builder-executor-credential",
+        note=(
+            "**job 帳號**的 provider 憑證（#640 裁決 (b)）。洩漏面＝一次模型呼叫的額度"
+            "——job unit 另有 `Environment=GH_TOKEN=` 把 GitHub token 清空，成果一律走 "
+            "`commit-spool` 由 Manager 代理推送。**與 `manager-gh-credential` 不同級**。"
+        ),
+    ),
+    RunDependency(
+        "codex-hooks", DependencyKind.ACCOUNT_CONFIG,
+        (Principal.BUILDER,), (RunStage.MODEL_CALL,),
+        covered_by="codex-hooks",
+        note="enforcement plane：root-owned，job 不得替換自己的 hooks（#623）。",
+    ),
+    RunDependency(
+        "builder-gitconfig", DependencyKind.ACCOUNT_CONFIG,
+        (Principal.BUILDER,), (RunStage.MODEL_CALL,),
+        covered_by="builder-gitconfig",
+        note="per-job clone 的 `safe.directory`；root-owned（`alias.*` 會執行外部命令）。",
+    ),
+    RunDependency(
+        "reviewer-planner-gitconfig", DependencyKind.ACCOUNT_CONFIG,
+        (Principal.REVIEWER, Principal.PLANNER), (RunStage.REVIEW,),
+        covered_by="reviewer-planner-gitconfig",
+        note="同 `builder-gitconfig`，掛在 reviewer／planner 共用的那個帳號 HOME 下。",
+    ),
+    # ---- REVIEW：reviewer 在 sandbox 內覆核 --------------------------------
+    RunDependency(
+        "srt", DependencyKind.TOOLCHAIN_PROGRAM,
+        (Principal.REVIEWER,), (RunStage.REVIEW,),
+        covered_by="SERVICE_TOOLS",
+        note=(
+            "Claude review sandbox 的強制面（#661）。由 `claude` 在執行途中 exec ⇒ "
+            "跑在 `strict` 剖面上，那一格仍未決，見 `unresolved_node_execution_surfaces()`。"
+        ),
+    ),
+    RunDependency(
+        "bwrap", DependencyKind.SYSTEM_PROGRAM,
+        (Principal.REVIEWER,), (RunStage.REVIEW,),
+        covered_by="SYSTEM_PROGRAMS",
+        note="`srt` 在 Linux 上的 namespace 隔離實作；doctor 會實跑 `--version`。",
+    ),
+    RunDependency(
+        "socat", DependencyKind.SYSTEM_PROGRAM,
+        (Principal.REVIEWER,), (RunStage.REVIEW,),
+        covered_by="SYSTEM_PROGRAMS",
+        note="`srt` 網路政策那一段的 socket 轉發。",
+    ),
+    RunDependency(
+        "python3", DependencyKind.SYSTEM_PROGRAM,
+        (Principal.GATE, Principal.REVIEWER, Principal.MANAGER),
+        (RunStage.GATE, RunStage.REVIEW),
+        covered_by="SYSTEM_PROGRAMS",
+        note=(
+            "**gate 宣告 `python3 -m pytest` 時解析到的是這一支**（系統層），不是部署 "
+            "venv 的那一支——#666 兩個漂移項之一的機械成因。`srt` 的沙箱 smoke test 也"
+            "拿它當被關的程式。#666 補進表。"
+        ),
+    ),
+    # ---- GATE：gate 執行身分重跑 operator 宣告的命令 -----------------------
+    RunDependency(
+        "pytest", DependencyKind.PYTHON_DISTRIBUTION,
+        (Principal.GATE,), (RunStage.GATE,),
+        covered_by="SYSTEM_PYTHON_DISTRIBUTIONS",
+        note=(
+            "#666 漂移項 1。裝在 operator 的 user site-packages 時 gate 身分讀不到 ⇒ "
+            "每張 build 卡的 ledger 為空 ⇒ 撞 #540 的 acceptance chain。版本約束由 "
+            "`pyproject.toml` 的 `test` extra 宣告（明示的部署決定）。"
+        ),
+    ),
+    RunDependency(
+        "PyYAML", DependencyKind.PYTHON_DISTRIBUTION,
+        (Principal.GATE,), (RunStage.GATE,),
+        covered_by="SYSTEM_PYTHON_DISTRIBUTIONS",
+        note=(
+            "**被測樹的 runtime 相依**，不是 pytest 的（#666 窮舉盤點才撞出來）。缺它"
+            "的症狀是 pytest exit code `2`（collection error），依 #307 的判準不會被誤"
+            "判成合格 RED，但整張卡照樣過不了。"
+        ),
+    ),
+    # ---- SHIP：preflight／archive／推送 ------------------------------------
+    RunDependency(
+        "openspec", DependencyKind.TOOLCHAIN_PROGRAM,
+        (Principal.MANAGER,), (RunStage.SHIP,),
+        covered_by="SERVICE_TOOLS",
+        note=(
+            "`openspec archive -y`／`validate --strict` 都是**採信判準**（#661），因此"
+            "版本進部署樹。由 Manager 的 system unit exec ⇒ 那一格同樣仍未決。"
+        ),
+    ),
+    RunDependency(
+        PREFLIGHT_BACKEND_DISTRIBUTION, DependencyKind.PYTHON_DISTRIBUTION,
+        (Principal.MANAGER,), (RunStage.SHIP,),
+        covered_by="DEPLOYMENT_PYTHON_DISTRIBUTIONS",
+        note=(
+            "preflight 的 backend（#661）。落點是既有的部署 venv ⇒ **不新增檔案系統"
+            "資產**；版本必須逐字等於 `.project-policy.yml` 的 `policy_version`。"
+        ),
+    ),
+    RunDependency(
+        "PyYAML", DependencyKind.PYTHON_DISTRIBUTION,
+        (Principal.MANAGER, Principal.MONITOR),
+        (RunStage.DISPATCH, RunStage.SHIP, RunStage.MONITOR),
+        covered_by="DEPLOYMENT_PYTHON_DISTRIBUTIONS",
+        note=(
+            "cortex 自己唯一的 runtime 相依，隨 venv 走。**與系統層那一份是兩個不同 "
+            "interpreter 下的兩份**，因此在盤點裡也是兩列（`RunDependency.key` 用 "
+            "`(name, covered_by)` 正是為了這個）。"
+        ),
+    ),
+    RunDependency(
+        "gh", DependencyKind.SYSTEM_PROGRAM,
+        (Principal.MANAGER, Principal.MONITOR), (RunStage.SHIP, RunStage.MONITOR),
+        covered_by="SYSTEM_PROGRAMS",
+        note="Manager 對 GitHub 的傳輸層；monitor 的兩個 github provider 也直接跑它。",
+    ),
+    RunDependency(
+        "manager-gh-credential", DependencyKind.CREDENTIAL,
+        (Principal.MANAGER, Principal.MONITOR), (RunStage.SHIP, RunStage.MONITOR),
+        covered_by="manager-gh-credential",
+        note=(
+            "#666 漂移項 2。**洩漏面與 job 憑證不同級**：Manager 是 durable state "
+            "owner，這個 token 推得動 PR、關得掉 issue、merge 得了分支。"
+        ),
+    ),
+    RunDependency(
+        "manager-gh-config", DependencyKind.ACCOUNT_CONFIG,
+        (Principal.MANAGER, Principal.MONITOR), (RunStage.SHIP, RunStage.MONITOR),
+        covered_by="manager-gh-config",
+        note=(
+            "同目錄下的非憑證設定，**owner 刻意與 `hosts.yml` 不同**：`aliases` 可宣告 "
+            "`!` shell alias ⇒ 必須 root-owned 唯讀（與三份 `.gitconfig` 同一條理由）。"
+        ),
+    ),
+)
+
+
+#: 盤點的 `covered_by` 可以指向哪些**名冊**（其餘視為登記表 `asset_id`）。
+_DEPENDENCY_ROSTERS: Mapping[str, Callable[[], frozenset[str]]] = MappingProxyType({
+    "EXECUTOR_TOOLS": lambda: frozenset(t.name for t in EXECUTOR_TOOLS),
+    "SERVICE_TOOLS": lambda: frozenset(t.name for t in SERVICE_TOOLS),
+    "SYSTEM_PROGRAMS": lambda: frozenset(p.name for p in SYSTEM_PROGRAMS),
+    "SYSTEM_PYTHON_DISTRIBUTIONS": lambda: frozenset(
+        d.name for d in SYSTEM_PYTHON_DISTRIBUTIONS
+    ),
+    "DEPLOYMENT_PYTHON_DISTRIBUTIONS": lambda: frozenset(
+        d.name for d in DEPLOYMENT_PYTHON_DISTRIBUTIONS
+    ),
+})
+
+
+def home_anchored_asset_ids(layout: "PathLayout | None" = None) -> frozenset[str]:
+    """掛在**帳號 HOME** 底下的登記表資產 id（＝憑證／per-account 設定那一族）。
+
+    由 `asset_paths()` × :func:`home_anchored_account` 機械導出，**不是手寫清單**：
+    新增一個掛在帳號 HOME 下的資產而沒有把它列進 :data:`RUN_EXTERNAL_DEPENDENCIES`，
+    :func:`unlisted_roster_entries` 就會非空。
+    """
+    resolved = layout if layout is not None else DEFAULT_LAYOUT
+    return frozenset(
+        asset_id
+        for asset_id, path in resolved.asset_paths().items()
+        if home_anchored_account(resolved, path) is not None
+    )
+
+
+def uncovered_run_dependencies() -> tuple[RunDependency, ...]:
+    """盤點裡 `covered_by` **查不到東西**的那些列（正常應為空）。
+
+    這不是字串比對：名冊型的 `covered_by` 會回頭去那張 tuple 裡找同名項，資產型的會
+    去 `registry.ASSET_REGISTRY` 找 `asset_id`。把一項從表上拿掉、或打錯資產 id，
+    這裡就會非空。
+    """
+    known_assets = {a.asset_id for a in registry.ASSET_REGISTRY}
+    missing: list[RunDependency] = []
+    for dep in RUN_EXTERNAL_DEPENDENCIES:
+        roster = _DEPENDENCY_ROSTERS.get(dep.covered_by)
+        if roster is not None:
+            if dep.name not in roster():
+                missing.append(dep)
+            continue
+        if dep.covered_by not in known_assets or dep.name != dep.covered_by:
+            missing.append(dep)
+    return tuple(missing)
+
+
+def unlisted_roster_entries(layout: "PathLayout | None" = None) -> tuple[str, ...]:
+    """**反方向**：名冊／登記表上有、但窮舉盤點沒列到的項目（正常應為空）。
+
+    回傳 `"<名冊或 registry>:<名字>"`。這條是本節真正的價值所在——它讓「往
+    `SERVICE_TOOLS` 加一支程式」與「說明它在 run 的哪一段被誰碰到」變成同一件事，
+    而不是兩件可以只做一半的事。#640→#661→#666 每一次的形態都是後者只做了一半。
+    """
+    listed = {dep.key for dep in RUN_EXTERNAL_DEPENDENCIES}
+    orphans: list[str] = []
+    for roster_name, members in _DEPENDENCY_ROSTERS.items():
+        for name in sorted(members()):
+            if (name, roster_name) not in listed:
+                orphans.append(f"{roster_name}:{name}")
+    for asset_id in sorted(home_anchored_asset_ids(layout)):
+        if (asset_id, asset_id) not in listed:
+            orphans.append(f"registry:{asset_id}")
+    return tuple(orphans)
+
+
+@dataclass(frozen=True)
+class DeferredDependency:
+    """盤點撞到、但**尚未有歸宿**的相依（#666）。不做裁決，只讓它不會靜默消失。"""
+
+    name: str
+    kind: DependencyKind
+    principals: tuple[Principal, ...]
+    #: 為什麼它現在沒有登記表資產／沒有產生器步驟。
+    reason: str
+    #: 實機上會怎麼表現出來（症狀，不是推測）。
+    symptom: str
+    #: 誰要裁決、往哪裡走。
+    disposition: str
+
+
+#: **窮舉盤點撞到的未決項**（#666）。比照 :func:`unresolved_node_execution_surfaces`
+#: 的先例：本 PR **不做裁決、不放寬任何一面**，只讓它們可列舉——落位計畫會把它們印在
+#: 輸出裡，測試釘住目前的內容，補上或悄悄拿掉都會讓測試變紅。
+#:
+#: 四項的共同形態是「**per-account 的機制已經就緒，但登記表只登記了其中一份**」——
+#: 與 #640 對 `builder-executor-credential` 的處置逐條同構（那一條的 note 有完整
+#: 論證），差別只在那時候 M2 還沒落地、現在落地了。
+_DEFERRED_RUN_DEPENDENCIES: tuple[DeferredDependency, ...] = (
+    DeferredDependency(
+        "reviewer-planner-executor-credential", DependencyKind.CREDENTIAL,
+        (Principal.REVIEWER, Principal.PLANNER),
+        reason=(
+            "登記表只登記 builder 那一份。#640 的理由是「登記第二份會讓二分部署的 "
+            "Manager unit 出現一條不存在的 `ReadWritePaths`，unit 直接起不來」，並寫明"
+            "「M2（#615）把 reviewer／planner 移上模板 unit 時補第二列即可」。**M2 已經"
+            "落地**（`cortex-reviewer-job@.service` 已在產生器裡），所以這條現在是逾期"
+            "未做，不再是「時候未到」。\n"
+            "#666 順帶把當年的阻礙拆掉了：`inapplicable_home_anchored_assets()` 讓"
+            "「本方案不存在的帳號 HOME 下的資產」機械地不進 RWP，二分部署不會再被"
+            "第二列弄壞。**但補這一列會改動 reviewer 模板 unit 的 RWP，屬 operator 的"
+            "部署面裁決，不在本票範圍。**"
+        ),
+        symptom=(
+            "檔案由 runbook 第 4e 步落位（owner 正確、0600），但 reviewer 模板 unit 的 "
+            "`ReadWritePaths` 不含它 ⇒ `ProtectSystem=strict` 下**讀得到、改不了** ⇒ "
+            "token 過期那天 reviewer 的 refresh 靜默失敗。"
+        ),
+        disposition="補登記表第二列（產生器一行都不必改）；建議另開票，實機驗 RWP 後再上。",
+    ),
+    DeferredDependency(
+        "gate-gitconfig", DependencyKind.ACCOUNT_CONFIG,
+        (Principal.GATE,),
+        reason=(
+            "`ACCOUNT_GITCONFIG_ASSETS` 只有 BUILDER／REVIEWER／MANAGER 三個 principal"
+            "——#629 開出 `cortex-gate` 時沒有一併考慮它需不需要 git 設定。"
+        ),
+        symptom=(
+            "gate 把 builder 的樹**複製**到自己的拋棄式工作區後才跑命令，因此複本由 "
+            "gate 自己擁有、多數情況不會撞 dubious ownership。真正會撞的是「gate 命令"
+            "碰到 `.git`」的情形（`setuptools-scm`、`git describe`、需要 git 的 pytest "
+            "plugin）。**目前 `PSC_GATE_CMD_PYTEST` 沒有這種相依，因此這是預防面而不是"
+            "現行症狀**——寫在這裡是為了不讓它變成第六個「症狀出現才補」。"
+        ),
+        disposition="等第一個需要 git 的 gate 宣告出現時再補，或 operator 主動裁決。",
+    ),
+    DeferredDependency(
+        "reviewer-planner-codex-hooks", DependencyKind.ACCOUNT_CONFIG,
+        (Principal.REVIEWER, Principal.PLANNER),
+        reason=(
+            "`asset_paths()` 把 `codex-hooks` 寫死在 `builder_home` 下，而 "
+            "`scaffold_directories()` 已為**每一個**跑模型的 job 帳號建出 root-owned "
+            "的 `~/.codex`。與上一項同一個形態：機制 per-account，登記表只登記一份。"
+        ),
+        symptom=(
+            "reviewer／planner 以 `codex` 為 executor 時拿不到 hooks（enforcement "
+            "plane 少一層）。目前 reviewer 走的是 `claude`，因此**尚未**在實機表現出來。"
+        ),
+        disposition="與 reviewer 憑證同一張票處理；兩者都是「補第二列」。",
+    ),
+    DeferredDependency(
+        "manager-claude-credential", DependencyKind.CREDENTIAL,
+        (Principal.MANAGER,),
+        reason=(
+            "`planning_runtime` 的 JSON 呼叫在 **Manager 行程內**直接 exec `claude`"
+            "（不是派一個降權 job），並讀 `<HOME>/.claude/.credentials.json` 播種一次性"
+            "的 `CLAUDE_CONFIG_DIR`。四分部署下 Manager 的 HOME 底下沒有那個檔，登記表"
+            "也沒有對應資產——`executor_credential_relpath` 是**單一**部署決定"
+            "（`.codex/auth.json`），一個帳號只表達得了一份憑證。"
+        ),
+        symptom=(
+            "程式碼在查無憑證時**明確回 `None` 並不代為猜測**，讓 claude CLI 自己回報"
+            "未登入——因此它不是靜默失敗，但也不是可用狀態。實機目前 planning 走 `agy`，"
+            "所以這條還沒有被踩到。"
+        ),
+        disposition=(
+            "要嘛把 `executor_credential_relpath` 擴成 per-executor 的一張表（產生器"
+            "改動不小），要嘛裁決「Manager 不直接跑模型、planning 一律走降權 job」。"
+            "兩條路都是設計裁決，屬 operator。"
+        ),
+    ),
+)
+
+
+def deferred_run_dependencies() -> tuple[DeferredDependency, ...]:
+    """窮舉盤點撞到、尚未有歸宿的相依（#666）。純函式；內容由測試釘住。"""
+    return _DEFERRED_RUN_DEPENDENCIES
 
 
 #: **實際具備啟動面降權的 job principal**（＝各有一組 root-owned 模板 unit 的角色）。
@@ -3680,6 +4529,147 @@ def build_toolchain_plan(
         "# 值寫進 Manager 端 root-owned 的 EnvironmentFile：",
         f"#   PSC_PREFLIGHT_CMD=\"{layout.preflight_command_value()}\"",
     ]
+    lines += _system_python_lines(layout)
+    lines += _manager_gh_credential_lines(scheme, layout)
+    lines += _dependency_inventory_lines()
+    return lines
+
+
+def _system_python_lines(layout: PathLayout) -> list[str]:
+    """系統層 python 發行版的落位段（#666 漂移項 1）。"""
+    lines = [
+        "",
+        "# ===== 系統層 python 發行版（#666 漂移項 1：pytest）=====",
+        "# **這一段不是 toolchain，也不是系統層可執行檔**——它是第四種相依：python",
+        "# 發行版，`import`／`-m` 得到才有意義，`command -v` 對它一律無解。",
+        "#",
+        "# **為什麼落在系統層而不是部署 venv**：operator 宣告的 gate 命令用的是相對名",
+        f"#   {' / '.join(f'{k}=\"{v}\"' for k, v in layout.gate_command_env().items())}",
+        "# 而 gate 的 PSC_GATE_PATH 尾段是系統層 ⇒ `python3` 解到 /usr/bin/python3。",
+        "# gate unit 自己的 ExecStart 用的是部署 venv 的 interpreter，但那只涵蓋 ledger",
+        "# writer 本身；**operator 宣告的命令另外解析一次**。兩者是不同的 interpreter。",
+        "#",
+        "# ⚠️ 裝在 operator 的 user site-packages（`pip install --user`）是**不夠的**：",
+        "#   ProtectHome=yes 之後 /home 整個不可見——",
+        "#     $ sudo -u <gate 帳號> env HOME=<gate HOME> python3 -m pytest --version",
+        "#     /usr/bin/python3: No module named pytest",
+        "#   而症狀不是「gate 失敗」，是**每張 build 卡的 ledger 為空** ⇒ 撞 #540 的",
+        "#   acceptance chain ⇒ 交付全部卡住，錯誤只在 manager.log 裡。",
+    ]
+    for dist in SYSTEM_PYTHON_DISTRIBUTIONS:
+        lines += [
+            "",
+            f"# --- {dist.name}（module `{dist.module}`；interpreter＝{dist.interpreter}）---",
+            f"#   版本約束：{dist.requirement}   ← 宣告在 {dist.declared_in}",
+        ]
+        lines += [f"#   {segment}" for segment in dist.note.split("\n")]
+        lines += [
+            f"#     sudo pip install --break-system-packages '{dist.requirement}'",
+            "#   ✅ 版本是**明示的部署決定**：裝完把解出來的版本記進 runbook，並與",
+            "#      operator 側逐字比對——同一台機器上兩個 interpreter 各有一份是常態，",
+            "#      而版本分岔的症狀是「gate 判定與本機跑不一樣」，不是報錯：",
+            f"#     python3 -m {dist.module} --version   # 系統層（gate 實際用的那一份）",
+        ]
+    lines += [
+        "",
+        "# ✅ 在**完整加固面下**實測（`sudo -u` 沒有 unit 的加固面，兩者可能不同結果）：",
+        "#   systemd-run --uid=<gate 帳號> … --property=MemoryDenyWriteExecute=yes \\",
+        "#     /usr/bin/python3 -m pytest -q",
+        "#   期望 rc=0。CPython **不是** V8——MDWE 對它沒有影響（與 #643 的 node 型",
+        "#   executor 相反），因此這一條在完整加固面下就應該過，不必放寬任何一項。",
+    ]
+    return lines
+
+
+def _manager_gh_credential_lines(scheme: UidScheme, layout: PathLayout) -> list[str]:
+    """Manager 的 gh 憑證落位段（#666 漂移項 2）。"""
+    account = scheme.durable_state_owner
+    root = scheme.deploy_account
+    group = scheme.group_of(root)
+    cred = layout.gh_credential_of(layout.manager_account)
+    settings = layout.gh_settings_of(layout.manager_account)
+    return [
+        "",
+        "# ===== Manager 的 gh 憑證（#666 漂移項 2；登記表 manager-gh-credential）=====",
+        "# 形態沿用 #640 裁決 (b)：**目錄 root-owned、憑證檔服務帳號 owned**。兩層",
+        "# 目錄由 `trust_root scaffold` 產出（本計畫不重複產），權限由登記表經",
+        "# `trust_root permissions … --commands` 產出。這裡只出**內容落位**。",
+        "#",
+        "# ⚠️ **兩個檔刻意不同 owner，這不是疏漏**——下一個讀到這裡的人最可能做的事",
+        "#    就是把兩個都設成同一種，因此把理由寫在計畫裡：",
+        f"#      {cred}",
+        f"#        → {account}:{scheme.group_of(account)} 0600"
+        "   ← `gh` 唯一寫回 token 的檔，要 refresh 得回來",
+        f"#      {settings}",
+        f"#        → {root}:{group} 0644"
+        "   ← 非憑證；但 `aliases` 可宣告 `!` shell alias ⇒ 唯讀",
+        "#    後者與三份 `.gitconfig` 維持 root-owned 是**同一條理由**（`core.fsmonitor`",
+        "#    ／`alias.*` 同樣會執行外部命令）。",
+        "#",
+        "# ⚠️ **與 #640 的 job 憑證形狀相同、洩漏面不同級，不要混為一談**：#640 那一份",
+        "#    是給 **job 帳號**的模型 provider 憑證（job unit 另有 `Environment=GH_TOKEN=`",
+        "#    把 GitHub token 清空，成果一律走 spool 由 Manager 代理推送）；這一份是給",
+        "#    **Manager** 的，而 Manager 是 durable state owner——這個 token 推得動 PR、",
+        "#    關得掉 issue、merge 得了分支。因此它只掛在 durable state owner 的 HOME 下，",
+        "#    job 帳號刻意沒有 `~/.config/gh` 那一層目錄。",
+        "#",
+        "# 🔧 落位（來源取 operator 實際在用的那一份）：",
+        f'#     sudo install -o {account} -g {scheme.group_of(account)} -m 0600 \\',
+        f'#       "$HOME/.config/gh/hosts.yml" {cred}',
+        f'#     sudo install -o {root} -g {group} -m 0644 \\',
+        f'#       "$HOME/.config/gh/config.yml" {settings}',
+        "#",
+        "# ✅ 驗證要**以該身分實測**，不是只驗檔案存在：",
+        f'#     sudo -u {account} env HOME={layout.home_of(layout.manager_account)} \\',
+        "#       gh auth status",
+        "#     期望：以 fleet 正式身分登入成功（不是 `You are not logged into any "
+        "GitHub hosts.`）",
+        "# ✅ 不變式「改得了內容、建不了新檔」（與 #640 的憑證逐條同構）：",
+        f'#     sudo -u {account} sh -c \'printf "" >> {cred}\'        # 期望：OK',
+        f'#     sudo -u {account} sh -c \'touch {_parent_dir(cred)}/x\' # 期望：Permission denied',
+        f'#     sudo -u {account} sh -c \'rm -f {settings}\'            # 期望：Permission denied',
+    ]
+
+
+def _dependency_inventory_lines() -> list[str]:
+    """窮舉盤點的摘要 ＋ 未決項（#666）。"""
+    lines = [
+        "",
+        "# ===== 窮舉盤點（#666）=====",
+        "# 判準：**降權帳號在完整加固面下，跑完一個 run 需要碰到的所有外部程式與憑證**",
+        "#（而不是「這一類東西有哪些」——前者才是 #640→#661→#666 每次漏掉的那個問題）。",
+        "# 機器可讀形式在 permgen.RUN_EXTERNAL_DEPENDENCIES，兩個方向都有測試釘住：",
+        "#   uncovered_run_dependencies()  盤點列到但表上查無 ⇒ 必須是空的",
+        "#   unlisted_roster_entries()     表上有但盤點沒列到 ⇒ 必須是空的",
+        f"# 目前共 {len(RUN_EXTERNAL_DEPENDENCIES)} 項，逐段列出：",
+    ]
+    for stage in RunStage:
+        rows = [d for d in RUN_EXTERNAL_DEPENDENCIES if stage in d.stages]
+        if not rows:
+            continue
+        lines.append(f"#   [{stage.value}]")
+        for dep in rows:
+            who = "／".join(p.value for p in dep.principals)
+            lines.append(
+                f"#     {dep.name}  ({dep.kind.value}; {who}) ← {dep.covered_by}"
+            )
+    deferred = deferred_run_dependencies()
+    if deferred:
+        lines += [
+            "#",
+            "# ===== ⚠️ 盤點撞到、**尚未有歸宿**的相依（不做裁決，只讓它不會消失）=====",
+        ]
+        for item in deferred:
+            who = "／".join(p.value for p in item.principals)
+            lines += [
+                f"#   {item.name}  ({item.kind.value}; {who})",
+                f"#     症狀：{item.symptom.splitlines()[0]}",
+                f"#     處置：{item.disposition}",
+            ]
+        lines += [
+            "#   完整理由：permgen.deferred_run_dependencies()。與 #661 的",
+            "#   unresolved_node_execution_surfaces() 同一個定位——**量到／裁決之前不動**。",
+        ]
     return lines
 
 

--- a/paulsha_cortex/trust_root/registry.py
+++ b/paulsha_cortex/trust_root/registry.py
@@ -540,6 +540,74 @@ ASSET_REGISTRY: tuple[TrustRootAsset, ...] = (
             "列即可，產生器一行都不必改。"
         ),
     ),
+    # ---- Manager 的 GitHub 傳輸層憑證（#666）--------------------------------
+    TrustRootAsset(
+        "manager-gh-credential", _T0, _MO, None,
+        (Principal.MANAGER, Principal.MONITOR),
+        (Principal.MANAGER, Principal.MONITOR),
+        IngressKind.DIRECT_FILE_WRITE,
+        derived_in=("trust_root/permgen.py:PathLayout.gh_credential_of",),
+        note=(
+            "Manager／monitor 帳號 HOME 下的 `gh` 登入態（`~/.config/gh/hosts.yml`）。"
+            "形態沿用 #640 裁決 (b)：**檔案由使用它的帳號擁有（0600）、放它的目錄維持 "
+            "root-owned 0755**——`hosts.yml` 是 `gh` 唯一寫回 token 的檔（`gh auth "
+            "login`／`refresh` 就地覆寫它），不歸該帳號就 refresh 不回來。\n"
+            "**為何必須存在（#666 實機）**：Manager system unit 帶 `ProtectHome=yes`，"
+            "而 operator 的登入態在 `~/.config/gh/` 底下，`/home` 整個不可見——\n"
+            "    $ sudo -u cortex-manager env HOME=<manager HOME> gh auth status\n"
+            "    You are not logged into any GitHub hosts.\n"
+            "monitor 起來之後兩個 github provider 一起 `degraded`；doctor 的 "
+            "`gh-auth`／`gh-permissions`／`auto-label` 三個 required probe 也全紅。"
+            "這是 #623／#640／#661 那一族的第五個成員，形態逐字相同：**job／服務需要"
+            "的外部相依散落在 operator home，`ProtectHome` 之後不可達**。\n"
+            "**與 #640 的 job 憑證形狀相同、洩漏面不同級——不得混為一談。** "
+            "`builder-executor-credential` 是給 **job 帳號**的模型 provider 憑證：job "
+            "拿它只能呼叫模型，且 job unit 另有 `Environment=GH_TOKEN=`／"
+            "`GITHUB_TOKEN=` 把 GitHub token 清空，成果一律走 `commit-spool` 由 "
+            "Manager 代理推送（D1 outbox）。本資產是給 **Manager** 的，而 Manager 是 "
+            "durable state owner：這個 token **推得動 PR、關得掉 issue、改得了 "
+            "label、merge 得了分支**——它洩漏的是治理平面對上游 repo 的寫入權，不是"
+            "一次模型呼叫的額度。因此\n"
+            "  1. 它**只**掛在 durable state owner 的 HOME 下（job 帳號刻意沒有這一層"
+            "     目錄，見 `scaffold_directories()`）；\n"
+            "  2. 它列在 `permgen.IN_PLACE_CONTENT_WRITE_ASSETS`——`ReadWritePaths` 掛"
+            "     在**檔案本身**，父目錄連 mount 層都不開放可寫；\n"
+            "  3. reader／writer 都只有 MANAGER 與 MONITOR（同一個帳號、同一個 HOME），"
+            "     沒有任何 job persona 在其中，因此機械上不會產生任何跨帳號 ACL。\n"
+            "**monitor 也是 writer 而不是只有 reader**：monitor 的 GitHub provider 直接"
+            "跑 `gh api`（`monitor/providers.py`），token 過期時 refresh 發生在**哪一個"
+            "行程**不由我們決定。只給讀取權會做出一個「平常好好的、token 到期那天 "
+            "monitor 整條 provider 靜默 degraded」的部署。#622 的不變式（monitor 的 "
+            "`ReadWritePaths` 嚴格窄於 Manager）不受影響：兩者都拿到這一條，而 Manager "
+            "另有整棵 durable state 樹。"
+        ),
+    ),
+    TrustRootAsset(
+        "manager-gh-config", _T1, _MO, None,
+        (Principal.INSTALLER,),
+        (Principal.MANAGER, Principal.MONITOR),
+        IngressKind.DEPLOYMENT_WRITE,
+        derived_in=("trust_root/permgen.py:PathLayout.gh_settings_of",),
+        note=(
+            "同一個目錄下的**非憑證**設定（`~/.config/gh/config.yml`：editor／pager／"
+            "prompt／aliases）。root-owned 0644，服務帳號唯讀。\n"
+            "**它與 `manager-gh-credential` 的 owner 刻意不同，這不是疏漏**——下一個"
+            "讀到這裡的人最可能做的事就是「兩個都設成同一種」，因此把理由寫在這裡：\n"
+            "  - `hosts.yml` **承載 token 且會被 `gh` 自己寫回**（refresh／re-login），"
+            "    不歸服務帳號就 refresh 不回來 ⇒ 檔案必須是服務帳號的、0600；\n"
+            "  - `config.yml` **不承載任何憑證、也沒有任何寫回它的執行期路徑**，但它的 "
+            "    `aliases` 可以宣告 `!` 開頭的 **shell alias**——讓服務帳號改得了它，"
+            "    等於給 Manager 一條「自己把任意命令掛進每一次 `gh` 呼叫」的執行面。"
+            "    這與三份 `.gitconfig` 維持 root-owned 的理由（`core.fsmonitor`／"
+            "    `alias.*` 同樣會執行外部命令）**逐字相同**，因此結論也相同：root 擁有、"
+            "    唯讀就夠。\n"
+            "機械落點：`writers` 只有部署身分 ⇒ `classify_owner()` → `DEPLOYMENT` ⇒ "
+            "owner＝root、`0644`、不出現在任何 unit 的 `ReadWritePaths` 上。與 "
+            "`builder-gitconfig` 那一族完全同構。\n"
+            "**Tier-1 而不是 Tier-0**：它改不了 token、也不直接授權發佈；但它能改變 "
+            "`gh` 的行為（alias 執行面），因此不是 advisory。"
+        ),
+    ),
     # ---- job-visible worktree 族 -------------------------------------------
     TrustRootAsset(
         "repo-worktree", _T1, _JV, "paulsha_cortex.config.paths:repo_root",

--- a/tests/test_trust_root_external_deps_exhaustive_666.py
+++ b/tests/test_trust_root_external_deps_exhaustive_666.py
@@ -1,0 +1,659 @@
+"""#666：pytest 與 gh 憑證進登記表，＋ 一次**窮舉盤點**。
+
+本檔釘住三件事，第三件才是重點：
+
+1. **`pytest`**（＋被測樹的 `PyYAML`）落在**系統層 python 發行版**這張新表上，版本
+   是明示的部署決定（約束的唯一真相在 `pyproject.toml`，測試對著它比）；
+2. **`manager-gh-credential`／`manager-gh-config`** 兩個資產，`hosts.yml` 與
+   `config.yml` **owner 刻意不同**，而且「改得了內容、建不了新檔」以真的 OS 語意驗；
+3. **窮舉盤點**（`RUN_EXTERNAL_DEPENDENCIES`）**兩個方向都封閉**——盤點列到的每一項
+   都真的在某張表上，每張表上的每一項也都被盤點列到。這一條是本票真正要買的東西：
+   #640→#661→#666 每一次都是「症狀出現才補一項」，而兩個方向都釘住之後，
+   「加一支相依」與「說明它在 run 的哪一段被誰碰到」變成同一件事。
+"""
+
+from __future__ import annotations
+
+import inspect
+import os
+import stat
+from pathlib import Path
+
+import pytest
+
+from paulsha_cortex import doctor
+from paulsha_cortex.coordinator import gate_ledger
+from paulsha_cortex.trust_root import permgen
+from paulsha_cortex.trust_root.permgen import (
+    DEFAULT_LAYOUT,
+    DEPLOYMENT_PYTHON_DISTRIBUTIONS,
+    DEPLOYMENT_VENV_INTERPRETER,
+    EXECUTOR_TOOLS,
+    FOUR_WAY_SCHEME,
+    GATE_COMMAND_DECLARATIONS,
+    GATE_COMMAND_ENV_PREFIX,
+    IN_PLACE_CONTENT_WRITE_ASSETS,
+    JOB_PATH_SYSTEM_TAIL,
+    RUN_EXTERNAL_DEPENDENCIES,
+    SERVICE_TOOLS,
+    SYSTEM_INTERPRETER,
+    SYSTEM_PROGRAMS,
+    SYSTEM_PYTHON_DISTRIBUTIONS,
+    THREE_WAY_SCHEME,
+    TWO_WAY_SCHEME,
+    DependencyKind,
+    Principal,
+    RunStage,
+    account_can_reach,
+    build_toolchain_plan,
+    deferred_run_dependencies,
+    generate_plan,
+    home_anchored_asset_ids,
+    inapplicable_home_anchored_assets,
+    read_write_paths,
+    unlisted_roster_entries,
+    unreachable_hops,
+    uncovered_run_dependencies,
+)
+from paulsha_cortex.trust_root.registry import ASSET_REGISTRY, check_registry_equation
+
+ALL_SCHEMES = (THREE_WAY_SCHEME, FOUR_WAY_SCHEME)
+
+GH_CREDENTIAL = "manager-gh-credential"
+GH_CONFIG = "manager-gh-config"
+NEW_ASSET_IDS = (GH_CREDENTIAL, GH_CONFIG)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+# ---------------------------------------------------------------------------
+# 1. 兩個新資產進登記表，等式仍綠
+# ---------------------------------------------------------------------------
+
+def test_registry_equation_stays_green() -> None:
+    """新增資產不得讓 path 契約 ⟷ 登記表的雙向等式失衡。
+
+    兩個新資產都是 `path_resolver=None`（路徑由 `PathLayout` 導出），因此等式的
+    LHS／RHS 都不動——但這條仍要跑，因為「新增資產順手加了一個 path 函式卻沒登記」
+    正是等式要抓的那個場景。
+    """
+    result = check_registry_equation()
+    assert result.ok, result.failure_summary()
+
+
+@pytest.mark.parametrize("asset_id", NEW_ASSET_IDS)
+def test_new_assets_are_registered_with_a_derivation(asset_id: str) -> None:
+    asset = next(a for a in ASSET_REGISTRY if a.asset_id == asset_id)
+    assert asset.path_resolver is None
+    assert asset.derived_in, asset_id
+    assert asset.note.strip(), asset_id
+
+
+@pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
+def test_gh_credential_is_owned_by_the_service_account_at_0600(scheme) -> None:
+    """`hosts.yml`＝`gh` 唯一寫回 token 的檔 ⇒ 必須由使用它的帳號擁有才 refresh 得回來。"""
+    entry = generate_plan(scheme).by_id(GH_CREDENTIAL)
+    assert entry.owner == scheme.durable_state_owner
+    assert entry.mode == 0o600
+    assert not entry.is_directory
+    # group／other 一個位都沒有——token 不得被同機任何其他帳號讀到。
+    assert entry.mode & 0o077 == 0
+    assert entry.acls == (), "同帳號的 Manager／monitor 不需要 ACL；出現 ACL 即為噪音"
+
+
+@pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
+def test_gh_settings_stay_root_owned_read_only(scheme) -> None:
+    """`config.yml` 的 `aliases` 可宣告 `!` shell alias ⇒ 服務帳號不得可寫。"""
+    entry = generate_plan(scheme).by_id(GH_CONFIG)
+    assert entry.owner == scheme.deploy_account
+    assert entry.mode == 0o644
+    assert entry.writer_accounts == frozenset({scheme.deploy_account})
+    assert scheme.durable_state_owner not in entry.writer_accounts
+
+
+@pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
+def test_the_two_files_deliberately_have_different_owners(scheme) -> None:
+    """**本票最容易被下一個人做錯的那一條**：兩個檔不是同一種 owner。
+
+    把 `config.yml` 也設成服務帳號 owned，就等於給 Manager 一條「自己把任意命令掛進
+    每一次 `gh` 呼叫」的執行面（`aliases` 的 `!` 前綴）；把 `hosts.yml` 設成 root
+    owned，則 token 過期後 refresh 不回來。兩個方向都會讓這條測試變紅。
+    """
+    plan = generate_plan(scheme)
+    credential = plan.by_id(GH_CREDENTIAL)
+    settings = plan.by_id(GH_CONFIG)
+    assert credential.owner != settings.owner, (credential.owner, settings.owner)
+    assert credential.owner == scheme.durable_state_owner
+    assert settings.owner == scheme.deploy_account
+
+
+@pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
+def test_the_gh_config_directory_stays_root_owned(scheme) -> None:
+    """「檔案服務帳號 owned、目錄 root-owned」——性質全部落在目錄那一層。"""
+    scaffold = {
+        path: (owner, mode)
+        for path, owner, _group, mode in DEFAULT_LAYOUT.scaffold_directories(scheme)
+    }
+    account = scheme.durable_state_owner
+    gh_dir = DEFAULT_LAYOUT.gh_config_dir_of(account)
+    parent = f"{DEFAULT_LAYOUT.home_of(account)}/.config"
+    for path in (parent, gh_dir):
+        assert path in scaffold, (scheme.scheme_id, path)
+        owner, mode = scaffold[path]
+        assert owner == scheme.deploy_account, path
+        assert mode == 0o755, oct(mode)
+        # group／other 皆無 `w`：增／刪／換需要的正是目錄的寫入權。
+        assert mode & 0o022 == 0, oct(mode)
+
+
+def test_job_accounts_get_no_gh_config_directory() -> None:
+    """job 帳號刻意沒有這一層——job unit 已把 `GH_TOKEN` 清空，GitHub 寫入走 Manager。"""
+    scheme = FOUR_WAY_SCHEME
+    paths = {p for p, _o, _g, _m in DEFAULT_LAYOUT.scaffold_directories(scheme)}
+    for principal in (Principal.BUILDER, Principal.REVIEWER, Principal.GATE):
+        account = scheme.resolve(principal)
+        if account is None:
+            continue
+        if account == scheme.durable_state_owner:
+            continue
+        assert DEFAULT_LAYOUT.gh_config_dir_of(account) not in paths, account
+
+
+# ---------------------------------------------------------------------------
+# 2. ReadWritePaths：掛在檔案本身，而且只有 Manager／monitor 拿得到
+# ---------------------------------------------------------------------------
+
+def test_the_credential_is_an_in_place_content_write_asset() -> None:
+    """折算成父目錄會連 root-owned 的 `config.yml` 一起開放可寫。"""
+    assert GH_CREDENTIAL in IN_PLACE_CONTENT_WRITE_ASSETS
+    # `config.yml` 是 root-owned、任何 unit 都不會寫它，因此不需要（也不該）掛在
+    # 任何 RWP 上；它列在 `_FILE_ASSET_IDS` 只是為了 file/dir 推斷正確。
+    assert GH_CONFIG not in permgen.IN_PLACE_CONTENT_WRITE_ASSETS
+
+
+@pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
+def test_manager_and_monitor_units_open_only_the_credential_file(scheme) -> None:
+    plan = generate_plan(scheme)
+    account = scheme.durable_state_owner
+    credential = DEFAULT_LAYOUT.asset_paths()[GH_CREDENTIAL]
+    directory = DEFAULT_LAYOUT.gh_config_dir_of(DEFAULT_LAYOUT.manager_account)
+    # Manager unit 走帳號全集（`principals=None`，既有行為），monitor 另過濾一層。
+    for principals in (None, permgen.MONITOR_PRINCIPALS):
+        rwp = read_write_paths(
+            plan, DEFAULT_LAYOUT, account,
+            extras=DEFAULT_LAYOUT.manager_extra_write_paths(account),
+            principals=principals,
+        )
+        assert credential in rwp, (scheme.scheme_id, sorted(rwp))
+        assert directory not in rwp, "父目錄不得出現——那會連 config.yml 一起開放"
+
+
+@pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
+def test_no_job_unit_can_write_the_manager_credential(scheme) -> None:
+    """Manager 的 token 洩漏面與 job 憑證不同級 ⇒ 任何 job 帳號都不得可寫。"""
+    plan = generate_plan(scheme)
+    entry = plan.by_id(GH_CREDENTIAL)
+    writable = plan.all_writable_accounts(entry)
+    for account in scheme.headless_accounts():
+        assert account not in writable, (scheme.scheme_id, account)
+
+
+@pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
+@pytest.mark.parametrize("asset_id", NEW_ASSET_IDS)
+def test_the_service_account_can_actually_reach_the_new_assets(scheme, asset_id) -> None:
+    """葉節點權限對 **≠** 路徑走得通：整條鏈每一層都要有 search 位（#620／#624）。"""
+    plan = generate_plan(scheme)
+    account = scheme.durable_state_owner
+    blocked = unreachable_hops(
+        plan, DEFAULT_LAYOUT, scheme, account=account, asset_id=asset_id
+    )
+    assert blocked == (), (scheme.scheme_id, asset_id, blocked)
+    assert account_can_reach(
+        plan, DEFAULT_LAYOUT, scheme, account=account, asset_id=asset_id
+    )
+
+
+@pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
+def test_monitor_read_write_paths_stay_strictly_narrower_than_manager(scheme) -> None:
+    """#622 的不變式不得因為兩者都拿到憑證那一條而退化。"""
+    plan = generate_plan(scheme)
+    account = scheme.durable_state_owner
+    extras = DEFAULT_LAYOUT.manager_extra_write_paths(account)
+    manager = set(
+        read_write_paths(plan, DEFAULT_LAYOUT, account, extras=extras)
+    )
+    monitor = set(
+        read_write_paths(plan, DEFAULT_LAYOUT, account, extras=extras,
+                         principals=permgen.MONITOR_PRINCIPALS)
+    )
+    assert monitor < manager, (sorted(monitor), sorted(manager))
+
+
+# ---------------------------------------------------------------------------
+# 3. 二分相容：本方案不存在的帳號 HOME 下的資產不得進 RWP
+# ---------------------------------------------------------------------------
+
+def test_two_way_deployment_never_gets_a_path_under_a_nonexistent_account() -> None:
+    """#640 當年「乾脆不登記第二份」的那個陷阱，這次由機械規則接住。
+
+    systemd 對不存在的 `ReadWritePaths=` 目標會讓 unit **直接起不來**；二分部署沒有
+    `cortex-manager` 這個帳號，因此掛在它 HOME 下的資產在二分下必須整條消失。
+    """
+    plan = generate_plan(TWO_WAY_SCHEME)
+    account = TWO_WAY_SCHEME.durable_state_owner
+    rwp = read_write_paths(
+        plan, DEFAULT_LAYOUT, account,
+        extras=DEFAULT_LAYOUT.manager_extra_write_paths(account),
+    )
+    manager_home = DEFAULT_LAYOUT.home_of(DEFAULT_LAYOUT.manager_account)
+    assert not any(path.startswith(manager_home) for path in rwp), sorted(rwp)
+    assert rwp, "扣掉不適用的那些之後仍必須有東西——全空代表過濾寫壞了"
+
+
+def test_inapplicable_assets_are_enumerable_not_silent() -> None:
+    """靜默扣掉一條 RWP 與「漏授一條 RWP」在輸出上長得一樣，因此必須可列舉。"""
+    two_way = {
+        asset_id
+        for asset_id, _path in inapplicable_home_anchored_assets(
+            generate_plan(TWO_WAY_SCHEME), DEFAULT_LAYOUT
+        )
+    }
+    assert two_way == {
+        GH_CREDENTIAL,
+        GH_CONFIG,
+        "manager-gitconfig",
+        "reviewer-planner-gitconfig",
+    }, sorted(two_way)
+    # 定案的兩個方案完全沒有不適用項——有的話就是 layout 的帳號欄位與方案對不上。
+    for scheme in ALL_SCHEMES:
+        assert inapplicable_home_anchored_assets(generate_plan(scheme), DEFAULT_LAYOUT) == ()
+
+
+# ---------------------------------------------------------------------------
+# 4. OS 層語意：能改內容、不能增刪換（#638／#657 的教訓）
+# ---------------------------------------------------------------------------
+
+class TestGhCredentialOsSemantics:
+    """把「目錄 root-owned」那組性質對**真的檔案系統**驗一次。
+
+    與 #642 的 `TestInPlaceCredentialOsSemantics` 同一個手法、同一個理由：裁決守的
+    規則是「**目錄沒有 `w` 位給這個行程**」，真實部署裡服務帳號落在 root-owned
+    `0755` 的 `other` 位（`r-x`），本測試以 owner 位為 `r-x`（`0555`）重現**同一段
+    kernel 檢查**（`inode_permission(dir, MAY_WRITE)`），只是命中不同那組權限位。
+    不需要第二個 UID。
+    """
+
+    @pytest.fixture()
+    def tree(self, tmp_path: Path):
+        """`~/.config/gh` 的最小重現：目錄不可寫、`hosts.yml` 可寫、`config.yml` 不可換。"""
+        gh_dir = tmp_path / ".config" / "gh"
+        gh_dir.mkdir(parents=True)
+        hosts = gh_dir / "hosts.yml"
+        hosts.write_text("github.com:\n    oauth_token: old\n", encoding="utf-8")
+        hosts.chmod(0o600)
+        settings = gh_dir / "config.yml"
+        settings.write_text("editor:\n", encoding="utf-8")
+        settings.chmod(0o644)
+        gh_dir.chmod(0o555)
+        try:
+            yield gh_dir, hosts, settings
+        finally:
+            gh_dir.chmod(0o755)
+
+    def test_the_token_can_be_refreshed_in_place(self, tree) -> None:
+        """refresh 走得通：`hosts.yml` 是自己的，`O_TRUNC` 覆寫不需要目錄的寫入權。"""
+        _gh_dir, hosts, _settings = tree
+        hosts.write_text("github.com:\n    oauth_token: refreshed\n", encoding="utf-8")
+        assert "refreshed" in hosts.read_text(encoding="utf-8")
+        assert stat.S_IMODE(hosts.stat().st_mode) == 0o600
+
+    def test_new_files_cannot_be_created_in_the_directory(self, tree) -> None:
+        """「建不了新檔」——同時封掉「暫存檔 ＋ rename」那條原子替換路徑。"""
+        gh_dir, _hosts, _settings = tree
+        with pytest.raises(PermissionError):
+            (gh_dir / "hosts.yml.tmp").write_text("x", encoding="utf-8")
+
+    def test_the_credential_cannot_be_unlinked(self, tree) -> None:
+        """「刪不掉」——unlink 需要的是**目錄**的寫入權，不是檔案的。"""
+        _gh_dir, hosts, _settings = tree
+        with pytest.raises(PermissionError):
+            hosts.unlink()
+        assert hosts.exists()
+
+    def test_the_root_owned_settings_file_cannot_be_replaced(self, tree) -> None:
+        """「換不掉同目錄下的另一個 root-owned 檔」——rename 同樣要目錄的寫入權。
+
+        這一條正是 `config.yml` 維持 root-owned 買到的東西：服務帳號沒辦法用自己那份
+        可寫的 `hosts.yml` 蓋掉它，因此宣告不了 `!` shell alias。
+        """
+        _gh_dir, hosts, settings = tree
+        with pytest.raises(PermissionError):
+            os.replace(hosts, settings)
+        assert settings.read_text(encoding="utf-8") == "editor:\n"
+
+
+@pytest.mark.skip(
+    reason=(
+        "#638／#657 的教訓：涉及 OS 層語意、單 UID 測不出來的，明確 skip 並說明理由，"
+        "不得靜默通過。這裡待驗的命題是「**檔案 owner 不是本行程**」那一半——"
+        "`config.yml` 由 root 擁有、服務帳號連內容都改不了（DAC 的 owner/group/other "
+        "三組位裡命中 `other` 的 `r--`）。上面 `TestGhCredentialOsSemantics` 重現得了"
+        "「目錄沒有 `w` 位」那一半（同一段 `inode_permission()`），但重現不了這一半："
+        "本行程就是檔案的 owner，chmod 0444 之後它仍改得掉（先 chmod 回來即可），"
+        "而以 root 執行時 DAC 對它整個不適用。真正驗得到它需要第二個 UID ＋ 真的 "
+        "systemd 加固面，兩者本測試環境都沒有。\n"
+        "**那一半改由兩個地方守**：(1) 產生器測試 `test_gh_settings_stay_root_owned_"
+        "read_only`（`entry.owner == deploy_account` 且 writer 不含服務帳號）；"
+        "(2) runbook 第 4e 步的實機驗證，以 `sudo -u <服務帳號>` 實跑並期望 "
+        "`Permission denied`。在這裡跑一次「同 UID 下改得掉 config.yml」只會證明一件"
+        "與待驗命題無關的事，卻會讓人以為驗過了。"
+    )
+)
+def test_the_service_account_cannot_rewrite_the_root_owned_settings_file() -> None:  # pragma: no cover
+    raise AssertionError("需要第二個 UID；見 skip 理由")
+
+
+# ---------------------------------------------------------------------------
+# 5. pytest／PyYAML：系統層 python 發行版，版本是明示的部署決定
+# ---------------------------------------------------------------------------
+
+def test_pytest_is_a_system_layer_python_distribution() -> None:
+    by_name = {d.name: d for d in SYSTEM_PYTHON_DISTRIBUTIONS}
+    assert set(by_name) == {"pytest", "PyYAML"}, sorted(by_name)
+    for dist in SYSTEM_PYTHON_DISTRIBUTIONS:
+        assert dist.interpreter == SYSTEM_INTERPRETER, dist.name
+        assert dist.requirement.strip() and dist.declared_in.strip(), dist.name
+        assert dist.required_by, dist.name
+        assert dist.note.strip(), dist.name
+    assert by_name["pytest"].module == "pytest"
+    # 發行版名與模組名不同的那一族——寫錯會讓 runbook 的驗證指令 import 錯東西。
+    assert by_name["PyYAML"].module == "yaml"
+
+
+def test_python_distributions_are_not_smuggled_into_the_executable_rosters() -> None:
+    """它們不是可執行檔：塞進 `SYSTEM_PROGRAMS` 會讓「名冊上每一項都 which 得到」變假。
+
+    這與 #661 對「不要把 `srt` 併進 `EXECUTOR_TOOLS`」是同一條論證：盤點完整性不可以
+    用「往別張表塞東西」來換，那會弄壞那張表原本承載的性質。
+    """
+    executables = (
+        {t.name for t in EXECUTOR_TOOLS}
+        | {t.name for t in SERVICE_TOOLS}
+        | {p.name for p in SYSTEM_PROGRAMS}
+    )
+    for dist in SYSTEM_PYTHON_DISTRIBUTIONS + DEPLOYMENT_PYTHON_DISTRIBUTIONS:
+        assert dist.name not in executables, dist.name
+
+
+def test_the_version_constraint_has_exactly_one_source_of_truth() -> None:
+    """「版本是明示的部署決定」＝約束由 `pyproject.toml` 宣告，表上不得另寫一份。
+
+    這條測試就是那句話的機器可讀形式：改了 `pyproject.toml` 的下限而沒同步表，
+    或反過來，都會紅。
+    """
+    text = (REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    by_name = {d.name: d for d in SYSTEM_PYTHON_DISTRIBUTIONS}
+    for name in ("pytest", "PyYAML"):
+        requirement = by_name[name].requirement
+        assert f'"{requirement}"' in text, (name, requirement)
+
+
+def test_deployment_venv_distributions_need_no_new_filesystem_asset() -> None:
+    """部署 venv 是既有的 root-owned 資產 ⇒ 這一族**不新增**任何登記表項（#661 裁決）。"""
+    asset_ids = {a.asset_id for a in ASSET_REGISTRY}
+    for dist in DEPLOYMENT_PYTHON_DISTRIBUTIONS:
+        assert dist.interpreter == DEPLOYMENT_VENV_INTERPRETER, dist.name
+        assert dist.name not in asset_ids, dist.name
+
+
+# ---------------------------------------------------------------------------
+# 6. gate 宣告：每一段都必須落在某張表上
+# ---------------------------------------------------------------------------
+
+def test_gate_env_prefix_matches_the_runtime_contract() -> None:
+    """`permgen` 與 `coordinator` 刻意不互相 import ⇒ 由契約測試釘住兩邊逐字相等。"""
+    assert GATE_COMMAND_ENV_PREFIX == gate_ledger.GATE_ENV_PREFIX
+
+
+def test_every_segment_of_the_gate_declaration_is_on_some_roster() -> None:
+    """#666 的核心不變式：gate 宣告用到的東西不得有任何一段不在盤點內。
+
+    實機症狀正是這條不成立——`python3` 沒進過任何名冊、`pytest` 也沒有，於是
+    「宣告合法」與「跑得起來」之間沒有任何機械關係。
+    """
+    system_programs = {p.name for p in SYSTEM_PROGRAMS}
+    system_modules = {d.module for d in SYSTEM_PYTHON_DISTRIBUTIONS}
+    assert GATE_COMMAND_DECLARATIONS, "至少要有一個宣告，否則 ledger 永遠是空的"
+    for name, argv in GATE_COMMAND_DECLARATIONS.items():
+        assert argv, name
+        assert argv[0] in system_programs, (name, argv[0])
+        if "-m" in argv:
+            module = argv[argv.index("-m") + 1]
+            assert module in system_modules, (name, module)
+
+
+def test_the_declaration_covers_every_gate_the_deck_requires() -> None:
+    """否則照 runbook 裝出來的部署一開機 doctor 的 `gate-declarations` 就是紅的（#540）。"""
+    required = doctor._deck_required_gate_names()
+    assert required <= set(GATE_COMMAND_DECLARATIONS), sorted(
+        required - set(GATE_COMMAND_DECLARATIONS)
+    )
+
+
+def test_the_generated_declaration_passes_the_runtime_validator() -> None:
+    """產生器出的值必須真的被 `gate_ledger` 收得下（typed argv、非 shell wrapper）。"""
+    env = DEFAULT_LAYOUT.gate_command_env()
+    specs = {spec.name: spec.argv for spec in gate_ledger.load_gate_specs(env)}
+    assert specs == {
+        name: tuple(argv) for name, argv in GATE_COMMAND_DECLARATIONS.items()
+    }, specs
+    assert set(gate_ledger.declared_gate_names(env)) == set(GATE_COMMAND_DECLARATIONS)
+
+
+def test_the_gate_interpreter_resolves_to_the_system_layer() -> None:
+    """宣告用相對名 ⇒ 由 `PSC_GATE_PATH` 解析 ⇒ 落在系統層，不是部署 venv。
+
+    這就是「pytest 為什麼必須裝到系統層」的機械成因；改成絕對路徑的 venv
+    interpreter 會讓這條測試變紅，那時 `SYSTEM_PYTHON_DISTRIBUTIONS` 也該一起改。
+    """
+    path_value = DEFAULT_LAYOUT.job_path_value()
+    assert path_value.endswith(":".join(JOB_PATH_SYSTEM_TAIL))
+    assert DEFAULT_LAYOUT.venv_root not in path_value
+    for argv in GATE_COMMAND_DECLARATIONS.values():
+        assert not argv[0].startswith("/"), argv[0]
+
+
+# ---------------------------------------------------------------------------
+# 7. 窮舉盤點：**兩個方向**都封閉
+# ---------------------------------------------------------------------------
+
+def test_every_listed_dependency_really_is_covered_by_some_roster() -> None:
+    """盤點列到但表上查無 ⇒ 紅。這條擋的是「寫了一列就算盤到了」。"""
+    assert uncovered_run_dependencies() == (), [
+        (d.name, d.covered_by) for d in uncovered_run_dependencies()
+    ]
+
+
+def test_every_roster_entry_is_accounted_for_in_the_inventory() -> None:
+    """**反方向**——本票真正要買的東西。
+
+    往 `SERVICE_TOOLS`／`SYSTEM_PROGRAMS`／兩張 python 發行版表加一項、或新增一個掛在
+    帳號 HOME 下的登記表資產，而沒有說明「它在 run 的哪一段被誰碰到」，這條就會紅。
+    #640→#661→#666 每一次的形態都是後者只做了一半。
+    """
+    assert unlisted_roster_entries() == (), unlisted_roster_entries()
+
+
+def test_the_inventory_rows_are_well_formed() -> None:
+    seen: set[tuple[str, str]] = set()
+    for dep in RUN_EXTERNAL_DEPENDENCIES:
+        assert dep.key not in seen, dep.key
+        seen.add(dep.key)
+        assert isinstance(dep.kind, DependencyKind), dep.name
+        assert dep.principals, dep.name
+        assert dep.stages, dep.name
+        for principal in dep.principals:
+            assert isinstance(principal, Principal), dep.name
+        for stage in dep.stages:
+            assert isinstance(stage, RunStage), dep.name
+        assert dep.note.strip(), dep.name
+
+
+def test_the_same_distribution_can_appear_once_per_interpreter() -> None:
+    """PyYAML 在系統層與部署 venv 各有一份，是**兩個**部署決定，不得被去重掉。"""
+    pyyaml = [d for d in RUN_EXTERNAL_DEPENDENCIES if d.name == "PyYAML"]
+    assert len(pyyaml) == 2, pyyaml
+    assert {d.covered_by for d in pyyaml} == {
+        "SYSTEM_PYTHON_DISTRIBUTIONS",
+        "DEPLOYMENT_PYTHON_DISTRIBUTIONS",
+    }
+
+
+def test_the_inventory_covers_every_review_sandbox_executable() -> None:
+    """doctor 要求的每一支都必須在盤點內——#664 那條的加強版。
+
+    #661 當時把 `python3` 排除在外，理由寫的是「它是部署 venv 自己的 interpreter，
+    不是外部相依」。**#666 查證後那個前提不成立**：`review-sandbox` probe 是以
+    `PATH` 解析它的，gate 宣告也是——兩處拿到的都是系統層那一支。因此這條不再有
+    例外。
+    """
+    listed = {dep.name for dep in RUN_EXTERNAL_DEPENDENCIES}
+    assert set(doctor.REVIEW_SANDBOX_EXECUTABLES) <= listed, sorted(
+        set(doctor.REVIEW_SANDBOX_EXECUTABLES) - listed
+    )
+
+
+def test_every_downgraded_principal_appears_somewhere_in_the_inventory() -> None:
+    """四個降權角色都要有相依被盤到；某個角色一項都沒有就代表那一面沒盤。"""
+    covered = {p for dep in RUN_EXTERNAL_DEPENDENCIES for p in dep.principals}
+    for principal in (
+        Principal.MANAGER, Principal.MONITOR,
+        Principal.BUILDER, Principal.REVIEWER, Principal.PLANNER, Principal.GATE,
+    ):
+        assert principal in covered, principal
+
+
+def test_home_anchored_assets_are_derived_not_hand_written() -> None:
+    """憑證／per-account 設定那一族由 `asset_paths()` 機械導出，不是手抄清單。"""
+    assert home_anchored_asset_ids() == frozenset({
+        "builder-executor-credential",
+        "builder-gitconfig",
+        "codex-hooks",
+        GH_CONFIG,
+        GH_CREDENTIAL,
+        "manager-gitconfig",
+        "reviewer-planner-gitconfig",
+    }), sorted(home_anchored_asset_ids())
+
+
+def test_deferred_dependencies_stay_enumerable() -> None:
+    """比照 #661 的 `unresolved_node_execution_surfaces()`：不裁決，但不得靜默消失。
+
+    這四項都是「per-account 的機制已就緒、登記表只登記了其中一份」。補上或悄悄拿掉
+    都會讓這條紅——那正是要的：它們必須是一個**被看見的**決定。
+    """
+    deferred = deferred_run_dependencies()
+    assert {item.name for item in deferred} == {
+        "reviewer-planner-executor-credential",
+        "gate-gitconfig",
+        "reviewer-planner-codex-hooks",
+        "manager-claude-credential",
+    }, sorted(item.name for item in deferred)
+    for item in deferred:
+        assert item.principals, item.name
+        assert item.reason.strip() and item.symptom.strip(), item.name
+        assert item.disposition.strip(), item.name
+    # 未決項**不得**混進主盤點——主盤點的每一列都必須真的有歸宿。
+    listed = {dep.name for dep in RUN_EXTERNAL_DEPENDENCIES}
+    for item in deferred:
+        assert item.name not in listed, item.name
+
+
+def test_the_reviewer_credential_gap_is_real_not_theoretical() -> None:
+    """把上面那條 deferred 的**症狀**釘成可驗證的事實，而不是一段散文。
+
+    M2（#615）的 reviewer 模板 unit 已經在產生器裡，但它的 `ReadWritePaths` 不含
+    reviewer 帳號那份 executor 憑證 ⇒ `ProtectSystem=strict` 下讀得到、改不了。
+    哪天有人補上登記表第二列，這條會紅——**那正是提醒去刪掉這條測試與那筆 deferred**。
+    """
+    scheme = FOUR_WAY_SCHEME
+    plan = generate_plan(scheme)
+    account = scheme.resolve(Principal.REVIEWER)
+    assert account is not None
+    credential = DEFAULT_LAYOUT.executor_credential_of(account)
+    rwp = read_write_paths(
+        plan, DEFAULT_LAYOUT, account,
+        extras=DEFAULT_LAYOUT.job_extra_write_paths(account),
+        principals=permgen.JOB_PRINCIPAL_PERSONAS[Principal.REVIEWER],
+        retired=permgen.RETIRED_JOB_WRITE_ASSETS,
+    )
+    assert not any(path == credential for path in rwp), sorted(rwp)
+    # 對照：builder 那一份**有**（同一條導出路徑，差別只在登記表登記了幾列）。
+    builder = scheme.resolve(Principal.BUILDER)
+    builder_rwp = read_write_paths(
+        plan, DEFAULT_LAYOUT, builder,
+        extras=DEFAULT_LAYOUT.job_extra_write_paths(builder),
+        principals=permgen.JOB_PRINCIPAL_PERSONAS[Principal.BUILDER],
+        retired=permgen.RETIRED_JOB_WRITE_ASSETS,
+    )
+    assert DEFAULT_LAYOUT.executor_credential_of(builder) in builder_rwp
+
+
+# ---------------------------------------------------------------------------
+# 8. 落位計畫：能重現實機那兩項，且仍是純字串
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
+def test_toolchain_plan_reproduces_the_two_manual_fixes(scheme) -> None:
+    """驗收條件是「重跑計畫後零漂移」⇒ 計畫本身必須帶得出這兩項。"""
+    text = "\n".join(build_toolchain_plan(scheme, DEFAULT_LAYOUT))
+    # 漂移項 1：系統層 pytest（＋被測樹的 PyYAML），版本約束與來源都要在計畫裡。
+    for dist in SYSTEM_PYTHON_DISTRIBUTIONS:
+        assert f"--break-system-packages '{dist.requirement}'" in text, dist.name
+        assert dist.declared_in in text, dist.name
+    # 漂移項 2：gh 憑證的兩個檔、兩種 owner、以該身分實測的驗證步驟。
+    credential = DEFAULT_LAYOUT.gh_credential_of(DEFAULT_LAYOUT.manager_account)
+    settings = DEFAULT_LAYOUT.gh_settings_of(DEFAULT_LAYOUT.manager_account)
+    assert f"-m 0600 \\" in text and credential in text
+    assert f"-m 0644 \\" in text and settings in text
+    assert "gh auth status" in text
+    assert "洩漏面不同級" in text
+
+
+def test_toolchain_plan_prints_the_exhaustive_inventory() -> None:
+    text = "\n".join(build_toolchain_plan(FOUR_WAY_SCHEME, DEFAULT_LAYOUT))
+    assert f"目前共 {len(RUN_EXTERNAL_DEPENDENCIES)} 項" in text
+    for dep in RUN_EXTERNAL_DEPENDENCIES:
+        assert f"{dep.name}  ({dep.kind.value};" in text, dep.name
+    for item in deferred_run_dependencies():
+        assert item.name in text, item.name
+
+
+def test_toolchain_plan_lines_are_still_comments_or_the_three_allowed_commands() -> None:
+    """新增的兩段全是註解——`install`／`chown`／`chmod` 之外的行不得出現。"""
+    allowed = ("install -d ", "chown ", "chmod ")
+    for scheme in (TWO_WAY_SCHEME,) + ALL_SCHEMES:
+        for line in build_toolchain_plan(scheme, DEFAULT_LAYOUT):
+            stripped = line.strip()
+            if not stripped or stripped.startswith("#"):
+                continue
+            assert stripped.startswith(allowed), (scheme.scheme_id, stripped)
+
+
+def test_toolchain_plan_is_deterministic() -> None:
+    assert build_toolchain_plan(FOUR_WAY_SCHEME, DEFAULT_LAYOUT) == build_toolchain_plan(
+        FOUR_WAY_SCHEME, DEFAULT_LAYOUT
+    )
+
+
+def test_the_new_generators_are_still_pure_functions() -> None:
+    """產生器不得取得任何實作面——本票新增的幾個函式一樣。"""
+    src = inspect.getsource(permgen)
+    for forbidden in ("subprocess", "os.system", "os.chown", "os.chmod", "shutil."):
+        assert forbidden not in src, forbidden
+    # 實跑一次確認沒有 IO（有 IO 會在無權限的環境炸掉，而不是靜默通過）。
+    uncovered_run_dependencies()
+    unlisted_roster_entries()
+    deferred_run_dependencies()
+    DEFAULT_LAYOUT.gate_command_env()
+    build_toolchain_plan(FOUR_WAY_SCHEME, DEFAULT_LAYOUT)

--- a/tests/test_trust_root_job_template_ab.py
+++ b/tests/test_trust_root_job_template_ab.py
@@ -427,6 +427,12 @@ class SchemeDerivedHomeTests(unittest.TestCase):
                 permgen.DEFAULT_LAYOUT.cache_of(a) for a in expected
             } | {
                 permgen.DEFAULT_LAYOUT.codex_hooks_dir_of(a) for a in expected
+            } | {
+                # #666：durable state owner 另有 root-owned 的 `~/.config` 與
+                # `~/.config/gh`（`gh` 的登入態落點）。仍在**本 scheme 解析得到的
+                # 帳號**底下，因此「無多餘」這條的原意未被放寬。
+                f"{permgen.DEFAULT_LAYOUT.home_of(scheme.durable_state_owner)}/.config",
+                permgen.DEFAULT_LAYOUT.gh_config_dir_of(scheme.durable_state_owner),
             }
             self.assertTrue(homes <= resolved, (scheme.scheme_id, homes - resolved))
 

--- a/tests/test_trust_root_monitor_unit_622.py
+++ b/tests/test_trust_root_monitor_unit_622.py
@@ -164,13 +164,21 @@ def test_monitor_read_write_paths_cover_every_monitor_asset(scheme) -> None:
         plan, DEFAULT_LAYOUT, scheme.durable_state_owner,
         principals=permgen.MONITOR_PRINCIPALS,
     )
-    assert set(targets) == {
+    expected = {
         "runtime-run-tree",
         "monitor-state-tree",
         "monitor-work-items-snapshot",
         "monitor-github-sync-cursor",
         "monitor-event-spool",
-    }, sorted(targets)
+    }
+    # #666：monitor 的 GitHub provider 直接跑 `gh api`，token 過期時的 refresh 發生
+    # 在哪一個行程不由我們決定，因此 `manager-gh-credential` 的 writer 含 MONITOR。
+    # **二分不在其中而且不是遺漏**：該資產掛在 `cortex-manager` 的 HOME 下，而二分
+    # 沒有那個帳號 ⇒ `inapplicable_home_anchored_assets()` 機械地把它扣掉（掛一條不
+    # 存在的 `ReadWritePaths=` 會讓 unit 直接起不來）。
+    if permgen.DEFAULT_LAYOUT.manager_account in scheme.declared_accounts():
+        expected.add("manager-gh-credential")
+    assert set(targets) == expected, sorted(targets)
     for asset_id, target in targets.items():
         assert any(_within(target, rwp) for rwp in unit.read_write_paths), (asset_id, target)
 


### PR DESCRIPTION
2026-08-18 啟用 monitor 時 operator **直接在實機補上**的兩項，收斂回權威計畫；並依票上要求做一次**窮舉盤點**——把「症狀出現才補一項」這個已經重複五次的形態，換成「從一個 run 反推」的判準。

## 1. 漂移項 1：`pytest`（系統層 python 套件）

**機械成因查證後比票上更精確一點**：`PSC_GATE_CMD_PYTEST="python3 -m pytest -q"` 的第一段是**相對名**，由 gate 的 `PSC_GATE_PATH`（`<toolchain>/bin` ＋ `/usr/local/bin:/usr/bin:/bin`）解析 ⇒ `/usr/bin/python3`。gate unit 自己的 `ExecStart` 用的是 `gate_runner.DEFAULT_GATE_PYTHON`（`/opt/cortex/venv/bin/python3`），但**那只涵蓋 ledger writer 本身**——`gate_ledger` 接著把 operator 宣告的命令**另外解析一次**。兩者是不同的 interpreter，這就是「為什麼一定要裝到系統層」。

**進 `SYSTEM_PROGRAMS` 這件事本身做不到，而理由值得寫下來。** 那張表的每一項都是「落在 `PATH` 上、`command -v` 解得到」的可執行檔（既有測試就靠這條性質對照 doctor 的 `REVIEW_SANDBOX_EXECUTABLES`）；`pytest` 不是。硬塞會讓那條既有性質變成假的——與 #661「不得把 `srt` 併進 `EXECUTOR_TOOLS`」是**同一條論證**：盤點完整性不可以用「往別張表塞東西」來換。因此另立**第四種相依**：

| 表 | 內容 | interpreter |
|---|---|---|
| `SYSTEM_PYTHON_DISTRIBUTIONS`（新） | `pytest`、`PyYAML` | 系統層 `/usr/bin/python3` |
| `DEPLOYMENT_PYTHON_DISTRIBUTIONS`（新） | `policy-check`、`PyYAML` | 部署 venv |

`PREFLIGHT_BACKEND_DISTRIBUTION` 這個原本散落的常數也收進後者，不再是第二份真相。

**票上只點名 pytest，實機兩個是一起裝的——`PyYAML` 的理由在這裡**：它是**被測樹**的 runtime 相依，不是 pytest 的。gate 命令的 cwd 是 gate 自己那份工作樹副本，pytest 會把 rootdir 插進 `sys.path` ⇒ `import paulsha_cortex` 解到**被驗的那棵樹** ⇒ 它 `import yaml`。缺它的症狀是 pytest exit code `2`（collection error），依 #307 的判準不會被誤判成合格 RED，但整張卡照樣過不了。**這條的一般形式**：`PSC_GATE_CMD_*` 用系統 interpreter 時，**被治理 repo 的整組 runtime 相依**都成了系統層的部署決定；目前受治理的只有 cortex 自己，治理面擴出去時這一列要跟著長。

**版本是明示的部署決定**：約束的唯一真相在 `pyproject.toml`（`pytest>=7` / `PyYAML>=6`），有測試對著檔案內容比——改一邊沒改另一邊即紅。實機解出來的版本（系統層 9.1.1 / operator 側 9.0.3）由 runbook 第 4f 步記錄並要求逐次比對：**兩者可以不同（兩個 interpreter 各有一份是常態），但必須被記下來**，因為版本分岔的症狀是「gate 判定與本機跑不一樣」，不是報錯。

> **刻意不做的事**：把宣告改成 `/opt/cortex/venv/bin/python3 -m pytest` 看起來能一步消掉整個系統層需求，但那會讓 gate 跑的 pytest 版本與 cortex 自己的部署版本綁在一起（升 cortex 會連帶換掉 gate 的判準）。那是 operator 平面的裁決，產生器不替它做——runbook 把取捨寫清楚，並註明「改了宣告，這一節就不再適用，同時要改 `SYSTEM_PYTHON_DISTRIBUTIONS`，測試會提醒你」。

## 2. 漂移項 2：`gh` 憑證（Manager 的傳輸層憑證）

比照 #640／#642 的形態新增兩個資產，產生器出來的命令與實機逐字相同：

```
/var/lib/cortex-manager/.config/        root:root 0755      ← scaffold_directories()
/var/lib/cortex-manager/.config/gh/     root:root 0755      ← scaffold_directories()
  hosts.yml    cortex-manager:cortex-manager 0600           ← manager-gh-credential
  config.yml   root:root 0644                               ← manager-gh-config
```

**兩個 owner 刻意不同這件事寫進了三處 note（資產、spec、runbook 表格）**，理由不是「一個是憑證一個不是」而已：`config.yml` 的 `aliases` 可以宣告 `!` 開頭的 **shell alias**——讓服務帳號改得了它，等於給 Manager 一條「自己把任意命令掛進每一次 `gh` 呼叫」的執行面。這與三份 `.gitconfig` 維持 root-owned 的理由（`core.fsmonitor`／`alias.*` 同樣會執行外部命令）**逐字相同**，所以結論也相同。

**與 job 憑證的實質差異，spec §R1 (b2)／資產 note／runbook 三處都明寫不得混為一談**：#640 那一份是給 **job 帳號**的模型 provider 憑證，被竊只換得到模型呼叫額度，而且 job 模板 unit 另有 `Environment=GH_TOKEN=`／`GITHUB_TOKEN=` 把 GitHub token 清空、成果一律走 `commit-spool` 由 Manager 代理推送。本份是給 **Manager**——durable state owner——的，這個 token **推得動 PR、關得掉 issue、改得了 label、merge 得了分支**，洩漏的是治理平面對上游 repo 的寫入權。因此 (i) 只掛在 durable state owner 的 HOME 下；(ii) **job 帳號刻意沒有 `~/.config/gh` 這一層目錄**（`scaffold_directories()` 不為它們建）；(iii) 列入 `IN_PLACE_CONTENT_WRITE_ASSETS`，`ReadWritePaths` 掛在**檔案本身**，父目錄連 mount 層都不開放。

**`monitor` 也是 writer 而不是只有 reader**：monitor 的 GitHub provider 直接跑 `gh api`，token 過期時 refresh 發生在哪一個行程不由我們決定；只給讀取權會做出一個「平常好好的、token 到期那天 monitor 整條 provider 靜默 degraded」的部署。#622 的不變式（monitor RWP 嚴格窄於 Manager）不受影響，有測試。

**落點為什麼是 `~/.config/gh`**：`gh` 依序看 `$GH_CONFIG_DIR` → `$XDG_CONFIG_HOME/gh` → `$HOME/.config/gh`，而產生出來的 unit 設 `HOME=` 與 `XDG_CACHE_HOME=`、**刻意不設 `XDG_CONFIG_HOME=`**。日後有人補上它，憑證落點會**無聲**搬走（`gh auth status` 變「未登入」而檔案還在原處）——這一條寫進 `gh_config_dir_of()` 的 docstring、spec 與 runbook。

### 順帶拆掉一個 #640 留下的阻礙

登記第二個掛在帳號 HOME 下、且**可寫**的資產，當場撞到 #640 記錄過的那個陷阱：路徑由 `PathLayout` 的部署決定欄位（取定案的三分／四分）導出，二分把 Manager 併進 `cortex-svc` ⇒ RWP 出現一條二分部署裡根本不存在的路徑 ⇒ systemd 讓 unit 直接起不來（`test_custom_layout_needs_no_code_change` 紅了才發現，與 #642 當年一模一樣）。

#640 的處置是「乾脆不登記第二份」。本 PR 改成一條**可列舉的機械規則** `permgen.inapplicable_home_anchored_assets()`：登記表的 note 早就寫著「二分下該資產不適用」、權限那一半也早就以 `[ ! -e ] || …` 守衛表達了它——缺的只有 RWP 那一半。**刻意做成可列舉而不是靜默過濾**：靜默扣掉一條 RWP 與「漏授一條 RWP」在輸出上長得一樣，而後者的症狀是 job 跑到一半 EROFS。

## 3. 本票的重點：窮舉盤點

判準改成「**降權帳號在完整加固面下，跑完一個 run 需要碰到的所有外部程式與憑證**」。前面每張表本身都完整，缺的是**沒有任何一處回答「一個 run 需要碰到的東西有哪些」**。

`permgen.RUN_EXTERNAL_DEPENDENCIES`：**25 項**，逐項標明 kind／哪些 principal／run 的哪一段（dispatch／model-call／review／gate／ship／monitor）／**登記在哪**。

**其中 5 項是既有三張表沒涵蓋的**：

| 項目 | 種類 | 為什麼一直沒被盤到 |
|---|---|---|
| `bash` | 系統層程式（新） | **每一支 job 的 `command[0]` 就是它**——wrapper 是 `bash -c <script>`，降權模式下 shim 的 `execvpe` 執行的第一支程式即為它；Manager 側的 exit 記帳 shell 亦然。它落在 `/bin` 且從來沒缺過，所以「沒被登記」與「不需要」長得一樣 |
| `python3` | 系統層程式（新） | #661 明文排除，理由寫「它是部署 venv 自己的 interpreter」——**查證後該前提不成立**：`review-sandbox` probe 與 gate 宣告都以 `PATH` 解析它，兩處拿到的都是系統層那一支 |
| `systemctl` | 系統層程式（新） | B 案定案後 Manager 派工的第一個動作就是 exec 它（`systemctl start --wait`），解不到就是「降權派工整條不可用」而非單一 job 失敗 |
| `pytest` | python 發行版（新表） | 本票漂移項 1 |
| `PyYAML`（系統層那一份） | python 發行版（新表） | 被測樹的 runtime 相依，票上未點名 |

其餘 20 項分別由 `EXECUTOR_TOOLS`(4)／`SERVICE_TOOLS`(2)／`SYSTEM_PROGRAMS`(5 既有)／`DEPLOYMENT_PYTHON_DISTRIBUTIONS`(2)／登記表 HOME-anchored 資產(7) 涵蓋。

### 怎麼做成測試釘得住的形態

**雙向封閉**，缺任一邊測試就紅：

- `uncovered_run_dependencies()` — 盤點列到但表上**查無**。不是字串比對：名冊型的 `covered_by` 回頭去那張 tuple 裡找同名項，資產型的去 `registry.ASSET_REGISTRY` 找 `asset_id`。
- `unlisted_roster_entries()` — **反方向**，本 PR 真正要買的東西。每張名冊上的每一項、以及**每一個掛在帳號 HOME 下的登記表資產**（由 `asset_paths()` × `home_anchored_account()` **機械導出**，不是手抄清單）都必須被盤點列到。往 `SERVICE_TOOLS` 加一支程式而沒說明「它在 run 的哪一段被誰碰到」，測試會紅。

這就是把「加一支相依」與「說明它的執行面」從兩件可以只做一半的事，變成同一件事——#640→#661→#666 每一次的形態都是後者只做了一半。

另有兩條交叉對照：`doctor.REVIEW_SANDBOX_EXECUTABLES` **每一支**（不再有 `python3` 例外）必須在盤點內；`GATE_COMMAND_DECLARATIONS` 的每一段 argv 都必須對照得到某張表（`python3` ∈ `SYSTEM_PROGRAMS`、`-m <module>` ∈ `SYSTEM_PYTHON_DISTRIBUTIONS`）。

### 盤到但**尚無歸宿**的四項——可列舉，不做裁決

比照 #664 的 `unresolved_node_execution_surfaces()`：`permgen.deferred_run_dependencies()`，測試釘住目前內容（補上或悄悄拿掉都會紅）。四項的共同形態是「**per-account 的機制已就緒，登記表只登記了其中一份**」：

1. **reviewer／planner 的 executor 憑證**——#640 的 note 寫「M2（#615）落地時補第二列即可」，而 **M2 已經落地**，所以這條現在是**逾期未做**而不是「時候未到」。已用產生器實測：reviewer 模板 unit 的 `ReadWritePaths` **不含**它 ⇒ `ProtectSystem=strict` 下讀得到、改不了 ⇒ token 過期那天 refresh 靜默失敗。有一條測試把這個**事實**釘住（並在 docstring 寫明：補上第二列時它會紅，那正是提醒去刪掉它與那筆 deferred）。#666 順帶把當年的阻礙（二分相容）拆掉了，但**補這一列會改動 reviewer unit 的 RWP，屬 operator 的部署面裁決，不在本票範圍**。
2. **`cortex-gate` 沒有 `.gitconfig`**——預防面而非現行症狀（gate 在**副本**上跑，且目前的 `PSC_GATE_CMD_PYTEST` 不碰 git）。寫下來是為了不讓它變成第六個「症狀出現才補」。
3. **reviewer／planner 的 `codex-hooks`**——`asset_paths()` 把它寫死在 builder HOME 下；reviewer 目前走 `claude`，尚未表現出來。
4. **Manager 的 claude 登入態**——`planning_runtime` 是在 **Manager 行程內**直接 exec `claude` 的（不是派降權 job），讀 `<HOME>/.claude/.credentials.json`；而 `executor_credential_relpath` 是**單一**部署決定，一個帳號只表達得了一份憑證。程式碼在查無憑證時**明確回 `None` 不代為猜測**，因此不是靜默失敗；實機 planning 走 `agy`，還沒踩到。

## 驗證

- **`trust_root equation`：綠**（`ok: true`，四個清單皆空）
- **產生器輸出與實機逐字相同**（＝「重跑計畫後零漂移」）：
  ```
  [ ! -e …/.config/gh/hosts.yml ]  || chown cortex-manager:cortex-manager …/hosts.yml
  [ ! -e …/.config/gh/hosts.yml ]  || chmod 0600 …/hosts.yml
  [ ! -e …/.config/gh/config.yml ] || chown root:root …/config.yml
  [ ! -e …/.config/gh/config.yml ] || chmod 0644 …/config.yml
  install -d -o root -g root -m 0755 /var/lib/cortex-manager/.config
  install -d -o root -g root -m 0755 /var/lib/cortex-manager/.config/gh
  ```
- **`ReadWritePaths` 只掛檔案不掛父目錄**：Manager 與 monitor unit 皆為 `…/.config/gh/hosts.yml`，`…/.config/gh` 不出現；job unit 對 `config/gh` **零命中**且仍帶 `Environment=GH_TOKEN=`
- **不變式「改得了內容、建不了新檔」以真的 OS 語意驗**（比照 #642 的 `TestInPlaceCredentialOsSemantics`）：`TestGhCredentialOsSemantics` 對真實檔案系統驗四條——就地改內容成功、建新檔 `PermissionError`、`unlink` `PermissionError`、`os.replace` 蓋 root-owned 鄰居 `PermissionError`。**不需要第二個 UID**：守的規則是「目錄沒有 `w` 位給這個行程」，以 owner 位 `0555` 重現**同一段 kernel 檢查**（`inode_permission(dir, MAY_WRITE)`）
- **OS 層語意明確 skip**（#638／#657 的教訓）：「`config.yml` 由 root 擁有、服務帳號連內容都改不了」那一半**單 UID 重現不了**（本行程就是 owner，chmod 回來即可改；root 下 DAC 整個不適用），以具名 `@pytest.mark.skip` ＋ 完整理由標示，並寫明那一半改由產生器測試與 runbook 實機驗證守——**在這裡跑一次只會證明一件與待驗命題無關的事，卻會讓人以為驗過了**
- **`permgen` 仍為純函式**（無 `subprocess`／`os.chown`／`os.chmod`／`shutil.`）；落位計畫非註解行仍只可能是 `install -d`／`chown`／`chmod`
- **#622 monitor RWP 嚴格窄於 manager**：兩個 scheme 皆 `monitor < manager`
- **二分部署不得出現不存在帳號的路徑**：有正向與反向兩條測試
- 新測試檔 `tests/test_trust_root_external_deps_exhaustive_666.py`：**53 passed, 1 skipped**
- 全套 `python3 -m pytest tests/ -q`：**4163 passed, 21 skipped, 49 subtests**，零回歸
- 本機 `policy_check` 帶 PR 上下文跑

## runbook

新增**第 4f**（系統層 python 套件）／**4g**（Manager gh 憑證）／**4h**（窮舉盤點複核）三步。**驗證一律以該身分實測，不是只驗檔案存在**：

- 4f：gate 身分跑 `python3 -m pytest --version` ＋ **完整加固面下**的 `systemd-run` 實跑（**CPython 不是 V8，MDWE 對它沒有影響**，因此這一條在完整加固面下就該過——失敗即為新發現，**不得就地放寬**）＋ operator 側／gate 側版本比對並記錄
- 4g：Manager 身分 `gh auth status` ＋ 完整加固面下複跑 ＋ 不變式**四條**（改得了內容／建不了新檔／刪不掉 root-owned 鄰居／**改不了 `config.yml`**）＋ RWP 只掛檔案不掛父目錄 ＋ job 側反向驗證（`config/gh` 零命中、`GH_TOKEN=` 為空）
- 4h：`uncovered_run_dependencies()` 與 `unlisted_roster_entries()` 皆須為 `()`；已知未決項印出來，並註明「**這幾項尚未落地，不要照著自己補**」

附錄 A 的漂移自我檢查同步補三條（gh 憑證兩個 owner、gate 的 pytest 版本、盤點雙向封閉）。第 4 步開頭的「產生器＝單一真相」清單補上「重跑計畫後零漂移」的驗收說明。

## 未動的部分

`coordinator/` 一行未動。實機安裝由 operator 執行；本 PR 只出登記表／產生器／runbook。既有測試僅改兩處**明示的 exact-set** 斷言（monitor 的 RWP 資產集合、scaffold 的「無多餘」集合），兩處都是本 PR 有意新增的項目，改動處皆附註解說明。

Closes #666

## Checklist
- [x] `changelog.d/external-deps-exhaustive.md` fragment 已新增且已 commit
- [x] `CHANGELOG.md [Unreleased]` 有對應 entry（Added ＋ Fixed ＋ Changed）
- [x] `VERSION` 與意圖一致（非 release PR，未動）
- [x] 測試通過（4163 passed）
- [x] `policy_check` 帶 PR 上下文跑過

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E7w9kaUxAzCCEk7piD5hfK
