### PR TITLE
feat(planner): 錯誤語意三分 ＋ 逐候選拒因表（#672 票 A）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,36 @@
 ## [Unreleased]
 
 ### Fixed
+- **#682（#672 票 A）：planner 失敗的錯誤語意三分 ＋ `no-heterogeneous-planner` 攜帶逐候選
+  拒因表**——修法前 `select_secondary_planner()` 失敗時只回一個沒有任何附加資訊的字面值
+  `no-heterogeneous-planner`，而迴圈裡四個 `continue`（同 domain／probe 缺席／probe 沒
+  ready／probe 身分不符）**全部靜默**，於是三類結構上完全不同的失敗（job／executor 起不來、
+  executor 異常退出、輸出不合約）被壓成同一個「拓撲問題」。#670 就是這樣被誤診的：真因是
+  `agy models` 兩欄漂移造成 100% `model-not-listed` ＋ code fence 造成 parse 失敗，blocking
+  reason 說的卻是「沒有異質 planner」，最後靠人工重跑六遍才看出來。修法四件：(1) **三分的
+  具名族**（`planning-job-start-failed`／`planning-executor-failed`／
+  `planning-output-malformed` ＋ `executor-silent-exit` 子類 ＋ fail-closed 的
+  `planning-probe-unclassified`）與 `classify_probe_failure()` 的單一明表，票 C／票 E 直接
+  消費同一組常數；`probe_agy_capability` 的非零退出改帶 `_exit_diagnostic()`，rc≠0 且
+  stdout／stderr 皆空時就地標記 `executor-silent-exit`（stderr 內容本身不入 diagnostic）。
+  (2) **逐候選拒因表** `CandidateRejection` ＋ `SecondarySelection.rejections`，四個
+  `continue` 各記一筆；`SecondarySelection.reason` **刻意維持原字面值**——它是下游既有的
+  機器判準，拒因表走新欄位而不是把那個字串改長。(3) `run_heterogeneous_brainstorm` 經
+  `render_secondary_rejection_reason()` 把表渲染進 blocking reason
+  （`no-heterogeneous-planner grade=<environment|content> candidates=<N> (<逐條>)`，可用
+  正規表示式釘住），**PR #674 的 probe stdout 節錄自此端到端活著抵達 blocking reason**，
+  不再被 `continue` 吃掉；截斷只犧牲 diagnostic、身分列永不被丟，單條超限就地記帳 `…+Nc`、
+  全表超預算改成 `<detail-elided:Nc>`——「哪一條被截掉、少了多少」永遠讀得出來。
+  (4) `manager._classify_planning_failure()` 增第四條 environment 例外（比照 #416／#533／
+  #554 的同一個模式）：拒因表含 environment 級拒因時整體改判 `environment`，
+  `_resume_decision` 得以浮現 `recover-planning`；全部是拓撲／格式級時仍為 `content`
+  （反向誤報同樣不可接受）。判準讀的是渲染端算好、**錨在字串開頭**的 `grade=` 欄位而非對
+  整串 reason 做 substring-search——拒因表的 diagnostic 帶的是模型輸出，否則一個回
+  「planning-executor-failed」的模型就能把 content 失敗偽裝成 environment。機密面：
+  `CandidateRejection` 六個欄位沒有一個接得到 env、argv、檔案內容或 stderr，自由文字入口
+  只有 probe 的 reason／diagnostic（模型對固定 probe prompt 的 stdout 節錄、例外**型別名**），
+  渲染時另剝除 C0／C1 控制字元並單行化。測試 `tests/test_planning_failure_taxonomy_672.py`；
+  **既有測試一行未改**。
 - **#679：job 的 `PATH` 沒有一個來源是被決定過的——兩層都補、fail-closed，並禁止驗證
   指令自帶 `PATH`**。降權模式下 job 解到哪一份 CLI 取決於三件沒人裁決過的事：六份模板
   unit 沒有一份有 `Environment=PATH=`；`build_job_env()` 對 `PSC_*_PATH` **fail-open**；

--- a/changelog.d/682-planner-rejection-table.md
+++ b/changelog.d/682-planner-rejection-table.md
@@ -1,0 +1,40 @@
+# 682-planner-rejection-table
+
+- **#682（#672 票 A）：planner 失敗的錯誤語意三分 ＋ `no-heterogeneous-planner` 攜帶逐候選
+  拒因表**——修法前 `select_secondary_planner()`（`model_identities.py`）失敗時只回一個
+  沒有任何附加資訊的字面值 `no-heterogeneous-planner`，而迴圈裡四個 `continue`（同 domain／
+  probe 缺席／probe 沒 ready／probe 身分不符）**全部靜默**，於是三類結構上完全不同的失敗
+  （job／executor 起不來、executor 異常退出、輸出不合約）被壓成同一個「拓撲問題」。
+  #670 就是這樣被誤診的：真因是 `agy models` 兩欄漂移造成 100% `model-not-listed`
+  ＋ code fence 造成 parse 失敗，blocking reason 說的卻是「沒有異質 planner」，排查方向
+  整個帶偏，最後靠人工重跑六遍才看出來。修法四件：
+  - **三分的具名族**（`PLANNING_FAILURE_JOB_START`／`PLANNING_FAILURE_EXECUTOR`／
+    `PLANNING_FAILURE_OUTPUT` ＋ `executor-silent-exit` 子類 ＋ fail-closed 的
+    `planning-probe-unclassified`）與 `classify_probe_failure()` 的**單一明表**；票 C
+    （probe 快取）與票 E（`JobPlanningInvoker`）直接消費同一組常數，不再各自發明。
+    `probe_agy_capability` 的非零退出改帶 `_exit_diagnostic()`：rc≠0 且 stdout／stderr
+    皆空時就地標記 `executor-silent-exit`（**stderr 內容本身不入 diagnostic**）。
+  - **逐候選拒因表**：`CandidateRejection` dataclass ＋ `SecondarySelection.rejections`，
+    四個 `continue` 各記一筆。`SecondarySelection.reason` **刻意維持原字面值**——它是下游
+    既有的機器判準，拒因表走新欄位而不是把那個字串改長。
+  - **渲染進 blocking reason**：`run_heterogeneous_brainstorm` 經
+    `render_secondary_rejection_reason()` 產出
+    `no-heterogeneous-planner grade=<environment|content> candidates=<N> (<逐條>)`，
+    可用正規表示式釘住。PR #674 補的 probe stdout 節錄（`stdout_excerpt`）自此**端到端
+    活著抵達** blocking reason，不再被 `continue` 吃掉——兩票的接縫由測試釘住。
+    截斷策略：身分列（executor／model_id／domain ＋ 拒因 ＋ 族名）**永不被截、永不被整列
+    丟棄**；只有 diagnostic 會被截，單條超限就地記帳 `…+Nc`，全表超預算時從最長的
+    diagnostic 開始整格換成 `<detail-elided:Nc>`——「哪一條被截掉、少了多少」永遠讀得出來。
+  - **分類改判**：`manager._classify_planning_failure()` 增第四條 environment 例外
+    （比照 #416／#533／#554 三條既有例外的同一個模式）——拒因表含 environment 級拒因時
+    整體改判 `environment`，`_resume_decision` 因而得以浮現 `recover-planning`；全部是
+    拓撲／格式級拒因時仍為 `content`（反向誤報同樣不可接受）。判準讀的是渲染端算好、
+    **錨在字串開頭**的 `grade=` 欄位，**不對整串 reason 做 substring-search**：拒因表的
+    diagnostic 帶的是模型輸出，一個回「planning-executor-failed」的模型否則就能把 content
+    失敗偽裝成 environment。
+  - **機密面**：`CandidateRejection` 六個欄位沒有任何一個接得到 env、argv、檔案內容或
+    stderr；自由文字入口只有 probe 的 `reason`／`diagnostic`，其最寬的來源是模型對一段
+    **固定 probe prompt**（只含兩個常數）的 stdout 節錄與例外**型別名**
+    （`type(exc).__name__`，不含訊息）。渲染時另剝除 C0／C1 控制字元並單行化，避免 ANSI
+    escape 或換行污染單行 log。
+  - 測試 `tests/test_planning_failure_taxonomy_672.py`（30 條）；**既有測試一行未改**。

--- a/docs/superpowers/plans/planner-job-downgrade.md
+++ b/docs/superpowers/plans/planner-job-downgrade.md
@@ -46,11 +46,13 @@ claude／agy 兩種剖面皆 rc=0——**現行 `EXECUTOR_HARDENING_PROFILE` 就
 
 ### 1. 票 A｜錯誤語意三分 ＋ 逐候選拒因表（對應 R6，**不依賴任何部署面改動**）
 
+**已由 issue #682 land。**
+
 最先做，因為它**立刻**降低今天的排查成本。PR #674（#670）已經把 probe 那一端的診斷
 補齊（`strip_code_fence()`／`stdout_excerpt()`），票 A 要做的是讓那份診斷**活著抵達**
 blocking reason——兩者剛好接得起來，缺任何一半都還是查不出原因。
 
-- [ ] `tests/test_planning_failure_taxonomy_672.py`（TDD RED）：
+- [x] `tests/test_planning_failure_taxonomy_672.py`（TDD RED）：
   - `test_no_heterogeneous_planner_reason_carries_per_candidate_rejections`：
     給一組 probe（agy=not-ready/malformed-output、claude=not-ready/safe-probe-failed、
     codex=same-domain），`run_heterogeneous_brainstorm` 的 reason 必須同時含三個
@@ -62,19 +64,33 @@ blocking reason——兩者剛好接得起來，缺任何一半都還是查不�
     使 `_resume_decision` 得以浮現 `recover-planning`。
   - `test_content_grade_rejections_stay_content`：全部拒因都是 `same-domain` 時仍為
     `content`（不得把拓撲問題誤判成環境問題——反向誤報同樣不可接受）。
-- [ ] `paulsha_cortex/coordinator/model_identities.py`：新增
+- [x] `paulsha_cortex/coordinator/model_identities.py`：新增
       `CandidateRejection` dataclass；`SecondarySelection` 增 `rejections` 欄位；
       `select_secondary_planner()` 的每個 `continue` 改成記錄一筆拒因。
-- [ ] `paulsha_cortex/coordinator/planning.py`：`run_heterogeneous_brainstorm` 把拒因表
+- [x] `paulsha_cortex/coordinator/planning.py`：`run_heterogeneous_brainstorm` 把拒因表
       渲染進 `BrainstormResult.reason`（格式見 design D8）。
