### PR TITLE
fix(claim): missing_issue 不再建立 run，改記可查詢的 not-claimable ledger（#669）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -487,6 +487,21 @@
   `tests/test_trust_root_job_template_ab.py`（80 測試）。
 
 ### Fixed
+- **#669：claim 判定 `missing_issue` 不再建立 run；跳過改記在可查詢的 `not-claimable`
+  ledger**——舊行為「先建 run 再宣告 blocked」讓自我託管首輪掃描在八秒內產出 24 個內容完全
+  同型的 `needs_human` 殭屍 run（全部停在 `current_phase: claim`、`evidence_refs: []`、
+  `next_actions: []`，永遠不會推進），把 `attention` 的信噪比壓成 1:24。根因是類別錯誤：
+  `missing_issue` 對 `docs/superpowers/workstreams/*` 這類 work item 是**預期狀態而非異常**
+  （`cost-governance-cluster/todo.md` 開頭逐字寫著「本 workstream 不對應單一 issue」），不該
+  進入 durable 的 run 生命週期。`_claim_action` 現在回 `not_claimable`／`run: None`，
+  **一次都不呼叫 workflow starter**；每一次跳過都在
+  `<coordinator_root>/not-claimable.json`（`cortex-not-claimable/v1`）留一筆帶
+  `first_observed_at`／`observations`／`next_step_hint` 的紀錄，由 `cortex status` 的新
+  `not_claimable` 區塊與 `cortex digest` 計數呈現——「不建 run」不得等於「靜默略過」，否則
+  只是把噪音換成盲區。work item 重新可 claim 時該筆自動清除。修正前留下的殭屍 run 不由系統
+  自行清除（沿用 `#373` 守衛），而是以唯一可機械辨識的簽名認出後，回
+  `reason: claim-blocked-stale-run` 並附完整的 `cortex work abandon … --expected-run-id …`
+  指令交由 operator 執行。
 - **#670：`probe_agy_capability()` 對「模型加了 code fence」偽失敗，並把格式問題誤報成
   `no-heterogeneous-planner`**——probe 問的是語言模型卻直接
   `json.loads(smoke_stdout.strip())`；票上實測 6 次有 1 次模型把**完全正確**的 JSON 包進

--- a/README.md
+++ b/README.md
@@ -376,6 +376,7 @@ systemctl --user status cortex-manager.service cortex-monitor.service
 - `in_flight`：正在執行的 Job。
 - `slices`：交付生命週期、gate、Candidate 與 evidence 摘要。
 - `attention`：全部 `needs_human` 項目，包含 reason 與當下合法的 `next_actions`。
+- `not_claimable`（#669）：claim 判定**現在不可 claim、且刻意不建立 run** 的 work item。最典型的是 `docs/superpowers/workstreams/*`——那類 work item 設計上就不對應單一 issue，`missing_issue` 是**預期狀態而非異常**，過去卻被物化成停在 `current_phase: claim`、永遠不會推進的 `needs_human` run（實測一次產出 24 個，把 `attention` 信噪比壓成 1:24）。現在改記在耐久的 `<coordinator_root>/not-claimable.json`（schema `cortex-not-claimable/v1`），欄位含 `reason`、`detail`、`first_observed_at`／`last_observed_at`／`observations`（卡多久了）與 `next_step_hint`（照抄即可執行的下一步）。work item 一旦變成可 claim，該筆紀錄於下一次判定時自動消失。`attention` 因此只留可行動的項目，被跳過的項目也不會變成盲區。
 - `recent_done`：最近完成或進入 terminal gate 的 slice 摘要，含 `slice_id`、`gate_status`、`at`、`gate_reason`、`job_id`、`branch`、明確的 `repo` project 歸屬（manifest 缺該欄時為 `null`）。`attention`／`slices` 也只接受明確的 slice 或 workflow job repo；不從 branch、worktree 或 path 猜測 project。只回溯 `--recent-done-window-seconds`（預設 86400 秒／24 小時，可用 `PSC_MANAGER_RECENT_DONE_WINDOW_SECONDS` 覆寫）內完成的 handoff manifest；window 內沒有資料時回空陣列，不會回退撈更舊的紀錄，過期 manifest 檔案本身的清理屬於 #178 program teardown GC 的範圍，不在 `recent_done` provider 職責內。
 
 Job `exited` 只代表 Agent process 以 exit code 0 結束，**不代表任務交付完成**。只有 Slice 通過 deterministic verification、必要的 foreign review，且 Candidate 已進入 target branch 後，才會變成 `completed` 並釋放下游 dependency。

--- a/changelog.d/669-claim-missing-issue.md
+++ b/changelog.d/669-claim-missing-issue.md
@@ -1,0 +1,33 @@
+# 669-claim-missing-issue
+
+- **`#669` 修正：claim 判定 `missing_issue` 不再建立 run**——舊行為是「先建 run 再宣告
+  blocked」（run 的結構化理由逐字寫著「claim 判定需要人工介入即建立 run：missing_issue」），
+  自我託管首輪掃描因此在八秒內產出 **24 個內容完全同型的 `needs_human` 殭屍 run**，全部停在
+  `current_phase: claim`、`gate_state: running`、`evidence_refs: []`、`next_actions: []`，
+  永遠不會推進。根因是類別錯誤：`missing_issue` 對 `docs/superpowers/workstreams/*` 這類
+  work item 而言**是預期狀態，不是異常**（`cost-governance-cluster/todo.md` 開頭逐字寫著
+  「本 workstream 不對應單一 issue」），系統卻把它物化成 durable state，`attention` 的信噪比
+  被壓成 1:24——唯一真正需要人看的 blocker 被埋在 24 筆噪音底下。`_claim_action` 現在回
+  `action: not_claimable`／`run: None`，**一次都不呼叫 workflow starter**。
+- **`#669`：跳過必須可查詢，不得把 fail-loud 換成 fail-silent**——只是「不建 run」會讓真的
+  漏開 issue 的 work item 被靜默略過，噪音變盲區、方向反而是錯的。新增
+  `coordinator/not_claimable.py`：耐久 ledger `<coordinator_root>/not-claimable.json`
+  （schema `cortex-not-claimable/v1`），逐筆記 `reason`／`detail`／`source`、
+  `first_observed_at`／`last_observed_at`／`observations`（卡多久、被判過幾次）、
+  `authority_digest`、`mapped_openspec`／`mapped_todo_paths`，以及可照抄執行的
+  `next_step_hint`。`cortex status` 新增獨立的 `not_claimable` 區塊（`attention` 因此只留
+  可行動的項目）、文字模式逐筆印出理由與下一步、`cortex digest` 帶計數。work item 一旦重新
+  可 claim，下一次判定即自動清掉該筆——不留永久假警報。
+- **`#669`：修正前留下的殭屍 run 帶著清理指令浮現，但不由系統自行清除**——沿用「auto-claim
+  不得自動清除或重試 `needs_human` run」的守衛（`#373`）。這批 run 有唯一可機械辨識的簽名
+  （ongoing ＋ `claim` phase ＋ `needs_human` facet ＋ 理由為
+  `claim-blocked`／`work_bridge.start_workflow_for_authority` ＋ 零 evidence／PR），命中時
+  claim 回 `reason: claim-blocked-stale-run`、附 `stale_run_id`、`legal_next_steps:
+  ("abandon",)` 與完整的 `cortex work abandon … --expected-run-id …` 指令，實機清理由
+  operator 明示執行。簽名逐項為必要條件，測試逐欄位釘住——停在 build／verify／review 的
+  `needs_human` run（握有真正工作成果）不會被誤判成殭屍。
+- **`#669` 測試**：新增 `tests/test_claim_not_claimable_669.py`（14 項），涵蓋
+  「`missing_issue` 時 starter 一次都不得被呼叫」「registry 與 delivery journal 零殘留」
+  「ledger 可查且 `observations` 不會每輪長出新列」「`cortex status`／文字模式看得到」
+  「**真的該建 run 的情況仍然建**」「issue 補上後 ledger 自動清空」「殭屍 run 帶清理指令」
+  「真正卡住的 run 不被誤分類」「ledger 對損毀 fail-closed、但呈現面不得因此死掉」。

--- a/docs/unified-work-lifecycle.md
+++ b/docs/unified-work-lifecycle.md
@@ -133,7 +133,13 @@ Verify/Review dispatch只接受schema v2明示`review` capability、且independe
 
 舊版曾把 planning-only canonical Agy 誤派成 reviewer，亦曾把Claude reviewer啟動在Plan Mode而得到`exited-0`卻沒有terminal payload。這些既存 terminal 不會成為 evidence；只有 operator 明確執行 `cortex work resume`，且最新 Job 的 run/claim/repo/source/card/phase/Candidate/builder/reviewer identity/output/sandbox snapshot contract 全部精確吻合時，Manager 才保留舊 Job/log並重派一次。Reviewer的原始Candidate root必須精確等於已驗證Builder Job worktree，而不是WorkflowRun主workspace。Periodic runner 不取得此 recovery authority。
 
