### PR TITLE
docs(trust-root): planner 降權的 spec／design／實作切分計畫（#672）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,37 @@
 ## [Unreleased]
 
 ### Added
+- **#672：planner 降權的設計交付（spec ＋ design ＋ 實作切分計畫，零 code）**——planning
+  （define／brainstorm）從來沒有被降權：`planning_runtime.py:830` `_invoke_json()` 以
+  `subprocess.run` 在**呼叫端行程內**執行、`:43` `_planning_argv()` 回傳裸 executor argv
+  （無 `systemd-run`／無 shim／無模板 unit），而呼叫端是以 `User=cortex-manager` 執行的
+  daemon（`manager_daemon.py:970`／`:1241`）。#615（M2）只把 **reviewer** 導上
+  `cortex-reviewer-job@.service`（`launcher.py:1239 _is_review_persona()`），planner 走的是
+  完全不同的一條 code path——`job_runner.py:405-408` 的 rationale 與
+  `permgen.deferred_run_dependencies()` 第四項都已把這條記成逾期項，後者的 `disposition`
+  給的兩條路之一正是本票的裁決（「planning 一律走降權 job」）。**這是結構性搬遷，因此本票
+  只出設計，不動一行 `paulsha_cortex/`。** 設計定案 R1–R8：執行身分（單一開關、不新增第二個）、
+  一次性 sandbox 的**十條防線逐條對應表**（operator 樹保護由「事後偵測」升級為 mount 層
+  不可寫；claude hermetic config 升級為帳號隔離）、probe 快取（指紋含 `PSC_JOB_RUNNER` 與
+  **模板 unit 檔本身**，fail-closed）、剖面零新增判定點、憑證由登記表機械導出（沿用 #671 的
+  `IN_PLACE_CONTENT_WRITE_ASSETS` 與 `inapplicable_home_anchored_assets()`，不重造）、
+  錯誤語意三分 ＋ **`no-heterogeneous-planner` 攜帶逐候選拒因表**（讓 #670 那種「格式問題被
+  報成拓撲問題」結構上不可能；PR #674 已修好 probe 那一端，本設計補的是「診斷活著抵達上游」
+  那一層）、逾時由 Manager 側 `systemctl stop` 強制終止。**剖面面沒有前置**——現行
+  `EXECUTOR_HARDENING_PROFILE` 實測可用（八份 unit 全帶 `SystemCallErrorNumber=EPERM`，
+  被過濾的 syscall 回 `EPERM` 而非 `KILL_PROCESS`，codex／copilot 在 `jit` 剖面 rc=0）。
+  另以 **D13** 把加固面的驗證方法定為設計驗收的依據：一律從已落檔 unit **機械讀出全部
+  property**，不得手抄子集——**該機制已由 PR #677 落地**（`unit_replica_properties()`／
+  CLI `trust_root unit-replica`／runbook 共用探針 `psc_run_under`），本設計消費它、不重造。
+  規則的理由仍記在設計裡（planner 是下一個會做這種宣稱的地方）：判準**雙向**，本 repo
+  已有四個實例、兩個方向都出現過（#638／#657 偏寬得假綠，#673 原 body 與其 repro 偏嚴得
+  假紅）。並消費 #677 的第二個維度（seccomp 過濾語意在剖面**之外**）——probe 快取的指紋
+  因此含**模板 unit 檔本身**而非只有剖面名，`executor-silent-exit` 的診斷帶
+  `seccomp_filter_is_fatal()` 的結果。誠實標註 4 條安全退步與 8 條未決裁決；實作切分成
+  六張票，其中三張不依賴任何部署面改動、可獨立 land。**另查到一條沒有票的部署缺口**：
+  `/opt/cortex/etc/cortex-manager.env` 未宣告 `PSC_REVIEWER_PATH` ⇒ 降權 job 拿到 PID 1 的
+  預設 PATH ⇒ `claude`／`agy` rc=127、`codex` **安靜地**解到系統層 `0.42.0`（toolchain 為
+  `0.147.0`，不會失敗、只是產出來自舊 CLI），**今天的 reviewer job 已受影響**。
 - **#667：R3 testpilot case 素材盤點——四路盲測 sweep 合成為 102 筆去重候選清單**——
   `docs/superpowers/workstreams/r3-testpilot-case-corpus/{todo.md,case-candidates.md}`。
   **唯一產出是文件**：不寫 case yaml、不建 harness、不動 `paulsha_cortex/`（`#667` scope

--- a/changelog.d/672-planner-downgrade-design.md
+++ b/changelog.d/672-planner-downgrade-design.md
@@ -1,0 +1,129 @@
+### Added
+
+- **#672：planner 降權的設計交付（spec ＋ design ＋ 實作切分計畫，零 code）**——
+  planning（define／brainstorm）從來沒有被降權：`planning_runtime.py:830` `_invoke_json()`
+  以 `subprocess.run`（同檔 `:1070` 的預設 runner）在**呼叫端行程內**執行，`:43`
+  `_planning_argv()` 回傳的是裸 executor argv（無 `systemd-run`、無 `cortex-job-shim`、
+  無模板 unit），而呼叫端是以 `User=cortex-manager` 執行的 daemon
+  （`manager_daemon.py:970`／`:1241`）。`#615`（M2）建了 `cortex-reviewer-job@.service`
+  並把 **reviewer** 導上去（`launcher.py:1239 _is_review_persona()`），planner 走的是
+  完全不同的一條 code path。repo 自己已經在兩處把這條記成逾期項：
+  `job_runner.py:405-408` 的 `JOB_ROLE_REVIEW` rationale，以及
+  `permgen.deferred_run_dependencies()` 第四項——後者的 `disposition` 給的兩條路之一
+  正是「裁決『Manager 不直接跑模型、planning 一律走降權 job』」，本票走那一條。
+
+  **這是結構性搬遷，因此本票只出設計，不動一行 `paulsha_cortex/`。**
+  交付：`docs/superpowers/specs/planner-job-downgrade-{spec,design}.md`、
+  `docs/superpowers/plans/planner-job-downgrade.md`、
+  `openspec/changes/2026-08-18-planner-job-downgrade/`（三件套 ＋
+  `persona-workflow-orchestration` 的 delta）。
+
+  設計定案的八條（R1–R8）：
+
+  - **R1 執行身分**——降權模式下 planning 的四個 adapter 與**所有 probe** 經
+    `JOB_ROLE_REVIEW` 的模板 unit 執行；`direct` 逐字不變；執行後端的選擇只有一個輸入
+    （`job_runner.resolve_runner_mode`，與 launcher 同一支函式），**刻意不新增第二個
+    開關**——第二個開關的失效模式是「以為降權了、其實沒有」，而那種失敗看起來是成功的。
+  - **R2 一次性 sandbox 的等價重建**——把 `_invoke_json` 現行的**十條**防線逐條列成
+    對應表，每條標成等價／升級／退步。operator 工作樹的保護從「事後比對雜湊 ＋
+    fail-closed」**升級**為 `ProtectSystem=strict` ＋ RWP 不含 `repo-source-tree` 的
+    mount 層不可寫；claude 的 hermetic config 從「複製憑證 ＋ 改 env」**升級**為帳號
+    隔離 ＋ `ProtectHome=yes`。兩條**退步**逐條指名（見下）。
+  - **R3 probe 快取**——`build_production_planning_runtime()` 目前每次建構都重跑全部
+    probe，而 `_probe_identity` 每次做**兩次整棵 repo 的 `copytree`**、
+    `probe_agy_capability` 是**兩次 CLI 呼叫**，且該函式由 periodic tick 呼叫。定案：
+    Manager-owned durable 快取，指紋涵蓋 `PSC_JOB_RUNNER`／executor 可執行檔 inode／
+    憑證檔／加固剖面 ＋ **模板 unit 檔本身**／roster 內容雜湊，一律 **fail-closed**
+    （絕不因「上次是 ready」而在無法重探時沿用）。模板 unit 進指紋是刻意的：**任何**讓
+    operator 重跑產生器落新 unit 的改動，在落檔那一刻就讓全部快取自動失效重探，
+    不靠任何人記得清快取。
+  - **R4 剖面路由**——剖面唯一來源是 `prepare_systemd_template(executor=…)`，planning
+    側零對應表。**現行 `EXECUTOR_HARDENING_PROFILE` 實測可用**（codex／copilot → `jit`，
+    claude／agy → `strict`），planner 上 job **不需要任何剖面面的前置修正**。
+    本設計早期版本寫著「假設 #673 已修」，該前提已由開票者更正撤回並移除（#673 由
+    **PR #677** 以「不放寬任何 syscall」收尾）：八份 unit
+    （六份 job 模板 ＋ manager ＋ monitor）**全部帶 `SystemCallErrorNumber=EPERM`**
+    （`cortex-reviewer-job@.service:148`、兩份 `-jit` 的 `:162`、`cortex-manager.service:89`），
+    從權限產生器落地的第一個 commit 起就在；有這一條時被過濾的 syscall 回 `EPERM` 而非
+    `SECCOMP_RET_KILL_PROCESS`，V8 走 fallback ⇒ codex／copilot 照常啟動。真 unit 完整
+    property 集合下實測：codex／copilot 在 `jit` 剖面 rc=0，claude／agy 兩剖面皆 rc=0
+    ——**預設派工路徑沒有壞**。實際被過濾的是 `pkey_alloc`（`@pkey`），不是原先猜測的
+    `landlock_*`／`seccomp`（`@sandbox`）。**另消費 #677 建立的第二個維度**：seccomp
+    過濾語意在剖面**之外**（`PROFILE_LOCKED_KEYS` 兩剖面逐字相同、`filtered_syscalls`／
+    `filtered_syscall_surfaces()`／`seccomp_filter_is_fatal()`）——因此 probe 快取的指紋
+    不能只放剖面名（要放**模板 unit 檔本身**），而 `executor-silent-exit` 的診斷要帶
+    `seccomp_filter_is_fatal()` 的結果（#673 走偏正因為當時沒有任何地方回答得了它）。
+  - **R5 憑證**——0818 已部署的 `.codex/auth.json`（檔 job-owned／目錄 root-owned）與
+    `.gemini → cache/gemini` 在**功能上足夠**，**治理上不足**：實機 reviewer 模板 unit 的
+    `ReadWritePaths` 只有 `cache` 與 `review-verdicts`，**不含憑證檔**——unit 自己的註解
+    花七行描述它該怎麼掛，但登記表只有 `builder-executor-credential` 一列，產生器產不出來。
+    定案沿用 #671 已建立的 `IN_PLACE_CONTENT_WRITE_ASSETS` 與
+    `inapplicable_home_anchored_assets()`（後者正是把 #640 當年「不敢登記第二份憑證」的
+    唯一理由拆掉的那一個），**不重造機制**。
+  - **R6 錯誤語意**——三分：`planning-job-start-failed`／`planning-executor-failed`
+    （含 `executor-silent-exit` 子類：rc≠0 而 stdout 與 stderr 皆空，即「連錯誤訊息都
+    沒有」的那一種；本設計不對其成因預設任何特定 syscall）／`planning-output-malformed`。
+    並把 `no-heterogeneous-planner` 從一個**沒有任何附加資訊的字面值**改成
+    「結論 ＋ 逐候選拒因表」——`select_secondary_planner()` 今天把每個候選落選的真正理由
+    用 `continue` 吃掉，#670 的 code fence 偽失敗因此被報成拓撲問題。**PR #674 已把
+    probe 那一端修好**（`strip_code_fence()`／`stdout_excerpt()`／`agy models` 兩欄漂移
+    造成的 100% `model-not-listed`），但那份診斷仍會在上游被吃掉——兩者剛好接得起來，
+    缺任何一半都還是查不出原因。拒因表含 environment 級原因時 classification 改判
+    `environment`，讓 `recover-planning` 有路（今天一律 `content` ⇒ 死路）。
+    快取的 ledger 形狀沿用 PR #675 的 `not_claimable`（`schema`／`items`／
+    `first_observed_at`／`observations`／條件解除自動清除／原子寫入），只在一處刻意不同：
+    `not_claimable.load_ledger()` 對壞檔 raise，probe 快取**不得** raise（一份輔助紀錄
+    不該取得否決整個 planning 的權力），改為「視為 miss ＋ 落可辨識診斷」，
+    而 fail-closed 的實質不變——**它永遠不會因為讀不到而回答 ready**。
+  - **R7 逾時**——實機 `cortex-reviewer-job@.service` 沒有 `RuntimeMaxSec=`／
+    `TimeoutStartSec=`，而 `systemctl start --wait` 會一路等；定案由 Manager 側
+    `wait(timeout)` → `systemctl stop` 強制終止，並確認 unit 離開 active（否則下一輪
+    撞 `instance-busy`，錯誤訊息與逾時無關）。
+  - **R8 驗收 ＋ D13**——凡宣稱「某 executor 在某加固剖面下**可用或不可用**」，驗證環境
+    MUST 由**已落檔 unit 機械讀出全部 property** 再複製，MUST NOT 手抄子集。
+    **該機制已由 PR #677 落地**（`permgen.unit_replica_properties()` 契約「全帶，不選」、
+    少任一加固鍵即 `UnitReplicaDriftError` 且 stdout 保持空；CLI `trust_root unit-replica`；
+    runbook 共用探針 `psc_run_under`），本設計**消費它、不重造**——實作票的矩陣不得自行組
+    `--property=` 清單。成對約束（`SystemCallFilter=` 必與 `SystemCallErrorNumber=` 同進
+    同出）已由 `PROFILE_LOCKED_KEYS` 固化。規則的**理由**仍記在設計裡，因為 planner 是
+    下一個會做這種宣稱的地方：**判準雙向，本 repo 已有四個實例、兩個方向都出現過**：#638、#657
+    手抄得比 production 寬 ⇒ **假綠**（斷言真空）；#673 原 body 與其 repro 手抄得比
+    production 嚴（漏 `SystemCallErrorNumber=EPERM`）⇒ **假紅**，並據此開票要求放寬
+    seccomp。假紅更貴——它會讓人去「修」一個不存在的問題，並在修的過程中放寬一條真的
+    有用的加固項。因此規則的正確形式是「驗證環境 ≠ production 環境在結構上不可能」，
+    與偏差方向無關。#643 早已記錄過 `SystemCallErrorNumber=EPERM` 這一條，#673 仍然
+    重蹈——**已經寫下來的教訓，在下一次用手抄複本時不會自動生效**，這正是它必須變成
+    機械規則而非一段註解的理由。矩陣每格另記「解析到的絕對路徑 ＋ 版本字串」。
+
+  **本票查證時新發現、尚無票的部署缺口（一張）**：PATH 宣告缺口——`/opt/cortex/etc/cortex-manager.env`
+  **沒有宣告 `PSC_REVIEWER_PATH`**，Manager unit 也沒有 `Environment=PATH=` ⇒ 降權 job
+  的 PATH 就是 PID 1 的預設（`/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/snap/bin`），
+  而 `/opt/cortex/toolchain/bin` 不在其中。實測：`codex` 解到 `/usr/bin/codex`＝
+  `codex-cli 0.42.0`（toolchain 那份是 `0.147.0`），`claude`／`agy` **不存在** ⇒ rc=127。
+  reviewer 模板 unit 的註解已預先寫過這條該怎麼修，只是那一行從未落到 env 檔裡。
+  **這條同時影響今天的 reviewer job**，需獨立開票，且是 planner 上 job 的前置。
+  `claude`／`agy` 的 rc=127 至少會失敗；**`codex` 那一種不會失敗**——它安靜地用舊 CLI
+  產出結果，只有把 `resolved_binary` 與 `binary_version` 記進失敗診斷與驗收矩陣才看得見。
+
+  **誠實標註的安全退步（4 條）**：
+  (R-1) 「模型弄髒自己的拋棄式 sandbox」的偵測在 job 模式下 Manager 無法執行
+  （job-owned 0700 樹進不去，而讓 job 自證違反 #628／#540）——失去的是一個**行為訊號**，
+  不影響任何 durable state；選未決項 U-2 的「scratch 對 job 唯讀」可把它從退步變成
+  「結構上不可能」。
+  (R-2) codex 的 `-o last.json` 第二輸出候選消失，`_extract_json` 從雙候選退成單候選。
+  (R-3) planner 帳號同時持有兩個 provider 的憑證（0818 已部署的事實），該帳號被攻陷時
+  兩邊 token 一起失，而 planner 正是吃 untrusted issue 內容的角色。
+  (R-4) 逾時終止從「父進程 kill 子進程」變成「Manager `systemctl stop`」。
+
+  **未決裁決（8 條，交 operator，本票不擅自決定）**：sandbox 要不要放 repo 複本（U-1）、
+  scratch 對 job 可寫或唯讀（U-2）、codex 第二輸出通道要不要保留（U-3）、planner 帳號
+  是否核可雙 independence domain 憑證（U-4）、`executor_credential_relpath` 要不要擴成
+  per-(account, executor) 表（U-5）、probe 快取 TTL 與 warm-up 入口（U-6）、agy 狀態樹
+  在登記表裡的表達方式（U-7）、模板 unit 要不要加 `RuntimeMaxSec=` 第二層保險（U-8）。
+
+  **實作切分成六張票**（A 拒因表／三分 → B invoker 抽象 → C probe 快取 → E job
+  invoker → F 切換與宣稱更正；D permgen codify 與 E 平行），A／B／C **不依賴任何部署面
+  改動**，可在 direct 部署上獨立 land 並各自產生價值；切換本身則是一次到位（probe 快取
+  的指紋含 `PSC_JOB_RUNNER`，一個部署不能一半走 job、一半走 in-process）。票 E 的前置
+  只有一張獨立的部署面票（PATH 宣告），**沒有剖面面前置**——原本另列的「runbook 驗證
+  方法改機械讀取」已由 PR #677 一併完成。

