### PR TITLE
fix(coordinator): retry-card evidence 寫入接 resolved_state_path（#752 補遺）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 本專案遵循 hamanpaul project policy v1.0.17。
 
 ## [Unreleased]
+- **#752 補遺：retry-card 的 adjudication evidence 改接 `resolved_state_path`**
+  （原始參數在 daemon 路徑恆為 None，人裁通道上線即不可用）。
 - **#752：verify 階段的人裁通道。** `retry-card --reason` → Manager-owned
   immutable evidence（`cortex-operator-adjudication/v1`）→ retry_context 的
   `operator_adjudications` 鍵（builder 與 reviewer 卡都吃）。design/todo 矛盾

--- a/changelog.d/752-state-path-wiring.md
+++ b/changelog.d/752-state-path-wiring.md
@@ -1,0 +1,6 @@
+# 752-state-path-wiring
+
+- **`#752` 補遺：retry-card 的 evidence 寫入接 `resolved_state_path`。** dispatcher
+  的原始 `state_path` 參數在 production（daemon 請求路徑）恆為 None，帶 reason 的
+  retry-card 因此一律被前置檢查拒於「requires a durable state path」——人裁通道
+  上線即不可用。改接與其餘 action 相同的 `resolved_state_path`。

--- a/paulsha_cortex/coordinator/work_actions.py
+++ b/paulsha_cortex/coordinator/work_actions.py
@@ -5838,7 +5838,9 @@ def execute_work_action(
             args=args,
             authority=authority,
             workflow_registry=workflow_registry,
-            state_path=state_path,
+            # #752 補遺：帶 reason 時要寫 evidence，必須用**解析後**的 state path
+            # ——原始參數在 production（daemon 請求）恆為 None。
+            state_path=resolved_state_path,
             now_epoch=now_epoch,
         )
     elif action == "retry-verify":


### PR DESCRIPTION
Fixes #752

## 病因
dispatcher 的原始 `state_path` 參數在 production（daemon 請求路徑）恆為 None——帶 reason 的 retry-card 一律被前置檢查拒於「requires a durable state path」，人裁通道上線即不可用（實機十連拒）。

## 修法
改接其餘 action 共用的 `resolved_state_path`（`Path(state_path) if … else _run_state_path()`）。

## 驗收
- [x] tests/test_operator_adjudication_752.py 全綠
- [x] 全套 pytest 綠（CI）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XcQLDun91sLCJfJeKoVgjS