### PR TITLE
fix(delivery): pr-preflight evidence 記 backend 輸出尾段（#759）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 本專案遵循 hamanpaul project policy v1.0.17。
 
 ## [Unreleased]
+- **#759：pr-preflight evidence 補 backend stdout/stderr 有界尾段**——失敗原因
+  進 evidence，不再只靠實機重現定位。
 - **#760：`--skip-tests` 的 FullSuiteEvidence 契約接上 production**——gate 綠的
   build 候選在採信點落 tree-hash 定址 evidence，delivery preflight 消費之；
   manager 環境不再第三跑全套。tdd-red 的 RED 天然排除、記錄失敗不影響採信。

--- a/changelog.d/759-preflight-evidence-output.md
+++ b/changelog.d/759-preflight-evidence-output.md
@@ -1,0 +1,7 @@
+# 759-preflight-evidence-output
+
+- **`#759` pr-preflight evidence 記錄 backend 逐字輸出（有界尾段）**——「只記
+  returncode」讓每一次 preflight 失敗都要靠實機重現才能定位（0820 delivery 首走
+  連三環皆如此：venv 缺 pytest、manager env 的 env-red、MDWE×node）。policy 與
+  ci_parity 各補 `stdout_tail`／`stderr_tail`（各 2000 字、保尾段——short summary
+  在尾巴，與 gate ledger detail 同向）。

--- a/paulsha_cortex/coordinator/work_bridge.py
+++ b/paulsha_cortex/coordinator/work_bridge.py
@@ -667,6 +667,11 @@ def _preflight_result_evidence(
         "policy": {
             "argv": list(preflight.policy.argv),
             "returncode": preflight.policy.returncode,
+            # #759：失敗的逐字原因必須在 evidence 裡——「只記 returncode」讓每一次
+            # preflight 失敗都要靠實機重現才能定位（本日三環皆如此）。有界尾段，
+            # short summary 在尾巴（與 gate ledger detail 同向）。
+            "stdout_tail": str(preflight.policy.stdout or "")[-2000:],
+            "stderr_tail": str(preflight.policy.stderr or "")[-2000:],
         },
         "ci_parity": (
             None
@@ -674,6 +679,8 @@ def _preflight_result_evidence(
             else {
                 "argv": list(preflight.ci_parity.argv),
                 "returncode": preflight.ci_parity.returncode,
+                "stdout_tail": str(preflight.ci_parity.stdout or "")[-2000:],
+                "stderr_tail": str(preflight.ci_parity.stderr or "")[-2000:],
             }
         ),
     }


### PR DESCRIPTION
Fixes #759

## 病因
pr-preflight evidence 只記 argv+returncode——0820 delivery 首走的三層失敗（venv 缺 pytest／manager env 的 env-red／MDWE×node）每一層都要靠實機重現才能定位。

## 修法
`_preflight_result_evidence` 的 policy 與 ci_parity 各補 `stdout_tail`／`stderr_tail`（各 2000 字、保尾段——short summary 在尾巴，與 gate ledger detail 同向）。

（#759 的另兩項：部署 venv 補 pytest 已操作性完成（pipx inject＋重部署帶入）；preflight env PATH 單一導出評估另行處理。）

## 驗收
- [x] 相關子集 207 passed；全套 4934 passed（零回歸）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XcQLDun91sLCJfJeKoVgjS