### PR TITLE
fix(planner): question-pack 驗證改為逐欄可診斷，並保存模型輸出（#701）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 本專案遵循 hamanpaul project policy v1.0.17。
 
 ## [Unreleased]
+- planning 的模型輸出驗證失敗改為**逐欄可診斷**：question-pack 的六種以上失敗不再塌縮成同一句話（改報「第一個差異的索引／欄位／expected／got」與列數），secondary evidence／primary integration／plan frontmatter／required headings 的同型塌縮一併掃過；三個 adapter 共用的 `_invoke_json` 於 rc≠0 時沿用 #674 的 `stdout_excerpt()` 保存模型輸出（只讀 stdout、不讀 stderr）；差異文字經產生端遮罩，模型無法偽裝成分類標記（#701）。
 - R9 的 T1.3 斷言改為驗「operator CLI 做得到事」而非「binary 跑得起來」（兩個 subject 同時假失敗）；runbook 記錄 0818 兩 subject 實測結果並標明 T3.9 對 reviewer-planner 為已知追蹤項（#698）（#699）。
 - runbook 的「M2′ 之後仍未涵蓋的」清單更正兩條陳舊項（gate 執行身分 #629 已完成、reviewer 憑證 refresh 已由 #685 解決），並加上「not-covered 清單本身也是宣稱」的約束（#696）。
 

--- a/changelog.d/701-question-pack-diagnostics.md
+++ b/changelog.d/701-question-pack-diagnostics.md
@@ -1,0 +1,48 @@
+# 701-question-pack-diagnostics
+
+- **#701：question-pack 驗證把六種以上的失敗塌縮成一句話、且不保存模型輸出——define
+  穩定卡住卻無人查得動**——`validate_question_pack()` 的最後一關是整份 `to_dict()` 相等
+  （`planning.py:797`），`pack_id`／任一 `question_id`／`kind`／`prompt`／`source_refs`／
+  questions 的順序／數量**全部**塌縮成 `question pack does not cover exact completeness
+  blockers` 一句話；而模型實際回了什麼**沒有任何地方保存**。實機後果是 define 穩定卡在
+  `question-pack-malformed`（兩筆 work item × `work start`／`work resume` 兩種觸發路徑，
+  四次皆同），落檔的 `cortex-planning-failure/v1` evidence 只有那句話。#701 的外部重現
+  12/12 逐位元 MATCH、R-5 已排除，唯一擋著下一步的就是「診斷面是空的」。修法三件，
+  **判準逐位元不動**——本票只讓失敗變成可診斷：
+  - **逐欄差異取代一句話**：`describe_question_pack_difference()` 回報**第一個**差異的
+    `<locator> expected=<值> got=<值>`，locator 為 `pack_id`／`questions[2].kind` 這種
+    可直接對位的座標；訊息開頭一律另帶 `rows expected=N got=M`，「有幾條」與「差在哪」
+    兩件事都答得出來。原句逐字保留在最前面，operator 既有的 grep 錨點不變。
+  - **同型塌縮逐處掃過**：`validate_secondary_evidence()`（identity 兩種、question_id
+    三種、覆蓋率不列出缺哪幾題）、`_validate_primary_integration()`（#516 的兩個
+    echo-back 欄位不說抄成了什麼、`invalid keys` 不說缺／多哪個鍵、artifact ref
+    對不上不說是「寫了沒人引用」還是「引用了沒寫」）、`_strict_string_list()`（三種
+    失敗同一句、不說第幾項）、plan frontmatter 三處（`invariant_count`／
+    `artifact_classes`／`scope_excludes`）、`builder envelope 格式錯誤`（五個條件同一
+    句），以及 `required-section-missing`（#520 的同型缺口：現在一併印出 planner 實際
+    寫了哪些標題與可接受集合）。
+  - **失敗時保存模型的實際輸出**：questioner／secondary／integrator 三個 adapter 共用的
+    `planning_runtime._invoke_json()` 在 rc≠0 時只留得下 `planning launcher failed:
+    <executor>/<model>`——rc 與模型輸出隨 invoker 的 tempdir 一起消失。改為沿用 #670／
+    PR #674 已建立的 `stdout_excerpt()` 帶上 `rc=<N> stdout=<節錄>`，**只讀 stdout、
+    不讀 stderr**（票 A／PR #688 立下的憑證邊界）。`_extract_json_candidates()` 的兩處
+    片段也改走同一支函式，不再是會把換行帶進單行 reason 的裸切。
+- **截斷策略沿用票 A**：locator（哪一列、哪一欄）**永不被截斷、永不被遮罩**；只有值會被
+  截，且視窗**對齊到第一個相異字元**（長 prompt 的前 72 字往往兩邊一模一樣，取前綴等於
+  印兩份相同的字），前後各犧牲幾個字以 `<+Nc>` 就地記帳。四個 `except` 分支的例外摘要
+  收斂成 `summarize_planning_exception()`，預算由 #397 的 160 放寬到 480（逐欄差異裝不進
+  160），截斷同樣就地記帳。
+- **防偽：模型輸出不得偽裝成分類標記**。差異文字進的是 `blocking_reason`，而
+  `manager._classify_planning_failure()` 除了票 A 那條**錨在字串開頭**的 `grade=`，還有
+  三條**不錨定**的文字判準（#533／#554 的 taxonomy marker 詞界比對、#416 的 authority
+  殘留、#507 的 worktree drift 裸子字串）。若把模型的值原樣丟進 reason，模型只要在某個
+  `prompt` 裡寫上 `timeout` 或 `503` 就能把一個 content 失敗改判成 environment。修法在
+  **產生端**堵住：詞界類 marker 兩側各加一個 `_` 破詞界（字面一個字都不少），裸子字串類
+  的三條長句整段換成不含 marker 的佔位符。**launcher 轉印的服務錯誤刻意不走這條**——
+  #533 的 503 自癒路徑正是要看見那一段。
+- **測試**：`tests/test_planning_diagnostics_701.py`（67 條）。核心斷言是**反塌縮**本身
+  ——八種 question-pack 變異 ⇒ 八個**互不相同**的訊息，`questions[i]` 的六種 scalar 失敗
+  ⇒ 六個、artifact row 四種 ⇒ 四個；防偽面對 `TRANSIENT_SERVICE_MARKERS` **全表**逐一
+  掃描（比照 #554 的同型測試），並正反兩向釘住票 A 的 `grade=` 錨定式（偽造的拒因表不
+  成立、真的拒因表照常成立）；`_invoke_json` 的節錄以 #674 的 `stdout_excerpt()` 實際
+  產生（不自造字串），另一條釘住 stderr 內容永不進診斷。既有測試**一行未改**。

--- a/paulsha_cortex/coordinator/planning.py
+++ b/paulsha_cortex/coordinator/planning.py
@@ -16,6 +16,7 @@ from .model_identities import (
     render_secondary_rejection_reason,
     select_secondary_planner,
 )
+from .outcome_taxonomy import TRANSIENT_SERVICE_MARKER_RE
 from .workflow import GateEvidenceRef
 
 PLANNING_KINDS = ("spec", "design", "plan")
