### PR TITLE
fix(coordinator): ship adapter refs 守衛改走 openspec 相容判定（#776 補遺）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 本專案遵循 hamanpaul project policy v1.0.17。
 
 ## [Unreleased]
+- **#776 補遺：ship adapter refs 守衛改走 openspec 相容判定**（helper 下沉 claim.py；refs-differ 誤擋修復）。
 - **#776 補遺：舊 manifest 的 openspec-propose 卡視慣例名 change 為 run 自產**（85114100 二度被誤殺的根因）。
 - **#776 補遺：`recover-superseded` 補進 control contract 白名單**（驗證分支與 porcelain choices 同步）。
 - **#776（#765 第八處）：resume 穩定識別容忍 run 自產 openspec 落地 authority**——不再 supersede 已驗證 run；新增 `work recover-superseded` 撿回被誤作廢的 run（official authority-restart 語意）。

--- a/changelog.d/ship-refs-compat.md
+++ b/changelog.d/ship-refs-compat.md
@@ -1,0 +1,1 @@
+#776 補遺：ship adapter 的 refs 守衛改走 openspec 相容判定（helper 下沉 claim.py 供 work_bridge 共用）——run.openspec_refs 是 claim 時快照、authority-restart 不回寫，authority 因 run 自產 change 落地而多出 ref 時全等比對把合法 ship 擋成 `WorkflowRun refs differ`（實機 workflow-advance-failed）。

--- a/paulsha_cortex/coordinator/claim.py
+++ b/paulsha_cortex/coordinator/claim.py
@@ -1141,6 +1141,55 @@ def _validate_candidate(candidate: ClaimCandidate) -> None:
             raise ValueError("active workflow pre-freeze identity digest missing")
 
 
