### PR TITLE
feat(planner): JobPlanningInvoker——planning 改走模板 unit（#686／#672 票 E）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,44 @@
 ## [Unreleased]
 
 ### Fixed
+- **#686（#672 票 E）：`JobPlanningInvoker`——planning 的模型呼叫改走
+  `cortex-reviewer-job@.service`，Manager 行程樹不再出現任何 executor**——`cortex-manager`
+  的 passwd 註記逐字寫著 `no model code`，而 planning（define／brainstorm）的四個 adapter
+  與**全部** probe 至今仍在 daemon 行程內以該身分 `subprocess.run` 模型 CLI（#672）。
+  #615（M2）只把 reviewer 導上模板 unit，planner 走的是完全不同的一條 code path。本票補齊
+  那半條：新增 `coordinator/planning_job.py` 的 `JobPlanningInvoker`（票 B 立的
+  `PlanningInvoker` 介面的第二個實作），一次 planning 呼叫＝一個模板 unit 實例，身分由
+  root-owned unit 的 `User=cortex-reviewer-planner` 決定、剖面由 `identity.executor` 單一
+  決定、spec 結構性不得攜帶身分／剖面欄位。**不複製任何一份 `job_runner` 的邏輯**：
+  preflight／instance 推導／spec 形狀／env 白名單／起動確認全部走既有函式。
+  選擇點仍只有 `job_runner.resolve_runner_mode()` 一個；`systemd-run`（A 案）**fail-closed
+  而不退回行程內執行**——A 案下加固面由呼叫端而非 root-owned unit 決定，而退回 in-process
+  的失敗**看起來像成功**，那正是 #672 要消除的失效模式。
+- **U-2 裁決＝planner scratch 對 job 唯讀，且它是登記表機械導出的性質、不是一個 `if`**——
+  新增登記表資產 `planning-scratch-pool`（writers 只有 `Principal.MANAGER`），
+  `required_write_targets()` 因此機械地不收它，它不出現在**任何** job 模板 unit 的
+  `ReadWritePaths=`，`ProtectSystem=strict` 下模型連寫都寫不進去。design 標記的安全退步
+  **R-1**（「模型弄髒自己的拋棄式 sandbox」的偵測在 job 側 Manager 做不到）因此從「失去
+  行為訊號」升級成「結構上不可能」。executor 的可寫落點改指向 unit 的 `PrivateTmp=yes`
+  私有 `/tmp`（per-invocation、job-owned、unit 結束即消失、Manager 看不到）。
+- **planning 的輸出通道不新開寫入面**——新增登記表資產 `planning-job-log-spool`，路徑掛在
+  既有 `review-verdict-spool` **底下**（`<spool>/planning-logs/<instance>/planning.log`）。
+  那個帳號今天本來就對這棵樹有 `wx`，而 `read_write_paths()` 的 `_minimize()` 會吃掉被涵蓋
+  的子路徑 ⇒ 模板 unit 的 `ReadWritePaths=` **逐字不變、零部署動作**、default ACL 自動
+  繼承。design D3 第一句是「不新開通道」、U-3 更把新開 job→Manager 寫入面列為未決，本票
+  因此不動用它。log 檔由 **Manager 預先建立且 mode 為 `0620`**：job 建的檔由 job 擁有
+  （`UMask=0077`）Manager 讀不到（#638 缺陷 2），而用 `0600` 建檔會把繼承來的
+  `user:<planner>:wx` 的 ACL mask 壓成 `#effective:---`（#638 缺陷 1 的同一個機制）。
+- **失敗語意三分在 job 側落地**——`PlanningJobError` 攜帶票 A 的族名，
+  `_probe_identity` 讓它**原樣**成為 `CapabilityProbe.reason`（票 A 的
+  `_PROBE_REASON_FAMILIES` 已預留這條路），拒因表因此看得到「job 起不來」與「executor 死」
+  的差別，而不是一律退化成型別名。`executor-silent-exit`（rc≠0 且輸出全空）的診斷指名
+  `unit`／`hardening_profile`／`resolved_binary`／**`--version` 字串**／
+  `permgen.seccomp_filter_is_fatal()` 的機械答案——最後一項正是 #673 整張票走偏的原因
+  （當時沒有任何地方回答得了「該不該懷疑 seccomp」），版本字串則是 #681 那類「只比路徑會
+  漏掉」的缺陷唯一看得見的地方。逾時走 D4 的 Manager 側 `wait(timeout)` →
+  `systemctl stop` → **確認 unit 離開 active**（不確認的話下一輪會撞
+  `job-runner-template-instance-busy`，而那個症狀與逾時完全無關）。
 - **#682（#672 票 A）：planner 失敗的錯誤語意三分 ＋ `no-heterogeneous-planner` 攜帶逐候選
   拒因表**——修法前 `select_secondary_planner()` 失敗時只回一個沒有任何附加資訊的字面值
   `no-heterogeneous-planner`，而迴圈裡四個 `continue`（同 domain／probe 缺席／probe 沒
@@ -67,6 +105,22 @@
   `@pytest.mark.skip` ＋ 完整理由標示，不靜默通過。
 
 ### Changed
+- `docs/superpowers/runbooks/trust-root-phase2b-setup.md`：新增第 4e-3／4e-4／4e-5 步
+  （唯讀 scratch 的 EROFS 驗證與逐 executor 實測表、跨 UID log 通道的 ACL mask 驗證、
+  「Manager 行程樹無 executor」的取證程序）與第 5-5c 步（補宣告 `PSC_REVIEWER_HOME`／
+  `PSC_GATE_HOME`）。加固面一律走既有共用探針 `psc_run_under`（其 property 清單由
+  `permgen.unit_replica_properties()` 從**落檔的 unit** 全量導出），**未新增任何手寫的
+  `--property=` 清單、未自帶 `--setenv=PATH=`**（design D13）。
+- `job_runner.build_job_env()` 的 docstring 更正一句**事實錯誤**：原文稱「`HOME` 未給時
+  systemd 依 passwd 填入正確值（而且模板 unit 另有一行 `Environment=HOME=`）」——那對
+  模板模式不成立，`cortex-job-shim` 以 `os.execvpe(command[0], command, job_env)` 把環境
+  **整份換掉**，unit 的 `Environment=HOME=` 到不了模型行程。實機 0818 複驗：未宣告
+  `PSC_REVIEWER_HOME` 時降權 planning job 的 agy 死在
+  `resolving log directory: getting home directory: $HOME is not defined`；補上之後同一條
+  呼叫 rc=0。與 #679 的 PATH 缺口**同型**（builder 那一份有宣告，另外兩個角色沒有）。
+  本票只更正事實並補 runbook 步驟，**不**順手把 `HOME` 也改成 fail-closed——那會讓所有
+  角色的既有派工在 EnvironmentFile 補齊前當場失敗，屬於需要獨立票的改動。
+
 - **#683（#672 票 B）：planning 的執行方式抽象成 `PlanningInvoker`——純重構、行為零改變**
   ——修法前 `planning_runtime._invoke_json()` 把三件事揉在同一支函式裡：**怎麼跑一個
   executor**（一次性 sandbox、`cwd`、hermetic env、逾時、雙向樹快照、drift 收容）、

--- a/changelog.d/686-job-planning-invoker.md
+++ b/changelog.d/686-job-planning-invoker.md
@@ -1,0 +1,56 @@
+### Fixed
+- **#686（#672 票 E）：`JobPlanningInvoker`——planning 的模型呼叫改走
+  `cortex-reviewer-job@.service`，Manager 行程樹不再出現任何 executor**——`cortex-manager`
+  的 passwd 註記逐字寫著 `no model code`，而 planning（define／brainstorm）的四個 adapter
+  與**全部** probe 至今仍在 daemon 行程內以該身分 `subprocess.run` 模型 CLI（#672）。
+  #615（M2）只把 reviewer 導上模板 unit，planner 走的是完全不同的一條 code path。本票補齊
+  那半條：新增 `coordinator/planning_job.py` 的 `JobPlanningInvoker`（票 B 立的
+  `PlanningInvoker` 介面的第二個實作），一次 planning 呼叫＝一個模板 unit 實例，身分由
+  root-owned unit 的 `User=cortex-reviewer-planner` 決定、剖面由 `identity.executor` 單一
+  決定、spec 結構性不得攜帶身分／剖面欄位。**不複製任何一份 `job_runner` 的邏輯**：
+  preflight／instance 推導／spec 形狀／env 白名單／起動確認全部走既有函式。
+  選擇點仍只有 `job_runner.resolve_runner_mode()` 一個；`systemd-run`（A 案）**fail-closed
+  而不退回行程內執行**——A 案下加固面由呼叫端而非 root-owned unit 決定，而退回 in-process
+  的失敗**看起來像成功**，那正是 #672 要消除的失效模式。
+- **U-2 裁決＝planner scratch 對 job 唯讀，且它是登記表機械導出的性質、不是一個 `if`**——
+  新增登記表資產 `planning-scratch-pool`（writers 只有 `Principal.MANAGER`），
+  `required_write_targets()` 因此機械地不收它，它不出現在**任何** job 模板 unit 的
+  `ReadWritePaths=`，`ProtectSystem=strict` 下模型連寫都寫不進去。design 標記的安全退步
+  **R-1**（「模型弄髒自己的拋棄式 sandbox」的偵測在 job 側 Manager 做不到）因此從「失去
+  行為訊號」升級成「結構上不可能」。executor 的可寫落點改指向 unit 的 `PrivateTmp=yes`
+  私有 `/tmp`（per-invocation、job-owned、unit 結束即消失、Manager 看不到）。
+- **planning 的輸出通道不新開寫入面**——新增登記表資產 `planning-job-log-spool`，路徑掛在
+  既有 `review-verdict-spool` **底下**（`<spool>/planning-logs/<instance>/planning.log`）。
+  那個帳號今天本來就對這棵樹有 `wx`，而 `read_write_paths()` 的 `_minimize()` 會吃掉被涵蓋
+  的子路徑 ⇒ 模板 unit 的 `ReadWritePaths=` **逐字不變、零部署動作**、default ACL 自動
+  繼承。design D3 第一句是「不新開通道」、U-3 更把新開 job→Manager 寫入面列為未決，本票
+  因此不動用它。log 檔由 **Manager 預先建立且 mode 為 `0620`**：job 建的檔由 job 擁有
+  （`UMask=0077`）Manager 讀不到（#638 缺陷 2），而用 `0600` 建檔會把繼承來的
+  `user:<planner>:wx` 的 ACL mask 壓成 `#effective:---`（#638 缺陷 1 的同一個機制）。
+- **失敗語意三分在 job 側落地**——`PlanningJobError` 攜帶票 A 的族名，
+  `_probe_identity` 讓它**原樣**成為 `CapabilityProbe.reason`（票 A 的
+  `_PROBE_REASON_FAMILIES` 已預留這條路），拒因表因此看得到「job 起不來」與「executor 死」
+  的差別，而不是一律退化成型別名。`executor-silent-exit`（rc≠0 且輸出全空）的診斷指名
+  `unit`／`hardening_profile`／`resolved_binary`／**`--version` 字串**／
+  `permgen.seccomp_filter_is_fatal()` 的機械答案——最後一項正是 #673 整張票走偏的原因
+  （當時沒有任何地方回答得了「該不該懷疑 seccomp」），版本字串則是 #681 那類「只比路徑會
+  漏掉」的缺陷唯一看得見的地方。逾時走 D4 的 Manager 側 `wait(timeout)` →
+  `systemctl stop` → **確認 unit 離開 active**（不確認的話下一輪會撞
+  `job-runner-template-instance-busy`，而那個症狀與逾時完全無關）。
+
+### Changed
+- `docs/superpowers/runbooks/trust-root-phase2b-setup.md`：新增第 4e-3／4e-4／4e-5 步
+  （唯讀 scratch 的 EROFS 驗證與逐 executor 實測表、跨 UID log 通道的 ACL mask 驗證、
+  「Manager 行程樹無 executor」的取證程序）與第 5-5c 步（補宣告 `PSC_REVIEWER_HOME`／
+  `PSC_GATE_HOME`）。加固面一律走既有共用探針 `psc_run_under`（其 property 清單由
+  `permgen.unit_replica_properties()` 從**落檔的 unit** 全量導出），**未新增任何手寫的
+  `--property=` 清單、未自帶 `--setenv=PATH=`**（design D13）。
+- `job_runner.build_job_env()` 的 docstring 更正一句**事實錯誤**：原文稱「`HOME` 未給時
+  systemd 依 passwd 填入正確值（而且模板 unit 另有一行 `Environment=HOME=`）」——那對
+  模板模式不成立，`cortex-job-shim` 以 `os.execvpe(command[0], command, job_env)` 把環境
+  **整份換掉**，unit 的 `Environment=HOME=` 到不了模型行程。實機 0818 複驗：未宣告
+  `PSC_REVIEWER_HOME` 時降權 planning job 的 agy 死在
+  `resolving log directory: getting home directory: $HOME is not defined`；補上之後同一條
+  呼叫 rc=0。與 #679 的 PATH 缺口**同型**（builder 那一份有宣告，另外兩個角色沒有）。
+  本票只更正事實並補 runbook 步驟，**不**順手把 `HOME` 也改成 fail-closed——那會讓所有
+  角色的既有派工在 EnvironmentFile 補齊前當場失敗，屬於需要獨立票的改動。

--- a/docs/superpowers/plans/planner-job-downgrade.md
+++ b/docs/superpowers/plans/planner-job-downgrade.md
@@ -230,7 +230,9 @@ blocking reason——兩者剛好接得起來，缺任何一半都還是查不�
 
 本票是整個搬遷的主體，也是唯一會改變執行身分的一張。
 
-- [ ] `tests/test_planning_job_invoker_672.py`（TDD RED）：
+**已由 issue #686 land。**
+
+- [x] `tests/test_planning_job_invoker_672.py`（TDD RED）：
   - `test_role_is_review_and_not_derivable_from_spec`：角色恆為 `JOB_ROLE_REVIEW`，
     且 job spec 不含任何身分／剖面欄位（`SPEC_FORBIDDEN_KEYS` 兩端各擋一次）。
   - `test_profile_comes_only_from_executor`：剖面唯一輸入是 `identity.executor`；
@@ -252,13 +254,13 @@ blocking reason——兩者剛好接得起來，缺任何一半都還是查不�
     `planning-output-malformed`，detail 帶 stdout 前綴。
   - `test_operator_tree_not_in_job_rwp`：`repo-source-tree` 不在 reviewer 模板 unit 的
     RWP 產出中（＝ D-e 的 kernel 層保證有測試釘住，不只靠 unit 註解）。
-- [ ] `paulsha_cortex/coordinator/planning_job.py`（新檔）：`JobPlanningInvoker`。
+- [x] `paulsha_cortex/coordinator/planning_job.py`（新檔）：`JobPlanningInvoker`。
       復用 `job_runner.prepare_systemd_template`／`build_job_spec`／`write_job_spec`／
       `build_systemctl_start_argv`／`build_manager_exit_recorder_argv`／
       `confirm_template_instance_started`；**不複製**任何一份 job_runner 的邏輯。
-- [ ] 依 U-1／U-2 的裁決實作 scratch（空 vs 複製；job 可寫 vs 唯讀＋`PrivateTmp`）。
-- [ ] 依 U-3 的裁決處理 codex 的第二輸出候選。
-- [ ] 實機驗收矩陣（R8）：`{codex, claude, agy} × {實際剖面}`，在**真實 unit 的完整
+- [x] 依 U-1／U-2 的裁決實作 scratch（空 vs 複製；job 可寫 vs 唯讀＋`PrivateTmp`）。
+- [x] 依 U-3 的裁決處理 codex 的第二輸出候選。
+- [x] 實機驗收矩陣（R8）：`{codex, claude, agy} × {實際剖面}`，在**真實 unit 的完整
       property 集合**下實跑，每格記錄 rc、stdout 前 80 字、**解析到的絕對路徑與版本
       字串**。矩陣 MUST 走 runbook 第 4e 步的共用探針 `psc_run_under`（其加固面由
       `permgen.unit_replica_properties()` 全量導出），MUST NOT 自行組 `--property=`
@@ -266,6 +268,40 @@ blocking reason——兩者剛好接得起來，缺任何一半都還是查不�
       （#638／#657 假綠，#673 原 body 與其 repro 假紅）。
 - 驗收：矩陣全綠；`cortex-manager` 的行程樹在一輪完整 planning 期間不出現任何
       executor 可執行檔（以 `systemd-cgls` 或 `ps --ppid` 佐證）。
