### PR TITLE
fix(dispatch): repair 回合帶上打回它的 verification 判定（#750）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 本專案遵循 hamanpaul project policy v1.0.17。
 
 ## [Unreleased]
+- **#750：repair 回合帶上打回它的 verification 判定（`retry_context.review_rejection`），
+  盲修不收斂的迴圈關掉。** 跨卡回饋機械組裝、有界、標注 reviewer-terminal 來源；
+  首派 prompt 不變、採信端零改動。
 - **#748：三分模式 reviewer settings 補 `allow: ["Bash"]`。** #746 關內層後
   `autoAllowBashIfSandboxed` 的放行消失，`dontAsk` 下 pytest 全拒、零 gate 可跑；
   deny 優先於 allow、憑證拒絕不變、direct 模式不變。

--- a/changelog.d/750-repair-review-feedback.md
+++ b/changelog.d/750-repair-review-feedback.md
@@ -1,0 +1,15 @@
+# 750-repair-review-feedback
+
+- **`#750` repair 回合終於看得到打回它的 verification 判定——盲修不收斂的迴圈
+  關掉。** #606 的 retry_context 只看同一張卡的前次 job；verification 判定在另一
+  張卡上、且因 harvest fail-closed（verify terminal 只認 verified/passed）沒有
+  綁進 run，`retry-build` 的 repair 文案要求 builder 依「current verification/
+  review evidence」修 candidate、卻沒有任何通道把 evidence 交到它手上（實機：
+  verification-22 實質 failed → repair -23 只補了測試 → verification-24 同因再
+  failed）。修法：`_prior_review_rejection(run, registry)` 經 harvest 同一支
+  `_extract_terminal_json` 讀回本 run 最近一顆 verify／review 非通過 terminal 的
+  summary／findings／conformance（各自有界），**誠實標注
+  `source: "reviewer-terminal"`**（reviewer 產物、非 manager-independent），由
+  dispatch 端只在 builder build 卡上併進 retry_context 的 `review_rejection` 鍵。
+  首派 prompt 逐字不變（#606 要求 2 不動）、採信端零改動、判定只進 prompt 不進
+  evidence。

