### PR TITLE
feat(planner): probe 結果快取，指紋含模板 unit 本身（#684／#672 票 C）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,31 @@
   ——那就是「純重構」的定義，也是本票行為零改變的主要證據。
 
 ### Added
+- **#684（#672 票 C）：planning capability probe 的跨 tick 結果快取，指紋含模板 unit 檔本身**
+  ——`build_production_planning_runtime()` 對每個 planning-capable identity 各跑一次 probe
+  （`_probe_identity` 每次兩次整棵 repo 的 `copytree`；`probe_agy_capability` 兩次 CLI
+  呼叫），而它由 periodic tick（實機 `PSC_MANAGER_INTERVAL_SECONDS=600`）與
+  `apply_work_action()` 兩條路徑呼叫；票 E 把 planning 搬上降權 job 之後**每一次 probe 就是
+  一個 systemd unit 實例**，等於每 10 分鐘起一批 job 去問模型「你是誰」。新增
+  `coordinator/planning_probe_cache.py`：指紋六格＝`PSC_JOB_RUNNER` 解析後模式、roster 解析
+  結果的 canonical JSON 雜湊、以該角色 PATH 解析出的 executor 絕對路徑 ＋
+  `st_dev/st_ino/st_size/st_mtime_ns`、憑證檔的 `st_size/st_mtime_ns`（**不讀內容**）、
+  `resolve_hardening_profile(executor)`、以及**模板 unit 檔本身**的 `st_size/st_mtime_ns`。
+  放 unit 檔而不是剖面名是因為 #677 的 `PROFILE_LOCKED_KEYS`——剖面名相同不代表 unit 內容
+  相同，只認剖面名會沿用一個對新 unit 不成立的 `ready`；放 unit 的 stat 則把**部署動作**與
+  **快取失效**綁成同一件事。含 `PSC_JOB_RUNNER` 是因為 direct 與 job 的執行環境完全不同，
+  它同時是「票 F 的切換必須一次到位」的機械保證。**fail-closed**：壞檔／schema 不符／row
+  形狀不合／身分欄位被改／同時帶 ready 與失敗診斷／指紋不符／TTL 過期／時鐘倒退一律視為
+  **miss 重探**，沒有任何一條路徑會因為「上次是 ready」而在無法重探時回答 ready；壞檔另落
+  可辨識的 `planning-probe-cache-unreadable`，與「probe 失敗」分開。與 `not_claimable`
+  （#675）**刻意的一處不同**是壞檔不 raise（輔助紀錄不該取得它不該有的否決權），ledger 形狀
+  與原子寫入則逐項沿用。TTL 兩段（ready 3600s／not-ready 300s，env 可覆寫，讀取時判定因此
+  調短立即生效；非法值當 0 而不落回預設）。落點是新增的登記表資產 `planning-probe-cache`
+  （`<coordinator_root>/planning-probe-cache.json`，Manager-owned 0600，writers／readers 只有
+  `Principal.MANAGER`），**刻意不進任何 job 模板 unit 的 `ReadWritePaths`**——job 一旦寫得動
+  快取，「這個 provider 是 ready 的」就變成模型可以自證的東西。指紋計算**永不 raise**，
+  算不出來的分量落 `<unresolved:<例外型別名>>`（只帶型別名不帶訊息），而那本身也是一個會變
+  的值。測試 `tests/test_planning_probe_cache_672.py`（40 條）；**既有測試一行未改**。
 - **#672：planner 降權的設計交付（spec ＋ design ＋ 實作切分計畫，零 code）**——planning
   （define／brainstorm）從來沒有被降權：`planning_runtime.py:830` `_invoke_json()` 以
   `subprocess.run` 在**呼叫端行程內**執行、`:43` `_planning_argv()` 回傳裸 executor argv

--- a/changelog.d/684-probe-cache.md
+++ b/changelog.d/684-probe-cache.md
@@ -1,0 +1,56 @@
+# 684-probe-cache
+
+- **#684（#672 票 C）：planning capability probe 的跨 tick 結果快取，指紋含模板 unit 檔本身**
+  ——`build_production_planning_runtime()` 對每個 planning-capable identity 各跑一次 probe
+  （`_probe_identity` 每次兩次整棵 repo 的 `copytree`；`probe_agy_capability` 兩次 CLI 呼叫），
+  而它由 `run_auto_claim_scan()`（periodic tick，實機 `PSC_MANAGER_INTERVAL_SECONDS=600`）
+  與 `apply_work_action()` 兩條路徑呼叫。票 E（#686）把 planning 搬上降權 job 之後，**每一次
+  probe 就是一個 systemd unit 實例**——沒有快取等於每 10 分鐘起一批 job 去問模型「你是誰」，
+  成本不可接受。新增 `paulsha_cortex/coordinator/planning_probe_cache.py`：
+  - **指紋六格**（design D-C／D5：任何會改變 probe 結論的輸入都在裡面）——
+    `PSC_JOB_RUNNER` 的**解析後模式**；roster 解析結果的 canonical JSON 雜湊；以該角色的
+    PATH 解析出的 executor **絕對路徑 ＋ `st_dev/st_ino/st_size/st_mtime_ns`**；憑證檔的
+    `st_size/st_mtime_ns`（**不讀內容**，避免把 token 帶進雜湊的任何中間狀態）；
+    `resolve_hardening_profile(executor)`；以及**模板 unit 檔本身**的
+    `st_size/st_mtime_ns`。
+  - **為什麼是 unit 檔而不是剖面名**：#677 落地的 `PROFILE_LOCKED_KEYS` 說明兩份剖面的
+    加固鍵逐字相同，剖面名相同**不代表** unit 內容相同（operator 重新落檔、產生器升級、
+    RWP 增列都會改 unit 而不改剖面名）。只認剖面名會沿用一個對新 unit 不成立的 `ready`。
+    把 unit 的 stat 放進指紋，等於把**部署動作**與**快取失效**綁成同一件事——沒有人需要
+    記得清快取。
+  - **為什麼要含 `PSC_JOB_RUNNER`**：direct 與 job 兩種模式的執行環境（PATH／HOME／憑證／
+    seccomp／MDWE）完全不同，切換一次就必須全部重探。這同時是 plan 要求「票 F 的生產切換
+    一次到位、不能一半走 job」的機械保證：混用時兩種語意的結論不會並存在同一格。
+  - **fail-closed**：檔案不存在／JSON 壞／payload 不是物件／schema 不符／`items` 不是物件／
+    row 形狀不合／身分欄位被改／同時帶 `ready` 與失敗診斷／指紋不符／TTL 過期／`probed_at`
+    落在未來（時鐘倒退）——**全部視為 miss 並重探**，沒有任何一條路徑會因為「上次是 ready」
+    而在無法重探時回答 ready。壞檔另落一筆**可辨識**的
+    `planning-probe-cache-unreadable`，與「probe 失敗」分開（否則會出現「快取檔壞了、
+    症狀卻報成 provider 不可用」）。
+  - **與 `not_claimable`（#675）刻意的一處不同**：那份 ledger 對壞檔 **raise**（不可 claim
+    的項目必須查得到）；probe 快取**不得** raise——它壞掉時若把整個 planning 拖垮，等於一份
+    輔助紀錄取得了它不該有的否決權。兩者是同一條原則（不得靜默產生有利答案）在不同後果下
+    的兩種實作。ledger 形狀（`schema` ＋ `items` ＋ `first_observed_at`／`last_observed_at`／
+    `observations` ＋ 條件解除自動清除 ＋ temp／`os.replace`／目錄 fsync 的原子寫入）則逐項
+    沿用。
+  - **TTL 兩段**：`ready` 預設 3600s、not-ready 預設 300s（`PSC_PLANNING_PROBE_CACHE_
+    READY_TTL_SECONDS`／`..._NOT_READY_TTL_SECONDS` 可覆寫）。失敗要快速重試（暫時性服務
+    錯誤、限流、模型輸出的隨機不從短時間內就會自己好），成功不需要頻繁重確認（重確認就是
+    一批 job 的成本）。TTL 在**讀取時**依當下設定判定，因此調短立即生效；非法值一律當 0
+    （＝永遠 miss）並落 log，**不落回預設**——落回預設會讓一個打錯的值靜默維持一小時的快取。
+  - **快取內容**：除 `ready` 外存失敗側的完整診斷。`reason`／`diagnostic` **逐字沿用**
+    `CapabilityProbe`（#674 的 `stdout_excerpt()`／`strip_code_fence()` 是那件事的唯一真相，
+    快取層不再造一份節錄邏輯），另存三分族（票 A 的 `classify_probe_failure()`）、`unit`、
+    `hardening_profile`、`resolved_binary` 與指紋分量明表（operator 直接看得出「是哪一格
+    變了」）。`returncode`／`stdout_prefix`／`binary_version` 先立在 schema 上、目前恆為
+    `None`——來源是票 E 的 `PlanningOutcome.diagnostics`。
+  - **落點與權限**：新增登記表資產 `planning-probe-cache`
+    （`<coordinator_root>/planning-probe-cache.json`，Manager-owned 0600，writers／readers
+    **只有** `Principal.MANAGER`），**刻意不進任何 job 模板 unit 的 `ReadWritePaths`**：
+    job 一旦寫得動快取，「這個 provider 是 ready 的」就變成模型可以自證的東西。
+  - **指紋計算永不 raise**：每個分量各自守備，算不出來的那一格落
+    `<unresolved:<例外型別名>>`（**只帶型別名、不帶訊息**，與票 A 依賴的是同一條邊界）。
+    因此 job 模式下 `PSC_REVIEWER_PATH` 未宣告（#679 的 fail-closed）只會讓
+    `executor_binary` 那一格變成標記，而 PATH 補上之後那一格會變、快取隨之失效——
+    **取不到答案本身也是一個會變的答案**。
+  - 測試 `tests/test_planning_probe_cache_672.py`（40 條）；**既有測試一行未改**。

--- a/docs/superpowers/plans/planner-job-downgrade.md
+++ b/docs/superpowers/plans/planner-job-downgrade.md
@@ -140,7 +140,9 @@ blocking reason——兩者剛好接得起來，缺任何一半都還是查不�
 
 ### 3. 票 C｜probe 結果快取（對應 R3；依賴票 A 的診斷欄位、票 B 的 invoker）
 
-- [ ] `tests/test_planning_probe_cache_672.py`（TDD RED）：
+**已由 issue #684 land。**
+
+- [x] `tests/test_planning_probe_cache_672.py`（TDD RED）：
   - `test_cache_key_includes_job_runner_mode`：`PSC_JOB_RUNNER` 由 `direct` 改
     `systemd-template` ⇒ 快取必失效（**這條是本票最重要的不變式**）。
   - `test_cache_invalidated_by_executor_binary_fingerprint`：可執行檔 mtime／inode 改變 ⇒ 失效。
@@ -154,16 +156,49 @@ blocking reason——兩者剛好接得起來，缺任何一半都還是查不�
     stdout 前 200 字／unit／resolved_binary／binary_version。
   - `test_cache_asset_not_in_any_job_unit_rwp`：登記表資產不出現在任一 job 模板 unit
     的 `ReadWritePaths` 產出中。
-- [ ] `paulsha_cortex/trust_root/registry.py`：新增資產 `planning-probe-cache`
+- [x] `paulsha_cortex/trust_root/registry.py`：新增資產 `planning-probe-cache`
       （`<coordinator_root>/planning-probe-cache.json`，Manager-owned 0600，
-      writers／readers 只有 `Principal.MANAGER`），並補進
-      `permgen.RUN_EXTERNAL_DEPENDENCIES` 的雙向封閉（否則
-      `unlisted_roster_entries()` 的測試會紅）。
-- [ ] `paulsha_cortex/coordinator/planning_probe_cache.py`（新檔）：指紋計算、讀寫、
+      writers／readers 只有 `Principal.MANAGER`），並補進 `permgen.PathLayout.asset_paths()`。
+      **`RUN_EXTERNAL_DEPENDENCIES` 不需要動**——見下方實作補充第 4 點。
+- [x] `paulsha_cortex/coordinator/planning_probe_cache.py`（新檔）：指紋計算、讀寫、
       TTL、fail-closed 語意。
-- [ ] `build_production_planning_runtime()` 改成先查快取、miss 才 probe。
+- [x] `build_production_planning_runtime()` 改成先查快取、miss 才 probe。
 - 驗收：direct 模式下連續兩次建構 runtime，第二次的 executor 呼叫次數為 0；
   改動任一指紋輸入後第二次必須重探；`python3 -m pytest tests/ -q` 全綠。
