### PR TITLE
fix(registry): retry-card reset evidence 守衛以 claim era 定錨（#765 補遺）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 本專案遵循 hamanpaul project policy v1.0.17。
 
 ## [Unreleased]
+- **#765 補遺：registry reset evidence 守衛以 claim era 定錨。**
 - **#765 補遺：dispatch reuse／retry 判定走同 era `reusable` 子集**（第五個出口，binding 必炸的真正回傳點）。
 - **#765 補遺：recovery 選擇器（最後一個 era-blind）以 claim era 過濾。**
 - **#765 補遺：delivery journal rebase 連 claim_key 一起帶**（era 雙店面不一致修復）。

--- a/changelog.d/765-reset-evidence-era.md
+++ b/changelog.d/765-reset-evidence-era.md
@@ -1,0 +1,5 @@
+# 765-reset-evidence-era
+
+- **`#765` 補遺：registry 的 retry-card reset evidence 守衛同樣以 claim era 定錨。**
+  前代 era 的已綁 evidence 拒絕新 era 重派＝同一個 catch-22（實機：era 修復鏈
+  最後一關，credentials 重放後 retry-card 被 -38 舊 evidence 擋）。

--- a/paulsha_cortex/coordinator/registry.py
+++ b/paulsha_cortex/coordinator/registry.py
@@ -2104,6 +2104,10 @@ class JobRegistry:
             # 的是「這張卡對**現在這個 candidate** 已經有被採信的結論」，而不是
             # 上一代 candidate 留下的歷史紀錄——後者拒絕等於再造一次 catch-22。
             and (phase == "build" or job.get("subject_head") == current.candidate_head)
+            # #765：與 candidate 定錨同一個道理再加一層——claim era 定錨（None
+            # 容忍比照 #766/#768/#772）。authority restart 後前代 era 的已綁
+            # evidence 是歷史稽核列；拿它拒絕新 era 的重派＝同一個 catch-22。
+            and job.get("workflow_claim_key") in (None, current.claim_key)
             and job.get("workflow_evidence") is not None
             for job in self._jobs
         ):


### PR DESCRIPTION
Fixes #765

registry 的 `_manager_reset_workflow_for_retry_card` evidence 守衛缺 era 定錨——前代 era 的已綁 evidence（verification-38）拒絕新 era 重派（`retry-card reset refuses a card with accepted evidence`）。加 `workflow_claim_key in (None, current.claim_key)`（與 candidate 定錨並列、比照 #766/#768/#772）。

- [x] 相關 51 passed＋全套 4938 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XcQLDun91sLCJfJeKoVgjS