### PR TITLE
fix(release): 分離確定性資格驗證與部署 canary

### DIFF
--- a/.github/workflows/deployment-canary.yml
+++ b/.github/workflows/deployment-canary.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout exact candidate
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
+        with:
+          fetch-depth: 0
 
       - name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
@@ -49,6 +51,10 @@ jobs:
 
           [[ "$(git rev-parse HEAD)" == "$CANDIDATE_SHA" ]] || {
             echo "::error::checkout HEAD does not match the workflow candidate SHA"
+            exit 1
+          }
+          [[ "$(git rev-parse --is-shallow-repository)" == "false" ]] || {
+            echo "::error::candidate checkout is shallow; source bundle would omit history"
             exit 1
           }
           git bundle create qualification-input/source/paulsha-cortex.bundle HEAD

--- a/.github/workflows/deployment-canary.yml
+++ b/.github/workflows/deployment-canary.yml
@@ -1,4 +1,4 @@
-name: RC qualification
+name: Deployment canary
 
 on:
   workflow_dispatch:
@@ -10,6 +10,7 @@ jobs:
   qualification:
     runs-on: ubuntu-24.04
     timeout-minutes: 180
+    environment: rc-qualification
     steps:
       - name: Checkout exact candidate
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
@@ -143,11 +144,19 @@ jobs:
           echo "wheel_sha256=$wheel_sha" >> "$GITHUB_OUTPUT"
           echo "bundle_sha256=$bundle_sha" >> "$GITHUB_OUTPUT"
 
-      - name: Run privileged systemd qualification
+      - name: Run protected live deployment canary
+        env:
+          CORTEX_RC_CODEX_AUTH: ${{ secrets.CORTEX_RC_CODEX_AUTH }}
+          CORTEX_RC_AGY_AUTH: ${{ secrets.CORTEX_RC_AGY_AUTH }}
+          CORTEX_RC_COPILOT_AUTH: ${{ secrets.CORTEX_RC_COPILOT_AUTH }}
+          CORTEX_RC_MANAGER_GITHUB_AUTH: ${{ secrets.CORTEX_RC_MANAGER_GITHUB_AUTH }}
+          CORTEX_RC_PROBE_REPOSITORY: ${{ vars.CORTEX_RC_PROBE_REPOSITORY }}
+          CORTEX_RC_PROBE_WORK_ID: ${{ vars.CORTEX_RC_PROBE_WORK_ID }}
+          CORTEX_RC_PROBE_ISSUE: ${{ vars.CORTEX_RC_PROBE_ISSUE }}
         run: |
           set -euo pipefail
           qualification/run.sh \
-            --profile release \
+            --profile deployment-canary \
             --artifacts qualification-input \
             --candidate-sha "${{ github.sha }}" \
             --wheel-sha256 "${{ steps.candidate.outputs.wheel_sha256 }}" \
@@ -156,14 +165,19 @@ jobs:
           test -s qualification-output/qualification.json
 
       - name: Fail closed on credential material in evidence
+        env:
+          CORTEX_RC_CODEX_AUTH: ${{ secrets.CORTEX_RC_CODEX_AUTH }}
+          CORTEX_RC_AGY_AUTH: ${{ secrets.CORTEX_RC_AGY_AUTH }}
+          CORTEX_RC_COPILOT_AUTH: ${{ secrets.CORTEX_RC_COPILOT_AUTH }}
+          CORTEX_RC_MANAGER_GITHUB_AUTH: ${{ secrets.CORTEX_RC_MANAGER_GITHUB_AUTH }}
         run: >-
           python qualification/redaction_scan.py qualification-output
-          --profile release
+          --profile deployment-canary
 
-      - name: Upload exact candidate and redacted evidence
+      - name: Upload exact candidate and redacted canary evidence
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1  # v4.6.1
         with:
-          name: rc-qualification-${{ github.sha }}
+          name: deployment-canary-${{ github.sha }}
           if-no-files-found: error
           retention-days: 3
           path: |

--- a/.github/workflows/rc-qualification.yml
+++ b/.github/workflows/rc-qualification.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Checkout exact candidate
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
+        with:
+          fetch-depth: 0
 
       - name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
@@ -48,6 +50,10 @@ jobs:
 
           [[ "$(git rev-parse HEAD)" == "$CANDIDATE_SHA" ]] || {
             echo "::error::checkout HEAD does not match the workflow candidate SHA"
+            exit 1
+          }
+          [[ "$(git rev-parse --is-shallow-repository)" == "false" ]] || {
+            echo "::error::candidate checkout is shallow; source bundle would omit history"
             exit 1
           }
           git bundle create qualification-input/source/paulsha-cortex.bundle HEAD

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -324,7 +324,7 @@ jobs:
             --wheel-sha256 "$qualified_sha" \
             --bundle-sha256 "$bundle_sha" \
             --evidence-root rc-candidate/qualification-output \
-            --require-full-suite
+            --require-release-profile
 
       - name: Stage the same wheel used by RC
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@
   intake-to-closeout 另移至受保護的 manual `deployment-canary`，不再阻擋 package release；
   qualification 與 canary 都會拒絕 shallow checkout，確保 source bundle 含完整 history 並
   通過安裝後 repository `fsck`；qualification evidence 改寫入一次性 Docker volume，避免
-  Docker archive API 無法從 container `/run` tmpfs 匯出已驗證結果。
+  Docker archive API 無法從 container `/run` tmpfs 匯出已驗證結果；release validator 也會
+  拒絕任何未列入 artifact inventory 的額外 evidence 檔案。
 
 - **Phase 2 部署與 Docker RC qualification release batch**：將已合併的 trust-root
   deployment hardening、exact-SHA qualification bundle 與 protected RC/release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@
   installer/systemd/attestation/attack-matrix gate；真實 provider、Manager GitHub 與
   intake-to-closeout 另移至受保護的 manual `deployment-canary`，不再阻擋 package release；
   qualification 與 canary 都會拒絕 shallow checkout，確保 source bundle 含完整 history 並
-  通過安裝後 repository `fsck`。
+  通過安裝後 repository `fsck`；qualification evidence 改寫入一次性 Docker volume，避免
+  Docker archive API 無法從 container `/run` tmpfs 匯出已驗證結果。
 
 - **Phase 2 部署與 Docker RC qualification release batch**：將已合併的 trust-root
   deployment hardening、exact-SHA qualification bundle 與 protected RC/release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@
 - **Release qualification 邊界修正**：exact-SHA `rc-qualification` 改為不讀 secrets、
   不呼叫 provider、以 `--network none` 執行且不修改外部 repository 的 deterministic
   installer/systemd/attestation/attack-matrix gate；真實 provider、Manager GitHub 與
-  intake-to-closeout 另移至受保護的 manual `deployment-canary`，不再阻擋 package release。
+  intake-to-closeout 另移至受保護的 manual `deployment-canary`，不再阻擋 package release；
+  qualification 與 canary 都會拒絕 shallow checkout，確保 source bundle 含完整 history 並
+  通過安裝後 repository `fsck`。
 
 - **Phase 2 部署與 Docker RC qualification release batch**：將已合併的 trust-root
   deployment hardening、exact-SHA qualification bundle 與 protected RC/release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
 
 ## [Unreleased]
 
+- **Release qualification 邊界修正**：exact-SHA `rc-qualification` 改為不讀 secrets、
+  不呼叫 provider、以 `--network none` 執行且不修改外部 repository 的 deterministic
+  installer/systemd/attestation/attack-matrix gate；真實 provider、Manager GitHub 與
+  intake-to-closeout 另移至受保護的 manual `deployment-canary`，不再阻擋 package release。
+
 - **Phase 2 部署與 Docker RC qualification release batch**：將已合併的 trust-root
   deployment hardening、exact-SHA qualification bundle 與 protected RC/release
   gate 收口為下一個 patch release，並保留 final-head review、CI、OpenSpec archive

--- a/README.md
+++ b/README.md
@@ -25,18 +25,18 @@ persona 是 manager 與 guardrail 共同引用的**角色契約資料**（role p
 
 需求：Python 3.10+、Git，以及至少一個已安裝並登入的 headless executor CLI（`copilot`、`claude` 或 `codex`）。套件只安裝 Python runtime，不會代裝或登入 executor。
 
-推薦：安裝已發版、可回滾、且已在 Python 3.10–3.13 完整 CI 驗證過的 release（目前最新 `v0.1.4`）：
+推薦：安裝已發版、可回滾、且已在 Python 3.10–3.13 完整 CI 驗證過的 release（目前 release batch `v0.1.9`）：
 
 ```bash
-pipx install "git+https://github.com/hamanpaul/paulsha-cortex.git@v0.1.4"
+pipx install "git+https://github.com/hamanpaul/paulsha-cortex.git@v0.1.9"
 cortex --help
-cortex --version   # 應印出 0.1.4
+cortex --version   # 應印出 0.1.9
 ```
 
-也可改用 GitHub Release 附帶的 wheel（`release.yml` 會把 wheel/sdist 附在該 tag 的 Release）：
+也可改用 GitHub Release 附帶的 wheel（`release.yml` 會把 exact RC-qualified wheel 附在該 tag 的 Release）：
 
 ```bash
-pipx install ./paulsha_cortex-0.1.4-py3-none-any.whl
+pipx install ./paulsha_cortex-0.1.9-py3-none-any.whl
 ```
 
 也可在專案內直接安裝：

--- a/changelog.d/release-qualification-boundary.md
+++ b/changelog.d/release-qualification-boundary.md
@@ -4,4 +4,5 @@ deployment canary；evidence schema v2 以 profile 防止兩種結果互相冒�
 也會在 source bundle 建立前強制取得並驗證完整 Git history，避免 shallow bundle 在安裝後
 repository `fsck` 才失敗。qualification evidence 會寫入獨立的一次性 Docker volume，再由
 runner 匯出；不新增 writable host bind，且避開 Docker archive API 無法讀取 container
-`/run` tmpfs 的限制。
+`/run` tmpfs 的限制。validator 會比對 canonical evidence tree 與 artifact inventory 的完整
+檔案集合，未列管檔案、symlink 或列在 tree 外的 artifact 都會 fail closed。

--- a/changelog.d/release-qualification-boundary.md
+++ b/changelog.d/release-qualification-boundary.md
@@ -1,3 +1,5 @@
 將 package release gate 改為 exact-SHA、無 secrets、無外部寫入的 deterministic systemd
 qualification，並把真實 provider、GitHub 與 full-dispatch 驗證拆成不阻擋 release 的 protected
-deployment canary；evidence schema v2 以 profile 防止兩種結果互相冒充。
+deployment canary；evidence schema v2 以 profile 防止兩種結果互相冒充。兩條 workflow
+也會在 source bundle 建立前強制取得並驗證完整 Git history，避免 shallow bundle 在安裝後
+repository `fsck` 才失敗。

--- a/changelog.d/release-qualification-boundary.md
+++ b/changelog.d/release-qualification-boundary.md
@@ -2,4 +2,6 @@
 qualification，並把真實 provider、GitHub 與 full-dispatch 驗證拆成不阻擋 release 的 protected
 deployment canary；evidence schema v2 以 profile 防止兩種結果互相冒充。兩條 workflow
 也會在 source bundle 建立前強制取得並驗證完整 Git history，避免 shallow bundle 在安裝後
