### PR TITLE
docs(trust-root): 更正 runbook 兩條陳舊的「仍未涵蓋」宣稱（#696）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 本專案遵循 hamanpaul project policy v1.0.17。
 
 ## [Unreleased]
+- runbook 的「M2′ 之後仍未涵蓋的」清單更正兩條陳舊項（gate 執行身分 #629 已完成、reviewer 憑證 refresh 已由 #685 解決），並加上「not-covered 清單本身也是宣稱」的約束（#696）。
 
 ### Fixed
 - **#687（#672 票 F）：planner 的 define／brainstorm 正式離開 Manager 行程——切換、

--- a/changelog.d/696-stale-uncovered-claims.md
+++ b/changelog.d/696-stale-uncovered-claims.md
@@ -1,0 +1,12 @@
+### Fixed
+
+- runbook 的「M2′ 之後仍未涵蓋的（不得順手宣稱）」清單有兩條長期陳舊，已更正並保留
+  更正紀錄（#696）：
+  - **gate 執行身分**寫「需要第四個帳號，屬 #629」——#629 早已 CLOSED，`cortex-gate`
+    帳號與 `cortex-gate-job@`／`-jit` 兩份模板 unit 均已落地。
+  - **reviewer 憑證無法就地 refresh** 寫「該檔不在 reviewer 模板 unit 的
+    `ReadWritePaths=` 內」——#685（#672 票 D）已把三份登入態改走 `HOME_REDIRECT_TREE`，
+    目標落在早已於 RWP 內的 `cache`，unit 的 RWP 逐字不變而憑證可寫。0818 實機於完整
+    加固面下實測 `touch -c "$HOME/.codex/auth.json"` 通過。
+- 同時加上一句約束：**not-covered 清單本身也是一種宣稱**，修好了要當場改掉，
+  否則它會反向說謊——把已完成的工作讀成未完成。

--- a/docs/superpowers/runbooks/trust-root-phase2b-setup.md
+++ b/docs/superpowers/runbooks/trust-root-phase2b-setup.md
@@ -108,17 +108,26 @@ unit 裡。
 
 **M2′ 之後仍未涵蓋的（不得順手宣稱）**：
 
-- **gate 執行身分**（#629）：gate 命令在 builder 完全掌控的 worktree 裡跑，`pytest`
-  會載入該 worktree 的 `conftest.py` ⇒ 執行者取得任意程式碼執行。**刻意不掛在
+> **⚠️ 本清單有兩條曾經長期陳舊。** 它們描述的缺口在 #629／#685 落地後就不成立，
+> 但清單沒跟著改——於是「Phase 2 還沒好」被讀成比實際更嚴重。**這份清單本身是
+> 一種宣稱，同樣受「不得順手宣稱」約束：修好了就要當場改掉，否則它會反向說謊。**
+> 兩條的更正紀錄保留在下方，作為「陳舊的 not-covered 清單也是一種假訊息」的實例。
+
+- ~~**gate 執行身分**（#629）：需要**第四個帳號**~~ ——**已完成（#629，已 CLOSED）**。
+  `cortex-gate` 帳號、`cortex-gate-job@`／`-jit` 兩份模板 unit 均已落地。
+  原始理由仍成立且值得保留：gate 命令在 builder 完全掌控的 worktree 裡跑，`pytest`
+  會載入該 worktree 的 `conftest.py` ⇒ 執行者取得任意程式碼執行；**刻意不掛在
   `cortex-reviewer-planner` 上**——那會讓被攻陷的 builder 經由 gate 執行影響到寫
-  verdict 的那個帳號，把 #638／#639 剛修好的東西整個抵銷。它需要**第四個帳號**，
-  屬 #629。在那之前降權 build 卡對 `require_ledger` fail closed。
-- **reviewer 的 executor 憑證就地 refresh**：`cortex-reviewer-planner` 的 `~/.codex`
-  骨架目錄已由 `scaffold_directories()` 建出並保護（root-owned），憑證檔由 root 於
-  第 4e 步複製並 chown 給它；但**該檔不在 reviewer 模板 unit 的 `ReadWritePaths=`
-  內**（登記表目前只登記 `builder-executor-credential` 一份，理由見該資產的 note：
-  在二分部署上登記第二份會讓 Manager unit 的 RWP 指向一條不存在的路徑而起不來）。
-  淨效果：reviewer 的 token 過期時**無法自行 refresh**，需 operator 重跑第 4e 步。
+  verdict 的那個帳號，把 #638／#639 剛修好的東西整個抵銷。
+- ~~**reviewer 的 executor 憑證就地 refresh**：該檔不在 reviewer 模板 unit 的
+  `ReadWritePaths=` 內，token 過期時無法自行 refresh~~ ——**已解（#685／#672 票 D）**。
+  三份登入態改走 `HOME_REDIRECT_TREE`：`~/.codex`／`~/.gemini`／`~/.claude` 是
+  **root-owned symlink**（job 換不掉指向），目標落在 `<HOME>/cache/{codex,gemini,claude}`，
+  而 `cache` **早已**在模板 unit 的 `ReadWritePaths=` 內 ⇒ **unit 的 RWP 逐字不變、
+  零新增可寫面，而憑證檔可寫、refresh 可行**。0818 實機以該帳號在完整加固面下
+  `touch -c "$HOME/.codex/auth.json"` 實測通過。
+  原 note 提到的「二分部署登記第二份會讓 Manager unit 的 RWP 指向不存在的路徑」
+  已由 #666／PR #671 的 `inapplicable_home_anchored_assets()` 機械處理。
 - **reviewer 的工作樹位置**：仍是 Manager provision 的 review worktree
   （`<來源樹>/.psc-review-worktrees/…`），不是 per-job clone。reviewer 是 read-only
   契約，對它只需**唯讀**可達；per-job clone 化屬 #623／#648 的範圍。


### PR DESCRIPTION
Closes #696

## 問題

runbook 的「M2′ 之後仍未涵蓋的（不得順手宣稱）」清單有兩條描述的缺口早已不成立，**把已完成的工作讀成未完成**。

| 條目 | 實際 |
|---|---|
| gate 執行身分「需要第四個帳號，屬 #629」 | #629 已 CLOSED，帳號與兩份模板 unit 均已落地 |
| reviewer 憑證「不在 RWP 內，無法 refresh」 | #685（票 D）已解，0818 實機實測可寫 |

## 改法

兩條**劃掉原文但保留**，標明由哪張票解決、以及原始理由中仍然成立的部分（gate 那條的「刻意不掛在 `cortex-reviewer-planner` 上」論證仍有效，值得留著）。

清單頂加一句約束：

> 這份清單本身是一種宣稱，同樣受「不得順手宣稱」約束：修好了就要當場改掉，否則它會反向說謊。

## 為什麼

repo 對「不得宣稱已完成」的紀律很嚴（#687 逐條更正 16 處），但**反方向沒有對稱約束**。陳舊的 not-covered 清單是同一種假訊息，只是方向相反——代價是完成度看起來比實際差，可能導致重複開工或錯誤排序。

## 驗證

- 0818 實機查證兩條（見 #696 的指令與輸出）
- docs-only，零程式變動
- `changelog.d/696-stale-uncovered-claims.md` ＋ `CHANGELOG.md [Unreleased]` 已補

## Checklist

- [x] changelog fragment 已新增且已 commit
- [x] CHANGELOG [Unreleased] 有對應 entry
- [x] PR body 寫 Closes
- [x] zh-tw
- [x] 分支非 main