### PR TITLE
refactor(planner): PlanningInvoker 抽象，行為零改變（#683／#672 票 B）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,45 @@
   一節。測試 `tests/test_job_path_fail_closed_679.py`；OS 層語意以具名
   `@pytest.mark.skip` ＋ 完整理由標示，不靜默通過。
 
+### Changed
+- **#683（#672 票 B）：planning 的執行方式抽象成 `PlanningInvoker`——純重構、行為零改變**
+  ——修法前 `planning_runtime._invoke_json()` 把三件事揉在同一支函式裡：**怎麼跑一個
+  executor**（一次性 sandbox、`cwd`、hermetic env、逾時、雙向樹快照、drift 收容）、
+  **跑之前準備什麼**（prompt 組裝）、**跑完之後怎麼解讀**（JSON 抽取與 CLI envelope 處理）。
+  票 E（#686）要把第一件事換成降權 job、第二／第三件事逐字不變——沒有接縫時那次改動只能
+  變成 `_invoke_json` 裡的 `if degraded:`，於是「design D2 的十條防線各自在哪個模式下生效」
+  變成要靠讀 `if` 才知道，而四個 adapter 與 probe 共用同一支函式，等於每個呼叫端都要重新
+  論證一次自己走的是哪條路（design D1）。本票只交付接縫：新增
+  `PlanningInvocation`／`PlanningOutcome`／`PlanningInvoker` 三個型別；
+  `InProcessPlanningInvoker` 收下「**怎麼跑**」的全部——D2 十條防線（D-a 一次性 tempdir、
+  D-b sandbox 複本、D-c `cwd=sandbox`、D-d sandbox 弄髒即 fail-closed、D-e operator 樹雙向
+  快照、D-f drift 唯讀收容、D-g claude hermetic `CLAUDE_CONFIG_DIR`、D-h `subprocess` 逾時、
+  D-i `capture_output`、D-j codex `-o` 第二輸出候選）逐字搬入，一行邏輯未改；呼叫端只留
+  prompt 組裝、rc 判定與 JSON 抽取，而 **JSON 抽取刻意留在共用層**
+  （`_extract_json_candidates`），兩個 invoker 吃同一份 envelope 處理與 fail-closed 判準
+  ——本 repo 已在 #401／#516／#520 買過三次「同一件事兩份真相」的單。**選擇點只有一個**：
+  `_select_planning_invoker(env)` 唯一輸入是 `PSC_JOB_RUNNER`，與 launcher 共用
+  `job_runner.resolve_runner_mode()`；**刻意不新增 `PSC_PLANNING_INVOKER` 之類的第二個
+  開關**——第二個開關的失效模式是「以為降權了、其實沒有」，而那種失敗看起來是成功的。
+  票 B 尚無第二個實作，三種模式目前全部回 in-process，這正是「行為零改變」的意思。
+  四個 adapter 與 `_probe_identity` 全部改走 `invoker.run()`；`probe_agy_capability()`
+  過去直接吃裸 `runner`、**繞過 `_invoke_json` 的全部防線**，現改吃
+  `invoker.capability_probe_runner()`——它不是 prompt 呼叫而是兩步 CLI 協定
+  （`agy models` ＋ smoke），協定的真相留在 `model_identities`（複製一份就是第二份真相），
+  invoker 只交出執行接縫，**兩次 CLI 呼叫各算一次 invocation**；direct 模式下該接縫就是
+  底層 runner 本身，行為逐字不變。`subprocess.run` 在 `planning_runtime.py` 內因此**只剩
+  `InProcessPlanningInvoker` 一處**（issue #683 驗收第二條，由 AST 測試機械釘住）。
+  **唯一刻意的行為差異**（design D1 明文要求）：daemon 路徑（不注入 `runner`／`invoker`）
+  現在會在建構 planning runtime 時解析 `PSC_JOB_RUNNER`，非法值 fail-closed 成
+  `JobRunnerError`；launcher 早已對同一個值 fail-closed，因此不會產生新的「本來能跑、
+  現在不能跑」的部署，`manager` 端會把它記成 `planning-runtime-initialization-failed`
+  （`environment` 級）。兩個精確度細節：`-o last.json` 的讀取條件與修法前逐字相同（只在
+  rc==0 且 stdout 是字串時才讀），否則失敗路徑上的讀取錯誤會換掉例外型別，而例外**型別名**
+  正是 `_probe_identity` 的 `safe-probe-failed` diagnostic 唯一內容、也是票 A
+  `classify_probe_failure()` 的分類輸入；`invoker` 與 `runner` 兩個注入口互斥，fail-closed。
+  測試 `tests/test_planning_invoker_672.py`；**既有 planning／probe 測試一行未改、全數綠燈**
+  ——那就是「純重構」的定義，也是本票行為零改變的主要證據。
+
 ### Added
 - **#672：planner 降權的設計交付（spec ＋ design ＋ 實作切分計畫，零 code）**——planning
   （define／brainstorm）從來沒有被降權：`planning_runtime.py:830` `_invoke_json()` 以

--- a/changelog.d/683-planning-invoker.md
+++ b/changelog.d/683-planning-invoker.md
@@ -1,0 +1,47 @@
+# 683-planning-invoker
+
+- **#683（#672 票 B）：planning 的執行方式抽象成 `PlanningInvoker`——純重構、行為零改變**
+  ——修法前 `planning_runtime._invoke_json()` 把三件事揉在同一支函式裡：**怎麼跑一個
+  executor**（一次性 sandbox、`cwd`、hermetic env、逾時、雙向樹快照、drift 收容）、
+  **跑之前準備什麼**（prompt 組裝）、**跑完之後怎麼解讀**（JSON 抽取與 CLI envelope 處理）。
+  票 E（#686）要把第一件事換成降權 job、第二／第三件事逐字不變——沒有接縫時那次改動只能
+  變成 `_invoke_json` 裡的 `if degraded:`，於是「D2 的十條防線各自在哪個模式下生效」變成
+  要靠讀 `if` 才知道，而四個 adapter 與 probe 共用同一支函式，等於每個呼叫端都要重新論證
+  一次自己走的是哪條路（design D1）。本票只交付接縫：
+  - **新增介面**：`PlanningInvocation`（identity／prompt／purpose／timeout／worktree／
+    evidence_root／run_id）、`PlanningOutcome`（returncode／stdout／stderr／output_text／
+    diagnostics）、`PlanningInvoker` Protocol。
+  - **切面**：`InProcessPlanningInvoker` 收下「**怎麼跑**」的全部——D2 的十條防線
+    （D-a 一次性 tempdir、D-b sandbox 複本、D-c `cwd=sandbox`、D-d sandbox 弄髒即
+    fail-closed、D-e operator 樹雙向快照、D-f drift 唯讀收容、D-g claude hermetic
+    `CLAUDE_CONFIG_DIR`、D-h `subprocess` 逾時、D-i `capture_output`、D-j codex `-o`
+    第二輸出候選）逐字搬入，一行邏輯未改。呼叫端只留「**跑之前跑之後**」：prompt 組裝、
+    rc 判定、JSON 抽取。**JSON 抽取刻意留在共用層**（`_extract_json_candidates`），
+    兩個 invoker 吃同一份 envelope 處理與 fail-closed 判準——本 repo 已在 #401／#516／
+    #520 買過三次「同一件事兩份真相」的單。
+  - **選擇點只有一個**：`_select_planning_invoker(env)` 唯一輸入是 `PSC_JOB_RUNNER`，
+    與 launcher 共用 `job_runner.resolve_runner_mode()`（非法值在該函式已 fail-closed）。
+    **刻意不新增 `PSC_PLANNING_INVOKER` 之類的第二個開關**——第二個開關的失效模式是
+    「以為降權了、其實沒有」，而那種失敗看起來是成功的。票 B 尚無第二個實作，因此三種
+    模式目前全部回 in-process，這正是「行為零改變」的意思。
+  - **全部呼叫端改走接縫**：四個 adapter（`invoke_primary`／`questioner`／`secondary`／
+    `integrator`）與 `_probe_identity` 走 `invoker.run()`；`probe_agy_capability()`
+    過去直接吃裸 `runner`、**繞過 `_invoke_json` 的全部防線**，現改吃
+    `invoker.capability_probe_runner()`——它不是 prompt 呼叫而是兩步 CLI 協定
+    （`agy models` ＋ smoke），協定本身的真相留在 `model_identities`（複製一份就是第二份
+    真相），invoker 只交出執行接縫，**兩次 CLI 呼叫各算一次 invocation**。direct 模式下
+    該接縫就是底層 runner 本身，行為逐字不變。
+  - **`subprocess.run` 在 `planning_runtime.py` 內只剩 `InProcessPlanningInvoker`
+    一處**（issue #683 驗收第二條，由 AST 測試機械釘住）。
+  - **唯一刻意的行為差異**（design D1 明文要求）：daemon 路徑（不注入 `runner`／`invoker`）
+    現在會在建構 planning runtime 時解析 `PSC_JOB_RUNNER`，非法值 fail-closed 成
+    `JobRunnerError`。launcher 早已對同一個值 fail-closed，因此不會產生新的
+    「本來能跑、現在不能跑」的部署；`manager` 端會把它記成
+    `planning-runtime-initialization-failed`（`environment` 級）。
+  - 兩個精確度細節：`-o last.json` 的讀取條件與修法前逐字相同（只在 rc==0 且 stdout 是
+    字串時才讀），否則失敗路徑上的讀取錯誤會換掉例外型別，而例外**型別名**正是
+    `_probe_identity` 的 `safe-probe-failed` diagnostic 唯一內容、也是票 A
+    `classify_probe_failure()` 的分類輸入；`invoker` 與 `runner` 兩個注入口互斥
+    （同時給等於同一件事有兩份真相），fail-closed。
+  - 測試 `tests/test_planning_invoker_672.py`（5 條）；**既有 planning／probe 測試一行
+    未改、全數綠燈**——那就是「純重構」的定義，也是本票行為零改變的主要證據。

