### PR TITLE
fix(coordinator): advance 選擇以 claim era 過濾，authority restart 後不再綁定炸裂（#765）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 本專案遵循 hamanpaul project policy v1.0.17。
 
 ## [Unreleased]
+- **#765（部分）：advance 的 terminal-job 選擇以 claim era 過濾**——authority
+  restart 後前代 job 不再造成每 tick 綁定炸裂，新 era 正常重新派工。
 - **#759：pr-preflight evidence 補 backend stdout/stderr 有界尾段**——失敗原因
   進 evidence，不再只靠實機重現定位。
 - **#760：`--skip-tests` 的 FullSuiteEvidence 契約接上 production**——gate 綠的

--- a/changelog.d/765-claim-era-advance.md
+++ b/changelog.d/765-claim-era-advance.md
@@ -1,0 +1,13 @@
+# 765-claim-era-advance
+
+- **`#765`（部分）advance 的 terminal-job 選擇以 claim era 過濾——authority
+  restart 後 run 不再卡死於前代 job 的綁定失配。** #373 的 authority restart
+  （operator link／PR 建立等 authority 前進）重算 claim_key 並把 verify/review
+  打回 pending，語意是「在新 era 下重驗」；但 resume 的 job 選擇無 era 條件，
+  前代 terminal job 被撿起 → `_job_for_workflow_card` 的 claim_key 綁定必炸且
+  每 tick 重炸（實機：`work link openspec` 觸發 restart 後 run 永久卡
+  `workflow job binding mismatch`）。修法：選擇條件加
+  `workflow_claim_key == run.claim_key`；era 不符的 job 成為前代稽核列，
+  `dispatch_or_stop` 為新 era 重新派工。派工端 matching（instance 編號唯一性）
+  刻意維持全 era。#765 其餘（openspec-propose 回寫 authority 的 intake 側）
+  另行處理。

--- a/paulsha_cortex/coordinator/manager.py
+++ b/paulsha_cortex/coordinator/manager.py
@@ -10306,6 +10306,14 @@ def resume_workflow_run(
         if job.get("workflow_run_id") == run.run_id
         and job.get("workflow_card") == step.card
         and job.get("workflow_phase") == step.phase
+        # #765：advance 只認**本 claim era** 的 terminal job。authority restart
+        # （#373：operator link／PR 建立等 authority 前進）會重算 claim_key 並把
+        # verify/review 打回 pending——設計語意是「在新 era 下重驗」；前代 era 的
+        # terminal job 若仍被撿起，`_job_for_workflow_card` 的 claim_key 綁定必炸，
+        # 而且每 tick 重炸（#373 docstring 記載的那個永動迴圈的另一半）。era 不符
+        # 的 job 是前代稽核列，不是本 era 的候選——跳過之後 `dispatch_or_stop`
+        # 會為新 era 重新派工。
+        and job.get("workflow_claim_key") == run.claim_key
         and (
             step.phase not in {"verify", "review"}
             or job.get("subject_head") == run.candidate_head

--- a/tests/test_claim_era_advance_765.py
+++ b/tests/test_claim_era_advance_765.py
@@ -1,0 +1,39 @@
+"""#765：advance 的 terminal-job 選擇必須以 claim era 過濾。
+
+authority restart（#373）重算 claim_key 並把 verify/review 打回 pending——語意是
+「在新 era 下重驗」。前代 era 的 terminal job 若仍被 advance 撿起，
+`_job_for_workflow_card` 的 claim_key 綁定必炸且每 tick 重炸（實機：operator
+`work link openspec` 觸發 restart 後 run 卡死於
+`workflow job binding mismatch: workflow_claim_key`，resume 永遠到不了重新派工）。
+"""
+
+from __future__ import annotations
+
+import inspect
+import unittest
+
+from paulsha_cortex.coordinator import manager
+
+
+class ClaimEraAdvanceTests(unittest.TestCase):
+    def test_advance_selection_filters_by_current_claim_key(self) -> None:
+        """resume 的 jobs 選擇必須含 claim era 條件（source-pin：與 dispatch 端的
+        matching 不同——那裡靠全 era 保 instance 編號唯一性，不得過濾）。"""
+
+        source = inspect.getsource(manager.resume_workflow_run)
+        anchor = source.index("job = jobs[-1] if jobs else dispatch_or_stop")
+        selection = source[:anchor]
+        selection = selection[selection.rindex("jobs = ["):]
+        self.assertIn('job.get("workflow_claim_key") == run.claim_key', selection)
+
+    def test_dispatch_matching_stays_era_agnostic(self) -> None:
+        """派工端 matching（instance 編號＋retry-context）維持全 era。"""
+
+        source = inspect.getsource(manager._dispatch_workflow_card)
+        anchor = source.index("matching = [")
+        block = source[anchor : anchor + 600]
+        self.assertNotIn("workflow_claim_key", block)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
Fixes #765

## 病因（實機）
#373 的 authority restart（operator `work link openspec` 等 authority 前進）重算 claim_key、verify/review 打回 pending——語意是「新 era 重驗」。但 `resume_workflow_run` 的 terminal-job 選擇無 era 條件：前代 job（subject_head 仍等於 candidate）被撿起 → `_job_for_workflow_card` 的 claim_key 綁定必炸、每 tick 重炸，run 永久卡 `workflow job binding mismatch`，重新派工永遠到不了——#373 docstring 記的那個永動迴圈的另一半。

## 修法
選擇條件加 `workflow_claim_key == run.claim_key`；era 不符的 job 成為前代稽核列（不動、不刪），`dispatch_or_stop` 為新 era 重新派工。**派工端 matching 刻意維持全 era**（instance 編號唯一性與 retry-context 依賴它，測試釘住）。

#765 其餘（openspec-propose 產出 change 時回寫 authority 的 intake 側修法）另行處理。

## 驗收
- [x] source-pin 測試×2（advance 有 era 條件、dispatch matching 無）
- [x] 全套 pytest：4936 passed（零回歸）

實機驗收（merge＋部署後由 operator 執行、回報於 #765）：resume 觸發新 era 的 verification 重派、run 走完 ship。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XcQLDun91sLCJfJeKoVgjS