### PR TITLE
fix(trust-root): allow safe reuse of runtime slots

### DIFF
--- a/changelog.d/718-runtime-slot-retry.md
+++ b/changelog.d/718-runtime-slot-retry.md
@@ -1,4 +1,5 @@
 ## Fixed
 
 - Allow a recovered job to reuse its isolated runtime home and cache without
-  recursively changing ACLs on state already owned by the downgraded job user.
+  recursively changing ACLs on state already owned by the downgraded job user
+  (#718).

--- a/changelog.d/718-runtime-slot-retry.md
+++ b/changelog.d/718-runtime-slot-retry.md
@@ -1,0 +1,4 @@
+## Fixed
+
+- Allow a recovered job to reuse its isolated runtime home and cache without
+  recursively changing ACLs on state already owned by the downgraded job user.

--- a/paulsha_cortex/coordinator/spool_slot.py
+++ b/paulsha_cortex/coordinator/spool_slot.py
@@ -267,6 +267,7 @@ def _apply_slot_acl(
     account: str,
     writable: bool,
     surface: "PerJobWritableSurface",
+    recursive: bool = True,
 ) -> None:
     """Apply ACL without the launcher's mocked ``subprocess.Popen`` surface."""
     binary = shutil.which("setfacl")
@@ -277,8 +278,11 @@ def _apply_slot_acl(
     spec = surface.acl_argument(
         account=account, writable=writable, directory=path.is_dir()
     )
-    argv = (binary, "-R", "-m", spec, str(path))
-    if os.spawnv(os.P_WAIT, binary, argv) != 0:
+    argv = [binary]
+    if recursive:
+        argv.append("-R")
+    argv.extend(("-m", spec, str(path)))
+    if os.spawnv(os.P_WAIT, binary, tuple(argv)) != 0:
         raise SpoolSlotError("acl", f"failed to apply per-job ACL: {path}")
 
 
@@ -426,11 +430,15 @@ def provision_runtime_surfaces(
         if principal not in row.principals:
             continue
         slot = canonical_job_slot(row.surface_id, job_id)
+        fresh_slot = False
+        auth: Path | None = None
+        auth_seeded = False
         try:
             if slot.exists():
                 validate_job_slot_shape(slot)
             else:
                 create_slot(slot, reset=False)
+                fresh_slot = True
             if row.surface_id.endswith("-codex-home"):
                 source = readable_codex_home(canonical_codex_home, require_auth=False)
                 for dirname in ("plugins", "skills"):
@@ -460,15 +468,31 @@ def provision_runtime_surfaces(
                     # Preserve the inherited named-user ACL mask. 0600 would mask
                     # the job principal out before Codex can refresh credentials.
                     auth.chmod(0o660)
+                    auth_seeded = True
             if account is not None and row.surface_id.endswith(
                 ("-codex-home", "-runtime-cache")
             ):
-                # The container remains Manager-only. Grant the resolved job
-                # account recursively on the explicit runtime projection only;
-                # write-only rows keep the deployment ACL already installed on
-                # their typed root.
-                _apply_slot_acl(slot, account=account, writable=True, surface=row)
+                # Fresh slots are still entirely Manager-owned, so the runtime
+                # projection may be seeded recursively. Reused slots can already
+                # contain job-owned runtime state; refresh only the slot root's
+                # access/default ACL and then re-lock the Manager-owned control
+                # leaves that were just copied back in place.
+                _apply_slot_acl(
+                    slot,
+                    account=account,
+                    writable=True,
+                    surface=row,
+                    recursive=fresh_slot,
+                )
                 if row.surface_id.endswith("-codex-home"):
+                    if auth_seeded and not fresh_slot and auth is not None:
+                        _apply_slot_acl(
+                            auth,
+                            account=account,
+                            writable=True,
+                            surface=row,
+                            recursive=False,
+                        )
                     for leaf in ("config.toml", "hooks.json", "plugins", "skills"):
                         _apply_slot_acl(
                             slot / leaf, account=account, writable=False, surface=row

--- a/tests/test_trust_root_isolation_718.py
+++ b/tests/test_trust_root_isolation_718.py
@@ -17,6 +17,7 @@ import subprocess
 import sys
 import tempfile
 import unittest
+import unittest.mock
 from pathlib import Path
 
 from paulsha_cortex.coordinator import spool_slot
@@ -273,8 +274,11 @@ class RuntimeSurfaceProvisionTests(unittest.TestCase):
     def test_write_only_rows_skip_runtime_projection_acl(self) -> None:
         applied: list[tuple[str, bool]] = []
 
-        def _record_acl(path: Path, *, account: str, writable: bool, surface) -> None:
+        def _record_acl(
+            path: Path, *, account: str, writable: bool, surface, recursive: bool = True
+        ) -> None:
             del path, account
+            assert recursive is True
             applied.append((surface.surface_id, writable))
 
         with tempfile.TemporaryDirectory() as d:
@@ -294,6 +298,86 @@ class RuntimeSurfaceProvisionTests(unittest.TestCase):
             {surface_id for surface_id, _writable in applied},
             {"builder-codex-home", "builder-runtime-cache"},
         )
+
+    def test_reused_runtime_slots_refresh_root_acl_without_recursive_walk(self) -> None:
+        applied: list[tuple[Path, str, bool, str, bool]] = []
+
+        with tempfile.TemporaryDirectory() as d:
+            root = Path(d)
+            with unittest.mock.patch.dict(os.environ, {"PSC_AGENTS_ROOT": str(root)}, clear=False):
+                canonical = self._seed_builder_projection(root)
+                spool_slot.provision_runtime_surfaces(
+                    principal="builder", job_id="job-a", canonical_codex_home=canonical
+                )
+                codex = spool_slot.canonical_job_slot("builder-codex-home", "job-a")
+                cache = spool_slot.canonical_job_slot("builder-runtime-cache", "job-a")
+                (codex / "sessions").mkdir()
+                (codex / "sessions" / "state.json").write_text('{"live":true}\n')
+                (cache / "copilot").mkdir()
+                (cache / "copilot" / "state.sqlite").write_text("keep\n")
+
+                def _record_acl(
+                    path: Path,
+                    *,
+                    account: str,
+                    writable: bool,
+                    surface,
+                    recursive: bool = True,
+                ) -> None:
+                    target = Path(path)
+                    if target in {codex, cache} and recursive:
+                        raise AssertionError("reused runtime slot root must not recurse")
+                    applied.append((target, account, writable, surface.surface_id, recursive))
+
+                with unittest.mock.patch.object(
+                    spool_slot, "_apply_slot_acl", side_effect=_record_acl
+                ):
+                    spool_slot.provision_runtime_surfaces(
+                        principal="builder",
+                        job_id="job-a",
+                        canonical_codex_home=canonical,
+                        account="cortex-builder",
+                    )
+
+        assert (codex, "cortex-builder", True, "builder-codex-home", False) in applied
+        assert (cache, "cortex-builder", True, "builder-runtime-cache", False) in applied
+        readonly_controls = {
+            (codex / "config.toml", "cortex-builder", False, "builder-codex-home"),
+            (codex / "hooks.json", "cortex-builder", False, "builder-codex-home"),
+            (codex / "plugins", "cortex-builder", False, "builder-codex-home"),
+            (codex / "skills", "cortex-builder", False, "builder-codex-home"),
+        }
+        assert readonly_controls <= {
+            (path, account, writable, surface_id)
+            for path, account, writable, surface_id, _recursive in applied
+        }
+
+    def test_fresh_runtime_slots_seed_recursive_acl(self) -> None:
+        applied: list[tuple[Path, str, bool, str, bool]] = []
+
+        def _record_acl(
+            path: Path, *, account: str, writable: bool, surface, recursive: bool = True
+        ) -> None:
+            applied.append((Path(path), account, writable, surface.surface_id, recursive))
+
+        with tempfile.TemporaryDirectory() as d:
+            root = Path(d)
+            with unittest.mock.patch.dict(os.environ, {"PSC_AGENTS_ROOT": str(root)}, clear=False):
+                canonical = self._seed_builder_projection(root)
+                codex = spool_slot.canonical_job_slot("builder-codex-home", "job-a")
+                cache = spool_slot.canonical_job_slot("builder-runtime-cache", "job-a")
+                with unittest.mock.patch.object(
+                    spool_slot, "_apply_slot_acl", side_effect=_record_acl
+                ):
+                    spool_slot.provision_runtime_surfaces(
+                        principal="builder",
+                        job_id="job-a",
+                        canonical_codex_home=canonical,
+                        account="cortex-builder",
+                    )
+
+        assert (codex, "cortex-builder", True, "builder-codex-home", True) in applied
+        assert (cache, "cortex-builder", True, "builder-runtime-cache", True) in applied
 
     def test_copilot_authority_requires_absolute_locked_manager_owned_file(self) -> None:
         with tempfile.TemporaryDirectory() as d:
@@ -341,7 +425,10 @@ class RuntimeSurfaceProvisionTests(unittest.TestCase):
     def test_provision_copilot_home_copies_authority_and_preserves_job_cache(self) -> None:
         applied: list[tuple[Path, str, bool, str]] = []
 
-        def _record_acl(path: Path, *, account: str, writable: bool, surface) -> None:
+        def _record_acl(
+            path: Path, *, account: str, writable: bool, surface, recursive: bool = True
+        ) -> None:
+            assert recursive is True
             applied.append((Path(path), account, writable, surface.surface_id))
 
         with tempfile.TemporaryDirectory() as d:


### PR DESCRIPTION
## 問題

PR #783 部署後的正式 `recover-pre-candidate` 暴露 retry 缺陷：同一 instance 的 Codex home/cache 已含 job-owned inode，Manager 再次對整棵 slot 執行 `setfacl -R` 會以 `Operation not permitted` fail-closed，導致 fallback provider 尚未啟動就失敗。

## 修正

- fresh slot 維持遞迴 ACL seed
- reused slot 只刷新 Manager-owned root 的 access/default ACL
- 重新複製並鎖定 Manager-owned control leaves
- 不 chown、不刪除、不授權 Manager 讀 job-owned descendants
- 補上 changelog fragment

## 驗證

- focused: `183 passed, 7 skipped, 4 subtests passed`
- full clean non-root suite: `5038 passed, 44 skipped, 171 subtests passed`
- Cortex Agy `gemini-3.7-flash-high`: `PASS`, no BLOCKER/MAJOR findings
- Cortex Copilot builder: `gpt-5.4`, effort `xhigh`, commit bundle successfully produced

Fixes #718.