### PR TITLE
fix(coordinator): dispatch reuse/retry 判定走同 era reusable 子集（#765 補遺，第五出口）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 本專案遵循 hamanpaul project policy v1.0.17。
 
 ## [Unreleased]
+- **#765 補遺：dispatch reuse／retry 判定走同 era `reusable` 子集**（第五個出口，binding 必炸的真正回傳點）。
 - **#765 補遺：recovery 選擇器（最後一個 era-blind）以 claim era 過濾。**
 - **#765 補遺：delivery journal rebase 連 claim_key 一起帶**（era 雙店面不一致修復）。
 - **#765 補遺：binding mismatch 錯誤帶 job_id 與兩側值。**

--- a/changelog.d/765-dispatch-reuse-era.md
+++ b/changelog.d/765-dispatch-reuse-era.md
@@ -1,0 +1,8 @@
+# 765-dispatch-reuse-era
+
+- **`#765` 補遺：dispatch 的 reuse／retry 判定改走同 era 的 `reusable` 子集——
+  第五個（真正的）出口。** `_dispatch_workflow_card` 的 `if matching: return
+  matching[-1]` reuse 決策 era-blind，authority restart 後把前代 era 的 terminal
+  （verification-38）回傳供 harvest，advance 的 binding 對現 era 必炸——resume 與
+  retry-card 兩處過濾後仍炸的最後出口（traceback 實證此路徑）。`matching` 本身
+  維持全 era（retry-context／sandbox 清理需要完整歷史）。

--- a/paulsha_cortex/coordinator/manager.py
+++ b/paulsha_cortex/coordinator/manager.py
@@ -9265,31 +9265,42 @@ def _dispatch_workflow_card(
             or job.get("subject_head") == run.candidate_head
         )
     ]
+    # #765：reuse／retry 判定只認**本 claim era** 的 job（None 容忍比照 #766/#768）。
+    # `matching` 本身維持全 era——retry-context 與 sandbox 清理需要完整歷史；但
+    # 「這張卡已有 job、直接回傳供 harvest」的 reuse 決策若拿到前代 era 的
+    # terminal（authority restart 之後），advance 的 binding 對現 era 必炸且每
+    # tick 重炸（實機：verification-38 經此路徑被無限重放，era 過濾了 resume 與
+    # retry-card 兩處後仍炸的最後出口）。
+    reusable = [
+        job
+        for job in matching
+        if job.get("workflow_claim_key") in (None, run.claim_key)
+    ]
     retryable_latest = bool(
-        matching
+        reusable
         and (
             (
                 retry_failed
                 and (
-                    _is_stale_terminalized_failed_job(matching[-1])
-                    or _retryable_nonpassing_workflow_terminal(matching[-1])
-                    or _malformed_workflow_card_terminal(matching[-1])
+                    _is_stale_terminalized_failed_job(reusable[-1])
+                    or _retryable_nonpassing_workflow_terminal(reusable[-1])
+                    or _malformed_workflow_card_terminal(reusable[-1])
                     or _is_rejected_workflow_review_evidence(
-                        matching[-1],
+                        reusable[-1],
                         run=run,
                         coordinator_root=coordinator_root,
                     )
                 )
             )
             or (
-                operator_recovery_job_id == matching[-1].get("job_id")
+                operator_recovery_job_id == reusable[-1].get("job_id")
                 and (
                     _is_exact_legacy_agy_recovery(
-                        matching[-1], run=run, step=step, identities=identities
+                        reusable[-1], run=run, step=step, identities=identities
                     )
                     or _is_exact_reviewer_terminal_recovery(
                         registry,
-                        matching[-1],
+                        reusable[-1],
                         run=run,
                         step=step,
                         identities=identities,
@@ -9297,11 +9308,11 @@ def _dispatch_workflow_card(
                     )
                 )
             )
-            or (force_new_card and matching[-1].get("status") in TERMINAL_STATUSES)
+            or (force_new_card and reusable[-1].get("status") in TERMINAL_STATUSES)
         )
     )
-    if matching and not retryable_latest:
-        return matching[-1]
+    if reusable and not retryable_latest:
+        return reusable[-1]
     # #569：reviewer 卡的強制重派要先回收被取代 job 的 sandbox。sandbox 目錄名是
     # `sha256(run_id:card:candidate)`（見 `_create_reviewer_sandbox`），重派同一
     # 張卡＋同一個 candidate 必然撞上「stale reviewer sandbox requires

--- a/tests/test_claim_era_advance_765.py
+++ b/tests/test_claim_era_advance_765.py
@@ -27,12 +27,18 @@ class ClaimEraAdvanceTests(unittest.TestCase):
         self.assertIn('job.get("workflow_claim_key") in (None, run.claim_key)', selection)
 
     def test_dispatch_matching_stays_era_agnostic(self) -> None:
-        """派工端 matching（instance 編號＋retry-context）維持全 era。"""
+        """派工端 matching 本身維持全 era（retry-context／sandbox 清理需要完整歷史），
+        但 reuse／retry 判定走同 era 的 `reusable` 子集（#765 第五出口）。"""
 
         source = inspect.getsource(manager._dispatch_workflow_card)
         anchor = source.index("matching = [")
-        block = source[anchor : anchor + 600]
-        self.assertNotIn("workflow_claim_key", block)
+        list_block = source[anchor : source.index("]", anchor) + 1]
+        self.assertNotIn("workflow_claim_key", list_block)
+        reuse_anchor = source.index("reusable = [")
+        reuse_block = source[reuse_anchor : source.index("]", reuse_anchor) + 1]
+        self.assertIn('workflow_claim_key") in (None, run.claim_key)', reuse_block)
+        self.assertIn("if reusable and not retryable_latest:", source)
+        self.assertIn("return reusable[-1]", source)
 
 class RetryCardEraTests(unittest.TestCase):
     def test_retry_card_target_jobs_filter_by_claim_era(self) -> None:


### PR DESCRIPTION
Fixes #765

## 病因（traceback 實證）
`_dispatch_workflow_card` 的 reuse 決策（`if matching and not retryable_latest: return matching[-1]`）era-blind——resume 的選擇（#766）與 retry-card（#768）、recovery（#771）都過濾後，前代 era 的 verification-38 仍經 `dispatch_or_stop → dispatch → reuse 回傳` 進入 terminalize/advance，binding 對現 era 必炸且每 tick 重炸。

## 修法
reuse／retry 判定改走 `reusable = [j for j in matching if claim era 相符（None 容忍）]`；`matching` 本身維持全 era（retry-context 與 sandbox 清理需要完整歷史，測試釘住兩者分工）。

- [x] source-pin 測試更新＋全套 4938 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XcQLDun91sLCJfJeKoVgjS