### PR TITLE
fix(coordinator): verify 階段的人裁通道——retry-card --reason 經 Manager evidence 進 prompt（#752）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 本專案遵循 hamanpaul project policy v1.0.17。
 
 ## [Unreleased]
+- **#752：verify 階段的人裁通道。** `retry-card --reason` → Manager-owned
+  immutable evidence（`cortex-operator-adjudication/v1`）→ retry_context 的
+  `operator_adjudications` 鍵（builder 與 reviewer 卡都吃）。design/todo 矛盾
+  這類 needs_human 判定，operator 裁決終於有可信路徑進 prompt。
 - **#750：repair 回合帶上打回它的 verification 判定（`retry_context.review_rejection`），
   盲修不收斂的迴圈關掉。** 跨卡回饋機械組裝、有界、標注 reviewer-terminal 來源；
   首派 prompt 不變、採信端零改動。

--- a/changelog.d/752-operator-adjudication.md
+++ b/changelog.d/752-operator-adjudication.md
@@ -1,0 +1,15 @@
+# 752-operator-adjudication
+
+- **`#752` verify 階段的人裁通道——`retry-card --reason` 落成 Manager-owned
+  evidence、經 retry_context 進 prompt，reviewer 終於讀得到 operator 裁決。**
+  實機連四輪：design D3/D8（fail-closed）與 todo／spec req 4/5（shareable
+  default）矛盾，reviewer 只能 needs_human——design 被 planning authority 釘死
+  不可 mid-run 修訂、builder 寫進 candidate 的註記依 #540/#628 不可採信、
+  `review-attest` 只受理 review phase：**operator 已做的裁決沒有任何可信通道**
+  （#717 的表親）。修法：`retry-card` 增列選填 `reason`（≤4000、前置驗證、
+  無 durable state path 即拒），重置成功後寫 content-addressed immutable
+  evidence `cortex-operator-adjudication/v1`（走既有 `_write_supersede_evidence`）；
+  dispatch 端 `_operator_adjudications()` 讀回本 run 最近 ≤3 筆（mtime 排序、
+  reason 有界）進 retry_context 的 `operator_adjudications` 鍵——builder 與
+  reviewer 卡都吃。首派 prompt 逐字不變、採信端零改動、作者歸屬不變（bounded
+  CLI＋Manager 落地，非 candidate 內容）。

--- a/paulsha_cortex/coordinator/manager.py
+++ b/paulsha_cortex/coordinator/manager.py
@@ -8638,11 +8638,61 @@ def _prior_review_rejection(run, registry) -> dict[str, object] | None:
     return context
 
 
