### PR TITLE
feat(trust-root): permgen codify planner 憑證面，per-(account, executor) 表（#685／#672 票 D）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,67 @@
 ## [Unreleased]
 
 ### Fixed
+- **#685（#672 票 D）：permgen 把 planner／reviewer 的憑證面 codify——`executor_credential_relpath`
+  從**單一部署決定**擴成 **per-(account, executor) 表**（U-5 裁決）**。0818 的三份登入態是
+  手工 `install` ＋ 手工 `ln -s` 落位的，**重跑 runbook 不會產生它們**；本票讓它可重現：
+  兩軸（`permgen.CREDENTIALED_ACCOUNTS` × `EXECUTOR_CREDENTIALS`）展開成登記表資產，
+  `asset_paths()`／`scaffold_directories()`／`IN_PLACE_CONTENT_WRITE_ASSETS`／unit 的
+  `ReadWritePaths` 全部由它機械導出，加一格憑證不必改產生器。
+  **U-4 追認**：`cortex-reviewer-planner` 同時持有 openai／google／anthropic 三份登入態為
+  核可狀態，design 的安全退步 **R-3**（該帳號被攻陷時多邊 token 一起失，而 planner 正是吃
+  untrusted issue 內容的角色）是**明文接受的有界殘餘風險**，在後續任何「planner 攻擊面」
+  討論中不得被當成未知。
+- **U-7 裁決落地：agy 的可寫狀態樹以 symlink 類資產進登記表（design 的選項 (a)）**——
+  登記表新增 symlink kind（`permgen.SYMLINK_ASSETS`／`PermissionEntry.is_symlink`），命令
+  形態是 `ln -sfn` ＋ `chown -h`，**刻意不出 `chmod`**：Linux 沒有 `lchmod`，而
+  `chown`／`chmod` 對 symlink 一律跟著走 ⇒ 裸用會改到 `cache/gemini` **那棵樹**的 owner，
+  而那棵樹歸 job 帳號正是本形狀的全部重點。守衛掛在**父目錄**（`[ ! -e <HOME> ] ||`）而
+  不是自己身上——`ln` 是建立動作，「不存在就跳過」對它沒有意義，真正要跳過的是
+  「本方案沒有這個帳號」。
+- **驗收條件因 #686 的實測而改寫，這一條必須逐字讀。** issue 原文要求「reviewer 模板 unit
+  的 RWP 逐字含憑證**檔案**」，前提是「codex 的登入態＝一個 `auth.json`」。#686 在完整
+  reviewer unit 沙箱下實測推翻了那個前提：codex 需要 `$CODEX_HOME`（預設 `~/.codex`）
+  **整個目錄**可寫（`state_5.sqlite`／`logs_2.sqlite`／`sessions/`／`skills/`／`plugins/`／
+  `thread-writer-locks/`……檔名帶版本序號），唯讀時回
+  `failed to initialize in-process app-server client: Read-only file system`，且**與 cwd
+  無關**。照字面滿足原驗收會產出一個 **codex 仍然跑不起來**的部署。因此
+  `cortex-reviewer-planner` 的三格改走新形狀 `CredentialShape.HOME_REDIRECT_TREE`：HOME 底下
+  一條 **root-owned symlink** 導進該帳號既有的 `cache`（`~/.codex → cache/codex`、
+  `~/.gemini → cache/gemini`、`~/.claude → cache/claude`），不變式換成**更強的那一條**——
+  **模板 unit 的 `ReadWritePaths=` 逐字不變、零新增可寫面**（`cache` 早已在其中，
+  `_minimize()` 吃掉子路徑），而 symlink 放在 root-owned 的 HOME 裡，job 換不掉指向。
+- **claude 的憑證缺口一併關掉**——#686 的驗收矩陣裡 claude 是「CLI rc=0、卻回
+  `Not logged in · Please run /login`」的那一列，而 **reviewer 的預設 executor 就是
+  claude**：缺它時「reviewer 已降權」（#615 M2）買到的是一個跑不動的 job。新增登記表資產
+  `reviewer-planner-claude-state`。job 模式下 `CLAUDE_CONFIG_DIR` 在
+  `job_runner.DENIED_ENV_NAMES` 內（design D-g 的帳號隔離取代了 in-process 的一次性
+  config dir），因此 claude 解到的就是 `$HOME/.claude`。
+- **`deferred_run_dependencies()` 縮短一項，另兩項的理由整段換掉**——
+  `reviewer-planner-executor-credential`（#640 寫「M2 落地時補第二列」、M2 早已落地 ⇒
+  逾期未做）**已關閉**；#671 釘住這條逾期事實的測試按其設計意圖翻成正向形態
+  （`test_the_reviewer_credential_gap_is_closed_without_widening_the_write_surface`）。
+  `reviewer-planner-codex-hooks` **留著但升為 U-9**：它與 codex 的可用性在 `$CODEX_HOME`
+  這一層**互斥**（要 hooks 就要有一個 job 換不掉的 root-owned 檔在一棵 job 必須整棵可寫的
+  樹裡）——原本「補第二列即可」的理由已被推翻，不是「還沒補」。
+  `manager-claude-credential` **留著**：U-5 解除了它的機械阻礙（表達得了了），但「要不要給
+  Manager 一份模型憑證」的答案是**不要**（Manager 是 durable state owner ＋ spawn 授權
+  持有者，passwd 註記逐字寫著 `no model code`），它由票 F（#687）切換後隨 direct 路徑
+  一起消失，本票不預先刪掉一件還沒成立的事。
+- **票 C（#684）的已知限制解除**——`planning_probe_cache._credential_path()` 跟著
+  `executor_credential_of()` 的新簽章走（多一個 `executor` 參數），並改 `stat`
+  **token 葉檔**而不是資產節點：`stat` 一條 symlink 只看得到目標目錄的 mtime，token
+  就地覆寫時它不變 ⇒ 「憑證換了」偵測不到。agy 的 `~/.gemini` 與 claude 的 `~/.claude`
+  因此**現在進得了指紋**（票 C PR body 明列的待補項）。未登記的 (account, executor)
+  fail-closed，由 `compute_fingerprint` 的 `_safe` 收成穩定的
+  `<unresolved:UnregisteredExecutorCredentialError>` 標記——**取不到答案本身也是一個會變的
+  答案**（與 PATH 那一格同一條原則）。
+- **`PSC_REVIEWER_HOME` 是本票的成對前置，不是別張票的事**——三份登入態的路徑**全部以
+  `$HOME` 為根**，而模板模式下 shim 以 `os.execvpe` 整份換掉環境，unit 的
+  `Environment=HOME=` 到不了模型（#686 實機更正）。`HOME` 沒宣告時它們在 job 內一條都解
+  不到，而症狀（`$HOME is not defined`／`Not logged in`）與「憑證沒放好」長得一模一樣。
+  新增 `permgen.JOB_HOME_ENV_BY_PRINCIPAL` 與 `PathLayout.job_home_value()`（與
+  `job_runner.JOB_ROLE_CONFIG.home_env` 的成對契約由測試釘住，比照 #679 的 PATH），
+  模板 unit 的憑證段直接印出 operator 要落進 EnvironmentFile 的那一行。
 - **#686（#672 票 E）：`JobPlanningInvoker`——planning 的模型呼叫改走
   `cortex-reviewer-job@.service`，Manager 行程樹不再出現任何 executor**——`cortex-manager`
   的 passwd 註記逐字寫著 `no model code`，而 planning（define／brainstorm）的四個 adapter
@@ -2163,6 +2224,28 @@
   被 `is_rate_limit_signal` 認得，`coordinator/claim.py` 的
   `provider-authority-rate-limited-canonical` 行為不變。
   詳見 `changelog.d/rate-limit-pressure.md`。
+
+### Security
+- **新增安全退步 R-6（明講，不是順手接受的）**：`HOME_REDIRECT_TREE` 的目標樹由 job 帳號
+  擁有 ⇒ 樹裡的 token 葉檔**可被該 job 刪除或替換**（builder 的 `IN_PLACE_FILE` 擋得住
+  「刪／換」，這裡擋不住）。影響面限於該帳號自己的登入態；換到的是 codex／claude
+  **能不能起得來**。直接後果是同一棵樹裡**不得**再放任何 root-owned 的 enforcement 檔
+  ——`reviewer-planner-codex-hooks` 因此升為 U-9。同時**修掉**一個 #640 刻意接受的代價：
+  「暫存檔 ＋ rename 原子替換」形式的 refresh 在這個形狀下走得通。
+- **builder 一行未改，且它的同型缺口已記錄**：`builder-executor-credential` 維持 #640 裁決
+  (b)（RWP 逐字掛在檔案本身、父目錄 root-owned、runbook 第 4e-2 步的三條反向驗證不變）。
+  但 #686 的量測同樣適用它——builder 在模板 unit 下跑 codex 會撞到同一條 `$CODEX_HOME`
+  唯讀阻斷。改它會同時賣掉 `codex-hooks` 的 enforcement（一棵 job 擁有的樹裡放不住
+  root-owned 檔），因此屬 **U-9** 的同一個裁決，本票不擅自做。
+
+### Changed
+- `docs/superpowers/runbooks/trust-root-phase2b-setup.md`：新增第 **4e-2b** 步
+  （`cortex-reviewer-planner` 三份登入態的四步部署順序：骨架目標 → 遷移 0818 手動落位的
+  舊目錄 → 由權限計畫落 symlink → 放 token，含跨 UID 的「換不掉指向／寫得進樹」反向驗證，
+  與三個 executor 在真實加固面下的 rc 驗收）；既有的 per-account 憑證段改為 builder 專用
+  並指向新步驟。**加固面一律走既有共用探針 `psc_run_under`**（property 由
+  `permgen.unit_replica_properties()` 從落檔的 unit 全量導出），**未新增任何手寫的
+  `--property=` 清單、未自帶 `--setenv=PATH=`**（design D13）。
 
 ## [0.1.8] - 2026-08-12
 

--- a/changelog.d/685-credential-codify.md
+++ b/changelog.d/685-credential-codify.md
@@ -1,0 +1,84 @@
+### Fixed
+- **#685（#672 票 D）：permgen 把 planner／reviewer 的憑證面 codify——`executor_credential_relpath`
+  從**單一部署決定**擴成 **per-(account, executor) 表**（U-5 裁決）**。0818 的三份登入態是
+  手工 `install` ＋ 手工 `ln -s` 落位的，**重跑 runbook 不會產生它們**；本票讓它可重現：
+  兩軸（`permgen.CREDENTIALED_ACCOUNTS` × `EXECUTOR_CREDENTIALS`）展開成登記表資產，
+  `asset_paths()`／`scaffold_directories()`／`IN_PLACE_CONTENT_WRITE_ASSETS`／unit 的
+  `ReadWritePaths` 全部由它機械導出，加一格憑證不必改產生器。
+  **U-4 追認**：`cortex-reviewer-planner` 同時持有 openai／google／anthropic 三份登入態為
+  核可狀態，design 的安全退步 **R-3**（該帳號被攻陷時多邊 token 一起失，而 planner 正是吃
+  untrusted issue 內容的角色）是**明文接受的有界殘餘風險**，在後續任何「planner 攻擊面」
+  討論中不得被當成未知。
+- **U-7 裁決落地：agy 的可寫狀態樹以 symlink 類資產進登記表（design 的選項 (a)）**——
+  登記表新增 symlink kind（`permgen.SYMLINK_ASSETS`／`PermissionEntry.is_symlink`），命令
+  形態是 `ln -sfn` ＋ `chown -h`，**刻意不出 `chmod`**：Linux 沒有 `lchmod`，而
+  `chown`／`chmod` 對 symlink 一律跟著走 ⇒ 裸用會改到 `cache/gemini` **那棵樹**的 owner，
+  而那棵樹歸 job 帳號正是本形狀的全部重點。守衛掛在**父目錄**（`[ ! -e <HOME> ] ||`）而
+  不是自己身上——`ln` 是建立動作，「不存在就跳過」對它沒有意義，真正要跳過的是
+  「本方案沒有這個帳號」。
+- **驗收條件因 #686 的實測而改寫，這一條必須逐字讀。** issue 原文要求「reviewer 模板 unit
+  的 RWP 逐字含憑證**檔案**」，前提是「codex 的登入態＝一個 `auth.json`」。#686 在完整
+  reviewer unit 沙箱下實測推翻了那個前提：codex 需要 `$CODEX_HOME`（預設 `~/.codex`）
+  **整個目錄**可寫（`state_5.sqlite`／`logs_2.sqlite`／`sessions/`／`skills/`／`plugins/`／
+  `thread-writer-locks/`……檔名帶版本序號），唯讀時回
+  `failed to initialize in-process app-server client: Read-only file system`，且**與 cwd
+  無關**。照字面滿足原驗收會產出一個 **codex 仍然跑不起來**的部署。因此
+  `cortex-reviewer-planner` 的三格改走新形狀 `CredentialShape.HOME_REDIRECT_TREE`：HOME 底下
+  一條 **root-owned symlink** 導進該帳號既有的 `cache`（`~/.codex → cache/codex`、
+  `~/.gemini → cache/gemini`、`~/.claude → cache/claude`），不變式換成**更強的那一條**——
+  **模板 unit 的 `ReadWritePaths=` 逐字不變、零新增可寫面**（`cache` 早已在其中，
+  `_minimize()` 吃掉子路徑），而 symlink 放在 root-owned 的 HOME 裡，job 換不掉指向。
+- **claude 的憑證缺口一併關掉**——#686 的驗收矩陣裡 claude 是「CLI rc=0、卻回
+  `Not logged in · Please run /login`」的那一列，而 **reviewer 的預設 executor 就是
+  claude**：缺它時「reviewer 已降權」（#615 M2）買到的是一個跑不動的 job。新增登記表資產
+  `reviewer-planner-claude-state`。job 模式下 `CLAUDE_CONFIG_DIR` 在
+  `job_runner.DENIED_ENV_NAMES` 內（design D-g 的帳號隔離取代了 in-process 的一次性
+  config dir），因此 claude 解到的就是 `$HOME/.claude`。
+- **`deferred_run_dependencies()` 縮短一項，另兩項的理由整段換掉**——
+  `reviewer-planner-executor-credential`（#640 寫「M2 落地時補第二列」、M2 早已落地 ⇒
+  逾期未做）**已關閉**；#671 釘住這條逾期事實的測試按其設計意圖翻成正向形態
+  （`test_the_reviewer_credential_gap_is_closed_without_widening_the_write_surface`）。
+  `reviewer-planner-codex-hooks` **留著但升為 U-9**：它與 codex 的可用性在 `$CODEX_HOME`
+  這一層**互斥**（要 hooks 就要有一個 job 換不掉的 root-owned 檔在一棵 job 必須整棵可寫的
+  樹裡）——原本「補第二列即可」的理由已被推翻，不是「還沒補」。
+  `manager-claude-credential` **留著**：U-5 解除了它的機械阻礙（表達得了了），但「要不要給
+  Manager 一份模型憑證」的答案是**不要**（Manager 是 durable state owner ＋ spawn 授權
+  持有者，passwd 註記逐字寫著 `no model code`），它由票 F（#687）切換後隨 direct 路徑
+  一起消失，本票不預先刪掉一件還沒成立的事。
+- **票 C（#684）的已知限制解除**——`planning_probe_cache._credential_path()` 跟著
+  `executor_credential_of()` 的新簽章走（多一個 `executor` 參數），並改 `stat`
+  **token 葉檔**而不是資產節點：`stat` 一條 symlink 只看得到目標目錄的 mtime，token
+  就地覆寫時它不變 ⇒ 「憑證換了」偵測不到。agy 的 `~/.gemini` 與 claude 的 `~/.claude`
+  因此**現在進得了指紋**（票 C PR body 明列的待補項）。未登記的 (account, executor)
+  fail-closed，由 `compute_fingerprint` 的 `_safe` 收成穩定的
+  `<unresolved:UnregisteredExecutorCredentialError>` 標記——**取不到答案本身也是一個會變的
+  答案**（與 PATH 那一格同一條原則）。
+- **`PSC_REVIEWER_HOME` 是本票的成對前置，不是別張票的事**——三份登入態的路徑**全部以
+  `$HOME` 為根**，而模板模式下 shim 以 `os.execvpe` 整份換掉環境，unit 的
+  `Environment=HOME=` 到不了模型（#686 實機更正）。`HOME` 沒宣告時它們在 job 內一條都解
+  不到，而症狀（`$HOME is not defined`／`Not logged in`）與「憑證沒放好」長得一模一樣。
+  新增 `permgen.JOB_HOME_ENV_BY_PRINCIPAL` 與 `PathLayout.job_home_value()`（與
+  `job_runner.JOB_ROLE_CONFIG.home_env` 的成對契約由測試釘住，比照 #679 的 PATH），
+  模板 unit 的憑證段直接印出 operator 要落進 EnvironmentFile 的那一行。
+
+### Security
+- **新增安全退步 R-6（明講，不是順手接受的）**：`HOME_REDIRECT_TREE` 的目標樹由 job 帳號
+  擁有 ⇒ 樹裡的 token 葉檔**可被該 job 刪除或替換**（builder 的 `IN_PLACE_FILE` 擋得住
+  「刪／換」，這裡擋不住）。影響面限於該帳號自己的登入態；換到的是 codex／claude
+  **能不能起得來**。直接後果是同一棵樹裡**不得**再放任何 root-owned 的 enforcement 檔
+  ——`reviewer-planner-codex-hooks` 因此升為 U-9。同時**修掉**一個 #640 刻意接受的代價：
+  「暫存檔 ＋ rename 原子替換」形式的 refresh 在這個形狀下走得通。
+- **builder 一行未改，且它的同型缺口已記錄**：`builder-executor-credential` 維持 #640 裁決
+  (b)（RWP 逐字掛在檔案本身、父目錄 root-owned、runbook 第 4e-2 步的三條反向驗證不變）。
+  但 #686 的量測同樣適用它——builder 在模板 unit 下跑 codex 會撞到同一條 `$CODEX_HOME`
+  唯讀阻斷。改它會同時賣掉 `codex-hooks` 的 enforcement（一棵 job 擁有的樹裡放不住
+  root-owned 檔），因此屬 **U-9** 的同一個裁決，本票不擅自做。
+
+### Changed
+- `docs/superpowers/runbooks/trust-root-phase2b-setup.md`：新增第 **4e-2b** 步
+  （`cortex-reviewer-planner` 三份登入態的四步部署順序：骨架目標 → 遷移 0818 手動落位的
+  舊目錄 → 由權限計畫落 symlink → 放 token，含跨 UID 的「換不掉指向／寫得進樹」反向驗證，
+  與三個 executor 在真實加固面下的 rc 驗收）；既有的 per-account 憑證段改為 builder 專用
+  並指向新步驟。**加固面一律走既有共用探針 `psc_run_under`**（property 由
+  `permgen.unit_replica_properties()` 從落檔的 unit 全量導出），**未新增任何手寫的
+  `--property=` 清單、未自帶 `--setenv=PATH=`**（design D13）。

--- a/docs/superpowers/plans/planner-job-downgrade.md
+++ b/docs/superpowers/plans/planner-job-downgrade.md
@@ -202,29 +202,59 @@ blocking reason——兩者剛好接得起來，缺任何一半都還是查不�
 
 ### 4. 票 D｜permgen 把 planner 憑證面 codify（對應 R5；依賴 U-4／U-5／U-7 裁決）
 
