### PR TITLE
docs(refine): 登錄有界 schema 與 backoff store 子計畫

### DIFF
--- a/.cortex/work-items.yaml
+++ b/.cortex/work-items.yaml
@@ -906,3 +906,27 @@ work_items:
       - kind: path
         ref: 'docs/superpowers/workstreams/execution-profile-contract/todo.md'
     excludes: []
+  execution-profile-schema-core:
+    title: 'execution-profile-schema-core'
+    links:
+      - kind: github_issue
+        ref: 'hamanpaul/paulsha-cortex#849'
+      - kind: path
+        ref: 'docs/superpowers/specs/execution-profile-schema-core-spec.md'
+      - kind: path
+        ref: 'docs/superpowers/specs/execution-profile-schema-core-design.md'
+      - kind: path
+        ref: 'docs/superpowers/workstreams/execution-profile-schema-core/todo.md'
+    excludes: []
+  executor-backoff-store-core:
+    title: 'executor-backoff-store-core'
+    links:
+      - kind: github_issue
+        ref: 'hamanpaul/paulsha-cortex#850'
+      - kind: path
+        ref: 'docs/superpowers/specs/executor-backoff-store-core-spec.md'
+      - kind: path
+        ref: 'docs/superpowers/specs/executor-backoff-store-core-design.md'
+      - kind: path
+        ref: 'docs/superpowers/workstreams/executor-backoff-store-core/todo.md'
+    excludes: []

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
 
 ## [Unreleased]
 
+- **有界核心 child 進件**：登錄 #849 可擴充 execution-profile schema／canonical key，
+  與 #850 跨程序 backoff store／immutable event fold；補 byte-level oracle、資源上限及
+  真 process-death 測試契約。獨立審查通過，現行 sizing 仍為 7／8 Red，
+  不把規劃登錄、機械 gate 或 #831 投影當成產品／派工／資格完成。
+
 - **Evidence／profile 進件**：補 #496/#497/#821 的 accepted 三件組與 #835 可擴充
   execution-profile／原生 effort／歷史 unknown 契約，保留 Red 真分數、writer ownership、
   archive 與 PatchMUD/#842 外部資格邊界；只交規劃，不宣稱產品、量測或部署生效。

--- a/changelog.d/refine-bounded-children-20260907.md
+++ b/changelog.d/refine-bounded-children-20260907.md
@@ -1,0 +1,6 @@
+# 有界核心 child 進件
+
+- 為 #835 與 #825 分別登錄 #849 schema-key 純契約、#850 有界跨程序 store 核心。
+- 定義 canonical byte golden、typed native effort、bounded decode/fold 與 process-death oracle。
+- 保留 Red 真分數、#831 loaded-runtime 前置、母件其餘 AC 與 PatchMUD／真人資格邊界；
+  本批只交付規劃，不含產品、部署或模型資格變更。

--- a/docs/superpowers/plans/2026-09-07-cortex-refine-complete.md
+++ b/docs/superpowers/plans/2026-09-07-cortex-refine-complete.md
@@ -187,8 +187,8 @@ B1 的主要目標是讓 Cortex 能可靠承接後續工作。B2–B4 完成後�
 | 批次 | 狀態 | 證據／下一動作 |
 |---|---|---|
 | B0 | complete | #832 規劃／進件已合併；review、PR-context preflight、CI通過，原稿及其他工作所有權保留。不是產品修正完成。 |
-| B1 | in-progress | #822 RED/GREEN已採信，verify因terminal schema拒收，等待合格reviewer重試；未review/merge/installed。#831為6/Yellow、#830為8/Red；#819/#825/#827 accepted intake均仍Red，#833未實作。 |
-| B2 | pending | PatchMUD #37已開；Cortex #835 profile與#842 qualification分工明確，契約待拆分／派工。 |
+| B1 | in-progress | #822 b448ce84 已採信 verify，review 因 Claude quota 等待，未 merge/installed；#831 RED 已採信，GREEN timeout checkpoint 尚未提交。#830/#819/#825/#827 仍依實際 runtime Red；#850 store child 已登錄但不可派，#833 未實作。 |
+| B2 | planning-in-progress | PatchMUD #37已開；#849 schema-key child 經審查並登錄，現行7/Red；#835其餘接線與#842 qualification尚待拆分／派工。產品仍未交付。 |
 | B3 | pending | 觀測與預估先 shadow。 |
 | B4 | pending | 資格、預估與所有權契約先過，再有限啟用動態路由。 |
 | B5 | pending | #828 獨立處理；其餘狀態／部署待分拆。 |
@@ -246,6 +246,8 @@ B1 的主要目標是讓 Cortex 能可靠承接後續工作。B2–B4 完成後�
 | production stage reuse | #844，#214 successor；先限同run/claim-era安全cohort，跨run新採信未支援，不倒退既有candidate保留政策。 |
 | requirement delivery accounting | #845；消費CompletionRecord與#841證據，不重建ship引擎、不代替#808/#810勾完成。 |
 | self-publication authority stability | #847；可信 frozen 自身同內容發布的 metadata 等價，不清 needs_human 或重開 gates；真需求變更仍走既有合法 restart。 |
+| schema/key pure core | #849，#835 child；精確 typed wire／canonical key、三層 profile 與 bounded input。現行7/Red，#831後5僅投影；不授予資格、不做母件 routing/migration。 |
+| backoff store/event fold | #850，#825 child A；有界 fresh store、flock/atomic replace/durability、immutable event fold與ack。現行8/Red，#831後6僅投影；C/D provenance/reconciliation与production lanes仍另交付。 |
 
 #835–#842的查重與read-back見[動態issue對照](../../../reports/review/refine-dynamic-issues-20260907.md)；
 #843–#845各票保存不可變source與10/12/12項AC，root已全文讀回。所有新scope都尚未
@@ -274,6 +276,28 @@ PatchMUD #37仍是外部producer gate，真人qualification核可若生效也需
   不變，但自身 plan source 晚加入 authority 後觸發了 restart；精確 Monitor 納入時間與
   單次 writer 身分未證實。不以 bytes 相同就授予豁免，仍須 exact run/era、owner、受治理
   發布 provenance 與其他 authority 不變；#843/#844 不代替這項產品修正。
+
+### 有界 child 與現場進度核對（2026-09-07 13:27 UTC）
+
+- #849／#850 已建立並全文讀回，本批登錄兩組 child 三件組與獨立報告；首輪 MAJOR、
+  R2 及 fresh-reader 歧義已處置，fresh compact R3 為 PASS。Root 重驗 schema 兩個
+  canonical golden、兩組 completeness／真 sizing／Tasks 負控制；產品 AC 全部未勾。
+- 兩組不是 #833 自動拆分證據。未載入 #831 前維持 7/8 Red；其 5/6 Yellow 僅為
+  設計情境投影，不先改 frozen run、現行 scoring 或 capability registry。
+- #822 的單引號 escape 修補 8073d1d2 及文件同步 b448ce84 已由 Cortex 提交；
+  root 在 b448ce84 的隔離 checkout 真跑 5663 passed、44 skipped、173 subtests，
+  214.35 秒、exit 0；verification53 已採信。review55/57/58 撞 Claude 五小時池，
+  最新 rejected utilization=1.04，reset 14:50 UTC。未 review／archive／merge／installed。
+- #831 RED c62df773 已採信；AGY GREEN52/54/56 五分鐘 timeout，沒有提交／合法
+  JSON terminal，保留原工作。56 checkpoint 的 Manager 全套 gate 通過、root 集中
+  51 passed，均不替代新 candidate evidence。正式重試先被 stale GitHub authority 擋下。
+- Monitor 13:27 UTC temporary user-service recovery 前為 5157 threads、GitHub stale；
+  不重啟 Manager、不清原 run/evidence。這是 #827 待修的現場證據，不是有界性驗收。
+- #824 launcher-only timeout 規劃另發現 optional AGY probe 的 argv ValueError 可穿透
+  並阻擋已可用的非 AGY primary。新增 probe-construction containment 前置正在獨立
+  審查，timeout-only 保持 blocked-dependency，兩者未登錄／dispatch。本批不混入未通過文件。
+- #827 watcher child 已收斂 controlled polling 候選並送 fresh R3；延遲、短命事件、
+  last-good snapshot recovery 與 CI watchdog 依賴均需真測試，仍未登錄／dispatch。
 
 ### Canary sizing 校正紀錄
 