+def _operator_adjudications(
+    run, coordinator_root: str | Path | None
+) -> list[dict[str, object]] | None:
+    """#752：本 run 的 operator 裁決紀錄（`cortex-operator-adjudication/v1`）。
+
+    verify 階段的人裁通道：design/todo 矛盾這類「reviewer 只能 needs_human」的判定，
+    operator 經 `retry-card --reason` 落成 Manager-owned immutable evidence，這裡讀回
+    最近 ≤3 筆（reason 有界）進 retry_context——builder 與 reviewer 卡都吃。內容經
+    bounded CLI＋Manager 落地，不是 builder 可偽造的 candidate 內容（#540／#628 的
+    作者歸屬不變）。取不到一律回 None。
+    """
+
+    if coordinator_root is None:
+        return None
+    root = Path(coordinator_root) / "evidence" / "operator-adjudication"
+    try:
+        # 檔名是 content-addressed（run_id-digest），不含時序——以 mtime 排序。
+        entries = sorted(
+            root.glob(f"{run.run_id}-*.json"), key=lambda item: item.stat().st_mtime
+        )
+    except Exception:
+        return None
+    rows: list[dict[str, object]] = []
+    for path in entries:
+        if path.is_symlink():
+            continue
+        try:
+            body = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+            continue
+        if not isinstance(body, Mapping) or body.get("run_id") != run.run_id:
+            continue
+        reason = body.get("reason")
+        if not isinstance(reason, str) or not reason.strip():
+            continue
+        rows.append(
+            {
+                "source": "operator-adjudication",
+                "actor": str(body.get("actor") or "operator"),
+                "card": str(body.get("card") or ""),
+                "created_at": str(body.get("created_at") or ""),
+                "reason": reason[:RETRY_CONTEXT_EVIDENCE_LIMIT],
+            }
+        )
+    if not rows:
+        return None
+    return rows[-3:]
+
+
 def _workflow_retry_context(
     prior_jobs: Sequence[Mapping[str, object]],
     *,
     registry=None,
     review_rejection: Mapping[str, object] | None = None,
+    operator_adjudications: Sequence[Mapping[str, object]] | None = None,
 ) -> dict[str, object] | None:
     """#606：重派這張卡時要機械附進 prompt 的「前次採信失敗證據」。
 
@@ -8686,6 +8736,10 @@ def _workflow_retry_context(
     if review_rejection is not None:
         # #750：repair 回合的跨卡回饋。鍵名明示它是「打回 candidate 的那份判定」。
         context["review_rejection"] = dict(review_rejection)
+    if operator_adjudications:
+        # #752：operator 的人裁紀錄——needs_human 判定的權威答覆，優先於文件間的
+        # 表面矛盾（例：design 與 todo 不一致時，以裁決指定的那一邊為準）。
+        context["operator_adjudications"] = [dict(row) for row in operator_adjudications]
     return context
 
 
@@ -9741,6 +9795,11 @@ def _dispatch_workflow_card(
                         _prior_review_rejection(run, registry)
                         if step.phase == "build" and step.persona == "builder"
                         else None
+                    ),
+                    # #752：operator 裁決對修復與複驗同樣有效——builder 與
+                    # reviewer 卡都帶。
+                    operator_adjudications=_operator_adjudications(
+                        run, coordinator_root
                     ),
                 ),
             ),

--- a/paulsha_cortex/coordinator/work_actions.py
+++ b/paulsha_cortex/coordinator/work_actions.py
@@ -2279,7 +2279,7 @@ def _retry_card_target_jobs(run, jobs, *, card: str) -> list[dict[str, Any]]:
     ]
 
 
-def _retry_card_action(*, args: dict[str, Any], authority, workflow_registry) -> dict[str, Any]:
+def _retry_card_action(*, args: dict[str, Any], authority, workflow_registry, state_path: Path | None = None, now_epoch: float | None = None) -> dict[str, Any]:
     """#545／#569：以現行 prompt 重派「當前 phase 內最早一張尚未採信的卡」。
 
     現場一（#545，run ``workflow-084f75e2178cf7547476`` build phase）：builder
@@ -2329,9 +2329,25 @@ def _retry_card_action(*, args: dict[str, Any], authority, workflow_registry) ->
 
     extras = set(args) - {
         "action", "repo", "work_id", "issue", "actor", "expected_run_id", "card",
+        "reason",
     }
     if extras:
         raise ValueError(f"retry-card rejects caller evidence/input: {sorted(extras)[0]}")
+    # #752：選填的 operator 裁決文字。驗在最前面——裁決寫不進去就不該動 run。
+    adjudication = args.get("reason")
+    if adjudication is not None:
+        if (
+            not isinstance(adjudication, str)
+            or not adjudication.strip()
+            or len(adjudication) > OPERATOR_ADJUDICATION_REASON_LIMIT
+        ):
+            raise ValueError(
+                "retry-card reason must be a non-empty string within "
+                f"{OPERATOR_ADJUDICATION_REASON_LIMIT} characters"
+            )
+        if state_path is None:
+            raise ValueError("retry-card reason requires a durable state path")
+        adjudication = adjudication.strip()
     expected_run_id = args.get("expected_run_id")
     if (
         not isinstance(expected_run_id, str)
@@ -2398,8 +2414,39 @@ def _retry_card_action(*, args: dict[str, Any], authority, workflow_registry) ->
         retry_classification=retry_classification.value,
     )
     updated = _recompute_and_persist_sizing(workflow_registry, updated)
