### PR TITLE
feat(planner): 切換、宣稱更正與收尾（#687／#672 票 F）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,76 @@
 ## [Unreleased]
 
 ### Fixed
+- **#687（#672 票 F）：planner 的 define／brainstorm 正式離開 Manager 行程——切換、
+  逐條宣稱更正，以及切換當下才撞得到的那一個阻斷**。四分部署的
+  `PSC_JOB_RUNNER=systemd-template` 讓 `planning_runtime._select_planning_invoker()`
+  恆回 `JobPlanningInvoker`（票 E／#686 land），planning 的每一次模型呼叫落成一個
+  `cortex-reviewer-job@`／`-jit@` 實例、`User=cortex-reviewer-planner` 由 root-owned
+  unit 決定。實機一輪 define 的證據：6 個模板 instance（`probe-1`／`probe-2`／
+  `probe-3`(jit)／`questioner-5`／`secondary-6`／`integrator-7`），全程
+  `systemd-cgls -u cortex-manager.service` **零 executor**（只有 daemon ＋ #604 的
+  `systemctl start --wait` 記帳 shell 兩層）；probe 快取五格的指紋 `job_runner_mode`
+  全為 `systemd-template`；`no-heterogeneous-planner` 消失
+  （primary＝`claude`/anthropic、secondary＝`agy`/google）。
+- **切換當天才浮出來的阻斷：`claude` 的 planning argv 結構性派不出 job**。
+  `_planning_argv()` 對 `claude` 產出 `["claude", "-p", …, "--tools", "", …]`，而
+  `job_runner.build_job_spec()` 與 `job_shim.load_spec()` 兩端都以 `all(argv)` 要求
+  「每個元素都是非空字串」⇒ **每一次** define 都落
+  `job-runner-job-spec-invalid`，且經 `question-pack-malformed` 被歸成 `content`。
+  `--tools ""` 是 CLI 的成文 API（`claude --help` 逐字 `Use "" to disable all tools`）
+  也是 #404 之後 planning「模型完全沒有工具」的唯一保證，不能改。判準因此收斂成
+  **`argv` 非空且 `argv[0]` 非空**（`job_runner.malformed_job_command()`，兩端各呼叫
+  一次同一支函式，比照 `forbidden_spec_keys()`）。
+  **「等價寫法」`--tools=` 已實測否決**：在真實 reviewer unit 的完整加固面下
+  （`psc_run_under`，38 條 property 全量導出）三臂對照，`--tools ""` 回 `NOTOOLS`、
+  `--tools=` **讓模型發出 Bash 工具呼叫**、不帶旗標則三個 turn。`<tools...>` 是
+  variadic，`--tools=` 不等於空清單——把它當等價寫法會讓吃 untrusted issue 內容的
+  planner 在降權 job 內拿回 Bash，而症狀是「planning 跑起來了」。
+- **這個阻斷為什麼躲過票 E 的驗收矩陣（可推廣的教訓）**：D13 的機械複本
+  （`permgen.unit_replica_properties()`／`psc_run_under`）複製的是**加固面**，
+  它證明得了「executor 在那個沙箱下跑得起來」，證明不了「**Manager 派得出那個
+  job**」。票 E 的 3/3 全綠與 `job-specs/reviewer/` 是空目錄這兩件事同時為真。
+  runbook 新增第 **5-6c** 步（planner／define 端到端）補上第二維，其 5 條檢查刻意
+  走 daemon 自己的派工路徑而不是手工 spec。
+
+### Changed
+- **`permgen.deferred_run_dependencies()` 移除 `manager-claude-credential`**——這是
+  票 D（#685）刻意留下、由本票收尾的一項。它從來不是「還沒補的憑證」，而是
+  「Manager 在 direct 模式下自己 exec `claude`」的登記表投影；切換之後 Manager 不再
+  exec 任何 executor ⇒ 本項**消失**，而不是被登記成一格資產（Manager 是 durable
+  state owner ＋ spawn 授權持有者，passwd 註記逐字寫著 `no model code`）。
+  測試同步翻成正向形態並**多守一條**：`manager_account not in CREDENTIALED_ACCOUNTS`
+  ——只驗「清單少一項」的話，「刪掉逾期項」與「把它登記成資產」看起來一模一樣。
+  逾期清單自 4 項（#666）→ 3 項（#685）→ **2 項**。
+
+### Documentation
+- **逐條更正「reviewer/planner 啟動面降權完成」這一族宣稱**（#672 明列，屬「不得順手
+  宣稱」紀律）。更正的原則是**改成精確描述，不是把「未完成」改成「完成」**：
+  - runbook 的 M1／M2 表拆成 **M2（reviewer，#615）** 與 **M2′（planner，#682-#687）**
+    兩列；「M2 之後可以宣稱的」那三句（「三個 persona 全部離開 Manager 的 UID」／
+    「injection 可達的進程皆無 spawn 授權**全稱**成立」／「D6 三分已生效」）逐句標明
+    **在 M2 之後仍是假的**，並註記這正是本 repo「為了收尾而宣稱過頭」的樣本案例——
+    下面那份「不得順手宣稱」清單看起來窮舉，卻漏掉最大的一項。
+  - 5-8 殘餘風險表的 `~~M2 未完成~~` 那一列拆成 reviewer／planner 兩列，並**保留原
+    那一列作為紀錄**：一句過寬的「已關閉」讓這個缺口在殘餘風險表上隱形了三天。
+  - `job_runner.JOB_ROLE_REVIEW` 的 rationale：從「M2：在此之前它們仍在 Manager
+    行程內」（對 planner 一直是**現在式**）改成兩張票、相隔三個月的分述。
+  - `launcher._downgraded_mode()`／`_job_role()`／`_is_review_persona()`：三處都補上
+    **範圍限定**。`_job_role()` 的「唯一決定點」與 `planning_runtime` 的「全庫唯一的
+    執行後端選擇點」原本互相矛盾——兩者其實是兩條 code path 各一個選擇點，全庫唯一
+    的是共用的 `resolve_runner_mode()`。`_is_review_persona()` 的 `read_only` 判準只
+    涵蓋 **workflow lane 的 planner 卡**，涵蓋不到 define／brainstorm；這個 docstring
+    是「planner 已經降權了」這個假直覺的來源之一。
+  - `permgen.DOWNGRADED_JOB_PRINCIPALS` 與 `registry` 的同一段（成對）：補一句
+    「本表是**產得出哪幾份 unit／spool**，不是**哪些執行路徑真的走上它**」——這兩件事
+    在 #615～#686 之間分岔了三個月，而產生器面永遠不會發現：unit 產得出來，只是沒有
+    人拿它起 job。
+  - runbook 的帳號表、A/B 兩層論述、5-1 邊界表、5-5 的 `PSC_JOB_RUNNER` 說明、5-6b
+    標題：逐處補上「哪一票讓這句成立」。
+  - README 的 `PSC_JOB_RUNNER` 段落補上 `systemd-template` 的四條涵蓋路徑，並點名
+    planning 是 #687 才接上的那一條。
+
+### Fixed
 - **#685（#672 票 D）：permgen 把 planner／reviewer 的憑證面 codify——`executor_credential_relpath`
   從**單一部署決定**擴成 **per-(account, executor) 表**（U-5 裁決）**。0818 的三份登入態是
   手工 `install` ＋ 手工 `ln -s` 落位的，**重跑 runbook 不會產生它們**；本票讓它可重現：

--- a/README.md
+++ b/README.md
@@ -112,6 +112,14 @@ cortex bootstrap --instance cortex --repo-root "$(git rev-parse --show-toplevel)
    token**）。**這個開關要在 `cortex-builder` 帳號與 polkit 規則就位之後才可打開**，
    步驟見 `docs/superpowers/runbooks/trust-root-phase2b-setup.md` 第 5 步；相關選配變數
    為 `PSC_BUILDER_ACCOUNT`／`PSC_BUILDER_GROUP`／`PSC_BUILDER_HOME`。
+
+   **`systemd-template` 是定案路徑（0816 第三輪裁決 B 案），涵蓋面比上一段廣**：
+   builder（#603／#584）、reviewer（#615）、gate（#629）、以及 **define／brainstorm
+   的 planning**（#672 票 A～F／#682-#687）四條執行路徑全部改經 root-owned 模板 unit。
+   最後一條是 #687 才接上的：在那之前 planning 走 `planning_runtime` 而非
+   `SubprocessLauncher`，`PSC_JOB_RUNNER` 對它**完全沒有效果**，模型 CLI 就在 Manager
+   行程內以 `cortex-manager` 執行（該帳號的 passwd 註記逐字寫著 `no model code`）。
+   `systemd-run`（A 案）對 planning **fail-closed，不退回行程內執行**。
    **`PSC_BUILDER_PATH` 不是選配**（#679）：它與 `PSC_REVIEWER_PATH`／`PSC_GATE_PATH`
    同為**必填**，未宣告時 Manager 在派工前即 fail-closed。值由產生器導出，不要手打：
    `python3 -m paulsha_cortex.trust_root unit four-way --job | grep '^Environment=PATH='`。

--- a/changelog.d/687-planner-switch.md
+++ b/changelog.d/687-planner-switch.md
@@ -1,0 +1,69 @@
+### Fixed
+- **#687（#672 票 F）：planner 的 define／brainstorm 正式離開 Manager 行程——切換、
+  逐條宣稱更正，以及切換當下才撞得到的那一個阻斷**。四分部署的
+  `PSC_JOB_RUNNER=systemd-template` 讓 `planning_runtime._select_planning_invoker()`
+  恆回 `JobPlanningInvoker`（票 E／#686 land），planning 的每一次模型呼叫落成一個
+  `cortex-reviewer-job@`／`-jit@` 實例、`User=cortex-reviewer-planner` 由 root-owned
+  unit 決定。實機一輪 define 的證據：6 個模板 instance（`probe-1`／`probe-2`／
+  `probe-3`(jit)／`questioner-5`／`secondary-6`／`integrator-7`），全程
+  `systemd-cgls -u cortex-manager.service` **零 executor**（只有 daemon ＋ #604 的
+  `systemctl start --wait` 記帳 shell 兩層）；probe 快取五格的指紋 `job_runner_mode`
+  全為 `systemd-template`；`no-heterogeneous-planner` 消失
+  （primary＝`claude`/anthropic、secondary＝`agy`/google）。
+- **切換當天才浮出來的阻斷：`claude` 的 planning argv 結構性派不出 job**。
+  `_planning_argv()` 對 `claude` 產出 `["claude", "-p", …, "--tools", "", …]`，而
+  `job_runner.build_job_spec()` 與 `job_shim.load_spec()` 兩端都以 `all(argv)` 要求
+  「每個元素都是非空字串」⇒ **每一次** define 都落
+  `job-runner-job-spec-invalid`，且經 `question-pack-malformed` 被歸成 `content`。
+  `--tools ""` 是 CLI 的成文 API（`claude --help` 逐字 `Use "" to disable all tools`）
+  也是 #404 之後 planning「模型完全沒有工具」的唯一保證，不能改。判準因此收斂成
+  **`argv` 非空且 `argv[0]` 非空**（`job_runner.malformed_job_command()`，兩端各呼叫
+  一次同一支函式，比照 `forbidden_spec_keys()`）。
+  **「等價寫法」`--tools=` 已實測否決**：在真實 reviewer unit 的完整加固面下
+  （`psc_run_under`，38 條 property 全量導出）三臂對照，`--tools ""` 回 `NOTOOLS`、
+  `--tools=` **讓模型發出 Bash 工具呼叫**、不帶旗標則三個 turn。`<tools...>` 是
+  variadic，`--tools=` 不等於空清單——把它當等價寫法會讓吃 untrusted issue 內容的
+  planner 在降權 job 內拿回 Bash，而症狀是「planning 跑起來了」。
+- **這個阻斷為什麼躲過票 E 的驗收矩陣（可推廣的教訓）**：D13 的機械複本
+  （`permgen.unit_replica_properties()`／`psc_run_under`）複製的是**加固面**，
+  它證明得了「executor 在那個沙箱下跑得起來」，證明不了「**Manager 派得出那個
+  job**」。票 E 的 3/3 全綠與 `job-specs/reviewer/` 是空目錄這兩件事同時為真。
+  runbook 新增第 **5-6c** 步（planner／define 端到端）補上第二維，其 5 條檢查刻意
+  走 daemon 自己的派工路徑而不是手工 spec。
+
+### Changed
+- **`permgen.deferred_run_dependencies()` 移除 `manager-claude-credential`**——這是
+  票 D（#685）刻意留下、由本票收尾的一項。它從來不是「還沒補的憑證」，而是
+  「Manager 在 direct 模式下自己 exec `claude`」的登記表投影；切換之後 Manager 不再
+  exec 任何 executor ⇒ 本項**消失**，而不是被登記成一格資產（Manager 是 durable
+  state owner ＋ spawn 授權持有者，passwd 註記逐字寫著 `no model code`）。
+  測試同步翻成正向形態並**多守一條**：`manager_account not in CREDENTIALED_ACCOUNTS`
+  ——只驗「清單少一項」的話，「刪掉逾期項」與「把它登記成資產」看起來一模一樣。
+  逾期清單自 4 項（#666）→ 3 項（#685）→ **2 項**。
+
+### Documentation
+- **逐條更正「reviewer/planner 啟動面降權完成」這一族宣稱**（#672 明列，屬「不得順手
+  宣稱」紀律）。更正的原則是**改成精確描述，不是把「未完成」改成「完成」**：
+  - runbook 的 M1／M2 表拆成 **M2（reviewer，#615）** 與 **M2′（planner，#682-#687）**
+    兩列；「M2 之後可以宣稱的」那三句（「三個 persona 全部離開 Manager 的 UID」／
+    「injection 可達的進程皆無 spawn 授權**全稱**成立」／「D6 三分已生效」）逐句標明
+    **在 M2 之後仍是假的**，並註記這正是本 repo「為了收尾而宣稱過頭」的樣本案例——
+    下面那份「不得順手宣稱」清單看起來窮舉，卻漏掉最大的一項。
+  - 5-8 殘餘風險表的 `~~M2 未完成~~` 那一列拆成 reviewer／planner 兩列，並**保留原
+    那一列作為紀錄**：一句過寬的「已關閉」讓這個缺口在殘餘風險表上隱形了三天。
+  - `job_runner.JOB_ROLE_REVIEW` 的 rationale：從「M2：在此之前它們仍在 Manager
+    行程內」（對 planner 一直是**現在式**）改成兩張票、相隔三個月的分述。
+  - `launcher._downgraded_mode()`／`_job_role()`／`_is_review_persona()`：三處都補上
+    **範圍限定**。`_job_role()` 的「唯一決定點」與 `planning_runtime` 的「全庫唯一的
+    執行後端選擇點」原本互相矛盾——兩者其實是兩條 code path 各一個選擇點，全庫唯一
+    的是共用的 `resolve_runner_mode()`。`_is_review_persona()` 的 `read_only` 判準只
+    涵蓋 **workflow lane 的 planner 卡**，涵蓋不到 define／brainstorm；這個 docstring
+    是「planner 已經降權了」這個假直覺的來源之一。
+  - `permgen.DOWNGRADED_JOB_PRINCIPALS` 與 `registry` 的同一段（成對）：補一句
+    「本表是**產得出哪幾份 unit／spool**，不是**哪些執行路徑真的走上它**」——這兩件事
+    在 #615～#686 之間分岔了三個月，而產生器面永遠不會發現：unit 產得出來，只是沒有
+    人拿它起 job。
+  - runbook 的帳號表、A/B 兩層論述、5-1 邊界表、5-5 的 `PSC_JOB_RUNNER` 說明、5-6b
+    標題：逐處補上「哪一票讓這句成立」。
+  - README 的 `PSC_JOB_RUNNER` 段落補上 `systemd-template` 的四條涵蓋路徑，並點名
+    planning 是 #687 才接上的那一條。

