### PR TITLE
fix(gate): snapshot 依名跳過可再生快取目錄，UMask=0077 下的寫入卡不再必炸（#736）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
 本專案遵循 hamanpaul project policy v1.0.17。
 
 ## [Unreleased]
+- **#736：gate snapshot 依名跳過可再生快取目錄（`__pycache__`／`.pytest_cache`／
+  `.mypy_cache`／`.ruff_cache`），寫入卡不再結構性必死。** builder unit 的
+  `UMask=0077` 讓 pytest 產生的 `.pytest_cache/` 以 group bits 0 落地 ⇒ ACL
+  `mask::---` ⇒ gate 帳號讀不到 ⇒ `snapshot_worktree` 整格 `SnapshotError` ⇒
+  `gate-spool-empty` crashloop（exit 74）。快取不是候選樹內容（.gitignore 排除、
+  gate 的 pytest 會自行重建）；清單外的不可讀項目維持 fail-closed。#723 一族第三例。
 - **#734：wrapper 斷言改為逐 token 語意判定，不再對整串 argv 做 substring 搜尋。**
   gate 執行帳號名（`cortex-gate`）出現在 pytest tmp 路徑裡，讓
   `test_planning_wrapper_has_no_gate_bundle_verdict_sentinel` 的 `"gate" not in joined`

--- a/changelog.d/736-snapshot-cache-ignore.md
+++ b/changelog.d/736-snapshot-cache-ignore.md
@@ -1,0 +1,16 @@
+# 736-snapshot-cache-ignore
+
+- **`#736` gate snapshot 依名跳過可再生快取目錄，寫入卡不再結構性必死**——
+  builder job unit 掛 `UMask=0077`，pytest 產生的 `.pytest_cache/` 以 mode 0700 落地，
+  POSIX ACL 的 mask 取自 create mode 的 group bits ⇒ `mask::---` ⇒ default ACL 給
+  `cortex-gate` 的 `r-x` 繼承了條目、繼承不到權限。`snapshot_worktree()`（#629）是
+  裸 `shutil.copytree`，一顆讀不到的快取目錄就 `SnapshotError` ⇒ 依設計不寫 ledger
+  ⇒ `gate-spool-empty`、gate unit 以 exit 74 crashloop。tdd-red 實測命中（run
+  `workflow-85114100` 第九環）；worktree-isolation 會過純因唯讀卡不產生檔案——
+  **任何會在工作樹跑 pytest 的寫入卡在此剖面下必炸**。修法：新增
+  `SNAPSHOT_REGENERABLE_CACHE_DIRS`（`__pycache__`／`.pytest_cache`／`.mypy_cache`／
+  `.ruff_cache`，皆為 .gitignore 排除、gate 重跑時 pytest 會自行重建的快取）於
+  copytree 依名跳過、任意深度；**清單外的不可讀項目維持 fail-closed 不變**——
+  「跳過讀不到的東西」是禁手，候選內容讀不到時靜默跳過會讓 gate 在殘缺的樹上判出
+  假 verdict。mutation 驗證：清空清單，skip 測試必轉紅。`#723` 環境可攜性一族的
+  第三個實例（umask×chmod `#724`、帳號名×tmp 路徑 `#734`、本票 umask×ACL mask）。

--- a/paulsha_cortex/coordinator/gate_ledger.py
+++ b/paulsha_cortex/coordinator/gate_ledger.py
@@ -381,6 +381,20 @@ class SnapshotError(OSError):
     """拋棄式副本無法建立（#629）。**不寫 ledger**，讓採信端照 `require_ledger` 拒。"""
 
 