--- a/docs/superpowers/plans/planner-job-downgrade.md
+++ b/docs/superpowers/plans/planner-job-downgrade.md
@@ -1,0 +1,255 @@
+---
+status: accepted
+work_item: planner-job-downgrade
+---
+
+# planner-job-downgrade Plan
+
+對應 spec：`docs/superpowers/specs/planner-job-downgrade-spec.md`
+對應 design：`docs/superpowers/specs/planner-job-downgrade-design.md`
+issue #672。
+
+**本 plan 描述的是後續實作票的切分，不是本票的工作項。** 本票（#672 設計票）的交付
+是 spec ＋ design ＋ 本 plan ＋ openspec 三件套 ＋ changelog，**不含任何
+`paulsha_cortex/` 的程式修改**。
+
+## Tasks
+
+### 0. 依賴與前置（不是本設計的工作項，但票 E 起算的 blocker）
+
+**剖面面沒有前置。** 本 plan 早期版本列了「#673 已 merge」為 blocker，該前提已由
+開票者更正撤回並移除：八份 unit 全帶 `SystemCallErrorNumber=EPERM`，被過濾的 syscall
+回 `EPERM` 而非 `KILL_PROCESS`，codex／copilot 在 `jit` 剖面實測 rc=0，
+claude／agy 兩種剖面皆 rc=0——**現行 `EXECUTOR_HARDENING_PROFILE` 就是對的**
+（見 design D6）。planner 上 job 不需要任何剖面面的修正。#673 已由 **PR #677** 以
+「不放寬任何 syscall」收尾，且該 PR 順帶把本 plan 原本要另開的「runbook 驗證方法改
+機械讀取」那張票一併做掉了（見下）。因此**票 E 的前置只剩一條：PATH 宣告**。
+
+- [ ] **PATH 前置票**（本票新查到，尚無 issue）：`/opt/cortex/etc/cortex-manager.env`
+      補 `PSC_REVIEWER_PATH=/opt/cortex/toolchain/bin:/usr/local/bin:/usr/bin:/bin`
+      （值由 `permgen.job_path_value()` 產生器出，operator 落進 root-owned
+      EnvironmentFile）。
+      現況：該變數不存在 ⇒ job 的 PATH 是 PID 1 預設 ⇒ `claude`／`agy` rc=127、
+      `codex` 解到系統層 `0.42.0`（toolchain 是 `0.147.0`）。
+      **這條同時影響今天的 reviewer job**，應獨立開票，不掛在 planner 票下。
+      驗收：以 `cortex-reviewer-job@probe` 的完整 property 集合實跑，逐 executor
+      記錄「解析到的絕對路徑 ＋ 版本字串」，與 `/opt/cortex/toolchain/bin` 逐條相符。
+- [x] ~~**runbook 驗證方法改機械讀取前置票**~~ ——**已由 PR #677 完成，不需另開票**。
+      #677 新增 `permgen.unit_replica_properties()` 與 CLI `trust_root unit-replica`
+      （契約「全帶，不選」，`require_hardening=True` 下落檔 unit 少任一加固鍵即
+      `UnitReplicaDriftError` 且 stdout 保持空），並把 runbook 4e／5-2b／5-3／5-4 的
+      手抄子集全部改走共用探針 `psc_run_under`；5-2b 由「正向四段」改為
+      4 executor × 2 剖面 × 2 角色 unit 的全矩陣 ＋ 反向對照。
+      **票 E 的驗收矩陣直接消費這些，不得自行組 property 清單**（見 design D13）。
+- [ ] **operator 裁決 U-1 ～ U-8**（見 design 的未決問題總覽）。U-2 影響票 E 的實作
+      形狀；U-4／U-5 影響票 D 的範圍；其餘可在對應票內收。
+
+### 1. 票 A｜錯誤語意三分 ＋ 逐候選拒因表（對應 R6，**不依賴任何部署面改動**）
+
+最先做，因為它**立刻**降低今天的排查成本。PR #674（#670）已經把 probe 那一端的診斷
+補齊（`strip_code_fence()`／`stdout_excerpt()`），票 A 要做的是讓那份診斷**活著抵達**
+blocking reason——兩者剛好接得起來，缺任何一半都還是查不出原因。
+
+- [ ] `tests/test_planning_failure_taxonomy_672.py`（TDD RED）：
+  - `test_no_heterogeneous_planner_reason_carries_per_candidate_rejections`：
+    給一組 probe（agy=not-ready/malformed-output、claude=not-ready/safe-probe-failed、
+    codex=same-domain），`run_heterogeneous_brainstorm` 的 reason 必須同時含三個
+    executor 名與各自的拒因，且 `malformed-output` 的 diagnostic 帶得出 stdout 前綴。
+  - `test_probe_diagnostic_survives_into_blocking_reason`：probe 的 diagnostic 不得
+    在 `select_secondary_planner` 被吃掉。
+  - `test_environment_grade_rejection_reclassifies_to_environment`：拒因表中有任一
+    environment 級拒因時，`_classify_planning_failure` 回 `environment`（而非 `content`），
+    使 `_resume_decision` 得以浮現 `recover-planning`。
+  - `test_content_grade_rejections_stay_content`：全部拒因都是 `same-domain` 時仍為
+    `content`（不得把拓撲問題誤判成環境問題——反向誤報同樣不可接受）。
+- [ ] `paulsha_cortex/coordinator/model_identities.py`：新增
+      `CandidateRejection` dataclass；`SecondarySelection` 增 `rejections` 欄位；
+      `select_secondary_planner()` 的每個 `continue` 改成記錄一筆拒因。
+- [ ] `paulsha_cortex/coordinator/planning.py`：`run_heterogeneous_brainstorm` 把拒因表
+      渲染進 `BrainstormResult.reason`（格式見 design D8）。
+- [ ] `paulsha_cortex/coordinator/manager.py`：`_classify_planning_failure` 增一條
+      environment 例外（比照既有的 `_is_planning_authority_residue_failure`／
+      `_is_planning_transient_service_failure`／`_is_planning_worktree_drift_failure`
+      三條，同一個模式，不新發明）。
+- [ ] 三個失敗族的具名常數（`planning-job-start-failed`／`planning-executor-failed`／
+      `planning-output-malformed` ＋ `executor-silent-exit` 子類）先定義，票 C 才有東西可落。
+- 驗收：既有 planning 測試一行不改全綠；新測試全綠；`no-heterogeneous-planner` 的
+  reason 可用正規表示式釘住必含拒因表。
+
+### 2. 票 B｜`PlanningInvoker` 抽象（對應 R1 的結構面，**純重構、行為零改變**）
+
+- [ ] `tests/test_planning_invoker_672.py`（TDD RED）：
+  - `test_in_process_invoker_preserves_sandbox_contract`：sandbox 被弄髒仍拋
+    `planning launcher modified disposable read-only sandbox`。
+  - `test_in_process_invoker_preserves_operator_drift_containment`：operator 樹 drift
+    仍走 `_contain_operator_drift`，`PLANNING_WORKTREE_DRIFT_MESSAGE_PREFIX` 逐字不變
+    （那是下游分類契約）。
+  - `test_invoker_selection_follows_resolve_runner_mode`：`PSC_JOB_RUNNER` 的值是**唯一**
+    輸入；非法值 fail-closed；不存在第二個開關。
+- [ ] `paulsha_cortex/coordinator/planning_runtime.py`：抽出 `PlanningInvocation`／
+      `PlanningInvoker`／`PlanningOutcome`；把現行 `_invoke_json` 的執行段搬進
+      `InProcessPlanningInvoker`；JSON 抽取（`_extract_json`／`_find_json_object`／
+      envelope 處理）留在共用層。
+- [ ] `build_production_planning_runtime()` 接受 `invoker` 參數（預設由
+      `resolve_runner_mode` 決定），四個 adapter 與 `_probe_identity` 全部改走它。
+- [ ] `probe_agy_capability()` 目前直接吃 `runner`（＝`subprocess.run`）且**繞過**
+      `_invoke_json` 的全部防線——把它一併改走 invoker，兩次 CLI 呼叫各算一次 invocation。
+- 驗收：既有 planning／probe 測試**一行不改**全綠（這就是「行為零改變」的定義）；
+  `git grep -n "subprocess.run" paulsha_cortex/coordinator/planning_runtime.py` 只剩
+  `InProcessPlanningInvoker` 內部一處。
+
+### 3. 票 C｜probe 結果快取（對應 R3；依賴票 A 的診斷欄位、票 B 的 invoker）
+
+- [ ] `tests/test_planning_probe_cache_672.py`（TDD RED）：
+  - `test_cache_key_includes_job_runner_mode`：`PSC_JOB_RUNNER` 由 `direct` 改
+    `systemd-template` ⇒ 快取必失效（**這條是本票最重要的不變式**）。
+  - `test_cache_invalidated_by_executor_binary_fingerprint`：可執行檔 mtime／inode 改變 ⇒ 失效。
+  - `test_cache_invalidated_by_template_unit_fingerprint`：模板 unit 檔改變 ⇒ 失效
+    （＝任何讓 operator 重跑產生器的改動都自動全重探）。
+  - `test_cache_invalidated_by_credential_fingerprint`：憑證檔 mtime／size 改變 ⇒ 失效。
+  - `test_cache_invalidated_by_roster_digest`：overlay 改動 ⇒ 失效。
+  - `test_corrupt_cache_is_miss_not_ready`：JSON 壞掉 ⇒ 重探，**絕不**沿用舊 ready。
+  - `test_expired_ready_never_served_when_reprobe_fails`：ready 過期且重探失敗 ⇒ not ready。
+  - `test_cache_records_failure_diagnostics`：失敗側存 reason／diagnostic／rc／
+    stdout 前 200 字／unit／resolved_binary／binary_version。
+  - `test_cache_asset_not_in_any_job_unit_rwp`：登記表資產不出現在任一 job 模板 unit
+    的 `ReadWritePaths` 產出中。
+- [ ] `paulsha_cortex/trust_root/registry.py`：新增資產 `planning-probe-cache`
+      （`<coordinator_root>/planning-probe-cache.json`，Manager-owned 0600，
+      writers／readers 只有 `Principal.MANAGER`），並補進
+      `permgen.RUN_EXTERNAL_DEPENDENCIES` 的雙向封閉（否則
+      `unlisted_roster_entries()` 的測試會紅）。
+- [ ] `paulsha_cortex/coordinator/planning_probe_cache.py`（新檔）：指紋計算、讀寫、
+      TTL、fail-closed 語意。
+- [ ] `build_production_planning_runtime()` 改成先查快取、miss 才 probe。
+- 驗收：direct 模式下連續兩次建構 runtime，第二次的 executor 呼叫次數為 0；
+  改動任一指紋輸入後第二次必須重探；`python3 -m pytest tests/ -q` 全綠。
+
+### 4. 票 D｜permgen 把 planner 憑證面 codify（對應 R5；依賴 U-4／U-5／U-7 裁決）
+
+- [ ] `tests/test_trust_root_planner_credentials_672.py`（TDD RED）：
+  - `test_reviewer_planner_credential_is_registered`：登記表有
+    `reviewer-planner-executor-credential`，且列在 `IN_PLACE_CONTENT_WRITE_ASSETS`。
+  - `test_reviewer_template_rwp_includes_credential_file_not_parent`：reviewer 模板
+    unit 的 `ReadWritePaths` 含**檔案本身**，不含父目錄。
+  - `test_two_way_scheme_unaffected`：二分方案下該資產經
+    `inapplicable_home_anchored_assets()` 機械排除，Manager unit 的 RWP 不多出
+    不存在的路徑（＝#640 當年不敢登記的那個理由已被 #671 拆掉）。
+  - `test_deferred_dependencies_shrink`：`deferred_run_dependencies()` 不再含
+    `reviewer-planner-executor-credential`、`reviewer-planner-codex-hooks`、
+    `manager-claude-credential` 三項（第三項因為本票的裁決是「planning 一律走降權
+    job」，Manager 不再需要 claude 登入態）。
+- [ ] `paulsha_cortex/trust_root/registry.py`：新增憑證資產列；
+      `paulsha_cortex/trust_root/permgen.py`：加進 `IN_PLACE_CONTENT_WRITE_ASSETS`、
+      移除對應的 `DeferredDependency`、`asset_paths()` 補 `codex-hooks` 的 per-account 版。
+- [ ] 依 U-5 的裁決處理 `executor_credential_relpath`（維持單一 vs 擴成
+      per-(account, executor) 表）。若裁決是擴表，本票範圍會顯著變大，應再切一張子票。
+- [ ] 依 U-7 的裁決處理 agy 狀態樹（symlink 資產 vs env 導向 `cache`）。
+- [ ] runbook `docs/superpowers/runbooks/trust-root-phase2b-setup.md` 第 4e 步：
+      補「逐帳號 × 逐 executor」的反向驗證矩陣（#668 的 C 項），並固定部署順序
+      「憑證落位 → 重跑產生器 → daemon-reload → `systemctl status` 確認 unit 起得來」。
+- 驗收：`python -m paulsha_cortex.trust_root permissions` 產出的 reviewer 模板 unit
+      逐字含憑證檔那一條 RWP；二分方案的產出不含它；deferred 清單縮短且測試釘住。
+
+### 5. 票 E｜`JobPlanningInvoker`（對應 R1／R2／R4／R7／R8；依賴票 B、票 C、PATH 前置票）
+
+本票是整個搬遷的主體，也是唯一會改變執行身分的一張。
+
+- [ ] `tests/test_planning_job_invoker_672.py`（TDD RED）：
+  - `test_role_is_review_and_not_derivable_from_spec`：角色恆為 `JOB_ROLE_REVIEW`，
+    且 job spec 不含任何身分／剖面欄位（`SPEC_FORBIDDEN_KEYS` 兩端各擋一次）。
+  - `test_profile_comes_only_from_executor`：剖面唯一輸入是 `identity.executor`；
+    未登記 executor（例如 `cg`）fail-closed。
+  - `test_planning_wrapper_has_no_gate_bundle_verdict_sentinel`：planning 的 wrapper
+    只有模型 argv 一段（不靠既有旗標碰巧為 None）。
+  - `test_instance_name_unique_per_invocation`：questioner／secondary／integrator／probe
+    的 instance 名互不相同且過 `JOB_SEGMENT_RE`。
+  - `test_timeout_stops_unit_and_classifies_as_timeout`：逾時 ⇒ 發 `systemctl stop`
+    ⇒ 落 `planning-job-timeout`（`environment`）⇒ 確認 unit 離開 active。
+  - `test_job_start_failure_maps_to_job_start_failed`：`JobRunnerError` 各族 ⇒
+    `planning-job-start-failed`。
+  - `test_silent_rc1_maps_to_executor_silent_exit`：rc=1、stdout／stderr 皆空 ⇒
+    `planning-executor-failed / executor-silent-exit`，reason 指名 unit／剖面／
+    resolved_binary（＝這一類「連錯誤訊息都沒有」的失敗不得再被誤報成拓撲問題），
+    並帶 `permgen.seccomp_filter_is_fatal()` 的結果——「該不該懷疑 seccomp」現在有
+    機械答案（PR #677），不得讓下一個人再猜一次。
+  - `test_malformed_output_maps_to_output_malformed`：rc=0、輸出非 JSON ⇒
+    `planning-output-malformed`，detail 帶 stdout 前綴。
+  - `test_operator_tree_not_in_job_rwp`：`repo-source-tree` 不在 reviewer 模板 unit 的
+    RWP 產出中（＝ D-e 的 kernel 層保證有測試釘住，不只靠 unit 註解）。
+- [ ] `paulsha_cortex/coordinator/planning_job.py`（新檔）：`JobPlanningInvoker`。
+      復用 `job_runner.prepare_systemd_template`／`build_job_spec`／`write_job_spec`／
+      `build_systemctl_start_argv`／`build_manager_exit_recorder_argv`／
+      `confirm_template_instance_started`；**不複製**任何一份 job_runner 的邏輯。
+- [ ] 依 U-1／U-2 的裁決實作 scratch（空 vs 複製；job 可寫 vs 唯讀＋`PrivateTmp`）。
+- [ ] 依 U-3 的裁決處理 codex 的第二輸出候選。
+- [ ] 實機驗收矩陣（R8）：`{codex, claude, agy} × {實際剖面}`，在**真實 unit 的完整
+      property 集合**下實跑，每格記錄 rc、stdout 前 80 字、**解析到的絕對路徑與版本
+      字串**。矩陣 MUST 走 runbook 第 4e 步的共用探針 `psc_run_under`（其加固面由
+      `permgen.unit_replica_properties()` 全量導出），MUST NOT 自行組 `--property=`
+      清單（design D13）。本 repo 已有四個手抄子集的事故，**兩個方向都出現過**
+      （#638／#657 假綠，#673 原 body 與其 repro 假紅）。
+- 驗收：矩陣全綠；`cortex-manager` 的行程樹在一輪完整 planning 期間不出現任何
+      executor 可執行檔（以 `systemd-cgls` 或 `ps --ppid` 佐證）。
+
+### 6. 票 F｜切換、宣稱更正與收尾（依賴票 D、票 E）
+
+- [ ] 生產部署切換：確認 `PSC_JOB_RUNNER=systemd-template`（已是），重啟 daemon，
+      跑一輪真實 define 並收集 evidence。
+- [ ] 更正既有宣稱（#672 明列，且屬「不得順手宣稱」紀律）：
+  - `docs/superpowers/runbooks/trust-root-phase2b-setup.md`：把「reviewer/planner
+    啟動面降權完成」改成分述，並在本票落地後才改回「兩者皆已降權」。
+  - #615 的 M2 完成宣稱：補一條註記說明它當時只涵蓋 reviewer。
+  - `job_runner.py` 的 `JOB_ROLE_REVIEW` rationale：把「在此之前它們仍在 Manager
+    行程內」的時態改掉（那句話對 planner 一直是現在式）。
+  - D6 的全稱宣稱（「三分已生效」）：在本票落地前對 planner 這一支不成立。
+- [ ] `permgen.deferred_run_dependencies()` 的 `manager-claude-credential` 移除，
+      並在 CHANGELOG 記錄「裁決＝planning 一律走降權 job」（那正是該項
+      `disposition` 給的兩條路之一）。
+- [ ] 若 U-2 的裁決是 (1)（接受 R-1 退步），該退步 MUST 逐字寫進 runbook 與
+      CHANGELOG，不得只活在程式註解裡。
+- 驗收：一輪完整的 define → build → review 在四分部署上跑通；`cortex status` 的
+      `attention` 不再含 `no-heterogeneous-planner`；R8 矩陣與 runbook 的反向驗證
+      逐條有實測輸出。
+
+### 7. 交付要件（本設計票 #672 自己的）
+
+- [ ] `docs/superpowers/specs/planner-job-downgrade-spec.md`
+- [ ] `docs/superpowers/specs/planner-job-downgrade-design.md`
+- [ ] `docs/superpowers/plans/planner-job-downgrade.md`（本檔）
+- [ ] `openspec/changes/2026-08-18-planner-job-downgrade/` 三件套 ＋
+      `specs/persona-workflow-orchestration/spec.md` delta
+- [ ] `changelog.d/672-planner-downgrade-design.md` fragment（R-09 硬性 gate，
+      須 **commit** 才進 diff）
+- [ ] `CHANGELOG.md [Unreleased]` 對應 entry
+- [ ] 帶 PR 上下文執行 `policy_check`，確認 `fail: 0`
+- [ ] `python3 -m pytest tests/ -q` 全綠（本票不改 code，應與 base 相同）
+- [ ] **不含任何 `paulsha_cortex/` 的程式修改**——`git diff --stat origin/main` 只有
+      `docs/`、`openspec/`、`changelog.d/`、`CHANGELOG.md`
+
+## 票的依賴順序
+
+```
+PATH 前置票（唯一待開的前置）──────────────────┐
+                                               ↓
+票 A（拒因表／三分）→ 票 B（invoker 抽象）→ 票 C（probe 快取）→ 票 E（job invoker）→ 票 F（切換與更正）
+                                                                  ↑
+U-4／U-5／U-7 裁決 → 票 D（permgen codify）───────────────────────┘
+
+（加固面驗證機制＝PR #677 已落地；票 E 消費 `psc_run_under`／`unit-replica`，非前置。）
+```
+
+- 票 A、票 B、票 C 可在 direct 部署上獨立 land 並各自產生價值（見 design D11）。
+- 票 D 與票 E 沒有硬性先後，但票 D 應在切換前完成，否則「這台機器可以、下一台不行」
+  會變成一條沒有票追蹤的隱性狀態。
+- 票 E land 之後，生產切換是**一次到位**：不能一半 planning 走 job、一半走 in-process
+  （probe 快取的指紋含 `PSC_JOB_RUNNER`，混用會讓兩種語意的結論在同一輪並存）。
+
+## 本票不做（範圍切分給後續實作票）
+
+- 不修改 `paulsha_cortex/` 下任何程式。
+- 不改剖面表、不改 unit 的加固項（現行 `EXECUTOR_HARDENING_PROFILE` 實測可用）。
+- 不重做 #670——其本體已由 PR #674 修好；本票只補「診斷活著抵達上游」那一層。
+- 不改 unit 檔、不動部署、不跑任何會改變 `/var/lib/cortex` 狀態的指令。
+- 不做非同步 planning 狀態機（design D12）。
+- 不做 provider 層的獨立（每個 job 帳號各自的 provider 帳號）。

