### PR TITLE
fix(dispatch): 誠實紀律補環境維度，sandbox-only 失敗省略 gate 而非自報 failed（#740）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 本專案遵循 hamanpaul project policy v1.0.17。
 
 ## [Unreleased]
+- **#740：誠實紀律補環境維度，builder sandbox 的環境紅不再使 focused 寫入卡確定性
+  自報 failed。** 判準來自 Manager 在 gate 環境的重跑；sandbox-only、與變更無關的
+  失敗改為「省略該 gate＋diagnostics 記錄＋照常交付 candidate」，宣稱綠仍禁止、
+  ledger 紅照樣 fail-closed。`status_policy` 失敗條款改為「because of your change」。
 - **#738：candidate 驗證下放 gate ledger，三分部署下帶 candidate 的 build 卡終於
   可被採信。** gate 身分在快照副本上收集 `worktree_state`（head／dirty／
   ancestry），Manager 只消費權威 ledger、不再以自己的身分 `git -C <builder 樹>`

--- a/changelog.d/740-environment-honesty.md
+++ b/changelog.d/740-environment-honesty.md
@@ -1,0 +1,16 @@
+# 740-environment-honesty
+
+- **`#740` 誠實紀律補上環境維度——builder sandbox 的環境紅不再使 focused 寫入卡
+  確定性自報 failed。** #738 之後 subagent-build 連兩個 job 交付合格 candidate
+  （focused 綠、含 changelog）卻誠實自報 `status=failed`：builder unit 的圍堵
+  （`IPAddressDeny=any`＋加固剖面）讓 network guard／egress proxy／stage9
+  snapshot 六族測試**只在 builder sandbox 紅**（gate 環境全綠），而
+  `status_policy` 逐字要求「If any gate failed, report failed」、#606 又禁止以
+  focused 綠推定全套綠——誠實的模型別無出路，run 落 `card-terminal-explicit-stop`
+  迴圈。修法：prompt 契約補 environment honesty——判準來自 Manager 在**它自己的
+  gate 環境**的重跑；sandbox-only、與變更無關的失敗不構成本卡 failed，**省略**該
+  gate（`authorize_terminal` 本就允許的形狀：ledger 綠即授權）、觀察寫進
+  diagnostics、照常交付 candidate；宣稱該 gate 綠仍然禁止（#606 不變）、ledger
+  紅照樣 fail-closed（採信端零改動、#586-B 不採）。`status_policy` 的失敗條款
+  改為「because of your change」。六族 sandbox-紅測試的可攜性（受限環境具名
+  skip）是 #723 一族第四例，另行處理。

--- a/paulsha_cortex/coordinator/gate_ledger.py
+++ b/paulsha_cortex/coordinator/gate_ledger.py
@@ -307,12 +307,24 @@ def gate_scope_honesty_hint(
             "own choosing never authorizes claiming the declared gate is green."
         )
     rendered = "; ".join(f'"{spec.name}" = `{spec.command}`' for spec in specs)
+    # #740：environment honesty——判準來自 Manager 在**它自己的 gate 環境**的重跑，
+    # 不是模型 sandbox 裡的那一次。builder unit 刻意更嚴（IPAddressDeny、加固剖面），
+    # 與變更無關的測試可能只在 sandbox 紅；#606 的誠實紀律少了這一維，誠實的模型
+    # 跑全套→看到環境紅→依指示自報 failed，形成 explicit-stop 確定性迴圈（實機
+    # jobs -15／-16）。省略沒忠實跑的 gate 本就是 `authorize_terminal` 允許的形狀
+    # （ledger 綠即授權），這裡只是把它講出來；宣稱該 gate 綠仍然禁止。
     return (
         "Scope discipline: after your process exits the Manager re-runs exactly these commands "
         f"({rendered}), and a passed status is judged against those real results. Running a "
         "focused subset first is fine, but then report only the scope you actually ran: a green "
         "focused subset is NOT evidence that the declared gate is green, and inferring the full "
-        "gate from it fails the card closed."
+        "gate from it fails the card closed. Environment honesty: those judged results come "
+        "from the Manager's re-run in its own gate environment, not from your sandbox — your "
+        "sandbox is deliberately more restricted (no general network, hardened unit), so tests "
+        "untouched by your change can fail there and nowhere else. Such sandbox-only failures "
+        "do not make this card failed: leave that gate out of gate_evidence, record what you "
+        "observed in diagnostics, and still deliver the candidate; claiming the gate green "
+        "stays forbidden — the Manager's ledger supplies the judged result."
     )
 
 

