### PR TITLE
fix(coordinator): archive 前補齊舊 manifest 世代的 openspec change scaffold（#776 補遺）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 本專案遵循 hamanpaul project policy v1.0.17。
 
 ## [Unreleased]
+- **#776 補遺：archive 前補齊舊 manifest 世代的 openspec change scaffold**（canonical-specs-invalid 修復）。
 - **#776 補遺：ship adapter refs 守衛改走 openspec 相容判定**（helper 下沉 claim.py；refs-differ 誤擋修復）。
 - **#776 補遺：舊 manifest 的 openspec-propose 卡視慣例名 change 為 run 自產**（85114100 二度被誤殺的根因）。
 - **#776 補遺：`recover-superseded` 補進 control contract 白名單**（驗證分支與 porcelain choices 同步）。

--- a/changelog.d/archive-openspec-scaffold.md
+++ b/changelog.d/archive-openspec-scaffold.md
@@ -1,0 +1,1 @@
+#776 補遺：archive gate 前由 Manager 於 ship workspace 補齊舊 manifest 世代缺失的 openspec change 結構（指標式 proposal.md＋canonical 驗收 delta；隨 archive commit 收進並經 re-verification 檢視）——只有 tasks.md 的 change 先前在 `openspec validate --strict` 以 Unknown item 結構性失敗（實機 `archive gate blocked: canonical-specs-invalid`）。

--- a/paulsha_cortex/coordinator/work_actions.py
+++ b/paulsha_cortex/coordinator/work_actions.py
@@ -132,6 +132,71 @@ def _pr_metadata(args: dict[str, Any], *, required_issues: tuple[int, ...]) -> P
     return metadata
 
 