+
+**#686 的實作補充**（design 之外的收斂與更正，票 F 必須沿用）：
+
+1. **U-2 裁決＝唯讀 scratch，而且它不是一個 `if`。** 登記表新增資產
+   `planning-scratch-pool`，writers 只有 `Principal.MANAGER` ⇒
+   `required_write_targets()` 機械地不收它 ⇒ 它不出現在任何 job 模板 unit 的
+   `ReadWritePaths=` ⇒ `ProtectSystem=strict` 下寫入回 EROFS。R-1 因此從「失去行為
+   訊號」變成「結構上不可能」。實機逐 executor 複驗見 runbook 第 4e-3 步。
+2. **U-1 在 job 模式只能是 (b)（空 scratch），而且 design 的取捨論證要更正。**
+   (a) 需要一套「把 Manager 建的整棵樹遞迴授權給 job 帳號」的機制（Manager unit 帶
+   `UMask=0077`，複本每個檔都是 `0600 cortex-manager`），那是新的一整個授權面。
+   另外 design 寫「(b) 是收緊（模型從理論上讀得到 repo 變成讀不到）」——**在 job
+   模式下不成立**：`ProtectSystem=strict` 只擋寫不擋讀，`/var/lib/cortex/repos/<slug>`
+   對 `cortex-reviewer-planner` 可讀（0818 複驗）。差別只在它不是 cwd。
+3. **U-3 不需要動用：輸出通道掛在既有 `review-verdict-spool` 底下。** design D3 第一句
+   是「不新開通道」，U-3 把「新開一條 job→Manager 的寫入面」列為未決；而
+   `cortex-reviewer-planner` 今天唯一既 Manager-owned 又對它開放寫入的落點就是那個
+   spool。掛在它底下 ⇒ `_minimize()` 吃掉子路徑 ⇒ 模板 unit 的 `ReadWritePaths=`
+   **逐字不變、零部署動作**、default ACL 自動繼承。新資產 `planning-job-log-spool`
+   仍獨立登記（治理面不因省下一條 RWP 而消失）。
+4. **`planning-job-timeout` 是 `planning-executor-failed` 的子類，不是第四個族。**
+   票 A 已把 `ENVIRONMENT_GRADE_PLANNING_FAMILIES` 釘成**逐字相等**的不變式；新增第
+   四個 environment 級族名會動到那條契約。分級結果與 D4 要求一致（environment ⇒
+   `recover-planning` 浮得出來），差別只在它掛在哪一個族底下——與
+   `executor-silent-exit` 同一種收法。
+5. **`PSC_JOB_RUNNER=systemd-run`（A 案）對 planning fail-closed，不退回 in-process。**
+   A 案下加固面由呼叫端而非 root-owned unit 決定，那正是 planning 這個吃 untrusted
+   內容的角色最需要的性質。退回 in-process 的失敗**看起來像成功**。
+6. **本票查到兩個 design 未預期的部署缺口，都不在本票處置範圍**（見 runbook）：
+   (i) `PSC_REVIEWER_HOME`／`PSC_GATE_HOME` 未宣告 ⇒ shim 的 `execvpe` 整份換掉環境，
+   unit 的 `Environment=HOME=` 到不了模型 ⇒ agy 死在 `$HOME is not defined`
+   （與 #679 的 PATH **同型**；runbook 第 5-5c 步）；(ii) codex 需要**整個
+   `$CODEX_HOME` 目錄**可寫（sqlite／sessions／skills／plugins），只放行
+   `auth.json` 一個檔不夠 ⇒ 屬票 D（#685）／U-4（runbook 第 4e-3 步）。
 
 ### 6. 票 F｜切換、宣稱更正與收尾（依賴票 D、票 E）
 

--- a/docs/superpowers/runbooks/trust-root-phase2b-setup.md
+++ b/docs/superpowers/runbooks/trust-root-phase2b-setup.md
@@ -2120,6 +2120,103 @@ sudo -u cortex-builder sh -c \
 
 ---
 
+#### 4e-3. planning 的**唯讀 scratch**（#686／#672 U-2 裁決）
+
+> **這一節驗的是一條「結構上不可能」的性質，不是一個開關。** 降權 planning job 的
+> cwd 是 `<coordinator_root>/planning-scratch/<instance>/cwd`；該 pool 的登記表資產
+> `planning-scratch-pool` 的 **writer 面只有 Manager**，因此
+> `permgen.required_write_targets()` 機械地不收它 ⇒ 它不出現在任何 job 模板 unit 的
+> `ReadWritePaths=` ⇒ `ProtectSystem=strict` 下模型連寫都寫不進去。
+> design D-d 的「模型是否弄髒了自己的拋棄式 sandbox」偵測需求因此**消失**，而不是
+> 退步成一條 Manager 在 job 側做不到的偵測（R-1）。
+
+```bash
+# 前置：一格可讀不可寫的 scratch（收尾記得 rm -rf）
+sudo install -d -o cortex-manager -g cortex-manager -m 0755 \
+  /var/lib/cortex/coordinator/planning-scratch
+sudo install -d -o cortex-manager -g cortex-manager -m 0755 \
+  /var/lib/cortex/coordinator/planning-scratch/probe
+
+# ✅ 驗證：在**真實加固面**下，job 對自己的 cwd 寫入必須回 EROFS
+psc_run_under cortex-reviewer-job /bin/sh -c \
+  'cd /var/lib/cortex/coordinator/planning-scratch/probe && touch w'
+#   期望：`touch: cannot touch 'w': Read-only file system`（0818 實測逐字如此）
+#   ⛔ 若成功寫進去：代表有人把這個 pool 加進了某份 unit 的 ReadWritePaths——
+#      **不要就地改 unit**，回去看登記表 writer 面為什麼多了一個 principal。
+
+# ✅ 對照：executor 的可寫落點是 unit 的 PrivateTmp 私有 /tmp（不是 cwd）
+psc_run_under cortex-reviewer-job /bin/sh -c 'touch /tmp/t && echo PRIVATETMP-WRITABLE'
+#   期望：PRIVATETMP-WRITABLE（0818 實測）
+```
+
+**逐 executor 的唯讀 cwd 實測（0818，本機）**——這是 U-2 裁決前必跑的那一輪：
+
+| executor | 剖面 | 唯讀 cwd 下的結果 | 它到底要寫什麼 |
+|---|---|---|---|
+| `agy` | strict | **rc=0，模型輸出逐位元等於 expected** | 只寫 `$HOME/.gemini → cache/gemini`（已在 RWP 內） |
+| `claude` | strict | **rc=0**（CLI 走完整條，回 `Not logged in`＝憑證缺口，非 cwd） | 無 cwd 寫入 |
+| `codex` | jit | 起不來，但**與 cwd 無關**（見下） | `$CODEX_HOME`（預設 `$HOME/.codex`）**整個目錄**要可寫 |
+
+> **codex 那一格必須逐字記下來，因為它很容易被誤記成「唯讀 scratch 跑不動」。**
+> 把 cwd 換成可寫的 `/tmp` 之後**症狀完全相同**；把 `CODEX_HOME` 指到一個可寫目錄
+> 之後，**同一個唯讀 cwd 下 rc=0、輸出正確**。所以阻斷點是 `CODEX_HOME`，不是 cwd。
+> codex 會在 `$CODEX_HOME` 底下建 `state_5.sqlite`／`logs_2.sqlite`／`sessions/`／
+> `skills/`／`plugins/`／`thread-writer-locks/` 等一整棵狀態樹——**只放行
+> `auth.json` 一個檔不夠**（那正是 `permgen.deferred_run_dependencies()` 第一項與
+> 票 D／#685 目前寫的範圍）。實機錯誤逐字：
+> `Error: failed to initialize in-process app-server client: Read-only file system (os error 30)`。
+> **這是 #686 查到、design 未預期的部署缺口，處置屬票 D（#685）／U-4；本票不擅自
+> 放寬任何路徑。**
+
+#### 4e-4. planning 的輸出通道（跨 UID ＋ ACL mask）
+
+> log 落在 `<review-verdict-spool>/planning-logs/<instance>/planning.log`：**掛在既有
+> verdict spool 底下是刻意的**（design D3「不新開通道」／U-3 未裁決）——那個帳號本來
+> 就對這棵樹有 `wx`，`_minimize()` 又會把子路徑吃掉，因此模板 unit 的
+> `ReadWritePaths=` **逐字不變、零部署動作**，default ACL 自動繼承。
+
+```bash
+# ✅ 驗證：Manager 建的目錄自動繼承 producer 的 wx（不需要任何 setfacl）
+sudo -u cortex-manager mkdir -p \
+  /var/lib/cortex/coordinator/review-verdicts/planning-logs
+sudo getfacl -p /var/lib/cortex/coordinator/review-verdicts/planning-logs | \
+  grep -E 'user:cortex-reviewer-planner|^mask'
+#   期望：user:cortex-reviewer-planner:-wx ＋ mask::-wx（0818 實測逐字如此）
+#   ⛔ 若看到 `#effective:---`：那是 #638 缺陷 1——有人用明確 mode 建了這個目錄，
+#      把繼承來的 ACL mask 壓掉了。刪掉重建，**不要**手動 setfacl 補回去。
+```
+
+> **log 檔的 mode 是 `0620` 而不是 `0600`，這一格不能省。** POSIX ACL 下新檔的 mask
+> 由 `open(2)` 的 mode 參數之 group 位夾擠：用 `0600` 建檔會把繼承來的
+> `user:<planner>:wx` 壓成 `#effective:---`，job 於是連 append 都不行——與缺陷 1 是
+> 同一個機制，只是換到檔案這一層。Manager 預建檔案（而不是讓 job 自己建）則是缺陷 2
+> 的解：job 建的檔由 job 擁有、帶 `UMask=0077`，Manager 是目錄 owner 但那不給檔案
+> 內容的讀取權。
+
+#### 4e-5. 「Manager 行程樹無 executor」的實機取證（#686 驗收 2）
+
+```bash
+# 一輪 planning 進行中，同時抓三張快照。executor 應該只出現在第二張裡。
+#   (a) 呼叫端（Manager 側）的完整後代行程樹
+ps -e -o uname:26,pid,args --no-headers   # 再以 ppid 由呼叫端 pid 遞迴展開
+#   (b) job unit 的 cgroup
+systemd-cgls -u 'cortex-reviewer-job@<instance>.service'
+#   (c) cortex-manager.service 的 cgroup
+systemd-cgls -u cortex-manager.service
+```
+
+0818 實測（逐字）：(a) 只有 `python3 → bash -c "… systemctl start --wait …" → systemctl`
+三個行程，**沒有任何 executor 可執行檔**；(b) `└─<pid> agy --print …`；
+(c) 只有 `/opt/cortex/venv/bin/cortex service run` 一個行程。
+`ps -o uname:26` 顯示 (a) 三個都是 `cortex-manager`、(b) 的 agy 是
+`cortex-reviewer-planner`。
+
+**收尾**：`sudo rm -rf /var/lib/cortex/coordinator/planning-scratch
+/var/lib/cortex/coordinator/review-verdicts/planning-logs`（兩個 pool 都由 Manager 在
+執行期自建，留著空目錄不影響，但取證用的 `probe` 那一格請務必刪掉）。
+
+---
+
 ### 4f. 系統層 python 套件（#666 漂移項 1：`pytest`）
 
 **沒有這一步，前面全部做完 dispatch 也走得完——但每張 build 卡都會在採信階段被拒。**
@@ -3308,6 +3405,49 @@ python3 -m paulsha_cortex.trust_root path-probe four-way
 > 狀態（Phase 2b 的全部隔離一次失效），只為了避開一個補三行設定就能解的錯誤。
 > 正確做法是回到第 1 步確認那三行真的進了 EnvironmentFile、且 Manager 真的重啟過
 > （`sudo systemctl show cortex-manager.service -p Environment | tr ' ' '\n' | grep PSC_`）。
+
+#### 5-5c. 補宣告 `PSC_REVIEWER_HOME`／`PSC_GATE_HOME`（#686 實機查到，**與 #679 同型**）
+
+> **這是 #679 的 PATH 缺口在 `HOME` 上的同一份複本。** `build_job_env()` 的舊註解寫著
+> 「`HOME` 未給時 systemd 依 passwd 填入該帳號自己的正確值（而且模板 unit 另有一行
+> `Environment=HOME=`）」——**那對模板模式不成立**：`cortex-job-shim` 以
+> `os.execvpe(command[0], command, job_env)` 把環境**整份換掉**，unit 的
+> `Environment=HOME=` 到不了模型行程。實機現況：`PSC_BUILDER_HOME` **有**宣告，
+> `PSC_REVIEWER_HOME`／`PSC_GATE_HOME` **沒有**——與 #679 逐字同一個形狀。
+>
+> 0818 實測（#686 取證）：未宣告時降權 planning job 的 agy 死在
+> `resolving log directory: getting home directory: $HOME is not defined`；
+> 補上 `PSC_REVIEWER_HOME=/var/lib/cortex-reviewer-planner` 之後同一條呼叫 rc=0、
+> 輸出逐位元等於 expected。
+
+```bash
+# --- 0) 確認你是不是受影響的部署 ---
+sudo grep -cE '^PSC_(BUILDER|REVIEWER|GATE)_HOME=' /opt/cortex/etc/cortex-manager.env
+#   期望（修正前）：1（只有 builder）⇒ 往下做。
+
+# --- 1) 補兩個變數（值＝該角色的帳號 HOME，由產生器導出，不要手打）---
+python3 -c 'from paulsha_cortex.trust_root import permgen as p; \
+from paulsha_cortex.trust_root.registry import Principal as P; \
+l = p.DEFAULT_LAYOUT; s = p.SCHEMES["four-way"]; \
+print("# --- #686：job 的 HOME；shim 的 execvpe 會整份換掉環境 ---"); \
+print("PSC_REVIEWER_HOME=" + l.home_of(s.resolve(P.REVIEWER))); \
+print("PSC_GATE_HOME=" + l.home_of(s.resolve(P.GATE)))' \
+  | sudo tee -a /opt/cortex/etc/cortex-manager.env
+
+# --- 2) 重啟 Manager 讓它讀到新的 EnvironmentFile ---
+sudo systemctl restart cortex-manager.service
+```
+
+```bash
+# ✅ 驗證：三個變數都在
+sudo grep -E '^PSC_(BUILDER|REVIEWER|GATE)_HOME=' /opt/cortex/etc/cortex-manager.env
+#   期望：三行。
+```
+
+> **為什麼 #686 不順手把 `HOME` 也改成 fail-closed（如 #679 對 PATH 所做）**：那會讓
+> **所有角色**的既有派工在 EnvironmentFile 補齊之前當場失敗（gate 今天也沒有
+> `PSC_GATE_HOME`）。那屬於需要獨立票 ＋ 升級程序的改動；#686 只把事實記正確
+> （`build_job_env()` 的 docstring）並補上本步驟。
 
 ### 5-6. 正向驗證（**必須成功**）
 

--- a/paulsha_cortex/config/paths.py
+++ b/paulsha_cortex/config/paths.py
@@ -133,6 +133,84 @@ def gate_ledger_spool_root() -> Path:
     return coordinator_root() / GATE_LEDGER_SPOOL_DIRNAME
 
 