--- a/docs/superpowers/runbooks/trust-root-phase2b-setup.md
+++ b/docs/superpowers/runbooks/trust-root-phase2b-setup.md
@@ -62,6 +62,12 @@ OS** 的手動流程。
 - **A（三分）縮小「誰持有授權」**：polkit 的 subject 只有 `cortex-manager`，而
   `cortex-manager` **不跑任何模型程式碼**。prompt injection 可達的進程
   （builder／reviewer／planner job）因此**完全不在授權面上**。
+  > **這句在 #687（M2′）之後才對 planner 成立。** #615 之後到 #687 之前，
+  > define／brainstorm 的模型 CLI 就在 `cortex-manager` 的行程樹裡跑（#672），
+  > 而 planning 的 prompt 逐字含 untrusted issue 內容——「injection 可達的進程完全
+  > 不在授權面上」在那段期間是**假的**。現在的實機證據：一次 planning 呼叫期間
+  > `systemd-cgls -u cortex-manager.service` 只有 daemon ＋ `systemctl start --wait`
+  > 兩層，零 executor（第 5-6c 步）。
 - **B（template unit）縮小「授權能做什麼」**：被授權的唯一動作是 start／stop 一個
   **root-owned** template 的 instance；`User=cortex-builder`、加固段、`ExecStart=` 全部
   寫死在 root 擁有的檔案裡。**即使 `cortex-manager` 整個被攻陷，也改不了 `User=`、
@@ -79,14 +85,28 @@ OS** 的手動流程。
 | 里程碑 | 內容 | 本 runbook |
 |---|---|---|
 | **M1** | 三帳號建立、**檔案權限面完整三分**、builder job 經 `cortex-job@.service`／`cortex-job-jit@.service` 降權、polkit 只授 `cortex-manager` 對這**兩個具名模板** | ✅ 已於 2026-08-17 實機完成 |
-| **M2** | reviewer／planner job 也改經 template instance（`User=cortex-reviewer-planner`）落到自己的帳號 | ✅ 程式碼已落地（**#615**）。落檔與驗證步驟已收進本 runbook：第 5-2 步落**四份** unit、5-4 polkit 涵蓋四個字幹、5-5 補 reviewer 的 env、5-6b 正向、5-7 反向、8b-2 verdict 端到端 |
+| **M2** | **reviewer** 的模型 job 改經 template instance（`User=cortex-reviewer-planner`）落到自己的帳號 | ✅ 程式碼已落地（**#615**）。落檔與驗證步驟已收進本 runbook：第 5-2 步落**四份** unit、5-4 polkit 涵蓋四個字幹、5-5 補 reviewer 的 env、5-6b 正向、5-7 反向、8b-2 verdict 端到端。**⚠️ M2 不含 planner 的 define／brainstorm**，見下方 M2′ |
+| **M2′** | **planner（define／brainstorm）** 的模型呼叫改經同一份 template instance | ✅ 程式碼 **#682～#686**（#672 票 A～E）、切換與實機驗收 **#687**（票 F）。驗證步驟見第 5-6c 步 |
 
-**M2 之後可以宣稱的**：三個會跑模型的 persona（builder／reviewer／planner）**啟動面
-全部離開 Manager 的 UID**，且每一個的 `User=` 都寫死在 root-owned 的 template unit 裡
-——「**injection 可達的進程皆無 spawn 授權**」這條的**全稱**因此成立，D6 的「三分已
-生效」不再被 #615 blocking。
+**M2 之後可以宣稱的（逐字，不得放大）**：**builder 與 reviewer** 兩個 persona 的模型
+job **啟動面已離開 Manager 的 UID**，且兩者的 `User=` 都寫死在 root-owned 的 template
+unit 裡。
 
-**M2 仍未涵蓋的（不得順手宣稱）**：
+**M2 當時不成立、要到 M2′（#687）才成立的**：
+
+- 「**三個**會跑模型的 persona 啟動面全部離開 Manager 的 UID」——**M2 之後這句是假的**。
+  planner 的 define／brainstorm 走的是 `planning_runtime._invoke_json()`，一條**完全
+  不經過 `SubprocessLauncher`** 的 code path，#615 一行都沒有碰到它（#672 的證據鏈）。
+- 「**injection 可達的進程皆無 spawn 授權**」這條的**全稱**——planning 的 prompt 逐字
+  含 untrusted issue 內容，而它在 M2′ 之前就在 `cortex-manager`（唯一的 polkit
+  subject）的行程裡跑。全稱在那之前**恰恰不成立**。
+- 「D6 的**三分已生效**」——對 planner 這一支在 M2′ 之前不成立。
+
+> **這三句在 #615 當時就被寫進本節，是本 repo「為了收尾而宣稱過頭」的樣本案例**：
+> 下面那份「不得順手宣稱」清單看起來窮舉，卻漏掉了最大的一項。#687 逐條更正它們，
+> 並補上 planner 那一條（見下）。M2′ 的實機證據見第 5-6c 步。
+
+**M2′ 之後仍未涵蓋的（不得順手宣稱）**：
 
 - **gate 執行身分**（#629）：gate 命令在 builder 完全掌控的 worktree 裡跑，`pytest`
   會載入該 worktree 的 `conftest.py` ⇒ 執行者取得任意程式碼執行。**刻意不掛在
@@ -102,6 +122,14 @@ OS** 的手動流程。
 - **reviewer 的工作樹位置**：仍是 Manager provision 的 review worktree
   （`<來源樹>/.psc-review-worktrees/…`），不是 per-job clone。reviewer 是 read-only
   契約，對它只需**唯讀**可達；per-job clone 化屬 #623／#648 的範圍。
+- **planner 的 `codex` executor 在 job 模式下不 ready**（#687 實測）：`codex exec --json`
+  的第二輸出候選 `-o last.json` 落在 job 的 `PrivateTmp` 私有 `/tmp`，Manager 讀不到
+  ⇒ `_extract_json` 只剩單一候選 ⇒ probe 落 `planning-output-malformed`。這是票 E
+  （#686）**已具名的安全退步 R-2**，不是新缺口；淨效果是 planning 的異質性由
+  `claude`（anthropic）＋`agy`（google）承擔，`codex` 這一格落選並在拒因表上現形。
+- **`cg` executor 結構性不可用**：未登記於 `EXECUTOR_HARDENING_PROFILE` ⇒
+  `prepare_systemd_template` fail-closed ⇒ probe 永遠 not ready。**這是設計要的**
+  （剖面表是白名單），拒因表逐字記錄它。
 
 ---
 
@@ -484,7 +512,7 @@ PY
 
 | 帳號 | 跑什麼 | durable state owner | 持 spawn 授權（polkit subject） |
 |---|---|:--:|:--:|
-| `cortex-manager` | Manager ＋ monitor。**不跑任何模型程式碼** | ✔ | ✔ |
+| `cortex-manager` | Manager ＋ monitor。**不跑任何模型程式碼**（此欄自 **#687** 起才對**全部**執行面成立：builder＝#603／#584、reviewer＝#615、**planner 的 define／brainstorm＝#687**。passwd 的 `no model code` 註記在此之前對 define 階段是假的——見 #672） | ✔ | ✔ |
 | `cortex-reviewer-planner` | reviewer ＋ planner 模型 job | ✘ | ✘ |
 | `cortex-builder` | builder 模型 job（會跑 untrusted repo code） | ✘ | ✘ |
 | **`cortex-gate`**（#629） | operator 宣告的 gate 命令（`PSC_GATE_CMD_*`）。**不跑模型**，但跑 builder 工作樹裡的 `conftest.py`／plugin ⇒ 同樣是 untrusted 執行 | ✘ | ✘ |
@@ -2632,7 +2660,7 @@ for d in p.deferred_run_dependencies(): print('-', d.name, '→', d.disposition)
 | (a) | **polkit 規則** | `/etc/polkit-1/rules.d/49-cortex-downgrade.rules` | root:root 0644 | 只有 `cortex-manager`、只有 `start`／`stop`、只有四個**具名**模板（`cortex-job@` / `cortex-job-jit@` / `cortex-reviewer-job@` / `cortex-reviewer-job-jit@`，皆 `*.service`）。**不授權 `manage-units` 的 transient 建立** |
 | (b) | **template unit ×4** | `/etc/systemd/system/cortex-job@.service`（builder, strict）<br>`cortex-job-jit@.service`（builder, jit，#643）<br>`cortex-reviewer-job@.service`（reviewer＋planner, strict，#615）<br>`cortex-reviewer-job-jit@.service`（reviewer＋planner, jit） | root:root 0644 | `User=` 寫死、加固段寫死、`ExecStart=` 寫死。呼叫端**選不了 UID、傳不了屬性**。四份的差異只有兩軸：加固剖面（`MemoryDenyWriteExecute`）與帳號（`User=`／HOME／RWP），見 5-2 |
 | (c) | **shim** | `/opt/cortex/bin/cortex-job-shim` | root:root 0755 | `ExecStart=` 的實體。argv 的**形狀**由 root-owned 程式從 Manager-owned job-spec 導出；Manager 只能給參數 |
-| — | **三分帳號事實** | — | — | polkit 的 subject 只有 `cortex-manager`，而它**不跑任何模型程式碼**；injection 可達的 job 帳號完全不在授權面上 |
+| — | **三分帳號事實** | — | — | polkit 的 subject 只有 `cortex-manager`，而它**不跑任何模型程式碼**（builder＝#603／#584、reviewer＝#615、**planner 的 define／brainstorm＝#687**；三票缺任一則本格不成立）；injection 可達的 job 帳號完全不在授權面上 |
 
 三者缺一都不成立：
 - 少了 (a)，`cortex-manager` 起不了 job（fail-closed，不會退回同 UID）。
@@ -3452,9 +3480,19 @@ exec /opt/cortex/venv/bin/python -c "import os; from paulsha_cortex.coordinator 
 > **不是**讓 builder 自己 `login`（toolchain 未落位前 `login` 這個動作本身就跑不起來，
 > 而且 job 的 HOME 是 root-owned，CLI 也建不了 `auth.json`）。Manager 不會在執行期把
 > 自己的憑證傳過去——job 的登入態是一次性的部署動作。
-> **#615 M2 起**：`PSC_JOB_RUNNER` 對**三個** persona 都生效。persona 不再決定
+> **#615 M2 起**：`PSC_JOB_RUNNER` 對**走 `SubprocessLauncher` 的三個 persona**
+> （builder／reviewer／workflow lane 的 planner 卡）都生效。persona 不再決定
 > 「降不降權」，只決定**降到哪個角色**（builder／review）——判定點在
 > `launcher.SubprocessLauncher._job_role()`，由 launcher 的建構契約導出，job 側碰不到。