-工作預設 manual。Auto claim 同時要求 confirmed Todo、confirmed issue 與 `cortex:auto-on-going` label；移除 label 只阻止尚未 claim 的工作，不會中止 active workflow。Todo 缺 issue 時不會自動建立 issue，而是 `needs_human: missing_issue`。
+工作預設 manual。Auto claim 同時要求 confirmed Todo、confirmed issue 與 `cortex:auto-on-going` label；移除 label 只阻止尚未 claim 的工作，不會中止 active workflow。Todo 缺 issue 時不會自動建立 issue。
+
+**缺 issue 不建立 run（#669）。** 判定 `missing_issue` 時，claim 回 `action: not_claimable`、`run: None`，**不呼叫 workflow starter**。舊行為是「先建 run 再宣告 blocked」（run 的理由逐字寫著「claim 判定需要人工介入即建立 run」），於是 `docs/superpowers/workstreams/*` 這類**設計上就不對應單一 issue** 的 work item，每一個都被物化成停在 `current_phase: claim`、`gate_state: running`、`evidence_refs: []`、`next_actions: []` 的 `needs_human` run——實測首輪掃描一次產出 24 個，永遠不會推進，把 `attention` 的信噪比壓成 1:24。`missing_issue` 對這類 work item 是**預期狀態，不是異常**，不該進入 durable 的 run 生命週期。
+
+但「不建 run」不得等於「靜默略過」，否則真的漏開 issue 的 work item 會變成盲區（fail-loud 換成 fail-silent）。每一次跳過都會在 `<coordinator_root>/not-claimable.json`（schema `cortex-not-claimable/v1`）記一筆：`reason`／`detail`／`source`、`first_observed_at`／`last_observed_at`／`observations`（卡多久、被判過幾次）與可照抄的 `next_step_hint`；`cortex status` 以獨立的 `not_claimable` 區塊呈現（`attention` 因此只留可行動的項目），`cortex digest` 帶計數。work item 一旦重新可 claim（補了 issue、或既有殭屍 run 已被 abandon），下一次判定即自動清掉該筆，不留永久假警報。
+
+修正**不會自行清除**修正前建立的殭屍 run（沿用「auto-claim 不得自動清除或重試 `needs_human` run」的守衛）。這類 run 有唯一可機械辨識的簽名——ongoing ＋ 停在 `claim` phase ＋ 掛 `needs_human` ＋ 結構化理由為 `claim-blocked`／`work_bridge.start_workflow_for_authority` ＋ 零 evidence 與 PR——命中時 claim 回 `reason: claim-blocked-stale-run`、附上該 `run_id` 與完整的 `cortex work abandon … --expected-run-id …` 指令，由 operator 明示清除。少任何一項簽名都不算殭屍，停在 build／verify／review 的 `needs_human` run 不受影響。
 
 合法且exact-bound的review `state=rejected`會保存immutable GateEvaluation、把當前card標成`needs_human`並停在原phase；periodic runner不得重派。只有operator explicit `cortex work resume`可在Candidate、report與evaluation hash重驗後建立fresh reviewer Job。Blocking category只描述Candidate或acceptance缺陷；若只是前份review report的措辭／列舉精度且不改變Candidate verdict，fresh reviewer應以non-blocking `style`留下更正，不得冒充Candidate correctness。
 

--- a/paulsha_cortex/control/client.py
+++ b/paulsha_cortex/control/client.py
@@ -86,6 +86,10 @@ def _ok_status(payload: dict[str, Any], updated_at: object) -> dict[str, Any]:
         "held": list(payload.get("held", [])),
         "slices": list(payload.get("slices", [])),
         "attention": list(payload.get("attention", [])),
+        # #669：claim 判定不可 claim（`missing_issue`）而刻意不建 run 的 work item。
+        # 與 `attention` 並列但分開——`attention` 只留可行動的項目，這份是「已知
+        # 不可行動、但不得變成盲區」的紀錄。
+        "not_claimable": list(payload.get("not_claimable", [])),
         "in_flight": list(payload.get("in_flight", [])),
         "recent_done": list(payload.get("recent_done", [])),
         "degraded": False,
@@ -134,6 +138,9 @@ def _degraded_status(reason: str, payload: dict[str, Any] | None = None) -> dict
         "held": list(payload.get("held", [])) if isinstance(payload, dict) else [],
         "slices": list(payload.get("slices", [])) if isinstance(payload, dict) else [],
         "attention": list(payload.get("attention", [])) if isinstance(payload, dict) else [],
+        "not_claimable": (
+            list(payload.get("not_claimable", [])) if isinstance(payload, dict) else []
+        ),
         "in_flight": [],
         "recent_done": [],
         "degraded": True,

--- a/paulsha_cortex/coordinator/cli.py
+++ b/paulsha_cortex/coordinator/cli.py
@@ -237,7 +237,10 @@ def _build_parser() -> argparse.ArgumentParser:
     toggle.add_argument("--disable", action="store_true")
     p_work.add_argument("--payload", help="額外 manager-side evidence refs JSON object")
 
-    sub.add_parser("status", help="讀取 manager daemon 的 ready/held/slices/attention 快照")
+    sub.add_parser(
+        "status",
+        help="讀取 manager daemon 的 ready/held/slices/attention/not_claimable 快照",
+    )
 
     p_reap = sub.add_parser("reap-brokers", help="操作員 dry-run/apply 孤兒 codex broker 回收")
     p_reap.add_argument("--apply", action="store_true")

--- a/paulsha_cortex/coordinator/digest.py
+++ b/paulsha_cortex/coordinator/digest.py
@@ -70,6 +70,10 @@ def assemble_digest(status: Mapping[str, Any], *, now: str) -> dict[str, Any]:
     """把 `read_status()` 快照彙整成結構化 digest（JSON-ready，含人類可讀摘要）。"""
 
     attention = _as_list(status.get("attention"))
+    # #669：claim 判定不可 claim（`missing_issue`）而刻意不建 run 的 work item。
+    # 只帶計數不帶明細——digest 是推播摘要，明細留給 `cortex status`；但計數必須
+    # 在，否則「被跳過的項目」在推播面完全不存在，等於再造一次盲區。
+    not_claimable = _as_list(status.get("not_claimable"))
     ready = _as_list(status.get("ready"))
     held = _as_list(status.get("held"))
     recent_done = _as_list(status.get("recent_done"))
@@ -84,6 +88,7 @@ def assemble_digest(status: Mapping[str, Any], *, now: str) -> dict[str, Any]:
         "degraded_reason": degraded_reason if isinstance(degraded_reason, str) else None,
         "counts": {
             "attention": len(attention),
+            "not_claimable": len(not_claimable),
             "ready": len(ready),
             "held": len(held),
             "recent_done": len(recent_done),
@@ -132,7 +137,9 @@ def render_digest_text(digest: Mapping[str, Any]) -> str:
         f"status_updated_at: {digest.get('status_updated_at')}",
         f"degraded: {digest.get('degraded')} ({digest.get('degraded_reason')})",
         (
-            f"attention={counts.get('attention', 0)} ready={counts.get('ready', 0)} "
+            f"attention={counts.get('attention', 0)} "
+            f"not_claimable={counts.get('not_claimable', 0)} "
+            f"ready={counts.get('ready', 0)} "
             f"held={counts.get('held', 0)} recent_done={counts.get('recent_done', 0)}"
         ),
     ]

--- a/paulsha_cortex/coordinator/manager_daemon.py
+++ b/paulsha_cortex/coordinator/manager_daemon.py
@@ -19,7 +19,7 @@ from typing import Any, Callable
 from paulsha_cortex.config import paths
 from ..control import constants, contract
 from ..trust_root import selfcheck as trust_root_selfcheck
-from . import autonomy, backoff, manager, planning_runtime
+from . import autonomy, backoff, manager, not_claimable, planning_runtime
 from .cli import _refuse_unsafe_fanout, _resolve_launcher
 from .diagnostics import diagnostic_reason, summarize_exception
 from .dispatcher import Dispatcher
@@ -252,6 +252,28 @@ def _in_flight_status(registry) -> list[dict[str, Any]]:
     return in_flight
 
 
