### PR TITLE
fix(coordinator): candidate 驗證下放 gate ledger，三分部署下 build 卡可被採信（#738）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
 本專案遵循 hamanpaul project policy v1.0.17。
 
 ## [Unreleased]
+- **#738：candidate 驗證下放 gate ledger，三分部署下帶 candidate 的 build 卡終於
+  可被採信。** gate 身分在快照副本上收集 `worktree_state`（head／dirty／
+  ancestry），Manager 只消費權威 ledger、不再以自己的身分 `git -C <builder 樹>`
+  （#641 收掉唯讀 ACL 後那條路結構上必死）。baseline 經封閉 argv
+  `--assert-ancestor` 由 job 記錄導出；ledger 缺席時逐字退回既有路徑（direct
+  模式零回歸）。#629 後半／#641 預留的那張票。
 - **#736：gate snapshot 依名跳過可再生快取目錄（`__pycache__`／`.pytest_cache`／
   `.mypy_cache`／`.ruff_cache`），寫入卡不再結構性必死。** builder unit 的
   `UMask=0077` 讓 pytest 產生的 `.pytest_cache/` 以 group bits 0 落地 ⇒ ACL

--- a/changelog.d/738-ledger-candidate-verification.md
+++ b/changelog.d/738-ledger-candidate-verification.md
@@ -1,0 +1,21 @@
+# 738-ledger-candidate-verification
+
+- **`#738` candidate 驗證下放 gate ledger——三分部署下帶 candidate 的 build 卡
+  終於可被採信**（#641 預留、一直沒開的那張票）。`_verify_exact_candidate` 原以
+  Manager 身分 `git -C <builder 樹>`，#641 收掉 `u:cortex-manager:rX` 後 builder
+  產生的 loose objects 結構上讀不到，任何寫入卡的採信必落
+  `candidate-worktree-unreadable-pending-gate-identity`。修法照 #629／#641 已裁定
+  的方向：gate 執行身分在**受控 checkout**（快照副本）上收集
+  `worktree_state`（`head`／`dirty`／`dirty_total`／`probe`／`ancestry_baseline`／
+  `ancestry_ok`），寫進同一份 ledger；baseline 經封閉 argv（`--assert-ancestor`）
+  由 Manager 的 job 記錄導出（自動路徑＝`dispatch_head`、`regenerate-gates`＝
+  已採信 candidate 或 `dispatch_head`），argv 仍無任何來自 job 的可變輸入。
+  `read_gate_spool` 對 state 逐項驗形狀（40-hex／有界清單），非法即
+  `gate-spool-invalid`。Manager 端 `_verify_exact_candidate`／
+  `_verify_build_candidate_transition` 先消費權威 ledger（head 等值、
+  ancestry_ok；ledger 的 baseline 與當下算出的不符視同缺席）；ledger 缺席／probe
+  非 ok 時逐字退回既有 git 路徑——direct 模式零回歸、三分模式維持既有
+  fail-closed。reviewer lane 不動（#650 起走 Manager 自己 clone 的樹）。乾淨度
+  本票只記錄不強制（現行路徑本就不驗，採信語意 parity；升級為 FAIL gate 另行
+  裁決）。ancestry 的另一道守衛（`harvest_branch` refspec 無 `+` 的 fast-forward
+  拒絕）不變，ledger 補的是新 branch 首張卡那一格。

--- a/paulsha_cortex/coordinator/gate_ledger.py
+++ b/paulsha_cortex/coordinator/gate_ledger.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import shlex
 import shutil
 import subprocess
@@ -395,6 +396,97 @@ def _snapshot_ignore_caches(directory: str, names: list[str]) -> set[str]:
     return {name for name in names if name in SNAPSHOT_REGENERABLE_CACHE_DIRS}
 
 
