### PR TITLE
docs(refine): 登錄 AGY 前置與受阻 timeout 子計畫

### DIFF
--- a/.cortex/work-items.yaml
+++ b/.cortex/work-items.yaml
@@ -853,8 +853,6 @@ work_items:
     links:
       - kind: github_issue
         ref: 'hamanpaul/paulsha-cortex#823'
-      - kind: github_issue
-        ref: 'hamanpaul/paulsha-cortex#824'
       - kind: path
         ref: 'docs/superpowers/workstreams/launcher-session-and-timeout/todo.md'
     excludes: []
@@ -929,4 +927,16 @@ work_items:
         ref: 'docs/superpowers/specs/executor-backoff-store-core-design.md'
       - kind: path
         ref: 'docs/superpowers/workstreams/executor-backoff-store-core/todo.md'
+    excludes: []
+  agy-probe-construction-containment:
+    title: 'agy-probe-construction-containment'
+    links:
+      - kind: github_issue
+        ref: 'hamanpaul/paulsha-cortex#851'
+      - kind: path
+        ref: 'docs/superpowers/specs/agy-probe-construction-containment-spec.md'
+      - kind: path
+        ref: 'docs/superpowers/specs/agy-probe-construction-containment-design.md'
+      - kind: path
+        ref: 'docs/superpowers/workstreams/agy-probe-construction-containment/todo.md'
     excludes: []

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 
 ## [Unreleased]
 
+- **AGY 前置契約進件**：登錄 #851 probe argv 例外隔離，#824 timeout 拆為獨立候選，
+  保留 #823 session/cgroup 邊界。#824 依賴未完成，移除母件重複 owner 並暫不登錄
+  可 claim child；真 completeness 阻擋與 surface-only Yellow gate 分帳，不依自訂欄位假鎖派工。
+
 - **有界核心 child 進件**：登錄 #849 可擴充 execution-profile schema／canonical key，
   與 #850 跨程序 backoff store／immutable event fold；補 byte-level oracle、資源上限及
   真 process-death 測試契約。獨立審查通過，現行 sizing 仍為 7／8 Red，

--- a/changelog.d/refine-agy-dependencies-20260907.md
+++ b/changelog.d/refine-agy-dependencies-20260907.md
@@ -1,0 +1,7 @@
+# AGY 前置契約進件
+
+- 登錄 #851 單模組 probe construction containment 與完整故障隔離測試契約。
+- #824 timeout-only 獨立保存 resolver／argv／parser／Go 上界與真 env 整合驗收，
+  #823 canonical work 保留 session scope；不以一次混合工作同時擁有兩個來源。
+- #824 仍有真依賴阻塞，暫不註冊或啟用自動 claim；機械完整性與 Yellow surface
+  檢查分開，不把規劃、獨立內容 review、CI 或 issue 更新當產品／loaded-runtime 完成。

--- a/docs/superpowers/plans/2026-09-07-cortex-refine-complete.md
+++ b/docs/superpowers/plans/2026-09-07-cortex-refine-complete.md
@@ -248,6 +248,7 @@ B1 的主要目標是讓 Cortex 能可靠承接後續工作。B2–B4 完成後�
 | self-publication authority stability | #847；可信 frozen 自身同內容發布的 metadata 等價，不清 needs_human 或重開 gates；真需求變更仍走既有合法 restart。 |
 | schema/key pure core | #849，#835 child；精確 typed wire／canonical key、三層 profile 與 bounded input。現行7/Red，#831後5僅投影；不授予資格、不做母件 routing/migration。 |
 | backoff store/event fold | #850，#825 child A；有界 fresh store、flock/atomic replace/durability、immutable event fold與ack。現行8/Red，#831後6僅投影；C/D provenance/reconciliation与production lanes仍另交付。 |
+| AGY probe exception containment | #851，#824 前置；只將 model_identities.py 的 argv 建構納入既有 smoke try。真6Yellow、独立內容審查與 fresh reader通過，正式派工／產品未完成。 |
 
 #835–#842的查重與read-back見[動態issue對照](../../../reports/review/refine-dynamic-issues-20260907.md)；
 #843–#845各票保存不可變source與10/12/12項AC，root已全文讀回。所有新scope都尚未
@@ -298,6 +299,36 @@ PatchMUD #37仍是外部producer gate，真人qualification核可若生效也需
   審查，timeout-only 保持 blocked-dependency，兩者未登錄／dispatch。本批不混入未通過文件。
 - #827 watcher child 已收斂 controlled polling 候選並送 fresh R3；延遲、短命事件、
   last-good snapshot recovery 與 CI watchdog 依賴均需真測試，仍未登錄／dispatch。
