### PR TITLE
fix(reviewer): claude 內層 bwrap sandbox 依 runner mode 分岔，三分模式關內層（#746）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 本專案遵循 hamanpaul project policy v1.0.17。
 
 ## [Unreleased]
+- **#746：claude reviewer 內層 sandbox 依 runner mode 分岔（#714 的 reviewer lane
+  版）。** bubblewrap 與加固剖面硬性互斥；三分模式關內層、外層＋採信端完整性
+  檢查為邊界，direct 模式逐字不變；`permissions.deny` 兩模式相同。
 - **#743：auto 路徑的 ancestry baseline 與採信端同一條導出（`run.candidate_head or
   dispatch_head`），中段 build 卡不再每張都要人工 `regenerate-gates`。**
   `dispatch_head` 是 run 層級凍結值、後續卡逐字繼承首張卡的，#738 首版拿它當

--- a/changelog.d/746-reviewer-inner-sandbox.md
+++ b/changelog.d/746-reviewer-inner-sandbox.md
@@ -1,0 +1,14 @@
+# 746-reviewer-inner-sandbox
+
+- **`#746` claude reviewer 的內層 sandbox 依 runner mode 分岔——verification 卡在
+  三分部署下終於能實跑命令**（#714 的 reviewer lane 版）。claude Bash 工具的內層
+  sandbox 是 bubblewrap，與模板 unit 加固剖面硬性互斥（`bwrap: Can't read
+  /proc/sys/kernel/overflowuid`；`failIfUnavailable: true` 使 8/8 命令全滅，模型
+  誠實 needs_human）。permgen 已量過保留 bwrap 要付四條放寬、其中兩條（user
+  namespace／mount）是外層加固面存在的理由——0819 對 codex 的裁決因此是「換掉
+  內層形態」（#716 B）。本票同型：direct（單 UID）逐字維持內層 sandbox（唯一
+  邊界、零回歸）；systemd 模板（三分）`sandbox: {enabled: false}`，邊界由既有
+  機制承擔——外層 26 項加固＋egress 白名單（#725）、candidate 竄改於採信端
+  fail-closed（#650 `require_candidate_unchanged`）、reviewer 對來源樹零可達
+  （#641）。`permissions.deny` 的憑證／HOME 讀取拒絕兩模式逐字相同。planner 的
+  claude job 走 `--tools ""` 從未啟動 bwrap，故此牆藏到 reviewer lane 首跑才露出。

--- a/paulsha_cortex/coordinator/launcher.py
+++ b/paulsha_cortex/coordinator/launcher.py
@@ -345,7 +345,18 @@ def _srt_runtime_root() -> Path | None:
 
 
 def _claude_review_settings(worktree: str) -> str:
-    """Build a CLI-only sandbox policy for a headless Claude reviewer."""
+    """Build a CLI-only sandbox policy for a headless Claude reviewer.
+
+    #746（#714 的 reviewer lane 版）：claude 的 Bash 工具內層 sandbox 是
+    **bubblewrap**，與模板 unit 的加固剖面（`ProcSubset=pid` 等）硬性互斥——
+    permgen 已量過保留 bwrap 要付四條放寬，其中兩條正是外層加固面存在的理由，
+    0819 對 codex 的裁決因此是「換一個不需要 bwrap 的執行形態」（#716 B）。這裡
+    依 runner mode 分岔：**direct（單 UID）逐字維持現行內層 sandbox**（它是唯一
+    邊界）；**systemd 模板（三分）關內層**，邊界由既有機制承擔——外層 unit 剖面
+    ＋ egress 白名單（#725）、candidate 竄改於採信端 fail-closed（#650 的
+    `require_candidate_unchanged`）、reviewer 對來源樹零可達（#641）。
+    `permissions.deny` 的憑證／HOME 讀取拒絕兩個模式**逐字相同**。
+    """
 
     candidate = (Path(worktree).resolve() / "candidate").resolve()
     home = Path.home().resolve()
@@ -385,6 +396,19 @@ def _claude_review_settings(worktree: str) -> str:
         f"Read(/{path.as_posix()}{'/**' if path.suffix == '' else ''})"
         for path in credential_paths
     ]