-- [ ] `tests/test_trust_root_planner_credentials_672.py`（TDD RED）：
-  - `test_reviewer_planner_credential_is_registered`：登記表有
-    `reviewer-planner-executor-credential`，且列在 `IN_PLACE_CONTENT_WRITE_ASSETS`。
-  - `test_reviewer_template_rwp_includes_credential_file_not_parent`：reviewer 模板
-    unit 的 `ReadWritePaths` 含**檔案本身**，不含父目錄。
-  - `test_two_way_scheme_unaffected`：二分方案下該資產經
-    `inapplicable_home_anchored_assets()` 機械排除，Manager unit 的 RWP 不多出
-    不存在的路徑（＝#640 當年不敢登記的那個理由已被 #671 拆掉）。
-  - `test_deferred_dependencies_shrink`：`deferred_run_dependencies()` 不再含
-    `reviewer-planner-executor-credential`、`reviewer-planner-codex-hooks`、
-    `manager-claude-credential` 三項（第三項因為本票的裁決是「planning 一律走降權
-    job」，Manager 不再需要 claude 登入態）。
-- [ ] `paulsha_cortex/trust_root/registry.py`：新增憑證資產列；
-      `paulsha_cortex/trust_root/permgen.py`：加進 `IN_PLACE_CONTENT_WRITE_ASSETS`、
-      移除對應的 `DeferredDependency`、`asset_paths()` 補 `codex-hooks` 的 per-account 版。
-- [ ] 依 U-5 的裁決處理 `executor_credential_relpath`（維持單一 vs 擴成
-      per-(account, executor) 表）。若裁決是擴表，本票範圍會顯著變大，應再切一張子票。
-- [ ] 依 U-7 的裁決處理 agy 狀態樹（symlink 資產 vs env 導向 `cache`）。
-- [ ] runbook `docs/superpowers/runbooks/trust-root-phase2b-setup.md` 第 4e 步：
-      補「逐帳號 × 逐 executor」的反向驗證矩陣（#668 的 C 項），並固定部署順序
-      「憑證落位 → 重跑產生器 → daemon-reload → `systemctl status` 確認 unit 起得來」。
-- 驗收：`python -m paulsha_cortex.trust_root permissions` 產出的 reviewer 模板 unit
-      逐字含憑證檔那一條 RWP；二分方案的產出不含它；deferred 清單縮短且測試釘住。
+**已由 issue #685 land。** U-4／U-5／U-7 由 operator 於 0818 裁決（追認雙 domain／
+兩者皆「照設計做」）。
+
+- [x] `tests/test_trust_root_planner_credentials_672.py`（24 條 ＋ 1 條具名 skip）。
+      **測試名與 plan 原文不同，因為驗收條件被 #686 的實測改寫**，見下方「實作補充」。
+- [x] `paulsha_cortex/trust_root/registry.py`：新增三份登入態資產
+      （`reviewer-planner-{codex,agy,claude}-state`）；
+      `paulsha_cortex/trust_root/permgen.py`：新增 per-(account, executor) 憑證表
+      （`CredentialShape`／`ExecutorCredential`／`EXECUTOR_CREDENTIALS`／
+      `CREDENTIALED_ACCOUNTS`）、symlink 資產 kind、`IN_PLACE_CONTENT_WRITE_ASSETS` 與
+      `_FILE_ASSET_IDS` 改為由表導出、移除已關閉的 `DeferredDependency`。
+- [x] U-5：`executor_credential_relpath` 擴成 per-(account, executor) 表。原欄位**保留**
+      為表上 primary 那一格的**值**（#640 的「換 executor 只改一個值」因此仍成立）。
+- [x] U-7：agy 狀態樹走 design 的 (a)——symlink 類資產（登記表新增 kind）。
+- [x] runbook 第 **4e-2b** 步：`cortex-reviewer-planner` 三份登入態的四步部署順序
+      （骨架目標 → 遷移 0818 手動落位的舊目錄 → 由權限計畫落 symlink → 放 token）＋
+      跨 UID 反向驗證 ＋ 三個 executor 在真實加固面下的 rc 驗收。
+- 驗收（**改寫後的形態**）：二分方案的產出不含那三格（`inapplicable_home_anchored_assets()`
+      機械排除，有測試釘住）；`deferred_run_dependencies()` 縮短一項；reviewer 模板 unit 的
+      `ReadWritePaths=` **逐字不變**。
+
+**#685 的實作補充**（plan／design 之外的四處，票 F 沿用）：
+
+1. **驗收條件「RWP 逐字含憑證**檔案**」被 #686 的實測推翻，已改寫。** 原條件的前提是
+   「codex 的登入態＝一個 `auth.json`」；#686 在完整 reviewer unit 沙箱下量到 codex 需要
+   `$CODEX_HOME` **整個目錄**可寫（`state_5.sqlite`／`sessions/`／`plugins/`…，檔名帶版本
+   序號 ⇒ 逐項列舉會在下次升版無聲失效），唯讀時回 `failed to initialize in-process
+   app-server client: Read-only file system`，且與 cwd 無關。**照字面滿足原條件會產出一個
+   codex 仍然跑不起來的部署。** 因此 planner 帳號改走新形狀 `HOME_REDIRECT_TREE`
+   （HOME 底下 root-owned symlink → 該帳號既有的 `cache`），不變式換成更強的一條：
+   **unit 的 `ReadWritePaths=` 逐字不變、零新增可寫面**。builder 維持 `IN_PLACE_FILE`
+   一行未改——「同一個 executor 在不同帳號上是不同形狀」正是 U-5 要 per-(account, executor)
+   而不是 per-executor 的具體理由。
+2. **claude 的憑證缺口一併關掉**（#686 矩陣裡「CLI rc=0、回 `Not logged in`」那一列）。
+   reviewer 的預設 executor 就是 claude，缺它時「reviewer 已降權」買到的是一個跑不動的 job。
+3. **新增安全退步 R-6**：`HOME_REDIRECT_TREE` 的目標樹由 job 帳號擁有 ⇒ 樹裡的 token 葉檔
+   可被該帳號刪除或替換（builder 的形狀擋得住）。影響面限於它自己的登入態，換到的是
+   executor 起不起得來；同時**修掉** #640 刻意接受的「rename 式 refresh 走不通」。
+   直接後果 ⇒ **U-9（新提，待 operator）**：`reviewer-planner-codex-hooks` 與 codex 的
+   可用性在 `$CODEX_HOME` 這一層**互斥**，因此**沒有**按 plan 原文關閉，理由整段換掉並留在
+   `deferred_run_dependencies()`。候選解是 root-owned ＋ sticky bit ＋ 給 job 一條 `rwx`
+   ACL 的目錄，但它要改 permgen 的 mode 管線（`_mask_write` 會拿掉 group 寫入位、
+   `mode & 0o700` 會吃掉 sticky 位，那是 spec §R2 的既有不變式），且「codex 能不能在一個
+   它**不擁有**的 `$CODEX_HOME` 下跑起來」**沒有實機證據** ⇒ 依 D13 不得宣稱可用。
+   **同一個裁決也涵蓋 builder**：它在模板 unit 下跑 codex 會撞同一條阻斷。
+4. **`manager-claude-credential` 沒有依 plan 原文刪除。** plan 寫「第三項因為本票的裁決是
+   『planning 一律走降權 job』」——那個裁決的**落地**是票 F（#687）的切換，而 direct 路徑
+   今天逐字還在。U-5 只解除了它的**機械**阻礙（表達得了了），要不要登記則答案是**不要**
+   （Manager 是 durable state owner ＋ spawn 授權持有者）。現在刪等於宣稱一件還沒成立的事。
+5. **`PSC_REVIEWER_HOME` 是本票的成對前置**（#686 查到）：三份登入態全部以 `$HOME` 為根，
+   而 shim 以 `os.execvpe` 整份換掉環境 ⇒ unit 的 `Environment=HOME=` 到不了模型。新增
+   `permgen.JOB_HOME_ENV_BY_PRINCIPAL`／`PathLayout.job_home_value()`（與 job_runner 的
+   成對契約由測試釘住，比照 #679 的 PATH），模板 unit 直接印出 operator 要落的那一行。
 
 ### 5. 票 E｜`JobPlanningInvoker`（對應 R1／R2／R4／R7／R8；依賴票 B、票 C、PATH 前置票）
 

--- a/docs/superpowers/runbooks/trust-root-phase2b-setup.md
+++ b/docs/superpowers/runbooks/trust-root-phase2b-setup.md
@@ -2069,16 +2069,17 @@ sudo systemd-run --pipe --wait --collect --quiet --service-type=exec \
 > 改不了 Manager 的 state、也讀不到另一個 job 帳號的憑證），**不是** provider 層的
 > 獨立——與 `independence_domain` 不是同一件事（見 spec §R1）。
 
