### PR TITLE
fix(gate): auto 路徑 ancestry baseline 與採信端同一條導出（#743）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 本專案遵循 hamanpaul project policy v1.0.17。
 
 ## [Unreleased]
+- **#743：auto 路徑的 ancestry baseline 與採信端同一條導出（`run.candidate_head or
+  dispatch_head`），中段 build 卡不再每張都要人工 `regenerate-gates`。**
+  `dispatch_head` 是 run 層級凍結值、後續卡逐字繼承首張卡的，#738 首版拿它當
+  基線使中段卡的 ledger 被「baseline 不符視同缺席」守衛正確拒絕。
 - **#742：reviewer sandbox 交接（#710 的 reviewer lane 版），三分部署下 verify／
   review 卡派得出去。** 容器收斂 0701；per-job sandbox 由 owner 顯式
   `setfacl -R u:<reviewer>:rwX`（default ACL 繼承在 `UMask=0077` 下會被 mask

--- a/changelog.d/743-auto-ancestry-baseline.md
+++ b/changelog.d/743-auto-ancestry-baseline.md
@@ -1,0 +1,12 @@
+# 743-auto-ancestry-baseline
+
+- **`#743` auto 路徑的 ancestry baseline 改由採信端同一條導出供給——中段 build 卡
+  不再每張都要人工 `regenerate-gates`。** #738 首版讓 `ensure_gate_ledger` 自行從
+  `job["dispatch_head"]` 導 baseline，但那是 run 層級、claim 時凍結、後續 build 卡
+  逐字繼承首張卡的值，不是這張卡 clone 的 handoff base；採信端的真導出是
+  `run.candidate_head or dispatch_head`。兩端各算一份（#521／#722 修過的同型），
+  中段卡的 ledger 量在錯的基線上、被「baseline 不符視同缺席」守衛正確拒絕。修法：
+  `_run_gate_execution_identity` 經 registry 取 `run.candidate_head`（合法 sha 時）
+  傳給 `ensure_gate_ledger` 新增的 `ancestry_baseline` 參數；未給時維持 job 導出
+  （首張卡兩者同值）。實機（run `workflow-85114100` subagent-build-17）逐字命中：
+  ledger 記 `59a7a9b`（stale dispatch_head）、採信端要 `b3b9aedc`（candidate_head）。

--- a/paulsha_cortex/coordinator/gate_runner.py
+++ b/paulsha_cortex/coordinator/gate_runner.py
@@ -708,6 +708,7 @@ def ensure_gate_ledger(
     env: Mapping[str, str] | None = None,
     coordinator_root: str | Path | None = None,
     runner: Any | None = None,
+    ancestry_baseline: str | None = None,
 ) -> dict[str, Any] | None:
     """降權模式下，在採信之前把缺席的 gate ledger 補上；回傳 payload 或 `None`。
 
@@ -745,16 +746,24 @@ def ensure_gate_ledger(
     if not isinstance(worktree, str) or not Path(worktree).is_dir():
         return None
     job_id = str(job.get("job_id") or spool_key)
-    # #738：ancestry baseline ＝ 這張卡 provision 時的 dispatch_head（Manager 寫進
-    # job 記錄的值，不是 job 的可變輸入）。缺席／非 sha 時不傳——ledger 的
-    # ancestry_ok 維持 None，採信端自然退回既有路徑。
-    dispatch_head = job.get("dispatch_head")
-    baseline = (
-        dispatch_head.lower()
-        if isinstance(dispatch_head, str)
-        and gate_ledger._SHA_RE.fullmatch(dispatch_head.lower()) is not None
-        else None
-    )
+    # #743：baseline 以**呼叫端（採信端同一條導出）**為準——`dispatch_head` 是 run
+    # 層級、claim 時凍結的值（後續 build 卡逐字繼承第一張卡的），不是這張卡 clone
+    # 的 handoff base；只有首張卡兩者碰巧同值。呼叫端未給時退回 job 導出（#738 的
+    # 既有行為），缺席／非 sha 一律不傳——ledger 的 ancestry_ok 維持 None，採信端
+    # 自然退回既有路徑。
+    baseline = ancestry_baseline
+    if baseline is None:
+        dispatch_head = job.get("dispatch_head")
+        baseline = (
+            dispatch_head.lower()
+            if isinstance(dispatch_head, str)
+            and gate_ledger._SHA_RE.fullmatch(dispatch_head.lower()) is not None
+            else None
+        )
+    elif gate_ledger._SHA_RE.fullmatch(baseline.lower()) is None:
+        baseline = None
+    else:
+        baseline = baseline.lower()
     return run_declared_gates(
         job_id=job_id,
         spool_key=spool_key,

--- a/paulsha_cortex/coordinator/manager.py
+++ b/paulsha_cortex/coordinator/manager.py
@@ -4110,7 +4110,33 @@ def _workflow_acceptance_definition_drifted(
     return pinned != fresh_test_policy
 
 
-def _run_gate_execution_identity(job: Mapping[str, object]) -> None:
+def _gate_ancestry_baseline(registry, job: Mapping[str, object]) -> str | None:
+    """auto 路徑 gate 量測 ancestry 的 baseline——**與採信端同一條導出**（#743）。
+
+    採信端（`_verify_build_candidate_transition`）的 baseline 是
+    `previous_candidate（run.candidate_head） or job["dispatch_head"]`；auto 路徑的
+    gate 若各算一份（#738 首版直接拿 `dispatch_head`），中段 build 卡的 ledger 就會
+    量在錯的基線上、被「baseline 不符視同缺席」的守衛正確拒絕，每張卡都得人工
+    `regenerate-gates`。這裡回 run 的 `candidate_head`（合法 sha 時），否則 None
+    ——`ensure_gate_ledger` 會退回 `dispatch_head`，首張卡兩者本就同值。
+    """
+
+    if registry is None:
+        return None
+    run_id = job.get("workflow_run_id")
+    if not isinstance(run_id, str):
+        return None
+    try:
+        run = registry.get_workflow_run(run_id)
+    except Exception:
+        return None
+    candidate = getattr(run, "candidate_head", None)
+    if isinstance(candidate, str) and verification.SAFE_SHA_RE.fullmatch(candidate):
+        return candidate.lower()
+    return None
+
+
+def _run_gate_execution_identity(job: Mapping[str, object], *, registry=None) -> None:
     """#629：降權模式下補上缺席的 gate ledger（`direct` 模式為 no-op）。
 
     **失敗一律翻成 `TerminalContractError` 並 fail closed**，不吞、不降級。gate 跑