+# 可再生的直譯器／測試快取（#736）：不是候選樹的一部分（.gitignore 排除、gate 的
+# pytest 會在副本裡重建自己的 cache），且 builder 在 `UMask=0077` 下產生它們時
+# POSIX ACL mask 會被 create mode 的 group bits 歸零——default ACL 給 gate 的
+# `r-x` 繼承了條目、繼承不到權限，gate 因此讀不到。依名跳過是語意判準（「這個
+# 名字的目錄是快取」），不是「跳過讀不到的東西」——後者是禁手，見 docstring。
+SNAPSHOT_REGENERABLE_CACHE_DIRS = frozenset(
+    {"__pycache__", ".pytest_cache", ".mypy_cache", ".ruff_cache"}
+)
+
+
+def _snapshot_ignore_caches(directory: str, names: list[str]) -> set[str]:
+    return {name for name in names if name in SNAPSHOT_REGENERABLE_CACHE_DIRS}
+
+
 def snapshot_worktree(source: str | Path, destination: str | Path) -> Path:
     """把被驗的工作樹複製成一份**拋棄式副本**，回傳副本路徑（#629）。
 
@@ -404,6 +418,13 @@ def snapshot_worktree(source: str | Path, destination: str | Path) -> Path:
     目的地**先整個移除再重建**：留下上一輪的殘留等於讓前一次 gate 的產物（甚至前一
     次被攻陷的 gate 留下的東西）參與這一次的判定。與 `spool_slot.create_slot(
     reset=True)` 同一條理由——重建比「就地清理」少一個要窮舉的清單。
+
+    `SNAPSHOT_REGENERABLE_CACHE_DIRS` **依名跳過、任意深度**（#736）：builder 在
+    `UMask=0077` 的 unit 下跑 pytest 產生的 `.pytest_cache/` mode 0700 ⇒ ACL mask
+    `---` ⇒ gate 讀不到，而它根本不是候選樹的內容。**只跳這份具名清單**——「跳過
+    任何讀不到的東西」是禁手：若候選內容本身讀不到（例如 RED 測試檔），靜默跳過
+    會讓 gate 在殘缺的樹上判出假 verdict，正是「不把沒驗到偽裝成驗過沒過」要擋的
+    ——清單外的不可讀項目照樣 `SnapshotError` fail-closed。
     """
 
     src = Path(source)
@@ -419,7 +440,13 @@ def snapshot_worktree(source: str | Path, destination: str | Path) -> Path:
         elif dst.is_dir():
             shutil.rmtree(dst)
         dst.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copytree(src, dst, symlinks=True, ignore_dangling_symlinks=True)
+        shutil.copytree(
+            src,
+            dst,
+            symlinks=True,
+            ignore_dangling_symlinks=True,
+            ignore=_snapshot_ignore_caches,
+        )
     except OSError as exc:
         raise SnapshotError(f"gate snapshot failed: {src} -> {dst}: {exc}") from exc
     return dst

--- a/tests/test_gate_execution_identity_629.py
+++ b/tests/test_gate_execution_identity_629.py
@@ -892,6 +892,49 @@ class SnapshotTests(unittest.TestCase):
             self.assertFalse((dst / "escape").joinpath("secret").is_file()
                              and not (dst / "escape").is_symlink())
 
+    def test_unreadable_regenerable_caches_are_skipped_by_name(self) -> None:
+        """#736：builder 在 `UMask=0077` 下產生的 `.pytest_cache` mode 0700 ⇒ ACL
+        mask `---` ⇒ gate 讀不到；而它是可再生快取、不是候選樹內容，snapshot 依名
+        跳過而不是整格死。"""
+        with tempfile.TemporaryDirectory() as root:
+            src = Path(root) / "src"
+            (src / "tests").mkdir(parents=True)
+            (src / "tests" / "test_red.py").write_text("def test(): ...\n", encoding="utf-8")
+            unreadable = src / ".pytest_cache"
+            unreadable.mkdir()
+            (unreadable / "CACHEDIR.TAG").write_text("Signature", encoding="utf-8")
+            nested = src / "tests" / "__pycache__"
+            nested.mkdir()
+            os.chmod(unreadable, 0)
+            os.chmod(nested, 0)
+            try:
+                dst = Path(root) / "snap"
+                gate_ledger.snapshot_worktree(src, dst)
+                self.assertTrue((dst / "tests" / "test_red.py").is_file())
+                # 跳過＝不進副本，任意深度皆然。
+                self.assertFalse((dst / ".pytest_cache").exists())
+                self.assertFalse((dst / "tests" / "__pycache__").exists())
+            finally:
+                os.chmod(unreadable, 0o700)
+                os.chmod(nested, 0o700)
+
+    def test_an_unreadable_non_cache_entry_still_fails_closed(self) -> None:
+        """清單外的不可讀項目照樣 `SnapshotError`——「跳過讀不到的東西」是禁手：
+        候選內容讀不到時靜默跳過會讓 gate 在殘缺的樹上判出假 verdict。"""
+        if os.geteuid() == 0:  # pragma: no cover - root 不受 mode 0 限制
+            self.skipTest("mode 0 對 root 不生效")
+        with tempfile.TemporaryDirectory() as root:
+            src = Path(root) / "src"
+            src.mkdir()
+            candidate = src / "tests"
+            candidate.mkdir()
+            os.chmod(candidate, 0)
+            try:
+                with self.assertRaises(gate_ledger.SnapshotError):
+                    gate_ledger.snapshot_worktree(src, Path(root) / "snap")
+            finally:
+                os.chmod(candidate, 0o700)
+
     def test_a_stale_snapshot_is_rebuilt_not_merged(self) -> None:
         with tempfile.TemporaryDirectory() as root:
             src = Path(root) / "src"


