### PR TITLE
fix(coordinator): recovery 選擇器以 claim era 過濾（#765 補遺，最後一個 era-blind）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 本專案遵循 hamanpaul project policy v1.0.17。
 
 ## [Unreleased]
+- **#765 補遺：recovery 選擇器（最後一個 era-blind）以 claim era 過濾。**
 - **#765 補遺：delivery journal rebase 連 claim_key 一起帶**（era 雙店面不一致修復）。
 - **#765 補遺：binding mismatch 錯誤帶 job_id 與兩側值。**
 - **#765 補遺：retry-card 的 target-jobs 亦以 claim era 過濾**（舊 era evidence

--- a/changelog.d/765-recovery-era.md
+++ b/changelog.d/765-recovery-era.md
@@ -1,0 +1,6 @@
+# 765-recovery-era
+
+- **`#765` 補遺：recovery 選擇器（最後一個 era-blind）同樣以 claim era 過濾。**
+  operator_resume 的 recovery 分支把前代 era 的已綁 evidence job 抓回重放，
+  advance 的 binding 對現 era 必炸——實機 verification-38 每次 resume 被重放，
+  正是 enriched diagnostics 抓到的確定性簽名的出處。

--- a/paulsha_cortex/coordinator/manager.py
+++ b/paulsha_cortex/coordinator/manager.py
@@ -10059,6 +10059,11 @@ def resume_workflow_run(
                 if job.get("workflow_run_id") == run.run_id
                 and job.get("workflow_card") == recovery_step.card
                 and job.get("workflow_phase") == recovery_step.phase
+                # #765：recovery 同樣只認本 claim era（None 容忍比照 #766/#768）。
+                # 這是最後一個 era-blind 選擇器：operator_resume 的 recovery 分支
+                # 會把前代 era 的已綁 evidence job 抓回重放，advance 的 binding
+                # 對現 era 必炸（實機：verification-38 每次 resume 被重放）。
+                and job.get("workflow_claim_key") in (None, run.claim_key)
             ]
             latest_recovery = recovery_jobs[-1] if recovery_jobs else None
             if (

--- a/tests/test_claim_era_advance_765.py
+++ b/tests/test_claim_era_advance_765.py
@@ -61,6 +61,13 @@ class RetryCardEraTests(unittest.TestCase):
         )
         self.assertEqual(rows, [current])
 
+class RecoveryEraTests(unittest.TestCase):
+    def test_recovery_selection_filters_by_claim_era(self) -> None:
+        source = inspect.getsource(manager.resume_workflow_run)
+        anchor = source.index("recovery_jobs = [")
+        block = source[anchor : anchor + 900]
+        self.assertIn('job.get("workflow_claim_key") in (None, run.claim_key)', block)
+
 
 if __name__ == "__main__":  # pragma: no cover
     unittest.main()


### PR DESCRIPTION
Fixes #765

## 病因（#769 diagnostics 鎖定）
每次 resume 確定性 `binding mismatch (job=verification-38, expected=5a…, actual=5929…)`——#766/#768 已濾 advance 與 retry-card，但 **operator_resume 的 recovery 分支**（`recovery_jobs`）era-blind：把前代 era 的已綁 evidence job（-38）抓回重放，advance 對現 era binding 必炸。

## 修法
recovery_jobs 選擇加 `workflow_claim_key in (None, run.claim_key)`（與 #766/#768 同一判準、None 容忍）。

- [x] source-pin 測試＋全套 4938 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XcQLDun91sLCJfJeKoVgjS