--- a/paulsha_cortex/coordinator/manager.py
+++ b/paulsha_cortex/coordinator/manager.py
@@ -8561,8 +8561,88 @@ def _prior_card_failed_gates(job: Mapping[str, object]) -> list[dict[str, object
     return rows
 
 
+def _prior_review_rejection(run, registry) -> dict[str, object] | None:
+    """#750：repair 回合的跨卡回饋——本 run 最近一顆 verify／review 非通過 terminal。
+
+    #606 的 retry_context 只看**同一張卡**的前次 job；把 candidate 打回來的那份
+    verification 判定在另一張卡上、且因 harvest fail-closed（verify terminal 只認
+    verified/passed）沒有綁進 run——`retry-build` 的 repair 文案要求 builder
+    「fix only real Candidate failures identified by the current verification/review
+    evidence」，卻沒有任何通道把那份 evidence 交到它手上，盲修不收斂是確定性的
+    （實機：verification-22 failed → repair -23 加了測試 → verification-24 同因再
+    failed）。這裡經 harvest 同一支 :func:`_extract_terminal_json` 讀回判定，
+    **誠實標注 `source: "reviewer-terminal"`**——它是 reviewer 產物，不是
+    manager-independent；它只進 prompt 供 repair 消費，不進任何採信路徑。
+    取不到一律回 ``None``（證據是加值，不得害死一次合法重派）。
+    """
+
+    if registry is None:
+        return None
+    try:
+        jobs = registry.list_jobs()
+    except Exception:
+        return None
+    rejected: tuple[Mapping[str, object], Mapping[str, object]] | None = None
+    for job in jobs:
+        if job.get("workflow_run_id") != getattr(run, "run_id", None):
+            continue
+        if job.get("workflow_phase") not in {"verify", "review"}:
+            continue
+        if job.get("status") != "exited":
+            continue
+        log_path = job.get("log_path")
+        if not isinstance(log_path, str) or not log_path:
+            continue
+        try:
+            raw = _extract_terminal_json(log_path)
+        except Exception:
+            continue
+        if raw.get("status") not in terminal_contract.NON_PASSING_STATUSES:
+            continue
+        rejected = (job, raw)
+    if rejected is None:
+        return None
+    job, raw = rejected
+    details = raw.get("details") if isinstance(raw.get("details"), Mapping) else {}
+    budget = RETRY_CONTEXT_EVIDENCE_LIMIT
+    context: dict[str, object] = {
+        "source": "reviewer-terminal",
+        "phase": str(job.get("workflow_phase")),
+        "job_id": str(job.get("job_id")),
+        "status": str(raw.get("status")),
+        "summary": str(raw.get("summary") or "")[:budget],
+    }
+    findings = details.get("findings")
+    if isinstance(findings, list) and findings:
+        rows: list[str] = []
+        remaining = budget
+        for item in findings[:8]:
+            text = (
+                json.dumps(item, ensure_ascii=False)
+                if isinstance(item, (dict, list))
+                else str(item)
+            )
+            kept = text[: max(0, remaining)]
+            if not kept:
+                break
+            remaining -= len(kept)
+            rows.append(kept)
+        if rows:
+            context["findings"] = rows
+    conformance = details.get("conformance")
+    if isinstance(conformance, Mapping) and conformance:
+        context["conformance"] = {
+            str(key): str(value)[:300]
+            for key, value in list(conformance.items())[:12]
+        }
+    return context
+
+
 def _workflow_retry_context(
-    prior_jobs: Sequence[Mapping[str, object]], *, registry=None
+    prior_jobs: Sequence[Mapping[str, object]],
+    *,
+    registry=None,
+    review_rejection: Mapping[str, object] | None = None,
 ) -> dict[str, object] | None:
     """#606：重派這張卡時要機械附進 prompt 的「前次採信失敗證據」。
 
@@ -8585,6 +8665,8 @@ def _workflow_retry_context(
     """
 
     if not prior_jobs:
+        # #750：理論上 rejection 只出現在 repair 回合（該卡必有前次 job）；防禦性
+        # 地維持「首派 prompt 逐字不變」的 #606 要求。
         return None
     latest = prior_jobs[-1]
     context: dict[str, object] = {
@@ -8601,6 +8683,9 @@ def _workflow_retry_context(
     error = _prior_card_acceptance_error(latest, registry=registry)
     if error is not None:
         context["acceptance_error"] = error
+    if review_rejection is not None:
+        # #750：repair 回合的跨卡回饋。鍵名明示它是「打回 candidate 的那份判定」。
+        context["review_rejection"] = dict(review_rejection)
     return context
 
 
@@ -9646,7 +9731,18 @@ def _dispatch_workflow_card(
                 # retry_context 為 None → prompt 逐字不變）。retry-card 的重派與
                 # daemon 的 forced retry 都走這唯一一條組裝路徑，因此兩者同時
                 # 拿到回饋，不需要第二份實作。
-                retry_context=_workflow_retry_context(matching, registry=registry),
+                retry_context=_workflow_retry_context(
+                    matching,
+                    registry=registry,
+                    # #750：只有 builder 的 build 卡吃跨卡回饋——repair 回合的
+                    # 消費者。reviewer 卡維持既有語意（它自己的前次失敗已由
+                    # #606 覆蓋）。
+                    review_rejection=(
+                        _prior_review_rejection(run, registry)
+                        if step.phase == "build" and step.persona == "builder"
+                        else None
+                    ),
+                ),
             ),
             worktree=worktree,
             log_dir=str(Path(coordinator_root).resolve() / "logs" / "workflow"),

--- a/tests/test_repair_review_feedback_750.py
+++ b/tests/test_repair_review_feedback_750.py
@@ -1,0 +1,130 @@
+"""#750：repair 回合的跨卡回饋——打回 candidate 的 verification 判定進 retry_context。
+
+#606 的 retry_context 只看同一張卡的前次 job；verification 判定在另一張卡上且因
+harvest fail-closed 沒有綁進 run，repair builder 因此盲修（實機：verification-22
+failed → repair -23 加了測試 → verification-24 同因再 failed）。本檔釘：最近一顆
+非通過 verify/review terminal 被選中、passing 略過、缺席回 None、欄位有界、
+`_workflow_retry_context` 把它掛在 `review_rejection` 鍵下、首派仍回 None。
+"""
+
+from __future__ import annotations
+
+import unittest
+from unittest import mock
+
+from paulsha_cortex.coordinator import manager
+
+
+class _Run:
+    run_id = "workflow-aaaaaaaaaaaaaaaaaaaa"
+
+
+class _Registry:
+    def __init__(self, jobs):
+        self._jobs = jobs
+
+    def list_jobs(self):
+        return self._jobs
+
+
+def _job(job_id, phase="verify", status="exited", log="/tmp/x.jsonl", run_id=_Run.run_id):
+    return {
+        "job_id": job_id,
+        "workflow_run_id": run_id,
+        "workflow_phase": phase,
+        "status": status,
+        "log_path": log,
+    }
+
+
+class PriorReviewRejectionTests(unittest.TestCase):
+    def _with_terminals(self, jobs, terminals):
+        """terminals: job log_path → raw terminal dict（模擬 _extract_terminal_json）。"""
+
+        def fake_extract(log_path):
+            raw = terminals.get(log_path)
+            if raw is None:
+                raise ValueError("no JSON")
+            return raw
+
+        return mock.patch.object(manager, "_extract_terminal_json", side_effect=fake_extract)
+
+    def test_latest_non_passing_verify_terminal_is_selected(self) -> None:
+        jobs = [
+            _job("v-1", log="/l/1"),
+            _job("v-2", log="/l/2"),
+        ]
+        terminals = {
+            "/l/1": {"status": "failed", "summary": "old", "details": {}},
+            "/l/2": {
+                "status": "failed",
+                "summary": "candidate fails: four checkpoints untouched",
+                "details": {
+                    "findings": [{"severity": "blocking", "requirement": "spec req 2"}],
+                    "conformance": {"spec_req_2_checkpoints": "FAIL"},
+                },
+            },
+        }
+        with self._with_terminals(jobs, terminals):
+            context = manager._prior_review_rejection(_Run(), _Registry(jobs))
+        self.assertEqual(context["job_id"], "v-2")
+        self.assertEqual(context["source"], "reviewer-terminal")
+        self.assertIn("four checkpoints", context["summary"])
+        self.assertIn("spec req 2", context["findings"][0])
+        self.assertEqual(context["conformance"]["spec_req_2_checkpoints"], "FAIL")
+
+    def test_passing_terminals_and_other_runs_are_skipped(self) -> None:
+        jobs = [
+            _job("v-ok", log="/l/ok"),
+            _job("v-other", log="/l/other", run_id="workflow-bbbbbbbbbbbbbbbbbbbb"),
+            _job("b-1", phase="build", log="/l/b"),
+        ]
+        terminals = {
+            "/l/ok": {"status": "passed", "summary": "fine", "details": {}},
+            "/l/other": {"status": "failed", "summary": "other run", "details": {}},
+            "/l/b": {"status": "failed", "summary": "build", "details": {}},
+        }
+        with self._with_terminals(jobs, terminals):
+            self.assertIsNone(manager._prior_review_rejection(_Run(), _Registry(jobs)))
+
+    def test_absent_registry_or_unreadable_logs_return_none(self) -> None:
+        self.assertIsNone(manager._prior_review_rejection(_Run(), None))
+        jobs = [_job("v-1", log="/l/broken")]
+        with self._with_terminals(jobs, {}):
+            self.assertIsNone(manager._prior_review_rejection(_Run(), _Registry(jobs)))
+
+    def test_summary_is_bounded(self) -> None:
+        jobs = [_job("v-1", log="/l/1")]
+        terminals = {
+            "/l/1": {
+                "status": "failed",
+                "summary": "x" * (manager.RETRY_CONTEXT_EVIDENCE_LIMIT * 2),
+                "details": {},
+            }
+        }
+        with self._with_terminals(jobs, terminals):
+            context = manager._prior_review_rejection(_Run(), _Registry(jobs))
+        self.assertEqual(len(context["summary"]), manager.RETRY_CONTEXT_EVIDENCE_LIMIT)
+
+
+class RetryContextMergeTests(unittest.TestCase):
+    def test_rejection_lands_under_its_own_key(self) -> None:
+        prior = [{"job_id": "b-1", "log_path": ""}]
+        rejection = {"source": "reviewer-terminal", "status": "failed", "summary": "s"}
+        context = manager._workflow_retry_context(prior, review_rejection=rejection)
+        self.assertEqual(context["review_rejection"], rejection)
+        self.assertEqual(context["attempt"], 2)
+
+    def test_without_rejection_the_context_shape_is_unchanged(self) -> None:
+        prior = [{"job_id": "b-1", "log_path": ""}]
+        context = manager._workflow_retry_context(prior)
+        self.assertNotIn("review_rejection", context)
+
+    def test_first_dispatch_stays_none(self) -> None:
+        self.assertIsNone(
+            manager._workflow_retry_context((), review_rejection={"status": "failed"})
+        )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
Fixes #750

## 病因（實機第十四環——repair 迴圈首走）

verification-22 實質 failed（spec req 2 四 checkpoint 零觸及、req 7 零測試）→ `retry-build` repair（-23）→ builder 只補了測試（看不到 findings，只能重讀 spec 猜）→ **verification-24 同因再 failed**（reviewer 更精準：gate 裝在 workflow lane、`read_repo_tier` 的真消費點在 slice lane、實際會炸的 lane 仍 fail-late）。

#606 的 retry_context 只從**同一張卡**的前次 job 取證據——subagent-build 的前次 gate ledger 全綠；打回 candidate 的判定在 verification 卡上、且因 harvest fail-closed 沒綁進 run。`retry-build` 的 repair 文案逐字要求依「current verification/review evidence」修——**evidence 沒有通道**。盲修不收斂是確定性的。

## 修法

- `_prior_review_rejection(run, registry)`：經 harvest 同一支 `_extract_terminal_json` 讀回本 run 最近一顆 verify/review、status=exited、terminal 非通過的判定：summary（有界）＋ findings（≤8 條、共用預算）＋ conformance（≤12 鍵、每值 300 字）。**誠實標注 `source: "reviewer-terminal"`**——它是 reviewer 產物、不是 manager-independent；本來就是打回 candidate 的那份判定。取不到一律 None（證據是加值，不得害死合法重派）。
- `_workflow_retry_context` 增 `review_rejection` 參數，併進 `review_rejection` 鍵；dispatch 端**只在 builder build 卡**帶入。
- 首派 prompt 逐字不變（#606 要求 2，測試釘住）；採信端零改動；判定只進 prompt、不進 evidence，builder 不可竄改 reviewer 判定的性質不變。

## 驗收

- [x] 單元：最新非通過 verify terminal 被選中；passing／他 run／build phase 略過；registry 缺席／log 不可讀回 None；summary 有界
- [x] `_workflow_retry_context`：rejection 落 `review_rejection` 鍵、無 rejection 形狀不變、首派仍 None
- [x] 全套 `python3 -m pytest tests/ -q`：4914 passed（零回歸）

實機驗收（merge＋部署後由 operator 執行、回報於 #750）：retry-build 後 repair builder 的 prompt 帶 findings、修到 slice lane／四 checkpoint、verify 收斂。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XcQLDun91sLCJfJeKoVgjS
