### PR TITLE
docs(refine): 納管 evidence 與動態 execution profile 進件

### DIFF
--- a/.cortex/work-items.yaml
+++ b/.cortex/work-items.yaml
@@ -707,6 +707,10 @@ work_items:
     links:
       - kind: path
         ref: 'docs/superpowers/workstreams/fix-superseded-terminal-replay/todo.md'
+      - kind: path
+        ref: 'docs/superpowers/specs/fix-superseded-terminal-replay-spec.md'
+      - kind: path
+        ref: 'docs/superpowers/specs/fix-superseded-terminal-replay-design.md'
       - kind: github_issue
         ref: 'hamanpaul/paulsha-cortex#497'
     excludes: []
@@ -715,6 +719,10 @@ work_items:
     links:
       - kind: path
         ref: 'docs/superpowers/workstreams/fix-dirty-recheck-idempotency/todo.md'
+      - kind: path
+        ref: 'docs/superpowers/specs/fix-dirty-recheck-idempotency-spec.md'
+      - kind: path
+        ref: 'docs/superpowers/specs/fix-dirty-recheck-idempotency-design.md'
       - kind: github_issue
         ref: 'hamanpaul/paulsha-cortex#496'
     excludes: []
@@ -803,6 +811,10 @@ work_items:
         ref: 'hamanpaul/paulsha-cortex#821'
       - kind: path
         ref: 'docs/superpowers/workstreams/registry-persist-hygiene/todo.md'
+      - kind: path
+        ref: 'docs/superpowers/specs/registry-persist-hygiene-spec.md'
+      - kind: path
+        ref: 'docs/superpowers/specs/registry-persist-hygiene-design.md'
     excludes: []
   executor-durable-backoff:
     title: 'executor-durable-backoff'
@@ -881,4 +893,16 @@ work_items:
         ref: 'docs/superpowers/specs/dispatch-decision-contract-design.md'
       - kind: path
         ref: 'docs/superpowers/workstreams/dispatch-decision-contract/todo.md'
+    excludes: []
+  execution-profile-contract:
+    title: 'execution-profile-contract'
+    links:
+      - kind: github_issue
+        ref: 'hamanpaul/paulsha-cortex#835'
+      - kind: path
+        ref: 'docs/superpowers/specs/execution-profile-contract-spec.md'
+      - kind: path
+        ref: 'docs/superpowers/specs/execution-profile-contract-design.md'
+      - kind: path
+        ref: 'docs/superpowers/workstreams/execution-profile-contract/todo.md'
     excludes: []

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 
 ## [Unreleased]
 
+- **Evidence／profile 進件**：補 #496/#497/#821 的 accepted 三件組與 #835 可擴充
+  execution-profile／原生 effort／歷史 unknown 契約，保留 Red 真分數、writer ownership、
+  archive 與 PatchMUD/#842 外部資格邊界；只交規劃，不宣稱產品、量測或部署生效。
+
 - **Refine P1 runtime 進件**：補 #819/#825/#827 accepted spec/design、保留全部
   原驗收並列真實 Red sizing／人工拆分；補限流事件亂序、寫入故障與到期去重負例。
   將 #835–#845 的 profile、quota、資格、recovery 與交付責任納入總帳；

--- a/changelog.d/refine-evidence-intake-20260907.md
+++ b/changelog.d/refine-evidence-intake-20260907.md
@@ -1,0 +1,4 @@
+## Added
+
+- 補 #496/#497/#821 accepted spec/design/todo、無降級驗收與真實 Red sizing，保留原子終局、writer ownership 及完整 archive 的邊界。
+- 補 #835 execution-profile 契約、原生 effort、requested/resolved/observed 分離與 #842/PatchMUD #37 責任；只交規劃，不宣稱產品或資格生效。

--- a/docs/superpowers/plans/2026-09-07-cortex-refine-complete.md
+++ b/docs/superpowers/plans/2026-09-07-cortex-refine-complete.md
@@ -245,11 +245,35 @@ B1 的主要目標是讓 Cortex 能可靠承接後續工作。B2–B4 完成後�
 | recovery conformance | #843；公開action矩陣與不變量測試；producer缺陷仍由#497/#547/#577等原票修。 |
 | production stage reuse | #844，#214 successor；先限同run/claim-era安全cohort，跨run新採信未支援，不倒退既有candidate保留政策。 |
 | requirement delivery accounting | #845；消費CompletionRecord與#841證據，不重建ship引擎、不代替#808/#810勾完成。 |
+| self-publication authority stability | #847；可信 frozen 自身同內容發布的 metadata 等價，不清 needs_human 或重開 gates；真需求變更仍走既有合法 restart。 |
 
 #835–#842的查重與read-back見[動態issue對照](../../../reports/review/refine-dynamic-issues-20260907.md)；
 #843–#845各票保存不可變source與10/12/12項AC，root已全文讀回。所有新scope都尚未
 implemented/tests/merge/installed/live；開票只補owner，不增加已完成數量。
 PatchMUD #37仍是外部producer gate，真人qualification核可若生效也需真receipt，兩者不由agent捏造。