+#: `planning_job_log_spool_root()` 在 `review_verdict_spool_root()` 底下的目錄名。
+#: 獨立成常數的理由與 `REVIEW_VERDICT_SPOOL_DIRNAME` 逐字相同（R1 登記表的「重複
+#: 路徑推導」Scenario 要求單一真相）。
+PLANNING_JOB_LOG_SPOOL_DIRNAME = "planning-logs"
+
+
+def planning_job_log_spool_root() -> Path:
+    """#686（#672 票 E）：降權 planning job 的**輸出通道**根。
+
+    planning 搬上 `cortex-reviewer-job@.service` 之後，模型的 stdout 不再由
+    `subprocess.run(capture_output=True)` 取回——job 跑在另一個 UID、另一個 mount
+    namespace 的加固面下，Manager 唯一拿得到輸出的方式是「job 寫得進、Manager 讀得到」
+    的一格落點（design D-i／D3）。
+
+    ## 為什麼掛在 `review_verdict_spool_root()` **底下**而不是自己一個根
+
+    design D3 的第一句是「**不新開通道**」，U-3 更把「新開一條 job→Manager 的寫入面」
+    明列為**未決、待 operator 裁決**的事項。`cortex-reviewer-planner` 今天**唯一**
+    既是 Manager-owned、又對它開放寫入的落點就是 review verdict spool
+    （`user:cortex-reviewer-planner:wx`、default ACL 會傳給子項）。掛在它底下因此：
+
+    1. **不新增任何寫入面**——那個帳號本來就寫得進這棵樹，多的只是它自己那一格；
+    2. **不需要任何部署動作**——`read_write_paths()` 的 `_minimize()` 會把被涵蓋的
+       子路徑吃掉，模板 unit 的 `ReadWritePaths=` 逐字不變，default ACL 自動繼承；
+    3. 仍是**登記表資產**（`planning-job-log-spool`）——它有自己的 note、自己的
+       writer／reader 面、自己的 ACL 命令，治理面沒有因為省了一條 RWP 而消失。
+
+    真正**不能**沿用的是 launcher 那條 reviewer log 路徑（`<log_dir>/<slice>.jsonl`，
+    實機解到 `/var/lib/cortex/runtime/review/<slice>/`）：它既不在模板 unit 的
+    `ReadWritePaths=` 內，Manager 自己也建不出那層目錄（`/var/lib/cortex/runtime`
+    是 root-owned 0755）。design D3 寫的「reviewer 已在用同一條通道」在本機**不成立**
+    ——實機 `job-specs/reviewer/` 是空的，那條路從未被真正走過（見 #686 PR body）。
+
+    ## per-invocation 那一格的形態
+
+    每次呼叫在 `<此根>/<instance>/` 有且只有自己那一格（生命週期走
+    `coordinator/spool_slot.py`，與另外兩個 spool 同一份實作），log 檔由 **Manager
+    預先建立**（mode `0620`），job 只是以 `O_APPEND` 接管它。
+
+    理由是 #638 缺陷 2——job 自己建的檔由 job 擁有、又帶 unit 的 `UMask=0077`，Manager
+    是**目錄**的 owner 但那不給檔案內容的讀取權。verdict／commit 兩個 spool 靠
+    producer 自己 `chmod 0644` 繞過（`spool_slot.publish_file_command`），那需要在模型
+    之後再跑一段 wrapper；而 planning 的 job **刻意只有模型 argv 一段**（design D3：
+    wrapper 自產的任何文字都會污染 `_extract_json` 的輸入），沒有可以掛 publish 的
+    位置。改由 Manager 先建檔就同時解掉兩件事：檔案 owner 恆為 Manager（讀得到），
+    job 只獲得繼承自 default ACL 的 `w`（寫得進、換不掉、刪不掉——它對那一格沒有 `w`）。
+
+    `0620` 不是隨手挑的：POSIX ACL 下新檔的 `mask` 由 open(2) 的 mode 參數之 group 位
+    夾擠。用 `0600` 建檔會把繼承來的 `user:<planner>:-wx` 壓成 `#effective:---`
+    （＝#638 缺陷 1 的同一個機制），job 於是連 append 都不行。
+    """
+    return review_verdict_spool_root() / PLANNING_JOB_LOG_SPOOL_DIRNAME
+
+
+#: `planning_scratch_root()` 在 `coordinator_root()` 底下的目錄名（同上，單一真相）。
+PLANNING_SCRATCH_DIRNAME = "planning-scratch"
+
+
+def planning_scratch_root() -> Path:
+    """#686（#672 票 E）：降權 planning job 的**唯讀** per-invocation scratch pool 根。
+
+    這一格是 design D-a／D-c 的 job 側對應：模型的 cwd 必須是一個一次性的、不是
+    operator 樹的目錄。U-2 的裁決是**唯讀**（design 的傾向 (2)）——本根**刻意不出現在
+    任何 job 模板 unit 的 `ReadWritePaths=`** 中，因此 `ProtectSystem=strict` 下模型連
+    寫都寫不進去：design D-d 的「模型是否弄髒了自己的拋棄式 sandbox」偵測需求因此
+    **結構上消失**，而不是退步成一條做不到的偵測（R-1）。
+
+    登記表資產 `planning-scratch-pool` 的 writers 只有 MANAGER、readers 含 PLANNER
+    ——「不進 RWP」因此也是**機械導出**的結果，不是靠註解約定：`required_write_targets()`
+    只收 writer 面。
+
+    executor 需要的可寫落點（codex 的 `-o`、agy 的 log/state）改指向 unit 的
+    `PrivateTmp=yes` 私有 `/tmp`：那是 per-invocation、job-owned、unit 結束即消失的，
+    而 Manager 看不到它——「弄髒它不產生任何後果」在這裡是結構事實。
+    """
+    return coordinator_root() / PLANNING_SCRATCH_DIRNAME
+
+
 def gate_worktree_root() -> Path:
     """#629：gate 執行身分的**拋棄式工作區** pool 根（`<agents_root>/gate-worktree`）。
 

--- a/paulsha_cortex/coordinator/job_runner.py
+++ b/paulsha_cortex/coordinator/job_runner.py
@@ -974,9 +974,23 @@ def build_job_env(
     reviewer 的 PATH 只能跟著 builder 走。
 
     **`PATH` 是必要鍵，不是選配**（#679）：未宣告 `PSC_*_PATH` 時
-    :func:`resolve_job_path` 直接 raise。`HOME` 仍是選配，兩者的差別是實質的——
-    `HOME` 未給時 systemd 依 passwd 填入該帳號自己的正確值（而且模板 unit 另有一行
-    `Environment=HOME=`），`PATH` 未給時沒有任何一層會填出正確值。
+    :func:`resolve_job_path` 直接 raise。
+
+    **`HOME` 目前仍是選配，但它的舊理由在模板模式下是錯的（#686 實機更正）。**
+    本段原文寫著「`HOME` 未給時 systemd 依 passwd 填入該帳號自己的正確值（而且模板
+    unit 另有一行 `Environment=HOME=`）」——後半句對**模板模式**不成立：`cortex-job-shim`
+    以 `os.execvpe(command[0], command, job_env)` 把環境**整份換掉**
+    （`job_shim.resolve_job_env`），unit 的 `Environment=HOME=` 因此到不了模型行程。
+    0818 實機複驗：`PSC_REVIEWER_HOME` 未宣告 ⇒ 降權 planning job 的 agy 死在
+    `resolving log directory: getting home directory: $HOME is not defined`；補上該變數
+    之後同一條呼叫 rc=0。`PSC_BUILDER_HOME` 在實機**有**宣告，`PSC_REVIEWER_HOME`／
+    `PSC_GATE_HOME` 沒有——與 #679 的 PATH 是**同一個形狀**（builder 那一份被宣告過，
+    另外兩個角色沒有）。
+
+    為什麼本票不順手把它也改成 fail-closed：那會讓**所有角色**的既有派工在
+    EnvironmentFile 補齊之前當場失敗（gate 今天也沒有 `PSC_GATE_HOME`），屬於
+    #679 那種需要獨立票 ＋ runbook 升級程序的改動。本票只把事實記正確，並在
+    runbook 第 5-5c 步補上宣告步驟。
     """
 
     config = resolve_job_role(role)

