### PR TITLE
docs(refine): 補齊十四類精修與動態額度派工規劃

### DIFF
--- a/.cortex/work-items.yaml
+++ b/.cortex/work-items.yaml
@@ -737,7 +737,11 @@ work_items:
         ref: 'hamanpaul/paulsha-cortex#665'
       - kind: path
         ref: 'docs/superpowers/workstreams/trust-root-executor-hardening/todo.md'
-    excludes: []
+    excludes:
+      - kind: github_issue
+        ref: 'hamanpaul/paulsha-cortex#692'
+      - kind: github_issue
+        ref: 'hamanpaul/paulsha-cortex#763'
   trust-root-copilot-toolchain-pinning:
     title: 'trust-root-copilot-toolchain-pinning'
     links:
@@ -779,4 +783,66 @@ work_items:
         ref: 'hamanpaul/paulsha-cortex#792'
       - kind: openspec
         ref: 'manager-gitconfig-delivery'
+    excludes: []
+  daemon-tick-clock-not-idle:
+    title: 'daemon-tick-clock-not-idle'
+    links:
+      - kind: github_issue
+        ref: 'hamanpaul/paulsha-cortex#819'
+      - kind: path
+        ref: 'docs/superpowers/workstreams/daemon-tick-clock-not-idle/todo.md'
+    excludes: []
+  registry-persist-hygiene:
+    title: 'registry-persist-hygiene'
+    links:
+      - kind: github_issue
+        ref: 'hamanpaul/paulsha-cortex#821'
+      - kind: path
+        ref: 'docs/superpowers/workstreams/registry-persist-hygiene/todo.md'
+    excludes: []
+  executor-durable-backoff:
+    title: 'executor-durable-backoff'
+    links:
+      - kind: github_issue
+        ref: 'hamanpaul/paulsha-cortex#825'
+      - kind: path
+        ref: 'docs/superpowers/workstreams/executor-durable-backoff/todo.md'
+    excludes: []
+  outcome-taxonomy-signals:
+    title: 'outcome-taxonomy-signals'
+    links:
+      - kind: github_issue
+        ref: 'hamanpaul/paulsha-cortex#826'
+      - kind: path
+        ref: 'docs/superpowers/workstreams/outcome-taxonomy-signals/todo.md'
+    excludes: []
+  yaml-inline-list-quotes:
+    title: 'yaml-inline-list-quotes'
+    links:
+      - kind: github_issue
+        ref: 'hamanpaul/paulsha-cortex#822'
+      - kind: path
+        ref: 'docs/superpowers/workstreams/yaml-inline-list-quotes/todo.md'
+      - kind: path
+        ref: 'docs/superpowers/specs/yaml-inline-list-quotes-spec.md'
+      - kind: path
+        ref: 'docs/superpowers/specs/yaml-inline-list-quotes-design.md'
+    excludes: []
+  launcher-session-and-timeout:
+    title: 'launcher-session-and-timeout'
+    links:
+      - kind: github_issue
+        ref: 'hamanpaul/paulsha-cortex#823'
+      - kind: github_issue
+        ref: 'hamanpaul/paulsha-cortex#824'
+      - kind: path
+        ref: 'docs/superpowers/workstreams/launcher-session-and-timeout/todo.md'
+    excludes: []
+  monitor-refresh-thread-backlog:
+    title: 'monitor-refresh-thread-backlog'
+    links:
+      - kind: github_issue
+        ref: 'hamanpaul/paulsha-cortex#827'
+      - kind: path
+        ref: 'docs/superpowers/workstreams/monitor-refresh-thread-backlog/todo.md'
     excludes: []

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
 
 ## [Unreleased]
 
+- **十四類 Cortex 精修進件（#829）**：收斂完整分批計畫、OpenSpec 驗收契約、動態
+  execution profile／額度觀測與預估／fallback 邊界；PatchMUD producer 由獨立 #37
+  列管。補齊 P1 canonical todo 與 #496／#497 校正，保留 #828 獨立工作所有權。
+  此項只交付規劃與進件，不宣稱產品修正、測試或部署完成。
+
 - **#807 agy headless terminal 改走 JSON envelope 並剝除前導文字**：`build_agy_argv` 對
   planner／reviewer／verifier／builder 所有 agy headless 形態一律附加 `--output-format json`，
   讓 terminal 證據落成單行 JSON envelope；Manager `_extract_terminal_json` 與

--- a/changelog.d/cortex-refine-complete-20260907.md
+++ b/changelog.d/cortex-refine-complete-20260907.md
@@ -1,0 +1,7 @@
+# 十四類 Cortex 精修計畫與 P1 進件
+
+- 以 #829 列管 R01–R14 修正／驗收與 B0–B6 依賴，保留 PatchMUD #37 外部 producer gate。
+- 明定可擴充 executor/model/native effort、profile-aware qualification、多池 quota observation、任務 forecast、atomic reservation 與安全 fallback。
+- 校正 P1 文件的 history API、損毀 backoff、failure consumer、session/cgroup 與 bounded refresh 契約，將 bucket-C 校正併回 #496／#497。
+- 保留既有 work_id；只註冊已具 P1 issue/todo 的工作，#828 與下游工作不混入本次進件。
+- 本 fragment 為規劃／進件交付，不代表相應 code、runtime 或完整生命周期已修正。

