### PR TITLE
fix(qualification): 補齊 AGY builder canary credential

### DIFF
--- a/.github/workflows/deployment-canary.yml
+++ b/.github/workflows/deployment-canary.yml
@@ -154,6 +154,7 @@ jobs:
         env:
           CORTEX_RC_CODEX_AUTH: ${{ secrets.CORTEX_RC_CODEX_AUTH }}
           CORTEX_RC_AGY_AUTH: ${{ secrets.CORTEX_RC_AGY_AUTH }}
+          CORTEX_RC_BUILDER_AGY_AUTH: ${{ secrets.CORTEX_RC_BUILDER_AGY_AUTH }}
           CORTEX_RC_COPILOT_AUTH: ${{ secrets.CORTEX_RC_COPILOT_AUTH }}
           CORTEX_RC_MANAGER_GITHUB_AUTH: ${{ secrets.CORTEX_RC_MANAGER_GITHUB_AUTH }}
           CORTEX_RC_PROBE_REPOSITORY: ${{ vars.CORTEX_RC_PROBE_REPOSITORY }}
@@ -174,6 +175,7 @@ jobs:
         env:
           CORTEX_RC_CODEX_AUTH: ${{ secrets.CORTEX_RC_CODEX_AUTH }}
           CORTEX_RC_AGY_AUTH: ${{ secrets.CORTEX_RC_AGY_AUTH }}
+          CORTEX_RC_BUILDER_AGY_AUTH: ${{ secrets.CORTEX_RC_BUILDER_AGY_AUTH }}
           CORTEX_RC_COPILOT_AUTH: ${{ secrets.CORTEX_RC_COPILOT_AUTH }}
           CORTEX_RC_MANAGER_GITHUB_AUTH: ${{ secrets.CORTEX_RC_MANAGER_GITHUB_AUTH }}
         run: >-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@
   direct mode 保留既有 operator overlay 相容性，且 packaged roster 不宣傳 AGY build
   fallback。
 
+- **#805 deployment-canary credential wiring**：qualification harness 現在以 install plan 的
+  `required_credentials` 為唯一判準，只有 host overlay 明列 `(builder, agy)` 時才匯入獨立的
+  `CORTEX_RC_BUILDER_AGY_AUTH`；plan 解析失敗會 fail closed，release default 不變，canary
+  redaction scan 也會涵蓋這份 optional credential。
+
 - **#802：fix-standard 的 planning publication 現在對 spec／design／plan 使用
   work-item-bound canonical destinations，即使 combo manifest 沒有
   `brainstorming` card 也能落地三件套；內容型 planning failure 的

--- a/changelog.d/agy-builder-canary-credential.md
+++ b/changelog.d/agy-builder-canary-credential.md
@@ -1,0 +1,3 @@
+- **#805 deployment-canary credential wiring**：依 install plan 的
+  `required_credentials` 條件式匯入獨立的 builder/AGY credential，並讓 optional secret
+  進入 canary redaction scan；release packaged config 與既有 builder/codex default 不變。

--- a/docs/superpowers/runbooks/release-qualification.md
+++ b/docs/superpowers/runbooks/release-qualification.md
@@ -64,10 +64,12 @@ tree 外 artifact 都會失敗。這能避免上傳內容存在未受 hash inven
 `rc-qualification` environment，既有 live inputs 為：
 
 - secrets：`CORTEX_RC_CODEX_AUTH`、`CORTEX_RC_AGY_AUTH`、
-  `CORTEX_RC_COPILOT_AUTH`、`CORTEX_RC_MANAGER_GITHUB_AUTH`
+  `CORTEX_RC_COPILOT_AUTH`、`CORTEX_RC_MANAGER_GITHUB_AUTH`；host overlay 選用
+  builder/agy 時另需獨立的 `CORTEX_RC_BUILDER_AGY_AUTH`
 - variables：`CORTEX_RC_PROBE_REPOSITORY`、`CORTEX_RC_PROBE_WORK_ID`、
   `CORTEX_RC_PROBE_ISSUE`
 