--- a/paulsha_cortex/coordinator/planning_job.py
+++ b/paulsha_cortex/coordinator/planning_job.py
@@ -1,0 +1,726 @@
+"""issue #686（#672 票 E）：`JobPlanningInvoker`——planning 改走模板 unit。
+
+## 這個檔換掉的是什麼
+
+票 B（#683）把「怎麼跑一個 executor」抽成 `PlanningInvoker`，並把現行行為原封搬進
+`InProcessPlanningInvoker`。本檔是那個介面的**第二個實作**：拿到一個 identity ＋
+prompt，起一個 `cortex-reviewer-job@<instance>.service` 實例，以
+`cortex-reviewer-planner` 的身分執行模型 CLI，再把輸出取回來。
+
+`cortex-manager` 的 passwd 註記逐字寫著 `no model code`。#615（M2）讓 reviewer 兌現了
+那句話，planner 沒有——它至今仍在 daemon 行程內 `subprocess.run` 模型 CLI（#672）。
+本檔是那半條的補齊。
+
+## 十條防線（design D2）在本實作裡分別由誰保證
+
+===  ===========================  =============================================
+ #    現行（in-process）           job 側對應
+===  ===========================  =============================================
+D-a  `TemporaryDirectory`         Manager 在 `planning-scratch-pool` 下建
+                                  per-invocation 一格，呼叫結束 `rmtree`；
+                                  unit 的 `CollectMode=inactive-or-failed`
+                                  讓 systemd 自己也不留實例
+D-b  整棵 repo 複本                **空 scratch**（見下方「U-1」段）
+D-c  `cwd=sandbox`                spec 的 `working_directory`＝那一格；
+                                  shim 在降權**之後** `chdir`
+D-d  sandbox 弄髒即 fail-closed    **結構上不可能**：scratch 的 writer 面只有
+                                  Manager ⇒ 不進任何 job 模板 unit 的
+                                  `ReadWritePaths=` ⇒ `ProtectSystem=strict`
+                                  下 job 連寫都寫不進去（U-2 裁決＝唯讀）
+D-e  operator 樹雙向快照            `repo-source-tree` 不在 reviewer 模板 unit 的
+                                  RWP 內 ⇒ kernel 直接擋（**升級**）
+D-f  `_contain_operator_drift`     job 模式下 operator 樹結構性不可能被 job 改；
+                                  程式保留給 direct 模式（**等價、範圍縮小**）
+D-g  hermetic `CLAUDE_CONFIG_DIR`  job 的 HOME 是 `cortex-reviewer-planner`，
+                                  `ProtectHome=yes` 讓 `/home` 整個不可見，
+                                  `build_job_env()` 的白名單不含
+                                  `CLAUDE_CONFIG_DIR`（**升級**）
+D-h  `subprocess.run(timeout=)`    Manager 側 `Popen.wait(timeout)` →
+                                  `systemctl stop` → 確認離開 active（D4）
+D-i  `capture_output=True`         Manager-owned log ＋ shim 降權後 O_APPEND
+                                  接管（`planning-job-log-spool`）
+D-j  codex `-o last.json`          落點在 job 的 `PrivateTmp` ⇒ Manager 讀不到
+                                  ⇒ `_extract_json` 退成單候選（**退步 R-2**）
+===  ===========================  =============================================
+
+## U-1（scratch 要不要放 repo 複本）：job 模式實作 (b)＝空 scratch
+
+design 傾向 (b) 而未定案。本實作在 **job 模式**走 (b)，direct 模式逐字不變（仍是整棵
+複製）。理由不是偏好，是 (a) 在 job 模式下**還不存在可行的機制**：複本由 Manager 建
+立、Manager 的 unit 帶 `UMask=0077`，複製出來的每個檔都是 `0600 cortex-manager`，job
+一個位元組都讀不到。要讓 (a) 成立得先有一套「把 Manager 建的整棵樹遞迴授權給 job 帳號」
+的機制——那是**新的一整個授權面**，不在任何一張票的範圍內。
+
+實測補充（本票在實機量的，寫進 PR body）：**(b) 在 job 模式下並不比 (a) 更緊**。
+`ProtectSystem=strict` 只擋寫，不擋讀；`/var/lib/cortex/repos/<slug>` 對
+`cortex-reviewer-planner` 是可讀的。因此「模型讀不到 repo」在 job 模式下**不成立**，
+差別只在它不是 cwd。這一點 design 的 U-1 取捨段（「(b) 是收緊」）在 job 模式下要更正。
+
+## U-2（scratch 對 job 可寫還是唯讀）：**唯讀**
+
+design 自己指出：選唯讀可以把安全退步 R-1（「模型弄髒自己的拋棄式 sandbox」的偵測，
+Manager 在 job 側做不到）從「失去行為訊號」變成「結構上不可能」。本票採唯讀。
+
+實作上它**不是**一個 `if`，而是登記表 writer 面的機械後果：`planning-scratch-pool`
+的 writers 只有 `Principal.MANAGER` ⇒ `permgen.required_write_targets()` 不收它 ⇒
+它不出現在任何 job 模板 unit 的 `ReadWritePaths=` ⇒ `ProtectSystem=strict` 讓寫入回
+EROFS。要打破這條性質必須改登記表，而那會在產生器輸出與 unit 檔上留下痕跡。
+
+executor 需要的可寫落點改指向 unit 的 `PrivateTmp=yes` 私有 `/tmp`（codex 的 `-o`、
+agy 的 log／state）：per-invocation、job-owned、unit 結束即消失，且 Manager 看不到。
+
+## 只支援模板模式（B 案），`systemd-run` 模式 fail-closed
+
+`PSC_JOB_RUNNER=systemd-run`（A 案）下 Manager 自己組 `--property=`／`--setenv=`，
+「身分與加固面只由 root-owned unit 決定」這條性質不成立——而那正是 planning 這個
+**吃 untrusted issue 內容**的角色最需要的性質。本檔因此只實作 B 案；A 案下
+:func:`planning_runtime._select_planning_invoker` 明確拒絕，**不**退回 in-process
+（退回去看起來會是成功的，那正是本票要消除的失效模式）。
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+import subprocess
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Mapping, Sequence
+from uuid import uuid4
+
+from ..config import paths
+from . import job_runner, spool_slot
+from .model_identities import (
+    PLANNING_FAILURE_EXECUTOR,
+    PLANNING_FAILURE_EXECUTOR_SILENT_EXIT,
+    PLANNING_FAILURE_JOB_START,
+)
+
+
+logger = logging.getLogger(__name__)
+
+
+#: 逾時的具名子類。design D4 把它寫成一個獨立的失敗族（`planning-job-timeout`），
+#: 但票 A 已經把三分族的集合釘成不變式
+#: （`tests/test_planning_failure_taxonomy_672.py` 對
+#: `ENVIRONMENT_GRADE_PLANNING_FAMILIES` 做的是**逐字相等**斷言），新增第四個
+#: environment 級族名會動到那條契約。
+#:
+#: 因此逾時在本實作裡是 `planning-executor-failed` 的**子類**——與
+#: `executor-silent-exit` 同一種收法：族名（＝分級輸入）不變，子類名進 diagnostic
+#: 並在拒因表上逐字現形。分級結果與 design 要求的一致（environment ⇒
+#: `_resume_decision` 浮得出 `recover-planning`），差別只在它掛在哪一個族底下。
+PLANNING_JOB_TIMEOUT = "planning-job-timeout"
+
+#: `systemctl stop` 之後確認 unit 真的離開 active 的輪詢上限（秒）。
+#:
+#: design D4：停止之後 MUST 確認 unit 已離開 active，否則下一次同 `job_id` 的呼叫會撞
+#: `job-runner-template-instance-busy`——而那個錯誤訊息與「逾時」毫無關係，會把下一輪
+#: 的排查完全帶偏。
+STOP_CONFIRM_TIMEOUT_SECONDS = 30.0
+STOP_CONFIRM_POLL_SECONDS = 0.2
+
+#: Manager 預建 log 檔的 mode。**不是 0600**：POSIX ACL 下新檔的 mask 由 open(2) 的
+#: mode 參數之 group 位夾擠，`0600` 會把繼承來的 `user:<planner>:wx` 壓成
+#: `#effective:---`（＝#638 缺陷 1 的同一個機制），job 於是連 append 都不行。
+#: 見 `config/paths.py:planning_job_log_spool_root` 的完整論證。
+LOG_FILE_MODE = 0o620
+
+#: 失敗診斷帶回的 log 尾段上限。診斷會一路進 log／evidence／`blocking_reason`。
+LOG_EXCERPT_LIMIT = 400
+
+#: executor 版本字串的探測逾時（秒）。它自己也是一個降權 job。
+VERSION_PROBE_TIMEOUT_SECONDS = 60
+
+
+class PlanningJobError(ValueError):
+    """降權 planning job 的 fail-closed，**帶三分族**（design D8／spec R6）。
+
+    繼承 `ValueError` 與 `job_runner.JobRunnerError` 同一個理由：本 repo 全部的
+    fail-closed 驗證都是 `ValueError`，daemon 的 tick isolation（#246）攔的就是它，
+    因此一次 planning 失敗不會打掛 daemon。
+
+    `family` 是**分級的唯一輸入**。它刻意不從 `detail` 的字串 substring-search
+    ——`detail` 帶的是模型輸出與 CLI 訊息，那是 job 影響得到的東西（票 A 的
+    `grade=` 錨在開頭就是為了同一件事）。
+    """
+
+    def __init__(
+        self,
+        family: str,
+        detail: str,
+        *,
+        diagnostics: Mapping[str, str] | None = None,
+    ) -> None:
+        super().__init__(f"{family}: {detail}")
+        self.family = family
+        self.detail = detail
+        self.diagnostics: dict[str, str] = dict(diagnostics or {})
+
+
+@dataclass(frozen=True)
+class _CompletedJob:
+    """`subprocess.CompletedProcess` 的最小同形物（`ProcessRunner` 契約）。
+
+    `stderr` 恆為空字串而不是 `None`：`model_identities._process_fields` 要求三個欄位
+    型別正確，回 `None` 會讓每一次 agy probe 落在 `malformed process result`——一個與
+    現場完全無關的診斷。
+
+    **stdout 為什麼同時含 stderr**：shim 在降權之後把 fd 1 與 fd 2 **同時** dup 到
+    spec 的 `log_path`（`job_shim._take_over_stdio`），Manager 這一側拿到的是一份合併
+    輸出。這是 design 未預期的第五條退步（R-5），已逐字記在本票 PR body。
+    """
+
+    returncode: int
+    stdout: str
+    stderr: str = ""
+
+
+def _job_repo_root() -> str:
+    """job spec 的 `PSC_REPO_ROOT`（與 `launcher.launch()` 逐字同一個推導）。"""
+
+    return str(Path(__file__).resolve().parents[2])
+
+
+def _excerpt(text: str, *, limit: int = LOG_EXCERPT_LIMIT) -> str:
+    collapsed = " ".join(text.split())
+    if not collapsed:
+        return "<empty>"
+    if len(collapsed) <= limit:
+        return collapsed
+    return collapsed[:limit] + "…"
+
+
+class JobPlanningInvoker:
+    """在 `cortex-reviewer-job@.service` 模板實例裡執行 planning 的模型呼叫。
+
+    **本類別不複製任何一份 `job_runner` 的邏輯**（plan 票 E 的硬性要求）：身分、
+    模板、加固剖面、env 白名單、preflight、spec 形狀、起動確認全部經
+    `job_runner` 的既有函式，本類別只負責「把一次 planning 呼叫翻成一次派工」。
+    """
+
+    def __init__(
+        self,
+        *,
+        env: Mapping[str, str] | None = None,
+        scratch_root: str | Path | None = None,
+        log_spool_root: str | Path | None = None,
+        popen: Callable[..., object] | None = None,
+        unit_active: Callable[[str, str], bool] | None = None,
+        stop_unit: Callable[[str, str], None] | None = None,
+        monotonic: Callable[[], float] = time.monotonic,
+        sleep: Callable[[float], None] = time.sleep,
+    ) -> None:
+        self._env: Mapping[str, str] = env if env is not None else os.environ
+        self._scratch_root = (
+            Path(scratch_root) if scratch_root is not None else paths.planning_scratch_root()
+        )
+        self._log_spool_root = (
+            Path(log_spool_root)
+            if log_spool_root is not None
+            else paths.planning_job_log_spool_root()
+        )
+        self._popen = popen if popen is not None else subprocess.Popen
+        self._unit_active = unit_active if unit_active is not None else job_runner._unit_is_active
+        self._stop_unit = stop_unit if stop_unit is not None else self._systemctl_stop
+        self._monotonic = monotonic
+        self._sleep = sleep
+        self._sequence = 0
+        self._version_cache: dict[str, str] = {}
+        self._resolving_version = False
+
+    # -- PlanningInvoker 介面 ------------------------------------------------
+
+    def run(self, invocation) -> object:
+        """跑一次 identity＋prompt 呼叫（`PlanningInvoker.run` 的 job 實作）。"""
+
+        from .planning_runtime import PlanningOutcome, _planning_argv
+
+        identity = invocation.identity
+        scratch_hint = self._reserve(invocation.run_id, invocation.purpose)
+        # `_planning_argv` 的 `temp_dir` 是 executor 的**可寫落點**（codex 的
+        # `-o`、agy 的 log_dir）。U-2 裁決下 scratch 唯讀，因此那些落點指向 unit
+        # 的 `PrivateTmp=yes` 私有 /tmp——per-invocation、job-owned、unit 結束即
+        # 消失，Manager 看不到（這正是 D-j／R-2 退步的來源）。
+        argv = _planning_argv(identity, invocation.prompt, "/tmp", scratch_hint.cwd)
+        completed = self._dispatch(
+            argv=argv,
+            executor=identity.executor,
+            timeout_seconds=invocation.timeout_seconds,
+            reservation=scratch_hint,
+        )
+        return PlanningOutcome(
+            returncode=completed.returncode,
+            stdout=completed.stdout,
+            stderr=completed.stderr,
+            # D-j／R-2：codex 的 `-o last.json` 落在 job 的 PrivateTmp，Manager
+            # 讀不到 ⇒ 第二候選恆為 None，`_extract_json` 退成單候選。
+            output_text=None,
+            diagnostics=dict(self._diagnostics_cache),
+        )
+
+    def capability_probe_runner(self) -> Callable[..., object]:
+        """`probe_agy_capability` 兩次裸 CLI 呼叫用的執行接縫（票 B 的 `ProcessRunner`）。
+
+        agy 的能力探測是一段**兩步 CLI 協定**（`agy models` → smoke），它的真相在
+        `model_identities.probe_agy_capability`；複製一份到這裡就是第二份真相。因此
+        這裡回傳的是「一個 argv → 一個降權 job」的閉包，**兩次 CLI 呼叫各算一次
+        invocation**（各自一個 unit 實例、各自一格 scratch 與 log）。
+        """
+
+        def runner(argv: Sequence[str], **kwargs: object) -> _CompletedJob:
+            timeout = kwargs.get("timeout")
+            timeout_seconds = int(timeout) if isinstance(timeout, (int, float)) else 45
+            command = [str(item) for item in argv]
+            if not command:
+                raise PlanningJobError(
+                    PLANNING_FAILURE_JOB_START, "capability probe argv is empty"
+                )
+            reservation = self._reserve("ephemeral", "probe")
+            return self._dispatch(
+                argv=command,
+                executor=command[0],
+                timeout_seconds=timeout_seconds,
+                reservation=reservation,
+            )
+
+        return runner
+
+    # -- 內部 ---------------------------------------------------------------
+
+    @property
+    def _diagnostics_cache(self) -> Mapping[str, str]:
+        return getattr(self, "_last_diagnostics", {})
+
+    def _reserve(self, run_id: str, purpose: str) -> "_Reservation":
+        """算出本次呼叫的 job_id 與 scratch cwd（D9 的 instance 命名）。
+
+        格式 `plan-<run_id 前 12 字>-<purpose>-<序號>-<隨機 8 碼>`：
+
+        - `purpose` 進名字是刻意的——`systemctl list-units 'cortex-reviewer-job@*'`
+          因此直接說得出「這一批 job 在做什麼」，不必回頭查 spec。它**不**進 spec 的
+          任何決策欄位。
+        - 隨機後綴：probe 的 `run_id` 在非 daemon 呼叫端是 `"ephemeral"`（D9 已點名），
+          而 daemon 與 CLI 的 `apply_work_action` 可能同時跑——序號只在行程內唯一，
+          跨行程要靠隨機碼，否則兩個並行的 probe 會互撞 `instance-busy`。
+
+        instance 名的**推導**不在這裡：`job_runner.template_instance_id()` →
+        `job_workspace.job_segment()` 是全 repo 唯一的推導點（#645），呼叫端一律只傳
+        job_id、不得自己拼名字。
+        """
+
+        self._sequence += 1
+        job_id = (
+            f"plan-{str(run_id or 'ephemeral')[:12]}-{purpose}-"
+            f"{self._sequence}-{uuid4().hex[:8]}"
+        )
+        instance = job_runner.template_instance_id(job_id)
+        slot = self._scratch_root / instance
+        return _Reservation(job_id=job_id, instance=instance, slot=slot, cwd=slot / "cwd")
+
+    def _dispatch(
+        self,
+        *,
+        argv: Sequence[str],
+        executor: str,
+        timeout_seconds: int,
+        reservation: "_Reservation",
+    ) -> _CompletedJob:
+        """一次呼叫 = 一個模板 unit 實例。**在任何副作用之前先 fail-closed。**"""
+
+        self._last_diagnostics: dict[str, str] = {}
+        try:
+            plan = job_runner.prepare_systemd_template(
+                self._env,
+                job_id=reservation.job_id,
+                executor=executor,
+                role=job_runner.JOB_ROLE_REVIEW,
+                unit_active=self._unit_active,
+            )
+        except job_runner.JobRunnerError as exc:
+            raise PlanningJobError(
+                PLANNING_FAILURE_JOB_START, str(exc)
+            ) from exc
+
+        diagnostics = self._base_diagnostics(plan, executor)
+        self._last_diagnostics = dict(diagnostics)
+        log_slot = self._log_spool_root / plan.instance
+        log_path = log_slot / "planning.log"
+        try:
+            self._prepare_scratch(reservation)
+            self._prepare_log(log_slot, log_path)
+        except (OSError, spool_slot.SpoolSlotError) as exc:
+            self._cleanup(reservation, log_slot)
+            raise PlanningJobError(
+                PLANNING_FAILURE_JOB_START,
+                f"planning job scratch/log 準備失敗: {type(exc).__name__}: {exc}",
+                diagnostics=diagnostics,
+            ) from exc
+
+        try:
+            return self._start_and_wait(
+                argv=argv,
+                plan=plan,
+                reservation=reservation,
+                log_path=log_path,
+                timeout_seconds=timeout_seconds,
+                diagnostics=diagnostics,
+            )
+        finally:
+            self._cleanup(reservation, log_slot)
+            # spec 是 job 的命令列，收割之後就沒有消費者；留著只會讓下一個人以為
+            # 有一個未回收的派工（`instance-busy` 的常見誤判來源）。
+            try:
+                os.unlink(plan.spec_path)
+            except OSError:
+                pass
+
+    def _start_and_wait(
+        self,
+        *,
+        argv: Sequence[str],
+        plan: job_runner.SystemdTemplatePlan,
+        reservation: "_Reservation",
+        log_path: Path,
+        timeout_seconds: int,
+        diagnostics: dict[str, str],
+    ) -> _CompletedJob:
+        sentinel = reservation.slot / "client.exit"
+        client_log = reservation.slot / "client.log"
+        env = job_runner.build_job_env(
+            manager_env=self._env,
+            job_id=reservation.job_id,
+            slice_id=reservation.job_id,
+            repo_root=_job_repo_root(),
+            role=job_runner.JOB_ROLE_REVIEW,
+        )
+        # design D3 的第 1 條：planning 的 job **顯式**只有模型 argv 一段。
+        # 不跑 gate、不產 bundle、不寫 verdict、不寫 sentinel，也不包 `bash -c`
+        # ——不是「既有旗標碰巧為 None」，是這裡根本沒有 wrapper 可言。理由不只是
+        # 潔癖：wrapper 自產的任何一個位元組都會進同一份 log，而那份 log 就是
+        # `_extract_json` 的輸入（D3 第 2 條）。
+        spec = job_runner.build_job_spec(
+            job_id=reservation.job_id,
+            instance=plan.instance,
+            unit=plan.unit,
+            command=list(argv),
+            working_directory=str(reservation.cwd),
+            log_path=str(log_path),
+            env=env,
+        )
+        try:
+            job_runner.write_job_spec(plan.spec_path, spec, account=plan.account)
+        except job_runner.JobRunnerError as exc:
+            raise PlanningJobError(
+                PLANNING_FAILURE_JOB_START, str(exc), diagnostics=diagnostics
+            ) from exc
+
+        client_argv = job_runner.build_manager_exit_recorder_argv(
+            client_argv=job_runner.build_systemctl_start_argv(
+                systemctl=plan.binary, unit=plan.unit
+            ),
+            sentinel=str(sentinel),
+        )
+        # client 的 stdout／stderr **刻意不與模型 log 共用一個檔**：那份 log 是
+        # `_extract_json` 的輸入，systemctl 自己的訊息（polkit 拒絕等）混進去就是
+        # design D3 第 2 條要擋的污染。它們落在 job 讀得到、寫不了的 scratch 那一格。
+        with open(client_log, "wb") as handle:
+            process = self._popen(
+                client_argv,
+                cwd=None,
+                env=self._client_env(),
+                stdin=subprocess.DEVNULL,
+                stdout=handle,
+                stderr=subprocess.STDOUT,
+            )
+        try:
+            job_runner.confirm_template_instance_started(
+                process=process,
+                sentinel=str(sentinel),
+                unit=plan.unit,
+                account=plan.account,
+                log_path=str(client_log),
+                timeout_ms=job_runner.resolve_start_timeout_ms(self._env),
+                manager_authored_sentinel=True,
+            )
+        except job_runner.JobRunnerError as exc:
+            self._stop_and_confirm(plan)
+            raise PlanningJobError(
+                PLANNING_FAILURE_JOB_START, str(exc), diagnostics=diagnostics
+            ) from exc
+
+        try:
+            process.wait(timeout=timeout_seconds)
+        except subprocess.TimeoutExpired as exc:
+            # D4：逾時由 Manager 側強制終止。**不能只是放棄等待**——那會讓下一次
+            # 同名 instance 撞 `job-runner-template-instance-busy`，而那個症狀與
+            # 逾時完全無關。
+            stopped = self._stop_and_confirm(plan)
+            diagnostics = {
+                **diagnostics,
+                "timeout_seconds": str(timeout_seconds),
+                "unit_left_active": "no" if stopped else "yes",
+            }
+            self._last_diagnostics = dict(diagnostics)
+            raise PlanningJobError(
+                PLANNING_FAILURE_EXECUTOR,
+                (
+                    f"{PLANNING_JOB_TIMEOUT} unit={plan.unit} "
+                    f"timeout={timeout_seconds}s "
+                    f"stopped={'yes' if stopped else 'no'}"
+                ),
+                diagnostics=diagnostics,
+            ) from exc
+
+        returncode = self._read_sentinel(sentinel, process)
+        stdout = self._read_log(log_path)
+        if returncode != 0:
+            client_tail = self._read_log(client_log)
+            silent = not stdout.strip()
+            detail = (
+                f"rc={returncode} unit={plan.unit} "
+                f"profile={plan.hardening_profile} "
+                f"binary={diagnostics.get('resolved_binary', '<unresolved>')} "
+                f"version={self._binary_version(executor=plan.executor, plan=plan)} "
+                f"seccomp_filter_fatal={diagnostics.get('seccomp_filter_fatal', '<unknown>')}"
+            )
+            if silent:
+                # spec R6：rc≠0 且完全無輸出是整個家族裡最難查的一種——**連錯誤訊息
+                # 都沒有**，歸因於是會落到模型、prompt、逾時或憑證，而不會落到執行
+                # 環境。它必須被顯式命名，而且診斷要指名 unit／剖面／resolved_binary
+                # ／`seccomp_filter_is_fatal()`——那四個就是唯一的線索來源，而最後
+                # 一個正是 #673 整張票走偏的原因（當時沒有任何地方回答得了它）。
+                detail = f"{PLANNING_FAILURE_EXECUTOR_SILENT_EXIT} {detail}"
+                detail = f"{detail} client={_excerpt(client_tail)}"
+            else:
+                detail = f"{detail} log={_excerpt(stdout)}"
+            diagnostics = {**diagnostics, "returncode": str(returncode)}
+            self._last_diagnostics = dict(diagnostics)
+            raise PlanningJobError(
+                PLANNING_FAILURE_EXECUTOR, detail, diagnostics=diagnostics
+            )
+        return _CompletedJob(returncode=returncode, stdout=stdout)
+
+    # -- 前置物 -------------------------------------------------------------
+
+    def _prepare_scratch(self, reservation: "_Reservation") -> None:
+        """建出 per-invocation 的 scratch 一格（**Manager-owned、job 唯讀**）。
+
+        兩個 mode 是刻意的，而且方向相反：
+
+        - 那一格與 cwd 給 `0755`：job 必須 chdir 進去、讀得到裡面（D-c）。「讀得到」
+          不等於「寫得進」——寫入面由 `ProtectSystem=strict` ＋ 本 pool 不在任何 job
+          模板 unit 的 RWP 內擋掉（U-2），與 mode 無關。
+        - pool 根若不存在才建，且**只在自己建的時候**設 mode：operator 依產生器套過
+          `chmod 0700` ＋ `setfacl rX` 之後，那是更緊的形態，這裡不得把它蓋回去。
+        """
+
+        root = self._scratch_root
+        if not root.exists():
+            root.mkdir(parents=True, exist_ok=True)
+            os.chmod(root, 0o711)
+        if reservation.slot.exists():
+            # instance 名帶 job_id 的 sha256 前 8 碼，撞名等於同一個 job_id 被重派，
+            # 而那是 `prepare_systemd_template` 的 `instance-busy` 該擋的事。走到這裡
+            # 代表上一輪留了殘骸，清掉再建（留著會讓模型讀到上一輪的東西）。
+            shutil.rmtree(reservation.slot, ignore_errors=True)
+        reservation.slot.mkdir(parents=True)
+        os.chmod(reservation.slot, 0o755)
+        reservation.cwd.mkdir()
+        os.chmod(reservation.cwd, 0o755)
+
+    def _prepare_log(self, slot: Path, log_path: Path) -> None:
+        """建出 per-invocation 的 log 一格，並**由 Manager 預先建立** log 檔。
+
+        `create_slot(reset=True)`：同一個 instance 撞名只可能是上一輪的殘骸（見
+        `_prepare_scratch`），而 `reset=False` 的 pre-seed 守衛在這裡會把殘骸變成一次
+        拒絕派工。commit-spool 走的就是 `reset=True`，同一個理由。
+
+        log 檔的 mode 見 :data:`LOG_FILE_MODE`：Manager 建檔讓檔案 owner 恆為 Manager
+        （讀得到），job 只拿到繼承自 default ACL 的 `w`。
+        """
+
+        slot.parent.mkdir(parents=True, exist_ok=True)
+        spool_slot.create_slot(slot, reset=True)
+        fd = os.open(str(log_path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, LOG_FILE_MODE)
+        try:
+            # umask 會把 open(2) 的 mode 夾掉（Manager unit 帶 `UMask=0077`），因此
+            # 一定要再 fchmod 一次；那一次同時把 ACL mask 設成 group 位＝`w`，
+            # 繼承來的 `user:<planner>:wx` 於是 effective `-w-`。
+            os.fchmod(fd, LOG_FILE_MODE)
+        finally:
+            os.close(fd)
+
+    def _cleanup(self, reservation: "_Reservation", log_slot: Path) -> None:
+        """D-a：呼叫結束即銷毀。診斷面失敗不得反過來變成新的失敗來源。"""
+
+        for target in (reservation.slot, log_slot):
+            try:
+                shutil.rmtree(target, ignore_errors=True)
+            except Exception:  # noqa: BLE001 - 清理失敗不得掩蓋上游的真實失敗
+                logger.warning("planning-job-cleanup-failed path=%s", target)
+
+    # -- 診斷 ---------------------------------------------------------------
+
+    def _base_diagnostics(
+        self, plan: job_runner.SystemdTemplatePlan, executor: str
+    ) -> dict[str, str]:
+        """`unit`／`hardening_profile`／`resolved_binary` ＋ seccomp 那一維（D8）。
+
+        `seccomp_filter_is_fatal()` 是 PR #677 提供的**機械答案**：
+        `SystemCallErrorNumber=EPERM` 在時答案是「不該懷疑 seccomp」，不在時才是
+        「該懷疑」。#673 整張票走偏，就是因為當時沒有任何地方回答得了這個問題。
+        """
+
+        diagnostics: dict[str, str] = {
+            "family": "",
+            "unit": plan.unit,
+            "instance": plan.instance,
+            "hardening_profile": plan.hardening_profile,
+            "account": plan.account,
+        }
+        try:
+            search_path = job_runner.resolve_job_path(
+                self._env, role=job_runner.JOB_ROLE_REVIEW
+            )
+            resolved = shutil.which(executor, path=search_path)
+        except Exception as exc:  # noqa: BLE001 - 診斷不得拖垮派工
+            resolved = None
+            diagnostics["job_path"] = f"<unresolved:{type(exc).__name__}>"
+        else:
+            diagnostics["job_path"] = search_path
+        diagnostics["resolved_binary"] = resolved or "<absent>"
+        try:
+            from ..trust_root import permgen
+
+            table = permgen.executor_hardening_profile(executor).effective()
+            diagnostics["seccomp_filter_fatal"] = (
+                "yes" if permgen.seccomp_filter_is_fatal(table) else "no"
+            )
+            surfaces = [
+                f"{surface.program}@{surface.surface}:"
+                f"{'|'.join(surface.syscalls)}:fatal={surface.fatal}"
+                for surface in permgen.filtered_syscall_surfaces()
+                if surface.program == executor
+            ]
+            diagnostics["filtered_syscalls"] = ",".join(surfaces) or "<none>"
+        except Exception as exc:  # noqa: BLE001 - 同上
+            diagnostics["seccomp_filter_fatal"] = f"<unresolved:{type(exc).__name__}>"
+        return diagnostics
+
+    def _binary_version(
+        self, *, executor: str, plan: job_runner.SystemdTemplatePlan
+    ) -> str:
+        """`<executor> --version` 的字串——**在同一個降權 job 面下量**（D10）。
+
+        為什麼非量不可：#681 就是「只比路徑會漏掉」的那一類缺陷（toolchain 的
+        `copilot` 是一支依 PATH／HOME 搜尋的 shim，job 實際跑系統層 0.0.330、operator
+        是 1.0.79，**路徑完全相同**）。而「解析到非預期版本」**不會表現為失敗**——它
+        會安靜地產出一份用別的 CLI 跑出來的結果。
+
+        只在失敗路徑上量（一次失敗多一個短命 job），並以「這一支檔案的 stat」為快取
+        鍵。遞迴由 `_resolving_version` 擋住：版本探測本身失敗時不得再去探它的版本。
+        """
+
+        if self._resolving_version:
+            return "<version-probe-skipped>"
+        key = f"{executor}"
+        cached = self._version_cache.get(key)
+        if cached is not None:
+            return cached
+        self._resolving_version = True
+        try:
+            reservation = self._reserve("version", "probe")
+            completed = self._dispatch(
+                argv=[executor, "--version"],
+                executor=plan.executor or executor,
+                timeout_seconds=VERSION_PROBE_TIMEOUT_SECONDS,
+                reservation=reservation,
+            )
+            value = _excerpt(completed.stdout, limit=120)
+        except Exception as exc:  # noqa: BLE001 - 診斷不得拖垮失敗回報
+            value = f"<unresolved:{type(exc).__name__}>"
+        finally:
+            self._resolving_version = False
+        self._version_cache[key] = value
+        return value
+
+    # -- systemd 互動 -------------------------------------------------------
+
+    def _client_env(self) -> dict[str, str]:
+        """`systemctl` **client 自己**的環境（與 `launcher.launch()` 同一份理由）。
+
+        它不會流進 unit——unit 的環境來自 root-owned 模板檔，job 的環境來自 spec，
+        由 shim 在 exec 時整份指定。client 端保留完整 env 是刻意的：polkit 授權可能
+        要查呼叫端的 session（`XDG_SESSION_ID` 等），砍掉會讓授權在某些部署下無故失敗。
+        """
+
+        from .launcher import _git_scope_env
+
+        return _git_scope_env()
+
+    def _systemctl_stop(self, systemctl: str, unit: str) -> None:
+        subprocess.run(
+            [systemctl, "stop", "--no-ask-password", unit],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=30,
+            check=False,
+        )
+
+    def _stop_and_confirm(self, plan: job_runner.SystemdTemplatePlan) -> bool:
+        """發 `systemctl stop` 並確認 unit 真的離開 active（D4）。回傳是否確認離開。"""
+
+        try:
+            self._stop_unit(plan.binary, plan.unit)
+        except Exception as exc:  # noqa: BLE001 - stop 失敗仍要回報逾時本身
+            logger.error(
+                "planning-job-stop-failed unit=%s error=%s", plan.unit, type(exc).__name__
+            )
+        deadline = self._monotonic() + STOP_CONFIRM_TIMEOUT_SECONDS
+        while True:
+            try:
+                if not self._unit_active(plan.binary, plan.unit):
+                    return True
+            except Exception:  # noqa: BLE001 - 查不動狀態不代表沒停
+                return False
+            if self._monotonic() >= deadline:
+                logger.error(
+                    "planning-job-still-active-after-stop unit=%s", plan.unit
+                )
+                return False
+            self._sleep(STOP_CONFIRM_POLL_SECONDS)
+
+    # -- 收割 ---------------------------------------------------------------
+
+    def _read_sentinel(self, sentinel: Path, process) -> int:
+        """exit code 的權威是 **Manager 側**記帳 shell 寫下的那一個（#604）。
+
+        job 一個位元組都沒參與：sentinel 落在 job 唯讀的 scratch 那一格，寫者是
+        `systemctl` client 外面那層 `bash -c`，跑在 Manager 的 uid 上。
+        """
+
+        try:
+            raw = sentinel.read_text(encoding="utf-8").strip()
+        except OSError:
+            raw = ""
+        if raw.lstrip("-").isdigit():
+            return int(raw)
+        code = getattr(process, "returncode", None)
+        return int(code) if isinstance(code, int) else 1
+
+    def _read_log(self, log_path: Path) -> str:
+        try:
+            return log_path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            return ""
+
+
+@dataclass(frozen=True)
+class _Reservation:
+    job_id: str
+    instance: str
+    slot: Path
+    cwd: Path

--- a/paulsha_cortex/coordinator/planning_runtime.py
+++ b/paulsha_cortex/coordinator/planning_runtime.py
@@ -1091,13 +1091,28 @@ def _select_planning_invoker(env: Mapping[str, str]) -> PlanningInvoker:
     `PSC_PLANNING_INVOKER` 之類的 planning 專屬開關：第二個開關的失效模式是
     「以為降權了、其實沒有」，而那種失敗看起來是成功的。
 
-    issue #683（票 B）只交付接縫，因此三種模式目前**全部**回 in-process
-    ——這正是「純重構、行為零改變」的意思。票 E（#686）新增
-    `JobPlanningInvoker` 之後，改的只有本函式的對應表一處。
+    issue #686（票 E）接上 `JobPlanningInvoker`：`systemd-template` ⇒ 降權 job。
+
+    **`systemd-run`（A 案）刻意 fail-closed，不退回 in-process。** A 案下 Manager 自己
+    組 `--property=`／`--setenv=`，「身分與加固面只由 root-owned unit 決定」這條性質
+    不成立——而那正是 planning 這個**吃 untrusted issue 內容**的角色最需要的性質。
+    退回 in-process 的失敗會**看起來像成功**（planning 照跑、產出正常），那正是 #672
+    整張票要消除的失效模式；因此這裡寧可讓部署當場以可讀理由停下來。
     """
 
