### PR TITLE
fix(trust-root): 修正 RC rollback state 分類

### DIFF
--- a/.github/workflows/policy-check.yml
+++ b/.github/workflows/policy-check.yml
@@ -2,6 +2,7 @@ name: Policy Check
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, edited, labeled, unlabeled]
   workflow_dispatch:
 
 permissions:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
   receipt inventory 排除刻意保留的 fresh checkout／content-addressed venv 及其 carrier parent，
   同時仍回報同層 foreign sibling；container harness 也改成 rollback／clean reinstall 完成後才
   加入非 transactional runtime scaffold fixture，避免合法 retained state 被誤判為 unknown。
+  Policy Check 同步監聽 PR `edited`／`labeled`／`unlabeled` 事件，讓 release／exemption label、
+  標題或 checklist 的變更都會以最新 metadata 重新判定。
 
 - **Phase 2 attestation 與 closeout authority 修正**：generated-vs-installed attestation
   依 artifact category 分辨真正註解，shebang、`;`-prefixed shell、polkit `#`／未閉合

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
 
 ## [Unreleased]
 
+- **RC rollback qualification 順序與 unknown-state 修正**：rollback scanner 現在會依 archived
+  receipt inventory 排除刻意保留的 fresh checkout／content-addressed venv 及其 carrier parent，
+  同時仍回報同層 foreign sibling；container harness 也改成 rollback／clean reinstall 完成後才
+  加入非 transactional runtime scaffold fixture，避免合法 retained state 被誤判為 unknown。
+
 - **Phase 2 attestation 與 closeout authority 修正**：generated-vs-installed attestation
   依 artifact category 分辨真正註解，shebang、`;`-prefixed shell、polkit `#`／未閉合
   block／`;` statement 都會 fail closed。Installer 新增明示 `--prior-receipt`，只讓同

--- a/changelog.d/phase2-rc-rollback-order.md
+++ b/changelog.d/phase2-rc-rollback-order.md
@@ -1,0 +1,4 @@
+- 修正 RC container qualification 的 fresh-install rollback：unknown-state scanner 會依
+  archived receipt inventory 辨識刻意保留的 checkout／content-addressed venv 與必要 parent，
+  但仍對 foreign sibling fail closed；runtime scaffold fixture 延後至 rollback 與 clean reinstall
+  之後，讓 qualification 真正驗證 installer transaction，而非混入 harness 外部狀態。

--- a/changelog.d/phase2-rc-rollback-order.md
+++ b/changelog.d/phase2-rc-rollback-order.md
@@ -2,3 +2,5 @@
   archived receipt inventory 辨識刻意保留的 checkout／content-addressed venv 與必要 parent，
   但仍對 foreign sibling fail closed；runtime scaffold fixture 延後至 rollback 與 clean reinstall
   之後，讓 qualification 真正驗證 installer transaction，而非混入 harness 外部狀態。
+- Policy Check 現在也監聽 PR title／body 與 label 的變更，確保 release／exemption label 或
+  checklist 在 PR 建立後調整時，gate 會以最新 metadata 重跑而不沿用舊 event payload。

--- a/docs/superpowers/runbooks/release-qualification.md
+++ b/docs/superpowers/runbooks/release-qualification.md
@@ -19,6 +19,10 @@
    wheel、完整 install-input archive、passed release qualification manifest。三份資產的
    GitHub REST `digest` 都必須等於 publication job 的本機 SHA-256。
 
+Release candidate PR 應帶對應 `release:<version>` label。Policy Check 必須在 PR 建立、commit
+同步、重開、title/body 編輯與 label 增刪時重跑；不能沿用缺少後加 label 的舊 event payload，
+否則 VERSION gate 會對相同 PR metadata 產生不同結論。
+
 publication job 刻意不 checkout source tree；所有 repository-aware `gh` 操作都必須由
 `GITHUB_REPOSITORY` 明確指定目標。尤其 `gh release create` 必須帶 `--repo`，不可依賴本地
 `.git` context。