+
+### Evidence／profile 正式進件（2026-09-07 10:03 UTC）
+
+- P1 planning PR #846 已合併 `fb31083e7325be86c6c9d217da56b9c4d799f5a5`：
+  exact head f7d77d3b 的 full preflight、四版 pytest、build、installed smoke 全綠，review 已解決。
+  #819/#825/#827 的產品驗收仍未完成，不將 PR 合併等同 runtime 修復。
+- 本批補 #496/#497/#821 三件組及 #835 execution-profile 三件組，均經 root 全文核對、
+  獨立 review、現行 runtime pure gate 與 Tasks 負控制。真分數為 7/9/8/10，均 Red。
+  #831 定案映射下 5/7/6/8 只是推算，真正派工前须重跑已載入 runtime；不提前降 band。
+- #497 保留 proof 後 consumed、原子解除 bindings、crash reconciliation；#821 保留 writer
+  ownership、rollback、digest/append fixture 及「輪替不等於完整 archive」的備份前置。
+- #835 對既有協定的 model/native-effort 採 descriptor 擴充，新協定可用受控 adapter；
+  requested/resolved/observed 分開，legacy 缺可信原 policy snapshot 就維持 unknown，
+  不猜版、不回寫 chain。schema-key child 先行，#842 不等待整張 #835 關閉，避免循環依賴。
+- #497/#835 即使 #831 載入仍 Red，須另建受治理 child；#833 自動分解仍未實作。
+  #581 原五項、PatchMUD #37 producer 與適用的真人 qualification receipt 邊界不變。
+  [整合核對](../../../reports/review/refine-evidence-profile-integration-20260907.md)
+  明列 AC、計分、根據與 residual；這批尚未交付產品 implemented/tests/merged/installed/live。
+- 新 [#847](https://github.com/hamanpaul/paulsha-cortex/issues/847) 接手本次 canary 揭露的
+  自發布 membership 變動 producer 缺口，root 已全文核對 10 項 AC。四份 frozen 內容 hash
+  不變，但自身 plan source 晚加入 authority 後觸發了 restart；精確 Monitor 納入時間與
+  單次 writer 身分未證實。不以 bytes 相同就授予豁免，仍須 exact run/era、owner、受治理
+  發布 provenance 與其他 authority 不變；#843/#844 不代替這項產品修正。
 
 ### Canary sizing 校正紀錄
 

--- a/docs/superpowers/specs/execution-profile-contract-design.md
+++ b/docs/superpowers/specs/execution-profile-contract-design.md
@@ -1,0 +1,135 @@
+---
+status: accepted
+work_item: execution-profile-contract
+---
+
+# Execution profile 契約設計
+
+## Scope
+
+依 [Spec](execution-profile-contract-spec.md) R1–R6／A1–A6；本件為完整母範圍設計，
+不是 Red 自動可執行的 build unit。所有下述資料型別／seam 是待實作設計，不宣稱 source 已存在。
+
+## Decisions
+
+### D1 — 以版本化資料為中心，不擴大全域產品枚舉
+
+新增獨立純契約模組（建議 `coordinator/execution_profile.py`），定義 descriptor、
+task requirements、profile 三層紀錄與 capability observation 的嚴格型別／serializer。
+descriptor 由既有 model identity loader 的公開 seam 載入；保留 packaged／operator overlay
+優先序與來源，不建立第二套身份 registry。舊 identity 的 `(executor, model_id)` 僅是相容索引，
+不能充當新版能力 key。新增 adapter 是受控程式擴充，不允許任意 descriptor 載入未受信任執行碼。
+
+descriptor 至少宣告 schema version、adapter id／協定版本、可解析 model id、原生 effort schema、
+工具／sandbox／權限 capability 與 adapter/loadout/toolchain 版本來源。
+effort 保留原生字串或 descriptor 明確定義的數值／結構型別，不轉成全域低中高分數；
+省略 effort 時 resolved 記錄 descriptor 的明示 default，provider 未回報時 observed 仍 unknown。
+unknown adapter/model、未知 schema、重複／矛盾 descriptor、非法 effort 均在 spawn 前拒收。
+
+### D2 — Canonicalization 只處理實際執行條件
+
+定義含 schema version 的 canonical payload，以固定鍵排序、UTF-8 與無歧義型別編碼序列化；
+工具／權限集合先去重排序，原生 effort 的有序結構不任意重排。字串 ID 不擅自大小寫折疊；
+拒絕未宣告欄位型別、非有限數值與含憑證的資料，不將機器絕對路徑納入可分享 key。
+digest 有版本化 domain separator，分別命名 request key、resolved key、actual-condition fingerprint；
+不同 evidence grade 不可互用，即使其已知欄位相同。
+
+actual payload 綁 adapter/協定版本、observed model/revision（已知時）、原生 effort、loadout/toolset、
+sandbox／權限條件與 toolchain 版本；缺觀測欄位保存 unknown 及原因，不產出「完整實測」標記。
+時間戳、價格、pricing provenance 留在報表 metadata，不進 capability fingerprint。
+資格另外由 #842 綁 execution fingerprint、role/deck/coverage、report 與 human-review receipt；
+不把 pricing 加進任何能力 key，不把本件 execution hash 當完整 qualification hash。
+
+### D3 — Adapter conformance 與既有安全 wrapper 分層
+
+新增公開 adapter protocol／受控 registry（建議 `coordinator/execution_adapters.py`），以 descriptor
+查 adapter，adapter 負責 native argv、option 支援、terminal/usage 解析、quota capability 聲明與
+cancel/timeout 接口。共用 wrapper 保留 worktree、Trust Root、spool／last-message、安全工具政策、
+process lifecycle 及審計責任，adapter 不能因能力宣告而越權。
+quota capability 是 supported／unsupported／unknown 及 schema/source，不是餘量或預算判斷。
+
+`launcher.SubprocessLauncher`、`coordinator.cli._resolve_launcher` 與各種 `as_*` specialization
+消費相同 resolved profile；既有 clone 已轉交 effort，不把它列作已知缺陷。
+`planning_runtime._planning_argv`／`_invoke_json` 是另一個生產入口，須接同一 adapter 契約，
+保留純 JSON、hermetic config、零工具／read-only、disposable sandbox 與 last-message 落點。
+review-only／commit-required／write-forbidden 仍依 card contract 決定，不依固定 Persona 名單推測。
+新增 model/effort 只改 descriptor；新 runtime 僅增加 adapter 實作、descriptor 與 conformance，
+central resolver／quota／workflow／reporting 以協定消費，不追加產品名稱 if/elif。
+
+### D4 — 選擇與 admission 不得互相稀釋硬條件
+
+沿用 `model_resolution.rank_candidates` 的分層順序與 credential／權限檢查，
+在 `manager._workflow_identity_candidates_for_persona`、`_runtime_preflight_gate` 及最終
+`_dispatch_workflow_card` 的選擇／launch 接縫傳遞完整 profile requirements。
+`manager_daemon` 與 `autonomy.dispatch_ready` 的 launcher factory 不再只轉交 executor/model pair。
+保留 generic dispatch 與 workflow lane 的各自 owner／preflight，不只接一條示範路徑。
+
+pin 固定目標但不豁免其適用政策的品質要求。既有 frozen run 只依可證的原 schema／policy snapshot 重讀，
+不因套入新版預設而追溯改變其語意，也不升格宣稱具備新版 profile 資格。新 run 或經正式
+authority 流程明示切換新版者，若 exact profile／最低品質不可證則阻塞，不修改 frozen chain
+讓它看似選到其他模型；active legacy job 的安全處置仍須走既有 owner-aware action。
+若歷史 run 沒有足以重建當時 schema／policy 的可信 snapshot，保存原件並明示
+legacy/unversioned/unknown；不從今天的預設、目前版本或猜測的歷史版本補值，不回寫原 chain，
+不據此宣稱恢復其可執行政策或繼承品質 bypass。切到新版必須正式、具 authority 的重新接受，
+不是單純 reload、升級安裝或修改展示標籤。root 對本設計的接受不等於該 run 的重新接受 authority。
+unknown-role 由 #581 收口 public role 解析 seam，
+#835 consumer 必須驗其 fail-loud 契約，不在別處保留 catch-all build 預設。
+資格查詢使用 #842 的 exact profile/role/coverage／有效 receipt 契約；該依賴未交付時可用 fixture
+開發，但不可接舊 pair-key roster 就宣稱新版 qualification 生效。
+#534 的人工核可政策保持權威，descriptor 登錄、probe 成功、測量 pass、quota 足夠都不是核可。
+
+### D5 — 相容欄位不變，新 binding 是 versioned sibling
+
+`workflow._validate_model_chain_override` 與 `_validate_model_chain_resolution` 現有嚴格鍵集合
+不得直接塞入未宣告 profile 欄位；新增獨立版本化 profile binding，保留原 override/resolution
+與舊 reader 所需投影。`WorkflowRun`、JobRegistry 與 launcher invocation 的 serialization 必須
+共同驗證同一 resolved key／descriptor revision；不要為此建立第二個 WorkflowRun 真值源。
+
+新 attempt 在現有 owner-aware registry 寫入邊界綁定 immutable requested/resolved profile；
+已觀測資料以該 attempt 的新 evidence 引用保存，不覆寫舊 evidence。registry 原子替換與其
+既有鎖／交易邊界沿用；寫入中斷後只能讀到一致的舊／新 binding，缺依據則 unknown／阻塞。
+凍結 manifest／chain 只讀不改，legacy 缺欄位不回填虛構 profile；新的 binding 可引用舊 receipt
+但不重算覆蓋它。unknown schema 明確診斷，不用「忽略新欄位」冒充前向相容。
+#581 擁有通用非 dispatch provenance 缺口；本件只確保新增 profile binding 經該共用 seam 傳遞。
+
+### D6 — Producer 與 qualification 的接合，不越過授權邊界
+
+沿用 `envelope_mapping.map_report_to_envelope`、`model_profile` 現有 CLI/file producer seam；
+現有六欄 fingerprint 不是含 effort/loadout/toolchain 的完整 actual-condition key，不能直接
+更名宣稱已符合。#835 提供新 key 對照，#581 接 producer，#842 管資格發布／撤銷／有效期／CAS。
+PatchMUD #37 immutable fixture 必須帶來源 revision／schema／digest，由實際 parser 消費；
+本地自行製造 fake report 只驗 Cortex contract，不假冒上游交付或完整 encounter coverage。
+若 observed effort、adapter/loadout、role 或 coverage 不符／unknown，保留證據且不授予新版資格。
+live 若要求真人批准，須 exact qualification 的合法真人 receipt；本 intake 與模型產出的
+審查文字不屬該批准。既有歷史 attempt/evidence 不因 producer 升版或 qualification 撤銷而重寫。
+
+## Validation
+
+| Spec 驗收 | 最小 fixture 與可驗證邊界 |
+|---|---|
+| A1 | 虛構 adapter 協定下兩個模型與新 native effort，descriptor-only 擴充；exact requested/resolved 與中央路徑差異檢查 |
+| A2 | fake adapter＋受控本地子程序，Event/barrier 確認 argv、terminal、usage、quota capability、取消／timeout、sandbox；unsupported spawn_count=0 |
+| A3 | 各一個 unknown-role／錯 pin／不足 qualification／同 domain／無效 Trust Root fixture；quota 足夠仍零 launch |
+| A4 | 配置欄位逐項 perturbation，effort/version/loadout/toolchain 必變，價格／時間／mapping 順序不變；unknown 不補值 |
+| A5 | legacy fixture＋frozen chain＋隔離 JobRegistry，序列化重讀／重啟／寫入 failpoint；歷史 bytes/digest 不變，未知版與半 descriptor 明確失敗 |
+| A6 | 真正 production resolver/factory/launcher/planning parser 搭 fake subprocess 先驗 contract，再驗 PatchMUD immutable fixture；真 launcher/install/live 獨立 gate |
+
+A5 另含缺可信 schema／policy snapshot 的歷史 run：重啟後仍是 legacy/unversioned/unknown，
+未填入目前／猜測版本，原 chain bytes/digest 不變；無重新接受 authority 的新版切換請求拒絕。
+測試 receipt 只驗 action contract，不冒充現場重新接受或真人 qualification 核可。
+
+先使用現有 `tests/test_model_resolution_chain_534.py`、`tests/test_per_work_model_chain.py`、
+`tests/test_model_identities.py`、`tests/test_model_chain_profile_resolution.py`、
+`tests/test_coordinator_launcher.py`、`tests/test_coordinator_agy_launcher.py`、
+`tests/test_planning_runtime.py`、`tests/test_card_contract_sandbox_mode_716.py`、
+`tests/test_trust_root_hardening_profile_643.py`、`tests/test_model_profile_cli.py` 作回歸入口。
+新增 profile schema／adapter conformance／production binding tests 由 Cortex 實作，
+測試命名不是既有成果。純函式、負例與 restart 先於任何需授權的實際 provider 呼叫。
+
+## Bounded Dependencies
+
+#842 qualification 與 #581 producer／role/provenance 在整合 gate 前須提供契約和證據；
+其前可在本件用明示 fixture，不把未完成依賴填成 pass。PatchMUD #37 的 immutable fixture 與
+真人批准 receipt 是對應 gate 的外部輸入，不能靠重跑付費 benchmark 或 agent 自行批准替代。
+#831 sizing 修正後仍 Red；#833 自動分解尚未交付，此處僅提供人工拆分候選，不假造 runtime 能力。
+這些依賴不阻止 schema／adapter 的離線開發準備，但阻止整件完成及未授權 live acceptance。

--- a/docs/superpowers/specs/execution-profile-contract-spec.md
+++ b/docs/superpowers/specs/execution-profile-contract-spec.md
@@ -1,0 +1,129 @@
+---
+status: accepted
+work_item: execution-profile-contract
+---
+
+# Execution profile 可擴充契約規格
+
+## Authority
+
+對應 [#835](https://github.com/hamanpaul/paulsha-cortex/issues/835)，屬 #829／R08／B2。
+基準是已合併 [PR #832](https://github.com/hamanpaul/paulsha-cortex/pull/832)
+的 `60a3ffa867377b0c86fa2f10e91fb9820d91938c`，沿用
+[完整 refine plan](../plans/2026-09-07-cortex-refine-complete.md) 與
+[execution-domain 語彙](2026-09-07-cortex-execution-domain.md)。
+`accepted` 只表示完整規劃輸入，不代表已註冊、freeze、build-ready、實作或驗收；
+本件 sizing 仍為 Red，須先完成獨立審查與有 owner 的人工拆分。
+
+## Requirements
+
+### R1 — 版本化配置與三層真值
+
+建立 adapter、model、原生 effort、工具、sandbox、權限、角色需求，以及
+adapter/loadout/toolchain 版本的共同 execution-profile 契約。
+requested 表示請求；resolved 表示 descriptor／政策解析後準備執行的配置；
+observed 表示執行器實際回報的配置。每層各自保存來源與版本，不能互相冒充。
+未觀測的 model revision、effort 或其他欄位明示 unknown，不能以 requested 補成實測。
+task role、最低品質與 independence 等要求與配置分欄，能力證據不能由 descriptor 自授。
+
+### R2 — 描述資料可擴充，adapter 隔離協定差異
+
+對已支援協定新增 model 或其原生 effort，只需 descriptor 變更；不在 central resolver、
+quota、workflow 或 reporting 增加產品名稱分支。新 runtime 可新增 adapter 與 conformance，
+不是承諾任意新協定零程式碼。adapter 宣告原生 effort 的型別／可接受值或範圍；不建立
+跨產品通用 effort 枚舉、同名等價假設或固定大小排序，也不固定 model／agent 名單。
+unsupported 的配置必須在 spawn 前拒絕；不偷偷刪 effort、改 sandbox 或換模型。
+
+### R3 — 硬條件先於選擇偏好
+
+保留 #205 per-work chain、#534 層次排序與 preference／explicit pin 差別。
+pin、最低品質、reviewer independence、Trust Root、sandbox／工具權限均為硬條件；
+quota 足夠不構成豁免，明示 pin 無可用合格配置時等待／阻塞而非靜默 fallback。
+unknown role 不得落入 build 候選池；與 #581 的 role 修復同步切換，保持 legacy manifest
+欄位與凍結 chain 的原始意圖，不重新解釋或改寫舊 receipt。
+歷史 explicit pin 先於 measured 篩選的路徑，不得成為新版 profile 的品質豁免。
+
+### R4 — Canonical key 與證據責任
+
+本票擁有版本化 canonical execution-profile key、actual-condition fingerprint 與 migration seam。
+fingerprint 綁實際執行條件；effort、adapter/version、loadout/toolset、sandbox／權限條件、
+model 或 toolchain 變更須可區別。時間戳、價格與 pricing provenance 不進能力 fingerprint；
+報表仍可獨立保存它們。缺 observed 的資料可保存結構化 unknown，但不得宣稱完整 actual key
+或借用另一配置的資格。canonicalization 與輸入順序無關，版本／型別錯誤明確拒收。
+
+### R5 — 無回寫的相容遷移
+
+legacy manifest／凍結 model chain 保持可讀，重新載入或重啟不換 pin、不補寫假 observed。
+新版配置以獨立版本化 binding 接合現有資料；未知版本與殘缺 descriptor fail-closed。
+已有 attempt/evidence/receipt 不回填、不重算覆蓋；新解析紀錄引用既有原件。
+舊資料缺完整 profile 或 qualification 時明示 legacy/unknown；保留可讀性不等於取得新版資格。
+只有可信 snapshot 足以重建當時 schema／policy 的既有 frozen run，才能依該可證版本保留語意。
+缺此證據時標記 legacy/unversioned/unknown，不猜填今天或某個舊版本、不回寫原 chain，
+也不宣稱已重建可執行政策；必須經正式且具 authority 的重新接受，才可切到新版契約。
+
+### R6 — 生產接線與明確外部邊界
+
+一般派工、workflow card、純規劃、review 模式均須在各自實際入口消費相同契約，
+維持其 sandbox、工具、last-message、terminal、cancel/timeout 行為；不能只更新資料類型或展示層。
+觀測／usage／quota capability 的 adapter 契約只描述資料可用性，不在本票實作額度觀測、
+預估、預留、admission 或自動 fallback。
+[PatchMUD #37](https://github.com/hamanpaul/paulsha-patchmud/issues/37) 提供版本化
+CLI/file report、profile-aware fingerprint 與 immutable fixture/revision；Cortex 零 PatchMUD
+runtime import、不代修 producer，不執行新的 benchmark 來補規劃證據。
+
+## Ownership
+
+| Owner | 本件使用的邊界；不接管的工作 |
+|---|---|
+| #835 | execution-profile schema、canonical key、adapter conformance、production 消費與相容 binding |
+| #842 | report → candidate → 明示 human-review receipt → approved roster 的發布、撤銷、有效期、CAS/crash、legacy qualification migration |
+| #581 | 原五項：doctor planning 身分、unknown-role、非 dispatch provenance、doctor overlay 公開 API、PatchMUD eval producer 管線 |
+| #534／#205 | 既有核可／分層排序政策與 per-work explicit chain，不重新授權或擴 scope |
+| PatchMUD #37 | 外部 producer schema、requested/resolved/observed 證據與 immutable fixture，僅 CLI/file 接合 |
+| #483／#475 | 既有 effort repro／自訂 executable 原 scope，不藉本件重開同類修復 |
+| #600／#836–#840 | availability、quota、forecast、reservation、admission、decision status 下游，各自保留 owner |
+
+#835 原票記載的 qualification owner gap，已由 root 後續裁定 #842 接手，不再是無 owner 缺口，
+也不能塞回 #581。沿用 `envelope_mapping.map_report_to_envelope` 的純 mapping，
+不把測量 pass 或 descriptor 登錄當作批准。#842 若依政策要求真人核可，live gate 必須取得
+對 exact qualification 的有效真人 receipt；測試 fixture、agent review、issue／plan 核可均不能代替。
+
+## Invariants
+
+- I1：requested／resolved／observed 分立，unknown 不得被補成實測或當作零。
+- I2：既有協定擴充 model／原生 effort 為 descriptor-only，中央 consumer 不增產品分支。
+- I3：unsupported configuration 零 spawn；adapter 不能降低工具、sandbox 或 timeout/cancel 契約。
+- I4：pin 與 preference 不混用，無合格 pin 不靜默換配置。
+- I5：最低品質、role、independence、Trust Root 與權限是硬條件，quota 不能覆蓋。
+- I6：canonical actual-condition key 隨執行條件改變，對順序、價格、時間戳穩定。
+- I7：profile key 不授予 qualification；不跨 profile／role／coverage 借用成績。
+- I8：未知版本／殘缺輸入 fail-closed；legacy 可讀不等於新版合格。
+- I9：重啟保留凍結 chain 與既有 attempt/evidence/receipt，無歷史回寫。
+- I10：各生產入口消費同一配置契約，fixture／source 成功不冒充 real launcher 或 live 證據。
+
+## Acceptance Criteria
+
+以下 A1–A6 與 #835 六條機械驗收逐項對應，均未執行，不得預先勾選。
+
+- [ ] A1：虛構 model＋新原生 effort 的 descriptor-only fixture，exact requested/resolved profile；
+      不改 central resolver 型號分支。重排 descriptor 欄位不改 key；不同 adapter 的同名 effort 不被視為等價。
+- [ ] A2：虛構 adapter 驗 argv、terminal、usage、quota capability、cancel/timeout、工具／sandbox；
+      unsupported 零 spawn。受控本地 subprocess 可驗生命週期，不呼叫模型 API。
+- [ ] A3：unknown role、pin 不符、qualification 不足、同 domain reviewer、Trust Root 不合均拒絕；
+      以「quota 足夠」的 negative fixture 證明仍不能繞過，保留無副作用的拒絕原因。
+- [ ] A4：effort/adapter/loadout/toolchain 改變會改 actual-condition key；時間戳與價格不漂移；
+      requested 不冒充 observed，缺任一必要 observed 欄位不能獲得完整實測資格。
+- [ ] A5：migration/restart 後 legacy manifest、凍結 chain 語意不變；未知版本／殘缺 descriptor 拒收；
+      隔離 state 的 crash/reload 不產生矛盾 binding，歷史 receipt／attempt/evidence bytes 或內容 digest 不變。
+      負例：歷史 run 缺足以重建原 schema／policy 的可信 snapshot 時，結果為 legacy/unversioned/unknown，
+      不猜版、不回寫 chain、不沿用推測的品質豁免；未經正式 authority 重新接受不得切到新版。
+- [ ] A6：既有 model-resolution/per-work-chain/launcher 回歸，加一般派工／workflow／純規劃／review
+      的 production producer/consumer contract；與 PatchMUD #37 immutable fixture/revision 實際互通。
+      fake 結果不能冒充真 launcher 驗收；real launcher、installed、live 各需獨立授權與證據。
+
+## Delivery Gates
+
+依 [設計](execution-profile-contract-design.md) 與 [Todo](../workstreams/execution-profile-contract/todo.md)
+人工拆分後才可註冊／freeze／Cortex build。規劃完整性、真正 qualification、產品測試、PR 合併、
+installed artifact 與 live acceptance 分帳；任一外部依賴未驗證不能標成整件完成。
+本 intake 不授權修改現場 registry、重啟 active Manager、付費 probe 或 benchmark。

--- a/docs/superpowers/specs/fix-dirty-recheck-idempotency-design.md
+++ b/docs/superpowers/specs/fix-dirty-recheck-idempotency-design.md
@@ -1,0 +1,26 @@
+---
+status: accepted
+work_item: fix-dirty-recheck-idempotency
+---
+
+# Dirty recheck design
+
+## Decisions
+
+1. **Single caller seam**：production 修改限 `coordinator/manager.py` dirty recheck 與必要純比較 helper；既有 registry／verification 是不改動的消費契約。domain_breadth=0（單 production 模組／單資料流），不能把測試消費端灌成新 production 領域。
+2. **Validate before equality**：新結果先過現行 `_validate_result_evidence`。再重新取得 current slice 與目前合法 evidence，組成 effective transition tuple：canonical hash、status、依既有規則推導的 gate_state、candidate、summary、refs。驗證失敗沿原錯誤路徑；不能把 unknown/null tuple 當相等。
+3. **No-op before apply**：只有 tuple 相等才略過 `_apply_verification_result`。其餘沿現行 apply 更新，避免改原語其他呼叫者的語意。state_consistency=1：涉及 lifecycle state/hash/refs 的一致性判斷，但本票不建立跨物件交易或改 writer。
+4. **Transition semantics**：reviewing→pending gate、verified→passed gate、其他合法結果→needs_human，與既有 apply 對齊；summary 從驗過的 evidence payload 取得，不新增另一份 summary authority。內容相同但 state/ref 壞掉必須修復一次。
+5. **Current hash is not contract hash**：讀 `current_verification_evidence_hash`；保持 #501 的既有 normalized legacy row、contract/evidence hash 分離與 immutable evidence 規則。比較 helper 不清洗或回填無法證明的 hash。
+6. **Isolated negative fixtures**：使用本機 fixture repo、明確 repo root 與假的可計數 verification runner。D07 同 path 不同內容只在專用隔離 fixture 建置；不得改 production writer 讓內容碰撞可以覆寫。
+7. **Tick isolation**：測試需預置合法 current terminal/manifest 關係，使測到的是 dirty recheck，不被另一條 terminal replay 干擾；另保留原 cleanup 測試與 current attempt 正常 completion 回歸，不能用 skip runner 使 no-op 假綠。
+8. **Recovery boundary**：本票不宣稱 record_action＋update_slice 已成新原子交易；CAS／durable attempt supersession 由 #497 原責任處理。未變結果不寫入、真實轉換恰好一次的正常 tick 契約先獨立驗證，跨程序 writer 保證仍受 #818 限制。
+9. **Completion boundary**：spec D01–D10 對應 todo T01–T10，T11–T12 補 documentation/CLI 與純計分要求。正式 Cortex intake/identity/review/loaded-runtime 仍由主流程處理，不拿此 accepted 文件當已採信 runtime evidence。
+
+## Verification
+
+新 focused 檔建議 `tests/test_dirty_recheck_idempotency_496.py`。斷言 runner 呼叫數、record_action/update_slice 呼叫數、history delta、current hash、contract hash、state/refs；對 D05/D09 不只檢查函式沒拋例外，還檢查沒有取得成功狀態／新的 accepted evidence。保留 `tests/test_coordinator_registry_headless.py` 的 legacy hash normalization。
+
+## Compatibility and Risks
+
+無新 CLI action、無 schema／evidence-address migration。CLI help 只做真實唯讀 regression。Complete tuple 比較的正確性由逐欄負例守門，不以「掃不到其他路徑」當全稱背書。當前算法會把完整 spec stability 算 2；#831 定案後應為 0，兩種純計算結果寫入 intake report，不回填歷史 run。

--- a/docs/superpowers/specs/fix-dirty-recheck-idempotency-spec.md
+++ b/docs/superpowers/specs/fix-dirty-recheck-idempotency-spec.md
@@ -1,0 +1,34 @@
+---
+status: accepted
+work_item: fix-dirty-recheck-idempotency
+---
+
+# Dirty recheck transition idempotency
+
+## Requirements
+
+Authority：[#496](https://github.com/hamanpaul/paulsha-cortex/issues/496)，保留 [#832 已接受 todo](https://github.com/hamanpaul/paulsha-cortex/blob/60a3ffa867377b0c86fa2f10e91fb9820d91938c/docs/superpowers/workstreams/fix-dirty-recheck-idempotency/todo.md) 的完整修正。accepted 是進件內容定案，不是實作、測試或 runtime 驗收完成。
+
+1. **D01 Validated recheck**：保留 needs_human dirty-summary 的定期 verification；只在 `complete_tick` 的 dirty recheck 呼叫點，經 `_validate_result_evidence` 後決定是否呼叫 `_apply_verification_result`，不移除 recheck 或改變其他呼叫者。
+2. **D02 Exact equality**：canonical content hash 與 `current_verification_evidence_hash`、effective state/gate_state、candidate、summary、current evidence refs 全部一致才 no-op。同路徑不是同內容，缺合法 hash／無法解析 current evidence 不能當相等。
+3. **D03 No-op writes**：結果未變不 `record_action`、不追加 evidence_history、不 `update_slice`；runner 仍確實執行。Optional last-rechecked telemetry 不進 lifecycle history，不成為每 tick 寫入的替代來源。
+4. **D04 Real transitions**：hash/status/gate/candidate/summary/refs 任一真實變更只記一筆 action/history，current evidence hash 更新；相同內容但 state/ref 需修復也算一次轉換。下一相同結果為 no-op；contract verification hash 不改。
+5. **D05 Fail closed**：新 evidence 不可讀、schema 錯誤或 payload mismatch，維持既有保守錯誤處理，不放行、不空值相等、不 catch-all 轉成成功。
+6. **D06 Stable polling test**：隔離 fixture 連續 10 個 complete ticks，同候選／內容，runner count 持續增加，actions/history 相對既有基準不增加；修前須可重現 RED，不能調低 history limit 偽造成功。
+7. **D07 Content negative**：第 K 次在受控 fixture 保持 evidence path 但改 details/canonical hash，恰好追加一次，後續相同 tick 不追加。這是測試驗 equality，不授權 production writer 覆寫 immutable evidence。
+8. **D08 Repair and cleanup**：dirty→verified、candidate 改變、gate_state/ref 不一致修復各恰好一次；保留既有 dirty cleanup 會脫困的 regression，不依賴 #497/#821 已交付。
+9. **D09 Hash compatibility**：壞檔／不可讀／payload mismatch 負例與 #501 normalization 回歸通過；不得使用或改寫 `slice.verification.hash` 作為 current evidence hash，不重寫 #501 migration。
+10. **D10 Delivery evidence**：focused RED/GREEN、必要全套與 CI/policy、獨立 review、exact-head merge、loaded runtime 重複 tick 的 action/history delta 分開留證。`changelog.d/fix-dirty-recheck-idempotency.md` 與 CHANGELOG 同步；純進件不勾產品完成。
+
+## Evidence
+
+Production/source 基底 `79ba644780bf1c697c722ac24a297e7d02416100`，與 intake 基底 `60a3ffa8` 在相關 code/tests 無差異。
+
+- [manager.py:2093](https://github.com/hamanpaul/paulsha-cortex/blob/79ba644780bf1c697c722ac24a297e7d02416100/paulsha_cortex/coordinator/manager.py#L2093-L2129)：dirty summary 觸發 runner，驗證後無條件 apply。
+- [manager.py:394](https://github.com/hamanpaul/paulsha-cortex/blob/79ba644780bf1c697c722ac24a297e7d02416100/paulsha_cortex/coordinator/manager.py#L394-L449)：validator 核 payload/hash/實體檔，apply 呼叫 record_action 再 update_slice。
+- [registry.py:1591](https://github.com/hamanpaul/paulsha-cortex/blob/79ba644780bf1c697c722ac24a297e7d02416100/paulsha_cortex/coordinator/registry.py#L1591-L1676)：真正追加 history/action 的是 record_action，不是 update_slice。
+- [existing cleanup fixture](https://github.com/hamanpaul/paulsha-cortex/blob/79ba644780bf1c697c722ac24a297e7d02416100/tests/test_pre_candidate_recovery.py#L241-L330)：證明 dirty recheck 可轉到新 candidate，尚不是 10 次未變 no-op 證據。
+
+## Non-goals
+
+不改 #497 attempt supersession、#821 persist/history、#501 bucket index authority、immutable writer/quarantine、fanout、tick clock、evidence 位址或 verification runner 能力。不新增全域去重引擎，也不把歷史 116 秒 33 筆當本次 live 量測。

--- a/docs/superpowers/specs/fix-superseded-terminal-replay-design.md
+++ b/docs/superpowers/specs/fix-superseded-terminal-replay-design.md
@@ -1,0 +1,29 @@
+---
+status: accepted
+work_item: fix-superseded-terminal-replay
+---
+
+# Superseded terminal design
+
+## Decisions
+
+1. **Registry authority**：job/attempt 的 durable disposition 是 replay admission authority；manifest 只是既有投影/捷徑。Additive row 須含原 job、取代原因/actor/time、可驗 superseding identity 或 recovery request receipt；consumed 與 superseded 分開，不能因 exit=0 就推定 consumed。
+2. **Current identity**：slice 存在但 builder/reviewer 綁定非該 job，屬非現行 attempt；row 缺新欄位時仍需核對 binding。不以 `_slice_for_job()==None` 同時代表「真正無 slice」和「舊 job」；workflow-lane explicit unbound 規則保持獨立。
+3. **Atomic in one registry snapshot**：新增專用原子 recovery 操作，先 revalidate expected builder/reviewer/candidate/state 與 recovery identity，再 staged mutation、單次 persist；失敗恢復 memory/durable snapshot。清除使用此 explicit API，不改 update_slice 的既有 None semantics。
+4. **Idempotent request boundary**：先識別相同已成功 receipt 再套 allowed-action gate，無合法 receipt 的 pending 不放行；CAS conflict 不能 last-writer-wins。這是既有 owner/單 writer 權威內的一致性，不宣稱 #818 多 manager 共享檔案問題已修。
+5. **Producer integration**：核對並讓 slice/work 的 recover、abandon、retry-build→repin 及新 binding 更新消費同一 disposition 契約。Production 最小範圍為 registry、manager、work_actions；#547 的 target 選擇/雙入口廣泛整併仍原票負責。若 trace 證明需第四模組，先回 root 重評，不暗中擴張。
+6. **Early completion guard**：terminal status 確定後，對已定位的 lane/current identity 做 admission，再碰 repo root、branch/candidate、evidence、handoff。被 skip 的 stale job 不執行那些副作用；malformed job/真正 missing proof 保持目前 fail-closed。
+7. **Durable consumption**：只有 required evidence、slice/gate transition、completion/handoff 等該路徑必要 proof 已具足才可 consumed。跨檔 proof 寫入需可重入順序與 receipt/reconciliation；crash 後補缺失，不得用 consumed 先遮掉未完成 proof。不改 immutable writer/quarantine 規範。
+8. **Reclaim is separate resource work**：filesystem reclaim 與 registry commit 不是同一原子寫入。沿既有 owner-aware reclaim，失敗保留具體 recoverable disposition，只有所有必要子步驟完成才回完整成功；不得因原子 row 更新就聲稱 workspace 也已處置。
+9. **Tick ordering**：基底 `run_tick` 是 dispatch_gate_scan→fanout→complete（manager.py:2605–2655），非 completion→fanout。先獨立驗 recovery→complete 不污染，再以完整 run_tick 真實順序驗一次派工；不修改順序或 #383 gate 以滿足錯誤 fixture。
+10. **Sizing**：domain_breadth=1（2–3 production 模組），state_consistency=2（job/slice/proof 跨持久物件 CAS、故障與 restart）。真實 fix-standard 分數依 pure helper；即使 #831 完整 stability=0，本 parent 仍 Red，不能整包派到 build。
+
+## Verification
+
+以 `tests/test_pre_candidate_recovery.py` 的 reachable candidate=None fixture 與真隔離 Git repo 作起點；新的 `tests/test_superseded_terminal_replay_497.py` 分別驗 builder、reviewer、workflow explicit-unbound、missing-slice、manifest missing/corrupt/指向新 job。Spy repo/candidate/evidence/handoff helpers 證實 stale skip 的零副作用，不只看 completed count。Fault injection 覆蓋 commit 前/後、proof 建立前/後、重複 request 與 late terminal。
+
+## Decomposition and Compatibility
+
+Report 列人工候選：registry disposition/CAS 原語、completion admission/consumption、recovery producer wiring/full-tick acceptance。每件都要有獨立 accepted authority、真實重新 sizing 與 parent S01–S13 coverage。這不是 #833 planner 產物；不註冊 child、不改 issue、不回填 depth/lineage。沒有全部必要 producer/consumer 接線與 parent end-to-end 驗證，不宣告 #497 完成。
+
+舊 row 可讀但 unknown disposition 不自動升為 consumed；既有證據與 current verification hash 保留，新的 row validation／copy／persist 與 #821 future additive fields 相容。若合法跨 attempt evidence-address 需求另現，作為有界後續 gap，不用本票改址掩蓋 replay。

--- a/docs/superpowers/specs/fix-superseded-terminal-replay-spec.md
+++ b/docs/superpowers/specs/fix-superseded-terminal-replay-spec.md
@@ -1,0 +1,37 @@
+---
+status: accepted
+work_item: fix-superseded-terminal-replay
+---
+
+# Superseded terminal identity and replay protection
+
+## Requirements
+
+Authority：[#497](https://github.com/hamanpaul/paulsha-cortex/issues/497)，完整保留 [#832 更正 todo](https://github.com/hamanpaul/paulsha-cortex/blob/60a3ffa867377b0c86fa2f10e91fb9820d91938c/docs/superpowers/workstreams/fix-superseded-terminal-replay/todo.md)。accepted 僅是進件規格，Red 必須保留；人工 split 候選不等於 #833 已產生 child 的 runtime 證據。
+
+1. **S01 Durable identity**：additive job/attempt superseded 與已完整 consumed 狀態可持久、可稽核、可 CAS/冪等更新；舊 row 缺欄位可讀，不新增 jobs.json 根欄位。
+2. **S02 Atomic recovery**：驗證原 builder/reviewer 綁定後，recover-pre-candidate 的同一次 durable 更新標記舊 jobs、slice/gate→pending，真正清除 builder_job_id/reviewer_job_id/candidate；不能以 `update_slice(None)` 假裝已清除。
+3. **S03 CAS and retry**：validation、state/history、supersession 一起成功或回復；stale recovery 不清除新 attempt。同一有身分 request 重送在 action gate 前可辨認已成功結果，不放寬其他 pending slice 的 allowed actions、不重追加 audit。
+4. **S04 Replacement and consumption**：abandon、retry-build→repin、新 binding 的真實取代路徑持久標記舊 job；正常收割只在所需 proof 與交易完成後標 consumed，不能先標完再丟 completion evidence。
+5. **S05 Early admission**：complete_tick 在解析 repo/branch HEAD/candidate/evidence path 前，skip superseded、已完整 consumed、或所屬 slice 存在但已非 current builder/reviewer 的 terminal job。真正 missing slice 保持 fail-closed，明確 workflow-lane unbound 例外保留。
+6. **S06 No stale side effect**：skip 不寫 evidence/handoff、不查 branch HEAD、不改 slice/action/history；舊 job/evidence 仍可讀。Current attempt 的正常 completion/review 和真正缺 proof 診斷不倒退，所有已列管 terminal 入口有 executable invariant regression。
+7. **S07 Reachable recovery fixture**：failed terminal builder、needs_human、candidate=None、明確 PSC_REPO_ROOT、合法 manifest；先證明 recover 在 allowed actions，再驗成功、bindings 真清除、舊 job superseded。合法 SHA dirty slice 不可拿來假造可 recover fixture。
+8. **S08 Completion and dispatch**：recover 後 complete_tick 不回舊 job 為 completed/errors、不寫舊 candidate evidence、不 quarantine，slice 保持 pending/history 不增；獨立完整 tick fixture 在其他 gates 合法時恰好派一個新 builder。Complete-only 不承諾派工。
+9. **S09 Manifest and restart**：至少測 needs_human＋空 verification_evidence_path＋verification-runner-error 的 manifest 回 None 路徑，另測 manifest missing/corrupt/已被新 job 取代；fresh JobRegistry/restart 仍 skip，不依賴單槽 manifest 保證已消費。
+10. **S10 Multi-attempt**：同 slice 多 terminal、manifest 指向最新 job，只允許 current 且未完成者終局化。合法 candidate 的 dirty slice 走 retry-build→repin，涵蓋 builder/reviewer 取代，不把所有 unbound job 當合法或全丟棄。
+11. **S11 Completed stability**：completed/passed slice 重啟後連續 10 ticks，CompletionRecord 與引用 evidence bytes 不變、不倒退 needs_human、不鎖下游；非 dirty recheck 的 superseded needs_human 靜止。合法 dirty recheck append 的 #496 殘餘不算本票缺陷。
+12. **S12 Failure matrix**：focused tests 覆蓋 stale CAS、原子寫入故障、重送、新舊 row、missing slice fail-closed、current attempt completion、歷史可讀。不可放寬 immutable writer 或靠未設定 repo root 讓修前提前 error 假綠。
+13. **S13 Delivery**：Cortex RED/GREEN、全套/CI/policy、獨立 review、exact-head merge、loaded runtime restart/proof 穩定分帳。同步 fragment 與 CHANGELOG；未過必要依賴與 parent 全部 AC，不關 #497。
+
+## Evidence
+
+基底 `79ba644780bf1c697c722ac24a297e7d02416100`，相關 code/tests 與 `60a3ffa8` 相同。
+
+- [manifest helper](https://github.com/hamanpaul/paulsha-cortex/blob/79ba644780bf1c697c722ac24a297e7d02416100/paulsha_cortex/coordinator/manager.py#L164-L215) 保留 job_id；不是 recover 一律清掉 manifest。 [terminal enumeration](https://github.com/hamanpaul/paulsha-cortex/blob/79ba644780bf1c697c722ac24a297e7d02416100/paulsha_cortex/coordinator/manager.py#L2131-L2170) 先依 manifest，再找現行綁定。
+- [update_slice](https://github.com/hamanpaul/paulsha-cortex/blob/79ba644780bf1c697c722ac24a297e7d02416100/paulsha_cortex/coordinator/registry.py#L1561-L1586) 的 None 為未提供；[recover call](https://github.com/hamanpaul/paulsha-cortex/blob/79ba644780bf1c697c722ac24a297e7d02416100/paulsha_cortex/coordinator/manager.py#L1738-L1828) 因此未真正清 binding。
+- [missing-slice-proof 分支](https://github.com/hamanpaul/paulsha-cortex/blob/79ba644780bf1c697c722ac24a297e7d02416100/paulsha_cortex/coordinator/manager.py#L2263-L2283) 需與 superseded unbound 分開；不能借題移除真正失聯 job 的診斷。
+- [既有 reclaim/manifest 測試](https://github.com/hamanpaul/paulsha-cortex/blob/79ba644780bf1c697c722ac24a297e7d02416100/tests/test_pre_candidate_recovery.py#L70-L235) 尚未驗 bindings 清空＋restart/complete/full tick 全鏈。
+
+## Non-goals
+
+不重做 #383 fanout、#496 dirty no-op、#501 contract/evidence hash 分離或 bucket index、#821 persist、#547 target selection。不可變 evidence 位址保持現行契約；原 issue「合法多次 observation 才需 attempt 位址」不構成本票授權普遍改址。本票消除不合法 replay，不新增自動 recovery/retry，不刪 job/證據，不宣稱跨 process writer lock 已由本票解決。

--- a/docs/superpowers/specs/registry-persist-hygiene-design.md
+++ b/docs/superpowers/specs/registry-persist-hygiene-design.md
@@ -1,0 +1,29 @@
+---
+status: accepted
+work_item: registry-persist-hygiene
+---
+
+# Registry persistence design
+
+## Decisions
+
+1. **One production module**：主要產品 scope 僅 `coordinator/registry.py`；必要 wrapper 修改屬 tests，不灌入 production domain。domain_breadth=0，state_consistency=2：disk/memory/digest/history/rollback 的一致性與 crash 邊界必須共同維持。
+2. **One canonical serialization**：`json.dumps(ensure_ascii=False, indent=2, sort_keys=True)` 的 UTF-8 bytes 為 digest 與落盤共同來源。`_persist` 可傳 optional serialized 給保留 dict positional 的 writer；缺 serialized 的 v1 caller 使用同一格式。相同 bytes 且 state 存在才 no-op，metadata 保持不動。
+3. **Digest lifecycle**：constructor 初始化未知 digest；load 完成 schema/內容驗證且尚未 normalization-persist 前用 original bytes 建 baseline。Writer 只有 replace 及必要 durability steps 成功才更新 digest；fault 依既有 rollback/reload 恢復正確值。非 canonical 格式 load 可能正規化一次，不能用 memory snapshot 誤當磁碟內容。
+4. **History configuration**：constructor 明示 history_limit 優先於 env，env 優先 default 500；constructor bool/非整數、env 非正十進位整數及 ≤0 均拒絕。Counter 僅允許三種 history key 的非負整數，bool 非合法 integer；缺欄位/缺 key 按零，未知格式拒絕而不靜默重設。
+5. **Shared trim helper**：record_action 真正 append 後 trim；load 在新 row/list/counter 上 trim，保留原 payload 比較。limit=1 最新；其他首筆+最新N。Current refs 與 completion 引用資料不依 history 截斷消失，counter 僅說明丟棄量、不冒稱全歷史可重播。
+6. **Copy invariants**：_copy_slice 與 loader 為 nested history_truncated 建獨立 dict；沿用 list item copy 契約。No-op 判定、normalization-once 與其他 additive row 欄位相容，不加 payload root keys。
+7. **Hardlink rollback**：backup 使用同目錄唯一名稱，不能直接對仍存在的 mkstemp placeholder 做 os.link；安全釋放佔位並建立 link，保留必要 fd/path 清理與 error propagation。任何 link OSError 回既有 copy+fsync，無法安全備份則不 replace。Replace 後 fsync 故障恢復舊 inode/bytes，rollback 失敗仍報真正 durable fault，不吞掉。
+8. **Conservative cleanup admission**：age+pattern 僅候選條件。刪除前必須有可信的 inactive writer 身分證據，或由既有 owner authority 證明此 instance state 目錄獨占；無法取得時預設 skip+具體診斷。不得新增「呼叫者傳 true 就當獨占」的旁路，也不在本票建立 #818 的跨 process lock。舊 random tmp 缺 owner metadata 時保持 unknown；這是明示安全 residual，不宣稱 cleanup rate 已改善。
+9. **One-level non-following sweep**：construction 一次、regular files only、no symlink follow、grace 不低於30；匹配限定 tmp*.tmp/tmp*.backup.tmp/tmp*.rollback.bak。掃描錯誤只影響 cleanup 診斷，不能改 _load 對 state 無權/壞檔的拒收結果。重啟再次掃同一已處置檔安全 no-op。
+10. **Archive boundary**：保留首/近期與計數不是完整 archive。需要完整歷史的部署在 root/operator 另行保存已驗證原 registry 備份前不得套用 destructive truncation；不在本票添加 archive 引擎。主流程對 #829 記錄 missing full-retention 能力，不因 H04 綠燈消除此 residual。
+
+## Verification
+
+新 `tests/test_coordinator_registry_persist_hygiene.py` 使用隔離 state、fake clock、monkeypatch writer/link/fsync/fault、可計數 tmp 建立；沒有 live process 或模型 probe。Sweep 的正例必須附可驗 exclusive/terminated-owner fixture，負例含老檔但活躍 writer；mtime-old alone 絕不充分。明示「production owner proof 缺席會 skip」與 unit positive proof 的差別。
+
+H01–H11 完整映射原 todo T01–T11；documentation/CLI/實際 sizing 在新增 T12–T13。如果要分解，report 的 digest、bounded-history、rollback/sweep 三候選各須具獨立 acceptance；parent 不因任何一件完成而關閉。
+
+## Compatibility and Risks
+
+不動 schema version/root key/mtime-size reload策略，不宣稱多 manager stale snapshot 已解決；#818 仍是共享寫入依賴。Hardlink 不支援走 copy，因此某 filesystem 不一定取得相同效能。History 限額減單次檔案大小，#496 決定寫入頻率；digest 僅減真 no-op，不能將其測試冒稱 E1 現場頻率改善。

--- a/docs/superpowers/specs/registry-persist-hygiene-spec.md
+++ b/docs/superpowers/specs/registry-persist-hygiene-spec.md
@@ -1,0 +1,34 @@
+---
+status: accepted
+work_item: registry-persist-hygiene
+---
+
+# Registry persistence hygiene
+
+## Requirements
+
+Authority：[#821](https://github.com/hamanpaul/paulsha-cortex/issues/821)，完整保留 [#832 更正 todo](https://github.com/hamanpaul/paulsha-cortex/blob/60a3ffa867377b0c86fa2f10e91fb9820d91938c/docs/superpowers/workstreams/registry-persist-hygiene/todo.md)。#832 已將 issue 的錯誤 append fixture、mtime-only sweep、limit=1 與 rollback 範圍校正，本規格以該定案為準。
+
+1. **H01 Byte digest no-op**：穩定 UTF-8 JSON bytes SHA-256 相同且 state file 仍存在時，不 writer/mkstemp/replace、不改 mtime/inode；檔案被刪仍重建。Digest 不壓掉真正新 timestamp/history。
+2. **H02 Writer compatibility**：`_write_payload_atomically(payload)` 保留 dict 第一位置參數。若新增 optional serialized，既有 fault wrappers 同步傳送但保留 fault 條件與 rollback 斷言；v1 dict-only migration 不壞，不吞 TypeError。
+3. **H03 Load and rollback digest**：_load 在 normalization 能 persist 前先採原磁碟 bytes digest；成功 durable 寫入才採新 digest。Rollback `_load` 回復舊 digest，不能讓失敗候選誤擋下一次合法寫入。
+4. **H04 Bounded histories**：default=500，constructor/env 可覆寫、僅正整數。evidence_history/evaluation_history/actions 共用 helper；limit≥2 保留首筆＋最新 limit−1，limit=1 保留最新；每丟一項累計 row-level history_truncated，不重設既有計數。
+5. **H05 Load and copy**：舊 row 缺 counter 可讀，超限在複本正規化以保留原 payload 的比較，首次載入落盤、二次不再改寫；nested counter copy 不共享 live row。非法 limit/counter 型別/負值明確拒絕；root schema 不變。
+6. **H06 Rollback efficiency**：依 #832 accepted todo，直接 hardlink state inode 作 rollback，不能把 v1「先 copy tmp 再 link 命名」冒稱零複製。EPERM/EXDEV/其他不支援 hardlink OSError fallback 原 bytes+fsync；保留 replace 後 fsync 故障 rollback 語意。
+7. **H07 Ownership-safe startup sweep**：僅 constructor、state 目錄單層、指定 tmp patterns、grace≥30 秒且**可證 inactive writer 或獨占權威**才清。mtime 不構成 ownership 證明；未知／活躍略過並診斷。不可遞迴／跟 symlink／刪目錄、state、v1 backup、operator backup、必要證據；reload/persist 不 sweep。
+8. **H08 Persistence matrix**：連續三次 persist 及真實同狀態 update_status 不建 tmp、不改 mtime/inode；deleted state 重建；writer fault/rollback/normalization digest 正確。保留 #501 normalization 與 released claim-key load 回歸。
+9. **H09 Real append fixture**：limit=5，12 次 record_action(evidence_refs) 使 actions/evidence_history=5、首筆/第12筆保留、dropped=7；evaluation_refs 同驗。涵蓋 limit=1/2、超限 load、二次 no-op、counter 延續、copy 隔離，不用 update_slice 假裝 append。
+10. **H10 Filesystem negatives**：hardlink 成功、EPERM/EXDEV fallback、replace 前後 fault；sweep 保留活躍/未知/新檔/symlink/subdir/人工備份，只清已證失活且逾 grace 匹配檔。缺目錄正常建置；讀 state 無權仍維持原錯誤，不因 sweep 容錯偽裝載入成功。
+11. **H11 Delivery and retention**：Cortex focused RED/GREEN、fault/rollback、全套/CI/policy、review/merge、loaded runtime 寫入次數分帳；fragment/CHANGELOG 同步。輪替不等於完整 archive；current/completion 必要 evidence 仍可追、不可清。需要全歷史的部署在長期 archive 完成前，由已授權主流程保留原 registry 備份才啟用截斷。
+
+## Evidence
+
+基底 `79ba644780bf1c697c722ac24a297e7d02416100`，相關 code/tests 與 `60a3ffa8` 相同。
+
+- [registry load](https://github.com/hamanpaul/paulsha-cortex/blob/79ba644780bf1c697c722ac24a297e7d02416100/paulsha_cortex/coordinator/registry.py#L353-L484)、[writer/persist](https://github.com/hamanpaul/paulsha-cortex/blob/79ba644780bf1c697c722ac24a297e7d02416100/paulsha_cortex/coordinator/registry.py#L550-L641)：每次 persist 呼叫 writer；rollback 目前複製 bytes。
+- [history loader/copy](https://github.com/hamanpaul/paulsha-cortex/blob/79ba644780bf1c697c722ac24a297e7d02416100/paulsha_cortex/coordinator/registry.py#L944-L987)、[record_action](https://github.com/hamanpaul/paulsha-cortex/blob/79ba644780bf1c697c722ac24a297e7d02416100/paulsha_cortex/coordinator/registry.py#L1591-L1676)：append 的真實入口與 row copy seam。
+- [normalization regression](https://github.com/hamanpaul/paulsha-cortex/blob/79ba644780bf1c697c722ac24a297e7d02416100/tests/test_coordinator_registry_headless.py#L375)、[publication fault wrapper](https://github.com/hamanpaul/paulsha-cortex/blob/79ba644780bf1c697c722ac24a297e7d02416100/tests/test_planning_publication_transaction_536.py#L551-L572) 與 `tests/test_workflow_production_wiring.py:5773` 的 wrapper 必須保留原驗收語意。
+
+## Non-goals
+
+不改 #496 dirty recheck 決策、#497 supersession、#501 bucket index authority、tick clock、_reload_if_changed 判定、跨 process lock/#818、字串 schema migration、instance decommission、per-slice 分檔/壓縮。只加 row 欄位、不 bump schema、不新增 jobs.json 根鍵。長期全歷史 archive/retention 未由本票提供，保留 #829 gap；本次進件不刪 registry 或任何現場 tmp。

--- a/docs/superpowers/workstreams/execution-profile-contract/todo.md
+++ b/docs/superpowers/workstreams/execution-profile-contract/todo.md
@@ -4,7 +4,10 @@ work_item: execution-profile-contract
 domain_breadth: 2
 state_consistency: 2
 invariant_count: 10
-artifact_classes: [source, tests, documentation]
+artifact_classes:
+  - source
+  - tests
+  - documentation
 ---
 
 # Execution profile 契約 Todo

--- a/docs/superpowers/workstreams/execution-profile-contract/todo.md
+++ b/docs/superpowers/workstreams/execution-profile-contract/todo.md
@@ -1,0 +1,79 @@
+---
+status: accepted
+work_item: execution-profile-contract
+domain_breadth: 2
+state_consistency: 2
+invariant_count: 10
+artifact_classes: [source, tests, documentation]
+---
+
+# Execution profile 契約 Todo
+
+## Authority
+
+Issue [#835](https://github.com/hamanpaul/paulsha-cortex/issues/835)，parent #829，
+基準 `60a3ffa867377b0c86fa2f10e91fb9820d91938c`／PR #832。
+[Spec](../../specs/execution-profile-contract-spec.md)、[Design](../../specs/execution-profile-contract-design.md)
+為本計畫的完整 scope；accepted 不代表可直接派工。本件保留所有 A1–A6／I1–I10。
+production 跨 profile/identity/resolution、launcher/adapter、planning runtime、registry/workflow，
+故 domain_breadth=2；含 schema migration／重啟一致性，故 state_consistency=2。
+依 feature-oneshot，舊算法 10/Red；#831 修正 spec_stability 後預計 8/Red，仍須人工拆分。
+
+## Boundary
+
+產品碼與測試只由 Cortex 開發，本 intake 不實作；下列未勾工作是母範圍交付清單，
+不是將 Red 母件直接作單一 build 派工的指令。人工拆分須保留 parent AC owner、依賴、真實 sizing
+及正常 authority/registration/freeze，不能刪驗收／降分；#833 自動分解尚未可用。
+#842 是 qualification lifecycle owner；#581 保留五項解析／producer 原 scope，
+PatchMUD #37 只提供 CLI/file schema／immutable fixture，不引入 runtime import。
+
+## Tasks
+
+- [ ] source T01：建立版本化 profile/descriptor/requirements 純契約與嚴格 parser，保留 requested/resolved/observed、原生 effort、unknown（A1、A4、A5；I1、I2、I8）。
+      adapter/model/effort 擴充由資料表述，unknown role 不默認 build；role public seam 與 #581 對接。
+- [ ] source T02：實作 canonical request/resolved/actual-condition key 與 versioned migration seam（A4、A5；I6、I7、I9）。
+      精確條件變更要換 key，價格／時間戳不進能力 fingerprint；未知 observed 不外推 qualification。
+- [ ] source T03：建立 adapter protocol/conformance seam，接 SubprocessLauncher、CLI factory 與 planning_runtime 的生產入口（A1、A2、A6；I2、I3、I10）。
+      保留工具／sandbox、terminal、usage、quota capability、cancel/timeout 與 last-message；新 runtime 僅加受控 adapter。
+- [ ] source T04：接 model identity/resolver、manager/daemon 與 autonomy 的完整 profile 傳遞與硬條件 preflight（A3、A6；I4、I5、I7）。
+      pin 不降級且不豁免最低品質／independence／Trust Root；quota 未知不當零，也不在此加入 quota fallback。
+- [ ] source T05：於既有 WorkflowRun／JobRegistry 寫入邊界增 versioned sibling binding，保留舊嚴格欄位與 frozen chain（A5、A6；I8、I9、I10）。
+      隔離 state 驗證一致的舊／新版本；保留 attempt/evidence 原件，非 dispatch provenance 沿 #581 共用契約。
+- [ ] source T06：接 #842 exact-profile qualification consumer 與 #581／PatchMUD #37 producer contract，沿用 map_report_to_envelope（A3、A4、A6；I5、I7、I10）。
+      未核可／撤銷／過期／unknown 的回覆不得授予資格；發布與 CAS/crash 狀態機由 #842 負責，不在本票重做。
+- [ ] tests T07：新增 descriptor-only 虛構 model/native-effort、canonicalization 與逐欄 perturbation 測試（A1、A4）。
+      exact requested/resolved、不同產品 effort 不等價、unknown 不補值、價格／時間穩定均需 assert。
+- [ ] tests T08：新增 fake adapter 與受控本地 subprocess conformance，argv/terminal/usage/quota capability/cancel/timeout/工具/sandbox（A2）。
+      Event/barrier 取代碰運氣 sleep；unsupported 與每個 hard-gate 負例斷言 spawn_count=0。
+- [ ] tests T09：新增 unknown role、錯 pin、qualification 不足、同 domain reviewer、Trust Root 不合法且 quota 足夠仍拒絕的負例（A3）。
+      同時核對真正 resolver／preflight／factory，不只測 fake validator；真人批准不能由測試 receipt 替代。
+- [ ] tests T10：新增 legacy/frozen-chain round-trip、未知版／殘缺 descriptor、registry 寫入 failpoint／重啟與歷史不變性測試（A5）。
+      使用隔離 state 及真 serializer/loader，保存前後 bytes 或內容 digest 作 assert；不手填 evidence hash。
+      明確負例：缺可信原 schema／policy snapshot 的歷史 run 重讀仍為 legacy/unversioned/unknown，
+      不猜填今天／舊版、不回寫原 chain；缺正式 authority 重新接受的新版切換請求須拒絕。
+- [ ] tests T11：跑既有 model-resolution/per-work-chain/launcher、planning runtime、Trust Root、card sandbox、model-profile 回歸與 production producer/consumer 整合（A6）。
+      先離線 fake process，再以 PatchMUD #37 真 immutable fixture/revision 驗 CLI/file；fake 不冒充 real launcher。
+- [ ] documentation T12：同步 README／配置及 CLI 文件，說明 profile 版本、原生 effort、pin/preference、unknown、migration、#581／#842／PatchMUD #37 邊界。
+      新增模型／adapter 的擴充操作與 legacy 讀取語意一致，不給固定模型／agent／effort 推薦名單。
+- [ ] CLI T13：同步受影響 help／解析與離線 descriptor 驗證的正負例，保留既有選項相容性；僅 --help／離線驗證不啟動模型。
+      不因增加 descriptor 而繞過 executable trust 或 sandbox；實際 provider probe 留獨立授權 gate。
+- [ ] changelog T14：由 Cortex delivery 新增 changelog.d/execution-profile-contract.md 並同步 CHANGELOG.md [Unreleased]，滿足 R-09。
+- [ ] tests T15：執行 focused/full suite、CI 與帶真實 PR context 的 policy-check，檢查 R-09/R-16/R-19/R-22，記錄候選 SHA 與實際結果。
+      三件組與 authority 有修訂時走正式流程，不改已 frozen run 或現場 registry。
+- [ ] documentation T16：分帳記錄 implemented/tests/merged/installed/live 證據；交付真 launcher／installed／live 時另取所需權限及 #842 真人 receipt。
+      未執行不得勾通過；產品碼只由 Cortex 派工，active Manager restart、付費評測及 deployment 不由 intake 自動授權。
+
+## Dependencies
+
+先人工拆分／審查／正式進件，再由 Cortex 實作 schema 與 adapter；resolver 使用 #581 role/provenance
+與 #842 qualification 的受控接口，durable binding 整合所有入口。#581 eval producer 與 PatchMUD #37
+immutable fixture 是 A6 真整合前置；#842 的真人 receipt（政策要求時）是 live 前置。
+#600／#836–#840 只消費本件契約，各自實作 availability／quota／forecast／reservation／admission／status。
+root 本輪僅採 schema-core 優先的人工規劃順序；其餘 child 候選仍須誠實重評／再拆，
+本裁決未建立 issue、註冊 work item 或授權產品／runtime／真人 qualification 操作。
+
+## Verification Status
+
+產品實作、產品 tests passed、PR merged、installed、live accepted 目前均未完成。
+本 intake 的純 planning helper 檢查與舊／預計新 sizing，另記於
+[審查報告](../../../../reports/review/refine-profile-intake-20260907.md)，不充當 builder qualification。

--- a/docs/superpowers/workstreams/fix-dirty-recheck-idempotency/todo.md
+++ b/docs/superpowers/workstreams/fix-dirty-recheck-idempotency/todo.md
@@ -1,6 +1,13 @@
 ---
 status: accepted
 work_item: fix-dirty-recheck-idempotency
+domain_breadth: 0
+state_consistency: 1
+invariant_count: 10
+artifact_classes:
+  - source
+  - tests
+  - documentation
 ---
 
 # Dirty recheck 結果未變時的寫入冪等
@@ -20,43 +27,49 @@ work_item: fix-dirty-recheck-idempotency
 - 不改不可變 evidence writer／quarantine、fanout gate、tick clock、證據位址或
   verification runner 的驗證能力。#496 與 #497 各自測試與交付，不建立第三個 bucket-C run。
 
+Spec/design：`docs/superpowers/specs/fix-dirty-recheck-idempotency-{spec,design}.md`。
+本清單保留 #832 全部原 AC；accepted 不代表 product implementation 或 runtime admission。
+
 ## Tasks
 
-- [ ] 在 `complete_tick` dirty recheck 中，先以 `_validate_result_evidence` 驗證新
+- [ ] **T01 source／D01**：在 `complete_tick` dirty recheck 中，先以 `_validate_result_evidence` 驗證新
       evidence，再在 `_apply_verification_result` 呼叫點建立 no-op 閘門；不把
       所有呼叫者的去重責任下沉到 `_apply_verification_result`。
-- [ ] 比較 canonical 內容 hash 與 slice 的 `current_verification_evidence_hash`，
+- [ ] **T02 source／D02**：比較 canonical 內容 hash 與 slice 的 `current_verification_evidence_hash`，
       並比較預期 state／gate_state、summary、candidate 與 current evidence refs；
       全部一致才略過。只有 ref path 相同不能判成未變；合法 hash 缺失或目前證據
       不可解析不能當成相等。若內容相同但需修正 slice 狀態／引用，仍作一次真實轉換。
-- [ ] 相同結果不 `record_action`、不追加 evidence_history、不 `update_slice`；
+- [ ] **T03 source／D03**：相同結果不 `record_action`、不追加 evidence_history、不 `update_slice`；
       驗證仍確實執行。若需要 last_rechecked_at 觀測，與 lifecycle history 分離，
       屬 optional；不能藉此恢復每 tick 的歷史 append。
-- [ ] hash／status／gate_state／candidate／summary／refs 任一真實變更，沿原路徑
+- [ ] **T04 source／D04**：hash／status／gate_state／candidate／summary／refs 任一真實變更，沿原路徑
       記錄恰好一筆 action 及 evidence_history，更新 current evidence hash；下一次
       相同結果即 no-op。不改 contract verification hash。
-- [ ] `_validate_result_evidence` 對不可讀／schema 不合法／payload mismatch 失敗時
+- [ ] **T05 source／D05**：`_validate_result_evidence` 對不可讀／schema 不合法／payload mismatch 失敗時
       維持既有保守錯誤處理，不放行為成功、不視為證據未變；不得以 catch-all equality
       或空值相等遮蔽壞證據。
-- [ ] 新增 `tests/test_dirty_recheck_idempotency_496.py` 或等價 focused 檔案，沿
+- [ ] **T06 tests／D06**：新增 `tests/test_dirty_recheck_idempotency_496.py` 或等價 focused 檔案，沿
       `tests/test_pre_candidate_recovery.py::test_candidate_worktree_dirty_reevaluation_on_tick`
       fixture：fake verification runner 回當前相同候選／內容，連續10次
       `complete_tick`，斷言 runner 仍被呼叫、action/history 數從既有基準完全不變、
       current evidence hash 不變；修前應 RED，不用降低 history limit 偽造不增長。
-- [ ] 同一 fixture 在第K次改回傳證據 details，維持同 path 但 canonical hash 改變；
+- [ ] **T07 tests／D07**：同一 fixture 在第K次改回傳證據 details，維持同 path 但 canonical hash 改變；
       斷言只增加一筆 action/history 且 hash 更新，後續 ticks 不再增加。此為受控
       測試 evidence fixture，不授權生產 writer 覆寫既有不可變證據。
-- [ ] 另測 dirty→verified、candidate 改變、gate_state 或 refs 不一致修復，每次真實
+- [ ] **T08 tests／D08**：另測 dirty→verified、candidate 改變、gate_state 或 refs 不一致修復，每次真實
       轉換恰好一次；原 `test_candidate_worktree_dirty_reevaluation_on_tick` 保持綠燈。
       不要求此測試依賴 #497 或 #821 已實作。
-- [ ] 壞檔／不可讀／payload mismatch 均保持 fail-closed；contract hash 不受 recheck
+- [ ] **T09 tests／D09**：壞檔／不可讀／payload mismatch 均保持 fail-closed；contract hash 不受 recheck
       改動。沿既有 #501 normalization 測試確認舊資料讀取相容，不重寫 migration。
-- [ ] 新增本正式 work_id 對應的 changelog fragment，同步
+- [ ] **T10 documentation／D10**：新增本正式 work_id 對應的 changelog fragment，同步
       `CHANGELOG.md [Unreleased]`；記錄 RED／GREEN、必要完整 gates、獨立 review、
       正確 HEAD merge 與 runtime 重複 tick 的 evidence/history delta。進件 accepted
       不代表任何測試或部署已完成。
 
-## 歷史證據與關聯
+- [ ] **T11 documentation／CLI**：在既有 recovery 文件補 dirty polling 與 lifecycle transition 的區別，未變結果不追加歷史；以候選環境從 checkout 外實跑 `python3 -m paulsha_cortex.cli work start --help`、`python3 -m paulsha_cortex.cli run work --help`，保存 exit/output。無新增 action，help 未變也實測，不呼叫 live manager。
+- [ ] **T12 tests／intake and delivery gates**：純函式檢查 accepted 三件組、source/tests/documentation surface 與 changelog/CLI/test/doc 契約；依實際 packaged fix-standard 及原 domain/state 計分。先 focused 再 full pytest/CI/PR-context policy、git diff --check；Red 不直接派 build，#831 後以實際 runtime 重算，不回填歷史 band。
+
+## Evidence
 
 - issue #496 的歷史現場為約116秒增加33筆 verification-failed action/history；
   該量測不等於這次 host 的最新值。成因是 `_apply_verification_result` 呼叫

--- a/docs/superpowers/workstreams/fix-superseded-terminal-replay/todo.md
+++ b/docs/superpowers/workstreams/fix-superseded-terminal-replay/todo.md
@@ -1,6 +1,13 @@
 ---
 status: accepted
 work_item: fix-superseded-terminal-replay
+domain_breadth: 1
+state_consistency: 2
+invariant_count: 13
+artifact_classes:
+  - source
+  - tests
+  - documentation
 ---
 
 # Superseded terminal job 的持久身分與防重播
@@ -17,61 +24,67 @@ work_item: fix-superseded-terminal-replay
 - #501 的 contract/evidence hash 分離已存在；本票維持正確 current evidence hash，
   不以修改 contract hash 或重寫 evidence 位址掩蓋 attempt 混淆。
 
+Spec/design：`docs/superpowers/specs/fix-superseded-terminal-replay-{spec,design}.md`。
+保留 #832 全部 parent AC。完整 parent 即使依 #831 定案 stability=0 仍須真實 sizing；Red 不降分，report 的人工候選不是 #833 自動 planner evidence。
+
 ## Tasks
 
-- [ ] 以 additive registry job／attempt 欄位持久記錄 superseded／已消費狀態，
+- [ ] **T01 source／S01**：以 additive registry job／attempt 欄位持久記錄 superseded／已消費狀態，
       提供 CAS／冪等更新。沿用可稽核的 superseded_at／superseded_by／superseded_reason
       或等價具體結構，缺新欄位的舊 state 正常載入；不新增 jobs.json 根欄位。
-- [ ] 為 recover-pre-candidate 增加明確的 registry 原子動作：在驗證原 builder／
+- [ ] **T02 source／S02**：為 recover-pre-candidate 增加明確的 registry 原子動作：在驗證原 builder／
       reviewer 綁定仍相同後，同一次 durable 更新將舊 job 標 superseded、slice 轉
       pending、gate_state 轉 pending，並清掉 builder_job_id／reviewer_job_id／candidate。
       不再依賴 `update_slice(...=None)`：現行該 API 把 None 當未提供，不會清欄位。
-- [ ] 原子動作內的 validation／state／history 與 supersession 一起成功或回復；
+- [ ] **T03 source／S03**：原子動作內的 validation／state／history 與 supersession 一起成功或回復；
       fault injection／CAS conflict 不得留下「slice pending 但仍綁舊 job」或「新
       attempt 綁定被舊 recover 清掉」的半套 durable 狀態。重複同一 recovery request
       不重複標記或寫 action；在 action gate 前處理有身分可驗的既有成功結果，
       不藉此放寬其他 pending slice 的 allowed actions。
-- [ ] 核對 abandon／retry-build→repin／新 attempt 綁定的取代路徑：當前綁定真的
+- [ ] **T04 source／S04**：核對 abandon／retry-build→repin／新 attempt 綁定的取代路徑：當前綁定真的
       被取代時持久標記舊 job；正常 terminal 被成功收割後保存 consumed 身分，
       不依賴單一 manifest job_id 推測跨重啟已消費。新增標記不可讓尚未完整持久化的
       completion proof 被略過，需與相應交易邊界一致。
-- [ ] `complete_tick` 對 terminal job 在解析 repo root／branch HEAD／candidate／
+- [ ] **T05 source／S05**：`complete_tick` 對 terminal job 在解析 repo root／branch HEAD／candidate／
       evidence path 之前先 skip：已標 superseded／已完整消費者，或其 slice 存在
       但當前 builder/reviewer 綁定已非該 job。不能只檢查 `_slice_for_job` 回 None
       就掉進 missing-slice-proof；真正 slice 不存在的 job 保持現行 fail-closed 行為。
-- [ ] skip 舊 job 不寫 evidence、不改 handoff、不解析 branch HEAD、不追加 slice
+- [ ] **T06 source／S06**：skip 舊 job 不寫 evidence、不改 handoff、不解析 branch HEAD、不追加 slice
       action/history；舊 job／舊 evidence 仍能讀取。保留真正當前 attempt 正常
       completion/review 與缺 proof 診斷，並以 source invariant 測試涵蓋所有 terminal 入口。
-- [ ] recovery fixture 沿
+- [ ] **T07 tests／S07**：recovery fixture 沿
       `tests/test_pre_candidate_recovery.py::test_recover_pre_candidate_supersedes_stale_handoff_manifest`：
       明設 `PSC_REPO_ROOT`、failed terminal builder、needs_human slice 且
       `candidate=None`，寫合法舊 manifest；先斷言 allowed actions 包含 recover，
       再執行 action 並斷言成功、bindings/candidate 真為 None、舊 job 已 superseded。
       不得使用帶合法 candidate SHA 的 dirty slice 呼叫 recover，那會被 action gate 擋下。
-- [ ] recovery 後執行 `complete_tick`，completed／errors 都不含舊 job，沒有對舊
+- [ ] **T08 tests／S08**：recovery 後執行 `complete_tick`，completed／errors 都不含舊 job，沒有對舊
       candidate 寫 evidence、沒有 quarantine，slice 維持 pending，history 不增。
       另在完整 `run_tick`／fanout fixture 中驗其他 gates 均合法時恰好派一個新 builder；
       `complete_tick` 本身不承諾派工。設定 repo root 避免測試提前 error 卻假綠。
-- [ ] manifest 回 None 的變體必測：gate_status=needs_human、
+- [ ] **T09 tests／S09**：manifest 回 None 的變體必測：gate_status=needs_human、
       verification_evidence_path=None、gate_reason=verification-runner-error；
       修前會重跑舊 job，修後仍跳過。再以 fresh JobRegistry 模擬 daemon restart，
       驗證 supersession／consumed 與 skip 持續有效。
-- [ ] 同一 slice 的多個 terminal jobs（例如 -6／-8／-9，manifest 指向 -9）只讓
+- [ ] **T10 tests／S10**：同一 slice 的多個 terminal jobs（例如 -6／-8／-9，manifest 指向 -9）只讓
       真正目前綁定且尚未合法完成者終局化；unbound 舊 job 不推導 candidate。
       帶合法 SHA 的 dirty slice 走 `retry-build`→repin 的合法路徑，覆蓋舊 builder
       與 reviewer 被取代的情境；不可偷換成不可達的 recover fixture。
-- [ ] completed/passed slice 在 restart 後連續10個 ticks，completion record 與
+- [ ] **T11 tests／S11**：completed/passed slice 在 restart 後連續10個 ticks，completion record 與
       被引用 evidence bytes 不變，不倒退 needs_human、不反鎖下游 deps；needs_human
       但不符合 dirty recheck 的 superseded 情境保持靜止，驗的是舊 replay 來源，
       不將 #496 尚未實作的合法 dirty recheck append 當本票責任。
-- [ ] 新增 `tests/test_superseded_terminal_replay_497.py` 或等價 focused 檔；涵蓋
+- [ ] **T12 tests／S12**：新增 `tests/test_superseded_terminal_replay_497.py` 或等價 focused 檔；涵蓋
       stale CAS、原子寫入故障、重複 recovery request、新舊 row 相容、真正 missing slice
       fail-closed、current attempt 正常完成與歷史可讀。不可放寬 immutable writer。
-- [ ] 補本正式 work_id changelog fragment 與 `CHANGELOG.md [Unreleased]`，透過
+- [ ] **T13 documentation／S13**：補本正式 work_id changelog fragment 與 `CHANGELOG.md [Unreleased]`，透過
       Cortex 記錄 RED／GREEN、必要完整 gates、獨立 review、merge、runtime restart
       與 completion proof 穩定性的證據。accepted todo 不等於修正／測試／部署完成。
 
-## 歷史證據與關聯
+- [ ] **T14 documentation／CLI**：更新 recovery/runbook 對 current/superseded/consumed、合法 pre-candidate request replay 及缺 proof 的說明；保留 slice/work action 邊界。從 checkout 外實跑候選 `python3 -m paulsha_cortex.cli work start --help`、`python3 -m paulsha_cortex.cli run work --help`，另以隔離 request fixture 驗欄位/拒絕，不呼叫 live manager。
+- [ ] **T15 tests／parent accounting**：純 completeness/contract/sizing 與完整 parent S01–S13 mapping 守門；Red 先受治理分解，每個 child 個別 sizing，不偽造 planner lineage。Parent closure 必須補齊所有 child、full pytest/CI/PR-context policy、review、exact-head merge 與 loaded runtime restart 證據；source 成功不替代 runtime。
+
+## Evidence
 
 - 舊紀錄中的 recover 後 pending 無法存活、unbound -8 汙染 bound -9 證據位址、
   manager 重啟後 completed slice 被回寫，是此票的回歸來源，不是此次 live 結果。

--- a/docs/superpowers/workstreams/registry-persist-hygiene/todo.md
+++ b/docs/superpowers/workstreams/registry-persist-hygiene/todo.md
@@ -1,6 +1,13 @@
 ---
 status: accepted
 work_item: registry-persist-hygiene
+domain_breadth: 0
+state_consistency: 2
+invariant_count: 11
+artifact_classes:
+  - source
+  - tests
+  - documentation
 ---
 
 # Registry persistence 與 history 有界化
@@ -22,52 +29,57 @@ work_item: registry-persist-hygiene
   retention 由 umbrella successor 列管，本票不宣稱提供全歷史重播。需完整歷史的
   既有部署在 archive 能力完成前，先由主流程保存原 registry 備份再啟用截斷。
 
+Spec/design：`docs/superpowers/specs/registry-persist-hygiene-{spec,design}.md`。
+保留 #832 明定的全部 AC，包括 hardlink、limit=1、writer ownership 與 archive residual；不得只沿用 #821 初稿的較弱 mtime-only sweep。
+
 ## Tasks
 
-- [ ] `_persist` 產生穩定 JSON（`ensure_ascii=False, indent=2, sort_keys=True`），
+- [ ] **T01 source／H01**：`_persist` 產生穩定 JSON（`ensure_ascii=False, indent=2, sort_keys=True`），
       以實際 UTF-8 bytes 的 SHA-256 比對 `_last_persisted_digest`；相同且 state
       檔仍存在時不呼叫原子 writer、mkstemp 或 replace。state 檔遭刪除仍須重建。
-- [ ] `_write_payload_atomically(payload)` 保留 dict 位置參數呼叫契約。若新增
+- [ ] **T02 source／H02**：`_write_payload_atomically(payload)` 保留 dict 位置參數呼叫契約。若新增
       optional `serialized=` 以避免重複序列化，需同步讓既有 fault-injection
       wrappers 接收／轉送該 keyword，不改其故障條件與 rollback 斷言：
       `tests/test_workflow_production_wiring.py::fail_plan_transition` 與
       `tests/test_planning_publication_transaction_536.py::crash_on_plan_transition`。
       v1 migration 原本只傳 dict 的路徑仍有效；不得用吞 TypeError 掩蓋相容性錯誤。
-- [ ] digest 只在成功寫入後更新；`_load` 必須在 normalization 可能觸發 `_persist`
+- [ ] **T03 source／H03**：digest 只在成功寫入後更新；`_load` 必須在 normalization 可能觸發 `_persist`
       之前以磁碟原始 bytes 建立 digest。rollback 重新 `_load()` 時恢復原 digest，
       不得讓失敗候選的 digest 遮蔽下一次正確寫入。
-- [ ] 新增 `DEFAULT_SLICE_HISTORY_LIMIT=500`，可由
+- [ ] **T04 source／H04**：新增 `DEFAULT_SLICE_HISTORY_LIMIT=500`，可由
       `PSC_COORDINATOR_SLICE_HISTORY_LIMIT` 或 `JobRegistry(history_limit=...)`
       覆寫，僅接受正整數。三種列表 `evidence_history`／`evaluation_history`／
       `actions` 共用輪替 helper：limit≥2 保留首筆及最新 limit−1 筆；limit=1
       保留最新一筆，避免第一筆永久遮蔽當前事件；每個丟棄項累計至
       `slice_row["history_truncated"][key]`，不重設已有計數。
-- [ ] `_validate_loaded_slice` 以複本正規化超限 history，不就地修改原始 payload，
+- [ ] **T05 source／H05**：`_validate_loaded_slice` 以複本正規化超限 history，不就地修改原始 payload，
       使既有 `slices != payload["slices"]` 偵測可落盤一次；第二次載入不再改寫。
       缺少 `history_truncated` 的舊檔正常讀取；`_copy_slice` 為該巢狀 dict 建立
       獨立複本。非法 limit／counter 類型或負值需有明確拒絕測試。
-- [ ] rollback snapshot 優先以 `os.link(state_path, backup)` 建立，同 filesystem
+- [ ] **T06 source／H06**：rollback snapshot 優先以 `os.link(state_path, backup)` 建立，同 filesystem
       成功時不重複複製整檔；EPERM／EXDEV／不支援 hardlink 等 OSError 時退回既有
       bytes 複製與 fsync 流程。這不同於 `_write_v1_backup` 的「先複製到 tmp 再
       link 命名」，不得混淆成本；保留替換後 fsync 失敗時的 rollback 語意。
-- [ ] construction 時只清理 state 目錄內已確認不屬於活躍 writer 的 stale temp：
+- [ ] **T07 source／H07**：construction 時只清理 state 目錄內已確認不屬於活躍 writer 的 stale temp：
       `tmp*.tmp`／`tmp*.backup.tmp`／`tmp*.rollback.bak`，grace 不低於 30 秒，
       不遞迴、不跟隨 symlink、不刪 subdirectory／jobs.json／v1 backup／人工備份。
       若無法證明 writer 已結束或此目錄具有獨占使用權，略過清理並留下診斷；
       檔案 mtime 超過 grace 本身不代表無活躍 writer。不要於 reload／persist 清理。
-- [ ] 新增 `tests/test_coordinator_registry_persist_hygiene.py`：一次 mutation 後
+- [ ] **T08 tests／H08**：新增 `tests/test_coordinator_registry_persist_hygiene.py`：一次 mutation 後
       連續三次 `_persist()`、同狀態 `update_status` 均 mkstemp=0、mtime_ns／inode
       不變；刪除 state 後可重建；writer error／rollback／normalization 的 digest
       正確；保留既有 #501 normalization 與 released claim-key load 測試。
-- [ ] history fixture 必須使用真正追加的 `record_action`：limit=5，12 次帶
+- [ ] **T09 tests／H09**：history fixture 必須使用真正追加的 `record_action`：limit=5，12 次帶
       `evidence_refs` 的 action 後 evidence_history／actions 為 5、保留首筆與第12筆、
       dropped=7；另用 `evaluation_refs` 驗 evaluation_history。覆蓋 limit=1、
       limit=2、超限載入、二次載入 no-op、既有 counter 延續、對 copy 改值不污染 live row。
       不得用 `update_slice(current_evidence_refs=...)` 期待 history 追加。
-- [ ] 測 hardlink 成功、EPERM／EXDEV fallback、replace 前後故障；stale sweep
+- [ ] **T10 tests／H10**：測 hardlink 成功、EPERM／EXDEV fallback、replace 前後故障；stale sweep
       保留活躍／未知 ownership／新檔／symlink／子目錄／人工備份，僅刪已證明失活
       且逾 grace 的匹配項。不存在目錄正常建置；無權讀 state 仍維持既有錯誤語意，
       不因 sweep 的容錯而偽裝 registry 已成功載入。
-- [ ] 補本 workstream changelog fragment 與 `CHANGELOG.md [Unreleased]`；透過
+- [ ] **T11 documentation／H11**：補本 workstream changelog fragment 與 `CHANGELOG.md [Unreleased]`；透過
       Cortex 記錄 RED／GREEN、fault/rollback regression、必要完整 gates 與 runtime
       寫入次數證據。不得把單純 digest 改善宣稱為 #496 的 E1 頻率已修。
+- [ ] **T12 documentation／CLI**：補 history_limit 來源/非法值、counter 與非完整 archive、sweep unknown-owner skip 診斷及 rollout 備份前置；從 checkout 外實跑候選 `python3 -m paulsha_cortex.cli work start --help`、`python3 -m paulsha_cortex.cli run work --help`，無新增 action 不等於可省略 CLI regression。不操作真 registry/服務。
+- [ ] **T13 tests／intake and delivery gates**：accepted 三件組與 source/tests/documentation surface 純檢查、原宣告真實 sizing；保留全 R-09/R-16/R-19，Red 不降分。Focused/fault tests 後跑 full pytest/CI/PR-context policy、git diff --check；#831 後以實際 loaded runtime 重算再派工，不用此 report 回填歷史。

--- a/openspec/changes/cortex-refine-complete/tasks.md
+++ b/openspec/changes/cortex-refine-complete/tasks.md
@@ -11,16 +11,17 @@
 - [ ] 2.1 透過 Cortex 完成 #822 argv/YAML canary，取得 RED/GREEN、review、policy 與 terminal delivery 證據。
 - [ ] 2.2 完成 #827 有界 refresh/coalesce、slow-provider 公平與 stop/diagnostics。
 - [ ] 2.3 完成 #819 not-idle clock、periodic 有效 max_load/require_idle 與非法值處置。
-- [ ] 2.4 完成 #496 內容/狀態冪等，驗同 path 內容改變仍恰好記錄。
-- [ ] 2.5 完成 #497 原子解除綁定、持久 supersession 與 restart/late-terminal 回歸；#501 只核對已修及殘餘污染。
-- [ ] 2.6 完成 #821 no-op persistence、history retention、writer/fault/rollback 相容與安全暫存清理。
+- [ ] 2.4 依 accepted 三件組完成 #496 內容/狀態冪等，驗同 path 內容改變仍恰好記錄；保留現行 7/Red，#831 後真重評。
+- [ ] 2.5 依 accepted 三件組分拆並完成 #497 原子解除綁定、持久 supersession 與 restart/late-terminal 回歸；#831 後仍預計 Red，#501 只核對已修及殘餘污染。
+- [ ] 2.6 依 accepted 三件組完成 #821 no-op persistence、history retention、writer/fault/rollback 相容與安全暫存清理；完整 archive 缺口/截斷前備份保持列管。
 - [ ] 2.7 完成 #823/#824 session 與 AGY timeout 合約，明示 cgroup restart survival 的獨立驗收。
 - [ ] 2.8 完成 #825 最小 durable backoff，所有 lane 與 corrupt-state/expiry 可測；不標 R05 完成。
 - [ ] 2.9 以實際已載入 revision 驗 B1 成效，退出暫時 bypass 前保存 active jobs 與 rollback 方案。
+- [ ] 2.10 由 #847 區分可信 frozen 自發布 metadata 等價與真 authority 變更；前者保持 needs_human/gates/attempt/model binding 且零 spawn，後者仍走合法 restart，缺 provenance 不豁免。
 
 ## 3. B2 可擴充配置與資格
 
-- [ ] 3.1 為 R08/R09/R12 建立/重用精確 child work items；#835 profile schema、原生 effort 與 registry 相容性先有 spec，完整母範圍仍須真實分拆。
+- [ ] 3.1 為 R08/R09/R12 建立/重用精確 child work items；#835 已有 accepted profile schema/原生 effort/registry 相容三件組，完整母範圍仍 Red，先 schema-key child 再分拆其他入口，不先勾產品完成。
 - [ ] 3.2 實作 adapter capability descriptors 與 conformance；新虛構 model/effort 無 central product-name diff。
 - [ ] 3.3 實作 requested/resolved/observed profile 與可追溯 effective argv/config；unsupported pre-spawn fail-closed。
 - [ ] 3.4 實作 PatchMUD versioned report consumer、legacy migration 與 profile/cohort/role/coverage 驗證。

--- a/reports/review/refine-evidence-intake-20260907.md
+++ b/reports/review/refine-evidence-intake-20260907.md
@@ -1,0 +1,189 @@
+# Refine B1 evidence intake report
+
+查證時間：2026-09-07 09:30 UTC。此文件只交規劃材料與唯讀純函式驗證；不宣稱產品修正、派工、merge、installed 或 live 完成。
+
+## Scope and Authority
+
+隔離 intake 子任務 branch `feature/refine-evidence-intake-20260907`，authoring base `60a3ffa867377b0c86fa2f10e91fb9820d91938c`（已合併 #832）。該子任務只允許本報告及三個 work_id 的 spec/design/todo 共 10 檔；不是 root 後續整合 PR 的完整 diff 範圍：
+
+- `docs/superpowers/specs/fix-dirty-recheck-idempotency-{spec,design}.md`、`docs/superpowers/workstreams/fix-dirty-recheck-idempotency/todo.md`。
+- `docs/superpowers/specs/fix-superseded-terminal-replay-{spec,design}.md`、`docs/superpowers/workstreams/fix-superseded-terminal-replay/todo.md`。
+- `docs/superpowers/specs/registry-persist-hygiene-{spec,design}.md`、`docs/superpowers/workstreams/registry-persist-hygiene/todo.md`。
+
+Live issues #496/#497/#821 均 OPEN；讀回後以 #832 已接受更正 todo 保留原始 scope/AC，而非退回 issue 的舊假設。隔離 authoring 當下沒有 commit/push、`.cortex` 註冊、issue 修改、code/tests、operator registry/runtime/service 變更；#501 bucket index authority 未碰。產品 todo 要求的 changelog/CI/policy 由後續正式交付補上，不在該子任務 10 檔授權外新增；root 後續整合/提交以獨立紀錄為準，不預述未來 Git 狀態。
+
+## Source and Test Findings
+
+Source/test 基底為 `79ba644780bf1c697c722ac24a297e7d02416100`。`git diff 79ba6447..60a3ffa8 -- paulsha_cortex tests` 無差異，故來源錨點同時適用本 intake base。Runtime tree 有既存 `service-manager.sh` dirty，未改；不宣稱整棵 runtime clean。
+
+| Work | 已實作及有測試的邊界 | 必要差額／不重做 |
+|---|---|---|
+| #496 | manager.py:394 validator；:426 apply；tests/test_pre_candidate_recovery.py:241 的 dirty cleanup 會前進 | manager.py:2093–2129 驗後仍無條件 apply；registry.py:1650/1673 真正 append。新增 caller-level no-op，保留 #501 current hash 與 immutable writer。舊現場頻率不當本次量測。 |
+| #497 | manager.py:164–215 的 manifest shortcut/superseded audit；tests/test_pre_candidate_recovery.py:139 驗 manifest | registry.py:1561–1579 的 None 不清 binding；manager.py:2131–2170 仍枚舉 terminal、:2263–2283 unbound/missing proof 易混淆。補持久 disposition/原子 clear/early admission，不重做 #383。 |
+| #821 | registry.py:572–641 atomic replace、rollback/reload；headless test:375 保護 #501 normalization；publication test:553 fault wrapper | 無 digest no-op/有界 history/ownership-safe cleanup；record_action 才是 append fixture。保留 schema/root whitelist/reload 策略，hardlink fallback 與 archive residual 全保留。 |
+
+具體校正：`run_tick`（manager.py:2605–2655）先 scan/fanout 再 complete，不採舊敘述「complete 一定先於 fanout」。#497 分兩個測試面：recover→complete 的純 skip；以及合法完整 run_tick 的一次新 builder。真正缺 repo root 的 early error 不是 replay 被修的證據。
+
+不可變來源與 fixture 已逐項列於三份 spec Evidence；該清冊為當下明確入口佐證，不保證不存在其他 terminal consumer。新 implementation 的 executable invariant 必須對列管入口守門，新增入口未分類應使測試失敗。
+
+## Pure Completeness and Sizing
+
+從 checkout 外執行現行 runtime 的 `planning.py`，`PYTHONDONTWRITEBYTECODE=1`，不建立 registry、不呼叫模型或 capability probe。實讀 packaged `fix-standard`：gate_spine=2、cards=9、persona_binding=9。Sizing 適用全集 R-09/R-16/R-19；不改 combo、persona 或門檻。
+
+| Work | domain/state 的真實邊界 | 現行五維 domain/state/acceptance/stability/orchestration | 現行 band | 同輸入採 #831 定案映射 |
+|---|---|---|---|---|
+| #496 | 0/1：只改 Manager 一個 production flow；lifecycle hash/state/ref 一致性 | 0/1/2/2/2 = 7 | Red | 0/1/2/0/2 = 5，Yellow |
+| #497 | 1/2：registry/manager/work_actions；多持久物件 CAS/restart/proof | 1/2/2/2/2 = 9 | Red | 1/2/2/0/2 = 7，Red |
+| #821 | 0/2：單 registry production 模組；disk/memory/digest/history/rollback | 0/2/2/2/2 = 8 | Red | 0/2/2/0/2 = 6，Yellow |
+
+三案 spec/design/plan 均 `accepted`、無 missing kind/blocking marker；task **首行**含 source/tests/documentation，新增 CLI/doc 任務也在 Tasks 下。用真 `plan_review_gate` 檢查三 surfaces 及 R-09/R-16/R-19/R-22：completeness/contract_compatibility 通過，envelope observation 為 `envelope_unavailable` bypass。本次沒有提供或偽造 builder 能力查表；單獨 gate ready 不代表 Red 可派工。
+
+最後欄是**純規格投影**：同一組已 accepted 輸入，按 #831 定案完整 stability risk=0 建立 SizingScore，其餘四維不變；不是 #831 新 runtime 的實測，也未 patch/import 一個假修正版。正式派工必須等 #831 實際交付後重新計分，不能把投影回填歷史 run。#497 即使映射修正仍 Red，必須受治理拆分。
+
+## Preserved Acceptance Mapping
+
+機械比較 #832 baseline Tasks 與新 todo：去除新加 T 編號/分類前綴後，原始 10/13/11 個 task 文字逐項完全相同；每份只新增 2 項 documentation/CLI/intake-gate task。Boundary 與原歷史證據內容保留，英文 Evidence heading 只為文件一致性。下表每一原 parent AC 都有 spec ID 與 todo ID，不漏掉先前明示殘餘。
+
+候選代號只供人工討論，不是 issue/work_id/已註冊 child。D=維持 #496 原工作；S-A/S-B/S-C 與 H-A/H-B/H-C 的定義見下一節。P=parent 整合驗收，不能由 child 單獨宣告。
+
+| Parent AC | Spec／Todo | 人工分工候選 | 關鍵驗證 |
+|---|---|---|---|
+| #496 validate before gate | D01／T01 | D | runner/validator 仍執行 |
+| #496 exact effective tuple | D02／T02 | D | hash/state/gate/candidate/summary/refs 逐欄負例 |
+| #496 no-op writes | D03／T03 | D | action/history/update_slice=0 |
+| #496 real transition once | D04／T04 | D | 真變更一次、下次不再增 |
+| #496 bad evidence | D05／T05 | D | schema/unreadable/mismatch fail-closed |
+| #496 10 ticks | D06／T06 | D | 既有基準 count 不變、runner count 增 |
+| #496 same path new hash | D07／T07 | D | 受控 fixture、不可放寬 writer |
+| #496 cleanup/repair | D08／T08 | D | cleanup 正例與 state/refs 修復 |
+| #496 hash compatibility | D09／T09 | D | #501 normalization、contract hash 不改 |
+| #496 delivery | D10／T10 | D/P | review/merge/runtime delta 分帳 |
+| #497 additive disposition | S01／T01 | S-A | 舊 row/copy/validation 相容 |
+| #497 atomic recover clear | S02／T02 | S-A + S-C | 真清 bindings、同次 persist |
+| #497 CAS/idempotent request | S03／T03 | S-A + S-C | fault/stale/request replay |
+| #497 replacement/consumed | S04／T04 | S-A + S-B + S-C | producers 取代；完整 proof 才 consumed |
+| #497 early terminal admission | S05／T05 | S-B | 在 repo/candidate/evidence 前 skip |
+| #497 stale zero side effect | S06／T06 | S-B | 舊 artifacts 可讀、current 正常 |
+| #497 reachable fixture | S07／T07 | S-C | candidate=None、明設 repo、先驗 allowed |
+| #497 complete/full tick | S08／T08 | S-B + S-C/P | complete 不污染；full tick 一次新派工 |
+| #497 manifest/restart | S09／T09 | S-B/P | 回 None/missing/corrupt、新 registry |
+| #497 multiple jobs | S10／T10 | S-B + S-C/P | retry-build→repin、builder/reviewer |
+| #497 completed stable | S11／T11 | S-B/P | 10 ticks proof bytes/依賴不倒退 |
+| #497 failure matrix | S12／T12 | S-A + S-B + S-C/P | CAS/fault/replay/missing/current/history |
+| #497 delivery | S13／T13 | P | 全部 child/full gates/loaded restart |
+| #821 digest no-op | H01／T01 | H-A | mkstemp/inode/mtime、deleted state |
+| #821 writer signature | H02／T02 | H-A | dict/optional serialized/fault wrapper |
+| #821 digest lifecycle | H03／T03 | H-A | original load、normalization、rollback |
+| #821 bounded histories | H04／T04 | H-B | 500/env/constructor、limit1/2、counter |
+| #821 load/copy | H05／T05 | H-B | clone input、once-only normalization |
+| #821 hardlink fallback | H06／T06 | H-C | link/copy/fsync/rollback 故障 |
+| #821 safe startup sweep | H07／T07 | H-C | ownership proof、不只 mtime、單層 |
+| #821 persistence tests | H08／T08 | H-A/P | real self-transition、#501/released load |
+| #821 append tests | H09／T09 | H-B | record_action 12次/limit5/dropped7 |
+| #821 filesystem negatives | H10／T10 | H-C/P | 活躍/unknown/symlink/permission |
+| #821 delivery/retention | H11／T11 | P | full gates/loaded writes、必要證據不刪/先備份 |
+
+#496 T11–T12、#497 T14–T15、#821 T12–T13 為新增正式 completeness/CLI/doc/交付守門，不取代或弱化上列原項。
+
+## Manual Split Candidates
+
+1. **#496 優先保留原 work**：production 只在 manager caller gate，#831 後投影 Yellow，無必要強拆。若正式 sizing 因真 scope 擴張仍 Red，才把「純 effective-transition predicate＋逐欄 unit」與「dirty caller 接線＋10-tick regression/delivery」分成有獨立 authority 的候選；D01–D10 仍全回 parent，不把 helper 測綠當整案完成。
+2. **#497 必須先拆**：
+   - **S-A registry disposition/atomic transition**：row schema/copy/loader、CAS/冪等 receipt、真正 clear、persist fault rollback 原語；不自行清 workspace、改 Manager tick 或造 completion proof。
+   - **S-B completion admission/consumption**：以 S-A 原語接 listed builder/reviewer/workflow terminal consumers；current/missing/stale 分離、required proof 完整後才 consumed、manifest/restart/late terminal；不改 fanout/immutable writer。
+   - **S-C recovery producer integration**：slice/work recovery、abandon、retry→repin 的窄接線，沿用現有 owner-aware reclaim，不接管 #547 target 選擇；reachable fixtures/full tick。依賴 S-A，與 S-B 共同完成 parent end-to-end。
+   - **P 整合 owner**：保存 S01–S13 全 coverage、foreign review、exact-head merge 與 loaded canary/restart，不能由三張 helper spec 的 accepted 狀態自動推成 parent completed。
+3. **#821 可在 #831 後原 work 重新裁決**：投影 Yellow，不先為了拆而拆。若實際 envelope/owner authority 或 source 範圍仍要求分解，候選 H-A=digest/writer compatibility；H-B=bounded history/load/copy；H-C=hardlink rollback/ownership-safe sweep。H-A/H-C 共碰 writer 必須順序整合；H-B 與 H-A 要有 normalization-once integration，不能讓各 child 分別綠卻互相遮蔽 digest。
+
+以上候選未新建 issue、未生成 accepted child 文件、未註冊 work、未給猜測 Yellow 分數、沒有 planner Job/child lineage/depth/authority receipt。Root 可裁決採用後再走正式 intake 與真實 sizing；**不是 #833 自動分解的完成證據**。
+
+## Bounded Residuals and Dependencies
+
+- #496 不把 record_action＋update_slice 重寫成全新原子引擎；#497/其他權威已有的 crash/CAS scope 保持獨立。#818 多 manager 共享檔案一致性不由三票暗中修掉。
+- #497 parent 仍 Red；S-B 的 consumed 要以已完整 durable proof 為前提，不可先標記後補證；resource reclaim 不是 registry 單檔原子性。#547 保留 target/dual-entry 整體修正。
+- #821 的 stale temp 若沒有可信 writer-death 或獨占 authority，只能 skip+診斷；舊 random tmp 缺 metadata 不等於自動可刪。正例 owner fixture 可驗機制，但不能代替 production owner proof。若接線需超出 registry scope，先回 root 重拆，不使用 always-true validator。
+- #821 截斷後首/近 history＋counter 不是完整 archive；必要 current/completion evidence 不刪。需全歷史部署必須在受治理備份完成後才啟用截斷，長期 archive 保持 #829 未完成 gap。
+- #501 hash 分離已存在，不重做、不改 bucket index authority；本組不改 #833 planner engine，不把 #831 投影當現場新 runtime。
+
+## Read-only Checks
+
+已實跑 runtime `python3 -m paulsha_cortex.cli work start --help`：exit=0、stdout 37 行、stderr 空；`run work --help`：exit=0、stdout 55 行、stderr 空。均在 checkout 外執行，只看 help，不 start/retry/tick、未呼叫 live manager。
+
+純檢查結果：3/3 accepted 三件組、3/3 completeness+contract、原 tasks 10/13/11 全保留；尚未跑產品 focused/full pytest、CI、PR-context policy、installed wheel 或 live canary，不能把上述結果填為其通過。No-op／supersession／hygiene 功能仍待 Cortex 正式實作。
+
+## Bounded Trace
+
+trace_mode: rg；maxDepth=3、maxFanout=10、maxNodes=200。LSP 回報未有可用 Python server；ctags 無 tags、cscope index_exists=false，依 skill 降級，沒有啟動/重建服務或索引。只追指定入口；沒有全 repo 窮舉或跨 scope vault 寫入，trace 併入此被允許報告。
+
+- manager.py:2093:1 dirty_recheck → validator/apply [via=rg conf=0.4]
+- manager.py:426:1 apply → registry.record_action [via=rg conf=0.4]
+- registry.py:1591:1 record_action → persist [via=rg conf=0.4]
+- manager.py:2131:1 terminal enumeration → current slice/manifest [via=rg conf=0.4]
+- registry.py:617:1 persist → atomic writer/load rollback [via=rg conf=0.4]
+
+```mermaid
+flowchart TD
+  D["Dirty recheck"] --> V["Validate evidence"]
+  V --> A["Apply transition"]
+  A --> R["Record action"]
+  T["Terminal enumeration"] --> B["Current binding"]
+  P["Persist snapshot"] --> W["Atomic writer"]
+  style D fill:#e0f2fe,stroke:#334155
+  style V fill:#dcfce7,stroke:#334155
+  style A fill:#fef9c3,stroke:#334155
+  style R fill:#fef9c3,stroke:#334155
+  style P fill:#e0f2fe,stroke:#334155
+  style T fill:#e0f2fe,stroke:#334155
+  style B fill:#dcfce7,stroke:#334155
+  style W fill:#f1f5f9,stroke:#334155
+```
+
+圖按 dirty/terminal/persist 三個 seed 展示有界片段，省略跨片段與錯誤/其他 lane；不是完整 workflow 拓撲。圖表變更：使用短 quoted labels、TD、fill/stroke 成對，每段不超過3層；沒有可用 Mermaid validator，不宣稱工具驗證完成。
+
+```json
+{"meta":{"trace_mode":"rg","revision":"79ba644780bf1c697c722ac24a297e7d02416100","limits":{"maxDepth":3,"maxFanout":10,"maxNodes":200},"scope":"selected entrypoints, not exhaustive"},"nodes":[{"id":"dirty","path":"paulsha_cortex/coordinator/manager.py","line":2093,"via":"rg","conf":0.4},{"id":"apply","path":"paulsha_cortex/coordinator/manager.py","line":426,"via":"rg","conf":0.4},{"id":"action","path":"paulsha_cortex/coordinator/registry.py","line":1591,"via":"rg","conf":0.4},{"id":"persist","path":"paulsha_cortex/coordinator/registry.py","line":617,"via":"rg","conf":0.4}],"edges":[{"from":"dirty","to":"apply","relation":"validated recheck"},{"from":"apply","to":"action","relation":"calls"},{"from":"action","to":"persist","relation":"calls"}]}
+```
+
+## Reader Review and Handoff
+
+doc-coauthoring 要求的 fresh-reader 已讀指定 10 檔並回 PASS，未報 BLOCKER/MAJOR；確認 planning/implemented、#497 仍 Red、#496/#497 責任、ownership-safe sweep、非完整 archive、34 項 AC mapping 與人工候選非 #833 evidence 都可清楚辨認。其範圍限文件內部一致性，沒有獨立讀 source/#832，不冒充來源複核或產品測試。
+
+作者另以程式讀 #832 原 todo 逐項比對（只移除新 T 前綴）、驗所有 immutable source link 路徑/行號存在、逐檔 whitespace、公開內容無個人路徑/credential pattern，並檢查 worktree 恰好 10 個授權變動。檔案變更為 6 份新增 accepted spec/design、3 份 todo 修改與本報告；沒有 commit/push 或發佈 `.cortex` authority。Root 整合前仍應全文讀回並重新執行純 gate；本子任務不代為關票或派工。
+
+## Pure Check Reproduction
+
+以 `CORTEX_RUNTIME_ROOT` 指定實際要核對的 runtime checkout、`CORTEX_INTAKE_ROOT` 指定本 intake worktree，從 checkout 外執行；全程不寫 registry、不啟動模型。下列 #831 projection 僅對已完整 accepted 的本三案套用已定案的 stability=0，不是新 runtime 的 proof。
+
+```bash
+PYTHONDONTWRITEBYTECODE=1 PYTHONPATH="$CORTEX_RUNTIME_ROOT" python3 - "$CORTEX_INTAKE_ROOT" <<'PY'
+import json
+import sys
+from dataclasses import asdict, replace
+from pathlib import Path
+from paulsha_cortex.coordinator import planning
+from paulsha_cortex.coordinator.claim import sizing_band
+from paulsha_cortex.deck.schema import DEFAULT_CARDS_PATH, load_cards, load_combo, resolve_combo_path
+root = Path(sys.argv[1])
+cards = load_cards(DEFAULT_CARDS_PATH)
+combo = load_combo(resolve_combo_path('fix-standard'), cards)
+counts = dict(gate_spine_count=len(combo.gate_spine), cards_count=len(combo.cards),
+              persona_binding_count=sum(cards[e.ref].persona_binding is not None for e in combo.cards))
+for slug in ('fix-dirty-recheck-idempotency', 'fix-superseded-terminal-replay', 'registry-persist-hygiene'):
+    refs = [('spec', f'docs/superpowers/specs/{slug}-spec.md'),
+            ('design', f'docs/superpowers/specs/{slug}-design.md'),
+            ('plan', f'docs/superpowers/workstreams/{slug}/todo.md')]
+    artifacts = tuple(planning.PlanningArtifact(k, r, (root / r).read_text()) for k, r in refs)
+    report = planning.assess_planning_completeness(artifacts)
+    assert report.complete
+    score = planning.compute_sizing_score(plan_artifact=artifacts[-1], completeness_report=report,
+                applicable_contract_rules=planning.ACCEPTANCE_SURFACE_RULES, **counts)
+    projected = replace(score, spec_stability=0)
+    gate = planning.plan_review_gate(plan_artifact=artifacts[-1],
+                acceptance_surfaces=frozenset({'source', 'tests', 'documentation'}),
+                applicable_contract_rules=planning.CONTRACT_COMPATIBILITY_RULES, envelope_lookup=None)
+    assert gate.ready
+    print(json.dumps({'work_item': slug, 'current': score.to_dict(), 'band': sizing_band(score.total),
+                      'projection': projected.to_dict(), 'projected_band': sizing_band(projected.total),
+                      'gate': asdict(gate)}, sort_keys=True))
+PY
+```

--- a/reports/review/refine-evidence-profile-integration-20260907.md
+++ b/reports/review/refine-evidence-profile-integration-20260907.md
@@ -1,0 +1,47 @@
+# Evidence／profile intake 整合核對
+
+本次是規劃文件交付，不是產品修正；產品只經 Cortex workflow 實作。
+Root 的整合範圍包含四組 accepted 三件組、作者報告、本文、`.cortex` links、
+plan/OpenSpec ledger 與 changelog，與兩個隔離 authoring 子任務的原 scope 分開。
+
+## Scope 與驗證
+
+- Root 全文讀 #496/#497/#821 九件、#835 初稿與最終 legacy 負例；另保留兩份作者 trace。
+- 獨立 reviewer 以 live 基底 `79ba6447` 核對 source/tests、#832 原 AC 與 ownership；
+  evidence 三件 PASS，原 10/13/11 項 Tasks 保留；profile 最終版另經獨立 review PASS。
+- #496 真分數 7、#497 9、#821 8、#835 10，均 Red；#831 後的 5/7/6/8
+  僅保持其他輸入不變的推算。需實際 loaded runtime 重評，不能提前宣稱 Yellow。
+- completeness／contract pure checks 通過不等於 model qualification；envelope unavailable
+  的 bypass 仍不是能力證據。任何未落地測試、PR/merge、installed/live 均不得勾完成。
+- Root 另從 checkout 外以現行 runtime 真正 `load_cards/load_combo`、completeness、
+  `compute_sizing_score` 與 `plan_review_gate` 重跑四件：7/9/8/10，
+  source/tests/documentation/CLI 與 R-09/R-16/R-19/R-22 全通過；
+  四件移除 Tasks 標題的記憶體負控制均被拒，未寫 registry 或執行模型。
+- 原始 source baseline、helper 參數、負控制與作者當時未提交的操作紀錄見
+  [evidence 報告](refine-evidence-intake-20260907.md)及
+  [profile 報告](refine-profile-intake-20260907.md)，不是對整合後 Git 狀態的宣稱。
+- 獨立 reader 對本輪文件的五題重讀 PASS：能區分規劃/產品、現行/條件式 sizing、
+  原子性/retention residual、原生 effort/legacy unknown 與跨 repo qualification DAG。
+  此為 reader test，不冒充產品故障測試或 live 驗收。
+
+## 不可省略的界線
+
+1. #496 no-op 必須先驗內容及完整状态；不建立 record_action/update_slice 的新跨寫入交易。
+2. #497 superseded/consumed 分開；必要 proof durable 後才 consumed，crash 要 reconcile；
+   原子解除綁定不把 filesystem reclaim 冒稱同一筆交易，也不偷接管 #818 多 writer。
+3. #821 only byte-equal no-op、true append fixture、digest rollback、hardlink fallback；
+   unknown writer 的老 tmp 仍略過。輪替非全 archive，需要完整歷史的部署先保留原 registry 備份。
+4. #835 不設固定模型/agent/effort 名單；新增協定允許受控 adapter，既有協定新增模型/原生 effort 為資料擴充。
+   unknown observed/policy 不猜填；歷史 chain 不回寫，正式新 authority 才可切新版。
+5. PatchMUD #37 是外部 CLI/file producer，#581 保留五項既有 scope，#842 擁有 qualification
+   publication/receipt/CAS/revocation。schema-key child 先行，避免 #835/#842 母票相互等待。
+6. #497/#835 修正 stability 後仍 Red，人工 child 只是候選，仍需獨立審查/凍結；
+   #833 自動分解未實作，母票仍持有整合與 closeout，不能以 child 完成取代全母驗收。
+
+## Delivery gate
+
+此 planning PR 須通過 strict OpenSpec、完整 preflight、exact-head CI 與 review；
+policy-exempt:issue-link 用於不誤關尚未完成的產品票。
+現場 #822 另以原候選進行真 verification，不因這批 isolated authoring 改寫 frozen inputs。
+本輪另外列管的 [#847](https://github.com/hamanpaul/paulsha-cortex/issues/847) 是獨立產品 child，
+root 已全文讀回 10 項 AC；只完成開票，未把 metadata 等價 helper 或 live guard 寫成已實作。

--- a/reports/review/refine-profile-intake-20260907.md
+++ b/reports/review/refine-profile-intake-20260907.md
@@ -1,0 +1,154 @@
+# #835 execution-profile planning intake 審查
+
+日期：2026-09-07。基準：`60a3ffa867377b0c86fa2f10e91fb9820d91938c`（已合併 PR #832）。
+branch：`feature/refine-profile-intake-20260907`。本報告與三件組是本次 authoring 唯一新增的四檔；
+作者在初稿與本輪修訂當下均未改產品碼／測試／registry／服務，未 commit/push、未開 issue、
+未跑模型 probe/benchmark。此為 authoring 當下操作紀錄，不預述 root 後續整合或交付狀態。
+
+## Outcome
+
+完整保留 [#835](https://github.com/hamanpaul/paulsha-cortex/issues/835) A1–A6，
+並以 root 後續明確裁定的 [#842](https://github.com/hamanpaul/paulsha-cortex/issues/842)
+取代原票「qualification lifecycle 無 owner」的歷史缺口描述。
+規劃可完整表示，但 **整件仍 Red，不可直接當單一 Yellow build unit**；
+accepted frontmatter 不是 registration/freeze 或 runtime readiness。
+
+## Artifacts
+
+- [Spec](../../docs/superpowers/specs/execution-profile-contract-spec.md)：R1–R6、I1–I10、A1–A6 與 ownership。
+- [Design](../../docs/superpowers/specs/execution-profile-contract-design.md)：D1–D6、production consumers、fixture 與 migration 邊界。
+- [Todo](../../docs/superpowers/workstreams/execution-profile-contract/todo.md)：完整 source/tests/documentation/CLI/changelog Tasks，未勾產品驗收。
+
+## Trace Method
+
+`trace_mode: rg`；查閱指定 SHA 的原始碼／測試與 GitHub #835/#842/#581/#208，
+Python LSP 未提供可用 server，worktree 無 tags/cscope index，故依 skill-code-tracker
+降級為有界文字追蹤，不建立索引或啟動服務。`maxDepth=3, maxFanout=10, maxNodes=200, timeout=30s`；
+下列為分別選定入口的局部 call/data-flow 合併圖，不宣稱一次追蹤已窮盡全部調用點。
+每條文字證據標記 `[via=rg conf=0.4]`；靜態證據是當下佐證，全入口一致性須由 A6 runtime 不變量測試守護。
+doc-coauthoring 用於規格／設計／驗收對齊；root 已全文閱讀初版四檔並裁定下述界線，
+本輪新增負例仍交 root／reviewer 核對，不以 root 初版閱讀冒充修訂版 fresh-reader 通過。
+
+```mermaid
+flowchart TD
+    A["Identity / task requirements"] --> B["Resolver + hard gates"]
+    B --> C["Workflow / generic dispatch"]
+    C --> D["Launcher factory + adapter argv"]
+    A --> E["Pure planning argv / JSON"]
+    D --> F["Attempt + profile evidence"]
+    E --> F
+    G["PatchMUD CLI / file report"] -.-> H["Qualification owner #842"]
+    H -.-> B
+    style A fill:#e8f0fe,stroke:#1a73e8
+    style B fill:#fff3cd,stroke:#856404
+    style C fill:#e8f0fe,stroke:#1a73e8
+    style D fill:#e8f0fe,stroke:#1a73e8
+    style E fill:#e8f0fe,stroke:#1a73e8
+    style F fill:#e2f0d9,stroke:#38761d
+    style G fill:#f3e8ff,stroke:#7030a0
+    style H fill:#f3e8ff,stroke:#7030a0
+```
+
+圖中實線為既有入口間的選定概念資料流，不表示新 profile 已接通；虛線為 producer／qualification
+待交付契約。無 Mermaid validator 工具可用，僅靜態語法檢查，未宣稱已渲染驗證。
+
+## Production Evidence
+
+以下路徑均以基準 commit 的 `paulsha_cortex/coordinator/` 為前綴。
+
+| 入口／資料 | Source 錨點與判斷 |
+|---|---|
+| Identity loader | `model_identities.py:284,349,547`：identity／registry／overlay loader，現有 key 為 executor/model；descriptor profile 需 additive seam `[via=rg conf=0.4]` |
+| Role／相容性／排序 | `model_resolution.py:96,151,311,476,622,882`：unknown persona fallback、builder capability、credential/sandbox checks、pair-key roster 與人工 reviewer/date 已存在；不應重做核可政策 `[via=rg conf=0.4]` |
+| Workflow 解析 | `manager.py:8119,8219,8466,8535`：候選、排序、preflight、resolution 紀錄；explicit override 先於 measured 篩選返回，不代表新版可豁免最低品質 `[via=rg conf=0.4]` |
+| 生產 launch | `manager.py:9373,9683,9697`、`manager_daemon.py:591,616,1031`、`autonomy.py:602,688`：workflow／generic lane factory 仍主要傳 identity pair，specialized launcher 另做相容性檢查 `[via=rg conf=0.4]` |
+| Adapter／CLI | `cli.py:30`、`launcher.py:797,1072,1341,1369,1424,1439,1912`：CLI factory 尚未帶完整 profile，effort/argv 有分散產品處理；as_* clone 已帶 effort，不誤列成漏傳缺陷 `[via=rg conf=0.4]` |
+| 純規劃 | `planning_runtime.py:68,85,95,101,1329`：獨立 argv 與 JSON invocation，不能只修 SubprocessLauncher；保留 hermetic config、純 JSON／零工具安全契約 `[via=rg conf=0.4]` |
+| 持久化 | `workflow.py:45,65,456,707,797`、`registry.py:646,1047,1962`：嚴格 legacy chain schema 與 JobRegistry；新 profile 不能直接注入舊 strict dictionary `[via=rg conf=0.4]` |
+| 評測接縫 | `model_profile.py:146,246,260,329`、`envelope_mapping.py:233,287,333`：report grouping／原子檔替換／舊六欄 fingerprint／coverage 侷限；不是完整 profile qualification lifecycle `[via=rg conf=0.4]` |
+
+## Owner Boundaries
+
+#581 原五項維持原 owner：doctor planning identity、unknown persona、非 dispatch provenance、
+doctor overlay 公開 API、eval producer 管線；本件只消費共用 role/provenance/producer seam，
+不增加第六項 qualification 發布工作。#842 獨立擁有發布／撤銷／有效期／human-review receipt／CAS／crash。
+沿用 #534 的核可政策與 `map_report_to_envelope`，不把測量 pass 當授權。
+[PatchMUD #37](https://github.com/hamanpaul/paulsha-patchmud/issues/37) 是 CLI/file schema
+與 immutable fixture 上游，零 runtime import；價格 provenance 不進能力 fingerprint。
+真 qualification 依 #842 政策若需真人 receipt，fixture／agent review／plan accepted 不可替代。
+
+## Pure Sizing
+
+完整 scope 的 domain_breadth=2：涉及 identity/resolution、adapter/launcher、planning runtime、
+registry/workflow 等至少四個 production 模組且跨執行／持久化資料流，不把 tests 數量當 breadth。
+state_consistency=2：#208 原 rubric 明列 migration、atomicity 或 concurrency 任一即 2，本件包含 migration。
+invariant_count=10，對應 Spec I1–I10；artifact_classes 為 source/tests/documentation，CLI 與 changelog
+仍在 Tasks 首行獨立標記。未刪 AC 或漏宣告以壓低分數。
+
+`feature-oneshot` 實際 loader 得 11 cards、11 persona bindings、4 core gates；
+`ACCEPTANCE_SURFACE_RULES={R-09,R-16,R-19}`，acceptance_signal=7，因此 acceptance_surfaces=2、orchestration=2。
+
+| 算法 | domain | state | acceptance | spec_stability | orchestration | 總分／band |
+|---|---:|---:|---:|---:|---:|---|
+| 基準 `planning.compute_sizing_score` | 2 | 2 | 2 | 2 | 2 | 10 / Red |
+| #831 修正完整／穩定規劃為 0 的預計情境 | 2 | 2 | 2 | 0 | 2 | 8 / Red |
+
+第二列只是保持其他輸入不變的推算，不表示 #831 已合併或 installed；修正後須重跑真實 runtime sizing。
+`planning.py:859` 的舊公式讓完整三件組得到 2，是 #831 已列管的方向問題。
+`claim.py:1497` 的 band 門檻為 Green 0–3、Yellow 4–6、Red 7–10，本件兩種算法均 Red。
+
+## Manual Split Candidates
+
+以下只是 root 人工規劃候選，不是已開 issue／已註冊 work_id、不是 #833 自動分解成果，
+也不預判各候選必為 Yellow。獨立 child 必須真實重算與檢查未遺失 parent AC，parent 仍持有整合／closeout。
+root 本輪只採 `execution-profile-schema-core` 優先；其餘候選待誠實重評與再拆，尚未核可整包進件。
+
+| 建議 child work_id | 單一 ownership／不接管 | 前置 | Parent AC mapping |
+|---|---|---|---|
+| `execution-profile-schema-core` | 純 schema、canonicalization、unknown 與 key；不接 adapter／registry migration | 無；採 #835 凍結契約 | A1 資料擴充、A4 全部、A5 parser 負例 |
+| `execution-profile-adapter-consumers` | adapter protocol、launcher／CLI／planning runtime 與離線 conformance；不接 resolver 選擇或資格發布 | schema-core | A1 實際 argv、A2 全部、A6 launcher/planning 回歸 |
+| `execution-profile-identity-resolution` | identity descriptor loader、resolver 硬條件、public role／qualification consumer seam；不寫 durable attempt | schema-core；#581 role；#842 查詢契約可先 fixture | A1 候選擴充、A3 全部、A6 resolution／per-work chain |
+| `execution-profile-attempt-binding` | manager/daemon/generic factory 接線、WorkflowRun/JobRegistry versioned binding、restart／migration；不重做 #842 lifecycle | 前三 child；#581 provenance seam | A5 全部、A6 production 跨入口／歷史不變 |
+
+schema-core 若確實只有單模組純資料流，可宣告 domain=0/state=0；不得先以此值代替獨立 scope 審查。
+adapter consumers 跨多個入口，resolver 與 attempt-binding 又各自含多模組；最後一項含 migration，
+仍可能 Red。若如此，先再拆「嚴格序列化 schema 相容」與「owner-aware 新 attempt 接線／migration」，
+維持同一 JobRegistry 真值及端到端 AC，不以刪 restart／production consumers 避免 Red。
+自動分解 #833 未實作不妨礙 root 人工規劃，但不能假造子件 authority 或跳過正式 freeze。
+
+最小依賴 DAG：schema-core → adapter-consumers／identity-resolution；前三項 → attempt-binding；
+schema-core 的凍結 key 契約 → #842，#581／PatchMUD #37 → producer fixture／#842。
+#842 的真 consumer 結果與各 child → parent A6 整合／closeout。#842 依賴 key 契約 child，
+不等待 #835 整個 parent 已關閉，避免「#835 整合需 #842、#842 又等整件 #835」的人為循環。
+
+## Validation Ledger
+
+- 規劃純 helper：以基準 checkout 的 `python3 -B` 直接讀三件組，`assess_planning_completeness.complete=true`，三個 artifact accepted、缺 kind／blocking markers 均空。
+- 真正 `compute_sizing_score` 及 `work_bridge.current_sizing_snapshot` 均得到 `10/red`；保留其餘維度、以 `dataclasses.replace(spec_stability=0)` 推算 #831 情境為 `8/red`，未改產品算法。
+- 真正 `_evaluate_yellow_plan_review` 的 completeness／contract compatibility 通過；另以 `plan_review_gate` 明確加入 CLI surface 與 R-22 亦通過。但兩次 envelope 均是 `bypass: envelope_unavailable`，**不是 builder qualification 通過，也不能把 Red 派成 Yellow**。
+- 離線負控制：只在記憶體中替換 spec 的 Requirements 或 plan 的 Tasks 標題，分別被 completeness／plan-review completeness 拒絕，未改真檔或執行產品測試。
+- 四檔行尾／whitespace、11 個相對連結、引用的既有 test 路徑與無個人絕對路徑均通過；`git diff --check` 通過，`git status --untracked-files=all` 僅列本次四檔，無 tracked 產品 diff。
+- 產品 implemented／tests passed／merged／installed／live accepted：均未完成，本 planning-only 任務未執行。
+- Root 已全文讀初稿四檔；本輪負例與裁決文字待 root／reviewer 核對。已承認、有界且列管的外部依賴不單獨構成 FAIL。
+- 未處置實質缺陷或遺失 AC 則 FAIL；若 reviewer 不接受某殘餘風險，須指出具體影響與可行替代。
+
+## Root Review Decisions
+
+2026-09-07 root 在全文閱讀四檔後接受 D4：只保留既有 frozen legacy run 的原可證 schema／policy，
+新的 profile-aware run 不得繼承品質 bypass；這是規劃裁決，不是產品行為已驗證，也不是任何 run 的
+重新接受、runtime 操作或真人 qualification 授權。
+
+root 要求補入的負例已映射到 Spec R5／A5、Design D4／A5 及 Todo T10：歷史 run 沒有足以
+重建當時 schema／policy 的可信 snapshot 時，標 legacy/unversioned/unknown，不猜填今天或某個
+舊版本、不回寫原 chain；需正式且具 authority 的重新接受才可切到新版。這條驗收仍未執行產品測試。
+
+#842 依 schema-key child 的凍結契約而非整件 #835 close 的 DAG 已獲接受；root 僅先採 schema-core
+優先，其餘 child 仍須誠實重評／再拆，尤其 attempt-binding 仍可能 Red。
+本輪未開票、註冊或給任何模型／agent／effort 固定組合；本次四檔 SHA-256 由外部工具實算交接，
+不將報告自己的 hash 嵌回本檔形成自引用，也不代寫任何產品 evidence hash。
+
+## References
+
+- [#829 完整精修 umbrella](https://github.com/hamanpaul/paulsha-cortex/issues/829)、[PR #832](https://github.com/hamanpaul/paulsha-cortex/pull/832)。
+- [#208 sizing／freeze rubric](https://github.com/hamanpaul/paulsha-cortex/issues/208)、[#831 sizing 方向修正](https://github.com/hamanpaul/paulsha-cortex/issues/831)、[#833 Red 分解](https://github.com/hamanpaul/paulsha-cortex/issues/833)。
+- [#581 解析與 producer 殘項](https://github.com/hamanpaul/paulsha-cortex/issues/581)、[#534 分層核可政策](https://github.com/hamanpaul/paulsha-cortex/issues/534)、[#205 per-work chain](https://github.com/hamanpaul/paulsha-cortex/issues/205)。


### PR DESCRIPTION
## 摘要

接續 #832/#834/#846，補 #496/#497/#821 evidence 基礎與 #835 execution-profile 的
accepted spec/design/todo、來源連結與完成 ledger；#847 獨立列管自身 planning 發布的 authority 穩定性。

只有規劃／進件；未改產品 code/tests、runtime、live registry 或 #822 frozen inputs。
policy-exempt:issue-link 用於不誤關仍未完成的產品 issue。

## 邊界

- 四件現行真分數 7/9/8/10，全部 Red；#831 後僅條件式預期 5/7/6/8，必須真重評。
- #497 proof 後 consumed、原子 clear、crash reconciliation；#821 digest/append/fault/ownership/archive 備份前置不縮減。
- #835 descriptor/native effort 與 requested/resolved/observed 分立；legacy policy 不猜填，#842 資格發布與 PatchMUD #37 producer 各有 owner。
- #847 只補 owner/10 AC，未實作 metadata 等價或繞過合法 authority restart。

## 檢查清單

- [x] Root 全文核對四件三件組與 final legacy 負例。
- [x] Evidence/profile 各有獨立 adversarial PASS；原 #832 的 10/13/11 項 AC 保留。
- [x] Root 用現行 runtime/package combo 重跑 completeness/sizing/contract 與 Tasks 負控制。
- [x] 本輪 reader 五題 PASS，規劃/產品、Red/投影、ownership/residual 與 qualification 邊界可辨。
- [x] strict OpenSpec 與 git diff --check 通過。
- [x] changelog fragment 與 Unreleased 同步，無產品驗收預先勾選。

- [x] `0da1bfa026899e46df990a9b65d40dfc9fec6f31` post-commit engine/policy/OpenSpec/full tests 全 PASS（tests 212.12 秒）。

遠端 CI/review 仍以實際 head 裁決；本機 preflight 不代表 merged/installed/live。