+> **⚠️ #685：本形態（單檔）現在只適用 `cortex-builder`。** `cortex-reviewer-planner`
+> 的三份登入態改走「root-owned symlink 導進 `cache`」的形狀——理由是 #686 實測 codex
+> 需要 `$CODEX_HOME` **整個目錄**可寫，單檔放行時它連起都起不來。那個帳號的步驟在
+> **第 4e-2b 步**，不要用下面這一段。
+
 ```bash
-# 🔧 sudo：把 operator 那份憑證複製給兩個 job 帳號，owner 給該帳號、目錄維持 root 的
-for who in builder reviewer-planner; do
-  sudo install -o "cortex-$who" -g "cortex-$who" -m 0600 \
-    "$HOME/.codex/auth.json" "/var/lib/cortex-$who/.codex/auth.json"
-done
+# 🔧 sudo：把 operator 那份憑證複製給 **builder**，owner 給該帳號、目錄維持 root 的
+sudo install -o cortex-builder -g cortex-builder -m 0600 \
+  "$HOME/.codex/auth.json" /var/lib/cortex-builder/.codex/auth.json
 #   ↑ `.codex/` 目錄本身由第 2b 步的骨架建成 root:root 0755，這裡**不要**動它。
-#   其他 executor 的憑證檔位置不同（`claude` 等各有自己的落點，本票未實測）：
-#   落位規則完全一樣——先確認該 CLI 實際寫哪個檔，再以同一條 install 命令落位；
-#   若該檔的父目錄還不存在，用 `sudo install -d -o root -g root -m 0755 <dir>` 補。
+#   ⚠️ `cortex-reviewer-planner` **不在**這一段（見第 4e-2b 步）。
 ```
 
 ```bash
@@ -2115,8 +2116,150 @@ sudo -u cortex-builder sh -c \
 > 比走到呼叫模型那一步才 rc=127 好查得多。journal 若出現
 > `Failed to set up mount namespacing … No such file or directory`，先回頭看這一步。
 
-**回滾**：`sudo rm -rf /opt/cortex/toolchain
-/var/lib/cortex-{builder,reviewer-planner}/.codex/auth.json`。
+**回滾**：`sudo rm -rf /opt/cortex/toolchain /var/lib/cortex-builder/.codex/auth.json`。
+
+---
+
+#### 4e-2b. `cortex-reviewer-planner` 的三份登入態（#685／#672 票 D；U-4／U-5／U-7）
+
+> **這一節取代 0818 的手動部署。** 那次是手工 `install` ＋ 手工 `ln -s`，**重跑 runbook
+> 不會產生它們**——本節讓它可重現：路徑、owner、mode、symlink 目標全部由
+> `python3 -m paulsha_cortex.trust_root permissions｜scaffold` 出，不手抄。
+
+**形狀（`permgen.CredentialShape.HOME_REDIRECT_TREE`）**：HOME 底下一條 root-owned
+symlink，指向該帳號 `cache` 裡的一格。
+
+| executor | symlink | 目標 | token 葉檔 |
+|---|---|---|---|
+| `codex` | `~/.codex` | `~/cache/codex` | `auth.json` |
+| `agy` | `~/.gemini` | `~/cache/gemini` | `antigravity-cli/antigravity-oauth-token` |
+| `claude` | `~/.claude` | `~/cache/claude` | `.credentials.json` |
+
+> **為什麼不是 builder 那種單檔**（#686 實測，逐條可複驗）：
+>
+> - `codex` 在 `$CODEX_HOME` 底下建 `state_5.sqlite`／`logs_2.sqlite`／`sessions/`／
+>   `skills/`／`plugins/`／`thread-writer-locks/`……唯讀時回
+>   `Error: failed to initialize in-process app-server client: Read-only file system
+>   (os error 30)`。把 cwd 換成可寫的 `/tmp` **症狀完全相同**；維持唯讀 cwd、只把
+>   `CODEX_HOME` 指到可寫目錄則 **rc=0**。所以阻斷點是 `CODEX_HOME`，不是 cwd。
+>   檔名帶版本序號 ⇒ **逐項列舉會在下一次 CLI 升版時無聲失效**。
+> - `agy` 往 `~/.gemini/antigravity-cli/` 寫 conversations SQLite、crashes、presence
+>   lock、builtin skills，並自解出一個 17 MB 的 `bin/webm_encoder`。
+> - `claude` 在 job 沙箱下 CLI rc=0 但回 `Not logged in · Please run /login`。
+>
+> **為什麼導進 `cache`**：那一層**早已**在模板 unit 的 `ReadWritePaths=` 內，因此
+> 這一步做完之後 **unit 的 `ReadWritePaths=` 逐字不變、零新增可寫面**——executor 能做
+> 的事，該帳號今天就已經能做。symlink 本身放在 root-owned 的 HOME 裡，job 換不掉指向。
+>
+> **代價（R-6，明講）**：目標樹由 job 帳號擁有 ⇒ 樹裡的 token 葉檔**可被該帳號刪除或
+> 替換**（builder 的單檔形態擋得住「刪／換」，這裡擋不住）。影響面限於它自己的登入態。
+> 直接後果：**同一棵樹裡不得再放任何 root-owned 的 enforcement 檔**——
+> `reviewer-planner-codex-hooks` 因此仍是未決項（U-9），見
+> `permgen.deferred_run_dependencies()`。
+
+**部署順序固定為四步，順序錯了 unit 會起不來或 executor 解不到路徑：**
+
+```bash
+# 1️⃣ 骨架：建出三個目標（該帳號擁有 0700，落在既有的 cache 內）
+python3 -m paulsha_cortex.trust_root scaffold four-way | grep '/cache/'
+#   期望三行：install -d -o cortex-reviewer-planner … /var/lib/cortex-reviewer-planner/cache/{codex,gemini,claude}
+sudo sh -e -c "$(python3 -m paulsha_cortex.trust_root scaffold four-way)"
+#   ⚠️ 目標**必須先存在**：對一條懸空 symlink 建目錄的 syscall 回 EEXIST（不是「建出
+#      目標」），executor 於是死在一個與權限完全無關的錯誤上。
+
+# 2️⃣ 遷移既有登入態（0818 手動部署留下的那一份）
+#    舊位置是**真目錄** /var/lib/cortex-reviewer-planner/.codex/，先把內容搬進目標，
+#    再把那個目錄清掉——第 3 步的 `ln -sfn` 不會覆蓋一個非空的真目錄。
+sudo sh -c '
+  d=/var/lib/cortex-reviewer-planner
+  if [ -d "$d/.codex" ] && [ ! -L "$d/.codex" ]; then
+    cp -a "$d/.codex/." "$d/cache/codex/" && rm -rf "$d/.codex"
+  fi
+  if [ -d "$d/.gemini" ] && [ ! -L "$d/.gemini" ]; then
+    cp -a "$d/.gemini/." "$d/cache/gemini/" && rm -rf "$d/.gemini"
+  fi
+  chown -R cortex-reviewer-planner:cortex-reviewer-planner "$d/cache"
+'
+#   ⚠️ 0818 的 `.gemini` 本來就是 symlink（指向同一個目標），上面的 `[ ! -L ]` 會跳過它。
+#   ⚠️ 舊 `.codex/hooks.json` 若存在，**不要**搬進去（那棵樹 job 可寫，root-owned 的
+#      hooks 在裡面擋不住替換 ⇒ 是名義上的 enforcement）。見 U-9。
+
+# 3️⃣ 落 symlink（由權限計畫出，不手打）
+python3 -m paulsha_cortex.trust_root permissions four-way --commands --paths \
+  --operator-account "$USER" --external-reader-account none \
+  | grep -E 'reviewer-planner-(codex|agy|claude)-state' -A6 | grep -E '^\[ ! -e'
+#   期望六行（三格 × `ln -sfn` ＋ `chown -h`），全部帶
+#   `[ ! -e /var/lib/cortex-reviewer-planner ] || ` 守衛
+#   ——守衛掛在**父目錄**上：本方案沒有這個帳號時整段跳過（二分部署）。
+#   套用時走整份權限 script（第 2b 步），不要只挑這六行執行。
+
+# 4️⃣ 放 token（三個 provider 各自的登入態，落點見上表）
+sudo install -o cortex-reviewer-planner -g cortex-reviewer-planner -m 0600 \
+  "$HOME/.codex/auth.json" /var/lib/cortex-reviewer-planner/cache/codex/auth.json
+sudo install -D -o cortex-reviewer-planner -g cortex-reviewer-planner -m 0600 \
+  "$HOME/.gemini/antigravity-cli/antigravity-oauth-token" \
+  /var/lib/cortex-reviewer-planner/cache/gemini/antigravity-cli/antigravity-oauth-token
+sudo install -o cortex-reviewer-planner -g cortex-reviewer-planner -m 0600 \
+  "$HOME/.claude/.credentials.json" \
+  /var/lib/cortex-reviewer-planner/cache/claude/.credentials.json
+#   ⚠️ 來源路徑依 operator 自己的登入態而定，先 `ls` 確認；三份都是**同一個 provider
+#      帳號**的複本 ⇒ 這一步就是 U-4 追認的 R-3（該帳號被攻陷時三邊 token 一起失）。
+```
+
+**成對前置：`PSC_REVIEWER_HOME` 必須同時宣告（第 5-5c 步）。** 三條 symlink 的路徑
+**全部以 `$HOME` 為根**，而模板模式下 shim 以 `os.execvpe` 整份換掉環境，unit 的
+`Environment=HOME=` 到不了模型（#686 實機更正）。沒有它，本節做得再對，job 內一條也
+解不到——而症狀（`$HOME is not defined`／`Not logged in`）與「憑證沒放好」長得一模
+一樣。產生器出的值：
+
+```bash
+python3 -m paulsha_cortex.trust_root unit four-way --review-job | grep PSC_REVIEWER_HOME
+#   期望：#      PSC_REVIEWER_HOME=/var/lib/cortex-reviewer-planner
+```
+
+```bash
+# ✅ 驗證 1：形狀（symlink root-owned、目標該帳號擁有）
+ls -ld /var/lib/cortex-reviewer-planner/.{codex,gemini,claude}
+#   期望三行：lrwxrwxrwx root root … -> /var/lib/cortex-reviewer-planner/cache/{codex,gemini,claude}
+ls -ld /var/lib/cortex-reviewer-planner/cache/{codex,gemini,claude}
+#   期望三行：drwx------ cortex-reviewer-planner cortex-reviewer-planner
+
+# ✅ 驗證 2：**零新增可寫面**——unit 的 RWP 逐字不變
+python3 -m paulsha_cortex.trust_root unit four-way --review-job | grep '^ReadWritePaths='
+#   期望**恰好**：ReadWritePaths=/var/lib/cortex-reviewer-planner/cache
+#                 ReadWritePaths=/var/lib/cortex/coordinator/review-verdicts
+#   ⛔ 多出任何一條含 `.codex`／`.gemini`／`.claude` 的路徑 ⇒ 有人把資產的 writer 面
+#      改成 job principal 了，回去看登記表，**不要**就地改 unit。
+
+# ✅ 驗證 3（跨 UID，**在真實加固面下**）：換不掉指向、但寫得進樹
+psc_run_under cortex-reviewer-job /bin/sh -c \
+  'ln -sfn /tmp/evil /var/lib/cortex-reviewer-planner/.gemini'
+#   期望：Permission denied ← symlink 在 root-owned 的 HOME 裡
+psc_run_under cortex-reviewer-job /bin/sh -c \
+  'touch /var/lib/cortex-reviewer-planner/.gemini/psc-probe && echo STATE-TREE-WRITABLE'
+#   期望：STATE-TREE-WRITABLE ← 目標在 cache 內，已在 unit 的 RWP 中
+#   （收尾：sudo rm -f /var/lib/cortex-reviewer-planner/cache/gemini/psc-probe）
+#   ⚠️ `psc_run_under` 的 property 清單由 `permgen.unit_replica_properties()` 從**落檔
+#      的 unit** 全量導出。**不得**自行組 `--property=`、**不得**自帶 `--setenv=PATH=`
+#      ——本 repo 兩個方向的事故各兩次（#638／#657 假綠；#673 body 與 repro 假紅）。
+
+# ✅ 驗證 4：三個 executor 在該 unit 下**真的跑得起來**（這一格才是驗收）
+psc_run_under cortex-reviewer-job-jit /opt/cortex/toolchain/bin/codex exec --json \
+  'Return only this JSON object and do not call tools: {"capability":"cortex-planning-json"}'
+#   期望：rc=0。**#686 當時這一格是紅的**（`Read-only file system`）——本節做完必須翻綠。
+psc_run_under cortex-reviewer-job /opt/cortex/toolchain/bin/claude --version
+psc_run_under cortex-reviewer-job /bin/sh -c \
+  '/opt/cortex/toolchain/bin/claude -p "hi" --output-format json --tools ""'
+#   期望：rc=0 且**不再**是 `Not logged in · Please run /login`（#686 那一格的成因）。
+psc_run_under cortex-reviewer-job /opt/cortex/toolchain/bin/agy \
+  --print 'Return only this JSON object and do not call tools: {"capability":"cortex-planning-json","executor":"agy","model":"gemini-3.1-pro-high"}' \
+  --mode plan --sandbox --model gemini-3.1-pro-high
+#   期望：rc=0、輸出逐位元等於 expected（0818 與 #686 兩次實測皆如此）。
+```
+
+**回滾**：`sudo rm -f /var/lib/cortex-reviewer-planner/.{codex,gemini,claude}` ＋
+`sudo rm -rf /var/lib/cortex-reviewer-planner/cache/{codex,gemini,claude}`。
+（回滾之後降權 planning 與 reviewer job 都會退回「沒有登入態」的狀態，不是壞掉。）
 
 ---
 

--- a/paulsha_cortex/coordinator/planning_probe_cache.py
+++ b/paulsha_cortex/coordinator/planning_probe_cache.py
@@ -235,18 +235,28 @@ def _search_path(mode: str, env: Mapping[str, str]) -> str:
     return job_runner.resolve_job_path(env, role=job_runner.JOB_ROLE_REVIEW)
 
 
-def _credential_path(mode: str, env: Mapping[str, str]) -> str:
-    """本模式下 executor 憑證的落點。
+def _credential_path(mode: str, env: Mapping[str, str], executor: str) -> str:
+    """本模式下**這個 executor** 的登入態落點。
 
-    - direct：probe 用的是 Manager 行程的 `$HOME`，因此憑證就在那底下；
+    - direct：probe 用的是 Manager 行程的 `$HOME`，因此登入態就在那底下；
     - job：`permgen` 的部署決定欄位（`reviewer_planner_account`）導出。
 
-    **已知限制（U-5／票 D）**：`PathLayout.executor_credential_relpath` 目前是
-    **單一**值（預設 `.codex/auth.json`），還沒有 per-(account, executor) 的表——
-    那正是 design 列為未決的 U-5。因此 agy 的 `~/.gemini` 狀態樹目前**不**在指紋
-    裡：它 refresh 時不會即時失效，最長由 not-ready TTL（預設 300s）兜住。票 D 把
-    憑證面 codify 之後，這裡跟著 `executor_credential_of` 的新簽章走即可，不必在
-    本模組另造一張表（那就是第二份真相）。
+    **票 D（#685）之後這裡是 per-(account, executor) 的。** 票 C 的原註解寫著
+    「`executor_credential_relpath` 目前是單一值……票 D 把憑證面 codify 之後，這裡跟著
+    `executor_credential_of` 的新簽章走即可，不必在本模組另造一張表」——本函式做的就是
+    那件事：多傳一個 `executor`，形狀（單檔 vs 導進 `cache` 的狀態樹）由 permgen 那張表
+    決定，本模組**不知道**也不需要知道差別。agy 的 `~/.gemini` 與 claude 的 `~/.claude`
+    因此**現在進得了指紋**（票 C 當時明列的已知限制解除）。
+
+    `(account, executor)` 不在表上時（例如 `copilot`，它不做 planning）permgen 會 raise
+    `UnregisteredExecutorCredentialError`，由 `compute_fingerprint` 的 `_safe` 收成
+    `<unresolved:UnregisteredExecutorCredentialError>`。那個標記是**穩定**的（同一個部署
+    上恆定），因此快取照常運作；而它一旦被登記進表，指紋就變、快取自動失效——與
+    「PATH 未宣告」那一格是同一條原則：**取不到答案本身也是一個會變的答案**。
+
+    取的是 `credential_token_path_of()`（**token 葉檔**）而不是登記表資產那個節點：
+    `HOME_REDIRECT_TREE` 的資產是一條 symlink，`stat` 它只看得到目標目錄的 mtime，而
+    token 就地覆寫時目錄 mtime 不變 ⇒ 「憑證換了」偵測不到。
     """
 
     from ..trust_root import permgen
@@ -256,8 +266,16 @@ def _credential_path(mode: str, env: Mapping[str, str]) -> str:
         home = (env.get("HOME") or "").strip()
         if not home:
             raise ValueError("HOME undeclared")
-        return os.path.join(home, layout.executor_credential_relpath)
-    return layout.executor_credential_of(layout.reviewer_planner_account)
+        # direct 模式跑在 Manager 帳號上，而 Manager **刻意沒有**任何登記表憑證資產
+        # （#672 的核心裁決）。因此這裡取的是「同一個 executor 在 job 帳號上的相對
+        # 落點」套到 Manager 的 HOME——那正是 direct 模式實際會解到的路徑。
+        prefix = layout.credential_prefix_of(layout.reviewer_planner_account)
+        credential = permgen.credential_for(prefix, executor)
+        relpath = layout.credential_relpath_of(credential)
+        if credential.token_leaf:
+            relpath = f"{relpath}/{credential.token_leaf}"
+        return os.path.join(home, relpath)
+    return layout.credential_token_path_of(layout.reviewer_planner_account, executor)
 
 
 def compute_fingerprint(
@@ -296,7 +314,9 @@ def compute_fingerprint(
         return _stat_marker(found, fields=_BINARY_STAT_FIELDS)
 
     def _credential() -> str:
-        return _stat_marker(_credential_path(mode, environ), fields=_FILE_STAT_FIELDS)
+        return _stat_marker(
+            _credential_path(mode, environ, identity.executor), fields=_FILE_STAT_FIELDS
+        )
 
     def _profile() -> str:
         return job_runner.resolve_hardening_profile(identity.executor)

--- a/paulsha_cortex/trust_root/permgen.py
+++ b/paulsha_cortex/trust_root/permgen.py
@@ -461,6 +461,29 @@ def _validate_credential_relpath(relpath: str) -> None:
         )
 
 
+#: HOME 相對路徑的形狀（#685）。與 :data:`_CREDENTIAL_RELPATH_RE` 的差別**只有一條**：
+#: 這裡允許單一 segment（`.codex`／`.gemini`／`.claude`）。理由是形狀不同——
+#: `IN_PLACE_FILE` 需要「檔案上面還有一層 root-owned 目錄」，因此至少兩段；
+#: `HOME_REDIRECT_TREE` 登記的是**那條 symlink 自己**，保護它的是 HOME 那一層
+#: （`scaffold_directories()` 產出 root:root 0755），所以一段就夠。
+#: 段名同樣限縮成無 shell metacharacter 且擋掉 `..`——值會被接成絕對路徑並嵌進 root
+#: 執行的 `ln`／`chown` 命令。
+_HOME_RELPATH_RE = re.compile(r"^[A-Za-z0-9._-]+(?:/[A-Za-z0-9._-]+)*$")
+
+
+def _validate_home_relpath(relpath: str) -> None:
+    if (
+        not isinstance(relpath, str)
+        or not _HOME_RELPATH_RE.match(relpath)
+        or any(seg in ("..", ".") for seg in relpath.split("/"))
+    ):
+        raise ValueError(
+            f"不是合法的 HOME 相對路徑：{relpath!r}。它會被接成 <帳號 HOME>/<relpath> "
+            "並嵌進 root 執行的 ln／chown 命令，只接受 "
+            "`^[A-Za-z0-9._-]+(?:/[A-Za-z0-9._-]+)*$` 且不得含 `.`／`..` 段。"
+        )
+
+
 # ---------------------------------------------------------------------------
 # 部署樹 toolchain 的實體形態（#640 實機盤點；#661 擴到非 executor）
 #
@@ -625,6 +648,244 @@ SERVICE_TOOLS: tuple[ToolchainProgram, ...] = (
 #: 部署樹 toolchain 的**完整**盤點（executor ∪ 非 executor）。落位計畫由它導出；
 #: `executor_hardening_profile()` 刻意只看 `EXECUTOR_TOOLS`。
 TOOLCHAIN_PROGRAMS: tuple[ToolchainProgram, ...] = EXECUTOR_TOOLS + SERVICE_TOOLS
+
+
+# ---------------------------------------------------------------------------
+# per-(account, executor) 憑證表（#685／#672 U-5 裁決；U-4 追認雙 independence domain）
+#
+# ## 這張表取代了什麼
+#
+# #640 落地時，「executor 的登入態長什麼樣」是**單一部署決定**：
+# `PathLayout.executor_credential_relpath`（預設 `.codex/auth.json`）。一個帳號因此只
+# 表達得了一份憑證，而三分／四分部署下 `cortex-reviewer-planner` 同時需要 codex 與 agy
+# 兩個 independence domain 的登入態（否則 `select_secondary_planner()` 結構性找不到異質
+# planner，見 #668／#672）。U-5 的裁決就是把它擴成**兩軸**：
+#
+#   - **executor 軸**＝:data:`EXECUTOR_CREDENTIALS`：一個 executor 的登入態是什麼形狀、
+#     落在 HOME 底下哪裡；
+#   - **account 軸**＝:data:`CREDENTIALED_ACCOUNTS`：哪個帳號**被核可**持有哪幾個
+#     executor 的登入態。
+#
+# 兩軸的交集就是登記表資產：`asset_paths()`／`scaffold_directories()`／
+# :data:`IN_PLACE_CONTENT_WRITE_ASSETS`／unit 的 `ReadWritePaths` 全部由它機械導出，
+# 加一格不必改產生器——這正是 #640 的 note 當年承諾、但因為只有一個純量而做不到的事。
+#
+# ## 為什麼形狀有兩種（#686 實測，design 未預期）
+#
+# design 假設所有 executor 的登入態都是**單檔**（codex 的 `auth.json`），因此 #640 裁決
+# (b) 的整套性質（檔 job-owned 0600／父目錄 root-owned ⇒ 能改內容、不能增刪換）對它成立。
+# 票 E（#686）在**完整 reviewer unit 沙箱**下逐 executor 實測，推翻了這個假設：
+#
+#   - `codex` 需要 **`$CODEX_HOME` 整個目錄可寫**（`state_5.sqlite`／`logs_2.sqlite`／
+#     `sessions/`／`skills/`／`plugins/`／`thread-writer-locks/`…）。實機錯誤逐字：
+#     `Error: failed to initialize in-process app-server client: Read-only file system`。
+#     **只放行 `auth.json` 一個檔，codex 連起都起不來**；且症狀與 cwd 無關（cwd 換成可寫
+#     的 `/tmp` 症狀相同，維持唯讀 cwd 只把 `CODEX_HOME` 指到可寫目錄則 rc=0）。
+#   - `agy` 需要 `~/.gemini` 底下一整棵可寫狀態樹（conversations SQLite、crashes、
+#     presence lock、builtin skills，並自解出一個 17 MB 的 `bin/webm_encoder`）。
+#   - `claude` 在 job 沙箱下 CLI 走得完整條（rc=0），但回 `Not logged in`——它需要
+#     `~/.claude` 底下的登入態，同樣是一棵它自己會寫的樹。
+#
+# 因此表上有兩種形狀，見 :class:`CredentialShape`。**兩種形狀並存不是過渡態**：builder
+# 的 codex 至今是 `IN_PLACE_FILE`（已部署、有實測、有 runbook 反向驗證），本票不動它；
+# reviewer/planner 三個 executor 全是 `HOME_REDIRECT_TREE`。「同一個 executor 在不同帳號
+# 上可以是不同形狀」正是 U-5 要求 per-(account, executor) 而不是 per-executor 的理由。
+# ---------------------------------------------------------------------------
+
+class CredentialShape(Enum):
+    """executor 登入態在帳號 HOME 底下的**形狀**。兩種形狀的保護機制完全不同。"""
+
+    #: **單檔、就地 `O_TRUNC` 覆寫**（#640 裁決 (b)）。檔案 job-owned 0600、父目錄維持
+    #: root-owned ⇒ job 改得了內容、建不了新檔、刪不掉、也換不掉同目錄下的 root-owned
+    #: 檔（例如 `codex-hooks`）。`ReadWritePaths` 因此掛在**檔案本身**
+    #: （:data:`IN_PLACE_CONTENT_WRITE_ASSETS`），父目錄連 mount 層都不開放可寫。
+    #: 代價（裁決刻意接受）：以「暫存檔 ＋ rename」做 refresh 的 CLI 走不通。
+    IN_PLACE_FILE = "in-place-file"
+
+    #: **HOME 底下的一整棵可寫狀態樹**，以一條 **root-owned symlink** 導進該帳號既有的
+    #: `cache`（`<HOME>/<relpath> -> <HOME>/cache/<target>`）。
+    #:
+    #: 為什麼是這個形狀而不是「把 HOME 那一層目錄開成可寫」：
+    #:
+    #: 1. **不新增任何可寫面**——`cache` 早已在 job 模板 unit 的 `ReadWritePaths` 內
+    #:    （`PathLayout.job_extra_write_paths`），因此登記這一格之後 unit 的
+    #:    `ReadWritePaths=` **逐字不變**（`test_home_redirect_adds_no_writable_surface`
+    #:    機械釘住）。executor 能做的事，該帳號今天就已經能做。
+    #: 2. **symlink 本身放在 root-owned 的 HOME 裡**（`scaffold_directories()` 產出
+    #:    `<HOME>` 為 root:root 0755），因此 job **換不掉它的指向**——換 symlink 需要對
+    #:    父目錄的寫入權。
+    #: 3. **不必動 job 的環境變數**。`CODEX_HOME`／`GEMINI_*` 這類覆寫要經
+    #:    `job_runner.build_job_env()` 的白名單，那是另一條要維護的放行面；symlink 讓
+    #:    executor 的**預設**路徑解析就落在對的地方。
+    #:
+    #: 代價（明講，見 CHANGELOG 的 R-6）：這棵樹由 job 帳號擁有，因此樹裡的憑證葉檔
+    #: （`auth.json`／`.credentials.json`）**可被該 job 刪除或替換**——它換來的是
+    #: 「codex／claude 能不能起得來」。影響面限於該帳號自己的登入態；同目錄下**不得**
+    #: 再放任何 root-owned 的 enforcement 檔（見 `reviewer-planner-codex-hooks` 那筆
+    #: deferred 與 U-9）。
+    HOME_REDIRECT_TREE = "home-redirect-tree"
+
+
+@dataclass(frozen=True)
+class ExecutorCredential:
+    """per-(account, executor) 表的 **executor 軸**：一個 executor 的登入態長什麼樣。"""
+
+    executor: str
+    shape: CredentialShape
+    #: HOME 相對落點。`HOME_REDIRECT_TREE` 時＝那條 symlink 自己。
+    #: `None`＝由 :attr:`PathLayout.executor_credential_relpath` 這個既有部署決定欄位
+    #: 供給（只有 :data:`PRIMARY_CREDENTIAL_EXECUTOR` 那一列會是 `None`，理由見該常數）。
+    relpath: str | None
+    #: 登記表資產 id 的後綴（`<帳號前綴>-<suffix>`）。
+    asset_suffix: str
+    #: `HOME_REDIRECT_TREE` 的 symlink 目標，**相對於該帳號的 `cache`**。刻意不是任意
+    #: 絕對路徑：目標必須落在該帳號本來就可寫的那一層裡，否則「不新增可寫面」不成立。
+    cache_target: str | None = None
+    #: 這一格裡真正承載 token 的葉檔（相對於 `relpath`）。只進註解與 runbook，不另立資產
+    #: ——它落在 job-owned 樹裡，權限由 unit 的 `UMask=0077` 決定，再登記一次是第二份真相。
+    token_leaf: str = ""
+    note: str = ""
+
+    def __post_init__(self) -> None:
+        if self.shape is CredentialShape.HOME_REDIRECT_TREE and not self.cache_target:
+            raise ValueError(f"{self.executor}：HOME_REDIRECT_TREE 必須宣告 cache_target")
+        if self.relpath is not None:
+            _validate_home_relpath(self.relpath)
+        if self.cache_target is not None:
+            _validate_home_relpath(self.cache_target)
+
+
+#: `relpath is None` 的那一列所對應的 executor。**它與
+#: :attr:`PathLayout.executor_credential_relpath` 是同一個部署決定的兩半**：那個欄位
+#: 存在的理由是「換 primary executor 時只改一個值」（#640），把它的值再抄一份進本表
+#: 就是第二份真相。因此本表對它留 `None`，由 layout 供給。
+PRIMARY_CREDENTIAL_EXECUTOR = "codex"
+
+#: **executor 軸**。順序＝資產在登記表裡的出現順序。
+EXECUTOR_CREDENTIALS: tuple[ExecutorCredential, ...] = (
+    ExecutorCredential(
+        "codex", CredentialShape.IN_PLACE_FILE,
+        relpath=None, asset_suffix="executor-credential",
+        token_leaf="",
+        note=(
+            "#640 裁決 (b) 的原形態：單檔 `~/.codex/auth.json`。**只有 builder 還是這個"
+            "形狀**——#686 實測 codex 需要 `$CODEX_HOME` 整個目錄可寫，因此凡是要在降權"
+            "模板 unit 下**真的跑起來**的帳號都必須改走 `codex-state`（下一列）。"
+            "builder 維持原形態是因為那份部署已存在、有 runbook 第 4e-2 步的反向驗證，"
+            "改它同時會賣掉 `codex-hooks` 的 enforcement（見 U-9），屬 operator 裁決。"
+        ),
+    ),
+    ExecutorCredential(
+        "codex", CredentialShape.HOME_REDIRECT_TREE,
+        relpath=".codex", asset_suffix="codex-state",
+        cache_target="codex", token_leaf="auth.json",
+        note=(
+            "codex 的 `$CODEX_HOME` 整棵（預設就是 `~/.codex`）。#686 在完整 reviewer "
+            "unit 沙箱下實測：唯讀時 `failed to initialize in-process app-server client: "
+            "Read-only file system`，且**與 cwd 無關**；只把 `CODEX_HOME` 指到可寫目錄"
+            "即 rc=0、輸出正確。底下會出現 `state_5.sqlite`／`logs_2.sqlite`／"
+            "`queue_1.sqlite`／`memories_1.sqlite`／`sessions/`／`skills/`／`plugins/`／"
+            "`thread-writer-locks/`／`models_cache.json`／`installation_id`——**檔名帶版本"
+            "序號**，逐項列舉會在下一次 CLI 升版時無聲失效，因此放行的是整棵樹而不是清單。"
+        ),
+    ),
+    ExecutorCredential(
+        "agy", CredentialShape.HOME_REDIRECT_TREE,
+        relpath=".gemini", asset_suffix="agy-state",
+        cache_target="gemini", token_leaf="antigravity-cli/antigravity-oauth-token",
+        note=(
+            "agy 的可寫狀態樹（U-7 裁決＝design 的 (a)：登記成 symlink 類資產）。agy 執行"
+            "時往 `~/.gemini/antigravity-cli/` 寫 conversations SQLite、crashes、presence "
+            "lock、builtin skills，並**自解出一個 17 MB 的可執行檔** `bin/webm_encoder`。"
+            "0818 實測：以 `cortex-reviewer-planner` 身分、在逐條複製落檔 unit 全部 "
+            "property 的沙箱下跑 `agy --print … --mode plan --sandbox`，rc=0、輸出逐位元"
+            "等於 `probe_agy_capability()` 的 expected（#686 複驗同一結論）。"
+        ),
+    ),
+    ExecutorCredential(
+        "claude", CredentialShape.HOME_REDIRECT_TREE,
+        relpath=".claude", asset_suffix="claude-state",
+        cache_target="claude", token_leaf=".credentials.json",
+        note=(
+            "claude 的登入態與狀態樹。#686 實測：job 沙箱下 CLI **走得完整條**（rc=0），"
+            "回的是 `{\"is_error\":true,…,\"result\":\"Not logged in · Please run /login\"}`"
+            "——擋住的是憑證，不是加固面。job 模式下 `CLAUDE_CONFIG_DIR` 在 "
+            "`job_runner.DENIED_ENV_NAMES` 內（design D-g 的帳號隔離取代了 in-process 的"
+            "一次性 config dir），因此 claude 解到的就是 `$HOME/.claude`——本列登記的就是"
+            "那一條。"
+        ),
+    ),
+)
+
+#: **account 軸**：登記表資產 id 的帳號前綴 → 該帳號**被核可持有登入態**的 (executor,
+#: shape) 組合。前綴（而非 OS 帳號名）當 key 是刻意的——資產 id 必須與帳號改名無關。
+#:
+#: **`reviewer-planner` 有三格，這是 U-4 的追認範圍**：該帳號同時持有 openai（codex）、
+#: google（agy）與 anthropic（claude）三個 provider 的登入態。design 的安全退步 **R-3**
+#: （該帳號被攻陷時多邊 token 一起失，而 planner 正是吃 untrusted issue 內容的角色）是
+#: **明文接受的有界殘餘風險**，不另拆帳號。它在後續任何「planner 攻擊面」討論中**不得**
+#: 被當成未知——U-4 的裁決逐字如此。
+#:
+#: **`builder` 只有一格**，且刻意維持 `IN_PLACE_FILE`：builder 不做 planning，不需要
+#: 異質性；擴大它的 provider 曝險面買不到任何東西。
+CREDENTIALED_ACCOUNTS: Mapping[str, tuple[tuple[str, CredentialShape], ...]] = (
+    MappingProxyType({
+        "builder": (("codex", CredentialShape.IN_PLACE_FILE),),
+        "reviewer-planner": (
+            ("codex", CredentialShape.HOME_REDIRECT_TREE),
+            ("agy", CredentialShape.HOME_REDIRECT_TREE),
+            ("claude", CredentialShape.HOME_REDIRECT_TREE),
+        ),
+    })
+)
+
+
+class UnregisteredExecutorCredentialError(KeyError):
+    """(account, executor) 這一格不在 :data:`CREDENTIALED_ACCOUNTS` 上。
+
+    **fail-closed 而不是回一個猜出來的路徑**：猜錯的後果是「指紋盯著一個不存在的檔、
+    unit 放行一條錯的路徑」，兩者都會靜默通過。呼叫端（例如 probe 快取的指紋計算）
+    把它收成一個**可辨識的標記**，而不是當成「憑證不存在」。
+    """
+
+
+def _credential_row(prefix: str, executor: str, shape: CredentialShape) -> ExecutorCredential:
+    for cred in EXECUTOR_CREDENTIALS:
+        if cred.executor == executor and cred.shape is shape:
+            return cred
+    raise UnregisteredExecutorCredentialError(f"{prefix}:{executor}:{shape.value}")
+
+
+def credential_asset_id(prefix: str, credential: ExecutorCredential) -> str:
+    """`<帳號前綴>-<suffix>`。與 layout 無關 ⇒ 換帳號名不會改資產 id。"""
+    return f"{prefix}-{credential.asset_suffix}"
+
+
+def credential_rows() -> tuple[tuple[str, ExecutorCredential], ...]:
+    """把兩軸展開成 `(帳號前綴, 該格的 executor 憑證)`。**唯一的展開點。**"""
+    rows: list[tuple[str, ExecutorCredential]] = []
+    for prefix, cells in CREDENTIALED_ACCOUNTS.items():
+        for executor, shape in cells:
+            rows.append((prefix, _credential_row(prefix, executor, shape)))
+    return tuple(rows)
+
+
+def credential_asset_ids(shape: CredentialShape | None = None) -> tuple[str, ...]:
+    """本表產生的登記表資產 id（可依形狀過濾）。`_FILE_ASSET_IDS`／
+    :data:`IN_PLACE_CONTENT_WRITE_ASSETS`／:data:`SYMLINK_ASSETS` 全部由它導出。"""
+    return tuple(
+        credential_asset_id(prefix, cred)
+        for prefix, cred in credential_rows()
+        if shape is None or cred.shape is shape
+    )
+
+
+def credential_for(prefix: str, executor: str) -> ExecutorCredential:
+    """該帳號在該 executor 上被核可的憑證形狀；沒有這一格就 raise（fail-closed）。"""
+    for cell_prefix, cred in credential_rows():
+        if cell_prefix == prefix and cred.executor == executor:
+            return cred
+    raise UnregisteredExecutorCredentialError(f"{prefix}:{executor}")
 
 
 @dataclass(frozen=True)
@@ -1086,6 +1347,10 @@ class PermissionEntry:
     writer_accounts: frozenset[str]
     reader_accounts: frozenset[str]
     acls: tuple[AclEntry, ...] = ()
+    #: 本資產是一條 **symlink**（#685）。與 `is_directory` 互斥；決定 `commands()` 出
+    #: `ln -sfn` ＋ `chown -h` 而不是裸 `chown`／`chmod`（後兩者在 Linux 上跟著 symlink
+    #: 走，會改到**目標**而不是 symlink 本身）。由 :data:`SYMLINK_ASSETS` 機械導出。
+    is_symlink: bool = False
     #: True＝容器的 per-child owner 由 launcher 在 spawn 時逐案 chown（如 worktree pool）。
     runtime_managed: bool = False
     #: 現況 writer（含 ANY_SAME_UID）——保留供對照，非目標。
@@ -1108,6 +1373,7 @@ class PermissionEntry:
             "group": self.group,
             "mode": self.mode_str,
             "is_directory": self.is_directory,
+            "is_symlink": self.is_symlink,
             "writer_accounts": sorted(self.writer_accounts),
             "reader_accounts": sorted(self.reader_accounts),
             "acls": [
@@ -1120,12 +1386,24 @@ class PermissionEntry:
             "open_points": list(self.open_points),
         }
 
-    def commands(self, path: str) -> list[str]:
+    def commands(self, path: str, link_target: str | None = None) -> list[str]:
         """產生本資產的 chown／chmod／setfacl 命令字串（**只回傳字串，不執行**）。
 
         `path` 由呼叫端提供（runbook 以 shell 變數帶入真實路徑）；未提供具體路徑時
         以清楚標記的 placeholder 呈現。
+
+        **symlink 資產（#685）走另一組動詞，這不是風格選擇。** Linux 沒有 `lchmod`，
+        而 `chown`／`chmod` 對 symlink 一律**跟著走**：對 `~/.gemini` 裸 `chown` 會把
+        `cache/gemini` **那棵樹**的 owner 改掉，而那棵樹歸 job 帳號正是本形狀的全部
+        重點。因此改出 `ln -sfn`（建立／重指，冪等）＋ `chown -h`（只改 symlink 自己）
+        ，且**不出 `chmod`**——symlink 的 mode 位在 Linux 上沒有語意。
         """