-canary 會產生 `deployment-canary-<sha>`，其 evidence profile 必須是
+builder/agy credential 只在 install plan 的 `required_credentials` 明列該組合時匯入；預設
+packaged config 仍只列 builder/codex。canary 會產生 `deployment-canary-<sha>`，其 evidence profile 必須是
 `deployment-canary`。provider login/quota/model mismatch、fallback、Manager dry-run ref drift 或
 full dispatch 未 terminal 都會讓 canary 失敗，但 release workflow 永遠不查詢該 artifact。

--- a/docs/superpowers/runbooks/trust-root-transactional-install.md
+++ b/docs/superpowers/runbooks/trust-root-transactional-install.md
@@ -747,8 +747,11 @@ exact token 清除可能殘留的 marker。
 
 ## 4. 明確匯入所需 credentials
 
-只匯入 plan 的 `required_credentials` 列出的項目。下列四個 source path 必須由 operator
-逐一指定到正確檔案；不要從任何 HOME 自動探索，也不要把 secret 值放進環境變數或命令列。
+只匯入 plan 的 `required_credentials` 列出的項目。預設 release／canary config 需要下列四個
+source path；若 host overlay 將 builder executor 選為 AGY，plan 會再列出
+`(builder, agy)`，此時必須另外指定第五個、與 reviewer 完全分離的 AGY source path。所有
+source path 都必須由 operator 逐一指定到正確檔案；不要從任何 HOME 自動探索，也不要把
+secret 值放進環境變數或命令列。
 
 ```bash
 cortex_builder_codex_source=/absolute/operator-selected/path/auth.json
@@ -767,6 +770,17 @@ cortex_root_cli install trust-root credentials import --receipt "$cortex_receipt
   --maintenance-token "$cortex_maintenance_token"
 cortex_root_cli install trust-root credentials import --receipt "$cortex_receipt_path" \
   --principal manager --provider github --source "$cortex_manager_github_source" \
+  --maintenance-token "$cortex_maintenance_token"
+```
+
+若人工 review 確認 plan 的 `required_credentials` 額外列出 `(builder, agy)`，才另外執行
+下列一筆 import。source basename 必須符合 AGY credential allowlist，且內容不可與
+`reviewer-planner` 的登入態共用；若 plan 沒有這一列，這筆命令應保持不執行。
+
+```bash
+cortex_builder_agy_source=/absolute/operator-selected/path/oauth_creds.json
+cortex_root_cli install trust-root credentials import --receipt "$cortex_receipt_path" \
+  --principal builder --provider agy --source "$cortex_builder_agy_source" \
   --maintenance-token "$cortex_maintenance_token"
 ```
 

--- a/qualification/redaction_scan.py
+++ b/qualification/redaction_scan.py
@@ -10,12 +10,16 @@ import sys
 from pathlib import Path
 
 