--- a/docs/superpowers/specs/execution-profile-schema-core-design.md
+++ b/docs/superpowers/specs/execution-profile-schema-core-design.md
@@ -1,0 +1,311 @@
+---
+status: accepted
+work_item: execution-profile-schema-core
+---
+
+# Execution profile schema／key core 設計
+
+## Scope
+
+依 [Spec](execution-profile-schema-core-spec.md) C01–C10，唯一 production 檔為新
+`paulsha_cortex/coordinator/execution_profile.py`。以下 API／型別是待 Cortex 實作的設計，尚不存在。
+不在 `model_identities`／`model_resolution`／`launcher`／`planning_runtime`／`workflow`／`registry`
+加 import 或轉換 shim；正常 `from ...execution_profile import ...` 不需要改 package exports。
+
+## Decisions
+
+### D1 — 公開純 API 與資料責任
+
+建議同一模組提供 `parse_descriptor`、`parse_profile`、`canonical_profile_bytes`、`profile_key`、
+`actual_condition_key` 與 immutable value 的 `to_dict`；解析接受 caller 提供的 mapping 或 JSON text，
+不接受檔案路徑／環境名稱／runtime object。JSON decoder 用 duplicate-key hook，數值非有限先拒絕。
+`parse_profile` 每次只處理一個 plane，並接受對應 descriptor；caller 可分別持有三筆紀錄。
+observed 若屬不同 model／adapter，保留其對應 descriptor 下的真值，不拿 requested descriptor 逼它改名；
+無對應 descriptor 的資料保留在上游原 report，本 core 不假裝驗過或補成原請求。
+
+v1 record 頂層恰為六個必填欄位：`schema_version`、`plane`、`conditions`、`requirements`、
+`provenance`、`metadata`；沒有隱含預設或額外頂層欄位。`schema_version` 是非 bool 的整數 1，
+plane 僅 `requested`／`resolved`／`observed`；record 不含 approved／qualified。
+requirements 恰有四個必填鍵 `role`、`minimum_quality`、`pin`、`independence`，值均使用 D2 的
+known／unknown wrapper，不能使用 not_applicable。known role 的 value 是非空 ID string 或 null；
+其餘三者的 known value 是有界 JSON data，core 不解釋內部政策 vocabulary。明示 known null 表示
+caller 沒加該項額外限制，與 unknown 不同；兩者都不能解除下游原有最低品質／Trust Root gate。
+core 不把未知角色映射為 build、不查 runtime 是否認得該角色；語意／eligibility 仍由 #581 與母件
+resolver 擁有。requirements 內的 array 保序，不由本 core 猜測哪一種政策集合可重排。
+
+`provenance` 為有序 array，每筆恰有非空 ID string `kind` 與非空 portable reference string `ref`；
+無來源時明示 `[]`，外部 proof 真偽交 producer／#842 驗證。ref 的 v1 grammar 恰為
+`namespace ":" body`：namespace 匹配 `[a-z][a-z0-9+.-]{1,31}`，body 至少一字元，只能使用
+ASCII letters/digits 與 `._~:/?#[]@!$&'()*+,;=%-`；整筆上限 1024 ASCII bytes，沒有 trim、percent
+decode 或 URI normalization。這是可攜的 opaque identifier 語法，不是 URL scheme 白名單／網址有效性
+或 credential scanner；未知 namespace 合法但不表示 proof 可取得或可信，也不會 dereference／開檔。
+`urn:fixture:observation-7`、`artifact:reports/r7.json`、`https://example.invalid/r/7` 是合法字面值；
+空字串、`urn:`、`/tmp/report.json`、`C:\temp\r.json`、`urn:one two`、前後空白／control／非 ASCII
+字元不合法。含憑證或無法跨環境解析的 reference 仍由 producer／#842 政策拒絕，不假裝語法檢查已完成該責任。
+`metadata` 是 object，頂層可選鍵只有
+`pricing`、`pricing_provenance`、`timestamps`、`evidence_refs`、`approval_receipt_refs`、`discovery`，
+值為有界 JSON data；無 metadata 時明示 `{}`。這些 opaque data 內部允許 caller 的資料鍵，不建立
+定價／政策 vocabulary。它們與 requirements 的 opaque values 是明示例外，不能據此放寬其他 strict object。
+
+### D2 — 原生 effort 的有界描述語法
+
+descriptor 頂層恰有必填 `schema_version`（integer 1）、`id`（非空 ID string）、`adapter`、`model`、
+`effort_grammar`、`provenance`、`metadata`。adapter/model 是 D3 對應 value 的完整 object；若 profile
+相應 condition 為 known，須逐型別／值相符；unknown 不猜填。其餘執行條件由 D3 固定資料語法描述，
+本件不藉 descriptor 做 launcher conformance。provenance/metadata 沿用 D1 語法且不進 key。
+
+effort grammar node 為 strict object，必填 `type`。以下是全部合法 node shape；方括號內表示可選鍵，
+不是 JSON 值。未列鍵一律拒絕，不支援 `$ref`、executable 或擅自轉型。
+
+| type | 其他合法鍵與 value 判準 |
+|---|---|
+| `none` | 無其他鍵，只能作頂層 effort grammar；只接受 not_applicable wrapper |
+| `string` | 可選 `enum`：非空、無重複的 string array；未提供 enum 時接受任意合法 Unicode string |
+| `integer` | 可選 `min`、`max`：同型別 integer，min≤max；value 必須是 integer，bool/float 不可代用 |
+| `number` | 可選 `min`、`max`：finite binary64 float，min≤max；value 必須是 float，integer/bool 不可代用 |
+| `object` | 必填 `properties`（欄位名→grammar object）、`required`（無重複的已宣告欄位名 array）；拒絕額外 value property |
+| `array` | 必填 `items` grammar，value 為有序 array |
+| `boolean`、`null` | 無其他鍵，只能是 object/array 的後代 node，接受對應原生型別 |
+
+這是資料型別語法，不是全域 effort 值或產品清單。新增模型與 grammar 內的原生值只改 descriptor。
+
+每個 tagged value 的完整 wire shape 只能是 `{"state":"known","value":...}`、
+`{"state":"unknown","reason":"..."}` 或 `{"state":"not_applicable"}`，不得有其他鍵。
+known 必須有符合 grammar 的 value；unknown reason 是非空、無頭尾空白的 string，不能帶 value；
+effort 的 not_applicable 只在 grammar=none 時允許。known string 的字面值 `"unknown"` 不是 unknown
+狀態；empty／0／null 也不得被 truthiness 轉成 missing。bool 不算 integer/number。
+core 不選 default：未指定的 request 以 unknown/reason 保留，resolved default 由上游明示 value/provenance。
+
+### D3 — 執行條件與 key 排除表
+
+`conditions` 恰有以下八個必填鍵，每個值使用 D2 tagged wrapper；只有 effort 可用 not_applicable。
+下表是 known wrapper 內 `value` 的完整 shape；表內 object 的鍵均必填且不可增加。
+ID string 與版本／revision 均為非空、無頭尾空白的 Unicode string，大小寫逐 byte 保存，不列產品表。
+
+| condition key | known value 的完整 shape |
+|---|---|
+| `adapter` | `{"id":ID,"protocol_id":ID,"protocol_version":ID,"runtime_version":ID}` |
+| `model` | `{"id":ID,"revision":ID}` |
+| `effort` | 精確符合該 descriptor effort_grammar 的 value |
+| `loadout` | `{"id":ID,"version":ID}` |
+| `toolset` | `[{"id":ID,"version":ID}, ...]`，空集合 `[]` 合法 |
+| `sandbox` | `{"id":ID,"version":ID}`，是契約 reference，不是本機路徑 |
+| `permissions` | `[{"id":ID,"version":ID}, ...]`，空集合 `[]` 合法 |
+| `toolchain` | `{"id":ID,"version":ID}` |
+
+只把 known toolset/permissions 的 value 視為集合：逐元素依 D4 `J(T(element))` 的 unsigned byte
+lexicographic order 排序，再移除 byte-identical 重複項。相同 id、不同 version 是不同元素，不猜等價。
+其他 array 一律保序。known object 若缺子欄位直接拒絕；部分未知需由 producer 明示整個 condition
+unknown 並保留原因／原 report，不自動將缺子欄位變成空字串或 known。
+observed 的每個條件均 known，或 effort 為合法 not_applicable，才可構造 actual-condition key；
+任一 unknown 回 `key=None` 與排序後的 missing-field locators。core 不驗 provider 是否真的使用此條件。
+
+| 欄位 | record key | actual-condition key |
+|---|---|---|
+| schema/key 版本、plane domain、conditions（含明示 unknown） | 納入 | 只接受完整 observed conditions，使用獨立 actual domain |
+| requirements | 納入，避免混淆請求意圖 | 排除；role/deck/coverage 與批准由 #842 組合資格 key |
+| provenance reference／descriptor 清單與 discovery metadata | 排除，保留於 record 原資料 | 排除，不讓清單擴充使相同實際條件失效 |
+| metadata 的 pricing／pricing provenance／時間戳／外部 report、approval receipt reference | 排除 | 排除 |
+
+排除 provenance 的 hash 敏感度不代表信任該 provenance；#842 仍須驗 proof、role/coverage 與核可。
+adapter/version 等實際條件不能藏在 metadata 以逃過變更識別，strict conditions 欄位必須完整存在。
+
+### D4 — 唯一 normative v1 encoding
+
+本節定義完整 wire→projection→typed tree→bytes→framed hash，不接受語意看似相同的其他 encoding。
+例如 `["integer","1"]` 與 `{"type":"integer","value":"1"}` 都不是本契約的 integer node。
+
+#### D4.1 — JSON text 與 native 型別
+
+輸入 JSON text 必須是無 BOM 的合法 Unicode／UTF-8 JSON；number token 只接受
+`-?(0|[1-9][0-9]*)(\.[0-9]+)?([eE][+-]?[0-9]+)?`。無 `.`／`e`／`E` 的 token 解析為任意精度
+integer，不能先轉 double；`-0` 解析成 integer 0。帶小數點或 exponent 的 token 解析為 IEEE-754
+binary64，依十進位精確值做 round-to-nearest, ties-to-even；包括 subnormal 與 underflow 至帶符號
+zero，負號保留。因此 `1.0`、`1e0` 是同一 float，`1` 是不同 integer；`-0.0`／`-0e0` 是 negative
+float zero。overflow 成 infinity 一律拒絕；NaN／Infinity token 本來就不是合法 JSON。
+跨語言實作者須保留 number token 的上述型別資訊；會先將全部數字混成 double 的預設 parser 不符合契約。
+
+native mapping 路徑只接受 exact JSON-compatible 型別：任意精度 integer、binary64 float、bool、null、
+Unicode string、array、string-key object；bool 不屬於 integer，Decimal／其他物件不偷偷轉型。
+serializer 的 float JSON token 必須含 `.` 或 exponent 且重解析後 binary64 bits 完全相同，包含 -0.0；
+integer 使用無前置零十進位 token，不走浮點中介。serializer JSON 外觀不必唯一，以下 canonical bytes 必須唯一。
+
+所有 object 在 JSON key escape 解碼後檢查重複，包括 `"a"`／`"\u0061"`；不得先用 last-key-wins。
+字串允許合法 surrogate pair 解成單一 Unicode scalar，但 lone／倒置 surrogate 或非 UTF-8 一律拒絕。
+不做 NFC／大小寫正規化。native 非有限 float、循環、非 string key 與 D5 越界資料同樣拒絕。
+
+#### D4.2 — 完整 projection 與 node shape
+
+令 `N` 為驗證後只按 D3 正規化兩個集合的 conditions；保留所有 tagged wrapper，不拆掉 state/value。
+record 的 projection **恰為** `{"schema_version":1,"plane":P,"conditions":N,"requirements":R}`，
+P 與 R 是該紀錄的 plane／完整 requirements。actual 的 projection **恰為**
+`{"schema_version":1,"conditions":N}`，且只允許 observed／全 known（effort 可合法 not_applicable）。
+若不符合 actual 前提，回 key=None／原因，不得 hash 不完整 projection。沒有其他預設欄位、descriptor
+digest、provenance 或 metadata 進 projection；不得任意 unwrap、改平面或將 requirement 塞入 actual。
+
+typed transform `T` 的 node 全為 JSON array，tag 與 arity 固定如下；表內 `...` 僅表示重複元素，
+不是輸出文字。object member name `k` 是 bare JSON string，不再套 `["s",k]`。
+
+| native value | 唯一 `T(value)` |
+|---|---|
+| null | `["n"]` |
+| boolean b | `["b",b]`，b 是 JSON literal true／false，不是字串 |
+| integer i | `["i",d]`，d 為無前置零十進位 string；zero 恰為 `"0"`，負數只有一個前導 `-` |
+| finite float f | `["f",h]`，h 為 binary64 big-endian bits 的恰 16 個 lowercase hex digits |
+| string s | `["s",s]` |
+| array a | `["a",[T(a0),T(a1),...]]`；空 array 恰為 `["a",[]]` |
+| object o | `["o",[[k0,T(v0)],[k1,T(v1)],...]]`，按未 escape 的 k 的 UTF-8 unsigned bytes 升序；空 object 為 `["o",[]]` |
+
+#### D4.3 — JSON bytes、framing 與公開 key
+
+`J` 是 typed tree 的唯一 JSON byte renderer：UTF-8，無 BOM、whitespace 或尾端 newline；array
+只用 `[`、`]` 與元素間的 `,`。string 用 `"` 包圍，U+0022 只寫 `\"`、U+005C 只寫 `\\`；
+U+0000–U+001F 一律寫六個 ASCII bytes 的 `\u00xx`（lowercase hex），**不用** `\n`／`\t` 等短寫。
+其餘 Unicode scalar 直接 UTF-8，不 escape `/`、非 ASCII 或 U+2028/U+2029。boolean 只寫
+ASCII `true`／`false`。T 輸出只包含 array、string、boolean，不再有 JSON number/object/null literal。
+
+`C = J(T(projection))`；`canonical_profile_bytes` 回 C，不含下列 frame。record domain 明確映射
+requested→`request`、resolved→`resolved`、observed→`observed`；actual domain 恰為 `actual`。
+`profile_key` 只從 record plane 選 domain，不能讓 caller 把 requested 指定成 observed。
+hash preimage `F` 的 bytes **恰為**以下串接，`00` 是一個 NUL byte，不是四字元 escape：
+
+```text
+ASCII("cortex.execution-profile") || 00 || ASCII("v1") || 00 ||
+ASCII(domain) || 00 || uint64_be(len(C)) || C
+```
+
+`len(C)` 是 UTF-8 byte 數，不是字元數，長度欄是恰 8 bytes unsigned big-endian，沒有十進位文字、
+冒號或 newline。digest = lowercase hex SHA-256(F)，對外完整 key 是 ASCII
+`epk:v1:` + domain + `:` + digest（64 hex）。沒有終端 NUL 或 newline。改 node tag、projection、
+framing 或版本均不相容，不能只改 key 外部 domain 字串而沿用 digest。
+
+#### D4.4 — 完整 profile golden vector
+
+以下是完整有效的合成 observed profile，無真實 observation／批准含意；對應 descriptor 的 adapter/model
+與此 value 相同、id=`fixture-descriptor`、schema_version=1、effort_grammar=`{"type":"number"}`、
+provenance=`[]`、metadata=`{}`。profile 中 metadata 的 pricing 故意存在但不進兩種 projection。
+
+```json
+{"schema_version":1,"plane":"observed","conditions":{"adapter":{"state":"known","value":{"id":"fixture-adapter","protocol_id":"fixture-wire","protocol_version":"1","runtime_version":"1"}},"model":{"state":"known","value":{"id":"fixture-model","revision":"r1"}},"effort":{"state":"known","value":1.0},"loadout":{"state":"known","value":{"id":"fixture-loadout","version":"1"}},"toolset":{"state":"known","value":[]},"sandbox":{"state":"known","value":{"id":"fixture-sandbox","version":"1"}},"permissions":{"state":"known","value":[]},"toolchain":{"state":"known","value":{"id":"fixture-toolchain","version":"1"}}},"requirements":{"role":{"state":"known","value":"review"},"minimum_quality":{"state":"known","value":null},"pin":{"state":"known","value":null},"independence":{"state":"known","value":null}},"provenance":[],"metadata":{"pricing":{"amount":9.0,"unit":"fixture"}}}
+```
+
+actual 的 C 恰為下一個 code block 的單一行 UTF-8 bytes，不含 Markdown fence／最後換行；長度 **920**：
+
+```json
+["o",[["conditions",["o",[["adapter",["o",[["state",["s","known"]],["value",["o",[["id",["s","fixture-adapter"]],["protocol_id",["s","fixture-wire"]],["protocol_version",["s","1"]],["runtime_version",["s","1"]]]]]]]],["effort",["o",[["state",["s","known"]],["value",["f","3ff0000000000000"]]]]],["loadout",["o",[["state",["s","known"]],["value",["o",[["id",["s","fixture-loadout"]],["version",["s","1"]]]]]]]],["model",["o",[["state",["s","known"]],["value",["o",[["id",["s","fixture-model"]],["revision",["s","r1"]]]]]]]],["permissions",["o",[["state",["s","known"]],["value",["a",[]]]]]],["sandbox",["o",[["state",["s","known"]],["value",["o",[["id",["s","fixture-sandbox"]],["version",["s","1"]]]]]]]],["toolchain",["o",[["state",["s","known"]],["value",["o",[["id",["s","fixture-toolchain"]],["version",["s","1"]]]]]]]],["toolset",["o",[["state",["s","known"]],["value",["a",[]]]]]]]]],["schema_version",["i","1"]]]]
+```
+
+actual frame 的前 43 bytes hex（包含長度欄）恰為
+`636f727465782e657865637574696f6e2d70726f66696c650076310061637475616c000000000000000398`；
+完整 F 長度 **963**，expected key：
+`epk:v1:actual:cccfc64a59aed4d4f3c14caa2468b18ff1ea067eeb84e3f376e0e722799e9ac2`。
+
+同一 profile 的 observed record C 恰為下列單一行，長度 **1227**：
+
+```json
+["o",[["conditions",["o",[["adapter",["o",[["state",["s","known"]],["value",["o",[["id",["s","fixture-adapter"]],["protocol_id",["s","fixture-wire"]],["protocol_version",["s","1"]],["runtime_version",["s","1"]]]]]]]],["effort",["o",[["state",["s","known"]],["value",["f","3ff0000000000000"]]]]],["loadout",["o",[["state",["s","known"]],["value",["o",[["id",["s","fixture-loadout"]],["version",["s","1"]]]]]]]],["model",["o",[["state",["s","known"]],["value",["o",[["id",["s","fixture-model"]],["revision",["s","r1"]]]]]]]],["permissions",["o",[["state",["s","known"]],["value",["a",[]]]]]],["sandbox",["o",[["state",["s","known"]],["value",["o",[["id",["s","fixture-sandbox"]],["version",["s","1"]]]]]]]],["toolchain",["o",[["state",["s","known"]],["value",["o",[["id",["s","fixture-toolchain"]],["version",["s","1"]]]]]]]],["toolset",["o",[["state",["s","known"]],["value",["a",[]]]]]]]]],["plane",["s","observed"]],["requirements",["o",[["independence",["o",[["state",["s","known"]],["value",["n"]]]]],["minimum_quality",["o",[["state",["s","known"]],["value",["n"]]]]],["pin",["o",[["state",["s","known"]],["value",["n"]]]]],["role",["o",[["state",["s","known"]],["value",["s","review"]]]]]]]],["schema_version",["i","1"]]]]
+```
+
+observed frame 的前 45 bytes hex 恰為
+`636f727465782e657865637574696f6e2d70726f66696c65007631006f627365727665640000000000000004cb`；
+完整 F 長度 **1272**，expected key：
+`epk:v1:observed:e2750040b4f91c563760daa19bcaa808f66bab7f4c445c3765522f19609b841b`。
+
+以下每列只把上述 profile 的 effort value 改成該 JSON token；descriptor type 相應改成 integer／number／
+string，使每列仍是合法 profile，而不是用錯 descriptor 跳過驗證。五把完整 actual key 必須兩兩不同：
+
+| effort JSON token | T(effort value) | expected 完整 actual key |
+|---|---|---|
+| `1` | `["i","1"]` | `epk:v1:actual:a5b73772473ec7f2926cc56d0117cf8b5e6ffa68431090d5be3fc552b91e729f` |
+| `1.0` | `["f","3ff0000000000000"]` | `epk:v1:actual:cccfc64a59aed4d4f3c14caa2468b18ff1ea067eeb84e3f376e0e722799e9ac2` |
+| `"1"` | `["s","1"]` | `epk:v1:actual:0bbfb460e7bd4e09122ac9737d14f9efb3ecba7387a562078a0496ce395a9e30` |
+| `0.0` | `["f","0000000000000000"]` | `epk:v1:actual:987c15ceb122f1e723247646330890502786b63a53a13bf01311b7e06a53cbd6` |
+| `-0.0` | `["f","8000000000000000"]` | `epk:v1:actual:a637e42ea4416af2af0e34e869c48ef3682dceec152f7124b0855d5550731f26` |
+
+`1e0` 是 1.0 同值正例；`-0` 是 integer 0、不是 -0.0；JSON `+0.0` 語法不合法。
+另需負控制：用其他 node shape、漏掉 length framing、只 hash C、保留 metadata、
+將 known wrapper 拆掉或把 record requirements 留在 actual，均不得等於此 golden。
+另外 `J(T({"z":"\n","a":"é/"}))` 恰為 UTF-8 的
+`["o",[["a",["s","é/"]],["z",["s","\u000a"]]]]`（無尾端換行）；改用短 `\n` escape、
+escape 非 ASCII／斜線、反轉 object member 次序都不符合這筆額外的字串 vector。
+這些 expected bytes／keys 由文件外的記憶體腳本與獨立 SHA-256 工具交叉驗算，不是待實作產品的自產 expected。
+
+### D5 — Strict、immutable 與資源界線
+
+v1 固定 `MAX_DEPTH=16`、`MAX_NODES=4096`、`MAX_SEMANTIC_BYTES=65536`（64 KiB），等於上限
+合法、超出一單位即拒絕。semantic metric 不使用 D4 serializer 的可變 JSON 外觀，規則如下：
+
+- root 的 depth=1；object 的每個 key string／value、array 的每個 element，其 depth 都是父 container+1。
+  primitive 與 container 都算 node；每個 object member key 另算一個 string node，不能漏算 key。
+  空 object／array 各為一 node；例如 `{}` 是 depth=1/nodes=1，`{"a":0}` 是 depth=2/nodes=3。
+- `parse_descriptor` 單獨計完整 descriptor；`parse_profile` 計完整 descriptor **加**一筆 profile：
+  兩個 root 都各算一 node、各從 depth=1 開始；合計 depth 取兩者 maximum，nodes 取兩者 sum，
+  不新增虛構 pair root。先前已解析的 immutable descriptor 也須計入，不得因呼叫順序不同免計。
+- semantic bytes 恰為 `len(J(T(descriptor))) + len(J(T(profile)))`；單獨 parse_descriptor 只有第一項。
+  使用 D4 的 UTF-8 typed bytes，但取完整資料，不取 key projection，不含 framing／分隔字元；
+  metadata／provenance／grammar 都計入。計算在 D3 集合去重之前，不先刪重複元素來省額度。
+  D4.4 的完整 golden profile 加該節描述的 descriptor，恰為 depth=5、nodes=144、semantic bytes=1740。
+  native mapping 與 transport 界內解碼後同資料使用相同 metric，mapping 排序、JSON whitespace、
+  等價 escaping 不改 semantic 裁決。不同型別的 1/1.0 不是同資料；重複集合元素是額外輸入資料，
+  即使之後得到同一 key，也不代表輸入資源數相同。T 展開產生的 tags 不另算 depth/nodes。
+- shared native object 每次出現都按值計數，不能用 identity memo 免計；目前 ancestry stack 再遇
+  同一 container 即報循環。必須在 push／遞迴／複製下一 node 前檢查 depth/nodes。
+  以有界累計器計 semantic byte 長度，超界立即停止，不先建整個 canonical tree／巨大字串副本。
+  大型 native string／integer 可先以長度／位數安全下界拒絕，再做有限編碼；不保證任意 input 常數成本。
+
+另有**獨立 transport guard**：每個 caller 提供的 JSON text operand 上限 `MAX_TEXT_BYTES=1048576`
+（1 MiB UTF-8；等於合法），descriptor/profile 各自適用，不是兩者合併的 semantic budget。
+core 不讀 stream／檔案；已有 native mapping 無 text guard。JSON text 在完整 decode／allocation 前，
+先做有上限的 UTF-8 length／lexical 掃描；不得先無界 encode 整個字串或先 json.loads 再檢查深度。
+掃描需理解 JSON string／escape，串流累計 depth/nodes 與 decoded token 的 semantic 長度；達到
+任何上限後的第一個單位即中止，不完整 materialize 超界 value。file/stream adapter 日後由其 owner
+以同一每 operand 上限做 bounded read，只能多讀一 byte 判定超界；本件不新增 I/O 入口。
+
+錯誤碼分開：raw text 超界 `transport_too_large`；semantic byte 超界 `semantic_size_exceeded`；
+深度／nodes 超界 `depth_exceeded`／`node_count_exceeded`；循環 `cyclic_value`。locator 可指出
+descriptor/profile，不能回印原始值。transport 上限內的等價排版才保證同 semantic 裁決；極端 padding
+可能先被 transport guard 拒絕，這不是新 schema/key 不相容。此有限讀取取捨已由 root 明確接受。
+上列數值是版本化 parser 邊界，不是模型 quota；調整需契約重審，不偷偷用機器資源決定。
+
+邊界 fixtures 必含：depth 16/17（root 計入）；nodes 合計 4096/4097；完整 typed bytes 合計
+65536/65537；每份 raw text 1048576/1048577。還須同資料的 compact／pretty／escaped/native 路徑
+在 transport 界內同裁決、單份都未超界但 descriptor+profile 合計超界、預解析 descriptor 仍計入、
+超大 padding 早停、深層 native chain 在第 17 層前止步與共享 alias 重複計數；不得只在完整 decode 後測錯誤。
+只接受明定的 JSON-compatible 型別；unknown fields、duplicate JSON keys、bool version、錯 union、
+malformed descriptor、NaN/Inf、不可編碼字串都 fail-closed。
+
+解析結果遞迴 immutable，不保留 caller 可修改的 dict/list alias；`to_dict` 回獨立副本。
+不快取依賴外部 state 的值，不引入 file lock／CAS／migration；跨 process round-trip 只驗同一新資料。
+metadata 頂層沒有 raw credentials／本機路徑欄位，error 不 echo arbitrary value；這不是通用機密偵測器，
+caller／producer 仍負責送入可分享且不含秘密的資料。
+
+### D6 — 合法升級與 downstream 接縫
+
+v1 parser 的缺版本／未知未來版一律拒收，不猜成當下或某個舊版。合法擴充是在既有 descriptor grammar
+內新增 model/effort 值，也包括 adapter.protocol_id/protocol_version/runtime_version 等已定義欄位的
+新值：這些只更新 descriptor／對應 profile，沿用 core v1，actual key 自然改變；不需中央產品名單分支。
+此處需要升版的 protocol/shape 專指 **core 資料 wire grammar／projection／canonical encoding** 改變，
+不是 adapter protocol 欄位新值；前者才須明示新 core schema/key version、保留舊 key 契約，不覆寫 receipt。
+legacy manifest／run 轉換、可信 snapshot 缺失的 legacy/unversioned/unknown 與 authority 重新接受，
+由母 T05/T10 後續 child 負責；core 不為此讀取或升級既有 state。
+
+#842 可在本 core 契約凍結後以明示 fixture 開發 publication consumer，無需等整件 #835 關閉；
+其 human-review receipt／qualification lifecycle 不回灌成 core 的 approve API。#581 五項與
+PatchMUD #37 CLI/file producer 各由原 owner 實作；新 module 不 import PatchMUD。
+母件 adapter／resolver／binding child 日後接正式 producer/consumer 與 actual routing，
+在此之前只能宣稱本 core 的純 API 可獨立測，不能宣稱 fallback、effort forwarding 或角色授權已生效。
+
+## Validation
+
+新增 `tests/test_execution_profile_schema_core.py`（C01/C02/C06/C07/C08/C10）、
+`tests/test_execution_profile_keys.py`（C03/C04/C05）、
+`tests/test_execution_profile_core_boundary.py`（C09/跨 process／import boundary）作為未來落點，
+可在相同 scope 內合併測試檔；不可把新增檔名當既有測試成果。
+fixture 一律虛構 adapter/model；string、integer、0.625、nested effort 分別驗 native 型別。
+正例與越界／錯型別／unknown／未核可／future-version 負例成對；元測試刪掉關鍵欄位驗證時必變紅。
+fixture consumer 只讀 core 公開 API，不能假扮 production resolver／真人資格批准。
+
+既有 `tests/test_model_identities.py`、`tests/test_model_identities_envelope_v3.py`、
+`tests/test_model_resolution_chain_534.py`、`tests/test_per_work_model_chain.py`、
+`tests/test_model_profile_cli.py` 與 full suite 作 no-regression gate；這些舊 consumer 不因測試綠燈就算接線。
+CLI 只做既有 --help smoke／文件說明，本件不加 flags、subcommands 或 native provider probe。

