### PR TITLE
docs(refine): 納管 sizing 與派工結果 bootstrap 契約

### DIFF
--- a/.cortex/work-items.yaml
+++ b/.cortex/work-items.yaml
@@ -846,3 +846,27 @@ work_items:
       - kind: path
         ref: 'docs/superpowers/workstreams/monitor-refresh-thread-backlog/todo.md'
     excludes: []
+  sizing-stability-direction:
+    title: 'sizing-stability-direction'
+    links:
+      - kind: github_issue
+        ref: 'hamanpaul/paulsha-cortex#831'
+      - kind: path
+        ref: 'docs/superpowers/specs/sizing-stability-direction-spec.md'
+      - kind: path
+        ref: 'docs/superpowers/specs/sizing-stability-direction-design.md'
+      - kind: path
+        ref: 'docs/superpowers/workstreams/sizing-stability-direction/todo.md'
+    excludes: []
+  dispatch-decision-contract:
+    title: 'dispatch-decision-contract'
+    links:
+      - kind: github_issue
+        ref: 'hamanpaul/paulsha-cortex#830'
+      - kind: path
+        ref: 'docs/superpowers/specs/dispatch-decision-contract-spec.md'
+      - kind: path
+        ref: 'docs/superpowers/specs/dispatch-decision-contract-design.md'
+      - kind: path
+        ref: 'docs/superpowers/workstreams/dispatch-decision-contract/todo.md'
+    excludes: []

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 
 ## [Unreleased]
 
+- **Refine bootstrap 進件**：補 #831 stability 風險方向與 #830 非 Job 派工決策的
+  accepted 三件組、真實 sizing 與純 gate 驗證；#833 獨立列管 Red planner 接續。
+  記錄 #832 規劃合併及 B2–B5 既有能力／待補 child 對照，不宣稱產品修正已交付。
+
 - **十四類 Cortex 精修進件（#829）**：收斂完整分批計畫、OpenSpec 驗收契約、動態
   execution profile／額度觀測與預估／fallback 邊界；PatchMUD producer 由獨立 #37
   列管。補齊 P1 canonical todo 與 #496／#497 校正，保留 #828 獨立工作所有權。

--- a/changelog.d/refine-bootstrap-intake-20260907.md
+++ b/changelog.d/refine-bootstrap-intake-20260907.md
@@ -1,0 +1,6 @@
+# Refine bootstrap 與後續進件對照
+
+- 為 #831 純 stability 風險映射與 #830 派工結果契約建立 accepted spec/design/todo。
+- 保留現行真實6/Yellow與8/Red；#830須待實際修正版runtime重評，不調低scope或移除gate。
+- #833獨立承接Red planner→children閉環；更新#829 ledger與B2–B5既有能力／新child對照。
+- 本次只有文件與註冊，產品程式、權限、模型配置、服務與live registry均不變。

--- a/docs/superpowers/plans/2026-09-07-cortex-refine-complete.md
+++ b/docs/superpowers/plans/2026-09-07-cortex-refine-complete.md
@@ -186,13 +186,28 @@ B1 的主要目標是讓 Cortex 能可靠承接後續工作。B2–B4 完成後�
 
 | 批次 | 狀態 | 證據／下一動作 |
 |---|---|---|
-| B0 | in-progress | 已保存原工作樹；隔離 authoring branch；補查缺少的 intake 驗證；本 umbrella strict OpenSpec validation 通過。 |
-| B1 | in-progress | #820 已合併基底；#822 前兩個進件 run 已正式 supersede，第三個 run 通過 Yellow plan review、進入 build，尚待實際 job／測試證據。#830/#831 已開票並準備獨立進件。 |
+| B0 | complete | #832 規劃／進件已合併；review、PR-context preflight、CI通過，原稿及其他工作所有權保留。不是產品修正完成。 |
+| B1 | in-progress | #820 已合併基底；#822 第三run的隔離卡已採信，TDD RED執行中，尚待產品測試／交付。#831為6/Yellow、#830為8/Red；#833補Red接續，皆未實作完成。 |
 | B2 | pending | PatchMUD producer 由專責 subagent 開票；Cortex contract 待派工。 |
 | B3 | pending | 觀測與預估先 shadow。 |
 | B4 | pending | 資格、預估與所有權契約先過，再有限啟用動態路由。 |
 | B5 | pending | #828 獨立處理；其餘狀態／部署待分拆。 |
 | B6 | pending | 所有驗收證據及逐票 closure 尚未取得。 |
