### PR TITLE
docs(refine): 納管 P1 runtime 契約與後續子票責任

### DIFF
--- a/.cortex/work-items.yaml
+++ b/.cortex/work-items.yaml
@@ -791,6 +791,10 @@ work_items:
         ref: 'hamanpaul/paulsha-cortex#819'
       - kind: path
         ref: 'docs/superpowers/workstreams/daemon-tick-clock-not-idle/todo.md'
+      - kind: path
+        ref: 'docs/superpowers/specs/daemon-tick-clock-not-idle-spec.md'
+      - kind: path
+        ref: 'docs/superpowers/specs/daemon-tick-clock-not-idle-design.md'
     excludes: []
   registry-persist-hygiene:
     title: 'registry-persist-hygiene'
@@ -807,6 +811,10 @@ work_items:
         ref: 'hamanpaul/paulsha-cortex#825'
       - kind: path
         ref: 'docs/superpowers/workstreams/executor-durable-backoff/todo.md'
+      - kind: path
+        ref: 'docs/superpowers/specs/executor-durable-backoff-spec.md'
+      - kind: path
+        ref: 'docs/superpowers/specs/executor-durable-backoff-design.md'
     excludes: []
   outcome-taxonomy-signals:
     title: 'outcome-taxonomy-signals'
@@ -845,6 +853,10 @@ work_items:
         ref: 'hamanpaul/paulsha-cortex#827'
       - kind: path
         ref: 'docs/superpowers/workstreams/monitor-refresh-thread-backlog/todo.md'
+      - kind: path
+        ref: 'docs/superpowers/specs/monitor-refresh-thread-backlog-spec.md'
+      - kind: path
+        ref: 'docs/superpowers/specs/monitor-refresh-thread-backlog-design.md'
     excludes: []
   sizing-stability-direction:
     title: 'sizing-stability-direction'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
 
 ## [Unreleased]
 
+- **Refine P1 runtime 進件**：補 #819/#825/#827 accepted spec/design、保留全部
+  原驗收並列真實 Red sizing／人工拆分；補限流事件亂序、寫入故障與到期去重負例。
+  將 #835–#845 的 profile、quota、資格、recovery 與交付責任納入總帳；
+  此項為規劃交付，不代表任何產品修正或 runtime gate 已完成。
+
 - **Refine bootstrap 進件**：補 #831 stability 風險方向與 #830 非 Job 派工決策的
   accepted 三件組、真實 sizing 與純 gate 驗證；#833 獨立列管 Red planner 接續。
   記錄 #832 規劃合併及 B2–B5 既有能力／待補 child 對照，不宣稱產品修正已交付。

--- a/changelog.d/refine-p1-runtime-intake-20260907.md
+++ b/changelog.d/refine-p1-runtime-intake-20260907.md
@@ -1,0 +1,6 @@
+# Refine P1 runtime 規劃與後續責任對齊
+
+- 納管 #819/#825/#827 accepted 三件組、真實 sizing 與必要人工拆分。
+- 補同 identity 限流終局亂序、原子寫入故障、到期後去重與跨 phase admission 驗收。
+- 更新 #829 後續 profile/quota/qualification/recovery/delivery child owners 與 canary 狀態。
+- 本批只有進件／文件，不修改產品碼，不提前關閉實作工單或宣稱已部署。

--- a/docs/superpowers/plans/2026-09-07-cortex-refine-complete.md
+++ b/docs/superpowers/plans/2026-09-07-cortex-refine-complete.md
@@ -187,8 +187,8 @@ B1 的主要目標是讓 Cortex 能可靠承接後續工作。B2–B4 完成後�
 | 批次 | 狀態 | 證據／下一動作 |
 |---|---|---|
 | B0 | complete | #832 規劃／進件已合併；review、PR-context preflight、CI通過，原稿及其他工作所有權保留。不是產品修正完成。 |
-| B1 | in-progress | #820 已合併基底；#822 第三run的隔離卡已採信，TDD RED執行中，尚待產品測試／交付。#831為6/Yellow、#830為8/Red；#833補Red接續，皆未實作完成。 |
-| B2 | pending | PatchMUD producer 由專責 subagent 開票；Cortex contract 待派工。 |
+| B1 | in-progress | #822 RED/GREEN已採信，verify因terminal schema拒收，等待合格reviewer重試；未review/merge/installed。#831為6/Yellow、#830為8/Red；#819/#825/#827 accepted intake均仍Red，#833未實作。 |
+| B2 | pending | PatchMUD #37已開；Cortex #835 profile與#842 qualification分工明確，契約待拆分／派工。 |
 | B3 | pending | 觀測與預估先 shadow。 |
 | B4 | pending | 資格、預估與所有權契約先過，再有限啟用動態路由。 |
 | B5 | pending | #828 獨立處理；其餘狀態／部署待分拆。 |
@@ -208,6 +208,48 @@ B1 的主要目標是讓 Cortex 能可靠承接後續工作。B2–B4 完成後�
   接續successor；#830/#831不代替它，完整parent→children→closure仍是未完成gate。
 - 後續工作依[動態進件對照](../../../reports/review/refine-dynamic-intake-map-20260907.md)
   查重拆票；D1–D10只是責任切面，仍須真實sizing及accepted child plan，不直接整包派工。
