### PR TITLE
fix(probe): agy capability probe 剝 code fence、失敗帶 stdout 節錄，並修 models 兩欄漂移

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -487,6 +487,26 @@
   `tests/test_trust_root_job_template_ab.py`（80 測試）。
 
 ### Fixed
+- **#670：`probe_agy_capability()` 對「模型加了 code fence」偽失敗，並把格式問題誤報成
+  `no-heterogeneous-planner`**——probe 問的是語言模型卻直接
+  `json.loads(smoke_stdout.strip())`；票上實測 6 次有 1 次模型把**完全正確**的 JSON 包進
+  ```` ```json ```` fence ⇒ `malformed-output` ⇒ probe not ready ⇒
+  `select_secondary_planner()` 回 `no-heterogeneous-planner` ⇒ run 進 `needs_human`。約 17%
+  的 define 階段憑空死掉，而 blocking_reason 指向**拓撲問題**，排查方向整個帶偏。新增可測
+  的 `strip_code_fence()`（```` ``` ````／```` ```json ```` 兩種開頭、有無尾隨 fence、CRLF、
+  前後空白、單行 fence），刻意只處理「整串剛好是單一 fenced block」——與
+  `planning_runtime._find_json_object` 頂層語意一致，**不會把「內容真的不對」順手救成
+  ready**（內容不符仍是 `identity-mismatch`，有測試釘住）。prompt 同步補上顯式輸出契約
+  在源頭壓低 fence 機率。
+- **#670：probe 失敗時帶出實際 stdout 節錄**——`malformed-output` 過去 `diagnostic=None`，
+  現場零線索（票上成因是人工重跑六遍才看見）。新增 `stdout_excerpt()`（前 200 字元、空白
+  壓成單一空格、空輸出標 `<empty>`），`malformed-output` 與 `identity-mismatch` 兩路都帶。
+  節錄是模型對**寫死在本模組**的 probe prompt 的回應，argv 不帶憑證、env 不回顯。
+- **#670 附帶：`agy models` 改成 `id\tDisplay Name` 兩欄輸出後，probe 100% 死在
+  `model-not-listed`**——2026-08-18 實機驗證 fence 修復時撞到，比 fence 偽失敗更早更絕對
+  （整行正規化成 `gemini-3-1-pro-high-gemini-3-1-pro-high`，字面與正規化雙雙落空，連 smoke
+  階段都到不了）。`_resolve_agy_cli_token()` 改為比對可用整行或任一欄、但**回傳一律是 id
+  欄**（`--model` 不吃顯示名）；單欄舊格式行為逐字不變。
 - **#666：實機為啟用 monitor 手動補的兩項收斂回登記表——`pytest`（系統層 python 套件）與
   Manager 的 `gh` 憑證**。兩項在實機都已生效，但**產生器的計畫產不出它們**：重跑
   `permissions`／`toolchain` 不會有、換一台機器部署也不會有。

--- a/changelog.d/670-probe-fence.md
+++ b/changelog.d/670-probe-fence.md
@@ -1,0 +1,31 @@
+# 670-probe-fence
+
+- **`#670` `probe_agy_capability()` 不再因為模型加了 markdown code fence 就偽失敗**——
+  probe 問的是**語言模型**，卻直接 `json.loads(smoke_stdout.strip())`。實測（票上表格）
+  6 次有 1 次模型把**完全正確**的 JSON 包進 ```` ```json ```` fence，於是 `JSONDecodeError`
+  ⇒ `_failed_agy("malformed-output")` ⇒ probe not ready ⇒ `select_secondary_planner()` 回
+  `no-heterogeneous-planner` ⇒ 整個 run 進 `needs_human`。約 17% 的 define 階段憑空死掉，
+  而 blocking_reason 指向「沒有異質 planner」——把**格式解析問題**誤報成**拓撲問題**。
+  - 新增可測的 `strip_code_fence()`：支援 ```` ``` ```` 與 ```` ```json ```` 兩種開頭、
+    有無尾隨 fence、CRLF、fence 前後空白、以及單行 ```` ```json {...}``` ````。
+  - 刻意**只**處理「整串剛好是單一 fenced block」，與 `planning_runtime._find_json_object`
+    的頂層嚴格語意一致：帶前言散文的輸出原樣落 `malformed-output`，剝 fence 是**純結構**
+    動作，不負責從散文撈 JSON，**更不會把「內容真的不對」順手救成 ready**——本體 JSON
+    合法但欄位不符時仍是 `identity-mismatch`（有測試釘住這一格）。
+  - prompt 同步補上與 `planning_runtime._JSON_OUTPUT_CONTRACT` 同款的顯式輸出契約
+    （`no code fences`／`MUST start with '{'`），在源頭壓低 fence 機率；`strip_code_fence()`
+    是模型仍不從時的保底。
+- **`#670` probe 失敗時帶出實際 stdout 節錄，不再只留一個沒有線索的 reason**——
+  `malformed-output` 過去 `diagnostic=None`，現場零線索，票上的成因是靠人工重跑六遍才看見。
+  新增 `stdout_excerpt()`：前 200 字元、連續空白壓成單一空格（不污染單行 log）、空輸出標
+  `<empty>`，`malformed-output` 與 `identity-mismatch` 兩路都帶上。節錄內容是模型對一段
+  **寫死在本模組的** probe prompt 的回應，argv 不帶憑證、env 不回顯，沒有把 token 帶進
+  log／evidence 的路徑。
+- **`#670` 附帶修復：`agy models` 改成兩欄 tab 輸出後，probe 100% 死在 `model-not-listed`**
+  ——2026-08-18 實機驗證 fence 修復時撞到。`agy models` 現在輸出
+  ``gemini-3.1-pro-high\tGemini 3.1 Pro (High)``，整行比對時字面與正規化雙雙落空（整行
+  正規化成 `gemini-3-1-pro-high-gemini-3-1-pro-high`），probe 連 smoke 階段都到不了。
+  這比 #670 的 fence 偽失敗**更早、更絕對**，且同樣是「格式漂移偽裝成能力／拓撲問題」。
+  `_resolve_agy_cli_token()` 改為：比對可用整行或任一欄，但**回傳一律是 id 欄**——
+  `--model` 只吃得下 kebab id，`Gemini 3.1 Pro (High)` 這種顯示名不是合法 CLI 值。
+  單欄（舊格式）行為逐字不變。