@@ -466,7 +467,10 @@ def _plan_review_contract_compatibility(
     frontmatter, body, _ = _frontmatter_and_body(plan_artifact.text)
     excludes_raw = frontmatter.get("scope_excludes", [])
     if not isinstance(excludes_raw, list) or any(not isinstance(item, str) for item in excludes_raw):
-        raise ValueError("plan frontmatter scope_excludes 必須為字串列表")
+        raise ValueError(
+            "plan frontmatter scope_excludes 必須為字串列表: "
+            + _render_difference("scope_excludes", "<str list>", excludes_raw)
+        )
     excludes = frozenset(item.strip().casefold() for item in excludes_raw if item.strip())
     haystack = "\n".join(_collect_task_items(body)).casefold()
 
@@ -510,14 +514,31 @@ def _plan_review_envelope(
     frontmatter, _, _ = _frontmatter_and_body(plan_artifact.text)
     invariant_count = frontmatter.get("invariant_count")
     if not isinstance(invariant_count, int) or isinstance(invariant_count, bool) or invariant_count < 0:
-        raise ValueError("plan frontmatter 缺少合法的 invariant_count（需為 >=0 整數宣告）")
+        # #701：三種失敗（欄位缺席／型別不是 int／負值）塌縮成同一句。
+        raise ValueError(
+            "plan frontmatter 缺少合法的 invariant_count（需為 >=0 整數宣告）: "
+            + _render_difference(
+                "invariant_count",
+                "<int >=0>",
+                frontmatter.get("invariant_count", DIAGNOSTIC_ABSENT_PLACEHOLDER),
+            )
+        )
     artifact_classes_raw = frontmatter.get("artifact_classes")
     if (
         not isinstance(artifact_classes_raw, list)
         or not artifact_classes_raw
         or any(not isinstance(item, str) or not item.strip() for item in artifact_classes_raw)
     ):
-        raise ValueError("plan frontmatter 缺少合法的 artifact_classes（需為非空字串列表宣告）")
+        # #701：四種失敗（欄位缺席／不是 list／空 list／含非字串或空白項）塌縮
+        # 成同一句。
+        raise ValueError(
+            "plan frontmatter 缺少合法的 artifact_classes（需為非空字串列表宣告）: "
+            + _render_difference(
+                "artifact_classes",
+                "<non-empty str list>",
+                frontmatter.get("artifact_classes", DIAGNOSTIC_ABSENT_PLACEHOLDER),
+            )
+        )
     artifact_classes = frozenset(item.strip() for item in artifact_classes_raw)
 
     # #209（能力封套）未落地：可插拔 provider，缺席時可觀測 bypass 通過。
@@ -536,7 +557,20 @@ def _plan_review_envelope(
         or not isinstance(envelope_artifact_classes_raw, list)
         or any(not isinstance(item, str) for item in envelope_artifact_classes_raw)
     ):
-        raise ValueError("builder envelope 格式錯誤")
+        # #701：五個條件（invariant_count 三種 ＋ artifact_classes 兩種）塌縮成
+        # 同一句。envelope 是 provider 供給、不是模型輸出，但塌縮是同一型。
+        raise ValueError(
+            "builder envelope 格式錯誤: "
+            + _render_difference(
+                "invariant_count", "<int >=0>", envelope.get("invariant_count", DIAGNOSTIC_ABSENT_PLACEHOLDER)
+            )
+            + " "
+            + _render_difference(
+                "artifact_classes",
+                "<str list>",
+                envelope.get("artifact_classes", DIAGNOSTIC_ABSENT_PLACEHOLDER),
+            )
+        )
     envelope_artifact_classes = frozenset(str(item).strip() for item in envelope_artifact_classes_raw)
     over_budget = artifact_classes - envelope_artifact_classes
     if invariant_count > envelope_invariant_count or over_budget:
@@ -656,7 +690,10 @@ def _declared_dimension(frontmatter: Mapping[str, object], field: str) -> int:
     比照 PlanningScope.__post_init__ 風格）。"""
     value = frontmatter.get(field)
     if not isinstance(value, int) or isinstance(value, bool) or not (0 <= value <= 2):
-        raise ValueError(f"plan frontmatter 缺少合法的 {field}（需為 0–2 整數宣告）")
+        raise ValueError(
+            f"plan frontmatter 缺少合法的 {field}（需為 0–2 整數宣告）: "
+            + _render_difference(field, "<int 0..2>", frontmatter.get(field, DIAGNOSTIC_ABSENT_PLACEHOLDER))
+        )
     return value
 
 
@@ -707,12 +744,17 @@ def compute_sizing_score(
     state_consistency = _declared_dimension(frontmatter, "state_consistency")
 
     if gate_spine_count < 0:
-        raise ValueError("gate_spine_count 不得為負")
+        raise ValueError(f"gate_spine_count 不得為負: got={gate_spine_count}")
     unknown_rules = applicable_contract_rules - ACCEPTANCE_SURFACE_RULES
     if unknown_rules:
         raise ValueError(f"applicable_contract_rules 含未知規則: {sorted(unknown_rules)}")
     if cards_count < 0 or persona_binding_count < 0 or persona_binding_count > cards_count:
-        raise ValueError("cards_count/persona_binding_count 不合法")
+        # #701：三種失敗（cards 為負／binding 為負／binding 多於 cards）塌縮成
+        # 同一句、且兩個值都不印。呼叫端算好的整數，不是模型輸出，但塌縮同型。
+        raise ValueError(
+            "cards_count/persona_binding_count 不合法: "
+            f"cards_count={cards_count} persona_binding_count={persona_binding_count}"
+        )
 
     # acceptance_surfaces：核心 gate_spine 計數 + 適用規則數的組合訊號，門檻切三級。
     acceptance_signal = gate_spine_count + len(applicable_contract_rules)
@@ -748,40 +790,330 @@ def compute_sizing_score(
     )
 
 
+# --- issue #701：模型輸出驗證失敗的逐欄診斷 -----------------------------------
+#
+# 修法前 `validate_question_pack()` 的最後一關是 `to_dict()` 整體相等：
+#
+#     if normalized.to_dict() != report.default_question_pack.to_dict():
+#         raise ValueError("question pack does not cover exact completeness blockers")
+#
+# `pack_id`／任一 `question_id`／`kind`／`prompt`／`source_refs`／questions 的
+# 順序／數量——**六種以上結構完全不同的失敗塌縮成同一句話**，而模型實際回了
+# 什麼一個字都沒留。實機後果：define 穩定卡住（兩筆 work item × 兩種觸發路徑，
+# 四次皆同），落檔 evidence 只有那句話，沒有人查得動。同型塌縮在
+# `validate_secondary_evidence()`／`_validate_primary_integration()` 各還有數處
+# （見各自的 raise），本節的三個工具三處共用：
+#
+#   1. `_render_difference()`——第一個差異的 `<locator> expected=… got=…`。
+#      **locator 永不被截斷**，被犧牲的只有值，且犧牲多少就地記帳。
+#   2. `_guard_classification_markers()`——讓模型可控的值不可能偽裝成
+#      `manager._classify_planning_failure` 的分類標記。
+#   3. `summarize_planning_exception()`——四個 `except` 分支共用的例外摘要。
+#
+# 本節**不動任何驗證判準**：什麼算合法、什麼算不合法逐位元不變，只讓「不合法
+# 在哪裡」變成看得見的。
+
+#: 單一值在診斷訊息裡的字元上限。兩個值（expected／got）＋ locator ＋ 原句約
+#: 落在 300 字元內，仍在 `PLANNING_FAILURE_DETAIL_LIMIT` 之內。
+PLANNING_DIAGNOSTIC_VALUE_LIMIT = 72
+#: 值視窗對齊到第一個相異字元時，差異點**之前**保留的字元數。長 prompt 的前
+#: 72 個字往往兩邊一模一樣，直接取前綴等於印兩份相同的字：視窗必須跟著差異
+#: 點走，「看得出差在哪」才成立。
+PLANNING_DIAGNOSTIC_WINDOW_LEAD = 16
+#: `run_heterogeneous_brainstorm` 四個 `except` 分支對底層例外訊息的字元預算。
+#: #397 定的 160 是「只有一句話」時代的數字，逐欄差異裝不下（locator ＋ 兩個
+#: 值就超過）；1200 是票 A 拒因表的全表預算，這裡取其零頭。
+PLANNING_FAILURE_DETAIL_LIMIT = 480
+
+#: 值不存在（questions 少一列、欄位缺席）時的顯示形。佔位符本身不得含任何
+#: taxonomy marker——`<unavailable>` 就是這樣撞上 #554 的。
+DIAGNOSTIC_ABSENT_PLACEHOLDER = "<absent>"
+
+#: `manager._classify_planning_failure` 以**裸子字串**比對整串 reason 的分類
+#: 標記：#416 的 authority 殘留兩條，與 #507／#554 的 operator worktree drift
+#: 一條。字面值刻意複製於此而不 import——`manager` 與 `planning_runtime` 都反
+#: 向依賴本模組，import 會成環；`tests/test_planning_diagnostics_701.py` 有一
+#: 條交叉比對測試釘住兩邊同步（那邊改了、這邊沒跟上，測試當場紅）。
+_CLASSIFICATION_MARKER_PHRASES = (
+    "planning artifact lacks current planning authority",
+    "planning artifact current authority drift",
+    "planning launcher modified operator worktree",
+)
+#: 上列 phrase 命中時的替代字（本身不含任何 marker）。
+CLASSIFICATION_MARKER_PLACEHOLDER = "<classification-marker-elided>"
+_CLASSIFICATION_MARKER_PHRASE_RE = re.compile(
+    "|".join(re.escape(phrase) for phrase in _CLASSIFICATION_MARKER_PHRASES),
+    re.IGNORECASE,
+)
+#: C0／C1 控制字元。診斷會進單行 log／`blocking_reason`，模型輸出裡的換行與
+#: ANSI escape 不得污染它（與票 A 的 `_CONTROL_CHARS_RE` 同一條規矩）。
+_DIAGNOSTIC_CONTROL_RE = re.compile(r"[\x00-\x1f\x7f-\x9f]+")
+
+
+def _guard_classification_markers(text: str) -> str:
+    """讓一段**模型可控**的文字不可能偽裝成 `_classify_planning_failure` 的標記。
+
+    票 A（#682／PR #688）為 probe 拒因表立下的規矩是：分類器讀渲染端算好、
+    **錨在字串開頭**的 `grade=` 欄位，不對整串 reason 做 substring search。本
+    票新增的逐欄差異走的是另一條路——它進的是 `question-pack-malformed: …`
+    這類 reason 的**尾段**，`grade=` 的錨定式（`\\A[a-z0-9-]+ grade=environment
+    candidates=\\d+ \\(`）在結構上碰不到它。
+
+    但 `_classify_planning_failure` 還有三條**不錨定**的判準：#533／#554 的
+    `outcome_taxonomy.TRANSIENT_SERVICE_MARKER_RE`（詞界比對整串）、#416 的
+    authority 殘留、#507 的 worktree drift（兩者裸子字串比對整串）。把模型的
+    值原樣丟進 reason，等於讓模型只要在某個 `prompt` 裡寫上 `timeout` 或
+    `503`，就能把一個**內容**失敗改判成 environment、讓 `recover-planning`
+    對著一個永遠不會自癒的失敗一直重試。本函式在**產生端**堵掉這條：
+
+    - 詞界類 marker（`timeout`／`503`／`overloaded`…）：兩側各加一個 `_`。
+      `_` 是 word char，`\\btimeout\\b` 於是不成立，而**字面一個字都沒少**
+      ——這正是 `test_every_marker_needs_word_boundaries`（#554）已經釘住的
+      性質（`x_{marker}_x` 不命中）反過來用。
+    - 裸子字串類 phrase（三條長句）：詞界破不了它們（`in` 不看邊界），只能
+      整段換成 `CLASSIFICATION_MARKER_PLACEHOLDER`。這三條是很長的特定句
+      子，出現在合法規劃輸出裡的機率遠低於前者，代價可接受。
+
+    只作用在**模型／repo 值**上。launcher 轉印的服務錯誤（`planning launcher
+    returned no JSON object: …Eligibility check failed…`）**不**走本函式：
+    #533 的判準刻意要看見那一段，遮掉它等於把 503 自癒路徑砍掉。
+    """
+
+    guarded = _CLASSIFICATION_MARKER_PHRASE_RE.sub(CLASSIFICATION_MARKER_PLACEHOLDER, text)
+    return TRANSIENT_SERVICE_MARKER_RE.sub(lambda match: f"_{match.group(0)}_", guarded)
+
+
+def _display_form(value: object) -> str:
+    """值 → 單行顯示形。字串原樣，其餘走 canonical JSON（不可序列化則 `repr`）。"""
+
+    if isinstance(value, str):
+        text = value
+    else:
+        try:
+            text = _canonical_json(value)
+        except (TypeError, ValueError):
+            text = repr(value)
+    return " ".join(_DIAGNOSTIC_CONTROL_RE.sub(" ", text).split())
+
+
+def _windowed_value(text: str, *, start: int = 0, limit: int = PLANNING_DIAGNOSTIC_VALUE_LIMIT) -> str:
+    """把顯示形壓成有界視窗，**被犧牲的字數就地記帳**（票 A 的截斷策略）。
+
+    `'<+12c>missing design<+40c>'`：前面少了 12 個字、後面少了 40 個字。記帳
+    數字算的是**遮罩前**的原始字元，因此「這個值總共多長」永遠推得回來。
+    """
+
+    start = max(0, min(start, len(text)))
+    body = text[start : start + limit]
+    prefix = f"<+{start}c>" if start else ""
+    dropped = len(text) - start - len(body)
+    suffix = f"<+{dropped}c>" if dropped > 0 else ""
+    return f"'{prefix}{_guard_classification_markers(body)}{suffix}'"
+
+
+def _common_prefix_length(left: str, right: str) -> int:
+    length = 0
+    for left_char, right_char in zip(left, right):
+        if left_char != right_char:
+            break
+        length += 1
+    return length
+
+
+def _render_difference(
+    locator: str,
+    expected: object,
+    got: object,
+    *,
+    limit: int = PLANNING_DIAGNOSTIC_VALUE_LIMIT,
+) -> str:
+    """`<locator> expected=<值> got=<值>`——本票所有差異訊息的唯一文法。
+
+    `locator`（`questions[2].kind`、`pack_id`、`resolutions[0].artifact_kind`）
+    是**判準端算出來的**，永不截斷、永不遮罩：它就是「差在哪」本身。兩個值
+    才是可犧牲的部分。
+    """
+
+    expected_text = _display_form(expected)
+    got_text = _display_form(got)
+    start = 0
+    if len(expected_text) > limit or len(got_text) > limit:
+        common = _common_prefix_length(expected_text, got_text)
+        if common > limit - PLANNING_DIAGNOSTIC_WINDOW_LEAD:
+            start = common - PLANNING_DIAGNOSTIC_WINDOW_LEAD
+    expected_rendered = _windowed_value(expected_text, start=start, limit=limit)
+    got_rendered = _windowed_value(got_text, start=start, limit=limit)
+    return f"{locator} expected={expected_rendered} got={got_rendered}"
+
+
+def _render_absent(locator: str, expected: object, *, limit: int = PLANNING_DIAGNOSTIC_VALUE_LIMIT) -> str:
+    return (
+        f"{locator} expected={_windowed_value(_display_form(expected), limit=limit)} "
+        f"got={DIAGNOSTIC_ABSENT_PLACEHOLDER}"
+    )
+
+
+def _render_unexpected(locator: str, got: object, *, limit: int = PLANNING_DIAGNOSTIC_VALUE_LIMIT) -> str:
+    return (
+        f"{locator} expected={DIAGNOSTIC_ABSENT_PLACEHOLDER} "
+        f"got={_windowed_value(_display_form(got), limit=limit)}"
+    )
+
+
+def summarize_planning_exception(
+    exc: BaseException, *, limit: int = PLANNING_FAILURE_DETAIL_LIMIT
+) -> str:
+    """`<ExceptionTypeName>: <訊息>`——四個 `except` 分支共用的例外摘要。
+
+    #397 起這四處就併入例外型別與訊息，本票只改兩件事：預算由 160 放寬到
+    `PLANNING_FAILURE_DETAIL_LIMIT`（逐欄差異裝不進 160），以及截斷改為
+    **就地記帳** `…+Nc`（原本是裸切，讀的人看不出還有沒有下文）。單行化與
+    型別名在前的順序不變——`outcome_taxonomy` 的 `timeoutexpired` 這類 marker
+    靠的就是型別名活著。
+    """
+
+    message = " ".join(_DIAGNOSTIC_CONTROL_RE.sub(" ", str(exc)).split())
+    if len(message) > limit:
+        message = f"{message[:limit]}…+{len(message) - limit}c"
+    return f"{type(exc).__name__}: {message}"
+
+
 def _strict_string_list(value: object, field: str, *, allow_empty: bool = False) -> tuple[str, ...]:
-    if not isinstance(value, list) or any(not isinstance(item, str) or not item.strip() for item in value):
-        raise ValueError(f"{field} must be a string list")
+    """字串列表判準。判準逐位元不變，只把「哪一項不合」講出來（#701）。
+
+    修法前三種失敗（不是 list／某一項不是字串／某一項是空白）塌縮成同一句
+    `must be a string list`，連是第幾項都沒有。
+    """
+
+    if not isinstance(value, list):
+        raise ValueError(
+            f"{field} must be a string list: "
+            + _render_difference("type", "list", type(value).__name__)
+        )
+    for index, item in enumerate(value):
+        if not isinstance(item, str):
+            raise ValueError(
+                f"{field}[{index}] must be a string: "
+                + _render_difference("type", "str", type(item).__name__)
+                + f" value={_windowed_value(_display_form(item))}"
+            )
+        if not item.strip():
+            raise ValueError(f"{field}[{index}] must not be blank")
     normalized = tuple(item.strip() for item in value)
     if not allow_empty and not normalized:
         raise ValueError(f"{field} must not be empty")
     return normalized
 
 
+#: `validate_question_pack` 的整體相等判準不相等時的**原句**。前綴逐字保留
+#: （operator 的 grep 習慣、既有 log 與 issue #701 都以它為錨點），逐欄差異接
+#: 在冒號之後。
+QUESTION_PACK_MISMATCH_MESSAGE = "question pack does not cover exact completeness blockers"
+
+
+def describe_question_pack_difference(got: QuestionPack, expected: QuestionPack) -> str:
+    """回傳 `got` 與 `expected` 的**第一個**差異描述；完全相等時回傳空字串。
+
+    掃描順序即報告順序：`schema_version` → `pack_id` → 逐列逐欄
+    （`question_id` → `kind` → `prompt` → `source_refs`）→ 列數。列數放最後
+    是因為「第 0 列的 kind 就錯了」比「總共少一列」更接近成因；但列數本身
+    **一律**寫在訊息開頭的 `rows expected=N got=M`，兩件事都答得出來
+    （票 A：「有幾條、分別是誰、各自為什麼」不得被犧牲）。
+
+    本函式**不參與判準**——判準仍是 `to_dict()` 逐位元相等，這裡只負責在它
+    說「不等」之後回答「哪裡不等」。
+    """
+
+    if got.schema_version != expected.schema_version:
+        return _render_difference("schema_version", expected.schema_version, got.schema_version)
+    if got.pack_id != expected.pack_id:
+        return _render_difference("pack_id", expected.pack_id, got.pack_id)
+    for index, (expected_question, got_question) in enumerate(zip(expected.questions, got.questions)):
+        for name in ("question_id", "kind", "prompt", "source_refs"):
+            expected_value = getattr(expected_question, name)
+            got_value = getattr(got_question, name)
+            if expected_value == got_value:
+                continue
+            if isinstance(expected_value, tuple):
+                expected_value = list(expected_value)
+            if isinstance(got_value, tuple):
+                got_value = list(got_value)
+            return _render_difference(f"questions[{index}].{name}", expected_value, got_value)
+    expected_rows = len(expected.questions)
+    got_rows = len(got.questions)
+    if got_rows < expected_rows:
+        return _render_absent(
+            f"questions[{got_rows}].question_id", expected.questions[got_rows].question_id
+        )
+    if got_rows > expected_rows:
+        return _render_unexpected(
+            f"questions[{expected_rows}].question_id", got.questions[expected_rows].question_id
+        )
+    return ""
+
+
 def validate_question_pack(payload: object, *, report: CompletenessReport) -> QuestionPack:
     if not isinstance(payload, dict):
-        raise ValueError("question pack must be an object")
+        raise ValueError(
+            "question pack must be an object: "
+            + _render_difference("type", "dict", type(payload).__name__)
+        )
     extras = set(payload) - {"schema_version", "pack_id", "questions"}
     if extras:
-        raise ValueError(f"question pack unexpected key: {sorted(extras)[0]}")
+        raise ValueError(f"question pack unexpected key: {sorted(extras)[0]} (all={sorted(extras)})")
     if payload.get("schema_version") != QUESTION_PACK_SCHEMA_VERSION:
-        raise ValueError("question pack schema_version invalid")
+        # #701：修法前這句不說「實際收到什麼」——缺欄位、型別不對、版本號不同
+        # 三種失敗看起來一模一樣。
+        raise ValueError(
+            "question pack schema_version invalid: "
+            + _render_difference(
+                "schema_version",
+                QUESTION_PACK_SCHEMA_VERSION,
+                payload.get("schema_version", DIAGNOSTIC_ABSENT_PLACEHOLDER),
+            )
+        )
     pack_id = payload.get("pack_id")
     rows = payload.get("questions")
-    if not isinstance(pack_id, str) or not pack_id or not isinstance(rows, list):
-        raise ValueError("question pack identity/questions invalid")
+    if not isinstance(pack_id, str) or not pack_id:
+        # #701：`identity/questions invalid` 一句話塌縮了三種失敗（pack_id 不是
+        # 字串／pack_id 是空字串／questions 不是 list）。拆成兩句、各自帶值。
+        raise ValueError(
+            "question pack pack_id invalid: "
+            + _render_difference("pack_id", "<non-empty str>", payload.get("pack_id", DIAGNOSTIC_ABSENT_PLACEHOLDER))
+        )
+    if not isinstance(rows, list):
+        raise ValueError(
+            "question pack questions invalid: "
+            + _render_difference("questions type", "list", type(rows).__name__)
+        )
     questions: list[PlanningQuestion] = []
     seen: set[str] = set()
     for index, row in enumerate(rows):
         if not isinstance(row, dict):
-            raise ValueError(f"questions[{index}] must be an object")
+            raise ValueError(
+                f"questions[{index}] must be an object: "
+                + _render_difference("type", "dict", type(row).__name__)
+            )
         extras = set(row) - {"question_id", "kind", "prompt", "source_refs"}
         if extras:
-            raise ValueError(f"questions[{index}] unexpected key: {sorted(extras)[0]}")
+            raise ValueError(
+                f"questions[{index}] unexpected key: {sorted(extras)[0]} (all={sorted(extras)})"
+            )
         question_id = row.get("question_id")
         kind = row.get("kind")
         prompt = row.get("prompt")
-        if not all(isinstance(value, str) and value.strip() for value in (question_id, kind, prompt)):
-            raise ValueError(f"questions[{index}] has invalid scalar")
+        for name, value in (("question_id", question_id), ("kind", kind), ("prompt", prompt)):
+            # #701：`has invalid scalar` 把三個欄位 × 兩種缺陷（非字串／空白）
+            # 共六種失敗塌縮成一句，連是哪一欄都不說。
+            if not isinstance(value, str):
+                raise ValueError(
+                    f"questions[{index}].{name} must be a string: "
+                    + _render_difference(
+                        "type", "str", DIAGNOSTIC_ABSENT_PLACEHOLDER if name not in row else type(value).__name__
+                    )
+                )
+            if not value.strip():
+                raise ValueError(f"questions[{index}].{name} must not be blank")
         if question_id in seen:
             raise ValueError(f"duplicate question_id: {question_id}")
         seen.add(question_id)
@@ -795,7 +1127,18 @@ def validate_question_pack(payload: object, *, report: CompletenessReport) -> Qu
         )
     normalized = QuestionPack(pack_id=pack_id, questions=tuple(questions))
     if normalized.to_dict() != report.default_question_pack.to_dict():
-        raise ValueError("question pack does not cover exact completeness blockers")
+        # #701：判準逐位元不變（仍是整份 `to_dict()` 相等），但失敗不再塌縮成
+        # 一句話——列數 ＋ 第一個差異的欄位與兩邊的值一起進 reason／evidence。
+        expected_pack = report.default_question_pack
+        difference = (
+            describe_question_pack_difference(normalized, expected_pack)
+            or "<no field-level difference found>"
+        )
+        raise ValueError(
+            f"{QUESTION_PACK_MISMATCH_MESSAGE}: "
+            f"rows expected={len(expected_pack.questions)} got={len(normalized.questions)}; "
+            f"first diff at {difference}"
+        )
     return normalized
 
 
@@ -829,27 +1172,69 @@ class SecondaryEvidence:
 
 def validate_secondary_evidence(payload: object, *, question_pack: QuestionPack) -> SecondaryEvidence:
     if not isinstance(payload, dict):
-        raise ValueError("secondary evidence must be an object")
+        raise ValueError(
+            "secondary evidence must be an object: "
+            + _render_difference("type", "dict", type(payload).__name__)
+        )
     extras = set(payload) - {"schema_version", "question_pack_id", "evidence"}
     if extras:
-        raise ValueError(f"secondary evidence unexpected key: {sorted(extras)[0]}")
-    if payload.get("schema_version") != 1 or payload.get("question_pack_id") != question_pack.pack_id:
-        raise ValueError("secondary evidence identity invalid")
+        raise ValueError(
+            f"secondary evidence unexpected key: {sorted(extras)[0]} (all={sorted(extras)})"
+        )
+    # #701：`identity invalid` 一句話塌縮了兩件毫無關係的事——schema 版本不對
+    # （契約漂移）與 pack_id 抄錯（模型沒 echo-back）。處置完全不同，訊息卻
+    # 一模一樣。
+    if payload.get("schema_version") != 1:
+        raise ValueError(
+            "secondary evidence schema_version invalid: "
+            + _render_difference(
+                "schema_version", 1, payload.get("schema_version", DIAGNOSTIC_ABSENT_PLACEHOLDER)
+            )
+        )
+    if payload.get("question_pack_id") != question_pack.pack_id:
+        raise ValueError(
+            "secondary evidence question_pack_id mismatch: "
+            + _render_difference(
+                "question_pack_id",
+                question_pack.pack_id,
+                payload.get("question_pack_id", DIAGNOSTIC_ABSENT_PLACEHOLDER),
+            )
+        )
     rows = payload.get("evidence")
     if not isinstance(rows, list):
-        raise ValueError("secondary evidence must be a list")
+        raise ValueError(
+            "secondary evidence must be a list: "
+            + _render_difference("evidence type", "list", type(rows).__name__)
+        )
     expected = {question.question_id for question in question_pack.questions}
     seen: set[str] = set()
     items: list[SecondaryEvidenceItem] = []
     for index, row in enumerate(rows):
         if not isinstance(row, dict):
-            raise ValueError(f"evidence[{index}] must be an object")
+            raise ValueError(
+                f"evidence[{index}] must be an object: "
+                + _render_difference("type", "dict", type(row).__name__)
+            )
         extras = set(row) - {"question_id", "claims", "source_refs"}
         if extras:
-            raise ValueError(f"evidence[{index}] unexpected key: {sorted(extras)[0]}")
+            raise ValueError(
+                f"evidence[{index}] unexpected key: {sorted(extras)[0]} (all={sorted(extras)})"
+            )
         question_id = row.get("question_id")
-        if not isinstance(question_id, str) or question_id not in expected or question_id in seen:
-            raise ValueError(f"evidence[{index}].question_id invalid")
+        # #701：三種失敗（不是字串／不在 pack 裡／同一題答兩次）塌縮成同一句。
+        if not isinstance(question_id, str):
+            raise ValueError(
+                f"evidence[{index}].question_id must be a string: "
+                + _render_difference("type", "str", type(question_id).__name__)
+            )
+        if question_id not in expected:
+            raise ValueError(
+                f"evidence[{index}].question_id is not in the question pack: "
+                f"got={_windowed_value(_display_form(question_id))} "
+                f"unanswered={_windowed_value(_display_form(sorted(expected - seen)))}"
+            )
+        if question_id in seen:
+            raise ValueError(f"evidence[{index}].question_id answered twice: {question_id}")
         seen.add(question_id)
         items.append(
             SecondaryEvidenceItem(
@@ -859,7 +1244,15 @@ def validate_secondary_evidence(payload: object, *, question_pack: QuestionPack)
             )
         )
     if seen != expected:
-        raise ValueError("secondary evidence does not cover every question")
+        # #701：修法前只說「沒有覆蓋每一題」，**沒說少了哪幾題**——而少一題與
+        # 少五題、少的是哪一題，排查方向完全不同。多出來的題在上面就被擋掉，
+        # 因此走到這裡的一定是「少」。
+        missing = sorted(expected - seen)
+        raise ValueError(
+            "secondary evidence does not cover every question: "
+            f"answered={len(seen)}/{len(expected)} "
+            f"missing={_windowed_value(_display_form(missing))}"
+        )
     return SecondaryEvidence(question_pack.pack_id, tuple(items))
 
 
@@ -870,7 +1263,10 @@ def _validate_primary_integration(
     secondary_evidence_hash: str,
 ) -> dict[str, object]:
     if not isinstance(payload, dict):
-        raise ValueError("primary integration must be an object")
+        raise ValueError(
+            "primary integration must be an object: "
+            + _render_difference("type", "dict", type(payload).__name__)
+        )
     extras = set(payload) - {
         "schema_version",
         "question_pack_id",
@@ -879,39 +1275,98 @@ def _validate_primary_integration(
         "artifacts",
     }
     if extras:
-        raise ValueError(f"primary integration unexpected key: {sorted(extras)[0]}")
+        raise ValueError(
+            f"primary integration unexpected key: {sorted(extras)[0]} (all={sorted(extras)})"
+        )
     if payload.get("schema_version") != 1:
-        raise ValueError("primary integration schema invalid")
+        raise ValueError(
+            "primary integration schema invalid: "
+            + _render_difference(
+                "schema_version", 1, payload.get("schema_version", DIAGNOSTIC_ABSENT_PLACEHOLDER)
+            )
+        )
+    # #516 的兩個 echo-back 欄位：值都已在模型輸入裡，模型只需原樣複製。#701：
+    # 「抄錯了」與「抄成什麼」是兩件事，修法前只說得出前者——而這正是 #516
+    # 反覆撞牆時最需要的一格（模型是把 hash 自己算了？抄了 pack_id？還是留空？）。
     if payload.get("question_pack_id") != question_pack.pack_id:
-        raise ValueError("primary integration pack mismatch")
+        raise ValueError(
+            "primary integration pack mismatch: "
+            + _render_difference(
+                "question_pack_id",
+                question_pack.pack_id,
+                payload.get("question_pack_id", DIAGNOSTIC_ABSENT_PLACEHOLDER),
+            )
+        )
     if payload.get("secondary_evidence_hash") != secondary_evidence_hash:
-        raise ValueError("primary integration evidence hash mismatch")
+        raise ValueError(
+            "primary integration evidence hash mismatch: "
+            + _render_difference(
+                "secondary_evidence_hash",
+                secondary_evidence_hash,
+                payload.get("secondary_evidence_hash", DIAGNOSTIC_ABSENT_PLACEHOLDER),
+            )
+        )
     rows = payload.get("resolutions")
     if not isinstance(rows, list):
-        raise ValueError("primary integration resolutions must be a list")
+        raise ValueError(
+            "primary integration resolutions must be a list: "
+            + _render_difference("resolutions type", "list", type(rows).__name__)
+        )
     expected = {question.question_id for question in question_pack.questions}
     seen: set[str] = set()
     normalized: list[dict[str, object]] = []
+    required_resolution_keys = {"question_id", "decision", "artifact_kind", "artifact_refs"}
     for index, row in enumerate(rows):
-        if not isinstance(row, dict) or set(row) != {
-            "question_id",
-            "decision",
-            "artifact_kind",
-            "artifact_refs",
-        }:
-            raise ValueError(f"resolutions[{index}] invalid keys")
+        # #701：`invalid keys` 塌縮了「根本不是 object」「少了哪幾個鍵」「多了
+        # 哪幾個鍵」三種失敗，而且一個鍵名都不說。
+        if not isinstance(row, dict):
+            raise ValueError(
+                f"resolutions[{index}] must be an object: "
+                + _render_difference("type", "dict", type(row).__name__)
+            )
+        if set(row) != required_resolution_keys:
+            raise ValueError(
+                f"resolutions[{index}] invalid keys: "
+                f"missing={sorted(required_resolution_keys - set(row))} "
+                f"unexpected={sorted(set(row) - required_resolution_keys)}"
+            )
         question_id = row.get("question_id")
         decision = row.get("decision")
-        if not isinstance(question_id, str) or question_id not in expected or question_id in seen:
-            raise ValueError(f"resolutions[{index}].question_id invalid")
+        # #701：三種失敗（不是字串／不在 pack 裡／同一題解兩次）塌縮成同一句。
+        if not isinstance(question_id, str):
+            raise ValueError(
+                f"resolutions[{index}].question_id must be a string: "
+                + _render_difference("type", "str", type(question_id).__name__)
+            )
+        if question_id not in expected:
+            raise ValueError(
+                f"resolutions[{index}].question_id is not in the question pack: "
+                f"got={_windowed_value(_display_form(question_id))} "
+                f"unresolved={_windowed_value(_display_form(sorted(expected - seen)))}"
+            )
+        if question_id in seen:
+            raise ValueError(f"resolutions[{index}].question_id resolved twice: {question_id}")
         if not isinstance(decision, str) or not decision.strip():
-            raise ValueError(f"resolutions[{index}].decision invalid")
+            raise ValueError(
+                f"resolutions[{index}].decision invalid: "
+                + _render_difference("decision", "<non-blank str>", decision)
+            )
         artifact_kind = row.get("artifact_kind")
         if artifact_kind not in PLANNING_KINDS:
-            raise ValueError(f"resolutions[{index}].artifact_kind invalid")
+            raise ValueError(
+                f"resolutions[{index}].artifact_kind invalid: "
+                + _render_difference("artifact_kind", list(PLANNING_KINDS), artifact_kind)
+            )
         question = next(item for item in question_pack.questions if item.question_id == question_id)
         if question.kind.startswith("missing-") and artifact_kind != question.kind.removeprefix("missing-"):
-            raise ValueError(f"resolutions[{index}].artifact_kind mismatch")
+            raise ValueError(
+                f"resolutions[{index}].artifact_kind mismatch: "
+                + _render_difference(
+                    f"artifact_kind for question kind={question.kind}",
+                    question.kind.removeprefix("missing-"),
+                    artifact_kind,
+                )
+            )
         seen.add(question_id)
         normalized.append(
             {
@@ -924,25 +1379,66 @@ def _validate_primary_integration(
             }
         )
     if seen != expected:
-        raise ValueError("primary integration does not resolve every question")
+        # #701：同 `validate_secondary_evidence`——少了哪幾題才是可行動的資訊。
+        missing = sorted(expected - seen)
+        raise ValueError(
+            "primary integration does not resolve every question: "
+            f"resolved={len(seen)}/{len(expected)} "
+            f"missing={_windowed_value(_display_form(missing))}"
+        )
     artifacts_raw = payload.get("artifacts", [])
     if not isinstance(artifacts_raw, list):
-        raise ValueError("primary integration artifacts must be a list")
+        raise ValueError(
+            "primary integration artifacts must be a list: "
+            + _render_difference("artifacts type", "list", type(artifacts_raw).__name__)
+        )
+    required_artifact_keys = {"kind", "path", "content"}
     artifacts: list[dict[str, str]] = []
     for index, row in enumerate(artifacts_raw):
-        if not isinstance(row, dict) or set(row) != {"kind", "path", "content"}:
-            raise ValueError(f"artifacts[{index}] invalid keys")
+        if not isinstance(row, dict):
+            raise ValueError(
+                f"artifacts[{index}] must be an object: "
+                + _render_difference("type", "dict", type(row).__name__)
+            )
+        if set(row) != required_artifact_keys:
+            raise ValueError(
+                f"artifacts[{index}] invalid keys: "
+                f"missing={sorted(required_artifact_keys - set(row))} "
+                f"unexpected={sorted(set(row) - required_artifact_keys)}"
+            )
         kind = row.get("kind")
         path = row.get("path")
         content = row.get("content")
-        if kind not in PLANNING_KINDS or not isinstance(path, str) or not path or not isinstance(content, str):
-            raise ValueError(f"artifacts[{index}] invalid")
+        # #701：修法前這四種失敗（kind 非法／path 非字串／path 空字串／content
+        # 非字串）共用同一句 `artifacts[i] invalid`。
+        if kind not in PLANNING_KINDS:
+            raise ValueError(
+                f"artifacts[{index}].kind invalid: "
+                + _render_difference("kind", list(PLANNING_KINDS), kind)
+            )
+        if not isinstance(path, str) or not path:
+            raise ValueError(
+                f"artifacts[{index}].path invalid: "
+                + _render_difference("path", "<non-empty str>", path)
+            )
+        if not isinstance(content, str):
+            raise ValueError(
+                f"artifacts[{index}].content must be a string: "
+                + _render_difference("type", "str", type(content).__name__)
+            )
         artifacts.append({"kind": str(kind), "path": path, "content": content})
     referenced = {
         ref for resolution in normalized for ref in resolution["artifact_refs"]
     }
-    if artifacts and {item["path"] for item in artifacts} != referenced:
-        raise ValueError("primary integration artifact content/ref mismatch")
+    written = {item["path"] for item in artifacts}
+    if artifacts and written != referenced:
+        # #701：這是 #406 反覆撞的那一條。修法前只說「對不上」，不說是「寫了
+        # 沒人引用」還是「引用了沒寫」——兩者的 prompt 修法完全相反。
+        raise ValueError(
+            "primary integration artifact content/ref mismatch: "
+            f"written_not_referenced={_windowed_value(_display_form(sorted(written - referenced)))} "
+            f"referenced_not_written={_windowed_value(_display_form(sorted(referenced - written)))}"
+        )
     return {
         "schema_version": 1,
         "question_pack_id": question_pack.pack_id,
@@ -1197,6 +1693,20 @@ def _artifact_assessment_failure(
     """
 
     details = [f"reasons={','.join(assessment.reasons)}"]
+    if "required-section-missing" in assessment.reasons:
+        # #701：這是 #520 的同型缺口——`required-section-missing` 五個字塌縮了
+        # 「一個標題都沒有」與「寫了標題但字面不在可接受集合」（#520 實機是
+        # `## Requirements for spec`）。修法前 planner 到底寫了什麼標題沒有任何
+        # 地方留下，而那正是唯一能分辨兩者的資訊。判準不動，只把兩邊印出來。
+        _, body, offset = _frontmatter_and_body(assessment.artifact.text)
+        found, _ = _headings_and_markers(body, line_offset=offset)
+        accepted = _ACCEPTED_HEADINGS.get(assessment.artifact.kind, ())
+        details.append(
+            "headings accepted="
+            + _windowed_value(_display_form(list(accepted)))
+            + " found="
+            + _windowed_value(_display_form(sorted(found)))
+        )
     markers = assessment.blocking_markers
     if markers:
         rendered = [
@@ -1243,7 +1753,10 @@ class PlanningGateRefs:
             if value is not None:
                 refs.append(value.ref)
         if len(refs) != len(set(refs)):
-            raise ValueError("planning gate refs must be distinct")
+            duplicates = sorted({ref for ref in refs if refs.count(ref) > 1})
+            raise ValueError(
+                f"planning gate refs must be distinct: duplicates={duplicates}"
+            )
 
     def as_tuple(self) -> tuple[GateEvidenceRef, ...]:
         return tuple(
@@ -1377,12 +1890,16 @@ def run_heterogeneous_brainstorm(
         # 內容是什麼——排障要另外重跑加 print 才查得到（曾經雙重誤導：真正
         # 原因是 planning launcher 把 operator worktree 判成被汙染而
         # ValueError，卻只顯示成籠統的「question-pack-malformed」）。這裡併入
-        # 例外型別與訊息前 160 字，供 #393 的 planning-failure evidence 與
+        # 例外型別與訊息，供 #393 的 planning-failure evidence 與
         # recover-planning 的 `_read_planning_failure_record` 直接讀出；兩者
         # 都只要求 reason 為非空字串，加長不影響既有契約。
+        #
+        # #701：摘要改走 `summarize_planning_exception()`——預算由 160 放寬到
+        # `PLANNING_FAILURE_DETAIL_LIMIT`（逐欄差異裝不進 160），截斷改為就地
+        # 記帳。四處共用同一支，避免第五種格式。
         return BrainstormResult(
             "needs_human",
-            f"question-pack-malformed: {type(exc).__name__}: {str(exc)[:160]}",
+            f"question-pack-malformed: {summarize_planning_exception(exc)}",
             None,
             empty_refs,
             None,
@@ -1395,7 +1912,7 @@ def run_heterogeneous_brainstorm(
     except Exception as exc:
         return BrainstormResult(
             "needs_human",
-            f"secondary-output-malformed: {type(exc).__name__}: {str(exc)[:160]}",
+            f"secondary-output-malformed: {summarize_planning_exception(exc)}",
             selection.identity.independence_domain,
             empty_refs,
             None,
@@ -1412,7 +1929,7 @@ def run_heterogeneous_brainstorm(
     except Exception as exc:
         return BrainstormResult(
             "needs_human",
-            f"primary-integration-malformed: {type(exc).__name__}: {str(exc)[:160]}",
+            f"primary-integration-malformed: {summarize_planning_exception(exc)}",
             selection.identity.independence_domain,
             empty_refs,
             None,
@@ -1421,7 +1938,16 @@ def run_heterogeneous_brainstorm(
     if artifact_writer is not None:
         try:
             if not integration.get("artifacts"):
-                raise ValueError("structured artifact content missing")
+                # #701：「鍵不存在」與「鍵在但是空 list」是兩種不同的模型行為
+                # （前者沒照 prompt 給欄位、後者給了卻沒內容），修法前同一句話。
+                raise ValueError(
+                    "structured artifact content missing: "
+                    + _render_difference(
+                        "artifacts",
+                        "<non-empty list>",
+                        integration.get("artifacts", DIAGNOSTIC_ABSENT_PLACEHOLDER),
+                    )
+                )
             rollback_publication = artifact_writer(integration.get("artifacts", []))
         except Exception as exc:
             # #408：這是 #397 儀器化時漏掉的第四個裸吞分支——artifact write 的
@@ -1429,7 +1955,7 @@ def run_heterogeneous_brainstorm(
             # 分支的例外摘要格式一致。
             return BrainstormResult(
                 "needs_human",
-                f"primary-artifact-write-rejected: {type(exc).__name__}: {str(exc)[:160]}",
+                f"primary-artifact-write-rejected: {summarize_planning_exception(exc)}",
                 selection.identity.independence_domain,
                 empty_refs,
                 None,

--- a/paulsha_cortex/coordinator/planning_runtime.py
+++ b/paulsha_cortex/coordinator/planning_runtime.py
@@ -26,6 +26,7 @@ from .model_identities import (
     ModelIdentity,
     load_model_identities,
     probe_agy_capability,
+    stdout_excerpt,
 )
 from .planning import required_heading_hint
 
@@ -803,12 +804,22 @@ def _extract_json_candidates(stdout: str, output_text: str | None) -> object:
                 if extracted is not None:
                     return extracted
                 if fallback_snippet is None:
-                    fallback_snippet = nested[:160]
+                    # 裁切交給下面的 `stdout_excerpt()`——由它統一單行化並在
+                    # 截斷處留 `…`，這裡先留全文（#701）。
+                    fallback_snippet = nested
             # 全部抽取失敗：絕不能 fall through 把整個 envelope dict 當成
             # 輸出本體回傳（修復前的行為）——那會讓下游驗證（例如
             # `validate_question_pack`）報出 `unexpected key: api_error_status`
             # 這種完全誤導的診斷。改為明確 raise，訊息帶散文片段方便除錯。
-            detail = fallback_snippet if fallback_snippet is not None else "<no string field>"
+            # #701：片段改走 `stdout_excerpt()`（#674 的既有函式）而非裸切
+            # ——模型的散文常含換行，裸切會把多行內容帶進單行 log／reason。
+            # 長度上限維持 160，`test_no_json_error_snippet_is_truncated` 的
+            # 「片段本身有界」不變。
+            detail = (
+                stdout_excerpt(fallback_snippet, limit=160)
+                if fallback_snippet is not None
+                else "<no string field>"
+            )
             raise ValueError(f"planning launcher result is not JSON: {detail}")
         return value
     # 2026-08-14 實測：agy 服務暫時性 503 時**印錯誤文字但 exit 0**
@@ -817,8 +828,13 @@ def _extract_json_candidates(stdout: str, output_text: str | None) -> object:
     # 被丟棄——operator 只看得到「no JSON object」，診斷得靠手動重現。帶上
     # 截斷片段後：(1) 503 當場可見；(2) 上游 `_is_planning_transient_service_failure`
     # 能據此把分類從 `content` 改判 `environment`，recover-planning 才有路。
+    #
+    # #701：片段同樣改走 `stdout_excerpt()`（單行化 ＋ 截斷處留 `…`）。`<empty
+    # output>` 這個哨兵**刻意保留**、不換成 `stdout_excerpt` 的 `<empty>`
+    # ——`test_no_json_error_with_empty_output_says_so` 以它為斷言對象，而且
+    # 「候選全空」與「候選只有空白」在這裡本來就是同一件事。
     snippet = next(
-        (candidate[:160] for candidate in candidates if candidate),
+        (stdout_excerpt(candidate, limit=160) for candidate in candidates if candidate),
         "<empty output>",
     )
     raise ValueError(f"planning launcher returned no JSON object: {snippet}")
@@ -1150,8 +1166,17 @@ def _invoke_json(
         )
     )
     if outcome.returncode != 0 or not isinstance(outcome.stdout, str):
+        # issue #701：修法前這句只有 executor/model 兩個常數——rc 是幾、模型／
+        # CLI 到底印了什麼，全部隨 invoker 的 tempdir 一起消失。questioner／
+        # secondary／integrator 三個 adapter 走的都是本函式，因此 #670／PR #674
+        # 為 probe 建立的 `stdout_excerpt()` 那條路，在這裡等於一次補齊三個。
+        #
+        # **只取 stdout，不取 stderr**——這是票 A（PR #688）已寫下、本票沿用的
+        # 邊界：stderr 是最容易夾帶路徑、env 與憑證錯誤原文的通道。
         raise ValueError(
-            f"planning launcher failed: {identity.executor}/{identity.model_id}"
+            f"planning launcher failed: {identity.executor}/{identity.model_id} "
+            f"rc={outcome.returncode} stdout="
+            + (stdout_excerpt(outcome.stdout) if isinstance(outcome.stdout, str) else "<no stdout>")
         )
     return _extract_json_candidates(outcome.stdout, outcome.output_text)
 

--- a/tests/test_planning_diagnostics_701.py
+++ b/tests/test_planning_diagnostics_701.py
@@ -1,0 +1,741 @@
+"""issue #701：planning 驗證失敗的逐欄診斷，以及模型輸出的保存。
+
+三組性質：
+
+1. **反塌縮**——同一個驗證器的 N 種失敗必須產生 N 種**互不相同**的訊息，而且
+   每一種都指得出「哪一個索引、哪一個欄位、expected 與 got 各是什麼」。修法前
+   `validate_question_pack()` 的六種以上失敗共用同一句
+   `question pack does not cover exact completeness blockers`。
+2. **截斷可判讀**——locator 永不被截斷，值的視窗對齊到第一個相異字元，被犧牲
+   多少就地記帳（票 A／PR #688 的截斷哲學）。
+3. **防偽**——差異文字帶的是模型輸出，它進的是 `blocking_reason`，而
+   `manager._classify_planning_failure` 有三條**不錨定**的文字判準。模型不得
+   靠在某個 `prompt` 裡寫 `503`／`timeout` 把 content 失敗偽裝成 environment，
+   也不得破壞票 A 錨在字串開頭的 `grade=` 設計。
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from paulsha_cortex.coordinator import manager, outcome_taxonomy, planning, planning_runtime
+from paulsha_cortex.coordinator.model_identities import (
+    CapabilityProbe,
+    IdentityRegistry,
+    ModelIdentity,
+    is_environment_grade_rejection_reason,
+    stdout_excerpt,
+)
+from paulsha_cortex.coordinator.outcome_taxonomy import matches_transient_service_markers
+from paulsha_cortex.coordinator.planning import (
+    CLASSIFICATION_MARKER_PLACEHOLDER,
+    DIAGNOSTIC_ABSENT_PLACEHOLDER,
+    PLANNING_FAILURE_DETAIL_LIMIT,
+    QUESTION_PACK_MISMATCH_MESSAGE,
+    PlanningArtifact,
+    PlanningScope,
+    QuestionPack,
+    _guard_classification_markers,
+    _render_difference,
+    _strict_string_list,
+    _validate_primary_integration,
+    assess_planning_completeness,
+    describe_question_pack_difference,
+    run_heterogeneous_brainstorm,
+    summarize_planning_exception,
+    validate_question_pack,
+    validate_secondary_evidence,
+)
+
+#: 刻意用 **未驗收** 的 spec：`assess_planning_completeness` 於是產出三題
+#: （missing-spec／design／plan），而第一題的 `source_refs` 非空——這正是 #701
+#: 現場「忠實重建」那一組輸入的形狀，也讓 `source_refs` 差異測得到。
+DRAFT_SPEC = """\
+---
+status: draft
+---
+# Feature specification
+
+## Requirements
+
+The behavior is still being decided.
+"""
+
+SCOPE = PlanningScope(
+    repo="hamanpaul/paulsha-cortex",
+    work_id="unified-work-lifecycle",
+    source_revision="tree:0123456789abcdef",
+)
+
+
+def _report() -> planning.CompletenessReport:
+    return assess_planning_completeness(
+        [PlanningArtifact(kind="spec", ref="docs/spec.md", text=DRAFT_SPEC)]
+    )
+
+
+def _mismatch_message(mutate) -> str:
+    """套用一個變異到 default pack，回傳 `validate_question_pack` 的錯誤訊息。"""
+
+    report = _report()
+    payload = report.default_question_pack.to_dict()
+    mutate(payload)
+    with pytest.raises(ValueError) as excinfo:
+        validate_question_pack(payload, report=report)
+    return str(excinfo.value)
+
+
+# ---------------------------------------------------------------------------
+# 1. 反塌縮：六種以上的失敗必須是六種以上的訊息
+# ---------------------------------------------------------------------------
+
+
+def _set_pack_id(payload: dict) -> None:
+    payload["pack_id"] = "qp-deadbeefdeadbeefdeadbeef"
+
+
+def _set_question_id(payload: dict) -> None:
+    payload["questions"][0]["question_id"] = "q-0000000000000000"
+
+
+def _set_kind(payload: dict) -> None:
+    payload["questions"][0]["kind"] = "missing-design"
+
+
+def _set_prompt(payload: dict) -> None:
+    payload["questions"][0]["prompt"] = payload["questions"][0]["prompt"].replace(
+        "spec?", "design?"
+    )
+
+
+def _set_source_refs(payload: dict) -> None:
+    payload["questions"][0]["source_refs"] = ["docs/somewhere-else.md"]
+
+
+def _reorder(payload: dict) -> None:
+    payload["questions"].reverse()
+
+
+def _drop_row(payload: dict) -> None:
+    payload["questions"].pop()
+
+
+def _add_row(payload: dict) -> None:
+    payload["questions"].append(dict(payload["questions"][0], question_id="q-extra"))
+
+
+_MUTATIONS = {
+    "pack_id": (_set_pack_id, "pack_id"),
+    "question_id": (_set_question_id, "questions[0].question_id"),
+    "kind": (_set_kind, "questions[0].kind"),
+    "prompt": (_set_prompt, "questions[0].prompt"),
+    "source_refs": (_set_source_refs, "questions[0].source_refs"),
+    "order": (_reorder, "questions[0].question_id"),
+    "row-dropped": (_drop_row, "questions[2].question_id"),
+    "row-added": (_add_row, "questions[3].question_id"),
+}
+
+
+@pytest.mark.parametrize("name", sorted(_MUTATIONS))
+def test_each_question_pack_mismatch_names_its_own_field(name: str) -> None:
+    """每一種變異都指得出 locator ＋ expected ＋ got。
+
+    修法前這八種變異全部是同一句 `question pack does not cover exact
+    completeness blockers`，落檔 evidence 只有那句話——#701 的現場正是這樣連
+    「差在哪一欄」都問不出來。
+    """
+
+    mutate, locator = _MUTATIONS[name]
+    message = _mismatch_message(mutate)
+    assert message.startswith(QUESTION_PACK_MISMATCH_MESSAGE + ":")
+    assert f"first diff at {locator} " in message
+    assert "expected=" in message and "got=" in message
+
+
+def test_the_eight_mismatch_messages_are_pairwise_distinct() -> None:
+    """反塌縮的本體斷言：八種失敗 ⇒ 八個互不相同的字串。"""
+
+    messages = {name: _mismatch_message(mutate) for name, (mutate, _) in _MUTATIONS.items()}
+    assert len(set(messages.values())) == len(messages), messages
+
+
+def test_mismatch_message_still_reports_row_counts() -> None:
+    """票 A 的規矩：「有幾條」永遠答得出來，不因為報了逐欄差異就被犧牲。"""
+
+    assert "rows expected=3 got=2;" in _mismatch_message(_drop_row)
+    assert "rows expected=3 got=4;" in _mismatch_message(_add_row)
+
+
+def test_mismatch_message_keeps_the_original_sentence_as_a_grep_anchor() -> None:
+    """原句逐字保留在最前面——既有 log、issue #701 與 operator 的 grep 以它為錨。"""
+
+    message = _mismatch_message(_set_kind)
+    assert message.startswith(QUESTION_PACK_MISMATCH_MESSAGE)
+
+
+def test_missing_and_extra_rows_render_absent_on_the_right_side() -> None:
+    assert f"got={DIAGNOSTIC_ABSENT_PLACEHOLDER}" in _mismatch_message(_drop_row)
+    assert f"expected={DIAGNOSTIC_ABSENT_PLACEHOLDER}" in _mismatch_message(_add_row)
+
+
+def test_identical_packs_report_no_difference() -> None:
+    report = _report()
+    assert describe_question_pack_difference(
+        report.default_question_pack, report.default_question_pack
+    ) == ""
+
+
+def test_scalar_failures_inside_a_question_are_not_collapsed() -> None:
+    """`questions[i] has invalid scalar` 過去把三欄 × 兩種缺陷共六種壓成一句。"""
+
+    report = _report()
+    messages = set()
+    for field in ("question_id", "kind", "prompt"):
+        for bad in (None, "   "):
+            payload = report.default_question_pack.to_dict()
+            payload["questions"][0][field] = bad
+            with pytest.raises(ValueError) as excinfo:
+                validate_question_pack(payload, report=report)
+            message = str(excinfo.value)
+            assert f"questions[0].{field}" in message
+            messages.add(message)
+    assert len(messages) == 6, messages
+
+
+def test_pack_id_and_questions_failures_are_separate_messages() -> None:
+    """`identity/questions invalid` 過去塌縮了三種毫無關係的失敗。"""
+
+    report = _report()
+    seen = set()
+    for mutate in (
+        lambda payload: payload.update(pack_id=None),
+        lambda payload: payload.update(pack_id=""),
+        lambda payload: payload.update(questions={"not": "a list"}),
+    ):
+        payload = report.default_question_pack.to_dict()
+        mutate(payload)
+        with pytest.raises(ValueError) as excinfo:
+            validate_question_pack(payload, report=report)
+        seen.add(str(excinfo.value))
+    assert len(seen) == 3, seen
+
+
+def test_schema_version_failure_reports_what_arrived() -> None:
+    report = _report()
+    payload = report.default_question_pack.to_dict()
+    payload.pop("schema_version")
+    with pytest.raises(ValueError) as excinfo:
+        validate_question_pack(payload, report=report)
+    assert DIAGNOSTIC_ABSENT_PLACEHOLDER in str(excinfo.value)
+
+
+def test_strict_string_list_says_which_item_is_wrong() -> None:
+    """三種失敗（不是 list／某項不是字串／某項空白）過去共用同一句。"""
+
+    messages = []
+    for value in ("nope", ["ok", 7], ["ok", "  "]):
+        with pytest.raises(ValueError) as excinfo:
+            _strict_string_list(value, "evidence[0].claims")
+        messages.append(str(excinfo.value))
+    assert len(set(messages)) == 3, messages
+    assert "evidence[0].claims[1]" in messages[1]
+    assert "evidence[0].claims[1]" in messages[2]
+
+
+# ---------------------------------------------------------------------------
+# 1b. 同型塌縮的另外兩處：secondary evidence 與 primary integration
+# ---------------------------------------------------------------------------
+
+
+def _pack() -> QuestionPack:
+    report = _report()
+    return report.default_question_pack
+
+
+def test_secondary_identity_failures_are_split_into_two_messages() -> None:
+    """`secondary evidence identity invalid` 塌縮了 schema 漂移與 pack_id 抄錯。"""
+
+    pack = _pack()
+    base = {"schema_version": 1, "question_pack_id": pack.pack_id, "evidence": []}
+    with pytest.raises(ValueError) as schema_exc:
+        validate_secondary_evidence({**base, "schema_version": 2}, question_pack=pack)
+    with pytest.raises(ValueError) as pack_exc:
+        validate_secondary_evidence({**base, "question_pack_id": "qp-wrong"}, question_pack=pack)
+    assert "schema_version" in str(schema_exc.value)
+    assert str(schema_exc.value) != str(pack_exc.value)
+    assert pack.pack_id in str(pack_exc.value) and "qp-wrong" in str(pack_exc.value)
+
+
+def test_secondary_coverage_failure_lists_the_missing_questions() -> None:
+    """「沒有覆蓋每一題」過去不說少了哪幾題——而那正是唯一可行動的資訊。"""
+
+    pack = _pack()
+    payload = {
+        "schema_version": 1,
+        "question_pack_id": pack.pack_id,
+        "evidence": [
+            {
+                "question_id": pack.questions[0].question_id,
+                "claims": ["missing"],
+                "source_refs": ["docs/spec.md:1"],
+            }
+        ],
+    }
+    with pytest.raises(ValueError) as excinfo:
+        validate_secondary_evidence(payload, question_pack=pack)
+    message = str(excinfo.value)
+    assert "answered=1/3" in message
+    assert pack.questions[1].question_id in message
+    assert pack.questions[2].question_id in message
+
+
+def test_secondary_question_id_failures_are_three_messages() -> None:
+    pack = _pack()
+
+    def evidence(rows: list[dict]) -> dict:
+        return {"schema_version": 1, "question_pack_id": pack.pack_id, "evidence": rows}
+
+    row = {
+        "question_id": pack.questions[0].question_id,
+        "claims": ["missing"],
+        "source_refs": ["docs/spec.md:1"],
+    }
+    messages = set()
+    for rows in (
+        [{**row, "question_id": 7}],
+        [{**row, "question_id": "q-not-in-pack"}],
+        [row, dict(row)],
+    ):
+        with pytest.raises(ValueError) as excinfo:
+            validate_secondary_evidence(evidence(rows), question_pack=pack)
+        messages.add(str(excinfo.value))
+    assert len(messages) == 3, messages
+
+
+def _integration(pack: QuestionPack, **overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "schema_version": 1,
+        "question_pack_id": pack.pack_id,
+        "secondary_evidence_hash": "hash-abc",
+        "resolutions": [
+            {
+                "question_id": question.question_id,
+                "decision": "write it",
+                "artifact_kind": question.kind.removeprefix("missing-"),
+                "artifact_refs": [f"docs/{question.kind.removeprefix('missing-')}.md"],
+            }
+            for question in pack.questions
+        ],
+        "artifacts": [],
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_integration_echo_back_mismatches_report_both_sides() -> None:
+    """#516 的兩個 echo-back 欄位：修法前只說「對不上」，不說抄成了什麼。"""
+
+    pack = _pack()
+    with pytest.raises(ValueError) as pack_exc:
+        _validate_primary_integration(
+            _integration(pack, question_pack_id="qp-copied-wrong"),
+            question_pack=pack,
+            secondary_evidence_hash="hash-abc",
+        )
+    with pytest.raises(ValueError) as hash_exc:
+        _validate_primary_integration(
+            _integration(pack, secondary_evidence_hash="sha256:model-invented"),
+            question_pack=pack,
+            secondary_evidence_hash="hash-abc",
+        )
+    assert "qp-copied-wrong" in str(pack_exc.value) and pack.pack_id in str(pack_exc.value)
+    assert "sha256:model-invented" in str(hash_exc.value) and "hash-abc" in str(hash_exc.value)
+
+
+def test_integration_invalid_keys_names_missing_and_unexpected() -> None:
+    pack = _pack()
+    rows = _integration(pack)["resolutions"]
+    broken = [dict(rows[0]) for _ in range(1)]
+    broken[0].pop("decision")
+    broken[0]["rationale"] = "extra"
+    with pytest.raises(ValueError) as excinfo:
+        _validate_primary_integration(
+            _integration(pack, resolutions=broken),
+            question_pack=pack,
+            secondary_evidence_hash="hash-abc",
+        )
+    message = str(excinfo.value)
+    assert "missing=['decision']" in message
+    assert "unexpected=['rationale']" in message
+
+
+def test_integration_artifact_ref_mismatch_says_which_direction() -> None:
+    """「寫了沒人引用」與「引用了沒寫」的 prompt 修法完全相反，訊息必須分得開。"""
+
+    pack = _pack()
+    payload = _integration(
+        pack,
+        artifacts=[{"kind": "spec", "path": "docs/unreferenced.md", "content": "x"}],
+    )
+    with pytest.raises(ValueError) as excinfo:
+        _validate_primary_integration(
+            payload, question_pack=pack, secondary_evidence_hash="hash-abc"
+        )
+    message = str(excinfo.value)
+    assert "written_not_referenced=" in message and "docs/unreferenced.md" in message
+    assert "referenced_not_written=" in message and "docs/spec.md" in message
+
+
+def test_integration_artifact_row_failures_are_four_messages() -> None:
+    pack = _pack()
+    good = {"kind": "spec", "path": "docs/spec.md", "content": "x"}
+    messages = set()
+    for artifact in (
+        {**good, "kind": "novel"},
+        {**good, "path": 7},
+        {**good, "path": ""},
+        {**good, "content": None},
+    ):
+        with pytest.raises(ValueError) as excinfo:
+            _validate_primary_integration(
+                _integration(pack, artifacts=[artifact]),
+                question_pack=pack,
+                secondary_evidence_hash="hash-abc",
+            )
+        messages.add(str(excinfo.value))
+    assert len(messages) == 4, messages
+
+
+def test_required_section_missing_reports_found_and_accepted_headings() -> None:
+    """#520 的同型缺口：`required-section-missing` 塌縮了「沒寫標題」與「寫了
+    但字面不在可接受集合」——修法前 planner 到底寫了什麼標題不留在任何地方。"""
+
+    artifact = PlanningArtifact(
+        kind="spec",
+        ref="docs/spec.md",
+        text="---\nstatus: accepted\n---\n\n## Requirements for spec\n\nbody\n",
+    )
+    assessment = planning.assess_planning_artifact(artifact)
+    assert assessment.reasons == ("required-section-missing",)
+    rendered = planning._artifact_assessment_failure(assessment, None).rendered()
+    assert "reasons=required-section-missing" in rendered
+    assert "requirements for spec" in rendered  # planner 實際寫的
+    assert "Requirements" in rendered  # 可接受集合
+
+
+def test_plan_frontmatter_failures_report_what_arrived() -> None:
+    """plan frontmatter 的三處判定同樣把 3–4 種失敗塌縮成一句（#701 掃描所得）。"""
+
+    plan = PlanningArtifact(
+        kind="plan",
+        ref="docs/plan.md",
+        text="---\nstatus: accepted\ninvariant_count: -1\nartifact_classes: []\n---\n\n## Task 1\n\nx\n",
+    )
+    with pytest.raises(ValueError) as excinfo:
+        planning._plan_review_envelope(plan, None)
+    assert "invariant_count expected='<int >=0>' got='-1'" in str(excinfo.value)
+
+    bad_scope = PlanningArtifact(
+        kind="plan",
+        ref="docs/plan.md",
+        text="---\nstatus: accepted\nscope_excludes: 7\n---\n\n## Task 1\n\nx\n",
+    )
+    with pytest.raises(ValueError) as scope_exc:
+        planning._plan_review_contract_compatibility(bad_scope, frozenset())
+    assert "scope_excludes expected='<str list>' got='7'" in str(scope_exc.value)
+
+
+# ---------------------------------------------------------------------------
+# 2. 截斷策略：locator 永不被犧牲，值的視窗跟著差異點走
+# ---------------------------------------------------------------------------
+
+
+def test_long_values_window_onto_the_first_divergence() -> None:
+    """長 prompt 的前 72 個字往往兩邊一模一樣——直接取前綴等於印兩份相同的字。"""
+
+    shared = "A" * 200
+    rendered = _render_difference(
+        "questions[0].prompt", shared + "accepted spec", shared + "accepted design"
+    )
+    assert "questions[0].prompt" in rendered
+    assert "accepted spec" in rendered and "accepted design" in rendered
+
+
+def test_truncation_accounts_for_every_elided_character() -> None:
+    """被犧牲了幾個字寫在原處——「還有沒有下文」不得變成不可知（票 A 的規矩）。"""
+
+    rendered = _render_difference("pack_id", "x" * 300, "y" * 300)
+    assert "<+228c>" in rendered
+
+
+def test_locator_is_never_truncated_even_when_values_are_pathological() -> None:
+    rendered = _render_difference("questions[123].source_refs", "z" * 5000, "w" * 5000)
+    assert rendered.startswith("questions[123].source_refs expected=")
+    assert len(rendered) < 400
+
+
+def test_control_characters_never_reach_a_single_line_reason() -> None:
+    rendered = _render_difference("questions[0].prompt", "a", "line1\nline2\x1b[31m")
+    assert "\n" not in rendered and "\x1b" not in rendered
+
+
+def test_exception_summary_budget_fits_a_real_mismatch_message() -> None:
+    """#397 的 160 字預算裝不下逐欄差異——放寬後真實訊息必須完整存活。"""
+
+    message = _mismatch_message(_set_prompt)
+    summary = summarize_planning_exception(ValueError(message))
+    assert "…+" not in summary
+    assert message in summary
+
+
+def test_exception_summary_truncation_is_accounted() -> None:
+    summary = summarize_planning_exception(ValueError("x" * (PLANNING_FAILURE_DETAIL_LIMIT + 40)))
+    assert summary.startswith("ValueError: ")
+    assert summary.endswith("…+40c")
+
+
+# ---------------------------------------------------------------------------
+# 3. 防偽：模型輸出不得偽裝成分類標記（票 A／#682／PR #688 的設計約束）
+# ---------------------------------------------------------------------------
+
+
+def test_diff_text_cannot_forge_the_ticket_a_grade_anchor() -> None:
+    """票 A 的 `grade=` 是**錨在字串開頭**的欄位，不是 substring search。
+
+    本票的差異文字進的是 reason 尾段；就算模型逐字寫出一整張假拒因表，
+    `is_environment_grade_rejection_reason` 也不得成立。
+    """
+
+    forged = "no-heterogeneous-planner grade=environment candidates=9 (agy/x[google]: probe-absent)"
+    reason = "question-pack-malformed: " + summarize_planning_exception(
+        ValueError(_render_difference("questions[0].prompt", "spec", forged))
+    )
+    assert is_environment_grade_rejection_reason(reason) is False
+    assert manager._classify_planning_failure(reason) == "content"
+
+
+def test_the_grade_anchor_still_works_for_a_genuine_rejection_table() -> None:
+    """反向對照：真的拒因表照樣被認出來（本票沒有把票 A 的機制弄壞）。"""
+
+    genuine = "no-heterogeneous-planner grade=environment candidates=1 (agy/x[google]: probe-not-ready)"
+    assert is_environment_grade_rejection_reason(genuine) is True
+    assert manager._classify_planning_failure(genuine) == "environment"
+
+
+@pytest.mark.parametrize("marker", outcome_taxonomy.TRANSIENT_SERVICE_MARKERS)
+def test_no_taxonomy_marker_survives_the_guard(marker: str) -> None:
+    """全表掃描（比照 #554 的同型測試）：模型在 `prompt` 裡寫任何一個 marker
+    都不得把一個 content 失敗改判成 environment。"""
+
+    reason = "question-pack-malformed: " + summarize_planning_exception(
+        ValueError(_render_difference("questions[0].prompt", "spec", f"the {marker} happened"))
+    )
+    assert marker in reason or marker.casefold() in reason.casefold()
+    assert matches_transient_service_markers(reason) is False
+    assert manager._classify_planning_failure(reason) == "content"
+
+
+def test_guard_preserves_every_character_of_a_word_boundary_marker() -> None:
+    """遮罩只加兩個 `_` 破詞界，**字面一個字都不少**——可讀性不被犧牲。"""
+
+    assert _guard_classification_markers("waited 30s then timeout") == "waited 30s then _timeout_"
+
+
+def test_substring_classification_phrases_are_elided_not_merely_wrapped() -> None:
+    """#416／#507 兩條判準用的是裸 `in`，詞界破不了它們，只能整段換掉。"""
+
+    for phrase in planning._CLASSIFICATION_MARKER_PHRASES:
+        guarded = _guard_classification_markers(f"model said: {phrase} here")
+        assert phrase not in guarded
+        assert CLASSIFICATION_MARKER_PLACEHOLDER in guarded
+
+
+def test_copied_classification_phrases_stay_in_sync_with_their_owners() -> None:
+    """字面值是**複製**的（import 會成環），因此必須有一條測試釘住同步。
+
+    `manager`／`planning_runtime` 改了那邊、`planning` 沒跟上，這條當場紅。
+    """
+
+    owners = set(manager._PLANNING_AUTHORITY_RESIDUE_MARKERS) | {
+        planning_runtime.PLANNING_WORKTREE_DRIFT_MESSAGE_PREFIX
+    }
+    assert owners == set(planning._CLASSIFICATION_MARKER_PHRASES)
+
+
+@pytest.mark.parametrize(
+    "placeholder",
+    [
+        DIAGNOSTIC_ABSENT_PLACEHOLDER,
+        CLASSIFICATION_MARKER_PLACEHOLDER,
+        "<no field-level difference found>",
+    ],
+)
+def test_placeholders_contain_no_marker(placeholder: str) -> None:
+    """#554 的既有不變式：佔位符自己不得命中任何 marker（`<unavailable>` 之鑑）。"""
+
+    assert matches_transient_service_markers(placeholder) is False
+
+
+def test_a_real_mismatch_reason_is_classified_content() -> None:
+    """端到端：真實產生的差異訊息（不是自造字串）分類仍是 content。"""
+
+    reason = "question-pack-malformed: " + summarize_planning_exception(
+        ValueError(_mismatch_message(_set_prompt))
+    )
+    assert manager._classify_planning_failure(reason) == "content"
+
+
+# ---------------------------------------------------------------------------
+# 4. 模型輸出的保存：三個 adapter 共用的 `_invoke_json` 補上 stdout 節錄
+# ---------------------------------------------------------------------------
+
+
+_IDENTITY = ModelIdentity(
+    executor="claude",
+    model_id="claude-sonnet-4.6",
+    independence_domain="anthropic",
+    capabilities=("planning",),
+)
+
+
+class _FixedInvoker:
+    def __init__(self, outcome: planning_runtime.PlanningOutcome) -> None:
+        self._outcome = outcome
+
+    def run(self, invocation: planning_runtime.PlanningInvocation) -> planning_runtime.PlanningOutcome:
+        return self._outcome
+
+    def capability_probe_runner(self):  # pragma: no cover - 本測試不用
+        raise AssertionError("not used")
+
+
+def test_nonzero_exit_carries_the_model_stdout_excerpt(tmp_path: Path) -> None:
+    """#670／PR #674 為 probe 做過一次；questioner／secondary／integrator 三個
+    adapter 共用的 `_invoke_json` 直到本票才跟上——修法前這條路只留得下
+    `planning launcher failed: claude/claude-sonnet-4.6`，rc 與輸出全部消失。"""
+
+    stdout = "I cannot comply with this request.\nPlease rephrase."
+    invoker = _FixedInvoker(
+        planning_runtime.PlanningOutcome(returncode=2, stdout=stdout, stderr="TOKEN=s3cret")
+    )
+    with pytest.raises(ValueError) as excinfo:
+        planning_runtime._invoke_json(
+            _IDENTITY, "prompt", worktree=tmp_path, invoker=invoker, timeout_seconds=10
+        )
+    message = str(excinfo.value)
+    assert "rc=2" in message
+    # 節錄由 #674 的既有函式產生，不是本測試自造的字串。
+    assert stdout_excerpt(stdout) in message
+    assert "\n" not in message
+
+
+def test_nonzero_exit_diagnostic_never_reads_stderr(tmp_path: Path) -> None:
+    """票 A（PR #688）的邊界：stderr 是最容易夾帶路徑／env／憑證原文的通道，
+    診斷一律不讀它。本票新增的節錄沿用同一條界線。"""
+
+    invoker = _FixedInvoker(
+        planning_runtime.PlanningOutcome(
+            returncode=1,
+            stdout="model output",
+            stderr="ANTHROPIC_API_KEY=sk-live-should-never-appear",
+        )
+    )
+    with pytest.raises(ValueError) as excinfo:
+        planning_runtime._invoke_json(
+            _IDENTITY, "prompt", worktree=tmp_path, invoker=invoker, timeout_seconds=10
+        )
+    assert "sk-live-should-never-appear" not in str(excinfo.value)
+    assert "ANTHROPIC_API_KEY" not in str(excinfo.value)
+
+
+def test_missing_stdout_is_stated_rather_than_silently_dropped(tmp_path: Path) -> None:
+    invoker = _FixedInvoker(planning_runtime.PlanningOutcome(returncode=0, stdout=None))
+    with pytest.raises(ValueError) as excinfo:
+        planning_runtime._invoke_json(
+            _IDENTITY, "prompt", worktree=tmp_path, invoker=invoker, timeout_seconds=10
+        )
+    assert "<no stdout>" in str(excinfo.value)
+
+
+def test_no_json_snippet_is_single_lined_by_the_shared_excerpt(tmp_path: Path) -> None:
+    """`_extract_json` 的片段改走 `stdout_excerpt()`，不再是會帶進換行的裸切。"""
+
+    with pytest.raises(ValueError) as excinfo:
+        planning_runtime._extract_json("Error: line one\nline two", tmp_path / "absent.json")
+    message = str(excinfo.value)
+    assert "\n" not in message
+    assert "line one line two" in message
+
+
+# ---------------------------------------------------------------------------
+# 5. 端到端：差異訊息活著抵達 `BrainstormResult.reason`
+# ---------------------------------------------------------------------------
+
+
+def test_field_level_difference_survives_into_the_blocking_reason(tmp_path: Path) -> None:
+    """#701 的現場條件重演：questioner 回一份只差一個欄位的 pack。
+
+    修法前 reason 是 `question-pack-malformed: ValueError: question pack does
+    not cover exact completeness blockers`——一個字都查不動。
+    """
+
+    report = _report()
+    registry = IdentityRegistry.from_rows(
+        [
+            {
+                "executor": "codex",
+                "model_id": "primary",
+                "independence_domain": "openai",
+                "capabilities": ["planning"],
+            },
+            {
+                "executor": "agy",
+                "model_id": "Gemini 3.1 Pro (High)",
+                "independence_domain": "google",
+                "capabilities": ["planning"],
+                "live_probe": "agy-plan-sandbox",
+            },
+        ]
+    )
+    probes = {
+        ("agy", "Gemini 3.1 Pro (High)"): CapabilityProbe.ready_for(
+            "agy", "Gemini 3.1 Pro (High)", "google"
+        )
+    }
+
+    def questioner(_input: object) -> object:
+        payload = report.default_question_pack.to_dict()
+        payload["questions"][1]["kind"] = "missing-spec"
+        return payload
+
+    result = run_heterogeneous_brainstorm(
+        report=report,
+        primary=("codex", "primary"),
+        registry=registry,
+        probes=probes,
+        evidence_dir=tmp_path,
+        artifact_root=tmp_path,
+        scope=SCOPE,
+        primary_questioner=questioner,
+        secondary_planner=lambda *_: {},
+        primary_integrator=lambda *_: {},
+    )
+    assert result.state == "needs_human"
+    assert result.reason is not None
+    assert result.reason.startswith("question-pack-malformed: ValueError: ")
+    assert "first diff at questions[1].kind" in result.reason
+    assert "expected='missing-design'" in result.reason
+    assert "got='missing-spec'" in result.reason
+    assert manager._classify_planning_failure(result.reason) == "content"
+
+
+def test_timeout_still_classifies_as_environment_through_the_new_summary() -> None:
+    """回歸：例外**型別名**仍在最前面，`timeoutexpired` 這個 marker 照樣活著
+    （#554 明列的真陽性樣態）。新的摘要函式不得把它弄丟。"""
+
+    exc = subprocess.TimeoutExpired(cmd=["claude", "--print", "x" * 500], timeout=300)
+    reason = "primary-integration-malformed: " + summarize_planning_exception(exc)
+    assert manager._classify_planning_failure(reason) == "environment"


### PR DESCRIPTION
Closes #701

## 問題

`validate_question_pack()` 的最後一關是整份 `to_dict()` 逐位元相等
（`planning.py:797`）：

```python
if normalized.to_dict() != report.default_question_pack.to_dict():
    raise ValueError("question pack does not cover exact completeness blockers")
```

`pack_id`／任一 `question_id`／`kind`／`prompt`／`source_refs`／questions 的順序／數量
——**六種以上結構完全不同的失敗塌縮成同一句話**，而模型實際回了什麼**一個字都沒保存**。
實機後果：define 穩定卡住（兩筆 work item ×「`work start`／`work resume`」兩種觸發路徑，
四次皆同），落檔的 `cortex-planning-failure/v1` evidence 只有那句話。

issue #701 的排除工作（12/12 外部重現逐位元 MATCH、R-5 已排除）指向「差異在 job 路徑
怎麼呼叫模型」，而現有診斷讓人**無法再往下一步**。本 PR 就是把那一步變成可能。

## 本票不做

**不動任何驗證判準。** 「question pack 必須逐位元等於 default pack」這條逐字保留；
secondary evidence 的覆蓋率、integrator 的 echo-back 相等、artifact ref 的集合相等
一律不變。本 PR 只讓失敗**可診斷**。判準本身的觀察見文末「觀察（另開票，未在本 PR 動）」。

## 1. 逐欄差異取代一句話

`describe_question_pack_difference()` 回報**第一個**差異；訊息開頭一律另帶列數。
文法對本 PR 所有差異訊息一致：

```
<原句>: rows expected=<N> got=<M>; first diff at <locator> expected=<值> got=<值>
```

**實際輸出**（皆為真跑，非手寫）：

```
question-pack-malformed: ValueError: question pack does not cover exact completeness blockers: rows expected=3 got=3; first diff at questions[1].kind expected='missing-design' got='missing-spec'

question-pack-malformed: ValueError: question pack does not cover exact completeness blockers: rows expected=3 got=3; first diff at pack_id expected='qp-b55f57b7e574dc3ac618d8ca' got='qp-0000000000000000000000'

question-pack-malformed: ValueError: question pack does not cover exact completeness blockers: rows expected=3 got=2; first diff at questions[2].question_id expected='q-625964133c364112' got=<absent>

question-pack-malformed: ValueError: question pack does not cover exact completeness blockers: rows expected=3 got=3; first diff at questions[0].prompt expected='<+49c>an accepted spec?' got='<+49c>an accepted spec for the planning subsystem?'
```

最後一條是**視窗**的樣子：兩個 prompt 的前 49 個字一模一樣，直接取前綴等於印兩份相同的
字，因此視窗對齊到第一個相異字元，前面少了幾個字以 `<+49c>` 就地記帳。

掃描順序即報告順序：`schema_version` → `pack_id` → 逐列逐欄（`question_id` → `kind` →
`prompt` → `source_refs`）→ 列數。列數放最後是因為「第 0 列的 kind 就錯了」比「總共少
一列」更接近成因；但**列數一律寫在訊息開頭**，「有幾條」與「差在哪」兩件事都答得出來。

## 2. 截斷策略（沿用票 A／PR #688）

**原則：截斷只犧牲值，永不犧牲「哪一列、哪一欄」。**

1. **locator 永不被截斷、永不被遮罩**——`questions[2].kind` 就是「差在哪」本身。
2. 值的顯示上限 `PLANNING_DIAGNOSTIC_VALUE_LIMIT = 72`；視窗**對齊到第一個相異字元**
   （差異點前保留 16 字），前後各犧牲幾個字以 `<+Nc>` **就地記帳**，記的是遮罩前的原始
   字元數，因此「這個值總共多長」永遠推得回來。
3. 值不存在時是 `<absent>`，不是空字串——「少一列」與「該列是空的」分得開。
4. 四個 `except` 分支的例外摘要收斂成 `summarize_planning_exception()`，預算由 #397 的
   **160 放寬到 480**（逐欄差異裝不進 160：locator ＋ 兩個值就超過），截斷同樣以
   `…+Nc` 記帳，不再是裸切。型別名仍在最前面——`outcome_taxonomy` 的 `timeoutexpired`
   這個 marker 靠的就是它活著（有回歸測試）。
5. 實測長度：上面四條 194–243 字元，遠在 480 內；票 A 的拒因表預算是 1200，同一量級。

## 3. 失敗時保存模型的實際輸出

questioner／secondary／integrator 三個 adapter 共用同一支
`planning_runtime._invoke_json()`，而它在 `rc≠0` 時只留得下：

```python
raise ValueError(f"planning launcher failed: {identity.executor}/{identity.model_id}")
```

rc 是幾、模型／CLI 印了什麼，全部隨 invoker 的 tempdir 一起消失。改為沿用 #670／PR #674
已建立的 `stdout_excerpt()`：

```
planning launcher failed: claude/claude-sonnet-4.6 rc=2 stdout=I cannot comply with this request. Please rephrase.
```

**一次補齊三個 adapter**——不另造函式、不改 `stdout_excerpt` 的語意。
`_extract_json_candidates()` 既有的兩處片段（`returned no JSON object:` /
`result is not JSON:`）也改走同一支，不再是會把換行帶進單行 reason 的裸切；
`<empty output>` 哨兵刻意保留（既有測試以它為斷言對象）。

測試不自造字串：`test_nonzero_exit_carries_the_model_stdout_excerpt` 斷言的是
`stdout_excerpt(stdout) in message`，走的是 #674 的真實產生路徑。

## 4. 同型塌縮逐處掃過（`#679` 修 PATH 沒看隔壁 HOME ⇒ `#692` 的教訓）

`planning.py` **全部** `raise ValueError` 逐處看過，結論如下。

### 已修（原本塌縮）

| 位置 | 原本塌縮了什麼 | 現在 |
|---|---|---|
| `validate_question_pack` 整體相等 | pack_id／question_id／kind／prompt／source_refs／順序／數量 **6+** | 列數 ＋ 第一個差異的 locator/expected/got |
| `questions[i] has invalid scalar` | 3 欄 × 2 種缺陷 ＝ **6** | 逐欄逐缺陷 6 種訊息 |
| `question pack identity/questions invalid` | pack_id 非字串／pack_id 空／questions 非 list **3** | 拆成兩句、各自帶值 |
| `question pack schema_version invalid` | 缺席／型別不對／版本不同 **3** | expected/got（缺席顯示 `<absent>`） |
| `_strict_string_list` | 非 list／某項非字串／某項空白 **3**，且不說第幾項 | 三種訊息 ＋ `[index]` |
| `secondary evidence identity invalid` | schema 漂移／pack_id 抄錯 **2**（處置完全不同） | 拆成兩句、各自帶值 |
| `evidence[i].question_id invalid` | 非字串／不在 pack／答兩次 **3** | 三種訊息（不在 pack 時列出未答清單） |
| `secondary evidence does not cover every question` | 不說**少了哪幾題** | `answered=1/3 missing=[...]` |
| `primary integration pack mismatch` | 不說抄成了什麼（#516 反覆撞的那一格） | expected/got |
| `primary integration evidence hash mismatch` | 同上 | expected/got |
| `resolutions[i] invalid keys` | 非 object／缺鍵／多鍵 **3**，且一個鍵名都不說 | `missing=[...] unexpected=[...]` |
| `resolutions[i].question_id invalid` | 非字串／不在 pack／解兩次 **3** | 三種訊息 |
| `resolutions[i].decision / artifact_kind invalid / mismatch` | 不說收到什麼、不說該是什麼 | expected/got |
| `primary integration does not resolve every question` | 不說少了哪幾題 | `resolved=2/3 missing=[...]` |
| `artifacts[i] invalid keys` / `artifacts[i] invalid` | 非 object／缺鍵／多鍵 ＋ kind／path 兩種／content 共 **4** | 逐項訊息 |
| `primary integration artifact content/ref mismatch` | 不說是「寫了沒人引用」還是「引用了沒寫」——**兩者 prompt 修法完全相反** | `written_not_referenced=[...] referenced_not_written=[...]` |
| `structured artifact content missing` | 鍵不存在／鍵在但空 list **2** | expected/got |
| `required-section-missing`（#520 同型） | 「一個標題都沒寫」與「寫了但字面不在可接受集合」**2**，且 planner 實際寫的標題不留在任何地方 | 併印 `headings accepted=[...] found=[...]` |
| plan frontmatter `invariant_count` | 缺席／非 int／負值 **3** | expected/got |
| plan frontmatter `artifact_classes` | 缺席／非 list／空 list／含非字串 **4** | expected/got |
| plan frontmatter `scope_excludes` | 非 list／含非字串 **2** | expected/got |
| `builder envelope 格式錯誤` | invariant_count 三種 ＋ artifact_classes 兩種 ＝ **5** | 兩欄各自 expected/got |
| `cards_count/persona_binding_count 不合法` | cards 負／binding 負／binding > cards **3**，兩個值都不印 | 併印兩個值 |
| `gate_spine_count 不得為負` | 不印值 | 併印值 |
| `planning gate refs must be distinct` | 不說**哪一個** ref 重複 | `duplicates=[...]` |

### 查過、結論是「不是塌縮」（不改）

| 位置 | 結論 |
|---|---|
| `planning scope <field> must be a non-empty string` | 已逐欄；單一失敗語意 |
| `unknown planning artifact kind: {kind}` / `plan_review_gate 需要 kind='plan'，實際 {kind!r}` / `compute_sizing_score …` | 已帶實際值 |
| `unknown plan review check: {name!r}` / passed 帶 reason / failed 缺 reason | dataclass 不變式，三句各自對應一個條件，且帶值 |
| `applicable_contract_rules 含未知規則: {sorted(...)}`（兩處） | 已列出全部未知規則 |
| `sizing dimension {name} must be an int in [0, 2], got {value!r}` | 已帶欄位名與值 |
| `duplicate question_id: {id}` / `evidence[i].question_id answered twice` | 已帶 id |
| `planning gate {field} 必須使用 {kind} kind` | 已帶欄位與期望 kind |
| `conflicting immutable evidence: {path}`（`FileExistsError`，兩處） | 已帶路徑；且 #535 已補 owner/mtime |
| `_post_integration_artifact_evidence` 的 14 條失敗 | **#515 已做過同一件事**（`ArtifactEvidenceFailure` 帶 reason/detail/ref），本 PR 只在 `required-section-missing` 這一格補上「找到什麼標題」 |
| `run_heterogeneous_brainstorm` 四個 `except` | **#397／#408 已儀器化**；本 PR 只換共用摘要函式並放寬預算 |

## 5. 憑證檢查（比照 PR #674 的做法）

**兩層窮舉，不是抽樣。**

**(a) 來源面** — 本 PR 新增的診斷文字只有三個來源：

1. **判準端算出來的常數**：locator（`questions[2].kind`）、期望值字面（`<int >=0>`、
   `list(PLANNING_KINDS)`）、`report.default_question_pack` 的內容（由 repo 內
   artifact 的 kind／ref 機械產生）。
2. **模型回傳的、已 parse 的 payload 值**：question pack／secondary evidence／
   integration 的欄位值。模型的輸入是 completeness report ＋ pack ＋ source material，
   **prompt 與 argv 不帶任何憑證，env 不會被回顯**（`_planning_argv` 的既有性質），
   因此模型沒有「知道 token 是什麼」的管道，也就沒有把它寫進回應的路徑——這與 PR #674
   對 `stdout_excerpt` 已寫下的論證是同一份，本 PR 沒有擴大它的來源。
3. **CLI stdout 節錄**（`_invoke_json` 的 rc≠0 路徑）：同上，且經 `stdout_excerpt()`。

**(b) 明確排除面** — **沒有任何一條路徑讀 stderr、env、argv 或檔案內容。**
`PlanningOutcome.stderr` 存在且就在隔壁一行，本 PR **刻意不取**：stderr 是最容易夾帶
路徑、env 與憑證錯誤原文的通道，這是票 A（PR #688）已寫下的邊界，本 PR 沿用並由測試
釘住（`test_nonzero_exit_diagnostic_never_reads_stderr`：stderr 放
`ANTHROPIC_API_KEY=sk-live-…`，斷言它不出現在訊息裡）。
例外摘要維持 `type(exc).__name__` 在前的既有格式，未新增任何 `os.environ` 讀取。

`R-21`（tier: shareable 機密掃描）帶 PR 上下文本機 **pass**。

## 6. 不破壞票 A（#682／PR #688）的 `grade=` 防偽設計——怎麼確認的

票 A 的設計是：**分類器讀渲染端算好、且錨在字串開頭的 `grade=` 欄位，不對整串 reason
做 substring search**（`_ENVIRONMENT_GRADE_REASON_RE = \A[a-z0-9-]+ grade=environment
candidates=\d+ \(`）。三點確認：

1. **結構上碰不到**：本 PR 的差異文字進的是 `question-pack-malformed: …` /
   `secondary-output-malformed: …` / `primary-integration-malformed: …` 這類 reason 的
   **尾段**，而錨定式只在**位置 0** 匹配，第一個 token 之後必須緊接一個空格 ＋ `grade=`
   ——那些前綴後面是冒號。**正向測試**：`test_diff_text_cannot_forge_the_ticket_a_grade_anchor`
   讓模型的 `prompt` 值逐字寫出一整張假拒因表
   （`no-heterogeneous-planner grade=environment candidates=9 (...)`），斷言
   `is_environment_grade_rejection_reason(reason) is False` 且
   `_classify_planning_failure(reason) == "content"`。
   **反向測試**：`test_the_grade_anchor_still_works_for_a_genuine_rejection_table`
   斷言真的拒因表照樣被認出來、照樣落 `environment`——確認我沒有把票 A 的機制弄壞。
2. **票 A 的程式碼一行未動**：`model_identities.py` 在本 PR 的 diff 中**沒有變更**
   （只多了一個 `from .model_identities import stdout_excerpt` 的 import 在
   `planning_runtime`）。
3. **但票 A 不是唯一的判準**——`_classify_planning_failure` 還有**三條不錨定**的文字
   判準：#533／#554 的 `TRANSIENT_SERVICE_MARKER_RE`（詞界比對整串）、#416 的 authority
   殘留、#507 的 worktree drift（兩者裸 `in`）。**把模型的值原樣丟進 reason，等於讓模型
   只要在某個 `prompt` 裡寫上 `timeout` 或 `503`，就能把一個 content 失敗改判成
   environment**，讓 `recover-planning` 對著一個永遠不會自癒的失敗一直重試——那正是票 A
   要防的那件事換一條路發生。因此在**產生端**堵住：
   - **詞界類 marker**（`timeout`／`503`／`overloaded`…）：兩側各加一個 `_` 破詞界。
     `_` 是 word char，`\btimeout\b` 於是不成立，而**字面一個字都沒少**
     （`waited 30s then timeout` → `waited 30s then _timeout_`）。這是 #554 已經釘住的
     性質（`test_every_marker_needs_word_boundaries` 斷言 `x_{marker}_x` 不命中）反過來用。
   - **裸子字串類的三條長句**：詞界破不了 `in`，只能整段換成
     `<classification-marker-elided>`（佔位符本身不含任何 marker——`<unavailable>` 就是
     這樣撞上 #554 的，本 PR 三個佔位符都有測試釘住這條不變式）。
   - **對 `TRANSIENT_SERVICE_MARKERS` 全表逐一掃描**的參數化測試（比照 #554 的同型
     測試）：每一個 marker 埋進模型的 `prompt` 值，斷言 reason 仍分類為 `content`。
   - **launcher 轉印的服務錯誤刻意不走這條遮罩**——`planning launcher returned no JSON
     object: …Eligibility check failed…` 那一段是 #533 的判準**要**看見的，遮掉它等於
     把 503 自癒路徑砍掉。分界線是：**已 parse 的模型 payload 值遮罩，CLI 層錯誤文字
     不遮罩**。
   - 字面值是**複製**到 `planning.py` 的（`manager`／`planning_runtime` 都反向依賴本
     模組，import 會成環），因此有一條交叉比對測試釘住兩邊同步：
     `test_copied_classification_phrases_stay_in_sync_with_their_owners`。

另外，所有進 reason 的值一律剝 C0／C1 控制字元並單行化（與票 A 的
`_CONTROL_CHARS_RE` 同一條規矩）。

## 觀察（另開票，未在本 PR 動）

1. **`_is_planning_transient_service_failure` 對整串 reason 做詞界 substring search，
   而 reason 裡本來就有一段 launcher 轉印的模型 stdout**（`returned no JSON object:
   <snippet>`，#533 的既有設計）。也就是說「模型印 `503` 就能改判 environment」這條路
   在本 PR 之前就存在於 launcher 那一段，本 PR 只是**沒有把它擴大到已 parse 的 payload**。
   要根治得比照票 A：讓分類讀一個渲染端算好的欄位，而不是 substring search。這牽動
   #533／#554 的既有判準與跨 lane 的 `outcome_taxonomy`，**超出本票「只讓失敗可診斷」
   的範圍**，建議另開票。
2. **判準本身**（「question pack 必須逐位元等於 default pack」）在 #701 的現場是否合理
   ——模型被要求逐字複製一份它已經收到的東西，任何正規化差異（空白、順序）都是硬失敗
   ——本 PR **刻意不動**。等這條 PR land、下一次 define 卡住時，逐欄差異會直接告訴我們
   「模型到底改了什麼」，那才是判斷「判準該不該放寬」的證據；現在改等於再猜一次。

## 變更

- `paulsha_cortex/coordinator/planning.py`：`_guard_classification_markers()`／
  `_render_difference()`／`_windowed_value()`／`summarize_planning_exception()`／
  `describe_question_pack_difference()` 五支新工具，三個驗證器 ＋ plan review ＋
  artifact assessment 的塌縮點逐處改寫。
- `paulsha_cortex/coordinator/planning_runtime.py`：`_invoke_json` 的 rc≠0 帶 rc ＋
  `stdout_excerpt()`；`_extract_json_candidates` 兩處片段改走同一支。
- `tests/test_planning_diagnostics_701.py`：67 條新測試。
- `changelog.d/701-question-pack-diagnostics.md`、`CHANGELOG.md [Unreleased]`。

## 驗收

- [x] 分支 `feature/701-question-pack-diagnostics`，未 commit 到 `main`
- [x] `changelog.d/701-question-pack-diagnostics.md` 已新增且**已 commit**
- [x] `CHANGELOG.md [Unreleased]` 有對應 entry
- [x] `python3 -m pytest tests/ -q` → **4462 passed / 28 skipped / 65 subtests**
- [x] **既有測試一行未改**（`git diff --stat origin/main -- tests/` 只有新檔）
- [x] `openspec validate --specs` → 16 passed, 0 failed
- [x] 帶 PR 上下文的 `policy_check` 通過
- [x] `git diff --check` 乾淨
- [x] 不動驗證判準、不動部署、不動 unit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E7w9kaUxAzCCEk7piD5hfK
