### PR TITLE
fix(coordinator): resume 識別容忍 run 自產 openspec 落地，新增 recover-superseded（#765 第八處）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 本專案遵循 hamanpaul project policy v1.0.17。
 
 ## [Unreleased]
+- **#776（#765 第八處）：resume 穩定識別容忍 run 自產 openspec 落地 authority**——不再 supersede 已驗證 run；新增 `work recover-superseded` 撿回被誤作廢的 run（official authority-restart 語意）。
 - **#765（intake 回寫）：`fix-read-repo-tier-fail-closed` openspec change 回寫 main**——monitor 只掃 main，change 僅在 candidate 導致 `mapped_openspec` 恆空、ship 卡 target 計數；檔案與 PR #764 byte-identical。
 - **#765 補遺：review 對 builder job 的綁定改跨 era（#216 AC5 落實）**——build 產物不再因 authority 前進成孤兒。
 - **#765 補遺：registry reset evidence 守衛以 claim era 定錨。**

--- a/changelog.d/recover-superseded-and-openspec-identity.md
+++ b/changelog.d/recover-superseded-and-openspec-identity.md
@@ -1,0 +1,1 @@
+#776（#765 第八處）：resume 穩定識別的 openspec 比對改為相容判定——authority 多出的 refs 皆為 run 的 define/plan 卡 outputs 宣告過的 change 時視為同一份工作，交由 #216 AC5 authority-restart 收尾，不再 supersede 已驗證 run；並新增 bounded verb `work recover-superseded`（exact CAS＋actor/reason 落 evidence），把被識別失誤作廢、candidate 與 PR 俱在的 run 以 official authority-restart 撿回。

--- a/paulsha_cortex/cli.py
+++ b/paulsha_cortex/cli.py
@@ -50,7 +50,7 @@ run 'cortex <command> --help' for command-specific help.
 """
 
 _WORK_HELP = """\
-usage: cortex work <show|gc|link|unlink|intake|start|resume|retry-build|retry-card|retry-verify|retry-review|recover-planning|recover-pre-candidate|recover-repair-commit|regenerate-gates|abandon|retire-delivered|reset-reclaim-budget|refreeze-base|auto|review-attest|ship> ...
+usage: cortex work <show|gc|link|unlink|intake|start|resume|retry-build|retry-card|retry-verify|retry-review|recover-planning|recover-pre-candidate|recover-repair-commit|regenerate-gates|abandon|retire-delivered|recover-superseded|reset-reclaim-budget|refreeze-base|auto|review-attest|ship> ...
 
 work item commands:
   show      從 Monitor 讀取 Work Item 與關聯解釋
@@ -66,6 +66,7 @@ work item commands:
   retry-review  以 exact Candidate CAS 只重跑 foreign review，不重跑 builder
   abandon   以 exact WorkflowRun CAS 將 pre-delivery run 標成 superseded
   retire-delivered  以 exact WorkflowRun CAS 退休交付已在管線外完成、pr_refs 全 terminal（merged/closed）的孤兒 run
+  recover-superseded  以 exact WorkflowRun CAS 撿回被識別失誤 supersede 的已驗證 run（需 candidate＋PR、verify/review phase、同 work 無 ongoing run；動作＝復歸 ongoing＋official authority-restart）
   recover-planning  對 define/needs_human 的 planning 失敗作可恢復重跑
   recover-pre-candidate  對 candidate 產生前的 builder 失敗作可恢復重跑並回收 worktree
   recover-repair-commit  對 repair commit 已存在但缺 terminal evidence 的 build 失敗做具 CAS 的採納恢復

--- a/paulsha_cortex/coordinator/cli.py
+++ b/paulsha_cortex/coordinator/cli.py
@@ -205,6 +205,7 @@ def _build_parser() -> argparse.ArgumentParser:
             "link", "unlink", "start", "resume", "retry-build", "retry-card",
             "retry-verify", "retry-review", "recover-planning", "recover-pre-candidate",
             "recover-repair-commit", "regenerate-gates", "abandon", "retire-delivered",
+            "recover-superseded",
             "reset-reclaim-budget", "refreeze-base", "auto", "ship", "review-attest",
             "intake",
         ],
