### PR TITLE
fix(trust-root): job 的 PATH 兩層都補、fail-closed，並禁止驗證指令自帶 PATH（#679）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@
 
 ## [Unreleased]
 
+### Fixed
+- **#679：job 的 `PATH` 沒有一個來源是被決定過的——兩層都補、fail-closed，並禁止驗證
+  指令自帶 `PATH`**。降權模式下 job 解到哪一份 CLI 取決於三件沒人裁決過的事：六份模板
+  unit 沒有一份有 `Environment=PATH=`；`build_job_env()` 對 `PSC_*_PATH` **fail-open**；
+  而 `PATH` 當時還在**轉發類**白名單上，因此未宣告時 job 靜默拿到 **Manager daemon 的**
+  `PATH`（daemon 自己也沒有時，`os.execvpe` 退回 `os.defpath`＝`:/bin:/usr/bin`）。終點
+  一樣：`claude`／`agy` rc=127，`codex` **靜默**解到 `/usr/bin/codex`（實機 0.42.0，
+  toolchain 那份 0.147.0）——不報錯，只是產出來自沒人判讀過的 CLI；三個角色全中。
+  修法四件：(1) 新增 `job_runner.resolve_job_path()`，三個 `PSC_*_PATH` 未宣告即
+  `job-runner-path-undeclared` fail-closed（採裁決 (a) raise，不採「退回產生器預設」——
+  #453「registry 永不寫入預設值」的同一條立場）；(2) **`PATH` 移出轉發白名單**（本票真正
+  的 fail-open，issue 證據鏈少的那一環：daemon 的 `PATH` 帶著 `<deploy_root>/venv/bin`，
+  與 `HOME`／`VIRTUAL_ENV` 同一類錯誤）；(3) 六份模板 unit 補 `Environment=PATH=`（permgen
+  機械產生、與 Manager 端變數同源），`job_shim` 在 spec 缺 `PATH` 時退回這一層（root-owned
+  ⇒ 不是 fail-open），兩層都缺才拒絕 exec 且失敗發生在**接管 log 之前**；(4) 驗證方法：
+  共用探針 `psc_run_under` 移除 `--setenv=PATH=`、`psc_probe_path()` 刪除，新增
+  `permgen.build_path_resolution_probe()`／CLI `trust_root path-probe` 的**角色 × executor
+  全列舉**反向不變式（零額外 env、斷言解到 `<toolchain>/bin/<cli>` 且版本與同一支檔案的
+  絕對路徑逐字相同）。**為什麼它活過五輪驗證**：每一條驗證都自帶 `--setenv=PATH=`——
+  驗證環境供應了 production 不供應的東西；runbook 4e 逐字預言了症狀、連 0.42.0 都寫對了，
+  但那條是 `sudo -u … env PATH=…` 跑的。這是「綠燈不承載語意」的第五個實例、新的一類
+  （前四次是複本比 production 弱或強，這次是**多**），#677 的規矩因此再推一格：**複本必須
+  連「production 沒有設什麼」也一起複製**。順手收掉 runbook 手打的 `PSC_GATE_PATH`
+  少 toolchain 段這條第三份真相（與 permgen／#666 不一致）；三個變數一律由產生器導出。
+  runbook 新增 **4e-2**（反向不變式）與 **5-5b**（升級既有部署：補三個變數、重新落檔六份
+  unit、重啟 Manager，含降級路徑警語），troubleshooting 新增 `job-runner-path-undeclared`
+  一節。測試 `tests/test_job_path_fail_closed_679.py`；OS 層語意以具名
+  `@pytest.mark.skip` ＋ 完整理由標示，不靜默通過。
+
 ### Added
 - **#672：planner 降權的設計交付（spec ＋ design ＋ 實作切分計畫，零 code）**——planning
   （define／brainstorm）從來沒有被降權：`planning_runtime.py:830` `_invoke_json()` 以

--- a/README.md
+++ b/README.md
@@ -111,7 +111,10 @@ cortex bootstrap --instance cortex --repo-root "$(git rev-parse --show-toplevel)
    `systemd-run --uid=cortex-builder` 的 transient unit 執行，只帶白名單 env（**不含任何
    token**）。**這個開關要在 `cortex-builder` 帳號與 polkit 規則就位之後才可打開**，
    步驟見 `docs/superpowers/runbooks/trust-root-phase2b-setup.md` 第 5 步；相關選配變數
-   為 `PSC_BUILDER_ACCOUNT`／`PSC_BUILDER_GROUP`／`PSC_BUILDER_HOME`／`PSC_BUILDER_PATH`。
+   為 `PSC_BUILDER_ACCOUNT`／`PSC_BUILDER_GROUP`／`PSC_BUILDER_HOME`。
+   **`PSC_BUILDER_PATH` 不是選配**（#679）：它與 `PSC_REVIEWER_PATH`／`PSC_GATE_PATH`
+   同為**必填**，未宣告時 Manager 在派工前即 fail-closed。值由產生器導出，不要手打：
+   `python3 -m paulsha_cortex.trust_root unit four-way --job | grep '^Environment=PATH='`。
 
 3. 使用 Deck 先 dry-run，再 emit `dispatch: hold` specs：
 

--- a/changelog.d/679-job-path.md
+++ b/changelog.d/679-job-path.md
@@ -54,12 +54,12 @@
   `<toolchain>/bin ＋ JOB_PATH_SYSTEM_TAIL`）不一致。三個 `PSC_*_PATH` 現一律由產生器
   導出，runbook 不再手打。
 
-  **測試**：`tests/test_job_path_fail_closed_679.py`（46 條）——三個角色各自缺席／空值
+  **測試**：`tests/test_job_path_fail_closed_679.py`（47 條）——三個角色各自缺席／空值
   的 fail-closed、角色互不污染、錯誤訊息的 `trust_root unit` 旗標與
   `permgen.JOB_UNIT_CLI_FLAG` 一致、六份 unit 皆有 `Environment=PATH=` 且值由
   `PathLayout` 導出（換部署根即跟著換）、shim 三種情形（spec 優先／退回 unit／兩層都缺
   即 `ShimError` 且不建 log）、**複本的 PATH 逐字來自 unit 且 unit 沒有時複本也沒有**、
-  探針產生器的可執行行不得出現 `--setenv=`（含偵測器自己的 negative control）、矩陣
+  探針產生器的可執行行不得出現 `--setenv=`（含偵測器自己的 negative control）、**探針呼叫共用的 `psc_run_under` 而不自帶第二份定義**（未定義時 fail-closed）、矩陣
   完整性與剖面對應。OS 層語意（真的解到哪個檔）需要第二個 UID ＋ 真實 systemd 加固面
   ＋ 兩份同名不同版的 CLI，本環境全部沒有，因此以**具名 `@pytest.mark.skip` ＋ 完整
   理由**標示，並列出改由哪三個地方守——不靜默通過。

--- a/changelog.d/679-job-path.md
+++ b/changelog.d/679-job-path.md
@@ -1,0 +1,65 @@
+### Fixed
+- **#679：job 的 `PATH` 沒有一個來源是被決定過的——兩層都補、fail-closed，並禁止驗證
+  指令自帶 `PATH`**。降權模式下每一個 job 解到哪一份 CLI，取決於三件全部沒人裁決過的
+  事：六份模板 unit 沒有一份有 `Environment=PATH=`；`job_runner.build_job_env()` 對
+  `PSC_*_PATH` **fail-open**（未宣告就不寫這個鍵）；而 `PATH` 當時還在**轉發類**白名單
+  上，於是未宣告時 job 靜默拿到 **Manager daemon 的** `PATH`。三條路的終點一樣：
+  `claude`／`agy` rc=127，而 `codex` **靜默**解到 `/usr/bin/codex`（實機 0.42.0，
+  toolchain 那份 0.147.0）——不報錯，只是產出來自一支 operator 從未判讀過的 CLI。
+  builder／reviewer／gate 三個角色全中。
+
+  **四件事**：
+
+  1. **`build_job_env()` 改 fail-closed（裁決 (a)：raise）**——新增
+     `job_runner.resolve_job_path()`，`PSC_BUILDER_PATH`／`PSC_REVIEWER_PATH`／
+     `PSC_GATE_PATH` 未宣告時以 `job-runner-path-undeclared` 當場失敗，訊息帶得出
+     「哪個變數」與「去哪一份 unit 取正規值」。**不採選項 (b)（退回產生器預設）**：
+     本 repo 對「未宣告即用預設」已有明確立場（#453「registry 永不寫入預設值」），
+     而「job 解哪一份 CLI」正是必須有人做的決定；替他做一次只會把「未宣告」與
+     「宣告成這樣」壓成同一種狀態，下一次漂移一樣看不見。既有部署會在下一次派工
+     直接 fail——**那是對的**，現況是靜默跑錯版本（升級步驟見 runbook 5-5b）。
+  2. **`PATH` 移出轉發類白名單**——這才是本票真正的 fail-open，issue 的證據鏈少了
+     這一環：daemon 的 `PATH` 帶著 `<deploy_root>/venv/bin`（等於把 job 的 `python3`
+     綁回 Manager 的 venv），且是否含 `<toolchain>/bin` 純看該機器的 EnvironmentFile
+     被誰手動加過什麼。與 `HOME`／`VIRTUAL_ENV`（早就在排除表上）同一類錯誤，
+     現改列 `BUILDER_SYNTHESIZED_ENV` ＋ `EXCLUDED_ENV_RATIONALE`。
+  3. **`Environment=PATH=` 寫進六份模板 unit**（permgen 機械產生，與 Manager 端變數
+     同源）——#640 當時判斷「寫在 unit 上會被 shim 丟掉」對了一半：spec 的 env 確實是
+     job 的完整環境，但產生它的那一支當時 fail-open，於是**兩層同時為空**。現在
+     `job_shim` 在 spec 沒有 `PATH` 時退回 unit 這一層（root-owned、可逐字稽核，
+     因此不是 fail-open），兩層都缺才拒絕 exec，且該失敗發生在**接管 log 之前**
+     （理由進 journal，而不是變成一份空的 job log）。第二層同時涵蓋「手工組 spec
+     繞過產生器」（#645 的同型前例）與「spool 裡還躺著升級前寫的舊 spec」。
+  4. **驗證方法**——runbook 共用探針 `psc_run_under` 移除 `--setenv=PATH=`，
+     `psc_probe_path()` 整支刪除；4e／5-3／5-4／附錄 A 五處自帶 `PATH` 的驗證改為
+     絕對路徑或改走新的 4e-2。新增 `permgen.build_path_resolution_probe()` ／ CLI
+     `trust_root path-probe`：**角色 × executor 全列舉**的反向不變式（剖面跟著
+     executor 走，因此 `codex` 與 `claude` 驗的是**兩份不同的 unit**），以**零額外
+     env** 起 job、斷言解到 `<toolchain>/bin/<cli>`，並與同一支檔案的絕對路徑版本
+     逐字比對（不另立第二份會漂移的版本清單）。產出**刻意不含任何 `--setenv=`**，
+     由 `path_probe_env_injections()` ＋ 測試釘住。
+
+  **為什麼它活過五輪驗證**：runbook 4e／5-2b、#661 與 #664 的量測、事故當天的每一次
+  探針，全部自帶 `--setenv=PATH=…`——**驗證環境供應了 production 不供應的東西**，
+  於是缺陷在結構上不可能被觀察到。runbook 4e 甚至逐字預言了症狀、連 0.42.0 這個版本
+  號都寫對了，但那一條是 `sudo -u … env PATH=…` 跑的，所以它驗的是「toolchain 裡那份
+  是對的版本」，不是「job 實際會解到哪一份」。這是「綠燈不承載語意」的**第五**個實例
+  且是新的一類：前四次（#638／#657／#673 兩次）是「複本比 production 弱或強」，這次是
+  **複本比 production 多**。#677 立下「加固面複本必須全量機械導出」，本票再推一格：
+  **複本必須連「production 沒有設什麼」也一起複製**——`unit_replica_properties()` 天生
+  做得到，要拿掉的是探針額外疊上去的那一行。
+
+  **順手收掉一條第三份真相**：runbook 5-5 手打的 `PSC_GATE_PATH=/usr/local/bin:/usr/bin:/bin`
+  少了 toolchain 段，與 permgen（#666 的 `SYSTEM_PROGRAMS` note 逐字記著
+  `<toolchain>/bin ＋ JOB_PATH_SYSTEM_TAIL`）不一致。三個 `PSC_*_PATH` 現一律由產生器
+  導出，runbook 不再手打。
+
+  **測試**：`tests/test_job_path_fail_closed_679.py`（46 條）——三個角色各自缺席／空值
+  的 fail-closed、角色互不污染、錯誤訊息的 `trust_root unit` 旗標與
+  `permgen.JOB_UNIT_CLI_FLAG` 一致、六份 unit 皆有 `Environment=PATH=` 且值由
+  `PathLayout` 導出（換部署根即跟著換）、shim 三種情形（spec 優先／退回 unit／兩層都缺
+  即 `ShimError` 且不建 log）、**複本的 PATH 逐字來自 unit 且 unit 沒有時複本也沒有**、
+  探針產生器的可執行行不得出現 `--setenv=`（含偵測器自己的 negative control）、矩陣
+  完整性與剖面對應。OS 層語意（真的解到哪個檔）需要第二個 UID ＋ 真實 systemd 加固面
+  ＋ 兩份同名不同版的 CLI，本環境全部沒有，因此以**具名 `@pytest.mark.skip` ＋ 完整
+  理由**標示，並列出改由哪三個地方守——不靜默通過。