--- a/docs/superpowers/specs/planner-job-downgrade-design.md
+++ b/docs/superpowers/specs/planner-job-downgrade-design.md
@@ -1,0 +1,620 @@
+---
+status: accepted
+work_item: planner-job-downgrade
+---
+
+# planner-job-downgrade Design
+
+對應 spec：`docs/superpowers/specs/planner-job-downgrade-spec.md`（issue #672）。
+實作切分：`docs/superpowers/plans/planner-job-downgrade.md`。
+
+## 背景與現況查證（main @ `ae089c3`，實機 0818）
+
+程式面（皆已逐條複驗）：
+
+| 事實 | 錨點 |
+|---|---|
+| planning 的模型呼叫是行程內 `subprocess.run` | `planning_runtime.py:830` `_invoke_json`、`:1070` 預設 runner |
+| planning argv 是裸 executor argv，無 `systemd-run`／無 shim | `planning_runtime.py:43` `_planning_argv` |
+| 呼叫端是 daemon（`User=cortex-manager`） | `manager_daemon.py:970`、`:1241` |
+| reviewer 已接上 job runner，planner 沒有 | `launcher.py:1203` `_is_review_persona` → `:1239` `_job_role` |
+| repo 自己已把這條記成逾期項 | `job_runner.py:405-408`、`permgen.deferred_run_dependencies()` 第 1／3／4 項 |
+| 帳號註記與行為矛盾 | `getent passwd cortex-manager` → `… no model code …` |
+
+部署面（本票以唯讀方式複驗）：
+
+| 事實 | 觀測 |
+|---|---|
+| 部署為 B 案模板模式 | `/opt/cortex/etc/cortex-manager.env`：`PSC_JOB_RUNNER=systemd-template` |
+| primary planner 是 codex | 同檔：`PSC_MANAGER_EXECUTOR=codex` |
+| 六份 job 模板 unit 已安裝 | `/etc/systemd/system/cortex-{job,reviewer-job,gate-job}[-jit]@.service` |
+| reviewer unit 的 RWP 只有兩條 | `…/cache`、`…/coordinator/review-verdicts`——**不含** `.codex/auth.json` |
+| reviewer unit 無執行時間上限 | 無 `RuntimeMaxSec=`／`TimeoutStartSec=` |
+| planner 憑證已落位 | `.codex/auth.json`（檔 job-owned 0600／目錄 root-owned）、`.gemini → cache/gemini`（root-owned symlink） |
+| **八份 unit 全帶 `SystemCallErrorNumber=EPERM`** | `cortex-reviewer-job@.service:148`、`cortex-reviewer-job-jit@.service:162`、`cortex-job-jit@.service:162`、`cortex-manager.service:89`——被過濾的 syscall 回 `EPERM` 而非 `KILL_PROCESS`，V8 走 fallback（見 D6） |
+| Manager unit 帶 `MemoryDenyWriteExecute=yes` | `cortex-manager.service:83`——這是 node 型 executor **在 Manager 行程內**結構性不可用的真正原因（與 seccomp 無關） |
+| `jit` 剖面與 `strict` 的唯一差異是 MDWE | `cortex-reviewer-job-jit@.service:156` `MemoryDenyWriteExecute=no`，unit 檔自己逐字寫明「這是本檔與 strict 剖面唯一的差異」 |
+| **PATH 缺口** | env 檔無 `PSC_REVIEWER_PATH`，Manager unit 無 `Environment=PATH=` ⇒ job 的 PATH＝PID 1 預設（`/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/snap/bin`）；`codex` 解到 `/usr/bin/codex`＝`codex-cli 0.42.0`，toolchain 那份是 `0.147.0`；`claude`／`agy` 在該 PATH 上不存在 |
+
+## Decisions
+
+### D1 執行後端抽象成 `PlanningInvoker`，而不是在 `_invoke_json` 裡塞 `if degraded:`
+
+`planning_runtime` 目前把「怎麼跑一個 executor」與「怎麼把輸出變成 JSON」揉在同一支
+`_invoke_json` 裡。直接在裡面分岔會產生兩個問題：(i) 現行 in-process 路徑的十條防線
+（sandbox 複製、雙向快照、drift 收容）有一半在 job 模式下不適用，混寫會讓「哪幾條
+在哪個模式下生效」變成要靠讀 `if` 才知道；(ii) probe 與四個 adapter 共用 `_invoke_json`，
+分岔寫在裡面等於每個呼叫端都要重新論證一次自己走的是哪條路。
+
+定案：抽出一層**只負責「拿 identity + prompt，回傳 stdout 與退出狀態」**的介面：
+
+```python
+class PlanningInvocation(Protocol):
+    identity: ModelIdentity
+    prompt: str
+    purpose: str        # "probe" / "questioner" / "secondary" / "integrator"，只進 instance 名與診斷
+    timeout_seconds: int
+
+class PlanningInvoker(Protocol):
+    def run(self, invocation: PlanningInvocation) -> PlanningOutcome: ...
+    # PlanningOutcome: (stdout, stderr, returncode, diagnostics)
+```
+
+兩份實作：
+
+- `InProcessPlanningInvoker`——現行 `_invoke_json` 的**前半段**原封搬進來（sandbox 複製、
+  `cwd=sandbox`、雙向快照、drift 收容、hermetic claude env、`subprocess` 逾時）。
+  行為逐字不變，既有測試不改一行。
+- `JobPlanningInvoker`——見 D3／D4。
+
+JSON 抽取（`_extract_json`、`_find_json_object`、envelope 處理）留在共用層，兩個
+invoker 都吃同一份——這是本 repo 反覆買到教訓的地方（#401、#516、#520 都是「同一件事
+兩份真相」）。
+
+選擇點只有一個：`job_runner.resolve_runner_mode(os.environ)`，與 launcher 同一支函式；
+非法值在該函式已 fail-closed。**刻意不新增 `PSC_PLANNING_INVOKER`**——第二個開關的
+失效模式是「以為降權了、其實沒有」，而那種失敗看起來是成功的。
+
+### D2 十條防線的逐條對應表（本設計的核心交付）
+
+| # | 現行機制（in-process） | 它買到什麼 | job 側對應 | 判定 |
+|---|---|---|---|---|
+| D-a | `tempfile.TemporaryDirectory(prefix="cortex-planning-")` | 一次性、呼叫結束即銷毀 | Manager 在 worktree pool 下建 per-invocation scratch（`<pool>/<instance>`），呼叫結束由 Manager `rmtree`；`CollectMode=inactive-or-failed` 讓 unit 自己也不留 | **等價** |
+| D-b | `_copy_planning_sandbox(worktree, …)` 整棵複製 repo | 讓模型有一份可讀的樹，且不是 operator 本尊 | 見 U-1：預設**不複製**（空 scratch），因為四個 adapter 的輸入全部已在 prompt 內 | **裁決中**（U-1） |
+| D-c | `cwd=sandbox` | 模型的 cwd 不是 operator 樹 | spec 的 `working_directory` = scratch；shim 依 spec chdir | **等價** |
+| D-d | 呼叫後 `_tree_snapshot(sandbox) != sandbox_before` ⇒ 失敗 | 偵測模型違反 read-only 契約 | 見 D-d 專段（下方） | **升級或退步，取決於 U-2** |
+| D-e | 呼叫前後 `_tree_snapshot(worktree)` 比對 operator 樹 | 偵測經絕對路徑寫 operator 樹 | `ProtectSystem=strict` ＋ RWP 不含 `repo-source-tree` ⇒ **kernel 直接擋** | **升級**（偵測 → 阻擋） |
+| D-f | `_contain_operator_drift`：唯讀 diff → 備份 → 報告 → 三道閘門的逐路徑還原 | drift 的 evidence 與不可逆抹除的保命索 | job 模式下 operator 樹不可能被 job 改，這一整套對 job 路徑是 dead code；**保留在 in-process invoker** 供 direct 模式使用 | **等價（範圍縮小）** |
+| D-g | `_seed_hermetic_claude_env`：一次性 `CLAUDE_CONFIG_DIR`，隔離 operator 的 plugin／hooks／MCP／user CLAUDE.md | 避免 operator 的 `~/.claude` 注入讓模型跑題 | job 的 HOME 是 `cortex-reviewer-planner`；`ProtectHome=yes` 讓 `/home` 整個不可見；unit 的 env 白名單不含 `CLAUDE_CONFIG_DIR` | **升級**（從複製憑證＋改 env，變成帳號隔離） |
+| D-h | `subprocess.run(timeout=…)` | 呼叫必然在上限內返回 | Manager 側 `Popen.wait(timeout)` → 逾時則 `systemctl stop <unit>`（見 D4） | **等價，但需新程式與實測** |
+| D-i | `capture_output=True` 取 stdout | 取回模型輸出 | spec 的 `log_path`（Manager-owned，Manager 先 truncate、shim 降權後以 O_APPEND 接管）；Manager 讀檔 | **等價**（reviewer 已在用同一條通道） |
+| D-j | codex 的 `-o <temp>/last.json` 第二輸出候選 | stdout 被 CLI envelope 污染時的乾淨來源 | 落點在 job-owned scratch，Manager 讀不到 ⇒ `_extract_json` 的雙候選退成單候選 | **退步（小）**，見 R-2 |
+
+**D-d 專段**——「模型是否弄髒了自己的拋棄式 sandbox」：
+
+- 現行做法是 Manager 在呼叫前後各對 sandbox 做一次 `_tree_snapshot`。降權之後
+  scratch 是 job-owned（`UMask=0077` ⇒ 0700），而 #623 已實測「Manager 走不進
+  builder 的樹」——同一條結論適用。所以**這個偵測在 job 模式下由 Manager 執行不可行**。
+- 讓 job 側 wrapper 自行 snapshot 再寫進 log 是**明確拒絕**的路：那是被驗方在自己的
+  進程裡產生自己的驗收證據（#628／#540 的原則），而且它能證明的東西恰好是它最有
+  動機造假的東西。
+- 剩下兩條路：
+  1. **接受退步**：不做這個偵測。論證是 scratch 每次呼叫新建即刪、job-owned、不承載
+     任何 durable state，弄髒它不產生任何後果；失去的只是「模型嘗試寫」這個**行為
+     訊號**（今天它會讓該次呼叫 fail-closed）。
+  2. **讓它結構上不可能**：把 scratch 設成 Manager-owned 且**不在** job unit 的 RWP
+     內 ⇒ 模型連寫都寫不進去，偵測需求消失。代價是 executor 需要一個可寫落點
+     （agy 的 `log_dir`、codex 的 `-o`），而 unit 已有 `PrivateTmp=yes`，job 拿得到
+     一個私有 `/tmp`——把那些落點指過去即可。
+- **本設計傾向 (2)**，因為它把一條「偵測」變成「不可能」，與 D-e 同一個方向；但它
+  需要逐 executor 實測「cwd 唯讀時能不能跑」。這是 U-2，交 operator 裁決。
+  若 operator 選 (1)，本設計要求 R-1 這條退步被逐字寫進 runbook 與 CHANGELOG，
+  不得只活在程式註解裡。
+
+### D3 輸出通道：沿用 reviewer 已經走通的「Manager-owned log ＋ shim O_APPEND」
+
+不新開通道。`launcher.launch()` 在模板模式下已經：Manager 先 `Path(log_path).write_bytes(b"")`
+把檔案建成 Manager-owned 並清空，spec 帶 `log_path`，shim 在降權**之後**以 O_APPEND
+接管——這正是「Manager 讀得到、job 只能追加」的形狀。planning 沿用它。
+
+三個附帶約束：
+
+1. planning 的 wrapper **不跑 gate、不產 bundle、不寫 verdict、不寫 sentinel**。
+   `_is_review_persona()` 為真時 `commit_bundle` 已是 `None`；`write_sentinel=not degraded`
+   已把 sentinel 交給 Manager 側記帳 shell。planning 的 wrapper 因此應該退化成
+   「只有模型 argv」一段——本設計要求它**顯式**只有那一段，不靠既有旗標碰巧為 None。
+2. log 內容 MUST 只有模型的 stdout／stderr。任何 wrapper 自產的文字都會污染
+   `_extract_json` 的輸入（本 repo 已有先例：`build_wrapper_script` 把 gate 階段的
+   輸出導向 `/dev/null` 就是為了不污染 terminal evidence）。
+3. `_extract_json` 現行接受兩個候選（`output_path` 的內容優先、再 stdout）。job 模式下
+   只剩 stdout（D-j 的退步）。若實測顯示 codex 的 stdout 在 job 環境下不可靠，
+   替代方案是再開一格「planning result spool」，形狀逐條比照 `review-verdict-spool`
+   （Manager-owned 目錄、job 只有 `wx` 無 `r`、收割後封口）。**那是新開一條 job→Manager
+   的寫入面**，因此列為 U-3 交裁決，不由本設計預先決定。
+
+### D4 逾時：Manager 側 `wait(timeout)` → `systemctl stop`，不靠 unit 的 `RuntimeMaxSec`
+
+兩條路：
+
+- **unit 側 `RuntimeMaxSec=`**：加在 root-owned 模板 unit 上。優點是 kernel 保證、
+  job 動不了；缺點是**上限變成部署常數**，而 planning 的四種呼叫（probe 45s、
+  questioner／secondary／integrator 120s）本來就有不同的上限，而 job spec
+  **結構性禁止攜帶任何 property**（`SPEC_FORBIDDEN_KEYS`）——那條禁令是對的，不該為
+  逾時鑽洞。
+- **Manager 側**：`Popen.wait(timeout=…)`，逾時則以 `systemctl stop <unit>`（polkit
+  已放行 `stop`），再落 `planning-job-timeout`。
+
+定案走 **Manager 側**，並**額外**建議 operator 在模板 unit 上加一條寬鬆的
+`RuntimeMaxSec=`（例如 1800s）作為第二層保險——那一層不需要精確，只需要保證
+「Manager 掛掉之後不會留下永遠在跑的模型 job」。這條屬部署面建議，不是本設計的
+硬性要求。
+
+停止之後 MUST 確認 unit 已離開 active：下一次同 `job_id` 的呼叫會撞
+`prepare_systemd_template` 的 `job-runner-template-instance-busy`，而那個錯誤訊息
+與「逾時」毫無關係，會把下一輪的排查完全帶偏。
+
+### D5 probe 快取：Manager-owned durable state，指紋含執行後端，fail-closed
+
+**成本現況**（本票量出來的）：`build_production_planning_runtime()` 對每個
+planning-capable identity 各跑一次 probe，而 `_probe_identity` 每次都做**兩次整棵 repo
+的 `copytree`**（baseline ＋ checkout）；agy 走的 `probe_agy_capability` 則是**兩次
+CLI 呼叫**（`agy models` ＋ smoke）。這個函式由 `manager.run_auto_claim_scan()`
+（periodic tick，實機 `PSC_MANAGER_INTERVAL_SECONDS=600`）與 `apply_work_action()`
+兩條路徑呼叫。搬到 job 之後，每個 probe 就是一個 unit 實例，agy 是兩個。
+
+**落點**：新增登記表資產 `planning-probe-cache`，路徑 `<coordinator_root>/planning-probe-cache.json`，
+Manager-owned `0600`，writers／readers 只有 `Principal.MANAGER`。**刻意不進任何 job
+模板 unit 的 RWP**：job 不該知道別的 provider 的探測結果，更不該寫得動它——快取一旦
+可由 job 寫，「這個 provider 是 ready 的」就變成模型可以自證的東西。
+
+**指紋（cache key 的第二半）**——任何會改變 probe 結論的輸入都要在裡面：
+
+| 輸入 | 為什麼 | 取法 |
+|---|---|---|
+| `PSC_JOB_RUNNER` 的值 | direct 與 job 的執行環境（PATH／HOME／憑證／seccomp／MDWE）完全不同 | 字面值 |
+| executor 可執行檔 | 換版就是換行為（實機同名兩份差 105 個小版本） | 以該角色的 PATH 解析出的**絕對路徑** ＋ `st_dev/st_ino/st_size/st_mtime_ns` |
+| 憑證檔 | refresh／換帳號 | `st_size/st_mtime_ns`（**不讀內容**，避免把 token 帶進雜湊的任何中間狀態） |
+| 加固剖面**與 seccomp 維度** | #643（MDWE 與 V8 互斥）＋ #677（seccomp 過濾語意是剖面**之外**的第二個維度，`PROFILE_LOCKED_KEYS` 兩剖面逐字相同）——**只放剖面名涵蓋不到第二維** | `resolve_hardening_profile(executor)` ＋ **模板 unit 檔本身**的 `st_size/st_mtime_ns` |
+| roster | overlay 改了候選就變了 | `load_model_identities()` 解析結果的 canonical JSON 雜湊 |
+
+模板 unit 檔進指紋是刻意的：**任何**讓 operator 重跑產生器落新 unit 的改動（RWP 增列、
+加固項調整、新增 executor），在落檔那一刻就讓全部快取自動失效並重探，不需要任何人
+記得清快取。這是把「部署動作」與「快取失效」綁成同一件事——本 repo 已經有太多
+「機制對了但沒人記得觸發」的例子。
+
+**TTL**：ready 與 not-ready 分開（建議預設 `ready=3600s`、`not_ready=300s`）。
+理由：失敗要快速重試（暫時性的服務錯誤、限流、以及模型輸出的隨機不從，短時間內
+就會自己好），成功不需要頻繁重確認（重確認就是一個 job 的成本）。
+兩者由 env 覆寫，實際值列為 U-6。
+
+**probe 本體以 PR #674 修後的形狀為準。** #674 已讓 `probe_agy_capability()`
+`strip_code_fence()`、失敗帶 `stdout_excerpt()`（前 200 字、空白壓成單一空格、空輸出
+標 `<empty>`），並修掉 `agy models` 改成 `id\tDisplay Name` 兩欄之後造成的 100%
+`model-not-listed`。快取的「失敗診斷」欄位因此**直接沿用** `CapabilityProbe.diagnostic`
+——不要在快取層再造一份自己的節錄邏輯（那就是第二份真相）。
+
+**ledger 形狀沿用 `not_claimable`（PR #675）的既有先例**，不另立一套：
+`schema` 版本字串 ＋ `items` 以穩定 key 索引 ＋ 每筆帶 `first_observed_at`／
+`last_observed_at`／`observations`（operator 因此看得出「這個 provider 掛多久了」）＋
+條件解除時自動清除。原子寫入（temp ＋ `os.replace` ＋ 目錄 fsync）也照抄
+`not_claimable._save()`。
+
+**一處刻意的不同**：`not_claimable.load_ledger()` 對壞掉的檔案 **raise**（理由是
+「靜默當成空的等於把盲區再造一次」）。probe 快取**不得** raise——它壞掉時若把整個
+planning 拖垮，那是一份輔助紀錄取得了它不該有的否決權。改為「視為 miss ＋ 落一筆
+可辨識的診斷」，而 fail-closed 的實質仍在：**它永遠不會因為讀不到而回答 ready**。
+兩者是同一條原則（不得靜默產生有利答案）在不同後果下的兩種實作，設計上必須寫明
+差異，否則下一個人會照抄 raise。
+
+**失效與錯誤時的行為（fail-closed）**：
+
+- 檔案不存在／JSON 壞掉／schema 版本不符／指紋不符 ⇒ 視為 **miss**，重探。
+- 重探失敗 ⇒ **not ready**（與今天相同）。
+- **絕不**因為「上次是 ready」而在無法重探時沿用 ready。
+- 快取損毀 MUST 落一筆可辨識的 log（`planning-probe-cache-unreadable`），與
+  「probe 失敗」分開——否則會出現「快取檔壞了，症狀卻報成 provider 不可用」。
+
+**fail-closed 的代價（明講）**：快取失效的那一輪 tick，planning 會多付一批 job 的
+時間；若那一刻環境剛好壞了（憑證過期、PATH 缺口未補、toolchain 換版換壞），那一批
+job 會全滅，於是 planning 從「上次成功」直接掉成 `no-heterogeneous-planner`。
+fail-open 可以掩蓋這件事、讓 planning 繼續跑，但代價是「憑證過期／unit 換版之後仍
+宣稱 ready」——那正是本 repo 已經記錄多次的「綠燈不承載語意」。選 fail-closed，
+並由 D8 的拒因表讓掉下去的原因當場可見。
+
+**快取內容**：除 `ready: bool` 外，MUST 存失敗側的完整診斷（`reason`、`diagnostic`、
+`returncode`、`stdout_prefix`（≤200 字）、`unit`、`hardening_profile`、`resolved_binary`、
+`binary_version`），供 D8 的拒因表消費。這一條讓「快取」同時變成「上次到底怎麼失敗的」
+的唯一可查落點——今天這份資訊在 `_failed_agy("malformed-output")` 之後就蒸發了（#670）。
+
+### D6 剖面路由：零新增判定點，且現行剖面表**實測可用**、無前置修正
+
+`JobPlanningInvoker` 取得剖面的唯一途徑是
+`job_runner.prepare_systemd_template(env, job_id=…, executor=identity.executor,
+role=JOB_ROLE_REVIEW)`。planning 側**不持有**任何 executor→剖面的對應表。
+
+`prepare_systemd_template` 已經滿足本 spec 需要的每一條：`executor` 必填無預設、
+未登記 executor fail-closed（`cg` 目前刻意不在表內，那是正確結果不是缺口）、
+`SPEC_FORBIDDEN_KEYS` 在寫端與讀端各擋一次剖面欄位、兩份 unit 都是 root-owned。
+
+**本設計原本寫著「假設 #673 已修」，這個前提是錯的，已移除。** #673 原 body 主張
+`SystemCallFilter=@system-service` 讓 codex／copilot 在全部 job unit 下靜默 rc=1；
+該主張已由開票者自行更正撤回，#673 由 **PR #677** 以「不放寬任何 syscall」收尾。
+更正後的事實（本票獨立複驗）：
+
+- 八份 unit（六份 job 模板 ＋ manager ＋ monitor）**全部帶
+  `SystemCallErrorNumber=EPERM`**——`cortex-reviewer-job@.service:148`、
+  `cortex-reviewer-job-jit@.service:162`、`cortex-job-jit@.service:162`、
+  `cortex-manager.service:89`——而且從權限產生器落地的第一個 commit 起就在。
+- 有這一條時，被過濾的 syscall 回 `EPERM` 而非 `SECCOMP_RET_KILL_PROCESS`，
+  V8 走 fallback ⇒ **codex／copilot 照常啟動**。
+- 真 unit 的**完整** property 集合下實測：codex／copilot 在 `jit` 剖面 rc=0，
+  claude／agy 在兩種剖面皆 rc=0。**預設派工路徑沒有壞。**
+- 實際被過濾的是 `pkey_alloc`（`@pkey`），不是原先猜測的 `landlock_*`／`seccomp`
+  （`@sandbox`）；加 `@sandbox` 對症狀完全無效。
+- 誤判來源：repro 手抄十條 property、漏抄 `SystemCallErrorNumber=EPERM`，比 production
+  **更嚴格**，於是製造出 production 不存在的 rc=1。這條教訓寫成硬規則見 **D13**。
+
+**結論**：現行 `EXECUTOR_HARDENING_PROFILE`（codex／copilot → `jit`，claude／agy →
+`strict`）就是對的，planner 上 job 之後**不需要任何剖面面的前置修正**。
+`jit` 剖面與 `strict` 的唯一差異仍是 `MemoryDenyWriteExecute=no`（#643 的既有結論，
+unit 檔自己逐字寫明「這是本檔與 strict 剖面唯一的差異」），那一條與 V8 的 JIT 互斥
+是真的，本設計不動它。
+
+**#677 另外建立了一個本設計必須消費、而不是重新發明的東西**：seccomp 過濾語意是
+**剖面之外的第二個維度**。
+
+- `permgen.SECCOMP_FATALITY_KEY = "SystemCallErrorNumber"`、
+  `PROFILE_LOCKED_KEYS = {"SystemCallFilter", "SystemCallErrorNumber"}`——這兩個鍵
+  **兩份剖面逐字相同**，剖面之間不分岔。
+- `ToolchainProgram.filtered_syscalls` 記錄實機量到、有 kernel audit 背書的被過濾
+  syscall；`filtered_syscall_surfaces()` 機械導出「哪個程式在哪個加固面上會撞到什麼」。
+  現況四筆（`codex`／`copilot` 在自己的 jit 剖面、`srt` 在 claude 的 strict 剖面、
+  `openspec` 在 Manager unit），**全部 `fatal=False`**——因為 `SystemCallErrorNumber=EPERM`。
+- `seccomp_filter_is_fatal(table)` 把「被過濾會不會殺行程」變成一個可查詢的函式；
+  `_validate_seccomp_tolerance()` 在 import 時強制，承重的那條因此**不可能被靜默拿掉**。
+
+對本設計的兩個直接影響：(i) D5 的快取指紋**不能只放剖面名**——seccomp 維度與剖面
+正交，只有把**模板 unit 檔本身**放進指紋才涵蓋得到（本設計原本就是這樣，#677 讓這個
+選擇有了明確的理由而不只是保守）；(ii) D8 的 `executor-silent-exit` 診斷 MUST 帶上
+`seccomp_filter_is_fatal()` 的結果——那是「這次空輸出到底該不該懷疑 seccomp」的
+機械答案，而 #673 整張票就是因為沒有這個答案才走偏。
+
+剖面表若日後因其他理由改動，本設計受影響處：
+
+| 改動 | 本設計受影響處 |
+|---|---|
+| 新增 executor 進 `EXECUTOR_TOOLS`／`EXECUTOR_HARDENING_PROFILE` | **零改動**（那張表的真相在 permgen，本設計只消費 `resolve_hardening_profile`） |
+| 新增剖面名（例如將來真有第三種加固形態） | `TEMPLATE_UNIT_SUFFIX_BY_PROFILE` 多一個值 ⇒ 本設計的**驗收矩陣多一列**；程式仍零改動 |
+| 任何 unit 檔內容變更 | D5 指紋的「模板 unit 檔」隨之改變 ⇒ 快取自動全失效重探（正確行為） |
+
+換句話說，本設計對剖面表的耦合**只在驗收矩陣與快取失效**，不在程式結構——這就是
+R4「不新增第二個判定點」買到的東西。
+
+### D7 憑證：把 0818 已部署的事實 codify 進登記表，不重造 #671 的機制
+
+0818 的部署在**功能上足夠**：`.codex/auth.json` 讓 codex 有登入態；`.gemini →
+cache/gemini` 讓 agy 的可寫狀態樹落在已在 RWP 內的 `cache`，因此
+`ProtectSystem=strict` 下 agy 建得出 log／state（`agy models` 列出
+`gemini-3.1-pro-high`、capability smoke 逐位元等於 expected）。
+
+**治理上不足**，兩個缺口：
+
+1. reviewer 模板 unit 的 `ReadWritePaths=` 不含 `.codex/auth.json` ⇒ 憑證讀得到、
+   **改不了** ⇒ token 過期那天 refresh 靜默失敗。這是
+   `permgen.deferred_run_dependencies()` 第一項逐字描述的逾期項，它的 `disposition`
+   已經寫好「補登記表第二列（產生器一行都不必改）」。
+2. `.gemini` 那條 root-owned symlink 是手動落位的，登記表不知道 ⇒ 換機器部署或重跑
+   產生器不會出現。
+
+**#671 已經把當年的阻礙拆掉了，不要重造**：
+
+- `permgen.IN_PLACE_CONTENT_WRITE_ASSETS`——葉檔資產的 `ReadWritePaths` 掛在**檔案
+  本身**而非折算成父目錄。憑證正是這一族（檔 job-owned、目錄 root-owned）。
+  補進來只要把 `reviewer-planner-executor-credential` 加進這個集合。
+- `permgen.inapplicable_home_anchored_assets()`——掛在「本方案不存在的帳號」HOME 下
+  的資產機械地不進 RWP。這正是 #640 當年「不敢登記第二份憑證」的唯一理由
+  （二分部署下該路徑不存在 ⇒ systemd 對不存在的 RWP 目標讓 unit 起不來）。
+  該理由**已經失效**，登記第二列不會再弄壞二分部署。
+- `required_write_targets()` 已經同時吃 `IN_PLACE_CONTENT_WRITE_ASSETS`、
+  `inapplicable_home_anchored_assets()` 與 `RETIRED_JOB_WRITE_ASSETS` 三者，
+  補一列不需要改產生器。
+
+**部署順序**（重要，unit 註解已寫明）：憑證檔不存在時，帶著該 RWP 的 unit 會**起不來**
+（那是刻意的 fail-closed）。因此順序必須是「憑證先落位 → 再重跑產生器落新 unit →
+再 `daemon-reload`」。0818 已完成第一步，因此這張票的部署風險比 #640 當時低。
+
+**agy 狀態樹的表達方式**有兩個選項，列為 U-7：
+(a) 把 `.gemini → cache/gemini` 登記成一個 symlink 類資產（登記表目前沒有這個 kind，
+    要新增）；
+(b) 不登記 symlink，改在 job env 上設 `GEMINI_*`／`XDG_*` 讓 agy 的狀態樹直接落在
+    `cache` 底下（若 agy 支援）——那樣就不需要 symlink，`cache` 已在 RWP 內。
+(b) 較乾淨（少一種資產 kind），但需要先查 agy 的路徑解析順序。
+
+**雙 provider 憑證**（#668 G2）：planner 帳號要有異質性，就得同時持有兩個
+independence domain 的憑證。`PathLayout.executor_credential_relpath` 目前是**單一
+部署決定**（`.codex/auth.json`），一個帳號只表達得了一份。要表達兩份就得把它擴成
+per-(account, executor) 的表。**這是新的安全決策**：擴大的是該帳號被攻陷時的
+provider 曝險面（同時失去兩邊的 token）。本設計不做這個決定，見 U-4／U-5。
+
+順帶：`permgen.deferred_run_dependencies()` 的第三項
+（`reviewer-planner-codex-hooks`，`asset_paths()` 把 `codex-hooks` 寫死在 builder HOME 下）
+與本題同族，它的 `disposition` 已寫「與 reviewer 憑證同一張票處理」。實作票 D 一併收。
+
+### D8 錯誤語意：三分 ＋ 逐候選拒因表，讓「格式問題被報成拓撲問題」結構上不可能
+
+**現況為什麼會誤報**：`select_secondary_planner()` 走完候選後回
+`SecondarySelection("needs_human", "no-heterogeneous-planner", None)`——一個**沒有任何
+附加資訊**的字面值。而每個候選被跳過的真正理由（同 domain？probe 沒 ready？ready
+但身分不符？）全部在迴圈裡被 `continue` 吃掉。#670 的實測就是這樣：agy 的 stdout 是
+完全正確的 JSON、只是被 code fence 包住，結論卻是「沒有異質 planner」。
+
+**三分**（新增具名族，皆帶結構化 detail）：
+
+| 族 | 判準 | 來源 | classification |
+|---|---|---|---|
+| `planning-job-start-failed` | job 起不來 | `prepare_systemd_template` 的 `JobRunnerError`（polkit／模板未安裝／shim 不可執行／spool 不可寫／instance busy）、`confirm_template_instance_started` 逾時、spec 寫入失敗 | `environment` |
+| `planning-executor-failed` | job 起來、executor 非零退出或零輸出 | Manager 側記帳 shell 寫下的 rc ＋ log 尾段 | `environment` |
+| `planning-output-malformed` | executor 正常退出、輸出不符契約 | `_extract_json` 既有的例外（已帶 stdout 前 160 字） | `content`（既有 transient-service 例外仍適用） |
+
+`planning-executor-failed` 的 **`executor-silent-exit` 子類**：rc≠0 且 stdout 與 stderr
+皆空。這是本 repo 稱為「連錯誤訊息都沒有」的那一種——歸因會落到模型、prompt、逾時或
+憑證，而不會落到執行環境。它 MUST 在 reason 裡指名 `unit`、`hardening_profile`、
+`resolved_binary`——因為那三個就是唯一的線索來源。
+
+（#673 原 body 曾把這一類的一個實例歸因到 `SystemCallFilter`，該歸因已被開票者更正
+撤回，見 D6。但「rc≠0 而完全無輸出」這個**類別**確實存在且值得具名——這正是它難查的
+證據本身：一個無輸出的失敗，連要不要懷疑執行環境都判斷不了。本子類因此保留，
+但不對成因預設任何特定 syscall。）
+
+**這一格的診斷 MUST 帶 `permgen.seccomp_filter_is_fatal()` 的結果**（PR #677 提供）。
+理由是這條子類唯一的資訊價值就在「該往哪個方向查」，而 seccomp 是否致命正是最容易
+被誤猜、也最容易機械回答的那一維：`SystemCallErrorNumber=EPERM` 在時答案是「不該懷疑
+seccomp」，不在時才是「該懷疑」。#673 整張票走偏，就是因為當時沒有任何地方回答得了
+這個問題——現在有了，本設計必須把它接進診斷，而不是讓下一個人再猜一次。
+同理，`filtered_syscall_surfaces()` 已經逐筆記錄「哪個程式在哪個加固面上撞到什麼」，
+診斷若能指出「本 executor 在本剖面上的已知過濾項為 X 且 fatal=False」，
+`executor-silent-exit` 就從一個死路變成一條有方向的線索。
+
+**拒因表**：`SecondarySelection` 增加一個欄位
+
+```python
+@dataclass(frozen=True)
+class CandidateRejection:
+    executor: str
+    model_id: str
+    domain: str
+    reason: str        # same-domain / probe-absent / probe-not-ready / probe-identity-mismatch
+    diagnostic: str    # probe 的 diagnostic（含 stdout 前 200 字、rc、unit）
+```
+
+`no-heterogeneous-planner` 從**結論**變成**結論 ＋ 每個候選為什麼落選**。
+`run_heterogeneous_brainstorm` 把它渲染進 `BrainstormResult.reason`，例如：
+
+```
+no-heterogeneous-planner (agy/gemini-3.1-pro-high[google]: probe-not-ready
+malformed-output ```json{"capability":"cortex-plan-…; claude/…[anthropic]:
+probe-not-ready planning-job-start-failed job-runner-template-unit-missing;
+codex/…[openai]: same-domain)
+```
+
+**這一條就是「讓誤報不可能」的機制本身**：只要拒因表是必填且渲染在 reason 裡，
+「格式問題」與「拓撲問題」在同一個字串裡就是兩個不同的欄位，讀的人不需要重跑六遍
+才發現。
+
+**分類改判**：`_classify_planning_failure()` 目前對 `no-heterogeneous-planner` 一律
+落 `content`，而 `content` 在 `_resume_decision` 一律不浮現 `recover-planning` ⇒ 死路。
+改成：拒因表中**只要有一條是 environment 級**（job 起不來、executor 死、probe 快取
+損毀），整體改判 `environment`，讓 recover-planning 有路。這與 #416／#533／#554 已經
+建立的三條例外是同一個模式（`_is_planning_authority_residue_failure`、
+`_is_planning_transient_service_failure`、`_is_planning_worktree_drift_failure`），
+不是新發明。
+
+### D9 instance 命名與併發：一次 planning 呼叫 = 一個 unit 實例
+
+`prepare_systemd_template` 用 `template_instance_id(job_id)` 算 instance，並在起動前
+檢查同名 unit 是否 active（因為 `systemctl start` 對已 active 的 unit 會**靜默回 0**）。
+planning 的一輪 brainstorm 會連續起 questioner → secondary → integrator 三個呼叫，
+加上 probe，因此 `job_id` MUST 每次呼叫唯一。
+
+定案格式：`plan-<run_id 前 12 字>-<purpose>-<序號>`，其中 `purpose` ∈
+{`probe`, `questioner`, `secondary`, `integrator`}，序號解決重試。
+`job_workspace.JOB_SEGMENT_RE`（`[A-Za-z0-9][A-Za-z0-9_.-]{0,62}`）是形狀的唯一真相，
+命名必須先過它。
+
+`purpose` 進 instance 名是刻意的：`systemctl list-units 'cortex-reviewer-job@*'` 的輸出
+因此直接說得出「這一批 job 在做什麼」，不需要回頭查 spec。它**不**進 spec 的任何
+決策欄位，只是識別字串。
+
+probe 的 `run_id` 在非 daemon 呼叫端是 `"ephemeral"`（`build_production_planning_runtime`
+的預設值），因此 probe 的 instance 名 MUST 另外帶時間戳或隨機後綴，否則兩個並行的
+probe 會互撞 `instance-busy`。
+
+### D10 PATH：本票新查到的部署缺口，是實作票 C 的前置
+
+實機 `/opt/cortex/etc/cortex-manager.env` 沒有 `PSC_REVIEWER_PATH`，Manager unit 也沒有
+`Environment=PATH=`。`build_job_env()` 的 PATH 來源是
+「`manager_env["PATH"]`，被 `PSC_<ROLE>_PATH` 覆寫」——覆寫不存在，所以 job 拿到的是
+PID 1 的 `PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/snap/bin`。
+
+實測後果：
+
+| executor | 在該 PATH 上解析到 | 版本 | toolchain 那一份 |
+|---|---|---|---|
+| `codex` | `/usr/bin/codex` | `codex-cli 0.42.0` | `0.147.0` |
+| `copilot` | `/usr/bin/copilot` | （未量） | toolchain 另有一份 |
+| `claude` | **不存在** → rc=127 | — | `/opt/cortex/toolchain/bin/claude` |
+| `agy` | **不存在** → rc=127 | — | `/opt/cortex/toolchain/bin/agy` |
+
+reviewer 模板 unit 的註解已經預先寫過這件事該怎麼修（「真正的來源是 Manager 端
+root-owned EnvironmentFile 裡的 `PSC_REVIEWER_PATH=/opt/cortex/toolchain/bin:…`」），
+只是那一行從未落到 env 檔裡。#671 的 `permgen` 已有 `job_path_value()` 這類
+「產生器出值、operator 落進 root-owned EnvironmentFile」的形態，補這一條不需要新機制。
+
+**這條同時影響今天的 reviewer job**（不只是未來的 planner），因此它應該是一張獨立的
+部署面票，並列為實作票 E 的前置。它也是 D8 為什麼要把 `resolved_binary` 與
+`binary_version` 放進失敗診斷的直接理由：`claude` rc=127 與「模型不聽話」在
+blocking reason 上必須長得不一樣，而**「跑起來了但跑的是 0.42.0 而不是 0.147.0」
+甚至不會失敗**——它會安靜地產出一份用舊版 CLI 跑出來的結果。這一種只有把版本字串
+記進診斷才看得見。
+
+### D11 分階段 land：能，但「切換」那一刻是一次到位
+
+**能分階段**的理由：`PSC_JOB_RUNNER` 是既有開關，`direct` 分支逐字保留現行行為。
+因此票 1／2／3（診斷、抽象、快取）可以先 land 並在 direct 部署上獨立產生價值：
+
+- 票 1（拒因表 ＋ 三分）：今天的 `no-heterogeneous-planner` 立刻開始講真話。
+  **不依賴任何部署面改動。** PR #674 已經把 probe 那一端的診斷補齊
+  （`stdout_excerpt()`），票 1 要做的是讓那份診斷**活著抵達** blocking reason
+  ——兩者剛好接得起來，而缺任何一半都還是查不出原因。
+- 票 2（invoker 抽象）：純重構，direct 路徑逐字等價。
+- 票 3（probe 快取）：direct 模式立刻受益——省掉每輪 tick 每個 identity 兩次整棵
+  repo 的 `copytree`。
+
+**不能分階段**的是切換本身：一個部署上不能「一半 planning 走 job、一半走 in-process」。
+理由是 probe 快取的指紋含 `PSC_JOB_RUNNER`，混用會讓兩種語意的結論在同一輪裡並存，
+而 `select_secondary_planner` 分不出來。因此票 5（`JobPlanningInvoker`）land 之後，
+生產部署的切換是「改 env → 重啟 → 全部 planning 走 job」一次到位。
+
+**中間狀態的可運作性**：票 5 land 但生產仍為 direct 的期間，系統完全可運作
+（direct 路徑不變）。票 5 land 且切換之後、票 4（憑證 codify）之前，系統也可運作
+——0818 手動落位的憑證在**這台機器上**有效，只是換機器會壞。因此票 4 與票 5 沒有
+硬性先後，但票 4 應盡量在切換前完成，否則「這台機器可以、下一台不行」會變成一條
+沒有票追蹤的隱性狀態。
+
+### D12 明確不做：非同步 planning 狀態機
+
+把 planning 拆成「起 job → 記錄在 spool → 下一個 tick 收割」的狀態機，會讓 Manager
+的 tick 不再被 planning 阻塞。這是對的方向，但：(i) 它與本票要解的「執行身分」正交；
+(ii) 它需要 planning 的三段呼叫（questioner→secondary→integrator）各自有 durable 的
+中間態，而那是 `WorkflowRun` schema 的改動；(iii) 它會讓本票的驗收面爆炸。
+
+本票維持同步：降權模式下阻塞源從「子進程」換成「`systemctl start --wait` 的 client」，
+粒度不變（今天 `_invoke_json` 一樣阻塞 tick 最多 120s × 3）。多出來的只有 job 啟動
+延遲（`DEFAULT_START_TIMEOUT_MS=200` 是起動確認的窗口，實際 unit 起動另計）。
+留給後續票。
+
+### D13 驗證方法的硬規則：加固面一律機械導出——**機制已由 PR #677 落地，本設計消費它**
+
+本設計早期版本把這條寫成「本票要求新增的一條硬規則」。**PR #677 已經把它做成程式**，
+因此本節改為兩件事：記錄規則的**理由**（它仍然是本設計驗收面的依據），以及明確指出
+planner 的驗收 **MUST 消費既有機制、MUST NOT 自行組 property 清單**。
+
+**規則**：凡是宣稱「某 executor 在某加固剖面下可用**或不可用**」，驗證環境 MUST 由
+**已落檔的 unit 機械讀出全部 property** 再複製。MUST NOT 手抄 property 子集。
+
+**現成的機制（不要重造）**：
+
+| 機制 | 用途 |
+|---|---|
+| `permgen.unit_replica_properties(unit_text, *, instance, require_hardening=True)` | 一份已落檔 unit → `systemd-run --property=` 的**完整**清單。契約是「全帶，不選」；落檔 unit 少任一加固鍵即 `UnitReplicaDriftError` 且 stdout 保持空 |
+| CLI `python -m paulsha_cortex.trust_root unit-replica <unit｜->` | 上一支的命令列入口，`-` 讀 stdin（可直接接 `systemctl cat`） |
+| runbook 第 4e 步的 `psc_run_under <unit 字幹> <命令>` | runbook 與測試**共用同一個「真實加固面」定義**，因此兩邊不會漂移 |
+| `permgen.seccomp_filter_is_fatal(table)` | 「被過濾的 syscall 會不會殺行程」的機械答案 |
+| `permgen.PROFILE_LOCKED_KEYS` | `SystemCallFilter`／`SystemCallErrorNumber` 兩份剖面逐字相同，剖面之間不分岔 |
+
+實作票 E 的驗收矩陣 MUST 走 `psc_run_under`／`unit-replica`；任何在測試或 runbook 裡
+出現的「手寫 `--property=` 清單」都是本規則要擋的東西。
+
+**為什麼這條規則值得記在本設計裡（而不是只留在 #677）**：因為 planner 是**下一個**
+會做這種宣稱的地方。規則的理由如下——
+
+| 事故 | 手抄的偏差方向 | 產生的錯誤 | 後果 |
+|---|---|---|---|
+| #638 | 單 UID 環境讓 ACL 斷言真空（比 production **寬**） | **假綠** | 斷言恆真，什麼都沒驗到 |
+| #657 | 同型（比 production **寬**） | **假綠** | 同上 |
+| #673 原 body | 十條 property 複本漏抄 `SystemCallErrorNumber=EPERM`（比 production **嚴**） | **假紅** | 製造出 production 不存在的 rc=1，據此開票要求放寬 seccomp |
+| #673 的 repro 步驟 | 同上 | **假紅** | 在「修 #643 漏抓」的名義下，第二次踩同一個坑 |
+
+前三次都是假綠，因此很容易把這條規則記成「防止把不夠嚴的環境當成夠嚴」。
+第四次證明那個記法是錯的：**手抄比 production 嚴的子集同樣有害**，而且後果更貴
+——它會讓人去「修」一個不存在的問題，並在修的過程中放寬一條真的有用的加固項。
+規則的正確形式因此是「驗證環境 ≠ production 環境」這件事**在結構上不可能發生**，
+與偏差方向無關；`unit_replica_properties()` 的 `require_hardening=True` 預設
+與 `UnitReplicaDriftError` 就是這句話的可執行形式。
+
+**成對約束**（本次事故的直接教訓，#677 已用 `PROFILE_LOCKED_KEYS` 固化）：
+`SystemCallFilter=` 與 `SystemCallErrorNumber=` 必須同進同出。只帶前者會把
+「被過濾的 syscall 回 `EPERM`（呼叫方可 fallback）」偷換成
+「`SECCOMP_RET_KILL_PROCESS`（行程直接死）」，而兩者的症狀（空輸出）一模一樣。
+#643 當年已經記錄過這一條，#673 仍然重蹈——**已經寫下來的教訓，在下一次用手抄複本時
+不會自動生效**，這正是為什麼它必須是機械規則而不是一段註解。
+
+## 風險與緩解
+
+| 風險 | 影響 | 緩解 |
+|---|---|---|
+| 以手抄 property 子集驗收 | 兩個方向都會錯：偏寬得假綠、偏嚴得假紅（後者更貴——會去「修」一個不存在的問題並放寬真的有用的加固項） | **D13**：走 PR #677 已落地的 `unit_replica_properties()`／`trust_root unit-replica`／runbook 的 `psc_run_under`，`require_hardening=True` 下少任一加固鍵即 `UnitReplicaDriftError`；不得手寫 `--property=` 清單 |
+| PATH 缺口未補 | `claude`／`agy` rc=127；`codex` 安靜地跑到 0.42.0 舊版（**不會失敗**，只是產出來自舊 CLI） | 獨立前置票；R8 的驗收矩陣與 D8 的失敗診斷都強制記錄「解析到的絕對路徑 ＋ 版本字串」 |
+| 憑證 RWP 第二列讓 unit 起不來 | 全部 reviewer／planner job 停擺 | 憑證檔已於 0818 落位（本票複驗）；部署順序固定為「憑證 → 產生器 → daemon-reload」；runbook 補一條起動後 `systemctl status` 的反向驗證 |
+| probe 快取 fail-closed 造成「上一輪好好的、這一輪全滅」 | planning 掉進 needs_human | 這是刻意取捨（見 D5）；緩解是 D8 的拒因表讓原因當場可見，而非只留一個 `no-heterogeneous-planner` |
+| 逾時後 unit 沒停乾淨 | 下一輪撞 `instance-busy`，錯誤訊息與逾時無關 | D4 要求停止後確認離開 active；建議 operator 另加寬鬆的 `RuntimeMaxSec=` 作第二層 |
+| `_extract_json` 的第二候選消失（D-j） | codex 的 envelope 若污染 stdout，抽取失敗 | 實測驗證；若成立則走 U-3 的 result spool |
+| 抽象層引入行為漂移 | direct 模式靜默改變 | 票 2 的驗收是「既有 planning 測試一行不改全綠」 |
+
+## 未決問題總覽（需 operator 拍板，本票不擅自決定）
+
+- **U-1 planning sandbox 要不要放 repo 複本。**
+  (a) 維持整棵複製（現行語意，成本是每次呼叫兩次 `copytree`）；
+  (b) 改成空 scratch（四個 adapter 的輸入全部已在 prompt 內：`secondary` 由
+      `_planning_source_material()` 在 Manager 側讀好嵌進 prompt，questioner／integrator
+      吃的是 JSON）；
+  (c) 走 `job_workspace` 的 per-job clone（與 builder 同形，但 planner 不需要 git）。
+  取捨：(b) 最便宜且是**收緊**（模型從「理論上讀得到 repo」變成「讀不到」），但它
+  改變了現行行為——今天若有模型靠讀 sandbox 補足 context，(b) 會讓它拿不到。
+  傾向 (b)，但這是行為改變，需要 operator 確認。
+
+- **U-2 scratch 對 job 是可寫還是唯讀**（＝ D-d 的兩條路）。
+  (1) 可寫 ＋ 接受「sandbox dirty 偵測」退步；
+  (2) 唯讀（Manager-owned、不進 RWP）＋ 把 executor 的可寫落點指向 `PrivateTmp` 的
+      私有 `/tmp` ⇒ 偵測需求消失。
+  傾向 (2)，但需要逐 executor 實測「cwd 唯讀時能不能跑」（agy 的 `log_dir`、codex 的
+  `-o`、claude 的 `--add-dir`）。
+
+- **U-3 codex 的第二輸出通道要不要保留。**
+  若實測顯示 job 模式下 codex 的 stdout 不可靠，是否新開一格「planning result spool」
+  （形狀比照 `review-verdict-spool`：Manager-owned 目錄、job `wx` 無 `r`、收割後封口）。
+  代價是**新開一條 job→Manager 的寫入面**——今天 planner 一條都沒有。
+
+- **U-4 planner 帳號是否核可持有兩個 independence domain 的憑證。**
+  這是 #668 G2 的同一題，本票不重複裁決，但它是「planner 有沒有異質性」的前提。
+  選項：(a) 核可雙 domain（曝險面擴大，換得異質 planner 可用）；
+  (b) 只給一份憑證 ⇒ 異質 planner 結構性不可得 ⇒ 需要另一條路徑滿足
+      「不完整規格必須經異質雙模型 brainstorm」這條既有 requirement
+      （例如把 secondary 派到**另一個帳號**，那是第五個 UID）。
+
+- **U-5 `executor_credential_relpath` 要不要擴成 per-(account, executor) 表。**
+  這是 U-4 的機械面。(a) 擴表（#668 B 案，產生器改動不小）；
+  (b) 維持單一 ⇒ 每個帳號只有一份憑證 ⇒ U-4 只能選 (b)。
+  兩者互相牽制，應一起裁決。
+
+- **U-6 probe 快取的 TTL 值，以及要不要提供 warm-up 入口。**
+  建議值 `ready=3600s`／`not_ready=300s`，但實際節奏由 operator 對 planning 頻率的
+  期望決定。warm-up（部署後主動跑一次全 probe，而不是等第一次 planning 撞上）會讓
+  runbook 多一步，但也讓「這台機器的 planner 到底能不能用」在部署當下就有答案，
+  而不是等到第一張卡。
+
+- **U-7 agy 狀態樹在登記表裡的表達方式。**
+  (a) 把 `.gemini → cache/gemini` 登記成 symlink 類資產（登記表要新增 kind）；
+  (b) 改用 env 讓 agy 的狀態樹直接落在 `cache` 底下（若 agy 支援，就不需要 symlink）。
+  傾向 (b)，但需要先查 agy 的路徑解析順序。
+
+- **U-8 模板 unit 要不要加 `RuntimeMaxSec=` 作為第二層逾時保險。**
+  本設計的 D4 已在 Manager 側解決逾時；unit 側那一層只保「Manager 掛掉後不留孤兒 job」。
+  加它會讓所有 job（含 builder 的長任務）共用同一個上限，值要 operator 定。
+
+## 安全退步總覽（本設計誠實標註）
+
+| 編號 | 退步 | 代價 | 是否可避免 |
+|---|---|---|---|
+| **R-1** | 「模型弄髒自己的拋棄式 sandbox」的偵測，在 job 模式下 Manager 無法執行 | 失去一個**行為訊號**（今天它會讓該次呼叫 fail-closed）；不影響任何 durable state——scratch 是一次性、job-owned、每次新建即刪 | **可避免**：選 U-2 的 (2) 就變成「結構上不可能」而非退步 |
+| **R-2** | codex 的 `-o last.json` 第二輸出候選消失，`_extract_json` 從雙候選退成單候選 | 若 codex 的 stdout 被 CLI envelope 污染而 `-o` 是唯一乾淨來源，該次呼叫會落 `planning-output-malformed` | **可避免**：選 U-3 的 result spool，但那是新開一條寫入面 |
+| **R-3** | planner 帳號同時持有 openai 與 google 兩個 provider 的憑證（0818 已部署的事實） | 該帳號被攻陷時兩邊 token 一起失，而 planner 正是吃 untrusted issue 內容的角色 | **不可避免**（除非放棄異質 planner）；屬 U-4，本設計只 codify 已部署的事實 |
+| **R-4** | 逾時終止從「父進程 kill 子進程」變成「Manager `systemctl stop`」 | 若 unit 不理 SIGTERM 或 polkit 的 `stop` 有缺口，逾時後 job 可能仍在跑 | **部分可避免**：U-8 的 `RuntimeMaxSec=` 是第二層 |
+
+以下**不是**退步，列出來避免被誤讀成退步：
+
+- operator 工作樹的保護（D-e）：從「事後偵測 + fail-closed」**升級**為 mount 層不可寫。
+- claude 的 hermetic config（D-g）：從「複製憑證 + 改 env」**升級**為帳號隔離
+  ＋`ProtectHome=yes`。
+- `_contain_operator_drift`（D-f）：範圍縮小到 direct 模式，因為 job 模式下 operator
+  樹結構性不可能被 job 改；程式不刪。

--- a/docs/superpowers/specs/planner-job-downgrade-spec.md
+++ b/docs/superpowers/specs/planner-job-downgrade-spec.md
@@ -1,0 +1,412 @@
+---
+status: accepted
+work_item: planner-job-downgrade
+---
+
+# planner-job-downgrade Specification
+
+issue #672：planning（define／brainstorm）從未降權——`planning_runtime` 的四個 adapter
+與所有 probe 至今仍在 **Manager 行程內**、以 `cortex-manager` 身分 `subprocess.run`
+執行模型 CLI，而該帳號的 passwd 註記逐字寫著 `no model code`。#615（M2）建了
+`cortex-reviewer-job@.service` 並把 **reviewer** 導上去，planner 走的是完全不同的一條
+code path，從未接上模板 unit。
+
+本 spec 定案「把 planning 的模型執行搬到 job runner」這件結構性搬遷的**契約面**：
+搬遷後哪些性質必須逐條成立、哪些現行防線必須等價重建、哪一條會退步、以及失敗時
+必須能被分辨成什麼。**本票只交付 spec／design／plan，不含任何 `paulsha_cortex/` 的
+程式修改**；實作切分見 `docs/superpowers/plans/planner-job-downgrade.md`。
+
+## 背景
+
+現況缺口（皆已在 `origin/main@ae089c3` 與實機部署上複驗）：
+
+- **執行面**：`paulsha_cortex/coordinator/planning_runtime.py:830` 的 `_invoke_json()`
+  以 `runner(argv, cwd=str(sandbox), …)` 呼叫，`runner` 預設值為 `subprocess.run`
+  （同檔 `:1070`）。`_planning_argv()`（同檔 `:43`）回傳的是**裸 executor argv**
+  （`codex exec …`／`claude -p …`／`build_agy_argv(...)`），沒有 `systemd-run`、沒有
+  `cortex-job-shim`、沒有任何模板 unit。
+- **呼叫端**：`paulsha_cortex/coordinator/manager_daemon.py:970` 與 `:1241` 把
+  `planning_runtime.build_production_planning_runtime` 接進 daemon 的 periodic tick
+  與 request executor，daemon 由 `cortex-manager.service` 以 `User=cortex-manager` 執行。
+- **repo 自己的註記已寫明狀態**：`paulsha_cortex/coordinator/job_runner.py:405-408`
+  `JOB_ROLE_REVIEW` 的 rationale 說「M2（#615）：在此之前它們仍在 Manager 行程內以
+  Manager 帳號執行」。reviewer 已藉 `launcher.py:1239 _is_review_persona()` 接上
+  job runner（`read_only` 是三個判準之一），**但 planner 根本沒有走 `SubprocessLauncher`
+  這條路**——它走 `planning_runtime._invoke_json`。那段 rationale 描述的「M2 之前的狀態」，
+  對 planner 而言就是現在的狀態。
+- **登記表已經把這條列成逾期項**：`paulsha_cortex/trust_root/permgen.py` 的
+  `deferred_run_dependencies()` 第四項 `manager-claude-credential` 逐字寫著
+  「`planning_runtime` 的 JSON 呼叫在 **Manager 行程內**直接 exec `claude`（不是派一個
+  降權 job）」，而它的 `disposition` 給的兩條路之一正是「裁決『Manager 不直接跑模型、
+  planning 一律走降權 job』」。本票就是走那一條。
+- **現行部署下 planner 結構性不可用**（#672 實測）：Manager unit 帶
+  `MemoryDenyWriteExecute=yes` ⇒ node 型 executor（codex／copilot）在 Manager 行程內
+  必崩；`ProtectSystem=strict` 讓 `$HOME` 唯讀 ⇒ agy 連 log／state 目錄都建不出來；
+  `/var/lib/cortex-manager` 下**零 executor 憑證**。三者疊起來，
+  `probe_agy_capability()` 與所有 `_probe_identity()` 必然全滅，
+  `select_secondary_planner()` 因此永遠回 `no-heterogeneous-planner`（#668）。
+- **誤報已經發生過**：#670 的 agy code fence 偽失敗（約 17%）被壓成
+  `no-heterogeneous-planner`，把一個**格式解析問題**報成**拓撲問題**，排查方向整個帶偏。
+  本 spec 的 R6 就是為了讓這一類誤報結構上不可能。
+  （#670 的**本體**已由 PR #674 修好：`probe_agy_capability()` 現在會 `strip_code_fence()`、
+  失敗帶 `stdout_excerpt()`，並修掉 `agy models` 改成 `id\tDisplay Name` 兩欄之後造成的
+  100% `model-not-listed`。本 spec 以修後形狀為準；R6 要解的是**上游把診斷吃掉**那一層，
+  那一層 #674 沒碰、也不該由它碰。）
+- **本票新查到的部署缺口**（0818，本票查證，尚未有票）：
+  `/opt/cortex/etc/cortex-manager.env` **沒有宣告 `PSC_REVIEWER_PATH`**，Manager unit 也
+  沒有 `Environment=PATH=`。因此降權 job 的 PATH 就是 PID 1 的預設
+  （`/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/snap/bin`），而
+  `/opt/cortex/toolchain/bin` 不在其中。實測：`codex` 解到系統層的 `/usr/bin/codex`
+  ＝ `codex-cli 0.42.0`，toolchain 那一份是 `codex-cli 0.147.0`；`claude`／`agy` 在
+  該 PATH 上**完全不存在**（rc=127）。這正是 reviewer 模板 unit 註解裡預先警告過的
+  「跑得起來但版本不是你以為的那個」，只是那段註解描述的 EnvironmentFile 內容從未落地。
+
+## Goals
+
+- 讓「Manager 永不執行模型程式碼」這句話在 **define 階段也成立**，而不是只對 builder
+  與 reviewer 成立。
+- 搬遷過程中**不弄丟**現行 `_invoke_json` 的任何一條防線；弄不回來的必須被逐條指名為
+  安全退步，並附代價評估。
+- 讓 probe 的成本從「每輪 tick × 每個 planning identity 各起一批 job」降到可接受，且
+  快取本身不得成為一條「綠燈不承載語意」的新缺口。
+- 讓 planning 失敗可以被機械分辨成「job 起不來 / executor 死 / 輸出不合約」三類，
+  並讓 `no-heterogeneous-planner` 永遠攜帶逐候選拒因。
+- 讓部署面（憑證、PATH、剖面）由登記表與產生器機械導出，而不是由 runbook 手抄。
+
+## Requirements
+
+### R1 planning 的每一次模型呼叫 MUST 經 job runner 以 job 帳號執行（對應 D1、D9）
+
+`PSC_JOB_RUNNER` ∈ {`systemd-run`, `systemd-template`} 時，`planning_runtime` 的
+`invoke_primary`／`questioner`／`secondary`／`integrator`（`planning_runtime.py:1105-1145`）
+與**所有 probe**（`_probe_identity()`、`probe_agy_capability()` 的兩次 CLI 呼叫）
+MUST 經 `job_runner` 起一個 `JOB_ROLE_REVIEW` 的降權 job 執行，MUST NOT 在 Manager
+行程內直接 `subprocess.run` 任何 executor argv。
+
+`PSC_JOB_RUNNER=direct` 時 MUST 逐字維持現行 in-process 行為（含 `_copy_planning_sandbox`
+與前後兩次 `_tree_snapshot`），本 spec 不改變 direct 模式的任何語意。
+
+執行後端的選擇 MUST 只有一個輸入：`job_runner.resolve_runner_mode(os.environ)`——與
+`launcher.SubprocessLauncher._downgraded_mode()` **同一支函式**。MUST NOT 新增
+planning 專用的第二個開關（例如 `PSC_PLANNING_INVOKER`）；第二個開關就是第二份真相，
+而它的失效模式是「以為降權了、其實沒有」。
+
+角色 MUST 是 `job_runner.JOB_ROLE_REVIEW`，由呼叫端在**建構期**固定，MUST NOT 從
+prompt、job spec、模型輸出或任何 job 可影響的來源導出（比照 `launcher._job_role()`
+的既有紀律；`job_runner.SPEC_FORBIDDEN_KEYS` 已在寫端與讀端各擋一次身分欄位）。
+
+若不做：`no model code` 這條帳號註記在 define 階段是假的，而 planner 正是**吃
+untrusted issue 內容**的那個角色；D6「三分已生效」的全稱宣稱在 planner 這一支不成立。
+
+#### Scenario: 降權模式下的 planning 呼叫
+
+- **WHEN** `PSC_JOB_RUNNER=systemd-template` 且 Manager 觸發 define／brainstorm
+- **THEN** 每一次模型呼叫落成一個 `cortex-reviewer-job@<instance>.service` 實例，
+  `User=cortex-reviewer-planner` 由 root-owned unit 檔決定
+- **AND** `cortex-manager` 的行程樹內不出現任何 executor 可執行檔
+
+#### Scenario: direct 模式回歸
+
+- **WHEN** `PSC_JOB_RUNNER` 未設或為 `direct`
+- **THEN** planning 的行為與本票之前逐字相同（含 sandbox 複製與 drift 收容）
+
+### R2 一次性 sandbox 的防線 MUST 逐條有對應，缺一條 MUST 在設計中明講「這條會退步」（對應 D2、D3）
+
+`_invoke_json` 現行的防線由十條組成（`tempfile.TemporaryDirectory`、
+`_copy_planning_sandbox`、`cwd=sandbox`、呼叫後 sandbox 快照比對、呼叫前後 operator
+樹快照比對、`_contain_operator_drift` 的備份與報告、`_seed_hermetic_claude_env`、
+`subprocess` 逾時、`capture_output` 取回 stdout、codex 的 `-o last.json` 第二輸出候選）。
+
+搬遷設計 MUST 對這十條逐條給出「誰、在哪裡、怎麼保證」的對應，且 MUST 明示每一條
+落在下列三類的哪一類：**等價**、**升級（由偵測改為 kernel 阻擋）**、**退步**。
+退步項 MUST 附代價評估與可觀測的替代訊號，MUST NOT 以「反正 sandbox 是拋棄式的」
+帶過而不記錄。
+
+其中兩條的結論在本 spec 直接固定：
+
+1. **operator 工作樹的保護 MUST 從「事後偵測 + fail-closed」升級為「mount 層不可寫」**。
+   `repo-source-tree`（`/var/lib/cortex/repos/<slug>`）MUST NOT 出現在 reviewer 模板
+   unit 的 `ReadWritePaths=` 中（現況已成立，且該 unit 註解已逐字寫明「下方
+   ReadWritePaths **不含**來源樹」）。因此「planner 經絕對路徑寫 operator 樹」這條
+   路在降權模式下由 `ProtectSystem=strict` 直接關掉，不再依賴呼叫端記得比對雜湊。
+2. **「模型是否弄髒了自己的拋棄式 sandbox」這條偵測 MUST NOT 由被驗方自證**。
+   job 側 wrapper 自行 snapshot 再寫進 log 是**明確禁止**的實作（違反 #628／#540
+   「被驗方不得在自己的進程裡產生自己的驗收證據」）。設計 MUST 在「Manager 側可驗」
+   與「結構上不可能發生」兩條路裡擇一，並在 design 註明取捨。
+
+若不做：搬遷會靜默弄丟 operator 樹的唯一防線，而症狀（planning 產出正常）與正常
+狀態完全一樣——這正是本 repo 已經記錄過三次的「綠燈不承載語意」家族。
+
+#### Scenario: 模型嘗試寫 operator 工作樹
+
+- **WHEN** 降權模式下 planner 以絕對路徑寫 `/var/lib/cortex/repos/<slug>` 底下任一檔
+- **THEN** 該寫入被 `ProtectSystem=strict` 擋下（EROFS），Manager 側無需比對雜湊
+- **AND** planning 呼叫本身的成敗由 executor 的退出碼與輸出決定，不受此影響
+
+### R3 probe 結果 MUST 跨 tick 快取，且快取判準 MUST 涵蓋執行後端（對應 D5）
+
+`build_production_planning_runtime()` 目前在**每次建構**時對每個 planning-capable
+identity 跑一次 probe，而它由 `manager.run_auto_claim_scan()`（periodic tick）與
+`apply_work_action()` 兩條路徑呼叫。搬到 job 之後，每個 probe 就是一個 job
+（`probe_agy_capability()` 是**兩個**：`agy models` 加一次 smoke）。
+
+probe 結果 MUST 落成 Manager-owned 的 durable 快取，並 MUST 滿足：
+
+- 快取 key MUST 至少涵蓋：`(executor, model_id)`、executor 可執行檔的解析結果與其
+  inode 指紋、該帳號憑證檔的指紋、加固剖面名與模板 unit 檔本身的指紋、roster
+  解析結果的內容雜湊、以及 **`PSC_JOB_RUNNER` 的值**。
+- 最後一項是硬性要求：direct 模式取得的 probe 結論 MUST NOT 被 job 模式採信（反之亦然）。
+  兩者的執行環境（PATH、HOME、憑證、seccomp、MDWE）完全不同，共用一格快取等於讓
+  開發機的成功替生產環境背書。
+- 快取檔不存在／JSON 損毀／schema 版本不符／指紋不符 MUST 一律視為 miss 並重探；
+  MUST NOT 因為「上一次是 ready」而在無法重探時沿用 ready（**fail-closed**）。
+- 快取 MUST 同時保存失敗側的完整診斷（reason、diagnostic、退出碼、stdout 前 200 字），
+  供 R6 的失敗分類消費。
+- 快取資產 MUST 進 `trust_root` 登記表，writers／readers 只有 MANAGER，且 MUST NOT
+  出現在任何 job 模板 unit 的 `ReadWritePaths=` 中。
+
+若不做：每輪 tick 起一批 job 去問模型「你是誰」，成本不可接受；而若快取做成
+fail-open，一個曾經 ready 過的 provider 會在憑證過期後繼續被當成可用，症狀是
+planning 到很後面才失敗。
+
+#### Scenario: 模板 unit 換版後的重探
+
+- **WHEN** operator 重跑產生器落下新的 `cortex-reviewer-job@.service`（剖面表改動、
+  RWP 增列、加固項調整任一者）
+- **THEN** 全部 probe 快取因模板 unit 指紋改變而失效並重探
+- **AND** 不需要任何人記得手動清快取
+
+#### Scenario: 快取檔損毀
+
+- **WHEN** 快取 JSON 無法解析
+- **THEN** 視為 miss 重探，MUST NOT 沿用任何舊結論
+- **AND** 落一筆結構化 log，指明是快取損毀而非 probe 失敗
+
+### R4 加固剖面 MUST 沿用單一判定點，MUST NOT 新增第二份剖面表（對應 D6）
+
+planner 的 job MUST 經 `job_runner.prepare_systemd_template(env, job_id=…,
+executor=identity.executor, role=JOB_ROLE_REVIEW)` 取得剖面，剖面的唯一輸入 MUST 是
+`identity.executor`，未登記的 executor MUST fail-closed（不落到寬鬆那一份）。
+
+planning 路徑 MUST NOT 自帶任何 executor→剖面的對應表；那張表的唯一真相在
+`permgen` 的 `EXECUTOR_HARDENING_PROFILE`（由 `EXECUTOR_TOOLS.needs_node` 機械導出），
+`job_runner` 那一份是成對契約、已有測試釘住兩邊逐字相等。
+
+**現行剖面表是對的，本 spec 不預設任何待修的剖面缺口。** #673 原 body 主張
+`SystemCallFilter=@system-service` 會讓 codex／copilot 在全部 job unit 下靜默 rc=1；
+該主張**已被開票者自行更正並撤回**，#673 由 **PR #677** 以「不放寬任何 syscall」收尾。
+實機複驗（本票獨立確認）：八份 unit
+（六份 job 模板 ＋ manager ＋ monitor）**全部帶 `SystemCallErrorNumber=EPERM`**
+（`cortex-reviewer-job@.service:148`、兩份 `-jit` 的 `:162`、`cortex-manager.service:89`），
+從權限產生器落地的第一個 commit 起就在。有這一條時被過濾的 syscall 回 `EPERM` 而非
+`SECCOMP_RET_KILL_PROCESS`，V8 走 fallback，codex／copilot 照常啟動。在真 unit 的
+**完整** property 集合下實測：codex／copilot 在 `jit` 剖面 rc=0，claude／agy 兩種剖面
+皆 rc=0——**預設派工路徑沒有壞**。實際被過濾的是 `pkey_alloc`（`@pkey`），不是
+`landlock_*`／`seccomp`（`@sandbox`）；加 `@sandbox` 對症狀完全無效。
+
+因此本 spec 的 R4 就是「照現行 `EXECUTOR_HARDENING_PROFILE` 機械導出」，
+planner 上 job 之後不需要任何剖面面的前置修正。
+
+**但剖面不是唯一的加固維度**（PR #677）：seccomp 過濾語意是**剖面之外的第二個維度**
+——`permgen.PROFILE_LOCKED_KEYS`（`SystemCallFilter`／`SystemCallErrorNumber`）兩份剖面
+逐字相同，`ToolchainProgram.filtered_syscalls` 與 `filtered_syscall_surfaces()` 記錄
+實機量到的過濾項，`seccomp_filter_is_fatal()` 回答「被過濾會不會殺行程」，
+`_validate_seccomp_tolerance()` 在 import 時強制承重的那條不得被靜默拿掉。
+本 spec 對此的要求是**消費、不重造**：R3 的快取指紋因此 MUST 含**模板 unit 檔本身**
+（只放剖面名涵蓋不到第二維），R6 的 `executor-silent-exit` 診斷 MUST 帶
+`seccomp_filter_is_fatal()` 的結果。
+
+剖面表若日後因其他理由改動（新增 executor、新增剖面名），需要跟著動的**只有**
+`permgen` 的那張表與 `job_runner` 的成對常數；本設計零改動——這正是「不新增第二個
+判定點」買到的東西。唯二會波及本設計的是：(i) R3 的快取指紋必須含模板 unit 檔本身，
+剖面表改動才會自動使快取失效；(ii) 若新增剖面名，R8 的驗收矩陣要多一列。
+
+### R5 planner 帳號的憑證 MUST 由登記表機械導出（對應 D7）
+
+`cortex-reviewer-planner` 已於 0818 部署（本票複驗）：
+
+```
+/var/lib/cortex-reviewer-planner/
+  drwxr-xr-x root:root                       .codex/
+  -rw------- cortex-reviewer-planner:…       .codex/auth.json      ← 檔 job-owned、目錄 root-owned
+  lrwxrwxrwx root:root .gemini -> /var/lib/cortex-reviewer-planner/cache/gemini
+  drwx------ cortex-reviewer-planner:…       cache/                ← 已在 unit 的 ReadWritePaths 內
+```
+
+這份部署在**功能上**足夠（agy 的可寫狀態樹落在已放行的 `cache`；`agy models` 列出
+`gemini-3.1-pro-high`，capability smoke 逐位元等於 expected），但在**治理上**不足，
+兩個缺口：
+
+1. 實機 `cortex-reviewer-job@.service` 的 `ReadWritePaths=` 只有
+   `/var/lib/cortex-reviewer-planner/cache` 與 `/var/lib/cortex/coordinator/review-verdicts`
+   ——**不含 `.codex/auth.json`**。該 unit 自己的註解花了七行描述這條路徑該怎麼掛，
+   但登記表只有 `builder-executor-credential` 一列，所以產生器產不出它。淨效果：
+   `ProtectSystem=strict` 下憑證**讀得到、改不了**，token 過期那天靜默 refresh 失敗。
+   這正是 `permgen.deferred_run_dependencies()` 第一項逐字描述的逾期項。
+2. `.gemini → cache/gemini` 這個 root-owned symlink 是一條**手動落位、登記表不知道**
+   的部署決定。換一台機器部署、或重跑產生器，它不會出現。
+
+因此本 spec 要求：planner 帳號的憑證面 MUST 由 `trust_root` 登記表表達，MUST NOT 只
+由 runbook 步驟落位。具體 MUST 涵蓋：`cortex-reviewer-planner` 的 executor 憑證檔
+（列入 `IN_PLACE_CONTENT_WRITE_ASSETS`，`ReadWritePaths` 掛檔案本身而非父目錄）、
+以及 agy 狀態樹的錨定方式。
+
+`executor_credential_relpath` 目前是**單一部署決定**（`.codex/auth.json`），一個帳號
+只表達得了一份憑證——而 planner 需要**兩個 independence domain** 才有異質性。
+把它擴成 per-(account, executor) 的表（#668 的 B 案）是**新的安全決策**而非既有裁決
+的延伸：擴大的是該帳號被攻陷時的 provider 曝險面。本 spec **不做這個決定**，只要求
+設計把選項與取捨列清楚交給 operator（見 design 的未決問題總覽 U-4／U-5）。
+
+若不做：憑證是「這台機器上有、下一台沒有」的隱性狀態，而失效症狀（token 過期）
+與 planning 內容問題長得一樣。
+
+### R6 planning 失敗 MUST 三分，且 `no-heterogeneous-planner` MUST 攜帶逐候選拒因（對應 D8）
+
+搬到 job 之後，同一個「planning 沒成功」有三個結構上不同的來源，MUST 能被機械分辨：
+
+| 族 | 條件 | classification |
+|---|---|---|
+| `planning-job-start-failed` | job 起不來：polkit 拒絕、模板未安裝、shim 不可執行、spec spool 不可寫、instance 已 active、`confirm_template_instance_started` 逾時 | `environment` |
+| `planning-executor-failed` | job 起來了、executor 非零退出或無任何輸出 | `environment` |
+| `planning-output-malformed` | executor 正常退出、輸出不符 JSON 契約 | `content`（既有 transient-service 例外仍適用） |
+
+`planning-executor-failed` MUST 另外標記 **`executor-silent-exit`** 子類：rc≠0 且
+stdout 與 stderr 皆空。這一類是整個家族裡最難查的一種——**連錯誤訊息都沒有**，因此
+歸因會落到模型、prompt、逾時或憑證，而不會落到執行環境。它 MUST 被顯式命名，並
+MUST NOT 被壓成任何拓撲原因。
+
+該子類的診斷 MUST 帶 `permgen.seccomp_filter_is_fatal()` 的結果，並 SHOULD 帶
+`filtered_syscall_surfaces()` 中對應該 (executor, 剖面) 的已知過濾項。理由：這條子類
+唯一的資訊價值就是「該往哪個方向查」，而「seccomp 是否致命」正是最容易被誤猜、
+也最容易機械回答的那一維——#673 整張票走偏，正因為當時沒有任何地方回答得了它。
+
+（#673 原 body 曾把這一類的一個實例歸因到 `SystemCallFilter`，該歸因已被開票者更正
+撤回——但「rc≠0 而完全無輸出」這個**類別**本身確實存在且值得具名，這是本子類保留的
+理由；本 spec 不對它的成因預設任何特定 syscall。）
+
+`select_secondary_planner()` 回傳 `no-heterogeneous-planner` 時，MUST 同時攜帶
+**逐候選的拒因表**：每個 planning-capable identity 記錄它為什麼沒被選中
+（`same-domain`／`probe-not-ready:<reason>:<diagnostic>`／`probe-identity-mismatch`／
+`probe-absent`），且 probe 側的 diagnostic MUST 帶得動 R3 快取裡保存的實際證據
+（stdout 前 200 字、退出碼）。`run_heterogeneous_brainstorm` MUST 把該表渲染進
+`BrainstormResult.reason`。
+
+`_classify_planning_failure()` MUST 能從拒因表看出「全部候選都是 environment 級拒因」
+並把整體改判 `environment`——今天 `no-heterogeneous-planner` 一律落 `content`，而
+`content` 在 `_resume_decision` 一律不浮現 `recover-planning`，等於一條死路。
+
+若不做：#670 那一類誤報會原封不動地重演，只是這次的誤報來源會多出「job 起不來」
+與「seccomp 靜默」兩種，而它們的症狀（空輸出）與模型不聽話完全無法區分。
+
+#### Scenario: agy 回傳被 code fence 包住的正確 JSON
+
+- **WHEN** probe 的 stdout 是 ` ```json\n{…}\n``` `
+- **THEN** blocking reason 為
+  `no-heterogeneous-planner (agy/gemini-3.1-pro-high: probe-not-ready malformed-output …)`
+- **AND** operator 從 reason 就看得出這是格式問題，不必重跑六遍才發現
+
+#### Scenario: executor 在 job unit 下靜默非零退出
+
+- **WHEN** job 成功啟動但 executor 回非零且 stdout 與 stderr 皆空
+- **THEN** 失敗落 `planning-executor-failed / executor-silent-exit`，classification
+  為 `environment`，reason 指名 unit、加固剖面與實際解析到的可執行檔絕對路徑
+- **AND** MUST NOT 出現 `no-heterogeneous-planner` 作為唯一線索
+
+### R7 逾時 MUST 由 Manager 側強制終止（對應 D4）
+
+現行 `_invoke_json` 以 `subprocess.run(..., timeout=timeout_seconds)` 保證呼叫必然在
+上限內返回。降權模式下 Manager 拿到的是 `systemctl start --wait` 的 client 進程，而
+實機 `cortex-reviewer-job@.service` **沒有 `RuntimeMaxSec=`／`TimeoutStartSec=`**
+（本票複驗），因此一個掛住的模型會讓 client 無限等待。
+
+降權模式 MUST 在 Manager 側強制上限：等待逾時後 MUST 主動停止該 unit（polkit 已
+放行 `stop`），並落 `planning-job-timeout`（歸 `environment`）。MUST NOT 只是放棄
+等待而讓 job 繼續跑——那會讓下一次同名 instance 撞上
+`job-runner-template-instance-busy`，症狀與逾時完全無關。
+
+若不做：一次 planning 逾時會把 Manager 的 periodic tick 永久卡住。
+
+### R8 加固面的驗證 MUST 走既有的機械導出機制（對應 D13、D6、D10）
+
+任何形如「某 executor 在某加固剖面下可用**或不可用**」的宣稱，驗證環境 MUST 由
+**已落檔的 unit 機械讀出全部 property** 再複製，MUST NOT 手抄 property 子集。
+
+**這條的機制已由 PR #677 落地，本 spec 要求消費它、不得重造**：
+
+| 機制 | 用途 |
+|---|---|
+| `permgen.unit_replica_properties(unit_text, *, instance, require_hardening=True)` | 已落檔 unit → `systemd-run --property=` 的**完整**清單（契約「全帶，不選」）；少任一加固鍵即 `UnitReplicaDriftError` 且 stdout 保持空 |
+| CLI `python -m paulsha_cortex.trust_root unit-replica <unit｜->` | 上一支的命令列入口（`-` 讀 stdin，可接 `systemctl cat`） |
+| runbook 第 4e 步的 `psc_run_under <unit 字幹> <命令>` | runbook 與測試共用**同一個**「真實加固面」定義 |
+
+實作票的驗收矩陣 MUST 走 `psc_run_under`／`unit-replica`。測試或 runbook 裡任何
+**手寫的 `--property=` 清單**都違反本條。
+
+**判準是雙向的**：手抄子集比 production **寬**會產生假綠（宣稱可用、實機不可用），
+比 production **嚴**會產生假紅（宣稱不可用、實機其實好的）。兩個方向都必須擋。
+本 repo 已有四個實例，而且兩個方向都出現過：
+
+| 事故 | 手抄的偏差方向 | 產生的錯誤 |
+|---|---|---|
+| #638 | 單 UID 環境讓 ACL 斷言真空（比 production 寬） | **假綠**——斷言恆真，什麼都沒驗到 |
+| #657 | 同型（比 production 寬） | **假綠** |
+| #673 原 body | 十條 property 複本漏抄 `SystemCallErrorNumber=EPERM`（比 production **嚴**） | **假紅**——製造出 production 不存在的 rc=1，並據此開了一張要求放寬 seccomp 的票 |
+| #673 的 repro 步驟本身 | 同上 | **假紅**——第二次踩同一個坑，只是這次是在「修 #643 漏抓」的名義下 |
+
+第四個實例特別值得記錄：它是在**已經知道「手抄子集會出錯」**的前提下，又一次用手抄
+子集去驗證，並且錯誤方向翻轉。這**強化**而非削弱本條要求——「機械讀取」不是為了防
+某一個特定方向的錯，而是為了讓「驗證環境 ≠ production 環境」在結構上不可能發生。
+`require_hardening=True` 的預設與 `UnitReplicaDriftError` 就是這句話的可執行形式。
+
+**成對約束**：`SystemCallFilter=` 與 `SystemCallErrorNumber=` MUST 同進同出
+（#677 已以 `permgen.PROFILE_LOCKED_KEYS` 固化）。只帶前者會把「被過濾的 syscall 回
+`EPERM`（呼叫方可 fallback）」偷換成「`SECCOMP_RET_KILL_PROCESS`（行程直接死）」，
+而症狀（空輸出）一模一樣。#643 已記錄過這一條，#673 仍然重蹈。
+
+驗收矩陣 MUST 至少涵蓋：`{codex, claude, agy} × {該 executor 實際解析到的剖面}`，
+每格記錄 rc、stdout 前 80 字、以及**解析到的可執行檔絕對路徑與版本字串**——最後一項
+是本票新查到的 PATH 缺口（見背景段）要求的：跑得起來不代表跑的是預期那一份，
+而「解析到非預期版本」**不會表現為失敗**。
+
+#### Scenario: 以 property 子集複本取得的宣稱
+
+- **WHEN** 驗證僅以帶部分 property 的 transient unit 執行
+- **THEN** 該結果 MUST NOT 被當作「可用」的證據
+- **AND** 同樣 MUST NOT 被當作「不可用」的證據——偏嚴的複本會產生假紅
+
+#### Scenario: 落檔 unit 少了加固鍵
+
+- **WHEN** 以 `unit_replica_properties(..., require_hardening=True)` 導出複本而該 unit
+  缺少任一加固鍵
+- **THEN** MUST 以 `UnitReplicaDriftError` fail-closed，且 stdout 保持空
+- **AND** MUST NOT 產出一份「能跑但比 production 弱」的複本
+
+## 非目標
+
+- **不改成非同步 planning**。把 planning 拆成跨 tick 的狀態機（spool + resume）是更
+  大的一次重構，且與本票要解的「執行身分」正交。本票維持同步阻塞語意——降權模式
+  下阻塞源從子進程換成 `systemctl start --wait`，粒度不變。留給後續票。
+- **不改 planning 的 prompt、契約、驗收判準**。`_JSON_OUTPUT_CONTRACT`、
+  `required_heading_hint()`、`validate_question_pack` 等一律不動。
+- **不重做 #670**（agy probe 的 code fence）。它的**本體**已由 PR #674 修好
+  （`strip_code_fence()`／`stdout_excerpt()`／`agy models` 兩欄漂移）；本票要解的是
+  上游把診斷吃掉那一層（R6），兩者不重疊。
+- **不改剖面表、不改 unit 的加固項**。現行 `EXECUTOR_HARDENING_PROFILE` 實測可用
+  （見 R4），本票不預設任何待修的剖面缺口，也不對 `SystemCallFilter` 提出任何放寬。
+- **不做 provider 層的獨立**。job 帳號用的仍是與 operator 同一個 provider 帳號；
+  三分買到的是檔案系統層隔離，不是 provider 層獨立（`builder-executor-credential`
+  的登記表 note 已有完整論證）。
+- **不動 unit 檔、不動部署**。本票是設計；unit 的實際改動（憑證 RWP 第二列）在實作
+  票，且需 operator 先行裁決。
+
+## 驗收面
+
+- R1–R8 逐條可對應到 `origin/main` 上至少一個具體檔案／函式作為改動錨點
+  （`planning_runtime.py`、`job_runner.py`、`launcher.py`、`model_identities.py`、
+  `planning.py`、`manager.py`、`trust_root/permgen.py`、`trust_root/registry.py`）。
+- R2 的十條防線對應表可逐條轉譯成一個測試或一條 unit 檔斷言。
+- R3 的快取指紋可轉譯成「改動任一輸入 ⇒ 快取失效」的參數化測試。
+- R6 的三分可轉譯成三個 RED 測試（各自對應一種注入的失敗），且
+  `no-heterogeneous-planner` 的 reason 字串可用正規表示式釘住必含拒因表。
+- R8 的矩陣是實機步驟，落在 runbook 而非測試；其**輸出格式**（含解析路徑與版本）
+  由本 spec 固定。

--- a/openspec/changes/2026-08-18-planner-job-downgrade/design.md
+++ b/openspec/changes/2026-08-18-planner-job-downgrade/design.md
@@ -1,0 +1,133 @@
+---
+status: accepted
+work_item: planner-job-downgrade
+---
+
+# planner-job-downgrade Design
+
+本檔為摘要；完整論證（含十條防線的逐條對應表、未決問題總覽、安全退步總覽）在
+`docs/superpowers/specs/planner-job-downgrade-design.md`。
+
+## Decisions
+
+### D1 執行後端抽象成 `PlanningInvoker`
+
+抽出「拿 identity + prompt、回傳 stdout 與退出狀態」的介面，兩份實作
+（`InProcessPlanningInvoker` 保留現行十條防線；`JobPlanningInvoker` 走 job runner）。
+JSON 抽取留在共用層，兩者吃同一份。選擇點只有
+`job_runner.resolve_runner_mode(os.environ)`——與 launcher 同一支函式，**刻意不新增
+planning 專用的第二個開關**（第二個開關的失效模式是「以為降權了、其實沒有」）。
+
+### D2 十條防線的逐條對應
+
+`tempfile` 一次性、`cwd=sandbox`、drift 收容、hermetic claude env、逾時、stdout 取回
+＝等價或升級；operator 樹保護從「事後比對雜湊」升級為 `ProtectSystem=strict` ＋
+RWP 不含 `repo-source-tree` 的 **mount 層不可寫**；兩條退步逐條指名：
+**R-1** sandbox dirty 偵測（Manager 進不去 job-owned 樹，且明確禁止由被驗方自證）、
+**R-2** codex `-o last.json` 第二輸出候選消失。兩條各有可避免路徑（U-2、U-3）。
+
+### D3 輸出通道沿用 reviewer 已走通的「Manager-owned log ＋ shim O_APPEND」
+
+不新開通道。planning 的 wrapper 顯式退化成「只有模型 argv」一段——不跑 gate、不產
+bundle、不寫 verdict、不寫 sentinel，且不靠既有旗標碰巧為 None。
+
+### D4 逾時由 Manager 側 `wait(timeout)` → `systemctl stop`
+
+不靠 unit 的 `RuntimeMaxSec=`：planning 的四種呼叫上限不同，而 job spec **結構性禁止
+攜帶任何 property**（`SPEC_FORBIDDEN_KEYS`），那條禁令是對的，不該為逾時鑽洞。
+停止後必須確認 unit 離開 active，否則下一輪會撞 `instance-busy`，錯誤訊息與逾時無關。
+
+### D5 probe 快取：Manager-owned、指紋含執行後端、fail-closed
+
+新增登記表資產 `planning-probe-cache`（Manager-owned 0600，writers／readers 只有
+MANAGER，**不進任何 job unit 的 RWP**——快取一旦可由 job 寫，「這個 provider 是 ready 的」
+就變成模型可以自證的東西）。指紋含 `PSC_JOB_RUNNER`（direct 的成功不得替 job 模式背書）、
+executor 可執行檔 inode 指紋、憑證檔指紋、加固剖面 ＋ **模板 unit 檔本身**的指紋、
+roster 內容雜湊。模板 unit 進指紋是刻意的：**任何**讓 operator 重跑產生器落新 unit 的
+改動，在落檔那一刻就讓全部快取自動失效重探，不需要任何人記得清快取。
+
+### D6 剖面零新增判定點；現行剖面表**實測可用**，無前置修正
+
+剖面唯一來源是 `prepare_systemd_template(executor=…)`，planning 側零對應表。
+
+本設計原本寫著「假設 #673 已修」，**該前提是錯的，已移除**。八份 unit 全帶
+`SystemCallErrorNumber=EPERM`（`cortex-reviewer-job@.service:148`、兩份 `-jit` 的 `:162`、
+`cortex-manager.service:89`），被過濾的 syscall 回 `EPERM` 而非 `SECCOMP_RET_KILL_PROCESS`，
+V8 走 fallback ⇒ codex／copilot 照常啟動；真 unit 完整 property 集合下實測
+codex／copilot 在 `jit` rc=0、claude／agy 兩剖面皆 rc=0。實際被過濾的是 `pkey_alloc`
+（`@pkey`），加 `@sandbox` 無效。**現行 `EXECUTOR_HARDENING_PROFILE` 就是對的**，
+planner 上 job 不需要任何剖面面的前置修正。#673 已由 PR #677 以「不放寬任何 syscall」收尾。
+剖面表日後若因其他理由改動，本設計零改動、只動驗收矩陣。
+
+**#677 另立了一個本設計必須消費的維度**：seccomp 過濾語意在剖面**之外**
+——`PROFILE_LOCKED_KEYS`（`SystemCallFilter`／`SystemCallErrorNumber`）兩剖面逐字相同，
+`ToolchainProgram.filtered_syscalls` 與 `filtered_syscall_surfaces()` 記錄實機量到、
+有 audit 背書的過濾項（現況四筆全部 `fatal=False`），`seccomp_filter_is_fatal()` 回答
+「被過濾會不會殺行程」，`_validate_seccomp_tolerance()` 在 import 時強制承重那條不得被
+靜默拿掉。影響：D5 的指紋不能只放剖面名（要放**模板 unit 檔本身**），D8 的
+`executor-silent-exit` 診斷要帶 `seccomp_filter_is_fatal()` 的結果。
+
+### D7 憑證 codify：沿用 #671 的機制，不重造
+
+`IN_PLACE_CONTENT_WRITE_ASSETS`（RWP 掛檔案本身而非父目錄）與
+`inapplicable_home_anchored_assets()`（二分部署下機械排除）已經把 #640 當年
+「不敢登記第二份憑證」的唯一理由拆掉。補一列不需要改產生器。
+部署順序固定為「憑證落位 → 重跑產生器 → daemon-reload」（憑證不存在時帶該 RWP 的
+unit 會刻意起不來）。雙 provider 憑證屬新的安全決策，列為 U-4／U-5 交 operator。
+
+### D8 錯誤語意三分 ＋ 逐候選拒因表
+
+`planning-job-start-failed`／`planning-executor-failed`（含 `executor-silent-exit`
+子類——「連錯誤訊息都沒有」的那一種；診斷 MUST 帶 `seccomp_filter_is_fatal()` 的結果，
+不對成因預設任何特定 syscall）／`planning-output-malformed`。
+`SecondarySelection` 增 `rejections`，`no-heterogeneous-planner` 從「結論」變成
+「結論 ＋ 每個候選為什麼落選」，並在 reason 裡渲染。
+`_classify_planning_failure` 對含 environment 級拒因的情形改判 environment，讓
+`recover-planning` 有路（今天一律 `content` ⇒ 死路）。
+
+### D9 一次 planning 呼叫 = 一個 unit 實例
+
+instance 名 `plan-<run_id 前 12 字>-<purpose>-<序號>`，先過
+`job_workspace.JOB_SEGMENT_RE`。`purpose` 只是識別字串，不進任何決策欄位。
+probe 在 `run_id="ephemeral"` 的呼叫端必須另帶隨機後綴，否則並行 probe 互撞
+`instance-busy`。
+
+### D10 PATH 缺口是實作票 E 的前置
+
+env 檔無 `PSC_REVIEWER_PATH` ⇒ job 的 PATH 是 PID 1 預設 ⇒ `claude`／`agy` rc=127、
+`codex` 解到 `0.42.0`。`claude`／`agy` 的 rc=127 至少會失敗；**`codex` 那一種不會失敗**
+——它安靜地用舊 CLI 產出結果。後者只有把 `resolved_binary` 與 `binary_version` 記進
+失敗診斷與驗收矩陣才看得見（D8／R8）。
+
+### D11 分階段 land：能，但切換一次到位
+
+票 A／B／C 可在 direct 部署上獨立 land 並各自產生價值。切換不能一半一半——probe 快取
+的指紋含 `PSC_JOB_RUNNER`，混用會讓兩種語意的結論在同一輪並存。
+
+### D12 明確不做：非同步 planning 狀態機
+
+與本票要解的「執行身分」正交，且需要 `WorkflowRun` schema 改動。本票維持同步阻塞語意
+（粒度與今天相同，只多出 job 啟動延遲）。
+
+### D13 驗證方法的硬規則：加固面一律機械導出——**機制已由 PR #677 落地，本設計消費它**
+
+凡宣稱「某 executor 在某加固剖面下可用／不可用」，驗證環境 MUST 由已落檔 unit 機械
+讀出全部 property 再複製，MUST NOT 手抄子集。**這條已經是程式**：
+`permgen.unit_replica_properties()`（契約「全帶，不選」，`require_hardening=True` 下
+少任一加固鍵即 `UnitReplicaDriftError` 且 stdout 保持空）、CLI
+`trust_root unit-replica`、runbook 第 4e 步的共用探針 `psc_run_under`。
+實作票的驗收矩陣 MUST 走它們，MUST NOT 自行組 `--property=` 清單。
+`SystemCallFilter=` 與 `SystemCallErrorNumber=` 的成對約束已由 `PROFILE_LOCKED_KEYS`
+固化（只帶前者會把「回 `EPERM`、呼叫方可 fallback」偷換成「行程直接死」，而兩者症狀
+都是空輸出）。
+
+**判準雙向，四個實例兩個方向**：#638、#657 手抄得比 production **寬** ⇒ **假綠**
+（斷言真空）；#673 原 body 與其 repro 手抄得比 production **嚴**（漏 
+`SystemCallErrorNumber=EPERM`）⇒ **假紅**，並據此開票要求放寬 seccomp。假紅更貴——它會
+讓人去「修」一個不存在的問題，並在修的過程中放寬一條真的有用的加固項。因此規則的正確
+形式是「驗證環境 ≠ production 環境在結構上不可能」，與偏差方向無關。
+
+#643 早已記錄過 `SystemCallErrorNumber=EPERM` 這一條，#673 仍然重蹈——**已經寫下來的
+教訓，在下一次用手抄複本時不會自動生效**，這正是它必須變成機械規則而非註解的理由。
+規則的理由記在本設計裡，因為 planner 是**下一個**會做這種宣稱的地方；
+runbook 第 4e／5-2b 步已由 #677 一併轉為機械導出，不需另開票。

--- a/openspec/changes/2026-08-18-planner-job-downgrade/proposal.md
+++ b/openspec/changes/2026-08-18-planner-job-downgrade/proposal.md
@@ -1,0 +1,122 @@
+---
+status: accepted
+work_item: planner-job-downgrade
+---
+
+## Goals
+
+定案「把 planning（define／brainstorm）的模型執行從 Manager 行程內搬到降權 job runner」
+這件結構性搬遷的契約面。本票以**設計文件為唯一交付**（比照 #210／#275／#279 的
+design-doc 票慣例），**不落地任何 `paulsha_cortex/` 的程式修改**；實作切分成六張後續票，
+依賴順序與逐票驗收見 `docs/superpowers/plans/planner-job-downgrade.md`。
+
+## Why
+
+issue #672 的訴求逐點查證：
+
+1. **「planner 從來沒有被降權」——查證屬實。**
+   `paulsha_cortex/coordinator/planning_runtime.py:830` `_invoke_json()` 以
+   `runner(argv, …)`（預設 `subprocess.run`，同檔 `:1070`）在呼叫端行程內執行；
+   `:43` `_planning_argv()` 回傳裸 executor argv（無 `systemd-run`、無 `cortex-job-shim`、
+   無模板 unit）；`manager_daemon.py:970`／`:1241` 把該 runtime 接進以
+   `User=cortex-manager` 執行的 daemon。reviewer 已藉 `launcher.py:1239 _is_review_persona()`
+   接上 job runner，**planner 走的是完全不同的一條 code path**。
+
+2. **「repo 自己已經把這條記成逾期項」——查證屬實，而且有兩處。**
+   `job_runner.py:405-408` 的 `JOB_ROLE_REVIEW` rationale 逐字寫「M2（#615）：在此之前
+   它們仍在 Manager 行程內以 Manager 帳號執行」；`permgen.deferred_run_dependencies()`
+   第四項 `manager-claude-credential` 逐字寫「`planning_runtime` 的 JSON 呼叫在
+   **Manager 行程內**直接 exec `claude`（不是派一個降權 job）」，其 `disposition` 給的
+   兩條路之一正是「裁決『Manager 不直接跑模型、planning 一律走降權 job』」——本票走那一條。
+
+3. **「搬遷最容易弄丟一次性 sandbox 的防線」——查證屬實，且比 issue 描述的更細。**
+   `_invoke_json` 現行有十條防線（含兩次 `_tree_snapshot`、`_copy_planning_sandbox`、
+   `_contain_operator_drift` 的備份與三道閘門、`_seed_hermetic_claude_env`、
+   codex 的 `-o` 第二輸出候選）。design D2 給出逐條對應表，並把每條標成
+   等價／升級／退步，退步兩條（R-1、R-2）附代價與可避免路徑。
+
+4. **「probe 成本不可接受」——查證屬實，而且比預期嚴重。**
+   `build_production_planning_runtime()` 對每個 planning-capable identity 各跑一次
+   probe，`_probe_identity` 每次做**兩次整棵 repo 的 `copytree`**，`probe_agy_capability`
+   是**兩次 CLI 呼叫**；而該函式由 `manager.run_auto_claim_scan()`（periodic tick）
+   呼叫。搬到 job 之後每個 probe 就是一個 unit 實例。design D5 定案快取。
+
+5. **「一接上 job unit 就會撞 #673」——查證**不**屬實，該前提已由開票者更正撤回。**
+   #673 原 body 主張 `SystemCallFilter=@system-service` 讓 codex／copilot 在全部 job
+   unit 下靜默 rc=1。實機複驗（本票獨立確認）：八份 unit（六份 job 模板 ＋ manager ＋
+   monitor）**全部帶 `SystemCallErrorNumber=EPERM`**（`cortex-reviewer-job@.service:148`、
+   兩份 `-jit` 的 `:162`、`cortex-manager.service:89`），從權限產生器落地的第一個 commit
+   起就在；有這一條時被過濾的 syscall 回 `EPERM` 而非 `SECCOMP_RET_KILL_PROCESS`，
+   V8 走 fallback ⇒ codex／copilot 照常啟動。真 unit 的**完整** property 集合下實測：
+   codex／copilot 在 `jit` 剖面 rc=0，claude／agy 兩種剖面皆 rc=0——**預設派工路徑沒有壞**。
+   實際被過濾的是 `pkey_alloc`（`@pkey`），不是原先猜測的 `landlock_*`／`seccomp`
+   （`@sandbox`）。誤判來源是 repro 手抄十條 property、漏抄 `SystemCallErrorNumber=EPERM`，
+   **比 production 更嚴格**。#673 已由 **PR #677** 以「不放寬任何 syscall」收尾，並
+   順帶把「加固面複本全量機械導出」做成程式（`permgen.unit_replica_properties()`／
+   CLI `trust_root unit-replica`／runbook 共用探針 `psc_run_under`）。因此 planner 上
+   job **不需要任何剖面面的前置修正**，且本設計的驗收面**消費 #677 的機制、不重造**。
+
+6. **本票另外查到一條沒有票的部署缺口。**
+   `/opt/cortex/etc/cortex-manager.env` **沒有 `PSC_REVIEWER_PATH`**，Manager unit 也沒有
+   `Environment=PATH=` ⇒ 降權 job 的 PATH 是 PID 1 預設
+   （`/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/snap/bin`）。實測：`codex` 解到
+   `/usr/bin/codex`＝`codex-cli 0.42.0`（toolchain 那份是 `0.147.0`），`claude`／`agy`
+   **不存在** ⇒ rc=127。reviewer 模板 unit 的註解已預先寫過這條該怎麼修，但那一行從未
+   落到 env 檔裡。**這條同時影響今天的 reviewer job**，應獨立開票（見 plan 第 0 節）。
+
+7. **「錯誤語意要能三分」——查證屬實，且 #670 已經是一次實例（上游那一層 PR #674 沒碰）。**
+   `select_secondary_planner()` 回的是一個沒有任何附加資訊的字面值
+   `no-heterogeneous-planner`，候選被跳過的真正理由全被 `continue` 吃掉。#670 的
+   code fence 偽失敗因此被報成拓撲問題。**PR #674 已把 probe 那一端修好**
+   （`strip_code_fence()`／`stdout_excerpt()`／`agy models` 兩欄漂移），但那份診斷仍會在
+   `select_secondary_planner` 被吃掉——design D8 把 `no-heterogeneous-planner` 從「結論」
+   改成「結論 ＋ 逐候選拒因表」，讓診斷活著抵達 blocking reason，這一類誤報因此結構上
+   不可能。兩者剛好接得起來，缺任何一半都還是查不出原因。
+
+## What Changes（設計層級，零 code）
+
+- **定案 R1**：`PSC_JOB_RUNNER` ∈ {`systemd-run`, `systemd-template`} 時，planning 的
+  四個 adapter 與**所有 probe** 經 `JOB_ROLE_REVIEW` 的降權 job 執行；`direct` 逐字不變。
+  執行後端的選擇只有一個輸入（`job_runner.resolve_runner_mode`），**刻意不新增第二個開關**。
+- **定案 R2**：十條防線的逐條對應表（design D2）。operator 樹保護由「事後偵測」升級為
+  「mount 層不可寫」；「sandbox dirty 偵測」明確禁止由被驗方自證，兩條可行路徑列為 U-2。
+- **定案 R3**：probe 結果進 Manager-owned durable 快取；指紋涵蓋 `PSC_JOB_RUNNER`、
+  executor 可執行檔、憑證檔、加固剖面與**模板 unit 檔本身**、roster 內容雜湊；
+  一律 **fail-closed**（絕不因「上次是 ready」而在無法重探時沿用）。
+- **定案 R4**：剖面由 `prepare_systemd_template(executor=…)` 單一判定點取得，
+  planning 側零對應表。**現行 `EXECUTOR_HARDENING_PROFILE` 實測可用**（codex／copilot →
+  `jit`，claude／agy → `strict`），planner 上 job 不需要任何剖面面的前置修正。
+- **定案 R5**：planner 帳號的憑證面由登記表機械導出（沿用 #671 已建立的
+  `IN_PLACE_CONTENT_WRITE_ASSETS` 與 `inapplicable_home_anchored_assets()`，**不重造**）。
+- **定案 R6**：失敗三分 ＋ `executor-silent-exit` 子類 ＋ 逐候選拒因表 ＋
+  environment 級拒因的分類改判。
+- **定案 R7**：逾時由 Manager 側 `wait(timeout)` → `systemctl stop` 強制終止。
+- **定案 R8 ＋ design D13**：凡宣稱「某 executor 在某加固剖面下可用／不可用」，驗證環境
+  MUST 由**已落檔 unit 機械讀出全部 property** 再複製，MUST NOT 手抄子集。**該機制已由
+  PR #677 落地**（`unit_replica_properties()` 契約「全帶，不選」、少任一加固鍵即
+  `UnitReplicaDriftError`；CLI `trust_root unit-replica`；runbook 共用探針
+  `psc_run_under`），本設計要求**消費它**——實作票的矩陣不得自行組 `--property=` 清單。
+  規則的理由記在設計裡，因為 planner 是**下一個**會做這種宣稱的地方：判準**雙向**，
+  偏寬得假綠（#638／#657），偏嚴得假紅（#673 原 body 與其 repro）——四個實例、兩個方向，
+  因此規則不是「防不夠嚴」，而是「驗證環境 ≠ production 環境在結構上不可能」。
+  矩陣每格另記「解析到的絕對路徑 ＋ 版本字串」（「解析到非預期版本」不會表現為失敗）。
+- **消費 #677 的第二個維度**：seccomp 過濾語意是**剖面之外**的維度
+  （`PROFILE_LOCKED_KEYS` 兩剖面逐字相同、`filtered_syscalls`／`filtered_syscall_surfaces()`
+  ／`seccomp_filter_is_fatal()`）。兩個直接影響：R3 的快取指紋 MUST 含**模板 unit 檔本身**
+  （只放剖面名涵蓋不到第二維）；R6 的 `executor-silent-exit` 診斷 MUST 帶
+  `seccomp_filter_is_fatal()` 的結果——#673 走偏正因為當時沒有任何地方回答得了它。
+- **本票唯一落地的產物**：`docs/superpowers/specs/planner-job-downgrade-{spec,design}.md`、
+  `docs/superpowers/plans/planner-job-downgrade.md`、本 change 三件套與 delta spec、
+  `changelog.d/672-planner-downgrade-design.md`、`CHANGELOG.md` entry。
+
+## Capabilities
+
+### Modified Capabilities
+
+- `persona-workflow-orchestration`：`不完整規格必須經異質雙模型brainstorm` 這條
+  requirement 的 contract delta——planner subprocess 的執行身分、一次性 sandbox 的
+  等價重建、probe 快取、以及 `no-heterogeneous-planner` 必須攜帶逐候選拒因。
+  詳見 `specs/persona-workflow-orchestration/spec.md` 的 MODIFIED／ADDED Requirements，
+  與 `docs/superpowers/specs/planner-job-downgrade-spec.md` 的完整 R1–R8、
+  `docs/superpowers/specs/planner-job-downgrade-design.md` 的 D1–D12、
+  未決問題總覽（U-1 ～ U-8）與安全退步總覽（R-1 ～ R-4）。

--- a/openspec/changes/2026-08-18-planner-job-downgrade/specs/persona-workflow-orchestration/spec.md
+++ b/openspec/changes/2026-08-18-planner-job-downgrade/specs/persona-workflow-orchestration/spec.md
@@ -1,0 +1,121 @@
+---
+status: accepted
+work_item: planner-job-downgrade
+---
+
+## MODIFIED Requirements
+
+### Requirement: 不完整規格必須經異質雙模型brainstorm
+
+Artifact只有在frontmatter `status: accepted`、必要章節存在且沒有blocking decision marker時才算accepted。Marker parser MUST只把獨立行`TBD`、`[TBD]`、`Decision: TBD`、`決策：未定`或Open Questions中的實際項目視為blocking，MUST忽略inline說明與fenced code。Accepted spec/design/plan缺失或有blocking marker時，primary planner MUST先產question pack；secondary planner MUST來自不同independence domain且只回evidence；primary MUST整合並落檔。Secondary選擇 MUST依三層解析鏈（operator overlay → 評估合格清單 → packaged fallback）排除primary domain；無異質model、unknown identity或malformed output MUST fail-closed。
+
+Planner subprocess與manifest plan card MUST只在temporary disposable checkout執行，並以read-only executor模式啟動；Claude MUST使用停用tools的模式、Codex MUST使用`--sandbox read-only`。**降權啟動器啟用時（`PSC_JOB_RUNNER` ∈ {`systemd-run`, `systemd-template`}），planner的每一次模型呼叫與每一次capability probe MUST經job runner以`review`角色的root-owned模板unit執行，MUST NOT在Manager行程內直接執行任何executor argv**；角色MUST由呼叫端建構期固定，MUST NOT從prompt、job spec或模型輸出導出。降權模式下，「planner不得寫operator工作樹」這條性質MUST由unit的`ProtectSystem=strict`與不含來源樹的`ReadWritePaths=`在mount層保證，而非僅由Manager的前後快照比對；「planner不得弄髒自己的拋棄式sandbox」這條 MUST NOT 由job自身產生的證據滿足。`PSC_JOB_RUNNER=direct`時，現行的sandbox複製、前後兩次tree snapshot、drift收容與逐路徑還原三道fail-closed閘門 MUST 逐字保留。
+
+Manager MUST在成功、nonzero或exception路徑驗sandbox與operator worktree的檔案、empty dirs、directory symlinks與stable metadata（direct模式）；snapshot遇權限錯誤也 MUST先恢復安全traversal再依baseline還原entries、mode與xattrs，restore fault MUST fail-closed。Primary只回傳structured artifact content；Manager MUST在scan時持久化canonical ref、kind、work item與content hash authority，replacement MUST逐欄符合該authority及manifest outputs，不得信任caller hash或filename推測。新檔 MUST no-clobber。Artifact、immutable或既存同內容brainstorm evidence、expected gate ref與registry phase update MUST由durable intent journal形成recoverable transaction；registry未commit的save fault MUST rollback，已commit的restart/resume MUST逐operation重驗type/hash/mode/evidence後保留產物，drift MUST設`needs_human`並保留journal，且不得覆蓋其他work item。
+
+`no-heterogeneous-planner` MUST NOT 是一個不帶附加資訊的字面值：selection MUST 同時攜帶**逐候選拒因**（每個planning-capable identity為什麼落選：same-domain／probe-absent／probe-not-ready／probe-identity-mismatch，以及probe側的實際診斷），且brainstorm的blocking reason MUST 渲染該表。拒因中含環境級原因（job起不來、executor異常退出、probe快取不可讀）時，planning failure的classification MUST 判為`environment`而非`content`，使`recover-planning`可浮現。
+
+#### Scenario: 降權模式下的planner呼叫
+
+- **WHEN** `PSC_JOB_RUNNER=systemd-template`且Manager觸發define／brainstorm
+- **THEN** 每一次模型呼叫落成一個root-owned模板unit的實例，執行身分由unit檔的`User=`決定
+- **AND** Manager帳號的行程樹內不出現任何executor可執行檔
+
+#### Scenario: direct模式回歸
+
+- **WHEN** `PSC_JOB_RUNNER`未設或為`direct`
+- **THEN** planning的sandbox複製、前後tree snapshot與drift收容行為逐字不變
+
+#### Scenario: Agy可用且primary非Google
+
+- **WHEN** completeness gate觸發且agy live capability/identity probe通過
+- **THEN** secondary使用Google domain回傳evidence
+- **THEN** primary負責final decisions與artifact write
+
+#### Scenario: 只剩same-domain model
+
+- **WHEN** 所有可用secondary都與primary同domain
+- **THEN** WorkflowRun設needs_human且不進build
+- **AND** blocking reason的拒因表對每個候選逐一標為`same-domain`，classification維持`content`
+
+#### Scenario: probe輸出被code fence包住
+
+- **WHEN** 某候選的probe stdout是被markdown code fence包住的正確JSON
+- **THEN** blocking reason MUST 指出該候選是`probe-not-ready`且診斷為輸出格式問題，並帶出stdout前綴
+- **AND** MUST NOT 只呈現`no-heterogeneous-planner`而讓格式問題被讀成拓撲問題
+
+#### Scenario: executor在job unit下靜默非零退出
+
+- **WHEN** job成功啟動但executor回非零且stdout與stderr皆空
+- **THEN** 失敗 MUST 落`planning-executor-failed`並標記`executor-silent-exit`子類，classification為`environment`
+- **AND** reason MUST 指名unit名、加固剖面與實際解析到的executor絕對路徑
+- **AND** 診斷 MUST 帶「該加固面下被過濾的syscall是否致命」的機械答案，使「要不要懷疑seccomp」不必再靠猜
+
+## ADDED Requirements
+
+### Requirement: Planner capability probe MUST跨tick快取，快取判準MUST涵蓋執行後端且MUST fail-closed
+
+Planning runtime的建構 MUST NOT 在每次建構時重跑全部capability probe。probe結果 MUST 落成Manager-owned的durable快取，其資產 MUST 登記在trust-root登記表、writers與readers只有Manager principal，且 MUST NOT 出現在任何降權job模板unit的`ReadWritePaths=`中。
+
+快取判準 MUST 至少涵蓋：`(executor, model_id)`、降權啟動器模式（`PSC_JOB_RUNNER`的值）、以該角色PATH解析出的executor可執行檔絕對路徑與其inode指紋、該帳號憑證檔的大小與mtime指紋、加固剖面名與**模板unit檔本身**的指紋、以及model identity roster解析結果的內容雜湊。其中「降權啟動器模式」為硬性項：direct模式取得的probe結論 MUST NOT 被降權模式採信，反之亦然。
+
+快取檔不存在、無法解析、schema版本不符或指紋不符時 MUST 一律視為miss並重探；重探失敗 MUST 判為not ready。系統 MUST NOT 因為快取中的前一次結論為ready，而在無法重探時沿用ready。快取 MUST 同時保存失敗側的完整診斷（reason、diagnostic、退出碼、stdout前綴、unit名、加固剖面、解析到的可執行檔與版本字串），供blocking reason的拒因表消費。
+
+#### Scenario: 模板unit換版後的重探
+
+- **WHEN** operator重跑權限產生器並落下新的job模板unit檔
+- **THEN** 全部probe快取因模板unit指紋改變而失效並重探
+- **AND** 不需要任何手動清快取的步驟
+
+#### Scenario: 快取檔損毀
+
+- **WHEN** 快取JSON無法解析
+- **THEN** 視為miss並重探，MUST NOT 沿用任何舊結論
+- **AND** 落一筆可與「probe失敗」區分的結構化診斷
+
+#### Scenario: 跨執行後端不得互相採信
+
+- **WHEN** 部署由`PSC_JOB_RUNNER=direct`切換為`systemd-template`
+- **THEN** 全部probe快取失效，切換後的第一輪planning重新探測
+
+### Requirement: 降權planning job的加固剖面MUST由executor單一判定，逾時MUST由Manager強制終止
+
+降權planning job的加固剖面 MUST 由既有的「executor → 剖面」單一判定點取得，其唯一輸入為Manager在dispatch當下決定的executor；未登記的executor MUST fail-closed，MUST NOT 落到較寬鬆的剖面。planning路徑 MUST NOT 自帶第二份executor→剖面對應表。
+
+降權planning job MUST 有Manager側強制的執行上限：等待逾時後 MUST 主動停止該unit並確認其離開active狀態，並落一個與「job起不來」「executor異常退出」「輸出不合約」三族可區分的逾時原因，classification為`environment`。系統 MUST NOT 僅放棄等待而讓job繼續執行。
+
+任何形如「某executor在某加固剖面下可用**或不可用**」的宣稱，其驗證環境 MUST 由**已落檔unit機械讀出全部property**再複製，MUST NOT 手抄property子集當作真實加固面的複本，亦 MUST NOT 自行組裝property清單——加固面複本 MUST 由既有的全量導出機制產生，且該機制在落檔unit缺任一加固鍵時 MUST fail-closed（產出為空而非降級）。此要求**雙向適用**：手抄得比production寬會產生假綠（宣稱可用而實機不可用），手抄得比production嚴會產生假紅（宣稱不可用而實機其實可用），兩者皆 MUST 被擋。
+
+驗證環境若帶`SystemCallFilter=`，MUST 一併帶入`SystemCallErrorNumber=`——只帶前者會把「被過濾的syscall回`EPERM`、呼叫方可fallback」偷換成「行程直接被殺」，而兩者的可觀測症狀（空輸出）相同。syscall過濾語意 MUST 被視為加固剖面**之外的第二個維度**：兩份剖面在該組鍵上逐字相同，因此任何以「剖面名」為索引的判斷（含probe快取判準）MUST NOT 只憑剖面名，MUST 涵蓋落檔unit本身。
+
+矩陣每一格 MUST 記錄退出碼、輸出前綴，以及**實際解析到的可執行檔絕對路徑與版本字串**；最後一項是必要的，因為「解析到非預期版本」不會表現為失敗，只會安靜地產出來自另一份CLI的結果。
+
+#### Scenario: 未登記的executor
+
+- **WHEN** planning以一個不在剖面表上的executor派出
+- **THEN** 派工在任何per-job產物產生之前fail-closed
+- **AND** MUST NOT 落到放寬的剖面
+
+#### Scenario: 模型呼叫逾時
+
+- **WHEN** 降權planning job超過Manager設定的上限仍未結束
+- **THEN** Manager停止該unit並確認其離開active
+- **AND** 下一次同角色的planning呼叫 MUST NOT 因殘留的active實例而失敗
+
+#### Scenario: 以property子集複本取得的宣稱
+
+- **WHEN** 驗收僅以帶部分property的transient unit執行
+- **THEN** 該結果 MUST NOT 被當作「可用」的證據
+- **AND** 同樣 MUST NOT 被當作「不可用」的證據——偏嚴的複本會產生假紅，而假紅會導致去放寬一條實際有效的加固項
+
+#### Scenario: 驗證環境帶了syscall過濾卻沒帶錯誤碼設定
+
+- **WHEN** 驗證環境宣告`SystemCallFilter=`而未宣告`SystemCallErrorNumber=`
+- **THEN** 該環境 MUST NOT 被視為production加固面的複本
+- **AND** 由它取得的任何可用性結論 MUST 重驗
+
+#### Scenario: executor解析到非預期版本
+
+- **WHEN** 驗證矩陣中某格rc=0，但解析到的可執行檔不是部署toolchain中的那一份
+- **THEN** 該格 MUST NOT 記為通過
+- **AND** 矩陣 MUST 呈現實際解析到的絕對路徑與版本字串，使差異可見

--- a/openspec/changes/2026-08-18-planner-job-downgrade/tasks.md
+++ b/openspec/changes/2026-08-18-planner-job-downgrade/tasks.md
@@ -1,0 +1,81 @@
+---
+status: draft
+work_item: planner-job-downgrade
+---
+
+# Tasks
+
+design-doc 票（結構性搬遷，直接開工很可能產出一個大而錯的 PR；比照 #210／#275／#279
+既有慣例以設計文件交付），非 code TDD RED/GREEN 主體；實作切分成六張後續票，
+依賴順序見 `docs/superpowers/plans/planner-job-downgrade.md`。
+
+- [ ] 1.1 `proposal.md`／`design.md`／`specs/persona-workflow-orchestration/spec.md`
+      三件套完整，且與 `docs/superpowers/specs/planner-job-downgrade-{spec,design}.md`
+      內容一致（openspec 三件套為摘要、docs/superpowers 為完整論證，兩者不得互相矛盾）。
+- [ ] 1.2 `docs/superpowers/specs/planner-job-downgrade-spec.md` 的 R1–R8 逐條對應
+      issue #672 原文的五件事（一次性 sandbox 的等價重建、probe 成本與快取、剖面路由、
+      憑證、錯誤語意），且每條有 `origin/main` 上的具體改動錨點。
+- [ ] 1.3 design 的 D2 給出十條防線的**逐條**對應表，每條標成等價／升級／退步；
+      退步項（R-1、R-2、R-3、R-4）逐條附代價與可避免路徑。
+- [ ] 1.4 design 的未決問題總覽（U-1 ～ U-8）逐條列出選項與取捨，**不由本票擅自決定**。
+- [ ] 1.5 `docs/superpowers/plans/planner-job-downgrade.md` 的實作切分含六張票、
+      依賴順序圖、每張票的 TDD RED 測試名與驗收條件。
+- [ ] 1.6 本設計文件經至少一輪 review（人工或 reviewer persona）才可勾完此清單；
+      不可自我勾完就 claim done。
+- [ ] 1.7 `changelog.d/672-planner-downgrade-design.md` fragment 與
+      `CHANGELOG.md [Unreleased]` entry（#672）。
+- [ ] 1.8 `python3 -m pytest -q` 全綠（本票不改 code，應與 base 相同）；
+      帶 PR 上下文的 `policy_check` 0 fail；`git diff --check` 乾淨。
+- [ ] 1.9 `git diff --stat origin/main` 只含 `docs/`、`openspec/`、`changelog.d/`、
+      `CHANGELOG.md`——**零 `paulsha_cortex/` 變動**（這是本票的硬性限制）。
+
+## 驗收
+
+「做完」＝ 一個沒有本票上下文的人，讀完三份 docs 之後可以：(i) 說出 planner 今天在哪個
+帳號上跑、為什麼那是問題；(ii) 逐條說出搬到 job 之後現行十條防線各自由誰保證，以及
+哪兩條會退步、代價多大；(iii) 知道哪些事需要 operator 拍板才能開工（U-1 ～ U-8）；
+(iv) 照 plan 的依賴順序開出第一張實作票並知道它的 RED 測試該長什麼樣。
+
+## 本票不做（範圍切分給後續實作票）
+
+- 不修改 `paulsha_cortex/` 下任何程式（含 `planning_runtime.py`、`job_runner.py`、
+  `launcher.py`、`model_identities.py`、`planning.py`、`manager.py`、`trust_root/**`）。
+- 不改剖面表、不改 unit 的加固項。現行 `EXECUTOR_HARDENING_PROFILE` 實測可用
+  （八份 unit 全帶 `SystemCallErrorNumber=EPERM`，codex／copilot 在 `jit` 剖面 rc=0），
+  planner 上 job **不依賴 #673**——該 issue 原 body 的前提已由開票者更正撤回，
+  且 #673 已由 PR #677 以「不放寬任何 syscall」收尾。
+- 不重做 #670——其本體已由 PR #674 修好（`strip_code_fence()`／`stdout_excerpt()`／
+  `agy models` 兩欄漂移）；本票只補「診斷活著抵達 blocking reason」那一層。
+- 不改 systemd unit、不動部署、不跑任何會改變 `/var/lib/cortex` 狀態的指令。
+- 不裁決 U-1 ～ U-8（那是 operator 的）。
+
+## 後續應拆分的 code 票（本 plan 已定案，此處只列摘要）
+
+1. **票 A｜錯誤語意三分 ＋ 逐候選拒因表**（不依賴任何部署面改動；與 PR #674 接得起來）。
+   驗收：`no-heterogeneous-planner` 的 reason 可用正規表示式釘住必含拒因表；
+   既有 planning 測試一行不改全綠。
+2. **票 B｜`PlanningInvoker` 抽象**（純重構、行為零改變）。
+   驗收：既有 planning／probe 測試一行不改全綠；`planning_runtime.py` 內
+   `subprocess.run` 只剩 `InProcessPlanningInvoker` 一處。
+3. **票 C｜probe 結果快取**（依賴 A、B）。
+   驗收：連續兩次建構 runtime 的第二次 executor 呼叫次數為 0；改動任一指紋輸入必重探；
+   快取損毀一律視為 miss（不得沿用 ready）。
+4. **票 D｜permgen 把 planner 憑證面 codify**（依賴 U-4／U-5／U-7 裁決）。
+   驗收：reviewer 模板 unit 的 RWP 逐字含憑證**檔案**（非父目錄）；二分方案產出不含它；
+   `deferred_run_dependencies()` 縮短且測試釘住。
+5. **票 E｜`JobPlanningInvoker`**（依賴 B、C、PATH 前置票）。
+   驗收：`{codex, claude, agy} × {實際剖面}` 矩陣在**真實 unit 的完整 property 集合**下
+   全綠——加固面走 PR #677 的 `psc_run_under`／`unit_replica_properties()`，不得自行組
+   `--property=` 清單（D13），每格記錄解析到的絕對路徑與版本字串；一輪完整 planning
+   期間 `cortex-manager` 的行程樹不出現任何 executor 可執行檔。
+6. **票 F｜切換、宣稱更正與收尾**（依賴 D、E）。
+   驗收：四分部署跑通一輪 define → build → review；runbook 與 #615／D6 的既有宣稱
+   逐條更正；`deferred_run_dependencies()` 的 `manager-claude-credential` 移除。
+
+另需獨立開票一張（本票查證時發現，不屬 planner 範圍、但比 planner 更廣）：
+
+- **`PSC_REVIEWER_PATH` 未在部署 EnvironmentFile 宣告**，導致今天的 reviewer job 與未來
+  的 planner job 都拿到 PID 1 的預設 PATH（`claude`／`agy` rc=127、`codex` **安靜地**解到
+  系統層 `0.42.0` 而非 toolchain 的 `0.147.0`——不會失敗，只是產出來自舊 CLI）。
+
+（原本另列的「runbook 加固面驗證改機械讀取」已由 **PR #677** 完成，不需開票。）


### PR DESCRIPTION
## 這是什麼

`Refs #672` —— **本 PR 是設計交付，不含任何 `paulsha_cortex/` 的程式修改**，因此
刻意**不用** closing keyword。issue #672 由後續的實作票收關（切分見下）。

planning（define／brainstorm）從來沒有被降權：`planning_runtime.py:830` `_invoke_json()`
以 `subprocess.run`（同檔 `:1070` 的預設 runner）在**呼叫端行程內**執行，`:43`
`_planning_argv()` 回傳的是裸 executor argv（無 `systemd-run`、無 `cortex-job-shim`、
無模板 unit），而呼叫端是以 `User=cortex-manager` 執行的 daemon
（`manager_daemon.py:970`／`:1241`）——該帳號的 passwd 註記逐字寫著 `no model code`。
#615（M2）只把 **reviewer** 導上 `cortex-reviewer-job@.service`
（`launcher.py:1239 _is_review_persona()`）。

把 planning 從「Manager 行程內 `subprocess.run`」搬到「經 job runner 走
`cortex-reviewer-job@.service`」是結構性搬遷，直接開工很可能產出一個大而錯的 PR。
因此本 PR 只出設計。

## 交付

| 檔案 | 內容 |
|---|---|
| `docs/superpowers/specs/planner-job-downgrade-spec.md` | R1–R8 契約面 |
| `docs/superpowers/specs/planner-job-downgrade-design.md` | D1–D12、未決問題總覽 U-1～U-8、安全退步總覽 R-1～R-4 |
| `docs/superpowers/plans/planner-job-downgrade.md` | 六張實作票、依賴順序圖、逐票 TDD RED 與驗收 |
| `openspec/changes/2026-08-18-planner-job-downgrade/` | proposal／design／tasks ＋ `persona-workflow-orchestration` delta |
| `changelog.d/672-planner-downgrade-design.md` ＋ `CHANGELOG.md` | R-09 |

`git diff --stat origin/main` 只有 `docs/`、`openspec/`、`changelog.d/`、`CHANGELOG.md`——
**零 `paulsha_cortex/` 變動**。

## 設計要點（issue 指定的五件事）

1. **一次性 sandbox 的等價重建**——把 `_invoke_json` 現行的**十條**防線逐條列成對應表
   （design D2），每條標成等價／升級／退步。operator 工作樹的保護從「事後比對雜湊 ＋
   fail-closed」**升級**為 `ProtectSystem=strict` ＋ RWP 不含 `repo-source-tree` 的
   mount 層不可寫；claude 的 hermetic config 從「複製憑證 ＋ 改 env」**升級**為帳號隔離
   ＋ `ProtectHome=yes`。兩條退步逐條指名（見下）。
2. **probe 成本與快取**——現況比預期嚴重：`_probe_identity` 每次做**兩次整棵 repo 的
   `copytree`**、`probe_agy_capability` 是**兩次 CLI 呼叫**，而
   `build_production_planning_runtime()` 由 periodic tick 呼叫。定案 Manager-owned durable
   快取，指紋含 `PSC_JOB_RUNNER`／executor 可執行檔 inode／憑證檔／加固剖面 ＋
   **模板 unit 檔本身**／roster 內容雜湊，**fail-closed**（絕不因「上次是 ready」而在無法
   重探時沿用）。模板 unit 進指紋是刻意的：#673 落地重跑產生器那一刻全部快取自動失效重探。
3. **剖面路由**——剖面唯一來源是 `prepare_systemd_template(executor=…)`，planning 側零
   對應表。#673 若只加 `@sandbox`、或把判準從 `needs_node` 改成「要不要 `@sandbox`」，
   本設計**零改動**；新增第三個剖面名時只有驗收矩陣多一列。
   **#673 的影響面比 issue 描述的大**：實機 `PSC_MANAGER_EXECUTOR=codex` ⇒ **primary**
   planner 就是 codex ⇒ questioner 與 integrator 兩支一起被擋，不是只有 secondary。
4. **憑證**——0818 部署的 `.codex/auth.json`（檔 job-owned／目錄 root-owned）與
   `.gemini → cache/gemini` 在**功能上足夠**，**治理上不足**：實機
   `cortex-reviewer-job@.service` 的 `ReadWritePaths` 只有 `cache` 與 `review-verdicts`，
   **不含憑證檔**（unit 自己的註解花七行描述它該怎麼掛，但登記表只有
   `builder-executor-credential` 一列）。定案沿用 PR #671 已建立的
   `IN_PLACE_CONTENT_WRITE_ASSETS` 與 `inapplicable_home_anchored_assets()`——後者正是把
   #640 當年「不敢登記第二份憑證」的唯一理由拆掉的那一個——**不重造機制**。
5. **錯誤語意**——三分：`planning-job-start-failed`／`planning-executor-failed`
   （含 `executor-silent-exit` 子類，＝#673 的逐字症狀）／`planning-output-malformed`。
   並把 `no-heterogeneous-planner` 從一個**沒有任何附加資訊的字面值**改成「結論 ＋ 逐候選
   拒因表」——`select_secondary_planner()` 今天把每個候選落選的真正理由用 `continue` 吃掉，
   #670 的 code fence 偽失敗因此被報成拓撲問題。拒因表含 environment 級原因時
   classification 改判 `environment`，讓 `recover-planning` 有路（今天一律 `content` ⇒ 死路）。

## 本 PR 查證時新發現、尚無票的部署缺口

`/opt/cortex/etc/cortex-manager.env` **沒有宣告 `PSC_REVIEWER_PATH`**，Manager unit 也沒有
`Environment=PATH=` ⇒ 降權 job 的 PATH 就是 PID 1 的預設
（`/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/snap/bin`），`/opt/cortex/toolchain/bin`
不在其中。實測：

| executor | 解析到 | 版本 | toolchain 那份 |
|---|---|---|---|
| `codex` | `/usr/bin/codex` | `codex-cli 0.42.0` | `0.147.0` |
| `claude` | **不存在** → rc=127 | — | `/opt/cortex/toolchain/bin/claude` |
| `agy` | **不存在** → rc=127 | — | `/opt/cortex/toolchain/bin/agy` |

reviewer 模板 unit 的註解已預先寫過這條該怎麼修，只是那一行從未落到 env 檔裡。
**這條同時影響今天的 reviewer job**，需獨立開票，且是 planner 上 job 的前置——否則症狀
（空輸出／127）與 #673 的 seccomp 靜默完全一樣，排查會再被帶偏一次。

## 誠實標註：安全退步（4 條）

| 編號 | 退步 | 代價 | 是否可避免 |
|---|---|---|---|
| **R-1** | 「模型弄髒自己的拋棄式 sandbox」的偵測，job 模式下 Manager 無法執行（job-owned 0700 樹進不去；讓 job 自證違反 #628／#540） | 失去一個**行為訊號**；不影響任何 durable state | **可避免**：選 U-2 的「scratch 對 job 唯讀」⇒ 變成「結構上不可能」 |
| **R-2** | codex 的 `-o last.json` 第二輸出候選消失，`_extract_json` 從雙候選退成單候選 | codex 的 stdout 若被 envelope 污染則抽取失敗 | **可避免**：選 U-3 的 result spool（但那是新開一條 job→Manager 的寫入面） |
| **R-3** | planner 帳號同時持有 openai 與 google 兩份憑證（0818 已部署的事實） | 該帳號被攻陷時兩邊 token 一起失，而 planner 正是吃 untrusted issue 內容的角色 | **不可避免**（除非放棄異質 planner）；屬 U-4 |
| **R-4** | 逾時終止從「父進程 kill 子進程」變成「Manager `systemctl stop`」 | unit 不理 SIGTERM 時逾時後仍可能在跑 | **部分可避免**：U-8 的 `RuntimeMaxSec=` 第二層 |

## 誠實標註：未決裁決（8 條，交 operator，本 PR 不擅自決定）

- **U-1** planning sandbox 要不要放 repo 複本（整棵複製／空 scratch／per-job clone）。
- **U-2** scratch 對 job 可寫還是唯讀（＝ R-1 是不是退步的分水嶺）。
- **U-3** codex 的第二輸出通道要不要保留（＝要不要新開一格 planning result spool）。
- **U-4** planner 帳號是否核可持有兩個 independence domain 的憑證（同 #668 G2）。
- **U-5** `executor_credential_relpath` 要不要擴成 per-(account, executor) 表（#668 B 案）。
- **U-6** probe 快取的 TTL 值，以及要不要提供 warm-up 入口。
- **U-7** agy 狀態樹在登記表裡的表達方式（symlink 資產 vs env 導向 `cache`）。
- **U-8** 模板 unit 要不要加 `RuntimeMaxSec=` 作為第二層逾時保險。

## 實作切分（六張票）

```
#673（別票）  ─────────────┐
PATH 前置票（待開）───────┐│
                          ↓↓
票 A（拒因表／三分）→ 票 B（invoker 抽象）→ 票 C（probe 快取）→ 票 E（job invoker）→ 票 F（切換與更正）
                                                                  ↑
U-4／U-5／U-7 裁決 → 票 D（permgen codify）───────────────────────┘
```

- **A／B／C 不依賴 #673、不依賴部署**，可在 direct 部署上獨立 land 並各自產生價值
  （A 讓今天的 `no-heterogeneous-planner` 立刻開始講真話；C 讓 direct 模式省掉每輪 tick
  每個 identity 兩次整棵 repo 的 `copytree`）。
- **切換本身是一次到位**：一個部署不能一半 planning 走 job、一半走 in-process——probe
  快取的指紋含 `PSC_JOB_RUNNER`，混用會讓兩種語意的結論在同一輪並存。
- **中間狀態可運作**：票 E land 但生產仍為 direct 期間，系統完全正常（direct 路徑逐字不變）。

## 驗證

- [x] `openspec validate --strict` — `Change '2026-08-18-planner-job-downgrade' is valid`（18 passed, 0 failed）
- [x] 三份 docs 逐一通過 cortex 自己的 `assess_planning_artifact()`（`accepted=True`，零 reason）
- [x] `python3 -m pytest tests/ -q` 全綠（本 PR 不改 code）
- [x] `policy_check` 帶 PR 上下文執行，R-17 以 `policy-exempt:issue-link` 豁免（設計票只引用不關閉），其餘 0 fail
- [x] `changelog.d/672-planner-downgrade-design.md` 已新增且**已 commit**
- [x] `CHANGELOG.md [Unreleased]` 有對應 entry
- [x] `git diff --stat origin/main` 零 `paulsha_cortex/` 變動
- [x] 文字一律 zh-tw

## 豁免

- `policy-exempt:issue-link`（R-17）——本 PR 是**設計交付**，issue #672 由後續實作票收關，
  因此用 `Refs #672` 而非 closing keyword。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E7w9kaUxAzCCEk7piD5hfK
