### PR TITLE
fix(delivery): FullSuiteEvidence 契約接上 production，delivery 免第三跑全套（#760）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 本專案遵循 hamanpaul project policy v1.0.17。
 
 ## [Unreleased]
+- **#760：`--skip-tests` 的 FullSuiteEvidence 契約接上 production**——gate 綠的
+  build 候選在採信點落 tree-hash 定址 evidence，delivery preflight 消費之；
+  manager 環境不再第三跑全套。tdd-red 的 RED 天然排除、記錄失敗不影響採信。
 - **#757：operator 裁決改為 run 級獨立 prompt 區塊**（verify/review 的 matching 以
   candidate 定錨，掛在 retry_context 下會在 candidate 換新時整組消失）。
 - **#755：`--reason` 擴到 `retry-build`（共用 #752 的 adjudication evidence 落地），

--- a/changelog.d/760-full-suite-wiring.md
+++ b/changelog.d/760-full-suite-wiring.md
@@ -1,0 +1,15 @@
+# 760-full-suite-wiring
+
+- **`#760` `--skip-tests` 的 FullSuiteEvidence 契約接上 production——delivery 不再
+  於 manager 環境（第三個 env-red 執行面，#723 第五例）第三跑全套而結構性卡死。**
+  契約（tree-hash 定址、immutable、age 上限、`run_preflight` 內建 load＋驗證）
+  早已完整，但 producer（`write_full_suite_evidence_after_run` 零 production
+  caller，verification-28 F2 點名）與 consumer（work_bridge 兩個 call site 硬編
+  `skip_tests=False`）都沒接。修法：(1) producer＝build 候選採信點（harvest 後），
+  **未反轉**的權威 ledger pytest 實際 passed（tdd-red 的 RED 天然排除）時以
+  `git rev-parse <candidate>^{tree}` 記 `record_external_full_suite_evidence`
+  （自 `write_full_suite_evidence_after_run` 抽出的共用 writer、格式不變、冪等）；
+  best-effort，記錄失敗不影響採信。(2) consumer＝`_run_exact_candidate_preflight`
+  兩個 call site 以 `fresh_full_suite_evidence`（存在＋未過期）預判請求
+  `--skip-tests`；缺席／過期照舊 False，最終驗證仍由既有 `--skip-tests` 契約
+  單一把關。

--- a/paulsha_cortex/coordinator/manager.py
+++ b/paulsha_cortex/coordinator/manager.py
@@ -29,6 +29,7 @@ from . import candidate_base
 from . import completion
 from . import coverage
 from . import gate_ledger
+from . import preflight
 from . import job_runner
 from . import job_workspace
 from . import planning_runtime
@@ -3263,6 +3264,62 @@ def _raise_if_worktree_read_blocked(result: object, *, what: str) -> None:
         f"blocked on {verification.WORKTREE_READ_BLOCKED_ISSUE}: "
         f"{verification.WORKTREE_READ_BLOCKED_DETAIL}"
     )