+
+**#684 的實作補充**（design D5 之外的六處收斂，票 E／票 F 沿用）：
+
+1. **`PSC_JOB_RUNNER` 進指紋的是「解析後的模式」，不是字面值。** design 的取法欄寫
+   「字面值」，但 `""`／`direct`／`DIRECT` 是**同一個部署**，用字面值會讓一次大小寫或
+   顯式化的整理造成一批無意義的重探；而解析走的正是 design D1 指定的
+   `job_runner.resolve_runner_mode()`，非法值在那支函式已 fail-closed。
+2. **指紋計算永不 raise，取不到的分量落 `<unresolved:<例外型別名>>`。** 這是必要的：
+   票 E 的前置「PATH 宣告票」尚未 land，而生產環境已是 `PSC_JOB_RUNNER=systemd-template`
+   ——`resolve_job_path(role=review)` 現在會 raise（#679 的 fail-closed 是對的）。若指紋
+   計算跟著 raise，票 C 一 land 就會把 planning 打掛。落標記則兩件事同時成立：這一輪照常
+   重探；PATH 補上之後指紋改變、快取自動失效。**取不到答案本身也是一個會變的答案。**
+   標記只帶例外**型別名**不帶訊息，與票 A `classify_probe_failure()` 依賴的是同一條邊界。
+3. **指紋多兩個不進 digest 的診斷欄位**（`resolved_binary`／`unit`）。內容已包含在對應的
+   digest 欄位字串裡，單獨列出只是讓快取 row 不必解析字串就能回答「當時解到哪一支、哪一
+   份 unit」——那正是 D8 拒因表要指名的兩件事。有測試逐欄釘住「六格改任一格 digest 必變、
+   這兩格改了 digest 必不變」。
+4. **`RUN_EXTERNAL_DEPENDENCIES` 不需要補。** plan 原文擔心的 `unlisted_roster_entries()`
+   只涵蓋**掛在帳號 HOME 底下**的資產（`home_anchored_asset_ids()` 由
+   `asset_paths()` × `home_anchored_account()` 機械導出）；本資產在
+   `<coordinator_root>`＝`<agents_root>/coordinator`，不在任何 `declared_accounts()` 的
+   HOME 下，因此雙向封閉本來就成立（已實跑
+   `tests/test_trust_root_external_deps_exhaustive_666.py` 確認）。
+5. **TTL 在讀取時依當下設定判定**（row 只存 `probed_at_epoch`），因此調短立即對既有 row
+   生效；非法值一律當 0（＝永遠 miss）而**不落回預設**——落回預設會讓一個打錯的值靜默
+   維持一小時的快取，那是 #643／#679 反覆買過單的形態。另加一條 design 沒寫的 fail-closed：
+   `probed_at` 落在未來（時鐘倒退）視為 miss，否則一次 NTP 校正就能讓 TTL 對某列永久失效。
+6. **並行不加鎖，但落盤前重讀磁碟合併。** Manager daemon 是單執行緒 poll 迴圈
+   （`manager_daemon.run_loop`，無 `threading`／`asyncio`），因此同一行程內兩輪 tick
+   不會重疊；跨行程（CLI 的 `apply_work_action` 與 daemon 同時跑）則可能兩邊同時 miss。
+   選擇是**接受多探一次**而不是加鎖：鎖住的那一邊會在 Manager 的 tick 迴圈裡等對方跑完
+   一批模型呼叫（每格上限 45s），那個代價比重探大得多。原子寫入（temp ＋ `os.replace`）
+   保證檔案永不半寫，落盤前重讀合併則保證「並行的代價」不會升級成「掉別人剛寫好的
+   結果」。**票 F 切換時仍須一次到位**——不是因為並行，而是因為指紋含 `PSC_JOB_RUNNER`。
 
 ### 4. 票 D｜permgen 把 planner 憑證面 codify（對應 R5；依賴 U-4／U-5／U-7 裁決）
 

