### PR TITLE
fix(coordinator): 舊 manifest openspec-propose 卡視慣例名 change 為 run 自產（#776 補遺）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 本專案遵循 hamanpaul project policy v1.0.17。
 
 ## [Unreleased]
+- **#776 補遺：舊 manifest 的 openspec-propose 卡視慣例名 change 為 run 自產**（85114100 二度被誤殺的根因）。
 - **#776 補遺：`recover-superseded` 補進 control contract 白名單**（驗證分支與 porcelain choices 同步）。
 - **#776（#765 第八處）：resume 穩定識別容忍 run 自產 openspec 落地 authority**——不再 supersede 已驗證 run；新增 `work recover-superseded` 撿回被誤作廢的 run（official authority-restart 語意）。
 - **#765（intake 回寫）：`fix-read-repo-tier-fail-closed` openspec change 回寫 main**——monitor 只掃 main，change 僅在 candidate 導致 `mapped_openspec` 恆空、ship 卡 target 計數；檔案與 PR #764 byte-identical。

--- a/changelog.d/legacy-manifest-openspec-declaration.md
+++ b/changelog.d/legacy-manifest-openspec-declaration.md
@@ -1,0 +1,1 @@
+#776 補遺：舊版 combo manifest 的 openspec-propose 卡 outputs 未列 openspec 路徑，`_planning_declared_openspec_changes` 對有這張卡的 run 視慣例名（= work_id）change 為 run 自產——實機 workflow-85114100 復活後 resume 仍被識別 miss 再度 supersede 的根因。

--- a/paulsha_cortex/coordinator/work_actions.py
+++ b/paulsha_cortex/coordinator/work_actions.py
@@ -2665,13 +2665,23 @@ def _planning_declared_openspec_changes(run) -> set[str]:
     """
 
     declared: set[str] = set()
+    has_openspec_propose = False
     for step in getattr(run, "steps", ()):
         if getattr(step, "phase", None) not in {"define", "plan"}:
             continue
+        if getattr(step, "card", None) == "openspec-propose":
+            has_openspec_propose = True
         for output in getattr(step, "outputs", ()):
             parts = str(output).split("/")
             if len(parts) >= 3 and parts[0] == "openspec" and parts[1] == "changes":
                 declared.add(parts[2])
+    # 舊版 combo manifest 的 openspec-propose 卡 outputs 未列 openspec 路徑
+    # （實機 workflow-85114100：outputs 只有 spec/design）；有這張卡即代表 run
+    # 的 planning 會產出慣例名（= work_id）的 change，一樣屬 run 自產。
+    if has_openspec_propose:
+        work_id = getattr(run, "work_id", None)
+        if isinstance(work_id, str) and work_id:
+            declared.add(work_id)
     return declared
 
 

--- a/tests/test_recover_superseded_776.py
+++ b/tests/test_recover_superseded_776.py
@@ -280,3 +280,43 @@ class ControlContractWhitelistTests(unittest.TestCase):
         broken["args"] = {**base["args"], "expected_run_id": "workflow-zzz"}
         with self.assertRaisesRegex(ValueError, "expected_run_id"):
             contract.validate_request(broken)
+
+class LegacyManifestOpenspecDeclarationTests(unittest.TestCase):
+    """#776 補遺：舊版 combo manifest 的 openspec-propose 卡 outputs 未列
+    openspec 路徑（實機 workflow-85114100 只列 spec/design）——有這張卡即視
+    慣例名（= work_id）的 change 為 run 自產，識別不得再 miss。"""
+
+    def _legacy_run(self, work_id="fix-demo"):
+        propose = _step("openspec-propose", phase="define", gate_result="passed",
+                        outputs=("docs/superpowers/specs/x-design.md",))
+        return SimpleNamespace(
+            work_id=work_id,
+            openspec_refs=(),
+            steps=(propose, _step("subagent-build", phase="build", gate_result="passed")),
+        )
+
+    def test_openspec_propose_card_declares_conventional_change_name(self) -> None:
+        declared = work_actions._planning_declared_openspec_changes(self._legacy_run())
+        self.assertIn("fix-demo", declared)
+
+    def test_legacy_run_stays_compatible_when_its_change_lands(self) -> None:
+        authority = SimpleNamespace(mapped_openspec=("fix-demo",))
+        self.assertTrue(
+            work_actions._openspec_refs_compatible(self._legacy_run(), authority)
+        )
+
+    def test_foreign_change_is_still_incompatible_for_legacy_run(self) -> None:
+        authority = SimpleNamespace(mapped_openspec=("other-change",))
+        self.assertFalse(
+            work_actions._openspec_refs_compatible(self._legacy_run(), authority)
+        )
+
+    def test_run_without_openspec_propose_gets_no_conventional_grant(self) -> None:
+        run = SimpleNamespace(
+            work_id="fix-demo",
+            openspec_refs=(),
+            steps=(_step("brainstorming", phase="define", gate_result="passed"),),
+        )
+        self.assertNotIn(
+            "fix-demo", work_actions._planning_declared_openspec_changes(run)
+        )


### PR DESCRIPTION
關聯 #776（引用不關閉：主修已於 #777 落地，本 PR 為舊 manifest 相容補遺，上 policy-exempt:issue-link）。

## 病因（實機二度誤殺）
#777 的 `_planning_declared_openspec_changes` 只認 define/plan 卡 outputs 裡的 `openspec/changes/...` 條目——但舊版 combo manifest 的 openspec-propose 卡 outputs 只列 spec/design（實機 `workflow-85114100`）。recover-superseded 復活後 resume：第一層 claim_key 又因 authority digest 流動成分漂移而 miss，第二層 declared 集合空 → `_openspec_refs_compatible` 不相容 → 又 claim 新 run `workflow-5ec04fd5` 並再度 supersede 85114100（已 abandon 止血；abandon 的 planning GC 順帶再刪一次恢復檔）。

## 修法
define/plan phase 存在 `openspec-propose` 卡即把慣例名（= work_id）的 change 納入 declared——這張卡的語意就是「planning 會產出該 change」。無此卡的 run 不獲此授與；外部 change（名稱非 work_id）仍不相容。

- [x] 測試補 LegacyManifestOpenspecDeclarationTests 四項（慣例名授與／相容／外部 change 拒絕／無卡不授與）
- [x] 全套 4955 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XcQLDun91sLCJfJeKoVgjS