### PR TITLE
chore(openspec): 回寫 fix-read-repo-tier-fail-closed change 至 main（#765 intake 回寫）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 本專案遵循 hamanpaul project policy v1.0.17。
 
 ## [Unreleased]
+- **#765（intake 回寫）：`fix-read-repo-tier-fail-closed` openspec change 回寫 main**——monitor 只掃 main，change 僅在 candidate 導致 `mapped_openspec` 恆空、ship 卡 target 計數；檔案與 PR #764 byte-identical。
 - **#765 補遺：review 對 builder job 的綁定改跨 era（#216 AC5 落實）**——build 產物不再因 authority 前進成孤兒。
 - **#765 補遺：registry reset evidence 守衛以 claim era 定錨。**
 - **#765 補遺：dispatch reuse／retry 判定走同 era `reusable` 子集**（第五個出口，binding 必炸的真正回傳點）。

--- a/changelog.d/openspec-intake-backfill.md
+++ b/changelog.d/openspec-intake-backfill.md
@@ -1,0 +1,1 @@
+回寫 `fix-read-repo-tier-fail-closed` 的 openspec change 至 main（#765 intake 側缺口的 operator 回寫）：monitor 只掃 main 樹，change 僅存在 candidate 分支導致 authority `mapped_openspec` 恆空、ship 卡 `multiple-delivery-targets-unsupported`。檔案與 candidate（PR #764）byte-identical，merge 不衝突。

--- a/openspec/changes/fix-read-repo-tier-fail-closed/tasks.md
+++ b/openspec/changes/fix-read-repo-tier-fail-closed/tasks.md
@@ -1,0 +1,12 @@
+# Tasks
+
+- [x] 新增 canonical `.project-policy.yml` 缺少 `tier` 時的 RED regression test，要求診斷列出 manifest 路徑與允許值。
+- [x] 前置驗證：foreign review 為 required 的流程，在 builder dispatch 前檢出缺失／非法 `tier`。
+- [x] 診斷訊息在所有缺失／非法 `tier` 情境一致且可操作。
+- [x] tier 前置驗證通過時不建立 `needs_human` 狀態，候選仍可進入 builder dispatch（archive 前置範圍）。
+- [x] 測試涵蓋無 manifest、canonical 缺 `tier`、非法 `tier`、合法 `shareable`。
+- [x] 文件化 canonical manifest 缺 `tier` 的 fail-closed 語意。
+- [x] slice lane（`run_tick`／`retry-build`）在 builder dispatch 前共用 tier 前置驗證，避免晚期 foreign review 設定錯誤。
+- [x] deck、doctor、delivery preflight 與 claim readiness 共用同一個 tier resolver，於各自權威前置面 fail-closed。
+- [x] production claim、direct slice dispatch 與 workflow preflight 均實際接入 tier/readiness checkpoint；repo-root resolution error 保留原分類。
+- [x] 文件同步涵蓋 canonical 與 legacy manifest 的缺 tier 語意；所有變更仍限於 archive 前置範圍。


### PR DESCRIPTION
關聯 #765（引用不關閉：intake 側自動回寫仍為 follow-up，本 PR 為 operator 手動回寫，故上 policy-exempt:issue-link）。

## 病因
run `workflow-85114100c37cc99e89b1` 的 ship 卡 `multiple-delivery-targets-unsupported`：builder 把 openspec change 寫進 candidate（PR #764），但 monitor 只掃 main 樹——`openspec/changes/fix-read-repo-tier-fail-closed/` 不在 main 上，authority 的 `mapped_openspec` 恆為空，ship 的 targets 檢查（prs=1／openspec=1／todo=1）永遠不成立。work-items.yaml 的 openspec link 已在，缺的是 main 上的 change 實體。

## 修法（operator 回寫）
自 candidate 分支取 `tasks.md` **byte-identical**（blob sha `8138024b`）落至 main 同路徑——PR #764 之後 merge 同路徑同內容不衝突；monitor 掃到後 link 依 ref 名稱對上（`_link_matches_source`），`mapped_openspec=1`，ship 可續。

- [x] 檔案與 candidate blob sha 一致（`8138024b02ea`）
- [x] changelog fragment 與 [Unreleased] entry 已補

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XcQLDun91sLCJfJeKoVgjS