--- a/docs/superpowers/plans/planner-job-downgrade.md
+++ b/docs/superpowers/plans/planner-job-downgrade.md
@@ -94,7 +94,9 @@ blocking reason——兩者剛好接得起來，缺任何一半都還是查不�
 
 ### 2. 票 B｜`PlanningInvoker` 抽象（對應 R1 的結構面，**純重構、行為零改變**）
 
-- [ ] `tests/test_planning_invoker_672.py`（TDD RED）：
+**已由 issue #683 land。**
+
+- [x] `tests/test_planning_invoker_672.py`（TDD RED）：
   - `test_in_process_invoker_preserves_sandbox_contract`：sandbox 被弄髒仍拋
     `planning launcher modified disposable read-only sandbox`。
   - `test_in_process_invoker_preserves_operator_drift_containment`：operator 樹 drift
@@ -102,17 +104,39 @@ blocking reason——兩者剛好接得起來，缺任何一半都還是查不�
     （那是下游分類契約）。
   - `test_invoker_selection_follows_resolve_runner_mode`：`PSC_JOB_RUNNER` 的值是**唯一**
     輸入；非法值 fail-closed；不存在第二個開關。
-- [ ] `paulsha_cortex/coordinator/planning_runtime.py`：抽出 `PlanningInvocation`／
+- [x] `paulsha_cortex/coordinator/planning_runtime.py`：抽出 `PlanningInvocation`／
       `PlanningInvoker`／`PlanningOutcome`；把現行 `_invoke_json` 的執行段搬進
       `InProcessPlanningInvoker`；JSON 抽取（`_extract_json`／`_find_json_object`／
       envelope 處理）留在共用層。
-- [ ] `build_production_planning_runtime()` 接受 `invoker` 參數（預設由
+- [x] `build_production_planning_runtime()` 接受 `invoker` 參數（預設由
       `resolve_runner_mode` 決定），四個 adapter 與 `_probe_identity` 全部改走它。
-- [ ] `probe_agy_capability()` 目前直接吃 `runner`（＝`subprocess.run`）且**繞過**
+- [x] `probe_agy_capability()` 目前直接吃 `runner`（＝`subprocess.run`）且**繞過**
       `_invoke_json` 的全部防線——把它一併改走 invoker，兩次 CLI 呼叫各算一次 invocation。
 - 驗收：既有 planning／probe 測試**一行不改**全綠（這就是「行為零改變」的定義）；
   `git grep -n "subprocess.run" paulsha_cortex/coordinator/planning_runtime.py` 只剩
   `InProcessPlanningInvoker` 內部一處。
+
+**#683 的實作補充**（design D1 之外的三處收斂，票 E 沿用）：
+
+1. **`probe_agy_capability` 的接縫形狀與 `run()` 不同，是刻意的。** agy 的能力探測不是
+   「一個 prompt」，而是一段**兩步 CLI 協定**（`agy models` 列出 model id → 拿解析到的
+   token 跑 smoke）。那段協定的真相在 `model_identities.probe_agy_capability`，把它複製
+   一份到 `planning_runtime` 就是第二份真相。因此 invoker 多一個
+   `capability_probe_runner() -> ProcessRunner` 方法，讓既有 probe 原樣消費；
+   direct 模式下它就是底層 runner 本身（行為逐字不變），票 E 在這裡回傳的是
+   「一個 argv → 一個降權 job」的閉包，**兩次 CLI 呼叫各算一次 invocation**。
+2. **`PlanningInvocation` 是 frozen dataclass，不是 Protocol。** design 的示意寫成
+   `class PlanningInvocation(Protocol)`，但它是呼叫端**建構**的值物件，不是呼叫端要
+   實作的介面；`PlanningInvoker` 才是 Protocol。欄位另比 design 多三個
+   （`worktree`／`evidence_root`／`run_id`）——前者是 in-process 的 sandbox 來源，
+   後兩者對 in-process 是 drift 報告落點、對票 E 是 D9 instance 命名的來源。
+3. **唯一刻意的行為差異**：daemon 路徑（不注入 `runner`／`invoker`）現在會在建構
+   planning runtime 時解析 `PSC_JOB_RUNNER`，非法值 fail-closed。design D1 明文要求
+   選擇點走 `resolve_runner_mode`，而該函式對非法值本來就 raise；launcher 早已對同一個
+   值 fail-closed，因此不會產生新的「本來能跑、現在不能跑」的部署。
+   `PlanningOutcome.diagnostics` 本票不產出任何內容（direct 模式沒有第二個資訊來源），
+   欄位先立在型別上，讓票 E 的 D8（`unit`／`hardening_profile`／`resolved_binary`）
+   不必再改一次 outcome 形狀。
 
 ### 3. 票 C｜probe 結果快取（對應 R3；依賴票 A 的診斷欄位、票 B 的 invoker）
 

--- a/paulsha_cortex/coordinator/planning_runtime.py
+++ b/paulsha_cortex/coordinator/planning_runtime.py
@@ -10,12 +10,13 @@ import stat
 import subprocess
 import tempfile
 from datetime import datetime, timezone
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from pathlib import PurePosixPath
-from typing import Callable, Mapping
+from typing import Callable, Mapping, Protocol
 from uuid import uuid4
 