@@ -4124,7 +4150,11 @@ def _run_gate_execution_identity(job: Mapping[str, object]) -> None:
     from . import gate_runner
 
     try:
-        gate_runner.ensure_gate_ledger(job, phases=GATE_EXECUTION_PHASES)
+        gate_runner.ensure_gate_ledger(
+            job,
+            phases=GATE_EXECUTION_PHASES,
+            ancestry_baseline=_gate_ancestry_baseline(registry, job),
+        )
     except (gate_runner.GateRunnerError, job_runner.JobRunnerError) as exc:
         reason = getattr(exc, "reason", None) or "gate-execution-failed"
         raise terminal_contract.TerminalContractError(
@@ -6153,7 +6183,7 @@ def terminalize_workflow_job(
     #
     # 位置在 `_assert_terminal_gate_consistency` **正前方**：那裡是唯一會讀 ledger
     # 的採信點，證據必須在被讀之前就已經落地，且**不得**在採信開始之後才產生。
-    _run_gate_execution_identity(job)
+    _run_gate_execution_identity(job, registry=registry)
     # #261 R2／D3：矛盾偵測排在任何狀態採信之前。放在 per-phase schema 驗證之前，
     # 是為了避免「先按 passed 走一段流程、後面才發現不對」造成的部分副作用。
     # #307：帶入 registry 讓 red-required 卡的測試 gate 語意反轉生效。

--- a/tests/test_auto_ancestry_baseline_743.py
+++ b/tests/test_auto_ancestry_baseline_743.py
@@ -1,0 +1,102 @@
+"""#743：auto 路徑的 ancestry baseline 與採信端同一條導出。
+
+採信端的 baseline 是 `run.candidate_head or job["dispatch_head"]`；#738 首版的
+auto 路徑各算一份（直接拿 `dispatch_head`——run 層級、claim 時凍結、後續卡逐字
+繼承首張卡的值），中段 build 卡的 ledger 於是量在錯的基線上、被「baseline 不符
+視同缺席」守衛正確拒絕，每張卡都得人工 `regenerate-gates`。
+"""
+
+from __future__ import annotations
+
+import unittest
+from unittest import mock
+
+from paulsha_cortex.coordinator import gate_runner, manager
+
+
+class _Run:
+    def __init__(self, candidate_head):
+        self.candidate_head = candidate_head
+
+
+class _Registry:
+    def __init__(self, run):
+        self._run = run
+
+    def get_workflow_run(self, run_id):
+        if self._run is None:
+            raise KeyError(run_id)
+        return self._run
+
+
+class GateAncestryBaselineTests(unittest.TestCase):
+    def test_candidate_head_wins_when_present(self) -> None:
+        head = "B" * 40
+        baseline = manager._gate_ancestry_baseline(
+            _Registry(_Run(head)), {"workflow_run_id": "workflow-x"}
+        )
+        self.assertEqual(baseline, "b" * 40)
+
+    def test_absent_candidate_falls_back_to_job_derivation(self) -> None:
+        for run in (_Run(None), None):
+            baseline = manager._gate_ancestry_baseline(
+                _Registry(run), {"workflow_run_id": "workflow-x"}
+            )
+            self.assertIsNone(baseline)
+        self.assertIsNone(manager._gate_ancestry_baseline(None, {}))
+
+
+class EnsureGateLedgerBaselineTests(unittest.TestCase):
+    def _capture_baseline(self, *, job, explicit):
+        captured = {}
+
+        def fake_run_declared_gates(**kwargs):
+            captured.update(kwargs)
+            return {"gates": []}
+
+        env = {"PSC_JOB_RUNNER": "systemd-template"}
+        with mock.patch.object(
+            gate_runner, "run_declared_gates", side_effect=fake_run_declared_gates
+        ), mock.patch.object(
+            gate_runner, "spool_key_for_job", return_value="wf-x-card-1"
+        ), mock.patch.object(
+            gate_runner.Path, "exists", return_value=False
+        ), mock.patch.object(
+            gate_runner.Path, "is_dir", return_value=True
+        ):
+            gate_runner.ensure_gate_ledger(
+                job,
+                phases=frozenset({"build"}),
+                env=env,
+                ancestry_baseline=explicit,
+            )
+        return captured.get("ancestry_baseline")
+
+    def _job(self, dispatch_head):
+        return {
+            "workflow_phase": "build",
+            "log_path": "/tmp/x/wf-x-card-1.jsonl",
+            "worktree": "/tmp/x/worktree",
+            "job_id": "wf-x-card-1",
+            "dispatch_head": dispatch_head,
+        }
+
+    def test_explicit_baseline_overrides_job_derivation(self) -> None:
+        baseline = self._capture_baseline(
+            job=self._job("a" * 40), explicit="B" * 40
+        )
+        self.assertEqual(baseline, "b" * 40)
+
+    def test_without_explicit_baseline_dispatch_head_is_used(self) -> None:
+        baseline = self._capture_baseline(job=self._job("a" * 40), explicit=None)
+        self.assertEqual(baseline, "a" * 40)
+
+    def test_malformed_explicit_baseline_becomes_none(self) -> None:
+        baseline = self._capture_baseline(
+            job=self._job(None), explicit="not-a-sha"
+        )
+        self.assertIsNone(baseline)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/tests/test_gate_execution_identity_629.py
+++ b/tests/test_gate_execution_identity_629.py
@@ -1078,7 +1078,7 @@ class RegenerateGatesConvergenceTests(unittest.TestCase):
         from paulsha_cortex.coordinator import manager
 
         source = inspect.getsource(manager.terminalize_workflow_job)
-        run_at = source.index("_run_gate_execution_identity(job)")
+        run_at = source.index("_run_gate_execution_identity(job, registry=registry)")
         read_at = source.index("_assert_terminal_gate_consistency(raw")
         self.assertLess(run_at, read_at)
 


### PR DESCRIPTION
Fixes #743

## 病因（#738 的實機首驗）

subagent-build-17 terminal passed、gate ledger 綠、`worktree_state.head == candidate`——但採信掉回 git fallback 撞 `#629` blocked。ledger 記 `ancestry_baseline: 59a7a9b`（job 的 `dispatch_head`，run 層級、claim 時凍結、後續 build 卡逐字繼承首張卡的值），而採信端當下算的 baseline 是 `run.candidate_head`（`b3b9aedc`）。#738 的「baseline 不符視同缺席」守衛**正確地**拒絕了陳舊量測——但 auto 路徑每張中段 build 卡都得人工 `regenerate-gates`（那條路的導出是對的），Phase 2 的無人值守不成立。兩端各算一份導出，#521／#722 修過的同型。

## 修法

- `manager._gate_ancestry_baseline(registry, job)`：經 `registry.get_workflow_run()` 取 `run.candidate_head`（合法 40-hex 時），與採信端同一條導出。
- `gate_runner.ensure_gate_ledger` 增 `ancestry_baseline` 參數：呼叫端給值即用（含非法值收斂 None）；未給維持既有 `dispatch_head` 導出——首張卡兩者本就同值，行為不變。
- `_run_gate_execution_identity` 帶 `registry` 傳遞。

## 驗收

- [x] 單元：`candidate_head` 存在 ⇒ baseline 用它；缺席／registry 缺席 ⇒ 退回 job 導出；非法顯式值 ⇒ None
- [x] 全套 `python3 -m pytest tests/ -q`：4897 passed（零回歸；629 的 source-pin 測試隨簽名更新）

實機驗收（merge＋部署後由 operator 執行、回報於 #743）：中段 build 卡 terminal passed 後免 regenerate 一路採信。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XcQLDun91sLCJfJeKoVgjS