+
+### 已核對的進度更新（2026-09-07 08:47 UTC）
+
+- B0 已完成規劃／進件交付：[PR #832](https://github.com/hamanpaul/paulsha-cortex/pull/832)
+  merge `60a3ffa867377b0c86fa2f10e91fb9820d91938c`。兩輪獨立 review、commit 後
+  PR-context preflight、Python3.10–3.13 tests、build與四版installed smoke全部通過；
+  未關閉任何尚未實作的精修 issue。
+- B1 仍在進行：#822 run `workflow-97a9aa661e4816e38964` 的隔離卡經Claude429後
+  正式fallback到Codex並被Manager採信；TDD RED卡已派，尚未取得產品RED/GREEN或交付。
+- #831 accepted三件組在現行runtime為6/Yellow；#830為8/Red，待#831真正載入runtime
+  後重評。兩者純gate的 `envelope_unavailable` 仍是既有bypass，不代表量測能力合格。
+- [#833](https://github.com/hamanpaul/paulsha-cortex/issues/833) 是R14/B1的Red planner
+  接續successor；#830/#831不代替它，完整parent→children→closure仍是未完成gate。
+- 後續工作依[動態進件對照](../../../reports/review/refine-dynamic-intake-map-20260907.md)
+  查重拆票；D1–D10只是責任切面，仍須真實sizing及accepted child plan，不直接整包派工。
 
 ### Canary sizing 校正紀錄
 

--- a/docs/superpowers/specs/dispatch-decision-contract-design.md
+++ b/docs/superpowers/specs/dispatch-decision-contract-design.md
@@ -1,0 +1,53 @@
+---
+status: accepted
+work_item: dispatch-decision-contract
+---
+
+# 派工結果契約設計
+
+## Decisions
+
+### D1 一個內部判定契約，多個正式消費端
+
+在 coordinator 定義共用的 dispatch-result 分類／投影 helper，供 manager 與 daemon 使用。
+實作可採帶 discriminator 的內部型別，但外部 request JSON 與 durable registry 不升 schema、不新增假 Job。
+既有 dict producer 遷移期間只能以明確可驗證的形狀轉接，未知 dict 不可當成 generic success。
+
+| 結果類別 | 必須證明 | 可回應內容 |
+|---|---|---|
+| 真正 Job | 有有效 job_id，且正式 registry 的 run/card 綁定相符 | exact job_id、最新 run；原有 Job status 不改判 |
+| 非 Job 決策 | 當前 run/phase 的正式 dispatch decision，具 reason；沒有 Job 副作用 | reason、最新 run、適用時既有 detail；不得標 dispatched |
+| 確定性 transition | 呼叫前後持久化 run 顯示合法 phase/card 推進，無 Job | 最新 run 與具體 transition，不臆測下一張模型已派出 |
+| None 且無 transition | 無新 Job、無 phase 推進 | 原有 not-dispatchable／空結果語意，不 fabricated success |
+| 未知或矛盾 | 無法符合以上任何一型 | fail-closed 的 contract 診斷，不吞掉真實例外 |
+
+各正式 consumer 在派工後重新讀取該 run；不得把呼叫前的 run payload 原封回傳。
+Job 判斷不只測字串存在；測試須證明 forged job_id、錯 run、malformed dict 不會獲得 dispatch authority。
+
+### D2 Side effect 與回應分開
+
+Claim/define/plan 可能先 durable 完成，再回傳無 Job 決策；回應層失敗不能抹掉已完成動作。
+仍保留既有 claim/CAS/terminal evidence 不變量，不為修 adapter 加 transaction rollback 或重派。
+真正 dispatch/launcher 例外仍照原補償；只將合法無 Job 結果從例外路徑移開。
+
+### D3 Forced retry 保留較嚴格後置條件
+
+forced retry 的成功後置條件是新 replacement Job。None、拆分、preflight refusal 或僅 phase transition 均不滿足。
+回應保留原 decision 作診斷，補回 needs_human 時附具體 reason；不能產生 KeyError、假 job_id 或假 redispatched。
+
+### D4 Consumer 清冊與回歸矩陣
+
+實作先用函式引用找出 `dispatch_workflow_card`、`_dispatch_workflow_card`、`resume_workflow_run` 的 consumer，至少涵蓋：
+
+- daemon workflow-action 同步 dispatch、work start/intake、forced retry。
+- manager resume 的首派、operator recovery、provider bounded retry、terminal 後的下一張 dispatch。
+- periodic workflow resume，以及它將例外轉成 needs_human 的外層。
+
+每個適用入口以真 Job／None／非 Job／transition 測試；forced retry 另驗拒絕。
+「沒有其他 consumer」只可標當下掃描佐證；上述分類不變量由測試鎖住，新增 consumer 未接契約時測試必須紅燈。
+
+### D5 交付與 sizing
+
+Production 至少跨 manager/daemon 兩個模組，domain_breadth=1；維持舊結果兼容與 durable workflow 狀態投影，state_consistency=1。
+基底舊算法預估 8/red，保留真實宣告。先完成 #831 並以實際新 runtime 重算；若仍 Red，先拆有獨立驗收的子工作，不直接 dispatch 本整包。
+不以改 combo、清欄位、調低數值、手改 frozen authority 或刪 gate 通過。

--- a/docs/superpowers/specs/dispatch-decision-contract-spec.md
+++ b/docs/superpowers/specs/dispatch-decision-contract-spec.md
@@ -1,0 +1,33 @@
+---
+status: accepted
+work_item: dispatch-decision-contract
+---
+
+# 派工結果的非 Job 決策契約
+
+## Requirements
+
+對應 [Cortex #830](https://github.com/hamanpaul/paulsha-cortex/issues/830)，屬 refine #829 的 R14 接續契約修正。
+accepted 表示需求與測試邊界已定案，不表示已實作、可繞過 sizing，或已完成交付。
+
+1. **R1 結果分類**：所有正式派工消費端須辨識真正 Job、合法非 Job 決策、確定性 phase transition 與 None。不能以「非 None」推論為 Job；未知／malformed 結果須具體拒絕，不得降格為成功。
+2. **R2 非 Job 真實性**：needs-decomposition、runtime preflight refusal、plan-output missing／plan-review 待處理等合法決策不產生假 job_id、dispatched 或 model session。回應保留原 reason、run ID、最新持久化 phase/facets。
+3. **R3 入口一致性**：work start/intake、workflow-action 同步續推、explicit resume、periodic continuation、terminal 後續 dispatch／provider retry 的同型消費端使用同一契約；不能只修最早一個 KeyError。
+4. **R4 狀態保全**：合法拆分／等待不得因 adapter 例外變成一般 needs_human/resume-workflow-failed。確定性 transition 若已落盤、即使沒有 Job，回應仍反映新 phase；None 且沒有 transition 不假稱推進。
+5. **R5 冪等性**：start 已建立 run 後的無 Job 結果，重送不得新增重複 claim/run、改寫已採信 evidence 或重複派模型；真 Job 保留 exact job_id 與原有綁定。
+6. **R6 Forced retry**：retry-build/retry-card 要求 replacement Job 時，合法非 Job／None仍是不滿足重派要求；保留原有 fail-closed 補償和具體診斷，不能回假 redispatched。
+7. **R7 不放寬治理**：不改 reviewer independence、權限、quota、sizing 或 recovery CAS。不可手造 evidence、修改 live registry 或新增隱含重試來掩蓋契約錯誤。
+8. **R8 可驗證交付**：真 producer→consumer RED/GREEN、全套、policy、CLI smoke 與 bounded Cortex canary 各留獨立證據；request 完成、job 啟動與 workflow terminal 不互相替代。
+
+## Scope
+
+- Production：`paulsha_cortex/coordinator/manager.py` 與 `manager_daemon.py` 的派工結果產生／消費接線；如需共用內部結果型別，可在同一 coordinator 邊界新增小型 helper，但不得改 durable Job/WorkflowRun schema。
+- Tests：既有 producer、daemon request、resume/periodic、provider retry、forced retry fixture；新增集中 contract matrix。
+- Documentation：`docs/unified-work-lifecycle.md`、必要 CLI 操作說明與 changelog。
+- 非目標：#831 stability 量表、#223 Red 自動拆分、quota 預測、#822 parser、語意 recovery 擴權。
+
+## Evidence
+
+基底 `79ba644780bf1c697c722ac24a297e7d02416100`：`manager.py:9494-9537` 合法回傳無 job_id 的 needs-decomposition；`manager_daemon.py:809-810` 直接取 job_id。
+`tests/test_dispatch_needs_decomposition_223.py:94-115` 已驗 producer 零 Job；`tests/test_manager_daemon_intake_dispatch.py:50` 只涵蓋真正 Job。
+另須實作前重新定位 `resume_workflow_run` 及後續 dispatch 的所有消費點，避免行號漂移被當成漏查理由。

--- a/docs/superpowers/specs/sizing-stability-direction-design.md
+++ b/docs/superpowers/specs/sizing-stability-direction-design.md
@@ -1,0 +1,41 @@
+---
+status: accepted
+work_item: sizing-stability-direction
+---
+
+# Spec stability 風險映射設計
+
+## Decisions
+
+### D1 將穩定度訊號轉成風險分，不更動其他維度
+
+在`planning.py`抽出純helper或等價的局部判定；`compute_sizing_score`只替換stability分量。
+優先序：任何blocking marker→2；任何assessment遭拒且不屬「單純缺少一種材料」→2；缺失kind至少兩種→2；缺一種→1；其餘完整accepted→0。
+同一kind的額外不合格artifact不能被另一份accepted同kind覆蓋而消失。
+實作須測試actual assessments與missing_kinds的一致性；不允許以手拼不可能的report使unknown變0。
+本映射命名為 `stability-risk-v2`，透過模組常數/文件與精確runtime revision辨識；不新增WorkflowRun或CompletionRecord欄位。
+
+### D2 保留三層 unknown 與失敗邊界
+
+1. Artifact assessment仍負責status/heading/blocking判定；本票不放寬accepted規則。
+2. `compute_sizing_score`仍要求合法plan與domain/state宣告；非法值仍拋ValueError。具合法plan但其他kind缺失只輸出有界風險，不代表已達build readiness。
+3. `work_bridge.current_sizing_snapshot`既有fail-soft不改：找不到plan/檔案、宣告非法、combo無法解析時仍 `(None,None)`，不得用0替代。
+
+### D3 Frozen與版本遷移採明示重新評估
+
+此次是新計算算法切換，不是資料庫migration。舊run/CompletionRecord已記分數照原樣保存；服務啟動、read model讀取、報告重播不得重算覆寫它們。
+新claim/reclaim和已存在的正式retry重算入口，透過既有函式接線取得新分數；重新計分前後的run/attempt與runtime revision由獨立測試/交付證據記錄，不改舊evidence bytes。
+若舊紀錄能由歷史部署/原始artifact證據定位算法，就保留其來源；沒有來源則在說明中明示legacy/unversioned，不以今天runtime猜過去算法。
+本票不增加新的live全量重算動詞，不修改已有frozen planning metadata後resume。需要採新規劃的工作由正式abandon/reclaim等既有入口建立新世代。
+
+### D4 驗收以規格與性質為oracle
+
+更新既有反向測試之前，先新增完整→0的RED、缺漏/marker增加不降分的property matrix。
+保留每維/總分/band邊界，覆蓋Green/Yellow/Red的跨界效果；比較時domain/state/其他機械維度固定，不以改輸入湊分。
+對claim helper/正式retry writer/registry roundtrip分別測試：新計算有效、舊記錄未被讀取副作用更寫。測試state僅在tmp_path，不讀live registry。
+
+### D5 範圍與sizing依據
+
+Production單一`planning.py`純函式，domain_breadth=0、state_consistency=0；tests雖涉及callers與registry fixture，不修改production caller/schema。
+這不是以移除測試降低scope。若要新增per-run算法欄位、版本migration writer或跨模組修復，已超出本純函式邊界，必須先重拆/重評。
+基底舊算法完整標準lane仍6/yellow；使用實際runtime的Yellow機械gate驗證進件，不依預期修後算法偷降現在的分數。

--- a/docs/superpowers/specs/sizing-stability-direction-spec.md
+++ b/docs/superpowers/specs/sizing-stability-direction-spec.md
@@ -1,0 +1,28 @@
+---
+status: accepted
+work_item: sizing-stability-direction
+---
+
+# Spec stability 風險方向修正
+
+## Requirements
+
+對應 [Cortex #831](https://github.com/hamanpaul/paulsha-cortex/issues/831)；上位量表見 [#208](https://github.com/hamanpaul/paulsha-cortex/issues/208)，機械計分實作來源 #221。
+
+1. **R1 正向風險**：完整且 accepted、無 blocking marker、deterministic completeness通過的三件組，stability risk=0；增加缺漏或未決變更不得降低風險。
+2. **R2 明確映射**：完整三件組=0；恰一個缺失kind且無其他拒收/阻塞=1；至少兩個缺失kind、任一blocking marker，或存在不被accepted的artifact造成authority需重整=2。所有三種kind均無材料屬unknown，不得單憑缺材料宣稱低風險；直接純函式可給保守2，既有claim helper仍回sizing unavailable。
+3. **R3 範圍/門檻不變**：每維0..2、總分0..10、Green/Yellow/Red邊界不變；domain/state宣告、acceptance_surfaces與orchestration算法完全不改。
+4. **R4 Unknown邊界**：缺少/invalid domain或state在純函式仍ValueError，在既有current_sizing_snapshot仍fail-soft `(None,None)`；不造0、不新增「清欄位繞gate」途徑。未accepted的完整kind集合不得因missing_kinds為0而被當低風險。
+5. **R5 新舊版本隔離**：新claim/reclaim及既有明示retry重算入口採新映射；讀取/重啟不得自動重算或改寫歷史run、frozen planning、CompletionRecord或immutable evidence。既有紀錄沒有算法來源時標legacy/unversioned，不猜填新算法。
+6. **R6 最小純函式修正**：production只改`coordinator/planning.py`的stability映射及可識別的算法常數；不新增durable欄位、不修改registry loader/CAS或自動migration。若實作需要擴張上述邊界，先重新規劃/計分，不在本票暗中擴張。
+7. **R7 可驗證交付**：rubric-based RED/GREEN、monotonicity/property、不同scope與band邊界、claim/retry重算及歷史不改寫測試；全套、policy、CLI read-only smoke與新runtime身份證據分開記錄，不消耗模型測量分數。
+
+## Evidence
+
+基底 `79ba644780bf1c697c722ac24a297e7d02416100` 的 `planning.py:853-859` 用 `max(0, 2 - missing_penalty - blocking_penalty)`，完整accepted給2。
+`tests/test_planning_sizing_score.py:62` 固化此反向oracle。
+#208原量表的Spec stability明定「frozen且機械驗證完成=0、少量明確缺口=1、authority很可能需改寫=2」；本文件R2是機械映射的顯式delta，不靜默沿用錯誤oracle。
+
+## Non-goals
+
+不改#822 parser、#830派工結果契約、#223自動拆分、模型資格/effort/quota；不改另外兩個機械維度或band門檻，也不把修正後分數回填成歷史當時分數。

--- a/docs/superpowers/workstreams/dispatch-decision-contract/todo.md
+++ b/docs/superpowers/workstreams/dispatch-decision-contract/todo.md
@@ -1,0 +1,28 @@
+---
+status: accepted
+work_item: dispatch-decision-contract
+domain_breadth: 1
+state_consistency: 1
+invariant_count: 8
+artifact_classes:
+  - source
+  - tests
+  - documentation
+---
+
+# 派工非 Job 決策契約工作清單
+
+Issue：[Cortex #830](https://github.com/hamanpaul/paulsha-cortex/issues/830)。
+Spec/design 為同 work_item 的 `dispatch-decision-contract-{spec,design}.md`。
+accepted 只代表進件內容定案；當前 sizing=red 時不得整包派工。
+
+## Tasks
+
+- [ ] **T1 source/責任清冊**：從 runtime 精確 base 追 `dispatch_workflow_card`／`_dispatch_workflow_card` 到 daemon workflow-action、start/intake、manager resume、provider retry、terminal-next、periodic consumer，記錄函式/行號/回傳型別；不把 keyword 搜尋當全稱保證。
+- [ ] **T2 tests/RED**：在 `tests/test_manager_daemon_intake_dispatch.py` 與新的 `tests/test_dispatch_decision_contract.py` 接入真 red producer 形狀，重現 KeyError；assert 零 Job/model invocation、run已存在、phase/facets/reason正確。模型與外部服務用可計數替身，fixture/state僅在tmp_path。
+- [ ] **T3 source/最小修正**：在 coordinator 共享內部結果分類/投影契約，接完整 T1 清冊；真Job驗registry binding，合法decision保留reason與最新run，None/transition不造job_id；malformed/foreign-run payload fail-closed。
+- [ ] **T4 tests/consumer矩陣**：涵蓋真正Job、None且未推進、確定性plan→build、needs-decomposition、runtime preflight refusal、plan-output missing、plan-review retry；start/intake重送與periodic resume不得新增run/Job、抹掉reason或誤轉resume-workflow-failed。
+- [ ] **T5 tests/forced retry**：retry-build/retry-card的None、decision、transition仍拒絕假redispatched；補償維持needs_human與原失敗原因。正常replacement Job仍成功；reviewer independence、CAS、舊evidence/hash均不變。
+- [ ] **T6 documentation/CLI help**：更新 `docs/unified-work-lifecycle.md` 的request完成/無Job決策/phase推進區別；同步必要README與CLI說明。以候選環境從checkout外真跑 `python3 -m paulsha_cortex.cli work start --help`、`run work --help` 與fixture-backed request JSON smoke，不呼叫live manager。CLI help未變也記錄實際輸出與exit code，不能只有字串mock。
+- [ ] **T7 tests/CI**：先跑集中contract矩陣，再跑 `tests/test_dispatch_needs_decomposition_223.py`、`tests/test_manager_daemon_intake_dispatch.py`、`tests/test_coordinator_manager_daemon.py` 及T1定位的resume/provider/retry相關測試；最後 full pytest、既有CI/pinned preflight、含PR上下文policy、git diff --check。不可把單元測試等同live驗收。
+- [ ] **T8 documentation/交付**：新增並commit `changelog.d/dispatch-decision-contract.md`、補 `CHANGELOG.md [Unreleased]`；PR保留正確issue/非目標關聯，獨立review與exact-head checks綠燈後由Cortex交付。新runtime重算sizing合格才選bounded canary，驗run/Job/decision/terminal分開呈現，保存installed/runtime版本和original frozen authority；不動其他進行中的工作。

--- a/docs/superpowers/workstreams/sizing-stability-direction/todo.md
+++ b/docs/superpowers/workstreams/sizing-stability-direction/todo.md
@@ -1,0 +1,26 @@
+---
+status: accepted
+work_item: sizing-stability-direction
+domain_breadth: 0
+state_consistency: 0
+invariant_count: 7
+artifact_classes:
+  - source
+  - tests
+  - documentation
+---
+
+# Spec stability 方向修正工作清單
+
+Issue：[Cortex #831](https://github.com/hamanpaul/paulsha-cortex/issues/831)。
+Spec/design為同work_item的`sizing-stability-direction-{spec,design}.md`。
+
+## Tasks
+
+- [ ] **T1 documentation/rubric delta**：對照#208/#221與本spec R1–R7，在`docs/unified-work-lifecycle.md`記錄stability-risk-v2的0/1/2映射、unknown邊界、legacy/unversioned及明示新世代規則；不得偷偷更改歷史量表或舊紀錄。
+- [ ] **T2 tests/RED**：於`tests/test_planning_sizing_score.py`先新增完整accepted→0、單缺kind→1、至少兩缺kind或marker/拒收artifact→2的規格oracle；保留舊算法會失敗的證據，再更新反向oracle。增`tests/test_sizing_stability_direction.py`做單調性/property、重複kind中不合格artifact、空artifact/unknown與非法report負例，所有分數由真函式算。
+- [ ] **T3 source/純函式修正**：只在`paulsha_cortex/coordinator/planning.py`修改stability風險分量與算法識別常數；domain/state、acceptance_surfaces、orchestration、sizing band門檻、registry/schema/loader皆不改。不新增模型session或背景migration。
+- [ ] **T4 tests/傳播與歷史**：在`tests/test_wiring_claim_time_sizing.py`、`tests/test_wiring_retry_sizing_recompute.py`與registry/completion測試建立隔離新舊fixtures；驗新claim/reclaim/正式retry重算採新映射，舊run/frozen revisions/CompletionRecord/evidence在read/reload後bytes/hash不變；缺少舊algo來源不被回填。record只用tmp_path，禁止碰live狀態。
+- [ ] **T5 tests/邊界矩陣**：固定其餘四維，驗單模組與跨模組完整/缺漏/blocked、0..2每維、0..10總分、3/4與6/7 band邊界；缺/invalid domain/state在compute仍ValueError、current_sizing_snapshot仍(None,None)。新的低風險分不代表accepted/readiness gate被略過。
+- [ ] **T6 documentation/CLI help與smoke**：更新README/操作說明中的新舊計分辨識與明示重新評估限制；從checkout外用候選Python環境真跑`python3 -m paulsha_cortex.cli work start --help`、`run work --help`，以隔離fixture跑唯讀stat/sizing JSON smoke並驗退出碼。無新增CLI旗標仍記錄CLI help實跑，不能只mock字串，也不接live服務。
+- [ ] **T7 tests/CI及documentation/交付**：先跑本票兩份集中測試、`test_claim_sizing_band.py`、`test_wiring_claim_time_sizing.py`、`test_wiring_retry_sizing_recompute.py`、`test_registry_sizing_band.py`、`test_completion_sizing_band.py`，再full pytest、既有CI/pinned preflight與含PR上下文policy、git diff --check；新增並commit`changelog.d/sizing-stability-direction.md`並補`CHANGELOG.md [Unreleased]`。Cortex獨立review/exact-head交付後，記錄實際installed/runtime revision，再對#830重新計分；不修改其他active run。

--- a/openspec/changes/cortex-refine-complete/tasks.md
+++ b/openspec/changes/cortex-refine-complete/tasks.md
@@ -1,13 +1,13 @@
 ## 1. B0 進件與責任邊界
 
-- [ ] 1.1 收斂十四類 plan、domain glossary、OpenSpec 與 PatchMUD producer issue 連結，獨立審查零未處置 MAJOR。
-- [ ] 1.2 將 Claude 已完成的進件驗證與本輪缺失複核併回 canonical child todo；保留 #828 獨立 ownership。
-- [ ] 1.3 保存 operator dirty 原稿並對齊實際 builder base；核對 Monitor confirmed authority 後只啟動一條低風險 Cortex canary。
-- [ ] 1.4 進件 artifact-only commit/PR 經 preflight 與 CI；不關閉尚未實作的 issues。
+- [x] 1.1 收斂十四類 plan、domain glossary、OpenSpec 與 PatchMUD producer issue 連結，獨立審查零未處置 MAJOR。（#832）
+- [x] 1.2 將 Claude 已完成的進件驗證與本輪缺失複核併回 canonical child todo；保留 #828 獨立 ownership。（#832；operator原稿另存）
+- [x] 1.3 保存 operator dirty 原稿並對齊實際 builder base；核對 Monitor confirmed authority 後只啟動一條低風險 Cortex canary。（#822 run workflow-97a9aa661e4816e38964；不是canary完成）
+- [x] 1.4 進件 artifact-only commit/PR 經 preflight 與 CI；不關閉尚未實作的 issues。（#832 merge 60a3ffa8；#829仍OPEN）
 
 ## 2. B1 執行基礎
 
-- [ ] 2.0 補 #830 非 Job 決策回覆與 #831 sizing stability 方向；保留合理單模組 sizing 及所有 gate，另列 Red planner 分解接線的必要 child 範圍。
+- [ ] 2.0 補 #830 非 Job 決策回覆與 #831 sizing stability 方向；保留合理單模組 sizing 及所有 gate；#833 獨立交付 Red planner 分解接線。
 - [ ] 2.1 透過 Cortex 完成 #822 argv/YAML canary，取得 RED/GREEN、review、policy 與 terminal delivery 證據。
 - [ ] 2.2 完成 #827 有界 refresh/coalesce、slow-provider 公平與 stop/diagnostics。
 - [ ] 2.3 完成 #819 not-idle clock、periodic 有效 max_load/require_idle 與非法值處置。

--- a/reports/review/refine-bootstrap-intake-20260907.md
+++ b/reports/review/refine-bootstrap-intake-20260907.md
@@ -1,0 +1,149 @@
+# Refine bootstrap intake 驗證與 #223 接續缺口
+
+Runtime 與 issue 查證：2026-09-07 08:38 UTC；報告整理及檔案檢查隨後完成。此報告只交付 intake 文件，不宣稱產品缺陷已修、已派工或已部署。
+
+## 產物與邊界
+
+隔離分支 `feature/refine-bootstrap-intake-20260907`，基底 `79ba644780bf1c697c722ac24a297e7d02416100`。
+僅新增以下六件 accepted 規劃材料與本報告；未 commit/push、開 issue、改 code/tests、註冊 `.cortex` links、改其他 worktree、registry 或服務。
+
+- #831：`docs/superpowers/specs/sizing-stability-direction-{spec,design}.md`、`docs/superpowers/workstreams/sizing-stability-direction/todo.md`。
+- #830：`docs/superpowers/specs/dispatch-decision-contract-{spec,design}.md`、`docs/superpowers/workstreams/dispatch-decision-contract/todo.md`。
+
+#831 production 邊界僅 `paulsha_cortex/coordinator/planning.py` 的純計分與算法識別常數；caller、durable schema、loader、CAS 不改。歷史算法來源在說明/交付證據辨識，不引入 migration writer。若需越界，先重拆/重評。
+#830 至少涉及 manager/daemon 兩模組及持久化狀態回應一致性，故 domain=1/state=1，不能降成單模組小修。
+
+## 實跑結果
+
+使用現行 runtime checkout 的 Python 模組，從 checkout 外的暫存目錄執行；runtime HEAD 同上述基底。`git status` 唯一列出的既存修改是 `paulsha_cortex/scripts/service-manager.sh`，本次未讀其內容或改動，不能宣稱整個 runtime tree clean。
+實際 import 的 `coordinator/planning.py`、`manager.py` 等計分路徑沒有列為 dirty。
+
+| Work item | 三件組完整性 | 五維分數 domain/state/acceptance/stability/orchestration | Band | 純 Yellow gate |
+|---|---|---|---|---|
+| sizing-stability-direction | 三件均 accepted，無 missing kind/marker | 0 / 0 / 2 / 2 / 2 = 6 | Yellow | ready=true；三檢查皆執行 |
+| dispatch-decision-contract | 三件均 accepted，無 missing kind/marker | 1 / 1 / 2 / 2 / 2 = 8 | Red | 單獨函式檢查 ready=true；不代表 Red 可派工 |
+
+combo 為 packaged `fix-standard`：gate_spine_count=2、cards_count=9、persona_binding_count=9；適用規則使用 runtime 的完整 `ACCEPTANCE_SURFACE_RULES`：R-09/R-16/R-19。
+沒有改 combo、宣告數值或刪欄位迴避門檻。
+
+Yellow gate 的 completeness 與 contract_compatibility 通過；用真 `load_model_identities()` 加 `_plan_review_envelope_lookup` 讀取目前投影，envelope observation 是 `{"bypass":"envelope_unavailable"}`。
+這是可觀測的既有 bypass，不是已取得 measured builder 能力證據；lookup 使用純記憶體 run fixture，沒有執行 capability probe 或啟動模型。
+來源：`manager.py:9315`、`model_identities.py:1480`。正式 dispatch 仍須重新依真 run/identity/candidate 狀態裁決，不可拿本 report 當 runtime authority。
+
+實際 read-only CLI smoke（checkout 外、同一候選 Python/PYTHONPATH）各退出碼 0、stderr 空：
+
+```text
+python3 -m paulsha_cortex.cli work start --help
+python3 -m paulsha_cortex.cli run work --help
+```
+
+未執行 start、retry 或 stat 的 live 變更；未執行產品 full pytest、CI、含 PR 上下文 policy 或 installed-wheel smoke。上述是現況入口 smoke，候選修正交付時仍須重跑 todo 要求的 CLI/fixture/完整驗證。
+此 intake 範圍不允許新增 changelog 檔或 commit；產品 todo 已要求對應 fragment、CHANGELOG、policy、CI 與 exact-head 交付證據。
+
+doc-coauthoring 的 fresh-reader 檢查回 PASS，未報 BLOCKER/MAJOR；僅確認範圍、0/1/2 映射、歷史邊界、forced-retry fail-closed、所有列管 consumer 與 Red 後續重評可理解，不能替代產品測試。
+檔案檢查：六件內容 hash 全相符；逐檔 `git diff --no-index --check` 無 whitespace 診斷；`git status --porcelain --untracked-files=all` 恰好等於授權的七件新增檔案，沒有其他修改。
+
+## 重現純函式檢查
+
+以下等價 probe 以 `CORTEX_RUNTIME_ROOT` 指定現行 runtime checkout、`CORTEX_INTAKE_ROOT` 指定此 intake worktree；從 checkout 外執行。讀目前 identity 宣告但不寫任何 registry、不啟動模型。
+
+```bash
+PYTHONDONTWRITEBYTECODE=1 PYTHONPATH="$CORTEX_RUNTIME_ROOT" python3 - "$CORTEX_INTAKE_ROOT" <<'PY'
+import json
+import sys
+from dataclasses import asdict
+from pathlib import Path
+from types import SimpleNamespace
+from paulsha_cortex.coordinator import planning, manager
+from paulsha_cortex.coordinator.claim import sizing_band
+from paulsha_cortex.coordinator.model_identities import load_model_identities
+from paulsha_cortex.deck.schema import DEFAULT_CARDS_PATH, load_cards, load_combo, resolve_combo_path
+
+root = Path(sys.argv[1])
+cards = load_cards(DEFAULT_CARDS_PATH)
+combo = load_combo(resolve_combo_path('fix-standard'), cards)
+identities = load_model_identities()
+for slug in ('sizing-stability-direction', 'dispatch-decision-contract'):
+    refs = (
+        ('spec', f'docs/superpowers/specs/{slug}-spec.md'),
+        ('design', f'docs/superpowers/specs/{slug}-design.md'),
+        ('plan', f'docs/superpowers/workstreams/{slug}/todo.md'),
+    )
+    artifacts = tuple(planning.PlanningArtifact(k, r, (root / r).read_text()) for k, r in refs)
+    complete = planning.assess_planning_completeness(artifacts)
+    score = planning.compute_sizing_score(
+        plan_artifact=artifacts[-1], completeness_report=complete,
+        gate_spine_count=len(combo.gate_spine),
+        applicable_contract_rules=planning.ACCEPTANCE_SURFACE_RULES,
+        cards_count=len(combo.cards),
+        persona_binding_count=sum(cards[c.ref].persona_binding is not None for c in combo.cards),
+    )
+    band = sizing_band(score.total)
+    run = SimpleNamespace(steps=(), primary_domain=None, model_chain_override=None,
+                          sizing_band=band, run_id='read-only-intake-check')
+    gate = manager._evaluate_yellow_plan_review(
+        artifacts, envelope_lookup=manager._plan_review_envelope_lookup(run, identities))
+    print(json.dumps({'work_item': slug, 'complete': complete.complete,
+                     'score': asdict(score), 'total': score.total, 'band': band,
+                     'yellow_gate': asdict(gate) if gate else None}, sort_keys=True))
+PY
+```
+
+## #223：已實作路由，不等於已接上自動拆分
+
+GitHub 只讀核對：[原 #223](https://github.com/hamanpaul/paulsha-cortex/issues/223) 是 CLOSED，但 body 的「Red 自動回派 planner 拆分」驗收仍列未勾選。
+08:38 UTC 核對 [#830](https://github.com/hamanpaul/paulsha-cortex/issues/830)、[#831](https://github.com/hamanpaul/paulsha-cortex/issues/831) 都 OPEN；兩者明文排除自動拆分修復。
+以 open issues、limit=200 的 body 搜尋 `needs_decomposition|#223|Red.{0,40}planner|planner.{0,40}拆|自動.{0,15}拆分`，命中只有 #830/#831，未找到可直接承接的專票。這是該時間點/查詢範圍的佐證，不是「不存在任何其他 issue」的全稱證明；請 root 建 successor 前再次查重。
+
+以下 source/test 行號都對上述 runtime 基底：
+
+1. `coordinator/manager.py:9481` 在最後一個完整 plan step 檢查 Red；`:9494` 進拆分分支，`:9502` 呼叫純 `decomposition_route`，`:9508` 更新 facet，`:9529` 直接 return 無 job_id 決策。這條明確執行路徑沒有建立 planner Job，不能把它描述為「planner 已在跑，只需等待」。
+2. `coordinator/work_bridge.py:568` 投影 facet 為 `needs_decomposition`；`coordinator/claim.py:1390` 的 active claim 分支只回 action/reason，`:1400` 是 `next_actions=()`，不走 ordinary resume。
+3. `coordinator/claim.py:1524` 上限 2；`:1527` 的 `decomposition_route` 只選 needs_decomposition/needs_human，沒有 child lineage 或工作生成。
+4. `tests/test_dispatch_needs_decomposition_223.py:94` 的 Red 測試使用 must-not-launch，`:108` 只斷言決策與 facet，`:116` 明定 jobs=[]；`:119` 驗深度 2，`:136` 驗重複 dispatch 仍停 plan。
+5. `tests/test_claim_needs_decomposition_223.py:108`、`:117` 驗 manual/auto claim 浮現拆分而不 resume；沒有 planner 回傳子工作後的端到端接續證據。
+6. bounded `rg` 掃 coordinator/control/deck 的 `decomposition_depth` 與 `decomposition_route(`，目前只找到 schema/registry 欄位、序列化、CLI 統計、上述路由。這份清冊是當下佐證；真正「不漏接續」必須由 successor 的 runtime invariant/integration tests 守護。
+
+### 建議 successor 最小接續契約（尚未實作）
+
+- Parent 保持 plan/needs_decomposition，專用 decomposition generation 以 parent run + exact source authority 做 CAS/idempotency key；不可將它當原 builder 的 resume 或把等待判成 done。
+- 明確且可持久恢復的 planner decomposition Job；身份須通過 planner 的真 capability/independence/資格規則，禁止為 Red 偷用 builder 或假 envelope。planner 429、重播或 crash 不得重複發 Job/子工作。
+- Planner 輸出 bounded child proposals，逐件具有獨立 scope、requirements、testability、task、真實 sizing 宣告、parent lineage/depth+1；manager 做結構、重疊、權威與深度檢查，不能只相信自然語言「已拆」。
+- 子工作必須經正式受治理 intake/claim，保留 exact accepted revisions；parent issue authority 與子 issue/工作 ownership 的映射需在設計中明定，不得讓多 child 共用同一 claim key 衝突。若需新 GitHub 寫入，必須由已授權的正式動作處理，不由未審核 planner 任意發送。
+- 深度已達 2，或 proposal 無法合法接納時 fail-closed，提供具體 needs_human/replan 理由；parent 完成需等待子工作正式 terminal 證據及 parent closure，不以建立子工作代替完成。
+- RED/GREEN integration 至少驗 Red→planner→validated proposals→正式 child admission、depth 0/1/2、duplicate delivery、partial crash/restart、429 recovery、權威 stale、child scope overlap、parent closure；所有測試使用隔離 fixture，實際 canary 另留證據。
+
+此契約可能需要真實多子項拆分，不能在沒有量測前猜成 Yellow。新 CLI/registry schema 是否必要、正式 child admission 動作名稱、單一或多 successor 的最小可交付切點皆未證實，應由 root 的新票設計裁決。
+
+## 接手次序
+
+1. Root 將 #831 intake 依正式來源/link/freshness 規則納管後，由 Cortex 派工；本報告不建立或釋放 authority。
+2. #831 修正經 tests/review/CI/exact-head/runtime 交付後，使用該實際 runtime 對 #830 原始 scope 重新計分。
+3. #830 若仍 Red，先拆出有獨立驗收的子工作；不得直接把目前 8/red 整包派進 build。純 Yellow gate 單獨 ready 不覆蓋 band 路由。
+4. #223 successor 由 root 查重開票；#830 只保住合法非 Job 的結果契約，不聲稱補上 planner 接續。
+
+## 受測文件 SHA-256
+
+```text
+3658370c6d1002711f6e797681dbff1acef9d79ae21d6ad88e11c5986674a710  docs/superpowers/specs/dispatch-decision-contract-spec.md
+dd1f091f9fbf15b025741ed05030e09cd5418dd4ced6ab7d6c8b5bd4ec654857  docs/superpowers/specs/dispatch-decision-contract-design.md
+5ec7b4f5990a750233acd520bfd8e3da932d7de61696adb556ce0f176bc3acb6  docs/superpowers/workstreams/dispatch-decision-contract/todo.md
+7a6661453d2aef10a2e9799e3e5d516595243716a50332e7a756ef2dc4aa505b  docs/superpowers/specs/sizing-stability-direction-spec.md
+2576596be86e30dce70669973051d3d49d02e4cfd5c4c7c76945e4651d3fa193  docs/superpowers/specs/sizing-stability-direction-design.md
+10c1db60a64cee927ee09273c52ece6f076683ffaac3717937d080e1c5126ed5  docs/superpowers/workstreams/sizing-stability-direction/todo.md
+```
+
+這些是本次 intake 內容雜湊，不是手造 runtime gate evidence；後續若材料變更需重新計算並重跑驗證。
+
+## 主流程整合與獨立複核
+
+作者子任務完成後，主流程將本分支以ff-only推進至#832 merge
+`60a3ffa867377b0c86fa2f10e91fb9820d91938c`，保留六件規劃bytes不變；補正式
+work_id links、changelog、B0真實完成證據與後續動態進件地圖。#223接續專票已另建#833。
+
+獨立reviewer再次讀完整bootstrap diff並重跑純gate，結果PASS、無未處置
+BLOCKER/MAJOR；#831仍6/Yellow、#830仍8/Red，envelope unavailable仍明示。
+Root亦獨立重跑同一純函式取得一致結果。B0只對應規劃交付，非產品完成；
+凍結歷史、#828 ownership、PatchMUD pricing與未量測資格邊界均未放寬。
+本地policy-only gate PASS；產品full tests／commit-aware preflight仍由主流程另跑，
+不能把這次純gate結果代為填入。

--- a/reports/review/refine-bootstrap-intake-20260907.md
+++ b/reports/review/refine-bootstrap-intake-20260907.md
@@ -5,7 +5,7 @@ Runtime 與 issue 查證：2026-09-07 08:38 UTC；報告整理及檔案檢查隨
 ## 產物與邊界
 
 隔離分支 `feature/refine-bootstrap-intake-20260907`，基底 `79ba644780bf1c697c722ac24a297e7d02416100`。
-僅新增以下六件 accepted 規劃材料與本報告；未 commit/push、開 issue、改 code/tests、註冊 `.cortex` links、改其他 worktree、registry 或服務。
+隔離查證當下僅新增以下六件 accepted 規劃材料與本報告，尚未 commit/push，亦未開 issue、改 code/tests、註冊 `.cortex` links、改其他 worktree、registry 或服務；後續 root 整合與提交另列於本報告末節。
 
 - #831：`docs/superpowers/specs/sizing-stability-direction-{spec,design}.md`、`docs/superpowers/workstreams/sizing-stability-direction/todo.md`。
 - #830：`docs/superpowers/specs/dispatch-decision-contract-{spec,design}.md`、`docs/superpowers/workstreams/dispatch-decision-contract/todo.md`。

--- a/reports/review/refine-dynamic-intake-map-20260907.md
+++ b/reports/review/refine-dynamic-intake-map-20260907.md
@@ -1,0 +1,152 @@
+# B2–B5 動態派工進件對照（2026-09-07）
+
+本檔是唯讀查證後的規劃建議，不是 accepted todo、註冊資料或實作證據。未執行模型探測、
+評測、產品測試、部署、服務重啟或 GitHub 寫入。產品實作仍須由 Cortex 正式進件執行。
+
+## 查證基線與結論
+
+- 原始碼基線：`79ba644780bf1c697c722ac24a297e7d02416100`；同時讀取整合 worktree
+  的 `docs/superpowers/plans/2026-09-07-cortex-refine-complete.md` B2–B5、R05/R08/R09
+  及 `docs/superpowers/specs/2026-09-07-cortex-execution-domain.md`。取樣時主 agent
+  尚在整理計畫；後續已由 #832 合併。本文行號仍是原查證快照，不代表 installed runtime。
+- GitHub 狀態為本次 `gh issue view`／issue list 唯讀結果；搜尋不是全稱性的無重複證明，
+  正式註冊前仍須用 exact work_id／issue 再查 authority。下列新 ID 均只是建議，尚無新 issue。
+- 既有能力可沿用：用量擷取、終局 outcome、分層候選排序、runtime preflight、spawn 間隔節流、
+  PatchMUD CLI／envelope mapping、Trust Root 安裝 attestation。缺口是把這些組成
+  **profile 可追、資格核可、額度有來源、預估有不確定性、並行保留、派前准入**的生產鏈。
+- 最多 10 個進件單位如下；這是最小責任切面，不保證每單都符合 Green／Yellow。
+  由 Cortex 真實 sizing 決定是否再拆，不能降低分數或刪去必要驗收以便啟動。
+- B5 已有獨立 issue 的 instance／installer／restart 缺陷保留原所有權，列為既有依賴，
+  不暗中塞進這 10 單，也不能因這 10 單完成就宣稱 B5 或整個 plan 已完成。
+
+## 既有工作應重用，不能被過時文字帶回重做
+
+| 既有項目 | 本次對帳與處置 |
+|---|---|
+| [#137](https://github.com/hamanpaul/paulsha-cortex/issues/137)、[#138](https://github.com/hamanpaul/paulsha-cortex/issues/138)、[#210](https://github.com/hamanpaul/paulsha-cortex/issues/210) | CLOSED 設計票；不重開為實作票。`model_identities.py:1656` 的 track-record-not-landed 註記仍是局部缺口，但不能推論「完全沒有 outcome」。後續實作以 #829 child 交付。 |
+| [#325](https://github.com/hamanpaul/paulsha-cortex/issues/325) | CLOSED；`usage_extractors.py:205`、`registry.py:1384` 已擷取並持久化 job usage。沿用原生 missing／unsupported 語意，不新增另一套 token parser。 |
+| [#205](https://github.com/hamanpaul/paulsha-cortex/issues/205)、[#534](https://github.com/hamanpaul/paulsha-cortex/issues/534) | 前者 CLOSED；後者 OPEN，但 `model_resolution.py:844,882` 已有 overlay／evaluated／packaged 分層排序。新選擇不得抹掉 per-work explicit pin、凍結集及既有 provenance；#534 需證據化收口而非重建全部排序。 |
+| [#452](https://github.com/hamanpaul/paulsha-cortex/issues/452)、[#454](https://github.com/hamanpaul/paulsha-cortex/issues/454)、[#466](https://github.com/hamanpaul/paulsha-cortex/issues/466) | CLOSED；沿用 CLI／report 持久化／純 mapping／缺值 default。新補 execution-profile qualification，不把未測欄位升為測量通過。 |
+| [#262](https://github.com/hamanpaul/paulsha-cortex/issues/262)、[#381](https://github.com/hamanpaul/paulsha-cortex/issues/381) | CLOSED；`_runtime_preflight_gate` 與 `SpawnAdmissionLimiter` 已存在。後者只是 per-provider spawn 間隔，不是 shared quota reservation，也不是執行期全序列化。 |
+| [#483](https://github.com/hamanpaul/paulsha-cortex/issues/483) | OPEN，但 `launcher.py:1072` 已有特定型號 effort override。原票先做窄範圍驗收；一般化 descriptor／adapter 契約另屬 D1，不能擴原票 scope。 |
+| [#581](https://github.com/hamanpaul/paulsha-cortex/issues/581)、[#600](https://github.com/hamanpaul/paulsha-cortex/issues/600) | OPEN，可直接重用下列 D2／D3；不要新開同義 producer／availability 票。 |
+| [#490](https://github.com/hamanpaul/paulsha-cortex/issues/490) | OPEN，原 scope 是 retry-review 讀取 packaged+overlay 一致性。保留為相鄰回歸／既有票驗收，不把全域動態配置塞入此票。 |
+| [#830](https://github.com/hamanpaul/paulsha-cortex/issues/830) | OPEN，合法非 Job 派工決策的消費契約；D7 可依賴其結果。原票明確排除 quota／fallback，不擴 scope。 |
+
+`docs/superpowers/workstreams/cost-governance-cluster/todo.md`、舊
+`docs/superpowers/plans/cost-governance-judge.md` 仍含過時 issue state、舊固定 roster、
+`capable()` 未落地及四因子恆真 stub 等歷史描述；`dispatch-runtime-preflight/todo.md`
+也仍未勾且記載舊固定路由。它們只能作歷史設計來源，不能覆蓋新版 #829 的資格與 unknown
+契約。這次不改它們；root 整理權威時應標註 successor／歷史狀態，不重派已交付設計。
+
+## 建議 child 邊界（最多 10 個）
+
+表中 coordinator 檔名皆位於 `paulsha_cortex/coordinator/`；其他位置明列。
+
+| ID／建議 work_id／issue | 最小範圍與 production 入口 | 驗收邊界、最小 fixture |
+|---|---|---|
+| D1 `execution-profile-contract`；#829 新 child | R08／B2。版本化 execution-profile、descriptor、角色需求與 adapter conformance；requested／resolved／observed 分開。`model_resolution.py:151,311,422` 相容性及 launcher contract；`launcher.py:797,1072,1341,1912` 的 effort／builder seam。此單擁有 profile key／canonical fingerprint 契約，D2 擁有 qualification 消費。 | 既有協定加入虛構 model+effort 僅需 descriptor；新協定允許新增 adapter，但不改 central resolver／quota／workflow 的產品分支。fake adapter 驗 unsupported 在 spawn 前拒絕、權限不得提升、工具／sandbox／terminal／usage conformance。舊 manifest migration、explicit pin 不變；未知角色不默認 build 的切換與 D2 同步。 |
+| D2 `evaluated-roster-producer`；重用 #581，註冊前核 exact work_id | R08/R09／B2。限定原票五項：doctor 不硬要求單一 planning identity、unknown persona fail-loud、provenance 到 launcher、doctor 用公開 overlay API、評測 producer 接 evaluated roster。`model_profile.py:146,260,329`；`model_resolution.py:476,497,500,569`；`model_resolution.py:96`；`doctor.py:434,444`。D1 提供 profile schema。 | 版本化 report→qualification candidate→human review receipt→approved roster；未核可不得自動授權。fake report 覆蓋 effort／loadout／adapter 變更不能偷用舊評分、role coverage 缺漏保持 unknown；舊格式可讀但不自動升格。真正跨 repo 驗收需 PatchMUD #37 immutable fixture；完整角色覆蓋另依 #13。 |
+| D3 `model-availability-preflight`；重用 #600，註冊前核 exact work_id | R09／B2→B3。沿用 `model_identities.py:688` CapabilityProbe、`manager.py:8466` runtime preflight；增加 profile-aware availability 快取、TTL、原因與 doctor 顯示。只回答「目前能否使用」，不授予品質資格或臆測餘額。 | fake clock／fake adapter 測 available、unavailable、unknown、expired、reset 後重探；doctor 與 dispatch 使用同一觀測。熱路徑不能重跑 PatchMUD 或付費推論探測；TTL 過期不無聲沿用成功。 |
+| D4 `quota-observation-provenance`；#829 新 child | R05／B3。pool/account 非機敏 ID、profile 對多 pool/window 的映射、原生 unit、bounds、reset、TTL、authority、來源／缺值原因；涵蓋受管控制器／worker／review 與可讀的外部 session。接 `usage_extractors.py:205`、`registry.py:1384` 作 usage 證據，而非把 usage 當 remaining API；adapter 的 quota 能力入口由 D1 提供。 | fake provider 狀態檔／事件：短窗足夠但週窗不足、同池不同 model、不同單位、stale／損毀／missing；unknown 不變零或無限。tokens／request／credits 不任意互換；外部 host／session 無法讀取時保留 coverage gap 與安全 headroom。只做 shadow，不改排序。 |
+| D5 `operational-usage-forecast`；#829 新 child，引用已關閉 #137/#138/#325 | R05/R06/R09／B3。在既有使用量與終局 outcome 上建立 attempt/profile/task-cohort 歸屬、成功品質與 infra 原因分層聚合，輸出可版本化的需求範圍、分位數、樣本數、信心及資料期間；不實作泛用 lesson-loop／RL。`engineering_outcome.py:123,157,199,221,418,527`；`work_actions.py:3384,5383` 終局 emitter。現有 job projection 沒有完整 profile/cohort，弱時間關聯不可當精確歸屬。 | fixture 含 planning/build/review、retry、固定 overhead、失敗已消耗、累計／增量及 reasoning subset；同事件 replay 不重計、重啟不歸零、infra failure 不降品質分。冷啟動／分布偏移輸出 unknown 或有來源的保守先驗，不能用零。先離線回測及 shadow 校準，PatchMUD prior 可缺省，不是唯一來源。 |
+| D6 `shared-quota-reservation`；#829 新 child | R05/R12／B4。共享 account/pool 有唯一 reservation authority；一個候選涉及的全部 pool 原子預留，job/attempt 綁定、consume／release／uncertain、crash/restart reconciliation。沿用 registry job lifecycle seam，但不把 #818 的 jobs.json writer lock 冒充跨 quota authority。`registry.py:1384` terminal usage 是 reconcile 輸入之一。 | 兩 process barrier 同讀一單位，僅一個成功；多 pool 任一失敗全回滾；spawn 前後 crash、重複 terminal、clock reset。lease 到期但 job 仍活不能釋放；無法確認 liveness 則 uncertain 並拒絕超額預留。跨 instance 同 pool 同 authority，不以 model/executor 名稱分裂帳號。 |
+| D7 `quota-aware-admission`；#829 新 child | R05/R07/R08／B4。在 `manager.py:8219,8285` 選擇及 `manager.py:9381,10006` 實際 spawn 之前、`autonomy.py:602` fanout 同步接線：資格／權限／獨立性／pin 硬濾→可用與需求範圍→可行集依既有分層排序→所選候選全部 pool 原子預留→決策 receipt；競爭落敗須重算，不先替每個候選扣額度。沿用 #825 最小退避、#826 原因分類、#497 generation、#830 非 Job 契約與 #381 spawn 間隔。 | 有獨立池合格候選才 fallback；同池換型號不算恢復；唯一合格 reviewer 同 domain 時等待。fake executor 注入派前可用、spawn 時 429／外部消耗，保留消耗與校準訊號；僅安全 attempt 邊界重選、不搬動執行中的 job。policy rollback 不丟 reservation／usage／decision。全不合格回合法等待及理由，不造 job_id。 |
+| D8 `decision-status-projection`；#829 新 child | R10／B5。消費 D7 的不可變 decision receipt、等待／恢復原因、候選排除理由、有效 policy/config 與 freshness／needs_human；所有 section 同一 read model。接 `monitor/work_snapshot.py:36,188` 及 #828 producer；不得在 read model 修 workflow，也不另造 #828 的 actual/planned/last identity。 | fixture 綁 run/card/attempt/decision，顯示分別為 confirmed／estimated／unknown；等待與 Job 明確不同，needs_human 不消失，stale last-good 不偽裝現在值。消費 #828 immutable fixture 驗 retry、多卡、跨 repo；讀取前後 registry 不變。 |
+| D9 `workflow-execution-identity-producer`；重用 #828，保留現有 owner | R10／B5。只做原 issue 的 actual executor/model/job/card/source/status 與 planned/last 分離。此 work 已有獨立現場所有權；不重派、不接收 D7/整份 R10 擴張，也不為本圖重啟其 manager。 | 沿用原票的 current-card in-flight→same-card last→unknown 規則；多卡／retry／跨 repo／未派工 fixture。下游 paulshaclaw #328 只按 upstream immutable merge SHA／fixture 驗收；issue open、程式已改、merged、consumer pass 各別記帳。 |
+| D10 `loaded-runtime-attestation`；#829 新 child | R11／B5。報告正在執行的 CLI／service artifact、載入 revision、有效 config revision、instance/root identity 與 source-override receipt；重用 Trust Root installed inventory／activate／rollback receipt，不重造安裝器。入口 `trust_root/install/core.py:5950,6173,6268`、`trust_root/install/backend.py:1693`、`doctor.py:751,1129`、`deploy/installer.py:363`。 | 隔離 prefix 安裝、從 checkout 外執行 CLI；假服務／受控短生命週期 service 驗 disk 新 artifact≠舊 process 已載入、改 config 也有 revision 差異、rollback 可追。真正服務 fixture 必須另經部署 gate；本單不授權重啟 active manager，不包含 #800 配置重寫或 #582 drain 的修復。 |
+
+## 最小依賴 DAG 與 owner
+
+箭頭是 production 接線前置，不表示等待前置後才能寫 fake fixture。D1 契約先凍結，
+D2/D3/D4 可並行；D5 可先沿既有 usage/outcome 做隔離 fixture，再依 D4 的 unit/authority
+契約對接。D6 可在 D4 schema 穩定後以假需求獨立實作，不必等待預估器訓練資料。
+
+```text
+D1 ─┬→ D2 ───────────────────┐
+    ├→ D3 ───────────────────┤
+    └→ D4 ─┬→ D5 ────────────┤
+           └→ D6 ────────────┼→ D7 ──┐
+已交付 P1／#497／#830 契約 ────┘       ├→ D8
+D9（#828，獨立現有 owner）──────────────┘
+D10（可獨立準備）──────────────→ B5 installed/live gate
+```
+
+- shared files 要序列整合：D1→D2/D3 的 `model_resolution`／launcher 契約；D4/D5/D6
+  的 registry 欄位以 additive schema 管理；D7 最後接 Manager/fanout，不能三線同改派工權威。
+- reservation authority 是額度狀態的唯一寫入者；Manager 是 workflow 與 attempt 的寫入者；
+  adapter 產觀測／執行結果；forecast 是可重建投影；Monitor 僅讀；human receipt 才核可資格。
+- 設計上的 reservation 狀態至少能區分預留、已綁 job、已結算／釋放及 uncertain；
+  transition 必須可重送、可恢復，不能靠 TTL 或 process 名稱猜測終局。
+- 切換 policy 只影響新決策；既有 attempt/decision/profile/fingerprint 不原地改寫。
+
+## B5 既有依賴：保留原票，不另建同義 child
+
+| 既有 issue | 在 DAG 的位置與可驗證邊界 |
+|---|---|
+| [#818](https://github.com/hamanpaul/paulsha-cortex/issues/818) OPEN | 多 Manager live gate 前需 canonical jobs.json single-writer 或跨 process serialization/CAS；兩 process stale snapshot mutation 都保留或明確 conflict。D6 的 quota authority 不能代替它，它也不能代替 D6。 |
+| [#800](https://github.com/hamanpaul/paulsha-cortex/issues/800) OPEN | D10 真安裝／B5 部署前處理原票配置保留、root 隔離與 builder 不寫 operator config。`deploy/installer.py:291,302,345` 仍有 migration 重建配置入口；只把 artifact revision 報對不等於不再覆寫配置。 |
+| [#582](https://github.com/hamanpaul/paulsha-cortex/issues/582) OPEN | 任何 active-job upgrade/restart 驗收前，原票須證明 drain／明確 abort 或可恢復的 manager broker 生命週期。#823 session isolation 不等於 systemd cgroup 隔離或 manager RPC 連線存活。 |
+| [#476](https://github.com/hamanpaul/paulsha-cortex/issues/476) OPEN | fresh-instance project config scaffold 或 fail-fast、manager/monitor 均可診斷；當前 installer 已有 scaffold 路徑，需重驗原 repro，不能重造後再撞 #800。 |
+| [#548](https://github.com/hamanpaul/paulsha-cortex/issues/548) OPEN | `doctor.py:751` 已依有序 EnvironmentFiles 合成 effective env，`run_doctor:1129` 已消費；不能再宣稱 source 一律只看 operator shell。原票重驗 service 環境一致性；這不證明正在跑的 process 載入哪個 artifact。 |
+| [#695](https://github.com/hamanpaul/paulsha-cortex/issues/695) CLOSED | generated installed assets attestation 可沿用。`trust_root/install/backend.py:1236,1290,1814` 已提供 process＋durable job 的 in-flight facts；新部署 gate 應消費它，不另寫寬鬆「沒有 active job」判定。 |
+
+以上是既有依賴清單，不是額外 6 個新進件提案。若任何必要依賴尚未獲有效驗收，
+B5/whole-plan ledger 應保持 pending／blocked-by-具體項目，不能以文件收斂視為完成。
+
+## PatchMUD #37 的精確外部位置
+
+[PatchMUD #37](https://github.com/hamanpaul/paulsha-patchmud/issues/37) 已開且 OPEN，
+Cortex 不承包其產品碼，也不把本次授權延伸成付費 benchmark campaign。
+
+1. **D1/D2 契約依賴**：producer 的 requested/resolved/observed execution-profile、native
+   effort、adapter/loadout/toolchain version、canonical fingerprint 與版本化 CLI/file schema。
+   Cortex 以自己的 qualification 契約消費；維持零 PatchMUD runtime import。
+2. **D2 真整合 gate**：先用固定 fake/golden report 開發 importer；真正
+   report→candidate→human receipt→approved roster→實際派工，須等 #37 可追的 schema／
+   immutable fixture 與 producer revision。未回報 observed effort 可以是 unknown，不能
+   當 requested effort 的實測；不自動放寬最低品質或任意批准。
+3. **D5 可選先驗**：#37 的 observed/estimated/unknown usage、unit、來源、累計/增量及
+   failure consumption。可先用 Cortex 實務資料校準，不必讓全部 B3 等 benchmark；
+   但聲稱「PatchMUD 冷啟動先驗已接通」必須取得真正契約 fixture。
+4. **不是 #37 自動解決的項目**：完整角色 deck 是 PatchMUD #13，難度分布是 #21，
+   agent-native end-to-end 是 #12；各自保持 coverage unknown／有界依賴。價格快照只影響
+   cost report，不進入 capability fingerprint；同模型不同 effort 不合併成同一實測資格。
+
+## 最小測試矩陣與執行順序
+
+下列全為待實作／待執行案例，沒有 PASS 宣稱。沿用 pytest、tmp_path、fake runner，
+clock／Event／barrier 控制時序；不以大量 sleep 或真實 provider 呼叫製造回歸。
+
+| 風險／owner | 觸發與 harness | 必須斷言的 oracle／層 |
+|---|---|---|
+| 配置擴充 D1 | 虛構 profile、新原生 effort、fake adapter | 舊 adapter 新 descriptor 不改 central resolver；unsupported 零 spawn；contract/unit。 |
+| 誤授權 D2 | 修改 effort/adapter、缺 role coverage、無 review receipt | 舊 qualification 不匹配、unknown 不變合格；contract。 |
+| 過時探活 D3 | fake clock 越 TTL、adapter 不可用或回 unknown | 精確 status/reason，不假裝 available；unit/component。 |
+| 額度誤判 D4 | 同池不同型號、短窗足夠/週窗不足、unknown/損毀、混合 unit | 每個約束均滿足才可確認；未知保留來源與 gap；contract。 |
+| 用量重計 D5 | fail+retry、cumulative+delta、reasoning subset、replay/restart | 已消耗不消失、不重計；quality/infra 分開、forecast version 可追；unit/durability。 |
+| 競爭超額 D6 | 兩 process barrier 共一份 state，多 pool 中途失敗 | 僅一份 grant，all-or-none；兩 instance 同 pool 共 authority；integration。 |
+| 孤兒預留 D6 | spawn 前後 crash、lease 過期但 fake job 活著 | 不重複 grant；存活／uncertain 不釋放，終局結算冪等；recovery。 |
+| 錯誤 fallback D7 | 耗盡原 pool；另一同池及另一獨立池候選 | 同池拒絕、獨立池合格才選；pin/independence 優先；component。 |
+| 無安全候選 D7 | 唯一 reviewer 與 builder 同 domain | 零 spawn，合法等待 reason，#830 consumer 不讀假 job_id；integration。 |
+| 預估落空 D7 | 預留後 fake provider 回 429、外部消耗提高 | 記錄消耗/退避/reset，安全 attempt 邊界再選，不污染品質；recovery。 |
+| 狀態冒充 D8/D9 | 多卡/retry/跨 repo、stale snapshot、needs_human | actual/planned/last/decision 不混用、精確 key、read 不改 registry；contract/integration。 |
+| 部署冒充 D10 | 隔離安裝後 disk 更新但舊服務 process 存活 | loaded revision≠disk revision 可見；checkout 外 CLI、source override、rollback receipt；installed E2E。 |
+
+執行順序：先 deterministic unit/contract，再 crash/recovery、barrier concurrency，
+再 bounded stress（跨多次觀測／重啟，檢查 ledger 不重計且持久化大小有治理），最後隔離
+installed E2E 與經核可的 live canary。真正 provider 的可用介面與 quota 單位應在 adapter
+實作時另查官方當時契約；這次未驗證各家是否有 remaining API。
+
+可重用的已存在測試入口（命令列僅建議，**本次未執行**）：
+
+```bash
+python3 -m pytest tests/test_model_resolution_chain_534.py tests/test_per_work_model_chain.py tests/test_model_identities.py tests/test_model_identities_envelope_v3.py tests/test_model_profile_cli.py
+python3 -m pytest tests/test_coordinator_usage_extractors.py tests/test_engineering_outcome.py tests/test_coordinator_launcher.py
+python3 -m pytest tests/test_stage9_project_monitor_service.py
+python3 -m pytest
+```
+
+新測試檔名由各 Cortex child 實作時定案；不得把上列既有測試名當成已涵蓋所有新矩陣。
+root 整合時還需做 PR-context policy、文件／schema／fixture 對齊，並個別記錄
+implemented、tests passed、merged、installed、live accepted；完整文件不是其中任何一項的替代品。


### PR DESCRIPTION
## 摘要

接續已合併 #832 的完整精修規劃，補 #831 stability 方向與 #830 非 Job 派工結果的 accepted 三件組與正式 work_id links；#833 獨立追蹤 Red planner 接續。

本 PR 只有規劃與註冊，不修改產品 code、runtime、model overlay 或 live registry。#829 全計畫仍未完成。

## 範圍與邊界

- #831 只改 planning 純函式的預定實作邊界；目前真實 sizing 6/Yellow，未啟動本票 builder。
- #830 保留真實 8/Red，待 #831 修正版 runtime 後再評；純 Yellow helper ready 不覆蓋 Red gate。
- 歷史 run／frozen source／evidence 不自動重寫；無模型 qualification 的 envelope bypass 明確列管，不當成評測成功。
- B0 完成 checkbox 僅對應 #832 的規劃交付證據；B1–B6 產品工作仍未勾完成。
- B2–B5 map 是待拆分與查重的規劃建議，不是另一份 accepted work authority；保留 #828 及既有 issue 的原 scope。
- 使用 `policy-exempt:issue-link`：本 PR 為進件，不關閉尚未實作的 #830／#831／#829。

## 檢查清單

- [x] scope、非目標、依賴與必要驗收已列明。
- [x] 純 runtime completeness/sizing/Yellow gate已實跑，未調低真實分數。
- [x] CLI help smoke exit 0；產品修正後仍需重跑。
- [x] 新增 changelog fragment 與 Unreleased 記錄。
- [x] 未修改凍結 #822 規劃、產品程式或其他工作所有權。

## 驗證

作者 fresh-reader、root純函式複核及最終獨立review均PASS；umbrella strict OpenSpec、diff whitespace與policy-only gate通過。
commit `80c868b910375857746860e44a3c200d14cb3efa` 後完整preflight的policy、OpenSpec與全套tests均PASS（tests205.23秒）；遠端CI另驗，不以本地結果冒充部署。
