### PR TITLE
fix(delivery): journal authority rebase 連 claim_key 一起帶（#765 補遺）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 本專案遵循 hamanpaul project policy v1.0.17。
 
 ## [Unreleased]
+- **#765 補遺：delivery journal rebase 連 claim_key 一起帶**（era 雙店面不一致修復）。
 - **#765 補遺：binding mismatch 錯誤帶 job_id 與兩側值。**
 - **#765 補遺：retry-card 的 target-jobs 亦以 claim era 過濾**（舊 era evidence
   不再擋死新 era 重派）。

--- a/changelog.d/765-journal-claim-rebase.md
+++ b/changelog.d/765-journal-claim-rebase.md
@@ -1,0 +1,6 @@
+# 765-journal-claim-rebase
+
+- **`#765` 補遺：delivery journal 的 authority rebase 連 `claim_key` 一起帶。**
+  journal 停在建列時代的 claim 使 delivery/resume 的 canonical 視圖與 run row
+  分屬兩個 era——下游 job 選擇撿到舊 era terminal、binding 每 tick 必炸（實機：
+  run row 5a1615 vs journal 5929，resume 永遠 mismatch）。

--- a/paulsha_cortex/coordinator/work_bridge.py
+++ b/paulsha_cortex/coordinator/work_bridge.py
@@ -1085,6 +1085,10 @@ def _rebase_delivery_journal_authority(
             "snapshot_hash": authority.snapshot_hash,
             "provider_revision": authority.github_provider_revision,
             "authority_digest": work_authority_digest(authority),
+            # #765：claim_key 必須跟著 run 的現值走——journal 停在建列時代的 claim
+            # 會讓 delivery/resume 的 canonical 視圖與 run row 分屬兩個 era，
+            # 下游 job 選擇撿到舊 era terminal、binding 每 tick 必炸。
+            "claim_key": run.claim_key,
             "mapped_issues": list(authority.mapped_issues),
             "mapped_prs": list(authority.mapped_prs),
             "mapped_openspec": list(authority.mapped_openspec),


### PR DESCRIPTION
Fixes #765

## 病因（實機，enriched diagnostics #769 抓到的雙店面）
run row claim=5a1615、delivery journal row claim=5929（建列時代）——`_rebase_delivery_journal_authority` 重寫 digest/mappings 卻漏 claim_key。canonical 視圖與 run row 分屬兩 era，resume 的 job 選擇撿到舊 era 的 verification-38，binding 每 tick 必炸（job='verification-38' expected=5a…actual=5929…）。

## 修法
rebase row 補 `claim_key: run.claim_key`。

- [x] delivery/journal 相關 144 passed；全套 4937 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XcQLDun91sLCJfJeKoVgjS