### PR TITLE
fix(trust-root): seccomp 過濾語意是剖面外的第二個維度；加固面複本改為全量機械導出（#673）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,31 @@
 ## [Unreleased]
 
 ### Added
+- **#673：seccomp 過濾**語意**是加固剖面之外的第二個維度，且它是**承重**的**——
+  `@system-service` 確實過濾掉 V8 啟動時要用的 `pkey_alloc`（x86_64 330，systemd 歸在
+  `@pkey`；**不是** `@sandbox` 的 `landlock_*`／`seccomp`，kernel audit `type=1326 …
+  syscall=330` 為證，加 `@sandbox` 實測完全無效），但同一份 unit 上的
+  `SystemCallErrorNumber=EPERM` 讓被過濾的 syscall 只回錯誤碼、不殺行程，V8 走 fallback
+  ——以**完整 37 條** property 複製真 unit，四支 executor **全部 rc=0**，#673 回報的
+  「預設派工路徑靜默壞掉」不成立。新增 `ToolchainProgram.filtered_syscalls`（實機量到、
+  有 audit record 背書的被過濾 syscall；**刻意不共用 `needs_node`**——處置方向相反，
+  且 `openspec` 跑在根本沒有剖面的 Manager unit 上）、`SECCOMP_FATALITY_KEY`／
+  `PROFILE_LOCKED_KEYS`（`SystemCallFilter` 與 `SystemCallErrorNumber` 任何剖面都不得
+  分岔）、`filtered_syscall_surfaces()`（程式 × 執行面，由 `TOOLCHAIN_PROGRAMS` 機械
+  導出）與 import 時強制的 `_validate_seccomp_tolerance()`。**沒有放寬任何 syscall**：
+  八份 unit 的 `SystemCallFilter=@system-service` 逐字不動（沿用 #643 的「量到才改」，
+  而這次量到的結論是不用改）。
+- **#673：`permgen.unit_replica_properties()` ／ CLI `trust_root unit-replica`——加固面
+  複本改為從**已落檔的 unit** 全量機械導出**。#673 的 repro 是一份手抄的十 property
+  複本，抄了 `SystemCallFilter=` 卻漏抄 `SystemCallErrorNumber=EPERM`，於是**比
+  production 更嚴格**，量出一個不存在的 P0——#638（單 UID 讓 ACL 斷言真空）、#657、
+  #673 是同一族的第一到第三次，而**假紅與假綠一樣會發生**。新函式的契約是「全帶，
+  不選」：`[Service]` 段除執行面指令外全部帶出（含 `ReadWritePaths=`／
+  `WorkingDirectory=`／per-account `Environment=`），落檔的 unit 少任一加固鍵即
+  `UnitReplicaDriftError` 且 stdout 保持空。runbook 4e／5-2b／5-3／5-4 的手抄子集全部
+  改走它，5-2b 的驗收由「正向四段」改為 **4 executor × 2 剖面 × 2 角色 unit 的全矩陣**
+  ＋**反向對照**（`claude`／`agy` 在 jit 剖面下仍須 rc=0），並更正其措辭（原宣稱是在
+  弱化環境下取得的）。
 - **#666：外部相依的窮舉盤點——判準從「這一類東西有哪些」改成「跑完一個 run 需要碰到
   什麼」**——`#640`（executor toolchain ＋ job 憑證）、`#661`／`#664`（`srt`／`openspec`／
   preflight backend）、#666（`pytest` ＋ Manager 的 gh 憑證）是同一族的第一到第五個成員，

--- a/changelog.d/673-syscall-sandbox-profile.md
+++ b/changelog.d/673-syscall-sandbox-profile.md
@@ -56,6 +56,12 @@ syscall**，被擋的照樣擋，只是不殺行程。（若哪天真的需要�
 - **`_validate_seccomp_tolerance()`**：import 時強制——任何 `filtered_syscalls` 非空
   的程式，其執行面若是致命過濾語意，**permgen 直接炸**，並在錯誤訊息裡把處置講清楚
   （設 errno，**不是**把 syscall 加進白名單）。
+- **加固表的註解改走既有的 `_wrap_comment`**：那支 helper 的 docstring 早就寫著
+  「數百字元的單行註解會讓 `systemctl cat` 完全失去可審查性」，但 `_hardening_lines`
+  一直是 `f"# {why}"` 直出。「這一行為什麼在這裡」正是這份 root-owned 檔存在的理由，
+  讀不了等於沒有。指令值一字未改，純粹是 unit 的呈現。兩個既有測試（manager／monitor
+  的「每項加固都要帶註解」）改為比對 directive 上方**整段連續註解**——比原本的「正上方
+  那一行」更強，也對折行穩健。
 
 ## 更重要的一半：加固面複本必須全量機械導出
 

--- a/changelog.d/673-syscall-sandbox-profile.md
+++ b/changelog.d/673-syscall-sandbox-profile.md
@@ -1,0 +1,112 @@
+# seccomp 過濾**語意**是剖面之外的第二個維度；加固面複本改為全量機械導出（#673）
+
+## 先講量測結論：本票的因果診斷不成立，production 沒有壞
+
+#673 的診斷是「`SystemCallFilter=@system-service` 讓 `codex`／`copilot` 在全部八份
+unit 下 rc=1，需要放行 `@sandbox`（`landlock_*`／`seccomp`）」。實機逐條量完，這條
+推論的**每一步**都被推翻：
+
+| 命題 | 實機結果 |
+|---|---|
+| 被過濾的是 `@sandbox` 那四支 | **否**。是 **`pkey_alloc`**（x86_64 syscall 330，systemd 歸在 `@pkey`）。kernel audit `type=1326 … comm="node" sig=31 syscall=330 code=0x80000000` 直接證據，全程**沒有任何一筆** `landlock_*`（444–446）或 `seccomp`（317）的 record |
+| 加 `@sandbox` 可以修好 | **否**。在致命過濾語意下加了 `@sandbox`，`codex`／`copilot` 照樣 rc=1、輸出全空 |
+| 真 unit 上 codex／copilot 是壞的 | **否**。以**完整 37 條** property 複製 `cortex-reviewer-job-jit@.service`（＝它們實際跑的剖面），四支 executor **全部 rc=0**；`codex debug models`、`copilot --help`、`openspec`、`srt` 亦全部 rc=0 |
+| `DEFAULT_EXECUTOR = "copilot"` 讓預設派工路徑靜默壞掉 | **否**，同上。該疑慮撤銷 |
+
+真正發生的事：`@system-service` 確實不含 `pkey_alloc`（V8 啟動時會叫它），但**同一份
+unit 上的 `SystemCallErrorNumber=EPERM`** 把「被過濾 ⇒ `SECCOMP_RET_KILL_PROCESS`」
+變成「被過濾 ⇒ 回 `EPERM`」，V8 收到 `EPERM` 走 fallback，一切正常。那一行從 permgen
+的**第一個** commit 就在加固表裡，八份 unit 全部都有。
+
+**本票的 repro 是一份手抄的十 property 複本**，它抄了 `SystemCallFilter=` 卻**漏抄**
+`SystemCallErrorNumber=EPERM` ⇒ 複本落回 systemd 預設的致命語意 ⇒ **比 production
+更嚴格** ⇒ 量出一個 production 沒有的 rc=1。逐字重現該複本可得本票矩陣；**只**補上
+那一條，四支 executor 立刻全綠。
+
+#638（單 UID 讓 ACL 斷言真空）、#657、本票是同一族事故的第一、二、三次。
+**本票的方向是假紅，前兩次是假綠——手抄子集的錯法不由人選。**
+
+## 因此**沒有**放寬任何 syscall
+
+`SystemCallFilter=@system-service` 在八份 unit 上逐字不動。沿用 #643 的先例
+「量到才改，改的是一份具名剖面，不是全域放寬」——而這次量到的結論是**不用改**。
+放行 `pkey_alloc`／`@pkey`／`@sandbox` 都是無量測支撐的放寬：`EPERM` **不放行任何
+syscall**，被擋的照樣擋，只是不殺行程。（若哪天真的需要，最小必要集合已量出來是
+**單一具名 syscall `pkey_alloc`**，連 `@pkey` 整群都不必——但今天不需要。）
+
+## 改的是「這條為什麼不能被靜默拿掉」
+
+`SystemCallErrorNumber=EPERM` 是**承重**的，但在此之前沒有任何東西知道它承重：加固表
+裡它的理由只寫「失敗可觀測」。任何人為了「更 fail-closed」把它刪掉或清空，`codex`／
+`copilot`／`srt`／`openspec` 會在**全部**執行面上同時靜默死，而 diff 看起來只是
+「移除一個放寬」。
+
+- **`ToolchainProgram.filtered_syscalls`**（新欄位）：該程式在 `@system-service` 下
+  **實機量到**會撞上的被過濾 syscall。`codex`／`copilot`／`srt`／`openspec` 各填
+  `("pkey_alloc",)`，每一列都有 audit record 背書，不填形態推論。
+  **刻意不共用 `needs_node`**：兩者處置方向相反（換一份放寬的剖面 vs. 鎖定一個所有
+  剖面都不得分岔的鍵），適用面也不同——`openspec` 跑在 **Manager unit** 上，那一格
+  根本沒有剖面，綁在剖面上會整個漏掉它。
+- **`SECCOMP_FATALITY_KEY` ／ `PROFILE_LOCKED_KEYS`**：`SystemCallFilter` 與
+  `SystemCallErrorNumber` 列為**任何剖面都不得分岔**的鎖定鍵，與
+  `PROFILE_DIVERGENCE_KEYS` 恆為互斥（import 時強制）。
+- **`filtered_syscall_surfaces()`**：程式 × 它實際跑的加固面，由
+  `TOOLCHAIN_PROGRAMS` 機械導出（executor 走自己的剖面、非 executor 走 `consumed_by`
+  指到的消費者面），**不另立第二張人工對照表**。
+- **`_validate_seccomp_tolerance()`**：import 時強制——任何 `filtered_syscalls` 非空
+  的程式，其執行面若是致命過濾語意，**permgen 直接炸**，並在錯誤訊息裡把處置講清楚
+  （設 errno，**不是**把 syscall 加進白名單）。
+
+## 更重要的一半：加固面複本必須全量機械導出
+
+- **`permgen.unit_replica_properties()`** ＋ CLI **`trust_root unit-replica <unit|->`**：
+  把一份**已落檔**的 unit 讀成 `systemd-run --property=` 的**完整**清單。契約是
+  **「全帶，不選」**——`[Service]` 段除執行面指令（`ExecStart=` 之類）外全部帶出，
+  含 `User=`／`Group=`／`WorkingDirectory=`／`Environment=`／`ReadWritePaths=`。
+  日後往加固表加一項，runbook 不必改也不會漏，這正是它與 grep 白名單的差別。
+- **落檔的 unit 少任一加固鍵 ⇒ `UnitReplicaDriftError`，stdout 保持空**。半套清單就是
+  把 #673 再演一次，因此寧可不產出。展不開的 systemd specifier 同樣拒絕。
+- 讀的是**磁碟上那一份**（`systemctl cat` 含 drop-in），不是產生器展開的——兩者會漂移，
+  而漂移正是要被驗出來的東西（runbook 自己就記著「產生器修好 ≠ 已落檔的 unit 跟著更新」）。
+
+## runbook（`trust-root-phase2b-setup.md`）
+
+- 新增 **4e「共用探針 `psc_run_under`」**一節，之後每一條「在真實加固面下」的驗證都走它。
+  原本 4e 的三條、5-3 的 `pytest`、5-4 的 `gh` 各自手抄**四條** property；5-2b 稍好但
+  是一份**手維護的 27 鍵 grep 白名單**，且不含 `ReadWritePaths=`／`WorkingDirectory=`／
+  per-account `Environment=`。全部改為機械導出。
+- **5-2b 由「正向四段」改為全矩陣**：4 executor × 2 剖面 × 2 角色 unit 逐格量，並新增
+  **反向對照**（`claude`／`agy` 在 jit 剖面下仍須 rc=0——放寬剖面若弄壞原本好的兩支，
+  這是唯一看得見的地方）。通過條件表一併更正措辭：該宣稱現在是在**完整導出**的
+  property 集合下取得的。
+- 負向那兩格新增「**失敗原因要對得上**」：strict 剖面下 `codex` 的 stderr 必須是 V8 的
+  `Check failed: 12 == (*__errno_location ())` ／ `Runtime_CompileLazy`。
+  **stderr 空是另一回事**——那代表複本漏了 `SystemCallErrorNumber=EPERM`，是本票誤判的
+  指紋。看到空 stderr 先回去查複本，不要開票說 executor 壞了。
+- 兩個「弱複本從來看不到、全量複本立刻撞到」的實例寫進 runbook：
+  (i) `ReadWritePaths=…/%i` 的目標不存在時 systemd 在 exec **前**就 rc=226、輸出全空；
+  (ii) `PrivateTmp=yes` 讓 `/tmp` 下的探測目錄在 unit 內根本不存在——5-3 的 `pytest`
+  探針因此改放進 gate 自己登記表上的可寫面。
+
+## 測試
+
+新增 `tests/test_trust_root_syscall_profile_673.py`（26 測試）：八份 unit 的
+`SystemCallFilter` 逐字比對與「`@sandbox`／`@pkey`／`pkey_alloc` 不得出現在任何指令值上」、
+剖面導出（executor → 剖面 → filter 值）、`filtered_syscalls` 的機械導出涵蓋 Manager 面、
+鎖定鍵不變式、`unit_replica_properties` 的八份 unit round-trip 與漂移拒絕。
+
+**守衛測試不可省**：把加固表的 `SystemCallErrorNumber` 清空後
+`_validate_seccomp_tolerance()` **必須拋**，且訊息要同時點名 `codex` 與 `openspec`
+——否則第 3／4 節的綠只是恰好成立。
+
+**OS 層語意具名 skip ＋ 完整理由**（#638／#657 的教訓、PR #671 的做法）：「`@system-service`
+是否真的擋掉 `pkey_alloc`」需要 kernel audit，「executor × 剖面全矩陣」需要真 UID ＋
+真 ACL ＋ 已落檔的 unit。CI 是單 UID／無 systemd，套不上 seccomp，在那裡跑會**永遠綠**
+——而那個綠恰恰是本票誤判的成因。
+
+## 刻意不做
+
+- **Manager／monitor unit 不放寬**（連帶：任何 unit 都不放寬）。詳見 PR body 的裁決理由。
+- **不修 Manager 在行程內跑模型 CLI**（那是 #672 的主訴）。
+- **`openspec` 在 Manager 面下仍失敗**（MDWE，非 seccomp），維持 #661 的未決狀態；本次
+  只把它的量測方法修正並在 runbook 上記清楚，不順手放寬 Manager 的 MDWE。