--- a/docs/superpowers/specs/execution-profile-schema-core-spec.md
+++ b/docs/superpowers/specs/execution-profile-schema-core-spec.md
@@ -1,0 +1,121 @@
+---
+status: accepted
+work_item: execution-profile-schema-core
+---
+
+# Execution profile schema／key core 規格
+
+## Authority
+
+本件是 [#835](https://github.com/hamanpaul/paulsha-cortex/issues/835) T01/T02 的獨立純契約切面，
+parent #829。依 root 採納的 schema-core 優先裁決及 [PR #848](https://github.com/hamanpaul/paulsha-cortex/pull/848)
+head `be59f769786eeee2e1f97e073c722d8e49272653` 的完整母規格、設計、Todo、審查報告。
+獨立 owner 為 [#849](https://github.com/hamanpaul/paulsha-cortex/issues/849)，由本批登錄進件；
+尚未 freeze／dispatch。`accepted` 是規劃內容狀態，不是產品／模型資格授權。
+
+## Requirements
+
+### R1 — 唯一 production 範圍是新純模組
+
+未來只新增 `paulsha_cortex/coordinator/execution_profile.py`，提供 descriptor、profile／requirements
+資料驗證、immutable value、serializer 與 canonical key 純函式。只使用 Python 標準函式庫，
+輸入為 caller 明示交入的資料；不讀環境、檔案、clock、catalog／registry，不跑 subprocess／network。
+不得修改現有 loader、launcher、resolver、workflow、registry、CLI command 或 package `__init__.py`。
+測試可由正常 module import 使用公開 API，但這不代表現有 routing 已消費新契約。
+
+### R2 — 版本化 descriptor 與原生 effort
+
+v1 descriptor／profile 描述 adapter／協定及版本、model、loadout、toolset、sandbox／權限、toolchain 等
+執行條件及 effort 資料語法；名稱／值由輸入資料提供，不建立全域 model／agent／effort 名單。
+原生 effort 支援 string、integer／finite number、結構化 object／array；descriptor 可約束其
+值域／欄位／型別，新增原生值只改 descriptor，不改中央產品分支。不同 adapter 同名 effort 不等價。
+本件是明定且有界的資料語法，不是完整 JSON Schema 引擎、不執行 descriptor 內的程式碼。
+
+### R3 — 三層資料不相互猜填
+
+requested、resolved、observed 是各自標記 plane 的獨立紀錄；caller 對每筆提供對應 descriptor，
+不能將 requested 覆蓋 observed，亦不能因兩者值不同而抹掉實際觀測。
+core 只驗資料格式，不選候選、不套 provider 預設；resolved 的 default 必須由上游明示解析並留來源。
+每個條件使用明確 known／unknown 狀態，unknown 保留原因而不帶假 value；effort 的 not_applicable
+僅在 descriptor 明示無該設定時合法，不能等同 missing／unsupported。
+role／最低品質／pin／independence 是分立的 task requirements 資料，不是本 core 的授權結論。
+
+### R4 — Key plane 與實際條件分立
+
+request/resolved/observed record key 各有版本及 domain separator；actual-condition key 只能從
+observed 的完整執行條件構造，不能從 request/resolved key 改名取得。
+effort、adapter／協定／runtime 版本、model/revision、loadout/toolset、sandbox／權限或 toolchain
+條件改變時，actual key 須不同。必要觀測 unknown 時回 `key=None` 與缺欄位原因，不產假完整 key。
+core 可檢查 provenance reference 的結構，但不能驗其外部真實性；有 key 也不代表 measured／qualified。
+
+### R5 — 精確 canonicalization 與排除項
+
+canonical bytes 跨 mapping 順序、process／hash seed 穩定；明定集合與有序 array、number／string、
+integer／float 的語意，拒絕 NaN／Inf、非法 Unicode、重複 JSON keys、循環／越界資料與未知欄位。
+Design D4 的完整欄位 projection、typed-array tags／arity、JSON token 型別、字串 escaping、
+NUL／uint64 length framing 與完整 profile golden 是 normative v1，不得另選看似等價的 node shape。
+Design D5 的 depth/nodes／完整 typed semantic bytes 計數與獨立 raw transport guard 同樣 normative，
+不得用 serializer 排版決定 64 KiB 裁決；超界在有界讀取／遍歷時拒絕，不完整 decode 後才檢查。
+metadata 的時間戳、價格／pricing provenance、report／approval receipt reference 不進 capability key。
+descriptor 的可用模型／effort 清單擴充、發現時間或來源 metadata 不改既有相同執行條件的 actual key；
+有執行語意的 adapter／協定版本則是條件，不能為了穩定而剝除。
+
+### R6 — 不遷移 state、不代替政策
+
+v1 strict parser 不猜測缺失／未知 schema version，不把舊 identity、envelope 或 manifest 自動升格。
+pure serialize/parse 是新資料的 round-trip，不是既有 state migration／restart recovery。
+只有具可信原 schema／policy snapshot 的 frozen legacy run 可保留原可證語意；無者維持
+legacy/unversioned/unknown，需正式 authority 重新接受才可切新版。這條 stateful 行為由母件後續
+binding/migration child 實作，本 core 不接觸舊檔、run、chain、attempt、evidence 或 receipt。
+未來 schema 升版必須明示新 parser／key 版本與相容政策；未知版不得默默當 v1，舊 key 不回寫重算。
+此升版指 core wire/encoding 契約；adapter protocol/version 等既有欄位的新值仍為 descriptor-only
+合法擴充，沿用 core v1 並自然得到不同 actual key，不需因名稱／版本新值重改中央產品。
+
+## Invariants
+
+- I1：唯一新 production 模組、純資料輸入輸出；不啟動 runtime 或自動接線。
+- I2：版本／型別／必填欄位嚴格驗證，缺版本與未知版本不猜填。
+- I3：原生 effort 由 descriptor 表達，不建立全域等價排序或產品名單。
+- I4：requested/resolved/observed 分立，unknown／not_applicable 不冒充 known。
+- I5：record key 與 actual key domain 分離，canonical bytes 不依 process／mapping 順序。
+- I6：實際執行條件變動可識別，不因同 model 名稱而借用其他配置 key。
+- I7：價格／時間戳／外部 receipt 與清單 metadata 不污染能力 key。
+- I8：必要 observed 缺失無完整 actual key；格式合法／有 key 不等於資格或授權。
+- I9：輸入／回傳值不可藉 alias mutation 改寫已解析紀錄，解析有界且錯誤不洩露原始值。
+- I10：無 state migration、歷史回寫、模型／角色授權或真實 producer 已接通的假宣稱。
+
+## Acceptance Criteria
+
+- [ ] C01：虛構 adapter/model descriptor 下，string、新原生 string 值、integer、finite number、nested object/array effort 都可依資料擴充；公開 API 無產品名稱分支（I2、I3）。
+- [ ] C02：同一請求的 requested／resolved 與不同的 observed 分筆 round-trip，不互覆；unknown 與合法 not_applicable 保留，錯誤 not_applicable 拒絕（I4）。
+- [ ] C03：固定有效紀錄依 Design D4 重算完整 actual／observed canonical bytes 與完整 golden key；不同 process／hash seed、mapping 插入順序及集合排列得到相同結果，ordered array 次序改變則不同。int 1／float 1.0／string "1"／+0.0／-0.0 的五個完整 profile key 逐筆吻合既定 vector，不能用其他 tags／shape／escaping／framing 代替（I5）。
+- [ ] C04：逐一 perturb effort、adapter/id/version/protocol、model/revision、loadout/toolset、sandbox/permissions、toolchain；每個有效條件變動都改 actual key，三層 key 不互用（I5、I6）。
+- [ ] C05：只改價格、pricing provenance、時間戳、外部 evidence reference 或擴充 descriptor 其他允許值，既有條件 key 不變；不影響執行的欄位有明確排除表（I7）。
+- [ ] C06：任一必要 observed 欄位 unknown 時 actual key 不可用，原因精確；格式合法／全 known 仍不產 approved／qualified／permission grant，fake provenance 不冒充已驗真（I8、I10）。
+- [ ] C07：未知／缺失／bool schema version、缺欄位、多餘欄位、escape 解碼後重複 JSON key、錯原生型別、bool 冒充 number、NaN/Inf／浮點 overflow、非法 Unicode、越界／循環資料都明確拒絕；整數 token 不先轉 double，float token 採 D4 的 binary64 rounding／signed-zero 規則，合法 surrogate pair 與 exponent 正例可重算（I2、I3、I9）。
+      D1 reference grammar 正負例與 D5 depth 16/17、nodes 4096/4097、semantic bytes 65536/65537、raw text 1048576/1048577 均成對驗；合計 descriptor/profile、預解析路徑與 transport 界內不同 encoding 同裁決，超界提早中止。
+- [ ] C08：解析後修改 caller 原 dict/list 或 serializer 回傳的副本，已解析內容與 key 不變；API 不改輸入，錯誤只含 code／field locator 而非原始敏感值（I9）。
+- [ ] C09：以公開 module API 的 consumer fixture 驗單筆 schema/key 契約，另證明無檔案／環境／clock／subprocess／network 依賴；既有 production consumers 未改，不宣稱 routing 或 PatchMUD 已接通（I1、I10）。
+- [ ] C10：新 v1 資料在全新 process round-trip 穩定；缺版本 legacy payload／未知未來版不自動 migrate，舊資料 fixture 原 bytes 不變；更新 descriptor 值域是合法擴充，變更 schema 協定須明示版本（I2、I10）。
+      新 adapter protocol/version 值仍 core v1／descriptor-only 且 key 改變；只有 core wire/encoding shape 改變須新版，兩者不可混為一談。
+
+## Parent Coverage
+
+| 母件 AC／Tasks | 本 child 的精確覆蓋 | 留在母件／其他 owner 的必要交付 |
+|---|---|---|
+| A1／T01 | C01/C02 的 descriptor 與三層 schema | 實際 resolver/launcher descriptor-only 接線，母 T03/T04 |
+| A2 | C07 只拒絕資料不支援的值；core 本身無 spawn | argv/terminal/usage/quota/cancel/timeout/sandbox conformance，母 T03/T08 |
+| A3 | requirements 保留、C06 不自授權 | unknown-role 語意 #581；pin/品質/independence/Trust Root 真 gate，母 T04/T09 與 #842 |
+| A4／T02 | C03–C08 的 key／unknown／metadata 全部純契約 | 真 observed producer 與 qualification 採信，母 T06、#581/#842/PatchMUD #37 |
+| A5／T02 | C07/C10 新 schema 與未知／舊版拒收 | frozen run／state migration、CAS/crash、歷史不變、無 snapshot 的正式重新接受，母 T05/T10 |
+| A6 | C09 公開 API 的離線契約 fixture | 真 production consumer/producer、既有 routing 回歸與 installed/live，母 T11/T16 |
+
+## Dependencies
+
+本 core 的 schema/key → [#842](https://github.com/hamanpaul/paulsha-cortex/issues/842) qualification
+發布 consumer，後者不等整件 #835 close。#842 獨立擁有 report→candidate→human-review receipt→roster、
+撤銷／有效期／CAS／migration；真人政策要求的 receipt 不由本件批准。
+#581 保留 doctor planning 身分、unknown-role、非 dispatch provenance、doctor overlay 公開 API、
+eval producer 五項；[PatchMUD #37](https://github.com/hamanpaul/paulsha-patchmud/issues/37) 只供
+外部 CLI/file schema／immutable fixture，零 runtime import、不實作上游或重跑 benchmark。
+本 child 可獨立測純契約，不表示母件或 #842 的 production／live 驗收完成。

--- a/docs/superpowers/specs/executor-backoff-store-core-design.md
+++ b/docs/superpowers/specs/executor-backoff-store-core-design.md
@@ -1,0 +1,129 @@
+---
+status: accepted
+work_item: executor-backoff-store-core
+---
+
+# Executor backoff store 核心設計
+
+## Decisions
+
+### D1 Ownership and input contract
+
+流程：可信 caller 的 immutable event/policy envelope → schema/完整性檢查 → root lock 內重讀 ledger → event-time pure fold → atomic store/ack commit → fresh observation；caller terminal inventory → ack 對帳 → 獨立 reconciliation 狀態。只有 C/D 能把最後結果接成 production admission；A 沒有 registry writer、job reader、log scanner、launcher 或模型呼叫。
+
+輸入 envelope 必備：store scope、exact executor/model、terminal key、原 event epoch、原 payload 與其 canonical fingerprint、outcome/authority、policy revision/參數、reset provenance。caller 負責證明這是已持久且未受覆寫的真終局；A 驗證值一致，不把 JSON 形狀或 `trusted=true` 當 cryptographic/terminal authority。缺少任一必要證據即 unknown；不重讀現在的 job/settings 代填。
+
+reset provenance 有明確 `structured`、`parsed`、`absent` 三類：前兩者須有原 reset epoch、source/evidence ref、解析規則版本；parsed 另有明示 timezone/base-year/原解析基準時刻。absent 是 caller 已可靠判斷無可用 hint 的明確結果，不是 metadata 沒傳。A 不解析文字，也不升級 classification authority；外層 envelope 不改既有 provider_outcome 四鍵＋可選 reset_at。原 payload/reset/provenance 相矛盾回 unknown。
+
+policy envelope 凍結 rate base、quota base、margin、倍率／上限及算法 revision；所有數值有限且範圍合法，quota base > rate base，margin 非負且受該 revision 明定上界限制。v1 只接受有明確 interpreter 的 revision；支援新 revision 必須保留舊語意與 golden oracle，不以新增模型/agent/effort 重寫 key 或算法。本模組可重用現有 backoff helper，但須驗該 helper 語意等於 frozen revision，不能讓 helper/settings 升級改掉 replay 結果。
+
+### D2 Schema and explicit observation
+
+schema `executor-backoff/v1` 儲存 scope、canonical event map、每 identity aggregate、事件 fingerprint/ack、policy/provenance 與資料版本。terminal key 全 store 唯一；identity 用結構化二元 key，不靠可碰撞的分隔字串。同 key 重送先比完整 canonical envelope；缺欄位／變更 identity/time/policy/reset 皆拒絕且不覆蓋原記憶。
+
+epoch/deadline/policy 數值拒絕 bool、NaN、infinity 與運算溢位，hits 為非 bool 的正整數；empty identity/key、非法 outcome/authority、fingerprint 不符與未知資料版本回 unknown。可採 reset 不早於其原解析基準時刻（Retry-After 0 可等於基準）；缺資料不默認 absent，A 不把現在時間代入驗舊事件。
+
+`read_store` / `active_backoff` / `record_backoff` / `clear_backoff` 的確切 Python types 隨實作固定於同模組，但必須顯式保存兩個維度：
+
+| 維度 | 值 | 禁止的推論 |
+|---|---|---|
+| store observation | missing / valid / unknown，附 last-good 與具體 diagnostic | missing 或 valid 無 active ≠ quota 足夠 |
+| reconciliation | unverified / pending / complete / unknown，附 missing/conflicting keys 與 caller evidence ref | 沒提供 inventory ≠ complete；可解析旧檔 ≠ 新 intent 已 ack |
+
+query `now` 只決定 active/expired，永不參與 event epoch、hits、policy 或 reset 的重建。未知輸入／IO error 回 unknown，不以 `None`、空 dict 或布林 false 混同正常無 active。`complete` 僅表示「本次 supplied、具 scope/revision/completeness 聲明的 inventory」已可靠合併；是否 canonical、fresh、retained 仍是 C/D 的外部責任，沒有通用 `allowed=true` API。
+
+### D2.1 Capacity and computation profile
+
+v1 使用固定 `capacity_profile=bounded-ledger/v1`；同模組所有 process 採同一 profile，不從現在 model/settings 或 caller 任意覆寫上限。這是資源限制，不是 frozen backoff policy。遇未知 profile 或 runtime 無法遵守其上限回 unknown；不得自動提高 cap／改 ledger policy。測試可在隔離同一 profile fixture 注入更小上限驗邊界，不能把測試小 cap 當 production policy。
+
+| Resource | v1 上限 | 執行點 |
+|---|---|---|
+| 已存／候選完整 encoded store | 2 MiB | fd size 預檢＋最多讀 cap+1 bytes；候選串流 encode 超限即停，replace 前拒收 |
+| 單次 input／inventory encoded bytes | 1 MiB | bytes 長度先檢查；stream 最多 cap+1；不得先 loads/dumps 整份才量大小 |
+| retained distinct events／identities | 1024／128 | 鎖內最新 ledger 與候選 union 驗證；duplicate 不算新增 |
+| 單次 input records／canonical event bytes | 1024／8 KiB | 不無界消耗 iterable；逐 event canonicalize/hash 有界 |
+| JSON depth／單 string bytes／key bytes／numeric token chars | 12／4 KiB／512／64 | decode 前 bounded lexical check；拒 bool-as-number、過深結構與巨型數字 |
+| input＋store＋候選累計結構節點 | 131072 | bounded pre-count 與遍歷工作計數；不可只 decode 完後才檢查 |
+| sort comparisons／fold event visits | 65536／2048 | 舊 store 驗證與候選 union 各最多一輪；不對每個 incoming event 重 fold 全 ledger |
+| decode/hash/encode 累計 byte work | 16 MiB／operation | 所有通道共同計數；多 pass 不各自重置預算 |
+| 合作式 compute deadline | 1 秒／operation | monotonic clock；每≤4096 bytes、≤128 nodes 或一個 fold event 檢查，排序比較亦檢查 |
+
+只讀 regular file，fd 上限檢查後仍使用 bounded read，避免檔案增長／stat race 令 read 無界。大小只讀到 cap+1 就能判超限；超限舊 store 回 `store-too-large` unknown，不解析尾部、不截斷或 migration。shape/token 限制在一般 JSON decoder 大配置之前以有限掃描驗證；結構化 Python input 只接受可有界遍歷的資料形狀，不接受無界 generator/custom object hook，避免驗證前 deepcopy/json.dumps。caller 已配置的記憶體不在 A 所有權內，但 A 自己不得先完整複製／展開超限 input。
+
+計算界為固定 byte/node/comparison/visit 上限；因此 retained ledger 即使永不 GC，A 單操作擁有的解碼／排序／fold／輸出配置也不隨運行歷史無限增長，不聲稱掌控外部 caller 數或 host 全域記憶體。deadline 超出回 `computation-budget-exceeded` unknown；不靠背景 worker 超時後棄置工作／另起 worker。所有可拒收的 CPU/容量檢查都在 replace 前完成，commit 後不再套新增事件拒收判定；post-replace sync failure 仍是 D3 durability-unknown，而非「零 replace」的計算超限。deadline 只約束可合作中止的 CPU 工作，不能宣稱能搶占阻塞的 filesystem syscall 或 OS scheduling；lock acquisition timeout 與 POSIX durability/IO 故障維持 D3 的獨立契約。
+
+容量判斷順序：先 bounded input／fresh store validation → 同 key 完整 fingerprint/provenance 比對與去重 → 計候選 distinct union／output bytes/work budget → 單次 atomic commit。合法 store **恰達 cap** 時，size 合法的 exact duplicate 仍回 unchanged，bytes/acks/hits/deadline 不變；不得一看到 count==cap 就短路拒 duplicate。same-key 衝突仍 integrity unknown。任何新增事件使一項 cap 超出，整批回 `capacity-exceeded` unknown，不部分 ack、不更動原 bytes，也不從別 identity 刪資料騰位。若 input 自身超限或舊 store 已越安全 cap，則無法承諾辨認 duplicate，回具體 unknown，不突破讀取界。
+
+飽和不是遺忘權：expiry/clear 不清 ledger 額度；跨 process pending intent 仍由 C/D 的 canonical terminal inventory 找出，不能用舊合法 at-cap store 把新事件說成已合併。正常 reader 仍可觀察 at-cap store 的已知事實，但有未合併新事件時 reconciliation 保持 pending/unknown，不能變成 admission 完成。滿額後拒新是一個明示的可用性限制；後续擴容量／安全 GC 需另裁，不在 A 自動恢復。
+
+### D3 Cross-process commit and failures
+
+使用與 state 檔分離且不隨 replace 更換 inode 的 lock 檔；同 root 所有 writers 使用 `fcntl.flock` 排他鎖，read/對帳使用相容鎖界。鎖取得需可控有限 timeout，timeout/permission error 回 unknown，finally 釋放 descriptor；不刪 lock 檔以免形成兩把鎖。
+
+writer 取得鎖後才按 D2.1 bounded read 重讀最新 state，在 byte/node/work/deadline 界內驗證完整 ledger/aggregate，再有界寫同目錄唯一 temp，flush/fsync 後 atomic replace，並完成目錄 durability barrier。候選容量與計算預算不足在 replace 前拒絕，舊 bytes/acks 保留；不能因留住所有歷史而無限持鎖。不能共用固定 `.tmp` 路徑、用 process cache 當基底、把 corrupt 檔改成空檔，或先 ack 再提交事件。無變化的相同重送不重寫檔案。
+
+故障切點分開驗：read／validation／temp write／temp sync／replace 前失敗保留舊檔 bytes、無新 ack；replace 失敗也不能回 success。replace 成功但後續 durability barrier 失敗時，檔案可能已是新版本，必須回 `commit-durability-unknown`，不可假稱 rollback 舊 bytes。另一 process 不得僅因新檔可解析而解除：所有 fresh valid observation 須在同 lock 內完成該 data fd/目錄所需 durability check，再由 caller 以 fresh terminal inventory 驗 ack。barrier 持續失敗即持續 unknown；barrier 恢復且全部 intent 可靠收斂才可回 valid/complete。這是明示的 store protocol，不靠可能寫不出的 error sidecar 或 process sticky flag。
+
+read permission/IO/unknown schema、lock timeout、同 key 衝突與政策 mismatch 均不會清掉別的 identity。last-good 只可引用同 scope、曾驗證之已知內容；fresh process 拿不到可信 last-good 就明說 unknown，不憑舊 reader cache 宣稱全貌。crash、sync 與 lock 行為由 POSIX 本地檔案系統 fixture 驗證，不聲稱已認證所有網路檔案系統。
+
+#### D3.1 Real process-death test boundary
+
+T09 同時要求 exception fault 與真正 process-death，兩者不可互代。harness 先把 A/B immutable intent 寫入隔離 durable fixture inventory、store 僅有 A，再以 `multiprocessing` 的 fresh/spawn writer 操作 B；writer 用 Event/barrier 明確向 parent 確認以下切點。parent 僅對本測試直接建立、持有 Process handle/PID 的 writer 發 SIGKILL（或等效不可捕捉的 process kill），有界 join 並驗 exitcode；禁止搜尋／終止既有 daemon、provider、其他 agent 或任意 PID。不得讓 writer 捕捉例外後執行正常 rollback/finally 來替代死亡窗口。
+
+| 切點 | Kill 的精確位置 | Fresh-process oracle（先觀察、再對帳） |
+|---|---|---|
+| K0 | temp 已寫/sync，atomic replace 尚未呼叫 | 舊 store bytes/ack A 保留、B 未 ack；B 仍在 durable fixture inventory，可靠 replay/commit 前 reconciliation 不完整 |
+| K1 | replace 已回成功，directory durability barrier 尚未執行 | 不憑可見新 bytes/ack 就宣稱完成；fresh process 同 lock 內重讀 data、執行 data/directory sync，並重讀 durable inventory 核對；sync/merge 失敗保持 unknown |
+| K2 | data 與 directory barrier 已成功，回傳 caller 前 | 在本測試持續運作的 filesystem 觀察已提交版本與 B ack；fresh sync/inventory 對帳後重送 B 仍 unchanged，不增加 hits/deadline |
+
+每個切點都另啟不承接 writer 記憶體/cache 的 fresh reader/consumer，驗證死亡 writer 的 flock 已由 OS 釋放、data/directory sync、durable fixture inventory 的完整重讀，以及 pending→可靠合併的結果；不能只重開同一物件或沿用 parent 已讀 inventory。wait/kill/join 全有界，finally 清理只限自建 subprocess 與 tmp fixture。這證明 process-death/restart protocol，不是 machine power-loss、掉電後 filesystem replay，亦不宣稱重現任意 filesystem 的持久性行為。
+
+### D4 Deterministic fold and expiry
+
+v1 保存容量內已接收的完整事件，無 GC/checkpoint 最佳化；超限新事件按 D2.1 原子拒收，不能要求先全讀無限 ledger 才判斷。驗 byte/node/event cap 後，在固定 comparison/fold budget 內按 `(event_epoch, terminal_key)` 排序，從 deadline 無值/hits=0 開始：
+
+1. 首事件，或 `event_epoch >= previous_deadline`：本事件 hits=1；否則 previous hits+1。
+2. structured/parsed reset 已由 caller 證明可採時，候選為 reset+frozen margin；明示 absent 才用 `event_epoch + frozen_backoff(base(outcome), hits)`。
+3. `deadline=max(previous_deadline,candidate)`；輸出末事件的 episode hits。若加入較舊事件，從完整 ledger 重 fold；不按 arrival order 或 record now 更新。
+4. 驗 store aggregate 與 event ledger 一致；不一致一律 integrity unknown，若舊 persisted deadline 仍 active 另保留其最低保護界，不因 expiry 掩蓋完整性問題。正常同政策完整集合的 aggregate 必須 arrival permutation 不變。
+
+固定測試 policy：rate base=10、quota base=40、margin=5、倍率2、max exponent4。先寫 event=200/reset=1000，再寫 event=100/reset=300，最終 deadline=1005、hits=2；反向、同時刻 key tie、混合 absent 及 fresh process 皆依相同 fold。`event_epoch == previous_deadline` 重開 episode；query now 遠晚於 deadline 不改 events/hits。
+
+`clear_backoff` 遇 active entry 回 `active-cooldown` 拒絕；expired 時可冪等 no-op，因 active projection 本就由 query clock 導出。ack/event/policy 與歷史 aggregate 保留，不按期限清除，也不因此釋放事件額度。成功 job、auth success 不在 record 的 eligible outcomes，不能化為 clear；較短新 reset 是新事件候選，不是縮短權。ledger 在 D2.1 cap 停止接收新事件，容量／計算／磁碟不足均回 unknown、不丟 bytes/acks；安全 compaction 與擴容留後續契約，不再用 disk-full residual 代替記憶體／CPU 保護。
+
+### D5 Reconciliation seam and delivery boundary
+
+原子替換失敗後，未合併 intent 的 durable authority 位於 caller 的 canonical terminal evidence，不在 A 新 error 檔。A 接收 caller 提供的完整／不可讀／未完整 inventory 描述與其 immutable events，核對 event keys、fingerprints、policy 與 ack。缺對帳／不可讀／缺 retention 證明不能默認零 pending；record 再失敗仍 unknown。old-valid-A＋new-unacked-B 的跨 process 測試必須明確把 B 以 fixture caller 的 durable inventory 送給 fresh consumer，不能僅在單 process 呼叫兩次 raw reader。
+
+fixture caller 是測試邊界，不是聲稱 C/D 已存在。A 不掃 live/installed state，不新增 registry writer，不修可覆寫 exited_at。C 必須提供 immutable terminal/provenance、strict fresh reader、retention；D 必須在所有 admission 前取 fresh inventory 並對帳，E/F 接 consumers/slice。A 無 API 可以獨自證明「沒有其他未 ack terminal」；該全稱性交 C/D runtime invariant tests，不由 source scan 或測試注入 always-complete inventory 背書。
+
+### D6 Risk matrix and negative controls
+
+所有測試使用 tmp_path、fake clock、multiprocessing Event/barrier；等待有界，finally 放行/join，禁止真 provider、daemon、模型或 live store。沿用 pytest，不新增框架。
+
+| ID / AC | Surface / Harness | Oracle / 負控制 |
+|---|---|---|
+| T01 R1 | 真 missing、corrupt bytes、unknown schema、read fault | 三態不同；corrupt 不寫 empty；把 unknown 壓成 missing 的 mutant 必紅 |
+| T02 R2 | fresh processes 同 root，鎖內 pause 後第二 writer | 寫入序列互斥、無 lost update；移除 flock/reload 的 mutant 必紅 |
+| T03 R2/R3 | 兩 identity record 與 expired clear 交錯 | 他 key bytes/ack/deadline 保留；固定 temp/stale RMW mutant 必紅 |
+| T04 R4 | 原事件 replay、同 key/time/policy/identity 衝突 | replay bytes/hits/deadline 不變；衝突 unknown；僅 last-key 去重 mutant 必紅 |
+| T05 R5/R6 | 小集合全 permutation、same-time tie、event-time=deadline | reset1000/300→1005/hits2；arrival-now 與 last-arrival-wins mutant 必紅 |
+| T06 R6 | 改 caller 現在 settings/now，重送 frozen envelope | 原結果不變；缺/未知 policy/provenance unknown；套當前 settings mutant 必紅 |
+| T07 R7 | expiry/clear→restart→舊 replay＋未 ack 舊事件 | 不復活、不丟 ack；按 TTL 刪 ledger mutant 必紅；active clear 拒絕 |
+| T08 R2/R8 | durable fixture inventory A+B、store 只有 A，replace fault，fresh consumer | B 未合併仍 unknown；只讀舊合法檔當恢復的 mutant 必紅 |
+| T09 R2 | temp sync／replace／dir sync exception faults，另依 D3.1 在 K0/K1/K2 真 kill 自建 writer＋fresh process | 三切點以 barrier 定位；驗 old/committed bytes、flock 釋放、fresh data+directory sync 與 durable inventory 對帳；K1 不僅靠可解析新檔，K2 replay unchanged；exception-only 不算 crash，SIGKILL 不算斷電 |
+| T10 R1/R8 | inventory omitted、unreadable、stale/incomplete window、fake last-good | unverified/unknown 不等 complete；預設空 inventory mutant 必紅 |
+| T11 R4/R6/R7 | hint、success、auth success、短 reset、缺 identity | 不造 key、不清 active；可採短 reset 仍只做 max；fallback policy 不猜 |
+| T12 R2/R8 | lock timeout、exception cleanup、有限多輪 process replay | descriptors/locks/processes 收斂；無死鎖；測試失敗 finally 仍放行 |
+| T13 R1/R2 | store/input cap+1、成長中 fd、深度/node/string/number 超限 fixture | 讀取≤cap+1；decode/copy 前拒；store bytes/acks 不變；先無界 read/loads/dumps 後檢查 mutant 必紅 |
+| T14 R2/R3/R7 | 合法 ledger 填到 count/identity/encoded-byte cap；兩 process 同搶最後額度 | 最多合法一筆新增被 ack；另一筆 unknown，無 lost update/越限/部分 batch；expiry 不釋放額度；自動丟最舊 event mutant 必紅 |
+| T15 R4/R7/R8 | at-cap exact duplicate→fresh process→expiry/clear→duplicate；同 key 衝突、新 distinct event | duplicate bytes/hits/deadline/acks 不變；衝突 integrity unknown；新事件 capacity unknown，未 ack intent 仍可見；先 count==cap 就拒 duplicate mutant 必紅 |
+| T16 R2/R5/R8 | 受控 byte/node/comparison/fold counter 與 fake monotonic deadline；近 cap 單操作 | 在各有限界停止、釋放鎖，超預算 unknown 且零 replace；無每新增 event 重 fold 全 ledger；忽略 counters/deadline mutant 必紅 |
+
+negative controls 在隔離測試 harness 或 disposable mutation 環境跑，記 oracle 名、失敗原因與還原；不把 mutant 提交到 production。本 authoring 不執行產品 RED/GREEN。
+
+### D7 Sizing and acceptance
+
+唯一 production 模組→domain=0；跨 process lock/atomicity/durable ack→state=2；spec 八組→invariant_count=8。容量修正強化 R1/R2/R4/R7 的 bounded observation／atomic refusal／duplicate／retention，不另藏跨模組或降低 state。fix-standard 保留 cards=9、bindings=9、core gates=2、R-09/R-16/R-19 全集：`[0,2,2,2,2]=8/Red`；#831 完整 accepted case 僅 stability→0 時投影 `[0,2,2,0,2]=6/Yellow`。不得減 cards、改 combo、降 state 或用缺規格換低分；實際正式 gate 仍 Red 就停，不派 build。
+
+A 的完成界線是單模組 store 的規格、unit/component/跨 process 故障測試、文件／CLI 相容檢查、獨立 review、policy/CI、merge 與隔離 installed import/API smoke 分別有證據。尚未 C/D/E/F wiring 的 live 安全層與 #825 母票保持未完成；root 才能裁決真正 admission rollout。第二 production 模組會使 domain≥1/state2，#831 後≥7/Red，必須再拆或重新裁決。

--- a/docs/superpowers/specs/executor-backoff-store-core-spec.md
+++ b/docs/superpowers/specs/executor-backoff-store-core-spec.md
@@ -1,0 +1,33 @@
+---
+status: accepted
+work_item: executor-backoff-store-core
+---
+
+# Executor backoff store／event-fold 核心規格
+
+## Requirements
+
+獨立 owner 為 [#850](https://github.com/hamanpaul/paulsha-cortex/issues/850)，本批僅登錄規劃，
+尚未 freeze／dispatch；`accepted` 不代表產品驗收或可派工。
+
+本件是 [#825](https://github.com/hamanpaul/paulsha-cortex/issues/825) 母工作 `executor-durable-backoff` 的人工 child A，承接母 spec R1–R4 的 store 部分及 R8 component 驗收。母 [spec](executor-durable-backoff-spec.md)、[design](executor-durable-backoff-design.md) 與 [todo](../workstreams/executor-durable-backoff/todo.md) 的其餘 AC 不取消。`accepted` 表示本 child 文件契約，不表示已註冊、通過 sizing、實作、merge、installed 或 live。
+
+1. **R1 Three-state bounded observation**：獨立 `<coordinator_root>/executor-backoff.json`、schema `executor-backoff/v1`，每次 store query 重新讀磁碟，遵守 design D2.1 的固定容量 profile。先作有限讀取／結構計數，再 decode；不可先無界 read/loads/dumps 才檢查長度。只有真缺檔可回 `missing`；可解析且 schema／資料／durability 驗證通過才 `valid`；read error、corrupt、未知 schema／policy、超限或無法確定持久狀態均 `unknown`。missing 只是無本機已知 backoff，valid 無 active entry 也不是 quota-positive 證據。可附已驗證 last-good，但不能把其缺少的 identity 當可用；不得以 corrupt→empty 自癒覆寫。
+2. **R2 Cross-process atomic ownership**：所有 record／expire／clear 的 read-modify-write 都在同 root 的穩定 `flock` lock 邊界內重讀最新檔，使用同目錄唯一暫存檔、完整寫入與 atomic replace；不得用 stale instance cache 覆蓋。input/store bytes、事件／identity 數、解碼深度／節點與 sort/fold/encode 工作量皆有固定有限上限，另有合作式計算 deadline；檢查在大配置與 replace 前完成，超限保留舊 bytes/ack，回具體 unknown，不部分接收 batch。read／serialize／write／sync／replace／lock 失敗也不得截斷既有檔或提前發 acknowledgment。持久性未確認時不得僅以檔案可解析解封；原子 commit 與 durability 故障窗口按 design D3 驗證。crash 驗收必須在 replace 前、replace 後而 directory barrier 前、barrier 後三個精確切點，真正終止測試自建 writer process，再由 fresh process 重讀 data、完成 data/directory sync 與 durable fixture inventory 對帳；只拋可捕捉例外不算 process-death 證據，也不把 SIGKILL 說成真斷電。
+3. **R3 Identity isolation**：key 是 exact `(executor, model_id)`，不是 quota pool。不同 identity 交錯 record、expired clear 都保留其他 entries／events／ack；禁止拼接歧義碰撞或推導共享帳號獨立性。缺 executor/model、terminal identity 或 scope 不能捏造 key，回 unknown／input diagnostic，不使已知 cooldown 消失。
+4. **R4 Immutable events and acknowledgment**：只接收可信 caller 提供的不可變 terminal key、原 terminal event-time、identity、非 hint 的 rate_limited/quota payload、payload fingerprint 及 frozen policy/reset provenance。去重 key 在 store scope 內唯一；同 key 的時間、identity、payload 或 policy 不同是 integrity unknown，不改名計第二次。成功 record 與 ack 一起原子提交；完全相同重送不改 bytes/hits/deadline。在合法容量上限內的 store 即使已飽和，仍先核對 duplicate，再裁決新事件容量；exact duplicate 不消耗新容量、維持冪等，不因已滿而被當新事件拒收。超出讀取安全上限的既有檔則保持 unknown，不能為辨認 duplicate 而無界解析。A 不驗真 job authority、不掃 registry/log、不從可覆寫 `exited_at`、arrival now 或今天 settings 補證據。
+5. **R5 Event-time fold and episode hits**：對完整已知去重事件集合按 `(terminal_event_epoch, terminal_key)` 穩定排序。首事件或 event-time ≥ 上一 fold deadline 時 hits=1，否則上一 hits+1；期限按 R6。較舊 distinct event 晚到必須重 fold，不只追加尾項。相同事件集合與政策的所有 arrival permutation、跨 process／restart 得相同 aggregate；不同 arrival now 不影響結果。同時刻 key tie、episode 邊界相等與混合無 reset 都有機械 oracle。
+6. **R6 Frozen policy and conservative deadline**：每事件使用其記錄的 policy revision、rate/quota base、margin、指數曲線／上限與 reset 解析 provenance；quota base 大於 rate base。可信 reset 候選為 reset_at+margin；caller 明示已可靠判定無 reset 時才以 event-time 加有界 backoff。缺失／矛盾 provenance 不等於「無 hint」，未知政策也不能套今天公式。累積 deadline 取保守最大值，已持久仍有效 deadline 是最低保護界；重建更短則保留保護界並報 integrity unknown。success、auth success、較短 reset 不授予提早縮短權。
+7. **R7 Bounded retention without forgetting**：active 僅由 query now 與 deadline 比較。v1 保留已接收的完整 dedupe events／ack／frozen policy，但不再無限接收：達事件數、identity 數、encoded store bytes 或其他資源上限時，distinct 新事件／超限 batch 回 `capacity-exceeded` unknown，原 store bytes/ack/deadline 不變，未接收 intent 留 caller 對帳。無 TTL GC 或未證明安全的 checkpoint 壓縮；expired clear 不釋放 ledger 額度。`clear_backoff` 對 active entry 明確拒絕；對 expired entry 至多清 active projection／回冪等 no-op，不刪 ledger、ack 或其他 identity。到期後舊 terminal 重送不能復活 cooldown；未 ack 舊事件在容量允許時按原 event-time fold，否則仍 unknown 而不遺忘。future GC／容量 migration 必須另有 authority，不能因磁碟或記憶體壓力静默丟事件。
+8. **R8 Honest reconciliation seam and component evidence**：raw store observation 與 caller 的 terminal 對帳結果分開。query 可回 missing/valid，但 readiness 必須保留 `reconciliation=unverified|pending|complete|unknown`；缺對帳輸入預設 unverified，不能預設 pending=0。A 可驗 supplied immutable intent 集合對 ack 的 missing/conflict 及合併結果，但不背書 caller inventory 的完整性、freshness、retention 或真 admission。可信 caller 說來源不可讀／窗口不完整、pending 未合併或持久寫失敗時有效決策保持 unknown；恢復須 fresh 可信 inventory＋可靠 merge，不能靠 process-local sticky flag 或 error sidecar。所有 component tests 僅用隔離 fixture；C/D production 尚未接線必須明示。
+
+## Boundary
+
+- 唯一未來 production 新增：`paulsha_cortex/coordinator/executor_backoff.py`；同模組容納 types、schema validator、pure fold、store 和對帳 seam。可以唯讀重用 `backoff.tick_backoff_seconds`，不修改它或其他 production 模組。
+- 本件 authoring 僅 spec/design/todo 與 `reports/review/refine-backoff-store-child-20260907.md` 四檔；產品工作、tests、changelog、registry 登錄由後續正式工作執行，現在全部未交付。
+- 不實作 reset 文字 parser、launcher property、terminal producer/registry reader、Manager hooks、workflow/slice admission、request/CLI projection、registry migration/GC、新 override/clear CLI、quota forecast/reservation 或模型/effort 固定名單。
+- C 的 immutable terminal/provenance／strict reader／retention 契約與 D 的 production 對帳仍未裁決或接線；A 的 component green 不得關閉 #825。任何第二 production 模組變更須先重裁 child boundary/sizing。
+
+## Evidence
+
+基底 `79ba644780bf1c697c722ac24a297e7d02416100`：[GitHub backoff reader](https://github.com/hamanpaul/paulsha-cortex/blob/79ba644780bf1c697c722ac24a297e7d02416100/paulsha_cortex/coordinator/provider_backoff.py#L42) 的 corrupt→empty 不是 A 的 oracle；[純 backoff 曲線](https://github.com/hamanpaul/paulsha-cortex/blob/79ba644780bf1c697c722ac24a297e7d02416100/paulsha_cortex/coordinator/backoff.py#L23) 為現行算法佐證。Registry [terminal self-transition](https://github.com/hamanpaul/paulsha-cortex/blob/79ba644780bf1c697c722ac24a297e7d02416100/paulsha_cortex/coordinator/registry.py#L65)、[重寫 exited_at/payload](https://github.com/hamanpaul/paulsha-cortex/blob/79ba644780bf1c697c722ac24a297e7d02416100/paulsha_cortex/coordinator/registry.py#L1333)、[stat error 保留 reader cache](https://github.com/hamanpaul/paulsha-cortex/blob/79ba644780bf1c697c722ac24a297e7d02416100/paulsha_cortex/coordinator/registry.py#L376) 是 caller seam 尚不可當成既有安全保證的精確理由，不是靜態掃描背書全稱不存在。

--- a/docs/superpowers/workstreams/execution-profile-schema-core/todo.md
+++ b/docs/superpowers/workstreams/execution-profile-schema-core/todo.md
@@ -1,0 +1,60 @@
+---
+status: accepted
+work_item: execution-profile-schema-core
+domain_breadth: 0
+state_consistency: 1
+invariant_count: 10
+artifact_classes:
+  - source
+  - tests
+  - documentation
+---
+
+# Execution profile schema／key core Todo
+
+## Authority
+
+母 [#835](https://github.com/hamanpaul/paulsha-cortex/issues/835) T01/T02，依
+[Spec](../../specs/execution-profile-schema-core-spec.md)／[Design](../../specs/execution-profile-schema-core-design.md)。
+本 child owner 為 [#849](https://github.com/hamanpaul/paulsha-cortex/issues/849)，本批登錄 accepted 規劃；
+尚未 freeze／dispatch，不因登錄而授權模型派工。
+production 只有新 `coordinator/execution_profile.py` 單一資料流，domain=0；定義版本化 schema，
+依 #208 rubric state=1。無既有 state migration／transaction，不能冒稱母件 migration 已完成。
+feature-oneshot 的現行 79 runtime 純函式實算 7/Red；#831 完整穩定規劃=0 的情境為 5/Yellow，
+後者僅投影，須等真修正版 runtime 重算與正式 gate，不能按投影直接當 Yellow 派工。
+
+## Tasks
+
+- [ ] source T01：只新增 execution_profile.py 純 descriptor/profile/requirements schema API；嚴格版本、原生 effort grammar、三層 plane/tagged unknown（C01/C02/C06/C07）。
+      使用 stdlib，normal direct import 不改現有 __init__/loader/launcher/registry/CLI；不讀檔／環境或呼叫模型。
+- [ ] source T02：實作 typed canonical bytes、分 domain record/actual key、unknown 無 actual key、metadata 排除與 immutable serializer（C03–C08）。
+      逐 byte 遵守 Design D3/D4 完整欄位、projection、node tags/arity、JSON token／escaping、NUL／uint64 framing；無 approved／qualified API，role 是資料不是 build fallback。
+- [ ] tests T03：新增虛構 descriptor 的 string/new value/integer/finite number/nested effort 正負矩陣與 exact requested/resolved/observed round-trip（C01/C02/C07）。
+      unknown model/role 的 runtime eligibility 留母 resolver；不把 schema 合法視為相容性已過。
+- [ ] tests T04：新增 canonical golden vectors、field perturbation、metadata-only、set/order/type/domain 差異及缺 observed 無 actual key（C03–C06）。
+      直接使用 Design D4 兩個完整 canonical payload／key 與五個 int/float/string/signed-zero key；替換 node shape／framing／projection 的負控制須拒絕，不能用被測函式自產 expected；測量 pass 不產資格 grant。
+- [ ] tests T05：新增 mutation alias、duplicate keys、bool version/number、NaN/Inf、surrogate、未知欄位、depth/nodes/bytes 邊界、循環／未來版負例（C07/C08/C10）。
+      依 D5 精確計完整 descriptor+profile/root/keys，16/17、4096/4097、65536/65537、1048576/1048577 成對；transport/semantic 錯誤分開且提早中止，預解析／native／等價 JSON 路徑一致；D1 reference 正負 grammar；no-version legacy input 拒收但原 bytes 不變。
+- [ ] tests T06：以公開 API 做 fixture consumer 與獨立 process／hash seed round-trip、純函式 I/O 邊界與負控制（C09/C10）。
+      從 checkout 外讀已建 package 的新 module 驗 packaging/import；不因此宣稱 production routing／installed Manager 已接線。
+- [ ] tests T07：跑既有 model identity/envelope/resolution/per-work-chain/profile CLI 回歸、focused/full suite 與 CI；保存實際 RED→GREEN／候選 SHA 與未執行項目。
+- [ ] documentation T08：同步 README／純 API 契約、版本／數值規則、未知值、native effort 擴充與 parent AC 對照；#581/#842/PatchMUD #37 owner 邊界不得遺失。
+      #842 只依 core 契約；母 T03/T04/T05/T06 的 routing/qualification/migration 接線仍另行交付。
+      區分 core wire 升版與 adapter protocol 欄位新值；後者 descriptor-only／key 自然變。記載 D5 transport 界內的 encoding 等價保證及超大 padding 的獨立拒絕。
+- [ ] CLI T09：既有 --help smoke 與文件說明本件沒有新 flags/commands，也不提供任何 model/agent/effort 固定清單或 runtime probe。
+- [ ] changelog T10：正式 Cortex delivery 新增 changelog.d/execution-profile-schema-core.md 並同步 CHANGELOG.md [Unreleased]，本 planning-only authoring 不代寫。
+- [ ] tests T11：以實際 PR context 跑 policy R-09/R-16/R-19/R-22 等適用 gate；只允許本 core production 檔，若必須改其他 consumer 則停止並重裁 scope/sizing。
+- [ ] documentation T12：分帳 core implemented/tests/merged/package import 與母 routing/installed/live；未知或 legacy qualification 不補值，真人批准仍由 #842 政策要求的 receipt 決定。
+
+## Dependencies
+
+本件 pure core 可獨立建測；其 schema/key → #842 publication consumer，沒有母件 close 的反向依賴。
+母件保持 A1–A6 完整責任；legacy state migration／authority 重新接受與 actual routing 不在本件。
+未修 #831 前現行 Red 必須照實保留；不得降低 schema 的 state 宣告或刪 AC 取得 Yellow。
+本批只交付規劃與 owner 登錄；產品開發須另走正式 Cortex workflow，不修改現場 state 或服務。
+
+## Verification Status
+
+本輪只跑 planning 純 helper；結果與 source revision、hash 交接見
+[報告](../../../../reports/review/refine-profile-schema-child-20260907.md)。
+產品 tests／實作／merge／installed／live 尚未完成，所有產品 checkbox 保持未勾。

--- a/docs/superpowers/workstreams/executor-backoff-store-core/todo.md
+++ b/docs/superpowers/workstreams/executor-backoff-store-core/todo.md
@@ -1,0 +1,37 @@
+---
+status: accepted
+work_item: executor-backoff-store-core
+domain_breadth: 0
+state_consistency: 2
+invariant_count: 8
+artifact_classes:
+  - source
+  - tests
+  - documentation
+---
+
+# Executor backoff store core child A
+
+## Boundary
+
+- Parent：`executor-durable-backoff`／#825；本件只實作新 `paulsha_cortex/coordinator/executor_backoff.py`。母 [spec](../../specs/executor-durable-backoff-spec.md)、[design](../../specs/executor-durable-backoff-design.md)、[todo](../executor-durable-backoff/todo.md) 的其他 AC 保留。
+- 同 work_item [spec](../../specs/executor-backoff-store-core-spec.md)／[design](../../specs/executor-backoff-store-core-design.md) 為八組 AC 與 T01–T16 oracle，含 review R1 新增的 bounded capacity/decode/fold。C/D terminal provenance、strict reader、retention、production reconciliation 尚未接線；store component green 不等母安全層啟用。
+- 本 child owner 為 [#850](https://github.com/hamanpaul/paulsha-cortex/issues/850)，本批只登錄 accepted 規劃，未 freeze／dispatch。下列全部是產品工作待辦，不是此次已執行項目；不讀寫 live state／呼叫模型。
+
+## Tasks
+
+- [ ] **Intake source/tests/documentation**：逐項讀回父與 child 三件組，核對新 store 單模組、八組 AC、T01–T16；記 accepted source refs/hashes、R1–R9 分工、C/D 未接線與 quota residual，不自動推為 #825 完成。
+- [ ] **source/tests/input contract**：在唯一新模組固定 envelope、三態 observation／獨立 reconciliation、canonical fingerprint、scope/exact identity、immutable terminal time/key、policy/reset provenance。缺/衝突 unknown，absent hint 與缺資料分開；不從 registry/settings/arrival now 代填。
+- [ ] **source/tests/store schema**：實作 executor-backoff/v1 strict reader、fresh disk query、已驗 last-good 與明確 error diagnostics；真 missing 只表示本機無已知 backoff。補 T01/T10/unknown schema/read/permission faults，拒 corrupt→empty。
+- [ ] **source/tests/bounded resource profile**：按 design D2.1 固定 store/input/event/identity/JSON depth-node-token/canonical bytes/sort-fold/compute deadline 界；decode/copy 前 bounded read/lexical count、replace 前完整容量判斷，超限整批 unknown 且原 bytes/acks 不變。補 T13–T16，包括 cap+1/成長 fd/過深結構、兩 process 搶最後額度、at-cap exact duplicate 仍 unchanged、衝突/新事件拒收、計算超限釋鎖；不新增 GC、不靠 disk-full 或無界 future/thread timeout 冒充資源界。
+- [ ] **source/tests/process atomicity**：穩定 flock、鎖內 fresh RMW、唯一 temp、sync/replace/durability barrier、finally cleanup；補 T02/T03/T09/T12，包括 stale-reader、不同 identity、lock timeout、replace 前後 exception faults。T09 另須按 design D3.1 的 K0（replace 前）、K1（replace 成功而 dir barrier 前）、K2（barrier 後）真正 kill 僅由測試自建的隔離 writer；barrier 定位、bounded kill/join，fresh process 重讀 data＋data/directory sync＋durable fixture inventory 對帳、驗 flock 釋放與 replay 冪等。exception-only 不替代死亡測試，SIGKILL 不等斷電；無法確認 durability 不可回成功。
+- [ ] **source/tests/immutable ledger and ack**：驗 same-key payload/time/policy/identity 一致，成功 commit 才 ack；完整 replay 不重寫 bytes/hits/deadline。補 T04、跨 process/fresh instance、hint/缺 identity、同 key 衝突負例；不改 provider_outcome 既有 keys。
+- [ ] **source/tests/event-time fold**：依 design D4 由完整事件穩定排序重算 episode/hits/max deadline；補 T05/T06 的 reset1000→舊 reset300、反向/all permutations、same-time tie、deadline 相等、新 episode、混合 absent、不同 arrival now、原 policy replay。不得靠 arrival-time 或當前 helper/settings 取得假綠。
+- [ ] **source/tests/expiry and no early clear**：補 T07/T11/T14/T15；expiry/clear/restart 仍保留 events/ack/policy 且不釋放 ledger 額度，舊 replay 不復活；未 ack 舊 event 容量內才 fold、超限保留 unknown。active clear/success/auth success/短 reset 不解封，無 TTL GC/checkpoint；容量/計算/磁碟不足均不丟已接收事件。
+- [ ] **source/tests/reconciliation seam**：以可跨 process 重讀的 fixture caller inventory 驗 T08/T10：store 只有 A、B terminal 已持久、replace fault、fresh consumer 仍 unknown；可靠 merge/barrier 恢復＋fresh supplied inventory 才 complete。缺 inventory、不可讀/不完整窗口保持 unverified/unknown；不能用 always-complete fake 背書 production C/D。
+- [ ] **tests/negative controls**：新增 `tests/test_executor_backoff.py`，逐一記 T01–T16 正例與 mutant RED oracle；隔離證明去掉 flock、只記最後 key、arrival-now、TTL 清 ack、unknown→missing、舊合法檔→complete、sync-error→valid、先無界 read/decode 再檢查、count==cap 拒 duplicate、容量不足刪最舊 ack、忽略 work/deadline budget 都會被抓。所有 wait 有界、finally 放行，無真 provider/模型/daemon。
+- [ ] **tests/compatibility and CI**：跑 `python -m pytest tests/test_executor_backoff.py tests/test_provider_backoff.py tests/test_provider_outcome.py -q`，既有 GitHub backoff 原斷言保留；再跑 `python -m pytest tests/ -q` 與既有 CI。新 store 測試未建立時此命令不是已通過證據，環境缺口具體列出。
+- [ ] **documentation/CLI help and tests**：文件明列 raw missing/valid 不等 admission/餘量足夠、C/D 尚缺、API/diagnostic/lock/retention residual。真跑候選 `cortex status --help`、`cortex stat --help`、`cortex tick --help`、`cortex dispatch --help`；最後一個是已停用舊低階入口，只驗 help 相容，不執行 dispatch。隔離 help/API smoke，不發 control request、不新增不存在的 top-level inspect 或 clear/override CLI；產品 JSON skip/unknown 真入口留 D/E/F。
+- [ ] **documentation/changelog and policy**：產品實作 PR 補 `changelog.d/executor-backoff-store-core.md` 與 `CHANGELOG.md [Unreleased]`，既有 docs/README 只在語意需同步處更新；用真 PR title/body/labels/base/head 跑 `policy_check`、驗 symlinks、`git diff --check`，不裸跑假綠、不改 VERSION。
+- [ ] **tests/planning completeness and sizing**：純函式驗三件完整、三個固定 headings、Tasks 的 source/tests/documentation/CLI/changelog coverage；fix-standard 9 cards/9 bindings/2 gates與全規則實算現行8/Red，#831完整case投影6/Yellow另列且未 loaded。刪 spec／改 draft／缺 state 宣告／blocking marker 的負控制須拒，舊算法降低 incomplete score 不能被當可派。
+- [ ] **documentation/review and delivery evidence**：Cortex 正式 RED/GREEN、獨立 adversarial review、policy/CI、merge、隔離 installed module/API smoke 分別留 evidence。未處置缺口 FAIL；明示有界 residual 不單獨 FAIL。root 確認正式 sizing 可派才開始產品工作；A 不執行 live admission rollout，也不關閉 #825/R05/R08/R09。

--- a/openspec/changes/cortex-refine-complete/tasks.md
+++ b/openspec/changes/cortex-refine-complete/tasks.md
@@ -16,6 +16,7 @@
 - [ ] 2.6 依 accepted 三件組完成 #821 no-op persistence、history retention、writer/fault/rollback 相容與安全暫存清理；完整 archive 缺口/截斷前備份保持列管。
 - [ ] 2.7 完成 #823/#824 session 與 AGY timeout 合約，明示 cgroup restart survival 的獨立驗收。
 - [ ] 2.8 完成 #825 最小 durable backoff，所有 lane 與 corrupt-state/expiry 可測；不標 R05 完成。
+- [ ] 2.8.1 先依 #850 有界 store／immutable event-fold child 交付 component；C/D provenance、reconciliation 與所有 lane 接線仍由 #825 後續 child 承接。
 - [ ] 2.9 以實際已載入 revision 驗 B1 成效，退出暫時 bypass 前保存 active jobs 與 rollback 方案。
 - [ ] 2.10 由 #847 區分可信 frozen 自發布 metadata 等價與真 authority 變更；前者保持 needs_human/gates/attempt/model binding 且零 spawn，後者仍走合法 restart，缺 provenance 不豁免。
 
@@ -24,6 +25,7 @@
 - [ ] 3.1 為 R08/R09/R12 建立/重用精確 child work items；#835 已有 accepted profile schema/原生 effort/registry 相容三件組，完整母範圍仍 Red，先 schema-key child 再分拆其他入口，不先勾產品完成。
 - [ ] 3.2 實作 adapter capability descriptors 與 conformance；新虛構 model/effort 無 central product-name diff。
 - [ ] 3.3 實作 requested/resolved/observed profile 與可追溯 effective argv/config；unsupported pre-spawn fail-closed。
+- [ ] 3.3.1 依 #849 交付純 schema／canonical key 核心，原生 effort 與 observed unknown 不補值；母 #835 routing／migration 與 #842 qualification 另留正式 evidence。
 - [ ] 3.4 實作 PatchMUD versioned report consumer、legacy migration 與 profile/cohort/role/coverage 驗證。
 - [ ] 3.5 由 #842 實作 qualification candidate→review receipt→approved roster 發布鏈；保留 operator 核可與 independence policy，不擴 #581 原scope。
 - [ ] 3.6 實作安全 model register/probe 操作面與 TTL、角色擴充契約；探活不暗中消耗無上限額度。

--- a/reports/review/refine-backoff-store-child-20260907.md
+++ b/reports/review/refine-backoff-store-child-20260907.md
@@ -1,0 +1,81 @@
+# Executor backoff store child A authoring report
+
+## Scope and status
+
+- Work item：`executor-backoff-store-core`，#825 人工 child A；原 author 只交 spec/design/todo＋本 report 四檔；root 後續已建 #850 並於本批登錄。這不是 #833 自動 decomposition/re-entry 證據，也未 freeze／dispatch。
+- 隔離 branch：`feature/refine-backoff-store-child-20260907`，base `fb31083e7325be86c6c9d217da56b9c4d799f5a5`（merged #846）。先盤點後由 origin/main 建 worktree，正常 `pull --ff-only origin main` 為 already up to date；主 worktree 原有 dirty 未動。
+- 唯一未來 production scope：新 `paulsha_cortex/coordinator/executor_backoff.py`。目前無 store implementation、product tests、changelog、runtime/registry 變更；todo 全部未勾。
+- Authoring context：root 已接受六拆作候選，但 C provenance/strict terminal seam 尚未裁決。本文使用 doc-coauthoring 的 context/結構檢查與 test-playbook 的 deterministic matrix/negative controls；fresh reader/獨立 review 由 root 執行，未另派模型。
+
+## Parent AC map
+
+| Parent | A 的交付 | 母工作尚需 owner |
+|---|---|---|
+| R1 durable cooldown | fresh store observation、持久 events/aggregate | D/F 每個 admission 接線，非只有 fixture query |
+| R2 atomic/idempotent/replay | R2/R4/R5/R7/R8、T02–T09；ack 對 supplied intent | C immutable terminal/policy/strict inventory/retention；D 跨 consumer production 對帳 |
+| R3 unknown | R1/R8；raw state 與 reconciliation 分開 | D/E/F unknown 停新增、不影響 active job／不耗 retry |
+| R4 deadlines/provenance | R5/R6 frozen policy fold/max；不提早 clear | B 文字 parser/時區；C 固化真來源/解析上下文；D 送正確 envelope |
+| R5 eligible terminal | shape/outcome/authority defensive rejection，不背書真 job | C durable authority；D slice/workflow failed 共用 helper |
+| R6 workflow/pin | 無 admission/reroute 實作 | D candidate order/permission/pin/independence，known wait/unknown，不耗 provider retry |
+| R7 slice/consumers | 無 launch/request side effect | B 公開 model；D manager retry/tick；E request/periodic；F pending 前 slice gate |
+| R8 tests/observability | A pure/component/process fault/mutation、help/API 相容檢查 | D/E/F 雙 lane/request JSON；root merge/installed/live 分帳 |
+| R9 quota boundary | 所有文件保留非目標 | R05/R08/R09、D4–D7 的 shared pool/forecast/reservation/dynamic profiles 仍未完成 |
+
+## Candidate DAG and sizing boundaries
+
+候選 DAG：A ∥ B → C → D；E 可並行準備；A+B+C+D+E → F → #825 母驗收。這是依賴方向，不是已建立的 child authority 或派工。
+
+| Child | Production 修改 | domain/state/invariants | #831 完整case投影 |
+|---|---|---|---|
+| A store/event fold（本件） | executor_backoff.py only | 0/2/8 | 6 Yellow |
+| B reset／identity 純輸入 | provider_outcome.py、launcher.py；若獨立 parser 合計最多3 | 1/0/5 | 5 Yellow；只在確為無 durable state 的 pure 邊界成立 |
+| C terminal anchor／strict inventory | registry.py only | 0/2/4 | 6 Yellow，provenance/retention 尚需裁決 |
+| D terminal reconcile/workflow/manager consumers | manager.py only | 0/2/6 | 6 Yellow，依 C 真契約 |
+| E request/periodic consumers | manager_daemon.py only | 0/2/3 | 6 Yellow |
+| F slice admission | autonomy.py only | 0/2/4 | 6 Yellow；D/E 先相容才啟用 |
+
+C 若必須修改 `dispatcher.py` 以固化首次 terminal observation/reset parsing context/policy，需 root 修訂母 boundary、另列 producer child；不能 registry＋dispatcher 兩模組還寫 domain0。2–3 production 模組且 state2 →7/Red；≥4模組且 state2 →8/Red。母完整 plan 現行10/Red，#831後8/Red，不因候選六拆改成可派。
+
+## Evidence and unresolved producer responsibility
+
+已全文讀 parent spec/design/todo 與 canonical policy。下列 `79ba6447` source 與 authoring base 的對應 production 檔無差異；source trace 是當下佐證，不宣稱窮盡所有未來／外部 caller。
+
+- [provider_backoff.py:42](https://github.com/hamanpaul/paulsha-cortex/blob/79ba644780bf1c697c722ac24a297e7d02416100/paulsha_cortex/coordinator/provider_backoff.py#L42)：GitHub fail-soft reader 不能複製成 executor unknown 語意。
+- [registry.py:1333](https://github.com/hamanpaul/paulsha-cortex/blob/79ba644780bf1c697c722ac24a297e7d02416100/paulsha_cortex/coordinator/registry.py#L1333)：terminal self-transition 可重寫 exited_at/provider_outcome；A 不把它升成 immutable authority。[既有 timestamp 測試](https://github.com/hamanpaul/paulsha-cortex/blob/79ba644780bf1c697c722ac24a297e7d02416100/tests/test_coordinator_registry_headless.py#L925) 只驗存在/時間順序。
+- [registry.py:376](https://github.com/hamanpaul/paulsha-cortex/blob/79ba644780bf1c697c722ac24a297e7d02416100/paulsha_cortex/coordinator/registry.py#L376)：stat error 可留下 reader cache；C 需 strict fresh snapshot，不能空集合/舊 cache 代表 pending=0。
+- [dispatcher.py:438](https://github.com/hamanpaul/paulsha-cortex/blob/79ba644780bf1c697c722ac24a297e7d02416100/paulsha_cortex/coordinator/dispatcher.py#L438)：現有 classification→dict→registry 生產接線；需要新增 provenance producer 時顯式另裁，不由 A 修改。
+- [manager.py:9636](https://github.com/hamanpaul/paulsha-cortex/blob/79ba644780bf1c697c722ac24a297e7d02416100/paulsha_cortex/coordinator/manager.py#L9636)：forced_identity bypass 與無 capability 路徑必須由 D 最後副作用前 gate 涵蓋。
+- [manager_daemon.py:908](https://github.com/hamanpaul/paulsha-cortex/blob/79ba644780bf1c697c722ac24a297e7d02416100/paulsha_cortex/coordinator/manager_daemon.py#L908)、[manager.py:1861](https://github.com/hamanpaul/paulsha-cortex/blob/79ba644780bf1c697c722ac24a297e7d02416100/paulsha_cortex/coordinator/manager.py#L1861)：empty dispatch/retry 需 D/E 先相容，F 不可先啟用造成 IndexError 或假 retry failure/success。
+
+Residual：A 可驗 envelope 內在一致但不能證明 caller authority/完整性；C/D 缺口是外部交付依賴，不用 always-complete fixture 冒充解決。v1 只保留已在有限容量內接收的全 ledger，不實作 GC；飽和停止接收新事件、保留 bytes/acks、未合併 intent 回 caller，這是有界可用性限制而非假恢復。資源 profile 與 POSIX filesystem 支援範圍明示，IO/鎖/durability 不確定即 unknown；合作式 compute deadline 不假稱能搶占 kernel IO。所有模型/effort 名稱保持資料，不加入固定路由表。
+
+## Review R1 disposition
+
+Root 轉交一條 MAJOR，獨立核對成立：舊 design D3 全量 fresh read/validation、D4 完整 ledger sort/fold 與永久 retention 組合，沒有 bytes/events/decode/compute cap；只列 disk-full 不能排除磁碟未滿前的 OOM／長期持鎖。因此不駁回、不以已列 residual 宣稱該問題可接受。
+
+四檔此次修訂：新增固定 `bounded-ledger/v1` resource profile（store 2 MiB、input 1 MiB、retained events 1024／identities128、input1024、event8KiB、JSON depth12/string4KiB/key512/numeric64、累計nodes131072、comparisons65536/fold visits2048、byte work16MiB、合作式compute1秒）。先 bounded read/lexical count 再配置/decode；舊 store/候選最多各一轮 fold；完整候選超限在 replace 前原子拒收，不部分 ack。已合法達 cap 的 duplicate 先比對去重，仍 unchanged；新 distinct event 回 capacity unknown，原 bytes/acks 不動。已超讀取 cap 的檔不為辨認 duplicate 而越界解析；expiry 不釋放額度，仍不 GC。
+
+新增產品測試契約 T13–T16：超大/成長 fd/深度與節點超限、multi-process 最後額度競爭、duplicate-replay-at-cap 與 expired replay、同 key 衝突／新 event、計算 counter/deadline 中止與釋鎖；配套 mutant 必須抓到晚檢查、拒 duplicate、刪最舊 ack、忽略預算。這些是尚未實作的 RED/GREEN Tasks，不是此次已跑產品測試。
+
+多程序 freshness/flock、post-replace durability-unknown、immutable policy/time、raw store≠reconciled admission 皆保留。domain0/state2/八組不變量不變：本修訂具體收緊 R1/R2/R4/R7 的既有責任，沒有新增 production 模組。此處僅記 author 修訂；**不宣稱獨立 review PASS**，交 root 重審。
+
+## Review R2 and fresh-reader clarification
+
+Root 已回報 R2 獨立審查 PASS、R1 原 MAJOR 已處置，且全文讀回四檔；fresh reader 五個問題回答正確。這是 root 回傳的審查結果，不是 author 自評或產品已完成。
+
+唯一真歧義為 crash 是否僅以可捕捉 sync/replace exception 模擬。本次在 spec R2、design D3.1/T09、既有 process-atomicity Task 明訂真正終止測試自建 writer：barrier 定位 replace 前 K0、replace 成功但 directory barrier 前 K1、barrier 後 K2，fresh process 重讀 data 並完成 data/directory sync、重讀 durable fixture inventory 對帳，驗死亡釋放 flock 與重播不加 hits/deadline。只准 kill 本 fixture 建立且持有 handle/PID 的子程序，bounded join/finally cleanup；不碰任何 live process。SIGKILL 僅證明 process-death/restart protocol，不等真斷電或任意 filesystem 持久性驗證。
+
+此為測試契約澄清，維持四檔、domain0/state2/8 invariants、15個產品 Tasks 未勾；T09 產品測試尚未實作或執行，未新增 issue/code/registry/runtime 變更。最終文件 hash 交 root，停止 author 寫入。
+
+## Author verification
+
+產品待辦與下面 authoring checks 分帳；此 report 不宣稱 store RED/GREEN、CI、獨立 review、merge 或 installed/live 完成。
+
+- 已用 `PYTHONDONTWRITEBYTECODE=1 python3` 載入 checkout 的 `assess_planning_completeness`、`plan_review_gate`、`compute_sizing_score`、`sizing_band`，以及 packaged `load_cards/load_combo` 作一次性純運算；未讀 live registry、不啟模型、不產生產品 test evidence。
+- 三件組 completeness=True、missing=()、blocking=0；plan-review 的 source/tests/documentation coverage 與 R-09/R-16/R-19/R-22 compatibility 通過。envelope 明確為 `bypass: envelope_unavailable`，不是已評測 builder 資格；另以明示 synthetic invariant limit=7 負控制，8 invariant 正確 `envelope-exceeded`，不將 synthetic fixture 冒充真 envelope。
+- packaged fix-standard 實讀 cards=9/bindings=9/gates=2；sizing rules 為 R-09/R-16/R-19 全集。完整 A 真五維 `[0,2,2,2,2]`＝8/Red；`dataclasses.replace(score, spec_stability=0)` 僅投影 #831 完整case 為6/Yellow，非 loaded gate，不改 production 算法。
+- 11 組 authoring 負控制均拒絕：刪 spec、spec 改 draft、design 加獨立 blocking marker（completeness）；缺 domain、缺 state（sizing ValueError）；移除 Tasks 的 source/tests/documentation/CLI/changelog coverage（plan-review）；synthetic envelope 7（envelope-exceeded）。改 blocking design 的舊 score 會降到6/Yellow，但 completeness=False，明確不能當 admission 成功。
+- CLI 由真 source 確認 status/stat/tick help 與 deprecated dispatch：top-level 沒有通用 inspect，已修正 child todo，不沿母文件泛稱發明新指令；本 authoring 沒有發 control request。產品 help/API smoke 仍未勾。
+- R1 修訂後已重跑純 completeness、plan-review coverage、真 sizing 與同11組 authoring 負控制，結果維持上述8/Red／#831投影6/Yellow、envelope_unavailable。四檔逐一 `git diff --no-index --check /dev/null <file>` 無 whitespace 問題；相對 Markdown links 均存在、無個人絕對路徑、exact scope 仍四檔、8組 Requirements／15個產品 Tasks 全未勾。T13–T16／容量字面值只做文件存在檢查，不等產品資源限制已驗證；最終 hash 交 root。sizing/deck 純函式來源以 `git diff --exit-code 79ba6447 HEAD -- <paths>` 驗為同版。
+- 完整 authority 仍須 root reader review；未處置缺陷/缺口為 FAIL，已明示且影響有界、文件列管 residual 不單獨 FAIL（不同意須具體反駁影響分析）。
+- 本 authoring 僅四檔，無 changelog/policy 豁免寫入；root 整合 PR 需自行帶正確 changelog 或既有白名單豁免理由，未跑裸 `policy_check` 宣稱通過。

--- a/reports/review/refine-bounded-children-integration-20260907.md
+++ b/reports/review/refine-bounded-children-integration-20260907.md
@@ -1,0 +1,43 @@
+# 有界 child 整合核對
+
+此報告只記規劃交付；產品仍未實作／merge／installed／live。兩個 designs 的 bytes
+保持原獨立審查版本，root 只整合 owner、登錄、狀態與進度文字，未改核心契約。
+
+## 審查與新讀者核對
+
+- Schema R1 canonical wire 未定義的 MAJOR 已修，R2 PASS；fresh reader 的 wire
+  版本、transport padding 上限、reference grammar 三項歧義修後逐項確認，fresh compact
+  R3 對最後 schema/store 八份文件 PASS。Root 另以獨立 encoder 重驗兩個 golden：
+  actual canonical/framed 920/963 bytes、key
+  `cccfc64a59aed4d4f3c14caa2468b18ff1ea067eeb84e3f376e0e722799e9ac2`；
+  observed 1227/1272 bytes、key
+  `e2750040b4f91c563760daa19bcaa808f66bab7f4c445c3765522f19609b841b`。
+- Store R1 無界 event ledger 的 MAJOR 已修為固定 bytes/depth/nodes/events/identity/
+  sort/fold/work/deadline 界，R2 PASS；fresh reader 五題確認，process-death 歧義補
+  K0/K1/K2 真正終止測試自建 process、fresh reader/flock/durability/replay oracle。
+  SIGKILL 不等真斷電；不可中斷的外部 POSIX I/O 殘餘已明示。
+- 以上是規劃 review／pure oracle，不是產品測試或模型 qualification evidence。
+
+## Root 整合後重驗
+
+2026-09-07 13:29 UTC，從 checkout 外載入 runtime
+`79ba644780bf1c697c722ac24a297e7d02416100` 的真 planning/deck/gate 純函式：
+
+| Owner / work | 真 sizing / combo | 純 gate / 負控制 |
+|---|---|---|
+| #849 execution-profile-schema-core | 0+1+2+2+2=7 Red；feature-oneshot 11 cards/11 bindings/4 gates | 三份 accepted、complete；R09/R16/R19/R22 coverage ready；缺 Tasks 拒收 |
+| #850 executor-backoff-store-core | 0+2+2+2+2=8 Red；fix-standard 9 cards/9 bindings/2 gates | 三份 accepted、complete；相同 coverage ready；缺 Tasks 拒收 |
+
+兩者 envelope 仍 `bypass: envelope_unavailable`，不代表 builder 封套合格。
+#831 修正後的 5/6 Yellow 僅推算；必須實際 loaded runtime 重評，不捏造現行 band。
+每張 issue 已建立、全文讀回且 OPEN；work-items 各自只綁該唯一 owner。
+
+## 邊界與後續
+
+- Schema 只供純 typed descriptor/profile/key；key 不是資格，unknown observed 無
+  actual key。#835 routing/migration 與 #842 human-review publication 未完成。
+- Store A 不驗真 terminal authority；C/D immutable inventory/provenance/reconciliation
+  以及所有 admission lane 仍由 #825 後續 child 交付，raw valid 不等 quota-positive。
+- PatchMUD #37 僅開票，不冒充 producer 實作／實測／真人 qualification。
+- 本批有自己的 changelog fragment、Unreleased entry 與 PR-context preflight／CI
+  gates。未取得 exact-head gate 結果前不得把本報告當作 PASS receipt。

--- a/reports/review/refine-profile-schema-child-20260907.md
+++ b/reports/review/refine-profile-schema-child-20260907.md
@@ -1,0 +1,154 @@
+# #835 schema/key core child planning 審查
+
+日期：2026-09-07。branch：`feature/refine-profile-schema-child-20260907`。
+authoring 基底為當下 `origin/main` `fb31083e7325be86c6c9d217da56b9c4d799f5a5`；
+先 inventory 確認新 branch/path 不存在，再開隔離 worktree，只在新 worktree 做 `pull --ff-only origin main`，
+結果 already up to date。未改 operator/runtime／services；authoring 當下只新增本報告與三件組，無 commit/push。
+
+## Authority Readback
+
+完整讀 [PR #848](https://github.com/hamanpaul/paulsha-cortex/pull/848) 的母 spec/design/todo/report。
+首次 GitHub 查得 head `0da1bfa026899e46df990a9b65d40dfc9fec6f31`，隨 root 通知更新至
+`be59f769786eeee2e1f97e073c722d8e49272653`；精確比較證明三檔 bytes 不變，Todo 只有
+artifact_classes inline→block、值不變，已全文重讀最新 Todo，不拿不同 HEAD 的 checkout 冒充同一版本。
+#835／#842 issue 全文另已讀回；母件 qualification owner 舊 gap 依後續 #842/root 裁決收口。
+Authoring 階段未開 issue／registration；root 後續已建立 #849 並於本批登錄，
+尚未 freeze／dispatch，不改 PR #848 或母件四檔。以下歷史審查依其當時階段閱讀。
+
+## Outcome
+
+可把 T01/T02 的純資料切面限制為一個新 production module；不需要先改現有 consumer。
+但這是新版本化 schema，不只是無資料契約的運算；依 #208 state/consistency rubric，
+`domain_breadth=0, state_consistency=1`。母件「schema-core 可能 0/0」僅是未審候選，不沿用其暫估。
+母件 T02 的 legacy migration 不在此拆分；母 T05/T10 仍持有，沒有透過刪 AC 消失。
+Root 本輪接受新版本化資料契約的 state=1 分析，要求保留 vocabulary 權責、合法升版負例及
+既有 consumer 未接線的界線；此裁決不等於產品完成或真人資格批准。
+
+## Artifacts
+
+- [Spec](../../docs/superpowers/specs/execution-profile-schema-core-spec.md)：R1–R6、I1–I10、C01–C10 與母 A1–A6 全對照。
+- [Design](../../docs/superpowers/specs/execution-profile-schema-core-design.md)：單 module 純 API、原生 grammar、key/metadata、合法升版及 consumer 邊界。
+- [Todo](../../docs/superpowers/workstreams/execution-profile-schema-core/todo.md)：source/tests/documentation/CLI/changelog 首行 Tasks，產品項目均未勾。
+
+## Source and Consumer Seams
+
+`trace_mode=rg`，Python LSP unconfigured、worktree tags/cscope index 皆無；不建索引或啟動 server。
+有界選定入口：maxDepth=3、maxFanout=10、maxNodes=200、timeout=30s；各錨點 `[via=rg conf=0.4]`。
+以下以 authoring 基底的 `paulsha_cortex/coordinator/` 為前綴；只作當下局部證據，無全稱無其他 caller 宣稱。
+
+| 現有 seam | 證據與本 child 邊界 |
+|---|---|
+| `model_identities.py:284,349` | 現有 identity/registry 嚴格 schema；不加新欄位、不換 loader。新 core record 獨立於既有身份註冊 |
+| `model_resolution.py:476` | EvalRosterEntry 為 executor/model key 並有 approved/roles；#842 日後消費 core key，不在本件重寫資格政策 |
+| `model_profile.py:260`、`envelope_mapping.py:287` | 舊 fingerprint 六欄不等於 actual-condition key；新 API 不默默替換它、不重算舊 evidence |
+| `workflow.py:45,65` | frozen chain 嚴格欄位集合；新版 binding／legacy migration 留母 child，不往舊 dict 塞 profile |
+| `verification.py:58` | 現有一般 JSON hash 不定義 native float 跨 producer canonical 政策；新純 module 用 stdlib 建 typed canonical tree，不 import 此含其他 runtime dependencies 的模組 |
+| `coordinator/__init__.py:3` | 既有 package imports 保持不變；直接 import 新 module 不需新增 export，也不代表其他 consumer 已接線 |
+
+```mermaid
+flowchart TD
+    A["Caller data / descriptors"] --> B["Pure schema core"]
+    B --> C["Versioned keys / unknown"]
+    C -.-> D["#842 qualification publication"]
+    C -.-> E["Parent adapter / resolver"]
+    C -.-> F["Parent durable binding / migration"]
+    G["PatchMUD #37 CLI / file"] -.-> D
+    style A fill:#e8f0fe,stroke:#1a73e8
+    style B fill:#e2f0d9,stroke:#38761d
+    style C fill:#e2f0d9,stroke:#38761d
+    style D fill:#fff3cd,stroke:#856404
+    style E fill:#fff3cd,stroke:#856404
+    style F fill:#fff3cd,stroke:#856404
+    style G fill:#f3e8ff,stroke:#7030a0
+```
+
+圖為待實作契約依賴，不是已存在 runtime call graph。虛線全部留 downstream owner，
+#842 只依 core schema/key，不等 #835 整件 close。Mermaid 未經 renderer 驗證，僅作小型依賴示意。
+
+## Pure Gates and Sizing
+
+純 gate 使用既有 runtime checkout `79ba644780bf1c697c722ac24a297e7d02416100` 的 planning/manager/
+work_bridge，從 checkout 外以 `python3 -B` import，核對 module.__file__，不執行 dispatch/probe。
+這是 runtime 版本的純函式檢查，不是 active daemon 已載入新 core，也不是產品行為測試。
+套用 packaged feature-oneshot：11 cards、11 persona bindings、4 core gates；R-09/R-16/R-19 全集，
+故 acceptance_surfaces=2、orchestration=2。invariant_count=10 對應 Spec I1–I10，非壓分清單。
+
+| 情境 | domain | state | acceptance | stability | orchestration | 分數／band |
+|---|---:|---:|---:|---:|---:|---|
+| 79 runtime 真算法，完整 accepted 三件組 | 0 | 1 | 2 | 2 | 2 | 7 / Red |
+| #831 完整／穩定規劃=0，其他維度不變的投影 | 0 | 1 | 2 | 0 | 2 | 5 / Yellow |
+
+第二列只做算術投影，未替換 runtime 函式、未假裝 #831 已安裝；真修正後須重跑正式 gate。
+當前 Red 不得直接派單一 builder；schema 的 state=1 不因純函式實作或想得到 Yellow 而改 0。
+本輪 helper／負控制／link／whitespace 實際結果如下，不以文件自身宣告當 pass。
+此單 module 的 schema 與 key 共用同一版本化資料契約；再把 state 宣告切為 0 沒有事實依據。
+若 root 要繼續進件，需先等 #831 真實修正後重算，或依正式 Red 路徑重裁；本件不自動分解或派工。
+
+## Validation Ledger
+
+- 首輪獨立 review 為 FAIL／1 MAJOR：舊 D4 未固定 node tags／shape、完整 projection、JSON bytes 與 framing，
+  `["integer","1"]`／`{"type":"integer","value":"1"}` 都可能被解讀為符合舊文字卻產生不同 key。
+  Root 已採納此缺陷；本修訂直接替換 D4，並補 D1–D3 精確欄位與型別，不保留相互矛盾的 encoding。
+- 獨立 R2 為 PASS，root 以 JavaScript encoder＋sha256sum 再驗 actual 920/963、observed 1227/1272
+  bytes 與完整 golden 吻合；root 已確認原 1 MAJOR 處置完成，不沿用上一輪未關閉的暫態。
+- Fresh reader 五問理解正確，但另找出三項真歧義：D6 core wire 與 adapter protocol 值升版混淆、
+  D5 計數／早停未定義、D1 portable reference grammar 缺席。本次已補文字，fresh-reader 再確認尚未收口，
+  當時不拿 R2 PASS 冒充這三項也已驗收；後續 fresh reader 已逐項確認修訂清楚。
+- Root 接受 D5 分層：depth=16、nodes=4096、完整 J(T(descriptor/profile)) 合計 65536 bytes；
+  root/keys 計入、depth 取 max、nodes/bytes 取 sum，native 路徑同 metric。每份 JSON text 另有
+  1048576-byte 有界讀取 guard，錯誤分類與作用範圍獨立；只保證 transport 界內等價排版同 semantic
+  裁決，超大 padding 可先拒絕，不宣稱任意 input 常數成本。固定正負邊界已加入待實作 AC/Tasks。
+- 本輪記憶體計數驗算得到 golden descriptor+profile depth=5/nodes=144/semantic bytes=1740；
+  已構造上述四組精確邊界、分開皆未超界而合計超界、等價 compact/pretty/escaped/native、共享 alias
+  重複計數與循環 fixture；reference 正負字面值及 1024/1025-byte 邊界也已驗算。D4 兩筆 canonical
+  bytes／SHA-256 再讀回皆不變。這些是規劃 fixture 算術，不宣稱產品 parser 的 early-stop 已實作或通過。
+- D6 的需升版 protocol/shape 現明確只指 core wire/encoding；adapter protocol/version 新值仍
+  descriptor-only 且 key 自然改變。D1 ref 是有界 ASCII namespace:body opaque grammar，無 URL
+  白名單／dereference／credential scanner；語法合法不替代 producer/#842 的 provenance 真偽／政策。
+- 新 D4.1–D4.4 為 normative：JSON token→integer/binary64、duplicate-key／surrogate 拒絕、完整
+  record/actual projection、七種固定 tagged-array node、UTF-8／control escaping、NUL＋uint64_be length
+  framing。metadata 排除、三層分立、unknown 不授權與母件 scope 都未放寬。
+- 文件中的完整 profile 與兩行 canonical payload 已直接讀回，由不 import Cortex 產品的 in-memory
+  獨立 encoder 對照：actual C=920/F=963 bytes、observed C=1227/F=1272 bytes，兩把完整 key 與
+  文件逐 byte 相同；每個 framed digest 再經外部 `sha256sum` 交叉核對。
+- 五個完整 profile 的 int 1／float 1.0／string "1"／+0.0／-0.0 actual key 均吻合文件、兩兩不同。
+  獨立 parser 檢查 int 9007199254740993 不經 double、1e0 等同 float 1.0、-0e0 保留負零、
+  -0 為 integer 0、合法 surrogate pair 可解碼、underflow 保留負零；escape 後重複 key、NaN、Infinity、
+  overflow、lone surrogate、+0.0／01 非法 token 均拒絕。這是文件數學／JSON 契約驗算，不是新產品 parser 已通過測試。
+- 另實算 node tag 改寫／直接 hash C／錯 projection 保留 metadata 不能命中 golden；只改 excluded
+  metadata/provenance 不改 actual key；control／非 ASCII／斜線 vector 按精確 escaping 與排序成立。
+- 實際 `assess_planning_completeness`：complete=true；spec/design/plan 均 accepted=true，missing、reasons、blocking markers 全空。
+- 實際 `compute_sizing_score` 為 7/Red；`current_sizing_snapshot` 從三個真實相對路徑讀回亦為 `(7, red)`。
+  只以 dataclass 的 spec_stability=0 另算 #831 投影 5/Yellow，未改函式或檔案。
+- 實際 `_evaluate_yellow_plan_review`：ready=true；completeness／contract_compatibility／envelope 三步皆跑，
+  最後一項 observations 是 `bypass: envelope_unavailable`。這只代表現行 helper 結構檢查過關，
+  不證明任何 measured envelope／真人授權，更不能越過目前 Red band。
+- 額外直接 `plan_review_gate` 明示 source/tests/documentation/CLI，適用 R-09/R-16/R-19/R-22：ready=true，
+  envelope 同為 unavailable bypass，不宣稱真 CI 或 policy_check 已跑。
+- 四個 in-memory 負控制均拒絕：移除 Spec 的 Requirements 標題→completeness=false；移除 Todo 的 Tasks
+  標題→failed_check=completeness；注入明示測試 envelope invariant_count=9、三個 artifact classes→
+  failed_check=envelope／envelope-exceeded；把 state_consistency 改成 bool true→ValueError。
+  此 envelope 僅供負控制，不是實際模型的測量或 qualification 資料；四個變體皆未寫入檔案。
+- 四檔 newline／逐行尾端 whitespace／個人絕對路徑檢查通過；7 個相對 Markdown links 與 5 個既有
+  regression test 路徑均存在。新 core module／新測試只是待實作落點，未當成存在的成果。
+- 產品 core implemented／產品 tests／merge／package import／installed／live：本 authoring 未執行，均非完成證據。
+- 原 MAJOR 已於 R2 關閉；本次三項 fresh-reader 澄清的再確認在後續完成。技能 doc-coauthoring
+  用於母 AC／child scope 對齊，不代替 fresh-reader 或正式 authority。
+
+## Bounded Residuals
+
+1. 新 core 不能驗外部 observed/provenance 真偽；有 key 不是 measured/qualified。#842 另驗 exact profile、
+   role/deck/coverage、receipt 與真人政策，不能把 schema 測試 fixture 當批准。
+2. 原生 grammar 是有界 subset，不承諾任意新 core wire 協定零碼；未知 core shape/version 拒收。
+   新增合法 descriptor 值（含 adapter protocol/version）不改 core；新的 core wire/encoding 契約才需升版，
+   真 adapter 接線／conformance 仍由原 owner 驗收，不固定模型／agent／effort 清單。
+3. 母 A2/A3/A5/A6 的 adapter／resolver／state migration／真 producer/consumer 與 installed/live 仍未交付。
+   frozen legacy snapshot 無法證實時不得猜補原 schema/policy；本件只拒收不轉換，由母 child 走正式重新接受。
+4. #581 五原 scope、PatchMUD #37 外部 producer 與 #842 lifecycle 都保留，不作本 core 的反向完成依賴。
+   downstream 可對本純 API 開發 fixture，不可藉此宣稱 routing 已改用新 module。
+
+## References
+
+- [#835](https://github.com/hamanpaul/paulsha-cortex/issues/835)、[#842](https://github.com/hamanpaul/paulsha-cortex/issues/842)、[#581](https://github.com/hamanpaul/paulsha-cortex/issues/581)。
+- [PR #848 母 Todo](https://github.com/hamanpaul/paulsha-cortex/blob/be59f769786eeee2e1f97e073c722d8e49272653/docs/superpowers/workstreams/execution-profile-contract/todo.md)。
+- [#208 rubric](https://github.com/hamanpaul/paulsha-cortex/issues/208)、[#831](https://github.com/hamanpaul/paulsha-cortex/issues/831)、[#833](https://github.com/hamanpaul/paulsha-cortex/issues/833)。


### PR DESCRIPTION
## 摘要

登錄 #849 schema／canonical key 純契約及 #850 有界 backoff store child，母責任仍在 #835／#825／#829。
補齊 byte-level golden、資源上限、真 process-death oracle、獨立審查與當前 run 進度；本 PR 只交付規劃，不关闭產品 issues。

## 驗證與邊界

- [x] 兩組三件組 accepted/completeness、實際 packaged combo／gate coverage 與缺 Tasks 負控制通過。
- [x] 核心契約 R1 修訂、R2、fresh reader 及 fresh compact R3 審查完成；產品 Tasks 均未勾。
- [x] 真 sizing 保留 7／8 Red；#831 後 5／6 僅投影，envelope bypass 不冒充可派工。
- [x] 新增分支對應 changelog fragment，同步 Unreleased、owner registry 與 umbrella ledger。
- [x] VERSION／symlinks／policy pin 不變；未改產品、runtime、capability 或 frozen run/evidence。
- [x] 所有 runtime／產品／資格完成宣稱均分開；PatchMUD #37 仍只有外部開票。

標籤 `policy-exempt:issue-link`：本 PR 僅進件，以上 issues 尚未完成產品交付，刻意不使用 closing keyword；不豁免其他 gates。
Exact-head post-commit preflight 與遠端 CI／review threads 必須通過才 merge。