-- [ ] `paulsha_cortex/coordinator/manager.py`：`_classify_planning_failure` 增一條
+- [x] `paulsha_cortex/coordinator/manager.py`：`_classify_planning_failure` 增一條
       environment 例外（比照既有的 `_is_planning_authority_residue_failure`／
       `_is_planning_transient_service_failure`／`_is_planning_worktree_drift_failure`
       三條，同一個模式，不新發明）。
-- [ ] 三個失敗族的具名常數（`planning-job-start-failed`／`planning-executor-failed`／
+- [x] 三個失敗族的具名常數（`planning-job-start-failed`／`planning-executor-failed`／
       `planning-output-malformed` ＋ `executor-silent-exit` 子類）先定義，票 C 才有東西可落。
 - 驗收：既有 planning 測試一行不改全綠；新測試全綠；`no-heterogeneous-planner` 的
   reason 可用正規表示式釘住必含拒因表。
+
+**#682 的實作補充**（design D8 之外的兩處收斂，後續票沿用）：
+
+1. **`CandidateRejection` 多一個 `family` 欄位**（三分族）。D8 的示意 dataclass 只有
+   `reason`／`diagnostic` 兩欄，但整體分級若要靠 reason 字串的 substring-search 就會出
+   一個洩漏面：拒因表的 `diagnostic` 帶的是**模型輸出**，一個回「planning-executor-failed」
+   的模型即可把 content 失敗偽裝成 environment。改成渲染端依 `family` 算出
+   `grade=<environment|content>` 並**錨在字串開頭**，`_classify_planning_failure` 只讀
+   那個欄位。另加一個 fail-closed 的 `planning-probe-unclassified`：未知 probe 失敗一律
+   落 content 且在表上現形，不擅自宣稱是環境問題。
+2. **primary 自己不佔一條拒因**。`primary` 也在 planning 名單裡，而它與自己當然同 domain；
+   記一條「primary 因為與 primary 同 domain 而落選」是零資訊的套套邏輯。同 domain 的
+   **其他**身分照記。副作用是「roster 裡真的只有 primary」時拒因表為空、reason 維持原
+   字面值——那個情境下 `no-heterogeneous-planner` 本來就是真話。
 
 ### 2. 票 B｜`PlanningInvoker` 抽象（對應 R1 的結構面，**純重構、行為零改變**）
 

--- a/paulsha_cortex/coordinator/manager.py
+++ b/paulsha_cortex/coordinator/manager.py
@@ -51,6 +51,7 @@ from .model_identities import (
     CapabilityProbe,
     IdentityRegistry,
     ModelIdentity,
+    is_environment_grade_rejection_reason,
     load_model_identities,
 )
 from .planning import (
@@ -7181,11 +7182,30 @@ def _is_planning_worktree_drift_failure(reason: str | None) -> bool:
     return reason is not None and _PLANNING_WORKTREE_DRIFT_MARKER in reason
 
 
+# --- issue #682（#672 票 A）：拒因表裡的 environment 級拒因 -------------------
+#
+# `no-heterogeneous-planner` 今天一律落 `content`，而 `content` 在
+# `_resume_decision` 一律不浮現 `recover-planning` ⇒ 死路。但那個 reason 底下
+# 其實混著三類完全不同的失敗：拓撲問題（roster 真的沒有異質 planner）、輸出
+# 不合約（#670 的 code fence／`agy models` 兩欄漂移），以及 executor 根本起不
+# 來（#672 實測的沙箱／憑證缺口）。後者是環境事件，重跑或修環境就好，不該被
+# 判成模型內容缺陷。
+#
+# 判準刻意**不**對整串 reason 做 substring-search：拒因表的 diagnostic 帶的是
+# 模型 stdout 節錄，一個回「planning-executor-failed」的模型就能把 content
+# 失敗偽裝成 environment。改成讀渲染端算好、且**錨在字串開頭**的 `grade=`
+# 欄位（`model_identities.render_secondary_rejection_reason`）。
+def _is_planning_candidate_rejection_environment_failure(reason: str | None) -> bool:
+    """判斷 planning 失敗的 reason 是否為帶 environment 級拒因的逐候選拒因表。"""
+
+    return is_environment_grade_rejection_reason(reason)
+
+
 def _classify_planning_failure(reason: str | None) -> str:
     """brainstorm not-ready 的 reason → `environment` / `content` 的**單一判準**。
 
     #393 的預設是 `content`（fail-closed，`_resume_decision` 不浮現
-    `recover-planning`）。三個具名例外改歸 `environment`：
+    `recover-planning`）。四個具名例外改歸 `environment`：
 
     1. `_is_planning_authority_residue_failure`（#416）——abandon 未回滾的發佈
        殘留撞見 authority fail-closed，是狀態殘留而非模型內容缺陷。
@@ -7193,8 +7213,11 @@ def _classify_planning_failure(reason: str | None) -> str:
        的暫時性錯誤（503／限流／逾時），幾分鐘後自癒。
     3. `_is_planning_worktree_drift_failure`（#507／#554）——operator worktree
        在 planning 視窗內被動過；#543 之後不再銷毀資料，是環境事件。
+    4. `_is_planning_candidate_rejection_environment_failure`（#682／#672 票 A）
+       ——`no-heterogeneous-planner` 的逐候選拒因表裡有 environment 級拒因
+       （job 起不來、executor 異常退出）。
 
-    三個判準合成一個具名函式，是為了讓「reason → classification」這條映射有
+    四個判準合成一個具名函式，是為了讓「reason → classification」這條映射有
     單一可測的入口（過去它只以三元表達式活在 `_run_define_stage` 中段，測不到
     也看不見）。
     """
@@ -7203,6 +7226,7 @@ def _classify_planning_failure(reason: str | None) -> str:
         _is_planning_authority_residue_failure(reason)
         or _is_planning_transient_service_failure(reason)
         or _is_planning_worktree_drift_failure(reason)
+        or _is_planning_candidate_rejection_environment_failure(reason)
     ):
         return "environment"
     return "content"

--- a/paulsha_cortex/coordinator/model_identities.py
+++ b/paulsha_cortex/coordinator/model_identities.py
@@ -6,7 +6,7 @@ import re
 import subprocess
 from dataclasses import dataclass, field, replace
 from pathlib import Path
-from typing import Callable, Iterable, Mapping
+from typing import Callable, Iterable, Mapping, Sequence
 
 from paulsha_cortex.config import paths
 from paulsha_cortex.deck.schema import BAND_LEVELS
@@ -718,6 +718,139 @@ def _failed_agy(reason: str, diagnostic: str | None = None) -> CapabilityProbe:
     return CapabilityProbe(False, "agy", AGY_MODEL_ID, AGY_DOMAIN, reason, diagnostic)
 
 
+# ---------------------------------------------------------------------------
+# issue #682（#672 票 A）：錯誤語意三分
+#
+# 修法前 planning 失敗只有一個字面值 `no-heterogeneous-planner`——它把三類
+# 結構上完全不同的失敗壓成同一個「拓撲問題」：
+#
+#   1. job／executor 起不來（沙箱、PATH、runtime、polkit、模板未安裝）
+#   2. executor 起來了但異常退出（含「連錯誤訊息都沒有」的靜默退出）
+#   3. executor 正常退出但輸出不合約（parse 不了、內容不符、model 不在列）
+#
+# #670 就是被這樣誤診的：真因是 `agy models` 兩欄漂移造成 100%
+# `model-not-listed` ＋ code fence 造成 25% parse 失敗，blocking reason 說的
+# 卻是「沒有異質 planner」，排查方向整個帶偏。
+#
+# 族名在此定義（design D8／spec R6）；票 C（probe 快取）與票 E
+# （`JobPlanningInvoker`）落地時直接消費同一組常數，不再各自發明一套。
+# ---------------------------------------------------------------------------
+
+#: job 起不來：polkit 拒絕、模板未安裝、shim 不可執行、spec spool 不可寫、
+#: instance 已 active、`confirm_template_instance_started` 逾時。
+PLANNING_FAILURE_JOB_START = "planning-job-start-failed"
+#: job／行程起來了，但 executor 非零退出或零輸出。
+PLANNING_FAILURE_EXECUTOR = "planning-executor-failed"
+#: executor 正常退出，輸出不符契約（parse 失敗、身分不符、model 不在列）。
+PLANNING_FAILURE_OUTPUT = "planning-output-malformed"
+#: `planning-executor-failed` 的子類：rc≠0 且 stdout／stderr 皆空。
+#:
+#: 這是整個家族裡最難查的一種——**連錯誤訊息都沒有**，歸因於是會落到模型、
+#: prompt、逾時或憑證，而不會落到執行環境。它 MUST 被顯式命名，MUST NOT 被
+#: 壓成任何拓撲原因（spec R6）。
+PLANNING_FAILURE_EXECUTOR_SILENT_EXIT = "executor-silent-exit"
+#: 尚未歸類的 probe 失敗。**fail-closed**：不當作環境問題，只當作「這個族還
+#: 沒被對應過」的可見標記——新增 probe 失敗原因時會直接在拒因表上現形，而不是
+#: 被默默塞進三族之一。
+PLANNING_FAILURE_UNCLASSIFIED = "planning-probe-unclassified"
+
+PLANNING_FAILURE_FAMILIES = (
+    PLANNING_FAILURE_JOB_START,
+    PLANNING_FAILURE_EXECUTOR,
+    PLANNING_FAILURE_OUTPUT,
+    PLANNING_FAILURE_UNCLASSIFIED,
+)
+
+#: 哪些族屬「環境」——命中者讓 `manager._classify_planning_failure` 改判
+#: `environment`，`_resume_decision` 因而得以浮現 `recover-planning`。
+#: `planning-output-malformed` 刻意**不在**此列：那是模型內容／格式問題，
+#: 維持 `content` 的 fail-closed 意圖（反向誤報同樣不可接受）。
+ENVIRONMENT_GRADE_PLANNING_FAMILIES = frozenset(
+    {PLANNING_FAILURE_JOB_START, PLANNING_FAILURE_EXECUTOR}
+)
+
+#: probe 失敗原因 → 三分族的明表。散落的 `if` 是漂移的來源，這裡只留一張表。
+_PROBE_REASON_FAMILIES: dict[str, str] = {
+    # `agy models` 這一次 CLI 呼叫死掉／非零退出：CLI 根本起不來或環境不對。
+    "models-probe-failed": PLANNING_FAILURE_EXECUTOR,
+    # smoke 呼叫非零退出。
+    "smoke-failed": PLANNING_FAILURE_EXECUTOR,
+    # CLI 正常退出但列表裡沒有我們要的 model（#670 的兩欄漂移就落在這裡）：
+    # 輸出與 roster 契約不符，不是環境壞掉。
+    "model-not-listed": PLANNING_FAILURE_OUTPUT,
+    "malformed-output": PLANNING_FAILURE_OUTPUT,
+    "identity-mismatch": PLANNING_FAILURE_OUTPUT,
+    # 票 C／票 E 之後 probe 自己就會回族名，這裡讓它原樣通過。
+    PLANNING_FAILURE_JOB_START: PLANNING_FAILURE_JOB_START,
+    PLANNING_FAILURE_EXECUTOR: PLANNING_FAILURE_EXECUTOR,
+    PLANNING_FAILURE_OUTPUT: PLANNING_FAILURE_OUTPUT,
+}
+
+#: `_probe_identity` 的 `safe-probe-failed` 只帶例外**型別名**（不帶訊息），
+#: 那個型別名就是唯一能機械分辨「executor 死了」還是「輸出不合約」的線索。
+_PROBE_FAILED_REASON = "safe-probe-failed"
+_ENVIRONMENT_EXCEPTION_NAMES = frozenset(
+    {
+        "BrokenPipeError",
+        "CalledProcessError",
+        "ConnectionError",
+        "ConnectionResetError",
+        "FileNotFoundError",
+        "IsADirectoryError",
+        "NotADirectoryError",
+        "OSError",
+        "PermissionError",
+        "SubprocessError",
+        "TimeoutError",
+        "TimeoutExpired",
+    }
+)
+_OUTPUT_EXCEPTION_NAMES = frozenset(
+    {
+        "JSONDecodeError",
+        "KeyError",
+        "TypeError",
+        "ValueError",
+    }
+)
+
+
+def classify_probe_failure(reason: str | None, diagnostic: str | None = None) -> str:
+    """probe 的失敗 reason（＋diagnostic）→ 三分族。
+
+    未知 reason 一律落 `planning-probe-unclassified`（content 級）——**寧可
+    標成未分類，也不擅自宣稱是環境問題**。把未知失敗當 environment 會讓
+    `recover-planning` 對著一個永遠不會自癒的失敗一直重試；當 content 則最多
+    是多要一次人工判斷，而且拒因表上會直接看到「unclassified」這個字。
+    """
+
+    if not reason:
+        return PLANNING_FAILURE_UNCLASSIFIED
+    if reason == _PROBE_FAILED_REASON:
+        # diagnostic 是 `type(exc).__name__`，由 `_probe_identity` 產生，
+        # 不含例外訊息，也就不含路徑／env／憑證。
+        name = (diagnostic or "").strip()
+        if name in _ENVIRONMENT_EXCEPTION_NAMES:
+            return PLANNING_FAILURE_EXECUTOR
+        if name in _OUTPUT_EXCEPTION_NAMES:
+            return PLANNING_FAILURE_OUTPUT
+        return PLANNING_FAILURE_UNCLASSIFIED
+    return _PROBE_REASON_FAMILIES.get(reason, PLANNING_FAILURE_UNCLASSIFIED)
+
+
+def _exit_diagnostic(returncode: int, stdout: str, stderr: str) -> str:
+    """非零退出的 diagnostic：`exit-code:N`，全空輸出時加註 silent-exit 子類。
+
+    只讀 rc 與「stdout／stderr 是否為空」兩件事，**不把 stderr 內容帶進
+    diagnostic**——stderr 是最容易夾帶路徑、env 與憑證錯誤原文的通道，而
+    diagnostic 會一路進 log／evidence／`blocking_reason`。
+    """
+
+    if not stdout.strip() and not stderr.strip():
+        return f"exit-code:{returncode} {PLANNING_FAILURE_EXECUTOR_SILENT_EXIT}"
+    return f"exit-code:{returncode}"
+
+
 # issue #670：開頭 fence 允許帶 info string（``` 後面的語言標籤，例如 `json`），
 # 但字元集刻意收斂到「語言標籤長得出來的樣子」——絕不可含 `{`／反引號，否則
 # 單行形態 ```` ```{"a":1}``` ```` 會被整串當成 info string 吃掉。