--- a/paulsha_cortex/coordinator/model_identities.py
+++ b/paulsha_cortex/coordinator/model_identities.py
@@ -718,10 +718,89 @@ def _failed_agy(reason: str, diagnostic: str | None = None) -> CapabilityProbe:
     return CapabilityProbe(False, "agy", AGY_MODEL_ID, AGY_DOMAIN, reason, diagnostic)
 
 
+# issue #670：開頭 fence 允許帶 info string（``` 後面的語言標籤，例如 `json`），
+# 但字元集刻意收斂到「語言標籤長得出來的樣子」——絕不可含 `{`／反引號，否則
+# 單行形態 ```` ```{"a":1}``` ```` 會被整串當成 info string 吃掉。
+_CODE_FENCE_OPEN = re.compile(r"\A```[A-Za-z0-9_+.\-]*[ \t]*\r?\n?")
+_CODE_FENCE_CLOSE = re.compile(r"\r?\n?[ \t]*```\Z")
+
+#: `_failed_agy` diagnostic 帶的原始 stdout 節錄長度上限（issue #670）。
+STDOUT_EXCERPT_LIMIT = 200
+
+
+def strip_code_fence(text: str) -> str:
+    """剝掉「整串剛好被一個 markdown code fence 包住」時的 fence，回傳本體。
+
+    issue #670：`probe_agy_capability` 問的是語言模型，實測約 1/6 次會把
+    正確的 JSON 包進 ```` ```json ```` fence，於是 `json.loads` 拋錯 ⇒
+    `malformed-output` ⇒ probe not ready ⇒ `no-heterogeneous-planner` ⇒ run
+    進 `needs_human`。內容明明正確，卻被誤報成拓撲問題。
+
+    支援的形態：``` 與 ```json 兩種開頭、有無尾隨 fence、fence 前後的空白／
+    換行、以及單行的 ``` ```json {...}``` ```。
+
+    刻意**只**處理「整串就是單一 fenced block」：帶前言散文的輸出
+    （``"Here you go:\\n```json\\n{...}\\n```"``）原樣回傳，交給呼叫端的
+    `json.loads` 失敗成 `malformed-output`。這與 `planning_runtime`
+    `_find_json_object` 的頂層嚴格語意一致——剝 fence 是**純結構**動作，
+    不負責從散文裡撈 JSON，更不負責救「內容真的不對」的輸出：本函式回傳後
+    仍要走原本的 `json.loads` 與 `payload != expected` 比對，內容錯誤照樣
+    落在 `identity-mismatch`。
+    """
+    stripped = text.strip()
+    opened = _CODE_FENCE_OPEN.match(stripped)
+    if opened is None:
+        return stripped
+    body = stripped[opened.end() :]
+    closed = _CODE_FENCE_CLOSE.search(body)
+    if closed is not None:
+        body = body[: closed.start()]
+    return body.strip()
+
+
+def stdout_excerpt(text: str, *, limit: int = STDOUT_EXCERPT_LIMIT) -> str:
+    """把 probe 的原始 stdout 壓成單行節錄，供失敗 diagnostic 使用（issue #670）。
+
+    修復前 `malformed-output` 的 diagnostic 是 `None`，現場零線索——#670 是靠
+    人工重跑六遍才看見成因是 code fence。這裡把實際 stdout 前 `limit` 個字元
+    帶進 diagnostic，讓下一次同類失敗一眼看得出是格式問題還是別的。
+
+    節錄內容是**模型對一段固定 probe prompt 的回應**：prompt 由本模組寫死
+    （只含 `capability`／`model` 兩個常數），argv 不帶任何憑證，env 也不會被
+    回顯，因此沒有把 token／憑證帶進 log 或 evidence 的路徑。換行與連續空白
+    一律壓成單一空格，避免多行內容污染單行 log。
+    """
+    collapsed = " ".join(text.split())
+    if not collapsed:
+        return "<empty>"
+    if len(collapsed) <= limit:
+        return collapsed
+    return collapsed[:limit] + "…"
+
+
 def _normalize_model_token(value: str) -> str:
     """正規化 model id／顯示名，容忍 `agy models` 輸出格式（顯示名 vs kebab id、
     大小寫、空白/括號等標點差異）未來再次改版。"""
     return re.sub(r"[^a-z0-9]+", "-", value.strip().lower()).strip("-")