--- a/docs/superpowers/runbooks/release-qualification.md
+++ b/docs/superpowers/runbooks/release-qualification.md
@@ -46,6 +46,10 @@ qualification evidence 位於專用的一次性 Docker volume，再由 runner �
 daemon 的 archive API 無法看見其中檔案；也不要改成 writable host bind，以免擴大 qualification
 對 host 的寫入面。
 
+container 內的 rollback proof 必須發生在任何 harness runtime scaffold fixture 之前。rollback
+可以依 archived receipt inventory 辨識並保留 fresh checkout 與 content-addressed venv，但仍須
+對同一 parent 下的 foreign sibling fail closed；fixture 若提前建立，會混淆這條 authority 邊界。
+
 release validator 會要求 `qualification-output/evidence/` 的實際 regular-file 集合與
 `qualification.json`／`artifact-inventory.json` 列管集合完全一致；額外檔案、symlink、缺檔或
 tree 外 artifact 都會失敗。這能避免上傳內容存在未受 hash inventory 約束的旁路檔案。

--- a/openspec/changes/archive/2026-08-26-phase2-rc-rollback-order/design.md
+++ b/openspec/changes/archive/2026-08-26-phase2-rc-rollback-order/design.md
@@ -1,0 +1,27 @@
+# Design: Phase 2 RC rollback order
+
+## Decision 1: archive inventory is the only retained-subtree authority
+
+`rollback_journal` preserves the full set of filesystem steps after live journal entries are
+removed. The scanner derives managed paths from asset, repository, toolchain, and venv steps in that
+archive. A current inventory row is known only when it equals, contains, or is contained by one of
+those receipt-bound paths. This permits necessary carrier directories while a nested retained venv
+or checkout remains.
+
+The scanner still recursively reports paths outside those relationships. Toolchain trees retain
+their separate member-by-member manifest check, so adding them to the parent carrier exclusion does
+not hide modified or foreign toolchain members.
+
+## Decision 2: test installer rollback before runtime fixtures
+
+The RC harness proves fresh apply, idempotent apply, drift rejection, rollback, and clean reinstall
+before it creates the scaffold state needed by later runtime/service probes. This keeps the rollback
+proof scoped to installer-owned state and prevents fixture ordering from deciding transaction
+success.
+
+## Rejected alternatives
+
+- Treat every non-empty fresh parent as safe: rejects fail-closed foreign sibling detection.
+- Teach rollback about qualification-only scaffold paths: creates a harness-specific exception in
+  production authority.
+- Retry the failed RC unchanged: the deterministic state classification would fail again.

--- a/openspec/changes/archive/2026-08-26-phase2-rc-rollback-order/proposal.md
+++ b/openspec/changes/archive/2026-08-26-phase2-rc-rollback-order/proposal.md
@@ -1,0 +1,33 @@
+---
+status: accepted
+work_item: phase2-rc-rollback-order
+---
+
+## Why
+
+Exact-main RC qualification run `32981448179` failed during its real systemd-container rollback:
+the installer intentionally retained a receipt-bound content-addressed venv and fresh checkout, but
+the unknown-state scanner classified their newly-created carrier parents as unknown. The harness
+also created non-transactional runtime scaffold fixtures before exercising rollback, mixing two
+ownership domains inside the rollback proof.
+
+## What Changes
+
+- Classify a retained filesystem entry as managed only when its path or carrier relationship is
+  proven by the archived receipt inventory.
+- Continue reporting every foreign sibling and toolchain drift; do not weaken fail-closed rollback.
+- Move harness-authored runtime scaffolding after rollback and clean reinstall.
+- Re-run the exact feature SHA through the same RC container workflow before merge, then re-run the
+  final-main RC before release.
+
+## Capabilities
+
+### Added Capabilities
+
+- `trust-root-phase2-closeout`: explicit rollback classification contract for retained managed
+  subtrees versus foreign siblings.
+
+## Impact
+
+- Changes only installer rollback classification, qualification ordering, focused tests, and their
+  docs/spec/changelog. No production service or `/opt/cortex` mutation is performed locally.