+>
+> **#687（M2′）起有第二個消費者，而它不在 launcher 上**：define／brainstorm 的
+> planning **不建立 `SubprocessLauncher`**，它讀同一個 `PSC_JOB_RUNNER`，經
+> `planning_runtime._select_planning_invoker()` 選 `JobPlanningInvoker`。
+> 兩處共用**同一支** `job_runner.resolve_runner_mode()`（刻意不新增
+> `PSC_PLANNING_INVOKER` 之類的第二個開關），但**選擇點有兩個**——
+> 「判定點只有 `_job_role()` 一個」這句在 #687 之後要讀成「launcher 這條路徑上
+> 只有一個」。這正是 #672 之所以能存在三個月而沒被發現的機制：所有人都在讀
+> launcher，而 planner 從來不經過它。
 >
 > **角色判定的三個來源（缺一即誤判）**：`review_only`（workflow lane reviewer）、
 > `read_only`（planner）、**`verdict_spool_dir is not None`（slice lane 的 foreign
@@ -3681,10 +3719,15 @@ sudo journalctl -u "cortex-job@$JOB.service" -n 20 --no-pager
 sudo -u cortex-manager systemctl stop "cortex-job@$JOB.service"; echo "exit=$?"   # 期望 0
 ```
 
-### 5-6b. 正向驗證（**reviewer／planner 模板**，#615 M2）
+### 5-6b. 正向驗證（**reviewer 模板**，#615 M2）
 
 > **與 5-6 逐條同構，只換模板名與帳號。** 它要證明的是一件 M1 完全沒有證據的事：
 > reviewer 的 job **不是**以 `cortex-manager` 跑的，也**不是**以 `cortex-builder` 跑的。
+>
+> **標題原本寫「reviewer／planner 模板」，#687 改掉了。** 本節的 spec 由手工寫、
+> 走 builder spool、驗的是 reviewer 面；planner 的 define／brainstorm 那一半在本節
+> **沒有任何證據**（它連 `job-specs/reviewer/` 都沒寫過一個檔——#686 查證、#687 於
+> 實機複驗：切換當天該目錄為空）。planner 的正向驗證是**第 5-6c 步**。
 >
 > 同 5-6 的誠實邊界：這一段是手工 spec，**只驗隔離、驗不了功能**；功能面由第 8b-2 步
 > 的真實 dispatch 驗。
@@ -3763,6 +3806,85 @@ sudo rm -rf /var/lib/cortex/coordinator/review-verdicts/probe
 sudo rm -f "/var/lib/cortex/coordinator/job-specs/reviewer/$RJOB.json" \
            "/var/lib/cortex-reviewer-planner/cache/$RJOB.log"
 ```
+
+### 5-6c. 正向驗證（**planner／define 端到端**，#687 M2′）
+
+> **這一節是本 runbook 的新增缺口**（#687 查到）：#615～#686 之間，全文對
+> `define`／`brainstorm` **零覆蓋**——5-6b 驗 reviewer、8b-2 驗 verdict 通道，
+> 沒有任何一步碰過 planning 這條 code path。缺口的具體代價是 `job-specs/reviewer/`
+> 在切換當天仍是**空目錄**：那條通道從來沒有被端到端跑過，而所有人都以為它跑過了。
+>
+> **與 5-6b 的差別是「誰組 spec」**：5-6b 的 spec 由 operator 手工寫進 spool，
+> 因此它驗得了加固面與身分、**驗不到 Manager 側的 `build_job_spec()`**。5-6c 走的是
+> daemon 自己的派工路徑，這一段才是 #687 唯一撞到的那個阻斷點（`claude` 的
+> `--tools ""` 撞上 `build_job_spec` 的 `not all(argv)`）。
+> **教訓可推廣**：`psc_run_under`／`unit_replica_properties()` 複製的是**加固面**，
+> 它證明得了「executor 在那個沙箱下跑得起來」，證明不了「Manager 派得出那個 job」。
+> D13 沒有錯，它只是不涵蓋這一維——**兩維都要有實跑證據**。
+
+```bash
+# 前置：`PSC_JOB_RUNNER=systemd-template` 已在 EnvironmentFile 內（5-5），daemon 已重啟。
+#       planning 與 reviewer 共用同一份模板 unit，因此 5-2／5-4 之外零額外部署。
+
+# (1) 確認 planning **選到的是 job invoker**——這是「切換有沒有生效」的機械答案，
+#     不要靠讀 EnvironmentFile 推論（那只說明變數存在，不說明它被誰消費）。
+sudo -u cortex-manager env PSC_JOB_RUNNER=systemd-template /opt/cortex/venv/bin/python3 -c \
+  "from paulsha_cortex.coordinator.planning_runtime import _select_planning_invoker
+print(type(_select_planning_invoker({'PSC_JOB_RUNNER':'systemd-template'})).__name__)"
+#   期望逐字：JobPlanningInvoker
+#   ⛔ 印出 InProcessPlanningInvoker ⇒ 切換沒生效，**停下來**。
+#   ⛔ 拋例外 ⇒ `PSC_JOB_RUNNER` 是 `systemd-run` 或非法值：那條路徑刻意 fail-closed，
+#      **不會**靜默退回行程內執行（#686）。
+
+# (2) 觸發一輪真實 define，並在**同時**取樣 Manager 的 cgroup。
+#     ⚠️ 這是正常的工作流動作（`resume` 對 needs_human 的 define run 重呼叫
+#        workflow_starter），不是手改 durable state。
+( cortex work resume <work_id> --repo <owner>/<repo> & )
+for i in $(seq 1 40); do
+  echo "[$(date -u +%H:%M:%S)] $(sudo systemd-cgls -u cortex-manager.service --no-pager \
+      | grep -cE '(codex|claude|agy|copilot)') executor(s) in manager cgroup | jobs: \
+      $(sudo systemctl list-units 'cortex-*job*' --all --no-legend --plain | awk '{print $1}' | tr '\n' ' ')"
+  sleep 3
+done
+#   期望：**executor 計數恆為 0**，而 job 欄位依序出現
+#         cortex-reviewer-job@plan-<run>-probe-N-…／-questioner-N-…／-secondary-N-…／
+#         -integrator-N-…（codex 那格是 `-jit` 字幹）。
+#   期望 Manager cgroup 裡**只有三層**：daemon ＋ `bash -c systemctl start --wait …`
+#         ＋ `systemctl start --wait …`。那兩層是 #604 的 exit 記帳 shell，不是模型。
+#   ⛔ 出現任何 executor 可執行檔 ⇒ 切換沒有一次到位，停下來。
+
+# (3) 逐個 job 的身分（root 端佐證，不靠 job 自證）
+sudo journalctl --since "-10 minutes" -o short-iso \
+  | grep -oP 'cortex-reviewer-job(-jit)?@plan-[a-z0-9-]+\.service' | sort -u \
+  | while read -r u; do echo "$u user=$(systemctl show "$u" -p User --value)"; done
+#   期望：每一行 user=cortex-reviewer-planner。
+#   ⚠️ **不要**改用 job 自己印出的 `id`——被驗方不得在自己的進程裡產生自己的驗收證據
+#      （#628／#540）。`systemctl show -p User` 讀的是 root-owned unit。
+
+# (4) probe 快取：指紋的 `job_runner_mode` 必須全部是 systemd-template
+sudo python3 -c "
+import json;d=json.load(open('/var/lib/cortex/coordinator/planning-probe-cache.json'))
+print({v['fingerprint_inputs']['job_runner_mode'] for v in d['items'].values()})
+for k,v in sorted(d['items'].items()): print(k, v['ready'], v['hardening_profile'], v['unit'])"
+#   期望：{'systemd-template'}；每一格的 unit 是 cortex-reviewer-job@.service
+#         （agy／claude＝strict）或 cortex-reviewer-job-jit@.service（codex＝jit）。
+#   ⛔ 混到 'direct' ⇒ 有一半的結論是開發機環境背書的，清掉快取重探（#684 的指紋
+#      本來就會讓它自動失效；混用代表指紋算錯了）。
+
+# (5) `job-specs/reviewer/` 用過了沒有——切換前它是空的
+sudo ls -la /var/lib/cortex/coordinator/job-specs/reviewer/
+#   期望：跑完之後是空的（spec 是 create-then-consume），但目錄 mtime 已更新。
+#   要看內容請在 (2) 的取樣迴圈裡加一行 `sudo ls` ——spec 的生命週期以秒計。
+```
+
+**0818（#687）實機結果**：`_select_planning_invoker` → `JobPlanningInvoker`；
+一輪 define 落成 6 個模板 instance（`probe-1`／`probe-2`／`probe-3`(jit)／
+`questioner-5`／`secondary-6`／`integrator-7`），全部 `User=cortex-reviewer-planner`；
+Manager cgroup 全程零 executor；probe 快取五格的 `job_runner_mode` 全為
+`systemd-template`；`no-heterogeneous-planner` 消失（primary＝claude/anthropic、
+secondary＝agy/google）。**未涵蓋**：該 run 的 brainstorm 因 `blocking-decision`
+（planner 誠實回報來源材料不足）落 `content` 級失敗，因此 build／review 兩階段在這一輪
+**沒有被執行到**——見 PR #687 的誠實邊界段。
 
 ### 5-7. 反向驗證（**11 條全部必須被拒**，＋#643 的第 12 條）
 
@@ -3956,7 +4078,7 @@ sudo systemctl reset-failed "cortex-job@*" "cortex-job-jit@*" 2>/dev/null || tru
 | 舊殘餘 | A+B 之後 |
 |---|---|
 | 「polkit 看不到 `User=`，授權後可請求任意 UID」 | **不再成立**——polkit 根本沒授權 transient 建立；唯一能起的是 root-owned template 的 instance，`User=` 在 root-owned 檔內寫死。5-7 (2)(3) 實測 |
-| 「跑模型的 reviewer／planner 與 Manager 併帳，其中任一被攻陷即取得 grant」 | **不再成立**——三分把它們移到 `cortex-reviewer-planner`；polkit subject 只有 `cortex-manager`，而它**不跑模型程式碼**。5-7 (9) 實測 |
+| 「跑模型的 reviewer／planner 與 Manager 併帳，其中任一被攻陷即取得 grant」 | **不再成立**——三分把它們移到 `cortex-reviewer-planner`；polkit subject 只有 `cortex-manager`，而它**不跑模型程式碼**。reviewer 由 #615 落地（5-7 (9) 實測）、**planner 的 define／brainstorm 由 #687 落地**（5-6c 實測）。**#615～#687 之間這一格對 planner 是假的**：帳號映射面成立，但執行面沒有——模型 CLI 仍在 `cortex-manager` 的行程樹裡 |
 | 「授權帳號被攻陷即可提權」 | **降級為「無法向上」**——`cortex-manager` 即使被完全攻陷，也改不了 `User=`（unit 是 root-owned）、傳不了屬性（transient 被拒）、換不掉 argv 入口（shim 是 root-owned）。它能做的上界是「以 `cortex-builder` 身分起 job」，而那正是設計要它做的事 |
 
 **polkit 粗粒度仍在，但已不構成提權**：規則只能看到 unit 名與 verb，**這在 A+B 下
@@ -3973,7 +4095,9 @@ sudo systemctl reset-failed "cortex-job@*" "cortex-job-jit@*" 2>/dev/null || tru
 | **Manager 自身邏輯被攻陷** | Manager 程式碼路徑被誘導寫出惡意 job-spec | root-owned shim 限定 argv 形狀（5-3）；spec 的 schema 是**白名單**且身分欄位 fail-closed（寫端 `build_job_spec()`、讀端 `job_shim.load_spec()` 各驗一次）；job 仍降到 `cortex-builder`、拿不到 token | shim 只能保證「身分／入口不可選」，**不**保證 command 內容良性——惡意 spec 仍可讓 builder 跑任意命令（上界＝builder 權限）。這條要靠 Manager 端的派工邏輯與 R9 族 2 的檔案邊界共同壓住 |
 | **operator 帳號** | 有 `sudo`，可改任何東西 | 設計上信任邊界之外（本 runbook 全部 root 操作都由 operator 親自輸入） | 不在本階段範圍 |
 | **polkit 不可用** | polkit 掛掉 ⇒ 全部 job 起不來 | fail-closed（安全但功能全停）；執行前提第 6 項＋WSL2 段第 5 項複驗 | 需監控，否則表現為「靜默停擺」 |