+
+### AGY dependency 與 recovery 核對（2026-09-07 13:51 UTC）
+
+- [PR #852](https://github.com/hamanpaul/paulsha-cortex/pull/852) 已合併
+  `984fce5b86604aa71c6e8ecf82cc253a1441a106`；exact head `512688413e4c60480907a0076d12f0fdb80133bd`
+  全 preflight（tests176.89s）、四版pytest/build/installed smoke與遠端review gate通過。
+  這只交付 #849/#850 規劃；現行 Red、不曾產品派工，B1/B2 仍未完成。
+- #831 GREEN59 再遇AGY五分鐘 timeout，雖有8項dirty artifacts及Manager全套gate通過，
+  無 commit/JSON仍拒收。正式resume `20260907T133842Z-bcf9249f391245ca91bb8147e7932696`
+  採信失敗並保留 needs_human／RED c62df773；不再重複相同AGY路徑。
+- 原 run 不能經目前公開 recovery 原子換 builder+reviewer；只換Codex builder會撞到
+  Codex reviewer pin，首次reviewer job前失敗又不滿足retry-card terminal前提。
+  Root與獨立reviewer核對現行paths／純helper，具體缺口已補
+  [#839](https://github.com/hamanpaul/paulsha-cortex/issues/839#issuecomment-5571522109)／
+  [#843](https://github.com/hamanpaul/paulsha-cortex/issues/843#issuecomment-5571522360)。
+  不放寬pin／independence、不手改registry；Claude額度恢復後可只換builder，保留Codex reviewer。
+- 本批登錄 #851 containment：單production model_identities.py，真6Yellow；
+  timeout-only 的 #824 與 session 的 #823 分開，後者保留 canonical work_id。
+  #824 AC5/AC6／fullmatch與Go界線／#851依賴已由root正式修訂並全文讀回。
+- #824 自訂 dispatch_readiness／dependency_issues 不是79 runtime的canonical guard。
+  Root在Todo加入真Open Questions marker，completeness=false／blocking-decision；
+  原完整6分因舊反向stability成4分，surface-only Yellow helper仍ready且envelope bypass。
+  兩者都不能授權派工，也不偽造Red。incomplete start還可能啟動brainstorm，因此
+  本批只發布其候選文件、從母件移除 #824，**暫不登錄 timeout 可 claim owner**，
+  不啟用 `cortex:auto-on-going`、不start；目前兩issue均無此label、沒有相關既有run。
+  #851產品／預定base／loaded runtime證據具備後才正式解除、登錄與重新接受。
+- #824 parser另經root無憑證／無prompt／stdin EOF真跑AGY1.1.27五列：全部exit2；
+  abc/missing-unit/overflow與合法duration到unknown sentinel可區分。這不是模型或live gate。
+- #827 watcher修订fresh R4已PASS：failure latch與逐層nofollow契約處置兩MAJOR，
+  純memory/source證據不等dirfd/FD上界/OS/產品/CI；仍8Red且未派工。
 
 ### Canary sizing 校正紀錄
 

--- a/docs/superpowers/specs/agy-print-timeout-only-design.md
+++ b/docs/superpowers/specs/agy-print-timeout-only-design.md
@@ -1,0 +1,163 @@
+---
+status: accepted
+work_item: agy-print-timeout-only
+authority_state: proposed-unregistered
+dispatch_readiness: blocked-dependency
+depends_on:
+  - agy-probe-construction-containment
+dependency_issues:
+  - "hamanpaul/paulsha-cortex#851"
+---
+
+# AGY print timeout 單模組設計
+
+## Decisions
+
+### D1：只有 launcher 改 production
+
+原 author 以 `25c9a4e4040476523d0bb5f2132236f87b8d65f8` 為規劃 base。唯一 production
+寫入目標是 `paulsha_cortex/coordinator/launcher.py`。其第 13 行本來就 import
+`gate_ledger`，直接使用現有 `_gate_timeout()` 即可；不新增第二份 gate parser。
+
+資料流為 caller env → `resolve_agy_print_timeout` → canonical `Ns` →
+`build_agy_argv` → 既有 shell wrapper → Popen。resolver 不存取檔案／服務／registry。
+`build_agy_argv(None)` 與正式 launcher 的顯式值共用同一解析與最終範圍檢查。
+
+`SubprocessLauncher` 的工作目錄、bundle、gate、sentinel、降權與 permissions
+流程保持原樣。timeout 在 manager 組 argv 時已物化，因此不新增 job env allowlist。
+若有 evidence 顯示必須改 `gate_ledger.py` 才能完成，停止本切面並回 root 重裁決。
+
+### D2：解析、正規化與溢位防護
+
+- module-local 常數：env 名稱、600 秒 buffer、`9223372036` 整秒最大值。
+- env 使用 key presence 區分未設定與空白；strip 後 ASCII digits only；前導零
+  正規化，不接受符號、小數、指數、unit 或 Unicode digits。
+- 先正規化 digit string，再以長度與同長 lexicographic 比較最大值，最後才
+  `int()`；超長數字不依賴 Python 的字數上限。零值明確拒絕。
+- keyword 使用 `re.fullmatch(r"[1-9][0-9]*s", value)`，不使用會容許末尾
+  newline 的 `re.match(...$)`；型別先驗證，再檢查整秒最大值。
+- override 存在且合法即返回，不呼叫 gate helper。未設定時直接呼叫既有 helper，
+  取 `max(DEFAULT_GATE_TIMEOUT_SECONDS, gate_seconds) + 600` 後套用上界。
+- valid gate `9223371436` 是無 override 時最大可推導值；下一秒使最後 duration
+  超界，launcher 回 `ValueError`。不變更 gate helper 的 fallback 或設定本身。
+
+### D3：argv exactness
+
+```text
+planner / reviewer / write-forbidden:
+  agy --print <one-prompt> --mode plan --sandbox [--add-dir ...]
+      [--output-format json] --print-timeout <Ns> [--model ...]
+builder / commit-required / unsafe:
+  agy --print <one-prompt> --mode accept-edits --add-dir <worktree>
+      [existing git directories / unsafe flag]
+      [--output-format json] --print-timeout <Ns> [--model ...]
+```
+
+插入位置保留原本所有 argv prefix slices。`json_envelope=False` 只控制 JSON
+flag，timeout 仍存在。`SubprocessLauncher` 只向 agy builder kwargs 新增
+`print_timeout`；不把它塞給其他 executor 或增通用 `extra_args` 逃生口。
+
+Fake Popen capture 不使用 `script.split(';', 1)` 擷取命令，因 prompt 本身
+可以有分號。以 `shlex.shlex(script, posix=True, punctuation_chars=";")` 並設
+`whitespace_split=True` 取得保留引號语意、將 shell 分隔符獨立切出的 tokens；
+避免 model 缺省時把 `2400s;` 誤認成 timeout 值。再以 builder kwargs capture
+證明精確傳遞；另有帶分號／引號 prompt 的直接 argv 測試證明 prompt 單元素契約。
+每種形狀檢查 flag count==1。
+
+### D4：測試與 CLI proof 分離
+
+pytest 全為 offline fake contract tests，主要放在
+`tests/test_coordinator_agy_launcher.py`，另在既有
+`tests/test_coordinator_launcher.py` 增非 AGY regression assertion。
+不加 #823 的 signal／session 測試。
+
+resolver matrix 包含 spec R2/R3 所有列；額外驗證 keyword `1s`／max／max+1、
+末尾 newline、非 str，以及 5000-digit env／keyword 均為 `ValueError`。
+以 monkeypatch gate helper 證明無 override 時走既有 helper，override 時不走。
+保留 existing `DEFAULT_GATE_TIMEOUT_SECONDS=1800` 與 helper fallback 的 source
+hash，不修改其測試 oracle 以迎合新 resolver。
+
+CLI proof 由 candidate evidence 執行，不進 pytest。先讀實際 `agy --version`，
+無 credential env／無 prompt 下令 parser 在未知 flag 必停：
+
+```bash
+env -i HOME=/dev/null XDG_CONFIG_HOME=/dev/null PATH=/usr/bin:/bin \
+  "$AGY_BIN" --print-timeout 2400s --cortex-timeout-parser-sentinel </dev/null
+```
+
+`AGY_BIN` 是 operator 已解析且版本已記錄的絕對可執行檔路徑，不由模型自行下載。
+此命令故意不帶 `--print`、`--help` 或任何 prompt，unknown flag 位於 timeout
+之後。完整 drain stdout/stderr 並保存實際 exit code，不用 `head` 截流造成
+SIGPIPE。可用 `subprocess.run(capture_output=True, stdin=DEVNULL, env=...)`
+在記憶體檢查，無需保存完整 help；不修改 HOME 本體或任何設定。
+
+| value | 真正預期 |
+|---|---|
+| `abc` | exit 2；timeout invalid duration |
+| `2400` | exit 2；timeout missing unit |
+| `2400s` | exit 2；只到 unknown sentinel flag |
+| `9223372036s` | exit 2；只到 unknown sentinel flag |
+| `9223372037s` | exit 2；timeout invalid duration |
+
+這個對照證明 timeout parser 接受 canonical 合法值並拒絕溢位；不聲稱執行成功、
+模型回覆、實際 deadline 等待或完整 argv 的 headless E2E。
+
+### D5：bootstrap 與保留項
+
+新增必須先完成的 dependency：`agy-probe-construction-containment`，唯一 owner
+為 [#851](https://github.com/hamanpaul/paulsha-cortex/issues/851)，已由 root
+建立並已納入本 PR repository intake。本 child #824 則刻意不登錄、仍 blocked-dependency。
+在原 author 核對的 runtime 中，
+`model_identities.py:1071-1078` 的 argv construction 在既有 smoke try 外，
+timeout resolver 的 `ValueError` 因此可能從 `planning_runtime.py:1664` 穿透，
+連 ready 的非 AGY primary 都無法取得 runtime。R1 已獨立重現；timeout-only
+不可先 freeze／dispatch，不能以殘餘接受或不驗證 probe env 的方式放行。
+該 dependency 只改 `model_identities.py`，將 construction 納入既有 try／
+`_failed_agy`；本 child 仍只改 launcher。待 root 核對 containment candidate、
+實際 runtime 與 frozen base 證據後才能解除 block。
+
+containment 的獨立驗收用 builder fault injection，不反向等待尚未落地的
+timeout resolver。本 child 落地後須補真非法 `PSC_AGY_PRINT_TIMEOUT` 的
+direct-launch／capability-probe雙路徑測試，並用isolated roster與fresh tmp cache
+走真runtime constructor證ready非AGYprimary可建runtime；不mock整個probe，
+不跳過probe的env解析。測試可加到既有model identities／planning runtime測試檔，
+production仍只改launcher；若containment base不符就停止，不在本child偷修另一模組。
+
+原 author 時期母 work item `launcher-session-and-timeout` 映射 #823/#824；
+root 已在本 PR 移除其中 #824、保留 #823。本 child 唯一owner仍#824，但刻意
+不登錄timeout child，待前置真完成後再正式進件／freeze。本文件整合不修改
+`.cortex/work-items.yaml`、issue、source owner、active run 或 runtime。
+既有來源不得同時把同一 #824 授權給兩個 active work item。
+
+Root 已定案本 child 只映射 #824。`manager.workflow_build_branch()` 依最小 issue
+與 work_id 固定回 `feature/824-agy-print-timeout-only`，不能由 todo 任意換名。
+canonical fragment 為 `changelog.d/agy-print-timeout-only.md`；母
+`changelog.d/launcher-session-and-timeout.md` 的責任留 #823，不複製兩份 fragment。
+#824 已由 root 正式更新，唯讀 readback 的 updatedAt 為
+`2026-09-07T13:40:04Z`：AC5 已同步此名稱與 branch，AC6 已改 sentinel
+parser proof，另明列 fullmatch／range 與 #851 dependency。timeout child的
+registration刻意保留未登錄，block不解除；本author不改issue、registration或Manager。
+
+原author完整三件套／記憶體移除marker控制組在runtime `79ba6447` 得6 Yellow，
+不需要先修#831才能算分；目前帶marker的真文件不完整、4 Yellow，並非dispatch-ready。
+Yellow strong plan review、provider capability/preflight、exact frozen base 仍是
+派工必要條件。若用 AGY 自己實作此 child，舊 runtime 尚有五分鐘上限；應由 root
+使用已授權的可用 builder route，或先完成有界 focused RED，不能讓此 child 又以
+未修改的 timeout 依賴自己的修正結果。
+
+實作完成、candidate test PASS、merged、installed、live workflow retry 是不同狀態。
+本 child 的 code acceptance 到 candidate／exact-head gate；安裝與對 #831 的
+正式 retry 留給另行已授權的操作，不包成 production scope 擴張。
+
+## Current integration gate
+
+root於#852 merge `984fce5b`的整合worktree登錄#851，故意不登錄本child。
+runtime79忽略workflow文件的`dispatch_readiness`／`dependency_issues`，
+`depends_on`僅舊slice lane使用；不能把這些frontmatter當正式依賴閘。
+todo的root marker必須保留：真completeness=false、plan blocking-decision、
+stability=0、total4 Yellow；surface-only gate卻仍ready／envelope bypass。
+即使不完整，start也可能走brainstorm，故不宣稱marker零派工。
+root當次核對#824/#851 labels皆空、無相關run，且auto新work需
+`cortex:auto-on-going`；維持不登錄、不auto-label、不start #824才是本次
+操作邊界。前置產品、預定base和loaded runtime均通過後，再由root解除marker、
+重接受並正式登錄；本輪不修改任何resolver／test契約或0／0／7宣告。

--- a/docs/superpowers/specs/agy-print-timeout-only-spec.md
+++ b/docs/superpowers/specs/agy-print-timeout-only-spec.md
@@ -1,0 +1,178 @@
+---
+status: accepted
+work_item: agy-print-timeout-only
+authority_state: proposed-unregistered
+dispatch_readiness: blocked-dependency
+depends_on:
+  - agy-probe-construction-containment
+dependency_issues:
+  - "hamanpaul/paulsha-cortex#851"
+---
+
+# AGY print timeout 單獨交付規格
+
+## Requirements
+
+本文件把 [#824](https://github.com/hamanpaul/paulsha-cortex/issues/824) 已定案的
+print-mode 等待契約整理為獨立 child。初次需求核對為 2026-09-07、issue
+`updatedAt=2026-09-07T10:01:44Z`；root 後續已正式同步 AC5／AC6、fullmatch／
+range 與 #851 dependency，本輪唯讀確認最新 `updatedAt=2026-09-07T13:40:04Z`。
+`status: accepted` 是需求文件的機械輸入狀態，
+不表示這個 child 已註冊、已通過獨立 plan review、已凍結 authority 或已授予派工權。
+
+目標是讓 Cortex 明確傳入可配置、可由 AGY 解析的 print deadline，解除
+[#831](https://github.com/hamanpaul/paulsha-cortex/issues/831) 在全庫測試前後碰到
+AGY 預設五分鐘上限的 bootstrap 依賴。這不是 #831 的 sizing 算法修正。
+
+唯一 production 修改檔為 `paulsha_cortex/coordinator/launcher.py`。
+`gate_ledger.py` 僅使用既有 `_gate_timeout()` 與 `DEFAULT_GATE_TIMEOUT_SECONDS`；
+不得修改其內容。若現有 helper 不能滿足下面契約，先回報重新裁決 scope。
+
+此 child 目前不可先派，必須先完成獨立 dependency
+`agy-probe-construction-containment`，其唯一 owner 已由 root 建立為
+[#851](https://github.com/hamanpaul/paulsha-cortex/issues/851)，其 registration 已由
+root 納入本 PR 的 repository intake；#824 本 child 則刻意不登錄、不解除 block。
+R1 對抗審查已用 fake 反證：目前
+`model_identities.probe_agy_capability()` 在 smoke try 外建立 argv，R4 的
+probe 也 resolve timeout，因此非法設定的 `ValueError` 會穿透
+`planning_runtime` 的 roster probe loop，阻止原本 ready 的非 AGY primary
+建立 runtime。這是必修缺陷，不列為可直接接受的殘餘風險。
+dependency 要把 argv construction 納入既有失敗回傳邊界；本 child 保持
+launcher-only，保留全部 env／range 驗證及 probe timeout，不以忽略 probe 值繞過。
+root 確認 containment 已完成驗證且預定 base／實際 runtime 已含保護後，才可
+解除本 child 的 dispatch block；機械 completeness／6 Yellow 不能取代此條件。
+
+### Current integration gate
+
+root 已將 #824 從母 #823 mapping 移除，但故意不登錄 `agy-print-timeout-only`；
+owner issue #824 仍 OPEN，#851 的產品前置尚未完成。runtime `79ba6447` 不把
+`dispatch_readiness`／`dependency_issues` 當 workflow guard，`depends_on`
+只作用於舊 slice lane。本 todo 保留 root 的未決問題 marker，當前真
+completeness=false、plan 被判 `blocking-decision`，舊反向分數為4 Yellow，
+不是原 author 完整文件的6 Yellow，也不是降低了0／0／7宣告。
+surface-only `plan_review_gate` 仍可能ready／envelope bypass；incomplete start
+可能進 brainstorm，故 marker 本身不保證zero-spawn。root保持不登錄、不加
+`cortex:auto-on-going`、不start #824；待#851產品、預定base及loaded runtime
+保護均核對後，才可解除marker、重新接受並正式登錄，不能先派。
+
+### R1：輸出形狀與數值界線
+
+- `resolve_agy_print_timeout(env: Mapping[str, str]) -> str` 輸出 canonical
+  正整數秒加 `s`，符合 `re.fullmatch(r"[1-9][0-9]*s", value)`。
+- Go duration 為 signed 64-bit nanoseconds；本契約只輸出整秒，最大值為
+  `floor((2**63 - 1) / 1_000_000_000) = 9223372036` 秒。`1s` 與
+  `9223372036s` 可表示；`0s`、負值與 `9223372037s` 不可輸出。
+- 顯式 env、顯式 keyword 與 default 推導結果都必須檢查此界線；超界
+  `ValueError`，不得 wrap、truncate、clamp 或把無法解析的值交給 AGY。
+- 錯誤訊息只識別設定名稱與錯誤類型，不 dump env，也不回顯任意原始值。
+
+### R2：顯式 AGY override
+
+- 新增 `AGY_PRINT_TIMEOUT_ENV = "PSC_AGY_PRINT_TIMEOUT"`。用 key 是否存在
+  判斷顯式設定；存在但空白不是未設定。
+- env 值去除頭尾空白後，只接受 ASCII 十進位數字；容許前導零，正規化後
+  必須在 `1..9223372036`。例如 `" 0900 "` 輸出 `900s`。
+- 空字串、全空白、`abc`、`0`、`-5`、`+900`、`1.5`、`1e3`、`900s`、
+  Unicode 數字或超界值皆 `ValueError`。超長字串也只能產生可預測的
+  `ValueError`，不依賴 Python 大整數字數限制的錯誤文字。
+- 顯式設定優先，不受 gate 值提高或降低：override `900` 與 gate `3600`
+  並存仍為 `900s`。此分支不需要解析 gate 值。
+
+### R3：未設定 override 的推導
+
+直接重用既有 helper：
+
+```text
+gate_seconds = gate_ledger._gate_timeout(env)
+seconds = max(gate_ledger.DEFAULT_GATE_TIMEOUT_SECONDS, gate_seconds) + 600
+```
+
+| AGY override | Gate 設定 | 結果 |
+|---|---|---|
+| 未設定 | 未設定 | `2400s` |
+| 未設定 | `900` | `2400s` |
+| 未設定 | `3600` | `4200s` |
+| 未設定 | `abc`、`0`、`-5`、空白 | helper fallback 後 `2400s` |
+| `900` | `3600` 或非法值 | `900s` |
+| 未設定 | `9223371436` | `9223372036s` |
+| 未設定 | `9223371437` | 推導結果超界，`ValueError` |
+
+非法／非正 gate 值維持 `_gate_timeout()` 的既有 fallback；不得另造 gate
+parser 或改成 gate 設定一錯便拒派。合法正 gate 值使最後結果超過 AGY 可表示
+範圍時，拒絕的是 AGY duration 推導結果，並未改變 gate parser 的語意。
+
+### R4：全部 AGY argv 形狀
+
+- `build_agy_argv()` 新增 keyword `print_timeout: str | None = None`。
+  `None` 時自行從 `os.environ` 呼叫 resolver；直接呼叫者也必須收到 flag。
+- 非 `None` keyword 必須是 canonical `Ns` 字串，使用 `fullmatch` 且
+  數值符合 R1。`2400`、`abc`、`00s`、`01s`、`2400s\n`、有頭尾空白、
+  非字串與超界值皆拒絕；keyword 不做 env 的 strip／前導零正規化。
+- 所有 planner、reviewer、builder、unsafe builder、write-forbidden builder、
+  write-forbidden planner、commit-required builder 形狀，恰有一組
+  `--print-timeout <value>`。
+- 插入點在可選的 `--output-format json` 之後、可選 `--model` 之前。
+  prompt 仍是一個 argv 元素，既有 scope directories、permissions 與前綴切片不變。
+- `json_envelope=False` 的 capability probe 形狀也帶 timeout，仍不帶
+  `--output-format`；probe 本身的 45 秒 process deadline 不變。
+
+### R5：正式 launcher 傳遞與失敗邊界
+
+- `SubprocessLauncher.launch()` 只對 `executor == "agy"` 計算並顯式傳入
+  `print_timeout=resolve_agy_print_timeout(os.environ)`。
+- 檢查 caller→builder kwargs，也檢查 fake Popen 收到的實際 shell script
+  中有正確的單一 `--print-timeout 2400s`，並測 override `900s`。
+- 非法 override 或超界結果必須在 Popen 前 `ValueError`，不啟動 executor。
+  此要求不擴充成新交易、rollback、registry 或 job lifecycle 設計。
+
+### R6：原有界線與母範圍
+
+- [#823](https://github.com/hamanpaul/paulsha-cortex/issues/823) 的
+  `start_new_session`、process-group 測試與 Popen kwargs refactor 全部留在
+  `launcher-session-and-timeout` 母範圍；本 child 不完成、關閉或吞併 #823。
+- 保留 #820 的 `json_envelope`、JSON envelope 解析；不改 effort、timeout
+  outcome taxonomy、gate timeout default、installer、runner default、Manager
+  kill/cancel、`LaunchHandle` 或其他 executor 的 argv。
+- 不修改 `planning_runtime.py` 的 120 秒或 probe 的 45 秒 timeout，不修改
+  `job_runner.py` 的 env allowlist。timeout 已轉為 argv，不需將新 env 傳入 job。
+- 不操作服務、安裝、共享 runtime、既有 worktree、active run 或其他會話。
+
+### R7：可驗證交付
+
+- pytest 覆蓋 R1–R6 的 resolver、exact argv、正式 launcher 轉發、其他 executor
+  無 flag 的回歸，以及非法值不 spawn；全部 fake，不呼叫模型 CLI。
+- containment dependency 完成後，本 candidate 必須用真 resolver 與非法
+  `PSC_AGY_PRINT_TIMEOUT` 測兩條路徑：direct launch 仍 ValueError／零 Popen，
+  真 capability probe 在 fake discovery 下回 failed AGY／不呼叫 smoke。
+  再用 fresh tmp probe cache、真 runtime constructor、ready 非 AGY primary
+  證 runtime 可建立；不能只沿用 dependency 的 builder fault injection。
+  這些是本 child 的下游整合測試，不要求 containment child 先有 timeout resolver。
+- CLI parser 證據必須有可區分的負控制；`--help` exit 0 不構成 flag 值被解析
+  的證据。無憑證、無 prompt、stdin EOF 下，以 timeout flag 後的未知 sentinel
+  flag 強制停止：非法 duration 先報 duration 錯，合法 duration 才報未知 flag。
+- 本 child 的 canonical build branch 由 `manager.workflow_build_branch()` 固定
+  產生為 `feature/824-agy-print-timeout-only`；candidate 使用
+  `changelog.d/agy-print-timeout-only.md`，同步 `CHANGELOG.md [Unreleased]`。
+  fragment 內容只宣告 #824 timeout；舊 `launcher-session-and-timeout` fragment
+  責任留給 #823，不新增重複 fragment，也不改 Manager 的 branch 推導。
+- 以上 child 契約已由 root 正式更新至 #824（2026-09-07T13:40:04Z）：AC5
+  使用本 child fragment／branch，AC6 使用 sentinel parser proof，並明列
+  fullmatch／range 與 #851 dependency。root 本 PR 已移除母 mapping 的 #824，
+  但刻意不登錄本 child；dependency block 不解除。本 author 僅唯讀核對遠端更新，
+  本 planning 分支也不是 build branch。
+- 操作文件與 CLI help smoke、focused/full pytest、manifest 的 OpenSpec specs
+  gate、pinned preflight、PR-context policy、exact-head review 均需完成。
+  不把 parser proof 或 fake Popen 當成已安裝／live workflow 的驗收。
+
+## Sizing 與 authority
+
+依 [#208](https://github.com/hamanpaul/paulsha-cortex/issues/208) 原 rubric，
+domain=0：單一 production 模組與 env→duration→argv 資料流；state=0：純解析／
+local argv，無 schema、持久化相容層、concurrency、atomicity 或 migration。
+既有 gate helper 已被 launcher import，使用其不變輸出不構成第二個修改模組。
+
+原 author 的完整 accepted 三件套在舊runtime反向stability算法得2，總分
+`0+0+2+2+2=6` Yellow；這是歷史與僅在記憶體移除marker的控制組結果。
+當前磁碟保留marker，stability=0、總分`0+0+2+0+2=4` Yellow且不完整，
+不可據較低分數派工。domain/state/invariant仍0／0／7，不改#831算法或門檻。
+須先完成前置、正式登錄及Yellow真gate／authority流程，才可freeze／dispatch。

--- a/docs/superpowers/specs/agy-probe-construction-containment-design.md
+++ b/docs/superpowers/specs/agy-probe-construction-containment-design.md
@@ -1,0 +1,142 @@
+---
+status: accepted
+work_item: agy-probe-construction-containment
+authority_state: repository-intake-unfrozen
+owner_issue: "hamanpaul/paulsha-cortex#851"
+registration_state: repository-intake
+dispatch_readiness: awaiting-freeze
+---
+
+# AGY probe 建構失敗邊界設計
+
+## Decisions
+
+### D1：最小例外邊界
+
+原 author 規劃 base=`25c9a4e4040476523d0bb5f2132236f87b8d65f8`。當時核對
+`model_identities.py:1071-1078` 建 argv 在 smoke `try` 外；
+`planning_runtime.py:1664` 對 canonical AGY roster probe 不另 catch，
+即使 primary 是非 AGY，建構 `ValueError` 也會中止整個 runtime 建立。
+
+唯一 production diff 是將原 argv assignment 整塊縮排移入既有第二個 `try`。
+`except Exception` 仍使用原 `_failed_agy("smoke-failed", ...)`，其內容不變。
+原 prompt 構造、第一段 models discovery 和 smoke 後的 payload 驗證位置不變。
+不把整個 runtime loop 包成寬廣 catch，也不在 launcher 吃掉 invalid 設定。
+
+```text
+models discovery 成功
+  → 同一 smoke try：[build argv → process runner → process fields]
+      Exception → 既有 failed AGY result
+      BaseException → 繼續向 caller 傳播
+  → 原 payload／identity 驗證 → 原 ready result
+```
+
+下游 timeout resolver 可因此維持嚴格驗證；probe 設定非法只變成明確不 ready，
+不再意外阻止其他 roster identity 的 runtime construction。
+
+### D2：精確 seam 與 RED test
+
+`model_identities.py:16` 已用 `from .launcher import build_agy_argv` 存本地 alias，
+所以 probe fault injection 必須 patch `model_identities.build_agy_argv`。
+只 patch `launcher.build_agy_argv` 不會替換已匯入 alias，會形成假測試。
+
+在 `tests/test_model_identities.py` 增 focused test：fake runner 的 discovery
+回 canonical `AGY_MODEL_ID`，fake builder 記下 kwargs 然後拋帶 harmless marker
+的 plain `ValueError`。舊 source 必因例外外洩 RED；修後 assert `ready=False`、
+reason=`smoke-failed`、diagnostic=`ValueError`、原 executor/model/domain、
+runner 只收到一次 `["agy", "models"]`、builder 僅一次且 safe kwargs 原樣。
+另以 `KeyboardInterrupt`／`SystemExit` 參數化驗證仍拋出，不能擴成 BaseException。
+
+### D3：真正 runtime construction integration
+
+在 `tests/test_planning_runtime.py`，沿用現有 safe-runner 測試模式，
+monkeypatch `planning_runtime.load_model_identities` 返回兩列 isolated registry：
+非 AGY primary（例如 codex/primary）與 canonical AGY planning identity。
+兩種 roster 順序都走真 `build_production_planning_runtime`，不 mock 真 probe。
+fake 非 AGY runner 回原 compact JSON echo；fake AGY discovery 回 canonical
+model。probe builder alias 拋 `ValueError`；禁止任何 real subprocess/model。
+
+顯式新 `tmp_path / "probe-cache.json"` 保證 miss，不讓既有 cached ready 掩蓋
+建構路徑。worktree 使用 test 暫存樹，registry 只在 monkeypatch 內替換；需要
+的 fingerprint/stat 依 test tmp fixtures 注入，不讀 credentials 內容。
+assert runtime.identity_registry 是該 registry、primary ready、AGY failed、
+builder 恰一次、沒有 AGY smoke invocation；再以既有 secondary selection
+介面確認 failed AGY 不符合 ready 候選。若只有該 AGY 異質候選，允許既有
+no-heterogeneous-planner 結果，不能為滿足測試而提升 ready。
+
+不改 cache get/put/flush 語意；只證本次 cache miss 上的 construction 例外。
+cache 命中原有 ready 值的 freshness、env fingerprint 等議題不在本 child
+新增行為範圍，不能拿本測試宣稱所有 cache 情境已被覆蓋。
+
+### D4：直接 launcher 仍 fail closed
+
+在 `tests/test_coordinator_agy_launcher.py` 使用既有 tmp-path launcher fixture，
+`PSC_JOB_RUNNER=direct`，patch `launcher._ARGV_BUILDERS["agy"]` 為拋
+`ValueError` 的 builder，fake Popen 只記次數、不建程序。
+`SubprocessLauncher("agy").launch(...)` 必須傳播 ValueError、零 Popen。
+必要 workspace helper 只回 test 暫存路徑，不觸及 operator／runtime。
+
+這驗證 probe-local catch 沒有變成全域吞錯，不聲稱未落地的 resolver 已能解析 env。
+timeout-only 後續須加入真非法 env 的 direct-launch 與 capability-probe regression，
+並保持 `json_envelope=False` 仍 resolve／帶 timeout。兩 child 不形成反向依賴：
+containment 的 code acceptance 由 fault-injection 證明，真 timeout env proof
+是下游 timeout candidate 的 acceptance，不拿它阻擋此 child 的先行實作。
+
+### D5：成功／既有失敗與 policy gates
+
+保留現有 model token、code fence、exact payload、safe argv、runner timeout
+與 error family 測試；新增測試不修改 oracle 以接納 ready 升格。
+focused suite 涵蓋三個修改 test 檔及 `tests/test_planning_job_argv_687.py`。
+focused RED 卡不先跑全庫 baseline、不讀無關歷史；全庫 gate 仍在後續 verify
+完整跑 `python3 -m pytest tests/ -q`，不得將 focused green 當全庫結果。
+
+future candidate 依 `preflight-ci` 執行 manifest 的 `openspec validate --specs`
+與 tests，並以 candidate 環境、checkout 外 cwd 執行
+`python3 -m paulsha_cortex.cli --help` 及
+`python3 -m paulsha_cortex.cli run work --help`。沒有新 CLI flag 也保留 R-16 smoke。
+本規劃不要求 live AGY session；沒有安裝／真模型 acceptance 的假宣稱。
+
+同步 operation docs、Unreleased 與 canonical fragment；真正 candidate commit
+完成後，带精確 PR title/body/labels/base main/head 跑 pinned policy-preflight。
+policy 版本=v1.0.17，CI workflow 的 engine pin為
+`9e7fabbf0b5eea9ad933fa6798764b723934a0b7`。root 已核對當下 local preflight
+skill engine `b281c5da` 的 `policy_check` bytes 與 CI pin 無差；兩者不是同一
+SHA／執行身份，bytes 比對也不代替 candidate 的真 policy gate。
+必查 R-09/R-16/R-19/R-22、R-14 symlink、R-20/R-23 pin；VERSION 非 release 不改。
+PR 文案 zh-tw，closing keyword 使用唯一 owner `Closes #851`；不自創豁免 label。
+
+### D6：owner／branch／dependency 與交付狀態
+
+work_id=`agy-probe-construction-containment`；原 author 規劃 branch 是
+`feature/agy-probe-construction-containment-planning`，不是 Manager builder branch。
+`manager.workflow_build_branch:3510-3528` 使用本 repo issue refs 最小正整數：
+root 已建立唯一 owner
+[#851](https://github.com/hamanpaul/paulsha-cortex/issues/851)，故正式 builder
+branch 固定為 `feature/851-agy-probe-construction-containment`。
+沒有 issue refs 時函式會退到 `feature/agy-probe-construction-containment`，
+但這個 fallback 不代表無 owner 也獲准派工。fragment 去掉 issue 前綴後固定為
+`changelog.d/agy-probe-construction-containment.md`，不使用另一 child 的名稱。
+
+root 回報獨立 `agy_containment_review` R1 內容審查及 fresh-reader 五題 PASS；
+registration 已由 root 納入本 PR 的 repository intake。
+狀態為 `awaiting-freeze`，不是已核准派工：仍須整合審查、
+完整 preflight、真 builder envelope 與 Cortex Yellow plan-review gate，
+通過後凍結精確 source revisions/base，再由合法 route build。
+此 child 不依賴 timeout resolver；若原 AGY deadline 不足，route 決定仍由 root
+依已授權來源裁決，不能自行 fallback 或重跑模型。
+
+timeout-only 四檔已 blocked-dependency。其解除需要 root 確認 containment
+candidate 通過、timeout 的預定 base 及實際 runtime 已含相同保護；安裝和舊 run
+正式 retry 是另外的 operation authority，不在本四檔 authoring 中執行。
+
+## Current integration gate
+
+目前整合 branch 為 `feature/refine-agy-dependencies-20260907`，base 為 #852 merge
+`984fce5b`；本 PR 登錄 #851 三件套，未 freeze、未 start。#851 的現行文件仍
+completeness=true、6 Yellow，surface-only gate 的 envelope bypass 不代表
+真 builder capability，正式 gate 待 root 的合法 start 流程。
+root 已把 #824 從母 #823 mapping 移除，但故意不登錄 timeout child；
+其目前帶 marker 的 plan 不完整、4 Yellow，不得誤用作者原 6 Yellow 當下游 ready。
+marker 不能阻止所有 start 路徑：incomplete start 可能進 brainstorm，故保持
+不登錄／不 auto-label／不 start #824，待本 child 產品、base及 loaded runtime
+保護均確認後再由 root 解除和正式登錄。

--- a/docs/superpowers/specs/agy-probe-construction-containment-spec.md
+++ b/docs/superpowers/specs/agy-probe-construction-containment-spec.md
@@ -1,0 +1,121 @@
+---
+status: accepted
+work_item: agy-probe-construction-containment
+authority_state: repository-intake-unfrozen
+owner_issue: "hamanpaul/paulsha-cortex#851"
+registration_state: repository-intake
+dispatch_readiness: awaiting-freeze
+---
+
+# AGY probe argv 建構例外 containment 規格
+
+## Requirements
+
+本 child 修正 `probe_agy_capability()` 的既有 smoke 失敗邊界，使 argv 建構
+失敗只令 AGY probe 不可用，不中斷 ready 非 AGY primary 的 runtime 建立。
+這是 `agy-print-timeout-only` 的前置依賴；timeout child 不可先派。
+唯一 production 修改檔為 `paulsha_cortex/coordinator/model_identities.py`。
+
+唯一 owner 已由 root 建立為
+[#851](https://github.com/hamanpaul/paulsha-cortex/issues/851)，root 已將其正式登錄
+納入本 PR 的 repository intake，尚未 freeze。root 回報獨立 reviewer
+`agy_containment_review` 的 R1 內容審查與 fresh-reader 五題均 PASS；
+`status: accepted` 與這些 PASS 不代表 Cortex 正式 plan-review gate、
+builder 封套、完整 preflight 或 frozen authority 已完成，更不授予派工權。
+目前狀態為 `awaiting-freeze`；不得冒用 #824 或 #823 的 source owner。
+
+### Current integration gate
+
+本整合工作樹已從 #852 merge `984fce5b` 快轉；#851 的 registration 狀態為
+`repository-intake`、authority 為 `repository-intake-unfrozen`，是本 PR 的
+登錄內容，不等於 runtime 已 claim、產品已實作或已安裝。當前文件在 runtime
+`79ba6447` 的真 completeness=true、6 Yellow；正式 gate／freeze 仍待 root
+完成整合審查、full preflight 後以合法 start 流程處理。
+下游 #824 刻意不登錄、不加 auto label、不 start；其 marker／metadata
+不能單獨保證零派工，細節見 timeout 四檔的 current integration gate。
+
+### R1：建構納入既有 smoke 失敗邊界
+
+把 `build_agy_argv(...)` 呼叫移入目前包住 `process_runner(argv, **common)`
+與 `_process_fields()` 的同一個 `try`，不新增 runtime 外層 catch。
+建構拋出 `Exception` 子類時，沿用
+`_failed_agy("smoke-failed", probe_exception_diagnostic(exc))` 回傳。
+不得改動 discovery 的 models-probe-failed 邊界或捕捉 `BaseException`。
+
+### R2：失敗不升格、診斷不擴張
+
+建構失敗的 `CapabilityProbe` 必須為 `ready=False`，executor/model/domain
+維持既有 `_failed_agy` 身分，reason 精確為 `smoke-failed`。
+plain `ValueError` 的 diagnostic 為 `ValueError`；即使其 message 帶任意
+marker，也不新增 `str(exc)`、env 原值、credentials 或完整 prompt 回顯。
+保留既有 diagnostic helper 的有界 detail 投影與失敗分類，不新增 taxonomy。
+models discovery 可已被呼叫一次，但 argv 建構失敗後不得呼叫 AGY smoke runner。
+
+### R3：非 AGY primary runtime 可建立
+
+對 isolated roster 內 ready 非 AGY primary 加 canonical AGY planning identity，
+使用真正 `build_production_planning_runtime()`、真 AGY probe 函式與 fake runner；
+在 cache miss 下令 argv builder 拋 `ValueError`，runtime 必須成功回傳，primary
+probe 仍 ready、AGY probe 仍 failed。兩种 roster 順序都要測，避免僅證明已完成
+primary probe 的一種先後關係。AGY 不得因此被挑為 ready secondary。
+
+測試必須提供 `probe_cache_path=tmp_path / "probe-cache.json"`，使用新 cache、
+暫存 worktree 與 isolated registry，不能讀寫實際 coordinator cache／registry。
+不要 mock 掉 `probe_agy_capability()`，否則無法覆蓋這次漏掉的例外邊界。
+這是 runtime construction 可用性，不保證一定有合格 heterogeneous secondary，
+也不代表後續 primary 真模型呼叫或整個 workflow 已成功。
+
+### R4：直接 launch 的拒絕邊界不變
+
+本 child 不修改 launcher，也不吞掉直接 AGY launch 的 invalid 設定錯誤。
+以 `_ARGV_BUILDERS["agy"]` fault injection 在直接 `SubprocessLauncher.launch()`
+令 builder 拋 `ValueError`，必須仍向 caller 傳播，且 Popen 呼叫為零。
+此 baseline 尚無 timeout resolver；fault injection 不冒充真非法 env 的驗證。
+後續 timeout child 必須再以真 resolver／非法 `PSC_AGY_PRINT_TIMEOUT` 驗證
+直接 launch 拋錯與 probe containment 兩條路徑，不得省略 env 或 probe timeout。
+
+### R5：既有成功與例外契約保持
+
+成功時保留既有兩段 discovery → smoke 流程、CLI token、prompt、
+`read_only=True`、`json_envelope=False` 及所有 argv 參數；common process
+timeout 預設仍為 45 秒，runtime 傳入的 `min(timeout_seconds, 45)` 不變。
+既有 models discovery 失敗、model-not-listed、smoke runner 例外／非零 rc、
+malformed-output、identity-mismatch 判準和 ready 身分核對保持。
+建構的 `KeyboardInterrupt`／`SystemExit` 必須繼續傳播，不吞 cancellation。
+不重試、不用預設值重建 argv、不忽略 env、不將 failed probe 變成 ready。
+
+### R6：可交付的 source／tests／documentation 範圍
+
+production 只改 `model_identities.py`；測試可改
+`tests/test_model_identities.py`、`tests/test_planning_runtime.py`、
+`tests/test_coordinator_agy_launcher.py`。同步 `docs/unified-work-lifecycle.md`
+的 probe 失敗邊界說明、`CHANGELOG.md [Unreleased]` 及唯一 fragment
+`changelog.d/agy-probe-construction-containment.md`。
+canonical build branch 由 Manager 從唯一 owner #851 與 work_id 推導，固定為
+`feature/851-agy-probe-construction-containment`，不得自行改 slug。
+這是正式 builder 的預定名稱；本 PR 已有 registration，不代表該 branch 或 run 已建立。
+
+### R7：驗收與 dependency 解除
+
+先 focused RED，再最小 source change 與 focused green；最後按 repo policy
+執行 full tests、OpenSpec、CLI help smoke、PR-aware policy 與 exact-head review。
+任何 required gate 不通過不得聲稱完成。測試均為 offline fake，不啟動額外模型。
+root 核對此 child candidate／base 及實際使用 runtime 已含 containment，才能
+解除 timeout-only 的 dependency block；merge、部署與重試各自需另行授權和證據。
+原 author 時期只新增四份規劃文件，沒有產品、issue、registration、commit、push
+或服務操作；目前本 PR 的 registration 由 root 負責，本文件整合不代行該操作。
+
+## Exclusions
+
+不修改 `launcher.py`、`planning_runtime.py`、`gate_ledger.py`、probe cache
+schema／fingerprint／TTL、registry、Manager、job runner 或 session lifecycle。
+#823 的 `start_new_session` 留母範圍；#824 的 duration resolver 與 Go range
+全部留 timeout child。若須改第二個 production 模組，先停下回 root 重裁決。
+
+## Sizing declaration
+
+依 [#208](https://github.com/hamanpaul/paulsha-cortex/issues/208) 原 rubric：
+domain=0（單 production 模組／同一 probe 資料流），state=0（只改既有 local
+exception-to-result 控制流）。本 probe 原本會呼叫 runner，不把它宣稱為純函式；
+本次不新增 schema、持久化、cache protocol、concurrency、atomicity 或 migration。
+跨 caller 的 regression 測試不等於跨 production 模組改動，但仍完整列入驗收面。

--- a/docs/superpowers/workstreams/agy-print-timeout-only/report.md
+++ b/docs/superpowers/workstreams/agy-print-timeout-only/report.md
@@ -1,0 +1,188 @@
+# AGY timeout-only 規劃與證據報告
+
+日期：2026-09-07。原 author 時期僅交付四份 planning 文件，未註冊、freeze、
+派工、實作、commit／push；這些「僅四檔／未操作registration」描述屬歷史。
+目前root已將文件納入本PR整合，但刻意不登錄timeout child，#824產品尚未修好。
+
+目前 dispatch readiness：**blocked-dependency**，不得先派。
+新增 prerequisite=`agy-probe-construction-containment`；R1 fake 反證已成立，
+不是可直接接受的殘餘風險。containment 完成且 root 核對 base／實際 runtime
+保護證據前，下面 completeness／sizing／機械 gate 結果都不代表 dispatch-ready。
+dependency 的唯一 owner 已由 root 建立為
+[#851](https://github.com/hamanpaul/paulsha-cortex/issues/851)，其registration已由
+root納入本PR repository intake；這不改本child的#824 owner或核心契約。
+
+## Current integration gate
+
+本整合工作樹已從#852 merge `984fce5b`快轉。root已在本PR登錄#851三件套，
+並從母#823 mapping移除#824；但故意不登錄`agy-print-timeout-only`，owner
+issue #824仍OPEN。root當次live核對#824/#851 labels均空且無相關run；這是
+該時點的觀測，不是不會產生run的永久保證。
+
+runtime `79ba6447` 忽略workflow文件的`dispatch_readiness`／`dependency_issues`，
+`depends_on`只在舊slice lane起作用。root在todo加入真正的未決問題marker，
+本author保留其逐字內容，純文件實算如下：
+
+| 輸入狀態 | 真 completeness／plan assessment | 舊runtime分數 |
+|---|---|---|
+| 原author完整三件套（歷史） | true／accepted | 6 Yellow |
+| 當前磁碟保留root marker | false／blocking-decision、missing kind=plan | 4 Yellow |
+| 僅在記憶體移除marker（控制組） | true／accepted | 6 Yellow |
+
+當前詳細分數是0+0+2+0+2=4；下降來自舊反向stability公式，不是減少0／0／7
+宣告或驗收面。surface-only `plan_review_gate`和Manager wrapper仍可能ready，
+envelope仍bypass；不等於真正completeness通過。更重要的是incomplete start
+可能進brainstorm，故marker／metadata本身不能證zero-spawn。
+
+當前操作邊界是root保持不登錄timeout child、不加`cortex:auto-on-going`、
+不start #824；新work auto路徑需要該label。待#851產品驗收、timeout預定base
+及loaded runtime保護均核對後，才可解除marker、重新接受並正式登錄。
+本輪沒有解除block，沒有start／模型／現場操作，也不改resolver或tests契約。
+
+## Scope 裁決
+
+新 child=`agy-print-timeout-only`；#824 是來源，#823 留既有
+`launcher-session-and-timeout` 母範圍。原author時期未更動母todo、
+`.cortex/work-items.yaml`、GitHub issue或runtime；目前root已另做本PR登錄／
+mapping整合，本八檔metadata工作沒有代改它們。唯一預定production是`launcher.py`；它原本就
+import `gate_ledger`，既有 `_gate_timeout` 可滿足 default/fallback，無須第二個
+production 模組。若後續發現需修改 helper，scope 必須先重裁決。
+
+R1 發現的另一模組缺陷獨立處理：`model_identities.py:1071-1078` 在 try 外
+呼叫 AGY argv builder；新增 timeout env 驗證會使 `ValueError` 穿透
+`planning_runtime.py:1664`，影響 ready 的非 AGY primary。新 dependency 的
+唯一 production 模組是 `model_identities.py`，將 construction 納入既有
+smoke try／`_failed_agy` 回傳。timeout-only 保持 launcher-only、所有驗證及
+probe timeout 值都保留，不改假值／預設值掩蓋錯誤；dependency owner票 #851
+已由root建立且registration已納入本PR；不代表其產品／loaded runtime已通過。
+
+dependency 本身用 builder fault injection獨立驗收，不等待本child的resolver。
+本timeout candidate仍須補真非法env的direct launch／probe雙路徑與fresh tmpcache
+的非AGYprimary runtime regression；已同步spec R7、design D5、todo T8。
+不以dependency的fake結果冒稱真env已測，也不忽略probe值或跨模組偷修。
+
+原 author 規劃 worktree 從遠端 main 的
+`25c9a4e4040476523d0bb5f2132236f87b8d65f8` 建立；分支
+`feature/824-agy-print-timeout-only-planning`。先 inventory，僅在新 worktree
+執行 `git pull --ff-only origin main`，結果 Already up to date；既有 operator／
+runtime-main 的工作內容保持不變。
+
+## 為什麼需要此 child
+
+#831 run `workflow-edbde4754ca662936aea` 的兩筆 AGY TDD job，各有自己的
+print timeout；不是已證實的 quota 故障，也不是 planning_runtime 的 120 秒。
+
+| job | AGY 工具／測試證據 | 終局 |
+|---|---|---|
+| `wf-30ca23c08c-tdd-red-42` | 全庫 baseline 18:40:08 開始；task log 停在 95% | 18:43:19 print timeout，1496 polls |
+| `wf-30ca23c08c-tdd-red-44` | baseline 5648 passed、44 skipped、173 subtests，201.33秒；18:52:54 完成 | 18:53:20 print timeout，1495 polls |
+
+兩筆在 timeout 前皆未寫入 tracked RED test。原 AGY 1.1.27 的預設為五分鐘；
+現行 runtime HEAD `79ba6447` 的 `build_agy_argv` 未傳 timeout flag。
+root 可另裁決 focused TDD 執行順序減少浪費，但這不代表已修正 deadline。
+
+僅以工作識別與日期保存上述摘要，不將原始 session、thinking、credentials、
+個人路徑或完整 stdout 帶入 repo。
+
+## Source 與母文件對照
+
+- [#824](https://github.com/hamanpaul/paulsha-cortex/issues/824)，初次核對的更新
+  時點為 `2026-09-07T10:01:44Z`；當時依六項 AC 整理 spec R1–R7／todo T1–T9。
+  root 後續正式修訂，最新唯讀 readback 為 `2026-09-07T13:40:04Z`。
+- `launcher.py:1179-1249`：AGY argv builder；`:1918` 為 builder kwargs 呼叫，
+  `:2257`／`:2262` 為 spawn；`gate_ledger.py:331-339` 為現有 fallback。
+- 原author再次讀operator母todo時，它已包含「非法gate重用helper fallback」
+  與「不能以 help 作 duration proof」兩项更正。本 child 獨立固定同語意，沒有
+  反向改母 scope；不把較舊版本的矛盾當成當下尚未修訂的事實。
+- root 查證 `manager.workflow_build_branch:3510-3528` 固定使用最小 issue 與
+  work_id，因此本 child 的 build branch 必為 `feature/824-agy-print-timeout-only`。
+  已修正原規劃任意更名的真缺口；canonical fragment 改為
+  `changelog.d/agy-print-timeout-only.md`，母 `launcher-session-and-timeout`
+  fragment 責任留 #823，不建立兩份重複 fragment，不改 Manager。
+- 歷史時點：本報告初稿時 #824 AC5 仍為舊 fragment，root 已裁決但尚未更新
+  遠端。此待辦已由 root 於 `2026-09-07T13:40:04Z` 正式完成：AC5 使用本 child
+  fragment／branch，AC6 使用 sentinel proof，另明列 fullmatch／range 及 #851
+  dependency。本author當時已唯讀核對；目前root已移除母mapping的#824，但
+  刻意不登錄timeout child，block不解除。沒有把issue更新冒充產品／runtime完成。
+
+## 原 author Sizing 證據（歷史）
+
+[#208](https://github.com/hamanpaul/paulsha-cortex/issues/208) 的真 rubric：
+domain 0=單模組／單資料流；state 0=純函式／local state。本 child 明列一個
+production 模組、既有 env 讀取與 local argv，沒有新 schema／持久化／migration／
+concurrency，故兩者都為 0；pytest／docs／changelog 不偽裝成 production 模組。
+
+`work_bridge.current_sizing_snapshot` 固定使用 R-09/R-16/R-19；實際載入現行
+feature-oneshot 得核心 gate=4、card=11、persona binding=11。完整 spec/design/plan 在舊
+`compute_sizing_score` 仍為 spec_stability=2；門檻沿用
+`claim.sizing_band` 的 Green≤3、Yellow≤6。原author以該runtime實算完整文件：
+
+```json
+{"domain_breadth":0,"state_consistency":0,"acceptance_surfaces":2,"spec_stability":2,"orchestration":2,"total":6,"band":"yellow"}
+```
+
+這不是要求 runtime 套用 #831 的尚未落地新算法，也不省略任何 acceptance
+surface；Yellow 強 plan review 與 owner／authority 裁決仍獨立必要。
+四檔作者提供的 accepted frontmatter 不等於 reviewer 已PASS或work已授權。
+本段6 Yellow只保留為歷史；當前帶marker的磁碟真狀態與記憶體控制組見current
+integration gate，不可沿用此數字宣稱目前完整或可派。
+
+## CLI parser 實測
+
+使用已安裝 AGY 1.1.27；無憑證 env、無 prompt、stdin EOF，timeout flag 後加
+`--cortex-timeout-parser-sentinel`，完整讀完 stderr保留退出碼，全部 exit 2：
+
+| value | 第一個錯誤 |
+|---|---|
+| `abc` | `time: invalid duration` |
+| `2400` | `time: missing unit in duration` |
+| `2400s` | unknown sentinel flag |
+| `9223372036s` | unknown sentinel flag |
+| `9223372037s` | `time: invalid duration` |
+
+這是 R1 上界的已安裝 parser 證據。#824 所列 `--print --input-format ...`
+命令在這個已安裝版本會先把下一 flag 當 prompt，所有 value 都得到相同 prompt
+形狀錯誤，不能據此判斷 duration 是否解析；child 使用可區分的 sentinel 負控制。
+`--help` 一樣不能使用。曾嘗試 explicit 空 print 的合法值會進 startup，因
+HOME=/dev/null 不可建檔而退出；該次不計為純 parser proof，沒有真實 prompt或
+模型呼叫，後續只採用在 flag parser 必停的控制形狀。
+
+後續獨立佐證：root 回報於 2026-09-07 21:38（Asia/Taipei）對 AGY 1.1.27
+再跑同五列離線控制，全部 exit 2；`2400s` 與 `9223372036s` 的實際 first line
+皆為 `flags provided but not defined: -cortex-timeout-parser-sentinel`。
+這是 root 的再驗證，不是本 author 本輪重跑 CLI；舊 print 形狀不能作 proof
+的限制也已正式寫入更新後 #824 AC6，不再是尚待遠端同步的建議。
+
+## 原 author 規劃檢查（歷史）與後續 gate
+
+原author使用外部cwd、Python `-B`與明確runtime import path，確認載入
+`79ba644780bf1c697c722ac24a297e7d02416100` 的實際模組；沒有寫入 bytecode。
+
+- spec/design/plan 三件套 `assess_planning_completeness.complete=true`，三份均
+  accepted，missing kinds 與 blocking markers 皆空。
+- `current_sizing_snapshot` 直接讀本四檔中的三份規劃與 runtime combo，回
+  `(6, "yellow")`，詳細五維與上列一致。
+- `_evaluate_yellow_plan_review` 走實際 Manager wrapper，completeness 與
+  contract_compatibility 通過；另外將 R-22 加入契約檢查也通過。
+- envelope 欄位明示 `bypass: envelope_unavailable`，因本輪沒有指定真 builder
+  profile；不是 builder capability 已證實，也不是獨立強 plan review 已PASS。
+  root 定案模型後仍需帶真 profile 與 authority 做正式 gate。
+- 初次機械檢查抓到 Tasks 首行缺 `documentation`，已在 T6 首行補正並重跑
+  上述檢查；沒有以降低 artifact_classes 或排除 policy 的方式繞過。
+- 原author四份新檔逐一用 `git diff --no-index --check /dev/null <file>`驗whitespace；
+  當時tracked diff為空、只有四份預期新文件，無個人絕對路徑或未定marker。
+  目前root已新增真正marker，歷史complete=true結果不能代表當前磁碟。
+
+原author未跑無產品差異的全庫測試或policy-preflight，不聲稱policy PASS。
+本輪八檔整合仍不代跑root的fresh integration review／full preflight，root將在
+本PR另期完整執行；其必要性已明列todo。
+
+實作完成後以 `preflight-ci` 規範跑 manifest 的 `openspec validate --specs`
+及 `python3 -m pytest tests/ -q`；policy版本為v1.0.17，CI workflow 的引擎 pin為
+`9e7fabbf0b5eea9ad933fa6798764b723934a0b7`。root 另回報當下 local preflight skill
+engine 為 `b281c5da`（v1.0.17 release-ledger merge），並已用 git diff 核對
+`policy_check` bytes 與 CI pin 無差；兩者不宣稱為同一 SHA，本 author 本輪
+沒有另跑 local engine 或把此比對當 policy PASS。提交 fragment 後帶真正 PR title、
+body、labels、base main、implementation head 驗R-09與其餘PR-aware規則；
+單純裸跑policy的零fail不採信。最終 exact-head審查與遠端CI、threads、merge
+各自驗證；部署／既有run正式retry另由root依既有授權安排。

--- a/docs/superpowers/workstreams/agy-print-timeout-only/todo.md
+++ b/docs/superpowers/workstreams/agy-print-timeout-only/todo.md
@@ -1,0 +1,59 @@
+---
+status: accepted
+work_item: agy-print-timeout-only
+authority_state: proposed-unregistered
+dispatch_readiness: blocked-dependency
+depends_on:
+  - agy-probe-construction-containment
+dependency_issues:
+  - "hamanpaul/paulsha-cortex#851"
+domain_breadth: 0
+state_consistency: 0
+invariant_count: 7
+artifact_classes:
+  - source
+  - tests
+  - documentation
+---
+
+# AGY print timeout 單獨交付工作清單
+
+## Current integration gate
+
+#851已由root納入本PR repository intake，但其產品／base／loaded runtime前置
+未完成；#824已移出母#823 mapping、故意不登錄timeout child，owner issue仍OPEN。
+下方root marker逐字保留：當前真completeness=false、plan blocking-decision、
+total4 Yellow；原author完整6 Yellow與記憶體移除marker的6僅是歷史／控制組。
+runtime79不以dispatch_readiness／dependency_issues阻擋workflow，depends_on只舊
+slice lane使用；surface-only plan_review_gate仍ready／envelope bypass，而且
+incomplete start可能進brainstorm，故metadata／marker不保證zero-spawn。
+root保持不登錄、不加cortex:auto-on-going、不start #824；前置真完成後才解除
+marker、重接受並正式登錄。0／0／7與R1–R7、Tasks的resolver／tests契約均不變。
+
+## Open Questions
+
+- #851 的產品驗收、預定 base 及實際 loaded runtime 保護尚未完成；須由有權 operator 核對證據並正式解除依賴後重接受。本 marker 未解除前，#824 不得進入實作／派工。
+
+## Tasks
+
+- [ ] **T0 dependency/tests**：本 child 不可先 freeze／dispatch；先完成 `agy-probe-construction-containment` 的 argv-construction try 邊界修正與 fake regression，root 核對預定 base／實際 runtime 已含保護後才解除 block；保留 R4 probe 的 timeout resolve 與全部非法 env／Go range 驗證，不在此 child 改 `model_identities.py` 或忽略 probe 值。
+- [ ] **T1 tests/RED**：以本 child spec R1–R7 與 design D1–D5 為需求，先在 `tests/test_coordinator_agy_launcher.py` 新增預設／override／exact flag 的 focused RED tests；確認舊 launcher 缺 flag 或 resolver 的真實失敗，再提交 RED candidate；此卡不先重跑全庫 baseline，不探索無關歷史，不修改 source 或 pinned plan。
+- [ ] **T2 source/resolver**：只改 `launcher.py`，新增 `AGY_PRINT_TIMEOUT_ENV`、600 秒 buffer／9223372036 秒上界、canonical duration 驗證與 `resolve_agy_print_timeout`；env strip 後 ASCII digits only／容許前導零，顯式空白／零／非法／超界一律 `ValueError`；未設定時直接重用 `gate_ledger._gate_timeout(env)`，invalid gate 仍 fallback，最後推導結果才檢查 Go 上界。
+- [ ] **T3 source/argv**：`build_agy_argv(print_timeout: str | None = None)` 對 None 自行 resolve，顯式 keyword 做 fullmatch 與上界驗證；所有 AGY 形狀、包含 `json_envelope=False`，於 JSON flag 後／model 前恰加入一組 timeout；正式 `SubprocessLauncher.launch` 對 AGY 顯式傳入 resolver 值，非法設定在 Popen 前失敗。
+- [ ] **T4 tests/matrix**：涵蓋 spec R2/R3 的完整值矩陣、最大／最大+1、derived gate 9223371436／9223371437、5000-digit 值、Unicode／符號／浮點／尾 newline／非字串；以 fake gate helper 驗證重用與 override priority；保留 helper 本體不變，若需修改則停止回 root。
+- [ ] **T5 tests/shapes**：更新 AGY 七個 direct shape cases、兩個 exact argv lists、probe opt-out case；保留前綴 slices／permission／scope／JSON assertions；用 fake builder 與 fake Popen 分別證 kwargs 和最終 script，測 unset=2400s、override=900s、invalid 不 spawn；非 AGY 四個 builder 維持無 timeout flag，不改 #823 的 Popen/session 行為。
+- [ ] **T6 documentation/CLI/docs**：candidate evidence 記錄 AGY 版本及 D4 無憑證／無 prompt／未知 sentinel 的五列 parser 負控制；不是用 help exit0當 parser proof；更新 `docs/unified-work-lifecycle.md` 的 AGY timeout 設定／範圍／override與gate fallback語意，再從 checkout 外以 candidate Python 環境實跑 `python3 -m paulsha_cortex.cli --help`、`python3 -m paulsha_cortex.cli run work --help` 並記退出碼；無新增 Cortex CLI flag也需保留 help smoke。
+- [ ] **T7 changelog/docs**：實作 candidate 新增並 commit `changelog.d/agy-print-timeout-only.md`（root 已定案的 child fragment，內容只寫 timeout），同步 `CHANGELOG.md [Unreleased]`；canonical build branch 依 Manager 固定為 `feature/824-agy-print-timeout-only`，不可自行換名；root 已於2026-09-07T13:40:04Z正式同步 #824 AC5 的名稱與 branch（並更新AC6／range／#851 dependency），registration仍待另期進件、block不解除；母 `launcher-session-and-timeout` fragment 責任留 #823，不產生重複 fragment；檢查 README/docs 引用、symlinks、VERSION與policy pin不變。
+- [ ] **T8 tests/policy**：containment base上用真resolver／非法PSC_AGY_PRINT_TIMEOUT證direct launch仍ValueError零Popen、真probe回failed且無smoke，再以fresh tmpcache＋真runtime constructor證ready非AGYprimary仍可用，不只沿用dependency的fault injection；focused 執行 `tests/test_coordinator_agy_launcher.py`、`tests/test_coordinator_launcher.py`、`tests/test_planning_runtime.py`、`tests/test_planning_job_argv_687.py`、`tests/test_model_identities.py`、`tests/test_trust_root_agy_builder_grant_805.py`；再執行全 `python3 -m pytest tests/ -q`、manifest `openspec validate --specs`、`git diff --check`，保存實際結果；不將 focused RED/green 冒充 Manager 全庫 pytest gate 結果。
+- [ ] **T9 policy/CLI/交付**：按 `preflight-ci` 以精確 PR title/body/labels/base/head 跑 pinned `policy-preflight`，另核對 R-09/R-16/R-19/R-22、R-14 symlink、R-20/R-23 pin；只在 candidate commit 完成後以 PR context 驗证 R-09。root裁決唯一owner及authority重綁、Yellow強plan review通過後才freeze；final review須exact candidate，遠端CI／threads／mergeability各自確認，保留 #823 母範圍。
+
+## Boundary
+
+- dependency `agy-probe-construction-containment` 的唯一 owner [#851](https://github.com/hamanpaul/paulsha-cortex/issues/851) 已由root建立且納入本PR repository intake；本child仍屬#824、刻意不登錄且blocked-dependency，不以依賴內容審查PASS代替產品／runtime保護完成。
+- Child 需求來源：[#824](https://github.com/hamanpaul/paulsha-cortex/issues/824)；母 work item `launcher-session-and-timeout` 的 #823 不在此交付。
+- Spec：`docs/superpowers/specs/agy-print-timeout-only-spec.md`；design：`docs/superpowers/specs/agy-print-timeout-only-design.md`。
+- 唯一 production 寫入：`paulsha_cortex/coordinator/launcher.py`；測試、操作文件及 changelog 允許同步，registry/schema/loader/installer/job_runner/gate_ledger/CLI production皆不改。
+- 原author時期僅四份planning文件，未操作產品、issue或registration；目前root另負責本PR登錄，本八檔整合不代行registration／commit／push／服務／runtime／模型session操作。
+- R1 已證 argv construction 例外可穿透非 AGY primary runtime 建立；這是 active dependency blocker，不以6 Yellow或機械plan-review通過宣稱ready。
+- 切面依#208真rubric仍domain=0／state=0；原author完整三件套與記憶體移除marker控制組為6 Yellow，當前帶marker的真狀態為不完整4 Yellow，不能派工；不使用#831候選算法，不改band門檻。
+- `invariant_count: 7` 對應 spec R1–R7；`artifact_classes` 列 source、tests、documentation，未隱藏 CLI proof／policy／changelog acceptance surfaces。

--- a/docs/superpowers/workstreams/agy-probe-construction-containment/report.md
+++ b/docs/superpowers/workstreams/agy-probe-construction-containment/report.md
@@ -1,0 +1,128 @@
+# AGY probe containment 規劃報告
+
+日期：2026-09-07。原 author 時期只交付 spec／design／todo／report 四份規劃，
+未註冊、freeze、dispatch、實作、commit、push、merge或安裝；該「僅四檔、
+未操作registration」描述保留為歷史，不再當成本 PR 的當前登錄狀態。
+root 已建立唯一 owner [#851](https://github.com/hamanpaul/paulsha-cortex/issues/851)，
+並將 registration 納入本 PR：`repository-intake`／`repository-intake-unfrozen`。
+產品與 Cortex 正式 gate／freeze 仍未完成，本 author 的整合只修改八份文件。
+
+目前為 `awaiting-freeze`。root 全文讀回四檔與 source，並回報獨立 reviewer
+`agy_containment_review` 的 R1 內容審查 PASS；此 PASS 歸因該 reviewer，
+不是本 author 自行批准，也不代替真 builder 封套、Cortex 正式 gate、完整
+preflight 或 frozen authority。root 另回報 fresh-reader 五題 PASS，將再做
+fresh integration review 與 full preflight，之後才由合法 start 路徑處理正式 gate。
+#851 原 author 時期唯讀 readback：OPEN、updatedAt=`2026-09-07T13:32:04Z`，
+當時產品 AC 均未完成；本輪未再操作 issue。
+
+## Current integration gate
+
+整合工作樹已從 #852 merge `984fce5b` 快轉，root 已在本 PR 登錄 #851 三件套。
+當前用 runtime `79ba6447` 純文件函式重算仍 complete=true、6 Yellow；
+正式封套／plan review／freeze／start 不能由文件 frontmatter 或機械 bypass 代替。
+root 當次 live 核對 #824／#851 labels 均空且無相關 run；這是該時點的觀測，
+不是永久不會派工的不變量。本 author 本輪未呼叫 start／模型或修改現場。
+
+下游 #824 已由 root 從母 #823 mapping 移除，故意不登錄 timeout child。
+其現有 marker 令 true completeness=false、plan blocking-decision、4 Yellow；
+surface-only gate 仍可能 ready，incomplete start 也可能進 brainstorm。
+因此 metadata／marker 不保證zero-spawn；root保持不登錄、不auto-label、不start
+#824，待本child產品、預定base及loaded runtime保護完成才解除並正式登錄。
+
+## 問題與切面
+
+R1 獨立 reviewer 已由 root 的 fake 反證核實：timeout-only 的 R4 要求 probe
+`json_envelope=False` 一樣呼叫 resolver；然而既有
+`model_identities.py:1071-1078` 在 smoke try 外建構 argv，非法設定
+`ValueError` 可以從 `planning_runtime.py:1664` 穿透，連 ready 非 AGY primary
+都無法建立 runtime。這是實質前置缺陷，不是可直接接受的殘餘風險。
+
+原 author 已將 timeout-only 四檔標記 `blocked-dependency`，depends_on 為本 child；
+這些宣告不是現行workflow lane的機械依賴閘，當前控制見上段。
+timeout-only 仍只改 launcher，全部 env／Go range 驗證和 probe timeout 值保留。
+本 child 唯一 production 是 `model_identities.py`，只移動 argv assignment
+到既有 smoke try，沿用 failed result與bounded diagnostic，沒有第二個prod模組。
+
+現有呼叫鏈的 source 證據在規劃 base與現行 runtime一致：
+
+- `model_identities.py:16` 的 imported builder alias 是真 fault injection seam。
+- `model_identities.py:717` 的 `_failed_agy` 保持 failed identity／reason。
+- `model_identities.py:956` 的 `probe_exception_diagnostic` 不回顯 plain
+  ValueError message；本child不能另增raw env/error/prompt輸出。
+- `model_identities.py:1024-1101` 已有 discovery與smoke兩段例外邊界；只補後者。
+- `planning_runtime.py:1632-1683` 遍歷roster／cache miss時呼叫probe，並非只probe
+  primary；tests要兩種roster順序、真constructor和新tmpcache，不能mock整個probe。
+
+本報告原始證據是author時期已讀source與root提供的獨立fake反證；本輪沒有另跑產品fake
+reproducer或真正模型。未實作的 regression 全部明列todo，沒有宣称已測PASS。
+
+## 隔離與 authority
+
+原 author 時期先 inventory確認新path／branch不存在與既有worktrees，再從origin/main
+`25c9a4e4040476523d0bb5f2132236f87b8d65f8` 新開
+`feature/agy-probe-construction-containment-planning`。僅新worktree執行
+`git pull --ff-only origin main`，結果Already up to date；operator／runtime
+不切branch、不pull、不改內容。
+
+正式work_id=`agy-probe-construction-containment`，唯一owner已確定為#851。
+Manager固定以最小同repo issue與work_id導出
+`feature/851-agy-probe-construction-containment`；planning branch不是
+正式builder branch。canonical fragment固定
+`changelog.d/agy-probe-construction-containment.md`，不複製timeout或#823 fragment。
+這些是未來candidate要求，本輪沒有新增fragment或產品變更。
+
+## Sizing 與 dispatch 分離
+
+live核對 [#208](https://github.com/hamanpaul/paulsha-cortex/issues/208)，
+updatedAt=`2026-07-27T12:42:35Z`：domain0=單模組／單資料流，state0=純函式／
+local state。本切面單一production module、同一probe的local exception-to-result
+flow，沒有schema／backward compatibility的新資料契約、cache protocol、
+concurrency、atomicity或migration；故domain=0／state=0，不是把原subprocess
+probe聲稱為pure function。跨caller regression、docs與changelog完整保留。
+
+機械計算採現行runtime而非#831候選算法：core gates／policy rules／cards／
+persona bindings從真feature-oneshot讀取；完整文件仍按舊spec_stability公式。
+驗證結果在本報告後續段記錄，不以規劃者自行指定總分冒充runtime結果。
+
+## 原 author 純文件機械檢查（歷史）
+
+從checkout外cwd、Python `-B`、明確runtime import path執行；讀到的runtime
+HEAD為`79ba644780bf1c697c722ac24a297e7d02416100`，没有寫bytecode或cache。
+
+- `assess_planning_completeness`：complete=true；spec/design/plan三份accepted，
+  missing kinds、reasons、blocking markers均空。
+- 真`feature-oneshot`：必要core gates=4、cards=11、persona bindings=11；
+  `work_bridge.current_sizing_snapshot`回`(6, "yellow")`。
+- `compute_sizing_score`詳細值：domain=0、state=0、acceptance=2、stability=2、
+  orchestration=2；沿用`claim.sizing_band`的Green≤3／Yellow≤6，不改算法或門檻。
+- 真Manager `_evaluate_yellow_plan_review`與額外加入R-22的`plan_review_gate`
+  均ready=true，completeness／contract compatibility通過；envelope明示
+  `bypass: envelope_unavailable`。這不是builder封套已核准，也不是獨立強審PASS
+  的來源；獨立R1內容審查PASS另由root所委派的reviewer回報。
+- 原 author 工作樹的tracked product diff為空，只有四個預期untracked規劃檔；四檔逐一以
+  `git diff --no-index --check /dev/null <file>`驗whitespace，無個人絕對路徑。
+
+因此可用舊runtime做6 Yellow的正式進件準備；owner已建立、獨立內容R1已PASS，
+但仍是`awaiting-freeze`，不得直接dispatch。正式gate仍須以真builder封套核對
+0／0宣告與七組不變式，不能把先前機械bypass補寫成能力核准。
+
+## 驗證邊界與後續
+
+四檔使用`doc-coauthoring`做跨文件一致性與reader問題自查，使用`preflight-ci`
+把required CLI／changelog／full tests／PR-aware policy先列入Tasks首行。
+root既有獨立reviewer的R1內容審查已PASS，本輪不另外啟動模型；正式Cortex
+plan-review與freeze仍由root後續依法定流程完成。
+
+尚無產品candidate，故不跑full pytest或policy-preflight，也不宣稱它們PASS。
+future candidate按manifest跑OpenSpec/full tests、帶真PR context跑pinned
+v1.0.17 policy；fragment需commit，exact-head final及遠端CI／threads／merge
+各自驗證。accepted frontmatter與機械ready不等於獨立review或capability ready。
+CI workflow engine pin為`9e7fabbf0b5eea9ad933fa6798764b723934a0b7`；root核對
+local preflight skill engine `b281c5da` 的 `policy_check` bytes與CI pin相同，
+不代表同一SHA／執行身份或本PR已通過policy。
+
+containment code acceptance用offline fault injection覆蓋真exception boundary；
+直接AGY launch的ValueError仍傳播／零Popen。真非法timeout env的雙路徑proof是
+下游timeout child責任，不讓本child反向等待尚未落地resolver。
+本child通過後，root核對timeout預定base及實際runtime含保護再解除dependency；
+安裝和#831 retry不在本輪授權範圍。

--- a/docs/superpowers/workstreams/agy-probe-construction-containment/todo.md
+++ b/docs/superpowers/workstreams/agy-probe-construction-containment/todo.md
@@ -1,0 +1,46 @@
+---
+status: accepted
+work_item: agy-probe-construction-containment
+authority_state: repository-intake-unfrozen
+owner_issue: "hamanpaul/paulsha-cortex#851"
+registration_state: repository-intake
+dispatch_readiness: awaiting-freeze
+domain_breadth: 0
+state_consistency: 0
+invariant_count: 7
+artifact_classes:
+  - source
+  - tests
+  - documentation
+---
+
+# AGY probe 建構 containment 工作清單
+
+## Tasks
+
+- [ ] **T0 authority/policy**：唯一 owner #851 已由root建立、獨立 agy_containment_review R1內容審查與fresh-reader五題PASS；registration已納入本PR repository intake，整合審查／full preflight待root後續完成，確認 spec R1–R7、design D1–D6、source revisions與 exact base；指定真 builder envelope 並由合法start流程完成 Cortex Yellow plan-review gate 後才 freeze／dispatch，不沿用 #824/#823 的 source owner，不自行啟動模型或改現場。
+- [ ] **T1 tests/RED**：先在 `tests/test_model_identities.py` patch `model_identities.build_agy_argv` alias 拋 plain ValueError，fake discovery 回 canonical model，assert failed／smoke-failed／ValueError、原 identity、只有 models runner；舊 source 因例外外洩為真 RED。這張 focused RED 卡不先跑全庫 baseline、不修改 source／frozen plan。
+- [ ] **T2 source/containment**：唯一 production `model_identities.py`，只把原 `build_agy_argv(...)` assignment 納入既有 smoke try；沿用 except Exception 與 `_failed_agy("smoke-failed", probe_exception_diagnostic(exc))`，不改 prompt／kwargs／common timeout／payload驗證，不改 launcher／planning_runtime／gate_ledger／cache。
+- [ ] **T3 tests/runtime**：在 `tests/test_planning_runtime.py` 使用真 runtime constructor＋真 AGY probe、isolated registry與tmp worktree/cache、fake runner；兩種 roster順序均證 ready非AGYprimary仍可取得runtime、AGYfailed且不選為readysecondary、無AGYsmoke；patch alias而非mock整個probe，explicit新probe_cache_path避免cache假green。
+- [ ] **T4 tests/boundaries**：在 `tests/test_coordinator_agy_launcher.py` 以 direct模式fake `_ARGV_BUILDERS["agy"]` 拋ValueError、fake Popen零呼叫證直接launch仍傳播；model identity測試另證KeyboardInterrupt/SystemExit不吞、原成功/發現失敗/runner失敗/rc/payload/fence/token/diagnostic不變。此fault injection不冒稱真timeoutenvproof，下游timeout候選另須真env雙路徑測試。
+- [ ] **T5 documentation/CLI/docs**：更新 `docs/unified-work-lifecycle.md` 說明probe建構失敗只降AGYready、非AGYruntime可建但不保證異質secondary；以candidate環境checkout外cwd跑 `python3 -m paulsha_cortex.cli --help` 與 `python3 -m paulsha_cortex.cli run work --help` 並留退出碼，不啟動AGY模型／不改CLIproduction。
+- [ ] **T6 changelog/docs**：新增並commit唯一 `changelog.d/agy-probe-construction-containment.md`、同步 `CHANGELOG.md [Unreleased]`；canonical builder branch從Manager以唯一owner #851導出 `feature/851-agy-probe-construction-containment`，不能拿planning branch當正式head；保持VERSION、policy pin、agent symlinks不變，核對README/docs引用與zh-tw PR `Closes #851` closing link。
+- [ ] **T7 tests/policy/CLI**：先focused三個修改test檔＋`tests/test_planning_job_argv_687.py`；再完整 `python3 -m pytest tests/ -q`、`openspec validate --specs`、`git diff --check`。candidate commit後按preflight-ci帶真PR title/body/labels/base/head跑v1.0.17 pinned policy-preflight，核對R-09/R-16/R-19/R-22及R-14/R-20/R-23；不拿裸跑policy零fail或focused結果冒充full gate。
+- [ ] **T8 review/dependency**：exact候選final review、remote current-head CI、threads、mergeability分別留證；修好／merged／installed不混用。root核對此child的containment證據、timeout預定base與實際runtime後才解除timeout-only block；安裝／retry需另外authority。本child不等待尚未落地resolver才可驗收，也不替下游忽略env／probe值。
+
+## Boundary
+
+- Spec：`docs/superpowers/specs/agy-probe-construction-containment-spec.md`。
+- Design：`docs/superpowers/specs/agy-probe-construction-containment-design.md`。
+- 唯一 production 模組：`paulsha_cortex/coordinator/model_identities.py`；其餘只限上述tests／documentation／changelog同步。
+- 不修改 registry／schema／cache protocol／Manager／launcher／planning_runtime／gate_ledger／session；若需要第二個production模組先停止，回root重裁決。
+- domain=0指單模組／單probe流；state=0指這次只改local exception-to-result控制流，不把既有runner宣稱為純函式。
+- `invariant_count: 7` 對應R1–R7；source、tests、documentation全部列入，CLI／changelog／full policy也在Tasks首行，不為壓低band刪驗收面。
+- 唯一 owner [#851](https://github.com/hamanpaul/paulsha-cortex/issues/851) 已由root建立並納入本PR repository intake；原author時期僅四檔、未操作registration的敘述是歷史。本整合僅更新八份文件，不代行root登錄、commit、push、產品實作或現場操作；`awaiting-freeze`與獨立內容審查PASS不等於Cortex正式gate已通過。
+
+## Current integration gate
+
+#851 當前真 completeness=true、6 Yellow，宣告仍為0／0／7；獨立R1與fresh-reader
+PASS由root回報，正式gate／freeze待root完成本PR整合審查與full preflight後start。
+root刻意不把下游timeout child登錄或auto-label／start；其marker不是zero-spawn
+保證，需待#851產品、預定base與loaded runtime保護完成才可解除並正式登錄#824。

--- a/docs/superpowers/workstreams/launcher-session-and-timeout/todo.md
+++ b/docs/superpowers/workstreams/launcher-session-and-timeout/todo.md
@@ -3,15 +3,17 @@ status: accepted
 work_item: launcher-session-and-timeout
 ---
 
-# Headless launcher session 與 AGY timeout
+# Headless launcher session（保留 canonical work_id）
 
 ## Boundary
 
-- Issues：`hamanpaul/paulsha-cortex#823`／`hamanpaul/paulsha-cortex#824`。
+- 唯一 issue：`hamanpaul/paulsha-cortex#823`。#824 已拆至
+  [agy-print-timeout-only](../agy-print-timeout-only/todo.md)，其 timeout／parser／
+  值域及 #851 前置驗收均保留在 child；本工作不再實作或關閉 #824。
 - 相關但不在本票關閉：#813／#568／#826。開發基底必須包含已合併 #820 的
   AGY JSON terminal／argv 修正；不得覆蓋或重新引入舊 probe 形態。
-- 範圍限 `coordinator/launcher.py` 的兩個 headless Popen spawn 點及 AGY
-  `--print-timeout` 解析／傳遞，加相應測試與文件。
+- 範圍限 `coordinator/launcher.py` 的兩個 headless Popen spawn 點及
+  session／process-group 相應測試與文件；timeout 專用解析／傳遞已移交 child。
 - `start_new_session=True` 隔離 session／process group，**不隔離 systemd cgroup**；
   若 Manager unit 的 KillMode 涵蓋整個 control-group，重啟仍可能終止 direct job。
   本票不承諾 daemon restart survival，該要求交完整 refine plan 的 runner／instance
@@ -35,34 +37,15 @@ work_item: launcher-session-and-timeout
       `os.getpgid(proc.pid)==proc.pid` 且不同於測試 process group；向子 process group
       發 SIGTERM，5秒內 reap，測試進程仍存活。以 try/finally 清理本測試建立的子程序，
       不碰 Manager／真實 job。此案例只證明 process-group 隔離。
-- [ ] 實作前取得目前 AGY CLI version／help 的離線證據，執行
-      `agy --print-timeout 2400s --help` 或等價不啟動 prompt 的參數 parser smoke，
-      確認 Go duration `2400s` 被接受且 exit code 成功。若目前 CLI 不支援，停止
-      該旗標變更並將版本／錯誤交主流程裁決；不可透過付費模型 prompt 猜測旗標。
-- [ ] 新增 `resolve_agy_print_timeout(env: Mapping[str, str]) -> str`：顯式
-      `PSC_AGY_PRINT_TIMEOUT` 為正整數秒，優先且不 clamp；未設時採
-      `max(DEFAULT_GATE_TIMEOUT_SECONDS, PSC_GATE_TIMEOUT 或預設) + 600`，
-      格式如 `2400s`。顯式空字串／非整數／0／負數拒絕；未設 override 時，非法
-      PSC_GATE_TIMEOUT 同樣拒絕，不能默默壓低 gate 時間。
-- [ ] `build_agy_argv` 新增 `print_timeout: str | None = None`；None 時自行依 env
-      resolve，其他顯式值也驗證符合已證實的正 duration 契約。所有 planner／reviewer／
-      builder／unsafe／write-forbidden／commit-required argv 形態都帶此旗標；
-      `SubprocessLauncher` 對 agy 顯式傳入 resolve 結果，避免不同入口語意分歧。
-- [ ] `tests/test_coordinator_agy_launcher.py` 的7個直接 argv shape 測試加入
-      timeout 斷言，並守住 #820 的 JSON flag。兩個 env 都 unset→2400s；
-      gate=900→2400s、gate=3600→4200s、override=900→900s；非法 override／gate
-      與顯式 duration 負例均拒絕；合法 override 優先、不受未採用的 gate env 干擾。
-- [ ] launch 傳遞測試沿 `test_agy_commit_required_launcher_emits_real_scoped_git_dirs`
-      的 recording fake Popen，direct script argv 含 `--print-timeout 2400s`。
-      不誤用只 stub `_ARGV_BUILDERS`、未記錄 Popen argv 的測試當 end-to-end 證據。
 - [ ] 搜尋並更新固定 keyword-only fake Popen 以接受 start_new_session 或 **kwargs：
       基底約為 `tests/test_coordinator_launcher.py` 19處及
       `tests/test_headless_claude_hook_506.py` 3處，數量以實際 base 重新確認；保留
       原始安全斷言。已接受 **kwargs 的 `_RecordingPopen` 不無謂改寫。
-- [ ] codex／copilot／claude／cg argv 均不得包含 `--print-timeout`；既有 launcher、
+- [ ] 保留 timeout child 的非 AGY argv 無專用旗標契約；既有 launcher、
       headless hook、trust-root runner/template、reviewer downgrade、accounting 與
       #820 planning/AGY 回歸測試維持綠燈。
-- [ ] 文件與 changelog 同時交代 process-group／cgroup 邊界、timeout 優先序及實際
-      CLI 版本；新增 fragment 並同步 `CHANGELOG.md [Unreleased]`。透過 Cortex
-      記錄 RED／GREEN、離線 CLI 合約、完整 gates、review、merge 與 installed 驗證；
+- [ ] 文件與 changelog 交代 process-group／cgroup 邊界及 timeout child 移交；
+      新增 `changelog.d/launcher-session-and-timeout.md` fragment 並同步
+      `CHANGELOG.md [Unreleased]`。透過 Cortex 記錄 RED／GREEN、
+      CLI help／完整 gates、review、merge 與 installed 驗證；
       尚未執行的 smoke 不得填成通過。

--- a/openspec/changes/cortex-refine-complete/tasks.md
+++ b/openspec/changes/cortex-refine-complete/tasks.md
@@ -15,6 +15,8 @@
 - [ ] 2.5 依 accepted 三件組分拆並完成 #497 原子解除綁定、持久 supersession 與 restart/late-terminal 回歸；#831 後仍預計 Red，#501 只核對已修及殘餘污染。
 - [ ] 2.6 依 accepted 三件組完成 #821 no-op persistence、history retention、writer/fault/rollback 相容與安全暫存清理；完整 archive 缺口/截斷前備份保持列管。
 - [ ] 2.7 完成 #823/#824 session 與 AGY timeout 合約，明示 cgroup restart survival 的獨立驗收。
+- [ ] 2.7.1 先依 #851 補 AGY probe 的 argv construction containment，真 ready 非 AGY primary 不被阻擋；#824 仍需真非法 env 的 direct/probe/runtime 整合驗收，不拿 baseline fault injection 代替。
+- [ ] 2.7.2 #824 dependency 證據未滿前不登錄可 claim child／不開 auto label；解除後重新核對完整性、真 sizing、唯一 owner 與正式 freeze，不能依 custom frontmatter 自稱已鎖派工。
 - [ ] 2.8 完成 #825 最小 durable backoff，所有 lane 與 corrupt-state/expiry 可測；不標 R05 完成。
 - [ ] 2.8.1 先依 #850 有界 store／immutable event-fold child 交付 component；C/D provenance、reconciliation 與所有 lane 接線仍由 #825 後續 child 承接。
 - [ ] 2.9 以實際已載入 revision 驗 B1 成效，退出暫時 bypass 前保存 active jobs 與 rollback 方案。

--- a/reports/review/refine-agy-dependency-integration-20260907.md
+++ b/reports/review/refine-agy-dependency-integration-20260907.md
@@ -1,0 +1,53 @@
+# AGY 前置契約整合核對
+
+本批只有進件文件／owner分拆；產品、run、installed／loaded runtime均未修正。
+Root從 #852 merge `984fce5b86604aa71c6e8ecf82cc253a1441a106` 的獨立worktree整合，
+不pull／reset原operator或runtime，不改任何frozen run／原evidence。
+
+## Scope與驗收映射
+
+- #851 唯一production model_identities.py、R1–R7；argv construction納入原smoke try，
+  Exception回failed AGY、BaseException外拋、direct launch仍拒絕。真constructor、
+  两種roster順序、freshcache、alias injection與zero-smoke均有oracle。
+- #824 唯一production launcher.py、R1–R7；env/keyword正規化、Go整秒範圍、
+  gate helper重用、所有argv與Popen轉發、非法值pre-spawn拒絕、非AGY不變；
+  真非法env的direct/probe/runtime整合仍由下游candidate驗收。
+- #823 從母todo移出timeout五項待辦，全部由child spec/design/tasks承接並校正
+  原help短路／invalid gate語意；session/spawn/TypeError/process-group/cgroup與
+  原fake-Popen／回歸仍保留。canonical work_id與session fragment不改名。
+- #824 child fragment已由root正式更新遠端AC5；AC6改為no-prompt sentinel負控制。
+  先讀回原body／updatedAt、保存原稿、確認未被其他writer修改才edit，再全文核對。
+
+## Review與機械gate
+
+Containment R1独立PASS；timeout原例外穿透MAJOR由#851前置承接、不可直接接受殘餘。
+兩組fresh reader五題皆正確，核心contract未藉metadata整合改變。
+
+| 工作 | 真完整性／sizing | 不可混淆的狀態 |
+|---|---|---|
+| #851 containment | complete=true；0+0+2+2+2=6Yellow | 內容review不是正式builder envelope／freeze |
+| #824 timeout候選 | 有Open Questions marker：complete=false、plan blocking-decision；舊stability下4Yellow | surface-only helper仍ready/envelope bypass；不代表准入 |
+
+Root在記憶體移除marker的對照恢復complete/ready，實際文件marker保留；
+不改0/0/7宣告或公式壓分。以Tasks缺失負控制驗contract coverage；
+marker之存在拒絕不能冒稱所有Tasks語意皆已產品測試。
+
+79 runtime不讀canonical dependency自訂欄位。新work auto還需fresh confirmed authority與
+`cortex:auto-on-going`，既有ongoing run的resume則先於label檢查；不能拿移除label
+當全域pause。#824／#851兩issue目前labels=[]、無相關既有run。
+#824 marker不能保證zero planning spawn（incomplete start可走brainstorm），所以本批
+**不登錄其可claim owner、不啟auto、不start**；僅#851登錄。
+父#823移除#824映射，避免未來混合派工。真正解除依賴須root驗base／loaded證據後另行
+登錄、重接受與正式gate；不是請模型自動刪marker。
+
+## Evidence與交付gate
+
+Root再次離線跑AGY1.1.27 parser：abc／2400／2400s／9223372036s／9223372037s，
+皆exit2；兩合法值只遇unknown sentinel，其他分別invalid/missing-unit/overflow。
+未跑模型、未修改任何credential env或HOME；此parser證據不等live deadline。
+
+CI policy pin為v1.0.17／`9e7fabbf0b5eea9ad933fa6798764b723934a0b7`；
+本機skill source engine是release-ledger merge `b281c5da5cda0b7e3c67e148c759d99304893c56`，
+root git diff確認兩者policy_check bytes相同。兩個identity仍分開記。
+本PR須exact-head獨立整合review、post-commit fullpreflight、remoteCI／threads才merge；
+此文件不是尚未取得的gate PASS receipt。產品Tasks全部保持未完成。


### PR DESCRIPTION
## 摘要

登錄 #851 AGY probe construction containment；#824 timeout-only 保留完整獨立候選文件，#823 母 work 只保留 session scope。
此 PR 是 #829 規劃進件，不關閉任何尚未完成產品驗收的 issue。

## 驗證與安全邊界

- [x] #851 獨立 R1 內容審查與兩組 fresh reader 完成；真 completeness/6 Yellow，不冒充 builder envelope 或正式 gate。
- [x] #824 保留 #851 dependency、完整 env/argv/Go 範圍與真非法 env 整合驗收；root 已同步遠端 AC5/AC6 並讀回。
- [x] 真 blocking marker 使 #824 completeness=false；舊反向算法為4 Yellow且surface helper仍ready，兩者都不當授權。
- [x] #824 暫不登錄可 claim owner、不啟 auto label、不start；目前兩issue均無auto label／無相關run。#851才正式登錄。
- [x] #823 原 session/process-group/TypeError/cgroup 邊界保留，timeout五項完整移交，不遺漏、不重複擁有來源。
- [x] 新增分支對應 changelog fragment，同步 Unreleased、umbrella ledger/tasks；產品 Tasks 全未完成。
- [x] 未改產品、VERSION、policy pin、symlinks、operator/runtime、frozen artifacts 或 durable evidence。

使用 `policy-exempt:issue-link`：只交付規劃與 owner 邊界，所有引用 issue 的產品工作尚未完成，故刻意不寫 closing keyword；不豁免其他 gate。
須 exact-head 獨立整合 review、post-commit full preflight、remote CI/threads/mergeability 全部通過才 merge。