--- a/docs/superpowers/runbooks/trust-root-phase2b-setup.md
+++ b/docs/superpowers/runbooks/trust-root-phase2b-setup.md
@@ -4758,6 +4758,11 @@ print("unit prefix contract OK:", prefix)
 PY
 
 # ✅ 正向：transient job 起得來且降到 cortex-builder
+# ⚠️ 這一條**刻意不是**加固面複本（因此不走 `psc_run_under`）：它驗的是「Manager 起得了
+#    transient unit 且降得到 cortex-builder」，＝ A 方案的**派工**能力，與加固面無關。
+#    A 方案本來就只送 `NoNewPrivileges=yes`（見 `job_runner`），這裡逐字反映那個現況。
+#    A 方案的完整加固建議清單另有出處：`trust_root unit --job-properties`。
+#    **不要**把這一條當成「真實加固面下的驗證」——那一族全部走第 4e 步的共用探針（#673）。
 sudo -u cortex-manager systemd-run --quiet --collect --pipe --wait \
   --unit=cortex-job-smoke-00000000.service \
   --uid=cortex-builder --gid=cortex-builder --service-type=exec \

--- a/docs/superpowers/runbooks/trust-root-phase2b-setup.md
+++ b/docs/superpowers/runbooks/trust-root-phase2b-setup.md
@@ -300,6 +300,15 @@ A/B 並列時同一件事要寫兩遍（5-A／5-B、第 8 步兩種起法、附�
   兩字幹複跑（含 `systemd-analyze verify` 的未知鍵落檔後檢查——#645 修的是產生器，
   已落檔的 unit 不會自己更新），4e 的 executor 形態表回填「`copilot` 也需要 node」
   → **50** 個 sudo 點、**184** 個驗證點。
+- **#673（加固面複本必須全量導出）新增**：4e 新增「共用探針 `psc_run_under`」一節，
+  加固面改由 `permgen.unit_replica_properties()`（CLI：`trust_root unit-replica`）從
+  **已落檔的 unit** 全量導出——4e 的三條、5-3 的 pytest、5-4 的 `gh` 原本各自手抄
+  四條 property，5-2b 則是一份手維護的 27 鍵 grep 白名單且不含
+  `ReadWritePaths=`／`WorkingDirectory=`／per-account `Environment=`；5-2b 的驗收
+  由「正向四段」改為 **4 executor × 2 剖面 × 2 角色 unit 的全矩陣**（新增**反向對照**：
+  `claude`／`agy` 在 jit 剖面下仍須 rc=0），並補「失敗原因要對得上」與 seccomp 過濾
+  語意不變式兩條。**起因**：一份漏抄 `SystemCallErrorNumber=EPERM` 的手抄複本比
+  production 更嚴格，量出一個不存在的 P0——手抄子集的假紅與假綠一樣會發生。
 - **#615（M2：reviewer／planner 啟動面降權）新增**：第 5-2 步再擴為落**四份**
   template unit（2 角色 × 2 剖面，另含「四份加固表集合比對」與「reviewer 的 RWP
   恰好兩條且不含任何 `%i` 路徑」兩條 gate）、5-5 補 reviewer 那一組 env ＋ 角色解析
@@ -339,7 +348,7 @@ A/B 並列時同一件事要寫兩遍（5-A／5-B、第 8 步兩種起法、附�
 | 登記表雙向等式 | 執行前提 4／第 7 步 | `ok: true`（切換前後皆是） |
 | legacy-import manifest | 第 3 步 | 78,674 檔；全量複驗 78,674/78,674 `OK` |
 | 5-6 正向 smoke | 第 5 步 | 成功；`uid=…(cortex-builder)`、token 已 scrub、fd 僅 0/1/2、`HOME=/var/lib/cortex-builder`（root-owned）、部署樹不可寫 |
-| 5-2b 雙剖面（#643） | 第 5 步 | 正向四段皆 rc=0 且版本相符；**負向對照**：`codex`／`copilot` 在 strict 剖面下**空輸出** |
+| 5-2b 雙剖面（#643／#673） | 第 5 步 | **在 `unit-replica` 全量導出的加固面下**跑滿 4 executor × 2 剖面 × 2 角色 unit：正向四格 rc=0 且版本相符；**負向對照** `codex`／`copilot` @strict 失敗且 stderr 為 V8 的 `Runtime_CompileLazy`（**不是**空 stderr）；**反向對照** `claude`／`agy` @jit 仍 rc=0 |
 | 5-7 反向 11 條 | 第 5 步 | **全數非 0**（(5)(7)(8)(9)(10) 對兩個字幹各一次） |
 | 5-7 (12) 剖面不可選（#643） | 第 5 步 | 三小條**全部 0**（＝拒絕確實發生） |
 | 5-7 (11) fail-closed | 第 5 步 | 移除 polkit 規則後起 job **失敗**、還原後**成功**（證明是規則在守，不是全紅假綠） |
@@ -1867,24 +1876,83 @@ codex --version
 #   而 job 跑的就變成 operator 從未判讀過的版本（症狀是「結果對不上」，不是報錯）。
 #   不同 ⇒ PATH 順序錯（toolchain 沒排最前面），或複製到的是系統那份。
 
+```
+
+#### 共用探針：`psc_run_under`（在**真實加固面**下跑一條命令）
+
+> **本 runbook 之後每一條「在真實加固面下」的驗證都用它，不再手打 `--property=`。**
+> 這是 #638（單 UID 讓 ACL 斷言真空）／#657（同型）／#673（同型）三次同一族事故
+> 之後定下的規矩：**加固面的定義只有一份，在 `permgen.unit_replica_properties()`**。
+> runbook 與 `tests/test_trust_root_syscall_profile_673.py` 共用它。
+>
+> #673 值得逐字記住：那份手抄複本抄了 `SystemCallFilter=@system-service`、**漏抄**
+> 同一份 unit 上的 `SystemCallErrorNumber=EPERM`，於是複本落回 systemd 預設的
+> `SECCOMP_RET_KILL_PROCESS`——**比 production 更嚴格**，量出一個 production 沒有的
+> `rc=1`。**手抄子集的假紅與假綠一樣會發生，方向不由人選。**
+
+```bash
+# 一次貼進 shell，之後各步驟直接呼叫。
+psc_probe_path() {
+  # PATH 也不手打：job 的 PATH 來自 Manager 端 root-owned 的 EnvironmentFile
+  # （模板 unit 刻意不寫 Environment=PATH=，因為 shim 會整份換掉環境）。
+  sudo grep -hoE '^(PSC_[A-Z]+_PATH|PATH)=.*' /opt/cortex/etc/cortex-manager.env \
+    | head -1 | cut -d= -f2-
+}
+
+psc_run_under() {   # psc_run_under <unit 字幹> <命令> [參數…]
+  local stem="$1"; shift
+  local -a props
+  # `systemctl cat` 帶上 drop-in，因此驗到的是**實際生效**的那一份，不是主檔而已。
+  mapfile -t props < <(
+    sudo systemctl cat "${stem}@.service" \
+      | python3 -m paulsha_cortex.trust_root unit-replica - --instance probe
+  )
+  # unit-replica 在落檔的 unit 少任一加固鍵時 fail-closed（stdout 空、rc=2）——
+  # 這一關不能省：空清單會讓下面那條變成「完全沒有加固的探針」，然後全綠。
+  if [ "${#props[@]}" -lt 30 ]; then
+    echo "⛔ 加固面複本只有 ${#props[@]} 條——unit 落檔不完整或產生器已漂移，停下來" >&2
+    return 90
+  fi
+  sudo systemd-run --pipe --wait --collect --quiet --service-type=exec \
+    "${props[@]}" --setenv=PATH="$(psc_probe_path)" "$@"
+}
+```
+
+**兩個必須先做的前置**（做不到就是探針本身壞了，不是被驗的東西壞了）：
+
+```bash
+# 1) 模板 unit 的 ReadWritePaths 含 %i（builder 的 /var/lib/cortex/worktree/%i）。
+#    systemd 對不存在的 ReadWritePaths 目標**在 exec 前就失敗**（rc=226 EXIT_NAMESPACE，
+#    輸出全空——症狀與「CLI 起不來」一模一樣）。--instance probe 因此需要一格真目錄。
+sudo install -d -o cortex-builder -g cortex-builder -m 0700 /var/lib/cortex/worktree/probe
+#    收尾：sudo rm -rf /var/lib/cortex/worktree/probe
+#    ⚠️ **這一格正是手抄四 property 複本永遠看不到的東西**——那份複本連
+#       ReadWritePaths 都沒有，所以它從來不會因為這個原因失敗，也就從來沒驗到它。
+
+# 2) 確認複本條數與 unit 相符（漂移偵測；數字會隨加固表成長，不要寫死在別處）
+sudo systemctl cat cortex-reviewer-job@.service \
+  | python3 -m paulsha_cortex.trust_root unit-replica - | wc -l
+#    期望：與 `grep -cE '^[A-Za-z]+=' <unit 的 [Service] 段>` 扣掉執行面指令後相同，
+#    且**至少**含 27 條加固鍵。少於 30 ⇒ 停下來，不要繼續往下驗。
+```
+
+回到 4e 那條「在真實加固面下驗 toolchain 可達性」的驗證——現在它走共用探針：
+
+```bash
 # ✅ 驗證（**在真實加固面下**跑一次）：`sudo -u` 沒有 unit 的加固，兩者可能不同結果
-sudo systemd-run --pipe --wait --collect \
-  --uid=cortex-builder --gid=cortex-builder \
-  --property=NoNewPrivileges=yes --property=ProtectSystem=strict \
-  --property=ProtectHome=yes --property=MemoryDenyWriteExecute=yes \
-  --setenv=HOME=/var/lib/cortex-builder \
-  --setenv=PATH=/opt/cortex/toolchain/bin:/usr/local/bin:/usr/bin:/bin \
-  /opt/cortex/toolchain/bin/codex --version
-#   期望（`codex` 這一支）：**空輸出**。
+#    這一步**不再手打 --property=**（#673：手抄的子集抄了 SystemCallFilter 卻漏抄
+#    SystemCallErrorNumber，量出一個 production 根本沒有的失敗）。
+psc_run_under cortex-job /opt/cortex/toolchain/bin/codex --version
+#   期望（`codex` 在 **strict** 剖面下）：**stdout 空**、rc≠0。
 #   ✅ 這不是失敗，是 #643 已經定案的事實：`MemoryDenyWriteExecute=yes` 與 V8 的 JIT
-#      天生互斥（node 崩在 `v8::internal::Runtime_CompileLazy`）。上面這條刻意保留
-#      **完整**加固面，是為了讓執行者親眼看到「為什麼需要第二份剖面」。
-#   ✅ 把 `--property=MemoryDenyWriteExecute=yes` 改成 `=no` 複跑，應印出與 operator
-#      側逐字相同的版本——那正是 `cortex-job-jit@.service`（jit 剖面）的加固面。
+#      天生互斥。stderr 會出現 V8 的 `Check failed: 12 == (*__errno_location ())`
+#      ——那就是它（V8 期待 mmap 回 ENOMEM(12)，被 MDWE 擋成 EPERM(1)）。
+#   ✅ 改跑 `psc_run_under cortex-job-jit /opt/cortex/toolchain/bin/codex --version`，
+#      應印出與 operator 側逐字相同的版本——那正是 jit 剖面的加固面。
 #   ⚠️ 若**兩種**都失敗，那就不是 MDWE，回到上一條查 PATH／toolchain 可達性。
 #   ⚠️ `claude`／`agy` 在**兩種**下都應該 rc=0；若它們在完整加固面下也失敗，代表
 #      這台機器上還有第三個阻斷點——**停下來查清楚**，不要順手再放寬一項。
-#   完整的雙剖面驗證（含負向對照）在第 5-2b 步；這裡只是提早看見那條分岔。
+#   完整的雙剖面驗證（含負向對照與反向矩陣）在第 5-2b 步；這裡只是提早看見那條分岔。
 ```
 
 ```bash
