### PR TITLE
fix(reviewer): review sandbox 交接給 reviewer 帳號，verify/review 卡在三分部署下派得出去（#742）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 本專案遵循 hamanpaul project policy v1.0.17。
 
 ## [Unreleased]
+- **#742：reviewer sandbox 交接（#710 的 reviewer lane 版），三分部署下 verify／
+  review 卡派得出去。** 容器收斂 0701；per-job sandbox 由 owner 顯式
+  `setfacl -R u:<reviewer>:rwX`（default ACL 繼承在 `UMask=0077` 下會被 mask
+  歸零，#736 同族）。帳號單一導出、direct 模式零回歸、回收不受影響。
 - **#740：誠實紀律補環境維度，builder sandbox 的環境紅不再使 focused 寫入卡確定性
   自報 failed。** 判準來自 Manager 在 gate 環境的重跑；sandbox-only、與變更無關的
   失敗改為「省略該 gate＋diagnostics 記錄＋照常交付 candidate」，宣稱綠仍禁止、

--- a/changelog.d/742-reviewer-sandbox-handover.md
+++ b/changelog.d/742-reviewer-sandbox-handover.md
@@ -1,0 +1,15 @@
+# 742-reviewer-sandbox-handover
+
+- **`#742` reviewer sandbox 交接——三分部署下 verify／review 卡終於派得出去**
+  （#710 的 reviewer lane 版）。`review-sandboxes` 是 verify 首走才被 mkdir 出來的
+  pool（`0700 cortex-manager`、零 ACL、不在部署清單），reviewer principal 一個
+  inode 都讀不到，`cortex-reviewer-job@` unit 秒死於 shim 的 Permission denied
+  （exit 78）。宣告的 `inherited-default-acl` reach 模型對它不成立：Manager unit
+  掛 `UMask=0077`，default ACL 的繼承會被 create mode 的 group bits 把 mask 歸零
+  （#736 在 gate 快照上的同一個交互）。修法：容器收斂 `0701`（traverse 不可列，
+  `dispatch-worktree-pool` 先例）；per-job sandbox 建好之後由 owner（Manager）
+  顯式 `setfacl -R u:<reviewer>:rwX`＋default 同值——走 #710 的同一支
+  `grant_workspace_acl`（mask 由 setfacl 重算），帳號由
+  `resolve_job_account(role=review)` 單一導出（#657）。帳號不在 passwd 時整支
+  略過（direct 模式零回歸）。pool 根授權範圍不變、Manager 保留 owner ⇒ 回收
+  （`_discard_reviewer_sandbox`）不受影響。

--- a/paulsha_cortex/coordinator/manager.py
+++ b/paulsha_cortex/coordinator/manager.py
@@ -6,6 +6,7 @@ import hashlib
 import json
 import logging
 import os
+import pwd
 import re
 import shutil
 import stat
@@ -5871,6 +5872,47 @@ def _prepare_claude_review_sandbox(sandbox: Path) -> None:
                 os.fsync(handle.fileno())
 
 