--- a/paulsha_cortex/coordinator/planning_probe_cache.py
+++ b/paulsha_cortex/coordinator/planning_probe_cache.py
@@ -1,0 +1,642 @@
+"""issue #684（#672 票 C）：planning capability probe 的跨 tick 結果快取。
+
+## 為什麼要有這個檔
+
+`build_production_planning_runtime()` 對**每一個** planning-capable identity 各跑一次
+probe：`_probe_identity` 每次做兩次整棵 repo 的 `copytree`，`probe_agy_capability`
+則是兩次 CLI 呼叫。這個函式由 `manager.run_auto_claim_scan()`（periodic tick，實機
+`PSC_MANAGER_INTERVAL_SECONDS=600`）與 `apply_work_action()` 兩條路徑呼叫。
+
+票 E（#686）把 planning 搬上降權 job 之後，**每一次 probe 就是一個 systemd unit
+實例**（agy 是兩個）。沒有快取的話，那等於每 10 分鐘起一批 job 去問模型「你是誰」
+——成本不可接受，而且那批 job 的產出在絕大多數輪次裡與上一輪逐字相同。
+
+## 指紋：為什麼不能只放剖面名
+
+design D-C／D5 明文要求指紋放**模板 unit 檔本身**而不是剖面名。理由是 #677 落地的
+`PROFILE_LOCKED_KEYS`：兩份剖面的加固鍵逐字相同，剖面名相同**不代表** unit 內容
+相同（operator 重新落檔、產生器升級、RWP 增列都會改 unit 而不改剖面名）。只認剖面
+名會讓一個對新 unit 不成立的 `ready` 被沿用下去——而那正是「綠燈不承載語意」。
+
+把 unit 檔的 `st_size/st_mtime_ns` 放進指紋，等於把**部署動作**與**快取失效**綁成
+同一件事：operator 重跑產生器落新 unit 的那一刻，全部快取自動失效並重探，不需要
+任何人記得清快取。
+
+指紋另含 `PSC_JOB_RUNNER`：direct 與 job 兩種模式的執行環境（PATH／HOME／憑證／
+seccomp／MDWE）完全不同，切換一次就必須重探。這同時是 plan 要求「票 F 的生產切換
+必須一次到位、不能一半走 job」的機械保證——混用時兩種語意的結論不會在同一份快取裡
+並存，因為它們的指紋不同。
+
+## fail-closed：壞掉的快取永遠不會回答 ready
+
+`not_claimable.load_ledger()`（PR #675）對壞檔 **raise**，理由是「靜默當成空的等於
+把盲區再造一次」。本模組**刻意不同**——design D5 已寫明這處差異與理由：probe 快取
+只是一份輔助紀錄，它壞掉時若把整個 planning 拖垮，等於一份輔助紀錄取得了它不該有的
+否決權。因此改為「視為 miss ＋ 落一筆可辨識的診斷（`planning-probe-cache-unreadable`）」。
+
+兩者是**同一條原則**（不得靜默產生有利答案）在不同後果下的兩種實作：
+
+- `not_claimable`：壞檔 ⇒ raise（不可 claim 的項目必須查得到）；
+- 本模組：壞檔 ⇒ miss ＋ 重探（**絕不**因為讀不到而回答 ready）。
+
+「有利答案」在這裡就是 `ready`。本模組**沒有任何一條路徑**會在讀檔失敗、schema 不
+符、指紋不符、TTL 過期、或 row 形狀不合時回傳一個 ready 的 `CapabilityProbe`——
+:func:`ProbeCache.get` 只有一個 `return`，而它的輸入是一列**逐欄驗過**的 row。
+
+## 為什麼快取不進任何 job 模板 unit 的 RWP
+
+登記表資產 `planning-probe-cache` 的 writers／readers 只有 `Principal.MANAGER`
+（Manager-owned、`<coordinator_root>/planning-probe-cache.json`）。job 不該知道別的
+provider 的探測結果，更不該寫得動它——快取一旦可由 job 寫，「這個 provider 是
+ready 的」就變成模型可以自證的東西。
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import shutil
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable, Mapping
+from uuid import uuid4
+
+from . import job_runner
+from .model_identities import CapabilityProbe, IdentityRegistry, ModelIdentity
+
+__all__ = [
+    "CACHE_FILENAME",
+    "CACHE_SCHEMA",
+    "CACHE_UNREADABLE_REASON",
+    "CACHE_UNWRITABLE_REASON",
+    "DEFAULT_NOT_READY_TTL_SECONDS",
+    "DEFAULT_READY_TTL_SECONDS",
+    "FINGERPRINT_ABSENT",
+    "FINGERPRINT_DIGEST_FIELDS",
+    "FINGERPRINT_UNRESOLVED_PREFIX",
+    "NOT_READY_TTL_ENV",
+    "READY_TTL_ENV",
+    "ProbeCache",
+    "ProbeFingerprint",
+    "cache_path",
+    "compute_fingerprint",
+    "roster_digest",
+]
+
+
+logger = logging.getLogger(__name__)
+
+
+CACHE_SCHEMA = "cortex-planning-probe-cache/v1"
+CACHE_FILENAME = "planning-probe-cache.json"
+
+#: 快取檔讀不回來時落的**可辨識**診斷。與「probe 失敗」分開是硬性要求（design D5）
+#: ——否則會出現「快取檔壞了，症狀卻報成 provider 不可用」這種把排查方向整個帶偏的
+#: 誤報（#670 就是同一型的教訓）。
+CACHE_UNREADABLE_REASON = "planning-probe-cache-unreadable"
+#: 寫不進去時落的診斷。寫入失敗**不得**讓 planning 失敗：那一輪只是沒有快取。
+CACHE_UNWRITABLE_REASON = "planning-probe-cache-unwritable"
+
+READY_TTL_ENV = "PSC_PLANNING_PROBE_CACHE_READY_TTL_SECONDS"
+NOT_READY_TTL_ENV = "PSC_PLANNING_PROBE_CACHE_NOT_READY_TTL_SECONDS"
+
+#: ready 的預設保鮮期。成功不需要頻繁重確認——每一次重確認就是一批 job 的成本。
+DEFAULT_READY_TTL_SECONDS = 3600
+#: not-ready 的預設保鮮期。失敗要**快速**重試：暫時性的服務錯誤、限流、以及模型
+#: 輸出的隨機不從，短時間內就會自己好；把它們鎖在一小時的快取裡等於讓一次抖動
+#: 決定接下來六輪 tick 的 planning 拓撲。
+DEFAULT_NOT_READY_TTL_SECONDS = 300
+
+#: 指紋分量取不到時的標記。**只帶例外型別名**，不帶訊息——例外訊息會夾帶路徑與
+#: env，型別名不會（這條邊界與 `model_identities.classify_probe_failure()` 依賴的
+#: 是同一條，見票 A 的論證）。
+FINGERPRINT_UNRESOLVED_PREFIX = "<unresolved:"
+#: 指紋分量指向的檔案不存在。與 `<unresolved:…>` 是**兩件事**：前者是「查得到答案，
+#: 答案是沒有這個檔」，後者是「連查都查不動」。憑證從無到有必須重探，因此兩者都要
+#: 進指紋、且必須可分辨。
+FINGERPRINT_ABSENT = "<absent>"
+
+#: 參與 digest 計算的欄位。:class:`ProbeFingerprint` 另有兩個**不參與** digest 的
+#: 診斷欄位（`resolved_binary`／`unit`），它們的內容已經包含在對應的 digest 欄位裡，
+#: 單獨列出只是為了讓快取 row 不必再解析字串就能回答「當時解到哪一支、哪一份 unit」。
+FINGERPRINT_DIGEST_FIELDS: tuple[str, ...] = (
+    "job_runner_mode",
+    "roster_digest",
+    "executor_binary",
+    "executor_credential",
+    "hardening_profile",
+    "template_unit",
+)
+
+
+def cache_path(coordinator_root: str | Path) -> Path:
+    """`<coordinator_root>/planning-probe-cache.json`（登記表資產 `planning-probe-cache`）。
+
+    與 `not_claimable.ledger_path()`／`provider_backoff._state_path()` 同一個慣例：
+    路徑在本模組推導、由 `trust_root.registry` 以 `derived_in` 登記，權限則由
+    `permgen` 依登記表機械產出（Manager-owned，writers／readers 只有 Manager）。
+    """
+
+    return Path(coordinator_root) / CACHE_FILENAME
+
+
+def _utcnow() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _unresolved(exc: BaseException) -> str:
+    return f"{FINGERPRINT_UNRESOLVED_PREFIX}{type(exc).__name__}>"
+
+
+def roster_digest(registry: IdentityRegistry) -> str:
+    """roster 解析結果的 canonical JSON 雜湊（design D5 的第五個指紋輸入）。
+
+    來源刻意是**解析結果**而不是 overlay 檔的 mtime：overlay 可以被改了又改回來、
+    也可以由 packaged roster 提供同一列，真正會改變 probe 結論的是「合併之後的
+    候選集合長什麼樣」。`ModelIdentity.to_dict()` 是既有的 canonical 投影
+    （`write_registry_file` 用的同一支），這裡不另造一份序列化。
+    """
+
+    payload = {
+        "schema_version": registry.schema_version,
+        "identities": [identity.to_dict() for identity in registry.identities],
+    }
+    return hashlib.sha256(
+        json.dumps(payload, ensure_ascii=False, sort_keys=True).encode("utf-8")
+    ).hexdigest()
+
+
+def _stat_marker(path: str, *, fields: tuple[str, ...]) -> str:
+    """`<path>|k=v,…`；檔案不存在回 `<path>|<absent>`。**不讀任何內容。**
+
+    憑證那一格只取 `st_size/st_mtime_ns` 是刻意的（design D5）：讀內容才能算雜湊，
+    而那會讓 token 出現在本行程的記憶體與任何中間狀態裡。size＋mtime 已足以偵測
+    refresh 與換帳號，而它們**不是**祕密。
+    """
+
+    try:
+        info = os.stat(path)
+    except OSError:
+        return f"{path}|{FINGERPRINT_ABSENT}"
+    parts = [f"{name}={getattr(info, f'st_{name}')}" for name in fields]
+    return f"{path}|{','.join(parts)}"
+
+
+_BINARY_STAT_FIELDS = ("dev", "ino", "size", "mtime_ns")
+_FILE_STAT_FIELDS = ("size", "mtime_ns")
+
+
+@dataclass(frozen=True)
+class ProbeFingerprint:
+    """一個 identity 在**當下這個部署**上的 probe 前提。
+
+    「快取命中」的定義就是「指紋逐欄相同」——任何一格變了就重探。欄位少一個的
+    失效模式是**沿用一個對新環境不成立的 ready**，那種失敗看起來是成功的。
+    """
+
+    job_runner_mode: str
+    roster_digest: str
+    executor_binary: str
+    executor_credential: str
+    hardening_profile: str
+    template_unit: str
+    #: 診斷用（不進 digest）：PATH 解析到的絕對路徑，供 D8 的拒因表指名「跑的是哪一支」。
+    resolved_binary: str | None = None
+    #: 診斷用（不進 digest）：本 identity 在 job 模式下會用的模板 unit 名。
+    unit: str | None = None
+
+    def as_dict(self) -> dict[str, str]:
+        """digest 欄位的明表。存進 row 供 operator 直接看出「是哪一格變了」。"""
+
+        return {name: getattr(self, name) for name in FINGERPRINT_DIGEST_FIELDS}
+
+    @property
+    def digest(self) -> str:
+        return hashlib.sha256(
+            json.dumps(self.as_dict(), ensure_ascii=False, sort_keys=True).encode("utf-8")
+        ).hexdigest()
+
+
+def _search_path(mode: str, env: Mapping[str, str]) -> str:
+    """本模式下 executor 會被**誰的** PATH 解析。
+
+    - direct：probe 在 Manager 行程內跑，解析用的就是 Manager 自己的 `PATH`；
+    - job：probe 在降權 job 裡跑，PATH 由 `resolve_job_path(role=review)` 宣告，
+      未宣告即 fail-closed（#679）——那時指紋落 `<unresolved:JobRunnerError>`，
+      而 PATH 一旦補上，指紋就變、快取自動失效重探。
+    """
+
+    if mode == job_runner.RUNNER_DIRECT:
+        return env.get("PATH") or os.defpath
+    return job_runner.resolve_job_path(env, role=job_runner.JOB_ROLE_REVIEW)
+
+
+def _credential_path(mode: str, env: Mapping[str, str]) -> str:
+    """本模式下 executor 憑證的落點。
+
+    - direct：probe 用的是 Manager 行程的 `$HOME`，因此憑證就在那底下；
+    - job：`permgen` 的部署決定欄位（`reviewer_planner_account`）導出。
+
+    **已知限制（U-5／票 D）**：`PathLayout.executor_credential_relpath` 目前是
+    **單一**值（預設 `.codex/auth.json`），還沒有 per-(account, executor) 的表——
+    那正是 design 列為未決的 U-5。因此 agy 的 `~/.gemini` 狀態樹目前**不**在指紋
+    裡：它 refresh 時不會即時失效，最長由 not-ready TTL（預設 300s）兜住。票 D 把
+    憑證面 codify 之後，這裡跟著 `executor_credential_of` 的新簽章走即可，不必在
+    本模組另造一張表（那就是第二份真相）。
+    """
+
+    from ..trust_root import permgen
+
+    layout = permgen.DEFAULT_LAYOUT
+    if mode == job_runner.RUNNER_DIRECT:
+        home = (env.get("HOME") or "").strip()
+        if not home:
+            raise ValueError("HOME undeclared")
+        return os.path.join(home, layout.executor_credential_relpath)
+    return layout.executor_credential_of(layout.reviewer_planner_account)
+
+
+def compute_fingerprint(
+    identity: ModelIdentity,
+    *,
+    roster: str,
+    env: Mapping[str, str] | None = None,
+) -> ProbeFingerprint:
+    """算出這個 identity 的 probe 前提指紋。**本函式永不 raise。**
+
+    永不 raise 是硬性要求：指紋是**輔助**設施，它算不出來時正確的行為是「這一格
+    落一個可辨識的標記、快取視為 miss、照常重探」，不是把整條 planning 拖垮。
+    每個分量各自守備，因此「PATH 未宣告」只會讓 `executor_binary` 那一格變成
+    `<unresolved:JobRunnerError>`，其餘五格照常參與比對；而 PATH 補上之後那一格
+    會變，快取隨之失效——**取不到答案本身也是一個會變的答案**。
+    """
+
+    environ = env if env is not None else os.environ
+
+    def _safe(compute) -> str:
+        try:
+            return compute()
+        except Exception as exc:  # noqa: BLE001 — 見 docstring：指紋不得拖垮 planning
+            return _unresolved(exc)
+
+    mode = _safe(lambda: job_runner.resolve_runner_mode(environ))
+    resolved_binary: str | None = None
+    unit_name: str | None = None
+
+    def _binary() -> str:
+        nonlocal resolved_binary
+        found = shutil.which(identity.executor, path=_search_path(mode, environ))
+        if found is None:
+            return f"{identity.executor}|{FINGERPRINT_ABSENT}"
+        resolved_binary = found
+        return _stat_marker(found, fields=_BINARY_STAT_FIELDS)
+
+    def _credential() -> str:
+        return _stat_marker(_credential_path(mode, environ), fields=_FILE_STAT_FIELDS)
+
+    def _profile() -> str:
+        return job_runner.resolve_hardening_profile(identity.executor)
+
+    def _template() -> str:
+        nonlocal unit_name
+        profile = job_runner.resolve_hardening_profile(identity.executor)
+        base = job_runner.resolve_template_unit(environ, role=job_runner.JOB_ROLE_REVIEW)
+        unit_name = job_runner.template_unit_for_profile(base, profile)
+        return _stat_marker(
+            os.path.join(job_runner.DEFAULT_TEMPLATE_UNIT_DIR, unit_name),
+            fields=_FILE_STAT_FIELDS,
+        )
+
+    return ProbeFingerprint(
+        job_runner_mode=mode,
+        roster_digest=roster,
+        executor_binary=_safe(_binary),
+        executor_credential=_safe(_credential),
+        hardening_profile=_safe(_profile),
+        template_unit=_safe(_template),
+        resolved_binary=resolved_binary,
+        unit=unit_name,
+    )
+
+
+def _entry_key(executor: str, model_id: str) -> str:
+    return f"{executor}::{model_id}"
+
+
+def _empty() -> dict[str, Any]:
+    return {"schema": CACHE_SCHEMA, "items": {}}
+
+
+def _positive_int(env: Mapping[str, str], name: str, default: int) -> int:
+    """TTL 的 env 覆寫。**非法值一律當 0（＝永遠 miss）**，不落回預設。
+
+    落回預設會讓一個打錯的 `PSC_..._TTL_SECONDS=3O0` 靜默地維持一小時的快取，
+    operator 以為自己調短了卻沒有——那是 #643／#679 反覆買過單的形態。當 0 的代價
+    只是多付探測成本（而且 log 會指名），方向與本模組其餘部分一致：不確定就重探。
+    """
+
+    raw = (env.get(name) or "").strip()
+    if not raw:
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        logger.error("planning-probe-cache-ttl-invalid variable=%s value=%r", name, raw)
+        return 0
+    if value < 0:
+        logger.error("planning-probe-cache-ttl-invalid variable=%s value=%r", name, raw)
+        return 0
+    return value
+
+
+@dataclass
+class ProbeCache:
+    """`<coordinator_root>/planning-probe-cache.json` 的讀寫。**建構與讀取永不 raise。**
+
+    形狀沿用 `not_claimable`（PR #675）：`schema` 版本字串 ＋ `items` 以穩定 key
+    索引 ＋ 每筆帶 `first_observed_at`／`last_observed_at`／`observations`（operator
+    因此看得出「這個 provider 掛多久了」）＋ 條件解除時自動清除（roster 不再有這個
+    identity ⇒ :meth:`flush` 把它移掉）。原子寫入（temp ＋ `os.replace` ＋ 目錄
+    fsync）也照抄 `not_claimable._save()`。
+
+    唯一刻意的不同是「壞檔不得 raise」，理由見模組 docstring。
+    """
+
+    path: Path
+    env: Mapping[str, str] = field(default_factory=lambda: os.environ)
+    clock: Any = time.time
+    _items: dict[str, Any] = field(default_factory=dict, repr=False)
+    #: 本次開檔時檔案是否讀不回來（壞檔／schema 不符）。呼叫端可據此在診斷面上把
+    #: 「快取壞了」與「provider 不可用」分開。
+    unreadable: bool = False
+    _dirty: bool = False
+
+    @classmethod
+    def open(
+        cls,
+        path: str | Path,
+        *,
+        env: Mapping[str, str] | None = None,
+        clock: Any = time.time,
+    ) -> "ProbeCache":
+        target = Path(path)
+        cache = cls(path=target, env=env if env is not None else os.environ, clock=clock)
+        cache._load()
+        return cache
+
+    # -- 讀 -----------------------------------------------------------------
+
+    def _load(self) -> None:
+        if not self.path.exists():
+            return
+        try:
+            payload = json.loads(self.path.read_text(encoding="utf-8"))
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+            self._corrupt(f"{type(exc).__name__}")
+            return
+        if not isinstance(payload, dict):
+            self._corrupt("payload-not-object")
+            return
+        if payload.get("schema") != CACHE_SCHEMA:
+            self._corrupt(f"schema={payload.get('schema')!r}")
+            return
+        items = payload.get("items")
+        if not isinstance(items, dict):
+            self._corrupt("items-not-object")
+            return
+        self._items = {key: row for key, row in items.items() if isinstance(key, str)}
+
+    def _corrupt(self, detail: str) -> None:
+        """壞檔：視為空 ＋ 落一筆可辨識的診斷。**絕不 raise、絕不沿用任何 ready。**"""
+
+        self.unreadable = True
+        self._items = {}
+        # 下一次 flush 會以「空的既有內容」為底重寫，等於就地修好這份檔案；在那之前
+        # 這一輪的每一格都是 miss，全部重探。
+        self._dirty = True
+        logger.error("%s path=%s detail=%s", CACHE_UNREADABLE_REASON, self.path, detail)
+
+    def ttl_seconds(self, *, ready: bool) -> int:
+        if ready:
+            return _positive_int(self.env, READY_TTL_ENV, DEFAULT_READY_TTL_SECONDS)
+        return _positive_int(self.env, NOT_READY_TTL_ENV, DEFAULT_NOT_READY_TTL_SECONDS)
+
+    def get(
+        self, identity: ModelIdentity, *, fingerprint: ProbeFingerprint
+    ) -> CapabilityProbe | None:
+        """命中回一個與當初逐欄相同的 `CapabilityProbe`；任何不確定一律回 `None`。
+
+        本函式只有一個回傳 `CapabilityProbe` 的出口，而它的輸入是一列**逐欄驗過**
+        的 row。指紋不符、TTL 過期、`probed_at` 在未來（時鐘倒退）、row 形狀不合、
+        身分欄位與 roster 對不上——全部回 `None`（＝miss ＝重探）。
+        """
+
+        row = self._items.get(_entry_key(identity.executor, identity.model_id))
+        if not isinstance(row, dict):
+            return None
+        if row.get("fingerprint") != fingerprint.digest:
+            return None
+        ready = row.get("ready")
+        if not isinstance(ready, bool):
+            return None
+        # 身分三欄必須與 roster 這一列逐字相同。roster digest 已在指紋裡，因此這是
+        # 第二層；但快取 row 是**檔案**，而檔案是可以被就地改的——一份手動改過
+        # `executor` 的 row 不該讓別人的 ready 落到這一格上。
+        if (
+            row.get("executor") != identity.executor
+            or row.get("model_id") != identity.model_id
+            or row.get("independence_domain") != identity.independence_domain
+        ):
+            return None
+        probed_at = row.get("probed_at_epoch")
+        if not isinstance(probed_at, (int, float)) or isinstance(probed_at, bool):
+            return None
+        age = float(self.clock()) - float(probed_at)
+        if age < 0:
+            # 時鐘倒退（NTP 校正、VM 還原）。fail-closed：寧可重探。
+            return None
+        ttl = self.ttl_seconds(ready=ready)
+        if ttl <= 0 or age >= ttl:
+            return None
+        reason = row.get("reason")
+        diagnostic = row.get("diagnostic")
+        if reason is not None and not isinstance(reason, str):
+            return None
+        if diagnostic is not None and not isinstance(diagnostic, str):
+            return None
+        if ready and (reason is not None or diagnostic is not None):
+            # ready 的 probe 依定義沒有失敗欄位（`CapabilityProbe.ready_for`）。
+            # 一列同時帶 ready 與失敗診斷是矛盾的 row，fail-closed。
+            return None
+        return CapabilityProbe(
+            ready,
+            identity.executor,
+            identity.model_id,
+            identity.independence_domain,
+            reason,
+            diagnostic,
+        )
+
+    # -- 寫 -----------------------------------------------------------------
+
+    def put(
+        self,
+        identity: ModelIdentity,
+        probe: CapabilityProbe,
+        *,
+        fingerprint: ProbeFingerprint,
+        now: str | None = None,
+    ) -> dict[str, Any]:
+        """記一次實際探測的結果（含失敗側的完整診斷，design D5）。
+
+        `reason`／`diagnostic` **逐字沿用** `CapabilityProbe`，不在快取層再造一份
+        節錄邏輯——#674 的 `stdout_excerpt()`／`strip_code_fence()` 已經是那件事的
+        唯一真相，複製一份到這裡就是第二份。
+
+        `returncode`／`stdout_prefix`／`binary_version` 三欄先立在 schema 上但目前
+        恆為 `None`：它們的來源是票 E 的 `PlanningOutcome.diagnostics`（direct 模式
+        沒有第二個資訊來源）。這不是缺口，是票的邊界——票 E 落地時只要填這三格，
+        schema 版本不必動。
+        """
+
+        key = _entry_key(identity.executor, identity.model_id)
+        observed_at = now if isinstance(now, str) and now else _utcnow()
+        previous = self._items.get(key)
+        # 「同一件事的第 N 次觀測」的判準：指紋、ready、reason 三者皆同。任何一格變
+        # 了就是**新的**一件事，`first_observed_at` 重新起算——否則「這個 provider
+        # 掛多久了」會把兩段不同原因的失敗接成一段，那個數字就不再是真話。
+        same = (
+            isinstance(previous, dict)
+            and previous.get("fingerprint") == fingerprint.digest
+            and previous.get("ready") is probe.ready
+            and previous.get("reason") == probe.reason
+        )
+        row: dict[str, Any] = {
+            "executor": identity.executor,
+            "model_id": identity.model_id,
+            "independence_domain": identity.independence_domain,
+            "ready": bool(probe.ready),
+            "reason": probe.reason,
+            "diagnostic": probe.diagnostic,
+            "family": (
+                None
+                if probe.ready or probe.reason is None
+                else _classify(probe.reason, probe.diagnostic)
+            ),
+            # 票 E 的 D8 會填這三格（來源＝`PlanningOutcome.diagnostics`）。
+            "returncode": None,
+            "stdout_prefix": None,
+            "binary_version": None,
+            "unit": fingerprint.unit,
+            "hardening_profile": fingerprint.hardening_profile,
+            "resolved_binary": fingerprint.resolved_binary,
+            "fingerprint": fingerprint.digest,
+            "fingerprint_inputs": fingerprint.as_dict(),
+            "probed_at": observed_at,
+            "probed_at_epoch": float(self.clock()),
+            "first_observed_at": (
+                previous.get("first_observed_at")
+                if same and isinstance(previous.get("first_observed_at"), str)
+                else observed_at
+            ),
+            "last_observed_at": observed_at,
+            "observations": (
+                previous.get("observations", 0) + 1
+                if same and isinstance(previous.get("observations"), int)
+                else 1
+            ),
+        }
+        self._items[key] = row
+        self._dirty = True
+        return dict(row)
+
+    def flush(self, *, keep: Iterable[tuple[str, str]] | None = None) -> bool:
+        """落盤。`keep` 給定時，**不在**該集合裡的 row 一併清除（自我收斂）。
+
+        清除是 `not_claimable.clear()` 的同型：roster 移掉一個 identity 之後，它的
+        探測結果沒有任何消費者，留著只會讓 operator 對著一筆永遠不會更新的紀錄猜。
+
+        寫入前**重讀一次**磁碟並以它為底疊上本次的異動：兩個行程同時 miss 時，先寫
+        的那一份不會被後寫的整份蓋掉。這**不是**鎖（見 :meth:`put` 上方的說明），
+        只是把「並行的代價」收斂成「多探一次」，而不是「掉一批別人剛寫好的結果」。
+        """
+
+        keep_keys = (
+            {_entry_key(executor, model_id) for executor, model_id in keep}
+            if keep is not None
+            else None
+        )
+        stale = (
+            [key for key in self._items if key not in keep_keys]
+            if keep_keys is not None
+            else []
+        )
+        if not self._dirty and not stale:
+            return False
+        for key in stale:
+            del self._items[key]
+        merged = self._merged_payload(keep_keys)
+        try:
+            self._save(merged)
+        except OSError as exc:
+            logger.error(
+                "%s path=%s error=%s", CACHE_UNWRITABLE_REASON, self.path, type(exc).__name__
+            )
+            return False
+        self._dirty = False
+        return True
+
+    def _merged_payload(self, keep_keys: set[str] | None) -> dict[str, Any]:
+        """磁碟現況（讀不回來即空）＋ 本行程異動；`keep_keys` 之外的一律不留。"""
+
+        disk = ProbeCache(path=self.path, env=self.env, clock=self.clock)
+        disk._load()
+        items: dict[str, Any] = {}
+        for source in (disk._items, self._items):
+            for key, row in source.items():
+                if keep_keys is not None and key not in keep_keys:
+                    continue
+                items[key] = row
+        return {"schema": CACHE_SCHEMA, "items": items}
+
+    def _save(self, payload: dict[str, Any]) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        temporary = self.path.parent / f".{self.path.name}.{uuid4().hex}.tmp"
+        try:
+            with temporary.open("x", encoding="utf-8") as handle:
+                json.dump(payload, handle, ensure_ascii=False, indent=2, sort_keys=True)
+                handle.write("\n")
+                handle.flush()
+                os.fsync(handle.fileno())
+            # Manager-owned 0600（登記表 `planning-probe-cache` 的宣告）。權限由
+            # permgen 依登記表機械產出，這裡是**建檔當下**的同一個值——一份新建的
+            # 快取不該在 permgen 下一次跑之前是 group-readable 的。
+            os.chmod(temporary, 0o600)
+            os.replace(temporary, self.path)
+            directory_fd = os.open(self.path.parent, os.O_RDONLY | os.O_DIRECTORY)
+            try:
+                os.fsync(directory_fd)
+            finally:
+                os.close(directory_fd)
+        except BaseException:
+            temporary.unlink(missing_ok=True)
+            raise
+
+    # -- 呈現面 -------------------------------------------------------------
+
+    def entries(self) -> list[dict[str, Any]]:
+        """穩定排序的 row 清單（診斷用；壞檔時為空）。"""
+
+        return [dict(self._items[key]) for key in sorted(self._items)]
+
+
+def _classify(reason: str, diagnostic: str | None) -> str:
+    """票 A 的 `classify_probe_failure()`——延後 import 避免無謂的模組層耦合。"""
+
+    from .model_identities import classify_probe_failure
+
+    return classify_probe_failure(reason, diagnostic)

--- a/paulsha_cortex/coordinator/planning_probe_cache.py
+++ b/paulsha_cortex/coordinator/planning_probe_cache.py
@@ -331,7 +331,7 @@ def _empty() -> dict[str, Any]:
     return {"schema": CACHE_SCHEMA, "items": {}}
 
 
-def _positive_int(env: Mapping[str, str], name: str, default: int) -> int:
+def _ttl_from_env(env: Mapping[str, str], name: str, default: int) -> int:
     """TTL 的 env 覆寫。**非法值一律當 0（＝永遠 miss）**，不落回預設。
 
     落回預設會讓一個打錯的 `PSC_..._TTL_SECONDS=3O0` 靜默地維持一小時的快取，