+        if self.is_symlink:
+            target = link_target or f"<TARGET:{self.asset_id}>"
+            return [
+                f"ln -sfn {target} {path}",
+                f"chown -h {self.owner}:{self.group} {path}",
+            ]
         cmds = [
             f"chown {self.owner}:{self.group} {path}",
             f"chmod {self.mode_str} {path}",
@@ -1164,17 +1442,32 @@ _DIR_ASSET_IDS = frozenset({
     "commit-spool",                 # <coordinator>/commit-spool/<job-id>/
     "executor-toolchain",           # <deploy_root>/toolchain/（四個模型 CLI 的落點）
 })
+#: 登記表上是 **symlink** 的資產（#685／U-7）。
+#:
+#: 它們**不是目錄**（不得 `install -d`）也不是普通檔（不得裸 `chown`／`chmod`——兩者在
+#: Linux 上都**跟著 symlink 走**，套在 `.gemini` 上會改到 `cache/gemini` 那棵樹本身的
+#: owner，而那正是要保護的東西）。命令形態改由 `PermissionEntry.commands()` 出
+#: `ln -sfn` ＋ `chown -h`，見該方法。
+#:
+#: 由 :func:`credential_asset_ids` 機械導出，不是手寫清單：往
+#: :data:`CREDENTIALED_ACCOUNTS` 加一格 `HOME_REDIRECT_TREE`，這裡自動跟著長。
+SYMLINK_ASSETS: frozenset[str] = frozenset(
+    credential_asset_ids(CredentialShape.HOME_REDIRECT_TREE)
+)
+
 _FILE_ASSET_IDS = frozenset({
     "control-daemon-lock",
     "control-status",
-    # #640：憑證是**單一檔**（`<HOME>/<relpath>`）。這條明列不是裝飾——file/dir 的
-    # 判定直接決定 permgen 會不會把一整個目錄 chown 給 job 帳號，而該目錄必須維持
-    # root-owned 才有「能改內容、不能增刪換」那條性質。
-    "builder-executor-credential",
-    # #666：`~/.config/gh/` 底下的兩個檔，理由與上一條逐字相同——那一層目錄必須維持
-    # root-owned，`hosts.yml` 與 `config.yml` 才能是**不同 owner** 的兩個檔。
+    # #666：`~/.config/gh/` 底下的兩個檔——那一層目錄必須維持 root-owned，`hosts.yml`
+    # 與 `config.yml` 才能是**不同 owner** 的兩個檔。
     "manager-gh-credential",
     "manager-gh-config",
+    # #640／#685：憑證那一族**一律不是目錄**。這條明列不是裝飾——file/dir 的判定直接
+    # 決定 permgen 會不會把一整層 `install -d` 出來再 chown 給 job 帳號：
+    #   - `IN_PLACE_FILE` 是單檔，父目錄必須維持 root-owned 才有「能改內容、不能增刪換」；
+    #   - `HOME_REDIRECT_TREE` 是 **symlink**，`install -d` 會在它的位置建出一個真目錄，
+    #     把整條導向 `cache` 的機制無聲換掉（見 :data:`SYMLINK_ASSETS`）。
+    *credential_asset_ids(),
 })
 
 
@@ -1394,6 +1687,7 @@ def build_entry(asset: TrustRootAsset, scheme: UidScheme) -> PermissionEntry:
         group=scheme.group_of(owner),
         mode=mode,
         is_directory=is_dir,
+        is_symlink=asset.asset_id in SYMLINK_ASSETS,
         writer_accounts=writer_accounts,
         reader_accounts=reader_accounts,
         acls=tuple(acls),
@@ -1567,6 +1861,10 @@ def plan_to_commands(
     """
     scheme = _scheme_for(plan, scheme)
     assert_principals_resolved(plan, scheme)
+    # #685：symlink 資產的目標由 layout 導出（`asset_paths()` 給的是 symlink 自己）。
+    # 未給 layout 時退回 `DEFAULT_LAYOUT`，與下方 traverse 那一節同一個取法；未給
+    # `path_of`（placeholder 模式）時 `commands()` 自己會出 `<TARGET:asset_id>`。
+    link_of = (layout or DEFAULT_LAYOUT).symlink_targets() if path_of else None
     lines: list[str] = [
         f"# trust-root Phase 2b 權限套用命令（scheme={plan.scheme_id}）",
         "# 由 permgen 機械產生；operator 逐項 review 後手動 sudo 執行。",
@@ -1584,8 +1882,25 @@ def plan_to_commands(
             lines.append(f"#   後續依賴：{op}")
         if per_job:
             lines.append("#   per-job：由降權啟動器在 spawn 時套用，setup 階段不執行。")
-        cmds = list(e.commands(path))
-        if e.is_directory:
+        link_target = (link_of or {}).get(e.asset_id)
+        cmds = list(e.commands(path, link_target))
+        if e.is_symlink:
+            # #685：symlink 的守衛掛在**父目錄**上，不是自己身上——`ln` 是建立動作，
+            # 「不存在就跳過」對它沒有意義；真正要跳過的情形是「本方案沒有這個帳號、
+            # 那個 HOME 根本不存在」（二分方案下 `cortex-reviewer-planner` 就是如此）。
+            # 這與葉檔的 `[ ! -e <檔> ]` 守衛是同一條原則的兩個位置。
+            parent = _parent_dir(path)
+            lines.append(
+                f"#   symlink 守衛：{parent} 不存在時跳過（本方案沒有這個帳號的 HOME）。"
+            )
+            lines.append(
+                "#   目標落在該帳號既有的 cache 底下 ⇒ 不新增任何可寫面；symlink 自己"
+            )
+            lines.append(
+                "#   放在 root-owned 的 HOME 裡 ⇒ job 換不掉它的指向。"
+            )
+            cmds = [f"[ ! -e {parent} ] || {cmd}" for cmd in cmds]
+        elif e.is_directory:
             # 目錄一定先建起來，後續 chown／chmod／setfacl 必然有對象。
             cmds.insert(0, f"install -d {path}")
         else:
@@ -1897,6 +2212,28 @@ class PathLayout:
         """
         return ":".join((self.toolchain_bin,) + JOB_PATH_SYSTEM_TAIL)
 
+    def job_home_value(self, account: str) -> str:
+        """job 應該拿到的 `HOME`（＝ Manager 端 `PSC_<ROLE>_HOME` 的值，#685／#686）。
+
+        **它與 PATH 是同一個形狀的缺口**（#679）：模板模式下 `cortex-job-shim` 以
+        `os.execvpe(command[0], command, job_env)` 把環境**整份換掉**，因此 unit 上那行
+        `Environment=HOME=` 到不了模型行程；`HOME` 只能來自 spec 的 env，而那份 env 由
+        `job_runner.build_job_env()` 從 Manager 端的 `PSC_<ROLE>_HOME` 取。實機 0818：
+        `PSC_BUILDER_HOME` **有**宣告，`PSC_REVIEWER_HOME`／`PSC_GATE_HOME` **沒有** ⇒
+        降權 planning 的 agy 死在
+        `resolving log directory: getting home directory: $HOME is not defined`（#686）。
+
+        **這條與憑證面是綁在一起的**：#685 登記的三份登入態全部以 `$HOME` 為根
+        （`~/.codex`／`~/.gemini`／`~/.claude` 三條 symlink），`HOME` 解不到時它們在 job
+        內**一條都不存在**——codify 出來的路徑會全部落空，而症狀（`Not logged in`／
+        `$HOME is not defined`）與「憑證沒放好」長得一模一樣。產生器出這個值，是為了讓
+        operator 落進 root-owned EnvironmentFile 的那一行有**單一來源**，不必手抄。
+
+        本函式只**出值**，不改 `job_runner` 的 fail-open/closed 語意——那屬於獨立票
+        （#686 已把理由寫進 `build_job_env()` 的 docstring）。
+        """
+        return self.home_of(account)
+
     def preflight_command_value(self) -> str:
         """`PSC_PREFLIGHT_CMD` 應該拿到的值（#661）。
 
@@ -1979,18 +2316,124 @@ class PathLayout:
         """該帳號的 `~/.codex`。root-owned——job 不得替換自己的 hooks。"""
         return f"{self.home_of(account)}/.codex"
 
-    def executor_credential_of(self, account: str) -> str:
-        """該帳號的 executor 憑證檔（#640 裁決 (b)）。**檔案由該帳號擁有**（0600）。
+    def credential_relpath_of(self, credential: ExecutorCredential) -> str:
+        """該憑證在帳號 HOME 底下的相對落點（`None` 的那一列由本 layout 供給）。"""
+        if credential.relpath is None:
+            return self.executor_credential_relpath
+        return credential.relpath
 
-        與 `codex_hooks_dir_of()` 刻意落在**同一層**目錄：那一層是 root-owned 的骨架
-        目錄，因此 job 能就地改寫自己這份憑證的內容（refresh），卻建不了新檔、刪不掉、
-        也換不掉同目錄下的 `hooks.json`——「增／刪／換」需要的是**目錄**的寫入權。
+    def executor_credential_of(
+        self, account: str, executor: str = PRIMARY_CREDENTIAL_EXECUTOR,
+    ) -> str:
+        """該帳號**該 executor** 的登入態落點（#640 裁決 (b)／#685 U-5 擴表）。
+
+        **簽章多了 `executor`，預設值是 :data:`PRIMARY_CREDENTIAL_EXECUTOR`**——單參數
+        的既有呼叫端（票 C 的 probe 快取指紋、runbook、測試）行為逐字不變，而需要表達
+        「同一個帳號的第二／第三份憑證」的呼叫端多給一個名字即可。
+
+        回傳值的**形狀跟著 (account, executor) 這一格走**（:data:`CREDENTIALED_ACCOUNTS`）：
+
+        - `IN_PLACE_FILE`（builder×codex）：回傳的是**那個檔**（`~/.codex/auth.json`）。
+          它與 `codex_hooks_dir_of()` 落在同一層 root-owned 目錄，因此 job 改得了內容、
+          建不了新檔、刪不掉、也換不掉同目錄下的 `hooks.json`。
+        - `HOME_REDIRECT_TREE`（reviewer-planner×{codex, agy, claude}）：回傳的是那條
+          **root-owned symlink**（`~/.codex`／`~/.gemini`／`~/.claude`），真正的 token
+          葉檔在它底下（`credential.token_leaf`）。
+
+        **帳號不在表上時**（`cortex-gate` 不跑模型；二分方案的 `cortex-svc` 沒有登記表
+        憑證資產）退回 #640 的單一部署決定 `executor_credential_relpath`——那正是本函式
+        在 #685 之前對**任何**帳號的行為，因此「這個帳號有沒有憑證骨架」這類既有查詢
+        逐字不變。**但只對 primary executor 退回**：問一個未登記帳號的第二／第三份憑證
+        沒有正確答案，猜一條路徑的後果是「指紋盯著一個不存在的檔、unit 放行一條錯的
+        路徑」，兩者都會靜默通過 ⇒ raise :class:`UnregisteredExecutorCredentialError`。
         """
-        return f"{self.home_of(account)}/{self.executor_credential_relpath}"
+        try:
+            prefix = self.credential_prefix_of(account)
+        except UnregisteredExecutorCredentialError:
+            if executor != PRIMARY_CREDENTIAL_EXECUTOR:
+                raise
+            return f"{self.home_of(account)}/{self.executor_credential_relpath}"
+        credential = credential_for(prefix, executor)
+        return f"{self.home_of(account)}/{self.credential_relpath_of(credential)}"
 
-    def executor_credential_dir_of(self, account: str) -> str:
-        """憑證檔的父目錄。**必須 root-owned**——裁決 (b) 的性質全部落在這一層。"""
-        return _parent_dir(self.executor_credential_of(account))
+    def executor_credential_dir_of(
+        self, account: str, executor: str = PRIMARY_CREDENTIAL_EXECUTOR,
+    ) -> str:
+        """`IN_PLACE_FILE` 憑證檔的父目錄。**必須 root-owned**——裁決 (b) 的性質全部
+        落在這一層。`HOME_REDIRECT_TREE` 的那一格回傳的是 symlink 的父目錄（＝HOME）。
+        """
+        return _parent_dir(self.executor_credential_of(account, executor))
+
+    def credential_token_path_of(
+        self, account: str, executor: str = PRIMARY_CREDENTIAL_EXECUTOR,
+    ) -> str:
+        """真正承載 token 的那個**葉檔**（`HOME_REDIRECT_TREE` 時是樹裡的一格）。
+
+        與 :meth:`executor_credential_of` 的差別只有一個消費者，但那個差別是必要的：
+        登記表要的是「要保護／要放行的那個節點」（symlink 或單檔），而**指紋**要的是
+        「refresh 之後會變的那個檔」。拿 symlink 或目錄去 `stat` 只看得到目錄本身的
+        mtime——token 就地覆寫時它不變，於是「憑證換了」偵測不到（票 C 的
+        `test_cache_invalidated_by_credential_fingerprint` 釘的正是這條）。
+
+        `token_leaf` 為空（`IN_PLACE_FILE`）時兩者相同。
+        """
+        base = self.executor_credential_of(account, executor)
+        try:
+            credential = credential_for(self.credential_prefix_of(account), executor)
+        except UnregisteredExecutorCredentialError:
+            return base
+        return f"{base}/{credential.token_leaf}" if credential.token_leaf else base
+
+    def credential_target_of(self, account: str, credential: ExecutorCredential) -> str:
+        """`HOME_REDIRECT_TREE` 的 symlink 目標絕對路徑（恆在該帳號的 `cache` 底下）。"""
+        if credential.cache_target is None:
+            raise ValueError(f"{credential.executor}：不是 HOME_REDIRECT_TREE，沒有目標")
+        return f"{self.cache_of(account)}/{credential.cache_target}"
+
+    def credential_accounts(self) -> Mapping[str, str]:
+        """登記表資產 id 的**帳號前綴** → OS 帳號名。**只有這裡把前綴接回帳號欄位。**
+
+        前綴是資產 id 的一部分（因此與帳號改名無關），OS 帳號名則是部署決定欄位。
+        兩者的對應寫在這一支函式裡，`asset_paths()`／`scaffold_directories()` 都從這裡取。
+        """
+        return MappingProxyType({
+            "builder": self.builder_account,
+            "reviewer-planner": self.reviewer_planner_account,
+        })
+
+    def credential_prefix_of(self, account: str) -> str:
+        """OS 帳號名 → 資產 id 前綴（反查）。查不到即 fail-closed。"""
+        for prefix, name in self.credential_accounts().items():
+            if name == account:
+                return prefix
+        raise UnregisteredExecutorCredentialError(account)
+
+    def credential_placements(self) -> tuple[tuple[str, str, str, ExecutorCredential], ...]:
+        """per-(account, executor) 表的**絕對路徑展開**：
+        `(asset_id, account, 絕對路徑, 該格的憑證形狀)`。
+
+        `asset_paths()`／`scaffold_directories()`／`symlink_targets()`／unit 註解全部由
+        本函式導出——加一格憑證只改 :data:`CREDENTIALED_ACCOUNTS`，產生器一行都不必動。
+        """
+        accounts = self.credential_accounts()
+        rows: list[tuple[str, str, str, ExecutorCredential]] = []
+        for prefix, credential in credential_rows():
+            account = accounts[prefix]
+            rows.append((
+                credential_asset_id(prefix, credential),
+                account,
+                f"{self.home_of(account)}/{self.credential_relpath_of(credential)}",
+                credential,
+            ))
+        return tuple(rows)
+
+    def symlink_targets(self) -> dict[str, str]:
+        """symlink 型資產 → 它應該指向的絕對路徑（:data:`SYMLINK_ASSETS` 的值那一半）。"""
+        return {
+            asset_id: self.credential_target_of(account, credential)
+            for asset_id, account, _path, credential in self.credential_placements()
+            if credential.shape is CredentialShape.HOME_REDIRECT_TREE
+        }
 
     def gitconfig_of(self, account: str) -> str:
         """該帳號的 `~/.gitconfig`。root-owned——job 不得替換自己的 git 設定（#623）。
@@ -2109,11 +2552,16 @@ class PathLayout:
             "builder-gitconfig": self.gitconfig_of(self.builder_account),
             "reviewer-planner-gitconfig": self.gitconfig_of(self.reviewer_planner_account),
             "manager-gitconfig": self.gitconfig_of(self.manager_account),
-            # #640：四個模型 executor 的部署樹落點 ＋ 兩個 job 帳號各自的憑證。
+            # #640：四個模型 executor 的部署樹落點。
             "executor-toolchain": self.toolchain_root,
-            "builder-executor-credential": self.executor_credential_of(
-                self.builder_account
-            ),
+            # #685（#672 票 D／U-4／U-5）：per-(account, executor) 憑證表的展開。
+            # 逐項寫死換成由 `CREDENTIALED_ACCOUNTS` × `EXECUTOR_CREDENTIALS` 導出——
+            # 「機制是 per-account 的、登記表只登記其中一份」那個結構性缺口（#666 的
+            # deferred 第 1／3 項）就是逐項寫死造成的。
+            **{
+                asset_id: path
+                for asset_id, _account, path, _credential in self.credential_placements()
+            },
             # #666：Manager 的 gh 登入態。**兩個檔刻意不同 owner**——`hosts.yml` 承載
             # token（要 refresh ⇒ 服務帳號擁有），`config.yml` 是偏好設定（可宣告
             # `!` shell alias ⇒ 必須 root-owned 唯讀）。
@@ -2170,6 +2618,11 @@ class PathLayout:
             "combo-card-override": f"{a}/config/combos",
             "handoff-manifest": f"{job}/.psc-handoff.json",
             "runtime-bootstrap-env": self.env_file,
+            # **只有 builder 這一份，而 #685 之後這是一條有結論的事實、不再是「還沒補」**：
+            # reviewer／planner 帳號的 `~/.codex` 是導進 `cache` 的 symlink（#686 實測
+            # codex 需要 `$CODEX_HOME` 整棵可寫），hooks 若落在那棵樹裡就由 job 帳號擁有
+            # ⇒ 擋不住替換 ⇒ 登記成 root-owned 的 Tier-0 資產是做不到的事。因此它**仍在**
+            # `deferred_run_dependencies()`，並升為 U-9 交 operator 裁決。
             "codex-hooks": f"{self.builder_home}/.codex/hooks.json",
             "work-items-yaml": f"{job}/.cortex/work-items.yaml",
         }
@@ -2196,20 +2649,58 @@ class PathLayout:
         account_dirs: list[tuple[str, str, str, int]] = []
         for account in service_accounts:
             account_dirs.append((self.home_of(account), root, g(root), 0o755))
-            if account in job_accounts:
+            account_dirs.append((self.cache_of(account), account, g(account), 0o700))
+        # #685：憑證那一族的骨架**由 per-(account, executor) 表導出**，不再逐項寫死。
+        # 兩種形狀各自要先存在的東西不同，而「哪個帳號是哪種形狀」是表上的一格：
+        #
+        #   - `IN_PLACE_FILE`：憑證檔的**父目錄**必須 root-owned（#640 裁決 (b) 的性質
+        #     全部落在這一層——job 因此改得了內容，卻建不了新檔、刪不掉、也換不掉同
+        #     目錄下的 root-owned `hooks.json`）。預設 relpath 下這一層就是 `~/.codex`，
+        #     `codex-hooks` 也住在裡面，去重後只出現一次。
+        #   - `HOME_REDIRECT_TREE`：symlink 自己由權限計畫的 `ln -sfn` 落位；骨架要先
+        #     建的是它的**目標**——那一格落在該帳號的 `cache` 底下，由**該帳號**擁有
+        #     0700。這一層不建的話，`~/.gemini` 會是一條懸空 symlink，而建目錄的
+        #     syscall 對懸空 symlink 回 `EEXIST`（**不是**「建出目標」）——executor 於是
+        #     死在一個與權限完全無關的錯誤上。
+        #
+        # 兩者的保護都不是寫在這裡的字面量：symlink 換不掉是因為 HOME 那一層 root-owned
+        # （上面那一行），目標不新增可寫面是因為它在 `cache` 裡（`_minimize()` 會吃掉）。
+        for _asset_id, account, path, credential in self.credential_placements():
+            if account not in job_accounts:
+                # 本方案沒有這個帳號（二分把 reviewer／planner 併進 `cortex-svc`），
+                # 或它不跑模型（`cortex-gate`）——都不該生出這一層。
+                continue
+            if credential.shape is CredentialShape.IN_PLACE_FILE:
+                account_dirs.append((_parent_dir(path), root, g(root), 0o755))
+            else:
+                account_dirs.append((
+                    self.credential_target_of(account, credential),
+                    account, g(account), 0o700,
+                ))
+        # 跑模型的 job 帳號還要一個 root-owned 的 `~/.codex`（hooks 不得被 job 替換）
+        # ——**但只有 codex 憑證是 `IN_PLACE_FILE` 的那些**。`HOME_REDIRECT_TREE` 的帳號
+        # 上 `~/.codex` 是一條 symlink，在這裡建出同名的真目錄會把整條導向 `cache` 的
+        # 機制無聲換掉（症狀是 codex 又回到「起不來」，而現場看起來一切正常）。
+        #
+        # 表上查無的 job 帳號（二分的 `cortex-svc`）維持 #640 的既有形態不變：它沒有
+        # 登記表憑證資產，但骨架那兩層 root-owned 目錄照舊——本票不改二分部署。
+        for account in job_accounts:
+            try:
+                prefix = self.credential_prefix_of(account)
+                primary = credential_for(prefix, PRIMARY_CREDENTIAL_EXECUTOR)
+            except UnregisteredExecutorCredentialError:
                 account_dirs.append(
                     (self.codex_hooks_dir_of(account), root, g(root), 0o755)
                 )
-                # #640 裁決 (b)：憑證**檔**由 job 帳號擁有，放它的**目錄**維持
-                # root-owned——job 因此改得了自己那份憑證的內容，卻建不了新檔、
-                # 刪不掉、也換不掉同目錄下的 root-owned `hooks.json`。預設 relpath
-                # 下這一層就是上面那個 `~/.codex`，去重後不會重複出現；由
-                # `executor_credential_dir_of()` **導出**而非再寫死一次，換 relpath
-                # 時這條保護才會跟著走。
+                account_dirs.append((
+                    _parent_dir(f"{self.home_of(account)}/{self.executor_credential_relpath}"),
+                    root, g(root), 0o755,
+                ))
+                continue
+            if primary.shape is CredentialShape.IN_PLACE_FILE:
                 account_dirs.append(
-                    (self.executor_credential_dir_of(account), root, g(root), 0o755)
+                    (self.codex_hooks_dir_of(account), root, g(root), 0o755)
                 )
-            account_dirs.append((self.cache_of(account), account, g(account), 0o700))
         # #666：**durable state owner 才需要** `~/.config/gh` 那兩層。`gh` 依序看
         # `$GH_CONFIG_DIR` → `$XDG_CONFIG_HOME/gh` → `$HOME/.config/gh`，而產生出來的
         # unit 只設 `HOME=` 與 `XDG_CACHE_HOME=`（**刻意不設 `XDG_CONFIG_HOME=`**），
@@ -2346,8 +2837,13 @@ def principal_needs_write(
 #:
 #: 代價（裁決刻意接受）：以「暫存檔 ＋ rename 原子替換」形式 refresh 的 CLI 會失敗，
 #: 因為那需要在同目錄建檔。診斷方式見 Phase 2b runbook 第 4e 步。
+#:
+#: **#685：憑證那一半改由 per-(account, executor) 表導出，不是手寫清單。** 往
+#: :data:`CREDENTIALED_ACCOUNTS` 加一格 `IN_PLACE_FILE`，這裡自動跟著長；加一格
+#: `HOME_REDIRECT_TREE` 則**刻意不進**——那一族的 RWP 由 `cache` 涵蓋（見
+#: :class:`CredentialShape`），掛在 symlink 上只會讓 systemd 去 bind-mount 一條連結。
 IN_PLACE_CONTENT_WRITE_ASSETS: frozenset[str] = frozenset({
-    "builder-executor-credential",
+    *credential_asset_ids(CredentialShape.IN_PLACE_FILE),
     # #666：Manager 的 gh token。與上一條同形，但**洩漏面不同級**，這點不得混談：
     # #640 的憑證是給 **job 帳號**的，job unit 另有 `Environment=GH_TOKEN=` 把 token
     # 清空、成果一律走 spool 由 Manager 代理推送；這一份是給 **Manager** 的，而
@@ -3411,10 +3907,46 @@ RUN_EXTERNAL_DEPENDENCIES: tuple[RunDependency, ...] = (
         ),
     ),
     RunDependency(
+        "reviewer-planner-codex-state", DependencyKind.CREDENTIAL,
+        (Principal.REVIEWER, Principal.PLANNER), (RunStage.MODEL_CALL, RunStage.REVIEW),
+        covered_by="reviewer-planner-codex-state",
+        note=(
+            "#685：planner／reviewer 帳號的 codex 登入態＋狀態樹（`~/.codex` → "
+            "`cache/codex` 的 root-owned symlink）。**不是一個 `auth.json`**——#686 實測 "
+            "codex 需要 `$CODEX_HOME` 整棵可寫，只放行單檔時它連起都起不來。"
+        ),
+    ),
+    RunDependency(
+        "reviewer-planner-agy-state", DependencyKind.CREDENTIAL,
+        (Principal.PLANNER,), (RunStage.MODEL_CALL,),
+        covered_by="reviewer-planner-agy-state",
+        note=(
+            "#685／U-7：agy 的可寫狀態樹（`~/.gemini` → `cache/gemini`）。planning 的異質 "
+            "planner 就是它——0818 在完整 unit 沙箱下實測 rc=0、輸出逐位元等於 expected。"
+            "principals 只列 PLANNER 是因為 reviewer 的 executor 是 `claude`；帳號共用，"
+            "因此 ACL 面上兩者不可分（三分方案的既有性質）。"
+        ),
+    ),
+    RunDependency(
+        "reviewer-planner-claude-state", DependencyKind.CREDENTIAL,
+        (Principal.REVIEWER, Principal.PLANNER), (RunStage.MODEL_CALL, RunStage.REVIEW),
+        covered_by="reviewer-planner-claude-state",
+        note=(
+            "#685：reviewer 的**預設 executor** 是 `claude`，而這個帳號從 M2（#615）起"
+            "就沒有 claude 登入態——#686 的矩陣裡它是「CLI rc=0、卻回 `Not logged in`」"
+            "的那一列。缺它時「reviewer 已降權」買到的是一個跑不動的 job。"
+        ),
+    ),
+    RunDependency(
         "codex-hooks", DependencyKind.ACCOUNT_CONFIG,
         (Principal.BUILDER,), (RunStage.MODEL_CALL,),
         covered_by="codex-hooks",
-        note="enforcement plane：root-owned，job 不得替換自己的 hooks（#623）。",
+        note=(
+            "enforcement plane：root-owned，job 不得替換自己的 hooks（#623）。"
+            "**只有 builder 這一份**：reviewer／planner 帳號的 `~/.codex` 是導進 `cache` "
+            "的 symlink（#685），hooks 落在那棵 job-owned 的樹裡就擋不住替換——那一格"
+            "仍在 `deferred_run_dependencies()`，升為 U-9 交 operator 裁決。"
+        ),
     ),
     RunDependency(
         "builder-gitconfig", DependencyKind.ACCOUNT_CONFIG,
@@ -3631,27 +4163,6 @@ class DeferredDependency:
 #: 論證），差別只在那時候 M2 還沒落地、現在落地了。
 _DEFERRED_RUN_DEPENDENCIES: tuple[DeferredDependency, ...] = (
     DeferredDependency(
-        "reviewer-planner-executor-credential", DependencyKind.CREDENTIAL,
-        (Principal.REVIEWER, Principal.PLANNER),
-        reason=(
-            "登記表只登記 builder 那一份。#640 的理由是「登記第二份會讓二分部署的 "
-            "Manager unit 出現一條不存在的 `ReadWritePaths`，unit 直接起不來」，並寫明"
-            "「M2（#615）把 reviewer／planner 移上模板 unit 時補第二列即可」。**M2 已經"
-            "落地**（`cortex-reviewer-job@.service` 已在產生器裡），所以這條現在是逾期"
-            "未做，不再是「時候未到」。\n"
-            "#666 順帶把當年的阻礙拆掉了：`inapplicable_home_anchored_assets()` 讓"
-            "「本方案不存在的帳號 HOME 下的資產」機械地不進 RWP，二分部署不會再被"
-            "第二列弄壞。**但補這一列會改動 reviewer 模板 unit 的 RWP，屬 operator 的"
-            "部署面裁決，不在本票範圍。**"
-        ),
-        symptom=(
-            "檔案由 runbook 第 4e 步落位（owner 正確、0600），但 reviewer 模板 unit 的 "
-            "`ReadWritePaths` 不含它 ⇒ `ProtectSystem=strict` 下**讀得到、改不了** ⇒ "
-            "token 過期那天 reviewer 的 refresh 靜默失敗。"
-        ),
-        disposition="補登記表第二列（產生器一行都不必改）；建議另開票，實機驗 RWP 後再上。",
-    ),
-    DeferredDependency(
         "gate-gitconfig", DependencyKind.ACCOUNT_CONFIG,
         (Principal.GATE,),
         reason=(
@@ -3671,35 +4182,61 @@ _DEFERRED_RUN_DEPENDENCIES: tuple[DeferredDependency, ...] = (
         "reviewer-planner-codex-hooks", DependencyKind.ACCOUNT_CONFIG,
         (Principal.REVIEWER, Principal.PLANNER),
         reason=(
-            "`asset_paths()` 把 `codex-hooks` 寫死在 `builder_home` 下，而 "
-            "`scaffold_directories()` 已為**每一個**跑模型的 job 帳號建出 root-owned "
-            "的 `~/.codex`。與上一項同一個形態：機制 per-account，登記表只登記一份。"
+            "**#685 換掉了本項的理由，因為原本那個已經被推翻。** 原文寫的是「機制 "
+            "per-account，登記表只登記一份，補第二列即可」——#686 的實測讓「補第二列」"
+            "在這一格**做不到**：codex 需要 `$CODEX_HOME` 整個目錄可寫，因此 "
+            "`cortex-reviewer-planner` 的 `~/.codex` 已改成導進 `cache` 的 root-owned "
+            "symlink（登記表資產 `reviewer-planner-codex-state`），而那棵樹由 **job 帳號"
+            "擁有**。hooks 若放進去，job 對它的父目錄有寫入權 ⇒ 隨時 unlink／rename 換掉"
+            "⇒ 登記成 root-owned 的 Tier-0 enforcement 資產是**名義上的**，不是真的。\n"
+            "**兩件事在 `$CODEX_HOME` 這一層互斥**：(i) codex 起得來（整棵可寫）、"
+            "(ii) 同棵樹裡有一個 job 換不掉的 root-owned `hooks.json`。本票選 (i)——"
+            "選 (ii) 的部署裡 codex 根本跑不起來，hooks 也就沒有東西可以約束。"
         ),
         symptom=(
-            "reviewer／planner 以 `codex` 為 executor 時拿不到 hooks（enforcement "
-            "plane 少一層）。目前 reviewer 走的是 `claude`，因此**尚未**在實機表現出來。"
+            "reviewer／planner 以 `codex` 為 executor 時拿不到 root-owned hooks"
+            "（enforcement plane 少一層），且該帳號可自行放一份自己的 hooks.json 在 "
+            "`cache/codex/` 底下並持久化。**攻擊價值有界**：hooks 命令跑的身分就是它"
+            "自己、影響的也只有它自己後續的 codex 呼叫；跨帳號與跨 job 的面不受影響"
+            "（`~/.codex` 那條 symlink 在 root-owned 的 HOME 裡，換不掉）。"
         ),
-        disposition="與 reviewer 憑證同一張票處理；兩者都是「補第二列」。",
+        disposition=(
+            "**U-9（本票新提，交 operator）**：要 hooks enforcement 就必須讓 "
+            "`$CODEX_HOME` 同時「整棵可寫」與「裡面放得住 root-owned 檔」。已知的候選是"
+            "**root-owned ＋ sticky bit ＋ 給 job 帳號一條 `rwx` ACL** 的目錄（sticky 讓"
+            "非 owner 只能刪自己的檔 ⇒ root-owned 的 hooks.json 換不掉）。**本票不做，"
+            "兩個理由**：(i) 它要改 permgen 的 mode 管線——安全網 `_mask_write` 會拿掉 "
+            "group 寫入位、`mode & 0o700` 會吃掉 sticky 位，那是 spec §R2 的既有不變式；"
+            "(ii) 「codex 能不能在一個它**不擁有**的 `$CODEX_HOME` 下跑起來」**沒有實機"
+            "證據**，而 #686 量到的是「指到一個可寫目錄」。依 D13，未經落檔 unit 全量"
+            "導出的實測不得宣稱可用。"
+        ),
     ),
     DeferredDependency(
         "manager-claude-credential", DependencyKind.CREDENTIAL,
         (Principal.MANAGER,),
         reason=(
-            "`planning_runtime` 的 JSON 呼叫在 **Manager 行程內**直接 exec `claude`"
-            "（不是派一個降權 job），並讀 `<HOME>/.claude/.credentials.json` 播種一次性"
-            "的 `CLAUDE_CONFIG_DIR`。四分部署下 Manager 的 HOME 底下沒有那個檔，登記表"
-            "也沒有對應資產——`executor_credential_relpath` 是**單一**部署決定"
-            "（`.codex/auth.json`），一個帳號只表達得了一份憑證。"
+            "`planning_runtime` 的 **direct 模式**在 Manager 行程內直接 exec `claude`，"
+            "並讀 `<HOME>/.claude/.credentials.json` 播種一次性的 `CLAUDE_CONFIG_DIR`。"
+            "四分部署下 Manager 的 HOME 底下沒有那個檔，登記表也沒有對應資產。\n"
+            "**#685 解除了本項的機械阻礙，但沒有解除它本身。** 原文寫的阻礙是"
+            "「`executor_credential_relpath` 是單一部署決定，一個帳號只表達得了一份憑證」"
+            "——U-5 的裁決已經把它擴成 per-(account, executor) 表"
+            "（:data:`CREDENTIALED_ACCOUNTS`），現在**表達得了**。剩下的是**要不要登記**"
+            "這一格，而那是 #672 的核心裁決：Manager 是 durable state owner ＋ spawn "
+            "授權持有者，passwd 註記逐字寫著 `no model code`——給它一份模型憑證正是 #672 "
+            "要消除的東西。因此本票**刻意不登記**。"
         ),
         symptom=(
             "程式碼在查無憑證時**明確回 `None` 並不代為猜測**，讓 claude CLI 自己回報"
-            "未登入——因此它不是靜默失敗，但也不是可用狀態。實機目前 planning 走 `agy`，"
-            "所以這條還沒有被踩到。"
+            "未登入——因此它不是靜默失敗，但也不是可用狀態。實機 direct 模式的 planning "
+            "走 `agy`，所以這條還沒有被踩到。"
         ),
         disposition=(
-            "要嘛把 `executor_credential_relpath` 擴成 per-executor 的一張表（產生器"
-            "改動不小），要嘛裁決「Manager 不直接跑模型、planning 一律走降權 job」。"
-            "兩條路都是設計裁決，屬 operator。"
+            "由**票 F（#687）**收尾：`PSC_JOB_RUNNER` 切到 `systemd-template` 之後，"
+            "planning 一律走降權 job（票 E／#686 已把 `JobPlanningInvoker` land），Manager "
+            "行程內不再 exec 任何 executor，本項隨之消失而不是被登記。**本票不預先刪掉它**"
+            "——切換尚未發生，direct 路徑逐字還在，現在刪等於宣稱一件還沒成立的事。"
         ),
     ),
 )
@@ -3747,6 +4284,22 @@ JOB_PATH_ENV_BY_PRINCIPAL: Mapping[Principal, str] = MappingProxyType(
         Principal.BUILDER: "PSC_BUILDER_PATH",
         Principal.REVIEWER: "PSC_REVIEWER_PATH",
         Principal.GATE: "PSC_GATE_PATH",
+    }
+)
+
+#: 每個 job 角色的 `HOME` 覆寫變數名（#685／#686）。與 `job_runner.JOB_ROLE_CONFIG` 的
+#: `home_env` 是**成對契約**，與上面那張 PATH 表逐條同構、同一個理由：模板模式下 shim
+#: 以 `os.execvpe` 整份換掉環境，unit 的 `Environment=HOME=` 到不了模型，`HOME` 只能
+#: 來自 spec 的 env。
+#:
+#: **本表對 #685 是必要的，不是順手加的**：三份登入態（`~/.codex`／`~/.gemini`／
+#: `~/.claude`）全部以 `$HOME` 為根，`HOME` 沒宣告時它們在 job 內一條都解不到——而
+#: 症狀（`Not logged in`／`$HOME is not defined`）與「憑證沒放好」長得一模一樣。
+JOB_HOME_ENV_BY_PRINCIPAL: Mapping[Principal, str] = MappingProxyType(
+    {
+        Principal.BUILDER: "PSC_BUILDER_HOME",
+        Principal.REVIEWER: "PSC_REVIEWER_HOME",
+        Principal.GATE: "PSC_GATE_HOME",
     }
 )
 
@@ -4140,6 +4693,47 @@ def build_monitor_unit(
     )
 
 
+def _job_unit_credential_lines(job_layout: "PathLayout", account: str) -> list[str]:
+    """模板 unit 裡「本帳號有哪幾份登入態、各是什麼形狀」那一段（#685）。
+
+    逐格由 `credential_placements()` 導出，**不是寫死的一段文字**：加一格憑證之後
+    unit 的註解會自己長出來，而不是變成一份與登記表不同步的說明。
+    """
+    lines: list[str] = []
+    for _asset_id, cred_account, path, credential in job_layout.credential_placements():
+        if cred_account != account:
+            continue
+        if credential.shape is CredentialShape.IN_PLACE_FILE:
+            lines += [
+                f"#   [{credential.executor}] {path}",
+                "#     單檔：**檔案**由本 job 帳號擁有（0600，token 過期可就地 refresh），",
+                "#     **放它的目錄維持 root-owned** ⇒ 本帳號建不了新檔、刪不掉、也換不掉",
+                "#     同目錄下的 root-owned hooks.json。下方 ReadWritePaths 只掛**那一個",
+                "#     檔**，不是它的父目錄（明示的例外，見 IN_PLACE_CONTENT_WRITE_ASSETS）。",
+                "#     憑證尚未落位時本 unit 會**起不來**（systemd 對不存在的",
+                "#     ReadWritePaths 目標報錯）——刻意的 fail-closed：沒有登入態的 job",
+                "#     本來就做不了事，在 exec 前失敗比走到呼叫模型那一步才 rc=127 好查。",
+                "#     ⚠️ #686 實測：codex 需要 $CODEX_HOME **整棵**可寫，因此這個形狀下的",
+                "#     codex 在本 unit 內**起不來**（見 runbook 4e-3、deferred 的 U-9）。",
+            ]
+        else:
+            target = job_layout.credential_target_of(account, credential)
+            leaf = credential.token_leaf or "（無單一 token 葉檔）"
+            lines += [
+                f"#   [{credential.executor}] {path} -> {target}",
+                f"#     可寫狀態樹（token 葉檔：{leaf}）。symlink 由 root 擁有、放在",
+                "#     root-owned 的 HOME 裡 ⇒ 本帳號**換不掉它的指向**；目標落在本帳號",
+                "#     既有的 cache 底下 ⇒ **下方 ReadWritePaths 逐字不變、不新增任何",
+                "#     可寫面**（那條 cache 本來就在，_minimize() 會吃掉子路徑）。",
+                "#     代價（R-6）：這棵樹由本帳號擁有，樹裡的 token 葉檔因此**可被本",
+                "#     帳號刪除或替換**——換到的是 executor 起不起得來。同一棵樹裡不得",
+                "#     再放 root-owned 的 enforcement 檔（見 U-9）。",
+            ]
+    if not lines:
+        lines.append("#   （本帳號在表上沒有任何登入態——它不跑模型 CLI。）")
+    return lines
+
+
 def build_job_unit(
     scheme: UidScheme,
     layout: PathLayout = DEFAULT_LAYOUT,
@@ -4313,15 +4907,19 @@ def build_job_unit(
         "#    `unit_replica_properties()` 會把上面這一行機械帶進 --property=，複本因此",
         "#    連「production 供應什麼／不供應什麼」都一起複製。再加一個 --setenv=PATH=",
         "#    就等於驗證環境供應了 production 不供應的東西，結構上永遠驗不出這個缺陷。",
-        "# --- executor 憑證（登記表 *-executor-credential，#640 裁決 (b)）---",
-        f"#   {job_layout.executor_credential_of(account)}：**檔案**由本 job 帳號擁有",
-        "# （0600，token 過期可自行 refresh），**放它的目錄維持 root-owned**——因此",
-        "# 本帳號建不了新檔、刪不掉、也換不掉同目錄下的 root-owned hooks.json。",
-        "# 下方 ReadWritePaths 只掛**那一個檔**，不是它的父目錄（一般規則會折算成父",
-        "# 目錄，這一族是明示的例外，見 permgen.IN_PLACE_CONTENT_WRITE_ASSETS）。",
-        "# 憑證尚未落位時本 unit 會**起不來**（systemd 對不存在的 ReadWritePaths 目標",
-        "# 報錯）——那是刻意的 fail-closed：沒有登入態的 job 本來就做不了事，在 exec",
-        "# 前失敗比走到呼叫模型那一步才 rc=127 好查得多。",
+        "# --- executor 登入態（登記表的 per-(account, executor) 憑證表，#640／#685）---",
+        "# 形狀由 permgen.CREDENTIALED_ACCOUNTS × EXECUTOR_CREDENTIALS 決定，**不是**",
+        "# 本檔的字面量；本帳號被核可的每一格逐條列在下面。",
+    ]
+    body += _job_unit_credential_lines(job_layout, account)
+    body += [
+        "# ⚠️ 三條 symlink 的路徑**全部以 $HOME 為根**，而模板模式下 shim 以",
+        "#    os.execvpe 整份換掉環境 ⇒ 下面那行 Environment=HOME= **到不了模型**",
+        "#    （#686 實機更正）。HOME 只能來自 spec 的 env，也就是 Manager 端",
+        f"#    root-owned EnvironmentFile 的 {JOB_HOME_ENV_BY_PRINCIPAL[principal]}：",
+        f"#      {JOB_HOME_ENV_BY_PRINCIPAL[principal]}={job_layout.job_home_value(account)}",
+        "#    未宣告時症狀是 `$HOME is not defined`／`Not logged in`——與「憑證沒放好」",
+        "#    長得一模一樣，因此憑證面與這一行**必須一起成立**（runbook 第 5-5c 步）。",
         "# shim 讀 spec 的唯一合法來源：這一行在 root-owned 的 unit 檔裡，",
         "# 因此持 spawn 授權的帳號也改不掉 spec 要從哪個目錄讀。shim 對未設此",
         "# 變數的情況 fail-closed（不猜、不落回 $HOME 推導的預設）。",

--- a/paulsha_cortex/trust_root/registry.py
+++ b/paulsha_cortex/trust_root/registry.py
@@ -533,11 +533,109 @@ ASSET_REGISTRY: tuple[TrustRootAsset, ...] = (
             "（`cortex-svc`），登記第二份會讓 Manager unit 的 `ReadWritePaths` 出現一條"
             "**二分部署裡根本不存在**的 HOME 路徑——systemd 對不存在的 `ReadWritePaths` "
             "目標直接讓 unit 起不來，等於用一個 M2 才需要的資產弄壞一個現存的部署形態。\n"
-            "**機制本身已經是 per-account 的**：`PathLayout.executor_credential_of()` 吃"
-            "任意帳號，`scaffold_directories()` 也已為**每一個** job 帳號建出 root-owned "
-            "的憑證父目錄（因此 `cortex-reviewer-planner` 那一份憑證照同一條規則落位、"
-            "同樣受保護）。M2（#615）把 reviewer／planner 移上模板 unit 時，登記表補第二"
-            "列即可，產生器一行都不必改。"
+            "**#685 更正「補第二列即可」這句話**（原文寫於 #640，前提已被 #686 的實測"
+            "推翻）：reviewer／planner 那一份**不能**照抄本形態。#686 在完整 reviewer "
+            "unit 沙箱下實測，codex 需要 `$CODEX_HOME`（預設 `~/.codex`）**整個目錄**可寫"
+            "——只放行 `auth.json` 一個檔時它連起都起不來（`failed to initialize in-process "
+            "app-server client: Read-only file system`），且症狀與 cwd 無關。因此那個帳號"
+            "改走 `reviewer-planner-codex-state`（`CredentialShape.HOME_REDIRECT_TREE`）。\n"
+            "**builder 維持本形態不動**：這份部署已存在、runbook 第 4e-2 步有「建不了新檔／"
+            "刪不掉／換不掉」的反向驗證，而改它會同時賣掉 `codex-hooks` 的 enforcement"
+            "（同目錄下的 root-owned 檔擋不住一個擁有該目錄的 job）——那是 operator 的"
+            "裁決（U-9），不是本票能順手做的事。**代價已知並記錄**：builder 在模板 unit 下"
+            "跑 codex 會撞到與 #686 同一條 `$CODEX_HOME` 唯讀阻斷，見 `deferred` 與 runbook。"
+        ),
+    ),
+    # ---- reviewer／planner 帳號的三份登入態（#685／#672 票 D；U-4 追認雙 domain）----
+    #
+    # 三項同形，因此共用這一段說明，各自的 note 只寫「這個 executor 特有的部分」。
+    #
+    # **形狀**：`permgen.CredentialShape.HOME_REDIRECT_TREE`——HOME 底下一條 root-owned
+    # symlink，指向該帳號 `cache` 裡的一格。三條性質同時成立，而且都是機械結果：
+    #
+    #   1. **不新增任何可寫面**：`cache` 早已在 reviewer 模板 unit 的 `ReadWritePaths` 內
+    #      （`PathLayout.job_extra_write_paths`），`_minimize()` 因此吃掉目標路徑 ⇒ unit 的
+    #      `ReadWritePaths=` **逐字不變**。executor 能做的事，該帳號今天就已經能做。
+    #   2. **job 換不掉指向**：symlink 落在 root-owned 的 HOME（`scaffold_directories()`
+    #      產出 root:root 0755），換 symlink 需要對父目錄的寫入權。
+    #   3. **writers 只有 INSTALLER**：`required_write_targets()` 只收 writer 面，因此
+    #      這三項機械地不會產生任何 RWP 條目，也不會產生任何跨帳號 ACL。
+    #
+    # **為什麼不是「把憑證檔登記成葉節點」**（#640 對 builder 的做法）：#686 實測 codex
+    # 與 agy 要寫的都是**一整棵**狀態樹，檔名還帶版本序號（`state_5.sqlite`）——逐項列舉
+    # 會在下一次 CLI 升版時無聲失效。claude 同理。
+    #
+    # **U-4 的追認範圍**：這三格代表 `cortex-reviewer-planner` 同時持有 openai／google／
+    # anthropic 三個 provider 的登入態。design 的安全退步 **R-3**（該帳號被攻陷時多邊
+    # token 一起失，而 planner 正是吃 untrusted issue 內容的角色）是**明文接受的有界
+    # 殘餘風險**——它在後續任何「planner 攻擊面」討論中不得被當成未知。
+    #
+    # **本形狀新增的退步（R-6，明講）**：目標樹由 job 帳號擁有 ⇒ 樹裡的 token 葉檔可被
+    # 該 job 刪除或替換（builder 的 `IN_PLACE_FILE` 擋得住「刪／換」，這裡擋不住）。
+    # 影響面限於該帳號自己的登入態；換到的是 codex／claude **能不能起得來**。直接後果：
+    # 同一棵樹裡**不得**再放任何 root-owned 的 enforcement 檔——`reviewer-planner-codex-hooks`
+    # 因此仍留在 `permgen.deferred_run_dependencies()` 並升為 **U-9**。
+    TrustRootAsset(
+        "reviewer-planner-codex-state", _T0, _JV, None,
+        (Principal.INSTALLER,), (Principal.REVIEWER, Principal.PLANNER),
+        IngressKind.DEPLOYMENT_WRITE,
+        derived_in=("trust_root/permgen.py:PathLayout.executor_credential_of",),
+        note=(
+            "`<HOME>/.codex` → `<HOME>/cache/codex` 的 root-owned symlink：codex 的 "
+            "`$CODEX_HOME` 整棵，token 葉檔是它底下的 `auth.json`。\n"
+            "**為何是整棵而不是一個檔**（#686 實測，design 未預期）：唯讀時 codex 回 "
+            "`Error: failed to initialize in-process app-server client: Read-only file "
+            "system (os error 30)`；把 cwd 換成可寫的 `/tmp` **症狀完全相同**，維持唯讀 "
+            "cwd 只把 `CODEX_HOME` 指到可寫目錄則 **rc=0、輸出正確**。阻斷點是 "
+            "`CODEX_HOME`，不是 cwd。它在底下建 `state_5.sqlite`／`logs_2.sqlite`／"
+            "`queue_1.sqlite`／`memories_1.sqlite`／`sessions/`／`skills/`／`plugins/`／"
+            "`thread-writer-locks/`／`models_cache.json`／`installation_id`。\n"
+            "**為何不用 `CODEX_HOME=` 這個環境變數而用 symlink**：env 覆寫要經 "
+            "`job_runner.build_job_env()` 的白名單，那是第二條要維護的放行面；而 symlink "
+            "讓 executor 的**預設**路徑解析就落在對的地方，job 側零改動。代價是 "
+            "`~/.codex` 這個名字被佔用（見上方 R-6 與 U-9）。"
+        ),
+    ),
+    TrustRootAsset(
+        "reviewer-planner-agy-state", _T0, _JV, None,
+        (Principal.INSTALLER,), (Principal.REVIEWER, Principal.PLANNER),
+        IngressKind.DEPLOYMENT_WRITE,
+        derived_in=("trust_root/permgen.py:PathLayout.executor_credential_of",),
+        note=(
+            "`<HOME>/.gemini` → `<HOME>/cache/gemini` 的 root-owned symlink：agy 的可寫"
+            "狀態樹，token 葉檔是 `antigravity-cli/antigravity-oauth-token`。**U-7 的裁決"
+            "就是這一項**（design 的選項 (a)：登記成 symlink 類資產）。\n"
+            "agy 執行時往 `~/.gemini/antigravity-cli/` 寫 conversations SQLite、crashes、"
+            "presence lock、builtin skills，並**自解出一個 17 MB 的可執行檔** "
+            "`bin/webm_encoder`——這正是「單檔憑證」表達不了的那一類。\n"
+            "**這是三項裡唯一端到端實測全綠的一格**：0818 以 `cortex-reviewer-planner` "
+            "身分、在逐條複製落檔 unit 全部 property 的沙箱下跑 "
+            "`agy --print … --mode plan --sandbox --model gemini-3.1-pro-high`，rc=0、輸出"
+            "逐位元等於 `probe_agy_capability()` 的 expected；#686 以 `JobPlanningInvoker` "
+            "端到端複驗同一結論。**0818 的部署是手動落位的，本項讓重跑產生器能重現它。**"
+        ),
+    ),
+    TrustRootAsset(
+        "reviewer-planner-claude-state", _T0, _JV, None,
+        (Principal.INSTALLER,), (Principal.REVIEWER, Principal.PLANNER),
+        IngressKind.DEPLOYMENT_WRITE,
+        derived_in=("trust_root/permgen.py:PathLayout.executor_credential_of",),
+        note=(
+            "`<HOME>/.claude` → `<HOME>/cache/claude` 的 root-owned symlink：claude 的"
+            "登入態與狀態樹，token 葉檔是 `.credentials.json`。\n"
+            "**這一格是 #686 驗收矩陣裡唯一「CLI 全綠、卻做不了事」的那一列**：job 沙箱下"
+            "claude 走得完整條（rc=0），回的是 "
+            "`{\"is_error\":true,…,\"result\":\"Not logged in · Please run /login\"}`"
+            "——擋住的是憑證，不是加固面。它同時是 `reviewer-planner` 這個帳號**唯一**"
+            "在 M2（#615）之後就該有、卻從來沒有過的登入態：reviewer 的預設 executor 是 "
+            "`claude`，因此本項缺席時「reviewer 已降權」這句話買到的是一個跑不動的 job。\n"
+            "**job 模式下 `CLAUDE_CONFIG_DIR` 不可用**（它在 `job_runner.DENIED_ENV_NAMES` "
+            "內，design D-g 的帳號隔離取代了 in-process 的一次性 config dir），因此 claude "
+            "解到的就是 `$HOME/.claude`——也就是本項。\n"
+            "**`$HOME` 必須在 job 內解得到**：模板模式下 shim 以 `os.execvpe` 整份換掉環境"
+            "，unit 的 `Environment=HOME=` 到不了模型（#686 更正）。三項憑證的路徑**全部**"
+            "以 `$HOME` 為根，因此它們與 `PSC_REVIEWER_HOME` 的宣告**必須一起成立**；"
+            "產生器出的值見 `permgen.PathLayout.job_home_value()`，runbook 第 5-5c 步。"
         ),
     ),
     # ---- Manager 的 GitHub 傳輸層憑證（#666）--------------------------------

--- a/tests/test_trust_root_external_deps_exhaustive_666.py
+++ b/tests/test_trust_root_external_deps_exhaustive_666.py
@@ -263,6 +263,14 @@ def test_inapplicable_assets_are_enumerable_not_silent() -> None:
         GH_CONFIG,
         "manager-gitconfig",
         "reviewer-planner-gitconfig",
+        # #685：per-(account, executor) 憑證表的三格全掛在 `cortex-reviewer-planner`
+        # 的 HOME 下，而二分方案把 reviewer／planner 併進 `cortex-svc` ⇒ 那三條路徑在
+        # 二分部署裡不存在。**這正是 #640 當年「乾脆不登記第二份憑證」的那個陷阱**，
+        # 而 #671 的 `inapplicable_home_anchored_assets()` 已經把它變成一條機械規則：
+        # 二分方案的產出因此不含它們，Manager unit 的 RWP 不會多出不存在的路徑。
+        "reviewer-planner-codex-state",
+        "reviewer-planner-agy-state",
+        "reviewer-planner-claude-state",
     }, sorted(two_way)
     # 定案的兩個方案完全沒有不適用項——有的話就是 layout 的帳號欄位與方案對不上。
     for scheme in ALL_SCHEMES:
@@ -543,18 +551,35 @@ def test_home_anchored_assets_are_derived_not_hand_written() -> None:
         GH_CREDENTIAL,
         "manager-gitconfig",
         "reviewer-planner-gitconfig",
+        # #685（#672 票 D）：per-(account, executor) 憑證表為 `cortex-reviewer-planner`
+        # 展開的三格。它們**是機械導出的結果**——這條測試本身就是在驗那件事：新增一個
+        # 掛在帳號 HOME 下的資產而沒有把它列進 `RUN_EXTERNAL_DEPENDENCIES`，
+        # `unlisted_roster_entries()` 就會非空（見下一條）。
+        "reviewer-planner-codex-state",
+        "reviewer-planner-agy-state",
+        "reviewer-planner-claude-state",
     }), sorted(home_anchored_asset_ids())
 
 
 def test_deferred_dependencies_stay_enumerable() -> None:
     """比照 #661 的 `unresolved_node_execution_surfaces()`：不裁決，但不得靜默消失。
 
-    這四項都是「per-account 的機制已就緒、登記表只登記了其中一份」。補上或悄悄拿掉
-    都會讓這條紅——那正是要的：它們必須是一個**被看見的**決定。
+    補上或悄悄拿掉都會讓這條紅——那正是要的：它們必須是一個**被看見的**決定。
+
+    **#685（#672 票 D）縮短了這份清單，並更正了另外兩項的理由**：
+
+    - `reviewer-planner-executor-credential` **已關閉**——per-(account, executor) 憑證表
+      （U-5 裁決）為那個帳號登記了三格登入態（codex／agy／claude）。原本那條 deferred
+      的 `disposition` 寫的是「補登記表第二列（產生器一行都不必改）」，而 #686 的實測
+      證明那句話是錯的：codex 需要 `$CODEX_HOME` 整棵可寫，單檔不夠。
+    - `reviewer-planner-codex-hooks` **留著，但理由整段換掉**：它現在不是「還沒補」，
+      而是與 codex 的可用性**在 `$CODEX_HOME` 這一層互斥**（升為 U-9）。
+    - `manager-claude-credential` **留著**：U-5 解除了它的機械阻礙（表達得了了），但
+      「要不要給 Manager 一份模型憑證」是 #672 的核心裁決，答案是不要；本項由票 F
+      （#687）切換之後隨 direct 路徑一起消失，**不是**現在刪掉。
     """
     deferred = deferred_run_dependencies()
     assert {item.name for item in deferred} == {
-        "reviewer-planner-executor-credential",
         "gate-gitconfig",
         "reviewer-planner-codex-hooks",
         "manager-claude-credential",
@@ -569,26 +594,43 @@ def test_deferred_dependencies_stay_enumerable() -> None:
         assert item.name not in listed, item.name
 
 
-def test_the_reviewer_credential_gap_is_real_not_theoretical() -> None:
-    """把上面那條 deferred 的**症狀**釘成可驗證的事實，而不是一段散文。
+def test_the_reviewer_credential_gap_is_closed_without_widening_the_write_surface() -> None:
+    """#685 把上面那條 deferred 的**症狀**翻面：缺口關了，而且沒有付出可寫面。
 
-    M2（#615）的 reviewer 模板 unit 已經在產生器裡，但它的 `ReadWritePaths` 不含
-    reviewer 帳號那份 executor 憑證 ⇒ `ProtectSystem=strict` 下讀得到、改不了。
-    哪天有人補上登記表第二列，這條會紅——**那正是提醒去刪掉這條測試與那筆 deferred**。
+    本測試的前身是 `test_the_reviewer_credential_gap_is_real_not_theoretical`，它的
+    docstring 逐字寫著「哪天有人補上登記表第二列，這條會紅——那正是提醒去刪掉這條測試
+    與那筆 deferred」。#685 就是那一天，所以它按設計被翻成正向的形態。
+
+    **翻面的方式與 #640 當初預期的不同，這一點必須釘住**：預期是「reviewer 模板 unit
+    的 RWP 逐字含憑證**檔案**」，而 #686 實測 codex 需要 `$CODEX_HOME` 整棵可寫 ⇒ 那個
+    帳號的三份登入態改走 `HOME_REDIRECT_TREE`（root-owned symlink → 該帳號既有的
+    `cache`）。因此正確的不變式是**更強的那一條**：
+
+      unit 的 `ReadWritePaths` **逐字不變**，而三份登入態全部落在它已經涵蓋的 `cache`
+      底下 ⇒ 憑證面可寫、可 refresh，且**零新增可寫面**。
     """
     scheme = FOUR_WAY_SCHEME
     plan = generate_plan(scheme)
     account = scheme.resolve(Principal.REVIEWER)
     assert account is not None
-    credential = DEFAULT_LAYOUT.executor_credential_of(account)
     rwp = read_write_paths(
         plan, DEFAULT_LAYOUT, account,
         extras=DEFAULT_LAYOUT.job_extra_write_paths(account),
         principals=permgen.JOB_PRINCIPAL_PERSONAS[Principal.REVIEWER],
         retired=permgen.RETIRED_JOB_WRITE_ASSETS,
     )
-    assert not any(path == credential for path in rwp), sorted(rwp)
-    # 對照：builder 那一份**有**（同一條導出路徑，差別只在登記表登記了幾列）。
+    cache = DEFAULT_LAYOUT.cache_of(account)
+    for asset_id, target in DEFAULT_LAYOUT.symlink_targets().items():
+        if not asset_id.startswith("reviewer-planner-"):
+            continue
+        # (a) 落在 cache 底下 ⇒ 已被既有那條 RWP 涵蓋；
+        assert target.startswith(cache + "/"), (asset_id, target)
+        # (b) 自己**不**出現在 RWP 上（`_minimize()` 吃掉子路徑，且 writer 只有 root）。
+        assert target not in rwp, (asset_id, sorted(rwp))
+        assert DEFAULT_LAYOUT.asset_paths()[asset_id] not in rwp, asset_id
+    assert cache in rwp, sorted(rwp)
+    # 對照：builder 那一份仍是 `IN_PLACE_FILE`，RWP 逐字掛在**檔案本身**（#640 裁決 (b)
+    # 一行未改）——同一張表，兩種形狀，這正是 U-5 要 per-(account, executor) 的理由。
     builder = scheme.resolve(Principal.BUILDER)
     builder_rwp = read_write_paths(
         plan, DEFAULT_LAYOUT, builder,

--- a/tests/test_trust_root_job_template_ab.py
+++ b/tests/test_trust_root_job_template_ab.py
@@ -433,6 +433,20 @@ class SchemeDerivedHomeTests(unittest.TestCase):
             } | {
                 permgen.DEFAULT_LAYOUT.codex_hooks_dir_of(a) for a in expected
             } | {
+                # #685：per-(account, executor) 憑證表產生的骨架——`IN_PLACE_FILE` 的
+                # root-owned 父目錄，與 `HOME_REDIRECT_TREE` 落在該帳號 `cache` 底下的
+                # 目標。**逐格由那張表導出、不手抄**，因此加一格憑證時這裡自動涵蓋；
+                # 兩者都仍在本 scheme 解析得到的帳號 HOME 底下，「無多餘」的原意
+                # （不得殘留別的 scheme 的帳號樹）未被放寬。
+                target
+                for _aid, acct, path, cred in permgen.DEFAULT_LAYOUT.credential_placements()
+                if acct in expected
+                for target in (
+                    (permgen.DEFAULT_LAYOUT.credential_target_of(acct, cred),)
+                    if cred.shape is permgen.CredentialShape.HOME_REDIRECT_TREE
+                    else (path.rsplit("/", 1)[0],)
+                )
+            } | {
                 # #666：durable state owner 另有 root-owned 的 `~/.config` 與
                 # `~/.config/gh`（`gh` 的登入態落點）。仍在**本 scheme 解析得到的
                 # 帳號**底下，因此「無多餘」這條的原意未被放寬。
@@ -442,16 +456,36 @@ class SchemeDerivedHomeTests(unittest.TestCase):
             self.assertTrue(homes <= resolved, (scheme.scheme_id, homes - resolved))
 
     def test_every_model_job_account_gets_a_root_owned_codex_dir(self) -> None:
-        """跑模型的帳號都不得替換自己的 `~/.codex`（hooks 是 Tier-0 資產）。"""
+        """跑模型的帳號都不得替換自己的 codex 設定落點。
+
+        **#685 之後這條分兩種形狀成立，不再是「兩個帳號都有 root-owned `~/.codex`」。**
+        原因是 #686 的實測：codex 需要 `$CODEX_HOME` **整棵**可寫，因此
+        `cortex-reviewer-planner` 的 `~/.codex` 改成導進 `cache` 的 root-owned symlink。
+        「job 換不掉」這條性質**沒有消失，只是換了守它的那一層**：
+
+        - builder（`IN_PLACE_FILE`）：`~/.codex` 是 root-owned 目錄 ⇒ 連同 `hooks.json`
+          一起擋住；
+        - reviewer-planner（`HOME_REDIRECT_TREE`）：`~/.codex` 是 root-owned **symlink**，
+          放在 root-owned 的 HOME 裡 ⇒ job 換不掉它的**指向**（但擋不住樹裡的內容，
+          那正是 U-9 那筆 deferred 記錄的代價）。
+        """
         scheme = permgen.THREE_WAY_SCHEME
+        layout = permgen.DEFAULT_LAYOUT
         by_path = {
             path: owner
-            for path, owner, _g, _m in permgen.DEFAULT_LAYOUT.scaffold_directories(scheme)
+            for path, owner, _g, _m in layout.scaffold_directories(scheme)
         }
-        for account in ("cortex-builder", "cortex-reviewer-planner"):
-            self.assertEqual(
-                by_path[permgen.DEFAULT_LAYOUT.codex_hooks_dir_of(account)], "root", account
-            )
+        # builder：root-owned 的真目錄。
+        self.assertEqual(by_path[layout.codex_hooks_dir_of("cortex-builder")], "root")
+        # reviewer-planner：`~/.codex` **不得**是骨架目錄（它是 symlink），而它的 HOME
+        # 是 root-owned ⇒ 換不掉那條 symlink。
+        planner = "cortex-reviewer-planner"
+        self.assertNotIn(layout.codex_hooks_dir_of(planner), by_path)
+        self.assertEqual(by_path[layout.home_of(planner)], "root")
+        # symlink 的目標由該帳號自己擁有，且落在既有的 `cache` 底下（不新增可寫面）。
+        target = layout.symlink_targets()["reviewer-planner-codex-state"]
+        self.assertEqual(by_path[target], planner)
+        self.assertTrue(target.startswith(layout.cache_of(planner) + "/"), target)
 
     def test_custom_home_root_needs_no_code_change(self) -> None:
         alt = permgen.PathLayout(home_root="/srv/homes")

--- a/tests/test_trust_root_planner_credentials_672.py
+++ b/tests/test_trust_root_planner_credentials_672.py
@@ -1,0 +1,481 @@
+"""issue #685（#672 票 D）：permgen 把 planner／reviewer 的憑證面 codify。
+
+裁決背景（0818 operator）：
+
+- **U-4 追認雙 domain**——`cortex-reviewer-planner` 同時持有多個 provider 的登入態是
+  **核可狀態**，design 的安全退步 R-3 是明文接受的有界殘餘風險。
+- **U-5 照設計做**——`executor_credential_relpath` 擴成 per-(account, executor) 表。
+- **U-7 照設計做**——agy 的可寫狀態樹依 design 的 (a)（symlink 類資產）進登記表。
+
+本檔釘的是**表的形狀**與**它導出的三條性質**：
+
+1. 三份登入態進得了登記表，且是由表機械導出（不是三行手寫的 `asset_paths()`）；
+2. reviewer 模板 unit 的 `ReadWritePaths` **逐字不變**——`HOME_REDIRECT_TREE` 的目標
+   落在該帳號既有的 `cache` 內，因此**零新增可寫面**；
+3. **二分方案的產出不含它們**（#640 記錄的陷阱：登記第二份會讓 Manager unit 的 RWP
+   指向一條不存在的路徑而起不來；#671 的 `inapplicable_home_anchored_assets()` 已把
+   那個阻礙拆成一條機械規則，本檔驗它仍然成立）。
+
+**為什麼驗收條件從「RWP 逐字含憑證檔案」改成上面第 2 條**：issue 原文寫的是前者，前提
+是「codex 的登入態＝一個 `auth.json`」。#686 在完整 reviewer unit 沙箱下實測推翻了那個
+前提——codex 需要 `$CODEX_HOME` **整個目錄**可寫（`state_5.sqlite`／`sessions/`／
+`plugins/`…），只放行單檔時它連起都起不來。照字面滿足原驗收會產出一個 **codex 仍然
+跑不起來**的部署，因此本票改走 `HOME_REDIRECT_TREE`，並把不變式換成**更強的那一條**：
+可寫面一格都沒有增加。差異在 PR body 逐條說明。
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from paulsha_cortex.trust_root import permgen, registry  # noqa: E402
+from paulsha_cortex.trust_root.permgen import (  # noqa: E402
+    DEFAULT_LAYOUT,
+    CREDENTIALED_ACCOUNTS,
+    CredentialShape,
+    EXECUTOR_CREDENTIALS,
+    FOUR_WAY_SCHEME,
+    IN_PLACE_CONTENT_WRITE_ASSETS,
+    PathLayout,
+    Principal,
+    SYMLINK_ASSETS,
+    THREE_WAY_SCHEME,
+    TWO_WAY_SCHEME,
+    UnregisteredExecutorCredentialError,
+    build_job_unit,
+    generate_plan,
+    inapplicable_home_anchored_assets,
+    read_write_paths,
+)
+
+PLANNER_ACCOUNT = DEFAULT_LAYOUT.reviewer_planner_account
+BUILDER_ACCOUNT = DEFAULT_LAYOUT.builder_account
+PLANNER_ASSETS = (
+    "reviewer-planner-codex-state",
+    "reviewer-planner-agy-state",
+    "reviewer-planner-claude-state",
+)
+
+
+def _reviewer_rwp(scheme=FOUR_WAY_SCHEME) -> tuple[str, ...]:
+    account = scheme.resolve(Principal.REVIEWER)
+    assert account is not None
+    return read_write_paths(
+        generate_plan(scheme),
+        DEFAULT_LAYOUT,
+        account,
+        extras=DEFAULT_LAYOUT.job_extra_write_paths(account),
+        retired=permgen.RETIRED_JOB_WRITE_ASSETS,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. U-5：表的形狀
+# ---------------------------------------------------------------------------
+
+def test_the_table_has_two_axes_and_both_are_consulted() -> None:
+    """per-(account, executor) 而不是 per-executor——差別要驗得出來。
+
+    判準：**同一個 executor 在兩個帳號上是兩種形狀**。builder×codex 仍是 #640 的
+    單檔（那份部署已存在、有 runbook 反向驗證），reviewer-planner×codex 是導進
+    `cache` 的狀態樹（#686 實測 codex 需要整棵可寫）。一張 per-executor 的表表達
+    不了這件事——這就是 U-5 要兩軸的具體理由。
+    """
+    builder = permgen.credential_for("builder", "codex")
+    planner = permgen.credential_for("reviewer-planner", "codex")
+    assert builder.shape is CredentialShape.IN_PLACE_FILE
+    assert planner.shape is CredentialShape.HOME_REDIRECT_TREE
+    assert builder is not planner
+
+
+def test_the_account_axis_is_the_u4_ratification() -> None:
+    """U-4 追認的範圍＝planner 帳號那一列有幾格。"""
+    assert dict(CREDENTIALED_ACCOUNTS)["builder"] == (
+        ("codex", CredentialShape.IN_PLACE_FILE),
+    )
+    planner_cells = dict(CREDENTIALED_ACCOUNTS)["reviewer-planner"]
+    assert [executor for executor, _shape in planner_cells] == ["codex", "agy", "claude"]
+    # 三格分屬三個 independence domain——那正是 R-3 描述的曝險面，也正是
+    # `select_secondary_planner()` 要有異質 planner 的前提。
+    assert len({e for e, _s in planner_cells}) == 3
+
+
+def test_every_table_row_is_a_registered_asset_and_vice_versa() -> None:
+    """兩軸展開 ⇔ 登記表，**雙向封閉**。少一邊就是「機制有、登記表不知道」。"""
+    from_table = set(permgen.credential_asset_ids())
+    # 判準取 `derived_in`（登記表自己宣告「這條路徑由誰導出」），而不是 asset_id 的
+    # 字串樣式——樣式比對會在下一個命名慣例出現時無聲失效。
+    from_registry = {
+        asset.asset_id
+        for asset in registry.ASSET_REGISTRY
+        if any("executor_credential_of" in src for src in asset.derived_in)
+    }
+    assert from_table == from_registry, (sorted(from_table), sorted(from_registry))
+    assert from_table == set(PLANNER_ASSETS) | {"builder-executor-credential"}
+    for asset_id in from_table:
+        assert asset_id in DEFAULT_LAYOUT.asset_paths(), asset_id
+
+
+def test_unregistered_cells_fail_closed_instead_of_guessing_a_path() -> None:
+    """猜一條路徑的後果是「指紋盯著不存在的檔、unit 放行錯的路徑」——兩者都靜默通過。"""
+    with pytest.raises(UnregisteredExecutorCredentialError):
+        permgen.credential_for("reviewer-planner", "copilot")
+    with pytest.raises(UnregisteredExecutorCredentialError):
+        DEFAULT_LAYOUT.executor_credential_of(PLANNER_ACCOUNT, "copilot")
+    # 表上沒有的**帳號**在 primary executor 上退回 #640 的單一部署決定（既有行為），
+    # 但問它的第二份憑證同樣 fail-closed。
+    gate = "cortex-gate"
+    assert DEFAULT_LAYOUT.executor_credential_of(gate).endswith("/.codex/auth.json")
+    with pytest.raises(UnregisteredExecutorCredentialError):
+        DEFAULT_LAYOUT.executor_credential_of(gate, "agy")
+
+
+def test_the_primary_relpath_stays_a_single_deployment_decision() -> None:
+    """`executor_credential_relpath` 沒有被表取代——它是表上那一格的**值**。
+
+    #640 的「換 executor 只改一個值」因此仍然成立；把它的值抄一份進表就是第二份真相。
+    """
+    alt = PathLayout(executor_credential_relpath=".claude/credentials.json")
+    assert alt.executor_credential_of(BUILDER_ACCOUNT).endswith("/.claude/credentials.json")
+    # 骨架那條 root-owned 保護跟著走（不是寫死 `.codex`）。
+    scaffold = {p: (o, m) for p, o, _g, m in alt.scaffold_directories(THREE_WAY_SCHEME)}
+    assert scaffold[alt.executor_credential_dir_of(BUILDER_ACCOUNT)] == ("root", 0o755)
+    # 表上有明確 relpath 的那幾格**不**受它影響。
+    assert alt.executor_credential_of(PLANNER_ACCOUNT, "agy").endswith("/.gemini")
+
+
+def test_relpath_shapes_are_validated_at_construction_time() -> None:
+    """值會被接成絕對路徑並嵌進 root 執行的 `ln`／`chown`，因此形狀在建構當下就驗。"""
+    for bad in ("/etc/passwd", "../../etc/passwd", "..", ".codex/a b", "./x"):
+        with pytest.raises(ValueError):
+            permgen._validate_home_relpath(bad)
+    for good in (".codex", ".gemini", ".codex/auth.json"):
+        permgen._validate_home_relpath(good)
+
+
+# ---------------------------------------------------------------------------
+# 2. U-7：agy（以及 codex／claude）的可寫狀態樹怎麼進登記表
+# ---------------------------------------------------------------------------
+
+def test_state_trees_are_registered_as_root_owned_symlinks() -> None:
+    """U-7 的裁決＝design 的 (a)：登記成 symlink 類資產（登記表新增的 kind）。"""
+    plan = generate_plan(FOUR_WAY_SCHEME)
+    for asset_id in PLANNER_ASSETS:
+        entry = plan.by_id(asset_id)
+        assert entry.is_symlink, asset_id
+        assert not entry.is_directory, asset_id
+        assert asset_id in SYMLINK_ASSETS, asset_id
+        # root-owned ⇒ job 換不掉指向；且**沒有任何跨帳號 ACL**。
+        assert entry.owner == FOUR_WAY_SCHEME.deploy_account == "root", asset_id
+        assert entry.acls == (), asset_id
+        assert entry.writer_accounts == frozenset({"root"}), asset_id
+
+
+def test_symlink_commands_never_use_a_bare_chown_or_chmod() -> None:
+    """Linux 的 `chown`／`chmod` 跟著 symlink 走 ⇒ 裸用會改到**目標樹**的 owner。
+
+    那棵樹歸 job 帳號正是本形狀的全部重點，所以這條不是風格檢查。
+    """
+    plan = generate_plan(FOUR_WAY_SCHEME)
+    for asset_id in PLANNER_ASSETS:
+        entry = plan.by_id(asset_id)
+        path = DEFAULT_LAYOUT.asset_paths()[asset_id]
+        target = DEFAULT_LAYOUT.symlink_targets()[asset_id]
+        cmds = entry.commands(path, target)
+        assert cmds[0] == f"ln -sfn {target} {path}"
+        assert cmds[1].startswith("chown -h "), cmds
+        assert not any(c.startswith("chmod ") for c in cmds), cmds
+        assert not any(c.startswith(f"chown {entry.owner}") for c in cmds), cmds
+
+
+def test_the_state_tree_target_lives_inside_the_accounts_own_cache() -> None:
+    """「不新增可寫面」的**前提**：目標必須落在該帳號本來就可寫的那一層裡。"""
+    cache = DEFAULT_LAYOUT.cache_of(PLANNER_ACCOUNT)
+    for asset_id, target in DEFAULT_LAYOUT.symlink_targets().items():
+        assert asset_id in PLANNER_ASSETS, asset_id
+        assert target.startswith(cache + "/"), (asset_id, target)
+
+
+def test_scaffold_creates_the_target_but_not_a_directory_at_the_symlink() -> None:
+    """骨架建的是**目標**；在 symlink 的位置建真目錄會把整條導向機制無聲換掉。"""
+    scaffold = {
+        path: (owner, mode)
+        for path, owner, _g, mode in DEFAULT_LAYOUT.scaffold_directories(FOUR_WAY_SCHEME)
+    }
+    for asset_id in PLANNER_ASSETS:
+        link = DEFAULT_LAYOUT.asset_paths()[asset_id]
+        target = DEFAULT_LAYOUT.symlink_targets()[asset_id]
+        assert link not in scaffold, asset_id
+        assert scaffold[target] == (PLANNER_ACCOUNT, 0o700), asset_id
+    # symlink 自己的保護來自 HOME 那一層。
+    assert scaffold[DEFAULT_LAYOUT.home_of(PLANNER_ACCOUNT)] == ("root", 0o755)
+
+
+def test_the_token_leaf_is_what_the_fingerprint_should_stat() -> None:
+    """登記表要的是「要保護的節點」，指紋要的是「refresh 之後會變的檔」。
+
+    兩者在 `HOME_REDIRECT_TREE` 下不同；`stat` 一條 symlink 只看得到目標**目錄**的
+    mtime，而 token 就地覆寫時它不變 ⇒ 「憑證換了」偵測不到。
+    """
+    assert DEFAULT_LAYOUT.credential_token_path_of(PLANNER_ACCOUNT, "agy").endswith(
+        "/.gemini/antigravity-cli/antigravity-oauth-token"
+    )
+    assert DEFAULT_LAYOUT.credential_token_path_of(PLANNER_ACCOUNT, "codex").endswith(
+        "/.codex/auth.json"
+    )
+    assert DEFAULT_LAYOUT.credential_token_path_of(PLANNER_ACCOUNT, "claude").endswith(
+        "/.claude/.credentials.json"
+    )
+    # `IN_PLACE_FILE` 兩者相同。
+    assert DEFAULT_LAYOUT.credential_token_path_of(
+        BUILDER_ACCOUNT
+    ) == DEFAULT_LAYOUT.executor_credential_of(BUILDER_ACCOUNT)
+
+
+# ---------------------------------------------------------------------------
+# 3. 驗收：零新增可寫面（取代 issue 原文的「RWP 逐字含憑證檔案」，理由見模組 docstring）
+# ---------------------------------------------------------------------------
+
+def test_home_redirect_adds_no_writable_surface_to_the_reviewer_unit() -> None:
+    """reviewer 模板 unit 的 `ReadWritePaths` **逐字不變**，且憑證面仍然可寫。
+
+    這條比 issue 原文的驗收更強：不是「多一條放行」，是「一條都不必多」。機制是
+    `_minimize()`——目標落在 `cache` 之內，被那條既有的 RWP 涵蓋。
+    """
+    unit = build_job_unit(FOUR_WAY_SCHEME, principal=Principal.REVIEWER)
+    assert set(unit.read_write_paths) == {
+        DEFAULT_LAYOUT.cache_of(PLANNER_ACCOUNT),
+        DEFAULT_LAYOUT.review_verdict_spool_root,
+    }, unit.read_write_paths
+    for asset_id in PLANNER_ASSETS:
+        link = DEFAULT_LAYOUT.asset_paths()[asset_id]
+        target = DEFAULT_LAYOUT.symlink_targets()[asset_id]
+        assert link not in unit.read_write_paths, asset_id
+        assert target not in unit.read_write_paths, asset_id
+        # 但**寫得進去**：目標被 cache 那一條涵蓋。
+        assert target.startswith(DEFAULT_LAYOUT.cache_of(PLANNER_ACCOUNT) + "/")
+
+
+def test_the_builder_in_place_credential_is_untouched() -> None:
+    """#640 裁決 (b) 一行未改——RWP 逐字掛在**檔案本身**，不是它的父目錄。"""
+    unit = build_job_unit(FOUR_WAY_SCHEME, principal=Principal.BUILDER)
+    credential = DEFAULT_LAYOUT.executor_credential_of(BUILDER_ACCOUNT)
+    assert "builder-executor-credential" in IN_PLACE_CONTENT_WRITE_ASSETS
+    assert credential in unit.read_write_paths
+    parent = DEFAULT_LAYOUT.executor_credential_dir_of(BUILDER_ACCOUNT)
+    assert parent not in unit.read_write_paths
+    assert not any(
+        parent == rwp or parent.startswith(rwp.rstrip("/") + "/")
+        for rwp in unit.read_write_paths
+    ), unit.read_write_paths
+
+
+def test_the_state_trees_are_absent_from_manager_and_monitor_units() -> None:
+    """job 的登入態不屬於 Manager 的可寫面（兩個定案方案皆然）。"""
+    for scheme in (THREE_WAY_SCHEME, FOUR_WAY_SCHEME):
+        for unit in (
+            permgen.build_manager_unit(scheme, DEFAULT_LAYOUT),
+            permgen.build_monitor_unit(scheme, DEFAULT_LAYOUT),
+        ):
+            for asset_id in PLANNER_ASSETS:
+                path = DEFAULT_LAYOUT.asset_paths()[asset_id]
+                assert not any(
+                    path == rwp or path.startswith(rwp.rstrip("/") + "/")
+                    for rwp in unit.read_write_paths
+                ), (scheme.scheme_id, unit.unit_name, asset_id)
+
+
+# ---------------------------------------------------------------------------
+# 4. 驗收：二分方案的產出不含它（#640 的陷阱，#671 已拆）
+# ---------------------------------------------------------------------------
+
+def test_two_way_scheme_excludes_the_planner_credentials_mechanically() -> None:
+    """#640 當年「乾脆不登記第二份憑證」的唯一理由，在 #671 之後已經是一條機械規則。
+
+    二分方案把 reviewer／planner 併進 `cortex-svc`，那三條 HOME 路徑因此**不存在**；
+    systemd 對不存在的 `ReadWritePaths=` 目標會讓 unit 直接起不來。
+    """
+    plan = generate_plan(TWO_WAY_SCHEME)
+    excluded = {aid for aid, _p in inapplicable_home_anchored_assets(plan, DEFAULT_LAYOUT)}
+    for asset_id in PLANNER_ASSETS:
+        assert asset_id in excluded, asset_id
+    # 兩個定案方案則一格都不排除。
+    for scheme in (THREE_WAY_SCHEME, FOUR_WAY_SCHEME):
+        assert inapplicable_home_anchored_assets(generate_plan(scheme), DEFAULT_LAYOUT) == ()
+
+
+def test_two_way_units_never_reference_the_planner_home() -> None:
+    """把上一條的**後果**釘住：二分部署的每一份 unit 都不得出現那個 HOME。"""
+    planner_home = DEFAULT_LAYOUT.home_of(PLANNER_ACCOUNT)
+    units = [
+        permgen.build_manager_unit(TWO_WAY_SCHEME, DEFAULT_LAYOUT),
+        permgen.build_monitor_unit(TWO_WAY_SCHEME, DEFAULT_LAYOUT),
+    ]
+    for principal in permgen.downgraded_job_principals(TWO_WAY_SCHEME):
+        for profile in permgen.HARDENING_PROFILES:
+            units.append(
+                build_job_unit(
+                    TWO_WAY_SCHEME, DEFAULT_LAYOUT, principal=principal, profile=profile
+                )
+            )
+    for unit in units:
+        for rwp in unit.read_write_paths:
+            assert not rwp.startswith(planner_home), (unit.unit_name, rwp)
+
+
+def test_two_way_scaffold_creates_no_planner_state_trees() -> None:
+    """骨架同理——二分部署不該生出一棵沒有帳號的樹。"""
+    paths = {p for p, *_rest in DEFAULT_LAYOUT.scaffold_directories(TWO_WAY_SCHEME)}
+    planner_home = DEFAULT_LAYOUT.home_of(PLANNER_ACCOUNT)
+    assert not any(p.startswith(planner_home) for p in paths), sorted(paths)
+
+
+def test_two_way_symlink_commands_are_guarded_by_the_missing_home() -> None:
+    """權限 script 以 `sudo sh -e` 執行——`ln` 打在不存在的 HOME 會中止整份 script。"""
+    scheme = TWO_WAY_SCHEME.with_principal_accounts({
+        Principal.OPERATOR: permgen.ABSENT_ACCOUNT,
+        Principal.EXTERNAL: permgen.ABSENT_ACCOUNT,
+    })
+    lines = permgen.plan_to_commands(
+        generate_plan(scheme),
+        path_of=DEFAULT_LAYOUT.asset_paths(),
+        layout=DEFAULT_LAYOUT,
+        scheme=scheme,
+    )
+    guard = f"[ ! -e {DEFAULT_LAYOUT.home_of(PLANNER_ACCOUNT)} ] || "
+    ln_lines = [l for l in lines if " ln -sfn " in l or l.startswith("ln -sfn ")]
+    assert ln_lines, lines
+    for line in ln_lines:
+        assert line.startswith(guard), line
+
+
+# ---------------------------------------------------------------------------
+# 5. 逾期項：deferred 清單縮短，且沒有假裝關掉關不掉的那兩條
+# ---------------------------------------------------------------------------
+
+def test_the_overdue_reviewer_credential_entry_is_gone() -> None:
+    """#640 寫的「M2 落地時補第二列」——M2（#615）早已落地，本票補完它。"""
+    names = {item.name for item in permgen.deferred_run_dependencies()}
+    assert "reviewer-planner-executor-credential" not in names, sorted(names)
+
+
+def test_the_two_entries_that_could_not_be_closed_say_why() -> None:
+    """**沒關掉的兩條必須說得出新的阻礙，而不是留著舊理由。**
+
+    - `reviewer-planner-codex-hooks`：與 codex 的可用性在 `$CODEX_HOME` 這一層互斥
+      （U-9）；
+    - `manager-claude-credential`：U-5 解除了它的機械阻礙，但「要不要給 Manager 一份
+      模型憑證」的答案是不要，而它的消失要等票 F 切換。
+    """
+    by_name = {item.name: item for item in permgen.deferred_run_dependencies()}
+    hooks = by_name["reviewer-planner-codex-hooks"]
+    assert "U-9" in hooks.disposition
+    assert "CODEX_HOME" in hooks.reason
+    # 舊理由不得還「作為理由」留在上面——它必須是被**引述後推翻**的那一段。
+    assert "做不到" in hooks.reason and "#686" in hooks.reason
+    manager = by_name["manager-claude-credential"]
+    assert "#687" in manager.disposition
+    assert "executor_credential_relpath` 是**單一**部署決定" not in manager.reason
+
+
+def test_the_inventory_stays_closed_in_both_directions() -> None:
+    """新增資產必須同時被窮舉盤點列到——#671 的雙向封閉不得因為本票而破。"""
+    assert permgen.uncovered_run_dependencies() == ()
+    assert permgen.unlisted_roster_entries() == ()
+    listed = {dep.name for dep in permgen.RUN_EXTERNAL_DEPENDENCIES}
+    for asset_id in PLANNER_ASSETS:
+        assert asset_id in listed, asset_id
+
+
+# ---------------------------------------------------------------------------
+# 6. `HOME` 這條成對前置（#686 查到，憑證面與它必須一起成立）
+# ---------------------------------------------------------------------------
+
+def test_every_credential_path_is_home_rooted_so_home_must_be_declared() -> None:
+    """三份登入態全部以 `$HOME` 為根 ⇒ `HOME` 解不到時它們在 job 內一條都不存在。
+
+    模板模式下 shim 以 `os.execvpe` 整份換掉環境，unit 的 `Environment=HOME=` 到不了
+    模型（#686 實機更正）——因此 `PSC_REVIEWER_HOME` 是本票的**成對前置**，而不是
+    另一張票的事。症狀（`$HOME is not defined`／`Not logged in`）與「憑證沒放好」
+    長得一模一樣，這正是它必須被寫在同一個地方的理由。
+    """
+    home = DEFAULT_LAYOUT.home_of(PLANNER_ACCOUNT)
+    for asset_id in PLANNER_ASSETS:
+        assert DEFAULT_LAYOUT.asset_paths()[asset_id].startswith(home + "/"), asset_id
+    assert DEFAULT_LAYOUT.job_home_value(PLANNER_ACCOUNT) == home
+    unit = build_job_unit(FOUR_WAY_SCHEME, principal=Principal.REVIEWER)
+    assert f"PSC_REVIEWER_HOME={home}" in unit.content
+
+
+def test_the_home_env_names_match_the_job_runner_contract() -> None:
+    """permgen 與 job_runner 刻意不互相 import ⇒ 成對契約由測試釘住（比照 PATH）。"""
+    from paulsha_cortex.coordinator import job_runner
+
+    for principal, env_name in permgen.JOB_HOME_ENV_BY_PRINCIPAL.items():
+        role = {
+            Principal.BUILDER: job_runner.JOB_ROLE_BUILDER,
+            Principal.REVIEWER: job_runner.JOB_ROLE_REVIEW,
+            Principal.GATE: job_runner.JOB_ROLE_GATE,
+        }[principal]
+        assert job_runner.resolve_job_role(role).home_env == env_name, principal
+
+
+# ---------------------------------------------------------------------------
+# 7. OS 層語意：具名 skip（CI 重現不了，**不得靜默通過**）
+# ---------------------------------------------------------------------------
+
+@pytest.mark.skip(
+    reason=(
+        "需要**第二個 UID** 與真實 systemd 加固面才驗得到，CI 兩者皆無 ⇒ 斷言會恆真"
+        "（#638／#657 的假綠形態）。要驗的性質有三條，全部在 runbook 第 4e-2b 步以"
+        "`psc_run_under`（property 由 `permgen.unit_replica_properties()` 從**落檔的"
+        "unit** 全量導出，不得自行組 `--property=`、不得自帶 `--setenv=PATH=`，見"
+        "design D13）逐條實跑：\n"
+        "  (a) 以 cortex-reviewer-planner 身分 `ln -sfn /tmp/evil ~/.gemini` ⇒ 必須"
+        "      `Permission denied`（symlink 在 root-owned 的 HOME 裡，換不掉指向）；\n"
+        "  (b) 同一身分在 `~/.gemini/` 底下建檔 ⇒ 必須成功（目標在 cache 內，已在"
+        "      unit 的 RWP 中）——這一條同時證明「零新增可寫面」不是靠放棄可寫性換的；\n"
+        "  (c) `codex exec` 與 `claude -p` 在該 unit 的完整 property 集合下 rc=0"
+        "      （#686 的矩陣裡這兩格分別被 `$CODEX_HOME` 與 `Not logged in` 擋住，"
+        "      本票的部署步驟做完之後必須翻綠——那是驗收，不是推測）。\n"
+        "**本票沒有實機執行任何一條**：runbook 是給 operator 的，實機部署不在本票範圍。"
+    )
+)
+def test_planner_cannot_repoint_its_own_state_symlink() -> None:  # pragma: no cover
+    raise AssertionError("見 skip reason：本條由 runbook 第 4e-2b 步實機驗證")
+
+
+class TestSymlinkGuardOsSemantics:
+    """把「`chown` 跟著 symlink 走」對**真的檔案系統**驗一次（#638 的手法）。
+
+    這一條不需要第二個 UID：要驗的是 `chown` 的**解析語意**（跟不跟著 symlink），
+    而那在單 UID 下就成立。它守的是 `PermissionEntry.commands()` 為什麼一定要出
+    `chown -h`——裸 `chown` 會改到目標樹的 owner，而目標樹歸 job 帳號正是重點。
+    """
+
+    @pytest.mark.skipif(
+        os.geteuid() == 0, reason="root 不受 DAC 限制；本組驗的是解析語意，以非 root 跑"
+    )
+    def test_bare_chown_follows_the_link_and_lchown_does_not(self, tmp_path: Path) -> None:
+        target = tmp_path / "cache" / "gemini"
+        target.mkdir(parents=True)
+        link = tmp_path / ".gemini"
+        link.symlink_to(target)
+        before = target.stat()
+        # `chown -h` 對 symlink 本身；同 UID 下 owner 不變，但重點是**它不解析目標**。
+        subprocess.run(
+            ["chown", "-h", f"{os.getuid()}:{os.getgid()}", str(link)],
+            check=True, capture_output=True,
+        )
+        assert target.stat().st_ino == before.st_ino
+        # 反向：裸 `chmod` 打在 symlink 上會落到**目標**（Linux 無 lchmod）。
+        subprocess.run(["chmod", "0700", str(link)], check=True, capture_output=True)
+        assert oct(target.stat().st_mode & 0o777) == "0o700"
+        assert not link.is_symlink() or link.resolve() == target.resolve()


### PR DESCRIPTION
Closes #685

## 這張票做了什麼

把 planner／reviewer 帳號的憑證面 codify 進 permgen。現況是 **0818 手動部署**的
（`install` ＋ `ln -s`），**重跑 runbook 不會產生它們**；本票讓它可重現。

三條裁決（operator 0818，見 #685 comment）全部落地：

| | 裁決 | 落地形態 |
|---|---|---|
| **U-4** | 追認雙 domain | `cortex-reviewer-planner` 持有 openai／google／anthropic 三份登入態為核可狀態；**R-3 是明文接受的有界殘餘風險**，寫進登記表 note、CHANGELOG 與 `CREDENTIALED_ACCOUNTS` 的 docstring——後續任何「planner 攻擊面」討論中不得被當成未知 |
| **U-5** | 照設計做 | `executor_credential_relpath` 擴成 per-(account, executor) 表 |
| **U-7** | 照設計做 | agy 的可寫狀態樹以 **symlink 類資產**（design 的選項 (a)）進登記表 |

**本票沒有動實機部署**（unit／EnvironmentFile／`/var/lib/cortex` 狀態一律沒碰），
要 operator 做的事全部寫進 runbook 第 **4e-2b** 步。**沒有改 `PSC_JOB_RUNNER` 的預設**
（那是票 F／#687）。

---

## ⚠️ 驗收條件被 #686 的實測改寫——這一段請先讀

issue 原文的第一條驗收是「reviewer 模板 unit 的 RWP **逐字含憑證檔案（非父目錄）**」。
它的前提是 **「codex 的登入態＝一個 `auth.json`」**。票 E（#686）在完整 reviewer unit
沙箱下實測推翻了這個前提：

- codex 需要 **`$CODEX_HOME`（預設 `~/.codex`）整個目錄可寫**。唯讀時逐字回
  `Error: failed to initialize in-process app-server client: Read-only file system (os error 30)`；
- 且**與 cwd 無關**——cwd 換成可寫的 `/tmp` 症狀完全相同，維持唯讀 cwd 只把 `CODEX_HOME`
  指到可寫目錄則 **rc=0、輸出正確**；
- 它在底下建 `state_5.sqlite`／`logs_2.sqlite`／`queue_1.sqlite`／`memories_1.sqlite`／
  `sessions/`／`skills/`／`plugins/`／`thread-writer-locks/`／`models_cache.json`／
  `installation_id`——**檔名帶版本序號**，逐項列舉會在下一次 CLI 升版時無聲失效。

**照字面滿足原驗收，會產出一個 codex 仍然跑不起來的部署。** 因此我把不變式換成
**更強的那一條**，並在此明講差異：

> **模板 unit 的 `ReadWritePaths=` 逐字不變、零新增可寫面**，而三份登入態全部落在它
> **已經涵蓋**的 `cache` 底下 ⇒ 憑證面可寫、可 refresh，可寫面一格都沒有增加。

實際產出（`trust_root unit four-way --review-job`）：

```
ReadWritePaths=/var/lib/cortex-reviewer-planner/cache
ReadWritePaths=/var/lib/cortex/coordinator/review-verdicts
```

與本票之前**逐字相同**。有測試釘住
（`test_home_redirect_adds_no_writable_surface_to_the_reviewer_unit`）。

**builder 那一格的原驗收仍然逐字成立且一行未改**：`builder-executor-credential` 維持
#640 裁決 (b)，RWP 掛在**檔案本身**、父目錄 root-owned
（`test_the_builder_in_place_credential_is_untouched`）。

---

## per-(account, executor) 表的實際形狀

**兩軸**，交集就是登記表資產；`asset_paths()`／`scaffold_directories()`／
`IN_PLACE_CONTENT_WRITE_ASSETS`／`SYMLINK_ASSETS`／`_FILE_ASSET_IDS`／unit 的 RWP
**全部由它機械導出**，加一格憑證產生器一行都不必改。

**executor 軸**（`permgen.EXECUTOR_CREDENTIALS`）——一個 executor 的登入態長什麼樣：

```python
class CredentialShape(Enum):
    IN_PLACE_FILE      = "in-place-file"       # 單檔就地覆寫；RWP 掛檔案本身
    HOME_REDIRECT_TREE = "home-redirect-tree"  # 整棵可寫狀態樹；root-owned symlink → cache

@dataclass(frozen=True)
class ExecutorCredential:
    executor: str
    shape: CredentialShape
    relpath: str | None        # None ⇒ 由 PathLayout.executor_credential_relpath 供給
    asset_suffix: str          # 資產 id ＝ <帳號前綴>-<suffix>
    cache_target: str | None   # symlink 目標，**相對於該帳號的 cache**
    token_leaf: str            # 樹裡真正承載 token 的葉檔（只進註解／指紋，不另立資產）
```

| executor | shape | relpath | cache_target | token_leaf | asset_suffix |
|---|---|---|---|---|---|
| `codex` | `IN_PLACE_FILE` | *(layout 供給)* | — | — | `executor-credential` |
| `codex` | `HOME_REDIRECT_TREE` | `.codex` | `codex` | `auth.json` | `codex-state` |
| `agy` | `HOME_REDIRECT_TREE` | `.gemini` | `gemini` | `antigravity-cli/antigravity-oauth-token` | `agy-state` |
| `claude` | `HOME_REDIRECT_TREE` | `.claude` | `claude` | `.credentials.json` | `claude-state` |

**account 軸**（`permgen.CREDENTIALED_ACCOUNTS`）——哪個帳號被核可持有哪幾格
（key 是**資產 id 前綴**而非 OS 帳號名，因此與帳號改名無關）：

```python
{
  "builder":          (("codex", IN_PLACE_FILE),),
  "reviewer-planner": (("codex", HOME_REDIRECT_TREE),
                       ("agy",   HOME_REDIRECT_TREE),
                       ("claude", HOME_REDIRECT_TREE)),   # ← U-4 追認的範圍
}
```

展開後的四個登記表資產：

| asset_id | 路徑 | 形狀 |
|---|---|---|
| `builder-executor-credential` | `/var/lib/cortex-builder/.codex/auth.json` | 單檔（#640，未動） |
| `reviewer-planner-codex-state` | `/var/lib/cortex-reviewer-planner/.codex` → `…/cache/codex` | symlink |
| `reviewer-planner-agy-state` | `…/.gemini` → `…/cache/gemini` | symlink |
| `reviewer-planner-claude-state` | `…/.claude` → `…/cache/claude` | symlink |

**為什麼一定要 per-(account, executor) 而不是 per-executor**：`codex` 在 builder 上是
單檔、在 reviewer-planner 上是狀態樹。一張 per-executor 的表表達不了這件事——這就是
U-5 的具體理由，有測試逐條釘住（`test_the_table_has_two_axes_and_both_are_consulted`）。

**`executor_credential_relpath` 沒有被表取代**：它是表上 primary 那一格的**值**
（`relpath=None` 的那一列），#640 的「換 primary executor 只改一個值」因此仍然成立；
把值抄一份進表就是第二份真相。單參數的既有呼叫端（票 C 的指紋、runbook、測試）
行為逐字不變——`executor_credential_of(account, executor=PRIMARY)`。

---

## agy 的可寫狀態樹在登記表怎麼表達（U-7）

**一個 symlink 類資產**（登記表新增的 kind），不是「登記一個目錄」也不是 env 覆寫：

- `PermissionEntry.is_symlink`（由 `SYMLINK_ASSETS` 機械導出，而 `SYMLINK_ASSETS` 又由
  憑證表導出）；
- 命令形態是 **`ln -sfn` ＋ `chown -h`，刻意不出 `chmod`**。理由不是風格：Linux 沒有
  `lchmod`，而 `chown`／`chmod` 對 symlink 一律**跟著走** ⇒ 對 `~/.gemini` 裸 `chown`
  會把 `cache/gemini` **那棵樹**的 owner 改掉，而那棵樹歸 job 帳號正是本形狀的重點。
  有測試釘住（`test_symlink_commands_never_use_a_bare_chown_or_chmod`）；
- 守衛掛在**父目錄**：`[ ! -e /var/lib/cortex-reviewer-planner ] || ln -sfn …`。`ln` 是
  建立動作，「不存在就跳過」對它沒有意義；真正要跳過的是「本方案沒有這個帳號」。
  **副作用（刻意）**：`plan_to_commands()` 輸出的每一行仍然以既有的
  `install -d`／`chown`／`chmod`／`setfacl`／`[ ! -e ` 開頭，因此
  `test_commands_are_strings_only_and_never_execute` 的動詞白名單**一個字都不必改**；
- writers 只有 `INSTALLER` ⇒ `required_write_targets()` 機械地不收它 ⇒ **不會產生任何
  RWP 條目、也不會產生任何跨帳號 ACL**。

三條性質，全部是機械結果而非註解約定：

1. **不新增可寫面**——目標在 `cache` 內，`_minimize()` 吃掉子路徑；
2. **job 換不掉指向**——symlink 在 root-owned 的 HOME 裡（換 symlink 要對父目錄可寫）；
3. **骨架建的是目標、不是 symlink 的位置**——在 symlink 位置建真目錄會把整條導向機制
   無聲換掉；而目標**必須先存在**（對懸空 symlink 建目錄的 syscall 回 `EEXIST`，不是
   「建出目標」，executor 於是死在一個與權限完全無關的錯誤上）。

實際產出：

```
$ python3 -m paulsha_cortex.trust_root scaffold four-way | grep reviewer-planner/cache/
install -d -o cortex-reviewer-planner -g cortex-reviewer-planner -m 0700 /var/lib/cortex-reviewer-planner/cache/codex
install -d -o cortex-reviewer-planner -g cortex-reviewer-planner -m 0700 /var/lib/cortex-reviewer-planner/cache/gemini
install -d -o cortex-reviewer-planner -g cortex-reviewer-planner -m 0700 /var/lib/cortex-reviewer-planner/cache/claude

$ … permissions four-way --commands --paths | grep -A1 'reviewer-planner-agy-state'
[ ! -e /var/lib/cortex-reviewer-planner ] || ln -sfn /var/lib/cortex-reviewer-planner/cache/gemini /var/lib/cortex-reviewer-planner/.gemini
[ ! -e /var/lib/cortex-reviewer-planner ] || chown -h root:root /var/lib/cortex-reviewer-planner/.gemini
```

---

## 二分方案不含它是怎麼保證的

**機械排除，不是靠「不要登記」繞過去**——這正是 #640 當年那個阻礙，#671 已用
`inapplicable_home_anchored_assets()` 拆掉，本票只消費它、沒有重造：

三格的路徑由 `PathLayout.reviewer_planner_account` 這個**部署決定欄位**導出，而二分
方案把 reviewer／planner 併進 `cortex-svc` ⇒ `home_anchored_account()` 判定它們掛在一個
**本方案不存在的帳號** HOME 下 ⇒ `required_write_targets()` 直接跳過。三條測試釘住：

- `test_two_way_scheme_excludes_the_planner_credentials_mechanically`：三格都在
  `inapplicable_home_anchored_assets(TWO_WAY)` 的輸出裡，且兩個**定案**方案一格都不排除；
- `test_two_way_units_never_reference_the_planner_home`：二分部署的 **每一份** unit
  （manager／monitor ＋ 全部 job 模板 × 全部剖面）的 RWP 都不得出現那個 HOME
  ——這是 #640 記錄的症狀（Manager unit 指向不存在的路徑而起不來）的直接反面；
- `test_two_way_symlink_commands_are_guarded_by_the_missing_home`：權限 script 以
  `sudo sh -e` 執行，`ln` 打在不存在的 HOME 會**中止整份 script**，因此每一行 `ln`
  都必須帶父目錄守衛。

另外 `test_two_way_scaffold_creates_no_planner_state_trees` 確保骨架也不生出那棵樹。

---

## `deferred_run_dependencies()` 縮短了哪幾條

**4 → 3。關掉一條，另外兩條的理由整段換掉但留著。**

### ✅ 關閉：`reviewer-planner-executor-credential`

#640 寫「M2 落地時補第二列」，而 M2（#615）早已落地 ⇒ 逾期未做。#671 用一條測試把這個
事實釘住，並在 docstring 逐字寫著「哪天有人補上登記表第二列，這條會紅——**那正是提醒
去刪掉這條測試與那筆 deferred**」。**本 PR 就是那一天，我按它的設計意圖動了它**：

- `tests/test_trust_root_external_deps_exhaustive_666.py::test_the_reviewer_credential_gap_is_real_not_theoretical`
  → 翻成正向的 `…_is_closed_without_widening_the_write_surface`，斷言換成「三格都在
  `cache` 之內、都不出現在 RWP 上，而 `cache` 在」＋ builder 的對照組保留。

### 🔺 留著但理由整段換掉：`reviewer-planner-codex-hooks`（升為 **U-9**）

plan 原文要求本票一併關掉它，理由是「機制 per-account、登記表只登記一份，補第二列即可」。
**那個理由已被 #686 推翻**：codex 需要 `$CODEX_HOME` 整棵可寫，所以那個帳號的 `~/.codex`
是導進 `cache` 的 symlink，而**那棵樹由 job 帳號擁有**。hooks 放進去，job 對它的父目錄有
寫入權 ⇒ 隨時 unlink／rename 換掉 ⇒ 登記成 root-owned 的 Tier-0 enforcement 資產是
**名義上的**，不是真的。

**兩件事在 `$CODEX_HOME` 這一層互斥**：(i) codex 起得來（整棵可寫）、(ii) 同棵樹裡有一個
job 換不掉的 root-owned `hooks.json`。本票選 (i)——選 (ii) 的部署裡 codex 根本跑不起來，
hooks 也就沒有東西可以約束。

**候選解已寫進 disposition（U-9，交 operator）**：root-owned ＋ **sticky bit** ＋ 給 job
帳號一條 `rwx` ACL 的目錄（sticky 讓非 owner 只能刪自己的檔 ⇒ root-owned 的 hooks.json
換不掉）。**本票不做，兩個理由**：

1. 它要改 permgen 的 mode 管線——安全網 `_mask_write` 會拿掉 group 寫入位、
   `mode & 0o700` 會吃掉 sticky 位，那是 spec §R2 的既有不變式；
2. **「codex 能不能在一個它不擁有的 `$CODEX_HOME` 下跑起來」沒有實機證據**，而 #686
   量到的是「指到一個**可寫**目錄」。依 **D13**，未經落檔 unit 全量導出的實測不得宣稱可用。

**同一個裁決也涵蓋 builder**：它在模板 unit 下跑 codex 會撞同一條阻斷（`~/.codex` 是
root-owned 0755）。本票**沒有**改 builder——改它會同時賣掉 `codex-hooks` 的 enforcement，
屬同一個 operator 裁決。事實已寫進 `builder-executor-credential` 的 note 與 CHANGELOG。

### 🔺 留著：`manager-claude-credential`

plan 原文也要求刪它（「本票的裁決是『planning 一律走降權 job』」）。**我沒有刪，理由**：
那個裁決的**落地**是票 F（#687）的切換，而 direct 路徑今天逐字還在（`PSC_JOB_RUNNER`
預設未變）。U-5 只解除了它的**機械**阻礙（原 reason 寫的「單一部署決定表達不了兩份」現在
不成立了，已就地更正）；「要不要登記」的答案則是**不要**——Manager 是 durable state owner
＋ spawn 授權持有者，passwd 註記逐字寫著 `no model code`。現在刪等於宣稱一件還沒成立的事。
disposition 已改寫成「由票 F 收尾，隨 direct 路徑一起消失，而不是被登記」。

---

## claude 的憑證缺口（#686 矩陣裡的第二格紅燈）

#686 的驗收矩陣裡 claude 是「CLI rc=0、卻回
`{"is_error":true,…,"result":"Not logged in · Please run /login"}`」的那一列——擋住的是
**憑證**，不是加固面。而 **reviewer 的預設 executor 就是 claude**：缺它時「reviewer 已
降權」（#615 M2）買到的是一個跑不動的 job。

本票新增 `reviewer-planner-claude-state`（`~/.claude` → `cache/claude`，token 葉檔
`.credentials.json`）。job 模式下 `CLAUDE_CONFIG_DIR` 在 `job_runner.DENIED_ENV_NAMES` 內
（design D-g 的帳號隔離取代了 in-process 的一次性 config dir），因此 claude 解到的就是
`$HOME/.claude`——也就是本項。

---

## `PSC_REVIEWER_HOME`：憑證面與它必須一起成立

**是的，憑證路徑的解析依賴 `HOME`**——三份登入態全部是 `$HOME/.{codex,gemini,claude}`。
而模板模式下 shim 以 `os.execvpe` 把環境整份換掉，unit 的 `Environment=HOME=` **到不了
模型**（#686 實機更正）。沒有 `PSC_REVIEWER_HOME`，本票 codify 的路徑在 job 內**一條都
解不到**，而症狀（`$HOME is not defined`／`Not logged in`）與「憑證沒放好」長得一模一樣。

因此本票讓 permgen **出這個值**，與 #679 的 PATH 同一個形態（產生器出值、operator 落進
root-owned EnvironmentFile）：

- `permgen.JOB_HOME_ENV_BY_PRINCIPAL`（與 `job_runner.JOB_ROLE_CONFIG.home_env` 的成對
  契約由 `test_the_home_env_names_match_the_job_runner_contract` 釘住，比照既有的 PATH 表）；
- `PathLayout.job_home_value(account)`；
- 模板 unit 的憑證段直接印出 operator 要落的那一行：

```
#    root-owned EnvironmentFile 的 PSC_REVIEWER_HOME：
#      PSC_REVIEWER_HOME=/var/lib/cortex-reviewer-planner
```

**沒有改 `job_runner` 的 fail-open/closed 語意**（#686 已把理由寫進 `build_job_env()`
的 docstring，那屬獨立票）。部署面由 operator 處理（runbook 第 5-5c 步，#686 已建立）。

---

## 新增的安全退步 R-6（明講）

`HOME_REDIRECT_TREE` 的目標樹由 job 帳號擁有 ⇒ **樹裡的 token 葉檔可被該 job 刪除或
替換**（builder 的 `IN_PLACE_FILE` 擋得住「刪／換」，這裡擋不住）。

- **影響面**：限於該帳號自己的登入態。symlink 本身換不掉（在 root-owned 的 HOME 裡），
  跨帳號與跨 job 的面不受影響，可寫面一格都沒有增加。
- **換到的是**：codex／claude **能不能起得來**。
- **順帶修掉**一個 #640 刻意接受的代價：「暫存檔 ＋ rename 原子替換」形式的 refresh
  在這個形狀下走得通。
- **直接後果**：同一棵樹裡不得再放任何 root-owned 的 enforcement 檔 ⇒ U-9（見上）。

R-3（U-4 追認的雙／三 domain）在登記表 note、`CREDENTIALED_ACCOUNTS` 的 docstring、
runbook 與 CHANGELOG 四處逐字記錄，**不得在後續討論中被當成未知**。

---

## 既有測試的改動（逐條明講）

| 檔案／測試 | 改動 | 為什麼 |
|---|---|---|
| `…_666.py::test_deferred_dependencies_stay_enumerable` | 名單 4→3，docstring 補三條的處置 | **這條是刻意會紅的**——#671 的設計意圖就是「補上那一列時提醒你刪掉它」 |
| `…_666.py::test_the_reviewer_credential_gap_is_real_not_theoretical` | 翻成 `…_is_closed_without_widening_the_write_surface` | 同上，該測試的 docstring 逐字要求「哪天補上，刪掉這條測試」 |
| `…_666.py::test_home_anchored_assets_are_derived_not_hand_written` | 加三個 asset id | 新增的三格就是掛在帳號 HOME 下的資產；這條測試的存在意義就是強制它們被列 |
| `…_666.py::test_inapplicable_assets_are_enumerable_not_silent` | 二分的不適用集加三項 | 同上的二分側，**這正是驗收第 2 條的證據** |
| `test_trust_root_job_template_ab.py::test_every_model_job_account_gets_a_root_owned_codex_dir` | 改成分兩種形狀斷言 | reviewer-planner 的 `~/.codex` 現在是 symlink；「job 換不掉」沒有消失，換了守它的那一層（HOME） |
| `test_trust_root_job_template_ab.py::test_scaffold_covers_every_account_the_scheme_resolves` | 「無多餘」的允許集改由憑證表**導出** | 不手抄；新增一格憑證時自動涵蓋，原意（不得殘留別的 scheme 的帳號樹）未放寬 |

**其餘既有測試一行未改**，包含 `plan_to_commands` 與 `build_toolchain_plan` 的三處
**動詞白名單**——symlink 的兩行都以既有的 `[ ! -e ` 守衛開頭，因此白名單不必放寬。

`python3 -m pytest tests/ -q`：**4388 passed / 28 skipped**
（base 是 4364/27；新增 24 條測試 ＋ 1 條具名 skip）。

## OS 層語意的具名 skip（不得靜默通過）

`test_planner_cannot_repoint_its_own_state_symlink` 帶 `@pytest.mark.skip` ＋ 完整理由：
需要**第二個 UID** 與真實 systemd 加固面，CI 兩者皆無 ⇒ 斷言會恆真（#638／#657 的假綠
形態）。要驗的三條性質（換不掉指向／寫得進樹／三個 executor rc=0）全部寫進 runbook
第 4e-2b 步，一律走 `psc_run_under`。

另有 `TestSymlinkGuardOsSemantics` **不 skip**：它驗的是 `chown`／`chmod` 的**解析語意**
（跟不跟著 symlink），單 UID 下就成立——那是 `commands()` 為什麼一定要出 `chown -h`
的理由本身。

---

## 驗證方法紀律（D13）

- **未新增任何手寫的 `--property=` 清單、未自帶 `--setenv=PATH=`**（`git diff` 可查）。
  runbook 新增段落一律走既有共用探針 `psc_run_under`，其 property 由
  `permgen.unit_replica_properties()` 從**落檔的 unit** 全量導出。
- **本 PR 對「executor 在某剖面下可用」沒有做任何新的宣稱**。引用的三筆實測全部來自
  #686（在完整 unit 沙箱下量的），並逐條標明出處；本票新加的部署步驟其 rc 驗收寫成
  runbook 的**待驗項**（第 4e-2b 步驗證 4），不是已完成的斷言——codex 那一格在 #686
  當時是紅的，本票的部署做完之後**應該**翻綠，那是 operator 的驗收，不是我的宣稱。

## 我有沒有改到 `job_runner.py`

**沒有。** `git diff --stat origin/main` 的 `paulsha_cortex/` 只有三個檔：
`trust_root/permgen.py`、`trust_root/registry.py`、`coordinator/planning_probe_cache.py`。
票 E（#686／PR #691）已 merge 進 main，本分支已 rebase 其上。

## 票 C（#684）的接點

票 C 的 PR body 寫著「票 D codify 憑證面後跟著 `executor_credential_of` 的新簽章走即可，
不在本模組另造表」。已照做：`planning_probe_cache._credential_path(mode, env, executor)`
多吃一個 executor，形狀由 permgen 那張表決定。**一處超出照抄的收斂**：改 `stat`
**token 葉檔**（`credential_token_path_of()`）而不是資產節點——`stat` 一條 symlink 只看得到
目標**目錄**的 mtime，token 就地覆寫時它不變 ⇒「憑證換了」偵測不到，而票 C 的
`test_cache_invalidated_by_credential_fingerprint` 釘的正是這條。副作用是票 C 明列的
已知限制解除：agy 的 `~/.gemini` 與 claude 的 `~/.claude` **現在進得了指紋**。
未登記的 (account, executor) fail-closed，由 `_safe` 收成穩定的
`<unresolved:UnregisteredExecutorCredentialError>`——**取不到答案本身也是一個會變的答案**。

## 檢查清單

- [x] 分支 `feature/685-credential-codify`，未 commit 到 `main`
- [x] `changelog.d/685-credential-codify.md` 已新增並 commit
- [x] `CHANGELOG.md [Unreleased]` 有對應 entry
- [x] `python3 -m pytest tests/ -q` 全綠（4388 passed / 28 skipped）
- [x] 未修改實機部署（unit／EnvironmentFile／`/var/lib/cortex` 狀態一律沒碰）
- [x] 未改 `PSC_JOB_RUNNER` 的預設（票 F／#687）
- [x] 未改 `job_runner.py`
- [x] 加固面相關敘述全部引用 #686 的實測出處，未自行組 `--property=`、未自帶 `--setenv=PATH=`