-repository `fsck` 才失敗。
+repository `fsck` 才失敗。qualification evidence 會寫入獨立的一次性 Docker volume，再由
+runner 匯出；不新增 writable host bind，且避開 Docker archive API 無法讀取 container
+`/run` tmpfs 的限制。

--- a/changelog.d/release-qualification-boundary.md
+++ b/changelog.d/release-qualification-boundary.md
@@ -1,0 +1,3 @@
+將 package release gate 改為 exact-SHA、無 secrets、無外部寫入的 deterministic systemd
+qualification，並把真實 provider、GitHub 與 full-dispatch 驗證拆成不阻擋 release 的 protected
+deployment canary；evidence schema v2 以 profile 防止兩種結果互相冒充。

--- a/docs/superpowers/plans/2026-08-22-phase2-install-docker-qualification.md
+++ b/docs/superpowers/plans/2026-08-22-phase2-install-docker-qualification.md
@@ -1,5 +1,9 @@
 # Cortex Phase 2 install and Docker release qualification plan
 
+> Historical plan: its step 11 coupled live provider/full-dispatch evidence to package release.
+> `2026-08-26-release-qualification-boundary.md` supersedes that release-gate decision;
+> this file remains as the implementation record for the Phase 2 installer and attack matrix.
+
 Authority: `openspec/changes/phase2-install-docker-qualification/`.
 
 ## Boundaries

--- a/docs/superpowers/plans/2026-08-26-release-qualification-boundary.md
+++ b/docs/superpowers/plans/2026-08-26-release-qualification-boundary.md
@@ -1,0 +1,31 @@
+# Release qualification boundary correction plan
+
+Authority: `openspec/changes/release-qualification-boundary/`.
+
+## Boundary
+
+- Worktree: `$HOME/prj_pri/paulsha-cortex-worktrees/release-qualification-boundary`
+- Branch: `feature/release-qualification-boundary`
+- Base: `origin/main` at `b46417b96d0b8d903c622cdf6b207335588795ce`
+- Scope: qualification workflows, harness/evidence validation, focused tests, OpenSpec and release docs only.
+- Explicitly excluded: uploading operator credentials, changing a probe repository, production install, PyPI publish.
+
+## Ordered execution
+
+1. Record the contradictory SHA/external-write contract in OpenSpec and validate it strictly.
+2. Add RED workflow tests for a secret-free, external-write-free release profile and an isolated live canary.
+3. Add RED validator/schema tests proving profile separation and cross-profile rejection.
+4. Implement schema v2 and profile-aware validator/redaction behavior.
+5. Implement runner/driver branching while preserving all shared installer and attack-matrix gates.
+6. Make `rc-qualification.yml` deterministic; add `deployment-canary.yml`; bind release to release-profile evidence.
+7. Run focused tests, full pytest, build/twine/clean-wheel smoke, OpenSpec strict checks and PR-context preflight.
+8. Independently review each finding as fix/rebut/accepted-boundary, archive the OpenSpec change and re-run gates.
+9. Commit with a conventional message, push, open a zh-TW PR, obtain independent final-head approval and merge.
+10. Run exact-main deterministic qualification, dispatch `v0.1.9` release and verify tag target, non-draft release and wheel asset.
+
+## Release proof required
+
+- The deterministic qualification run succeeds on the exact merged main SHA without environment secrets.
+- Its schema-v2 evidence says `profile=release` and passes exact wheel/bundle validation.
+- Main Tests and final-head approval/checks are green for the merge commit's unique PR.
+- `v0.1.9` is an annotated tag at that exact SHA and the GitHub Release is published with exactly the rebuilt wheel.

--- a/docs/superpowers/runbooks/release-qualification.md
+++ b/docs/superpowers/runbooks/release-qualification.md
@@ -24,6 +24,11 @@
 前確認 `git rev-parse --is-shallow-repository` 為 `false`。depth-1 bundle 會漏掉 candidate 的
 parent history，直到 installer 執行 repository `fsck` 才以 drift 失敗，不能作為 release evidence。
 
+qualification evidence 位於專用的一次性 Docker volume，再由 runner 以 `docker cp` 匯出並於
+結束時刪除 volume。不要改回 container `/run`：systemd container 的 `/run` 是 tmpfs，Docker
+daemon 的 archive API 無法看見其中檔案；也不要改成 writable host bind，以免擴大 qualification
+對 host 的寫入面。
+
 ## 可選的 live canary
 
 只有要驗特定部署環境時才執行 `Deployment canary`。它使用 protected

--- a/docs/superpowers/runbooks/release-qualification.md
+++ b/docs/superpowers/runbooks/release-qualification.md
@@ -1,0 +1,35 @@
+# Release qualification and deployment canary
+
+這兩條 workflow 回答不同問題，不可互相替代：
+
+| Workflow | 回答的問題 | Credentials | 外部寫入 | 阻擋 GitHub Release |
+| --- | --- | --- | --- | --- |
+| `RC qualification` | exact wheel 能否安全安裝、啟動、驗證、回滾，且權限不變量是否成立？ | 不需要；只走固定非秘密 fixture | 禁止；container runtime 使用 `--network none` | 是，必須為同一 main SHA |
+| `Deployment canary` | 此刻的 provider 登入／配額／model、Manager GitHub 與完整派工是否健康？ | 需要 protected environment | 僅限明示 probe repository | 否 |
+
+## 發版操作
+
+1. 合入 release candidate PR，確認 default branch exact SHA 的 `Tests` workflow 全綠。
+2. 在 Actions 手動執行 `RC qualification`，ref 必須選同一個 default branch SHA。
+3. workflow 會產生 `rc-qualification-<sha>`；`qualification.json` 必須為
+   `schema_version: 2`、`profile: release`、`providers: []`。
+4. 手動執行 `Release`，輸入與 `VERSION` 完全相同的版本。release workflow 會重新 build wheel、
+   比對 wheel/bundle hashes，並以 `--require-release-profile` 驗證 evidence。
+5. 驗證 annotated tag、non-draft GitHub Release 與唯一 wheel asset 都指向同一 main SHA。
+
+這條路徑不需要設定 GitHub environment secrets 或 variables；若 `RC qualification` 要求它們，
+代表 workflow contract 已退化，應先修復而不是補值。
+
+## 可選的 live canary
+
+只有要驗特定部署環境時才執行 `Deployment canary`。它使用 protected
+`rc-qualification` environment，既有 live inputs 為：
+
+- secrets：`CORTEX_RC_CODEX_AUTH`、`CORTEX_RC_AGY_AUTH`、
+  `CORTEX_RC_COPILOT_AUTH`、`CORTEX_RC_MANAGER_GITHUB_AUTH`
+- variables：`CORTEX_RC_PROBE_REPOSITORY`、`CORTEX_RC_PROBE_WORK_ID`、
+  `CORTEX_RC_PROBE_ISSUE`
+
+canary 會產生 `deployment-canary-<sha>`，其 evidence profile 必須是
+`deployment-canary`。provider login/quota/model mismatch、fallback、Manager dry-run ref drift 或
+full dispatch 未 terminal 都會讓 canary 失敗，但 release workflow 永遠不查詢該 artifact。

--- a/docs/superpowers/runbooks/release-qualification.md
+++ b/docs/superpowers/runbooks/release-qualification.md
@@ -20,6 +20,10 @@
 這條路徑不需要設定 GitHub environment secrets 或 variables；若 `RC qualification` 要求它們，
 代表 workflow contract 已退化，應先修復而不是補值。
 
+兩條 qualification workflow 的 checkout 都必須使用 `fetch-depth: 0`，並在建立 source bundle
+前確認 `git rev-parse --is-shallow-repository` 為 `false`。depth-1 bundle 會漏掉 candidate 的
+parent history，直到 installer 執行 repository `fsck` 才以 drift 失敗，不能作為 release evidence。
+
 ## 可選的 live canary
 
 只有要驗特定部署環境時才執行 `Deployment canary`。它使用 protected

--- a/docs/superpowers/runbooks/release-qualification.md
+++ b/docs/superpowers/runbooks/release-qualification.md
@@ -29,6 +29,10 @@ qualification evidence 位於專用的一次性 Docker volume，再由 runner �
 daemon 的 archive API 無法看見其中檔案；也不要改成 writable host bind，以免擴大 qualification
 對 host 的寫入面。
 
+release validator 會要求 `qualification-output/evidence/` 的實際 regular-file 集合與
+`qualification.json`／`artifact-inventory.json` 列管集合完全一致；額外檔案、symlink、缺檔或
+tree 外 artifact 都會失敗。這能避免上傳內容存在未受 hash inventory 約束的旁路檔案。
+
 ## 可選的 live canary
 
 只有要驗特定部署環境時才執行 `Deployment canary`。它使用 protected

