### PR TITLE
docs(r3): testpilot case 素材盤點——四路盲測 sweep 合成 102 筆去重候選（#667）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,25 @@
 ## [Unreleased]
 
 ### Added
+- **#667：R3 testpilot case 素材盤點——四路盲測 sweep 合成為 102 筆去重候選清單**——
+  `docs/superpowers/workstreams/r3-testpilot-case-corpus/{todo.md,case-candidates.md}`。
+  **唯一產出是文件**：不寫 case yaml、不建 harness、不動 `paulsha_cortex/`（`#667` scope
+  fence）。四路（症狀家族／子系統／生命週期階段／artifact 型別）互相盲測共 **155 個原始
+  條目**，以「真實事件」為單位跨軸去重後 **102 筆**；`hit_by` 分佈為四路 **1**、三路 **9**、
+  二路 **31**、單路 **61**。**單路命中全數保留**——artifact 路的 24 筆純實測發現沒有對應
+  issue，掃 issue 的三路在結構上不可能命中。排序依「**可以最早開始長**」而非 `hit_by` 數量
+  （分 T1–T6 六個 tier）：第 1 名是單路命中、零 harness 前置、oracle 為集合相等的 `#490`；
+  唯一四路命中的 `#501` 排第 59，因為它需要 tick 推進與**可控的 review-launch 失敗**
+  （issue 明言 happy path 會遮蔽該缺陷，只跑快樂路徑必然是一條永遠綠的假 case）。文件保留
+  三個橫向發現：**oracle 品質分級**（差分／集合相等型無法靠放寬任一邊滿足，結構上擋得住
+  fail-open；閾值型與存在性型容易被放寬成空過，每筆均標注型別）、**既有陷阱必須進
+  `harness_needs` 並強制拆 tier**（多 UID／root／`direct` 模式／缺 `acl` 時**標
+  `unsupported`，不得標 `pass`**；且「手抄 property 子集 ＝ 驗證無效」已有四個實例，
+  `#638`／`#657`／`#673` 原 body 為假綠、`#673` 的 repro 為**假紅**）、**define 八環串聯
+  攻關鏈應整組存在**不得拆為八個獨立 case。另含 **`evidence-insufficient` 32 筆**（四路原始
+  41 筆去重，每筆保留「缺什麼證據才能判定」；3 筆與候選重疊者為四路真實判斷分歧，兩邊皆
+  保留）與**四格覆蓋缺口**（08-12 波 6 張未深讀；**ship／delivery 零條語意候選是覆蓋度與
+  風險落差最大的一格**；porcelain 分不出穩定與繞過；deck-combo 自動選型零事故）。
 - **#673：seccomp 過濾**語意**是加固剖面之外的第二個維度，且它是**承重**的**——
   `@system-service` 確實過濾掉 V8 啟動時要用的 `pkey_alloc`（x86_64 330，systemd 歸在
   `@pkey`；**不是** `@sandbox` 的 `landlock_*`／`seccomp`，kernel audit `type=1326 …

--- a/changelog.d/667-r3-case-corpus.md
+++ b/changelog.d/667-r3-case-corpus.md
@@ -1,0 +1,47 @@
+# 667-r3-case-corpus
+
+### Added
+- **R3 testpilot case 素材盤點（`#667`）——四路盲測 sweep 合成為 102 筆去重候選清單**
+  ——`docs/superpowers/workstreams/r3-testpilot-case-corpus/` 新增 `todo.md` 與
+  `case-candidates.md` 兩份文件。**唯一產出是文件**：不寫任何 case yaml、不建 mock
+  provider／tick harness、不動 `paulsha_cortex/` 下任何程式（`#667` scope fence）。
+  - **四路互相盲測**（症狀家族／子系統／生命週期階段／artifact 型別，執行期間彼此不看對方的
+    發現）共產出 **155 個原始條目**（37／49／37／32），跨軸以「真實事件」為單位去重後
+    **102 筆**。`hit_by` 分佈：四路命中 **1**、三路 **9**、二路 **31**、單路 **61**。
+    **61 筆單路命中全數保留並標示**——artifact 路的 24 筆純實測發現（0-byte evidence、
+    雜湊方案不一致、log 截斷、run journal 與正典 manifest 對不上…）**沒有對應 issue，
+    掃 issue 的三路在結構上不可能命中**。
+  - **排序依「可以最早開始長」而非 `hit_by` 數量**，分 T1–T6 六個 tier（純函式／fs 佈置／
+    tick 與真實 git／crash 注入／多 UID 殘量／期望值待定）。第 1 名是單路命中的 `#490`
+    （review 與 tick 的 identity 集合必須相等），唯一的四路命中 `#501` 排第 59——因為前者
+    零 harness 前置而後者需要 tick 推進與可控的 review-launch 失敗。
+  - **oracle 品質分級**：每筆標注 oracle 型別。最高等級是**差分／集合相等**型
+    （`#490` identity 集合、`#509` doctor 與 tick 同源、`#383` tick 與 fanout dispatch 集合、
+    `#486` prompt severity enum、`#420` 兩條 claim 入口到達同一 phase）——共同性質是
+    **無法靠放寬任一邊來滿足**，結構上擋得住 fail-open；閾值型與存在性型則容易被放寬成空過。
+  - **既有陷阱寫進 `harness_needs` 並強制拆 tier**：多條 trust-root case 的原 issue 逐字
+    記錄了「上次是怎麼被繞過去的」（`#657`「測試環境是單 UID，spool 的 ACL 不影響任何事」、
+    `#645`「我在手工組時自己挑了一個與 instance 名相符的 worktree 路徑——等於把這個 bug
+    繞過去了」、`#638`「per-job 的正常流程沒有任何一條測試涵蓋」、`#478`「existing recovery
+    test uses a normal temporary directory rather than a real Git worktree」）。文件層級訂五條
+    硬規則，其中兩條為本次新增的具名約束：**多 UID／root／`direct` 模式／缺 `acl` 時必須標
+    `unsupported`，不得標 `pass`，也不得 skip 成綠**；以及**手抄 property 子集 ＝ 驗證無效，
+    且兩個方向都會錯**——後者現有四個實例，`#638`／`#657`／`#673` 原 body 是假綠，
+    而 `#673` 的 repro（漏抄 `SystemCallErrorNumber=EPERM`，比 production 更嚴格）是**假紅**。
+  - **define 八環串聯攻關鏈**（`#391`→`#393`→`#397`→`#399`→`#401`→`#404`→`#406`→`#408`，
+    每修一環露下一環、每環確定性、每環燒一個世代）明載為**應整組存在的 case 套件**，
+    不得拆成八個獨立 case——tier 是動工成本，不是拆包單位。
+  - **`evidence-insufficient` 32 筆**（四路原始 41 筆去重），每筆保留「缺什麼證據才能判定」。
+    其中 3 筆與候選清單重疊（`#502`／`#524`／`#488`），那是**四路之間真實的判斷分歧**，
+    兩邊都保留並明載。
+  - **覆蓋缺口四格，刻意不淡化**：(1) 08-12 波 6 張未深讀（`#473`／`#475`／`#476`／`#478`／
+    `#506`／`#508`，補齊成本約 1 次 `gh` 呼叫，下一輪最高投報）；(2) **ship／delivery 是
+    覆蓋度與風險落差最大的一格**——`github_delivery.py`(47KB)＋`delivery.py`(21KB) 是全庫
+    第三大功能面，卻**零條 delivery 語意候選**，成因是 08-12 波深讀的 33 張裡零張是 ship
+    事故（全部卡在 define/build/verify/review 就死了）且 ship 卡由 Manager deterministic
+    執行不經 launcher，無 LLM 參與故 dogfooding 難顯現，而 **ship 是離 merge 最近的那道閘**；
+    (3) porcelain 七個 verb 家族零原生事故，現有語料**分不出「真的穩定」還是「operator 當場
+    繞過而不開票」**，補這格應去讀 `docs/` 的 onboarding／troubleshooting 與 driving-cortex
+    skill 而非再掃 issue；(4) deck-combo 自動選型面零事故（次級）。
+  - 另記錄四路的**誠實負面結果**（查過、乾淨的比對），避免後續重工——包含
+    `evidence/workflow-inputs/` 是全庫唯一完全自洽的 content-addressed store，可作正面對照組。

--- a/docs/superpowers/workstreams/r3-testpilot-case-corpus/case-candidates.md
+++ b/docs/superpowers/workstreams/r3-testpilot-case-corpus/case-candidates.md
@@ -1,0 +1,3148 @@
+# R3 testpilot case 候選清單
+
+issue `#667` 的產出本體。四路**互相盲測**的語料 sweep（症狀家族／子系統／生命週期階段／
+artifact 型別）跨軸去重後的候選清單。
+
+**本清單不進派工鏈、不當 gate、不擋 merge。** 它是給人看的素材盤點。要把任何一筆長成
+case，需另開實作票；R3 本體依賴 R2 Compact，本盤點不依賴。
+
+---
+
+## 一、去重方法與 `hit_by`
+
+四路各自獨立掃過同一批語料，執行期間彼此不看對方的發現。因此**同一個真實事件會以不同
+`id` 出現在多份報告裡**。本清單以「真實事件」為合併單位——同一個 issue／同一次 run 事故／
+同一份 artifact 上的同一種不一致，合成一筆，`hit_by` 列出命中它的軸。
+
+| | 數量 |
+|---|---:|
+| 四路原始條目 | **155**（症狀 37／子系統 49／生命週期 37／artifact 32） |
+| 去重後候選 | **102** |
+| — `hit_by` 四路 | **1** |
+| — `hit_by` 三路 | **9** |
+| — `hit_by` 二路 | **31** |
+| — `hit_by` 單路 | **61** |
+| evidence-insufficient（四路原始 41）| 去重後 **32** |
+
+> `#667` 派工單記 artifact 路為 31 筆，實際條目重算為 **32**（`### ` 級候選標題逐一計數）。
+> 以實際條目為準。
+
+**155 與 102×`hit_by` 的對帳**：`1×4 + 9×3 + 31×2 + 61×1 = 154`。差額來自兩種情形，皆已在
+對應候選標註：(a) 三筆候選各吸收了**同一軸的兩個條目**（`#536` 吸收子系統路的
+`planning-define-ongoing-run-invisible…` 與 `planning-publish-and-run-state-not-one-transaction`；
+`#487/#500/#554` 吸收子系統路的兩條 classifier；`#482/#497/#571` 吸收子系統路的
+`review-absent-evidence-path-collision` 與 `tick-recovered-slice-reprocesses-superseded-job`）
+＝ +3；(b) 兩個條目各自跨了**兩筆**合成候選（症狀路 `abandon-does-not-enumerate-named-resources`
+橫跨 artifacts／evidence 與 branch 兩筆；生命週期路 `ship-card-handoff-must-not-depend-on-disk-residue`
+的 (c) 項橫跨 ship git cwd 與 ship 卡交接兩筆）＝ −2。`154 + 3 − 2 = 155`。
+
+### 單路命中不等於不重要
+
+**61 筆單路命中全數保留。** 單路命中的成因有三種，只有第一種代表「份量較輕」：
+
+1. 事件本身局部，其他軸的視角看不到它；
+2. **其他軸的視角在結構上取不到它**——最典型是 artifact 路的 24 筆純實測發現（0-byte
+   evidence、雜湊方案不一致、log 截斷、journal steps 與正典 manifest 對不上…），它們沒有
+   對應的 issue，掃 issue 的三路**不可能**命中；
+3. **只有一路挖到那個深度**——例如 `#490`（review 與 tick 的 identity 集合必須相等）只有
+   子系統路命中，但它是全盤點 oracle 品質最高的一條；`#420`（auto-claim 與 explicit intake
+   的 phase 不對稱）只有生命週期路命中，但它是唯一一條 differential oracle 形狀的入口對比。
+
+因此**排序不依 `hit_by` 數量**。詳見下節。
+
+---
+
+## 二、排序依據
+
+排序目標是「**可以最早開始長**」，不是「最重要」。判準依序為：
+
+1. **oracle 型別品質**（見橫向發現 1）——差分／集合相等 ＞ 逐欄等式／精確計數 ＞ 結構不變式
+   ＞ 閾值型／存在性型；
+2. **harness 前置成本**——純函式＋凍結 fixture ＞ fs 佈置 ＞ tick 推進／注入時鐘／真實 git
+   ＞ crash 注入／並行 seam ＞ 多 UID／systemd／root；
+3. **`determinism_risk`**；
+4. **期望值是否已定案**（有已 merge 的 PR 或明文裁決 ＞ 只有 issue 建議）；
+5. **`hit_by` 數量**——僅作**同分時的次要加權**。
+
+一個四路命中但 oracle 未定的候選，比一個單路命中但 oracle 是集合相等的候選**更難動工**。
+本清單的第 1 名是單路命中的 `#490`，第 59 名才是唯一的四路命中 `#501`——這是刻意的。
+
+### tier 定義
+
+| tier | 含義 | 筆數 |
+|---|---|---:|
+| **T1** | 純函式／純資料 oracle，凍結輸入。無 fs 佈置或僅需單一 fixture 檔；無 tick、無時間、無 git、無 UID | 27 |
+| **T2** | 需 fs 佈置（目錄樹／yaml／registry 靜態狀態），但無 tick 推進、無時間注入、無真實 git、無多 UID | 31 |
+| **T3** | 需驅動：tick 推進／注入時鐘／真實 git worktree | 27 |
+| **T4** | 需 crash／fault 注入、並行 seam、多世代驅動 | 7 |
+| **T5** | 不可拆的多 UID／systemd／root／acl 殘量（可拆的 tier 1 部分已提前到 T1／T2） | 2 |
+| **T6** | oracle 型別弱、期望值部分待定，或必須先修訂既有測試——**保留但不宜首批** | 8 |
+
+---
+
+## 三、三個橫向發現（合成時不得弄丟）
+
+### 發現 1：oracle 有品質分級，差分／集合相等型結構上擋得住 fail-open
+
+來自子系統路。品質最高的 oracle 是**差分或集合相等**型：
+
+- `#490`——review 路徑解析出的 identity 集合**必須等於** manager／tick 路徑解析出的集合；
+- `#509`——`cortex doctor` 的判定與 tick 載入路徑**必須同源**；
+- `#383`——`set(tick.dispatched) == set(fanout.dispatched)`；
+- `#486`——`set(prompt 中列出的 severity) == VALID_SEVERITIES`；
+- `#420`——explicit intake 與 auto-claim 兩條入口**必須到達同一個 phase**（不需知道正確
+  phase 是哪個）。
+
+共同性質是**無法靠放寬任一邊來滿足**：放寬 A 端會讓集合變大而不等，放寬 B 端亦然。唯一能
+滿足它的實作就是修法本身。相對地，**閾值型**（「N 次之後必須熔斷」）與**存在性型**
+（「必須產生某個輸出」「必須 raise」）容易被放寬成空過——本 repo 已有兩起同型事故
+（`cmd 2>&1 | tail -6` 後讀 `$?` 讀到的是 `tail` 的 exit code；多 agent 共用 checkout 使
+`base..head` diff 變空、`policy_check` 報 `fail: 0` 空過）。
+
+**因此本清單每一筆都標注 `oracle 型別`。** 型別分級（由強到弱）：
+
+| 型別 | 說明 | 為何擋得住／擋不住 fail-open |
+|---|---|---|
+| **差分／集合相等** | 兩條路徑的輸出必須相等 | 放寬任一邊都不成立 |
+| **逐欄等式／逐位元組相等** | 指定欄位前後必須完全相同 | 需獨立重算期望值才夠強（見 `#501`） |
+| **精確計數** | 計數必須「恰好等於」而非「不成長」 | 「乾脆不做」的退化實作會被計數的另一半擋住 |
+| **結構不變式（窮舉／參數化）** | 對狀態空間或設定表全覆蓋 | 新增分支時自動變紅；但需驗證列舉來源是機械導出而非硬編 |
+| **雙向（正向＋負向對照）** | 正向必須通、負向必須仍擋 | 缺負向即允許「把整道檢查拆掉」的修法 |
+| **閾值型** | 「超過 N 就…」 | N 未定案時等於編期望；N 已定案時仍可被設成極大值空過 |
+| **存在性型** | 「必須存在某輸出／必須 raise」 | 最弱。換個字串走同一條路仍會綠 |
+
+### 發現 2：既有陷阱必須寫進 `harness_needs`，並拆 tier
+
+來自子系統路。多條 trust-root case 的原 issue **逐字記錄了「上次是怎麼被繞過去的」**：
+
+- `#657`：「同一族的老問題：測試環境是單 UID，spool 的 ACL 不影響任何事；
+  `prepare_systemd_template()` 的 preflight 檢查的是**『spec 檔存在』而不是『該 job 身分讀
+  得到』**。這是 `#638`／`#630`／`#631` 那條『綠燈不承載三分語意』的第四個實例。」
+- `#645`：「M1 的 5-6 正向 smoke……用的都是**手工組的 job spec**，而我在手工組時**自己挑了
+  一個與 instance 名相符的 worktree 路徑**——等於把這個 bug 繞過去了。」
+- `#638`：「M1 的 R9 攻擊測的是 **spool 根**……**per-job 的正常流程**（Manager 建目錄 →
+  producer 寫 → consumer 讀 → seal）沒有任何一條測試涵蓋。」
+- `#478`：「The existing recovery test uses a normal temporary directory rather than a real
+  Git worktree, so it proves filesystem deletion but cannot detect stale Git registry state.」
+- `#626`：「Phase 2b M1 實機沒踩到這條，只是因為我在執行前把兩個 principal 手動替換掉了：
+  `sed -i 's/u:operator:/u:paul_chen:/g; ...'` ——這個替換是**我當場的判斷**，不在 runbook
+  也不在 spec 裡。」
+
+#### 硬規則（本文件層級，適用於所有由本清單長出的 case）
+
+1. **走真實 provisioning 路徑。** case 的 fixture **不得手工指定「本該由產生器導出」的值**
+   ——worktree 路徑、instance 名、job spec 路徑一律由各自的產生函式導出後比對。
+2. **tier 拆分是強制的，不是選配。** 每條需要環境能力的 case 必須明確拆成：
+   - **tier 1（hermetic）**：對**輸出資料**（命令清單、unit 檔文字、ACL 條目、argv、cwd
+     參數）做純函式斷言。單 UID 可跑，進 CI。tier 1 的斷言必須落在**會導致 tier 2 失敗的
+     那個資料上**，而不是「產生器有輸出東西」。
+   - **tier 2（實機）**：多 UID ＋ root ＋ `acl` ＋ systemd 的真實 smoke，預設 skip、需顯式旗標。
+3. **多 UID 不可用時必須標 `unsupported`，絕不可標 `pass`，也不可 skip 成綠。**
+   同理適用於：root 執行時（`#657` 的 (a) 在 root 下全部可讀會假綠）、`direct` 模式下
+   （`#604` 明言 direct 模式同 UID 本來就可寫）、缺 `acl` 掛載選項時。
+   **這條是本文件的硬規則**：一條在環境不足時回綠的 case，比沒有 case 更糟。
+4. **以效果斷言，不以回傳值斷言。** `#638` 的 seal 失敗是**刻意不 raise** 的
+   （`review.py:304` 註解：「封存失敗不該讓一次合法的 review 反而卡住」），任何以回傳值為準
+   的斷言必然假綠；必須以「用 producer 身分實際覆寫 → 必須被拒」判定。
+5. **手抄 property 子集 ＝ 驗證無效，而且兩個方向都會錯。** 這條是硬規則 1 的一般化，語料中
+   已有**四個實例**，且它們證明失真是雙向的：
+   - `#638`（**假綠**）——測試環境是單 UID，spool 的 ACL「不影響任何事」，斷言在真空中通過；
+   - `#657`（**假綠**）——同型；preflight 抄了「檔案存在」而沒抄「該身分讀得到」；
+   - `#673` 原 body（**假綠方向的誤判**）——宣稱「codex／copilot 在所有 job unit 下靜默
+     rc=1」，實測推翻：八份 unit 都有 `SystemCallErrorNumber=EPERM`，被過濾的 syscall 回
+     `EPERM` 而非殺行程，真 unit 上 codex／copilot 是 **rc=0**；
+   - `#673` 的 repro（**假紅**）——repro 手抄了十條 property 卻**漏抄 `SystemCallErrorNumber=EPERM`
+     那一條**，比 production 更嚴格，於是造出一個 production 不存在的失敗。
+   
+   **規則**：任何 case 的環境／unit／權限剖面，**必須由 production 的產生器導出或直接引用
+   production 的資產**，不得在 fixture 裡手抄一份「看起來等價」的子集。抄少了會假紅（`#673`
+   repro），抄少了另一種東西會假綠（`#638`／`#657`）。`#673` 本身已由實測推翻並撤回，
+   **本清單不採用其結論**，但這條方法論教訓保留。
+
+### 發現 3：define 是八環串聯攻關鏈，作為 case 套件應整組存在
+
+來自生命週期路。`#391`→`#393`→`#397`→`#399`→`#401`→`#404`→`#406`→`#408`，**每修好一環就
+露出下一環**，每一環都是**確定性**失敗（非機率性），且每環都燒掉一個 canary 世代。
+
+0814 的實測結論「12 卡成本下小案派工不成立，每案 define 必死」在語料中對應的不是單一 bug，
+而是這條**串聯故障鏈**——這也解釋了為何每次修復後仍然必死：修好第 N 環只會露出第 N+1 環。
+
+**處置：不要拆成八個獨立 case。** 這條鏈應作為一個**迴歸套件整組存在**，判定「define 可用」
+的語意才成立；只做其中幾條會讓該判定失去意義。本清單中該鏈的成員分散在不同 tier
+（`#401` 在 T1、`#404` 在 T2、`#397`／`#399` 在 T3、`#406`／`#520` 在 T1），**tier 是動工
+成本，不是拆包單位**——套件仍須整組交付。
+
+> 本清單只涵蓋鏈上有 sweep 命中的六環（`#397` `#399` `#401` `#404` `#406` ＋ 同族的 `#520`）。
+> `#391` 與 `#393` 未被任一路獨立產出候選（`#391` 的同型在候選 89 `needs_human` 無理由中
+> 以 build 實測為錨記錄）。長套件時需回頭補讀這兩張。
+
+---
+
+## 四、候選清單
+
+格式：
+
+```
+### N. `id` ｜ hit_by: <軸>（M 路）｜ oracle 型別: <型別>
+```
+
+`observed` 一律**逐字引用來源**，未經改寫或潤飾。
+
+## T1 — 純函式／純資料 oracle，凍結輸入（27 筆）
+
+零 harness 前置。這 27 筆可以在 R2 尚未收斂時就先寫，因為它們不需要 tick、不需要時鐘、
+不需要 git、不需要多 UID。
+
+### 1. `review-identity-loader-asymmetry` ｜ hit_by: subsystem（1 路）｜ oracle 型別: 集合相等 ★
+
+- **source**：issue `#490`（open）。子系統路原始 id 同名。
+- **observed**（逐字）：
+  > `paulsha_cortex/coordinator/review.py:77-80` calls `load_model_identities(config_root, use_packaged_default=False)`, while `manager_daemon.py` workflow actions use `load_model_identities()` and therefore include packaged identities.
+  > Keep claude/sonnet only in the packaged data/model-identities.yaml → retry-review … The immutable absent review evidence records reason `reviewer-identity-unknown`
+  > Add a custom claude/sonnet row … retry-review dispatches, but the next tick fails with `custom identity shadows packaged default`
+  > Workaround：Duplicate the packaged claude/sonnet row in the host overlay with every field exactly equal
+- **oracle**：對同一個 config root，review 路徑解析出的 identity 集合必須**等於** manager／
+  tick 路徑解析出的集合（雙向包含）。
+  *為何是全盤點最強的一條*：它無法靠「放寬其中一邊」滿足——放寬 review 端會讓集合變大而
+  不等，放寬 tick 端亦然。唯一能滿足它的實作是「兩邊走同一條載入路徑」，正是修法本身。
+- **harness_needs**：fs 佈置 packaged + overlay 兩份 YAML。無 provider、無時間、無 tick。
+- **determinism_risk**：極低。
+
+### 2. `porcelain-cli-verb-must-match-permgen-execstart` ｜ hit_by: subsystem（1 路）｜ oracle 型別: 集合／跨模組綁定
+
+- **source**：issue `#618`（closed）＋ `#619`（closed）／PR `#619` 對應實作／既有測試
+  `tests/test_service_run_verb.py`。
+- **observed**（逐字，`#619`）：
+  > `permgen` 產生的 unit 寫：`ExecStart=/opt/cortex/venv/bin/cortex service run`
+  > 但 CLI 沒有這個 verb：`usage: cortex service [-h] {install,start,stop,restart,status,logs,uninstall} ...`
+  > unit 一 `start` 就以 `unsupported service command` 失敗。**ExecStart 契約只存在於產生器端，CLI 沒跟上。**
+  > 新增 `tests/test_service_run_verb.py` 五條，其中一條是**契約鎖**：把「產生器輸出的 ExecStart」與「CLI 實際提供的 verb」綁在一起斷言，讓同一條契約不能再單邊漂移（#618 就是這條斷掉）
+- **oracle**：解析 permgen 產生的**每一個** unit 的 `ExecStart=`，抽出 `cortex <verb...>`
+  尾段，斷言**每一個**都能被真實 CLI parser 接受（不拋 `unsupported`／不回 usage error）。
+  *fail-open 風險*：分別測 permgen 產得出 unit、以及 CLI 有 `run` verb——**兩邊各自綠而契約
+  仍可漂移**，這就是 `#618` 逃過的機制。跨模組的綁定斷言是唯一有效形式。
+- **harness_needs**：permgen 輸出解析 ＋ CLI parser（不執行 daemon，只解析）。完全 hermetic。
+- **determinism_risk**：極低。
+
+### 3. `unbounded-substring-marker-misclassifies-failure` ｜ hit_by: symptom·subsystem（2 路）｜ oracle 型別: property＋雙向 golden
+
+- **source**：issue `#487`（open）＋ `#500`（open）＋ `#554`（open）——三個獨立實例。
+  子系統路拆為 `dispatch-auth-classifier-oauth-substring` 與
+  `dispatch-transient-classifier-timeout-substring` 兩條（同一軸吸收兩個條目）。
+- **observed**（逐字）：
+  > （#487）`github_rate_limit._AUTH_PATTERN` contains an unbounded case-insensitive `oauth` alternative, so the ordinary skill name `doc-coauthoring` matches `oauth` inside `coauthoring`.
+  > 直接復現：`executor_auth._LOGIN_SIGNAL_RE`: no match / `github_rate_limit._AUTH_PATTERN`: match `oauth` / context: `...copilot-sdk,doc-coauthoring,docx...`。結果 `gate_reason: builder-failed-auth`、`retryable: false`，而「There was no authentication or login failure.」
+  > （#500）`_TRANSIENT_RE` in `coordinator/provider_outcome.py` matches the unscoped token `timeout` anywhere in that tail. 被誤判來源是工具訊息 `Parser aborted (timeout, resource limit, or over-length)`，實際終局是 `[Request interrupted by user]` / `aborted_streaming`，卻記成 `{"outcome":"transient","authority":"text_signal","reason":"transient/network signal detected in executor output","retryable":true}`
+  > （#554）`location = report_path or backup_root or "<unavailable>"`，而「taxonomy markers 表含裸 `"unavailable"`」→ `evidence=/tmp/psc-report.json → False（正常）` / `evidence=<unavailable> → True（誤判，靠子字串巧合）`
+- **oracle**：一條 **property case ＋ 三條 golden fixture**。(1) property——對 taxonomy／
+  classifier 的每一個 marker，斷言它在「該 marker 作為更長識別字的子字串」時**不得命中**
+  （生成器：對每個 marker 產生 `x{marker}y` 形式的字串）；(2) 三條 golden：`doc-coauthoring`
+  的 init skill list → **不得為 `auth`**（子系統路更強：**必須是 `unknown`**——指定值才擋得住
+  把 auth 分支整個刪掉）；`Parser aborted (timeout, ...)` ＋ `aborted_streaming` 終局 →
+  不得為 `transient`；`evidence=<unavailable>` → 不得為 transient-service；(3) **正向保留**：
+  真實 OAuth 失敗、真實網路逾時、agy `UNAVAILABLE (code 503)` 仍須正確命中。
+  *fail-open 關鍵*：(3) 絕不可省——只有 (1)(2) 的話，「刪掉所有 marker」會全綠而 classifier
+  失效。另：應優先比對**結構化終局記錄**而非文字 tail（三個 issue 一致建議），oracle 宜額外
+  斷言「有結構化輸出時不得回退到文字比對」。
+- **harness_needs**：純函式（classifier／taxonomy 可單獨呼叫）＋ JSONL log fixture。
+  不需 model、不需 fs、不需時間。**本盤點最乾淨的一條。**
+- **determinism_risk**：極低。唯一風險是 marker 表會演進——property case 必須**自動讀取現行
+  marker 表**而非硬編清單（這正是它的價值）。fixture 內含真實 token 樣態需脫敏。
+
+### 4. `permgen-emits-unmapped-abstract-principal` ｜ hit_by: symptom·subsystem（2 路）｜ oracle 型別: 枚舉對值域＋產生階段 fail-closed
+
+- **source**：issue `#626`（closed）／PR `#632`。症狀路 id
+  `sh-e-aborts-leaving-half-applied-permission-tree`。
+- **observed**（逐字）：
+  > ```
+  > setfacl -m u:operator:rX      /var/lib/cortex/control
+  > setfacl -m u:cortex-outbox:rX /var/lib/cortex/coordinator/digest/outbox
+  > ```
+  > `operator` 與 `cortex-outbox` **不是真實帳號**——它們是 `registry.Principal` 的抽象角色名，`permgen` 直接把角色名當成 UID 印出來
+  > ```
+  > $ sudo setfacl -m u:operator:rX /tmp
+  > setfacl: Option -m: Invalid argument near character 3
+  > $ sudo sh -e -c 'setfacl -m u:operator:rX /tmp; echo "後續命令仍執行了"'
+  > setfacl: Option -m: Invalid argument near character 3
+  >                     ← 「後續命令仍執行了」沒有印出來
+  > ```
+  > 權限樹處於**半套用**狀態……最危險的是：半套用的樹**看起來像是裝好了**（目錄都在、前段權限正確），只有後段資產仍是預設權限。自檢會抓到，但如果執行者只看 `exit=` 就往下走，會帶著一棵漏洞樹進第 5 步降權
+  > Phase 2b M1 實機沒踩到這條，只是因為我在執行前把兩個 principal 手動替換掉了：`sed -i 's/u:operator:/u:paul_chen:/g; ...'` ——這個替換是**我當場的判斷**，不在 runbook 也不在 spec 裡
+- **oracle**：(a) 未提供對應時，產生器 **fail-closed 且不輸出任何命令**（斷言 exit≠0 且
+  stdout 無 `setfacl`）；(b) 解析輸出中所有 `u:<name>:` token，斷言**每一個 name 都在宣告的
+  帳號對應表值域內**——以**掃描全輸出**斷言，不是抽查；(c) 選配 host 層稽核：
+  `grep -oE "u:[a-z_-]+:" script | sort -u` 的每個名字都 `getent passwd` 得到。
+  *fail-open 關鍵*：(a) 的「不輸出任何命令」比「印警告」強得多——印警告的版本在 `sh -e` 下
+  仍會半套用。(b) 必須掃全輸出，因為 bug 的本質是「對應表缺兩個角色」，抽查會漏。
+  *額外價值*：permgen 在產生階段就擋住，`sh -e` 中止的半套用情境根本不會發生。
+- **harness_needs**：純函式，只需 principal 對應表 fixture。**無需 root、無需多 UID。**
+  (c) 依賴 host 帳號，應標為 integration 層。
+- **determinism_risk**：極低。是 trust-root 區段唯一完全 hermetic 的一條，應作為 trust-root
+  的第一條 case。
+
+### 5. `review-verdict-enum-not-in-prompt` ｜ hit_by: subsystem（1 路）｜ oracle 型別: 集合相等（漂移鎖）
+
+- **source**：issue `#486`（open）／相鄰 `#617`。
+- **observed**（逐字）：
+  > its only severity example is：`{"category":"style","severity":"minor", ...}`
+  > It does not state that the validator accepts only：`critical | important | minor`
+  > A reviewer emitted `severity: "major"` for a blocking security finding. The JSON structure, identity, candidate, and evidence were otherwise valid. `validate_review_verdict()` rejects it because `major` is outside `VALID_SEVERITIES`.
+- **oracle**：**漂移鎖**——從 `build_review_prompt()` 的輸出字串中解析出宣告的 severity 集合
+  與 category 集合，斷言 `set(prompt) == VALID_SEVERITIES` 與 `== VALID_CATEGORIES`
+  （集合相等，雙向）。加：非法 enum 仍 fail-closed，且 evaluation 記錄**精確欄位錯誤**而非
+  泛化 `foreign-review-absent`。
+  *fail-open 風險*：斷言「prompt 含 'critical'」→ 漏一個值照樣過，而漏一個值正是本 bug。
+- **harness_needs**：純字串 ＋ 常數同源引用。
+- **determinism_risk**：極低。prompt 內 enum 的排版格式若改，解析器要跟著改 → 建議 prompt
+  端以機器可解析的固定區塊輸出。
+
+### 6. `define-required-heading-prompt-ambiguity` ｜ hit_by: lifecycle（1 路）｜ oracle 型別: 集合相等
+
+- **source**：issue `#520`（open），run `workflow-6b3e215f18c5b68b991c`（另三個命中：
+  `workflow-c24a4e837b306e8c6c1a`、`workflow-87ef197f9f79c2acae1b`、
+  `workflow-ef40fb2793c5b83818d9`）。**define 八環攻關鏈同族。**
+- **observed**（逐字）：
+  > planner 實際產出：「```markdown\n---\nstatus: accepted\nwork_item: fix-read-repo-tier-fail-closed\n---\n\n## Requirements for spec\n- Authoritative source is ...```」
+  > 「`markers: []`——**不是** blocking-decision，frontmatter 也完全正確；唯一的問題就是標題多了 ` for spec` 三個字」
+  > prompt 原文：「`required headings: Requirements for spec, Decisions for design, Tasks for plan.`」
+  > 根因：「原意是「kind=spec 用 `Requirements`…」，但字面同樣可讀成「必要標題是 `Requirements for spec`」」
+- **oracle**：採 issue 建議 4（唯一從結構上消除漂移的一條）：**斷言 prompt 中該段文字由判準
+  常數機械產生**——`set(prompt 中列出的 heading)` 與 `_REQUIRED_HEADINGS` 的值集合完全相等。
+  這條在「新增一個合法 heading 但忘了改 prompt」時會紅，正是缺陷的真正形狀。輔以 validator
+  側：`## Requirements for spec` 必須被 `required-section-missing` 拒（保留 fail-closed），
+  `## Requirements` 必須通過。
+- **harness_needs**：純函式層；`_REQUIRED_HEADINGS`／`PLANNING_KINDS` 可 import。
+- **determinism_risk**：建議 1（改寫成無歧義文字）與建議 4（機械產生）並非互斥；若實作只採
+  建議 1，本 case 的集合相等斷言會紅——**這是可接受的紅**（它會迫使實作補上同源保證），
+  但需在 case 註解標明此意圖，否則會被誤判為 case 寫錯。
+
+### 7. `build-gate-name-set-must-be-mechanically-derived` ｜ hit_by: lifecycle（1 路）｜ oracle 型別: 集合相等（同源）
+
+- **source**：issue `#540`（open，缺陷一＋三；PR `#541` 已落地 doctor 前置驗與 prompt 機械
+  帶名，見 `#545` body），run `workflow-084f75e2178cf7547476`。
+- **observed**（逐字）：
+  > 缺陷三：「`TerminalContractError: terminal 宣稱跑了 gate 'focused pytest RED expectation'，但 manager 的 ledger 沒有這一項`」
+  > 根因：「builder 的 gate_evidence 名稱是模型即興命名，非 canonical `pytest`。與 `#486`…同構：**prompt 未把 canonical gate 名稱（`PSC_GATE_CMD_*` 導出的集合）告訴模型，卻要求模型自報時精確命中**」
+  > 缺陷一：「`cortex-manager.env` 缺 `PSC_GATE_CMD_PYTEST`（hippo-manager.env 有）→ job 結束時 wrapper 寫出的 ledger 為 `gates: []` → `gate-ledger-missing-expected-gate` fail-closed。此為正確的反自證行為，但錯誤只進 `manager.log`」
+- **oracle**：兩條，皆結構性。(a) **prompt 同源**——dispatch prompt 中列出的 gate 名稱集合
+  == 由 `PSC_GATE_CMD_*` env 導出的集合（機械產生）；(b) **doctor 前置驗**——「combo 宣告的
+  `test_policy` gates ⊆ 各 instance 的 `PSC_GATE_CMD_*` 宣告」，缺一即 doctor FAIL。
+  (b) 用 `combos/*.yaml` 的 `test_policy` 值（`red-required`／`focused`／`none`，由 manifest
+  全量解析證實）與 env 佈置驅動。**不斷言模型是否照做。**
+- **harness_needs**：env 注入（`PSC_GATE_CMD_*` 有／無兩態）；fs（combo yaml、instance env
+  檔）；mock provider 捕捉 prompt。
+- **determinism_risk**：低。缺陷三的替代修法（「envelope gate 名稱比對放寬為別名映射」）若被
+  採用，(a) 仍成立但需追加別名表的同源斷言。
+
+### 8. `gate-ledger-required-phases-must-match-sandbox-capability` ｜ hit_by: symptom·lifecycle（2 路）｜ oracle 型別: 結構不變式窮舉＋雙向
+
+- **source**：issue `#313`（closed 2026-08-04）；同型 `#307`（closed，red-required 卡）。
+- **observed**（逐字）：
+  > （#313）「`GATE_LEDGER_REQUIRED_PHASES={build, verify}`（manager.py），`authorize_terminal` 對 verify phase 的 passed terminal 要求可重驗 gate ledger；但 verification 卡以 review-only 沙箱啟動，`launcher._should_run_gates` 對 review-only/read-only 明確回 False——wrapper 不含 ledger 階段、不寫任何 ledger 檔。結果：verification 卡 terminal 一律「terminal 宣稱 passed 但 manager 端沒有可重驗的 gate ledger」fail-closed。**#283 上線後 verify 永不可過**（7/25-26 批次 runs 全數停在 verify 至今、W1 四 run 實測同型）。」
+  > （#307，同構）「copilot 正確寫入 261 行 RED 測試並 commit，pytest gate ledger 記 failed（預期！），但 `_assert_terminal_gate_consistency`（#261 R2）對 terminal 自稱 passed 一律 fail-closed → needs_human」
+- **oracle**：**結構不變式**——對每個 phase，若該 phase 的卡片以 `_should_run_gates` 回 False
+  的沙箱模式啟動，則該 phase **不得**出現在 `GATE_LEDGER_REQUIRED_PHASES`。以 manifest 的
+  phase→persona 對映驅動參數化。期望值已由 checkout 證實：0.1.8 `manager.py:3821` 為
+  `GATE_LEDGER_REQUIRED_PHASES = frozenset({"build"})`。同理對 `test_policy=red-required`：
+  斷言其宣告的測試類 gate 在 ledger 中為 failed 時，一致性檢查**不得**判 fail，且非
+  red-required 卡的同情境仍須判 fail。
+  *fail-open 關鍵*：**負向必須斷言 `"build" in` 該集合**——只測「verify 不在裡面」會允許把
+  整個要求刪光的假修。
+- **harness_needs**：純程式碼層（import 兩個常數／函式）；無 provider、無 fs、無時間控制。
+- **determinism_risk**：極低。唯一風險：`_should_run_gates` 的簽章從 sandbox mode 改為
+  persona 或 card 時，參數化來源需同步。
+
+### 9. `template-instance-name-vs-worktree-dirname` ｜ hit_by: symptom·subsystem（2 路）｜ oracle 型別: 同源 property
+
+- **source**：issue `#645`（closed）／PR `#646`、`#651`、`#648`。
+- **observed**（逐字）：
+  > ```
+  > $ sudo -u cortex-manager systemctl start cortex-job@dispatch1.service
+  > Job for cortex-job@dispatch1.service failed because the control process exited with error code.
+  > $ journalctl -u cortex-job@dispatch1.service
+  > (job-shim)[…]: cortex-job@dispatch1.service: Failed to set up mount namespacing:
+  >                /var/lib/cortex/worktree/dispatch1: No such file or directory
+  > systemd[1]: cortex-job@dispatch1.service: Main process exited, code=exited, status=226/NAMESPACE
+  > ```
+  > `autonomy._branch_for_slice(slice_id)` → `feature/<slice_id>`；`seams.ScriptWorktreeCreator.create()` → `slug = branch.replace("/","-")`，工作區＝`<worktree_root>/feature-<slice_id>`；`job_runner.prepare_systemd_template(job_id=slice_id)` → instance＝`<slice_id>`；template unit → `ReadWritePaths=<worktree_root>/%i`
+  > **`feature-<slice_id>` ≠ `<slice_id>`**——兩者永遠差一個 `feature-` 前綴
+  > 它證明 `PSC_JOB_RUNNER=systemd-template` **從未經正式路徑成功啟動過任何 job**
+  > M1 的 5-6 正向 smoke……用的都是**手工組的 job spec**，而我在手工組時**自己挑了一個與 instance 名相符的 worktree 路徑**——等於把這個 bug 繞過去了
+- **oracle**：*tier 1*——對一組 slice id（含含 `/`、含 CJK、含連字號的），斷言三個導出結果
+  **逐字相等**：`job_workspace.job_segment(job_id)` == systemd instance 名 ==
+  `basename(ScriptWorktreeCreator.create(...))` 的實際產出目錄名。**不需要 systemd 也不需要
+  多 UID**，成本極低而覆蓋根因。*tier 2*——真實 systemd template start smoke。
+  *fail-open 關鍵（本 repo 逐字記錄）*：**case 必須經真實 provisioning 路徑產生工作區名**，
+  harness 契約必須寫死「兩個名字皆由各自的產生函式導出」，**不允許測試直接餵路徑**。
+- **harness_needs**：tier 1：兩個純函式可單獨呼叫（可用 `StubWorktreeCreator` 的真實命名
+  邏輯）＋ fs 佈置。tier 2：systemd ＋ 多 UID ＋ root（**環境不足標 `unsupported`**）。
+- **determinism_risk**：tier 1 極低。tier 2 高。
+
+### 10. `planning-extract-json-returns-cli-envelope` ｜ hit_by: subsystem·lifecycle（2 路）｜ oracle 型別: 差分＋否定式鎖
+
+- **source**：issue `#401`（closed 2026-08-10）／PR `#403`。**define 八環攻關鏈第五環。**
+- **observed**（逐字）：
+  > planning-failure evidence：`question-pack-malformed: ValueError: question pack unexpected key: api_error_status`
+  > envelope `is_error: False`、`api_error_status: None`——**成功回應的 envelope 本來就含 `api_error_status` 鍵**（值為 null），先前對「API 錯誤」的推測不成立
+  > `result` 欄位是**散文說明**（模型解釋了 default_question_pack 就是答案的推理過程），不是純 JSON
+  > 失敗時 fall through 到 `return value`——**把整個 CLI envelope dict 當成模型輸出回傳**
+- **oracle**：三 fixture。(A) `envelope.result` = 散文＋內嵌 JSON → 抽出物件**逐欄等於**該
+  內嵌 JSON；(B) `envelope.result` = 純散文 → raise，且錯誤訊息**必須含 result 前 160 字**、
+  **且不含任何 envelope 鍵名**（明確斷言 `"api_error_status" not in message`）；(C) 純 JSON
+  路徑不變。
+  *fail-open 風險*：(B) 若只斷言 "raises"，一個仍回傳 envelope 但改了訊息的實作會過。
+  **`not in` 那條才是真正的鎖**——原缺陷的病徵正是「診斷指向完全錯誤方向」。
+- **harness_needs**：純函式 ＋ envelope fixture。無 fs、無時間、無 provider。
+- **determinism_risk**：極低。唯一風險是 CLI envelope schema 隨 claude／codex 版本演進 →
+  fixture envelope 需標註取樣版本。
+
+### 11. `builder-self-report-must-never-be-a-gate-fact` ｜ hit_by: symptom·subsystem·lifecycle（3 路）｜ oracle 型別: 三 fixture 含反向證偽
+
+- **source**：issue `#379`（closed）＋其 2026-08-10 重新 review 留言；slice
+  `testpilot-ux-plugin-39-r2-build`，builder=copilot/gpt-5.4。子系統路以
+  `verify-gate-set-must-be-derived-from-plan-acceptance`（`#379`+`#380`，PR `#433`）命中。
+- **observed**（逐字）：
+  > builder exit code **0**、commit 已落（`cd91699`+`c034a76`）、worktree 乾淨。完成摘要：
+  > ```
+  > 驗證結果：
+  > - `make contract-check` ✅
+  > - `make test` ✅
+  > - `python3 -m policy_check --repo .` ✅
+  > - `make ux-probe` ✅            ← 自報通過
+  >
+  > UX probe 摘要：
+  > - V1/V2/V3/V10/V14 pass
+  > - V4/V5/V6/V7/V8/V9/V11/V12/V13 fail    ← 同一則摘要：9/14 為 fail
+  > ```
+  > 人工實跑：`"summary": { "passed": 5, "failed": 9, "skipped": 0 }` / `make: *** [Makefile:14: ux-probe] Error 1`
+  > 「`make ux-probe` 不在 spec 宣告的 `verification` 內，所以 gate 根本沒跑它。gate 只跑了 `make contract-check` / `make test` / `policy_check`，三者確實是綠的」
+  > 「於是形成一個空隙：**builder 自報的驗收項目集合 ⊃ gate 實際驗證的集合**，差集裡的項目由 builder 自己『說了算』，而且說錯了也沒有任何機制會發現」
+  > 複驗留言：「builder 摘要中的「✅/❌」本質是 **untrusted self-report**。即使未來改成結構化 `exit_code`，只要 exit code 是 builder 自己回報、不是 Manager/verification runner 觀測，就仍不能成為 gate fact。」
+- **oracle**：取兩方（issue 本文與複驗留言）**無條件同意**的不變式，三 fixture：
+  (a) 「envelope 全綠 + ledger 全綠」→ pass；(b) 「envelope 全綠 + ledger 有紅」→ **必須
+  reject**；(c) 「**envelope 全紅 + ledger 全綠**」→ **必須 pass**。
+  *(c) 是防 fail-open 的核心*：只有它能證偽「gate 其實在 AND 兩者」。
+  另加集合包含關係（子系統路）：給一個 plan，其驗收清單含 `make ux-probe`；編出的 spec 的
+  `verification` **必須包含該指令**（plan acceptance ⊆ gate set）；ledger 為空時必須
+  fail-closed。**明確禁止 `cmd 2>&1 | tail -6` 後讀 `$?` 的寫法**（本 repo 已有同型事故）。
+- **harness_needs**：fixture terminal envelope JSON ＋ gate ledger JSON；`authorize_terminal`／
+  gate 判定函式；plan 文件 ＋ deck compile（集合包含那半）。無 provider、無真實指令執行。
+- **determinism_risk**：低。`claimed_checks[]` schema／`unverified_claims` 呈現的期望值**未
+  定案**（見 evidence-insufficient 2）——本 case 刻意只測「自報不成為 gate fact」，不測「自報
+  如何被呈現」。
+
+### 12. `structured-429-flattened-to-absent-verdict` ｜ hit_by: symptom·subsystem（2 路）｜ oracle 型別: 逐欄等式＋否定式
+
+- **source**：issue `#499`（open），job
+  `task-3-private-repo-and-forbidden-documentation-scan-build-3`，candidate
+  `88b31a3349bd6ba56987c4936b959cbd79b69ae4`。
+- **observed**（逐字）：
+  > The Claude stream-json log contained authoritative structured evidence：`rate_limit_event.status = rejected` / `rateLimitType = five_hour` / `resetsAt = 1786554000` / terminal result `api_error_status = 429` / `terminal_reason = api_error`
+  > The coordinator recorded the job as failed with exit_code 1, but the slice projection became：`gate_state = needs_human` / `reason = foreign-review-absent` / `provider_outcome = null` / next action only exposes manual retry-review
+  > 「A machine-readable transient provider failure is flattened into a generic absent-verdict needs_human state.」
+- **oracle**：以該結構化 log 為 fixture，斷言 (a) `provider_outcome` **非 null** 且 outcome
+  為 typed transient `rate_limited`；(b) `resets_at` 欄位**逐字等於 `1786554000`**（被保留在
+  結構化欄位供退避邏輯讀取）；(c) reason **不得**為 `foreign-review-absent`（限流與缺 verdict
+  必須可區分）；(d) exact candidate 與 foreign-review 獨立性不變。四條都要。
+  *fail-open 關鍵*：(c) 用否定式斷言防止「換個字串但仍走同一條路」；(d) 是 issue 明列的必須
+  維持項，防止修法順手放寬 review 獨立性。
+- **harness_needs**：stream-json log fixture（含 `rate_limit_event` 記錄）；adapter 可單獨
+  呼叫。不需真實 provider、不需網路。
+- **determinism_risk**：低。`resetsAt` 是絕對 epoch——**建議只驗欄位透傳，不驗退避時機**
+  （驗時機會隨掛鐘漂移）。Claude stream-json schema 屬外部契約可能改版，case 應同時保留一條
+  「未知 schema 時保守處理」的斷言。
+
+### 13. `envelope-failed-vs-ledger-passed-no-reconciliation` ｜ hit_by: symptom（1 路）｜ oracle 型別: 差分＋對稱項
+
+- **source**：issue `#586`（closed），run `workflow-084f75e2178cf7547476`，subagent-build job 488。
+- **observed**（逐字）：
+  > retry-build repair builder（codex）產出新 candidate `83a31e35`……但自報：`"status":"failed"`, `"diagnostics":{"preflight":{"engine":"passed","policy":"passed","openspec":"passed","pytest":"failed"}, "pytest_failure":"AF_UNIX socket creation raised PermissionError EPERM in the sandbox.", "focused_pytest":"104 passed"}`, `"gate_evidence":[{"name":"pytest","status":"failed"}]`
+  > 「而 manager 的**獨立 gate ledger**（正常環境重跑 `python3 -m pytest -q`）＝ `pytest passed exit 0`。」
+  > 「當 envelope 自報 **failed 而 ledger 實為 passed** 時，直接以 envelope 為準判 fail——模型的**自貶**被無條件採信，即使權威 ledger 證明它其實通過。」
+- **oracle**：佈置 envelope(gate `pytest`=failed) ＋ 獨立 ledger(同名 gate=passed)，斷言
+  (a) 最終判定採 **ledger**；(b) 必須落一筆結構化理由標記「envelope/ledger 分歧，採信 ledger」
+  並保留 envelope 原文供稽核。
+  *fail-open 關鍵*：(a) 單獨存在會製造新的 fail-open（模型謊報 failed 就被平反卻無痕跡）；
+  (b) 是必要對稱項，缺 (b) 判 fail。另需一條**負向 case**：envelope=passed ＋ ledger=failed
+  → 必須判 fail（`#540` 反自證方向不得被這條修法弄壞）。
+- **harness_needs**：fs 佈置（envelope JSON ＋ ledger JSON）；harvest／採信邏輯可單獨驅動。
+  不需 model、不需 sandbox。
+- **determinism_risk**：低——純資料驅動。唯一風險是 envelope schema 版本演進。
+
+### 14. `review-codex-jsonl-banner-rejects-valid-verdict` ｜ hit_by: subsystem（1 路）｜ oracle 型別: 三 fixture 雙向
+
+- **source**：issue `#485`（open）。
+- **observed**（逐字）：
+  > ```
+  > Reading additional input from stdin...
+  > {"type":"thread.started", ...}
+  > {"type":"turn.started"}
+  > ...
+  > {"type":"turn.completed", "usage": {...}}
+  > ```
+  > The process exits 0 and writes the requested `.psc-review-verdict.json`. The job registry records `status: exited`, but slice evaluation becomes：`{"state":"absent","reason":"invalid-process-output"}`
+  > That helper applies `json.loads()` to every non-empty line. The normal Codex banner is not JSON, so a valid Codex JSONL run can never reach verdict validation.
+- **oracle**：三 fixture。(A) 逐字 banner ＋ 合法 JSONL ＋ `turn.completed` → **必須到達
+  verdict validation**（斷言最終 state 來自 verdict，不是 `absent`）；(B) 任意非 JSON 垃圾 →
+  仍 `absent` fail-closed；(C) 缺 `turn.completed` → 仍 fail-closed。**三條缺一不可。**
+  *fail-open 風險*：只做 (A) →「把 JSONL 驗證整段拿掉」會全綠，而那會讓任意 process 垃圾被
+  當成合法 review。
+- **harness_needs**：log fixture ＋ verdict JSON 檔的 fs 佈置。不需真 codex。
+- **determinism_risk**：低。banner 逐字內容綁定 Codex CLI 0.147.0 → 需標注版本並在 fixture
+  註明來源。
+
+### 15. `reviewer-argv-must-stay-read-only` ｜ hit_by: subsystem·lifecycle（2 路）｜ oracle 型別: 安全不變式雙向×executor
+
+- **source**：issue `#484`（open）＋ `#568`（open），run `workflow-084f75e2178cf7547476`，
+  job `wf-865ecb7f70-verification-484`。
+- **observed**（逐字）：
+  > （#484）The resulting registry row says：`kind: review` / `persona: reviewer` / `executor: codex`
+  > Live process argv nevertheless contains：`codex exec ... --json --sandbox workspace-write --model gpt-5.6-sol ...`
+  > The disposable review checkout is the candidate Git worktree itself, so workspace-write permits edits to candidate files. Prompt text and an effective-tools list are not sandbox enforcement.
+  > The workflow lane has the missing enforcement in `_specialize_workflow_launcher()`, but the legacy slice foreign-review lane does not.
+  > （#568）verification job…（agy/gemini-3.7-flash-high，overlay 合法 review 身分）exit 0，log 唯一內容：`jetski: no output produced — a tool required the "unsandboxed" permission that headless mode cannot prompt for, so it was auto-denied. Add an allow-rule under permissions.allow in settings.json (e.g. unsandboxed(<target>)). Alternatively, re-run with --dangerously-skip-permissions to auto-approve all tools.`／harvest → `ValueError: workflow terminal log has no JSON evidence` → needs_human
+  > 約束：「**不可用 `--dangerously-skip-permissions` 或寬鬆 unsandboxed allow-rule 解**：等於製造 write-capable reviewer，違反 #484 與 0.2.0 join gate 第 4 條（read-only 強制）」
+  > `build_agy_argv`：「固定 `--print --mode plan --sandbox`（launcher.py:667），從不放權——設計正確（read-only reviewer）」
+- **oracle**：安全不變式，對**每個** executor（claude／codex／agy／copilot——`#396` 證實四種
+  在編）參數化：reviewer persona 的 argv 中不得出現 `--dangerously-skip-permissions`、不得
+  出現 workspace-write 等價旗標、不得注入寬鬆 `unsandboxed(...)` allow-rule；並斷言含
+  `--sandbox read-only`。**三條入口全覆蓋**（automatic review／`retry-verify`／`retry-review`）
+  ——只測 workflow lane（本來就對的那條）會全綠而 bug 原封不動。
+  *負向不可省*：builder persona 的 argv **必須**具備寫入能力，否則「全部關掉」也會通過。
+  另加：實際寫入 candidate 的嘗試必須被拒；verdict artifact 仍能落地。
+- **harness_needs**：mock provider（捕捉 argv，不啟動真 CLI）；persona catalog；四 executor
+  的 launcher builder 函式；三條 action 路徑的觸發能力。
+- **determinism_risk**：低。argv 為確定性組裝。**「零輸出該如何處置」不在本 case**（`#568` 的
+  三個修復方向未定案，見 evidence-insufficient 24）。
+
+### 16. `dispatch-persona-effective-tools-not-in-claude-argv` ｜ hit_by: subsystem（1 路）｜ oracle 型別: argv 雙向
+
+- **source**：issue `#480`（open）／相鄰 `#494` `#495`。
+- **observed**（逐字）：
+  > The injected builder contract listed: `python -m unittest` / `git add` / `git commit` / `rg`
+  > Every required test attempt was denied, including: `python3 -m unittest tests.test_deliver_gate -v` / `python3 -m unittest discover ...` / a subprocess wrapper around the same command / running the unittest file directly
+  > `build_claude_argv()` … uses `--permission-mode acceptEdits` for a normal commit-required builder … but does not add any `--allowedTools` entries for the persona effective tools
+  > 每次 bash 呼叫回 `This command requires approval`（headless job 無人可批）
+- **oracle**：對一個宣告 effective_tools 含 `git commit` 的 builder persona，`build_claude_argv`
+  的輸出 argv 必須含由該結構化欄位**導出**的 `--allowedTools` 條目（正向）；且 argv 必須
+  **不含** `git push` / `git reset` / `git clean` 的授權，也**不含** `bypassPermissions`（負向）。
+  斷言在 argv list 上，**不斷言 job 成功**。
+  *fail-open 風險*：只驗正向 → 一個 `--allowedTools "Bash(*)"` 的實作會全綠，而那正是 issue
+  明說不要的。
+- **harness_needs**：mock provider（不啟動真 claude，只驗 argv）；persona 契約 fixture。
+- **determinism_risk**：低。風險在「declared tools → allowedTools 規則」的映射表若硬編在測試
+  裡會與實作漂移；**必須同源引用**。
+
+### 17. `reviewer-verdict-and-findings-severity-must-agree` ｜ hit_by: lifecycle（1 路）｜ oracle 型別: 四組合 fixture 雙向
+
+- **source**：issue `#617`（open），run `workflow-50b4fb018b3412a7f487`，review job 502→repair→505。
+- **observed**（逐字）：
+  > 「**散文結論明確**：505 結尾「The defect described in #501 is closed at its root … **Recommend merge**, with findings 1 and 3 as small follow-ups.」；502 亦「genuinely fixed … two items block acceptance」但其一是測試缺失。**但結構化 gate 判定 = `blocking-findings`(5 條)、rejected**。」
+  > 「gate 只採信結構化 findings 的 severity(**正確**——#540 反自證：不能靠模型散文結論放行)，但 reviewer 把「建議 merge 的 follow-up」也填進了 blocking severity 欄位。散文說可放行、結構化說擋——**reviewer 自身輸出不一致**，gate 忠實反映後者 → run 卡死於 review，repair 迴圈每輪 reviewer 又找到不同的小 findings(502 四條→505 五條，LLM reviewer 非決定性)。」
+- **oracle**：全部在 fixture payload 上判定，**LLM 非決定性完全隔離在 harness 之外**：
+  (a) `verdict=approve` 且存在 severity=blocking 的 finding → gate 必須判為「reviewer 輸出
+  矛盾」並給**具名 diagnostic**，斷言 reason 字串明確區分於「candidate 真有阻擋問題」
+  （issue 建議 2：「非靜默取其一」）；(b) 反向 `verdict=reject` 但零 blocking finding → 同樣
+  判矛盾；(c) **負向**：一致的 approve（零 blocking）與一致的 reject（有 blocking）必須正常
+  通過，不得被誤擋；(d) prompt 側同源：prompt 中列出的 severity enum == validator 的 enum
+  （比照候選 5）。
+- **harness_needs**：fixture review payload JSON（四種組合）；gate 判定函式；prompt 產生器。
+  無真模型。
+- **determinism_risk**：低（fixture 化之後）。**repair 迴圈熔斷不進本 case**——N 未定案（見
+  evidence-insufficient 8）。⚠ **artifact 路獨立查證：`#617` 的那批 review evidence 在任何
+  store 中都找不到**（見 evidence-insufficient 7），故 fixture 需自行構造而非取自真實 artifact。
+
+### 18. `define-integrator-prompt-artifact-refs-semantics` ｜ hit_by: lifecycle（1 路）｜ oracle 型別: 約束清單驅動參數化
+
+- **source**：issue `#406`（closed 2026-08-10），run `workflow-23693db2efe20b6da079`。
+  **define 八環攻關鏈第七環。**
+- **observed**（逐字）：
+  > 「hermetic 修復（404）後 brainstorm 深入三關：questioner PASS、secondary（agy）PASS，integrator 死於：`primary-integration-malformed: ValueError: resolutions[0].artifact_refs must not be empty`」
+  > 根因：「integrator prompt 只說「Each resolution has only question_id, decision, artifact_kind, artifact_refs」——列了欄位名，**未給語意**」
+  > 缺的四項：artifact_refs 非空且為 destination path／artifact_kind 等於去掉 `missing-` 前綴／artifacts 的 path 集合恰等於全部 artifact_refs 聯集／每個 question 恰一個 resolution
+- **oracle**：**結構性而非字串比對**：對 `validate_primary_integration` 逐條列舉的每個約束，
+  斷言 prompt 中存在對應說明——實作為「**約束清單驅動的參數化測試**」，而非硬編 4 個
+  `assert "..." in prompt`。理由：後者在 prompt 被合法改寫時假紅、在新增第 5 條約束時假綠
+  （正是 `#516`／`#520` 兩次復發的機制）。配一條 validator-side 正向測試：符合四項語意的
+  payload 必須通過。
+- **harness_needs**：純字串／純函式層；無 provider、無 fs。
+- **determinism_risk**：**本 case 的 oracle 不保證模型會照做**——它只保證「語意有被講給模型」。
+  這是刻意的取捨（斷言模型輸出會引入 LLM 非決定性）。**此限制須寫進 case 註解**，避免日後被
+  誤讀為「define 不會再因 prompt 失敗」。
+
+### 19. `ship-completion-reread-must-tolerate-source-revision-drift` ｜ hit_by: lifecycle（1 路）｜ oracle 型別: 逐欄參數化雙向
+
+- **source**：issue `#165`（closed 2026-07-23），實機驗收 F49c，B7 porcelain-init-sample。
+- **observed**（逐字）：
+  > 「跨多次 main 前進而長期 in-flight 的 run，其 completion_payload 的 `work_authority.source_revisions`（openspec/todo/spec 綁 default-branch tree SHA）在 build 時凍結，但 ship 時 `ShipOrchestrator` 以**當前 authority** 重算 `expected_work_authority`（含當前 source_revisions）。兩者漂移 → `completion_records_semantically_match(reread, expected_record)` 判 mismatch → `completion record reread WorkAuthority mismatch` → ship/merge 卡死。實測：B7 porcelain-init-sample 跨 F45/F49/F49b/B7-planning 等約 7 次 merge 後 ship，反覆刷此錯誤。」
+- **oracle**：雙向（issue 逐字界定 blast radius）：(a) completion 與 expected **僅**
+  `source_revisions` 不同 → ship 比對通過；(b) `candidate`／`merge_commit`／`mapped_prs`／
+  `mapped_issues` **任一**不同 → 仍必須 mismatch。**(b) 必須逐欄參數化**——只做 (a) 等於把
+  completion 比對整道放寬，正是本 repo 兩起 fail-open 事故的形狀。
+- **harness_needs**：fixture completion record 兩份；`completion_records_semantically_match`；
+  registry。無 provider。
+- **determinism_risk**：低。`VOLATILE_WORK_AUTHORITY_FIELDS` 日後若再加欄位，(b) 的參數化
+  來源應改為「非 volatile 欄位集合」以自動涵蓋。
+- **附註**：這是 ship 區段**唯一一條 delivery 語意面**的候選（其餘兩條皆為權限／工作區歸屬）。
+  見「覆蓋缺口」第 2 節。
+
+### 20. `monitor-socket-umask-and-mode-assertion` ｜ hit_by: symptom·subsystem（2 路）｜ oracle 型別: 結構不變式（呼叫次數 0）
+
+- **source**：issue `#464`（closed）＋ `#439`（closed）＋ `#425`（closed）＋ `#608`（closed）／
+  PR `#444`、`#470`、`#631`／既有 harness `tests/socket_fixtures.py`、
+  `tests/conftest.py::socket_dir`。
+- **observed**（逐字）：
+  > （#464）
+  > ```
+  > FAILED tests/test_stage9_project_monitor_service.py::Stage9ServerTests::test_server_socket_has_0600_permission
+  > AssertionError: 493 != 384   # 0o755 != 0o600
+  > ```
+  > 同 run 內 3.10/3.11/3.12 全綠；`gh run rerun --failed` 後 3.13 轉綠——典型偶發。失敗 commit `cf791a2` 只動 VERSION/CHANGELOG/changelog.d（release 收攏）
+  > 0o755 代表 socket 建立當下 umask(0o177) 根本沒生效
+  > （#439）「`os.umask()` 是 **process-global 非 thread-local**。每個 monitor 測試/運行都起背景 server 執行緒；umask 被翻到 0o177 的窗口內，**其他執行緒**的 `mkdir(parents=True)` 新建的祖先目錄會繼承 0600（無 execute 位），導致該目錄下的 mkdir/stat raise PermissionError。這正是 #425 flaky 的機制」
+  > 「umask dance 之後緊接著 `os.chmod(0o600)` 明確設定 socket 權限——umask 的效果被 chmod 覆蓋」
+  > （#608）長 TMPDIR 使 AF_UNIX `sun_path` 超 108 bytes，`test_monitor_work_api` 三測必紅——「而那種紅會被 manager 的 gate ledger 記成『交付沒過』」
+- **oracle**：**主判準（T1、不受競態影響）**：(B) 斷言 `server.py` 執行期間 **`os.umask`
+  呼叫次數為 0**（monkeypatch 計數）——這是結構不變式，不 flaky。
+  **輔證（T3）**：(A) 併發建立 N 個 server 實例，每個 socket 最終 mode 必須是 `0o600`，
+  且取樣必須在 **readiness gate 之後**（不是 bind 之後立刻取樣）；(C) 在人為加長的 `TMPDIR`
+  下，socket 路徑仍短於 `sun_path` 上限。
+  *(b) 不可省*：否則「移除 umask 也移除 chmod」會通過而讓 socket 權限放寬。
+  *為何本條特別重要*：它是本 repo「檢查本身壞掉」的**教材級案例**——原測試的斷言（bind 後
+  立刻讀 mode）本身就是競態的一半，而它的紅會被 gate ledger 記成交付失敗。
+- **harness_needs**：monkeypatch umask 計數（主判準，純結構）；`socket_dir` fixture
+  （**已存在**）；併發建立與 `TMPDIR` 加長（輔證層）。
+- **determinism_risk**：主判準極低。(A) 本質上仍有殘餘競態 → 應標為輔助。
+
+### 21. `gate-ref-hash-unverifiable` ｜ hit_by: artifact（1 路）｜ oracle 型別: round-trip 100%
+
+- **source**：**artifact 路實測**：run `workflow-88d089d71416a754dda8` 的 `gate_refs`；目標檔
+  `~/.agents/coordinator/evidence/planning/brainstorm-195d98ade85c884ded70289af1521935.json`。
+- **observed**（逐字）：
+  > 該 gate_ref 記錄 `sha256 = 599876222b8d8d9b0ee5bbec12ab3bd1809b2ca1f225de211c1b9bb0df9102a0`。對目標檔案窮舉 **26 種序列化組合**（`sort_keys ∈ {T,F}` × `separators ∈ {緊湊, 寬鬆}` × `indent ∈ {None,2}` × `ensure_ascii ∈ {T,F}`，加 raw bytes，再加逐一去掉單一 top-level key 的 9 種）**全部不吻合**；也不等於檔內的 `secondary_evidence_hash`（`ad2fc83a723902ec30c0f0e5092861e282a82db9b3c1df40732b5e765b794750`）。
+  > 對照：其餘 27 個 gate_ref 全部可用上述某一方案驗證通過。
+- **oracle**：「寫入 gate_ref 時計算的雜湊，必須能被讀取端以同一函式重算吻合；round-trip
+  測試（寫→讀→重算）必須 100% 通過，且對全庫做一次 sweep 斷言 0 筆不可驗證」。
+- **harness_needs**：fs 佈置。無需 provider。
+- **determinism_risk**：低。
+
+### 22. `evidence-hash-canonicalization-inconsistent` ｜ hit_by: artifact（1 路）｜ oracle 型別: 宣告方案==實際方案
+
+- **source**：**artifact 路實測**：對每個 store 窮舉 `raw bytes` /
+  `json.dumps(sort_keys, separators=(',',':'), ensure_ascii=True)` / `…ensure_ascii=False`
+  三種方案。
+- **observed**（逐字）：
+  > 同一個 coordinator root 內至少有 **4 種並存的雜湊方案**：
+  > ‧ `evidence/work-abandon/` 檔名尾段：**73 檔用 canonical-JSON + `ensure_ascii=False`，9 檔用 `ensure_ascii=True`**，2 檔為空
+  > ‧ `jobs.json.gate_refs[].sha256`：**20 筆用 raw bytes、6 筆用 canonical-utf8、1 筆用 canonical-ascii、1 筆無法驗證**
+  > ‧ `evidence/workflow-inputs/` 檔名：155 檔**全部**用 raw bytes
+  > ‧ `evidence/workflow`（388 檔）與 `workflow-manifests/`（61 檔）的檔名**不是**任何一種內容雜湊
+  > ‧ `delivery-journal` 的 `ship.completion_record.hash` 用 canonical-ascii；同一物件的 `ship.merge_authorization.hash` 卻是對內層 `payload` 取雜湊
+  > 亦即：**一個只實作單一方案的驗證器，會對其餘方案回報「雜湊不符」；而一個「比對失敗就略過」的驗證器則全部空過。**
+- **oracle**：「evidence 的內容雜湊方案必須在 schema 中明示（例如
+  `hash_alg: "sha256/canonical-json-utf8"`），驗證器依宣告方案計算並比對；未宣告方案即 fail」。
+  *fail-open 關鍵*：**嚴禁**「依序嘗試多種方案，任一吻合即通過」——那正是把不一致合法化。
+  要斷言「宣告方案 == 實際方案」。
+- **harness_needs**：fs 佈置（**含 CJK 內容的 evidence**，才能區分 ascii/utf8 方案）。無需
+  provider。
+- **determinism_risk**：低。CJK 內容是區分方案的必要條件，fixture 必須含中文。
+
+### 23. `manifest-step-schema-drift-within-v1` ｜ hit_by: artifact（1 路）｜ oracle 型別: 集合相等（version→keyset）
+
+- **source**：**artifact 路實測**：61 個 manifest 的 step keyset 統計；例
+  `workflow-manifests/2bf95083561aa6204bd78ecc3da2b06148923e07ffd42ef9124b0c37572fd4da.json`。
+- **observed**（逐字）：
+  > 61 個 manifest **全部 `"version": 1`**、top-level keyset 全部一致（`combo`/`steps`/`task_slug`/`version`），但 step 層有**兩種 keyset**：
+  > ‧ 647 個 step：13 鍵 `(action, card, commit_policy, domain, executor, gate_result, inputs, model, outputs, persona, phase, skill_ref, test_policy)`
+  > ‧ **60 個 step：9 鍵**，缺 `action`／`commit_policy`／`skill_ref`／`test_policy`
+  > 缺鍵者集中在 5 個 manifest：`docs-only-lifecycle-canary`（×2）、`docs-only-lifecycle-canary-v2`（×2）、`terminal-lifecycle-canary`。同一個 `version: 1` 涵蓋兩種形狀，讀取端無從辨別。
+- **oracle**：「載入 manifest → 依 `version` 查 schema → 每個 step 的鍵集合必須**等於**（不是
+  包含於）該 schema 的鍵集合」。**不可**寫成 `step.get("skill_ref")` 取到 `None` 就當合法
+  ——那正是本案的 fail-open。
+- **harness_needs**：fs 佈置（兩份不同世代的 manifest fixture）。純資料。
+- **determinism_risk**：低。**但需先確認「version 1 的正典鍵集合是 13 鍵」**——本 repo 未見
+  成文 schema 文件，須先釘住再寫死。
+
+### 24. `job-record-timing-fields-optional-under-one-schema-version` ｜ hit_by: artifact（1 路）｜ oracle 型別: 集合相等＋死欄位偵測
+
+- **source**：**artifact 路實測**：505 個 job record 的 keyset 統計。
+- **observed**（逐字）：
+  > `jobs.json` 宣告 `"schema_version": 2`，但 job record 有 **6 種 keyset**（33／35／36／37／44／45 鍵）：
+  > ‧ 399 筆 36 鍵、71 筆 37 鍵（多 `workflow_stage_execution_key`）
+  > ‧ **僅 26 筆（14+12）帶 `started_at`／`exited_at`／`usage`／`usage_raw`／`usage_reason`／`provider_outcome`**
+  > ‧ 5 筆 33 鍵、4 筆 35 鍵（缺 `workflow_input_root`／`workflow_input_snapshot`／`workflow_builder_job_id`）
+  > 另：`verification_hash` 欄位在 **505 筆全部為 `null`**（死欄位），而 `evidence/verification/` 有 206 個檔案——job → verification evidence 之間沒有任何雜湊層級的連結，只靠檔名前綴約定。
+- **oracle**：「同一 `schema_version` 下，所有 job record 的鍵集合必須相同；歷史記錄若不補齊，
+  必須以 `schema_version` 區隔」。另一條可獨立判定：「若一個欄位在全庫 100% 為 null，測試
+  必須要求它被移除或被填」——**這正是 fail-open 的溫床：任何 `if job["verification_hash"] ==
+  expected` 的檢查永遠取到 None**。
+- **harness_needs**：fs 佈置。無需 provider。
+- **determinism_risk**：低。⚠ `verification_hash` 是「已廢棄待刪」還是「應該要填但沒填」
+  **未定**（見 evidence-insufficient 31）——本 case 只做「必須被移除**或**被填」的二選一斷言，
+  不指定哪一邊。
+
+### 25. `delivery-journal-ship-phase-enum-inconsistent` ｜ hit_by: artifact（1 路）｜ oracle 型別: 成文 enum＋未知值 fail-closed
+
+- **source**：**artifact 路實測**：`~/.agents/coordinator/delivery-journal.json`
+  （`schema: "cortex-delivery-journal/v1"`，19 runs）。
+- **observed**（逐字）：
+  > 同一個 `cortex-delivery-journal/v1` 內出現 4 種 phase 值，且**分隔符不一致**：
+  > `"done"` ×7、`"merged"` ×2、`"needs_human"` ×8（底線）、**`"needs-fix"` ×1（連字號）**。
+  > `"needs-fix"` 出現在 `workflow-7dd63eeeacac77d06b54`（add-cortex-version-flag），同一 run 的其他欄位為 `finding_count: 1`、`review_id: 4744071629`、`pr_number: 110`。
+  > 另外 `"done"` 與 `"merged"` 並存且都帶 `merge_commit`，語意重疊未定義。
+- **oracle**：「`ship.phase` 必須落在一份成文的 enum 中；讀取端對未知值必須 fail-closed
+  （不得 fallback 成任何預設）」。
+  *fail-open 關鍵*：**嚴禁** `phase in ("done", "merged")` 這種白名單判斷（`needs-fix` 會被
+  靜默當成「非完成」而不報錯）；要對未列舉值主動 raise。
+- **harness_needs**：fs 佈置。無需 provider。
+- **determinism_risk**：低。
+
+### 26. `delivery-journal-ship-keyset-drift` ｜ hit_by: artifact（1 路）｜ oracle 型別: phase→必填鍵集合
+
+- **source**：**artifact 路實測**：18 個有 ship 的 run。
+- **observed**（逐字）：
+  > `phase == "done"` 的 7 筆有 **3 種不同鍵集合**：
+  > ‧ 17 鍵（含 `epoch_started_at`, `finding_count`, `findings`, `requested_at_epoch`, `review_id`）×4
+  > ‧ 14 鍵（缺 `finding_count`, `findings`, `review_id`）×1（`workflow-5a196f6f2f67cd979313`）
+  > ‧ 12 鍵（另缺 `epoch_started_at`, `requested_at_epoch`）×1（`workflow-c7b01a2f3cfac88a1ffc`）
+  > ‧ 15 鍵、且**額外帶 `reason`** ×1（`workflow-ed15cd16ffa5e2c26306`，`phase == "done"` 卻有 `reason` 欄位——`reason` 在其他所有紀錄中只出現在 `needs_human`）
+  > run entry 本身亦有 3 種 keyset（10 筆含 `delivery_binding`+`pushes`、8 筆兩者皆無、1 筆有兩者但無 `ship`）。
+- **oracle**：「`ship.phase` 的值必須唯一決定其必填鍵集合（例：`done` ⇒ 必含 `merge_commit`／
+  `pr_number`／`completion_record`；`needs_human` ⇒ 必含 `reason` 且不得含 `merge_commit`）；
+  違反即 fail」。
+- **harness_needs**：fs 佈置。
+- **determinism_risk**：低。
+- **附註**：這是 ship／delivery 區段的第三條候選，仍屬 **schema 一致性**而非 delivery 語意。
+  見「覆蓋缺口」第 2 節。
+
+### 27. `run-journal-step-output-attribution-collapsed` ｜ hit_by: artifact（1 路）｜ oracle 型別: 集合不相等＋子集
+
+- **source**：**artifact 路實測**：`jobs.json.workflows[].steps[].outputs`。
+- **observed**（逐字）：
+  > **50 個 run** 內有一個以上「不同 card 共用同一份 outputs 清單」的情形。逐字例（run `workflow-a864f07cb5615440fd73`，`brainstorming`／`openspec-propose`／`writing-plans` 三張卡的 `outputs` 完全相同）：
+  > `["docs/superpowers/plans/porcelain-skeleton.md", "docs/superpowers/specs/porcelain-skeleton-design.md", "docs/superpowers/specs/porcelain-skeleton-spec.md", "openspec/changes/porcelain-skeleton/proposal.md", "openspec/changes/porcelain-skeleton/design.md", "openspec/changes/porcelain-skeleton/tasks.md", "docs/superpowers/workstreams/porcelain-skeleton/todo.md"]`
+  > 其正典 manifest 對這三張卡分別是：
+  > `brainstorming` → `["docs/superpowers/specs/*porcelain-skeleton*-spec.md", "docs/superpowers/specs/*porcelain-skeleton*-design.md"]`
+  > `openspec-propose` → `["openspec/changes/porcelain-skeleton/proposal.md", "openspec/changes/porcelain-skeleton/tasks.md"]`
+  > `writing-plans` → `["docs/superpowers/plans/*porcelain-skeleton*.md"]`
+  > 即：run journal 把整個 define+plan 階段的產出聯集回填給每一張卡，因此 `openspec-propose` 被記成產出了 `docs/superpowers/plans/...`。
+- **oracle**：「同一 run 內，任兩張不同 card 的 `outputs` 集合不得完全相同；且每張卡的
+  `outputs` 必須是其 manifest glob 的子集」。
+  *fail-open 關鍵*：`outputs` 為空的卡要**單獨計數並斷言**（全庫有 7 處被清空），不能因為
+  `[] == []` 就當「相同」而放行或誤報。
+- **harness_needs**：fs 佈置。無需 provider。
+- **determinism_risk**：低（純資料）。
+
+## T2 — 需 fs 佈置，但無 tick／無時鐘／無 git／無多 UID（31 筆）
+
+### 28. `mandated-checkbox-tick-must-not-count-as-authority-drift` ｜ hit_by: symptom·lifecycle（2 路）｜ oracle 型別: 雙向＋豁免不外溢 ★★
+
+生命週期路標為**旗艦**。三個各自正確的機制組合後互斥，6/6 lane 全中。
+
+- **source**：issue `#296`（closed）＋ `#310`（closed，同一缺陷在 cortex 自身 repo 的複現）。
+- **observed**（逐字）：
+  > （#296）「2026-08-04 在 paulsha-hippo 以 cortex workflow lane（instance `hippo`，cortex 0.1.1）平行驅動 6 個 work item（hippo #74/#98/#99/#105/#106/#109），全部順利通過 claim→define→plan→build（tdd-red、subagent-build 皆過、candidate 落地），但**六條 lane 在 verify dispatch 全數以同一 deterministic 錯誤卡死**：`ValueError: workflow planning input drift`」
+  > 「`control/done` 連續 15+ 筆 request 同錯誤；resume / retry-verify（帶 expected_candidate payload）皆在同一檢查點復現，重試無效」
+  > 「1. **Builder 卡契約**…要求 builder 更新 `openspec/changes/<change>/tasks.md` 的 checkbox…實測 agy 與 copilot 兩種 executor 的 builder 都遵守——6/6 lane 的 build commit 均含 tasks.md tick。2. **Claim 凍結**…納入 `planning_authority`，並凍結 baseline sha256。3. **#219 reviewer authority-proving**…對 builder worktree 逐檔驗 baseline hash，不符即 raise。→ 只要 builder 遵守 (1)，(3) 必炸。任何 issue 都過不了 build→verify 邊界。」
+  > 「例：issue-105 `578fc308…→6a4cdb79…`，內容 diff 僅 checkbox tick」
+  > （#310）「run workflow-1b9d279908562fe8d926…build 三卡全 passed、candidate 7e765eb4，唯一 drift＝…tasks.md 的 checkbox 勾選 → verify 永遠派不出」
+- **oracle**：`#310` 修法逐字給出精確雙向：(a) builder 依卡片契約 tick 了 `tasks.md`／`todo.md`
+  的 checkbox（`- [ ]` → `- [x]`）→ verify dispatch **必須成功**；(b) 同檔的**任何非 checkbox
+  差異**（改動文字、增刪行、改動 frontmatter）→ **仍必須** fail-closed 為 planning input
+  drift。判準逐字：「對 authority kind=plan 且 basename 為 tasks.md／todo.md 的 ref 做
+  checkbox-insensitive 比對（`- [x]` 正規化為 `- [ ]` 後相等即放行）；其餘任何差異維持
+  fail-closed」。(c) **豁免不得外溢**：非 `tasks.md`／`todo.md` 的 authority 檔即使只差一個
+  checkbox 也必須 drift。
+  *fail-open 關鍵*：(b) 是全部價值所在——單做 (a) 等於把 `#219` 的 authority-proving 整道拆掉。
+- **harness_needs**：fs（operator_root 與 builder worktree 各一份 `tasks.md`，三種差異態）；
+  registry（`planning_authority` 含凍結 `baseline_sha256`）；git worktree；verify dispatch 可
+  單獨驅動。**不需模型**（builder 行為以 fixture commit 表示）。
+- **determinism_risk**：低（hash 與 diff 皆確定；需注意換行／BOM 造成 hash 差異）。真正的風險
+  是**修法路線**：issue 列三選一（豁免 kind=plan／build 後 re-baseline／build 卡禁動
+  `openspec/**`）。若採第三案，(a) 的前提「builder 會 tick」不再成立 → oracle 應改以不變式
+  表述：「**卡片契約要求的產出，不得被下一階段的 authority 檢查判為未授權漂移**」，並以
+  manifest 的 `commit_policy`／卡片 action 文字驅動。**此表述在三案下皆成立**。
+
+### 29. `non-build-phase-job-must-not-take-slice-gate-contract` ｜ hit_by: symptom·lifecycle（2 路）｜ oracle 型別: 雙向＋輔語料重放
+
+生命週期路標為「唯一由輔語料 artifact 獨立取證」，且是**唯一橫跨四個階段轉換邊界**的缺陷。
+
+- **source**：issue `#264`（closed 2026-07-30）＋ **輔語料實證**：
+  `/var/lib/cortex/legacy-imported/coordinator/handoff/*.json`（33 筆全量解析，兩路各自獨立
+  重跑並得到一致結果）。
+- **observed**（逐字）：
+  > （#264）「`~/.agents/coordinator/handoff/` 33 份 terminal manifest 中有 **30 份** 的 `gate_reason` 是 `missing-slice-proof`，而它們的 `exit_code` 全部是 **0**（工作本身成功結束）。」
+  > 根因：「`slice_row` 來自 `_slice_for_job()` / `_slice_for_reviewer_job()`…查的是 registry 的 **`slices`** 表…但 workflow lane 的 phase job **不註冊進 `slices`**…**這不是這些工作真的需要人裁決，而是把 slice lane 的 gate 契約套用在 workflow lane 的 job 上。**」
+  > （症狀路獨立重算）33 檔中 `('needs_human','missing-slice-proof')` = 30 且 `exit_code` 皆為 0；`('failed','builder-failed')` = 2（exit 137 與 1）；`('needs_human','pinned-input-mismatch')` = 1（exit 0）。樣本：`wf-16534fef9f-adversarial-review.json` / `wf-16534fef9f-code-review.json`，branch 皆為 `feature/87-porcelain-skeleton`（已交付合併）。
+  > （生命週期路獨立取證）`wf-3fa5c69448-policy-commit.json` 的 verdict 逐字為 `{'candidate': '0000000000000000000000000000000000000000', 'details': {'reason': 'builder exited without pinned slice verification contract'}, 'summary': 'missing-slice-proof'}`——**但 `policy-commit` 是 ship phase 的 manager 卡，該卡根本不存在 builder**。同型出現在 `writing-plans`(plan)、`verification`(verify)、`code-review`／`adversarial-review`(review)、`openspec-archive`(ship)，即**除 build 外的每一個 phase 都被套上了 build 語意的 gate 理由**，且 candidate 為全零 SHA
+- **oracle**：(a) 帶 `workflow_run_id`／`workflow_phase`／`workflow_card`／`workflow_claim_key`
+  的 job 收工時，即使 `registry.get_slice()` miss，**不得**打 `missing-slice-proof`，必須走
+  workflow-lane 的 gate 契約；(b) **負向**：真正的 slice-lane job（`slices` 表有 row、但 builder
+  未交出 pinned verification contract）**仍必須**打 `missing-slice-proof`；(c) 非 builder
+  persona 的卡（manager／reviewer，由 manifest 判定）產生的 verdict `details.reason` **不得含
+  `builder exited...` 字樣**；(d) verdict 的 candidate **不得為全零 SHA**。
+  *(b) 不可省*——原缺陷的第二層傷害是「同一個 reason 表達兩件完全不同的事」，只做 (a) 會把
+  真訊號一起刪掉。
+  *golden 強化*：**可直接用輔語料的 33 檔重放**——斷言重跑後 30 筆的判定改變、3 筆維持原判。
+  這比合成 fixture 強，因為期望值有兩個獨立來源（issue 敘事 ＋ 實體 artifact）。
+- **harness_needs**：fs 佈置（handoff manifest 目錄，可拷貝 33 檔匿名化版本）；registry 佈置
+  （`slices` 表空／有 row 兩態；`workflows` 表有 run）；harvest／completion sweep 可單獨驅動。
+  無 provider。
+- **determinism_risk**：低。輔語料為 `legacy-imported` 快照，schema 可能落後現行版本——case
+  應以 schema 版本欄位守門。job_id → slice_id 的推導規則若改變，fixture job_id 需同步。
+
+### 30. `doctor-and-tick-identity-loader-divergence` ｜ hit_by: symptom·subsystem（2 路）｜ oracle 型別: 差分／同源
+
+- **source**：issue `#509`（open）。
+- **observed**（逐字）：
+  > `ValueError: model-identities custom identity shadows packaged default: claude/sonnet（packaged roster v3 已收編此身分：請自 host overlay 移除該列，或改成與 packaged 逐欄相等）`
+  > `consecutive_tick_failures: 16`、`tick_circuit_open: true`，期間**完全無法 auto-claim 或派工**
+  > manager.log 顯示同一錯誤自 `2026-08-12T09:43` 起反覆出現（claude/sonnet 與 codex/gpt-5.3-codex-spark 交替），直到 2026-08-14 人工修正
+  > 「`cortex doctor` 當時**回報 model-identities PASS**（因為 doctor 走的驗證路徑與 tick 載入路徑不同），operator 依 doctor 判斷會誤以為健康。」
+- **oracle**：**差分斷言**——對同一個 config root，在會讓 tick 失敗的 overlay 狀態下，
+  `cortex doctor` 的 model-identities verdict **不得是 PASS**。強化版（建議採用）：斷言 doctor
+  與 tick 呼叫的是**同一個載入函式**（loader spy／呼叫計數），避免「doctor 另寫一份剛好也會紅
+  的檢查」這種假修復。附帶斷言 `tick_circuit_open=true` 時 `status`／digest 必須以顯著層級呈現。
+  *為何只取差分*：「shadowing 該降級還是該 fail-closed」是**尚未裁決的政策**（見
+  evidence-insufficient 15）；差分斷言**不論裁決往哪邊倒都成立**，因此不會固化錯誤期望。
+- **harness_needs**：fs 佈置 packaged roster ＋ host overlay 兩份 YAML；loader spy。
+- **determinism_risk**：低。packaged roster 版本會隨 release 變動——fixture 必須**釘住 roster
+  版本**而非依賴內建。
+
+### 31. `permgen-missing-parent-traverse-acl` ｜ hit_by: symptom·subsystem（2 路）｜ oracle 型別: 逐字元比對＋負向
+
+- **source**：issue `#620`（closed）／PR `#624`，Phase 2b 實機第 2 步。
+- **observed**（逐字）：
+  > ```
+  > $ sudo -u cortex-builder sh -c 'echo x > /var/lib/cortex/monitor/event-spool/probe.json'
+  > sh: 1: cannot create /var/lib/cortex/monitor/event-spool/probe.json: Permission denied
+  > $ sudo -u cortex-reviewer-planner mkdir /var/lib/cortex/coordinator/review-verdicts/probe
+  > mkdir: cannot create directory '/var/lib/cortex/coordinator': Permission denied
+  > ```
+  > 但**父目錄**是 `0700 cortex-manager:cortex-manager`：`drwx------ cortex-manager cortex-manager /var/lib/cortex/coordinator`
+  > 「POSIX 要求路徑上**每一層**都要有 `x`（search）位才走得到葉節點。」
+  > `--x` 而非 `r-x` 是重點：**只給 traverse，不給列目錄**（實測 `ls /var/lib/cortex/coordinator/evidence` 仍 Permission denied）
+  > 漏掉會讓整個降權部署看起來「裝好了但 job 全部失敗」，而失敗訊息（Permission denied on parent）指向的位置與真正缺的授權不同層，很難診斷
+- **oracle**：*tier 1（fs／純資料，CI 可跑）*：對每一條跨帳號葉節點 ACL，permgen 輸出中必須
+  存在該帳號在**路徑上每一個中間目錄**的 ACL 條目，且其權限位**恰為 `--x`**（字串相等，
+  **不得**是 `r-x` 或 `rX`）。雙向：既要「有」，也要「不是 r-x」。
+  *tier 2（實機，多 UID）*：套用後 (a) builder 寫 event-spool 成功、reviewer-planner 寫
+  verdict spool 成功；(b) **同樣條件下 `ls /var/lib/cortex/coordinator` 對兩個 job 帳號仍
+  Permission denied**。
+  *fail-open 關鍵*：只測 (a) → `chmod 0755 /var/lib/cortex/coordinator` 就會通過而把整個隔離
+  拆掉。(b) 是本 case 的一半。tier 1 的 `--x` vs `r-x` 斷言必須逐字元比對。
+- **harness_needs**：tier 1：產生器單獨呼叫、輸出解析。tier 2：多帳號 UID ＋ `acl` 檔案系統
+  ＋ root ＋ sudo。
+- **determinism_risk**：tier 1 低。tier 2 **高**：依賴 `setfacl` 存在、filesystem 掛載含 acl
+  選項、三個服務帳號存在——本 repo 已記錄部署陷阱（缺 acl）。**tier 2 缺件時必須標
+  `unsupported`，不得標 pass。**
+
+### 32. `preflight-checks-existence-not-effective-permission` ｜ hit_by: symptom·subsystem（2 路）｜ oracle 型別: 斷言「探測帶了身分」
+
+- **source**：issue `#657`（closed）／PR `#660`，實機四分部署。
+- **observed**（逐字）：
+  > ```
+  > $ sudo -u cortex-manager systemctl start 'cortex-gate-job@<inst>.service'
+  > $ journalctl -u 'cortex-gate-job@<inst>.service'
+  > cortex-job-shim: 讀不到 job spec /var/lib/cortex/coordinator/job-specs/<inst>.json:
+  >                  [Errno 13] Permission denied
+  > systemd[1]: Main process exited, code=exited, status=78/CONFIG
+  > ```
+  > 但登記表的 `job-spec-spool` 只授 **builder**：`setfacl -m u:cortex-builder:rX /var/lib/cortex/coordinator/job-specs`
+  > shim 是在 systemd 套完 `User=cortex-gate` **之後**才執行的（`ExecStart` 就是 shim），所以它以 gate 身分讀 spec ⇒ 必然被拒
+  > **為什麼 CI 綠**：同一族的老問題：測試環境是單 UID，spool 的 ACL 不影響任何事；`prepare_systemd_template()` 的 preflight 檢查的是**『spec 檔存在』而不是『該 job 身分讀得到』**。這是 #638／#630／#631 那條『綠燈不承載三分語意』的第四個實例
+- **oracle**：*tier 1（hermetic，主斷言，**單 UID CI 下也能跑**）*：(a) 斷言 preflight 以
+  **目標 principal** 為參數呼叫有效權限探測（注入 spy 斷言「呼叫時帶了 principal」且**不是**
+  `Path.exists()`）；可用一個 mode 0600 且 owner 非該身分的檔驗證：**檔案存在但 preflight
+  必須失敗**；(b) 對每一個降權 job principal，permgen 的 spool ACL 輸出必須含該 principal 的
+  `rX` 條目——**枚舉 `DOWNGRADED_JOB_PRINCIPALS` 全集**，不得硬編 builder 一個。
+  *tier 2（實機）*：每個降權 principal 讀得到**自己的** spec；跨 principal **讀不到**彼此的
+  spec（若裁決放棄則須在 spec 明載）。
+  *fail-open 關鍵*：`Path.exists()` 在單 UID 永遠真——這正是本 bug 逃過的機制。斷言必須落在
+  「**探測帶了身分**」而非「探測回真」。**tier 1 是本 case 最有價值的一項**，因為它把「綠燈
+  不承載語意」這個系統性缺口拉進可測範圍；若只寫 tier 2，case 在 CI 上永遠 skip，等於沒有。
+- **harness_needs**：tier 1：preflight spy ＋ principal 集合同源引用 ＋ fs 佈置（不同 owner／
+  mode 的 spec 檔）。tier 2：多 UID ＋ systemd ＋ root。
+- **determinism_risk**：tier 1 低，但**以 root 執行測試會全部可讀而假綠**——case 必須斷言
+  「非 root 執行」，root 下應標 `unsupported`。tier 2 高。
+
+### 33. `claim-provider-scope-github-only-work-item` ｜ hit_by: symptom·subsystem（2 路）｜ oracle 型別: 雙向
+
+- **source**：issue `#530`（closed）／PR `#531`／既有測試 `tests/test_claim_provider_scope_530.py`，
+  2026-08-14 帳號遭 abuse-detection 封鎖期間實測。
+- **observed**（逐字）：
+  > `$ cortex work start fix-instance-config-isolation --repo hamanpaul/paulsha-cortex --actor operator` → `錯誤: AuthorityValidationError: durable GitHub provider authority rate-limited (reason=provider-authority-rate-limited-canonical, repo=hamanpaul/paulsha-cortex, work_id=fix-instance-config-isolation, provider_id=github:hamanpaul/paulsha-cortex, field=status)`
+  > 而該 work item 的 sources 只有一筆，來自本機檔案系統 provider：`sources: [('todo', 'docs/superpowers/workstreams/fix-instance-config-isolation/todo.md', 'active')] provider: repo:hamanpaul/paulsha-cortex`
+  > **零個 GitHub 來源**
+  > 根因：`claim.py:546-594` 直接 `provider_id = f"github:{repo}"` 並要求其為 ok，「但接下來它**完全不看那些 source 由誰提供**」
+  > 三層放大：`claim.py:561-594` fail-closed／`monitor/lifecycle.py:reduce_lifecycle` 的 `provider_degraded_freeze`／`hard_gates.auto_claim`——「三層各擋一次，只修一層仍然卡死。」
+  > 形成「限流 → 無法派工 → 修不了限流」的死結
+- **oracle**：四條。(a) sources 全為 `repo:` provider 的 work item，在 `github:<repo>` provider
+  `status != ok` 時 **claim 必須成功**；(b) 掛有 `github_issue` source 的 work item，同樣
+  provider 狀態下 **必須 fail-closed 且 `reason_code == REASON_PROVIDER_RATE_LIMITED_CANONICAL`**；
+  (c) `reduce_lifecycle` 的 degraded 凍結同樣 scope 到相關 provider；(d) `hard_gates.auto_claim`
+  同理。
+  *fail-open 關鍵*：(b) 與 (a) 必須**成對**——只寫 (a) 會被「刪掉整段 provider 檢查」滿足，
+  而那正是 issue 明說不要的（「fail-closed 本身沒錯，錯的是適用範圍」）。且**必須三層都測**，
+  否則修一層仍卡死。
+- **harness_needs**：fs 佈置 snapshot（含 providers 區塊，可直接寫 `status: rate_limited`）
+  ＋ work-items.yaml ＋ todo.md；claim ／ lifecycle ／ hard_gates 三條路徑皆可單獨驅動。
+  不需真實 GitHub。
+- **determinism_risk**：低。需覆蓋 `status != ok`、`revision` 缺、`last_success_at` 缺三種
+  degraded 形態（程式碼是 or 條件）；provider 狀態欄位名若變動需同源引用。
+
+### 34. `claim-issue-only-work-item-topic-diagnostic` ｜ hit_by: subsystem·lifecycle（2 路）｜ oracle 型別: 三 reason_code 互異
+
+- **source**：issue `#389`（closed 2026-08-10）／PR `#437`／既有測試
+  `tests/test_claim_authority_topic_diagnostics_389.py`。
+- **observed**（逐字）：
+  > 「`.cortex/work-items.yaml` 已登錄 work item 並 link `github_issue`（confidence=confirmed、status=open），monitor correlation 已把 row 收進 `work-items.snapshot.json`。`cortex work intake <work-id> --repo <repo>` → `ValueError: confirmed work authority missing or ambiguous`。重跑、等 correlation 週期都無效——不是時序問題，是結構性不可能。」
+  > `todo_kinds = {"todo", "superpowers_spec", "superpowers_plan", "openspec"}`；`open_issue` 只能讓 work item 停在 `topic`
+  > `next_actions=("start",)` 只在 `state == "todo" and confidence == "confirmed"` 時投影
+  > `_authority_from_canonical_row`「`next_actions` 不含 `start` 且無 workflow source 的 row 直接 `return None`（靜默、不進 skipped diagnostics）」
+  > 錯誤訊息把「row 存在但 lifecycle 停在 topic」與「row 根本不存在」與「issue 被兩個 work item 認領」三種情況壓平成同一句話
+- **oracle**：三個獨立場景（row 不存在／row 存在但 lifecycle=topic／同一 issue 被兩個 work item
+  認領）必須回**三個互異的 `reason_code`**，斷言三者兩兩不等。**斷言在 `reason_code` 欄位上，
+  不得斷言訊息子字串。** topic 場景的診斷必須指名缺的是「active todo source」。加正向：備妥
+  workstream `todo.md` path link 後同一 row 必須 intake 成功（證明檢查不是恆拒）。
+  *fail-open 風險*：只斷言「raises ValueError」今天就會過；只斷言訊息含 "topic" 則任何一句話
+  塞進去都算過。
+- **harness_needs**：fs 佈置（`.cortex/work-items.yaml` ＋ `work-items.snapshot.json`）。
+  不需 mock provider（三場景可純由 snapshot 內容構造）、不需時間控制。
+- **determinism_risk**：低。**harness 必須直接佈置 snapshot 檔而非等待真實 correlation 週期**
+  （等待即 flaky）。`todo_kinds` 常數若被改，測試需同源引用而非硬編字串。
+
+### 35. `claim-rename-orphan-run-triple-deadlock` ｜ hit_by: subsystem·lifecycle（2 路）｜ oracle 型別: 三環構造＋爆炸半徑
+
+- **source**：issue `#410`（closed 2026-08-10）／PR `#412`、`#411`，孤兒 run `workflow-99cac69a`。
+- **observed**（逐字）：
+  > 「1. **孤兒 run 不可觸**：`abandon` 等一切 work action 需 `load_work_authority`，而 v2 的 yaml row 已被改名移除；canonical row 只剩 workflow_run sources，`_authority_from_canonical_row` 的「無 todo-kind source → return None」把 v2 靜默丟出 authority 集合 → `confirmed work authority missing or ambiguous`
+  > 2. **issue 認領相撞**：ongoing run 的 issue_refs 使 v2 仍認領 issue 374，與 v3 的 yaml link 相撞 → `repo` provider degraded：`confirmed source collision: github_issue:#374 -> ['v2','v3']`
+  > 3. **全域凍結**：provider degraded → lifecycle reducer 凍結所有 row → v3 永遠 topic、無 start、不可 claim
+  > 三環互鎖：解 3 需解 2，解 2 需 abandon 孤兒（解 1），解 1 需 v2 有 todo source——而改名恰恰移走了它」
+- **oracle**：構造完整三環（yaml row 改名移除 ＋ registry 留一個非終態 run ＋ 該 run 的
+  issue_refs 與新 row 相撞），然後：(a) `abandon --expected-run-id <run>` 必須成功（直接尋址
+  registry、不經 authority 載入）；成功後 collision 必須消失；**且新識別的 row 必須離開
+  `topic`、`next_actions` 含 `start`**；(b) **爆炸半徑**：single-source collision 導致 provider
+  degraded 時，**與該 collision 無關的其他 work item 仍必須可 claim**。
+  *(a) 的第三條與 (b) 都是關鍵*——只驗 abandon 回 0 會漏掉「凍結沒解開」；只測 (a) 會漏掉
+  原缺陷的真正傷害（全域凍結）。
+- **harness_needs**：fs 佈置（`.cortex/work-items.yaml` 改名前後兩態 ＋ registry jobs.json ＋
+  monitor snapshot）；registry 的非終態 run 狀態構造能力。不需真 GitHub（collision 由 snapshot
+  內容構造）。
+- **determinism_risk**：中。三個子系統的狀態要同時擺對，順序依賴明顯。**provider degraded 狀態
+  的傳播需經 monitor snapshot，時序敏感 → harness 必須直接注入 degraded 快照。** lifecycle
+  reducer 的凍結語意若改（例如改成只凍結受影響 row，見候選 64）本 case 的第三條斷言需重寫。
+
+### 36. `deck-verification-block-must-derive-from-project-policy` ｜ hit_by: subsystem·lifecycle（2 路）｜ oracle 型別: 來源對應三等式
+
+- **source**：issue `#380`（closed）／PR `#423`（merged）。
+- **observed**（逐字）：
+  > 對 `hamanpaul/embedebuguide`（測試指令是 `make test` ＝ `python3 -m unittest discover -s tests`，**repo 內無 pytest**）執行 …… 產出的 `*-build.md` frontmatter：
+  > ```yaml
+  > verification:
+  >   checks:
+  >     - kind: "command"
+  >       name: "policy"                                    # ← 名為 policy
+  >       argv: ["python3", "-m", "pytest", "-q"]           # ← 實際跑 pytest
+  >       timeout_seconds: 30
+  >   tests:
+  >     - argv: ["python3", "-m", "pytest", "-q"]
+  >   full_suite:
+  >     argv: ["python3", "-m", "pytest", "-q"]
+  > ```
+  > 三個位置全是同一條 pytest。其中 `name: "policy"` 的 check **語意上是政策檢查，argv 卻是 pytest**——這不只是預設值不合用，是名稱與內容不一致
+  > timeout 30/60 秒對任何真實 repo 的全測試也不現實（本 repo `make test` 約 200 秒）
+  > 本輪三個 slice 全部要手改……上一批（2026-08-07 UX 修復，6 個 slice）也是同樣手改六次
+  > 2026-08-10 複驗留言：「current `main` 的 `_verification_skeleton()` 仍可直接看到三處硬編碼 `python3 -m pytest -q`，其中 `checks[].name == "policy"` 但 argv 實際是 pytest，名實不符仍在。」
+- **oracle**：對一個 `.project-policy.yml` 宣告 `preflight.steps` 含 `policy` 與 `tests` 兩個
+  不同 argv 的 repo 編譯，斷言**三個位置各自等於其對應的 policy step argv**（三條獨立等式，
+  不是一條）；特別斷言 `checks[name=policy].argv != tests[].argv`（此即原 bug 的簽名——三處
+  相同）。加：對**未**宣告 project policy 的 repo，**不得憑空填入一個測試框架**。
+  *fail-open 風險*：斷言「argv 不是 pytest」→ 換成別的硬編值照樣過。必須驗**來源對應**。
+  「允許猜一個看似合理的指令」就是製造假綠燈的機制本身。
+- **harness_needs**：fs 佈置 `.project-policy.yml` ＋ plan；`cortex deck compile` CLI。
+  無模型、無網路。
+- **determinism_risk**：低—中。「未宣告時該怎麼辦」有兩種可能實作（fail-fast vs 產出
+  `dispatch: hold`／`verification_incomplete`）——oracle 表述為「**不得填入具體測試框架 argv**」
+  可涵蓋兩者。**verification 完整性（acceptance surface 權威來源）不進本 case**（見
+  evidence-insufficient 14）。
+
+### 37. `evidence-claim-combo-must-attach-adversarial-review-card` ｜ hit_by: subsystem·lifecycle（2 路）｜ oracle 型別: 差分（band=green）
+
+- **source**：issue `#378`（closed）／PR `#431`（merged）；佐證 artifact：
+  `paulsha_cortex/deck/data/combos/mcu-feature.yaml`。
+- **observed**（逐字）：
+  > builder 可以產出一份**兩條對照臂共用狀態、差異由 setup 順序製造而非由被測性質產生**的 demo，寫出一個看似正確的 `verdict`，而 cortex 的 verification gate（persona-scope + spec 宣告的 tests/full_suite/checks）**沒有任何一道會發現**——因為程式跑得起來、測試全綠、政策全過，只有「證據本身不成立」。2026-08-07 對 `hamanpaul/embedebuguide` 派工 issue #47 時實際發生，4 支 probe 中 2 支如此。
+  > case2：`reader.start(); writer.start(); writer.join(); reader.join()` … `naive_fd = os.open(slave_path, ...)   # ← 同一個 PTY`。provider 臂已經把 PTY 讀空，naive 臂當然拿到 0 bytes。實測反證：`burst 總行數 = 200` ／ `provider 臂（常駐） = 200` ／ `naive 臂（0.5s 輪詢）= 200` ／ `verdict = no-difference`
+  > case4：naive 臂 `def _naive_actor(...): time.sleep(hold_seconds)   # ← 全部行為就這樣`；「「兩個 `sleep(0.2)` 的時間區間有重疊」被當成「兩個 actor 爭用同一個 debug probe」的證據。沒有 PTY、沒有檔案、沒有任何共享資源。`overlap_seconds > 0` 是必然成立的恆真式。」
+  > 落地佐證（讀 `mcu-feature.yaml` 原文）：「adversarial-review 直接落在核心層（combo.cards / combo.gate_spine），不透過 band_triggered 加掛層…evidence-claim 類 slice 不論 band 評估結果都要對抗式檢視 rigged setup，不能像 feature-oneshot 的 band_triggered 加掛層那樣被 Green band 跳過。」
+- **oracle**：**只取 deck 層可機械判定的部分**。(a) 任何 evidence-claim 類 combo（現為
+  `mcu-feature`）的 `combo.cards` 必須含 `adversarial-review`，且該卡**不得**出現在
+  `band_triggered.cards` 下；(b) `combo.gate_spine` 必須含 `after: adversarial-review` 的
+  exists 條目；(c) **反 fail-open 關鍵**：以 band=green 編譯該 combo，斷言 `adversarial-review`
+  **仍在** compile 結果的 `acceptance_surfaces` 中，而 `feature-oneshot` 在 band=green 下則應
+  **不含**——**差分斷言**，防止「兩個 combo 都被跳過」的假綠；(d) 缺該卡的 combo 定義必須在
+  compile／verify 階段被拒（`deck verify` 回非零）。
+  *明確的範圍限制*：「**這份 evidence 是不是 rigged**」**不進本 case**（見
+  evidence-insufficient 1）。**case 註解必須寫明本 case 只保證「對抗式檢視卡有被掛上」，不保證
+  該卡真能偵測出 rigged setup**，否則會被誤讀為「rigged setup 已被擋住」。
+- **harness_needs**：fs 佈置 combo 定義 ＋ task 描述；`compile_combo` 可傳入 band；
+  `deck verify`／`selector`。無模型。
+- **determinism_risk**：低—中。`task_type` 的判定若含啟發式（`deck/task_types.py`），輸入描述
+  的措辭會影響選型 → case 應**直接指定 task_type，不走自然語言推斷**。
+
+### 38. `deterministic-pass-must-verify-declared-outputs` ｜ hit_by: lifecycle·artifact（2 路）｜ oracle 型別: 通用不變式參數化 ★
+
+- **source**：issue `#414`（closed 2026-08-11），run `workflow-e18785acc54e5ad87836`
+  （「首個通過 define 的 run」）＋ **artifact 路實測**：388 個 workflow evidence 逐筆比對
+  `artifacts[].baseline_sha256` vs `artifacts[].sha256`。
+- **observed**（逐字）：
+  > （#414）「define（brainstorm 三棒）✓ → plan 卡被 `cortex-manager/deterministic` 標 passed → build 派工失敗：`ValueError: workflow declared input missing: docs/superpowers/plans/*fix-log-error-dedup-v3*.md`，run 掛 needs_human、無 job 產生。」
+  > 根因：「`assess_planning_completeness` 把 workstream todo（`docs/superpowers/workstreams/<slug>/todo.md`，kind=plan、accepted）視為 plan 已存在 → planning-complete → plan 卡（writing-plans-light）被 deterministic pass。但該卡宣告的 outputs 是 `docs/superpowers/plans/*<slug>*.md`——todo 路徑不符合此 pattern，canonical plan 檔從未產出。」
+  > **不對稱性**：「build 派工會驗證宣告 inputs 存在，但卡片被 deterministic pass 時沒有任何人驗證其宣告 outputs 已滿足——「跳過」隱含「產物已在」的假設從未被檢查。」
+  > 影響：「todo 錨定＋small-fix combo 的所有 work item（本批 14 個全中）在 define 通過後必卡 build」
+  > （artifact 路實測）全庫 388 筆中，**2 筆的所有宣告 artifact 都與 baseline 位元組完全相同**——而這 2 筆**正好就是全部的 `kind == "plan"` evidence**：
+  > ‧ `bc681efd892b`：job `wf-854f00a416-writing-plans-58`、card `writing-plans`、`status: "passed"`、`artifacts[0] = {"path": "docs/superpowers/plans/add-cortex-version-flag.md", "baseline_sha256": "7de11792132f2f370232ea9598c6841e1bc969789d6de16d252c9183708bc610", "sha256": "7de11792132f2f370232ea9598c6841e1bc969789d6de16d252c9183708bc610"}`
+  > ‧ `f9dc691031a1`：job `wf-3fa5c69448-writing-plans-3`、`docs/superpowers/plans/terminal-lifecycle-canary.md`，同樣 baseline == sha256。
+  > 即：`writing-plans` 卡以 `passed` 落盤，但宣告的產出檔一個位元組也沒動。
+- **oracle**：**通用不變式，對每張卡參數化**（`#414` 修法 1 明言此原則適用任何未來的
+  deterministic pass 點）：任何被標 passed 的卡，其 manifest 宣告的 `outputs` glob 必須在
+  workspace 有命中；不滿足即不得標 passed。以 `workflow-manifests` 的卡片集合驅動——新增
+  deterministic pass 點而漏驗 outputs 即紅。
+  **artifact 路的加強版**：宣告 `outputs` 的卡片若回報 `passed`，至少一個 artifact 的 `sha256`
+  必須 `!=` 其 `baseline_sha256`；全部相同則判為 no-op 並 fail（或明示 `skipped-unchanged`）。
+  *fail-open 關鍵*：`baseline_sha256` 為 `null` 時（新檔）要視為「有變更」而非跳過——現行
+  review／verify evidence 的 baseline 多為 null，若 oracle 寫成 `if baseline is None: continue`
+  會**漏掉真正的 no-op**。負向：outputs 已滿足時**不得**重複派工（否則會退回候選 45）。
+- **harness_needs**：fs（todo.md 存在、`plans/*.md` 不存在）；registry；manifest 佈置；
+  mock provider（讓 writing-plans 不做任何修改就回 passed）。無需模型。
+- **determinism_risk**：低。若實作選了修法 2（completeness 對 plan kind 收窄，強制
+  writing-plans 一律執行），本 case 的正向分支形狀會變，但**不變式本身仍成立且非空**。
+
+### 39. `doctor-probe-env-sampling-source-mismatch` ｜ hit_by: symptom·subsystem（2 路）｜ oracle 型別: 雙向
+
+- **source**：issue `#548`（open），0815 `#541` 部署後。
+- **observed**（逐字）：
+  > 實測（0815，#541 部署後）：manager 行程環境確認含 `PSC_GATE_CMD_PYTEST=python3 -m pytest -q`（`/proc/<pid>/environ` 驗證），但 operator shell 直接跑 `cortex doctor` 的 `gate-declarations` probe 回報 `declared: []` → required FAIL
+  > probe 判準正確、部署也正確，錯在取樣來源：doctor 以呼叫端 shell 的 effective env 為準，沒有載入 service unit 的 EnvironmentFile（`~/.agents/core/runtime/cortex-manager.env`）
+  > 「**任何 env 依賴的 probe……在 operator shell 語境都會對健康部署喊狼來了；反過來，shell 有宣告、service 沒有時 doctor 會假 PASS——兩個方向都失真。**」
+- **oracle**：**雙向**。(a) service EnvironmentFile 有宣告、呼叫端 shell 沒有 → probe 必須
+  **PASS**，且報告必須標示取樣來源為 service；(b) 呼叫端 shell 有宣告、service 沒有 → probe
+  必須 **FAIL**。
+  *fail-open 關鍵*：**(b) 絕不可省**——只寫 (a) 的話，「讀 shell 與 service 的聯集」這個錯誤
+  修法會通過，而它保留了假 PASS（更危險的那個方向）。
+- **harness_needs**：fs 佈置（假的 service unit ＋ EnvironmentFile）；環境變數完全隔離
+  （`conftest.py` 的 `_clear_runtime_env` 可沿用）；doctor probe 可單獨呼叫。若走
+  `/proc/<MainPID>/environ` 路徑則需要一個可控的長駐子行程。
+- **determinism_risk**：中。`/proc` 路徑為 Linux-only；EnvironmentFile 解析路徑需覆蓋**含空格
+  的值**（`#633` 已記錄同族慣用法在含空格值上拆壞）。建議 oracle **只約束「結論」與「報告的
+  取樣來源標示」，不約束取樣手段**。
+
+### 40. `build-prompt-must-anchor-resolved-worktree` ｜ hit_by: subsystem·lifecycle（2 路）｜ oracle 型別: 逐字相等＋順序證明
+
+- **source**：issue `#477`（open），paulsha-cortex 0.1.8 (`dc8a968`)。
+- **observed**（逐字）：
+  > `build_dispatch_prompt()` 只 emit：`請於本 worktree 內讀取上述 plan 並依 persona 契約邊界執行。`
+  > init cwd: feature worktree／first repeated target: base checkout `.gitignore`／later repeated target: base checkout `tests/test_led_rgbw_static.py`／no file changes and no candidate commit
+  > The sandbox returns `Path is outside allowed working directories`. The builder repeats the denied read instead of switching to its cwd.
+  > usage before termination: more than one million input tokens
+  > after bounded operator termination, Cortex classified the slice as `builder-failed-unknown`
+  > `autonomy.py` builds this prompt **before** the per-slice dispatcher resolves/creates the worktree, so the resolved path cannot currently be included.
+- **oracle**：全部在 prompt 組裝面（不跑模型）。(a) prompt 逐字含 `creator.create()` 實際回傳
+  的絕對路徑——斷言 `resolved_path in prompt` **且** `resolved_path == creator 回傳值`
+  （**後者才證明順序修正，前者可被硬編路徑假綠**）；(b) prompt 含明示排除 base checkout 的
+  語句；(c) **邊界**：worktree 路徑含空白與 shell 特殊字元時，prompt 中的路徑未被 shell 插值
+  破壞（比對 argv 而非 shell 字串）。負向：sandbox 行為不得改變（仍 fail-closed 拒絕 base
+  checkout 存取）。
+  *fail-open 風險*：斷言「prompt 非空」或「含 worktree 字樣」——現況就會過。
+  *硬性前置*：**case 必須走真實的 autonomy→dispatcher 路徑**，不能直接呼叫
+  `build_dispatch_prompt` 餵一個手工路徑，否則會複製 `#645` 那個「手工 spec 繞過 bug」的錯誤。
+- **harness_needs**：fs 佈置（假 repo ＋ worktree，`tests/git_fixtures.py::make_fake_repo` /
+  `StubWorktreeCreator` 可用；路徑須含空白／`$`／引號）；mock provider 捕捉 prompt；worktree
+  creator seam。不需模型、不需網路。
+- **determinism_risk**：低（純字串組裝）。若實作選「launcher 在執行前 append resolved root」
+  而非「prompt 組裝後移」，(a) 的第二個斷言需改為對 **launcher 最終送出的 prompt** 取樣。
+  **「終止行為」不在本 case**（見 evidence-insufficient 6）。
+
+### 41. `review-tier-prerequisite-fails-after-all-work-spent` ｜ hit_by: subsystem（1 路）｜ oracle 型別: 零 builder job 計數
+
+- **source**：issue `#492`（open）。
+- **observed**（逐字）：
+  > ```text
+  > foreign-review-config-error:unsupported project tier: None
+  > ```
+  > The canonical `.project-policy.yml` was a valid mapping with `policy_profile`, `policy_version`, and `preflight.steps`, but no `tier`
+  > `coordinator.review.read_repo_tier()` defaults to `shareable` only when no policy manifest exists. Once a manifest exists, it reads `payload.get("tier")` and rejects `None`
+  > The deck/readiness/preflight path does not surface that review prerequisite before spending the builder and verification work
+- **oracle**：四 fixture（無 manifest／有 manifest 無 tier／invalid tier／valid `shareable`）。
+  對中間兩者：診斷必須在 **builder dispatch 之前**出現——斷言 registry 內**零個 builder job
+  被建立**；且診斷文字必須指名所選 manifest 路徑與允許值 `shareable, work, personal`。
+  *fail-open 風險*：只驗「最後會失敗」→ 現況就會失敗，只是失敗得太晚。**「零 builder job」
+  那條才是本 case 的本體。**
+- **harness_needs**：fs 佈置四份 policy yaml；registry 的 job 計數斷言。不需真 builder。
+- **determinism_risk**：低。
+
+### 42. `verify-persona-scope-vacuous-under-broad-write-paths` ｜ hit_by: subsystem（1 路）｜ oracle 型別: 雙向＋標籤語意鎖
+
+- **source**：issue `#489`（open）。
+- **observed**（逐字）：
+  > A builder slice whose plan explicitly limited files to `.project-policy.yml`, `.gitignore`, and `tests/test_deliver_gate.py` committed an extra `changelog.d/2026-08-12-schema-validator.md`
+  > Candidate verification recorded all four paths in `details.scope.changed_paths`, yet returned：`scope.status: passed` / `scope.violations: []` / overall `verification-succeeded`
+  > The packaged builder persona has `write_paths: ["**"]`, so every repository path passes
+  > `scope.status: passed` overstates what was checked
+- **oracle**：issue 逐字給了配方——「builder `write_paths: ["**"]`, slice paths `src/a.py`,
+  and candidate paths `src/a.py` plus `docs/extra.md`; verification must fail on the extra path」。
+  **加第二條**：slice 無路徑契約時，evidence 標籤必須是 `persona-only`／`partial`，**不得**是
+  裸 `passed`。
+  *fail-open 風險*：只做第一條 → 一個「無契約就一律 pass」的實作照樣讓 `scope.status: passed`
+  名不副實。**第二條把「檢查的語意」也鎖住。**
+- **harness_needs**：fs 佈置 git repo ＋ candidate commit（`tests/git_fixtures.py` 可用）；
+  persona 契約 fixture。
+- **determinism_risk**：低。`changed_paths` 由 git diff 導出，確定性高。
+
+### 43. `declared-next-action-always-rejected` ｜ hit_by: symptom（1 路）｜ oracle 型別: 狀態空間窮舉 property
+
+- **source**：issue `#382`（closed），三個 slice 同時命中（embedebuguide 派工）。
+- **observed**（逐字）：
+  > `allowed_slice_actions()`（`manager.py:446-448`）**只看 `state`**，但 `Registry.repin_slice()`（`registry.py:1039-1049`）有**兩道**閘門，閘門 1 `if str(slice_row["state"]) not in {"pending","needs_human"}` 就把 `state=="failed"` 擋掉。實測：
+  > `$ cortex slice-action runtime-evidence-cases-closes-47-build retry-build --actor claude` → `錯誤: DispatchReadyError: ... (ValueError: 非法 slice state repin: 'failed'（只允許 pending/needs_human 重派）)`
+  > 同時 `cortex status` 回報 `state=failed  next_actions=['retry-build','recover-pre-candidate','abandon']`
+  > 再者兩張轉換表不對稱：`SLICE_STATE_TRANSITIONS["failed"] = {"failed","pending","needs_human"}` 但 `GATE_STATE_TRANSITIONS["failed"] = {"failed","needs_human"}`，導致救回後 `state=pending  gate=failed  next=[]`——「**這個組合沒有任何出口。**」
+- **oracle**：**雙向不變式（property test，非單點）**：對狀態空間中每一個可達的
+  `(state, gate_state)` 組合，斷言 `allowed_slice_actions()` 回傳的每一個動作**實際執行後不得
+  拋 ValueError**（動作可回「無效果」但不得拒絕）；以及**不存在 `next_actions == []` 且非終局
+  的 `(state, gate_state)` 組合**。
+  *fail-open 關鍵*：不可寫成「`failed` 時 `retry-build` 應被拒」——那是把當前 bug 固化；也不可
+  只測 issue 舉的三個組合，**要對兩張轉換表做窮舉交叉**。
+- **harness_needs**：registry 狀態可直接佈置（不經真實派工）；動作執行 seam；窮舉驅動。
+- **determinism_risk**：低。純狀態機。轉換表未來擴充時 case 需同步——**這反而是優點**（case
+  會逼人更新）。
+
+### 44. `plan-materialized-authority-reconciliation` ｜ hit_by: lifecycle（1 路）｜ oracle 型別: 雙向＋第三條件
+
+- **source**：issue `#418`（closed 2026-08-11），run `workflow-24e66842db09921e92e1`。
+- **observed**（逐字）：
+  > 「plan materialize（#414）產出 canonical plan 檔並登記為 planning_authority，但 build 前 resume 掛 needs_human：`reason: planning-authority-reconciliation-failed`。隔離重現：`_validated_brainstorm_planning_authority` raise `workflow brainstorm evidence omits persisted authority`（manager.py:2528）。」
+  > 根因：「`_validated_brainstorm_planning_authority` 以 brainstorm evidence 為權威真值重算 `scanned`，末尾 `if set(persisted) - set(scanned): raise "omits persisted authority"`。materialized plan 不在 brainstorm evidence → 差集非空 → raise。」
+  > **簽名**：「materialized plan 與 todo.md 的 `baseline_sha256` **逐位元組相同**（materialize 是 byte-copy），kind 同為 plan，ref 匹配宣告的 plan-phase output pattern——即「合法的 materialized 副本」簽名明確。」
+- **oracle**：雙向（issue 修法逐字要求「其餘真正的 omission 維持 fail-closed」）：(a) persisted
+  中某 entry 滿足三條件（`kind == plan`、`baseline_sha256` 等於某 scanned plan entry 的 digest、
+  ref 匹配 `docs/superpowers/plans/*<slug>*.md`）→ 不 raise，**且該 entry 必須留在回傳的
+  authority tuple**（斷言它有 seed 進 build worktree——只斷言「不 raise」會漏掉這半，導致 build
+  inputs 又缺）；(b) persisted 有一個 scanned 沒有**且 digest 不匹配任何 scanned entry** →
+  **仍必須 raise**；(c) digest 相同但 ref **不**匹配 plan-phase pattern 的 entry **仍必須 raise**
+  （防實作只放寬其中兩條）。
+- **harness_needs**：fs（brainstorm evidence JSON、todo.md、materialized plan 兩份 byte-identical
+  檔）；registry（`run.planning_authority`）。無需模型。
+- **determinism_risk**：低。
+
+### 45. `plan-card-deterministic-pass-when-complete` ｜ hit_by: lifecycle（1 路）｜ oracle 型別: job 計數不變
+
+- **source**：issue `#128`（closed 2026-07-22），run `workflow-a864f07cb5615440fd73`。
+- **observed**（逐字）：
+  > 「define 階段對「規劃產物已完備」有決定性通過路徑（planning-complete，attribution=manager/deterministic），但 **plan 階段（writing-plans 卡）無對應路徑**——即使 accepted 的 plan 文件已存在且在 define 的 completeness 評估中通過，仍派 planner executor 去「執行」一張橡皮章卡。實測兩個 planner 都不可靠：agy headless（jetski）權限自動拒絕恆空輸出；claude plan-mode 對 workflow-card 契約漂移（不輸出 terminal JSON，jobs 130–137 七連敗）。malformed-retry 使其無限重派燒額度，且 registry 恆有 active job 令 `work abandon` 被拒」
+- **oracle**：issue 修法 3 逐字給出雙向：(a) plan 卡 ＋ 完備產物 → **不產生 job**（斷言
+  registry job 數不變）、step 標 passed 且 attribution 為
+  `executor=cortex-manager, model=deterministic`、phase 推進至 build；(b) 產物不完備 → **照舊
+  派工**（斷言確實產生 job）；(c) claim 的 planning-complete 路徑行為不變。
+  *(a) 中「不產生 job」是關鍵斷言*——只斷言「step passed」會被「派工成功且模型剛好回對」假綠。
+- **harness_needs**：fs（plan 產物存在／不存在兩態）；registry（job 計數）；mock provider
+  （(b) 分支需可派工）。
+- **determinism_risk**：低。**但本 case 與候選 38（`#414`）互為約束**：`#128` 引入
+  deterministic pass，`#414` 揭露它不驗 outputs——**兩條必須同時存在於套件**，只留 `#128`
+  會固化一個已知有害的行為。
+
+### 46. `dispatch-retry-build-loses-launcher-factory` ｜ hit_by: subsystem（1 路）｜ oracle 型別: 三條＋狀態不得被抹
+
+- **source**：issue `#479`（open）。
+- **observed**（逐字）：
+  > `DispatchReadyError ... ValueError: slice <id> declares executor/model_id but launcher_factory is unavailable`
+  > The action did not launch a job. It also rewrote the slice to `needs_human` with `missing-slice-proof` and cleared the builder/candidate fields, requiring an additional recovery action.
+  > `manager_daemon.py` constructs identity registries and launcher factories for normal fan-out paths, but its `slice-action` call to `manager.apply_slice_action()` passes only a resolved single launcher.
+- **oracle**：三條。(1) 對宣告 `executor: claude` / `model_id: <registered>` 的 slice，
+  `retry-build` 必須建立新 job 且該 job 記錄的 executor／model **逐欄等於 spec 宣告**；
+  (2) 未註冊身分仍 fail-closed；(3) **dispatch setup 失敗時，slice 的 builder／candidate 欄位
+  必須不變、reason 不得被換成 `missing-slice-proof`**。
+  *(3) 是防 fail-open 的核心*——沒有它，一個「失敗時把狀態抹掉」的實作照樣過 (1)(2)。
+- **harness_needs**：fs 佈置 registry ＋ spec；mock launcher factory（驗記錄值而非真啟動）；
+  需涵蓋 **coordinator CLI 與 porcelain/control-request 兩條路徑**（issue 明列）。
+- **determinism_risk**：中。兩條入口路徑的參數傳遞順序是本 bug 的本質 → **只測其中一條會漏**。
+
+### 47. `dispatch-codex-ambient-reasoning-effort-leak` ｜ hit_by: subsystem（1 路）｜ oracle 型別: argv 值域
+
+- **source**：issue `#483`（open）。
+- **observed**（逐字）：
+  > ambient `~/.codex/config.toml`: `model_reasoning_effort = "max"`；reviewer identity: `codex/gpt-5.3-codex-spark`
+  > The job starts and exits 1 before producing a verdict. Its JSONL log reports that `max` is unsupported for the resolved model and that supported values stop at `xhigh`.
+  > ```python
+  > if model is not None:
+  >     argv += ["--model", model]
+  > ```
+  > Codex therefore combines the Cortex-selected model with an ambient effort value that belongs to a different model.
+- **oracle**：在 ambient config 宣告不相容 effort 的情況下，emitted argv 必須**顯式帶上一個與
+  所選 model 相容的 effort**（斷言 argv 內確有該旗標且值在該 model 的支援集合內）；且不相容
+  組合必須以 **typed preflight/launch error** 呈現——斷言 slice 的 reason **不是**
+  `foreign-review-absent`。
+  *fail-open 風險*：只驗「job 沒炸」；本 issue 的傷害就是失敗被歸類成一般的 reviewer 缺席。
+- **harness_needs**：fs 佈置假 `~/.codex/config.toml`（**需 HOME 隔離**）；argv 捕捉。
+  不需真 codex CLI。
+- **determinism_risk**：中。「該 model 支援哪些 effort」是**外部 CLI 的版本相依事實**（觀測值
+  來自 Codex CLI 0.147.0）。**case 必須把支援集合當成注入的 fixture，不得向真 CLI 查詢**，
+  否則升版即紅。
+
+### 48. `define-planning-config-inheritance-hermetic` ｜ hit_by: lifecycle（1 路）｜ oracle 型別: 四項機械可判 argv／env／mode
+
+- **source**：issue `#404`（closed 2026-08-10），run `workflow-4e8b746a50deee6bc070`。
+  **define 八環攻關鏈第六環。**
+- **observed**（逐字）：
+  > reason：「`planning launcher result is not JSON: **Using superpowers 相關記憶** 指出：completeness report 若含 default_question_pack，應原樣回傳，不需重新產生問題。讓我先讀取記憶全文確認格式細節。`」
+  > 實測矩陣五列：「現行（繼承配置＋plan 模式）→ 散文敘事，validation FAIL」「`--bare` → 連 OAuth 憑證鏈一起跳過 → Not logged in」「hermetic `CLAUDE_CONFIG_DIR`（空）→ Not logged in」「hermetic＋credentials＋plan 模式 → 模型自述 plan 模式義務，拒回 JSON」「**hermetic＋credentials＋default 模式＋`--tools ""`** → **VALIDATION PASS**」
+- **oracle**：**全部在呼叫面斷言，完全不觸及模型輸出**（這正是本 case 的價值：把「模型會不會
+  照做」轉成確定性的 argv／env 契約）：(a) 組出的 argv **不含** `--permission-mode plan`；
+  (b) runner 收到的 env 含 `CLAUDE_CONFIG_DIR` 且其值**不是** `~/.claude`、是 temp 目錄下的
+  路徑；(c) 該目錄下 `.credentials.json` 存在且 `stat().st_mode & 0o777 == 0o600`；(d) argv
+  含 `--tools ""`。四項皆為機械可判。
+- **harness_needs**：mock provider（捕捉 argv ＋ env ＋ cwd，不執行）；**真實 fs**（(c) 的權限
+  位元不能用 memfs 假造）；temp 目錄生命週期。
+- **determinism_risk**：低。`~/.claude` 若在測試機不存在，(b) 的斷言仍成立但語意變弱 →
+  建議同時斷言路徑落在 `tempfile.gettempdir()` 之下。**codex 路徑的等價物 `CODEX_HOME` 不要
+  一併斷言**（issue 列為「後續觀察項，不在本票」，一併斷言就是編期望）。
+
+### 49. `claim-combo-override-not-frozen-on-resume` ｜ hit_by: lifecycle（1 路）｜ oracle 型別: 前置斷言防僥倖
+
+- **source**：issue `#390`（closed 2026-08-10），run `workflow-6569c45012d9c2b84db9`。
+- **observed**（逐字）：
+  > 「`cortex work intake fix-log-error-dedup --combo small-fix` claim 成功，manifest 落盤（combo=small-fix）。define 失敗掛 needs_human 後，`cortex work resume`（帶或不帶 `--combo`）一律：`RuntimeError: canonical workflow manifest conflicts with persisted claim`（work_bridge.py:278 `_write_manifest` byte 比對）。實測以 combo=small-fix 重生 manifest 與落盤檔 **byte-identical**——衝突不是內容漂移，是 resume 用了別的 combo。」
+  > 「同函式上方對 `model_chain_override` 有明確的凍結處理（#205 R2）…**combo_override 漏了同等待遇**」
+- **oracle**：claim 帶 `--combo small-fix` → resume 不帶 → 斷言 (a) 不 raise，(b)
+  `run.combo == "small-fix"`。
+  **反 fail-open 的關鍵**：issue 原文自陳「auto-selection 結果與 override 恰好相同時例外，
+  純屬僥倖」——因此 fixture 的 issue 標題必須被刻意選成「auto-selection 會選出
+  `feature-oneshot`」，並在測試中**先斷言 `select_combo(titles, override=None) != "small-fix"`**。
+  少了這個前置斷言，本 case 會在 auto-selection 剛好命中時**永久假綠**。
+- **harness_needs**：fs（manifest 落盤路徑）；registry 佈置 existing_run；taxonomy 佈置。
+  無需模型。
+- **determinism_risk**：`select_combo` 的 taxonomy 對映日後改版 → 前置斷言可能翻面
+  （**這正是前置斷言存在的理由**：翻面時測試該紅，而不是靜默假綠）。
+
+### 50. `deck-emit-must-print-the-path-that-ready-reads` ｜ hit_by: subsystem（1 路）｜ oracle 型別: 差分（兩 CLI resolve 相等）
+
+- **source**：issue `#474`（open）第 2 項。
+- **observed**（逐字）：
+  > `--emit` 成功時**沒有任何輸出指出寫入路徑**。`--help` 只說「寫入預設 specs 目錄」，而該目錄由 `PSC_MANAGER_SPECS_DIR → paths.specs_root()（吃 PSC_SPECS_ROOT/PSC_AGENTS_ROOT）` 決定——這條鏈在 CLI 層完全不可見
+  > 我因此誤判成「什麼都沒寫」：repo 內 `git status` 沒新檔、`find` 也沒抓到。實際上它寫進了 `~/.agents/specs/`，是第二次執行時的「emit 目標已存在同名 spec（--force 才覆蓋）」才反推出來的
+  > `cortex ready` 又強制要 `--specs-dir`（無預設），所以使用者無法用 CLI 問出「剛才寫到哪」
+- **oracle**：**差分**——`deck compile --emit` 的輸出必須含每個寫入檔的絕對路徑；且該路徑所在
+  目錄必須**等於** `cortex ready` 在無 `--specs-dir` 時會讀的目錄（斷言兩者 resolve 後相等）。
+  *fail-open 風險*：只斷言「有印出一個路徑」→ 印出一個 ready 讀不到的路徑照樣過，而使用者的
+  困境原封不動。**差分那條是本 case 的本體。**
+- **harness_needs**：fs 佈置 ＋ 環境變數控制（`PSC_SPECS_ROOT`／`PSC_AGENTS_ROOT`）；兩個 CLI
+  的路徑解析。
+- **determinism_risk**：低—中。**環境變數敏感**（本 case 本身就是關於環境變數鏈）→ harness
+  必須完全清空並顯式設定，`tests/conftest.py` 已有 `_clear_runtime_env` 清 `PSC_*` 的慣例可沿用。
+- **附註**：`#474` 第 1 項（`.project-policy.yml` 雞生蛋）為 evidence-insufficient 14。
+
+### 51. `second-instance-adopts-foreign-daemon-and-idles` ｜ hit_by: symptom（1 路）｜ oracle 型別: 純函式主判準＋整合層
+
+- **source**：issue `#375`（closed）。
+- **observed**（逐字）：
+  > 第二個 instance 的 `*-manager.service` 每次被 timer 觸發都只印一行 `manager pid=<N> (adopted existing)`，然後以 `status=0/SUCCESS` 結束。「看起來完全正常，但它認養的是**另一個 instance 的 daemon**——該 daemon 跑的是對方的 `--specs-dir`，所以第二個 instance 的 specs 目錄從頭到尾沒有任何人處理。」
+  > 根因：`manager_lock_path()` 的 `local control_root="${PSC_CONTROL_ROOT:-$HOME/.agents/control}"`，「lock 路徑**沒有 instance 成分**」；`installer.py:291` 的 `managed_env` 八個變數「**不含 `PSC_CONTROL_ROOT`**」。
+  > 難發現的四個理由：「`(adopted existing)` 是設計內的正常訊息，不是 warning／error」「wrapper 以 exit 0 結束，`systemctl` 不會標 failed」「timer 觸發、跑完即 `inactive (dead)`……所以 `systemctl is-active` 看不出異常」。
+- **oracle**：**主 case（純函式，CI 可跑）**：斷言 `manager_lock_path()` 對兩個不同 instance
+  回傳**不相等**的路徑；斷言 `managed_env` 的變數集合**包含** `PSC_CONTROL_ROOT`。
+  **整合層（`requires: systemd-user`）**：同機安裝兩個 instance 並各自啟動後，(a) 存在**兩個**
+  `manager_daemon` 行程，`--specs-dir` 分別指向各自 instance；(b) 兩個 lock 檔路徑不相等；
+  (c) 第二個 instance 的 work item 能被 claim；(d) 認養前若 `--specs-dir` 不符，必須以 error
+  結束（可見的 failed unit），斷言 exit code ≠ 0。
+  *fail-open 關鍵*：(a) 必須斷言 `--specs-dir` 的**實際值**，不可只數行程數（單 daemon 被兩個
+  unit 認養時行程數也可能因時序看起來是 2）。
+- **harness_needs**：主 case：純函式。整合層：兩份 instance 的 fs 佈置、行程啟動與 `ps` 檢視。
+- **determinism_risk**：主 case 極低。整合層在 CI 上不穩（timer、`systemd --user` 可能不存在）
+  → **環境不足標 `unsupported`，不得標 pass**。
+
+### 52. `manifest-missing-for-past-claim-run` ｜ hit_by: artifact（1 路）｜ oracle 型別: 缺檔即 fail ＋ negative control
+
+- **source**：**artifact 路實測**：`~/.agents/coordinator/jobs.json` ＋ `workflow-manifests/`；
+  旁證 issue `#390`。
+- **observed**（逐字）：
+  > manifest store 只有 **61 檔**，`jobs.json` 卻有 **144 個 workflow run**。以 `claim_key` 尾段對檔名比對：**56 個 distinct claim key（78 個 run）在磁碟上沒有對應 manifest**。其中 62 個 run 停在 `claim` phase（manifest 尚未生成，屬正常），但 **16 個 run 已過 claim**：
+  > `workflow-084f75e2178cf7547476 fix-instance-config-isolation phase=build status=ongoing`（`claim:v1:d92e5d5598f7136accc28f6c3b5631e606a571ea264d6b393e14adcb17536304` → 檔案不存在）
+  > `workflow-50b4fb018b3412a7f487 fix-verification-contract-hash-overwrite phase=verify status=ongoing`
+  > 另 14 個 `phase=verify status=superseded`（含 `workflow-7dd63eeeacac77d06b54`、`workflow-7edf60c1fee8e42a244b`、`workflow-5b1f0e891b85466a83a0`…）。
+  > **跨 instance 重現**：`~/.agents/instances/hippo-open-issues/coordinator/` 有 8 個 manifest、5 個 orphan、且有 5 個 `status=ongoing / phase=verify` 的 run 沒有 manifest（`workflow-77be474e97c34f3fee78 issue-98-search-retrieval-schema` 等）。
+- **oracle**：對 `jobs.json.workflows` 中每個 `current_phase != "claim"` 的 run，
+  `workflow-manifests/<claim_key 尾段>.json` 必須存在且可 parse；**缺檔即 fail**。
+  *fail-open 關鍵*：oracle 自身要有一個 **negative control**（刻意刪一個 manifest 後測試必須
+  轉紅），否則「檔案清單為空 → 迴圈跑 0 次 → pass」就是 fail-open。**不得**用「manifest 不
+  存在就跳過檢查」。
+- **harness_needs**：fs 佈置（造 coordinator root：`jobs.json` ＋ `workflow-manifests/`）。
+  不需 mock provider、不需時間控制。
+- **determinism_risk**：低。claim_key 前綴格式（`claim:v1:`）若改版需同步。
+- **附註**：「manifest store 是以 claim 定址還是以內容定址」尚無成文規格（見
+  evidence-insufficient 27）——本 case 只斷言「已過 claim 的 run 必須有 manifest」，**不碰去重
+  語意**。
+
+### 53. `job-terminal-status-contradicts-journal-log` ｜ hit_by: artifact（1 路）｜ oracle 型別: 列舉合法組合
+
+- **source**：**artifact 路實測**：`~/.agents/coordinator/jobs.json` ×
+  `~/.agents/coordinator/logs/workflow/`。
+- **observed**（逐字）：
+  > 37 個 `status: "failed"` 的 job 中，**18 個 `exit_code == 0`，而其 journal log 的終局記錄是 `"subtype": "success"`、`"is_error": false`**，且 `workflow_evidence == null`（沒有寫出任何 evidence）。清單含 `wf-ec0e7b2d1c-verification-431/-432/-433/-434`、`wf-efce4a166b-code-review-440/-446/-450`、`wf-ce02b3993c-code-review-441/-449/-453` 等。
+  > 逐字（`logs/workflow/wf-ec0e7b2d1c-verification-431.jsonl` 終局 `result` 記錄）：`"subtype": "success"`, `"is_error": false`, `"num_turns": 41`, `"total_cost_usd": 1.0381952999999997`, `"permission_denials": []`；同一筆 `result.result` 文字結尾為 `Verdict: **verified**`。
+  > 而 `jobs.json` 中該 job：`"status": "failed"`, `"exit_code": 0`, `"workflow_evidence": null`。
+  > 另有一筆 `wf-7662e228f5-verification-499`：log 記 `"subtype": "success"` **同時** `"is_error": true`——單一 log 記錄自身矛盾。
+  > 旁證：同一份 log 內模型自述的 gate 失效原文——`R-09 (changelog-fragment gate) reports pass via its "no code change detected" branch because this detached checkout has no origin remote, so the tool's internal git diff origin/<base>...HEAD silently returns empty — this is a checkout artifact, not a real gap.`
+- **oracle**：三方必須互相自洽。「job 終局後，`status`／`exit_code`／log `result.is_error`／
+  `workflow_evidence` 存否 四者必須落在一組**列舉過的合法組合**上；出現未列舉組合即 fail」。
+  特別要斷言：`status == "failed"` 時**必須**能指出失敗來源（`exit_code != 0` 或
+  `log.is_error == true` 或 `provider_outcome != null`）——三者皆無而仍 failed，就是本案。
+  *fail-open 關鍵*：`log` 缺 `result` 記錄時（見候選 54，143/485）**不得**視為通過；要當作
+  獨立 fail 類別。
+- **harness_needs**：fs 佈置（jobs.json ＋ 對應 jsonl ＋ `.exit` sidecar）；能產出「合法 result
+  記錄」的 mock provider fixture。
+- **determinism_risk**：log 的 `result` schema 由 Claude Code CLI 決定（外部）；
+  `subtype`／`is_error` 欄位名若上游改版會漂。**case 應把 fixture 版本釘住。**
+- **附註**：那段模型自述的 `R-09 ... silently returns empty` 是本 repo `#667` 前言警示的
+  fail-open **真實落在語料裡**的一筆——同一形狀的檢查失效已經發生在 gate 上。
+
+### 54. `run-journal-log-truncated-without-terminal-record` ｜ hit_by: artifact（1 路）｜ oracle 型別: 逐行 parse 必 raise
+
+- **source**：**artifact 路實測**：485 個 `.jsonl` 逐行 parse；例
+  `~/.agents/coordinator/logs/workflow/wf-437ca052b0-writing-plans-122.jsonl`。
+- **observed**（逐字）：
+  > **485 個 log 中 143 個（29.5%）最後一行是不完整 JSON（無法 parse），且完全沒有 `type: "result"` 終局記錄**——兩個集合完全重合（143 = 143），是典型寫到一半被截斷的簽名。
+  > 樣本：`wf-437ca052b0-writing-plans-122.jsonl`（303 bytes、1 行、該行即為截斷行）、`wf-7662e228f5-subagent-build-498.jsonl`（543,750 bytes、114 行、最後一行截斷）、`wf-ce02b3993c-tdd-red-417.jsonl`（3,208,090 bytes）。
+  > 0 個 log 為空檔；`.exit` sidecar 478 個與 `jobs.json.exit_code` **逐筆一致（0 筆不符）**，故截斷只發生在 jsonl 寫入端。
+  > 另有 7 個 job 有 `.jsonl` 但**沒有 `.exit` sidecar**：`wf-28009189b5-code-review-451`、`wf-3fa5c69448-tdd-red-5`、`wf-7835881f89-adversarial-review-290`、`wf-865ecb7f70-verification-485`、`wf-ce02b3993c-code-review-449`、`wf-ce02b3993c-tdd-red-417`、`wf-efce4a166b-code-review-450`——全部 `status=failed, exit_code=1`。
+- **oracle**：「job 進入終局狀態後，其 `.jsonl` 必須：(a) 每一行都是合法 JSON，(b) 含**且僅含
+  一筆** `type=="result"`，(c) 有對應 `.exit` sidecar 且值等於 `jobs.json.exit_code`」。
+  *fail-open 關鍵*：**逐行 parse 失敗必須 raise，不得 `try/except: continue`**——本 repo 現有
+  讀取端若用 continue，143 個截斷 log 會被讀成「正常但無 result」。另需 negative control：
+  注入一個截斷 log，oracle 必須轉紅。
+- **harness_needs**：fs 佈置。**「截斷」必須以確定性方式製造（直接寫半行 fixture），不要靠真的
+  kill 進程。**
+- **determinism_risk**：低（fixture 化之後）。
+
+### 55. `zero-byte-evidence-file-referenced-as-proof` ｜ hit_by: artifact（1 路）｜ oracle 型別: 原子寫＋0-byte negative control
+
+- **source**：**artifact 路實測**：84 個 work-abandon evidence 逐檔 parse ＋
+  `jobs.json.workflows[].evidence_refs` 交叉比對。
+- **observed**（逐字）：
+  > 84 個 work-abandon evidence 中 **2 個為 0 bytes**：
+  > ‧ `workflow-1b9d279908562fe8d926-ac723ac5d156…json`，mtime `2026-08-06 09:04:17.750872620 +0800`
+  > ‧ `workflow-57fb398f8389b18fe6e1-56110339fb1e…json`，mtime `2026-08-06 09:04:17.717646018 +0800`
+  > （相差 33 ms，同一批寫入）
+  > 兩者**都被 `jobs.json` 引用為證據**：`workflow-1b9d279908562fe8d926.evidence_refs == ["<HOME>/.agents/coordinator/evidence/work-abandon/workflow-1b9d279908562fe8d926-ac723ac5d156a188957a04405e6ef5be5e4f58a73de33fd748436cc3d7385695.json"]`
+
+  > **逐字引用的唯一例外**：原始 `evidence_refs` 值是絕對路徑，前綴為 operator 的 home
+  > 目錄。此處以 `<HOME>` 取代該前綴以通過 R-21 結構偵測（`/home/<username>/`），
+  > **路徑其餘部分與雜湊逐字未改**。這也正是本候選 oracle 的一個附帶觀察：`evidence_refs`
+  > 存的是**絕對路徑**（而非相對 coordinator root 的路徑），本身就不利於跨機重放。
+  > 且該 run 的 `updated_at = "2026-08-06T01:04:17.752609+00:00"`（＝ 09:04:17.752 +0800）——**檔案在 .7508 建立，jobs.json 在 .7526 提交，中間 1.8 ms，內容從未寫入**。典型「先建檔、後寫入、中途中止」的非原子寫。
+  > 兩個 run 的 `needs_human_reason` 皆為 `null`、`facets` 為 `['blocked', 'needs_human', 'planning_released']`——abandon 的理由只存在於那個空檔案裡，已永久遺失。
+  > 對照健康樣本（473 bytes）內含 `"reason": "planning 失敗肇因為 operator 並行編輯觸發 worktree rollback（issue 507），非模型內容缺陷；工作區已淨空，重新 claim 以乾淨環境重跑"`。
+  > **其他四個 instance 的 433 個 JSON 檔中 0 個空檔／0 個損壞** —— 此為單一 coordinator 的偶發寫入事故。
+- **oracle**：「evidence 寫入必須原子（temp file + fsync + rename）；崩潰注入後，目標路徑要嘛
+  不存在、要嘛是完整可 parse 的內容——**絕不允許存在 0 bytes 或半截檔**」。讀取端斷言：
+  「`evidence_refs` 指向的每個檔案必須非空且可 parse；`os.path.exists()` 為真但 parse 失敗要
+  fail-closed 且回報路徑」。
+  *fail-open 關鍵*：本案的 fail-open 就是「`exists()` 回 True 就當證據齊備」。**case 必須有一條
+  專門測 0-byte 的 negative control。**
+- **harness_needs**：fs 佈置；中斷注入（可用 monkeypatch 讓 write 在 open 後 raise）。
+  不需 provider。
+- **determinism_risk**：低（注入式，非靠真實 race）。
+
+### 56. `evidence-ref-without-integrity-hash` ｜ hit_by: artifact（1 路）｜ oracle 型別: 參照必帶雜湊
+
+- **source**：**artifact 路實測**：`jobs.json`。
+- **observed**（逐字）：
+  > `evidence_refs` 共 **103 筆，全部是裸字串路徑**（`entry types: [('str', 103)]`）——沒有 `sha256` 欄位。
+  > 同一份 run journal 的 `gate_refs` 共 28 筆，**全部是 `{kind, ref, sha256}` 三鍵物件**。
+  > 因此 `evidence_refs` 指向的檔案被改動或截斷時，系統沒有任何偵測手段（前一條的 2 個 0-byte 檔就是這樣通過的）。
+- **oracle**：「所有 evidence 參照必須攜帶內容雜湊；讀取時必須重算並比對，不符即 fail-closed」。
+  *fail-open 關鍵*：比對函式必須明確處理「檔案空／不可 parse」的分支，且 oracle 需驗證
+  「**參照數 > 0**」（避免 `evidence_refs` 為空陣列時迴圈跑 0 次而 pass）。
+- **harness_needs**：fs 佈置；篡改注入（寫完後改一個 byte）。
+- **determinism_risk**：低。
+
+### 57. `duplicate-review-evidence-two-naming-schemes` ｜ hit_by: artifact（1 路）｜ oracle 型別: job_id 分群大小 == 1
+
+- **source**：**artifact 路實測**：`~/.agents/coordinator/evidence/review/` 60 個檔名分群。
+- **observed**（逐字）：
+  > 兩套並存命名：
+  > ‧ 方案 A `<run_id>-<card>-<job_id>.json` ×51
+  > ‧ 方案 B `<run_id>-<job_id>.json` ×9
+  > 且 **9 個 job 同時以兩種檔名各存了一份**，內容**不同**（各差 19 bytes）。逐字 diff（job `wf-3fa5c69448-adversarial-review-54`）：
+  > A `workflow-ed15cd16ffa5e2c26306-adversarial-review-wf-3fa5c69448-adversarial-review-54.json` → `slice_id: "workflow-ed15cd16ffa5e2c26306-adversarial-review"`
+  > B `workflow-ed15cd16ffa5e2c26306-wf-3fa5c69448-adversarial-review-54.json` → `slice_id: "workflow-ed15cd16ffa5e2c26306"`
+  > 其餘欄位（`state`、`findings`、`candidate`、`reviewer_job_id`…）完全相同。9 對全部呈現同一模式。
+  > （另：跨檔比對發現同一份 completion record 的 `review_evaluation_path` 與 `work_authority.trusted_evidence_refs[0]` 分別指向這兩個分身，兩個雜湊**各自都正確**。）
+- **oracle**：「一個 `(run_id, job_id)` 對最多只能有一筆 review evidence；`slice_id` 的計算必須
+  只有單一實作」。sweep 斷言：`evidence/review/` 中不得存在兩個檔名解析到同一 `job_id`。
+  *fail-open 關鍵*：不能只比對「檔案數 == job 數」——要**以 job_id 為鍵做分群後斷言每群大小
+  == 1**。
+- **harness_needs**：fs 佈置；需能觸發兩條寫入路徑（多半是 workflow-lane 與 slice-lane 各一份）。
+- **determinism_risk**：低。
+
+### 58. `todo-frontmatter-missing-required-status` ｜ hit_by: artifact（1 路）｜ oracle 型別: 不得帶預設值
+
+- **source**：**artifact 路實測**：64 個 `docs/superpowers/workstreams/*/todo.md` 全部解析 ＋
+  `paulsha_cortex/coordinator/planning.py:199-206`（契約來源）。
+- **observed**（逐字）：
+  > 64 個 workstream todo.md 的 frontmatter：**63 個是 `(status, work_item)`，1 個只有 `(work_item,)`**。
+  > 該檔逐字開頭：`---\nwork_item: terminal-lifecycle-canary\n---\n\n# Terminal Lifecycle Canary Todo\n`——缺 `status`。
+  > 其餘 63 個 `status` 值全為 `accepted`；64 個 `work_item` 值全部等於所在目錄名（0 筆不符）。
+  > 契約來源（`planning.py`）逐字：`status = frontmatter.get("status")` / `if not isinstance(status, str) or status.strip().casefold() != "accepted":` / `reasons.append("status-not-accepted")`
+  > 另 `planning_runtime.py:1173` 的 integrator prompt 逐字：`content must be complete UTF-8 Markdown with frontmatter status: accepted and the matching work_item.`
+  > 該 work item 於 `delivery-journal.json` 中是 `workflow-ed15cd16ffa5e2c26306`，`ship.phase = "done"`、`delivery_binding.todo_paths = ["docs/superpowers/workstreams/terminal-lifecycle-canary/todo.md"]`、`mapped_prs = [54]`——**已交付的 work item 其授權檔卻不符現行 authority 契約**。
+- **oracle**：「任何被 delivery journal 綁定為 `todo_paths` 的檔案，其 frontmatter 必須通過
+  `assess_planning_artifact`（`status: accepted` ＋ `work_item` 等於目錄名 ＋ 必要 heading）」。
+  *fail-open 關鍵*：**不可用 `frontmatter.get("status", "accepted")` 這種帶預設值的取法**；
+  缺鍵必須與值錯誤同樣 fail。
+- **harness_needs**：fs 佈置（造 workstream 目錄樹）。不需 provider。
+- **determinism_risk**：中。**時序疑慮**：該 run 於 2026-07 交付，而 `status: accepted` 的要求
+  可能是後來才加的。**case 應寫成「當前狀態不變式」（現有檔案必須合規），而非「當時應該
+  擋下」。**
+- **本 workstream 自身的關係**：本 workstream 的 `todo.md` 刻意使用 `status: proposed`
+  （非 accepted），因此它**不是** claim 目標、不會被 `assess_planning_artifact` 判為可交付
+  ——這是設計，不是本候選所指的缺陷。
+
+## T3 — 需 tick 推進／注入時鐘／真實 git worktree（27 筆）
+
+### 59. `verification-contract-hash-overwritten-by-evidence-hash` ｜ hit_by: symptom·subsystem·lifecycle·artifact（**4 路**）｜ oracle 型別: 逐位元組相等＋獨立重算 ★
+
+**全盤點唯一的四路命中。** 四路各自從失敗表徵、模組落點、階段轉換、以及**實體狀態檔的雜湊
+重算**四個角度撞到同一個缺陷；artifact 路是唯一**沒有讀 issue 就獨立算出來**的一路。
+
+- **source**：issue `#501`（open），paulsha-cortex 0.1.8 實機復現，candidate `77e13f2`；
+  且是 0816 dogfooding gen2 的主題（見 `#606`／`#617`）。artifact 路實測對象：`jobs.json` 唯一
+  一筆 slice `add-cortex-version-flag-build`。
+- **observed**（逐字）：
+  > （#501）`_apply_verification_result()` passes the **verification evidence payload hash** as `verification_hash` to `registry.update_slice()`, which stores it in `slice_row["verification"]["hash"]`. That field originally contains the **verification contract hash** used by `_pinned_input_mismatches()`.
+  > `stored contract object canonical hash: f30e5bfe...` / `current parsed spec verification hash: f30e5bfe...` / `slice_row.verification.hash` after successful verification: `98b73f70...` / `98b73f70... is the evidence payload hash, not the contract hash`
+  > ```python
+  > registry.update_slice(
+  >     slice_id,
+  >     verification_hash=evidence["hash"],
+  >     current_evidence_refs=refs,
+  >     candidate=payload["candidate"],
+  > )
+  > ```
+  > 「The next tick therefore compares `f30e5bfe... != 98b73f70...` and emits `verification-hash` mismatch. Repeated ticks then replace the successful current evidence with `needs_human` mismatch evidence.」
+  > 「The bug is usually masked when a reviewer job is successfully attached because builder completion is then skipped. **A review-launch failure exposes it immediately.**」
+  > （artifact 路獨立重算，非轉述）該 slice：`state: needs_human`、`gate_state: needs_human`、`candidate: 72d52d0844732751993ab8947237819280fed38d`。
+  > ‧ 紀錄的 `verification.hash` = `9a794c5d231e7adb4dde0acf0fd40af531267af7119f80d99f9caab3f3200e3b`
+  > ‧ 對同一物件的 `verification.contract` 取 canonical-JSON sha256（ascii 與 utf8 兩種結果相同）= `1372e5b078e174518d0e51f3459d4e3b5c0311f835f5453690b190739d32988d` → **不吻合**
+  > ‧ 對 `current_evidence_refs[0]`（`evidence/verification/add-cortex-version-flag-build-72d52d0844732751993ab8947237819280fed38d.json`）取 canonical-JSON sha256 = `9a794c5d231e7adb4dde0acf0fd40af531267af7119f80d99f9caab3f3200e3b` → **完全吻合**
+  > 該 evidence 自身內容：`status: "needs_human"`、`summary: "pinned-input-mismatch"`——**迴圈自我延續的證據**。
+- **oracle**：(a) `_apply_verification_result()` **前後 `slice_row["verification"]["hash"]` 逐
+  位元組相同**；(b) evidence hash 可從**另一個欄位**獨立取得（斷言兩者不相等且皆非空）；
+  (c) **e2e**：verification pass → **review launch absent** → 下一 tick 不得報
+  `pinned-input-mismatch`，且 evidence **不得 churn**（以 action 數與 `evidence_history` 長度的
+  **計數斷言** before/after 相等）；(d) 原成功 evidence 保持 immutable 直到顯式 retry。
+  **artifact 路的加強版（最強的一條）**：不能只比「前後值相同」——若兩次都被覆寫成同一個
+  evidence hash 也會 pass。要**獨立重算 `sha256(canonical(slice.verification.contract))` 作為
+  期望值**。
+  *fail-open 關鍵*：**case 必須刻意製造 review launch 失敗**——issue 明說正常路徑（reviewer
+  成功綁定）會遮蔽此缺陷，只跑快樂路徑必然是一條**永遠綠的假 case**。這是本 sweep 中「既有
+  測試為何沒抓到」最明確的一例。
+- **harness_needs**：registry 佈置 slice row；可控地使 review launch 失敗（mock provider 或缺
+  identity 或 tier config error）；tick 可重複驅動；fs（evidence 目錄）。不需模型。
+  **fixture 可直接沿用輔語料的真實 handoff manifest**（含 `verification_hash` 欄位）。
+- **determinism_risk**：低。hash 是內容定址，可完全確定。需注意 canonical JSON 序列化的鍵序
+  穩定性；hash 值應以「前後相等／獨立重算」表述而非「等於某常數」（spec 序列化方式變動會使
+  常數 fixture 失效）。
+
+### 60. `stale-handoff-manifest-shadows-recovered-slice` ｜ hit_by: symptom·subsystem·artifact（3 路）｜ oracle 型別: 差分＋三元組不變式
+
+- **source**：issue `#383`（closed）／PR `#430`，slice `input-ritual-cost-closes-48-build`。
+- **observed**（逐字）：
+  > ```python
+  > already_terminal[slice_id] = payload        # ← 不看 mtime、不看 registry state
+  > ```
+  > `manager.py:2009-2022`「只要 handoff 檔存在且能 parse 成 dict 就進 `already_terminal`，**沒有任何新鮮度或狀態比對**」
+  > `grep -rn "already_terminal" paulsha_cortex/` 只命中 `manager.py` 的 2009 / 2022 / 2048 三處——**`fanout` 路徑（`manager_daemon.py:813`）不套用這個過濾**
+  > ```
+  > $ cortex ready --specs-dir <specs> | jq ...
+  > input-ritual-cost-closes-48-build auto            ← ready 認為可派
+  > $ cortex run tick --specs-dir <specs> --executor copilot --model gpt-5.4
+  > #   "dispatched": []          ← 派 0 個
+  > #   "dispatch_skipped": false ← 而且不是被 idle gate 擋
+  > #   "errors": []              ← 也沒有任何錯誤
+  > ```
+  > 一分半後同一組 spec、同一 daemon、期間未做任何狀態變更：`$ cortex run fanout ...` → `"dispatched": [{"job_id": "input-ritual-cost-closes-48-build-12", "status": "dispatched", ...}]`
+  > 殘留檔內容：`needs_human missing-slice-proof`（上一輪的結果，registry 當時已是 pending）
+  > （artifact 路補充）程式碼原文 `except (OSError, UnicodeDecodeError, json.JSONDecodeError): continue`——**損壞或截斷的 manifest 會被靜默略過**，與 `evidence/work-abandon/` 的 0-byte 檔屬同型讀取端 fail-open。
+- **oracle**：(a) **差分**——對同一組 spec 與同一個「已 recover 但留有 stale handoff 檔」的
+  slice，斷言 `set(tick.dispatched) == set(fanout.dispatched)`，且 `len(dispatched) == len(ready)`；
+  (b) **三元組不變式**——當 tick 確實略過時，回傳必須帶**具名的 skip 原因**：斷言
+  `dispatched`／`dispatch_skipped`／`errors` **不得同時為空／false／空**（**這個三元組正是本
+  bug 的簽名**）；(c) **對帳**——handoff manifest 與 registry state 矛盾時，以 registry 為準或
+  明確報衝突，不得單憑檔案存在排除；(d) manifest **不可 parse 時必須 fail-closed 且回報路徑，
+  不得 `continue`**。
+  *fail-open 關鍵*：(a) 若寫成「tick 派得出去」，一個「刪掉整個過濾」的修法就能通過而失去
+  in-flight 保護；(b) 是類別級的鎖——未來換一個不同的略過條件又會靜默。
+- **harness_needs**：fs 佈置（specs ＋ registry ＋ `runtime/handoff/<slice>.json` 殘留檔，含
+  一個截斷檔）；tick 與 fanout **兩條路徑皆可驅動**。不需模型。
+- **determinism_risk**：低。全為檔案狀態。
+
+### 61. `unchanged-recheck-appends-history-every-tick` ｜ hit_by: symptom·subsystem·artifact（3 路）｜ oracle 型別: 精確計數恆等＋恰好一次
+
+- **source**：issue `#496`（open），slice
+  `task-3-private-repo-and-forbidden-documentation-scan-build`；artifact 路獨立實測
+  `jobs.json.workflows[].attempts`。
+- **observed**（逐字）：
+  > （#496）`33 verification-failed actions` / `33 evidence_history entries` / `first at 2026-08-12T14:12:06.381861Z` / `last at 2026-08-12T14:14:02.820132Z` / `same slice and candidate 0c9faff912201238b238014909c0f58816260575`
+  > 「The 5-second manager timer then re-ran the same verification on every tick and appended a fresh verification-failed action plus evidence_history entry even though the worktree, candidate, result, and evidence path were unchanged.」
+  > 根因：「`_apply_verification_result` always record_action and update_slice. There is no comparison against the current verification hash, status, summary, candidate, or refs.」
+  > 「This grows jobs.json indefinitely while the slice is waiting for an operator.」
+  > （artifact 路實測）14 個 run 的 `attempts.verify` 落在 **13,097 – 13,199** 之間，同一 run 的其他 phase 皆為個位數。逐字（`workflow-7dd63eeeacac77d06b54`）：`attempts= {'build': 7, 'claim': 1, 'define': 1, 'plan': 1, 'verify': 13199}`；`workflow-7edf60c1fee8e42a244b`：`{'build': 1, 'claim': 1, 'define': 1, 'plan': 1, 'verify': 13107}`。全部 14 個現為 `status=superseded, current_phase=verify`。
+- **oracle**：(a) 對未變動的 dirty worktree **重複驅動 `complete_tick` N 次**，斷言
+  `attempts[phase]`、action 數、`evidence_history` 長度在第一次之後**完全不變**（**精確等值，
+  非「成長緩慢」**）；(b) 中途把 worktree 清乾淨，斷言**恰好一次**狀態轉換（不是 0 次、不是
+  2 次）。
+  *fail-open 關鍵*：計數必須精確相等；(b) 不可省——只斷言「不成長」會讓「乾脆不 recheck」的
+  修法通過，那會使 operator 清理後永遠不被偵測。「不能只斷言有上限」——把上限設成 20000 也會
+  pass。
+- **harness_needs**：tick 可重複驅動；registry 與 evidence 計數可讀；fs 佈置（dirty worktree：
+  一個 untracked 檔）；**時間控制**（避免 5 秒 timer 依賴牆鐘）。不需模型。
+- **determinism_risk**：低。需注意 evidence 檔名若含時間戳會每次不同（`last_rechecked_at` 應
+  分離），**斷言要看 history 長度而非檔名集合**。
+
+### 62. `terminal-jobs-ping-pong-overwrites-operator-decision` ｜ hit_by: symptom·subsystem·artifact（3 路）｜ oracle 型別: 六欄位穩定＋單調柵欄
+
+- **source**：issue `#481`（open），paulsha-cortex 0.1.8 isolated live instance；artifact 路獨立
+  實測同一筆 slice `add-cortex-version-flag-build` 的 `actions`／`evidence_history`。
+- **observed**（逐字）：
+  > （#481）「Cortex recorded `verification-failed` actions for the same exited job on every manager tick, approximately every six seconds. More than twenty identical actions accumulated before the next retry.」
+  > 「Operator later ran `recover-pre-candidate` and received `state=pending, gate_state=pending, result=ok`. …… **Nine seconds later** `complete_tick` reapplied an older `failed` job: slice returned to failed / old builder_job_id was rebound / provider outcome/reason returned to the old failure. The superseded handoff marker did not prevent this replay.」
+  > 機制：「If terminal jobs A, B, and C share a slice and the manifest currently names C: A differs and rewrites the manifest to A / B differs and rewrites it to B / C differs and rewrites it to C / Next tick starts from the same condition and repeats forever.」
+  > 「Its idempotency check compares each job only with the single current handoff manifest job ID. While iterating old-to-new, each older job overwrites the manifest and each newer job overwrites it again.」
+  > （artifact 路實測，`actions` 依時間序逐字）
+  > 1. `{"action": "verification-failed", "actor": "manager", "at": "2026-07-21T03:50:06.774145+00:00", "gate_state": "needs_human", "state": "needs_human"}`
+  > 2. `{"action": "dispatch-failed", "actor": "manager", "at": "2026-07-21T03:51:48.514600+00:00", …}`
+  > 3. `{"action": "verification-failed", "actor": "manager", "at": "2026-07-22T03:44:16.924014+00:00", …}`
+  > 4. **`{"action": "operator-abandon", "actor": "operator-cleanup", "at": "2026-08-11T10:35:06.871187+00:00", …, "gate_state": "failed", "result": "ok", "state": "failed"}`**
+  > 5. **`{"action": "verification-failed", "actor": "manager", "at": "2026-08-13T23:46:27.830327+00:00", "gate_state": "needs_human", "state": "needs_human"}`**
+  > 亦即：operator 在 08-11 明示 abandon 並把狀態推到 `failed`，**兩天後 manager 的自動重驗把它翻回 `needs_human`**，且該 slice 至今仍掛在 `attention` 清單裡、`repo: null`。`evidence_history` 三筆全部指向**同一個** evidence 路徑，內容未變卻記了三次。
+- **oracle**：佈置終局 job A/B/C 同 slice → 推兩個 tick → 執行 `recover-pre-candidate` →
+  再推一個 tick。斷言收斂後 **action 數、evidence refs、manifest hash、builder_job_id、
+  slice state、gate state 全部穩定不變（六項齊查）**。並斷言 recovery 之後**所有較舊的終局
+  job 皆為 audit-only，不得改動 current slice state**（**單調柵欄**）。
+  **artifact 路的加強版（更廣的表述）**：「operator 顯式終局動作（abandon／retire）之後，任何
+  自動路徑不得再改寫該 slice 的 `state`／`gate_state`；若自動路徑偵測到新資訊，只能追加
+  advisory 記錄」——**在 abandon 之後再推進 N 個 tick，斷言 state 仍為 failed 且 `actions` 未
+  新增 manager 動作**。
+  *fail-open 關鍵*：六項要全查——只查 slice state 的話，manifest 仍在 ping-pong 卻看不出來；
+  「單調柵欄」要用「recovery 之後**任何**舊 job 都不能改狀態」表述，**不可用「A 不能覆寫 C」**
+  （換個順序就繞過）。只斷言「不再拋例外」或「最終狀態正確」→ 每 6 秒一筆的 churn 仍在。
+- **harness_needs**：registry 佈置（多筆終局 job ＋ handoff manifest）；tick 可重複驅動；
+  manifest hash 可讀；operator action seam；時間控制。不需模型。
+- **determinism_risk**：中。**job 迭代順序（old-to-new）是 bug 的必要條件**，harness 必須能
+  控制 `list_jobs()` 順序，否則測試可能偶然不觸發。
+
+### 63. `monitor-refresh-exception-silently-swallowed` ｜ hit_by: symptom·subsystem·artifact（3 路）｜ oracle 型別: 確定性／暫時性分流＋可與限流區分
+
+- **source**：issue `#273`（closed）／PR `#289`；同型 `#523`（見候選 66）；artifact 路獨立
+  schema 檢查 `~/.agents/monitor/work-items.snapshot.json`。
+- **observed**（逐字）：
+  > ```python
+  > def _refresh_work_model(self, *, include_github: bool) -> None:
+  >     try:
+  >         events = self._work_refresher.refresh(...)
+  >     except (OSError, ValueError):
+  >         # Durable last-good remains available; the next scheduled refresh retries.
+  >         return
+  > ```
+  > Monitor 的 `work-items.snapshot.json` 從 **2026-07-26 起就沒有再更新過**（實測到 07-30 仍是 7/26 的內容），期間服務一直是 `active running`、`journalctl` 沒有任何錯誤訊息
+  > `cortex work show <id>` 回 `unknown work item`，`cortex work start` 回 `confirmed work authority missing or ambiguous` —— 兩者都不會指向 snapshot 已停更這個真正原因
+  > 診斷這件事花了數小時，其中大部分時間耗在「服務看起來正常」這個假象上
+  > 「註解假設『下一次排程重試就會好』，但當失敗原因是**確定性**的（資料本身有問題）時，每一次重試都會以同樣方式失敗。」影響：「一行 frontmatter 不一致，讓 `hamanpaul/paulsha-cortex` 的 work item 從 43 個變成 **0 個**」
+  > （#523 補強）`snapshot 的 written_at 就凍結在 03:25:25Z；20 分鐘內每個 refresh 週期（poll 30s／rescan 300s／github 300s）都以同一例外失敗，26 個 github provider 的 last_attempt_at 全部停在該時刻`；且「對外表徵是『provider 一直 degraded、authority 永不新鮮』，與限流症狀難以區分——**實際上根本沒有發出任何請求**。」
+  > （artifact 路實測）snapshot 的 top-level 鍵為 `['exclusions', 'providers', 'schema', 'sequence', 'source_owners', 'work_items', 'written_at']`——**沒有 `last_refresh_error`、沒有連續失敗計數、沒有 `last_successful_refresh_at`**。
+- **oracle**：(a) 注入確定性 `ValueError`（資料問題）→ status／snapshot 必須含
+  `last_refresh_error` 與**連續失敗計數**（斷言欄位存在且計數遞增）；(b) 注入暫時性 `OSError`
+  → 仍可靜默重試（計數行為與 (a) 有別）；(c) snapshot 過期時 `cortex work show`／`work start`
+  的錯誤訊息必須**指名 staleness**，**不得**是 `unknown work item`；(d) **必須能與限流區分**
+  ——斷言 degraded 理由欄位對「未發出請求」與「請求被限流」給出**不同值**。
+  *fail-open 關鍵*：(a) 的斷言必須落在**結構化欄位**上，「有 log 就算過」不行——log 不是 status
+  欄位，operator 看的是 status。(d) 不可省：issue 明言 operator 花 20 分鐘誤診為限流。
+  另：**不得以「檔案存在且可 parse」當作 monitor 健康的判準**——凍結的 snapshot 永遠是合法
+  JSON。要斷言 `written_at` 與注入時鐘的落差有上界。
+- **harness_needs**：fs 佈置 snapshot（含 duplicate work item id、frontmatter 不一致）；service
+  refresh 的注入 seam；**時間推進（多個 refresh 週期）**。不需真實 GitHub。
+- **determinism_risk**：低。`include_github` 路徑須以 mock provider 取代真實 API。
+
+### 64. `planning-snapshot-pycache-false-drift` ｜ hit_by: symptom·subsystem·lifecycle（3 路）｜ oracle 型別: 雙向＋底層例外摘要
+
+**define 八環攻關鏈第三環。**
+
+- **source**：issue `#397`（closed 2026-08-10）／PR `#398`，run `workflow-71f912efc167641d5356`。
+- **observed**（逐字）：
+  > define brainstorm 失敗，evidence：`classification=content, reason=question-pack-malformed`。operator shell 重現 questioner 呼叫得到真正的錯誤：`ValueError: planning launcher modified operator worktree; changes rolled back`
+  > `planning_runtime._tree_snapshot`（:61-111）雜湊整棵工作樹**只排除 `.git`**——`__pycache__/*.pyc` 全部入雜湊
+  > 實證：restart 後 `coordinator/__pycache__/{manager,work_bridge}.cpython-312.pyc` 恰在 define 呼叫窗口內重生（正是 PR 392/394 改過的兩個模組）
+  > `planning.py:1094` 的 `except Exception` 再把它壓平成 `question-pack-malformed`——**雙重誤導**（既非 question pack、也非 malformed）
+  > 影響：「共享工作樹部署下，**每次部署後的第一個 define 幾乎必踩**」
+- **oracle**：雙向。(a) 快照窗口內寫入／重寫 `__pycache__/*.pyc` → **不得**觸發 mismatch；
+  (b) 真正的非 bytecode 寫入（新增 `.py`／`.md`）→ **仍必須**觸發 mismatch（fail-closed 保留）；
+  (c) 例外壓平路徑必須附底層例外摘要（`type: message[:160]`），斷言 reason **不等於裸
+  `question-pack-malformed`**、且含真實根因型別名。
+  *fail-open 關鍵*：(b) 是核心——(a) 單獨存在會讓「乾脆不做 snapshot 比對」通過，而該比對是
+  防越界的安全網。
+- **harness_needs**：fs 佈置（工作樹 ＋ 可控的 `__pycache__` 寫入）；**在 `_tree_snapshot` 的
+  T0 與 T1 之間注入寫入的 seam**（時序控制，不是掛鐘）；mock planning launcher。
+- **determinism_risk**：中。原始現象是 lazy import 的隨機重編譯 → case 必須把「窗口內寫入」
+  做成**顯式注入**而非依賴真實 import 行為。另注意 `PYTHONDONTWRITEBYTECODE` 若在 CI 設了，
+  自然的 .pyc churn 不會發生——**case 要主動寫入 .pyc**。
+
+### 65. `planning-snapshot-runtime-dir-false-drift` ｜ hit_by: subsystem·lifecycle（2 路）｜ oracle 型別: 雙向＋兩份排除清單同源
+
+**define 八環攻關鏈第四環。** `#397` 落地後才露出來。
+
+- **source**：issue `#399`（closed 2026-08-10）／PR `#400`，run `workflow-244b7cfdee547d58a022`。
+- **observed**（逐字）：
+  > #397（pycache 排除）落地後，operator shell 重現 questioner 仍撞 `planning launcher modified operator worktree; changes rolled back`。90 秒雙快照 diff 抓到 churn 真源：**`runtime/handoff/wf-*.json`**——#373 的 authority-restart 迴圈每 ~55 秒重寫 14 個 run 的 handoff manifest（含時間戳，內容必變）
+  > `/runtime/` 在 `.gitignore:8` 明列為「dogfood runtime 殘留（daemon cwd=repo root 時產生）」——是 daemon 狀態，不是 operator 內容
+  > 「任何 planning 呼叫（questioner/secondary/integrator，動輒 30–120 秒）只要窗口跨過一次 tick 的 handoff 重寫即誤判為 planner 汙染。#373 的迴圈讓這件事**每 55 秒必然發生**」
+- **oracle**：與候選 64 同形（雙向），對象換成頂層 `runtime/`。**這兩條必須是同一個 harness 的
+  參數化用例**——`#399` 的存在證明了「修一個排除項不代表修好類別」，只有把排除清單做成資料
+  驅動的參數化，第三個同型漏洞才擋得住。
+  再加**結構性 oracle（更耐改）**：**`_tree_snapshot` 與 `_copy_planning_sandbox` 的排除集合
+  必須完全相同**——issue 指出兩者是各自維護的兩份清單，`#397`／`#399` 兩次都得改兩處，
+  **漂移即復發**。
+- **harness_needs**：fs ＋ tick 推進（模擬 daemon 在窗口內重寫 handoff）；mock launcher。
+  **不得 sleep 55 秒**——churn 必須由 harness 顯式觸發。
+- **determinism_risk**：中。依賴「daemon 在窗口內寫入」的注入點；`runtime/` 若改為可設定的
+  state root，fixture 路徑會漂。
+
+### 66. `monitor-ownership-collision-freezes-entire-snapshot` ｜ hit_by: symptom·subsystem（2 路）｜ oracle 型別: 精確計數＋`written_at` 前進
+
+- **source**：issue `#523`（closed／open 兩路記載不一，以 issue 現況為準）／PR `#532`
+  （處理相鄰分支），2026-08-14。
+- **observed**（逐字）：
+  > ```
+  > ValueError: ownership collision for github_issue:hamanpaul/paulsha-cortex#514:
+  >   hamanpaul/paulsha-cortex::fix-brainstorm-revalidation-diagnostics,
+  >   hamanpaul/paulsha-cortex::issue:hamanpaul/paulsha-cortex#514
+  > ```
+  > 堆疊 `monitor/service.py:353 _refresh_work_model` → `work_api.py:645 refresh` → `WorkSnapshot.__post_init__` → `work_snapshot.py:63,90 validate_ownership`
+  > 「不只受影響的那一項，是全部（含所有 repo 的 provider 狀態）」；「11:25 執行 `cortex work link fix-brainstorm-revalidation-diagnostics --issue 514` 後，snapshot 的 `written_at` 就凍結在 `03:25:25Z`」
+  > 「**`work link` 當下不擋**：造成衝突的那個指令回傳成功，破壞在下一次 refresh 才發作，且發作處與指令完全脫節。」
+- **oracle**：(a) **前置檢查**——`cortex work link` 在目標 source 已被其他 work item（含自動
+  衍生的 `issue:<repo>#<n>`）擁有時，**當場**失敗，訊息指名現任擁有者 id；(b) **爆炸半徑**
+  ——即使衝突已存在，`validate_ownership()` 失敗只得把衝突的 source／work item 標 degraded 並
+  排除，**其餘 N−1 個 work item 必須仍在 snapshot 中**：斷言 snapshot 內 work item 數 =
+  總數 − 衝突數（**精確計數**，非 0），且 snapshot 的 **`written_at` 前進**、未受影響的
+  provider `last_attempt_at` 前進；(c) 衝突必須出現在 `status`／`doctor`，且其 degraded 理由
+  可與限流區分。
+  *fail-open 關鍵*：(b) 若寫成「snapshot 非空」，一個「衝突時回退到 last-good」的實作也會通過
+  ——但那正是候選 63 的凍結行為。若只斷言「refresh 沒拋例外」，catch-all 吞例外的實作會過。
+  **必須斷言 `written_at` 前進。**
+- **harness_needs**：fs 佈置（work-items.yaml 造出 ownership collision ＋ snapshot）；monitor
+  refresh 可單獨驅動；`work link` CLI 路徑；**注入 clock**（才能穩定斷言「前進」）。
+  不需真實 GitHub。
+- **determinism_risk**：低—中。自動衍生 work item 的規則（`issue:<repo>#<n>`）需與現行實作
+  一致。**「受影響的那一列該長什麼樣」不在本 case**（見 evidence-insufficient 16）。
+
+### 67. `ship-git-cwd-must-not-be-builder-owned-tree` ｜ hit_by: subsystem·lifecycle（2 路）｜ oracle 型別: cwd 集合斷言（**單 UID 可驗**）
+
+- **source**：issue `#635`（open）＋ `#653`（closed）／PR `#656`。
+- **observed**（逐字，`#635` 的落點表）：
+  > `_push_exact_candidate` — `git -C <工作區> push origin HEAD:refs/heads/<branch>` — builder-owned
+  > `_push_exact_candidate` — `git -C <工作區> ls-remote origin <ref>`（push 前後 readback） — builder-owned
+  > `_commit_archive_and_require_reverification` — `git -C <工作區> add -A` ＋ `commit` — builder-owned
+  > `_remove_canonical_untracked_reports` — 刪工作區內的 reviewer report 檔 — builder-owned
+  > `_run_exact_candidate_preflight` — 在工作區內再開一個巢狀 `git worktree add` — builder-owned
+  > `_builder_binding`（`work_bridge.py:673`）取的就是 `builder_job["worktree"]`，delivery 全段以它為 git cwd
+  > （#653 逐字）ship phase **永遠回 None**——它們不經任何 launcher、不 spawn job，由 Manager 自己在 `work_bridge.py` 內以 deterministic 身分執行
+  > ⇒ **ship phase 在降權模式下會在第一個 `git -C` 就 `Permission denied`**。症狀是**權限**，不是 mount namespace。
+- **oracle**：透過既有的 `dispatcher git_runner` seam 記錄 ship phase 期間**每一次** git 呼叫
+  的 cwd，斷言集合中**不含任何 builder job 的 `worktree` 路徑**。加：`direct` 模式零回歸
+  （同一組斷言在 direct 下也成立）。生命週期路加一條：ship 段 `git -C` 目標路徑的 owner uid
+  == Manager 的 uid（**該條需多 UID，屬 tier 2**）。
+  *fail-open 風險（本 repo 已具名的同型事故）*：斷言「ship 成功」在單 UID CI 下**永遠綠**
+  ——`#657` 逐字記錄了這個機制。**必須斷言 cwd 參數本身，不能斷言結果。**
+  *本 case 的價值*：它把「只有多 UID 才顯現的缺陷」降到**單 UID 可驗**。
+- **harness_needs**：git_runner seam 的呼叫記錄（既有 seam，`coordinator/seams.py`）；fs 佈置
+  builder worktree ＋ Manager 來源樹。**主斷言不需要多 UID。**
+- **determinism_risk**：低—中。git 呼叫順序依賴實作；**斷言用集合而非序列**可降風險。
+
+### 68. `ship-card-handoff-must-not-depend-on-disk-residue` ｜ hit_by: subsystem·lifecycle（2 路）｜ oracle 型別: 刪工作區直接證偽
+
+- **source**：issue `#649`（closed）＋ `#653`（closed，`#649` 的查證結論）／PR `#654`。
+- **observed**（逐字）：
+  > ship 卡的成果**沒有 harvest 通道**：`manager._harvest_build_candidate()` 只在 `current.current_phase == "build"` 時被呼叫（`manager.py` 的 `_advance` 路徑）。ship 卡在工作區裡 commit 出來的東西，只靠「下一張 ship 卡沿用同一個工作區」才看得到。
+  > 因此**先改 per-job 會造成回歸**：`policy-commit` 會 clone 到一棵沒有 `openspec-archive` commit 的樹。
+  > 它容許 `openspec-archive` 的 `subject_head` 是 `candidate` 的**祖先**，並在 `run.workspace_root` 上跑 `merge-base --is-ancestor`——那條 ancestry 檢查要成立，ship 卡的 commit 就必須已經在來源樹裡
+  > 驗收（逐字）：- [ ] 兩張 ship 卡之間的交接不依賴磁碟殘留（把前一張的工作區刪掉，後一張仍正確）
+  > （#653）`manager._dispatch_workflow_card()` 的第一道判準是 ```python\nif step is None or run.current_phase not in {"plan", "build", "verify", "review"}:\n    return None\n``` **ship phase 永遠回 None**
+- **oracle**：跑一個含 ship phase 的 run，在第一張 ship 卡（`openspec-archive`）完成後**刪除其
+  工作區**，第二張（`policy-commit`）仍必須看到第一張的 commit 並正確完成；且
+  `merge-base --is-ancestor` 的 ancestry 檢查仍成立。加 (b) `direct` 模式零回歸。
+  *fail-open 關鍵*：不刪工作區的版本現況就會過。**「刪掉前一張的工作區」是本 case 的唯一有效
+  動作**——這是直接證偽「靠殘留」的實驗，無法假綠。
+- **harness_needs**：fs 佈置多卡 run；git repo（可用 `make_job_clone`）；工作區刪除能力。
+  **不需模型**（ship 卡由 Manager deterministic 執行，`#653` 已逐字證實不經 launcher）。
+- **determinism_risk**：低。ship 卡無模型參與 → 是本盤點中**少數完全無 LLM 不確定性的端到端
+  case**。生命週期路的 (c) 項（owner uid == Manager uid）需多 UID，**應拆成獨立 tier 2 層級**，
+  `direct` 模式下該項恆真而無鑑別力。
+
+### 69. `verification-evidence-addressing-collides-across-attempts` ｜ hit_by: subsystem·artifact（2 路）｜ oracle 型別: 兩份皆在且可區分
+
+- **source**：issue `#482`（open）＋ `#497`（open）＋ `#571`（旁證）＋ **artifact 路實測**
+  206 個 verification evidence 檔名 × 505 個 job_id。子系統路以
+  `review-absent-evidence-path-collision-blocks-retry` 與
+  `tick-recovered-slice-reprocesses-superseded-job` 兩條命中（同一軸吸收兩個條目）。
+- **observed**（逐字）：
+  > （#482）Cortex writes an immutable absent evaluation with：`reviewer_job_id: null`、reason `reviewer-identity-missing`、path ending in `-absent.json`
+  > If that requested identity is not yet registered, reviewer selection correctly changes to `reviewer-identity-unknown`
+  > `write_gate_evaluation()` resolves the same absent path, sees a different payload, and raises：`RuntimeError: immutable gate evaluation already exists: ...-absent.json`
+  > `gate_evaluation_path() is keyed by slice, builder job, candidate, and nullable reviewer job. All pre-launch failures have reviewer_job_id=None, so distinct attempts/reasons/identity requests collapse to one path.`
+  > （#497）`conflicting verification evidence: .../task-3-private-repo-and-forbidden-documentation-scan-build-0c9faff912201238b238014909c0f58816260575.json (content mismatch)`
+  > The recovered slice had builder_job_id null, candidate null, state pending, and gate_state pending. The old job was no longer the current attempt. Its dispatch base and the target HEAD were the same SHA, so the deterministic evidence path collided
+  > No new builder was dispatched in that tick.
+  > `Verification evidence is keyed only by slice_id plus candidate SHA.`
+  > （#571）「`{slice_id}-{reviewer_job_id}.json` 的 evidence 路徑不含 candidate，registry recovery 重用 job id 時會撞既有 immutable evidence」
+  > （artifact 路實測）206 個 verification evidence 檔名只由 **113 個 distinct `<run短碼>-<card>` 前綴**構成——**job 的序號（`-483`、`-488`…）不在鍵裡**。把 job_id 去掉尾端序號後分群，**83 個前綴由 >1 個 job 共用，涵蓋 366 個 job**。極端例：`wf-437ca052b0-writing-plans` 有 **40 個 job**（含 `-129` failed、`-137` failed exit 137），但只對應 **1 個** evidence 檔。`wf-3fa5c69448-subagent-build` 有 13 個 job、12 個 evidence 檔。
+- **oracle**：「同一 (slice/run, card, candidate) 的第二次嘗試，必須寫到**不同**的 evidence
+  路徑（鍵含 attempt／job identity），且第一次的內容保持不變」。具體：跑完整三步（missing
+  identity → unknown identity → registered ready）於同一 candidate，斷言 (a) 事後**三個互異
+  evidence 路徑皆存在**；(b) **前兩份的內容逐位元組未變**；(c) 第三步恰啟動 **1 個** reviewer
+  job；(d) unknown identity 呈現為 typed needs_human 而非 unhandled RuntimeError。
+  `#497` 分支再加：terminal dirty builder → `recover-pre-candidate` → tick，斷言舊 job 被略過、
+  無 evidence 衝突、**恰好一個**新 builder 被派出；並加 **daemon restart 變體**（`#497` 逐字
+  要求）證明略過在重啟後仍成立。
+  *fail-open 關鍵*：**不可斷言「第二次寫入 raise 即通過」**——fail-closed 的 raise 正是
+  `#482`／`#497` 卡死 run 的原因；要斷言「兩份 evidence 都在、都可讀、且能區分先後」。
+  只斷言「沒有 RuntimeError」則一個「覆寫舊 evidence」的實作會全綠，那直接摧毀稽核鏈。
+  不做 restart 變體 → 一個只存在記憶體的 supersession 標記會過，重啟後 bug 復發。
+- **harness_needs**：fs 佈置 evidence 目錄；identity registry 的三種狀態；tick 推進（同 candidate
+  重跑兩次）；mock provider（讓兩次輸出不同）；**daemon 重啟模擬**（重新載入 registry）。
+- **determinism_risk**：中。「兩次輸出不同」需 mock 保證，真實模型不可用。「dispatch base 與
+  target HEAD 同 SHA」是 `#497` 的觸發條件之一，需刻意構造。
+
+### 70. `abandon-must-archive-then-delete-build-branch` ｜ hit_by: symptom·lifecycle（2 路）｜ oracle 型別: reachability 負向
+
+- **source**：issue `#613`（open），gen1 `workflow-7812` → gen2 `workflow-50b4fb`。症狀路以
+  `abandon-does-not-enumerate-named-resources`（合併 `#613`+`#416`+`#535`）命中。
+- **observed**（逐字）：
+  > gen1 run(workflow-7812)abandon 後：worktree 目錄+registry 由 #544 正確回收 ✅，但 **branch `feature/501-...` 留在主 repo**(含 gen1 的 RED+fix commits)。gen2 run(workflow-50b4fb)的 worktree-isolation provision 同名 branch → `ValueError: existing worktree branch has commits outside requested base` → needs_human。fail-closed 方向正確(不得靜默吸收外來 commits)，但換代必卡。
+  > operator 處置：`git tag archive/501-gen1-<sha>` 歸檔舊代 commits(稽核可達)→ `branch -D` → resume
+  > 修法：branch 上有 commits 時**先 tag 歸檔**(`archive/<work_id>-gen<N>-<sha>` 或等價，保 reachability)再刪；無 commits 直接刪
+  > 收斂方向：**abandon 應窮舉 run 生命週期建立的所有具名資源**(worktree/registry/branch/openspec change/evidence namespace)
+- **oracle**：(a) abandon 一個 build branch 上有 commits 的 run → 下一世代的 `worktree-isolation`
+  provision 必須成功；(b) **reachability 負向（最強）**：被刪 branch 上的 commit SHA 在 abandon
+  後仍必須可達（斷言 `git cat-file -e <sha>` 成功**且存在指向它的 ref**）——單做 (a) 的實作會是
+  `branch -D` 直接丟失 gen1 工作，正是 issue 明確要防的；(c) branch 上無 commits 時直接刪，
+  不留無謂的 archive tag；(d) 廣義不變式：對五類具名資源（worktree／registry／branch／openspec
+  change／evidence namespace）逐類參數化，abandon 後皆不得阻斷下一世代。
+- **harness_needs**：**真實 git repo fixture（含 branch 與 commits）**；registry；fs。
+- **determinism_risk**：低—中。(d) 的第五類（openspec change）處置**未定案**（見
+  evidence-insufficient 22）→ (d) 的參數化應暫時**排除 openspec change**，或只斷言「不阻斷
+  下一世代」這個弱形式。
+
+### 71. `auto-claim-vs-explicit-intake-phase-asymmetry` ｜ hit_by: lifecycle（1 路）｜ oracle 型別: differential ★
+
+生命週期路標為「本路最不易 fail-open 的一條」。**單路命中，但 oracle 型別是最高級。**
+
+- **source**：issue `#420`（closed 2026-08-11），run `workflow-29a1247ddaf88d11eda8`。
+- **observed**（逐字）：
+  > 「daemon periodic auto-claim 自動建立的 run 完成 brainstorm（`brainstorm_required: False`）後**永久停在 `current_phase: define`**、facets 乾淨、零 job，`updated_at` 停在建立當時（>1.5h 未動）。`cortex work resume` 回 `reason: active-workflow`——看到 run 已 active 即早退、把後續 phase 派工交給 periodic tick，但 tick 從不推進「define 已完成但仍在 define phase」的 run。」
+  > 對比：「explicit `cortex work intake` 會在**同一個 request 內**同步跑 define→plan→build（實測前幾個世代皆如此，intake 回傳時 phase 已在 plan）。auto-claim（`run_auto_claim_scan`）只跑到 define 就停，後續無人接手。兩條入口路徑對「define 之後如何續推」的行為不對稱。」
+  > 影響：「ready 說 ready、auto-claim 建了 run、然後無限停滯，無 needs_human、無錯誤，**觀測面全綠**」
+- **oracle**：**differential**——同一組 fixture（同 work item、同 combo、同 mock planning 結果），
+  分別走 (A) `cortex work intake` 與 (B) `run_auto_claim_scan` ＋ N 次 periodic tick，斷言兩者
+  **到達同一個 `current_phase`**。**不需要知道「正確 phase 是哪個」——只需要兩條入口不得分岔。**
+  這使 case 在實作細節改變時仍然有效，且**無法用「兩邊都卡住」來假綠**（A 路徑實測會到 plan，
+  可加 `phase != "define"` 的下界斷言）。
+- **harness_needs**：mock provider（planning 三棒皆成功、確定性回應）；tick 推進（可指定次數，
+  **不得靠 wall-clock**）；registry；時間控制（periodic 間隔壓縮）。
+- **determinism_risk**：中。tick 次數 N 需夠大以涵蓋所有推進步；auto-claim scan 的 work item
+  掃描順序若非確定性，多 item fixture 會 flaky → **fixture 應只放一個 work item**。`#373` 的
+  authority-restart 迴圈會搶佔 resume lane（issue 明載「即使 tick 想接手，mismatch 迴圈也在
+  搶佔」）→ **harness 必須關閉該迴圈或斷言其不活躍**。
+
+### 72. `retry-verify-must-invalidate-stale-exited-job` ｜ hit_by: lifecycle（1 路）｜ oracle 型別: job_id 不等
+
+- **source**：issue `#315`（closed 2026-08-04）。
+- **observed**（逐字）：
+  > 「retry-verify（#216 AC2）把 verify step 打回 pending，但本 run 的舊 verification job row 維持 exited；periodic tick／resume 的 dispatch 路徑對 exited+sentinel 的最新 job 先 terminalize——reviewer sandbox 已於先前失敗清除，input snapshot 實檔不可重驗 → `ValueError: workflow input snapshot file missing` → needs_human，永遠到不了 fresh dispatch。W1 實測：四條 run 於 #313 部署後 retry-verify 全數回 verification-rerun-dispatched，下一輪 tick 全數以 input snapshot file missing 打回。」
+- **oracle**：(a) `retry-verify` 後，本 run 的 exited verify-phase job rows 必須標 `failed`；
+  (b) 下一次 tick 必須產生**新** verification job（斷言 `job_id != 舊 job_id`），而非 terminalize
+  舊 job；(c) **負向**：未經 retry-verify 時，exited verify job 仍照常走 harvest（不得因為放寬
+  而讓所有 exited job 都被丟棄）。
+  *fail-open 關鍵*：(b) 的 job_id 比對是核心——只斷言「沒有 raise」會被「tick 靜默不派工」
+  假綠（那正是候選 60／71 的形狀）。
+- **harness_needs**：registry（job rows）；fs（沙箱已刪的狀態——input snapshot 實檔不存在）；
+  tick 推進；CAS／admission。
+- **determinism_risk**：中。tick 中 dispatch 與 harvest 的相對順序決定 (b) 是否穩定；候選 91
+  （`#564`）指出同窗口另有競態 → **harness 應以單執行緒確定性 tick 而非併發**。
+
+### 73. `tick-failure-does-not-advance-clock` ｜ hit_by: symptom（1 路）｜ oracle 型別: 間隔序列單調遞增＋regression
+
+- **source**：issue `#249`（closed）。
+- **observed**（逐字）：
+  > `~/.agents/log/manager.log` 出現 **17,013 次**相同的 `manager_daemon error: ValueError`，自 2026-07-27 起每 4–5 秒一次、連續 22 小時，log 檔累積超過 51,000 行。
+  > 「systemd unit 設定本身**是正確的**……但 service 進程**從未真的退出**，所以 systemd 的 restart 限流保護從未生效；`systemctl is-active` 一路回報 `active`，形成假健康訊號。」
+  > 根因：
+  > `if not skipped:` / `    last_tick_at = now_fn()` / `    last_tick_monotonic = monotonic_fn()   # 只有成功路徑推進時鐘`
+  > `except Exception as exc:` / `    _log_error(exc)                            # 失敗路徑不推進時鐘`
+  > 「`tick_interval` 預設 300 秒、`poll_interval` 預設 3 秒……5 分鐘週期退化成 3 秒熱迴圈。」
+- **oracle**：以**注入時鐘**驅動：讓 tick 連續失敗，斷言 (a) 相鄰兩次 tick 嘗試的時間間隔
+  **單調遞增**（指數退避）且有上限；(b) 連續失敗達門檻後熔斷（停止嘗試）且 `status.json` 的
+  daemon 區塊出現連續失敗次數與熔斷旗標；(c) 熔斷期間 request 佇列（含人工 tick）仍被處理；
+  (d) **regression**：無失敗時 tick 節奏與現況逐次相同。
+  *fail-open 關鍵*：(a) 必須斷言**間隔序列**而非「不是 3 秒」——單純把失敗路徑也設成固定 300
+  秒會通過弱斷言但仍無退避；(d) 不可省，否則「一律睡很久」的退化修法會通過。
+- **harness_needs**：時間控制（可注入 `now_fn`／`monotonic_fn`——issue 已指出 `run_loop` 用注入
+  的時鐘函式，**seam 現成**）；可注入的 tick 失敗；`status.json` 讀取。不需模型。
+- **determinism_risk**：低。風險僅在若改用 wall clock 測試會 flaky。
+
+### 74. `retry-resets-card-but-never-dispatches` ｜ hit_by: symptom（1 路）｜ oracle 型別: 同 action 內 job 非 null
+
+- **source**：issue `#569`（open），run `workflow-084f75e2178cf7547476`；同型 `#545`（見候選 75）。
+- **observed**（逐字）：
+  > `1. 16:48 verification job wf-865ecb7f70-verification-484（agy，#568 權限缺陷）exit 0 但 log 無 JSON → needs_human。`
+  > `2. 17:3x operator retry-verify（candidate CAS）受理，回 verification-rerun-dispatched 但 job: None——只重置卡片與 facets，未派新 job、未 supersede 舊 job。`
+  > `3. 17:3x–21:24 約 20 個 tick 期間 run（ongoing、facets=[]、verification pending、無 active job）沒有任何新 job 被派；resume 路徑每次重讀 job 484 的壞 log（workflow terminal log has no JSON evidence）。`
+  > `4. 21:24 tick 把 job 484 標 failed、needs_human 回鍋。淨效果：4 小時不可見＋回到原點。`
+  > 根因：「卡片的最新 terminal job 輸出損壞時，**harvest 永遠贏過 dispatch**」
+- **oracle**：**同 action 內完成性**：呼叫 `retry-verify`／`retry-card` 後，在**同一個 action
+  的回傳中**斷言 `job` 欄位非 null，且舊 job 已標 superseded。接著推進 N 個 tick，斷言至少
+  一個新 job 被派出、且舊壞 log **不再被重讀**（以讀取次數計數斷言）。
+  *fail-open 關鍵*：**不可斷言「回傳 `verification-rerun-dispatched`」**——現況就回這個字串卻沒
+  派工；必須斷言**新 job id 存在**。「4 小時不可見」要用 **tick 推進計數**而非 wall clock。
+- **harness_needs**：tick 推進（可注入時鐘／可迴圈驅動）；fs 佈置（壞 terminal log：exit 0 且
+  log 無 JSON）；registry job 表佈置。不需模型。
+- **determinism_risk**：需可控時鐘；`retry-card` 與 `retry-verify` 兩條路徑行為不同（`#569`
+  明言 reviewer 卡沒有等價物）→ **case 需分別覆蓋 builder 卡與 reviewer 卡**。
+
+### 75. `build-mid-card-retry-path-must-exist` ｜ hit_by: lifecycle（1 路）｜ oracle 型別: 新 job_id ＋ immutability
+
+- **source**：issue `#545`（open）＋ `#540` 缺陷二，run `workflow-084f75e2178cf7547476`。
+- **observed**（逐字）：
+  > 「唯一乾淨出路是**以修正後的 prompt 重派 tdd-red 產生新 envelope**——但：`retry-build` 只受理「最後一張 builder 卡」（tdd-red 是中段卡）／`recover-pre-candidate` 要求 null candidate（worktree-isolation 已錨定 candidate）／abandon 換代會燒掉合格的 RED commit 與一個世代（本 run 已耗 2/3）」
+  > （#540 缺陷二）「`resume` 只重讀舊 ledger 再拒一次」
+  > 現場保存：「worktree `feature-518-fix-instance-config-isolation` 含合格 RED commit `1e4f04b`」
+- **oracle**：(a) 中段 builder 卡（`tdd-red`，manifest 證實它夾在 `worktree-isolation` 與
+  `subagent-build` 之間）採信失敗時，`next_actions` 必須非空，且執行後產生**新 job**（斷言
+  `新 job_id != 舊 job_id`）；(b) **immutability 負向**：已採信卡的 evidence 在重派前後 bytes
+  完全相同（issue 逐字：「已採信卡的 evidence 不得重寫」）；(c) 重派不得毀掉既有 candidate
+  commit（斷言 `1e4f04b` 型的 commit 在 worktree 中仍可達）。
+  **刻意不斷言動作名稱**（`retry-build` 放寬 vs `retry-card --card` 兩案；語料顯示已定案為
+  retry-card——`#555`／`#557` 皆以 retry-card 為既有動作——但 oracle 用「存在某動作」表述更耐改）。
+- **harness_needs**：registry（多張 builder 卡、中段卡失敗態）；fs（含 commit 的 worktree）；
+  mock provider；候選 CAS。
+- **determinism_risk**：中。candidate CAS 需精確的 SHA fixture；`worktree-isolation` 是否已錨定
+  candidate 會改變 `recover-pre-candidate` 分支（`#556` 質疑錨定時機過早，OPEN）→ **fixture
+  應同時涵蓋錨定與未錨定兩態**。
+
+### 76. `retry-card-has-no-per-card-circuit-breaker` ｜ hit_by: symptom（1 路）｜ oracle 型別: 閾值型（**弱**）＋ blocking_reason 指名
+
+- **source**：issue `#555`（open，PR `#552` 回報）；動機由 `#617`（open）提供。
+- **observed**（逐字）：
+  > （#555 全文）「`retry-card` 每次 `attempts["build"] +1` 但無上限，也沒有比照 `schema-mismatch:<card>` 的 per-card 熔斷。若 prompt 修正無效（模型仍寫錯 gate 名），operator 可無限重派而不被攔。」
+  > （#617）「repair 迴圈每輪 reviewer 又找到不同的小 findings(502 四條→505 五條,LLM reviewer 非決定性)」，並建議「同 candidate 連續 N 輪 review 都 reject 但 blocking findings 每輪不同 → 停 repair、needs_human 標「review 非收斂」,不無限燒。」
+- **oracle**：以 mock provider 讓同一張卡連續失敗，斷言在第 N+1 次 `retry-card` 時**被拒絕**並
+  轉 needs_human，且 `blocking_reason` **指名該卡 id**。附帶：熔斷後仍存在一條有稽核的重置路徑
+  （避免製造 `#519` 型永久鎖死）。
+  *fail-open 關鍵*：斷言必須含「blocking_reason 指名卡片」——只斷言「第 N+1 次失敗」的話，
+  一個「所有 retry 都拒絕」的退化實作也會通過。
+  ⚠ **oracle 型別偏弱（閾值型）**：N 的預設值**目前未定**（issue 只說「比照
+  `schema_retry_limit`」）——**case 必須把上限當參數讀取而非硬編數字**，否則預設值一改 case 就
+  假紅。「熔斷上限 N 與熔斷後狀態」的裁決見 evidence-insufficient 8；本 case 只做「有一個
+  參數化的上限且被遵守」，不做「N 應該是多少」。
+- **harness_needs**：mock provider（可設定失敗次數）；attempts 計數可讀；action seam。
+  不需真實 model。
+- **determinism_risk**：中（因 N 未定案）。
+
+### 77. `recovery-reports-ok-while-git-registry-stale` ｜ hit_by: symptom（1 路）｜ oracle 型別: 雙向＋真實 git 硬性前置
+
+- **source**：issue `#478`（open），paulsha-cortex 0.1.8 live isolated instance；同型 `#601`（open）。
+  ⚠ **子系統路未深讀 `#478`**（列在其 evidence-insufficient「08-12 波未深讀 6 張」），故僅單路
+  命中——**補讀後可升級**（見「覆蓋缺口」第 1 節）。
+- **observed**（逐字）：
+  > 「Operator ran `cortex slice-action <slice> recover-pre-candidate` → Cortex returned `result: ok` / `slice_state: pending` / `gate_state: pending`. The worktree directory no longer existed. **`git worktree list --porcelain` still showed the same worktree** with the feature branch and `prunable gitdir file points to non-existent location`. **Four seconds later** the manager recorded a new `dispatch-failed` action and changed both slice states back to `needs_human`.」
+  > 根因：「`runner = git_runner or getattr(dispatcher, "_git_runner", None)`；Git cleanup runs only under `if runner is not None`；otherwise Cortex falls through to `shutil.rmtree(target_wt, ignore_errors=True)`。The production dispatcher can legitimately have `_git_runner is None`。」
+  > **測試為何沒抓到**：「The existing recovery test uses a normal temporary directory rather than a real Git worktree, so it proves filesystem deletion but cannot detect stale Git registry state.」
+- **oracle**：用**真實 git repo 與真實 linked worktree**（**非普通 tmp 目錄**），斷言 recovery
+  成功後：(a) worktree 目錄不存在；(b) `git worktree list --porcelain` **無該路徑條目**；
+  (c) slice 與 gate state 皆 pending；(d) 同一 feature branch **可被再次 attach**；(e) 再推一個
+  tick，斷言 slice **不得**退回 `dispatch-failed/needs_human`。負向：git cleanup 失敗時 recovery
+  必須 **fail closed 且不得回 `ok`**。
+  *fail-open 關鍵*：本 case 的全部價值在於「**必須用真 git worktree**」——issue 明言舊測試正是
+  因為用了普通 tmp 目錄而假綠。**harness 契約要把「真 git repo」寫成硬性前置，不可用 mock git
+  runner 取代。**
+- **harness_needs**：真實 git repo ＋ linked worktree 佈置（**不可 mock**）；tick 推進；
+  `_git_runner is None` 的注入。不需模型。
+- **determinism_risk**：git 版本差異（`worktree list --porcelain` 輸出格式、`prunable` 欄位在
+  舊版不存在）；**case 應斷言「無該路徑條目」而非解析 `prunable` 字樣**。
+
+### 78. `ship-orphan-run-retire-delivered` ｜ hit_by: lifecycle（1 路）｜ oracle 型別: 雙向×2
+
+- **source**：issue `#449`（closed 2026-08-11）。
+- **observed**（逐字）：
+  > 「當 work 的實際交付發生在 cortex 管線**外**…cortex 對應的 WorkflowRun 卡在 `status=ongoing`、`current_phase=verify`、`facets=['needs_human']`，且它自己 build 階段建的 PR（記於 `pr_refs`）早已 terminal（merged/closed）。實測 4 個真實案例：add-cortex-version-flag（PR #110 MERGED）、porcelain-skeleton（#132 MERGED）、porcelain-inspect（#145 MERGED）、release-pipeline（#171 CLOSED）。」
+  > Gap 1：「pre-delivery 閘門會拒絕任何有 `pr_refs`／ship-passed 的 run（`workflow abandon only permits pre-delivery run`）。於是這種 run **不能 abandon**（有 pr_refs），也**不能 ship**（candidate dirty），永久卡 needs_human。」
+  > Gap 2：「`load_work_authority` 在 durable provider authority snapshot 因 rate-limit degraded 時直接 raise `REASON_PROVIDER_RATE_LIMITED_CANONICAL`——**正好在系統被限流、最需要清 stuck run 時把清理擋死**。」
+- **oracle**：兩組雙向。(a) 所有 `pr_ref` 皆 terminal（merged/closed）→ `retire-delivered` 必須
+  成功並落 audit evidence；(a') **任一** pr_ref 仍 open → 必須拒絕（issue 逐字：「不弱化既有
+  abandon 的 pre-delivery 嚴格性」）；(b) rate-limit degraded 且有 last-known-good revision →
+  退休類 action（abandon／retire-delivered）必須可執行；(b') 同條件下 `claim`／`start`
+  **仍必須** fail-closed。
+  *fail-open 關鍵*：(a')(b') 是防 fail-open 的兩道——只做 (a)(b) 會製造一個**能繞過交付檢查與
+  限流保護的萬用出口**。
+- **harness_needs**：mock GitHub provider（PR 狀態、429／degraded、last-known-good snapshot）；
+  registry；evidence 目錄。
+- **determinism_risk**：中。degraded 狀態與 last-known-good revision 的組合態需精確佈置；
+  provider snapshot 的新鮮度判準若改變會影響 (b) 的觸發。
+
+### 79. `local-closeout-must-not-require-pr-binding` ｜ hit_by: lifecycle（1 路）｜ oracle 型別: 零 external mutation 負向斷言
+
+- **source**：issue `#263`（closed 2026-07-30），2026-07-30 auto-run dogfood `#252`～`#254`。
+- **observed**（逐字）：
+  > 「exact-head review 已完成後，`resume` 先執行 PR-metadata preflight；在尚未建立／綁定 PR 時直接失敗，導致本來可以本地完成的 OpenSpec archive／closeout 也無法推進。」
+  > 「frozen planning／report artifacts 在部分 reviewer worktree 或 sandbox 中以 untracked overlay、未完整 materialize 或缺乏 hash attestation 的形式存在。reviewer 是否真的讀到 run 所凍結的 authority，不能只靠 prompt 宣稱。」
+  > 「目前流程把「本地 deterministic closeout」、「review input materialization」與「需要 GitHub mutation 的 ship」混在同一前置鏈上。」
+- **oracle**：取 issue 驗收條件三條：(a) pre-PR run：local archive/closeout gate 可完成，ship
+  停在明確的 PR-binding／authorization 邊界（斷言停止點的 reason 具名）；(b) **零 external
+  mutation 的 negative 斷言**——mock GitHub provider 記錄所有 write call，斷言 **call 清單為空**
+  （**最強的一條，無法用「看起來沒開 PR」假綠**）；(c) reviewer verdict 回填其實際讀取的
+  artifact manifest hash，不符時 fail closed（正向：相符時通過；負向：manifest hash 漂移時
+  必須拒）。
+- **harness_needs**：mock GitHub provider（可記錄／斷言零 write）；fs（reviewer workspace、
+  frozen artifacts）；registry。
+- **determinism_risk**：低。(c) 的 manifest 形狀（相對路徑／hash／revision／candidate SHA
+  四欄，issue 逐字列出）若實作只落其中兩欄，case 需相應收斂——但四欄皆為 issue 明列驗收條件，
+  非推測。
+- **附註**：這是 ship／delivery 區段第四條、也是**唯一觸及 delivery 前置鏈語意**的候選。
+
+### 80. `exit-zero-without-commit-never-completes` ｜ hit_by: symptom（1 路）｜ oracle 型別: 存在性型（**弱**）＋契約檢查
+
+- **source**：issue `#119`（closed）＋ `#340`（closed，同型復發）。
+- **observed**（逐字）：
+  > （#119）headless builder（copilot/gpt-5.4）於 worktree **實作了正確改動但不 commit**，導致完成偵測（`dispatcher.poll_done`：branch head ≠ dispatch_head baseline 才標 done）永遠不觸發——job 恆停在 `dispatched`。實測「`coordinator tick --executor copilot --allow-unsafe` 派 build slice → worker exit 0、worktree 有 5 個 modified 檔（正確實作 plan）、但 `git log dispatch_head..HEAD` 為空」，**2 次一致**。
+  > （#340）同批 6 個 build slice……2 個 slice 的 executor 完成所有檔案修改（含測試與 changelog fragment、各 11/17 個檔案）後**從未呼叫 git commit** 就 exit 0。dispatch jsonl 全文搜尋 `git commit` 只命中 persona contract 的工具清單，無任何實際執行。
+- **oracle**：兩段。(1) **不得把 exit 0 當完成**——mock executor 改檔但不 commit、回 exit 0，
+  斷言 job 不得進入 `done`，且**必須產出可讀的診斷**（非裸 `dispatched` 卡住）；(2) **契約
+  檢查**——builder persona contract 必須含「完成時 MUST `git add` 全部變更並 `git commit`；
+  worktree 不乾淨即視為未完成」這條義務（`#340` 建議 1）。
+  *fail-open 關鍵*：(1) 的 pass 條件是「**產出診斷**」，不是「不進 done」——後者現況就成立
+  （恆停 dispatched），寫成後者等於把 bug 當期望值固化。
+  ⚠ **oracle 型別偏弱（存在性型）**：「產出診斷」可被任何字串滿足。建議把 (2) 的契約檢查
+  （純字串／集合）當主判準，(1) 當輔證。
+- **harness_needs**：mock provider（改檔、不 commit、exit 0）；git 工作區佈置（worktree ＋
+  `dispatch_head` baseline）；完成偵測可單獨驅動。
+- **determinism_risk**：低。git 操作確定；需固定 git 版本以免 `worktree` 子命令輸出格式差異。
+
+### 81. `completion-draft-nondeterminism-and-quarantine` ｜ hit_by: artifact（1 路）｜ oracle 型別: distinct 內容數 == 1
+
+- **source**：**artifact 路實測**：`~/.agents/coordinator/evidence/completion-drafts/`（55）、
+  `completion/`（7）、`completion/quarantine/`（13）。
+- **observed**（逐字）：
+  > 55 個 draft 分屬 10 個 `(run_id, candidate)` 組，其中 7 組有 >1 個 draft。極端：`workflow-aac760e88972156e8b6a-9a97804d2500cf50a12099b3e9bc7f5bbded44bc` 有 **18 個 draft，18 個都是不同內容雜湊**；`workflow-aaa7219e0ed2d4ac3948-…` 有 **13 個 draft、13 個不同內容**。每組最終只有 1 個 draft 與 final 位元組相同。
+  > quarantine 的 13 筆與 final 的 schema **完全相同（21 鍵）**，逐欄位 diff 後只差 `completed_at` 與 `work_authority` 兩欄——例如 quarantined `…-53c69196e082431f812d2ac618fec67c.json` 的 `completed_at = "2026-07-23T04:13:23.598463+00:00"`，final 為 `"2026-07-23T11:44:46.108428+00:00"`（相隔 7.5 小時）。
+- **oracle**：「同一 (run, candidate) 的 completion record 必須是輸入的確定性函式：給定相同
+  evidence 集合，重跑 N 次產生的 draft **位元組必須相同**（`completed_at` 等時間欄位由注入
+  時鐘決定）」。
+  *fail-open 關鍵*：**不能只斷言「final 存在」**——18 個互異 draft 中挑 1 個成功，這種斷言恆真。
+  要斷言「**draft 集合的 distinct 內容數 == 1**（扣除時間欄位）」。
+- **harness_needs**：mock provider；**時間控制（凍結／注入時鐘）**；fs 佈置。
+- **determinism_risk**：高。`completed_at` 必須由 harness 控制，否則永遠不相等。
+
+### 82. `snapshot-item-updated-at-equals-write-time` ｜ hit_by: artifact（1 路）｜ oracle 型別: 未變 item 的 `updated_at` 不變
+
+- **source**：**artifact 路實測**：`~/.agents/monitor/work-items.snapshot.json`
+  （`schema: "work-items-snapshot/v1"`，390 items、904 source_owners、1.8 MB）。
+- **observed**（逐字）：
+  > 390 個 work item 的 `updated_at` **只有 1 個 distinct 值**，且該值 == 檔案的 `written_at`（`2026-08-17T00:32:09.250576Z`）。亦即 per-item 的變更時間根本沒被追蹤，整檔重寫時全部蓋成同一時刻。
+  > （其他一致性檢查通過：`work_id` 無重複、無任一 `source_id` 被 >1 個 work item 宣告、35 個 `workflow_run_id` 全部能在 `jobs.json` 找到對應 run。）
+- **oracle**：「snapshot 重寫時，內容未變的 work item 其 `updated_at` 必須保持不變；只有實際
+  欄位變動的 item 才更新」。具體：連寫兩次 snapshot（中間推進注入時鐘），斷言未變 item 的
+  `updated_at` 不得改變。
+  *fail-open 關鍵*：**任何以 `updated_at` 判定「陳舊 work item」的檢查，在現況下都恆為假綠燈。**
+- **harness_needs**：fs 佈置；時間控制（兩次寫入之間推進時鐘）。
+- **determinism_risk**：低（時鐘由 harness 注入）。
+
+### 83. `handoff-manifest-lacks-repo-attribution` ｜ hit_by: artifact（1 路）｜ oracle 型別: repo 實際值相等
+
+- **source**：**artifact 路實測**：33 個 handoff manifest 逐一 dump ＋
+  `~/.agents/control/status.json`；旁證 `#465`（closed）、`#469`（closed）。
+- **observed**（逐字）：
+  > 33 個 handoff manifest 的 keyset **完全一致（19 鍵）**，且**沒有任何 repo 歸屬欄位**（無 `repo`／`workflow_repo`／`work_authority`）：`(branch, completed_at, completion, completion_record_hash, completion_record_path, exit_code, gate_reason, gate_status, gate_verdict, job_id, plan_hash, review_evaluation_hash, review_evaluation_path, slice_id, slice_state, spec_hash, verification_evidence_hash, verification_evidence_path, verification_hash)`。
+  > （#465）「`handoff.write_manifest`（約 L1965-2012）組出的 manifest dict **沒有任何 repo 歸屬欄位**——即使 job record 派工時就帶著 `workflow_repo`」「`manager_daemon._repo_from_manifest`（約 L200）依 #230 的契約讀 manifest 的 `repo`／`workflow_repo`／`work_authority.repo`，缺就明確回 `null`、不從 branch 推斷——所以 workflow-lane 的 recent_done 永遠 `repo=null`」。
+  > **修復後的現況**（實測 `control/status.json`）：`recent_done` 10 筆全部帶 `repo: "hamanpaul/paulsha-cortex"`，且 10 筆的 `branch` 與 `jobs.json` 中對應 job 的 `branch` **逐筆吻合（0 筆不符）**。但 `attention` 中那一筆 slice 型 entry 仍是 `repo: null`。
+- **oracle**：「job 終局後寫出的 handoff manifest 必須含 repo 歸屬；下游投影（`status.json` 的
+  `recent_done`／`attention`）的 `repo` **不得為 null**」。
+  *fail-open 關鍵*：`_repo_from_manifest` 現行行為是「缺就回 null」——測試若只斷言「不 raise」
+  會空過。**要斷言 `repo` 的實際值等於預期 repo 字串。**
+- **harness_needs**：fs 佈置；tick 推進到 job 終局。不需 provider（可用 deterministic 卡）。
+- **determinism_risk**：低。
+
+### 84. `report-artifact-hashed-but-bytes-never-preserved` ｜ hit_by: artifact（1 路）｜ oracle 型別: 可還原數 == 宣稱數
+
+- **source**：**artifact 路實測**：`evidence/workflow/*.json` 的 `artifacts[]` × repo 工作樹 ×
+  `git log --all`。
+- **observed**（逐字）：
+  > evidence 共引用 **77 個 distinct report 路徑**（review 45、verify 30、plan 2）。其中：
+  > ‧ **69 個在 repo 工作樹中不存在**
+  > ‧ 抽三個做 `git log --oneline --all -- <path>`：`reports/review/2026-07-26-fix-slice-failed-deadend.md`、`reports/verify/onboarding-docs.md`、`reports/review/fix-preflight-closeout-order-review.md` **全部零 commit（從未進入任何 ref）**
+  > ‧ evidence 只存 `sha256`，**不存內容**——對照 `evidence/workflow-inputs/` 的 155 個檔案，每一個都完整保存 `content` 欄位（且 571 筆 `input_snapshot` 的 `content_ref` 全部存在、`sha256` 全部吻合，0 筆不符）。
+  > 即：**input 端保存位元組、output（report）端只保存雜湊**——verify／review 兩個 phase 的人類可讀交付物在系統中不可回溯。
+- **oracle**：「任何被 evidence 以 `sha256` 宣稱的 artifact，其位元組必須可從系統內某處還原
+  （content-addressed store 或 git ref），且還原後的 sha256 必須等於宣稱值」。
+  *fail-open 關鍵*：**不得寫成「檔案存在就 pass」**——69/77 不存在時迴圈跳過即空過。
+  **要斷言「可還原數 == 宣稱數」。**
+- **harness_needs**：fs 佈置（evidence ＋ content store ＋ git fixture repo）；需 git。
+- **determinism_risk**：低—中。「report 不進 git」可能是刻意設計（見 `report-cleanup` evidence）
+  → oracle 應要求「**可還原**」而非「在 git 裡」。
+
+### 85. `report-cleanup-does-not-account-for-all-referenced-reports` ｜ hit_by: artifact（1 路）｜ oracle 型別: 三集合差為空
+
+- **source**：**artifact 路實測**：39 筆 report-cleanup evidence × evidence/workflow 的 artifacts。
+- **observed**（逐字）：
+  > 39 筆 cleanup evidence 共登記 **50 個 report 路徑**（`payload.reports[].{path, sha256}`，`schema: "cortex-workflow-report-cleanup/v1"`）。與前一條的 69 個「已消失」report 交集後：
+  > ‧ **50 個有 cleanup 紀錄可解釋**
+  > ‧ **19 個沒有任何 cleanup 紀錄**，包含：`reports/review/2026-07-26-docs-archived-spec-purpose-review.md`、`reports/review/2026-07-26-fix-slice-failed-deadend.md`、`reports/review/2026-08-16-fix-verification-contract-hash-overwrite-review.md`、`reports/review/fix-preflight-closeout-order-review.md`、`reports/verify/2026-07-26-docs-monitor-load-config-verify.md` 等。
+  > 即：report 的消失有兩條路徑，只有一條被 journal 記錄。
+- **oracle**：「evidence 宣稱過的 report 若不在工作樹／git，必須存在一筆 cleanup evidence 覆蓋
+  該路徑；`宣稱集合 − 現存集合 − cleanup 集合` 必須為空集」。
+  *fail-open 關鍵*：**明確斷言三個集合的大小**，不要只做 `for p in cleanup: assert ...`
+  （cleanup 集合本身可能為空而空過）。
+- **harness_needs**：fs 佈置；git fixture。
+- **determinism_risk**：低。
+
+## T4 — 需 crash／fault 注入、並行 seam、多世代驅動（7 筆）
+
+### 86. `define-run-stalls-artifacts-published-state-never-written` ｜ hit_by: symptom·subsystem·lifecycle（3 路）｜ oracle 型別: 事務性＋可見性
+
+子系統路把它拆成兩條（`planning-define-ongoing-run-invisible-to-all-recovery-loops` 與
+`planning-publish-and-run-state-not-one-transaction`，同一軸吸收兩個條目）；本清單以**同一個
+真實 run 事故**為單位合併，兩條 oracle 限肢皆保留。
+
+- **source**：issue `#536`（open→PR `#538` tick resume 最小修、PR `#553` 事務邊界），
+  run `workflow-7a430d31eff66ef13630`，work_id `fix-instance-config-isolation`。
+- **observed**（逐字）：
+  > workflow run 停在 `define`／`status=ongoing`／**facets 空**（非 needs_human），但：brainstorm 實際已成功——spec 與 design **已發佈到 operator worktree**；run 記錄卻完全沒推進：`updated_at` 停在建立時刻、`evidence_refs=[]`、`gate_refs=[]`、只有 `workflow-claim` 一張卡 passed；無 planner 行程存活、manager log 無任何錯誤；**之後永遠不會有任何機制碰它**。
+  > 實測時間：`12:53:51Z` 建立 → `~12:56Z` spec/design 落地（檔案 mtime）→ 此後 25+ 分鐘零變化。
+  > 根因：`manager_daemon.py:954` `if workflow.current_phase not in {"plan","build","verify","review"}: continue`——「define 階段的 ongoing run 不在任何自動恢復路徑上。」
+  > 建議 2（逐字）：「planning 的『發佈 artifacts』與『更新 run 狀態』必須是同一個事務單位——現況可以發佈成功而狀態不動，直接製造 #416/#535 型殘留」
+  > 「發佈成功的 spec/design 成為 operator worktree 的未追蹤殘留——下一次 define 重試會撞 `#416` 的 authority fail-closed 或 no-clobber（`#535` 同型），**成功產出再次變成下一輪的地雷**」
+- **oracle**：兩條限肢，皆須。
+  **(A) 可見性不變式**（第一條已可由 checkout 驗證期望值：0.1.8 `manager_daemon.py:1026` 現為
+  `{"define", "plan", "build", "verify", "review"}`，即修法方向 1 已落地）：`tick resume` 的
+  phase 白名單必須涵蓋 manifest 中出現的**每一個非終態 phase**，由 `workflow-manifests` 的
+  phase 集合驅動參數化——新增 phase 而忘了加白名單即紅。並斷言：構造一個 define/ongoing、
+  artifacts 已落盤、facets 空的 run，跑一次 tick 後**必須**滿足其一：run 推進到下一 phase，
+  或 `facets != []` **且** `next_actions != []`。
+  **(B) 事務性**：在「artifacts 已寫入磁碟、run 狀態尚未寫回」的窗口注入 crash，斷言重啟後
+  處於一致狀態之一：artifacts 已回滾，或 run 狀態已推進（**不得兩者中間**）。具體斷言：
+  **若 run 狀態未更新，則 operator 樹上不得留下本世代的 artifact 檔（列目錄比對）**。
+  *fail-open 關鍵*：(A) 只斷言「tick 沒拋例外」正是本 bug 的現況（tick 靜默 continue）；也**不可**
+  寫成「run 被推進」（正確行為可能是「標記為需人工」）。(B) 只斷言 run 狀態一致 → 殘留檔仍在，
+  下一代照樣中地雷，**必須斷言檔案系統**。
+- **harness_needs**：registry 佈置（define/ongoing/facets 空）；fs（spec/design 已落地但未登記）；
+  tick 推進；**crash 注入 seam**（發佈與狀態更新之間）；mock planning provider；時間控制
+  （心跳閾值）。
+- **determinism_risk**：中。crash 注入點需要程式碼 seam；**若實作把兩步合成單一原子寫，注入點
+  會消失** → case 需依賴公開的事務邊界 API 而非內部呼叫順序。無 seam 時 (B) 退化為不可測——
+  建議先以「publish 與 state write 是否在同一事務函式內」的結構斷言代替，待 seam 落地後升級。
+  phase 集合常數需同源引用。issue 建議 3 的「phase 層級心跳／deadline」**閾值未定案** →
+  oracle 刻意不含時間閾值，只測「進入恢復迴圈視野」。
+- **⚠ 伴生問題不進本 case**：同一時間窗三份前代 brainstorm evidence 被刪除，歸屬未查明，
+  且 artifact 路實測與 issue 敘述矛盾（見 evidence-insufficient 5）。
+
+### 87. `abandon-must-reclaim-planning-artifacts-and-evidence` ｜ hit_by: symptom·lifecycle·artifact（3 路）｜ oracle 型別: 換代可重跑端到端＋保護性負向
+
+- **source**：issue `#416`（closed，run `workflow-21813110c6dfc97fa891`）＋ `#535`（open，
+  work_id `fix-instance-config-isolation`）；**artifact 路實測該 evidence 檔仍在磁碟上**。
+  `#535` 自陳這是「**前代殘留阻斷下一世代**」模式的**第六個實例**。
+- **observed**（逐字）：
+  > （#416）「gen2（workflow-e18785ac）define 成功發佈 spec/design 到工作樹（未提交），隨後因 #414 在 build 卡被棄單。gen3 重新 claim 後 brainstorm 再跑，integrator 寫同一 destinations 時：`primary-artifact-write-rejected: ValueError: planning artifact lacks current planning authority: docs/superpowers/specs/fix-log-error-dedup-v3-design.md`」
+  > 根因：「**run 被 abandon 時無人回滾已發佈未提交的 artifacts**（abandon 只動 registry/facets，不知道 publication 的存在）」
+  > （#535）`ValueError: planning artifact no-clobber conflict: evidence/planning/brainstorm-195d98ade85c884ded70289af1521935.json`
+  > 時間軸：「12:52 resume 舊 run（workflow-88d089d71416a754dda8）：brainstorm 實際執行成功、寫出 brainstorm-195d98…json（12KB，mtime 12:53:10＝該 request 完成時刻）——但 run 隨即被更早的失敗 evidence（content 分類）擋下」「12:53 新世代 work start：brainstorm 重跑、產出內容幾乎相同的 evidence → content-addressed 檔名相同 → publish() 的 no-clobber fail-closed（manager.py:5644）」
+  > 「publish() 對 evidence 的冪等豁免條件是 before == content（byte-identical）。兩個世代的 brainstorm 輸出**語意相同但 byte 不同**」
+  > （artifact／症狀路實測佐證）該檔確實仍在 `/var/lib/cortex/legacy-imported/coordinator/evidence/planning/`（12 KB / 16926 bytes，`kind: "brainstorm-peer"`，mtime Aug 15 13:25）。同目錄可見命名空間後來已 gen-scope 化（新檔為 `brainstorm-workflow-<run_id>-<hash>.json`，如 `brainstorm-workflow-50b4fb018b3412a7f487-5ff00bc87edf73dbef0af3d17a17e662.json`），舊檔為裸 `brainstorm-<hash>.json`——**兩種命名並存於同一目錄**。且它正是候選 21 那筆雜湊不可驗證的檔案——**同一個檔案同時卡住兩件事**。
+- **oracle**：**窮舉式而非逐項式**。(a) abandon 一個已發佈未提交 planning artifacts 的 run →
+  **下一世代的 define 必須能完成**（端到端斷言，不只是「檔案被刪」）；(b) **保護性負向**
+  （`#416` 建議 1 逐字）：殘留檔的 hash 與發佈時**不一致**（被人動過）→ **不得刪除**，必須
+  留檔並記 diagnostics；(c) evidence 命名空間：abandon 後同名 content-addressed evidence 檔
+  不得阻斷下一世代（歸檔或 gen-scope 皆可，**斷言「下一世代成功」而非斷言實作手段**），且
+  **舊世代 evidence 必須仍可讀（歸檔而非刪除）**，新舊兩份都存在且可區分世代。
+  *決定性斷言*：**abandon → 立刻重新 claim 同一 work item → 新世代必須能走到與前代相同的階段**。
+  *fail-open 關鍵*：逐項 case 已被證明會漏（`#535` 自陳這是第六個實例）——必須加上「換代可
+  重跑」這條端到端斷言，它對未來新增的資源型別自動有效。**且資源清單應由程式導出而非硬編**，
+  否則新增資源時 case 不會跟著紅。(b) 極重要——只做 (a) 的實作會變成「abandon 時無條件清空
+  工作樹」，那正是候選 88（`#507`）已造成資料遺失的同一種錯誤。不得以「捕捉 no-clobber 例外
+  後續跑」通過。
+- **harness_needs**：fs（已發佈未提交的 artifacts、content-addressed evidence 檔、openspec
+  change 目錄）；真實 git repo（branch／worktree）；registry（多世代 run）；abandon ＋ claim
+  兩個 action；**多世代驅動**；mock launcher（**讓下一世代的 brainstorm 產生 byte 不同但語意
+  相同的輸出**）。
+- **determinism_risk**：中。mock 必須**刻意注入 byte 差異**，否則 no-clobber 的冪等豁免會讓
+  case 假綠。「content-addressed 檔名對什麼計算」在 `#535` 中本身是開放問題（原文：「檔名相同
+  （content-hash 對正規化後的 pack 計算？或對部分欄位）」）→ **fixture 必須直接構造出檔名
+  碰撞，不可依賴真實 hash 推導**。
+
+### 88. `planning-rollback-wipes-concurrent-operator-work` ｜ hit_by: symptom·subsystem·lifecycle（3 路）｜ oracle 型別: 雙向＋越界仍須偵測
+
+- **source**：issue `#507`（open→PR `#543`），run `workflow-0529388d8e290c8fb938`
+  （work_id `fix-rate-limit-classification`，phase `define`，combo `feature-oneshot`）；
+  **輔語料直接驗證 evidence 實體存在**。
+- **observed**（逐字）：
+  > 「planning 階段若偵測到 operator worktree 有變動，`_restore_operator_tree()` 會**刪除該 worktree 內除 `.git` 以外的全部內容**，再從啟動當下的 baseline 複本還原。偵測條件無法分辨『planning launcher 越界寫入』與『operator（或其他 agent／程序）在同一時間正常編輯』——後者的工作會被**靜默銷毀且無備份**。」
+  > `:205-224` — `_restore_operator_tree()` 逐一 `child.unlink()` / `shutil.rmtree(child)`（僅跳過 `.git`）
+  > 實測：operator 新建的 `docs/superpowers/workstreams/fix-read-repo-tier-fail-closed/todo.md`「在 planning 視窗內被整棵樹還原抹除」。時間軸 `2026-08-13T23:45:18Z` 建立 → `23:46:10Z` 失敗。「視窗**之前**已存在的修改…因為已被納入 baseline 而倖存——正好佐證「還原到 T0 baseline」的語意。」
+  > 「後果不只丟檔：……檔案被抹除後 registry 留下懸空連結，work item 的 `active_todo` 為假 → lifecycle 停在 `topic` → 不可 claim。單一次抹除同時造成資料遺失與 registry 不一致。」
+  > **輔語料驗證**：`evidence/planning-recovery/workflow-0529388d8e290c8fb938-207a11a5….json` 實體存在，內容逐字為 `{"classification": "content", "created_at": "2026-08-13T23:46:10.204498+00:00", "reason": "secondary-output-malformed: ValueError: planning launcher modified operator worktree; changes rolled back", "run_id": "workflow-0529388d8e290c8fb938", "schema": "cortex-planning-failure/v1"}`
+- **oracle**：(a) planning 期間第三方**新增未追蹤檔** → 斷言該檔在 planning 失敗後**仍存在**
+  （**內容逐位元組不變**，或可從 evidence 記錄的備份路徑／`git stash create` 物件完整復原，
+  且 evidence 必須含該路徑）；(b) planning 期間**修改既有 tracked 檔** → 斷言修改仍在；
+  (c) **真正的 launcher 越界寫入**（以 sandbox 外絕對路徑寫入）**仍必須被偵測並報告 diff**
+  （路徑清單＋雜湊，斷言清單非空且含該路徑）。兩情境的失敗訊息都必須可辨識（區分
+  `operator-concurrent-edit` 與 launcher 越界）。
+  *fail-open 關鍵*：(c) 不可省——(a)(b) 單獨存在會讓「乾脆不做 snapshot 比對」通過而拆掉整個
+  安全網。且 (a) 必須斷言**內容相同**而非「檔案存在」（還原後檔案可能存在但內容是 baseline 版本）。
+  *表述選擇*：若實作改採建議 4 的 advisory lock，(a) 的形狀會從「檔案倖存」變成「第三方寫入被
+  lock 擋下」——兩者都滿足「**operator 工作不得被銷毀**」，故 **oracle 應以該不變式表述**而非
+  以檔案存在表述。
+- **harness_needs**：**真實 fs（不可 memfs——測的就是「檔案有沒有被 unlink」）**；git worktree
+  含 tracked／untracked 檔；**在 `_tree_snapshot(T0)` 與 `_tree_snapshot(T1)` 之間注入第三方
+  寫入的 seam**（不是 sleep）；mock planning launcher（可分別扮演「乖」與「越界」兩種）。
+- **determinism_risk**：中。「在窗口內寫入」需 seam 而非 sleep；`_tree_snapshot` 對 uid/gid/xattr
+  敏感（`#551` 明確記錄此風險），case 環境需固定這些屬性，否則會有無關的 mismatch；**在多 UID
+  harness 下可能誤報**。
+
+### 89. `needs-human-must-always-carry-structured-reason` ｜ hit_by: symptom·lifecycle（2 路）｜ oracle 型別: 全庫不變式 ★
+
+- **source**：issue `#527`（open），run `workflow-6607ac1307feb02ffe06`。issue 自陳這是**第四次**
+  命中同類。
+- **observed**（逐字）：
+  > `run: 6607ac13 | phase: build | status: ongoing | facets: ['needs_human']`／`evidence_refs: []`／`passed cards: workflow-claim, brainstorming, openspec-propose, writing-plans`／`pending cards: worktree-isolation, tdd-red, subagent-build`
+  > 「時間軸：`14:58:28` 進入 `build`、facets 為**空**；約兩分鐘後 facets 變成 `['needs_human']`，期間無 evidence 落檔、journal 無相關輸出。」
+  > 後續操作：`tick` → `dispatched: []`、`errors: []`／`complete` → `errors: []`、`needs_human: null`／`cortex status` → 本 run 不出現在任何清單／`cortex work show` → `next_actions: []`
+  > 「四次獨立命中同一類缺陷，顯示這不是個別疏漏，而是『狀態轉換未強制附帶可稽核理由』的系統性缺口。」
+- **oracle**：**全庫不變式（invariant test，非情境 test）**：掃描所有會把 `needs_human` 加進
+  facets 的程式路徑，斷言每一條都同時寫入 reason／evidence；以「無理由不得設置」為**型別或
+  API 層強制**（設 facet 的函式強制要求 reason 參數），再以測試斷言不存在繞過點。
+  附帶：`cortex status` 必須呈現 needs_human 的 workflow run；`work show` 的 `next_actions`
+  不得為空陣列（無動作時須給明確說明）。負向：合法的無 reason facet（如 `blocked`）不得被誤擋。
+  *fail-open 關鍵*：**情境式 case 只能擋住已知的一條路徑**，而語料顯示同型已復發四次
+  （`#511`/`#514`/`#515`/`#527`）——必須寫成全庫掃描式不變式，否則第五條路徑照樣漏。
+  本 repo 已有此模式先例（`#563`「全庫不變式測試」）。
+- **harness_needs**：registry 更新 API 的攔截 seam；或靜態掃描 ＋ 動態雙軌；tick 推進。
+  不需 model、不需時間控制。
+- **determinism_risk**：低（不變式測試本質確定）。風險在 **seam 覆蓋率**——若有路徑繞過 registry
+  API 直接寫狀態檔，不變式測不到 → **case 應附一條「facets 只能經由該 API 變更」的次級不變式**。
+  靜態掃描對 reflection／動態 dispatch 有盲點；建議以 API 強制為主。
+
+### 90. `infer-repo-root-hijack-and-test-hermeticity` ｜ hit_by: symptom·subsystem（2 路）｜ oracle 型別: 擾動矩陣「與乾淨環境相同」
+
+症狀路把它命名為**「環境形狀敏感的採信判準」**族，並指出這是本 repo 自己命名的族——`#608`
+逐字：「凡發現全套 pytest 對 host 環境形狀敏感的測試,一律視為 P1(它們汙染採信判準)」。
+
+- **source**：issue `#565`（closed）＋ `#612`（open）＋ `#586` ＋ `#608`（closed）＋ `#610` ＋
+  `#303`（六個獨立實例）／PR `#607`、`#630`／既有 fixture
+  `tests/git_fixtures.py::make_empty_git_dir`。
+- **observed**（逐字）：
+  > （#565）「builder job 執行期間（16:35:08）有行程在 /tmp 建立了**空的** `.git` 目錄（mkdir 而非 git init）……`_infer_repo_root` 對任何 /tmp 下路徑走親層搜尋時，把空的 `/tmp/.git` 當 repo 根 → 回傳 `/tmp`；`tests/test_fix_dispatch_spec_path.py` 的推斷測試在本機必炸（**CI 無汙染故綠**）——gate ledger 的全套 pytest 因此 fail，**合格 candidate 被拒**。」
+  > （#612）「`_infer_repo_root` 的 cwd fallback 是危險預設:相對路徑輸入使 production 動作(git fetch 等)落在真實 checkout」
+  > （#608）「`tests/test_monitor_work_api.py` 有 3 個測試在 `TMPDIR` 為長路徑時必紅——AF_UNIX socket 的 `sun_path` 上限 108 bytes,tmp_path 一長 bind 就 EINVAL/ENAMETOOLONG。」並：「**每一個都可能讓合格 candidate 被 GateContradictionError 拒絕**。」
+  > （#610）`Network access to "github.com" was blocked: domain is not on the allowlist for the current sandbox mode.` / `exit -1`，且「分批跑各測試檔幾乎全綠……porcelain 批次首跑也曾在中途被同樣阻擋、重跑同批卻過——**網路呼叫是條件性/順序敏感的**」
+  > （#303）三個測試「直接讀取宿主的 `~/.agents/coordinator/jobs.json`」，「四個 builder worktree 的 `PSC_GATE_CMD_PYTEST` gate 全紅，失敗來源是宿主狀態而非候選程式碼。CI 環境乾淨所以綠，形成『本地 gate 紅、CI 綠』的假訊號。」
+- **oracle**：**不逐例修，改成守衛**（`#610` 自陳「一勞永逸,防第五次」）。
+  **(A) production 層**：`_infer_repo_root` 遇到**無 `HEAD` 的 `.git` 目錄**必須繼續往上找
+  （斷言回傳值不是該目錄的父層）；且相對路徑輸入不得 fallback 到 cwd（斷言 fail-closed）。
+  **(B) conftest 守衛三道**，並斷言其生效：(1) socket 攔截——測試期間任何非 localhost／非
+  AF_UNIX 的 connect 一律 fail（附白名單）；(2) host 狀態隔離——任何測試觸及
+  `$PSC_AGENTS_ROOT`／`~/.agents` 即 fail；(3) repo root 推斷不得落在共用根（`/tmp`）且必須
+  驗 `.git` 為真 repo。
+  **(C) 形狀擾動矩陣**：以 `TMPDIR=<很長的路徑>`、`/tmp/.git` 存在、無網路 三種擾動各跑一次
+  全套，斷言結果與乾淨環境**逐測相同**。
+  **(D) 測試自身的 hermeticity**：harness **主動建立** `/tmp/.git` 形狀的汙染
+  （用 `make_empty_git_dir`），斷言推斷測試**仍然通過**。
+  *fail-open 關鍵*：(C) 的斷言是「**與乾淨環境結果相同**」，**不是「全綠」**——若某測試在兩種
+  環境下都紅，那是真缺陷，不該被這條 case 掩蓋。守衛 (1)(2)(3) 必須各自附一條「守衛會擋」的
+  自測（故意違反 → 必須 fail），否則守衛壞掉沒人知道（本 repo 已有「檢查存在但檢查本身壞掉」
+  的兩起前例）。
+  *(D) 是本 case 的重點*：原事故的傷害不是 production 出錯，而是**測試因宿主汙染變紅，紅被
+  gate ledger 記成交付失敗，合格 candidate 被拒**——這是「檢查本身壞掉」的第三種形態，**不是
+  假綠而是假紅**，同樣致命。
+- **harness_needs**：環境變數控制（`TMPDIR`）；fs 佈置（`make_empty_git_dir` **已存在**）；
+  網路隔離（socket patch 或 netns）；全套 pytest 可驅動；搜尋上界的注入。
+- **determinism_risk**：**高，需明確管理**。`#610` 明言網路呼叫「條件性/順序敏感」，單跑會過、
+  整批會炸——**擾動矩陣必須跑整套且固定隨機種子與收集順序**（`-p no:randomly`／固定 `--seed`），
+  否則本 case 自己就會 flaky。**`/tmp/.git` 佈置會影響同機並行的其他測試**，需在隔離的 mount
+  namespace 或改以 `tmp_path` 為根並注入搜尋上界，**而非真的汙染 `/tmp`**。
+  ⚠ **肇事測試（`#610` 的定位部分）從未被找到**——見 evidence-insufficient 10；本 case 只做
+  守衛，不做針對性定位。
+
+### 91. `harvest-wins-race-against-gate-ledger-write` ｜ hit_by: symptom（1 路）｜ oracle 型別: 中間態＋超時後 fail-closed
+
+- **source**：issue `#564`（open），run `workflow-084f75e2178cf7547476`，job
+  `wf-865ecb7f70-subagent-build-483`。
+- **observed**（逐字）：
+  > `16:37:54 daemon 的 resume-workflow harvest 判 TerminalContractError: terminal 宣稱 passed 但 manager 端沒有可重驗的 gate ledger → needs_human`
+  > `16:38:xx wrapper 的 gate 重跑（python3 -m pytest -q，~45s）完成、ledger 才落地`
+  > 「job 進程 exit 後 wrapper 還要跑 gate 才寫 ledger；這段窗口內 job status 已是 `exited`，任何 harvest（daemon tick 或 operator resume）都會以『無 ledger』fail-closed 成 needs_human——但這不是終局狀態，是**尚未完成的採信前置**。**fail-closed 方向正確、時機錯誤。**」
+- **oracle**：以**可控時鐘**佈置窗口：job 標 exited、ledger 尚未寫入 → 驅動 harvest，斷言結果
+  為 **in-flight／`exited-pending-gates`**，**不得**為終局 needs_human。接著寫入 ledger →
+  再驅動 harvest（或斷言 wrapper 完成時觸發重新 harvest），斷言正常採信。
+  **負向（核心）**：ledger 在合理窗口過後仍缺席 → **必須 fail-closed 成 needs_human**
+  （超時後的 fail-closed 不可被拆掉）。
+  *fail-open 關鍵*：負向項是核心——只寫「窗口內不判終局」會讓「永遠等下去」通過，那會製造新的
+  無限停滯（本 repo 的無訊號停滯族）。
+- **harness_needs**：時間控制（窗口長度可注入）；fs 佈置（job 狀態檔、**ledger 檔的寫入時序
+  可控**）；harvest 可單獨驅動。不需模型。
+- **determinism_risk**：這是**真競態**，若用真實 sleep 會 flaky。**case 必須以「注入時鐘 ＋
+  顯式控制 ledger 寫入時點」把競態轉成確定性序列，絕不可用 `time.sleep` 對齊。**
+  ⚠ **artifact 路獨立查證：gate ledger artifact 本身在任何 store 中都不存在**
+  （`gate-ledger-spool/` 為空；legacy 樹無此目錄）——「`exited-pending-gates` 中間狀態該以什麼
+  欄位表達」與「窗口界線 N 秒」目前**只能靠實作定義**，見 evidence-insufficient 29。
+  **建議：先寫「中間態存在且與終局態可區分」的弱形式，欄位形狀待 ledger schema 落地後補強。**
+
+### 92. `delivery-journal-run-without-ship-record` ｜ hit_by: artifact（1 路）｜ oracle 型別: ship 缺席即未完成交易
+
+- **source**：**artifact 路實測**：`delivery-journal.json` 19 個 run 逐一 dump。
+- **observed**（逐字）：
+  > `workflow-f9f639b2a677496c29c1`（`work_id: release-pipeline`）：
+  > `delivery_binding = {"change": "release-pipeline", "pr_number": 171, "todo_paths": ["docs/superpowers/workstreams/release-pipeline/todo.md"]}`
+  > `mapped_prs = [171]`、`pushes = ['5dfb522260b18ec9c4d4e08c3ac68a7f311b5062', 'ee623b0a9211bb0b2eaee1943978a8b72b23963a', 'fee3b230d718ea7c6297d8ba35194918acf62117']`
+  > **`ship = None`**
+  > 19 個 run 中唯一一個「已綁定交付目標、已推送三個 commit、卻沒有任何 ship 紀錄」的——交易寫到一半停住。keyset 統計亦顯示它是唯一缺 `ship` 鍵的變體（1 筆）。
+  > 另 8 個 run 是 `ship = {"phase": "needs_human", "reason": "multiple-delivery-targets-unsupported"}` 且 `pushes = []`、`delivery_binding = null`——那是**完整記錄的失敗**，不算未完成交易。
+- **oracle**：「delivery journal 中任一 run 若有 `delivery_binding` 或非空 `pushes`，就必須有
+  `ship` 物件（即使是 `{phase: needs_human, reason}`）；`ship` 缺席即為未完成交易，必須 fail
+  並可被 reconcile 掃出」。
+  *fail-open 關鍵*：**`ship` 是 `None` 與 `ship` 是 `{}` 要分開處理**；
+  `journal.get("ship", {}).get("phase")` 這種寫法會把兩者都變成 `None` 而無法區分。
+- **harness_needs**：fs 佈置；**崩潰注入**（在寫 ship 前中止）；tick 推進以測 reconcile。
+- **determinism_risk**：低（注入式）。
+- **附註**：這是 ship／delivery 區段第五條候選，**是唯一一條觸及 delivery journal 交易完整性**
+  的。見「覆蓋缺口」第 2 節。
+
+---
+
+## T5 — 不可拆的多 UID／systemd／root 殘量（2 筆）
+
+> 這兩條**無法**降到單 UID 驗證。其餘 trust-root 候選（20／31／32／9）的 tier 1 部分已提前到
+> T1／T2。**環境不足時必須標 `unsupported`，不得標 `pass`，也不得 skip 成綠。**
+
+### 93. `spool-per-job-producer-consumer-seal` ｜ hit_by: symptom·subsystem（2 路）｜ oracle 型別: 以效果斷言＋走正向流程
+
+- **source**：issue `#638`（closed）／PR `#639`；`#636` 的 `commit-spool` 繼承同缺陷。
+- **observed**（逐字）：
+  > **缺陷 1**：`coordinator/review.py:289` 是 `spool_dir.mkdir(mode=0o700)`。明確 mode 會**重設 ACL mask**：
+  > ```
+  > user:cortex-reviewer-planner:-wx    #effective:---     ← 被 mask 遮掉
+  > mask::---
+  > $ sudo -u cortex-reviewer-planner printf x > <spool>/<job>/v.json
+  > sh: cannot create …: Permission denied
+  > ```
+  > **缺陷 2**：`-rw--w----+ 1 cortex-reviewer-planner cortex-reviewer-planner  v.json` ／ `$ sudo -u cortex-manager cat <spool>/<job>/v.json` → consumer 讀不到；bundle 側 `fatal: error opening '…/commit-spool/<job>/commits.bundle': Permission denied`
+  > **缺陷 3**：`review.py:311` 是 `os.chmod(target, 0o444)`。**只有檔案 owner 或 root 能 chmod**，而檔案是 producer 擁有的：
+  > `$ sudo -u cortex-manager python3 -c "os.chmod(<verdict>, 0o444)"` → `PermissionError: [Errno 1] Operation not permitted`
+  > 而該處**刻意不對失敗 raise**（`review.py:304` 的註解：「封存失敗不該讓一次合法的 review 反而卡住」），所以它**無聲失敗**：
+  > ```
+  > $ sudo -u cortex-reviewer-planner printf TAMPERED > <verdict>
+  >   !! 覆寫成功——落地後轉唯讀的保證未成立
+  > ```
+  > 「也就是 reviewer 可以在 Manager 判讀之後回頭改自己的 verdict。」
+  > **為什麼 M1 沒抓到**：M1 的 R9 攻擊測的是 **spool 根**……**per-job 的正常流程**（Manager 建目錄 → producer 寫 → consumer 讀 → seal）沒有任何一條測試涵蓋
+  > **Phase 2a 的 verdict 通道在三分下從未真正成立過**
+- **oracle**：完整 per-job 流程三段，各自獨立斷言。(1) Manager 建 per-job 目錄後，**producer
+  身分**寫入成功；(2) **consumer 身分**讀得到 producer 寫的檔（斷言內容相等）；(3) seal 之後，
+  **producer 身分的覆寫必須被拒**——**以真實寫入嘗試斷言，不得只斷言 mode 為 0444**。
+  額外斷言：seal 的回傳／例外不得被吞——`chmod` 失敗必須落結構化 diagnostic。
+  *fail-open 關鍵（雙重）*：(a) seal 失敗是**刻意不 raise** 的，所以任何以回傳值為準的斷言
+  **必然假綠**；(b) M1 只測 spool 根的攻擊面，正向流程零覆蓋。**本 case 的價值全在「以效果
+  斷言，且走正向流程」。**
+  **硬規則**：若 harness 跑在單 UID 下，(3) 的覆寫會成功——此時 case 必須判 **error／
+  `unsupported`，絕不可降級成綠燈**。case 必須宣告 `requires: multi-uid`。
+- **harness_needs**：**多 UID 必需**（≥2 個真實 job 帳號 ＋ manager 帳號；三段各以不同身分執行）；
+  `setfacl` 可用的 fs（非 tmpfs/overlay 需驗 acl mount option）；fs 佈置（spool 樹 ＋ default
+  ACL ＋ per-job 目錄的真實建立）；sudo 切換身分。**無法降到單 UID——這是 trust-root 區段唯一
+  不能做 tier 1 替代的一條。**
+- **determinism_risk**：**高**。UID 環境、filesystem acl 支援、default ACL 繼承行為皆環境相依；
+  `umask` 影響 mkdir mode；需 root 建帳號故 CI 上不可得——**這正是它逃過 CI 的原因，也是 case
+  必須顯式宣告環境需求的原因**。必須有嚴格前置檢查並在缺件時標 `unsupported`。
+
+### 94. `gate-ledger-and-exit-sentinel-self-written-by-builder` ｜ hit_by: symptom·subsystem（2 路）｜ oracle 型別: 竄改後仍正確
+
+- **source**：issue `#604`（closed）／PR `#628`；＋ `#602`（open，同型第二條路）。
+- **observed**（逐字）：
+  > （#604）`build_wrapper_script` 讓 gate ledger writer 跑在 **job 進程內**(builder UID),寫進 Manager 開的 log 目錄……exit sentinel 同樣由 job 側寫
+  > direct 模式下這是既有性質(同 UID 本來就無界),但 **Phase 2b OS 隔離上線後,這變成一條具名的信任邊界**:builder 可偽造自己的 gate 結果(ledger)與 exit code(sentinel)
+  > 抵觸 spec 對「Manager 獨立產生 evidence」的期待(`#540` 的 ledger 獨立性在降權後反而退化為 builder 自報)
+  > （#602）slice-lane reviewer 的 `log_dir="runtime/review/<slice>"` 是相對路徑→落在 repo 工作樹內、builder 可寫。workflow lane 的 verdict 正是從 log(`_extract_terminal_json(job["log_path"])`)收割——log 可代寫等於終局 JSON 可代寫。
+- **oracle**：降權模式下跑完一個 build job 後：(A) ledger 檔的 owner 必須是 Manager principal；
+  (B) **以 builder 身分對 (a) gate ledger 路徑、(b) exit sentinel 路徑、(c) reviewer `log_dir`
+  路徑各執行一次寫入，三者皆須 `Permission denied`**（真實寫入嘗試）；(C) job 的 exit code
+  取自 systemd `ExecMainStatus`，而非 sentinel 檔——**斷言即使刪除／竄改 sentinel 檔，回報的
+  exit code 仍正確**。第二層：以 builder UID 寫入偽造 ledger（宣稱 pytest passed）後跑 harvest，
+  斷言 Manager 判定**不採信**該 ledger。
+  *fail-open 關鍵*：(C) 若只驗「有拿到 exit code」，現況（讀 sentinel）就過。**「竄改 sentinel
+  後仍正確」才是鎖。** 只斷言「路徑在 coordinator_root 底下」不夠（路徑對但 mode 0777 一樣
+  可寫）——必須**實際嘗試寫入並要求被拒**。
+  **硬規則**：case 必須以「降權模式」為前提；**`direct` 模式下應標 `unsupported` 而非 pass**
+  （issue 明言 direct 模式下同 UID 本來就可寫，是既有性質）。
+- **harness_needs**：多帳號 UID ＋ systemd（`ExecMainStatus` 需真 unit）＋ 降權啟動器
+  （`systemd-run` 或等價）；fs 佈置；harvest 可單獨驅動。
+- **determinism_risk**：高。systemd 相依。
+
+---
+
+## T6 — oracle 型別弱、期望值部分待定，或須先修既有測試（8 筆）
+
+> **保留但不宜首批。** 這 8 筆的觀測值都充分，但動工前有一個必須先解決的前置。
+
+### 95. `dispatch-headless-no-stale-progress-signal` ｜ hit_by: subsystem（1 路）｜ oracle 型別: 閾值型（**弱**）｜ ⚠ 既有測試固化了 fail-open
+
+- **source**：issue `#488`（open）／相鄰 `#495` `#498`。
+  ⚠ **症狀路與生命週期路各自把它（的一部分）判為 evidence-insufficient**（門檻未定案）。
+- **observed**（逐字）：
+  > A Cortex-dispatched Claude builder stayed `dispatched` / slice `building` for more than five minutes while producing four consecutive malformed tool calls：two `Write` calls rejected as `InputValidationError: JSON parse failed`／two fallback `Bash` calls rejected with the same error／no new tracked file after the first policy file
+  > `Dispatcher.poll_headless_done` has only three states：1. exit sentinel exists: finalize 2. PID is alive: leave `dispatched` unchanged 3. PID is dead without sentinel: fail closed
+  > **Existing tests explicitly preserve `dispatched` whenever the PID is alive.**
+  > 「The process remained alive, so every manager tick continued to report a healthy in-flight job.」
+  > `Add configurable wall-clock and inactivity thresholds per job/spec; **do not hard-code a short timeout for valid builds**`
+- **oracle**：三場景，**門檻由注入而非硬編**。(A) PID alive ＋ 近期有 log 活動 → 仍 active；
+  (B) PID alive ＋ 超過注入門檻無活動 → `status.attention` 含 `stale-in-flight` **且原 evidence
+  仍存在**（斷言 evidence 路徑與 hash 未變）；(C) **重複的 executor tool-validation error 可見**，
+  而非看起來健康。
+  **可先做的那一塊**：只有 (C)「連續 N 次 executor tool-validation error 必須可見（不得看起來
+  健康）」的期望值是確定的，可獨立成 case。
+  *⚠ 動工前置*：issue 逐字寫「Existing tests explicitly preserve `dispatched` whenever the PID
+  is alive」——**既有測試本身就是這個 fail-open 的固化**。新 case 必須**同時處理該既有測試的
+  修訂**，否則兩者互相矛盾。
+- **harness_needs**：時間控制（注入 clock）；PID 存活 mock；log 活動時間戳的 fs 佈置。
+- **determinism_risk**：中—高。掛鐘與 PID 存活都是環境敏感，必須全部注入。
+  **門檻預設值、config key 名稱、以及「cortex 是否被授權自動中斷一個活著的 job」三者皆未定**
+  （見 evidence-insufficient 6）——本 case 只涵蓋「注入門檻下的三種相對行為」。
+
+### 96. `controller-rejection-after-foreign-review-pass` ｜ hit_by: lifecycle（1 路）｜ oracle 型別: 弱表述（存在某動作）｜ ⚠ 另一路判為 evidence-insufficient
+
+- **source**：issue `#502`（open），slice review job
+  `task-4-deliver-export-tree-orchestrator-build-11`，candidate
+  `6421bc98272a72270222cf4ef6c0bdaf30e3bb09`。
+  ⚠ **子系統路把 `#502` 整條列為 evidence-insufficient**（「issue 要求的是一個尚不存在的生命
+  週期階段……現在寫 case 等於發明一台狀態機並把它焊死」）。生命週期路則以「弱表述」保留它。
+  **本清單保留，但把該衝突明載於此。**
+- **observed**（逐字）：
+  > 「A slice reached `state=verified`, `gate_state=passed` after an independent foreign reviewer accepted exact candidate…The controller then independently reproduced a blocking data-loss escape that the reviewer missed: an exclude glob `../outside/marker` made the trim tool return exit 0 and unlink the marker outside the export tree; a glob reached through a symlinked directory also returned exit 0 and unlinked an external marker.」
+  > ```text
+  > ValueError: 非法 gate_state transition: 'passed' -> 'failed'
+  > ```
+  > 「`allowed_slice_actions()` also returns no actions for a `verified/passed` slice, and `retry-build` repinning deliberately excludes `verified`. The only normal continuation is merge/completion even though a later authorized gate found a real blocking defect.」
+  > 「`GATE_STATE_TRANSITIONS["passed"]` permits only `passed`，`REPINNABLE_SLICE_STATES` excludes `verified`」
+  > 影響：「operators must either merge a known-bad candidate or edit coordinator state outside the public lifecycle API」
+- **oracle**：取**不依賴命名裁決**的部分。(a) controller 對 exact candidate 提交結構化 blocking
+  finding 後，該 slice 必須進入可修復狀態且暴露**某個** bounded repair 動作（**不寫死動作
+  名稱**）；(b) **negative test（最強的一條）**：controller rejection 之後，舊的 accepted
+  candidate **不得**被 completed；(c) 先前 foreign-review evidence 必須 bytes 不變（immutable，
+  斷言前後相同）；(d) `completed`／merged 之後拒收該動作。
+  *fail-open 關鍵*：(b) 是核心——只測「可以 repair」而不測「舊 candidate 不可 merge」，會允許
+  實作把兩條路都開著。
+  *⚠ 動工前置*：**三件事全未裁決**——(1) 轉移後的目標 state 叫什麼；(2) 舊的 foreign-review
+  evidence 是留在 `current` 還是降為 `history`；(3) merge 是被硬擋還是僅告警；以及「新增 stage
+  vs 新增 typed action」二選一。若新增 phase，manifest 的 phase 集合會改變（**連帶影響候選
+  86／8／29 的參數化來源**）。見 evidence-insufficient 12。
+  **建議：先只寫 (b)(c)（兩條都不依賴命名裁決），(a)(d) 待裁決後補。**
+- **harness_needs**：registry（verified/passed slice、gate_state 轉換表）；evidence 目錄；
+  operator action 介面。
+- **determinism_risk**：中。`GATE_STATE_TRANSITIONS` 若被整表重寫，fixture 的狀態名需同步。
+
+### 97. `claim-inflight-run-self-supersede` ｜ hit_by: subsystem（1 路）｜ oracle 型別: 計數不變｜ ⚠ **另兩路皆判為 evidence-insufficient**
+
+- **source**：issue `#524`（closed）／PR `#526`／既有測試 `tests/test_claim_inflight_supersede_524.py`。
+  ⚠ **症狀路（EI-3）與生命週期路（E4）都把它判為 evidence-insufficient**，理由是根因未定位、
+  issue 用的是推測語氣。**子系統路則指出已有 merged PR `#526` 與既有測試**——這是四路之間**最大
+  的一組判斷分歧**，本清單保留候選並明載分歧。
+- **observed**（逐字）：
+  > （子系統路）`workflow-009fe9ab303df196209d` created 04:55:07、superseded 04:56:42、完成的卡 `workflow-claim` / `brainstorming` / `openspec-propose` / `writing-plans` 全 **passed**，phase 已達 **build**
+  > 該 run 沒有 `work-abandon` evidence、facets 僅 `['blocked']`（無 `needs_human`），且新一代在同一毫秒建立
+  > 第三代：`primary-artifact-write-rejected: planning artifact lacks current planning authority: …-design.md`
+  > （症狀路引用 issue 原文的推測語氣）「**形態像是**claim 路徑沒把它視為 active run 而開了新世代。**若屬實**……建議檢查 `_existing(candidate)` / active-run 偵測與 `start_canonical_workflow` 的世代建立條件之間**是否存在**競態」
+- **oracle**：一個 phase 已推進到 `build`、且至少一張卡 passed 的 ongoing run，在後續 N 次
+  claim scan 後，registry 內 ongoing run 的 **id 必須不變且數量恰為 1**。**斷言 run id 相等
+  而非「沒有例外」。**
+  *另一半（supersede 殘留 artifact 使下一代 fail-closed）已併入候選 87*，不重複。
+- **harness_needs**：fs 佈置 registry；「連續觸發 claim scan」的推進能力（tick 推進）。不需模型。
+- **determinism_risk**：**高**。原始現象是競態（「run 剛從 define 推進到 build、registry 尚未
+  落盤的窗口」）。**case 必須把窗口做成確定性的**（在落盤前注入 scan），否則會變成 flaky——
+  **而 flaky 的綠等於假綠**。
+  *⚠ 動工前置*：先確認 PR `#526` 的實作是否已固定了觸發窗口。若否，兩路的 evidence-insufficient
+  判斷成立——見 evidence-insufficient 4。
+
+### 98. `define-artifact-rejection-reason-and-evidence` ｜ hit_by: lifecycle（1 路）｜ oracle 型別: 只做「可區分」二分
+
+- **source**：issue `#511`（PR `#513` 已落地）＋ `#515`（open，同族最大殘留），
+  run `workflow-c24a4e837b306e8c6c1a`。**define 八環攻關鏈同族。**
+- **observed**（逐字）：
+  > （#511）evidence：`{"classification": "content", "reason": "primary-artifact-write-rejected: ValueError: planning artifact is not accepted: docs/superpowers/specs/fix-read-repo-tier-fail-closed-spec.md", "schema": "cortex-planning-failure/v1"}`
+  > 根因：「`assess_planning_artifact()` 明確回傳 `reasons`（`status-not-accepted`／`required-section-missing`／`blocking-decision`）與 `markers`，但 `manager.py:6023` 的呼叫端只用 `.accepted` 布林值」；「artifact 內容…寫在 `tempfile.TemporaryDirectory()` 內…context 結束即刪除」
+  > （#515）「`_post_integration_artifact_evidence()`（`planning.py:919` 起）內有 **14 個裸 `return None`**，涵蓋語意完全不同的失敗：symlink、非一般檔案、路徑逃逸（絕對路徑／`..`）、UTF-8 解碼失敗、`assess_planning_artifact()` 判定不合格……全部塌縮成同一個回傳值」
+- **oracle**：(a) 三種 assessment reason 各自產生**互異**的錯誤訊息，斷言三者兩兩不等（含
+  `blocking-decision` 需另帶 `markers` 行號）；(b) 被拒 artifact 內容必須落進 evidence，schema
+  `cortex-planning-artifact-rejection/v1`（`#520` 的 evidence 引用已證實此 schema 存在），
+  斷言檔案內容 == planner 原輸出 bytes；(c) `#515` 的**二分**：路徑／編碼類（symlink、`..`
+  逃逸、UTF-8 失敗）與 assessment 類必須可從 reason 區分，且 reason 必須含出事的 `ref`。
+  *⚠ 動工前置與刻意的弱化*：**14 個分支各自該對到哪個 reason 字串未定案** → oracle 只做
+  「**可區分**」的二分，不做逐字串比對，否則就是編期望。且**刻意不斷言 `classification` 值**
+  ——`classification` 直接決定 `recover-planning` 是否受理（`work_actions.py:2912`），
+  environment／content 的通則二分未定（見 evidence-insufficient 23）。
+- **harness_needs**：fs（建 symlink、非 UTF-8 檔、`..` 路徑）；evidence 目錄；mock launcher
+  回傳指定 artifact 內容。
+- **determinism_risk**：低—中（因刻意弱化）。
+
+### 99. `verify-evidence-details-freeform-no-machine-oracle` ｜ hit_by: artifact（1 路）｜ oracle 型別: 需 schema 先落地
+
+- **source**：**artifact 路實測**：`evidence/workflow/` 中 77 筆 `kind == "verify"`。
+- **observed**（逐字）：
+  > 77 筆 verify evidence 的 `payload.status` **全部是 `"verified"`**（0 筆其他值）；`payload.details` 卻有 **69 種不同的鍵集合**。抽樣：
+  > `('candidate', 'checks')` ×9
+  > `('candidate', 'contract_tests', 'finding', 'full_suite', 'openspec', 'path_hygiene')` ×1
+  > `('candidate', 'conflict_markers', 'failure_root_cause', 'scope_check', 'test_run', 'working_tree')` ×1
+  > `('base_compared', 'candidate', 'checks_performed', 'diff_scope', 'residual_risk')` ×1
+  > …（共 69 種）
+  > 對照組：同一 store 的 137 筆 `kind == "review"` payload keyset **只有 1 種**（`builder_job_id, candidate, findings, launch_identity, outputs, reason, reviewer_job_id, schema_version, slice_id, state`），且 `state` 與 `findings[].blocking` **完全自洽**（`passed` ∧ 無 blocking = 83 筆；`rejected` ∧ 有 blocking = 54 筆；矛盾 0 筆）。
+  > 即：review 端已結構化，verify 端仍是自由文字字典。
+- **oracle**：「verify evidence 的 `details` 必須符合一份宣告過的 schema：每個 check 是
+  `{name, kind, passed: bool, …}` 的陣列；`status` 必須是 `details` 中所有 `passed` 的合取，
+  而非模型自報」。
+  *fail-open 關鍵*：**不得只斷言 `status == "verified"`——全庫 77/77 都是 verified，這種斷言
+  恆真。** 必須斷言「存在一條失敗 check → status 必為非 verified」的反向路徑（negative control）。
+  *⚠ 動工前置*：**schema 尚未存在**。在 schema 落地前，只能做「schema 存在性」斷言。
+- **harness_needs**：mock provider（回傳可控的 verify payload）；fs 佈置。
+- **determinism_risk**：`details` 內容由模型自由生成 → **高**。case 必須用 mock provider 固定
+  輸出，不能靠真實模型。
+
+### 100. `verify-verdict-contradicts-its-own-finding` ｜ hit_by: artifact（1 路）｜ oracle 型別: 需結構化 `violations` 欄位
+
+- **source**：**artifact 路實測**：
+  `evidence/workflow/072698e9ac3d541a3a688bb205cbbefdc8007ce6711ab9d5b4eded0475bc2062.json`
+  （job `wf-e6ad935ef9-verification-304`，run `workflow-25ee690b25612b854a8c`）。
+- **observed**（逐字）：
+  > `payload.status` = `"verified"`，同一 payload 的 `details.finding`：
+  > `git diff --check flags openspec/specs/onboarding-documentation/spec.md:24 'new blank line at EOF' introduced in the archive commit (b6a8410); this is the only diff-check violation across the whole change and directly contradicts tasks.md item 1.5 which requires a clean git diff --check`
+  > `payload.summary` 亦承認：`One minor nit: trailing blank line in the new live spec.md trips git diff --check, contradicting task 1.5's own acceptance criterion.`
+  > 亦即：evidence 自己寫明「違反了計畫的驗收條件 1.5」，卻仍以 `status: verified` 落盤，而該 run 最終 `ship.phase = "done"`、merge 進 PR #168。
+  > （另 51 筆 verify evidence 的 `details` 含 `N passed, M failed` 且 M>0，但多數附有明確豁免說明，例如 `all 29 failures/error are sandbox-environment artifacts: AF_UNIX socket PermissionError and read-only-filesystem writes to repo paths, unrelated to onboarding-docs`——**這些不算違規**，本條僅取 `finding` 明示違反驗收條件的那筆。）
+- **oracle**：「verify evidence 的 `status == verified` 時，`details` 中不得存在任何被標記為
+  違反 plan/tasks 驗收條件的項目；若模型寫出 `finding`／`violation` 類欄位且非空，status 必須
+  降級」。**要求 evidence schema 提供結構化的 `violations: []` 欄位，讓判定不靠關鍵字比對散文。**
+  *fail-open 關鍵*：**不可用「`finding` 字串含 'contradicts' 就 fail」這種脆弱比對**；要求
+  schema 化後才判定，否則**此 case 本身會是假綠燈**。
+  *⚠ 動工前置*：**目前無結構化 violation 欄位**，oracle 依賴 schema 先落地；在此之前只能做
+  「schema 存在性」斷言。與候選 99 同一前置，**應合併為同一張 schema 票**。
+- **harness_needs**：mock provider（產出「status=verified 但帶 violation」的 payload）；fs 佈置。
+- **determinism_risk**：中。
+
+### 101. `run-journal-steps-diverge-from-canonical-manifest` ｜ hit_by: artifact（1 路）｜ oracle 型別: 逐欄相等（**glob 收斂規則未成文**）
+
+- **source**：**artifact 路實測**：`~/.agents/coordinator/jobs.json` × `workflow-manifests/`。
+- **observed**（逐字）：
+  > 66 個 run 的 manifest 存在可比對，**其中 54 個（81.8%）的內嵌 `steps` 與正典 manifest 不同**。逐欄位統計：`skill_ref` 遺失 **521** 處、`action` 遺失 **122** 處、`commit_policy` 遺失 122 處、`test_policy` 遺失 122 處、`outputs` 不同 **148** 處、`outputs` 被清空成 `[]` **7** 處。
+  > 逐字例（run `workflow-fa973e5b3628f3f31342`，step 0 `workflow-claim`）：
+  > ‧ manifest：`"skill_ref": "coordinator:workflow-claim"`；run journal：`"skill_ref": null`
+  > ‧ manifest step 4 `worktree-isolation`：`"commit_policy": "forbidden"`、`"test_policy": "none"`、`"action": "確認 Manager provision 的 builder worktree，並依 accepted plan 回報隔離狀態；不得另建第二個 worktree"`；run journal 三者皆 `null`。
+  > 逐字例（run `workflow-ed15cd16ffa5e2c26306`，step 10 `openspec-archive`）：
+  > ‧ manifest `outputs`：`["openspec/changes/archive/*terminal-lifecycle-canary*"]`；run journal `outputs`：`[]`。
+  > 另一組（manifest `a460eb36…`，step 2 vs run `workflow-c09f0f730da74be88ea8`）：manifest `{"card": "openspec-propose", "skill_ref": "openspec-propose", …, "outputs": ["openspec/changes/issue-34-atomization-release/proposal.md", "openspec/changes/issue-34-atomization-release/tasks.md"]}`；run journal `{"card": "openspec-propose", "skill_ref": null, …, "outputs": ["docs/superpowers/plans/2026-07-15-issue-34-atomization-release.md", "openspec/changes/issue-34-atomization-release/proposal.md", "openspec/changes/issue-34-atomization-release/design.md", "openspec/changes/issue-34-atomization-release/tasks.md"]}`
+- **oracle**：「對每個有 manifest 的 run，`run.steps[i]` 的契約欄位（`card`／`phase`／`persona`／
+  `skill_ref`／`commit_policy`／`test_policy`／`action`）必須逐一等於 `manifest.steps[i]`；
+  `outputs` 允許 glob→具體路徑的收斂，但**收斂後的路徑必須 match 原 glob**」。
+  *fail-open 關鍵*：不得用 `if manifest is None: return`（見候選 52，78/144 沒有 manifest 就會
+  全部跳過）；**缺 manifest 必須另外報錯而非靜默 pass。**
+  *⚠ 動工前置*：**`outputs` 的 glob→具體路徑收斂規則未成文**，需先釘規格；否則 oracle 會誤判
+  合法收斂。**建議先只做契約欄位（非 outputs）那七欄的逐一相等**，outputs 那半待規格落地。
+- **harness_needs**：fs 佈置（成對 manifest ＋ jobs.json fixture）；glob 比對需 `fnmatch`。
+- **determinism_risk**：中（因規格未成文）。
+
+### 102. `job-claim-key-diverges-from-run-claim-key` ｜ hit_by: artifact（1 路）｜ oracle 型別: 前半可判、後半語意未成文
+
+- **source**：**artifact 路實測**：`jobs.json`。
+- **observed**（逐字）：
+  > **505 個 job 中 156 個的 `workflow_claim_key` 與其所屬 run 的 `claim_key` 不同**。最集中：`workflow-7dd63eeeacac77d06b54`（41 jobs）、`workflow-5b1f0e891b85466a83a0`（28）、`workflow-7edf60c1fee8e42a244b`（10）、`workflow-50b4fb018b3412a7f487`（10）。
+  > 具體（run `workflow-084f75e2178cf7547476`，即 #564 現場）：
+  > ‧ jobs 480–484：`claim:v1:260aa6fcc9b35030d7b2025559038f936961a312da35d01b548a5c4d4e2261ba` → **manifest 存在**
+  > ‧ jobs 485–488：`claim:v1:d92e5d5598f7136accc28f6c3b5631e606a571ea264d6b393e14adcb17536304` → **manifest 不存在**
+  > ‧ run 本身的 `claim_key` 是後者，`status=ongoing, current_phase=build`。
+  > 即：同一個 run 的前後半段 job 綁在兩份不同契約上，且 run 現行契約在磁碟上不存在。**job record 上沒有任何 `superseded` 標記可資區分。**
+- **oracle**：**保守版（可從現有證據判定）**＝「run 的 `claim_key` 必須解析到存在的 manifest」。
+  第二半（「若 job 的 `workflow_claim_key != run 的 claim_key`，該 job 必須帶有明示的 supersede
+  標記，否則 fail」）**目前不可判定**——re-claim 情境下歷史 job 保留舊 key 可能是設計意圖。
+  *⚠ 動工前置*：**re-claim 的合法語意未成文** → **建議 case 先只斷言前半條**。
+  **不要寫成「job ck 必須等於 run ck」。**
+- **harness_needs**：fs 佈置；需模擬 re-claim（同 run 換 claim_key）流程。
+- **determinism_risk**：中（因語意未成文）。
+
+---
+
+## 五、覆蓋缺口
+
+**本節刻意不淡化。** 一份「哪裡都覆蓋到了」的盤點報告，本身就是造假的訊號。以下四格是四路
+sweep 合起來仍然沒有覆蓋到、或覆蓋了卻分不出真假的地方。
+
+### 缺口 1：08-12 波有 6 張未深讀（最容易補、下一輪優先）
+
+子系統路自陳：08-12 波的 65 張裡，深讀了 33 張，**`#473`／`#475`／`#476`／`#478`／`#506`／
+`#508` 這 6 張只讀了標題、沒有讀 body**。依本次盤點的硬性準則——`observed` 必須逐字引用來源、
+**不得憑標題推測**——它們不能以子系統路的身分進候選。
+
+依標題可粗歸屬（**這是歸屬，不是候選**）：
+
+| issue | 粗歸屬 | 現況 |
+|---|---|---|
+| `#473` | deck | 四路皆無候選 |
+| `#475` | dispatch／launcher | 四路皆無候選 |
+| `#476` | porcelain／service | 四路皆無候選 |
+| `#478` | coordinator／worktree 回收 | **症狀路已獨立深讀並產出候選 77**（單路命中） |
+| `#506` | claim／GitHub 節流 | **症狀路已讀，但判為 evidence-insufficient 9**（cortex 自身行為從未被觀測） |
+| `#508` | claim／work-registry schema | 四路皆無候選 |
+
+**補齊成本：約 1 次 `gh` 呼叫。** 這是本次 sweep 中投報最高的一塊。
+
+預期效果：`#478` 與 `#506` 會從單路命中升級為雙路（強化候選 77 與 evidence-insufficient 9
+的判定）；`#473`／`#475`／`#476`／`#508` 有可能各補一條新候選，其中 `#476` 若真是 porcelain
+事故，會**直接填補缺口 3**（porcelain 七個 verb 家族目前零原生事故）。
+
+**下一輪應先做這件事，再做任何新的 sweep。**
+
+### 缺口 2：ship／delivery 是覆蓋度與風險落差最大的一格
+
+`delivery.py`(21KB) ＋ `github_delivery.py`(47KB) ＋ `preflight.py`(16KB) 是**全庫第三大的
+功能面**，四路合起來卻只擠出五條候選，而且**沒有一條是 delivery 語意問題**：
+
+| # | 候選 | 實質內容 |
+|---|---|---|
+| 19 | `ship-completion-reread-must-tolerate-source-revision-drift` | completion record 比對的欄位範圍 |
+| 26 | `delivery-journal-ship-keyset-drift` | journal schema 一致性 |
+| 67 | `ship-git-cwd-must-not-be-builder-owned-tree` | **權限／工作區歸屬** |
+| 68 | `ship-card-handoff-must-not-depend-on-disk-residue` | **工作區歸屬** |
+| 92 | `delivery-journal-run-without-ship-record` | journal 交易完整性 |
+
+再加候選 25（`delivery-journal-ship-phase-enum-inconsistent`，enum 一致性）、候選 78
+（`#449` orphan run 退休）、候選 79（`#263` 本地 closeout 前置鏈）。子系統路自己的統計是
+**ship／delivery 只有 2 條候選，且兩條都是權限問題**——那 2 條就是 67 與 68。
+
+**成因可考，三條都有據**：
+
+1. **dogfooding 很少走到 ship。** 08-12 波深讀的 33 張 issue 裡，**零張是 ship 階段事故**——
+   全部卡在 define／build／verify／review 就死了（`#536` 停在 define、`#524` 停在 build、
+   `#617` 停在 review、`#501` 停在 verify→review 交界）。**跑不到的階段自然不會噴事故。**
+2. **ship 卡由 Manager deterministic 執行、不經 launcher。** `#653` 逐字證實：「ship phase
+   **永遠回 None**……由 Manager 自己在 `work_bridge.py` 內以 deterministic 身分執行」。
+   **無模型參與 ＝ 無 LLM 不確定性 ＝ dogfooding 不容易顯現缺陷**。這一段的缺陷只會在**權限
+   模型或狀態機**變動時才浮現——恰恰是 08-17 trust-root 那一週才第一次系統性地翻出來
+   （`#635`／`#649`／`#653`），而那一週翻出來的**全都是權限問題**，這正是候選 67／68 的來歷。
+3. **`github_delivery.py` 的整片表面在本次語料中幾乎零覆蓋**：PR metadata preflight、
+   merge authorization、delivery journal 寫入端、push readback、closed-unmerged PR 處理。
+   相關 issue（`#263`／`#166`／`#175`／`#220`）都是 7 月的，且多為單點修補，body 遠不如 08 月
+   那批詳盡。
+
+**風險判讀：ship 是離 merge 最近的那道閘。** `#220`（`final attestation 必須先於 merge
+mutation`）與 `#502`（verified 之後發現阻擋缺陷卻無法退回，見候選 96）都指向同一個位置。
+**這裡的假綠代價最高，而語料最薄——這是本次盤點中風險與覆蓋度落差最大的一格。**
+
+**補這格的建議（不要再掃 issue）**：
+
+- 讀 `github_delivery.py` 的五個表面，以 `delivery-journal.json` 的 **19 個 run** 當 fixture
+  來源（artifact 路已全部逐欄 dump 過，形狀已知）。
+- 候選 92 已證實 journal 上存在**一筆未完成交易**（`workflow-f9f639b2a677496c29c1`：已綁定
+  交付目標、已推送三個 commit、`ship = None`）——那是唯一一個由實體 artifact 直接指出的
+  delivery 語意破口，可作為切入點。
+- **不要**用「ship 成功」當 oracle。候選 67 已經記錄了原因：在單 UID CI 下永遠綠。
+
+### 缺口 3：porcelain 分不出「真的穩定」還是「operator 當場繞過而不開票」
+
+`porcelain/` 有 14 個模組、merged PR 數不算少（約 25），但**兩條候選都是其他子系統外溢進來
+的，不是 porcelain 原生事故**：
+
+- 候選 39 `doctor-probe-env-sampling-source-mismatch`（`#548`）——觸發點是 **trust-root 的
+  部署形態**（service EnvironmentFile），doctor 只是受害者。
+- 候選 2 `porcelain-cli-verb-must-match-permgen-execstart`（`#618`/`#619`）——契約的另一端在
+  `trust_root/permgen.py`；標題掛 `fix(trust-root)` 而 PR 只動 `porcelain/`。
+
+也就是說：**`cortex request` / `inspect` / `service` / `bootstrap` / `run` / `recover` /
+`init-sample` 七個 verb 家族本身，在本次語料中沒有任何一條事故。**
+
+PR 數不少卻零事故的原因是**那些 PR 幾乎全是 feature 交付而非事故**：`#84`–`#95` 的七家族、
+`#122`–`#167` 的 B1–B9 系列，body 全是規格與驗收清單，**沒有可填 `observed` 的實測錯誤行為**
+——這也是四路都刻意不深讀它們的理由。
+
+**這有兩種可能，而現有語料分不出是哪一種**：
+
+- (a) porcelain 真的穩定；
+- (b) porcelain 是 **operator 的唯一介面**，它的失敗會被 operator **當場繞過而不開票**。
+
+`#474` 是唯一的反例，而且那是在一個**外部 repo 首次使用時**才被寫下來的；`#474` 的三個項目
+全是「摩擦」而非「崩潰」——**這比較支持 (b)**。
+
+**補這格的建議（不要再掃 issue）**：最有效的動作是去讀 `docs/` 底下的 onboarding／quickstart／
+troubleshooting，以及 **driving-cortex skill**（`#177`／`#192`）。**operator 繞過的手法通常
+沉澱在文件與 skill 裡，而不是在 issue tracker 裡。** 若那些文件裡出現「如果 X 失敗，改用 Y」
+形式的段落，每一段都是一條沒有開票的 porcelain 事故。
+
+### 缺口 4（次級）：deck-combo 的自動選型面零事故
+
+`deck/` 只有 7 個模組，但它是**派工前的最後一道成形關卡**（`#380` 逐字：「gate 綠 ≠ 交付物
+成立。gate 只跑 spec 宣告的指令，而 spec 是模板產生的」）。本清單有 3 條 deck 候選
+（36／37／50），但 `selector.py` 的 combo 自動選型（`#202`／`#335`／`#359`／`#324`）與
+`task_types.py` 的分類邏輯是**零事故候選**。
+
+**這不代表沒問題**：`#474` 實測「30 個檔、沒有一組能翻 auto」顯示這一面在**外部 repo 上壓力
+很大**，只是壓力沒被寫成 issue——與缺口 3 同型。且 `#474` 第 1 項（`.project-policy.yml`
+雞生蛋）已被判為 evidence-insufficient 14，**該格連期望值都還沒有**。
+
+### 四路各自申報的其他未讀範圍（彙整，供下一輪查核）
+
+| 範圍 | 哪幾路刻意不讀 | 理由（各路自陳） |
+|---|---|---|
+| `#84`–`#95`、`#122`–`#167` porcelain 交付系列 | 全四路 | 功能建置票，body 是規格與驗收清單，無可填 `observed` 的錯誤行為 |
+| `#136`–`#140`、`#209`–`#211` design 家族 | 全四路 | 路線圖設計票，無實測事件 |
+| `#452`＋`#453`–`#456`、`#466` 能力封套 benchmark | 全四路 | 評測設計而非事故；determinism 依賴外部 patchmud ranked 榜 |
+| trust-root Phase 2b 序列（`#615`–`#666` 大半） | 症狀／生命週期／artifact 三路 | 症狀高度同質（Permission denied／226 NAMESPACE）；子系統路完整覆蓋 |
+| `#425`／`#439`／`#445`／`#464`／`#284`／`#303`／`#608`／`#610`／`#586` | 生命週期路 | 測試基礎設施問題而非工作流階段問題（症狀／子系統兩路已覆蓋，見候選 20／90） |
+| `#483`–`#494`、`#498`–`#500` provider／launcher／prompt 家族 | artifact 路 | 屬失敗表徵那一路的素材 |
+| `#152`／`#165`／`#339` | 症狀路（已 fetch 未深讀） | context 排序落在門檻外，非否定其價值（`#165` 已由生命週期路產出候選 19） |
+| `~/.agents/instances/*/run/` 內容（5 個 instance） | 症狀／子系統兩路只 list | 屬 hippo／idk 等**被治理 repo**，其 repo 上下文不在本次語料內，**無法判斷當時的正確行為** |
+| `evidence/verification/`（207）／`workflow-manifests/`（61）逐檔解析 | 症狀路只抽樣 head | artifact 路已全量解析並產出候選 69／101 |
+
+---
+
+## 六、evidence-insufficient
+
+**期望值無法從既有證據判定的，一律不進候選清單。**
+
+理由（`#667` 本文）：**編了錯誤期望的 case 比沒有 case 更糟**，它會變成永久性的假綠燈。
+本 repo 近期已有兩起同型事故——驗證指令寫成 `cmd 2>&1 | tail -6` 後讀 `$?`，實際捕捉到的是
+`tail` 的 exit code；多個 agent 共用同一 checkout，HEAD 被移走後 `base..head` diff 變空、
+`policy_check` 報 `fail: 0` 空過。兩起都是「檢查存在，但檢查本身壞掉」。
+
+**本節必須非空。** 若全部候選都「證據充分」，那是造假的訊號，不是品質的訊號。
+
+四路原始 **41 筆**（症狀 9／子系統 11／生命週期 12／artifact 9），去重後 **32 筆**。
+
+> **注意**：本節有 3 筆與候選清單**重疊**——`#502`（EI 12 ↔ 候選 96）、`#524`（EI 4 ↔ 候選 97）、
+> `#488`（EI 6 ↔ 候選 95）。這不是矛盾，是**四路之間真實的判斷分歧**：某一路認為可判定的
+> 部分已進 T6 候選，另一路認為不可判定的部分留在此處。**兩邊都保留，分歧明載。**
+
+---
+
+### EI 1. `#378` rigged evidence 的語意層偵測
+
+- **來源軸**：症狀路 EI-1 ＋ 子系統路 E（前半）
+- **已有的觀測**（逐字，證據非常強）：
+  > builder 產出「兩條對照臂共用狀態、差異由 setup 順序製造」的假證據，`verification gate 全綠也擋不住`
+  > provider 臂已經把 PTY 讀走，naive 臂當然拿到 0 bytes。這證明的是「別人讀走的資料不在了」，**不是**「離散輪詢會錯過瞬態事件」
+  > case4 的判準 `overlap_seconds > 0` 是「**必然成立的恆真式**」
+- **為何無法定期望值**：**通用 oracle 不存在。**「這份 evidence 是不是 rigged」**不是**從現有
+  artifact 機械可判定的謂詞。issue 自己提的三個修法（對抗式 verification persona／
+  `verification.evidence_claims` 宣告／persona 契約文字）**沒有一個給出「這份證據成不成立」的
+  機械判準**。以本例的修正版數字寫成 case 只能覆蓋這一支 probe，無法泛化，且會誤導成「已有防護」。
+- **缺什麼證據才能判定**：一份**已定案**的 `evidence_claims` schema，或至少「恆真式判準偵測」
+  的可執行定義（例如：probe 必須宣告 arms、arms 的資源不得相交，並由 harness 機械檢查；或
+  verdict 表達式中不得出現與被測性質無關的變數）。**全庫目前不存在對 evidence probe 的機器
+  可讀契約。**
+- **已獨立成候選的那一半**：候選 37（`evidence-claim-combo-must-attach-adversarial-review-card`）
+  ——只保證「對抗式檢視卡有被掛上」，**不保證該卡真能偵測出 rigged setup**。
+
+### EI 2. `#379` `claimed_checks[]` schema 與 `unverified_claims` 的呈現
+
+- **來源軸**：子系統路 E（後半）＋ 生命週期路 E7
+- **已有的觀測**（逐字）：
+  > **同一則摘要的兩行直接互相矛盾**：宣稱 `make ux-probe ✅`，緊接著列出 9 條 fail
+  > 2026-08-10 複驗留言：「builder terminal contract 可以要求列出 `claimed_checks[]`，但 schema 應明確標為 `diagnostic` / `claimed`；Manager 對每個 claimed command 與 canonical verification contract 做集合比較：`claimed ∩ contract`…`claimed - contract`：顯示為 `unverified_claims`」，並明說「**不建議以掃描摘要字串 `fail/Error/✅` 作最終修法，這只能當 transitional lint**」
+- **為何無法定期望值**：「這段散文自不自相矛盾」不是機械可判定的謂詞；而結構化替代方案的
+  **欄位名、是否分流 needs_human、`claimed - contract` 的處置（顯示 vs 阻斷）皆未定**。
+  `gh pr list` 未查得明確落地此 schema 的 PR（`#433` 是「gate 集合由 plan 導出、空 ledger
+  fail-closed、acceptance 定義 pinned」，範圍不同）。
+- **缺什麼證據才能判定**：terminal contract 的 schema 定案，或 `#379` closing PR 的實際 diff。
+- **已獨立成候選的那一半**：候選 11——只取雙方無條件同意的不變式（**自報不得成為 gate fact**），
+  不含本項的呈現形式。
+
+### EI 3. `#373` workflow job binding mismatch 的根因
+
+- **來源軸**：症狀路 EI-2
+- **已有的觀測**（逐字）：
+  > `workflow job binding mismatch: source_revision` 累計 **143,502 筆**，單一 work item 最高 10,266 次
+- **為何無法定期望值**：issue 標題頁逐字寫「**根因未明，本票先立案追查**」，並列出**四個互斥的**
+  待驗證假說（facet 被重複清除／early-return 條件不成立／錯誤發生在 early-return 之前／
+  多 instance ×3）。**不知道正確行為是什麼，就寫不出期望值。**
+- **缺什麼證據才能判定**：先確認 `source_revision` 不一致的產生機制（job 記錄過期 vs
+  `WorkflowRun.source_revision` 被更新 vs 寫入時序競態），以及多 instance 對計數的貢獻度。
+  **四個假說對應四種不同的正確行為。**
+- **附帶影響**：`#373` 的 authority-restart 迴圈是候選 65（`#399`）的 churn 來源，也是候選 71
+  （`#420`）必須關閉的干擾源——**它未解決會讓那兩條 case 的 harness 更難佈置**。
+
+### EI 4. `#524`(1) 成功 in-flight run 於 90 秒後自行 supersede 的根因
+
+- **來源軸**：症狀路 EI-3 ＋ 生命週期路 E4
+- **⚠ 與候選 97 重疊**——子系統路認為 PR `#526` 已落地且有既有測試，故產出候選；另兩路認為
+  根因未定位。**這是四路之間最大的一組判斷分歧。**
+- **已有的觀測**：planning 完全成功、已到 `build` 的 run 在 90 秒後被自行 supersede
+  （`04:55:07` → `04:56:42`），無 `work-abandon` evidence。
+- **為何無法定期望值**：issue 逐字用的是**推測語氣**——「**形態像是**claim 路徑沒把它視為
+  active run 而開了新世代。**若屬實**……建議檢查 `_existing(candidate)` / active-run 偵測與
+  `start_canonical_workflow` 的世代建立條件之間**是否存在**競態」。**競態的存在與觸發條件都未
+  確認。** 根因未定位 → 觸發條件未知 → 無法構造能穩定重現的 fixture；勉強編一個「90 秒內不得
+  supersede」的 case 會是**對時間常數的迷信**，且會在真正的競態下 flaky。
+- **缺什麼證據才能判定**：`_existing(candidate)` 在該窗口的實際回傳、registry 落盤時序日誌，
+  或一次可控復現。**或者：讀 PR `#526` 的實際 diff，確認它是否已固定了觸發窗口**——若已固定，
+  候選 97 成立；若未固定，候選 97 應退回本節。
+- **可判定的那一半**：`#524`(2)（前代成功產出使後代 fail-closed）證據充分，**已併入候選 87**。
+
+### EI 5. `#536` 伴生：三份前代 brainstorm evidence 被刪除
+
+- **來源軸**：症狀路 EI-4 ＋ 生命週期路 E5
+- **已有的觀測**（逐字）：
+  > 同一時間窗（`12:56:23Z`）`evidence/planning/` 目錄下**三個前代世代的 brainstorm evidence 檔被刪除**（`5b7ea3…`／`70acf4…`／`899aa2…`，僅餘 7 月的一筆）——**何者所為需查明**；若是本次 define 的 rollback 波及非本世代檔案，是獨立的嚴重缺陷。
+- **為何無法定期望值**：兩個理由。(1) issue **自陳歸屬未查明**——連「這是不是一個缺陷」都未
+  確認；若那是合法 GC 而 case 斷言「不得刪除」，等於把正確行為測成失敗。
+  (2) **症狀路的輔語料觀測與 issue 敘述矛盾**——`brainstorm-5b7ea3ab15a4f0f70be13a541da3cd22.json`
+  （Jul 18 21:59）、`brainstorm-70acf4ba636de07373824f0bcd028201.json`（Aug 11 07:40）、
+  `brainstorm-899aa2a748c721e440547be25038c824.json`（Aug 11 06:46）三檔在 `legacy-imported`
+  快照中**皆存在**。可能是快照時點在刪除之前、可能是已被還原、也可能 issue 的觀測有誤。
+- **缺什麼證據才能判定**：釐清 `legacy-imported` 快照的擷取時點與 `#536` 觀測時點的先後；
+  刪除動作的歸屬（哪個 code path、哪個 run）；以及 rollback 的作用域定義。
+  **在兩個來源矛盾未解前，任何 case 都會固化錯誤事實。**
+
+### EI 6. `#488`／`#477` stale-progress 的門檻預設值與自動中斷授權
+
+- **來源軸**：症狀路 EI-5 ＋ 子系統路 D ＋ 生命週期路 E11
+- **⚠ 與候選 95 重疊**——「注入門檻下的三種相對行為」可判定（已進 T6 候選），「門檻是多少／
+  是否授權自動中斷」不可判定（留在此處）。
+- **已有的觀測**（逐字）：
+  > （#488）headless builder 停留 `dispatched`/`building` 超過五分鐘、產出四次連續 malformed tool call，「The process remained alive, so every manager tick continued to report a healthy in-flight job.」
+  > `Add configurable wall-clock and inactivity thresholds per job/spec; **do not hard-code a short timeout for valid builds**`
+  > `a configured bounded interruption/recovery policy **may** then act without guessing`
+  > （#477）「after **bounded operator termination**, Cortex classified the slice as `builder-failed-unknown`」「usage before termination: more than one million input tokens」
+- **為何無法定期望值**：**閾值未定，且 issue 明確禁止猜。** 一個合法的長 build 與一個 error-loop
+  在既有證據下**沒有可判定的分界**。且三件事皆未定：(1) 預設門檻值是多少；(2) config key 叫
+  什麼；(3) cortex 是否被授權**自動**中斷一個活著的 job——issue 逐字說「**may** then act」
+  而非「must」。`#477` 實測的那個「bounded」是 **operator 手動介入，不是系統判準**。
+- **缺什麼證據才能判定**：「有意義的 log 活動」的定義；per-spec 閾值的預設值來源與 config key
+  定案；自動中斷的授權裁決（**這關係到會不會誤殺長時間的合法 build**）。
+- **部分可先寫**：「**連續 N 次 executor tool-validation error 必須可見（不得看起來健康）**」
+  這條的期望值是確定的，可獨立成 case（已列為候選 95 的 (C) 項）；wall-clock 部分不行。
+
+### EI 7. `#617` reviewer 散文結論與結構化 severity 不一致——fixture 缺席
+
+- **來源軸**：子系統路 F ＋ artifact 路 5
+- **已有的觀測**（逐字）：
+  > 505 結尾「The defect described in #501 is closed at its root … **Recommend merge**, with findings 1 and 3 as small follow-ups.」
+  > 但**結構化 gate 判定 = `blocking-findings`(5 條)、rejected**
+  > repair 迴圈每輪 reviewer 又找到不同的小 findings(502 四條→505 五條,**LLM reviewer 非決定性**)
+- **為何無法定期望值**：三個理由。(1) 修法有三個並行選項（prompt self-check／gate 端矛盾診斷／
+  `#555` 熔斷），**無一落地、未裁決**；(2) issue **只引用了散文節錄，沒有附完整 verdict JSON**
+  ——而 case 需要的正是那兩份 JSON 當 fixture；(3) **artifact 路獨立查證：手上這批語料無法重現
+  `#617`**——該 run（`workflow-50b4fb018b3412a7f487`）存在於 `jobs.json`
+  （`status=ongoing, current_phase=verify`），但它的 review evidence **不在**
+  `~/.agents/coordinator/evidence/workflow/`（該 store 最新一批屬 08-15 之前），現役
+  `/var/lib/cortex/coordinator/evidence/workflow/` 又是空的。artifact 路實測到的 **137 筆
+  review evidence 全部自洽**（`state` 與 `findings[].blocking` 零矛盾：passed∧無 blocking = 83、
+  rejected∧有 blocking = 54、矛盾 0）。
+- **缺什麼證據才能判定**：job 502 與 505 的**完整 verdict JSON**（含 findings 陣列的 severity
+  欄位），或其 journal log；以及三個修法選項的裁決。
+- **與候選 17 的關係**：候選 17（`reviewer-verdict-and-findings-severity-must-agree`）**自行構造
+  四組合 fixture**，把 LLM 非決定性完全隔離在 harness 之外，因此不受本項阻擋——但**它無法宣稱
+  自己重現了 `#617`**，這點必須寫進 case 註解。
+
+### EI 8. `#555`／`#617` repair／retry 迴圈的熔斷上限 N 與熔斷後狀態
+
+- **來源軸**：症狀路 EI-6 ＋ 生命週期路 E10
+- **已有的觀測**（逐字）：
+  > （#555）「`retry-card` 每次 `attempts["build"] +1` 但無上限，也沒有比照 `schema-mismatch:<card>` 的 per-card 熔斷。」
+  > （#617 建議 3）「同 candidate 連續 **N** 輪 review 都 reject 但 blocking findings 每輪不同 → 停 repair、needs_human 標「review 非收斂」,不無限燒。」
+- **為何無法定期望值**：**N 未定**，且熔斷後的狀態（needs_human 標「review 非收斂」）與 `#519`
+  的世代熔斷如何互動也未定。斷言具體 N 是編期望；斷言「有界」雖然弱形式可測（跑 M >> 預期上限
+  次，斷言 job 數不隨 M 線性成長），但在無上限裁決時，「有界」的實作可能是任何值，**測試會與
+  `#519` 的額度耗盡互相干擾**。另：findings 的**內容與數量本身不可重現**（issue 自陳 LLM
+  reviewer 非決定性），無法寫「應該找到幾條」的期望值。
+- **缺什麼證據才能判定**：熔斷上限值與熔斷後狀態的裁決，以及它與 semantic-reclaim 額度（EI 20）
+  的關係。
+- **處置：拆分。** 不依賴 findings 內容的**一致性不變式**（verdict=approve 但存在 blocking
+  finding，或反之 → 判為 reviewer 輸出矛盾）證據充分，**已成候選 17**；「重派幾輪後應收斂」
+  這部分留在本節。候選 76（`#555`）只做「有一個**參數化的**上限且被遵守」，**不做「N 應該是
+  多少」**。
+
+### EI 9. `#506` cortex 自身在 secondary rate limit 下的行為
+
+- **來源軸**：症狀路 EI-7
+- **已有的觀測**：事故本身是 **fleet conventions 升級批次**（7 個平行 agent 用
+  `gh pr checks --watch`）觸發，**不是 cortex 自己的行為**；issue 是把外部事故的教訓**預防性**
+  寫進 cortex。
+- **為何無法定期望值**：**cortex 自身在 secondary rate limit 下的實際行為從未被觀測。**
+  issue 的五條建議**全是「應該」而非「觀測到」**。以未觀測的行為寫 case 就是編期望。
+- **缺什麼證據才能判定**：一次 cortex 自身在 secondary limit 下的實測記錄（403 訊息、
+  `rate_limit` 端點回應、cortex 的分類與後續動作）。
+- **部分可先寫**：「auto-claim scan 每 tick 對每個 mapped issue 打一次 REST」這條是**可由程式碼
+  直接驗證**的（`work_actions.py:3425`），可寫成 API 呼叫次數為 O(1)~O(log n) 的斷言；
+  403 分診行為不行。
+- **⚠ 與缺口 1 交叉**：`#506` 是子系統路未深讀的 6 張之一。補讀後可能改變本項判定。
+
+### EI 10. `#610` github egress 的肇事測試定位
+
+- **來源軸**：症狀路 EI-8
+- **已有的觀測**：全套 pytest 在 builder sandbox 跑到約 71% 被殺於
+  `Network access to "github.com" was blocked`。
+- **為何無法定期望值**：**肇事測試從未被找到。** issue 的修法第 1 步逐字是「**定位**:在斷網
+  環境……找出實際發出 github.com 連線的測試」，且觀測顯示行為「**條件性/順序敏感**」（分批跑
+  幾乎全綠、同批重跑卻過）。不知道是哪個測試、什麼條件觸發，就寫不出針對性的期望值。
+- **缺什麼證據才能判定**：定位結果。
+- **部分已納入候選 90**：conftest 層 socket 攔截守衛的期望值是確定的（任何非白名單 egress
+  即 fail）；**針對性的「某測試不得打網路」則不可判定**。
+
+### EI 11. `#582` sandbox broker 生命週期與 manager service 的耦合
+
+- **來源軸**：症狀路 EI-9
+- **已有的觀測**：manager 重啟後在飛 claude job 的 terminal 記為
+  `"terminal_reason":"aborted_tools","subtype":"error_during_execution"`。
+- **為何無法定期望值**：機制是**推測**——issue 逐字：「**合理推斷**:Claude native Bash sandbox
+  的 broker/runtime 生命週期與 manager service 綁定……service 重啟把 broker 收走」。
+  **綁定關係未經證實**，且屬 Claude Code 的**外部實作細節**，cortex 無法直接觀測。
+- **缺什麼證據才能判定**：確認 broker 的實際生命週期歸屬（例如以 `systemd-cgls` 或行程樹驗證
+  broker 是否為 manager 的子行程）。
+- **可先寫的替代**：`aborted_tools` 型 terminal 的 taxonomy 分類應為 environment 而非 content、
+  且 retry-card 須被曝光為 next_action——這條期望值確定（issue 建議 3），但那屬**分類問題**
+  （候選 3 的族），**不是本項的重啟耦合**。
+
+### EI 12. `#502` controller／final review 的階段建模與動作型別
+
+- **來源軸**：子系統路 A ＋ 生命週期路 E12
+- **⚠ 與候選 96 重疊**——生命週期路以「存在某動作」的弱表述保留了它；子系統路整條判為不可判定。
+- **已有的觀測**（逐字）：
+  > `ValueError: 非法 gate_state transition: 'passed' -> 'failed'`
+  > `allowed_slice_actions()` 也返回 no actions for a `verified/passed` slice，且 `retry-build` repinning deliberately excludes `verified`
+  > `GATE_STATE_TRANSITIONS["passed"]` permits only `passed`，`REPINNABLE_SLICE_STATES` excludes `verified`
+  > acceptance 首條逐字：「Add an explicit controller/final-review **stage or** typed operator action」
+- **為何無法定期望值**：issue 要求的是一個**尚不存在的生命週期階段**。**四件事全未裁決**：
+  (1) 「新增 stage」vs「新增 typed action」二選一；(2) 轉移後的目標 state 叫什麼；(3) 舊的
+  foreign-review evidence 是留在 `current` 還是降為 `history`；(4) merge 是被硬擋還是僅告警。
+  issue 仍 open、無對應 PR。**現在寫 case 等於發明一台狀態機並把它焊死。**
+  且若新增 phase，manifest 的 phase 集合會改變——**連帶影響候選 86／8／29 的參數化來源**；
+  若是 typed action，則 `allowed_slice_actions()` 的回傳集合改變。
+- **缺什麼證據才能判定**：一份對上述四點的明文裁決（spec 或 openspec change），或一個已 merge
+  的實作 PR。若新增 phase，還需其 persona／sandbox mode／是否需 gate ledger 的裁決
+  （**會直接影響候選 8 的不變式參數化**）。
+- **可先寫的那一半**：候選 96 的 (b)（controller rejection 後舊 candidate 不得被 completed）
+  與 (c)（先前 foreign-review evidence bytes 不變）**兩條都不依賴命名裁決**，可先寫。
+
+### EI 13. `#626` 抽象 principal → 真實帳號的對應來源
+
+- **來源軸**：子系統路 B
+- **已有的觀測**（逐字）：
+  > `operator` 對應到誰是**部署決定**，不是程式能猜的：單人機器上 `operator` 就是那個人的帳號（本機是 `paul_chen`）；多人／CI 部署上可能是(截斷)
+  > 這個替換是**我當場的判斷**，不在 runbook 也不在 spec 裡——換句話說目前這份 runbook 任何人照做都會中止
+- **為何無法定期望值**：「對應到哪個帳號」與「**這個對應從哪裡讀**（env？registry 欄位？
+  runbook 互動提示？）」皆未裁決。
+- **缺什麼證據才能判定**：對應來源的設定介面定案（欄位名／檔案位置／預設行為）。
+- **可判定的那一半已成候選 4**：「**永不輸出未對應的字面值、未對應即產生階段 fail-closed**」
+  ——這一半不依賴對應來源的裁決。
+
+### EI 14. `#474`／`#380` verification acceptance surface 的權威來源與雞生蛋
+
+- **來源軸**：子系統路 C ＋ 生命週期路 E8
+- **已有的觀測**（逐字）：
+  > （#474）**當計畫的第一個任務正是「建立 `.project-policy.yml`」時，這個環永遠解不開。** 編譯時該檔必然不存在 → 全部 slice 拿到 placeholder → 沒有一組能翻 auto，包括那個會建立設定檔的 slice 本身
+  > 我先把 `preflight.steps` 的宣告寫進計畫文件……重編後 warning 完全沒變——因為 compile 讀的是磁碟現況，不是計畫裡描述的未來狀態
+  > （#380 複驗留言）定義 machine-readable acceptance surface（可放 plan metadata / typed block），Deck 只做轉譯，不從 prose 猜測；且「缺少 task-specific acceptance 時保持 `dispatch: hold` / `verification_incomplete` 比填一個看似合理的指令安全」
+- **為何無法定期望值**：`#474` 自己提了**兩個互斥的補救**——(a) warning 補一句說明繞法；
+  (b) 提供 `--policy-from <path>` 讓 compile 從指定檔讀。issue open、無 PR。**若現在照 (a) 寫
+  「warning 含某子字串」的 case，之後採 (b) 時那條 case 會變成永久假綠**（warning 還在、但正確
+  行為已改成不再需要 warning）。且「無宣告時該 hold 還是該 fail-fast 還是該用 repo-level
+  discovery 產生 default」三者未定，**三者的 case 期望互斥**。
+- **缺什麼證據才能判定**：(a)/(b) 的裁決或已 merge 的實作；以及 acceptance surface 的**來源
+  優先序裁決**。
+- **已納入候選的部分**：候選 36 只取「name/argv 名實一致」與「**不得憑空填入測試框架**」兩條
+  已定案部分——後者的表述（「不得填入具體測試框架 argv」）刻意設計成在 hold 與 fail-fast
+  兩種實作下**皆成立**。
+
+### EI 15. `#509` overlay shadowing 應降級還是 fail-closed
+
+- **來源軸**：子系統路 G
+- **已有的觀測**：見候選 30（逐字引用已在該處）。
+- **為何無法定期望值**：issue 的「**降級而非中止**」是**建議**（「建議：1. 降級而非中止……」），
+  **不是裁決**；issue open、無對應 PR。若寫成「shadowing 時 tick 必須存活」，而專案最後決定
+  維持 fail-closed 並改由啟動期告警，**該 case 就成為永久假綠**。
+- **缺什麼證據才能判定**：對 shadowing 失效模式的裁決。
+- **已納入候選的部分**：候選 30 只取**差分**（doctor 與 tick 必須同源）——**不論裁決往哪邊倒
+  都成立**，因此不會固化錯誤期望。
+
+### EI 16. `#523` collision 時受影響列的呈現形態
+
+- **來源軸**：子系統路 H
+- **已有的觀測**：見候選 66。
+- **為何無法定期望值**：候選 66 只涵蓋兩塊可判定的（`work link` 當場擋、其餘 N−1 列仍推進）。
+  但「**受影響的那一列**在 snapshot 裡長什麼樣」未定：它應該完全消失、以 degraded 狀態出現、
+  還是以 collision 專屬狀態出現？PR `#532` 標題是「degraded 保留分支不得複製已轉移歸屬的
+  source」，看起來處理的是**相鄰但不同**的分支，而**子系統路自陳沒有讀該 PR 的 diff，就不能
+  斷定它是否落實了本 issue 的建議 2**。
+- **缺什麼證據才能判定**：PR `#532` 的實際 diff，或對受影響列呈現形態的明文裁決。
+
+### EI 17. 08-12 波未深讀的 6 張：`#473` `#475` `#476` `#478` `#506` `#508`
+
+- **來源軸**：子系統路 I
+- **為何列在這裡**：標題已足以粗歸屬，但**沒有讀原文**。依本次的硬性準則——`observed` 必須
+  逐字引用來源、**不得憑標題推測**——它們不能進候選。
+- **缺什麼證據才能判定**：讀完 6 張的 body。
+- **⚠ 這是本次 sweep 中最容易補齊的一塊**（成本約 1 次 `gh` 呼叫）。詳見「覆蓋缺口」缺口 1。
+  註：`#478` 已由症狀路獨立深讀並產出候選 77；`#506` 已由症狀路讀過但判為 EI 9。
+
+### EI 18. 輔語料 `/var/lib/cortex/legacy-imported/coordinator/` 缺配對期望值
+
+- **來源軸**：子系統路 J
+- **已有的觀測**：artifact **形狀**確實可用。逐字抽樣一份 handoff manifest：
+  > ```json
+  > {"branch": "feature/add-cortex-version-flag-build", "completion": "exited", "exit_code": 0,
+  >  "gate_reason": "pinned-input-mismatch", "gate_status": "needs_human",
+  >  "gate_verdict": {"details": {"mismatches": ["spec-unreadable"]}, "status": "needs_human",
+  >                   "summary": "pinned-input-mismatch"},
+  >  "job_id": "add-cortex-version-flag-build-56",
+  >  "verification_hash": "1372e5b078e174518d0e51f3459d4e3b5c0311f835f5453690b190739d32988d", ...}
+  > ```
+- **為何無法定期望值**：這些檔案有「**發生了什麼**」，但**沒有配對的「應該發生什麼」**。
+  例如上面這份 `pinned-input-mismatch: spec-unreadable`——無法從檔案本身判斷當時的正確行為是
+  「應該讀得到 spec」還是「spec 確實不存在、fail-closed 正確」。
+- **缺什麼證據才能判定**：每份 manifest 對應的 issue／PR 編號，或當時 operator 的糾正動作紀錄。
+- **仍有的用途——這一點很重要**：**當 fixture 來源**（真實 artifact 的欄位形狀與值域），
+  **而不是當 oracle 來源**。候選 59／60／62／29 四條都可直接沿用這批真實 manifest 當輸入；
+  候選 29 更可直接**重放 33 檔**，因為它的期望值有兩個獨立來源（issue 敘事 ＋ 實體 artifact）。
+
+### EI 19. `~/.agents/instances/*/run/` 的 daemon log（5 個 instance）
+
+- **來源軸**：子系統路 K（症狀路亦列為「刻意沒讀」）
+- **為何列在這裡**：只 list 未讀內容。同 EI 18 的理由——log 記錄了行為，但沒有配對期望值；
+  而且這些是**其他 instance**（conventions／hippo-issue-41／hippo-issues-18-41／
+  hippo-open-issues／idk-open-issues）的 run，其 **repo 上下文不在本次語料內**，無法判斷當時
+  的正確行為。症狀路自陳：「直接讀 run 目錄只能取得無上下文的狀態檔，**反而增加『靠推測補
+  期望值』的風險**」。
+- **缺什麼證據才能判定**：對應 repo 的 issue／PR，或 run 當時的 work item 與 spec。
+- **仍有的用途**：artifact 路已對這 5 個 instance 的 **433 個 JSON 全部 parse**，結果是
+  **0 個空檔、0 個無法 parse**——這是一個**誠實的負面結果**，證明候選 55 的 0-byte evidence
+  是**單一 coordinator 的偶發寫入事故**，而非系統性缺陷。
+
+### EI 20. `#519` semantic-reclaim 世代熔斷的重置判準
+
+- **來源軸**：生命週期路 E1
+- **為何無法定期望值**：issue 列了**五個互斥程度不一的建議**（納入 engine／source_revision
+  版本維度／只計相同失敗原因／時間窗／帶審計的 reset action／改善錯誤訊息），**並未裁決**。
+  若 case 斷言「engine 升版後放行」而實作採了「operator reset action」，case 就是**錯的期望**，
+  且會在正確實作上永久紅或永久綠（視斷言方向）。反之若斷言「額度耗盡必須擋」，會把「**根因
+  已修好仍鎖死**」這個真缺陷固化。
+- **缺什麼證據才能判定**：一份裁決紀錄，說明熔斷計數的維度（版本／reason／時間窗）以及是否
+  提供 operator override。
+- **已可判定的殘片**：`semantic-reclaim-budget-exhausted` 的錯誤訊息必須指出下一步——但「下一步
+  是什麼」同樣依賴裁決，**故本輪整條排除**。
+
+### EI 21. `#516` integrator echo-back 欄位（prompt 說明 vs 呼叫端自填）
+
+- **來源軸**：生命週期路 E2
+- **為何無法定期望值**：issue 建議 1（prompt 明寫來源）與建議 4（「這類 echo-back 識別值其實
+  不必經過模型——可由呼叫端在收到模型輸出後自行填入」）在原文中被**明確標為「建議 2 與 4
+  擇一定案」**。採建議 4 時，`question_pack_id`／`secondary_evidence_hash` **根本不再進 prompt**，
+  任何「prompt 必須含該欄位說明」的斷言都是錯期望；反之採建議 1 時，「validator 不得比對模型
+  回傳的 echo-back 欄位」也是錯期望。
+- **缺什麼證據才能判定**：兩案之一的裁決。
+- **註**：`#406`（`artifact_refs` 語意）已定案並落地，**故單獨進候選 18**；`#516` 不隨之進入。
+  **這是 define 八環攻關鏈中唯一一環被判為 evidence-insufficient 的相鄰票**——長套件時需留意
+  這個缺口。
+
+### EI 22. `#595` abandon 對 run 建立的 openspec change 的處置
+
+- **來源軸**：生命週期路 E3
+- **已有的觀測**（逐字）：
+  > 判準需能分辨「修復已在管線外落地」（archive）vs「純放棄」（移除/標記）
+- **為何無法定期望值**：**該判準未定義。** archive 與「標記 superseded-orphan」是**兩種相反的
+  終態**；case 斷言任一都可能與實作相反。
+- **缺什麼證據才能判定**：一個**可機械判定**的「修復是否已在管線外落地」判準（例如 pr_refs 全
+  merged？candidate 已在 default branch 可達？），或明確裁決一律標記。
+- **影響**：候選 70 的 (d) 廣義不變式因此**暫時排除 openspec change 這一類**，或只斷言「不阻斷
+  下一世代」這個弱形式。
+
+### EI 23. `#515` 環境類拒收原因的 classification 歸屬
+
+- **來源軸**：生命週期路 E6
+- **為何無法定期望值**：原文逐字用的是「**宜考慮**分類為 `environment` 而非 `content`」，且與
+  `#507`／`#416` 的分類修正「同一方向」但**未合併裁決**。`#416` 已為「abandon 未回滾的發佈
+  殘留」建立 `_is_planning_authority_residue_failure()` carve-out 改判 `environment`——但那是
+  **逐案 carve-out，不是通則**。而 `classification` **直接決定 `recover-planning` 是否受理**
+  （`work_actions.py:2912`）：斷言 symlink／路徑逃逸／解碼失敗一律 `environment` 若與實作相反，
+  **會把一條錯誤的復原路徑固化**。
+- **缺什麼證據才能判定**：environment／content 二分的**通則定義**（何謂「輸入沒變、重試無意義」），
+  或逐類的裁決表。
+- **影響**：候選 98 的 (c) 因此**只斷言「reason 可區分」，刻意不碰 classification**。
+
+### EI 24. `#568` reviewer 零輸出（權限剖面缺失）的處置方向
+
+- **來源軸**：生命週期路 E9
+- **已有的觀測**（逐字）：見候選 15 的 `#568` 引用。
+- **為何無法定期望值**：原文逐字列「待釐清（**修復方向擇一或並行**）」三項：jetski 細粒度
+  allow-rule／verification 卡對 read-only reviewer 的期望降為「不執行測試、只審 evidence」／
+  dispatch 端預檢權限剖面後 fail-fast 換身分。**第二項會改變 verification 卡的職責定義**
+  （reviewer 是否跑測試），**第三項會改變 dispatch 的身分解析**。case 期望在三者之下完全不同。
+- **缺什麼證據才能判定**：三方向的裁決，特別是「**read-only reviewer 是否應執行測試**」——原文
+  自陳「gate ledger 已提供獨立測試證據——`#379`/`#540` 之後 reviewer 重跑測試的邊際價值下降」，
+  **這是傾向但非決定**。
+- **已納入候選的部分**：候選 15 只取**安全不變式**（reviewer argv 恆 read-only），**該條在三個
+  方向下皆成立**。
+
+### EI 25. outbox／event-spool／commit-spool／gate-ledger-spool／review-verdicts／job-specs 語料為空
+
+- **來源軸**：artifact 路 1
+- **現況（逐字）**：`/var/lib/cortex/coordinator/digest/outbox/`、
+  `/var/lib/cortex/monitor/event-spool/`、`/var/lib/cortex/coordinator/gate-ledger-spool/`、
+  `/var/lib/cortex/coordinator/review-verdicts/`、
+  `/var/lib/cortex/coordinator/job-specs/{builder,gate,reviewer}/`、`commit-spool/smoke2/`
+  **全部是空目錄**（trust-root 部署後尚未產生語料）。legacy-imported 樹裡**完全沒有這些目錄**。
+- **缺什麼證據才能判定**：至少一輪跑滿的 outbox／spool 檔案樣本（**含正常投遞、重試、
+  quarantine 三態**），才能判定「什麼算損壞、什麼算合法的中間態」。
+- **相關 issue（僅標題級，未深讀 body 以免編造）**：`#585`「spool janitor 缺席（quarantine 無
+  保留策略、孤兒事件、每輪 N 次掃描、寫入端不驗 repo 形狀）」。**這張 issue 本身就說明保留
+  策略尚未定案**——在策略定案前寫 case 必然固化錯誤期望。
+- **⚠ 交叉影響**：這使候選 93（`#638` spool seal）的 tier 2 **沒有真實語料可對照**——它只能靠
+  自己造 fixture，無法驗證 fixture 是否貼近 production 形狀。**這正是「手抄 property 子集」
+  風險最高的一格**（見發現 2 硬規則 5）。
+
+### EI 26. planning-transaction journal 為空
+
+- **來源軸**：artifact 路 2
+- **現況**：`planning-transactions/` 與 `workflow-report-transactions/` 在
+  `~/.agents/coordinator/`、`/var/lib/cortex/legacy-imported/coordinator/`、
+  `/var/lib/cortex/coordinator/`、以及 `hippo-issue-41`／`hippo-issues-18-41` 兩個 instance 中
+  **全部為空**。唯一非空的是
+  `planning-sandboxes/74a73a92009d594a0828c52c0a406a95/`（一個舊沙箱目錄，非交易 journal）。
+- **已有的觀測**（`#559` 逐字）：
+  > `_materialize_plan_card_output` 用 `journal_root=None` 的 `_PlanningPublicationTransaction`（該函式 docstring 自陳：寫入成功後、registry 提交前崩潰會留下未登記的孤兒檔）。#553 的 tick sweep 看不到它——**沒有 journal 就沒有收斂依據**。
+- **缺什麼證據才能判定**：一份實際的 transaction journal 檔（**哪怕是成功案例**），才知道
+  journal entry 的 schema、以及「未完成交易」在檔案層長什麼樣。**目前只知道「應該要有
+  journal」，不知道 journal 該長什麼樣，寫不出可信 oracle。**
+- **⚠ 交叉影響**：這直接限制候選 86 的 (B) 事務性限肢——沒有 journal schema，crash 注入後
+  「一致狀態」的判定只能靠列目錄比對，而不能靠 journal 對帳。
+
+### EI 27. manifest 內容相同卻存在不同 claim-hash 下（是否應去重）
+
+- **來源軸**：artifact 路 3
+- **實測**：9 組 manifest 的 JSON 內容**完全相同**卻存成不同檔名，例如
+  `fix-brainstorm-revalidation-diagnostics` 有 3 份（`033ceb244d6e`／`0504fa5e8e66`／
+  `098fd29221b9`，mtime 相隔 1–4 分鐘）、`docs-only-lifecycle-canary` 2 份、
+  `add-cortex-version-flag` 2 份等。檔名經驗證**不是**內容雜湊（`delivery-journal` 的
+  `claim_key` 尾段與檔名吻合，故**檔名是 claim 摘要**）。
+- **為何無法定期望值**：**「manifest store 是以 claim 定址還是以內容定址」的成文規格不存在。**
+  若是前者，重複是**設計意圖**；若是後者，這是**嚴重去重失效**。**兩種期望值完全相反，猜錯就是
+  永久假綠燈。**
+- **缺什麼證據才能判定**：manifest store 定址語意的成文規格。
+- **影響**：候選 52 因此**只斷言「已過 claim 的 run 必須有 manifest」，不碰去重語意**。
+
+### EI 28. work-item snapshot 的 `source_owners` 覆蓋規則
+
+- **來源軸**：artifact 路 4
+- **實測**：`work_items[].sources` 共引用 1050 個 `source_id`，`source_owners` 只有 904 筆——
+  **146 個 source 沒有 owner 記錄**。細分後：其中 144 個屬於「只有單一 source 的 work item」
+  （無需仲裁，可能是設計上不記錄），但有 **1 個 work item**
+  （`hamanpaul/paulsha-conventions` 的 `issue-39-internal-release-channel`）**有 2 個 source 且
+  兩個都沒有 owner**，而另外 284 個 2-source item 都有 owner。
+- **為何無法定期望值**：`source_owners` 的填充條件未知（所有 source？只有被多方宣告的 source？
+  只有 confirmed work item？）。**1 個反例不足以判定是 bug 還是狀態機的合法過渡。**
+- **缺什麼證據才能判定**：`correlate_work_sources` 的規格，或多次 snapshot 的時序對照。
+
+### EI 29. `#564` gate ledger artifact 的實體樣本
+
+- **來源軸**：artifact 路 6
+- **實測**：artifact 路在 `jobs.json` 找到 `#564` 現場的 job
+  （`wf-865ecb7f70-subagent-build-483`，`exited_at: 2026-08-15T08:37:54.035401+00:00`，
+  與 issue 的 16:37:54 +0800 吻合），但 **gate ledger artifact 本身在任何 store 中都不存在**
+  （`gate-ledger-spool/` 為空；legacy 樹無此目錄）。
+- **缺什麼證據才能判定**：一份 gate ledger 檔的**實體樣本**（schema、寫入路徑、落地時序標記）。
+  沒有它，「`exited-pending-gates` 中間狀態」該以什麼欄位表達**無從判定**，時間窗界線（N 秒）
+  **也只能猜**。
+- **與候選 91 的關係**：候選 91（`#564`）**保留在清單中**，但其欄位形狀與窗口界線受本項限制
+  ——**建議先寫「中間態存在且與終局態可區分」的弱形式**，欄位形狀待 ledger schema 落地後補強。
+  這是「候選成立但 oracle 的一部分需降級」的典型，與整條排除不同。
+
+### EI 30. `status.json` 的 `attention` 保留策略（`#265` 家族）
+
+- **來源軸**：artifact 路 7
+- **實測**：`~/.agents/control/status.json`（`updated_at: 2026-08-17T00:42:53`）的 `attention`
+  有 36 筆，其中包含 slice `add-cortex-version-flag-build`——該 slice 的最後一次 operator 動作在
+  `2026-08-11`，evidence 最早可回溯到 `2026-07-21`，且 `repo: null`。`#265` 標題自陳
+  「`recent_done` 無 recency window，8 天前的歷史 manifest 永久佔滿 status 全部名額」
+  （**已 CLOSED，但那修的是 `recent_done` 不是 `attention`**）。
+- **為何無法定期望值**：`attention` 是否應有 recency window 的成文決策不存在。**`attention` 的
+  語意可能就是「無限期保留直到處理」，那 26 天不算 bug。**
+- **缺什麼證據才能判定**：規格或 issue 明示。
+
+### EI 31. `verification_hash` 死欄位的正確處置
+
+- **來源軸**：artifact 路 8
+- **實測**：505 個 job **全部 `verification_hash: null`**，而 `evidence/verification/` 有 206 檔。
+- **為何無法定期望值**：這欄位是「**已廢棄待刪**」還是「**應該要填但沒填**」未知。
+  前者的 oracle 是「必須移除」，後者是「必須非 null」——**相反的期望值**。
+- **缺什麼證據才能判定**：schema 版本歷史或 PR 紀錄佐證。
+- **影響**：候選 24 因此只做「必須被移除**或**被填」的二選一斷言，**不指定哪一邊**。
+  但「**若一個欄位在全庫 100% 為 null，任何 `if job["verification_hash"] == expected` 的檢查
+  永遠取到 None**」這條 fail-open 警示本身是確定的，已寫進候選 24。
+
+### EI 32. 8 個 `multiple-delivery-targets-unsupported` run 的 openspec ref 同日期前綴
+
+- **來源軸**：artifact 路 9
+- **實測**：`delivery-journal.json` 中 8 個 `ship.phase == "needs_human"` 的 run，其
+  `mapped_openspec` **全部以 `2026-07-26-` 開頭**（`2026-07-26-fix-deck-emit-frontmatter`、
+  `2026-07-26-fix-service-install-overwrite`、`2026-07-26-docs-archived-spec-purpose`…），
+  而其 issue 編號分散在 `#98`–`#169`、`mapped_prs` 全為 `[]`、`delivery_binding` 全為 `null`。
+  看起來像一次批次改寫的產物。
+- **為何無法定期望值**：這 8 筆是「**批次回填時被統一貼上日期前綴**」（資料污染）還是
+  「**那天真的批次建了 8 個 openspec change**」（正常）無法分辨。
+- **缺什麼證據才能判定**：repo 的 `openspec/changes/` 目錄歷史或當時的 commit。
+  **單看 journal 無法判定，貿然寫成「日期前綴不得重複」的 case 會誤傷正常批次。**
+
+---
+
+## 七、四路的誠實負面結果
+
+artifact 路做了比對但**沒有**找到矛盾的項目，一併記錄以免後續重工。這些是「查過、乾淨」而非
+「沒查」：
+
+- `~/.agents/coordinator/` 與 `/var/lib/cortex/legacy-imported/coordinator/` 全樹 `diff -rq`：
+  **零差異**（兩份獨立拷貝，尚未漂移）。
+- `logs/workflow/*.exit`（478 檔）vs `jobs.json.exit_code`：**0 筆不符**。
+- `~/.agents/control/status.json` 的 `recent_done`（10 筆）vs `jobs.json` 的 `branch`：
+  **0 筆不符**；`attention` 的 35 筆 workflow entry 與 `jobs.json` 的
+  `status`／`current_phase`／`work_id`：**0 筆不符**。
+- `evidence/workflow-inputs/`（155 檔）：檔名一律 = raw-bytes sha256、571 筆
+  `input_snapshot.content_ref` 全部存在、`sha256` 全部吻合、**0 個 orphan**。
+  **這是全庫唯一完全自洽的 content-addressed store**——可作為候選 22／84 的正面對照組。
+- `evidence/workflow` 的 137 筆 review payload：`state` 與 `findings[].blocking` **完全自洽**
+  （passed∧無 blocking = 83、rejected∧有 blocking = 54、矛盾 0）。**`#617` 描述的散文-vs-結構化
+  矛盾不在這批 evidence 裡**（見 EI 7）。
+- 388 筆 `evidence/workflow` 的 `job_id`／`run_id`／`claim_key`／`input_snapshot.content_ref`
+  對 `jobs.json` 與檔案系統的參照：**0 筆懸空**。
+- 其他四個 instance（`conventions`／`hippo-issue-41`／`hippo-issues-18-41`／`hippo-open-issues`／
+  `idk-open-issues`）共 **433 個 JSON：0 個空檔、0 個無法 parse**。
+- work-item snapshot：`work_id` 無重複、無 source 被多個 work item 宣告、35 個 `workflow_run_id`
+  全部有對應 run。
+
+症狀路的誠實負面結果：**資源洩漏未成族**——記憶體／fd 型只有 `#153` 一例，量不成族；本 repo
+的「洩漏」實際上都是**具名資源殘留**，已併入交易未完成／半套用族（候選 70／87）。
+
+---
+
+## 八、下一步建議（供 R3 排序參考）
+
+1. **先補缺口 1**（6 張未讀，約 1 次 `gh` 呼叫），再做任何新的 sweep。
+2. **首批三筆**：候選 1（`#490`）、候選 2（`#618`/`#619`）、候選 3（`#487`/`#500`/`#554`）。
+   三筆皆為純函式＋凍結 fixture、oracle 型別為集合相等或差分／property、零 harness 前置，
+   且**不依賴任何未定裁決**。
+3. **旗艦兩筆**（風險最高、但需 T2 fs 佈置）：候選 28（`#296`/`#310`）與候選 59（`#501`，
+   唯一四路命中）。
+4. **define 八環攻關鏈整組長**（候選 10／48／64／65／18／6，＋ 補讀 `#391`／`#393`）——
+   **不要拆開只做其中幾條**，見發現 3。
+5. **ship／delivery 補課**——見缺口 2，從候選 92 指出的那筆未完成交易切入。
+6. 把「多 UID 不可用時標 `unsupported`，不得標 `pass`」與「手抄 property 子集 ＝ 驗證無效」
+   兩條**寫進 harness 契約層**，目前它們只是本文件裡的硬規則，**尚無執行機制**。
+

--- a/docs/superpowers/workstreams/r3-testpilot-case-corpus/todo.md
+++ b/docs/superpowers/workstreams/r3-testpilot-case-corpus/todo.md
@@ -1,0 +1,68 @@
+---
+status: proposed
+work_item: r3-testpilot-case-corpus
+---
+
+# r3-testpilot-case-corpus Todo
+
+R3（原 v3 的 1-B）testpilot plugin case 的**素材盤點** workstream，對應 issue `#667`。
+
+**status 刻意不是 `accepted`**：本 workstream 的產出是一份**候選清單**，不是已核可的實作
+計畫。清單本身不進派工鏈、不當 gate、不擋 merge。要把其中任何一筆長成 case，需要另開
+實作票並在該票上取得 accepted 的計畫——本 workstream 不代行那個核可。
+
+本票的唯一產出是文件。**明確不做**（`#667` scope fence，越界即為失敗）：不寫任何 case
+yaml、不建 mock provider／tick harness、不動 `paulsha_cortex/` 下任何程式、不預蓋框架。
+
+## Tasks
+
+- [x] 四路盲測 sweep 執行完成（症狀家族／子系統／生命週期階段／artifact 型別，四路互不
+      看對方的發現）。原始筆數：症狀 37、子系統 49、生命週期 37、artifact 32（`#667`
+      派工單記為 31，實際條目重算為 32）。
+- [x] 跨軸去重並計算 `hit_by`：**101 筆**去重後候選。分佈為四路命中 1、三路 9、二路 31、
+      單路 60。合成後的清單本體見 `case-candidates.md`。
+- [x] `evidence-insufficient` 四路合併去重：原始 41 筆（症狀 9／子系統 11／生命週期 12／
+      artifact 9）→ 去重後 **32 筆**，全部保留「缺什麼證據才能判定」。
+- [x] 三個橫向發現落檔（oracle 品質分級／既有陷阱與 tier 拆分硬規則／define 八環攻關鏈
+      整組存在）。見 `case-candidates.md` 的「三個橫向發現」一節。
+- [x] 覆蓋缺口誠實記錄（08-12 波未深讀 6 張／ship-delivery 語意零覆蓋／porcelain 分不出
+      穩定與繞過／deck-combo 次級缺口）。見 `case-candidates.md` 的「覆蓋缺口」一節。
+- [ ] **下一輪優先**：補讀 08-12 波未深讀的 6 張（`#473`／`#475`／`#476`／`#478`／`#506`／
+      `#508`）。成本約 1 次 `gh` 呼叫。其中 `#478` 與 `#506` 已由症狀路獨立取證進入候選
+      （`recovery-reports-ok-while-git-registry-stale`／`secondary-rate-limit-response`），
+      補讀可把它們從單路命中升級，並可能新增 deck 與 work-registry schema 兩格。
+- [ ] **下一輪優先**：補 ship／delivery 的語意面。**不要再掃 issue**——語料已證實 08-12 波
+      33 張深讀裡零張是 ship 事故。建議改讀 `github_delivery.py`(47KB) 的 PR metadata
+      preflight／merge authorization／delivery journal／push readback／closed-unmerged PR
+      五個表面，並以 `delivery-journal.json` 的 19 個 run 當 fixture 來源。
+- [ ] **下一輪優先**：補 porcelain 的 operator 繞過手法。同樣**不要再掃 issue**——建議讀
+      `docs/` 的 onboarding／quickstart／troubleshooting 與 driving-cortex skill
+      （`#177`／`#192`），operator 的繞法沉澱在那裡而不在 issue tracker。
+- [ ] 決定 T1 三筆（`review-identity-loader-asymmetry` `#490`／
+      `porcelain-cli-verb-must-match-permgen-execstart` `#618`+`#619`／
+      `unbounded-substring-marker-misclassifies-failure` `#487`+`#500`+`#554`）是否為 R3 的
+      首批實作票。三筆皆為純函式＋凍結 fixture、oracle 型別為集合相等或差分、零 harness
+      前置。**待 R2 Compact 收斂後才開實作票**（R3 本體依賴 R2，本盤點不依賴）。
+- [ ] 確認 case report 與 `EvidenceAttestation` 的契約對齊（subject 綁 candidate、**不得
+      自我背書**）。本盤點未涉及此契約的實作形狀，僅記錄依賴。
+- [ ] 把「多 UID 不可用時標 `unsupported`，不得標 `pass`」寫進未來 case harness 的契約層
+      （目前只是本文件裡的硬規則，尚無執行機制）。
+
+## 一句話狀態
+
+四路盲測 sweep 已完成並合成為 101 筆去重候選 ＋ 32 筆 evidence-insufficient；清單本體與
+三個橫向發現、四個覆蓋缺口皆已落檔。**尚未有任何 case 被實作**，也不應在 R2 Compact
+收斂前開始。
+
+## 依賴
+
+- **本 workstream 零前置**（`#667` 刻意如此設計）。
+- **R3 本體**（把候選長成 case）依賴 **R2 Compact**。理由是 0814 實測「12 卡成本下小案派工
+  不成立，每案 define 必死」——見候選清單的 define 八環攻關鏈。
+
+## 相關
+
+- issue：`#667`
+- 計畫：`~/prj_pri/cortex-redesign-rollout-plan.md` → `Phase R3【原 1-B｜testpilot plugin
+  cases，用 Compact 跑】`
+- 清單本體：`docs/superpowers/workstreams/r3-testpilot-case-corpus/case-candidates.md`


### PR DESCRIPTION
Closes #667

## 這張票做了什麼

四路**互相盲測**的語料 sweep（症狀家族／子系統／生命週期階段／artifact 型別，執行期間彼此
不看對方的發現）合成為 R3 testpilot case 的候選清單。

**唯一產出是文件**，符合 `#667` 的 scope fence：不寫任何 case yaml、不建 mock provider／tick
harness、不動 `paulsha_cortex/` 下任何程式。`git status` 只有 `docs/`＋`changelog.d/`＋
`CHANGELOG.md`。

## 產出

- `docs/superpowers/workstreams/r3-testpilot-case-corpus/todo.md`（`status: proposed`——這是
  盤點，不是已核可的計畫）
- `docs/superpowers/workstreams/r3-testpilot-case-corpus/case-candidates.md`（3143 行）

## 去重結果

| | 數量 |
|---|---:|
| 四路原始條目 | **155**（症狀 37／子系統 49／生命週期 37／artifact 32） |
| 去重後候選 | **102** |
| — `hit_by` 四路 | **1** |
| — `hit_by` 三路 | **9** |
| — `hit_by` 二路 | **31** |
| — `hit_by` 單路 | **61** |
| evidence-insufficient（原始 41） | 去重後 **32** |

> `#667` 派工單記 artifact 路為 31 筆，實際 `### ` 級條目重算為 **32**，以實際為準。

**61 筆單路命中全數保留並明確標示。** 單路不等於不重要——artifact 路的 24 筆純實測發現
（0-byte evidence、雜湊方案不一致、log 截斷、run journal 與正典 manifest 對不上…）**沒有
對應 issue，掃 issue 的三路在結構上不可能命中**。

## 排序依據

**依「可以最早開始長」排，不依 `hit_by` 數量。** 判準依序為 oracle 型別品質 → harness 前置
成本 → `determinism_risk` → 期望值是否已定案 → `hit_by`（僅同分時加權）。分 T1–T6 六個 tier。

第 1 名是**單路命中**的 `#490`（review 與 tick 的 identity 集合必須相等，純函式、零前置）；
唯一的**四路命中** `#501` 排第 59——它需要 tick 推進與**可控的 review-launch 失敗**，而
issue 明言 happy path 會遮蔽該缺陷，只跑快樂路徑必然是一條永遠綠的假 case。

## 三個橫向發現（四路各自撞出來的，合成時保留）

1. **oracle 有品質分級。** 最高等級是**差分／集合相等**型（`#490` identity 集合、`#509`
   doctor 與 tick 同源、`#383` tick 與 fanout dispatch 集合、`#486` prompt severity enum、
   `#420` 兩條 claim 入口到達同一 phase）——共同性質是**無法靠放寬任一邊來滿足**，結構上擋得住
   fail-open。相對地閾值型與存在性型容易被放寬成空過。**每筆候選都標注 oracle 型別。**
2. **既有陷阱必須在 `harness_needs` 標明，並強制拆 tier。** 多條 trust-root case 的原 issue
   逐字記錄了「上次是怎麼被繞過去的」。文件層級訂五條硬規則，其中：**多 UID／root／`direct`
   模式／缺 `acl` 時必須標 `unsupported`，不得標 `pass`，也不得 skip 成綠**；以及新增的
   **「手抄 property 子集 ＝ 驗證無效，且兩個方向都會錯」**——四個實例中 `#638`／`#657`／
   `#673` 原 body 是**假綠**，而 `#673` 的 repro（漏抄 `SystemCallErrorNumber=EPERM`、比
   production 更嚴格）是**假紅**。`#673` 的結論已被實測推翻，本清單**不採用其結論**，但方法論
   教訓保留並強化。
3. **define 是八環串聯攻關鏈**（`#391`→`#393`→`#397`→`#399`→`#401`→`#404`→`#406`→`#408`，
   每修一環露下一環、每環確定性、每環燒一個世代）。作為 case 套件**應整組存在**，不得拆成
   八個獨立 case——tier 是動工成本，不是拆包單位。

## evidence-insufficient（32 筆，非空）

期望值無法從既有證據判定的一律不進候選。每筆保留「缺什麼證據才能判定」。

其中 **3 筆與候選清單重疊**（`#502`／`#524`／`#488`）——那不是矛盾，是**四路之間真實的判斷
分歧**：某一路認為可判定的部分已進 T6 候選，另一路認為不可判定的部分留在 EI 區。兩邊都保留、
分歧明載。

## 覆蓋缺口（刻意不淡化）

1. **08-12 波 6 張未深讀**（`#473`／`#475`／`#476`／`#478`／`#506`／`#508`）。補齊成本約 1 次
   `gh` 呼叫，是本次投報最高的一塊，**下一輪應先做這件事再做任何新 sweep**。
2. **ship／delivery 是覆蓋度與風險落差最大的一格。** `github_delivery.py`(47KB)＋
   `delivery.py`(21KB) 是全庫第三大功能面，卻**零條 delivery 語意候選**（子系統路只擠出 2 條，
   兩條都是權限問題）。成因可考：08-12 波深讀的 33 張裡**零張是 ship 事故**（全部卡在
   define/build/verify/review 就死了），且 ship 卡由 Manager deterministic 執行、**不經
   launcher、無 LLM 參與**，所以 dogfooding 難顯現。**ship 是離 merge 最近的那道閘，這裡的
   假綠代價最高。** 補這格建議讀 `github_delivery.py` 的五個表面，以 `delivery-journal.json`
   的 19 個 run 當 fixture，從候選 92 指出的那筆未完成交易切入。
3. **porcelain 分不出「真的穩定」還是「operator 當場繞過而不開票」。** 2 條候選都是 trust-root
   外溢，七個 verb 家族本身零原生事故。補這格建議去讀 `docs/` 的 onboarding／troubleshooting
   與 driving-cortex skill（`#177`／`#192`），**而非再掃 issue**——operator 繞過的手法沉澱在
   文件裡。
4. deck-combo 自動選型面零事故（次級）。

另附四路的**誠實負面結果**（查過、乾淨的比對），避免後續重工。

## 驗收對照（`#667`）

1. ✅ 每筆 `observed` 逐字引用來源、可回溯到具體 issue／run／artifact，未經改寫或潤飾。
2. ✅ 四路 sweep 的命中集合可分辨——`hit_by` 欄位全部非空，並在標題行標示路數。
3. ✅ `evidence-insufficient` 區段存在且非空（32 筆）。
4. ✅ `git status` 只有 `docs/` 變更（＋R-09 要求的 `changelog.d/` fragment 與 `CHANGELOG.md`）。

## 建議首批三筆

`#490`、`#618`+`#619`、`#487`+`#500`+`#554`——三筆皆為純函式＋凍結 fixture、oracle 型別為
集合相等或 property、零 harness 前置，且**不依賴任何未定裁決**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E7w9kaUxAzCCEk7piD5hfK