+# ---------------------------------------------------------------------------
+# candidate 驗證所需的 worktree 狀態（#738；#629 後半／#641 預留的那張票）
+# ---------------------------------------------------------------------------
+
+#: ledger 內 worktree 狀態的鍵名。作者與 gates rows 同為 gate 執行身分——
+#: 三分部署下 Manager 讀不進 builder 樹（#641 收掉唯讀 ACL），candidate 驗證
+#: （HEAD == candidate、ancestry）因此在**受控 checkout**（快照副本）上由本模組
+#: 收集，Manager 只消費 ledger，不再以自己的身分伸手進 job 樹。
+WORKTREE_STATE_KEY = "worktree_state"
+
+#: `dirty` 清單的筆數上限（有界診斷；總數另記在 `dirty_total`）。
+MAX_DIRTY_PATHS = 40
+
+_SHA_RE = re.compile(r"[0-9a-f]{40}")
+
+
+def collect_worktree_state(
+    worktree: str | Path,
+    *,
+    ancestry_baseline: str | None = None,
+) -> dict[str, object]:
+    """在受控 checkout 上收集 candidate 驗證所需的 git 狀態。
+
+    量測時點在**跑任何宣告 gate 之前**——gate 命令（pytest 等）會往樹裡寫，
+    state 必須反映快照當下、也就是被驗 candidate 的那一瞬。三種欄位：
+
+    - ``head``：`rev-parse HEAD`（小寫 40-hex；取不到時為 None 且 ``probe`` 記原因）
+    - ``dirty``／``dirty_total``：`status --porcelain --untracked-files=all` 的
+      有界前綴與總數。**本票只記錄不強制**（Manager 現行 git 路徑本就不驗乾淨度，
+      採信語意維持 parity）；升級為 FAIL gate 是另一個裁決。
+    - ``ancestry_baseline``／``ancestry_ok``：`merge-base --is-ancestor <baseline>
+      HEAD`。baseline 由 Manager 經封閉 argv 提供（`--assert-ancestor`），不是
+      job 的可變輸入。它補的是 `harvest_branch` fast-forward 守衛蓋不到的那一格
+      （新 branch 首張卡：fetch 建新 ref 時沒有 FF 檢查）。
+
+    任何 git 呼叫失敗都記進 ``probe`` 並提前回傳——消費端（manager）把
+    ``probe != "ok"`` 視同 state 缺席，退回既有 fail-closed 路徑，不猜。
+    """
+
+    def _run(argv: list[str]):
+        return subprocess.run(
+            argv, capture_output=True, text=True, check=False, cwd=str(worktree)
+        )
+
+    state: dict[str, object] = {
+        "head": None,
+        "dirty": [],
+        "dirty_total": 0,
+        "probe": "ok",
+        "ancestry_baseline": ancestry_baseline,
+        "ancestry_ok": None,
+    }
+    head = _run(["git", "rev-parse", "HEAD"])
+    if head.returncode != 0:
+        state["probe"] = (
+            "error: rev-parse HEAD: " + (head.stderr or head.stdout).strip()[:400]
+        )
+        return state
+    sha = head.stdout.strip().lower()
+    if _SHA_RE.fullmatch(sha) is None:
+        state["probe"] = f"error: rev-parse HEAD returned non-sha: {sha[:80]!r}"
+        return state
+    state["head"] = sha
+    status = _run(["git", "status", "--porcelain", "--untracked-files=all"])
+    if status.returncode != 0:
+        state["probe"] = (
+            "error: status --porcelain: " + (status.stderr or status.stdout).strip()[:400]
+        )
+        return state
+    lines = [line for line in status.stdout.splitlines() if line.strip()]
+    state["dirty_total"] = len(lines)
+    state["dirty"] = [line[:200] for line in lines[:MAX_DIRTY_PATHS]]
+    if ancestry_baseline is not None:
+        if _SHA_RE.fullmatch(ancestry_baseline) is None:
+            state["probe"] = (
+                f"error: ancestry baseline is not a sha: {ancestry_baseline[:80]!r}"
+            )
+            return state
+        ancestry = _run(["git", "merge-base", "--is-ancestor", ancestry_baseline, "HEAD"])
+        if ancestry.returncode == 0:
+            state["ancestry_ok"] = True
+        elif ancestry.returncode == 1:
+            state["ancestry_ok"] = False
+        else:
+            state["probe"] = (
+                "error: merge-base --is-ancestor: "
+                + (ancestry.stderr or ancestry.stdout).strip()[:400]
+            )
+    return state
+
+
 def snapshot_worktree(source: str | Path, destination: str | Path) -> Path:
     """把被驗的工作樹複製成一份**拋棄式副本**，回傳副本路徑（#629）。
 
@@ -456,13 +548,17 @@ def build_ledger(
     gates: Sequence[Mapping[str, object]],
     *,
     slice_id: str | None = None,
+    worktree_state: Mapping[str, object] | None = None,
 ) -> dict[str, object]:
-    return {
+    payload: dict[str, object] = {
         "schema_version": terminal_contract.GATE_LEDGER_SCHEMA_VERSION,
         "kind": terminal_contract.GATE_LEDGER_KIND,
         "slice_id": slice_id or "",
         "gates": [dict(row) for row in gates],
     }
+    if worktree_state is not None:
+        payload[WORKTREE_STATE_KEY] = dict(worktree_state)
+    return payload
 
 
 def write_gate_ledger(
@@ -471,6 +567,7 @@ def write_gate_ledger(
     worktree: str | Path,
     env: Mapping[str, str] | None = None,
     runner: Runner | None = None,
+    ancestry_baseline: str | None = None,
 ) -> dict[str, object]:
     """執行宣告的 gate 並原子寫出 ledger；回傳寫出的 payload。
 