@@ -220,8 +221,8 @@ def _build_parser() -> argparse.ArgumentParser:
     p_work.add_argument(
         "--expected-run-id",
         help=(
-            "abandon／retire-delivered／regenerate-gates／retry-card／refreeze-base "
-            "使用的 exact WorkflowRun CAS"
+            "abandon／retire-delivered／recover-superseded／regenerate-gates／"
+            "retry-card／refreeze-base 使用的 exact WorkflowRun CAS"
         ),
     )
     p_work.add_argument(
@@ -231,8 +232,8 @@ def _build_parser() -> argparse.ArgumentParser:
     p_work.add_argument(
         "--reason",
         help=(
-            "abandon／retire-delivered／reset-reclaim-budget／refreeze-base "
-            "的單行審計理由（最多 500 字）"
+            "abandon／retire-delivered／recover-superseded／reset-reclaim-budget／"
+            "refreeze-base 的單行審計理由（最多 500 字）"
         ),
     )
     p_work.add_argument(

--- a/paulsha_cortex/coordinator/work_actions.py
+++ b/paulsha_cortex/coordinator/work_actions.py
@@ -1584,7 +1584,7 @@ def _claim_action(
                     f"{authority.repo}#{number}"
                     for number in authority.mapped_issues
                 )
-                and run.openspec_refs == authority.mapped_openspec
+                and _openspec_refs_compatible(run, authority)
             ]
             if len(active) > 1:
                 raise RuntimeError("active workflow identity is ambiguous")
@@ -2656,6 +2656,46 @@ def _validate_abandon_evidence_target(
         raise RuntimeError(f"workflow {label} evidence conflict")
 
 
+def _planning_declared_openspec_changes(run) -> set[str]:
+    """run 的 define/plan 卡 outputs 宣告過的 openspec change 名。
+
+    #776：planning 卡把 ``openspec/changes/<name>/...`` 列在 outputs 裡即代表
+    該 change 是 run 自己的 planning 產物——它日後落地 authority checkout 屬於
+    「run 自產成果回寫」，不是外部 authority 變更。
+    """
+
+    declared: set[str] = set()
+    for step in getattr(run, "steps", ()):
+        if getattr(step, "phase", None) not in {"define", "plan"}:
+            continue
+        for output in getattr(step, "outputs", ()):
+            parts = str(output).split("/")
+            if len(parts) >= 3 and parts[0] == "openspec" and parts[1] == "changes":
+                declared.add(parts[2])
+    return declared
+
+
+def _openspec_refs_compatible(run, authority) -> bool:
+    """#776：resume 穩定識別的 openspec 比對。
+
+    全等視為相同 work（原行為）。authority 只「多出」refs 且多出的每一個都在
+    run 的 planning 卡 outputs 宣告過時，視為 run 自產 openspec change 落地
+    authority——run 沒有被外部重新定義，仍是同一份工作，交由 #216 AC5 分支以
+    authority-restart 收尾。authority 少了 run 已宣告的 ref、或多出非 run 自產
+    的 change，仍屬真正的 authority 變更，維持開新世代。
+    """
+
+    run_refs = tuple(getattr(run, "openspec_refs", ()) or ())
+    mapped = tuple(getattr(authority, "mapped_openspec", ()) or ())
+    if run_refs == mapped:
+        return True
+    run_set = set(run_refs)
+    mapped_set = set(mapped)
+    if not run_set <= mapped_set:
+        return False
+    return (mapped_set - run_set) <= _planning_declared_openspec_changes(run)
+
+
 def _write_supersede_evidence(
     body: dict[str, Any],
     *,
@@ -3100,6 +3140,116 @@ def _superseded_abandon_body(
     if raw != content or target.name != f"{run.run_id}-{digest}.json":
         raise RuntimeError("WorkflowRun was superseded by different authority")
     return body
+
+
+def _recover_superseded_action(
+    *,
+    args: dict[str, Any],
+    authority,
+    state_path: Path,
+    workflow_registry,
+) -> dict[str, Any]:
+    """#776：把被 resume 識別失誤 supersede 的已驗證 run 撿回。
+
+    只受理「有 candidate_head、pr_refs 非空、phase 停在 verify/review、同
+    (repo, work_id) 無 ongoing run、無 active job」的 superseded run——即
+    build 成果與 PR 都在、只是識別鏈斷裂被錯誤作廢的那種。動作＝status 復歸
+    ongoing 後立即走 official ``_manager_reset_workflow_for_authority_restart``
+    （#216 AC5 語意：verify/review 打回 pending、claim_key/source_revision 對齊
+    現 authority、build/candidate/PR 保留），不發明第三種恢復語意。
+    """
+
+    from .registry import ACTIVE_JOB_STATUSES
+
+    extras = set(args) - {
+        "action", "repo", "work_id", "actor", "expected_run_id", "reason",
+    }
+    if extras:
+        raise ValueError(
+            f"recover-superseded rejects caller evidence/input: {sorted(extras)[0]}"
+        )
+    expected_run_id = args.get("expected_run_id")
+    actor = args.get("actor")
+    reason = args.get("reason")
+    if (
+        not isinstance(expected_run_id, str)
+        or re.fullmatch(r"workflow-[0-9a-f]{20}", expected_run_id) is None
+    ):
+        raise ValueError("recover-superseded requires exact expected_run_id")
+    if (
+        not isinstance(actor, str)
+        or actor != actor.strip()
+        or not 1 <= len(actor) <= 128
+        or not actor.isprintable()
+    ):
+        raise ValueError("recover-superseded requires bounded actor")
+    if (
+        not isinstance(reason, str)
+        or reason != reason.strip()
+        or not 1 <= len(reason) <= 500
+        or not reason.isprintable()
+    ):
+        raise ValueError("recover-superseded requires bounded reason")
+    related = [
+        run
+        for run in workflow_registry.list_workflow_runs()
+        if run.repo == authority.repo and run.work_id == authority.work_id
+    ]
+    exact = [run for run in related if run.run_id == expected_run_id]
+    if len(exact) != 1:
+        raise RuntimeError("recover-superseded expected WorkflowRun CAS mismatch")
+    run = exact[0]
+    if run.status != "superseded":
+        raise RuntimeError("recover-superseded requires superseded run")
+    if not run.candidate_head or not run.pr_refs:
+        raise RuntimeError(
+            "recover-superseded requires delivered candidate (candidate_head + pr_refs)"
+        )
+    if run.current_phase not in {"verify", "review"}:
+        raise RuntimeError("recover-superseded requires verify/review phase run")
+    if any(item.status == "ongoing" for item in related):
+        raise RuntimeError("recover-superseded refuses while another run is ongoing")
+    if any(
+        job.get("workflow_run_id") == run.run_id
+        and job.get("status") in ACTIVE_JOB_STATUSES
+        for job in workflow_registry.list_jobs()
+    ):
+        raise RuntimeError("recover-superseded refuses active workflow job")
+    body = {
+        "schema": "cortex-work-recover-superseded/v1",
+        "repo": authority.repo,
+        "work_id": authority.work_id,
+        "run_id": run.run_id,
+        "authority_digest": work_authority_digest(authority),
+        "actor": actor,
+        "reason": reason,
+    }
+    record = _write_supersede_evidence(
+        body,
+        state_path=state_path,
+        subdir="work-recover-superseded",
+        label="recover-superseded",
+    )
+    # 兩步走：先復歸 ongoing 並剝掉 supersede 迴圈附加的 blocked facet（保留
+    # needs_human facet＋理由，維持 `_resolve_needs_human_reason` 的 facet⟷理由
+    # invariant），再交給 official restart 一步清 needs_human 並打回 verify。
+    workflow_registry._manager_update_workflow_run(
+        run.run_id,
+        status="ongoing",
+        facets=tuple(facet for facet in run.facets if facet != "blocked"),
+    )
+    updated = workflow_registry._manager_reset_workflow_for_authority_restart(
+        run.run_id,
+        authority_digest=work_authority_digest(authority),
+    )
+    return {
+        "action": "recovered-superseded",
+        "actor": actor,
+        "reason": reason,
+        "expected_run_id": expected_run_id,
+        "evidence": record,
+        "run": updated.to_dict(),
+    }
 
 
 def _abandon_action(
@@ -5813,6 +5963,7 @@ def execute_work_action(
         "link", "unlink", "start", "resume", "retry-build", "retry-card",
         "retry-verify", "retry-review", "recover-planning", "recover-pre-candidate",
         "recover-repair-commit", "regenerate-gates", "abandon", "retire-delivered",
+        "recover-superseded",
         "reset-reclaim-budget", "refreeze-base", "auto", "ship", "review-attest",
         "intake",
     }:
@@ -5934,6 +6085,13 @@ def execute_work_action(
         )
     elif action == "abandon":
         result = _abandon_action(
+            args=args,
+            authority=authority,
+            state_path=resolved_state_path,
+            workflow_registry=workflow_registry,
+        )
+    elif action == "recover-superseded":
+        result = _recover_superseded_action(
             args=args,
             authority=authority,
             state_path=resolved_state_path,

--- a/tests/test_recover_superseded_776.py
+++ b/tests/test_recover_superseded_776.py
@@ -1,0 +1,245 @@
+"""#776：resume 識別對 planning 自產 openspec 落地 authority 全盲的兩瓣修法。
+
+實機現場：run（candidate=verified、PR 已建、review 全 passed）在 operator 把
+planning 自產的 openspec change 回寫 authority checkout 後 resume，三層識別
+全 miss → 走全新 claim → registry supersede 迴圈把已驗證 run 作廢。本檔釘：
+(A) 穩定識別的 openspec 比對容忍「authority 多出的 refs 皆為 run 自產」；
+(B) ``recover-superseded`` 把被誤作廢的 run 以 official authority-restart 撿回。
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+from paulsha_cortex.coordinator import work_actions
+from paulsha_cortex.coordinator.claim import claim_key_for_authority_digest
+from paulsha_cortex.coordinator.registry import JobRegistry, WorkflowStep
+
+_REPO = "o/r"
+_WORK_ID = "fix-demo"
+_DIGEST = "a" * 64
+
+
+def _step(card: str, *, phase: str, gate_result: str, outputs: tuple[str, ...] = ()) -> WorkflowStep:
+    return WorkflowStep(
+        phase=phase,
+        persona="builder" if phase == "build" else "planner",
+        card=card,
+        executor=None,
+        model=None,
+        domain=None,
+        inputs=(),
+        outputs=outputs,
+        commit_policy=None,
+        test_policy=None,
+        gate_result=gate_result,
+    )
+
+
+def _planning_run(*, openspec_refs=(), declared_change=None):
+    outputs = (
+        (f"openspec/changes/{declared_change}/tasks.md",) if declared_change else ()
+    )
+    return SimpleNamespace(
+        openspec_refs=tuple(openspec_refs),
+        steps=(
+            _step("brainstorming", phase="define", gate_result="passed", outputs=outputs),
+            _step("subagent-build", phase="build", gate_result="passed"),
+        ),
+    )
+
+
+class OpenspecRefsCompatibleTests(unittest.TestCase):
+    def test_equal_refs_are_compatible(self) -> None:
+        authority = SimpleNamespace(mapped_openspec=("c1",))
+        self.assertTrue(
+            work_actions._openspec_refs_compatible(
+                _planning_run(openspec_refs=("c1",)), authority
+            )
+        )
+        empty = SimpleNamespace(mapped_openspec=())
+        self.assertTrue(
+            work_actions._openspec_refs_compatible(_planning_run(), empty)
+        )
+
+    def test_authority_gaining_run_declared_change_is_compatible(self) -> None:
+        """run 自產 change 落地 authority → 同一份工作，識別不得斷。"""
+
+        authority = SimpleNamespace(mapped_openspec=("c1",))
+        run = _planning_run(openspec_refs=(), declared_change="c1")
+        self.assertTrue(work_actions._openspec_refs_compatible(run, authority))
+
+    def test_authority_gaining_foreign_change_is_incompatible(self) -> None:
+        authority = SimpleNamespace(mapped_openspec=("other",))
+        run = _planning_run(openspec_refs=(), declared_change="c1")
+        self.assertFalse(work_actions._openspec_refs_compatible(run, authority))
+
+    def test_authority_losing_run_ref_is_incompatible(self) -> None:
+        authority = SimpleNamespace(mapped_openspec=())
+        run = _planning_run(openspec_refs=("c1",), declared_change="c1")
+        self.assertFalse(work_actions._openspec_refs_compatible(run, authority))
+
+    def test_claim_lookup_uses_the_compatible_predicate(self) -> None:
+        """source-pin：第二層穩定識別必須改走 _openspec_refs_compatible。"""
+
+        source = inspect.getsource(work_actions._claim_action)
+        self.assertIn("_openspec_refs_compatible(run, authority)", source)
+        anchor = source.index("_openspec_refs_compatible(run, authority)")
+        self.assertNotIn(
+            "run.openspec_refs == authority.mapped_openspec",
+            source[max(0, anchor - 800) : anchor],
+        )
+
+
+def _make_registry(tmp: Path) -> JobRegistry:
+    return JobRegistry(state_path=tmp / "jobs.json")
+
+
+def _create_run(registry: JobRegistry, *, phase="verify", candidate="c" * 40,
+                prs=("o/r#1",), facets=()):
+    return registry._manager_create_workflow_run(
+        work_id=_WORK_ID,
+        repo=_REPO,
+        claim_key="claim:v1:" + "1" * 64,
+        source_revision="2" * 64,
+        workspace_root="/tmp/ws",
+        combo="feature-oneshot",
+        current_phase=phase,
+        steps=(
+            _step("subagent-build", phase="build", gate_result="passed"),
+            _step("verification", phase="verify", gate_result="passed"),
+            _step("code-review", phase="review", gate_result="passed"),
+        ),
+        issue_refs=(f"{_REPO}#9",),
+        openspec_refs=(),
+        pr_refs=tuple(prs),
+        attempts={"build": 1},
+        candidate_head=candidate,
+        verified_head=candidate,
+        facets=tuple(facets),
+        gate_status="running",
+    )
+
+
+def _args(run_id: str, **overrides):
+    base = {
+        "action": "recover-superseded",
+        "repo": _REPO,
+        "work_id": _WORK_ID,
+        "actor": "operator",
+        "expected_run_id": run_id,
+        "reason": "recover verified run",
+    }
+    base.update(overrides)
+    return base
+
+
+_AUTHORITY = SimpleNamespace(repo=_REPO, work_id=_WORK_ID, mapped_openspec=())
+
+
+class RecoverSupersededActionTests(unittest.TestCase):
+    def _recover(self, registry, state, run_id, **overrides):
+        with mock.patch.object(
+            work_actions, "work_authority_digest", return_value=_DIGEST
+        ):
+            return work_actions._recover_superseded_action(
+                args=_args(run_id, **overrides),
+                authority=_AUTHORITY,
+                state_path=state,
+                workflow_registry=registry,
+            )
+
+    def test_recovers_run_via_official_authority_restart(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            registry = _make_registry(root)
+            run = _create_run(registry)
+            registry._manager_update_workflow_run(
+                run.run_id, status="superseded", facets=("blocked",)
+            )
+            result = self._recover(registry, root / "jobs.json", run.run_id)
+            self.assertEqual(result["action"], "recovered-superseded")
+            updated = registry.get_workflow_run(run.run_id)
+            self.assertEqual(updated.status, "ongoing")
+            self.assertEqual(updated.current_phase, "verify")
+            self.assertEqual(
+                updated.claim_key,
+                claim_key_for_authority_digest(
+                    repo=_REPO, work_id=_WORK_ID, authority_digest=_DIGEST
+                ),
+            )
+            self.assertEqual(updated.source_revision, _DIGEST)
+            self.assertIsNone(updated.verified_head)
+            self.assertEqual(updated.candidate_head, "c" * 40)
+            self.assertEqual(updated.pr_refs, ("o/r#1",))
+            self.assertNotIn("blocked", updated.facets)
+            by_phase = {step.phase: step.gate_result for step in updated.steps}
+            self.assertEqual(by_phase["build"], "passed")
+            self.assertEqual(by_phase["verify"], "pending")
+            self.assertEqual(by_phase["review"], "pending")
+            evidence = json.loads(
+                Path(result["evidence"]["ref"]).read_text(encoding="utf-8")
+            )
+            self.assertEqual(evidence["schema"], "cortex-work-recover-superseded/v1")
+            self.assertEqual(evidence["run_id"], run.run_id)
+
+    def test_rejects_non_superseded_run(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            registry = _make_registry(root)
+            run = _create_run(registry)
+            with self.assertRaisesRegex(RuntimeError, "superseded"):
+                self._recover(registry, root / "jobs.json", run.run_id)
+
+    def test_rejects_run_without_candidate_or_pr(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            registry = _make_registry(root)
+            run = _create_run(registry, candidate=None, prs=())
+            registry._manager_update_workflow_run(run.run_id, status="superseded")
+            with self.assertRaisesRegex(RuntimeError, "candidate"):
+                self._recover(registry, root / "jobs.json", run.run_id)
+
+    def test_rejects_while_another_run_is_ongoing(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            registry = _make_registry(root)
+            run = _create_run(registry)
+            registry._manager_update_workflow_run(run.run_id, status="superseded")
+            _create_run(registry)
+            with self.assertRaisesRegex(RuntimeError, "ongoing"):
+                self._recover(registry, root / "jobs.json", run.run_id)
+
+    def test_rejects_pre_verify_phase_run(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            registry = _make_registry(root)
+            run = _create_run(registry, phase="build")
+            registry._manager_update_workflow_run(run.run_id, status="superseded")
+            with self.assertRaisesRegex(RuntimeError, "verify/review"):
+                self._recover(registry, root / "jobs.json", run.run_id)
+
+    def test_rejects_malformed_cas_or_unbounded_fields(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            registry = _make_registry(root)
+            with self.assertRaisesRegex(ValueError, "expected_run_id"):
+                self._recover(registry, root / "jobs.json", "workflow-zzz")
+            run = _create_run(registry)
+            registry._manager_update_workflow_run(run.run_id, status="superseded")
+            with self.assertRaisesRegex(ValueError, "reason"):
+                self._recover(registry, root / "jobs.json", run.run_id, reason="  ")
+            with self.assertRaisesRegex(ValueError, "caller evidence"):
+                self._recover(
+                    registry, root / "jobs.json", run.run_id, payload="x"
+                )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
Fixes #776

## 病因（實機第八處）
run `workflow-85114100`（candidate=verified=43be4bdc、PR #764、review 全 passed、只差 ship）在 planning 自產的 openspec change 回寫 authority checkout 後 resume——三層識別全 miss（claim_key 換代／openspec_refs 全等比對破／in-flight 傘不剝 openspec 且對 restart 過的 run 結構性失效）→ 走全新 claim → supersede 迴圈把已驗證 run 作廢。#524「run 被自己的成功產出擠掉識別」的 openspec 變體。

## 修法
- **識別**：第二層 openspec 比對改 `_openspec_refs_compatible`——全等，或 authority 多出的 refs ⊆ run 的 define/plan 卡 outputs 宣告過的 change 名；命中後由既有 #216 AC5 分支走 official authority-restart。外部 openspec 變更（多出的 ref 非 run 自產、或 authority 丟失 run 已宣告的 ref）仍開新世代。
- **救援**：新 bounded verb `work recover-superseded`（exact `--expected-run-id` CAS＋`--actor`/`--reason`，evidence 落 `work-recover-superseded/`）：僅受理 candidate_head＋pr_refs 俱在、phase verify/review、同 work 無 ongoing run、無 active job 的 superseded run；動作＝復歸 ongoing＋`_manager_reset_workflow_for_authority_restart`（verify/review 打回、build/candidate/PR 保留），不發明第三種恢復語意。
- CLI help 同步（R-16）：usage 與 `--expected-run-id`/`--reason` 文案。

- [x] 新增 tests/test_recover_superseded_776.py 11 項（相容判定四象限＋source-pin＋recover 成功路徑與五種拒絕）
- [x] 全套 4949 passed, 36 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XcQLDun91sLCJfJeKoVgjS