### PR TITLE
fix(dispatch): operator 裁決 run 級獨立於 retry_context（#757）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 本專案遵循 hamanpaul project policy v1.0.17。
 
 ## [Unreleased]
+- **#757：operator 裁決改為 run 級獨立 prompt 區塊**（verify/review 的 matching 以
+  candidate 定錨，掛在 retry_context 下會在 candidate 換新時整組消失）。
 - **#755：`--reason` 擴到 `retry-build`（共用 #752 的 adjudication evidence 落地），
   operator 對 repair 回合的指示有通道；retry-card 收斂到同一支 helper。**
 - **#752 補遺：retry-card 的 adjudication evidence 改接 `resolved_state_path`**

--- a/changelog.d/757-adjudication-scope.md
+++ b/changelog.d/757-adjudication-scope.md
@@ -1,0 +1,9 @@
+# 757-adjudication-scope
+
+- **`#757` operator 裁決改為 run 級獨立 prompt 區塊——不再因 candidate 換新而
+  消失。** verify/review 卡的 retry-context matching 以 candidate 定錨，repair 後
+  candidate 換新即空；#752 把裁決掛在 retry_context 底下，於是 verification-37 的
+  prompt 完全沒有裁決、reviewer 重新升級已裁決的 D3 矛盾。修法：
+  `_workflow_job_prompt` 增獨立 `operator_adjudications` 參數與 contract 鍵——
+  evidence 存在即隨每一次派工出現（builder／reviewer 皆然）；無裁決時鍵缺席、
+  prompt 逐字不變。retry_context 的舊掛點保留相容。

--- a/paulsha_cortex/coordinator/manager.py
+++ b/paulsha_cortex/coordinator/manager.py
@@ -8753,6 +8753,7 @@ def _workflow_job_prompt(
     candidate_checkout: str | None = None,
     env: Mapping[str, str] | None = None,
     retry_context: Mapping[str, object] | None = None,
+    operator_adjudications: Sequence[Mapping[str, object]] | None = None,
 ) -> str:
     """組出單張 workflow card 的派工 prompt。
 
@@ -8998,6 +8999,13 @@ def _workflow_job_prompt(
     if retry_context is not None:
         # #606：首派沒有這個鍵，prompt 因此逐字不變（見 `_workflow_retry_context`）。
         contract["retry_context"] = dict(retry_context)
+    if operator_adjudications:
+        # #757：operator 裁決是 **run 級**的權威答覆，不是某卡的重試歷史——一旦
+        # 存在就隨每一次派工出現（builder／reviewer 皆然），不因 candidate 換新、
+        # 卡片首派而消失。無裁決時本鍵缺席，prompt 逐字不變。
+        contract["operator_adjudications"] = [
+            dict(row) for row in operator_adjudications
+        ]
     effective_commit_policy = step.commit_policy or fallback[2]
     tasks_path = (
         f"openspec/changes/{contract['openspec_ref']}/tasks.md"
@@ -9796,12 +9804,10 @@ def _dispatch_workflow_card(
                         if step.phase == "build" and step.persona == "builder"
                         else None
                     ),
-                    # #752：operator 裁決對修復與複驗同樣有效——builder 與
-                    # reviewer 卡都帶。
-                    operator_adjudications=_operator_adjudications(
-                        run, coordinator_root
-                    ),
                 ),
+                # #757：run 級裁決獨立於 retry_context——verify/review 的 matching
+                # 以 candidate 定錨，candidate 換新即空，掛在底下會讓裁決消失。
+                operator_adjudications=_operator_adjudications(run, coordinator_root),
             ),
             worktree=worktree,
             log_dir=str(Path(coordinator_root).resolve() / "logs" / "workflow"),

--- a/tests/test_adjudication_scope_757.py
+++ b/tests/test_adjudication_scope_757.py
@@ -1,0 +1,34 @@
+"""#757：operator 裁決是 run 級，獨立於 retry_context 隨每次派工出現。
+
+verify/review 的 retry-context matching 以 candidate 定錨——candidate 換新即空，
+#752 把裁決掛在 retry_context 底下，裁決因此消失（實機 verification-37：
+operator_adjudications=False，reviewer 重新升級已裁決的 D3 矛盾）。
+"""
+
+from __future__ import annotations
+
+import inspect
+import unittest
+
+from paulsha_cortex.coordinator import manager
+
+
+class AdjudicationScopeTests(unittest.TestCase):
+    def test_prompt_builder_accepts_adjudications_independently(self) -> None:
+        parameters = inspect.signature(manager._workflow_job_prompt).parameters
+        self.assertIn("operator_adjudications", parameters)
+
+    def test_dispatch_passes_adjudications_outside_retry_context(self) -> None:
+        """呼叫端必須把裁決作為獨立參數傳遞，不得只藏在 retry_context 內。"""
+
+        source = inspect.getsource(manager._dispatch_workflow_card)
+        independent = "operator_adjudications=_operator_adjudications(run, coordinator_root)"
+        self.assertIn(independent, source)
+
+    def test_prompt_embeds_adjudications_as_their_own_contract_key(self) -> None:
+        source = inspect.getsource(manager._workflow_job_prompt)
+        self.assertIn('contract["operator_adjudications"]', source)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
Fixes #757

## 病因（實機 verification-37）
repair 後 candidate 換新（43be4bdc），verification 卡自動重派；verify/review 的 retry-context matching **以 candidate 定錨** ⇒ matching 空 ⇒ retry_context=None ⇒ #752 掛在其下的 operator_adjudications 一併消失（job spec 實測 False）。reviewer 在無裁決的 prompt 下重新升級已裁決的 D3/todo 矛盾。

## 修法
`_workflow_job_prompt` 增獨立 `operator_adjudications` 參數與 contract 鍵：evidence 存在即隨**每一次**派工出現（builder/reviewer 皆然）、與 retry_context 脫鉤；無裁決時鍵缺席、prompt 逐字不變。retry_context 舊掛點保留相容。

## 驗收
- [x] 單元＋source-pin：prompt builder 獨立參數、呼叫端獨立傳遞、contract 鍵存在
- [x] 全套 pytest：4927 passed（零回歸）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XcQLDun91sLCJfJeKoVgjS