-| ~~**M2 未完成**~~ | ~~reviewer／planner 仍在 Manager 行程內以 `cortex-manager` 身分跑~~ | **已關閉（#615）**：三個會跑模型的 persona 啟動面全部離開 Manager 的 UID；5-6b／8b-2 為其驗收 | — |
+| ~~**M2 未完成（reviewer 這一半）**~~ | ~~reviewer 仍在 Manager 行程內以 `cortex-manager` 身分跑~~ | **已關閉（#615）**：**reviewer** 的模型 job 啟動面離開 Manager 的 UID；5-6b／8b-2 為其驗收 | — |
+| ~~**M2′ 未完成（planner 這一半）**~~ | ~~planner 的 define／brainstorm 仍在 Manager 行程內以 `cortex-manager` 身分跑模型~~ | **已關閉（#687／#672 票 F）**：`planning_runtime` 的四個 adapter 與全部 probe 改經 `JobPlanningInvoker` → `cortex-reviewer-job@`；`PSC_JOB_RUNNER=systemd-template` 下 `_select_planning_invoker()` 對 `direct` 之外的退路 fail-closed。驗收＝第 5-6c 步 | — |
+| ⚠️ **原本這一列寫的是「已關閉（#615）：三個會跑模型的 persona 啟動面全部離開 Manager 的 UID」** | 那句話對 planner **不成立**——#615 只改了 `SubprocessLauncher`，而 define／brainstorm 根本不走它 | #687 把它拆成上面兩列，各自指名自己的票與驗收步驟 | 這一列保留為**紀錄**：一句過寬的「已關閉」讓這個缺口在殘餘風險表上隱形了三天 |
 | **gate 執行身分**（#629） | gate 命令在 builder 掌控的 worktree 裡跑，`pytest` 載入該 worktree 的 `conftest.py` ⇒ 執行者取得任意程式碼執行 | 降權模式下 job **不跑 gate**（`_should_run_gates()` 對三個 persona 皆 False），build 卡對 `require_ledger` **fail closed**——沒有獨立證據就不採信 | 需要**第四個帳號**（既非 builder 也非 reviewer／planner，更非 Manager）。**刻意不掛在 `cortex-reviewer-planner` 上**：那會讓被攻陷的 builder 經由 gate 執行影響寫 verdict 的帳號，抵銷 #638／#639。屬 #629 |
 | **reviewer 憑證無法就地 refresh** | `cortex-reviewer-planner` 的 executor 憑證不在其模板 unit 的 `ReadWritePaths=` 內 | 憑證檔本身由 root 於第 4e 步放置並 chown（0600），父目錄 root-owned；讀取不受影響 | token 過期需 operator 重跑第 4e 步。登記表目前只登記 `builder-executor-credential` 一份，理由見該資產 note（二分部署上登記第二份會讓 Manager unit 的 RWP 指向不存在的路徑而起不來） |
 

--- a/paulsha_cortex/coordinator/job_runner.py
+++ b/paulsha_cortex/coordinator/job_runner.py
@@ -1559,8 +1559,8 @@ def malformed_job_command(command: object) -> str | None:
     ## 為什麼「其餘元素也必須非空」這條要拿掉（#687／#672 票 F）
 
     原判準是 `not all(argv)`，寫在 `fe7d5f5`（三分 UID 定案）——當時 spec 的唯一
-    產生者是 builder 的 `launcher`，它組出來的 argv 從來沒有空元素，所以這條**從未
-    被執行過的路徑證偽**。票 E（#686）把 planning 接上同一條通道之後，
+    產生者是 builder 的 `launcher`，它組出來的 argv 從來沒有空元素，因此這條判準
+    **從未被任何真實 argv 證偽過**。票 E（#686）把 planning 接上同一條通道之後，
     `planning_runtime._planning_argv()` 對 `claude` 產出的
     `["claude", "-p", …, "--tools", "", …]` 在**每一次** define 都撞上它：
 

