### PR TITLE
fix(coordinator): agy headless terminal 改走 JSON envelope 並剝除前導文字

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@
 
 ## [Unreleased]
 
+- **#807 agy headless terminal 改走 JSON envelope 並剝除前導文字**：`build_agy_argv` 對
+  planner／reviewer／verifier／builder 所有 agy headless 形態一律附加 `--output-format json`，
+  讓 terminal 證據落成單行 JSON envelope；Manager `_extract_terminal_json` 與
+  planning_runtime `_ENVELOPE_KEYS` 新增接受 agy envelope 的 `response` 鍵，
+  `_parse_terminal_json_text` 只在 json code fence 為回應尾綴時剝殼、並在 agy 前綴進度文字時
+  只採信回應尾端的完整 terminal payload（內嵌範例 fence 與任意內嵌 JSON 仍拒絕）。status
+  enum 別名與 rate-limit 同 identity 重試不在本次範圍。
+
 - **Trust Root AGY builder 契約（#805）**：four-way generator、install attestation 與
   builder credential import 現在支援明示的 AGY builder grant；Trust Root hardened runner
   （`PSC_JOB_RUNNER` 為非 `direct`）的 model resolution、doctor 與 dispatch preflight 會在

--- a/changelog.d/agy-terminal-unwrap.md
+++ b/changelog.d/agy-terminal-unwrap.md
@@ -1,0 +1,9 @@
+- **#807 agy headless terminal 改走 JSON envelope 並剝除前導文字**：`build_agy_argv` 對
+  planner／reviewer／verifier／builder 所有 agy headless 形態一律附加 `--output-format json`，
+  讓 terminal 證據落成單行 JSON envelope，而非 Antigravity 預設多行 pretty-print 的 text
+  輸出；Manager `_extract_terminal_json` 與 planning_runtime `_ENVELOPE_KEYS` 新增接受
+  agy envelope 的 `response` 鍵。`_parse_terminal_json_text` 容忍尾端 json code fence 後的
+  換行、只在 fence 為回應**尾綴**時剝殼（內嵌範例 fence 仍不是 terminal 證據），並在 agy
+  前綴進度文字（如「Waiting for tests...」）時只採信回應**尾端**的完整 terminal payload
+  （任意內嵌 JSON 仍拒絕）。status enum 別名（`verified`→`passed`）與 rate-limit 時的同
+  identity 重試不在本次範圍，仍留在 #807。

