### PR TITLE
fix(release): 明確指定 GitHub repository context

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -506,6 +506,7 @@ jobs:
             }
 
           gh release create "$tag_name" "${wheels[0]}" \
+            --repo "$GITHUB_REPOSITORY" \
             --draft \
             --verify-tag \
             --target "$release_sha" \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 
 ## [Unreleased]
 
+- **Release publication repo context 修正**：不含 checkout 的 publication job 現在明確把
+  `GITHUB_REPOSITORY` 傳給 `gh release create --repo`，避免 gh 嘗試從不存在的 `.git`
+  推導 repository，並保留既有 annotated-tag transaction rollback。
+
 - **Release qualification 邊界修正**：exact-SHA `rc-qualification` 改為不讀 secrets、
   不呼叫 provider、以 `--network none` 執行且不修改外部 repository 的 deterministic
   installer/systemd/attestation/attack-matrix gate；真實 provider、Manager GitHub 與

--- a/changelog.d/release-gh-repo-context.md
+++ b/changelog.d/release-gh-repo-context.md
@@ -1,0 +1,3 @@
+Release publication job 在沒有 checkout 的情況下，明確以
+`gh release create --repo "$GITHUB_REPOSITORY"` 指定 remote repository；避免 gh 因找不到
+`.git` 而在已通過 qualification gate 後失敗，transactional tag/release rollback 契約不變。

--- a/docs/superpowers/runbooks/release-qualification.md
+++ b/docs/superpowers/runbooks/release-qualification.md
@@ -17,6 +17,10 @@
    比對 wheel/bundle hashes，並以 `--require-release-profile` 驗證 evidence。
 5. 驗證 annotated tag、non-draft GitHub Release 與唯一 wheel asset 都指向同一 main SHA。
 
+publication job 刻意不 checkout source tree；所有 repository-aware `gh` 操作都必須由
+`GITHUB_REPOSITORY` 明確指定目標。尤其 `gh release create` 必須帶 `--repo`，不可依賴本地
+`.git` context。
+
 這條路徑不需要設定 GitHub environment secrets 或 variables；若 `RC qualification` 要求它們，
 代表 workflow contract 已退化，應先修復而不是補值。
 

--- a/tests/test_release_pipeline_workflows.py
+++ b/tests/test_release_pipeline_workflows.py
@@ -345,6 +345,10 @@ def test_release_requires_exact_sha_qualification_and_wheel_hash_before_publish(
     assert "repos/${GITHUB_REPOSITORY}/git/refs" in release_runs
     assert "refs/tags/$tag_name" in release_runs
     assert "gh release create" in release_runs
+    assert '--repo "$GITHUB_REPOSITORY"' in release_runs, (
+        "the release job has no checkout, so gh release create must receive "
+        "an explicit repository context"
+    )
     assert "--verify-tag" in release_runs
     assert "--method DELETE" in release_runs
     assert "--draft" in release_runs


### PR DESCRIPTION
## 摘要

- 修正 release publication job 在沒有 checkout 時執行 `gh release create` 的 repository context。
- 明確傳入 `--repo "$GITHUB_REPOSITORY"`，避免 gh 嘗試從不存在的 `.git` 推導目標。
- 保留既有 annotated-tag／draft-release transaction 與失敗 rollback 邊界。

## 失敗證據

- Release run `32931148000` 的 governance、wheel reproduction 與 qualification gate 均通過。
- publication step 逐字失敗為 `fatal: not a git repository`。
- transaction cleanup 後查無 `v0.1.9` tag 或 GitHub Release 殘留。

## 驗證

- [x] RED regression：舊 workflow 缺少 explicit repository context 時失敗
- [x] release workflow tests：6 passed
- [x] full pytest：5445 passed、41 skipped、173 subtests passed
- [x] canonical OpenSpec：18 passed、0 failed
- [x] workflow YAML parse、`git diff --check`

## Policy checklist

- [x] `changelog.d/release-gh-repo-context.md` 已提交
- [x] `CHANGELOG.md [Unreleased]` 已同步
- [x] release qualification runbook 已同步
- [x] `VERSION` 保持 `0.1.9`
- [x] workflow action SHA pins 未變動
- [x] agent convention symlinks 未變動
- [x] 不發布 PyPI、不讀取 deployment-canary secrets
