### PR TITLE
fix(control): recover-superseded 補進 contract 白名單與驗證分支（#776 補遺）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 本專案遵循 hamanpaul project policy v1.0.17。
 
 ## [Unreleased]
+- **#776 補遺：`recover-superseded` 補進 control contract 白名單**（驗證分支與 porcelain choices 同步）。
 - **#776（#765 第八處）：resume 穩定識別容忍 run 自產 openspec 落地 authority**——不再 supersede 已驗證 run；新增 `work recover-superseded` 撿回被誤作廢的 run（official authority-restart 語意）。
 - **#765（intake 回寫）：`fix-read-repo-tier-fail-closed` openspec change 回寫 main**——monitor 只掃 main，change 僅在 candidate 導致 `mapped_openspec` 恆空、ship 卡 target 計數；檔案與 PR #764 byte-identical。
 - **#765 補遺：review 對 builder job 的綁定改跨 era（#216 AC5 落實）**——build 產物不再因 authority 前進成孤兒。

--- a/changelog.d/contract-whitelist-recover-superseded.md
+++ b/changelog.d/contract-whitelist-recover-superseded.md
@@ -1,0 +1,1 @@
+#776 補遺：`recover-superseded` 補進 control contract 的 work-action 白名單與 CAS/actor/reason 驗證分支（漏接時 CLI submit 直接 `work-action action invalid`），porcelain recover 的 choices 同步。

--- a/paulsha_cortex/control/contract.py
+++ b/paulsha_cortex/control/contract.py
@@ -18,6 +18,7 @@ WORK_ACTIONS = frozenset(
         "link", "unlink", "start", "resume", "retry-build", "retry-card",
         "retry-verify", "retry-review", "recover-planning", "recover-pre-candidate",
         "recover-repair-commit", "regenerate-gates", "abandon", "retire-delivered",
+        "recover-superseded",
         "reset-reclaim-budget", "refreeze-base", "auto", "ship", "review-attest",
         "intake",
     }
@@ -183,7 +184,7 @@ def validate_request(payload: dict[str, Any]) -> dict[str, Any]:
                 or re.fullmatch(r"[a-z0-9][a-z0-9-]{0,63}", card) is None
             ):
                 raise ValueError("work-action retry-card requires exact card id")
-        if action in {"abandon", "retire-delivered"}:
+        if action in {"abandon", "retire-delivered", "recover-superseded"}:
             expected_run_id = args.get("expected_run_id")
             actor = args.get("actor")
             reason = args.get("reason")

--- a/paulsha_cortex/porcelain/recover.py
+++ b/paulsha_cortex/porcelain/recover.py
@@ -61,7 +61,8 @@ def _build_parser() -> argparse.ArgumentParser:
         choices=(
             "retry-build", "retry-card", "resume", "recover-pre-candidate",
             "recover-repair-commit", "regenerate-gates", "abandon",
-            "retire-delivered", "reset-reclaim-budget", "refreeze-base",
+            "retire-delivered", "recover-superseded", "reset-reclaim-budget",
+            "refreeze-base",
         ),
     )
     work.add_argument("--repo", required=True)

--- a/tests/test_recover_superseded_776.py
+++ b/tests/test_recover_superseded_776.py
@@ -243,3 +243,40 @@ class RecoverSupersededActionTests(unittest.TestCase):
 
 if __name__ == "__main__":  # pragma: no cover
     unittest.main()
+
+class ControlContractWhitelistTests(unittest.TestCase):
+    """#776 補遺：control contract 的 verb 白名單與 CAS/actor/reason 驗證分支。
+
+    漏接 contract 白名單時 CLI submit 直接 `work-action action invalid`——
+    verb 在 coordinator 端存在但 control 通道進不去。
+    """
+
+    def test_recover_superseded_is_a_valid_work_action(self) -> None:
+        from paulsha_cortex.control import contract
+
+        self.assertIn("recover-superseded", contract.WORK_ACTIONS)
+
+    def test_contract_enforces_cas_actor_reason(self) -> None:
+        from paulsha_cortex.control import contract
+
+        base = {
+            "schema_version": 1,
+            "type": "work-action",
+            "req_id": "r" * 20,
+            "requested_by": "coordinator-cli",
+            "created_at": contract.utcnow(),
+            "args": {
+                "action": "recover-superseded",
+                "repo": _REPO,
+                "work_id": _WORK_ID,
+                "actor": "operator",
+                "reason": "recover verified run",
+                "expected_run_id": "workflow-" + "a" * 20,
+            },
+        }
+        validated = contract.validate_request(dict(base))
+        self.assertEqual(validated["args"]["action"], "recover-superseded")
+        broken = dict(base)
+        broken["args"] = {**base["args"], "expected_run_id": "workflow-zzz"}
+        with self.assertRaisesRegex(ValueError, "expected_run_id"):
+            contract.validate_request(broken)


### PR DESCRIPTION
關聯 #776（引用不關閉：主修已於 #777 落地並自動關閉 issue，本 PR 為漏接補遺，上 policy-exempt:issue-link）。

## 病因
#777 加了 `work recover-superseded` verb，但 control 通道的 `contract.WORK_ACTIONS` 白名單與 CAS/actor/reason 驗證分支漏接——實機 CLI submit 直接 `ValueError: work-action action invalid`，verb 在 coordinator 端存在但請求進不了 daemon。

## 修法
- `control/contract.py`：WORK_ACTIONS 加 `recover-superseded`；`expected_run_id`/`actor`/`reason` 驗證分支納入同族（界限與 abandon/retire-delivered 完全一致）。
- `porcelain/recover.py`：choices 同步。

- [x] 測試補 ControlContractWhitelistTests（白名單成員＋合法請求通過＋非法 CAS 拒絕）
- [x] 全套 4951 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XcQLDun91sLCJfJeKoVgjS