--- a/paulsha_cortex/coordinator/launcher.py
+++ b/paulsha_cortex/coordinator/launcher.py
@@ -1191,6 +1191,10 @@ def build_agy_argv(
     review_only: bool = False,
     commit_required: bool = False,
     write_forbidden: bool = False,
+    # Workflow lanes want the single-line JSON envelope; the capability probe
+    # (#670) keeps the bare ``--output-format text`` shape because the CLI
+    # rejects ``--json-schema`` there and the probe parser reads raw JSON.
+    json_envelope: bool = True,
 ) -> list[str]:
     """Build the headless Antigravity invocation for each launcher persona.
 
@@ -1238,7 +1242,8 @@ def build_agy_argv(
     # Antigravity's default text output pretty-prints structured responses over
     # multiple lines.  Workflow terminal evidence is JSONL, so ask the CLI for
     # its single-line JSON envelope and let Manager unwrap the ``response``.
-    argv.extend(["--output-format", "json"])
+    if json_envelope:
+        argv.extend(["--output-format", "json"])
     if model is not None:
         argv.extend(["--model", model])
     return argv

--- a/paulsha_cortex/coordinator/launcher.py
+++ b/paulsha_cortex/coordinator/launcher.py
@@ -1235,6 +1235,10 @@ def build_agy_argv(
                 argv += ["--add-dir", git_write_dir]
         if allow_unsafe:
             argv.append("--dangerously-skip-permissions")
+    # Antigravity's default text output pretty-prints structured responses over
+    # multiple lines.  Workflow terminal evidence is JSONL, so ask the CLI for
+    # its single-line JSON envelope and let Manager unwrap the ``response``.
+    argv.extend(["--output-format", "json"])
     if model is not None:
         argv.extend(["--model", model])
     return argv

--- a/paulsha_cortex/coordinator/manager.py
+++ b/paulsha_cortex/coordinator/manager.py
@@ -4386,7 +4386,7 @@ def _extract_terminal_json(log_path: object) -> dict[str, object]:
             parsed = _parse_terminal_json_text(data.get("content"))
             if parsed is not None:
                 return parsed
-        for key in ("result", "content", "message", "text"):
+        for key in ("result", "content", "message", "text", "response"):
             parsed = _parse_terminal_json_text(value.get(key))
             if parsed is not None:
                 return parsed
@@ -4408,12 +4408,32 @@ def _extract_terminal_json(log_path: object) -> dict[str, object]:
 def _parse_terminal_json_text(value: object) -> dict[str, object] | None:
     if not isinstance(value, str):
         return None
-    fenced = re.fullmatch(r"```json\r?\n(?P<body>[\s\S]+)\r?\n```", value)
+    fenced = re.fullmatch(r"```json\r?\n(?P<body>[\s\S]+)\r?\n```\r?\n?", value)
     if fenced is not None:
         value = fenced.group("body")
+    else:
+        # AGY can emit progress prose before its final fenced terminal object.
+        # Accept the fence only when it is the response suffix; embedded example
+        # blocks remain non-terminal evidence.
+        trailing_fenced = re.search(
+            r"(?:^|\r?\n)```json\r?\n(?P<body>[\s\S]+?)\r?\n```\r?\n?\Z",
+            value,
+        )
+        if trailing_fenced is not None:
+            value = trailing_fenced.group("body")
     try:
         parsed = json.loads(value)
     except json.JSONDecodeError:
+        # AGY may prepend progress text even when asked for a terminal JSON object.
+        # Accept only a complete terminal payload at the very end of the response;
+        # arbitrary embedded JSON remains rejected.
+        for start in (index for index, char in enumerate(value) if char == "{"):
+            try:
+                parsed = json.loads(value[start:].strip())
+            except json.JSONDecodeError:
+                continue
+            if _is_workflow_terminal_payload(parsed):
+                return parsed
         return None
     return parsed if _is_workflow_terminal_payload(parsed) else None
 

--- a/paulsha_cortex/coordinator/model_identities.py
+++ b/paulsha_cortex/coordinator/model_identities.py
@@ -1074,6 +1074,7 @@ def probe_agy_capability(
         log_dir=".",
         model=cli_model_token,
         read_only=True,
+        json_envelope=False,
     )
     try:
         smoke_raw = process_runner(argv, **common)

--- a/paulsha_cortex/coordinator/planning_runtime.py
+++ b/paulsha_cortex/coordinator/planning_runtime.py
@@ -726,7 +726,7 @@ _FENCED_JSON = re.compile(
 
 # issue #401 巢狀欄位名——CLI launcher（claude/codex/agy）的成功 envelope
 # 用來裝「模型實際輸出」的欄位名不一而足，沿用既有偵測順序。
-_ENVELOPE_KEYS = ("result", "content", "message", "text")
+_ENVELOPE_KEYS = ("result", "content", "message", "text", "response")
 
 # issue #401：questioner／integrator／secondary planner 的 prompt 過去只用
 # 「Return only ... JSON」這類軟性措辭，模型（實測 sonnet 對 questioner

--- a/tests/test_coordinator_agy_launcher.py
+++ b/tests/test_coordinator_agy_launcher.py
@@ -381,3 +381,24 @@ def test_agy_commit_required_launcher_emits_real_scoped_git_dirs(monkeypatch, tm
     ]
     assert add_dirs == [str(tmp_path.resolve()), *git_write_dirs]
     assert "--sandbox" not in inner_argv
+
+
+def test_build_agy_argv_json_envelope_opt_out_keeps_probe_shape() -> None:
+    """#670 probe 契約：``json_envelope=False`` 時不得帶 ``--output-format``；預設仍帶 json。"""
+    probe = build_agy_argv(
+        prompt="p",
+        slice_id="cortex-capability-probe",
+        log_dir=".",
+        model="gemini-3.1-pro-high",
+        read_only=True,
+        json_envelope=False,
+    )
+    assert "--output-format" not in probe
+    default = build_agy_argv(
+        prompt="p",
+        slice_id="cortex-capability-probe",
+        log_dir=".",
+        model="gemini-3.1-pro-high",
+        read_only=True,
+    )
+    assert default[default.index("--output-format") + 1] == "json"

--- a/tests/test_coordinator_agy_launcher.py
+++ b/tests/test_coordinator_agy_launcher.py
@@ -24,6 +24,8 @@ def test_agy_argv_is_headless_plan_sandbox_and_keeps_prompt_single() -> None:
         "--mode",
         "plan",
         "--sandbox",