--- a/paulsha_cortex/coordinator/job_runner.py
+++ b/paulsha_cortex/coordinator/job_runner.py
@@ -410,9 +410,17 @@ JOB_ROLE_CONFIG: Mapping[str, JobRoleConfig] = MappingProxyType(
             spec_spool_env=REVIEW_JOB_SPEC_SPOOL_ENV,
             default_spec_spool=DEFAULT_REVIEW_JOB_SPEC_SPOOL,
             rationale=(
-                "reviewer ＋ planner persona（三分方案下同一個 OS 帳號）。M2（#615）："
-                "在此之前它們仍在 Manager 行程內以 Manager 帳號執行，"
-                "「injection 可達的進程皆無 spawn 授權」因此只對 builder 成立。"
+                "reviewer ＋ planner persona（三分方案下同一個 OS 帳號）。"
+                "**兩者的降權是兩張票、相隔三個月**：\n"
+                "M2（#615）只搬了 **reviewer**——`launcher.SubprocessLauncher` 這條路徑。"
+                "**planner 的 define／brainstorm 不走 launcher**，它走 "
+                "`planning_runtime._invoke_json()`，因此 #615 一行都沒有碰到它；"
+                "「injection 可達的進程皆無 spawn 授權」在那之後仍**只對 builder 與 "
+                "reviewer 成立**（#672 的證據鏈）。\n"
+                "M2′（#672 票 A～F／#682-#687）補上 planner：`JobPlanningInvoker` 讓四個 "
+                "planning adapter 與全部 probe 都經本角色起 job，`PSC_JOB_RUNNER="
+                "systemd-template` 下 `_select_planning_invoker()` 對其餘值 fail-closed。"
+                "**至此該全稱才成立**，實機驗收見 runbook 第 5-6c 步。"
             ),
         ),
         JOB_ROLE_GATE: JobRoleConfig(
@@ -1535,6 +1543,59 @@ def forbidden_spec_keys(spec: Mapping[str, object]) -> list[str]:
     return sorted(key for key in SPEC_FORBIDDEN_KEYS if key in spec)
 
 
+def malformed_job_command(command: object) -> str | None:
+    """job spec 的 `command` 合法嗎？不合法時回一句可讀理由，合法回 `None`。
+
+    **與 `forbidden_spec_keys()` 同一個模式**：寫端（:func:`build_job_spec`）與讀端
+    （`job_shim.load_spec`）各呼叫一次**同一支**函式，兩端的判準因此不可能漂移。
+    #679 買過一次「同一件事兩份實作」的單，這裡不再重演。
+
+    ## 判準：`argv` 非空、`argv[0]` 非空、每個元素都是 `str`
+
+    `argv[0]` 是要 exec 的程式名——空字串沒有任何意義，`execvpe("", …)` 的失敗訊息
+    也不可讀，因此 fail-closed。**其餘元素可以是任何字串，包含空字串**：那是 POSIX
+    argv 本來的語意。
+
+    ## 為什麼「其餘元素也必須非空」這條要拿掉（#687／#672 票 F）
+
+    原判準是 `not all(argv)`，寫在 `fe7d5f5`（三分 UID 定案）——當時 spec 的唯一
+    產生者是 builder 的 `launcher`，它組出來的 argv 從來沒有空元素，所以這條**從未
+    被執行過的路徑證偽**。票 E（#686）把 planning 接上同一條通道之後，
+    `planning_runtime._planning_argv()` 對 `claude` 產出的
+    `["claude", "-p", …, "--tools", "", …]` 在**每一次** define 都撞上它：
+
+        job-runner-job-spec-invalid: spec 的 command 不得為空、且每個元素都必須是
+        非空字串 (source=job_runner.build_job_spec)
+
+    而 `--tools ""` 是 CLI 的成文 API（`claude --help` 逐字：`Use "" to disable all
+    tools`），也是 #404 之後 planning「模型完全沒有工具可呼叫」的唯一保證，不能改。
+    實測過的「等價寫法」`--tools=` **會讓模型拿回全部工具**（真實 unit 加固面下量到
+    模型發出 Bash 呼叫），那是靜默放寬，比這條守衛壞得多。
+
+    ## 放寬的安全論證
+
+    這條**不是**信任控制，是 well-formedness 檢查。spec 上真正承重的三道是
+    :func:`forbidden_spec_keys`（身分／加固剖面結構性禁止）、
+    :func:`reject_unsafe_env`（憑證與 `LD_PRELOAD`）、以及
+    `working_directory`／`log_path` 的絕對路徑要求——**沒有一道靠元素長度**。
+
+    而 argv 裡**早就**有任意的、攻擊者可影響的字串：planning 的 prompt 逐字含
+    untrusted issue 內容，它就是 `argv[2]`。在那個前提下多允許一個空字串換不到任何
+    新能力——空字串命名不了程式、指不到路徑、夾帶不了 token。相對地，繼續禁止它換到
+    的是「claude 這個 planning／reviewer 的預設 executor 結構性派不出 job」。
+    """
+
+    if not isinstance(command, (list, tuple)):
+        return "spec 的 command 必須是字串陣列"
+    if not command:
+        return "spec 的 command 不得為空"
+    if not all(isinstance(item, str) for item in command):
+        return "spec 的 command 每個元素都必須是字串"
+    if not command[0]:
+        return "spec 的 command[0]（要 exec 的程式名）不得為空字串"
+    return None
+
+
 def build_job_spec(
     *,
     job_id: str,
@@ -1550,13 +1611,20 @@ def build_job_spec(
     「User 不在 spec 裡」是本模式全部的價值：身分只有一個來源＝root-owned unit
     檔的 `User=`。因此這裡除了不放，還在寫端主動掃一次 forbidden key（未來有人
     往 spec 加欄位時測試會紅），讀端（shim）再掃一次。
+
+    #687：`command` 的合法性判準搬進 :func:`malformed_job_command`——與
+    `forbidden_spec_keys()` 同一個模式，讀端（shim）呼叫**同一支**函式。
+    先做 `str()` 正規化再驗，是因為本函式的型別契約是 `Sequence[str]`
+    （呼叫端全部逐字給 str，見 `launcher`／`gate_runner`／`planning_job`）；
+    shim 那端沒有型別契約可言（bytes 剛從磁碟讀回來），因此它驗的是原值。
     """
 
     argv = [str(item) for item in command]
-    if not argv or not all(argv):
+    problem = malformed_job_command(argv)
+    if problem is not None:
         raise _fail(
             "job-runner-job-spec-invalid",
-            "spec 的 command 不得為空、且每個元素都必須是非空字串",
+            problem,
             source="build_job_spec",
             instance=instance,
         )

--- a/paulsha_cortex/coordinator/job_shim.py
+++ b/paulsha_cortex/coordinator/job_shim.py
@@ -62,6 +62,7 @@ from .job_runner import (
     SPEC_REQUIRED_KEYS,
     forbidden_spec_keys,
     instance_name_valid,
+    malformed_job_command,
     reject_unsafe_env,
 )
 
@@ -70,6 +71,7 @@ __all__ = [
     "ShimError",
     "forbidden_spec_keys",
     "load_spec",
+    "malformed_job_command",
     "main",
     "resolve_job_env",
     "resolve_spec_path",
@@ -168,13 +170,13 @@ def load_spec(instance: str, spool_root: str) -> dict[str, object]:
             f"{instance!r}）: {path}"
         )
 
-    command = spec.get("command")
-    if (
-        not isinstance(command, list)
-        or not command
-        or not all(isinstance(item, str) and item for item in command)
-    ):
-        raise ShimError(f"job spec 的 command 必須是非空的字串陣列: {path}")
+    # #687：判準與寫端 `job_runner.build_job_spec()` 走**同一支**
+    # `malformed_job_command()`——`argv` 非空、`argv[0]` 非空、每個元素都是 str，
+    # 但**其餘元素允許空字串**（`claude --tools ""` 是成文 API，見該函式 docstring）。
+    # 這裡不再自寫一份判準：#679 已經買過「同一件事兩份實作會漂移」的單。
+    problem = malformed_job_command(spec.get("command"))
+    if problem is not None:
+        raise ShimError(f"job spec 的 command 不合法（{problem}）: {path}")
     for key in ("working_directory", "log_path"):
         value = spec.get(key)
         if not isinstance(value, str) or not value.startswith("/"):

--- a/paulsha_cortex/coordinator/launcher.py
+++ b/paulsha_cortex/coordinator/launcher.py
@@ -1206,8 +1206,17 @@ class SubprocessLauncher:
         **三個判準，缺一不可**——這是 #615 實作時發現的一個真缺口：
 
         1. `review_only`＝workflow lane 的 reviewer（`as_review_only()`）；
-        2. `read_only`＝planner（`as_read_only()`）；
+        2. `read_only`＝**workflow lane 的 planner 卡**（`as_read_only()`）；
         3. `verdict_spool_dir is not None`＝**slice lane 的 foreign reviewer**。
+
+        **第 2 條的範圍要看清楚（#672／#687）**：它涵蓋的是 workflow lane 上
+        `persona == "planner"` 的那幾張卡（`manager._specialize_workflow_launcher()`
+        呼叫 `as_read_only()`）。**define／brainstorm 的 planning 不在其中**——那條路
+        根本不建立 `SubprocessLauncher`，它走 `planning_runtime._invoke_json()`。
+        這個 docstring 曾經是「planner 已經降權了」這個假直覺的來源之一：讀完三個
+        判準，很自然會以為 planner 全部路徑都在本函式的射程內。它不是。
+        planning 那一條由 `planning_runtime._select_planning_invoker()` 決定
+        （#686 接上 `JobPlanningInvoker`、#687 切換）。
 
         第 3 條容易漏掉，而漏掉的後果最嚴重。slice lane 的 foreign reviewer 走的是
         `manager._spool_writable_launcher()` → `as_verdict_spool_writer()`，而那支
@@ -1225,10 +1234,17 @@ class SubprocessLauncher:
         return bool(self._review_only or self._read_only or self._verdict_spool_dir)
 
     def _job_role(self) -> str:
-        """本 launcher 的降權 job 角色（#615 M2）——**唯一決定點**。
+        """本 launcher 的降權 job 角色（#615 M2）——**launcher 這條路徑的唯一決定點**。
 
         reviewer 與 planner 同屬 `review` 角色，因為三分方案把它們映到**同一個**
         OS 帳號（`cortex-reviewer-planner`）；其餘為 `builder`。
+
+        **「唯一」的範圍限定（#687）**：本函式原本寫「唯一決定點」，那在 #686 之後
+        不再是全稱——`planning_job.JobPlanningInvoker` 是第二個消費者，它把角色**在
+        建構期固定**成 `JOB_ROLE_REVIEW`（不經本函式，也不從 spec 導出）。兩處共用
+        同一組角色常數與同一支 `resolve_runner_mode()`，但「哪些程式碼決定角色」
+        的答案是**兩個地方**。這不是缺陷，是兩條 code path 的事實；把它寫清楚，是
+        因為 #672 的三個月盲區正是由「大家都在讀 launcher」造成的。
 
         **角色由 launcher 的建構契約導出，不由 job 導出**：三個判準
         （見 :meth:`_is_review_persona`）在 `__init__` 就固定，此後 immutable。
@@ -1249,9 +1265,16 @@ class SubprocessLauncher:
         **#615（M2）移除了第二個條件。** 在此之前這裡對 `review_only`／`read_only`
         回 `None`，於是 reviewer／planner 仍在 Manager 行程內以 Manager 帳號執行
         ——A+B 裁決的核心論述「injection 可達的進程皆無 spawn 授權」因此**只對
-        builder 成立**，而 reviewer 正是寫 verdict 的那一個。M2 之後三個會跑模型的
-        persona 全部離開 Manager 的 UID，persona 只決定**哪一個角色**
-        （:meth:`_job_role`），不再決定「降不降權」。
+        builder 成立**，而 reviewer 正是寫 verdict 的那一個。M2 之後**經過本
+        launcher 的**派工，persona 只決定**哪一個角色**（:meth:`_job_role`），
+        不再決定「降不降權」。
+
+        **原文寫的是「M2 之後三個會跑模型的 persona 全部離開 Manager 的 UID」，
+        #687 更正了它。** 那句話的射程被誤讀成全稱：define／brainstorm 的 planning
+        不經過本 launcher，因此 #615 對它零效果，它到 #672 票 A～F（#682-#687）才
+        離開 Manager 的 UID。本函式今天能宣稱的，逐字是「**走本 launcher 的**派工
+        全部降權」。全稱要合上 `planning_runtime._select_planning_invoker()` 那一半
+        才成立。
 
         `systemd-run`（A 案）與 `systemd-template`（B 案，0816 第三輪裁決）在
         launcher 這一層共用**完全相同**的 env 白名單與 `bash -c` 決定，差別只在

--- a/paulsha_cortex/coordinator/planning_job.py
+++ b/paulsha_cortex/coordinator/planning_job.py
@@ -8,8 +8,15 @@ prompt，起一個 `cortex-reviewer-job@<instance>.service` 實例，以
 `cortex-reviewer-planner` 的身分執行模型 CLI，再把輸出取回來。
 
 `cortex-manager` 的 passwd 註記逐字寫著 `no model code`。#615（M2）讓 reviewer 兌現了
-那句話，planner 沒有——它至今仍在 daemon 行程內 `subprocess.run` 模型 CLI（#672）。
-本檔是那半條的補齊。
+那句話，planner 沒有——在 #687 切換之前它仍在 daemon 行程內 `subprocess.run` 模型
+CLI（#672）。本檔是那半條的補齊。
+
+**#687（票 F）之後的狀態**：四分部署的 `PSC_JOB_RUNNER=systemd-template` 使本類成為
+planning 的實際執行後端，`direct` 在該部署上不是可達組態。實機一輪 define 的每一次
+模型呼叫（probe／questioner／secondary／integrator）都落成一個
+`cortex-reviewer-job@`／`-jit@` 實例，`User=cortex-reviewer-planner`；同一段期間
+`systemd-cgls -u cortex-manager.service` 只有 daemon ＋ `systemctl start --wait`
+兩層，零 executor（runbook 第 5-6c 步）。
 
 ## 十條防線（design D2）在本實作裡分別由誰保證
 

--- a/paulsha_cortex/coordinator/planning_runtime.py
+++ b/paulsha_cortex/coordinator/planning_runtime.py
@@ -1345,7 +1345,12 @@ def build_production_planning_runtime(
     2. `runner=`——注入 process runner，等同「用 in-process invoker 跑」。
        這是既有呼叫端與大量既有測試的用法，逐字保留。
     3. 兩者皆無（＝daemon 的實際呼叫形態）——由 `_select_planning_invoker`
-       依 `PSC_JOB_RUNNER` 決定。**這是全庫唯一的執行後端選擇點。**
+       依 `PSC_JOB_RUNNER` 決定。**這是 planning 這條路徑唯一的執行後端選擇點。**
+       （#687 的範圍限定：本行原文寫「全庫唯一」，那與 `launcher._job_role()`
+       docstring 的「唯一決定點」互相矛盾——兩者其實是**兩條 code path 各一個**
+       選擇點，共用同一支 `job_runner.resolve_runner_mode()`。全庫唯一的是那支
+       **解析函式**，不是選擇點。#672 的三個月盲區正是「以為只有 launcher 一條」
+       造成的，因此這兩個 docstring 都改成帶範圍的說法。）
 
     四個 adapter 與兩種 probe 全部走同一個 invoker——票 E 因此只換一個物件，
     不必再碰任何呼叫端。

--- a/paulsha_cortex/trust_root/permgen.py
+++ b/paulsha_cortex/trust_root/permgen.py
@@ -4212,33 +4212,23 @@ _DEFERRED_RUN_DEPENDENCIES: tuple[DeferredDependency, ...] = (
             "導出的實測不得宣稱可用。"
         ),
     ),
-    DeferredDependency(
-        "manager-claude-credential", DependencyKind.CREDENTIAL,
-        (Principal.MANAGER,),
-        reason=(
-            "`planning_runtime` 的 **direct 模式**在 Manager 行程內直接 exec `claude`，"
-            "並讀 `<HOME>/.claude/.credentials.json` 播種一次性的 `CLAUDE_CONFIG_DIR`。"
-            "四分部署下 Manager 的 HOME 底下沒有那個檔，登記表也沒有對應資產。\n"
-            "**#685 解除了本項的機械阻礙，但沒有解除它本身。** 原文寫的阻礙是"
-            "「`executor_credential_relpath` 是單一部署決定，一個帳號只表達得了一份憑證」"
-            "——U-5 的裁決已經把它擴成 per-(account, executor) 表"
-            "（:data:`CREDENTIALED_ACCOUNTS`），現在**表達得了**。剩下的是**要不要登記**"
-            "這一格，而那是 #672 的核心裁決：Manager 是 durable state owner ＋ spawn "
-            "授權持有者，passwd 註記逐字寫著 `no model code`——給它一份模型憑證正是 #672 "
-            "要消除的東西。因此本票**刻意不登記**。"
-        ),
-        symptom=(
-            "程式碼在查無憑證時**明確回 `None` 並不代為猜測**，讓 claude CLI 自己回報"
-            "未登入——因此它不是靜默失敗，但也不是可用狀態。實機 direct 模式的 planning "
-            "走 `agy`，所以這條還沒有被踩到。"
-        ),
-        disposition=(
-            "由**票 F（#687）**收尾：`PSC_JOB_RUNNER` 切到 `systemd-template` 之後，"
-            "planning 一律走降權 job（票 E／#686 已把 `JobPlanningInvoker` land），Manager "
-            "行程內不再 exec 任何 executor，本項隨之消失而不是被登記。**本票不預先刪掉它**"
-            "——切換尚未發生，direct 路徑逐字還在，現在刪等於宣稱一件還沒成立的事。"
-        ),
-    ),
+    # #687（#672 票 F）：`manager-claude-credential` 已移除。
+    #
+    # 它從來不是「還沒補的憑證」，而是「Manager 在 direct 模式下自己 exec `claude`」
+    # 這件事的登記表投影。票 F 的裁決是 **planning 一律走降權 job**：四分部署的
+    # `PSC_JOB_RUNNER=systemd-template` 使 `planning_runtime._select_planning_invoker()`
+    # 恆回 `JobPlanningInvoker`，模型 CLI 只在 `cortex-reviewer-job@` 實例內、以
+    # `cortex-reviewer-planner` 執行。Manager 不再 exec 任何 executor ⇒ 它不需要
+    # 任何 executor 憑證 ⇒ 本項**消失**，而不是被登記成一格資產。
+    #
+    # **這條裁決不是「刪一列」，它有可驗證的內容**：`_select_planning_invoker` 對
+    # `systemd-run`（A 案）與任何非法值 fail-closed、**不退回 in-process**——因此
+    # 「Manager 又開始跑模型」這件事不可能靜默發生。direct 模式的程式碼逐字保留
+    # （開發機、離線重現），它在四分部署上不是一個可達的組態。
+    #
+    # 票 D（#685）刻意沒刪，理由是「切換尚未發生，現在刪等於宣稱一件還沒成立的
+    # 事」。票 F 讓它成立了：實機一輪 define 的每一次模型呼叫都落成一個模板 unit
+    # 實例（PR #687 的 E2E evidence）。
 )
 
 
@@ -4259,6 +4249,15 @@ def deferred_run_dependencies() -> tuple[DeferredDependency, ...]:
 #: 相同、只是名字不同的 unit，等於多一個要同步維護的放行面（polkit pattern 也會多
 #: 一個字幹），卻換不到任何隔離。`REVIEWER` 在這裡是**那個帳號的代表 principal**，
 #: 由 :data:`JOB_PRINCIPAL_PERSONAS` 明載它代表誰。
+#:
+#: **本表是「unit／spool 產得出哪幾份」，不是「哪些執行路徑真的走上它」（#687）。**
+#: 這兩件事在 #615～#686 之間**分岔了三個月**：本表從 #615 起就宣稱 reviewer／planner
+#: 這一格已降權，而 planner 的 define／brainstorm 當時仍在 Manager 行程內跑模型
+#: （#672）——因為它走的是 `planning_runtime`，不是 `SubprocessLauncher`。
+#: 產生器面永遠不會發現這件事：unit 產得出來，只是沒有人拿它起 job。
+#: 「執行路徑走不走上這份 unit」的答案在
+#: `coordinator/planning_runtime._select_planning_invoker()` 與
+#: `coordinator/launcher.SubprocessLauncher._job_role()` 兩處，不在本表。
 #:
 #: - `GATE`（#629）：`cortex-gate-job@.service`／`cortex-gate-job-jit@.service`，
 #:   `User=cortex-gate`。它不跑模型，跑的是 operator 宣告的 gate 命令——但那些命令

--- a/paulsha_cortex/trust_root/registry.py
+++ b/paulsha_cortex/trust_root/registry.py
@@ -96,6 +96,15 @@ UNTRUSTED_EXECUTION_PRINCIPALS: frozenset[Principal] = (
 #: 卻換不到任何隔離。`REVIEWER` 在這裡是**那個帳號的代表 principal**，由
 #: `permgen.JOB_PRINCIPAL_PERSONAS` 明載它代表誰。
 #:
+#: **本表是「產得出哪幾份 unit／spool」，不是「哪些執行路徑真的走上它」（#687）。**
+#: `REVIEWER` 這一格從 #615 起就在表上，但 planner 的 define／brainstorm 直到
+#: #672 票 A～F（#682-#687）才真的以它起 job——在那之前 `job-specs/reviewer/`
+#: 從未被寫過任何一個 spec（#686 查證、#687 於實機複驗）。判定執行路徑的是
+#: `coordinator/planning_runtime._select_planning_invoker()` 與
+#: `coordinator/launcher.SubprocessLauncher._job_role()`，不是本表。
+#: （本段與 `permgen.DOWNGRADED_JOB_PRINCIPALS` 的同一段是**成對**的，改一邊
+#: 就要改另一邊——兩者是同一個 tuple 物件的兩份說明。）
+#:
 #: 定義在登記表而非 `permgen`：permgen import registry（反向不成立），而本清單同時
 #: 要決定**登記表有哪些資產**。放在 permgen 會讓資產清單得從產生器 import 回來。
 #: `permgen.DOWNGRADED_JOB_PRINCIPALS` 是指向本項的別名，不是第二份。

--- a/tests/test_planning_job_argv_687.py
+++ b/tests/test_planning_job_argv_687.py
@@ -1,0 +1,201 @@
+"""issue #687（#672 票 F）：planning argv 與 job spec 的 argv 合法性契約。
+
+## 這組測試釘的是什麼
+
+票 F 的第一件事是「查清楚 planning 現在到底走哪條路」，而查證的方式是在四分部署上
+實跑一輪 define。那一跑立刻撞到一條**票 E（#686）從未被執行過的路徑**上的阻斷：
+
+```
+brainstorm-not-ready … reason=question-pack-malformed: JobRunnerError:
+  job-runner-job-spec-invalid: spec 的 command 不得為空、且每個元素都必須是非空字串
+  (source=job_runner.build_job_spec)
+```
+
+根因：`planning_runtime._planning_argv()` 對 `claude` 產出的 argv 含一個**空字串
+元素**——`["claude", "-p", …, "--tools", "", …]`——而 `job_runner.build_job_spec()`
+與 `job_shim.load_spec()` 兩端都以 `all(argv)` 要求「每個元素都是非空字串」。
+
+`--tools ""` **不是筆誤，是 CLI 的成文 API**（`claude --help` 逐字：
+`Use "" to disable all tools`），也是 #404 之後 planning 唯一的「模型完全沒有工具
+可呼叫」保證。它必須逐字保留。
+
+## 為什麼不是把 `--tools ""` 改寫成 `--tools=`
+
+因為那個「等價寫法」**不等價，而且失敗方向是靜默放寬**。本票在真實 reviewer unit
+的完整加固面下（`psc_run_under`／`permgen.unit_replica_properties()` 全量導出，38 條
+property）做過三臂對照，同一個 prompt：
+
+===============================  ==========================================
+argv                             模型回報
+===============================  ==========================================
+`--tools ""`（兩個 token）        `NOTOOLS`（工具真的不存在）
+`--tools=`（單一 token）          **發出 Bash 工具呼叫**（工具全開）
+不帶 `--tools`                    有工具、三個 turn（對照組）
+===============================  ==========================================
+
+`--tools <tools...>` 在 commander 是 variadic；`--tools=` 不會被解成「空清單」。
+把它當成等價寫法，等於讓**吃 untrusted issue 內容**的 planner 在降權 job 內拿回
+Bash——而症狀是「planning 跑起來了」，看起來像成功。這正是 #672 整張票要消除的
+失效模式，因此本檔有一條測試把 `["--tools", ""]` 逐字釘死。
+
+## 因此修的是那條過嚴的守衛
+
+`argv[0]` 必須非空（`execvpe("")` 是沒有意義的呼叫，失敗訊息也不可讀）；**其餘元素
+可以是任何字串**，那是 POSIX argv 本來的語意。放寬的安全論證見
+`job_runner.malformed_job_command()` 的 docstring：spec 的信任控制是
+`forbidden_spec_keys()`（身分／剖面）與 `reject_unsafe_env()`（憑證），不是元素長度；
+而 argv 裡**早就**有任意的攻擊者可影響字串（planning prompt 逐字含 issue 內容），
+多允許一個空字串換不到任何新能力。
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from paulsha_cortex.coordinator import job_runner, job_shim  # noqa: E402
+from paulsha_cortex.coordinator.model_identities import ModelIdentity  # noqa: E402
+from paulsha_cortex.coordinator.planning_runtime import _planning_argv  # noqa: E402
+
+
+def _identity(executor: str, model_id: str) -> ModelIdentity:
+    return ModelIdentity(
+        executor=executor,
+        model_id=model_id,
+        independence_domain="test-domain",
+        capabilities=frozenset({"planning"}),
+    )
+
+
+_SPEC_BASE = {
+    "job_id": "j",
+    "instance": "j-deadbeef",
+    "unit": "cortex-reviewer-job@j-deadbeef.service",
+    "working_directory": "/wt",
+    "log_path": "/logs/j.jsonl",
+    "env": {"PATH": "/usr/bin"},
+}
+
+
+class PlanningArgvSurvivesJobSpec(unittest.TestCase):
+    """票 E 的路徑實跑之後才會撞到的那一條（RED）。"""
+
+    def test_every_planning_executor_argv_builds_a_valid_job_spec(self) -> None:
+        """三個 planning executor 的 production argv 都必須組得出 job spec。
+
+        這條之所以到票 F 才紅，是因為票 E 的驗收矩陣走的是 `psc_run_under`——它
+        複製的是**加固面**，完全繞過 Manager 側的 `build_job_spec()`。機械導出的
+        複本證明得了「executor 在那個沙箱下跑得起來」，證明不了「Manager 派得出
+        那個 job」。`job-specs/reviewer/` 在票 F 之前**一個檔都沒寫過**。
+        """
+
+        for executor, model_id in (
+            ("claude", "claude-opus-5"),
+            ("codex", "gpt-5.3-codex-spark"),
+            ("agy", "gemini-3.1-pro-high"),
+        ):
+            with self.subTest(executor=executor):
+                argv = _planning_argv(
+                    _identity(executor, model_id), "PROMPT", "/tmp", Path("/scratch/cwd")
+                )
+                spec = job_runner.build_job_spec(command=argv, **_SPEC_BASE)
+                self.assertEqual(spec["command"], argv)
+
+    def test_claude_planning_argv_keeps_the_documented_empty_tools_value(self) -> None:
+        """`--tools ""` 逐字不得被「等價寫法」換掉。
+
+        `claude --help` 逐字：`Use "" to disable all tools`。本票在真實 reviewer
+        unit 的完整加固面下實測，`--tools=` 會讓模型**拿回全部工具**（發出 Bash
+        呼叫），而 planning 照樣跑得完——一個看起來像成功的失敗。
+        """
+
+        argv = _planning_argv(
+            _identity("claude", "claude-opus-5"), "PROMPT", "/tmp", Path("/scratch/cwd")
+        )
+        self.assertIn("--tools", argv)
+        self.assertEqual(argv[argv.index("--tools") + 1], "")
+        self.assertNotIn("--tools=", argv)
+
+
+class JobCommandWellformednessContract(unittest.TestCase):
+    """放寬之後**還剩下什麼**——以及寫端讀端不得漂移。"""
+
+    def test_argv0_must_still_be_non_empty(self) -> None:
+        for command in ([], [""], ["", "-c", "true"]):
+            with self.subTest(command=command):
+                with self.assertRaises(job_runner.JobRunnerError) as ctx:
+                    job_runner.build_job_spec(command=command, **_SPEC_BASE)
+                self.assertEqual(
+                    ctx.exception.diagnostic.reason, "job-runner-job-spec-invalid"
+                )
+
+    def test_non_leading_empty_arguments_are_accepted(self) -> None:
+        spec = job_runner.build_job_spec(command=["bash", ""], **_SPEC_BASE)
+        self.assertEqual(spec["command"], ["bash", ""])
+
+    def test_write_end_and_read_end_agree_on_every_case(self) -> None:
+        """同一組 argv 在 `build_job_spec()` 與 `job_shim.load_spec()` 判定相同。
+
+        #679 的教訓是「兩份會漂移的真相」。本票把判準收進一支
+        `malformed_job_command()`，兩端各呼叫一次；這條測試釘的是**呼叫端真的
+        改了**——只要有人把任一端改回自寫判準，這裡就紅。
+
+        比對範圍是 `list[str]`：那是兩端的實際交集（寫端的型別契約是
+        `Sequence[str]` 且會先 `str()` 正規化，讀端拿到的是 JSON 解出來的值）。
+        非 list／非 str 的情形由 `test_read_end_still_rejects_non_string_arrays`
+        單獨守。
+        """
+
+        cases: tuple[list[str], ...] = (
+            ["bash", "-c", "true"],
+            ["bash", ""],
+            ["claude", "-p", "x", "--tools", "", "--model", "m"],
+            [],
+            [""],
+            ["", "-c", "true"],
+        )
+        for command in cases:
+            with self.subTest(command=command):
+                try:
+                    job_runner.build_job_spec(command=command, **_SPEC_BASE)
+                    write_rejected = False
+                except job_runner.JobRunnerError:
+                    write_rejected = True
+                self.assertEqual(write_rejected, self._shim_rejects(command), command)
+
+    def test_read_end_still_rejects_non_string_arrays(self) -> None:
+        """讀端沒有型別契約可依賴（bytes 剛從磁碟讀回來），因此仍要自己擋型別。"""
+
+        for command in ("bash -c true", ["bash", 3], {"argv": ["bash"]}, None):
+            with self.subTest(command=command):
+                self.assertTrue(self._shim_rejects(command), command)
+
+    def _shim_rejects(self, command: object) -> bool:
+        with tempfile.TemporaryDirectory() as spool:
+            spec = {
+                "spec_version": job_runner.JOB_SPEC_VERSION,
+                "instance": "j-deadbeef",
+                "job_id": "j",
+                "unit": "cortex-reviewer-job@j-deadbeef.service",
+                "command": command,
+                "working_directory": "/wt",
+                "log_path": "/logs/j.jsonl",
+                "env": {"PATH": "/usr/bin"},
+            }
+            path = Path(spool) / "j-deadbeef.json"
+            path.write_text(json.dumps(spec), encoding="utf-8")
+            try:
+                job_shim.load_spec("j-deadbeef", spool)
+            except job_shim.ShimError as exc:
+                self.assertIn("command", str(exc))
+                return True
+            return False
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/tests/test_trust_root_external_deps_exhaustive_666.py
+++ b/tests/test_trust_root_external_deps_exhaustive_666.py
@@ -574,16 +574,22 @@ def test_deferred_dependencies_stay_enumerable() -> None:
       證明那句話是錯的：codex 需要 `$CODEX_HOME` 整棵可寫，單檔不夠。
     - `reviewer-planner-codex-hooks` **留著，但理由整段換掉**：它現在不是「還沒補」，
       而是與 codex 的可用性**在 `$CODEX_HOME` 這一層互斥**（升為 U-9）。
-    - `manager-claude-credential` **留著**：U-5 解除了它的機械阻礙（表達得了了），但
-      「要不要給 Manager 一份模型憑證」是 #672 的核心裁決，答案是不要；本項由票 F
-      （#687）切換之後隨 direct 路徑一起消失，**不是**現在刪掉。
+    - `manager-claude-credential` 在 #685 當時**留著**：U-5 解除了它的機械阻礙
+      （表達得了了），但「要不要給 Manager 一份模型憑證」是 #672 的核心裁決，答案是
+      不要；本項由票 F（#687）切換之後隨 direct 路徑一起消失，**不是**當時刪掉。
+
+    **#687（票 F）把它移除了，而且是「消失」不是「登記」。** 四分部署的
+    `PSC_JOB_RUNNER=systemd-template` 讓 `_select_planning_invoker()` 恆回
+    `JobPlanningInvoker`，模型 CLI 只在 `cortex-reviewer-job@` 實例內執行，Manager
+    不再 exec 任何 executor ⇒ 它不需要 executor 憑證。清單因此**再縮短一項**，剩兩項。
     """
     deferred = deferred_run_dependencies()
     assert {item.name for item in deferred} == {
         "gate-gitconfig",
         "reviewer-planner-codex-hooks",
-        "manager-claude-credential",
     }, sorted(item.name for item in deferred)
+    # #687：被移除的那一項不得以任何形式「改個名字留下來」。
+    assert "manager-claude-credential" not in {item.name for item in deferred}
     for item in deferred:
         assert item.principals, item.name
         assert item.reason.strip() and item.symptom.strip(), item.name

--- a/tests/test_trust_root_job_template_ab.py
+++ b/tests/test_trust_root_job_template_ab.py
@@ -861,6 +861,17 @@ class JobSpecContentTests(unittest.TestCase):
         self.assertTrue(leftovers[0].endswith(".json"), leftovers)
 
     def test_build_job_spec_rejects_relative_paths_and_empty_command(self) -> None:
+        """#687：`["bash", ""]` 那一格改成 `["", "-c", "true"]`（空的是 argv[0]）。
+
+        原判準是 `not all(argv)`＝「每個元素都必須非空」。票 E（#686）把 planning
+        接上同一條 spec 通道之後，`claude` 的 production argv
+        （`… --tools "" …`，CLI 成文 API「`Use "" to disable all tools`」）在**每一次**
+        define 都撞上它。判準因此收斂成「`argv` 非空且 `argv[0]` 非空」，其餘元素
+        依 POSIX 語意允許空字串；完整論證見
+        `job_runner.malformed_job_command()` 與 `tests/test_planning_job_argv_687.py`。
+        本格改測**現在仍應被擋**的那一種，不是把斷言刪掉。
+        """
+
         base = {
             "job_id": "j",
             "instance": "j-deadbeef",
@@ -872,7 +883,7 @@ class JobSpecContentTests(unittest.TestCase):
         }
         for override in (
             {"command": []},
-            {"command": ["bash", ""]},
+            {"command": ["", "-c", "true"]},
             {"working_directory": "relative/wt"},
             {"log_path": "relative.jsonl"},
         ):

--- a/tests/test_trust_root_planner_credentials_672.py
+++ b/tests/test_trust_root_planner_credentials_672.py
@@ -366,13 +366,16 @@ def test_the_overdue_reviewer_credential_entry_is_gone() -> None:
     assert "reviewer-planner-executor-credential" not in names, sorted(names)
 
 
-def test_the_two_entries_that_could_not_be_closed_say_why() -> None:
-    """**沒關掉的兩條必須說得出新的阻礙，而不是留著舊理由。**
+def test_the_entry_that_could_not_be_closed_says_why() -> None:
+    """**沒關掉的那條必須說得出新的阻礙，而不是留著舊理由。**
 
-    - `reviewer-planner-codex-hooks`：與 codex 的可用性在 `$CODEX_HOME` 這一層互斥
-      （U-9）；
-    - `manager-claude-credential`：U-5 解除了它的機械阻礙，但「要不要給 Manager 一份
-      模型憑證」的答案是不要，而它的消失要等票 F 切換。
+    `reviewer-planner-codex-hooks`：與 codex 的可用性在 `$CODEX_HOME` 這一層互斥
+    （U-9）。
+
+    **#687（票 F）之後這裡只剩它一條。** 原本並列的 `manager-claude-credential`
+    已由票 F 移除——切換之後 Manager 不再 exec 任何 executor，該項不是「被登記」
+    而是**消失**（見 `test_the_manager_credential_entry_disappeared_by_switching`）。
+    本測試因此從 `..._two_entries_...` 改名為單數。
     """
     by_name = {item.name: item for item in permgen.deferred_run_dependencies()}
     hooks = by_name["reviewer-planner-codex-hooks"]
@@ -380,9 +383,27 @@ def test_the_two_entries_that_could_not_be_closed_say_why() -> None:
     assert "CODEX_HOME" in hooks.reason
     # 舊理由不得還「作為理由」留在上面——它必須是被**引述後推翻**的那一段。
     assert "做不到" in hooks.reason and "#686" in hooks.reason
-    manager = by_name["manager-claude-credential"]
-    assert "#687" in manager.disposition
-    assert "executor_credential_relpath` 是**單一**部署決定" not in manager.reason
+
+
+def test_the_manager_credential_entry_disappeared_by_switching() -> None:
+    """#687：`manager-claude-credential` 移除，且**不得**改以資產形式偷渡回來。
+
+    票 D（#685）刻意留著它，理由逐字是「切換尚未發生，direct 路徑逐字還在，現在刪
+    等於宣稱一件還沒成立的事」。票 F 讓它成立：`PSC_JOB_RUNNER=systemd-template`
+    下 `_select_planning_invoker()` 恆回 `JobPlanningInvoker`，Manager 行程內不再
+    exec 任何 executor。
+
+    因此正確的收法是**兩件事同時成立**：deferred 清單少一項，而登記表**沒有**多出
+    一格 Manager 的 executor 憑證。只驗前者的話，「刪掉逾期項」與「把它登記成資產」
+    看起來一模一樣——而後者正是 #672 要消除的東西（Manager 是 durable state owner
+    ＋ spawn 授權持有者，passwd 註記逐字寫著 `no model code`）。
+    """
+    names = {item.name for item in permgen.deferred_run_dependencies()}
+    assert "manager-claude-credential" not in names, sorted(names)
+    manager_account = permgen.DEFAULT_LAYOUT.manager_account
+    assert manager_account not in permgen.CREDENTIALED_ACCOUNTS, (
+        f"{manager_account} 不得取得任何 executor 憑證——那正是 #672 的核心裁決"
+    )
 
 
 def test_the_inventory_stays_closed_in_both_directions() -> None:


### PR DESCRIPTION
Closes #687

#672 的最後一張票。planner 在本票之後才真正離開 Manager 行程。

---

## 1. 先回答本票最重要的那個問題：planning 現在到底走哪條路

**走 job。而且在我動手之前它就已經「選」了 job，只是它從來沒有真的跑成功過一次。**

開票者提醒「`PSC_JOB_RUNNER=systemd-template` 早就在 env 裡，所以重新部署之後
planning 可能已經在走 job 路徑了」——查證結果比這更精確，分三層：

| 層 | 狀態（我動手之前） | 查證方式 |
|---|---|---|
| **選擇點** | ✅ 已選 job | `_select_planning_invoker({'PSC_JOB_RUNNER':'systemd-template'})` → `JobPlanningInvoker` |
| **部署** | ✅ 已具備 | Manager 行程的 `/proc/<pid>/environ` 逐字含 `PSC_JOB_RUNNER=systemd-template`；`/opt/cortex/venv` 與 `origin/main@3591084` 逐檔相同（`diff -rq` 空輸出） |
| **實際跑通** | ❌ **每一次 define 都失敗** | `job-specs/reviewer/` 是**空目錄**；一跑就落 `job-runner-job-spec-invalid` |

也就是說：**切換的開關早就打開了，但開關後面接的東西是壞的。** 這個狀態最危險的地方
在於它不像壞掉——`cortex status` 顯示的是 `no-heterogeneous-planner`（一個拓撲問題），
而真正的原因在三層之下。

### 那條阻斷：`claude` 的 planning argv 結構性派不出 job

實跑第一輪 define，失敗理由從 `no-heterogeneous-planner` 換成一行從沒見過的：

```
brainstorm-not-ready … reason=question-pack-malformed: JobRunnerError:
  job-runner-job-spec-invalid: spec 的 command 不得為空、且每個元素都必須是非空字串
  (source=job_runner.build_job_spec)
```

根因：

```python
# planning_runtime._planning_argv(), executor == "claude"
["claude", "-p", prompt, "--output-format", "json",
 "--tools", "",                    # ← 空字串元素
 "--model", model, "--add-dir", str(worktree)]
```

而寫端 `job_runner.build_job_spec()` 與讀端 `job_shim.load_spec()` **兩端**都以
`all(argv)` 要求「每個元素都是非空字串」。逐 executor 檢查，只有 `claude` 命中：

| executor | 空字串元素 |
|---|---|
| `claude` | **index 6（`--tools` 的值）** |
| `codex` | 無 |
| `agy` | 無 |

`claude` 是 reviewer 的預設 executor，也是本部署 roster 裡兩格 planning identity
（`claude-opus-5`／`sonnet`）。**它派不出 job ⇒ planning 的主要 primary 全滅。**

### 為什麼不是把 `--tools ""` 改寫成 `--tools=`（這是本 PR 最重要的一次否決）

`--tools ""` 不是筆誤，是 CLI 的成文 API：

```
$ claude --help
  --tools <tools...>   Specify the list of available tools from the built-in set.
                       Use "" to disable all tools, "default" to use all tools, …
```

它也是 #404 之後 planning「模型完全沒有工具可呼叫」的唯一保證。我原本打算用
`--tools=`（單一 token，不含空字串元素）繞過，並先在**真實 reviewer unit 的完整加固
面下**（`psc_run_under`，`permgen.unit_replica_properties()` 全量導出 **38 條**
property）做了三臂對照，同一個 prompt（`Use your tools to list files … If you have no
tools available reply exactly NOTOOLS`）：

| argv | 模型回報 | turns |
|---|---|---|
| `--tools ""`（兩個 token，production 現況） | `NOTOOLS`（明確說「no Bash, Glob, Read, or similar tool is exposed to me here」） | 1 |
| `--tools=`（單一 token） | **發出 Bash 工具呼叫**（`{"command": "ls -1A … \| wc -l"}`） | 1 |
| 不帶 `--tools`（對照組） | 有工具、實際去 stat 目錄權限 | 3 |

`--tools <tools...>` 在 commander 是 **variadic**，`--tools=` 不會被解成空清單。
**這個「等價寫法」會讓吃 untrusted issue 內容的 planner 在降權 job 內拿回 Bash，
而症狀是「planning 跑起來了」**——一個看起來像成功的失敗，正是 #672 整張票要消除的
失效模式。已否決，並在 `tests/test_planning_job_argv_687.py` 用一條測試把
`["--tools", ""]` 逐字釘死。

### 因此修的是那條過嚴的守衛

判準收斂成 **`argv` 非空 且 `argv[0]` 非空**，其餘元素依 POSIX 語意允許空字串。
實作是一支 `job_runner.malformed_job_command()`，**寫端讀端各呼叫一次同一支函式**
（比照既有的 `forbidden_spec_keys()`；#679 已經買過「同一件事兩份實作會漂移」的單）。

放寬的安全論證（完整版在該函式 docstring）：

- 這**不是**信任控制，是 well-formedness 檢查。spec 上真正承重的三道是
  `forbidden_spec_keys()`（身分／加固剖面結構性禁止）、`reject_unsafe_env()`（憑證與
  `LD_PRELOAD`）、`working_directory`／`log_path` 的絕對路徑要求——**沒有一道靠元素長度**。
- argv 裡**早就**有任意的、攻擊者可影響的字串：planning prompt 逐字含 untrusted issue
  內容，它就是 `argv[2]`。多允許一個空字串換不到任何新能力——空字串命名不了程式、
  指不到路徑、夾帶不了 token。
- `argv[0]` 仍 fail-closed：`execvpe("")` 是沒有意義的呼叫，失敗訊息也不可讀。

### 這個阻斷為什麼躲過了票 E 的 3/3 驗收矩陣（可推廣的教訓）

**D13 沒有錯，它只是不涵蓋這一維。** `psc_run_under`／`unit_replica_properties()`
複製的是**加固面**——它證明得了「executor 在那個沙箱下跑得起來」，證明不了
「**Manager 派得出那個 job**」。票 E 交付時「3/3 全綠」與「`job-specs/reviewer/` 是空
目錄」這兩件事同時為真，而且不矛盾：矩陣繞過了 `build_job_spec()`。

runbook 新增第 **5-6c** 步補上第二維，其 5 條檢查刻意走 daemon 自己的派工路徑而不是
手工 spec（5-6b 的 spec 是 operator 手寫的，所以它驗得了加固面與身分、驗不到派工端）。

---

## 2. E2E：一輪 define 的實際結果

### 正規重試路徑的選擇

那筆卡住的 run（`workflow-ff855e0517ecb2b187dd` / `fix-rate-limit-classification`）
的 durable 失敗分類是 **`content`**（2026-08-17T23:29:32 記錄），因此：

- ❌ `recover-planning` **不可用**——`work_actions.py:3813` 對 content 明確 fail-closed
  （`recover-planning is not allowed for content failures`），`next_actions` 也只有
  `abandon`。
- ❌ `abandon` 會把 run 標成 superseded，是**銷毀式**的出口。
- ✅ **`cortex work resume`**——`_resume_decision` 回 `needs_human` 且
  `args["action"] == "resume"` 時重呼叫 `workflow_starter`（`work_actions.py:1883-1888`），
  等於讓同一個 run 重跑一次 define。CLI help 逐字寫著「resume 恢復 needs_human／blocked
  workflow」，**不改任何 durable state 的結構**，是系統本來就提供的人工介入出口。

### 實際結果

| 階段 | 結果 |
|---|---|
| **define（planning 執行面）** | ✅ **通** |
| **define（brainstorm 收斂）** | ❌ 未收斂——**content 級**，見下方誠實邊界 |
| **build** | ⛔ **未執行到** |
| **review** | ⛔ **未執行到** |

**執行面的證據（run `workflow-ff855e0517ecb2b187dd`）**——一輪 define 落成 6 個模板
instance，全部 `User=cortex-reviewer-planner`（以 `systemctl show -p User` 從 root 端
讀，**不採信 job 自己印的 `id`**，#628／#540）：

| 順序 | unit instance | 字幹／剖面 | 角色 |
|---|---|---|---|
| 1 | `cortex-reviewer-job@plan-workflow-ff8-probe-1-97e1a1bf-04a50589` | strict | probe |
| 2 | `cortex-reviewer-job@plan-workflow-ff8-probe-2-709e5d64-a17ef60b` | strict | probe |
| 3 | `cortex-reviewer-job-jit@plan-workflow-ff8-probe-3-f80ef581-4ec2b2fc` | **jit** | probe（codex） |
| 5 | `cortex-reviewer-job@plan-workflow-ff8-questioner-5-67051b95-b1c653ce` | strict | primary questioner |
| 6 | `cortex-reviewer-job@plan-workflow-ff8-secondary-6-6c1d02f8-c833cd99` | strict | secondary planner |
| 7 | `cortex-reviewer-job@plan-workflow-ff8-integrator-7-b0ca9670-90a0e37a` | strict | primary integrator |

**Manager 行程樹（plan §5 的驗收條件）**——一次 planning 呼叫期間每 3 秒取樣一次
`systemd-cgls -u cortex-manager.service`，**零 executor**，只有三層：

```
[10:30:13] /opt/cortex/venv/bin/python … cortex service run
           | bash -c /usr/bin/systemctl start --wait --no-ask-password cortex-revi…
           | /usr/bin/systemctl start --wait --no-ask-password cortex-reviewer-job…
           || jobs: cortex-reviewer-job@plan-workflow-ff8-questioner-1-95bd68e3-be6a1f1d.service
```

後兩層是 #604 的 exit 記帳 shell，不是模型。

**probe 快取（票 C 的指紋含 `PSC_JOB_RUNNER`）**——五格全部 `systemd-template`，
沒有一格混到 direct：

| identity | ready | 剖面 | unit | reason |
|---|---|---|---|---|
| `claude::claude-opus-5` | ✅ | strict | `cortex-reviewer-job@.service` | — |
| `claude::sonnet` | ✅ | strict | `cortex-reviewer-job@.service` | — |
| `agy::gemini-3.1-pro-high` | ✅ | strict | `cortex-reviewer-job@.service` | — |
| `codex::gpt-5.3-codex-spark` | ❌ | jit | `cortex-reviewer-job-jit@.service` | `planning-output-malformed`（＝票 E 已具名的 **R-2**，見下） |
| `cg::glm-5.2` | ❌ | `<unresolved:JobRunnerError>` | — | 未登記 executor，**設計上的 fail-closed** |

**`no-heterogeneous-planner` 消失**：primary＝`claude`/anthropic、
secondary＝`agy`/google，兩個 independence domain。#668 的根因至此關閉。

### 誠實邊界：**define → build → review 這一輪沒有跑完**

第二、三次 `resume` 都停在同一處，但**失敗性質已經換了一族**：

```
primary-artifact-write-rejected: planning artifact is not accepted:
  docs/superpowers/specs/fix-rate-limit-classification-spec.md
  (reasons=blocking-decision; markers=L19:The authoritative definition of the current
   misclassification (inputs, expected outputs, affected call sites) is not present in
   the supplied source material …)
```

planner 誠實回報「來源材料裡沒有足以寫出 accepted spec 的權威內容」，artifact
authority 因此拒收帶 open-question 的 spec。**這是 content 級失敗，而且是系統正確的
行為**——`docs/superpowers/workstreams/fix-rate-limit-classification/todo.md` 本身內容
不足，需要人的裁決，不是本票能修的東西。兩次重試落在**不同的** open question 行號，
可重現。

因此：

- ✅ 「planning 的執行面已降權」——有實機證據。
- ✅ 「失敗語意三分把拓撲誤報換成了真正的原因」——`no-heterogeneous-planner` →
  `job-runner-job-spec-invalid` → `blocking-decision`，三次都指向不同的真實原因，
  這正是票 A（#682）要買的東西。
- ❌ **「四分部署跑通一輪 define → build → review」——沒有做到。** build 與 review
  兩階段在本票期間**一次都沒有被執行到**（它們的降權在 M1／#615 就已落地並各自有
  驗收，但本票沒有為它們產生新證據）。當時可 claim 的 work item 只有這一個，其餘 24
  筆全是 `missing_issue` 的 workstream 類。

---

## 3. `deferred_run_dependencies()` 的 `manager-claude-credential` 移除

票 D（#685）刻意沒刪，理由逐字是「切換尚未發生，direct 路徑逐字還在，現在刪等於宣稱
一件還沒成立的事」。本票讓它成立了。

它從來不是「還沒補的憑證」，而是「Manager 在 direct 模式下自己 exec `claude`」這件事的
登記表投影。切換之後 Manager 不再 exec 任何 executor ⇒ 本項**消失**，而不是被登記成一
格資產（Manager 是 durable state owner ＋ spawn 授權持有者，passwd 註記逐字寫著
`no model code`）。

新測試多守一條，因為只驗「清單少一項」的話，**「刪掉逾期項」與「把它登記成資產」看
起來一模一樣**：

```python
assert manager_account not in permgen.CREDENTIALED_ACCOUNTS
```

逾期清單：4 項（#666）→ 3 項（#685）→ **2 項**。

---

## 4. 逐條更正了哪些宣稱

原則：**改成精確的描述，不是把「未完成」改成「完成」。**

| # | 位置 | 原文 | 改法 |
|---|---|---|---|
| 1 | runbook「分段落地」表 | 「**M2**：reviewer／planner job 也改經 template instance ✅ 程式碼已落地（#615）」 | 拆成 **M2（reviewer，#615）** 與 **M2′（planner，#682-#687）** 兩列 |
| 2 | runbook「M2 之後可以宣稱的」 | 「三個會跑模型的 persona **啟動面全部離開 Manager 的 UID**」／「injection 可達的進程皆無 spawn 授權」**全稱**成立／「D6 三分已生效」 | 三句逐句標明**在 M2 之後仍是假的**，並註記這是本 repo「為了收尾而宣稱過頭」的樣本案例——下面那份「不得順手宣稱」清單看起來窮舉，卻漏掉最大的一項 |
| 3 | runbook「M2 仍未涵蓋的」清單 | 三條（gate 身分／reviewer 憑證 refresh／reviewer 工作樹） | 改標題為 **M2′ 之後**，並補上 **codex 的 R-2** 與 **`cg` fail-closed** 兩條 |
| 4 | runbook 5-8 殘餘風險表 | `~~M2 未完成~~` … 「已關閉（#615）：三個會跑模型的 persona 啟動面全部離開 Manager 的 UID」 | 拆成 reviewer／planner 兩列，**並保留原列作為紀錄**：一句過寬的「已關閉」讓這個缺口在殘餘風險表上隱形了三天 |
| 5 | runbook 5-8「已被關掉的」表 | 「reviewer／planner 與 Manager 併帳 → **不再成立**」 | 註明 #615～#687 之間**對 planner 是假的**：帳號映射面成立、執行面沒有 |
| 6 | runbook A/B 兩層論述 ＋ 5-1 邊界表 | 「injection 可達的進程**完全不在授權面上**」×2 | 各補「#687 之後才對 planner 成立」＋ 現在的 cgroup 實測 |
| 7 | runbook 帳號表 | 「`cortex-manager` … **不跑任何模型程式碼**」 | 補「此欄自 #687 起才對**全部**執行面成立」 |
| 8 | runbook 5-5 的 `PSC_JOB_RUNNER` 說明 | 「#615 M2 起對**三個** persona 都生效，判定點在 `_job_role()`」 | 改成「走 `SubprocessLauncher` 的三個」，並指出 #687 起有**第二個消費者且不在 launcher 上** |
| 9 | runbook 5-6b 標題 | 「正向驗證（**reviewer／planner 模板**）」 | 改成「**reviewer 模板**」，並指明 planner 那一半在本節**沒有任何證據** |
| 10 | `job_runner.JOB_ROLE_REVIEW` rationale | 「M2（#615）：**在此之前**它們仍在 Manager 行程內」 | 那句對 planner 一直是**現在式**；改成兩張票、相隔三個月的分述 |
| 11 | `launcher._downgraded_mode()` | 「M2 之後三個會跑模型的 persona 全部離開 Manager 的 UID」 | 改成「**走本 launcher 的**派工全部降權」，並說明射程被誤讀成全稱 |
| 12 | `launcher._job_role()` ＋ `planning_runtime.build_production_planning_runtime()` | 兩處**互相矛盾**的「唯一決定點」／「全庫唯一的執行後端選擇點」 | 各自加範圍限定：兩條 code path 各一個選擇點，全庫唯一的是共用的 `resolve_runner_mode()` |
| 13 | `launcher._is_review_persona()` | 判準 2「`read_only`＝planner」 | 限定為 **workflow lane 的 planner 卡**；這個 docstring 是「planner 已經降權了」這個假直覺的來源之一 |
| 14 | `permgen.DOWNGRADED_JOB_PRINCIPALS` ＋ `registry` 同一段（成對） | 「**實際具備啟動面降權**的 job principal」＋「`PLANNER` 刻意不在表內」 | 語義不動，補一句「本表是**產得出哪幾份 unit／spool**，不是**哪些執行路徑真的走上它**」——這兩件事分岔了三個月，而產生器面永遠不會發現 |
| 15 | `planning_job.py` 模組 docstring | 「它**至今仍在** daemon 行程內 `subprocess.run` 模型 CLI」 | 改成過去式 ＋ 補 #687 之後的實測狀態 |
| 16 | `README.md` 的 `PSC_JOB_RUNNER` | 只講 builder／`systemd-run` | 補 `systemd-template` 的四條涵蓋路徑，點名 planning 是 #687 才接上的那一條 |

**刻意不改的**：`CHANGELOG.md` 與 `changelog.d/` 的既有 fragment（歷史紀錄，
按 repo 慣例不改寫；#615 的完成宣稱在**本票自己的新條目**裡註記）、
`docs/superpowers/specs/trust-root-isolation-spec.md`（通篇沒有「M2 已完成」類宣稱，
它全是 SHALL／MUST 且**每一條都把 planner 與 builder／reviewer 並列**——它其實是證明
runbook 過度宣稱的那把尺）。

---

## 5. 仍然不成立的宣稱（誠實列出）

1. **「四分部署跑通一輪 define → build → review」——沒有做到。**
   build／review 在本票期間一次都沒被執行到。理由是 content 級的（唯一可 claim 的
   work item 的 `todo.md` 內容不足以收斂），不是執行面的。
2. **`codex` 在 job 模式下不是可用的 planning executor。** probe 落
   `planning-output-malformed`——`codex exec --json` 的第二輸出候選 `-o last.json`
   落在 job 的 `PrivateTmp` 私有 `/tmp`，Manager 讀不到 ⇒ `_extract_json` 只剩單一
   候選。這是票 E（#686）**已具名的安全退步 R-2**，不是新缺口，也不在本票處置範圍。
   淨效果：planning 的異質性由 `claude`＋`agy` 承擔（兩個 domain，足夠），`codex`
   那格在拒因表上現形。
3. **spec §R9 對 planner 的「分別執行」仍是靠等價論證。** `trust-root-isolation-spec.md:1185`
   要求四族測試矩陣「對 builder／reviewer／planner 三者分別執行（或明確論證等價性）」；
   runbook 第 8 步只跑 `cortex-builder` 與 `cortex-reviewer-planner` **兩個 subject**，
   planner 這一支走的是「同帳號 ⇒ 等價」。本票讓那個等價論證第一次有了**執行面**的
   支撐（planner 真的以該帳號起跑），但沒有為 planner 另跑一輪 R9。
4. **#692（HOME 的 fail-open）、#681（copilot shim）、#685 留下的 U-9
   （codex-hooks 與 `$CODEX_HOME` 互斥）** 一律未動，依開票者指示。
5. **`cg` executor 永遠 not ready**（未登記於 `EXECUTOR_HARDENING_PROFILE`）。這是設計
   要的白名單行為，但它每一輪都會佔一格 probe 並在拒因表上出現一次；沒有票在追。

---

## 6. 既有測試的修改（逐條理由）

| 檔案／測試 | 改法 | 理由 |
|---|---|---|
| `test_trust_root_job_template_ab.py::test_build_job_spec_rejects_relative_paths_and_empty_command` | `{"command": ["bash", ""]}` → `{"command": ["", "-c", "true"]}` | 判準從「每個元素非空」收斂成「`argv[0]` 非空」。**不是刪掉斷言**——改測現在仍應被擋的那一種（空的 `argv[0]`），並在 docstring 逐字記錄原因與論證出處 |
| `test_trust_root_external_deps_exhaustive_666.py::test_deferred_dependencies_stay_enumerable` | 期望集合去掉 `manager-claude-credential`，加一條「不得改名留下」 | 該項由本票移除（#672 plan 明列的工作項），這條測試的用意就是「補上或悄悄拿掉都要紅」 |
| `test_trust_root_planner_credentials_672.py::test_the_two_entries_that_could_not_be_closed_say_why` | 改名為 `..._the_entry_...`（單數），移除 `manager-claude-credential` 的斷言；**另新增** `test_the_manager_credential_entry_disappeared_by_switching` | 同上。新測試多守一條 `manager_account not in CREDENTIALED_ACCOUNTS`——只驗「清單少一項」的話，「刪掉逾期項」與「把它登記成資產」看起來一模一樣，而後者正是 #672 要消除的東西 |

新增 `tests/test_planning_job_argv_687.py`（6 tests / 16 subtests），含三臂實測結論的
逐字記錄與「`--tools ""` 不得被等價寫法換掉」的反向守衛。

---

## 7. Operator 待辦（本票沒有做、也不該由 PR 做）

1. **merge 後重新部署 `/opt/cortex/venv`。** 為了跑 E2E，我把本分支的三個檔
   （`coordinator/job_runner.py`／`coordinator/job_shim.py`／`trust_root/permgen.py`）
   複製進了實機 venv 並重啟 Manager——**否則 planning 在這台機器上 100% 失敗**
   （`PSC_JOB_RUNNER=systemd-template` 已是生產設定，而未修的 venv 每一次 define 都落
   `job-runner-job-spec-invalid`）。目前實機跑的是**未 merge 的程式碼**。
   回滾：`sudo cp -a /tmp/psc-venv-backup-687/* /opt/cortex/venv/lib/python3.12/site-packages/paulsha_cortex/`
   ＋ `systemctl restart cortex-manager`（`venv.prev` 則可退回 A～E 之前）。
2. **unit／EnvironmentFile／durable state 的結構一行未動**（本票紀律）。
   `/opt/cortex/bin/cortex-job-shim` 是 root-owned 的三行 sh wrapper，它 exec 的是
   venv 裡的 `paulsha_cortex.coordinator.job_shim`，因此讀端判準隨 venv 更新，**不需要
   重落 shim 檔**。
3. `cortex-job-shim` 的檔頭註解仍寫著 `scheme=three-way`（實際部署是 four-way）與一條
   非 per-principal 的 spec 路徑。**功能無影響**（路徑由 `job_shim` 依 unit 的
   `PSC_JOB_SPEC_SPOOL` 解析），但那份註解已經漂移。未開票，記在這裡。

---

## 驗證

- `python3 -m pytest tests/ -q` → **4395 passed, 28 skipped, 65 subtests passed**
- `policy_check`（帶 PR 上下文）→ **pass: 25 / fail: 0 / warn: 1**（R-22 陳年懸空引用，
  非本次新增，WARN 不擋 merge）
- 加固面驗證全部走 `psc_run_under`（`permgen.unit_replica_properties()` 從落檔 unit
  全量導出 **38 條** property），**零手寫 `--property=`、零 `--setenv=PATH=`**（D13）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E7w9kaUxAzCCEk7piD5hfK