@@ -1895,27 +1963,30 @@ for s in permgen.unresolved_node_execution_surfaces(): print(s.program, '←', s
 #   目前預期兩列：srt ← executor claude ⇒ strict；openspec ← manager-unit。
 
 # (1) srt 在 reviewer job 的 strict 剖面下（＝ claude 實際 exec 它的那個加固面）
-sudo systemd-run --pipe --wait --collect \
-  --uid=cortex-reviewer-planner --gid=cortex-reviewer-planner \
-  --property=NoNewPrivileges=yes --property=ProtectSystem=strict \
-  --property=ProtectHome=yes --property=MemoryDenyWriteExecute=yes \
-  --setenv=HOME=/var/lib/cortex-reviewer-planner \
-  --setenv=PATH=/opt/cortex/toolchain/bin:/usr/local/bin:/usr/bin:/bin \
-  /opt/cortex/toolchain/bin/srt --version
+psc_run_under cortex-reviewer-job /opt/cortex/toolchain/bin/srt --version
 
 # (2) openspec 在 Manager system unit 的加固面下
-sudo systemd-run --pipe --wait --collect \
-  --uid=cortex-manager --gid=cortex-manager \
-  --property=NoNewPrivileges=yes --property=ProtectSystem=strict \
-  --property=ProtectHome=yes --property=MemoryDenyWriteExecute=yes \
-  --setenv=HOME=/var/lib/cortex-manager \
-  --setenv=PATH=/opt/cortex/toolchain/bin:/usr/local/bin:/usr/bin:/bin \
+#     Manager 不是模板 unit，字幹沒有 `@`——直接餵檔案（--instance 用不到）。
+mapfile -t mprops < <(sudo systemctl cat cortex-manager.service \
+  | python3 -m paulsha_cortex.trust_root unit-replica -)
+sudo systemd-run --pipe --wait --collect --quiet --service-type=exec \
+  "${mprops[@]}" --setenv=PATH="$(psc_probe_path)" \
   /opt/cortex/toolchain/bin/openspec --version
 
-#   ⚠️ 兩條**預期都會失敗（空輸出或非零）**，症狀與 #643 的 codex／copilot 逐字相同：
-#      node 的 V8 崩在 `Runtime_CompileLazy`，`MemoryDenyWriteExecute=yes` 與 JIT 天生互斥。
-#   ✅ 確認方式：把該條的 `--property=MemoryDenyWriteExecute=yes` 改成 `=no` 複跑，
-#      若印得出版本，就確認阻斷點是它、不是別的。
+#   ⚠️ 兩條**預期都失敗（stdout 空、rc=1）**，症狀與 #643 的 codex／copilot 逐字
+#      相同——#673 已在完整加固面下複驗，兩條的 stderr 都是同一段 V8 stack trace：
+#          # Check failed: 12 == (*__errno_location ()).
+#          … v8::internal::Runtime_CompileLazy …
+#      `MemoryDenyWriteExecute=yes` 與 V8 的 JIT 天生互斥（V8 期待 mmap 回
+#      ENOMEM(12)，被 MDWE 擋成 EPERM(1)，於是那個 CHECK 炸掉）。
+#   ✅ 確認阻斷點是 MDWE 而非別的：改跑 `psc_run_under cortex-reviewer-job-jit
+#      /opt/cortex/toolchain/bin/srt --version`（jit 剖面，與 strict 只差 MDWE 一項）
+#      ——#673 實機為 `1.0.0`、rc=0。openspec 沒有對應的 jit Manager unit，
+#      因此 (2) 目前**無解**，維持 #661 的未決狀態。
+#   ⚠️ **注意 stderr 不是空的**。#673 的原始回報寫「stdout 與 stderr 皆空」，那是
+#      因為它的手抄複本漏掉 `SystemCallErrorNumber=EPERM`，行程被 SIGSYS 當場殺掉、
+#      連 V8 的錯誤都來不及印。在**真實**加固面下這一族失敗是有 stack trace 的
+#      ——看到空 stderr 就代表你的複本不等於 production，回去查複本。
 #   ⛔ **不要就地把 unit 的 MDWE 改掉**。#643 的先例是「量到才改，而且改的是一份具名
 #      剖面，不是全域放寬」——reviewer 要不要走 jit 剖面、Manager 這一面要不要動，
 #      是 operator 的裁決。把兩條的實際輸出貼回 #661 的 follow-up issue。
@@ -2040,24 +2111,36 @@ sudo -u cortex-gate env HOME=/var/lib/cortex-gate python3 -c 'import yaml; print
 #   期望：印出版本
 
 # ✅ 驗證（2）：**在完整加固面下**複跑（`sudo -u` 沒有 unit 的加固面）
-#    探測目錄給 gate 帳號擁有——pytest 會在 rootdir 建 `.pytest_cache`，root-owned 的
-#    目錄會讓它印一段與待驗命題無關的 cache 警告，白白製造雜訊。
-sudo install -d -o cortex-gate -g cortex-gate -m 0755 /tmp/psc-gate-probe
-printf 'def test_ok():\n    assert True\n' \
-  | sudo tee /tmp/psc-gate-probe/test_probe.py >/dev/null
-sudo systemd-run --pipe --wait --collect \
-  --uid=cortex-gate --gid=cortex-gate \
-  --property=NoNewPrivileges=yes --property=ProtectSystem=strict \
-  --property=ProtectHome=yes --property=MemoryDenyWriteExecute=yes \
-  --setenv=HOME=/var/lib/cortex-gate \
-  --setenv=PATH=/opt/cortex/toolchain/bin:/usr/local/bin:/usr/bin:/bin \
-  --working-directory=/tmp/psc-gate-probe \
+#    探測目錄放在 gate **自己登記表上的可寫面**底下（`/var/lib/cortex/gate-worktree`），
+#    不放 /tmp——理由見下方 ⚠️。並給 gate 帳號擁有：pytest 會在 rootdir 建
+#    `.pytest_cache`，root-owned 的目錄會讓它印一段與待驗命題無關的警告。
+PROBE=/var/lib/cortex/gate-worktree/psc-probe
+sudo install -d -o cortex-gate -g cortex-gate -m 0700 "$PROBE"
+printf 'def test_ok():\n    assert True\n' | sudo tee "$PROBE/test_probe.py" >/dev/null
+sudo chown cortex-gate:cortex-gate "$PROBE/test_probe.py"
+#    加固面從已落檔的 gate 模板 unit 機械導出（見上方「共用探針」），只覆寫
+#    WorkingDirectory 指向探測目錄——**其餘一條都不減**。
+mapfile -t gprops < <(sudo systemctl cat cortex-gate-job@.service \
+  | python3 -m paulsha_cortex.trust_root unit-replica - --instance probe)
+sudo systemd-run --pipe --wait --collect --quiet --service-type=exec \
+  "${gprops[@]}" \
+  --property=WorkingDirectory="$PROBE" \
+  --setenv=PATH="$(psc_probe_path)" \
   /usr/bin/python3 -m pytest -q
 #   期望：`1 passed`，rc=0。
+#   ⚠️ `--property=WorkingDirectory=` 必須排在複本**之後**才覆寫得掉（systemd 取
+#      最後一次指定的值）。
+#   ⚠️ **不要把探測目錄放在 /tmp**：完整加固面含 `PrivateTmp=yes`，host 上的
+#      `/tmp/psc-gate-probe` 在 unit 的私有 /tmp 裡根本不存在，`WorkingDirectory=`
+#      指過去會在 exec **之前**就失敗——rc=226（EXIT_NAMESPACE）、輸出全空，
+#      症狀與「pytest 起不來」一模一樣。#673 實機踩到並複驗過。
+#      **這正是舊版四 property 複本看不到的東西**：那份複本沒有 PrivateTmp，
+#      所以 /tmp 一直能用，於是這條驗證多年來驗的都不是 production 的條件。
 #   ✅ **這一條在完整加固面下就應該過，不需要放寬任何一項**：CPython 不是 V8，
 #      `MemoryDenyWriteExecute=yes` 對它沒有影響（與 #643 的 node 型 executor 相反）。
+#      #673 實機複驗：完整 38 條複本下 `1 passed`、rc=0。
 #   ⚠️ 若這一條失敗而拿掉 MDWE 才過，那是新發現——**停下來記回 issue**，不要就地放寬。
-sudo rm -rf /tmp/psc-gate-probe
+sudo rm -rf "$PROBE"
 
 # ✅ 驗證（3）：**版本是明示的部署決定** —— 記下來並與 operator 側比對
 python3 -m pytest --version                                  # operator 側
@@ -2160,14 +2243,17 @@ sudo -u cortex-manager env HOME=/var/lib/cortex-manager gh auth status
 #      `XDG_CONFIG_HOME`／`GH_CONFIG_DIR`（見上方那條無聲漂移的警告）。
 
 # ✅ 驗證（3）：**在完整加固面下**複跑（`sudo -u` 沒有 unit 的加固面）
-sudo systemd-run --pipe --wait --collect \
-  --uid=cortex-manager --gid=cortex-manager \
-  --property=NoNewPrivileges=yes --property=ProtectSystem=strict \
-  --property=ProtectHome=yes --property=MemoryDenyWriteExecute=yes \
-  --setenv=HOME=/var/lib/cortex-manager \
-  --setenv=PATH=/opt/cortex/toolchain/bin:/usr/local/bin:/usr/bin:/bin \
+#    加固面從已落檔的 Manager unit 機械導出——手打子集抄漏一條就驗不到 production
+#    的條件（#673）。Manager 不是模板 unit，因此不需要 --instance。
+mapfile -t mprops < <(sudo systemctl cat cortex-manager.service \
+  | python3 -m paulsha_cortex.trust_root unit-replica -)
+sudo systemd-run --pipe --wait --collect --quiet --service-type=exec \
+  "${mprops[@]}" --setenv=PATH="$(psc_probe_path)" \
   /usr/bin/gh auth status
 #   期望：同上。`gh` 是原生 ELF，MDWE 不影響它。
+#   ⚠️ 這份複本會連 `EnvironmentFile=/opt/cortex/etc/cortex-manager.env` 一起帶上
+#      （它是 [Service] 段的一部分）——那是刻意的：Manager 的 PSC_* 設定同屬它的
+#      執行條件。檔案缺席時 unit 本來就 fail-closed，探針一起失敗是正確行為。
 
 # ✅ 驗證（4）：**不變式「改得了內容、建不了新檔」**（與 4e 的憑證逐條同構）
 sudo -u cortex-manager sh -c \
@@ -2441,47 +2527,69 @@ PY
 #        sudo systemctl reset-failed 'cortex-job@*' 'cortex-job-jit@*'
 ```
 
-### 5-2b. 在**真實加固面下**驗證兩種剖面（#643 的核心驗收）
+### 5-2b. 在**真實加固面下**驗證兩種剖面（#643 的核心驗收；#673 改為全矩陣）
 
 **只驗寬鬆環境的 `--version` 會整個溜過去**——四支 executor 在 `sudo -u` 下全部
-rc=0、版本全部相符，而其中兩支在真實加固面下是空輸出。這一步的形狀比照第 4e 步：
-用 `systemd-run` 把**真的加固指令**帶上去跑，且**必須有負向對照**（strict 剖面下
-node 型 executor 應該失敗；只驗 jit 成功等於什麼都沒驗）。
+rc=0、版本全部相符，而其中兩支在真實加固面下是空輸出。
+
+**但「比 production 弱的複本」只是兩種錯法的其中一種。** #673 量到另一個方向：
+一份手抄的十 property 複本抄了 `SystemCallFilter=` 卻**漏抄** `SystemCallErrorNumber=EPERM`，
+於是它比 production **更嚴格**（seccomp 落回預設的 `SECCOMP_RET_KILL_PROCESS`），
+量出一個 production 根本不存在的 `codex`／`copilot` rc=1，並據此開了一張「預設派工
+路徑是壞的」的 P0。**手抄子集的假綠與假紅一樣會發生，方向不由人選。**
+
+因此本步驟的規矩是：
+
+1. **加固面一律走 `psc_run_under`**（見第 4e 步的「共用探針」），由
+   `permgen.unit_replica_properties()` 從**已落檔的 unit** 全量導出，不手抄、不 grep
+   白名單。落檔的 unit 少任一加固鍵時該函式 fail-closed，不會產出半套清單。
+2. **驗的是矩陣，不是四段**：每個 executor × 每個剖面都要跑，因為「A 在自己的剖面下
+   能動」證明不了「B 在同一份剖面下沒被弄壞」。
 
 ```bash
-# ✅ 直接從已落檔的 unit 取出加固面，組成 systemd-run 的 --property 清單
-#    （不要手打——手打的清單與 unit 漂移時，這一步驗的就不是 unit 了）
-props() {
-  sudo grep -E "^(NoNewPrivileges|CapabilityBoundingSet|AmbientCapabilities|ProtectSystem|ProtectHome|PrivateTmp|PrivateDevices|ProtectProc|ProcSubset|ProtectControlGroups|ProtectKernelModules|ProtectKernelTunables|ProtectKernelLogs|ProtectClock|ProtectHostname|RestrictSUIDSGID|RestrictNamespaces|RestrictRealtime|RestrictAddressFamilies|LockPersonality|MemoryDenyWriteExecute|SystemCallArchitectures|SystemCallFilter|SystemCallErrorNumber|RemoveIPC|KeyringMode|UMask)=" \
-    "/etc/systemd/system/$1@.service" | sed 's/^/--property=/'
-}
-run_under() {   # run_under <unit-stem> <cli>
-  sudo systemd-run --pipe --wait --collect --quiet \
-    --uid=cortex-builder --gid=cortex-builder \
-    $(props "$1") \
-    --setenv=HOME=/var/lib/cortex-builder \
-    --setenv=PATH=/opt/cortex/toolchain/bin:/usr/local/bin:/usr/bin:/bin \
-    "/opt/cortex/toolchain/bin/$2" --version
-}
+# 前置：--instance probe 需要一格真的 worktree（見第 4e 步的說明）
+sudo install -d -o cortex-builder -g cortex-builder -m 0700 /var/lib/cortex/worktree/probe
 
-# ✅ (1) 正向：每個 executor 在**它自己的**剖面下必須跑得出版本
-for cli in claude agy; do echo "== $cli @strict"; run_under cortex-job     "$cli"; echo "rc=$?"; done
-for cli in codex copilot; do echo "== $cli @jit"; run_under cortex-job-jit "$cli"; echo "rc=$?"; done
-#   期望：四段皆印出版本字串且 rc=0，且版本與 operator 側逐字相同（第 4e 步那條）。
+# ✅ (1) 全矩陣：4 executor × 2 剖面 × 2 角色 unit，一次跑完並列印
+for stem in cortex-job cortex-job-jit cortex-reviewer-job cortex-reviewer-job-jit; do
+  for cli in claude agy codex copilot; do
+    out="$(psc_run_under "$stem" "/opt/cortex/toolchain/bin/$cli" --version 2>/dev/null)"; rc=$?
+    printf '%-26s %-8s rc=%-3s out=[%s]\n' "$stem" "$cli" "$rc" "$(echo "$out" | tr -d '\n' | cut -c1-34)"
+  done
+done
+```
 
-# ✅ (2) **負向對照（不可省略）**：node 型 executor 在 strict 剖面下必須**失敗**
-for cli in codex copilot; do echo "== $cli @strict（期望空輸出／非 0）"; run_under cortex-job "$cli"; echo "rc=$?"; done
-#   期望：**空輸出**（V8 崩在 Runtime_CompileLazy）。
-#   ⚠️ 若這兩段也印出版本 ⇒ strict 那份 unit 的 MemoryDenyWriteExecute 沒生效
-#      （落檔錯／被 drop-in 覆蓋／props() 沒抓到那一行）。此時 (1) 的綠是假的，
-#      因為它證明不了「jit 剖面是必要的」，也證明不了「strict 剖面真的在守」。
+**期望矩陣**（#673 實機逐格量測，`cortex-job*`＝builder、`cortex-reviewer-job*`＝
+reviewer／planner；同一剖面下兩個角色**必須**逐格相同，不同代表帳號面有分岔）：
 
-# ✅ (3) 對照：原生 ELF 在 jit 剖面下也會動（證明差異只在 node 型身上）
-run_under cortex-job-jit claude; echo "rc=$?"
-#   期望：rc=0。這條不是驗收條件，是在 (2) 失敗時區分「MDWE 沒生效」與
-#   「toolchain 根本不可達」的分流點。
+| executor | `…-job@`（strict） | `…-job-jit@`（jit） |
+|---|---|---|
+| `claude` | **rc=0** `2.1.233 (Claude Code)` | **rc=0** 同左 |
+| `agy` | **rc=0** `1.1.13` | **rc=0** 同左 |
+| `codex` | rc=1、stdout 空 | **rc=0** `codex-cli 0.147.0` |
+| `copilot` | rc=1、stdout 空 | **rc=0** `0.0.330` |
 
-# ✅ (4) 剖面對應表：確認程式碼看到的分類與上面實測一致
+- **正向**（每個 executor 在**它自己的**剖面下）：`claude`／`agy` 看 strict 欄，
+  `codex`／`copilot` 看 jit 欄——**四格皆 rc=0，且版本與 operator 側逐字相同**
+  （第 4e 步那條）。
+- **負向對照（不可省略）**：`codex`／`copilot` 的 strict 欄**必須失敗**。
+  只驗 jit 成功等於什麼都沒驗。
+- **反向對照（#673 新增，同樣不可省略）**：`claude`／`agy` 的 **jit** 欄必須
+  rc=0。放寬剖面若弄壞了原本好的兩支，這是唯一看得見的地方。
+
+```bash
+# ✅ (2) 負向那兩格的**失敗原因**要對得上，不能只看 rc
+psc_run_under cortex-job /opt/cortex/toolchain/bin/codex --version
+#   期望 stderr 含：`Check failed: 12 == (*__errno_location ())` 與
+#                   `v8::internal::Runtime_CompileLazy`
+#   ——那是 MDWE：V8 期待 mmap 回 ENOMEM(12)，被擋成 EPERM(1)。
+#   ⚠️ **stderr 空**是另一回事，不是這一條：那代表行程被 SIGSYS 當場殺掉，
+#      ＝你的複本漏了 `SystemCallErrorNumber=EPERM`（#673 的原始誤判）。
+#      看到空 stderr 先回去查複本，不要開票說 executor 壞了。
+#   ⚠️ 若這兩格反而**印出版本** ⇒ strict 那份 unit 的 MDWE 沒生效（落檔錯／被
+#      drop-in 覆蓋）。此時正向的綠是假的：它證明不了 jit 剖面是必要的。
+
+# ✅ (3) 剖面對應表：確認程式碼看到的分類與上面實測一致
 python3 - <<'PY'
 from paulsha_cortex.trust_root import permgen
 for tool in permgen.EXECUTOR_TOOLS:
@@ -2490,9 +2598,29 @@ for tool in permgen.EXECUTOR_TOOLS:
           f"profile={p.profile_id:6s} unit={permgen.job_unit_stem(profile=p)}@.service")
 PY
 #   期望：codex/copilot → jit（cortex-job-jit@.service）；claude/agy → strict。