+def planning_declared_openspec_changes(run) -> set[str]:
+    """run 的 define/plan 卡 outputs 宣告過的 openspec change 名（#776）。
+
+    planning 卡把 ``openspec/changes/<name>/...`` 列在 outputs 裡即代表該
+    change 是 run 自己的 planning 產物——它日後落地 authority checkout 屬於
+    「run 自產成果回寫」，不是外部 authority 變更。舊版 combo manifest 的
+    openspec-propose 卡 outputs 未列 openspec 路徑（實機 workflow-85114100：
+    outputs 只有 spec/design）；有這張卡即代表 run 的 planning 會產出慣例名
+    （= work_id）的 change，一樣屬 run 自產。
+    """
+
+    declared: set[str] = set()
+    has_openspec_propose = False
+    for step in getattr(run, "steps", ()):
+        if getattr(step, "phase", None) not in {"define", "plan"}:
+            continue
+        if getattr(step, "card", None) == "openspec-propose":
+            has_openspec_propose = True
+        for output in getattr(step, "outputs", ()):
+            parts = str(output).split("/")
+            if len(parts) >= 3 and parts[0] == "openspec" and parts[1] == "changes":
+                declared.add(parts[2])
+    if has_openspec_propose:
+        work_id = getattr(run, "work_id", None)
+        if isinstance(work_id, str) and work_id:
+            declared.add(work_id)
+    return declared
+
+
+def openspec_refs_compatible(run, authority) -> bool:
+    """#776：run 身分與 authority 的 openspec 比對（resume 識別／ship 守衛共用）。
+
+    全等視為相同 work（原行為）。authority 只「多出」refs 且多出的每一個都是
+    run 自產 planning 產物時，視為 run 自產 openspec change 落地 authority——
+    run 沒有被外部重新定義，仍是同一份工作。authority 少了 run 已宣告的 ref、
+    或多出非 run 自產的 change，仍屬真正的 authority 變更。
+    """
+
+    run_refs = tuple(getattr(run, "openspec_refs", ()) or ())
+    mapped = tuple(getattr(authority, "mapped_openspec", ()) or ())
+    if run_refs == mapped:
+        return True
+    run_set = set(run_refs)
+    mapped_set = set(mapped)
+    if not run_set <= mapped_set:
+        return False
+    return (mapped_set - run_set) <= planning_declared_openspec_changes(run)
+
+
 def claim_key_for_authority_digest(*, repo: str, work_id: str, authority_digest: str) -> str:
     """Deterministic ``claim:v1:...`` key for an exact (repo, work_id,
     authority_digest) triple.

--- a/paulsha_cortex/coordinator/work_actions.py
+++ b/paulsha_cortex/coordinator/work_actions.py
@@ -29,6 +29,8 @@ from .claim import (
     build_claim_key,
     build_label_argv,
     claim_identity_digest,
+    openspec_refs_compatible as claim_openspec_refs_compatible,
+    planning_declared_openspec_changes as claim_planning_declared_openspec_changes,
     decide_auto_claim,
     decide_manual_start,
     load_work_authorities,
@@ -2656,54 +2658,10 @@ def _validate_abandon_evidence_target(
         raise RuntimeError(f"workflow {label} evidence conflict")
 
 
-def _planning_declared_openspec_changes(run) -> set[str]:
-    """run 的 define/plan 卡 outputs 宣告過的 openspec change 名。
-
-    #776：planning 卡把 ``openspec/changes/<name>/...`` 列在 outputs 裡即代表
-    該 change 是 run 自己的 planning 產物——它日後落地 authority checkout 屬於
-    「run 自產成果回寫」，不是外部 authority 變更。
-    """
-
-    declared: set[str] = set()
-    has_openspec_propose = False
-    for step in getattr(run, "steps", ()):
-        if getattr(step, "phase", None) not in {"define", "plan"}:
-            continue
-        if getattr(step, "card", None) == "openspec-propose":
-            has_openspec_propose = True
-        for output in getattr(step, "outputs", ()):
-            parts = str(output).split("/")
-            if len(parts) >= 3 and parts[0] == "openspec" and parts[1] == "changes":
-                declared.add(parts[2])
-    # 舊版 combo manifest 的 openspec-propose 卡 outputs 未列 openspec 路徑
-    # （實機 workflow-85114100：outputs 只有 spec/design）；有這張卡即代表 run
-    # 的 planning 會產出慣例名（= work_id）的 change，一樣屬 run 自產。
-    if has_openspec_propose:
-        work_id = getattr(run, "work_id", None)
-        if isinstance(work_id, str) and work_id:
-            declared.add(work_id)
-    return declared
-
-
-def _openspec_refs_compatible(run, authority) -> bool:
-    """#776：resume 穩定識別的 openspec 比對。
-
-    全等視為相同 work（原行為）。authority 只「多出」refs 且多出的每一個都在
-    run 的 planning 卡 outputs 宣告過時，視為 run 自產 openspec change 落地
-    authority——run 沒有被外部重新定義，仍是同一份工作，交由 #216 AC5 分支以
-    authority-restart 收尾。authority 少了 run 已宣告的 ref、或多出非 run 自產
-    的 change，仍屬真正的 authority 變更，維持開新世代。
-    """
-
-    run_refs = tuple(getattr(run, "openspec_refs", ()) or ())
-    mapped = tuple(getattr(authority, "mapped_openspec", ()) or ())
-    if run_refs == mapped:
-        return True
-    run_set = set(run_refs)
-    mapped_set = set(mapped)
-    if not run_set <= mapped_set:
-        return False
-    return (mapped_set - run_set) <= _planning_declared_openspec_changes(run)
+# #776：helper 下沉至 claim.py 供 work_bridge 的 ship 守衛共用（work_bridge
+# 不能反向 import 本模組）；底線別名保留既有呼叫點與測試的引用名。
+_planning_declared_openspec_changes = claim_planning_declared_openspec_changes
+_openspec_refs_compatible = claim_openspec_refs_compatible
 
 
 def _write_supersede_evidence(

--- a/paulsha_cortex/coordinator/work_bridge.py
+++ b/paulsha_cortex/coordinator/work_bridge.py
@@ -37,6 +37,7 @@ from .claim import (
     WorkAuthority,
     load_work_authority,
     mapped_issue_titles,
+    openspec_refs_compatible,
     sizing_band,
     work_authority_digest,
 )
@@ -1855,7 +1856,11 @@ def build_production_ship_validator(
             snapshot_path=snapshot_path,
         )
         expected_issues = tuple(f"{run.repo}#{number}" for number in authority.mapped_issues)
-        if run.issue_refs != expected_issues or run.openspec_refs != authority.mapped_openspec:
+        # #776：openspec 比對走相容判定——authority 多出的 refs 若皆為 run 自產
+        # planning 產物（含舊 manifest 的 openspec-propose 慣例名授與），run 身分
+        # 未被外部重新定義；run.openspec_refs 是 claim 時快照，authority-restart
+        # 不回寫它，全等比對會把合法 ship 擋成 refs-differ。
+        if run.issue_refs != expected_issues or not openspec_refs_compatible(run, authority):
             raise RuntimeError("WorkflowRun refs differ from current WorkAuthority")
         branch = _builder_binding(
             registry,

--- a/tests/test_recover_superseded_776.py
+++ b/tests/test_recover_superseded_776.py
@@ -320,3 +320,32 @@ class LegacyManifestOpenspecDeclarationTests(unittest.TestCase):
         self.assertNotIn(
             "fix-demo", work_actions._planning_declared_openspec_changes(run)
         )
+
+class ShipAdapterRefsCompatTests(unittest.TestCase):
+    """#776 補遺：ship adapter 的 refs 守衛改走相容判定。
+
+    run.openspec_refs 是 claim 時快照、authority-restart 不回寫；authority 因
+    run 自產 change 落地而多出 ref 時，全等比對把合法 ship 擋成
+    `WorkflowRun refs differ`（實機 workflow-advance-failed）。helper 下沉
+    claim.py 供 work_bridge 使用（不得反向 import work_actions）。
+    """
+
+    def test_ship_validate_uses_compatible_predicate(self) -> None:
+        from paulsha_cortex.coordinator import work_bridge
+
+        source = inspect.getsource(work_bridge)
+        anchor = source.index("WorkflowRun refs differ from current WorkAuthority")
+        window = source[max(0, anchor - 600) : anchor]
+        self.assertIn("openspec_refs_compatible(run, authority)", window)
+        self.assertNotIn("run.openspec_refs != authority.mapped_openspec", window)
+
+    def test_helpers_live_in_claim_and_alias_in_work_actions(self) -> None:
+        from paulsha_cortex.coordinator import claim
+
+        self.assertIs(
+            work_actions._openspec_refs_compatible, claim.openspec_refs_compatible
+        )
+        self.assertIs(
+            work_actions._planning_declared_openspec_changes,
+            claim.planning_declared_openspec_changes,
+        )


### PR DESCRIPTION
關聯 #776（引用不關閉：主修已於 #777 落地，本 PR 為 ship 段同族補遺，上 policy-exempt:issue-link）。

## 病因（實機 workflow-advance-failed）
review 三卡全過後 advance 進 ship，ship adapter 的守衛 `run.openspec_refs != authority.mapped_openspec` 全等比對炸 `WorkflowRun refs differ from current WorkAuthority`——`run.openspec_refs` 是 claim 時快照（`()`），authority-restart 不回寫它；authority 因 run 自產 change 落地而成 `('fix-read-repo-tier-fail-closed',)`。與 resume 第二層識別同族的第九處全等比對。

## 修法
`_planning_declared_openspec_changes`／`_openspec_refs_compatible` 下沉 `claim.py`（公開名；work_bridge 不能反向 import work_actions），work_actions 以底線別名保留既有引用；ship adapter 守衛改 `openspec_refs_compatible(run, authority)`。issue_refs 全等檢查不變；authority 多出非 run 自產 change 仍拒絕。

- [x] 測試補 ShipAdapterRefsCompatTests（守衛 source-pin＋helper 單一真身 alias 驗證）
- [x] 全套 4957 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XcQLDun91sLCJfJeKoVgjS