@@ -422,8 +422,8 @@ class ProbeCache:
 
     def ttl_seconds(self, *, ready: bool) -> int:
         if ready:
-            return _positive_int(self.env, READY_TTL_ENV, DEFAULT_READY_TTL_SECONDS)
-        return _positive_int(self.env, NOT_READY_TTL_ENV, DEFAULT_NOT_READY_TTL_SECONDS)
+            return _ttl_from_env(self.env, READY_TTL_ENV, DEFAULT_READY_TTL_SECONDS)
+        return _ttl_from_env(self.env, NOT_READY_TTL_ENV, DEFAULT_NOT_READY_TTL_SECONDS)
 
     def get(
         self, identity: ModelIdentity, *, fingerprint: ProbeFingerprint

--- a/paulsha_cortex/coordinator/planning_runtime.py
+++ b/paulsha_cortex/coordinator/planning_runtime.py
@@ -16,7 +16,8 @@ from pathlib import PurePosixPath
 from typing import Callable, Mapping, Protocol
 from uuid import uuid4
 
-from . import job_runner
+from ..config import paths
+from . import job_runner, planning_probe_cache
 from .launcher import build_agy_argv
 from .model_identities import (
     AGY_MODEL_ID,
@@ -1283,6 +1284,7 @@ def build_production_planning_runtime(
     timeout_seconds: int = 120,
     evidence_root: str | Path | None = None,
     run_id: str = "ephemeral",
+    probe_cache_path: str | Path | None = None,
 ) -> ProductionPlanningRuntime:
     """Build the daemon's real, safe, heterogeneous planning adapters.
 
@@ -1303,6 +1305,12 @@ def build_production_planning_runtime(
 
     四個 adapter 與兩種 probe 全部走同一個 invoker——票 E 因此只換一個物件，
     不必再碰任何呼叫端。
+
+    issue #684（票 C）：probe 結果跨 tick 快取。`probe_cache_path` 未給時落在
+    `<coordinator_root>/planning-probe-cache.json`（登記表資產
+    `planning-probe-cache`，Manager-owned 0600）。快取層**永不 raise**：讀不回來
+    ／指紋不符／TTL 過期一律視為 miss 重探，因此本函式的失敗語意與 #684 之前逐字
+    相同（見 `planning_probe_cache` 的模組 docstring）。
     """
 
     if invoker is not None and runner is not None:
@@ -1315,20 +1323,38 @@ def build_production_planning_runtime(
         )
     root = Path(worktree).resolve()
     registry = load_model_identities()
+    cache = planning_probe_cache.ProbeCache.open(
+        probe_cache_path
+        if probe_cache_path is not None
+        else planning_probe_cache.cache_path(paths.coordinator_root())
+    )
+    roster = planning_probe_cache.roster_digest(registry)
     probes: dict[tuple[str, str], CapabilityProbe] = {}
+    planning_keys: list[tuple[str, str]] = []
     for identity in registry.identities:
         if "planning" not in identity.capabilities:
+            continue
+        key = (identity.executor, identity.model_id)
+        planning_keys.append(key)
+        # #684：指紋是「這一格的 probe 前提」——`PSC_JOB_RUNNER`、PATH 解析到的
+        # executor 絕對路徑與 stat、憑證檔 stat、加固剖面、**模板 unit 檔本身**的
+        # stat、roster 摘要。任何一格變了就重探；算不出來的那一格落
+        # `<unresolved:…>`，同樣是一個會變的值。
+        fingerprint = planning_probe_cache.compute_fingerprint(identity, roster=roster)
+        cached = cache.get(identity, fingerprint=fingerprint)
+        if cached is not None:
+            probes[key] = cached
             continue
         if identity.executor == "agy" and identity.model_id == AGY_MODEL_ID:
             # agy 的能力探測是兩步 CLI 協定，不是一個 prompt——它拿的是 invoker
             # 的 `capability_probe_runner()` 接縫（見該方法的 docstring），
             # 而不再是呼叫端手上的裸 runner。
-            probes[(identity.executor, identity.model_id)] = probe_agy_capability(
+            probe = probe_agy_capability(
                 runner=invoker.capability_probe_runner(),
                 timeout_seconds=min(timeout_seconds, 45),
             )
         else:
-            probes[(identity.executor, identity.model_id)] = _probe_identity(
+            probe = _probe_identity(
                 identity,
                 worktree=root,
                 invoker=invoker,
@@ -1336,6 +1362,11 @@ def build_production_planning_runtime(
                 evidence_root=evidence_root,
                 run_id=run_id,
             )
+        probes[key] = probe
+        cache.put(identity, probe, fingerprint=fingerprint)
+    # roster 不再含有的 identity 自動清除（`not_claimable.clear()` 的同型）：
+    # 沒有消費者的探測結果留著只會讓 operator 對一筆永不更新的紀錄猜。
+    cache.flush(keep=planning_keys)
 
     primary_identity = registry.get(*primary)
 

--- a/paulsha_cortex/trust_root/permgen.py
+++ b/paulsha_cortex/trust_root/permgen.py
@@ -2128,6 +2128,10 @@ class PathLayout:
             "gate-ledger": self.dispatch_log_root,
             "delivery-journal": f"{c}/delivery-journal.json",
             "provider-backoff": f"{c}/provider-rate-limit-backoff.json",
+            # #684：planning probe 的跨 tick 快取。Manager-owned 葉檔，**不**列入
+            # 任何 job 模板 unit 的 RWP（登記表的 writers/readers 只有 MANAGER，
+            # 因此 `required_write_targets()` 對 job 帳號機械地不會產出這一條）。
+            "planning-probe-cache": f"{c}/planning-probe-cache.json",
             "workflow-report-journal": f"{c}/workflow-report-transactions",
             "digest-outbox": f"{c}/digest/outbox",
             "engineering-outcome-outbox": f"{c}/engineering-outcomes",

--- a/paulsha_cortex/trust_root/registry.py
+++ b/paulsha_cortex/trust_root/registry.py
@@ -888,6 +888,25 @@ ASSET_REGISTRY: tuple[TrustRootAsset, ...] = (
         derived_in=("coordinator/provider_backoff.py:22,38-39",),
     ),
     TrustRootAsset(
+        "planning-probe-cache", _T1, _MO, None,
+        (Principal.MANAGER,), (Principal.MANAGER,), IngressKind.MANAGER_INTERNAL,
+        derived_in=("coordinator/planning_probe_cache.py:cache_path",),
+        note=(
+            "#684（#672 票 C）：planning capability probe 的跨 tick 結果快取"
+            "（`<coordinator_root>/planning-probe-cache.json`）。\n"
+            "**writers／readers 刻意只有 Manager，且刻意不進任何 job 模板 unit 的 "
+            "`ReadWritePaths`**：job 不該知道別的 provider 的探測結果，更不該寫得動它"
+            "——快取一旦可由 job 寫，「這個 provider 是 ready 的」就變成模型可以自證的"
+            "東西，而 `select_secondary_planner()` 的整個異質性論證就建立在那個判定不是"
+            "模型說了算上。tier 是 T1 而非 T0：它改不了 acceptance、也給不了 ship "
+            "authority，最壞情況是讓 planning 選到一個實際不可用的 secondary（下一次"
+            "呼叫即失敗）。\n"
+            "快取本身 fail-closed：讀不回來一律視為 miss 重探，**絕不**沿用 ready"
+            "（見 `planning_probe_cache` 的模組 docstring 對 `not_claimable` 那處"
+            "刻意差異的說明）。"
+        ),
+    ),
+    TrustRootAsset(
         "workflow-report-journal", _T1, _MO, None,
         (Principal.MANAGER,), (Principal.MANAGER,), IngressKind.MANAGER_INTERNAL,
         derived_in=("coordinator/manager.py:4434",),

--- a/tests/test_planning_probe_cache_672.py
+++ b/tests/test_planning_probe_cache_672.py
@@ -1,0 +1,770 @@
+"""issue #684（#672 票 C）：probe 結果快取——指紋、TTL、fail-closed。
+
+驗收（issue 原文三條）：
+
+1. 連續兩次建構 runtime，第二次的 executor 呼叫次數為 **0**；
+2. 改動**任一**指紋輸入必重探；
+3. 快取損毀一律視為 **miss**，**不得沿用 `ready`**（fail-closed）。
+
+第三條是本票最重要的不變式：一份壞掉的快取檔絕對不能被解讀成「探過了、是
+ready」。因此本檔對「壞」窮舉了七種形態（JSON 壞、payload 不是物件、schema 不符、
+items 不是物件、row 不是物件、row 身分欄位被改、row 同時帶 ready 與失敗診斷），
+每一種都必須以**重探**收場。
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import stat
+from pathlib import Path
+
+import pytest
+
+from paulsha_cortex.coordinator import job_runner, planning_probe_cache, planning_runtime
+from paulsha_cortex.coordinator.model_identities import (
+    AGY_MODEL_ID,
+    CapabilityProbe,
+    IdentityRegistry,
+    ModelIdentity,
+)
+from paulsha_cortex.trust_root import permgen, registry as trust_registry
+
+
+CACHE_ASSET = "planning-probe-cache"
+
+
+def _completed(stdout: str = "", returncode: int = 0):
+    return type("Completed", (), {"stdout": stdout, "stderr": "", "returncode": returncode})()
+
+
+def _identity(executor: str = "codex", model_id: str = "primary") -> ModelIdentity:
+    return ModelIdentity(
+        executor=executor,
+        model_id=model_id,
+        independence_domain="openai" if executor == "codex" else "google",
+        capabilities=("planning",),
+    )
+
+
+def _registry(*identities: ModelIdentity) -> IdentityRegistry:
+    rows: list[dict[str, object]] = []
+    for identity in identities or (_identity(),):
+        row: dict[str, object] = {
+            "executor": identity.executor,
+            "model_id": identity.model_id,
+            "independence_domain": identity.independence_domain,
+            "capabilities": list(identity.capabilities),
+        }
+        if identity.executor == "agy":
+            row["live_probe"] = "agy-plan-sandbox"
+        rows.append(row)
+    return IdentityRegistry.from_rows(rows)
+
+
+def _echo_runner(calls: list[list[str]]):
+    """把 probe prompt 裡的 JSON 原樣回吐——probe 因此一律 ready。"""
+
+    def runner(argv, **kwargs):
+        calls.append(list(argv))
+        if list(argv) == ["agy", "models"]:
+            return _completed(f"{AGY_MODEL_ID}\n")
+        prompt = argv[argv.index("--print") + 1] if "--print" in argv else argv[2]
+        for marker in (
+            "Return only this compact JSON object and perform no tool calls: ",
+            "Return only this JSON object and do not call tools: ",
+        ):
+            if marker in prompt:
+                return _completed(prompt.split(marker, 1)[1] + "\n")
+        return _completed(json.dumps({"schema_version": 1, "question_pack_id": "qp"}))
+
+    return runner
+
+
+@pytest.fixture
+def hermetic_fingerprint(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    """把三個會被 stat 的指紋來源全部釘進 tmp_path，讓測試可以逐一改動它們。
+
+    - executor 可執行檔：`PATH` 指向 `bin/`（裡面有一支假 `codex`）；
+    - 憑證：`HOME` 指向 `home/`（`.codex/auth.json`）；
+    - 模板 unit：`job_runner.DEFAULT_TEMPLATE_UNIT_DIR` 指向 `units/`。
+    """
+
+    binaries = tmp_path / "bin"
+    binaries.mkdir()
+    fake = binaries / "codex"
+    fake.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    fake.chmod(0o755)
+
+    home = tmp_path / "home"
+    (home / ".codex").mkdir(parents=True)
+    (home / ".codex" / "auth.json").write_text("{}", encoding="utf-8")
+
+    units = tmp_path / "units"
+    units.mkdir()
+    (units / "cortex-reviewer-job-jit@.service").write_text("[Unit]\n", encoding="utf-8")
+
+    monkeypatch.setenv("PATH", str(binaries))
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setattr(job_runner, "DEFAULT_TEMPLATE_UNIT_DIR", str(units))
+    return tmp_path
+
+
+def _fingerprint(identity: ModelIdentity | None = None, *, roster: str = "roster-v1"):
+    return planning_probe_cache.compute_fingerprint(identity or _identity(), roster=roster)
+
+
+# ---------------------------------------------------------------------------
+# 驗收 1：連續兩次建構 runtime，第二次零 executor 呼叫
+# ---------------------------------------------------------------------------
+
+
+def test_second_runtime_build_makes_zero_executor_calls(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    identities = _registry(_identity(), _identity("agy", AGY_MODEL_ID))
+    monkeypatch.setattr(planning_runtime, "load_model_identities", lambda: identities)
+    cache = tmp_path / "planning-probe-cache.json"
+    calls: list[list[str]] = []
+
+    first = planning_runtime.build_production_planning_runtime(
+        primary=("codex", "primary"),
+        worktree=tmp_path,
+        runner=_echo_runner(calls),
+        probe_cache_path=cache,
+    )
+    assert first.probes[("codex", "primary")].ready is True
+    assert first.probes[("agy", AGY_MODEL_ID)].ready is True
+    assert calls, "第一次建構必須真的探測"
+    first_round = len(calls)
+
+    second = planning_runtime.build_production_planning_runtime(
+        primary=("codex", "primary"),
+        worktree=tmp_path,
+        runner=_echo_runner(calls),
+        probe_cache_path=cache,
+    )
+    # 驗收第一條：第二次的 executor 呼叫次數為 0。
+    assert len(calls) == first_round
+    # 而且結果逐欄相同——快取不是「跳過探測」，是「重放上一次的結論」。
+    assert second.probes == first.probes
+
+
+def test_cache_defaults_to_the_manager_owned_coordinator_root(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """未指定路徑時落在 `<coordinator_root>/planning-probe-cache.json`。"""
+
+    monkeypatch.setenv("PSC_AGENTS_ROOT", str(tmp_path / "agents"))
+    monkeypatch.setattr(planning_runtime, "load_model_identities", lambda: _registry())
+    planning_runtime.build_production_planning_runtime(
+        primary=("codex", "primary"), worktree=tmp_path, runner=_echo_runner([])
+    )
+    expected = tmp_path / "agents" / "coordinator" / planning_probe_cache.CACHE_FILENAME
+    assert expected.is_file()
+    # Manager-owned 0600：一份新建的快取不該在 permgen 下一次跑之前是可被別人讀的。
+    assert stat.S_IMODE(expected.stat().st_mode) == 0o600
+
+
+# ---------------------------------------------------------------------------
+# 驗收 2：改動任一指紋輸入必重探
+# ---------------------------------------------------------------------------
+
+
+def test_cache_key_includes_job_runner_mode(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, hermetic_fingerprint: Path
+) -> None:
+    """`PSC_JOB_RUNNER` 由 direct 改 systemd-template ⇒ 快取必失效。
+
+    **這條是本票最重要的不變式**：兩種模式的執行環境（PATH／HOME／憑證／seccomp／
+    MDWE）完全不同，一個在 direct 下成立的 ready 對 job 模式毫無保證。它同時是
+    plan 要求「票 F 的切換必須一次到位」的機械保證。
+    """
+
+    monkeypatch.delenv("PSC_JOB_RUNNER", raising=False)
+    direct = _fingerprint()
+    assert direct.job_runner_mode == job_runner.RUNNER_DIRECT
+
+    monkeypatch.setenv("PSC_JOB_RUNNER", job_runner.RUNNER_SYSTEMD_TEMPLATE)
+    downgraded = _fingerprint()
+    assert downgraded.job_runner_mode == job_runner.RUNNER_SYSTEMD_TEMPLATE
+    assert downgraded.digest != direct.digest
+
+    cache = planning_probe_cache.ProbeCache.open(tmp_path / "cache.json")
+    cache.put(_identity(), CapabilityProbe.ready_for("codex", "primary", "openai"), fingerprint=direct)
+    assert cache.get(_identity(), fingerprint=direct) is not None
+    assert cache.get(_identity(), fingerprint=downgraded) is None
+
+
+def test_cache_invalidated_by_executor_binary_fingerprint(
+    tmp_path: Path, hermetic_fingerprint: Path
+) -> None:
+    before = _fingerprint()
+    assert before.resolved_binary == str(hermetic_fingerprint / "bin" / "codex")
+
+    cache = planning_probe_cache.ProbeCache.open(tmp_path / "cache.json")
+    cache.put(_identity(), CapabilityProbe.ready_for("codex", "primary", "openai"), fingerprint=before)
+    assert cache.get(_identity(), fingerprint=before) is not None
+
+    binary = hermetic_fingerprint / "bin" / "codex"
+    os.utime(binary, ns=(1, 1))
+    after = _fingerprint()
+    assert after.digest != before.digest
+    assert cache.get(_identity(), fingerprint=after) is None
+
+
+def test_cache_invalidated_by_template_unit_fingerprint(
+    tmp_path: Path, hermetic_fingerprint: Path
+) -> None:
+    """模板 unit 檔改變 ⇒ 失效（＝任何讓 operator 重跑產生器的改動都自動全重探）。
+
+    這一條是 design D-C 的核心：`PROFILE_LOCKED_KEYS`（#677）說明**剖面名相同不代表
+    unit 內容相同**。只認剖面名會沿用一個對新 unit 不成立的 ready。
+    """
+
+    unit = hermetic_fingerprint / "units" / "cortex-reviewer-job-jit@.service"
+    before = _fingerprint()
+    assert before.unit == "cortex-reviewer-job-jit@.service"
+    # 剖面名這一格**沒有**變（jit 還是 jit）——變的是 unit 檔本身。
+    unit.write_text("[Unit]\n[Service]\nReadWritePaths=/new\n", encoding="utf-8")
+    after = _fingerprint()
+    assert after.hardening_profile == before.hardening_profile == job_runner.HARDENING_PROFILE_JIT
+    assert after.template_unit != before.template_unit
+    assert after.digest != before.digest
+
+    cache = planning_probe_cache.ProbeCache.open(tmp_path / "cache.json")
+    cache.put(_identity(), CapabilityProbe.ready_for("codex", "primary", "openai"), fingerprint=before)
+    assert cache.get(_identity(), fingerprint=after) is None
+
+
+def test_cache_invalidated_by_credential_fingerprint(
+    tmp_path: Path, hermetic_fingerprint: Path
+) -> None:
+    credential = hermetic_fingerprint / "home" / ".codex" / "auth.json"
+    before = _fingerprint()
+    credential.write_text('{"token": "refreshed"}', encoding="utf-8")
+    after = _fingerprint()
+    assert after.executor_credential != before.executor_credential
+    assert after.digest != before.digest
+
+    cache = planning_probe_cache.ProbeCache.open(tmp_path / "cache.json")
+    cache.put(_identity(), CapabilityProbe.ready_for("codex", "primary", "openai"), fingerprint=before)
+    assert cache.get(_identity(), fingerprint=after) is None
+
+
+def test_credential_fingerprint_never_reads_the_file_contents(
+    hermetic_fingerprint: Path,
+) -> None:
+    """憑證只取 `st_size/st_mtime_ns`——token 不得出現在指紋的任何中間狀態。"""
+
+    credential = hermetic_fingerprint / "home" / ".codex" / "auth.json"
+    credential.write_text('{"token":"sk-secret-value"}', encoding="utf-8")
+    fingerprint = _fingerprint()
+    assert "sk-secret-value" not in json.dumps(fingerprint.as_dict())
+    assert "size=" in fingerprint.executor_credential
+    assert "mtime_ns=" in fingerprint.executor_credential
+
+
+def test_credential_appearing_from_absent_invalidates(
+    tmp_path: Path, hermetic_fingerprint: Path
+) -> None:
+    """`<absent>` → 有檔案也是一次改動。憑證剛部署好的那一輪必須重探。"""
+
+    credential = hermetic_fingerprint / "home" / ".codex" / "auth.json"
+    credential.unlink()
+    absent = _fingerprint()
+    assert absent.executor_credential.endswith(planning_probe_cache.FINGERPRINT_ABSENT)
+    credential.write_text("{}", encoding="utf-8")
+    assert _fingerprint().digest != absent.digest
+
+
+def test_cache_invalidated_by_roster_digest(tmp_path: Path, hermetic_fingerprint: Path) -> None:
+    """overlay 改動 ⇒ 失效。摘要取的是**解析結果**，不是 overlay 檔的 mtime。"""
+
+    one = planning_probe_cache.roster_digest(_registry(_identity()))
+    two = planning_probe_cache.roster_digest(
+        _registry(_identity(), _identity("agy", AGY_MODEL_ID))
+    )
+    assert one != two
+    # 同樣內容重算一次必須相同（canonical，不吃順序／空白）。
+    assert one == planning_probe_cache.roster_digest(_registry(_identity()))
+
+    before = _fingerprint(roster=one)
+    after = _fingerprint(roster=two)
+    assert before.digest != after.digest
+    cache = planning_probe_cache.ProbeCache.open(tmp_path / "cache.json")
+    cache.put(_identity(), CapabilityProbe.ready_for("codex", "primary", "openai"), fingerprint=before)
+    assert cache.get(_identity(), fingerprint=after) is None
+
+
+def test_every_digest_field_changes_the_digest(hermetic_fingerprint: Path) -> None:
+    """六個 digest 欄位**逐欄**釘住：少算任何一格都會讓某類改動靜默沿用舊 ready。
+
+    用機械方式列舉而不是六條手寫測試——新增一個指紋分量時這條自動涵蓋它。
+    """
+
+    import dataclasses
+
+    base = _fingerprint()
+    assert set(planning_probe_cache.FINGERPRINT_DIGEST_FIELDS) <= {
+        f.name for f in dataclasses.fields(base)
+    }
+    for name in planning_probe_cache.FINGERPRINT_DIGEST_FIELDS:
+        mutated = dataclasses.replace(base, **{name: getattr(base, name) + "-changed"})
+        assert mutated.digest != base.digest, name
+    # 兩個診斷欄位刻意**不**進 digest（它們的內容已包含在對應的 digest 欄位裡）。
+    for name in ("resolved_binary", "unit"):
+        mutated = dataclasses.replace(base, **{name: "irrelevant"})
+        assert mutated.digest == base.digest, name
+
+
+# ---------------------------------------------------------------------------
+# 驗收 3：快取損毀一律視為 miss，不得沿用 ready
+# ---------------------------------------------------------------------------
+
+
+CORRUPTIONS: tuple[tuple[str, str], ...] = (
+    ("not-json", "{ this is not json"),
+    ("payload-not-object", "[]"),
+    ("schema-mismatch", json.dumps({"schema": "cortex-planning-probe-cache/v0", "items": {}})),
+    ("items-not-object", json.dumps({"schema": planning_probe_cache.CACHE_SCHEMA, "items": []})),
+    ("empty-file", ""),
+)
+
+
+@pytest.mark.parametrize("label,payload", CORRUPTIONS, ids=[c[0] for c in CORRUPTIONS])
+def test_corrupt_cache_is_miss_not_ready(
+    tmp_path: Path, hermetic_fingerprint: Path, label: str, payload: str
+) -> None:
+    """壞檔 ⇒ 重探，**絕不**沿用舊 ready。
+
+    「舊 ready」在這裡是刻意先寫進去的：檔案裡確實有一列 ready 的內容，只是外層
+    壞掉。fail-open 的實作會「盡量救回能救的」——那正是本條要擋的。
+    """
+
+    path = tmp_path / "cache.json"
+    path.write_text(payload, encoding="utf-8")
+    cache = planning_probe_cache.ProbeCache.open(path)
+    assert cache.unreadable is True
+    assert cache.get(_identity(), fingerprint=_fingerprint()) is None
+    assert cache.entries() == []
+
+
+def test_corrupt_cache_never_serves_a_ready_row_hidden_inside(
+    tmp_path: Path, hermetic_fingerprint: Path
+) -> None:
+    """壞掉的**外層**裡包著一列格式完全正確的 ready，仍然是 miss。"""
+
+    fingerprint = _fingerprint()
+    good = tmp_path / "good.json"
+    cache = planning_probe_cache.ProbeCache.open(good)
+    cache.put(_identity(), CapabilityProbe.ready_for("codex", "primary", "openai"), fingerprint=fingerprint)
+    cache.flush()
+    intact = json.loads(good.read_text(encoding="utf-8"))
+    assert intact["items"]["codex::primary"]["ready"] is True
+
+    broken = tmp_path / "broken.json"
+    # schema 換成別的版本；items 裡那一列逐字不動。
+    broken.write_text(
+        json.dumps({"schema": "cortex-planning-probe-cache/v9", "items": intact["items"]}),
+        encoding="utf-8",
+    )
+    assert planning_probe_cache.ProbeCache.open(broken).get(
+        _identity(), fingerprint=fingerprint
+    ) is None
+
+
+@pytest.mark.parametrize(
+    "mutate",
+    [
+        pytest.param(lambda row: row.update({"ready": "yes"}), id="ready-not-bool"),
+        pytest.param(lambda row: row.update({"executor": "claude"}), id="executor-rewritten"),
+        pytest.param(lambda row: row.update({"model_id": "other"}), id="model-rewritten"),
+        pytest.param(lambda row: row.update({"independence_domain": "zhipu"}), id="domain-rewritten"),
+        pytest.param(lambda row: row.update({"probed_at_epoch": "soon"}), id="timestamp-not-number"),
+        pytest.param(lambda row: row.pop("probed_at_epoch"), id="timestamp-missing"),
+        pytest.param(lambda row: row.update({"reason": "smoke-failed"}), id="ready-with-failure"),
+        pytest.param(lambda row: row.update({"diagnostic": 7}), id="diagnostic-not-string"),
+        pytest.param(lambda row: row.update({"fingerprint": "0" * 64}), id="fingerprint-rewritten"),
+    ],
+)
+def test_malformed_ready_row_is_a_miss(
+    tmp_path: Path, hermetic_fingerprint: Path, mutate
+) -> None:
+    """row 層級的窮舉：任何一格不對，那一列的 ready 就不得被端出來。"""
+
+    fingerprint = _fingerprint()
+    path = tmp_path / "cache.json"
+    cache = planning_probe_cache.ProbeCache.open(path)
+    cache.put(_identity(), CapabilityProbe.ready_for("codex", "primary", "openai"), fingerprint=fingerprint)
+    cache.flush()
+
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    mutate(payload["items"]["codex::primary"])
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    reopened = planning_probe_cache.ProbeCache.open(path)
+    # 外層沒壞，所以不是 `unreadable`——但那一列仍然不得被採信。
+    assert reopened.unreadable is False
+    assert reopened.get(_identity(), fingerprint=fingerprint) is None
+
+
+def test_corrupt_cache_logs_a_reason_distinct_from_probe_failure(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """壞檔要落 `planning-probe-cache-unreadable`——與「probe 失敗」分開。
+
+    少了這一條就會出現「快取檔壞了，症狀卻報成 provider 不可用」，而那正是 #670
+    的排查方向被整個帶偏的形態。
+    """
+
+    path = tmp_path / "cache.json"
+    path.write_text("{ broken", encoding="utf-8")
+    with caplog.at_level(logging.ERROR, logger=planning_probe_cache.logger.name):
+        planning_probe_cache.ProbeCache.open(path)
+    messages = [record.getMessage() for record in caplog.records]
+    assert any(planning_probe_cache.CACHE_UNREADABLE_REASON in message for message in messages)
+    # 三個既有的 probe 失敗 reason 都不得出現——它們是不同的一件事。
+    assert not any(
+        marker in message
+        for message in messages
+        for marker in ("safe-probe-failed", "smoke-failed", "models-probe-failed")
+    )
+
+
+def test_corrupt_cache_is_repaired_in_place_on_next_flush(
+    tmp_path: Path, hermetic_fingerprint: Path
+) -> None:
+    """壞檔不是死結：下一輪重探之後就地寫回一份合法的快取。"""
+
+    path = tmp_path / "cache.json"
+    path.write_text("{ broken", encoding="utf-8")
+    cache = planning_probe_cache.ProbeCache.open(path)
+    fingerprint = _fingerprint()
+    cache.put(_identity(), CapabilityProbe.ready_for("codex", "primary", "openai"), fingerprint=fingerprint)
+    assert cache.flush() is True
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    assert payload["schema"] == planning_probe_cache.CACHE_SCHEMA
+    assert planning_probe_cache.ProbeCache.open(path).get(
+        _identity(), fingerprint=fingerprint
+    ) is not None
+
+
+def test_expired_ready_never_served_when_reprobe_fails(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """ready 過期且重探失敗 ⇒ not ready。**不得**因為「上次是 ready」而沿用。"""
+
+    identities = _registry(_identity())
+    monkeypatch.setattr(planning_runtime, "load_model_identities", lambda: identities)
+    cache = tmp_path / "cache.json"
+    good = planning_runtime.build_production_planning_runtime(
+        primary=("codex", "primary"),
+        worktree=tmp_path,
+        runner=_echo_runner([]),
+        probe_cache_path=cache,
+    )
+    assert good.probes[("codex", "primary")].ready is True
+
+    # TTL 設 1 秒並把時鐘往前推——ready 過期。
+    monkeypatch.setenv(planning_probe_cache.READY_TTL_ENV, "1")
+    payload = json.loads(cache.read_text(encoding="utf-8"))
+    payload["items"]["codex::primary"]["probed_at_epoch"] -= 3600
+    cache.write_text(json.dumps(payload), encoding="utf-8")
+
+    def exploding(argv, **kwargs):
+        raise FileNotFoundError(argv[0])
+
+    degraded = planning_runtime.build_production_planning_runtime(
+        primary=("codex", "primary"),
+        worktree=tmp_path,
+        runner=exploding,
+        probe_cache_path=cache,
+    )
+    probe = degraded.probes[("codex", "primary")]
+    assert probe.ready is False
+    assert probe.reason == "safe-probe-failed"
+    assert probe.diagnostic == "FileNotFoundError"
+
+
+def test_clock_going_backwards_is_a_miss(tmp_path: Path, hermetic_fingerprint: Path) -> None:
+    """`probed_at` 落在未來（NTP 校正、VM 還原）⇒ miss。
+
+    不擋這一條的話，一次時鐘跳躍就能讓一列 ready 被無限期沿用——TTL 對它失效。
+    """
+
+    fingerprint = _fingerprint()
+    path = tmp_path / "cache.json"
+    cache = planning_probe_cache.ProbeCache.open(path, clock=lambda: 10_000.0)
+    cache.put(_identity(), CapabilityProbe.ready_for("codex", "primary", "openai"), fingerprint=fingerprint)
+    cache.flush()
+
+    rewound = planning_probe_cache.ProbeCache.open(path, clock=lambda: 1_000.0)
+    assert rewound.get(_identity(), fingerprint=fingerprint) is None
+
+
+def test_ttl_defaults_and_overrides(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """ready／not-ready 兩段 TTL 分開，且非法值一律當 0（＝永遠 miss），不落回預設。"""
+
+    cache = planning_probe_cache.ProbeCache.open(tmp_path / "cache.json")
+    assert cache.ttl_seconds(ready=True) == planning_probe_cache.DEFAULT_READY_TTL_SECONDS
+    assert cache.ttl_seconds(ready=False) == planning_probe_cache.DEFAULT_NOT_READY_TTL_SECONDS
+    # 失敗要快速重試、成功不需要頻繁重確認——兩段不同是刻意的。
+    assert cache.ttl_seconds(ready=False) < cache.ttl_seconds(ready=True)
+
+    monkeypatch.setenv(planning_probe_cache.READY_TTL_ENV, "60")
+    monkeypatch.setenv(planning_probe_cache.NOT_READY_TTL_ENV, "3O0")  # 打錯字（字母 O）
+    tuned = planning_probe_cache.ProbeCache.open(tmp_path / "cache.json")
+    assert tuned.ttl_seconds(ready=True) == 60
+    assert tuned.ttl_seconds(ready=False) == 0
+
+
+def test_zero_ttl_disables_the_cache(tmp_path: Path, hermetic_fingerprint: Path) -> None:
+    fingerprint = _fingerprint()
+    path = tmp_path / "cache.json"
+    cache = planning_probe_cache.ProbeCache.open(path)
+    cache.put(_identity(), CapabilityProbe.ready_for("codex", "primary", "openai"), fingerprint=fingerprint)
+    cache.flush()
+    disabled = planning_probe_cache.ProbeCache.open(
+        path, env={planning_probe_cache.READY_TTL_ENV: "0"}
+    )
+    assert disabled.get(_identity(), fingerprint=fingerprint) is None
+
+
+# ---------------------------------------------------------------------------
+# 快取內容：失敗側的診斷（design D5）
+# ---------------------------------------------------------------------------
+
+
+def test_cache_records_failure_diagnostics(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """失敗側存 reason／diagnostic／族／unit／hardening_profile／resolved_binary。
+
+    `reason`／`diagnostic` **逐字沿用** `CapabilityProbe`——#674 的
+    `stdout_excerpt()`／`strip_code_fence()` 是那件事的唯一真相，快取層不得再造一份
+    節錄邏輯（design D5 明文）。
+    """
+
+    identities = _registry(_identity())
+    monkeypatch.setattr(planning_runtime, "load_model_identities", lambda: identities)
+    cache = tmp_path / "cache.json"
+
+    def malformed(argv, **kwargs):
+        return _completed("not json at all", returncode=0)
+
+    runtime = planning_runtime.build_production_planning_runtime(
+        primary=("codex", "primary"),
+        worktree=tmp_path,
+        runner=malformed,
+        probe_cache_path=cache,
+    )
+    probe = runtime.probes[("codex", "primary")]
+    assert probe.ready is False
+
+    row = json.loads(cache.read_text(encoding="utf-8"))["items"]["codex::primary"]
+    assert row["ready"] is False
+    assert row["reason"] == probe.reason
+    assert row["diagnostic"] == probe.diagnostic
+    assert row["family"] == "planning-output-malformed"
+    # D8 要的三格（票 E 之後的拒因表消費者）。
+    for key in ("unit", "hardening_profile", "resolved_binary"):
+        assert key in row
+    # 票 E 才有來源的三格先立在 schema 上，目前恆為 None——這是票的邊界，不是缺口。
+    assert row["returncode"] is None
+    assert row["stdout_prefix"] is None
+    assert row["binary_version"] is None
+    # 指紋分量明表：operator 直接看得出「是哪一格變了」。
+    assert set(row["fingerprint_inputs"]) == set(
+        planning_probe_cache.FINGERPRINT_DIGEST_FIELDS
+    )
+
+
+def test_ledger_keeps_first_observed_and_counts_observations(
+    tmp_path: Path, hermetic_fingerprint: Path
+) -> None:
+    """沿用 `not_claimable` 的 ledger 形狀：operator 看得出「這個 provider 掛多久了」。"""
+
+    fingerprint = _fingerprint()
+    failed = CapabilityProbe(False, "codex", "primary", "openai", "smoke-failed", "exit-code:1")
+    cache = planning_probe_cache.ProbeCache.open(tmp_path / "cache.json")
+    first = cache.put(_identity(), failed, fingerprint=fingerprint, now="2026-08-18T00:00:00+00:00")
+    second = cache.put(_identity(), failed, fingerprint=fingerprint, now="2026-08-18T00:10:00+00:00")
+    assert second["first_observed_at"] == first["first_observed_at"]
+    assert second["last_observed_at"] == "2026-08-18T00:10:00+00:00"
+    assert second["observations"] == 2
+
+    # 結果變了就是**新的**一件事，`first_observed_at` 重新起算——否則「掛多久了」
+    # 會把兩段不同原因的失敗接成一段，那個數字就不再是真話。
+    recovered = cache.put(
+        _identity(),
+        CapabilityProbe.ready_for("codex", "primary", "openai"),
+        fingerprint=fingerprint,
+        now="2026-08-18T00:20:00+00:00",
+    )
+    assert recovered["first_observed_at"] == "2026-08-18T00:20:00+00:00"
+    assert recovered["observations"] == 1
+
+
+def test_identity_leaving_the_roster_is_pruned(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """roster 移掉一個 identity ⇒ 它的 row 自動清除（`not_claimable.clear()` 同型）。"""
+
+    cache = tmp_path / "cache.json"
+    monkeypatch.setattr(
+        planning_runtime,
+        "load_model_identities",
+        lambda: _registry(_identity(), _identity("agy", AGY_MODEL_ID)),
+    )
+    planning_runtime.build_production_planning_runtime(
+        primary=("codex", "primary"),
+        worktree=tmp_path,
+        runner=_echo_runner([]),
+        probe_cache_path=cache,
+    )
+    assert set(json.loads(cache.read_text(encoding="utf-8"))["items"]) == {
+        "codex::primary",
+        f"agy::{AGY_MODEL_ID}",
+    }
+
+    monkeypatch.setattr(planning_runtime, "load_model_identities", lambda: _registry(_identity()))
+    planning_runtime.build_production_planning_runtime(
+        primary=("codex", "primary"),
+        worktree=tmp_path,
+        runner=_echo_runner([]),
+        probe_cache_path=cache,
+    )
+    assert set(json.loads(cache.read_text(encoding="utf-8"))["items"]) == {"codex::primary"}
+
+
+# ---------------------------------------------------------------------------
+# 快取是輔助設施：它壞掉／寫不進去都不得拖垮 planning
+# ---------------------------------------------------------------------------
+
+
+def test_fingerprint_never_raises_when_a_component_is_unresolvable(
+    monkeypatch: pytest.MonkeyPatch, hermetic_fingerprint: Path
+) -> None:
+    """job 模式 ＋ PATH 未宣告（#679 的 fail-closed）⇒ 那一格落 `<unresolved:…>`。
+
+    而且它是一個**會變**的值：PATH 一旦補上，指紋就變、快取自動失效重探。
+    """
+
+    monkeypatch.setenv("PSC_JOB_RUNNER", job_runner.RUNNER_SYSTEMD_TEMPLATE)
+    monkeypatch.delenv("PSC_REVIEWER_PATH", raising=False)
+    undeclared = _fingerprint()
+    assert undeclared.executor_binary.startswith(
+        planning_probe_cache.FINGERPRINT_UNRESOLVED_PREFIX
+    )
+    # 只帶例外**型別名**，不帶訊息——訊息會夾帶路徑與 env。
+    assert undeclared.executor_binary == "<unresolved:JobRunnerError>"
+
+    monkeypatch.setenv("PSC_REVIEWER_PATH", str(hermetic_fingerprint / "bin"))
+    declared = _fingerprint()
+    assert not declared.executor_binary.startswith(
+        planning_probe_cache.FINGERPRINT_UNRESOLVED_PREFIX
+    )
+    assert declared.digest != undeclared.digest
+
+
+def test_unknown_executor_fails_closed_into_the_fingerprint(hermetic_fingerprint: Path) -> None:
+    """未登記的 executor（`cg`）沒有剖面 ⇒ 兩格都是 `<unresolved:…>`，不是猜一份。"""
+
+    fingerprint = planning_probe_cache.compute_fingerprint(
+        _identity("cg", "glm-5.3"), roster="roster-v1"
+    )
+    assert fingerprint.hardening_profile == "<unresolved:JobRunnerError>"
+    assert fingerprint.template_unit == "<unresolved:JobRunnerError>"
+    assert fingerprint.unit is None
+
+
+def test_unwritable_cache_does_not_break_planning(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """寫不進去 ⇒ 那一輪只是沒有快取，planning 照常完成。"""
+
+    identities = _registry(_identity())
+    monkeypatch.setattr(planning_runtime, "load_model_identities", lambda: identities)
+    blocked = tmp_path / "blocked"
+    blocked.write_text("i am a file, not a directory", encoding="utf-8")
+    with caplog.at_level(logging.ERROR, logger=planning_probe_cache.logger.name):
+        runtime = planning_runtime.build_production_planning_runtime(
+            primary=("codex", "primary"),
+            worktree=tmp_path,
+            runner=_echo_runner([]),
+            probe_cache_path=blocked / "cache.json",
+        )
+    assert runtime.probes[("codex", "primary")].ready is True
+    assert any(
+        planning_probe_cache.CACHE_UNWRITABLE_REASON in record.getMessage()
+        for record in caplog.records
+    )
+
+
+def test_concurrent_writer_rows_survive_our_flush(
+    tmp_path: Path, hermetic_fingerprint: Path
+) -> None:
+    """另一個行程在我們探測期間寫進來的 row 不會被我們整份蓋掉。
+
+    這**不是**鎖：兩個同時 miss 的 tick 仍會各自探一次（代價＝多探一次）。這條釘
+    住的是「並行的代價不得升級成掉資料」——落盤前重讀磁碟並以它為底疊上本次異動。
+    """
+
+    path = tmp_path / "cache.json"
+    ours = planning_probe_cache.ProbeCache.open(path)
+    ours.put(_identity(), CapabilityProbe.ready_for("codex", "primary", "openai"), fingerprint=_fingerprint())
+
+    # 「另一個行程」在我們 flush 之前寫了別的 identity。
+    theirs = planning_probe_cache.ProbeCache.open(path)
+    agy = _identity("agy", AGY_MODEL_ID)
+    theirs.put(agy, CapabilityProbe.ready_for("agy", AGY_MODEL_ID, "google"), fingerprint=_fingerprint(agy))
+    theirs.flush()
+
+    ours.flush(keep=[("codex", "primary"), ("agy", AGY_MODEL_ID)])
+    items = json.loads(path.read_text(encoding="utf-8"))["items"]
+    assert set(items) == {"codex::primary", f"agy::{AGY_MODEL_ID}"}
+
+
+# ---------------------------------------------------------------------------
+# 登記表：Manager-owned，且不在任何 job 模板 unit 的 RWP 裡
+# ---------------------------------------------------------------------------
+
+
+def test_cache_asset_is_registered_manager_owned() -> None:
+    asset = trust_registry.asset_by_id(CACHE_ASSET)
+    assert asset.tree is trust_registry.TrustTree.MANAGER_OWNED
+    assert asset.writers == (trust_registry.Principal.MANAGER,)
+    assert asset.readers == (trust_registry.Principal.MANAGER,)
+    path = permgen.DEFAULT_LAYOUT.asset_paths()[CACHE_ASSET]
+    assert path.endswith("/" + planning_probe_cache.CACHE_FILENAME)
+    assert path.startswith(permgen.DEFAULT_LAYOUT.coordinator_root + "/")
+
+
+def test_cache_asset_not_in_any_job_unit_rwp() -> None:
+    """快取不出現在任一 job 模板 unit 的 `ReadWritePaths` 產出中。
+
+    job 一旦寫得動快取，「這個 provider 是 ready 的」就變成模型可以自證的東西——
+    而 `select_secondary_planner()` 的整個異質性論證正建立在那個判定不是模型說了算上。
+    """
+
+    path = permgen.DEFAULT_LAYOUT.asset_paths()[CACHE_ASSET]
+    for scheme in permgen.SCHEMES.values():
+        plan = permgen.generate_plan(scheme)
+        for principal in trust_registry.UNTRUSTED_EXECUTION_PRINCIPALS:
+            account = scheme.resolve(principal)
+            if account is None:
+                continue
+            targets = permgen.required_write_targets(
+                plan, permgen.DEFAULT_LAYOUT, account, principals=frozenset({principal})
+            )
+            assert CACHE_ASSET not in targets, (scheme.scheme_id, principal)
+            assert path not in set(targets.values())
+
+    for principal in trust_registry.DOWNGRADED_JOB_PRINCIPALS:
+        for profile in permgen.HARDENING_PROFILES:
+            unit = permgen.build_job_unit(
+                permgen.FOUR_WAY_SCHEME, principal=principal, profile=profile
+            )
+            assert path not in unit.content
+            assert path not in unit.read_write_paths


### PR DESCRIPTION
Closes #684

母票 #672 的**票 C**（`docs/superpowers/plans/planner-job-downgrade.md` 第 3 節，design D-C／D5）。
依賴票 A（#682／PR #688）與票 B（#683／PR #689），兩者皆已 merge，本 PR 由 `origin/main` 開出。

## 問題

`build_production_planning_runtime()` 對**每一個** planning-capable identity 各跑一次 probe：
`_probe_identity` 每次做**兩次整棵 repo 的 `copytree`**，`probe_agy_capability` 則是**兩次 CLI
呼叫**。這個函式由 `manager.run_auto_claim_scan()`（periodic tick，實機
`PSC_MANAGER_INTERVAL_SECONDS=600`）與 `apply_work_action()` 兩條路徑呼叫。

票 E（#686）把 planning 搬上降權 job 之後，**每一次 probe 就是一個 systemd unit 實例**
（agy 是兩個）。沒有快取的話，那等於每 10 分鐘起一批 job 去問模型「你是誰」——成本不可接受，
而且那批 job 的產出在絕大多數輪次裡與上一輪逐字相同。

## 指紋的完整組成（六格，design D5 逐條）

| # | 分量 | 取法 | 為什麼 |
|---|---|---|---|
| 1 | `job_runner_mode` | `job_runner.resolve_runner_mode(env)` 的**解析結果** | direct 與 job 的執行環境（PATH／HOME／憑證／seccomp／MDWE）完全不同 |
| 2 | `roster_digest` | `load_model_identities()` 解析結果的 canonical JSON（`ModelIdentity.to_dict()`）sha256 | overlay 改了候選就變了 |
| 3 | `executor_binary` | 以該角色的 PATH 解析出的**絕對路徑** ＋ `st_dev/st_ino/st_size/st_mtime_ns` | 換版就是換行為（實機同名兩份差 105 個小版本） |
| 4 | `executor_credential` | 憑證檔的 `st_size/st_mtime_ns`（**不讀內容**） | refresh／換帳號 |
| 5 | `hardening_profile` | `job_runner.resolve_hardening_profile(identity.executor)` | #643：MDWE 與 V8 互斥 |
| 6 | `template_unit` | **模板 unit 檔本身**的 `st_size/st_mtime_ns`（`<unit dir>/cortex-reviewer-job[-jit]@.service`） | 見下 |

digest ＝ 這六格的 canonical JSON sha256。另有兩個**不進 digest** 的診斷欄位
（`resolved_binary`／`unit`）——內容已包含在第 3／6 格的字串裡，單獨列出只是讓快取 row 不必
解析字串就能回答「當時解到哪一支、哪一份 unit」，那正是 D8 拒因表要指名的兩件事。
`test_every_digest_field_changes_the_digest` 用 `dataclasses.replace` **機械列舉**釘住
「六格改任一格 digest 必變、那兩格改了 digest 必不變」，新增分量時自動涵蓋。

### 為什麼第 6 格是 unit 檔而不是剖面名

#677 落地的 `PROFILE_LOCKED_KEYS` 說明兩份剖面的加固鍵**逐字相同**——剖面名相同**不代表**
unit 內容相同（operator 重新落檔、產生器升級、RWP 增列都會改 unit 而不改剖面名）。只認剖面名
會沿用一個對新 unit 不成立的 `ready`，而那正是本 repo 反覆買單的「綠燈不承載語意」。

把 unit 的 stat 放進指紋，等於把**部署動作**與**快取失效**綁成同一件事：operator 重跑產生器
落新 unit 的那一刻全部快取自動失效並重探，**不需要任何人記得清快取**。
`test_cache_invalidated_by_template_unit_fingerprint` 直接釘住這個分界——它斷言改 unit 內容之後
`hardening_profile` 那一格**沒有變**（jit 還是 jit）而 digest 變了。

### 為什麼含 `PSC_JOB_RUNNER`

兩種模式的執行環境完全不同，切換一次就必須全部重探。它同時是 plan 要求「票 F 的生產切換一次
到位、不能一半走 job」的**機械保證**：混用時兩種語意的結論不會並存在同一格，因為它們的指紋不同。

**一處對 design 的收斂**：design 的取法欄寫「字面值」，本 PR 放的是**解析後的模式**。理由是
`""`／`direct`／`DIRECT` 是同一個部署，用字面值會讓一次大小寫或顯式化的整理造成一批無意義的
重探；而解析走的正是 design D1 指定的同一支 `resolve_runner_mode()`（非法值在那裡已 fail-closed）。

## TTL：本票內決定，值保守且 env 可覆寫

design 的 **U-6**（「probe 快取的 TTL 值，以及要不要提供 warm-up 入口」）列為未決。**我把 TTL
的機制與預設值在本票內定掉，warm-up 入口維持不做**，理由分開講：

**TTL 可以在本票內決定**，因為它不是一個跨票的介面決定——它只影響「多久重探一次」，而重探
本身在任何 TTL 下都是安全的（fail-closed 那一側不受影響）。把它留成未決的代價是票 C 沒有可
驗收的行為；把它決定下來的代價是 operator 可能想調——而那件事由兩個 env 變數解決，不需要動 code。

- `ready`：**3600s**（`PSC_PLANNING_PROBE_CACHE_READY_TTL_SECONDS`）
- not-ready：**300s**（`PSC_PLANNING_PROBE_CACHE_NOT_READY_TTL_SECONDS`）

兩段分開是刻意的：**失敗要快速重試**（暫時性服務錯誤、限流、模型輸出的隨機不從，短時間內
就會自己好；把它們鎖在一小時的快取裡等於讓一次抖動決定接下來六輪 tick 的 planning 拓撲），
**成功不需要頻繁重確認**（重確認就是一批 job 的成本）。以實機 600s 的 tick 算：ready 每 6 輪
重確認一次、not-ready 每輪都重試——後者正是今天的行為，因此本票對「失敗中的 provider」沒有
任何回復速度的退步。

三個實作面決定（design 未寫）：

1. **TTL 在讀取時依當下設定判定**（row 只存 `probed_at_epoch`），因此調短**立即**對既有 row
   生效，不必等舊 row 過期或手動清檔。
2. **非法值一律當 0（＝永遠 miss）並落 log，不落回預設**。落回預設會讓一個打錯的
   `...=3O0`（字母 O）靜默維持一小時的快取，operator 以為自己調短了卻沒有——那是 #643／#679
   反覆買過單的形態。當 0 的代價只是多付探測成本，方向與本模組其餘部分一致：不確定就重探。
3. **`probed_at` 落在未來（時鐘倒退：NTP 校正、VM 還原）視為 miss**。不擋這一條的話，一次
   時鐘跳躍就能讓一列 ready 被無限期沿用，TTL 對它完全失效。

**warm-up 入口不做（YAGNI）**：它的價值只在「第一輪 tick 想避開探測成本」，但第一輪本來就
必須探（沒有任何可信的先驗），warm-up 只是把同一批呼叫挪到別的時間點。若未來要做，它的自然
落點是 `cortex` CLI 的一個唯讀子命令，與本模組的讀寫 API 無關，不必為它預留任何機制。

## 快取存哪、誰可寫、job 讀不讀得到

**落點**：`<coordinator_root>/planning-probe-cache.json`，新增登記表資產 `planning-probe-cache`
（`trust_root/registry.py` ＋ `permgen.PathLayout.asset_paths()`）：

- `tree = MANAGER_OWNED`、`writers = (MANAGER,)`、`readers = (MANAGER,)`、`ingress = MANAGER_INTERNAL`；
- tier 是 **T1 而非 T0**：它改不了 acceptance、也給不了 ship authority，最壞情況是讓 planning
  選到一個實際不可用的 secondary（下一次呼叫即失敗）；
- 建檔當下就 `chmod 0o600`——一份新建的快取不該在 permgen 下一次跑之前是可被別人讀的。

**job 讀不讀得到：讀不到，也寫不到，而且是機械保證的。** 登記表的 writers／readers 只有
`MANAGER`，因此 `permgen.required_write_targets()` 對任何 job 帳號都不會產出這一條；
`test_cache_asset_not_in_any_job_unit_rwp` 對 **三個 scheme × 五個
`UNTRUSTED_EXECUTION_PRINCIPALS`**（builder／reviewer／planner／headless-hook／gate）逐一斷言資產 id 與路徑都不在寫入目標裡，再對
**三個降權 principal × 兩個加固剖面**的實際 unit 產出斷言路徑不出現在 `content` 與
`read_write_paths` 任一處。

**為什麼一定要這樣**：job 一旦寫得動快取，「這個 provider 是 ready 的」就變成**模型可以自證**
的東西——而 `select_secondary_planner()` 的整個異質性論證正建立在那個判定不是模型說了算上。
job 甚至不該**讀**：它沒有理由知道別的 provider 的探測結果。

**一處對 plan 的更正**：plan 票 C 寫著「並補進 `permgen.RUN_EXTERNAL_DEPENDENCIES` 的雙向封閉
（否則 `unlisted_roster_entries()` 的測試會紅）」。**這一步不需要，plan 那句話不成立**：
`unlisted_roster_entries()` 的資產側只涵蓋 `home_anchored_asset_ids()`，而後者由
`asset_paths()` × `home_anchored_account()` 機械導出——本資產在
`<coordinator_root>`＝`<agents_root>/coordinator`，不在任何 `declared_accounts()` 的 HOME 底下。
已實跑 `tests/test_trust_root_external_deps_exhaustive_666.py` 確認（126 passed）。plan 已就地更正。

## 併發：兩個 tick 同時 miss 會不會起兩批 probe job

**同一行程內不會；跨行程可能會，而我選擇接受它。**

- **同一行程內不會**：Manager daemon 是**單執行緒 poll 迴圈**（`manager_daemon.run_loop`，
  全檔沒有 `threading`／`asyncio`／`ThreadPool`），periodic tick 的 `run_auto_claim_scan` 與
  control queue 的 `apply_work_action` 都在同一個迴圈裡依序執行，兩輪 tick 結構性不會重疊。
- **跨行程可能會**：CLI 直接呼叫 `apply_work_action` 時與 daemon 是兩個行程。

**不加鎖是刻意的**：鎖住的那一邊會在 Manager 的 tick 迴圈裡等對方跑完一批模型呼叫（每格上限
45s、identity 數量成正比），而那個代價比「多探一次」大得多——而且它是**阻塞 Manager 主迴圈**
的代價，會連帶拖慢與 planning 無關的一切。取而代之的兩層保證：

1. **原子寫入**（temp ＋ `os.replace` ＋ 目錄 fsync，逐項沿用 `not_claimable._save()`）：檔案
   永不半寫，因此並行**不可能**製造出一份壞掉的快取。
2. **落盤前重讀磁碟合併**：以磁碟現況為底疊上本行程的異動，因此「另一個行程剛寫好的 row」
   不會被我們整份蓋掉。`test_concurrent_writer_rows_survive_our_flush` 釘住這一條。

結論：並行的**最壞後果是多探一次**（兩邊各自付一批 job 的成本，結果相同、互不覆蓋），
不是壞檔、也不是錯誤的 ready。而**票 F 的切換仍須一次到位**——那不是因為並行，是因為指紋含
`PSC_JOB_RUNNER`。

## 「壞檔視為 miss」怎麼測的

這是 issue 三條驗收裡最重要的一條（「壞掉的快取檔絕不能被解讀成『探過了、是 ready』」），
因此**測法是窮舉兩層，不是抽樣**。

**第一層（外層壞掉，`ProbeCache.open` 就攔下）**——`test_corrupt_cache_is_miss_not_ready`
parametrize 五種：`not-json`／`payload-not-object`／`schema-mismatch`／`items-not-object`／
`empty-file`。每一種都斷言 `unreadable is True`、`get(...) is None`、`entries() == []`。

**第二層（外層合法、那一列被就地改過）**——`test_malformed_ready_row_is_a_miss` parametrize
九種 row 級竄改：`ready` 不是 bool／`executor` 被改寫／`model_id` 被改寫／
`independence_domain` 被改寫／時戳不是數字／時戳缺欄／**ready 同時帶失敗 reason**／
`diagnostic` 不是字串／`fingerprint` 被改寫。每一種都斷言 `unreadable is False`（外層沒壞）
但 `get(...) is None`（那一列仍不得被採信）。

**關鍵的一條：`test_corrupt_cache_never_serves_a_ready_row_hidden_inside`。** 它先寫一份**完全
正確**的 ready 快取、讀出那一列的原始 JSON，再把它**逐字**塞進一個 schema 版本不符的外層。
fail-open 的實作會「盡量救回能救的」——這條就是為了擋那個。斷言：仍然是 `None`。

**另外三條配套**：

- `test_corrupt_cache_logs_a_reason_distinct_from_probe_failure`：壞檔必落
  `planning-probe-cache-unreadable`，且 log 裡**不得**出現 `safe-probe-failed`／`smoke-failed`／
  `models-probe-failed` 任一個。少了這條就會出現「快取檔壞了、症狀卻報成 provider 不可用」，
  而那正是 #670 排查方向被整個帶偏的形態。
- `test_corrupt_cache_is_repaired_in_place_on_next_flush`：壞檔不是死結——重探之後就地寫回一份
  合法的快取。
- `test_expired_ready_never_served_when_reprobe_fails`：ready 過期 ＋ 重探丟 `FileNotFoundError`
  ⇒ 結果是 `ready=False / safe-probe-failed / FileNotFoundError`，**不是**沿用上一次的 ready。

## 與 `not_claimable`（PR #675）刻意的一處不同

design D5 已寫明這處差異與理由，本 PR 照做並在模組 docstring 逐字記下：

| | `not_claimable.load_ledger()` | `planning_probe_cache` |
|---|---|---|
| 壞檔 | **raise** | **視為 miss ＋ 落可辨識診斷，絕不 raise** |
| 理由 | 「不可 claim 的項目必須查得到」，靜默當成空的等於把盲區再造一次 | 它是一份**輔助**紀錄；壞掉時若把整個 planning 拖垮，等於取得了它不該有的否決權 |

兩者是**同一條原則**（不得靜默產生有利答案）在不同後果下的兩種實作。「有利答案」在這裡就是
`ready`——而本模組**沒有任何一條路徑**會在讀不到／不確定時回答 ready：`ProbeCache.get()` 只有
一個回傳 `CapabilityProbe` 的出口，它的輸入是一列逐欄驗過的 row。

ledger 形狀則**逐項沿用**：`schema` 版本字串 ＋ `items` 以穩定 key 索引 ＋ 每筆帶
`first_observed_at`／`last_observed_at`／`observations`（operator 因此看得出「這個 provider 掛
多久了」）＋ 條件解除時自動清除（roster 移掉一個 identity ⇒ `flush(keep=…)` 把它的 row 清掉，
`test_identity_leaving_the_roster_is_pruned`）＋ 原子寫入。

`first_observed_at` 的重置判準是**指紋、ready、reason 三者皆同才續**——任何一格變了就是**新的**
一件事，重新起算；否則「掛多久了」會把兩段不同原因的失敗接成一段，那個數字就不再是真話
（`test_ledger_keeps_first_observed_and_counts_observations`）。

## 指紋計算永不 raise——而這是必要的，不是保守

每個分量各自守備，算不出來的那一格落 `<unresolved:<例外型別名>>`。

**為什麼必要**：票 E 的前置「PATH 宣告票」尚未 land，而生產環境**已經**是
`PSC_JOB_RUNNER=systemd-template`（plan 票 F 原話：「確認 `PSC_JOB_RUNNER=systemd-template`
（已是）」）。第 3 格要用 `resolve_job_path(role=review)`，而它今天會 raise（#679 的 fail-closed
是對的）。若指紋計算跟著 raise，**票 C 一 land 就會把生產的 planning 打掛**。

落標記則兩件事同時成立：這一輪照常重探；PATH 補上之後指紋改變、快取自動失效。
**取不到答案本身也是一個會變的答案**（`test_fingerprint_never_raises_when_a_component_is_unresolvable`
先斷言 `<unresolved:JobRunnerError>`，再 setenv `PSC_REVIEWER_PATH` 後斷言 digest 變了）。

標記**只帶例外型別名、不帶訊息**——訊息會夾帶路徑與 env，型別名不會。這與票 A
`classify_probe_failure()` 依賴的是同一條邊界，本 PR 沒有擴大它。

未登記的 executor（`cg`）同理：`resolve_hardening_profile` fail-closed ⇒ 第 5／6 格都是
`<unresolved:JobRunnerError>`，**不是猜一份剖面**（`test_unknown_executor_fails_closed_into_the_fingerprint`）。

## 機密：憑證不進指紋的任何中間狀態

- 第 4 格**只取 `st_size/st_mtime_ns`**，`_stat_marker()` 全函式沒有任何一行讀檔內容——
  讀內容才能算雜湊，而那會讓 token 出現在本行程的記憶體與任何中間狀態裡。size＋mtime 已足以
  偵測 refresh 與換帳號，而它們不是祕密。`test_credential_fingerprint_never_reads_the_file_contents`
  寫一份帶假 token 的憑證，斷言那個字串不出現在指紋的任何一格。
- 快取 row 的 `reason`／`diagnostic` **逐字沿用** `CapabilityProbe`，快取層**不再造一份節錄
  邏輯**（design D5 明文：那就是第二份真相）。因此本 PR **沒有擴大**票 A 已論證過的那個來源面
  ——快取進了什麼，就是拒因表今天已經會拿到的東西。
- 快取檔本身含 operator 的絕對路徑（`resolved_binary`／`fingerprint_inputs`），這是刻意的
  診斷價值，落在 Manager-owned 0600 的檔案裡，不進 log／evidence／`blocking_reason`。
- `R-21`（tier: shareable 機密掃描）本機帶 PR 上下文 **pass**。

## 快取內容（design D5 的必存欄位）

`ready` ＋ `reason`／`diagnostic`（逐字沿用）＋ 三分族（票 A 的 `classify_probe_failure()`）
＋ `unit`／`hardening_profile`／`resolved_binary` ＋ `fingerprint`／`fingerprint_inputs`
（operator 直接看得出「是哪一格變了」）＋ ledger 三欄。

`returncode`／`stdout_prefix`／`binary_version` 三欄**先立在 schema 上、目前恆為 `None`**：
它們的來源是票 E 的 `PlanningOutcome.diagnostics`（direct 模式沒有第二個資訊來源）。這**不是
缺口，是票的邊界**——票 E 落地時只要填這三格，schema 版本不必動。`test_cache_records_failure_diagnostics`
把這個邊界逐欄釘住。

## 驗收

**(1) 連續兩次建構 runtime，第二次的 executor 呼叫次數為 0** ✅

`test_second_runtime_build_makes_zero_executor_calls`：兩個 identity（codex ＋ agy），第一次
3 次 CLI 呼叫，第二次 `len(calls) == first_round`，且 `second.probes == first.probes`
（快取不是「跳過探測」，是「重放上一次的結論」）。

**這條測試有牙**——實跑過一次 mutation：把 `cached = cache.get(...)` 改成 `cached = None`，
該測試當場 `assert 6 == 3` 紅，其餘 39 條全綠。

**(2) 改動任一指紋輸入必重探** ✅

六格各有測試（`test_cache_key_includes_job_runner_mode`／
`test_cache_invalidated_by_executor_binary_fingerprint`／
`test_cache_invalidated_by_template_unit_fingerprint`／
`test_cache_invalidated_by_credential_fingerprint`／`test_cache_invalidated_by_roster_digest`
＋ `test_unknown_executor_fails_closed_into_the_fingerprint`），另加
`test_every_digest_field_changes_the_digest` 的機械列舉與
`test_credential_appearing_from_absent_invalidates`（`<absent>` → 有檔案也是一次改動：憑證剛
部署好的那一輪必須重探）。

測試用 `hermetic_fingerprint` fixture 把三個會被 stat 的來源全部釘進 `tmp_path`
（`PATH` → 假 `codex`、`HOME` → `.codex/auth.json`、`job_runner.DEFAULT_TEMPLATE_UNIT_DIR`
→ 假 unit），因此「改動」是真的改檔案，不是改 mock 的回傳值。

**(3) 快取損毀一律視為 miss，不得沿用 ready** ✅ — 見上一節（兩層窮舉共 14 個 case ＋ 3 條配套）。

**(4) 既有測試一行不改全綠** ✅

```
$ git diff --stat origin/main -- tests/
 tests/test_planning_probe_cache_672.py | 770 +++++++++++++++++++++
```

只有新檔。`python3 -m pytest tests/ -q` → **4348 passed, 24 skipped, 49 subtests passed**
（base 是 4308；新增 40 條）。

## 變更

- `paulsha_cortex/coordinator/planning_probe_cache.py`（新檔，642 行）：`ProbeFingerprint`／
  `compute_fingerprint()`／`roster_digest()`／`ProbeCache`／`cache_path()`／TTL 與 fail-closed 語意。
- `paulsha_cortex/coordinator/planning_runtime.py`：`build_production_planning_runtime()` 多一個
  `probe_cache_path` 參數（未給時落 `<coordinator_root>`），probe 迴圈改成先查快取、miss 才探、
  探完寫回，最後 `flush(keep=…)` 清掉離開 roster 的 row。
- `paulsha_cortex/trust_root/registry.py`：新增資產 `planning-probe-cache`。
- `paulsha_cortex/trust_root/permgen.py`：`PathLayout.asset_paths()` 補該資產的路徑。
- `tests/test_planning_probe_cache_672.py`：40 條新測試（含 plan 指定的九條 RED）。
- `docs/superpowers/plans/planner-job-downgrade.md`：票 C 勾完 ＋ 六處實作補充（含對
  `RUN_EXTERNAL_DEPENDENCIES` 那句的更正），供票 E／票 F 沿用。
- `changelog.d/684-probe-cache.md`、`CHANGELOG.md [Unreleased]`。

## 本票不做

- 不新增 `JobPlanningInvoker`（票 E／#686）——本票只讓快取的接縫先就位。
- 不動 permgen／憑證的 codify（票 D）；不做 U-5 的 per-(account, executor) 憑證表。
  **已知限制並已寫進程式碼註解**：`PathLayout.executor_credential_relpath` 目前是單一值
  （`.codex/auth.json`），因此 agy 的 `~/.gemini` 狀態樹**不在**第 4 格裡——它 refresh 時不會
  即時失效，最長由 not-ready TTL（300s）兜住。票 D 把憑證面 codify 之後，這裡跟著
  `executor_credential_of` 的新簽章走即可，不必在本模組另造一張表（那就是第二份真相）。
- 不碰部署、不改 unit、不跑任何會改變 `/var/lib/cortex` 狀態的指令。
- 不做 warm-up 入口（理由見 TTL 一節）。

## 檢查清單

- [x] 分支 `feature/684-probe-cache`，未 commit 到 `main`
- [x] `changelog.d/684-probe-cache.md` 已新增且**已 commit**
- [x] `CHANGELOG.md [Unreleased]` 有對應 entry（`### Added`）
- [x] `docs/superpowers/plans/planner-job-downgrade.md` 票 C 勾選 ＋ 實作補充
- [x] `python3 -m pytest tests/ -q` 全綠（4348 passed / 24 skipped / 49 subtests）
- [x] `openspec validate --specs` → 16 passed, 0 failed
- [x] 既有測試**一行未改**
- [x] `git diff --check` 乾淨
- [x] 帶 PR 上下文執行 `policy_check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E7w9kaUxAzCCEk7piD5hfK