+    adjudication_evidence = None
+    if adjudication is not None:
+        # #752：operator 裁決經 Manager 落地為 immutable evidence——dispatch 端由
+        # `manager._operator_adjudications()` 讀回、進 retry_context 的
+        # `operator_adjudications` 鍵。這是 verify 階段唯一可信的人裁通道：
+        # 內容經 bounded CLI、Manager-owned 檔案，不是 builder 可偽造的 candidate 內容。
+        actor_value = args.get("actor")
+        adjudication_evidence = _write_supersede_evidence(
+            {
+                "schema": OPERATOR_ADJUDICATION_SCHEMA,
+                "repo": run.repo,
+                "work_id": run.work_id,
+                "run_id": run.run_id,
+                "card": card,
+                "actor": (
+                    actor_value if isinstance(actor_value, str) and actor_value.strip() else "operator"
+                ),
+                "reason": adjudication,
+                "phase": run.current_phase,
+                "created_at": (
+                    datetime.fromtimestamp(float(now_epoch), tz=timezone.utc).isoformat()
+                    if isinstance(now_epoch, (int, float)) and not isinstance(now_epoch, bool)
+                    else ""
+                ),
+            },
+            state_path=state_path,
+            subdir="operator-adjudication",
+            label="operator-adjudication",
+            max_size=16384,
+        )
     return {
         "action": "retry-card",
+        "adjudication_evidence": adjudication_evidence,
         "reason": f"{expected_persona}-card-redispatched",
         "expected_run_id": expected_run_id,
         "run_id": run.run_id,
@@ -3600,6 +3647,10 @@ def _reset_reclaim_budget_action(
 # 真實來源；而且順帶把 run 從「隱式跟著本地 main 漂」升級成「明示 pin 在一個
 # SHA」，hermetic pinning 只有更強、沒有放寬。
 CANDIDATE_BASE_REFREEZE_SCHEMA = "cortex-work-candidate-base-refreeze/v1"
+
+#: #752：operator 對 needs_human 判定的裁決紀錄——verify 階段唯一的可信人裁通道。
+OPERATOR_ADJUDICATION_SCHEMA = "cortex-operator-adjudication/v1"
+OPERATOR_ADJUDICATION_REASON_LIMIT = 4000
 
 #: 沒有前次凍結集（production 的常態）時寫進 `frozen_readiness` 的形狀。**刻意
 #: 不用** `pre-claim-readiness-frozen-set/v1`：那個 schema 的語意是「六道
@@ -5787,6 +5838,8 @@ def execute_work_action(
             args=args,
             authority=authority,
             workflow_registry=workflow_registry,
+            state_path=state_path,
+            now_epoch=now_epoch,
         )
     elif action == "retry-verify":
         result = _retry_verify_action(

--- a/tests/test_operator_adjudication_752.py
+++ b/tests/test_operator_adjudication_752.py
@@ -1,0 +1,113 @@
+"""#752：verify 階段的人裁通道——`retry-card --reason` → Manager evidence → prompt。
+
+design/todo 矛盾這類判定 reviewer 只能 needs_human（design 被 planning authority
+釘死不可 mid-run 修訂、builder 寫進 candidate 的註記不可採信、`review-attest` 只
+受理 review phase）。operator 裁決經 bounded CLI 落成 Manager-owned immutable
+evidence，dispatch 端讀回進 retry_context 的 `operator_adjudications` 鍵。
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from paulsha_cortex.coordinator import manager, work_actions
+
+
+class _Run:
+    run_id = "workflow-cccccccccccccccccccc"
+
+
+def _write_evidence(root: Path, *, run_id: str, reason: str, created_at: str = "") -> Path:
+    target_dir = root / "evidence" / "operator-adjudication"
+    target_dir.mkdir(parents=True, exist_ok=True)
+    body = {
+        "schema": work_actions.OPERATOR_ADJUDICATION_SCHEMA,
+        "run_id": run_id,
+        "card": "verification",
+        "actor": "operator",
+        "reason": reason,
+        "created_at": created_at,
+    }
+    digest = f"{abs(hash(reason)) % (16**8):08x}" * 8
+    path = target_dir / f"{run_id}-{digest[:64]}.json"
+    path.write_text(json.dumps(body, ensure_ascii=False), encoding="utf-8")
+    return path
+
+
+class OperatorAdjudicationsReaderTests(unittest.TestCase):
+    def test_reads_bounded_rows_for_the_run(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _write_evidence(root, run_id=_Run.run_id, reason="D3 superseded: todo wins")
+            _write_evidence(root, run_id="workflow-dddddddddddddddddddd", reason="other run")
+            rows = manager._operator_adjudications(_Run(), root)
+            self.assertEqual(len(rows), 1)
+            self.assertEqual(rows[0]["source"], "operator-adjudication")
+            self.assertIn("todo wins", rows[0]["reason"])
+
+    def test_absent_directory_returns_none(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            self.assertIsNone(manager._operator_adjudications(_Run(), Path(tmp)))
+        self.assertIsNone(manager._operator_adjudications(_Run(), None))
+
+    def test_at_most_three_latest_rows_survive(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            import os, time
+            for index in range(5):
+                path = _write_evidence(
+                    root, run_id=_Run.run_id, reason=f"ruling-{index}"
+                )
+                stamp = time.time() + index
+                os.utime(path, (stamp, stamp))
+            rows = manager._operator_adjudications(_Run(), root)
+            self.assertEqual(len(rows), 3)
+            self.assertEqual(rows[-1]["reason"], "ruling-4")
+
+
+class RetryContextMergeTests(unittest.TestCase):
+    def test_adjudications_land_under_their_own_key(self) -> None:
+        prior = [{"job_id": "v-1", "log_path": ""}]
+        rows = [{"source": "operator-adjudication", "reason": "todo wins"}]
+        context = manager._workflow_retry_context(prior, operator_adjudications=rows)
+        self.assertEqual(context["operator_adjudications"], rows)
+
+    def test_without_adjudications_the_shape_is_unchanged(self) -> None:
+        prior = [{"job_id": "v-1", "log_path": ""}]
+        context = manager._workflow_retry_context(prior)
+        self.assertNotIn("operator_adjudications", context)
+
+
+class RetryCardReasonValidationTests(unittest.TestCase):
+    def _call(self, reason):
+        args = {
+            "action": "retry-card",
+            "repo": "o/r",
+            "work_id": "w",
+            "expected_run_id": "workflow-" + "a" * 20,
+            "card": "verification",
+            "reason": reason,
+        }
+        # 只驗前置檢查——非法 reason 必須在動到 run 之前被拒。
+        with self.assertRaises(ValueError) as ctx:
+            work_actions._retry_card_action(
+                args=args, authority=None, workflow_registry=None, state_path=None
+            )
+        return str(ctx.exception)
+
+    def test_empty_reason_is_rejected_before_any_side_effect(self) -> None:
+        self.assertIn("reason", self._call("   "))
+
+    def test_oversized_reason_is_rejected(self) -> None:
+        self.assertIn("reason", self._call("x" * 4001))
+
+    def test_reason_without_durable_state_path_is_rejected(self) -> None:
+        message = self._call("D3 superseded: todo wins")
+        self.assertIn("durable state path", message)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
Fixes #752

## 病因（實機第十五環——verify 連四輪 needs_human 的結構性死結）

verification-28 判定核心缺陷已真修好，但 F1（blocking-adjudication）：實作維持 shareable default（與 todo／spec req 4/5 一致）逐字牴觸 accepted design D3/D8 的 fail-closed——reviewer 連四輪標註「needs human adjudication」。而 operator 已做的裁決**沒有任何可信通道**進到 reviewer 眼前：design 被 planning authority 以 baseline hash 釘死（mid-run 修訂＝input snapshot 驗證炸掉）；builder 寫進 candidate 的「已裁決」註記依 #540/#628 不可採信；`review-attest` 只受理 review phase。#717 的表親：最需要被表達的訊息，契約表達不出來。

## 修法（最小可信通道）

- `retry-card` 增列選填 `reason`（≤4000；前置驗證，非法即拒、不動 run；帶 reason 但無 durable state path 亦拒）。重置成功後寫 content-addressed immutable evidence `cortex-operator-adjudication/v1`（run_id／card／actor／reason／created_at，走既有 `_write_supersede_evidence`，冪等）。
- dispatch 端 `_operator_adjudications(run, coordinator_root)`：讀本 run 的 adjudication evidence（mtime 排序取最近 ≤3 筆、reason 有界），經 `_workflow_retry_context` 掛 `operator_adjudications` 鍵——**builder 與 reviewer 卡都吃**（裁決對修復與複驗同樣有效）。
- 信任性質：內容經 bounded CLI（actor/reason）→ Manager-owned evidence → Manager 組 prompt，與 #750 的 reviewer-terminal 通道同構但作者是 operator——reviewer 可採信為人裁；作者歸屬紀律不變。
- 首派 prompt 逐字不變（無 evidence 即無鍵）；採信端零改動。

## 驗收

- [x] 單元：非法 reason（空白／超長／無 state path）在任何 side effect 之前被拒；讀取端過濾本 run、mtime 取最新 ≤3、缺席回 None；retry_context 掛鍵、無裁決形狀不變
- [x] 全套 `python3 -m pytest tests/ -q`：4922 passed（零回歸）

實機驗收（merge＋部署後由 operator 執行、回報於 #752）：`retry-card --card verification --reason "<裁決>"` 後 reviewer prompt 帶 operator_adjudications、F1 收斂。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XcQLDun91sLCJfJeKoVgjS