--- a/docs/onboarding/troubleshooting.md
+++ b/docs/onboarding/troubleshooting.md
@@ -27,6 +27,7 @@
 | F34 / stale `venv` | `cortex inspect service --json` | unit 指向已刪的安裝位置，或 service 還在跑舊碼 | 看 [stale venv 或 exec path drift](#stale-venv-或-exec-path-drift-f34) |
 | build 卡全數在採信階段被拒（`gate-ledger-missing-expected-gate`），但 gate 宣告看起來正常 | `sudo -u <gate 帳號> env HOME=<gate HOME> python3 -m pytest --version` | 降權部署下 gate 宣告的 `python3` 解析到**系統層** interpreter，而 `pytest` 只裝在 operator 的 user site-packages（`ProtectHome` 之後不可達） | 看 [降權部署下 gate ledger 為空](#降權部署下-gate-ledger-為空) |
 | monitor 起得來但兩個 github provider `degraded`；doctor 的 `gh-*` probe 全紅 | `sudo -u <manager 帳號> env HOME=<manager HOME> gh auth status` | 降權部署下 Manager 沒有自己的 `gh` 登入態（operator 的在 `/home` 底下，`ProtectHome` 之後不可達） | 看 [降權部署下 Manager 沒有 gh 登入態](#降權部署下-manager-沒有-gh-登入態) |
+| 升級後每一次派工都 `job-runner-path-undeclared` | `sudo grep PSC_ /opt/cortex/etc/cortex-manager.env` | #679 起三個 `PSC_*_PATH` 是**必填**；升級前的部署一個都沒宣告 | 看 [job-runner-path-undeclared](#job-runner-path-undeclared) |
 
 ## delivery preflight 失敗
 
@@ -140,7 +141,11 @@ cortex inspect service --instance cortex --json
 ```bash
 # HOME 由產生器導出，不要手寫絕對路徑（換 layout 時這裡會跟著動）
 GATE_HOME="$(python3 -c 'from paulsha_cortex.trust_root.permgen import DEFAULT_LAYOUT as L; print(L.home_of("cortex-gate"))')"
-sudo -u cortex-gate env HOME="$GATE_HOME" python3 -m pytest --version
+# ⚠️ 這一條問的是「**系統層那支** python3 import 得到 pytest 嗎」，因此 interpreter 走
+#    絕對路徑、且**不自帶 PATH**（#679）。「gate 實際會解到哪一支 python3」是另一個
+#    命題，走 Runbook 第 4e-2 步的反向不變式——兩者混在一起正是 #679 的機制。
+SYS_PY="$(command -v python3)"   # 系統層那一支（不是部署 venv 的）
+sudo -u cortex-gate env HOME="$GATE_HOME" "$SYS_PY" -m pytest --version
 #   `No module named pytest` ⇒ 就是這一條
 ```
 
@@ -165,6 +170,29 @@ sudo -u cortex-manager env HOME="$MANAGER_HOME" gh auth status
 （`0600`，token 要 refresh 得回來），`config.yml` 維持 `root:root 0644`（它的 `aliases`
 可宣告 `!` shell alias，讓服務帳號改得了它等於多一條執行面）。若落位後仍顯示未登入，先確認
 沒有人設了 `XDG_CONFIG_HOME` 或 `GH_CONFIG_DIR`——那會讓 `gh` 去看別的目錄，而檔案還在原處。
+
+## job-runner-path-undeclared
+
+**升級到 #679 之後才會出現，而且是刻意的。** 症狀：降權模式下每一次派工都在 Manager
+端當場失敗，理由 `job-runner-path-undeclared: PSC_BUILDER_PATH 未宣告…`。
+
+成因：#679 之前 `build_job_env()` 對三個 `PSC_*_PATH` 是 **fail-open** 的——未宣告時
+job 靜默拿到 **Manager daemon 的** `PATH`（那份值是否含 `<toolchain>/bin` 純看該機器的
+EnvironmentFile 被誰手動加過什麼；Manager 自己也沒有 `PATH` 時，`os.execvpe` 退回
+`os.defpath`＝`:/bin:/usr/bin`）。兩種情形下 `codex` 都可能**靜默**解到 `/usr/bin/codex`
+（實機 0.42.0，toolchain 那份是 0.147.0）：不報錯，只是每一筆產出都來自一支從未被判讀
+過的 CLI。現在未宣告即當場失敗——**「當場失敗且訊息可讀」嚴格優於「靜默跑錯版本」**。
+
+```bash
+# 值由產生器導出，不要手打（三個角色各一份）
+for flag in --job --review-job --gate-job; do
+  python3 -m paulsha_cortex.trust_root unit four-way "$flag" | grep '^Environment=PATH='
+done
+```
+
+完整的升級步驟（補三個變數、重新落檔六份模板 unit、重啟 Manager、跑反向不變式）在
+Runbook 第 **5-5b** 步。**不要**把 `PSC_JOB_RUNNER` 改回 `direct` 來繞開：那會讓 Phase 2b
+的全部隔離一次失效，只為了避開一個補三行設定就能解的錯誤。
 
 ## 什麼時候該直接走 Runbook
 

--- a/docs/superpowers/runbooks/trust-root-phase2b-setup.md
+++ b/docs/superpowers/runbooks/trust-root-phase2b-setup.md
@@ -1913,9 +1913,12 @@ done
 > 一律不得帶 `PATH`。**
 
 ```bash
-# 探針與矩陣都由產生器出（角色 × executor 全列舉，剖面跟著 executor 走）：
+# 前置：先貼上下一節的共用探針 `psc_run_under`（本步驟**呼叫它、不重造**——
+#       加固面的定義只有一份，連呼叫它的那幾行 shell 也不該有第二份複本）。
+# 矩陣由產生器出（角色 × executor 全列舉，剖面跟著 executor 走）：
 python3 -m paulsha_cortex.trust_root path-probe four-way
-#   → 貼進 shell 直接跑。產出**刻意不含任何 --setenv=**。
+#   → 貼進 shell 直接跑。產出**刻意不含任何 --setenv=**；未定義 psc_run_under 時
+#     它會 fail-closed（而不是靜默跑出一組沒有加固面的假綠）。
 #   ⛔ 任何一列失敗時**不要**加 `--setenv=PATH=` 讓它過——那正是讓這個缺陷活了五輪
 #      的那個動作。要補的是兩層本身：
 #        (1) 模板 unit 的 `Environment=PATH=`（#679 起由 permgen 產生）

--- a/docs/superpowers/runbooks/trust-root-phase2b-setup.md
+++ b/docs/superpowers/runbooks/trust-root-phase2b-setup.md
@@ -332,6 +332,21 @@ A/B 並列時同一件事要寫兩遍（5-A／5-B、第 8 步兩種起法、附�
   結構時舊的 default ACL 會靜默繼承」的警語 ＋ `setfacl -k <容器>` 步驟 ＋ 一條機械
   判準（每格具名條目 `foreign=0`、`#effective:` 註記為 0）
   → **55** 個 sudo 點、**208** 個驗證點。
+- **#679（job 沒有 PATH ／ 驗證環境供應了 production 不供應的東西）新增**：
+  新增 **4e-2「反向不變式：job 在零額外 env 下解到哪一份 CLI」**（產生器出矩陣：
+  `trust_root path-probe`，角色 × executor 全列舉、剖面跟著 executor 走）與
+  **5-5b「升級既有部署」**（補三個 `PSC_*_PATH`、重新落檔六份 unit、重啟 Manager，
+  含降級路徑警語）；**共用探針 `psc_run_under` 移除 `--setenv=PATH=`、`psc_probe_path()`
+  整支刪除**——PATH 現由 `unit_replica_properties()` 從落檔 unit 的
+  `Environment=PATH=`（#679 補上）自動帶進複本；4e／5-3／5-4／附錄 A 五處自帶 `PATH`
+  的驗證改為絕對路徑或改走 4e-2；5-5 的三個 `PSC_*_PATH` 改由產生器導出（此前手打的
+  `PSC_GATE_PATH` 少了 toolchain 段，與 permgen／#666 的紀錄不一致＝第三份真相）。
+  **起因**：模板 unit 沒有 `Environment=PATH=`、shim 不補、`build_job_env()` fail-open、
+  部署 EnvironmentFile 三個變數皆未宣告 ⇒ `codex` 靜默解到系統層 0.42.0
+  （toolchain 是 0.147.0）。缺陷活過五輪驗證，因為**每一條驗證都自己帶 `PATH`**——
+  runbook 4e 甚至逐字預言了症狀、版本號都對上了，但那條驗證是 `sudo -u … env PATH=…`
+  跑的。這是「綠燈不承載語意」的第五個實例，且是新的一類：複本比 production **多**。
+  → **57** 個 sudo 點、**219** 個驗證點。
 
 ---
 
@@ -1858,25 +1873,57 @@ ls -ld /opt/cortex/toolchain
 sudo -u cortex-builder sh -c "touch /opt/cortex/toolchain/bin/evil" 2>&1 | tail -1
 #   期望：Permission denied
 
-# ✅ 功能驗證（本票的核心驗收）：以 job 帳號實跑一次 `--help`，期望 rc=0
+# ✅ 檔案面驗證：以 job 帳號、**用絕對路徑**實跑一次 `--help`，期望 rc=0
+#    這一條驗的是「toolchain 那幾支檔案對 job 帳號可讀可執行、runtime 也解得開」。
+#    ⚠️ 它**不驗**「job 會解到哪一份」——那是下面反向不變式那一節的事，兩者不可互相
+#       代替（#679：把這兩個命題混為一談，正是這個缺陷活過五輪驗證的機制）。
 for cli in codex claude copilot agy; do
   sudo -u cortex-builder env HOME=/var/lib/cortex-builder \
-    PATH=/opt/cortex/toolchain/bin:/usr/local/bin:/usr/bin:/bin \
-    "$cli" --help >/dev/null 2>&1; echo "$cli rc=$?"
+    "/opt/cortex/toolchain/bin/$cli" --help >/dev/null 2>&1; echo "$cli rc=$?"
 done
 #   期望：四行皆 rc=0。**rc=127 ＝ #640 的原症狀**（CLI 或它的 runtime 不可達）：
-#     先 `sudo -u cortex-builder ... command -v <cli>` 看解到哪裡，
-#     再 `head -n 1 /opt/cortex/toolchain/bin/codex` 確認 shebang 解得開（node 在系統層）。
+#     `head -n 1 /opt/cortex/toolchain/bin/codex` 確認 shebang 解得開（node 在系統層）。
 
-# ✅ 驗證（**裁決 (a) 真正要守的那條**）：job 帳號跑出來的版本 == operator 側的版本
-sudo -u cortex-builder env HOME=/var/lib/cortex-builder \
-  PATH=/opt/cortex/toolchain/bin:/usr/local/bin:/usr/bin:/bin codex --version
-codex --version
-#   期望：**兩行逐字相同**。只驗 rc=0 是不夠的——系統層那份 0.42.0 一樣會 rc=0，
-#   而 job 跑的就變成 operator 從未判讀過的版本（症狀是「結果對不上」，不是報錯）。
-#   不同 ⇒ PATH 順序錯（toolchain 沒排最前面），或複製到的是系統那份。
+# ✅ 記下 operator 側判讀過的版本（＝登記表登記的那一份，反向不變式要比對它）
+for cli in codex claude copilot agy; do
+  printf '%-8s %s\n' "$cli" "$(/opt/cortex/toolchain/bin/$cli --version 2>&1 | head -1)"
+done
+#   期望：`codex` 那行是 operator 實際在用的版本（本機實測 0.147.0），**不是** 0.42.0。
+#   ⚠️ **這一條到此為止只證明「toolchain 裡那份是對的版本」**。它一個字都沒有說到
+#      「job 實際會解到哪一份」——#679 之前這裡寫的是
+#      `sudo -u cortex-builder env PATH=<toolchain 在最前> codex --version`，
+#      PATH 是**驗證者給的**，而 production 一個 `PSC_*_PATH` 都沒宣告。警語（「系統層
+#      那份 0.42.0 一樣會 rc=0」）在、版本號也對上了，缺陷仍然活了五輪。
+#      → 「job 會解到哪一份」一律走第 4e-2 步（**零額外 env**）。
 
 ```
+
+#### 4e-2. 反向不變式：job 在**零額外 env** 下解到哪一份 CLI（#679）
+
+> **這一節的存在理由是驗證方法本身**。#679 的缺陷是一個 `if path_override:`
+> ——`PSC_*_PATH` 未宣告時 `build_job_env()` 靜默省略 `PATH`，`execvpe` 退回
+> `os.defpath`（`:/bin:/usr/bin`），`claude`／`agy` rc=127，而 `codex` **靜默**解到
+> `/usr/bin/codex`＝0.42.0（toolchain 是 0.147.0）。它活過五輪驗證，因為**每一條
+> 驗證都自己帶 `--setenv=PATH=`**：驗證環境供應了 production 不供應的東西，
+> 於是「job 沒有 PATH」在結構上不可能被觀察到。
+>
+> **規矩（#677 的規矩再推一格）**：加固面複本必須連「production **沒有**設什麼」
+> 也一起複製。`unit_replica_properties()` 天生做得到（它從落檔的 unit 全量導出）；
+> 要拿掉的是探針**額外**疊上去的那一行。**凡是驗「job 會解到哪一份 CLI」的檢查，
+> 一律不得帶 `PATH`。**
+
+```bash
+# 探針與矩陣都由產生器出（角色 × executor 全列舉，剖面跟著 executor 走）：
+python3 -m paulsha_cortex.trust_root path-probe four-way
+#   → 貼進 shell 直接跑。產出**刻意不含任何 --setenv=**。
+#   ⛔ 任何一列失敗時**不要**加 `--setenv=PATH=` 讓它過——那正是讓這個缺陷活了五輪
+#      的那個動作。要補的是兩層本身：
+#        (1) 模板 unit 的 `Environment=PATH=`（#679 起由 permgen 產生）
+#            → 該 unit 若沒有這一行＝落檔的是舊版產生器的產物，重跑第 5-2 步落檔；
+#        (2) Manager EnvironmentFile 的 `PSC_BUILDER_PATH`／`PSC_REVIEWER_PATH`／
+#            `PSC_GATE_PATH`（第 5-5 步）。
+```
+
 
 #### 共用探針：`psc_run_under`（在**真實加固面**下跑一條命令）
 
@@ -1889,16 +1936,17 @@ codex --version
 > 同一份 unit 上的 `SystemCallErrorNumber=EPERM`，於是複本落回 systemd 預設的
 > `SECCOMP_RET_KILL_PROCESS`——**比 production 更嚴格**，量出一個 production 沒有的
 > `rc=1`。**手抄子集的假紅與假綠一樣會發生，方向不由人選。**
+>
+> **#679 起：探針不再自帶 `PATH`。** 在此之前 `psc_run_under` 尾端有一行
+> `--setenv=PATH="$(psc_probe_path)"`，而 `psc_probe_path()` 在 `PSC_*_PATH` 全部
+> 未宣告時會退回 EnvironmentFile 裡 **Manager 自己**那條 `PATH=`——於是探針拿到一份
+> production 的 job 從來拿不到的 PATH，「job 沒有 PATH」因此不可能被量到。
+> 複本必須連「production **沒有**設什麼」也一起複製；`unit_replica_properties()`
+> 是全量機械導出的，模板 unit 的 `Environment=PATH=`（#679 補上）會自動帶進 `--property=`，
+> 因此探針**什麼都不必補**——補了就錯。
 
 ```bash
 # 一次貼進 shell，之後各步驟直接呼叫。
-psc_probe_path() {
-  # PATH 也不手打：job 的 PATH 來自 Manager 端 root-owned 的 EnvironmentFile
-  # （模板 unit 刻意不寫 Environment=PATH=，因為 shim 會整份換掉環境）。
-  sudo grep -hoE '^(PSC_[A-Z]+_PATH|PATH)=.*' /opt/cortex/etc/cortex-manager.env \
-    | head -1 | cut -d= -f2-
-}
-
 psc_run_under() {   # psc_run_under <unit 字幹> <命令> [參數…]
   local stem="$1"; shift
   local -a props
@@ -1913,10 +1961,16 @@ psc_run_under() {   # psc_run_under <unit 字幹> <命令> [參數…]
     echo "⛔ 加固面複本只有 ${#props[@]} 條——unit 落檔不完整或產生器已漂移，停下來" >&2
     return 90
   fi
+  # ⛔ **這裡不得再加任何 --setenv=**（#679）。環境完全由上面的複本決定，
+  #    複本完全由落檔的 unit 決定——這兩句話成立，量到的才是 production。
   sudo systemd-run --pipe --wait --collect --quiet --service-type=exec \
-    "${props[@]}" --setenv=PATH="$(psc_probe_path)" "$@"
+    "${props[@]}" "$@"
 }
 ```
+
+> **`psc_probe_path()` 已刪除**（#679）。若你在別處的筆記裡還留著它：那個函式本身
+> 就是缺陷的載體，不要復活它。要知道 job 的 PATH 是什麼，讀**落檔的 unit**：
+> `sudo systemctl cat cortex-job@.service | grep '^Environment=PATH='`。
 
 **兩個必須先做的前置**（做不到就是探針本身壞了，不是被驗的東西壞了）：
 
@@ -1969,8 +2023,10 @@ psc_run_under cortex-reviewer-job /opt/cortex/toolchain/bin/srt --version
 #     Manager 不是模板 unit，字幹沒有 `@`——直接餵檔案（--instance 用不到）。
 mapfile -t mprops < <(sudo systemctl cat cortex-manager.service \
   | python3 -m paulsha_cortex.trust_root unit-replica -)
+#     ⚠️ **不補 --setenv=**（#679）：Manager unit 的複本已含它的
+#        `EnvironmentFile=`（PATH 就在那份檔裡），再疊一層只會蓋掉 production 的值。
 sudo systemd-run --pipe --wait --collect --quiet --service-type=exec \
-  "${mprops[@]}" --setenv=PATH="$(psc_probe_path)" \
+  "${mprops[@]}" \
   /opt/cortex/toolchain/bin/openspec --version
 
 #   ⚠️ 兩條**預期都失敗（stdout 空、rc=1）**，症狀與 #643 的 codex／copilot 逐字
@@ -2103,9 +2159,11 @@ sudo pip install --break-system-packages 'pytest>=7' 'PyYAML>=6'
 
 ```bash
 # ✅ 驗證（1）：**以 gate 身分實測**，不是只驗檔案存在
+#    interpreter 用絕對路徑，**不自帶 PATH**（#679）：這一條驗的是「系統層那支
+#    python3 import 得到 pytest」，而不是「gate 會解到哪一支 python3」——後者是
+#    第 4e-2 步的事，混在一起正是 #679 的機制。
 sudo -u cortex-gate env HOME=/var/lib/cortex-gate \
-  PATH=/opt/cortex/toolchain/bin:/usr/local/bin:/usr/bin:/bin \
-  python3 -m pytest --version
+  /usr/bin/python3 -m pytest --version
 #   期望：印出版本，rc=0（不是 `No module named pytest`）
 sudo -u cortex-gate env HOME=/var/lib/cortex-gate python3 -c 'import yaml; print(yaml.__version__)'
 #   期望：印出版本
@@ -2122,10 +2180,11 @@ sudo chown cortex-gate:cortex-gate "$PROBE/test_probe.py"
 #    WorkingDirectory 指向探測目錄——**其餘一條都不減**。
 mapfile -t gprops < <(sudo systemctl cat cortex-gate-job@.service \
   | python3 -m paulsha_cortex.trust_root unit-replica - --instance probe)
+#    ⚠️ **不補 --setenv=**（#679）：PATH 由複本從 gate 模板 unit 的
+#       `Environment=PATH=` 帶進來，那才是 production 的值。
 sudo systemd-run --pipe --wait --collect --quiet --service-type=exec \
   "${gprops[@]}" \
   --property=WorkingDirectory="$PROBE" \
-  --setenv=PATH="$(psc_probe_path)" \
   /usr/bin/python3 -m pytest -q
 #   期望：`1 passed`，rc=0。
 #   ⚠️ `--property=WorkingDirectory=` 必須排在複本**之後**才覆寫得掉（systemd 取
@@ -2248,7 +2307,7 @@ sudo -u cortex-manager env HOME=/var/lib/cortex-manager gh auth status
 mapfile -t mprops < <(sudo systemctl cat cortex-manager.service \
   | python3 -m paulsha_cortex.trust_root unit-replica -)
 sudo systemd-run --pipe --wait --collect --quiet --service-type=exec \
-  "${mprops[@]}" --setenv=PATH="$(psc_probe_path)" \
+  "${mprops[@]}" \
   /usr/bin/gh auth status
 #   期望：同上。`gh` 是原生 ELF，MDWE 不影響它。
 #   ⚠️ 這份複本會連 `EnvironmentFile=/opt/cortex/etc/cortex-manager.env` 一起帶上
@@ -3052,20 +3111,22 @@ PY
 ### 5-5. (d) 打開切換點 `PSC_JOB_RUNNER=systemd-template`
 
 ```bash
-# ✅ 先取 PSC_BUILDER_PATH 的正規值（產生器＝單一真相，**不要手打**）
-python3 -m paulsha_cortex.trust_root unit four-way --job | grep PSC_BUILDER_PATH
-#   期望：PSC_BUILDER_PATH=/opt/cortex/toolchain/bin:/usr/local/bin:/usr/bin:/bin
-
-# ✅ #615：reviewer／planner 那一組（**與 builder 不共用**，見下方說明）
-python3 -m paulsha_cortex.trust_root unit four-way --review-job | grep PSC_REVIEWER_PATH
-#   期望：PSC_REVIEWER_PATH=/opt/cortex/toolchain/bin:/usr/local/bin:/usr/bin:/bin
-
-# ✅ #629：gate 執行身分那一組。**PATH 刻意不含 toolchain**——gate 不跑任何模型 CLI，
-#    它跑的是 operator 宣告的 gate 命令（pytest／make／npm…）。把 toolchain 排進去
-#    只會多開一條「gate 也能起模型」的面，換不到任何東西。
-python3 -m paulsha_cortex.trust_root unit four-way --gate-job | grep PSC_GATE_PATH
+# ✅ 三個 PSC_*_PATH 的正規值全部由產生器導出（**不要手打**，#679）。
+#    #679 起模板 unit 自己也有 `Environment=PATH=`，兩層同源——就從 unit 上取：
+for flag in --job --review-job --gate-job; do
+  python3 -m paulsha_cortex.trust_root unit four-way "$flag" \
+    | grep -E '^(Environment=PATH=|#   PSC_[A-Z]+_PATH=)'
+done
+#   期望：三組各兩行，`Environment=PATH=` 與 `PSC_*_PATH=` 的值**逐字相同**，
+#   且都是 /opt/cortex/toolchain/bin:/usr/local/bin:/usr/bin:/bin。
+#   ⚠️ **toolchain 必須在最前面，三個角色皆然**。gate 也要：`PSC_GATE_CMD_PYTEST=
+#      "python3 -m pytest -q"` 是相對名、同樣走 PATH 解析（#666），gate 沒有 PATH
+#      的後果與 builder 逐字同型。
+#      （歷史註記：#679 之前這份 runbook 手打的 `PSC_GATE_PATH` 少了 toolchain 段，
+#      與 permgen／#666 的紀錄不一致——那是第三份真相。現在只有產生器一份。）
 
 # 🔧 sudo：把降權模式寫進第 4b 步的 EnvironmentFile
+#    ⚠️ 下面的 PATH 三行是**產生器的值**，若產生器輸出與這裡不同，以產生器為準。
 sudo tee -a /opt/cortex/etc/cortex-manager.env >/dev/null <<'ENVFILE'
 PSC_JOB_RUNNER=systemd-template
 PSC_BUILDER_ACCOUNT=cortex-builder
@@ -3077,7 +3138,7 @@ PSC_REVIEWER_PATH=/opt/cortex/toolchain/bin:/usr/local/bin:/usr/bin:/bin
 # --- #629 gate 執行身分 ---
 PSC_GATE_ACCOUNT=cortex-gate
 PSC_GATE_HOME=/var/lib/cortex-gate
-PSC_GATE_PATH=/usr/local/bin:/usr/bin:/bin
+PSC_GATE_PATH=/opt/cortex/toolchain/bin:/usr/local/bin:/usr/bin:/bin
 # gate 用來跑 ledger writer 的直譯器。必須是**絕對路徑且 gate 讀得到**——
 # Manager 的 repo root 在 /home 底下，而 job unit 帶 ProtectHome=yes，
 # `PYTHONPATH=<repo>` 那條路在那裡不成立（#623 缺口 1 的同一件事）。
@@ -3125,18 +3186,24 @@ exec /opt/cortex/venv/bin/python -c "import os; from paulsha_cortex.coordinator 
 > `PSC_JOB_RUNNER` 預設 `direct`＝不降權；值非法時**fail-closed**（不會靜默當成
 > `direct`）。
 >
-> **`PSC_BUILDER_PATH` 是必填，不再是選配（#640 改）**：未設時 job 會拿到 Manager
-> 轉發的 `PATH`，而 Manager 以 system unit 跑、拿到的是 systemd 的預設 `PATH`
-> （`/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin`）——裡面**沒有**
-> `/opt/cortex/toolchain/bin`。toolchain 必須排在最前面：系統層可能另有一份同名但舊
-> 很多的 CLI（本機實測兩份 `codex` 差 100 個以上小版本），排後面的症狀是「跑得起來
-> 但版本不是預期的那個」。
+> **三個 `PSC_*_PATH` 全部必填，未宣告即 fail-closed（#679 改；#640 起就已經是宣告上
+> 的必填，但程式碼直到 #679 才跟上）**：在此之前 `build_job_env()` 是 fail-open 的
+> ——未宣告就整個不寫 `PATH` 這個鍵，而 job spec 的 `env` 就是 job 的**完整**環境，
+> 於是 `execvpe` 退回 `os.defpath`＝`:/bin:/usr/bin`：`claude`／`agy` rc=127，
+> `codex` **靜默**解到 `/usr/bin/codex`（系統層 0.42.0，toolchain 那份 0.147.0）。
+> **不報錯，只是產出來自一支 operator 從未判讀過的 CLI。**
+> 現在未宣告時 Manager 會在派工前就以 `job-runner-path-undeclared` 失敗。
 >
-> **為什麼是 `PSC_BUILDER_PATH` 而不是模板 unit 的 `Environment=PATH=`**：模板 unit
-> 的 `ExecStart` 是 root-owned shim，shim 以 `execvpe(argv[0], argv, spec['env'])`
-> **整份換掉**環境——job 解析命令用的 `PATH` 來自 **spec 的 env**（即 Manager 端這個
-> 變數），不是 unit 的 `Environment=`。寫在 unit 上只會是一個看起來承載作用、實際被
-> shim 丟掉的設定。產生的 job unit 內有一段註解把這個取捨寫在產物本身。
+> **PATH 現在是兩層（#679）**：
+> 1. **spec 的 `env`**——來自 Manager 端這三個變數，`build_job_env()` 對未宣告
+>    fail-closed；
+> 2. **模板 unit 的 `Environment=PATH=`**——由 permgen 機械產生，root-owned、可逐字
+>    稽核。shim 在 spec 的 env 沒有 `PATH` 時改用它（退回的是**更可信**的來源，不是
+>    猜預設值），兩層都缺才拒絕 exec。
+>
+> 第 2 層不是多餘的：它涵蓋「手工組 spec 繞過產生器」（#645 逐字記錄過的同型前例）
+> 與「spool 裡還躺著升級前寫的舊 spec」，而且讓 `unit_replica_properties()` 產生的
+> 加固面複本**自動**帶上 production 的 PATH——探針因此什麼都不必補（見 4e-2）。
 >
 > **憑證**：見第 4e 步——由 root 複製進 job 帳號 HOME、chown 給該帳號（0600），
 > **不是**讓 builder 自己 `login`（toolchain 未落位前 `login` 這個動作本身就跑不起來，
@@ -3152,6 +3219,79 @@ exec /opt/cortex/venv/bin/python -c "import os; from paulsha_cortex.coordinator 
 > `manager._spool_writable_launcher()` → `as_verdict_spool_writer()`，而那支工廠產出的
 > launcher 前兩個旗標**都是 False**（verdict spool 放行與 read-only 契約互斥）。只看前
 > 兩條會把它判成 builder 並以 `cortex-builder` 起跑——**而它正是寫 verdict 的那一個**。
+
+#### 5-5b. 升級既有部署到 #679（**已在跑降權模式的機器必做**）
+
+> **為什麼一定要做**：#679 之前裝好的機器，`/opt/cortex/etc/cortex-manager.env` 裡
+> **一個 `PSC_*_PATH` 都沒有**，六份模板 unit 也**沒有** `Environment=PATH=`。升級
+> cortex 之後，Manager 會在**下一次派工**就以 `job-runner-path-undeclared` 失敗。
+> **那是正確行為**：在此之前它不失敗，只是每一筆 `codex` 產出都來自系統層 0.42.0。
+> 「當場失敗且訊息可讀」嚴格優於「靜默跑錯版本」，但它需要 operator 先做完下面三步。
+
+```bash
+# --- 0) 先確認你是不是受影響的部署（三個變數一個都沒有 ⇒ 是）---
+sudo grep -cE '^PSC_(BUILDER|REVIEWER|GATE)_PATH=' /opt/cortex/etc/cortex-manager.env
+#   期望（升級前）：0 或 <3 ⇒ 往下做。已經是 3 ⇒ 只需做第 2 步（unit 落檔）。
+sudo systemctl cat cortex-job@.service | grep -c '^Environment=PATH='
+#   期望（升級前）：0 ⇒ 落檔的是舊版產生器的 unit，第 2 步會換掉它。
+
+# --- 1) 補三個 PSC_*_PATH（值由產生器導出，不要手打）---
+{
+  echo "# --- #679：job 的 PATH，未宣告即 fail-closed ---"
+  for pair in "--job PSC_BUILDER_PATH" "--review-job PSC_REVIEWER_PATH" \
+              "--gate-job PSC_GATE_PATH"; do
+    set -- $pair
+    val="$(python3 -m paulsha_cortex.trust_root unit four-way "$1" \
+           | sed -n 's/^Environment=PATH=//p' | head -1)"
+    [ -n "$val" ] || { echo "⛔ 產生器沒有輸出 PATH——cortex 尚未升級到 #679" >&2; exit 1; }
+    echo "$2=$val"
+  done
+} | sudo tee -a /opt/cortex/etc/cortex-manager.env
+#   ⚠️ EnvironmentFile 是 root-owned 的（第 4b 步）——這是刻意的：job 改不了自己的
+#      PATH。因此這一步必須 sudo，而不是讓任何服務帳號自己補。
+
+# --- 2) 重新落檔六份模板 unit（它們現在多了 Environment=PATH=）---
+for pair in "--job cortex-job" "--review-job cortex-reviewer-job" \
+            "--gate-job cortex-gate-job"; do
+  set -- $pair
+  for prof in strict jit; do
+    suffix=""; [ "$prof" = jit ] && suffix="-jit"
+    python3 -m paulsha_cortex.trust_root unit four-way "$1" --profile "$prof" \
+      | sudo tee "/etc/systemd/system/$2$suffix@.service" >/dev/null
+  done
+done
+sudo systemctl daemon-reload
+#   ⚠️ 只 `daemon-reload`，**不要** restart 任何 job unit——模板 unit 是一次性的，
+#      下一個 job 起來時就是新的那份。正在跑的 job 不受影響（也不該被打斷）。
+
+# --- 3) 重啟 Manager 讓它讀到新的 EnvironmentFile ---
+sudo systemctl restart cortex-manager.service
+```
+
+```bash
+# ✅ 驗證（1）：三個變數都在，且值與產生器逐字相同
+sudo grep -E '^PSC_(BUILDER|REVIEWER|GATE)_PATH=' /opt/cortex/etc/cortex-manager.env
+#   期望：三行，值都是 /opt/cortex/toolchain/bin:/usr/local/bin:/usr/bin:/bin
+
+# ✅ 驗證（2）：六份落檔的 unit 都有 Environment=PATH=
+for stem in cortex-job cortex-job-jit cortex-reviewer-job cortex-reviewer-job-jit \
+            cortex-gate-job cortex-gate-job-jit; do
+  printf '%-26s %s\n' "$stem" \
+    "$(sudo systemctl cat "$stem@.service" | grep '^Environment=PATH=' || echo '<NO PATH>')"
+done
+#   期望：六行都印出 Environment=PATH=…，**一個 `<NO PATH>` 都不能有**。
+#   （#679 的原始證據就是這張表全是 `<NO PATH>`。）
+
+# ✅ 驗證（3）：**反向不變式**——回第 4e-2 步整段跑一次（零額外 env）。
+#    這一條才是升級真正的驗收；前兩條只驗宣告，不驗解析。
+python3 -m paulsha_cortex.trust_root path-probe four-way
+```
+
+> **降級路徑**：若第 3 步之後 Manager 因 `job-runner-path-undeclared` 拒絕派工，
+> **不要**把 `PSC_JOB_RUNNER` 改回 `direct` 來繞開——那會讓所有 job 回到不降權的
+> 狀態（Phase 2b 的全部隔離一次失效），只為了避開一個補三行設定就能解的錯誤。
+> 正確做法是回到第 1 步確認那三行真的進了 EnvironmentFile、且 Manager 真的重啟過
+> （`sudo systemctl show cortex-manager.service -p Environment | tr ' ' '\n' | grep PSC_`）。
 
 ### 5-6. 正向驗證（**必須成功**）
 
@@ -3198,9 +3338,12 @@ spec = job_runner.build_job_spec(
     command=["/bin/sh", "-c", smoke],
     working_directory=f"/var/lib/cortex/worktree/{instance}",
     log_path=f"/var/lib/cortex/worktree/{instance}/{instance}.log",
-    # ⚠️ job 的 env **就是**這一份，不繼承 unit 的 Environment=——shim 是
-    #    `execvpe(command, spec["env"])`。因此 PATH／HOME 要在這裡給，
-    #    而 token 類的名字 build_job_spec() 直接拒收（見下方註）。
+    # ⚠️ job 的 env **就是**這一份——shim 是 `execvpe(command, spec["env"])`。
+    #    #679 起 `PATH` 多一層保險：spec 沒給時 shim 改用模板 unit 的
+    #    `Environment=PATH=`（root-owned），兩層都沒有才拒絕 exec。
+    #    這裡刻意給一份**不含 toolchain** 的 PATH：本步驟只驗隔離（身分／token／
+    #    可寫面），不驗模型 CLI 解析——後者是第 4e-2 步的反向不變式，而那一條
+    #    **不得手工組 spec**（#645：手工挑路徑恰好把 bug 繞過去的同型前例）。
     env={"HOME": "/var/lib/cortex-builder", "PATH": "/usr/local/bin:/usr/bin:/bin"},
 )
 # `account=` 讓寫端在落地後就地複驗「那個身分讀得到這個檔」（#657）——
@@ -4690,11 +4833,12 @@ for U in cortex-manager cortex-reviewer-planner cortex-builder; do id -nG "$U"; 
 # ✅ 權限沒有漂移
 sudo find /var/lib/cortex /opt/cortex -perm /022 -print | head
 
-# ✅ executor toolchain 仍可用，且版本沒有跟 operator 側分岔（#640）
-sudo -u cortex-builder env HOME=/var/lib/cortex-builder \
-  PATH=/opt/cortex/toolchain/bin:/usr/local/bin:/usr/bin:/bin codex --version
-codex --version
-#   期望：兩行逐字相同。分岔＝某一側被升級了而另一側沒有——那正是裁決 (a) 要防的漂移。
+# ✅ executor toolchain 仍可用，且版本沒有跟 operator 側分岔（#640／#679）
+#    ⚠️ **不自帶 PATH**（#679）：自帶就變成「驗證者給的 PATH 下解到哪一份」，
+#       與 job 實際會解到哪一份無關。改走反向不變式的產生器探針：
+python3 -m paulsha_cortex.trust_root path-probe four-way
+#   期望：每一組「PATH 解出來的那支」與「<toolchain>/bin/<cli> 絕對路徑那支」
+#   印出逐字相同的版本。分岔＝某一側被升級了而另一側沒有，或 job 根本沒有 PATH。
 
 # ✅ 憑證仍是「檔 job-owned／目錄 root-owned」（#640 裁決 (b)）
 stat -c '%n %U:%G %a' /var/lib/cortex-builder/.codex /var/lib/cortex-builder/.codex/auth.json
@@ -4712,9 +4856,19 @@ sudo -u cortex-manager env HOME=/var/lib/cortex-manager gh auth status >/dev/nul
   && echo "manager gh: OK"
 
 # ✅ gate 跑得動 pytest，且版本沒有無聲換掉（#666；第 4f 步）
+#    interpreter 用絕對路徑、**不自帶 PATH**（#679）：這一條驗的是「系統層那支
+#    python3 import 得到 pytest」。「gate 會解到哪一支 python3」由第 4e-2 步驗。
 sudo -u cortex-gate env HOME=/var/lib/cortex-gate \
-  PATH=/opt/cortex/toolchain/bin:/usr/local/bin:/usr/bin:/bin python3 -m pytest --version
+  /usr/bin/python3 -m pytest --version
 #   期望：與部署紀錄裡記下的那一版逐字相同。換掉了而沒人知道 ⇒ gate 判準已漂移。
+
+# ✅ 六份模板 unit 都還有 Environment=PATH=（#679 的原始證據是這張表全空）
+for stem in cortex-job cortex-job-jit cortex-reviewer-job cortex-reviewer-job-jit \
+            cortex-gate-job cortex-gate-job-jit; do
+  printf '%-26s %s\n' "$stem" \
+    "$(sudo systemctl cat "$stem@.service" | grep '^Environment=PATH=' || echo '<NO PATH>')"
+done
+#   期望：六行都有值。任何一行 `<NO PATH>` ⇒ 落檔的是舊產生器的 unit，回第 5-5b 步。
 
 # ✅ 窮舉盤點仍雙向封閉（#666；第 4h 步）——非空即代表登記表已落後於程式碼
 python3 -c "from paulsha_cortex.trust_root import permgen as p

--- a/docs/superpowers/runbooks/trust-root-phase2b-setup.md
+++ b/docs/superpowers/runbooks/trust-root-phase2b-setup.md
@@ -3239,30 +3239,43 @@ sudo systemctl cat cortex-job@.service | grep -c '^Environment=PATH='
 #   期望（升級前）：0 ⇒ 落檔的是舊版產生器的 unit，第 2 步會換掉它。
 
 # --- 1) 補三個 PSC_*_PATH（值由產生器導出，不要手打）---
-{
-  echo "# --- #679：job 的 PATH，未宣告即 fail-closed ---"
-  for pair in "--job PSC_BUILDER_PATH" "--review-job PSC_REVIEWER_PATH" \
-              "--gate-job PSC_GATE_PATH"; do
-    set -- $pair
-    val="$(python3 -m paulsha_cortex.trust_root unit four-way "$1" \
-           | sed -n 's/^Environment=PATH=//p' | head -1)"
-    [ -n "$val" ] || { echo "⛔ 產生器沒有輸出 PATH——cortex 尚未升級到 #679" >&2; exit 1; }
-    echo "$2=$val"
-  done
-} | sudo tee -a /opt/cortex/etc/cortex-manager.env
+#     **先全部組好再一次寫入**：中途 abort 會在 root-owned 的 env 檔留下半套宣告，
+#     而「三個裡有兩個」的部署會是「兩個角色能派、一個角色每次都 fail」——比全都
+#     沒有更難查。
+BLOCK="# --- #679：job 的 PATH，未宣告即 fail-closed ---"
+for pair in "--job:PSC_BUILDER_PATH" "--review-job:PSC_REVIEWER_PATH" \
+            "--gate-job:PSC_GATE_PATH"; do
+  flag="${pair%%:*}"; var="${pair##*:}"
+  val="$(python3 -m paulsha_cortex.trust_root unit four-way "$flag" \
+         | sed -n 's/^Environment=PATH=//p' | head -1)"
+  if [ -z "$val" ]; then
+    echo "⛔ 產生器沒有輸出 Environment=PATH=——這份 cortex 還沒升級到 #679，停下來" >&2
+    unset BLOCK
+    break
+  fi
+  BLOCK="$BLOCK
+$var=$val"
+done
+[ -n "${BLOCK:-}" ] && printf '%s\n' "$BLOCK" | sudo tee -a /opt/cortex/etc/cortex-manager.env
 #   ⚠️ EnvironmentFile 是 root-owned 的（第 4b 步）——這是刻意的：job 改不了自己的
 #      PATH。因此這一步必須 sudo，而不是讓任何服務帳號自己補。
 
 # --- 2) 重新落檔六份模板 unit（它們現在多了 Environment=PATH=）---
-for pair in "--job cortex-job" "--review-job cortex-reviewer-job" \
-            "--gate-job cortex-gate-job"; do
-  set -- $pair
-  for prof in strict jit; do
-    suffix=""; [ "$prof" = jit ] && suffix="-jit"
-    python3 -m paulsha_cortex.trust_root unit four-way "$1" --profile "$prof" \
-      | sudo tee "/etc/systemd/system/$2$suffix@.service" >/dev/null
-  done
-done
+#     unit 檔名（含剖面後綴）由產生器導出，**不要手拼 `-jit`**：後綴是
+#     `permgen.HARDENING_PROFILES` 的一部分，手拼等於第二份會漂移的真相。
+python3 - <<'PY' | sudo sh -e
+from paulsha_cortex.trust_root import permgen as p
+scheme = p.SCHEMES["four-way"]
+for principal in p.downgraded_job_principals(scheme):
+    flag = p.JOB_UNIT_CLI_FLAG[principal]
+    for profile in p.HARDENING_PROFILES:
+        stem = p.job_unit_stem(p.DEFAULT_LAYOUT, principal, profile)
+        print(
+            f"python3 -m paulsha_cortex.trust_root unit four-way {flag}"
+            f" --profile {profile.profile_id}"
+            f" > /etc/systemd/system/{stem}@.service"
+        )
+PY
 sudo systemctl daemon-reload
 #   ⚠️ 只 `daemon-reload`，**不要** restart 任何 job unit——模板 unit 是一次性的，
 #      下一個 job 起來時就是新的那份。正在跑的 job 不受影響（也不該被打斷）。

--- a/docs/superpowers/specs/trust-root-isolation-spec.md
+++ b/docs/superpowers/specs/trust-root-isolation-spec.md
@@ -556,12 +556,26 @@ $ sudo -u cortex-builder env HOME=<job HOME> codex exec --help
   症狀後回填）。**因此系統層 node 的版本風險涵蓋 `codex` 與 `copilot` 兩個。**
   同一個 `needs_node` 欄位也是 §R3 per-executor 加固剖面的分類來源——**一張表，兩個
   用途**，不另立第二份清單。
-- job 的 `PATH` SHALL 由 Manager 端既有的 `PSC_BUILDER_PATH` 注入，且 toolchain
-  SHALL 排在**最前面**——系統層可能另有一份同名但舊很多的 CLI，排在後面的症狀是
-  「跑得起來但版本不是預期的那個」，比 `command not found` 難查得多。**MUST NOT**
-  改以模板 unit 的 `Environment=PATH=` 提供：模板 unit 的 `ExecStart` 是 root-owned
-  shim，shim 以 `execvpe(argv[0], argv, spec['env'])` 整份換掉環境，job 解析命令用的
-  `PATH` 來自 **spec 的 env**——寫在 unit 上只會是一個看起來承載作用、實際被丟掉的設定。
+- job 的 `PATH` SHALL 由**本角色的** `PSC_*_PATH`（`PSC_BUILDER_PATH`／
+  `PSC_REVIEWER_PATH`／`PSC_GATE_PATH`）注入，且 toolchain SHALL 排在**最前面**——
+  系統層可能另有一份同名但舊很多的 CLI，排在後面的症狀是「跑得起來但版本不是預期的
+  那個」，比 `command not found` 難查得多。
+- 該變數未宣告時 `build_job_env()` **SHALL fail-closed**（#679）。它 **MUST NOT**
+  靜默省略 `PATH`，也 **MUST NOT** 落回 Manager daemon 的 `PATH`——後者是 #679 的
+  實際成因：`PATH` 曾在轉發類白名單上，於是未宣告時 job 拿到的是「沒有人為它做過
+  決定」的值（daemon 的 `PATH` 帶著 `<deploy_root>/venv/bin`，且是否含
+  `<toolchain>/bin` 純看該機器被誰手動加過什麼）。Manager 自己也沒有 `PATH` 時，
+  `os.execvpe` 退回 `os.defpath`（`:/bin:/usr/bin`），`codex` 因此**靜默**解到系統層
+  那一份（實機 0.42.0，toolchain 是 0.147.0）——不報錯，只是產出來自沒人判讀過的 CLI。
+- 模板 unit **SHALL** 另外帶一行 `Environment=PATH=`（由 permgen 機械產生，與上述
+  變數同源）。#640 當時判斷「寫在 unit 上會被 shim 丟掉」——那對了一半：spec 的 env
+  確實是 job 的完整環境，但產生它的那一支當時 fail-open，於是兩層同時為空。現在是
+  兩層：spec 那層 fail-closed，unit 這層是 shim 的退路（root-owned、比 spec 更可信，
+  因此**不是** fail-open），兩層都缺時 shim SHALL 拒絕 exec。
+- **驗「job 會解到哪一份 CLI」的檢查 MUST NOT 自帶 `PATH`**（#679）。加固面複本
+  （`permgen.unit_replica_properties()`）SHALL 連「production **沒有**設什麼」也一起
+  複製；探針 MUST NOT 額外疊 `--setenv=`。反向不變式（角色 × executor，零額外 env）
+  由 `permgen.build_path_resolution_probe()` 機械導出。
 
 ##### (a2) 盤點範圍：**所有**外部程式，不只 executor（#661）
 

--- a/paulsha_cortex/coordinator/job_runner.py
+++ b/paulsha_cortex/coordinator/job_runner.py
@@ -194,6 +194,7 @@ __all__ = [
     "resolve_hardening_profile",
     "resolve_job_account",
     "resolve_job_group",
+    "resolve_job_path",
     "resolve_job_spec_spool",
     "resolve_job_role",
     "template_instance_id",
@@ -226,8 +227,12 @@ BUILDER_GROUP_ENV = "PSC_BUILDER_GROUP"
 #: 反之 daemon 的 HOME 絕不可轉發（那是 cortex-svc 的樹，且是 #588 第 1 點的核心）。
 BUILDER_HOME_ENV = "PSC_BUILDER_HOME"
 
-#: builder 的 PATH 覆寫。未設時轉發 Manager 的 PATH（見 `BUILDER_FORWARDED_ENV`）；
-#: Phase 2b 若把模型 CLI 裝在 builder 才讀得到的路徑，用這個覆寫。
+#: builder 的 PATH。**必填，且未設時 fail-closed**（#679）。
+#:
+#: #640 起它就已經是「必填」的部署契約（runbook 明講），但程式碼這一側直到 #679 都
+#: 還是 fail-open：未設就整個不寫 `PATH`，於是 `execvpe` 退回 `os.defpath`
+#: （`:/bin:/usr/bin`）——`codex` 靜默解到系統層那份舊 CLI，不報錯、只是產出來自一支
+#: operator 從未判讀過的執行檔。宣告與實作的落差本身就是那個缺陷。
 BUILDER_PATH_ENV = "PSC_BUILDER_PATH"
 
 #: reviewer＋planner 的 OS 帳號名（#615 M2）。三分方案把兩個 persona 映到**同一個**
@@ -750,16 +755,6 @@ class ForwardedEnvVar:
 #: `CLAUDE_CONFIG_DIR`／`GH_CONFIG_DIR`、以及下面「刻意排除」段列出的項目。
 BUILDER_FORWARDED_ENV: tuple[ForwardedEnvVar, ...] = (
     ForwardedEnvVar(
-        "PATH",
-        # 沒有 PATH，transient unit 只會拿到 PID 1 的 manager PATH（通常是
-        # /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin），裡面沒有 npm global／
-        # pipx shim，`claude`／`codex`／`copilot` 一律 127；wrapper 內的 `python3`
-        # （gate ledger writer，見 launcher.build_wrapper_script）與 `git`（builder
-        # 要 commit candidate）同樣靠它解析。可用 PSC_BUILDER_PATH 覆寫成 builder
-        # 帳號讀得到的路徑。
-        "模型 CLI（claude／codex／copilot）、wrapper 的 python3 gate writer 與 git 的解析路徑",
-    ),
-    ForwardedEnvVar(
         "LANG",
         # claude／copilot 是 node CLI、codex 是 rust CLI，prompt 與 candidate 檔案
         # 常含非 ASCII（本 repo 的 spec／CHANGELOG 全是 zh-tw）；locale 缺失時
@@ -801,8 +796,16 @@ BUILDER_FORWARDED_ENV: tuple[ForwardedEnvVar, ...] = (
 #: - `PSC_RELAY_TARGET`：僅在 launcher 有設定時才出現（與 direct 模式同條件）。
 #: - `HOME`：僅在 `PSC_BUILDER_HOME` 明示時才設；未設時交給 systemd 依 passwd 填入
 #:   builder 帳號自己的 HOME。**任何情況下都不會是 daemon 的 HOME。**
+#: - `PATH`：#679 起由 :func:`resolve_job_path` 從**本角色的** `PSC_*_PATH` 算出，
+#:   未宣告即 fail-closed。**它以前在轉發類白名單上，那是本票真正的 fail-open**：
+#:   未宣告時 job 靜默拿到 **Manager daemon 的** `PATH`——一個沒有人為「job 該解到
+#:   哪一份 CLI」做過決定的值，而且它是否含 `<toolchain>/bin` 完全看那台機器的
+#:   EnvironmentFile 被誰手動加過什麼。轉發 daemon 的 `PATH` 與轉發 daemon 的
+#:   `HOME`／`VIRTUAL_ENV`（早就在排除表上）是同一類錯誤：daemon 的 `PATH` 還帶著
+#:   `<deploy_root>/venv/bin`，等於把 job 的 `python3` 綁回 Manager 的 venv。
 BUILDER_SYNTHESIZED_ENV = (
     "HOME",
+    "PATH",
     "PSC_JOB_ID",
     "PSC_RELAY_TARGET",
     "PSC_REPO_ROOT",
@@ -824,6 +827,11 @@ BUILDER_SYNTHESIZED_ENV = (
 #:   PATH 決定，不該被綁進 Manager 的 venv。
 EXCLUDED_ENV_RATIONALE: Mapping[str, str] = {
     "HOME": "systemd 依 passwd 填入 builder 自己的 HOME；daemon 的 HOME 絕不轉發",
+    "PATH": (
+        "#679：daemon 的 PATH 絕不轉發——它帶著 <deploy_root>/venv/bin，且是否含 "
+        "toolchain 全看那台機器被手動加過什麼。job 的 PATH 只由本角色的 "
+        "PSC_*_PATH 決定（resolve_job_path，未宣告即 fail-closed）"
+    ),
     "HTTPS_PROXY": "proxy URL 可內嵌 user:pass，屬憑證面；由 builder 自己的 drop-in 提供",
     "HTTP_PROXY": "同 HTTPS_PROXY",
     "LOGNAME": "systemd 依 passwd 填入",
@@ -874,6 +882,67 @@ def _reject_unsafe(env: Mapping[str, str], *, source: str) -> None:
             )
 
 
+#: `resolve_job_path()` 的錯誤訊息要指出「去哪一份 unit 取正規值」——角色與
+#: `trust_root unit` 旗標的對應（與 `permgen.JOB_UNIT_CLI_FLAG` 成對契約，由
+#: `tests/test_job_path_fail_closed_679.py` 釘住兩邊一致）。
+_UNIT_FLAG_HINT: Mapping[str, str] = MappingProxyType(
+    {
+        JOB_ROLE_BUILDER: "--job",
+        JOB_ROLE_REVIEW: "--review-job",
+        JOB_ROLE_GATE: "--gate-job",
+    }
+)
+
+
+def resolve_job_path(manager_env: Mapping[str, str], *, role: str = JOB_ROLE_BUILDER) -> str:
+    """解析本角色的 job `PATH`。**未宣告即 fail-closed，絕不省略、絕不猜預設。**
+
+    ## 為什麼是 raise 而不是「退回一份預設值」（#679 裁決 (a)）
+
+    在此之前這裡是 fail-open：
+
+        path_override = (manager_env.get(config.path_env) or "").strip()
+        if path_override:
+            env["PATH"] = path_override      # 沒設就整個不寫 PATH
+
+    而 job spec 的 `env` 就是 job 的**完整**環境（shim 以
+    `os.execvpe(command[0], command, spec["env"])` 整份換掉），少了 `PATH` 這個鍵
+    不是「用系統預設」，是 `execvpe` 退回 `os.defpath`＝`:/bin:/usr/bin`。實機後果：
+    `claude`／`agy` rc=127（只存在於 toolchain），而 `codex` **靜默**解到
+    `/usr/bin/codex`——系統層 0.42.0，toolchain 那份是 0.147.0。不失敗、不報錯，
+    只是每一筆產出都來自一支 operator 從未判讀過的 CLI。
+
+    退回「permgen 導出的預設」（#679 的選項 (b)）看起來溫和，但那正是本 repo 已經
+    否決過的形態：#453「registry 永不寫入預設值」。一個沒有宣告 `PSC_*_PATH` 的部署
+    ＝operator 沒有對「job 解哪一份 CLI」做過決定，而那是**必須有人做**的決定；
+    替他做一次、只在 spec 上留一行痕跡，等於把「未宣告」與「宣告成這樣」壓成同一種
+    狀態，下一次漂移一樣看不見。
+
+    **升級既有部署會痛，而那是對的**：現況是靜默跑錯版本，改完之後是下一次派工當場
+    以可讀理由失敗。runbook 第 5-5 步有逐字的補宣告步驟。
+    """
+
+    config = resolve_job_role(role)
+    value = (manager_env.get(config.path_env) or "").strip()
+    if not value:
+        raise _fail(
+            "job-runner-path-undeclared",
+            (
+                f"{config.path_env} 未宣告——{config.role_id} job 會拿不到 PATH。"
+                "job spec 的 env 就是 job 的完整環境（shim 以 execvpe 整份換掉），"
+                "少了 PATH 不是「用系統預設」而是退回 os.defpath（:/bin:/usr/bin）："
+                "toolchain 裡的 CLI 一律 rc=127，而系統層同名的舊版本會被**靜默**解到。"
+                "請在 Manager 的 root-owned EnvironmentFile 宣告（值由產生器導出，"
+                "不要手打）：`python3 -m paulsha_cortex.trust_root unit four-way "
+                f"{_UNIT_FLAG_HINT.get(config.role_id, '--job')} | grep '^Environment=PATH='`"
+            ),
+            source="resolve_job_path",
+            role=config.role_id,
+            variable=config.path_env,
+        )
+    return value
+
+
 def build_job_env(
     *,
     manager_env: Mapping[str, str],
@@ -893,6 +962,11 @@ def build_job_env(
     相同。角色只決定 `PATH`／`HOME` 的**覆寫變數名**（見 :data:`JOB_ROLE_CONFIG`）：
     兩個帳號的 HOME 與 toolchain 可見性不同，共用一個 `PSC_BUILDER_PATH` 會讓
     reviewer 的 PATH 只能跟著 builder 走。
+
+    **`PATH` 是必要鍵，不是選配**（#679）：未宣告 `PSC_*_PATH` 時
+    :func:`resolve_job_path` 直接 raise。`HOME` 仍是選配，兩者的差別是實質的——
+    `HOME` 未給時 systemd 依 passwd 填入該帳號自己的正確值（而且模板 unit 另有一行
+    `Environment=HOME=`），`PATH` 未給時沒有任何一層會填出正確值。
     """
 
     config = resolve_job_role(role)
@@ -901,9 +975,7 @@ def build_job_env(
         value = manager_env.get(forwarded.name)
         if value:
             env[forwarded.name] = value
-    path_override = (manager_env.get(config.path_env) or "").strip()
-    if path_override:
-        env["PATH"] = path_override
+    env["PATH"] = resolve_job_path(manager_env, role=config.role_id)
     home = (manager_env.get(config.home_env) or "").strip()
     if home:
         env["HOME"] = home

--- a/paulsha_cortex/coordinator/job_runner.py
+++ b/paulsha_cortex/coordinator/job_runner.py
@@ -230,9 +230,11 @@ BUILDER_HOME_ENV = "PSC_BUILDER_HOME"
 #: builder 的 PATH。**必填，且未設時 fail-closed**（#679）。
 #:
 #: #640 起它就已經是「必填」的部署契約（runbook 明講），但程式碼這一側直到 #679 都
-#: 還是 fail-open：未設就整個不寫 `PATH`，於是 `execvpe` 退回 `os.defpath`
-#: （`:/bin:/usr/bin`）——`codex` 靜默解到系統層那份舊 CLI，不報錯、只是產出來自一支
-#: operator 從未判讀過的執行檔。宣告與實作的落差本身就是那個缺陷。
+#: 還是 fail-open——而且是兩段的：`PATH` 當時在 :data:`BUILDER_FORWARDED_ENV` 上，
+#: 因此未設此變數時 job 先靜默拿到 **Manager daemon 的** `PATH`（一個沒有人為「job
+#: 該解到哪一份 CLI」做過決定的值）；daemon 自己也沒有 `PATH` 時，spec 連這個鍵都
+#: 沒有，`execvpe` 退回 `os.defpath`（`:/bin:/usr/bin`）。兩段的終點相同：`codex`
+#: 靜默解到系統層那份舊 CLI，不報錯、只是產出來自一支 operator 從未判讀過的執行檔。
 BUILDER_PATH_ENV = "PSC_BUILDER_PATH"
 
 #: reviewer＋planner 的 OS 帳號名（#615 M2）。三分方案把兩個 persona 映到**同一個**
@@ -903,13 +905,19 @@ def resolve_job_path(manager_env: Mapping[str, str], *, role: str = JOB_ROLE_BUI
 
         path_override = (manager_env.get(config.path_env) or "").strip()
         if path_override:
-            env["PATH"] = path_override      # 沒設就整個不寫 PATH
+            env["PATH"] = path_override      # 沒設就不覆寫
 
-    而 job spec 的 `env` 就是 job 的**完整**環境（shim 以
-    `os.execvpe(command[0], command, spec["env"])` 整份換掉），少了 `PATH` 這個鍵
-    不是「用系統預設」，是 `execvpe` 退回 `os.defpath`＝`:/bin:/usr/bin`。實機後果：
-    `claude`／`agy` rc=127（只存在於 toolchain），而 `codex` **靜默**解到
-    `/usr/bin/codex`——系統層 0.42.0，toolchain 那份是 0.147.0。不失敗、不報錯，
+    而它上面那一圈轉發迴圈當時**含 `PATH`**，所以「沒設」的實際後果分兩段：
+
+    1. Manager 自己有 `PATH` ⇒ job 逐字沿用 **daemon 的** `PATH`。那份值是否含
+       `<toolchain>/bin` 純看那台機器的 EnvironmentFile 被誰手動加過什麼，而且它帶著
+       `<deploy_root>/venv/bin`——等於把 job 的 `python3` 綁回 Manager 的 venv。
+    2. Manager 自己也沒有 `PATH` ⇒ spec 連這個鍵都沒有。job spec 的 `env` 就是 job 的
+       **完整**環境（shim 以 `os.execvpe(command[0], command, spec["env"])` 整份換掉），
+       少了 `PATH` 不是「用系統預設」，是 `execvpe` 退回 `os.defpath`＝`:/bin:/usr/bin`。
+
+    兩段的終點相同：`claude`／`agy` rc=127（只存在於 toolchain），而 `codex` **靜默**
+    解到 `/usr/bin/codex`——系統層 0.42.0，toolchain 那份是 0.147.0。不失敗、不報錯，
     只是每一筆產出都來自一支 operator 從未判讀過的 CLI。
 
     退回「permgen 導出的預設」（#679 的選項 (b)）看起來溫和，但那正是本 repo 已經
@@ -919,7 +927,9 @@ def resolve_job_path(manager_env: Mapping[str, str], *, role: str = JOB_ROLE_BUI
     狀態，下一次漂移一樣看不見。
 
     **升級既有部署會痛，而那是對的**：現況是靜默跑錯版本，改完之後是下一次派工當場
-    以可讀理由失敗。runbook 第 5-5 步有逐字的補宣告步驟。
+    以可讀理由失敗。runbook 第 **5-5b** 步有逐字的升級程序（補三個變數、重新落檔六份
+    模板 unit、重啟 Manager、跑反向不變式），`docs/onboarding/troubleshooting.md` 的
+    `job-runner-path-undeclared` 一節是同一件事的簡版。
     """
 
     config = resolve_job_role(role)

--- a/paulsha_cortex/coordinator/job_shim.py
+++ b/paulsha_cortex/coordinator/job_shim.py
@@ -26,7 +26,10 @@ fail-closed、不猜、不落回預設）——「哪個身分讀哪個 spool」
 - schema 驗證是**白名單**：spec 裡出現 `user`／`uid`／`group`／`gid` 這類身分欄位
   一律拒絕。身分只有一個來源＝root-owned 的 unit 檔，spec 連提都不准提；
 - env 走與 `job_runner` **同一條** `CREDENTIAL_ENV_RE`／`DENIED_ENV_NAMES` 守衛，
-  spec 被塞進 token 或 `LD_PRELOAD` 時 fail-closed，而不是照單 exec。
+  spec 被塞進 token 或 `LD_PRELOAD` 時 fail-closed，而不是照單 exec；
+- **`PATH` 兩層都缺時 fail-closed**（#679，見 :func:`resolve_job_env`）：spec 的 env
+  沒有 `PATH` 時退回模板 unit 的 `Environment=PATH=`（root-owned，比 spec 更可信），
+  兩層都沒有才拒絕 exec——絕不讓 `execvpe` 退回 `os.defpath` 去靜默解系統層那份。
 
 ## 為什麼 log 由這裡接管，而不是 unit 的 `StandardOutput=append:`
 
@@ -68,6 +71,7 @@ __all__ = [
     "forbidden_spec_keys",
     "load_spec",
     "main",
+    "resolve_job_env",
     "resolve_spec_path",
 ]
 
@@ -189,6 +193,44 @@ def load_spec(instance: str, spool_root: str) -> dict[str, object]:
     return spec
 
 
+def resolve_job_env(spec: Mapping[str, object], environ: Mapping[str, str]) -> dict[str, str]:
+    """spec 的 `env` → job 的**完整**環境，並補上 `PATH` 這一條的第二層（#679）。
+
+    ## 為什麼這裡要有第二層
+
+    `os.execvpe(file, args, env)` 解析 `file` 用的是 **`env` 這個參數裡的 `PATH`**，
+    不是本行程的 `os.environ`；`env` 沒有 `PATH` 時退回 `os.defpath`＝`:/bin:/usr/bin`。
+    也就是說「spec 的 env 少了 PATH」不會報錯，只會讓 job 解到系統層那份同名 CLI
+    ——實機上 `codex` 因此跑的是 0.42.0，而 toolchain（登記表登記的那份）是 0.147.0。
+
+    第二層的來源是**模板 unit 的 `Environment=PATH=`**（#679 同時補上的那一行）：
+    root-owned、可逐字稽核、job 帳號改不了。因此這**不是** fail-open——它退回的是比
+    spec 更可信的來源，而不是猜一個預設值。它涵蓋兩種現實情況：
+
+    - Manager 端的產生器被繞過（手工組 spec；#645 逐字記錄過的同型前例）；
+    - spool 裡還躺著升級前寫的舊 spec。
+
+    兩層**都**沒有時 fail-closed。這一條刻意不落回 `os.defpath`：那正是本票的原症狀，
+    而它的失敗模式是「不報錯、只是版本不對」——最難查的那一種。
+    """
+
+    env = {str(k): str(v) for k, v in dict(spec["env"]).items()}  # type: ignore[index]
+    if (env.get("PATH") or "").strip():
+        return env
+    inherited = (environ.get("PATH") or "").strip()
+    if not inherited:
+        raise ShimError(
+            "job spec 的 env 沒有 PATH，模板 unit 也沒有 Environment=PATH=——"
+            "execvpe 會退回 os.defpath（:/bin:/usr/bin）並**靜默**解到系統層那份同名 "
+            "CLI（實機：codex 0.42.0，而 toolchain 是 0.147.0）。兩層都缺時一律拒絕 "
+            "exec：請確認 Manager 端已宣告 PSC_BUILDER_PATH／PSC_REVIEWER_PATH／"
+            "PSC_GATE_PATH，且模板 unit 是由現行 permgen 產生的那一份"
+            "（`python3 -m paulsha_cortex.trust_root unit four-way --job` 等）。"
+        )
+    env["PATH"] = inherited
+    return env
+
+
 def _take_over_stdio(log_path: str) -> None:
     """把 stdout／stderr 接到 spec 指定的 JSONL log（append、`O_NOFOLLOW`）。
 
@@ -226,6 +268,10 @@ def main(argv: Sequence[str] | None = None, environ: Mapping[str, str] | None = 
                 f"spool 根（root-owned unit 檔是這個值唯一的合法來源）"
             )
         spec = load_spec(args[0], spool_root)
+        # PATH 的解析刻意在**接管 log 之前**（與 spool 根 fail-closed 同一段）：
+        # 這一族失敗代表 job 根本不該起跑，理由要進 journal，而不是進一份 job
+        # 自己的 log——那份 log 在 Manager 眼裡與「job 跑了但沒輸出」長得一樣。
+        job_env = resolve_job_env(spec, env)
         _take_over_stdio(str(spec["log_path"]))
         os.chdir(str(spec["working_directory"]))
     except ShimError as exc:
@@ -236,7 +282,6 @@ def main(argv: Sequence[str] | None = None, environ: Mapping[str, str] | None = 
         return EXIT_SPEC_ERROR
 
     command = [str(item) for item in spec["command"]]  # type: ignore[index]
-    job_env = {str(k): str(v) for k, v in dict(spec["env"]).items()}  # type: ignore[index]
     try:
         # execvpe：同一個 pid 直接變成 job，unit 的 MAINPID 因此就是 job 本身
         # （`systemctl start --wait` 的等待語意與 exit sentinel 都建立在這點上）。

--- a/paulsha_cortex/trust_root/__main__.py
+++ b/paulsha_cortex/trust_root/__main__.py
@@ -55,6 +55,16 @@ Phase 1 不改 `cortex` CLI（避免動到 R-16 help 對齊面）；operator／C
                                                     # 落檔的 unit 少了任一加固鍵即
                                                     # **拒絕產出**（--allow-drift 可關，
                                                     # 但那等於放棄本命令的用途）
+    python -m paulsha_cortex.trust_root path-probe [four-way|three-way|two-way]
+                                                    # #679：反向不變式的實機探針——
+                                                    # 每個 job 角色 × 每支 executor，
+                                                    # 以**零額外 env** 起 job，斷言
+                                                    # 解到的是 <toolchain>/bin/<cli>
+                                                    # 且版本 == 登記表登記的那一份。
+                                                    # 產出**刻意不含任何 --setenv=**：
+                                                    # 驗證環境供應 production 不供應的
+                                                    # 東西，正是讓 #679 活過五輪驗證的
+                                                    # 那個動作。
     python -m paulsha_cortex.trust_root shim [four-way|three-way|two-way]
                                                     # Phase 2b 方案 B 的降權 shim 內容
                                                     # （模板 unit 的固定 ExecStart=）
@@ -94,7 +104,8 @@ UID 方案未指定時一律用 **`four-way`**（#629 的定案：`cortex-manage
 gate 的 unit／ACL／polkit 字幹，降權模式下 build 卡照 `require_ledger` fail closed
 （＝#629 之前的現況）。
 
-`permissions`／`unit`／`shim`／`gitconfig`／`toolchain`／`polkit`／`scaffold` 只**產生**計畫與內容字串，
+`permissions`／`unit`／`shim`／`gitconfig`／`toolchain`／`polkit`／`scaffold`／`path-probe`
+只**產生**計畫與內容字串，
 **絕不執行**任何 root 操作、不寫任何系統路徑——命令供 operator 在 Phase 2b runbook
 中手動 sudo 執行。`--paths` 讓 `--commands` 以 `permgen.DEFAULT_LAYOUT` 的真實絕對
 路徑輸出（0816 裁決：/var/lib/cortex ＋ /opt/cortex），不再帶 placeholder。
@@ -468,6 +479,18 @@ def main(argv: Sequence[str] | None = None) -> int:
             return 2
         for prop in props:
             print(prop)
+        return 0
+    if command == "path-probe":
+        rest = args[1:]
+        scheme_id = permgen.DEFAULT_SCHEME_ID
+        for token in rest:
+            if token in permgen.SCHEMES:
+                scheme_id = token
+            else:
+                print(f"unknown path-probe arg: {token}", file=sys.stderr)
+                return 2
+        for line in permgen.build_path_resolution_probe(permgen.SCHEMES[scheme_id]):
+            print(line)
         return 0
     if command == "shim":
         rest = args[1:]

--- a/paulsha_cortex/trust_root/permgen.py
+++ b/paulsha_cortex/trust_root/permgen.py
@@ -5389,6 +5389,11 @@ def unit_replica_properties(
 #: 探針補任何一個 production 不供應的變數，都是同一個失效模式的下一個版本。
 PATH_PROBE_FORBIDDEN_FRAGMENTS: tuple[str, ...] = ("--setenv=", "PATH=")
 
+#: runbook 第 4e 步的共用探針名（#673 落地、#677 定案）。反向不變式**呼叫它、不重造**
+#: ——加固面的定義只有一份（:func:`unit_replica_properties`），連呼叫它的那幾行 shell
+#: 也不該有第二份會漂移的複本。runbook 那一節與本產生器共用這個名字。
+PATH_PROBE_HELPER = "psc_run_under"
+
 
 def path_probe_env_injections(lines: Sequence[str]) -> tuple[str, ...]:
     """探針裡**注入了環境變數**的可執行行（正常應為空 tuple）。
@@ -5506,19 +5511,14 @@ def build_path_resolution_probe(
     )
     lines += [
         "",
-        "psc_path_probe() {   # psc_path_probe <unit 字幹> <命令> [參數…]",
-        "  local stem=\"$1\"; shift",
-        "  local -a props",
-        "  mapfile -t props < <(",
-        "    sudo systemctl cat \"${stem}@.service\" \\",
-        "      | python3 -m paulsha_cortex.trust_root unit-replica - --instance probe",
-        "  )",
-        "  if [ \"${#props[@]}\" -lt 30 ]; then",
-        "    echo \"⛔ 加固面複本只有 ${#props[@]} 條——先修 unit 落檔，不要繼續\" >&2",
-        "    return 90",
-        "  fi",
-        "  sudo systemd-run --pipe --wait --collect --quiet --service-type=exec \\",
-        "    \"${props[@]}\" \"$@\"",
+        f"# 前置：先貼上 runbook 第 4e 步的**共用探針** `{PATH_PROBE_HELPER}`。",
+        "# **本產生器刻意不自己定義一份**——加固面的定義只有一份"
+        "（`unit_replica_properties()`），",
+        "# 連呼叫它的那幾行 shell 也不該有第二份複本；兩份複本會漂移，而漂移的方向",
+        "# 不由人選（#638／#657／#673／#679 是同一族事故的第一到第四次）。",
+        f"declare -F {PATH_PROBE_HELPER} >/dev/null || {{",
+        f"  echo \"⛔ 未定義 {PATH_PROBE_HELPER}——先貼上 runbook 第 4e 步的共用探針\" >&2",
+        "  return 1 2>/dev/null || exit 1",
         "}",
         "",
     ]
@@ -5526,12 +5526,12 @@ def build_path_resolution_probe(
         lines += [
             f"# --- {case.principal.value} × {case.executor}"
             f"（{case.account}／{case.unit_stem}@／剖面 {case.hardening_profile}）---",
-            f"psc_path_probe {case.unit_stem} /bin/sh -c 'command -v {case.executor}'",
+            f"{PATH_PROBE_HELPER} {case.unit_stem} /bin/sh -c 'command -v {case.executor}'",
             f"#   期望逐字：{case.expected_binary}",
             f"#   ⛔ 空輸出 ⇒ job 沒有 PATH（或 toolchain 不在上面）；",
             f"#      /usr/bin/{case.executor} ⇒ **本票的原症狀**：解到系統層那一份，",
             "#      不報錯、只是產出來自一支沒人判讀過的 CLI。",
-            f"psc_path_probe {case.unit_stem} /bin/sh -c '{case.executor} --version'",
+            f"{PATH_PROBE_HELPER} {case.unit_stem} /bin/sh -c '{case.executor} --version'",
             f"{case.version_reference} --version",
             "#   期望：**兩行逐字相同**（PATH 解出來的那支 == 登記表登記的那支）。",
             "",

--- a/paulsha_cortex/trust_root/permgen.py
+++ b/paulsha_cortex/trust_root/permgen.py
@@ -4254,15 +4254,30 @@ def build_job_unit(
         "# 本 job 帳號**唯讀＋可執行**。ProtectSystem=strict 讓 /opt 唯讀，但唯讀只擋",
         "# 寫入，讀取與執行完全不受影響；下方 ReadWritePaths 因此機械地不含它",
         "# （writer 只有部署身分）。",
-        "# **PATH 刻意不寫在這份 unit 上**：模板 unit 的 ExecStart 是 root-owned shim，",
-        "# 而 shim 以 `execvpe(argv[0], argv, spec['env'])` **整份換掉**環境——job 解析",
-        "# 命令用的 PATH 來自 **spec 的 env**，不是本 unit 的 Environment=。在這裡寫一行",
-        "# Environment=PATH= 只會產生一個看起來承載作用、實際被 shim 丟掉的設定。",
-        "# 真正的來源是 Manager 端 root-owned EnvironmentFile 裡的（job 改不了）：",
+        "# --- PATH：**兩層都補**（#679）---",
+        "# #679 之前這份 unit 刻意不寫 PATH，理由是「shim 以 execvpe(argv[0], argv,",
+        "# spec['env']) 整份換掉環境，寫在 unit 上會被丟掉」。那個理由對了一半、也因此",
+        "# 錯得很貴：spec 的 env 確實是 job 的完整環境，但產生那份 env 的",
+        "# `job_runner.build_job_env()` 當時是 **fail-open** 的——Manager 端沒宣告",
+        "# PSC_*_PATH 就整個不寫 PATH 這個鍵，execvpe 於是退回 os.defpath",
+        "# （`:/bin:/usr/bin`），`codex` 靜默解到系統層那份舊 CLI。實機部署的",
+        "# EnvironmentFile 三個變數一個都沒有，於是三個角色全中。",
+        "# 現在是兩層：",
+        "#   1. spec 的 env——`build_job_env()` 對未宣告 fail-closed（不再靜默省略）；",
+        "#   2. **這一行**——shim 在 spec 的 env 沒有 PATH 時，改用本 unit 給的這一份",
+        "#      （root-owned、可逐字稽核），兩層都缺才 fail-closed。",
+        "# 第 2 層不是 fail-open：它退回的是**更可信**的來源（root-owned unit），不是",
+        "# 猜一個預設值。它同時涵蓋「手工組 spec 繞過產生器」（#645 的同型前例）。",
+        f"Environment=PATH={job_layout.job_path_value()}",
+        "# 值與 Manager 端 root-owned EnvironmentFile 裡的這個變數同源（job 改不了）：",
         f"#   {JOB_PATH_ENV_BY_PRINCIPAL[principal]}={job_layout.job_path_value()}",
         "# toolchain 排最前面是必要的：系統層可能另有一份同名但舊很多的 CLI（實機盤點",
         "# 到兩份 codex 差 100 個以上小版本），排後面會被它蓋掉，而症狀是「跑得起來但",
         "# 版本不是你以為的那個」。",
+        "# ⚠️ 驗「job 會解到哪一份 CLI」的檢查**不得自帶 PATH**（#679 的核心教訓）：",
+        "#    `unit_replica_properties()` 會把上面這一行機械帶進 --property=，複本因此",
+        "#    連「production 供應什麼／不供應什麼」都一起複製。再加一個 --setenv=PATH=",
+        "#    就等於驗證環境供應了 production 不供應的東西，結構上永遠驗不出這個缺陷。",
         "# --- executor 憑證（登記表 *-executor-credential，#640 裁決 (b)）---",
         f"#   {job_layout.executor_credential_of(account)}：**檔案**由本 job 帳號擁有",
         "# （0600，token 過期可自行 refresh），**放它的目錄維持 root-owned**——因此",
@@ -5340,6 +5355,194 @@ def unit_replica_properties(
                 "`python3 -m paulsha_cortex.trust_root unit …`。"
             )
     return tuple(props)
+
+
+# ---------------------------------------------------------------------------
+# 反向不變式：job 在**零額外 env** 下解到哪一份 CLI（#679）
+#
+# ## 這一節要修的不是程式，是驗證方法
+#
+# #679 的缺陷本身很小（一個 `if path_override:`），但它**存活了五輪驗證**：runbook
+# 4e／5-2b、#661 與 #664 的量測、以及事故當天的每一次探針，全部長這樣：
+#
+#     systemd-run … --setenv=PATH=/opt/cortex/toolchain/bin:/usr/local/bin:/usr/bin:/bin
+#
+# 驗證環境**供應了 production 不供應的東西**，於是「job 拿不到 PATH」在結構上不可能
+# 被觀察到。runbook 4e 甚至逐字預言了症狀（「系統層那份 0.42.0 一樣會 rc=0，而 job
+# 跑的就變成 operator 從未判讀過的版本」），連版本號都對上了——但那一條是
+# `sudo -u … env PATH=…` 跑的，所以它驗的是「toolchain 裡那份是對的版本」，
+# 不是「job 實際會解到哪一份」。
+#
+# 這是「綠燈不承載語意」的**第五**個實例，而且是新的一類：前四次（#638 單 UID、
+# #657 同型、#673 假紅兩次）是「複本比 production 弱或強」，這次是「複本比
+# production **多**」。因此 #677 立下的規矩要再推一格：
+#
+#   **複本必須連「production 沒有設什麼」也一起複製。**
+#
+# `unit_replica_properties()` 天生做得到——它是從落檔的 unit 全量機械導出的，unit 有
+# `Environment=PATH=` 它就帶、沒有就不帶。真正要拿掉的是探針**額外**疊上去的那一行
+# `--setenv=PATH=`。本節的產生器因此有一條硬性質，由測試釘住：
+# **輸出裡不得出現任何 `--setenv=`，PATH 只能來自 unit 複本本身。**
+# ---------------------------------------------------------------------------
+
+#: 探針**可執行的那些行**禁止出現的片段。`--setenv=` 一律禁止（不只 `PATH=`）：
+#: 探針補任何一個 production 不供應的變數，都是同一個失效模式的下一個版本。
+PATH_PROBE_FORBIDDEN_FRAGMENTS: tuple[str, ...] = ("--setenv=", "PATH=")
+
+
+def path_probe_env_injections(lines: Sequence[str]) -> tuple[str, ...]:
+    """探針裡**注入了環境變數**的可執行行（正常應為空 tuple）。
+
+    只看非註解行是刻意的：這一節的註解必須講得出「為什麼不能加 `--setenv=PATH=`」，
+    而講這句話就得寫出那個字串。判準是「探針**做**了什麼」，不是「探針**提**到什麼」。
+    """
+
+    offenders: list[str] = []
+    for line in lines:
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if any(fragment in stripped for fragment in PATH_PROBE_FORBIDDEN_FRAGMENTS):
+            offenders.append(line)
+    return tuple(offenders)
+
+
+@dataclass(frozen=True)
+class PathResolutionCase:
+    """反向不變式的一列：某個 job 角色 × 某支 executor。
+
+    「角色 × executor」是**兩層列舉**，與 :func:`job_unit_stems` 同一個理由：
+    executor 決定加固剖面（#643），因此同一個角色的 `codex` 與 `claude` 跑的是**兩份
+    不同的 unit 檔**——只驗其中一份等於沒驗另一份的 PATH。
+    """
+
+    principal: Principal
+    account: str
+    executor: str
+    #: 該 (角色, executor) 實際會被起動的模板字幹（含剖面後綴）。
+    unit_stem: str
+    hardening_profile: str
+    #: 這一列要斷言的解析結果：`<toolchain>/bin/<executor>`。
+    expected_binary: str
+    #: 版本的比對對象＝**同一支檔案的絕對路徑**。登記表把 toolchain 落點登記成
+    #: `<toolchain>/bin/<cli>`，因此「PATH 解出來的那支」與「絕對路徑那支」印出同一
+    #: 個版本字串，就是「job 跑的是登記表登記的那一份」的直接證據——不需要第二份
+    #: 手抄的版本清單（那會立刻變成下一個會漂移的真相）。
+    version_reference: str
+
+
+def path_resolution_cases(
+    scheme: UidScheme,
+    layout: "PathLayout" = None,  # type: ignore[assignment]
+) -> tuple[PathResolutionCase, ...]:
+    """`DOWNGRADED_JOB_PRINCIPALS` × :data:`EXECUTOR_TOOLS` 的完整矩陣。
+
+    本 scheme 沒有的角色（two-way／three-way 沒有 `GATE`）機械略去，不留空列。
+    """
+
+    layout = layout if layout is not None else DEFAULT_LAYOUT
+    cases: list[PathResolutionCase] = []
+    for principal in downgraded_job_principals(scheme):
+        account = scheme.resolve(principal)
+        if account is None:  # pragma: no cover - downgraded_job_principals 已過濾
+            continue
+        for tool in EXECUTOR_TOOLS:
+            profile = executor_hardening_profile(tool.name)
+            binary = f"{layout.toolchain_bin}/{tool.name}"
+            cases.append(
+                PathResolutionCase(
+                    principal=principal,
+                    account=account,
+                    executor=tool.name,
+                    unit_stem=job_unit_stem(layout, principal, profile),
+                    hardening_profile=profile.profile_id,
+                    expected_binary=binary,
+                    version_reference=binary,
+                )
+            )
+    return tuple(cases)
+
+
+def build_path_resolution_probe(
+    scheme: UidScheme,
+    layout: "PathLayout" = None,  # type: ignore[assignment]
+) -> list[str]:
+    """反向不變式的實機探針（**只回傳字串，不執行**）。
+
+    形態與 :func:`build_toolchain_plan` 一致：產生器出內容，runbook 貼上去跑。
+    要求逐條寫在產物本身，因為讀它的人正是會忍不住「補一個 PATH 讓它過」的人。
+    """
+
+    layout = layout if layout is not None else DEFAULT_LAYOUT
+    cases = path_resolution_cases(scheme, layout)
+    lines: list[str] = [
+        "# === #679 反向不變式：job 在**零額外 env** 下解到哪一份 CLI ===",
+        f"# 由 permgen 機械產生（scheme={scheme.scheme_id}）——勿手改；重跑：",
+        f"#   python3 -m paulsha_cortex.trust_root path-probe {scheme.scheme_id}",
+        "#",
+    ]
+    lines += _wrap_comment(
+        "本探針**刻意不帶任何 `--setenv=`**。這是本票的核心教訓：在此之前每一條驗證"
+        "都自己帶 `--setenv=PATH=…`，於是驗證環境供應了 production 不供應的東西，"
+        "「job 根本沒有 PATH」在結構上不可能被觀察到。加固面複本由 "
+        "`unit_replica_properties()` 從**落檔的 unit** 全量導出，因此它連"
+        "「production 沒有設什麼」也一起複製——只要不再往上疊，量到的就是 job 真正"
+        "會拿到的環境。"
+    )
+    lines += [
+        "#",
+        "# ⛔ 這條探針失敗時**不要**加 `--setenv=PATH=` 讓它過——那正是讓這個缺陷活了",
+        "#    五輪驗證的那個動作。要補的是 unit 的 `Environment=PATH=`（重跑產生器並",
+        "#    重新落檔）與 Manager EnvironmentFile 的 `PSC_*_PATH`。",
+        "#",
+    ]
+    lines += _wrap_comment(
+        "本探針量的是**第 2 層**（模板 unit 的 `Environment=PATH=`）：systemd-run "
+        "起的是探針命令，不經過 shim，因此看不到 spec 那一層。第 1 層（spec 的 env）"
+        "由 `job_runner.resolve_job_path()` 的 fail-closed ＋ 契約測試守住，兩層的值"
+        "同源（都是 `PathLayout.job_path_value()`）。要一併驗第 1 層，走 runbook 的"
+        "真實 dispatch smoke，不要在這裡手工組 spec——#645 逐字記錄過那條路怎麼把"
+        "bug 繞過去。"
+    )
+    lines += [
+        "",
+        "psc_path_probe() {   # psc_path_probe <unit 字幹> <命令> [參數…]",
+        "  local stem=\"$1\"; shift",
+        "  local -a props",
+        "  mapfile -t props < <(",
+        "    sudo systemctl cat \"${stem}@.service\" \\",
+        "      | python3 -m paulsha_cortex.trust_root unit-replica - --instance probe",
+        "  )",
+        "  if [ \"${#props[@]}\" -lt 30 ]; then",
+        "    echo \"⛔ 加固面複本只有 ${#props[@]} 條——先修 unit 落檔，不要繼續\" >&2",
+        "    return 90",
+        "  fi",
+        "  sudo systemd-run --pipe --wait --collect --quiet --service-type=exec \\",
+        "    \"${props[@]}\" \"$@\"",
+        "}",
+        "",
+    ]
+    for case in cases:
+        lines += [
+            f"# --- {case.principal.value} × {case.executor}"
+            f"（{case.account}／{case.unit_stem}@／剖面 {case.hardening_profile}）---",
+            f"psc_path_probe {case.unit_stem} /bin/sh -c 'command -v {case.executor}'",
+            f"#   期望逐字：{case.expected_binary}",
+            f"#   ⛔ 空輸出 ⇒ job 沒有 PATH（或 toolchain 不在上面）；",
+            f"#      /usr/bin/{case.executor} ⇒ **本票的原症狀**：解到系統層那一份，",
+            "#      不報錯、只是產出來自一支沒人判讀過的 CLI。",
+            f"psc_path_probe {case.unit_stem} /bin/sh -c '{case.executor} --version'",
+            f"{case.version_reference} --version",
+            "#   期望：**兩行逐字相同**（PATH 解出來的那支 == 登記表登記的那支）。",
+            "",
+        ]
+    lines += _wrap_comment(
+        "gate 角色同樣在矩陣內，而且不是湊數：gate 宣告的 "
+        "`PSC_GATE_CMD_PYTEST=\"python3 -m pytest -q\"` 是相對名，同樣走 PATH 解析"
+        "（#666）。gate 這三列驗的是「gate 的 PATH 確實生效且順序正確」，那條性質對 "
+        "`python3` 與對 `codex` 是同一條。"
+    )
+    return lines
 
 
 def evaluate_polkit(

--- a/tests/test_gate_execution_identity_629.py
+++ b/tests/test_gate_execution_identity_629.py
@@ -64,7 +64,10 @@ REVIEW_ACCOUNT = "cortex-reviewer-planner"
 MANAGER_ACCOUNT = "cortex-manager"
 
 _BASE_ENV = {
+    # daemon 自己的 PATH。#679 起它**不會**流進 job——job 的 PATH 只由
+    # `PSC_GATE_PATH` 決定，未宣告即 fail-closed。
     "PATH": "/usr/local/bin:/usr/bin:/bin",
+    job_runner.GATE_PATH_ENV: "/opt/cortex/toolchain/bin:/usr/local/bin:/usr/bin:/bin",
     "HOME": "/var/lib/cortex-manager",
     "LANG": "en_US.UTF-8",
     "PSC_REPO_ROOT": "/opt/cortex",
@@ -791,6 +794,8 @@ class GateExecutionTests(unittest.TestCase):
                     {
                         job_runner.JOB_SPEC_SPOOL_ENV: "/tmp",
                         job_runner.GATE_JOB_SPEC_SPOOL_ENV: "/tmp",
+                        job_runner.BUILDER_PATH_ENV: "/opt/cortex/toolchain/bin:/usr/bin",
+                        job_runner.GATE_PATH_ENV: "/opt/cortex/toolchain/bin:/usr/bin",
                     },
                     job_id="j", executor="codex", role=job_runner.JOB_ROLE_GATE,
                 )
@@ -802,6 +807,8 @@ class GateExecutionTests(unittest.TestCase):
                     {
                         job_runner.JOB_SPEC_SPOOL_ENV: "/tmp",
                         job_runner.GATE_JOB_SPEC_SPOOL_ENV: "/tmp",
+                        job_runner.BUILDER_PATH_ENV: "/opt/cortex/toolchain/bin:/usr/bin",
+                        job_runner.GATE_PATH_ENV: "/opt/cortex/toolchain/bin:/usr/bin",
                     },
                     job_id="j", executor=None, role=job_runner.JOB_ROLE_BUILDER,
                 )

--- a/tests/test_job_path_fail_closed_679.py
+++ b/tests/test_job_path_fail_closed_679.py
@@ -345,7 +345,27 @@ def test_the_probe_explains_why_it_must_not_inject() -> None:
 
     text = "\n".join(permgen.build_path_resolution_probe(FOUR_WAY_SCHEME))
     assert "--setenv=" in text, "產物要講得出禁止的是什麼"
-    assert "unit-replica" in text, "加固面必須走共用的全量複本"
+    assert "unit_replica_properties" in text, "加固面必須走共用的全量複本"
+
+
+def test_the_probe_reuses_the_shared_helper_instead_of_redefining_it() -> None:
+    """加固面的定義只有一份——連呼叫它的那幾行 shell 也不該有第二份複本。
+
+    #638／#657／#673／#679 是同一族事故：**兩份複本一定會漂移，而方向不由人選**
+    （偏寬得假綠、偏嚴得假紅，後者更貴）。因此本產生器**呼叫** runbook 第 4e 步的
+    `psc_run_under`，並在它未定義時 fail-closed——而不是自己再定義一份長得一樣的。
+    """
+
+    lines = permgen.build_path_resolution_probe(FOUR_WAY_SCHEME)
+    text = "\n".join(lines)
+    assert f"{permgen.PATH_PROBE_HELPER} " in text
+    assert f"{permgen.PATH_PROBE_HELPER}() {{" not in text, "不得自帶第二份定義"
+    assert f"declare -F {permgen.PATH_PROBE_HELPER}" in text, "未定義時必須 fail-closed"
+    # 也不得繞過共用探針自己叫 systemd-run。
+    assert not [
+        line for line in lines
+        if line.strip().startswith("sudo systemd-run") or line.strip().startswith("systemd-run")
+    ]
 
 
 def test_the_injection_detector_actually_detects() -> None:

--- a/tests/test_job_path_fail_closed_679.py
+++ b/tests/test_job_path_fail_closed_679.py
@@ -1,0 +1,446 @@
+"""#679：job 的 `PATH` ——兩層都補，並禁止驗證指令自帶 `PATH`。
+
+## 這一票在修什麼
+
+實機上每一個經模板 unit 派出的 job，`PATH` 的來源是**沒有人做過決定的那一個**：
+
+- 六份模板 unit 沒有一份有 `Environment=PATH=`；
+- `job_runner.build_job_env()` 對 `PSC_*_PATH` **fail-open**（未宣告就不寫這個鍵）；
+- 而 `PATH` 當時還在**轉發類**白名單上，因此未宣告時 job 靜默拿到 **Manager daemon
+  的** `PATH`——那份值是否含 `<toolchain>/bin` 完全看該機器的 EnvironmentFile 被誰
+  手動加過什麼；Manager 自己也沒有 `PATH` 時，spec 連 `PATH` 這個鍵都沒有，
+  `os.execvpe` 於是退回 `os.defpath`（`:/bin:/usr/bin`）。
+
+三條路的終點都一樣：`claude`／`agy` rc=127，而 `codex` **靜默**解到 `/usr/bin/codex`
+（實機 0.42.0，toolchain 那份 0.147.0）。**不報錯，只是產出來自一支 operator 從未
+判讀過的 CLI。**
+
+## 為什麼它活過五輪驗證（本檔第 4 節釘住的就是這件事）
+
+runbook 4e／5-2b、#661 與 #664 的量測、事故當天的每一次探針——**全部自帶
+`--setenv=PATH=`**。驗證環境供應了 production 不供應的東西，於是缺陷在結構上不可能
+被觀察到。runbook 4e 甚至逐字預言了症狀、連 0.42.0 這個版本號都寫對了，但那一條是
+`sudo -u … env PATH=…` 跑的，所以它驗的是「toolchain 裡那份是對的版本」，
+**不是「job 實際會解到哪一份」**。
+
+這是「綠燈不承載語意」的第五個實例，且是新的一類：前四次（#638／#657／#673 兩次）
+是「複本比 production 弱或強」，這次是「複本比 production **多**」。#677 立下
+「加固面複本必須全量機械導出」，本票把它再推一格：**複本必須連「production 沒有設
+什麼」也一起複製**。
+"""
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from paulsha_cortex.coordinator import job_runner, job_shim
+from paulsha_cortex.coordinator.job_runner import JobRunnerError
+from paulsha_cortex.trust_root import permgen
+from paulsha_cortex.trust_root.permgen import (
+    DEFAULT_LAYOUT,
+    EXECUTOR_TOOLS,
+    FOUR_WAY_SCHEME,
+    HARDENING_PROFILES,
+    Principal,
+    build_job_unit,
+    downgraded_job_principals,
+)
+
+#: 三個角色 × 它們的 `PSC_*_PATH` 變數名（由產生器那張表導出，不是第二份手寫清單）。
+_ROLE_PATH_ENV = {
+    job_runner.JOB_ROLE_BUILDER: job_runner.BUILDER_PATH_ENV,
+    job_runner.JOB_ROLE_REVIEW: job_runner.REVIEWER_PATH_ENV,
+    job_runner.JOB_ROLE_GATE: job_runner.GATE_PATH_ENV,
+}
+
+
+def _manager_env(**overrides: str) -> dict[str, str]:
+    """一份「Manager daemon 有自己的 PATH」的環境——本票的關鍵前提。"""
+
+    env = {
+        "PATH": "/opt/cortex/venv/bin:/usr/local/sbin:/usr/local/bin:/usr/bin:/bin",
+        "LANG": "en_US.UTF-8",
+    }
+    env.update(overrides)
+    return env
+
+
+# ---------------------------------------------------------------------------
+# 1. `build_job_env()` fail-closed（#679 修法 1，裁決 (a)）
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("role", sorted(_ROLE_PATH_ENV))
+def test_build_job_env_fails_closed_when_the_role_path_is_undeclared(role: str) -> None:
+    """三個角色各自缺席時都必須 raise，**不得**靜默省略 PATH。"""
+
+    with pytest.raises(JobRunnerError) as excinfo:
+        job_runner.build_job_env(
+            manager_env=_manager_env(),
+            job_id="j",
+            slice_id="s",
+            repo_root="/r",
+            role=role,
+        )
+    diagnostic = excinfo.value.diagnostic
+    assert diagnostic.reason == "job-runner-path-undeclared"
+    # 訊息必須帶得出「哪個變數」與「去哪裡取正規值」——operator 讀到它就該能修。
+    assert _ROLE_PATH_ENV[role] in str(excinfo.value)
+    assert "trust_root unit" in str(excinfo.value)
+
+
+@pytest.mark.parametrize("role", sorted(_ROLE_PATH_ENV))
+def test_blank_and_whitespace_only_declarations_are_also_refused(role: str) -> None:
+    """`PSC_*_PATH=` 空值＝沒宣告。空字串若被當成「宣告了」，job 的 PATH 就是空的。"""
+
+    for blank in ("", "   ", "\t"):
+        with pytest.raises(JobRunnerError) as excinfo:
+            job_runner.resolve_job_path(
+                _manager_env(**{_ROLE_PATH_ENV[role]: blank}), role=role
+            )
+        assert excinfo.value.diagnostic.reason == "job-runner-path-undeclared"
+
+
+@pytest.mark.parametrize("role", sorted(_ROLE_PATH_ENV))
+def test_the_job_path_never_falls_back_to_the_daemon_path(role: str) -> None:
+    """**本票真正的 fail-open**：`PATH` 曾經在轉發類白名單上。
+
+    未宣告 `PSC_*_PATH` 時 job 會靜默拿到 daemon 的 `PATH`——它帶著
+    `<deploy_root>/venv/bin`（等於把 job 的 `python3` 綁回 Manager 的 venv），
+    而且是否含 `<toolchain>/bin` 純看那台機器被誰手動加過什麼。
+    """
+
+    declared = "/opt/cortex/toolchain/bin:/usr/bin:/bin"
+    env = job_runner.build_job_env(
+        manager_env=_manager_env(**{_ROLE_PATH_ENV[role]: declared}),
+        job_id="j",
+        slice_id="s",
+        repo_root="/r",
+        role=role,
+    )
+    assert env["PATH"] == declared
+    assert env["PATH"] != _manager_env()["PATH"]
+
+
+def test_path_is_synthesized_not_forwarded() -> None:
+    """契約層的同一件事：`PATH` 不在轉發白名單上，且排除表講得出理由。"""
+
+    forwarded = {item.name for item in job_runner.BUILDER_FORWARDED_ENV}
+    assert "PATH" not in forwarded, "daemon 的 PATH 不得轉發"
+    assert "PATH" in job_runner.BUILDER_SYNTHESIZED_ENV
+    assert "PATH" in job_runner.EXCLUDED_ENV_RATIONALE
+    assert job_runner.EXCLUDED_ENV_RATIONALE["PATH"].strip()
+
+
+def test_roles_do_not_contaminate_each_other() -> None:
+    """一個角色宣告了、另一個沒有 ⇒ 沒宣告的那個必須失敗，不得借用鄰居的值。"""
+
+    env = _manager_env(**{job_runner.BUILDER_PATH_ENV: "/opt/cortex/toolchain/bin"})
+    assert job_runner.resolve_job_path(env, role=job_runner.JOB_ROLE_BUILDER)
+    for role in (job_runner.JOB_ROLE_REVIEW, job_runner.JOB_ROLE_GATE):
+        with pytest.raises(JobRunnerError):
+            job_runner.resolve_job_path(env, role=role)
+
+
+def test_error_message_points_at_the_right_generator_flag() -> None:
+    """錯誤訊息裡的 `trust_root unit <旗標>` 必須與 permgen 那張表一致。
+
+    寫死 `--job` 會讓 operator 照抄之後拿到 builder 的 unit 覆蓋掉 reviewer／gate 的
+    那一份——與 `permgen.JOB_UNIT_CLI_FLAG` 立下的理由逐字相同。
+    """
+
+    principal_of = {
+        job_runner.JOB_ROLE_BUILDER: Principal.BUILDER,
+        job_runner.JOB_ROLE_REVIEW: Principal.REVIEWER,
+        job_runner.JOB_ROLE_GATE: Principal.GATE,
+    }
+    for role, principal in principal_of.items():
+        with pytest.raises(JobRunnerError) as excinfo:
+            job_runner.resolve_job_path(_manager_env(), role=role)
+        assert permgen.JOB_UNIT_CLI_FLAG[principal] in str(excinfo.value), role
+
+
+# ---------------------------------------------------------------------------
+# 2. 模板 unit 的 `Environment=PATH=`（#679 修法 2：**兩層都補**）
+# ---------------------------------------------------------------------------
+
+_ALL_JOB_UNITS = [
+    (principal, profile)
+    for principal in downgraded_job_principals(FOUR_WAY_SCHEME)
+    for profile in HARDENING_PROFILES
+]
+
+
+def test_the_matrix_is_the_six_units_the_issue_counted() -> None:
+    """#679 的證據是「六份 unit 沒有一份有 PATH」——那個 6 必須是機械導出的。"""
+
+    assert len(_ALL_JOB_UNITS) == 6
+
+
+@pytest.mark.parametrize(
+    ("principal", "profile"),
+    _ALL_JOB_UNITS,
+    ids=lambda item: getattr(item, "value", getattr(item, "profile_id", str(item))),
+)
+def test_every_job_unit_declares_path(principal, profile) -> None:
+    unit = build_job_unit(FOUR_WAY_SCHEME, DEFAULT_LAYOUT, principal, profile=profile)
+    expected = f"Environment=PATH={DEFAULT_LAYOUT.job_path_value()}"
+    assert f"\n{expected}\n" in unit.content, unit.unit_name
+
+
+@pytest.mark.parametrize(
+    ("principal", "profile"),
+    _ALL_JOB_UNITS,
+    ids=lambda item: getattr(item, "value", getattr(item, "profile_id", str(item))),
+)
+def test_unit_path_value_is_exported_not_a_literal(principal, profile) -> None:
+    """值必須由 `PathLayout` 導出：換一個部署根，unit 的 PATH 必須跟著換。"""
+
+    from paulsha_cortex.trust_root.permgen import PathLayout
+
+    layout = PathLayout(instance="acme", deploy_root="/srv/acme")
+    unit = build_job_unit(FOUR_WAY_SCHEME, layout, principal, profile=profile)
+    emitted = unit.content.split("\nEnvironment=PATH=", 1)[1].split("\n", 1)[0]
+    assert emitted == layout.job_path_value()
+    assert emitted.startswith("/srv/acme/toolchain/bin:")
+
+
+def test_unit_path_and_manager_variable_are_the_same_value() -> None:
+    """兩層必須同源。不同源就等於「兩份真相」，而漂移一定往少的那邊倒。"""
+
+    for principal in downgraded_job_principals(FOUR_WAY_SCHEME):
+        unit = build_job_unit(FOUR_WAY_SCHEME, DEFAULT_LAYOUT, principal)
+        emitted = unit.content.split("\nEnvironment=PATH=", 1)[1].split("\n", 1)[0]
+        variable = permgen.JOB_PATH_ENV_BY_PRINCIPAL[principal]
+        assert f"{variable}={emitted}" in unit.content
+
+
+def test_toolchain_comes_first_in_the_unit_path() -> None:
+    """排在後面就會被系統層那份同名舊 CLI 蓋掉——症狀是「跑得起來但版本不對」。"""
+
+    value = DEFAULT_LAYOUT.job_path_value()
+    assert value.split(":")[0] == DEFAULT_LAYOUT.toolchain_bin
+
+
+# ---------------------------------------------------------------------------
+# 3. shim 端的第二層 ＋ 兩層都缺時 fail-closed
+# ---------------------------------------------------------------------------
+
+def _spec(env: dict[str, str]) -> dict[str, object]:
+    return {
+        "spec_version": job_runner.JOB_SPEC_VERSION,
+        "instance": "demo",
+        "command": ["bash", "-c", "true"],
+        "working_directory": "/var/lib/cortex/worktree/demo",
+        "log_path": "/var/lib/cortex/worktree/demo/demo.log",
+        "env": env,
+    }
+
+
+def test_spec_path_wins_when_present() -> None:
+    resolved = job_shim.resolve_job_env(
+        _spec({"PATH": "/opt/cortex/toolchain/bin:/usr/bin"}),
+        {"PATH": "/unit/layer"},
+    )
+    assert resolved["PATH"] == "/opt/cortex/toolchain/bin:/usr/bin"
+
+
+def test_shim_falls_back_to_the_unit_layer() -> None:
+    """spec 漏了時退回模板 unit 的 `Environment=PATH=`。
+
+    這**不是** fail-open：退回的是 root-owned、可逐字稽核的來源，不是猜一個預設值。
+    它涵蓋「手工組 spec 繞過產生器」（#645 的同型前例）與「spool 裡還躺著升級前寫的
+    舊 spec」兩種現實情況。
+    """
+
+    resolved = job_shim.resolve_job_env(
+        _spec({"HOME": "/var/lib/cortex-builder"}),
+        {"PATH": "/opt/cortex/toolchain/bin:/usr/bin:/bin"},
+    )
+    assert resolved["PATH"] == "/opt/cortex/toolchain/bin:/usr/bin:/bin"
+    assert resolved["HOME"] == "/var/lib/cortex-builder"
+
+
+@pytest.mark.parametrize("environ", [{}, {"PATH": ""}, {"PATH": "   "}])
+def test_shim_refuses_to_exec_when_both_layers_are_missing(environ) -> None:
+    """兩層都缺時**絕不** exec。
+
+    退回 `os.defpath` 正是本票的原症狀，而它的失敗模式是「不報錯、只是版本不對」。
+    """
+
+    with pytest.raises(job_shim.ShimError) as excinfo:
+        job_shim.resolve_job_env(_spec({"HOME": "/var/lib/cortex-builder"}), environ)
+    assert "PATH" in str(excinfo.value)
+
+
+def test_shim_main_reports_the_missing_path_before_taking_over_the_log() -> None:
+    """理由要進 journal，而不是進一份 job 自己的 log。
+
+    「job 跑了但沒輸出」與「job 從未起跑」在 Manager 眼裡長得一樣；接管 log 之前
+    失敗才分辨得出來（與 spool 根 fail-closed 同一段，見 `job_shim` 模組 docstring）。
+    """
+
+    with tempfile.TemporaryDirectory() as root:
+        spool = Path(root) / "job-specs"
+        spool.mkdir()
+        log_path = Path(root) / "demo.log"
+        spec = _spec({"HOME": "/var/lib/cortex-builder"})
+        spec["log_path"] = str(log_path)
+        spec["working_directory"] = root
+        (spool / "demo.json").write_text(json.dumps(spec), encoding="utf-8")
+        rc = job_shim.main(
+            ["demo"], {job_runner.JOB_SPEC_SPOOL_ENV: str(spool)}
+        )
+    assert rc == job_shim.EXIT_SPEC_ERROR
+    # 接管之前就失敗 ⇒ 那份 log 根本沒被建立。
+    assert not log_path.exists()
+
+
+# ---------------------------------------------------------------------------
+# 4. 驗證方法本身：複本不得注入 PATH（#679 修法 3）
+# ---------------------------------------------------------------------------
+
+def test_the_replica_carries_path_and_it_comes_from_the_unit() -> None:
+    """複本的 PATH 必須**逐字**來自 unit——不是探針補的，也不是產生器另算的。"""
+
+    unit = build_job_unit(FOUR_WAY_SCHEME, DEFAULT_LAYOUT)
+    props = permgen.unit_replica_properties(unit.content, instance="probe")
+    expected = f"--property=Environment=PATH={DEFAULT_LAYOUT.job_path_value()}"
+    assert expected in props
+    assert sum(1 for p in props if p.startswith("--property=Environment=PATH=")) == 1
+
+
+def test_a_unit_without_path_produces_a_replica_without_path() -> None:
+    """反向：unit 沒設，複本就必須沒有。
+
+    這條是「複本連 production **沒有**設什麼也一起複製」的直接斷言——#679 的整個
+    要害就在這裡。複本若自己補一個 PATH，「job 沒有 PATH」就永遠量不到。
+    """
+
+    unit = build_job_unit(FOUR_WAY_SCHEME, DEFAULT_LAYOUT)
+    stripped = "\n".join(
+        line for line in unit.content.splitlines()
+        if not line.startswith("Environment=PATH=")
+    )
+    props = permgen.unit_replica_properties(stripped, instance="probe")
+    assert not [p for p in props if "PATH=" in p]
+
+
+@pytest.mark.parametrize("scheme_id", sorted(permgen.SCHEMES))
+def test_the_probe_never_injects_environment(scheme_id: str) -> None:
+    """探針產生器的**可執行行**不得出現 `--setenv=` 或任何 `PATH=`。
+
+    註解行不在判準內：這一節的註解必須講得出「為什麼不能加 `--setenv=PATH=`」，
+    而講這句話就得寫出那個字串。判準是「探針**做**了什麼」，不是「探針**提**到什麼」。
+    """
+
+    lines = permgen.build_path_resolution_probe(permgen.SCHEMES[scheme_id])
+    assert permgen.path_probe_env_injections(lines) == ()
+
+
+def test_the_probe_explains_why_it_must_not_inject() -> None:
+    """理由必須留在產物本身——讀它的人正是會忍不住「補一個 PATH 讓它過」的人。"""
+
+    text = "\n".join(permgen.build_path_resolution_probe(FOUR_WAY_SCHEME))
+    assert "--setenv=" in text, "產物要講得出禁止的是什麼"
+    assert "unit-replica" in text, "加固面必須走共用的全量複本"
+
+
+def test_the_injection_detector_actually_detects() -> None:
+    """守衛自己的 negative control：偵測器對真的注入必須是紅的。"""
+
+    poisoned = ["# 說明行提到 --setenv=PATH= 不算", "systemd-run --setenv=PATH=/usr/bin true"]
+    offenders = permgen.path_probe_env_injections(poisoned)
+    assert len(offenders) == 1
+    assert offenders[0].startswith("systemd-run")
+
+
+# ---------------------------------------------------------------------------
+# 5. 反向不變式的矩陣（#679 修法 4）
+# ---------------------------------------------------------------------------
+
+def test_the_matrix_is_every_role_times_every_executor() -> None:
+    cases = permgen.path_resolution_cases(FOUR_WAY_SCHEME, DEFAULT_LAYOUT)
+    principals = downgraded_job_principals(FOUR_WAY_SCHEME)
+    assert len(cases) == len(principals) * len(EXECUTOR_TOOLS)
+    assert {c.principal for c in cases} == set(principals)
+    assert {c.executor for c in cases} == {t.name for t in EXECUTOR_TOOLS}
+
+
+def test_every_case_expects_the_toolchain_copy() -> None:
+    """斷言的對象是「解到 `<toolchain>/bin/<cli>`」，而版本比對的對象是同一支檔案。
+
+    版本不另立一份手抄清單：登記表把 toolchain 落點登記成 `<toolchain>/bin/<cli>`，
+    因此「PATH 解出來的那支」與「絕對路徑那支」印出同一個版本字串，就是「job 跑的
+    是登記表登記的那一份」的直接證據。第二份清單只會變成下一個會漂移的真相。
+    """
+
+    for case in permgen.path_resolution_cases(FOUR_WAY_SCHEME, DEFAULT_LAYOUT):
+        assert case.expected_binary == f"{DEFAULT_LAYOUT.toolchain_bin}/{case.executor}"
+        assert case.version_reference == case.expected_binary
+
+
+def test_each_case_points_at_the_unit_that_executor_actually_starts() -> None:
+    """剖面跟著 executor 走（#643）：`codex` 的 unit 與 `claude` 的**不是同一份**。
+
+    只驗其中一份等於沒驗另一份的 PATH——這正是「角色 × executor」必須是兩層列舉的
+    理由，與 `job_unit_stems()` 同一條論證。
+    """
+
+    by_executor = {
+        case.executor: case
+        for case in permgen.path_resolution_cases(FOUR_WAY_SCHEME, DEFAULT_LAYOUT)
+        if case.principal is Principal.BUILDER
+    }
+    assert by_executor["codex"].hardening_profile == "jit"
+    assert by_executor["claude"].hardening_profile == "strict"
+    assert by_executor["codex"].unit_stem != by_executor["claude"].unit_stem
+    for case in by_executor.values():
+        expected_stem = permgen.job_unit_stem(
+            DEFAULT_LAYOUT,
+            case.principal,
+            permgen.executor_hardening_profile(case.executor),
+        )
+        assert case.unit_stem == expected_stem
+
+
+def test_schemes_without_a_gate_account_drop_those_rows() -> None:
+    """本方案沒有的角色機械略去，不留一列指向不存在帳號的假斷言。"""
+
+    cases = permgen.path_resolution_cases(permgen.THREE_WAY_SCHEME, DEFAULT_LAYOUT)
+    assert Principal.GATE not in {c.principal for c in cases}
+
+
+def test_the_cli_emits_the_probe() -> None:
+    from paulsha_cortex.trust_root.__main__ import main
+
+    assert main(["path-probe", "four-way"]) == 0
+
+
+# ---------------------------------------------------------------------------
+# 6. OS 層語意：在這個環境重現不了，**明確 skip**
+# ---------------------------------------------------------------------------
+
+@pytest.mark.skip(
+    reason=(
+        "#638／#657／#673 立下的規矩：涉及 OS 層語意、這個環境重現不了的，明確 skip "
+        "並說明理由，不得靜默通過。待驗的命題是**本票的核心**——「以零額外 env 起一個 "
+        "降權 job，`codex` 解到的是 /opt/cortex/toolchain/bin/codex，而不是 "
+        "/usr/bin/codex」。要驗它需要三樣這個環境都沒有的東西：(1) 第二個 UID"
+        "（cortex-builder／cortex-reviewer-planner／cortex-gate）；(2) 真的 systemd ＋ "
+        "polkit 授權，才起得了模板實例；(3) 一棵真的 /opt/cortex/toolchain 樹，裡面那份 "
+        "codex 與系統層那份是**不同版本**——而「兩份同名不同版」正是待驗現象本身，"
+        "CI 上只有一份（或一份都沒有）。\n"
+        "在這裡跑 `command -v codex` 只會證明「這台 CI 的 PATH 上有沒有 codex」，"
+        "與待驗命題無關，卻會讓人以為驗過了——而『以為驗過了』正是本票的病因：五輪"
+        "驗證全部自帶 PATH，每一輪都是綠的。\n"
+        "**這一半改由三個地方守**：(1) 本檔第 1～3 節（spec 層 fail-closed、unit 層"
+        "有值且同源、shim 兩層都缺即拒絕 exec）；(2) 本檔第 4 節（複本不得注入 PATH——"
+        "驗證方法本身的不變式）；(3) runbook 第 4e-2 步的實機矩陣，由 "
+        "`trust_root path-probe` 產生，operator 逐列比對版本字串。"
+    )
+)
+def test_a_downgraded_job_resolves_the_toolchain_copy_with_zero_extra_env() -> None:  # pragma: no cover
+    raise AssertionError("需要第二個 UID ＋ 真實 systemd 加固面 ＋ 兩份同名不同版的 CLI；見 skip 理由")

--- a/tests/test_manager_authored_job_accounting_604.py
+++ b/tests/test_manager_authored_job_accounting_604.py
@@ -53,6 +53,11 @@ _ISOLATED_AGENTS_ROOT = tempfile.mkdtemp(prefix="psc-agents-root-")
 
 _BASE_ENV = {
     "PATH": "/usr/local/bin:/usr/bin:/bin",
+    # #679：job 的 PATH 只由本角色的 `PSC_*_PATH` 決定（daemon 的 PATH 不再轉發），
+    # 未宣告即 fail-closed。三個角色各給一份，測試才驗得到「不會互相污染」。
+    "PSC_BUILDER_PATH": "/opt/cortex/toolchain/bin:/usr/local/bin:/usr/bin:/bin",
+    "PSC_REVIEWER_PATH": "/opt/cortex/toolchain/bin:/usr/local/bin:/usr/bin",
+    "PSC_GATE_PATH": "/opt/cortex/toolchain/bin:/usr/bin:/bin",
     "HOME": "/var/lib/cortex-manager",
     # conftest 的 `_clear_runtime_env` 把 PSC_AGENTS_ROOT 指向 per-test 暫存目錄，
     # 但本檔的 launch 測試以 `clear=True` 重建整份 environ（要驗的就是白名單本身），

--- a/tests/test_reviewer_planner_downgrade_615.py
+++ b/tests/test_reviewer_planner_downgrade_615.py
@@ -56,6 +56,11 @@ MANAGER_ACCOUNT = "cortex-manager"
 
 _BASE_ENV = {
     "PATH": "/usr/local/bin:/usr/bin:/bin",
+    # #679：job 的 PATH 只由本角色的 `PSC_*_PATH` 決定（daemon 的 PATH 不再轉發），
+    # 未宣告即 fail-closed。三個角色各給一份，測試才驗得到「不會互相污染」。
+    "PSC_BUILDER_PATH": "/opt/cortex/toolchain/bin:/usr/local/bin:/usr/bin:/bin",
+    "PSC_REVIEWER_PATH": "/opt/cortex/toolchain/bin:/usr/local/bin:/usr/bin",
+    "PSC_GATE_PATH": "/opt/cortex/toolchain/bin:/usr/bin:/bin",
     "HOME": "/var/lib/cortex-manager",
     "LANG": "en_US.UTF-8",
 }

--- a/tests/test_trust_root_executor_toolchain_640.py
+++ b/tests/test_trust_root_executor_toolchain_640.py
@@ -492,18 +492,32 @@ def test_job_path_puts_the_toolchain_first() -> None:
     assert not any(seg.endswith("/sbin") for seg in segments)
 
 
-def test_job_unit_documents_where_path_actually_comes_from() -> None:
-    """取捨寫在產物本身：模板 unit 的 `Environment=PATH=` 會被 shim 丟掉。
+def test_job_unit_carries_path_as_the_second_layer() -> None:
+    """#679：模板 unit **必須**有 `Environment=PATH=`，且值由產生器導出。
 
-    shim 以 `execvpe(argv[0], argv, spec['env'])` 整份換掉環境，job 解析命令用的
-    PATH 因此來自 **spec 的 env**（Manager 端 `PSC_BUILDER_PATH`），不是 unit。
-    在 unit 裡寫一行 `Environment=PATH=` 只會是一個看起來承載作用、實際無效的設定。
+    #640 當時的判斷是「shim 以 `execvpe(argv[0], argv, spec['env'])` 整份換掉環境，
+    寫在 unit 上會被丟掉」——對了一半：spec 的 env 確實是 job 的完整環境，但產生它的
+    `build_job_env()` 當時 fail-open，於是「spec 沒給 PATH」與「unit 沒有 PATH」同時
+    成立，兩層皆空。#679 兩層都補：spec 那層 fail-closed，unit 這層是 shim 的退路
+    （root-owned、比 spec 更可信），並讓加固面複本自動帶上 production 的 PATH。
     """
     unit = build_job_unit(THREE_WAY_SCHEME, DEFAULT_LAYOUT)
-    assert "\nEnvironment=PATH=" not in unit.content, "不得產生無效的 PATH 指令"
+    assert f"\nEnvironment=PATH={DEFAULT_LAYOUT.job_path_value()}\n" in unit.content
     assert f"PSC_BUILDER_PATH={DEFAULT_LAYOUT.job_path_value()}" in unit.content
     assert DEFAULT_LAYOUT.toolchain_root in unit.content
     assert "execvpe" in unit.content, "取捨的理由必須留在產物裡"
+
+
+def test_job_unit_path_is_derived_not_hardcoded() -> None:
+    """值必須跟著 `PathLayout` 走——改部署根就跟著改，不是寫死的字面量。"""
+    from paulsha_cortex.trust_root.permgen import PathLayout
+
+    layout = PathLayout(instance="acme", deploy_root="/srv/acme")
+    unit = build_job_unit(THREE_WAY_SCHEME, layout)
+    assert f"\nEnvironment=PATH={layout.job_path_value()}\n" in unit.content
+    emitted = unit.content.split("\nEnvironment=PATH=", 1)[1].split("\n", 1)[0]
+    assert emitted.startswith("/srv/acme/toolchain/bin:"), emitted
+    assert DEFAULT_LAYOUT.toolchain_bin not in emitted
 
 
 def test_builder_path_env_name_matches_the_job_runner_contract() -> None:

--- a/tests/test_trust_root_job_runner_p2a.py
+++ b/tests/test_trust_root_job_runner_p2a.py
@@ -32,9 +32,20 @@ from paulsha_cortex.coordinator.launcher import SubprocessLauncher
 # 每一輪 launch 測試都在乾淨的 env 上疊加，避免 operator 自己的 shell 汙染判定。
 _ISOLATED_AGENTS_ROOT = tempfile.mkdtemp(prefix="psc-agents-root-")
 
+#: #679：job 的 PATH 只由**本角色的** `PSC_*_PATH` 決定，未宣告即 fail-closed。
+#: 三個角色各給一份可辨識的值，測試才驗得到「角色不會互相污染」。
+_JOB_PATH_ENV = {
+    job_runner.BUILDER_PATH_ENV: "/opt/cortex/toolchain/bin:/usr/local/bin:/usr/bin:/bin",
+    job_runner.REVIEWER_PATH_ENV: "/opt/cortex/toolchain/bin:/usr/local/bin:/usr/bin",
+    job_runner.GATE_PATH_ENV: "/opt/cortex/toolchain/bin:/usr/bin:/bin",
+}
+
 _BASE_ENV = {
+    # daemon 自己的 PATH。**#679 起它不再被轉發**——留在這裡正是為了驗那件事：
+    # job 的 PATH 不得等於 daemon 的 PATH。
     "PATH": "/usr/local/bin:/usr/bin:/bin",
     "HOME": "/var/lib/cortex-svc",
+    **_JOB_PATH_ENV,
     # conftest 的 `_clear_runtime_env` 把 PSC_AGENTS_ROOT 指向 per-test 暫存目錄，
     # 但本檔的 launch 測試以 `clear=True` 重建整份 environ（要驗的就是白名單本身），
     # 那層保護因此被清掉。顯式帶上一個 per-process 暫存根：`launcher.launch()` 會在
@@ -297,10 +308,28 @@ class BuilderEnvAllowlistTests(unittest.TestCase):
         self.assertEqual(env["HOME"], "/var/lib/cortex-builder")
         self.assertNotEqual(env["HOME"], _BASE_ENV["HOME"])
 
-    def test_path_is_forwarded_and_overridable(self) -> None:
-        self.assertEqual(self._build()["PATH"], _BASE_ENV["PATH"])
-        env = self._build(**{job_runner.BUILDER_PATH_ENV: "/opt/cortex/bin:/usr/bin"})
-        self.assertEqual(env["PATH"], "/opt/cortex/bin:/usr/bin")
+    def test_path_comes_from_the_role_variable_and_never_from_the_daemon(self) -> None:
+        """#679：job 的 PATH 只有一個來源＝本角色的 `PSC_*_PATH`。
+
+        在此之前 `PATH` 在**轉發類**白名單上，於是未宣告 `PSC_BUILDER_PATH` 時 job
+        靜默拿到 daemon 的 PATH——一個沒有人為「job 該解到哪一份 CLI」做過決定的值。
+        """
+
+        env = self._build()
+        self.assertEqual(env["PATH"], _JOB_PATH_ENV[job_runner.BUILDER_PATH_ENV])
+        self.assertNotEqual(env["PATH"], _BASE_ENV["PATH"], "daemon 的 PATH 不得外流")
+        overridden = self._build(**{job_runner.BUILDER_PATH_ENV: "/opt/cortex/bin:/usr/bin"})
+        self.assertEqual(overridden["PATH"], "/opt/cortex/bin:/usr/bin")
+
+    def test_path_is_fail_closed_when_the_role_variable_is_absent(self) -> None:
+        """未宣告時**不得**靜默省略、也不得落回 daemon 的 PATH——一律 raise。"""
+
+        manager_env = {k: v for k, v in _BASE_ENV.items() if k not in _JOB_PATH_ENV}
+        with self.assertRaises(JobRunnerError) as ctx:
+            job_runner.build_builder_env(
+                manager_env=manager_env, job_id="j", slice_id="s", repo_root="/r"
+            )
+        self.assertEqual(ctx.exception.diagnostic.reason, "job-runner-path-undeclared")
 
     def test_relay_target_only_when_configured(self) -> None:
         manager_env = {**_BASE_ENV}
@@ -338,7 +367,7 @@ class BuilderEnvAllowlistTests(unittest.TestCase):
         with mock.patch.object(job_runner, "BUILDER_FORWARDED_ENV", poisoned):
             with self.assertRaises(JobRunnerError) as ctx:
                 job_runner.build_builder_env(
-                    manager_env={"SOME_API_KEY": "leaked"},
+                    manager_env={"SOME_API_KEY": "leaked", **_JOB_PATH_ENV},
                     job_id="j",
                     slice_id="s",
                     repo_root="/r",
@@ -346,9 +375,13 @@ class BuilderEnvAllowlistTests(unittest.TestCase):
         self.assertEqual(ctx.exception.diagnostic.reason, "job-runner-credential-env-leak")
 
     def test_newline_in_value_is_rejected(self) -> None:
+        # #679：注入點跟著 PATH 的來源走——現在是 `PSC_BUILDER_PATH`，不是 daemon 的
+        # `PATH`（後者已不再轉發）。守衛必須仍然攔得到。
         with self.assertRaises(JobRunnerError) as ctx:
             job_runner.build_builder_env(
-                manager_env={"PATH": "/usr/bin\n--property=User=root"},
+                manager_env={
+                    job_runner.BUILDER_PATH_ENV: "/usr/bin\n--property=User=root"
+                },
                 job_id="j",
                 slice_id="s",
                 repo_root="/r",
@@ -708,7 +741,9 @@ class DegradedLaunchTests(unittest.TestCase):
         self.assertEqual(unit_env["PSC_JOB_ID"], "psc-0001-demo")
         self.assertEqual(unit_env["PSC_SLICE_ID"], "psc-0001-demo")
         self.assertIn("PSC_REPO_ROOT", unit_env)
-        self.assertEqual(unit_env["PATH"], _BASE_ENV["PATH"])
+        # #679：unit 的 PATH 來自 `PSC_BUILDER_PATH`，**不是** daemon 的 PATH。
+        self.assertEqual(unit_env["PATH"], _JOB_PATH_ENV[job_runner.BUILDER_PATH_ENV])
+        self.assertNotEqual(unit_env["PATH"], _BASE_ENV["PATH"])
 
     def test_stdin_is_devnull_and_working_directory_is_the_worktree(self) -> None:
         call = self._launch_builder().call
@@ -826,7 +861,8 @@ class DegradedLaunchTests(unittest.TestCase):
         ):
             reported = SubprocessLauncher("codex").executor_environment()
         self.assertEqual(reported.home, "/var/lib/cortex-builder")
-        self.assertEqual(reported.path, _BASE_ENV["PATH"])
+        # #679：preflight 報的 PATH 也必須是 job 真的會拿到的那一份。
+        self.assertEqual(reported.path, _JOB_PATH_ENV[job_runner.BUILDER_PATH_ENV])
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/tests/test_trust_root_job_template_ab.py
+++ b/tests/test_trust_root_job_template_ab.py
@@ -43,6 +43,11 @@ _ISOLATED_AGENTS_ROOT = tempfile.mkdtemp(prefix="psc-agents-root-")
 
 _BASE_ENV = {
     "PATH": "/usr/local/bin:/usr/bin:/bin",
+    # #679：job 的 PATH 只由本角色的 `PSC_*_PATH` 決定（daemon 的 PATH 不再轉發），
+    # 未宣告即 fail-closed。三個角色各給一份，測試才驗得到「不會互相污染」。
+    "PSC_BUILDER_PATH": "/opt/cortex/toolchain/bin:/usr/local/bin:/usr/bin:/bin",
+    "PSC_REVIEWER_PATH": "/opt/cortex/toolchain/bin:/usr/local/bin:/usr/bin",
+    "PSC_GATE_PATH": "/opt/cortex/toolchain/bin:/usr/bin:/bin",
     "HOME": "/var/lib/cortex-manager",
     # conftest 的 `_clear_runtime_env` 把 PSC_AGENTS_ROOT 指向 per-test 暫存目錄，
     # 但本檔的 launch 測試以 `clear=True` 重建整份 environ（要驗的就是白名單本身），
@@ -784,7 +789,9 @@ class JobSpecContentTests(unittest.TestCase):
         self.assertEqual(spec["command"][:2], ["bash", "-c"])
         self.assertEqual(spec["working_directory"], ctx["root"])
         self.assertEqual(spec["log_path"], ctx["log_path"])
-        self.assertEqual(spec["env"]["PATH"], _BASE_ENV["PATH"])
+        # #679：spec 的 PATH 來自 `PSC_BUILDER_PATH`，**不是** daemon 的 PATH。
+        self.assertEqual(spec["env"]["PATH"], _BASE_ENV["PSC_BUILDER_PATH"])
+        self.assertNotEqual(spec["env"]["PATH"], _BASE_ENV["PATH"])
         self.assertEqual(spec["env"]["PSC_JOB_ID"], "psc-0042-template")
         self.assertEqual(
             spec["unit"],


### PR DESCRIPTION
## 摘要

修 #679。降權模式下**每一個 job 解到哪一份 CLI，取決於三件全部沒有人裁決過的事**：

1. 六份模板 unit 沒有一份有 `Environment=PATH=`；
2. `job_runner.build_job_env()` 對 `PSC_*_PATH` **fail-open**（未宣告就不寫這個鍵）；
3. 而 `PATH` 當時還在**轉發類**白名單上，因此未宣告時 job 靜默拿到 **Manager daemon 的**
   `PATH`；daemon 自己也沒有 `PATH` 時，`os.execvpe` 退回 `os.defpath`（`:/bin:/usr/bin`）。

三條路的終點一樣：`claude`／`agy` rc=127，而 `codex` **靜默**解到 `/usr/bin/codex`
（實機 0.42.0，toolchain 那份 0.147.0）——不報錯，只是產出來自一支 operator 從未判讀過的
CLI。builder／reviewer／gate 三個角色全中。

## 一條對 issue 證據鏈的更正（複驗結果）

Issue 第 3 點寫「`PSC_*_PATH` 任一未設 ⇒ **spec 的 env 裡根本沒有 `PATH` 這個鍵**」。
複驗後**那一句只在一種情況下成立**：`PATH` 本來就在 `BUILDER_FORWARDED_ENV` 上，所以
`build_job_env()` 會先把 Manager 的 `PATH` 轉發進去，`PSC_*_PATH` 只是覆寫它。以 `origin/main`
的 `job_runner.py` 實跑三種 Manager 環境：

| Manager 的 `PATH` | 未宣告 `PSC_*_PATH` 時 spec 的 `PATH` |
|---|---|
| systemd 預設（無 toolchain） | 逐字沿用 ⇒ `codex` 解到系統層 0.42.0 |
| 手動加過 toolchain-first（issue 證據 4 那台機器就是這樣） | 逐字沿用 ⇒ 其實**解得到** toolchain |
| 完全沒有 `PATH` | 鍵不存在 ⇒ `execvpe` 退回 `os.defpath` |

也就是說：issue 證據 5 那條 `systemd-run -p Environment=HOME=… /bin/sh -c 'command -v codex'`
探針**同樣不是 production 的忠實複本**——它供應的比 production **少**（沒有走
`build_job_env()` 的轉發）。方向與它所診斷的那個缺陷正好相反，但屬於同一族。

**這不會讓票變小，反而讓它更該修**：真正的 fail-open 是「job 的 `PATH` ＝ daemon 的
`PATH`」——一個沒有人為「job 該解到哪一份 CLI」做過決定、且會隨那台機器被誰手動改過什麼
而漂移的值。daemon 的 `PATH` 還帶著 `<deploy_root>/venv/bin`，等於把 job 的 `python3` 綁回
Manager 的 venv（`HOME`／`VIRTUAL_ENV` 早就因為同一條理由在排除表上）。因此本 PR 除了
issue 列的三件事，**多做第四件：把 `PATH` 移出轉發白名單**。

## 修法

### 1. `build_job_env()` fail-closed —— 採裁決 **(a) raise**

新增 `job_runner.resolve_job_path()`：`PSC_BUILDER_PATH`／`PSC_REVIEWER_PATH`／
`PSC_GATE_PATH` 未宣告（或空白）時以 `job-runner-path-undeclared` 當場失敗，訊息帶得出
「哪個變數」與「去哪一份 unit 取正規值」（旗標由 `permgen.JOB_UNIT_CLI_FLAG` 導出，有契約
測試釘住，避免 operator 照抄 `--job` 覆蓋掉 reviewer／gate 那一份）。

**不採選項 (b)（退回 permgen 導出的預設 ＋ 在 spec 留痕跡）**，理由：本 repo 對「未宣告即用
預設」已有明確立場（#453「registry 永不寫入預設值」）；而「job 解哪一份 CLI」正是**必須有人
做**的決定。替他做一次、只在 spec 留一行痕跡，等於把「未宣告」與「宣告成這樣」壓成同一種
狀態，下一次漂移一樣看不見。既有部署會在下一次派工直接 fail——**那是對的**，現況是靜默跑錯
版本；升級步驟見 runbook 5-5b 與 troubleshooting 新增的一節。

### 2. `PATH` 移出轉發白名單

改列 `BUILDER_SYNTHESIZED_ENV` ＋ `EXCLUDED_ENV_RATIONALE`（理由跟著值走，與 `HOME`／
`VIRTUAL_ENV` 同一段）。

### 3. `Environment=PATH=` 寫進六份模板 unit —— **兩層都補**

由 permgen 機械產生，值與 Manager 端變數同源（`PathLayout.job_path_value()`，換部署根就跟著
換，有測試釘住不是字面量）。#640 當時判斷「寫在 unit 上會被 shim 丟掉」**對了一半**：spec 的
env 確實是 job 的完整環境，但產生它的那一支當時 fail-open，於是**兩層同時為空**。

現在 `job_shim.resolve_job_env()` 在 spec 沒有 `PATH` 時退回 unit 這一層——**這不是
fail-open**：它退回的是 root-owned、可逐字稽核、job 帳號改不掉的來源，不是猜一個預設值。
兩層都缺才拒絕 exec，且該失敗發生在**接管 log 之前**（理由進 journal，而不是變成一份空的
job log——「job 跑了但沒輸出」與「job 從未起跑」在 Manager 眼裡長得一樣）。第二層同時涵蓋
「手工組 spec 繞過產生器」（#645 的同型前例）與「spool 裡還躺著升級前寫的舊 spec」。

### 4. 驗證方法：禁止驗證指令自帶 `PATH`

- runbook 共用探針 `psc_run_under` **移除 `--setenv=PATH=`**，`psc_probe_path()` 整支刪除
  （那個函式本身就是缺陷的載體：`PSC_*_PATH` 全未宣告時它會退回 EnvironmentFile 裡
  **Manager 自己**那條 `PATH=`）。
- 4e／5-3／5-4／附錄 A 共五處自帶 `PATH` 的驗證，改為絕對路徑（驗的是「這支檔案跑得動嗎」）
  或改走新的 4e-2（驗的是「job 會解到哪一份」）。**這兩個命題被明確分開並互相標註**——把它們
  混為一談正是缺陷活過五輪驗證的機制。
- `unit_replica_properties()` 現在會機械帶上 unit 的 `Environment=PATH=`，因此探針**什麼都
  不必補**。測試同時釘住反向：**unit 沒有 `PATH` 時，複本也必須沒有**。

### 反向不變式實際怎麼寫的

`permgen.build_path_resolution_probe()` ／ CLI `python3 -m paulsha_cortex.trust_root path-probe`，
產出貼進 shell 就跑的矩陣（`path_resolution_cases()` 是它的結構化形式，供測試斷言完整性）：

```bash
# 前置：先貼上 runbook 第 4e 步的共用探針 `psc_run_under`（產生器**呼叫它、不重造**
# ——加固面的定義只有一份，連呼叫它的那幾行 shell 也不該有第二份會漂移的複本）。
declare -F psc_run_under >/dev/null || {
  echo "⛔ 未定義 psc_run_under——先貼上 runbook 第 4e 步的共用探針" >&2
  return 1 2>/dev/null || exit 1
}

# --- builder × codex（cortex-builder／cortex-job-jit@／剖面 jit）---
psc_run_under cortex-job-jit /bin/sh -c 'command -v codex'
#   期望逐字：/opt/cortex/toolchain/bin/codex
#   ⛔ 空輸出 ⇒ job 沒有 PATH；/usr/bin/codex ⇒ 本票的原症狀
psc_run_under cortex-job-jit /bin/sh -c 'codex --version'
/opt/cortex/toolchain/bin/codex --version
#   期望：**兩行逐字相同**（PATH 解出來的那支 == 登記表登記的那支）
```

而 `psc_run_under` 本身（4e 那一節）現在長這樣——**尾端不再有 `--setenv=PATH=`**：

```bash
psc_run_under() {   # psc_run_under <unit 字幹> <命令> [參數…]
  local stem="$1"; shift
  local -a props
  mapfile -t props < <(
    sudo systemctl cat "${stem}@.service" \
      | python3 -m paulsha_cortex.trust_root unit-replica - --instance probe
  )
  if [ "${#props[@]}" -lt 30 ]; then
    echo "⛔ 加固面複本只有 ${#props[@]} 條——unit 落檔不完整或產生器已漂移，停下來" >&2
    return 90
  fi
  # ⛔ 這裡不得再加任何 --setenv=（#679）。環境完全由上面的複本決定，
  #    複本完全由落檔的 unit 決定——這兩句話成立，量到的才是 production。
  sudo systemd-run --pipe --wait --collect --quiet --service-type=exec \
    "${props[@]}" "$@"
}
```

四個設計點：

- **角色 × executor 是兩層列舉**（3 × 4 ＝ 12 列，本 scheme 沒有的角色機械略去）。剖面跟著
  executor 走（#643），所以 `codex` 與 `claude` 驗的是**兩份不同的 unit 檔**——只驗其中一份
  等於沒驗另一份的 PATH。
- **版本的比對對象是同一支檔案的絕對路徑**，不另立一份手抄的版本清單（登記表把 toolchain
  落點登記成 `<toolchain>/bin/<cli>`；第二份清單只會變成下一個會漂移的真相）。
- **產出刻意不含任何 `--setenv=`**，由 `path_probe_env_injections()` ＋ 測試釘住（只看
  非註解行——這一節的註解必須講得出「為什麼不能加」，而講這句話就得寫出那個字串）。
- **產生器不自帶第二份 `psc_run_under`**，未定義時 fail-closed。第一版寫成自帶一份逐字
  相同的 helper，那正是本票這一族事故的成因形態（兩份複本一定會漂移，方向不由人選），
  已在第二個 commit 改掉並加測試釘住。

### 順手收掉的一條「第三份真相」

runbook 5-5 手打的 `PSC_GATE_PATH=/usr/local/bin:/usr/bin:/bin` **少了 toolchain 段**，與
permgen（#666 的 `SYSTEM_PROGRAMS` note 逐字記著 `<toolchain>/bin ＋ JOB_PATH_SYSTEM_TAIL`）
不一致。三個 `PSC_*_PATH` 現一律由產生器導出，runbook 不再手打。

## 為什麼它活過五輪驗證

runbook 4e／5-2b、#661 與 #664 的量測、事故當天的每一次探針——**全部自帶
`--setenv=PATH=…`**。驗證環境供應了 production 不供應的東西，於是「job 沒有自己的 PATH」在
結構上不可能被觀察到。runbook 4e 甚至逐字預言了症狀、連 `0.42.0` 這個版本號都寫對了，但那條
是 `sudo -u … env PATH=…` 跑的，所以它驗的是「toolchain 裡那份是對的版本」，**不是「job 實際
會解到哪一份」**。

這是「綠燈不承載語意」的**第五**個實例，且是新的一類：前四次（#638 單 UID、#657 同型、#673
原 body 與其 repro）是「複本比 production **弱或強**」，這次是「複本比 production **多**」。
#677 立下「加固面複本必須全量機械導出」，本票再推一格：**複本必須連「production 沒有設什麼」
也一起複製**。

## 測試

新增 `tests/test_job_path_fail_closed_679.py`（47 條）：

- 三個角色各自缺席／空值／空白的 fail-closed；角色互不污染；錯誤訊息的 `trust_root unit`
  旗標與 `permgen.JOB_UNIT_CLI_FLAG` 一致。
- `PATH` 不在轉發白名單、在合成白名單、排除表講得出理由；job 的 PATH 恆不等於 daemon 的。
- 六份 unit 皆有 `Environment=PATH=`，值由 `PathLayout` 導出（換部署根即跟著換），且與該
  principal 的 `PSC_*_PATH` 同值。
- shim 三種情形：spec 優先／退回 unit／兩層都缺即 `ShimError` 且**不建 log 檔**。
- **複本的 PATH 逐字來自 unit；unit 沒有時複本也必須沒有**（本票要害的直接斷言）。
- 探針產生器的可執行行不得出現 `--setenv=`／`PATH=`，含偵測器自己的 negative control。
- 矩陣完整性（角色 × executor）、剖面對應、無 gate 帳號的 scheme 略去那些列。

OS 層語意（真的解到哪個檔）需要第二個 UID ＋ 真實 systemd 加固面 ＋ **兩份同名不同版的
CLI**（「兩份同名不同版」正是待驗現象本身，CI 上只有一份），三者本環境全部沒有，因此以
**具名 `@pytest.mark.skip` ＋ 完整理由**標示，並列出改由哪三個地方守——不靜默通過（#638／
#657／#673 立下的慣例）。

`python3 -m pytest tests/ -q`：**4273 passed, 24 skipped**。
本機 `policy_check` 帶 PR 上下文跑：**fail: 0**（R-22 為 71 條**既有**懸空引用的 advisory warn，非本 PR 造成）。

## 沒有做的事

- **沒有動任何實機部署**（`/opt/cortex/etc/cortex-manager.env`、已落檔的 unit）——那是
  operator 的動作；runbook 5-5b 有逐字步驟（含「不要把 `PSC_JOB_RUNNER` 改回 `direct`
  來繞開」的降級路徑警語）。
- **沒有改 gate 宣告的內容**（`PSC_GATE_CMD_PYTEST` 裡的 `python3`）——本票修好之後它自然
  被涵蓋。

## Checklist

- [x] 分支 `feature/679-job-path`，未 commit 到 `main`
- [x] `changelog.d/679-job-path.md` 已新增並 commit
- [x] `CHANGELOG.md [Unreleased]` 有對應 entry
- [x] `VERSION` 未動（非 release PR）
- [x] 全套測試通過（4272 passed / 24 skipped）
- [x] docs 同步：runbook（4e-2／5-5b／變更紀錄）、spec、README、troubleshooting
- [x] PR body 寫 `Closes #679`

Closes #679

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E7w9kaUxAzCCEk7piD5hfK