--- a/openspec/changes/archive/2026-08-26-release-qualification-boundary/design.md
+++ b/openspec/changes/archive/2026-08-26-release-qualification-boundary/design.md
@@ -1,0 +1,85 @@
+---
+status: accepted
+work_item: release-qualification-boundary
+---
+
+## Context
+
+目前 manual RC workflow 在 privileged systemd container 內先驗 exact wheel/bundle，再匯入四份
+protected secrets，呼叫三個 provider、執行 Manager GitHub dry-run，最後對真實 repository 做完整
+intake-to-closeout。release workflow 只接受同一 default-branch SHA 的成功 RC evidence。
+
+這兩個條件無法同時穩定成立：若 full dispatch 產生並合入 PR，default branch 由 A 前進到 B，
+則綁定 A 的 RC evidence 立即不符合 release 的 `main == candidate SHA` gate。即使 probe 沒有合入
+本 repo，release 仍被第三方 login、quota、network 與 mutable repository state 決定，這些都不是
+wheel 是否可安全安裝的屬性。
+
+## Decisions
+
+### 1. Evidence schema v2 明列不可互換的 profile
+
+root 新增 `profile`，唯一允許值為 `release` 或 `deployment-canary`，並將 `schema_version` 升為 2。
+Python validator 依 profile 套用不同 required tests/artifacts/provider semantics；CLI 以互斥的
+`--require-release-profile` 與 `--require-canary-profile` 鎖定呼叫端意圖。release workflow 必須使用
+前者，不能接受 canary evidence；canary workflow 必須使用後者，不能以缺少 live evidence 通過。
+
+### 2. Release profile 只驗 candidate 可控制的 deterministic invariant
+
+release profile 保留 exact wheel/bundle/image binding、fresh/idempotent/drift/rollback/reinstall、
+selfcheck、registry equation、generated-installed attestation、service identity/hardening、五族 attack
+matrix 與 negative controls。它不呼叫 provider CLI、不讀 GitHub auth、不執行 Manager remote probe，
+也不進入 `cortex work intake`。
+
+installer 的 required credential contract 仍透過固定 `{}` bytes 走正式 stdin import adapter；這些
+fixture 不是有效登入資料，不取自環境，也不可能授權外部操作。release profile 啟動服務後只執行
+本機驗證與權限攻擊矩陣。evidence 的 `providers` 必須是空陣列，且不得列出 provider、dispatch 或
+Manager GitHub artifacts/tests。
+
+### 3. Deployment canary 保留 live flow，但永不成為 package release prerequisite
+
+新增 manual `deployment-canary.yml`，在 protected `rc-qualification` environment 中接收既有四份
+secrets 與三個 probe variables，呼叫同一 runner 的 `deployment-canary` profile。它保留 native
+provider preflight/smoke、Manager GitHub dry-run 與 full dispatch closeout，並產生獨立 artifact
+名稱。它可以用來判斷特定部署環境是否健康，但 release workflow 不查詢、不下載也不驗證該 run。
+
+### 4. Redaction 依 profile fail closed
+
+release profile 只做 credential/token pattern 掃描，且若 workflow 或 runner 引用任何
+`CORTEX_RC_*` live input，contract tests 直接失敗。deployment-canary profile 除 token pattern 外，
+仍要求四份 secret env 都存在，並逐值掃描輸出；缺值即失敗。
+
+### 5. Release exact-SHA join 保持不變，只更正被 join 的證據
+
+release workflow 仍要求 default-branch HEAD、Tests、final-head approval/checks、fresh RC run、wheel
+hash 與 candidate SHA 完全一致。唯一變更是 qualification validator 要求 `release` profile。
+如此 RC 不再改變 GitHub remote state，A 的成功 evidence 能合法解鎖 A，不會自行製造 B。
+
+## Safety and Failure Semantics
+
+- profile 缺失、未知、與 validator flag 不符或混入另一 profile 的 artifacts/tests/providers，一律失敗。
+- release profile 不接受 environment secrets 或 probe variables；synthetic fixtures 固定於 runner，
+  只經 stdin 傳入 container tmpfs，使用後立即移除。
+- canary 仍不得輸出 credential bytes；secret 缺失、provider fallback、quota/login/model mismatch、
+  remote ref drift 或 dispatch 未 terminal 都失敗。
+- 兩條 workflow 均只允許 `workflow_dispatch` 並維持 40-hex action pins。
+
+## Rollout
+
+1. 先以 workflow/validator/runner regression 建立 RED，證明舊 RC 仍依賴 secrets 與 external writes。
+2. 實作 profile split，跑 focused/full tests、OpenSpec strict validation 與 policy preflight。
+3. 合入後在 exact default-branch SHA 執行 deterministic RC qualification。
+4. 只在該 evidence 與 release preflight 全綠後建立 `v0.1.9` tag/GitHub Release。
+5. deployment canary 可另行手動執行；其成功與否不改變 `v0.1.9` package release 判定。
+
+## Risks / Trade-offs
+
+- [Risk] package release 不再證明第三方 provider 當下可用。→ 這是 deployment canary 的責任；release
+  notes 與證據必須精確區分 installed-system qualification 與 live deployment health。
+- [Risk] synthetic credential 可能只驗到 import plumbing，未驗 credential 語意。→ canary 保留 native
+  auth/quota/model 驗證；release profile 明確不做 live-auth 宣稱。
+- [Risk] schema v2 使既有 v1 evidence 不能重用。→ fail closed 是刻意行為；重新對 exact SHA 跑新版
+  deterministic workflow，避免舊 live evidence 被誤認為新 release profile。
+
+## Open Questions
+
+無。

--- a/openspec/changes/archive/2026-08-26-release-qualification-boundary/proposal.md
+++ b/openspec/changes/archive/2026-08-26-release-qualification-boundary/proposal.md
@@ -1,0 +1,59 @@
+---
+status: accepted
+work_item: release-qualification-boundary
+---
+
+## Why
+
+現有 `rc-qualification` 同時承擔兩種互相衝突的責任：一方面要對 exact candidate
+wheel、systemd installer、權限與 rollback 提供可重現的 release 證據；另一方面又要求
+四份真實 provider/GitHub credentials，並在 probe repository 執行完整 intake-to-merge。
+完整派工會改變 GitHub default branch，而 release 又要求 qualification SHA 等於當下
+default-branch HEAD，因此成功的 live probe 本身即可使 candidate 過期。這讓 release gate
+依賴外部配額、真實憑證與可變 remote state，也形成無法穩定閉合的 SHA 循環。
+
+## Goals
+
+- 將 release-blocking qualification 收斂為 exact-SHA、無真實 credentials、無外部寫入且可重現的
+  Ubuntu 24.04 systemd/container 驗證。
+- 保留 installer credential import/activation plumbing，但只使用固定、非秘密的合成 fixture。
+- 將真實 provider、Manager GitHub 與 intake-to-closeout 驗證拆成受保護、手動執行的
+  deployment canary；其結果不得阻擋 package release。
+- 以 profile-aware evidence schema 與 validator 防止兩種證據互相冒充。
+
+## Non-Goals
+
+- 不降低 fresh install、idempotency、drift、rollback、reinstall、service identity、generated-vs-installed
+  attestation 或五族 attack matrix 的 release gate 強度。
+- 不將 deployment canary 自動化為 production deployment，也不替 operator 建立或上傳 credentials。
+- 不以 canary 成功宣稱所有 provider、配額或第三方服務永久可用。
+
+## What Changes
+
+- qualification evidence 升為 schema v2，明列不可互換的 `release` 與
+  `deployment-canary` profiles。
+- `rc-qualification` 移除 protected environment、live secrets 與 probe variables，
+  只執行 deterministic installer/systemd/attestation/attack gates。
+- 新增受保護的 manual deployment canary，承接 provider、Manager GitHub 與 full-dispatch
+  驗證，但 release workflow 不查詢其結果。
+- release validator 只接受 exact-SHA `release` profile，並拒絕 canary tests/artifacts。
+
+## Capabilities
+
+### New Capabilities
+
+無。
+
+### Modified Capabilities
+
+- `release-engineering-pipeline`: exact-SHA release qualification 必須 deterministic、credential-free、
+  external-write-free；live deployment canary 必須與 release gate 分離。
+
+## Impact
+
+- 修改 `qualification/run.sh`、`driver.py`、`validate.py`、evidence schema 與 redaction scanner，加入
+  `release`／`deployment-canary` profiles。
+- 修改 `.github/workflows/rc-qualification.yml`，移除 protected environment、secrets 與 probe variables。
+- 新增 `.github/workflows/deployment-canary.yml`，保留既有 live provider/GitHub/full-dispatch 驗證。
+- 修改 `.github/workflows/release.yml`，只接受 exact-SHA `release` profile evidence。
+- 擴充 workflow、validator、runner 與 redaction regression tests。

--- a/openspec/changes/archive/2026-08-26-release-qualification-boundary/specs/release-engineering-pipeline/spec.md
+++ b/openspec/changes/archive/2026-08-26-release-qualification-boundary/specs/release-engineering-pipeline/spec.md
@@ -1,27 +1,4 @@
-# release-engineering-pipeline Specification
-
-## Purpose
-建立 v0.1.0 可信賴發佈所需的 CI/release pipeline：多版本測試、封裝驗證、乾淨環境 smoke-install 與 tag 觸發 release。
-## Requirements
-### Requirement: release pipeline 必須驗證封裝產物可在乾淨環境安裝執行
-
-CI MUST 新增 build job 產出 wheel/sdist 並以 `twine check --strict` 驗證；MUST 新增 clean-venv smoke-install job，於乾淨虛擬環境安裝該 wheel 後執行 `cortex --version` 與 `cortex --help` 並確認皆 exit 0。
-
-#### Scenario: smoke-install 驗證
-
-- **WHEN** CI 於乾淨虛擬環境安裝 build job 產出的 wheel
-- **THEN** `cortex --version` 與 `cortex --help` 皆以 exit 0 結束
-- **THEN** 若安裝或執行失敗，smoke-install job MUST 標示為失敗，阻止該次 CI 視為全綠
-
-### Requirement: 新增 workflow 的 uses 必須 SHA pin 且不得變動既有引擎 pin
-
-本批次新增／修改的所有 `uses:` MUST 以 40-hex commit SHA 加版本註解 pin；MUST NOT 變動 `.github/workflows/policy-check.yml` 既有的引擎 pin。
-
-#### Scenario: release.yml 的 action pin
-
-- **WHEN** 審查 `.github/workflows/release.yml` 新增的每一個 `uses:` 步驟
-- **THEN** 每一個 `uses:` 皆為 `owner/action@<40-hex-sha>` 形式並附版本註解
-- **THEN** `.github/workflows/policy-check.yml` 的引擎 pin 內容與變更前完全一致
+## ADDED Requirements
 
 ### Requirement: GitHub Release MUST require deterministic exact-SHA qualification
 

--- a/openspec/changes/archive/2026-08-26-release-qualification-boundary/tasks.md
+++ b/openspec/changes/archive/2026-08-26-release-qualification-boundary/tasks.md
@@ -1,0 +1,30 @@
+---
+status: accepted
+work_item: release-qualification-boundary
+---
+
+# Tasks
+
+- [x] [RED] 新增 workflow regression：`rc-qualification` 不得使用 environment/secrets/probe variables，
+  必須以 `release` profile 執行；`deployment-canary` 才能持有 protected live inputs。
+- [x] [RED] 新增 schema/validator regression：release evidence 允許空 providers、拒絕 live artifacts/tests；
+  canary evidence 必須具備 provider/GitHub/full-dispatch semantics，兩者不可互換。
+- [x] [RED] 新增 runner/redaction regression：release profile 不讀任何 `CORTEX_RC_*` secret，canary
+  profile 仍對缺少 secret fail closed。
+- [x] [GREEN] 將 qualification evidence 升為 schema v2，加入 `release`／`deployment-canary` profile。
+- [x] [GREEN] 分流 runner/driver：共同執行 installer/systemd/attestation/attack gates；只在 canary 執行
+  provider smoke、Manager GitHub probe 與 full dispatch。
+- [x] [GREEN] 將 rc workflow 改為 deterministic release profile，並新增受保護的 manual canary workflow。
+- [x] [GREEN] release workflow 改用 `--require-release-profile`，維持 exact-SHA/freshness/hash join。
+- [x] [GREEN] 更新 redaction scanner、CHANGELOG、fragment 與 release qualification 操作文件。
+- [x] 驗證 focused/full pytest、schema、active OpenSpec strict validation、build/twine 與 clean-wheel smoke。
+- [x] 逐項自我對抗 review：release profile 不會呼叫 live functions、runtime 無網路、profile 不可互換、
+  candidate build recipe 相同，且 canary artifact 不被 release workflow 引用；查無未處置 BLOCKER/MAJOR。
+
+## External closeout gates
+
+以下步驟刻意不偽裝成 archive 前可完成的 implementation checkbox：
+
+- 封存本 change、驗 canonical specs，並以真實 PR metadata 跑 policy/preflight。
+- conventional commit、push、PR、final-head checks 與 `paulc-arc` 獨立 approval 後才 merge。
+- merge 後在 exact main SHA 跑 deterministic qualification，再執行並驗證 `v0.1.9` GitHub Release。

--- a/qualification/driver.py
+++ b/qualification/driver.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
-"""Trusted executable probes for Cortex RC qualification.
+"""Trusted executable probes for Cortex release qualification and deployment canary.
 
 The driver is copied into the reference image before the candidate is mounted.