--- a/openspec/changes/archive/2026-08-26-phase2-rc-rollback-order/specs/trust-root-phase2-closeout/spec.md
+++ b/openspec/changes/archive/2026-08-26-phase2-rc-rollback-order/specs/trust-root-phase2-closeout/spec.md
@@ -1,0 +1,21 @@
+## ADDED Requirements
+
+### Requirement: Rollback classification MUST distinguish retained managed subtrees
+
+The rollback unknown-state scan MUST treat only filesystem relationships proven by the archived
+receipt inventory as managed. An intentionally retained content-addressed venv or fresh checkout and
+the carrier parents required to reach it MUST NOT make an otherwise safe rollback fail. Every
+foreign sibling outside those receipt-bound relationships MUST still be reported, and specialized
+toolchain member attestation MUST remain authoritative. Qualification MUST complete rollback and a
+clean reinstall before adding any non-transactional runtime scaffold fixture.
+
+#### Scenario: fresh rollback retains only receipt-bound durable subtrees
+
+- **WHEN** rollback leaves a receipt-bound content-addressed venv or fresh checkout under a parent created by the same receipt
+- **THEN** the parent MUST NOT be reported as unknown solely because that managed subtree remains
+- **THEN** any foreign sibling under that parent MUST still make rollback fail closed
+
+#### Scenario: qualification needs runtime scaffold state
+
+- **WHEN** later service/runtime probes need harness-authored scaffold fixtures
+- **THEN** qualification MUST create those fixtures only after rollback and clean reinstall succeed

--- a/openspec/changes/archive/2026-08-26-phase2-rc-rollback-order/tasks.md
+++ b/openspec/changes/archive/2026-08-26-phase2-rc-rollback-order/tasks.md
@@ -1,0 +1,18 @@
+---
+status: accepted
+work_item: phase2-rc-rollback-order
+---
+
+# Tasks
+
+- [x] Reproduce the failed RC state with RED tests for a fresh carrier parent and early scaffold ordering.
+- [x] Extend archived-receipt path classification without suppressing foreign siblings.
+- [x] Move runtime scaffold creation after rollback and clean reinstall.
+- [x] Pass focused backend/transaction/qualification tests and the complete pytest suite.
+- [x] Synchronize canonical docs, changelog fragment, and strict-valid OpenSpec delta.
+
+## Post-merge operational closeout
+
+The feature SHA and final-main SHA must each pass the real RC container workflow. Only the final-main
+run may unlock `v0.1.10`; its Actions and Release records are external evidence, not pre-completed
+OpenSpec task checkboxes.

--- a/openspec/specs/trust-root-phase2-closeout/spec.md
+++ b/openspec/specs/trust-root-phase2-closeout/spec.md
@@ -350,3 +350,23 @@ cleanup MUST treat publication as committed external state and retain both relea
 - **WHEN** the owned release is already non-draft but the publication process has not yet disarmed its cleanup trap
 - **THEN** cleanup MUST retain both the published release and its annotated tag
 - **THEN** cleanup MUST return the signal-derived status without attempting either deletion
+
+### Requirement: Rollback classification MUST distinguish retained managed subtrees
+
+The rollback unknown-state scan MUST treat only filesystem relationships proven by the archived
+receipt inventory as managed. An intentionally retained content-addressed venv or fresh checkout and
+the carrier parents required to reach it MUST NOT make an otherwise safe rollback fail. Every
+foreign sibling outside those receipt-bound relationships MUST still be reported, and specialized
+toolchain member attestation MUST remain authoritative. Qualification MUST complete rollback and a
+clean reinstall before adding any non-transactional runtime scaffold fixture.
+
+#### Scenario: fresh rollback retains only receipt-bound durable subtrees
+
+- **WHEN** rollback leaves a receipt-bound content-addressed venv or fresh checkout under a parent created by the same receipt
+- **THEN** the parent MUST NOT be reported as unknown solely because that managed subtree remains
+- **THEN** any foreign sibling under that parent MUST still make rollback fail closed
+
+#### Scenario: qualification needs runtime scaffold state
+
+- **WHEN** later service/runtime probes need harness-authored scaffold fixtures
+- **THEN** qualification MUST create those fixtures only after rollback and clean reinstall succeed