+def _ensure_openspec_change_scaffold(*, repo_root: Path, change: str) -> None:
+    """#776：archive 前補齊舊 manifest 世代缺失的 openspec change 結構。
+
+    舊版 combo manifest 的 planning 只把 ``tasks.md`` 寫進 candidate（實機
+    workflow-85114100），archive gate 的 ``openspec validate --strict`` 因缺
+    ``proposal.md``／specs delta 而結構性失敗（``Unknown item``）。Manager 在
+    自己的 ship workspace 於 gate 之前補齊 scaffold——內容為指標式：canonical
+    規格仍是 ``docs/superpowers/specs/`` 的 spec/design（與 repo 既有 proposal
+    的 Capabilities 段慣例一致），delta 以單一 Requirement 錨定「以 canonical
+    規格驗收」。scaffold 隨 archive commit 一起收進、candidate 前進並經
+    re-verification 檢視（#653 設計本有的重驗步驟）。已有 proposal／delta 的
+    change 一字不動；產出 deterministic（無時間戳）。
+    """
+
+    change_dir = repo_root / "openspec" / "changes" / change
+    if not change_dir.is_dir():
+        return
+    spec_ref = f"docs/superpowers/specs/{change}-spec.md"
+    design_ref = f"docs/superpowers/specs/{change}-design.md"
+    proposal = change_dir / "proposal.md"
+    if not proposal.is_file():
+        proposal.write_text(
+            "---\n"
+            "status: accepted\n"
+            f"work_item: {change}\n"
+            "---\n"
+            "\n"
+            "## Goals\n"
+            "\n"
+            f"本 change 的 canonical 目標與需求載於 `{spec_ref}`。\n"
+            "\n"
+            "## Why\n"
+            "\n"
+            f"設計取捨與動機載於 `{design_ref}`。\n"
+            "\n"
+            "## What Changes\n"
+            "\n"
+            f"- 依 `{spec_ref}` 的 Requirements 實作並驗收（本 proposal 由 Manager 於 archive 前補齊結構，canonical 規格不在此重複）。\n"
+            "\n"
+            "## Capabilities\n"
+            "\n"
+            "### Modified Capabilities\n"
+            f"- 詳見 `{spec_ref}` 與 `{design_ref}`。\n",
+            encoding="utf-8",
+        )
+    specs_dir = change_dir / "specs"
+    has_delta = specs_dir.is_dir() and any(specs_dir.rglob("*.md"))
+    if not has_delta:
+        delta_dir = specs_dir / change
+        delta_dir.mkdir(parents=True, exist_ok=True)
+        (delta_dir / "spec.md").write_text(
+            "## ADDED Requirements\n"
+            "\n"
+            f"### Requirement: 依 canonical superpowers 規格驗收\n"
+            "\n"
+            f"本 change 的 canonical Requirements 載於 `{spec_ref}`；candidate MUST 滿足該規格的全部驗收條件，且 verify／review 以該規格為唯一需求來源。\n"
+            "\n"
+            "#### Scenario: canonical 規格驗收\n"
+            "\n"
+            f"- **WHEN** 依 `{spec_ref}` 的 Requirements 對 candidate 驗收\n"
+            "- **THEN** 全部驗收條件成立\n",
+            encoding="utf-8",
+        )
+
+
 def _validate_local_archive_inputs(
     *,
     repo_root: Path,

--- a/paulsha_cortex/coordinator/work_bridge.py
+++ b/paulsha_cortex/coordinator/work_bridge.py
@@ -1884,6 +1884,13 @@ def build_production_ship_validator(
             from . import work_actions
 
             validate_ship_stage_transition("local-closeout", "pr-preflight")
+            # #776：舊 manifest 世代的 change 只有 tasks.md——archive gate 的
+            # strict validate 會以 Unknown item 結構性失敗；gate 前補齊指標式
+            # scaffold（隨 archive commit 收進並經 re-verification 檢視）。
+            work_actions._ensure_openspec_change_scaffold(
+                repo_root=worktree,
+                change=str(change),
+            )
             work_actions._validate_local_archive_inputs(
                 repo_root=worktree,
                 change=str(change),

--- a/tests/test_recover_superseded_776.py
+++ b/tests/test_recover_superseded_776.py
@@ -349,3 +349,65 @@ class ShipAdapterRefsCompatTests(unittest.TestCase):
             work_actions._planning_declared_openspec_changes,
             claim.planning_declared_openspec_changes,
         )
+
+class ArchiveScaffoldTests(unittest.TestCase):
+    """#776 補遺：archive 前補齊舊 manifest 世代缺失的 change 結構。
+
+    舊 planning 只把 tasks.md 寫進 candidate，`openspec validate --strict`
+    以 Unknown item 結構性失敗。Manager 在 ship workspace gate 前補指標式
+    scaffold；已有 proposal／delta 一字不動。
+    """
+
+    def _tree(self, tmp, *, with_proposal=False, with_delta=False):
+        root = Path(tmp)
+        change = root / "openspec" / "changes" / "fix-demo"
+        change.mkdir(parents=True)
+        (change / "tasks.md").write_text("# Tasks\n\n- [x] done\n", encoding="utf-8")
+        if with_proposal:
+            (change / "proposal.md").write_text("original\n", encoding="utf-8")
+        if with_delta:
+            delta = change / "specs" / "existing"
+            delta.mkdir(parents=True)
+            (delta / "spec.md").write_text("## ADDED Requirements\n", encoding="utf-8")
+        return root, change
+
+    def test_scaffold_fills_missing_proposal_and_delta(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root, change = self._tree(tmp)
+            work_actions._ensure_openspec_change_scaffold(
+                repo_root=root, change="fix-demo"
+            )
+            proposal = (change / "proposal.md").read_text(encoding="utf-8")
+            self.assertIn("work_item: fix-demo", proposal)
+            self.assertIn("docs/superpowers/specs/fix-demo-spec.md", proposal)
+            delta = (change / "specs" / "fix-demo" / "spec.md").read_text(
+                encoding="utf-8"
+            )
+            self.assertIn("## ADDED Requirements", delta)
+            self.assertIn("#### Scenario:", delta)
+
+    def test_existing_content_is_left_untouched(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root, change = self._tree(tmp, with_proposal=True, with_delta=True)
+            work_actions._ensure_openspec_change_scaffold(
+                repo_root=root, change="fix-demo"
+            )
+            self.assertEqual(
+                (change / "proposal.md").read_text(encoding="utf-8"), "original\n"
+            )
+            self.assertFalse((change / "specs" / "fix-demo").exists())
+
+    def test_absent_change_dir_is_a_noop(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            work_actions._ensure_openspec_change_scaffold(
+                repo_root=Path(tmp), change="fix-demo"
+            )
+            self.assertFalse((Path(tmp) / "openspec").exists())
+
+    def test_ship_adapter_scaffolds_before_gate(self) -> None:
+        from paulsha_cortex.coordinator import work_bridge
+
+        source = inspect.getsource(work_bridge)
+        scaffold = source.index("_ensure_openspec_change_scaffold")
+        gate = source.index("_validate_local_archive_inputs")
+        self.assertLess(scaffold, gate)


### PR DESCRIPTION
關聯 #776（引用不關閉：主修已於 #777 落地，本 PR 為 ship 段 archive gate 補遺，上 policy-exempt:issue-link）。

## 病因（實機 `archive gate blocked: canonical-specs-invalid`）
舊版 combo manifest 的 planning 只把 `tasks.md` 寫進 candidate（workflow-85114100）；archive gate 的 `openspec validate --strict` 對缺 `proposal.md`／specs delta 的 change 直接 `Unknown item`，gate 結構性紅。

## 修法
gate 前由 Manager 在**自己的 ship workspace** 補齊指標式 scaffold（實驗驗證的最小合法結構）：
- `proposal.md`：frontmatter（status/work_item）＋ Goals/Why/What Changes/Capabilities 皆指向 canonical `docs/superpowers/specs/` spec/design（與 repo 既有 proposal 的 Capabilities 段慣例一致）。
- `specs/<change>/spec.md`：單一 ADDED Requirement＋Scenario，錨定「以 canonical 規格驗收」。

scaffold 隨 archive commit 一起收進、candidate 前進並經 re-verification 檢視（#653 設計本有的重驗步驟）；已有 proposal／delta 的 change 一字不動；產出 deterministic。

- [x] 測試補 ArchiveScaffoldTests 四項（補齊／不覆寫／noop／gate 前順序 source-pin）
- [x] 本機以 openspec CLI 驗證 scaffold 結構 `is valid`
- [x] 全套 4961 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XcQLDun91sLCJfJeKoVgjS