+def _not_claimable_status(registry) -> list[dict[str, Any]]:
+    """#669：把 `not-claimable` ledger 投影進 status 快照。
+
+    ledger 與 `jobs.json` 同住 coordinator root，故由 registry 的 state path 推導
+    （與 `work_actions` 的 ``state_path.parent`` 同一個慣例）。推不出路徑（測試
+    double 沒有 ``_state_path``）時退回 `paths.coordinator_root()`；讀取失敗一律
+    回空清單——一份輔助紀錄壞掉不得讓整份 status 死掉（比照下方
+    `list_workflow_runs()` 的 try/except）。
+    """
+
+    state_path = getattr(registry, "_state_path", None)
+    try:
+        root = (
+            Path(state_path).resolve().parent
+            if state_path is not None
+            else paths.coordinator_root().resolve()
+        )
+        return not_claimable.list_entries(not_claimable.ledger_path(root))
+    except Exception:  # noqa: BLE001 - 呈現面失效不得癱瘓整份 status
+        return []
+
+
 def _available_identity_candidates(identity_registry) -> str:
     identities = getattr(identity_registry, "identities", ())
     return ", ".join(
@@ -456,6 +478,11 @@ def build_runtime_status_provider(
             "recent_done": recent_done_provider(),
             "slices": slices,
             "attention": attention,
+            # #669：claim 判定「不可 claim」的 work item 不再物化成 needs_human
+            # run，因此不會出現在 `attention`（那份清單只留可行動的項目）。但
+            # 「不建 run 就跳過」若沒有任何可查詢的出口，就只是把噪音換成盲區
+            # ——fail-loud 換 fail-silent，方向是錯的。這份清單就是那個出口。
+            "not_claimable": _not_claimable_status(registry),
         }
 
     return provider
@@ -1419,6 +1446,8 @@ def run_loop(
                 status_payload["held"] = list(snapshot.get("held", []))
                 status_payload["slices"] = list(snapshot.get("slices", []))
                 status_payload["attention"] = list(snapshot.get("attention", []))
+                # #669：claim 判定不可 claim 而**沒有**建立 run 的 work item。
+                status_payload["not_claimable"] = list(snapshot.get("not_claimable", []))
                 contract.atomic_write_json(constants.status_path(), status_payload)
             except Exception as exc:  # noqa: BLE001
                 _log_error(exc)

--- a/paulsha_cortex/coordinator/not_claimable.py
+++ b/paulsha_cortex/coordinator/not_claimable.py
@@ -1,0 +1,220 @@
+"""Issue #669：`claim` 判定「這個 work item 現在不可 claim」時的耐久記錄。
+
+## 為什麼要有這個檔
+
+`work_bridge.start_canonical_workflow` 過去在 claim 判定 `missing_issue` 時**仍然
+建立 run**（`detail` 逐字是「claim 判定需要人工介入即建立 run：missing_issue」）。
+自我託管首輪掃描後，24 個 `docs/superpowers/workstreams/*/` work item 因此各自變成
+一個永遠不會推進的 `needs_human` run：`current_phase: claim`、`gate_state: running`、
+`evidence_refs: []`、`next_actions: []`。
+
+而 `missing_issue` 對 workstream 來說**是預期狀態，不是異常**——
+`docs/superpowers/workstreams/cost-governance-cluster/todo.md` 開頭逐字寫著「本
+workstream 不對應單一 issue」。系統把一個預期狀態物化成 durable state 的結果是
+`attention` 信噪比 1:24，真正該人看的 blocker 被埋掉。
+
+## 這個檔買到什麼
+
+修法是「不建 run」（#669 選項 A）。但**只是不建 run 就是把 fail-loud 換成
+fail-silent**：真的該有 issue 卻沒有的 work item 會被靜默略過，噪音變成盲區，方向
+是錯的。因此每一次「不建 run 就跳過」都必須在這裡留下一筆 operator 查得到的紀錄：
+
+- 耐久：落在 `<coordinator_root>/not-claimable.json`，daemon 重啟不失憶。
+- 可查詢：`build_runtime_status_provider` 把它投影進 `cortex status` 的
+  `not_claimable` 區塊（與 `attention` 並列但分開——`attention` 只留可行動的項目）。
+- 自我收斂：work item 一旦變成可 claim（例如真的補了 issue），下一次 claim 判定
+  就會把該筆記錄清掉（見 :func:`clear`），不會留下永久的假警報。
+
+欄位刻意沿用既有詞彙（`reason`／`detail`／`source` 來自 `diagnostics.DiagnosticReason`
+的三要素），不另立一套平行的理由體系。
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
+from uuid import uuid4
+
+__all__ = [
+    "LEDGER_SCHEMA",
+    "LEDGER_FILENAME",
+    "ledger_path",
+    "load_ledger",
+    "list_entries",
+    "record",
+    "clear",
+]
+
+
+LEDGER_SCHEMA = "cortex-not-claimable/v1"
+LEDGER_FILENAME = "not-claimable.json"
+
+
+def _utcnow() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def ledger_path(coordinator_root: str | Path) -> Path:
+    """`<coordinator_root>/not-claimable.json`。
+
+    呼叫端多半手上只有 `delivery-journal.json` 的路徑（`work_actions` 的
+    ``state_path``），傳 `state_path.parent` 即可——與 `jobs.json` 的推導
+    （``resolved_state.parent / "jobs.json"``）同一個慣例。
+    """
+
+    return Path(coordinator_root) / LEDGER_FILENAME
+
+
+def _entry_key(*, repo: str, work_id: str) -> str:
+    return f"{repo}::{work_id}"
+
+
+def _empty() -> dict[str, Any]:
+    return {"schema": LEDGER_SCHEMA, "items": {}}
+
+
+def load_ledger(path: str | Path) -> dict[str, Any]:
+    """讀回整份 ledger；檔案不存在＝空 ledger，內容壞掉則 fail-closed。
+
+    壞掉時 raise 而非回空：這份檔案的存在理由就是「不可 claim 的項目必須查得
+    到」，靜默當成空的等於把盲區再造一次。
+    """
+
+    target = Path(path)
+    if not target.exists():
+        return _empty()
+    try:
+        payload = json.loads(target.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ValueError("not-claimable ledger unreadable") from exc
+    if (
+        not isinstance(payload, dict)
+        or payload.get("schema") != LEDGER_SCHEMA
+        or not isinstance(payload.get("items"), dict)
+    ):
+        raise ValueError("not-claimable ledger malformed")
+    for key, row in payload["items"].items():
+        if (
+            not isinstance(key, str)
+            or not isinstance(row, dict)
+            or not isinstance(row.get("repo"), str)
+            or not isinstance(row.get("work_id"), str)
+            or not isinstance(row.get("reason"), str)
+            or key != _entry_key(repo=row["repo"], work_id=row["work_id"])
+        ):
+            raise ValueError("not-claimable ledger row malformed")
+    return payload
+
+
+def _save(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.parent / f".{path.name}.{uuid4().hex}.tmp"
+    try:
+        with temporary.open("x", encoding="utf-8") as handle:
+            json.dump(payload, handle, ensure_ascii=False, indent=2, sort_keys=True)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)
+        directory_fd = os.open(path.parent, os.O_RDONLY | os.O_DIRECTORY)
+        try:
+            os.fsync(directory_fd)
+        finally:
+            os.close(directory_fd)
+    except BaseException:
+        temporary.unlink(missing_ok=True)
+        raise
+
+
+def list_entries(path: str | Path) -> list[dict[str, Any]]:
+    """呈現面用的穩定排序清單；ledger 壞掉或不存在時回空清單。
+
+    這是唯一一個對壞檔案容忍的入口——`cortex status` 的呈現不得因為一份輔助
+    紀錄壞掉就整份死掉（比照 `manager_daemon` 對 `list_workflow_runs()` 的
+    try/except 慣例）。寫入路徑（:func:`record`／:func:`clear`）仍然 fail-closed。
+    """
+
+    try:
+        payload = load_ledger(path)
+    except ValueError:
+        return []
+    return [payload["items"][key] for key in sorted(payload["items"])]
+
+
+def record(
+    path: str | Path,
+    *,
+    repo: str,
+    work_id: str,
+    reason: str,
+    detail: str,
+    source: str,
+    next_step_hint: str,
+    authority_digest: str | None = None,
+    mapped_openspec: Iterable[str] = (),
+    mapped_todo_paths: Iterable[str] = (),
+    stale_run_id: str | None = None,
+    now: str | None = None,
+) -> dict[str, Any]:
+    """記一筆「這個 work item 現在不可 claim」，回傳落盤後的 row。
+
+    重複觀測（每個 tick 都會再判一次）不新增 row，只更新 ``last_observed_at``
+    與 ``observations``；``first_observed_at`` 永遠是第一次觀測的時間，operator
+    因此看得出「這件事卡多久了」。
+    """
+
+    if not isinstance(repo, str) or not repo:
+        raise ValueError("not-claimable record requires repo")
+    if not isinstance(work_id, str) or not work_id:
+        raise ValueError("not-claimable record requires work_id")
+    if not isinstance(reason, str) or not reason:
+        raise ValueError("not-claimable record requires reason")
+    target = Path(path)
+    payload = load_ledger(target)
+    key = _entry_key(repo=repo, work_id=work_id)
+    observed_at = now if isinstance(now, str) and now else _utcnow()
+    previous = payload["items"].get(key)
+    row = {
+        "repo": repo,
+        "work_id": work_id,
+        "reason": reason,
+        "detail": detail,
+        "source": source,
+        "next_step_hint": next_step_hint,
+        "authority_digest": authority_digest,
+        "mapped_openspec": list(mapped_openspec),
+        "mapped_todo_paths": list(mapped_todo_paths),
+        "stale_run_id": stale_run_id,
+        "first_observed_at": (
+            previous.get("first_observed_at")
+            if isinstance(previous, dict) and isinstance(previous.get("first_observed_at"), str)
+            else observed_at
+        ),
+        "last_observed_at": observed_at,
+        "observations": (
+            previous.get("observations", 0) + 1
+            if isinstance(previous, dict) and isinstance(previous.get("observations"), int)
+            else 1
+        ),
+    }
+    payload["items"][key] = row
+    _save(target, payload)
+    return dict(row)
+
+
+def clear(path: str | Path, *, repo: str, work_id: str) -> bool:
+    """work item 重新變成可 claim 時移除該筆記錄；沒有該筆時完全不寫檔。"""
+
+    target = Path(path)
+    if not target.exists():
+        return False
+    payload = load_ledger(target)
+    key = _entry_key(repo=repo, work_id=work_id)
+    if key not in payload["items"]:
+        return False
+    del payload["items"][key]
+    _save(target, payload)
+    return True

--- a/paulsha_cortex/coordinator/work_actions.py
+++ b/paulsha_cortex/coordinator/work_actions.py
@@ -55,6 +55,7 @@ from .github_delivery import (
     evaluate_delivery_gate,
 )
 from . import engineering_outcome
+from . import not_claimable
 from . import verification
 from . import worktree_reclaim
 from .preflight import PreflightRequest, load_preflight_command, run_preflight
@@ -1424,6 +1425,108 @@ def _fallback_workflow_starter(workflow_registry, state_path: Path):
     return start
 
 
+# #669：`work_bridge.start_canonical_workflow` 在 claim 判定需要人工介入時建立的
+# run，其結構化理由固定帶這組 (reason, source)。這是「修正前留下的殭屍 run」唯一
+# 可機械辨識的簽名，用它把清理指引精準綁到那批 run 上，不會誤傷任何真的在跑的
+# needs_human run（build／verify／review 卡住的 run 既不在 claim phase，
+# `source` 也不是這一支）。
+_CLAIM_BLOCKED_REASON = "claim-blocked"
+_CLAIM_BLOCKED_SOURCE = "work_bridge.start_workflow_for_authority"
+
+_NOT_CLAIMABLE_SOURCE = "work_actions._claim_action:not-claimable"
+
+
+def _claim_blocked_stale_run(run) -> Any | None:
+    """#669 修正前留下的 claim-blocked 殭屍 run；不是的話回 ``None``。
+
+    判準刻意收到最窄：**ongoing ＋ 停在 `claim` phase ＋ 掛 `needs_human` ＋ 結構化
+    理由正是 `claim-blocked`／`work_bridge.start_workflow_for_authority` ＋ 沒有任何
+    evidence／PR**。少任何一項都不算——宣告一個「可以直接清掉」的 run 卻其實握有
+    工作成果，比不宣告更糟。
+    """
+
+    if run is None or getattr(run, "status", None) != "ongoing":
+        return None
+    if getattr(run, "current_phase", None) != "claim":
+        return None
+    if "needs_human" not in tuple(getattr(run, "facets", ()) or ()):
+        return None
+    if tuple(getattr(run, "evidence_refs", ()) or ()) or tuple(getattr(run, "pr_refs", ()) or ()):
+        return None
+    payload = getattr(run, "needs_human_reason", None)
+    if not isinstance(payload, dict):
+        return None
+    if payload.get("reason") != _CLAIM_BLOCKED_REASON:
+        return None
+    if payload.get("source") != _CLAIM_BLOCKED_SOURCE:
+        return None
+    return run
+
+
+def _not_claimable_response(
+    *,
+    authority,
+    state_path: Path,
+    stale_run=None,
+) -> dict[str, Any]:
+    """#669：記一筆耐久的 `not-claimable` 並回報「沒有建立 run」。
+
+    回傳的 ``run`` 恆為 ``None``——這正是本次修正的重點：判定「不可 claim」不再
+    留下任何 durable run。既有殭屍 run（修正前建立的）以 ``stale_run_id`` 如實
+    揭露並附上清理指令，不隱藏、也不由系統自行清除（清除是 operator 的明示動作，
+    見 `#373` 的守衛：auto-claim 不得自動清除或重試 needs_human run）。
+    """
+
+    # 兩種 row 分開命名，operator 一眼就知道要不要動手：
+    # - `missing_issue`：沒建 run，work item 現在就是不可 claim（workstream 多半
+    #   永遠停在這個狀態，屬預期）。
+    # - `claim-blocked-stale-run`：#669 修正前留下的殭屍 run 還在，需要一次清理。
+    reason = "missing_issue" if stale_run is None else "claim-blocked-stale-run"
+    detail = "claim 判定 work item 目前不可 claim，且刻意不建立 run：missing_issue"
+    if stale_run is not None:
+        detail += f"；另有 #669 修正前留下的 claim-blocked run {stale_run.run_id} 待清理"
+    if stale_run is not None:
+        hint = (
+            f"殭屍 run {stale_run.run_id} 是 #669 修正前「判定 missing_issue 仍建立 run」"
+            "留下的，永遠不會推進。確認無誤後以 `cortex work abandon "
+            f"{authority.work_id} --repo {authority.repo} --expected-run-id "
+            f"{stale_run.run_id} --actor <operator> --reason '#669 claim-blocked zombie'` "
+            "清除；清掉之後本項目只會留在 not_claimable 清單，不再佔用 attention。"
+        )
+    else:
+        hint = (
+            "本 work item 沒有對應的 GitHub issue，claim 因此不建立 run。"
+            "workstream 類（`docs/superpowers/workstreams/*`，設計上不對應單一 issue）"
+            "維持現狀即可；若這是漏開 issue，開好之後以 `cortex work link "
+            f"{authority.work_id} --repo {authority.repo} --issue <N>` 綁定，"
+            "下一輪掃描即自動 claim，本筆記錄同時自動消失。"
+        )
+    entry = not_claimable.record(
+        not_claimable.ledger_path(Path(state_path).parent),
+        repo=authority.repo,
+        work_id=authority.work_id,
+        reason=reason,
+        detail=detail,
+        source=_NOT_CLAIMABLE_SOURCE,
+        next_step_hint=hint,
+        authority_digest=work_authority_digest(authority),
+        mapped_openspec=authority.mapped_openspec,
+        mapped_todo_paths=authority.mapped_todo_paths,
+        stale_run_id=None if stale_run is None else stale_run.run_id,
+    )
+    response: dict[str, Any] = {
+        "action": "not_claimable",
+        "reason": reason,
+        "run": None,
+        "not_claimable": entry,
+        "next_step_hint": hint,
+    }
+    if stale_run is not None:
+        response["stale_run_id"] = stale_run.run_id
+        response["legal_next_steps"] = ("abandon",)
+    return response
+
+
 def _claim_action(
     *,
     args: dict[str, Any],
@@ -1666,6 +1769,19 @@ def _claim_action(
         if automatic
         else decide_manual_start(candidate, now_epoch=now_epoch)
     )
+    # #669：這一輪判定「不可 claim」與否，決定 `not-claimable` ledger 該記還是該收。
+    # 兩者共用同一個布林，兩邊對「這件事還在不在」的認知不可能分歧——ledger 因此
+    # 不會留下永久假警報（issue 補上、或既有殭屍 run 被 abandon 之後自動消失）。
+    stale_claim_blocked_run = _claim_blocked_stale_run(canonical_run)
+    work_item_not_claimable = decision.action == "needs_human" and (
+        decision.reason == "missing_issue" or stale_claim_blocked_run is not None
+    )
+    if not work_item_not_claimable:
+        not_claimable.clear(
+            not_claimable.ledger_path(Path(state_path).parent),
+            repo=authority.repo,
+            work_id=authority.work_id,
+        )
     if decision.action == "claim":
         if workflow_starter is None:
             raise RuntimeError("canonical workflow starter unavailable")
@@ -1719,6 +1835,33 @@ def _claim_action(
                 ),
             }
         active = run.to_dict()
+    elif work_item_not_claimable:
+        # #669：`missing_issue` 不得再物化成 run。
+        #
+        # 舊行為是「先建 run 再宣告 blocked」（`work_bridge.start_canonical_workflow`
+        # 的 `needs_human_reason` 分支，detail 逐字寫著「claim 判定需要人工介入即
+        # 建立 run」）。實機首輪掃描後 24 個 workstream work item 因此各自變成一個
+        # `current_phase: claim`／`gate_state: running`／`evidence_refs: []`／
+        # `next_actions: []` 的 `needs_human` run，永遠不會推進，`attention` 信噪比
+        # 1:24——真正該人看的 blocker 被埋掉。
+        #
+        # 而 `missing_issue` 對 workstream 而言**是預期狀態，不是異常**：
+        # `docs/superpowers/workstreams/cost-governance-cluster/todo.md` 開頭逐字
+        # 寫著「本 workstream 不對應單一 issue」。把預期狀態物化成 durable state
+        # 是根本的類別錯誤。
+        #
+        # 但「只是不建 run」會把 fail-loud 換成 fail-silent：真的該有 issue 卻沒有
+        # 的 work item 會被靜默略過。因此每一次跳過都必須在 `not-claimable` ledger
+        # 留一筆 operator 查得到的紀錄（`cortex status` 的 `not_claimable` 區塊）。
+        #
+        # 第二個判準（`_claim_blocked_stale_run`）只涵蓋**修正前既有的殭屍 run**：
+        # 它們存在時 `_resume_decision` 會先回 `human-intervention-required`，
+        # `missing_issue` 這條判準看不到它們，operator 因此也拿不到清理指引。
+        return _not_claimable_response(
+            authority=authority,
+            state_path=state_path,
+            stale_run=stale_claim_blocked_run,
+        )
     elif decision.action == "needs_human":
         claim_key = build_claim_key(
             ClaimCandidate(

--- a/paulsha_cortex/coordinator/work_bridge.py
+++ b/paulsha_cortex/coordinator/work_bridge.py
@@ -457,6 +457,18 @@ def start_canonical_workflow(
         workspace_root=root, combo_name=manifest.combo, artifact_rows=artifact_rows
     )
     if needs_human_reason is not None:
+        # #669：這條路徑**不再由 claim 的 `missing_issue` 判定觸發**。
+        #
+        # 舊行為是「先建 run 再宣告 blocked」，於是「workstream 本來就不對應單一
+        # issue」這個預期狀態被物化成 24 個 `current_phase: claim`／
+        # `evidence_refs: []`／`next_actions: []` 的 needs_human 殭屍 run。
+        # `work_actions._claim_action` 現在在判定 `missing_issue` 時直接回
+        # `not_claimable`（記進 `not-claimable` ledger、**不呼叫本函式**），
+        # 那條不變式由 `tests/test_claim_not_claimable_669.py` 釘住：
+        # workflow_starter 在 missing_issue 時一次都不得被呼叫。
+        #
+        # 分支本身保留：它是「以指定理由建立一個 needs_human run」的通用設施，
+        # 與 claim 判定的語意無關。
         if existing_run is not None:
             return existing_run
         run = registry._manager_create_workflow_run(

--- a/paulsha_cortex/porcelain/inspect.py
+++ b/paulsha_cortex/porcelain/inspect.py
@@ -125,6 +125,26 @@ def _print_status(status: dict[str, Any]) -> None:
         )
         for ref in blocking.get("evidence_refs") or []:
             sys.stdout.write(f"    evidence: {ref}\n")
+    # #669：claim 判定 `missing_issue` 時不再建立 run（那會把「workstream 本來就
+    # 不對應單一 issue」這個**預期狀態**物化成永遠不會推進的 needs_human 殭屍，
+    # 實機一次產出 24 個、把 attention 信噪比壓成 1:24）。但只是不建 run 等於把
+    # fail-loud 換成 fail-silent，因此改記在這份 ledger，並在這裡印出來——
+    # operator 巡檢時看得到「哪些 work item 被跳過、為什麼、多久了、下一步」。
+    not_claimable = status.get("not_claimable", []) or []
+    sys.stdout.write(
+        "not_claimable: " + json.dumps(not_claimable, ensure_ascii=False, sort_keys=True) + "\n"
+    )
+    for entry in not_claimable:
+        if not isinstance(entry, dict):
+            continue
+        sys.stdout.write(
+            f"  not_claimable[{entry.get('repo', '-')}/{entry.get('work_id', '-')}]: "
+            f"{entry.get('reason')}: {entry.get('detail')} "
+            f"(since={entry.get('first_observed_at')}, seen={entry.get('observations')})\n"
+        )
+        hint = entry.get("next_step_hint")
+        if hint:
+            sys.stdout.write(f"    next: {hint}\n")
     sys.stdout.write(
         "in_flight: " + json.dumps(status.get("in_flight", []), ensure_ascii=False, sort_keys=True) + "\n"
     )

--- a/tests/test_claim_not_claimable_669.py
+++ b/tests/test_claim_not_claimable_669.py
@@ -1,0 +1,524 @@
+"""`#669` 迴歸測試：claim 判定 `missing_issue` 不得建立 run。
+
+實測背景：自我託管首輪掃描後，`cortex status` 的 `attention` 一口氣出現 **24 個內容
+完全同型的 `needs_human` run**，全部停在 `current_phase: claim`、`gate_state:
+running`、`evidence_refs: []`、`next_actions: []`，`detail` 逐字是「claim 判定需要
+人工介入即建立 run：missing_issue」。它們永遠不會推進，卻把唯一真正需要人看的
+blocker 壓成 1:24 的信噪比。
+
+根因是類別錯誤：`missing_issue` 對 workstream 而言**是預期狀態，不是異常**——
+`docs/superpowers/workstreams/cost-governance-cluster/todo.md` 開頭逐字寫著「本
+workstream 不對應單一 issue」。系統卻把這個預期狀態物化成 durable state。
+
+本檔釘住四件事：
+
+1. `missing_issue` 時 **`workflow_starter` 一次都不得被呼叫**（不建 run）。
+2. 跳過必須留下**可查詢**的 `not-claimable` 紀錄——否則只是把噪音換成盲區，
+   fail-loud 變 fail-silent，方向是錯的。
+3. **真的該建 run 的情況仍然建**（不得為了消噪音把正常路徑一併關掉）。
+4. 修正前留下的 claim-blocked 殭屍 run 不被靜默忽略，而是帶著清理指令浮現；
+   真正卡住的 needs_human run（build／verify／review）不得被誤判成殭屍。
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from paulsha_cortex.coordinator import manager_daemon, not_claimable, work_actions
+from paulsha_cortex.coordinator.diagnostics import diagnostic_reason
+from paulsha_cortex.coordinator.registry import JobRegistry
+
+
+def _init_repo(root: Path, repo: str = "acme/demo") -> Path:
+    root.mkdir(parents=True, exist_ok=True)
+    subprocess.run(["git", "init", "-q", str(root)], check=True)
+    remote = subprocess.run(
+        ["git", "-C", str(root), "remote", "get-url", "origin"],
+        capture_output=True,
+        text=True,
+    )
+    if remote.returncode != 0:
+        subprocess.run(
+            ["git", "-C", str(root), "remote", "add", "origin", f"git@github.com:{repo}.git"],
+            check=True,
+        )
+    return root
+
+
+def _snapshot(
+    path: Path,
+    *,
+    work_id: str = "cost-governance-cluster",
+    issues: tuple[int, ...] = (),
+    source_revisions: tuple[str, ...] = ("openspec:cost-governance-cluster@1",),
+) -> Path:
+    """一個 workstream 形狀的 work item：有 confirmed todo、有 openspec，但**沒有
+    mapped issue**（`docs/superpowers/workstreams/*` 的常態）。"""
+
+    _init_repo(path.parent)
+    path.write_text(
+        json.dumps(
+            {
+                "schema": "work-items-snapshot/v1",
+                "providers": {
+                    "github": {
+                        "provider_id": "github",
+                        "revision": "gh-1",
+                        "last_success_epoch": 100,
+                        "degraded": False,
+                    }
+                },
+                "work_items": [
+                    {
+                        "repo": "acme/demo",
+                        "work_id": work_id,
+                        "mapped_issues": list(issues),
+                        "mapped_prs": [],
+                        "mapped_openspec": [work_id],
+                        "mapped_todo_paths": [
+                            f"docs/superpowers/workstreams/{work_id}/todo.md"
+                        ],
+                        "confirmed_todo": True,
+                        "auto_label": True,
+                        "source_revisions": list(source_revisions),
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _authority(snapshot: Path, *, work_id: str = "cost-governance-cluster"):
+    return work_actions.load_work_authority(
+        repo="acme/demo", work_id=work_id, snapshot_path=snapshot
+    )
+
+
+def _refusing_starter(*_args, **_kwargs):
+    raise AssertionError("missing_issue 不得建立 run（#669）")
+
+
+def _ledger(state: Path) -> Path:
+    return not_claimable.ledger_path(state.parent)
+
+
+# --- 1. 不建 run ---------------------------------------------------------------
+
+
+@pytest.mark.parametrize("action", ["start", "resume"])
+def test_missing_issue_never_calls_the_workflow_starter(tmp_path: Path, action: str) -> None:
+    """核心不變式：判定 `missing_issue` 時 workflow_starter 一次都不得被呼叫。
+
+    這條釘住的是 issue 標題那句話本身——「missing_issue 仍建立 run」。starter
+    被叫到就直接 AssertionError，不必再推論 run 的形狀。
+    """
+
+    snapshot = _snapshot(tmp_path / "work" / "snapshot.json")
+    state = tmp_path / "work" / "runs.json"
+    registry = JobRegistry(state_path=state.parent / "jobs.json")
+
+    result = work_actions._claim_action(
+        args={"action": action},
+        authority=_authority(snapshot),
+        now_epoch=200,
+        state_path=state,
+        workflow_registry=registry,
+        workflow_starter=_refusing_starter,
+    )
+
+    assert result["action"] == "not_claimable"
+    assert result["reason"] == "missing_issue"
+    assert result["run"] is None
+    assert registry.list_workflow_runs() == []
+
+
+def test_auto_scan_leaves_no_durable_run_for_a_workstream_without_issue(
+    tmp_path: Path,
+) -> None:
+    """整條 auto-claim scan 走完，registry 與 delivery journal 皆零殘留。"""
+
+    snapshot = _snapshot(tmp_path / "work" / "snapshot.json")
+    state = tmp_path / "work" / "runs.json"
+    registry = JobRegistry(state_path=state.parent / "jobs.json")
+
+    results = work_actions.run_auto_claim_scan(
+        snapshot_path=snapshot,
+        state_path=state,
+        now=lambda: 200,
+        workflow_registry=registry,
+        workflow_starter=_refusing_starter,
+    )
+
+    assert [row["action"] for row in results] == ["not_claimable"]
+    assert registry.list_workflow_runs() == []
+    assert not state.exists()
+
+
+# --- 2. 跳過必須可查詢 ---------------------------------------------------------
+
+
+def test_missing_issue_records_a_queryable_not_claimable_entry(tmp_path: Path) -> None:
+    """「不建 run」不得等於「靜默略過」：ledger 必須落一筆可查的紀錄。"""
+
+    snapshot = _snapshot(tmp_path / "work" / "snapshot.json")
+    state = tmp_path / "work" / "runs.json"
+    registry = JobRegistry(state_path=state.parent / "jobs.json")
+
+    result = work_actions._claim_action(
+        args={"action": "start"},
+        authority=_authority(snapshot),
+        now_epoch=200,
+        state_path=state,
+        workflow_registry=registry,
+        workflow_starter=_refusing_starter,
+    )
+
+    entries = not_claimable.list_entries(_ledger(state))
+    assert len(entries) == 1
+    entry = entries[0]
+    assert entry["repo"] == "acme/demo"
+    assert entry["work_id"] == "cost-governance-cluster"
+    assert entry["reason"] == "missing_issue"
+    assert entry["stale_run_id"] is None
+    assert entry["observations"] == 1
+    assert entry["first_observed_at"] == entry["last_observed_at"]
+    # 下一步必須具體到可以照抄，否則 operator 只知道「被跳過了」。
+    assert "cortex work link" in entry["next_step_hint"]
+    assert result["not_claimable"] == entry
+
+    on_disk = json.loads(_ledger(state).read_text(encoding="utf-8"))
+    assert on_disk["schema"] == not_claimable.LEDGER_SCHEMA
+    assert list(on_disk["items"]) == ["acme/demo::cost-governance-cluster"]
+
+
+def test_repeated_scans_track_observations_without_multiplying_rows(tmp_path: Path) -> None:
+    """每個 tick 都會再判一次；ledger 不得因此每輪長出一列。"""
+
+    snapshot = _snapshot(tmp_path / "work" / "snapshot.json")
+    state = tmp_path / "work" / "runs.json"
+    registry = JobRegistry(state_path=state.parent / "jobs.json")
+
+    for _ in range(3):
+        work_actions._claim_action(
+            args={"action": "auto-scan"},
+            authority=_authority(snapshot),
+            now_epoch=200,
+            state_path=state,
+            automatic=True,
+            auto_label=True,
+            workflow_registry=registry,
+            workflow_starter=_refusing_starter,
+        )
+
+    entries = not_claimable.list_entries(_ledger(state))
+    assert len(entries) == 1
+    assert entries[0]["observations"] == 3
+    # 第一次觀測時間必須保留——operator 靠它判斷「這件事卡多久了」。
+    assert entries[0]["first_observed_at"] <= entries[0]["last_observed_at"]
+
+
+def test_status_snapshot_exposes_the_not_claimable_ledger(tmp_path: Path) -> None:
+    """`cortex status` 必須看得到；否則 ledger 只是另一個沒人會看的角落。"""
+
+    snapshot = _snapshot(tmp_path / "work" / "snapshot.json")
+    state = tmp_path / "work" / "runs.json"
+    registry = JobRegistry(state_path=state.parent / "jobs.json")
+    work_actions._claim_action(
+        args={"action": "start"},
+        authority=_authority(snapshot),
+        now_epoch=200,
+        state_path=state,
+        workflow_registry=registry,
+        workflow_starter=_refusing_starter,
+    )
+
+    provider = manager_daemon.build_runtime_status_provider(
+        registry=registry,
+        specs_dir=str(tmp_path / "specs"),
+        handoff_dir=str(tmp_path / "handoff"),
+        scan_specs_fn=lambda _: [],
+        ready_units_fn=lambda metas, predicate: [],
+    )
+    payload = provider()
+
+    # attention 只留可行動的項目——不可 claim 的 work item 不得再污染它。
+    assert payload["attention"] == []
+    assert [row["work_id"] for row in payload["not_claimable"]] == [
+        "cost-governance-cluster"
+    ]
+    assert payload["not_claimable"][0]["reason"] == "missing_issue"
+
+
+def test_status_text_mode_prints_the_not_claimable_reason(capsys) -> None:
+    from paulsha_cortex.porcelain import inspect as porcelain_inspect
+
+    porcelain_inspect._print_status(
+        {
+            "updated_at": "2026-08-18T00:00:00Z",
+            "degraded": False,
+            "attention": [],
+            "not_claimable": [
+                {
+                    "repo": "acme/demo",
+                    "work_id": "cost-governance-cluster",
+                    "reason": "missing_issue",
+                    "detail": "claim 判定 work item 目前不可 claim，且刻意不建立 run：missing_issue",
+                    "first_observed_at": "2026-08-18T00:00:00+00:00",
+                    "observations": 7,
+                    "next_step_hint": "cortex work link cost-governance-cluster --repo acme/demo --issue <N>",
+                }
+            ],
+        }
+    )
+
+    out = capsys.readouterr().out
+    assert "not_claimable[acme/demo/cost-governance-cluster]: missing_issue" in out
+    assert "next: cortex work link" in out
+
+
+# --- 3. 正常路徑不得被關掉 -----------------------------------------------------
+
+
+def test_work_item_with_an_issue_still_starts_a_run(tmp_path: Path) -> None:
+    """為了消噪音而把可 claim 的項目一併擋掉，才是真正嚴重的迴歸。"""
+
+    snapshot = _snapshot(
+        tmp_path / "work" / "snapshot.json",
+        work_id="fix-claim-provider-scope",
+        issues=(12,),
+        source_revisions=("issue:12@open", "openspec:fix-claim-provider-scope@1"),
+    )
+    state = tmp_path / "work" / "runs.json"
+    registry = JobRegistry(state_path=state.parent / "jobs.json")
+
+    result = work_actions._claim_action(
+        args={"action": "start"},
+        authority=_authority(snapshot, work_id="fix-claim-provider-scope"),
+        now_epoch=200,
+        state_path=state,
+        workflow_registry=registry,
+        workflow_starter=work_actions._fallback_workflow_starter(registry, state),
+    )
+
+    assert result["action"] == "claim"
+    assert result["run"]["status"] == "ongoing"
+    assert len(registry.list_workflow_runs()) == 1
+    assert not_claimable.list_entries(_ledger(state)) == []
+
+
+def test_ledger_entry_is_cleared_once_the_issue_appears(tmp_path: Path) -> None:
+    """work item 補上 issue 之後，`not-claimable` 那筆必須自動消失。
+
+    否則修法只是把「永久的假 needs_human run」換成「永久的假 not-claimable 紀錄」。
+    """
+
+    root = tmp_path / "work"
+    snapshot = _snapshot(root / "snapshot.json")
+    state = root / "runs.json"
+    registry = JobRegistry(state_path=state.parent / "jobs.json")
+    work_actions._claim_action(
+        args={"action": "start"},
+        authority=_authority(snapshot),
+        now_epoch=200,
+        state_path=state,
+        workflow_registry=registry,
+        workflow_starter=_refusing_starter,
+    )
+    assert len(not_claimable.list_entries(_ledger(state))) == 1
+
+    _snapshot(
+        snapshot,
+        issues=(208,),
+        source_revisions=("issue:208@open", "openspec:cost-governance-cluster@1"),
+    )
+    result = work_actions._claim_action(
+        args={"action": "start"},
+        authority=_authority(snapshot),
+        now_epoch=200,
+        state_path=state,
+        workflow_registry=registry,
+        workflow_starter=work_actions._fallback_workflow_starter(registry, state),
+    )
+
+    assert result["action"] == "claim"
+    assert not_claimable.list_entries(_ledger(state)) == []
+
+
+# --- 4. 既有殭屍 run 的收口 ----------------------------------------------------
+
+
+def _zombie_run(authority, *, run_id: str = "workflow-" + "c" * 20):
+    """#669 修正前 `work_bridge.start_canonical_workflow` 會建出來的那種 run。"""
+
+    return SimpleNamespace(
+        run_id=run_id,
+        repo=authority.repo,
+        work_id=authority.work_id,
+        claim_key=work_actions._expected_claim_key(authority),
+        status="ongoing",
+        current_phase="claim",
+        facets=("needs_human",),
+        gate_status="running",
+        issue_refs=(),
+        openspec_refs=authority.mapped_openspec,
+        pr_refs=(),
+        evidence_refs=(),
+        source_revision=work_actions.work_authority_digest(authority),
+        needs_human_reason=diagnostic_reason(
+            "claim-blocked",
+            "claim 判定需要人工介入即建立 run：missing_issue",
+            source="work_bridge.start_workflow_for_authority",
+            work_id=authority.work_id,
+            repo=authority.repo,
+        ).to_dict(),
+        to_dict=lambda: {"run_id": run_id, "current_phase": "claim"},
+    )
+
+
+def test_legacy_claim_blocked_run_surfaces_with_an_exact_cleanup_command(
+    tmp_path: Path,
+) -> None:
+    """修正前建立的 24 個殭屍 run 仍在 durable state 裡。
+
+    修正不會自行清除它們（`#373`：auto-claim 不得自動清除或重試 needs_human
+    run），但**必須讓 operator 查得到、且拿得到可照抄的清理指令**——否則修完之後
+    那批 run 依舊在 attention 裡卡著，只是沒人知道該怎麼收。
+    """
+
+    snapshot = _snapshot(tmp_path / "work" / "snapshot.json")
+    state = tmp_path / "work" / "runs.json"
+    authority = _authority(snapshot)
+    zombie = _zombie_run(authority)
+    registry = SimpleNamespace(list_workflow_runs=lambda: [zombie])
+
+    result = work_actions._claim_action(
+        args={"action": "auto-scan"},
+        authority=authority,
+        now_epoch=200,
+        state_path=state,
+        automatic=True,
+        auto_label=True,
+        workflow_registry=registry,
+        workflow_starter=_refusing_starter,
+    )
+
+    assert result["action"] == "not_claimable"
+    assert result["reason"] == "claim-blocked-stale-run"
+    assert result["stale_run_id"] == zombie.run_id
+    assert result["legal_next_steps"] == ("abandon",)
+    hint = result["next_step_hint"]
+    assert f"cortex work abandon {authority.work_id}" in hint
+    assert f"--expected-run-id {zombie.run_id}" in hint
+
+    entry = not_claimable.list_entries(_ledger(state))[0]
+    assert entry["reason"] == "claim-blocked-stale-run"
+    assert entry["stale_run_id"] == zombie.run_id
+
+
+def test_a_genuinely_stuck_run_is_not_mistaken_for_a_claim_blocked_zombie(
+    tmp_path: Path,
+) -> None:
+    """判準必須窄到不會誤傷：停在 build 的 needs_human run 握有真正的工作成果，
+    不得被重新分類成「不可 claim、可直接清掉」。"""
+
+    snapshot = _snapshot(
+        tmp_path / "work" / "snapshot.json",
+        work_id="fix-claim-provider-scope",
+        issues=(12,),
+        source_revisions=("issue:12@open", "openspec:fix-claim-provider-scope@1"),
+    )
+    state = tmp_path / "work" / "runs.json"
+    authority = _authority(snapshot, work_id="fix-claim-provider-scope")
+    stuck = SimpleNamespace(
+        run_id="workflow-" + "d" * 20,
+        repo=authority.repo,
+        work_id=authority.work_id,
+        claim_key=work_actions._expected_claim_key(authority),
+        status="ongoing",
+        current_phase="build",
+        facets=("needs_human",),
+        gate_status="running",
+        steps=(),
+        issue_refs=("acme/demo#12",),
+        openspec_refs=authority.mapped_openspec,
+        pr_refs=(),
+        evidence_refs=("/tmp/evidence/build.json",),
+        source_revision=work_actions.work_authority_digest(authority),
+        needs_human_reason=diagnostic_reason(
+            "resume-workflow-failed",
+            "ValueError: worktree target already exists",
+            source="manager_daemon.periodic_tick:resume-workflow",
+        ).to_dict(),
+        to_dict=lambda: {"run_id": "workflow-" + "d" * 20, "current_phase": "build"},
+    )
+    registry = SimpleNamespace(list_workflow_runs=lambda: [stuck], list_jobs=lambda: [])
+
+    result = work_actions._claim_action(
+        args={"action": "auto-scan"},
+        authority=authority,
+        now_epoch=200,
+        state_path=state,
+        automatic=True,
+        auto_label=True,
+        workflow_registry=registry,
+        workflow_starter=_refusing_starter,
+    )
+
+    assert result["action"] == "needs_human"
+    assert result["reason"] == "human-intervention-required"
+    assert result["run"]["run_id"] == stuck.run_id
+    assert not_claimable.list_entries(_ledger(state)) == []
+
+
+def test_claim_blocked_signature_requires_every_marker(tmp_path: Path) -> None:
+    """`_claim_blocked_stale_run` 的判準逐項為必要條件——少任何一項都不算殭屍。"""
+
+    snapshot = _snapshot(tmp_path / "work" / "snapshot.json")
+    authority = _authority(snapshot)
+    zombie = _zombie_run(authority)
+    assert work_actions._claim_blocked_stale_run(zombie) is zombie
+
+    for field, value in (
+        ("status", "superseded"),
+        ("current_phase", "define"),
+        ("facets", ()),
+        ("evidence_refs", ("/tmp/evidence/x.json",)),
+        ("pr_refs", ("acme/demo#9",)),
+        (
+            "needs_human_reason",
+            diagnostic_reason(
+                "claim-blocked",
+                "另一支來源寫的",
+                source="manager.some_other_path",
+            ).to_dict(),
+        ),
+    ):
+        mutated = _zombie_run(authority)
+        setattr(mutated, field, value)
+        assert work_actions._claim_blocked_stale_run(mutated) is None, field
+
+
+# --- ledger 本身的耐久性契約 ---------------------------------------------------
+
+
+def test_ledger_is_fail_closed_on_corruption_but_status_stays_alive(tmp_path: Path) -> None:
+    path = tmp_path / not_claimable.LEDGER_FILENAME
+    path.write_text("{ not json", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="not-claimable ledger unreadable"):
+        not_claimable.load_ledger(path)
+    # 呈現面不得因為一份輔助紀錄壞掉就整份 status 死掉。
+    assert not_claimable.list_entries(path) == []
+
+
+def test_clear_is_a_no_op_when_nothing_was_recorded(tmp_path: Path) -> None:
+    path = tmp_path / not_claimable.LEDGER_FILENAME
+    assert not_claimable.clear(path, repo="acme/demo", work_id="demo") is False
+    assert not path.exists()

--- a/tests/test_coordinator_digest.py
+++ b/tests/test_coordinator_digest.py
@@ -43,7 +43,14 @@ def test_assemble_digest_builds_structured_summary_from_status_snapshot() -> Non
     assert result["status_updated_at"] == "2026-08-10T12:30:00+00:00"
     assert result["degraded"] is False
     assert result["degraded_reason"] is None
-    assert result["counts"] == {"attention": 1, "ready": 1, "held": 1, "recent_done": 1}
+    assert result["counts"] == {
+        "attention": 1,
+        # #669：claim 判定不可 claim 而刻意不建 run 的 work item 計數。
+        "not_claimable": 0,
+        "ready": 1,
+        "held": 1,
+        "recent_done": 1,
+    }
     assert result["attention"] == status["attention"]
     assert result["ready"] == status["ready"]
     assert result["held"] == status["held"]
@@ -59,7 +66,13 @@ def test_assemble_digest_tolerates_sparse_or_degraded_status() -> None:
 
     assert result["degraded"] is True
     assert result["degraded_reason"] == "stalled"
-    assert result["counts"] == {"attention": 0, "ready": 0, "held": 0, "recent_done": 0}
+    assert result["counts"] == {
+        "attention": 0,
+        "not_claimable": 0,
+        "ready": 0,
+        "held": 0,
+        "recent_done": 0,
+    }
     assert result["attention"] == []
     assert result["ready"] == []
     assert result["held"] == []
@@ -72,7 +85,7 @@ def test_render_digest_text_lists_attention_ready_held_recent_done() -> None:
     text = digest_module.render_digest_text(digest)
 
     assert f"digest @ {FIXED_NOW}" in text
-    assert "attention=1 ready=1 held=1 recent_done=1" in text
+    assert "attention=1 not_claimable=0 ready=1 held=1 recent_done=1" in text
     assert "- slice-c: verify-failed" in text
     assert "- slice-a" in text
     assert "- slice-b: dispatch-hold" in text

--- a/tests/test_porcelain_digest.py
+++ b/tests/test_porcelain_digest.py
@@ -74,7 +74,14 @@ def test_digest_emit_writes_file_outbox_by_default_and_reports_json(
     assert written_path.parent == digest_runtime["coordinator_root"] / "digest" / "outbox"
     on_disk = json.loads(written_path.read_text(encoding="utf-8"))
     assert on_disk["attention"][0]["slice_id"] == "slice-c"
-    assert on_disk["counts"] == {"attention": 1, "ready": 1, "held": 1, "recent_done": 1}
+    assert on_disk["counts"] == {
+        "attention": 1,
+        # #669：claim 判定不可 claim 而刻意不建 run 的 work item 計數。
+        "not_claimable": 0,
+        "ready": 1,
+        "held": 1,
+        "recent_done": 1,
+    }
 
 
 def test_digest_emit_human_output_lists_attention_and_delivery_path(

--- a/tests/test_work_actions.py
+++ b/tests/test_work_actions.py
@@ -2055,7 +2055,7 @@ def test_explicit_resume_selects_unique_done_ship_run_after_authority_changes(
     assert result["run"]["run_id"] == terminal.run_id
 
 
-def test_periodic_auto_scan_claims_labeled_work_and_persists_missing_issue(tmp_path: Path) -> None:
+def test_periodic_auto_scan_claims_labeled_work_and_skips_missing_issue(tmp_path: Path) -> None:
     snapshot = _snapshot(tmp_path / "snapshot.json")
     state = tmp_path / "runs.json"
     claimed = work_actions.run_auto_claim_scan(
@@ -2071,19 +2071,31 @@ def test_periodic_auto_scan_claims_labeled_work_and_persists_missing_issue(tmp_p
     assert claimed[0]["action"] == "claim"
     assert claimed[0]["run"]["status"] == "ongoing"
 
+    # #669：missing-issue 的情境改用**獨立的 coordinator root**。原本兩段共用
+    # `tmp_path/jobs.json`，而舊行為建立 missing_issue run 時
+    # `_manager_create_workflow_run` 會把同 (repo, work_id) 的 ongoing run 全部
+    # 標成 superseded——上一段剛 claim 成功的 run 就是被它作廢的（這正是「判定
+    # missing_issue 卻建 run」的第二層傷害），最後那個 `resume` 才會回 `claim`。
+    # 修正後不再建 run，共用 registry 會讓 resume 正確地接回上一段那個 run
+    # （回 `resume`），與本測試想驗的「missing → issue 補上 → 可 claim」無關。
+    missing_root = tmp_path / "missing"
     missing_snapshot = _snapshot(
-        tmp_path / "missing.json",
+        missing_root / "missing.json",
         issues=(),
         source_revisions=("openspec:demo@2",),
     )
-    missing_state = tmp_path / "missing-runs.json"
+    missing_state = missing_root / "runs.json"
     attention = work_actions.run_auto_claim_scan(
         snapshot_path=missing_snapshot,
         state_path=missing_state,
         now=lambda: 200,
     )
-    assert attention[0]["action"] == "needs_human"
-    assert attention[0]["run"]["reason"] == "missing_issue"
+    # #669：`missing_issue` 不再物化成 run——掃描回報 `not_claimable` 且 run 為
+    # None，理由改落在耐久的 `not-claimable` ledger（operator 從 `cortex status`
+    # 的 `not_claimable` 區塊查得到）。
+    assert attention[0]["action"] == "not_claimable"
+    assert attention[0]["reason"] == "missing_issue"
+    assert attention[0]["run"] is None
 
     _snapshot(
         missing_snapshot,

--- a/tests/test_work_actions_auto_claim_pressure.py
+++ b/tests/test_work_actions_auto_claim_pressure.py
@@ -265,10 +265,12 @@ def test_rate_limited_scan_still_claims_authorities_needing_no_github_read(
 
     by_work = {row["work_id"]: row for row in result}
     assert by_work["with-issue"]["reason"] == "github-rate-limited"
-    # 沒有 mapped issue 的 authority 仍走完 _claim_action（此處因 auto_label 為 False
-    # 而落在 needs_human——那是既有語意，與限流無關）；重點是它**沒有**被停手擋掉。
+    # 沒有 mapped issue 的 authority 仍走完 _claim_action（#669 之後落在
+    # `not_claimable`／`missing_issue`：不建 run，只記進 not-claimable ledger）；
+    # 重點是它**沒有**被限流停手擋掉。
     assert by_work["no-issue"].get("reason") != "github-rate-limited-scan-aborted"
-    assert by_work["no-issue"]["action"] == "needs_human"
+    assert by_work["no-issue"]["action"] == "not_claimable"
+    assert by_work["no-issue"]["run"] is None
 
 
 def test_invalid_interval_env_fails_loud(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## 問題

`claim` 判定 `missing_issue` 時**仍然建立 run**（`work_bridge.start_canonical_workflow`
的 `needs_human_reason` 分支，run 上的理由逐字是「claim 判定需要人工介入即建立 run：
missing_issue」）。自我託管首輪掃描因此在八秒內產出 **24 個內容完全同型的 `needs_human`
殭屍 run**，全部停在 `current_phase: claim`、`gate_state: running`、`evidence_refs: []`、
`next_actions: []`，永遠不會推進。

根因是**類別錯誤**：`missing_issue` 對 `docs/superpowers/workstreams/*` 這類 work item
而言是**預期狀態，不是異常**——`cost-governance-cluster/todo.md` 開頭逐字寫著「本
workstream 不對應單一 issue」。把預期狀態物化成 durable state 的後果是 `attention`
信噪比 1:24，唯一真正需要人看的 blocker 被埋掉。

## 採用的選項：A（＋必要的可觀測性補強）

**A：判定 `missing_issue` 時不建 run，只在 work item 上記一筆 `not-claimable` 並跳過。**

沒有改採 B（`todo.md` frontmatter 加「不需 issue」欄位），理由是 B 只治了 workstream
這一個子集：`missing_issue` 這條判定對**任何**還沒開 issue 的 work item 都會觸發，B 之後
那些 work item 照樣會長出殭屍 run。A 修的是「不可 claim 的判定不得物化成 run」這條更上游
的不變式，且不需要動 frontmatter schema、不需要 fleet 全體改檔。C（保留建 run、補
`next_actions`）被否決：那等於承認「預期狀態應該進入 run 生命週期」，durable state 污染
與每 tick 重複判定都還在。

### A 的風險與處理：不得讓「真的該有 issue 卻沒有」被靜默略過

只是「不建 run」會把 fail-loud 換成 fail-silent——噪音變盲區，方向是錯的。因此每一次跳過
都必須留下 operator 查得到的紀錄：

- 新增 `paulsha_cortex/coordinator/not_claimable.py`：耐久 ledger
  `<coordinator_root>/not-claimable.json`（schema `cortex-not-claimable/v1`），逐筆記
  `reason`／`detail`／`source`、`first_observed_at`／`last_observed_at`／`observations`
  （卡多久、被判過幾次）、`authority_digest`、`mapped_openspec`／`mapped_todo_paths`，以及
  **可照抄執行**的 `next_step_hint`（`cortex work link <work_id> --repo … --issue <N>`）。
- `cortex status` 新增獨立的 `not_claimable` 區塊（`attention` 因此只留可行動的項目），
  文字模式逐筆印出理由與下一步；`cortex digest` 帶 `not_claimable` 計數。
- **自我收斂**：work item 一旦重新可 claim（補了 issue、或殭屍 run 已被 abandon），下一次
  判定就把該筆清掉——不留永久假警報。ledger 對損毀 fail-closed（`load_ledger` raise），
  但呈現面 fail-soft（`list_entries` 回空清單），一份輔助紀錄壞掉不得讓整份 status 死掉。

## 既有 24 個殭屍 run 的清理路徑

**由 operator 明示執行，系統不自行清除**——沿用 `#373` 既有守衛「auto-claim 不得自動清除
或重試 `needs_human` run」，也避免在 operator 不知情下消耗 semantic-reclaim 世代額度。
本 PR 只寫 code 與指引，**未觸碰實機狀態**。

修正後，claim 會以唯一可機械辨識的簽名認出這批 run——**ongoing ＋ 停在 `claim` phase ＋
掛 `needs_human` ＋ 結構化理由正是 `claim-blocked`／`work_bridge.start_workflow_for_authority`
＋ 零 `evidence_refs` 與零 `pr_refs`**——命中時回 `reason: claim-blocked-stale-run`，附
`stale_run_id`、`legal_next_steps: ("abandon",)` 與完整指令，同時落進 `not-claimable`
ledger（operator 從 `cortex status` 的 `not_claimable` 區塊就看得到全部 24 筆與各自的
`run_id`）。簽名逐項為必要條件，測試逐欄位釘住：停在 build／verify／review 的 `needs_human`
run（握有真正工作成果）不會被誤判。

實機清理（**待 merge 並部署後由 operator 執行**）：

```bash
cortex status \
  | jq -r '.not_claimable[] | select(.reason=="claim-blocked-stale-run")
           | "\(.work_id) \(.stale_run_id)"' \
  | while read -r work_id run_id; do
      cortex work abandon "$work_id" --repo hamanpaul/paulsha-cortex \
        --expected-run-id "$run_id" --actor operator \
        --reason '#669 claim-blocked zombie'
    done
```

`abandon` 對這批 run 的前置驗證全部成立（ongoing、無 active job、非 ship phase、無 PR
refs、`issue_refs`／`openspec_refs` 與當前 authority 相符），會留下
`cortex-work-abandon/v1` 稽核 evidence 並把 run 轉為 `superseded` + `planning_released`
（因此不擋日後重新 claim）。**副作用需知**：每筆 abandon 各消耗該 work item 的一個
semantic-reclaim 世代（上限 3）；日後若某 work item 因此接近熔斷，以既有的
`cortex work reset-reclaim-budget` 明示重置。清理完成後那些 work item 只會留在
`not_claimable` 清單，不再佔用 `attention`。

之所以不做「下次 tick 自動收」：那正是 `#373` 明文禁止的形態，且會在 operator 不知情下
燒掉世代額度；不做 migration：registry 的 durable state migration 風險遠高於一次性的
operator 動作，而這批 run 的數量有限、簽名精確。

## 測試

新增 `tests/test_claim_not_claimable_669.py`（14 項）：

- `missing_issue` 時 **`workflow_starter` 一次都不得被呼叫**（start／resume 皆驗），
  registry 與 delivery journal 零殘留。
- ledger 落一筆可查的紀錄、欄位齊全、`next_step_hint` 具體到可照抄；重複掃描只累加
  `observations`，不會每輪長出新列。
- `cortex status` 快照確實帶出 `not_claimable` 且 `attention` 為空；文字模式印得出理由與
  下一步。
- **真的該建 run 的情況仍然建**（有 issue 的 work item 照常 `claim` 出 ongoing run，且不
  留 ledger 紀錄）——不得為了消噪音把正常路徑一併關掉。
- issue 補上之後 ledger 自動清空。
- 殭屍 run 帶著 `stale_run_id` 與 `cortex work abandon …` 指令浮現；停在 build 的真正卡住
  的 `needs_human` run 不被重新分類；殭屍簽名逐欄位驗證為必要條件。
- ledger 對損毀 fail-closed，但呈現面回空清單不讓 status 死掉。

同時更新既有測試的預期（`test_work_actions.py`、`test_work_actions_auto_claim_pressure.py`、
digest 兩檔的 counts）。全套 **4177 passed / 21 skipped**。

> 附帶發現：`test_periodic_auto_scan_claims_labeled_work_and_persists_missing_issue` 舊版之所以
> 通過，是因為建立 missing_issue run 時 `_manager_create_workflow_run` 會把同 (repo, work_id)
> 的 ongoing run 全部標成 superseded——**上一段剛 claim 成功的 run 就是被這個 bug 作廢的**。
> 這是同一個缺陷的第二層傷害。該測試已改用獨立的 coordinator root 隔離兩個情境。

## Checklist

- [x] 分支 `feature/669-claim-missing-issue`，未 commit 到 `main`
- [x] `changelog.d/669-claim-missing-issue.md` 已新增並 commit
- [x] `CHANGELOG.md [Unreleased] / Fixed` 已補 entry
- [x] `README.md`（`cortex status` 欄位）與 `docs/unified-work-lifecycle.md`（claim 政策）已同步
- [x] 全套測試通過（4177 passed / 21 skipped）
- [x] 本機 `policy_check` 帶 PR 上下文跑過
- [x] 未觸碰實機狀態；清理由 operator 執行

Closes #669