+
+
+def _record_candidate_full_suite_evidence(
+    job: Mapping[str, object], *, run, candidate: str
+) -> None:
+    """#760：權威 gate 的全套綠 → tree-hash 定址的 FullSuiteEvidence。
+
+    delivery 的 pr-preflight 用它請求 `--skip-tests`：manager 環境是第三個
+    env-red 執行面（#723 第五例），在那裡第三跑全套只會把已由 gate 環境獨立驗過、
+    CI 又會在 PR 上重驗的訊號變成結構性 block。判準取**未反轉**的 ledger outcome
+    （`_ledger_outcomes`）——tdd-red 的 RED（pytest failed＝達成）因此天然排除，
+    只有真正全綠的候選會留下 evidence。best-effort：記不下來不影響採信（fail-open
+    僅及於「delivery 屆時老老實實再跑一次」）。
+    """
+
+    try:
+        log_path = job.get("log_path")
+        if not isinstance(log_path, str) or not log_path:
+            return
+        found = terminal_contract.read_gate_ledger(
+            terminal_contract.gate_ledger_path(log_path)
+        )
+        if found is None:
+            return
+        outcomes = terminal_contract._ledger_outcomes(found[0])
+        pytest_outcome = outcomes.get(terminal_contract.RED_REQUIRED_TEST_GATE_NAME)
+        if not isinstance(pytest_outcome, Mapping) or pytest_outcome.get("status") != "passed":
+            return
+        workspace_root = getattr(run, "workspace_root", None)
+        if not isinstance(workspace_root, str) or not workspace_root:
+            return
+        tree = subprocess.run(
+            ["git", "-C", workspace_root, "rev-parse", f"{candidate}^{{tree}}"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        tree_hash = tree.stdout.strip().lower()
+        if tree.returncode != 0 or verification.SAFE_SHA_RE.fullmatch(tree_hash) is None:
+            return
+        specs = gate_ledger.load_gate_specs(os.environ)
+        command: tuple[str, ...] = ()
+        for spec in specs:
+            if spec.name == terminal_contract.RED_REQUIRED_TEST_GATE_NAME:
+                command = spec.argv
+                break
+        if not command:
+            return
+        preflight.record_external_full_suite_evidence(
+            tree_hash=tree_hash,
+            command=command,
+            completed_at_epoch=time.time(),
+        )
+    except Exception:
+        # 證據是加值：記錄失敗不得影響採信本身。
+        return
 
 
 def _job_gate_worktree_state(job: Mapping[str, object]) -> Mapping[str, object] | None:
@@ -10966,6 +11023,9 @@ def apply_workflow_action(
             )
             _harvest_build_candidate(
                 job, run=current, candidate=candidate, coordinator_root=coordinator_root
+            )
+            _record_candidate_full_suite_evidence(
+                job, run=current, candidate=candidate
             )
         elif current.current_phase in {"verify", "review"}:
             job_candidate = _verify_exact_candidate(job, git_runner=git_runner)

--- a/paulsha_cortex/coordinator/preflight.py
+++ b/paulsha_cortex/coordinator/preflight.py
@@ -149,16 +149,42 @@ def write_full_suite_evidence_after_run(
     if final_head != head or final_tree != tree_hash:
         raise RuntimeError("full-suite tree changed during execution")
     completed = now()
+    return record_external_full_suite_evidence(
+        tree_hash=tree_hash,
+        command=command,
+        completed_at_epoch=completed,
+        state_root=state_root,
+    )
+
+
+def record_external_full_suite_evidence(
+    *,
+    tree_hash: str,
+    command: Sequence[str],
+    completed_at_epoch: float,
+    state_root: str | Path | None = None,
+) -> FullSuiteEvidence:
+    """把一次**已在別處完成**的全套綠落成 canonical FullSuiteEvidence（#760）。
+
+    producer 是 build 候選的採信點：權威 gate ledger 的 pytest 實際 passed（未反轉
+    語意——tdd-red 的 RED 天然排除）時，Manager 以 candidate 的 git tree hash 記錄。
+    檔案格式與 :func:`load_full_suite_evidence` 完全相同；content-addressed、
+    immutable、重複寫入以逐位元組相等視為冪等。
+    """
+
+    _validate_typed_command(command)
+    if not _is_sha(tree_hash):
+        raise ValueError("full-suite evidence tree_hash invalid")
     if (
-        not isinstance(completed, (int, float))
-        or isinstance(completed, bool)
-        or not math.isfinite(float(completed))
+        not isinstance(completed_at_epoch, (int, float))
+        or isinstance(completed_at_epoch, bool)
+        or not math.isfinite(float(completed_at_epoch))
     ):
         raise ValueError("full-suite completion timestamp must be finite")
     body = {
         "schema": FULL_SUITE_EVIDENCE_SCHEMA,
-        "tree_hash": tree_hash,
-        "completed_at_epoch": float(completed),
+        "tree_hash": tree_hash.lower(),
+        "completed_at_epoch": float(completed_at_epoch),
         "command": list(command),
     }
     envelope = {"payload": body, "payload_hash": verification.canonical_json_hash(body)}
@@ -177,6 +203,28 @@ def write_full_suite_evidence_after_run(
             raise RuntimeError("conflicting immutable full-suite evidence")
         return existing
     return load_full_suite_evidence(tree_hash=tree_hash, state_root=state_root)
+
+
+def fresh_full_suite_evidence(
+    *,
+    tree_hash: str,
+    now_epoch: float,
+    state_root: str | Path | None = None,
+) -> FullSuiteEvidence | None:
+    """有效（存在＋未過期）的 full-suite evidence，否則 None（#760 consumer 端）。
+
+    只做「要不要請求 --skip-tests」的預判；最終驗證仍由
+    :func:`build_preflight_argv`／:func:`_validate_skip_tests` 的既有契約把關。
+    """
+
+    try:
+        evidence = load_full_suite_evidence(tree_hash=tree_hash, state_root=state_root)
+    except ValueError:
+        return None
+    age = float(now_epoch) - float(evidence.completed_at_epoch)
+    if age < 0 or age > DEFAULT_FULL_SUITE_MAX_AGE_SECONDS:
+        return None
+    return evidence
 
 
 def load_preflight_command(

--- a/paulsha_cortex/coordinator/work_bridge.py
+++ b/paulsha_cortex/coordinator/work_bridge.py
@@ -1518,6 +1518,42 @@ def _workflow_evidence_payload(
     return payload, job
 
 
+def _candidate_skip_tests_request(
+    *, worktree: Path, candidate: str, now
+) -> bool:
+    """#760：candidate 的全套綠已由 gate 環境獨立驗過時，delivery 請求 --skip-tests。
+
+    manager 環境是第三個 env-red 執行面（#723 第五例），在此第三跑全套是把已驗訊號
+    變成結構性 block。這裡只做預判（tree-hash 定址＋age）；最終驗證由
+    `preflight.build_preflight_argv` 的既有 `--skip-tests` 契約把關。任何讀取失敗
+    一律 False——行為退回「老老實實再跑一次」。
+    """
+
+    try:
+        tree = subprocess.run(
+            ["git", "-C", str(worktree), "rev-parse", f"{candidate}^{{tree}}"],
+            shell=False,
+            capture_output=True,
+            text=True,
+        )
+        tree_hash = tree.stdout.strip().lower()
+        if tree.returncode != 0:
+            return False
+        now_epoch = now()
+        evidence = load_fresh_full_suite_evidence(
+            tree_hash=tree_hash, now_epoch=float(now_epoch)
+        )
+        return evidence is not None
+    except Exception:
+        return False
+
+
+def load_fresh_full_suite_evidence(*, tree_hash: str, now_epoch: float):
+    from .preflight import fresh_full_suite_evidence
+
+    return fresh_full_suite_evidence(tree_hash=tree_hash, now_epoch=now_epoch)
+
+
 def _run_exact_candidate_preflight(
     *,
     worktree: Path,
@@ -1892,7 +1928,13 @@ def build_production_ship_validator(
                 branch=branch,
                 candidate=candidate,
                 command=load_preflight_command(),
-                request=PreflightRequest(metadata_path=str(metadata_path)),
+                request=PreflightRequest(
+                    metadata_path=str(metadata_path),
+                    # #760：gate 已於自己的環境獨立跑過全套且綠時請求 --skip-tests。
+                    skip_tests=_candidate_skip_tests_request(
+                        worktree=worktree, candidate=candidate, now=now
+                    ),
+                ),
                 runner=runner,
                 now=now,
             )
@@ -1975,7 +2017,12 @@ def build_production_ship_validator(
             branch=branch,
             candidate=candidate,
             command=load_preflight_command(),
-            request=PreflightRequest(pr_number=number),
+            request=PreflightRequest(
+                pr_number=number,
+                skip_tests=_candidate_skip_tests_request(
+                    worktree=worktree, candidate=candidate, now=now
+                ),
+            ),
             runner=runner,
             now=now,
         )

--- a/tests/test_full_suite_wiring_760.py
+++ b/tests/test_full_suite_wiring_760.py
@@ -1,0 +1,167 @@
+"""#760：--skip-tests 的 FullSuiteEvidence 契約接線（producer＋consumer）。
+
+manager 環境是第三個 env-red 執行面；gate 已在自己的環境獨立跑過全套且綠、CI 又會
+在 PR 上重驗，delivery preflight 第三跑只會把已驗訊號變成結構性 block。
+"""
+
+from __future__ import annotations
+
+import subprocess
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from paulsha_cortex.coordinator import manager, preflight, work_bridge
+
+
+class RecordAndLoadRoundtripTests(unittest.TestCase):
+    def test_external_record_is_loadable_and_fresh(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tree = "a" * 40
+            now = time.time()
+            written = preflight.record_external_full_suite_evidence(
+                tree_hash=tree,
+                command=("python3", "-m", "pytest", "-q"),
+                completed_at_epoch=now,
+                state_root=tmp,
+            )
+            self.assertEqual(written.tree_hash, tree)
+            fresh = preflight.fresh_full_suite_evidence(
+                tree_hash=tree, now_epoch=now + 60, state_root=tmp
+            )
+            self.assertIsNotNone(fresh)
+            self.assertEqual(fresh.evidence_hash, written.evidence_hash)
+
+    def test_identical_rewrite_is_idempotent(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tree = "b" * 40
+            kwargs = dict(
+                tree_hash=tree,
+                command=("python3", "-m", "pytest", "-q"),
+                completed_at_epoch=123.0,
+                state_root=tmp,
+            )
+            first = preflight.record_external_full_suite_evidence(**kwargs)
+            second = preflight.record_external_full_suite_evidence(**kwargs)
+            self.assertEqual(first.evidence_hash, second.evidence_hash)
+
+    def test_stale_or_absent_evidence_is_none(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tree = "c" * 40
+            self.assertIsNone(
+                preflight.fresh_full_suite_evidence(
+                    tree_hash=tree, now_epoch=time.time(), state_root=tmp
+                )
+            )
+            preflight.record_external_full_suite_evidence(
+                tree_hash=tree,
+                command=("python3", "-m", "pytest", "-q"),
+                completed_at_epoch=100.0,
+                state_root=tmp,
+            )
+            self.assertIsNone(
+                preflight.fresh_full_suite_evidence(
+                    tree_hash=tree,
+                    now_epoch=100.0 + preflight.DEFAULT_FULL_SUITE_MAX_AGE_SECONDS + 1,
+                    state_root=tmp,
+                )
+            )
+
+
+def _make_repo(root: Path) -> str:
+    subprocess.run(["git", "init", "-q", "-b", "main"], cwd=root, check=True)
+    subprocess.run(["git", "config", "user.email", "t@example.invalid"], cwd=root, check=True)
+    subprocess.run(["git", "config", "user.name", "t"], cwd=root, check=True)
+    (root / "a.txt").write_text("1\n", encoding="utf-8")
+    subprocess.run(["git", "add", "-A"], cwd=root, check=True)
+    subprocess.run(["git", "commit", "-qm", "c"], cwd=root, check=True)
+    return subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=root, capture_output=True, text=True, check=True
+    ).stdout.strip()
+
+
+class ConsumerPredicateTests(unittest.TestCase):
+    def test_requests_skip_only_when_fresh_evidence_exists(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp) / "repo"
+            repo.mkdir()
+            candidate = _make_repo(repo)
+            with mock.patch.object(
+                work_bridge, "load_fresh_full_suite_evidence", return_value=object()
+            ) as loader:
+                self.assertTrue(
+                    work_bridge._candidate_skip_tests_request(
+                        worktree=repo, candidate=candidate, now=time.time
+                    )
+                )
+                tree = subprocess.run(
+                    ["git", "rev-parse", f"{candidate}^{{tree}}"],
+                    cwd=repo, capture_output=True, text=True, check=True,
+                ).stdout.strip().lower()
+                self.assertEqual(loader.call_args.kwargs["tree_hash"], tree)
+            with mock.patch.object(
+                work_bridge, "load_fresh_full_suite_evidence", return_value=None
+            ):
+                self.assertFalse(
+                    work_bridge._candidate_skip_tests_request(
+                        worktree=repo, candidate=candidate, now=time.time
+                    )
+                )
+
+    def test_unreadable_worktree_never_requests_skip(self) -> None:
+        self.assertFalse(
+            work_bridge._candidate_skip_tests_request(
+                worktree=Path("/nonexistent"), candidate="d" * 40, now=time.time
+            )
+        )
+
+
+class ProducerTests(unittest.TestCase):
+    def _job(self, log="/l/x.jsonl"):
+        return {"log_path": log}
+
+    class _Run:
+        workspace_root = None
+
+    def test_red_required_semantics_never_record(self) -> None:
+        """ledger pytest failed（tdd-red 的 RED）不得留下 full-suite evidence。"""
+
+        with mock.patch.object(
+            manager.terminal_contract, "read_gate_ledger",
+            return_value=({"gates": [{"name": "pytest", "exit_code": 1, "status": "failed"}]}, "d"),
+        ), mock.patch.object(manager.preflight, "record_external_full_suite_evidence") as rec:
+            manager._record_candidate_full_suite_evidence(
+                self._job(), run=self._Run(), candidate="e" * 40
+            )
+        rec.assert_not_called()
+
+    def test_green_ledger_records_candidate_tree(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp) / "repo"
+            repo.mkdir()
+            candidate = _make_repo(repo)
+            run = type("R", (), {"workspace_root": str(repo)})()
+            with mock.patch.object(
+                manager.terminal_contract, "read_gate_ledger",
+                return_value=({"gates": [{"name": "pytest", "exit_code": 0, "status": "passed"}]}, "d"),
+            ), mock.patch.object(
+                manager.gate_ledger, "load_gate_specs",
+                return_value=(type("S", (), {"name": "pytest", "argv": ("python3", "-m", "pytest", "-q")})(),),
+            ), mock.patch.object(
+                manager.preflight, "record_external_full_suite_evidence"
+            ) as rec:
+                manager._record_candidate_full_suite_evidence(
+                    self._job(), run=run, candidate=candidate
+                )
+            rec.assert_called_once()
+            tree = subprocess.run(
+                ["git", "rev-parse", f"{candidate}^{{tree}}"],
+                cwd=repo, capture_output=True, text=True, check=True,
+            ).stdout.strip().lower()
+            self.assertEqual(rec.call_args.kwargs["tree_hash"], tree)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
Fixes #760

## 病因（實機第十七環）
#759 補 pytest 後 preflight tests step 真跑了——在 **manager 環境**紅（第三個 env-red 執行面，#723 第五例）。gate 環境已獨立全綠、CI 又會在 PR 上重驗；`--skip-tests` 的 FullSuiteEvidence 契約早已完整（tree-hash 定址／immutable／age／`run_preflight` 內建驗證），但 producer 零 production caller（verification-28 F2 點名）、consumer 兩個 call site 硬編 `skip_tests=False` ⇒ delivery 結構性 `pr-preflight-blocked`。

## 修法
- **producer**：build 候選採信點（harvest 後），**未反轉**的權威 ledger pytest 實際 passed（tdd-red 的 RED 天然排除）時以 `git rev-parse <candidate>^{tree}` 記 `record_external_full_suite_evidence`（自既有 writer 抽出、格式不變、content-addressed 冪等）；best-effort、失敗不影響採信。
- **consumer**：`_run_exact_candidate_preflight` 兩個 call site 以 `fresh_full_suite_evidence`（存在＋未過期）預判請求 `--skip-tests`；缺席／過期照舊 False。最終驗證仍由 `build_preflight_argv`／`_validate_skip_tests` 既有契約單一把關。

## 驗收
- [x] 單元：external record↔load↔fresh 往返、冪等、過期／缺席回 None；consumer 只在 fresh evidence 時請求 skip、tree hash 正確；producer 綠 ledger 記錄、RED 不記錄
- [x] 全套 pytest：4934 passed（零回歸）

實機驗收（merge＋部署後由 operator 執行、回報於 #760）：resume 後 delivery preflight 過、PR 建立。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XcQLDun91sLCJfJeKoVgjS