+
+
+def _agy_model_line_tokens(line: str) -> tuple[str, tuple[str, ...]]:
+    """把 `agy models` 的一行拆成 ``(要傳給 --model 的字面 token, 可比對候選)``。
+
+    issue #670 實測附帶發現：2026-08-18 實機的 `agy models` 已改成**兩欄
+    tab 分隔**——``gemini-3.1-pro-high\\tGemini 3.1 Pro (High)``。整行拿去比對
+    時字面與正規化雙雙落空（整行正規化後是
+    `gemini-3-1-pro-high-gemini-3-1-pro-high`），於是 probe **100%** 死在
+    `model-not-listed`——比 #670 的 fence 偽失敗更早、更絕對。
+
+    多欄時 `--model` 只吃得下第一欄的 kebab id，顯示名（`Gemini 3.1 Pro (High)`）
+    不是合法 CLI 值，因此**比對**可以用整行或任一欄，**回傳**一律是第一欄。
+    單欄（舊格式）時 token 就是整行，行為與修復前逐字相同。
+    """
+    fields = [field.strip() for field in line.split("\t") if field.strip()]
+    if len(fields) <= 1:
+        return line, (line,)
+    return fields[0], (line, *fields)
 
 
 def _resolve_agy_cli_token(expected: str, listed: Iterable[str]) -> str | None:
@@ -729,15 +808,17 @@ def _resolve_agy_cli_token(expected: str, listed: Iterable[str]) -> str | None:
 
     優先字面完全比對；找不到時退而用正規化比對，讓顯示名／kebab id 之間的
     命名落差不必等到常數再次寫死才修（issue #255）。回傳的是 `agy models`