@@ -837,11 +970,13 @@ def probe_agy_capability(
     }
     try:
         listed_raw = process_runner(["agy", "models"], **common)
-        listed_rc, listed_stdout, _listed_stderr = _process_fields(listed_raw)
+        listed_rc, listed_stdout, listed_stderr = _process_fields(listed_raw)
     except Exception as exc:
         return _failed_agy("models-probe-failed", type(exc).__name__)
     if listed_rc != 0:
-        return _failed_agy("models-probe-failed", f"exit-code:{listed_rc}")
+        return _failed_agy(
+            "models-probe-failed", _exit_diagnostic(listed_rc, listed_stdout, listed_stderr)
+        )
     listed_lines = {line.strip() for line in listed_stdout.splitlines() if line.strip()}
     cli_model_token = _resolve_agy_cli_token(AGY_MODEL_ID, listed_lines)
     if cli_model_token is None:
@@ -872,11 +1007,13 @@ def probe_agy_capability(
     )
     try:
         smoke_raw = process_runner(argv, **common)
-        smoke_rc, smoke_stdout, _smoke_stderr = _process_fields(smoke_raw)
+        smoke_rc, smoke_stdout, smoke_stderr = _process_fields(smoke_raw)
     except Exception as exc:
         return _failed_agy("smoke-failed", type(exc).__name__)
     if smoke_rc != 0:
-        return _failed_agy("smoke-failed", f"exit-code:{smoke_rc}")
+        return _failed_agy(
+            "smoke-failed", _exit_diagnostic(smoke_rc, smoke_stdout, smoke_stderr)
+        )
     try:
         payload = json.loads(strip_code_fence(smoke_stdout))
     except (json.JSONDecodeError, TypeError):
