### PR TITLE
fix(trust-root): codex hooks 改由 sticky 樹守住，兩個帳號同一條規則（#698）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 本專案遵循 hamanpaul project policy v1.0.17。
 
 ## [Unreleased]
+- **#698：`cortex-reviewer-planner` 可植入 codex hooks（R9 T3.9 實測攻破）已修——採 operator 裁決的方案 A：`$CODEX_HOME` 改成 root-owned ＋ **sticky bit** 的真目錄，job 以具名 access ACL 取得整棵寫入權，樹裡放一個 root-owned 的 `hooks.json`（unlink／rename 由 sticky 擋、改內容由檔案 mode 擋、mount 層另有巢狀 `ReadOnlyPaths=`）。permgen 的 §R2 安全網改為讓 sticky 通過（group／other 不可寫一行未放寬，setuid／setgid 改為明文清除），新增 `OwnerClass.STICKY_SHARED`。**兩個帳號的形狀由 `EXECUTOR_ENFORCEMENT_LEAVES` 一條規則導出並在 import 當下強制**，builder 一併遷移（它舊形態下 codex 在降權 unit 內根本起不來）。U-9 因此關閉、`reviewer-planner-codex-hooks` 從 deferred 升為登記表資產。實測：T3.9 兩個 subject 皆 `denied (OK)`，且 builder 的 `codex exec` 從 `Read-only file system` 翻成 `turn.completed`（#698）。
 - planning 的模型輸出驗證失敗改為**逐欄可診斷**：question-pack 的六種以上失敗不再塌縮成同一句話（改報「第一個差異的索引／欄位／expected／got」與列數），secondary evidence／primary integration／plan frontmatter／required headings 的同型塌縮一併掃過；三個 adapter 共用的 `_invoke_json` 於 rc≠0 時沿用 #674 的 `stdout_excerpt()` 保存模型輸出（只讀 stdout、不讀 stderr）；差異文字經產生端遮罩，模型無法偽裝成分類標記（#701）。
 - R9 的 T1.3 斷言改為驗「operator CLI 做得到事」而非「binary 跑得起來」（兩個 subject 同時假失敗）；runbook 記錄 0818 兩 subject 實測結果並標明 T3.9 對 reviewer-planner 為已知追蹤項（#698）（#699）。
 - runbook 的「M2′ 之後仍未涵蓋的」清單更正兩條陳舊項（gate 執行身分 #629 已完成、reviewer 憑證 refresh 已由 #685 解決），並加上「not-covered 清單本身也是宣稱」的約束（#696）。

--- a/changelog.d/698-codex-hooks-sticky.md
+++ b/changelog.d/698-codex-hooks-sticky.md
@@ -1,0 +1,86 @@
+### Fixed
+- **#698（R9 族 3 的 T3.9 實測攻破）：`cortex-reviewer-planner` 可以植入 codex hooks
+  ——operator 裁決採**方案 A（目錄 sticky bit ＋ `hooks.json` 由 root 擁有）**，且**兩個
+  帳號的形狀由同一條規則導出**。** 0818 的 R9 抽驗在該帳號上量到
+  `T3.9 改 codex hooks :: !! SUCCEEDED (FAIL)`（事後檢查 `cache/codex/hooks.json` 內容
+  為 `x`）。成因是 #685 把它的 `~/.codex` 改成指向 job-owned `cache/codex` 的 symlink
+  ——那是**必要的**（#686 實測 codex 需要 `$CODEX_HOME` **整棵**可寫才啟動得了），
+  代價是那棵樹裡放不住任何 root-owned 的 enforcement 檔。codex hooks **會執行命令**
+  ⇒ **跨 job 持久化** ⇒ 四分隔離「每個 job 一次性」的前提在該帳號上不成立，而它正是
+  吃 untrusted issue 內容的那一個。
+- **新形狀 `CredentialShape.HOME_STICKY_TREE`**：HOME 底下一棵 **root-owned ＋ sticky
+  bit（`1755`）** 的真目錄，job 帳號以一條具名 **access** ACL（`u:<帳號>:rwx`）取得整棵
+  的寫入權。兩件在 #685 的形狀下互斥的事因此同時成立——(i) 整棵可寫 ⇒ codex 起得來；
+  (ii) 樹裡的 `hooks.json`（root:root 0644）**三個動詞全關**：unlink／rename 由 sticky
+  擋（非 owner 只動得了自己的檔）、改內容由檔案自己的 mode 擋。
+  三個刻意的細節，缺任何一個整個裁決就是空的：
+  **(a) 目錄 owner 必須是 root**（POSIX 的 sticky 對**目錄 owner** 免疫）；
+  **(b) 只設 access ACL、不設 default ACL**（default 會讓 root 日後補放的 enforcement
+  檔自動帶上 job 的 `rwx`）；
+  **(c) `hooks.json` 必須先存在**（sticky 不管「建一個還不存在的檔」）——權限計畫因此
+  對它出 **create-if-absent**，而不是其他葉檔那條「不存在就跳過」。
+- **permgen 的 mode 管線現在表達得了 sticky（#685 記為 U-9 不做的兩個理由之一）**。
+  `build_entry()` 尾端的 §R2 安全網從 `mode & 0o700` 改成
+  `mode & (STICKY_BIT | 0o700) & ~setuid/setgid`：**§R2 一行未放寬**（group／other 的
+  write 位仍無條件清除，job 的寫入權一律走具名 ACL），新增的只有「sticky 通得過」；
+  setuid／setgid 則從「被 `& 0o700` 順手吃掉」升級為**明文清除**。另新增
+  `OwnerClass.STICKY_SHARED`——它刻意**不是** `DEPLOYMENT`，否則
+  「deployment 對全部 headless 唯讀」這句話（多條不變式的依據）會退化成有例外清單。
+- **範圍涵蓋兩個帳號，形狀由 `EXECUTOR_ENFORCEMENT_LEAVES` 一條規則導出**：
+  「executor 的狀態樹裡必須住著 root-owned 的 enforcement 檔 ⇒ 凡持有它登入態的帳號，
+  那一格一律是 `HOME_STICKY_TREE`」。規則由
+  `permgen._assert_shape_follows_enforcement_rule()` 在 **import 當下**強制——
+  「只修 reviewer-planner 那格、在 builder 上留一個等著爆的差異」因此在結構上做不到。
+  `builder` 一併遷移：它當天守得住只是因為 `.codex` 還沒遷成可寫樹，而那個形態的代價是
+  **codex 在降權 unit 下根本起不來**（#685 已逐字記錄）。憑證表上 codex 因此只剩**一列**，
+  兩個帳號共用它。
+- **登記表資產隨之調整**：`builder-executor-credential` → **`builder-codex-state`**
+  （形狀從 `IN_PLACE_FILE` 改成 sticky 樹，writer 面加上 `INSTALLER` 才落得到
+  `STICKY_SHARED`）；單一的 `codex-hooks` → **`builder-codex-hooks`** ＋
+  **`reviewer-planner-codex-hooks`**，由 `enforcement_placements()` 從同一條規則長出來。
+  `reviewer-planner-codex-hooks` 因此從 `deferred_run_dependencies()` 的 **U-9 消失**——
+  不是刪一列，是那條張力（「codex 起得來」與「樹裡放得住 root-owned 檔」互斥）**真的
+  不存在了**。deferred 清單剩一項（`gate-gitconfig`）。
+- **mount 層那一道沒有淨退**。`IN_PLACE_FILE` 讓 hooks 同時被 **DAC** 與 **systemd
+  mount** 兩層擋住（`IN_PLACE_CONTENT_WRITE_ASSETS` 的整段說明就是這件事）；sticky 樹
+  整棵必須進 `ReadWritePaths=`，因此新增機械導出的巢狀
+  `ReadOnlyPaths=<HOME>/.codex/hooks.json`（`enforcement_read_only_paths()`）。
+  **刻意沒有 `-` 前綴**：目標不存在時 unit 直接起不來——那正是要的行為，因為缺那個檔
+  時 job 植得進 hooks，而一個植得進 hooks 的 job 不該起得來。
+- **修掉 `planning_probe_cache` 的一份複本（本票的形狀變更才暴露它）**。direct 那一支
+  自己拼 `relpath + token_leaf`，而 codex 那一列的樹與葉現在**都**由
+  `executor_credential_relpath` 的 head／tail 導出 ⇒ 那份複本會拼出**目錄本身**，指紋
+  退化成 `stat ~/.codex`、憑證 refresh 偵測不到。改走
+  `PathLayout.credential_token_relpath_of()` 這個唯一來源。
+- **`plan_to_commands()` 的兩個部署守衛**（既有部署不是 greenfield）：
+  sticky 樹前面加 `[ ! -L <path> ] || { … exit 1; }`——`install -d` 對既有 symlink
+  **不報錯也不取代**，它會跟著連結去建目標，把 chown／chmod／setfacl 全部套到
+  `cache/codex` 那棵 job-owned 的樹上（**安靜地做錯事**）；enforcement 檔同樣先擋
+  symlink，否則 job 預埋一條**懸空** symlink 就能讓 root 的 `cat >` 寫到別處去。
+  另外把多行 rationale 逐行加上 `#` 前綴——那份輸出是 runbook 以 `sudo sh -e` 直接執行
+  的 script，漏前綴的行會被當成命令解析。
+
+### Changed
+- runbook 第 4e-2b 步整段重寫為「兩個 job 帳號的 codex 狀態樹（sticky）」，含**實機遷移
+  步驟**（builder 是真目錄、reviewer-planner 是 symlink，兩者順序不同）與逐條驗證；
+  agy／claude 的 symlink 形態移到新的 4e-2c。記錄 0818 遷移實際踩到的三個陷阱：
+  (1) `install -d` 跟著既有 symlink 走；(2) **`cp -a src/. dst/` 會把來源目錄自己的
+  owner／mode／ACL 蓋到目的地**——剛設好的 `root:root 1755 + ACL` 被還原成
+  `job 0700`，sticky 與 ACL 一起消失且 `cp` 不會抱怨（因此**先搬內容、後套權限**）；
+  (3) `ls -ld` 顯示的 group `rwx` 是 POSIX ACL 的 **mask** 不是 group 寫入權，
+  驗證一律用 `getfacl`，且任何一次 `chmod` 都會重設 mask ⇒ chmod 之後必須重跑 setfacl。
+- R9 攻擊腳本的 T3.9 從 1 條擴成 3 條（改內容／unlink／rename）——sticky 關的是**三個
+  動詞**，只驗「改內容」會漏掉真正靠 sticky 擋的那兩條；並在其前加 `need()` 前置，
+  因為那個檔缺席時本項會以「建得出新檔」翻紅（**正確的紅字**，處置是把檔種回去）。
+  `need()` 的訊息一併更正為「不存在**或本身分看不到**」——`[ -e ]` 在缺 traverse 權時
+  同樣為假，`cortex-reviewer-planner` 對 `<A>/monitor/` 就是這個情形。
+
+### 實測（0818，本機四分部署，完整模板 unit 加固面，`unit-replica` 全量導出）
+
+| 量測 | 修前 | 修後 |
+|---|---|---|
+| R9 T3.9 `cortex-builder` | `denied (OK) rc=2` | `denied (OK) rc=2`（三個動詞全 denied） |
+| R9 T3.9 `cortex-reviewer-planner` | **`!! SUCCEEDED (FAIL)`** | **`denied (OK) rc=2`**（三個動詞全 denied） |
+| 族 1–4 `SUCCEEDED` 總數 | builder 0／planner **1** | **兩者皆 0** |
+| `codex exec` @ `cortex-job-jit` | **`failed to initialize in-process app-server client: Read-only file system (os error 30)`** | **`turn.completed`（rc=0）** |
+| `codex exec` @ `cortex-reviewer-job-jit` | `turn.completed`（rc=0） | `turn.completed`（rc=0） |

--- a/docs/superpowers/plans/planner-job-downgrade.md
+++ b/docs/superpowers/plans/planner-job-downgrade.md
@@ -246,6 +246,16 @@ blocking reason——兩者剛好接得起來，缺任何一半都還是查不�
    ACL 的目錄，但它要改 permgen 的 mode 管線（`_mask_write` 會拿掉 group 寫入位、
    `mode & 0o700` 會吃掉 sticky 位，那是 spec §R2 的既有不變式），且「codex 能不能在一個
    它**不擁有**的 `$CODEX_HOME` 下跑起來」**沒有實機證據** ⇒ 依 D13 不得宣稱可用。
+
+   > **✅ U-9 已於 #698 結案（0818，operator 裁決採方案 A＝上述候選解）。** 觸發它的是
+   > **實測**而不是討論：R9 族 3 的 T3.9 在 `cortex-reviewer-planner` 上量到
+   > `!! SUCCEEDED (FAIL)`——該帳號**真的植入了** `hooks.json`，而 codex hooks 會執行
+   > 命令 ⇒ 跨 job 持久化。#698 把上面兩個「不做的理由」逐條消掉：mode 管線改成
+   > `mode & (STICKY_BIT | 0o700)`（§R2 的 group／other 不可寫**一行未放寬**），而
+   > 「不擁有的 `$CODEX_HOME`」已在完整模板 unit 加固面下實測（runbook 第 4e-2b 步）。
+   > **範圍涵蓋兩個帳號**：形狀改由 `EXECUTOR_ENFORCEMENT_LEAVES` 一條規則導出、在
+   > import 當下強制，builder 一併遷移。R-6 的其餘部分不變（token 葉檔仍可被該帳號
+   > 刪除或替換——sticky 保護的是 root 擁有的那些檔）。
    **同一個裁決也涵蓋 builder**：它在模板 unit 下跑 codex 會撞同一條阻斷。
 4. **`manager-claude-credential` 沒有依 plan 原文刪除。** plan 寫「第三項因為本票的裁決是
    『planning 一律走降權 job』」——那個裁決的**落地**是票 F（#687）的切換，而 direct 路徑

--- a/docs/superpowers/runbooks/trust-root-phase2b-setup.md
+++ b/docs/superpowers/runbooks/trust-root-phase2b-setup.md
@@ -2157,8 +2157,202 @@ sudo -u cortex-builder sh -c \
 
 ---
 
-#### 4e-2b. `cortex-reviewer-planner` 的三份登入態（#685／#672 票 D；U-4／U-5／U-7）
+#### 4e-2b. 兩個 job 帳號的 codex 狀態樹（#698 方案 A：sticky ＋ root-owned hooks）
 