+from . import job_runner
 from .launcher import build_agy_argv
 from .model_identities import (
     AGY_MODEL_ID,
@@ -756,9 +757,31 @@ def _find_json_object(text: str, *, allow_partial: bool = False) -> object | Non
 
 
 def _extract_json(stdout: str, output_path: Path) -> object:
+    """就地讀取第二輸出候選（codex 的 `-o last.json`）後交給共用抽取層。
+
+    issue #683：抽取本身移到 `_extract_json_candidates`，因為降權之後
+    「第二候選是哪來的」由 invoker 決定（in-process 是 tempdir 裡的檔案，
+    job 模式下 Manager 讀不到 job-owned scratch，只剩 stdout——design D-j 的
+    退步）。本函式維持既有簽章，供直接持有 `output_path` 的呼叫端使用。
+    """
+
+    output_text = (
+        output_path.read_text(encoding="utf-8") if output_path.is_file() else None
+    )
+    return _extract_json_candidates(stdout, output_text)
+
+
+def _extract_json_candidates(stdout: str, output_text: str | None) -> object:
+    """兩個候選（第二輸出優先、再 stdout）→ 模型輸出本體。
+
+    JSON 抽取刻意**留在共用層**、不進 invoker：兩個 invoker 吃同一份
+    envelope 處理與 fail-closed 判準（design D1）。本 repo 已經在 #401／#516／
+    #520 買過三次「同一件事兩份真相」的單。
+    """
+
     candidates = [stdout.strip()]
-    if output_path.is_file():
-        candidates.insert(0, output_path.read_text(encoding="utf-8").strip())
+    if output_text is not None:
+        candidates.insert(0, output_text.strip())
     for candidate in candidates:
         value = _find_json_object(candidate)
         if not isinstance(value, dict):
@@ -827,114 +850,301 @@ def _seed_hermetic_claude_env(temp_dir: str) -> dict[str, str] | None:
     return {**os.environ, "CLAUDE_CONFIG_DIR": str(config_dir)}
 
 
+# ---------------------------------------------------------------------------
+# issue #683（#672 票 B）：`PlanningInvoker` 抽象
+#
+# 修法前 `_invoke_json` 把三件事揉在一起：**怎麼跑一個 executor**（sandbox、
+# cwd、env、逾時、雙向快照、drift 收容）、**跑之前準備什麼**（prompt）、
+# **跑完之後怎麼解讀**（JSON 抽取）。票 E（#686）要把第一件事換成降權 job，
+# 而第二／第三件事逐字不變——沒有接縫時那次改動會落在同一支函式裡，變成
+# `if degraded:` 分岔，於是「哪幾條防線在哪個模式下生效」只能靠讀 `if` 才知道
+# （design D1）。
+#
+# 切面因此切在「拿 identity ＋ prompt，回傳 stdout／stderr／rc」這一層：
+#
+#   進 invoker（＝**怎麼跑**）：一次性 sandbox、`cwd`、hermetic claude env、
+#     逾時、以及**執行前後的雙向快照與 drift 收容**——後者看似屬於呼叫端，
+#     但它們的作用對象（sandbox 與 operator 樹的關係）完全由「怎麼跑」決定：
+#     job 模式下 operator 樹由 `ProtectSystem=strict` 在 kernel 層擋掉（D-e
+#     從偵測升級為阻擋），那時這幾條就**不該**再由呼叫端執行一次。
+#   留呼叫端（＝**跑之前跑之後**）：prompt 組裝、rc 判定、JSON 抽取與 envelope
+#     處理（design D1 明文要求兩個 invoker 吃同一份）。
+#
+# 本票**只**新增接縫，不新增第二個實作、不改任何行為。
+# ---------------------------------------------------------------------------
+
+#: `PlanningInvocation.purpose` 的四個 production 值（design D9）。只進 instance
+#: 名與診斷，**不參與任何決策**——票 E 用它讓
+#: `systemctl list-units 'cortex-reviewer-job@*'` 的輸出直接說得出「這一批 job
+#: 在做什麼」，不必回頭查 spec。
+PLANNING_PURPOSE_PROBE = "probe"
+PLANNING_PURPOSE_QUESTIONER = "questioner"
+PLANNING_PURPOSE_SECONDARY = "secondary"
+PLANNING_PURPOSE_INTEGRATOR = "integrator"
+#: 直呼叫（測試、診斷）的預設。production 的四條路徑一律明示 purpose。
+PLANNING_PURPOSE_UNSPECIFIED = "planning"
+
+
+@dataclass(frozen=True)
+class PlanningInvocation:
+    """一次 planning 模型呼叫的完整輸入（design D1）。
+
+    `evidence_root`／`run_id` 對 in-process 是 drift 報告的落點，對票 E 的 job
+    invoker 則是 instance 命名的來源（`plan-<run_id 前 12 字>-<purpose>-<序號>`）
+    ——兩邊都需要，因此屬於 invocation 而非 invoker 的建構參數。
+    """
+
+    identity: ModelIdentity
+    prompt: str
+    purpose: str
+    timeout_seconds: int
+    worktree: Path
+    evidence_root: str | Path | None = None
+    run_id: str = "ephemeral"
+
+
+@dataclass(frozen=True)
+class PlanningOutcome:
+    """一次呼叫的原始結果——**不含任何解讀**。
+
+    `output_text` 是 codex `-o last.json` 這個第二輸出候選的內容（無則 ``None``）。
+    它必須在這裡被讀出來，因為 in-process 的落點在 invoker 自己的一次性 tempdir
+    裡，invoker 一返回就消失；job 模式下 Manager 讀不到 job-owned scratch，這一格
+    恆為 ``None``（design D-j 的 R-2 退步）。
+
+    `diagnostics` 本票不產出任何內容（direct 模式沒有第二個資訊來源）；票 E 的
+    D8 會在這裡放 `unit`／`hardening_profile`／`resolved_binary`，讓
+    `executor-silent-exit` 這種「連錯誤訊息都沒有」的失敗有方向可查。
+    """
+
+    returncode: int | None
+    stdout: str | None
+    stderr: str | None = None
+    output_text: str | None = None
+    diagnostics: Mapping[str, str] = field(default_factory=dict)
+
+
+class PlanningInvoker(Protocol):
+    """planning 的執行後端。票 E 換掉的就是這個介面的實作。"""
+
+    def run(self, invocation: PlanningInvocation) -> PlanningOutcome:
+        """跑一次 identity＋prompt 呼叫，回傳原始結果。
+
+        契約：executor 非零退出**不是**本方法的錯誤（交呼叫端判定）；但
+        「執行過程違反了隔離契約」（弄髒拋棄式 sandbox、動到 operator 樹）
+        MUST 由本方法 fail-closed 拋出——那是 invoker 才有的視角。
+        """
+
+    def capability_probe_runner(self) -> Callable[..., object]:
+        """`probe_agy_capability` 兩次裸 CLI 呼叫用的執行接縫。
+
+        為什麼不是 `run()`：agy 的能力探測不是「一個 prompt」，而是一段兩步
+        CLI 協定（`agy models` 列出 model id，再拿解析到的 token 跑 smoke）。
+        那段協定的真相在 `model_identities.probe_agy_capability`，把它複製一份
+        到這裡就是第二份真相。因此 invoker 交出一個 `ProcessRunner` 形狀的
+        callable，讓既有 probe 原樣使用——**兩次 CLI 呼叫各算一次 invocation**
+        （plan 票 B）。票 E 在這裡回傳的是「一個 argv → 一個降權 job」的閉包。
+        """
+
+
+class InProcessPlanningInvoker:
+    """在呼叫端行程內執行（＝**現行行為**，direct 模式）。
+
+    design D2 的十條防線在 direct 模式下全部由本類別保證：D-a 一次性 tempdir、
+    D-b sandbox 複本、D-c `cwd=sandbox`、D-d sandbox 弄髒即 fail-closed、
+    D-e operator 樹雙向快照、D-f drift 唯讀收容、D-g claude hermetic env、
+    D-h `subprocess` 逾時、D-i `capture_output`、D-j codex 第二輸出候選。
+
+    本檔唯一持有 `subprocess.run` 的地方（issue #683 驗收第二條）。
+    """
+
+    def __init__(self, runner: Callable[..., object] | None = None) -> None:
+        self._runner = runner if runner is not None else subprocess.run
+
+    def capability_probe_runner(self) -> Callable[..., object]:
+        # direct 模式下「一次 agy CLI 呼叫」就是「一次 process 呼叫」，因此
+        # 接縫退化成底層 runner 本身——行為與修法前逐字相同（本票是純重構）。
+        # 注意 `probe_agy_capability` 刻意**不**帶 cwd／sandbox：那是它繞過
+        # `_invoke_json` 全部防線的既有事實（#672 母票已記錄），本票不改變它，
+        # 只讓它從此有一個能被票 E 換掉的接縫。
+        return self._runner
+
+    def run(self, invocation: PlanningInvocation) -> PlanningOutcome:
+        identity = invocation.identity
+        worktree = invocation.worktree
+        run_id = invocation.run_id
+        evidence_root = invocation.evidence_root
+        operator_before = _tree_snapshot(worktree)
+        with tempfile.TemporaryDirectory(prefix="cortex-planning-") as temp_dir:
+            baseline = Path(temp_dir) / "baseline"
+            sandbox = Path(temp_dir) / "checkout"
+            _copy_planning_sandbox(worktree, baseline)
+            shutil.copytree(baseline, sandbox, symlinks=True)
+            sandbox_before = _tree_snapshot(sandbox)
+            output_path = Path(temp_dir) / "last.json"
+            argv = _planning_argv(identity, invocation.prompt, temp_dir, sandbox)
+            run_kwargs: dict[str, object] = {}
+            if identity.executor == "claude":
+                # 僅 claude 路徑帶 env 覆寫；其他 executor（codex/agy）維持不帶，
+                # 避免行為外溢。
+                env = _seed_hermetic_claude_env(temp_dir)
+                if env is not None:
+                    run_kwargs["env"] = env
+            failure: BaseException | None = None
+            outcome: PlanningOutcome | None = None
+            try:
+                raw = self._runner(
+                    argv,
+                    cwd=str(sandbox),
+                    shell=False,
+                    capture_output=True,
+                    text=True,
+                    timeout=invocation.timeout_seconds,
+                    **run_kwargs,
+                )
+                returncode = getattr(raw, "returncode", None)
+                stdout = getattr(raw, "stdout", None)
+                # 第二候選必須在 tempdir 消失之前讀出來（見 `PlanningOutcome`）。
+                # 讀取條件與修法前逐字相同：修法前 `_extract_json` 只在
+                # 「rc==0 且 stdout 是字串」時才被呼叫，因此 `last.json`
+                # 在失敗路徑上**從不被讀**。無條件讀會讓「檔案存在但讀不出來」
+                # （非 UTF-8、權限）在失敗路徑上換掉例外型別，而例外型別正是
+                # `_probe_identity` 的 `safe-probe-failed` diagnostic 唯一內容、
+                # 也是票 A `classify_probe_failure()` 的分類輸入。
+                output_text: str | None = None
+                if returncode == 0 and isinstance(stdout, str) and output_path.is_file():
+                    output_text = output_path.read_text(encoding="utf-8")
+                outcome = PlanningOutcome(
+                    returncode=returncode,
+                    stdout=stdout,
+                    stderr=getattr(raw, "stderr", None),
+                    output_text=output_text,
+                )
+            except BaseException as exc:
+                failure = exc
+            finally:
+                try:
+                    sandbox_dirty = _tree_snapshot(sandbox) != sandbox_before
+                except BaseException:
+                    sandbox_dirty = True
+                    try:
+                        _make_tree_traversable(sandbox)
+                    except BaseException:
+                        pass
+                if sandbox_dirty:
+                    failure = ValueError(
+                        "planning launcher modified disposable read-only sandbox"
+                    )
+
+                operator_dirty = False
+                try:
+                    operator_dirty = _tree_snapshot(worktree) != operator_before
+                except BaseException:
+                    operator_dirty = True
+                if operator_dirty:
+                    # issue #507：偵測到 drift 一律 fail-closed（本次 planning 呼叫
+                    # 的結果不可信），但**不得改寫 operator worktree**。
+                    # `rollback_scope` 傳空集合是刻意的：launcher 以 `cwd=sandbox`
+                    # 執行、`--add-dir` 也只指向 sandbox，這條路徑在 operator 樹裡
+                    # 沒有任何「本次 run 自產」的產物可言，因此可證明的還原範圍就是
+                    # 空的。planning artifact 的落地另走
+                    # `manager._publish_planning_artifacts`（有交易與 authority 把
+                    # 關），不在此。任何差異都當成 operator／其他 agent 的並行工作
+                    # 保留原地，只做備份與報告。
+                    try:
+                        summary = _contain_operator_drift(
+                            worktree,
+                            baseline,
+                            evidence_root=(
+                                Path(evidence_root) if evidence_root is not None else None
+                            ),
+                            run_id=run_id,
+                            rollback_scope=frozenset(),
+                        )
+                    except BaseException as exc:  # noqa: BLE001 - 診斷面 fail-open
+                        # drift 收斂只負責診斷；它自己壞掉時仍要拋出可辨識的
+                        # planning 失敗，不得換成一個與現場無關的例外（修法前那條
+                        # 「restore failed」出口就是這個反例）。
+                        logger.error(
+                            "planning-worktree-drift-containment-failed run_id=%s error=%s: %s",
+                            run_id,
+                            type(exc).__name__,
+                            str(exc)[:200],
+                        )
+                        summary = {"counts": {}, "report_path": None, "backup_root": None}
+                    message = _operator_drift_message(summary)
+                    logger.error("planning-worktree-drift run_id=%s %s", run_id, message)
+                    failure = ValueError(message)
+            if failure is not None:
+                raise failure
+            if outcome is None:  # pragma: no cover - failure 為 None ⇒ 必已賦值
+                raise ValueError("planning invoker produced no outcome")
+            return outcome
+
+
+def _select_planning_invoker(env: Mapping[str, str]) -> PlanningInvoker:
+    """依部署宣告挑執行後端。**選擇點只有這一個**（design D1）。
+
+    唯一輸入是 `PSC_JOB_RUNNER`，與 launcher 共用同一支解析函式——非法值在該
+    函式已 fail-closed，這裡不重寫一份判定。刻意**不**新增
+    `PSC_PLANNING_INVOKER` 之類的 planning 專屬開關：第二個開關的失效模式是
+    「以為降權了、其實沒有」，而那種失敗看起來是成功的。
+
+    issue #683（票 B）只交付接縫，因此三種模式目前**全部**回 in-process
+    ——這正是「純重構、行為零改變」的意思。票 E（#686）新增
+    `JobPlanningInvoker` 之後，改的只有本函式的對應表一處。
+    """
+
+    job_runner.resolve_runner_mode(env)
+    return InProcessPlanningInvoker()
+
+
 def _invoke_json(
     identity: ModelIdentity,
     prompt: str,
     *,
     worktree: Path,
-    runner: Callable[..., object],
+    runner: Callable[..., object] | None = None,
+    invoker: PlanningInvoker | None = None,
+    purpose: str = PLANNING_PURPOSE_UNSPECIFIED,
     timeout_seconds: int,
     evidence_root: str | Path | None = None,
     run_id: str = "ephemeral",
 ) -> object:
-    operator_before = _tree_snapshot(worktree)
-    with tempfile.TemporaryDirectory(prefix="cortex-planning-") as temp_dir:
-        baseline = Path(temp_dir) / "baseline"
-        sandbox = Path(temp_dir) / "checkout"
-        _copy_planning_sandbox(worktree, baseline)
-        shutil.copytree(baseline, sandbox, symlinks=True)
-        sandbox_before = _tree_snapshot(sandbox)
-        output_path = Path(temp_dir) / "last.json"
-        argv = _planning_argv(identity, prompt, temp_dir, sandbox)
-        run_kwargs: dict[str, object] = {}
-        if identity.executor == "claude":
-            # 僅 claude 路徑帶 env 覆寫；其他 executor（codex/agy）維持不帶，
-            # 避免行為外溢。
-            env = _seed_hermetic_claude_env(temp_dir)
-            if env is not None:
-                run_kwargs["env"] = env
-        failure: BaseException | None = None
-        result: object | None = None
-        try:
-            raw = runner(
-                argv,
-                cwd=str(sandbox),
-                shell=False,
-                capture_output=True,
-                text=True,
-                timeout=timeout_seconds,
-                **run_kwargs,
-            )
-            returncode = getattr(raw, "returncode", None)
-            stdout = getattr(raw, "stdout", None)
-            if returncode != 0 or not isinstance(stdout, str):
-                raise ValueError(
-                    f"planning launcher failed: {identity.executor}/{identity.model_id}"
-                )
-            result = _extract_json(stdout, output_path)
-        except BaseException as exc:
-            failure = exc
-        finally:
-            try:
-                sandbox_dirty = _tree_snapshot(sandbox) != sandbox_before
-            except BaseException:
-                sandbox_dirty = True
-                try:
-                    _make_tree_traversable(sandbox)
-                except BaseException:
-                    pass
-            if sandbox_dirty:
-                failure = ValueError("planning launcher modified disposable read-only sandbox")
+    """呼叫端這一半：組 invocation → 交 invoker → 判 rc → 抽 JSON。
 
-            operator_dirty = False
-            try:
-                operator_dirty = _tree_snapshot(worktree) != operator_before
-            except BaseException:
-                operator_dirty = True
-            if operator_dirty:
-                # issue #507：偵測到 drift 一律 fail-closed（本次 planning 呼叫
-                # 的結果不可信），但**不得改寫 operator worktree**。
-                # `rollback_scope` 傳空集合是刻意的：launcher 以 `cwd=sandbox`
-                # 執行、`--add-dir` 也只指向 sandbox，這條路徑在 operator 樹裡
-                # 沒有任何「本次 run 自產」的產物可言，因此可證明的還原範圍就是
-                # 空的。planning artifact 的落地另走
-                # `manager._publish_planning_artifacts`（有交易與 authority 把
-                # 關），不在此。任何差異都當成 operator／其他 agent 的並行工作
-                # 保留原地，只做備份與報告。
-                try:
-                    summary = _contain_operator_drift(
-                        worktree,
-                        baseline,
-                        evidence_root=(
-                            Path(evidence_root) if evidence_root is not None else None
-                        ),
-                        run_id=run_id,
-                        rollback_scope=frozenset(),
-                    )
-                except BaseException as exc:  # noqa: BLE001 - 診斷面 fail-open
-                    # drift 收斂只負責診斷；它自己壞掉時仍要拋出可辨識的
-                    # planning 失敗，不得換成一個與現場無關的例外（修法前那條
-                    # 「restore failed」出口就是這個反例）。
-                    logger.error(
-                        "planning-worktree-drift-containment-failed run_id=%s error=%s: %s",
-                        run_id,
-                        type(exc).__name__,
-                        str(exc)[:200],
-                    )
-                    summary = {"counts": {}, "report_path": None, "backup_root": None}
-                message = _operator_drift_message(summary)
-                logger.error("planning-worktree-drift run_id=%s %s", run_id, message)
-                failure = ValueError(message)
-        if failure is not None:
-            raise failure
-        return result
+    `runner` 與 `invoker` 互斥。前者是既有呼叫端（與大量既有測試）注入 process
+    runner 的方式，等同「用 in-process invoker 跑」；兩者同時給等於同一件事有
+    兩份真相，fail-closed。
+    """
+
+    if invoker is None:
+        invoker = InProcessPlanningInvoker(runner)
+    elif runner is not None:
+        raise ValueError("planning invoker and runner are mutually exclusive")
+    outcome = invoker.run(
+        PlanningInvocation(
+            identity=identity,
+            prompt=prompt,
+            purpose=purpose,
+            timeout_seconds=timeout_seconds,
+            worktree=Path(worktree),
+            evidence_root=evidence_root,
+            run_id=run_id,
+        )
+    )
+    if outcome.returncode != 0 or not isinstance(outcome.stdout, str):
+        raise ValueError(
+            f"planning launcher failed: {identity.executor}/{identity.model_id}"
+        )
+    return _extract_json_candidates(outcome.stdout, outcome.output_text)
 
 
 def _probe_identity(
     identity: ModelIdentity,
     *,
     worktree: Path,
-    runner: Callable[..., object],
+    invoker: PlanningInvoker,
     timeout_seconds: int,
     evidence_root: str | Path | None = None,
     run_id: str = "ephemeral",
@@ -952,7 +1162,8 @@ def _probe_identity(
             identity,
             prompt,
             worktree=worktree,
-            runner=runner,
+            invoker=invoker,
+            purpose=PLANNING_PURPOSE_PROBE,
             timeout_seconds=timeout_seconds,
             evidence_root=evidence_root,
             run_id=run_id,
@@ -1067,7 +1278,8 @@ def build_production_planning_runtime(
     *,
     primary: tuple[str, str],
     worktree: str | Path,
-    runner: Callable[..., object] = subprocess.run,
+    runner: Callable[..., object] | None = None,
+    invoker: PlanningInvoker | None = None,
     timeout_seconds: int = 120,
     evidence_root: str | Path | None = None,
     run_id: str = "ephemeral",
@@ -1079,8 +1291,28 @@ def build_production_planning_runtime(
     未帶入時（直呼叫、探測、測試）**不寫任何 evidence**——刻意不 fallback 到
     `paths.coordinator_root()`，避免非 daemon 的呼叫端在 operator 的執行期狀態
     目錄下留下非預期檔案。
+
+    issue #683：執行後端改由 `PlanningInvoker` 承載。三種注入方式的優先序
+    （由高到低、互斥）：
+
+    1. `invoker=`——直接指定後端（票 E 的 `JobPlanningInvoker` 與測試用）。
+    2. `runner=`——注入 process runner，等同「用 in-process invoker 跑」。
+       這是既有呼叫端與大量既有測試的用法，逐字保留。
+    3. 兩者皆無（＝daemon 的實際呼叫形態）——由 `_select_planning_invoker`
+       依 `PSC_JOB_RUNNER` 決定。**這是全庫唯一的執行後端選擇點。**
+
+    四個 adapter 與兩種 probe 全部走同一個 invoker——票 E 因此只換一個物件，
+    不必再碰任何呼叫端。
     """
 
+    if invoker is not None and runner is not None:
+        raise ValueError("planning invoker and runner are mutually exclusive")
+    if invoker is None:
+        invoker = (
+            InProcessPlanningInvoker(runner)
+            if runner is not None
+            else _select_planning_invoker(os.environ)
+        )
     root = Path(worktree).resolve()
     registry = load_model_identities()
     probes: dict[tuple[str, str], CapabilityProbe] = {}
@@ -1088,14 +1320,18 @@ def build_production_planning_runtime(
         if "planning" not in identity.capabilities:
             continue
         if identity.executor == "agy" and identity.model_id == AGY_MODEL_ID:
+            # agy 的能力探測是兩步 CLI 協定，不是一個 prompt——它拿的是 invoker
+            # 的 `capability_probe_runner()` 接縫（見該方法的 docstring），
+            # 而不再是呼叫端手上的裸 runner。
             probes[(identity.executor, identity.model_id)] = probe_agy_capability(
-                runner=runner, timeout_seconds=min(timeout_seconds, 45)
+                runner=invoker.capability_probe_runner(),
+                timeout_seconds=min(timeout_seconds, 45),
             )
         else:
             probes[(identity.executor, identity.model_id)] = _probe_identity(
                 identity,
                 worktree=root,
-                runner=runner,
+                invoker=invoker,
                 timeout_seconds=timeout_seconds,
                 evidence_root=evidence_root,
                 run_id=run_id,
@@ -1103,14 +1339,15 @@ def build_production_planning_runtime(
 
     primary_identity = registry.get(*primary)
 
-    def invoke_primary(prompt: str) -> object:
+    def invoke_primary(prompt: str, *, purpose: str) -> object:
         if primary_identity is None:
             raise ValueError("primary planning identity is not configured")
         return _invoke_json(
             primary_identity,
             prompt,
             worktree=root,
-            runner=runner,
+            invoker=invoker,
+            purpose=purpose,
             timeout_seconds=timeout_seconds,
             evidence_root=evidence_root,
             run_id=run_id,
@@ -1121,7 +1358,8 @@ def build_production_planning_runtime(
             "Return only the exact question-pack JSON required to resolve this completeness report. "
             + _JSON_OUTPUT_CONTRACT
             + " Input: "
-            + json.dumps(report, ensure_ascii=False, sort_keys=True)
+            + json.dumps(report, ensure_ascii=False, sort_keys=True),
+            purpose=PLANNING_PURPOSE_QUESTIONER,
         )
 
     def secondary(pack: Mapping[str, object], identity: ModelIdentity) -> object:
@@ -1139,7 +1377,8 @@ def build_production_planning_runtime(
                 sort_keys=True,
             ),
             worktree=root,
-            runner=runner,
+            invoker=invoker,
+            purpose=PLANNING_PURPOSE_SECONDARY,
             timeout_seconds=timeout_seconds,
             evidence_root=evidence_root,
             run_id=run_id,
@@ -1182,7 +1421,8 @@ def build_production_planning_runtime(
                 },
                 ensure_ascii=False,
                 sort_keys=True,
-            )
+            ),
+            purpose=PLANNING_PURPOSE_INTEGRATOR,
         )
 
     return ProductionPlanningRuntime(registry, probes, questioner, secondary, integrator)

--- a/tests/test_planning_invoker_672.py
+++ b/tests/test_planning_invoker_672.py
@@ -1,0 +1,305 @@
+"""issue #683（#672 票 B）：`PlanningInvoker` 抽象的回歸釘子。
+
+本票是**純重構**：planning 的執行方式抽出一層 `PlanningInvoker`，讓票 E
+（#686）能把 in-process `subprocess.run` 換成降權 job，而不必再碰四個 adapter
+與 probe。因此這裡的每一條測試都在釘「切面切在哪裡」，而不是釘新行為：
+
+- 十條防線（design D2）在 direct 模式下**逐條仍由 `InProcessPlanningInvoker`
+  保證**——sandbox 契約與 operator drift 收容是其中最容易在搬家途中掉件的兩條，
+  因為它們活在 `finally` 裡、正常路徑不會經過。
+- 選擇點只有 `job_runner.resolve_runner_mode()` 一個（design D1）。第二個開關的
+  失效模式是「以為降權了、其實沒有」，而那種失敗**看起來是成功的**。
+- `subprocess.run` 在 `planning_runtime.py` 內只剩一處（issue #683 驗收第二條）。
+
+行為零改變的主證據不在本檔，而在「既有 planning／probe 測試一行不改全綠」——
+本檔只補既有測試涵蓋不到的**結構**斷言。
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+import pytest
+
+from paulsha_cortex.coordinator import job_runner, planning_runtime
+from paulsha_cortex.coordinator.model_identities import AGY_MODEL_ID, IdentityRegistry, ModelIdentity
+
+
+def _completed(stdout: str = "", returncode: int = 0):
+    return type("Completed", (), {"stdout": stdout, "stderr": "", "returncode": returncode})()
+
+
+def _module_tree() -> ast.Module:
+    return ast.parse(Path(planning_runtime.__file__).read_text(encoding="utf-8"))
+
+
+def _code_string_literals(tree: ast.Module) -> set[str]:
+    """模組內**程式碼**用到的字串字面值（排除 docstring）。
+
+    註解與 docstring 會談到本票刻意不做的事（例如「不新增第二個開關」），
+    對它們做 substring 比對只會得到反向的答案——因此一律走 AST。
+    """
+
+    docstrings: set[int] = set()
+    for node in ast.walk(tree):
+        if not isinstance(
+            node, (ast.Module, ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)
+        ):
+            continue
+        body = getattr(node, "body", [])
+        if (
+            body
+            and isinstance(body[0], ast.Expr)
+            and isinstance(body[0].value, ast.Constant)
+            and isinstance(body[0].value.value, str)
+        ):
+            docstrings.add(id(body[0].value))
+    return {
+        node.value
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Constant)
+        and isinstance(node.value, str)
+        and id(node) not in docstrings
+    }
+
+
+def _invocation(
+    identity: ModelIdentity,
+    *,
+    worktree: Path,
+    prompt: str = "return JSON",
+    purpose: str = planning_runtime.PLANNING_PURPOSE_PROBE,
+    timeout_seconds: int = 30,
+    evidence_root: Path | None = None,
+    run_id: str = "workflow-683",
+) -> planning_runtime.PlanningInvocation:
+    return planning_runtime.PlanningInvocation(
+        identity=identity,
+        prompt=prompt,
+        purpose=purpose,
+        timeout_seconds=timeout_seconds,
+        worktree=worktree,
+        evidence_root=evidence_root,
+        run_id=run_id,
+    )
+
+
+def test_in_process_invoker_preserves_sandbox_contract(tmp_path: Path) -> None:
+    """D2 的 D-d：模型弄髒自己的拋棄式 sandbox ⇒ 該次呼叫 fail-closed。
+
+    這條防線活在 `finally` 裡，成功路徑完全不會經過它——搬家時最容易變成
+    「程式還在、但沒有人再呼叫它」。訊息字面值同時被釘住：它是 `_invoke_json`
+    唯一能分辨「模型違反 read-only 契約」與其他失敗的字串。
+    """
+
+    identity = ModelIdentity("codex", "primary", "openai", ("planning",))
+    worktree = tmp_path / "worktree"
+    worktree.mkdir()
+    (worktree / "tracked.md").write_text("operator\n", encoding="utf-8")
+
+    def runner(argv, **kwargs):
+        # 模型透過 cwd（＝sandbox）寫檔：合法的 argv、不合法的行為。
+        (Path(kwargs["cwd"]) / "leak.md").write_text("sandbox mutation\n", encoding="utf-8")
+        return _completed(json.dumps({"ok": True}))
+
+    invoker = planning_runtime.InProcessPlanningInvoker(runner)
+    with pytest.raises(ValueError, match="planning launcher modified disposable read-only sandbox"):
+        invoker.run(_invocation(identity, worktree=worktree))
+
+    # operator 樹本身未被波及（sandbox 是拋棄式複本，不是 operator 本尊）。
+    assert (worktree / "tracked.md").read_text(encoding="utf-8") == "operator\n"
+    assert not (worktree / "leak.md").exists()
+
+
+def test_in_process_invoker_preserves_operator_drift_containment(tmp_path: Path) -> None:
+    """D2 的 D-e／D-f：operator 樹任何內容變化 ⇒ fail-closed ＋ 唯讀收容。
+
+    `PLANNING_WORKTREE_DRIFT_MESSAGE_PREFIX` 是**下游分類契約**
+    （`manager._is_planning_worktree_drift_failure` 唯一能依賴的部分，見 #554），
+    因此逐字釘住；同時釘住「內容一個位元組都沒被改寫」與「evidence 報告落地」
+    ——#507 的教訓是這條防線的補救動作曾經比它要防的傷害更貴。
+    """
+
+    identity = ModelIdentity("codex", "primary", "openai", ("planning",))
+    worktree = tmp_path / "worktree"
+    worktree.mkdir()
+    evidence_root = tmp_path / "coordinator"
+    tracked = worktree / "tracked.md"
+    tracked.write_text("operator\n", encoding="utf-8")
+
+    def runner(argv, **kwargs):
+        # 經絕對路徑越界寫 operator 樹（cwd 是 sandbox，這是繞過 cwd 的寫入）。
+        tracked.write_text("polluted\n", encoding="utf-8")
+        return _completed(json.dumps({"ok": True}))
+
+    invoker = planning_runtime.InProcessPlanningInvoker(runner)
+    with pytest.raises(ValueError) as excinfo:
+        invoker.run(_invocation(identity, worktree=worktree, evidence_root=evidence_root))
+
+    message = str(excinfo.value)
+    assert message.startswith(planning_runtime.PLANNING_WORKTREE_DRIFT_MESSAGE_PREFIX)
+    # 唯讀收容：operator 的內容原地保留，不得被「還原」抹掉。
+    assert tracked.read_text(encoding="utf-8") == "polluted\n"
+
+    reports = sorted(
+        (evidence_root / "evidence" / planning_runtime.PLANNING_WORKTREE_DRIFT_DIRNAME).glob(
+            "*/report.json"
+        )
+    )
+    assert len(reports) == 1
+    report = json.loads(reports[0].read_text(encoding="utf-8"))
+    assert report["run_id"] == "workflow-683"
+    assert report["counts"] == {"added": 0, "modified": 1, "removed": 0}
+    assert report["rollback_scope_applied"] == []
+
+
+def test_invoker_selection_follows_resolve_runner_mode(monkeypatch) -> None:
+    """design D1：選擇點只有 `job_runner.resolve_runner_mode()` 一個。
+
+    三件事各釘一條：
+
+    1. `PSC_JOB_RUNNER` 是**唯一**輸入——選擇函式對它以外的 env 完全不敏感。
+    2. 非法值 fail-closed（借用 `resolve_runner_mode` 既有的 `JobRunnerError`，
+       不自建第二套判定）。
+    3. **不存在第二個開關**：`PSC_PLANNING_INVOKER` 這類 planning 專屬旗標若被
+       加進來，它的失效模式是「以為降權了、其實沒有」，而那種失敗看起來是成功的。
+    """
+
+    # 1／2：唯一輸入 ＋ 非法值 fail-closed。
+    for value in (None, "", job_runner.RUNNER_DIRECT, job_runner.RUNNER_SYSTEMD_TEMPLATE):
+        env = {} if value is None else {job_runner.JOB_RUNNER_ENV: value}
+        assert isinstance(
+            planning_runtime._select_planning_invoker(env),
+            planning_runtime.InProcessPlanningInvoker,
+        )
+    with pytest.raises(job_runner.JobRunnerError):
+        planning_runtime._select_planning_invoker({job_runner.JOB_RUNNER_ENV: "definitely-not-a-mode"})
+
+    # 3：沒有第二個開關。`planning_runtime` 的程式碼不得自行命名任何 `PSC_*`
+    #    env——env 的解讀一律外包給 `job_runner`，那裡的判定是全庫唯一一份。
+    tree = _module_tree()
+    assert not [name for name in _code_string_literals(tree) if name.startswith("PSC_")]
+    selection_calls = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "resolve_runner_mode"
+    ]
+    assert len(selection_calls) == 1
+
+    # 選擇函式只讀 `PSC_JOB_RUNNER`：其他 env 一律不影響結果。
+    monkeypatch.setenv("PSC_PLANNING_INVOKER", "systemd-template")
+    assert isinstance(
+        planning_runtime._select_planning_invoker({}),
+        planning_runtime.InProcessPlanningInvoker,
+    )
+
+
+def test_subprocess_run_survives_only_inside_the_in_process_invoker() -> None:
+    """issue #683 驗收第二條：`planning_runtime.py` 內 `subprocess.run` 只剩一處。
+
+    這是「接縫真的接上了」的機械證據：只要還有第二處直接 `subprocess.run`，
+    票 E 換掉 invoker 之後就會留下一條仍在 Manager 行程內跑模型的暗路——而那
+    正是 #672 整張母票要消滅的東西。
+    """
+
+    tree = _module_tree()
+    hits = [
+        node.lineno
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Attribute)
+        and node.attr == "run"
+        and isinstance(node.value, ast.Name)
+        and node.value.id == "subprocess"
+    ]
+    assert len(hits) == 1, f"預期只剩 InProcessPlanningInvoker 一處，實得行號 {hits}"
+
+    invoker = next(
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ClassDef) and node.name == "InProcessPlanningInvoker"
+    )
+    assert invoker.lineno <= hits[0] <= (invoker.end_lineno or hits[0])
+
+
+def test_every_planning_call_site_routes_through_the_invoker(monkeypatch, tmp_path: Path) -> None:
+    """四個 adapter ＋ 兩種 probe 全部經同一個接縫（plan 票 B 的第三／第四條）。
+
+    票 E 只換 invoker、不再碰 `planning_runtime` 的呼叫端——前提是**今天沒有任何
+    一條 planning 路徑繞過它**。`probe_agy_capability` 是最容易漏的一條：它不吃
+    prompt、吃的是兩次裸 CLI 呼叫（`agy models` ＋ smoke），過去直接拿 `runner`
+    就跑，繞過了 `_invoke_json` 的全部防線。
+    """
+
+    registry = IdentityRegistry.from_rows(
+        [
+            {
+                "executor": "codex", "model_id": "primary", "independence_domain": "openai",
+                "capabilities": ["planning"],
+            },
+            {
+                "executor": "agy", "model_id": AGY_MODEL_ID, "independence_domain": "google",
+                "capabilities": ["planning"], "live_probe": "agy-plan-sandbox",
+            },
+        ]
+    )
+    monkeypatch.setattr(planning_runtime, "load_model_identities", lambda: registry)
+
+    purposes: list[str] = []
+    capability_argvs: list[list[str]] = []
+
+    def _echo(prompt: str) -> str:
+        for marker in (
+            "Return only this compact JSON object and perform no tool calls: ",
+            "Return only this JSON object and do not call tools: ",
+        ):
+            if marker in prompt:
+                return prompt.split(marker, 1)[1] + "\n"
+        return json.dumps({"ok": True})
+
+    class RecordingInvoker:
+        def run(self, invocation: planning_runtime.PlanningInvocation):
+            purposes.append(invocation.purpose)
+            return planning_runtime.PlanningOutcome(
+                returncode=0, stdout=_echo(invocation.prompt), stderr="", output_text=None
+            )
+
+        def capability_probe_runner(self):
+            def runner(argv, **kwargs):
+                capability_argvs.append(list(argv))
+                if list(argv) == ["agy", "models"]:
+                    return _completed(f"{AGY_MODEL_ID}\n")
+                prompt = argv[argv.index("--print") + 1]
+                return _completed(_echo(prompt))
+
+            return runner
+
+    runtime = planning_runtime.build_production_planning_runtime(
+        primary=("codex", "primary"), worktree=tmp_path, invoker=RecordingInvoker()
+    )
+
+    assert runtime.probes[("codex", "primary")].ready is True
+    assert runtime.probes[("agy", AGY_MODEL_ID)].ready is True
+    # agy 的 capability probe 是兩次 CLI 呼叫，各算一次 invocation。
+    assert [argv[0] for argv in capability_argvs] == ["agy", "agy"]
+    assert capability_argvs[0] == ["agy", "models"]
+
+    runtime.primary_questioner({"gaps": []})
+    runtime.primary_integrator({"pack_id": "qp"}, {"evidence_hash": "h"})
+    assert purposes == [
+        planning_runtime.PLANNING_PURPOSE_PROBE,
+        planning_runtime.PLANNING_PURPOSE_QUESTIONER,
+        planning_runtime.PLANNING_PURPOSE_INTEGRATOR,
+    ]
+
+    # 明示 invoker 與明示 runner 互斥：兩者同時給等於有兩個真相，fail-closed。
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        planning_runtime.build_production_planning_runtime(
+            primary=("codex", "primary"),
+            worktree=tmp_path,
+            runner=lambda *a, **k: _completed("{}"),
+            invoker=RecordingInvoker(),
+        )


### PR DESCRIPTION
Closes #683

## 這張票做什麼

把 planning 的**執行方式**抽象成 `PlanningInvoker`——**純重構、行為零改變**，
為票 E（#686，改走降權 job runner）鋪一條只需要換一個物件的路。

修法前 `planning_runtime._invoke_json()` 把三件事揉在同一支函式裡：

1. **怎麼跑一個 executor**——一次性 sandbox、`cwd`、hermetic env、逾時、
   雙向樹快照、drift 收容；
2. **跑之前準備什麼**——prompt 組裝；
3. **跑完之後怎麼解讀**——JSON 抽取與 CLI envelope 處理。

票 E 只要換第 1 項、第 2／3 項逐字不變。沒有接縫時那次改動只能寫成
`_invoke_json` 裡的 `if degraded:`，於是「design D2 的十條防線各自在哪個模式下
生效」變成要靠讀 `if` 才知道；而四個 adapter 與 probe 共用同一支函式，等於每個
呼叫端都要重新論證一次自己走的是哪條路（design D1 的原話）。

## 抽象的切面切在哪裡

| | 由誰負責 | 為什麼 |
|---|---|---|
| 一次性 sandbox、`cwd`、hermetic env、逾時、**雙向快照與 drift 收容** | **invoker** | 「快照要不要做」完全由「怎麼跑」決定：job 模式下 operator 樹被 `ProtectSystem=strict` 在 kernel 層擋掉（D-e 從偵測**升級**為阻擋），那時這幾條**不該**再由呼叫端執行一次 |
| prompt 組裝、rc 判定、JSON 抽取與 envelope 處理 | **呼叫端（共用層）** | design D1 明文要求兩個 invoker 吃同一份抽取邏輯——本 repo 已在 #401／#516／#520 買過三次「同一件事兩份真相」的單 |

新增三個型別：`PlanningInvocation`（identity／prompt／purpose／timeout／worktree／
evidence_root／run_id）、`PlanningOutcome`（returncode／stdout／stderr／output_text／
diagnostics）、`PlanningInvoker` Protocol。實作只有一個：`InProcessPlanningInvoker`
（＝現行行為）。

## 十條防線各自由誰保證（design D2 逐條）

| # | 防線 | 本票之後由誰保證 |
|---|---|---|
| D-a | `tempfile.TemporaryDirectory(prefix="cortex-planning-")` | `InProcessPlanningInvoker.run()` |
| D-b | `_copy_planning_sandbox` ＋ `shutil.copytree(baseline, sandbox)` | 同上 |
| D-c | `cwd=sandbox` | 同上 |
| D-d | 呼叫後 sandbox 快照比對 ⇒ `modified disposable read-only sandbox` | 同上（`finally`，逐字搬入） |
| D-e | 呼叫前後 operator 樹快照 ⇒ fail-closed | 同上（`finally`，逐字搬入） |
| D-f | `_contain_operator_drift` 唯讀 diff → 備份 → 報告 → 三道閘門 | 同上；函式本體留在模組層（票 E 之後對 job 路徑是 dead code，但**不刪**，direct 模式仍要用） |
| D-g | `_seed_hermetic_claude_env`（claude 路徑限定） | 同上 |
| D-h | `subprocess.run(timeout=…)` | 同上（本檔唯一持有 `subprocess.run` 的地方） |
| D-i | `capture_output=True` 取 stdout | 同上 → `PlanningOutcome.stdout` |
| D-j | codex `-o last.json` 第二輸出候選 | invoker 讀出檔案內容放進 `PlanningOutcome.output_text`（tempdir 一返回就消失，必須在裡面讀）；**判讀**留在共用層 `_extract_json_candidates` |

十條全部**逐字搬入**，一行邏輯未改。

## probes 有沒有一起進去

**有，兩個都進。** 但形狀不同，而且是刻意的：

- `_probe_identity`：本來就走 `_invoke_json`，改成吃 `invoker=`，
  `purpose=probe`。零額外處理。
- `probe_agy_capability`：本來直接吃裸 `runner`、**繞過 `_invoke_json` 的全部
  防線**（#672 母票已記錄）。它不是「一個 prompt」，而是一段**兩步 CLI 協定**
  （`agy models` 列出 model id → 拿解析到的 token 跑 smoke）。那段協定的真相在
  `model_identities.probe_agy_capability`，把它複製一份到 `planning_runtime`
  就是第二份真相。因此 invoker 多一個 `capability_probe_runner() -> ProcessRunner`
  方法，讓既有 probe **原樣消費**——direct 模式下它就是底層 runner 本身（行為
  逐字不變），票 E 在這裡回傳「一個 argv → 一個降權 job」的閉包，
  **兩次 CLI 呼叫各算一次 invocation**（plan 票 B 的原話）。

## 我怎麼證明「行為零改變」

**主證據：既有 planning／probe 測試一行不改、全數綠燈。**
`git diff --stat origin/main` 對 `tests/` 只有一個**新增**檔案，零修改。

```
tests/test_planning_runtime.py          63 passed
tests/test_model_identities.py          ...
tests/test_planning_failure_taxonomy_672.py
tests/test_planning_transient_service_failure.py
tests/test_planning_drift_classification_554.py
→ 172 passed

python3 -m pytest tests/ -q → 4308 passed, 24 skipped, 49 subtests passed
```

那批既有測試**直接呼叫** `planning_runtime._invoke_json(identity, prompt,
worktree=…, runner=…, timeout_seconds=…)`，並逐字斷言 sandbox 訊息、drift
訊息前綴、evidence 報告內容、hermetic `CLAUDE_CONFIG_DIR` 的 mode／內容、
非 claude executor 不得帶 env——因此「簽章、訊息、防線觸發時機」三者只要動一格
就會紅。這就是本票對「純重構」的定義。

**補充證據（新測試，`tests/test_planning_invoker_672.py`）**：

- `test_in_process_invoker_preserves_sandbox_contract` — D-d 活在 `finally`
  裡、成功路徑不會經過，搬家時最容易變成「程式還在、沒人呼叫」。
- `test_in_process_invoker_preserves_operator_drift_containment` —
  `PLANNING_WORKTREE_DRIFT_MESSAGE_PREFIX` 是下游分類契約（#554），逐字釘住。
- `test_invoker_selection_follows_resolve_runner_mode` — 唯一輸入是
  `PSC_JOB_RUNNER`；非法值 fail-closed；**用 AST** 檢查程式碼裡沒有任何
  `PSC_*` 字面值、`resolve_runner_mode(` 只有一個呼叫點。
- `test_subprocess_run_survives_only_inside_the_in_process_invoker` — 用 AST 找
  `subprocess.run` 屬性存取，斷言只有一處且落在 `InProcessPlanningInvoker`
  的行號範圍內（issue 驗收第二條的機械證據）。
- `test_every_planning_call_site_routes_through_the_invoker` — 注入一個假
  invoker，斷言四個 adapter 與兩種 probe **全部**經過它、purpose 正確、
  agy 的兩次 CLI 呼叫都落在 `capability_probe_runner()` 上。

**逐案手動核對**（重構前後同輸入同輸出，已實跑）：

| 情境 | 修法前 | 本 PR |
|---|---|---|
| rc≠0、樹乾淨 | `ValueError: planning launcher failed: codex/primary` | 同 |
| rc=0、stdout 非 JSON | `ValueError: planning launcher returned no JSON object: Error: UNAVAILABLE (code 503)` | 同 |
| runner 拋 `TimeoutExpired` | probe → `safe-probe-failed` / `TimeoutExpired` | 同（**例外物件原樣重拋，不包裝**——型別名是票 A `classify_probe_failure()` 的分類輸入） |
| codex 寫了 `-o last.json`、stdout 是垃圾 | 取 `last.json` | 同 |
| 回傳物件沒有 `stdout` 屬性 | `planning launcher failed` | 同 |
| rc≠0 且 sandbox 被弄髒 | sandbox 訊息覆蓋 rc 錯誤 | 同（`finally` 的覆蓋順序原封不動） |

**對票 A（#682／PR #688）契約的影響：無。** 本 PR 不碰
`model_identities.py`／`planning.py`／`manager.py`。「分類器只讀錨在字串開頭的
`grade=`、不對整串做 substring search」那條防偽設計完全在票 A 的檔案裡，未被
觸及；`classify_probe_failure()` 的輸入（`safe-probe-failed` 的例外**型別名**）
則由上表第三列與下節的精確度處理保住。

## 兩處為了「逐字等價」而做的精確度處理

1. **`-o last.json` 的讀取條件**與修法前逐字相同：只在 `rc==0 且 stdout 是字串`
   時才讀。修法前 `_extract_json` 只在該條件下被呼叫，因此失敗路徑上
   `last.json` **從不被讀**；無條件讀會讓「檔案存在但讀不出來」（非 UTF-8、
   權限）在失敗路徑上換掉例外型別——而例外**型別名**正是 `_probe_identity` 的
   `safe-probe-failed` diagnostic 唯一內容、也是票 A 分類的輸入。
2. **`invoker` 與 `runner` 兩個注入口互斥**，同時給即 fail-closed。兩者同時存在
   等於同一件事有兩份真相。

## 唯一刻意的行為差異（design D1 明文要求，不是我自己加的）

daemon 路徑（不注入 `runner`／`invoker`）現在會在建構 planning runtime 時解析
`PSC_JOB_RUNNER`，非法值 fail-closed 成 `JobRunnerError`。

- design D1：「選擇點只有一個：`job_runner.resolve_runner_mode(os.environ)`，
  與 launcher 同一支函式；非法值在該函式已 fail-closed」；
- plan 票 B 的 RED 測試也明列「非法值 fail-closed」；
- launcher（`launcher.py:1265`）早已對**同一個值**fail-closed，因此不存在
  「本來能跑、現在不能跑」的部署——一個打錯字的 `PSC_JOB_RUNNER` 今天就已經讓
  派工掛掉；
- `manager` 端把它記成 `planning-runtime-initialization-failed`（`environment`
  級，走既有的 `recover-planning` 路徑），不是未捕捉的 crash。

我把它明講出來而不是藏在「純重構」四個字底下。

## 對 design 的三處收斂（**不是**改設計，是把示意落成程式）

1. **`PlanningInvocation` 是 frozen dataclass，不是 Protocol。** design 寫成
   `class PlanningInvocation(Protocol)`，但它是呼叫端**建構**的值物件、不是呼叫端
   要實作的介面；`PlanningInvoker` 才是 Protocol。
2. **`PlanningInvocation` 多三個欄位**（`worktree`／`evidence_root`／`run_id`）。
   前者是 in-process 的 sandbox 來源；後兩者對 in-process 是 drift 報告落點、
   對票 E 是 D9 instance 命名（`plan-<run_id 前 12 字>-<purpose>-<序號>`）的來源
   ——兩邊都要，所以屬 invocation 而非 invoker 的建構參數。
3. **`capability_probe_runner()` 的形狀與 `run()` 不同**，理由見上「probes」段。

`PlanningOutcome.diagnostics` 本票不產出任何內容（direct 模式沒有第二個資訊
來源），欄位先立在型別上，讓票 E 的 D8（`unit`／`hardening_profile`／
`resolved_binary`）不必再改一次 outcome 形狀。除此之外**沒有**新增任何為了
「將來可能會用到」的機制——YAGNI。

## 本票明確不做

- 不新增 `JobPlanningInvoker`（票 E）。
- 不改 probe 的快取行為（票 C）。
- 不改 `probe_agy_capability` 沒有 sandbox／cwd 這個既有事實——本票只讓它從此
  有一個能被票 E 換掉的接縫。
- 不改任何既有測試。

## Checklist

- [x] 分支 `feature/683-planning-invoker`，非 `main`
- [x] `changelog.d/683-planning-invoker.md` fragment 已新增且已 commit
- [x] `CHANGELOG.md [Unreleased]` 有對應 entry（`### Changed`）
- [x] `docs/superpowers/plans/planner-job-downgrade.md` 票 B 勾選 ＋ 實作補充
- [x] `python3 -m pytest tests/ -q` 全綠（4308 passed／24 skipped）
- [x] 既有 planning／probe 測試**一行未改**
- [x] `subprocess.run` 在 `planning_runtime.py` 只剩 `InProcessPlanningInvoker` 一處
- [x] 帶 PR 上下文執行 `policy_check`