--- a/paulsha_cortex/trust_root/install/backend.py
+++ b/paulsha_cortex/trust_root/install/backend.py
@@ -3090,10 +3090,22 @@ class LocalInstallBackend:
             step = entry.get("step") if isinstance(entry, Mapping) else None
             if (
                 isinstance(step, Mapping)
-                and step.get("kind") in {"asset", "venv"}
+                and step.get("kind") in {"asset", "repository", "toolchain", "venv"}
                 and isinstance(step.get("path"), str)
             ):
                 managed_paths.add(Path(str(step["path"])))
+
+        def is_managed_inventory_path(candidate: Path, container: Path) -> bool:
+            return any(
+                managed != container
+                and (
+                    candidate == managed
+                    or managed in candidate.parents
+                    or candidate in managed.parents
+                )
+                for managed in managed_paths
+            )
+
         for entry in journal_rows:
             if not isinstance(entry, Mapping):
                 continue
@@ -3108,8 +3120,14 @@ class LocalInstallBackend:
                 path = Path(str(step.get("path", "")))
                 try:
                     if not prior.get("exists"):
-                        if path.is_dir() and any(path.iterdir()):
+                        if path.is_symlink() or (path.exists() and not path.is_dir()):
                             retained.append(str(path))
+                        elif path.is_dir():
+                            for relative in _directory_inventory(path):
+                                candidate = path / relative
+                                if is_managed_inventory_path(candidate, path):
+                                    continue
+                                retained.append(str(candidate))
                         continue
                     baseline = prior.get("children")
                     if not isinstance(baseline, list) or not all(
@@ -3121,11 +3139,7 @@ class LocalInstallBackend:
                     current = set(_directory_inventory(path))
                     for relative in sorted(current - set(baseline)):
                         candidate = path / relative
-                        if any(
-                            managed != path
-                            and (candidate == managed or managed in candidate.parents)
-                            for managed in managed_paths
-                        ):
+                        if is_managed_inventory_path(candidate, path):
                             continue
                         retained.append(str(candidate))
                 except (InstallError, OSError):

--- a/qualification/run.sh
+++ b/qualification/run.sh
@@ -136,24 +136,6 @@ plan_sha=$(docker exec "$container_name" sha256sum "$plan_path" | awk '{print $1
 # installer owns receipt replay; the harness never translates its plan to shell.
 docker exec "$container_name" cortex install trust-root apply \
     --plan "$plan_path" --confirm-sha256 "$plan_sha" --receipt "$receipt_path"
-# The real template unit has read-only bindings for the deployment-owned Codex
-# controls. A clean reference image has no operator HOME, so seed only a
-# non-secret, root-owned legacy control fixture after the installer creates the
-# four accounts, then execute the production scaffold helper. Credentials are
-# still imported exclusively through the protected stdin path below.
-docker exec "$container_name" sh -eu -c '
-    for account in cortex-builder cortex-reviewer-planner; do
-        install -d -o root -g root -m 0755 "/var/lib/$account/.codex/plugins" "/var/lib/$account/.codex/skills"
-        printf "%s\n" "# qualification control fixture" > "/var/lib/$account/.codex/config.toml"
-        test -f "/var/lib/$account/.codex/hooks.json"
-        printf "%s\n" "{}" > "/var/lib/$account/.codex/auth.json"
-    done
-    python3 -m paulsha_cortex.trust_root scaffold | sh -eu
-    for principal in builder reviewer; do
-        rm -f "/var/lib/cortex/config/codex-credentials/$principal/auth.json"
-    done
-    rm -f /var/lib/cortex-builder/.codex/auth.json /var/lib/cortex-reviewer-planner/.codex/auth.json
-'
 docker exec "$container_name" cortex install trust-root apply \
     --plan "$plan_path" --confirm-sha256 "$plan_sha" --receipt "$receipt_path"
 
@@ -178,6 +160,25 @@ docker exec "$container_name" cortex install trust-root apply \
 docker exec "$container_name" cortex install trust-root rollback --receipt "$receipt_path"
 docker exec "$container_name" cortex install trust-root apply \
     --plan "$plan_path" --confirm-sha256 "$plan_sha" --receipt "$receipt_path"
+
+# The real template unit has read-only bindings for the deployment-owned Codex
+# controls. Add this non-transactional runtime fixture only after the rollback
+# proof and clean reinstall, so the rollback scanner never has to classify
+# harness-authored state as installer-owned state. Credentials are still
+# imported exclusively through the protected stdin path below.
+docker exec "$container_name" sh -eu -c '
+    for account in cortex-builder cortex-reviewer-planner; do
+        install -d -o root -g root -m 0755 "/var/lib/$account/.codex/plugins" "/var/lib/$account/.codex/skills"
+        printf "%s\n" "# qualification control fixture" > "/var/lib/$account/.codex/config.toml"
+        test -f "/var/lib/$account/.codex/hooks.json"
+        printf "%s\n" "{}" > "/var/lib/$account/.codex/auth.json"
+    done
+    python3 -m paulsha_cortex.trust_root scaffold | sh -eu
+    for principal in builder reviewer; do
+        rm -f "/var/lib/cortex/config/codex-credentials/$principal/auth.json"
+    done
+    rm -f /var/lib/cortex-builder/.codex/auth.json /var/lib/cortex-reviewer-planner/.codex/auth.json
+'
 
 # The reference image never fetches mutable runtime tools.  Every executor and
 # qualification helper must resolve through the root-owned installed wrappers.

--- a/tests/test_phase2_qualification.py
+++ b/tests/test_phase2_qualification.py
@@ -581,6 +581,17 @@ def test_runner_declares_disposable_systemd_container_boundaries() -> None:
     assert mode & 0o100, "qualification/run.sh must be executable"
 
 
+def test_release_harness_rolls_back_before_adding_runtime_scaffold_fixture() -> None:
+    runner = _required_text(RUNNER)
+    rollback = runner.index(
+        'cortex install trust-root rollback --receipt "$receipt_path"'
+    )
+    reinstall = runner.index("cortex install trust-root apply", rollback)
+    scaffold = runner.index("python3 -m paulsha_cortex.trust_root scaffold")
+
+    assert rollback < reinstall < scaffold
+
+
 def test_qualification_schema_binds_release_evidence_and_runtime_identity() -> None:
     raw = _required_text(SCHEMA)
     payload = json.loads(raw)

--- a/tests/test_policy_check_workflow.py
+++ b/tests/test_policy_check_workflow.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_policy_check_reacts_to_pr_metadata_changes() -> None:
+    workflow = yaml.load(
+        (REPO_ROOT / ".github/workflows/policy-check.yml").read_text(encoding="utf-8"),
+        Loader=yaml.BaseLoader,
+    )
+
+    event_types = set(workflow["on"]["pull_request"]["types"])
+    assert event_types == {
+        "opened",
+        "synchronize",
+        "reopened",
+        "edited",
+        "labeled",
+        "unlabeled",
+    }

--- a/tests/test_trust_root_install_backend.py
+++ b/tests/test_trust_root_install_backend.py
@@ -706,8 +706,9 @@ def test_venv_post_rename_interruption_replays_from_prepublished_authority(
     assert active.resolve() == slot
 
 
+@pytest.mark.parametrize("parent_existed_before", [False, True])
 def test_unknown_scanner_excludes_retained_receipt_bound_venv_slot(
-    tmp_path: Path,
+    tmp_path: Path, parent_existed_before: bool
 ) -> None:
     venvs = tmp_path / "opt/cortex/venvs"
     slot = venvs / ("a" * 64)
@@ -730,9 +731,89 @@ def test_unknown_scanner_excludes_retained_receipt_bound_venv_slot(
             "rollback_journal": [
                 {
                     "step": directory_step,
-                    "prior": {"exists": True, "children": []},
+                    "prior": (
+                        {"exists": True, "children": []}
+                        if parent_existed_before
+                        else {"exists": False}
+                    ),
                 },
                 {"step": venv_step, "prior": {"exists": False}},
+            ],
+        }
+    )
+
+    assert LocalInstallBackend(require_root=False).list_unknown_state(receipt) == ()
+
+
+def test_unknown_scanner_keeps_foreign_sibling_of_retained_managed_subtree(
+    tmp_path: Path,
+) -> None:
+    managed_root = tmp_path / "opt/cortex"
+    slot = managed_root / "venvs" / ("a" * 64)
+    (slot / "bin").mkdir(parents=True)
+    (slot / "bin/python").write_text("python", encoding="utf-8")
+    unknown = managed_root / "operator" / "keep.txt"
+    unknown.parent.mkdir()
+    unknown.write_text("keep\n", encoding="utf-8")
+    receipt = InstallReceipt(
+        {
+            "journal": [],
+            "rollback_journal": [
+                {
+                    "step": {
+                        "step_id": "asset:deploy-root",
+                        "kind": "asset",
+                        "asset_type": "directory",
+                        "path": str(managed_root),
+                    },
+                    "prior": {"exists": False},
+                },
+                {
+                    "step": {
+                        "step_id": "candidate-venv",
+                        "kind": "venv",
+                        "path": str(slot),
+                    },
+                    "prior": {"exists": False},
+                },
+            ],
+        }
+    )
+
+    retained = LocalInstallBackend(require_root=False).list_unknown_state(receipt)
+
+    assert str(unknown) in retained
+    assert str(managed_root) not in retained
+
+
+def test_unknown_scanner_excludes_receipt_bound_fresh_repository_from_parent(
+    tmp_path: Path,
+) -> None:
+    repositories = tmp_path / "var/lib/cortex/repos"
+    checkout = repositories / "example"
+    checkout.mkdir(parents=True)
+    (checkout / "HEAD").write_text("candidate\n", encoding="utf-8")
+    receipt = InstallReceipt(
+        {
+            "journal": [],
+            "rollback_journal": [
+                {
+                    "step": {
+                        "step_id": "asset:repositories",
+                        "kind": "asset",
+                        "asset_type": "directory",
+                        "path": str(repositories),
+                    },
+                    "prior": {"exists": False},
+                },
+                {
+                    "step": {
+                        "step_id": "repository:example",
+                        "kind": "repository",
+                        "path": str(checkout),
+                    },
+                    "prior": {"exists": False},
+                },
             ],
         }
     )


### PR DESCRIPTION
## 摘要

修正 exact-main RC container qualification 實際抓到的 fresh-install rollback 分類缺口：
receipt-bound、刻意保留的 checkout／content-addressed venv 不再讓其 carrier parent 被誤判
為 unknown；foreign sibling 仍維持 fail closed。qualification runtime scaffold fixture 延後至
rollback 與 clean reinstall 之後，避免混淆 installer ownership。

## 失敗與修正證據

- 原 exact-main RC run `32981448179` 在 rollback 回傳 `restore_safe:false`，錯誤列出
  `/opt/cortex`、venvs 與 repositories 等 carrier parents。
- RED regression 同時重現 fresh parent 誤判與 scaffold ordering 錯誤。
- 修正只依 archived receipt inventory 排除已知 path／ancestor／descendant 關係；同層
  foreign fixture 仍被逐路徑回報。
- rollback implementation head `e8e1c28a7fa254434d8bed6d069d6e7e70345a99` 的 RC qualification
  run `32982729623` 全綠，含 privileged systemd qualification、credential redaction scan 與
  exact candidate evidence upload；final PR head 仍須另有 exact-head RC 才可 merge。

## 驗證

- 完整 pytest：`5579 passed, 41 skipped, 173 subtests passed`。
- installer backend／transaction／qualification focused：203 passed。
- pinned OpenSpec 1.10.0 change strict-valid、archive 後 canonical spec strict-valid。
- `bash -n qualification/run.sh`、compileall、`git diff --check` 全綠。

## Checklist

- [x] 新增並 commit `changelog.d/phase2-rc-rollback-order.md`。
- [x] 同步 `CHANGELOG.md [Unreleased]`、canonical runbook 與 OpenSpec。
- [x] 保留 foreign sibling／toolchain drift 的 fail-closed 行為。
- [x] 未讀取 credentials，未修改 production services 或 `/opt/cortex`。
- [x] 合併後仍須由 exact final-main RC 成功才能啟動 0.1.10 Release。