@@ -886,11 +1023,230 @@ def probe_agy_capability(
     return CapabilityProbe.ready_for("agy", AGY_MODEL_ID, AGY_DOMAIN)
 
 
+# ---------------------------------------------------------------------------
+# issue #682（#672 票 A）：逐候選拒因表
+#
+# `select_secondary_planner()` 的迴圈裡有四個 `continue`，全部靜默——每個候選
+# 被跳過的真正理由（同 domain？probe 缺席？probe 沒 ready？ready 但身分不
+# 符？）都在原地被吃掉，最後只剩一個沒有任何附加資訊的 `no-heterogeneous-
+# planner`。拒因表把那四個 `continue` 各記一筆，讓「格式問題」與「拓撲問題」
+# 在同一個字串裡是**兩個不同的欄位**，不必重跑六遍才發現（design D8）。
+# ---------------------------------------------------------------------------
+
+#: 候選與 primary 同 independence domain（純拓撲事實）。
+REJECTION_SAME_DOMAIN = "same-domain"
+#: 這個候選根本沒有被 probe 過（probes 表沒有這一格）。
+REJECTION_PROBE_ABSENT = "probe-absent"
+#: probe 跑了但沒 ready——真正的失敗原因在 `family`／`diagnostic` 兩欄。
+REJECTION_PROBE_NOT_READY = "probe-not-ready"
+#: probe ready，但它回報的身分與 roster 這一列不符（probe 問到了別人）。
+REJECTION_PROBE_IDENTITY_MISMATCH = "probe-identity-mismatch"
+
+REJECTION_REASONS = (
+    REJECTION_SAME_DOMAIN,
+    REJECTION_PROBE_ABSENT,
+    REJECTION_PROBE_NOT_READY,
+    REJECTION_PROBE_IDENTITY_MISMATCH,
+)
+
+
+@dataclass(frozen=True)
+class CandidateRejection:
+    """一個 planning-capable identity 為什麼沒被選上。
+
+    欄位刻意只有六個，而且**沒有任何一個接得到 env、argv、檔案內容或
+    stderr**——這份資料會一路進 log／evidence／`blocking_reason`，能不能夾帶
+    憑證是欄位面就要回答的問題，不是渲染時再過濾。
+
+    - `executor`／`model_id`／`domain`：roster 常數（`model-identities.yaml`）。
+    - `reason`：四個 `continue` 之一，見 `REJECTION_REASONS`。
+    - `diagnostic`：probe 側的自由文字。最寬的來源是模型對一段**固定 probe
+      prompt** 的 stdout 節錄（PR #674 的 `stdout_excerpt`）與例外**型別名**
+      （`type(exc).__name__`，不含訊息）。
+    - `family`：三分族（`PLANNING_FAILURE_*`）。`same-domain`／`probe-absent`
+      這類拓撲拒因為空字串——它們不是「執行失敗」，不該被硬塞進三族之一。
+    """
+
+    executor: str
+    model_id: str
+    domain: str
+    reason: str
+    diagnostic: str = ""
+    family: str = ""
+
+    @property
+    def environment_grade(self) -> bool:
+        return self.family in ENVIRONMENT_GRADE_PLANNING_FAMILIES
+
+    @classmethod
+    def from_probe(
+        cls, identity: "ModelIdentity", probe: CapabilityProbe
+    ) -> "CandidateRejection":
+        """probe 沒 ready ⇒ 帶著 probe 自己的 reason／diagnostic 一起落表。
+
+        **這裡就是 PR #674 與本票的接縫**：#674 讓 `probe_agy_capability`
+        失敗時帶 stdout 節錄，本方法讓那份節錄不在 `select_secondary_planner`
+        被 `continue` 吃掉，而是原樣（僅做單行化）活到 blocking reason。
+        """
+
+        probe_reason = (probe.reason or "").strip()
+        probe_diagnostic = (probe.diagnostic or "").strip()
+        detail = " ".join(part for part in (probe_reason, probe_diagnostic) if part)
+        return cls(
+            executor=identity.executor,
+            model_id=identity.model_id,
+            domain=identity.independence_domain,
+            reason=REJECTION_PROBE_NOT_READY,
+            diagnostic=detail,
+            family=classify_probe_failure(probe_reason, probe_diagnostic),
+        )
+
+    @classmethod
+    def topological(
+        cls, identity: "ModelIdentity", reason: str, diagnostic: str = ""
+    ) -> "CandidateRejection":
+        return cls(
+            executor=identity.executor,
+            model_id=identity.model_id,
+            domain=identity.independence_domain,
+            reason=reason,
+            diagnostic=diagnostic,
+        )
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            "executor": self.executor,
+            "model_id": self.model_id,
+            "domain": self.domain,
+            "reason": self.reason,
+            "diagnostic": self.diagnostic,
+            "family": self.family,
+        }
+
+    def head(self) -> str:
+        """身分 ＋ 拒因 ＋ 族名。**這一段永不被截斷**（見 `render_...`）。"""
+
+        head = f"{self.executor}/{self.model_id}[{self.domain}]: {self.reason}"
+        return f"{head} {self.family}" if self.family else head
+
+
+#: 單一候選 diagnostic 的字元上限。超出部分以 `…+Nc` 就地記帳。
+#: 160 與 `summarize_exception`／`#397` 既有的例外摘要上限同數量級，
+#: 足以完整看見一個 fence 開頭與 JSON 前綴。
+REJECTION_TABLE_DETAIL_LIMIT = 160
+#: 整張表（含前綴）的字元預算。roster 五個 identity、每格 diagnostic 上限
+#: 160 時綽綽有餘；超出時**只犧牲 diagnostic、不犧牲身分列**。
+REJECTION_TABLE_TOTAL_LIMIT = 1200
+
+#: C0／C1 控制字元（換行、tab、ANSI escape 的 ESC）。diagnostic 帶的是模型
+#: 輸出，直接進單行 log 會被它污染。
+_CONTROL_CHARS_RE = re.compile(r"[\x00-\x1f\x7f-\x9f]+")
+
+#: 環境級拒因表的辨識式。**錨在字串開頭**，因此模型 stdout 節錄裡就算逐字
+#: 寫著 `planning-executor-failed`，也騙不到 `_classify_planning_failure`：
+#: grade 是渲染端依 `CandidateRejection.family` 算出來的一個欄位，不是對整串
+#: reason 做 substring-search 的結果。
+_ENVIRONMENT_GRADE_REASON_RE = re.compile(
+    r"\A[a-z0-9-]+ grade=environment candidates=\d+ \("
+)
+
+
+def _single_line_detail(text: str) -> str:
+    return " ".join(_CONTROL_CHARS_RE.sub(" ", text).split())
+
+
+def _truncate_detail(detail: str, limit: int) -> str:
+    if len(detail) <= limit:
+        return detail
+    return f"{detail[:limit]}…+{len(detail) - limit}c"
+
+
+def rejection_table_grade(rejections: Sequence[CandidateRejection]) -> str:
+    """拒因表 → `environment` / `content`。任一條 environment 級即整體 environment。"""
+
+    return (
+        "environment"
+        if any(rejection.environment_grade for rejection in rejections)
+        else "content"
+    )
+
+
+def render_secondary_rejection_reason(
+    base_reason: str | None,
+    rejections: Sequence[CandidateRejection],
+    *,
+    detail_limit: int = REJECTION_TABLE_DETAIL_LIMIT,
+    total_limit: int = REJECTION_TABLE_TOTAL_LIMIT,
+) -> str | None:
+    """把拒因表渲染進 blocking reason（design D8 的格式）。
+
+    ``<base> grade=<environment|content> candidates=<N> (<逐條>; <逐條>)``
+
+    三段都是必要的：``grade`` 讓下游分類有一個**不必去 substring-search 模型
+    輸出**的欄位；``candidates=<N>`` 讓「表裡應該有幾條」變成一個可核對的
+    數字。沒有任何候選時原樣回傳 ``base_reason``——roster 裡真的沒有別人時，
+    `no-heterogeneous-planner` 是真話，不必生一張空表。
+
+    **截斷策略**（issue #682 明列的要求：截斷不得讓「哪一條被截掉」變成不可
+    知）：
+
+    1. 每一條的**身分 ＋ 拒因 ＋ 族名**（`head()`）永不被截斷、永不被整列丟
+       棄。表再長也答得出「有幾個候選、分別是誰、各自為什麼落選」。
+    2. 只有 `diagnostic` 會被截。單條超過 `detail_limit` 時就地記帳
+       `…+Nc`（少了幾個字寫在原處）。
+    3. 全表仍超過 `total_limit` 時，從**最長的 diagnostic 開始**整格換成
+       `<detail-elided:Nc>`，同樣就地記帳。因此「被犧牲的是哪一條、犧牲了
+       多少」永遠讀得出來。
+    4. 身分列本身就撐爆預算時（roster 大到病態）寧可超出預算也不丟列——
+       丟列會讓拒因表失去它存在的唯一理由。
+    """
+
+    if not rejections:
+        return base_reason
+    prefix = (
+        f"{base_reason} grade={rejection_table_grade(rejections)} "
+        f"candidates={len(rejections)} "
+    )
+    heads = [rejection.head() for rejection in rejections]
+    details = [
+        _truncate_detail(_single_line_detail(rejection.diagnostic), detail_limit)
+        for rejection in rejections
+    ]
+
+    def assemble() -> str:
+        entries = [
+            f"{head} {detail}" if detail else head for head, detail in zip(heads, details)
+        ]
+        return f"{prefix}({'; '.join(entries)})"
+
+    rendered = assemble()
+    # 由長到短逐格讓位；同長度時取索引小的，讓結果與輸入順序一樣是決定性的。
+    order = sorted(range(len(details)), key=lambda index: (-len(details[index]), index))
+    for index in order:
+        if len(rendered) <= total_limit:
+            break
+        if not details[index]:
+            continue
+        details[index] = f"<detail-elided:{len(details[index])}c>"
+        rendered = assemble()
+    return rendered
+
+
+def is_environment_grade_rejection_reason(reason: str | None) -> bool:
+    """reason 是否為帶 environment 級拒因的拒因表（`manager` 的分類例外用）。"""
+
+    return bool(reason) and _ENVIRONMENT_GRADE_REASON_RE.match(reason) is not None
+
+
 @dataclass(frozen=True)
 class SecondarySelection:
     state: str
     reason: str | None
     identity: ModelIdentity | None