+        "--output-format",
+        "json",
         "--model",
         "Gemini 3.1 Pro (High)",
     ]
@@ -49,6 +51,7 @@ def test_agy_reviewer_argv_grants_only_the_disposable_checkout(tmp_path) -> None
         "--sandbox",
     ]
     assert argv[6:8] == ["--add-dir", str(worktree.resolve())]
+    assert argv[argv.index("--output-format") + 1] == "json"
     assert "--dangerously-skip-permissions" not in argv
 
 
@@ -71,6 +74,7 @@ def test_agy_builder_argv_uses_accept_edits_and_scopes_worktree(tmp_path) -> Non
         "accept-edits",
     ]
     assert argv[5:7] == ["--add-dir", str(worktree.resolve())]
+    assert argv[argv.index("--output-format") + 1] == "json"
     assert "--sandbox" not in argv
     assert "--dangerously-skip-permissions" not in argv
 
@@ -122,6 +126,7 @@ def test_agy_builder_write_forbidden_argv_keeps_strict_plan_sandbox(tmp_path) ->
         "--sandbox",
     ]
     assert argv[6:8] == ["--add-dir", str(worktree.resolve())]
+    assert argv[argv.index("--output-format") + 1] == "json"
     assert "accept-edits" not in argv
     assert "--dangerously-skip-permissions" not in argv
 
@@ -144,6 +149,8 @@ def test_agy_planner_write_forbidden_argv_never_adds_worktree(tmp_path) -> None:
         "--mode",
         "plan",
         "--sandbox",
+        "--output-format",
+        "json",
     ]
     assert "--add-dir" not in argv
 

--- a/tests/test_planning_runtime.py
+++ b/tests/test_planning_runtime.py
@@ -14,6 +14,24 @@ def _completed(stdout: str = "", returncode: int = 0):
     return type("Completed", (), {"stdout": stdout, "stderr": "", "returncode": returncode})()
 
 
+def test_planning_json_extracts_agy_response_envelope() -> None:
+    expected = {
+        "schema_version": 1,
+        "question_pack_id": "qp-demo",
+        "evidence": [],
+    }
+    stdout = json.dumps(
+        {
+            "conversation_id": "conversation",
+            "status": "SUCCESS",
+            "response": json.dumps(expected),
+            "duration_seconds": 1.0,
+        }
+    )
+
+    assert planning_runtime._extract_json_candidates(stdout, None) == expected
+
+
 def test_production_runtime_loads_registry_and_probes_only_safe_launchers(
     monkeypatch, tmp_path: Path
 ) -> None:

--- a/tests/test_workflow_production_wiring.py
+++ b/tests/test_workflow_production_wiring.py
@@ -4377,6 +4377,89 @@ def test_terminal_json_reads_copilot_assistant_message_data_content(tmp_path: Pa
     assert manager._extract_terminal_json(str(log)) == evidence
 
 
+def test_terminal_json_reads_agy_json_response(tmp_path: Path) -> None:
+    evidence = {
+        "schema_version": 2,
+        "kind": "workflow-card",
+        "status": "passed",
+        "run_id": "run",
+        "card_id": "card",
+        "candidate": "a" * 40,
+        "outputs": [],
+        "diagnostics": {},
+        "gate_evidence": [],
+    }
+    log = tmp_path / "agy.jsonl"
+    log.write_text(
+        json.dumps({
+            "conversation_id": "conversation",
+            "status": "SUCCESS",
+            "response": f"```json\n{json.dumps(evidence)}\n```\n",
+        })
+        + "\nfatal: Refusing to create empty bundle.\n"
+        + "\n",
+        encoding="utf-8",
+    )
+
+    assert manager._extract_terminal_json(str(log)) == evidence
+
+
+def test_terminal_json_reads_agy_response_with_progress_prefix(tmp_path: Path) -> None:
+    evidence = {
+        "schema_version": 2,
+        "kind": "workflow-card",
+        "status": "passed",
+        "run_id": "run",
+        "card_id": "card",
+        "candidate": "a" * 40,
+        "outputs": [],
+        "diagnostics": {},
+        "gate_evidence": [],
+    }
+    log = tmp_path / "agy-progress.jsonl"
+    log.write_text(
+        json.dumps({
+            "conversation_id": "conversation",
+            "status": "SUCCESS",
+            "response": "Waiting for tests...\n" + json.dumps(evidence, indent=2) + "\n",
+        })
+        + "\n",
+        encoding="utf-8",
+    )
+
+    assert manager._extract_terminal_json(str(log)) == evidence
+
+
+def test_terminal_json_reads_agy_response_with_progress_prefix_and_fence(tmp_path: Path) -> None:
+    evidence = {
+        "schema_version": 2,
+        "kind": "workflow-card",
+        "status": "passed",
+        "run_id": "run",
+        "card_id": "card",
+        "candidate": "a" * 40,
+        "outputs": [],
+        "diagnostics": {},
+        "gate_evidence": [],
+    }
+    log = tmp_path / "agy-progress-fenced.jsonl"
+    log.write_text(
+        json.dumps({
+            "conversation_id": "conversation",
+            "status": "SUCCESS",
+            "response": (
+                "I have launched the test suite.\n"
+                "Waiting for tests...\n"
+                f"```json\n{json.dumps(evidence, indent=2)}\n```\n"
+            ),
+        })
+        + "\n",
+        encoding="utf-8",
+    )
+
+    assert manager._extract_terminal_json(str(log)) == evidence
+
+
 def test_terminal_json_rejects_copilot_non_message_data_content(tmp_path: Path) -> None:
     fake = {
         "schema_version": 1,


### PR DESCRIPTION
## 摘要

Refs #807 — 把 runtime-main 工作樹上 daemon 正在跑的 hotfix（agy headless `--output-format json`＋Manager terminal 剝殼）落成正式 PR。agy headless 的 planner／reviewer／verifier／builder 形態一律改帶 JSON envelope 輸出，Manager 與 planning_runtime 接受 envelope 的 `response` 鍵，並在剝除尾端 json code fence 與前導進度文字後才認 terminal。

#807 的 status enum 別名（`verified`→`passed`）與 claude rate-limit 時同 identity 重試等殘項**不在本 PR**，因此只 Refs 不 Closes（帶 `policy-exempt:issue-link`）。

## 變更

- `paulsha_cortex/coordinator/launcher.py`：`build_agy_argv` 在 `--model` 之前一律附加 `--output-format json`，避免 Antigravity 預設 text 輸出把 structured response 多行 pretty-print 而破壞 JSONL terminal 證據。
- `paulsha_cortex/coordinator/manager.py`：`_extract_terminal_json` envelope 鍵新增 `response`；`_parse_terminal_json_text` 容忍 fence 尾端換行、只在 json code fence 為回應尾綴時剝殼（內嵌範例 fence 仍非 terminal 證據）、agy 前綴進度文字時只採信回應尾端的完整 terminal payload（任意內嵌 JSON 仍拒絕）。
- `paulsha_cortex/coordinator/planning_runtime.py`：`_ENVELOPE_KEYS` 新增 `response`。
- 測試：`tests/test_coordinator_agy_launcher.py`（五個 argv 形狀案例釘住 `--output-format json`）、`tests/test_planning_runtime.py`（agy `response` envelope 抽取）、`tests/test_workflow_production_wiring.py`（三個 agy terminal 案例：fence＋尾隨 git 雜訊、前綴進度文字＋純 JSON、前綴進度文字＋fence）。
- `changelog.d/agy-terminal-unwrap.md` 新增；`CHANGELOG.md [Unreleased]` 同步補一條。

## 測試證據

- `python -m pytest -q tests/test_workflow_production_wiring.py tests/test_coordinator_agy_launcher.py tests/test_planning_runtime.py` → **158 passed**。
- `python3 -m policy_check --repo . --pr-title … --pr-body … --pr-labels policy-exempt:issue-link --pr-base-ref main --pr-head-ref feature/807-agy-terminal-unwrap`（引擎 policy-check 1.0.17）→ **pass 23 / fail 0 / warn 2 / skip 1**；warn 為 R-18（docs-sync advisory，內部 launcher／harvest 行為修正、無使用者可見文件變更）與 R-22（72 筆陳年懸空引用，advisory），skip 為 R-17（`policy-exempt:issue-link`）。

## Checklist

- [x] `changelog.d/agy-terminal-unwrap.md` fragment 已新增且已 commit
- [x] `CHANGELOG.md [Unreleased]` 有對應 entry
- [x] `VERSION` 未變動（非 release PR）
- [x] 焦點測試通過（158 passed）
- [x] policy_check 帶 PR 上下文於本機跑過
- [x] 未新增個人絕對路徑／機敏標記（R-21）
- [x] 只 Refs #807 不關閉，帶 `policy-exempt:issue-link`

Refs #807

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bh2MFJFbU1ZZ87U8cXNxDF
