### PR TITLE
fix(coordinator): review 對 builder job 綁定改跨 era，落實 #216 AC5（#765 補遺）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 本專案遵循 hamanpaul project policy v1.0.17。
 
 ## [Unreleased]
+- **#765 補遺：review 對 builder job 的綁定改跨 era（#216 AC5 落實）**——build 產物不再因 authority 前進成孤兒。
 - **#765 補遺：registry reset evidence 守衛以 claim era 定錨。**
 - **#765 補遺：dispatch reuse／retry 判定走同 era `reusable` 子集**（第五個出口，binding 必炸的真正回傳點）。
 - **#765 補遺：recovery 選擇器（最後一個 era-blind）以 claim era 過濾。**

--- a/changelog.d/765-builder-binding-era.md
+++ b/changelog.d/765-builder-binding-era.md
@@ -1,0 +1,10 @@
+# 765-builder-binding-era
+
+- **`#765` 補遺：review 採信對 builder job 的綁定改為跨 era——#216 AC5 的語意
+  落實。** authority restart 只 invalidate verify/review、build 產物的 Candidate
+  跨 era 保留；builder job 因此合法地屬於較早 era。原本的 claim_key／
+  source_revision 等值檢查讓每一次 authority 前進（PR 建立、openspec link）把
+  已採信的 build 產物變成孤兒（實機：`review evaluation builder binding
+  mismatch: workflow_claim_key`）。真正的綁定＝run_id＋repo＋
+  `subject_head == candidate`（candidate 由 harvest fast-forward 與 gate ledger
+  錨定）；mismatch 錯誤同時補上 job/兩側值。

--- a/paulsha_cortex/coordinator/manager.py
+++ b/paulsha_cortex/coordinator/manager.py
@@ -3793,9 +3793,7 @@ def _review_builder_job_binding(
     )
     expected = {
         "workflow_run_id": run.run_id,
-        "workflow_claim_key": run.claim_key,
         "workflow_repo": run.repo,
-        "source_revision": run.source_revision,
         "subject_head": candidate,
         "status": "exited",
         "exit_code": 0,
@@ -3808,7 +3806,17 @@ def _review_builder_job_binding(
     )
     for field, value in expected.items():
         if builder.get(field) != value:
-            raise ValueError(f"review evaluation builder binding mismatch: {field}")
+            raise ValueError(
+                f"review evaluation builder binding mismatch: {field} "
+                f"(job={builder.get('job_id')!r} expected={value!r} actual={builder.get(field)!r})"
+            )
+    # #765：builder 引用**刻意不驗 claim era／source_revision 等值**——#216 AC5
+    # 明言 authority restart 只 invalidate verify/review、build 產物的 Candidate
+    # 跨 era 保留；builder job 因此**合法地**屬於較早的 era。真正把 builder 綁進
+    # 本 run 的是 run_id＋repo＋`subject_head == candidate`（candidate 本身由
+    # harvest 的 fast-forward 與 gate ledger 錨定）。era 等值檢查在此只會讓每一次
+    # authority 前進（PR 建立、openspec link）把已採信的 build 產物變成孤兒。
+
     card = builder.get("workflow_card")
     if not isinstance(card, str) or not any(
         step.card == card


### PR DESCRIPTION
Fixes #765

## 病因（實機第七處 era-blind）
review 採信驗 evaluation 引用的 builder job 時要求 `workflow_claim_key`／`source_revision` 與 run 現值等值——但 #216 AC5 明言 authority restart 只 invalidate verify/review、build 產物跨 era 保留；builder job **合法地**屬於較早 era。每次 authority 前進（PR 建立、openspec link）都把已採信 build 變孤兒（`review evaluation builder binding mismatch: workflow_claim_key`）。

## 修法
綁定改為 run_id＋repo＋`subject_head == candidate`（candidate 由 harvest fast-forward＋gate ledger 錨定）＋phase/persona/exit 檢查不變；claim/source_revision 等值移除；mismatch 錯誤帶 job/兩側值。

- [x] review/foreign 相關 420 passed＋全套 4938 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XcQLDun91sLCJfJeKoVgjS