### PR TITLE
chore(daemon): _log_error 首次出現附 traceback（#765 補遺）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 本專案遵循 hamanpaul project policy v1.0.17。
 
 ## [Unreleased]
+- **#765 補遺：daemon `_log_error` 首次出現附完整 traceback**（重複維持抑制）。
 - **#765（部分）：advance 的 terminal-job 選擇以 claim era 過濾**——authority
   restart 後前代 job 不再造成每 tick 綁定炸裂，新 era 正常重新派工。
 - **#759：pr-preflight evidence 補 backend stdout/stderr 有界尾段**——失敗原因

--- a/changelog.d/765-daemon-traceback.md
+++ b/changelog.d/765-daemon-traceback.md
@@ -1,0 +1,5 @@
+# 765-daemon-traceback
+
+- **`#765` 補遺（#511 家族）：`_log_error` 於 signature 首次出現時附完整
+  traceback。** 「只有 str(exc)」讓每個新失敗面都要靠實機逐層猜（0820 實測
+  claim_key 綁定失配的 raiser 路徑追蹤一小時未果）。重複出現維持既有抑制。

--- a/paulsha_cortex/coordinator/manager_daemon.py
+++ b/paulsha_cortex/coordinator/manager_daemon.py
@@ -8,6 +8,7 @@ import os
 import re
 import signal
 import sys
+import traceback
 import tempfile
 import time
 from collections import OrderedDict
@@ -1636,6 +1637,15 @@ def _log_error(exc: Exception, *, context: dict[str, Any] | None = None) -> None
             _LOG_ERROR_DEDUP_STATE.popitem(last=False)  # 淘汰最久未用的 slot
         _LOG_ERROR_DEDUP_STATE[signature] = {"repeat_count": 0}
         print(f"{timestamp} manager_daemon error: {signature}", file=sys.stderr)
+        # #765 補遺（#511 家族）：signature 首次出現時附完整 traceback——「只有
+        # str(exc)」讓每一個新失敗面都要靠實機逐層猜（0820 實測 claim_key 綁定
+        # 失配追了一小時仍不知 raiser 路徑）。重複出現維持既有抑制，不重印。
+        print(
+            "".join(
+                traceback.format_exception(type(exc), exc, exc.__traceback__)
+            ).rstrip(),
+            file=sys.stderr,
+        )
         return
 
     _LOG_ERROR_DEDUP_STATE.move_to_end(signature)  # 標記為最近使用，維持 LRU 順序

--- a/tests/test_manager_daemon_tick_backoff.py
+++ b/tests/test_manager_daemon_tick_backoff.py
@@ -243,7 +243,8 @@ def test_log_error_deduplicates_repeated_signature_with_periodic_summary(capsys)
     output_lines = [line for line in capsys.readouterr().err.splitlines() if line.strip()]
 
     interval = manager_daemon.LOG_ERROR_SUMMARY_INTERVAL
-    expected_lines = 1 + (total_calls - 1) // interval
+    # #765 補遺：首次出現另附 traceback（未 raise 的例外＝1 行例外文字）。
+    expected_lines = 2 + (total_calls - 1) // interval
     assert len(output_lines) == expected_lines
     assert len(output_lines) < total_calls
     # First occurrence is always printed in full, never suppressed.
@@ -290,7 +291,8 @@ def test_log_error_deduplicates_interleaved_signatures_independently(capsys):
     assert len(output_lines) < total_calls
 
     interval = manager_daemon.LOG_ERROR_SUMMARY_INTERVAL
-    expected_lines_per_signature = 1 + (calls_per_signature - 1) // interval
+    # #765 補遺：首次出現另附 traceback 1 行。
+    expected_lines_per_signature = 2 + (calls_per_signature - 1) // interval
     for exc in signatures:
         marker = str(exc)
         sig_lines = [line for line in output_lines if marker in line]


### PR DESCRIPTION
Fixes #765

## 內容
signature 首次出現時附完整 traceback（未 raise 例外＝1 行）；重複出現維持 #249/#374 的抑制。實機動機：claim_key 綁定失配的 raiser 路徑僅憑 str(exc) 追蹤一小時未果。

- [x] daemon 測試 8 passed（行數期望隨 traceback +1 更新）
- [x] 全套 pytest 綠

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XcQLDun91sLCJfJeKoVgjS