-    job_runner.resolve_runner_mode(env)
-    return InProcessPlanningInvoker()
+    mode = job_runner.resolve_runner_mode(env)
+    if mode == job_runner.RUNNER_DIRECT:
+        return InProcessPlanningInvoker()
+    if mode == job_runner.RUNNER_SYSTEMD_TEMPLATE:
+        from .planning_job import JobPlanningInvoker
+
+        return JobPlanningInvoker(env=env)
+    raise ValueError(
+        f"{job_runner.JOB_RUNNER_ENV}={mode} 尚未支援 planning 降權"
+        "（#686 只實作模板模式；A 案下加固面由呼叫端而非 root-owned unit 決定，"
+        "planning 不走它）。改用 systemd-template，或以 direct 明示不降權——"
+        "**本函式不會靜默退回行程內執行**。"
+    )
 
 
 def _invoke_json(
@@ -1141,6 +1156,42 @@ def _invoke_json(
     return _extract_json_candidates(outcome.stdout, outcome.output_text)
 
 
+def _probe_failure(identity: ModelIdentity, exc: BaseException) -> CapabilityProbe:
+    """一次失敗的 probe → `CapabilityProbe`，**族名活著抵達拒因表**。
+
+    #683 之前（也就是 direct 模式今天仍走的那條路）只留得下 `type(exc).__name__`，
+    而票 A 的 `classify_probe_failure()` 就是靠那個型別名把失敗分成三族。job 模式有
+    **更好的資訊**：`PlanningJobError` 自己就帶著族名（job 起不來 vs executor 死），
+    那是型別名推不出來的區分。
+
+    `_PROBE_REASON_FAMILIES` 已經預留了這條路（票 A：「票 C／票 E 之後 probe 自己就會
+    回族名，這裡讓它原樣通過」），因此這裡把族名放進 `reason`、把 detail 放進
+    `diagnostic`，分類器原樣採用，不需要第二張表。
+
+    direct 模式逐字不變——那條路上不會出現 `PlanningJobError`。
+    """
+
+    from .planning_job import PlanningJobError
+
+    if isinstance(exc, PlanningJobError):
+        return CapabilityProbe(
+            False,
+            identity.executor,
+            identity.model_id,
+            identity.independence_domain,
+            exc.family,
+            exc.detail,
+        )
+    return CapabilityProbe(
+        False,
+        identity.executor,
+        identity.model_id,
+        identity.independence_domain,
+        "safe-probe-failed",
+        type(exc).__name__,
+    )
+
+
 def _probe_identity(
     identity: ModelIdentity,
     *,
@@ -1170,14 +1221,7 @@ def _probe_identity(
             run_id=run_id,
         )
     except Exception as exc:
-        return CapabilityProbe(
-            False,
-            identity.executor,
-            identity.model_id,
-            identity.independence_domain,
-            "safe-probe-failed",
-            type(exc).__name__,
-        )
+        return _probe_failure(identity, exc)
     if value != expected:
         return CapabilityProbe(
             False,

--- a/paulsha_cortex/trust_root/permgen.py
+++ b/paulsha_cortex/trust_root/permgen.py
@@ -1790,6 +1790,32 @@ class PathLayout:
         return f"{self.coordinator_root}/review-verdicts"
 
     @property
+    def planning_job_log_spool_root(self) -> str:
+        """planning job 寫、Manager 讀的輸出通道根（登記表資產
+        `planning-job-log-spool`，#686）。
+
+        路徑與 `config.paths.planning_job_log_spool_root()` 是**成對契約**，由
+        `asset_paths()` 供給權限計畫；本 property 只是給 unit 產生器引用的同一份
+        字面量（比照 `review_verdict_spool_root`）。
+
+        **掛在 `review_verdict_spool_root` 底下是刻意的**（design D3「不新開通道」／
+        U-3 未裁決）：`_minimize()` 因此把它從模板 unit 的 `ReadWritePaths=` 吃掉，
+        planner 帳號的寫入面逐字不變，default ACL 自動繼承。理由全文見
+        `config/paths.py:planning_job_log_spool_root`。
+        """
+        return f"{self.review_verdict_spool_root}/planning-logs"
+
+    @property
+    def planning_scratch_root(self) -> str:
+        """planning job 的 per-invocation **唯讀** scratch pool 根（登記表資產
+        `planning-scratch-pool`，#686）。
+
+        它**不**出現在任何 job 模板 unit 的 `ReadWritePaths=`——那是登記表 writer 面
+        只有 Manager 的機械後果，不是這裡的字面決定（見該資產的 note）。
+        """
+        return f"{self.coordinator_root}/planning-scratch"
+
+    @property
     def gate_ledger_spool_root(self) -> str:
         """gate 寫、Manager 讀的 per-job ledger spool 根（登記表資產
         `gate-ledger-spool`，#629）。
@@ -2101,6 +2127,11 @@ class PathLayout:
             "review-verdict-spool": self.review_verdict_spool_root,
             # #623／#634 成果回收的 bundle spool：<coordinator>/commit-spool/<job-id>/
             "commit-spool": self.commit_spool_root,
+            # #686（#672 票 E）：降權 planning job 的輸出通道與唯讀 scratch pool。
+            # 前者進 reviewer 模板 unit 的 RWP（writer 面含 PLANNER），後者**不**進
+            # （writer 面只有 MANAGER）——U-2「scratch 唯讀」因此是機械導出的。
+            "planning-job-log-spool": self.planning_job_log_spool_root,
+            "planning-scratch-pool": self.planning_scratch_root,
             # Phase 2b 方案 B（0816 第三輪 A+B）：模板 unit 的 per-job 執行規格。
             # #657：容器 ＋ per-principal 子 spool。子項由登記表的同一張
             # `DOWNGRADED_JOB_PRINCIPALS` 導出，不逐項寫死——asset_paths() 漏一項的

--- a/paulsha_cortex/trust_root/registry.py
+++ b/paulsha_cortex/trust_root/registry.py
@@ -907,6 +907,67 @@ ASSET_REGISTRY: tuple[TrustRootAsset, ...] = (
         ),
     ),
     TrustRootAsset(
+        "planning-job-log-spool", _T0, _JV,
+        "paulsha_cortex.config.paths:planning_job_log_spool_root",
+        (Principal.MANAGER, Principal.PLANNER), (Principal.MANAGER,),
+        IngressKind.INTERPROCESS,
+        derived_in=(
+            "config/paths.py:planning_job_log_spool_root",
+            "coordinator/planning_job.py:JobPlanningInvoker",
+        ),
+        note=(
+            "#686（#672 票 E）：降權 planning job 的**輸出通道**"
+            "（`<review-verdict-spool>/planning-logs/<instance>/planning.log`）。planning "
+            "搬上 `cortex-reviewer-job@.service` 之後，模型 stdout 不再由 "
+            "`subprocess.run(capture_output=True)` 取回；這一格就是 design D-i 的 job 側"
+            "對應，per-invocation 生命週期走 `coordinator/spool_slot.py`（與另外兩個 spool "
+            "同一份實作）。\n"
+            "**路徑掛在 `review-verdict-spool` 底下是刻意的**：design D3 第一句是「不新開"
+            "通道」，U-3 更把「新開一條 job→Manager 的寫入面」列為**未決、待 operator "
+            "裁決**。`cortex-reviewer-planner` 今天唯一既 Manager-owned 又對它開放寫入的"
+            "落點就是 verdict spool，掛在它底下因此 (i) 不新增任何寫入面（那個帳號本來就"
+            "寫得進這棵樹）、(ii) `read_write_paths()` 的 `_minimize()` 會吃掉被涵蓋的子"
+            "路徑 ⇒ 模板 unit 的 `ReadWritePaths=` **逐字不變、零部署動作**、(iii) 仍是"
+            "獨立登記表資產，治理面沒有因為省下一條 RWP 而消失。\n"
+            "**一處刻意的不同：log 檔由 Manager 預先建立（mode 0620），不是由 job 建。**"
+            "另外兩個 spool 靠 producer 在模型跑完之後自己 `chmod 0644`（#638 缺陷 2 的"
+            "既有繞法）讓 Manager 讀得到，那需要一段跑在模型之後的 wrapper；而 planning "
+            "的 job **刻意只有模型 argv 一段**（design D3：wrapper 自產的任何文字都會污染 "
+            "`_extract_json` 的輸入），沒有掛 publish 的位置。Manager 先建檔讓檔案 owner "
+            "恆為 Manager，job 只拿到繼承自 default ACL 的 `w`——寫得進、換不掉、刪不掉"
+            "（它對容器沒有 `w`）。\n"
+            "**writer 是 PLANNER 而不是 REVIEWER**：三分方案下兩者是同一個 OS 帳號，因此"
+            "產出的 ACL 逐字相同；宣告成 PLANNER 是為了讓登記表講的是**誰在用這條通道**"
+            "——reviewer 的通道是 `review-verdict-spool`，兩條不共用。二分方案下 PLANNER "
+            "映到哪個帳號由 `SCHEME` 決定，機制與 `review-verdict-spool` 相同。"
+        ),
+    ),
+    TrustRootAsset(
+        "planning-scratch-pool", _T1, _MO,
+        "paulsha_cortex.config.paths:planning_scratch_root",
+        (Principal.MANAGER,), (Principal.MANAGER, Principal.PLANNER),
+        IngressKind.MANAGER_INTERNAL,
+        derived_in=(
+            "config/paths.py:planning_scratch_root",
+            "coordinator/planning_job.py:JobPlanningInvoker",
+        ),
+        note=(
+            "#686（#672 票 E）：降權 planning job 的 per-invocation **唯讀** scratch "
+            "（`<coordinator_root>/planning-scratch/<instance>`，模型的 cwd）。\n"
+            "**writers 只有 MANAGER 是本項的全部重點**——U-2 的裁決是「scratch 對 job "
+            "唯讀」，而 `required_write_targets()` 只收 writer 面，因此「本根不出現在任何 "
+            "job 模板 unit 的 `ReadWritePaths=`」是**機械導出**的結果，不是靠註解約定。"
+            "`ProtectSystem=strict` 於是讓「模型弄髒自己的拋棄式 sandbox」**結構上不可能**"
+            "，design D-d 的偵測需求隨之消失（那條偵測在 job 側由 Manager 執行本來就"
+            "不可行——scratch 若可寫，弄髒它的是 job、看得到的也只有 job）。\n"
+            "readers 含 PLANNER：模型要 chdir 進去、要讀得到裡面的東西，因此需要 `rX`；"
+            "產生器據此出 traverse／讀取 ACL，而**不**出任何寫入授權。\n"
+            "executor 需要的可寫落點（codex 的 `-o`、agy 的 log／state）改指向 unit 的 "
+            "`PrivateTmp=yes` 私有 `/tmp`——per-invocation、job-owned、unit 結束即消失，"
+            "且 Manager 看不到它。"
+        ),
+    ),
+    TrustRootAsset(
         "workflow-report-journal", _T1, _MO, None,
         (Principal.MANAGER,), (Principal.MANAGER,), IngressKind.MANAGER_INTERNAL,
         derived_in=("coordinator/manager.py:4434",),

--- a/tests/test_planning_invoker_672.py
+++ b/tests/test_planning_invoker_672.py
@@ -168,11 +168,30 @@ def test_invoker_selection_follows_resolve_runner_mode(monkeypatch) -> None:
     """
 
     # 1／2：唯一輸入 ＋ 非法值 fail-closed。
-    for value in (None, "", job_runner.RUNNER_DIRECT, job_runner.RUNNER_SYSTEMD_TEMPLATE):
+    #
+    # #686（票 E）更新：`systemd-template` 這一格從 `InProcessPlanningInvoker` 改成
+    # `JobPlanningInvoker`。票 B 當時的值是**刻意的過渡態**（見
+    # `_select_planning_invoker` 的 docstring：「票 E 新增 JobPlanningInvoker 之後，
+    # 改的只有本函式的對應表一處」），本次改的就是那一處。這條斷言因此是**收緊**
+    # 而不是放寬：原本三種模式都回同一個物件，現在每一種模式各自被釘住。
+    for value in (None, "", job_runner.RUNNER_DIRECT):
         env = {} if value is None else {job_runner.JOB_RUNNER_ENV: value}
         assert isinstance(
             planning_runtime._select_planning_invoker(env),
             planning_runtime.InProcessPlanningInvoker,
+        )
+    from paulsha_cortex.coordinator.planning_job import JobPlanningInvoker
+
+    assert isinstance(
+        planning_runtime._select_planning_invoker(
+            {job_runner.JOB_RUNNER_ENV: job_runner.RUNNER_SYSTEMD_TEMPLATE}
+        ),
+        JobPlanningInvoker,
+    )
+    # A 案（`systemd-run`）**不得**靜默退回 in-process——那種失敗看起來是成功的。
+    with pytest.raises(ValueError):
+        planning_runtime._select_planning_invoker(
+            {job_runner.JOB_RUNNER_ENV: job_runner.RUNNER_SYSTEMD_RUN}
         )
     with pytest.raises(job_runner.JobRunnerError):
         planning_runtime._select_planning_invoker({job_runner.JOB_RUNNER_ENV: "definitely-not-a-mode"})

--- a/tests/test_planning_job_invoker_672.py
+++ b/tests/test_planning_job_invoker_672.py
@@ -1,0 +1,606 @@
+"""issue #686（#672 票 E）：`JobPlanningInvoker` 的行為契約。
+
+本檔釘的是「planning 的每一次模型呼叫都變成一個 `cortex-reviewer-job@` 實例」這件事
+的**可在單 UID 環境驗證的那一半**：角色、剖面、spec 形狀、instance 命名、逾時處置、
+三分族的對應。
+
+**不能在這裡驗的那一半**（OS 層語意）一律以具名 `@pytest.mark.skip` 標出並指向
+runbook，不得靜默通過——#638／#657 的教訓逐字如此：單 UID 環境讓斷言真空，斷言恆真、
+什麼都沒驗到，而它看起來是綠的。
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from paulsha_cortex.coordinator import job_runner, planning_job, planning_runtime
+from paulsha_cortex.coordinator.model_identities import (
+    ENVIRONMENT_GRADE_PLANNING_FAMILIES,
+    PLANNING_FAILURE_EXECUTOR,
+    PLANNING_FAILURE_EXECUTOR_SILENT_EXIT,
+    PLANNING_FAILURE_JOB_START,
+    PLANNING_FAILURE_OUTPUT,
+    ModelIdentity,
+    classify_probe_failure,
+)
+from paulsha_cortex.trust_root import permgen, registry
+from paulsha_cortex.trust_root.registry import Principal
+
+
+IDENTITY_CODEX = ModelIdentity(
+    executor="codex",
+    model_id="gpt-5.3-codex-spark",
+    independence_domain="openai",
+    capabilities=("planning",),
+)
+IDENTITY_AGY = ModelIdentity(
+    executor="agy",
+    model_id="gemini-3.1-pro-high",
+    independence_domain="google",
+    capabilities=("planning",),
+)
+IDENTITY_UNREGISTERED = ModelIdentity(
+    executor="cg",
+    model_id="glm-5.2",
+    independence_domain="zhipu",
+    capabilities=("planning",),
+)
+
+
+class _FakeProcess:
+    """`systemctl start --wait` client 的替身。
+
+    `wait()` 的兩種行為對應真實世界的兩種：正常結束、以及**掛住**（由 `hang=True`
+    模擬，`wait()` 直接拋 `TimeoutExpired`——那正是 `Popen.wait` 的真實語意）。
+    """
+
+    def __init__(self, *, returncode: int = 0, hang: bool = False) -> None:
+        # 起動確認窗內 client **還活著**——那正是真實世界的形狀：`--wait` 的 client
+        # 只有在 unit 跑完之後才返回，而 unit 啟動（systemd 排程 → 降權 → shim 讀
+        # spec → exec 模型 CLI）不可能在預設 200ms 的窗內走完。讓替身在窗內就回一個
+        # 非零狀態，等於把「executor 失敗」偽裝成「unit 起不來」，那會讓本檔的三分
+        # 斷言全部驗錯對象。
+        self.returncode = None
+        self._hang = hang
+        self._final = returncode
+        self.killed = False
+
+    def poll(self):
+        return self.returncode
+
+    def wait(self, timeout=None):
+        if self._hang:
+            raise subprocess.TimeoutExpired(cmd="systemctl", timeout=timeout or 0)
+        self.returncode = self._final
+        return self.returncode
+
+    def kill(self):  # pragma: no cover - 介面完整性
+        self.killed = True
+
+
+class _Harness:
+    """把一次派工的每一個副作用都攔下來，並記錄下來供斷言。
+
+    刻意**只**替換三個 seam：`prepare_systemd_template` 的 preflight（單 UID 環境沒有
+    systemd／三個帳號）、`Popen`、以及 `systemctl` 的兩個查詢／控制動作。剖面決定、
+    instance 推導、spec 組裝與寫入、env 白名單全部走**真的那一份**——那些正是本票要
+    釘的東西，換掉就等於什麼都沒驗（#638 的形態）。
+    """
+
+    def __init__(self, tmp_path: Path, monkeypatch, *, log_payload: str = "{}", rc: int = 0,
+                 hang: bool = False) -> None:
+        self.tmp_path = tmp_path
+        self.spool = tmp_path / "job-specs" / "reviewer"
+        self.spool.mkdir(parents=True)
+        self.log_payload = log_payload
+        self.rc = rc
+        self.hang = hang
+        self.specs: list[dict] = []
+        self.started: list[list[str]] = []
+        self.stopped: list[str] = []
+        self.active: set[str] = set()
+        self.env = {
+            job_runner.JOB_RUNNER_ENV: job_runner.RUNNER_SYSTEMD_TEMPLATE,
+            "PSC_REVIEWER_PATH": "/opt/cortex/toolchain/bin:/usr/bin:/bin",
+            "PSC_REVIEWER_HOME": "/var/lib/cortex-reviewer-planner",
+        }
+        real_prepare = job_runner.prepare_systemd_template
+
+        def fake_prepare(env, *, job_id, executor, role=job_runner.JOB_ROLE_BUILDER,
+                         unit_active=None):
+            # 角色／剖面／instance 三條走真的推導；只跳過需要 systemd 與真實帳號的
+            # preflight。剖面未登記時**照樣 fail-closed**（那正是 R4 要釘的）。
+            config = job_runner.resolve_job_role(role)
+            profile = job_runner.resolve_hardening_profile(executor)
+            base = job_runner.resolve_template_unit(env, role=role)
+            template = job_runner.template_unit_for_profile(base, profile)
+            instance = job_runner.template_instance_id(job_id)
+            unit = job_runner.template_unit_name(instance, template=template)
+            if unit in self.active:
+                raise job_runner._fail(
+                    "job-runner-template-instance-busy",
+                    f"模板實例 {unit} 已在執行中",
+                    source="prepare_systemd_template",
+                    unit=unit,
+                )
+            return job_runner.SystemdTemplatePlan(
+                binary="/usr/bin/systemctl",
+                template_unit=template,
+                instance=instance,
+                unit=unit,
+                account=config.default_account,
+                group=config.default_account,
+                shim="/opt/cortex/bin/cortex-job-shim",
+                spool_dir=str(self.spool),
+                spec_path=job_runner.job_spec_path(str(self.spool), instance),
+                hardening_profile=profile,
+                executor=str(executor or ""),
+                base_template_unit=base,
+                role=config.role_id,
+            )
+
+        monkeypatch.setattr(job_runner, "prepare_systemd_template", fake_prepare)
+        self._real_prepare = real_prepare
+
+    def popen(self, argv, *, cwd=None, env=None, stdin=None, stdout=None, stderr=None):
+        self.started.append(list(argv))
+        # 真實世界裡這一段由 job（寫 log）與 Manager 側記帳 shell（寫 sentinel）分別
+        # 完成；替身把兩者一起做掉，形狀與落點逐字相同。
+        script = argv[-1]
+        sentinel = script.split("> ")[-1].split(";")[0].strip().strip("'")
+        if not self.hang:
+            spec = self.specs[-1]
+            Path(spec["log_path"]).write_text(self.log_payload, encoding="utf-8")
+            Path(sentinel).write_text(str(self.rc), encoding="utf-8")
+        return _FakeProcess(returncode=self.rc, hang=self.hang)
+
+    def unit_active(self, systemctl: str, unit: str) -> bool:
+        return unit in self.active
+
+    def stop_unit(self, systemctl: str, unit: str) -> None:
+        self.stopped.append(unit)
+        self.active.discard(unit)
+
+    def invoker(self, monkeypatch) -> planning_job.JobPlanningInvoker:
+        real_write = job_runner.write_job_spec
+
+        def recording_write(spec_path, spec, *, account=None):
+            self.specs.append(dict(spec))
+            # `account` 一律不傳給真的那一支：spec 落地後的「那個身分讀得到嗎」是
+            # 跨 UID 語意，單 UID 環境驗不出來（見本檔最後的具名 skip）。
+            return real_write(spec_path, spec)
+
+        monkeypatch.setattr(planning_job.job_runner, "write_job_spec", recording_write)
+        return planning_job.JobPlanningInvoker(
+            env=self.env,
+            scratch_root=self.tmp_path / "planning-scratch",
+            log_spool_root=self.tmp_path / "planning-logs",
+            popen=self.popen,
+            unit_active=self.unit_active,
+            stop_unit=self.stop_unit,
+            monotonic=lambda: 0.0,
+            sleep=lambda _seconds: None,
+        )
+
+
+def _invocation(identity=IDENTITY_AGY, *, purpose="questioner", timeout=120, worktree=None):
+    return planning_runtime.PlanningInvocation(
+        identity=identity,
+        prompt="Return only this JSON object: {}",
+        purpose=purpose,
+        timeout_seconds=timeout,
+        worktree=Path(worktree or "/var/lib/cortex/repos/paulsha-cortex"),
+        run_id="workflow-686abcdef012",
+    )
+
+
+# ---------------------------------------------------------------------------
+# R1／R4：身分與剖面
+# ---------------------------------------------------------------------------
+
+def test_role_is_review_and_not_derivable_from_spec(tmp_path, monkeypatch) -> None:
+    """角色恆為 `JOB_ROLE_REVIEW`，且 spec 不含任何身分／剖面欄位。
+
+    「User 不在 spec 裡」是 B 案全部的價值：身分只有一個來源＝root-owned unit 檔的
+    `User=`。`SPEC_FORBIDDEN_KEYS` 在寫端與讀端各擋一次，這裡釘的是**寫端真的沒放**。
+    """
+
+    harness = _Harness(tmp_path, monkeypatch, log_payload='{"ok":true}')
+    invoker = harness.invoker(monkeypatch)
+    invoker.run(_invocation())
+
+    assert len(harness.specs) == 1
+    spec = harness.specs[0]
+    assert spec["unit"].startswith("cortex-reviewer-job")
+    assert job_runner.forbidden_spec_keys(spec) == []
+    for forbidden in job_runner.SPEC_FORBIDDEN_KEYS:
+        assert forbidden not in spec
+    # 角色由呼叫端在建構期固定，不從 prompt／spec／模型輸出導出。
+    assert job_runner.JOB_ROLE_REVIEW == "review"
+    assert spec["env"]["PSC_JOB_ID"] == spec["job_id"]
+
+
+def test_profile_comes_only_from_executor(tmp_path, monkeypatch) -> None:
+    """剖面唯一輸入是 `identity.executor`；未登記 executor fail-closed。
+
+    `cg` 刻意不在 `EXECUTOR_HARDENING_PROFILE` 內——猜嚴格會讓它靜默起不來，猜寬鬆
+    會讓 per-executor 剖面退化成「全域移除 MDWE」。正確行為是**拒絕**。
+    """
+
+    harness = _Harness(tmp_path, monkeypatch, log_payload='{"ok":true}')
+    invoker = harness.invoker(monkeypatch)
+
+    invoker.run(_invocation(IDENTITY_CODEX))
+    assert harness.specs[-1]["unit"].startswith("cortex-reviewer-job-jit@")
+
+    invoker.run(_invocation(IDENTITY_AGY))
+    assert harness.specs[-1]["unit"].startswith("cortex-reviewer-job@")
+
+    # `cg` 走不到 `_planning_argv`（那一層先拒），因此改用票 B 的 `ProcessRunner`
+    # 接縫直接餵一條 `cg` argv——剖面決定就在那條路上。
+    with pytest.raises(planning_job.PlanningJobError) as excinfo:
+        invoker.capability_probe_runner()(["cg", "--version"], timeout=10)
+    assert excinfo.value.family == PLANNING_FAILURE_JOB_START
+    assert "hardening-profile-unknown" in str(excinfo.value)
+
+
+# ---------------------------------------------------------------------------
+# D3：wrapper 只有模型 argv 一段
+# ---------------------------------------------------------------------------
+
+def test_planning_wrapper_has_no_gate_bundle_verdict_sentinel(tmp_path, monkeypatch) -> None:
+    """spec 的 `command` **就是**模型 argv，不是任何一種 wrapper script。
+
+    不靠「既有旗標碰巧為 None」：這裡釘的是 command[0] 是 executor 本身、整條 argv 裡
+    沒有 shell、沒有 gate、沒有 bundle、沒有 verdict、沒有 sentinel。理由不只是潔癖
+    ——wrapper 自產的任何一個位元組都會進同一份 log，而那份 log 就是 `_extract_json`
+    的輸入。
+    """
+
+    harness = _Harness(tmp_path, monkeypatch, log_payload='{"ok":true}')
+    invoker = harness.invoker(monkeypatch)
+    invoker.run(_invocation(IDENTITY_CODEX))
+
+    command = harness.specs[-1]["command"]
+    assert command[0] == "codex"
+    joined = " ".join(command)
+    for banned in ("bash", "sh -c", "git bundle", "verdict", ".exit", "gate"):
+        assert banned not in joined
+    # working_directory 是 scratch，不是 operator 樹。
+    assert harness.specs[-1]["working_directory"].startswith(
+        str(tmp_path / "planning-scratch")
+    )
+    assert "/repos/" not in harness.specs[-1]["working_directory"]
+
+
+def test_instance_name_unique_per_invocation(tmp_path, monkeypatch) -> None:
+    """四種 purpose ＋ 重試的 instance 名互不相同，且全部過 `JOB_SEGMENT_RE`。
+
+    一輪 brainstorm 會連續起 questioner → secondary → integrator，加上 probe；
+    `systemctl start` 對已 active 的 unit 會**靜默回 0**，因此撞名的後果是「以為起了
+    一個 job，實際掛在別人的 unit 上等」。
+    """
+
+    harness = _Harness(tmp_path, monkeypatch, log_payload='{"ok":true}')
+    invoker = harness.invoker(monkeypatch)
+    for purpose in (
+        planning_runtime.PLANNING_PURPOSE_PROBE,
+        planning_runtime.PLANNING_PURPOSE_QUESTIONER,
+        planning_runtime.PLANNING_PURPOSE_SECONDARY,
+        planning_runtime.PLANNING_PURPOSE_INTEGRATOR,
+        planning_runtime.PLANNING_PURPOSE_QUESTIONER,  # 重試
+    ):
+        invoker.run(_invocation(purpose=purpose))
+
+    instances = [spec["instance"] for spec in harness.specs]
+    assert len(set(instances)) == len(instances) == 5
+    for instance in instances:
+        assert job_runner.instance_name_valid(instance)
+    # purpose 進 instance 名（D9）：`systemctl list-units` 因此說得出這批 job 在做什麼。
+    assert any("questioner" in instance for instance in instances)
+    assert any("integrator" in instance for instance in instances)
+
+
+# ---------------------------------------------------------------------------
+# R7／D4：逾時
+# ---------------------------------------------------------------------------
+
+def test_timeout_stops_unit_and_classifies_as_timeout(tmp_path, monkeypatch) -> None:
+    """逾時 ⇒ 發 `systemctl stop` ⇒ 確認離開 active ⇒ 落 environment 級失敗。
+
+    **不能只是放棄等待**：那會讓下一次同名 instance 撞
+    `job-runner-template-instance-busy`，而那個症狀與逾時完全無關，會把排查帶偏。
+    """
+
+    harness = _Harness(tmp_path, monkeypatch, hang=True)
+    invoker = harness.invoker(monkeypatch)
+    unit_holder: list[str] = []
+
+    def stop_unit(systemctl: str, unit: str) -> None:
+        unit_holder.append(unit)
+        harness.active.discard(unit)
+
+    invoker._stop_unit = stop_unit
+    # unit 起來了（active），模型掛住。
+    original_popen = harness.popen
+
+    def popen(argv, **kwargs):
+        process = original_popen(argv, **kwargs)
+        harness.active.add(harness.specs[-1]["unit"])
+        Path(
+            harness.specs[-1]["log_path"]
+        ).write_text("", encoding="utf-8")
+        sentinel = argv[-1].split("> ")[-1].split(";")[0].strip().strip("'")
+        Path(sentinel).write_text("0", encoding="utf-8")
+        return process
+
+    invoker._popen = popen
+
+    with pytest.raises(planning_job.PlanningJobError) as excinfo:
+        invoker.run(_invocation(timeout=5))
+
+    failure = excinfo.value
+    assert failure.family == PLANNING_FAILURE_EXECUTOR
+    assert planning_job.PLANNING_JOB_TIMEOUT in failure.detail
+    assert unit_holder and unit_holder[0].startswith("cortex-reviewer-job@")
+    assert failure.diagnostics["unit_left_active"] == "no"
+    # environment 級 ⇒ `_resume_decision` 浮得出 `recover-planning`（D8 的改判）。
+    assert failure.family in ENVIRONMENT_GRADE_PLANNING_FAMILIES
+
+
+# ---------------------------------------------------------------------------
+# R6：三分族
+# ---------------------------------------------------------------------------
+
+def test_job_start_failure_maps_to_job_start_failed(tmp_path, monkeypatch) -> None:
+    """`JobRunnerError` 各族 ⇒ `planning-job-start-failed`（environment）。"""
+
+    harness = _Harness(tmp_path, monkeypatch, log_payload='{"ok":true}')
+    invoker = harness.invoker(monkeypatch)
+
+    def refuse(*_args, **_kwargs):
+        raise job_runner._fail(
+            "job-runner-job-template-missing",
+            "模板 unit 未安裝",
+            source="preflight_systemd_template",
+        )
+
+    monkeypatch.setattr(job_runner, "prepare_systemd_template", refuse)
+    with pytest.raises(planning_job.PlanningJobError) as excinfo:
+        invoker.run(_invocation())
+    assert excinfo.value.family == PLANNING_FAILURE_JOB_START
+    assert PLANNING_FAILURE_JOB_START in ENVIRONMENT_GRADE_PLANNING_FAMILIES
+    # 族名活著抵達拒因表：`classify_probe_failure` 原樣採用（票 A 已預留這條路）。
+    assert classify_probe_failure(
+        excinfo.value.family, excinfo.value.detail
+    ) == PLANNING_FAILURE_JOB_START
+
+
+def test_silent_rc1_maps_to_executor_silent_exit(tmp_path, monkeypatch) -> None:
+    """rc≠0 且無任何輸出 ⇒ 具名 `executor-silent-exit`，並指名四個線索來源。
+
+    這一類是整個家族裡最難查的一種（**連錯誤訊息都沒有**），因此診斷 MUST 指名
+    unit、加固剖面、實際解析到的可執行檔，並帶 `seccomp_filter_is_fatal()` 的機械
+    答案——#673 整張票走偏，正是因為當時沒有任何地方回答得了最後那一個。
+    """
+
+    harness = _Harness(tmp_path, monkeypatch, log_payload="", rc=1)
+    invoker = harness.invoker(monkeypatch)
+    with pytest.raises(planning_job.PlanningJobError) as excinfo:
+        invoker.run(_invocation(IDENTITY_CODEX))
+
+    failure = excinfo.value
+    assert failure.family == PLANNING_FAILURE_EXECUTOR
+    assert PLANNING_FAILURE_EXECUTOR_SILENT_EXIT in failure.detail
+    assert "cortex-reviewer-job-jit@" in failure.detail
+    assert "profile=jit" in failure.detail
+    assert "binary=" in failure.detail
+    assert "version=" in failure.detail
+    # `SystemCallErrorNumber=EPERM` 在時，答案是「不該懷疑 seccomp」。
+    assert failure.diagnostics["seccomp_filter_fatal"] == "no"
+    assert "seccomp_filter_fatal=no" in failure.detail
+
+
+def test_malformed_output_maps_to_output_malformed(tmp_path, monkeypatch) -> None:
+    """rc=0 但輸出非 JSON ⇒ `planning-output-malformed`（content），detail 帶 stdout 前綴。
+
+    分級的方向性在這裡也一併釘住：格式問題**不得**被改判成環境問題（反向誤報同樣
+    不可接受）。
+    """
+
+    harness = _Harness(tmp_path, monkeypatch, log_payload="I am not JSON at all.")
+    invoker = harness.invoker(monkeypatch)
+    outcome = invoker.run(_invocation())
+    assert outcome.returncode == 0
+
+    with pytest.raises(ValueError) as excinfo:
+        planning_runtime._extract_json_candidates(outcome.stdout, outcome.output_text)
+    assert "I am not JSON" in str(excinfo.value)
+    assert classify_probe_failure("safe-probe-failed", "ValueError") == PLANNING_FAILURE_OUTPUT
+    assert PLANNING_FAILURE_OUTPUT not in ENVIRONMENT_GRADE_PLANNING_FAMILIES
+
+
+def test_second_output_candidate_is_none_in_job_mode(tmp_path, monkeypatch) -> None:
+    """D-j／R-2：codex 的 `-o last.json` 落在 job 的 `PrivateTmp`，Manager 讀不到。
+
+    退步是**已知且已標註**的，不是被吞掉的：`output_text` 恆為 `None`，
+    `_extract_json` 因此從雙候選退成單候選。argv 仍帶 `-o`——那一份對 job 自己有效
+    （codex 少了它會改變行為），只是第二候選這條路對 Manager 消失了。
+    """
+
+    harness = _Harness(tmp_path, monkeypatch, log_payload='{"ok":true}')
+    invoker = harness.invoker(monkeypatch)
+    outcome = invoker.run(_invocation(IDENTITY_CODEX))
+    assert outcome.output_text is None
+    command = harness.specs[-1]["command"]
+    assert "-o" in command
+    assert command[command.index("-o") + 1].startswith("/tmp/")
+
+
+# ---------------------------------------------------------------------------
+# R2／U-2：可寫面由登記表機械導出
+# ---------------------------------------------------------------------------
+
+def test_operator_tree_not_in_job_rwp() -> None:
+    """D-e：`repo-source-tree` 不在 reviewer 模板 unit 的 RWP 產出中。
+
+    「planner 經絕對路徑寫 operator 樹」這條路在降權模式下由 `ProtectSystem=strict`
+    直接關掉——本測試讓那條保證**有測試釘住**，而不是只靠 unit 檔的註解。
+    """
+
+    unit = permgen.build_job_unit(permgen.THREE_WAY_SCHEME, principal=Principal.REVIEWER)
+    layout = permgen.PathLayout()
+    assert layout.repo_source_root not in unit.read_write_paths
+    for path in unit.read_write_paths:
+        assert "/repos/" not in path
+
+
+def test_scratch_pool_is_read_only_for_every_job_unit() -> None:
+    """U-2 的機械形式：scratch pool 的 writer 面只有 Manager ⇒ 不進任何 job unit 的 RWP。
+
+    這一條就是「模型弄髒自己的拋棄式 sandbox」從**偵測**變成**結構上不可能**的地方。
+    要打破它必須改登記表 writer 面，而那會在產生器輸出與 unit 檔上留下痕跡。
+    """
+
+    asset = next(
+        item for item in registry.ASSET_REGISTRY if item.asset_id == "planning-scratch-pool"
+    )
+    assert asset.writers == (Principal.MANAGER,)
+    assert Principal.PLANNER in asset.readers
+
+    layout = permgen.PathLayout()
+    for principal in registry.DOWNGRADED_JOB_PRINCIPALS:
+        unit = permgen.build_job_unit(permgen.FOUR_WAY_SCHEME, principal=principal)
+        assert all(
+            not path.startswith(layout.planning_scratch_root)
+            for path in unit.read_write_paths
+        ), f"{principal} 的 unit 不得對 planning scratch 可寫"
+
+
+def test_planning_log_spool_needs_no_new_write_surface() -> None:
+    """log 通道掛在既有 verdict spool 底下 ⇒ 模板 unit 的 RWP **逐字不變**。
+
+    design D3 第一句是「不新開通道」，U-3 更把「新開一條 job→Manager 的寫入面」列為
+    未決。這條斷言讓「本票沒有偷偷開一條」變成可檢查的事實。
+    """
+
+    layout = permgen.PathLayout()
+    assert layout.planning_job_log_spool_root.startswith(
+        layout.review_verdict_spool_root + "/"
+    )
+    unit = permgen.build_job_unit(permgen.THREE_WAY_SCHEME, principal=Principal.REVIEWER)
+    assert sorted(unit.read_write_paths) == [
+        layout.cache_of(layout.reviewer_planner_account),
+        layout.review_verdict_spool_root,
+    ]
+
+
+def test_probe_cache_asset_still_absent_from_job_rwp() -> None:
+    """票 C 的不變式在本票之後仍成立：probe 快取不得被 job 寫。
+
+    快取一旦可由 job 寫，「這個 provider 是 ready 的」就變成模型可以自證的東西。
+    """
+
+    layout = permgen.PathLayout()
+    cache_path = permgen.asset_paths(layout)["planning-probe-cache"]
+    for principal in registry.DOWNGRADED_JOB_PRINCIPALS:
+        unit = permgen.build_job_unit(permgen.FOUR_WAY_SCHEME, principal=principal)
+        assert all(not cache_path.startswith(path + "/") for path in unit.read_write_paths)
+        assert cache_path not in unit.read_write_paths
+
+
+# ---------------------------------------------------------------------------
+# capability probe 接縫
+# ---------------------------------------------------------------------------
+
+def test_capability_probe_runner_makes_each_cli_call_a_job(tmp_path, monkeypatch) -> None:
+    """`agy models` 與 smoke **各算一次 invocation**（各自一個 unit 實例）。
+
+    agy 的能力探測是一段兩步 CLI 協定，真相在 `model_identities.probe_agy_capability`；
+    複製一份到 invoker 就是第二份真相，因此這裡走的是票 B 立的 `ProcessRunner` 接縫。
+    """
+
+    harness = _Harness(tmp_path, monkeypatch, log_payload="gemini-3.1-pro-high\tGemini")
+    invoker = harness.invoker(monkeypatch)
+    runner = invoker.capability_probe_runner()
+
+    first = runner(["agy", "models"], shell=False, capture_output=True, text=True, timeout=45)
+    second = runner(["agy", "--print", "x"], shell=False, capture_output=True, text=True, timeout=45)
+
+    assert first.returncode == 0 and isinstance(first.stdout, str)
+    assert isinstance(first.stderr, str)  # `_process_fields` 要求三個欄位型別正確
+    assert second.returncode == 0
+    assert len(harness.specs) == 2
+    assert harness.specs[0]["instance"] != harness.specs[1]["instance"]
+    assert all(spec["unit"].startswith("cortex-reviewer-job@") for spec in harness.specs)
+
+
+def test_scratch_and_log_slots_are_removed_after_the_call(tmp_path, monkeypatch) -> None:
+    """D-a：一次性——呼叫結束即銷毀（成功與失敗兩條路都要）。"""
+
+    harness = _Harness(tmp_path, monkeypatch, log_payload='{"ok":true}')
+    invoker = harness.invoker(monkeypatch)
+    invoker.run(_invocation())
+    scratch_root = tmp_path / "planning-scratch"
+    log_root = tmp_path / "planning-logs"
+    assert list(scratch_root.iterdir()) == []
+    assert not log_root.exists() or list(log_root.iterdir()) == []
+    # spec 也不留：留著只會讓下一個人以為有一個未回收的派工。
+    assert list(harness.spool.iterdir()) == []
+
+
+def test_direct_mode_is_unchanged(tmp_path) -> None:
+    """direct 模式逐字不變——本票只新增第二個實作，不動第一個。"""
+
+    invoker = planning_runtime._select_planning_invoker(
+        {job_runner.JOB_RUNNER_ENV: job_runner.RUNNER_DIRECT}
+    )
+    assert isinstance(invoker, planning_runtime.InProcessPlanningInvoker)
+
+
+# ---------------------------------------------------------------------------
+# OS 層語意：單 UID／無 systemd 的 CI 重現不了，具名 skip（不得靜默通過）
+# ---------------------------------------------------------------------------
+
+@pytest.mark.skip(
+    reason=(
+        "跨 UID 的唯讀 scratch 語意在單 UID／無 systemd 的 CI 重現不了：這裡要驗的是"
+        "「job 帳號對 scratch 的寫入回 EROFS」，而它的成立條件是 `ProtectSystem=strict`"
+        "＋該路徑不在模板 unit 的 `ReadWritePaths=` 內——兩者在 CI 都不存在，斷言會"
+        "**恆真**（#638／#657 的形態：斷言真空、什麼都沒驗到、看起來是綠的）。"
+        "實機驗證在 runbook 第 4e-3 步（`psc_run_under cortex-reviewer-job /bin/sh -c "
+        "'cd <scratch> && touch w'` 期望 `Read-only file system`）；#686 的 PR body "
+        "有 0818 的實測輸出。"
+    )
+)
+def test_real_readonly_scratch_rejects_job_writes() -> None:  # pragma: no cover
+    raise AssertionError("此測項只在具備三分帳號與已落檔 unit 的實機上執行")
+
+
+@pytest.mark.skip(
+    reason=(
+        "「Manager 讀得到 job 寫的 log」是跨 UID ＋ POSIX ACL mask 的語意：Manager 預建"
+        "檔案的 mode 0620 讓繼承來的 `user:<planner>:wx` 保住 effective `-w-`，用 0600 "
+        "會被壓成 `#effective:---`（#638 缺陷 1 的同一個機制）。單 UID 環境下 producer "
+        "與 consumer 是同一個 uid，ACL 沒生效也會綠。實機驗證在 runbook 第 4e-4 步；"
+        "#686 的 PR body 有 0818 的實測輸出。"
+    )
+)
+def test_real_cross_uid_log_channel_roundtrip() -> None:  # pragma: no cover
+    raise AssertionError("此測項只在具備三分帳號與已落檔 unit 的實機上執行")
+
+
+@pytest.mark.skip(
+    reason=(
+        "「一輪完整 planning 期間 cortex-manager 的行程樹不出現任何 executor 可執行檔」"
+        "需要真的 systemd、真的三個帳號與真的模型呼叫；CI 沒有任何一項，而在單 UID "
+        "環境下 `systemd-cgls`／`ps --ppid` 的輸出對這個宣稱完全不承載語意。"
+        "實機驗證在 runbook 第 4e-5 步；#686 的 PR body 有 0818 的實測輸出（cgroup "
+        "逐行 ＋ `ps --ppid` 逐行）。"
+    )
+)
+def test_real_manager_process_tree_has_no_executor() -> None:  # pragma: no cover
+    raise AssertionError("此測項只在具備三分帳號與已落檔 unit 的實機上執行")


### PR DESCRIPTION
Closes #686

## 這張票做了什麼

`planning_runtime` 的四個 adapter 與**全部** probe 至今仍在 daemon 行程內、以
`cortex-manager` 身分 `subprocess.run` 模型 CLI——而該帳號的 passwd 註記逐字寫著
`no model code`（#672）。#615（M2）只把 reviewer 導上 `cortex-reviewer-job@.service`，
planner 走的是完全不同的一條 code path，從未接上模板 unit。本票是 #672 的主體：
新增 `coordinator/planning_job.py` 的 `JobPlanningInvoker`，一次 planning 呼叫＝一個
模板 unit 實例。

**本票只讓它存在且可驗證，不切換預設**——`PSC_JOB_RUNNER` 走 job 的切換是票 F（#687）。

## U-2 裁決：scratch **唯讀**（design 傾向 (2)），並附四個 executor 的實測

裁決理由用 design 自己的話：選唯讀把安全退步 **R-1**（「模型弄髒自己的拋棄式 sandbox」
的偵測，Manager 在 job 側做不到）從「失去行為訊號」變成「結構上不可能」。

**它不是一個 `if`**：新增登記表資產 `planning-scratch-pool`，writers 只有
`Principal.MANAGER` ⇒ `permgen.required_write_targets()` 機械地不收它 ⇒ 它不出現在
**任何** job 模板 unit 的 `ReadWritePaths=` ⇒ `ProtectSystem=strict` 下寫入回 EROFS。
要打破這條性質必須改登記表 writer 面，而那會在產生器輸出與 unit 檔上留下痕跡。

實測（0818，本機，全部走 `psc_run_under` 從落檔 unit 全量導出的 38 條 property）：

```
$ psc_run_under cortex-reviewer-job /bin/sh -c \
    'cd /var/lib/cortex/coordinator/planning-scratch/probe && touch w; touch /tmp/t && echo PRIVATETMP-WRITABLE'
touch: cannot touch 'w': Read-only file system      ← cwd 唯讀成立
PRIVATETMP-WRITABLE                                 ← PrivateTmp 是 executor 的可寫落點
```

| executor | 剖面 | 唯讀 cwd 下跑得完一輪 planning？ | 它要寫什麼／寫到哪／為什麼 |
|---|---|---|---|
| `agy` | strict | **✅ 跑得完**——模型輸出逐位元等於 expected | cwd 零寫入；狀態樹在 `$HOME/.gemini → cache/gemini`（已在 RWP 內） |
| `claude` | strict | **✅ CLI 走得完**（rc=0，回 `Not logged in · Please run /login`） | cwd 零寫入；擋住的是**憑證**（planner 帳號沒有 `~/.claude`），屬票 D／U-4 |
| `codex` | jit | **⚠️ 起不來，但與 cwd 無關** | `$CODEX_HOME`（預設 `$HOME/.codex`）**整個目錄**要可寫 |
| `copilot` | jit | 不適用 | `capabilities` 只有 `[build]`，`_planning_argv` 不支援它 |

**codex 那一格必須逐字讀，因為它極容易被誤記成「唯讀 scratch 跑不動」**：

- cwd 換成**可寫的 `/tmp`** ⇒ **症狀完全相同**（`Error: failed to initialize in-process
  app-server client: Read-only file system (os error 30)`）；
- cwd 維持**唯讀 scratch**、只把 `CODEX_HOME` 指到一個可寫目錄 ⇒ **rc=0，輸出正確**。

所以阻斷點是 `CODEX_HOME`，不是 cwd。codex 在 `$CODEX_HOME` 底下建的東西（實測 `find`）：
`state_5.sqlite`／`logs_2.sqlite`／`queue_1.sqlite`／`memories_1.sqlite`／`sessions/`／
`skills/.system/`／`plugins/cache/`／`thread-writer-locks/`／`models_cache.json`／
`installation_id`——**只放行 `auth.json` 一個檔不夠**，而那正是
`permgen.deferred_run_dependencies()` 第一項與票 D（#685）目前寫的範圍。
**這是 design 未預期的部署缺口，處置屬票 D／U-4；本票沒有擅自放寬任何路徑，也沒有
「因為跑不起來就整個放寬」**——scratch 維持唯讀，codex 的缺口寫進 runbook 第 4e-3 步。

## 十條防線（design D2）逐條對應

| # | 現行（in-process） | job 側對應 | 判定 |
|---|---|---|---|
| D-a | `TemporaryDirectory` | Manager 在 `planning-scratch-pool` 下建 per-invocation 一格，呼叫結束 `rmtree`（成功與失敗兩條路都在 `finally`）；unit 的 `CollectMode=inactive-or-failed` 讓 systemd 自己也不留 | **等價** |
| D-b | 整棵 repo 複本 | **空 scratch**（U-1；見下方「U-1 的更正」） | **行為改變，已標註** |
| D-c | `cwd=sandbox` | spec 的 `working_directory`＝那一格，shim 在降權**之後** `chdir` | **等價** |
| D-d | sandbox 弄髒即 fail-closed | **結構上不可能**（U-2＝唯讀，writer 面只有 Manager） | **升級**（R-1 消滅） |
| D-e | operator 樹雙向快照 | `repo-source-tree` 不在 reviewer 模板 unit 的 RWP 內 ⇒ kernel 直接擋；有測試釘住（`test_operator_tree_not_in_job_rwp`） | **升級**（偵測→阻擋） |
| D-f | `_contain_operator_drift` | job 模式下 operator 樹結構性不可能被 job 改；程式**不刪**，保留給 direct | **等價（範圍縮小）** |
| D-g | hermetic `CLAUDE_CONFIG_DIR` | job 的 HOME 是 `cortex-reviewer-planner`、`ProtectHome=yes`、`build_job_env()` 白名單不含 `CLAUDE_CONFIG_DIR`（它在 `DENIED_ENV_NAMES` 裡） | **升級**（改 env→帳號隔離） |
| D-h | `subprocess.run(timeout=)` | Manager 側 `Popen.wait(timeout)` → `systemctl stop` → **確認離開 active** | **等價（新程式，已實作＋測試）** |
| D-i | `capture_output=True` | Manager-owned log ＋ shim 降權後 O_APPEND 接管 | **等價** |
| D-j | codex `-o last.json` 第二候選 | 落點在 job 的 `PrivateTmp`，Manager 讀不到 ⇒ `output_text` 恆為 `None` | **退步 R-2**（design 已預期） |

四條 design 已標的退步的實際結果：

- **R-1（sandbox dirty 偵測）**：**已消滅**——U-2 選唯讀。
- **R-2（codex 第二輸出候選）**：**成立**，如上。實測未觸發（唯一跑得完整條的 agy 走
  stdout；codex 被 `CODEX_HOME` 擋在更前面）。U-3 的 result spool **不動用**——那是新開
  一條 job→Manager 寫入面，design 明列為未決。
- **R-3（雙 domain 憑證）**：本票不碰（U-4／票 D）。
- **R-4（逾時改 `systemctl stop`）**：**成立**，並補上 design D4 要求的「停止後確認離開
  active」（不確認的話下一輪撞 `job-runner-template-instance-busy`，症狀與逾時無關）。

### design 未預期的新退步／缺陷（明講，沒有吞掉）

- **R-5（新）：stdout 與 stderr 在 job 側合併。** `job_shim._take_over_stdio()` 把 fd 1 與
  fd 2 **同時** dup 到 spec 的 `log_path`，Manager 這一側因此拿到一份合併輸出；direct 模式
  的 `capture_output=True` 是分開的。代價：executor 往 stderr 印的任何東西都會進
  `_extract_json` 的輸入。緩解：`_find_json_object` 的頂層語意本來就是「整串才算」，因此
  污染的結果是明確的 `planning-output-malformed`（帶 stdout 前綴），不是靜默採信。
  修法（把 stderr 導到第二個落點）需要改 shim 與 spec schema ⇒ 部署面改動，不在本票。
- **缺陷（新，非本票造成）：`PSC_REVIEWER_HOME`／`PSC_GATE_HOME` 未宣告，與 #679 的 PATH
  同型。** `build_job_env()` 的 docstring 原文稱「`HOME` 未給時 systemd 依 passwd 填入
  正確值（而且模板 unit 另有一行 `Environment=HOME=`）」——**對模板模式不成立**：shim 以
  `os.execvpe(command[0], command, job_env)` 把環境整份換掉。實機第一次端到端跑就撞上：
  `agy` 死在 `resolving log directory: getting home directory: $HOME is not defined`；補上
  `PSC_REVIEWER_HOME` 之後同一條呼叫 rc=0。實機 `PSC_BUILDER_HOME` **有**、另外兩個角色
  **沒有**——與 #679 逐字同一個形狀。本票只更正 docstring ＋ 補 runbook 第 5-5c 步，
  **沒有**順手把 HOME 也改成 fail-closed（那會讓所有角色的既有派工在 EnvironmentFile
  補齊前當場失敗，屬獨立票）。
- **更正 design D3 的一句話**：「沿用 reviewer 已經走通的 Manager-owned log ＋ shim
  O_APPEND」——**reviewer 那條通道在本機從未走通過**。reviewer 的 `log_dir` 是
  `manager.py:1264` 的 `runtime/review/<slice_id>`，以 Manager 的 `WorkingDirectory=/var/lib/cortex`
  解成 `/var/lib/cortex/runtime/review/<slice>`：`/var/lib/cortex/runtime` 是 `root:root 0755`，
  Manager 連 `mkdir` 都不行；就算建得出來，那條路徑也不在模板 unit 的 `ReadWritePaths=` 內。
  佐證：`/var/lib/cortex/coordinator/job-specs/reviewer/` 是**空的**（從未派過一個模板
  reviewer job）。planning 因此不能「沿用」，本票另外走 `planning-job-log-spool`。

## U-1／U-3 的處置（本票沒有被授權裁決，因此都選「不擴大」的那一邊）

- **U-1**：job 模式實作 **(b) 空 scratch**，direct 模式**逐字不變**（仍是整棵複製）。
  (a) 在 job 模式**還不存在可行機制**：Manager unit 帶 `UMask=0077`，複本每個檔都是
  `0600 cortex-manager`，job 一個位元組都讀不到；要讓 (a) 成立得先有「把 Manager 建的
  整棵樹遞迴授權給 job 帳號」的新授權面。
  **同時更正 design 的取捨論證**：design 說「(b) 是收緊（模型從理論上讀得到 repo 變成
  讀不到）」——**在 job 模式下不成立**。`ProtectSystem=strict` 只擋寫不擋讀，實測
  `sudo -u cortex-reviewer-planner test -r /var/lib/cortex/repos/paulsha-cortex/README.md`
  = 可讀。(b) 的差別只在「repo 不是 cwd」。
- **U-3**：**不動用**。輸出通道掛在既有 `review-verdict-spool` **底下**
  （`<spool>/planning-logs/<instance>/planning.log`）：那個帳號今天本來就對這棵樹有
  `wx`，`read_write_paths()` 的 `_minimize()` 又會吃掉被涵蓋的子路徑 ⇒ 模板 unit 的
  `ReadWritePaths=` **逐字不變、零部署動作**、default ACL 自動繼承（實測 `getfacl` 逐字
  為 `user:cortex-reviewer-planner:-wx` ＋ `mask::-wx`）。仍登記成獨立資產
  `planning-job-log-spool`，治理面不因省下一條 RWP 而消失。

## 驗收 1：`{codex, claude, agy} × {實際剖面}` 矩陣（含絕對路徑與版本字串）

方法：**只**走 runbook 第 4e 步的共用探針 `psc_run_under`，其 property 清單由
`permgen.unit_replica_properties()` 從**落檔的 unit** 全量導出（本機 38 條）。
**沒有任何手寫的 `--property=`、沒有任何 `--setenv=PATH=`**（design D13）。

| executor | 剖面／unit | 解析到的絕對路徑 | 版本字串 | rc | planning 呼叫 stdout 前 80 字 |
|---|---|---|---|---|---|
| `codex` | jit ／ `cortex-reviewer-job-jit@` | `/opt/cortex/toolchain/bin/codex` | `codex-cli 0.147.0` | 0（`--version`） | ⚠️ `Error: failed to initialize in-process app-server client: Read-only file system` ← `CODEX_HOME`，見 U-2 段 |
| `claude` | strict ／ `cortex-reviewer-job@` | `/opt/cortex/toolchain/bin/claude` | `2.1.233 (Claude Code)` | 0 | `{"is_error":true,…,"result":"Not logged in · Please run /login",…}` ← 憑證缺口（票 D） |
| `agy` | strict ／ `cortex-reviewer-job@` | `/opt/cortex/toolchain/bin/agy` | `1.1.13` | 0 | `` ```json\n{"capability":"cortex-planning-json","executor":"agy","model":"gemini-3.1-pro-high"}\n``` `` ← **逐位元等於 expected** |
| （對照）`copilot` | jit ／ `cortex-reviewer-job-jit@` | `/opt/cortex/toolchain/bin/copilot` | `0.0.330`（operator 側 1.0.79） | 0 | 不參與 planning（`capabilities` 只有 `[build]`）；版本落差＝**#681 複現**，路徑相同、版本不同 |

**版本字串這一欄不是形式要求**：copilot 那一列就是 #681——路徑逐字相同、版本差兩個
major。只比路徑會漏掉，而「解析到非預期版本」**不會表現為失敗**。同一個理由讓
`executor-silent-exit` 的診斷也帶 `--version` 字串（在同一個降權 job 面下量、快取、
遞迴保護）。

**矩陣不是全綠**：三格裡只有 agy 端到端全綠，codex／claude 各被一個**部署面**缺口擋住
（`CODEX_HOME` 目錄可寫、planner 帳號的 claude 登入態），兩者都屬票 D（#685）／U-4，
本票不擅自裁決、不擅自放寬。兩格的成因都已精確定位並可複驗（見上）。

## 驗收 2：一輪完整 planning 期間 Manager 行程樹無 executor

以 `JobPlanningInvoker` 實跑一次真實 planning 呼叫（agy／`gemini-3.1-pro-high`，
以 `cortex-manager` 身分、帶實機 EnvironmentFile），同時逐秒抓三張快照：

```
--- t=1s caller-descendants(pid=3512170) ---     ← (a) 呼叫端（Manager 側）的完整後代樹
3512178 3512170 cortex-manager python3    /usr/bin/python3 /tmp/psc686-e2e.py
3512180 3512178 cortex-manager bash       bash -c /usr/bin/systemctl start --wait --no-ask-password cortex-reviewer-job@plan-issue686evid-probe-1-0b80174f-80ed2b94.service; rc=$?; printf %s "$rc" > …/client.exit; exit "$rc"
3512181 3512180 cortex-manager systemctl  /usr/bin/systemctl start --wait --no-ask-password cortex-reviewer-job@plan-issue686evid-probe-1-0b80174f-80ed2b94.service
--- t=1s cgroup of cortex-reviewer-job@plan-issue686evid-probe-1-0b80174f-80ed2b94.service ---
Unit … (/system.slice/system-cortex\x2dreviewer\x2djob.slice/cortex-reviewer-job@….service):
└─3512183 agy --print Return only this JSON object and do not call tools: {"cap…    ← (b) executor 只在這裡
--- t=1s cortex-manager.service cgroup ---
Unit cortex-manager.service (/system.slice/cortex-manager.service):
└─3351269 /opt/cortex/venv/bin/python /opt/cortex/venv/bin/cortex service run       ← (c) daemon 本身，沒有別的
```

t=1s…t=11s 每一秒的快照**逐張相同**（呼叫全程 10.9s）。執行身分（`ps -o uname:26`）：

```
cortex-manager             3512740 python3    /usr/bin/python3 /tmp/psc686-e2e.py
cortex-manager             3512744 bash       bash -c /usr/bin/systemctl start --wait …
cortex-manager             3512745 systemctl  /usr/bin/systemctl start --wait …
cortex-reviewer-planner    3512747 agy        agy --print Return only this JSON object … --mode plan --sandbox --model gemini-3.1-pro-high
```

呼叫端那三個行程是 `python3 → bash -c "… systemctl …" → systemctl`——**沒有任何
executor 可執行檔**；executor 只出現在另一個 cgroup、另一個 UID 上。

端到端結果（同一輪）：

```
INVOKER: JobPlanningInvoker
ELAPSED: 10.9s
RC: 0
STDOUT: '{"capability":"cortex-planning-json","executor":"agy","model":"gemini-3.1-pro-high"}\n'
OUTPUT_TEXT: None                                    ← R-2：第二候選在 job 模式恆為 None
DIAGNOSTICS: {"unit": "cortex-reviewer-job@plan-issue686evid-probe-1-454ad8b7-5a8cc3e9.service",
              "hardening_profile": "strict", "account": "cortex-reviewer-planner",
              "job_path": "/opt/cortex/toolchain/bin:/usr/local/bin:/usr/bin:/bin",
              "resolved_binary": "/opt/cortex/toolchain/bin/agy",
              "seccomp_filter_fatal": "no", "filtered_syscalls": "<none>"}
EXTRACTED: {"capability": "cortex-planning-json", "executor": "agy", "model": "gemini-3.1-pro-high"}
MATCHES_EXPECTED: True
```

取證後 `/var/lib/cortex` 已還原（`planning-scratch`／`planning-logs`／`probe` 全部刪除，
job spec 由 invoker 自己 unlink，`job-specs/reviewer/` 回到空）。**未動任何 unit、
EnvironmentFile 或 durable state。**

## 部署面：要 operator 做的事（都寫進 runbook，本票一律沒做）

1. **第 5-5c 步（新）**：補宣告 `PSC_REVIEWER_HOME`／`PSC_GATE_HOME`。**這是票 F 切換
   之前的硬前置**——沒有它，降權 planning 的 agy 100% 死在 `$HOME is not defined`。
2. **第 4e-3 步（新）**：codex 的 `CODEX_HOME` 需要**整個目錄**可寫（票 D／U-4 的範圍
   要據此擴大——只登記 `auth.json` 一個檔不夠）。
3. planner 帳號的 claude 登入態（票 D／U-4）。
4. `planning-scratch-pool` 的 `install -d`／`chmod 0700`／`setfacl rX`（產生器已會出，
   不套用也能跑：Manager 在執行期以 0711／0755 自建，operator 套用後是**更緊**的形態）。

## 驗證方法紀律（D13）

- 加固面**只**走 `psc_run_under`（`permgen.unit_replica_properties()` 從落檔 unit 全量
  導出，本機 38 條，`require_hardening=True`）。
- **未新增任何手寫的 `--property=` 清單**（`git diff` 可查：新增的 runbook 段落與測試都
  沒有這個字串）。
- **未自帶 `--setenv=PATH=`**（#679 的教訓：複本必須連 production「沒有什麼」也複製）。
- 反過來說，本票**第一次端到端跑就撞上 `$HOME is not defined`**，正是因為探針沒有補
  production 不供應的東西——那個缺口因此當場現形，而不是活過五輪驗證。

## OS 層語意的具名 skip（不得靜默通過）

`tests/test_planning_job_invoker_672.py` 三條 `@pytest.mark.skip`，各自附完整理由與
runbook 步驟：跨 UID 唯讀 scratch 的 EROFS、跨 UID log 通道的 ACL mask、Manager 行程樹
無 executor。單 UID／無 systemd 的 CI 對這三件事的斷言會**恆真**（#638／#657 的形態）。

## 一處既有測試的更新（明講）

`tests/test_planning_invoker_672.py::test_invoker_selection_follows_resolve_runner_mode`
原本斷言 `systemd-template` ⇒ `InProcessPlanningInvoker`。那是票 B **刻意的過渡態**
（`_select_planning_invoker` 的 docstring 逐字寫著「票 E 新增 `JobPlanningInvoker` 之後，
改的只有本函式的對應表一處」），本票改的就是那一處。改動是**收緊**：原本三種模式都回
同一個物件，現在每一種模式各自被釘住，並新增「A 案不得靜默退回 in-process」一條。
其餘既有測試**一行未改**（`4348 → 4364 passed`，`24 → 27 skipped`＝本票新增的三條具名
skip）。

## 檢查清單

- [x] 分支 `feature/686-job-planning-invoker`，未 commit 到 `main`
- [x] `changelog.d/686-job-planning-invoker.md` 已新增並 commit
- [x] `CHANGELOG.md [Unreleased]` 有對應 entry
- [x] `python3 -m pytest tests/ -q` 全綠（4364 passed / 27 skipped）
- [x] 未修改實機部署（unit／EnvironmentFile／`/var/lib/cortex` 狀態；取證產物已還原）
- [x] 未切換 `PSC_JOB_RUNNER` 預設（那是票 F／#687）
- [x] 未裁決 U-4／U-5／U-7
- [x] 加固面驗證全量機械導出，未手寫 `--property=`、未自帶 `--setenv=PATH=`