-    實際印出的那一行，因為 `--model` 必須用 CLI 認得的字面值呼叫。
+    實際印出的字面值（單欄輸出是整行、多欄輸出是 id 欄），因為 `--model`
+    必須用 CLI 認得的字面值呼叫。
     """
-    listed_set = {line for line in listed if line}
-    if expected in listed_set:
-        return expected
+    entries = [_agy_model_line_tokens(line) for line in listed if line]
+    for token, candidates in entries:
+        if expected in candidates:
+            return token
     target = _normalize_model_token(expected)
-    for line in listed_set:
-        if _normalize_model_token(line) == target:
-            return line
+    for token, candidates in entries:
+        if any(_normalize_model_token(candidate) == target for candidate in candidates):
+            return token
     return None
 
 
@@ -771,7 +852,15 @@ def probe_agy_capability(
         )
 
     expected = {"capability": "cortex-plan-sandbox", "model": AGY_MODEL_ID}
+    # issue #670：軟性措辭（「Return only ...」）不足以讓模型穩定不加 fence，
+    # 補上與 `planning_runtime._JSON_OUTPUT_CONTRACT` 同款的顯式輸出契約，把
+    # fence 機率壓在源頭；`strip_code_fence` 則是模型仍不從時的保底。
+    # 契約放在 payload **之前**，比照 `planning_runtime` 把 `_JSON_OUTPUT_CONTRACT`
+    # 排在 `Input:` 之前的既有寫法，讓「指示 → 目標物」的順序一致，
+    # 也讓 prompt 尾端仍然剛好是那個 JSON 物件。
     prompt = (
+        "Output contract: reply with exactly one JSON object and nothing else — "
+        "no prose, no explanation, no code fences. Your reply MUST start with '{'. "
         "Return only this compact JSON object and perform no tool calls: "
         + json.dumps(expected, ensure_ascii=False, separators=(",", ":"))
     )
@@ -789,11 +878,11 @@ def probe_agy_capability(
     if smoke_rc != 0:
         return _failed_agy("smoke-failed", f"exit-code:{smoke_rc}")
     try:
-        payload = json.loads(smoke_stdout.strip())
+        payload = json.loads(strip_code_fence(smoke_stdout))
     except (json.JSONDecodeError, TypeError):
-        return _failed_agy("malformed-output")
+        return _failed_agy("malformed-output", stdout_excerpt(smoke_stdout))
     if payload != expected:
-        return _failed_agy("identity-mismatch")
+        return _failed_agy("identity-mismatch", stdout_excerpt(smoke_stdout))
     return CapabilityProbe.ready_for("agy", AGY_MODEL_ID, AGY_DOMAIN)
 
 

--- a/tests/test_model_identities.py
+++ b/tests/test_model_identities.py
@@ -7,11 +7,14 @@ import pytest
 from paulsha_cortex.coordinator.model_identities import (
     AGY_LIVE_PROBE,
     AGY_MODEL_ID,
+    STDOUT_EXCERPT_LIMIT,
     CapabilityProbe,
     IdentityRegistry,
     load_model_identities,
     probe_agy_capability,
     select_secondary_planner,
+    stdout_excerpt,
+    strip_code_fence,
 )
 
 
@@ -236,6 +239,187 @@ def test_agy_probe_fails_closed_on_drift(model_stdout, smoke_result, reason) -> 
 
     assert probe.ready is False
     assert probe.reason == reason
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        # 裸輸入：原樣（只 strip）回傳。
+        ('{"a":1}', '{"a":1}'),
+        ('  {"a":1}\n', '{"a":1}'),
+        # ```json 前綴（#670 實測到的真實形態）。
+        ('```json\n{"a":1}\n```', '{"a":1}'),
+        # 裸 ``` 前綴。
+        ('```\n{"a":1}\n```', '{"a":1}'),
+        # 尾隨空白／換行，以及 fence 前後的空白。
+        ('```json\n{"a":1}\n```\n\n  ', '{"a":1}'),
+        ('\n  ```JSON\n{"a":1}\n```  \n', '{"a":1}'),
+        # 沒有尾隨 fence（輸出被截斷）也要能取出本體。
+        ('```json\n{"a":1}', '{"a":1}'),
+        # 單行 fence：info string 有無皆可，且不得把本體當成 info string 吃掉。
+        ('```json {"a":1}```', '{"a":1}'),
+        ('```{"a":1}```', '{"a":1}'),
+        # CRLF。
+        ('```json\r\n{"a":1}\r\n```', '{"a":1}'),
+        # 空字串。
+        ("", ""),
+        # 帶前言散文的 fence **不**處理：維持與 planning_runtime 頂層一致的
+        # 嚴格「整串才算」語意，交給呼叫端 json.loads 失敗。
+        ('Here you go:\n```json\n{"a":1}\n```', 'Here you go:\n```json\n{"a":1}\n```'),
+    ],
+)
+def test_strip_code_fence_handles_fenced_and_bare_inputs(raw: str, expected: str) -> None:
+    assert strip_code_fence(raw) == expected
+
+
+def test_agy_probe_accepts_fenced_json_from_the_model() -> None:
+    """#670：模型把正確 JSON 包進 code fence 時，probe 必須照樣 ready。"""
+    fenced = f'```json\n{{"capability":"cortex-plan-sandbox","model":"{AGY_MODEL_ID}"}}\n```\n'
+    responses = iter([_completed(stdout=f"{AGY_MODEL_ID}\n"), _completed(stdout=fenced)])
+
+    probe = probe_agy_capability(runner=lambda *a, **k: next(responses))
+
+    assert probe.ready is True
+    assert probe.reason is None
+
+
+def test_agy_probe_accepts_bare_fence_without_language_tag() -> None:
+    fenced = f'```\n{{"capability":"cortex-plan-sandbox","model":"{AGY_MODEL_ID}"}}\n```'
+    responses = iter([_completed(stdout=f"{AGY_MODEL_ID}\n"), _completed(stdout=fenced)])
+
+    probe = probe_agy_capability(runner=lambda *a, **k: next(responses))
+
+    assert probe.ready is True
+
+
+def test_agy_probe_still_reports_identity_mismatch_for_fenced_wrong_content() -> None:
+    """剝 fence 不得順手吞掉「內容真的不對」——這是 #670 最容易改壞的一格。
+
+    fence 剝法只處理結構；本體 JSON 合法但欄位不符時，reason 必須仍是
+    `identity-mismatch`（拓撲／身分問題），不能因為「有 fence」就被誤救成
+    ready，也不能退化成 `malformed-output`。
+    """
+    fenced = '```json\n{"capability":"wrong","model":"some-other-model"}\n```'
+    responses = iter([_completed(stdout=f"{AGY_MODEL_ID}\n"), _completed(stdout=fenced)])
+
+    probe = probe_agy_capability(runner=lambda *a, **k: next(responses))
+
+    assert probe.ready is False
+    assert probe.reason == "identity-mismatch"
+    assert probe.diagnostic is not None
+    assert "wrong" in probe.diagnostic
+
+
+def test_agy_probe_malformed_output_diagnostic_carries_stdout_excerpt() -> None:
+    """#670：`malformed-output` 過去 diagnostic 為 None，現場零線索。"""
+    responses = iter(
+        [
+            _completed(stdout=f"{AGY_MODEL_ID}\n"),
+            _completed(stdout="I cannot comply with that request.\nPlease clarify.\n"),
+        ]
+    )
+
+    probe = probe_agy_capability(runner=lambda *a, **k: next(responses))
+
+    assert probe.ready is False
+    assert probe.reason == "malformed-output"
+    assert probe.diagnostic is not None
+    assert "I cannot comply with that request." in probe.diagnostic
+    # 多行 stdout 壓成單行，不污染 log。
+    assert "\n" not in probe.diagnostic
+
+
+def test_agy_probe_malformed_output_diagnostic_is_bounded() -> None:
+    responses = iter(
+        [_completed(stdout=f"{AGY_MODEL_ID}\n"), _completed(stdout="x" * 4096)]
+    )
+
+    probe = probe_agy_capability(runner=lambda *a, **k: next(responses))
+
+    assert probe.reason == "malformed-output"
+    assert probe.diagnostic is not None
+    assert len(probe.diagnostic) <= STDOUT_EXCERPT_LIMIT + 1
+
+
+def test_stdout_excerpt_collapses_whitespace_and_marks_empty() -> None:
+    assert stdout_excerpt("  a\n\n b\t c  ") == "a b c"
+    assert stdout_excerpt("") == "<empty>"
+    assert stdout_excerpt("   \n  ") == "<empty>"
+    assert stdout_excerpt("y" * 300, limit=10) == "y" * 10 + "…"
+
+
+def test_agy_probe_accepts_two_column_models_listing() -> None:
+    """#670 實測附帶發現：`agy models` 已改成 `id\\tDisplay Name` 兩欄輸出。
+
+    整行比對時字面與正規化都不中，probe 100% 死在 `model-not-listed`——比
+    fence 偽失敗更早、更絕對。要能認出 id 欄，且傳給 `--model` 的必須是
+    kebab id，不是顯示名。
+    """
+    listing = (
+        "gemini-3.7-flash-high\tGemini 3.7 Flash (High)\n"
+        f"{AGY_MODEL_ID}\tGemini 3.1 Pro (High)\n"
+        "claude-sonnet-4-6\tClaude Sonnet 4.6 (Thinking)\n"
+    )
+    calls: list[list[str]] = []
+
+    def runner(argv, **kwargs):
+        calls.append(list(argv))
+        if argv == ["agy", "models"]:
+            return _completed(stdout=listing)
+        return _completed(
+            stdout=f'{{"capability":"cortex-plan-sandbox","model":"{AGY_MODEL_ID}"}}'
+        )
+
+    probe = probe_agy_capability(runner=runner)
+
+    assert probe.ready is True
+    assert calls[1][calls[1].index("--model") + 1] == AGY_MODEL_ID
+
+
+def test_agy_probe_two_column_listing_prefers_id_column_over_display_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """兩欄輸出且只有顯示名語意相符時，仍必須挑 id 欄，不能回傳顯示名。"""
+    monkeypatch.setattr(
+        "paulsha_cortex.coordinator.model_identities.AGY_MODEL_ID", "Gemini 3.1 Pro (High)"
+    )
+    calls: list[list[str]] = []
+
+    def runner(argv, **kwargs):
+        calls.append(list(argv))
+        if argv == ["agy", "models"]:
+            return _completed(stdout="gemini-3.1-pro-high\tGemini 3.1 Pro (High)\n")
+        return _completed(
+            stdout='{"capability":"cortex-plan-sandbox","model":"Gemini 3.1 Pro (High)"}'
+        )
+
+    probe = probe_agy_capability(runner=runner)
+
+    assert probe.ready is True
+    assert calls[1][calls[1].index("--model") + 1] == "gemini-3.1-pro-high"
+
+
+def test_agy_probe_prompt_forbids_code_fences_at_the_source() -> None:
+    """保底之外，prompt 本身也要顯式禁止 fence（#670 源頭壓制）。"""
+    calls: list[list[str]] = []
+
+    def runner(argv, **kwargs):
+        calls.append(list(argv))
+        if argv == ["agy", "models"]:
+            return _completed(stdout=f"{AGY_MODEL_ID}\n")
+        return _completed(
+            stdout=f'{{"capability":"cortex-plan-sandbox","model":"{AGY_MODEL_ID}"}}'
+        )
+
+    probe = probe_agy_capability(runner=runner)
+
+    assert probe.ready is True
+    prompt = calls[1][calls[1].index("--print") + 1]
+    assert "no code fences" in prompt
+    # #670 實測：`--json-schema` 在 `--output-format text`（build_agy_argv 現行
+    # 形態）下被 CLI 直接拒絕（rc=1），因此 argv 保持不變。
+    assert "--json-schema" not in calls[1]
+    assert "--output-format" not in calls[1]
 
 
 def test_secondary_selection_uses_priority_and_excludes_primary_domain() -> None:


### PR DESCRIPTION
Closes #670

## 問題

`probe_agy_capability()`（`paulsha_cortex/coordinator/model_identities.py`）問的是**語言模型**，卻直接 `json.loads(smoke_stdout.strip())`。票上實測 6 次有 1 次模型把**完全正確**的 JSON 包進 ```` ```json ```` fence ⇒ `JSONDecodeError` ⇒ `_failed_agy("malformed-output")` ⇒ probe not ready ⇒ `select_secondary_planner()` 回 `no-heterogeneous-planner` ⇒ run 進 `needs_human`。約 17% 的 define 階段憑空死掉，而 blocking_reason 指向「沒有異質 planner」——把**格式解析問題**誤報成**拓撲問題**。

## 本 PR 做了什麼

### 1. 剝 code fence（保底修法）

新增可測的 `strip_code_fence()`（不 inline 在 probe 裡）。支援 ```` ``` ````／```` ```json ```` 兩種開頭、有無尾隨 fence、CRLF、fence 前後空白、以及單行 ```` ```json {...}``` ````。

**刻意只處理「整串剛好是單一 fenced block」**，與 `planning_runtime._find_json_object` 的頂層嚴格語意一致：帶前言散文的輸出原樣落 `malformed-output`。剝 fence 是**純結構**動作，不負責從散文撈 JSON，**更不會把「內容真的不對」順手救成 ready**——本體 JSON 合法但欄位不符時仍是 `identity-mismatch`，有專門測試釘住這一格。

prompt 同步補上與 `planning_runtime._JSON_OUTPUT_CONTRACT` 同款的顯式輸出契約（`no code fences`／`MUST start with '{'`），在**源頭**壓低 fence 機率。

### 2. `--json-schema`：實測後**不採用**，argv 保持不變

票上建議「改用 `--json-schema` 由 CLI 層強制結構化輸出」為主要修法。以 operator 身分實機驗證後**確認不可行**，因此不改 `build_agy_argv()`。

實測指令（逐字照 `build_agy_argv()` 現行形態，即預設 `--output-format text`）：

```
/opt/cortex/toolchain/bin/agy --print '<probe prompt>' --mode plan --sandbox \
  --model gemini-3.1-pro-high --json-schema '<schema>'