@@ -481,13 +578,22 @@ def write_gate_ledger(
 
     source = os.environ if env is None else env
     specs = load_gate_specs(source)
+    # worktree 狀態在**跑任何 gate 之前**收集（#738）：gate 命令會往樹裡寫，
+    # state 必須反映被驗 candidate 的那一瞬。
+    worktree_state = collect_worktree_state(
+        worktree, ancestry_baseline=ancestry_baseline
+    )
     gates = run_gates(
         specs,
         worktree=worktree,
         timeout=_gate_timeout(source),
         runner=runner,
     )
-    payload = build_ledger(gates, slice_id=source.get("PSC_SLICE_ID"))
+    payload = build_ledger(
+        gates,
+        slice_id=source.get("PSC_SLICE_ID"),
+        worktree_state=worktree_state,
+    )
     write_ledger_payload(ledger_path, payload)
     return payload
 
@@ -530,6 +636,15 @@ def main(argv: Sequence[str] | None = None) -> int:
         ),
     )
     parser.add_argument(
+        "--assert-ancestor",
+        default=None,
+        help=(
+            "#738：要求 worktree HEAD 是這個 40-hex baseline 的 descendant，結果記進 "
+            "ledger 的 worktree_state.ancestry_ok。由 Manager 的封閉 argv 提供，"
+            "不是 job 的可變輸入。"
+        ),
+    )
+    parser.add_argument(
         "--publish",
         action="store_true",
         help=(
@@ -548,7 +663,11 @@ def main(argv: Sequence[str] | None = None) -> int:
             print(str(exc), file=sys.stderr)
             return 74
     try:
-        write_gate_ledger(ledger_path=args.out, worktree=args.worktree)
+        write_gate_ledger(
+            ledger_path=args.out,
+            worktree=args.worktree,
+            ancestry_baseline=args.assert_ancestor,
+        )
         if args.publish:
             spool_slot.publish_file(args.out)
     except GateSpecError:

--- a/paulsha_cortex/coordinator/gate_runner.py
+++ b/paulsha_cortex/coordinator/gate_runner.py
@@ -272,6 +272,7 @@ def build_gate_argv(
     ledger_out: str | Path,
     snapshot: str | Path,
     source_worktree: str | Path,
+    ancestry_baseline: str | None = None,
 ) -> list[str]:
     """gate unit 實際執行的 argv。**封閉：沒有任何來自 job 的可變輸入。**
 
@@ -285,7 +286,7 @@ def build_gate_argv(
     Manager 是**目錄**的 owner 但那不給檔案內容的讀取權（#638 缺陷 2）。
     """
 
-    return [
+    argv = [
         str(python),
         "-m",
         "paulsha_cortex.coordinator.gate_ledger",
@@ -297,6 +298,11 @@ def build_gate_argv(
         str(source_worktree),
         "--publish",
     ]
+    if ancestry_baseline is not None:
+        # #738：baseline 來自 Manager 的 run／job 記錄（dispatch_head 或已採信的
+        # candidate），不是 job 的可變輸入——argv 的封閉性不變。
+        argv.extend(["--assert-ancestor", str(ancestry_baseline)])
+    return argv
 
 
 def prepare_gate_spool(
@@ -342,6 +348,80 @@ def seal_gate_spool(ledger_file: str | Path) -> None:
     """
 
     spool_slot.seal_slot(Path(ledger_file).parent)
+
+
+def _normalize_worktree_state(
+    payload: Mapping[str, Any], *, path: Path
+) -> dict[str, Any] | None:
+    """spool ledger 的 `worktree_state` 逐項驗形狀（#738）。
+
+    寫這份檔的 gate 身分正在執行 builder 交出來的程式碼，可能被攻陷：這裡擋的是
+    **形狀**（發明的鍵、無界字串、非 sha 的 head），不是內容真偽——那是圍堵買不到
+    的東西，與 gates rows 的誠實邊界一致。缺席回 None（老 ledger／direct 路徑產物），
+    形狀非法一律 `gate-spool-invalid` fail-closed。
+    """
+
+    raw = payload.get(gate_ledger.WORKTREE_STATE_KEY)
+    if raw is None:
+        return None
+    if not isinstance(raw, Mapping):
+        raise GateRunnerError(
+            "gate-spool-invalid", "worktree_state 必須為物件", path=str(path)
+        )
+    sha_re = gate_ledger._SHA_RE
+    head = raw.get("head")
+    if head is not None and (not isinstance(head, str) or sha_re.fullmatch(head) is None):
+        raise GateRunnerError(
+            "gate-spool-invalid", f"worktree_state.head 非法: {head!r}", path=str(path)
+        )
+    baseline = raw.get("ancestry_baseline")
+    if baseline is not None and (
+        not isinstance(baseline, str) or sha_re.fullmatch(baseline) is None
+    ):
+        raise GateRunnerError(
+            "gate-spool-invalid",
+            f"worktree_state.ancestry_baseline 非法: {baseline!r}",
+            path=str(path),
+        )
+    ancestry_ok = raw.get("ancestry_ok")
+    if ancestry_ok is not None and not isinstance(ancestry_ok, bool):
+        raise GateRunnerError(
+            "gate-spool-invalid",
+            f"worktree_state.ancestry_ok 非法: {ancestry_ok!r}",
+            path=str(path),
+        )
+    dirty_total = raw.get("dirty_total")
+    if type(dirty_total) is not int or dirty_total < 0:
+        raise GateRunnerError(
+            "gate-spool-invalid",
+            f"worktree_state.dirty_total 非法: {dirty_total!r}",
+            path=str(path),
+        )
+    dirty_raw = raw.get("dirty")
+    if not isinstance(dirty_raw, list) or len(dirty_raw) > gate_ledger.MAX_DIRTY_PATHS:
+        raise GateRunnerError(
+            "gate-spool-invalid", "worktree_state.dirty 必須為有界清單", path=str(path)
+        )
+    dirty = []
+    for item in dirty_raw:
+        if not isinstance(item, str):
+            raise GateRunnerError(
+                "gate-spool-invalid", "worktree_state.dirty 項目必須為字串", path=str(path)
+            )
+        dirty.append(item[:MAX_DETAIL_CHARS])
+    probe = raw.get("probe")
+    if not isinstance(probe, str):
+        raise GateRunnerError(
+            "gate-spool-invalid", f"worktree_state.probe 非法: {probe!r}", path=str(path)
+        )
+    return {
+        "head": head,
+        "dirty": dirty,
+        "dirty_total": dirty_total,
+        "probe": probe[:MAX_DETAIL_CHARS],
+        "ancestry_baseline": baseline,
+        "ancestry_ok": ancestry_ok,
+    }
 
 
 def read_gate_spool(ledger_file: str | Path, *, env: Mapping[str, str]) -> dict[str, Any]:
@@ -432,7 +512,11 @@ def read_gate_spool(ledger_file: str | Path, *, env: Mapping[str, str]) -> dict[
                 "detail": (detail if isinstance(detail, str) else "")[-MAX_DETAIL_CHARS:],
             }
         )
-    return gate_ledger.build_ledger(normalized, slice_id=str(env.get("PSC_SLICE_ID", "")))
+    return gate_ledger.build_ledger(
+        normalized,
+        slice_id=str(env.get("PSC_SLICE_ID", "")),
+        worktree_state=_normalize_worktree_state(payload, path=path),
+    )
 
 
 def run_declared_gates(
@@ -444,6 +528,7 @@ def run_declared_gates(
     env: Mapping[str, str] | None = None,
     coordinator_root: str | Path | None = None,
     runner: Any | None = None,
+    ancestry_baseline: str | None = None,
 ) -> dict[str, Any]:
     """執行 operator 宣告的 gate 並讓 **Manager** 落地權威 ledger，回傳 payload。
 
@@ -464,7 +549,10 @@ def run_declared_gates(
     mode = job_runner.resolve_runner_mode(source)
     if mode == job_runner.RUNNER_DIRECT:
         return gate_ledger.write_gate_ledger(
-            ledger_path=ledger_path, worktree=worktree, env=source
+            ledger_path=ledger_path,
+            worktree=worktree,
+            env=source,
+            ancestry_baseline=ancestry_baseline,
         )
     return _run_as_gate_identity(
         job_id=job_id,
@@ -474,6 +562,7 @@ def run_declared_gates(
         env=source,
         coordinator_root=coordinator_root,
         runner=runner,
+        ancestry_baseline=ancestry_baseline,
     )
 
 
@@ -502,6 +591,7 @@ def _run_as_gate_identity(
     env: Mapping[str, str],
     coordinator_root: str | Path | None,
     runner: Any | None,
+    ancestry_baseline: str | None = None,
 ) -> dict[str, Any]:
     """降權模式的實作：起 `cortex-gate-job@<instance>.service`，消費 spool，落地。"""
 
@@ -557,6 +647,7 @@ def _run_as_gate_identity(
         ledger_out=spool_ledger,
         snapshot=snapshot,
         source_worktree=resolved_worktree,
+        ancestry_baseline=ancestry_baseline,
     )
     spec = job_runner.build_job_spec(
         job_id=job_id,
@@ -654,6 +745,16 @@ def ensure_gate_ledger(
     if not isinstance(worktree, str) or not Path(worktree).is_dir():
         return None
     job_id = str(job.get("job_id") or spool_key)
+    # #738：ancestry baseline ＝ 這張卡 provision 時的 dispatch_head（Manager 寫進
+    # job 記錄的值，不是 job 的可變輸入）。缺席／非 sha 時不傳——ledger 的
+    # ancestry_ok 維持 None，採信端自然退回既有路徑。
+    dispatch_head = job.get("dispatch_head")
+    baseline = (
+        dispatch_head.lower()
+        if isinstance(dispatch_head, str)
+        and gate_ledger._SHA_RE.fullmatch(dispatch_head.lower()) is not None
+        else None
+    )
     return run_declared_gates(
         job_id=job_id,
         spool_key=spool_key,
@@ -662,6 +763,7 @@ def ensure_gate_ledger(
         env=source,
         coordinator_root=coordinator_root,
         runner=runner,
+        ancestry_baseline=baseline,
     )
 
 

--- a/paulsha_cortex/coordinator/manager.py
+++ b/paulsha_cortex/coordinator/manager.py
@@ -3264,6 +3264,32 @@ def _raise_if_worktree_read_blocked(result: object, *, what: str) -> None:
     )
 
 
+def _job_gate_worktree_state(job: Mapping[str, object]) -> Mapping[str, object] | None:
+    """這個 job 的權威 gate ledger 裡的 `worktree_state`（#738），讀不到即 None。
+
+    權威 ledger（`<log>.gates.json`）由 Manager 自己落地（#628 的
+    `foreign_evidence_author()` 檢查的就是它），內容則是 gate 執行身分在快照副本上
+    收集的——這是 #629／#641 裁定的「第三執行身分在受控 checkout 執行」的落點。
+    `probe != "ok"` 視同缺席：消費端一律退回既有 fail-closed 路徑，不對半套狀態
+    做任何推論。
+    """
+
+    log_path = job.get("log_path")
+    if not isinstance(log_path, str) or not log_path:
+        return None
+    path = terminal_contract.gate_ledger_path(log_path)
+    try:
+        payload = json.loads(Path(path).read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return None
+    if not isinstance(payload, Mapping):
+        return None
+    state = payload.get(gate_ledger.WORKTREE_STATE_KEY)
+    if not isinstance(state, Mapping) or state.get("probe") != "ok":
+        return None
+    return state
+
+
 def _verify_exact_candidate(job: Mapping[str, object], *, git_runner=None) -> str:
     candidate = job.get("subject_head")
     # reviewer 走 `workflow_repo_root`，不讀 reviewer 的工作樹（那是 sandbox）。
@@ -3281,6 +3307,21 @@ def _verify_exact_candidate(job: Mapping[str, object], *, git_runner=None) -> st
         or not isinstance(worktree, str)
     ):
         raise ValueError("workflow job candidate/worktree missing")
+
+    if job.get("persona") != "reviewer":
+        # #738：builder 樹那條先消費 gate ledger 的 worktree_state——三分部署下
+        # Manager 讀不進 builder 的樹（#641），HEAD == candidate 由 gate 執行身分
+        # 在快照副本上量測。state 缺席／probe 非 ok 時退回下面的既有 git 路徑：
+        # direct 模式（同 UID）照走、三分模式維持 #629 的 fail-closed。
+        state = _job_gate_worktree_state(job)
+        if state is not None:
+            head = state.get("head")
+            if not isinstance(head, str) or head != candidate.lower():
+                raise ValueError(
+                    "workflow candidate is not exact worktree HEAD "
+                    f"(gate ledger head={head!r})"
+                )
+            return candidate
 
     def run_git(argv: list[str]):
         if git_runner is None:
@@ -3330,6 +3371,17 @@ def _verify_build_candidate_transition(
         raise ValueError("workflow build candidate baseline missing")
     if baseline == candidate:
         return candidate
+
+    # #738：ancestry 同樣先消費 gate ledger。ledger 記錄的 baseline 必須恰等於
+    # Manager 當下算出的 baseline——不等（refreeze／換代造成的陳舊 ledger）視同
+    # 缺席，退回既有路徑，不採信一份針對別的基線量出來的答案。
+    state = _job_gate_worktree_state(job)
+    if state is not None and state.get("ancestry_baseline") == baseline:
+        ancestry_ok = state.get("ancestry_ok")
+        if ancestry_ok is True:
+            return candidate
+        if ancestry_ok is False:
+            raise ValueError("workflow build candidate is not a descendant")
 
     argv = ["git", "-C", worktree, "merge-base", "--is-ancestor", baseline, candidate]
     if git_runner is None:

--- a/paulsha_cortex/coordinator/work_actions.py
+++ b/paulsha_cortex/coordinator/work_actions.py
@@ -4108,12 +4108,24 @@ def _regenerate_gates_action(
     spool_key = gate_runner.spool_key_for_job(job)
     if spool_key is None:
         raise RuntimeError("regenerate-gates requires a resolvable gate spool key")
+    # #738：ancestry baseline 與採信端 `_verify_build_candidate_transition` 同一條
+    # 導出（已採信的 candidate，否則這張卡 provision 時的 dispatch_head）。缺席／
+    # 非 sha 時不傳，ledger 的 ancestry_ok 維持 None，採信端自然退回既有路徑。
+    baseline = None
+    for value in (getattr(run, "candidate_head", None), job.get("dispatch_head")):
+        if (
+            isinstance(value, str)
+            and gate_ledger._SHA_RE.fullmatch(value.lower()) is not None
+        ):
+            baseline = value.lower()
+            break
     try:
         payload = gate_runner.run_declared_gates(
             job_id=str(job.get("job_id") or spool_key),
             spool_key=spool_key,
             ledger_path=ledger_path,
             worktree=worktree,
+            ancestry_baseline=baseline,
         )
     except gate_ledger.GateSpecError as exc:
         # operator 宣告仍不合法：不寫出任何東西，把設定錯誤原樣回報。

--- a/tests/test_gate_worktree_state_738.py
+++ b/tests/test_gate_worktree_state_738.py
@@ -1,0 +1,373 @@
+"""#738：candidate 驗證下放 gate ledger 的行為契約。
+
+三分部署下 Manager 讀不進 builder 的樹（#641 收掉唯讀 ACL），
+`_verify_exact_candidate` 的 `git -C <job 樹>` 結構上必死。修法照 #629／#641
+裁定：worktree 狀態（HEAD／dirty／ancestry）由 gate 執行身分在受控 checkout
+（快照副本）上收集、寫進 ledger 的 `worktree_state`，Manager 只消費 ledger。
+本檔釘四段：收集端、spool 驗證端、argv 封閉性、Manager 消費端（含「ledger
+有 state 時完全不碰 builder 樹」與「缺席時逐字退回既有路徑」）。
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+from paulsha_cortex.coordinator import gate_ledger, gate_runner, manager, terminal_contract
+
+
+def _git(cwd: Path, *argv: str) -> str:
+    proc = subprocess.run(
+        ["git", *argv], cwd=str(cwd), capture_output=True, text=True, check=True
+    )
+    return proc.stdout.strip()
+
+
+def _make_repo(root: Path) -> tuple[str, str]:
+    """一個 base→head 兩個 commit 的 repo，回傳 (base_sha, head_sha)。"""
+
+    root.mkdir(parents=True, exist_ok=True)
+    _git(root, "init", "-q", "-b", "main")
+    _git(root, "config", "user.email", "t@example.invalid")
+    _git(root, "config", "user.name", "t")
+    (root / "a.txt").write_text("1\n", encoding="utf-8")
+    _git(root, "add", "-A")
+    _git(root, "commit", "-qm", "base")
+    base = _git(root, "rev-parse", "HEAD")
+    (root / "b.txt").write_text("2\n", encoding="utf-8")
+    _git(root, "add", "-A")
+    _git(root, "commit", "-qm", "head")
+    head = _git(root, "rev-parse", "HEAD")
+    return base.lower(), head.lower()
+
+
+# ---------------------------------------------------------------------------
+# 1. 收集端
+# ---------------------------------------------------------------------------
+
+class CollectWorktreeStateTests(unittest.TestCase):
+    def test_clean_repo_reports_head_and_ancestry(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp) / "repo"
+            base, head = _make_repo(repo)
+            state = gate_ledger.collect_worktree_state(repo, ancestry_baseline=base)
+            self.assertEqual(state["probe"], "ok")
+            self.assertEqual(state["head"], head)
+            self.assertEqual(state["dirty_total"], 0)
+            self.assertEqual(state["dirty"], [])
+            self.assertEqual(state["ancestry_baseline"], base)
+            self.assertIs(state["ancestry_ok"], True)
+
+    def test_non_descendant_baseline_is_false_not_error(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp) / "repo"
+            base, head = _make_repo(repo)
+            # 從 base 岔出一條 side：head 不是 side 的祖先。
+            _git(repo, "checkout", "-q", "-b", "side", base)
+            (repo / "c.txt").write_text("3\n", encoding="utf-8")
+            _git(repo, "add", "-A")
+            _git(repo, "commit", "-qm", "side")
+            state = gate_ledger.collect_worktree_state(repo, ancestry_baseline=head)
+            self.assertEqual(state["probe"], "ok")
+            self.assertIs(state["ancestry_ok"], False)
+
+    def test_dirty_worktree_is_recorded_not_hidden(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp) / "repo"
+            _make_repo(repo)
+            (repo / "stray.txt").write_text("x\n", encoding="utf-8")
+            state = gate_ledger.collect_worktree_state(repo)
+            self.assertEqual(state["dirty_total"], 1)
+            self.assertIn("stray.txt", state["dirty"][0])
+
+    def test_non_git_tree_reports_probe_error(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            plain = Path(tmp) / "plain"
+            plain.mkdir()
+            state = gate_ledger.collect_worktree_state(plain)
+            self.assertTrue(str(state["probe"]).startswith("error:"), state)
+            self.assertIsNone(state["head"])
+
+    def test_malformed_baseline_reports_probe_error(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp) / "repo"
+            _make_repo(repo)
+            state = gate_ledger.collect_worktree_state(
+                repo, ancestry_baseline="not-a-sha"
+            )
+            self.assertTrue(str(state["probe"]).startswith("error:"), state)
+            self.assertIsNone(state["ancestry_ok"])
+
+    def test_write_gate_ledger_embeds_worktree_state(self) -> None:
+        """direct 模式的落點：payload 與檔案都帶 `worktree_state`。"""
+
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp) / "repo"
+            base, head = _make_repo(repo)
+            out = Path(tmp) / "ledger.json"
+            payload = gate_ledger.write_gate_ledger(
+                ledger_path=out,
+                worktree=repo,
+                env={},
+                ancestry_baseline=base,
+            )
+            self.assertEqual(
+                payload[gate_ledger.WORKTREE_STATE_KEY]["head"], head
+            )
+            on_disk = json.loads(out.read_text(encoding="utf-8"))
+            self.assertIs(
+                on_disk[gate_ledger.WORKTREE_STATE_KEY]["ancestry_ok"], True
+            )
+
+
+# ---------------------------------------------------------------------------
+# 2. spool 驗證端
+# ---------------------------------------------------------------------------
+
+class ReadGateSpoolWorktreeStateTests(unittest.TestCase):
+    def _spool_payload(self, state: object) -> dict:
+        return {
+            "schema_version": terminal_contract.GATE_LEDGER_SCHEMA_VERSION,
+            "kind": terminal_contract.GATE_LEDGER_KIND,
+            "slice_id": "s",
+            "gates": [],
+            gate_ledger.WORKTREE_STATE_KEY: state,
+        }
+
+    def _read(self, payload: dict) -> dict:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "ledger.json"
+            path.write_text(json.dumps(payload), encoding="utf-8")
+            return gate_runner.read_gate_spool(path, env={})
+
+    def test_valid_state_passes_through(self) -> None:
+        head = "a" * 40
+        result = self._read(
+            self._spool_payload(
+                {
+                    "head": head,
+                    "dirty": ["?? x.txt"],
+                    "dirty_total": 1,
+                    "probe": "ok",
+                    "ancestry_baseline": "b" * 40,
+                    "ancestry_ok": True,
+                }
+            )
+        )
+        state = result[gate_ledger.WORKTREE_STATE_KEY]
+        self.assertEqual(state["head"], head)
+        self.assertIs(state["ancestry_ok"], True)
+
+    def test_absent_state_is_tolerated(self) -> None:
+        payload = self._spool_payload(None)
+        payload.pop(gate_ledger.WORKTREE_STATE_KEY)
+        result = self._read(payload)
+        self.assertNotIn(gate_ledger.WORKTREE_STATE_KEY, result)
+
+    def test_malformed_head_fails_closed(self) -> None:
+        with self.assertRaises(gate_runner.GateRunnerError) as ctx:
+            self._read(
+                self._spool_payload(
+                    {
+                        "head": "not-a-sha",
+                        "dirty": [],
+                        "dirty_total": 0,
+                        "probe": "ok",
+                        "ancestry_baseline": None,
+                        "ancestry_ok": None,
+                    }
+                )
+            )
+        self.assertEqual(ctx.exception.reason, "gate-spool-invalid")
+
+    def test_unbounded_dirty_list_fails_closed(self) -> None:
+        with self.assertRaises(gate_runner.GateRunnerError):
+            self._read(
+                self._spool_payload(
+                    {
+                        "head": None,
+                        "dirty": ["x"] * (gate_ledger.MAX_DIRTY_PATHS + 1),
+                        "dirty_total": 999,
+                        "probe": "ok",
+                        "ancestry_baseline": None,
+                        "ancestry_ok": None,
+                    }
+                )
+            )
+
+
+# ---------------------------------------------------------------------------
+# 3. argv 封閉性
+# ---------------------------------------------------------------------------
+
+class BuildGateArgvTests(unittest.TestCase):
+    def test_baseline_extends_argv_and_absence_leaves_it_unchanged(self) -> None:
+        base_kwargs = dict(
+            python="/opt/x/bin/python3",
+            ledger_out="/spool/ledger.json",
+            snapshot="/gate/snap",
+            source_worktree="/worktree/job",
+        )
+        bare = gate_runner.build_gate_argv(**base_kwargs)
+        self.assertNotIn("--assert-ancestor", bare)
+        sha = "c" * 40
+        argv = gate_runner.build_gate_argv(**base_kwargs, ancestry_baseline=sha)
+        index = argv.index("--assert-ancestor")
+        self.assertEqual(argv[index + 1], sha)
+        # baseline 只是多兩個 token，前綴逐字不變——argv 仍然封閉。
+        self.assertEqual(argv[: len(bare)], bare)
+
+
+# ---------------------------------------------------------------------------
+# 4. Manager 消費端
+# ---------------------------------------------------------------------------
+
+def _forbidden_git_runner(*argv, **kwargs):
+    raise AssertionError(f"manager must not touch the builder tree: {argv!r}")
+
+
+class _SentinelGitCalled(RuntimeError):
+    pass
+
+
+def _sentinel_git_runner(*argv, **kwargs):
+    raise _SentinelGitCalled(str(argv))
+
+
+class ManagerConsumesLedgerTests(unittest.TestCase):
+    def _job(self, tmp: Path, *, candidate: str, dispatch_head: str | None = None) -> dict:
+        log_path = tmp / "job.jsonl"
+        log_path.write_text("", encoding="utf-8")
+        job = {
+            "subject_head": candidate,
+            "worktree": str(tmp / "unreadable-builder-tree"),
+            "persona": "builder",
+            "log_path": str(log_path),
+        }
+        if dispatch_head is not None:
+            job["dispatch_head"] = dispatch_head
+        return job
+
+    def _write_ledger(self, job: dict, state: dict) -> None:
+        path = terminal_contract.gate_ledger_path(job["log_path"])
+        payload = {
+            "schema_version": terminal_contract.GATE_LEDGER_SCHEMA_VERSION,
+            "kind": terminal_contract.GATE_LEDGER_KIND,
+            "slice_id": "s",
+            "gates": [],
+            gate_ledger.WORKTREE_STATE_KEY: state,
+        }
+        Path(path).write_text(json.dumps(payload), encoding="utf-8")
+
+    def _state(self, **overrides: object) -> dict:
+        state: dict = {
+            "head": None,
+            "dirty": [],
+            "dirty_total": 0,
+            "probe": "ok",
+            "ancestry_baseline": None,
+            "ancestry_ok": None,
+        }
+        state.update(overrides)
+        return state
+
+    def test_ledger_head_match_never_touches_the_builder_tree(self) -> None:
+        candidate = "a" * 40
+        with tempfile.TemporaryDirectory() as tmp:
+            job = self._job(Path(tmp), candidate=candidate)
+            self._write_ledger(job, self._state(head=candidate))
+            result = manager._verify_exact_candidate(
+                job, git_runner=_forbidden_git_runner
+            )
+            self.assertEqual(result, candidate)
+
+    def test_ledger_head_mismatch_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            job = self._job(Path(tmp), candidate="a" * 40)
+            self._write_ledger(job, self._state(head="b" * 40))
+            with self.assertRaises(ValueError) as ctx:
+                manager._verify_exact_candidate(job, git_runner=_forbidden_git_runner)
+            self.assertIn("not exact worktree HEAD", str(ctx.exception))
+
+    def test_probe_error_falls_back_to_the_existing_git_path(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            job = self._job(Path(tmp), candidate="a" * 40)
+            self._write_ledger(
+                job, self._state(head="a" * 40, probe="error: rev-parse HEAD: boom")
+            )
+            with self.assertRaises(_SentinelGitCalled):
+                manager._verify_exact_candidate(job, git_runner=_sentinel_git_runner)
+
+    def test_absent_ledger_falls_back_to_the_existing_git_path(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            job = self._job(Path(tmp), candidate="a" * 40)
+            with self.assertRaises(_SentinelGitCalled):
+                manager._verify_exact_candidate(job, git_runner=_sentinel_git_runner)
+
+    def test_reviewer_lane_is_untouched_by_the_ledger(self) -> None:
+        """reviewer 走 Manager 自己 clone 的樹（#650），照舊直接 git。"""
+
+        with tempfile.TemporaryDirectory() as tmp:
+            job = self._job(Path(tmp), candidate="a" * 40)
+            job["persona"] = "reviewer"
+            job["workflow_repo_root"] = str(Path(tmp) / "manager-owned")
+            self._write_ledger(job, self._state(head="a" * 40))
+            with self.assertRaises(_SentinelGitCalled):
+                manager._verify_exact_candidate(job, git_runner=_sentinel_git_runner)
+
+    def test_transition_consumes_ledger_ancestry_true(self) -> None:
+        candidate = "a" * 40
+        baseline = "b" * 40
+        with tempfile.TemporaryDirectory() as tmp:
+            job = self._job(Path(tmp), candidate=candidate, dispatch_head=baseline)
+            self._write_ledger(
+                job,
+                self._state(
+                    head=candidate, ancestry_baseline=baseline, ancestry_ok=True
+                ),
+            )
+            result = manager._verify_build_candidate_transition(
+                job, previous_candidate=None, git_runner=_forbidden_git_runner
+            )
+            self.assertEqual(result, candidate)
+
+    def test_transition_consumes_ledger_ancestry_false(self) -> None:
+        candidate = "a" * 40
+        baseline = "b" * 40
+        with tempfile.TemporaryDirectory() as tmp:
+            job = self._job(Path(tmp), candidate=candidate, dispatch_head=baseline)
+            self._write_ledger(
+                job,
+                self._state(
+                    head=candidate, ancestry_baseline=baseline, ancestry_ok=False
+                ),
+            )
+            with self.assertRaises(ValueError) as ctx:
+                manager._verify_build_candidate_transition(
+                    job, previous_candidate=None, git_runner=_forbidden_git_runner
+                )
+            self.assertIn("not a descendant", str(ctx.exception))
+
+    def test_transition_baseline_mismatch_is_treated_as_absent(self) -> None:
+        """陳舊 ledger（針對別的基線量的答案）不得被採信——退回既有路徑。"""
+
+        candidate = "a" * 40
+        with tempfile.TemporaryDirectory() as tmp:
+            job = self._job(Path(tmp), candidate=candidate, dispatch_head="b" * 40)
+            self._write_ledger(
+                job,
+                self._state(
+                    head=candidate, ancestry_baseline="c" * 40, ancestry_ok=True
+                ),
+            )
+            with self.assertRaises(_SentinelGitCalled):
+                manager._verify_build_candidate_transition(
+                    job, previous_candidate=None, git_runner=_sentinel_git_runner
+                )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
Fixes #738

## 病因（實機第十環，run `workflow-85114100` tdd-red 卡）

`#736` 修好 gate snapshot 後 ledger 正常產出（pytest=failed=RED 正確），但 `resume` 採信時 `_verify_exact_candidate()` 以 **Manager 身分** `git -C <builder 樹> cat-file`——三分部署下 builder 產生的 loose objects 依 default ACL 只有 gate 具名條目與 owner，Manager 自 #641 收掉 `u:cortex-manager:rX` 後結構上讀不到 ⇒ `candidate-worktree-unreadable-pending-gate-identity` fail-closed。#641 本文明列這條檢查「建議另開票、兩條路要一起決定」——票一直沒開，⇒ **三分部署下任何帶 candidate 的 build 卡都永不可採信**。

## 修法（照 #629／#641 已裁定的方向：第三執行身分在受控 checkout 執行）

- `gate_ledger.collect_worktree_state()`：gate 在快照副本上（跑任何宣告 gate **之前**）收 `rev-parse HEAD`／`status --porcelain --untracked-files=all`（有界）／`merge-base --is-ancestor <baseline> HEAD`，進 ledger 的 `worktree_state`。
- baseline 經**封閉 argv**（`build_gate_argv` 增 `--assert-ancestor`）由 Manager 的 job 記錄導出：自動路徑（`ensure_gate_ledger`）＝`dispatch_head`；`regenerate-gates`＝已採信 candidate 或 `dispatch_head`。argv 仍無任何來自 job 的可變輸入。
- `read_gate_spool` 對 state 逐項驗形狀（40-hex head／baseline、有界 dirty 清單、bool ancestry_ok），非法即 `gate-spool-invalid`；缺席容忍（老 ledger）。
- Manager 端 `_verify_exact_candidate`（builder 樹那條）先消費**權威 ledger**：`head == candidate` 即成立、完全不碰 builder 樹；`_verify_build_candidate_transition` 消費 `ancestry_ok`，且 **ledger 的 `ancestry_baseline` 必須恰等於 Manager 當下算出的 baseline**（陳舊 ledger 視同缺席）。缺席／probe 非 ok 一律逐字退回既有 git 路徑——direct 模式零回歸、三分模式維持既有 fail-closed。

## 誠實邊界

- reviewer lane 不動（#650 起走 Manager 自己 clone 的 candidate 樹，#641 問題結構性不存在）；測試釘住 reviewer 照舊直接 git。
- `worktree_state` 作者是 gate 身分，與 gates rows 同一信任等級（被攻陷的 gate 能造假是圍堵買不到的東西；builder 連 gate spool 都 traverse 不進去）。
- ancestry 另有 `harvest_branch` refspec 無 `+` 的 fast-forward 拒絕；ledger 補的是新 branch 首張卡（fetch 建新 ref 無 FF 檢查）那一格。
- **乾淨度只記錄不強制**：現行 Manager git 路徑本就只驗 `HEAD == candidate`，採信語意維持 parity；`dirty`／`dirty_total` 已入 ledger，是否升級 FAIL gate 另行裁決。

## 驗收（照 #738）

- [x] git fixture：`collect_worktree_state` 正確回 head／dirty／ancestry true／false／非 git 樹 probe error／非法 baseline probe error
- [x] `read_gate_spool` 通過合法 state、拒絕非 40-hex head 與無界 dirty 清單、容忍缺席
- [x] `_verify_exact_candidate`：ledger 有 state 時**完全不碰** builder 樹（git_runner 一被呼叫即 AssertionError）；head 不符拒絕；probe error／缺席退回既有路徑
- [x] `_verify_build_candidate_transition`：ancestry_ok=false ⇒ not-a-descendant；baseline 不符 ⇒ 視同缺席退回
- [x] 全套 `python3 -m pytest tests/ -q`：4889 passed, 36 skipped（零回歸）

實機驗收（merge＋部署後由 operator 執行、回報於 #738）：run `workflow-85114100` 的 tdd-red 經 `regenerate-gates` → `resume` 採信通過、phase 推進。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XcQLDun91sLCJfJeKoVgjS