-#   ⚠️ 若實測 (1)(2) 與這張表對不上，**以實測為準**並回填 permgen.EXECUTOR_TOOLS
+#   ⚠️ 若實測 (1) 與這張表對不上，**以實測為準**並回填 permgen.EXECUTOR_TOOLS
 #      的 needs_node（那張表是唯一真相來源），不要在 runbook 裡各記一份。
+
+# ✅ (4) seccomp 過濾語意的不變式（#673）：與剖面**正交**的第二個維度
+python3 - <<'PY'
+from paulsha_cortex.trust_root import permgen
+for f in permgen.filtered_syscall_surfaces():
+    print(f"{f.program:9s} {','.join(f.syscalls):12s} fatal={f.fatal!s:5s} {f.detail}")
+PY
+#   期望：四列（codex／copilot／srt／openspec），**fatal 全部 False**。
+#   出現 fatal=True ⇒ 那支程式會在該面上靜默死（rc=1、stdout 與 stderr 皆空）。
+#   （permgen import 時就會擋下這種狀態，因此這裡看到的是「檢查有跑」的確認。）
+
+sudo rm -rf /var/lib/cortex/worktree/probe   # 收尾
 ```
+
+> **不要把 `pkey_alloc`／`@pkey`／`@sandbox` 加進 `SystemCallFilter=`。**
+> #673 量到：`@system-service` 確實過濾掉 V8 要用的 `pkey_alloc`（x86_64 330），
+> 但同一份 unit 上的 `SystemCallErrorNumber=EPERM` 讓它只回錯誤碼、不殺行程，V8
+> 走 fallback，四支 executor 全部正常。放行那支 syscall 是**放寬過濾器**且沒有
+> 量測支撐；`EPERM` **不放行任何 syscall**。沿用 #643 的先例：量到才改，改的是
+> 一份具名剖面，不是全域放寬——而這次量到的結論是**不用改**。
+> （順帶：`@sandbox` 對此症狀完全無效，實測加了照樣死。）
 
 ### 5-2c. 兩份 gate 模板（#629 gate 執行身分）
 

--- a/paulsha_cortex/trust_root/__main__.py
+++ b/paulsha_cortex/trust_root/__main__.py
@@ -40,6 +40,21 @@ Phase 1 不改 `cortex` CLI（避免動到 R-16 help 對齊面）；operator／C
                                                     #   MemoryDenyWriteExecute，給 node 型
                                                     #   executor（codex／copilot）用，
                                                     #   unit 名尾綴 -jit）
+    python -m paulsha_cortex.trust_root unit-replica <unit 檔路徑|->
+                                        [--instance <job id>]
+                                        [--allow-drift]
+                                                    # #673：把一份**已落檔**的 unit 讀成
+                                                    # systemd-run 的 --property= 完整清單，
+                                                    # 供 runbook／測試在**真實加固面**下
+                                                    # 跑探針。`-` 讀 stdin（可接
+                                                    # `systemctl cat`）。
+                                                    # 契約是「全帶，不選」：[Service] 段
+                                                    # 除執行面指令（ExecStart= 之類）外
+                                                    # 全部帶出——手抄子集是 #638／#657／
+                                                    # #673 同一族事故的成因。
+                                                    # 落檔的 unit 少了任一加固鍵即
+                                                    # **拒絕產出**（--allow-drift 可關，
+                                                    # 但那等於放棄本命令的用途）
     python -m paulsha_cortex.trust_root shim [four-way|three-way|two-way]
                                                     # Phase 2b 方案 B 的降權 shim 內容
                                                     # （模板 unit 的固定 ExecStart=）
@@ -114,6 +129,7 @@ from __future__ import annotations
 import json
 import os
 import sys
+from pathlib import Path
 from typing import Sequence
 
 from . import permgen, registry, selfcheck
@@ -402,6 +418,56 @@ def main(argv: Sequence[str] | None = None) -> int:
             "monitor": permgen.build_monitor_unit,
         }
         print(builders[which](scheme).content, end="")
+        return 0
+    if command == "unit-replica":
+        rest = args[1:]
+        source: str | None = None
+        instance = "probe"
+        require_hardening = True
+        expect_instance = False
+        for token in rest:
+            if expect_instance:
+                instance = token
+                expect_instance = False
+            elif token == "--instance":
+                expect_instance = True
+            elif token.startswith("--instance="):
+                instance = token.split("=", 1)[1]
+            elif token == "--allow-drift":
+                require_hardening = False
+            elif not token.startswith("--") and source is None:
+                source = token
+            else:
+                print(f"unknown unit-replica arg: {token}", file=sys.stderr)
+                return 2
+        if expect_instance:
+            print("--instance 需要一個 job id", file=sys.stderr)
+            return 2
+        if source is None:
+            print(
+                "unit-replica 需要一個 unit 檔路徑（`-` 讀 stdin）",
+                file=sys.stderr,
+            )
+            return 2
+        try:
+            text = (
+                sys.stdin.read()
+                if source == "-"
+                else Path(source).read_text(encoding="utf-8")
+            )
+        except OSError as exc:
+            print(f"讀不到 unit: {exc}", file=sys.stderr)
+            return 2
+        try:
+            props = permgen.unit_replica_properties(
+                text, instance=instance, require_hardening=require_hardening
+            )
+        except permgen.UnitReplicaDriftError as exc:
+            # fail-closed：stdout 保持空的，被 `$(...)` 展開時不會產生半套清單。
+            print(str(exc), file=sys.stderr)
+            return 2
+        for prop in props:
+            print(prop)
         return 0
     if command == "shim":
         rest = args[1:]

--- a/paulsha_cortex/trust_root/permgen.py
+++ b/paulsha_cortex/trust_root/permgen.py
@@ -512,6 +512,16 @@ class ToolchainProgram:
     #: 一份加固面下**——這正是 #643 的剖面推導（只看 executor 名）看不到的那一格。
     #: 值為 executor 名（⇒ 該 executor 的 job 模板 unit）或 :data:`MANAGER_SURFACE`。
     consumed_by: tuple[str, ...] = ()
+    #: 在 `SystemCallFilter=@system-service` 下，本程式**實機量到**會撞上的、被過濾
+    #: 掉的 syscall（#673）。
+    #:
+    #: **這是與 `needs_node` 正交的第二個加固維度，刻意不共用那個欄位**：
+    #: `needs_node` 導向「換一份放寬 `MemoryDenyWriteExecute` 的剖面」，本欄位導向
+    #: 「被過濾時不得致命」——處置方向相反，適用面也不同（本欄位涵蓋跑在 Manager
+    #: unit 上的非 executor，那一格根本沒有剖面）。詳見 `SECCOMP_FATALITY_KEY` 段。
+    #:
+    #: 只填**有 audit record 背書**的（`type=1326 … syscall=<n>`），不填形態推論。
+    filtered_syscalls: tuple[str, ...] = ()
 
 
 #: #640 的名字，保留為別名：那時表上只有 executor，型別名跟著語意走；#661 把非
@@ -531,6 +541,7 @@ ExecutorTool = ToolchainProgram
 EXECUTOR_TOOLS: tuple[ExecutorTool, ...] = (
     ExecutorTool(
         "codex", ExecutorShape.NODE_SCRIPT, needs_node=True, copy_tree=True,
+        filtered_syscalls=("pkey_alloc",),
         note=(
             "唯一硬需要 node 的：本體是 JS，進入點的 shebang 是 `#!/usr/bin/env node`。"
             "單搬那支 `.js` 會缺 `node_modules`，必須整包搬 npm 套件樹。"
