### PR TITLE
chore(coordinator): binding mismatch 錯誤帶 job_id 與兩側值（#765 補遺）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 本專案遵循 hamanpaul project policy v1.0.17。
 
 ## [Unreleased]
+- **#765 補遺：binding mismatch 錯誤帶 job_id 與兩側值。**
 - **#765 補遺：retry-card 的 target-jobs 亦以 claim era 過濾**（舊 era evidence
   不再擋死新 era 重派）。
 - **#765 補遺：daemon `_log_error` 首次出現附完整 traceback**（重複維持抑制）。

--- a/changelog.d/765-binding-diagnostics.md
+++ b/changelog.d/765-binding-diagnostics.md
@@ -1,0 +1,4 @@
+# 765-binding-diagnostics
+
+- **`#765` 補遺：workflow job binding mismatch 錯誤帶上 job_id 與 expected/actual
+  值**——「只有欄位名」讓 era 失配只能實機逐層猜。值皆為系統雜湊／識別碼。

--- a/paulsha_cortex/coordinator/manager.py
+++ b/paulsha_cortex/coordinator/manager.py
@@ -3229,7 +3229,12 @@ def _job_for_workflow_card(
     }
     for field, value in expected.items():
         if job.get(field) != value:
-            raise ValueError(f"workflow job binding mismatch: {field}")
+            # #765 補遺：帶上 job 與兩側值——「只有欄位名」的版本讓 era 失配只能
+            # 實機逐層猜（0820-21 實測兩小時）。值皆為系統雜湊／識別碼，非敏感內容。
+            raise ValueError(
+                f"workflow job binding mismatch: {field} "
+                f"(job={job.get('job_id')!r} expected={value!r} actual={job.get(field)!r})"
+            )
     if job.get("status") != "exited" or job.get("exit_code") != 0:
         raise ValueError("workflow job has no successful terminal result")
     executor = job.get("executor")


### PR DESCRIPTION
Fixes #765

診斷補遺：era 失配的 raiser 僅報欄位名，實機定位耗時兩小時。帶上 job_id 與 expected/actual（皆系統雜湊／識別碼）。

- [x] 全套 pytest 綠

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XcQLDun91sLCJfJeKoVgjS