```

結果 **rc=1**，stdout 空，stderr：

```
Error: --json-schema can only be used when --output-format is 'json' or 'stream-json'
```

`--help` 的括號註記（「for stream-json, only applicable to the final result」）**低估了限制**：這不是「在 text 下退化成無效」，而是 CLI **直接拒絕整個呼叫**。若照票上建議把旗標加進 `build_agy_argv()`，**每一次** agy 呼叫（含 planner 熱路徑）都會 rc=1 掛掉——會把 17% 的偽失敗變成 100% 的真失敗。

補充實測：加上 `--output-format json` 後 `--json-schema` **確實有效**（rc=0），stdout 是 envelope 並帶乾淨的 `structured_output`：

```json
{"conversation_id":"…","status":"SUCCESS",
 "response":"{\"capability\":\"cortex-plan-sandbox\",\"model\":\"gemini-3.1-pro-high\"}\n{\"capability\":\"cortex-plan-sandbox\",\"model\":\"gemini-3.1-pro-high\",\"toolAction\":\"Finishing task\",\"toolSummary\":\"Finish task\"}\n",
 "structured_output":{"capability":"cortex-plan-sandbox","model":"gemini-3.1-pro-high"},
 "json_schema":{…},"usage":{…}}
```

**本 PR 不走這條路**，理由有二：(a) `build_agy_argv()` 是所有 agy 呼叫端共用的建構器（planner 熱路徑、`planning_runtime`），改 `--output-format` 會改變全部呼叫端的 stdout 形狀，blast radius 遠大於本票；(b) 即使開了 schema，`response` 欄位裡仍是**兩個** JSON 物件（第二個多了 `toolAction`／`toolSummary`），乾淨的只有 `structured_output` ——換句話說 schema 約束的是 envelope 的一個欄位，模型自己那串輸出仍不保證單一物件。若要走這條，應該是一張獨立的票（probe 專用 argv 分岔 + 改讀 `structured_output`）。

### 3. 失敗時帶出實際 stdout 節錄

`malformed-output` 過去 `diagnostic=None`，現場零線索——票上的成因是靠人工重跑六遍才看見。新增 `stdout_excerpt()`：前 200 字元、連續空白壓成單一空格（不污染單行 log）、空輸出標 `<empty>`；`malformed-output` 與 `identity-mismatch` 兩路都帶上。

**憑證外洩檢查（已確認）**：節錄內容是模型對一段**寫死在本模組**的 probe prompt（只含 `capability`／`model` 兩個常數）的回應；`build_agy_argv()` 產生的 argv 不含任何 token／憑證；probe 不回顯 env，也不把 stderr 放進 diagnostic。因此沒有把憑證帶進 log／evidence 的路徑。

## 附帶修復：`agy models` 兩欄漂移（實機驗證時撞到）

實機驗證 fence 修復時發現 probe **根本到不了 smoke 階段**：`agy models` 現在輸出**兩欄 tab 分隔**——

```
gemini-3.1-pro-high	Gemini 3.1 Pro (High)
```

整行拿去比對時字面與正規化雙雙落空（整行正規化成 `gemini-3-1-pro-high-gemini-3-1-pro-high`），probe **100%** 死在 `model-not-listed`。這比 #670 的 fence 偽失敗**更早、更絕對**，且是同一個家族（格式漂移偽裝成能力／拓撲問題，issue #255 的再現）。

`_resolve_agy_cli_token()` 改為：比對可用整行或任一欄，但**回傳一律是 id 欄**——`--model` 只吃得下 kebab id，`Gemini 3.1 Pro (High)` 這種顯示名不是合法 CLI 值。單欄（舊格式）行為逐字不變。

不修這格，本 PR 的 fence 修復在實機上無從驗證。

## 順帶：其他 probe 的同型問題排查

**已查以下全部，`probe_agy_capability` 是唯一有此毛病的**：

| 位置 | 形狀 | 結論 |
|---|---|---|
| `model_identities.probe_agy_capability` | 問模型要裸 JSON → `json.loads` | **有毛病，本 PR 修** |
| `planning_runtime._probe_identity` | 問模型要裸 JSON → `_invoke_json` → `_extract_json` → `_find_json_object` | **已免疫**——`_find_json_object` 早有 `_FENCED_JSON` 剝 fence（#401） |
| `planning_runtime` questioner／secondary／integrator | 問模型要 JSON | **已免疫**，同上，且 prompt 已帶 `_JSON_OUTPUT_CONTRACT` |
| `claim_readiness.github_owner_probe` | `gh api` → `json.loads` | 不適用——`gh` 是決定性 CLI，不是模型 |
| `claim_readiness.live_probe_check` | 委派 `probe_agy_capability` | 不適用——本身不 parse |
| `claim_readiness` 其餘（`local_scope`／`base_sha`／`monitor_snapshot`／`capability`） | 無模型呼叫 | 不適用 |
| `executor_auth.check_executor_auth`（copilot／claude／codex） | 問模型 `Respond with OK only.` | 不適用——只看 returncode ＋ `classify_cli_output` 文字訊號，不 parse JSON |
| `porcelain/bootstrap._executor_status` | `codex doctor --json` → `json.loads` | 不適用——決定性 CLI JSON，非模型輸出 |
| `outcome_taxonomy._parse_*` | 逐行 parse stream-json | 不適用——CLI 記錄流，非「整串裸 JSON」 |
| `doctor._default_agy_probe` | 委派 `probe_agy_capability` | 不適用——本身不 parse |

`model_identities.py` 內只有 `probe_agy_capability` 一支會呼叫模型；其餘 `json.loads` 皆是讀設定檔／round-trip 序列化。

## 測試

新增 10 個測試函式（參數化後 20 個 case，`tests/test_model_identities.py`），涵蓋票上要求的每一格：

- `strip_code_fence` 參數化 13 組：裸輸入、` ```json ` 前綴、裸 ` ``` ` 前綴、尾隨空白／換行、CRLF、無尾隨 fence（截斷）、單行 fence（有／無 info string）、空字串、帶前言散文（**不**處理）
- fenced 正確內容 → `ready=True`（```json 與裸 ``` 兩版）
- **fenced 但內容錯誤 → 仍回 `identity-mismatch`**（不被 fence 剝法誤救）
- `malformed-output` diagnostic 帶 stdout 節錄、壓成單行、長度有界
- prompt 含 `no code fences`、且 argv **不含** `--json-schema`／`--output-format`（釘住上面的實測結論）
- `agy models` 兩欄輸出可解析，且 `--model` 拿到的是 id 欄而非顯示名

驗證結果：

- 全套件 `python3 -m pytest -q`：**4131 passed, 20 skipped, 49 subtests passed**
- **實機 6/6**：修復後以 operator 身分連跑 6 次 `probe_agy_capability()`，全部 `ready=True`（修復前同一台機器 3/3 `model-not-listed`）

## Checklist

- [x] `changelog.d/670-probe-fence.md` fragment 已新增且已 commit
- [x] `CHANGELOG.md [Unreleased] ### Fixed` 已補對應 entry
- [x] 分支為 `feature/670-probe-fence`，未 commit 到 `main`
- [x] PR body 帶 closing keyword（`Closes #670`）
- [x] 全套件測試通過
- [x] 已確認 diagnostic 不會帶入憑證／token（見上「憑證外洩檢查」）
- [x] `VERSION` 未變動（非 release PR）

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E7w9kaUxAzCCEk7piD5hfK