--- a/paulsha_cortex/coordinator/manager.py
+++ b/paulsha_cortex/coordinator/manager.py
@@ -8664,9 +8664,10 @@ def _workflow_job_prompt(
             status_policy = (
                 "Report passed only when every deterministic gate you ran (OpenSpec / pytest / "
                 "policy) actually passed. Natural-language confidence, an exit code of 0, and "
-                "the absence of an explicit error do NOT authorize passed. If any gate failed, "
-                "report failed; the Manager re-reads the gate ledger and fails closed on any "
-                "contradiction, so a dishonest passed only costs you a retry. "
+                "the absence of an explicit error do NOT authorize passed. If a gate failed "
+                "because of your change, report failed; the Manager re-reads the gate ledger "
+                "and fails closed on any contradiction, so a dishonest passed only costs you "
+                "a retry. "
                 + gate_ledger.gate_scope_honesty_hint(env, test_policy=effective_test_policy)
             )
             gate_evidence_description = (

--- a/tests/test_environment_honesty_740.py
+++ b/tests/test_environment_honesty_740.py
@@ -1,0 +1,37 @@
+"""#740：誠實紀律的環境維度。
+
+builder sandbox 刻意比 gate 環境嚴（IPAddressDeny、加固剖面），與變更無關的測試
+可能只在 sandbox 紅；#606 的文字少了這一維，誠實的模型跑全套→看到環境紅→依指示
+自報 failed，形成 explicit-stop 確定性迴圈（實機 jobs subagent-build-15／-16）。
+本檔釘：有宣告 gate 的分支帶 environment-honesty 段（省略而非自貶、宣稱綠仍禁止），
+且 `test_policy=none` 的分支（#721 的隔離）一個位元組都不受影響。
+"""
+
+from __future__ import annotations
+
+from paulsha_cortex.coordinator import gate_ledger
+
+_ENV = {"PSC_GATE_CMD_PYTEST": "python3 -m pytest -q"}
+
+
+def test_declared_gate_hint_carries_environment_honesty() -> None:
+    hint = gate_ledger.gate_scope_honesty_hint(_ENV, test_policy="focused")
+    assert "Environment honesty" in hint
+    assert "in its own gate environment" in hint
+    assert "leave that gate out of gate_evidence" in hint
+    # #606 的紀律原樣保留：省略 ≠ 可以宣稱綠。
+    assert "claiming the gate green stays forbidden" in hint
+    assert "NOT evidence that the declared gate is green" in hint
+
+
+def test_no_gate_card_hint_is_untouched_by_740() -> None:
+    """#721 的隔離不變：不要求 gate 的卡拿到的文字不含任何 #740 新句。"""
+
+    hint = gate_ledger.gate_scope_honesty_hint(_ENV, test_policy="none")
+    assert "Environment honesty" not in hint
+    assert "leave that gate out of gate_evidence" not in hint
+
+
+def test_no_declared_specs_branch_is_untouched_by_740() -> None:
+    hint = gate_ledger.gate_scope_honesty_hint({}, test_policy="focused")
+    assert "Environment honesty" not in hint

--- a/tests/test_gate_scope_test_policy_721.py
+++ b/tests/test_gate_scope_test_policy_721.py
@@ -48,20 +48,29 @@ MULTI_GATE_ENV = {
 }
 
 # --------------------------------------------------------------------------
-# 修改前的原文複本（逐字釘住；本票**不得**動到這兩段）
+# 有宣告 gate 時的原文複本（逐字釘住；#740 補上 environment honesty 一維——
+# 判準來自 Manager 在 gate 環境的重跑，sandbox-only 失敗省略該 gate 而非自報 failed）
 # --------------------------------------------------------------------------
 
 _FOCUSED_STATUS_POLICY = (
     "Report passed only when every deterministic gate you ran (OpenSpec / pytest / "
     "policy) actually passed. Natural-language confidence, an exit code of 0, and "
-    "the absence of an explicit error do NOT authorize passed. If any gate failed, "
-    "report failed; the Manager re-reads the gate ledger and fails closed on any "
-    "contradiction, so a dishonest passed only costs you a retry. "
+    "the absence of an explicit error do NOT authorize passed. If a gate failed "
+    "because of your change, report failed; the Manager re-reads the gate ledger "
+    "and fails closed on any contradiction, so a dishonest passed only costs you "
+    "a retry. "
     "Scope discipline: after your process exits the Manager re-runs exactly these commands "
     '("pytest" = `python3 -m pytest -q`), and a passed status is judged against those real '
     "results. Running a focused subset first is fine, but then report only the scope you "
     "actually ran: a green focused subset is NOT evidence that the declared gate is green, "
-    "and inferring the full gate from it fails the card closed."
+    "and inferring the full gate from it fails the card closed. Environment honesty: those "
+    "judged results come from the Manager's re-run in its own gate environment, not from "
+    "your sandbox — your sandbox is deliberately more restricted (no general network, "
+    "hardened unit), so tests untouched by your change can fail there and nowhere else. "
+    "Such sandbox-only failures do not make this card failed: leave that gate out of "
+    "gate_evidence, record what you observed in diagnostics, and still deliver the "
+    "candidate; claiming the gate green stays forbidden — the Manager's ledger supplies "
+    "the judged result."
 )
 
 _FOCUSED_GATE_EVIDENCE_DESCRIPTION = (


### PR DESCRIPTION
Fixes #740

## 病因（實機第十一環）

#738 之後 subagent-build 連兩個 job（-15／-16）交付合格 candidate（focused 綠、含 changelog fragment）卻**誠實自報 `status=failed`**，run 落 `card-terminal-explicit-stop`。builder sandbox 實跑全套 pytest 紅的六族（`test_network_guard_610` loopback、`test_trust_root_egress_716` ProxyServerDenyTests×4、`test_stage9_project_monitor` snapshot）全部是 builder unit 圍堵（`IPAddressDeny=any`＋專屬 loopback＋加固剖面）造成的**環境紅**——同一套件在 gate 環境全綠（tdd-red 的 gate 重跑實證）。

`status_policy` 逐字要求「If any gate failed, report failed」，#606 又禁止以 focused 綠推定全套綠——誠實的模型別無出路：跑全套 → sandbox 紅 → 自報 failed → 重派 → 同因 → explicit-stop。**任何 focused 寫入卡在三分部署下都會撞。**

## 修法（prompt 契約；採信端零改動）

判準本來就是 Manager 在**它自己的 gate 環境**的重跑（ledger），且 `authorize_terminal` 本就允許 envelope **省略**它沒（忠實）跑的 gate——ledger 綠即授權、envelope 只是不得與 ledger 矛盾。本 PR 把這件事寫進 prompt：

- `gate_scope_honesty_hint`（有宣告 gate 的分支）追加 **Environment honesty** 段：sandbox-only、與你的變更無關的失敗不構成本卡 failed——省略該 gate、觀察寫進 diagnostics、照常交付 candidate；**宣稱該 gate 綠仍然禁止**（#606 原句逐字保留）。
- `status_policy` 失敗條款改為「If a gate failed **because of your change**, report failed」。
- #721 測試逐字釘住的原文複本同步更新（該票的釘住範圍是「#721 不得動」；本票就是要動它的那張票）。

**不放寬任何採信**：ledger 紅照樣 fail-closed；模型把真失敗說成環境紅繞不過 ledger；#586-B（ledger 平反 envelope failed）維持不採、不在本 PR。

## 驗收

- [x] focused 卡 prompt 含 Environment honesty 段與「because of your change」；`test_policy=none` 卡與無宣告分支一個位元組不變（#721 隔離，新測試釘住）
- [x] 全套 `python3 -m pytest tests/ -q`：4892 passed, 36 skipped（零回歸）

實機驗收（merge＋部署後由 operator 執行、回報於 #740）：retry-card 後 subagent-build 新 job terminal passed、gate ledger 綠、卡片採信、run 進 verify。

六族 sandbox-紅測試的可攜性（受限環境具名 skip，#723 一族第四例）另行處理，不在本 PR。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XcQLDun91sLCJfJeKoVgjS