--- a/docs/superpowers/plans/2026-09-07-cortex-refine-complete.md
+++ b/docs/superpowers/plans/2026-09-07-cortex-refine-complete.md
@@ -1,0 +1,214 @@
+---
+status: accepted
+date: 2026-09-07
+---
+
+# Cortex 精修完整範圍與動態派工計畫
+
+交付總帳：[Cortex #829](https://github.com/hamanpaul/paulsha-cortex/issues/829)。PatchMUD producer：[PatchMUD #37](https://github.com/hamanpaul/paulsha-patchmud/issues/37)。
+
+本版把前述 14 類問題全部納入具體交代，保留既有 P1 工單並補齊未涵蓋部分。本版為使用者核可方向後的執行計畫；各項交付進度以末節 ledger 與 Cortex receipts 為準，不能以文件接受代替實作完成。
+
+原始基線：2026-09-06 精修筆記與 2026-09-07 Claude→Codex handoff（operator 保存的唯讀歷史證據）。
+本版語彙：[動態派工語彙](../specs/2026-09-07-cortex-execution-domain.md)。既有 repo `CONTEXT.md` 仍是工作生命週期與權責的基線。
+
+## 1. 使用者已明確指定的要求
+
+1. 前述 14 類問題都要有修正範圍、驗收與剩餘限制，不能用 P1 完成代替全部完成。
+2. 額度處理包含偵測與任務用量預估，能在耗盡前選擇尚可承擔工作的 fallback。
+3. 不採固定 model／agent／effort 配對作為系統規則；新模型、新執行器、新 effort 能經擴充契約加入。
+4. 核對並沿用已引入的 paulsha-patchmud 評估機制，避免重做平行評測系統。
+
+以下動態路由、額度預留及分批安排為執行設計；尚未宣稱功能已發布。先前「Claude 優先」視為本批選擇偏好；不把它寫成所有工作永久固定使用 Claude 的 invariant。明確指定不可替換的 pin 仍保留。
+
+## 2. PatchMUD 確實已引入：目前實作與缺口
+
+本輪直接核對 Cortex operator HEAD `002196d7`、runtime/main `79ba6447` 與 PatchMUD checkout `1184c9e`。以下 Cortex profile／resolution／mapping 檔案在兩個 Cortex revisions 之間沒有差異；未執行新 benchmark，也未消耗模型額度。
+
+### 2.1 已有的資料流
+
+1. `cortex model profile` porcelain → `coordinator.model_profile.run_model_profile()`。
+2. 透過 CLI 執行 `patchmud run`、`patchmud report`，優先讀 `report.json`。
+3. `map_report_to_envelope()` 將符合條件的 ranked report 映射為能力封套與 provenance。
+4. 預設產 diff，明確 `--apply` 才寫 identity registry；現行預設目的地是 packaged `data/model-identities.yaml`。
+5. 正式派工已有 `operator-overlay → evaluated-roster → packaged-fallback` 分層，以及 persona、independence domain、launcher/toolchain/credential 相容性篩選。
+6. 第 2 層需要 `model-eval-roster.yaml` 的 `verdict=pass`、`review_status=approved` 與適用 role。這保留既有人工複核政策；動態選擇是在合格候選中選，不自動把評測成功等同授權。
+
+本機有歷史報告：
+
+operator 本機保存的 `runs/profile-claude-sonnet-20260812T140439Z/report/report.json`（未宣稱已上傳 GitHub）
+
+它記錄 `claude:claude-sonnet-5 / P0T0R0` 的 8 runs、8 clears，並有 `tokens_per_clear`、`cost_per_clear`、QATY 等榜。這只證明當時那組評測有報告；未在本輪重跑或將它外推為今日所有任務、模型、effort 的能力。
+
+### 2.2 接線不完整的具體證據
+
+| 缺口 | 現有證據／入口 | 本版處置 |
+|---|---|---|
+| profile producer 與 evaluated-roster consumer 未形成完整發布鏈 | Cortex `model_profile.py:350,606` 預設寫 packaged registry；`model_resolution.py:650` 讀 host eval roster；模組開頭明記供給管線屬後續工作 | 建立 report → qualification candidate → review receipt → approved roster 的版本化發布／匯入流程；沿用現有機械驗證。 |
+| active root 無評估合格檔案 | 本輪確認 `$HOME/.agents/config/paulsha/model-eval-roster.yaml` 不存在 | 顯示 empty／unqualified 的實況，補真實評測供給；不得造資料填空。 |
+| Cortex profile 只支援少數固定配對 | `model_profile.py:54` 的 aliases 僅 claude/sonnet、agy/gemini-3.1-pro-high；`:454` 查不到就 adapter-unavailable | 改由 adapter capability 與 profile descriptor 解析；新模型在既有協定內以資料宣告加入。 |
+| 評測 effort 與 production effort 不一致 | PatchMUD `cli.py:1438,1513,1522` 固定 CLI high；Cortex launcher 另有硬編與 ambient 設定 | 評測及生產共享同一個 execution profile 語意，adapter 分別轉譯並回報實際值；禁止以 high 成績冒充 max。 |
+| 評測識別不足以避免不同設定混用 | Cortex `_fingerprint()` `model_profile.py:260` 未含 effort／loadout／實際 adapter 版本 | 新版 fingerprint 納入所有影響結果的已解析設定、版本與環境條件，舊證據缺欄位保持 legacy/unknown。 |
+| Persona 與能力維度量測仍有限 | pilot-v1 在 `model_profile.py:60` 僅 builder；`envelope_mapping.py:184` 有三欄 default 理由 | 逐角色建立可重現測量；未量測維度不由其他角色分數代填。 |
+| 實務品質與用量尚未回饋到選擇 | `model_identities.py:1655` 的 track_record=bypass；registry `:1384` 只在 headless 結束時抽 usage | 增加獨立 operational telemetry 與預估器，作為派工證據來源；不覆寫 benchmark 原始排名。 |
+| 現行用量來源品質不一致 | `usage_extractors.py`：AGY unsupported、Copilot input 缺值；PatchMUD Claude adapter `:102` 缺 usage 時用字元數估算 | 所有量測帶 observed/estimated/unknown 與來源；歷史資料若無法辨識來源，不提升為權威額度事實。 |
+
+PatchMUD 的責任是可重現的能力／效率評測與報告；Cortex 的責任是把資格、任務需求、當前額度及運作紀錄合併成派工決策。品質合格不表示此刻額度足夠，用量較低也不表示品質合格。
+
+PatchMUD producer 由 [issue #37](https://github.com/hamanpaul/paulsha-patchmud/issues/37) 追蹤，沿用 #13 角色 deck、#23 token 語意、#16 pricing provenance 等既有工作。pricing snapshot 屬成本報告 provenance，不納入能力 fingerprint；單純調價不要求重新量測能力。effort、loadout、工具及 adapter 等影響實驗條件的變動仍須重新判定證據相容性。
+
+## 3. 全部 14 類問題的覆蓋契約
+
+R01–R14 是本文件的需求識別碼，**不是新建的 GitHub issue**。既有 issues 保留原 scope；超出其範圍的內容另拆 successor/child 工單，不偷偷擴大既有驗收。
+
+| ID／問題 | 本版明確納入的修正 | 既有落點／需要補的範圍 | 必須取得的驗收證據 |
+|---|---|---|---|
+| R01 Monitor 堆積與 freshness | 有界 refresh worker、事件合併、各 provider 執行公平性與時間上限、具體 stale 原因；一次刷新完成後仍有新事件要再刷新 | #827；補慢 provider／持續 churn／shutdown 的案例 | fake clock 與持續事件壓力下 thread/backlog 有界；GitHub 更新不被本地刷新無限餓死；停止可退出；故障時保留 last-good。 |
+| R02 Manager tick 熱迴圈 | skip/success/failure 都有明確下次 eligibility；max_load／require_idle 的有效值可見、可設定 | #819；補 manual/periodic 預設與 scope 決定 | 非 idle 持續一段時間，periodic 呼叫次數受 interval 約束；skip 不算 failure；配置錯誤與非有限值可診斷；bypass 不顯示為實際閒置。 |
+| R03 evidence／terminal 冪等 | 同內容與狀態不重複產 evidence；變更恰好一次；舊 attempt 不能改現行候選或 completion | #496／#497；#501 只驗已修版本與既存污染 | 同 path 不同內容、重複 tick、重啟、delayed terminal、retry generation 的回歸；evidence hash 與 contract hash 各自保持語意。 |
+| R04 registry 寫入放大 | 無變更 no-op、history 上限與可追溯封存、安全 tmp sweep、rollback 成本與相容性；高頻寫入量測 | #821；更大 storage 遷移須有 profiling 依據，不預設重寫資料庫 | 無變更零寫入；history 有界而必要 audit 證據可追；crash recovery／migration／讀者 schema 全過；真變更仍正確持久化。 |
+| R05 額度／預估／fallback | 多額度池與時間窗觀測、任務需求預估、並行額度預留、動態候選選擇、持久退避與 reset reconciliation | #825 保留最小退避修復；新增 quota observation、forecast、reservation 與 admission 範圍 | 派前拒絕不足候選；同池換模型仍排除；不同池合格候選可選；並行不超額預留；重啟不丟；預估不足／外部消耗可修正；未知餘量不假裝足夠。 |
+| R06 失敗分類失真 | 原始結構化原因、phase、retryability、reset 與診斷鏈一致保留；planning／build／review 共用語意 | #826 補訊號；另補 planning launcher error 被包成 content 等消費端 | auth、quota、rate-limit、effort unsupported、127、缺 handle、schema/content 各有真實 fixture；同一底層原因不因 phase 換名而丟失恢復資訊。 |
+| R07 Recovery 語意與可恢復性 | 定義 resume/retry/recover/abandon 各自 precondition、effect、generation、資源處置與合法 next_actions；解除綁定必須真的生效 | #497 + 現有 recovery 家族（含 #545/#546/#547/#577 等需先查現況再拆票） | 狀態轉換矩陣、重送冪等、CAS mismatch、重啟續跑、late evidence、已合併工作禁止重派；只清受控 attempt 資源，不丟 operator 修改。 |
+| R08 model/agent/effort 彈性 | 可擴充 capability/adapter 契約；任務需求與執行配置分離；effort 實際解析與 operator preference/pin 語意 | #483/#581 與新 execution-profile 範圍；替換分散硬編，不把本次型號寫成 invariant | 新虛構模型與新 effort 只改 descriptor 即能在既有 adapter 執行；新 runtime 只加 adapter 與測試、不改 central resolver；unsupported 在 spawn 前拒絕；requested/resolved 可對照。 |
+| R09 評測／探活／實務紀錄 | PatchMUD qualification 供給、角色 deck、完整 profile fingerprint、版本化核可清單、TTL probe 與分層 track-record | 沿用 #452/#454/#466/#534 成果；補後續管線；PatchMUD 端獨立 PR | 一份真實 report 可追到核可條目，再追到實際派工；未測量維度為 unknown；更換 effort/adapter/toolchain 後不沿用不相容評分；評測不中斷 tick 熱路徑。 |
+| R10 狀態真實性與可解釋性 | actual/planned/last execution、完整 facets、等待額度/恢復原因、有效配置與選模依據；read model 不寫 workflow | #828 負責 identity producer；另補 needs_human/freshness/decision provenance | 同卡 retry 換模型、多卡同 phase、跨 repo、未派工／已退出均不猜測；registry needs_human 保留；所有 status sections 一致；下游 fixture 獨立驗收。 |
+| R11 runtime／release 一致性 | CLI 安裝、服務載入 revision、設定 revision、artifact digest 可辨識；受治理 upgrade/restart/rollback 與 source override receipt | P4 擴充成部署一致性工作；先核對既有 installer/release 實作，避免重建 | 從 checkout 外驗 installed CLI；真正服務報告載入 artifact；未重啟舊程序不算已更新；upgrade/rollback 不丟 active jobs；#820 僅計已完成的部分。 |
+| R12 instance／工作所有權 | instance roots、workspaces、writer、資源與共享 quota authority 的邊界；installer/doctor 同源檢查，owner-aware 清理 | #818/#800/#476 等既有票；P0 手動配置轉成產品契約 | 多 instance 並行與重啟不互寫 registry；共享 quota 仍能協調；stop/cleanup 只作用於指定 owner；dirty artifacts 與下游工作不被混入 commit。 |
+| R13 launcher／parser 基礎可靠性 | argv 引號／逗號解析、process/session 與 cgroup 生命週期、timeout/取消、terminal envelope/enum 契約、adapter conformance | #822/#823/#824 + #807/#820 residual；systemd 取消語意若超出 #823 另票 | 實際 argv round-trip；kill 單 job 不連坐 manager；manager restart 對 child 的處置有證據；timeout 可設定且 parse 正確；terminal 不靠寬鬆 status 別名繞過驗證。 |
+| R14 進件／驗證／交付脫節 | 規範文件唯一來源、coverage matrix、逐項 evidence-backed checklist、可恢復分批審查與人力/用量預算、issue/PR/installed 狀態分開 | #830 非 Job 派工決策契約、#831 sizing 方向；補 Red 分解接續與 delivery-accounting；P5 backlog hygiene 沿用 | 缺任一驗收、未 commit、policy 佔位字時不可宣告完成；合法等待／轉換不冒充 Job；完整 spec 不因算法反向變高風險；Red 真正產出可追溯子工作；中斷只重跑缺失工作；同 issue 不重複註冊；已修未關逐票證據關閉。 |
+
+「全部交代」的意思是每列均有責任模組、交付邊界、驗收與殘餘限制；不代表用有限的靜態掃描證明今後不存在同類缺陷。關鍵全稱需求由 runtime 不變量與負面測試守護。
+
+## 4. R05 與 R08/R09 的共同設計
+
+### 4.1 可擴充候選與資格
+
+- Persona 與權限要求屬於任務；executor/model/effort 是每次選擇的結果。planner/builder/reviewer 不綁任何固定產品。
+- 每個 executor adapter 宣告可列出的 models、每個模型的原生 effort options、工具／sandbox 能力、probe、terminal、usage、quota observation 能力與版本。
+- 偏好可指向供應商、資格群組、成本／延遲條件；保留 allow/deny 與 explicit pin。相容性、獨立 reviewer domain、權限與最低品質是硬條件，不被額度或偏好覆蓋。
+- 新模型／effort：既有 adapter 協定可表達時，只新增/更新 descriptor、probe 與相符 qualification；不修改 central resolver 的型號表。
+- 新 agent runtime：允許新增 adapter 實作並通過 conformance／Trust Root qualification。不能承諾任意新協定零程式碼，但核心排序、額度、workflow 與 reporting 不需加入該產品的特判。
+- 非已知 Persona 不自動視為 build；新角色要有明確 role capability／artifact／qualification 契約。既有相容行為需做 migration，不能一次破壞舊 manifest。
+- `high`、`max` 等字串是 adapter 原生選項，不形成全域硬編枚舉或等價大小關係。使用者可指定抽象品質/預算意圖，但到實際 effort 的映射必須有宣告與證據。
+
+### 4.2 Quota observation 與用量預估
+
+觀測按來源分級：provider 官方可讀狀態／結構化事件優先，其次執行器實際 usage，最後才是明示估計；不抓取憑證內容、不繞過 provider 限制。實作各 adapter 時需再核對當時可用介面，本版不宣稱四家都有可查餘量 API。
+
+Quota observation 至少包含：pool/account 的非機敏識別、適用 profile/group、unit、window、remaining 或 remaining bounds、reset_at、observed_at、TTL、authority、來源與缺值原因。同一候選可能同時受帳號短期池、週額度、模型專屬池與 concurrency limit 約束。
+
+Usage forecast 按 task type／Persona／sizing／context 大小／工具與預期步驟／execution profile 產生需求範圍，涵蓋 planning、build、review、重試及 CLI 固定 overhead。PatchMUD report 可作冷啟動先驗，實務紀錄用於校準；跨任務分布轉移須降低信心。
+
+- 保留 token、request、premium request、credit、時間及 API-equivalent cost 的不同單位；只有可驗證 mapping 才可換算，不能拿 tokens 直接減 subscription quota。
+- 分開 input/output/cache/reasoning 的原生定義，防止累計值與增量相加、reasoning 重複計數；失敗 job 已消耗的量仍計入。
+- 預估器輸出上界／分位數、樣本數、信心、模型版本與資料期間。採用哪個風險分位數由政策設定，不硬釘某個模型或 effort。
+- 低樣本：採有來源的保守先驗與限額探索；完全不可比或未知時，標明 unknown，依 operator 政策選已知候選、有限 canary 或等待。不得用零代表未知，也不承諾絕不撞 limit。
+- 外層互動 session／未受管 CLI：可用唯讀量測接入同一 pool，無法觀測的消耗列 coverage gap，增加 headroom 並於新 provider 觀測到來時 reconcile。
+
+### 4.3 派工決策流程
+
+每個安全派工點（claim/planning dispatch、每張 card、retry/review）依同一服務取得決策：
+
+1. 凍結該次 task demand 與 policy revision；讀取最新 descriptor、qualification 與 quota observations。
+2. 篩選角色能力、工具／隔離、credentials grant、review independence、品質、context capacity、明確 allow/deny/pin 等硬條件。
+3. 針對每個合格 profile 估算需求；檢查它依賴的所有 pools/windows，扣除已預留額度並保留不確定性 headroom。
+4. 在 feasible 候選中，依 operator preference、可驗證品質、需求估計與期限排序。保留既有來源/核可政策，動態策略另有版本與明確啟用範圍，不靜默改變 legacy pin 行為。
+5. 原子取得全部必要 reservations 才可 spawn。任一池競爭失敗就重新評估，不能因先前讀到的舊餘量繼續派出。
+6. 記錄決策 receipt、job/attempt/profile 綁定及預留識別。執行期間可收到增量用量與限流事件；結束後以實際用量對帳。
+7. 必須切換時，先判定原 attempt 已終止或可安全交接，再建立有 supersession 關係的新 attempt。保留已驗證 artifact；中途不在未結束的工具／寫入交易上直接換模型。
+
+若所有合格候選都無法承擔工作，呈現「等待哪個 pool、最早重評時刻、缺哪項資料」。不得以不合格模型、不同名字但相同已耗盡 pool、或降低 reviewer independence 來假造可繼續。
+
+### 4.4 預留、持久退避與權責
+
+- 每個共享 quota pool 指定唯一 budget authority；受管 instance 的 admission 經同一原子仲裁，避免各自持有可雙花的剩餘數字。broker 介面與 Manager 單一 writer 模型一致，非授權 job 不寫預算狀態。
+- Pool 可以跨 executor/model/profile；短期與長期限制同時存在。#825 的 executor×model cooldown 作為 fallback 訊號之一，不能成為唯一額度邊界。
+- 狀態持久化包含 reservation、lease/liveness、observed consumption、reset 與 decision id；敏感帳號資訊不進公開報告。
+- Crash/restart 對 reservation 的處置須查 job liveness／已提交輸出與消耗；不能只因 TTL 到期就釋放仍在執行的工作額度。無法判定時保持 uncertain 並限制新的預留。
+- 退避檔損毀或過期資料不得被解讀為「額度全滿」；#825 初稿的 `corrupt file → empty` 必須在擴充設計中明確區分 unknown 與可用。
+- 本機多 instance 先取得原子仲裁證據；多 host 同帳號若未共用 authority，必須呈現外部消耗／分散一致性限制，不宣稱全域 reservation 保證。
+
+### 4.5 最少 12 個必要場景
+
+1. A 模型品質合格但短期池不足，B 有獨立池且合格：spawn B，A 不產失敗 job。
+2. A/B 是同池兩模型，池耗盡：兩者皆排除，不能靠換名稱繞過。
+3. 短期池足、週額度不足：仍不派；使用同單位檢查所有限制。
+4. 兩個 Manager instance 同時要求剩餘一份額度：只有一方取得 reservation。
+5. run 主控、worker、reviewer 共用帳號：所有已觀測消耗與預留合併；未受管 session 消耗以 coverage gap 顯示。
+6. 新模型與新的非既有 effort 字串進既有 adapter：無 central resolver diff，能探活、評測並參與動態選擇。
+7. 新 executor adapter 支援同樣合約：workflow 與 budget core 不改即可選用；工具或 Trust Root 不相容則拒絕。
+8. profile 評的是 high、生產要求 max：不沿用舊資格/用量成績冒充相符；排程 qualification 或套明示的未量測政策。
+9. provider 不提供剩餘量：unknown 有界處置，receipt 不顯示「已確認足夠」。
+10. job 失敗前已花額度、隨後 Manager 重啟：消耗不歸零、不重派已完成 attempt、不重複預留。
+11. reviewer 只有同 independence domain 候選有額度：等待並明示品質/獨立性阻擋，不自動放寬。
+12. 預估誤差與外部消耗導致執行中限流：保存現況、記錄 pool 狀態、在安全邊界 reroute；用可追溯資料修正 estimator，不把 infrastructure failure 全算模型能力失敗。
+
+以上使用 deterministic fake quota/adapter/clock、concurrency/crash fixtures 先驗契約；最後才安排有預算、可追溯的 live canary，避免測試本身耗盡額度。
+
+## 5. 分批交付與每批責任邊界
+
+此為新計畫批次，與舊筆記 P0–P5 名稱分開。以下批次不指定固定 agent 或模型；各次派工由當時合格候選與資源條件決定。實作時採隔離 worktree，跨 repo producer/consumer 分別 PR。
+
+| 批次 | 主要範圍 | 前置依賴／交付邊界 |
+|---|---|---|
+| B0 現場與進件收斂 | R14 的缺驗證補齊、canonical todo 整合、scope ownership；建立 R01–R14 coverage 清單 | 保存指定 Claude session 已完成結果；不重跑整批；不動既有 paulshaclaw active jobs 與 #828 scope。 |
+| B1 執行基礎穩定 | R01/R02/R03/R04/R13/R14：#822 canary、#830/#831 bootstrap、既有 P1 修復 | #820 merge 基底；canary 後優先補派工決策與 sizing，再進複雜任務；Red 分解未接續前須真實拆分，不改低分避開。monitor／daemon／registry／launcher 的共享檔案分批整合；退出暫時 bypass 要有 live 證據。#825 最小持久退避不代表 R05 完成。 |
+| B2 可擴充執行與資格契約 | R08/R09/R12 的 profile、adapter、role、pool identity 與 ownership 接口 | Cortex 定義消費契約，PatchMUD 以 producer PR 支援 profile-aware 評測；既有資料 migration 與 qualification review 保留。 |
+| B3 遙測與預估 | R05/R06/R09：quota observations、usage provenance、需求估計、實務紀錄 | 用既有 usage_extractors／PatchMUD reports 作來源；先 shadow 記錄不改派工；量測 forecast 誤差、可用率與來源缺口。 |
+| B4 動態選模與安全恢復 | R05/R07/R08：feasible candidates、atomic reservation、fallback、recover matrix | B2/B3 具證據後小範圍 opt-in；可回復 legacy policy，但不可刪除已形成的 evidence／reservation。 |
+| B5 狀態與部署契約 | R10/R11/R12：#828 producer、其餘 facets/decision receipt、installed runtime 與 instance 管理 | #828 可先獨立交付；下游顯示根據 upstream immutable fixture/pin 驗收；部署操作與 code PR 分開，不隨意重啟 active manager。 |
+| B6 完整閉環與 backlog | R14 加全部 R 的端到端驗收、issue closure、文件與 runtime 一致性 | 每類 requirement → tests → merge SHA → installed/canary evidence 完整；逐票判斷已修／取代／殘餘，不批次假關閉。 |
+
+B1 的主要目標是讓 Cortex 能可靠承接後續工作。B2–B4 完成後才可宣稱「可擴充、考慮額度與預估的動態派工」落地。B5/B6 完成後才可宣稱本版 14 類整體交付。
+
+## 6. 可觀察指標與證據清單
+
+- R01/R02：thread/backlog 上限、provider refresh age、poll/tick 次數與 skip 原因；持續負載壓測及停止時間。
+- R03/R04/R07：每個語意轉換的 evidence/action 次數、registry bytes/writes、replayed/superseded attempt、恢復耗時與資料保存證據。
+- R05/R08/R09：觀測覆蓋率、預估區間覆蓋率／誤差、同 pool double-reservation 次數、quota-caused failure／重複嘗試、fallback 原因、qualification 年齡與 profile 相符率。
+- R06/R10：可診斷失敗比例、原始原因保留率、registry→status facet 一致性、actual job identity 證據缺漏率；unknown 必須保留。
+- R11/R12：CLI/service/artifact/config revision 一致性、跨 instance 非預期寫入、active jobs 在 upgrade/rollback 的保存／終止 receipts。
+- R14：14/14 requirement 有 owner/scope/test/evidence、未驗證 checkbox 零容忍、中斷後重跑比例、逐 issue 真實 closure。
+
+效能／預估門檻先取 baseline，再在對應 spec 定義有理由的門檻與例外；不能用「CPU 必歸零」「所有 provider 都能精確預測」這類不可支持的保證代替驗收。
+
+## 7. 執行契約與完成 ledger
+
+使用者於 2026-09-07 要求修正計畫後接手 Claude 工作，持續派入 Cortex 開發直到完成。PatchMUD 端本輪授權為由 subagent 建 issue；Cortex 端承接 producer contract 消費與相容性驗證，不越界替 PatchMUD 實作。
+
+- 實作只走 Cortex workflow；主 agent 負責進件、觀察、核對、失敗裁決與整合，禁止繞過 authority 手改 registry、手造通過 evidence 或把未驗證工作勾成完成。
+- 完成門檻：每個 R 對應的必要工作均具 spec/plan、RED/GREEN、獨立 review、policy/CI、merge revision 與適當 runtime/installed 證據；R14 backlog 逐票裁決。
+- 既有 #828 及 paulshaclaw 工作保留獨立所有權，不混入 intake commit、不重派、不重啟它們所依賴的 manager。
+- Cortex self-hosting 修正須先單案 canary；共享 coordinator 核心依序整合。未足夠的新模型/agent 資格不得以 bypass 取得。
+- PatchMUD producer 尚未交付時，Cortex 可以 fixture 契約及 legacy migration 推進；live integration 仍明列外部依賴，不能將開 issue 當完成。
+- 此計畫與 OpenSpec 為 umbrella 規劃權威；保留既有 work_id，child todo 為每次 Cortex 啟動來源。umbrella 不另啟動一條重複實作 workflow。
+
+| 批次 | 狀態 | 證據／下一動作 |
+|---|---|---|
+| B0 | in-progress | 已保存原工作樹；隔離 authoring branch；補查缺少的 intake 驗證；本 umbrella strict OpenSpec validation 通過。 |
+| B1 | in-progress | #820 已合併基底；#822 前兩個進件 run 已正式 supersede，第三個 run 通過 Yellow plan review、進入 build，尚待實際 job／測試證據。#830/#831 已開票並準備獨立進件。 |
+| B2 | pending | PatchMUD producer 由專責 subagent 開票；Cortex contract 待派工。 |
+| B3 | pending | 觀測與預估先 shadow。 |
+| B4 | pending | 資格、預估與所有權契約先過，再有限啟用動態路由。 |
+| B5 | pending | #828 獨立處理；其餘狀態／部署待分拆。 |
+| B6 | pending | 所有驗收證據及逐票 closure 尚未取得。 |
+
+### Canary sizing 校正紀錄
+
+首輪 #822 的 domain_breadth 被主 agent 設為 1，將 emitter/frontmatter 的回歸測試消費端誤算為 production 模組。依 #208 原始 rubric（0=單模組／單資料流、1=2–3 模組），本工作 production 只改 `_yaml._parse_scalar`，正確為 0；state_consistency=0、其餘實際條件不變。更正不直接改凍結 run；使用正式 abandon/重新接受流程保留原 receipts，且 yellow plan review 仍須執行。spec_stability 與原 rubric 方向不一致由 #831 列管，不以刪欄位/捏造數值繞過 sizing gate。
+
+第二輪 plan-review completeness 因 task 首行缺 source/documentation 標記及 CLI 契約被拒。已補實際文件同步與 CLI help smoke 工作、以既有純函式確認 ready，再透過正式 abandon/重新接受處理；不把純規劃檢查當成產品測試通過。#830 修復必須區分 Job、非 Job 決策、deterministic transition 及無派工結果，保留 forced retry 的 fail-closed。
+
+## 8. 精確來源索引
+
+- Cortex 評測 CLI：[model_profile.py](https://github.com/hamanpaul/paulsha-cortex/blob/79ba644780bf1c697c722ac24a297e7d02416100/paulsha_cortex/porcelain/model_profile.py#L33)。
+- Cortex profile producer：[核心](https://github.com/hamanpaul/paulsha-cortex/blob/79ba644780bf1c697c722ac24a297e7d02416100/paulsha_cortex/coordinator/model_profile.py#L329)；aliases 在同檔 54；fingerprint 260；寫回 606。
+- 能力映射：[envelope_mapping.py](https://github.com/hamanpaul/paulsha-cortex/blob/79ba644780bf1c697c722ac24a297e7d02416100/paulsha_cortex/coordinator/envelope_mapping.py#L184)。
+- 評估清單／排序：[model_resolution.py](https://github.com/hamanpaul/paulsha-cortex/blob/79ba644780bf1c697c722ac24a297e7d02416100/paulsha_cortex/coordinator/model_resolution.py#L650)；分層 844；排序 882。
+- 實際 Manager 消費：[manager.py](https://github.com/hamanpaul/paulsha-cortex/blob/79ba644780bf1c697c722ac24a297e7d02416100/paulsha_cortex/coordinator/manager.py#L8199)。
+- track-record 缺口：[model_identities.py](https://github.com/hamanpaul/paulsha-cortex/blob/79ba644780bf1c697c722ac24a297e7d02416100/paulsha_cortex/coordinator/model_identities.py#L1655)。
+- production usage：[usage_extractors.py](https://github.com/hamanpaul/paulsha-cortex/blob/79ba644780bf1c697c722ac24a297e7d02416100/paulsha_cortex/coordinator/usage_extractors.py#L1)。
+- PatchMUD 固定 effort／adapter：[cli.py](https://github.com/hamanpaul/paulsha-patchmud/blob/1184c9e33d5511648b9adbab147780cbd3a0322f/patchmud/cli.py#L1436)；report per-run usage/cost 2278。
+- PatchMUD 現存報告：operator 本機 `runs/profile-claude-sonnet-20260812T140439Z/report/report.json`；對外只引用上述非機敏摘要，取得新報告後記 artifact digest。
+- PatchMUD 估計 fallback：[claude_cli.py](https://github.com/hamanpaul/paulsha-patchmud/blob/1184c9e33d5511648b9adbab147780cbd3a0322f/patchmud/adapters/claude_cli.py#L102)。

--- a/docs/superpowers/specs/2026-09-07-cortex-execution-domain.md
+++ b/docs/superpowers/specs/2026-09-07-cortex-execution-domain.md
@@ -1,0 +1,50 @@
+# Cortex 動態派工討論語彙
+
+本文件補充 Cortex 現有語彙，供 2026-09-07 精修實作與評測契約使用；既有 repo CONTEXT.md 定義持續適用。Work Item、WorkflowRun、Persona、Facet 與 Independence domain 沿用 repo 定義。
+
+## Language
+
+**Executor（執行器）**：承接任務並操作模型與工具的 agent runtime，例如一種 CLI agent；同一執行器可以提供多個模型。
+_Avoid_: 將 agent runtime、模型及 Persona 視為同一件事。
+
+**Model identity（模型身分）**：執行器提供的一個可辨識模型選項；它本身不代表已具備特定角色能力或有剩餘額度。
+_Avoid_: 註冊即合格、模型名稱即能力保證。
+
+**Execution profile（執行配置）**：一次評測或執行所實際採用的執行器版本、模型版本、effort、工具及隔離條件的組合。
+_Avoid_: 全系統固定模型組合、只以模型名稱代表實驗條件。
+
+**Effort setting（推理設定）**：某個模型與執行器原生支援的推理投入選項；不同產品的同名檔位不保證等價。
+_Avoid_: 跨模型通用的 high／max 數值尺度。
+
+**Task demand（任務需求）**：完成一個工作步驟所需的角色能力、品質、工具、獨立性、資源與時間條件。
+_Avoid_: 任務需求直接等同某個固定模型名稱。
+
+**Qualification evidence（資格證據）**：針對特定任務類別及執行配置，支持其通過品質或相容性門檻的可追溯證據。
+_Avoid_: 候選宣告、probe 成功、額度足夠。
+
+**Operational track record（實務紀錄）**：實際工作中觀測到的結果、用量與耗時紀錄；它的任務分布與量測條件有別於標準評測。
+_Avoid_: 將生產成功率直接改寫成 PatchMUD 排名。
+
+**Quota pool（額度池）**：由同一額度規則約束的一群使用者、工作或執行配置；可同時有短期、長期、模型專屬及帳號共用等多重限制。
+_Avoid_: executor×model 即完整的額度邊界。
+
+**Quota observation（額度觀測）**：某個來源在特定時間對額度池餘量、限制或重置時間的觀測，可能完整、部分或未知。
+_Avoid_: 剩餘 token 保證、沒有資料即額度為零或無限。
+
+**Usage forecast（用量預估）**：針對任務與執行配置的資源需求估計，包含不確定性與適用範圍。
+_Avoid_: 已發生的用量、帳單、provider 保證值。
+
+**Budget reservation（額度預留）**：在派出任務前，為其預期需求保留的可用額度份額，避免受管並行工作重複使用同一份餘量。
+_Avoid_: provider 已扣款、外部工作絕不會消耗此額度。
+
+**Selection preference（選擇偏好）**：在滿足硬性要求的候選中，調整優先順序的操作者意圖，例如偏好某個供應商。
+_Avoid_: 無法 fallback 的固定綁定。
+
+**Explicit pin（明確綁定）**：操作者要求本次工作使用特定執行配置的硬性限制；無法滿足時必須明示等待或阻塞。
+_Avoid_: 將一般偏好解讀成禁止 fallback，或把明確綁定靜默降級。
+
+**Selection decision（派工決策）**：針對一個步驟，根據當時需求、候選資格、額度及政策所作的可重讀選擇。
+_Avoid_: 永久 model chain、事後由 Persona 猜測執行者。
+
+**Fallback（候選切換）**：當原選擇無法滿足執行條件時，改用另一個仍符合任務及政策要求的配置。
+_Avoid_: 換模型名稱便算避開同一額度池、為了有模型可用而降低品質或隔離門檻。

--- a/docs/superpowers/specs/yaml-inline-list-quotes-design.md
+++ b/docs/superpowers/specs/yaml-inline-list-quotes-design.md
@@ -1,0 +1,14 @@
+---
+status: accepted
+work_item: yaml-inline-list-quotes
+---
+
+# YAML inline list 引號設計
+
+## Decisions
+
+1. 在現有 scalar parser 內新增小型 quote-aware flow-sequence 掃描；只有引號外的逗號是分隔符。追蹤單／雙引號與既有 quoted-scalar 支援的跳脫，保留元素原文交由既有 scalar decoder。
+2. 不引入完整 YAML 相依或重寫 block parser；此修正涵蓋 repo 自有 emitter 產出的 quoting 契約。未支援的巢狀 flow/mapping 不列為新增功能，不能藉此放寬 verifier。
+3. 畸形輸入在 tokenizer 層拒絕並維持可診斷的 list 錯誤，不容許空中間元素偷偷改 argv。空引號字串與空 list 為合法值，尾逗號是明確相容政策。
+4. RED 先驗含逗號元素在舊實作被 split 破壞，再以正負例、兩種 emitter、真 frontmatter consumer 驗 GREEN。完整測試保留所有既有消費端。
+5. 工作在 Cortex 管理的隔離 clone／branch 執行；不得改 operator 工作樹、模型設定或服務。依當時合格可用候選派工，本工作不永久指定 model／agent／effort。

--- a/docs/superpowers/specs/yaml-inline-list-quotes-spec.md
+++ b/docs/superpowers/specs/yaml-inline-list-quotes-spec.md
@@ -1,0 +1,19 @@
+---
+status: accepted
+work_item: yaml-inline-list-quotes
+---
+
+# YAML inline list 引號規格
+
+## Requirements
+
+- 修正 `_yaml._parse_scalar` 的 flow list 邊界辨識，讓字串中的逗號、右中括號與跳脫引號完整往返；保留既有純 scalar 轉型與空 list。
+- 接受尾逗號；中間空元素、未閉合引號等畸形 list 必須拋 `YAMLError`，訊息含 `malformed inline list`。
+- `deck.compile._format_inline_list` 與 `_format_scalar` 兩種 emitter 的 list 皆須讀回相同元素，不能只驗手寫字串。
+- 合法 spec frontmatter 經 `autonomy.parse_spec_frontmatter` 後，tests 與 full_suite argv 必須逐項相等；verification 不得因逗號被拆而誤判。
+- 範圍只改 flow sequence tokenizer 與相應測試／文件。保留 block parser、零依賴解析路径與 `verification.normalize_argv`；不擴充完整 YAML、inline mapping 或巢狀 flow list。
+- 獨立 review、聚焦與完整測試、policy 及正式 Cortex completion 證據均為交付條件。Issue #822 僅在實作交付時關閉，規劃完成不關票。
+
+## Acceptance
+
+依 canonical `docs/superpowers/workstreams/yaml-inline-list-quotes/todo.md` 的單元、兩 emitter round-trip 與 frontmatter consumer 場景逐一取證。測試資料與 repo root 使用 tmp_path；不操作共享 live registry。

--- a/docs/superpowers/workstreams/bucket-c-evidence-dedup/todo.md
+++ b/docs/superpowers/workstreams/bucket-c-evidence-dedup/todo.md
@@ -1,0 +1,28 @@
+# Bucket-C 進件校正交接索引
+
+本檔是歷史材料的導覽，不是 accepted plan／work item authority；沒有獨立
+work_item，不得註冊或派工第三個 bucket-C 工作。
+
+## 正式驗收來源
+
+- [#496 dirty recheck 冪等](../fix-dirty-recheck-idempotency/todo.md)：
+  canonical 內容 hash、同路徑改內容仍記錄、未變結果不追加、fail-closed 保留。
+- [#497 superseded terminal replay](../fix-superseded-terminal-replay/todo.md)：
+  明確解除 job 綁定、持久 supersession、合法 action fixture、重啟與多 terminal 防重播。
+- [#821 persistence hygiene](../registry-persist-hygiene/todo.md)：
+  digest no-op、history 有界與原子備份；它不取代 #496 的 append 冪等修復。
+
+## 已移植校正
+
+- #501 的 contract／evidence hash 分離已存在於本次基底，#496 讀
+  `current_verification_evidence_hash`，不重做或假設仍需污染 contract hash。
+- #496 比較內容而不是 evidence path；同 path 不等於同結果。
+- #497 不依賴 `update_slice(builder_job_id=None, candidate=None)` 解除綁定，
+  因該 API 把 None 視作未提供。recover fixture 必須是無合法 candidate SHA 的
+  needs_human slice，並明確提供 `PSC_REPO_ROOT`；有 SHA 的 dirty slice 走 retry-build。
+- 保留 #383 fanout 語意、不可變證據／quarantine 與歷史可稽核性，不以刪除 job
+  或放寬 evidence writer 避開衝突。
+
+原紀錄的92,403筆 history、每小時增加527–600筆及58.7MB jobs.json 是歷史觀察，
+不是此次 host 的最新測量。進件文件完成不代表上述修正、測試或 installed runtime
+已交付；各正式 work item 分別記錄完整 Cortex lifecycle 證據。

--- a/docs/superpowers/workstreams/daemon-tick-clock-not-idle/todo.md
+++ b/docs/superpowers/workstreams/daemon-tick-clock-not-idle/todo.md
@@ -1,0 +1,69 @@
+---
+status: accepted
+work_item: daemon-tick-clock-not-idle
+---
+
+# Daemon periodic tick 時鐘與 idle 設定
+
+## Boundary
+
+- Issue：`hamanpaul/paulsha-cortex#819`。
+- 修正 `manager_daemon.run_loop` periodic lane 在 `dispatch_skipped="not-idle"`
+  時未推進時鐘的問題，並提供 periodic runner 的 max load／require idle 設定。
+- 不改 dirty recheck／terminal replay（#496／#497）、registry persistence（#821）、
+  instance isolation（#818）、`lib/idle.py`、#249 backoff／circuit-breaker 公式、
+  manual tick request lane、`coordinator/cli.py` tick 預設、installer managed_env，
+  或 `status.json` schema。
+- 保留 `DEFAULT_MAX_LOAD = 1.0` 與 `build_periodic_tick_runner`／
+  `build_request_executor` 簽名預設；CPU-aware 預設只用於 daemon CLI 啟動的
+  periodic lane。manual lane 預設仍為 1.0，這是明確的相容性邊界。
+
+## Tasks
+
+- [ ] 在 periodic runner 回傳 not-idle 時推進 `last_tick_monotonic`，如同失敗分支
+      會推進時鐘；不更新 `last_tick_at`、`consecutive_tick_failures`、
+      `tick_circuit_open`、`last_tick_error`，且 `daemon.idle` 保持 False。
+- [ ] 在 `tests/test_manager_daemon_tick_backoff.py` 新增
+      `test_periodic_tick_not_idle_does_not_hot_loop`：使用既有 `_FakeClock`，
+      `poll_interval=1.0`、`tick_interval=10.0`、`max_rounds=85`，runner 恆回
+      not-idle，斷言呼叫時刻恰為 `[10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 70.0, 80.0]`；
+      同時斷言上述 daemon 欄位分別為 None／0／False／None／False。
+- [ ] 新增 `default_max_load()`：呼叫時以 `max(1.0, (os.cpu_count() or 1) * 0.5)`
+      計算預設；讀取 `PSC_MANAGER_MAX_LOAD` 時只接受 `math.isfinite(value)` 且
+      `value > 0` 的浮點數。unset／空字串／無法解析／NaN／正負 Inf／零／負數
+      均安全回預設，不得使非法值進入 idle probe。
+- [ ] daemon `main()` 新增 `--max-load`，CLI 與 env 共用「有限正數」驗證規則；
+      CLI 的顯式非法值回 argparse error，env 非法值則採上條安全預設。CLI
+      合法值優先於 env；文件須明示這項錯誤呈現差異，不得默默接受 NaN／Inf。
+- [ ] `run_loop` 新增 `default_max_load: float | None = None`；只有非 None 時
+      才加進 `periodic_kwargs`，且非 None 值也必須為有限正數；不要將新參數傳入
+      `build_request_executor`。參數與 helper 同名，函式內不得誤呼叫遮蔽後的參數。
+- [ ] 新增 `default_require_idle()`：`PSC_MANAGER_REQUIRE_IDLE` 經
+      `strip().lower()` 為 `0`／`false`／`off`／`no` 時 False，其他值、unset／空字串
+      都為 True；`main()` 採 `default_require_idle() and not args.no_require_idle`。
+      不改 `service-manager.sh` 啟動 argv。
+- [ ] 新增 `tests/test_manager_daemon_env_defaults.py`；固定 `cpu_count=20`，驗證
+      unset／空字串／abc／NaN／nan／Inf／-Inf／0／-1 回 10.0、4.5 回 4.5，
+      `cpu_count=None` 回 1.0。CLI 非法值均拒絕，CLI 7 覆寫 env 4.5，未帶旗標則
+      使用 env 4.5；以 stub `run_loop` 捕獲 `main()` 的實際傳參。
+- [ ] 同檔以 monkeypatch `build_periodic_tick_runner` 捕獲 `run_loop` 的 kwargs：
+      顯式 7.0 有傳入、未提供參數時 key 不存在，非法顯式值拒絕；設定
+      `PSC_CONTROL_ROOT=tmp_path`，不要傳入不存在的 `run_tick_fn` 給 `run_loop`。
+      另直測 `build_periodic_tick_runner(run_tick_fn=fake, default_max_load=7.0)`
+      會將 7.0 傳給 `run_tick`。
+- [ ] 驗證 require-idle helper 的大小寫／空白與 main 路徑：env 0→False、unset→True、
+      unset 或 env 1 加 `--no-require-idle`→False。保留既有 tick backoff、idle、
+      coordinator manager daemon 測試的原始斷言；只新增必要測試，不變更 manual lane。
+- [ ] README 的 daemon env 設定段記載新 env／CLI、實際優先序、非法值規則及行為變更；
+      periodic 預設由 1.0 改為 CPU-aware，可設 `PSC_MANAGER_MAX_LOAD=1.0` 保留舊門檻。
+      新增本 workstream 的 changelog fragment 並同步 `CHANGELOG.md [Unreleased]`。
+- [ ] 透過 Cortex 記錄修前 RED、修後 focused／完整 gates、review、merge 與實際
+      runtime 驗證；本 todo 的 accepted 不代表修正或測試已完成。
+
+## 已列管限制
+
+- `os.cpu_count()` 不保證反映 cgroup CPU 配額；本票不新增 cgroup 探測。容器環境須
+  顯式設定適當門檻，後續 capacity 工作再處理。不能以 bypass 模式的 idle=True
+  證明自然負載低於門檻。
+- manual request 預設、installer env 清單與 status schema 保持原狀，後續統一設定／
+  可觀測性工作需引用此邊界；不得把它們宣稱為本票交付。

--- a/docs/superpowers/workstreams/executor-durable-backoff/todo.md
+++ b/docs/superpowers/workstreams/executor-durable-backoff/todo.md
@@ -1,0 +1,69 @@
+---
+status: accepted
+work_item: executor-durable-backoff
+---
+
+# Executor durable backoff 最小安全層
+
+## Boundary
+
+- Issue：`hamanpaul/paulsha-cortex#825`。
+- 本票持久化 executor×model 已知 rate-limit／quota cooldown，供 slice／workflow
+  dispatch 共用，解析 reset hint 並留下 skip evidence；不新增 outcome taxonomy、
+  不改 GitHub provider backoff、不新增 operator override CLI。
+- 這是被動限流後的最小退避，不是完整 quota-aware routing：共享帳號／quota pool、
+  任務用量預估、reservation、動態 model／agent／effort 選擇由 refine plan 後續
+  工作實作。本票的 identity key 不能代表不同模型具有獨立帳號額度；#825 完成不等於
+  完整第5類問題完成，也不授權降低品質或突破 pin／independence-domain。
+
+## Tasks
+
+- [ ] 新增 `coordinator/executor_backoff.py`，狀態位於
+      `<coordinator_root>/executor-backoff.json`，schema `executor-backoff/v1`，
+      key 為 executor／model_id；提供 `active_backoff`、`record_backoff`、
+      `clear_backoff`，dispatch 前重讀持久狀態。以原子替換保存，故障不得遺失仍有效的
+      已知 cooldown；相同 terminal job 重複觀測須冪等，不可每 tick 增加次數或延後期限。
+- [ ] 缺檔表示無本機已知 backoff；損壞／不可讀／未知 schema 則回顯式
+      unknown/degraded 與診斷，**不可當空檔／所有模型可用**。保留可取得的 last-good
+      cooldown，但無法確定涵蓋範圍時暫停此 store 管轄範圍的新增派工；不改已執行 job。
+      後續讀到有效檔可恢復，不需要消耗 provider retry count。
+- [ ] deadline 優先採可信 `reset_at + RESET_MARGIN_SECONDS`，缺 hint 時沿用
+      `backoff.tick_backoff_seconds` 的有界指數退避，quota base 大於 rate-limited。
+      清除已過期條目不得縮短其他 identity 的期限；不同 identity 同時寫入的更新
+      不可互相覆蓋，測試 stale-reader／交錯 writer 或明確 single-writer enforcement。
+- [ ] 新增 `parse_reset_hint(text, *, now) -> int | None`，支援 Retry-After 秒數及
+      `try again at Sep 7th 12:23 PM`；對缺時區／年份文字記錄解析所採的 operator
+      timezone／基準年份，無法可靠判定或過去時刻則回 None，採本機保守退避。
+      structured `resetsAt` 保有優先序，文字 hint 不提高 authority；不改既有 outcome
+      vocabulary 與 `provider_outcome` 四個必要 keys＋可選 `reset_at` 的形狀。
+- [ ] 以 `record_executor_backoff_from_job` 接入 slice build failed 與 workflow
+      failed 終局路徑，限 `rate_limited`／`quota` 且 authority 非 hint 的證據。
+      無 executor／model_id 時不捏造 key，記錄缺少 identity 的診斷供後續觀測。
+- [ ] workflow `_runtime_preflight_gate` 與 `_provider_failure_reroute` 的 lookup
+      對 cooldown identity 回 `ProviderFreshness(status="degraded",
+      source="executor-backoff")`；所有候選 cooldown 時回 `reason="executor-backoff"`、
+      `retry_after_epoch`、`skipped`，不轉 needs_human、不耗 `provider-retry:<card>`。
+      store unknown 使用可區分的 reason 與診斷，不捏造 reset 時間。
+- [ ] 有合格可用候選時沿既有資格／permission／pin／independence-domain 規則選擇，
+      replacement job 保存 `dispatch_reroute` 的 source 與 skipped 證據；不得為繞過
+      cooldown 放寬原有 gate，也不能把相同共享帳號池的其他模型宣稱為額度獨立。
+- [ ] slice `autonomy.dispatch_ready` 在 `_record_pending_slice`／建立 worktree 前
+      查詢 backoff；identity 採 spec 的 executor／model_id，否則使用 launcher 的
+      公開 executor／model property（為 model 新增公開 property，不讀 private `_model`）。
+      命中時保留 dispatchable，不建立 job／worktree，不轉 failed／needs_human。
+- [ ] `dispatch`／`retry-build`／`fanout`／`tick` 回傳
+      `dispatch_skipped_by_backoff: [{slice_id, executor, model_id, retry_after_epoch}]`；
+      unknown store 另附診斷且不填假 deadline。`retry-build` 不拋
+      `retry-build-dispatch-failed`；dispatch request 必須先檢查空 dispatched list，
+      不再直接取 `dispatched[0]`。
+- [ ] 新增 `tests/test_executor_backoff.py`／`tests/test_reset_hint_parsing.py`：
+      record→active→expire、reset 優先序、quota base、指數上限、重啟讀取、同 job
+      重複觀測冪等、損壞／權限／schema unknown、原子寫入故障、交錯更新；reset hint
+      覆蓋明確 timezone、跨日／跨年、過去／不合法、Retry-After 0 與負值。
+- [ ] 新增 workflow／slice lane 回歸測試：fresh `JobRegistry` 且清
+      `_EXECUTOR_AUTH_CACHE` 後仍跳過、期限屆滿後可派、全候選 cooldown 不增加 retries、
+      corrupt store 重啟後不 launch、未知恢復後可派、無空列表 IndexError／無多餘 worktree。
+      保留既有 provider backoff／failure recovery／outcome 測試原始斷言。
+- [ ] 補本 workstream changelog fragment／`CHANGELOG.md [Unreleased]`，透過 Cortex
+      完成 RED／GREEN、獨立 review、完整 gates、merge 與 restart-safe runtime 驗證；
+      另以後續 quota work item 承接本票明確未交付的主動預估與共享池能力。

--- a/docs/superpowers/workstreams/fix-dirty-recheck-idempotency/todo.md
+++ b/docs/superpowers/workstreams/fix-dirty-recheck-idempotency/todo.md
@@ -3,100 +3,64 @@ status: accepted
 work_item: fix-dirty-recheck-idempotency
 ---
 
-# fix-dirty-recheck-idempotency Todo
+# Dirty recheck 結果未變時的寫入冪等
 
-`#496`：slice 因 `candidate-worktree-dirty` 掛上 `needs_human` 後，manager 每個
-tick 都會重跑同一份 verification，並**無條件**寫入一筆新的 `verification-failed`
-action ＋ 一筆 evidence_history——即使 worktree、candidate、結果、證據位址
-四者全部沒變。實測 5 秒 timer 下約 2 分鐘累積 **33 筆**重複紀錄，`jobs.json`
-在等待 operator 期間無界成長。
+## Boundary
 
-## 現況查核（0816，對 main `48b0205`）
-
-**缺陷仍完整成立。** 兩段程式碼構成迴圈：
-
-1. `manager.py:1815-1853` —— `complete_tick` 開頭掃 `list_slices()`，對
-   `state == "needs_human"` 且 current evidence summary 落在
-   `{"candidate-worktree-dirty", "candidate-worktree-dirty-after-verification"}`
-   的 slice **刻意**重跑 `verification_runner`。這個 recheck 行為本身是設計意圖
-   （讓 operator 清乾淨 worktree 後能自動脫困），**不是缺陷、不要移除**。
-2. `manager.py:1845-1851` —— 重跑結果經 `_validate_result_evidence()` 後，
-   **無條件**呼叫 `_apply_verification_result(registry, slice_item["slice_id"], validated_ev)`。
-   沒有任何「與現況比對」的閘門。
-3. `manager.py:386-409` —— `_apply_verification_result()` 一律
-   `registry.record_action(...)`（`:395`）＋ `registry.update_slice(...)`（`:404`），
-   本身不具冪等性，也不該由它自己承擔冪等責任（它是「套用一個真實轉換」的原語）。
-
-因此「沒變化」與「有變化」走完全相同的寫入路徑，每 tick 各記一筆。
-
-**放大效應**：`_apply_verification_result()` 同時會把證據 hash 寫進
-`slice_row["verification"]["hash"]`（見 `#501`），所以這個迴圈**每 tick 還會
-重覆污染 contract hash**。`#501` 0812-18:05 留言即由此現場觸發。本張不修那條，
-但實作者需知道兩者共用同一個原語。
-
-### 既有測試覆蓋
-
-`tests/test_pre_candidate_recovery.py:218`
-`test_candidate_worktree_dirty_reevaluation_on_tick` **只覆蓋「結果有變」**
-（dirty → verified，candidate 換新）並斷言轉換發生。**沒有任何測試斷言
-「結果沒變時不得寫入」**——這正是本張要補的缺口。修復不得讓這個既有測試轉紅。
-
-## Scope（明確邊界）
-
-**本 work item 的主體是「recheck 結果未變時的寫入冪等」，不是「recheck 該不該存在」，
-也不是「terminal job 重播治理」。**
-
-- 要做：在套用 recheck 結果**之前**，與當前狀態比對——至少涵蓋 verification
-  evidence hash、`state`、`gate_state`、summary、candidate、
-  `current_evidence_refs` 六者。完全相同就直接 return，**不 `record_action`、
-  不 append `evidence_history`、不 `update_slice`**。
-- 要做：worktree 真的變乾淨、verification 結果真的改變時，**恰好記錄一次**
-  真實轉換（不得因為新增比對而漏記，也不得記兩次）。
-- 要做：保持 fail-closed——證據不可讀、schema 不合法、內容不一致時，
-  維持現行的保守行為，**不得**因為「比對不出差異」就把壞證據當成「沒變化」放行。
-- 可做：若確有觀測需求，另立 `last_rechecked_at` 之類的欄位承載「我有在輪詢」
-  這個事實，**與 lifecycle history 分離**（`#496` 建議驗收最後一條）。
-  這是 optional，不做也可驗收。
-- **不要做**：移除或停用 `manager.py:1815-1853` 的 dirty recheck。它是 operator
-  清理後的自動脫困路徑，移掉會製造新的人工卡點。
-- **不要做**：把冪等閘門塞進 `_apply_verification_result()` 內部去「一次修好所有
-  呼叫點」。該函式另有五個呼叫點（`manager.py:1851`、`1960`、`2046`、`2057`，
-  以及 `1623`／`1638` 的 slice action 路徑），它們的語意是「一個真實轉換剛發生」，
-  在原語層加靜默 skip 會改變那些路徑的行為並可能遮蔽真實轉換。
-  **閘門應加在 recheck 呼叫點（本張現場）**；若實作者評估後仍主張下沉到原語層，
-  必須為上述每個呼叫點補測試證明語意不變。
-- **不要做**：修 `#501` 的 contract／evidence hash 欄位混用、或 `#497` 的
-  superseded terminal job 重播。本張驗收**不得依賴**那兩張是否已落地。
+- Issue：`hamanpaul/paulsha-cortex#496`；正式 work_id 保持不變。
+- `complete_tick` 對 needs_human 且 verification summary 為
+  `candidate-worktree-dirty`／`candidate-worktree-dirty-after-verification` 的 slice
+  刻意重驗，讓 operator 清乾淨 worktree 後能自動脫困；該 recheck 不得移除。
+- 本票只在 recheck 呼叫 `_apply_verification_result` 前判斷是否為真實轉換；
+  不改原語其他呼叫點的語意，不實作 #497 terminal supersession 或 #821 persistence。
+- #501 的 contract／evidence hash 分離已在本次基底：`registry.py` 的
+  `_read_current_verification_evidence_hash`／`_normalize_loaded_slice_verification`
+  與 manager 寫入 `current_verification_evidence_hash` 維持原意。本票不得讀寫
+  `slice_row["verification"]["hash"]` 作為當前 evidence hash，也不重做 #501。
+- 不改不可變 evidence writer／quarantine、fanout gate、tick clock、證據位址或
+  verification runner 的驗證能力。#496 與 #497 各自測試與交付，不建立第三個 bucket-C run。
 
 ## Tasks
 
-- [ ] **冪等閘門**：dirty recheck 套用前與當前 verification hash／`state`／
-      `gate_state`／summary／candidate／evidence refs 比對；一致即 no-op 返回
-- [ ] **真實轉換恰好一次**：worktree 轉乾淨後，脫離 dirty 狀態只產生**一筆**
-      action ＋ 一筆 evidence_history
-- [ ] **fail-closed 保留**：證據不可讀／schema 不合法／與 registry 現況不一致時，
-      不得被冪等閘門誤判為「沒變化」而靜默略過
-- [ ] **（optional）觀測分離**：如需呈現「仍在輪詢」，以獨立欄位承載，
-      不寫進 lifecycle action／evidence_history
-- [ ] **測試**：
-      - 對未變的 dirty worktree 連續呼叫 `complete_tick` N 次（N ≥ 5），
-        斷言 action 數與 evidence_history 數**完全不變**（`#496` 建議驗收第 5 條）
-      - tick 之間把 worktree 清乾淨，斷言**恰好一次**脫離 dirty 的轉換
-        （`#496` 建議驗收第 6 條）
-      - 既有 `test_candidate_worktree_dirty_reevaluation_on_tick` 維持綠燈
-      - 證據檔被破壞／不可讀時仍 fail-closed，不因冪等閘門而放行
+- [ ] 在 `complete_tick` dirty recheck 中，先以 `_validate_result_evidence` 驗證新
+      evidence，再在 `_apply_verification_result` 呼叫點建立 no-op 閘門；不把
+      所有呼叫者的去重責任下沉到 `_apply_verification_result`。
+- [ ] 比較 canonical 內容 hash 與 slice 的 `current_verification_evidence_hash`，
+      並比較預期 state／gate_state、summary、candidate 與 current evidence refs；
+      全部一致才略過。只有 ref path 相同不能判成未變；合法 hash 缺失或目前證據
+      不可解析不能當成相等。若內容相同但需修正 slice 狀態／引用，仍作一次真實轉換。
+- [ ] 相同結果不 `record_action`、不追加 evidence_history、不 `update_slice`；
+      驗證仍確實執行。若需要 last_rechecked_at 觀測，與 lifecycle history 分離，
+      屬 optional；不能藉此恢復每 tick 的歷史 append。
+- [ ] hash／status／gate_state／candidate／summary／refs 任一真實變更，沿原路徑
+      記錄恰好一筆 action 及 evidence_history，更新 current evidence hash；下一次
+      相同結果即 no-op。不改 contract verification hash。
+- [ ] `_validate_result_evidence` 對不可讀／schema 不合法／payload mismatch 失敗時
+      維持既有保守錯誤處理，不放行為成功、不視為證據未變；不得以 catch-all equality
+      或空值相等遮蔽壞證據。
+- [ ] 新增 `tests/test_dirty_recheck_idempotency_496.py` 或等價 focused 檔案，沿
+      `tests/test_pre_candidate_recovery.py::test_candidate_worktree_dirty_reevaluation_on_tick`
+      fixture：fake verification runner 回當前相同候選／內容，連續10次
+      `complete_tick`，斷言 runner 仍被呼叫、action/history 數從既有基準完全不變、
+      current evidence hash 不變；修前應 RED，不用降低 history limit 偽造不增長。
+- [ ] 同一 fixture 在第K次改回傳證據 details，維持同 path 但 canonical hash 改變；
+      斷言只增加一筆 action/history 且 hash 更新，後續 ticks 不再增加。此為受控
+      測試 evidence fixture，不授權生產 writer 覆寫既有不可變證據。
+- [ ] 另測 dirty→verified、candidate 改變、gate_state 或 refs 不一致修復，每次真實
+      轉換恰好一次；原 `test_candidate_worktree_dirty_reevaluation_on_tick` 保持綠燈。
+      不要求此測試依賴 #497 或 #821 已實作。
+- [ ] 壞檔／不可讀／payload mismatch 均保持 fail-closed；contract hash 不受 recheck
+      改動。沿既有 #501 normalization 測試確認舊資料讀取相容，不重寫 migration。
+- [ ] 新增本正式 work_id 對應的 changelog fragment，同步
+      `CHANGELOG.md [Unreleased]`；記錄 RED／GREEN、必要完整 gates、獨立 review、
+      正確 HEAD merge 與 runtime 重複 tick 的 evidence/history delta。進件 accepted
+      不代表任何測試或部署已完成。
 
-## 現場紀錄（供實作者參考）
+## 歷史證據與關聯
 
-- issue `#496` 首則：slice `task-3-private-repo-and-forbidden-documentation-scan-build`、
-  candidate `0c9faff9…`，5 秒 timer 下
-  `2026-08-12T14:12:06.381861Z` → `14:14:02.820132Z` 約 **116 秒累積 33 筆**
-  `verification-failed` action ＋ 33 筆 evidence_history，worktree／candidate／
-  結果／證據位址全程未變
-- issue 首則的 root cause 段已精準點出
-  「`_apply_verification_result` always record_action and update_slice.
-  There is no comparison against the current verification hash, status, summary,
-  candidate, or refs」——0816 複查確認這段描述與 main 現況逐字相符
-- 本張與 `#501`／`#497` 同屬「桶C slice 迴圈家族」。三者的關係：
-  `#497` 是重播**來源**、`#496` 是 recheck **迴圈**、`#501` 是兩者共用的
-  **污染原語**。三張各自獨立可驗收，不得合併修
+- issue #496 的歷史現場為約116秒增加33筆 verification-failed action/history；
+  該量測不等於這次 host 的最新值。成因是 `_apply_verification_result` 呼叫
+  `record_action` 無條件追加，不是 `update_slice` 自己追加 history。
+- #497 消除不該進入 completion 的舊 attempt；本票消除合法 dirty recheck 中未變
+  結果的重複寫入；#501 已分離 contract/evidence hash；#821 管控檔案與 history 大小。
+  各項完成狀態必須獨立驗證。

--- a/docs/superpowers/workstreams/fix-superseded-terminal-replay/todo.md
+++ b/docs/superpowers/workstreams/fix-superseded-terminal-replay/todo.md
@@ -3,132 +3,78 @@ status: accepted
 work_item: fix-superseded-terminal-replay
 ---
 
-# fix-superseded-terminal-replay Todo
+# Superseded terminal job 的持久身分與防重播
 
-`#497`：**已被取代（superseded／unbound）的 terminal job 會被 `complete_tick`
-反覆重新終局化**，並在「slice_id + candidate SHA」這個決定性證據位址上撞上
-不可變證據寫入器，fail-closed 阻斷本輪 fanout。實測後果包含：復原後不派新
-builder、`completed/passed` 的 slice 被回寫成 `needs_human`、下游 slice 被
-`deps-unsatisfied` 反向鎖死。
+## Boundary
 
-## 現況查核（0816，對 main `48b0205`）
-
-**缺陷仍成立。`#383` 只修了 fanout 側，completion 側完全沒有 supersession 概念。**
-
-已落地的部分（不要重做）：
-
-- `manager.py:2194-2215` `_manifest_still_blocks_fanout()`：fanout 放行改與
-  registry 現況對帳，復原成 `pending` 的 slice 不再被殘留 manifest 永久跳過。
-- `manager.py:164-199` `_supersede_handoff_manifest()`：復原動作後替 manifest 補
-  `superseded_at`／`superseded_by`／`superseded_reason` 稽核欄位。
-
-**沒修到的部分（本 work item 的主體）**：
-
-1. `manager.py:1855` —— `complete_tick` 直接 `for snapshot in registry.list_jobs():`
-   **全量列舉**所有 job，對每個 terminal job 嘗試終局化。沒有任何
-   supersession／attempt 過濾。
-2. `manager.py:1879` —— 唯一的冪等短路是
-   `if _existing_manifest_job_id(manifest_path) == job_id: continue`。
-   這是**每 slice 單槽**的記憶：manifest 只記得住**一個** job_id。同一 slice
-   歷史上若有 `-6`／`-8`／`-9` 三個 terminal job，manifest 指向 `-9` 時，
-   `-6`／`-8` 完全不受保護，每輪都重跑。
-3. `manager.py:154-161` —— `_existing_manifest_job_id()` 另外在
-   `gate_status in {"passed","verified"}`、以及
-   `needs_human + verification_evidence_path is None + gate_reason ∈
-   {pinned-input-mismatch, verification-runner-error, verification-state-update-error}`
-   時**主動回 None**（＝放行重播）。證據寫入撞衝突時 `evidence` 留 None，正好落進
-   第二個條件，形成穩定的每 tick 重播迴圈。
-4. `manager.py:226-236` `_slice_for_job()` 在 `builder_job_id != job_id` 時回 None，
-   但**回 None 不等於跳過**：build lane 會掉進 `manager.py:1997-2010` 的
-   `missing-slice-proof` 分支，該分支**照樣寫證據**——且 candidate 由
-   `_candidate_for_evidence()`（`manager.py:285-309`）以 **branch 當前 HEAD**
-   解析。這就是 `#497` 0812-18:05 現場的機制：舊的 unbound job `-8` 先被終局化，
-   用 branch HEAD 解出 `6421bc98…`，把 `missing-slice-proof` 寫進本該屬於
-   bound job `-9` 的證據位址；`-9` 隨後撞
-   `conflicting verification evidence … (content mismatch)`。
-5. `registry.create_job()`（`registry.py:873-900`）的 job schema **沒有任何**
-   consumed／superseded／attempt 欄位，因此 supersession 目前根本無處持久化。
-6. `manager.py:1477-1560` `recover-pre-candidate`：把 slice 撥回 `pending`、
-   `builder_job_id=None`、`candidate=None`，並標記 manifest——但**舊 job row
-   本身完全沒動**，仍是 `list_jobs()` 的合法 terminal 成員。
-7. `verification.py:377-397` `_existing_evidence_result_or_raise()`：同位址內容不同時
-   把原檔 `os.replace` 進 `quarantine/` 後 `raise RuntimeError`。**這一段是對的
-   （不可變證據 fail-closed），不要為了消 symptom 去放寬它。**
-
-## Scope（明確邊界）
-
-**本 work item 的主體是「completion 側的 attempt 身分與 supersession 過濾」，
-不是「證據不可變規則放寬」，也不是「證據位址重設計以外的其他一切」。**
-
-- 要做：terminal job 在被終局化**之前**先判定它是否仍是該 slice 當前 attempt 的
-  綁定 job；不是就跳過——且**必須在「解析 candidate／推導證據位址」之前**跳過，
-  否則就像現況一樣，已經寫壞了才發現。
-- 要做：supersession 需**持久化在 registry**（job row 或 attempt 層），
-  不能只靠 handoff manifest 的單槽 job_id 或檔案系統狀態——`#497` 的
-  0812-19:10 現場證明 daemon 重啟後重播照樣發生。
-- 要做：舊 job 保持**可稽核**（不刪 row、不刪既有證據），只是不再有資格成為
-  當前 attempt 的終局。
-- 可做（若判定必要）：在證據位址中納入 job／attempt 身分，讓「同 slice 同 SHA
-  的多次合法終局觀測」各有位址——這是 `#497` 建議驗收的第 4 條。若採此路，
-  **既有證據路徑必須保持可讀**（completion record 會引用舊位址，
-  見 `manager.py:843` `verification_evidence_path`）。
-- **不要做**：放寬 `write_verification_evidence()` 的不可變性、或把 quarantine
-  改成靜默覆寫。fail-closed 抓到的是真問題，本修復要消除的是「不該發生的
-  第二次寫入」，不是「抓到衝突時的反應」。
-- **不要做**：修 `#501` 的 contract／evidence hash 欄位混用，或 `#496` 的
-  dirty recheck 冪等。本張假設 `#501` 可能尚未落地，因此**驗收不得依賴
-  contract hash 正確性**；若 `#501` 已先行 merge，測試可一併收緊。
-- **不要做**：改動 `_manifest_still_blocks_fanout()`／`dispatch_gate_scan()`
-  的 fanout 語意（`#383` 已定案且有測試）。本張只碰 completion 側。
-- **不要做**：新增自動 retry／自動修復。`needs_human` 在 operator 動作前必須
-  **靜止**（quiescent），這正是驗收條件之一。
+- Issue：`hamanpaul/paulsha-cortex#497`；正式 work_id 保持不變。
+- 本票修 completion 側 attempt 身分／supersession／consume 判定，讓已取代的
+  terminal job 不再推導 candidate 或寫 missing-slice-proof，保護目前與已完成 slice。
+- #383 的 `_manifest_still_blocks_fanout`／`dispatch_gate_scan` 與 manifest
+  superseded 註記已存在，不重做 fanout 語意；manifest 單槽 job_id 不是完整冪等權威。
+- 不放寬 evidence writer 不可變性／quarantine、不刪 job 或舊 evidence、不實作
+  #496 dirty recheck 去重／#821 persistence、不新增自動 retry 或自動 recovery。
+- #501 的 contract/evidence hash 分離已存在；本票維持正確 current evidence hash，
+  不以修改 contract hash 或重寫 evidence 位址掩蓋 attempt 混淆。
 
 ## Tasks
 
-- [ ] **attempt 身分持久化**：registry 提供「此 terminal job 已被消費／已被取代」
-      的持久標記（CAS 更新，restart-safe），並在
-      `recover-pre-candidate`／`abandon`／新 attempt 派工時原子地設定
-- [ ] **completion 前置過濾**：`complete_tick`（`manager.py:1855` 起）在**推導
-      candidate 與證據位址之前**先跳過非當前 attempt 的 terminal job；
-      `_slice_for_job()` 回 None 的 build-lane 情境不得再無條件寫
-      `missing-slice-proof` 證據（`manager.py:1997-2010`）
-- [ ] **單槽記憶除役**：不再以 handoff manifest 的單一 `job_id`
-      （`manager.py:1879`／`_existing_manifest_job_id`）作為多 terminal job 的
-      冪等權威；改以持久 attempt 標記為準
-- [ ] **completion 證明穩定性**：已 `completed/passed` 且持有合法 completion record
-      的 slice，其被引用的 verification evidence 位址在 daemon 重啟後不得被任何
-      重播改寫（`#497` 0812-19:10 現場）
-- [ ] **測試**：
-      - terminal dirty builder → `recover-pre-candidate` → tick：舊 job 被跳過、
-        無證據衝突、**恰好**派出一個新 builder
-      - 上述情境的 **daemon restart 變體**：跳過語意跨重啟存活
-      - 同 slice 多 terminal job（`-6`／`-8`／`-9`）：只有當前綁定的 job 被終局化，
-        unbound job 不寫任何證據、不解析 branch HEAD 當 candidate
-      - `completed/passed` slice 在 manager 重啟後連續多 tick：completion record
-        與其引用證據 byte 不變、下游 slice 不被 `deps-unsatisfied` 反向鎖
-      - `needs_human` 靜止性：連續 tick 不新增 action／evidence_history
-        （與 `#496` 的驗收互補，但本張測的是「重播來源」而非「recheck 迴圈」）
-      - 舊證據與舊 job row 仍可稽核讀取（不因修復而遺失歷史）
+- [ ] 以 additive registry job／attempt 欄位持久記錄 superseded／已消費狀態，
+      提供 CAS／冪等更新。沿用可稽核的 superseded_at／superseded_by／superseded_reason
+      或等價具體結構，缺新欄位的舊 state 正常載入；不新增 jobs.json 根欄位。
+- [ ] 為 recover-pre-candidate 增加明確的 registry 原子動作：在驗證原 builder／
+      reviewer 綁定仍相同後，同一次 durable 更新將舊 job 標 superseded、slice 轉
+      pending、gate_state 轉 pending，並清掉 builder_job_id／reviewer_job_id／candidate。
+      不再依賴 `update_slice(...=None)`：現行該 API 把 None 當未提供，不會清欄位。
+- [ ] 原子動作內的 validation／state／history 與 supersession 一起成功或回復；
+      fault injection／CAS conflict 不得留下「slice pending 但仍綁舊 job」或「新
+      attempt 綁定被舊 recover 清掉」的半套 durable 狀態。重複同一 recovery request
+      不重複標記或寫 action；在 action gate 前處理有身分可驗的既有成功結果，
+      不藉此放寬其他 pending slice 的 allowed actions。
+- [ ] 核對 abandon／retry-build→repin／新 attempt 綁定的取代路徑：當前綁定真的
+      被取代時持久標記舊 job；正常 terminal 被成功收割後保存 consumed 身分，
+      不依賴單一 manifest job_id 推測跨重啟已消費。新增標記不可讓尚未完整持久化的
+      completion proof 被略過，需與相應交易邊界一致。
+- [ ] `complete_tick` 對 terminal job 在解析 repo root／branch HEAD／candidate／
+      evidence path 之前先 skip：已標 superseded／已完整消費者，或其 slice 存在
+      但當前 builder/reviewer 綁定已非該 job。不能只檢查 `_slice_for_job` 回 None
+      就掉進 missing-slice-proof；真正 slice 不存在的 job 保持現行 fail-closed 行為。
+- [ ] skip 舊 job 不寫 evidence、不改 handoff、不解析 branch HEAD、不追加 slice
+      action/history；舊 job／舊 evidence 仍能讀取。保留真正當前 attempt 正常
+      completion/review 與缺 proof 診斷，並以 source invariant 測試涵蓋所有 terminal 入口。
+- [ ] recovery fixture 沿
+      `tests/test_pre_candidate_recovery.py::test_recover_pre_candidate_supersedes_stale_handoff_manifest`：
+      明設 `PSC_REPO_ROOT`、failed terminal builder、needs_human slice 且
+      `candidate=None`，寫合法舊 manifest；先斷言 allowed actions 包含 recover，
+      再執行 action 並斷言成功、bindings/candidate 真為 None、舊 job 已 superseded。
+      不得使用帶合法 candidate SHA 的 dirty slice 呼叫 recover，那會被 action gate 擋下。
+- [ ] recovery 後執行 `complete_tick`，completed／errors 都不含舊 job，沒有對舊
+      candidate 寫 evidence、沒有 quarantine，slice 維持 pending，history 不增。
+      另在完整 `run_tick`／fanout fixture 中驗其他 gates 均合法時恰好派一個新 builder；
+      `complete_tick` 本身不承諾派工。設定 repo root 避免測試提前 error 卻假綠。
+- [ ] manifest 回 None 的變體必測：gate_status=needs_human、
+      verification_evidence_path=None、gate_reason=verification-runner-error；
+      修前會重跑舊 job，修後仍跳過。再以 fresh JobRegistry 模擬 daemon restart，
+      驗證 supersession／consumed 與 skip 持續有效。
+- [ ] 同一 slice 的多個 terminal jobs（例如 -6／-8／-9，manifest 指向 -9）只讓
+      真正目前綁定且尚未合法完成者終局化；unbound 舊 job 不推導 candidate。
+      帶合法 SHA 的 dirty slice 走 `retry-build`→repin 的合法路徑，覆蓋舊 builder
+      與 reviewer 被取代的情境；不可偷換成不可達的 recover fixture。
+- [ ] completed/passed slice 在 restart 後連續10個 ticks，completion record 與
+      被引用 evidence bytes 不變，不倒退 needs_human、不反鎖下游 deps；needs_human
+      但不符合 dirty recheck 的 superseded 情境保持靜止，驗的是舊 replay 來源，
+      不將 #496 尚未實作的合法 dirty recheck append 當本票責任。
+- [ ] 新增 `tests/test_superseded_terminal_replay_497.py` 或等價 focused 檔；涵蓋
+      stale CAS、原子寫入故障、重複 recovery request、新舊 row 相容、真正 missing slice
+      fail-closed、current attempt 正常完成與歷史可讀。不可放寬 immutable writer。
+- [ ] 補本正式 work_id changelog fragment 與 `CHANGELOG.md [Unreleased]`，透過
+      Cortex 記錄 RED／GREEN、必要完整 gates、獨立 review、merge、runtime restart
+      與 completion proof 穩定性的證據。accepted todo 不等於修正／測試／部署完成。
 
-## 現場紀錄（供實作者參考）
+## 歷史證據與關聯
 
-- issue `#497` 首則：Task 3 `recover-pre-candidate` 後首個 tick 未派工，
-  改為重跑舊 terminal builder 並撞 `conflicting verification evidence … (content mismatch)`
-- 0812-14:57 留言：recovery 回 `slice_state: pending` 後 8 秒，terminal reviewer
-  `-2` 被重跑，slice 退回 `needs_human / missing-slice-proof`
-- 0812-16:11 留言：重複 recovery 每次都被同一個 terminal job 打回，
-  「pending 無法存活」——明確要求 consumed／superseded marker CAS
-- 0812-17:25 留言：foreign-review launch 失敗後，約 90 秒累積 **24 筆**
-  evidence_history（本張是重播來源，`#496`／`#501` 是放大器）
-- 0812-18:05 留言：unbound job `-8` 先於 bound job `-9` 被終局化，
-  造成同 candidate `6421bc98…` 證據位址衝突與兩份 quarantine 檔——
-  這則最精確地指出「必須在解析 candidate 之前跳過」
-- 0812-19:10 留言：**daemon 正常重啟**即可讓已 `completed/passed` 的 Task 4
-  被重播回寫成 305-byte 的 `missing-slice-proof`，handoff 被改寫為
-  `completion-record-missing`，Task 5 被 `deps-unsatisfied` 反鎖——
-  證明缺陷不限於 recovery 競態
-- 0812-19:40／21:09 留言：狀態快照內部不一致（`completed/passed` 併
-  `reason=completion-record-missing`）；以及 manager interval 被夾到 3600 秒
-  當 workaround 後，`stat`／`status` 無法收割已存在的 exit sentinel。
-  **後者（sentinel 收割／targeted `complete <job-id>`）屬觀測面 follow-up，
-  不在本張 scope 內**——本張只負責讓重播不再發生
+- 舊紀錄中的 recover 後 pending 無法存活、unbound -8 汙染 bound -9 證據位址、
+  manager 重啟後 completed slice 被回寫，是此票的回歸來源，不是此次 live 結果。
+- `verification.write_verification_evidence` 發現內容衝突時 quarantine 並 fail-closed
+  是必要保護；本票消除不合法第二次寫入，不將既有證據改成可覆寫。
+- sentinel 收割／targeted complete 是觀測面後續工作，不在本票擴張操作權限。

--- a/docs/superpowers/workstreams/launcher-session-and-timeout/todo.md
+++ b/docs/superpowers/workstreams/launcher-session-and-timeout/todo.md
@@ -1,0 +1,68 @@
+---
+status: accepted
+work_item: launcher-session-and-timeout
+---
+
+# Headless launcher session 與 AGY timeout
+
+## Boundary
+
+- Issues：`hamanpaul/paulsha-cortex#823`／`hamanpaul/paulsha-cortex#824`。
+- 相關但不在本票關閉：#813／#568／#826。開發基底必須包含已合併 #820 的
+  AGY JSON terminal／argv 修正；不得覆蓋或重新引入舊 probe 形態。
+- 範圍限 `coordinator/launcher.py` 的兩個 headless Popen spawn 點及 AGY
+  `--print-timeout` 解析／傳遞，加相應測試與文件。
+- `start_new_session=True` 隔離 session／process group，**不隔離 systemd cgroup**；
+  若 Manager unit 的 KillMode 涵蓋整個 control-group，重啟仍可能終止 direct job。
+  本票不承諾 daemon restart survival，該要求交完整 refine plan 的 runner／instance
+  ownership 工作與對應服務整合測試；不可用 pgid 測試代替 cgroup 證據。
+- 不改 dispatcher spawn（該處沒有 Popen）、effort、gate timeout 預設、Manager
+  kill/cancel 操作面、LaunchHandle pgid 欄位；不為其他 executor 加 AGY 專用旗標。
+  不操作共享 runtime-main、服務或正在執行的其他 repo job。
+
+## Tasks
+
+- [ ] 在 `SubprocessLauncher.launch` 共用 `popen_kwargs` 加
+      `start_new_session=True`；正常及只針對 stdin TypeError 的重試路徑都保留。
+      direct／systemd-run／systemd-template 三個 runner 包裝層，以及現有五個
+      executor，必須使用同一設定；不放寬現有 TypeError 判斷以吞掉其他參數錯誤。
+- [ ] 新增 fake Popen 測試：codex direct `bash -lc`、claude stdin=PIPE、
+      stdin 第一次 TypeError 後的第二次 spawn，均捕獲 start_new_session=True。
+      systemd-run／template 模式沿既有 `_RecordingPopen` fixture 驗最外層 spawn，
+      不宣稱此斷言代表內層 job 的 cgroup／PGID 身分。
+- [ ] 新增 `tests/test_coordinator_launcher_session.py`，只使用測試 subprocess，
+      不呼叫模型 CLI：以同 kwargs 形狀啟動 `bash -c 'sleep 30'`，斷言
+      `os.getpgid(proc.pid)==proc.pid` 且不同於測試 process group；向子 process group
+      發 SIGTERM，5秒內 reap，測試進程仍存活。以 try/finally 清理本測試建立的子程序，
+      不碰 Manager／真實 job。此案例只證明 process-group 隔離。
+- [ ] 實作前取得目前 AGY CLI version／help 的離線證據，執行
+      `agy --print-timeout 2400s --help` 或等價不啟動 prompt 的參數 parser smoke，
+      確認 Go duration `2400s` 被接受且 exit code 成功。若目前 CLI 不支援，停止
+      該旗標變更並將版本／錯誤交主流程裁決；不可透過付費模型 prompt 猜測旗標。
+- [ ] 新增 `resolve_agy_print_timeout(env: Mapping[str, str]) -> str`：顯式
+      `PSC_AGY_PRINT_TIMEOUT` 為正整數秒，優先且不 clamp；未設時採
+      `max(DEFAULT_GATE_TIMEOUT_SECONDS, PSC_GATE_TIMEOUT 或預設) + 600`，
+      格式如 `2400s`。顯式空字串／非整數／0／負數拒絕；未設 override 時，非法
+      PSC_GATE_TIMEOUT 同樣拒絕，不能默默壓低 gate 時間。
+- [ ] `build_agy_argv` 新增 `print_timeout: str | None = None`；None 時自行依 env
+      resolve，其他顯式值也驗證符合已證實的正 duration 契約。所有 planner／reviewer／
+      builder／unsafe／write-forbidden／commit-required argv 形態都帶此旗標；
+      `SubprocessLauncher` 對 agy 顯式傳入 resolve 結果，避免不同入口語意分歧。
+- [ ] `tests/test_coordinator_agy_launcher.py` 的7個直接 argv shape 測試加入
+      timeout 斷言，並守住 #820 的 JSON flag。兩個 env 都 unset→2400s；
+      gate=900→2400s、gate=3600→4200s、override=900→900s；非法 override／gate
+      與顯式 duration 負例均拒絕；合法 override 優先、不受未採用的 gate env 干擾。
+- [ ] launch 傳遞測試沿 `test_agy_commit_required_launcher_emits_real_scoped_git_dirs`
+      的 recording fake Popen，direct script argv 含 `--print-timeout 2400s`。
+      不誤用只 stub `_ARGV_BUILDERS`、未記錄 Popen argv 的測試當 end-to-end 證據。
+- [ ] 搜尋並更新固定 keyword-only fake Popen 以接受 start_new_session 或 **kwargs：
+      基底約為 `tests/test_coordinator_launcher.py` 19處及
+      `tests/test_headless_claude_hook_506.py` 3處，數量以實際 base 重新確認；保留
+      原始安全斷言。已接受 **kwargs 的 `_RecordingPopen` 不無謂改寫。
+- [ ] codex／copilot／claude／cg argv 均不得包含 `--print-timeout`；既有 launcher、
+      headless hook、trust-root runner/template、reviewer downgrade、accounting 與
+      #820 planning/AGY 回歸測試維持綠燈。
+- [ ] 文件與 changelog 同時交代 process-group／cgroup 邊界、timeout 優先序及實際
+      CLI 版本；新增 fragment 並同步 `CHANGELOG.md [Unreleased]`。透過 Cortex
+      記錄 RED／GREEN、離線 CLI 合約、完整 gates、review、merge 與 installed 驗證；
+      尚未執行的 smoke 不得填成通過。

--- a/docs/superpowers/workstreams/monitor-refresh-thread-backlog/todo.md
+++ b/docs/superpowers/workstreams/monitor-refresh-thread-backlog/todo.md
@@ -1,0 +1,68 @@
+---
+status: accepted
+work_item: monitor-refresh-thread-backlog
+---
+
+# Monitor refresh 有界排程、公平性與停止契約
+
+## Boundary
+
+- Issue：`hamanpaul/paulsha-cortex#827`。
+- 修正 watcher／service 每事件 Timer、flush 進入同步 refresh 後的堆積，並提供
+  refresh 排隊／執行／timeout／skip／stop 的診斷。允許調整 `monitor/work_api.py`
+  refresh 排程／鎖邊界以滿足公平與停止契約；保留 snapshot 驗證、last-good 與
+  fail-closed authority，不重寫 provider 業務語意。
+- 不改 GitHub 節流／quota policy，不新增記憶體上限，不以重啟止血代替根因修正；
+  不操作其他 instance 或同 Manager 的其他 repo 工作。
+- 現況入口：`watcher._DebouncedHandler._schedule/_flush`、
+  `ProjectMonitorService._schedule_project_refresh/_flush_project_refresh` 與
+  `WorkModelRefresher.refresh`。後者目前持有全域鎖執行 provider scan，僅替換 Timer
+  而不驗公平性不足以宣稱消除飢餓。
+
+## Tasks
+
+- [ ] 用固定、可查詢的 refresh worker 上限 W 取代每事件建立 Timer/thread；
+      W 在測試中明確設定，執行中同一 project／refresh source 最多一份 pending dirty
+      標記，無界 executor queue 不算有界實作。workspace 未映射事件的全量 scan
+      也必須進入同一有界排程，不能另有同步事件旁路持續堆 thread。
+- [ ] debounce 改為 coalesce 並保留最大等待期限 D，連續新事件不得無限向後推遲；
+      active refresh 期間的新事件於其後補跑一次，重建最後狀態。不丟棄不同 project／
+      source 的待更新標記；來源去重不以來源內最新一條事件代替所有 project 真相。
+- [ ] 在 `tests/test_monitor_refresh_backlog.py` 寫可決定 RED：fake clock、
+      `threading.Event` 屏障阻塞 project A 的首個 refresh；首個已開始後、放行前
+      注入100個 A 事件。斷言 active≤W、A pending≤1；放行且不再注入事件後，
+      A 的首輪＋補跑最多2次、最後 snapshot 含最後一次狀態。測實際使用的
+      `refresh_project` 或 batch API，不只 spy 原路徑未呼叫的 `refresh_projects`。
+- [ ] 另測不同 debounce 窗的合法更新可以分批執行；不得把任意時序100事件均≤2次
+      寫成全稱契約。固定 seeds 的長事件串以虛擬60秒執行，查 component-owned
+      worker／pending 數有界，避免用受其他測試影響的全域 active_count 作唯一斷言。
+- [ ] 定義公平順序：local event／periodic poll／rescan／GitHub pending 均不能被
+      同來源後來的事件無限插隊；每個已就緒來源最遲於當前有界工作結束加一輪
+      既有就緒來源的服務時間內開始。測試持續 local event 下 GitHub 能開始、A
+      熱點下 B 能開始，時限由 fake provider latency／D／W 推導，不依真實網路速度。
+- [ ] slow provider 測試用可控制、遵守 timeout/cancel 的 fake：GitHub 卡住時
+      local 更新仍於文件列出的 deadline 內執行或明確標示等待／timeout，不能回報
+      虛假 freshness；適用時縮小全域鎖，只在 publication 持有。保留 generation／
+      source revision 檢查，避免慢舊結果覆蓋較新的 snapshot。
+- [ ] 對每個來源記錄 pending_since／started_at／last_success／failure reason 等
+      可觀測資料；stale 僅表示時間狀態，另提供 queue-wait／provider-timeout／
+      scheduler-skipped／refresh-failed 的具體原因。某來源成功不得抹掉其他來源
+      尚未解除的錯誤；時間與既有 snapshot schema 的相容方式需附測試。
+- [ ] stop 先拒收新事件並標記 generation 失效，取消 pending，再停止 watcher／
+      scheduler。callback／provider 在 stop 前已開始的結果，stop 後不得發布事件
+      或寫 durable snapshot；把檢查放在實際 commit/publish 邊界，不只 callback 入口。
+- [ ] 測試 stop 期間仍有事件、callback 已開始、provider 正阻塞、unwatch/stop 重複
+      呼叫等競態；合作式工作在明定 shutdown deadline S 內 join，之後無新 worker、
+      pending 或 publication。各屏障以 bounded wait 收尾並於 finally 釋放，不留測試 thread。
+- [ ] 不可取消的外部呼叫不宣稱已終止：保留最多 W 個既有 worker 的有界殘餘與
+      stuck/timeout 診斷，不再替它建立新 thread；stop/generation fence 禁止遲到
+      結果寫入／發布。若 provider 沒有可證實的有限 timeout，交回主流程處理 adapter
+      邊界，不能用丟棄引用或更多 executor 規避驗收。
+- [ ] 保留 `tests/test_stage9_project_monitor_service.py` 的 burst、rename、
+      watch/unwatch、project recreate、Git control paths、rescan 與 last-good 回歸；
+      補短 bounded real-thread smoke 驗證 owned threads 停止後回到基準，不呼叫
+      GitHub API 或模型 CLI 作為單元測試。
+- [ ] 補 changelog fragment／`CHANGELOG.md [Unreleased]` 與操作說明；透過 Cortex
+      記錄 RED／GREEN、完整 gates、review、merge。部署驗收先保存現場，再在實際
+      event 負載下量測 thread／queue／freshness 的有界性；任何服務重啟由主流程
+      按當時 in-flight ownership 另外執行，不由本票測試擅自重啟共享 Manager。

--- a/docs/superpowers/workstreams/outcome-taxonomy-signals/todo.md
+++ b/docs/superpowers/workstreams/outcome-taxonomy-signals/todo.md
@@ -1,0 +1,67 @@
+---
+status: accepted
+work_item: outcome-taxonomy-signals
+---
+
+# Outcome taxonomy 與 launch failure 訊號保真
+
+## Boundary
+
+- Issue：`hamanpaul/paulsha-cortex#826`。
+- 範圍包含共享 `outcome_taxonomy.py`／`provider_outcome.py`、三條 launch failure
+  寫入路徑（dispatcher／autonomy／workflow manager），及 slice gate_reason／workflow
+  needs_human 消費端。新增分類必須完整穿過 persisted job 與 runtime diagnostic。
+- 不新增 identity reasoning_effort 設定、不移除 launcher effort 預設、不實作
+  durable backoff（#825）；不以模型散文／nested tool results 當成 provider authority。
+
+## Tasks
+
+- [ ] 新增 `TextSignal.EFFORT_NOT_SUPPORTED`／`EXECUTABLE_NOT_FOUND` 與
+      `StructuredKind.EXECUTABLE_NOT_FOUND`／`LAUNCH_FAILED`，映射至
+      `OutcomeFamily.ENVIRONMENT`；effort regex 擷取 effort、model，能辨識
+      `Reasoning effort "xhigh" is not supported for model "mai-code-1-flash-picker"`。
+- [ ] executable 訊號必須有啟動程式識別／shell command-not-found 上下文，或來自
+      可證實啟動失敗的 exit 127／typed exception。裸 `not found`／HTTP 404／
+      model not found／一般工作檔案 `No such file or directory` 不得直接分類為
+      executable_not_found 或觸發 reroute；provider text 與 model text 保持分層。
+- [ ] 保留 structured terminal／controller interruption 優先序，再處理可信 exit 127，
+      然後 text 的 rate limit→quota→auth→effort→executable→content→transient。
+      `classify_text(exit_code=127)` 的單元契約與 provider 分類的 structured authority
+      各自測試，不能讓一般 exit 127 覆蓋已存在的強 authority 終局證據。
+- [ ] 新增 `ProviderOutcome.EFFORT_NOT_SUPPORTED`／`EXECUTABLE_NOT_FOUND`／
+      `LAUNCH_FAILED` 與對照；加入非持久的 `reroutable` property，僅前兩者且
+      authority 非 hint 時 True。`to_dict()` 保持 outcome／authority／reason／retryable
+      加可選 reset_at；`launch_failed` 本身不自動 retry／reroute。
+- [ ] `JobRegistry.update_headless_result` 加 optional executor／model_id（僅非 None
+      才覆寫），不另造 registry enum validation：現行只驗 payload shape。
+      以三種 outcome 寫入→reload→`classification_from_job` round-trip 驗證相容。
+- [ ] `Dispatcher.poll_headless_done` 遇 pid／log_path 缺失時記 structured
+      launch_failed，reason 精確寫 `launch handle missing: pid=None, log_path=None`。
+      這可能是 Manager 在 create_job 與 attach_handle 間中斷；不可偽稱 launcher
+      已拋例外。更新既有 missing-launch-handle 測試，保留真實缺失欄位。
+- [ ] `autonomy._fail_launching_job` 接收 executor／model_id／exc，保存身分、
+      provider_outcome 與 `runtime_diagnostic`（reason=`launch-failed`、exception
+      type／detail、source=`autonomy.dispatch_ready:launch`、job_id）；workflow
+      `_dispatch_workflow_card` 的 launch exception 同樣保存 diagnostic，source
+      明確為該函式。可驗證的缺 executable exception 才使用相應細分類；無法確定的
+      `FileNotFoundError`（例如 cwd 缺失）保留 launch_failed 原因，不猜測 executor 壞掉。
+- [ ] `_poll_workflow_job` 依 runtime diagnostic 的 reason 分流：真正
+      runtime-contract failure／sandbox drift 繼續禁止 provider reroute；
+      launch-failed 診斷不因「任何 dict 都算 contract failure」而清掉原 classification。
+      保留原始 exception／缺 handle reason，不用 generic runtime-contract-failed 覆蓋。
+- [ ] reroute 條件採 `retryable or reroutable`，仍受 MAX_PROVIDER_RETRIES、品質資格、
+      明確 pin、工具權限及 independence-domain 限制；不可換同一失敗配置無限重跑。
+      needs_human diagnostic 保留 executor／model／可擷取的 effort；缺欄位明示未知。
+- [ ] 單元測試涵蓋 effort 正例、明確 command-not-found／127 空輸出、一般檔案／
+      model／HTTP404 負例、model-text-only 負例、structured 429／interruption 優先；
+      保留 `test_no_signal_classifies_as_unknown_hint_and_not_retryable`。
+- [ ] fake launcher 觸發真 exception→寫 registry→reload→workflow poll，驗證
+      launch_failed／來源原因仍在、真正 runtime-contract 不 reroute；另一個合格且
+      獨立候選存在時，effort_not_supported 可有界 reroute。不能只 seed 已分類 row
+      就宣稱 producer→consumer 接線已驗證。
+- [ ] 新增 `tests/test_outcome_taxonomy_signals_826.py`，以 copilot effort 日誌、
+      exit-127 空日誌與缺 handle 三種 row 經 `poll_headless_done`，斷言 outcome
+      authority 非 hint，slice gate_reason 分別包含 builder-failed 與具體分類。
+      覆蓋三條寫入路徑與 workflow 消費端，保留既有 retry／contract fail-closed gates。
+- [ ] 更新 outcome 詞彙文件、changelog fragment 與 `CHANGELOG.md [Unreleased]`；
+      透過 Cortex 記錄 RED／GREEN、完整 gates、獨立 review、merge 與 runtime 診斷證據。

--- a/docs/superpowers/workstreams/registry-persist-hygiene/todo.md
+++ b/docs/superpowers/workstreams/registry-persist-hygiene/todo.md
@@ -1,0 +1,73 @@
+---
+status: accepted
+work_item: registry-persist-hygiene
+---
+
+# Registry persistence 與 history 有界化
+
+## Boundary
+
+- Issue：`hamanpaul/paulsha-cortex#821`；相關 #496／#781／#818。
+- 範圍限 `coordinator/registry.py` 的無變更寫入短路、slice history 輪替、rollback
+  備份與 stale temp 清理。不改 `COORDINATOR_STATE_SCHEMA_VERSION`、
+  `_reload_if_changed` 偵測、dirty recheck 決策、tick 時鐘或跨 process 鎖。
+- 新欄位只加在 slice row，不新增 jobs.json 根欄位；monitor 對根 keys 有白名單。
+- digest no-op 只減少真正無變更的 `update_status` 同狀態自轉／`update_job` 同
+  worktree 等寫入；`record_action` 的新 timestamp 是真實內容變更，#496 才負責
+  消除 dirty recheck 的重複 append。`update_slice` 本身不追加 history。
+- 字串 schema `"1.0"` migration 與 instance decommission 屬完整 refine plan 的
+  相容性／ownership 工作；不誤引 #815 作為本票實作依據。
+- 輪替後的首筆／近期 history 與截斷計數不等於完整封存。current evidence refs、
+  completion record 引用的必要證據必須保持可追且不可被清理；完整長期 archive／
+  retention 由 umbrella successor 列管，本票不宣稱提供全歷史重播。需完整歷史的
+  既有部署在 archive 能力完成前，先由主流程保存原 registry 備份再啟用截斷。
+
+## Tasks
+
+- [ ] `_persist` 產生穩定 JSON（`ensure_ascii=False, indent=2, sort_keys=True`），
+      以實際 UTF-8 bytes 的 SHA-256 比對 `_last_persisted_digest`；相同且 state
+      檔仍存在時不呼叫原子 writer、mkstemp 或 replace。state 檔遭刪除仍須重建。
+- [ ] `_write_payload_atomically(payload)` 保留 dict 位置參數呼叫契約。若新增
+      optional `serialized=` 以避免重複序列化，需同步讓既有 fault-injection
+      wrappers 接收／轉送該 keyword，不改其故障條件與 rollback 斷言：
+      `tests/test_workflow_production_wiring.py::fail_plan_transition` 與
+      `tests/test_planning_publication_transaction_536.py::crash_on_plan_transition`。
+      v1 migration 原本只傳 dict 的路徑仍有效；不得用吞 TypeError 掩蓋相容性錯誤。
+- [ ] digest 只在成功寫入後更新；`_load` 必須在 normalization 可能觸發 `_persist`
+      之前以磁碟原始 bytes 建立 digest。rollback 重新 `_load()` 時恢復原 digest，
+      不得讓失敗候選的 digest 遮蔽下一次正確寫入。
+- [ ] 新增 `DEFAULT_SLICE_HISTORY_LIMIT=500`，可由
+      `PSC_COORDINATOR_SLICE_HISTORY_LIMIT` 或 `JobRegistry(history_limit=...)`
+      覆寫，僅接受正整數。三種列表 `evidence_history`／`evaluation_history`／
+      `actions` 共用輪替 helper：limit≥2 保留首筆及最新 limit−1 筆；limit=1
+      保留最新一筆，避免第一筆永久遮蔽當前事件；每個丟棄項累計至
+      `slice_row["history_truncated"][key]`，不重設已有計數。
+- [ ] `_validate_loaded_slice` 以複本正規化超限 history，不就地修改原始 payload，
+      使既有 `slices != payload["slices"]` 偵測可落盤一次；第二次載入不再改寫。
+      缺少 `history_truncated` 的舊檔正常讀取；`_copy_slice` 為該巢狀 dict 建立
+      獨立複本。非法 limit／counter 類型或負值需有明確拒絕測試。
+- [ ] rollback snapshot 優先以 `os.link(state_path, backup)` 建立，同 filesystem
+      成功時不重複複製整檔；EPERM／EXDEV／不支援 hardlink 等 OSError 時退回既有
+      bytes 複製與 fsync 流程。這不同於 `_write_v1_backup` 的「先複製到 tmp 再
+      link 命名」，不得混淆成本；保留替換後 fsync 失敗時的 rollback 語意。
+- [ ] construction 時只清理 state 目錄內已確認不屬於活躍 writer 的 stale temp：
+      `tmp*.tmp`／`tmp*.backup.tmp`／`tmp*.rollback.bak`，grace 不低於 30 秒，
+      不遞迴、不跟隨 symlink、不刪 subdirectory／jobs.json／v1 backup／人工備份。
+      若無法證明 writer 已結束或此目錄具有獨占使用權，略過清理並留下診斷；
+      檔案 mtime 超過 grace 本身不代表無活躍 writer。不要於 reload／persist 清理。
+- [ ] 新增 `tests/test_coordinator_registry_persist_hygiene.py`：一次 mutation 後
+      連續三次 `_persist()`、同狀態 `update_status` 均 mkstemp=0、mtime_ns／inode
+      不變；刪除 state 後可重建；writer error／rollback／normalization 的 digest
+      正確；保留既有 #501 normalization 與 released claim-key load 測試。
+- [ ] history fixture 必須使用真正追加的 `record_action`：limit=5，12 次帶
+      `evidence_refs` 的 action 後 evidence_history／actions 為 5、保留首筆與第12筆、
+      dropped=7；另用 `evaluation_refs` 驗 evaluation_history。覆蓋 limit=1、
+      limit=2、超限載入、二次載入 no-op、既有 counter 延續、對 copy 改值不污染 live row。
+      不得用 `update_slice(current_evidence_refs=...)` 期待 history 追加。
+- [ ] 測 hardlink 成功、EPERM／EXDEV fallback、replace 前後故障；stale sweep
+      保留活躍／未知 ownership／新檔／symlink／子目錄／人工備份，僅刪已證明失活
+      且逾 grace 的匹配項。不存在目錄正常建置；無權讀 state 仍維持既有錯誤語意，
+      不因 sweep 的容錯而偽裝 registry 已成功載入。
+- [ ] 補本 workstream changelog fragment 與 `CHANGELOG.md [Unreleased]`；透過
+      Cortex 記錄 RED／GREEN、fault/rollback regression、必要完整 gates 與 runtime
+      寫入次數證據。不得把單純 digest 改善宣稱為 #496 的 E1 頻率已修。

--- a/docs/superpowers/workstreams/yaml-inline-list-quotes/todo.md
+++ b/docs/superpowers/workstreams/yaml-inline-list-quotes/todo.md
@@ -1,0 +1,59 @@
+---
+status: accepted
+work_item: yaml-inline-list-quotes
+domain_breadth: 0
+state_consistency: 0
+invariant_count: 5
+artifact_classes: [source, tests, documentation]
+---
+
+# YAML inline list 引號修正 Todo
+
+Sizing 依 #208：production 只改 `_yaml._parse_scalar`，為單模組／單資料流；
+emitter/frontmatter 是回歸測試消費端，不另算 production 模組。原 domain=1
+估計已由正式 abandon/reclaim 更正為0；state=0 與其餘機械分、Yellow 審查不變。
+
+## Boundary（範圍）
+
+- Issue: `hamanpaul/paulsha-cortex#822`.
+- 範圍僅限 `paulsha_cortex/_yaml.py::_parse_scalar` 的 inline（flow）list
+  分支：讓含 `,` 或 `]` 的引號元素能經 `safe_load` 正確讀回；不重寫 block
+  parser、不把 PyYAML 引入 runtime、不加 inline mapping／巢狀 inline list
+  支援、不改 `verification.normalize_argv` 的驗證語意。
+
+## Tasks
+
+- [ ] source（原始碼）：把 `paulsha_cortex/_yaml.py:23` 的 `inner.split(",")` 換成一個小型
+      quote-aware flow-sequence tokenizer（單／雙引號、雙引號內反斜線跳脫、
+      引號內的 `,` 與 `]` 視為字面值）；尾逗號容忍，中間空元素或未閉合引號
+      raise `YAMLError` 且訊息含 `malformed inline list`；未引號元素沿用既有
+      `_parse_scalar` 語意。
+- [ ] 新增 `tests/test_yaml_inline_list.py`，覆蓋 issue #822 驗收條件 1–4：
+      引號內逗號、引號內 `]`、跳脫引號、尾逗號、中間空元素、空引號字串、
+      空 list、未閉合引號、未引號 scalar 轉型（`[1, true, null, ~, x]`）。
+- [ ] 新增 round-trip 測試（同檔或 `tests/test_deck_compile.py`）：把含
+      `,`、`]`、`'`、`"` 的 values 分別經
+      `paulsha_cortex.deck.compile._format_inline_list(values)`（`tests[].argv`
+      路徑，`compile.py:432`）與 `_format_scalar(values)`（`full_suite.argv`
+      路徑，`compile.py:441`）再餵回 `safe_load`，斷言與原 list 相等。
+- [ ] 在 `tests/test_yaml_inline_list.py` 加端到端回歸：於 `tmp_path` 先
+      `git init`（或 `monkeypatch.setenv("PSC_REPO_ROOT", str(tmp_path))`，
+      否則 `autonomy._infer_repo_root` 回 `repo-root-unresolved`），寫一份
+      `dispatch: auto` spec，形狀比照 `tests/test_coordinator_verification.py:44-63`
+      （`plan:`、`target_branch`、`verification.docs_class: code`、`checks`
+      含 `kind: persona-scope` 與 `kind: command`＋`name: policy`；policy
+      check／`tests[]`／`full_suite` 都帶 `argv`、`cwd: .`、`timeout_seconds`，
+      `full_suite` 另帶 `baseline: no-regression`），`tests[0].argv` 含
+      `"a or b, c"`、`full_suite.argv` 含 `"src,lib"`，斷言
+      `autonomy.parse_spec_frontmatter` 回傳 `parse_error is None`、
+      `dispatch == "auto"`，且正規化後的兩組 argv 與來源逐項相等。
+- [ ] 執行 `python3 -m pytest tests/test_yaml_subset.py
+      tests/test_zero_dependency_runtime.py tests/test_deck_compile.py
+      tests/test_persona_config_loader.py tests/test_model_profile_cli.py
+      tests/test_deck_task_types.py tests/test_yaml_inline_list.py -q`，
+      確保所有既有 `_yaml` consumer 維持綠燈。
+- [ ] documentation（文件）：新增 `changelog.d/yaml-inline-list-quotes.md`，同步補
+      `CHANGELOG.md [Unreleased]` 與 README 的支援 YAML 子集／argv 引號限制。
+- [ ] CLI 契約：執行 `python3 -m paulsha_cortex.cli --help` 與 `python3 -m paulsha_cortex.cli deck --help`，
+      核對既有指令解析無回歸；本票不新增旗標。
+- [ ] 執行聚焦／完整關卡，經 Cortex 保存 candidate 與驗收證據。

--- a/openspec/changes/cortex-refine-complete/.openspec.yaml
+++ b/openspec/changes/cortex-refine-complete/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-07

--- a/openspec/changes/cortex-refine-complete/README.md
+++ b/openspec/changes/cortex-refine-complete/README.md
@@ -1,0 +1,3 @@
+# cortex-refine-complete
+
+Cortex 十四類精修交付契約：動態執行配置、評測接線、額度預估與可靠生命週期

--- a/openspec/changes/cortex-refine-complete/design.md
+++ b/openspec/changes/cortex-refine-complete/design.md
@@ -1,0 +1,36 @@
+## Context
+
+本次沿用既有 Cortex 工作生命週期、角色能力與核可分層。P1 intake 尚未實作，已有 W0 合併基底；本變更將十四類修正轉成可派工的有界批次。完整範圍與驗收見 `docs/superpowers/plans/2026-09-07-cortex-refine-complete.md`；語彙見同層 specs 的 `2026-09-07-cortex-execution-domain.md`。
+
+## Goals / Non-Goals
+
+Goals：全部 R01–R14 有明確 owner/scope/依賴與可機械驗收；可靠執行、可擴充 profile、quota-aware admission 及可追溯交付。
+
+Non-Goals：固定供應商組合、繞過 Trust Root、偽造核可清單、手改 runtime registry、跨 repo 直接共享 import、以一次 benchmark 保證全部工作。PatchMUD 本輪僅開 producer issue；外部未交付的驗收不得被 fixture 通過取代。
+
+## Decisions
+
+1. **單一工作權威與分批交付**：保留既有 work_id；child Todo/規劃產物經現行 Cortex authority gate 進入 workflow。umbrella 只列管覆蓋，不再派一條重複實作線。相較整批重新註冊，這保留已完成審查與 evidence lineage。
+2. **Profile 契約**：任務需求獨立於 executor/model/native effort/tools/isolation 的 execution profile。adapter 以資料宣告原生能力；新增協定需要 adapter/conformance，核心不加產品名稱分支。requested/resolved/observed 分開，未知不冒充實際採用。
+3. **評測與即時資源分責**：PatchMUD CLI/檔案提供 profile-aware qualification/效率證據；Cortex 發布核可 candidate/receipt/roster 並收集實務 telemetry。保留角色、coverage、ranked validity、review approval、independence 約束。能力 fingerprint 不含純 pricing snapshot；成本報告另記 provenance。
+4. **多池 admission**：候選先過品質/權限/獨立性/pin，再估計任務需求及所有 pool/window 約束；唯一 budget authority 原子預留完整需求才 spawn。provider 未提供餘量與外部消耗不可觀測時明示不確定性，不能用本地 token 數冒充 subscription 餘額。
+5. **安全 fallback**：可在每 card/retry/review 的安全邊界重選；跨 attempt 留 supersession 與 artifact receipt。只因 lease 過期不釋放仍存活 job 的預留。全部候選不足即等待，不能降低 reviewer independence 或覆寫 explicit pin。
+6. **漸進啟用**：先 deterministic fake adapter/quota/clock 與 crash/concurrency tests；telemetry/forecast 先 shadow；驗證預估誤差與 coverage 後有限 opt-in。既有 pin/legacy policy 具可回復路徑，回復不刪除已產生的 audit/reservations。
+7. **不以文件代替完成**：RED/GREEN、獨立 review、policy、remote CI、精確 merge HEAD、installed/canary 各自記錄。正式進件 PR 僅引用工單，不因文件合併自動關閉實作 issue。
+
+## Risks / Trade-offs
+
+- provider 沒有可讀餘量介面 → unknown/partial 與 operator 風險政策、headroom、觀测更新對帳；不保證永不撞限流。
+- 多 host 同帳號未共用 authority → 顯示 coverage gap；僅對已納管範圍保證不重複預留。
+- 既有 effort/adapter 證據不足 → legacy/unknown；不得讓舊 high 成績充當新 max 的資格。
+- 自我修復期間核心共享檔衝突 → B1 先單案 canary、隔離分支、依序整合；保留其他 workflow。
+- PatchMUD 外部依賴尚未完成 → consumer 可先驗版本化 fixtures；live report→approval→dispatch 列為未完成 gate。
+- cgroup/環境相依的資源預設 → #819 最小修復只改 periodic clock/明確配置；後續 cgroup 與 installer 對齊另有驗收，不能把 os.cpu_count 預設當容器配額。
+
+## Migration Plan
+
+B0 進件收斂 → B1 執行基礎 → B2 profile/ownership → B3 shadow telemetry/forecast → B4 opt-in admission/recovery → B5 狀態/installed runtime → B6 全部證據及 backlog closure。每批保留舊資料可讀；資料 schema 或 policy 行為改變須顯式版本化、rollback 測試與 operator receipt。
+
+## Open Questions
+
+供應商可讀 quota 的實際介面與覆蓋率、不同任務的 forecast 風險門檻與樣本量由 B3 baseline 決定；這些未知在未取證前不得宣稱解決。其餘實作選擇由各 child spec 在已核可的有界契約內裁決，不改變使用者的動態選模意圖。

--- a/openspec/changes/cortex-refine-complete/proposal.md
+++ b/openspec/changes/cortex-refine-complete/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+Cortex 精修原 P1 只涵蓋執行基礎的部分缺陷，未閉合全部十四類問題，且固定模型映射、評測配置與派工配置漂移、被動限流處理使接手工作反覆中斷。使用者已要求完整交代十四類修正並透過 Cortex workflow 持續交付；需要一份可追溯的跨批次驗收契約。
+
+## What Changes
+
+- 建立 R01–R14 覆蓋與 B0–B6 依賴／完成證據 ledger，保留既有 work_id 與已完成的修正，不重複啟動 umbrella workflow。
+- 補齊 Monitor／tick／registry／evidence／launcher 的有界性、冪等與恢復驗收。
+- 引入可擴充 execution profile、相符資格、版本化選模決策；任務 Persona 不永久綁定 executor/model/effort。
+- 引入多池多時間窗 quota observation、來源明示的用量 forecast、原子 reservation 與安全 fallback；未知狀態維持可解釋的保守處置。
+- 沿用 PatchMUD 評測 producer 與 Cortex 消費端，外部 producer 工作由 PatchMUD issue #37 列管；本變更不授權修改 PatchMUD code。
+- 補齊狀態、installed runtime、instance 所有權與逐 issue delivery closure 的證據鏈。
+
+## Capabilities
+
+### New Capabilities
+
+- `refine-delivery-acceptance`: 十四類精修的分批進件、執行、驗收與交付會計。
+- `execution-profile-qualification`: 可擴充 executor/model/effort 配置與 profile-aware 評測核可消費契約。
+- `quota-aware-admission`: 多額度池觀測、用量預估、並行預留、動態候選與安全限流恢復。
+
+### Modified Capabilities
+
+本 umbrella 新增交付契約；既有 lifecycle、Trust Root、status 與 release 的既定要求持續生效。child change 若需調整既有要求，須獨立 delta 與 migration 審查，不以本文件隱性放寬。
+
+## Impact
+
+- Cortex：coordinator、monitor、porcelain model/work/run/install/inspect、release/runtime、工作項目與測試。
+- 外部檔案／CLI 契約：PatchMUD [#37](https://github.com/hamanpaul/paulsha-patchmud/issues/37)；維持零 runtime import 依賴。
+- 保留 #828 producer 及並行下游工作的 ownership。自我部署須確認 active jobs 與版本，不能把 source merge 視為服務已更新。
+- 正式計畫：`docs/superpowers/plans/2026-09-07-cortex-refine-complete.md`。新機制先 shadow，再有限 opt-in；不靜默修改既有明確 pin。

--- a/openspec/changes/cortex-refine-complete/specs/execution-profile-qualification/spec.md
+++ b/openspec/changes/cortex-refine-complete/specs/execution-profile-qualification/spec.md
@@ -1,0 +1,37 @@
+## ADDED Requirements
+
+### Requirement: Extensible execution profiles
+
+Cortex SHALL separate task role/demand from executor, model and adapter-native effort; supported profiles SHALL be resolved through versioned capability descriptors rather than a central product-name table.
+
+#### Scenario: Add a new model and effort
+- **WHEN** an existing adapter receives a new model and previously unseen supported effort through its descriptor
+- **THEN** it participates in validation and selection without a product-specific central resolver change, while unsupported combinations fail before spawn
+
+#### Scenario: Add a new runtime
+- **WHEN** a new executor adapter passes capability and Trust Root conformance
+- **THEN** workflow, quota and report consumers use the shared contract without adding that runtime's product-name branch
+
+### Requirement: Profile-aware qualification and provenance
+
+Cortex SHALL validate imported PatchMUD evidence against the requested role, measured dimensions, compatible execution profile and producer schema; it SHALL preserve explicit review approval and report requested/resolved/observed values separately.
+
+#### Scenario: Effort mismatch
+- **WHEN** stored evidence measures high but the candidate requires max
+- **THEN** Cortex does not claim that evidence measures the requested profile and records legacy/unknown or requires matching qualification
+
+#### Scenario: Pricing-only revision
+- **WHEN** only a pricing snapshot changes
+- **THEN** cost-report provenance changes without invalidating the capability fingerprint solely due to that price revision
+
+#### Scenario: Unmeasured role
+- **WHEN** a report contains only builder coverage
+- **THEN** planner/reviewer and unmeasured dimensions remain unknown and report success does not itself grant runtime authorization
+
+### Requirement: Evidence plane isolation
+
+Cortex SHALL consume versioned CLI/file reports without importing PatchMUD runtime; qualification, operational telemetry and live quota SHALL remain distinct evidence classes.
+
+#### Scenario: Producer unavailable
+- **WHEN** PatchMUD is absent or its required producer schema is not yet delivered
+- **THEN** current runtime reports the qualification limitation without running benchmark work in the dispatch hot path or inventing an approved roster

--- a/openspec/changes/cortex-refine-complete/specs/quota-aware-admission/spec.md
+++ b/openspec/changes/cortex-refine-complete/specs/quota-aware-admission/spec.md
@@ -1,0 +1,45 @@
+## ADDED Requirements
+
+### Requirement: Sourced multi-pool observations and forecasts
+
+Cortex SHALL retain pool/account scope, units, windows, observation time, reset, TTL and observed/estimated/unknown provenance. Forecasts SHALL include uncertainty, context, task/profile applicability and failed-attempt consumption without treating model tokens as subscription quota.
+
+#### Scenario: Missing balance
+- **WHEN** a provider exposes no authoritative remaining quota
+- **THEN** admission reports unknown or partial coverage and follows explicit bounded-risk policy rather than claiming confirmed sufficient balance
+
+#### Scenario: Multiple windows
+- **WHEN** short-term allowance is sufficient but a shared weekly pool is exhausted
+- **THEN** the candidate is not admitted and renaming the model within that same pool does not bypass the restriction
+
+### Requirement: Atomic reservation and reconciliation
+
+Cortex SHALL reserve all required managed pools atomically before spawn and reconcile actual consumption, uncertain liveness and provider observations durably across restart.
+
+#### Scenario: Competing instances
+- **WHEN** two managed instances contend for one remaining task-sized allowance
+- **THEN** only one obtains the reservation and the other re-evaluates without spawning against stale balance
+
+#### Scenario: Restart with uncertain job
+- **WHEN** the budget authority restarts and cannot confirm whether a reserved job remains alive
+- **THEN** it preserves uncertain consumption/reservation and does not release allowance solely because a TTL elapsed
+
+#### Scenario: Corrupt cooldown state
+- **WHEN** persisted backoff or quota state is corrupt
+- **THEN** the system reports degraded/unknown or uses validated last-good state, never treating corruption as confirmed full allowance
+
+### Requirement: Qualified dynamic fallback
+
+Cortex SHALL select among compatible qualified profiles using current task demand, available resources and versioned preferences, preserving explicit pin, credentials, tools and reviewer independence. Rerouting SHALL occur at safe attempt boundaries with supersession evidence.
+
+#### Scenario: Independent usable pool
+- **WHEN** profile A is qualified but lacks quota and qualified profile B has sufficient independent allowance
+- **THEN** Cortex reserves and dispatches B without first launching a predictably failing A job
+
+#### Scenario: No compliant fallback
+- **WHEN** only candidates violating an explicit pin or reviewer independence have quota
+- **THEN** Cortex waits with a specific reason instead of silently relaxing the constraint
+
+#### Scenario: Forecast misses external consumption
+- **WHEN** unobserved external activity causes in-flight quota failure
+- **THEN** Cortex preserves verified artifacts, records the affected pool and safely supersedes the attempt before rerouting, retaining the forecast error as calibration evidence

--- a/openspec/changes/cortex-refine-complete/specs/refine-delivery-acceptance/spec.md
+++ b/openspec/changes/cortex-refine-complete/specs/refine-delivery-acceptance/spec.md
@@ -1,0 +1,113 @@
+## ADDED Requirements
+
+### Requirement: R01 Monitor bounded refresh
+
+系統 SHALL 合併相同 project 的 pending 事件、固定 worker 數、公平處理 local/remote 刷新，並保留 last-good 與具體 timeout/stale 診斷。
+
+#### Scenario: R01 acceptance boundary
+- **WHEN** 首個 refresh 受控阻塞時注入一百個同 project 事件，再放行
+- **THEN** 不新增無界 worker，僅一份合併補跑；持續事件不使其他 provider 無限飢餓；stop 後不再發布。
+
+### Requirement: R02 Periodic tick eligibility
+
+系統 SHALL 對 skipped/success/failure 各自推進明確 eligibility，保留 skip 與 failure 的差別並曝光有效配置。
+
+#### Scenario: R02 acceptance boundary
+- **WHEN** fake clock 下持續 not-idle
+- **THEN** periodic 呼叫遵守 interval、failure counter 不增加；非有限或非法配置可診斷。
+
+### Requirement: R03 Evidence and terminal idempotency
+
+系統 SHALL 對相同內容/狀態維持冪等並阻止非現行 attempt 重播影響 completion。
+
+#### Scenario: R03 acceptance boundary
+- **WHEN** 相同 evidence path 的內容改變，之後 terminal 舊 attempt 延遲到達
+- **THEN** 真變更恰好記一次，舊 attempt 不改現行 candidate/證據；跨 restart 語意保持。
+
+### Requirement: R04 Registry persistence hygiene
+
+系統 SHALL 使無變更寫入 no-op、history 有界且必要稽核可追、暫存清理限於受控所有權與安全時點。
+
+#### Scenario: R04 acceptance boundary
+- **WHEN** 多次 no-op、history 超限或持久化失敗
+- **THEN** 無變更不寫；輪替及 rollback/normalization 可驗證；不刪 active writer 暫存或 unrelated archive。
+
+### Requirement: R05 Resource-aware dispatch acceptance
+
+系統 SHALL 以 quota-aware-admission 契約驗收多池觀測、需求預估、原子預留與安全切換。
+
+#### Scenario: R05 acceptance boundary
+- **WHEN** 最小 executor cooldown 修復通過
+- **THEN** R05 仍未完成，直到 forecast/reservation/多池與動態 fallback 的必要場景具證據。
+
+### Requirement: R06 Actionable failure provenance
+
+系統 SHALL 跨各 phase 保留可追溯原始原因、可信分類與 retryability，不以泛化文字覆蓋結構訊號。
+
+#### Scenario: R06 acceptance boundary
+- **WHEN** fake launcher 真正拋錯，經持久化/reload 後進 workflow poll
+- **THEN** launch failure 原因保持；runtime-contract/sandbox drift 不被錯誤 reroute，缺 handle 不冒稱有 exception。
+
+### Requirement: R07 Recovery transition semantics
+
+系統 SHALL 明定每種 resume/retry/recover/abandon 的前置條件、CAS、attempt generation 與資源處置。
+
+#### Scenario: R07 acceptance boundary
+- **WHEN** 相同恢復請求重送並有 late evidence
+- **THEN** 不重派已完成工作，不丟 operator artifacts；解除綁定與 supersession 原子有效。
+
+### Requirement: R08 Extensible selection acceptance
+
+系統 SHALL 依 execution-profile-qualification 契約分離任務需求與實際配置，保留明確 pin 的硬約束。
+
+#### Scenario: R08 acceptance boundary
+- **WHEN** 候選模型與原生 effort 新增或切換
+- **THEN** 無永久角色/產品硬配對；requested/resolved/observed 可追，unsupported 在 spawn 前拒絕。
+
+### Requirement: R09 Qualification lifecycle acceptance
+
+系統 SHALL 讓真實評測報告、核可條目與派工 profile 可追溯，明示 TTL 探活及實務紀錄來源。
+
+#### Scenario: R09 acceptance boundary
+- **WHEN** 舊 report 缺 effort 或新角色未量測
+- **THEN** 保持 legacy/unknown，不能把註冊、探活或其他角色成功當相符資格。
+
+### Requirement: R10 Honest workflow status
+
+系統 SHALL 一致呈現 actual/planned/last execution、registry facets、等待與選模理由；read model 不寫 workflow。
+
+#### Scenario: R10 acceptance boundary
+- **WHEN** 同卡 retry 換模型或 registry 標 needs_human
+- **THEN** 各 status section 與 source job binding 一致，不由 Persona 推測實際 executor。
+
+### Requirement: R11 Installed runtime identity
+
+系統 SHALL 可驗證 CLI、服務已載入 artifact/config revision，並保留 upgrade/rollback job 處置證據。
+
+#### Scenario: R11 acceptance boundary
+- **WHEN** source 已 merge 但長駐程序未更新
+- **THEN** 不宣稱 live 已部署；checkout 外的 installed CLI 與服務各自取證。
+
+### Requirement: R12 Ownership and shared resources
+
+系統 SHALL 隔離 instance 的 registry/workspaces/清理 writer，並對共享 quota 使用共同 authority。
+
+#### Scenario: R12 acceptance boundary
+- **WHEN** 多 instance 並行及重啟
+- **THEN** 無非預期互寫；owner-aware stop/cleanup 不傷其他工作，共用 quota 不雙重預留。
+
+### Requirement: R13 Launcher and parser contracts
+
+系統 SHALL 驗 argv round-trip、session/process lifecycle、timeout/取消與 terminal schema，不以放寬 status 偽造通過。
+
+#### Scenario: R13 acceptance boundary
+- **WHEN** 引號含逗號或右括號、單 job 被取消、manager unit 重啟
+- **THEN** argv 完整；單 job kill 不連坐 manager；session 測試不冒充 cgroup restart survival。
+
+### Requirement: R14 End-to-end delivery accounting
+
+系統 SHALL 維持十四類 requirement 到 child work/test/review/merge/installed 證據的完整 ledger，逐票裁決已修/取代/殘餘。
+
+#### Scenario: R14 acceptance boundary
+- **WHEN** intake 文檔或單一 PR 已完成但尚缺必要 live 驗收
+- **THEN** 不能宣稱全部完成或批次關票；中斷後只重做缺失工作並保留原 receipts。

--- a/openspec/changes/cortex-refine-complete/tasks.md
+++ b/openspec/changes/cortex-refine-complete/tasks.md
@@ -1,0 +1,61 @@
+## 1. B0 進件與責任邊界
+
+- [ ] 1.1 收斂十四類 plan、domain glossary、OpenSpec 與 PatchMUD producer issue 連結，獨立審查零未處置 MAJOR。
+- [ ] 1.2 將 Claude 已完成的進件驗證與本輪缺失複核併回 canonical child todo；保留 #828 獨立 ownership。
+- [ ] 1.3 保存 operator dirty 原稿並對齊實際 builder base；核對 Monitor confirmed authority 後只啟動一條低風險 Cortex canary。
+- [ ] 1.4 進件 artifact-only commit/PR 經 preflight 與 CI；不關閉尚未實作的 issues。
+
+## 2. B1 執行基礎
+
+- [ ] 2.0 補 #830 非 Job 決策回覆與 #831 sizing stability 方向；保留合理單模組 sizing 及所有 gate，另列 Red planner 分解接線的必要 child 範圍。
+- [ ] 2.1 透過 Cortex 完成 #822 argv/YAML canary，取得 RED/GREEN、review、policy 與 terminal delivery 證據。
+- [ ] 2.2 完成 #827 有界 refresh/coalesce、slow-provider 公平與 stop/diagnostics。
+- [ ] 2.3 完成 #819 not-idle clock、periodic 有效 max_load/require_idle 與非法值處置。
+- [ ] 2.4 完成 #496 內容/狀態冪等，驗同 path 內容改變仍恰好記錄。
+- [ ] 2.5 完成 #497 原子解除綁定、持久 supersession 與 restart/late-terminal 回歸；#501 只核對已修及殘餘污染。
+- [ ] 2.6 完成 #821 no-op persistence、history retention、writer/fault/rollback 相容與安全暫存清理。
+- [ ] 2.7 完成 #823/#824 session 與 AGY timeout 合約，明示 cgroup restart survival 的獨立驗收。
+- [ ] 2.8 完成 #825 最小 durable backoff，所有 lane 與 corrupt-state/expiry 可測；不標 R05 完成。
+- [ ] 2.9 以實際已載入 revision 驗 B1 成效，退出暫時 bypass 前保存 active jobs 與 rollback 方案。
+
+## 3. B2 可擴充配置與資格
+
+- [ ] 3.1 為 R08/R09/R12 建立/重用精確 child work items；profile schema、原生 effort 與 registry 相容性先有 spec。
+- [ ] 3.2 實作 adapter capability descriptors 與 conformance；新虛構 model/effort 無 central product-name diff。
+- [ ] 3.3 實作 requested/resolved/observed profile 與可追溯 effective argv/config；unsupported pre-spawn fail-closed。
+- [ ] 3.4 實作 PatchMUD versioned report consumer、legacy migration 與 profile/cohort/role/coverage 驗證。
+- [ ] 3.5 實作 qualification candidate→review receipt→approved roster 發布鏈；保留 operator 核可與 independence policy。
+- [ ] 3.6 實作安全 model register/probe 操作面與 TTL、角色擴充契約；探活不暗中消耗無上限額度。
+- [ ] 3.7 定義 pool/account 非機敏 identity、instance authority 與所有權邊界，為共享 admission 建 fixture。
+
+## 4. B3 遙測與預估
+
+- [ ] 4.1 完成 #826 failure 原始訊號→持久化→消費端分類，保留 runtime-contract 硬阻擋。
+- [ ] 4.2 整合 usage provenance：observed/estimated/unknown、增量/累計、input/cache/reasoning 不重複加總。
+- [ ] 4.3 核對各 provider 真正可用的 quota observation 介面，實作帶來源/TTL/window/unit 的 adapters 與 unknown fallback。
+- [ ] 4.4 實作與 benchmark 分開的 operational track record，涵蓋失敗消耗、duration 及任務分布。
+- [ ] 4.5 實作 task/profile 用量 forecast 與冷啟動先驗、風險區間、版本與資料期間。
+- [ ] 4.6 以 shadow 流程取得觀測覆蓋率、預估誤差與 confidence baseline；據此核定有限啟用門檻。
+
+## 5. B4 動態派工與恢復
+
+- [ ] 5.1 完成 qualified feasible candidate selection，維持 explicit pin、permissions、role、independence 硬條件。
+- [ ] 5.2 完成多池/多時間窗原子 reservation 與同主機多 instance contention 測試。
+- [ ] 5.3 完成 consumption reconciliation、crash/restart uncertain liveness 與 lease 不誤釋放。
+- [ ] 5.4 完成 card/attempt 安全邊界的 fallback、supersession 與 artifact preservation；同耗盡 pool 不可繞過。
+- [ ] 5.5 補 R07 recovery matrix 與 exact-run/card CAS、late evidence、重送冪等、abandon owner-aware 資源處置。
+- [ ] 5.6 通過計畫 12 個 quota/profile 場景，再有限 opt-in canary；保留 legacy policy 回復路徑與 receipts。
+
+## 6. B5 狀態與部署
+
+- [ ] 6.1 核對 #828 獨立 producer 交付；補 actual/planned/last、facets、quota wait 與 selection receipts 的 status 一致性。
+- [ ] 6.2 建立 CLI/site-packages/service loaded artifact/config identity 的同源驗證與 checkout 外 smoke。
+- [ ] 6.3 完成 installer/doctor instance roots、writer ownership 與 owner-aware stop/cleanup 的契約驗收。
+- [ ] 6.4 取得 upgrade/restart/rollback 對 active jobs 的實際 receipts；未重載程序不得標已部署。
+- [ ] 6.5 PatchMUD #37 producer 交付後，以真實 report→approval→dispatch 驗跨 repo 接線；外部依賴未交付則保持未完成。
+
+## 7. B6 整體閉環
+
+- [ ] 7.1 對全部 R01–R14 逐列核對 spec、work/run、測試、獨立 review、merge revision 與 runtime/installed evidence。
+- [ ] 7.2 逐 issue 重驗已修、取代與殘餘分類，補 closing/cross-reference；不依歷史清單批次猜測關閉。
+- [ ] 7.3 完成 release/changelog/install 一致性與 plan ledger；全部必要驗收完成後才 archive 本 umbrella。

--- a/reports/review/refine-intake-20260907.md
+++ b/reports/review/refine-intake-20260907.md
@@ -1,0 +1,111 @@
+# Refine P1 進件校正與審查交接
+
+日期：2026-09-07。文件基底：`79ba644780bf1c697c722ac24a297e7d02416100`。
+
+## 範圍與證據等級
+
+本次只整理9份 todo 與本審查報告；不改產品 code、tests、work-items 註冊表、
+umbrella/spec、changelog、operator/runtime checkout 或服務。#822 已派工的 canary
+材料不在本次改動範圍。未 commit／push／建立 PR，整合與必要 changelog 由主流程處理。
+
+審查判準：未處置的缺陷／缺口為 FAIL；明文承認、影響有界且列管的殘餘風險
+不單獨構成 FAIL。PASS 只表示目前進件敘述可進入實作／驗收，不能代替 RED／GREEN、
+CI、merge、installed runtime 或 live lifecycle 證據。
+
+使用 doc-coauthoring 的結構／歧義檢查整理已提供的任務脈絡；未再啟動 Claude 或
+付費模型評測。獨立讀者驗證交主流程讀 diff 完成，本報告不冒充其結論。
+
+## 審查發現與文件處置
+
+| 正式 workstream | 原稿判定 | 已寫入的最小修正 | 實作狀態 |
+|---|---|---|---|
+| daemon-tick-clock-not-idle | PASS；新增防護要求 | 保留完成的 FakeClock／傳參驗收，新增有限正值規則、NaN／Inf／非正值測試 | 未實作／未測 |
+| registry-persist-hygiene | FAIL | history fixture 改用 record_action；writer keyword／fault wrapper 相容；hardlink fallback；必要 audit 追溯界線 | 未實作／未測 |
+| fix-dirty-recheck-idempotency | canonical FAIL；綜合稿可用 | canonical hash／state／gate／candidate／refs 比對，同 path 改內容恰好記一次 | 未實作／未測 |
+| fix-superseded-terminal-replay | canonical FAIL；綜合稿可用 | 原子清綁／持久 supersession／consume、合法 recovery fixture、restart／completed proof 保護 | 未實作／未測 |
+| executor-durable-backoff | FAIL | corrupt store 為 unknown，不解除 cooldown；重複觀測冪等，重啟與 skip 證據；分開完整動態 quota scope | 未實作／未測 |
+| outcome-taxonomy-signals | FAIL | reason-aware diagnostic 消費端；排除裸 not-found 誤判；producer→persist→poll 回歸 | 未實作／未測 |
+| launcher-session-and-timeout | FAIL | 加離線 CLI duration 合約 smoke；明示 session≠cgroup；以含 #820 基底開發 | 未實作／未測 |
+| monitor-refresh-thread-backlog | FAIL | 明定事件屏障／W／pending bound／D／公平性與停止 fence；不以任意100事件≤2次作契約 | 未實作／未測 |
+| bucket-c-evidence-dedup | 不應另行派工 | 移除 accepted/work_item authority，改成兩份 canonical todo 的交接索引 | 索引文件已整理 |
+
+以上是發現已在文件處置的記錄；主流程仍需讀 diff 驗證語意並跑正式 intake gates，
+不能把本表改寫成所有開發 work item 已 PASS／完成。
+
+## 關鍵 source／test 錨點
+
+以下行號對上述基底核對，後續 code 變更時應以函式名稱重新定位。
+
+- #819：`paulsha_cortex/coordinator/manager_daemon.py:1449` periodic lane；
+  `:1458` not-skipped 才推時鐘；`:1474` failure 會推時鐘。
+  `tests/test_manager_daemon_tick_backoff.py` 的 `_FakeClock` 可建決定性 regression。
+- #821：`paulsha_cortex/coordinator/registry.py:1571` 的 update_slice 只更新 refs；
+  `:1650`／`:1655`／`:1673` 才是 record_action 的三種 history append。
+  `:572` 原子 writer、`:617` persist、`:478` normalization on load。
+  `tests/test_workflow_production_wiring.py:5690` 與
+  `tests/test_planning_publication_transaction_536.py:553` 是單參 fault wrappers。
+- #496：`paulsha_cortex/coordinator/manager.py` 的 `complete_tick` dirty recheck
+  與 `_apply_verification_result`；`registry.py` 的
+  `_read_current_verification_evidence_hash`／`_normalize_loaded_slice_verification`。
+  `tests/test_pre_candidate_recovery.py::test_candidate_worktree_dirty_reevaluation_on_tick`
+  只有既有真實轉換測試，需要另補 unchanged／same-path-changed 變體。
+- #497：`manager.py:555` allowed_slice_actions 與 `:1740` candidate guard；
+  `registry.py:1575`／`:1579` 只在參數非 None 時更新綁定／candidate。
+  `tests/test_pre_candidate_recovery.py:139` 是合法 candidate=None fixture；
+  `:198` 另有 candidate 存在則 fail-closed 的守衛測試。
+- #825：`coordinator/provider_outcome.py` 已有 reset_at 與 authority 分級，
+  `manager.py` 的 `_runtime_preflight_gate`／`_provider_failure_reroute` 是候選 gate
+  入口；`autonomy.dispatch_ready` 是 slice 派工入口。新 store 本身尚未存在。
+- #826：`manager.py:10533` 對所有 runtime_diagnostic dict 清除 classification，
+  `:10543` 目前只考慮 retryable；只加 enum 與欄位寫入不足以交付。
+  `outcome_taxonomy.py:621` 文字層維持 provider/model text 分離。
+- #823／#824：`launcher.py` 的 SubprocessLauncher.launch 共用 popen_kwargs 與
+  兩個 Popen 路徑；#820 可能改變精確行號，不能沿用舊並行衝突說明。
+  真 process-group 測試和 systemd runner/template 測試必須分清證明範圍。
+- #827：`monitor/watcher.py:130` 每事件 Timer；`monitor/service.py:317` 第二層
+  Timer、`:337` 呼叫 refresh_project；`monitor/work_api.py:502` 全域 refresh 鎖；
+  `tests/test_stage9_project_monitor_service.py:977` 只有三次事件的 burst 測試，
+  `:1199` 只有 watch state 的 unwatch 測試，均不足以證明慢 provider／stop 競態。
+
+## 需主流程保留的裁決與邊界
+
+1. #819 有限正值規則一致；保留 env 非法值安全回預設、CLI 顯式非法值拒絕的
+   相容政策，兩者不能讓 NaN／Inf／零／負值成為生效門檻。manual lane／cgroup-aware
+   capacity 仍是後續範圍，不是這次不小心遺漏的設定入口。
+2. #821 limit=1 明定保留最新筆；limit≥2 維持首筆＋近期資料。截斷計數不是完整
+   archive，必要 current/completion evidence 仍可追溯；完整長期封存由 umbrella
+   successor 列管。需全歷史的現場須先保存 registry 備份，再啟用截斷。
+3. #821 stale temp 清理要求能證明失活／目錄獨占，mtime 超過30秒本身不夠；
+   不為清理擴張跨 process lock scope。無證據即保留並診斷，不任意刪除。
+4. #825 只交付已知失敗後的最小持久退避；動態選模／共享 quota pool／任務用量
+   預估／reservation 交完整 plan。這些後續工作不得因本票 merge 被標完成。
+5. #823 session 隔離不保證 systemd restart survival；#824 CLI smoke 必須實際
+   跑到不耗模型用量的參數 parser。若不支援該旗標，交主流程決定 adapter／版本路徑。
+6. #827 文件要求 bounded provider timeout／stop fence；若實作選定的 adapter
+   根本沒有可驗證的 timeout，主流程需處理依賴，不以多開 thread 冒充完成。
+7. #496／#497 是兩個正式 work item；bucket-C 索引不得再註冊。#497 的
+   supersession／state／binding 原子提交須有故障注入測試，不能只靠多次 persist 的
+   註解宣稱 atomic。
+
+## 文件檢查與交付邊界
+
+本次只執行純文件範圍／空白／識別字檢查；未執行產品 unit/integration tests、
+正式 planning/authority mutation、policy-check、CLI flag smoke 或 runtime canary。
+所有 todo 的工作項維持未勾選；不存在代填的 evidence hash 或預先勾好的 CI／部署結果。
+
+純文件檢查結果：變更路徑與授權10檔完全一致；8份正式 todo 的 work_item／
+`## Tasks` 符合對應路徑，bucket-C 無 authority frontmatter；10檔均無尾端空白、
+預勾工作項、個人絕對路徑或佔位字。tracked diff 的 `git diff --check` 成功；
+產品 code／tests／work-items／CHANGELOG／#822 路徑的 diff 為空。
+
+主流程整合時需補正式 changelog fragment／Unreleased、帶 PR context 的 policy-check，
+並確認每個 accepted todo 的 authority 與 issue／work registration 一致。不要對已凍結
+的 #822 canary 改 plan bytes，也不要提交 operator 的 #828 或其他 repo 無關工作。
+
+## 主流程整合補註
+
+`.cortex/work-items.yaml` 的 `trust-root-executor-hardening` 排除 #692／#763，
+是接手時已存在的 Claude collision 修正，不是新增產品功能。核對基底中 #692
+已有 `trust-root-home-fail-closed`、#763 已有 `manager-gitconfig-delivery`，
+各自 canonical todo 引用自己的 issue；hardening 的正式 issue 為 #665。
+保留 excludes 是為維持分責與唯一 authority，不重開、重派或改變這些工作的驗收。

--- a/reports/review/refine-plan-20260907.md
+++ b/reports/review/refine-plan-20260907.md
@@ -1,0 +1,27 @@
+# 十四類精修計畫獨立審查
+
+日期：2026-09-07。
+
+Reviewer：獨立 subagent `refine_plan_review`；作者與整合：root。
+輸入：完整 refine plan、execution-domain glossary 與 `cortex-refine-complete` OpenSpec。
+
+首輪判準：未處置 BLOCKER/MAJOR→FAIL；已明文承認、影響有界且列管的殘餘風險不單獨構成 FAIL；不同意接受須具體反駁。
+
+結果：PASS，未發現未處置 BLOCKER/MAJOR。核對十四類 scope、依賴、驗收及完成界線；profile/quota 契約保留 Trust Root、reviewer independence、explicit pin，未知額度、token 語意、歷史 effort 不相容及 pricing provenance 已分開。
+
+PatchMUD producer 未交付的 live integration 是未完成 gate，fixture 不替代整體交付。此次為計畫審查，不是產品 code review 或 runtime 驗收。後續 child 實作仍各自需要 RED/GREEN、獨立 review、policy/CI、merge 與部署證據。
+
+主流程另補機械檢查：`openspec validate cortex-refine-complete --strict` 通過；planning artifacts 完整不等於 tasks 完成，全部 implementation checkbox 仍未勾。
+
+## 最終 planning-only diff 複核
+
+Reviewer 再次核對 #830/#831 的 R14/B1 接線、完整 P1 todo、bucket-C 索引、
+註冊與 changelog，結果 PASS，無未處置 BLOCKER/MAJOR。直接比對第三個 #822
+run `workflow-97a9aa661e4816e38964` 的 frozen baseline 與作者三件組，SHA256
+完全一致；前兩個 run 的 superseded 與本次 Yellow 通過有正式 receipts。
+#692/#763 各自 canonical authority 與 excludes 分責已核對，#828 不在 diff。
+
+首次 PR-context preflight：policy PASS、canonical OpenSpec PASS、
+`python3 -m pytest tests/ -q` PASS（180.79秒）。這是本地規劃分支基底測試，
+不是 #822 新修正的 GREEN 證據。commit 後仍需重跑 diff-aware preflight，
+遠端 CI／merge／runtime 不由本報告提前宣告。


### PR DESCRIPTION
## 摘要

建立十四類精修的完整規劃權威、動態 execution profile／quota-aware admission 契約，以及既有 P1 的可驗證進件；本變更只有規劃與註冊資料，不宣稱產品修正已完成。

追蹤總帳：#829。接手範圍包括 #819、#821–#827、#496、#497；新發現的 bootstrap 缺口由 #830、#831 列管。PatchMUD producer 由 hamanpaul/paulsha-patchmud#37 追蹤。

## 邊界

- 保留既有 work_id；bucket-C 只是索引，不重複註冊 authority。
- 保留 Claude 既有 #692／#763 collision excludes；兩票已有各自 canonical work_id，不由 #665 hardening 重複承接。
- 排除另有 owner 的 #828 與 paulshaclaw 工作；不修改產品程式碼、runtime 或服務設定。
- 尚未實作的 issue 不由本 intake PR 關閉；申請 `policy-exempt:issue-link`，原因是規劃與追蹤交叉連結，不是完成宣告。
- quota、effort、qualification、release／installed／live 驗收均保留未完成 gate；PatchMUD 開票不等於 producer 已交付。

## 檢查清單

- [x] 十四類需求都有 scope、依賴、驗收與殘餘限制。
- [x] 原始 operator dirty 工作與 #828 ownership 保留。
- [x] 已新增 changelog fragment 及 Unreleased 記錄。
- [x] OpenSpec umbrella strict validation 通過；implementation tasks 不預勾完成。

## 驗證

`openspec validate cortex-refine-complete --strict`、`git diff --check`、兩輪獨立 planning review 通過。首次 PR-context preflight 的 policy、canonical OpenSpec、完整 `python3 -m pytest tests/ -q` 均 PASS（測試180.79秒）；commit 後會再核對 diff-aware gate。這是規劃分支基底驗證，不是各產品修正的 RED/GREEN 或 runtime 證據。