+    if job_runner.resolve_runner_mode(os.environ) != job_runner.RUNNER_DIRECT:
+        return json.dumps(
+            {
+                "permissions": {"deny": read_denials},
+                # 內層 bwrap 在加固 unit 下起不來（bwrap: Can't read
+                # /proc/sys/kernel/overflowuid），且 `failIfUnavailable` 讓 8/8 命令
+                # 全滅——刻意關閉，不是放寬外層（#746）。
+                "sandbox": {"enabled": False},
+            },
+            ensure_ascii=True,
+            sort_keys=True,
+            separators=(",", ":"),
+        )
     settings = {
         "permissions": {"deny": read_denials},
         "sandbox": {

--- a/tests/test_reviewer_inner_sandbox_746.py
+++ b/tests/test_reviewer_inner_sandbox_746.py
@@ -1,0 +1,45 @@
+"""#746：claude reviewer 的內層 sandbox 依 runner mode 分岔（#714 的 reviewer lane 版）。
+
+claude Bash 工具的內層 sandbox 是 bubblewrap，與模板 unit 的加固剖面硬性互斥
+（`bwrap: Can't read /proc/sys/kernel/overflowuid`、8/8 命令全滅）。#716 B 的同型
+處置：direct（單 UID）逐字維持內層 sandbox；systemd 模板（三分）關內層、外層為
+唯一邊界。兩個模式的 `permissions.deny`（憑證／HOME 讀取拒絕）逐字相同。
+"""
+
+from __future__ import annotations
+
+import json
+import unittest
+from unittest import mock
+
+from paulsha_cortex.coordinator import job_runner, launcher
+
+
+def _settings(mode: str) -> dict:
+    env = {"PSC_JOB_RUNNER": mode}
+    with mock.patch.dict(launcher.os.environ, env, clear=False):
+        return json.loads(launcher._claude_review_settings("/tmp/wt"))
+
+
+class ReviewerInnerSandboxTests(unittest.TestCase):
+    def test_direct_mode_keeps_the_inner_sandbox_verbatim(self) -> None:
+        settings = _settings(job_runner.RUNNER_DIRECT)
+        self.assertIs(settings["sandbox"]["enabled"], True)
+        self.assertIs(settings["sandbox"]["failIfUnavailable"], True)
+
+    def test_systemd_mode_disables_the_inner_sandbox(self) -> None:
+        settings = _settings("systemd-template")
+        self.assertEqual(settings["sandbox"], {"enabled": False})
+
+    def test_permission_denials_are_identical_across_modes(self) -> None:
+        direct = _settings(job_runner.RUNNER_DIRECT)
+        hardened = _settings("systemd-template")
+        self.assertEqual(direct["permissions"], hardened["permissions"])
+        # 憑證讀取拒絕真的在裡面，不是空清單。
+        joined = json.dumps(hardened["permissions"])
+        self.assertIn(".claude", joined)
+        self.assertIn(".ssh", joined)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
Fixes #746

## 病因（實機第十三環——reviewer lane 首次真跑 Bash）

#742＋憑證重放後 claude reviewer 起得來，但 `launcher._claude_review_settings()` 硬性 `sandbox: {enabled: true, failIfUnavailable: true}`——claude Bash 工具的內層 sandbox 是 **bubblewrap**，與 reviewer 模板 unit 的加固剖面（`ProcSubset=pid`＋`ProtectProc=invisible`＋`RestrictNamespaces=yes`）硬性互斥：`bwrap: Can't read /proc/sys/kernel/overflowuid`，8 命令 0 成功，模型誠實 `needs_human`（blocker_class=environment）。permgen 的 #714 註解逐字記著：保留 bwrap 要付四條放寬，其中 user namespace 與 mount 兩條是外層加固面存在的理由本身。planner 的 claude job 走 `--tools ""` 從未啟動 bwrap，此牆因此藏到現在。

## 修法（#716 B 的 reviewer lane 版）

`_claude_review_settings()` 依 `job_runner.resolve_runner_mode()` 分岔：

- **direct（單 UID）**：現行 settings **逐字不變**（內層 sandbox 是唯一邊界，零回歸）。
- **systemd 模板（三分）**：`sandbox: {enabled: false}`——刻意關內層、不放寬外層。邊界由既有機制承擔：外層 26 項加固＋`IPAddressDeny`＋egress 白名單 proxy（#725）；candidate 竄改於採信端 fail-closed（#650 `_discard_reviewer_sandbox(require_candidate_unchanged=True)`＋tree snapshot）；reviewer 對來源樹零可達（#641）、能寫的只有自己的 per-job sandbox（#742 的授權範圍）。
- `permissions.deny`（憑證／HOME 讀取拒絕）**兩模式逐字相同**，CLI 層仍擋。

## 驗收

- [x] 單元：direct 模式輸出逐字維持（enabled/failIfUnavailable true）；systemd 模式 `sandbox={enabled:false}`；`permissions.deny` 跨模式相同且非空
- [x] 全套 `python3 -m pytest tests/ -q`：4905 passed（零回歸）

實機驗收（merge＋部署後由 operator 執行、回報於 #746）：retry-card 後 verification 的 claude reviewer 實跑命令、產出 verification evidence。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XcQLDun91sLCJfJeKoVgjS
