### PR TITLE
fix(reviewer): 三分模式補 Bash allow 規則，dontAsk 下 pytest 不再全拒（#748）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 本專案遵循 hamanpaul project policy v1.0.17。
 
 ## [Unreleased]
+- **#748：三分模式 reviewer settings 補 `allow: ["Bash"]`。** #746 關內層後
+  `autoAllowBashIfSandboxed` 的放行消失，`dontAsk` 下 pytest 全拒、零 gate 可跑；
+  deny 優先於 allow、憑證拒絕不變、direct 模式不變。
 - **#746：claude reviewer 內層 sandbox 依 runner mode 分岔（#714 的 reviewer lane
   版）。** bubblewrap 與加固剖面硬性互斥；三分模式關內層、外層＋採信端完整性
   檢查為邊界，direct 模式逐字不變；`permissions.deny` 兩模式相同。

--- a/changelog.d/748-reviewer-bash-allow.md
+++ b/changelog.d/748-reviewer-bash-allow.md
@@ -1,0 +1,8 @@
+# 748-reviewer-bash-allow
+
+- **`#748` 三分模式的 reviewer settings 補 `allow: ["Bash"]`——#746 關內層 sandbox
+  後 `autoAllowBashIfSandboxed` 的放行跟著消失，`dontAsk` 下 Bash 只剩內建安全命令
+  白名單（實機：`python3 --version` 過、`pytest` 不過，12 × permission_denied、
+  零 gate 可跑）。** deny 規則優先於 allow，憑證／HOME 讀取拒絕逐字不變；Bash 的
+  邊界照 #746 裁決由外層 unit＋egress 白名單＋採信端完整性檢查承擔。direct 模式
+  逐字不變。

--- a/paulsha_cortex/coordinator/launcher.py
+++ b/paulsha_cortex/coordinator/launcher.py
@@ -399,7 +399,11 @@ def _claude_review_settings(worktree: str) -> str:
     if job_runner.resolve_runner_mode(os.environ) != job_runner.RUNNER_DIRECT:
         return json.dumps(
             {
-                "permissions": {"deny": read_denials},
+                # #748：`dontAsk` 下 Bash 需要 allow 規則才會自動放行（僅內建安全
+                # 命令例外——實機：`python3 --version` 過、`pytest` 不過）。原本由
+                # `autoAllowBashIfSandboxed` 供給的放行隨 #746 關內層而消失，這裡
+                # 補等價 allow；deny 規則優先於 allow，憑證／HOME 讀取拒絕不受影響。
+                "permissions": {"allow": ["Bash"], "deny": read_denials},
                 # 內層 bwrap 在加固 unit 下起不來（bwrap: Can't read
                 # /proc/sys/kernel/overflowuid），且 `failIfUnavailable` 讓 8/8 命令
                 # 全滅——刻意關閉，不是放寬外層（#746）。

--- a/tests/test_reviewer_inner_sandbox_746.py
+++ b/tests/test_reviewer_inner_sandbox_746.py
@@ -31,10 +31,22 @@ class ReviewerInnerSandboxTests(unittest.TestCase):
         settings = _settings("systemd-template")
         self.assertEqual(settings["sandbox"], {"enabled": False})
 
+    def test_systemd_mode_allows_bash_explicitly(self) -> None:
+        """#748：關內層後 `autoAllowBashIfSandboxed` 消失，dontAsk 下 Bash 需要
+        顯式 allow；deny 優先於 allow，憑證拒絕不受影響。"""
+
+        settings = _settings("systemd-template")
+        self.assertEqual(settings["permissions"]["allow"], ["Bash"])
+        self.assertTrue(settings["permissions"]["deny"])
+
+    def test_direct_mode_has_no_allow_entry(self) -> None:
+        settings = _settings(job_runner.RUNNER_DIRECT)
+        self.assertNotIn("allow", settings["permissions"])
+
     def test_permission_denials_are_identical_across_modes(self) -> None:
         direct = _settings(job_runner.RUNNER_DIRECT)
         hardened = _settings("systemd-template")
-        self.assertEqual(direct["permissions"], hardened["permissions"])
+        self.assertEqual(direct["permissions"]["deny"], hardened["permissions"]["deny"])
         # 憑證讀取拒絕真的在裡面，不是空清單。
         joined = json.dumps(hardened["permissions"])
         self.assertIn(".claude", joined)


### PR DESCRIPTION
Fixes #748

## 病因（#746 部署後實機下一層，verification-21）

bwrap 互斥解除、命令跑得動，但 `dontAsk` 模式下 Bash 需要 allow 規則才自動放行（僅內建安全命令例外——實機逐字：`python3 --version is permitted, python3 -m pytest is not`，12 × permission_denied）。原本的放行由 `sandbox.autoAllowBashIfSandboxed: true` 供給（「已被 sandbox 的 Bash」全放行）；#746 在三分模式關內層 sandbox 後，這條放行跟著消失、沒有等價補償 ⇒ 零 gate 可跑 ⇒ reviewer 依 status policy 誠實 needs_human。

## 修法

#746 的 systemd 分岔 settings 補 `"permissions": {"allow": ["Bash"], "deny": [既有拒絕，逐字不變]}`。Claude Code 的 deny 規則優先於 allow ⇒ 憑證／HOME 讀取拒絕不受影響；Bash 的邊界照 #746 裁決由外層 unit（26 項加固＋IPAddressDeny＋egress 白名單 #725）＋採信端完整性檢查（#650）承擔。direct 模式逐字不變。

## 驗收

- [x] 單元：systemd 模式含 `allow: ["Bash"]` 且 deny 非空逐字保留；direct 模式無 allow 條目、settings 逐字不變；兩模式 deny 相同
- [x] 全套 `python3 -m pytest tests/ -q`：4907 passed（零回歸）

實機驗收（merge＋部署後由 operator 執行、回報於 #748）：retry-card 後 reviewer 實跑 pytest、產出 verification evidence。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XcQLDun91sLCJfJeKoVgjS
