### PR TITLE
fix(release): 限定 final-head 必要 workflow gates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -221,16 +221,32 @@ jobs:
             echo "::error::merged PR lacks an approval bound to its final head"
             exit 1
           }
-          check_pages=$(gh api --paginate \
-            "repos/${GITHUB_REPOSITORY}/commits/$pr_head/check-runs?per_page=100")
-          checks=$(jq -sc '{check_runs: [.[].check_runs[]]}' <<<"$check_pages")
-          jq -e '
-            (.check_runs | length) > 0 and
-            all(.check_runs[]; .status == "completed" and .conclusion == "success")
-          ' <<<"$checks" >/dev/null || {
-            echo "::error::the merged PR final head has missing or non-green checks"
-            exit 1
-          }
+          required_pr_workflows=(
+            "tests.yml:pull_request"
+            "persona-scope.yml:pull_request"
+            "policy-check.yml:pull_request"
+            "rc-qualification.yml:workflow_dispatch"
+          )
+          for required_workflow in "${required_pr_workflows[@]}"; do
+            IFS=: read -r workflow event <<<"$required_workflow"
+            workflow_runs=$(gh api --method GET \
+              "repos/${GITHUB_REPOSITORY}/actions/workflows/$workflow/runs" \
+              -f head_sha="$pr_head" -f event="$event" -f per_page=100)
+            latest_run=$(jq -c --arg sha "$pr_head" --arg event "$event" '
+              [.workflow_runs[]
+                | select(.head_sha == $sha and .event == $event)]
+              | sort_by([.created_at, .run_attempt])
+              | last // null
+            ' <<<"$workflow_runs")
+            jq -e '
+              . != null and
+              .status == "completed" and
+              .conclusion == "success"
+            ' <<<"$latest_run" >/dev/null || {
+              echo "::error::latest required PR workflow run is missing or non-green: $workflow"
+              exit 1
+            }
+          done
 
           run_json=$(gh api --method GET \
             "repos/${GITHUB_REPOSITORY}/actions/workflows/rc-qualification.yml/runs" \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
 
 ## [Unreleased]
 
+- **Release final-head check scope 修正**：release preflight 現在逐一驗證 exact PR head
+  最新的 Tests、Persona Scope、Policy Check 與 RC qualification workflow run，保留
+  missing／pending／failure fail-closed，同時不再讓事故留下的第三方歷史 check 永久阻擋
+  已由必要 gates 驗證完成的 release。
+
 - **RC rollback qualification 順序與 unknown-state 修正**：rollback scanner 現在會依 archived
   receipt inventory 排除刻意保留的 fresh checkout／content-addressed venv 及其 carrier parent，
   同時仍回報同層 foreign sibling；container harness 也改成 rollback／clean reinstall 完成後才

--- a/changelog.d/phase2-release-check-contract.md
+++ b/changelog.d/phase2-release-check-contract.md
@@ -1,0 +1,3 @@
+- Release preflight 改為逐一驗證 exact PR head 最新的 Tests、Persona Scope、Policy Check 與
+  RC qualification workflow run；必要 gate 缺失、執行中或失敗仍會 fail closed，但事故留下的
+  非必要第三方歷史 check 不再永久阻擋 release。

--- a/tests/test_release_pipeline_workflows.py
+++ b/tests/test_release_pipeline_workflows.py
@@ -282,10 +282,16 @@ def test_release_requires_exact_sha_qualification_and_wheel_hash_before_publish(
     )
     assert "merge_commit_sha" in preflight_runs
     assert 'state == "APPROVED"' in preflight_runs
-    assert "check-runs" in preflight_runs
-    assert "check-runs?per_page=100" in preflight_runs
-    assert "--paginate" in preflight_runs
-    assert "jq -sc" in preflight_runs
+    for workflow, event in (
+        ("tests.yml", "pull_request"),
+        ("persona-scope.yml", "pull_request"),
+        ("policy-check.yml", "pull_request"),
+        ("rc-qualification.yml", "workflow_dispatch"),
+    ):
+        assert f'"{workflow}:{event}"' in preflight_runs
+    assert "sort_by([.created_at, .run_attempt])" in preflight_runs
+    assert "latest required PR workflow run is missing or non-green" in preflight_runs
+    assert "all(.check_runs[]" not in preflight_runs
     assert "openspec validate --specs --no-interactive" in preflight_runs
     assert (
         "openspec validate phase2-install-docker-qualification" in preflight_runs


### PR DESCRIPTION
## 摘要

修正 release preflight 對 merged PR final head 的 gate scope。它不再要求該 SHA 上所有歷史與第三方 check 一律成功，而是逐一驗證最新的 Tests、Persona Scope、Policy Check 與 RC qualification workflow run。

## 根因與邊界

GitHub Actions 事故留下了一個母 run 已完成、job check 卻永久停在 queued 的 Copilot coding-agent check。原本的 universal check-runs 判定把這個非 release authority 的歷史項目永久納入；新判定仍會對任何必要 workflow 的 missing、pending、failure fail closed，且以 exact PR head、event 與最新 created_at/run_attempt 綁定。

## 驗證

- RED regression：舊 workflow 下 targeted test 如預期失敗。
- 修正後 release pipeline tests：11 passed。
- 實際 workflow API probe：Tests、Persona Scope、Policy Check、RC qualification 均在 exact head completed/success；stale Copilot check 未刪除。
- 完整 pytest：5579 passed, 41 skipped, 173 subtests passed。
- canonical OpenSpec：19 passed, 0 failed。
- git diff --check：通過。

## Checklist

- [x] 新增並 commit changelog.d/phase2-release-check-contract.md。
- [x] 同步 CHANGELOG.md [Unreleased]。
- [x] VERSION 保持 release batch 的 0.1.10。
- [x] 必要 workflow 缺失、執行中或失敗仍維持 fail closed。
- [x] 未刪除或竄改事故期間的歷史 check/run 證據。
- [x] 未修改 production service、credentials 或 release tag。