-It never imports qualification verdicts from the candidate checkout.  A missing
-probe, missing provider-native runtime identity, or missing protected probe
-repository is a hard failure.
+It never imports qualification verdicts from the candidate checkout. Shared
+installer and isolation probes always fail closed; provider-native identity and
+protected repository probes are additionally required by deployment-canary mode.
 """
 
 from __future__ import annotations
@@ -2882,9 +2882,12 @@ def main() -> int:
     parser.add_argument("--bundle-sha256", required=True)
     parser.add_argument("--image-digest", required=True)
     parser.add_argument("--wheel-filename", required=True)
-    parser.add_argument("--probe-repository", required=True)
-    parser.add_argument("--probe-work-id", required=True)
-    parser.add_argument("--probe-issue", required=True, type=int)
+    parser.add_argument(
+        "--profile", required=True, choices=("release", "deployment-canary")
+    )
+    parser.add_argument("--probe-repository")
+    parser.add_argument("--probe-work-id")
+    parser.add_argument("--probe-issue", type=int)
     parser.add_argument("--dispatch-timeout", type=int, default=7200)
     parser.add_argument("--output", required=True, type=Path)
     parser.add_argument("--evidence-dir", required=True, type=Path)
@@ -2894,6 +2897,13 @@ def main() -> int:
     for label, value in (("wheel", args.wheel_sha256), ("bundle", args.bundle_sha256)):
         if SHA256.fullmatch(value) is None:
             parser.error(f"{label} SHA-256 is invalid")
+    probe_values = (args.probe_repository, args.probe_work_id, args.probe_issue)
+    if args.profile == "release" and any(value is not None for value in probe_values):
+        parser.error("release profile must not receive external probe inputs")
+    if args.profile == "deployment-canary" and any(
+        value is None for value in probe_values
+    ):
+        parser.error("deployment-canary profile requires every external probe input")
     try:
         receipt = _load_json(args.receipt, "install receipt")
         args.evidence_dir.mkdir(parents=True, exist_ok=False)
@@ -2914,20 +2924,25 @@ def main() -> int:
             )
         ]
         tests.append({"name": "negative-controls", "status": "passed"})
-        providers = _provider_smokes(args.evidence_dir)
-        tests.append({"name": "provider-capability-smoke", "status": "passed"})
-        _manager_github_probe(
-            args.probe_repository, args.candidate_sha, args.evidence_dir
-        )
-        tests.append({"name": "manager-github-dry-run-push", "status": "passed"})
-        _full_dispatch(
-            repository=args.probe_repository,
-            work_id=args.probe_work_id,
-            issue=args.probe_issue,
-            timeout=args.dispatch_timeout,
-            evidence_dir=args.evidence_dir,
-        )
-        tests.append({"name": "full-dispatch-closeout", "status": "passed"})
+        providers: list[dict[str, object]] = []
+        if args.profile == "deployment-canary":
+            providers = _provider_smokes(args.evidence_dir)
+            tests.append({"name": "provider-capability-smoke", "status": "passed"})
+            assert args.probe_repository is not None
+            assert args.probe_work_id is not None
+            assert args.probe_issue is not None
+            _manager_github_probe(
+                args.probe_repository, args.candidate_sha, args.evidence_dir
+            )
+            tests.append({"name": "manager-github-dry-run-push", "status": "passed"})
+            _full_dispatch(
+                repository=args.probe_repository,
+                work_id=args.probe_work_id,
+                issue=args.probe_issue,
+                timeout=args.dispatch_timeout,
+                evidence_dir=args.evidence_dir,
+            )
+            tests.append({"name": "full-dispatch-closeout", "status": "passed"})
         tests = [
             {"name": name, "status": "passed"}
             for name in (
@@ -2940,7 +2955,8 @@ def main() -> int:
         ] + tests
         artifacts = _artifact_inventory(args.evidence_dir)
         qualification = {
-            "schema_version": 1,
+            "schema_version": 2,
+            "profile": args.profile,
             "status": "passed",
             "candidate_sha": args.candidate_sha,
             "wheel": {"filename": args.wheel_filename, "sha256": args.wheel_sha256},

--- a/qualification/qualification.schema.json
+++ b/qualification/qualification.schema.json
@@ -6,6 +6,7 @@
   "additionalProperties": false,
   "required": [
     "schema_version",
+    "profile",
     "status",
     "candidate_sha",
     "wheel",
@@ -17,7 +18,8 @@
     "artifacts"
   ],
   "properties": {
-    "schema_version": {"const": 1},
+    "schema_version": {"const": 2},
+    "profile": {"enum": ["release", "deployment-canary"]},
     "status": {"enum": ["passed", "failed", "skipped"]},
     "candidate_sha": {"type": "string", "pattern": "^[0-9a-f]{40}$"},
     "wheel": {
@@ -68,7 +70,7 @@
     },
     "providers": {
       "type": "array",
-      "minItems": 1,
+      "minItems": 0,
       "items": {
         "type": "object",
         "additionalProperties": false,
@@ -123,5 +125,15 @@
         }
       }
     }
-  }
+  },
+  "allOf": [
+    {
+      "if": {"properties": {"profile": {"const": "release"}}},
+      "then": {"properties": {"providers": {"maxItems": 0}}}
+    },
+    {
+      "if": {"properties": {"profile": {"const": "deployment-canary"}}},
+      "then": {"properties": {"providers": {"minItems": 3, "maxItems": 3}}}
+    }
+  ]
 }

--- a/qualification/redaction_scan.py
+++ b/qualification/redaction_scan.py
@@ -23,7 +23,11 @@ TOKEN_PATTERNS = (
 )
 
 
-def _needles() -> tuple[bytes, ...]:
+def _needles(profile: str) -> tuple[bytes, ...]:
+    if profile == "release":
+        return ()
+    if profile != "deployment-canary":
+        raise ValueError("profile must be release or deployment-canary")
     values: set[bytes] = set()
     for name in SECRET_ENV:
         raw = os.environ.get(name)
@@ -40,10 +44,10 @@ def _needles() -> tuple[bytes, ...]:
     return tuple(sorted(values, key=len, reverse=True))
 
 
-def scan(root: Path) -> None:
+def scan(root: Path, *, profile: str) -> None:
     if root.is_symlink() or not root.is_dir():
         raise ValueError("upload root must be a regular directory")
-    needles = _needles()
+    needles = _needles(profile)
     for path in root.rglob("*"):
         if path.is_symlink():
             raise ValueError(f"upload candidate contains a symlink: {path}")
@@ -59,9 +63,12 @@ def scan(root: Path) -> None:
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("root", type=Path)
+    parser.add_argument(
+        "--profile", required=True, choices=("release", "deployment-canary")
+    )
     args = parser.parse_args()
     try:
-        scan(args.root)
+        scan(args.root, profile=args.profile)
     except (OSError, ValueError) as exc:
         print(f"redaction scan failed: {exc}", file=sys.stderr)
         return 1

--- a/qualification/run.sh
+++ b/qualification/run.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 usage() {
-    echo "usage: $0 --artifacts DIR --candidate-sha SHA --wheel-sha256 SHA --bundle-sha256 SHA --output DIR" >&2
+    echo "usage: $0 --profile {release|deployment-canary} --artifacts DIR --candidate-sha SHA --wheel-sha256 SHA --bundle-sha256 SHA --output DIR" >&2
     exit 2
 }
 
@@ -17,9 +17,11 @@ candidate_sha=""
 expected_wheel_sha=""
 expected_bundle_sha=""
 output_dir=""
+profile=""
 
 while (($#)); do
     case "$1" in
+        --profile) profile=${2-}; shift 2 ;;
         --artifacts) artifact_dir=${2-}; shift 2 ;;
         --candidate-sha) candidate_sha=${2-}; shift 2 ;;
         --wheel-sha256) expected_wheel_sha=${2-}; shift 2 ;;
@@ -30,6 +32,7 @@ while (($#)); do
 done
 
 [[ -d "$artifact_dir" && -n "$output_dir" ]] || usage
+[[ "$profile" == release || "$profile" == deployment-canary ]] || usage
 [[ "$candidate_sha" =~ ^[0-9a-f]{40}$ ]] || die "candidate SHA must be 40 lowercase hex characters"
 [[ "$expected_wheel_sha" =~ ^[0-9a-f]{64}$ ]] || die "wheel SHA-256 must be 64 lowercase hex characters"
 [[ "$expected_bundle_sha" =~ ^[0-9a-f]{64}$ ]] || die "bundle SHA-256 must be 64 lowercase hex characters"
@@ -72,6 +75,12 @@ image_digest=$(docker image inspect --format '{{.Id}}' "$image_tag")
 [[ "$image_digest" =~ ^sha256:[0-9a-f]{64}$ ]] || die "Docker image has no content digest"
 
 docker volume create "$volume_name" >/dev/null
+network_args=()
+if [[ "$profile" == release ]]; then
+    # The release profile must be incapable of contacting providers or remotes,
+    # even if an installed service unexpectedly attempts a network operation.
+    network_args=(--network none)
+fi
 docker run --detach \
     --name "$container_name" \
     --hostname cortex-qualification \
@@ -82,6 +91,7 @@ docker run --detach \
     --mount "type=bind,source=$artifact_dir,target=/artifacts,readonly" \
     --volume "/sys/fs/cgroup:/sys/fs/cgroup:rw" \
     --mount "type=volume,source=$volume_name,target=/var/lib/cortex" \
+    "${network_args[@]}" \
     "$image_tag" >/dev/null
 
 for _attempt in $(seq 1 60); do
@@ -173,10 +183,10 @@ for provider_tool in codex claude copilot agy srt openspec; do
         sh "$provider_tool"
 done
 
-# Credentials are deliberately not discovered from any HOME. Each protected
-# environment secret is streamed over stdin into container tmpfs, imported by
-# the explicit provider adapter, and then removed. Secret values are never
-# arguments, receipts, or log output.
+# Credential inputs are deliberately not discovered from any HOME. Canary
+# secrets and release-profile non-secret fixtures both travel over stdin into
+# container tmpfs, pass through the production adapter, and are then removed.
+# Secret values are never arguments, receipts, or log output.
 import_secret() {
     local variable_name=$1 principal=$2 provider=$3 source_path=$4
     [[ -n ${!variable_name:-} ]] || die "required protected secret $variable_name is unavailable"
@@ -191,17 +201,37 @@ import_secret() {
     unset "$variable_name"
 }
 
-import_secret CORTEX_RC_CODEX_AUTH builder codex /run/auth.json
-import_secret CORTEX_RC_AGY_AUTH reviewer-planner agy /run/oauth_creds.json
-import_secret CORTEX_RC_COPILOT_AUTH reviewer-planner copilot /run/hosts.json
-import_secret CORTEX_RC_MANAGER_GITHUB_AUTH manager github /run/hosts.yml
+import_fixture() {
+    local principal=$1 provider=$2 source_path=$3
+    printf '%s' '{}' | docker exec -i "$container_name" \
+        sh -eu -c 'umask 077; cat > "$1"' sh "$source_path"
+    docker exec "$container_name" cortex install trust-root credentials import \
+        --receipt "$receipt_path" \
+        --principal "$principal" \
+        --provider "$provider" \
+        --source "$source_path"
+    docker exec "$container_name" sh -eu -c 'rm -f -- "$1"' sh "$source_path"
+}
 
-# The protected Codex import lands in the account's legacy ``~/.codex`` path.
-# Run the same production scaffold once more so that this newly supplied
-# credential is projected into the Manager-owned canonical authority consumed
-# by ``spool_slot.provision_runtime_surfaces``. Existing control trees and
-# generated hooks are already present, so the scaffold is idempotent here and
-# does not replace them.
+if [[ "$profile" == deployment-canary ]]; then
+    import_secret CORTEX_RC_CODEX_AUTH builder codex /run/auth.json
+    import_secret CORTEX_RC_AGY_AUTH reviewer-planner agy /run/oauth_creds.json
+    import_secret CORTEX_RC_COPILOT_AUTH reviewer-planner copilot /run/hosts.json
+    import_secret CORTEX_RC_MANAGER_GITHUB_AUTH manager github /run/hosts.yml
+else
+    # Exercise the production import/activation path without introducing a
+    # credential or external authority into release qualification.
+    import_fixture builder codex /run/auth.json
+    import_fixture reviewer-planner agy /run/oauth_creds.json
+    import_fixture reviewer-planner copilot /run/hosts.json
+    import_fixture manager github /run/hosts.yml
+fi
+
+# Imported Codex material lands in the account's legacy ``~/.codex`` path. Run
+# the same production scaffold once more so the canary credential or release
+# fixture traverses the Manager-owned canonical projection used by
+# ``spool_slot.provision_runtime_surfaces``. Existing controls and generated
+# hooks are already present, so the scaffold remains idempotent.
 docker exec "$container_name" sh -eu -c \
     'printf "%s\n" "{}" > /var/lib/cortex-reviewer-planner/.codex/auth.json
      python3 -m paulsha_cortex.trust_root scaffold | sh -eu
@@ -218,15 +248,24 @@ docker exec \
     "$container_name" cortex install trust-root verify \
     --receipt "$receipt_path" --json --evidence "$install_evidence_path"
 
-# Provider smokes, runtime-model metadata, all five attack families (including
-# negative controls), Manager auth dry-run, and full intake-to-closeout must be
-# run by a fixed harness installed in the reference image, not by candidate JSON.
-# Protected repository identity is deployment input; it is never inferred from
-# a mounted HOME or from an untrusted candidate-produced evidence document.
+# A fixed harness installed in the reference image always runs the five attack
+# families and negative controls. Only deployment-canary mode adds provider
+# smokes/runtime identity, Manager auth dry-run, and full intake-to-closeout;
+# protected repository identity is never inferred from HOME or candidate JSON.
 qualification_driver=/usr/local/libexec/cortex-release-qualification
-[[ -n ${CORTEX_RC_PROBE_REPOSITORY:-} ]] || die "protected probe repository is unavailable"
-[[ -n ${CORTEX_RC_PROBE_WORK_ID:-} ]] || die "protected probe work id is unavailable"
-[[ ${CORTEX_RC_PROBE_ISSUE:-} =~ ^[1-9][0-9]*$ ]] || die "protected probe issue is unavailable"
+driver_profile_args=(--profile "$profile")
+validator_profile_args=(--require-release-profile)
+if [[ "$profile" == deployment-canary ]]; then
+    [[ -n ${CORTEX_RC_PROBE_REPOSITORY:-} ]] || die "protected probe repository is unavailable"
+    [[ -n ${CORTEX_RC_PROBE_WORK_ID:-} ]] || die "protected probe work id is unavailable"
+    [[ ${CORTEX_RC_PROBE_ISSUE:-} =~ ^[1-9][0-9]*$ ]] || die "protected probe issue is unavailable"
+    driver_profile_args+=(
+        --probe-repository "$CORTEX_RC_PROBE_REPOSITORY"
+        --probe-work-id "$CORTEX_RC_PROBE_WORK_ID"
+        --probe-issue "$CORTEX_RC_PROBE_ISSUE"
+    )
+    validator_profile_args=(--require-canary-profile)
+fi
 wheel_filename=$(basename "$wheel_path")
 docker exec "$container_name" "$qualification_driver" \
     --receipt "$receipt_path" \
@@ -236,9 +275,7 @@ docker exec "$container_name" "$qualification_driver" \
     --bundle-sha256 "$expected_bundle_sha" \
     --image-digest "$image_digest" \
     --wheel-filename "$wheel_filename" \
-    --probe-repository "$CORTEX_RC_PROBE_REPOSITORY" \
-    --probe-work-id "$CORTEX_RC_PROBE_WORK_ID" \
-    --probe-issue "$CORTEX_RC_PROBE_ISSUE" \
+    "${driver_profile_args[@]}" \
     --output "$qualification_path" \
     --evidence-dir "$qualification_root/evidence"
 
@@ -248,7 +285,7 @@ docker exec "$container_name" /usr/local/libexec/cortex-qualification-validate \
     --wheel-sha256 "$expected_wheel_sha" \
     --bundle-sha256 "$expected_bundle_sha" \
     --evidence-root "$qualification_root" \
-    --require-full-suite
+    "${validator_profile_args[@]}"
 
 # docker cp is used instead of binding a host output directory. The only host
 # input bind is the read-only artifact directory above.
@@ -262,4 +299,4 @@ python3 "$script_dir/validate.py" \
     --wheel-sha256 "$expected_wheel_sha" \
     --bundle-sha256 "$expected_bundle_sha" \
     --evidence-root "$output_dir" \
-    --require-full-suite
+    "${validator_profile_args[@]}"

--- a/qualification/run.sh
+++ b/qualification/run.sh
@@ -63,10 +63,12 @@ python3 "$script_dir/verify_bundle.py" \
 image_tag="cortex-qualification:${candidate_sha}"
 container_name="cortex-qualification-${candidate_sha:0:12}-$$"
 volume_name="cortex-qualification-data-${candidate_sha:0:12}-$$"
+output_volume_name="cortex-qualification-output-${candidate_sha:0:12}-$$"
 
 cleanup() {
     docker rm --force "$container_name" >/dev/null 2>&1 || true
     docker volume rm "$volume_name" >/dev/null 2>&1 || true
+    docker volume rm "$output_volume_name" >/dev/null 2>&1 || true
 }
 trap cleanup EXIT INT TERM
 
@@ -75,6 +77,7 @@ image_digest=$(docker image inspect --format '{{.Id}}' "$image_tag")
 [[ "$image_digest" =~ ^sha256:[0-9a-f]{64}$ ]] || die "Docker image has no content digest"
 
 docker volume create "$volume_name" >/dev/null
+docker volume create "$output_volume_name" >/dev/null
 network_args=()
 if [[ "$profile" == release ]]; then
     # The release profile must be incapable of contacting providers or remotes,
@@ -91,6 +94,7 @@ docker run --detach \
     --mount "type=bind,source=$artifact_dir,target=/artifacts,readonly" \
     --volume "/sys/fs/cgroup:/sys/fs/cgroup:rw" \
     --mount "type=volume,source=$volume_name,target=/var/lib/cortex" \
+    --mount "type=volume,source=$output_volume_name,target=/qualification-output" \
     "${network_args[@]}" \
     "$image_tag" >/dev/null
 
@@ -117,7 +121,7 @@ docker exec "$container_name" sh -eu -c \
 
 plan_path=/run/cortex-install/install-plan.json
 receipt_path=/run/cortex-install/install-receipt.json
-qualification_root=/run/cortex-qualification
+qualification_root=/qualification-output
 qualification_path=$qualification_root/qualification.json
 
 docker exec "$container_name" install -d -o root -g root -m 0700 /run/cortex-install
@@ -287,8 +291,9 @@ docker exec "$container_name" /usr/local/libexec/cortex-qualification-validate \
     --evidence-root "$qualification_root" \
     "${validator_profile_args[@]}"
 
-# docker cp is used instead of binding a host output directory. The only host
-# input bind is the read-only artifact directory above.
+# Evidence lives on a dedicated disposable Docker volume because Docker's archive
+# API cannot read the /run tmpfs. docker cp still avoids a writable host bind; the
+# only host input bind is the read-only artifact directory above.
 docker cp "$container_name:$qualification_path" "$output_dir/qualification.json"
 docker cp "$container_name:$qualification_root/evidence" "$output_dir/evidence"
 

--- a/qualification/validate.py
+++ b/qualification/validate.py
@@ -206,6 +206,38 @@ def _validate_artifact_inventory(
         )
 
 
+def _validate_evidence_file_set(
+    *, evidence_root: Path, artifact_paths: set[str]
+) -> None:
+    evidence_dir = evidence_root / "evidence"
+    if evidence_dir.is_symlink() or not evidence_dir.is_dir():
+        _fail("evidence root must contain a regular evidence directory")
+
+    actual_paths: set[str] = set()
+    for candidate in evidence_dir.rglob("*"):
+        relative = candidate.relative_to(evidence_root).as_posix()
+        if candidate.is_symlink():
+            _fail(f"evidence tree contains a symlink: {relative}")
+        if candidate.is_dir():
+            continue
+        if not candidate.is_file():
+            _fail(f"evidence tree contains a non-regular entry: {relative}")
+        actual_paths.add(relative)
+
+    unlisted = actual_paths - artifact_paths
+    if unlisted:
+        _fail(
+            "evidence tree contains unlisted evidence files: "
+            + ", ".join(sorted(unlisted))
+        )
+    outside_tree = artifact_paths - actual_paths
+    if outside_tree:
+        _fail(
+            "qualification lists files outside the canonical evidence tree: "
+            + ", ".join(sorted(outside_tree))
+        )
+
+
 def _validate_profile_artifacts(
     *,
     qualification: dict[str, Any],
@@ -778,6 +810,10 @@ def validate(
                 + ", ".join(sorted(missing_artifacts))
             )
         assert evidence_root is not None
+        _validate_evidence_file_set(
+            evidence_root=evidence_root,
+            artifact_paths=artifact_paths,
+        )
         _validate_profile_artifacts(
             qualification=root,
             evidence_root=evidence_root,

--- a/qualification/validate.py
+++ b/qualification/validate.py
@@ -22,6 +22,7 @@ IMAGE_DIGEST = re.compile(r"^sha256:[0-9a-f]{64}$")
 WHEEL_NAME = re.compile(r"^[A-Za-z0-9_.+-]+\.whl$")
 ROOT_KEYS = {
     "schema_version",
+    "profile",
     "status",
     "candidate_sha",
     "wheel",
@@ -37,7 +38,8 @@ REQUIRED_PROVIDERS = {
     "copilot": ("gpt-5.4", "xhigh"),
     "codex": ("gpt-5", "normal"),
 }
-REQUIRED_TESTS = {"fresh-install", "full-dispatch-closeout"}
+QUALIFICATION_PROFILES = {"release", "deployment-canary"}
+BASE_TESTS = {"fresh-install"}
 REQUIRED_RELEASE_SERVICES = {
     "cortex-egress-proxy.service",
     "cortex-manager.service",
@@ -47,10 +49,12 @@ REQUIRED_RELEASE_ARTIFACTS = {
     "evidence/install-verification.json",
     "evidence/generated-installed-attestation.json",
     "evidence/attack-matrix.json",
+    "evidence/artifact-inventory.json",
+}
+CANARY_ONLY_ARTIFACTS = {
     "evidence/provider-capabilities.json",
     "evidence/dispatch-closeout.json",
     "evidence/manager-github-auth.json",
-    "evidence/artifact-inventory.json",
 }
 REQUIRED_RELEASE_TESTS = {
     "fresh-install",
@@ -68,10 +72,14 @@ REQUIRED_RELEASE_TESTS = {
     "process-attack-matrix",
     "gate-attack-matrix",
     "negative-controls",
+}
+CANARY_ONLY_TESTS = {
     "provider-capability-smoke",
     "full-dispatch-closeout",
     "manager-github-dry-run-push",
 }
+REQUIRED_CANARY_ARTIFACTS = REQUIRED_RELEASE_ARTIFACTS | CANARY_ONLY_ARTIFACTS
+REQUIRED_CANARY_TESTS = REQUIRED_RELEASE_TESTS | CANARY_ONLY_TESTS
 R9_HEADLESS_PRINCIPALS = {"cortex-builder", "cortex-reviewer-planner"}
 R9_DENY_ONLY_ASSET_IDS = {"review-verdict"}
 R9_MUTATIONS = {
@@ -160,11 +168,50 @@ def _normalized_keys(value: Any, keys: set[str]) -> set[str]:
     return found
 
 
-def _validate_full_suite_artifacts(
+def _validate_artifact_inventory(
+    *,
+    evidence_root: Path,
+    artifact_hashes: dict[str, str],
+) -> None:
+    inventory = _mapping(
+        _artifact_json(evidence_root, "evidence/artifact-inventory.json"),
+        "artifact-inventory",
+        {"schema_version", "status", "artifacts"},
+    )
+    if inventory["schema_version"] != 1 or inventory["status"] != "passed":
+        _fail("artifact-inventory must pass")
+    inventory_hashes: dict[str, str] = {}
+    for index, raw in enumerate(
+        _list(inventory["artifacts"], "artifact-inventory.artifacts")
+    ):
+        row = _mapping(
+            raw, f"artifact-inventory.artifacts[{index}]", {"path", "sha256"}
+        )
+        path = _nonempty_string(
+            row["path"], f"artifact-inventory.artifacts[{index}].path"
+        )
+        if path in inventory_hashes:
+            _fail(f"artifact-inventory duplicates {path}")
+        inventory_hashes[path] = _digest(
+            row["sha256"], f"artifact-inventory.artifacts[{index}].sha256"
+        )
+    expected_inventory = {
+        path: digest
+        for path, digest in artifact_hashes.items()
+        if path != "evidence/artifact-inventory.json"
+    }
+    if inventory_hashes != expected_inventory:
+        _fail(
+            "artifact-inventory does not exactly attest every non-inventory evidence file"
+        )
+
+
+def _validate_profile_artifacts(
     *,
     qualification: dict[str, Any],
     evidence_root: Path,
     artifact_hashes: dict[str, str],
+    include_canary: bool,
 ) -> None:
     """Validate evidence semantics, not merely candidate-supplied filenames and hashes."""
 
@@ -376,6 +423,12 @@ def _validate_full_suite_artifacts(
             "attack-matrix must include a successful negative control for every family"
         )
 
+    if not include_canary:
+        _validate_artifact_inventory(
+            evidence_root=evidence_root, artifact_hashes=artifact_hashes
+        )
+        return
+
     provider_evidence = _mapping(
         _artifact_json(evidence_root, "evidence/provider-capabilities.json"),
         "provider-capabilities",
@@ -506,37 +559,9 @@ def _validate_full_suite_artifacts(
     if before != after:
         _fail("manager-github-auth remote refs changed")
 
-    inventory = _mapping(
-        _artifact_json(evidence_root, "evidence/artifact-inventory.json"),
-        "artifact-inventory",
-        {"schema_version", "status", "artifacts"},
+    _validate_artifact_inventory(
+        evidence_root=evidence_root, artifact_hashes=artifact_hashes
     )
-    if inventory["schema_version"] != 1 or inventory["status"] != "passed":
-        _fail("artifact-inventory must pass")
-    inventory_hashes: dict[str, str] = {}
-    for index, raw in enumerate(
-        _list(inventory["artifacts"], "artifact-inventory.artifacts")
-    ):
-        row = _mapping(
-            raw, f"artifact-inventory.artifacts[{index}]", {"path", "sha256"}
-        )
-        path = _nonempty_string(
-            row["path"], f"artifact-inventory.artifacts[{index}].path"
-        )
-        if path in inventory_hashes:
-            _fail(f"artifact-inventory duplicates {path}")
-        inventory_hashes[path] = _digest(
-            row["sha256"], f"artifact-inventory.artifacts[{index}].sha256"
-        )
-    expected_inventory = {
-        path: digest
-        for path, digest in artifact_hashes.items()
-        if path != "evidence/artifact-inventory.json"
-    }
-    if inventory_hashes != expected_inventory:
-        _fail(
-            "artifact-inventory does not exactly attest every non-inventory evidence file"
-        )
 
 
 def validate(
@@ -546,15 +571,26 @@ def validate(
     wheel_sha256: str,
     bundle_sha256: str | None = None,
     evidence_root: Path | None = None,
-    require_full_suite: bool = False,
+    require_release_profile: bool = False,
+    require_canary_profile: bool = False,
 ) -> None:
     """Validate schema, release binding, and every fail-closed verdict."""
 
     root = _mapping(payload, "$", ROOT_KEYS)
-    if root["schema_version"] != 1 or isinstance(root["schema_version"], bool):
-        _fail("$.schema_version must be 1")
+    if root["schema_version"] != 2 or isinstance(root["schema_version"], bool):
+        _fail("$.schema_version must be 2")
     if root["status"] != "passed":
         _fail("$.status must be passed")
+    profile = _nonempty_string(root["profile"], "$.profile")
+    if profile not in QUALIFICATION_PROFILES:
+        _fail("$.profile must be release or deployment-canary")
+    if require_release_profile and require_canary_profile:
+        _fail("release and deployment-canary profiles are mutually exclusive")
+    if require_release_profile and profile != "release":
+        _fail("qualification profile is not release")
+    if require_canary_profile and profile != "deployment-canary":
+        _fail("qualification profile is not deployment-canary")
+    require_profile_suite = require_release_profile or require_canary_profile
 
     evidence_sha = _nonempty_string(root["candidate_sha"], "$.candidate_sha")
     if SHA40.fullmatch(evidence_sha) is None:
@@ -593,9 +629,9 @@ def validate(
                 _fail(f"{path}.{key} must be a non-negative integer")
         if service["active"] is not True:
             _fail(f"{path}.active must be true")
-    if require_full_suite and service_names != REQUIRED_RELEASE_SERVICES:
+    if require_profile_suite and service_names != REQUIRED_RELEASE_SERVICES:
         _fail("$.services must contain exactly egress proxy, Manager, and Monitor")
-    if require_full_suite:
+    if require_profile_suite:
         services_by_name = {service["name"]: service for service in root["services"]}
         manager = services_by_name["cortex-manager.service"]
         monitor = services_by_name["cortex-monitor.service"]
@@ -622,7 +658,10 @@ def validate(
         "quota",
         "fallback",
     }
-    for index, raw_provider in enumerate(_list(root["providers"], "$.providers")):
+    raw_providers = root["providers"]
+    if not isinstance(raw_providers, list):
+        _fail("$.providers must be an array")
+    for index, raw_provider in enumerate(raw_providers):
         path = f"$.providers[{index}]"
         provider = _mapping(raw_provider, path, provider_keys)
         name = _nonempty_string(provider["provider"], f"{path}.provider")
@@ -651,18 +690,22 @@ def validate(
             _fail(f"{path} runtime model does not match requested model")
         if runtime_effort != requested_effort:
             _fail(f"{path} runtime effort does not match requested effort")
-    if provider_names != set(REQUIRED_PROVIDERS):
-        _fail("$.providers must contain exactly agy, copilot, and codex verdicts")
-    for provider in root["providers"]:
-        expected_model, expected_effort = REQUIRED_PROVIDERS[provider["provider"]]
-        if provider["requested_model"] != expected_model:
-            _fail(
-                f"provider {provider['provider']} must request model {expected_model}"
-            )
-        if provider["requested_effort"] != expected_effort:
-            _fail(
-                f"provider {provider['provider']} must request effort {expected_effort}"
-            )
+    if profile == "release":
+        if provider_names:
+            _fail("release qualification must not contain provider verdicts")
+    else:
+        if provider_names != set(REQUIRED_PROVIDERS):
+            _fail("$.providers must contain exactly agy, copilot, and codex verdicts")
+        for provider in root["providers"]:
+            expected_model, expected_effort = REQUIRED_PROVIDERS[provider["provider"]]
+            if provider["requested_model"] != expected_model:
+                _fail(
+                    f"provider {provider['provider']} must request model {expected_model}"
+                )
+            if provider["requested_effort"] != expected_effort:
+                _fail(
+                    f"provider {provider['provider']} must request effort {expected_effort}"
+                )
 
     test_names: set[str] = set()
     for index, raw_test in enumerate(_list(root["tests"], "$.tests")):
@@ -674,19 +717,27 @@ def validate(
         test_names.add(name)
         if test["status"] != "passed":
             _fail(f"{path}.status must be passed")
-    missing_tests = REQUIRED_TESTS - test_names
+    required_base_tests = BASE_TESTS | (
+        {"full-dispatch-closeout"} if profile == "deployment-canary" else set()
+    )
+    missing_tests = required_base_tests - test_names
     if missing_tests:
         _fail(
             "$.tests missing release-critical results: "
             + ", ".join(sorted(missing_tests))
         )
-    if require_full_suite:
-        missing_release_tests = REQUIRED_RELEASE_TESTS - test_names
-        if missing_release_tests:
+    required_profile_tests = (
+        REQUIRED_RELEASE_TESTS if profile == "release" else REQUIRED_CANARY_TESTS
+    )
+    if require_profile_suite:
+        missing_profile_tests = required_profile_tests - test_names
+        if missing_profile_tests:
             _fail(
-                "$.tests missing full release qualification results: "
-                + ", ".join(sorted(missing_release_tests))
+                f"$.tests missing full {profile} qualification results: "
+                + ", ".join(sorted(missing_profile_tests))
             )
+    if profile == "release" and test_names & CANARY_ONLY_TESTS:
+        _fail("release qualification must not contain live canary tests")
 
     artifact_paths: set[str] = set()
     artifact_hashes: dict[str, str] = {}
@@ -710,20 +761,28 @@ def validate(
             if actual_artifact_sha != expected_artifact_sha:
                 _fail(f"{path}.sha256 does not match the evidence file")
 
-    if require_full_suite and evidence_root is None:
-        _fail("full release validation requires --evidence-root")
-    if require_full_suite:
-        missing_artifacts = REQUIRED_RELEASE_ARTIFACTS - artifact_paths
+    if require_profile_suite and evidence_root is None:
+        _fail(f"full {profile} validation requires --evidence-root")
+    if profile == "release" and artifact_paths & CANARY_ONLY_ARTIFACTS:
+        _fail("release qualification must not contain live canary artifacts")
+    if require_profile_suite:
+        required_artifacts = (
+            REQUIRED_RELEASE_ARTIFACTS
+            if profile == "release"
+            else REQUIRED_CANARY_ARTIFACTS
+        )
+        missing_artifacts = required_artifacts - artifact_paths
         if missing_artifacts:
             _fail(
-                "$.artifacts missing release-critical evidence: "
+                f"$.artifacts missing {profile}-critical evidence: "
                 + ", ".join(sorted(missing_artifacts))
             )
         assert evidence_root is not None
-        _validate_full_suite_artifacts(
+        _validate_profile_artifacts(
             qualification=root,
             evidence_root=evidence_root,
             artifact_hashes=artifact_hashes,
+            include_canary=profile == "deployment-canary",
         )
 
 
@@ -734,7 +793,9 @@ def _parser() -> argparse.ArgumentParser:
     parser.add_argument("--wheel-sha256", required=True)
     parser.add_argument("--bundle-sha256")
     parser.add_argument("--evidence-root", type=Path)
-    parser.add_argument("--require-full-suite", action="store_true")
+    profile_group = parser.add_mutually_exclusive_group()
+    profile_group.add_argument("--require-release-profile", action="store_true")
+    profile_group.add_argument("--require-canary-profile", action="store_true")
     return parser
 
 
@@ -758,12 +819,13 @@ def main(argv: list[str] | None = None) -> int:
             wheel_sha256=args.wheel_sha256,
             bundle_sha256=args.bundle_sha256,
             evidence_root=args.evidence_root,
-            require_full_suite=args.require_full_suite,
+            require_release_profile=args.require_release_profile,
+            require_canary_profile=args.require_canary_profile,
         )
     except (OSError, json.JSONDecodeError, ValidationError) as exc:
         print(f"qualification validation failed: {exc}", file=sys.stderr)
         return 1
-    print("qualification evidence is valid and release-bound")
+    print("qualification evidence is valid and profile-bound")
     return 0
 
 

--- a/tests/test_phase2_qualification.py
+++ b/tests/test_phase2_qualification.py
@@ -681,6 +681,15 @@ def test_full_suite_validator_checks_evidence_semantics(tmp_path: Path) -> None:
     assert completed.returncode == 0, completed.stdout + completed.stderr
 
 
+def test_full_suite_validator_rejects_unlisted_evidence_files(tmp_path: Path) -> None:
+    payload = _valid_full_qualification(tmp_path)
+    _write_json(tmp_path / "evidence" / "unlisted.json", {"status": "passed"})
+
+    completed = _run_full_validator(tmp_path, payload)
+    assert completed.returncode != 0, completed.stdout + completed.stderr
+    assert "unlisted evidence files" in completed.stderr
+
+
 def test_release_profile_validator_accepts_deterministic_evidence_without_providers(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_phase2_qualification.py
+++ b/tests/test_phase2_qualification.py
@@ -487,7 +487,12 @@ def test_runner_keeps_preinstall_control_files_outside_managed_state() -> None:
     assert "plan_path=/run/cortex-install/install-plan.json" in raw
     assert "receipt_path=/run/cortex-install/install-receipt.json" in raw
     assert "install -d -o root -g root -m 0700 /run/cortex-install" in raw
-    assert "qualification_root=/run/cortex-qualification" in raw
+    assert "qualification_root=/qualification-output" in raw
+    assert "output_volume_name=" in raw
+    assert 'docker volume create "$output_volume_name"' in raw
+    assert "target=/qualification-output" in raw
+    assert 'docker volume rm "$output_volume_name"' in raw
+    assert "qualification_root=/run/cortex-qualification" not in raw
     assert "/var/lib/cortex/qualification" not in raw
     assert "/var/lib/cortex/qualification" not in dockerfile
     assert "plan_path=/var/lib/cortex" not in raw
@@ -521,6 +526,7 @@ def test_runner_declares_disposable_systemd_container_boundaries() -> None:
         assert (
             target == "/artifacts"
             or target == "/sys/fs/cgroup"
+            or target == "/qualification-output"
             or target.startswith("/var/lib/cortex")
         ), f"unexpected host bind/volume target: {target}"
 

--- a/tests/test_phase2_qualification.py
+++ b/tests/test_phase2_qualification.py
@@ -20,10 +20,22 @@ RUNNER = QUALIFICATION / "run.sh"
 SCHEMA = QUALIFICATION / "qualification.schema.json"
 VALIDATOR = QUALIFICATION / "validate.py"
 DRIVER = QUALIFICATION / "driver.py"
+REDACTION = QUALIFICATION / "redaction_scan.py"
 
 
 def _load_driver_module():
     spec = importlib.util.spec_from_file_location("cortex_qualification_driver", DRIVER)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _load_redaction_module():
+    spec = importlib.util.spec_from_file_location(
+        "cortex_qualification_redaction", REDACTION
+    )
     assert spec is not None and spec.loader is not None
     module = importlib.util.module_from_spec(spec)
     sys.modules[spec.name] = module
@@ -38,7 +50,8 @@ def _required_text(path: Path) -> str:
 
 def _valid_qualification() -> dict:
     return {
-        "schema_version": 1,
+        "schema_version": 2,
+        "profile": "deployment-canary",
         "status": "passed",
         "candidate_sha": "a" * 40,
         "wheel": {
@@ -318,6 +331,46 @@ def _valid_full_qualification(tmp_path: Path) -> dict:
     return payload
 
 
+def _valid_release_qualification(tmp_path: Path) -> dict:
+    payload = _valid_full_qualification(tmp_path)
+    payload["profile"] = "release"
+    payload["providers"] = []
+    canary_tests = {
+        "provider-capability-smoke",
+        "full-dispatch-closeout",
+        "manager-github-dry-run-push",
+    }
+    payload["tests"] = [
+        row for row in payload["tests"] if row["name"] not in canary_tests
+    ]
+
+    evidence = tmp_path / "evidence"
+    for name in (
+        "provider-capabilities.json",
+        "dispatch-closeout.json",
+        "manager-github-auth.json",
+    ):
+        (evidence / name).unlink()
+    documents = sorted(
+        path for path in evidence.iterdir() if path.name != "artifact-inventory.json"
+    )
+    inventory_rows = [
+        {"path": f"evidence/{path.name}", "sha256": _sha256(path)} for path in documents
+    ]
+    inventory_path = evidence / "artifact-inventory.json"
+    _write_json(
+        inventory_path,
+        {"schema_version": 1, "status": "passed", "artifacts": inventory_rows},
+    )
+    payload["artifacts"] = inventory_rows + [
+        {
+            "path": "evidence/artifact-inventory.json",
+            "sha256": _sha256(inventory_path),
+        }
+    ]
+    return payload
+
+
 def _refresh_full_hashes(tmp_path: Path, payload: dict) -> None:
     evidence = tmp_path / "evidence"
     inventory_path = evidence / "artifact-inventory.json"
@@ -350,7 +403,7 @@ def _run_full_validator(
             "c" * 64,
             "--evidence-root",
             str(tmp_path),
-            "--require-full-suite",
+            "--require-canary-profile",
         ],
         cwd=REPO_ROOT,
         text=True,
@@ -484,6 +537,7 @@ def test_qualification_schema_binds_release_evidence_and_runtime_identity() -> N
     required = set(payload.get("required", []))
     assert {
         "schema_version",
+        "profile",
         "status",
         "candidate_sha",
         "wheel",
@@ -494,6 +548,12 @@ def test_qualification_schema_binds_release_evidence_and_runtime_identity() -> N
         "tests",
         "artifacts",
     } <= required
+    assert payload["properties"]["schema_version"] == {"const": 2}
+    assert set(payload["properties"]["profile"]["enum"]) == {
+        "release",
+        "deployment-canary",
+    }
+    assert payload["properties"]["providers"]["minItems"] == 0
 
     normalized = json.dumps(payload, sort_keys=True).lower()
     for field in (
@@ -613,6 +673,73 @@ def test_full_suite_validator_checks_evidence_semantics(tmp_path: Path) -> None:
     payload = _valid_full_qualification(tmp_path)
     completed = _run_full_validator(tmp_path, payload)
     assert completed.returncode == 0, completed.stdout + completed.stderr
+
+
+def test_release_profile_validator_accepts_deterministic_evidence_without_providers(
+    tmp_path: Path,
+) -> None:
+    payload = _valid_release_qualification(tmp_path)
+    qualification = tmp_path / "qualification.json"
+    _write_json(qualification, payload)
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(VALIDATOR),
+            "--qualification",
+            str(qualification),
+            "--candidate-sha",
+            "a" * 40,
+            "--wheel-sha256",
+            "b" * 64,
+            "--bundle-sha256",
+            "c" * 64,
+            "--evidence-root",
+            str(tmp_path),
+            "--require-release-profile",
+        ],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+
+
+@pytest.mark.parametrize(
+    ("payload_factory", "required_profile"),
+    [
+        (_valid_release_qualification, "--require-canary-profile"),
+        (_valid_full_qualification, "--require-release-profile"),
+    ],
+)
+def test_qualification_profiles_cannot_unlock_each_other(
+    tmp_path: Path, payload_factory, required_profile: str
+) -> None:
+    payload = payload_factory(tmp_path)
+    qualification = tmp_path / "qualification.json"
+    _write_json(qualification, payload)
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(VALIDATOR),
+            "--qualification",
+            str(qualification),
+            "--candidate-sha",
+            "a" * 40,
+            "--wheel-sha256",
+            "b" * 64,
+            "--bundle-sha256",
+            "c" * 64,
+            "--evidence-root",
+            str(tmp_path),
+            required_profile,
+        ],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert completed.returncode != 0, completed.stdout + completed.stderr
 
 
 def _add_authorized_repo_worktree_to_attack_matrix(tmp_path: Path) -> None:
@@ -795,7 +922,10 @@ def test_qualification_driver_and_runner_are_fail_closed_on_live_inputs() -> Non
         assert f"T5.{index}" in driver
     assert "registry_asset_ids" in driver
     assert "native_metadata" in driver and "QUALIFICATION_OK" in driver
-    assert "--require-full-suite" in runner
+    assert "--profile" in runner
+    assert "--require-release-profile" in runner
+    assert "--require-canary-profile" in runner
+    assert "network_args=(--network none)" in runner
     for variable in (
         "CORTEX_RC_CODEX_AUTH",
         "CORTEX_RC_AGY_AUTH",
@@ -806,6 +936,108 @@ def test_qualification_driver_and_runner_are_fail_closed_on_live_inputs() -> Non
         "CORTEX_RC_PROBE_ISSUE",
     ):
         assert variable in runner
+
+
+def test_release_driver_never_calls_live_provider_or_repository_functions(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    driver = _load_driver_module()
+    receipt = tmp_path / "receipt.json"
+    receipt.write_text("{}", encoding="utf-8")
+    output = tmp_path / "qualification.json"
+    evidence_dir = tmp_path / "evidence"
+
+    monkeypatch.setattr(
+        driver,
+        "_installed_checks",
+        lambda **_kwargs: [
+            {"name": "selfcheck", "status": "passed"},
+            {"name": "registry-equation", "status": "passed"},
+            {"name": "generated-installed-attestation", "status": "passed"},
+            {"name": "service-identity-hardening", "status": "passed"},
+        ],
+    )
+    monkeypatch.setattr(driver, "_permission_attack_matrix", lambda *_args: None)
+    monkeypatch.setattr(
+        driver,
+        "_service_rows",
+        lambda: [
+            {"name": "cortex-manager.service", "uid": 991, "gid": 991, "active": True}
+        ],
+    )
+    monkeypatch.setattr(
+        driver,
+        "_artifact_inventory",
+        lambda _path: [{"path": "evidence/local.json", "sha256": "e" * 64}],
+    )
+
+    def unexpected_live_call(*_args, **_kwargs):
+        raise AssertionError("release profile called a live canary function")
+
+    monkeypatch.setattr(driver, "_provider_smokes", unexpected_live_call)
+    monkeypatch.setattr(driver, "_manager_github_probe", unexpected_live_call)
+    monkeypatch.setattr(driver, "_full_dispatch", unexpected_live_call)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            str(DRIVER),
+            "--receipt",
+            str(receipt),
+            "--install-evidence",
+            str(tmp_path / "install.json"),
+            "--candidate-sha",
+            "a" * 40,
+            "--wheel-sha256",
+            "b" * 64,
+            "--bundle-sha256",
+            "c" * 64,
+            "--image-digest",
+            "sha256:" + "d" * 64,
+            "--wheel-filename",
+            "paulsha_cortex-0.1.9-py3-none-any.whl",
+            "--profile",
+            "release",
+            "--output",
+            str(output),
+            "--evidence-dir",
+            str(evidence_dir),
+        ],
+    )
+
+    assert driver.main() == 0
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    assert payload["schema_version"] == 2
+    assert payload["profile"] == "release"
+    assert payload["providers"] == []
+    assert not {
+        "provider-capability-smoke",
+        "manager-github-dry-run-push",
+        "full-dispatch-closeout",
+    } & {row["name"] for row in payload["tests"]}
+
+
+def test_release_redaction_profile_does_not_require_live_secret_environment(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    redaction = _load_redaction_module()
+    for name in redaction.SECRET_ENV:
+        monkeypatch.delenv(name, raising=False)
+    (tmp_path / "qualification.json").write_text("{}", encoding="utf-8")
+
+    redaction.scan(tmp_path, profile="release")
+
+
+def test_canary_redaction_profile_requires_every_live_secret(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    redaction = _load_redaction_module()
+    for name in redaction.SECRET_ENV:
+        monkeypatch.delenv(name, raising=False)
+    (tmp_path / "qualification.json").write_text("{}", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="protected secret"):
+        redaction.scan(tmp_path, profile="deployment-canary")
 
 
 def test_account_runtime_env_uses_installed_psc_roots_without_manager_identity(

--- a/tests/test_release_pipeline_workflows.py
+++ b/tests/test_release_pipeline_workflows.py
@@ -151,12 +151,12 @@ def _job_needs(job: dict) -> set[str]:
     return set(needs)
 
 
-def test_rc_qualification_is_manual_protected_and_sha_pinned() -> None:
+def test_release_qualification_is_manual_secret_free_and_sha_pinned() -> None:
     payload = _load_workflow("rc-qualification.yml")
     on_block = _workflow_on(payload)
     assert set(on_block) == {
         "workflow_dispatch"
-    }, "RC qualification is privileged and must never run on push, pull_request, or schedule"
+    }, "release qualification is privileged and must never run on push, pull_request, or schedule"
 
     jobs = payload.get("jobs", {})
     assert isinstance(jobs, dict) and jobs
@@ -167,17 +167,21 @@ def test_rc_qualification_is_manual_protected_and_sha_pinned() -> None:
     ]
     assert qualification_jobs, "RC workflow must execute qualification/run.sh"
     assert all(
-        job.get("environment") == "rc-qualification" for job in qualification_jobs
-    ), "every job running privileged qualification must use the protected rc-qualification environment"
+        "environment" not in job for job in qualification_jobs
+    ), "deterministic release qualification must not request a protected environment"
 
     raw = (WORKFLOWS / "rc-qualification.yml").read_text(encoding="utf-8")
     lowered = raw.lower()
     assert "python -m build" in lowered
     assert "qualification/run.sh" in raw
+    assert "--profile release" in raw
+    assert "--profile deployment-canary" not in raw
     assert "qualification.json" in raw
     assert "upload-artifact" in lowered
     assert "github.sha" in lowered or "github.event.inputs" in lowered
     assert "timeout-minutes" in lowered
+    assert "secrets." not in raw
+    assert "CORTEX_RC_" not in raw
 
     _assert_all_uses_are_sha_pinned(
         payload, relpath=".github/workflows/rc-qualification.yml"
@@ -185,10 +189,57 @@ def test_rc_qualification_is_manual_protected_and_sha_pinned() -> None:
     _assert_all_uses_have_version_comments("rc-qualification.yml")
 
 
+def test_deployment_canary_is_manual_protected_and_separate_from_release() -> None:
+    payload = _load_workflow("deployment-canary.yml")
+    on_block = _workflow_on(payload)
+    assert set(on_block) == {"workflow_dispatch"}
+
+    jobs = payload.get("jobs", {})
+    assert isinstance(jobs, dict) and jobs
+    canary_jobs = [
+        job
+        for job in jobs.values()
+        if isinstance(job, dict) and "qualification/run.sh" in _job_step_runs(job)
+    ]
+    assert canary_jobs
+    assert all(job.get("environment") == "rc-qualification" for job in canary_jobs)
+
+    raw = (WORKFLOWS / "deployment-canary.yml").read_text(encoding="utf-8")
+    assert "--profile deployment-canary" in raw
+    assert "CORTEX_RC_CODEX_AUTH" in raw
+    assert "CORTEX_RC_AGY_AUTH" in raw
+    assert "CORTEX_RC_COPILOT_AUTH" in raw
+    assert "CORTEX_RC_MANAGER_GITHUB_AUTH" in raw
+    assert "CORTEX_RC_PROBE_REPOSITORY" in raw
+    assert "CORTEX_RC_PROBE_WORK_ID" in raw
+    assert "CORTEX_RC_PROBE_ISSUE" in raw
+    assert "deployment-canary-${{ github.sha }}" in raw
+    assert "rc-qualification-${{ github.sha }}" not in raw
+
+    _assert_all_uses_are_sha_pinned(
+        payload, relpath=".github/workflows/deployment-canary.yml"
+    )
+    _assert_all_uses_have_version_comments("deployment-canary.yml")
+
+    release_payload = _load_workflow("rc-qualification.yml")
+    release_steps = release_payload["jobs"]["qualification"]["steps"]
+    canary_steps = payload["jobs"]["qualification"]["steps"]
+    release_build = next(
+        step for step in release_steps if step.get("id") == "candidate"
+    )
+    canary_build = next(step for step in canary_steps if step.get("id") == "candidate")
+    assert canary_build["run"] == release_build["run"], (
+        "release qualification and deployment canary must build the exact candidate "
+        "through one byte-identical recipe"
+    )
+
+
 def test_release_requires_exact_sha_qualification_and_wheel_hash_before_publish() -> (
     None
 ):
     payload = _load_workflow("release.yml")
+    release_workflow_raw = (WORKFLOWS / "release.yml").read_text(encoding="utf-8")
+    assert "deployment-canary" not in release_workflow_raw
     jobs = payload.get("jobs", {})
     assert isinstance(jobs, dict)
 
@@ -241,6 +292,9 @@ def test_release_requires_exact_sha_qualification_and_wheel_hash_before_publish(
     gate_lower = gate_runs.lower()
     assert "qualification.json" in gate_text
     assert "qualification/validate.py" in gate_runs
+    assert "--require-release-profile" in gate_runs
+    assert "--require-canary-profile" not in gate_runs
+    assert "--require-full-suite" not in gate_runs
     assert "--candidate-sha" in gate_runs
     assert "--wheel-sha256" in gate_runs
     assert "sha256sum" in gate_lower

--- a/tests/test_release_pipeline_workflows.py
+++ b/tests/test_release_pipeline_workflows.py
@@ -151,6 +151,26 @@ def _job_needs(job: dict) -> set[str]:
     return set(needs)
 
 
+def _assert_exact_candidate_checkout_has_complete_history(name: str) -> None:
+    payload = _load_workflow(name)
+    steps = payload["jobs"]["qualification"]["steps"]
+    checkout = next(
+        step
+        for step in steps
+        if isinstance(step, dict) and step.get("name") == "Checkout exact candidate"
+    )
+    assert checkout.get("with", {}).get("fetch-depth") == 0, (
+        f"{name} must fetch complete history before `git bundle create`; a depth-1 "
+        "bundle omits the candidate parent and fails installed-repository fsck"
+    )
+    candidate = next(
+        step
+        for step in steps
+        if isinstance(step, dict) and step.get("id") == "candidate"
+    )
+    assert 'git rev-parse --is-shallow-repository' in candidate.get("run", "")
+
+
 def test_release_qualification_is_manual_secret_free_and_sha_pinned() -> None:
     payload = _load_workflow("rc-qualification.yml")
     on_block = _workflow_on(payload)
@@ -187,6 +207,7 @@ def test_release_qualification_is_manual_secret_free_and_sha_pinned() -> None:
         payload, relpath=".github/workflows/rc-qualification.yml"
     )
     _assert_all_uses_have_version_comments("rc-qualification.yml")
+    _assert_exact_candidate_checkout_has_complete_history("rc-qualification.yml")
 
 
 def test_deployment_canary_is_manual_protected_and_separate_from_release() -> None:
@@ -220,6 +241,7 @@ def test_deployment_canary_is_manual_protected_and_separate_from_release() -> No
         payload, relpath=".github/workflows/deployment-canary.yml"
     )
     _assert_all_uses_have_version_comments("deployment-canary.yml")
+    _assert_exact_candidate_checkout_has_complete_history("deployment-canary.yml")
 
     release_payload = _load_workflow("rc-qualification.yml")
     release_steps = release_payload["jobs"]["qualification"]["steps"]


### PR DESCRIPTION
## 摘要

- 將 exact-SHA release qualification 改成 deterministic、無 secrets、無外部 repository 寫入的 systemd/container gate。
- evidence schema 升為 v2，以 `release`／`deployment-canary` profile 防止兩種結果互相冒充。
- 將 provider、Manager GitHub 與 full-dispatch 驗證移至受保護的 manual deployment canary，且 release workflow 不查詢該結果。

## 驗證

- [x] focused qualification/workflow tests：43 passed
- [x] full pytest：5444 passed、41 skipped、173 subtests passed
- [x] wheel build、`twine check --strict`、clean-venv install、`cortex --version`／`--help`
- [x] archived change strict replay、canonical release spec strict、all specs production-mode validation
- [x] `bash -n`、JSON/YAML parse、`git diff --check`

## Policy checklist

- [x] `changelog.d/release-qualification-boundary.md` 已納入 diff
- [x] `CHANGELOG.md [Unreleased]` 已同步
- [x] README 與 release qualification runbook 已同步
- [x] `VERSION` 保持 release batch `0.1.9`
- [x] 所有新增／修改 workflow action 均為 40-hex SHA pin 且附版本註解
- [x] agent convention symlinks 未變動
- [x] 不發布 PyPI、不上傳 operator credentials、不修改 production deployment