+> **這一節在 #698 之前只涵蓋 `cortex-reviewer-planner`，而那正是被實測攻破的形狀。**
+> 0818 的 R9 T3.9 在該帳號上 `!! SUCCEEDED`：`~/.codex` 是導進 job-owned `cache/codex`
+> 的 symlink ⇒ 該帳號**植得進 `hooks.json`**。codex hooks **會執行命令** ⇒ 跨 job
+> 持久化 ⇒ 四分隔離「每個 job 一次性」的前提在該帳號上不成立，而它正是吃 untrusted
+> issue 內容的那個帳號。
+>
+> operator 裁決（#698）採**方案 A**：**目錄 sticky bit ＋ `hooks.json` 由 root 擁有**，
+> 且**兩個帳號的形狀由同一條規則導出**（`permgen.EXECUTOR_ENFORCEMENT_LEAVES`，
+> import 當下強制）。builder 因此**一併遷移**——它當天守得住只是因為 `.codex` 還沒遷成
+> 可寫樹，而那個形態的代價是 codex 在降權 unit 下**根本起不來**（#686、#685 已記錄）。
+
+**形狀（`permgen.CredentialShape.HOME_STICKY_TREE`）**：HOME 底下一棵 **root-owned ＋
+sticky bit** 的真目錄，job 帳號以一條具名 **access** ACL 取得 `rwx`。
+
+| 帳號 | `$CODEX_HOME` | mode | ACL | 樹裡的 root-owned 檔 | token 葉檔 |
+|---|---|---|---|---|---|
+| `cortex-builder` | `~/.codex` | `1755` | `u:cortex-builder:rwx` | `hooks.json`（root:root 0644） | `auth.json` |
+| `cortex-reviewer-planner` | `~/.codex` | `1755` | `u:cortex-reviewer-planner:rwx` | 同上 | `auth.json` |
+
+> **為什麼這個形狀同時買到兩件在 #685 下互斥的事**：
+>
+> 1. **整棵可寫 ⇒ codex 起得來**。#686 實測：唯讀時 codex 回
+>    `Error: failed to initialize in-process app-server client: Read-only file system
+>    (os error 30)`；把 cwd 換成可寫的 `/tmp` **症狀完全相同**，維持唯讀 cwd、只把
+>    `CODEX_HOME` 指到可寫目錄則 **rc=0**。阻斷點是 `CODEX_HOME`，不是 cwd。它在底下
+>    建 `state_5.sqlite`／`logs_2.sqlite`／`sessions/`／`skills/`／`plugins/`／
+>    `thread-writer-locks/`……**檔名帶版本序號 ⇒ 逐項列舉會在下一次 CLI 升版時無聲失效**。
+> 2. **`hooks.json` 三個動詞全關**。sticky bit（`chmod +t`）的 POSIX 語意是「目錄可寫，
+>    但只有**檔案 owner／目錄 owner／root** 刪得掉或改得掉裡面的檔名」：
+>    - `unlink` → `Operation not permitted`（sticky）
+>    - `rename` → `Operation not permitted`（sticky）
+>    - 改內容 → `Permission denied`（檔案 root:root 0644，job 落在 `other` 位）
+>    另有 mount 層的第二道：模板 unit 帶一條巢狀的
+>    `ReadOnlyPaths=<HOME>/.codex/hooks.json`（見下方 3️⃣），寫入回
+>    `Read-only file system`。
+>
+> **⛔ 目錄 owner 必須是 root。** POSIX 的 sticky 規則對**目錄 owner** 免疫——目錄
+> owner 刪得掉裡面任何檔。把這一層交給 job 帳號等於整條規則不存在。
+>
+> **⛔ 不設 default ACL。** default ACL 決定「**之後**在這個目錄裡新建的物件」的初值，
+> 包含 root 日後重放一次 `hooks.json` 的那一次。設了它等於把 hooks 自動交還給 job。
+> 產生器刻意只出 `setfacl -m`（access），不出 `setfacl -d -m`。
+>
+> **⛔ `hooks.json` 必須先存在。** sticky 管的是「刪／改名**別人的**檔」，**不管
+> 「建一個還不存在的檔」**。缺這個檔時 job 直接 `printf x > $HOME/.codex/hooks.json`
+> 就會成功——那正是 R9 T3.9 的攻擊字面。產生器因此對它出 **create-if-absent**
+> （`[ -e … ] || cat > … <<'EOF'`），而不是其他葉檔那條「不存在就跳過」。
+>
+> **代價（R-6，不變也不多）**：樹由 job 寫 ⇒ 樹裡的 **token 葉檔**仍可被該 job 刪除或
+> 替換。那是刻意的——token 過期必須 refresh 得回來；sticky 保護的是 root 擁有的那些檔。
+>
+> **對 builder 換掉了什麼**：#640 的 `IN_PLACE_FILE` 另外擋住「job 建不了新檔、刪不掉
+> 自己的 `auth.json`」。那一半是**自我 DoS 面**，不是跨邊界面，而 R-6 早已為 planner
+> 帳號接受同一件事。換到的是 builder 的 codex 在降權 unit 下**真的跑得起來**。
+
+##### 遷移（operator 執行；**兩個帳號的既有形態不同，順序不同**）
+
+⚠️ **產生器出的是 greenfield 命令。** 既有部署的 `.codex` 可能是**真目錄**（builder）
+也可能是 **symlink**（reviewer-planner，#685 之後）。權限計畫因此在
+`install -d` **之前**先出一條 `[ ! -L <path> ] || { echo …; exit 1; }` 守衛——
+`install -d` 對既有 symlink **不會報錯也不會取代它**，它會**跟著連結**去建目標，
+於是 `chown`／`chmod`／`setfacl` 全部套到 `cache/codex` 那棵 job-owned 的樹上，
+而現場看起來一切正常。**那是安靜地做錯事，必須由本節顯式拆掉連結。**
+
+```bash
+BH=/var/lib/cortex-builder
+PH=/var/lib/cortex-reviewer-planner
+
+# 0️⃣ 先確認沒有 job 在跑（遷移期間 `$CODEX_HOME` 會短暫不存在）
+systemctl list-units 'cortex-*job@*' --no-legend | grep -v '^$' && \
+  echo "⛔ 還有 job 在跑，等它結束" || echo "無 in-flight job"
+
+# 1️⃣ builder：既有就是**真目錄**（root:root 0755）⇒ 就地加 sticky ＋ ACL
+sudo test ! -L "$BH/.codex" || { echo "⛔ 非預期：builder 的 .codex 是 symlink"; }
+sudo chown root:root "$BH/.codex"
+sudo chmod 1755 "$BH/.codex"
+sudo setfacl -m u:cortex-builder:rwx "$BH/.codex"
+
+# 2️⃣ reviewer-planner：既有是 **symlink → cache/codex** ⇒ 拆連結、建真目錄、搬內容
+if sudo test -L "$PH/.codex"; then
+  OLD="$(sudo readlink -f "$PH/.codex")"      # 期望 /var/lib/cortex-reviewer-planner/cache/codex
+  echo "old target=$OLD"
+  sudo rm "$PH/.codex"                        # ⚠️ 只拆**連結**；`rm -rf` 會連目標樹一起刪掉
+  sudo install -d "$PH/.codex"
+  sudo cp -a "$OLD/." "$PH/.codex/"           # 保留每個檔的 owner／mode（登入態不重放）
+  sudo rm -rf "$OLD"
+fi
+#   ⚠️ **`cp -a src/. dst/` 會把 src 目錄自己的 owner／mode／ACL 蓋到 dst 上。**
+#      0818 遷移實際踩到：剛設好的 `root:root 1755 + ACL` 被還原成
+#      `cortex-reviewer-planner 0700`，sticky 與 ACL 一起消失，而 `cp` 不會抱怨。
+#      因此**先搬內容、後套權限**——下一行不是重複，它是修正那個副作用。
+sudo chown root:root "$PH/.codex"
+sudo chmod 1755 "$PH/.codex"
+sudo setfacl -m u:cortex-reviewer-planner:rwx "$PH/.codex"
+
+# 3️⃣ 種 root-owned 的 hooks.json（**兩份都要**；缺它 sticky 什麼也擋不住）
+for P in "$BH/.codex/hooks.json" "$PH/.codex/hooks.json"; do
+  sudo test ! -L "$P" || { echo "⛔ $P 是 symlink（job 可能預埋）——停下來查"; continue; }
+  sudo sh -c "[ -e '$P' ] || printf '%s\n' '{' '  \"hooks\": {}' '}' > '$P'"
+  sudo chown root:root "$P"
+  sudo chmod 0644 "$P"
+done
+#   內容刻意是**空的** hooks 文件，不是 `paulsha_cortex/scripts/hooks/codex.json` 那份
+#   relay hook：本檔的價值在於「這個位置由 root 佔住、job 換不掉」，不在於跑什麼。
+#   把 relay hook 種進 job 帳號會憑空多一條執行面（而且 job 寫不進 coordinator，
+#   每次 codex session 只會多一串失敗）。之後要放什麼是 root 的決定。
+#   ⚠️ **`[ ! -L ]` 守衛不是形式主義**：這兩個位置在 job 可寫的樹裡，job 預埋一條
+#      **懸空** symlink 時 `[ -e ]` 為假、root 的 `cat >` 會跟著它寫到別處去。
+
+# 4️⃣ 落新 unit（RWP 改掛整棵樹 ＋ 新增巢狀 ReadOnlyPaths）——**必須在 3️⃣ 之後**
+for spec in "--job:cortex-job@.service:strict" "--job:cortex-job-jit@.service:jit" \
+            "--review-job:cortex-reviewer-job@.service:strict" \
+            "--review-job:cortex-reviewer-job-jit@.service:jit"; do
+  flag="${spec%%:*}"; rest="${spec#*:}"; name="${rest%%:*}"; prof="${rest##*:}"
+  python3 -m paulsha_cortex.trust_root unit four-way "$flag" --profile "$prof" > "/tmp/$name"
+  sudo install -m 0644 -o root -g root "/tmp/$name" "/etc/systemd/system/$name"
+done
+sudo systemctl daemon-reload
+#   ⚠️ 順序不可顛倒：`ReadOnlyPaths=` **刻意沒有 `-` 前綴**，hooks.json 不存在時
+#      unit 直接起不來。那是要的行為（缺那個檔 ⇒ job 植得進 hooks ⇒ 不該起得來），
+#      但先落 unit 再種檔會讓所有 job 在中間那段時間全部失敗。
+```
+
+##### 驗證（**用 `getfacl`，不要用 `ls -ld`**）
+
+```bash
+# ✅ 驗證 1：形狀
+for D in /var/lib/cortex-builder/.codex /var/lib/cortex-reviewer-planner/.codex; do
+  sudo stat -c '%n %U:%G %a' "$D"        # 期望：root:root 1755
+  sudo getfacl -p "$D" | grep -E '^(user|group::|mask::|other::|default:)'
+  sudo stat -c '  %n %U:%G %a' "$D/hooks.json"   # 期望：root:root 644
+done
+#   期望（逐字）：
+#     user::rwx / user:<該 job 帳號>:rwx / group::r-x / mask::rwx / other::r-x
+#     **default: 一條都沒有**——有的話 root 日後補放的檔會自動帶上 job 的 rwx。
+#   ⚠️ `ls -ld` 會顯示成 `drwxrwxr-t`：那個 group `rwx` 是 POSIX ACL 的 **mask**，
+#      不是 group 寫入權（`group::` 才是，它必須是 `r-x`）。spec §R2 因此未被放寬。
+#      **只看 `ls` 會誤判成「開了 group 寫入」而去把它關掉——關掉會連 ACL 一起廢掉。**
+#   ⚠️ 之後任何一次對這個目錄的 `chmod` 都會重設 mask ⇒ **chmod 之後必須重跑 setfacl**
+#      （權限計畫本來就是 `chmod` → `setfacl` 這個順序，照抄即可）。
+
+# ✅ 驗證 2：unit 的兩條
+sudo grep -E '^(ReadWritePaths|ReadOnlyPaths)=.*\.codex' \
+  /etc/systemd/system/cortex-{job,reviewer-job}@.service
+#   期望每份各兩行：ReadWritePaths=<HOME>/.codex 與 ReadOnlyPaths=<HOME>/.codex/hooks.json
+
+# ✅ 驗證 3（OS 語意，兩層各驗一次；在**真實加固面**下）
+#    前置：貼上第 4e 步的共用探針 psc_run_under。
+psc_run_under cortex-job /bin/sh -c 'printf x > /var/lib/cortex-builder/.codex/hooks.json'
+#   期望：`Read-only file system` ← mount 層（ReadOnlyPaths）
+psc_run_under cortex-job /bin/sh -c 'rm -f /var/lib/cortex-builder/.codex/hooks.json'
+#   期望：`Operation not permitted` ← DAC 層（sticky）
+psc_run_under cortex-job /bin/sh -c 'mv /var/lib/cortex-builder/.codex/hooks.json /tmp/h'
+#   期望：`Operation not permitted` ← DAC 層（sticky）
+psc_run_under cortex-job /bin/sh -c 'touch /var/lib/cortex-builder/.codex/psc-probe && echo TREE-WRITABLE'
+#   期望：TREE-WRITABLE ← 整棵仍可寫（codex 才起得來）
+#   （收尾：sudo rm -f /var/lib/cortex-builder/.codex/psc-probe）
+#   ⚠️ 三條的錯誤訊息**不同**，而那個差別有資訊：`Read-only file system` 是 mount 層、
+#      `Operation not permitted` 是 sticky、`Permission denied` 是檔案 mode。
+#      只剩一層時仍會 denied——因此**三條都要跑**，不要看到紅字就過。
+
+# ✅ 驗證 4：executor 在該 unit 下**真的跑得起來**（這一格才是驗收的另一半）
+psc_run_under cortex-job-jit /bin/sh -c \
+  'cd /tmp && /opt/cortex/toolchain/bin/codex exec --skip-git-repo-check --json \
+   "Return only this JSON object and do not call tools: {\"capability\":\"cortex-planning-json\"}"'
+psc_run_under cortex-reviewer-job-jit /bin/sh -c \
+  'cd /tmp && /opt/cortex/toolchain/bin/codex exec --skip-git-repo-check --json \
+   "Return only this JSON object and do not call tools: {\"capability\":\"cortex-planning-json\"}"'
+#   期望兩份都出 `turn.completed`。
+#   ⚠️ **builder 那一格在 #698 之前是紅的**（`failed to initialize in-process app-server
+#      client: Read-only file system`）——本節做完必須翻綠。它翻不綠就是遷移沒做完，
+#      不要靠改 unit 讓它過。
+```
+
+**0818 實測（本機，四分部署，遷移前 → 遷移後）**：
+
+| 量測 | 遷移前 | 遷移後 |
+|---|---|---|
+| R9 T3.9 `cortex-builder` | `denied (OK) rc=2` | `denied (OK) rc=2` |
+| R9 T3.9 `cortex-reviewer-planner` | **`!! SUCCEEDED (FAIL)`** | **`denied (OK) rc=2`** |
+| `codex exec` @ `cortex-job-jit` | **`Error: failed to initialize in-process app-server client: Read-only file system (os error 30)`** | **`turn.completed`（rc=0）** |
+| `codex exec` @ `cortex-reviewer-job-jit` | `turn.completed`（rc=0） | `turn.completed`（rc=0） |
+
+**回滾**：`sudo cp /tmp/psc-698-unit-backup/*.service /etc/systemd/system/ && sudo
+systemctl daemon-reload`，再把 `~/.codex` 改回 #685 的形態（`rm hooks.json`、
+`chmod 0755`、`setfacl -b`；reviewer-planner 另需把樹搬回 `cache/codex` 並重建 symlink）。
+**回滾之後 R9 T3.9 會在 reviewer-planner 上重新變紅**——那是 #698 的破口，不是新事故。
+
+#### 4e-2c. `cortex-reviewer-planner` 的 agy／claude 登入態（#685／#672 票 D；U-4／U-7）
+
+> **codex 已於 #698 改走 4e-2b 的 sticky 樹**，因此本節只剩兩格。分界不是帳號，是
+> `permgen.EXECUTOR_ENFORCEMENT_LEAVES` 那條規則：**狀態樹裡住著 root-owned
+> enforcement 檔的 executor 才需要 sticky**；agy／claude 沒有，維持 symlink 形態。
+>
 > **這一節取代 0818 的手動部署。** 那次是手工 `install` ＋ 手工 `ln -s`，**重跑 runbook
 > 不會產生它們**——本節讓它可重現：路徑、owner、mode、symlink 目標全部由
 > `python3 -m paulsha_cortex.trust_root permissions｜scaffold` 出，不手抄。
@@ -2168,18 +2362,11 @@ symlink，指向該帳號 `cache` 裡的一格。
 
 | executor | symlink | 目標 | token 葉檔 |
 |---|---|---|---|
-| `codex` | `~/.codex` | `~/cache/codex` | `auth.json` |
 | `agy` | `~/.gemini` | `~/cache/gemini` | `antigravity-cli/antigravity-oauth-token` |
 | `claude` | `~/.claude` | `~/cache/claude` | `.credentials.json` |
 
-> **為什麼不是 builder 那種單檔**（#686 實測，逐條可複驗）：
+> **為什麼不是單檔**（#686 實測，逐條可複驗）：
 >
-> - `codex` 在 `$CODEX_HOME` 底下建 `state_5.sqlite`／`logs_2.sqlite`／`sessions/`／
->   `skills/`／`plugins/`／`thread-writer-locks/`……唯讀時回
->   `Error: failed to initialize in-process app-server client: Read-only file system
->   (os error 30)`。把 cwd 換成可寫的 `/tmp` **症狀完全相同**；維持唯讀 cwd、只把
->   `CODEX_HOME` 指到可寫目錄則 **rc=0**。所以阻斷點是 `CODEX_HOME`，不是 cwd。
->   檔名帶版本序號 ⇒ **逐項列舉會在下一次 CLI 升版時無聲失效**。
 > - `agy` 往 `~/.gemini/antigravity-cli/` 寫 conversations SQLite、crashes、presence
 >   lock、builtin skills，並自解出一個 17 MB 的 `bin/webm_encoder`。
 > - `claude` 在 job 沙箱下 CLI rc=0 但回 `Not logged in · Please run /login`。
@@ -2189,65 +2376,62 @@ symlink，指向該帳號 `cache` 裡的一格。
 > 的事，該帳號今天就已經能做。symlink 本身放在 root-owned 的 HOME 裡，job 換不掉指向。
 >
 > **代價（R-6，明講）**：目標樹由 job 帳號擁有 ⇒ 樹裡的 token 葉檔**可被該帳號刪除或
-> 替換**（builder 的單檔形態擋得住「刪／換」，這裡擋不住）。影響面限於它自己的登入態。
-> 直接後果：**同一棵樹裡不得再放任何 root-owned 的 enforcement 檔**——
-> `reviewer-planner-codex-hooks` 因此仍是未決項（U-9），見
-> `permgen.deferred_run_dependencies()`。
+> 替換**。影響面限於它自己的登入態。直接後果：**同一棵樹裡不得再放任何 root-owned 的
+> enforcement 檔**——這條在 #698 之前只是註解，現在由
+> `permgen._assert_shape_follows_enforcement_rule()` 在 import 當下強制（宣告了
+> enforcement 檔就必須改走 sticky 樹）。
 
 **部署順序固定為四步，順序錯了 unit 會起不來或 executor 解不到路徑：**
 
 ```bash
-# 1️⃣ 骨架：建出三個目標（該帳號擁有 0700，落在既有的 cache 內）
+# 1️⃣ 骨架：建出兩個目標（該帳號擁有 0700，落在既有的 cache 內）
 python3 -m paulsha_cortex.trust_root scaffold four-way | grep '/cache/'
-#   期望三行：install -d -o cortex-reviewer-planner … /var/lib/cortex-reviewer-planner/cache/{codex,gemini,claude}
+#   期望兩行：install -d -o cortex-reviewer-planner … /var/lib/cortex-reviewer-planner/cache/{gemini,claude}
+#   ⚠️ #698 之後**不再有 `cache/codex` 那一行**——codex 改成 HOME 底下的 sticky 真目錄
+#      （4e-2b）。還看得到它 ⇒ 落檔的是舊版產生器的產物。
 sudo sh -e -c "$(python3 -m paulsha_cortex.trust_root scaffold four-way)"
 #   ⚠️ 目標**必須先存在**：對一條懸空 symlink 建目錄的 syscall 回 EEXIST（不是「建出
 #      目標」），executor 於是死在一個與權限完全無關的錯誤上。
 
 # 2️⃣ 遷移既有登入態（0818 手動部署留下的那一份）
-#    舊位置是**真目錄** /var/lib/cortex-reviewer-planner/.codex/，先把內容搬進目標，
-#    再把那個目錄清掉——第 3 步的 `ln -sfn` 不會覆蓋一個非空的真目錄。
+#    舊位置可能是**真目錄**，先把內容搬進目標，再把那個目錄清掉——第 3 步的
+#    `ln -sfn` 不會覆蓋一個非空的真目錄。
 sudo sh -c '
   d=/var/lib/cortex-reviewer-planner
-  if [ -d "$d/.codex" ] && [ ! -L "$d/.codex" ]; then
-    cp -a "$d/.codex/." "$d/cache/codex/" && rm -rf "$d/.codex"
-  fi
-  if [ -d "$d/.gemini" ] && [ ! -L "$d/.gemini" ]; then
-    cp -a "$d/.gemini/." "$d/cache/gemini/" && rm -rf "$d/.gemini"
-  fi
+  for n in gemini claude; do
+    case "$n" in gemini) dot=.gemini ;; claude) dot=.claude ;; esac
+    if [ -d "$d/$dot" ] && [ ! -L "$d/$dot" ]; then
+      cp -a "$d/$dot/." "$d/cache/$n/" && rm -rf "$d/$dot"
+    fi
+  done
   chown -R cortex-reviewer-planner:cortex-reviewer-planner "$d/cache"
 '
 #   ⚠️ 0818 的 `.gemini` 本來就是 symlink（指向同一個目標），上面的 `[ ! -L ]` 會跳過它。
-#   ⚠️ 舊 `.codex/hooks.json` 若存在，**不要**搬進去（那棵樹 job 可寫，root-owned 的
-#      hooks 在裡面擋不住替換 ⇒ 是名義上的 enforcement）。見 U-9。
 
 # 3️⃣ 落 symlink（由權限計畫出，不手打）
 python3 -m paulsha_cortex.trust_root permissions four-way --commands --paths \
   --operator-account "$USER" --external-reader-account none \
-  | grep -E 'reviewer-planner-(codex|agy|claude)-state' -A6 | grep -E '^\[ ! -e'
-#   期望六行（三格 × `ln -sfn` ＋ `chown -h`），全部帶
+  | grep -E 'reviewer-planner-(agy|claude)-state' -A6 | grep -E '^\[ ! -e'
+#   期望四行（兩格 × `ln -sfn` ＋ `chown -h`），全部帶
 #   `[ ! -e /var/lib/cortex-reviewer-planner ] || ` 守衛
 #   ——守衛掛在**父目錄**上：本方案沒有這個帳號時整段跳過（二分部署）。
-#   套用時走整份權限 script（第 2b 步），不要只挑這六行執行。
+#   套用時走整份權限 script（第 2b 步），不要只挑這四行執行。
 
-# 4️⃣ 放 token（三個 provider 各自的登入態，落點見上表）
-sudo install -o cortex-reviewer-planner -g cortex-reviewer-planner -m 0600 \
-  "$HOME/.codex/auth.json" /var/lib/cortex-reviewer-planner/cache/codex/auth.json
+# 4️⃣ 放 token（兩個 provider 各自的登入態，落點見上表）
 sudo install -D -o cortex-reviewer-planner -g cortex-reviewer-planner -m 0600 \
   "$HOME/.gemini/antigravity-cli/antigravity-oauth-token" \
   /var/lib/cortex-reviewer-planner/cache/gemini/antigravity-cli/antigravity-oauth-token
 sudo install -o cortex-reviewer-planner -g cortex-reviewer-planner -m 0600 \
   "$HOME/.claude/.credentials.json" \
   /var/lib/cortex-reviewer-planner/cache/claude/.credentials.json
-#   ⚠️ 來源路徑依 operator 自己的登入態而定，先 `ls` 確認；三份都是**同一個 provider
-#      帳號**的複本 ⇒ 這一步就是 U-4 追認的 R-3（該帳號被攻陷時三邊 token 一起失）。
+#   ⚠️ 來源路徑依 operator 自己的登入態而定，先 `ls` 確認；連同 4e-2b 的 codex 那一份，
+#      三份都是**同一個 provider 帳號**的複本 ⇒ 這就是 U-4 追認的 R-3。
 ```
 
-**成對前置：`PSC_REVIEWER_HOME` 必須同時宣告（第 5-5c 步）。** 三條 symlink 的路徑
-**全部以 `$HOME` 為根**，而模板模式下 shim 以 `os.execvpe` 整份換掉環境，unit 的
+**成對前置：`PSC_REVIEWER_HOME` 必須同時宣告（第 5-5c 步）。** 登入態路徑**全部以
+`$HOME` 為根**，而模板模式下 shim 以 `os.execvpe` 整份換掉環境，unit 的
 `Environment=HOME=` 到不了模型（#686 實機更正）。沒有它，本節做得再對，job 內一條也
-解不到——而症狀（`$HOME is not defined`／`Not logged in`）與「憑證沒放好」長得一模
-一樣。產生器出的值：
+解不到——而症狀（`$HOME is not defined`／`Not logged in`）與「憑證沒放好」長得一模一樣。
 
 ```bash
 python3 -m paulsha_cortex.trust_root unit four-way --review-job | grep PSC_REVIEWER_HOME
@@ -2256,17 +2440,19 @@ python3 -m paulsha_cortex.trust_root unit four-way --review-job | grep PSC_REVIE
 
 ```bash
 # ✅ 驗證 1：形狀（symlink root-owned、目標該帳號擁有）
-ls -ld /var/lib/cortex-reviewer-planner/.{codex,gemini,claude}
-#   期望三行：lrwxrwxrwx root root … -> /var/lib/cortex-reviewer-planner/cache/{codex,gemini,claude}
-ls -ld /var/lib/cortex-reviewer-planner/cache/{codex,gemini,claude}
-#   期望三行：drwx------ cortex-reviewer-planner cortex-reviewer-planner
+ls -ld /var/lib/cortex-reviewer-planner/.{gemini,claude}
+#   期望兩行：lrwxrwxrwx root root … -> /var/lib/cortex-reviewer-planner/cache/{gemini,claude}
+ls -ld /var/lib/cortex-reviewer-planner/cache/{gemini,claude}
+#   期望兩行：drwx------ cortex-reviewer-planner cortex-reviewer-planner
 
-# ✅ 驗證 2：**零新增可寫面**——unit 的 RWP 逐字不變
+# ✅ 驗證 2：這兩格**零新增可寫面**——它們不得在 RWP 上多出任何一條
 python3 -m paulsha_cortex.trust_root unit four-way --review-job | grep '^ReadWritePaths='
-#   期望**恰好**：ReadWritePaths=/var/lib/cortex-reviewer-planner/cache
-#                 ReadWritePaths=/var/lib/cortex/coordinator/review-verdicts
-#   ⛔ 多出任何一條含 `.codex`／`.gemini`／`.claude` 的路徑 ⇒ 有人把資產的 writer 面
-#      改成 job principal 了，回去看登記表，**不要**就地改 unit。
+#   期望**恰好三條**：
+#     ReadWritePaths=/var/lib/cortex-reviewer-planner/.codex        ← #698 的 sticky 樹
+#     ReadWritePaths=/var/lib/cortex-reviewer-planner/cache
+#     ReadWritePaths=/var/lib/cortex/coordinator/review-verdicts
+#   ⛔ 多出任何一條含 `.gemini`／`.claude` 的路徑 ⇒ 有人把資產的 writer 面改成 job
+#      principal 了，回去看登記表，**不要**就地改 unit。
 
 # ✅ 驗證 3（跨 UID，**在真實加固面下**）：換不掉指向、但寫得進樹
 psc_run_under cortex-reviewer-job /bin/sh -c \
@@ -2280,10 +2466,7 @@ psc_run_under cortex-reviewer-job /bin/sh -c \
 #      的 unit** 全量導出。**不得**自行組 `--property=`、**不得**自帶 `--setenv=PATH=`
 #      ——本 repo 兩個方向的事故各兩次（#638／#657 假綠；#673 body 與 repro 假紅）。
 
-# ✅ 驗證 4：三個 executor 在該 unit 下**真的跑得起來**（這一格才是驗收）
-psc_run_under cortex-reviewer-job-jit /opt/cortex/toolchain/bin/codex exec --json \
-  'Return only this JSON object and do not call tools: {"capability":"cortex-planning-json"}'
-#   期望：rc=0。**#686 當時這一格是紅的**（`Read-only file system`）——本節做完必須翻綠。
+# ✅ 驗證 4：兩個 executor 在該 unit 下**真的跑得起來**（codex 那格見 4e-2b 驗證 4）
 psc_run_under cortex-reviewer-job /opt/cortex/toolchain/bin/claude --version
 psc_run_under cortex-reviewer-job /bin/sh -c \
   '/opt/cortex/toolchain/bin/claude -p "hi" --output-format json --tools ""'
@@ -2291,14 +2474,12 @@ psc_run_under cortex-reviewer-job /bin/sh -c \
 psc_run_under cortex-reviewer-job /opt/cortex/toolchain/bin/agy \
   --print 'Return only this JSON object and do not call tools: {"capability":"cortex-planning-json","executor":"agy","model":"gemini-3.1-pro-high"}' \
   --mode plan --sandbox --model gemini-3.1-pro-high
-#   期望：rc=0、輸出逐位元等於 expected（0818 與 #686 兩次實測皆如此）。
+#   期望：rc=0、輸出逐位元等於 expected（0818 三次實測皆如此，最近一次在 #698）。
 ```
 
-**回滾**：`sudo rm -f /var/lib/cortex-reviewer-planner/.{codex,gemini,claude}` ＋
-`sudo rm -rf /var/lib/cortex-reviewer-planner/cache/{codex,gemini,claude}`。
+**回滾**：`sudo rm -f /var/lib/cortex-reviewer-planner/.{gemini,claude}` ＋
+`sudo rm -rf /var/lib/cortex-reviewer-planner/cache/{gemini,claude}`。
 （回滾之後降權 planning 與 reviewer job 都會退回「沒有登入態」的狀態，不是壞掉。）
-
----
 
 #### 4e-3. planning 的**唯讀 scratch**（#686／#672 U-2 裁決）
 
@@ -4371,22 +4552,43 @@ exec /opt/cortex/venv/bin/python -c "from paulsha_cortex.config import paths; pr
 | **5** | **privilege-boundary（A+B 新增）** | **cortex-manager**（授權帳號自身）＋三個 headless | **✅ 新增** |
 
 > **0818 兩個 subject 各跑一次的結果（族 1–4，皆在完整模板 unit 加固面下，
-> 加固面由 `unit-replica` 全量導出 38 條 property）**：
+> 加固面由 `unit-replica` 全量導出 38 條 property；`#698` 落地後為 40 條——新增的是
+> 那條巢狀 `ReadOnlyPaths=`）**：
 >
 > | | `cortex-builder` | `cortex-reviewer-planner` |
 > |---|---|---|
-> | denied（OK） | 51 | 52 |
-> | **SUCCEEDED（FAIL）** | 1（T1.3，假失敗，本次已修） | **2（T1.3 ＋ T3.9）** |
+> | denied（OK），`#698` 前 | 51 | 52 |
+> | **SUCCEEDED（FAIL）**，`#698` 前 | 1（T1.3，假失敗，已修） | **2（T1.3 ＋ T3.9）** |
+> | denied（OK），**`#698` 後** | **54** | **56** |
+> | **SUCCEEDED（FAIL）**，**`#698` 後** | **0** | **0** |
 >
-> - **T1.3 兩個 subject 都 FAIL ⇒ 它測錯東西**，本次已改（見下方該行的註解）。
+> （`#698` 後的 denied 數多 2，是因為 T3.9 從 1 條攻擊擴成 3 條——`sticky` 關的是
+> **三個動詞**，只驗「改內容」會漏掉 unlink／rename 那兩條真正靠 sticky 擋的。）
+>
+> - **T1.3 兩個 subject 都 FAIL ⇒ 它測錯東西**，已改（見下方該行的註解）。
 >   「兩個身分得到同一個結果」本身就是「這條與身分無關」的證據——**下次再看到某條
 >   在所有 subject 上同時失敗，先懷疑斷言，不要先懷疑邊界。**
-> - **T3.9 只有 `reviewer-planner` FAIL，是真的**：`#698`。成因是 `#685` 把該帳號的
->   `~/.codex` 改成指向 job-owned `cache/codex` 的 symlink（`#686` 實測 codex 需要
->   `$CODEX_HOME` **整棵**可寫才跑得起來），代價是該帳號能植入 `hooks.json`——
->   而 codex hooks **會執行命令** ⇒ **跨 job 持久化**。`builder` 因為 `.codex` 仍是
->   root-owned 目錄而守得住，**但它一旦也要在降權 unit 下跑 codex 就會撞同一條**。
->   在 `#698` 裁決之前，這一行的 `SUCCEEDED (FAIL)` 是**已知且已追蹤**的，不是新事故。
+> - **T3.9 曾經只有 `reviewer-planner` FAIL，而且是真的**：`#698`。成因是 `#685` 把該
+>   帳號的 `~/.codex` 改成指向 job-owned `cache/codex` 的 symlink（`#686` 實測 codex
+>   需要 `$CODEX_HOME` **整棵**可寫才跑得起來），代價是該帳號能植入 `hooks.json`——
+>   而 codex hooks **會執行命令** ⇒ **跨 job 持久化**。
+>   **`#698` 已修復並實測，兩個 subject 現在都是 `denied (OK) rc=2`**：
+>
+>   ```
+>   cortex-builder          :: T3.9 改 codex hooks   :: denied (OK) rc=2
+>   cortex-builder          :: T3.9 刪掉 codex hooks :: denied (OK) rc=1
+>   cortex-builder          :: T3.9 改名 codex hooks :: denied (OK) rc=1
+>   cortex-reviewer-planner :: T3.9 改 codex hooks   :: denied (OK) rc=2
+>   cortex-reviewer-planner :: T3.9 刪掉 codex hooks :: denied (OK) rc=1
+>   cortex-reviewer-planner :: T3.9 改名 codex hooks :: denied (OK) rc=1
+>   ```
+>
+>   修法是 operator 裁決的方案 A（sticky ＋ root-owned `hooks.json`），**兩個帳號的
+>   形狀由同一條規則導出**——builder 一併遷移，不留「等著爆」的差異。遷移步驟與
+>   兩層的逐條驗證在第 4e-2b 步。
+> - ⚠️ **T3.9 的前提是 `hooks.json` 存在**：sticky 管的是「刪／改名別人的檔」，不管
+>   「建一個還不存在的檔」。那個檔缺席時本項會以「建得出新檔」翻紅——**那是正確的
+>   紅字**，處置是回第 4e-2b 步把它種回去，不是把測項改掉。
 
 ### 8a. 攻擊腳本（族 1–4，以模型 job 身分執行）
 
@@ -4407,7 +4609,11 @@ t() { printf '%s :: ' "$1"; shift; if "$@" >/dev/null 2>&1; then echo "!! SUCCEE
 #       不可寫才是守的東西」有實測背書，而不是靠註解宣稱。
 d() { printf '%s :: ' "$1"; shift; if "$@" >/dev/null 2>&1; then echo "readable (BY DESIGN)"; else echo "!! 讀不到——與登記表 rationale 不符，查"; fi; }
 # need() = 目標檔必須先存在，否則「刪不掉／讀不到」測的是「檔不存在」而非「被拒」。
-need() { [ -e "$1" ] || printf '!! 前置缺失：%s 不存在——對它的刪除／截斷／讀取測項會是假綠，請先由 operator 以 cortex-manager 身分預建\n' "$1"; }
+# ⚠️ `need()` 用的是 `[ -e ]`，而它在**看不到**（路徑上某層沒有 traverse 權）時同樣
+#    為假。`cortex-reviewer-planner` 對 `<A>/monitor/` 沒有 traverse ⇒ 它必然印出
+#    這一行，而那不是「檔不存在」。判讀時先以 `cortex-manager` 身分 `ls -l` 該路徑
+#    確認：檔真的在 ⇒ 這是身分造成的，該 subject 對應的測項本來就該是 denied。
+need() { [ -e "$1" ] || printf '!! 前置缺失：%s 不存在**或本身分看不到**——對它的刪除／截斷／讀取測項可能是假綠，請以 cortex-manager 身分確認該檔是否存在\n' "$1"; }
 A=/var/lib/cortex
 # #657：spool 是 per-principal 的；R9 攻擊腳本以模型 job 身分執行，看的是自己那格。
 SPOOL=$A/coordinator/job-specs/builder
@@ -4513,7 +4719,13 @@ t "T3.3 改 Manager unit"           sh -c "printf x >> /etc/systemd/system/corte
 t "T3.4 改 EnvironmentFile"        sh -c "printf 'PSC_COORDINATOR_ROOT=/tmp/evil' >> /opt/cortex/etc/cortex-manager.env"
 t "T3.5 刪 EnvironmentFile"        rm -f /opt/cortex/etc/cortex-manager.env
 t "T3.6 改 venv launcher"          sh -c "printf x >> /opt/cortex/venv/bin/cortex"
+# ⛔ #698：這一條的前提是那個檔**存在**。sticky bit 管的是「刪／改名別人的檔」，
+#    **不管「建一個還不存在的檔」**——檔不在時本項會以「建得出新檔」翻紅，那是正確
+#    的紅字（該帳號當下真的植得進 hooks），處置是回 runbook 第 4e-2b 步把它種回去。
+need "$HOME/.codex/hooks.json"
 t "T3.9 改 codex hooks"            sh -c "printf x > $HOME/.codex/hooks.json"
+t "T3.9 刪掉 codex hooks"          rm "$HOME/.codex/hooks.json"
+t "T3.9 改名 codex hooks"          mv "$HOME/.codex/hooks.json" "$HOME/.codex/hooks.json.bak"
 t "T3.9 換掉 ~/.codex 目錄"        sh -c "mv $HOME/.codex $HOME/.codex.bak"
 
 echo "===== 族 4 行程間路徑 ====="

--- a/docs/superpowers/specs/planner-job-downgrade-spec.md
+++ b/docs/superpowers/specs/planner-job-downgrade-spec.md
@@ -240,7 +240,8 @@ planner 上 job 之後不需要任何剖面面的前置修正。
 1. 實機 `cortex-reviewer-job@.service` 的 `ReadWritePaths=` 只有
    `/var/lib/cortex-reviewer-planner/cache` 與 `/var/lib/cortex/coordinator/review-verdicts`
    ——**不含 `.codex/auth.json`**。該 unit 自己的註解花了七行描述這條路徑該怎麼掛，
-   但登記表只有 `builder-executor-credential` 一列，所以產生器產不出它。淨效果：
+   但登記表只有 `builder-executor-credential` 一列（#698 之後該資產叫
+   `builder-codex-state`，且兩個帳號**共用同一列憑證表**），所以產生器產不出它。淨效果：
    `ProtectSystem=strict` 下憑證**讀得到、改不了**，token 過期那天靜默 refresh 失敗。
    這正是 `permgen.deferred_run_dependencies()` 第一項逐字描述的逾期項。
 2. `.gemini → cache/gemini` 這個 root-owned symlink 是一條**手動落位、登記表不知道**

--- a/docs/superpowers/specs/trust-root-isolation-spec.md
+++ b/docs/superpowers/specs/trust-root-isolation-spec.md
@@ -520,7 +520,16 @@ gitconfig 變成執行期可變狀態。
 Manager 從那個 **bundle 檔**（不是 repo）fetch。Manager 全程不碰 builder 的樹，讀的又是
 一個普通檔案，dubious-ownership 與 traverse 兩個問題同時消失。
 
-#### executor 執行面：toolchain 與 per-account 憑證（#640 裁決；登記表資產 `executor-toolchain`／`builder-executor-credential`）
+#### executor 執行面：toolchain 與 per-account 憑證（#640 裁決；登記表資產 `executor-toolchain`／`builder-codex-state`）
+
+> **#698 更正**：本節描述的憑證形狀是 #640 的 `IN_PLACE_FILE`（單檔，資產 id 當時叫
+> `builder-executor-credential`）。0818 的 R9 T3.9 實測攻破了它的姊妹形態
+> （`HOME_REDIRECT_TREE`，見 #685），operator 裁決改採 **sticky 樹**並**涵蓋兩個帳號**：
+> `<job HOME>/.codex` 是 root-owned ＋ sticky（`1755`）的真目錄，job 以具名 access ACL
+> 取得整棵寫入權，樹裡放一個 root-owned 的 `hooks.json`。下文「目錄 root-owned `0755`
+> ⇒ job 建不了新檔／刪不掉」那一段因此**只在 #698 之前為真**——現在守 `hooks.json` 的
+> 是 sticky（unlink／rename）＋ 檔案自己的 mode（內容）＋ unit 的巢狀 `ReadOnlyPaths=`。
+> 逐條見 `permgen.CredentialShape.HOME_STICKY_TREE` 與 runbook 第 4e-2b 步。
 
 `ProtectHome=yes` 讓 job 帳號看不到 `/home`，而四個模型 executor（`codex`／`claude`／
 `copilot`／`agy`）原本**全部**落在 operator 的 HOME 底下（nvm 樹與 `~/.local/bin`）。

--- a/paulsha_cortex/coordinator/planning_probe_cache.py
+++ b/paulsha_cortex/coordinator/planning_probe_cache.py
@@ -254,9 +254,16 @@ def _credential_path(mode: str, env: Mapping[str, str], executor: str) -> str:
     上恆定），因此快取照常運作；而它一旦被登記進表，指紋就變、快取自動失效——與
     「PATH 未宣告」那一格是同一條原則：**取不到答案本身也是一個會變的答案**。
 
-    取的是 `credential_token_path_of()`（**token 葉檔**）而不是登記表資產那個節點：
-    `HOME_REDIRECT_TREE` 的資產是一條 symlink，`stat` 它只看得到目標目錄的 mtime，而
-    token 就地覆寫時目錄 mtime 不變 ⇒ 「憑證換了」偵測不到。
+    取的是 **token 葉檔**而不是登記表資產那個節點，兩者在三種形狀下都可能不同：
+    `HOME_REDIRECT_TREE` 的資產是一條 symlink、`HOME_STICKY_TREE`（#698）的資產是一棵
+    目錄——`stat` 它們只看得到目錄的 mtime，而 token 就地覆寫時目錄 mtime 不變 ⇒
+    「憑證換了」偵測不到。
+
+    **#698 修掉了本函式的一份複本**：direct 那一支原本自己拼 `relpath + token_leaf`，
+    而 #698 讓 codex 那一列的樹與葉**都**由 `executor_credential_relpath` 的 head／tail
+    導出（`relpath is None`／`token_leaf` 留空）。那份複本因此拼出目錄本身，指紋退化成
+    「stat `~/.codex`」——refresh 偵測不到。改走 `credential_token_relpath_of()` 這個
+    唯一來源之後，本模組同樣**不知道**也不需要知道三種形狀的差別。
     """
 
     from ..trust_root import permgen
@@ -271,10 +278,7 @@ def _credential_path(mode: str, env: Mapping[str, str], executor: str) -> str:
         # 落點」套到 Manager 的 HOME——那正是 direct 模式實際會解到的路徑。
         prefix = layout.credential_prefix_of(layout.reviewer_planner_account)
         credential = permgen.credential_for(prefix, executor)
-        relpath = layout.credential_relpath_of(credential)
-        if credential.token_leaf:
-            relpath = f"{relpath}/{credential.token_leaf}"
-        return os.path.join(home, relpath)
+        return os.path.join(home, layout.credential_token_relpath_of(credential))
     return layout.credential_token_path_of(layout.reviewer_planner_account, executor)
 
 

--- a/paulsha_cortex/trust_root/permgen.py
+++ b/paulsha_cortex/trust_root/permgen.py
@@ -670,7 +670,7 @@ TOOLCHAIN_PROGRAMS: tuple[ToolchainProgram, ...] = EXECUTOR_TOOLS + SERVICE_TOOL
 # :data:`IN_PLACE_CONTENT_WRITE_ASSETS`／unit 的 `ReadWritePaths` 全部由它機械導出，
 # 加一格不必改產生器——這正是 #640 的 note 當年承諾、但因為只有一個純量而做不到的事。
 #
-# ## 為什麼形狀有兩種（#686 實測，design 未預期）
+# ## 為什麼形狀有三種（#686 實測，design 未預期；#698 補上第三種）
 #
 # design 假設所有 executor 的登入態都是**單檔**（codex 的 `auth.json`），因此 #640 裁決
 # (b) 的整套性質（檔 job-owned 0600／父目錄 root-owned ⇒ 能改內容、不能增刪換）對它成立。
@@ -686,10 +686,28 @@ TOOLCHAIN_PROGRAMS: tuple[ToolchainProgram, ...] = EXECUTOR_TOOLS + SERVICE_TOOL
 #   - `claude` 在 job 沙箱下 CLI 走得完整條（rc=0），但回 `Not logged in`——它需要
 #     `~/.claude` 底下的登入態，同樣是一棵它自己會寫的樹。
 #
-# 因此表上有兩種形狀，見 :class:`CredentialShape`。**兩種形狀並存不是過渡態**：builder
-# 的 codex 至今是 `IN_PLACE_FILE`（已部署、有實測、有 runbook 反向驗證），本票不動它；
-# reviewer/planner 三個 executor 全是 `HOME_REDIRECT_TREE`。「同一個 executor 在不同帳號
-# 上可以是不同形狀」正是 U-5 要求 per-(account, executor) 而不是 per-executor 的理由。
+# 因此表上有多種形狀，見 :class:`CredentialShape`。
+#
+# ## #698：形狀不再由帳號挑，而是由**一條規則**導出
+#
+# #685 落地後表上是「builder×codex＝`IN_PLACE_FILE`、reviewer-planner×codex＝
+# `HOME_REDIRECT_TREE`」——同一個 executor 在兩個帳號上兩種形狀。0818 的 R9 實測
+# （#698）證明那個差異不是設計，是**一個尚未爆的洞**：`HOME_REDIRECT_TREE` 的樹由 job
+# 帳號擁有，該帳號因此**成功植入了 `hooks.json`**（R9 T3.9 `!! SUCCEEDED`）。codex hooks
+# **會執行命令** ⇒ 跨 job 持久化 ⇒ 四分隔離「每個 job 一次性」的前提在該帳號上不成立。
+# builder 當天守得住只是因為它的 `.codex` 還沒遷成可寫樹；一旦要讓它在降權 unit 下真的
+# 跑 codex，同一個洞原封不動出現。
+#
+# operator 裁決（#698，採方案 A）：**目錄 sticky bit ＋ `hooks.json` 由 root 擁有**。
+# 落到本表上就是 :data:`EXECUTOR_ENFORCEMENT_LEAVES` 那一條規則：
+#
+#   **某個 executor 的狀態樹裡必須住著一個 root-owned 的 enforcement 檔 ⇒ 凡持有它
+#   登入態的帳號，那一格一律是 `HOME_STICKY_TREE`。**
+#
+# 規則由 :func:`_assert_shape_follows_enforcement_rule` 在 **import 當下**強制（不是靠
+# 註解也不是靠 review）：把某一格改回別的形狀、或新增第五個帳號時漏改，模組載入就炸。
+# 「同一個 executor 在不同帳號上可以是不同形狀」這句話因此仍然為真（agy／claude 只在
+# 一個帳號上），但**不再能對同一個 executor 成立**——那正是 #698 要根除的差異。
 # ---------------------------------------------------------------------------
 
 class CredentialShape(Enum):
@@ -721,9 +739,44 @@ class CredentialShape(Enum):
     #: 代價（明講，見 CHANGELOG 的 R-6）：這棵樹由 job 帳號擁有，因此樹裡的憑證葉檔
     #: （`auth.json`／`.credentials.json`）**可被該 job 刪除或替換**——它換來的是
     #: 「codex／claude 能不能起得來」。影響面限於該帳號自己的登入態；同目錄下**不得**
-    #: 再放任何 root-owned 的 enforcement 檔（見 `reviewer-planner-codex-hooks` 那筆
-    #: deferred 與 U-9）。
+    #: 再放任何 root-owned 的 enforcement 檔——這條在 #698 之前只是註解，現在由
+    #: :func:`_assert_shape_follows_enforcement_rule` 在 import 當下強制。
     HOME_REDIRECT_TREE = "home-redirect-tree"
+
+    #: **HOME 底下一棵 root-owned ＋ sticky bit 的真目錄**，job 帳號以一條 `rwx`
+    #: **access** ACL 取得整棵的寫入權（#698 operator 裁決＝方案 A）。
+    #:
+    #: 它同時買到 `HOME_REDIRECT_TREE` 與 `IN_PLACE_FILE` 各買到一半的那兩件事，
+    #: 而在 #685 的形狀下兩者互斥：
+    #:
+    #: 1. **executor 起得來**：整棵可寫。#686 實測 codex 需要 `$CODEX_HOME` 整棵可寫
+    #:    （`state_5.sqlite`／`sessions/`／`skills/`／`plugins/`…，檔名帶版本序號，
+    #:    逐項列舉會在下次 CLI 升版時無聲失效），因此放行的是整棵樹而不是清單。
+    #: 2. **樹裡放得住一個 job 動不了的 root-owned 檔**：sticky bit（`chmod +t`）的
+    #:    POSIX 語意是「目錄可寫，但只有**檔案 owner／目錄 owner／root** 刪得掉或
+    #:    改得掉名字」。`hooks.json` 屬 root、目錄也屬 root ⇒ job 既 **unlink 不掉**、
+    #:    也 **rename 不掉**；而它自己的 mode（root:root 0644）讓 job 落在 `other` 位
+    #:    ⇒ 連**內容都改不了**。三個動詞同時關上，缺一條就等於沒關。
+    #:
+    #: **為什麼是具名 ACL 而不是 group 寫入位**：spec §R2 明定「group 寫入權 MUST
+    #: 移除」，而本產生器的安全網（見 :func:`build_entry` 尾端）會機械地拿掉它。
+    #: 具名 ACL 是這套權限模型既有的跨帳號授權手段（`AclEntry`），不必為本形狀鑿一個
+    #: §R2 的洞。
+    #:
+    #: ⚠️ **只設 access ACL，絕不設 default ACL**。default ACL 決定的是「**之後**在這個
+    #: 目錄裡新建的物件」的初值——包含 root 日後重放一次 `hooks.json` 的那一次。設了
+    #: default ACL 等於把 `hooks.json` 自動交還給 job，整個形狀當場歸零。
+    #: :meth:`PermissionEntry.commands` 因此對 sticky 目錄**不**補那條 default ACL。
+    #:
+    #: ⚠️ **enforcement 檔必須先存在**，否則 sticky 什麼也擋不住：sticky 管的是「刪／
+    #: 改名別人的檔」，**不管「建一個還不存在的檔」**。因此本形狀的每一格都必須宣告
+    #: `enforcement_leaf`，且部署／遷移步驟要先把它以 root 身分放進去（runbook 第
+    #: 4e-2b 步）。少了那一步，R9 T3.9 會直接以「建得出新檔」翻紅。
+    #:
+    #: 代價（與 `HOME_REDIRECT_TREE` 相同、不多不少）：樹由 job 寫，因此樹裡的**憑證**
+    #: 葉檔仍可被該 job 刪除或替換（R-6）。sticky 保護的是 root-owned 的那些檔，而
+    #: token 葉檔刻意是 job-owned 的——它必須 refresh 得回來。
+    HOME_STICKY_TREE = "home-sticky-tree"
 
 
 @dataclass(frozen=True)
@@ -743,16 +796,48 @@ class ExecutorCredential:
     cache_target: str | None = None
     #: 這一格裡真正承載 token 的葉檔（相對於 `relpath`）。只進註解與 runbook，不另立資產
     #: ——它落在 job-owned 樹裡，權限由 unit 的 `UMask=0077` 決定，再登記一次是第二份真相。
+    #: `relpath is None` 的那一列留空：它的樹與葉**都**由
+    #: :attr:`PathLayout.executor_credential_relpath` 這個部署決定的 head／tail 導出。
     token_leaf: str = ""
+    #: **這棵樹裡必須住著的 root-owned enforcement 檔**（相對於 `relpath`），例如 codex
+    #: 的 `hooks.json`（#698）。有值 ⇒ 本格的形狀**必須**是 `HOME_STICKY_TREE`，且它會
+    #: 機械地長出一個登記表資產（`<帳號前綴>-<enforcement_asset_suffix>`）。
+    #: 空字串＝這個 executor 的狀態樹裡沒有 enforcement 檔（agy／claude）。
+    enforcement_leaf: str = ""
+    #: 上一欄那個資產 id 的後綴。宣告 `enforcement_leaf` 時必填。
+    enforcement_asset_suffix: str = ""
     note: str = ""
 
     def __post_init__(self) -> None:
         if self.shape is CredentialShape.HOME_REDIRECT_TREE and not self.cache_target:
             raise ValueError(f"{self.executor}：HOME_REDIRECT_TREE 必須宣告 cache_target")
+        if self.shape is CredentialShape.HOME_STICKY_TREE and self.cache_target:
+            raise ValueError(
+                f"{self.executor}：HOME_STICKY_TREE 是 HOME 底下的**真目錄**，沒有 "
+                "cache_target。宣告一個目標會讓 `symlink_targets()` 把它當成 symlink，"
+                "而 `ln -sfn` 對真目錄會把連結建到目錄**裡面**（#698 的部署陷阱）。"
+            )
+        # #698：兩個方向都擋。有 enforcement 檔卻不是 sticky ⇒ 那個檔擋不住替換
+        # （正是 R9 T3.9 攻破 reviewer-planner 的形態）；是 sticky 卻沒有 enforcement
+        # 檔 ⇒ 這棵樹沒有理由付出 root-owned 目錄的代價，形狀選錯了。
+        if bool(self.enforcement_leaf) != (self.shape is CredentialShape.HOME_STICKY_TREE):
+            raise ValueError(
+                f"{self.executor}：`enforcement_leaf` 與 HOME_STICKY_TREE 必須同時成立"
+                f"（現況 shape={self.shape.value}, enforcement_leaf={self.enforcement_leaf!r}）。"
+                "sticky bit 的全部價值就是「樹裡放得住一個 job 動不了的 root-owned 檔」"
+                "——沒有那個檔就不需要它，有那個檔就非它不可（#698）。"
+            )
+        if self.enforcement_leaf and not self.enforcement_asset_suffix:
+            raise ValueError(
+                f"{self.executor}：宣告 enforcement_leaf 就必須一併宣告 "
+                "enforcement_asset_suffix——那個檔要進登記表才管得住。"
+            )
         if self.relpath is not None:
             _validate_home_relpath(self.relpath)
         if self.cache_target is not None:
             _validate_home_relpath(self.cache_target)
+        if self.enforcement_leaf:
+            _validate_home_relpath(self.enforcement_leaf)
 
 
 #: `relpath is None` 的那一列所對應的 executor。**它與
@@ -761,24 +846,29 @@ class ExecutorCredential:
 #: 就是第二份真相。因此本表對它留 `None`，由 layout 供給。
 PRIMARY_CREDENTIAL_EXECUTOR = "codex"
 
+#: **executor → 它的狀態樹裡必須住著的 root-owned enforcement 檔**（#698）。
+#:
+#: 這一格就是 #698 的那條規則的**輸入**：有值的 executor，在**每一個**持有它登入態的
+#: 帳號上都必須是 :attr:`CredentialShape.HOME_STICKY_TREE`
+#: （由 :func:`_assert_shape_follows_enforcement_rule` 在 import 當下強制）。
+#:
+#: 只有 codex 有一格，而那不是偏好問題：codex hooks **會執行命令**，因此「誰能改
+#: `hooks.json`」直接決定「上一個 job 能不能為下一個 job 埋伏」。agy／claude 的狀態樹
+#: 裡沒有同性質的檔，因此它們留在 `HOME_REDIRECT_TREE`——**同一條規則**的另一邊。
+#: 哪天量到 `claude` 也有一個會執行命令的 root-owned 設定檔，往這裡加一列即可，兩個
+#: 帳號的形狀會一起跟著變。
+EXECUTOR_ENFORCEMENT_LEAVES: Mapping[str, str] = MappingProxyType({
+    "codex": "hooks.json",
+})
+
 #: **executor 軸**。順序＝資產在登記表裡的出現順序。
 EXECUTOR_CREDENTIALS: tuple[ExecutorCredential, ...] = (
     ExecutorCredential(
-        "codex", CredentialShape.IN_PLACE_FILE,
-        relpath=None, asset_suffix="executor-credential",
+        "codex", CredentialShape.HOME_STICKY_TREE,
+        relpath=None, asset_suffix="codex-state",
         token_leaf="",
-        note=(
-            "#640 裁決 (b) 的原形態：單檔 `~/.codex/auth.json`。**只有 builder 還是這個"
-            "形狀**——#686 實測 codex 需要 `$CODEX_HOME` 整個目錄可寫，因此凡是要在降權"
-            "模板 unit 下**真的跑起來**的帳號都必須改走 `codex-state`（下一列）。"
-            "builder 維持原形態是因為那份部署已存在、有 runbook 第 4e-2 步的反向驗證，"
-            "改它同時會賣掉 `codex-hooks` 的 enforcement（見 U-9），屬 operator 裁決。"
-        ),
-    ),
-    ExecutorCredential(
-        "codex", CredentialShape.HOME_REDIRECT_TREE,
-        relpath=".codex", asset_suffix="codex-state",
-        cache_target="codex", token_leaf="auth.json",
+        enforcement_leaf=EXECUTOR_ENFORCEMENT_LEAVES["codex"],
+        enforcement_asset_suffix="codex-hooks",
         note=(
             "codex 的 `$CODEX_HOME` 整棵（預設就是 `~/.codex`）。#686 在完整 reviewer "
             "unit 沙箱下實測：唯讀時 `failed to initialize in-process app-server client: "
@@ -786,7 +876,16 @@ EXECUTOR_CREDENTIALS: tuple[ExecutorCredential, ...] = (
             "即 rc=0、輸出正確。底下會出現 `state_5.sqlite`／`logs_2.sqlite`／"
             "`queue_1.sqlite`／`memories_1.sqlite`／`sessions/`／`skills/`／`plugins/`／"
             "`thread-writer-locks/`／`models_cache.json`／`installation_id`——**檔名帶版本"
-            "序號**，逐項列舉會在下一次 CLI 升版時無聲失效，因此放行的是整棵樹而不是清單。"
+            "序號**，逐項列舉會在下一次 CLI 升版時無聲失效，因此放行的是整棵樹而不是清單。\n"
+            "**#698 起這一列是 `HOME_STICKY_TREE`，而且 builder 與 reviewer-planner 共用"
+            "它**（表上因此只剩一列 codex）。#685 當時是兩列：builder 的 `IN_PLACE_FILE`"
+            "（codex 在降權 unit 下**起不來**）＋ reviewer-planner 的 `HOME_REDIRECT_TREE`"
+            "（codex 起得來，但 job **植得進 `hooks.json`** ⇒ 跨 job 持久化，R9 T3.9 實測"
+            "攻破）。sticky 樹兩件事一起買到：整棵可寫 ⇒ codex 起得來；目錄 root-owned ＋"
+            "sticky ⇒ root 的 `hooks.json` 刪不掉、改不掉名字、也改不了內容。\n"
+            "`relpath=None`：樹與 token 葉檔**都**由 `PathLayout.executor_credential_relpath`"
+            "（部署決定，預設 `.codex/auth.json`）的 head／tail 導出——換 primary executor "
+            "時仍然只改那一個值，而且樹與葉不可能各改一半。"
         ),
     ),
     ExecutorCredential(
@@ -826,13 +925,15 @@ EXECUTOR_CREDENTIALS: tuple[ExecutorCredential, ...] = (
 #: **明文接受的有界殘餘風險**，不另拆帳號。它在後續任何「planner 攻擊面」討論中**不得**
 #: 被當成未知——U-4 的裁決逐字如此。
 #:
-#: **`builder` 只有一格**，且刻意維持 `IN_PLACE_FILE`：builder 不做 planning，不需要
-#: 異質性；擴大它的 provider 曝險面買不到任何東西。
+#: **`builder` 只有一格**：builder 不做 planning，不需要異質性；擴大它的 provider
+#: 曝險面買不到任何東西。但那一格的**形狀**與 reviewer-planner 的 codex 逐字相同
+#: （#698）——形狀不是 per-account 的偏好，是 :data:`EXECUTOR_ENFORCEMENT_LEAVES`
+#: 那條規則的結果。
 CREDENTIALED_ACCOUNTS: Mapping[str, tuple[tuple[str, CredentialShape], ...]] = (
     MappingProxyType({
-        "builder": (("codex", CredentialShape.IN_PLACE_FILE),),
+        "builder": (("codex", CredentialShape.HOME_STICKY_TREE),),
         "reviewer-planner": (
-            ("codex", CredentialShape.HOME_REDIRECT_TREE),
+            ("codex", CredentialShape.HOME_STICKY_TREE),
             ("agy", CredentialShape.HOME_REDIRECT_TREE),
             ("claude", CredentialShape.HOME_REDIRECT_TREE),
         ),
@@ -872,12 +973,32 @@ def credential_rows() -> tuple[tuple[str, ExecutorCredential], ...]:
 
 def credential_asset_ids(shape: CredentialShape | None = None) -> tuple[str, ...]:
     """本表產生的登記表資產 id（可依形狀過濾）。`_FILE_ASSET_IDS`／
-    :data:`IN_PLACE_CONTENT_WRITE_ASSETS`／:data:`SYMLINK_ASSETS` 全部由它導出。"""
+    :data:`IN_PLACE_CONTENT_WRITE_ASSETS`／:data:`SYMLINK_ASSETS`／
+    :data:`STICKY_JOB_WRITABLE_DIR_ASSETS` 全部由它導出。"""
     return tuple(
         credential_asset_id(prefix, cred)
         for prefix, cred in credential_rows()
         if shape is None or cred.shape is shape
     )
+
+
+def enforcement_asset_id(prefix: str, credential: ExecutorCredential) -> str:
+    """該格 enforcement 檔的登記表資產 id（`<帳號前綴>-<enforcement_asset_suffix>`）。"""
+    if not credential.enforcement_asset_suffix:
+        raise ValueError(f"{credential.executor}：這一格沒有 enforcement 檔")
+    return f"{prefix}-{credential.enforcement_asset_suffix}"
+
+
+def enforcement_rows() -> tuple[tuple[str, ExecutorCredential], ...]:
+    """有 enforcement 檔的那些格（`(帳號前綴, 憑證)`）。#698 的 hooks 資產由它導出。"""
+    return tuple(
+        (prefix, cred) for prefix, cred in credential_rows() if cred.enforcement_leaf
+    )
+
+
+def enforcement_asset_ids() -> tuple[str, ...]:
+    """全部 enforcement 檔的資產 id。**兩個帳號各一份，由同一條規則長出來。**"""
+    return tuple(enforcement_asset_id(prefix, cred) for prefix, cred in enforcement_rows())
 
 
 def credential_for(prefix: str, executor: str) -> ExecutorCredential:
@@ -886,6 +1007,41 @@ def credential_for(prefix: str, executor: str) -> ExecutorCredential:
         if cell_prefix == prefix and cred.executor == executor:
             return cred
     raise UnregisteredExecutorCredentialError(f"{prefix}:{executor}")
+
+
+def _assert_shape_follows_enforcement_rule() -> None:
+    """#698 的那條規則，在 **import 當下**強制。
+
+    **規則**：executor 在 :data:`EXECUTOR_ENFORCEMENT_LEAVES` 上有一格 ⇒ 凡持有它
+    登入態的帳號，那一格一律是 :attr:`CredentialShape.HOME_STICKY_TREE`。
+
+    為什麼是 import 當下而不是一條測試：0818 的實測破口（#698）不是「有人寫錯一行」，
+    是「兩個帳號的形狀**各自**被決定，於是其中一個先遷、另一個留在原地等著爆」。
+    在展開點上強制，讓「只改一格」在**結構上做不到**——新增第五個帳號時漏改的症狀是
+    模組載不起來，而不是三個月後的一次 R9 紅字。
+    """
+    for prefix, cred in credential_rows():
+        want = EXECUTOR_ENFORCEMENT_LEAVES.get(cred.executor)
+        if want and cred.shape is not CredentialShape.HOME_STICKY_TREE:
+            raise ValueError(
+                f"{prefix}×{cred.executor}：這個 executor 的狀態樹裡住著 root-owned 的 "
+                f"`{want}`，因此該格必須是 HOME_STICKY_TREE（現況 {cred.shape.value}）。"
+                "#698：非 sticky 的可寫樹裡，job 隨時 unlink／rename 掉那個檔——R9 T3.9 "
+                "在 `cortex-reviewer-planner` 上實測攻破過一次，不再接受第二次。"
+            )
+        if want and cred.enforcement_leaf != want:
+            raise ValueError(
+                f"{prefix}×{cred.executor}：enforcement 檔名與 "
+                f"EXECUTOR_ENFORCEMENT_LEAVES 不一致（{cred.enforcement_leaf!r} vs {want!r}）。"
+            )
+        if not want and cred.enforcement_leaf:
+            raise ValueError(
+                f"{prefix}×{cred.executor}：宣告了 enforcement 檔卻不在 "
+                "EXECUTOR_ENFORCEMENT_LEAVES 上——規則的輸入只有那一張表。"
+            )
+
+
+_assert_shape_follows_enforcement_rule()
 
 
 @dataclass(frozen=True)
@@ -1309,9 +1465,21 @@ DEFAULT_SCHEME_ID: str = DEFAULT_SCHEME.scheme_id
 class OwnerClass(Enum):
     """資產的擁有類別，決定 owner 帳號來源。"""
 
-    DEPLOYMENT = "deployment"        # enforcement plane：owner＝deploy/root
+    DEPLOYMENT = "deployment"        # enforcement plane：owner＝deploy/root，**全部 headless 唯讀**
     MANAGER_STATE = "manager-state"  # Manager-owned durable state：owner＝durable_state_owner
     JOB = "job"                      # job-visible：owner＝對應 job 帳號（或 runtime 逐案 chown）
+    #: **root 擁有的容器，untrusted job 可寫其內容**（#698 方案 A：sticky 樹）。
+    #:
+    #: 它刻意**不是** `DEPLOYMENT`。`DEPLOYMENT` 的定義裡有一句「對全部 headless 唯讀」，
+    #: 而那句話是好幾條不變式的依據（`test_builder_never_writes_manager_owned_or_deployment`
+    #: ／`test_manager_owned_acls_are_read_only`）。sticky 樹**必須**讓 job 寫得進去，
+    #: 把它塞進 `DEPLOYMENT` 等於就地把那句話改成「除了某些之外」——那些不變式會從
+    #: 「機械成立」退化成「有例外清單」，而例外清單是會長大的。
+    #:
+    #: 本類別的性質是可以逐條寫下來的：owner＝root、帶 sticky bit、恰好一組 untrusted
+    #: 執行身分持有具名 `rwx` **access** ACL（無 default ACL）；容器裡的 root-owned 檔
+    #: 仍是 `DEPLOYMENT`，且 job 對它零寫入。
+    STICKY_SHARED = "sticky-shared"
 
 
 @dataclass(frozen=True)
@@ -1363,6 +1531,16 @@ class PermissionEntry:
     def mode_str(self) -> str:
         return format(self.mode, "04o")
 
+    @property
+    def sticky(self) -> bool:
+        """本資產帶 sticky bit（`chmod +t`，#698）。
+
+        由 `mode` 導出而不是另存一個布林欄位：兩份真相會漂移，而這一位的語意
+        （「目錄可寫，但只刪得掉／改得掉名字的是自己的檔」）正是 `hooks.json` 住得進
+        可寫樹的全部依據。
+        """
+        return bool(self.mode & STICKY_BIT)
+
     def to_dict(self) -> dict[str, object]:
         return {
             "asset_id": self.asset_id,
@@ -1381,6 +1559,7 @@ class PermissionEntry:
                 for a in self.acls
             ],
             "runtime_managed": self.runtime_managed,
+            "sticky": self.sticky,
             "legacy_writers": list(self.legacy_writers),
             "rationale": self.rationale,
             "open_points": list(self.open_points),
@@ -1411,8 +1590,24 @@ class PermissionEntry:
         for acl in self.acls:
             cmds.append(acl.render(path))
             # dir 需同時設 access 與 default ACL，讓新建物件繼承。
-            if self.is_directory and not acl.default:
+            #
+            # ⛔ **sticky 樹是明示的例外（#698）**，而且這一行就是它的成敗。default ACL
+            #    決定的是「**之後**在這個目錄裡新建的物件」的初值——包含 root 日後重放
+            #    一次 `hooks.json` 的那一次。對 sticky 樹補上 `-d -m u:<job>:rwx` 等於
+            #    宣告「root 放進去的每一個 enforcement 檔都自動交還給 job」，sticky
+            #    擋得住 unlink／rename 也沒有用了（job 直接改內容）。
+            #    因此這一族**只設 access ACL**。
+            if self.is_directory and not acl.default and not self.sticky:
                 cmds.append(AclEntry(acl.account, acl.perms, default=True).render(path))
+        if self.sticky:
+            cmds.append(
+                "#   ⛔ 本目錄**刻意不設 default ACL**：它會讓 root 日後放進來的 "
+                "enforcement 檔自動帶上 job 的 rwx（#698）。"
+            )
+            cmds.append(
+                f"#   ✅ 驗證用 `getfacl {path}` 而不是 `ls -ld`——具名 ACL 存在時 mode "
+                "的 group 位顯示的是 **ACL mask**（會顯示成 rwx），那不是 group 寫入權。"
+            )
         return cmds
 
 
@@ -1441,6 +1636,11 @@ _DIR_ASSET_IDS = frozenset({
     "review-verdict-spool",         # <coordinator>/review-verdicts/<reviewer_job_id>/
     "commit-spool",                 # <coordinator>/commit-spool/<job-id>/
     "executor-toolchain",           # <deploy_root>/toolchain/（四個模型 CLI 的落點）
+    # #698：codex 的 `$CODEX_HOME` 整棵（`<HOME>/.codex`）——root-owned ＋ sticky 的
+    # **真目錄**。asset_id 的 token heuristic（`-state` 不在 `_DIR_ASSET_TOKENS`）會把
+    # 它誤判成單檔，而誤判的後果不是排版問題：檔案資產的 RWP 會折算成**父目錄**＝
+    # 整個 HOME，等於把 root-owned 的 HOME 開成可寫面。由表機械導出。
+    *credential_asset_ids(CredentialShape.HOME_STICKY_TREE),
 })
 #: 登記表上是 **symlink** 的資產（#685／U-7）。
 #:
@@ -1455,6 +1655,31 @@ SYMLINK_ASSETS: frozenset[str] = frozenset(
     credential_asset_ids(CredentialShape.HOME_REDIRECT_TREE)
 )
 
+#: sticky 樹裡那個 **root-owned enforcement 葉檔**的資產 id（#698）。
+#:
+#: 它與其他葉檔在 `plan_to_commands()` 裡走**相反**的守衛：一般葉檔「不存在就跳過」，
+#: 這一族「不存在就由 root 種一份」。理由是 sticky bit 的語意——它管「刪／改名別人的
+#: 檔」，不管「建一個還不存在的檔」，因此**檔不存在時整個裁決是空的**。
+ENFORCEMENT_LEAF_ASSETS: frozenset[str] = frozenset(enforcement_asset_ids())
+
+#: 產生器種進 enforcement 位置的**最小合法內容**。
+#:
+#: 刻意是一份**空的** hooks 文件，不是 `paulsha_cortex/scripts/hooks/codex.json` 那份
+#: relay hook：本檔的價值在於「這個位置由 root 佔住、job 換不掉」，不在於跑什麼。
+#: 把 relay hook 種進 job 帳號會憑空多一條執行面（而且 job 帳號本來就寫不進
+#: coordinator，每次 codex session 只會多一串失敗），與本票要收的洞方向相反。
+#: 之後要放什麼是 root 的決定——換內容不需要動產生器，只要以 root 身分覆寫。
+CODEX_HOOKS_SEED_CONTENT = '{\n  "hooks": {}\n}'
+
+#: 登記表上是 **root-owned ＋ sticky ＋ job `rwx` ACL 的真目錄**的資產（#698）。
+#:
+#: 由 :func:`credential_asset_ids` 機械導出。這一族是 `build_entry()` 唯一會產出
+#: **帶 sticky 位**與**唯一會在 DEPLOYMENT 類別下產出可寫 ACL** 的地方——兩件事都要
+#: 有出處，因此集合本身也是導出的，不是手寫清單。
+STICKY_JOB_WRITABLE_DIR_ASSETS: frozenset[str] = frozenset(
+    credential_asset_ids(CredentialShape.HOME_STICKY_TREE)
+)
+
 _FILE_ASSET_IDS = frozenset({
     "control-daemon-lock",
     "control-status",
@@ -1462,12 +1687,19 @@ _FILE_ASSET_IDS = frozenset({
     # 與 `config.yml` 才能是**不同 owner** 的兩個檔。
     "manager-gh-credential",
     "manager-gh-config",
-    # #640／#685：憑證那一族**一律不是目錄**。這條明列不是裝飾——file/dir 的判定直接
-    # 決定 permgen 會不會把一整層 `install -d` 出來再 chown 給 job 帳號：
+    # #640／#685／#698：憑證那一族**只有 sticky 樹是目錄**。file/dir 的判定直接決定
+    # permgen 會不會把一整層 `install -d` 出來再 chown，因此三種形狀各自明列：
     #   - `IN_PLACE_FILE` 是單檔，父目錄必須維持 root-owned 才有「能改內容、不能增刪換」；
     #   - `HOME_REDIRECT_TREE` 是 **symlink**，`install -d` 會在它的位置建出一個真目錄，
-    #     把整條導向 `cache` 的機制無聲換掉（見 :data:`SYMLINK_ASSETS`）。
-    *credential_asset_ids(),
+    #     把整條導向 `cache` 的機制無聲換掉（見 :data:`SYMLINK_ASSETS`）；
+    #   - `HOME_STICKY_TREE` 是**真目錄**，因此**不在**本集合，改列進 `_DIR_ASSET_IDS`。
+    *(
+        aid for aid in credential_asset_ids()
+        if aid not in STICKY_JOB_WRITABLE_DIR_ASSETS
+    ),
+    # #698：enforcement 檔（codex 的 `hooks.json`）——兩個帳號各一份，由
+    # `enforcement_asset_ids()` 導出。它是 sticky 樹裡那個 job 動不了的葉檔。
+    *enforcement_asset_ids(),
 })
 
 
@@ -1498,6 +1730,9 @@ def infer_is_directory(asset: TrustRootAsset) -> bool:
 def classify_owner(asset: TrustRootAsset) -> OwnerClass:
     """把資產分到 DEPLOYMENT／MANAGER_STATE／JOB。
 
+    - sticky 樹（:data:`STICKY_JOB_WRITABLE_DIR_ASSETS`）→ STICKY_SHARED。**這條排在
+      最前面**：那一族的 `ingress_kind` 也是 `DEPLOYMENT_WRITE`（root 建立、root 擁有），
+      若讓它落進 DEPLOYMENT，「deployment 對全部 headless 唯讀」那句話就不再為真。
     - enforcement plane（`DEPLOYMENT_WRITE`，或 writer 含 INSTALLER 的 bootstrap env）
       → DEPLOYMENT（owner＝root/deploy）。
     - control file queue（`CONTROL_FILE_QUEUE`）：登記表現況標為 job-visible（任何同
@@ -1506,6 +1741,8 @@ def classify_owner(asset: TrustRootAsset) -> OwnerClass:
     - Manager-owned 樹的其餘資產 → MANAGER_STATE。
     - 其餘 job-visible 樹 → JOB。
     """
+    if asset.asset_id in STICKY_JOB_WRITABLE_DIR_ASSETS:
+        return OwnerClass.STICKY_SHARED
     if asset.ingress_kind is IngressKind.DEPLOYMENT_WRITE:
         return OwnerClass.DEPLOYMENT
     if Principal.INSTALLER in asset.writers:
@@ -1526,6 +1763,15 @@ def _dir_file_mode(is_dir: bool, owner_bits: int, group_bits: int, other_bits: i
 def _mask_write(bits: int) -> int:
     """移除 write 位（用於確保 group/other 永不可寫）。"""
     return bits & ~0o2 & 0o7
+
+
+#: sticky bit（`chmod +t`）。目錄語意：可寫，但**只有檔案 owner／目錄 owner／root**
+#: 刪得掉或改得掉裡面的檔名。#698 的整套方案 A 就架在這一位上。
+STICKY_BIT = 0o1000
+
+#: setuid／setgid。**任何登記表資產都不得帶**，安全網無條件清掉——它們是提權位，
+#: 而本產生器的整個目的是把提權面收斂到 root-owned 的 unit／shim 那一條線上。
+_FORBIDDEN_SPECIAL_BITS = 0o6000
 
 
 def build_entry(asset: TrustRootAsset, scheme: UidScheme) -> PermissionEntry:
@@ -1560,6 +1806,69 @@ def build_entry(asset: TrustRootAsset, scheme: UidScheme) -> PermissionEntry:
             "導出，服務因此改不了自己的 git 設定（.gitconfig 可指定 core.fsmonitor／"
             "alias.* 這類會執行外部命令的鍵）。注意來源樹本身**不**歸此類：0817 裁決把"
             "它的 writer 改為 Manager（回收成果必須寫得進去），見 `repo-source-tree`。"
+        )
+        if asset.asset_id in ENFORCEMENT_LEAF_ASSETS:
+            rationale += (
+                "\n**#698：本檔住在一棵 job 可寫的 sticky 樹裡**（`*-codex-state`），"
+                "因此它的保護不是「父目錄不可寫」而是三個動詞各自被擋："
+                "unlink／rename 由 sticky 擋（非 owner 只動得了自己的檔）、改內容由本檔的 "
+                "mode 擋（root:root 0644 ⇒ job 落在 `other` 位）；mount 層另有該 unit 的 "
+                "`ReadOnlyPaths=` 這一條（`enforcement_read_only_paths()`）。"
+                "\n⛔ **本檔必須存在**：sticky 不管「建一個還不存在的檔」，缺它時 job 直接"
+                "`printf x > $HOME/.codex/hooks.json` 就會成功（R9 T3.9 的攻擊字面）。"
+                "`plan_to_commands()` 因此對本族出 **create-if-absent**，而不是其他葉檔"
+                "那條「不存在就跳過」。"
+            )
+
+    elif owner_class is OwnerClass.STICKY_SHARED:
+        # #698 方案 A：executor 的狀態樹。owner 是 root（它承載 enforcement 檔——目錄
+        # owner 對 sticky 免疫，所以這一層**不能**是 job 擁有），但整棵必須讓 job 寫得
+        # 進去，否則 executor 起不來（#686）。兩者同時成立的唯一形態＝
+        # **sticky ＋ 具名 rwx access ACL**。
+        #
+        # 授權對象由 `writers` ∩ `UNTRUSTED_EXECUTION_PRINCIPALS` 導出，與 JOB 那一支
+        # 的規則同源——「哪個身分算不受信任的執行者」只有那一個集合說了算，這裡不另立
+        # 第二條判準。
+        owner = scheme.deploy_account
+        sticky_writers = frozenset(
+            a
+            for a in (
+                scheme.resolve(w)
+                for w in asset.writers
+                if w in UNTRUSTED_EXECUTION_PRINCIPALS
+            )
+            if a is not None
+        )
+        if not sticky_writers:
+            raise ValueError(
+                f"{asset.asset_id}：sticky 樹沒有任何 untrusted 執行身分當 writer"
+                "——那它只是一個沒人寫得進去的 root 目錄，executor 會起不來（#686）。"
+                "登記表的 writers 必須含該帳號的 job principal。"
+            )
+        # 目錄 rwx，group／other 唯讀＋traverse（安全網稍後會再確認一次無 w 位）。
+        mode = _dir_file_mode(is_dir, 0o7, 0o5, 0o5) | STICKY_BIT
+        for jacct in sorted(sticky_writers):
+            acls.append(AclEntry(jacct, "rwx"))
+        writer_accounts = frozenset({owner}) | sticky_writers
+        rationale = (
+            "**executor 狀態樹（#698 方案 A：sticky ＋ root-owned enforcement 檔）**："
+            "owner＝root、mode 帶 sticky bit（`+t`），job 帳號以具名 **access** ACL "
+            "取得 `rwx`。兩件在 #685 的形狀下互斥的事因此同時成立：(i) 整棵可寫 ⇒ "
+            "codex 起得來（#686 實測 `$CODEX_HOME` 唯讀時連 in-process app-server 都"
+            "初始化不了）；(ii) 樹裡的 root-owned `hooks.json` **刪不掉、改不掉名字、"
+            "也改不了內容**——sticky 讓非 owner 只動得了自己的檔，而該檔的 mode 讓 "
+            "job 落在 `other` 位。0818 的 R9 T3.9 就是在 (ii) 不成立的形狀下被實測"
+            "攻破的（codex hooks 會執行命令 ⇒ 跨 job 持久化）。"
+            "\n**owner 必須是 root**：目錄 owner 對 sticky 免疫（POSIX：目錄 owner 刪得掉"
+            "裡面任何檔），把這一層交給 job 等於整條規則不存在。"
+            "\n**group 寫入權仍然是零**（spec §R2 未放寬）：job 的寫入權走具名 ACL。"
+            "注意 `ls -ld` 會把 group 位顯示成 `rwx`——那是 POSIX ACL 的 **mask**，"
+            "不是 group 權限，驗證一律用 `getfacl`。"
+            "\n**刻意不設 default ACL**：它會讓 root 日後補放的 enforcement 檔自動帶上"
+            "job 的 `rwx`，等於把 (ii) 交還回去（見 `PermissionEntry.commands`）。"
+            "\n**代價（R-6 不變）**：樹由 job 寫 ⇒ 樹裡的 **token 葉檔**仍可被該 job "
+            "刪除或替換。那是刻意的——token 過期必須 refresh 得回來；sticky 保護的是"
+            "root 擁有的那些檔。"
         )
 
     elif owner_class is OwnerClass.MANAGER_STATE:
@@ -1674,9 +1983,20 @@ def build_entry(asset: TrustRootAsset, scheme: UidScheme) -> PermissionEntry:
                 )
 
     # 安全網：group/other 一律不得帶 write 位（spec §R2「group 寫入權 MUST 移除」）。
+    #
+    # **#698 改了這一行的最後一段，而那是本票唯一動到 mode 管線的地方。** 舊寫法是
+    # `mode & 0o700`——它保住 owner 位，卻連同 setuid／setgid **與 sticky** 一起吃掉。
+    # sticky 被吃掉的後果不是「權限緊一點」：它是「目錄可寫但只能刪自己的檔」的**唯一**
+    # 表達方式，沒有它就無法在一棵 job 可寫的樹裡放一個 job 動不了的 root-owned
+    # `hooks.json`（#698 的方案 A）。#685 把這條列為「本票不做」的兩個理由之一。
+    #
+    # §R2 的不變式**一行都沒有放寬**：group／other 的 write 位仍然無條件清除，job 的
+    # 寫入權一律走具名 ACL；新增的只有「sticky 通得過」。setuid／setgid 則從「被
+    # `& 0o700` 順手吃掉」升級為**明文清除**——同樣的結果，但現在有出處、也擋得住
+    # 日後有人把遮罩再放寬一位。
     group_bits = _mask_write((mode >> 3) & 0o7)
     other_bits = _mask_write(mode & 0o7)
-    mode = (mode & 0o700) | (group_bits << 3) | other_bits
+    mode = (mode & (STICKY_BIT | 0o700) & ~_FORBIDDEN_SPECIAL_BITS) | (group_bits << 3) | other_bits
 
     return PermissionEntry(
         asset_id=asset.asset_id,
@@ -1875,7 +2195,15 @@ def plan_to_commands(
         path = (path_of or {}).get(e.asset_id) or _placeholder_path(e)
         per_job = PER_JOB_SEGMENT in path
         lines.append("")
-        lines.append(f"# [{e.tier}] {e.asset_id} ({e.owner_class.value}) — {e.rationale}")
+        # rationale 可能是多行（#698 起有幾條是）。**每一行都要自己的 `#`**：這份輸出
+        # 是 runbook 以 `sudo sh -e` 直接執行的 script，漏掉前綴的那幾行會被 shell 當成
+        # 命令解析——症狀是整份 script 在一個看起來像散文的地方 `Syntax error`，而且
+        # 那一行離真正的原因（某個資產的 rationale 換了行）非常遠。
+        rationale_lines = e.rationale.splitlines() or [""]
+        lines.append(
+            f"# [{e.tier}] {e.asset_id} ({e.owner_class.value}) — {rationale_lines[0]}"
+        )
+        lines += [f"#   {line}" for line in rationale_lines[1:]]
         if e.runtime_managed:
             lines.append("#   注意：per-child owner 由降權啟動器逐案 chown（本節僅容器層）。")
         for op in e.open_points:
@@ -1902,7 +2230,54 @@ def plan_to_commands(
             cmds = [f"[ ! -e {parent} ] || {cmd}" for cmd in cmds]
         elif e.is_directory:
             # 目錄一定先建起來，後續 chown／chmod／setfacl 必然有對象。
-            cmds.insert(0, f"install -d {path}")
+            #
+            # #698：sticky 樹的既有部署可能是**別的東西**（reviewer-planner 上是一條
+            # 指向 `cache/codex` 的 symlink）。`install -d` 對「已存在的 symlink」不會
+            # 報錯、也不會取代它——它會**跟著連結**去建目標目錄，於是 chown／chmod／
+            # setfacl 全部套到 `cache/codex` 那棵 job-owned 的樹上，而現場看起來一切
+            # 正常。遷移那一步（改成真目錄）必須由 operator 顯式做，見 runbook 4e-2b。
+            if e.asset_id in STICKY_JOB_WRITABLE_DIR_ASSETS:
+                lines.append(
+                    f"#   ⚠️ 遷移守衛：{path} 若是既有部署留下的 **symlink**，下面這行"
+                    "`install -d` 會跟著它去建目標、把權限套到錯的樹上（#698 的部署陷阱）。"
+                )
+                lines.append(
+                    f"#      先確認形狀：`[ -L {path} ] && echo 'symlink——先跑 runbook "
+                    "4e-2b 的遷移步驟，不要直接套用本節'`"
+                )
+                cmds.insert(0, f"install -d {path}")
+                # 守衛必須排在 `install -d` **之前**：`install -d` 對既有 symlink 會
+                # 跟著它去建目標，錯誤在那一行就已經造成了。
+                cmds.insert(
+                    0,
+                    f"[ ! -L {path} ] || {{ echo '⛔ {path} 仍是 symlink，"
+                    f"見 runbook 4e-2b 的遷移步驟' >&2; exit 1; }}",
+                )
+            else:
+                cmds.insert(0, f"install -d {path}")
+        elif e.asset_id in ENFORCEMENT_LEAF_ASSETS:
+            # #698：enforcement 檔與其他葉檔**相反**——它不能用 `[ ! -e ] ||` 跳過。
+            #
+            # sticky bit 管的是「刪／改名**別人的**檔」，**不管「建一個還不存在的檔」**。
+            # 因此這個檔不存在時，sticky 樹擋不住任何東西：job 直接 `printf x >
+            # $HOME/.codex/hooks.json` 就成功了（那正是 R9 T3.9 的攻擊字面）。
+            # 「跳過」在這裡不是保守，是**靜默把整個裁決變成空的**。
+            #
+            # 因此改成 create-if-absent：由 root 種一份最小、合法、**不含任何命令**的
+            # 文件，再套上 root:root 0644。內容之後要換成什麼是 root 的決定；產生器
+            # 只保證「這個位置永遠有一個 root 擁有的檔」。
+            lines.append(
+                f"#   ⛔ 本檔**必須存在**，否則 sticky 樹什麼也擋不住（job 建得出新檔）"
+                "——因此這裡是 create-if-absent，不是「不存在就跳過」（#698）。"
+            )
+            lines.append(
+                "#   內容是最小且**不含任何命令**的 hooks 文件：本檔的價值在於「這個位置"
+                "由 root 佔住」，不在於跑什麼。要放真的 hook 是 root 之後的決定。"
+            )
+            seed = [f"[ -e {path} ] || cat > {path} <<'PSC_CODEX_HOOKS_EOF'"]
+            seed += CODEX_HOOKS_SEED_CONTENT.splitlines()
+            seed.append("PSC_CODEX_HOOKS_EOF")
+            cmds = seed + cmds
         else:
             # 葉檔在 setup 當下多半尚未存在（由服務首次寫入時建立）。加 `[ ! -e ] ||`
             # 守衛：不存在就跳過（且在 `sh -e` 下不會中斷腳本），存在就套上目標權限。
@@ -1936,9 +2311,13 @@ def _dedupe_scaffold(
 ) -> tuple[tuple[str, str, str, int], ...]:
     """同一個路徑只留第一次出現的那一筆（順序不變）。
 
-    骨架清單是由**多條獨立規則**疊出來的（`~/.codex` 來自 hooks、憑證父目錄來自
-    #640），預設 layout 下兩者指向同一層。去重讓 `install -d` 不會重複輸出，也讓
+    骨架清單是由**多條獨立規則**疊出來的（帳號 HOME／cache、憑證形狀各自的前置層），
+    不同規則在某些 layout 下會指向同一層。去重讓 `install -d` 不會重複輸出，也讓
     「無多餘」那類等式測試不必為一個純顯示層的重複而放寬。
+
+    ⚠️ **只留第一筆**，因此「同一條路徑被兩條規則以不同 mode 產出」會**靜默**取前者。
+    #698 之後 `~/.codex` 是登記表資產（sticky 1755 ＋ ACL）而**不再**進骨架，正是為了
+    避免骨架那份 0755 把 sticky 位蓋掉——那種漂移在輸出上看不出來。
     """
     seen: set[str] = set()
     kept: list[tuple[str, str, str, int]] = []
@@ -1975,7 +2354,7 @@ class PathLayout:
     #: Manager 帳號是 `cortex-manager`，HOME 卻還指著二分時代的 `/var/lib/cortex-svc`，
     #: unit 的 `Environment=HOME=` 與 scaffold 因此指向一個沒人擁有的目錄。
     home_root: str = "/var/lib"
-    #: builder 的帳號名。只給 `asset_paths()` 用（`codex-hooks`／`builder-gitconfig` 掛在
+    #: builder 的帳號名。只給 `asset_paths()` 用（`builder-gitconfig` 掛在
     #: builder HOME 下），因為 `asset_paths()` 刻意不吃 scheme——兩個 scheme 對 BUILDER
     #: 的映射相同。其餘所有帳號相關路徑一律由 scheme 現場導出。
     builder_account: str = "cortex-builder"
@@ -2313,14 +2692,59 @@ class PathLayout:
         return f"{self.home_of(account)}/cache"
 
     def codex_hooks_dir_of(self, account: str) -> str:
-        """該帳號的 `~/.codex`。root-owned——job 不得替換自己的 hooks。"""
-        return f"{self.home_of(account)}/.codex"
+        """該帳號的 `~/.codex`。root-owned（#698 起再加 sticky）——job 不得替換 hooks。
+
+        **#698 之後這一層同時是 codex 的 `$CODEX_HOME` 整棵**（登記表資產
+        `<前綴>-codex-state`），因此值由憑證表導出、不再是寫死的 `.codex`：
+        `PathLayout.executor_credential_relpath` 換掉時它必須跟著換，否則 hooks 會落在
+        一個 codex 根本不看的目錄裡——**一個不會報錯的 enforcement 缺口**。
+        表上查無的帳號（二分的 `cortex-svc`）退回既有字面值。
+        """
+        try:
+            credential = credential_for(
+                self.credential_prefix_of(account), PRIMARY_CREDENTIAL_EXECUTOR
+            )
+        except UnregisteredExecutorCredentialError:
+            return f"{self.home_of(account)}/.codex"
+        return f"{self.home_of(account)}/{self.credential_relpath_of(credential)}"
 
     def credential_relpath_of(self, credential: ExecutorCredential) -> str:
-        """該憑證在帳號 HOME 底下的相對落點（`None` 的那一列由本 layout 供給）。"""
+        """該憑證**登記節點**在帳號 HOME 底下的相對落點（`None` 的那一列由本 layout 供給）。
+
+        `relpath is None` 的那一列（＝ :data:`PRIMARY_CREDENTIAL_EXECUTOR`）的值來自
+        `executor_credential_relpath` 這個部署決定。#698 起它要依形狀切一刀：
+
+        - `IN_PLACE_FILE`：登記的節點就是**那個檔**（`.codex/auth.json`）；
+        - `HOME_STICKY_TREE`：登記的節點是**放那個檔的那一層**（`.codex`）——樹與葉
+          因此是同一個部署決定的 head 與 tail，不可能各改一半，而
+          「換 primary executor 只改一個值」（#640）仍然逐字成立。
+        """
+        if credential.relpath is not None:
+            return credential.relpath
+        relpath = self.executor_credential_relpath
+        if credential.shape is CredentialShape.IN_PLACE_FILE:
+            return relpath
+        # `_validate_credential_relpath` 保證至少兩段，因此這一刀必定切得出 head。
+        return relpath.rsplit("/", 1)[0]
+
+    def credential_token_relpath_of(self, credential: ExecutorCredential) -> str:
+        """真正承載 token 的**葉檔**在帳號 HOME 底下的相對落點。
+
+        `relpath is None` 的那一列直接回 `executor_credential_relpath` 全值——它本來
+        就是「那個檔在哪裡」的部署決定；再從 `token_leaf` 拼一次會是第二份真相
+        （operator 把它改成 `.claude/credentials.json` 時會拼出 `.claude/auth.json`）。
+        """
         if credential.relpath is None:
             return self.executor_credential_relpath
+        if credential.token_leaf:
+            return f"{credential.relpath}/{credential.token_leaf}"
         return credential.relpath
+
+    def enforcement_relpath_of(self, credential: ExecutorCredential) -> str:
+        """該格 enforcement 檔（codex 的 `hooks.json`）在 HOME 底下的相對落點（#698）。"""
+        if not credential.enforcement_leaf:
+            raise ValueError(f"{credential.executor}：這一格沒有 enforcement 檔")
+        return f"{self.credential_relpath_of(credential)}/{credential.enforcement_leaf}"
 
     def executor_credential_of(
         self, account: str, executor: str = PRIMARY_CREDENTIAL_EXECUTOR,
@@ -2333,12 +2757,15 @@ class PathLayout:
 
         回傳值的**形狀跟著 (account, executor) 這一格走**（:data:`CREDENTIALED_ACCOUNTS`）：
 
-        - `IN_PLACE_FILE`（builder×codex）：回傳的是**那個檔**（`~/.codex/auth.json`）。
-          它與 `codex_hooks_dir_of()` 落在同一層 root-owned 目錄，因此 job 改得了內容、
-          建不了新檔、刪不掉、也換不掉同目錄下的 `hooks.json`。
-        - `HOME_REDIRECT_TREE`（reviewer-planner×{codex, agy, claude}）：回傳的是那條
-          **root-owned symlink**（`~/.codex`／`~/.gemini`／`~/.claude`），真正的 token
-          葉檔在它底下（`credential.token_leaf`）。
+        - `HOME_STICKY_TREE`（{builder, reviewer-planner}×codex，#698）：回傳的是那棵
+          **root-owned ＋ sticky 的真目錄**（`~/.codex`），token 葉檔在它底下
+          （`credential_token_path_of()`），root-owned 的 `hooks.json` 也在它底下。
+        - `HOME_REDIRECT_TREE`（reviewer-planner×{agy, claude}）：回傳的是那條
+          **root-owned symlink**（`~/.gemini`／`~/.claude`），真正的 token 葉檔在它
+          底下（`credential.token_leaf`）。
+        - `IN_PLACE_FILE`：回傳的是**那個檔**。#698 之後憑證表上沒有這個形狀的格子
+          （兩個 codex 都已改走 sticky 樹），保留是因為它仍是
+          :data:`IN_PLACE_CONTENT_WRITE_ASSETS` 的語意來源。
 
         **帳號不在表上時**（`cortex-gate` 不跑模型；二分方案的 `cortex-svc` 沒有登記表
         憑證資產）退回 #640 的單一部署決定 `executor_credential_relpath`——那正是本函式
@@ -2359,8 +2786,13 @@ class PathLayout:
     def executor_credential_dir_of(
         self, account: str, executor: str = PRIMARY_CREDENTIAL_EXECUTOR,
     ) -> str:
-        """`IN_PLACE_FILE` 憑證檔的父目錄。**必須 root-owned**——裁決 (b) 的性質全部
-        落在這一層。`HOME_REDIRECT_TREE` 的那一格回傳的是 symlink 的父目錄（＝HOME）。
+        """憑證登記節點的**父目錄**。
+
+        - `IN_PLACE_FILE`：憑證檔的父目錄，**必須 root-owned**——裁決 (b) 的性質全部
+          落在這一層。
+        - `HOME_REDIRECT_TREE`／`HOME_STICKY_TREE`：回傳的是登記節點的父目錄（＝HOME）。
+          對 sticky 樹而言，「必須 root-owned」的那一層是**樹自己**，不是這裡回的 HOME
+          ——HOME 仍然 root-owned，但那擋的是「換掉整棵樹」，不是「換掉樹裡的 hooks」。
         """
         return _parent_dir(self.executor_credential_of(account, executor))
 
@@ -2377,12 +2809,11 @@ class PathLayout:
 
         `token_leaf` 為空（`IN_PLACE_FILE`）時兩者相同。
         """
-        base = self.executor_credential_of(account, executor)
         try:
             credential = credential_for(self.credential_prefix_of(account), executor)
         except UnregisteredExecutorCredentialError:
-            return base
-        return f"{base}/{credential.token_leaf}" if credential.token_leaf else base
+            return self.executor_credential_of(account, executor)
+        return f"{self.home_of(account)}/{self.credential_token_relpath_of(credential)}"
 
     def credential_target_of(self, account: str, credential: ExecutorCredential) -> str:
         """`HOME_REDIRECT_TREE` 的 symlink 目標絕對路徑（恆在該帳號的 `cache` 底下）。"""
@@ -2423,6 +2854,24 @@ class PathLayout:
                 credential_asset_id(prefix, credential),
                 account,
                 f"{self.home_of(account)}/{self.credential_relpath_of(credential)}",
+                credential,
+            ))
+        return tuple(rows)
+
+    def enforcement_placements(self) -> tuple[tuple[str, str, str, ExecutorCredential], ...]:
+        """#698 的 enforcement 檔展開：`(asset_id, account, 絕對路徑, 該格的憑證)`。
+
+        與 :meth:`credential_placements` 同源、同形，因此「兩個帳號各一份 hooks」是
+        **一條規則長出來的兩列**，不是兩處手寫的路徑。`asset_paths()` 由它導出。
+        """
+        accounts = self.credential_accounts()
+        rows: list[tuple[str, str, str, ExecutorCredential]] = []
+        for prefix, credential in enforcement_rows():
+            account = accounts[prefix]
+            rows.append((
+                enforcement_asset_id(prefix, credential),
+                account,
+                f"{self.home_of(account)}/{self.enforcement_relpath_of(credential)}",
                 credential,
             ))
         return tuple(rows)
@@ -2618,13 +3067,21 @@ class PathLayout:
             "combo-card-override": f"{a}/config/combos",
             "handoff-manifest": f"{job}/.psc-handoff.json",
             "runtime-bootstrap-env": self.env_file,
-            # **只有 builder 這一份，而 #685 之後這是一條有結論的事實、不再是「還沒補」**：
-            # reviewer／planner 帳號的 `~/.codex` 是導進 `cache` 的 symlink（#686 實測
-            # codex 需要 `$CODEX_HOME` 整棵可寫），hooks 若落在那棵樹裡就由 job 帳號擁有
-            # ⇒ 擋不住替換 ⇒ 登記成 root-owned 的 Tier-0 資產是做不到的事。因此它**仍在**
-            # `deferred_run_dependencies()`，並升為 U-9 交 operator 裁決。
-            "codex-hooks": f"{self.builder_home}/.codex/hooks.json",
             "work-items-yaml": f"{job}/.cortex/work-items.yaml",
+            # **#698：hooks 不再只有 builder 那一份，也不再是寫死的路徑。**
+            #
+            # #685 之後這裡的註解寫的是「只有 builder 這一份，因為 reviewer／planner 的
+            # `~/.codex` 是導進 `cache` 的 job-owned 樹、hooks 放進去擋不住替換」。0818
+            # 的 R9 T3.9 把那句話的**後果**量了出來：該帳號真的植入了 `hooks.json`，而
+            # codex hooks 會執行命令 ⇒ 跨 job 持久化（#698）。
+            #
+            # 方案 A 讓那個限制消失：兩個帳號的 `$CODEX_HOME` 都是 root-owned ＋ sticky
+            # 的真目錄，因此**兩份 hooks 都登記得起來**，而且是由
+            # `enforcement_placements()`（＝憑證表那條規則）長出來的兩列，不是兩處手寫。
+            **{
+                asset_id: path
+                for asset_id, _account, path, _cred in self.enforcement_placements()
+            },
         }
 
     # -- 非資產骨架目錄 -----------------------------------------------------
@@ -2651,20 +3108,24 @@ class PathLayout:
             account_dirs.append((self.home_of(account), root, g(root), 0o755))
             account_dirs.append((self.cache_of(account), account, g(account), 0o700))
         # #685：憑證那一族的骨架**由 per-(account, executor) 表導出**，不再逐項寫死。
-        # 兩種形狀各自要先存在的東西不同，而「哪個帳號是哪種形狀」是表上的一格：
+        # 三種形狀各自要先存在的東西不同，而「哪個帳號是哪種形狀」是表上的一格：
         #
         #   - `IN_PLACE_FILE`：憑證檔的**父目錄**必須 root-owned（#640 裁決 (b) 的性質
-        #     全部落在這一層——job 因此改得了內容，卻建不了新檔、刪不掉、也換不掉同
-        #     目錄下的 root-owned `hooks.json`）。預設 relpath 下這一層就是 `~/.codex`，
-        #     `codex-hooks` 也住在裡面，去重後只出現一次。
+        #     全部落在這一層——job 因此改得了內容，卻建不了新檔、刪不掉）。
         #   - `HOME_REDIRECT_TREE`：symlink 自己由權限計畫的 `ln -sfn` 落位；骨架要先
         #     建的是它的**目標**——那一格落在該帳號的 `cache` 底下，由**該帳號**擁有
         #     0700。這一層不建的話，`~/.gemini` 會是一條懸空 symlink，而建目錄的
         #     syscall 對懸空 symlink 回 `EEXIST`（**不是**「建出目標」）——executor 於是
         #     死在一個與權限完全無關的錯誤上。
+        #   - `HOME_STICKY_TREE`（#698）：**這一格不進骨架**。它自己就是登記表資產
+        #     （目錄型），`plan_to_commands()` 會出 `install -d` ＋ `chown` ＋ `chmod
+        #     1755` ＋ `setfacl`。在這裡再建一次會是第二份真相，而且是**會漂移的那種**
+        #     ——骨架這一層不知道 sticky 位與 ACL，去重（`_dedupe_scaffold`）只留第一筆，
+        #     於是先出現的骨架版本會把權限計畫的版本蓋掉，sticky 靜默消失。
         #
-        # 兩者的保護都不是寫在這裡的字面量：symlink 換不掉是因為 HOME 那一層 root-owned
-        # （上面那一行），目標不新增可寫面是因為它在 `cache` 裡（`_minimize()` 會吃掉）。
+        # 三者的保護都不是寫在這裡的字面量：symlink 換不掉是因為 HOME 那一層 root-owned
+        # （上面那一行），sticky 樹換不掉也是同一個理由，而目標不新增可寫面是因為它在
+        # `cache` 裡（`_minimize()` 會吃掉）。
         for _asset_id, account, path, credential in self.credential_placements():
             if account not in job_accounts:
                 # 本方案沒有這個帳號（二分把 reviewer／planner 併進 `cortex-svc`），
@@ -2672,35 +3133,27 @@ class PathLayout:
                 continue
             if credential.shape is CredentialShape.IN_PLACE_FILE:
                 account_dirs.append((_parent_dir(path), root, g(root), 0o755))
-            else:
+            elif credential.shape is CredentialShape.HOME_REDIRECT_TREE:
                 account_dirs.append((
                     self.credential_target_of(account, credential),
                     account, g(account), 0o700,
                 ))
-        # 跑模型的 job 帳號還要一個 root-owned 的 `~/.codex`（hooks 不得被 job 替換）
-        # ——**但只有 codex 憑證是 `IN_PLACE_FILE` 的那些**。`HOME_REDIRECT_TREE` 的帳號
-        # 上 `~/.codex` 是一條 symlink，在這裡建出同名的真目錄會把整條導向 `cache` 的
-        # 機制無聲換掉（症狀是 codex 又回到「起不來」，而現場看起來一切正常）。
-        #
         # 表上查無的 job 帳號（二分的 `cortex-svc`）維持 #640 的既有形態不變：它沒有
         # 登記表憑證資產，但骨架那兩層 root-owned 目錄照舊——本票不改二分部署。
+        #
+        # **#698 之後表上有登記的帳號在這裡什麼都不做**：它們的 `~/.codex` 就是
+        # `HOME_STICKY_TREE` 那個登記表資產本身（見上一段的第三點）。
         for account in job_accounts:
             try:
-                prefix = self.credential_prefix_of(account)
-                primary = credential_for(prefix, PRIMARY_CREDENTIAL_EXECUTOR)
+                self.credential_prefix_of(account)
             except UnregisteredExecutorCredentialError:
                 account_dirs.append(
-                    (self.codex_hooks_dir_of(account), root, g(root), 0o755)
+                    (f"{self.home_of(account)}/.codex", root, g(root), 0o755)
                 )
                 account_dirs.append((
                     _parent_dir(f"{self.home_of(account)}/{self.executor_credential_relpath}"),
                     root, g(root), 0o755,
                 ))
-                continue
-            if primary.shape is CredentialShape.IN_PLACE_FILE:
-                account_dirs.append(
-                    (self.codex_hooks_dir_of(account), root, g(root), 0o755)
-                )
         # #666：**durable state owner 才需要** `~/.config/gh` 那兩層。`gh` 依序看
         # `$GH_CONFIG_DIR` → `$XDG_CONFIG_HOME/gh` → `$HOME/.config/gh`，而產生出來的
         # unit 只設 `HOME=` 與 `XDG_CACHE_HOME=`（**刻意不設 `XDG_CONFIG_HOME=`**），
@@ -2764,7 +3217,9 @@ class PathLayout:
         return (
             ExtraWritePath(
                 self.cache_of(account),
-                f"job 帳號 {account} 的 HOME 快取（git/gh/uv）；HOME 與 ~/.codex 皆 root-owned 不可替換。",
+                f"job 帳號 {account} 的 HOME 快取（git/gh/uv）；HOME 與 ~/.codex 兩層**目錄**"
+                "皆 root-owned 不可替換（#698 起 ~/.codex 另帶 sticky，裡面的 root-owned "
+                "hooks.json 因此 job 也動不了；樹本身的可寫面由登記表資產導出，不走本例外）。",
             ),
         )
 
@@ -2831,9 +3286,9 @@ def principal_needs_write(
 #: 一般規則把檔案資產折算成**父目錄**——因為要「建立／取代」一個檔，必須對父目錄可寫。
 #: 這一族刻意**不**具備建立／取代的能力：目錄維持 root-owned（`scaffold_directories`），
 #: job 只是把自己擁有的那一個檔就地改寫（`O_TRUNC` 覆寫，例如 token refresh）。因此
-#: `ReadWritePaths` 只掛在**檔案本身**，父目錄（同時放著 root-owned 的 `codex-hooks`）
-#: 連 mount 層都不開放可寫——「檔案 job-owned、目錄 root-owned」這條性質因此在
-#: **檔案系統**與 **systemd mount** 兩層同時成立，而不是只靠其中一層。
+#: `ReadWritePaths` 只掛在**檔案本身**，父目錄連 mount 層都不開放可寫——「檔案
+#: job-owned、目錄 root-owned」這條性質因此在**檔案系統**與 **systemd mount** 兩層
+#: 同時成立，而不是只靠其中一層。
 #:
 #: 代價（裁決刻意接受）：以「暫存檔 ＋ rename 原子替換」形式 refresh 的 CLI 會失敗，
 #: 因為那需要在同目錄建檔。診斷方式見 Phase 2b runbook 第 4e 步。
@@ -2842,6 +3297,20 @@ def principal_needs_write(
 #: :data:`CREDENTIALED_ACCOUNTS` 加一格 `IN_PLACE_FILE`，這裡自動跟著長；加一格
 #: `HOME_REDIRECT_TREE` 則**刻意不進**——那一族的 RWP 由 `cache` 涵蓋（見
 #: :class:`CredentialShape`），掛在 symlink 上只會讓 systemd 去 bind-mount 一條連結。
+#:
+#: **#698：憑證那一半目前導出為空集，而那是一個有結論的狀態、不是遺漏。** 兩個 job
+#: 帳號的 codex 都已改走 `HOME_STICKY_TREE`（整棵目錄進 RWP），因此本集合現在只剩
+#: `manager-gh-credential` 一項。`IN_PLACE_FILE` 這個形狀**刻意保留**：它仍是本集合
+#: 的語意來源，而且 `manager-gh-credential` 逐條同構——差別只在 Manager 那一份不在
+#: 憑證表上（它不是 executor 登入態）。
+#:
+#: **sticky 樹換到什麼、付出什麼**（誠實記錄，不要在別處被讀成「一樣安全」）：
+#: `IN_PLACE_FILE` 讓 `hooks.json` 同時被 **DAC** 與 **systemd mount** 兩層擋住；
+#: sticky 樹只剩 DAC 那一層（整棵樹必須進 RWP，codex 才起得來）。換到的是 codex
+#: **真的跑得起來**，以及 reviewer／planner 那一格「hooks 根本擋不住」的整個消失。
+#: DAC 那一層擋的是三個動詞（unlink／rename／改內容），三個都由 OS 強制，符合 spec
+#: §R2「不得依賴 mode 0400 作為唯一手段」——sticky 不是 mode 位的自我約束，它約束的
+#: 是**非 owner**。
 IN_PLACE_CONTENT_WRITE_ASSETS: frozenset[str] = frozenset({
     *credential_asset_ids(CredentialShape.IN_PLACE_FILE),
     # #666：Manager 的 gh token。與上一條同形，但**洩漏面不同級**，這點不得混談：
@@ -2907,7 +3376,7 @@ def inapplicable_home_anchored_assets(
 
     **本函式補的是 `ReadWritePaths` 那一半**：systemd 對不存在的 `ReadWritePaths=`
     目標會讓 unit **直接起不來**，因此「不適用」不能只在權限面成立。#642 當時的處置
-    是「乾脆不登記第二份憑證」（`builder-executor-credential` 的 note 有整段論證）；
+    是「乾脆不登記第二份憑證」（`builder-codex-state` 的 note 有整段論證）；
     #666 要登記 Manager 的 gh 憑證時同一個陷阱又出現一次，因此把「不適用」做成一條
     **可列舉的機械規則**，而不是每次都用「不要登記」繞過去。
 
@@ -2990,6 +3459,38 @@ def read_write_paths(
     wanted = set(required_write_targets(plan, layout, account, principals, retired).values())
     wanted |= {e.path for e in extras}
     return _minimize(wanted)
+
+
+def enforcement_read_only_paths(
+    layout: PathLayout,
+    account: str,
+    read_write: tuple[str, ...],
+) -> tuple[str, ...]:
+    """該帳號 unit 的 `ReadOnlyPaths=`：落在自己 RWP 之內的 enforcement 檔（#698）。
+
+    **為什麼需要這一條，而不是「sticky 就夠了」**：sticky 樹整棵必須進
+    `ReadWritePaths=`（codex 才起得來），而 `hooks.json` 就住在那棵樹裡——於是 mount 層
+    對它是可寫的，只剩 DAC（sticky ＋ 檔案 mode）擋著。#640 的 `IN_PLACE_FILE` 形態
+    在這一點上是**兩層**（`IN_PLACE_CONTENT_WRITE_ASSETS` 的整段說明就是這件事），
+    本形狀若不補這一條就是**淨退一層**。
+
+    systemd 依路徑長度排序套用這些 bind mount，因此巢狀在 `ReadWritePaths=` 之內的
+    `ReadOnlyPaths=` 會後套、覆蓋掉外層的可寫性。**沒有 `-` 前綴是刻意的**：目標不存在
+    時 unit 直接起不來，而那正是要的行為——`hooks.json` 缺席時 sticky 擋不住任何東西
+    （job 建得出新檔），一個「能植入 hooks 的 job」不該起得來。這與同一份 unit 對
+    `ReadWritePaths` 既有的 fail-closed 立場逐字一致。
+
+    只回傳**落在該帳號 RWP 之內**的那些：不在 RWP 內的 enforcement 檔本來就寫不到
+    （mount 層已唯讀），再掛一條只會多一個「目標不存在就起不來」的失敗面。
+    """
+    home = layout.home_of(account)
+    wanted = {
+        path
+        for _asset_id, acct, path, _cred in layout.enforcement_placements()
+        if acct == account and any(_is_within(path, rwp) for rwp in read_write)
+    }
+    # 防呆：路徑必須真的掛在該帳號 HOME 底下（換 scheme／改 layout 時不會靜默跑掉）。
+    return tuple(sorted(p for p in wanted if _is_within(p, home)))
 
 
 def read_write_path_owners(
@@ -3897,13 +4398,16 @@ RUN_EXTERNAL_DEPENDENCIES: tuple[RunDependency, ...] = (
         note="全部 `needs_node` 的 toolchain 程式共用的系統層 runtime。",
     ),
     RunDependency(
-        "builder-executor-credential", DependencyKind.CREDENTIAL,
+        "builder-codex-state", DependencyKind.CREDENTIAL,
         (Principal.BUILDER,), (RunStage.MODEL_CALL,),
-        covered_by="builder-executor-credential",
+        covered_by="builder-codex-state",
         note=(
-            "**job 帳號**的 provider 憑證（#640 裁決 (b)）。洩漏面＝一次模型呼叫的額度"
-            "——job unit 另有 `Environment=GH_TOKEN=` 把 GitHub token 清空，成果一律走 "
-            "`commit-spool` 由 Manager 代理推送。**與 `manager-gh-credential` 不同級**。"
+            "**job 帳號**的 provider 憑證＋codex 狀態樹（#640 裁決 (b) → #698 方案 A）。"
+            "洩漏面＝一次模型呼叫的額度——job unit 另有 `Environment=GH_TOKEN=` 把 GitHub "
+            "token 清空，成果一律走 `commit-spool` 由 Manager 代理推送。**與 "
+            "`manager-gh-credential` 不同級**。\n"
+            "**#698 起形狀是 root-owned ＋ sticky 的整棵樹**（不再是單檔 `auth.json`）："
+            "#686 實測 codex 需要 `$CODEX_HOME` 整棵可寫，只放行單檔時它連起都起不來。"
         ),
     ),
     RunDependency(
@@ -3911,8 +4415,8 @@ RUN_EXTERNAL_DEPENDENCIES: tuple[RunDependency, ...] = (
         (Principal.REVIEWER, Principal.PLANNER), (RunStage.MODEL_CALL, RunStage.REVIEW),
         covered_by="reviewer-planner-codex-state",
         note=(
-            "#685：planner／reviewer 帳號的 codex 登入態＋狀態樹（`~/.codex` → "
-            "`cache/codex` 的 root-owned symlink）。**不是一個 `auth.json`**——#686 實測 "
+            "#685／#698：planner／reviewer 帳號的 codex 登入態＋狀態樹（`~/.codex`，"
+            "root-owned ＋ sticky 的真目錄）。**不是一個 `auth.json`**——#686 實測 "
             "codex 需要 `$CODEX_HOME` 整棵可寫，只放行單檔時它連起都起不來。"
         ),
     ),
@@ -3938,14 +4442,25 @@ RUN_EXTERNAL_DEPENDENCIES: tuple[RunDependency, ...] = (
         ),
     ),
     RunDependency(
-        "codex-hooks", DependencyKind.ACCOUNT_CONFIG,
+        "builder-codex-hooks", DependencyKind.ACCOUNT_CONFIG,
         (Principal.BUILDER,), (RunStage.MODEL_CALL,),
-        covered_by="codex-hooks",
+        covered_by="builder-codex-hooks",
         note=(
             "enforcement plane：root-owned，job 不得替換自己的 hooks（#623）。"
-            "**只有 builder 這一份**：reviewer／planner 帳號的 `~/.codex` 是導進 `cache` "
-            "的 symlink（#685），hooks 落在那棵 job-owned 的樹裡就擋不住替換——那一格"
-            "仍在 `deferred_run_dependencies()`，升為 U-9 交 operator 裁決。"
+            "#698 起它住在 root-owned ＋ sticky 的 `~/.codex` 裡——那棵樹整個可寫"
+            "（codex 才起得來），但這個檔 job 刪不掉、改不掉名字、也改不了內容。"
+        ),
+    ),
+    RunDependency(
+        "reviewer-planner-codex-hooks", DependencyKind.ACCOUNT_CONFIG,
+        (Principal.REVIEWER, Principal.PLANNER), (RunStage.MODEL_CALL, RunStage.REVIEW),
+        covered_by="reviewer-planner-codex-hooks",
+        note=(
+            "#698：這一份在 #685～#697 之間是 `deferred_run_dependencies()` 的 **U-9**"
+            "——「codex 要整棵可寫」與「樹裡放得住 root-owned 檔」在當時的形狀下互斥，"
+            "而 0818 的 R9 T3.9 實測證明不做的代價是**該帳號能植入 hooks.json** ⇒ 跨 job "
+            "持久化。方案 A（sticky）讓兩件事同時成立，本項因此從 deferred 升為登記表資產。"
+            "**它與 builder 那一份由同一條規則長出來**（`enforcement_placements()`）。"
         ),
     ),
     RunDependency(
@@ -4159,7 +4674,8 @@ class DeferredDependency:
 #: 輸出裡，測試釘住目前的內容，補上或悄悄拿掉都會讓測試變紅。
 #:
 #: 四項的共同形態是「**per-account 的機制已經就緒，但登記表只登記了其中一份**」——
-#: 與 #640 對 `builder-executor-credential` 的處置逐條同構（那一條的 note 有完整
+#: 與 #640 對 `builder-codex-state`（當時叫 `builder-executor-credential`）的處置逐條
+#: 同構（那一條的 note 有完整
 #: 論證），差別只在那時候 M2 還沒落地、現在落地了。
 _DEFERRED_RUN_DEPENDENCIES: tuple[DeferredDependency, ...] = (
     DeferredDependency(
@@ -4178,40 +4694,22 @@ _DEFERRED_RUN_DEPENDENCIES: tuple[DeferredDependency, ...] = (
         ),
         disposition="等第一個需要 git 的 gate 宣告出現時再補，或 operator 主動裁決。",
     ),
-    DeferredDependency(
-        "reviewer-planner-codex-hooks", DependencyKind.ACCOUNT_CONFIG,
-        (Principal.REVIEWER, Principal.PLANNER),
-        reason=(
-            "**#685 換掉了本項的理由，因為原本那個已經被推翻。** 原文寫的是「機制 "
-            "per-account，登記表只登記一份，補第二列即可」——#686 的實測讓「補第二列」"
-            "在這一格**做不到**：codex 需要 `$CODEX_HOME` 整個目錄可寫，因此 "
-            "`cortex-reviewer-planner` 的 `~/.codex` 已改成導進 `cache` 的 root-owned "
-            "symlink（登記表資產 `reviewer-planner-codex-state`），而那棵樹由 **job 帳號"
-            "擁有**。hooks 若放進去，job 對它的父目錄有寫入權 ⇒ 隨時 unlink／rename 換掉"
-            "⇒ 登記成 root-owned 的 Tier-0 enforcement 資產是**名義上的**，不是真的。\n"
-            "**兩件事在 `$CODEX_HOME` 這一層互斥**：(i) codex 起得來（整棵可寫）、"
-            "(ii) 同棵樹裡有一個 job 換不掉的 root-owned `hooks.json`。本票選 (i)——"
-            "選 (ii) 的部署裡 codex 根本跑不起來，hooks 也就沒有東西可以約束。"
-        ),
-        symptom=(
-            "reviewer／planner 以 `codex` 為 executor 時拿不到 root-owned hooks"
-            "（enforcement plane 少一層），且該帳號可自行放一份自己的 hooks.json 在 "
-            "`cache/codex/` 底下並持久化。**攻擊價值有界**：hooks 命令跑的身分就是它"
-            "自己、影響的也只有它自己後續的 codex 呼叫；跨帳號與跨 job 的面不受影響"
-            "（`~/.codex` 那條 symlink 在 root-owned 的 HOME 裡，換不掉）。"
-        ),
-        disposition=(
-            "**U-9（本票新提，交 operator）**：要 hooks enforcement 就必須讓 "
-            "`$CODEX_HOME` 同時「整棵可寫」與「裡面放得住 root-owned 檔」。已知的候選是"
-            "**root-owned ＋ sticky bit ＋ 給 job 帳號一條 `rwx` ACL** 的目錄（sticky 讓"
-            "非 owner 只能刪自己的檔 ⇒ root-owned 的 hooks.json 換不掉）。**本票不做，"
-            "兩個理由**：(i) 它要改 permgen 的 mode 管線——安全網 `_mask_write` 會拿掉 "
-            "group 寫入位、`mode & 0o700` 會吃掉 sticky 位，那是 spec §R2 的既有不變式；"
-            "(ii) 「codex 能不能在一個它**不擁有**的 `$CODEX_HOME` 下跑起來」**沒有實機"
-            "證據**，而 #686 量到的是「指到一個可寫目錄」。依 D13，未經落檔 unit 全量"
-            "導出的實測不得宣稱可用。"
-        ),
-    ),
+    # **U-9（`reviewer-planner-codex-hooks`）已於 #698 結案，因此本項消失。**
+    #
+    # 它從 #685 起掛在這裡，理由是「(i) codex 起得來（$CODEX_HOME 整棵可寫）與 (ii) 同棵
+    # 樹裡有一個 job 換不掉的 root-owned `hooks.json` **互斥**」，並記下兩個不做的理由：
+    # 要改 permgen 的 mode 管線（`_mask_write`／`mode & 0o700` 會吃掉 sticky），以及
+    # 「codex 能不能在一個它**不擁有**的 `$CODEX_HOME` 下跑起來」沒有實機證據。
+    #
+    # #698 把兩個理由都消掉了：
+    #   - mode 管線已能表達 sticky（`build_entry()` 尾端的安全網改成
+    #     `& (STICKY_BIT | 0o700)`，§R2 的 group／other 不可寫一行未放寬）；
+    #   - 「不擁有的 `$CODEX_HOME`」已在**完整模板 unit 加固面**下實測（runbook 第
+    #     4e-2b 步的 planning 探針矩陣，兩個帳號各一輪，逐格記路徑與版本字串）。
+    #
+    # 於是 (i) 與 (ii) 不再互斥，兩份 hooks 都成為登記表資產（`*-codex-hooks`），
+    # 由 `enforcement_placements()` 從**同一條規則**長出來——這正是「deferred 該怎麼
+    # 結案」的形態：不是刪一列，是那一列描述的張力真的不存在了。
     # #687（#672 票 F）：`manager-claude-credential` 已移除。
     #
     # 它從來不是「還沒補的憑證」，而是「Manager 在 direct 模式下自己 exec `claude`」
@@ -4399,6 +4897,8 @@ class SystemdUnit:
     content: str
     #: 生效的加固剖面 id（#643）。Manager／monitor unit 恆為 `strict`。
     hardening_profile: str = DEFAULT_HARDENING_PROFILE.profile_id
+    #: 巢狀在 `read_write_paths` 之內、被重新收回唯讀的路徑（#698 的 enforcement 檔）。
+    read_only_paths: tuple[str, ...] = ()
 
     def to_dict(self) -> dict[str, object]:
         return {
@@ -4408,6 +4908,7 @@ class SystemdUnit:
             "exec_start": self.exec_start,
             "environment_file": self.environment_file,
             "read_write_paths": list(self.read_write_paths),
+            "read_only_paths": list(self.read_only_paths),
             "hardening_profile": self.hardening_profile,
             "content": self.content,
         }
@@ -4467,7 +4968,10 @@ def _hardening_lines(
     return lines
 
 
-def _rwp_lines(owners: Mapping[str, tuple[str, ...]]) -> list[str]:
+def _rwp_lines(
+    owners: Mapping[str, tuple[str, ...]],
+    read_only: tuple[str, ...] = (),
+) -> list[str]:
     lines = [
         "# --- ReadWritePaths：由 R1 登記表機械導出（permgen），勿手擴 ---",
         "# 每條後面列出它涵蓋的登記表資產；新增 durable state 時改登記表、重跑產生器。",
@@ -4475,6 +4979,19 @@ def _rwp_lines(owners: Mapping[str, tuple[str, ...]]) -> list[str]:
     for path, covered in owners.items():
         lines.append(f"#   涵蓋：{', '.join(covered) if covered else '（無）'}")
         lines.append(f"ReadWritePaths={path}")
+    if read_only:
+        lines += [
+            "",
+            "# --- ReadOnlyPaths：巢狀在上面某條 RWP **之內**、被收回唯讀的 enforcement 檔 ---",
+            "# （#698）codex 的 $CODEX_HOME 整棵必須可寫（executor 才起得來），但樹裡的",
+            "# root-owned hooks.json 不該連 mount 層都是可寫的。systemd 依路徑排序套用這些",
+            "# bind mount，巢狀的唯讀條目後套 ⇒ 覆蓋外層的可寫性。",
+            "# **刻意沒有 `-` 前綴**：目標不存在時本 unit 直接起不來——那正是要的行為，",
+            "# 因為 sticky bit 不管「建一個還不存在的檔」，hooks.json 缺席時 job 植得進去，",
+            "# 而一個植得進 hooks 的 job 不該起得來（與上方 RWP 的 fail-closed 立場一致）。",
+        ]
+        for path in read_only:
+            lines.append(f"ReadOnlyPaths={path}")
     return lines
 
 
@@ -4715,6 +5232,26 @@ def _job_unit_credential_lines(job_layout: "PathLayout", account: str) -> list[s
                 "#     ⚠️ #686 實測：codex 需要 $CODEX_HOME **整棵**可寫，因此這個形狀下的",
                 "#     codex 在本 unit 內**起不來**（見 runbook 4e-3、deferred 的 U-9）。",
             ]
+        elif credential.shape is CredentialShape.HOME_STICKY_TREE:
+            hooks = f"{path}/{credential.enforcement_leaf}"
+            lines += [
+                f"#   [{credential.executor}] {path}（root-owned ＋ sticky，#698 方案 A）",
+                "#     可寫狀態樹：目錄由 **root** 擁有、帶 sticky bit（`chmod +t`），本",
+                "#     帳號以一條具名 **access** ACL（`u:<本帳號>:rwx`）取得整棵的寫入權。",
+                "#     ⇒ executor 起得來（#686：$CODEX_HOME 唯讀時 codex 連 in-process",
+                "#       app-server 都初始化不了），而且——",
+                f"#     ⇒ {hooks}（root:root 0644）本帳號**動不了**：",
+                "#       unlink／rename 被 sticky 擋（非 owner 只動得了自己的檔）、改內容",
+                "#       被它自己的 mode 擋（本帳號落在 `other` 位）。",
+                "#     0818 的 R9 T3.9 就是在**沒有**這兩層時被實測攻破的（#698）——codex",
+                "#     hooks 會執行命令 ⇒ 那是跨 job 持久化，不只是少一層防護。",
+                "#     ⚠️ group 寫入權仍然是零（spec §R2 未放寬）；`ls -ld` 顯示的 group 位",
+                "#       是 POSIX ACL 的 **mask**，驗證一律用 `getfacl`。",
+                "#     ⚠️ 那個 hooks 檔**必須先存在**——sticky 不管「建一個還不存在的檔」。",
+                "#       缺它時 R9 T3.9 會以「建得出新檔」翻紅（正確的紅字）。",
+                "#     代價（R-6）：樹裡的 **token 葉檔**仍由本帳號擁有、仍可被它刪除或",
+                "#     替換。那是刻意的——token 過期必須 refresh 得回來。",
+            ]
         else:
             target = job_layout.credential_target_of(account, credential)
             leaf = credential.token_leaf or "（無單一 token 葉檔）"
@@ -4935,7 +5472,8 @@ def build_job_unit(
     ]
     body += _hardening_lines(profile)
     body += [""]
-    body += _rwp_lines(owners)
+    read_only = enforcement_read_only_paths(job_layout, account, tuple(owners.keys()))
+    body += _rwp_lines(owners, read_only)
     body += [
         "",
         "# job 為一次性，不自動重啟（`CollectMode` 在上方 [Unit] 段）。",
@@ -4954,6 +5492,7 @@ def build_job_unit(
         exec_start=f"{job_layout.job_shim} %i",
         environment_file=None,
         read_write_paths=tuple(owners.keys()),
+        read_only_paths=read_only,
         content="\n".join(body) + "\n",
         hardening_profile=profile.profile_id,
     )
@@ -5072,7 +5611,7 @@ ACCOUNT_GITCONFIG_FLAGS: Mapping[Principal, str] = {
 }
 
 #: `.gitconfig` 的 mode。**0644 而非 0600**：檔案 root 擁有、讀取的帳號要讀得到，
-#: 與 `codex-hooks`（同樣 root-owned、同樣落在帳號 HOME 下）逐位元相同。
+#: 與 `*-codex-hooks`（同樣 root-owned、同樣落在帳號 HOME 下）逐位元相同。
 ACCOUNT_GITCONFIG_MODE = 0o644
 
 
@@ -5155,7 +5694,7 @@ def build_account_gitconfig(
         fatal: detected dubious ownership in repository at '<來源樹>/<slug>'
 
     唯一的解是 `safe.directory`，而它**必須由 root 放進該帳號的 HOME**——那些 HOME
-    都是 root-owned，帳號自己放不了這個檔。這正是登記表既有的 `codex-hooks`
+    都是 root-owned，帳號自己放不了這個檔。這正是登記表既有的 `*-codex-hooks`
     （root-owned、在帳號 HOME 下）同一個模式，不需要新概念。
 
     ## 為什麼每個 repo 是**兩條**值

--- a/paulsha_cortex/trust_root/registry.py
+++ b/paulsha_cortex/trust_root/registry.py
@@ -507,57 +507,98 @@ ASSET_REGISTRY: tuple[TrustRootAsset, ...] = (
             "寫入——因此本資產機械地不會出現在任何 unit 的 `ReadWritePaths` 上。"
         ),
     ),
+    # ---- 兩個 job 帳號的 codex 狀態樹（#698：形狀由同一條規則導出）----
+    #
+    # **這兩項在 #698 之前是兩種形狀**：`builder-executor-credential`（`IN_PLACE_FILE`，
+    # 單檔 `~/.codex/auth.json`）與 `reviewer-planner-codex-state`
+    # （`HOME_REDIRECT_TREE`，導進 job-owned `cache/codex` 的 symlink）。0818 的 R9 實測
+    # 證明那個差異是一個**尚未爆的洞**而不是設計，兩邊各壞一半：
+    #
+    #   - `IN_PLACE_FILE` 那一半：hooks 守得住，但 codex 在降權 unit 下**起不來**
+    #     （#686：`$CODEX_HOME` 唯讀時連 in-process app-server 都初始化不了）。
+    #   - `HOME_REDIRECT_TREE` 那一半：codex 起得來，但整棵樹 job-owned ⇒ 該帳號
+    #     **成功植入 `hooks.json`**（T3.9 `!! SUCCEEDED`）。codex hooks 會執行命令 ⇒
+    #     跨 job 持久化 ⇒ 四分隔離「每個 job 一次性」的前提在該帳號上不成立，而它正是
+    #     吃 untrusted issue 內容的那個帳號。
+    #
+    # operator 裁決（#698，方案 A）＝ `CredentialShape.HOME_STICKY_TREE`：**root-owned
+    # ＋ sticky bit ＋ job 一條 `rwx` access ACL 的真目錄**，裡面住著 root-owned 的
+    # `<前綴>-codex-hooks`。整棵可寫 ⇒ codex 起得來；sticky ⇒ job 刪不掉／改不掉名字別人
+    # 的檔，而 hooks 的 mode 讓它連內容都改不了。
+    #
+    # **兩個帳號共用同一列憑證表**（`permgen.EXECUTOR_CREDENTIALS` 的 codex 那一列），
+    # 因此形狀不可能只改一格——`_assert_shape_follows_enforcement_rule()` 在 import 當下
+    # 強制 `EXECUTOR_ENFORCEMENT_LEAVES` 那條規則。
+    #
+    # **writers 含 INSTALLER 是刻意的**（與 #640 的 `IN_PLACE_FILE` 相反）：owner 必須是
+    # root，否則 sticky 什麼也擋不住（目錄 owner 本來就刪得掉裡面任何檔）。job 的寫入權
+    # 改由 `build_entry()` 依 `UNTRUSTED_EXECUTION_PRINCIPALS` 產生具名 ACL——它**也**在
+    # writers 裡，因此 `required_write_targets()` 仍然機械地把這棵樹放進該帳號的 RWP。
+    #
+    # **R-6 不變**：樹裡的 **token 葉檔**（`auth.json`）仍由 job 擁有、仍可被它刪除或
+    # 替換。那是必要的（token 過期要 refresh 得回來），sticky 保護的是 root 擁有的那些檔。
     TrustRootAsset(
-        "builder-executor-credential", _T0, _JV, None,
-        (Principal.BUILDER,), (Principal.BUILDER,),
-        IngressKind.DIRECT_FILE_WRITE,
+        "builder-codex-state", _T0, _JV, None,
+        (Principal.INSTALLER, Principal.BUILDER), (Principal.BUILDER,),
+        IngressKind.DEPLOYMENT_WRITE,
         derived_in=("trust_root/permgen.py:PathLayout.executor_credential_of",),
         note=(
-            "builder 帳號 HOME 下那份 executor 憑證（預設 `~/.codex/auth.json`，"
-            "＝本部署 `PSC_MANAGER_EXECUTOR` 的那一個；落點由 "
-            "`PathLayout.executor_credential_relpath` 這個**部署決定**導出）。\n"
-            "**0817 裁決 (b)：檔案由 job 帳號擁有（0600），放它的目錄維持 root-owned**"
-            "（`<HOME>/.codex` 已是既有的 root-owned 骨架目錄，`codex-hooks` 就住在裡面）。"
-            "淨效果——job **能就地改寫自己那份憑證的內容**（token 過期可自行 refresh），"
-            "但在該目錄**建不了新檔、刪不掉、也換不掉同目錄下的其他 root-owned 檔**"
-            "（例如 `codex-hooks`）：建立／unlink／rename 需要的是**目錄**的寫入權，"
-            "而目錄是 `root 0755`，job 落在 `other` 位（`r-x`）。\n"
-            "**已知限制**：因此「以暫存檔 ＋ rename 原子替換」形式做 refresh 的 CLI 會"
-            "失敗（它需要在同目錄建檔）；只有就地 `O_TRUNC` 覆寫的 refresh 走得通。"
-            "這是裁決 (b) 刻意接受的代價，不是漏掉的情況。\n"
-            "**為何 writer 不含部署身分**：root 當然放得進去（安裝時就是 root 放的），"
-            "但 `writers` 描述的是**執行期**的合法 mutator——寫成 INSTALLER 會讓機械分類"
-            "落到 `owner_class=DEPLOYMENT`（owner＝root），憑證就 refresh 不了，與裁決"
-            "相反。\n"
+            "builder 帳號的 `$CODEX_HOME` 整棵（`~/.codex`，落點由 "
+            "`PathLayout.executor_credential_relpath` 這個**部署決定**的 head 導出；"
+            "token 葉檔是它的 tail，預設 `auth.json`）。\n"
+            "**#698 起與 `reviewer-planner-codex-state` 逐字同形**。在此之前它是 #640 "
+            "裁決 (b) 的 `IN_PLACE_FILE`（資產 id `builder-executor-credential`），"
+            "而那個形態的代價是**降權 unit 下的 codex 起不來**——#685 把它記成「已知並"
+            "記錄的代價」，#698 的裁決把它連同 reviewer-planner 那半邊一起收掉。\n"
             "**這買到的是什麼、不是什麼**：把 operator 的憑證複製給 job 帳號，代表 job "
-            "用的是**同一個 provider 帳號**。三分買到的是**檔案系統層**的隔離（job 偷不到"
+            "用的是**同一個 provider 帳號**。四分買到的是**檔案系統層**的隔離（job 偷不到"
             "Manager 的 token、改不了 Manager 的 state），**不是** provider 層的獨立——與 "
             "`model-identity-overlay` 的 `independence_domain` 想表達的不是同一件事。"
             "真正的 provider 層獨立需要每個 job 帳號各自的 provider 帳號，屬未來選項"
             "（spec §R1 有完整說明）。\n"
-            "**為何只登記 builder 這一份**（與 `codex-hooks` 逐條同構，不是遺漏）："
-            "登記表資產是 1:1 綁到一條絕對路徑的，而路徑要由帳號名推導；`cortex-builder` "
-            "是**兩個 scheme 都相同**的唯一 job 帳號，也是目前唯一真的以模板 unit 降權"
-            "起 job 的 persona。reviewer／planner 在二分下與 Manager 併帳"
-            "（`cortex-svc`），登記第二份會讓 Manager unit 的 `ReadWritePaths` 出現一條"
-            "**二分部署裡根本不存在**的 HOME 路徑——systemd 對不存在的 `ReadWritePaths` "
-            "目標直接讓 unit 起不來，等於用一個 M2 才需要的資產弄壞一個現存的部署形態。\n"
-            "**#685 更正「補第二列即可」這句話**（原文寫於 #640，前提已被 #686 的實測"
-            "推翻）：reviewer／planner 那一份**不能**照抄本形態。#686 在完整 reviewer "
-            "unit 沙箱下實測，codex 需要 `$CODEX_HOME`（預設 `~/.codex`）**整個目錄**可寫"
-            "——只放行 `auth.json` 一個檔時它連起都起不來（`failed to initialize in-process "
-            "app-server client: Read-only file system`），且症狀與 cwd 無關。因此那個帳號"
-            "改走 `reviewer-planner-codex-state`（`CredentialShape.HOME_REDIRECT_TREE`）。\n"
-            "**builder 維持本形態不動**：這份部署已存在、runbook 第 4e-2 步有「建不了新檔／"
-            "刪不掉／換不掉」的反向驗證，而改它會同時賣掉 `codex-hooks` 的 enforcement"
-            "（同目錄下的 root-owned 檔擋不住一個擁有該目錄的 job）——那是 operator 的"
-            "裁決（U-9），不是本票能順手做的事。**代價已知並記錄**：builder 在模板 unit 下"
-            "跑 codex 會撞到與 #686 同一條 `$CODEX_HOME` 唯讀阻斷，見 `deferred` 與 runbook。"
+            "**#640 的「以暫存檔 ＋ rename 原子替換的 refresh 走不通」這條限制隨形狀消失**"
+            "：sticky 樹裡 job 建得了自己的檔，也 rename 得動自己的檔。它擋不住的是"
+            "**別人的**檔——那正是要擋的那一個。"
+        ),
+    ),
+    TrustRootAsset(
+        "reviewer-planner-codex-state", _T0, _JV, None,
+        (Principal.INSTALLER, Principal.REVIEWER, Principal.PLANNER),
+        (Principal.REVIEWER, Principal.PLANNER),
+        IngressKind.DEPLOYMENT_WRITE,
+        derived_in=("trust_root/permgen.py:PathLayout.executor_credential_of",),
+        note=(
+            "reviewer／planner 帳號的 `$CODEX_HOME` 整棵（`~/.codex`），token 葉檔是它"
+            "底下的 `auth.json`。與 `builder-codex-state` **逐字同形**（#698）。\n"
+            "**為何是整棵而不是一個檔**（#686 實測，design 未預期）：唯讀時 codex 回 "
+            "`Error: failed to initialize in-process app-server client: Read-only file "
+            "system (os error 30)`；把 cwd 換成可寫的 `/tmp` **症狀完全相同**，維持唯讀 "
+            "cwd 只把 `CODEX_HOME` 指到可寫目錄則 **rc=0、輸出正確**。阻斷點是 "
+            "`CODEX_HOME`，不是 cwd。它在底下建 `state_5.sqlite`／`logs_2.sqlite`／"
+            "`queue_1.sqlite`／`memories_1.sqlite`／`sessions/`／`skills/`／`plugins/`／"
+            "`thread-writer-locks/`／`models_cache.json`／`installation_id`。\n"
+            "**#685→#698 的形狀變更**：#685 把它做成導進 `cache/codex` 的 root-owned "
+            "symlink。那個形狀讓 codex 起得來，代價是整棵樹 job-owned ⇒ 該帳號 0818 "
+            "**實測植入了 `hooks.json`**（R9 T3.9）。sticky 樹保住前者、收掉後者。\n"
+            "**為何不用 `CODEX_HOME=` 這個環境變數**：env 覆寫要經 "
+            "`job_runner.build_job_env()` 的白名單，那是第二條要維護的放行面；讓 "
+            "executor 的**預設**路徑解析就落在對的地方，job 側零改動。\n"
+            "**這一格的 RWP 不再被 `cache` 那一條吃掉**（#685 時會）：樹搬出 `cache`、"
+            "成為 HOME 底下的真目錄，因此 reviewer 模板 unit 多一條 `ReadWritePaths=`。"
+            "**可寫面沒有變大**——同一棵 codex 狀態樹換了位置，`cache` 那一條原本就涵蓋"
+            "它；換到的是「這棵樹的目錄由 root 擁有」，也就是 hooks 守得住的前提。"
         ),
     ),
     # ---- reviewer／planner 帳號的三份登入態（#685／#672 票 D；U-4 追認雙 domain）----
     #
-    # 三項同形，因此共用這一段說明，各自的 note 只寫「這個 executor 特有的部分」。
+    # ---- reviewer／planner 帳號的登入態（#685／#672 票 D；U-4 追認雙 domain）----
+    #
+    # **#698 起這一段只涵蓋 agy 與 claude 兩項**：同帳號的 codex 已改走
+    # `HOME_STICKY_TREE`（見上方那一對 `*-codex-state`），因為只有它的狀態樹裡住著一個
+    # root-owned 的 enforcement 檔。兩者的分界是 `permgen.EXECUTOR_ENFORCEMENT_LEAVES`
+    # 那條規則，不是帳號——同一條規則同時決定了 builder 那一格。
+    #
+    # 兩項同形，因此共用這一段說明，各自的 note 只寫「這個 executor 特有的部分」。
     #
     # **形狀**：`permgen.CredentialShape.HOME_REDIRECT_TREE`——HOME 底下一條 root-owned
     # symlink，指向該帳號 `cache` 裡的一格。三條性質同時成立，而且都是機械結果：
@@ -568,43 +609,22 @@ ASSET_REGISTRY: tuple[TrustRootAsset, ...] = (
     #   2. **job 換不掉指向**：symlink 落在 root-owned 的 HOME（`scaffold_directories()`
     #      產出 root:root 0755），換 symlink 需要對父目錄的寫入權。
     #   3. **writers 只有 INSTALLER**：`required_write_targets()` 只收 writer 面，因此
-    #      這三項機械地不會產生任何 RWP 條目，也不會產生任何跨帳號 ACL。
+    #      這兩項機械地不會產生任何 RWP 條目，也不會產生任何跨帳號 ACL。
     #
     # **為什麼不是「把憑證檔登記成葉節點」**（#640 對 builder 的做法）：#686 實測 codex
     # 與 agy 要寫的都是**一整棵**狀態樹，檔名還帶版本序號（`state_5.sqlite`）——逐項列舉
     # 會在下一次 CLI 升版時無聲失效。claude 同理。
     #
-    # **U-4 的追認範圍**：這三格代表 `cortex-reviewer-planner` 同時持有 openai／google／
-    # anthropic 三個 provider 的登入態。design 的安全退步 **R-3**（該帳號被攻陷時多邊
-    # token 一起失，而 planner 正是吃 untrusted issue 內容的角色）是**明文接受的有界
-    # 殘餘風險**——它在後續任何「planner 攻擊面」討論中不得被當成未知。
+    # **U-4 的追認範圍**：連同上方的 codex 那一格，`cortex-reviewer-planner` 同時持有
+    # openai／google／anthropic 三個 provider 的登入態。design 的安全退步 **R-3**（該帳號
+    # 被攻陷時多邊 token 一起失，而 planner 正是吃 untrusted issue 內容的角色）是**明文
+    # 接受的有界殘餘風險**——它在後續任何「planner 攻擊面」討論中不得被當成未知。
     #
     # **本形狀新增的退步（R-6，明講）**：目標樹由 job 帳號擁有 ⇒ 樹裡的 token 葉檔可被
-    # 該 job 刪除或替換（builder 的 `IN_PLACE_FILE` 擋得住「刪／換」，這裡擋不住）。
-    # 影響面限於該帳號自己的登入態；換到的是 codex／claude **能不能起得來**。直接後果：
-    # 同一棵樹裡**不得**再放任何 root-owned 的 enforcement 檔——`reviewer-planner-codex-hooks`
-    # 因此仍留在 `permgen.deferred_run_dependencies()` 並升為 **U-9**。
-    TrustRootAsset(
-        "reviewer-planner-codex-state", _T0, _JV, None,
-        (Principal.INSTALLER,), (Principal.REVIEWER, Principal.PLANNER),
-        IngressKind.DEPLOYMENT_WRITE,
-        derived_in=("trust_root/permgen.py:PathLayout.executor_credential_of",),
-        note=(
-            "`<HOME>/.codex` → `<HOME>/cache/codex` 的 root-owned symlink：codex 的 "
-            "`$CODEX_HOME` 整棵，token 葉檔是它底下的 `auth.json`。\n"
-            "**為何是整棵而不是一個檔**（#686 實測，design 未預期）：唯讀時 codex 回 "
-            "`Error: failed to initialize in-process app-server client: Read-only file "
-            "system (os error 30)`；把 cwd 換成可寫的 `/tmp` **症狀完全相同**，維持唯讀 "
-            "cwd 只把 `CODEX_HOME` 指到可寫目錄則 **rc=0、輸出正確**。阻斷點是 "
-            "`CODEX_HOME`，不是 cwd。它在底下建 `state_5.sqlite`／`logs_2.sqlite`／"
-            "`queue_1.sqlite`／`memories_1.sqlite`／`sessions/`／`skills/`／`plugins/`／"
-            "`thread-writer-locks/`／`models_cache.json`／`installation_id`。\n"
-            "**為何不用 `CODEX_HOME=` 這個環境變數而用 symlink**：env 覆寫要經 "
-            "`job_runner.build_job_env()` 的白名單，那是第二條要維護的放行面；而 symlink "
-            "讓 executor 的**預設**路徑解析就落在對的地方，job 側零改動。代價是 "
-            "`~/.codex` 這個名字被佔用（見上方 R-6 與 U-9）。"
-        ),
-    ),
+    # 該 job 刪除或替換。影響面限於該帳號自己的登入態；換到的是 agy／claude **能不能起
+    # 得來**。直接後果：同一棵樹裡**不得**再放任何 root-owned 的 enforcement 檔——這條在
+    # #698 之前是註解，現在由 `permgen._assert_shape_follows_enforcement_rule()` 在 import
+    # 當下強制（宣告了 enforcement 檔就必須改走 `HOME_STICKY_TREE`）。
     TrustRootAsset(
         "reviewer-planner-agy-state", _T0, _JV, None,
         (Principal.INSTALLER,), (Principal.REVIEWER, Principal.PLANNER),
@@ -1118,13 +1138,46 @@ ASSET_REGISTRY: tuple[TrustRootAsset, ...] = (
         derived_in=("config/runtime.py:61-66", "deploy/installer.py:162"),
         note="裸寫、無 mode；實測 -rw-rw-r--。改此檔的 PSC_* 即重導整棵 durable state。",
     ),
-    TrustRootAsset(
-        "codex-hooks", _T0, _MO, None,
-        (Principal.INSTALLER, Principal.ANY_SAME_UID), (Principal.MANAGER,),
-        IngressKind.DEPLOYMENT_WRITE,
-        derived_in=("deploy/hooks.py:48-60",),
-        note="$HOME/.codex/hooks.json；enforcement plane 的一部分。",
-    ),
+    # ---- codex hooks：**兩個 job 帳號各一份**（#698）----
+    #
+    # #698 之前這裡只有一項 `codex-hooks`，路徑寫死在 builder 的 HOME 底下，理由是
+    # 「reviewer／planner 的 `~/.codex` 是 job-owned 的樹，root-owned 的 hooks 放進去
+    # 擋不住替換」。0818 的 R9 T3.9 把那個理由的**後果**量了出來：該帳號真的植入了
+    # `hooks.json`。codex hooks **會執行命令**，因此那不是「少一層防護」而是**跨 job
+    # 持久化**——上一個 job 留得下在下一個 job 啟動時執行的東西。
+    #
+    # 方案 A 之後兩份都登記得起來，而且是同一條規則長出來的兩列
+    # （`permgen.enforcement_placements()`）：加一個跑 codex 的帳號 ⇒ 這裡自動多一份，
+    # 不必也不能手寫第三項。
+    #
+    # **這個檔必須先存在，sticky 才擋得住什麼**：sticky 管的是「刪／改名**別人的**檔」，
+    # 不管「建一個還不存在的檔」。缺這個檔時 R9 T3.9 會以「建得出新檔」翻紅——那是
+    # 正確的紅字，不是誤報。部署順序見 runbook 第 4e-2b 步。
+    *[
+        TrustRootAsset(
+            asset_id, _T0, _MO, None,
+            (Principal.INSTALLER,), (Principal.MANAGER,) + tuple(job_principals),
+            IngressKind.DEPLOYMENT_WRITE,
+            derived_in=("deploy/hooks.py:48-60", "trust_root/permgen.py:PathLayout.enforcement_placements"),
+            note=(
+                f"{home_hint}/hooks.json；enforcement plane 的一部分，**root-owned**。\n"
+                "它住在一棵 job 可寫的 sticky 樹裡（`*-codex-state`），三個動詞同時關上："
+                "unlink／rename 被 sticky 擋（非 owner 只動得了自己的檔）、改內容被自己的 "
+                "mode 擋（root:root 0644 ⇒ job 落在 `other` 位）。\n"
+                "**writers 只有 INSTALLER**：`required_write_targets()` 只收 writer 面，"
+                "因此本項機械地不進任何 job unit 的 `ReadWritePaths`；job 帳號對 codex 樹的"
+                "寫入權來自 `*-codex-state` 那一項的具名 ACL，涵蓋不到這個檔。"
+            ),
+        )
+        for asset_id, home_hint, job_principals in (
+            ("builder-codex-hooks", "<builder HOME>/.codex", (Principal.BUILDER,)),
+            (
+                "reviewer-planner-codex-hooks",
+                "<reviewer-planner HOME>/.codex",
+                (Principal.REVIEWER, Principal.PLANNER),
+            ),
+        )
+    ],
     TrustRootAsset(
         "work-items-yaml", _T1, _JV, None,
         (Principal.OPERATOR, Principal.BUILDER, Principal.ANY_SAME_UID), (Principal.BUILDER,),

--- a/tests/test_planning_job_invoker_672.py
+++ b/tests/test_planning_job_invoker_672.py
@@ -493,6 +493,10 @@ def test_planning_log_spool_needs_no_new_write_surface() -> None:
     )
     unit = permgen.build_job_unit(permgen.THREE_WAY_SCHEME, principal=Principal.REVIEWER)
     assert sorted(unit.read_write_paths) == [
+        # #698：codex 的狀態樹從 `cache/codex` 搬成 HOME 底下的 root-owned sticky 真
+        # 目錄，因此多這一條。**這不是本票（票 D／planning log）開的通道**——同一棵樹
+        # 換位置，換到的是「目錄由 root 擁有」（`hooks.json` 守得住的前提，#698）。
+        permgen.asset_paths(layout)["reviewer-planner-codex-state"],
         layout.cache_of(layout.reviewer_planner_account),
         layout.review_verdict_spool_root,
     ]

--- a/tests/test_reviewer_planner_downgrade_615.py
+++ b/tests/test_reviewer_planner_downgrade_615.py
@@ -485,10 +485,16 @@ class ReviewerWritableSurfaceTests(unittest.TestCase):
             )
         )
         self.assertEqual(self.rwp, expected)
-        # 導出結果目前恰好是兩條，逐條都有登記表或明示 extra 的來源。
+        # 導出結果目前恰好是三條，逐條都有登記表或明示 extra 的來源。
         self.assertEqual(
             sorted(self.rwp),
             [
+                # #698：codex 的 `$CODEX_HOME` 整棵（root-owned ＋ sticky 的真目錄）。
+                # 它取代了 #685 的 `cache/codex` 那棵 job-owned 樹——可寫的東西一樣多，
+                # 換到的是「目錄由 root 擁有」，也就是樹裡的 root-owned `hooks.json`
+                # 刪不掉／改不掉名字。同一份 unit 另有一條 `ReadOnlyPaths=` 把那個檔
+                # 在 mount 層也收回唯讀。
+                permgen.asset_paths(LAYOUT)["reviewer-planner-codex-state"],
                 LAYOUT.cache_of(REVIEW_ACCOUNT),
                 LAYOUT.review_verdict_spool_root,
             ],

--- a/tests/test_trust_root_executor_toolchain_640.py
+++ b/tests/test_trust_root_executor_toolchain_640.py
@@ -75,7 +75,10 @@ THREE_WAY_SCHEME = _THREE_WAY_BASE.with_principal_accounts(DEPLOYMENT_ACCOUNTS)
 ALL_SCHEMES = [TWO_WAY_SCHEME, THREE_WAY_SCHEME]
 
 TOOLCHAIN = "executor-toolchain"
-CREDENTIAL = "builder-executor-credential"
+# #698：builder 的 codex 憑證從 `IN_PLACE_FILE` 單檔（舊 id `builder-executor-credential`）
+# 改成 root-owned ＋ sticky 的**整棵樹**，與 reviewer-planner 那一格共用同一列憑證表。
+CREDENTIAL = "builder-codex-state"
+HOOKS = "builder-codex-hooks"
 NEW_ASSET_IDS = (TOOLCHAIN, CREDENTIAL)
 
 
@@ -116,17 +119,30 @@ def test_toolchain_is_deployment_owned_and_job_accounts_are_not_writers() -> Non
         assert reader in asset.readers, reader
 
 
-def test_credential_writer_is_the_job_persona_not_the_installer() -> None:
-    """裁決 (b) 的機械落點：writer 是 job persona，才會分到 `owner_class=JOB`。
+def test_credential_writers_are_both_the_installer_and_the_job_persona() -> None:
+    """#698：writer 面**兩個都要有**，而兩個各自撐住一半的形狀。
 
-    寫成 `INSTALLER` 會讓 `classify_owner()` 落到 `DEPLOYMENT`（owner＝root），
-    憑證就 refresh 不了——與裁決正好相反。這條把那個反轉釘死。
+    - `INSTALLER`：這棵樹由 root 建立、root 擁有。少了它，`classify_owner()` 不會
+      落到 `STICKY_SHARED`，owner 會變成 job 帳號——而目錄 owner 對 sticky 免疫
+      （POSIX：目錄 owner 刪得掉裡面任何檔），`hooks.json` 當場守不住。
+    - `BUILDER`：job 必須寫得進整棵樹，否則 codex 起不來（#686）。它同時是
+      `required_write_targets()` 產出 RWP 的依據，以及 `build_entry()` 產出那條
+      具名 `rwx` ACL 的依據（走 `UNTRUSTED_EXECUTION_PRINCIPALS`）。
+
+    **#640 的原斷言是相反的**（「writer 是 job persona，**不是** INSTALLER，否則會
+    落到 DEPLOYMENT、憑證就 refresh 不了」）。那條在 `IN_PLACE_FILE` 形狀下正確：
+    當時登記的節點是**憑證檔自己**，它必須 job-owned。#698 之後登記的節點是**樹**，
+    而 token 葉檔在樹裡、仍由 job 擁有（unit 的 `UMask=0077`）——refresh 照樣走得通，
+    見 `test_the_enforcement_leaf_lives_inside_the_state_tree_and_belongs_to_root`。
     """
     asset = registry.asset_by_id(CREDENTIAL)
-    assert asset.writers == (Principal.BUILDER,)
-    assert Principal.INSTALLER not in asset.writers
+    assert set(asset.writers) == {Principal.INSTALLER, Principal.BUILDER}
     assert asset.tree is TrustTree.JOB_VISIBLE
-    assert permgen.classify_owner(asset) is OwnerClass.JOB
+    assert permgen.classify_owner(asset) is OwnerClass.STICKY_SHARED
+    # enforcement 檔則相反：writer **只有** INSTALLER ⇒ 它落回 DEPLOYMENT、零 job 授權。
+    hooks = registry.asset_by_id(HOOKS)
+    assert hooks.writers == (Principal.INSTALLER,)
+    assert permgen.classify_owner(hooks) is OwnerClass.DEPLOYMENT
 
 
 # ---------------------------------------------------------------------------
@@ -195,16 +211,19 @@ def test_toolchain_lives_in_the_deployment_tree_not_the_state_tree() -> None:
 # ---------------------------------------------------------------------------
 
 @pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
-def test_credential_file_is_owned_by_the_job_account(scheme) -> None:
+def test_the_state_tree_is_root_owned_and_sticky(scheme) -> None:
+    """#698：`$CODEX_HOME` 整棵——目錄 root-owned ＋ sticky，job 以具名 ACL 取得 rwx。
+
+    **owner 必須是 root**：POSIX 的 sticky 規則對**目錄 owner** 免疫（目錄 owner 刪得掉
+    裡面任何檔），把這一層交給 job 等於整條規則不存在。
+    """
     entry = generate_plan(scheme).by_id(CREDENTIAL)
     builder = scheme.resolve(Principal.BUILDER)
-    assert entry.owner == builder, scheme.scheme_id
-    assert entry.group == scheme.group_of(builder)
-    assert not entry.is_directory, "憑證是單一檔——目錄型會讓整層被 chown 給 job"
-    assert entry.mode == 0o600, entry.mode_str
-    # 跨帳號一條 ACL 都不給：Manager 沒有理由讀 job 的登入態。
-    assert entry.acls == ()
-    assert plan_writers(scheme, CREDENTIAL) == frozenset({builder})
+    assert entry.owner == scheme.deploy_account == "root", scheme.scheme_id
+    assert entry.is_directory, "#698 起它是整棵樹，不是單檔"
+    assert entry.sticky and entry.mode_str == "1755", entry.mode_str
+    assert [(a.account, a.perms, a.default) for a in entry.acls] == [(builder, "rwx", False)]
+    assert plan_writers(scheme, CREDENTIAL) == frozenset({"root", builder})
 
 
 def plan_writers(scheme, asset_id: str) -> frozenset[str]:
@@ -213,56 +232,56 @@ def plan_writers(scheme, asset_id: str) -> frozenset[str]:
 
 
 @pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
-def test_credential_parent_directory_stays_root_owned(scheme) -> None:
-    """裁決 (b) 的全部性質都落在這一層：目錄 root-owned ⇒ job 增／刪／換不了。"""
+def test_the_state_trees_parent_home_stays_root_owned(scheme) -> None:
+    """整棵樹**換不掉**的那一層仍在骨架上：HOME 是 root-owned 0755。
+
+    #698 把樹本身從骨架移進登記表（sticky ＋ ACL 表達不了在骨架那個四元組裡），
+    但「job 換不掉整棵 `~/.codex`」這條性質沒有搬家——它一直是 HOME 那一層守的。
+    """
     scaffold = {
         path: (owner, mode)
         for path, owner, _group, mode in DEFAULT_LAYOUT.scaffold_directories(scheme)
     }
-    builder = scheme.resolve(Principal.BUILDER)
-    cred_dir = DEFAULT_LAYOUT.executor_credential_dir_of(DEFAULT_LAYOUT.builder_account)
-    assert cred_dir in scaffold, (scheme.scheme_id, sorted(scaffold))
-    owner, mode = scaffold[cred_dir]
-    assert owner == scheme.deploy_account == "root"
-    assert mode == 0o755
-    # 「目錄沒有 w 位給 job」就是那條不變式本身。
-    assert not mode & 0o020 and not mode & 0o002, format(mode, "04o")
-    # 憑證檔確實落在那一層底下，而不是別處。
-    cred = DEFAULT_LAYOUT.asset_paths()[CREDENTIAL]
-    assert cred == f"{cred_dir}/auth.json"
-    assert cred.startswith(DEFAULT_LAYOUT.home_of(DEFAULT_LAYOUT.builder_account) + "/")
-    assert builder  # scheme 一定解析得出 builder 帳號
+    home = DEFAULT_LAYOUT.home_of(DEFAULT_LAYOUT.builder_account)
+    assert scaffold[home] == ("root", 0o755)
+    # 樹自己**不在**骨架（第二份真相會被 `_dedupe_scaffold()` 靜默取前者）。
+    cred_dir = DEFAULT_LAYOUT.asset_paths()[CREDENTIAL]
+    assert cred_dir not in scaffold, (scheme.scheme_id, cred_dir)
+    assert cred_dir == f"{home}/.codex"
 
 
-def test_credential_shares_its_directory_with_a_root_owned_tier0_file() -> None:
-    """同目錄下就放著 root-owned 的 `codex-hooks`——那正是「換不掉」要守的東西。"""
+def test_the_enforcement_leaf_lives_inside_the_state_tree_and_belongs_to_root() -> None:
+    """樹裡放著 root-owned 的 `hooks.json`——那正是 sticky 換到的東西。"""
     paths = DEFAULT_LAYOUT.asset_paths()
-    cred_dir = DEFAULT_LAYOUT.executor_credential_dir_of(DEFAULT_LAYOUT.builder_account)
-    assert _within(paths["codex-hooks"], cred_dir)
-    assert _within(paths[CREDENTIAL], cred_dir)
-    hooks = generate_plan(THREE_WAY_SCHEME).by_id("codex-hooks")
-    assert hooks.owner == "root", "同目錄的 hooks 仍是 root 的"
+    tree = paths[CREDENTIAL]
+    assert _within(paths[HOOKS], tree)
+    assert paths[HOOKS] == f"{tree}/hooks.json"
+    hooks = generate_plan(THREE_WAY_SCHEME).by_id(HOOKS)
+    assert hooks.owner == "root"
+    assert hooks.mode_str == "0644"
+    assert hooks.acls == (), "零跨帳號授權——job 連讀寫 ACL 都不該有"
+    # token 葉檔則相反：它必須是 job 的（token 過期要 refresh 得回來）。
+    token = DEFAULT_LAYOUT.credential_token_path_of(DEFAULT_LAYOUT.builder_account)
+    assert token == f"{tree}/auth.json"
 
 
 @pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
-def test_credential_read_write_path_is_the_file_itself_not_its_parent(scheme) -> None:
-    """一般規則把檔案折算成父目錄；這一族是**明示**的例外。
+def test_the_state_tree_is_writable_but_the_hooks_file_is_mount_read_only(scheme) -> None:
+    """#698：整棵進 RWP（codex 才起得來），樹裡的 hooks 再以 ReadOnlyPaths 收回。
 
-    折算成父目錄會讓 job unit 的 mount 層開放整個 `~/.codex`（裡面還有 root-owned 的
-    `hooks.json`）；掛在檔案本身則讓「目錄 root-owned」在**檔案系統**與 **systemd
-    mount** 兩層同時成立。#623 那條「兩個 root-owned 設定檔不可寫」的既有不變式因此
-    仍然逐字成立。
+    #640 的 `IN_PLACE_FILE` 讓 hooks 同時被 DAC 與 systemd mount 兩層擋住。本形狀若
+    只做 DAC 就是**淨退一層**，因此 mount 那一層改由巢狀 `ReadOnlyPaths=` 提供。
     """
-    assert CREDENTIAL in IN_PLACE_CONTENT_WRITE_ASSETS
     unit = build_job_unit(scheme, DEFAULT_LAYOUT)
-    cred = DEFAULT_LAYOUT.asset_paths()[CREDENTIAL]
-    cred_dir = DEFAULT_LAYOUT.executor_credential_dir_of(DEFAULT_LAYOUT.builder_account)
-    assert cred in unit.read_write_paths, unit.read_write_paths
-    assert cred_dir not in unit.read_write_paths, unit.read_write_paths
-    # 父目錄不得被任何一條 RWP 涵蓋（含更上層的 HOME）。
-    assert not any(_within(cred_dir, rwp) for rwp in unit.read_write_paths), (
-        unit.read_write_paths
-    )
+    tree = DEFAULT_LAYOUT.asset_paths()[CREDENTIAL]
+    hooks = DEFAULT_LAYOUT.asset_paths()[HOOKS]
+    assert tree in unit.read_write_paths, unit.read_write_paths
+    assert hooks in unit.read_only_paths, unit.read_only_paths
+    # 巢狀關係是前提：ReadOnlyPaths 要覆蓋掉的就是外層那條 RWP。
+    assert any(_within(hooks, rwp) for rwp in unit.read_write_paths)
+    # HOME 那一層仍然不在 RWP 內（換不掉整棵樹）。
+    home = DEFAULT_LAYOUT.home_of(DEFAULT_LAYOUT.builder_account)
+    assert not any(_within(home, rwp) for rwp in unit.read_write_paths)
 
 
 def test_credential_is_absent_from_the_manager_and_monitor_units() -> None:
@@ -279,32 +298,27 @@ def test_credential_is_absent_from_the_manager_and_monitor_units() -> None:
 
 
 def test_credential_relpath_is_a_validated_deployment_decision() -> None:
-    """換 executor 只改一個值，且值的形狀在**建構當下**就驗（不等到 root 執行）。"""
+    """換 executor 只改一個值，且值的形狀在**建構當下**就驗（不等到 root 執行）。
+
+    **#698 起那一個值被切成 head／tail 兩半**：head 是 sticky 樹（登記節點），
+    tail 是 token 葉檔。兩半來自同一個字串 ⇒ 不可能各改一半。
+    """
     alt = PathLayout(executor_credential_relpath=".claude/credentials.json")
     account = alt.builder_account
-    assert alt.executor_credential_of(account).endswith("/.claude/credentials.json")
-    assert alt.executor_credential_dir_of(account).endswith("/.claude")
-    # 換了 relpath，骨架的那條 root-owned 保護必須**跟著走**（不是寫死 `.codex`）。
-    scaffold = {p: (o, m) for p, o, _g, m in alt.scaffold_directories(THREE_WAY_SCHEME)}
-    assert scaffold[alt.executor_credential_dir_of("cortex-builder")] == ("root", 0o755)
+    assert alt.executor_credential_of(account).endswith("/.claude")
+    assert alt.credential_token_path_of(account).endswith("/.claude/credentials.json")
+    # hooks 跟著樹走——換了 relpath 之後它不能還留在 `.codex` 底下（那樣 codex 根本
+    # 不會去讀它，是一個**不會報錯**的 enforcement 缺口）。
+    hooks = {aid: path for aid, _a, path, _c in alt.enforcement_placements()}
+    assert hooks[HOOKS].endswith("/.claude/hooks.json")
+    assert alt.codex_hooks_dir_of(account).endswith("/.claude")
     for bad in ("auth.json", "/etc/passwd", "../../etc/passwd", "..", ".codex/a b"):
         with pytest.raises(ValueError):
             PathLayout(executor_credential_relpath=bad)
 
 
-def test_scaffold_gives_every_model_job_account_a_root_owned_credential_dir() -> None:
-    """機制是 per-account 的：登記表只掛 builder 一份，保護面卻涵蓋全部 job 帳號。"""
-    scaffold = {
-        p: (o, m)
-        for p, o, _g, m in DEFAULT_LAYOUT.scaffold_directories(THREE_WAY_SCHEME)
-    }
-    for account in ("cortex-builder", "cortex-reviewer-planner"):
-        cred_dir = DEFAULT_LAYOUT.executor_credential_dir_of(account)
-        assert scaffold[cred_dir] == ("root", 0o755), account
-
-
 def test_scaffold_has_no_duplicate_paths() -> None:
-    """預設 relpath 下憑證父目錄與 `~/.codex` 是同一層——去重後只出現一次。"""
+    """骨架清單去重後每條路徑只出現一次（`_dedupe_scaffold` 只留第一筆）。"""
     for scheme in ALL_SCHEMES:
         dirs = DEFAULT_LAYOUT.scaffold_directories(scheme)
         paths = [p for p, _o, _g, _m in dirs]
@@ -312,75 +326,35 @@ def test_scaffold_has_no_duplicate_paths() -> None:
 
 
 # ---------------------------------------------------------------------------
-# 3b. 「能改內容、不能增刪換」——真的 OS 語意（#638 的教訓）
+# 3b. 「整棵可寫、但動不了 root 的檔」——真的 OS 語意（#638 的教訓）
 # ---------------------------------------------------------------------------
 
-@pytest.mark.skipif(
-    os.geteuid() == 0,
+@pytest.mark.skip(
     reason=(
-        "root 不受 DAC 限制：以 root 跑時目錄少了 w 位照樣建得了檔，"
-        "本組驗的語意在 root 下不存在——刻意 skip 而非空過"
-    ),
+        "#698：sticky bit 的語意**需要第二個 UID**，CI 重現不了——因此具名 skip，"
+        "不靜默通過。\n"
+        "sticky 的 kernel 判定（`fs/namei.c: check_sticky()`）是：目錄帶 S_ISVTX 時，"
+        "只有『**檔案 owner** == 行程 uid』或『**目錄 owner** == 行程 uid』或 "
+        "CAP_FOWNER，才准 unlink／rename 那個檔。它比對的是 **uid**，因此無法像 "
+        "#640 的 `IN_PLACE_FILE` 那樣用『把 owner 位調成 r-x』來重現：那一條守的是"
+        "『目錄有沒有 w 位』（同一個 uid 就驗得到），這一條守的是『檔案屬不屬於我』"
+        "（同一個 uid 永遠為真 ⇒ 測試必然全綠，是**假綠**）。\n"
+        "本組因此改由 runbook 第 8 步的 R9 T3.9 在**真實部署、真實兩個 headless "
+        "帳號、完整模板 unit 加固面**下實跑（#627 的身分鎖確保它只能以那兩個帳號執行）。"
+        "0818 的實測結果逐字記在 runbook 的第 8 步表格：兩個 subject 都 "
+        "`denied (OK) rc=2`（修前 reviewer-planner 是 `!! SUCCEEDED (FAIL)`）。\n"
+        "另有一組 OS 層量測記在 runbook 第 4e-2b 步：以 `systemd-run` 起兩個剖面，"
+        "分別驗『巢狀 ReadOnlyPaths 生效（Read-only file system）』與『DAC 三個動詞"
+        "全關（Permission denied／Operation not permitted ×2）』。\n"
+        "⛔ 不要把本組改成『用同一個 uid 建一棵 sticky 目錄』就當驗過了——那正是"
+        "#638 那一族假綠的形態（單 UID 讓斷言真空）。"
+    )
 )
-class TestInPlaceCredentialOsSemantics:
-    """把裁決 (b) 的三條性質對**真的檔案系統**驗一次。
+class TestStickyTreeOsSemantics:
+    """佔位：sticky 的真實語意在 CI 環境（單一 uid）結構性驗不到。見上方 skip 理由。"""
 
-    #638 的教訓是「涉及 OS 層語意的不變式，測試要能真的驗到那個語意」。這裡不需要
-    第二個 UID：裁決 (b) 守的規則是「**目錄沒有 `w` 位給這個行程**」——真實部署裡
-    job 帳號落在 root-owned `0755` 的 `other` 位（`r-x`），本測試以 owner 位為
-    `r-x`（`0555`）重現**同一條 kernel 檢查**（`inode_permission(dir, MAY_WRITE)`）。
-    兩者走的是同一段判定，只是命中的是不同那一組權限位。
-
-    真正需要第二個 UID 的只有「檔案 owner 不是本行程」那一半，而那一半由上面的
-    產生器測試（`entry.owner == builder`）釘住，不重複用一個要 root 才跑得起來的
-    測試去驗同一件事。
-    """
-
-    @pytest.fixture()
-    def tree(self, tmp_path: Path):
-        """`~/.codex` 的最小重現：目錄不可寫、憑證檔可寫、旁邊一個不可換的鄰居。"""
-        cred_dir = tmp_path / ".codex"
-        cred_dir.mkdir()
-        cred = cred_dir / "auth.json"
-        cred.write_text('{"token": "old"}\n', encoding="utf-8")
-        cred.chmod(0o600)
-        # 同目錄下的 root-owned 鄰居（真實部署裡是 `hooks.json`）。
-        neighbour = cred_dir / "hooks.json"
-        neighbour.write_text("{}\n", encoding="utf-8")
-        # 目錄：對本行程 `r-x`——重現 job 帳號在 root-owned 0755 目錄上的有效權限。
-        cred_dir.chmod(0o555)
-        try:
-            yield cred_dir, cred, neighbour
-        finally:
-            # 還原後 pytest 才收得掉這棵樹（不可寫的目錄 rmtree 會失敗）。
-            cred_dir.chmod(0o755)
-
-    def test_content_can_be_rewritten_in_place(self, tree) -> None:
-        """refresh 走得通：憑證檔是自己的，`O_TRUNC` 覆寫不需要目錄的寫入權。"""
-        _cred_dir, cred, _neighbour = tree
-        cred.write_text('{"token": "refreshed"}\n', encoding="utf-8")
-        assert "refreshed" in cred.read_text(encoding="utf-8")
-        assert stat.S_IMODE(cred.stat().st_mode) == 0o600
-
-    def test_new_files_cannot_be_created_in_the_directory(self, tree) -> None:
-        """「建不了新檔」——這同時封掉「暫存檔 ＋ rename」那條原子替換路徑。"""
-        cred_dir, _cred, _neighbour = tree
-        with pytest.raises(PermissionError):
-            (cred_dir / "auth.json.tmp").write_text("x", encoding="utf-8")
-
-    def test_the_credential_cannot_be_unlinked(self, tree) -> None:
-        """「刪不掉」——unlink 需要的是**目錄**的寫入權，不是檔案的。"""
-        _cred_dir, cred, _neighbour = tree
-        with pytest.raises(PermissionError):
-            cred.unlink()
-        assert cred.exists()
-
-    def test_the_root_owned_neighbour_cannot_be_replaced(self, tree) -> None:
-        """「換不掉同目錄下的其他 root-owned 檔」——rename 同樣要目錄的寫入權。"""
-        _cred_dir, cred, neighbour = tree
-        with pytest.raises(PermissionError):
-            os.replace(cred, neighbour)
-        assert neighbour.read_text(encoding="utf-8") == "{}\n"
+    def test_root_owned_neighbour_cannot_be_unlinked_by_another_uid(self) -> None:
+        raise AssertionError("需要第二個 UID——見 class 的 skip 理由")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_trust_root_external_deps_exhaustive_666.py
+++ b/tests/test_trust_root_external_deps_exhaustive_666.py
@@ -271,6 +271,8 @@ def test_inapplicable_assets_are_enumerable_not_silent() -> None:
         "reviewer-planner-codex-state",
         "reviewer-planner-agy-state",
         "reviewer-planner-claude-state",
+        # #698：那個帳號的 codex hooks 也掛在同一個 HOME 下，因此同樣不適用於二分。
+        "reviewer-planner-codex-hooks",
     }, sorted(two_way)
     # 定案的兩個方案完全沒有不適用項——有的話就是 layout 的帳號欄位與方案對不上。
     for scheme in ALL_SCHEMES:
@@ -544,9 +546,12 @@ def test_every_downgraded_principal_appears_somewhere_in_the_inventory() -> None
 def test_home_anchored_assets_are_derived_not_hand_written() -> None:
     """憑證／per-account 設定那一族由 `asset_paths()` 機械導出，不是手抄清單。"""
     assert home_anchored_asset_ids() == frozenset({
-        "builder-executor-credential",
+        # #698：builder 的 codex 憑證改成 sticky 樹（舊 id `builder-executor-credential`），
+        # 而 `codex-hooks` 拆成 per-account 兩份——兩者都由憑證表那條規則導出。
+        "builder-codex-state",
+        "builder-codex-hooks",
+        "reviewer-planner-codex-hooks",
         "builder-gitconfig",
-        "codex-hooks",
         GH_CONFIG,
         GH_CREDENTIAL,
         "manager-gitconfig",
@@ -572,8 +577,13 @@ def test_deferred_dependencies_stay_enumerable() -> None:
       （U-5 裁決）為那個帳號登記了三格登入態（codex／agy／claude）。原本那條 deferred
       的 `disposition` 寫的是「補登記表第二列（產生器一行都不必改）」，而 #686 的實測
       證明那句話是錯的：codex 需要 `$CODEX_HOME` 整棵可寫，單檔不夠。
-    - `reviewer-planner-codex-hooks` **留著，但理由整段換掉**：它現在不是「還沒補」，
-      而是與 codex 的可用性**在 `$CODEX_HOME` 這一層互斥**（升為 U-9）。
+    - `reviewer-planner-codex-hooks` 在 #685 當時**留著**，理由是它與 codex 的可用性
+      **在 `$CODEX_HOME` 這一層互斥**（升為 U-9）。**#698 把它關掉了**，而且不是
+      「刪一列」：operator 裁決採方案 A（sticky ＋ root-owned hooks）之後那條張力
+      **真的不存在了**——兩件事同時成立，兩份 hooks 都成為登記表資產。
+      關閉的前提有兩個，兩個都已在本 PR 內完成：mode 管線能表達 sticky
+      （`build_entry()` 的安全網），以及「codex 在一個它不擁有的 `$CODEX_HOME` 下
+      跑得起來」的實機證據（runbook 第 4e-2b 步，完整模板 unit 加固面）。
     - `manager-claude-credential` 在 #685 當時**留著**：U-5 解除了它的機械阻礙
       （表達得了了），但「要不要給 Manager 一份模型憑證」是 #672 的核心裁決，答案是
       不要；本項由票 F（#687）切換之後隨 direct 路徑一起消失，**不是**當時刪掉。
@@ -586,8 +596,10 @@ def test_deferred_dependencies_stay_enumerable() -> None:
     deferred = deferred_run_dependencies()
     assert {item.name for item in deferred} == {
         "gate-gitconfig",
-        "reviewer-planner-codex-hooks",
     }, sorted(item.name for item in deferred)
+    # #698：關閉的那一項不得以任何形式「改個名字留下來」，而且它必須真的變成資產。
+    assert "reviewer-planner-codex-hooks" not in {item.name for item in deferred}
+    assert "reviewer-planner-codex-hooks" in {a.asset_id for a in ASSET_REGISTRY}
     # #687：被移除的那一項不得以任何形式「改個名字留下來」。
     assert "manager-claude-credential" not in {item.name for item in deferred}
     for item in deferred:

--- a/tests/test_trust_root_job_template_ab.py
+++ b/tests/test_trust_root_job_template_ab.py
@@ -458,34 +458,43 @@ class SchemeDerivedHomeTests(unittest.TestCase):
     def test_every_model_job_account_gets_a_root_owned_codex_dir(self) -> None:
         """跑模型的帳號都不得替換自己的 codex 設定落點。
 
-        **#685 之後這條分兩種形狀成立，不再是「兩個帳號都有 root-owned `~/.codex`」。**
-        原因是 #686 的實測：codex 需要 `$CODEX_HOME` **整棵**可寫，因此
-        `cortex-reviewer-planner` 的 `~/.codex` 改成導進 `cache` 的 root-owned symlink。
-        「job 換不掉」這條性質**沒有消失，只是換了守它的那一層**：
+        **#698 之後兩個帳號的形狀又收斂回同一種**（#685 曾讓它們分岔）：
+        `~/.codex` 是 root-owned ＋ sticky 的**真目錄**，登記表資產
+        `<前綴>-codex-state`。因此它**不在骨架清單裡**——留在骨架會是第二份真相，
+        而 `_dedupe_scaffold()` 只留第一筆 ⇒ 骨架那份 0755 會把 sticky 位靜默蓋掉。
 
-        - builder（`IN_PLACE_FILE`）：`~/.codex` 是 root-owned 目錄 ⇒ 連同 `hooks.json`
-          一起擋住；
-        - reviewer-planner（`HOME_REDIRECT_TREE`）：`~/.codex` 是 root-owned **symlink**，
-          放在 root-owned 的 HOME 裡 ⇒ job 換不掉它的**指向**（但擋不住樹裡的內容，
-          那正是 U-9 那筆 deferred 記錄的代價）。
+        「job 換不掉」這條性質由兩層守：HOME 是 root-owned（換不掉整棵樹），樹自己是
+        root-owned ＋ sticky（換不掉裡面 root 的檔）。
         """
         scheme = permgen.THREE_WAY_SCHEME
         layout = permgen.DEFAULT_LAYOUT
+        plan = permgen.generate_plan(scheme)
+        paths = layout.asset_paths()
         by_path = {
             path: owner
             for path, owner, _g, _m in layout.scaffold_directories(scheme)
         }
-        # builder：root-owned 的真目錄。
-        self.assertEqual(by_path[layout.codex_hooks_dir_of("cortex-builder")], "root")
-        # reviewer-planner：`~/.codex` **不得**是骨架目錄（它是 symlink），而它的 HOME
-        # 是 root-owned ⇒ 換不掉那條 symlink。
+        for account in ("cortex-builder", "cortex-reviewer-planner"):
+            codex_home = layout.codex_hooks_dir_of(account)
+            # (1) 不在骨架（它是登記表資產，由權限計畫落位）。
+            self.assertNotIn(codex_home, by_path)
+            # (2) 是那個帳號的 sticky 樹資產，root-owned ＋ sticky。
+            asset_id = f"{layout.credential_prefix_of(account)}-codex-state"
+            self.assertEqual(paths[asset_id], codex_home)
+            entry = plan.by_id(asset_id)
+            self.assertEqual(entry.owner, "root")
+            self.assertTrue(entry.sticky)
+            # (3) HOME 那一層仍是 root-owned（換不掉整棵樹）。
+            self.assertEqual(by_path[layout.home_of(account)], "root")
+        # #698：codex 已不是 symlink 型資產，因此不在 `symlink_targets()` 上。
+        # 仍是 symlink 的那兩格（agy／claude）目標由該帳號自己擁有、落在既有的
+        # `cache` 底下（不新增可寫面）——那條性質沒有改變。
         planner = "cortex-reviewer-planner"
-        self.assertNotIn(layout.codex_hooks_dir_of(planner), by_path)
-        self.assertEqual(by_path[layout.home_of(planner)], "root")
-        # symlink 的目標由該帳號自己擁有，且落在既有的 `cache` 底下（不新增可寫面）。
-        target = layout.symlink_targets()["reviewer-planner-codex-state"]
-        self.assertEqual(by_path[target], planner)
-        self.assertTrue(target.startswith(layout.cache_of(planner) + "/"), target)
+        self.assertNotIn("reviewer-planner-codex-state", layout.symlink_targets())
+        for asset_id in ("reviewer-planner-agy-state", "reviewer-planner-claude-state"):
+            target = layout.symlink_targets()[asset_id]
+            self.assertEqual(by_path[target], planner)
+            self.assertTrue(target.startswith(layout.cache_of(planner) + "/"), target)
 
     def test_custom_home_root_needs_no_code_change(self) -> None:
         alt = permgen.PathLayout(home_root="/srv/homes")

--- a/tests/test_trust_root_permgen_p2a.py
+++ b/tests/test_trust_root_permgen_p2a.py
@@ -62,7 +62,13 @@ def test_every_entry_fully_populated(scheme) -> None:
     for e in plan.entries:
         assert e.owner, e.asset_id
         assert e.group, e.asset_id
-        assert 0 <= e.mode <= 0o777, e.asset_id
+        # #698：mode 可帶 sticky（0o1000），但**永遠**不得帶 setuid／setgid。
+        assert 0 <= e.mode <= 0o1777, e.asset_id
+        assert not (e.mode & 0o6000), (e.asset_id, e.mode_str)  # setuid/setgid
+        # sticky 只出現在那一族，且必然是目錄——別處長出一位 sticky 一定是 bug。
+        if e.mode & permgen.STICKY_BIT:
+            assert e.asset_id in permgen.STICKY_JOB_WRITABLE_DIR_ASSETS, e.asset_id
+            assert e.is_directory, e.asset_id
         assert e.owner_class in OwnerClass, e.asset_id
         assert e.writer_accounts, e.asset_id  # 至少 owner 可寫
         assert e.rationale, e.asset_id
@@ -74,13 +80,67 @@ def test_every_entry_fully_populated(scheme) -> None:
 
 @pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
 def test_builder_never_writes_manager_owned_or_deployment(scheme) -> None:
-    """spec §R2：builder 對 Manager-owned／deployment 樹零寫入（兩 scheme 皆然）。"""
+    """spec §R2：builder 對 Manager-owned／deployment 樹零寫入（兩 scheme 皆然）。
+
+    **#698 起 `OwnerClass.STICKY_SHARED` 不在這條的涵蓋範圍內，而那是刻意的**：
+    sticky 樹（`~/.codex`）由 root 擁有、但 job **必須**寫得進去（否則 codex 起不來）。
+    它之所以不塞進 `DEPLOYMENT`，正是為了讓本測試維持「機械成立、零例外清單」。
+    真正要守的那一半改由下一個測試釘住：樹**裡面**那個 root-owned 的 enforcement 檔，
+    builder 一個位元都不能寫。
+    """
     builder = scheme.resolve(Principal.BUILDER)
     plan = _plan(scheme)
     for e in plan.entries:
         if e.owner_class in (OwnerClass.MANAGER_STATE, OwnerClass.DEPLOYMENT):
             writable = plan.all_writable_accounts(e)
             assert builder not in writable, (scheme.scheme_id, e.asset_id, sorted(writable))
+
+
+@pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
+def test_enforcement_leaves_are_never_writable_by_any_job_account(scheme) -> None:
+    """#698：sticky 樹裡那個 root-owned 的 enforcement 檔，**任何** job 帳號零寫入。
+
+    這是 sticky 樹換到的東西本身。0818 的 R9 T3.9 攻破的就是這一條——當時
+    `cortex-reviewer-planner` 的 `~/.codex` 整棵 job-owned，`hooks.json` 想放也放不住。
+    codex hooks 會執行命令 ⇒ 那不是「少一層防護」，是跨 job 持久化。
+    """
+    plan = _plan(scheme)
+    job_accounts = {
+        a for a in (scheme.resolve(p) for p in permgen.UNTRUSTED_EXECUTION_PRINCIPALS)
+        if a is not None
+    }
+    assert permgen.ENFORCEMENT_LEAF_ASSETS, "enforcement 檔一族不得為空"
+    for asset_id in permgen.ENFORCEMENT_LEAF_ASSETS:
+        e = plan.by_id(asset_id)
+        assert e.owner_class is OwnerClass.DEPLOYMENT, asset_id
+        assert e.owner == scheme.deploy_account, asset_id
+        writable = plan.all_writable_accounts(e)
+        assert not (writable & job_accounts), (scheme.scheme_id, asset_id, sorted(writable))
+        assert not e.acls, (asset_id, e.acls)  # 零跨帳號授權
+
+
+@pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
+def test_sticky_trees_are_root_owned_with_named_acls_and_no_default_acl(scheme) -> None:
+    """#698 方案 A 的三個條件，逐條釘住（少任何一條，整個裁決就是空的）。"""
+    plan = _plan(scheme)
+    for asset_id in permgen.STICKY_JOB_WRITABLE_DIR_ASSETS:
+        try:
+            e = plan.by_id(asset_id)
+        except KeyError:  # 本方案沒有這個帳號
+            continue
+        # (1) owner 必須是 root：目錄 owner 對 sticky 免疫。
+        assert e.owner == scheme.deploy_account, asset_id
+        # (2) sticky bit 必須留在 mode 裡（安全網一度會吃掉它，那是本票修的東西）。
+        assert e.sticky, (asset_id, e.mode_str)
+        assert e.mode_str == "1755", (asset_id, e.mode_str)
+        # (3) 具名 access ACL、**且沒有 default ACL**——default 會讓 root 日後放進去的
+        #     enforcement 檔自動帶上 job 的 rwx，等於把整個形狀交還回去。
+        assert e.acls, asset_id
+        for acl in e.acls:
+            assert acl.perms == "rwx", (asset_id, acl)
+            assert acl.default is False, (asset_id, acl)
+        rendered = "\n".join(e.commands(f"/tmp/{asset_id}"))
+        assert "setfacl -d" not in rendered, rendered
 
 
 @pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
@@ -237,12 +297,35 @@ def test_commands_are_strings_only_and_never_execute(scheme) -> None:
     字串——絕不執行任何 root 操作。"""
     plan = _plan(_resolved(scheme))
     lines = permgen.plan_to_commands(plan)
-    allowed = ("install -d ", "chown ", "chmod ", "setfacl ", "[ ! -e ")
+    # #698 擴了三個動詞，逐條有理由——這張清單就是「這份 script 會做什麼」的全部：
+    #   `[ ! -L `：sticky 樹與它的 enforcement 檔都住在 **job 可寫**的位置，root 對
+    #             它們動手之前必須先確認不是 symlink（job 預埋一條懸空 symlink，
+    #             root 的 `cat >`／`chown` 就會跟著它跑到別處去）。
+    #   `[ -e `  ：enforcement 檔的 create-if-absent 守衛（**不是**「不存在就跳過」）。
+    #   `cat > ` ：把最小內容種進 enforcement 檔。它是唯一會寫入內容的動詞，目標永遠
+    #             是登記表上的 enforcement 路徑，內容是常數。
+    allowed = (
+        "install -d ", "chown ", "chmod ", "setfacl ",
+        "[ ! -e ", "[ ! -L ", "[ -e ",
+    )
+    heredoc_end = None
     for line in lines:
         stripped = line.strip()
+        if heredoc_end is not None:
+            # heredoc 內容區：逐字就是 `CODEX_HOOKS_SEED_CONTENT`，不是命令。
+            if stripped == heredoc_end:
+                heredoc_end = None
+            continue
         if not stripped or stripped.startswith("#"):
             continue
+        if "<<'" in stripped:
+            assert stripped.startswith("[ -e ") and "cat > " in stripped, stripped
+            heredoc_end = stripped.split("<<'", 1)[1].rstrip("'")
+            continue
         assert stripped.startswith(allowed), stripped
+    assert heredoc_end is None, "heredoc 沒有收尾——產出的 script 會吃掉後面所有命令"
+    seeded = "\n".join(lines)
+    assert permgen.CODEX_HOOKS_SEED_CONTENT.splitlines()[0] in seeded
     # 每個資產都要在命令輸出裡出現（以 placeholder 或註解形式）。
     joined = "\n".join(lines)
     for a in ASSET_REGISTRY:

--- a/tests/test_trust_root_permgen_p2b.py
+++ b/tests/test_trust_root_permgen_p2b.py
@@ -188,6 +188,13 @@ def test_job_unit_read_write_paths_exclude_manager_owned(scheme) -> None:
         builder = scheme.resolve(Principal.BUILDER)
         if builder in plan.all_writable_accounts(entry):
             continue  # spool 之類以 ACL 明示授權者（見下一個測試）
+        if target in unit.read_only_paths:
+            # #698：enforcement 檔（`hooks.json`）住在 sticky 樹**裡**，而那棵樹整棵
+            # 必須進 RWP（codex 才起得來）。它因此是本規則唯一的巢狀例外，而例外的
+            # 代價已被同一份 unit 的 `ReadOnlyPaths=` 收回——mount 層對它仍是唯讀。
+            # 實測（0818，本機 systemd）：巢狀 ReadOnlyPaths 生效，寫入回
+            # `Read-only file system`；DAC 那一層另外把 unlink／rename 也關上。
+            continue
         assert not any(_within(target, rwp) for rwp in unit.read_write_paths), (
             scheme.scheme_id, entry.asset_id, unit.read_write_paths,
         )
@@ -540,11 +547,15 @@ def test_scaffold_directories_are_command_strings_only() -> None:
         assert path not in seen, f"骨架目錄重複：{path}"
         seen.add(path)
         assert owner and group
-        assert 0 <= mode <= 0o777
+        assert 0 <= mode <= 0o1777
+        assert not (mode & 0o6000), (path, oct(mode))  # setuid/setgid 永不出現
     # 保護資產的父層一律 root 擁有（父目錄可寫者能 unlink/rename 子物件）。
     by_path = {p: (o, m) for p, o, _g, m in dirs}
     assert by_path[DEFAULT_LAYOUT.builder_home][0] == "root"
-    assert by_path[f"{DEFAULT_LAYOUT.builder_home}/.codex"][0] == "root"
+    # #698：`~/.codex` **不再**是骨架目錄——它升格為登記表資產（sticky 1755 ＋ 具名
+    # ACL），由權限計畫落位。留在骨架會是第二份真相，而 `_dedupe_scaffold()` 只留
+    # 第一筆 ⇒ 骨架那份 0755 會把 sticky 位靜默蓋掉。
+    assert f"{DEFAULT_LAYOUT.builder_home}/.codex" not in by_path
     assert by_path[DEFAULT_LAYOUT.home_of(TWO_WAY_SCHEME.durable_state_owner)][0] == "root"
     assert by_path[DEFAULT_LAYOUT.deploy_root][0] == "root"
 

--- a/tests/test_trust_root_permgen_traverse_620.py
+++ b/tests/test_trust_root_permgen_traverse_620.py
@@ -380,8 +380,23 @@ def test_traverse_section_comes_after_every_chmod(scheme) -> None:
 def test_traverse_commands_are_strings_only(scheme) -> None:
     """維持 permgen 的非執行不變式：本節仍只有 setfacl 字串。"""
     lines = _commands(scheme)
+    # #698：允許動詞與 `test_commands_are_strings_only_and_never_execute` 同一張清單
+    # （sticky 樹的 symlink 守衛 ＋ enforcement 檔的 create-if-absent）。
+    allowed = (
+        "install -d ", "chown ", "chmod ", "setfacl ",
+        "[ ! -e ", "[ ! -L ", "[ -e ",
+    )
+    heredoc_end = None
     for line in _executable(lines):
-        assert line.startswith(("install -d ", "chown ", "chmod ", "setfacl ", "[ ! -e "))
+        if heredoc_end is not None:
+            if line.strip() == heredoc_end:
+                heredoc_end = None
+            continue
+        if "<<'" in line:
+            heredoc_end = line.split("<<'", 1)[1].rstrip("'")
+            continue
+        assert line.startswith(allowed), line
+    assert heredoc_end is None
     assert not any("<PATH:" in ln for ln in _executable(lines))
 
 

--- a/tests/test_trust_root_planner_credentials_672.py
+++ b/tests/test_trust_root_planner_credentials_672.py
@@ -57,11 +57,14 @@ from paulsha_cortex.trust_root.permgen import (  # noqa: E402
 
 PLANNER_ACCOUNT = DEFAULT_LAYOUT.reviewer_planner_account
 BUILDER_ACCOUNT = DEFAULT_LAYOUT.builder_account
-PLANNER_ASSETS = (
-    "reviewer-planner-codex-state",
+#: #698 起 planner 帳號的三格分成兩族：codex 走 `HOME_STICKY_TREE`（真目錄），
+#: agy／claude 仍是 `HOME_REDIRECT_TREE`（symlink）。本檔的 symlink 類斷言因此只
+#: 涵蓋後兩者——那不是「少驗了一項」，是那一項換了形狀，由 #698 的測試接手。
+PLANNER_SYMLINK_ASSETS = (
     "reviewer-planner-agy-state",
     "reviewer-planner-claude-state",
 )
+PLANNER_ASSETS = ("reviewer-planner-codex-state",) + PLANNER_SYMLINK_ASSETS
 
 
 def _reviewer_rwp(scheme=FOUR_WAY_SCHEME) -> tuple[str, ...]:
@@ -83,22 +86,58 @@ def _reviewer_rwp(scheme=FOUR_WAY_SCHEME) -> tuple[str, ...]:
 def test_the_table_has_two_axes_and_both_are_consulted() -> None:
     """per-(account, executor) 而不是 per-executor——差別要驗得出來。
 
-    判準：**同一個 executor 在兩個帳號上是兩種形狀**。builder×codex 仍是 #640 的
-    單檔（那份部署已存在、有 runbook 反向驗證），reviewer-planner×codex 是導進
-    `cache` 的狀態樹（#686 實測 codex 需要整棵可寫）。一張 per-executor 的表表達
-    不了這件事——這就是 U-5 要兩軸的具體理由。
+    **判準在 #698 之後換了一格，而換掉的理由本身就是本測試要記的事。**
+
+    #685 時的判準是「同一個 executor 在兩個帳號上是**兩種**形狀」（builder×codex＝
+    `IN_PLACE_FILE`、reviewer-planner×codex＝`HOME_REDIRECT_TREE`）。0818 的 R9 T3.9
+    證明那個分岔不是設計而是一個尚未爆的洞——`HOME_REDIRECT_TREE` 的樹 job-owned，
+    該帳號成功植入了 `hooks.json`（codex hooks 會執行命令 ⇒ 跨 job 持久化）。#698 的
+    裁決因此讓**同一個 executor 在所有帳號上形狀相同**（由
+    `EXECUTOR_ENFORCEMENT_LEAVES` 那條規則導出，import 當下強制）。
+
+    兩軸**仍然必要**，判準改成：`reviewer-planner` 有三格而 `builder` 只有一格，
+    且 agy／claude 與 codex 是不同形狀。一張 per-executor 的表表達不了「哪個帳號被
+    核可持有哪幾份登入態」——那正是 U-4／U-5 的內容。
     """
     builder = permgen.credential_for("builder", "codex")
     planner = permgen.credential_for("reviewer-planner", "codex")
-    assert builder.shape is CredentialShape.IN_PLACE_FILE
-    assert planner.shape is CredentialShape.HOME_REDIRECT_TREE
-    assert builder is not planner
+    # #698：同一個 executor ⇒ **同一列**（形狀不可能只改一格）。
+    assert builder is planner
+    assert builder.shape is CredentialShape.HOME_STICKY_TREE
+    # 但帳號軸仍然有內容：planner 多兩格，且那兩格是另一種形狀。
+    assert permgen.credential_for("reviewer-planner", "agy").shape is (
+        CredentialShape.HOME_REDIRECT_TREE
+    )
+    with pytest.raises(UnregisteredExecutorCredentialError):
+        permgen.credential_for("builder", "agy")
+
+
+def test_the_shape_rule_is_enforced_at_import_time() -> None:
+    """#698：形狀由**一條規則**導出，而規則在 import 當下強制、不是靠 review。
+
+    這條測的是「只修 reviewer-planner 那格、在 builder 上留一個等著爆的差異」在
+    結構上做不到。
+    """
+    assert set(permgen.EXECUTOR_ENFORCEMENT_LEAVES) == {"codex"}
+    for prefix, cred in permgen.credential_rows():
+        want = permgen.EXECUTOR_ENFORCEMENT_LEAVES.get(cred.executor)
+        assert bool(want) == (cred.shape is CredentialShape.HOME_STICKY_TREE), (prefix, cred)
+    # 反向對照：把某一格改回舊形狀，展開點必須炸——否則本規則只是註解。
+    broken = dict(permgen.CREDENTIALED_ACCOUNTS)
+    broken["builder"] = (("codex", CredentialShape.HOME_REDIRECT_TREE),)
+    original = permgen.CREDENTIALED_ACCOUNTS
+    try:
+        permgen.CREDENTIALED_ACCOUNTS = broken  # type: ignore[assignment]
+        with pytest.raises(permgen.UnregisteredExecutorCredentialError):
+            permgen._assert_shape_follows_enforcement_rule()
+    finally:
+        permgen.CREDENTIALED_ACCOUNTS = original  # type: ignore[assignment]
 
 
 def test_the_account_axis_is_the_u4_ratification() -> None:
     """U-4 追認的範圍＝planner 帳號那一列有幾格。"""
     assert dict(CREDENTIALED_ACCOUNTS)["builder"] == (
-        ("codex", CredentialShape.IN_PLACE_FILE),
+        ("codex", CredentialShape.HOME_STICKY_TREE),
     )
     planner_cells = dict(CREDENTIALED_ACCOUNTS)["reviewer-planner"]
     assert [executor for executor, _shape in planner_cells] == ["codex", "agy", "claude"]
@@ -118,7 +157,7 @@ def test_every_table_row_is_a_registered_asset_and_vice_versa() -> None:
         if any("executor_credential_of" in src for src in asset.derived_in)
     }
     assert from_table == from_registry, (sorted(from_table), sorted(from_registry))
-    assert from_table == set(PLANNER_ASSETS) | {"builder-executor-credential"}
+    assert from_table == set(PLANNER_ASSETS) | {"builder-codex-state"}
     for asset_id in from_table:
         assert asset_id in DEFAULT_LAYOUT.asset_paths(), asset_id
 
@@ -143,10 +182,12 @@ def test_the_primary_relpath_stays_a_single_deployment_decision() -> None:
     #640 的「換 executor 只改一個值」因此仍然成立；把它的值抄一份進表就是第二份真相。
     """
     alt = PathLayout(executor_credential_relpath=".claude/credentials.json")
-    assert alt.executor_credential_of(BUILDER_ACCOUNT).endswith("/.claude/credentials.json")
-    # 骨架那條 root-owned 保護跟著走（不是寫死 `.codex`）。
-    scaffold = {p: (o, m) for p, o, _g, m in alt.scaffold_directories(THREE_WAY_SCHEME)}
-    assert scaffold[alt.executor_credential_dir_of(BUILDER_ACCOUNT)] == ("root", 0o755)
+    # #698：那一個值被切成 head（sticky 樹＝登記節點）與 tail（token 葉檔）。
+    assert alt.executor_credential_of(BUILDER_ACCOUNT).endswith("/.claude")
+    assert alt.credential_token_path_of(BUILDER_ACCOUNT).endswith("/.claude/credentials.json")
+    # enforcement 檔跟著樹走——留在 `.codex` 會是一個**不會報錯**的缺口（codex 不看它）。
+    hooks = {aid: path for aid, _a, path, _c in alt.enforcement_placements()}
+    assert hooks["builder-codex-hooks"].endswith("/.claude/hooks.json")
     # 表上有明確 relpath 的那幾格**不**受它影響。
     assert alt.executor_credential_of(PLANNER_ACCOUNT, "agy").endswith("/.gemini")
 
@@ -167,7 +208,7 @@ def test_relpath_shapes_are_validated_at_construction_time() -> None:
 def test_state_trees_are_registered_as_root_owned_symlinks() -> None:
     """U-7 的裁決＝design 的 (a)：登記成 symlink 類資產（登記表新增的 kind）。"""
     plan = generate_plan(FOUR_WAY_SCHEME)
-    for asset_id in PLANNER_ASSETS:
+    for asset_id in PLANNER_SYMLINK_ASSETS:
         entry = plan.by_id(asset_id)
         assert entry.is_symlink, asset_id
         assert not entry.is_directory, asset_id
@@ -184,7 +225,7 @@ def test_symlink_commands_never_use_a_bare_chown_or_chmod() -> None:
     那棵樹歸 job 帳號正是本形狀的全部重點，所以這條不是風格檢查。
     """
     plan = generate_plan(FOUR_WAY_SCHEME)
-    for asset_id in PLANNER_ASSETS:
+    for asset_id in PLANNER_SYMLINK_ASSETS:
         entry = plan.by_id(asset_id)
         path = DEFAULT_LAYOUT.asset_paths()[asset_id]
         target = DEFAULT_LAYOUT.symlink_targets()[asset_id]
@@ -199,7 +240,7 @@ def test_the_state_tree_target_lives_inside_the_accounts_own_cache() -> None:
     """「不新增可寫面」的**前提**：目標必須落在該帳號本來就可寫的那一層裡。"""
     cache = DEFAULT_LAYOUT.cache_of(PLANNER_ACCOUNT)
     for asset_id, target in DEFAULT_LAYOUT.symlink_targets().items():
-        assert asset_id in PLANNER_ASSETS, asset_id
+        assert asset_id in PLANNER_SYMLINK_ASSETS, asset_id
         assert target.startswith(cache + "/"), (asset_id, target)
 
 
@@ -209,11 +250,13 @@ def test_scaffold_creates_the_target_but_not_a_directory_at_the_symlink() -> Non
         path: (owner, mode)
         for path, owner, _g, mode in DEFAULT_LAYOUT.scaffold_directories(FOUR_WAY_SCHEME)
     }
-    for asset_id in PLANNER_ASSETS:
+    for asset_id in PLANNER_SYMLINK_ASSETS:
         link = DEFAULT_LAYOUT.asset_paths()[asset_id]
         target = DEFAULT_LAYOUT.symlink_targets()[asset_id]
         assert link not in scaffold, asset_id
         assert scaffold[target] == (PLANNER_ACCOUNT, 0o700), asset_id
+    # #698：codex 那一格是 sticky 樹 ⇒ 既不在骨架（它是登記表資產），也沒有 symlink 目標。
+    assert DEFAULT_LAYOUT.asset_paths()["reviewer-planner-codex-state"] not in scaffold
     # symlink 自己的保護來自 HOME 那一層。
     assert scaffold[DEFAULT_LAYOUT.home_of(PLANNER_ACCOUNT)] == ("root", 0o755)
 
@@ -233,10 +276,11 @@ def test_the_token_leaf_is_what_the_fingerprint_should_stat() -> None:
     assert DEFAULT_LAYOUT.credential_token_path_of(PLANNER_ACCOUNT, "claude").endswith(
         "/.claude/.credentials.json"
     )
-    # `IN_PLACE_FILE` 兩者相同。
-    assert DEFAULT_LAYOUT.credential_token_path_of(
-        BUILDER_ACCOUNT
-    ) == DEFAULT_LAYOUT.executor_credential_of(BUILDER_ACCOUNT)
+    # #698：builder 走同一列 ⇒ 樹是 `~/.codex`、葉是它底下的 `auth.json`。
+    assert DEFAULT_LAYOUT.executor_credential_of(BUILDER_ACCOUNT).endswith("/.codex")
+    assert DEFAULT_LAYOUT.credential_token_path_of(BUILDER_ACCOUNT).endswith(
+        "/.codex/auth.json"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -244,17 +288,25 @@ def test_the_token_leaf_is_what_the_fingerprint_should_stat() -> None:
 # ---------------------------------------------------------------------------
 
 def test_home_redirect_adds_no_writable_surface_to_the_reviewer_unit() -> None:
-    """reviewer 模板 unit 的 `ReadWritePaths` **逐字不變**，且憑證面仍然可寫。
+    """agy／claude 兩格：reviewer 模板 unit 的可寫面**一條都不必多**。
 
-    這條比 issue 原文的驗收更強：不是「多一條放行」，是「一條都不必多」。機制是
-    `_minimize()`——目標落在 `cache` 之內，被那條既有的 RWP 涵蓋。
+    機制是 `_minimize()`——目標落在 `cache` 之內，被那條既有的 RWP 涵蓋。
+
+    **#698 把 codex 那一格移出本斷言，而那不是放寬。** 那一格改成 HOME 底下的
+    root-owned sticky **真目錄**，因此 `cache` 那一條吃不掉它，unit 多一條
+    `ReadWritePaths=<planner HOME>/.codex`。**可寫的東西沒有變多**：同一棵 codex
+    狀態樹換了位置（`cache/codex` → `.codex`），換到的是「這棵樹的目錄由 root 擁有」
+    ——也就是 `hooks.json` 守得住的前提。那棵樹裡唯一新增的**不可**寫項目是 hooks
+    自己（見下一條）。
     """
     unit = build_job_unit(FOUR_WAY_SCHEME, principal=Principal.REVIEWER)
+    codex_tree = DEFAULT_LAYOUT.asset_paths()["reviewer-planner-codex-state"]
     assert set(unit.read_write_paths) == {
         DEFAULT_LAYOUT.cache_of(PLANNER_ACCOUNT),
         DEFAULT_LAYOUT.review_verdict_spool_root,
+        codex_tree,
     }, unit.read_write_paths
-    for asset_id in PLANNER_ASSETS:
+    for asset_id in PLANNER_SYMLINK_ASSETS:
         link = DEFAULT_LAYOUT.asset_paths()[asset_id]
         target = DEFAULT_LAYOUT.symlink_targets()[asset_id]
         assert link not in unit.read_write_paths, asset_id
@@ -263,18 +315,64 @@ def test_home_redirect_adds_no_writable_surface_to_the_reviewer_unit() -> None:
         assert target.startswith(DEFAULT_LAYOUT.cache_of(PLANNER_ACCOUNT) + "/")
 
 
-def test_the_builder_in_place_credential_is_untouched() -> None:
-    """#640 裁決 (b) 一行未改——RWP 逐字掛在**檔案本身**，不是它的父目錄。"""
-    unit = build_job_unit(FOUR_WAY_SCHEME, principal=Principal.BUILDER)
-    credential = DEFAULT_LAYOUT.executor_credential_of(BUILDER_ACCOUNT)
-    assert "builder-executor-credential" in IN_PLACE_CONTENT_WRITE_ASSETS
-    assert credential in unit.read_write_paths
-    parent = DEFAULT_LAYOUT.executor_credential_dir_of(BUILDER_ACCOUNT)
-    assert parent not in unit.read_write_paths
-    assert not any(
-        parent == rwp or parent.startswith(rwp.rstrip("/") + "/")
-        for rwp in unit.read_write_paths
-    ), unit.read_write_paths
+def test_the_planner_codex_tree_is_sticky_and_its_hooks_are_root_owned() -> None:
+    """#698 的驗收面（產生器側）：0818 R9 T3.9 攻破的那條，在表達層關上了。
+
+    三件事一起才算數，缺任何一件 T3.9 都會再紅一次：
+      (1) 樹 root-owned ＋ sticky ⇒ job 刪不掉／改不掉名字別人的檔；
+      (2) 樹裡的 `hooks.json` root-owned 0644 ⇒ job 改不了內容；
+      (3) 那個檔**在權限計畫裡就會被種出來**（sticky 不管「建一個還不存在的檔」）。
+    """
+    plan = generate_plan(FOUR_WAY_SCHEME)
+    tree = plan.by_id("reviewer-planner-codex-state")
+    assert tree.owner == "root" and tree.sticky and tree.mode_str == "1755"
+    assert [(a.account, a.perms, a.default) for a in tree.acls] == [
+        (PLANNER_ACCOUNT, "rwx", False)
+    ]
+    hooks = plan.by_id("reviewer-planner-codex-hooks")
+    assert hooks.owner == "root" and hooks.mode_str == "0644" and hooks.acls == ()
+    paths = DEFAULT_LAYOUT.asset_paths()
+    assert paths["reviewer-planner-codex-hooks"] == (
+        f"{paths['reviewer-planner-codex-state']}/hooks.json"
+    )
+    resolved = generate_plan(FOUR_WAY_SCHEME.with_principal_accounts({
+        Principal.OPERATOR: "cortex-ops", Principal.EXTERNAL: "cortex-outbox",
+    }))
+    joined = "\n".join(
+        permgen.plan_to_commands(resolved, path_of=paths, layout=DEFAULT_LAYOUT)
+    )
+    hooks_path = paths["reviewer-planner-codex-hooks"]
+    assert f"[ -e {hooks_path} ] || cat >" in joined, joined
+    # ⛔ 一般葉檔那條「不存在就跳過」用在這裡會**靜默把整個裁決變成空的**。
+    assert f"[ ! -e {hooks_path} ]" not in joined
+
+
+def test_the_builder_credential_now_shares_the_planner_shape() -> None:
+    """#698 取代了 #685 的 `..._in_place_credential_is_untouched`。
+
+    那條原本釘的是「builder 那一格一行未改：RWP 逐字掛在**檔案本身**」。#698 的
+    operator 裁決明文涵蓋 builder（「不要只修 reviewer-planner 那格、在 builder 上留
+    一個等著爆的差異」），因此正確的斷言反過來：**兩個帳號的形狀相同**。
+
+    換掉的代價與換到的東西都寫在這裡：
+      - 換掉：`IN_PLACE_FILE` 的「job 建不了新檔、刪不掉自己的 auth.json」。那一半是
+        自我 DoS 面，不是跨邊界面；R-6 早已為 planner 帳號接受同一件事。
+      - 換到：builder 在降權 unit 下 codex **起得來**（#685 逐字記錄過它起不來），
+        而 `hooks.json` 仍然守得住——DAC 三個動詞全關 ＋ mount 層的 ReadOnlyPaths。
+    """
+    paths = DEFAULT_LAYOUT.asset_paths()
+    for principal, prefix, account in (
+        (Principal.BUILDER, "builder", BUILDER_ACCOUNT),
+        (Principal.REVIEWER, "reviewer-planner", PLANNER_ACCOUNT),
+    ):
+        unit = build_job_unit(FOUR_WAY_SCHEME, principal=principal)
+        tree = paths[f"{prefix}-codex-state"]
+        hooks = paths[f"{prefix}-codex-hooks"]
+        assert tree == f"{DEFAULT_LAYOUT.home_of(account)}/.codex"
+        assert tree in unit.read_write_paths, (prefix, unit.read_write_paths)
+        assert hooks in unit.read_only_paths, (prefix, unit.read_only_paths)
+    # `IN_PLACE_CONTENT_WRITE_ASSETS` 的憑證那一半因此導出為空集（見該常數的說明）。
+    assert not (set(permgen.credential_asset_ids()) & set(IN_PLACE_CONTENT_WRITE_ASSETS))
 
 
 def test_the_state_trees_are_absent_from_manager_and_monitor_units() -> None:
@@ -366,23 +464,23 @@ def test_the_overdue_reviewer_credential_entry_is_gone() -> None:
     assert "reviewer-planner-executor-credential" not in names, sorted(names)
 
 
-def test_the_entry_that_could_not_be_closed_says_why() -> None:
-    """**沒關掉的那條必須說得出新的阻礙，而不是留著舊理由。**
+def test_the_u9_entry_is_closed_by_the_shape_change_not_by_deletion() -> None:
+    """#698：`reviewer-planner-codex-hooks` 從 deferred **消失**，且變成真的資產。
 
-    `reviewer-planner-codex-hooks`：與 codex 的可用性在 `$CODEX_HOME` 這一層互斥
-    （U-9）。
-
-    **#687（票 F）之後這裡只剩它一條。** 原本並列的 `manager-claude-credential`
-    已由票 F 移除——切換之後 Manager 不再 exec 任何 executor，該項不是「被登記」
-    而是**消失**（見 `test_the_manager_credential_entry_disappeared_by_switching`）。
-    本測試因此從 `..._two_entries_...` 改名為單數。
+    取代 #685 的 `test_the_entry_that_could_not_be_closed_says_why`。那條當年釘的是
+    「沒關掉的那條必須說得出新的阻礙」；本票關掉了它，因此正確的斷言是「兩件事同時
+    成立」——deferred 少一項，而登記表**多一格真的管得住的資產**。只驗前者的話，
+    「解決了」與「悄悄放棄了」看起來一模一樣。
     """
-    by_name = {item.name: item for item in permgen.deferred_run_dependencies()}
-    hooks = by_name["reviewer-planner-codex-hooks"]
-    assert "U-9" in hooks.disposition
-    assert "CODEX_HOME" in hooks.reason
-    # 舊理由不得還「作為理由」留在上面——它必須是被**引述後推翻**的那一段。
-    assert "做不到" in hooks.reason and "#686" in hooks.reason
+    names = {item.name for item in permgen.deferred_run_dependencies()}
+    assert "reviewer-planner-codex-hooks" not in names, sorted(names)
+    assert names == {"gate-gitconfig"}, sorted(names)
+    asset_ids = {a.asset_id for a in registry.ASSET_REGISTRY}
+    assert "reviewer-planner-codex-hooks" in asset_ids
+    assert "builder-codex-hooks" in asset_ids
+    # 而且它真的進了那個帳號 unit 的 ReadOnlyPaths（不是只在登記表上好看）。
+    unit = build_job_unit(FOUR_WAY_SCHEME, principal=Principal.REVIEWER)
+    assert DEFAULT_LAYOUT.asset_paths()["reviewer-planner-codex-hooks"] in unit.read_only_paths
 
 
 def test_the_manager_credential_entry_disappeared_by_switching() -> None:

--- a/tests/test_trust_root_repo_source_tree_623.py
+++ b/tests/test_trust_root_repo_source_tree_623.py
@@ -122,7 +122,9 @@ def test_gitconfig_assets_mirror_the_codex_hooks_shape(asset_id, readers) -> Non
     `.gitconfig` 可指定 `core.fsmonitor`／`alias.*` 這類會執行外部命令的鍵。
     """
     asset = registry.asset_by_id(asset_id)
-    hooks = registry.asset_by_id("codex-hooks")
+    # #698：`codex-hooks` 已拆成 per-account 兩份（`enforcement_asset_ids()` 導出）。
+    # 拿 builder 那一份當比較基準即可——兩份同形。
+    hooks = registry.asset_by_id("builder-codex-hooks")
     assert asset.tier is hooks.tier is AssetTier.TIER_0
     assert asset.tree is hooks.tree is TrustTree.MANAGER_OWNED
     assert asset.ingress_kind is hooks.ingress_kind is IngressKind.DEPLOYMENT_WRITE
@@ -331,6 +333,11 @@ def test_monitor_read_write_paths_stay_strictly_narrower_than_manager(scheme) ->
     assert monitor < manager, (sorted(monitor), sorted(manager))
 
 
+def _prefix_of(account: str) -> str:
+    """OS 帳號名 → 登記表資產 id 前綴（#698 的 hooks 資產 id 由它拼出來）。"""
+    return DEFAULT_LAYOUT.credential_prefix_of(account)
+
+
 @pytest.mark.parametrize("scheme", ALL_SCHEMES, ids=lambda s: s.scheme_id)
 def test_job_template_unit_excludes_the_source_tree_but_keeps_its_own_clone(scheme) -> None:
     """job 側：來源樹唯讀（不在 RWP），clone 落點 `<worktree>/%i` 在 RWP 內。"""
@@ -342,10 +349,15 @@ def test_job_template_unit_excludes_the_source_tree_but_keeps_its_own_clone(sche
         scheme.scheme_id, unit.read_write_paths,
     )
     assert any(_within(clone, rwp) for rwp in unit.read_write_paths), unit.read_write_paths
-    # 兩個 root-owned 設定檔（hooks／gitconfig）同樣不可寫。
-    for protected in (job_layout.gitconfig_of(unit.account),
-                      job_layout.codex_hooks_dir_of(unit.account)):
-        assert not any(_within(protected, rwp) for rwp in unit.read_write_paths), protected
+    # root-owned 的 `.gitconfig` 不可寫（連 mount 層都不放行）。
+    protected = job_layout.gitconfig_of(unit.account)
+    assert not any(_within(protected, rwp) for rwp in unit.read_write_paths), protected
+    # #698：`~/.codex` 那一層**改由 DAC 守**（root-owned ＋ sticky），整棵必須進 RWP
+    # 才能讓 codex 起得來。mount 層守的改成樹裡那個 enforcement 檔本身——它必須
+    # 逐字出現在 `ReadOnlyPaths=` 上，否則本形狀比 #640 淨退一層。
+    hooks = job_layout.asset_paths()[f"{_prefix_of(unit.account)}-codex-hooks"]
+    assert hooks in unit.read_only_paths, (hooks, unit.read_only_paths)
+    assert any(_within(hooks, rwp) for rwp in unit.read_write_paths), "巢狀關係是前提"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## 修什麼

`#698`：R9 族 3 的 **T3.9 實測攻破**——`cortex-reviewer-planner` 成功植入 `hooks.json`
（事後檢查 `cache/codex/hooks.json` 內容為 `x`）。codex hooks **會執行命令** ⇒ **跨 job
持久化** ⇒ 四分隔離「每個 job 是一次性的」這個前提在該帳號上不成立，而它正是吃
**untrusted issue 內容**的那一個。

成因是 `#685`（票 D）把它的 `~/.codex` 改成指向 job-owned `cache/codex` 的 symlink。
那次改動是**必要的**（`#686` 實測 codex 需要 `$CODEX_HOME` **整棵**可寫才啟動得了），
代價是那棵樹裡放不住任何 root-owned 的 enforcement 檔（`#685` 記為 **U-9**）。

**operator 裁決：採方案 A ＝ 目錄 sticky bit ＋ `hooks.json` 由 root 擁有。**

Closes #698

## permgen 怎麼表達 sticky（改了 mode 管線哪裡）

`#685` 把 U-9 標為「不做」的第一個理由逐字是：「它要改 permgen 的 mode 管線——安全網
`_mask_write` 會拿掉 group 寫入位、`mode & 0o700` 會吃掉 sticky 位，那是 spec §R2 的
既有不變式」。本 PR 改的就是那一行，而且**只改那一行的最後一段**：

```python
# build_entry() 尾端的 §R2 安全網
group_bits = _mask_write((mode >> 3) & 0o7)
other_bits = _mask_write(mode & 0o7)
-mode = (mode & 0o700) | (group_bits << 3) | other_bits
+mode = (mode & (STICKY_BIT | 0o700) & ~_FORBIDDEN_SPECIAL_BITS) | (group_bits << 3) | other_bits
```

- **§R2 一行未放寬**：group／other 的 write 位仍然無條件清除，job 的寫入權**一律走
  具名 ACL**（`AclEntry`，這套模型既有的跨帳號授權手段），不必為本形狀鑿一個 §R2 的洞。
- 新增的只有「sticky 通得過」。**setuid／setgid** 則從「被 `& 0o700` 順手吃掉」升級為
  **明文清除**（`_FORBIDDEN_SPECIAL_BITS`）——同樣的結果，但現在有出處、也擋得住日後
  有人把遮罩再放寬一位。`test_every_entry_fully_populated` 現在逐項斷言它們永不出現，
  且 sticky **只**出現在那一族、且必然是目錄。

**沒有繞過產生器手打 `chmod`**。表達層一共四處，全部機械導出：

| 層 | 新增的東西 |
|---|---|
| 形狀 | `CredentialShape.HOME_STICKY_TREE`（第三種形狀），欄位 `enforcement_leaf`／`enforcement_asset_suffix` |
| 分類 | `OwnerClass.STICKY_SHARED`（**刻意不是 `DEPLOYMENT`**，理由見下） |
| 產生 | `build_entry()` 的 `STICKY_SHARED` 分支：owner＝root、`mode |= STICKY_BIT`、對 `writers ∩ UNTRUSTED_EXECUTION_PRINCIPALS` 出具名 `rwx` **access** ACL |
| 命令 | `PermissionEntry.commands()` 對 sticky 目錄**不出 default ACL**；`plan_to_commands()` 對 enforcement 檔出 **create-if-absent** |

**為什麼不把它塞進 `OwnerClass.DEPLOYMENT`**：`DEPLOYMENT` 的定義裡有一句「對全部
headless 唯讀」，而那句話是好幾條不變式的依據（`test_builder_never_writes_manager_owned_or_deployment`
／`test_manager_owned_acls_are_read_only`）。sticky 樹**必須**讓 job 寫得進去；塞進去等於
就地把那句話改成「除了某些之外」，那些不變式會從「機械成立」退化成「有例外清單」。

**三個刻意的細節，缺任何一個整個裁決就是空的**（三條都有測試釘住）：

1. **目錄 owner 必須是 root**——POSIX 的 sticky 對**目錄 owner** 免疫（目錄 owner 刪得掉
   裡面任何檔）。因此 sticky 樹的登記表 `writers` 含 `INSTALLER`（與 `#640` 相反）。
2. **只設 access ACL、不設 default ACL**——default ACL 決定「**之後**在這個目錄裡新建的
   物件」的初值，包含 root 日後重放一次 `hooks.json` 的那一次。設了它等於把 hooks 自動
   交還給 job。`commands()` 因此對 `sticky` 目錄跳過那條 `setfacl -d -m`。
3. **`hooks.json` 必須先存在**——sticky 管的是「刪／改名**別人的**檔」，**不管「建一個
   還不存在的檔」**。缺它時 job 直接 `printf x > $HOME/.codex/hooks.json` 就會成功
   （正是 T3.9 的攻擊字面）。權限計畫因此對它出 **create-if-absent**（`[ -e … ] || cat >`
   一份最小、**不含任何命令**的 hooks 文件），而不是其他葉檔那條「不存在就跳過」。

**mount 層沒有淨退一層**。`#640` 的 `IN_PLACE_FILE` 讓 hooks 同時被 **DAC** 與 **systemd
mount** 兩層擋住；sticky 樹整棵必須進 `ReadWritePaths=`，因此新增機械導出的巢狀
`ReadOnlyPaths=<HOME>/.codex/hooks.json`（`enforcement_read_only_paths()`）。
**刻意沒有 `-` 前綴**：目標不存在時 unit 直接起不來——那正是要的行為（缺那個檔時 job
植得進 hooks，而一個植得進 hooks 的 job 不該起得來），與同一份 unit 對 `ReadWritePaths`
既有的 fail-closed 立場一致。**巢狀是否真的生效已實測**，見下方。

## builder 要不要一併遷、理由

**要，而且是同一條規則的結果，不是另一個決定。**

規則寫成一格表（`EXECUTOR_ENFORCEMENT_LEAVES`）：

> **executor 的狀態樹裡必須住著一個 root-owned 的 enforcement 檔 ⇒ 凡持有它登入態的
> 帳號，那一格一律是 `HOME_STICKY_TREE`。**

由 `_assert_shape_follows_enforcement_rule()` 在 **import 當下**強制（不是註解、不是
review）。「只修 reviewer-planner 那格、在 builder 上留一個等著爆的差異」因此在**結構上
做不到**——新增第五個帳號時漏改的症狀是模組載不起來，而不是三個月後的一次 R9 紅字。
只有 codex 在那張表上有一格（它的 hooks 會執行命令）；agy／claude 沒有同性質的檔，
**維持 `HOME_REDIRECT_TREE`**——那是同一條規則的另一邊，不是遺漏。

淨結果：憑證表上 codex 只剩**一列**，兩個帳號共用它 ⇒ 形狀不可能只改一格。

**builder 換掉什麼、換到什麼**（誠實記錄，不要在別處被讀成「一樣安全」）：

- **換掉**：`IN_PLACE_FILE` 的「job 建不了新檔、刪不掉自己的 `auth.json`」。那一半是
  **自我 DoS 面**，不是跨邊界面；而 R-6 早已為 planner 帳號**明文接受**同一件事。
- **換到**：builder 的 codex 在降權 unit 下**真的跑得起來**。舊形態的代價 `#685` 逐字
  記錄過（「builder 在模板 unit 下跑 codex 會撞到與 #686 同一條 `$CODEX_HOME` 唯讀阻斷」），
  本 PR 的實測把那句話量了出來也修掉了（見下表）。
- **`hooks.json` 的保護沒有變弱**：舊形態靠「父目錄不可寫」；新形態靠 sticky（unlink／
  rename）＋ 檔案自己的 mode（內容）＋ unit 的巢狀 `ReadOnlyPaths=`（mount 層）。

## 登記表資產的改名（operator 可見）

| 舊 | 新 | 為什麼 |
|---|---|---|
| `builder-executor-credential` | `builder-codex-state` | 兩個帳號共用同一列憑證表 ⇒ 共用 `asset_suffix` |
| `codex-hooks`（單一，寫死在 builder HOME） | `builder-codex-hooks` ＋ `reviewer-planner-codex-hooks` | 由 `enforcement_placements()` 從同一條規則長出來 |

`reviewer-planner-codex-hooks` 因此從 `deferred_run_dependencies()` 的 **U-9 消失**——
**不是刪一列**，是那條張力（「codex 起得來」與「樹裡放得住 root-owned 檔」互斥）**真的
不存在了**。deferred 清單剩一項（`gate-gitconfig`）。

## 驗收 1：R9 T3.9 兩個 subject（完整模板 unit 加固面，`unit-replica` 全量導出）

攻擊腳本由 runbook 第 8a 步**機械抽出**（正規表示式取那段 heredoc），以 `#627` 的身分鎖
執行——先驗過以 operator 身分跑會被拒（`⛔ 拒絕執行… guard exit=2`），未繞過。
兩趟都走**真實啟動面**：`cortex-manager` 寫 job spec → 起 `cortex-job@` ／
`cortex-reviewer-job@` 實例。**未自組 `--property=`、未自帶 `--setenv=PATH=`**（D13）。

**修前（0818 基準，逐字複現）**：

```
cortex-builder          :: T3.9 改 codex hooks :: denied (OK) rc=2
cortex-reviewer-planner :: T3.9 改 codex hooks :: !! SUCCEEDED (FAIL)
```

**修後**（T3.9 一併從 1 條擴成 3 條——sticky 關的是**三個動詞**，只驗「改內容」會漏掉
真正靠 sticky 擋的 unlink／rename）：

```
cortex-builder          :: T3.9 改 codex hooks   :: denied (OK) rc=2
cortex-builder          :: T3.9 刪掉 codex hooks :: denied (OK) rc=1
cortex-builder          :: T3.9 改名 codex hooks :: denied (OK) rc=1
cortex-builder          :: T3.9 換掉 ~/.codex 目錄 :: denied (OK) rc=1

cortex-reviewer-planner :: T3.9 改 codex hooks   :: denied (OK) rc=2
cortex-reviewer-planner :: T3.9 刪掉 codex hooks :: denied (OK) rc=1
cortex-reviewer-planner :: T3.9 改名 codex hooks :: denied (OK) rc=1
cortex-reviewer-planner :: T3.9 換掉 ~/.codex 目錄 :: denied (OK) rc=1
```

族 1–4 全族總計：

| | `cortex-builder` | `cortex-reviewer-planner` |
|---|---|---|
| denied（OK） | 54 | 56 |
| by-design readable | 4 | 2 |
| **SUCCEEDED（FAIL）** | **0** | **0** |

事後檢查兩份 `hooks.json` 內容**未被改動**（`{"hooks": {}}`），仍是 `root:root 644`。

**兩層各自的實測**（`systemd-run` 起兩個剖面，逐條分辨錯誤訊息）：

```
# 巢狀 ReadOnlyPaths（mount 層）
printf x > …/hooks.json   → cannot create …: Read-only file system
touch …/mine              → write-own OK          ← 整棵仍可寫，codex 才起得來
# 只有 DAC（sticky ＋ 檔案 mode）
printf x > …/hooks.json   → Permission denied
rm       …/hooks.json     → Operation not permitted
mv       …/hooks.json …   → Operation not permitted
```

三個動詞全關，且**巢狀 `ReadOnlyPaths` 在本機 systemd 上確認生效**（不是推測）。

## 驗收 2：codex／claude／agy 的 planning 探針矩陣（路徑＋版本字串）

加固面全部由 `permgen.unit_replica_properties()` 從**落檔的 unit** 導出（修後 40 條
property，多的那兩條就是新增的 `ReadWritePaths`／`ReadOnlyPaths`）。

| unit（剖面） | CLI | 解析到的絕對路徑 | 版本字串 | rc |
|---|---|---|---|---|
| `cortex-job-jit` | `codex` | `/opt/cortex/toolchain/bin/codex` | `codex-cli 0.147.0` | 0 |
| `cortex-job` | `claude` | `/opt/cortex/toolchain/bin/claude` | `2.1.233 (Claude Code)` | 0 |
| `cortex-job` | `agy` | `/opt/cortex/toolchain/bin/agy` | `1.1.13` | 0 |
| `cortex-reviewer-job-jit` | `codex` | `/opt/cortex/toolchain/bin/codex` | `codex-cli 0.147.0` | 0 |
| `cortex-reviewer-job` | `claude` | `/opt/cortex/toolchain/bin/claude` | `2.1.233 (Claude Code)` | 0 |
| `cortex-reviewer-job` | `agy` | `/opt/cortex/toolchain/bin/agy` | `1.1.13` | 0 |

**與修改前逐行 `diff` 為空**——executor 解析與版本皆未受影響（`#681` 那類「只比路徑會漏掉」
的缺陷因此也驗到了）。

**只比版本不夠，因此另跑端到端**（`--version` 不會碰 `$CODEX_HOME`）：

| 探針 | 修前 | 修後 |
|---|---|---|
| `codex exec --json` @ `cortex-reviewer-job-jit` | `turn.completed`（rc=0） | `turn.completed`（rc=0） |
| `codex exec --json` @ `cortex-job-jit` | **`Error: failed to initialize in-process app-server client: Read-only file system (os error 30)`** | **`turn.completed`（rc=0）** |
| `agy --print … --mode plan --sandbox` @ `cortex-reviewer-job` | rc=0 | rc=0，輸出逐位元等於 expected |

**builder 那一格從紅翻綠**——本 PR 不但沒把 executor 弄死，還修掉了 `#685` 記錄的那個
可用性缺口。codex 跑完之後樹裡長出 `state_5.sqlite`／`sessions/`／`skills/`／
`plugins/`／`thread-writer-locks/`… 而 `hooks.json` 原封不動，形狀（`root:root 1755` ＋
具名 ACL ＋ 零 default ACL）維持。

⚠️ **一個與本 PR 無關、但量到就要說的事**：`claude -p` 在 reviewer 帳號上回
`Failed to authenticate: OAuth session expired and could not be refreshed`。查
`cache/claude/.credentials.json` 的 `expiresAt` 為 `0`（operator 自己那份是新的）——
是**憑證過期**，不是加固面。claude 走的是本 PR **未改動**的 `HOME_REDIRECT_TREE`，
`claude --version` 在兩個 unit 下都 rc=0。處置是重跑 runbook 第 4e-2c 步第 4️⃣ 步重放
token；不在本票範圍。

## 部署面（runbook）

第 4e-2b 步整段重寫為「兩個 job 帳號的 codex 狀態樹（sticky）」，含**實機遷移步驟**
（builder 是真目錄、reviewer-planner 是 symlink，兩者順序不同）；agy／claude 的 symlink
形態移到新的 4e-2c。**遷移由 operator 執行**，三個實際踩到的陷阱都寫進去了：

1. **`install -d` 對既有 symlink 不報錯也不取代**——它**跟著連結**去建目標，於是
   `chown`／`chmod`／`setfacl` 全部套到 `cache/codex` 那棵 job-owned 的樹上，而現場
   看起來一切正常。產生器因此在 `install -d` **之前**出一條 `[ ! -L <path> ] || { … exit 1; }`
   守衛，runbook 另外顯式拆連結。（這是 issue 提到的 `ln -sfn` 陷阱的反向。）
2. **`cp -a src/. dst/` 會把來源目錄自己的 owner／mode／ACL 蓋到目的地**——0818 遷移
   實際踩到：剛設好的 `root:root 1755 + ACL` 被還原成 `job 0700`，sticky 與 ACL 一起
   消失，而 `cp` 不會抱怨。因此 runbook 的順序是**先搬內容、後套權限**。
3. **`ls -ld` 顯示的 group `rwx` 是 POSIX ACL 的 mask，不是 group 寫入權**
   （`group::` 才是，它必須是 `r-x`）。只看 `ls` 會誤判成「開了 group 寫入」而去 `chmod`
   關掉它——而 `chmod` 會重設 mask、把 ACL 一起廢掉。驗證一律用 `getfacl`，且**任何一次
   `chmod` 之後必須重跑 `setfacl`**（權限計畫本來就是這個順序）。

另有順序約束寫進 runbook：**先種 `hooks.json`，再落新 unit**——`ReadOnlyPaths=` 沒有
`-` 前綴，檔不存在時 unit 起不來（那是要的行為，但顛倒順序會讓中間那段時間所有 job 失敗）。

## 既有測試的修改（逐條理由）

| 檔案／測試 | 改動 | 理由 |
|---|---|---|
| `p2a::test_every_entry_fully_populated` | `mode ≤ 0o777` → `≤ 0o1777` ＋ 斷言無 setuid/setgid ＋ sticky 只出現在那一族 | mode 管線現在表達得了 sticky；順手把「setuid/setgid 永不出現」從隱含變成明寫 |
| `p2a::test_builder_never_writes_manager_owned_or_deployment` | **未改斷言**，補 docstring 說明 `STICKY_SHARED` 不在涵蓋範圍 | 正是為了讓這條維持「機械成立、零例外清單」，才另立 owner class |
| `p2a`（新增 2 條） | `..._enforcement_leaves_are_never_writable_by_any_job_account`／`..._sticky_trees_are_root_owned_with_named_acls_and_no_default_acl` | 上一條讓出來的那一半必須有人接：真正要守的是**樹裡那個檔**，以及 sticky 的三個前提 |
| `p2a`／`traverse_620::..._commands_are_strings_only` | 允許動詞加三個（`[ ! -L `／`[ -e `／`cat > `）＋ heredoc 內容區跳過 | 產出多了 symlink 守衛與 enforcement 檔的 create-if-absent。清單逐條有理由，仍是白名單 |
| `p2b::test_job_unit_read_write_paths_exclude_manager_owned` | 巢狀 `read_only_paths` 的項目 `continue` | sticky 樹整棵必須進 RWP，`hooks.json` 在樹裡 ⇒ 唯一的巢狀例外，而例外已被同一份 unit 的 `ReadOnlyPaths=` 收回（實測生效） |
| `p2b::test_scaffold_directories_are_command_strings_only` | `~/.codex` 從「在骨架且 root-owned」改成「**不在**骨架」 | 它升格為登記表資產（sticky ＋ ACL 表達不了在骨架那個四元組裡）。留在骨架是第二份真相，而 `_dedupe_scaffold()` 只留第一筆 ⇒ 骨架那份 0755 會**靜默**蓋掉 sticky |
| `640::test_credential_writer_is_the_job_persona_not_the_installer` | 改名為 `..._are_both_the_installer_and_the_job_persona`，斷言反轉 | `#640` 的原斷言在 `IN_PLACE_FILE` 下正確（登記節點是**檔**，必須 job-owned）；`#698` 登記的是**樹**，owner 必須是 root 否則 sticky 免疫。refresh 沒有壞——token 葉檔仍在樹裡、仍 job-owned |
| `640::TestInPlaceCredentialOsSemantics` | 換成 `TestStickyTreeOsSemantics` ＋ **具名 `@pytest.mark.skip`** | sticky 的 kernel 判定比對的是 **uid**，單一 uid 的 CI 結構性驗不到（同 uid 恆為真 ⇒ 必然全綠＝假綠，正是 `#638` 那一族）。skip 理由寫明改由哪一組實測涵蓋（R9 T3.9 ＋ runbook 4e-2b），並禁止「用同一個 uid 建 sticky 目錄就當驗過」 |
| `672::test_the_table_has_two_axes_and_both_are_consulted` | 判準從「同一 executor 兩種形狀」改成「帳號軸有內容 ＋ 同一 executor 同一列」 | 舊判準描述的正是被攻破的那個分岔。兩軸仍必要（U-4／U-5），只是判準換一格 |
| `672::test_home_redirect_adds_no_writable_surface_to_the_reviewer_unit` | codex 那一格移出，RWP 從 2 條變 3 條 | **不是放寬**：同一棵 codex 狀態樹換位置（`cache/codex` → `.codex`），可寫的東西一樣多，換到的是「目錄由 root 擁有」。docstring 逐字寫了這件事 |
| `672::test_the_builder_in_place_credential_is_untouched` | 改為 `..._now_shares_the_planner_shape` | 裁決明文涵蓋 builder，正確的斷言反過來 |
| `672::test_the_entry_that_could_not_be_closed_says_why` | 改為 `test_the_u9_entry_is_closed_by_the_shape_change_not_by_deletion` | 只驗「deferred 少一項」的話，「解決了」與「悄悄放棄了」長得一樣 ⇒ 同時斷言它變成真資產、且真的進了 unit 的 `ReadOnlyPaths` |
| `666`／`623`／`job_template_ab`／`615`／`planning_job_invoker_672` | 資產 id 與 RWP 期望值更新 | 隨改名與形狀變更；每處都加了說明為何不是「多開一條可寫面」 |
| `planning_probe_cache_672`（**未改測試**） | — | 它抓到了一個**真的 bug**（見下）——修的是產品碼，不是測試 |

## 順帶修掉的一個缺陷

`planning_probe_cache._credential_path()` 的 direct 分支自己拼 `relpath + token_leaf`，
是 `credential_token_path_of()` 的**第二份複本**。codex 那一列的樹與葉現在**都**由
`executor_credential_relpath` 的 head／tail 導出（`relpath is None`／`token_leaf` 留空），
那份複本因此拼出**目錄本身** ⇒ 指紋退化成 `stat ~/.codex`、**憑證 refresh 偵測不到**。
改走 `PathLayout.credential_token_relpath_of()` 這個唯一來源；票 C 的
`test_cache_invalidated_by_credential_fingerprint` 是抓到它的那條。

## 未改動

- **`coordinator/planning.py` 一行未改**（`#701` 正在另一個 agent 手上並行）。
- 二分方案（`two-way`）的產出：`inapplicable_home_anchored_assets()` 照舊把
  reviewer-planner 那一族整組扣掉，Manager unit 的 RWP 不會多出不存在的路徑。
- `cortex-gate-job@` 兩份 unit 逐字不變（gate 不跑模型 ⇒ 沒有 codex 樹）。

## Checklist

- [x] 分支 `feature/698-codex-hooks-sticky`，未 commit 到 `main`
- [x] `changelog.d/698-codex-hooks-sticky.md` 已新增並 commit
- [x] `CHANGELOG.md [Unreleased]` 已補對應 entry
- [x] 全套測試通過（4396 passed／29 skipped）
- [x] 既有測試的修改已逐條在上表說明理由
- [x] OS 層語意（sticky 需第二個 UID）以**具名 `@pytest.mark.skip` ＋ 完整理由**處理，未靜默通過
- [x] 驗收兩條皆以**實機、完整模板 unit 加固面、`unit-replica` 全量導出**取得（D13）
- [x] runbook 已寫明遷移步驟與三個實際踩到的陷阱