### PR DESCRIPTION
Fixes #736

## 病因（實機第九環，run `workflow-85114100` tdd-red 卡）

builder job unit 掛 `UMask=0077`；builder（codex）驗證 RED 時跑 pytest，`.pytest_cache/` 以 mode 0700 落地。POSIX ACL 的 mask 取自 create mode 的 group bits ⇒ `mask::---` ⇒ default ACL 給 `cortex-gate` 的 `r-x` **繼承了條目、繼承不到權限**。以 `cortex-gate` 實測 `find` 整棵樹：唯一 Permission denied 的就是 `.pytest_cache`。

`snapshot_worktree()`（#629）是裸 `shutil.copytree`，一顆讀不到的快取目錄就 `SnapshotError` ⇒ 依設計刻意不寫 ledger（正確）⇒ 採信端 `gate-spool-empty`、gate unit 以 exit 74 每 tick crashloop。worktree-isolation 會過純因唯讀卡不產生檔案——**任何會在工作樹跑 pytest 的寫入卡（tdd-red／subagent-build）在此剖面下結構上必死**。

## 修法

新增 `SNAPSHOT_REGENERABLE_CACHE_DIRS = {"__pycache__", ".pytest_cache", ".mypy_cache", ".ruff_cache"}`，`copytree` 以 `ignore=` 依名跳過、任意深度。判準是**語意**（「這個名字的目錄是可再生快取」——.gitignore 第 1、3 行排除它們、gate 重跑時 pytest 會在副本裡重建自己的 cache），不是「跳過讀不到的東西」：**清單外的不可讀項目照樣 `SnapshotError` fail-closed**——候選內容（例如 RED 測試檔）讀不到時靜默跳過會讓 gate 在殘缺的樹上判出假 verdict，正是 #629「不把沒驗到偽裝成驗過沒過」要擋的。

## 驗收（照 #736）

- [x] 來源含不可讀 `.pytest_cache`（mode 0）與巢狀 `__pycache__` 時 snapshot 成功且副本內無該目錄
- [x] 清單外的不可讀目錄仍 `SnapshotError`（fail-closed 不退讓；root 下 skip 並具名）
- [x] mutation：把 ignore 集合清空，skip 測試轉紅（實測 1 failed）
- [x] 全套 `python3 -m pytest tests/ -q`：4870 passed, 36 skipped

部署後驗收（merge 後由 operator 執行、回報於 #736）：`wf-a546ff54f2-tdd-red-14` gate 重派自動收斂——ledger 產出、pytest=failed=RED 達成、卡片 passed。

## 系統性含意（不在本 PR）

`UMask=0077` × default ACL mask 歸零是系統性交互，本 PR 只救 gate snapshot 這一格；#723 的 gate 環境模擬 CI job 得到第三個實例支持。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XcQLDun91sLCJfJeKoVgjS