@@ -544,6 +555,7 @@ EXECUTOR_TOOLS: tuple[ExecutorTool, ...] = (
     ),
     ExecutorTool(
         "copilot", ExecutorShape.SHELL_SCRIPT, needs_node=True, copy_tree=False,
+        filtered_syscalls=("pkey_alloc",),
         note=(
             "shell script，但**內部再 exec node**（#643 實機量測確認：完整加固面下 "
             "`--version` 空輸出，單獨拿掉 `MemoryDenyWriteExecute` 即正常，與 codex "
@@ -571,6 +583,7 @@ EXECUTOR_TOOLS: tuple[ExecutorTool, ...] = (
 SERVICE_TOOLS: tuple[ToolchainProgram, ...] = (
     ToolchainProgram(
         "srt", ExecutorShape.NODE_SCRIPT, needs_node=True, copy_tree=True,
+        filtered_syscalls=("pkey_alloc",),
         note=(
             "`@anthropic-ai/sandbox-runtime` 的進入點（npm bin `srt` → `dist/cli.js`），"
             "**Claude review sandbox 的強制面**：doctor 的 `review-sandbox` probe 與 "
@@ -595,6 +608,7 @@ SERVICE_TOOLS: tuple[ToolchainProgram, ...] = (
     ),
     ToolchainProgram(
         "openspec", ExecutorShape.NODE_SCRIPT, needs_node=True, copy_tree=True,
+        filtered_syscalls=("pkey_alloc",),
         note=(
             "`@fission-ai/openspec` 的進入點（`bin/openspec.js`）。ship 段的 "
             "`openspec archive -y` 與 preflight 的 `openspec validate` 都是**採信判準**"
@@ -2781,9 +2795,16 @@ _HARDENING: tuple[tuple[str, str, str], ...] = (
     ("SystemCallArchitectures", "native",
      "只允許原生 ABI，封掉經 32-bit compat 介面規避 seccomp。"),
     ("SystemCallFilter", "@system-service",
-     "seccomp 白名單：只留一般服務所需 syscall。"),
+     "seccomp 白名單：只留一般服務所需 syscall。※ #673 實機量到它會過濾掉 "
+     "`pkey_alloc`（V8 啟動時會叫），但**不放寬**：處置在下一行的過濾語意，"
+     "不在白名單。"),
     ("SystemCallErrorNumber", "EPERM",
-     "被過濾的 syscall 回 EPERM 而非 SIGSYS——失敗可觀測，不是無聲當掉。"),
+     "被過濾的 syscall 回 EPERM 而非 SIGSYS——失敗可觀測，不是無聲當掉。"
+     "※ **本行承重，刪掉會讓六份 job unit 上的 codex／copilot 同時靜默死**"
+     "（#673 實機：systemd 預設的 SECCOMP_RET_KILL_PROCESS 會在 V8 叫 "
+     "`pkey_alloc` 時當場殺掉 node，rc=1、stdout 與 stderr 皆空）。它**不放行"
+     "任何 syscall**，被擋的照樣擋，因此不是放寬。要動它必須先讀 "
+     "`SECCOMP_FATALITY_KEY` 那一段——import 時有強制檢查。"),
     ("RemoveIPC", "yes", "服務結束即清掉該 UID 的 IPC 物件，不留跨 job 殘留。"),
     ("KeyringMode", "private", "私有 kernel keyring：不共用、不繼承金鑰。"),
     ("UMask", "0077",
@@ -2952,6 +2973,171 @@ def executor_hardening_profile(executor: str) -> HardeningProfile:
             "落到放寬的那一份。"
         )
     return HARDENING_PROFILES_BY_ID[profile_id]
+
+
+# ---------------------------------------------------------------------------
+# seccomp 過濾語意（#673）——與加固剖面**正交**的第二個維度
+#
+# #643 的剖面只有一個軸：「這個 executor 要不要 W+X 記憶體」（`needs_node` ⇒
+# `MemoryDenyWriteExecute`）。#673 在實機量到第二個軸，而它**不是**剖面問題：
+#
+#   `SystemCallFilter=@system-service` 會過濾掉 `pkey_alloc`（x86_64 syscall 330，
+#   systemd 歸在 `@pkey`，而 `@pkey` 不在 `@system-service` 的 16 個子集合裡）。
+#   V8 啟動時會叫它。在 systemd **預設**的過濾語意（`SECCOMP_RET_KILL_PROCESS`）下，
+#   node 當場被 SIGSYS 殺掉——rc=1、stdout 與 stderr **皆空**；在
+#   `SystemCallErrorNumber=EPERM` 下，V8 收到 `EPERM` 走 fallback，一切正常。
+#   （kernel audit 直接證據：`type=1326 … comm="node" sig=31 syscall=330
+#   code=0x80000000`；全程沒有任何一筆 `landlock_*`／`seccomp` 的 record。）
+#
+# 因此承重的不是「放不放行那支 syscall」，而是「被過濾時致不致命」。兩者在安全面
+# 上差很多：放行 `pkey_alloc` 是**放寬過濾器**（多一支 syscall 可用）；
+# `SystemCallErrorNumber=EPERM` **不放行任何 syscall**——被擋的照樣擋，只是回錯誤碼
+# 而非殺行程。#673 的量測結論因此是**不放寬**：`SystemCallFilter=@system-service`
+# 在八份 unit（六份 job 模板 ＋ manager ＋ monitor）上逐字不動。
+#
+# **為何不把這個維度塞進 `needs_node`**（那樣兩件事會繼續混在一起）：
+#   1. **適用面比剖面大**。剖面只覆蓋 `EXECUTOR_TOOLS`；`openspec` 是
+#      `SERVICE_TOOLS`，跑在 **Manager unit** 上——那一格沒有剖面，卻同樣撞
+#      `pkey_alloc`（#673 實機 audit 確認）。綁在剖面上會整個漏掉 Manager 面。
+#   2. **處置方向相反**。`needs_node` 導向「換一份放寬的剖面」；本維度導向「一個
+#      所有剖面都**不得**分岔的鎖定鍵」。
+#   3. **證據等級不同**。`filtered_syscalls` 每一列都有 audit record 背書，不是
+#      「它是 node，所以大概會」。
+#
+# 落法沿用 permgen 既有做法：事實填在既有那張登記表（`ToolchainProgram.
+# filtered_syscalls`）上一格，需求由它**機械導出**，import 時強制——不另立第二張
+# 人工對照表，也不靠 review 記得。
+# ---------------------------------------------------------------------------
+
+#: 加固表中決定「被 `SystemCallFilter=` 擋掉的 syscall 致不致命」的那一個鍵。
+SECCOMP_FATALITY_KEY: str = "SystemCallErrorNumber"
+
+#: 剖面**永遠不得**分岔的鍵：seccomp 白名單本身，與它的過濾語意。
+#:
+#: 白名單在此是因為「放寬 syscall」必須是全域可稽核的一次決定，不能變成某份剖面
+#: 偷偷多開一支；過濾語意在此是因為它是**全部** node 型程式的存活條件，per-profile
+#: 分岔等於讓其中一份剖面靜默地殺掉 codex／copilot。
+#:
+#: 與 :data:`PROFILE_DIVERGENCE_KEYS` 恆為互斥（import 時強制）：想分岔其中任一項，
+#: 必須先把它從這裡拿掉——而那是一個看得見的 diff。
+PROFILE_LOCKED_KEYS: frozenset[str] = frozenset(
+    {"SystemCallFilter", SECCOMP_FATALITY_KEY}
+)
+
+
+def seccomp_filter_is_fatal(table: Mapping[str, str]) -> bool:
+    """該加固表下，被過濾的 syscall 會不會**殺掉行程**。
+
+    systemd 的語意：`SystemCallErrorNumber=` 未設或設為空 ⇒ 預設動作是
+    `SECCOMP_RET_KILL_PROCESS`（SIGSYS）；設成 errno 名或數字 ⇒ 該 syscall 回那個
+    錯誤碼、行程續跑。
+    """
+
+    return not str(table.get(SECCOMP_FATALITY_KEY, "") or "").strip()
+
+
+@dataclass(frozen=True)
+class FilteredSyscallSurface:
+    """一支**量到會撞被過濾 syscall** 的程式 × 它實際跑的加固面上的過濾語意。"""
+
+    program: str
+    #: 實機量到的、被 `@system-service` 擋掉的 syscall。
+    syscalls: tuple[str, ...]
+    #: 剖面 id（executor）或 :data:`MANAGER_SURFACE`（非 executor 的消費者面）。
+    surface: str
+    #: 該面上被過濾的 syscall 是否致命——**為真即是缺陷**。
+    fatal: bool
+    detail: str
+
+
+def _surface_hardening_table(surface: str) -> tuple[dict[str, str], str]:
+    """加固面名 → 該面生效的加固表。與 :func:`_surface_allows_wx` 同一組判準。"""
+
+    if surface == MANAGER_SURFACE:
+        return {key: value for key, value, _why in _HARDENING}, MANAGER_SURFACE
+    profile = executor_hardening_profile(surface)
+    return profile.effective(), f"executor {surface} ⇒ 剖面 {profile.profile_id}"
+
+
+def filtered_syscall_surfaces() -> tuple[FilteredSyscallSurface, ...]:
+    """全部 `filtered_syscalls` 非空的程式 × 它跑的每一個加固面（機械導出）。
+
+    executor 走自己的剖面；非 executor 走 `consumed_by` 指到的消費者面（executor
+    名 ⇒ 該 executor 的剖面；:data:`MANAGER_SURFACE` ⇒ Manager／monitor unit 的
+    加固表）。**不另立清單**：改一支程式的形態只改 :data:`TOOLCHAIN_PROGRAMS`
+    上那一列，這裡跟著動。
+    """
+
+    executor_names = {tool.name for tool in EXECUTOR_TOOLS}
+    findings: list[FilteredSyscallSurface] = []
+    for tool in TOOLCHAIN_PROGRAMS:
+        if not tool.filtered_syscalls:
+            continue
+        surfaces = (
+            (tool.name,) if tool.name in executor_names else tuple(tool.consumed_by)
+        )
+        if not surfaces:
+            # `consumed_by` 空的非 executor 無從得知它跑在哪一面——那是登記表的漏，
+            # 不是可以省略的一格。fail-closed 交給 `_validate_seccomp_tolerance`。
+            findings.append(
+                FilteredSyscallSurface(
+                    program=tool.name,
+                    syscalls=tool.filtered_syscalls,
+                    surface="",
+                    fatal=True,
+                    detail="未登記 consumed_by，無法判定它跑在哪一份加固面上",
+                )
+            )
+            continue
+        for surface in surfaces:
+            table, label = _surface_hardening_table(surface)
+            fatal = seccomp_filter_is_fatal(table)
+            findings.append(
+                FilteredSyscallSurface(
+                    program=tool.name,
+                    syscalls=tool.filtered_syscalls,
+                    surface=surface,
+                    fatal=fatal,
+                    detail=(
+                        f"{label}（{SECCOMP_FATALITY_KEY}="
+                        f"{table.get(SECCOMP_FATALITY_KEY, '') or '（未設＝致命）'}）"
+                    ),
+                )
+            )
+    return tuple(findings)
+
+
+def _validate_seccomp_tolerance() -> None:
+    """import 時強制 #673 的不變式。三條，缺一即讓 import 炸掉。"""
+
+    overlap = sorted(PROFILE_LOCKED_KEYS & PROFILE_DIVERGENCE_KEYS)
+    if overlap:
+        raise ValueError(
+            f"PROFILE_LOCKED_KEYS 與 PROFILE_DIVERGENCE_KEYS 重疊: {overlap}"
+            "——鎖定鍵的意思就是任何剖面都不得分岔它。"
+        )
+    known = {key for key, _value, _why in _HARDENING}
+    missing = sorted(PROFILE_LOCKED_KEYS - known)
+    if missing:
+        raise ValueError(
+            f"PROFILE_LOCKED_KEYS 指到 _HARDENING 沒有的鍵: {missing}"
+            "——鎖一個不存在的鍵不會擋住任何東西。"
+        )
+    broken = [item for item in filtered_syscall_surfaces() if item.fatal]
+    if broken:
+        detail = "；".join(
+            f"{item.program}（{', '.join(item.syscalls)}）在 {item.detail}"
+            for item in broken
+        )
+        raise ValueError(
+            "#673 不變式失守：下列程式實機量到會撞被 `SystemCallFilter=` 過濾掉的 "
+            f"syscall，而它們的執行面是**致命**過濾語意 ⇒ 會靜默死（rc=1、無輸出）：{detail}。"
+            f"處置是把該面的 `{SECCOMP_FATALITY_KEY}` 設成一個 errno（現行為 EPERM），"
+            "**不是**把那些 syscall 加進 `SystemCallFilter=` 白名單——後者是放寬，前者不是。"
+        )
+
+
+_validate_seccomp_tolerance()
 
 
 @dataclass(frozen=True)
@@ -5023,6 +5209,126 @@ def transient_unit_properties(
         retired=RETIRED_JOB_WRITE_ASSETS,
     ):
         props.append(f"--property=ReadWritePaths={rwp}")
+    return tuple(props)
+
+
+# ---------------------------------------------------------------------------
+# 從**已落檔的 unit** 機械導出 systemd-run 的 --property= 清單（#673）
+#
+# 為什麼不能用上面的 `transient_unit_properties()` 代替：那一支是從**產生器**展開
+# 的，它回答的是「permgen 現在會產出什麼」。runbook 要驗的是另一個命題——「磁碟上
+# 那份 unit 現在是什麼」。兩者會漂移（runbook 自己就記著「產生器修好 ≠ 已落檔的
+# unit 跟著更新，#643 的教訓」），而漂移正是要被驗出來的東西。
+#
+# 為什麼不能手抄子集：#638（單 UID 讓 ACL 斷言真空）、#657（同型）、#673 是同一族
+# 事故的第一、二、三次。#673 特別值得記：它的複本抄了 `SystemCallFilter=` 卻漏抄
+# `SystemCallErrorNumber=EPERM`，於是複本比 production **更嚴格**，量出一個
+# production 沒有的 rc=1——**手抄子集的假綠與假紅一樣會發生**，方向不由人選。
+#
+# 因此本函式的契約是「全帶，不選」：`[Service]` 段除了明示排除的執行面指令
+# （`ExecStart=` 之類，探針要換掉它）以外**全部**帶進 `--property=`。新增一項加固
+# 時 runbook 不必改、也不會漏——這就是它與 grep 白名單的差別。
+# ---------------------------------------------------------------------------
+
+#: 複製加固面時**不該**帶進 `systemd-run` 的 `[Service]` 指令。
+#:
+#: 判準是「這一項描述的是**跑什麼／怎麼收尾**，不是**在什麼條件下跑**」。刻意寫成
+#: 排除表而非允許表：允許表漏一項＝複本比 production 弱一項且沒人看得見，排除表漏
+#: 一項＝探針多帶一個無害的屬性、最壞情況是 `systemd-run` 當場報錯（看得見）。
+UNIT_REPLICA_EXCLUDED_KEYS: frozenset[str] = frozenset({
+    "ExecStart", "ExecStartPre", "ExecStartPost", "ExecStop", "ExecStopPost",
+    "ExecReload", "ExecCondition",
+    "Type", "Restart", "RestartSec", "RemainAfterExit", "GuessMainPID",
+    "PIDFile", "BusName", "NotifyAccess", "WatchdogSec",
+    "TimeoutStartSec", "TimeoutStopSec", "TimeoutSec", "RuntimeMaxSec",
+    "KillMode", "KillSignal", "SuccessExitStatus", "FinalKillSignal",
+    "StandardInput", "StandardOutput", "StandardError", "SyslogIdentifier",
+})
+
+
+class UnitReplicaDriftError(ValueError):
+    """已落檔的 unit 少了加固表上的鍵——複本會**比 production 弱**，一律拒絕產出。
+
+    這是本函式存在的唯一理由：靜默產出一份少幾條的清單，就是把 #673 再演一次。
+    """
+
+
+def _unit_service_directives(unit_text: str) -> list[tuple[str, str]]:
+    """把一份 unit 的 `[Service]` 段讀成 (key, value) 序列（保留重複鍵的順序）。"""
+
+    directives: list[tuple[str, str]] = []
+    section: str | None = None
+    pending: str | None = None
+    for raw in unit_text.splitlines():
+        line = raw.rstrip("\n")
+        if pending is not None:
+            # 續行：systemd 以行尾 `\` 續行，值以空白接續。
+            merged = pending + " " + line.strip()
+            if merged.endswith("\\"):
+                pending = merged[:-1].rstrip()
+                continue
+            pending = None
+            key, _, value = merged.partition("=")
+            directives.append((key.strip(), value.strip()))
+            continue
+        stripped = line.strip()
+        if not stripped or stripped.startswith(("#", ";")):
+            continue
+        header = re.fullmatch(r"\[([^\]]+)\]", stripped)
+        if header is not None:
+            section = header.group(1)
+            continue
+        if section != "Service" or "=" not in stripped:
+            continue
+        if stripped.endswith("\\"):
+            pending = stripped[:-1].rstrip()
+            continue
+        key, _, value = stripped.partition("=")
+        directives.append((key.strip(), value.strip()))
+    return directives
+
+
+def unit_replica_properties(
+    unit_text: str,
+    *,
+    instance: str = "probe",
+    require_hardening: bool = True,
+) -> tuple[str, ...]:
+    """一份**已落檔**的 unit → `systemd-run --property=` 的**完整**清單。
+
+    runbook 與測試共用這一支，因此「真實加固面」在兩邊是同一個定義。
+
+    :param instance: 模板 unit 的 `%i` 代入值（探針用的假 job id）。
+    :param require_hardening: 產出前強制比對 :data:`_HARDENING` 的每一個鍵都在
+        unit 裡。**預設開啟**——關掉它就回到「複本可能比 production 弱」的世界。
+    :raises UnitReplicaDriftError: 落檔的 unit 少了加固鍵，或值裡留有本函式展不開的
+        systemd specifier（展不開就代表複本與 unit 不同義，寧可炸掉）。
+    """
+
+    props: list[str] = []
+    seen: set[str] = set()
+    for key, value in _unit_service_directives(unit_text):
+        if key in UNIT_REPLICA_EXCLUDED_KEYS:
+            continue
+        expanded = value.replace("%i", instance).replace("%%", "%")
+        leftover = re.search(r"%[a-zA-Z]", expanded)
+        if leftover is not None:
+            raise UnitReplicaDriftError(
+                f"{key}= 的值含本函式展不開的 systemd specifier "
+                f"{leftover.group(0)!r}：{value!r}。複本與 unit 不同義時**不產出**"
+                "——請先把該 specifier 加進展開規則，不要讓探針帶著一個字面上的 % 跑。"
+            )
+        seen.add(key)
+        props.append(f"--property={key}={expanded}")
+    if require_hardening:
+        missing = [key for key, _value, _why in _HARDENING if key not in seen]
+        if missing:
+            raise UnitReplicaDriftError(
+                f"已落檔的 unit 缺少加固鍵 {missing}——用它組出來的複本會**比 "
+                "production 弱**，在那個複本下取得的綠不承載任何語意（#638／#657／"
+                "#673 同一族事故）。先重跑產生器落檔："
+                "`python3 -m paulsha_cortex.trust_root unit …`。"
+            )
     return tuple(props)
 
 

--- a/paulsha_cortex/trust_root/permgen.py
+++ b/paulsha_cortex/trust_root/permgen.py
@@ -5313,7 +5313,13 @@ def unit_replica_properties(
     for key, value in _unit_service_directives(unit_text):
         if key in UNIT_REPLICA_EXCLUDED_KEYS:
             continue
-        expanded = value.replace("%i", instance).replace("%%", "%")
+        # `%%` 是 systemd 的跳脫（＝一個字面 `%`），**必須先抽走**：否則 `%%i` 會被
+        # 下一步當成 specifier 展開成 `%<instance>`，而它的正確結果是字面 `%i`。
+        # 這種錯法不會報錯，只會讓探針的加固面與 unit 悄悄不同——正是本票要根除的那類。
+        sentinel = "\x00PCT\x00"
+        expanded = (
+            value.replace("%%", sentinel).replace("%i", instance).replace(sentinel, "%")
+        )
         leftover = re.search(r"%[a-zA-Z]", expanded)
         if leftover is not None:
             raise UnitReplicaDriftError(

--- a/paulsha_cortex/trust_root/permgen.py
+++ b/paulsha_cortex/trust_root/permgen.py
@@ -3866,7 +3866,10 @@ def _hardening_lines(
     lines: list[str] = []
     for key, value, why in _HARDENING:
         effective = profile.overrides.get(key, value)
-        lines.append(f"# {why}")
+        # 折行（#673）：加固表的理由已長到單行數百字元，`systemctl cat` 讀起來完全
+        # 失去可審查性——而「這一行為什麼在這裡」正是這份 root-owned 檔存在的理由。
+        # `_wrap_comment` 就是為此而寫的（見它的 docstring），這裡沿用同一支。
+        lines += _wrap_comment(why)
         if effective != value:
             lines += _wrap_comment(
                 f"※ 剖面覆寫（profile={profile.profile_id}）：嚴格剖面為 "

--- a/paulsha_cortex/trust_root/permgen.py
+++ b/paulsha_cortex/trust_root/permgen.py
@@ -5317,10 +5317,11 @@ def unit_replica_properties(
         # 下一步當成 specifier 展開成 `%<instance>`，而它的正確結果是字面 `%i`。
         # 這種錯法不會報錯，只會讓探針的加固面與 unit 悄悄不同——正是本票要根除的那類。
         sentinel = "\x00PCT\x00"
-        expanded = (
-            value.replace("%%", sentinel).replace("%i", instance).replace(sentinel, "%")
-        )
+        expanded = value.replace("%%", sentinel).replace("%i", instance)
+        # 未知 specifier 的檢查必須在**還原跳脫之前**：還原後的字面 `%i` 長得跟
+        # specifier 一模一樣，先還原會把合法的 `%%i` 誤判成展不開的 specifier。
         leftover = re.search(r"%[a-zA-Z]", expanded)
+        expanded = expanded.replace(sentinel, "%")
         if leftover is not None:
             raise UnitReplicaDriftError(
                 f"{key}= 的值含本函式展不開的 systemd specifier "

--- a/tests/test_trust_root_monitor_unit_622.py
+++ b/tests/test_trust_root_monitor_unit_622.py
@@ -108,6 +108,21 @@ def test_monitor_hardening_is_set_equal_to_manager(scheme) -> None:
     assert keys <= set(monitor)
 
 
+def _comment_block_above(lines: list[str], index: int) -> str:
+    """directive 上方那一段**連續**註解，去掉 `# ` 前綴與空白後接成一串。
+
+    `_wrap_comment` 會在任意 CJK 字元處斷行、並在斷於空白時吞掉那個空白，因此逐行
+    比對已不可行；去空白後接成一串再找子字串，是對折行**穩健**的比法。
+    """
+
+    collected: list[str] = []
+    cursor = index - 1
+    while cursor >= 0 and lines[cursor].startswith("#"):
+        collected.append(lines[cursor].lstrip("#").strip())
+        cursor -= 1
+    return "".join(reversed(collected)).replace(" ", "")
+
+
 @pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
 def test_monitor_unit_carries_every_hardening_directive_with_a_comment(scheme) -> None:
     """每項加固都要帶「為何」的註解——可審查性要求，與 Manager unit 同標準。"""
@@ -117,7 +132,10 @@ def test_monitor_unit_carries_every_hardening_directive_with_a_comment(scheme) -
         assert directive in lines, directive
         index = lines.index(directive)
         assert lines[index - 1].startswith("# "), directive
-        assert why.split("：")[0][:6] in lines[index - 1], directive
+        # #673：加固表的理由現在會折行（`_wrap_comment`，CJK 可在任意字元處斷），
+        # 因此比對的是 directive 上方**整段連續註解**，不是它正上方那一行。
+        block = _comment_block_above(lines, index)
+        assert why.split("：")[0][:6].replace(" ", "") in block, directive
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_trust_root_permgen_p2b.py
+++ b/tests/test_trust_root_permgen_p2b.py
@@ -246,6 +246,21 @@ def test_manager_unit_environment_file_is_fail_closed(scheme) -> None:
     assert "EnvironmentFile=-" not in unit.content
 
 
+def _comment_block_above(lines: list[str], index: int) -> str:
+    """directive 上方那一段**連續**註解，去掉 `# ` 前綴與空白後接成一串。
+
+    `_wrap_comment` 會在任意 CJK 字元處斷行、並在斷於空白時吞掉那個空白，因此逐行
+    比對已不可行；去空白後接成一串再找子字串，是對折行**穩健**的比法。
+    """
+
+    collected: list[str] = []
+    cursor = index - 1
+    while cursor >= 0 and lines[cursor].startswith("#"):
+        collected.append(lines[cursor].lstrip("#").strip())
+        cursor -= 1
+    return "".join(reversed(collected)).replace(" ", "")
+
+
 @pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
 def test_manager_unit_carries_every_hardening_directive_with_a_comment(scheme) -> None:
     """每一項加固都必須帶「為何」的註解——這是可審查性要求，不只是設定。"""
@@ -256,7 +271,10 @@ def test_manager_unit_carries_every_hardening_directive_with_a_comment(scheme) -
         assert directive in lines, directive
         index = lines.index(directive)
         assert lines[index - 1].startswith("# "), directive
-        assert why.split("：")[0][:6] in lines[index - 1], directive
+        # #673：加固表的理由現在會折行（`_wrap_comment`，CJK 可在任意字元處斷），
+        # 因此比對的是 directive 上方**整段連續註解**，不是它正上方那一行。
+        block = _comment_block_above(lines, index)
+        assert why.split("：")[0][:6].replace(" ", "") in block, directive
     for required in ("NoNewPrivileges=yes", "ProtectSystem=strict", "ProtectHome=yes",
                      "PrivateTmp=yes"):
         assert required in unit.content, required

--- a/tests/test_trust_root_syscall_profile_673.py
+++ b/tests/test_trust_root_syscall_profile_673.py
@@ -358,6 +358,18 @@ class UnitReplicaTests(unittest.TestCase):
                 "[Service]\nWorkingDirectory=/srv/%n\n", require_hardening=False
             )
 
+    def test_escaped_percent_is_not_mistaken_for_a_specifier(self) -> None:
+        """`%%i` 的正確結果是字面 `%i`，**不是** `%<instance>`。
+
+        錯了不會報錯，只會讓探針的加固面與 unit 悄悄不同——正是本票要根除的那類。
+        """
+
+        props = permgen.unit_replica_properties(
+            "[Service]\nEnvironment=FMT=%%i-%i\n",
+            instance="job-9", require_hardening=False,
+        )
+        self.assertEqual(props, ("--property=Environment=FMT=%i-job-9",))
+
     def test_all_eight_units_survive_a_round_trip(self) -> None:
         for name, content in _all_units().items():
             props = permgen.unit_replica_properties(content, instance="probe")

--- a/tests/test_trust_root_syscall_profile_673.py
+++ b/tests/test_trust_root_syscall_profile_673.py
@@ -1,0 +1,414 @@
+"""#673：seccomp 過濾**語意**是加固剖面之外的第二個維度，且加固面複本必須全量導出。
+
+本票開票時的診斷是「`SystemCallFilter=@system-service` 讓 codex／copilot rc=1，需要
+加 `@sandbox`」。實機量測推翻了它的每一步：
+
+* 被過濾的是 **`pkey_alloc`**（x86_64 syscall 330，systemd 歸在 `@pkey`），不是
+  `landlock_*`／`seccomp`（`@sandbox`）——kernel audit `type=1326 … syscall=330`
+  直接證據，全程沒有任何一筆 landlock 的 record。加 `@sandbox` 實測毫無作用。
+* 真 unit 上四支 executor **全部 rc=0**：同一份 unit 上的 `SystemCallErrorNumber=EPERM`
+  把「被過濾 ⇒ SIGSYS 殺行程」變成「被過濾 ⇒ 回 EPERM」，V8 走 fallback。
+* 本票的 repro 是一份**手抄的十 property 複本**，抄了 `SystemCallFilter=` 卻漏抄
+  `SystemCallErrorNumber=EPERM`——複本比 production **更嚴格**，於是量出一個
+  production 沒有的失敗。#638（單 UID 讓 ACL 斷言真空）、#657、本票是同一族事故的
+  第一、二、三次；本票的方向是**假紅**，前兩次是假綠。
+
+因此本檔守兩件事：
+
+1. **不放寬**：八份 unit 的 `SystemCallFilter=` 逐字是 `@system-service`，
+   `@sandbox`／`@pkey`／`pkey_alloc` 一個都不得出現。
+2. **承重的那一條不得被靜默拿掉**：`SystemCallErrorNumber` 是全部 node 型程式的存活
+   條件，它與 `SystemCallFilter` 同列 :data:`permgen.PROFILE_LOCKED_KEYS`，任何剖面
+   都不得分岔；`filtered_syscalls` 非空的程式其執行面若變成致命語意，permgen **import
+   時就炸**。第 5 節證明這道檢查不是空的。
+
+**OS 層語意（syscall 是否真的被擋、被擋時致不致命）在單 UID／無 systemd 的 CI 環境
+重現不了**——第 6 節以具名 skip ＋ 完整理由標示，不留假綠（#638／#657 的教訓、
+PR #671 的做法）。
+"""
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from paulsha_cortex.trust_root import permgen  # noqa: E402
+from paulsha_cortex.trust_root.permgen import Principal  # noqa: E402
+
+_REAL_SURFACE = bool(os.environ.get("PSC_TEST_REAL_HARDENING"))
+
+#: 實機量到的、被 `@system-service` 過濾掉的 syscall（#673）。
+_MEASURED_SYSCALL = "pkey_alloc"
+
+#: 本票推測、但實測**無效**的 systemd syscall 群。不得出現在任何 unit 上。
+_REJECTED_FILTER_TOKENS = ("@sandbox", "@pkey", "pkey_alloc", "landlock")
+
+
+def _service_directives(content: str) -> list[tuple[str, str]]:
+    """unit 內容 → `[Service]` 段的 (key, value) 序列（保留重複鍵）。"""
+
+    out: list[tuple[str, str]] = []
+    section = ""
+    for line in content.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if stripped.startswith("[") and stripped.endswith("]"):
+            section = stripped[1:-1]
+            continue
+        if section != "Service" or "=" not in stripped:
+            continue
+        key, _, value = stripped.partition("=")
+        out.append((key.strip(), value.strip()))
+    return out
+
+
+def _all_units() -> dict[str, str]:
+    """本 repo 產生的**全部八份** unit：6 份 job 模板 ＋ manager ＋ monitor。"""
+
+    scheme = permgen.SCHEMES["four-way"]
+    units = {
+        "manager": permgen.build_manager_unit(scheme).content,
+        "monitor": permgen.build_monitor_unit(scheme).content,
+    }
+    for principal in (Principal.BUILDER, Principal.REVIEWER, Principal.GATE):
+        for profile in permgen.HARDENING_PROFILES:
+            unit = permgen.build_job_unit(scheme, principal=principal, profile=profile)
+            units[unit.unit_name] = unit.content
+    return units
+
+
+# ---------------------------------------------------------------------------
+# 1. 不放寬：八份 unit 的 seccomp 白名單逐字不變
+# ---------------------------------------------------------------------------
+
+class NoWideningTests(unittest.TestCase):
+
+    def test_all_eight_units_exist(self) -> None:
+        """先確認樣本數就是八——少算一份，下面每一條都會漏驗它。"""
+
+        self.assertEqual(len(_all_units()), 8, sorted(_all_units()))
+
+    def test_every_unit_keeps_the_untouched_system_service_filter(self) -> None:
+        for name, content in _all_units().items():
+            values = [v for k, v in _service_directives(content)
+                      if k == "SystemCallFilter"]
+            self.assertEqual(values, ["@system-service"], name)
+
+    def test_no_unit_mentions_the_rejected_syscall_sets_as_a_filter_value(self) -> None:
+        """`@sandbox`／`@pkey`／`pkey_alloc` 都不得被放進過濾器。
+
+        它們可以出現在**註解**裡（#673 的量測結論就寫在那），但一旦出現在指令值上
+        就是無量測支撐的放寬。
+        """
+
+        for name, content in _all_units().items():
+            for key, value in _service_directives(content):
+                for token in _REJECTED_FILTER_TOKENS:
+                    self.assertNotIn(
+                        token, value,
+                        f"{name} 的 {key}= 值出現 {token}——#673 實機量到 @sandbox "
+                        "對症狀完全無效，而 @pkey／pkey_alloc 沒有必要（處置是"
+                        "非致命的過濾語意，不是放行 syscall）",
+                    )
+
+    def test_every_unit_carries_the_non_fatal_filter_semantics(self) -> None:
+        for name, content in _all_units().items():
+            table = dict(_service_directives(content))
+            self.assertEqual(table.get(permgen.SECCOMP_FATALITY_KEY), "EPERM", name)
+            self.assertFalse(permgen.seccomp_filter_is_fatal(table), name)
+
+
+# ---------------------------------------------------------------------------
+# 2. 剖面導出：哪個 executor → 哪個剖面 → 哪些 SystemCallFilter 值
+# ---------------------------------------------------------------------------
+
+class ProfileDerivationTests(unittest.TestCase):
+
+    def test_executor_to_profile_to_filter_values(self) -> None:
+        expected_profile = {
+            "codex": "jit", "copilot": "jit", "claude": "strict", "agy": "strict",
+        }
+        for executor, profile_id in expected_profile.items():
+            profile = permgen.executor_hardening_profile(executor)
+            self.assertEqual(profile.profile_id, profile_id, executor)
+            table = profile.effective()
+            # 剖面**不影響** seccomp 這兩項——這正是 #673 的重點：兩者正交。
+            self.assertEqual(table["SystemCallFilter"], "@system-service", executor)
+            self.assertEqual(table[permgen.SECCOMP_FATALITY_KEY], "EPERM", executor)
+
+    def test_profile_mapping_is_derived_not_a_second_roster(self) -> None:
+        """對應表由 `EXECUTOR_TOOLS` 機械導出，不是人工列出來的第二張表。"""
+
+        self.assertEqual(
+            dict(permgen.EXECUTOR_HARDENING_PROFILE),
+            {
+                tool.name: ("jit" if tool.needs_node else "strict")
+                for tool in permgen.EXECUTOR_TOOLS
+            },
+        )
+
+    def test_unknown_executor_still_fails_closed(self) -> None:
+        with self.assertRaises(permgen.UnknownExecutorProfileError):
+            permgen.executor_hardening_profile("gpt-9000")
+
+
+# ---------------------------------------------------------------------------
+# 3. 新維度的資料模型：filtered_syscalls 與它的機械導出
+# ---------------------------------------------------------------------------
+
+class FilteredSyscallSurfaceTests(unittest.TestCase):
+
+    def test_measured_programs_are_exactly_the_node_shaped_ones(self) -> None:
+        """`filtered_syscalls` 非空者 ＝ 有 audit record 背書的那四支。
+
+        它今天與 `needs_node` 同集合（成因同樣是 V8），但**是分開量、分開存的**：
+        兩者的處置方向相反（換剖面 vs. 鎖定過濾語意），適用面也不同（本欄位涵蓋
+        跑在 Manager unit 上、根本沒有剖面的 `openspec`）。
+        """
+
+        measured = {
+            tool.name for tool in permgen.TOOLCHAIN_PROGRAMS if tool.filtered_syscalls
+        }
+        self.assertEqual(measured, {"codex", "copilot", "srt", "openspec"})
+        for tool in permgen.TOOLCHAIN_PROGRAMS:
+            if tool.filtered_syscalls:
+                self.assertEqual(tool.filtered_syscalls, (_MEASURED_SYSCALL,), tool.name)
+
+    def test_native_elf_executors_have_no_measured_filtered_syscall(self) -> None:
+        for name in ("claude", "agy"):
+            tool = next(t for t in permgen.EXECUTOR_TOOLS if t.name == name)
+            self.assertEqual(tool.filtered_syscalls, (), name)
+
+    def test_surfaces_cover_executors_and_the_manager_surface(self) -> None:
+        surfaces = {
+            (item.program, item.surface) for item in permgen.filtered_syscall_surfaces()
+        }
+        self.assertEqual(
+            surfaces,
+            {
+                ("codex", "codex"),          # executor ⇒ 自己的剖面
+                ("copilot", "copilot"),
+                ("srt", "claude"),           # 非 executor ⇒ 消費者的剖面
+                ("openspec", permgen.MANAGER_SURFACE),  # ⇒ Manager unit（沒有剖面）
+            },
+        )
+
+    def test_no_surface_is_fatal(self) -> None:
+        for item in permgen.filtered_syscall_surfaces():
+            self.assertFalse(item.fatal, f"{item.program} @ {item.detail}")
+
+
+# ---------------------------------------------------------------------------
+# 4. 鎖定鍵：任何剖面都不得分岔 seccomp 白名單與它的過濾語意
+# ---------------------------------------------------------------------------
+
+class LockedKeyTests(unittest.TestCase):
+
+    def test_locked_and_divergence_keys_are_disjoint(self) -> None:
+        self.assertEqual(
+            permgen.PROFILE_LOCKED_KEYS & permgen.PROFILE_DIVERGENCE_KEYS, frozenset()
+        )
+
+    def test_locked_keys_exist_in_the_hardening_table(self) -> None:
+        known = {key for key, _v, _w in permgen._HARDENING}
+        self.assertLessEqual(permgen.PROFILE_LOCKED_KEYS, known)
+
+    def test_locked_keys_are_the_seccomp_pair(self) -> None:
+        self.assertEqual(
+            permgen.PROFILE_LOCKED_KEYS,
+            frozenset({"SystemCallFilter", permgen.SECCOMP_FATALITY_KEY}),
+        )
+
+    def test_no_profile_overrides_a_locked_key(self) -> None:
+        for profile in permgen.HARDENING_PROFILES:
+            self.assertEqual(
+                set(profile.overrides) & permgen.PROFILE_LOCKED_KEYS, set(), profile.profile_id
+            )
+
+    def test_seccomp_fatality_semantics(self) -> None:
+        """systemd 語意：未設／空值 ⇒ SIGSYS 殺行程；設 errno ⇒ 回錯誤碼續跑。"""
+
+        self.assertTrue(permgen.seccomp_filter_is_fatal({}))
+        self.assertTrue(permgen.seccomp_filter_is_fatal(
+            {permgen.SECCOMP_FATALITY_KEY: ""}))
+        self.assertTrue(permgen.seccomp_filter_is_fatal(
+            {permgen.SECCOMP_FATALITY_KEY: "   "}))
+        self.assertFalse(permgen.seccomp_filter_is_fatal(
+            {permgen.SECCOMP_FATALITY_KEY: "EPERM"}))
+
+
+# ---------------------------------------------------------------------------
+# 5. 這道檢查不是空的——把加固表改成致命語意，import 時的驗證必須炸
+# ---------------------------------------------------------------------------
+
+class ToleranceGuardIsNotVacuousTests(unittest.TestCase):
+    """守衛測試：證明第 3／4 節的綠是**有人在守**，不是恰好成立。
+
+    `_validate_seccomp_tolerance()` 平時只在 import 時跑一次，因此若哪天有人把
+    `SystemCallErrorNumber` 刪掉，唯一會叫的就是它——本節確認它真的會叫。
+    """
+
+    def _with_hardening(self, table: tuple[tuple[str, str, str], ...]):
+        original = permgen._HARDENING
+        permgen._HARDENING = table
+        self.addCleanup(lambda: setattr(permgen, "_HARDENING", original))
+
+    def test_removing_the_error_number_trips_the_import_time_check(self) -> None:
+        """整行刪掉 ⇒ 撞「鎖定鍵必須存在於加固表」那一關（更早、訊息更直接）。"""
+
+        self._with_hardening(tuple(
+            row for row in permgen._HARDENING
+            if row[0] != permgen.SECCOMP_FATALITY_KEY
+        ))
+        with self.assertRaises(ValueError) as caught:
+            permgen._validate_seccomp_tolerance()
+        self.assertIn(permgen.SECCOMP_FATALITY_KEY, str(caught.exception))
+
+    def test_blanking_the_error_number_trips_the_tolerance_check(self) -> None:
+        """把值清空（＝systemd 的致命語意）⇒ 撞 #673 的容忍度不變式。
+
+        這是更危險的改法：鍵還在、diff 看起來只是「移除一個放寬」，但 codex／
+        copilot／srt／openspec 會在**全部**執行面上同時靜默死。
+        """
+
+        self._with_hardening(tuple(
+            (key, "" if key == permgen.SECCOMP_FATALITY_KEY else value, why)
+            for key, value, why in permgen._HARDENING
+        ))
+        with self.assertRaises(ValueError) as caught:
+            permgen._validate_seccomp_tolerance()
+        message = str(caught.exception)
+        # 錯誤訊息必須把處置講清楚，否則下一個人會「順手把 syscall 加進白名單」。
+        self.assertIn("#673", message)
+        self.assertIn(permgen.SECCOMP_FATALITY_KEY, message)
+        self.assertIn("openspec", message)   # Manager 面也必須被涵蓋
+        self.assertIn("codex", message)
+
+    def test_the_real_table_passes(self) -> None:
+        permgen._validate_seccomp_tolerance()   # 不得拋
+
+
+# ---------------------------------------------------------------------------
+# 6. 加固面複本：從**已落檔的 unit** 全量導出（本票真正的修法）
+# ---------------------------------------------------------------------------
+
+class UnitReplicaTests(unittest.TestCase):
+    """runbook 與本檔共用 `unit_replica_properties()`——加固面只有一份定義。"""
+
+    def setUp(self) -> None:
+        self.scheme = permgen.SCHEMES["four-way"]
+        self.unit = permgen.build_job_unit(
+            self.scheme, principal=Principal.REVIEWER,
+            profile=permgen.HARDENING_PROFILES_BY_ID["jit"],
+        )
+
+    def test_replica_contains_every_hardening_key(self) -> None:
+        props = permgen.unit_replica_properties(self.unit.content, instance="probe")
+        got = {prop.split("=", 2)[1] for prop in props}
+        for key, _value, _why in permgen._HARDENING:
+            self.assertIn(key, got, key)
+
+    def test_replica_carries_the_account_env_and_writable_face(self) -> None:
+        """手抄子集漏的正是這幾類——它們同樣是「加固面」的一部分。"""
+
+        props = permgen.unit_replica_properties(self.unit.content, instance="probe")
+        joined = "\n".join(props)
+        account = self.scheme.resolve(Principal.REVIEWER)
+        self.assertIn(f"--property=User={account}", props)
+        self.assertIn(f"--property=Group={account}", props)
+        self.assertIn("--property=WorkingDirectory=", joined)
+        self.assertIn("--property=Environment=HOME=", joined)
+        for rwp in self.unit.read_write_paths:
+            self.assertIn(f"--property=ReadWritePaths={rwp}", props)
+
+    def test_replica_drops_only_the_execution_face(self) -> None:
+        props = permgen.unit_replica_properties(self.unit.content, instance="probe")
+        keys = {prop.split("=", 2)[1] for prop in props}
+        self.assertEqual(keys & permgen.UNIT_REPLICA_EXCLUDED_KEYS, set())
+        # 排除表擋掉的必須真的是那幾項，而不是「剛好 unit 裡沒有」。
+        directive_keys = {key for key, _v in _service_directives(self.unit.content)}
+        self.assertIn("ExecStart", directive_keys)
+        self.assertNotIn("ExecStart", keys)
+
+    def test_instance_specifier_is_expanded(self) -> None:
+        builder = permgen.build_job_unit(self.scheme, principal=Principal.BUILDER)
+        props = permgen.unit_replica_properties(builder.content, instance="job-77")
+        joined = "\n".join(props)
+        self.assertNotIn("%i", joined)
+        self.assertIn("job-77", joined)
+
+    def test_incomplete_unit_is_refused_rather_than_silently_weakened(self) -> None:
+        """**本票的核心修法**：複本比 production 弱時**不產出**，而不是產出半套。"""
+
+        crippled = "\n".join(
+            line for line in self.unit.content.splitlines()
+            if not line.startswith(f"{permgen.SECCOMP_FATALITY_KEY}=")
+        )
+        with self.assertRaises(permgen.UnitReplicaDriftError) as caught:
+            permgen.unit_replica_properties(crippled)
+        self.assertIn(permgen.SECCOMP_FATALITY_KEY, str(caught.exception))
+
+    def test_unknown_specifier_is_refused(self) -> None:
+        with self.assertRaises(permgen.UnitReplicaDriftError):
+            permgen.unit_replica_properties(
+                "[Service]\nWorkingDirectory=/srv/%n\n", require_hardening=False
+            )
+
+    def test_all_eight_units_survive_a_round_trip(self) -> None:
+        for name, content in _all_units().items():
+            props = permgen.unit_replica_properties(content, instance="probe")
+            self.assertGreaterEqual(len(props), 30, name)
+            self.assertIn("--property=SystemCallFilter=@system-service", props, name)
+            self.assertIn(
+                f"--property={permgen.SECCOMP_FATALITY_KEY}=EPERM", props, name
+            )
+
+
+# ---------------------------------------------------------------------------
+# 7. 明確測不到的 OS 層語意（#638／#657 的教訓：不留假綠）
+# ---------------------------------------------------------------------------
+
+class RealSeccompSurfaceTests(unittest.TestCase):
+    """seccomp 的**執行期**語意在本 repo 的 CI 環境重現不了，一律具名 skip。
+
+    需要的條件：root ＋ system-level systemd（能起 transient unit 並套 seccomp）＋
+    四個真帳號 ＋ 已落檔的八份 unit ＋ 已裝的 toolchain ＋ 讀得到 kernel audit
+    （`type=1326`）。CI 容器是單 UID、無 systemd，`sudo -u` 或裸跑都套不上 seccomp
+    ——在那裡跑這幾條會**永遠綠**，而那個綠恰恰是 #673 誤判的成因（弱化環境下的
+    結論被當成 production 的結論）。
+
+    真實驗證在 runbook 第 5-2b 步（全矩陣 ＋ 負向 ＋ 反向對照）；具備條件的機器可設
+    `PSC_TEST_REAL_HARDENING=1` 啟用。
+    """
+
+    def setUp(self) -> None:
+        if not _REAL_SURFACE:
+            self.skipTest(
+                "需要 root ＋ systemd ＋ 已落檔的八份 unit ＋ 已裝的 toolchain ＋ "
+                "kernel audit；CI 是單 UID／無 systemd，套不上 seccomp，"
+                "跑出來的綠不代表任何事。真實驗證見 runbook 第 5-2b 步"
+                "（PSC_TEST_REAL_HARDENING=1 可在具備條件的機器上啟用）。"
+            )
+
+    def test_pkey_alloc_is_filtered_but_non_fatal(self) -> None:
+        self.skipTest(
+            "「`@system-service` 是否真的擋掉 `pkey_alloc`」只能由 kernel 回答："
+            "需要在真 unit 下拿掉 `SystemCallErrorNumber` 觸發 SIGSYS，再從 "
+            "`dmesg` 讀 `type=1326 … syscall=330` 的 audit record。無 systemd 的 "
+            "CI 既套不上過濾器，也讀不到 audit。#673 已在實機完成並記錄於該 issue。"
+        )
+
+    def test_all_executors_run_under_their_own_profile(self) -> None:
+        self.skipTest(
+            "executor × 剖面的全矩陣（含 `claude`／`agy` 在 jit 剖面下仍 rc=0 的**反向**"
+            "對照）需要真實 UID、真實 ACL 與已落檔的 unit。runbook 第 5-2b 步 (1) 是"
+            "唯一能承載該宣稱的地方；在弱化環境取得的 rc=0 不足以支撐它。"
+        )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
Closes #673

## TL;DR — 量測推翻了本票的診斷，production 沒有壞；真正的缺陷在驗證方法

#673 的診斷是「`SystemCallFilter=@system-service` 讓 `codex`／`copilot` 在全部八份 unit 下
rc=1，需要放行 `@sandbox`（`landlock_*`／`seccomp`）」。實機逐條量完，**這條推論的每一步
都不成立**（完整量測見 [#673 的 comment](https://github.com/hamanpaul/paulsha-cortex/issues/673#issuecomment-5322323474)）：

| 本票命題 | 實機結果 |
|---|---|
| 被過濾的是 `@sandbox` 那四支 | **否**。是 **`pkey_alloc`**（x86_64 syscall 330，systemd 歸在 `@pkey`）。kernel audit `type=1326 … comm="node" sig=31 syscall=330 code=0x80000000` 直接證據；全程**沒有任何一筆** `landlock_*`（444–446）或 `seccomp`（317）的 record |
| 加 `@sandbox` 可以修好 | **否**。致命語意下加了 `@sandbox`，`codex`／`copilot` 照樣 rc=1、輸出全空 |
| 真 unit 上 codex／copilot 是壞的 | **否**。以**完整 37 條** property 複製 `cortex-reviewer-job-jit@.service`（＝它們實際跑的剖面），四支 executor **全部 rc=0** |
| `DEFAULT_EXECUTOR = "copilot"` ⇒ 預設派工路徑靜默壞掉 | **否**，同上。該疑慮撤銷 |

`@system-service` 確實不含 `pkey_alloc`（V8 啟動會叫它），但**同一份 unit 上的
`SystemCallErrorNumber=EPERM`** 把「被過濾 ⇒ `SECCOMP_RET_KILL_PROCESS`」變成「被過濾 ⇒
回 `EPERM`」，V8 走 fallback。那一行從 permgen 的**第一個** commit（`e652606`）就在加固表
裡，八份 unit 全部都有；本票開票時磁碟上的 unit 也已經帶著它。

**本票的 repro 是一份手抄的十 property 複本**——抄了 `SystemCallFilter=` 卻漏抄
`SystemCallErrorNumber=EPERM`，於是複本落回 systemd 預設的致命語意、**比 production 更
嚴格**，量出一個 production 沒有的 rc=1。逐字重現該複本可得本票矩陣；**只**補上那一條，
四支立刻全綠：

```
# 本票的十條（含 SystemCallFilter，不含 SystemCallErrorNumber）
claude rc=0   codex rc=1 空   copilot rc=1 空   agy rc=0     ← 逐字重現本票矩陣
# 同一份複本，只補第 21 條 SystemCallErrorNumber=EPERM
claude rc=0   codex rc=0      copilot rc=0      agy rc=0     ← 差別只有這一條
```

#638（單 UID 讓 ACL 斷言真空）、#657、本票是同一族事故的第一、二、三次。
**本票的方向是假紅，前兩次是假綠——手抄子集的錯法不由人選。**

## 最小必要 syscall 集合（第一步的量測要求）

在**致命**語意下（刻意拿掉 `SystemCallErrorNumber` 把失敗放大成可見），其餘 36 條照
jit unit 完整回填，只變動 `SystemCallFilter`：

| `SystemCallFilter=` | codex | copilot | claude | agy |
|---|---|---|---|---|
| `@system-service`（現行） | rc=1 空 | rc=1 空 | rc=0 | rc=0 |
| `@system-service @sandbox`（本票推測） | **rc=1 空** | **rc=1 空** | rc=0 | rc=0 |
| `@system-service @pkey` | rc=0 | rc=0 | rc=0 | rc=0 |
| `@system-service pkey_alloc`（單一具名） | **rc=0** | **rc=0** | rc=0 | rc=0 |

**最小必要集合＝單一具名 syscall `pkey_alloc`**，連 `@pkey` 整群都不必。
`claude`／`agy` 在四種剖面下全部 rc=0（第 4 問）。

## 因此**沒有放寬任何 syscall**

`SystemCallFilter=@system-service` 在八份 unit 上**逐字不動**。沿用 #643 的先例「量到才改，
改的是一份具名剖面，不是全域放寬」——而這次量到的結論是**不用改**。放行 `pkey_alloc` 是
**放寬過濾器**（多一支 syscall 可用）且沒有量測支撐；`SystemCallErrorNumber=EPERM`
**不放行任何 syscall**，被擋的照樣擋，只是回錯誤碼而非殺行程。兩者不是同一件事。

## Manager unit 要不要一起放寬？**不要——而且這次連「放寬」這個選項都不存在**

票上要求把判斷寫進 PR body 而非靜默決定，所以即使結論是「什麼都不放寬」也記在這裡：

1. **本票沒有任何一項放寬，因此 Manager 的放寬問題在本票不成立。** 八份 unit 的
   `SystemCallFilter=` 逐字相同、逐字不變。
2. **即使將來要放寬，Manager 也不該一起。** 放寬 Manager 的 syscall 面等於在 OS 層承認
   「Manager 該跑模型 CLI」。Manager 是**唯一持 spawn 授權**的帳號，四分隔離的整個論述
   建立在「injection 可達的進程皆無 spawn 授權」上；為了讓模型 CLI 在 Manager 行程內跑得
   更順而擴大它的 syscall 面，是把 #672 的缺陷**固化進加固剖面**。#672 的正確方向是把
   模型 CLI 移出 Manager，不是讓 Manager 更適合跑它們。
3. **Manager 面上 node 的存活條件已經滿足，且是被機械檢查釘住的。** `openspec` 跑在
   Manager unit 上，本 PR 的 `filtered_syscall_surfaces()` 把這一格納入 import 時的強制
   檢查——Manager 的 `SystemCallErrorNumber` 若被改成致命語意，permgen 直接炸。**這是
   加固而非放寬**：它讓 Manager 面的存活條件變成不可靜默移除的，同時完全沒有擴大它能叫的
   syscall。
4. 附帶（**本 PR 不修**）：`openspec` 在 Manager 面下仍然失敗，原因是 `MemoryDenyWriteExecute`
   而非 seccomp（stderr 是 V8 的 `Runtime_CompileLazy`）。這是 #661 的未決點，本 PR 只把
   它的量測方法修正並在 runbook 上記清楚，**不順手放寬 Manager 的 MDWE**。

## 剖面機制：新增一個與剖面**正交**的維度（而不是塞進 `needs_node`）

票上要求剖面判準要能表達新維度、且不得硬塞進 `needs_node`。量測顯示這個維度的**適用面
比剖面大**，因此它本來就不該住在剖面裡：

- **`ToolchainProgram.filtered_syscalls`**（新欄位，登記表上多一格）：該程式在
  `@system-service` 下**實機量到**會撞上的被過濾 syscall。`codex`／`copilot`／`srt`／
  `openspec` 各填 `("pkey_alloc",)`，每一列都有 audit record 背書，不填形態推論。
- **為何不共用 `needs_node`**：(i) `needs_node` 導向「換一份放寬 MDWE 的**剖面**」，本維度
  導向「一個**所有剖面都不得分岔**的鎖定鍵」——處置方向相反；(ii) 剖面只覆蓋
  `EXECUTOR_TOOLS`，而 `openspec` 是 `SERVICE_TOOLS`、跑在 **Manager unit** 上，那一格
  根本沒有剖面，綁在剖面上會整個漏掉它；(iii) 證據等級不同（audit record vs. 形態推論）。
- **`SECCOMP_FATALITY_KEY` ／ `PROFILE_LOCKED_KEYS`**：`SystemCallFilter` 與
  `SystemCallErrorNumber` 列為任何剖面都不得分岔的鎖定鍵，與 `PROFILE_DIVERGENCE_KEYS`
  恆為互斥（import 時強制）。想分岔其中任一項，必須先把它從鎖定表拿掉——那是一個看得見的 diff。
- **機械導出，不是人工表**：`filtered_syscall_surfaces()` 由 `TOOLCHAIN_PROGRAMS` 導出
  （executor 走自己的剖面、非 executor 走 `consumed_by` 指到的消費者面），沿用
  `EXECUTOR_HARDENING_PROFILE`／`node_execution_surfaces()` 既有做法，未登記 `consumed_by`
  的 fail-closed。
- **`_validate_seccomp_tolerance()`**：import 時強制——任何 `filtered_syscalls` 非空的程式，
  其執行面若是致命語意，permgen **直接炸**，錯誤訊息並點明處置是設 errno、**不是**把
  syscall 加進白名單（避免下一個人「順手放寬」）。

這解決的是一個真實的埋伏：`SystemCallErrorNumber=EPERM` 在此之前的理由只寫「失敗可觀測」，
任何人為了「更 fail-closed」把它刪掉或清空，四支 node 型程式會在**全部**執行面上同時靜默死，
而 diff 看起來只是「移除一個放寬」。

## 驗證方法（票上說比第二步更重要——這是本 PR 的主體）

- **`permgen.unit_replica_properties()`** ＋ CLI **`trust_root unit-replica <unit|->`**：把一份
  **已落檔**的 unit 讀成 `systemd-run --property=` 的**完整**清單。契約是**「全帶，不選」**
  ——`[Service]` 段除執行面指令（`ExecStart=` 之類）外全部帶出，含 `User=`／`Group=`／
  `WorkingDirectory=`／`Environment=`／`ReadWritePaths=`。日後往加固表加一項，runbook 不必
  改也不會漏，這正是它與 grep 白名單的差別。
- **fail-closed**：落檔的 unit 少任一加固鍵 ⇒ `UnitReplicaDriftError`，**stdout 保持空**
  （被 `$(...)`／`mapfile` 展開時不會產生半套清單）。展不開的 systemd specifier 同樣拒絕。
- **讀磁碟那一份**（`systemctl cat`，含 drop-in），不是產生器展開的——兩者會漂移，而漂移
  正是要被驗出來的東西（runbook 自己就記著「產生器修好 ≠ 已落檔的 unit 跟著更新」）。
  既有的 `transient_unit_properties()` 回答的是另一個命題（產生器現在會產出什麼），保留不動。
- **runbook**：新增 4e「共用探針 `psc_run_under`」一節，之後每一條「在真實加固面下」的驗證
  都走它。原本 4e 的三條、5-3 的 `pytest`、5-4 的 `gh` 各自手抄**四條** property；5-2b 稍好
  但是一份**手維護的 27 鍵 grep 白名單**，且不含 `ReadWritePaths=`／`WorkingDirectory=`／
  per-account `Environment=`。全部改為機械導出。
- **5-2b 由「正向四段」改為全矩陣**（票上要求的反向驗證）：4 executor × 2 剖面 × 2 角色 unit
  逐格實跑並比對版本字串，含**反向對照**——`claude`／`agy` 在 jit 剖面下仍須 rc=0（放寬剖面
  若弄壞原本好的兩支，這是唯一看得見的地方）。**通過條件表一併更正措辭**：該宣稱現在明示是
  在「`unit-replica` 全量導出的加固面下」取得的。
- **負向那兩格新增「失敗原因要對得上」**：strict 剖面下 `codex` 的 stderr 必須是 V8 的
  `Check failed: 12 == (*__errno_location ())` ／ `Runtime_CompileLazy`。**stderr 空是另一
  回事**——那是複本漏了 `SystemCallErrorNumber=EPERM` 的指紋，也就是本票誤判的成因。
  runbook 明寫：看到空 stderr 先回去查複本，不要開票說 executor 壞了。

### 兩個「弱複本從來看不到、全量複本立刻撞到」的實例（都已寫進 runbook）

1. `ReadWritePaths=…/%i` 的目標不存在時，systemd 在 exec **之前**就失敗 ⇒ rc=226
   （`EXIT_NAMESPACE`）、輸出全空，症狀與「CLI 起不來」一模一樣。四 property 複本連
   `ReadWritePaths` 都沒有，所以從來不會因此失敗，也就從來沒驗到它。
2. `PrivateTmp=yes` 讓 `/tmp/psc-gate-probe` 在 unit 內根本不存在——5-3 的 `pytest` 探針
   原本就放在 `/tmp`，在完整加固面下必定 rc=226。已改放進 gate 自己登記表上的可寫面。

## 實機驗收（全部在本機 systemd 255 ＋ 四個真帳號 ＋ 已落檔的八份 unit 上跑過）

新的 runbook 程序端到端跑通，4 executor × 2 剖面 × 2 角色 unit：

```
cortex-job                 claude   rc=0   [2.1.233 (Claude Code)]
cortex-job                 agy      rc=0   [1.1.13]
cortex-job                 codex    rc=1   []            ← 負向：MDWE（stderr 有 V8 stack）
cortex-job                 copilot  rc=1   []            ← 負向
cortex-job-jit             claude   rc=0   [2.1.233 …]   ← 反向對照：放寬剖面沒弄壞它
cortex-job-jit             agy      rc=0   [1.1.13]      ← 反向對照
cortex-job-jit             codex    rc=0   [codex-cli 0.147.0]
cortex-job-jit             copilot  rc=0   [0.0.330]
（cortex-reviewer-job / cortex-reviewer-job-jit 八格逐格相同）
```

另：`gh auth status` 在完整 45 條 Manager 複本下 rc=0；`pytest -q` 在完整 38 條 gate 複本下
`1 passed`；`codex debug models`／`copilot --help`／`openspec`／`srt` 在 jit 完整面下皆 rc=0。

## 測試

新增 `tests/test_trust_root_syscall_profile_673.py`（26 測試 ＋ 2 具名 skip）：

- 八份 unit 的 `SystemCallFilter` 逐字比對，且 `@sandbox`／`@pkey`／`pkey_alloc`／`landlock`
  **不得出現在任何指令值上**（可以出現在註解裡——量測結論就寫在那）。
- 剖面導出：executor → 剖面 → `SystemCallFilter` 值；對應表由 `EXECUTOR_TOOLS` 機械導出；
  未知 executor 仍 fail-closed。
- `filtered_syscalls` 的機械導出涵蓋 Manager 面（`openspec`）與消費者面（`srt` ⇒ `claude`）。
- 鎖定鍵不變式；`unit_replica_properties` 的八份 unit round-trip、`%i` 展開、排除表只擋執行面、
  漂移拒絕。
- **守衛測試（不可省）**：把加固表的 `SystemCallErrorNumber` 清空後
  `_validate_seccomp_tolerance()` **必須拋**，訊息要同時點名 `codex` 與 `openspec`——否則
  上面那些綠只是恰好成立。

**OS 層語意具名 skip ＋ 完整理由**（#638／#657 的教訓、PR #671 的做法）：「`@system-service`
是否真的擋掉 `pkey_alloc`」需要 kernel audit，「executor × 剖面全矩陣」需要真 UID ＋ 真 ACL
＋ 已落檔的 unit。CI 是單 UID／無 systemd，套不上 seccomp，在那裡跑會**永遠綠**——而那個綠
恰恰是本票誤判的成因。具備條件的機器可設 `PSC_TEST_REAL_HARDENING=1`。

全套 `pytest tests/`：**4189 passed、23 skipped**。

## 附帶：加固表註解改走既有的 `_wrap_comment`

`_wrap_comment` 的 docstring 早就寫著「數百字元的單行註解會讓 `systemctl cat` 完全失去
可審查性」，但 `_hardening_lines` 一直是 `f"# {why}"` 直出。本 PR 往 `SystemCallFilter=`／
`SystemCallErrorNumber=` 兩項補上「為何承重」之後，那兩行各自長到 200+ 字元——而
「這一行為什麼在這裡」正是這份 root-owned 檔存在的理由，讀不了等於沒有。

**指令值一字未改**，純粹是 unit 的呈現（八份 unit 的 diff 因此看起來比實際大）。
`manager`／`monitor` 的「每項加固都要帶註解」兩個既有測試改為比對 directive 上方
**整段連續註解**——比原本的「正上方那一行」更強，也對折行穩健。

## 部署注意

`_HARDENING` 只改了 `SystemCallFilter=` 與 `SystemCallErrorNumber=` 兩行的**註解**，指令值
一字未改。已落檔的八份 unit 因此**語意上完全不需要重落**；merge 後依 runbook 重跑產生器落檔
即可讓註解（＝「這一行為什麼承重」的說明）跟上，不需要 `systemctl daemon-reload` 以外的動作。

## Checklist

- [x] 分支 `feature/673-syscall-sandbox-profile`，未 commit 到 `main`
- [x] `changelog.d/673-syscall-sandbox-profile.md` 已新增且已 commit
- [x] `CHANGELOG.md [Unreleased]` 已補對應 entry
- [x] `VERSION` 未動（非 release PR）
- [x] 全套測試通過（4189 passed / 23 skipped）
- [x] 新增測試涵蓋剖面導出、unit 內容比對、複本導出；OS 層語意具名 skip 並附完整理由
- [x] 實機在真實加固面下複驗（本 PR 的每一個數字都有實跑）
- [x] 本機 `policy_check` 帶 PR 上下文跑