-SECRET_ENV = (
+REQUIRED_SECRET_ENV = (
     "CORTEX_RC_CODEX_AUTH",
     "CORTEX_RC_AGY_AUTH",
     "CORTEX_RC_COPILOT_AUTH",
     "CORTEX_RC_MANAGER_GITHUB_AUTH",
 )
+OPTIONAL_SECRET_ENV = ("CORTEX_RC_BUILDER_AGY_AUTH",)
+# Keep one exported inventory for callers/tests while distinguishing the
+# optional host-overlay credential from the four default canary inputs.
+SECRET_ENV = REQUIRED_SECRET_ENV + OPTIONAL_SECRET_ENV
 TOKEN_PATTERNS = (
     re.compile(rb"gh[pousr]_[A-Za-z0-9_]{20,}"),
     re.compile(rb"sk-[A-Za-z0-9_-]{20,}"),
@@ -29,10 +33,22 @@ def _needles(profile: str) -> tuple[bytes, ...]:
     if profile != "deployment-canary":
         raise ValueError("profile must be release or deployment-canary")
     values: set[bytes] = set()
-    for name in SECRET_ENV:
+    for name in REQUIRED_SECRET_ENV:
         raw = os.environ.get(name)
         if not raw:
             raise ValueError(f"protected secret {name} is unavailable")
+        encoded = raw.encode()
+        if len(encoded) < 8:
+            raise ValueError(f"protected secret {name} is unexpectedly short")
+        values.add(encoded)
+        for line in encoded.splitlines():
+            stripped = line.strip()
+            if len(stripped) >= 8:
+                values.add(stripped)
+    for name in OPTIONAL_SECRET_ENV:
+        raw = os.environ.get(name)
+        if not raw:
+            continue
         encoded = raw.encode()
         if len(encoded) < 8:
             raise ValueError(f"protected secret {name} is unexpectedly short")

--- a/qualification/run.sh
+++ b/qualification/run.sh
@@ -132,6 +132,20 @@ docker exec "$container_name" cortex install trust-root plan \
     --output "$plan_path"
 plan_sha=$(docker exec "$container_name" sha256sum "$plan_path" | awk '{print $1}')
 
+# The packaged release config keeps the builder on Codex. A host overlay may
+# opt into AGY, in which case the plan is the authority for whether a separate
+# builder credential must be supplied. Treat an unreadable/malformed plan as a
+# harness failure instead of silently skipping the protected import.
+builder_agy_required=0
+if docker exec "$container_name" jq -e \
+    'any(.required_credentials[]?; .principal == "builder" and .provider == "agy")' \
+    "$plan_path" >/dev/null 2>&1; then
+    builder_agy_required=1
+else
+    plan_query_status=$?
+    [[ $plan_query_status -eq 1 ]] || die "install plan required_credentials could not be inspected"
+fi
+
 # Apply once for a fresh install and once more to prove idempotency. The public
 # installer owns receipt replay; the harness never translates its plan to shell.
 docker exec "$container_name" cortex install trust-root apply \
@@ -220,6 +234,9 @@ import_fixture() {
 
 if [[ "$profile" == deployment-canary ]]; then
     import_secret CORTEX_RC_CODEX_AUTH builder codex /run/auth.json
+    if (( builder_agy_required )); then
+        import_secret CORTEX_RC_BUILDER_AGY_AUTH builder agy /run/oauth_creds.json
+    fi
     import_secret CORTEX_RC_AGY_AUTH reviewer-planner agy /run/oauth_creds.json
     import_secret CORTEX_RC_COPILOT_AUTH reviewer-planner copilot /run/hosts.json
     import_secret CORTEX_RC_MANAGER_GITHUB_AUTH manager github /run/hosts.yml
@@ -227,6 +244,9 @@ else
     # Exercise the production import/activation path without introducing a
     # credential or external authority into release qualification.
     import_fixture builder codex /run/auth.json
+    if (( builder_agy_required )); then
+        import_fixture builder agy /run/oauth_creds.json
+    fi
     import_fixture reviewer-planner agy /run/oauth_creds.json
     import_fixture reviewer-planner copilot /run/hosts.json
     import_fixture manager github /run/hosts.yml

--- a/tests/test_phase2_closeout_runbook.py
+++ b/tests/test_phase2_closeout_runbook.py
@@ -181,7 +181,9 @@ def test_current_runbook_holds_maintenance_lease_before_service_snapshot() -> No
     ):
         assert f'"{field}"' in current
     assert 'token = document["maintenance_token"]' in current
-    assert current.count('--maintenance-token "$cortex_maintenance_token"') == 8
+    # The optional builder/AGY import adds one plan-gated mutation command;
+    # the default four credential imports remain unchanged.
+    assert current.count('--maintenance-token "$cortex_maintenance_token"') == 9
     assert "cortex_acquire_maintenance_lease()" in current
     assert current.count("cortex_acquire_maintenance_lease") == 2
     receipt_binding = 'document["receipt_path"] != sys.argv[3]'

--- a/tests/test_phase2_qualification.py
+++ b/tests/test_phase2_qualification.py
@@ -1162,6 +1162,7 @@ def test_qualification_driver_and_runner_are_fail_closed_on_live_inputs() -> Non
     for variable in (
         "CORTEX_RC_CODEX_AUTH",
         "CORTEX_RC_AGY_AUTH",
+        "CORTEX_RC_BUILDER_AGY_AUTH",
         "CORTEX_RC_COPILOT_AUTH",
         "CORTEX_RC_MANAGER_GITHUB_AUTH",
         "CORTEX_RC_PROBE_REPOSITORY",
@@ -1169,6 +1170,15 @@ def test_qualification_driver_and_runner_are_fail_closed_on_live_inputs() -> Non
         "CORTEX_RC_PROBE_ISSUE",
     ):
         assert variable in runner
+    assert "builder_agy_required" in runner
+    assert "jq -e" in runner
+    assert (
+        "import_secret CORTEX_RC_BUILDER_AGY_AUTH builder agy /run/oauth_creds.json"
+        in runner
+    )
+    assert (
+        "import_fixture builder agy /run/oauth_creds.json" in runner
+    )
 
 
 def test_release_driver_never_calls_live_provider_or_repository_functions(
@@ -1270,6 +1280,21 @@ def test_canary_redaction_profile_requires_every_live_secret(
     (tmp_path / "qualification.json").write_text("{}", encoding="utf-8")
 
     with pytest.raises(ValueError, match="protected secret"):
+        redaction.scan(tmp_path, profile="deployment-canary")
+
+
+def test_canary_redaction_covers_optional_builder_agy_secret(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    redaction = _load_redaction_module()
+    for name in redaction.SECRET_ENV:
+        monkeypatch.setenv(name, "base-secret-value")
+    builder_secret = "builder-agy-secret-value"
+    monkeypatch.setenv("CORTEX_RC_BUILDER_AGY_AUTH", builder_secret)
+    candidate = tmp_path / "qualification.json"
+    candidate.write_text(builder_secret, encoding="utf-8")
+
+    with pytest.raises(ValueError, match="credential-like material"):
         redaction.scan(tmp_path, profile="deployment-canary")
 
 

--- a/tests/test_release_pipeline_workflows.py
+++ b/tests/test_release_pipeline_workflows.py
@@ -232,6 +232,7 @@ def test_deployment_canary_is_manual_protected_and_separate_from_release() -> No
     assert "--profile deployment-canary" in raw
     assert "CORTEX_RC_CODEX_AUTH" in raw
     assert "CORTEX_RC_AGY_AUTH" in raw
+    assert "CORTEX_RC_BUILDER_AGY_AUTH" in raw
     assert "CORTEX_RC_COPILOT_AUTH" in raw
     assert "CORTEX_RC_MANAGER_GITHUB_AUTH" in raw
     assert "CORTEX_RC_PROBE_REPOSITORY" in raw


### PR DESCRIPTION
## 摘要

Closes #805

- 以 install plan 的 `required_credentials` 作為唯一判準，只有 host overlay 明列 `(builder, agy)` 時才匯入獨立的 `CORTEX_RC_BUILDER_AGY_AUTH`。
- plan 查詢失敗會 fail-closed；release packaged config 維持 builder/codex default。
- canary redaction、workflow env、Trust Root runbook 與回歸測試同步更新。

## 驗證

- [x] `bash -n qualification/run.sh`
- [x] focused qualification/workflow/runbook tests
- [x] full pytest：5646 passed，41 skipped，173 subtests passed
- [x] exact-SHA disposable release qualification：profile=release，status=passed，overlay plan 含 builder/agy credential
- [x] policy context：25 pass，0 fail，1 pre-existing R-22 warning

## 邊界

- 未匯入、未寫入或上傳任何 credential 值。
- 沒有修改 host systemd、`/opt/cortex` 或 root durable state。
- live provider OAuth / real builder commit acceptance 仍需 protected environment 與 operator credential，未以 fixture 冒充。