+
+### 已核對的進度更新（2026-09-07 09:30 UTC）
+
+- [PR #834](https://github.com/hamanpaul/paulsha-cortex/pull/834) 已合併，
+  merge `217ff5b701f2a6ae54a20ab07212d3acef1d2114`；修正文句後的新head
+  `04418f7f09ad6ad360c93866be2bb1867fb9db70` 通過post-commit preflight、
+  全CI及resolved review thread。#830/#831是進件交付，產品修正仍未完成。
+- #822 RED `357dece2a328acb43022d23539f06aaca91a2598`：root集中10 failed/4 passed，
+  production diff為空；GREEN `7d72dee3acd8cc36ea0a96be8713e1e52f2c7346`：
+  集中14/14與Manager pytest gate通過，worker全套5662 passed/44 skipped。
+  verifier AGY terminal因details不是object而拒收；candidate未變，不採用該結果。
+  尚待合法verify/review/ship，不能因GREEN就關#822或宣稱B1完成。
+- 既有fallback曾選到本批列出型號以外的packaged AGY 3.1；目前停在needs_human，
+  後續以run-scoped選擇受本批許可且具review資格的候選，不改共享capability或放寬
+  independence。這是舊runtime限制，不是本計畫新動態admission已完成。
+- #819/#825/#827的accepted intake見[獨立審查／真實sizing](../../../reports/review/refine-p1-runtime-intake-20260907.md)：
+  舊runtime依序7/10/9 Red。#825已補同identity不同terminal亂序的event-time合併、
+  deadline不縮短及expire後ack保留；獨立複審PASS不代表產品實作。#831真正載入後
+  才重新計分；#827/#825的人工child候選不是已接受的child authority。
+- Monitor於09:21 UTC再次只重啟使用者層服務，GitHub freshness恢復；舊程序曾3029 threads。
+  Manager與既有jobs未重啟。此為temporary recovery，不是#827有界性驗收。
+
+### 新增 child 責任總帳（issue 已建立，產品交付未完成）
+
+| Work scope | Owner／依賴與不可混淆的邊界 |
+|---|---|
+| execution profile | #835；schema-key先供#842，未知原生effort/observed不補成實測；各child仍需真實sizing。 |
+| quota observation | #836；只產來源/單位/窗口/TTL/unknown，不做reservation或選模。 |
+| operational forecast | #837；消費#835/#836，與benchmark分帳，不拿token直接扣訂閱額度。 |
+| shared reservation | #838；共同authority/all-or-none，#818 instance契約仍獨立。 |
+| quota admission | #839；依#835–#838/#842，保留pin、最低品質及review independence。 |
+| decision projection | #840；消費#828 producer與#839 receipts，不改workflow真值。 |
+| loaded-runtime attestation | #841；沿用installed/Trust Root receipt，另證實實際已載入程序。 |
+| qualification publication | #842；report→candidate→human-review receipt→approved roster、撤銷/到期/CAS；不擴#581五項原scope。 |
+| recovery conformance | #843；公開action矩陣與不變量測試；producer缺陷仍由#497/#547/#577等原票修。 |
+| production stage reuse | #844，#214 successor；先限同run/claim-era安全cohort，跨run新採信未支援，不倒退既有candidate保留政策。 |
+| requirement delivery accounting | #845；消費CompletionRecord與#841證據，不重建ship引擎、不代替#808/#810勾完成。 |
+
+#835–#842的查重與read-back見[動態issue對照](../../../reports/review/refine-dynamic-issues-20260907.md)；
+#843–#845各票保存不可變source與10/12/12項AC，root已全文讀回。所有新scope都尚未
+implemented/tests/merge/installed/live；開票只補owner，不增加已完成數量。
+PatchMUD #37仍是外部producer gate，真人qualification核可若生效也需真receipt，兩者不由agent捏造。
 
 ### Canary sizing 校正紀錄
 

--- a/docs/superpowers/specs/daemon-tick-clock-not-idle-design.md
+++ b/docs/superpowers/specs/daemon-tick-clock-not-idle-design.md
@@ -1,0 +1,47 @@
+---
+status: accepted
+work_item: daemon-tick-clock-not-idle
+---
+
+# Daemon periodic cadence 與設定傳播設計
+
+## Decisions
+
+### D1 Monotonic 排程與 wall-clock 狀態分離
+
+periodic due → runner → success/not-idle/failure；本票只補 not-idle 的排程 monotonic 更新，既有 success/failure 分支的時鐘與 status 語意原樣保留，不擴張其他 skipped reason 的處理。not-idle 不算 exception，不寫新的 failure/circuit 狀態；後續 exception 仍走 #249 邏輯。
+本票不改 manual tick request 的 skipped 時鐘分支。FakeClock 驗證 periodic 時刻而非真 sleep；85 rounds、poll=1、tick=10 的 runner 時刻必為 [10,20,30,40,50,60,70,80]。
+
+### D2 一套值域，三種錯誤呈現
+
+共享純 validator 定義 finite 且 >0。env helper 捕捉缺失/無法解析/非法值後回 CPU-aware 預設；argparse type 對顯式非法 CLI raise ArgumentTypeError；run_loop 顯式非法參數 raise ValueError，且在建立背景 worker/處理 request 前拒絕。
+CPU 數在 helper 呼叫時計算，不能 import-time 固化。default_max_load helper 與同名 run_loop 參數不互相誤呼叫。
+
+| 入口 | 值來源與結果 | 不受影響者 |
+|---|---|---|
+| main → periodic | 合法 CLI > 合法 env > CPU-aware default | manual request executor 預設 1.0 |
+| run_loop(default_max_load=None) | 不加 periodic_kwargs key | strict keyword-only fake/caller |
+| run_loop(default_max_load=合法值) | 只向 periodic builder 傳值 | build_request_executor 不接新參數 |
+| 直接 build_periodic_tick_runner() | 簽名預設仍 DEFAULT_MAX_LOAD=1.0 | 既有直呼測試 |
+| manual tick | request max_load 或原預設 1.0 | coordinator/cli.py、lib/idle.py 不改 |
+
+### D3 Require idle 與操作邊界
+
+main 將 `default_require_idle() and not args.no_require_idle` 傳給 run_loop。service argv、installer managed_env、status schema不動；文件明示 instance env 要由 operator 配置，不由測試寫入真 env。CPU-aware 是預設行為變更，不宣稱 cgroup-aware；容器 operator 可用顯式門檻。
+
+### D4 風險與測試
+
+| Surface／風險 | Harness | Oracle |
+|---|---|---|
+| skipped 熱迴圈 | 既有 _FakeClock | 八個精確時刻；status None/0/False/None/False |
+| NaN/Inf/非法 env | cpu_count=20 + monkeypatch env | fallback=10.0；cpu_count=None→1.0 |
+| 非法 CLI／優先序 | main stub + 真 subprocess parser | 非法 exit 2；CLI 7 覆寫 env 4.5；不進 run_loop |
+| kwargs 相容 | strict fake periodic builder | None 時無 key；顯式 7.0 只傳 periodic |
+| require idle | 大小寫/空白參數矩陣 | env 關閉與 CLI 關閉按 R4，不改 manual |
+| regression／usage | 原 daemon/idle tests、help smoke | 原斷言不變；help 含新旗標、README 說明可追溯 |
+
+重用 pytest/monkeypatch/tmp_path；無新框架、無真 loadavg 假設，PSC_CONTROL_ROOT 僅指 fixture。測試先保存 not-idle RED，再修 source，最後跑 focused/full/CI/policy 與實際候選 parser smoke。
+
+### D5 Sizing
+
+單 production 模組 → domain_breadth=0；維持跨入口 backward compatibility → state_consistency=1；7 條 requirements → invariant_count=7。現行完整 fix-standard lane 預期 7/Red，不能刪宣告變 unknown；#831 實際 runtime 落地後重評，仍 Red 才真拆 cadence 與配置傳播。不可預填修後分數當現行 authority。

--- a/docs/superpowers/specs/daemon-tick-clock-not-idle-spec.md
+++ b/docs/superpowers/specs/daemon-tick-clock-not-idle-spec.md
@@ -1,0 +1,26 @@
+---
+status: accepted
+work_item: daemon-tick-clock-not-idle
+---
+
+# Daemon periodic clock 與 idle 配置規格
+
+## Requirements
+
+對應 [#819](https://github.com/hamanpaul/paulsha-cortex/issues/819)，沿用 #832 已審查 todo。只修 periodic scheduler 的熱迴圈與啟動配置；不是關閉完成檢查或把 busy 主機標為 idle。
+
+1. **R1 Cadence**：periodic runner 回 `dispatch_skipped="not-idle"` 時推進 last_tick_monotonic，使下一次不得早於 effective_tick_interval；不推進 last_tick_at、不增加 consecutive_tick_failures、不開 circuit，idle=False、last_tick_error 無新錯誤。保留既有 failure/success/backoff 語意。
+2. **R2 CPU-aware env**：default_max_load() 每次呼叫才算 `max(1.0, (os.cpu_count() or 1)*0.5)`；PSC_MANAGER_MAX_LOAD 只接受有限正浮點。unset/空白/解析失敗/NaN/±Inf/零/負數回安全預設。
+3. **R3 CLI 與程式入口**：daemon --max-load 合法值優先 env；顯式非法值為 argparse error，不默默 fallback。run_loop 的非 None 顯式值也拒絕非法值；None 不向 periodic builder 加該 key，保留 strict fake/既有 caller 相容。
+4. **R4 Require idle**：PSC_MANAGER_REQUIRE_IDLE 經 strip/lower 為 0/false/off/no 才 False，其餘含 unset/空白為 True；--no-require-idle 仍可關閉。保持 service-manager.sh argv，不改 installer managed_env。
+5. **R5 Lane 隔離**：保留 DEFAULT_MAX_LOAD=1.0、build_request_executor/build_periodic_tick_runner 簽名預設、lib/idle.py、manual tick request 及 coordinator/cli.py tick 預設。新 run_loop 參數只流向 periodic builder；不新增 status schema 欄位，不改 idle gate 只擋 fanout 的設計。
+6. **R6 文件與 residual**：明示 periodic 預設從 1.0 變 CPU-aware、PSC_MANAGER_MAX_LOAD=1.0 可保留舊門檻、env fallback 與 CLI reject 差異。os.cpu_count 不等於 cgroup quota；容器需顯式設定，後續 capacity 工作承接。不能用 bypass idle=True 證明自然 idle。
+7. **R7 TDD 與真入口**：FakeClock 的 not-idle 呼叫時刻恰為 10..80 秒八次；固定 CPU 的 env/CLI/kwargs 矩陣、manual lane/backoff/idle 原斷言不改；真 parser help/invalid-argument smoke 不連 live daemon，不消耗模型。
+
+## Boundary
+
+Production 只改 `paulsha_cortex/coordinator/manager_daemon.py`。不修 #496/#497、registry persistence、instance 隔離、executor durable backoff，不改 #249 退避/熔斷公式或手動 tick 的時鐘。跨出此界先重新規劃/計分。
+
+## Evidence
+
+基底 `60a3ffa867377b0c86fa2f10e91fb9820d91938c`：manager_daemon.py:1456 取得 skipped、:1458 只有 not skipped 才推時鐘，:1474 failure 已推時鐘；:37 常數 1.0，:1344 periodic_kwargs 無 max_load 注入，:1661 main 無該旗標。`tests/test_manager_daemon_tick_backoff.py:16` 既有 _FakeClock 與 :208 cadence 測試可重用。

--- a/docs/superpowers/specs/executor-durable-backoff-design.md
+++ b/docs/superpowers/specs/executor-durable-backoff-design.md
@@ -1,0 +1,71 @@
+---
+status: accepted
+work_item: executor-durable-backoff
+---
+
+# Executor backoff 狀態與 admission 設計
+
+## Decisions
+
+### D1 Store observation 與 admission 不共用真假值
+
+資料流：真 terminal job/classification → idempotent record → executor-backoff/v1 → fresh observation → workflow/slice admission → launch 或 reasoned skip。
+store reader 的狀態區分 missing/valid/unknown；active_backoff 的「無 active entry」不可承載 unknown。可用 result type 或明確可識別 exception adapter，但 consumers 必須保留三態，不得 catch-all 回 None。missing 只表示本機沒有已知失敗記憶，不能提供 quota-positive 證據。
+unknown 將該 coordinator store 管轄的新增 executor admission 全部暫停；last-good 僅補充已知期限，不把缺失 entry 當已知可用。已執行 job 仍可 poll/terminalize；有效檔且 D2 未合併 terminal intent 已可靠收斂後才重新裁決，無人工 override 捷徑。
+
+### D2 冪等 ledger 與 writer 所有權
+
+entry 至少有 executor/model、outcome、deadline、consecutive_hits、terminal identity 去重資訊及診斷來源。終局識別必須可跨 restart 驗證，不能靠 in-memory seen set；重複 terminal observation 要返回原結果。需要保留到能證明該 terminal 不會再被 replay 的邊界；不得只保存最後一個 job 而讓較舊重播再次延長。
+在同 coordinator root 使用跨 process 的互斥 read-modify-write（或經機械證明的 single-writer owner），讀有效新狀態再合併，atomic replace；寫失敗保持舊檔/last-good並回 unknown/degraded，不截斷原檔。clear/expire 僅改 exact key 的已核可狀態，不誤刪其他 cooldown；無新 operator CLI。
+schema 驗證 finite epoch/合法 hits/identity/terminal key；unknown schema 不做隱含 migration，corrupt 不自動寫 empty 蓋掉證據。last-good 的取得/保存若跨 process 不可證實，重啟直接保持 unknown，不聲稱重啟後知道全貌。
+既有 durable job/provider_outcome 是 backoff intent 的回放權威；store 只有成功 atomic replace 後才記錄該 terminal 已合併的 acknowledgment。每次 admission/restart 先用持久 terminal identity 與 store acknowledgment 對帳，未合併則重放；對帳來源不可讀或合併再失敗時，整個 store 管轄範圍仍 unknown。禁止只讀舊合法 backoff 檔就解封，亦不能只靠未必寫得成功的新 error sidecar 或 process-local sticky flag。
+terminal evidence 的引用/保留必須覆蓋這段未合併窗口；若既有 registry retention 不能證明保留，先停下處理相依邊界，不默認零 pending。重放以原 terminal 觀測時刻/identity 計算，不以現在時間反覆延長 cooldown。此對帳只讀 canonical terminal，不新增另一個 registry writer。
+
+#### D2.1 同 identity 的亂序合併與期限不縮短
+
+每個獨立 job 終局使用不可變的 terminal key 去重；同 key 的 payload/event-time 若不一致屬 integrity unknown，不改名當新命中。排序鍵為 `(terminal_event_epoch, terminal_key)`，event epoch 來自首次持久終局證據而非本次 record/read 的 now。缺少可信 event-time 時保持 unknown/待對帳，不用 arrival time 補值。
+對同 identity 的完整已知去重事件集合依上述順序做純 fold；若無已證明可回放的 checkpoint，不得只折疊新到達的尾項：
+
+1. 初始 deadline 無值、hits=0。對事件 i，若是首筆或 `event_epoch_i >= previous_deadline`，該事件的連續命中數 h_i=1；否則 h_i=h_previous+1。相同 epoch 用 terminal key 的穩定順序裁決。
+2. 每事件候選 d_i 為可信 reset_i+margin；否則為 `event_epoch_i + tick_backoff_seconds(base(outcome_i), h_i)`。quota/rate-limited 的 base、margin 與算法 revision 為已記錄政策，replay 不套今天的新值。
+3. 累積 `deadline_i=max(previous_deadline,d_i)`，最後 h_i 為當前 event-time episode 的 consecutive_hits。亂序首次到達需重新 fold 相同事件集合，不能以「最後到達的那筆」覆寫 aggregate。distinct 較舊事件可改變真正的 episode/hits，但重送不改任何 aggregate；結果不得依 arrival 順序。
+4. 原先已持久的有效 deadline 仍是最低保護界；任何重建若算出更短值，要保留它並以 integrity/policy mismatch 診斷處理，不能自動降低。相同政策且完整事件集合的正常 fold 須以 permutation test 證明一致。
+
+具體 oracle：較新事件 event_epoch=200/reset=1000 先寫，較舊未 ack 事件 event_epoch=100/reset=300 晚到。後者合併後仍為 deadline=1000+margin、hits=2；反向到達、同 epoch 的 key tie、跨 process/restart 皆按相同 fold 收斂，不能提前至300+margin。再加入無 reset 的亂序事件，期限只由 event-time fold 決定，不能用到達當下 now 延長。
+active_backoff 到期回無 active 僅是時間查詢結果，不刪除已合併 terminal ack、policy/event fold 所需摘要。expired clear 只可移除 active projection，必須保留去重 tombstone／可驗證 fold checkpoint；除非證明舊 terminal 已不可再 replay 且未 ack 舊事件不會落在 checkpoint 前，不能依 TTL/期限已過回收。證明不足則保留或明示 unknown，不能遺忘後當新 job。
+本票沒有提早縮短 active cooldown 的 reset-reconciliation authority；clear_backoff 對仍有效 entry 必須拒絕（具體 active-cooldown reason），較短新 reset、成功 terminal、auth probe 成功也不得清除。自然到期且未合併 intent 為零才可解除；能提早縮短的可信事件／policy 由後續 quota 規格另定，本票不暗加。
+
+### D3 Reset parser 的 authority 不升級
+
+結構化 resetsAt 與文字互斥時保留結構化；可信未來 reset 加固定 margin。Retry-After 非負秒的 0 表示 now，再加 margin；負值/非有限/溢位不採。月日無年份只依已明示 timezone 與基準年解析，若該年所得時刻已過就回 None，不自動滾到明年。「跨年」正例需上游可信來源明示年份/reset 時刻；沒有該證據的年末→年初文字案例是保守拒收負例。無可靠 timezone/日期或模糊 DST 時不猜，採本機 backoff。
+parse_reset_hint 對外維持 int/None；內部解析結果或 store/診斷 metadata 記 timezone/base-year/source，不擴充 provider_outcome 五鍵形狀。取得 timezone/now 的 seam 必須可注入 deterministic fixture，不依 CI host 時區。文字命中不改 classification.authority，僅填既有 reset_at。
+
+### D4 最後副作用前共用 admission
+
+workflow preflight/reroute 讀最新 observation，把 active cooldown 投影為 ProviderFreshness(degraded, executor-backoff)；all-known-cooldown 是等待，不是 provider retry failure。全候選結果中若有 unknown，不能把已知最早期限當全體可恢復時間；須回 unknown 診斷並可附已知 skipped。
+slice 在 _record_pending_slice/worktree/launch 前先取得 exact identity 並查 store，缺 identity 只給診斷不可假造資格；fallback 使用 launcher 公開 model property。dispatch/retry-build/fanout/tick 和 inspect 必須區別 launched、known skip、unknown skip；共用空列表安全處理，不偽造 job_id。
+適用 pin/independence 等限制仍由既有 gate 最後裁決；所有候選 backoff 的等待不能偷偷建立新 run/attempt 或消耗 provider-retry。已進行的正式 forced-retry 若沒有 replacement Job，不得為本票假裝成功，與 #830 非 Job 契約整合時需保留其較嚴格後置條件。
+
+### D5 風險／測試矩陣
+
+| Surface／風險 | Harness | Oracle |
+|---|---|---|
+| deadline／命中數 | fake clock + tmp store | reset+margin；quota base 更大；指數有上限；到期可再評 |
+| 重送／restart／不同卡 | fresh process/JobRegistry + terminal fixture | 同終局 bytes/hits/deadline 不變；跨卡仍 skip |
+| corruption／原子故障 | malformed/schema/permission fixture + replace fault | unknown、不 launch、不寫 empty、不清已知期限；有效檔且 pending intent 合併後可派 |
+| 舊合法檔掩蓋新寫入故障 | store 僅 A、B terminal 已持久、replace fault、fresh process | B 未 acknowledged 時 admission 仍 unknown；可靠合併後才按 B cooldown 裁決 |
+| 交錯 writer／clear | barrier-controlled processes | 兩 identity 更新皆保留；clear 不丟別 key；同 terminal 只計一次 |
+| 同 identity／亂序首次到達 | 新 job reset1000→舊未 ack job reset300；反向/permutation/fresh process | deadline仍1000+margin、hits按 event-time fold 一致；now 改變不重新延長 |
+| 到期／ack 回收／舊終局重播 | expire/clear→restart→同 terminal 重送＋未 ack 舊事件 | ack/tombstone 仍有效，重送不變 hits/deadline、不復活已過期冷卻；有缺口則 unknown |
+| 非授權提早解封 | active entry + 較短 reset/成功 job/auth success/clear | 不縮短、不提前 launch；自然 expiry 且 pending=0 才解除 |
+| parser／時區 | aware fake now/operator timezone fixture | 跨日/年/DST/過去/非法/Retry-After 0/負數；結構化優先 |
+| workflow／pin | 既有 provider recovery harness | 合法下一候選帶 receipt；全冷卻不加 retry；unknown 無假 deadline |
+| slice/request adapter | fake launcher + registry/worktree spies | 副作用皆零、仍 dispatchable、無 IndexError/假 retry 成功 |
+| CLI／read model | 真 parser + 隔離 fixture result JSON | reason/skipped/deadline 可見；unknown 不等於額度足夠 |
+
+不使用真額度打滿作回歸；先 pure/store，再故障/replay，再雙 lane/request wiring，最後短 CLI/integration 和文檔。既有 GitHub provider_backoff 的 corrupt→none 測試保留，它不是新 executor store 的 oracle。
+
+### D6 Sizing 與後續
+
+≥4 production 模組 → domain_breadth=2；跨 process concurrency/atomicity/durability → state_consistency=2；原9組驗收不變量加上亂序合併一致性、到期後去重保存兩組，invariant_count=11，不以原先較小宣告遮蔽新增驗收。現行完整 fix-standard 預期 10/Red；#831 後仍可能 Red，正式實跑後真拆 store/parser、terminal 記錄、workflow admission、slice/request consumers，拆分不可讓尚未接 gate 的 half-feature宣稱安全層已交付。
+共享 quota pool、forecast、reservation、動態 model/agent/effort 不在此最小層；上位 `docs/superpowers/plans/2026-09-07-cortex-refine-complete.md` 的 R05/R08/R09 與 D4–D7 後續維持未完成，不因本票 merge 關閉。

--- a/docs/superpowers/specs/executor-durable-backoff-spec.md
+++ b/docs/superpowers/specs/executor-durable-backoff-spec.md
@@ -1,0 +1,29 @@
+---
+status: accepted
+work_item: executor-durable-backoff
+---
+
+# Executor 已知限流的持久退避規格
+
+## Requirements
+
+對應 [#825](https://github.com/hamanpaul/paulsha-cortex/issues/825)。#832 已審查 todo 與本 spec 明確取代原 issue「corrupt file→empty」條款；原 GitHub provider backoff 語意不改。
+
+1. **R1 Durable identity cooldown**：executor/model_id 的已知 rate_limited/quota 記入獨立 executor-backoff/v1 store；每次 admission 重讀磁碟，跨 tick/card/run/Manager restart 保留，不能只用 auth process cache。
+2. **R2 冪等與 atomicity**：同一終局 job 重送不增 hits、不延後 deadline；不同真 job 以 immutable event-time／去重 key 的確定排序合併，不能按 arrival time 更新。record/clear/expire 不得縮短同一或其他 identity 仍有效的 deadline；較新 reset=1000 已持久後，較舊未 ack 的 reset=300 晚到仍須保留至少1000+margin。deadline/hits 對相同事件集合與所有到達次序必須一致；到期不得遺忘 ack 後把舊終局重算為新命中。原子替換失敗後，以既有持久 terminal evidence 作未合併 intent，跨 consumer/restart 保持 unknown，直到可靠合併才解封；舊檔仍可解析不算恢復。
+3. **R3 Unknown 非可用**：缺檔只有「無本機已知 backoff」，不是額度已確認充足。corrupt/unreadable/unknown schema 回 unknown/degraded；保留可得 last-good 並暫停 store 管轄範圍新增派工，不動已執行 job、不捏造 deadline、不耗 provider retry。有效 store 恢復後可重新 admission。
+4. **R4 期限與 provenance**：每個終局事件優先以可信結構化 reset_at+固定小 margin 產生候選期限；無可靠 hint 用該事件時刻加有上限指數退避，quota base 大於 rate_limited。identity 的生效期限採既有期限與事件候選期限的保守最大值，不被較短 reset 覆寫。本票不授權任何事件提早縮短仍有效的 cooldown：後來較短 reset、成功 job、登入成功均不算解封權威；只有期限自然屆滿且 pending intent 已收斂才無 active backoff，主動 reset reconciliation 交後續 quota 工作。文字支援 Retry-After 秒與 Codex 月日/AM-PM，記解析 timezone/基準年；不可靠/過去/非法時刻回 None。文字不升 authority、不新增 outcome vocabulary，不改 provider_outcome 四必要 keys＋可選 reset_at。
+5. **R5 終局寫入資格**：slice/workflow failed 共用 helper，只接受 rate_limited/quota 且 authority 非 hint；使用終局 job 的真 executor/model_id/job identity。缺欄位不造 key、不炸掉終局收斂，留下診斷。
+6. **R6 Workflow admission**：preflight 與 reroute 都排除 cooldown；有合法候選沿原順序和資格/permission/pin/independence 規則選擇並存 dispatch_reroute/skipped。全候選 cooldown 回 executor-backoff/min retry_after/skipped，不轉 needs_human、不耗 provider-retry；unknown 使用不同 reason，不偽裝有期限。
+7. **R7 Slice admission／consumer**：在 pending slice/worktree/job 副作用前讀 store；identity 優先 spec，否則 launcher 公開 executor/model，不讀 private _model。skip 保持 dispatchable；dispatch/retry-build/fanout/tick 回 skip 明細，未知另診斷；不取空 dispatched[0]、不誤拋 retry-build-dispatch-failed。
+8. **R8 測試與觀測**：純 parser/clock/store、跨 process/原子寫入故障/同終局重播、兩 lane 和全部 request consumer 的 RED/GREEN；inspect/tick 可觀察 reason/skipped/retry_after，tests 不使用真 provider/模型；未知餘量不得顯示已確認足夠。
+9. **R9 後續 quota 邊界**：本票只是被動最小安全層。共享 account/quota pool、需求 forecast、reservation、動態 model/agent/effort 選擇仍由 refine 後續 D4–D7／R05/R08/R09 承接；executor/model key 不等於獨立額度池，#825 merge 不代表第 5 類問題完成。
+
+## Boundary
+
+Production 涵蓋新 executor_backoff、reset hint 純函式、provider_outcome、manager、autonomy、manager_daemon、launcher 的接線，必要時 registry 只處理新 job evidence 的相容性。保留 GitHub backoff namespace、taxonomy、spawn admission、候選順序；不新增 override/clear CLI、不降低 pin/independence，不能用換模型保證同池有餘量。
+這是 ≥4 模組加 durability/concurrency 的真實整包，不得直接派 Red build；#831 落地後重評仍 Red 必須真拆，各 child 保持本規格安全不變量。
+
+## Evidence
+
+基底 `60a3ffa867377b0c86fa2f10e91fb9820d91938c`：provider_backoff.py:1 僅 GitHub，:42 的 fail-soft reader 不能複製為本票語意；manager.py:3975 的 reroute、:8466 runtime preflight；autonomy.py:592 dispatch_ready、:662 pending side effect；launcher.py:1430 只有 executor 公開 property；provider_outcome.py:89/126 既有可選 reset_at。新 store 尚未存在，intake 不等於產品已接線。

--- a/docs/superpowers/specs/monitor-refresh-thread-backlog-design.md
+++ b/docs/superpowers/specs/monitor-refresh-thread-backlog-design.md
@@ -1,0 +1,44 @@
+---
+status: accepted
+work_item: monitor-refresh-thread-backlog
+---
+
+# Monitor refresh 排程與 publication 設計
+
+## Decisions
+
+### D1 單一排程邊界，不同來源各自保留真相
+
+資料流：watcher／poll／rescan／GitHub timer → bounded dirty map → 公平 ready queue → 至多 W 個 worker → generation/source revision 檢查 → snapshot commit/event publish。
+worker 是服務擁有的固定資源；watcher 不再為事件啟動 Timer。dirty map key 使用 canonical project/source；未知 workspace 事件歸全量 scan source，不走同步旁路。全量與局部 pending 合併時不得漏掉其覆蓋外 project。
+每 key 保存首次 pending 時刻、最新 generation、active/dirty 狀態。連續事件只更新 dirty/version，不刷新首次 pending；達 D 即 ready。active 結束後若 dirty 則至多重新排一份，新的 ready 項排在已有 ready 項後。
+
+### D2 公平與有限等待的前提明示
+
+同一輪已就緒來源數為 Q，各工作服務上界為 L；W=1 的保守開始上界為當前 active 剩餘上界 + Q×L，另計尚未 ready 的 D。W>1 仍可用此保守界，不宣稱真網路每次固定延遲。
+GitHub provider scan 不得在持有 publication 全域鎖時佔住整段 I/O；可以在鎖外建候選結果、在 commit 時檢查 generation/revision 並合併仍有效的來源狀態。測試 slow fake GitHub 時 local 可按有限界開始，或在無可用 worker 時明確呈現等待/timeout，不製造成功時間。
+新 local publication 與舊 remote 結果的衝突以 source revision 驗證/重新合併裁決；不可不檢查而整包覆寫，也不可讓持續 local churn 永久丟棄 remote 更新。若現有 provider adapter 不具有限 timeout，R7 的殘餘有界/診斷成立，但 R3 的一般有限進度尚未成立，需回主流程補依賴。
+
+### D3 寫入者與停止線性化
+
+服務/scheduler 擁有 lifecycle generation；work refresher 擁有 durable snapshot/read model commit。stop 與最後 generation check/commit 需共用同一 fencing 協議；publication 已在線性化點完成者算 stop 前，stop 已生效後的候選一律不得 commit。
+server.publish_events、publish_work_events 與 durable publish 均列入 fence 測試。停止順序為 reject → invalidate → cancel pending → stop watcher → join 合作式 worker → report residual；多次 stop/unwatch 不重複發布、不新增 worker。
+不以丟掉 Future/thread 引用宣稱停止；stuck worker 仍計入 W。不可取消外呼是明示 bounded residual，若要更強終止保證需另處理 adapter/process boundary。
+
+### D4 診斷與測試矩陣
+
+| Surface／風險 | Harness | Oracle |
+|---|---|---|
+| A burst／無界 worker | Event 擋住第一輪、100 次 submit | active≤W、A pending≤1；放行後最多兩次且 snapshot 最新 |
+| Debounce starvation／A 壓住 B | fake clock、固定來源順序 | 首次 pending+D 後 ready；B/GitHub 不被後來 A 插隊 |
+| 慢 provider／舊結果 | 可 timeout/cancel fake provider + revision barrier | queue-wait/provider-timeout 具體診斷；不假更新 freshness、不覆蓋新 authority |
+| Stop／已開始 callback | commit 前後兩個 barrier、durable bytes/hash spy | stop 生效後零 commit/event；合作式 S 內退出、pending=0 |
+| 不合作外呼／資源殘餘 | 受控 stuck fake、finally 放行 | owned worker≤W、stuck 可見、無補開 thread、遲到零 publish |
+| Wiring／usage drift | 既有 monitor fixture + 短 real-thread smoke | rename/rescan/last-good 原斷言不變，結束回 owned-thread 基準 |
+
+各等待皆 bounded 且 finally 放行；真 sleep 不作主要同步。原 issue 的全域 active_count 只作輔助指標，主要斷言 component-owned worker/pending。
+
+### D5 Sizing 與交付
+
+三個 production 模組 → domain_breadth=1；concurrency/atomicity → state_consistency=2；8 條 requirements 對應 invariant_count=8。W/D/S 由實作的可注入常數與文件明示，驗收測試固定實際數字及推導界，不用 host 速度硬猜。
+現行完整 fix-standard lane 預期 9/Red；即使 #831 改正 stability 分量，仍不能未經實跑就當 Yellow。拆分候選為 bounded scheduler/coalesce、work-model 公平 publication/stop 接線兩個有獨立測試的單元；只是後續規劃方向，不是已授權 child authority。

--- a/docs/superpowers/specs/monitor-refresh-thread-backlog-spec.md
+++ b/docs/superpowers/specs/monitor-refresh-thread-backlog-spec.md
@@ -1,0 +1,28 @@
+---
+status: accepted
+work_item: monitor-refresh-thread-backlog
+---
+
+# Monitor refresh 有界排程規格
+
+## Requirements
+
+對應 [#827](https://github.com/hamanpaul/paulsha-cortex/issues/827)。本規格補足 #832 已審查的同 work_item todo，不刪減其驗收；觀測到的 thread/RSS 數字屬 issue 現場證據，不宣稱已在本 intake 重現。
+
+1. **R1 有界 owner**：watcher/service 的檔案事件、未映射 workspace 全量 scan、poll/rescan/GitHub 都由有界排程承接；固定可查詢 worker 上限 W，不建立每事件 Timer 或無界 executor queue。
+2. **R2 有界 coalesce**：每個 project/source 最多一份 pending dirty 標記；保持首次 pending 時刻與最大 debounce 等待 D，新事件不得無限延後。active A 已開始後到放行前的 100 事件合併為一次後續更新，首輪加補跑最多兩次，最後 snapshot 含最後狀態。不同 project 不互相覆蓋，不把任意時序 100 事件均最多兩次當全稱契約。
+3. **R3 公平**：同來源後來事件不能插隊到已就緒其他來源前；local/poll/rescan/GitHub、熱點 A/非熱點 B 均需有依 W、D、有限工作耗時推導的開始上界。不能只改 Timer 而留下 provider 全域鎖飢餓。
+4. **R4 Timeout 與 last-good**：慢 provider 的等待、timeout、skip、失敗需具體可見；沒有完成不得假裝 freshness。保留 snapshot 驗證、last-good、source owner/fail-closed authority 與 GitHub 壓力閘，遲到舊 generation/source revision 不得覆蓋新 snapshot。
+5. **R5 診斷隔離**：各來源保留 pending_since、started_at、last_success、具體 failure reason；stale 是時間狀態而非根因。來源 A 成功不得清掉 B 未解除的錯誤；資料呈現必須相容既有 snapshot/read model。
+6. **R6 Stop fence**：stop 先拒收及使 generation 失效，再取消 pending、停止 watcher/scheduler；已開始 callback/provider 的遲到結果不得在 stop 後發布事件或寫 durable snapshot。檢查與 commit/publication 必須同屬可線性化邊界，不可只在 callback 入口判斷。
+7. **R7 有界收尾**：合作式工作於明定 S 內 join，重複 stop/unwatch 安全。不可取消呼叫最多留下既存 W 個有界殘餘，不宣稱已終止、不再增開替代 thread；保留 stuck/timeout 診斷與 stop fence。若所選 adapter 沒有可證明的有限 timeout，先回主流程處理依賴，不假裝驗收通過。
+8. **R8 可重現驗收**：Event/barrier/fake clock 的 RED/GREEN、虛擬 60 秒 churn、跨來源公平、實際 publication fence 與短真 thread smoke；測試無 GitHub/model 呼叫，finally 釋放所有 gate。保留既有 burst/rename/watch/unwatch/recreate/Git-control/rescan/last-good 測試。
+
+## Boundary
+
+Production 規劃限定 `monitor/watcher.py`、`monitor/service.py`、`monitor/work_api.py` 的排程、診斷與 publication seam；不改 provider 業務規則、stale 門檻、GitHub quota/backoff、supervisor 或其他 instance。如需第 4 個 production 模組或新 adapter 協定，先重評/真拆。
+本整包有 concurrency/atomicity，不是低風險單純 debounce 修正。Red 時只保留 accepted intake，不整包派 builder；#831 實際落地後重評，仍 Red 必須真拆。
+
+## Evidence
+
+基底 `60a3ffa867377b0c86fa2f10e91fb9820d91938c`：`watcher.py:130`、`service.py:317` 的 Timer；`service.py:279` 未映射事件同步 scan；`work_api.py:496` 的 refresh 在全域鎖內執行 provider scan。既有 `tests/test_stage9_project_monitor_service.py` 不足以單獨證明高 churn/stop race；測試 backlog 由同 work_item todo 完整列管。

--- a/docs/superpowers/workstreams/daemon-tick-clock-not-idle/todo.md
+++ b/docs/superpowers/workstreams/daemon-tick-clock-not-idle/todo.md
@@ -1,6 +1,13 @@
 ---
 status: accepted
 work_item: daemon-tick-clock-not-idle
+domain_breadth: 0
+state_consistency: 1
+invariant_count: 7
+artifact_classes:
+  - source
+  - tests
+  - documentation
 ---
 
 # Daemon periodic tick 時鐘與 idle 設定
@@ -20,6 +27,9 @@ work_item: daemon-tick-clock-not-idle
 
 ## Tasks
 
+- [ ] **Intake source/tests/documentation**：production 限 manager_daemon.py，按同
+      work_item spec/design 保留全部下列 #832 驗收與 residual。現行 Red 不派整包；
+      #831 實際 runtime 落地後重評，仍 Red 先真拆，不刪 sizing 宣告。
 - [ ] 在 periodic runner 回傳 not-idle 時推進 `last_tick_monotonic`，如同失敗分支
       會推進時鐘；不更新 `last_tick_at`、`consecutive_tick_failures`、
       `tick_circuit_open`、`last_tick_error`，且 `daemon.idle` 保持 False。
@@ -59,6 +69,14 @@ work_item: daemon-tick-clock-not-idle
       新增本 workstream 的 changelog fragment 並同步 `CHANGELOG.md [Unreleased]`。
 - [ ] 透過 Cortex 記錄修前 RED、修後 focused／完整 gates、review、merge 與實際
       runtime 驗證；本 todo 的 accepted 不代表修正或測試已完成。
+- [ ] **documentation/CLI help 與 tests/真入口**：從候選 checkout 外真跑
+      `python3 -m paulsha_cortex.coordinator.manager_daemon --help`；以隔離 env
+      subprocess 驗 --max-load NaN/Inf/0/-1 exit 2 且不啟動 run_loop，合法值透過
+      既有 main stub/harness 證明傳入。執行 focused/full pytest、CI、PR-context
+      policy、git diff --check；不連 live daemon、不修改任何 instance env。
+- [ ] **documentation/changelog fragment**：新增並 commit
+      `changelog.d/daemon-tick-clock-not-idle.md`，同步 CHANGELOG [Unreleased]；
+      明示預設行為變更與保留舊門檻的方式，不能只在未入 commit 的檔案提及。
 
 ## 已列管限制
 

--- a/docs/superpowers/workstreams/executor-durable-backoff/todo.md
+++ b/docs/superpowers/workstreams/executor-durable-backoff/todo.md
@@ -1,6 +1,13 @@
 ---
 status: accepted
 work_item: executor-durable-backoff
+domain_breadth: 2
+state_consistency: 2
+invariant_count: 11
+artifact_classes:
+  - source
+  - tests
+  - documentation
 ---
 
 # Executor durable backoff 最小安全層
@@ -18,6 +25,10 @@ work_item: executor-durable-backoff
 
 ## Tasks
 
+- [ ] **Intake source/tests/documentation**：按同 work_item spec/design 保留全部
+      #832 驗收，尤其 corrupt/unknown、跨卡/重啟、同終局冪等。≥4 production
+      模組與 concurrency 的 Red 不可整包派工；#831 後實跑重評，仍 Red 真拆，
+      D4–D7 完整 quota/forecast/reservation/dynamic routing 仍由後續承接。
 - [ ] 新增 `coordinator/executor_backoff.py`，狀態位於
       `<coordinator_root>/executor-backoff.json`，schema `executor-backoff/v1`，
       key 為 executor／model_id；提供 `active_backoff`、`record_backoff`、
@@ -67,3 +78,26 @@ work_item: executor-durable-backoff
 - [ ] 補本 workstream changelog fragment／`CHANGELOG.md [Unreleased]`，透過 Cortex
       完成 RED／GREEN、獨立 review、完整 gates、merge 與 restart-safe runtime 驗證；
       另以後續 quota work item 承接本票明確未交付的主動預估與共享池能力。
+- [ ] **documentation/CLI help 與 tests/真入口**：文件同步 known cooldown 與
+      unknown 的區別、skip/receipt 欄位及共享池 residual；真跑候選 CLI inspect
+      status/tick/dispatch 的 --help，隔離 fixture 透過既有 control request harness
+      驗 JSON skip/unknown，不連真 daemon 或 provider。focused/full pytest、
+      既有 CI、PR-context policy 與 git diff --check 全驗；不新增 override CLI。
+- [ ] **source/tests/寫入故障跨 process interlock**：以既有持久 terminal evidence
+      與 store acknowledgment 對帳，未可靠合併前保持 unknown；補「舊有效檔僅 A、
+      B 終局已持久、replace 故障、另一 consumer/fresh process admission」回歸。
+      不以舊檔可解析解除、不靠 process-local flag；replay 使用原 terminal 時刻，
+      terminal retention 若不足先回主流程處理依賴。
+- [ ] **tests/reset 過期負例**：今天15:00收到同日12:23的無年份 hint 必須 None，
+      不滾到明年；年末到年初的無年份文字若無可信 rollover 證據也 None。保留
+      明示年份/結構化 reset 的跨年正例、DST/非法時區負例。
+- [ ] **source/tests/同 identity 亂序合併**：依 design D2.1 的 immutable terminal
+      event-time/key 排序 fold，而非 arrival time；先持久較新 event=200/reset=1000，
+      再來較舊未 ack event=100/reset=300，deadline 仍1000+margin、hits=2。
+      反向到達、相同 event-time 的 key tie、跨 process/restart 與所有 permutation
+      收斂相同結果；混合無 reset 的事件也只能用原 event-time、原 policy 算 deadline。
+- [ ] **source/tests/到期去重與縮短權限**：expire/clear 後保留 ack/tombstone/fold
+      checkpoint，restart 再送舊 terminal 不增 hits、不用新 now 復活 cooldown；
+      未 ack 舊事件晚到按真 fold 合併，checkpoint 不能重建時 unknown。active clear、
+      較短 reset、成功 job/auth probe 都不得提早解封；只有自然到期且 pending=0
+      可無 active backoff。本票不新增可提早縮短的 reset reconciliation authority。

--- a/docs/superpowers/workstreams/monitor-refresh-thread-backlog/todo.md
+++ b/docs/superpowers/workstreams/monitor-refresh-thread-backlog/todo.md
@@ -1,6 +1,13 @@
 ---
 status: accepted
 work_item: monitor-refresh-thread-backlog
+domain_breadth: 1
+state_consistency: 2
+invariant_count: 8
+artifact_classes:
+  - source
+  - tests
+  - documentation
 ---
 
 # Monitor refresh 有界排程、公平性與停止契約
@@ -21,6 +28,10 @@ work_item: monitor-refresh-thread-backlog
 
 ## Tasks
 
+- [ ] **Intake source/tests/documentation**：以同 work_item 的 accepted spec/design
+      明定 W/D/S、三模組 scope、stop publication fence 與測試 oracle；下列 #832
+      已審查任務全部保留。現行 sizing 若 Red，等 #831 實際 runtime 重評，仍 Red
+      先真拆，不降低 domain/state 或拿 Yellow 純函式 ready 覆蓋 band。
 - [ ] 用固定、可查詢的 refresh worker 上限 W 取代每事件建立 Timer/thread；
       W 在測試中明確設定，執行中同一 project／refresh source 最多一份 pending dirty
       標記，無界 executor queue 不算有界實作。workspace 未映射事件的全量 scan
@@ -66,3 +77,9 @@ work_item: monitor-refresh-thread-backlog
       記錄 RED／GREEN、完整 gates、review、merge。部署驗收先保存現場，再在實際
       event 負載下量測 thread／queue／freshness 的有界性；任何服務重啟由主流程
       按當時 in-flight ownership 另外執行，不由本票測試擅自重啟共享 Manager。
+- [ ] **documentation/CLI help 與 tests/真入口**：同步 monitor 操作說明的排程、
+      timeout、stop 殘餘界線；在候選 checkout 外真跑 monitor --help 與
+      `monitor --config <fixture> --once` JSON smoke。另以隔離 socket/config、fake
+      provider 的 service harness 查 snapshot 並呼叫 stop，驗 owned worker 收尾；
+      不發明 monitor status/stop CLI，不連 live socket。先 focused pytest，再 full pytest、既有 CI、
+      PR-context policy、git diff --check；changelog fragment 必須 commit 後才算交付。

--- a/openspec/changes/cortex-refine-complete/tasks.md
+++ b/openspec/changes/cortex-refine-complete/tasks.md
@@ -20,11 +20,11 @@
 
 ## 3. B2 可擴充配置與資格
 
-- [ ] 3.1 為 R08/R09/R12 建立/重用精確 child work items；profile schema、原生 effort 與 registry 相容性先有 spec。
+- [ ] 3.1 為 R08/R09/R12 建立/重用精確 child work items；#835 profile schema、原生 effort 與 registry 相容性先有 spec，完整母範圍仍須真實分拆。
 - [ ] 3.2 實作 adapter capability descriptors 與 conformance；新虛構 model/effort 無 central product-name diff。
 - [ ] 3.3 實作 requested/resolved/observed profile 與可追溯 effective argv/config；unsupported pre-spawn fail-closed。
 - [ ] 3.4 實作 PatchMUD versioned report consumer、legacy migration 與 profile/cohort/role/coverage 驗證。
-- [ ] 3.5 實作 qualification candidate→review receipt→approved roster 發布鏈；保留 operator 核可與 independence policy。
+- [ ] 3.5 由 #842 實作 qualification candidate→review receipt→approved roster 發布鏈；保留 operator 核可與 independence policy，不擴 #581 原scope。
 - [ ] 3.6 實作安全 model register/probe 操作面與 TTL、角色擴充契約；探活不暗中消耗無上限額度。
 - [ ] 3.7 定義 pool/account 非機敏 identity、instance authority 與所有權邊界，為共享 admission 建 fixture。
 
@@ -32,30 +32,31 @@
 
 - [ ] 4.1 完成 #826 failure 原始訊號→持久化→消費端分類，保留 runtime-contract 硬阻擋。
 - [ ] 4.2 整合 usage provenance：observed/estimated/unknown、增量/累計、input/cache/reasoning 不重複加總。
-- [ ] 4.3 核對各 provider 真正可用的 quota observation 介面，實作帶來源/TTL/window/unit 的 adapters 與 unknown fallback。
+- [ ] 4.3 由 #836 核對各 provider 真正可用的 quota observation 介面，實作帶來源/TTL/window/unit 的 adapters 與 unknown fallback。
 - [ ] 4.4 實作與 benchmark 分開的 operational track record，涵蓋失敗消耗、duration 及任務分布。
-- [ ] 4.5 實作 task/profile 用量 forecast 與冷啟動先驗、風險區間、版本與資料期間。
+- [ ] 4.5 由 #837 實作 task/profile 用量 forecast 與冷啟動先驗、風險區間、版本與資料期間。
 - [ ] 4.6 以 shadow 流程取得觀測覆蓋率、預估誤差與 confidence baseline；據此核定有限啟用門檻。
 
 ## 5. B4 動態派工與恢復
 
-- [ ] 5.1 完成 qualified feasible candidate selection，維持 explicit pin、permissions、role、independence 硬條件。
-- [ ] 5.2 完成多池/多時間窗原子 reservation 與同主機多 instance contention 測試。
+- [ ] 5.1 由 #839 完成 qualified feasible candidate selection，維持 explicit pin、permissions、role、independence 硬條件。
+- [ ] 5.2 由 #838 完成多池/多時間窗原子 reservation 與同主機多 instance contention 測試。
 - [ ] 5.3 完成 consumption reconciliation、crash/restart uncertain liveness 與 lease 不誤釋放。
 - [ ] 5.4 完成 card/attempt 安全邊界的 fallback、supersession 與 artifact preservation；同耗盡 pool 不可繞過。
-- [ ] 5.5 補 R07 recovery matrix 與 exact-run/card CAS、late evidence、重送冪等、abandon owner-aware 資源處置。
+- [ ] 5.5 由 #843 補 R07 recovery matrix 與 exact-run/card CAS、late evidence、重送冪等、abandon owner-aware 資源處置；#497/#547/#577等原producer缺陷仍須修正。
 - [ ] 5.6 通過計畫 12 個 quota/profile 場景，再有限 opt-in canary；保留 legacy policy 回復路徑與 receipts。
+- [ ] 5.7 由 #844 完成 production stage reuse 的同run/claim-era安全cohort與可信採信；跨run新採信未支援需列管，不能以相同key改寫舊evidence。
 
 ## 6. B5 狀態與部署
 
-- [ ] 6.1 核對 #828 獨立 producer 交付；補 actual/planned/last、facets、quota wait 與 selection receipts 的 status 一致性。
-- [ ] 6.2 建立 CLI/site-packages/service loaded artifact/config identity 的同源驗證與 checkout 外 smoke。
+- [ ] 6.1 核對 #828 獨立 producer 交付；由 #840 補 actual/planned/last、facets、quota wait 與 selection receipts 的 status 一致性，不接管原producer。
+- [ ] 6.2 由 #841 建立 CLI/site-packages/service loaded artifact/config identity 的同源驗證與 checkout 外 smoke。
 - [ ] 6.3 完成 installer/doctor instance roots、writer ownership 與 owner-aware stop/cleanup 的契約驗收。
 - [ ] 6.4 取得 upgrade/restart/rollback 對 active jobs 的實際 receipts；未重載程序不得標已部署。
 - [ ] 6.5 PatchMUD #37 producer 交付後，以真實 report→approval→dispatch 驗跨 repo 接線；外部依賴未交付則保持未完成。
 
 ## 7. B6 整體閉環
 
-- [ ] 7.1 對全部 R01–R14 逐列核對 spec、work/run、測試、獨立 review、merge revision 與 runtime/installed evidence。
+- [ ] 7.1 以 #845 requirement delivery accounting 對全部 R01–R14 逐列核對 spec、work/run、測試、獨立 review、merge revision 與 runtime/installed evidence；索引建好不代表每條需求已交付。
 - [ ] 7.2 逐 issue 重驗已修、取代與殘餘分類，補 closing/cross-reference；不依歷史清單批次猜測關閉。
 - [ ] 7.3 完成 release/changelog/install 一致性與 plan ledger；全部必要驗收完成後才 archive 本 umbrella。

--- a/reports/review/refine-dynamic-issues-20260907.md
+++ b/reports/review/refine-dynamic-issues-20260907.md
@@ -1,0 +1,102 @@
+# 動態派工 child issues 對照（2026-09-07）
+
+## 本次結果與邊界
+
+查證時間：2026-09-07 09:00 UTC。依主 agent 核可的 D1–D10 規劃地圖，只對 D1/D4/D5/D6/D7/D8/D10
+精確查重並開票；新增 7 張，沒有重複建立同 scope 工單。既有 #581/#600/#828 不修改，保留原 owner。
+原 issue-authoring 子任務只做 GitHub issue 建立與本報告新增；當下未改產品碼、formal plan、registry、服務或 native runtime，
+未執行 commit/push/PR/派工/模型評測/付費 probe/部署/restart；後續 root 納入正式規劃的提交另列於 plan ledger。
+
+已唯讀確認 [PR #832](https://github.com/hamanpaul/paulsha-cortex/pull/832) 於
+2026-09-07 08:46:58 UTC 合併，merge `60a3ffa867377b0c86fa2f10e91fb9820d91938c`。
+該 revision 對先前 source 基底 `79ba644780bf1c697c722ac24a297e7d02416100` 的 compare
+只有文件／治理資料變更，故各新票以 merge SHA 的 immutable source links 引用已核對入口。
+這不表示服務已安裝或載入該 revision。
+
+## Issue 對照與 read-back
+
+每票建立後均用 `gh issue view --json number,title,body,url,state` 讀回，逐項比對送出內容。
+下列「一致」只證明 issue 內容寫入正確，**不是實作或測試通過**。
+
+| 地圖 ID | 建議 work_id（尚未註冊） | Issue | read-back | 最小依賴／原票邊界 |
+|---|---|---|---|---|
+| D1 | `execution-profile-contract` | [#835](https://github.com/hamanpaul/paulsha-cortex/issues/835) | number/title/body/url 精確一致；OPEN | profile/adapter/fingerprint 契約；沿用 #205/#534，與 #581 的 unknown-role 切換協調，不吸收 #483/#475 原修復。 |
+| D4 | `quota-observation-provenance` | [#836](https://github.com/hamanpaul/paulsha-cortex/issues/836) | 精確一致；OPEN | #835；沿用 #325，#825 僅最小 durable backoff。本票 shadow 觀測，不做 reservation/routing。 |
+| D5 | `operational-usage-forecast` | [#837](https://github.com/hamanpaul/paulsha-cortex/issues/837) | 精確一致；OPEN | #835/#836；重用 #325 與 EngineeringOutcome。#137/#138/#210 為 closed 設計，不重開，不重建 outcome ledger／泛用 RL。 |
+| D6 | `shared-quota-reservation` | [#838](https://github.com/hamanpaul/paulsha-cortex/issues/838) | 精確一致；OPEN | #835/#836；可用固定需求先做。多 Manager live 另依 #818；#381 spawn 間隔不是共享 quota authority。 |
+| D7 | `quota-aware-admission` | [#839](https://github.com/hamanpaul/paulsha-cortex/issues/839) | 精確一致；OPEN | #835/#836/#837/#838、#600，以及 #825/#826/#497/#830；qualification 發布鏈未決部分另列 gap，不能假設 #581 全包。 |
+| D8 | `decision-status-projection` | [#840](https://github.com/hamanpaul/paulsha-cortex/issues/840) | 精確一致；OPEN | #839/#828；消費 #527 reason/next-actions 與 #827 freshness。只新增 decision receipt 跨 section 投影，不重做 needs_human 根因修復或 actual identity producer。 |
+| D10 | `loaded-runtime-attestation` | [#841](https://github.com/hamanpaul/paulsha-cortex/issues/841) | 精確一致；OPEN | 沿用 #695/Trust Root receipt；#548 service-env 原票不重做；真部署前保留 #800/#815/#476/#818/#582 各票驗收。 |
+
+所有新票均含：#829/PR #832/immutable plan、現有 source 與非重做範圍、明確依賴、deterministic／
+negative／restart 驗收、真實 sizing 待評、implemented/tests/merge/installed/live 分帳、
+PatchMUD #37 外部邊界、禁止本票建立被當作付費評測或現場 restart 授權。未加 assignee/label，
+未註冊 work_id，未替新工作選固定 model/agent/effort。
+
+## 查重方法與相鄰範圍
+
+先以 GitHub open issue 搜尋逐項查 execution profile/descriptor、quota observation/remaining bounds、
+usage forecast/track-record、shared quota/reservation、quota-aware/cost-aware/fallback、
+decision receipt/provenance、loaded-runtime/artifact revision。另對全體 115 張 open issues 的
+title/body 做候選篩選，再閱讀相鄰 issue；建立前逐一 exact 搜尋 7 個 work_id，均無命中。
+也以標題補查額度預留、用量預估、載入 revision。這是當下查重證據，不是對未來新增 issue 的保證。
+
+| 範圍 | 查得相鄰項目與處置 |
+|---|---|
+| D1 | #483 特定 effort repro、#475 自訂 executable、#581 解析/producer 殘項不等於共同 profile 契約；新 #835 明確排除其獨立修復。 |
+| D4 | #825 明文不做共享帳號/token/cost 感知；#833 只是使用既有/後續 budget seam 的拆分 planner，本票不重做其工作。 |
+| D5 | #137/#138/#210 closed 設計與已存在 #325/outcome 可重用；#506 GitHub polling、#781 I/O 放大不是 profile 任務預估。 |
+| D6 | #818 registry single writer、#381 spawn 間隔與 #833 decomposition budget 是相鄰，不是跨 pool all-or-none 耐久 reservation。 |
+| D7 | #825 最小退避、#830 合法非 Job consumer、#807 terminal、#826 taxonomy 各留原 scope；新 #839 是觀測/預估/預留後的共同准入與安全 fallback。 |
+| D8 | #527 已有 needs_human reason/status/next-actions 原始缺陷；新 #840 只擁有 receipt 投影，將 #527/#827/#828 列消費／前置，不另吞根因修復。 |
+| D10 | #548 effective service env、#815 installer rollback、#800 config guard、#695 installed asset attestation 均可區分；新 #841 只補 loaded process 與磁碟/配置 revision 的實證對照。 |
+
+查重期間相鄰新增編號 #834 經查是 bootstrap 文件 PR，不是相同產品 scope 的 issue。
+
+## 保留的缺口與 root 待裁決
+
+1. **完整 qualification 發布鏈仍未有獨立 owner。** #581 原文五項涵蓋 doctor planning identity、
+   unknown persona、launcher provenance、公開 overlay API、PatchMUD eval producer；它沒有明文
+   承包 profile-aware qualification 發布／撤銷、human review receipt 的完整生命週期與 migration。
+   #534 有人工複核與 evaluated-roster 方向，#835 提供 key/schema，但不能據此宣稱上述全鏈已具體
+   進件。新 #835/#837/#839 已將此列 #829 gap；本次沒有擴 #581，也沒有擅開第 8 張新票。
+2. **PatchMUD 外部 gate。** [PatchMUD #37](https://github.com/hamanpaul/paulsha-patchmud/issues/37)
+   負責 profile-aware report/fingerprint/usage/schema，Cortex 可先用固定 fixtures；真
+   report→qualification→review receipt→approved roster→實際派工需要 immutable fixture/revision。
+   角色 deck #13、難度 #21、agent-native #12 保持不同依賴；未測/未核可不得外推。
+   PatchMUD 不供 Cortex 帳號 remaining，不擁有 reservation/routing/loaded-runtime authority。
+3. **B5 既有依賴仍獨立。** #818/#800/#815/#476/#548/#582 要按原票現況驗收或收口，
+   #695 成果沿用；不能因 #840/#841 完成就關閉 B5。#828 與下游 paulshaclaw #328 保留獨立 owner。
+4. **進件尚未發生。** 7 個新 scope 都需正式 spec/todo/authority 與 Cortex 真 sizing；地圖不保證
+   每單 Yellow，若 Red 用 #833 受治理分解，不改低分數、不刪 AC、不手造 evidence。
+
+## 檔案與驗證狀態
+
+本次僅新增本報告；既有 `refine-dynamic-intake-map-20260907.md` 及先前 intake corrections 未修改。
+branch：`feature/refine-intake-corrections-20260907`。只做文件 whitespace/scope 檢查，不跑產品測試。
+issue read-back 共 7/7 精確一致；新票實作／測試／合併／安裝／live 均未完成。
+
+## 後續 scope 裁決：qualification lifecycle 獨立 owner（#842）
+
+**本節是原七票完成後，root 明確擴定的後續範圍，不是原七票擅自增項。** 上述「未有獨立
+owner／未開第八票」描述原批次的查證時點；經此裁決，該 owner 缺口現在由下列新票承接，
+但 qualification 產品功能、真批准與 live acceptance 仍未完成。
+
+- 新 issue：[#842 — profile qualification 核可發布與撤銷生命週期](https://github.com/hamanpaul/paulsha-cortex/issues/842)。
+- 建議 work_id：`profile-qualification-publication`；尚未註冊，sizing 待 Cortex 真評。
+- 唯一 scope：versioned report→qualification candidate→明示 human-review receipt→approved
+  roster 的發布／撤銷／有效期／legacy migration／CAS 與 crash 原子一致性。
+- 查重：exact work_id、qualification publication／資格發布標題，以及當時 122 張 open
+  issues 的 title/body；只有 #829/#835/#837/#839 記載未分配 gap，未找到相同 lifecycle owner。
+- 重用 #581 producer 與解析五項、#534 核可政策、#835 profile key/fingerprint、既有
+  `map_report_to_envelope`、approved 必附 reviewer/reviewed_at 與原子檔案替換。
+  不擴 #581，不重做 benchmark/評分；#839 消費有效資格，#840 只投影。
+- PatchMUD #37 供 producer schema／immutable fixture；零 runtime import；價格 provenance
+  不進能力 fingerprint。舊 report 的樣本數不等於可證明的完整 encounter coverage。
+- 11 項 AC 涵蓋 effort/loadout/adapter/model/role/coverage mismatch、unknown/legacy、未核可、
+  撤銷／到期、replay、CAS/process barrier、crash/restart、歷史 attempt/evidence 不改寫及指紋。
+- 若實際 approval policy 要求真人，live gate 必須取得該真人對 exact qualification 的合法
+  receipt；fixture、agent review、issue/plan 核可都不能冒充。這個 gate 不因開票而通過。
+- 已建立並逐票 read-back：number/title/full body/url 精確一致、state=OPEN。只建立 #842
+  及追加本節，未改其他 issues/code/registry/runtime；目前累計 8 張新票的內容 read-back
+  均一致，所有產品交付狀態仍需各自實證。

--- a/reports/review/refine-p1-runtime-intake-20260907.md
+++ b/reports/review/refine-p1-runtime-intake-20260907.md
@@ -1,7 +1,7 @@
 # P1 runtime intake：完整性、真實 sizing 與人工分拆建議
 
 日期：2026-09-07；純 gate 初次查證09:14 UTC，同 identity 亂序校正後於09:27 UTC重跑。隔離分支 `feature/refine-p1-runtime-intake-20260907`，authoring 基底 `60a3ffa867377b0c86fa2f10e91fb9820d91938c`（#832 merge）。
-範圍只有三組 accepted spec/design/todo 與本報告。隔離 authoring 及此輪文件校正當下，作者未執行 commit/push、建 issue/run、改產品 code/tests、寫 `.cortex`/operator/runtime/服務，也未操作 #822；主流程後續提交/整合以其獨立紀錄為準，這段不是對未來 Git 狀態的宣稱。
+隔離分支的 intake 子任務範圍只有三組 accepted spec/design/todo 與本報告，不是整合 PR 的完整 diff 清單。隔離 authoring 及此輪文件校正當下，作者未執行 commit/push、建 issue/run、改產品 code/tests、寫 `.cortex`/operator/runtime/服務，也未操作 #822；主流程後續提交/整合另含 `.cortex` links、plan/OpenSpec ledger、changelog，以其獨立紀錄為準，這段不是對未來 Git 狀態的宣稱。
 
 ## 已交付 intake 與保留範圍
 

--- a/reports/review/refine-p1-runtime-intake-20260907.md
+++ b/reports/review/refine-p1-runtime-intake-20260907.md
@@ -1,0 +1,160 @@
+# P1 runtime intake：完整性、真實 sizing 與人工分拆建議
+
+日期：2026-09-07；純 gate 初次查證09:14 UTC，同 identity 亂序校正後於09:27 UTC重跑。隔離分支 `feature/refine-p1-runtime-intake-20260907`，authoring 基底 `60a3ffa867377b0c86fa2f10e91fb9820d91938c`（#832 merge）。
+範圍只有三組 accepted spec/design/todo 與本報告。隔離 authoring 及此輪文件校正當下，作者未執行 commit/push、建 issue/run、改產品 code/tests、寫 `.cortex`/operator/runtime/服務，也未操作 #822；主流程後續提交/整合以其獨立紀錄為準，這段不是對未來 Git 狀態的宣稱。
+
+## 已交付 intake 與保留範圍
+
+- #827：`docs/superpowers/specs/monitor-refresh-thread-backlog-{spec,design}.md` 及同 work_item todo。
+- #819：`docs/superpowers/specs/daemon-tick-clock-not-idle-{spec,design}.md` 及同 work_item todo。
+- #825：`docs/superpowers/specs/executor-durable-backoff-{spec,design}.md` 及同 work_item todo。
+
+所有 spec/design 的必要標題為 Requirements/Decisions；todo 保留 Tasks，僅新增 truthful sizing metadata、source/tests/documentation/CLI 任務與補強負例。
+機械讀取基底 todo，比對每個原始行仍按原順序存在：#827 68 行、#819 69 行、#825 69 行全部保留，未刪改 #832 的驗收或 residual。
+
+doc-coauthoring 用於結構與 fresh-reader；test-playbook 用於 actor/side-effect owner、狀態/非同步邊界、Event/fake clock、故障注入、明確 oracle 與測試分層。未另建測試框架，產品測試仍待 Cortex 實作。
+
+## 現行 runtime 純 gate：三項均 Red
+
+執行時 import 現行 runtime checkout 的 `paulsha_cortex.coordinator.planning/manager`，runtime HEAD=`79ba644780bf1c697c722ac24a297e7d02416100`，從 checkout 外執行 Python 並設 PYTHONDONTWRITEBYTECODE=1；不是用 authoring checkout 假裝已部署修正。
+輸入 packaged fix-standard：gate_spine=2、cards=9、persona_binding=9；規則為 runtime 全集 R-09/R-16/R-19。三組 artifact 都逐件 accepted、complete=True、零 missing/marker。
+
+| Work item | domain | state | acceptance | stability | orchestration | 現行真分數 |
+|---|---:|---:|---:|---:|---:|---|
+| monitor-refresh-thread-backlog | 1 | 2 | 2 | 2 | 2 | 9/Red |
+| daemon-tick-clock-not-idle | 0 | 1 | 2 | 2 | 2 | 7/Red |
+| executor-durable-backoff | 2 | 2 | 2 | 2 | 2 | 10/Red |
+
+declared rubric 來源為 [#208](https://github.com/hamanpaul/paulsha-cortex/issues/208)：domain 0=單模組/單流，1=2–3 模組，2=≥4/跨 subsystem；state 0=純/local，1=schema/backward compatibility，2=concurrency/atomicity/migration 任一。
+#827 的三 production 模組與 publication concurrency、#819 的單 daemon 模組與 backward-compatible lane、#825 的多模組/cross-process durability 均按此宣告，沒有為入場降分。
+
+另以 `_evaluate_yellow_plan_review` 單獨檢查三組：ready=True、checks_run=(completeness,contract_compatibility,envelope)。
+envelope 使用目前 `load_model_identities()` 及真 `_plan_review_envelope_lookup`，回 `bypass=envelope_unavailable`；不是 measured capability PASS，也不是 Red 的 dispatch 許可。
+#819 初次 gate 回 missing-task-for-rule:R-09：原 changelog 敘述在 continuation line，機械 task reader 沒採到；新增獨立明確 changelog task 後重新驗過，沒有改 sizing 欄位或刪 gate。
+
+純檢查用的呼叫鏈與參數：
+
+```text
+PlanningArtifact(spec/design/plan=todo，逐檔真文字)
+ → assess_planning_completeness(artifacts)
+ → compute_sizing_score(plan_artifact=todo, completeness_report=report,
+       gate_spine_count=2, applicable_contract_rules=ACCEPTANCE_SURFACE_RULES,
+       cards_count=9, persona_binding_count=9)
+ → sizing_band(score.total)
+ → _evaluate_yellow_plan_review(artifacts,
+       envelope_lookup=_plan_review_envelope_lookup(memory_run, load_model_identities()))
+```
+
+memory_run 只有 steps=()、primary_domain=None、model_chain_override=None、上述 band 與非 live 的診斷 run_id，未寫 registry、執行 probe 或啟動模型。
+目前未跑產品 unit/integration/full tests、CLI 進程、CI/policy、installed/live canary；真 CLI/fixture smoke 已列為各 todo 的交付任務。未以本報告或內容 hash 偽造 runtime authority/evidence。
+
+## Fresh-reader 發現、處置與重審
+
+首輪 FAIL：兩項 #825 MAJOR；作者逐條核對後補強，重審 PASS（只限九件 intake 一致性）。
+
+1. 無年份 reset hint 的「最近未來」可能把今天稍早的過期訊息推至明年。設計改為明示基準年解析，過去即 None；跨年正例須可信年份/reset 證據，未證實 rollover 是負例。todo 增同日15:00/12:23、年界/DST 反例。
+2. atomic replace 失敗保留舊合法檔，不代表新 identity 的 cooldown 已記住。設計改以既有 durable terminal/provider_outcome 作 pending intent，store acknowledgment 只在成功合併後更新；每次 admission/restart 先對帳，無法合併仍 unknown。新增舊檔僅 A、B 終局已持久但寫入故障、fresh process 查 B 的負例；不能只靠 process-local flag/error sidecar。若 terminal retention 不足，明示相依缺口並停下處理。
+
+#819 另把 D1 明訂只補 not-idle，不擴張其他 skipped reason。#827 公平依賴/非合作呼叫殘餘、#819 cgroup/manual/installer residual、#825 D4–D7 全部保留。
+
+主流程再審另指出一項 MAJOR：原 R2 只明文保護別的 identity，同 identity 較舊未 ack 終局晚到可能覆寫較新較長 reset。已在 R2/R4、design D2.1 與 todo 補 immutable event-time/key 去重排序 fold、aggregate deadline 單調保護、expire 後 ack/tombstone 不遺忘、跨 process/restart/permutation 的具體負例。reset=1000 先寫、reset=300 的舊事件晚到仍保留1000+margin，hits 依 event-time episode 計算，不依 arrival now。
+本票不授權提早縮短 active cooldown；較短新 reset、成功 job/auth probe 或 active clear 都不能解封，只有自然到期且 pending intent 收斂才可無 active backoff。主動 reset reconciliation 留後續 quota 工作。
+這兩組新增機械不變量使 #825 invariant_count 由9增至11；domain/state 仍2/2，未降低 sizing 或跳 gate。先前 fresh-reader PASS 是該輪文件狀態，本次再審是否通過由主流程 reviewer 另行記錄，不能沿用舊 PASS 冒充。
+
+## Source 與不耗模型的測試錨點
+
+行號對 authoring 基底；後續變更以函式名重新定位。
+
+- #827：`monitor/watcher.py:130` 每事件 Timer；`monitor/service.py:279` 未映射事件同步 scan、`:317` 第二層 Timer、`:332` refresh_project；`monitor/work_api.py:496` refresh、`:502` 全域鎖裡 provider scan。既有 `tests/test_stage9_project_monitor_service.py` 的 burst/rename/watch/rescan/last-good 保留，新增 backlog fixture 用 Event 阻首輪→100 events→最多一次補跑；fake clock 60 秒、owned worker/pending、跨來源公平與 commit fence，各 bounded wait/finally 收尾。
+- #819：`coordinator/manager_daemon.py:1456` skipped 判定、`:1458` not skipped 才推時鐘、`:1474` failure 已推時鐘；`:1344` periodic_kwargs、`:1661` main。重用 `tests/test_manager_daemon_tick_backoff.py:16` _FakeClock、`:208` cadence；85 rounds 的精確 oracle 為 [10,20,30,40,50,60,70,80]。env/CLI 值域與 kwargs 以 monkeypatch/stub，真 parser 負例只能在候選修正後隔離執行。
+- #825：`coordinator/provider_backoff.py:42` 的 corrupt→empty 僅為既有 GitHub 契約，不能當新 store oracle；`manager.py:3975` reroute、`:8466` preflight；`autonomy.py:592` dispatch_ready、`:662` pending 副作用；`launcher.py:1430` executor property；`provider_outcome.py:89/126` 既有 reset_at。重用 `tests/test_provider_failure_recovery.py:206`、`:398`、`:454` 的候選/independence fixtures 及 slice/provider backoff tests，新增 store fault/restart/replay 與全部 request consumers，無真 quota 打滿測試。
+
+## #831 後的重新裁決
+
+若 #831 實際修正完整 accepted stability=0、其他維度/組合不改，純算術預期 #827=7/Red、#819=5/Yellow、#825=8/Red。這只是明示條件的預估，不是已實跑的新 runtime 分數；必須待真部署 revision 再算。
+#819 保留整體 scope，不預先拆。#827/#825 若仍 Red，以下由 root 人工建立受治理 child spec/issue，逐件正式派入 Cortex。
+#833 自動 planner decomposition 尚未實作，本報告沒有建立 child、issue、authority 或 run，不宣稱 Cortex 已自動完成拆分。
+
+## #827 人工分拆候選與 parent coverage
+
+以下是可獨立驗收的最小責任切點建議，不是已 accepted 的 child。每件假設完整 fix-standard：acceptance+stability+orchestration 三維小計現行為6、#831生效後為4；加上各件 domain=0/state=2，總分才是表格的8/Red→條件式6/Yellow，現行均不可直接派builder。domain=0 只在真的限定單 production 模組成立；concurrency/atomicity 一律 state=2，沒有降掉。
+
+| 候選／依賴 | Production 邊界 | 獨立驗收與 parent AC | domain/state | 現行投影 → #831條件投影 |
+|---|---|---|---|---|
+| M1 排程核心 | 新 `monitor/refresh_scheduler.py` 單模組 | W/pending bound、D、ready FIFO、generation/stop 協議；R1/R2/R3/R6/R7 核心 | 0/2 | 8/Red → 6/Yellow |
+| M2 watcher 接線，依 M1 | `monitor/watcher.py` | 移除事件 Timer、watch/unwatch/rename/recreate、無旁路增 thread；R1/R2/R8 | 0/2 | 8/Red → 6/Yellow |
+| M3 work-model commit，依 M1 協議 | `monitor/work_api.py` | I/O 與 commit 鎖分離、source revision 合併、last-good、source 診斷、stop durable fence；R3/R4/R5/R6 | 0/2 | 8/Red → 6/Yellow |
+| M4 service 接線，依 M1–M3 | `monitor/service.py` | local/poll/rescan/GitHub/全量 scan 同邊界、server event fence、公平時限、S 收尾；R1–R7 wiring | 0/2 | 8/Red → 6/Yellow |
+| M5 parent 整合驗收，依 M1–M4 | tests/docs-only，不新增產品修補 | 原全部 todo + 60 秒 fake churn、短 real-thread、CLI 與 snapshot/stop harness、實際部署量測；R1–R8 | 0/2 | 8/Red → 6/Yellow |
+
+M1/M3 必須先明定 source-generation/publication 協議，使後續單模組接線可重用；若真正實作需同時改另一模組，不可照抄此 0 分，回 1 分並重評/再拆。M3 的 provider finite timeout 能力未證實，需在 child 設計先處理相依，不用更多 thread 吸收風險。
+M1–M3 的 core 單測通過不代表 monitor 功能已交付；parent 保留全部驗收，直到 M4/M5 接線與最後 runtime gate 才可宣稱 thread/freshness/stop 問題完成。
+
+## #825 人工分拆候選與 parent coverage
+
+| 候選／依賴 | Production 邊界 | 獨立驗收與 parent AC | domain/state | 現行投影 → #831條件投影 |
+|---|---|---|---|---|
+| E1 durable store core | 新 `coordinator/executor_backoff.py` | schema/三態、atomic writer、terminal ack/replay、交錯更新、期限計算；R1/R2/R3/R4 | 0/2 | 8/Red → 6/Yellow |
+| E2 reset parser | 新 `coordinator/reset_hint.py` 純函式 | timezone/year、Retry-After、過期/DST 拒收、provenance；R4 | 0/0 | 6/Yellow → 4/Yellow |
+| E3 classification 接線，依 E2 | `coordinator/provider_outcome.py` | 不改 taxonomy/authority/五鍵形狀，structured 優先；R4/R5 | 0/1 | 7/Red → 5/Yellow |
+| E4 terminal reconciliation + workflow，依 E1/E3 | `coordinator/manager.py` | 兩 lane 終局 intent、admission前對帳、preflight/reroute、全冷卻/unknown、pin與forced retry；R1–R6/R8 | 0/2 | 8/Red → 6/Yellow |
+| E5 launcher 公開 model | `coordinator/launcher.py` | 公開唯讀 property 與 executor/model 相符，原行為相容；R7 seam | 0/1 | 7/Red → 5/Yellow |
+| E6 slice admission，依 E1/E4/E5 | `coordinator/autonomy.py` | pending/worktree 前共用 observation、skip 保持可派、無副作用；R1/R3/R7 | 0/2 | 8/Red → 6/Yellow |
+| E7 request consumers，依 E4/E6 | `coordinator/manager_daemon.py` | dispatch/retry-build/fanout/tick/inspect 的 skip/unknown 與空列表安全；R7/R8 | 0/2 | 8/Red → 6/Yellow |
+| E8 parent 整合驗收，依 E1–E7 | tests/docs-only，不新增產品修補 | 全原 todo、fresh process+fault+兩lane真接線、CLI、部署重啟；R1–R9 | 0/2 | 8/Red → 6/Yellow |
+
+E2 的 state=0 只因它是無 writer 的純 parser；所有涉及 concurrency/atomicity 的 child 保留 state=2。E3/E5 是單純 backward compatibility，沒有把 durable work 藏在其中。
+E1 應提供必要 reconciliation observation/ack 協議但不自行新增 registry writer；E4 必須證明 canonical terminal retention 與 fresh-process對帳，未完成前 core 不可被當作安全 admission。E4 若 review 發現單檔含兩個不能一起驗收的流程，可再分 manager 終局記錄與 workflow admission，仍各 state=2，不能用少報不變量硬包。
+`dispatch_reroute` 是否需要 registry 新欄位 gate 尚未證實；若必要，另立 `registry.py` 單模組相容/atomic evidence child，不能偷塞進 E1/E4 的模組計數。E7 也需核對 inspect 真正 owner，若在其他檔則另拆 read-model child，保留 R8 coverage。
+在 E4/E6/E7 接線完整前，不把部分上線宣稱為跨 lane 安全層；parent 最終保留全部原驗收與獨立整合 gate。#830 非 Job 決策修正與本票 skip/wait 必須相容，不用假 job_id 補洞。
+
+## 未完成與禁止宣稱
+
+- child 表只供 root 人工規劃，尚無正式 authority/issue/sizing gate receipt；待 #831 真 runtime 重新計分及每件自身 spec/design/todo 完整性驗證。
+- parent 不因 child core 綠燈而 done，須保留跨 consumer、reset/replay/restart、stop/publication 與實際 runtime 的整合證據。
+- #825 不交付共享 quota pool、forecast、reservation 或動態 model/agent/effort。refine plan D4–D7／R05/R08/R09 仍未完成；未知餘量不等於滿額，換 model 不證明換了帳號池。
+- 本次未跑 full pytest/CI/PR-context policy 或真 CLI，亦未提供產品 merge/部署/現場改善數據。intake accepted、reader PASS 與純函式 ready 不可提升成那些證據。
+
+## 主流程補充的 canary 證據（此子任務未操作或重新查 live）
+
+主流程於 2026-09-07 17:16 Asia/Taipei 左右提供：#822 isolation、tdd-red、GREEN 每張新卡均再碰 Claude 429，各由合法 Codex fallback 接續；verify 的 reviewer/anthropic 新卡又碰 Claude 429，builder 此時為 Codex。
+原事件欄位為 rate_limit_info.resetsAt=1788774600、rateLimitType=five_hour，unifiedWindows 涵蓋五小時/七天；主流程觀測 registry provider_outcome 只有 structured 429，沒有 reset_at。
+這是主流程提供的現場摘要，不是本報告作者新取得的原始 log/hash，也不假造 terminal evidence。
+
+本票既有 R1 跨 tick/card/run/restart、R4 structured reset 優先與 R6 pin/independence 已涵蓋對應回歸：同一 cooldown 必須跨 phase/card admission 生效，不能每張新卡重燒；reviewer 不得 fallback 回 builder 的 independence domain。若唯一合格 reviewer 仍在 cooldown，應回有診斷的等待/恢復路由，不犧牲獨立性。
+reset 欄位從原事件到 classification/registry 遺失是 #825/#826 的 producer→consumer 交叉錨點，實作時先用這種 shape 的匿名 fixture 驗證；本 intake 不聲稱已修 extractor 或已取得 usable reset。五小時/七天多窗口只作來源保留，本票仍不等於 D4–D7 共享 quota window/forecast 完成。
+
+## 最終九件受測內容 SHA-256
+
+```text
+366ececf977ace98d280bc92c5d8241134f75065c07373a529e62a8ba15071b1  docs/superpowers/specs/monitor-refresh-thread-backlog-spec.md
+df334de08c1ae0f03e7ef53a8d20648f256dd94ec0d6026a20c026c0c1978633  docs/superpowers/specs/monitor-refresh-thread-backlog-design.md
+8e4eca204fea3cce70de35f4cad8908fc1081a7d1f98559c74ee0dcf3852f04d  docs/superpowers/workstreams/monitor-refresh-thread-backlog/todo.md
+46b4a089b9b8f86278c443484db9f6ad55d7392fa88a0667979514d2f727b688  docs/superpowers/specs/daemon-tick-clock-not-idle-spec.md
+6bbc7d2f2089b130709ba8107255d66da55601bc18eef5c79bddf405de222c90  docs/superpowers/specs/daemon-tick-clock-not-idle-design.md
+de12c8460c109ec7c054c536cb28021ead4f3b68030a9d799aca28d09e3abaa8  docs/superpowers/workstreams/daemon-tick-clock-not-idle/todo.md
+419bea738e10cf9cde961172491a23a09785cb98610e6e2a557850b251af08d9  docs/superpowers/specs/executor-durable-backoff-spec.md
+30db7e8d79de4bde83c6cd1388658a17699bab2b6e4864572c46b80bbb4d65ad  docs/superpowers/specs/executor-durable-backoff-design.md
+0ed7c907f4185e32286c009df5c54a0c55ba8f8e793b0c244a2216e67bf587ec  docs/superpowers/workstreams/executor-durable-backoff/todo.md
+```
+
+這是 intake 內容核對資料，不是 gate evidence；後續修改須重跑。
+09:27 UTC校正後機械檢查：九件 SHA-256 全相符；git status 恰為授權十檔（3 個 tracked todo 加 7 個新檔）；逐檔 whitespace 無診斷，三份原 todo 行完整保留。三組 planning/sizing/Yellow 純 probe 重跑為9/7/10 Red、gate ready=True、envelope_unavailable bypass；#825 invariant_count=11已被本輪讀取，沒有沿用舊檔驗證結果。
+
+## 主流程整合與獨立重驗（2026-09-07 09:34 UTC）
+
+作者交付後，root以ff-only將authoring基底推進至#834 merge
+`217ff5b701f2a6ae54a20ab07212d3acef1d2114`；九件intake bytes保留。
+補三組spec/design的正式links、changelog、十四類總帳的#835–#845 owners與真實canary狀態；
+不包含產品code或#828 operator artifacts，也未啟動這三票。
+
+獨立review首輪同identity亂序MAJOR已逐條核對並修正，複審PASS；reviewer以純模型
+確認含無reset事件的六種排列收斂，仍未驗產品持久化/跨process。
+Root另用現行runtime79ba6447的真planning函式重跑，#819/#825/#827依序7/10/9 Red，
+完整性/contract通過、envelope unavailable bypass仍明示；OpenSpec strict與diff-check通過。
+這是規劃check，不是產品RED/GREEN或實際能力評測。post-commit preflight/CI另由提交流程記錄。
+
+doc-coauthoring fresh-reader以無前文上下文核對五題，正確區分B0與產品交付、Red與
+Yellow helper、最小退避與完整quota、producer/qualification授權，以及recovery/delivery分工。
+初讀把三維機械小計6/4誤讀為child總分；root核對公式無誤後補明三維範圍與
+domain/state加總8/6，原Red限制不變。fresh-reader重讀PASS，歧義已處置。


### PR DESCRIPTION
## 摘要

接續已合併 #832／#834，補 #819/#825/#827 的 accepted spec/design/todo 與真實 sizing，
同步 #829 的後續 profile、quota、qualification、recovery、delivery 子票責任及現場狀態。

只有規劃／進件與文件；未修改產品碼、模型設定、runtime 或 live registry，未啟動這三張 Red 母票。

## 責任與限制

- #819/#825/#827 現行真分數為 7/10/9 Red；Yellow helper ready 不是派工許可，envelope unavailable 不是量測資格。
- #825 補同 identity 亂序首次終局、event-time hits/deadline、寫入故障跨 process unknown 與 expiry 後去重；完整 R05 仍另需觀測／forecast／reservation／admission。
- #827/#825 的人工 child 表只是規劃候選；#831 真正載入後要再評，#833 自動拆分尚未實作。
- #835–#845 開票只補 owner；#581/#828/#808/#810 等原 scope 保留，PatchMUD #37 producer 與真人 qualification receipt 不由 agent 假造。
- #822 僅 RED/GREEN 已採信；verify terminal 曾拒收，尚未 review/merge/installed。未將 temporary monitor restart 當根因修正。
- 使用 policy-exempt:issue-link：本 planning PR 不關閉以上尚未實作完成的產品 issue。

## 檢查清單

- [x] root 全文核對九件與規劃總帳，原 #832 驗收保留。
- [x] 獨立 review 的同 identity 亂序 MAJOR 已修並複審 PASS。
- [x] root 真 runtime pure gate 重跑，strict OpenSpec 與 diff-check 通過。
- [x] 新增 changelog fragment 與 Unreleased entry。
- [x] 沒有把母票 Red 改低分或把產品驗收預先勾選。

- [x] Fresh-reader 五題重讀 PASS；釐清 sizing 三維小計與總分，沒有改低母票分數。
- [x] `ee4914120bc5685ad58e0e3a1fcabb0bce19926e` post-commit preflight：engine／policy／strict OpenSpec／full tests 全 PASS（tests 171.88 秒）。

遠端 CI 與 review 仍由此 PR 的實際 head 狀態裁決；本機 PASS 不代表已合併或已部署。