+    #: issue #682：逐候選拒因表。`reason` 本身刻意維持原字面值
+    #: （`no-heterogeneous-planner` 是下游既有的機器判準），拒因走這個新欄位，
+    #: 由 `run_heterogeneous_brainstorm` 渲染進 `BrainstormResult.reason`。
+    rejections: tuple[CandidateRejection, ...] = ()
 
 
 def select_secondary_planner(
@@ -908,6 +1264,14 @@ def select_secondary_planner(
     任何新 executor）**永遠不可達**，packaged 的 agy 卻穩坐熱路徑首位，正是
     #534 的主訴現場。合法性條件（planning capability、異質 domain、probe
     ready 且 probe 身分相符）逐項不變。
+
+    #682（#672 票 A）：迴圈裡四個 `continue` 過去全部靜默，於是失敗時只剩一個
+    沒有任何附加資訊的 `no-heterogeneous-planner`。現在每次 `continue` 都記一筆
+    `CandidateRejection`，經 `SecondarySelection.rejections` 交給
+    `run_heterogeneous_brainstorm` 渲染進 blocking reason。
+
+    `reason` 欄位本身**刻意不變**（仍是 `no-heterogeneous-planner`）：它是下游
+    既有的機器判準與既有測試的斷言對象，拒因表走新欄位而不是把字串改長。
     """
 
     primary_identity = registry.get(*primary)
@@ -919,20 +1283,48 @@ def select_secondary_planner(
     ranked = model_resolution.rank_candidates(
         planning, role="planning", context=registry.resolution_context
     )
+    rejections: list[CandidateRejection] = []
     for identity in ranked.ordered:
         if identity.independence_domain == primary_identity.independence_domain:
+            # primary 自己也在 planning 名單裡，而它與自己當然同 domain。
+            # 記一條「primary 因為與 primary 同 domain 而落選」是**零資訊的
+            # 套套邏輯**，只會讓每張表都以一條廢話開頭，所以不記——它不是候選，
+            # 它是被拿來比對的那一方。同 domain 的**其他**身分照記。
+            if (identity.executor, identity.model_id) != (
+                primary_identity.executor,
+                primary_identity.model_id,
+            ):
+                rejections.append(
+                    CandidateRejection.topological(identity, REJECTION_SAME_DOMAIN)
+                )
             continue
         probe = probes.get((identity.executor, identity.model_id))
-        if probe is None or not probe.ready:
+        if probe is None:
+            rejections.append(
+                CandidateRejection.topological(identity, REJECTION_PROBE_ABSENT)
+            )
+            continue
+        if not probe.ready:
+            rejections.append(CandidateRejection.from_probe(identity, probe))
             continue
         if probe.identity != (
             identity.executor,
             identity.model_id,
             identity.independence_domain,
         ):
+            rejections.append(
+                CandidateRejection.topological(
+                    identity,
+                    REJECTION_PROBE_IDENTITY_MISMATCH,
+                    # probe 回報的身分是 roster／probe 兩側的常數，不含自由文字。
+                    diagnostic="probe-reported=" + "/".join(probe.identity),
+                )
+            )
             continue
         return SecondarySelection("ready", None, identity)
-    return SecondarySelection("needs_human", "no-heterogeneous-planner", None)
+    return SecondarySelection(
+        "needs_human", "no-heterogeneous-planner", None, tuple(rejections)
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/paulsha_cortex/coordinator/planning.py
+++ b/paulsha_cortex/coordinator/planning.py
@@ -13,6 +13,7 @@ from .model_identities import (
     CapabilityProbe,
     IdentityRegistry,
     ModelIdentity,
+    render_secondary_rejection_reason,
     select_secondary_planner,
 )
 from .workflow import GateEvidenceRef
@@ -1351,7 +1352,19 @@ def run_heterogeneous_brainstorm(
         return BrainstormResult("ready", None, None, empty_refs, None)
     selection = select_secondary_planner(registry=registry, primary=primary, probes=probes)
     if selection.state != "ready" or selection.identity is None:
-        return BrainstormResult("needs_human", selection.reason, None, empty_refs, None)
+        # issue #682（#672 票 A）：`no-heterogeneous-planner` 從**結論**變成
+        # **結論 ＋ 每個候選為什麼落選**。這一行就是「讓誤報不可能」的機制
+        # 本身——PR #674 讓 probe 失敗帶得出 stdout 節錄，這裡讓那份節錄活著
+        # 抵達 blocking reason，不再被 `select_secondary_planner` 的 `continue`
+        # 吃掉。沒有任何候選時（roster 裡真的只有 primary）拒因表為空，reason
+        # 維持原字面值。
+        return BrainstormResult(
+            "needs_human",
+            render_secondary_rejection_reason(selection.reason, selection.rejections),
+            None,
+            empty_refs,
+            None,
+        )
     try:
         questioner_input = {
             **report.to_dict(),

--- a/tests/test_planning_failure_taxonomy_672.py
+++ b/tests/test_planning_failure_taxonomy_672.py
@@ -1,0 +1,591 @@
+"""issue #682（#672 票 A）：錯誤語意三分 ＋ 逐候選拒因表。
+
+修法前 `select_secondary_planner()` 失敗時只回一個字面值
+`no-heterogeneous-planner`——它把三類結構上完全不同的失敗（憑證缺失／
+executor 啟動失敗／輸出不合約）壓成同一個「拓撲問題」。#670 就是被這樣誤診的：
+真因是 `agy models` 兩欄漂移 ＋ code fence，blocking reason 卻說「沒有異質
+planner」，排查方向整個帶偏，最後靠人工重跑六遍才看出來。
+
+本檔釘住的契約：
+- 每一個 planning-capable 候選為什麼落選都逐條記在 `SecondarySelection.rejections`；
+- `run_heterogeneous_brainstorm` 把該表渲染進 `BrainstormResult.reason`，
+  且該 reason **可用正規表示式釘住必含拒因表**（issue #682 驗收第一條）；
+- PR #674 補的 probe stdout 節錄**活著抵達** blocking reason，不在中途被壓掉；
+- 拒因表中出現 environment 級拒因時 `_classify_planning_failure` 改判
+  `environment`（讓 `recover-planning` 有路），全部是拓撲拒因時仍為 `content`
+  （反向誤報同樣不可接受）。
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from paulsha_cortex.coordinator import manager
+from paulsha_cortex.coordinator.model_identities import (
+    ENVIRONMENT_GRADE_PLANNING_FAMILIES,
+    PLANNING_FAILURE_EXECUTOR,
+    PLANNING_FAILURE_EXECUTOR_SILENT_EXIT,
+    PLANNING_FAILURE_JOB_START,
+    PLANNING_FAILURE_OUTPUT,
+    PLANNING_FAILURE_UNCLASSIFIED,
+    REJECTION_PROBE_ABSENT,
+    REJECTION_PROBE_IDENTITY_MISMATCH,
+    REJECTION_PROBE_NOT_READY,
+    REJECTION_SAME_DOMAIN,
+    REJECTION_TABLE_DETAIL_LIMIT,
+    REJECTION_TABLE_TOTAL_LIMIT,
+    CandidateRejection,
+    CapabilityProbe,
+    IdentityRegistry,
+    is_environment_grade_rejection_reason,
+    probe_agy_capability,
+    render_secondary_rejection_reason,
+    select_secondary_planner,
+)
+from paulsha_cortex.coordinator.planning import (
+    PlanningArtifact,
+    PlanningScope,
+    assess_planning_completeness,
+    run_heterogeneous_brainstorm,
+)
+
+# ---------------------------------------------------------------------------
+# 驗收條件（issue #682）：blocking reason 必含拒因表，且形狀可機械釘住。
+#
+#   no-heterogeneous-planner grade=<environment|content> candidates=<N> (<逐條>)
+#
+# 三段都是必要的：`grade` 讓下游分類不必去 substring-search 模型輸出；
+# `candidates` 讓「表裡應該有幾條」成為可核對的數字，截斷再嚴也不會把
+# 「有幾個候選、少了誰」變成不可知。
+# ---------------------------------------------------------------------------
+REJECTION_TABLE_RE = re.compile(
+    r"\Ano-heterogeneous-planner grade=(?P<grade>environment|content) "
+    r"candidates=(?P<count>\d+) \((?P<table>.+)\)\Z"
+)
+#: 逐條的頭段：`<executor>/<model_id>[<domain>]: <拒因>`。
+REJECTION_ENTRY_RE = re.compile(
+    r"(?P<executor>[a-z0-9_.-]+)/(?P<model_id>[^\[\]/]+)\[(?P<domain>[^\[\]]+)\]: "
+    r"(?P<reason>same-domain|probe-absent|probe-not-ready|probe-identity-mismatch)"
+)
+
+
+SCOPE = PlanningScope(
+    repo="hamanpaul/paulsha-cortex",
+    work_id="unified-work-lifecycle",
+    source_revision="tree:0123456789abcdef",
+)
+
+INCOMPLETE_SPEC = """\
+---
+status: draft
+---
+# Feature specification
+
+## Requirements
+
+BLOCKING: 尚未決定。
+"""
+
+
+def _registry() -> IdentityRegistry:
+    """三個候選、三個 domain：codex 與 primary 同 domain，agy／claude 異質。"""
+
+    return IdentityRegistry.from_rows(
+        [
+            {
+                "executor": "codex",
+                "model_id": "gpt-primary",
+                "independence_domain": "openai",
+                "capabilities": ["planning"],
+            },
+            {
+                "executor": "codex",
+                "model_id": "gpt-sibling",
+                "independence_domain": "openai",
+                "capabilities": ["planning"],
+            },
+            {
+                "executor": "agy",
+                "model_id": "gemini-3.1-pro-high",
+                "independence_domain": "google",
+                "capabilities": ["planning"],
+                "live_probe": "agy-plan-sandbox",
+            },
+            {
+                "executor": "claude",
+                "model_id": "claude-sonnet-4.6",
+                "independence_domain": "anthropic",
+                "capabilities": ["planning"],
+            },
+        ]
+    )
+
+
+FENCED_PROBE_STDOUT = (
+    '```json {"capability":"cortex-plan-sandbox","model":"gemini-3.1-pro-high", '
+    '"note":"模型多寫了一段散文所以 json.loads 失敗"} ```'
+)
+
+
+def _probes(*, agy_reason: str, agy_diagnostic: str) -> dict:
+    return {
+        ("agy", "gemini-3.1-pro-high"): CapabilityProbe(
+            False, "agy", "gemini-3.1-pro-high", "google", agy_reason, agy_diagnostic
+        ),
+        ("claude", "claude-sonnet-4.6"): CapabilityProbe(
+            False,
+            "claude",
+            "claude-sonnet-4.6",
+            "anthropic",
+            "safe-probe-failed",
+            "FileNotFoundError",
+        ),
+    }
+
+
+def _brainstorm(tmp_path: Path, probes) -> object:
+    report = assess_planning_completeness(
+        [PlanningArtifact(kind="spec", ref="docs/spec.md", text=INCOMPLETE_SPEC)]
+    )
+    assert report.complete is False
+    return run_heterogeneous_brainstorm(
+        report=report,
+        primary=("codex", "gpt-primary"),
+        registry=_registry(),
+        probes=probes,
+        evidence_dir=tmp_path,
+        artifact_root=tmp_path,
+        scope=SCOPE,
+        primary_questioner=lambda _: report.default_question_pack.to_dict(),
+        secondary_planner=lambda *_: {},
+        primary_integrator=lambda *_: {},
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. 逐候選拒因表
+# ---------------------------------------------------------------------------
+
+
+def test_no_heterogeneous_planner_reason_carries_per_candidate_rejections(
+    tmp_path: Path,
+) -> None:
+    """三個候選、三種落選理由，全部逐條出現在 blocking reason 裡。
+
+    這就是「讓誤報不可能」的機制本身：格式問題與拓撲問題在同一個字串裡是
+    兩個不同的欄位，讀的人不需要重跑六遍才發現。
+    """
+
+    result = _brainstorm(
+        tmp_path,
+        _probes(agy_reason="malformed-output", agy_diagnostic=FENCED_PROBE_STDOUT),
+    )
+
+    assert result.state == "needs_human"
+    matched = REJECTION_TABLE_RE.match(result.reason)
+    assert matched is not None, result.reason
+
+    entries = REJECTION_ENTRY_RE.findall(matched.group("table"))
+    by_executor = {entry[0]: entry for entry in entries}
+    # 三個候選都在（primary 自己不算候選，不佔一條無資訊的 same-domain）。
+    assert set(by_executor) == {"agy", "claude", "codex"}
+    assert int(matched.group("count")) == 3
+
+    assert by_executor["agy"][3] == REJECTION_PROBE_NOT_READY
+    assert by_executor["claude"][3] == REJECTION_PROBE_NOT_READY
+    assert by_executor["codex"][3] == REJECTION_SAME_DOMAIN
+    # 同 domain 的手足是 `gpt-sibling`，不是 primary 自己。
+    assert by_executor["codex"][1] == "gpt-sibling"
+
+    # 三分的族名要逐條在列，`malformed-output`（格式）與 `safe-probe-failed`
+    # 走 FileNotFoundError（executor 起不來）不得被壓成同一種東西。
+    assert PLANNING_FAILURE_OUTPUT in result.reason
+    assert PLANNING_FAILURE_EXECUTOR in result.reason
+    assert "malformed-output" in result.reason
+    assert "safe-probe-failed" in result.reason
+
+
+def test_probe_diagnostic_survives_into_blocking_reason(tmp_path: Path) -> None:
+    """PR #674 的 stdout 節錄必須端到端活著抵達 blocking reason。
+
+    #674 讓 `probe_agy_capability` 失敗時帶 stdout 節錄，但那份節錄過去在
+    `select_secondary_planner` 就被 `continue` 吃掉。這條測試釘住兩票的接縫。
+    """
+
+    result = _brainstorm(
+        tmp_path,
+        _probes(agy_reason="malformed-output", agy_diagnostic=FENCED_PROBE_STDOUT),
+    )
+
+    # 節錄的可辨識前綴（code fence ＋ JSON 開頭）必須逐字在 reason 裡。
+    assert '```json {"capability":"cortex-plan-sandbox"' in result.reason
+
+
+def test_probe_diagnostic_survives_from_real_agy_probe(tmp_path: Path) -> None:
+    """接縫的另一半：節錄真的由 `probe_agy_capability` 產生時也活得到終點。
+
+    不自造 diagnostic 字串，改用 #674 的真實產生路徑（`stdout_excerpt`），
+    確認中間沒有任何一層把它壓掉。
+    """
+
+    raw = '```json\n{"capability":"cortex-plan-sandbox","model":"gemini-3.1-pro-high"}\n```extra'
+
+    class _Completed:
+        def __init__(self, returncode: int, stdout: str, stderr: str = "") -> None:
+            self.returncode = returncode
+            self.stdout = stdout
+            self.stderr = stderr
+
+    responses = iter(
+        [_Completed(0, "gemini-3.1-pro-high\n"), _Completed(0, raw)]
+    )
+    probe = probe_agy_capability(runner=lambda *a, **k: next(responses))
+    assert probe.ready is False
+    assert probe.reason == "malformed-output"
+    assert probe.diagnostic
+
+    result = _brainstorm(
+        tmp_path,
+        {
+            ("agy", "gemini-3.1-pro-high"): probe,
+            ("claude", "claude-sonnet-4.6"): CapabilityProbe(
+                False,
+                "claude",
+                "claude-sonnet-4.6",
+                "anthropic",
+                "safe-probe-failed",
+                "FileNotFoundError",
+            ),
+        },
+    )
+    assert probe.diagnostic in result.reason
+
+
+def test_probe_absent_and_identity_mismatch_are_named_separately(tmp_path: Path) -> None:
+    """probe 缺席與 probe 身分不符是兩件事，不得共用一個拒因。"""
+
+    result = _brainstorm(
+        tmp_path,
+        {
+            # agy 完全沒被 probe 過。
+            ("claude", "claude-sonnet-4.6"): CapabilityProbe.ready_for(
+                "claude", "claude-sonnet-4.6", "openai"
+            ),
+        },
+    )
+    assert REJECTION_PROBE_ABSENT in result.reason
+    assert REJECTION_PROBE_IDENTITY_MISMATCH in result.reason
+
+
+# ---------------------------------------------------------------------------
+# 2. 分類改判
+# ---------------------------------------------------------------------------
+
+
+def test_environment_grade_rejection_reclassifies_to_environment(tmp_path: Path) -> None:
+    """拒因表含 environment 級拒因 ⇒ `_classify_planning_failure` 回 environment。
+
+    今天 `no-heterogeneous-planner` 一律落 `content`，而 `content` 在
+    `_resume_decision` 一律不浮現 `recover-planning`，等於一條死路。
+    """
+
+    result = _brainstorm(
+        tmp_path,
+        _probes(agy_reason="models-probe-failed", agy_diagnostic="exit-code:1"),
+    )
+    assert manager._classify_planning_failure(result.reason) == "environment"
+    assert REJECTION_TABLE_RE.match(result.reason).group("grade") == "environment"
+
+
+def test_content_grade_rejections_stay_content(tmp_path: Path) -> None:
+    """全部拒因都是拓撲／格式級 ⇒ 仍是 content（反向誤報同樣不可接受）。"""
+
+    result = _brainstorm(
+        tmp_path,
+        _probes(agy_reason="malformed-output", agy_diagnostic="not-json"),
+    )
+    # claude 側改成內容級失敗，讓整張表沒有任何 environment 拒因。
+    content_only = _brainstorm(
+        tmp_path,
+        {
+            ("agy", "gemini-3.1-pro-high"): CapabilityProbe(
+                False, "agy", "gemini-3.1-pro-high", "google", "malformed-output", "not-json"
+            ),
+            ("claude", "claude-sonnet-4.6"): CapabilityProbe(
+                False,
+                "claude",
+                "claude-sonnet-4.6",
+                "anthropic",
+                "identity-mismatch",
+                "",
+            ),
+        },
+    )
+    assert REJECTION_TABLE_RE.match(content_only.reason).group("grade") == "content"
+    assert manager._classify_planning_failure(content_only.reason) == "content"
+    # 第一個（claude 走 FileNotFoundError）本來就是 environment，兩者不同。
+    assert manager._classify_planning_failure(result.reason) == "environment"
+
+
+def test_all_same_domain_rejections_stay_content(tmp_path: Path) -> None:
+    """純拓撲（全部同 domain）⇒ content，不得被誤報成環境問題。"""
+
+    registry = IdentityRegistry.from_rows(
+        [
+            {
+                "executor": "codex",
+                "model_id": "gpt-primary",
+                "independence_domain": "openai",
+                "capabilities": ["planning"],
+            },
+            {
+                "executor": "codex",
+                "model_id": "gpt-sibling",
+                "independence_domain": "openai",
+                "capabilities": ["planning"],
+            },
+        ]
+    )
+    selection = select_secondary_planner(
+        registry=registry, primary=("codex", "gpt-primary"), probes={}
+    )
+    assert selection.reason == "no-heterogeneous-planner"
+    assert [rejection.reason for rejection in selection.rejections] == [REJECTION_SAME_DOMAIN]
+    rendered = render_secondary_rejection_reason(selection.reason, selection.rejections)
+    assert REJECTION_TABLE_RE.match(rendered).group("grade") == "content"
+    assert manager._classify_planning_failure(rendered) == "content"
+
+
+def test_environment_grade_marker_is_anchored_and_not_spoofable_by_model_output() -> None:
+    """grade 標記錨在字串開頭，模型輸出把族名寫進 stdout 也騙不到分類器。
+
+    拒因表的 detail 帶的是**模型回應**。若分類器改用 substring-search
+    `planning-executor-failed`，一個回「planning-executor-failed」的模型就能
+    把 content 失敗偽裝成 environment。
+    """
+
+    spoof = CandidateRejection(
+        executor="agy",
+        model_id="gemini-3.1-pro-high",
+        domain="google",
+        reason=REJECTION_PROBE_NOT_READY,
+        diagnostic=f"malformed-output {PLANNING_FAILURE_EXECUTOR} {PLANNING_FAILURE_JOB_START}",
+        family=PLANNING_FAILURE_OUTPUT,
+    )
+    rendered = render_secondary_rejection_reason("no-heterogeneous-planner", (spoof,))
+    assert PLANNING_FAILURE_EXECUTOR in rendered  # 字面確實出現在 detail 裡
+    assert is_environment_grade_rejection_reason(rendered) is False
+    assert manager._classify_planning_failure(rendered) == "content"
+
+
+def test_unrelated_reasons_are_not_environment_graded() -> None:
+    for reason in (
+        None,
+        "",
+        "no-heterogeneous-planner",
+        "question-pack-malformed: RuntimeError: boom",
+        "…tail grade=environment candidates=1 (agy/x[google]: probe-absent)",
+    ):
+        assert is_environment_grade_rejection_reason(reason) is False
+
+
+# ---------------------------------------------------------------------------
+# 3. 三分的族名與判準
+# ---------------------------------------------------------------------------
+
+
+def test_named_failure_families_exist_and_grade_boundary_is_explicit() -> None:
+    """三分的具名常數先定義好（票 C／票 E 才有東西可落），且分級邊界明確。"""
+
+    assert PLANNING_FAILURE_JOB_START == "planning-job-start-failed"
+    assert PLANNING_FAILURE_EXECUTOR == "planning-executor-failed"
+    assert PLANNING_FAILURE_OUTPUT == "planning-output-malformed"
+    assert PLANNING_FAILURE_EXECUTOR_SILENT_EXIT == "executor-silent-exit"
+    assert ENVIRONMENT_GRADE_PLANNING_FAMILIES == frozenset(
+        {PLANNING_FAILURE_JOB_START, PLANNING_FAILURE_EXECUTOR}
+    )
+    # 未知 probe 失敗一律 fail-closed 落 content，不擅自宣稱是環境問題。
+    assert PLANNING_FAILURE_UNCLASSIFIED not in ENVIRONMENT_GRADE_PLANNING_FAMILIES
+
+
+@pytest.mark.parametrize(
+    ("probe_reason", "diagnostic", "family"),
+    [
+        ("models-probe-failed", "exit-code:1", PLANNING_FAILURE_EXECUTOR),
+        ("models-probe-failed", "FileNotFoundError", PLANNING_FAILURE_EXECUTOR),
+        ("smoke-failed", "exit-code:2", PLANNING_FAILURE_EXECUTOR),
+        ("model-not-listed", "expected='x' available=[]", PLANNING_FAILURE_OUTPUT),
+        ("malformed-output", "not-json", PLANNING_FAILURE_OUTPUT),
+        ("identity-mismatch", "", PLANNING_FAILURE_OUTPUT),
+        ("safe-probe-failed", "CalledProcessError", PLANNING_FAILURE_EXECUTOR),
+        ("safe-probe-failed", "TimeoutExpired", PLANNING_FAILURE_EXECUTOR),
+        ("safe-probe-failed", "FileNotFoundError", PLANNING_FAILURE_EXECUTOR),
+        ("safe-probe-failed", "ValueError", PLANNING_FAILURE_OUTPUT),
+        ("safe-probe-failed", "SomethingBrandNew", PLANNING_FAILURE_UNCLASSIFIED),
+        (PLANNING_FAILURE_JOB_START, "polkit-denied", PLANNING_FAILURE_JOB_START),
+        ("brand-new-probe-reason", "", PLANNING_FAILURE_UNCLASSIFIED),
+    ],
+)
+def test_probe_failure_family_mapping(probe_reason: str, diagnostic: str, family: str) -> None:
+    """probe 失敗 → 三分族的映射是一張明表，不是散落的 if。"""
+
+    from paulsha_cortex.coordinator.model_identities import classify_probe_failure
+
+    assert classify_probe_failure(probe_reason, diagnostic) == family
+
+
+def test_agy_probe_marks_silent_exit_subclass() -> None:
+    """rc≠0 且 stdout／stderr 皆空 ⇒ 具名 `executor-silent-exit`。
+
+    這是整個家族裡最難查的一種——連錯誤訊息都沒有，歸因會落到模型、prompt、
+    逾時或憑證，而不會落到執行環境。它必須被顯式命名。
+    """
+
+    class _Completed:
+        def __init__(self, returncode: int, stdout: str = "", stderr: str = "") -> None:
+            self.returncode = returncode
+            self.stdout = stdout
+            self.stderr = stderr
+
+    responses = iter([_Completed(0, "gemini-3.1-pro-high\n"), _Completed(1)])
+    probe = probe_agy_capability(runner=lambda *a, **k: next(responses))
+    assert probe.reason == "smoke-failed"
+    assert PLANNING_FAILURE_EXECUTOR_SILENT_EXIT in (probe.diagnostic or "")
+
+    # 有 stderr 就不是 silent。
+    noisy = iter([_Completed(0, "gemini-3.1-pro-high\n"), _Completed(2, "", "unsupported flag")])
+    probe = probe_agy_capability(runner=lambda *a, **k: next(noisy))
+    assert probe.reason == "smoke-failed"
+    assert PLANNING_FAILURE_EXECUTOR_SILENT_EXIT not in (probe.diagnostic or "")
+
+
+# ---------------------------------------------------------------------------
+# 4. 截斷策略：長度有上限，但「哪一條被截掉」不得變成不可知
+# ---------------------------------------------------------------------------
+
+
+def test_rejection_table_never_drops_a_candidate_row() -> None:
+    """五個候選、每個都帶超長 diagnostic：列數與身分一條不少。"""
+
+    rejections = tuple(
+        CandidateRejection(
+            executor=f"exec{index}",
+            model_id=f"model-{index}",
+            domain=f"domain-{index}",
+            reason=REJECTION_PROBE_NOT_READY,
+            diagnostic="x" * 4000,
+            family=PLANNING_FAILURE_OUTPUT,
+        )
+        for index in range(5)
+    )
+    rendered = render_secondary_rejection_reason("no-heterogeneous-planner", rejections)
+    matched = REJECTION_TABLE_RE.match(rendered)
+    assert matched is not None
+    assert int(matched.group("count")) == 5
+    for index in range(5):
+        assert f"exec{index}/model-{index}[domain-{index}]" in rendered
+    assert len(rendered) <= REJECTION_TABLE_TOTAL_LIMIT
+
+
+def test_truncation_accounts_for_every_elided_character() -> None:
+    """截掉多少字必須寫在原地——被截的是哪一條、少了多少，都看得見。"""
+
+    long_detail = "y" * 900
+    rejections = (
+        CandidateRejection(
+            executor="agy",
+            model_id="gemini-3.1-pro-high",
+            domain="google",
+            reason=REJECTION_PROBE_NOT_READY,
+            diagnostic=long_detail,
+            family=PLANNING_FAILURE_OUTPUT,
+        ),
+    )
+    rendered = render_secondary_rejection_reason("no-heterogeneous-planner", rejections)
+    kept = REJECTION_TABLE_DETAIL_LIMIT
+    assert f"…+{len(long_detail) - kept}c" in rendered
+    assert "y" * kept in rendered
+
+
+def test_over_budget_table_elides_detail_not_identity() -> None:
+    """總預算爆掉時先犧牲 detail（並記下犧牲了幾個字），絕不犧牲身分列。"""
+
+    rejections = tuple(
+        CandidateRejection(
+            executor=f"exec{index}",
+            model_id=f"model-{index}",
+            domain="domain",
+            reason=REJECTION_PROBE_NOT_READY,
+            diagnostic="z" * 1000,
+            family=PLANNING_FAILURE_EXECUTOR,
+        )
+        for index in range(20)
+    )
+    rendered = render_secondary_rejection_reason("no-heterogeneous-planner", rejections)
+    matched = REJECTION_TABLE_RE.match(rendered)
+    assert matched is not None
+    assert int(matched.group("count")) == 20
+    for index in range(20):
+        assert f"exec{index}/model-{index}[domain]" in rendered
+    assert "detail-elided:" in rendered
+
+
+def test_rendered_table_is_single_line() -> None:
+    """reason 會進單行 log／`DiagnosticReason.rendered()`，不得帶換行或控制字元。"""
+
+    rejections = (
+        CandidateRejection(
+            executor="agy",
+            model_id="gemini-3.1-pro-high",
+            domain="google",
+            reason=REJECTION_PROBE_NOT_READY,
+            diagnostic="line one\nline two\r\n\x1b[31mred\x1b[0m\ttab",
+            family=PLANNING_FAILURE_OUTPUT,
+        ),
+    )
+    rendered = render_secondary_rejection_reason("no-heterogeneous-planner", rejections)
+    assert "\n" not in rendered and "\r" not in rendered and "\t" not in rendered
+    assert "\x1b" not in rendered
+    assert "line one line two" in rendered
+
+
+def test_empty_rejection_table_leaves_reason_untouched() -> None:
+    """沒有任何候選時 `no-heterogeneous-planner` 是真話（roster 裡真的沒有別人），
+    reason 維持原字面值，不生出一張空表。"""
+
+    assert render_secondary_rejection_reason("no-heterogeneous-planner", ()) == (
+        "no-heterogeneous-planner"
+    )
+    assert render_secondary_rejection_reason(None, ()) is None
+
+
+# ---------------------------------------------------------------------------
+# 5. 機密：拒因表不得把憑證／token 帶進 log／evidence／blocking_reason
+# ---------------------------------------------------------------------------
+
+
+def test_rejection_table_carries_no_environment_or_argv_material(tmp_path: Path) -> None:
+    """拒因表的輸入只有 roster 常數 ＋ probe 的 reason／diagnostic。
+
+    `CandidateRejection` 沒有任何欄位接得到 env、argv、檔案內容或 stderr；
+    probe 的 diagnostic 側最寬的來源是模型 stdout 節錄（固定 probe prompt 的
+    回應）與例外**型別名**（`type(exc).__name__`，不含訊息），因此沒有把
+    token／憑證帶進去的路徑。這條測試把「欄位面沒有洩漏通道」釘成契約。
+    """
+
+    import dataclasses
+
+    fields = {field.name for field in dataclasses.fields(CandidateRejection)}
+    assert fields == {"executor", "model_id", "domain", "reason", "diagnostic", "family"}
+
+    secret = "sk-live-DEADBEEFdeadbeef"
+    result = _brainstorm(
+        tmp_path,
+        _probes(agy_reason="malformed-output", agy_diagnostic="not-json"),
+    )
+    assert secret not in result.reason
+    # roster 的三個欄位是常數，probe 兩欄是唯一的自由文字入口。
+    assert result.reason.count("grade=") == 1


### PR DESCRIPTION
Closes #682

母票 #672 的**票 A**（`docs/superpowers/plans/planner-job-downgrade.md` 第 1 節，PR #676 已定案）。
不依賴任何部署面改動，可獨立 land。

## 問題

`select_secondary_planner()`（`model_identities.py`）失敗時只回一個沒有任何附加資訊的
字面值 `no-heterogeneous-planner`——這個 reason **說謊**：它把三類結構上完全不同的失敗
壓成「拓撲問題」。迴圈裡四個 `continue`（同 domain／probe 缺席／probe 沒 ready／probe
身分不符）**全部靜默**，每個候選被跳過的真正理由在原地就被吃掉。

#670 就是這樣被誤診的：真因是 `agy models` 兩欄漂移造成 100% `model-not-listed`
＋ code fence 造成 parse 失敗，blocking reason 說的卻是「沒有異質 planner」，排查方向
整個帶偏，最後是人工重跑六遍才看出來。

## 修法

### 1. 錯誤語意三分（具名族 ＋ 單一明表）

新增 `PLANNING_FAILURE_JOB_START`／`PLANNING_FAILURE_EXECUTOR`／`PLANNING_FAILURE_OUTPUT`
＋ `executor-silent-exit` 子類，以及 `classify_probe_failure()` 的**一張明表**（散落的
`if` 是漂移的來源）。票 C（probe 快取）與票 E（`JobPlanningInvoker`）直接消費同一組常數。

**分類邊界怎麼定的**——判準是「這個失敗的資訊價值指向哪裡」，不是「它有多嚴重」：

| probe 失敗 | 族 | grade | 為什麼 |
|---|---|---|---|
| `models-probe-failed`（rc≠0／例外） | `planning-executor-failed` | environment | CLI 根本沒跑成功，#672 實測的沙箱／`ProtectSystem=strict` 死法落在這裡 |
| `smoke-failed`（rc≠0） | `planning-executor-failed` | environment | 同上，模型那一次呼叫非零退出 |
| `model-not-listed` | `planning-output-malformed` | content | **CLI 正常退出**、列表回來了，只是沒有我們要的 model（#670 的兩欄漂移）——這是 roster／輸出契約不符，重跑不會好 |
| `malformed-output` | `planning-output-malformed` | content | executor 正常退出、輸出 parse 不了 |
| `identity-mismatch` | `planning-output-malformed` | content | 輸出合法但內容不是我們問的那個身分 |
| `safe-probe-failed` + `CalledProcessError`／`TimeoutExpired`／`FileNotFoundError`／`PermissionError`／`OSError`… | `planning-executor-failed` | environment | `_probe_identity` 的 diagnostic 是 `type(exc).__name__`，那個型別名就是唯一能機械分辨「executor 死了」還是「輸出不合約」的線索 |
| `safe-probe-failed` + `ValueError`／`JSONDecodeError`／`TypeError`／`KeyError` | `planning-output-malformed` | content | JSON 抽取／驗證層拋的 |
| 其他／未知 | `planning-probe-unclassified` | content | **fail-closed** |

分界線是：**「CLI 有沒有成功跑完並產出東西」**。跑不起來／異常退出 ⇒ environment；
跑完了但東西不對 ⇒ content。`planning-output-malformed` 刻意**不**列為 environment——
把格式問題判成環境問題是 #670 的鏡像錯誤，反向誤報同樣不可接受。

未知一律落 `planning-probe-unclassified`（content）而不是猜一個族：把未知失敗當
environment 會讓 `recover-planning` 對著一個永遠不會自癒的失敗一直重試；當 content 則
最多多要一次人工判斷，而且「unclassified」這個字會直接印在拒因表上，新增 probe 失敗
原因時當場現形。

`executor-silent-exit` 子類（rc≠0 且 stdout／stderr 皆空）已在 `probe_agy_capability`
的兩處非零退出實際標記——**不是一個只定義不用的常數**。

### 2. 逐候選拒因表

`CandidateRejection` dataclass ＋ `SecondarySelection.rejections`，四個 `continue`
各記一筆。`SecondarySelection.reason` **刻意維持原字面值** `no-heterogeneous-planner`
——它是下游既有的機器判準與既有測試的斷言對象；拒因表走新欄位，而不是把那個字串改長。

`run_heterogeneous_brainstorm` 經 `render_secondary_rejection_reason()` 渲染進
`BrainstormResult.reason`：

```
no-heterogeneous-planner grade=environment candidates=4 (codex/gpt-5.3[openai]: same-domain;
agy/gemini-3.1-pro-high[google]: probe-not-ready planning-output-malformed malformed-output
```json {"capability":"cortex-plan-sandbox","model":"gemini-3.1-pro-high"} ```;
claude/claude-sonnet-4.6[anthropic]: probe-not-ready planning-executor-failed safe-probe-failed
FileNotFoundError; cg/glm-5.3[zhipu]: probe-identity-mismatch probe-reported=cg/glm-5.3/openai)
```

（上為實跑輸出，456 字元。）

**primary 自己不佔一條**：primary 也在 planning 名單裡，而它與自己當然同 domain；記一條
「primary 因為與 primary 同 domain 而落選」是零資訊的套套邏輯，只會讓每張表都以一條廢話
開頭。同 domain 的**其他**身分照記。副作用是「roster 裡真的只有 primary」時表為空、reason
維持原字面值——那個情境下 `no-heterogeneous-planner` 本來就是真話。

### 3. 分類改判（第四條 environment 例外）

`manager._classify_planning_failure()` 增
`_is_planning_candidate_rejection_environment_failure`，比照 #416／#533／#554 三條既有
例外的**同一個模式**（不新發明）：拒因表含 environment 級拒因 ⇒ 整體改判 `environment`
⇒ `_resume_decision` 得以浮現 `recover-planning`；全部是拓撲／格式級 ⇒ 仍是 `content`。

**判準不對整串 reason 做 substring-search。** 拒因表的 diagnostic 帶的是**模型輸出**；
若用 substring-search，一個回「planning-executor-failed」的模型就能把 content 失敗
偽裝成 environment。改成讀渲染端依 `family` 算好、且**錨在字串開頭**的 `grade=` 欄位
（`\A[a-z0-9-]+ grade=environment candidates=\d+ \(`）。這條有專門的測試釘住
（`test_environment_grade_marker_is_anchored_and_not_spoofable_by_model_output`）。

## 驗收

**(1) reason 可用正規表示式釘住必含拒因表** ✅

```python
REJECTION_TABLE_RE = re.compile(
    r"\Ano-heterogeneous-planner grade=(?P<grade>environment|content) "
    r"candidates=(?P<count>\d+) \((?P<table>.+)\)\Z"
)
REJECTION_ENTRY_RE = re.compile(
    r"(?P<executor>[a-z0-9_.-]+)/(?P<model_id>[^\[\]/]+)\[(?P<domain>[^\[\]]+)\]: "
    r"(?P<reason>same-domain|probe-absent|probe-not-ready|probe-identity-mismatch)"
)
```

**(2) 既有測試一行不改全綠** ✅

```
$ git diff --stat origin/main -- tests/
 tests/test_planning_failure_taxonomy_672.py | 486 ++++++++++++++++++++++++++++
```

只有新檔。`python3 -m pytest tests/ -q` → **4303 passed, 24 skipped, 49 subtests passed**。

這一條是本 PR 最大的設計約束：`tests/test_planning_completeness.py:500`、
`tests/test_model_identities.py:520`／`:620`、`tests/test_model_chain_profile_resolution.py:283`
四處逐字斷言 `reason == "no-heterogeneous-planner"`。因此拒因表**必須**走新欄位
（`SecondarySelection.rejections`）而不是改寫那個字串；而
`test_planning_completeness.py:500` 是唯一一個走真實 `run_heterogeneous_brainstorm`
的斷言，它的 roster 只有 primary 一個 identity——這正是「primary 自己不佔一條拒因」
這個決定的獨立驗證：那個情境下表為空、reason 不變，且該行為在語意上也是對的。

## 拒因表的截斷策略

**原則：截斷只犧牲 diagnostic，永遠不犧牲「有幾條、分別是誰、各自為什麼」。**

1. 每一條的**身分 ＋ 拒因 ＋ 族名**（`CandidateRejection.head()`）**永不被截斷、永不被
   整列丟棄**。表再長也答得出「有幾個候選、分別是誰、各自落在哪一族」。
2. `candidates=<N>` 是表外的一個獨立計數：讀的人可以拿它跟表裡實際的條數對照。
3. 只有 `diagnostic` 會被截。單條超過 `REJECTION_TABLE_DETAIL_LIMIT`（160）時**就地
   記帳** `…+Nc`——少了幾個字寫在原處。
4. 全表仍超過 `REJECTION_TABLE_TOTAL_LIMIT`（1200）時，從**最長的 diagnostic 開始**
   整格換成 `<detail-elided:Nc>`，同樣就地記帳；同長度時取索引小的，結果對輸入是決定性的。
   因此「被犧牲的是哪一條、犧牲了多少」永遠讀得出來。
5. 身分列本身就撐爆預算時（roster 大到病態）**寧可超出預算也不丟列**——丟列會讓拒因表
   失去它存在的唯一理由。

roster 五個 identity、每格 diagnostic 上限 160 時實測 456 字元，遠在預算內；上面 3、4
兩層是給未來 roster 變大／diagnostic 變寬用的。三條規則各有測試
（`test_rejection_table_never_drops_a_candidate_row`／
`test_truncation_accounts_for_every_elided_character`／
`test_over_budget_table_elides_detail_not_identity`）。

另外渲染時剝除 C0／C1 控制字元並單行化：reason 會進單行 log 與
`DiagnosticReason.rendered()`，模型輸出裡的 ANSI escape 或換行不得污染它。

## 機密：拒因表不會把憑證／token 帶進去

**怎麼確認的——欄位面 ＋ 產生點兩層窮舉，不是抽樣。**

**欄位面**：`CandidateRejection` 只有六個欄位，**沒有任何一個接得到 env、argv、檔案內容
或 stderr**。前三欄（`executor`／`model_id`／`domain`）是 roster 常數
（`model-identities.yaml`）；`reason` 是四個列舉值之一；`family` 是族名常數。唯一的自由
文字入口是 `diagnostic`。有測試把欄位集合本身釘成契約
（`test_rejection_table_carries_no_environment_or_argv_material`）。

**產生點**：`CapabilityProbe` 在整個 `paulsha_cortex/` 只有**三個**建構點
（`git grep -n "CapabilityProbe("` → `model_identities.py:718`、
`planning_runtime.py:961`／`:970`），對應**九個**帶 diagnostic 的產生器，全部列舉：

| 產生器 | diagnostic 內容 |
|---|---|
| `models-probe-failed` / `smoke-failed`（例外） | `type(exc).__name__`（**只有型別名，不含訊息**） |
| `models-probe-failed` / `smoke-failed`（rc≠0） | `exit-code:N`［＋`executor-silent-exit`］ |
| `model-not-listed` | `expected='<常數>' available=[...]`，後者是 `agy models` **stdout** 的 model id 行 |
| `malformed-output` / `identity-mismatch`（agy） | `stdout_excerpt(smoke_stdout)` |
| `safe-probe-failed`（`_probe_identity`） | `type(exc).__name__` |
| `identity-mismatch`（`_probe_identity`） | `None` |

三點確認：

1. **沒有一個產生器讀 stderr。** 這是刻意的——stderr 是最容易夾帶路徑、env 與憑證錯誤
   原文的通道。本 PR 新增的 `_exit_diagnostic()` 只讀 rc 與「stdout／stderr **是否為空**」
   兩件事，**不把 stderr 內容帶進 diagnostic**（docstring 已寫明理由）。
2. **例外一律只取 `type(exc).__name__`，不取 `str(exc)`。** 例外訊息會帶路徑與 env；
   型別名不會。既有程式碼本來就是這樣寫的，本 PR 維持並在
   `classify_probe_failure()` 的 docstring 把它記成一條**要繼續維持的邊界**（因為分類
   現在依賴它，未來若有人想「順手」把訊息加進去，會同時破壞這條安全性質）。
3. **模型 stdout 的風險面**：probe prompt 由 `model_identities.py` 寫死，只含
   `capability`／`model` 兩個常數；`argv`（`build_agy_argv`）不帶任何憑證；env 不會被
   回顯。因此模型沒有「知道 token 是什麼」的管道，也就沒有把它寫進回應的路徑。這與
   PR #674 對 `stdout_excerpt` 已寫下的同一份論證一致（本 PR 只是讓那段節錄多走一段路
   到 blocking reason，沒有擴大它的來源）。

`R-21`（tier: shareable 機密掃描）本機帶 PR 上下文 **pass**。

## #674 的 stdout 節錄端到端活著抵達 blocking reason——怎麼確認的

三層，最後一層不自造資料：

1. `CandidateRejection.from_probe()` 把 `probe.reason` 與 `probe.diagnostic` 併成
   `detail` 一起落表（過去這兩個值在 `continue` 那一行就沒了）。
2. `render_secondary_rejection_reason()` 只做單行化與長度記帳，**不做內容過濾**；
   `test_probe_diagnostic_survives_into_blocking_reason` 斷言節錄的可辨識前綴
   （```` ```json {"capability":"cortex-plan-sandbox" ````）逐字出現在
   `BrainstormResult.reason` 裡。
3. `test_probe_diagnostic_survives_from_real_agy_probe` **不自造 diagnostic 字串**：
   餵一段 fence 包住的 stdout 給真的 `probe_agy_capability(runner=…)`，拿它產出的
   `CapabilityProbe`（diagnostic 由 #674 的 `stdout_excerpt` 實際產生）直接送進
   `run_heterogeneous_brainstorm`，斷言 `probe.diagnostic in result.reason`。
   這條走的是 #674 → #682 的真實路徑，中間沒有任何一層把它壓掉。

順帶：`test_probe_diagnostic_survives_from_real_agy_probe` 用的 stdout 是
「fence ＋ 尾巴多一段」，`strip_code_fence` 刻意不救（#674 的既有語意），因此它同時
確認了「#674 救不回來的那一半」現在至少**看得見原因**——這正是兩票分工的接縫。

## 變更

- `paulsha_cortex/coordinator/model_identities.py`：三分族常數、`classify_probe_failure()`、
  `_exit_diagnostic()`、`CandidateRejection`、`SecondarySelection.rejections`、
  `render_secondary_rejection_reason()`／`rejection_table_grade()`／
  `is_environment_grade_rejection_reason()`、四個 `continue` 各記一筆拒因。
- `paulsha_cortex/coordinator/planning.py`：`run_heterogeneous_brainstorm` 渲染拒因表。
- `paulsha_cortex/coordinator/manager.py`：`_classify_planning_failure` 第四條 environment 例外。
- `tests/test_planning_failure_taxonomy_672.py`：30 條新測試（含 plan 指定的四條 RED）。
- `docs/superpowers/plans/planner-job-downgrade.md`：票 A 勾完 ＋ 記兩處實作面收斂
  （`family` 欄位、primary 不佔一條），供後續票沿用。
- `changelog.d/682-planner-rejection-table.md`、`CHANGELOG.md [Unreleased]`。

## 本票不做

- 不動 `planning_runtime.py` 的執行路徑（票 B `PlanningInvoker` 抽象）。
- 不做 probe 快取（票 C）、不動 permgen／憑證（票 D）、不上 job runner（票 E）。
- `planning-job-start-failed` 目前只有常數與映射、還沒有產生點——那是票 E 的工作，
  plan 明列「先定義，票 C／E 才有東西可落」。
- 不碰部署、不改 unit、不跑任何會改變 `/var/lib/cortex` 狀態的指令。

## 檢查清單

- [x] 分支 `feature/682-planner-rejection-table`，未 commit 到 `main`
- [x] `changelog.d/682-planner-rejection-table.md` 已新增且**已 commit**
- [x] `CHANGELOG.md [Unreleased]` 有對應 entry
- [x] `python3 -m pytest tests/ -q` 全綠（4303 passed / 24 skipped / 49 subtests）
- [x] `openspec validate --specs` → 16 passed, 0 failed
- [x] 帶 PR 上下文的 `policy_check` → **pass: 25 / fail: 0 / warn: 1**（R-22 為 71 條
      **陳年** dangling reference，非本 PR 造成，屬 advisory）
- [x] `git diff --check` 乾淨
- [x] 既有測試**一行未改**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E7w9kaUxAzCCEk7piD5hfK