+def _prepare_reviewer_sandbox_container(parent: Path) -> None:
+    """建（並收斂）reviewer sandbox 的容器目錄（#742）。
+
+    `0701`＝job 帳號可 traverse、不可列目錄——`dispatch-worktree-pool` 的既有先例
+    （#641 記載）。容器上**只有** traverse：具名 rwX 一律落在 per-job 那一格
+    （:func:`_grant_reviewer_sandbox_access`），#710 的 per-job 隔離裁決不變。
+    """
+
+    parent.mkdir(parents=True, exist_ok=True)
+    os.chmod(parent, 0o701)
+
+
+def _grant_reviewer_sandbox_access(sandbox: Path) -> str | None:
+    """把建好的 per-job sandbox 交給 reviewer 執行帳號（#742；#710 的 reviewer 版）。
+
+    sandbox 整棵由 Manager 以 `UMask=0077` 建立（clone、bind 目標、input seed），
+    reviewer principal 一個 inode 都讀不到——`inherited-default-acl` 的 reach 模型
+    對這個 pool 不成立：它不在部署清單上（verify 首走才被 mkdir 出來），且 default
+    ACL 的繼承會被 Manager 的 umask 把 mask 歸零（#736 在 gate 快照上的同一個交互）。
+    修法比照 #710：owner（Manager）以 `setfacl -R` 顯式授 per-job 那一格，mask 由
+    setfacl 重算。帳號由 `resolve_job_account(role=review)` 解（#657 的單一導出）；
+    **不在 passwd 時整支略過**——direct／單 UID 模式同 UID 本就可達，且與
+    `ensure_workspace_reachable` 的既有處置一致，不是 fail-open（降權派工路徑在
+    `prepare_systemd_template()` 對帳號存在性 fail-closed）。
+    """
+
+    account = job_runner.resolve_job_account(os.environ, role=job_runner.JOB_ROLE_REVIEW)
+    try:
+        pwd.getpwnam(account)
+    except KeyError:
+        return None
+    return job_workspace.grant_workspace_acl(
+        sandbox,
+        (
+            job_workspace.WorkspaceAclGrant(
+                account=account, access_perms="rwX", default_perms="rwX"
+            ),
+        ),
+    )
+
+
 def _create_reviewer_sandbox(
     *,
     run,
@@ -5887,7 +5929,7 @@ def _create_reviewer_sandbox(
         coordinator_root=coordinator_root,
         candidate_root=candidate_root,
     )
-    parent.mkdir(parents=True, exist_ok=True)
+    _prepare_reviewer_sandbox_container(parent)
     name = hashlib.sha256(f"{run.run_id}:{step.card}:{candidate}".encode()).hexdigest()[:32]
     sandbox = parent / name
     if sandbox.exists() or sandbox.is_symlink():
@@ -5971,6 +6013,11 @@ def _create_reviewer_sandbox(
                     0o600,
                     expect_absent=True,
                 )
+    except BaseException:
+        shutil.rmtree(sandbox, ignore_errors=True)
+        raise
+    try:
+        _grant_reviewer_sandbox_access(sandbox)
     except BaseException:
         shutil.rmtree(sandbox, ignore_errors=True)
         raise

--- a/tests/test_reviewer_sandbox_handover_742.py
+++ b/tests/test_reviewer_sandbox_handover_742.py
@@ -1,0 +1,98 @@
+"""#742：reviewer sandbox 的交接（#710 的 reviewer lane 版）。
+
+`review-sandboxes` 是 verify 首走才被 mkdir 出來的 pool（不在部署清單），且
+Manager unit 掛 `UMask=0077`，default ACL 的繼承會被 mask 歸零（#736 同族交互）
+——`inherited-default-acl` 的 reach 模型對它不成立。修法：容器 `0701`（traverse
+不可列，`dispatch-worktree-pool` 先例）＋ per-job 那一格由 owner 顯式
+`setfacl -R`（走 #710 的 `grant_workspace_acl`）。本檔釘：帳號存在才授、不存在
+零動作（direct 模式零回歸）、grants 形狀、容器 mode。
+"""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from paulsha_cortex.coordinator import job_workspace, manager
+
+
+class ContainerTests(unittest.TestCase):
+    def test_container_is_created_with_traverse_only_mode(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            parent = Path(tmp) / "review-sandboxes"
+            manager._prepare_reviewer_sandbox_container(parent)
+            self.assertTrue(parent.is_dir())
+            self.assertEqual(parent.stat().st_mode & 0o777, 0o701)
+
+    def test_container_mode_is_converged_on_existing_dirs(self) -> None:
+        """已存在的 0700 容器（實機現況）也要收斂到 0701，不只新建的。"""
+
+        with tempfile.TemporaryDirectory() as tmp:
+            parent = Path(tmp) / "review-sandboxes"
+            parent.mkdir(mode=0o700)
+            manager._prepare_reviewer_sandbox_container(parent)
+            self.assertEqual(parent.stat().st_mode & 0o777, 0o701)
+
+
+class GrantTests(unittest.TestCase):
+    def test_grant_targets_the_sandbox_with_rwx_named_acl(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            sandbox = Path(tmp) / "s"
+            sandbox.mkdir()
+            captured: dict[str, object] = {}
+
+            def fake_grant(workspace, grants):
+                captured["workspace"] = Path(workspace)
+                captured["grants"] = grants
+                return "setfacl (captured)"
+
+            with mock.patch.object(
+                manager.job_runner, "resolve_job_account", return_value="cortex-reviewer-planner"
+            ), mock.patch.object(
+                manager.pwd, "getpwnam", return_value=object()
+            ), mock.patch.object(
+                manager.job_workspace, "grant_workspace_acl", side_effect=fake_grant
+            ):
+                result = manager._grant_reviewer_sandbox_access(sandbox)
+            self.assertEqual(result, "setfacl (captured)")
+            self.assertEqual(captured["workspace"], sandbox)
+            (grant,) = captured["grants"]
+            self.assertEqual(grant.account, "cortex-reviewer-planner")
+            self.assertEqual(grant.access_perms, "rwX")
+            self.assertEqual(grant.default_perms, "rwX")
+
+    def test_missing_account_is_a_named_no_op(self) -> None:
+        """direct／單 UID 模式：帳號不在 passwd ⇒ 零動作（同 UID 本就可達）。"""
+
+        with tempfile.TemporaryDirectory() as tmp:
+            sandbox = Path(tmp) / "s"
+            sandbox.mkdir()
+            with mock.patch.object(
+                manager.job_runner, "resolve_job_account", return_value="cortex-reviewer-planner"
+            ), mock.patch.object(
+                manager.pwd, "getpwnam", side_effect=KeyError("absent")
+            ), mock.patch.object(
+                manager.job_workspace, "grant_workspace_acl"
+            ) as grant:
+                result = manager._grant_reviewer_sandbox_access(sandbox)
+            self.assertIsNone(result)
+            grant.assert_not_called()
+
+    def test_grant_uses_the_710_validated_shape(self) -> None:
+        """grants 必須過 #710 的驗證（帳號名／perms 白名單）——形狀走同一支。"""
+
+        job_workspace._validate_grants(
+            (
+                job_workspace.WorkspaceAclGrant(
+                    account="cortex-reviewer-planner",
+                    access_perms="rwX",
+                    default_perms="rwX",
+                ),
+            )
+        )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
Fixes #742

## 病因（實機第十二環——canonical lane 的 verify phase 首次派工）

subagent-build 採信通過後 Manager 派 `verification` 卡，`cortex-reviewer-job@` unit 秒死（status=78）：shim `[Errno 13] Permission denied: /var/lib/cortex/coordinator/review-sandboxes/…`。

`review-sandboxes` 是 verify 首走才被 `_create_reviewer_sandbox()` 裸 mkdir 出來的 pool（`0700 cortex-manager`、零 ACL、**不在部署清單**），sandbox 內容全由 Manager 以 `UMask=0077` 建立——reviewer principal 一個 inode 都讀不到。宣告的 `inherited-default-acl` reach 模型對它不成立：即使補 default ACL，Manager 的 umask 會讓子目錄（mkdir 0700 ⇒ group bits 0）把 mask 歸零（#736 在 gate 快照上的同一個交互）。⇒ **三分部署下 verify／review 卡結構上派不出去**（builder lane 的同型是 #710）。

## 修法（比照 #710 的 per-job named ACL）

- 容器收斂 `0701`（job 帳號 traverse、不可列目錄——`dispatch-worktree-pool` 既有先例，#641 記載），已存在的 0700 容器也收斂。
- per-job sandbox 完整建好之後、回傳之前，由 owner（Manager，`setfacl` 不需 capability）走 #710 的同一支 `job_workspace.grant_workspace_acl()` 遞迴套 `u:<reviewer>:rwX`＋default 同值（mask 由 setfacl 重算）；失敗即 rmtree fail-closed。
- 帳號由 `resolve_job_account(role=review)` 單一導出（#657）；**不在 passwd 時整支略過**（direct／單 UID 零回歸，與 `ensure_workspace_reachable` 既有處置一致）。
- pool 根授權範圍不變（具名 rwX 只落 per-job 那一格，#710 隔離裁決不變）；Manager 保留 owner ⇒ `_discard_reviewer_sandbox` 回收不受影響。

## 驗收

- [x] helper 單元測試：帳號存在 ⇒ rwX/rwX named ACL 落在 sandbox；不存在 ⇒ 零動作；容器 0701（含既存 0700 收斂）；grants 過 #710 驗證
- [x] 全套 `python3 -m pytest tests/ -q`：4897 passed（零回歸）

實機驗收（merge＋部署後由 operator 執行、回報於 #742）：retry-card 後 `verification` reviewer job 起得來、進入執行。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XcQLDun91sLCJfJeKoVgjS
