### PR TITLE
docs(refine): 登錄 launcher 與 watcher 子計畫

### DIFF
--- a/.cortex/work-items.yaml
+++ b/.cortex/work-items.yaml
@@ -854,6 +854,10 @@ work_items:
       - kind: github_issue
         ref: 'hamanpaul/paulsha-cortex#823'
       - kind: path
+        ref: 'docs/superpowers/specs/launcher-session-and-timeout-spec.md'
+      - kind: path
+        ref: 'docs/superpowers/specs/launcher-session-and-timeout-design.md'
+      - kind: path
         ref: 'docs/superpowers/workstreams/launcher-session-and-timeout/todo.md'
     excludes: []
   monitor-refresh-thread-backlog:
@@ -939,4 +943,16 @@ work_items:
         ref: 'docs/superpowers/specs/agy-probe-construction-containment-design.md'
       - kind: path
         ref: 'docs/superpowers/workstreams/agy-probe-construction-containment/todo.md'
+    excludes: []
+  monitor-watcher-bounded:
+    title: 'monitor-watcher-bounded'
+    links:
+      - kind: github_issue
+        ref: 'hamanpaul/paulsha-cortex#853'
+      - kind: path
+        ref: 'docs/superpowers/specs/monitor-watcher-bounded-spec.md'
+      - kind: path
+        ref: 'docs/superpowers/specs/monitor-watcher-bounded-design.md'
+      - kind: path
+        ref: 'docs/superpowers/workstreams/monitor-watcher-bounded/todo.md'
     excludes: []

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 
 ## [Unreleased]
 
+- **Launcher／watcher 子計畫進件**：補齊 #823 session-only 三件組與唯一 owner links，
+  登錄 #853 有界 watcher A child。真 process-group 與 cgroup 邊界、raw0／generation／
+  partial-scan／nonfollow 驗收完整列管；現行 sizing 6／8 與正式產品交付分開。
+
 - **AGY 前置契約進件**：登錄 #851 probe argv 例外隔離，#824 timeout 拆為獨立候選，
   保留 #823 session/cgroup 邊界。#824 依賴未完成，移除母件重複 owner 並暫不登錄
   可 claim child；真 completeness 阻擋與 surface-only Yellow gate 分帳，不依自訂欄位假鎖派工。

--- a/changelog.d/refine-runtime-intake-20260907.md
+++ b/changelog.d/refine-runtime-intake-20260907.md
@@ -1,0 +1,8 @@
+### Added
+
+- 補齊 #823 session-only spec/design/todo authority links，保留 canonical work_id，
+  以真 production helper 接線、stdin 窄重試及安全 PGID/SID fixture 定義驗收。
+- 登錄 #853 watcher-only A child：受控 polling、raw0、generation/shared-backend、
+  partial-scan failure latch、nonfollow VFS 與平台／延遲殘餘明確分帳。
+- 本批只交付進件規劃；#823 現行6/Yellow，#853現行8/Red且不可派工，
+  #824依賴仍未解除。沒有產品、runtime、VERSION 或 policy pin 變更。

--- a/docs/superpowers/plans/2026-09-07-cortex-refine-complete.md
+++ b/docs/superpowers/plans/2026-09-07-cortex-refine-complete.md
@@ -249,6 +249,8 @@ B1 的主要目標是讓 Cortex 能可靠承接後續工作。B2–B4 完成後�
 | schema/key pure core | #849，#835 child；精確 typed wire／canonical key、三層 profile 與 bounded input。現行7/Red，#831後5僅投影；不授予資格、不做母件 routing/migration。 |
 | backoff store/event fold | #850，#825 child A；有界 fresh store、flock/atomic replace/durability、immutable event fold與ack。現行8/Red，#831後6僅投影；C/D provenance/reconciliation与production lanes仍另交付。 |
 | AGY probe exception containment | #851，#824 前置；只將 model_identities.py 的 argv 建構納入既有 smoke try。真6Yellow、独立內容審查與 fresh reader通過，正式派工／產品未完成。 |
+| bounded watcher A | #853，#827 child A；watcher-only controlled polling、raw0/root invalidation、generation/shared-backend及partial/nonfollow契約。R4與fresh reader通過；現行8/Red，#831後6僅投影，B/C與母件未完成。 |
+| headless session-only | #823；保留 launcher-session-and-timeout canonical id，補 spec/design/plan。單launcher的共用kwargs與窄retry、真安全PGID/SID及checkout外wheel驗收；現行6Yellow，timeout/probe與cgroup/restart均不混入完成宣稱。 |
 
 #835–#842的查重與read-back見[動態issue對照](../../../reports/review/refine-dynamic-issues-20260907.md)；
 #843–#845各票保存不可變source與10/12/12項AC，root已全文讀回。所有新scope都尚未

--- a/docs/superpowers/specs/launcher-session-and-timeout-design.md
+++ b/docs/superpowers/specs/launcher-session-and-timeout-design.md
@@ -1,0 +1,158 @@
+---
+status: accepted
+work_item: launcher-session-and-timeout
+---
+
+# Headless launcher session 設計
+
+## Intake metadata
+
+本 PR 於 `feature/refine-runtime-intake-20260907`（base `2c1bba01`）整合 repository intake，
+不是產品實作、正式 freeze／claim／dispatch，現行仍 6/Yellow。以下 D1–D7 保留原契約，
+984fce5b 行號是原 author 的 source snapshot。Root 已轉交獨立 reviewer R1 PASS 與 fresh
+reader 五題全正確結果，歸因及證據界見 author report；root 本 PR 後續 full preflight 另留證。
+#823 唯一 owner 與三件 links 已在本 PR 整合，正式 authority/source-condition 於 freeze 重驗。
+
+## Decisions
+
+### D1 — 最小 production 接線
+
+依 [Spec](launcher-session-and-timeout-spec.md)，只修改 launcher 一個 production module。
+基底 `984fce5b86604aa71c6e8ecf82cc253a1441a106` 的資料流為：
+
+```text
+launch (1764) → runner/role preflight → executor argv/wrapper
+ → 共用 popen_kwargs (2086) → runner env/stdin/cwd overrides
+ → stdout log handle → Popen (2257) → stdin-only TypeError retry (2262)
+ → 既有 prompt/start confirmation/LaunchHandle
+```
+
+`build_headless_popen_kwargs` 是待新增 helper，不是目前存在的 API。參數全部 caller 明示傳入，
+回一份新 dict，恰含既有 cwd/env/stderr 與 `start_new_session=True`，僅 executor=claude
+再放 `stdin=PIPE`；不讀環境、不 probe、不 spawn、不修改 caller env。`env` 仍由既有 launch
+建立並持有，本件不新增 immutable snapshot 或 serialization 契約。launch 以該回傳 dict 繼續
+原本的 runner 覆寫流程，不將 helper 放到覆寫之後重新蓋掉 runner 的 I/O／cwd。
+
+正常及 retry 共用 kwargs；現有 `if "stdin" not in str(exc): raise` 保持窄範圍，retry
+僅 pop stdin。第二次呼叫不放入新的 retry loop。未知參數 `start_new_session` 的 TypeError
+不可被當 stdin 兼容而吞掉。這項變更不產生 Manager 的 kill／reap 路徑；signal/reap 僅屬測試。
+
+### D2 — Recording tests 與 fake 兼容
+
+單元／component 測試沿既有 pytest、tmp fixture、monkeypatch/mock，不新增框架。
+以 `_ARGV_BUILDERS` 目前的 copilot/claude/codex/agy/cg 作參數來源，建立合法 launcher；
+cg 使用 read_only/review_only，不能為矩陣移除其拒絕 builder 的守衛。5×3 是 coverage
+inventory：14 個現有合法配置的真 launch 接線捕捉最外層 Popen；cg/template 則按
+`job_runner.py:696–710,1959` 保留 `job-runner-hardening-profile-unknown` 與 Popen=0。
+該拒絕不可被假 preflight stub 繞過，亦不新增 permgen/job_runner 的 cg 登記。
+不依賴 paid CLI／真 systemd；可在既有 test 檔分列案例，無需共享新的 production wrapper。
+
+保留 direct codex builder 的 `bash -lc` 斷言；read-only/reviewer 或 degraded 的 `bash -c`
+是既有行為，不一律改 login shell。claude direct 使用 PIPE；systemd-run client 使用原 client
+env、DEVNULL 和原 cwd；template client 使用原 client env、DEVNULL 和 `cwd=None`。
+兩種 systemd 模式的 argv 可能是 Manager exit-recorder shell 包住 systemd client，
+測試必須沿既有 unwrap/assertions 核對，不能假定 Popen argv[0] 直接是 systemctl。
+
+AGY construction 的 help/capability probe 須用現有 fixture seam stub；#851 尚未完成也不能
+令此 recording 測試觸發真 CLI。測試 fake 不證明 #851 containment，#823 不改該路徑。
+runner 的 account/unit/ACL/spec/sentinel preflight 使用現有 harness 的隔離 seam；
+通過表示 launch kwargs 接線，沒有真 systemd cgroup 證據。
+
+當下固定 keyword-only fake 共 22 處：`tests/test_coordinator_launcher.py` 19 處、
+`tests/test_headless_claude_hook_506.py` 3 處。新增顯式 `start_new_session` 參數並捕捉／斷言，
+或在必要處接 `**kwargs`；保持每個案例原有 argv/env/permissions/log oracle。
+不要靠放寬 production TypeError 補償 fake，也不要把原有未接受 stdin 的 fake 一律變寬，
+造成原 stdin retry coverage 消失。另設 dedicated retry fake，第一次記 kwargs 並拋
+`TypeError("stdin")`，第二次只差 stdin；非 stdin 與第二次再錯的負例都驗 call count。
+
+### D3 — 真 session／group fixture 與安全負控制
+
+新落點 `tests/test_coordinator_launcher_session.py`，僅 POSIX，本 repo Linux CI 必須實跑。
+在不支援 setsid/getpgid/getsid 的平台可明確 skip，但不能把 skip 算 C04/C07 通過。
+預先以純 helper + fake 接線測試定位 kwargs，真 fixture 自 production helper 取 kwargs，
+指定 cwd=tmp_path、最小 env、executor=codex，再加 stdout=DEVNULL。
+啟動 `bash -c 'exec sleep 30'`：與 issue 的 sleep 範例相同隔離面，明示 exec 讓單一
+process handle 可在 assertion 失敗時完整 reap，不依 shell 是否最佳化、也不留下 sleep 孫程序。
+此測試不宣稱已驗任意 provider 的孫程序／逃離 group 行為。
+
+順序與 oracle：
+
+1. 記 parent PGID/SID；Popen 成功後立刻保存 child handle，不用任意 sleep 同步。
+2. `getpgid(child.pid)==child.pid` 且 `getsid(child.pid)==child.pid`，兩者各不等 parent。
+   POSIX Popen return 已跨過 setsid/exec 的啟動握手；若 child 提早退出，測試失敗並 finally 收尾。
+3. 只有前項全部成功，才 `killpg(child.pid, SIGTERM)`。`wait(timeout=5)` 完成，驗
+   returncode 為 SIGTERM 終止，parent 繼續執行後續斷言。測試無需求終止自身 group。
+4. finally 若仍 alive，以該自建 `Popen` handle 的 kill + bounded wait 收尾；PIPE 若有就關閉。
+   這個 exec fixture 沒有 descendants，PID 在未 wait/reap 前仍由本 process 持有，不能依
+   process name、任意 PID 掃描或 operator registry 清理。成功與 assertion/timeout 路徑都走 finally。
+
+負控制必在 disposable mutation 環境進行：移除 helper session flag，先前 PGID/SID 斷言
+必紅，且 `killpg` call count 必為 0；finally 只 kill 本 fixture child。另在 fake seam 測
+「launch 不使用 helper」「只改 direct」「retry 丟 flag」「吞非 stdin TypeError」均變紅。
+不得讓 mutant 把 pytest 或 agent 的 parent group 當 signal target；不對 live process 做實驗。
+
+### D4 — Risk／oracle matrix
+
+| ID／AC | Surface／風險 | Harness／observable | Oracle／負控制 |
+|---|---|---|---|
+| T01 C01 | helper kwargs／遺漏旗標 | 純 helper 五 executor | 全數 literal True；caller env 不被改 |
+| T02 C01/C05 | launch 與 runner 覆寫／只修其中一支 | 既有 fake Popen，15 格 coverage inventory | 14 合法配置每次 Popen True；cg/template 原拒絕且 Popen=0；漏 helper 接線／flag 必紅 |
+| T03 C02 | stdin retry／靜默退回同 group | dedicated recording fake＋TypeError 注入 | 最多兩次、只 pop stdin；其他 TypeError 一次即傳出 |
+| T04 C03 | 22 固定 fake／既有安全斷言被抹掉 | 原 launcher/hook 與 runner harness | 簽名相容、原 argv/env/I/O/preflight oracle 保留 |
+| T05 C04 | setsid/group signal／parent 陪葬 | 真自建 exec fixture、PGID/SID/returncode | group 隔離、SIGTERM、5 秒內 reap；負控制 signal 前拒 |
+| T06 C03/C06 | session diff 覆蓋 #820 或偷帶 timeout | AGY/planning 與 full suite、diff scope | JSON/argv 原行為保持，#824/#851 無新實作 |
+| T07 C06/C07 | 文件／package 與 source 不一致 | CLI help、完整 policy/CI、checkout 外 wheel helper | exact candidate/import path、隔離 fixture；無 live/資格冒稱 |
+
+### D5 — 產品驗證入口與 artifacts
+
+先從原碼得到 RED，再實作最小 diff，保留完整 command/output/candidate SHA。focused 命令：
+
+```bash
+python -m pytest tests/test_coordinator_launcher.py tests/test_coordinator_launcher_session.py tests/test_headless_claude_hook_506.py tests/test_coordinator_agy_launcher.py tests/test_trust_root_job_runner_p2a.py tests/test_trust_root_job_template_ab.py tests/test_inner_sandbox_714.py tests/test_reviewer_planner_downgrade_615.py tests/test_manager_authored_job_accounting_604.py tests/test_planning_job_argv_687.py tests/test_planning_runtime.py -q
+python -m pytest tests/ -q
+```
+
+新 session test 目前不存在，上列是正式產品待辦，不是本次通過紀錄。`tests/conftest.py`
+已將 runtime/repo/config roots 轉到 tmp fixtures 並啟 network guard，保留該隔離；不使用
+ALLOW_NETWORK 逃生口，不讀寫 live root。`.github/workflows/tests.yml` 已配置執行四版 Python
+3.10–3.13 full pytest、build/twine 與 wheel smoke；沿既有 CI，不為本小改動修改 workflow。
+
+CLI compatibility 以 `cortex --help`、`cortex status --help`、`cortex stat --help` 與
+`cortex dispatch --help` 核對；dispatch 是停用的舊低階入口，只驗 help，不執行派工。
+README/docs 只在語意需要時更新 session/cgroup 邊界。正式 artifacts 允許必要 tests、
+docs/verification/review reports、`changelog.d/launcher-session-and-timeout.md`、
+`CHANGELOG.md [Unreleased]`，以及既有 feature-oneshot 的 planning/OpenSpec/archive 產物；
+不得以「唯一 production module」排除 policy 或 deck 必要文件。VERSION 不變。
+
+完整 feature-oneshot gates／Yellow adversarial gate、R-09/R-16/R-19/R-22 與其他適用 policy
+都保留。`policy_check` 使用真 PR title/body/labels/base/head；正式 delivery PR 只 `Closes #823`，
+不關閉 #824/#851 或家族票。source suite、CI、merge、checkout 外 wheel 的 helper／真 fixture
+分別留 evidence；installed 測試依舊用自建 process，不操作 Manager/service。
+
+### D6 — Sizing 與 authority
+
+依 #208 rubric，domain=0：production 只有 launcher 一模組、一條 kwargs→Popen 資料流。
+state=0：只改 local dict 與既有 Popen 的標準參數，不新增 schema、durable transaction、
+restart/reconciliation、跨 writer atomicity 或 concurrency protocol；fake 簽名修補不改 public
+backward-compatible state 契約。真多程序測試是 OS 既有 setsid 行為的驗收，不是產品新增
+協調狀態機。若後續要求 pgid 持久化／Manager cancel／cgroup ownership，必須重裁 scope/state。
+
+採 root 指定現行 packaged feature-oneshot，不換 combo 壓分：11 cards、11 bindings、
+4 core gates；R-09/R-16/R-19 全集使 acceptance=2，orchestration=2。
+現行 79 runtime 完整 accepted 規劃的 stability=2，故 `[0,0,2,2,2]=6/Yellow`。
+#831 完整 case 的 stability=0 只是 `[0,0,2,0,2]=4/Yellow` 投影，不能當已載入算法。
+Spec I1–I6 對應 invariant_count=6，artifact_classes 為 source/tests/documentation。
+
+Yellow 必須在正式 build 前完成獨立強審與 freeze/source-owner/fresh-base 檢查。
+缺真 measured envelope 的 helper bypass 不是模型合格；author 不替 root 啟動 workflow。
+Reviewer 從首輪固定：未處置 BLOCKER/MAJOR→FAIL；明文承認、影響有界且文件列管的 residual
+不單獨 FAIL；若不同意接受，須具體反駁其影響分析。Reviewer 必須讀 exact 三件組 hash，
+反證每個 AC、branch/fragment/source owner、OS signal 安全界與完整 gate 可交付性。
+
+### D7 — 有界 residual
+
+setsid 不移 cgroup，故不承諾 service restart survival；最外層 systemd wrapper 測試也不認證
+內層 job。新增 Manager cancel 或處理手動 kill 的終局 taxonomy 仍由後續 owner 負責。
+本票 signal fixture 只證自建 process group，沒有對任意 executor 子孫的保證。以上界線不削弱
+#823 的「本 launcher spawn 不與 parent 同 session/group」目標；完整 refine plan R13 其餘
+生命週期要求仍保留。#824/#851 的尚未交付不阻止本票離線 fixture authoring，亦不由此冒稱完成。

--- a/docs/superpowers/specs/launcher-session-and-timeout-spec.md
+++ b/docs/superpowers/specs/launcher-session-and-timeout-spec.md
@@ -1,0 +1,93 @@
+---
+status: accepted
+work_item: launcher-session-and-timeout
+---
+
+# Headless launcher session 規格
+
+## Authority
+
+唯一 issue owner 是 [#823](https://github.com/hamanpaul/paulsha-cortex/issues/823)，canonical
+work_id 保持 `launcher-session-and-timeout`。名稱保留不代表重新納入 timeout；
+[#824](https://github.com/hamanpaul/paulsha-cortex/issues/824) 的 AGY timeout 與
+[#851](https://github.com/hamanpaul/paulsha-cortex/issues/851) 的 probe containment 均另案。
+本三件組承接 root 已裁決的 session-only todo，`accepted` 是內容狀態。本 PR 是 repository
+intake，仍 unfrozen／未 claim，不是正式 freeze 或 dispatch；現行 sizing 維持 6/Yellow。
+正式 builder branch 為 `feature/823-launcher-session-and-timeout`；fragment 為
+`changelog.d/launcher-session-and-timeout.md`。原四檔 authoring 未實作產品；本 PR 整合進件資料，
+其後續 full preflight 由 root 另留證據，不把 author 檢查當產品或 PR CI 通過。
+
+## Requirements
+
+### R1 — 共用 spawn 參數
+
+唯一 production 修改檔為 `paulsha_cortex/coordinator/launcher.py`。抽出同模組的
+`build_headless_popen_kwargs(*, cwd, env, executor) -> dict[str, object]` 純 helper，
+保留既有 cwd/env/stderr 與 claude stdin 條件，加入 literal `start_new_session=True`。
+`SubprocessLauncher.launch()` 實際消費此 helper；正常及 stdin retry 的兩處 Popen
+共用同一 kwargs，不能只在測試另造 dict，亦不能只修 direct 或某一 executor。
+現有 `_ARGV_BUILDERS` 五個 executor 與 direct／systemd-run／systemd-template 三種 runner
+的合法 launch 都適用；既有角色／權限前置拒絕保持，不為湊測試矩陣放行不合法角色。
+目前 cg + systemd-template 缺 hardening profile，須在 Popen 前維持原拒絕；15 格 coverage
+包含此負例，不等於新增 15 種可執行配置。
+
+### R2 — stdin 的窄重試
+
+保留現有 `TypeError` 訊息須含 `stdin` 才移除 stdin 並重試一次的範圍；第二次仍須攜帶
+`start_new_session=True`，其餘 kwargs 不掉落。不得擴成吞任意 TypeError、移除 session flag、
+重試未知參數或在第二次失敗後再降級；`start_new_session`／其他不含 stdin 的 TypeError
+立即傳出，且沒有第二次 Popen。這是相容既有 fake 的有限退回，不增加新的 production fallback。
+
+### R3 — 保留 runner／executor 語意
+
+helper 只集中 spawn kwargs。runner 後續已有 env/stdin/cwd 覆寫、stdout log handle、
+argv／shell mode、prompt 傳遞、角色 preflight、sentinel／log 與 LaunchHandle 既有欄位保持。
+`PSC_JOB_RUNNER` 未設仍為 direct。systemd-run／template 測試捕捉的是最外層 Manager
+exit-recorder shell／client wrapper 的 Popen；不能把其 session 斷言當內層 unit job 的 PID／PGID。
+固定簽名 fake 必須接受新參數且保留原安全斷言；已收 `**kwargs` 的 fake 不必改簽名。
+保留已合併 #820 的 AGY JSON／argv 與 planning 回歸，不改 effort、timeout 或 probe。
+
+### R4 — 真 process-group 驗收
+
+POSIX 隔離測試必須從 production helper 取得 kwargs，啟動測試自建且無網路／模型的 subprocess。
+確認 child 的 PGID 與 SID 都等於該 child PID，並不同於測試 parent 的 PGID／SID；
+只有 ownership 確認後才向該 group 發 SIGTERM。child 必須在 5 秒內被 wait/reap，parent
+可繼續執行斷言。所有路徑含失敗的 finally 都有界收尾，只使用本測試持有的 process handle；
+不能以 Popen mock 單獨替代真 PGID／signal 證據，也不能因負控制失敗誤殺 parent group。
+
+### R5 — 明確作用範圍與交付
+
+本件只隔離 session／process group，沒有 systemd cgroup 移動、Manager kill/cancel API、
+LaunchHandle pgid schema、registry、dispatcher 或 service 變更。不承諾 Manager daemon restart
+後 direct job 存活；unit 的 KillMode 若涵蓋 control-group，setsid 不能提供該保證。
+該生命週期要求仍留完整 refine plan 的 runner／instance ownership 工作，不藉本票消失。
+正式產品工作須完成 focused/full tests、CLI help、docs、changelog、既有完整 gates、
+獨立 review、policy/CI、merge 與 checkout 外隔離 installed helper 測試，逐層留證；
+不要求對 operator 的 Manager／真 job 作訊號、重啟或模型實測。
+
+## Invariants
+
+- I1：每次合法 headless Popen 嘗試均帶 `start_new_session is True`，包括重試。
+- I2：stdin 之外的 TypeError 不被吞掉，無不帶 session flag 的 fallback。
+- I3：各 runner／executor 的既有 argv、環境／I/O 與角色限制保持，不改 durable schema。
+- I4：production helper 產生的新 session 讓 fixture child PGID/SID 等於自身 PID，group SIGTERM 不連坐 parent。
+- I5：測試只 signal 自建且已驗所有權的 group，所有自建 process 與 PIPE 有界收尾。
+- I6：process-group 綠燈不升格為 cgroup／restart survival、Manager cancel、timeout 或 probe 完成。
+
+## Acceptance Criteria
+
+- [ ] C01／I1/I3：helper 純資料正例與 launch recording matrix 盤點五 executor／三 runner 共 15 格；14 個現有合法配置測每次 Popen True，cg/template 保留 unknown-hardening 拒絕且 Popen=0。codex direct `bash -lc`、claude direct `stdin=PIPE` 與兩種 systemd wrapper 都有真 launch 接線斷言。新增 registry key 時重驗矩陣，沒有另一張 production 名單。
+- [ ] C02／I1/I2：第一次 `TypeError("stdin")`、第二次成功，恰兩次嘗試且只有 stdin 被移除；第一次不含 stdin 的 TypeError 只有一次，第二次 TypeError 不被循環吞掉。
+- [ ] C03／I3：重新盤點固定／寬簽名 fake，最小兼容修改並保留原始斷言；既有 runner env/stdin/cwd、hook、reviewer/accounting、安全 preflight 及 #820 回歸維持通過。
+- [ ] C04／I4/I5：Design D3 真 fixture 驗 PGID、SID、group SIGTERM、parent continuation、5 秒 wait/reap 與 finally；去掉 helper session flag 的負控制在任何 group signal 前變紅，不能誤殺 parent。
+- [ ] C05／I1/I6：刪除 launch 對 helper 的呼叫而只讓 helper 本身通過時，recording 測試必紅；只刪 retry 的 session flag、只修某 executor／runner 同樣可被抓到。
+- [ ] C06／I3/I6：source scope 僅 launcher、正式 artifacts 與全 gate 相容；新增對應 fragment 及 Unreleased entry，R-09/R-16/R-19/R-22、symlink／VERSION／PR context 與 CI 有實際結果。CLI 只做既有 help，不新增 cancel 入口。
+- [ ] C07／I4/I6：checkout 外以候選 wheel import 同一 helper，重跑隔離 fixture；核對 module path／候選 SHA，與合併、source suite、installed 及 live 分帳。此次 planning helper 結果不充當任何 C01–C07 的產品完成證據。
+
+## Source condition
+
+Root 回報本 PR 已將 #823 唯一 source 與 spec/design/todo path links 整合至本 work_id，
+#824 已移出；本 PR 未登錄 #824 child，也未 claim 本件。repository links 不等 frozen authority。
+真正 freeze 前仍由 root 重驗 #823 open／唯一 owner、本三件 exact refs/hashes、含 #820 的
+fresh remote base，以及 reviewer input 的完整契約／獨立審查結果；#824 不得重新綁回本件。
+純 completeness／sizing／plan gate 不讀 live registry，不能證明正式 admission 條件已成立。

--- a/docs/superpowers/specs/monitor-watcher-bounded-design.md
+++ b/docs/superpowers/specs/monitor-watcher-bounded-design.md
@@ -1,0 +1,141 @@
+---
+status: accepted
+work_item: monitor-watcher-bounded
+---
+
+# Watcher 排程、失效通知與停止設計
+
+Owner [#853](https://github.com/hamanpaul/paulsha-cortex/issues/853)，work item `monitor-watcher-bounded`；parent #827、umbrella #829。Root已建立/readback OPEN，並在本PR加入唯一`.cortex` spec/design/todo links；當前為repository intake／unfrozen，未merge、未正式freeze、未dispatch。本文件及repository links不授權繞過8/Red gate，不等於已凍結的run authority。
+
+## Decisions
+
+### D0 單一裁決：受控polling與直接root ingress
+
+Root已選watcher.py內受控polling：local BaseObserver subclass＋小型PollingEmitter adapter＋直接root-coalescing ingress，保留`WatchdogFileWatcher`公開名稱。native私有buffer/cache復原面更大，已不採用；不修改watchdog套件或全域monkeypatch。原K-ring/overflow queue方案撤回，不能與D4.2同時保留。此accepted規劃的R4 PASS／0 MAJOR由root轉交fresh reviewer `watcher_polling_r4` 結果，不是產品GREEN；現行完整combo仍8/Red，所有產品驗收未勾選。
+
+### D1 單檔 owner 與資源界
+
+`WatchdogFileWatcher`在watcher.py內擁有固定callback workers、一個backend owner、一把condition/state lock、logical/backend state map及唯一ready membership。資料流：受控PollingEmitter → immutable backend-generation proxy → 同一短鎖直接root pending → deadline/FIFO → callback active lease → consumer callback → generation-bound completion。Observer dispatch thread不運送data callback，只等stop控制latch；沒有第二個data backlog。backend owner只處理Observer控制/回收，不執行consumer callback；callback/Observer操作、join和等待均在state lock外。
+
+預設W=2、quiet debounce d=500ms、最大D=2000ms、shutdown總budget S=2s，poll interval P=1s。既有debounce_ms可覆寫；新增instance-only poll_interval_seconds與測試seams：W為正整數且非bool，d≥0、D>0、S>0皆有限，P為非bool有限數且0<P≤60秒；d>D時取D為有效quiet上界。monotonic clock可注入，不新增CLI/env。W workers共用condition等最早deadline，不建每event/watch Timer。P由BaseObserver timeout傳到PollingEmitter，與D/S不同；不能把S=2秒或D=2秒寫成端到端freshness。
+
+callback active≤W、每key active≤1/pending≤1；新增backend owner B=1，不是每次cleanup啟動thread。控制輸入為每個既有logical/backend key最多一份desired-state/cleanup intent，加最多一個新註冊in-flight槽；不用Future/每次request append queue。callback tombstones≤W，backend retiring records另列，不混充已移除的live key。
+
+只有backend owner執行Observer的schedule/start/remove_handler/unschedule/stop/join。採用的backend inventory為一個Observer dispatch thread＋每實際ObservedWatch一個PollingEmitter，另加W callback workers與B=1；沒有InotifyBuffer/helper/cache。owner阻塞或retirement未收斂時，新watch不配置backend、以可重試OSError拒收；既有key的unwatch/stop仍合併intent。因此阻塞開始時N0個backend加至多一個in-flight註冊，後續註冊churn不增thread/tombstone數。每個poll僅保留上一snapshot、當次snapshot/diff/暫存；其峰值依有限拓樸M計量，不隨事件總數累積。診斷只保留bounded當前原因/數值，不存event/exception traceback歷史；統計counter須固定寬度飽和或等价不隨event總數增配置。
+
+### D2 不漏路徑的 payload
+
+維持 `WatcherCallback = Callable[[Path], None]`。目錄 subscription 永遠 callback 該 watch root；它是可重建整個監看範圍的 invalidation，不回報任意 latest child。檔案 subscription callback 固定 watch file；註冊時保存 file/directory matching 類型，使 file 暫時被 rename/delete 時不被誤當目錄。Observer watch 範圍沿既有 file→parent、directory→self，recursive 匹配契約不擴張。
+
+src/dest 不能在第一個 match 就丟掉其餘適用 watch；每個 handler 可按自己的 root 合併，但 rename 跨 A/B watches 必須分別產生 A/B invalidation。目錄非 recursive 只匹配直接 child/root；不同 project 共用 workspace root 時收到 workspace invalidation，既有 service 的無 project match 分支執行全量 refresh，而非誤只刷新最後 project。
+
+`StubWatcher` 保留同步手動觸發角色；production 的 root invalidation 契約須另外用真 WatchdogFileWatcher/fake Observer 驗，不要求 stub 模擬非同步。若 repo consumer 實測依賴逐事件 Path 而不接受 root invalidation，先回報契約衝突、改規劃，不在本 child 暗改第二個 production 模組。
+
+遞迴拓樸沿現有native不跟隨descendant directory symlink的邊界：link entry自身可使root失效，external target的子項不進snapshot；file symlink同樣只記link metadata，沒有target內容監看。明確指定backend root可跟隨symlink，仍保留logical lexical Path；每scan重新開root，不把上一scan的root inode/fd當永久authority。D4.3的dirfd/no-follow supplied VFS還須防止檢查後directory被換symlink，不能只先lstat再以完整字串scandir。
+
+### D3 Deadline 與 active/pending state machine
+
+狀態：idle→pending(f,e,generation)→ready(FIFO)→active(lease)→idle；active期間可另掛一份pending，completion只把同generation pending加回ready。第一次ingress提交設f=e=now；後來只改e，deadline=`min(e+d,f+D)`。pending/ready共用同一record及membership，已ready不退回debounce；deadline先到者入隊，同時到以穩定順序裁決。補跑進隊尾，不重排既有其他key。raw event在put返回前已合併，不可能100次put完成後還留一批backend data稍晚生成第三輪；控制burst oracle以這個提交點為準。
+
+ready 是 deadline 到期後的排程資格，不是假稱 callback 已開始。若全部 W workers 正在 callback，仍保留原 deadline/首次pending；worker可用時先按到期時間/穩定序轉入ready，再取工作，不能把worker醒來時間冒充ready_at或重設D。唯讀diagnostics可據clock顯示已到期但尚未取得worker的等待；T2分別斷言ready資格與有限L前提下的開始界。
+
+lease在鎖內驗stopped/key generation後取得，是callback admission的線性化點。鎖外呼叫callback的前後都可設測試barrier。**內容invalidation**只設root dirty/pending，不撤銷registration；**stop/unwatch revoke**才使generation失效。revoke在該點之前則不得取得lease；之後算既有active，stop/unwatch只撤銷、不等該lease，drain才在安全外部上下文等待。完成時只按所帶lease generation更新自己的狀態，不碰同path的新registration，亦不因舊callback完成而新增worker。
+
+### D4 Stop/unwatch 與可見 residual
+
+**撤銷與等待分開。** `unwatch(path, recursive=...)` 只在state lock內invalidate目標logical generation、清pending/ready、合併cleanup intent、notify即返回；不進observer lock、不呼叫unschedule、不等callback。`stop()`同樣非阻塞撤銷全部keys、設定stopped並喚醒owner/workers；既有無參數signature/None回傳保留，返回語意明訂為revoked/requested，非drained。重複呼叫不增加工作。真service `_install_watches` 持`_watch_state_lock`呼叫unwatch，而callback讀project又要同鎖；此循環必須消除，不得等S才返回或標成非合作provider。
+
+新增watcher-local `drain(*, timeout_seconds=S, path=None, recursive=True)`：必須由不持consumer lock的外部呼叫者使用；path指定時只快照該path已revoked generations的callback/backend拆除，排除已成功re-watch的新generation；省略path等待當下全部撤銷工作，且stopped時包含owner/worker退出。drain在鎖內只取snapshot，鎖外按同一absolute deadline等待；不得直接呼叫可能阻塞的Observer操作。回傳JSON-safe診斷（drained、pending generations、alive callback workers、backend owner/operation、未釋放backend資源、timeout reason）；callback/owner執行緒呼叫drain明確拒絕，不self-join。N個worker/backend不能各花S變成N×S。
+
+backend owner自治處理cleanup，即使既有service不呼叫drain，合作式工作仍自行完成；服務整體等待與publication fence由C接線。A驗收用stop→drain或unwatch→指定path drain，明示兩階段。PollingEmitter可能卡stat/listdir，owner在emitter.join(None)等待；外部drain仍在S返回且保留B=1與實際inventory，不增owner或丟記錄，fixture放行後再次drain成功。source正常poll暫時OSError依D4.3保活，不能與不可取消scan混為同一故障。
+
+BaseObserver的unschedule仍可持全域lock等emitter，但本設計data ingress不取得該鎖：A teardown卡住時，健康B backend仍應能提交root pending並在W/L前提下執行callback，T10/T13必驗，不能把B被observer鎖卡住列residual。卡住scan本身沒有事件可提交，該backend的freshness與新registration/cleanup沒有有限完成保證；它及所有活資源必須degraded/tracked，不能假報healthy。固定拓樸memory有界是本票硬gate，只有不可取消外部scan的有限availability是母票列管殘餘。
+
+backend operation拋錯或部分清理時保留具體operation/handle/generation與unknown/retiring狀態，不能用Observer已先刪map條目當清理完成（emitter可能仍alive）。新註冊持續fail-closed，owner按有限既有intent對帳，不新增重試record；diagnostics每key只保留當前必要狀態/原因，不建立無界error歷史。
+
+drain/diagnostics只讀watcher-owned shadow state及已持有的thread/handle引用，不為取得狀態再進可能被卡住的Observer lock。owner在危險操作前保存operation、backend generation及已知資源；尚未返回的schedule若有未確認配置，明示in-flight/unknown、算入唯一註冊槽上界，不能回clean/drained或宣稱活資源已是零。部分失敗後若無法證明資源已釋放，記錄與新watch拒收都保留。
+
+**註冊成功不能造假。** `watch`保留同步成功/失敗語意：重複已成功active key沿既有idempotent/no-op，不換handler或新增槽；新註冊只在owner健康、retirement已收斂且唯一新註冊槽空閒時接納，caller放開state lock後最多等S；owner不等consumer callback。完成且generation仍有效才publish logical-active並回成功；busy/unhealthy/timeout回可重試OSError，使既有service不把失敗key加入`_watched_paths`。timeout要撤銷該註冊generation，late schedule結果只補償自己的實際handle，不能重新啟用已revoked key。slot/未釋放handle仍計數，直到cleanup ack才可接下一筆；不為每次重試保留新intent或thread。
+
+stop/unwatch只管watcher admission、pending與callback completion。consumer已開始的DB/file/socket/event side effect需B/C真正publication fence；本項不以入口generation check冒充它。真service鎖循環與共享handler被誤刪不是可接受residual；只有已隔離的非合作外部backend/callback、資源有界且可診斷的等待可列residual。
+
+### D4.1 Handler 引用與 backend generation
+
+logical key=(canonical watch path,recursive,logical generation)；backend key按實際ObservedWatch的root/recursive/event_filter決定，不能把logical path當backend唯一鍵。每backend record保存實際handle、固定長度backend token、source/emitter引用、logical handler集合/refcount、live/retiring/disposed。file A/B同parent可共享同backend。handler仍向BaseObserver正式註冊供shared-watch/refcount管理，但data callback只經直接ingress的shadow logical registry，不由Observer.dispatch_events再執行一遍。公開內部測試所讀`_watches/_handlers`移除logical claim時可立即清，尚活backend/handler引用另留retiring inventory，不假裝資源消失。
+
+owner處理撤A時，先只移除A的handler（`remove_handler_for_watch`或等价受控adapter），refcount仍有B則不unschedule；最後一個有效handler撤銷才可commit backend teardown。提交前重查desired refs/backend generation，所有Observer操作由單owner序列化。teardown已committed的backend不能被同key新watch復用，回可重試OSError，等待舊handle確實disposed後才建立新backend generation。完成比對實際handle+generation，而非只用path pop；舊detach/completion不得移除B或新generation。
+
+re-watch在尚未commit teardown時也不得繞過owner搶接；先收斂舊logical detach，再由新註冊槽安裝新handler，必要時復用仍有B的健康backend。保持每個logical key的generation fence，舊handler即使仍收到event也不可取得新lease。Observer內部私有結構只供fixture/adapter相容檢查，不能由其他consumer直接改；若必須改watchdog套件或service才能成立，先回root擴scope/re-sizing。
+
+### D4.2 直接ingress：一份data狀態與獨立stop latch
+
+在local BaseObserver構造完成、任何schedule/start之前，把該instance `_event_queue`設為watcher-owned ingress facade；不替換運行中的queue，不改套件全域。emitter factory在owner已預留backend record時建立proxy：proxy封存backend token及該實際emitter/handle身分，之後每次put不可依當下同path查新token。共享ObservedWatch的新logical handler沿用健康backend token；舊backend disposed後即使watch.key/path相等，新emitter必取新token。owner預先追蹤constructor/start中的proxy/emitter引用，供partial failure/late schedule精確補償。
+
+proxy.put((event,watch),block=True,timeout=None)在短state lock驗instance未stop、backend token仍有效，按該backend目前已准入logical generations逐一匹配src/dest（以註冊時保存的file/directory/recursive資訊做lexical匹配，不做stat/resolve）。相關每key直接更新D3的同一pending record並notify；同event兩端/多key各自完整合併，file仍固定file Path、directory仍root。put返回時data已提交，raw event不再持有；無K-ring、overflow list、future或第二批稍後入pending的data。暫態呼叫stack/poll snapshot-diff另計D1上界。被revoke/late backend proxy的event只drop，不建立未知key，也不喚醒新generation。
+
+Observer dispatch thread僅控制通道，facade不是一般用途work queue。有限狀態OPEN→DATA_CLOSED→TERMINATED；data close由watcher.stop在state lock內完成，撤銷logical pending/ready並喚醒W workers與owner。控制latch `wake_pending`最多一bit；put/put_nowait收到EventDispatcher.stop_event只set/notify，重複合併。get(block/timeout)只等待/取走此bit並回原stop sentinel，無bit時依參數等待或queue.Empty；永不返回data，不因DATA_CLOSED就連續回sentinel/Empty忙迴圈。
+
+local Observer僅另覆寫on_thread_stop：先置stop latch/notify，再呼叫super清emitters。此hook只由backend owner的Observer.stop觸發，且BaseThread.stop已先設stopped_event；因此真dispatch_events收到sentinel後在進Observer lock及task_done之前返回，run loop讀stop flag退出。EventDispatcher.stop在hook返回後還會put一次sentinel：此時仍只佔同一bit；owner確認Observer已join後把facade設TERMINATED、清bit，後來重複stop put為no-op，不留下待消費task或復活dispatch thread。TERMINATED才允許get回Empty而不等待，此時沒有存活的Observer消費loop。owner若已卡另一unschedule而尚未執行stop，dispatch thread可維持單一parked waiter，計入drain residual；不能為喚醒它另啟thread或從caller執行阻塞stop。
+
+facade不保留Queue的data unfinished計數：所有put在ingress同步完成data admission，`unfinished_tasks=0`恆定；task_done若意外被呼叫即像空Queue般拒絕，join只反映零deferred queue tasks、不能當callback/backend drain。qsize/empty只報控制latch0/1，另用diagnostics報真正logical pending/ready/active及raw_backlog=0，不拿空控制queue隱藏工作。T13須驗此實際get/put/stop/task_done路徑、closed無busy-spin、無第二次data callback，禁止復用普通無界Queue作暗中backlog。
+
+### D4.3 Polling snapshot保活與相容面
+
+使用BaseObserver公開emitter_class seam；受控PollingEmitter重用原constructor/queue_events與DirectorySnapshot/diff演算法，包instance `_take_snapshot/_snapshot`、on_thread_start並提供窄化stat/listdir。**外層catch不足**：watchdog6的DirectorySnapshot.walk會吞child stat OSError、recursive listdir PermissionError及部分errno；必須在supplied VFS先記錯，再於DirectorySnapshot返回後驗scan latch，不能把「constructor返回」視為完整成功。不複製walk/diff/poll loop，也不新增通用FS engine。
+
+每次_take_snapshot新建scan context，由backend owner的初次註冊或原emitter的poll執行緒取得root目錄fd，不持watcher state/consumer lock，沿用PollingEmitter自身鎖；root可跟隨明確指定的symlink，但每scan重開、finally關閉，不跨scan沿用。snapshot路徑仍為原lexical root；root stat取fstat(rootfd)。descendant stat先從此rootfd以逐component `os.open(...,dir_fd=...,O_DIRECTORY|O_NOFOLLOW)`走到parent，再以`os.stat(name,dir_fd=parentfd,follow_symlinks=False)`讀entry。descendant listdir同樣no-follow開到該目錄，再對fd使用os.scandir；只消費DirEntry.name，不利用跟隨symlink的DirEntry.stat。相對component不得含逸出root的`..`；不以resolve把descendant symlink重寫成外部路徑。中途換symlink/非目錄可使scan失敗，但不能掃入target；不在本票另做retry-walk引擎。
+
+rootfd、component走訪current/next fd與scandir iterator皆有finally/context-managed close；同時活descriptor保守上界每scan≤4（root＋走訪暫存＋scandir持有），不為每entry或depth永久留fd。DirectorySnapshot會先完整消費某層listdir才stat/遞迴，因此listdir generator必須在耗盡/raise時即關閉。候選snapshot保存的wrapper context不得保留已關fd/exception traceback；scan結束後不能重用其I/O。每scan額外path-component走訪成本按實際深度與entries計入Tscan，記憶體按該scan拓樸M及最大深度H計量；不宣稱不同拓樸/churn使M全域固定。卡住I/O仍只占原emitter及該有界fd inventory，直到合作式返回才可close。
+
+stat、listdir建立iterator及每次迭代皆用同一scan context攔OSError，**先**按下表記第一份bounded failure(operation/relative path/errno)，再原樣raise讓library走原路。不能只包呼叫listdir取得iterator而漏掉next()的PermissionError。failure只留有限字串/errno、不append錯誤或traceback；若library吞例外後回partial candidate，外層仍檢latch並丟棄candidate，拋合成OSError進既有initial/steady guard。其他例外照fatal路徑，不標healthy。任何失敗之後同一scan的成功操作都不能清latch；只有新scan完整成功才恢復。
+
+| 操作／錯誤 | 唯一裁決 |
+|---|---|
+| 任一root open/stat/listdir/iteration OSError，包括ENOENT | scan失敗，不偽造空root或成功註冊 |
+| no-follow descendant stat/listdir/iteration的ENOENT | 目錄列舉後entry/ancestor已消失的競態可略過；在該scan omission可合法形成deletion hint，不跟隨dangling link、不把permission failure轉ENOENT |
+| descendant EACCES/EPERM/EIO、EINVAL、ENOTDIR/ELOOP及其他OSError | 一律latch不完整scan；尤其ENOTDIR/ELOOP可能為directory→symlink/file競態，採保守重試下一poll，不假empty成功 |
+| 非OSError | fatal、不假last-good健康；不在本票無限自動重啟 |
+
+這裡「完整成功」只表示全部已嘗試的scan I/O沒有未准許錯誤，不是原子FS snapshot；並發新增/刪除可能形成best-effort視圖，下一poll/既有rescan補觀察。第一次on_thread_start只有latch通過才標initial_snapshot_done；不完整scan OSError傳回owner，watch失敗並精確清理，EmptyDirectorySnapshot不是last-good。
+
+initial成功之後，guard只catch OSError（含scan latch產生的錯誤）：保留本emitter上一成功`_snapshot`，記當前bounded degraded reason/last_error_at，首次degraded轉換提交該backend有效logical roots的invalidation，使真consumer依其last-good規則讀現況；不stop/restart或新增emitter，不每次失敗append事件歷史。後續每poll仍新建scan context/重錨root，latch通過才回新snapshot並clear自己的degraded，degraded→healthy轉換另提交root invalidation，即使metadata未變也讓consumer可清degraded觀察；正常無變化poll不強制refresh。partial candidate不得進diff/成功基線，因讀取失敗而假產生的FileDeletedEvent必須為零；一次degraded root hint與真consumer自己的重讀結果分開驗。此wrapper避免stock PollingEmitter將一次OSError當DirDeletedEvent後永久stop。
+
+非OSError不得轉成空/last-good後假healthy：記有界fatal診斷並保留原失敗路徑，該backend不宣稱watch健康，新同keywatch不得假成功；已註冊consumer可由既有rescan續讀，backend需明示unwatch→watch或外部修復，不私建無限自動restart。initial與steady-state未知例外、PermissionError暫時失敗、恢復成功均獨立測。只保留型別/有界訊息，不持exception traceback形成歷史引用。
+
+版本相容面限定目前watchdog6.0.0：BaseObserver constructor的emitter_class、schedule在emitter建立時傳event_queue、EventEmitter.queue_event呼叫put、EventDispatcher.stop_event identity、BaseObserver.dispatch_events sentinel先於lock/task_done、BaseThread.stop先設flag再hook；私有接點仍只有pre-schedule `_event_queue`及PollingEmitter `_take_snapshot/_snapshot`，新增VFS用DirectorySnapshot公開stat/listdir參數。支援平台必須有os.open/os.stat的supports_dir_fd、os.stat的supports_follow_symlinks、os.scandir的supports_fd及O_NOFOLLOW/O_DIRECTORY；能力缺席在watch成功前明確拒絕，不宣稱PollingEmitter的platform-independent描述等同本adapter跨平台相容。當下Linux/Python3.12.3能力均有，其他平台未證實；不靜默回native/普通字串scandir/無界queue。candidate/CI以真library和能力缺席fake測此契約，若現有平台承諾衝突須回root重裁。測試不得因未裝watchdog而全skip後算過關。
+
+### D4.4 延遲、成本與接受的觀察殘餘
+
+保留service現有workspace/project非recursive與.git HEAD(file)/refs(recursive)範圍，不擴成整repo recursive。每backend每P秒取得一次snapshot，實際週期含Tscan；固定有限拓樸M下前後snapshot/diff峰值O(M)，全instance成本依各backend的M相加（重疊backend不假設零成本）。新queue不使source因消費變慢累積多輪snapshot，非合作scan仍占原emitter且有bounded資源診斷。P=1秒不是已證能在任何拓樸跑完的承諾。
+
+可觀察變化的延遲包含P+Tscan+D+callback排隊/執行，再加service自己的debounce及scan；不等於D或S的2秒。polling看不到兩scan間完整消失的短命變化，也可能漏相同inode/mtime/size的內容改写；root已接受它們可能延後到既有rescan，而非新增每poll強制refresh。當下MonitorConfig預設full poll60秒、targeted rescan300秒，實際可配置/受慢scan影響，不能寫成永久硬期限。service把Path當重掃hint、SnapshotStore比較最終signature發ChangeEvent，沒有逐FS event log契約；不得把這個當下source佐證擴成所有未來consumer的全稱承諾。新增consumer若要求逐事件/瞬態，runtime不變量或相容測試紅燈必須重新裁決。
+
+### D5 離線 oracle 與實際消費端
+
+新`tests/test_monitor_watcher_bounded.py`重用pytest，提供fake Observer、monotonic fake clock、condition seam、Event/barrier、唯讀diagnostics；不新增測試框架。新核心fixture缺watchdog應明確失敗，不沿用既有optional全skip當GREEN。現有tests.yml只安裝.[test]，test extra只有pytest；產品PR須在該既有test job明列安裝watchdog6.0.0與import/version確認，這是test-only基礎設施，不增加production模組或修改runtime依賴。candidate focused/完整CI須實際跑新fixture與OS smoke，原無watchdogfallback另用隔離mock測。
+
+| Case | 操作／harness | 必要 oracle |
+|---|---|---|
+| T1 W/pending | W=2，兩個callback進入 barrier後卡住；對A注入100事件 | callback-owned worker≤2、A pending=1、無 Timer；放行後A首輪+補跑≤2 |
+| T2 D/FIFO | d=0.1s/D=0.5s，fake clock連續注入A；B已ready；顯式wake | A首次pending後0.5s前ready，B不被後來A插隊；L=0.2s時用Q/L/W推開始界 |
+| T3 多路徑/rename | workspace下A/B同窗、rename A→B、file HEAD.lock→HEAD | root invalidation覆蓋A/B；兩個獨立watch各通知；HEAD檔仍為固定payload；非recursive深層事件拒收 |
+| T4 真consumer相容 | production watcher+fake Observer，真service `_handle_fs_event`、fake store/禁用背景網路 | workspace root觸發full refresh，其結果含A/B最終狀態；project root觸發對應project既有入口，不能只有callback spy |
+| T5 停止時序 | admission前/lease後/completion前barriers，stop/unwatch、舊handler再event、同path re-watch | revoke前後分支可重現；內容invalidation仍准入、revoke才使pending=0；舊completion不重排新generation；stop後watch拒收 |
+| T6 自呼叫/例外 | callback內unwatch或stop、另一key仍active；另callback拋錯 | revoke不self-join/鎖死，callback內drain拒絕；錯誤歸自身key且worker可續其他key |
+| T7 不合作 | W callbacks gate永不自放行、stop後外部drain S=1s，finally釋放 | revoke立即返回；drain有界回≤W callback residual、零替代worker/新admission；finally後舊completion零重排 |
+| T8 長串/真thread | 固定seed虛擬60秒、反覆註冊/取消；短真watchdog tmpdir變更 | owned W+B及Observer/helper/retiring資源有界，合作stop→drain回基準，保留全部既有回歸 |
+| T9 真service鎖 | 真 `_install_watches` 持watch-state lock撤key；active callback已到 `_project_id_for_path` 等同鎖 | unwatch在callback gate尚未釋放時就返回，不等待S/不生stuck；caller釋鎖後callback完成，外部drain成功 |
+| T10 backend超S | 真BaseObserver+受控emitter，A scan/內部join(None)阻塞；另一B透過proxy持續提交；重複stop/unwatch/re-watch | revoke不等backend；drain≤S+明示排程容差返回backend-cleanup-timeout；owner=1/無新registration或資源增長；A unschedule持Observer鎖不得擋B ingress/callback（W/L前提）；finally放行後回收 |
+| T11 共享與re-watch | 真BaseObserver+fake emitter，不啟OS backend；同parent A/B handlers共享ObservedWatch，以真queue_event注入B/rename，撤A並drain；最後B撤銷時hold teardown/re-watch | B handler/backend及通知仍在；最後ref才拆；teardown中re-watch明確OSError，放行後正式重試成功；舊handle completion不拆新generation。真OS tmpdir/rename另屬T8，不把純fixture叫OS驗證 |
+| T12 late register | owner schedule進barrier→watch等S逾時→stop/unwatch→放行late結果，交錯健康新註冊 | 逾時未假成功/未加入service watched集合；late handle精確補償、無admission復活；slot/retiring refs不洩漏 |
+| T13 直接ingress與stop狀態 | 真BaseObserver/EventEmitter＋本地proxy/facade，不啟OS；A teardown持Observer鎖，B交替兩path 10k/100k，兩root rename/固定seed60秒；另W callbacks卡住而全部100次put已返回後才放行 | raw_backlog=0；每generation pending/ready membership/active各≤1、burst第一輪+補跑≤2；wake latch≤1、unfinished_tasks恆0、get從不返回data，stop sentinel先於Observer鎖/task_done、closed不busy-spin；同path重建後舊backend proxy不能誤投新代。root完整覆蓋；object inventory＋有容差tracemalloc retained plateau，不只thread/qsize/RSS |
+| T14 polling來源/錯誤/成本 | 真PollingEmitter/DirectorySnapshot＋instrumented memory stat/listdir：child stat EACCES、recursive listdir及iterator中途EACCES、EIO/EINVAL、root ENOENT、descendant ENOENT、非OSError，初次/後續/恢復各跑；scan barrier；另真OS HEAD.lock→HEAD/rename/recreate | 不完整初次watch失敗；partial candidate不進diff/成功基線；後續同emitterlast-good物件保留、degraded一次root hint且無假FileDeletedEvent，完整成功才healthy/root通知恢復。descendant消失可合法deletion，root ENOENT與ENOTDIR/ELOOP不假empty。P非法值拒絕；snapshot/diff/M/H、fd峰值及component走訪成本/Tscan分帳，短命/同metadata仍按rescan殘餘驗 |
+| T15 nonfollow拓樸/支援面 | 真DirectorySnapshot＋lstat-mode memory VFS及syscall spy；另真OS tmpdir的external directory link、self/ancestor cycle、dangling/file link、nonrecursive、HEAD/refs與明確symlink root；barrier把已stat目錄換成symlink、scan間更換root target；能力缺席fake | descendant link本身可入snapshot但不listdir其target、不讀outside或形成cycle；每component O_NOFOLLOW且stat follow_symlinks=False，競態不逸出、失敗latch與last-good/finally fd歸零。明確root每scan重錨，不沿用舊inode；最多4 scan fds，不隨M/H/次數積累；不支援平台watch明確失敗。memory與真OS結果分列，不以簡化VFS代替syscall/OS證明 |
+
+所有 barrier/wait 均有 bounded timeout；finally 先釋放 callbacks 再 join，測試失敗也不得遺留 thread。T7 真時間只驗明示 shutdown budget並給有限測試排程容差，非用 sleep 掩蓋競態；T2/T8主要靠fake clock。
+
+### D6 交付與範圍判定
+
+spec W1–W12對應12條機械不變量，domain=0（唯一watcher.py）、state=2（concurrency/lifecycle），artifact classes=source/tests/documentation。R3補強既有W2拓樸/W7健康判定，未另藏第二production模組；T15是這兩項的新反例面，不降低invariants或state。單一polling設計已由root裁決，三件組accepted的R4獨立內容審查已PASS；完整fix-standard仍8/Red，#831真正部署後完整accepted才條件式6/Yellow。R3兩MAJOR經fresh R4重新裁決為0 MAJOR，但pure/記憶體seam不是產品/真OS/壓力/停止PASS，#853 OPEN也不給現在dispatch許可。
+
+產品提交仍由 Cortex 完成 TDD→focused/full pytest→changelog/doc/真CLI smoke→PR-context policy/review/merge。CLI不新增功能，僅驗候選環境的 `python3 -m paulsha_cortex.cli monitor --help`、隔離 config 的 `monitor --once`；不發明 monitor stop/status 命令，不連 live socket。母 #827 的真服務全來源公平、durable publication fence/部署負載 gate 留在C，A綠燈不得關母票。

--- a/docs/superpowers/specs/monitor-watcher-bounded-spec.md
+++ b/docs/superpowers/specs/monitor-watcher-bounded-spec.md
@@ -1,0 +1,35 @@
+---
+status: accepted
+work_item: monitor-watcher-bounded
+---
+
+# Watcher 有界 callback 排程規格
+
+設計裁決：採watcher-local受控polling＋直接root-coalescing ingress；不裸換PollingObserver，不修改全域watchdog。此accepted規劃已由root轉交fresh reviewer `watcher_polling_r4` 的R4 PASS／0 MAJOR結果，非產品PASS；產品驗收全部仍未完成，現行8/Red不得派builder。原K-ring方案已撤回：原始event backlog=0，只留唯一logical pending/ready狀態，見design D4.2。
+
+## Requirements
+
+本項owner為 [#853](https://github.com/hamanpaul/paulsha-cortex/issues/853)，是 [#827](https://github.com/hamanpaul/paulsha-cortex/issues/827) 的人工規劃 A child，umbrella為 [#829](https://github.com/hamanpaul/paulsha-cortex/issues/829)；母規格基線為 `fb31083e7325be86c6c9d217da56b9c4d799f5a5` 的 `monitor-refresh-thread-backlog` accepted 三件組。A 可獨立驗收 watcher 邊界，不代表母票完成。A 與 work-model B 可分別完成，service C 最後整合。Root已查重後建立/readback #853 OPEN，並在本PR加入唯一`.cortex` spec/design/todo links；當前為repository intake／unfrozen，未merge、未正式freeze、未dispatch，仍8/Red禁派。Repository links不等於已凍結的run authority或產品交付。
+
+1. **W1 固定資源**：唯一production變動為`paulsha_cortex/monitor/watcher.py`，保留公開`WatchdogFileWatcher`名稱。backend為BaseObserver＋小型受控PollingEmitter，不使用native InotifyBuffer/DelayedQueue/move-cookie cache。無每事件Timer/thread或無界executor queue；每instance callback workers上限W固定，每logical generation active≤1/pending≤1/ready membership≤1，卡住worker仍占W，不增替代者。固定backend owner B=1處理可能阻塞的Observer控制操作；一個新註冊槽、每既有key cleanup intent≤1。實際Observer dispatch thread、每backend polling emitter與未釋放資源全計量；不能只報W/B或把revoked-but-alive當回收。
+2. **W2 完整失效範圍**：key 是正規化 watch path、recursive 與 registration generation，不按每個事件新增 key。目錄 callback 的 `Path` 表示整個 watch root 失效，檔案 watch 表示該檔案失效；不得拿最後一條 event path 代表其他路徑。一次 rename 的 src/dest 分別比對所有相關 watches，來源與目的地均不漏；同 key 的 root invalidation 可合併，跨 key 不覆蓋。非 recursive 只接受 root/直接子項。遞迴不跟隨descendant directory symlink：只記link本身metadata，不掃其external/cycle target；明確指定的backend root可為symlink，每scan重新錨定它當次指向的目錄。即使scan途中directory被換成symlink，也不得沿該descendant逸出範圍；檔案symlink只觀察link entry，不新增對外部target內容的監看承諾。
+3. **W3 有限 debounce**：emitter事件在直接ingress的同一短鎖內更新首次pending時間f、最近時間e，ready deadline=`min(e+d,f+D)`，不經另一data queue才進pending。新事件不重設f；active期間只合併一份後續invalidation。第一輪已開始且阻塞、100事件全部完成ingress提交後才放行、之後不再注入時，首輪加補跑最多兩次；不同時間窗可合法多輪。poll interval P預設1秒，instance-only合法範圍0<P≤60秒且有限、非bool；P不是D。實際偵測／消費延遲還包括P、Tscan、D、worker等待與service自己的debounce，不宣稱2秒端到端。
+4. **W4 Watcher 內就緒順序**：同 key 不重入；ready queue 每 key 一項，已 ready key 不被後來熱點事件插隊，補跑排在既有 ready 項後。對有限 N、callbacks 合作式在 L 內完成，已 ready key 的保守開始界為 active 剩餘時間加 Q×L；首次事件另計 D。這不是 service local/poll/rescan/GitHub 的公平承諾。非合作式 callback 下只承諾資源有界與可見等待，不假稱有限進度。
+5. **W5 生命周期拒收**：stop/unwatch 在同一排程鎖下拒收舊 generation、取消 pending、記錄有界cleanup intent即返回，不等待callback、observer lock或backend cleanup。stop 後 watch 拒絕；unwatch 後成功重新 watch 使用新 generation，旧 handler、待取出項、callback 結束都不能替新 generation 排入補跑。重複 stop/unwatch 安全，pending 不復活；backend尚未安全拆除時re-watch可回可重試OSError，不假稱已註冊。
+6. **W6 已開始 callback 與收尾**：callback 開始的線性化點是鎖內獲取 active lease；用 callback 前/完成後 barrier 驗 stop/unwatch 兩側。已取得 lease 是 in-flight，不宣稱 Python callback 或其外部副作用可被強殺。另提供顯式 `drain` 在不持consumer lock的外部上下文，以單一總 deadline S 等合作式收尾；stop/unwatch返回只表示撤銷完成，不代表drained。callback內drain拒絕、stop/unwatch不self-join。非合作式殘餘包含既有callback≤W、backend owner≤1及其未釋放backend資源，全部tracked且不補thread；遲到 completion 不重新排程。
+7. **W7 可觀測與相容**：唯讀instance診斷保存W/active/pending/ready、backend generation/scan health/P/Tscan、callback failure、stopped/residual；錯誤按key隔離且不存無界歷史。保留watch/unwatch/stop signature、同步StubWatcher用途與watchdog缺席行為；constructor可加instance-only poll_interval_seconds，不加CLI/env。supplied stat/listdir逐操作及iterator消費共用per-scan failure latch，不能只catch外層_take_snapshot：descendant EACCES/EPERM/EIO等即使被watchdog吞掉仍拒絕整份partial candidate。只有descendant真正消失的ENOENT可略過；root錯誤與ENOTDIR/ELOOP/EINVAL等不當空目錄成功。初次任何不完整scan讓同步watch失敗；後續僅OSError保留同emitter上一成功snapshot、degraded且繼續poll，完整成功才healthy及root恢復通知，不產生partial snapshot假刪除。此成功是best-effort非原子FS快照，不宣稱跨路徑同時一致。不得吞非OSError、永久空snapshot或靜默殺死emitter。nonfollow dirfd能力缺席的平台須在watch成功前明確拒絕，不能宣稱跨平台無行為改變。
+8. **W8 可重現交付**：離線 Event/barrier/fake clock 驗 W1–W7；虛擬 60 秒 churn 查 owned resources；真 watchdog 短 smoke 與現有 rename/watch/unwatch/recreate/Git-control/rescan/last-good 回歸。所有 wait 有界且 finally 放行。透過 Cortex 保存真正 TDD RED/GREEN、tests、文件/CLI、policy/review/merge gates，不啟動模型/GitHub 呼叫作為測試 fixture。
+9. **W9 Consumer 鎖不循環**：真service `_install_watches` 持 `_watch_state_lock` 呼叫unwatch，callback的 `_project_id_for_path` 需要同鎖。unwatch不能等待該callback或藉S timeout才釋鎖；用此真caller負例驗撤銷立即完成、caller釋鎖後callback正常結束、不產生虛假stuck/provider residual。backend owner不執行consumer callback、不持watcher state lock進Observer操作；event handler只做短狀態提交。
+10. **W10 Backend 清理全程有界觀測**：Observer `stop/unschedule/remove_handler/schedule/start` 的鎖、stop hook與內部join可能在外層timed join之前阻塞，必須全部留在固定backend owner。drain至S返回backend-cleanup-timeout與精確活資源，不等其真正完成；owner卡住後新註冊拒收，舊key cleanup intents合併，不因重試、stop或re-watch增owner/queue/emitter。合作式放行後正常清理；清理未完成不得從diagnostics刪除引用。
+11. **W11 共享 backend 與世代安全**：logical watch key/handler與Observer實際ObservedWatch分開記錄，依實際backend key（root/recursive及adapter參數）共享、引用計數。撤銷A只detach A；同parent的B仍存活時不得unschedule整個ObservedWatch。只有最後handler且generation仍相符才拆backend；teardown已開始則同backend新註冊先拒收/待正式重試，不能讓舊completion拆掉新generation。雙檔共享、撤A留B、最後一個撤銷、同path re-watch/遲到detach均須真watchdog fixture覆蓋。
+12. **W12 固定拓樸下事件記憶體有界**：pre-schedule安裝instance-local直接ingress；raw event backlog=0，emitter的immutable backend-generation proxy直接匹配src/dest並合併到每logical generation唯一pending/ready，不另存K-ring或overflow Path集合。入口只取短watcher鎖，不等容量、Observer lock、consumer或stop，不把Full送至emitter。Observer queue facade只保留一個stop latch，未完成queue task計數恆0；get不返回data，不能closed後忙迴圈。舊backend proxy不因ObservedWatch.path相等誤投新backend代。保留完整相關roots，內容invalidation不撤銷subscription；stop/unwatch才revoke。固定拓樸下交替兩path/跨A-B/持續rename/teardown卡住必須以pending/ready/retained-memory oracle驗有界，不能把無界記憶體列availability residual。
+
+## Boundary
+
+callback 是失效通知，不是檔案事件日誌。目錄 root 通知由既有 service `_handle_fs_event` 解析；workspace root 走全量 refresh，可覆蓋多 project，project root/子目錄走所屬 project。A 必須用真 consumer 加 fake store 證明這個相容性，不能只測最後 Path。
+
+明示 residual：service 第二層 Timer、同步全量 scan 的成本、poll/rescan/GitHub 全來源公平性、provider timeout/last-good、新舊 source revision 合併、durable snapshot/event publication fence，全部仍屬 B/C 與母 #827 R1–R8。watcher 無權撤销 consumer 已開始的外部寫入，本項 stop 只 fence watcher admission/pending/completion。既有service可呼叫非阻塞stop；其整體shutdown/drain整合由C在安全lock邊界完成，A以自己的stop→drain測試證明合作式收尾，不暗改service或宣稱其stop同步等待全部資源。A 不宣稱 Monitor 整體 thread/freshness 或部署 gate 完成。C 必須合計 watcher callback、backend owner與 refresh workers，不能各池各自稱 W 而漏算總量。
+
+接受的觀察取捨：polling不保證兩次scan間短命create/delete/rename、或相同inode/mtime/size的改寫即刻觸發；這些可能延後至既有rescan。當下config預設full poll=60秒、targeted rescan=300秒，不是永遠固定值或硬端到端期限。此consumer重讀最終狀態，不是filesystem event log；不新增每poll強制refresh、不宣稱不漏瞬態或偵測仍與native同延遲。P與snapshot/diff成本依有限監看拓樸M、backend數N計量；短命事件盲點與scan阻塞須明列診斷/成本，不能擴大成漏已接納invalidation的豁免。
+
+本候選單production domain=0/state=2，完整fix-standard現行8/Red；只有#831真正落地後完整accepted stability改0才条件式6/Yellow，仍須獨立review與重新gate。新增第二個production模組需重評domain，不降低concurrency state以求入場。

--- a/docs/superpowers/workstreams/launcher-session-and-timeout/todo.md
+++ b/docs/superpowers/workstreams/launcher-session-and-timeout/todo.md
@@ -1,51 +1,61 @@
 ---
 status: accepted
 work_item: launcher-session-and-timeout
+domain_breadth: 0
+state_consistency: 0
+invariant_count: 6
+artifact_classes:
+  - source
+  - tests
+  - documentation
 ---
 
 # Headless launcher session（保留 canonical work_id）
 
+## Authority
+
+唯一 owner [#823](https://github.com/hamanpaul/paulsha-cortex/issues/823)；
+[Spec](../../specs/launcher-session-and-timeout-spec.md)／
+[Design](../../specs/launcher-session-and-timeout-design.md) 為完整契約。
+正式 branch `feature/823-launcher-session-and-timeout`、fragment
+`changelog.d/launcher-session-and-timeout.md`。原四檔 authoring 未寫產品／tests／CI／changelog／
+registry，未 commit/push 或呼叫模型、操作服務與 live state。本 PR 是 repository intake：
+root 已整合 #823 唯一 owner 及三件 path links、移出 #824，未登錄 #824 child，未 claim 本件。
+以下仍是未交付的正式產品工作；`accepted` 不表示 freeze、資格或已可 dispatch。
+
 ## Boundary
 
-- 唯一 issue：`hamanpaul/paulsha-cortex#823`。#824 已拆至
-  [agy-print-timeout-only](../agy-print-timeout-only/todo.md)，其 timeout／parser／
-  值域及 #851 前置驗收均保留在 child；本工作不再實作或關閉 #824。
-- 相關但不在本票關閉：#813／#568／#826。開發基底必須包含已合併 #820 的
-  AGY JSON terminal／argv 修正；不得覆蓋或重新引入舊 probe 形態。
-- 範圍限 `coordinator/launcher.py` 的兩個 headless Popen spawn 點及
-  session／process-group 相應測試與文件；timeout 專用解析／傳遞已移交 child。
-- `start_new_session=True` 隔離 session／process group，**不隔離 systemd cgroup**；
-  若 Manager unit 的 KillMode 涵蓋整個 control-group，重啟仍可能終止 direct job。
-  本票不承諾 daemon restart survival，該要求交完整 refine plan 的 runner／instance
-  ownership 工作與對應服務整合測試；不可用 pgid 測試代替 cgroup 證據。
-- 不改 dispatcher spawn（該處沒有 Popen）、effort、gate timeout 預設、Manager
-  kill/cancel 操作面、LaunchHandle pgid 欄位；不為其他 executor 加 AGY 專用旗標。
-  不操作共享 runtime-main、服務或正在執行的其他 repo job。
+- production 只改 `coordinator/launcher.py` 共用 kwargs/helper 與兩處 headless Popen；
+  domain=0/state=0 的完整理由見 Design D6，不以測試檔數冒充 production 跨模組。
+- #824 timeout／parser／CLI 值域與 #851 probe containment 均另案；不在本票實作或關閉。
+  相關 #813/#568/#826 也不關閉。base 須含已合併 #820 的 AGY JSON／argv 修正。
+- 不改 dispatcher、service、Manager kill/cancel、LaunchHandle pgid、registry、effort、
+  gate timeout、runner 預設或權限；不承諾 systemd cgroup／daemon restart survival。
+- 正式 artifacts 包含必要 tests/docs/CLI/changelog/policy/verification/review 與原 combo 的
+  OpenSpec/archive／emitted plan；不能因單 production module 限制刪掉完整交付 gate。
+- 現行 feature-oneshot 真純函式為 6/Yellow；#831 完整case 4/Yellow 僅投影。
+  Root 已轉交獨立規劃 R1 PASS／fresh reader 結果；source-condition、exact authority 與
+  審查結果仍須於真正 freeze／正式 gate 重驗採信，author 不派 builder。
 
 ## Tasks
 
-- [ ] 在 `SubprocessLauncher.launch` 共用 `popen_kwargs` 加
-      `start_new_session=True`；正常及只針對 stdin TypeError 的重試路徑都保留。
-      direct／systemd-run／systemd-template 三個 runner 包裝層，以及現有五個
-      executor，必須使用同一設定；不放寬現有 TypeError 判斷以吞掉其他參數錯誤。
-- [ ] 新增 fake Popen 測試：codex direct `bash -lc`、claude stdin=PIPE、
-      stdin 第一次 TypeError 後的第二次 spawn，均捕獲 start_new_session=True。
-      systemd-run／template 模式沿既有 `_RecordingPopen` fixture 驗最外層 spawn，
-      不宣稱此斷言代表內層 job 的 cgroup／PGID 身分。
-- [ ] 新增 `tests/test_coordinator_launcher_session.py`，只使用測試 subprocess，
-      不呼叫模型 CLI：以同 kwargs 形狀啟動 `bash -c 'sleep 30'`，斷言
-      `os.getpgid(proc.pid)==proc.pid` 且不同於測試 process group；向子 process group
-      發 SIGTERM，5秒內 reap，測試進程仍存活。以 try/finally 清理本測試建立的子程序，
-      不碰 Manager／真實 job。此案例只證明 process-group 隔離。
-- [ ] 搜尋並更新固定 keyword-only fake Popen 以接受 start_new_session 或 **kwargs：
-      基底約為 `tests/test_coordinator_launcher.py` 19處及
-      `tests/test_headless_claude_hook_506.py` 3處，數量以實際 base 重新確認；保留
-      原始安全斷言。已接受 **kwargs 的 `_RecordingPopen` 不無謂改寫。
-- [ ] 保留 timeout child 的非 AGY argv 無專用旗標契約；既有 launcher、
-      headless hook、trust-root runner/template、reviewer downgrade、accounting 與
-      #820 planning/AGY 回歸測試維持綠燈。
-- [ ] 文件與 changelog 交代 process-group／cgroup 邊界及 timeout child 移交；
-      新增 `changelog.d/launcher-session-and-timeout.md` fragment 並同步
-      `CHANGELOG.md [Unreleased]`。透過 Cortex 記錄 RED／GREEN、
-      CLI help／完整 gates、review、merge 與 installed 驗證；
-      尚未執行的 smoke 不得填成通過。
+- [ ] source/documentation T01：讀回 #823 與 exact spec/design/todo，記 source revisions/hashes；由 root 核對 #823 唯一 owner、本 canonical work_id、#824 移交、三件 path links 與 fresh base 含 #820，正式 branch/fragment 不漂移。
+- [ ] tests T02：先建立 helper／launch recording RED，盤點 `_ARGV_BUILDERS` 五 executor × 三 runner 共15格；14個現有合法配置每次 Popen `start_new_session is True`，cg/template 保留 unknown-hardening 拒絕且 Popen=0，不 stub 掉該 guard。codex direct `bash -lc`、claude PIPE、degraded env/stdin/cwd 原 oracle 保留。
+- [ ] source/tests T03：只在 launcher 抽出 `build_headless_popen_kwargs` 並讓 launch 實際使用；共同加入 literal True，保留 runner 後續覆寫與 stdout log。只修 helper 而漏接 launch 必被 T02 抓到，不改其他 production module。
+- [ ] source/tests T04：正常與 stdin-only TypeError retry 都保留 session flag；dedicated fake 驗第一錯 stdin 只移除 stdin、第二次成功、非 stdin TypeError 立即傳出與第二次再錯停止。不得放寬 TypeError 來吞 session 參數。
+- [ ] tests T05：按實際 base 盤點並最小更新 22 個固定 keyword-only fake（launcher 19/hook 3），保留原始安全斷言與 stdin retry coverage；既有 **kwargs fake 簽名維持，必要新增 flag 斷言。
+- [ ] tests T06：新增 `tests/test_coordinator_launcher_session.py`，從 production helper 取得 kwargs，真自建 `bash -c 'exec sleep 30'` fixture；按 Design D3 先驗 PGID/SID 所有權再 group SIGTERM，5 秒內 wait/reap，parent 繼續，finally 有界且只清自建 handle／PIPE。
+- [ ] tests T07：隔離負控制驗漏 helper 接線、漏 runner/executor flag、retry 掉旗標、吞非 stdin TypeError 皆 RED；去掉 session flag 的真 fixture 在 group signal 前 RED，killpg 次數為 0，finally 只 kill/reap 自建 child。不得用 mutant 殺 parent／真 job。
+- [ ] tests T08：依 Design D5 跑 focused launcher/session/hook/AGY、trust-root runner/template、inner sandbox、reviewer/accounting、#820 planning 回歸，再 full `python -m pytest tests/ -q`；保留 network guard／tmp roots，mock AGY probe 與 systemd preflight，不呼叫真模型／daemon。
+- [ ] documentation/CLI T09：核對 README/docs 的 session／cgroup／restart 邊界與 #824/#851 owner；跑候選 `cortex --help`、`cortex status --help`、`cortex stat --help`、`cortex dispatch --help`，後者只驗停用舊入口 help。無新 cancel/timeout 旗標或 operator 訊號動作。
+- [ ] documentation/changelog T10：正式產品 PR 新增並 commit `changelog.d/launcher-session-and-timeout.md`、同步 `CHANGELOG.md [Unreleased]`；不改 VERSION，產品 PR 只 `Closes #823`。planning authoring 不代填產品交付紀錄。
+- [ ] tests/documentation T11：依 feature-oneshot 保留 emitted plan、OpenSpec/archive、verification/review reports 與 Yellow adversarial gate；真 PR context 跑 policy_check，R-09/R-16/R-19/R-22 與其他適用規則、symlinks、diff check、四版 pytest/build/twine/wheel CI 全部留結果，不裸跑假綠或刪 cards 壓分。
+- [ ] tests/documentation T12：完成 root 的獨立 plan review/source-condition/freeze 後才由正式 Cortex workflow 開始產品；candidate exact-head review/CI/merge 分帳，再從 checkout 外安裝候選 wheel、核對 helper module path 並重跑隔離真 session fixture。無 live Manager 重啟／signal；未執行項目不標完成。
+
+## Verification status
+
+原 authoring 僅執行 planning 純函式、source/static scope 與文件檢查，詳見
+[報告](../../../../reports/review/refine-launcher-session-intake-20260907.md)。
+獨立 reviewer R1 PASS 與 fresh reader 結果由 root 轉交，不是 author 自評；本 PR 後續
+full preflight／CI 由 root 另留證據。產品 RED/GREEN、產品 review、freeze、merge、installed/live
+仍未完成，12 項 Tasks 保持未勾。

--- a/docs/superpowers/workstreams/monitor-watcher-bounded/todo.md
+++ b/docs/superpowers/workstreams/monitor-watcher-bounded/todo.md
@@ -1,0 +1,42 @@
+---
+status: accepted
+work_item: monitor-watcher-bounded
+domain_breadth: 0
+state_consistency: 2
+invariant_count: 12
+artifact_classes:
+  - source
+  - tests
+  - documentation
+---
+
+# Watcher-only A child：固定 worker 與完整失效通知
+
+## Boundary
+
+Owner [#853](https://github.com/hamanpaul/paulsha-cortex/issues/853)，work item `monitor-watcher-bounded`；母項`monitor-refresh-thread-backlog` / #827，umbrella #829，基線fb31083e。未來唯一production檔`paulsha_cortex/monitor/watcher.py`；tests/docs/changelog及既有`.github/workflows/tests.yml`的test-only watchdog安裝可依下列任務變更，不改runtime依賴。不得改service/work_api/provider或新增scheduler第二production模組仍宣稱domain0。A∥B→C，C承接母R1–R8整合。Root已查重後建立/readback #853 OPEN，並在本PR加入唯一`.cortex` spec/design/todo links；當前為repository intake／unfrozen，未merge、未正式freeze、未dispatch，仍8/Red禁派。未來canonical build branch為`feature/853-monitor-watcher-bounded`，changelog fragment為`changelog.d/monitor-watcher-bounded.md`；此處不建立分支或fragment。
+
+下列「四檔authoring」是原作者時點，不代表整合PR只有四檔或不需planning preflight。當前整合branch為`feature/refine-runtime-intake-20260907`；root的planning preflight／CI與未來Cortex產品TDD／OS／CLI／policy／review gates分別留證，前者不代替後者，以下產品Tasks仍全未完成。
+
+## Tasks
+
+- [ ] **Intake source/tests/documentation**：讀accepted候選W1–W12、D0–D6及母R1–R8映射。Root已選watcher-local受控polling＋直接root ingress，不裸換PollingObserver、不改全域watchdog；原K-ring與native待選設計已撤回。Root轉交fresh reviewer `watcher_polling_r4` 的R4內容PASS／0 MAJOR，非產品PASS；保存本版pure gate/hash，正式進件與產品review仍須留證。完整fix-standard目前8/Red、禁派builder，#831真runtime後6/Yellow只是條件預估，不降state或刪欄位。產品驗收以下仍全未完成。
+- [ ] **Tests/TDD RED**：新增 `tests/test_monitor_watcher_bounded.py` 的fake Observer/clock、barrier與owned診斷fixture，先在舊產品碼可靠重現W/pending/最大D、latest-path漏跨project、stop/re-watch late completion缺陷，保存真RED，不只檢查字串或複製演算法。
+- [ ] **Source W1/W3/W4**：只在watcher.py內移除事件Timer，固定callback W=2、每generation active≤1/pending≤1/ready membership≤1、FIFO及補跑尾排。d=500ms/D=2000ms/S=2s，poll_interval_seconds預設P=1秒、0<P≤60且有限/非bool；不加CLI/env。deadline=min(e+d,f+D)，P/Tscan/consumer debounce不混入D或冒稱S=端到端。卡住worker占W，不建無界queue/替代thread。
+- [ ] **Source W2 + tests T3/T4/T15**：目錄用整watch-root invalidation、file用固定watch file；src/dest分別cover相關watches，非recursive邊界/file刪除重建不漂移。recursive不跟隨descendant directory symlink，file/dangling link只記link entry；明確backend root可跟隨symlink但每scan重錨，保留lexical callback Path。真service消費端加fake store驗workspace root全量包含A/B、project入口相容，不改consumer production；不能只保留最後一event。
+- [ ] **Source W5/W6/W7/W9 + tests T5/T6/T7/T9**：generation/active lease線性化；stop/unwatch只非阻塞revoke/cancel，不進backend、不等callback，重複安全。顯式drain在consumer lock外以總S等合作式收尾，callback內drain拒絕；舊callback完成不能重排。保留callback≤W及backend owner/活資源完整residual，區分revoked/drained，不宣稱外部publication已fence。
+- [ ] **Source W10 + tests T10/T12**：watcher.py內單一backend owner B=1處理所有Observer阻塞控制操作；每既有key cleanup intent1、唯一新註冊in-flight槽，無每操作thread/Future無界queue。backend卡住/未收斂retirement時新watch回可重試OSError；同步watch只有真backend完成且generation有效才成功，timeout撤銷且late schedule結果精確補償。drain≤總S返回精確backend-cleanup-timeout與未釋放inventory，重試不可加owner/emitter/queue。
+- [ ] **Source W11 + tests T11**：logical handler與backend ObservedWatch分層、refcount和backend generation；只撤A handler不傷同parent B，最後有效ref才unschedule。teardown開始後同backend re-watch明確拒收待重試，completion按實際handle+generation，不讓舊detach拆掉新watch；全部Observer操作留single owner。
+- [ ] **Source W12 + tests T13**：在任何schedule/start前替換該local BaseObserver instance `_event_queue`為直接ingress facade，小PollingEmitter的proxy封存實際backend token。put在短watcher鎖匹配src/dest/註冊時file-dir資訊，直接合併唯一logical pending，raw backlog=0，不另留K-ring/Future/overflow Path集合。Observer只等一個stop latch；local on_thread_stop先wake再super cleanup，真stop flag→sentinel→run退出；unfinished_tasks恆0/get不返回data/task_done意外呼叫拒絕，closed不得busy-spin。old backend即使path相等也不能投新代；ingress不等容量/Observer鎖或拋Full殺emitter。
+- [ ] **Source W2/W7 + tests T14/T15**：BaseObserver公開emitter_class seam配小PollingEmitter adapter及DirectorySnapshot supplied stat/listdir，不複製walk/diff/poll loop。每scan root-dirfd重錨、descendant逐component O_NOFOLLOW/O_DIRECTORY、final stat follow_symlinks=False、scandir(fd)，descriptor≤4/finally關閉、component成本計Tscan。stat/listdir建立與iterator中途OSError先記同一bounded failure latch再raise，library吞錯返回partial也必須丟棄；僅descendant消失ENOENT可略過，root錯誤與EACCES/EPERM/EIO/EINVAL/ENOTDIR/ELOOP等不可當empty成功。初次不完整snapshot令watch失敗；後續OSError保同emitterlast-good/degraded/一次root hint，完整成功才healthy與恢復通知，partial不得生假FileDeletedEvent。未知fatal不吞、不永久空snapshot；保留inventory及unwatch→watch路徑。缺dirfd/follow_symlinks/scandir(fd)/O_NOFOLLOW/O_DIRECTORY能力在watch成功前拒絕，不偷回字串follow/native或聲称全平台相容。
+- [ ] **Tests/真鎖負例 T9**：真service `_install_watches`持 `_watch_state_lock`呼叫unwatch，同時callback的 `_project_id_for_path`等待同鎖；斷言unwatch在gate未放行前即返回而非熬到S，釋鎖後callback完成/drain成功。此自造循環不是provider residual，不得以timeout過關。
+- [ ] **Tests/真watchdog負例 T10–T12**：真BaseObserver配受控fake emitter、不啟OS backend，重現內部`join(None)`超S及同parent A/B共享ObservedWatch；修正後外部revoke/drain有界，阻塞100次重試不增owner/queue/資源。驗撤A留B通知、last-ref teardown/re-watch、schedule timeout後latehandle補償與失敗不進service watched集合；finally釋放全部gate/join。
+- [ ] **Tests/固定拓樸backlog T13/T14**：真BaseObserver/EventEmitter雙backend鎖阻塞、W callback barrier與直接ingress，交替兩path10k/100k、兩root rename、固定seed60秒；object inventory驗raw0、每generation pending/ready/active≤1、control latch≤1、unfinished0、零closed busy-spin。全部100次put返回後才放callback gate，驗最多一次補跑；舊backend proxy/path-equal re-watch不得污染新代。tracemalloc retained delta有明示容差/不隨event倍增線性成長；A teardown持Observer鎖時健康B仍提交/通知。真polling OS source-stall/smoke另驗，不把fake emitter說成OS結果。
+- [ ] **Tests/R3 regression T14/T15**：初次與steady-state各注入child stat EACCES、recursive listdir即時/迭代中途EACCES、EIO/EINVAL、root/descendant ENOENT與非OSError；真library先驗RED吞錯，再驗latch不進partial diff、last-good物件/健康轉換/恢復hint。memory VFS另驗link mode不递迴、syscall spy驗每component nofollow；真OS external/cycle/dangling/file link、directory→symlink barrier競態、root symlink target跨scan更換及HEAD/refs/nonrecursive分開跑。FD≤4且finally歸零、無跨scan stale fd/inode，缺平台能力明確失敗；初次/恢復都須可機械反證，不能以root層PermissionError fixture代替descendant覆蓋。
+- [ ] **Tests W bound/D/FIFO**：W=2 barrier占滿、A首輪開始後注入100次再放行，驗A首輪+補跑≤2、pending1；不同窗允許多輪。fake clock d=0.1/D=0.5/L=0.2秒驗首次pending+D ready與B不被A插隊；record owned counts，不用全程序active_count當唯一oracle。
+- [ ] **Tests 60秒虛擬churn/real smoke**：固定seed含watch/unwatch/re-watch/rename，W+B、pending/tombstone/retiring backend及底層helpers均有界；backend卡住後資源以N0+既有in-flight上界凍結，不用live key減少掩蓋殘餘。短真watchdog tmpdir smoke與 `tests/test_stage9_project_monitor_service.py` 全部既有burst/rename/watch/unwatch/project recreate/Git-control/rescan/last-good回歸，stop後顯式drain再查owned基準。watchdog缺席不得全skip後宣稱production已驗；所有wait bounded/finally釋放join。
+- [ ] **Documentation**：同步內容invalidation vs subscription revoke、受控polling W+B/D/S/P、raw0/唯一pending與ready/stop latch、watchdog6及dirfd平台能力相容面、同步watch成功/失敗、per-scan failure latch/last-good恢復、nonfollow descendant與明確root symlink邊界、drain/inventory/refcount/generation。成功scan是允許消失競態的best-effort視圖，不宣稱原子一致；有限fd與component/depth成本計入Tscan，不假M對所有拓樸固定。明列短命與sameinode/mtime/size盲點可能等既有rescan，當下full60秒/targeted300秒非永久或硬期限；成本P+Tscan+D+排隊＋consumer debounce，正常poll不強制refresh。service第二Timer、全來源公平、durable fence/整體drain與部署仍B/C/母票；固定拓樸記憶體無界不能列residual，不關母票。
+- [ ] **Changelog R-09**：產品PR新增並commit `changelog.d/monitor-watcher-bounded.md` 及 `CHANGELOG.md [Unreleased]`；本次intake四檔authoring不冒稱完成這項產品交付。
+- [ ] **CLI R-16 + tests R-19**：不新增CLI選項，核對monitor help/usage仍相容；在候選checkout外實跑 `python3 -m paulsha_cortex.cli monitor --help` 與隔離fixture config `monitor --once` JSON smoke，不連live socket/模型/GitHub。先focused pytest再full pytest與現有CI，附命令/環境/實際輸出，不能用help成功代替watcher行為驗收。
+- [ ] **Test-only CI dependency**：既有`.github/workflows/tests.yml`的pytest job安裝watchdog6.0.0並確認import/version；當下pyproject test extra僅pytest，不可假設CI已有watchdog。新core watcher tests缺依賴明確FAIL，不能全部skip偽GREEN；真OS smoke與原缺watchdogfallback的隔離mock分開。此為tests artifact，不擴production module/domain或變更全域/正式runtime套件。
+- [ ] **Cortex delivery/review**：保存真RED/GREEN、全部tests/CLI、PR-context policy、git diff --check、expected head/CI/review/merge證據。未處置缺陷或gap判FAIL；明文有界residual且母票列管不單獨FAIL。產品code只能Cortex派工；任何部署/共享服務重啟由root另按in-flight ownership處理。

--- a/openspec/changes/cortex-refine-complete/tasks.md
+++ b/openspec/changes/cortex-refine-complete/tasks.md
@@ -10,6 +10,7 @@
 - [ ] 2.0 補 #830 非 Job 決策回覆與 #831 sizing stability 方向；保留合理單模組 sizing 及所有 gate；#833 獨立交付 Red planner 分解接線。
 - [ ] 2.1 透過 Cortex 完成 #822 argv/YAML canary，取得 RED/GREEN、review、policy 與 terminal delivery 證據。
 - [ ] 2.2 完成 #827 有界 refresh/coalesce、slow-provider 公平與 stop/diagnostics。
+- [ ] 2.2.1 先依 #853 交付 watcher-only A child 的固定 worker、raw0、generation/共享 backend、partial-scan latch 與 nonfollow VFS；現行8/Red不可派，#831 loaded 後重評。B work-model 與 C service 的 provider 公平、durable publication fence、整體 drain 仍需各自交付，不以 A 關閉母票。
 - [ ] 2.3 完成 #819 not-idle clock、periodic 有效 max_load/require_idle 與非法值處置。
 - [ ] 2.4 依 accepted 三件組完成 #496 內容/狀態冪等，驗同 path 內容改變仍恰好記錄；保留現行 7/Red，#831 後真重評。
 - [ ] 2.5 依 accepted 三件組分拆並完成 #497 原子解除綁定、持久 supersession 與 restart/late-terminal 回歸；#831 後仍預計 Red，#501 只核對已修及殘餘污染。
@@ -17,6 +18,7 @@
 - [ ] 2.7 完成 #823/#824 session 與 AGY timeout 合約，明示 cgroup restart survival 的獨立驗收。
 - [ ] 2.7.1 先依 #851 補 AGY probe 的 argv construction containment，真 ready 非 AGY primary 不被阻擋；#824 仍需真非法 env 的 direct/probe/runtime 整合驗收，不拿 baseline fault injection 代替。
 - [ ] 2.7.2 #824 dependency 證據未滿前不登錄可 claim child／不開 auto label；解除後重新核對完整性、真 sizing、唯一 owner 與正式 freeze，不能依 custom frontmatter 自稱已鎖派工。
+- [ ] 2.7.3 依 #823 session-only 三件組完成共用 kwargs 真接線、兩個 Popen／stdin 窄重試、合法配置及既有拒絕、所有權驗證先於 group signal 的真 fixture 與候選 wheel 驗收；不擴成 cgroup/restart/cancel 實作。
 - [ ] 2.8 完成 #825 最小 durable backoff，所有 lane 與 corrupt-state/expiry 可測；不標 R05 完成。
 - [ ] 2.8.1 先依 #850 有界 store／immutable event-fold child 交付 component；C/D provenance、reconciliation 與所有 lane 接線仍由 #825 後續 child 承接。
 - [ ] 2.9 以實際已載入 revision 驗 B1 成效，退出暫時 bypass 前保存 active jobs 與 rollback 方案。

--- a/reports/review/refine-launcher-session-intake-20260907.md
+++ b/reports/review/refine-launcher-session-intake-20260907.md
@@ -1,0 +1,129 @@
+# #823 session-only planning authoring report
+
+## Authority and scope
+
+本報告保留 author handoff 並同步 root 轉交的審查結果，沒有 author 自評 PASS。唯一 issue owner #823、canonical work_id
+`launcher-session-and-timeout`；正式 builder branch `feature/823-launcher-session-and-timeout`，
+fragment `changelog.d/launcher-session-and-timeout.md`。#824 timeout 與 #851 containment 完全另案。
+
+原 author branch `feature/refine-launcher-session-intake-20260907`，基底
+`984fce5b86604aa71c6e8ecf82cc253a1441a106`。先盤點 main worktree dirty/untracked 與 worktree
+清單，確認本 branch/path 不存在後才由 origin/main 建隔離 worktree；新 worktree 的
+`git pull --ff-only origin main` 為 already up to date。未改 operator 原工作、runtime-main 或服務。
+
+原 authoring 恰四檔：新 [spec](../../docs/superpowers/specs/launcher-session-and-timeout-spec.md)、
+[design](../../docs/superpowers/specs/launcher-session-and-timeout-design.md)、修訂
+[todo](../../docs/superpowers/workstreams/launcher-session-and-timeout/todo.md)、本 report。
+該 authoring 沒有產品 code/tests/CI/changelog/.cortex/issue 變更，無 commit/push、dispatch 或模型呼叫。
+doc-coauthoring 用於 owner／三件組對齊；test-playbook 用於 deterministic matrix、安全負控制
+與 process cleanup。fresh reader／獨立 review 由 root 安排並轉交結果，author 未另派 agent 或自評通過。
+
+目前四件已由 root 逐 hash 複製至 `refine-runtime-intake-20260907` worktree，branch
+`feature/refine-runtime-intake-20260907`、base `2c1bba01`。本 PR 是 repository intake／
+unfrozen，未正式 freeze、claim 或 dispatch，仍 6/Yellow。本次僅在新 root worktree 同步
+四件 metadata／歷史時態，原 author worktree 不變；root 的進件 links 與後續 full preflight／
+PR CI/commit 證據另記，不能把原 author 的「未執行」誤讀為整個 root PR 永遠不做 gate。
+
+## Readback and source condition
+
+- 已全文讀 GitHub #823（open、updated `2026-09-07T10:01:40Z`、comments 空）與 #208 rubric。
+  #823 的歷史錯行號不照抄，以下重新對照 author 基底 source。
+- root 最新 session-only todo 來自 `refine-agy-dependencies-20260907` worktree，SHA-256
+  `4fccca59be4efbada3f49b8e742acdc9063f999a7937baba53f14589f3a9b0e1`；只讀未回寫。
+  新 todo 延續該拆分，補齊 spec/design、rubric/AC、helper 真接線與安全 fixture；名稱不變。
+- `git merge-base --is-ancestor 79ba644780bf1c697c722ac24a297e7d02416100 HEAD` 成功，基底包含
+  #820。正式 source-condition 還要在 freeze 前核對 fresh remote base，不能永久沿用此 snapshot。
+- 原 author 基底 984fce5b 的 `.cortex/work-items.yaml:851–859` 曾在本 work_id 連 #823/#824，
+  只有 todo path。Root 現回報本 PR 已整合 #823 唯一 owner 與三件 path links，#824 已移出，
+  未登錄 #824 child，也未 claim 本件；本 metadata 同步不修改 `.cortex`。
+  repository links 不等正式 frozen authority；真正 freeze 前重驗唯一 owner、三件 exact
+  refs/hashes、fresh base 與 reviewer input。純 helper 無法證明 live admission/source-owner
+  已更新，不能拿 ready=true 直接 dispatch。
+
+## Anchored source trace
+
+以下相對路徑／行號以 author 基底為當下佐證，不宣稱窮盡所有未來 caller。
+
+| 錨點 | 當下事實／本票處理 |
+|---|---|
+| `coordinator/launcher.py:1341` | `_ARGV_BUILDERS` 為五 executor；測試使用原 registry，不加 production 對照表 |
+| `coordinator/launcher.py:1764` | launch 先 runner/role preflight，後續才 build argv；不移動安全前置條件 |
+| `coordinator/launcher.py:2085` | direct builder `bash -lc`；review/degraded `bash -c` 原分支保留 |
+| `coordinator/launcher.py:2086` | 共用 cwd/env/stderr kwargs，claude 加 PIPE；尚無 start_new_session/helper |
+| `coordinator/launcher.py:2112`、`:2231` | systemd runner 仍覆寫 client env/stdin，template 另設 cwd=None；新 helper 不能蓋回去 |
+| `coordinator/launcher.py:2257`、`:2262` | 正常與 stdin TypeError 兩處 Popen，共用同 dict；只 pop stdin，不擴退回 |
+| `coordinator/launcher.py:609` | LaunchHandle 除 pid 已有多個既有 provenance/control 欄；本件不增 pgid、不改任何欄位 |
+| `coordinator/job_runner.py:849` | runner unset=direct、非法 fail-closed；本件不改預設 |
+| `coordinator/job_runner.py:696`、`:1959` | cg 刻意不在 template hardening profile，template launch 於 Popen 前拒絕；15 格 coverage 是14個合法配置＋此拒絕，不能新增權限湊15個成功 |
+| `tests/test_trust_root_job_runner_p2a.py:104`、`test_trust_root_job_template_ab.py:105` | recording Popen 已收 **kwargs；沿現有 preflight/unwrap harness 驗最外層 wrapper |
+| `tests/test_coordinator_launcher.py:758`、`test_headless_claude_hook_506.py:535` | 固定 fake 19+3=22 處；需兼容新 keyword，保留 stdin retry／原安全斷言 |
+| `tests/test_coordinator_agy_launcher.py:344` | AGY recording fake 現在是 344，issue 舊 338 已漂移；不把只 stub argv 的案例冒充 launch 接線 |
+| `tests/conftest.py:97`、`tests/network_guard.py:426` | tmp runtime/repo roots 與 network guard；真 sleep fixture 無 provider/network，不能關 guard 取巧 |
+| `.github/workflows/tests.yml` | 既有 Python 3.10–3.13 full pytest＋build/twine＋wheel smoke；本 author 不執行或修改 CI |
+
+production 路徑表的 `coordinator/` 前綴為 `paulsha_cortex/coordinator/`。
+product focused/full 命令與 CLI help／installed fixture／完整 artifacts 已寫 Design D5、Todo T08–T12。
+原 authoring 只 trace/source-read，未跑產品測試；新增 helper/session test 尚待正式產品工作。
+
+## Rubric and pure verification
+
+宣告 domain=0/state=0：唯一 launcher production module、local kwargs→既有 Popen；無 schema、
+durable migration、跨 writer atomicity／reconciliation 或 Manager lifecycle protocol。測試真 OS
+session 不等產品新增 concurrency state；若要求 cgroup/pgid persistence/cancel 則重裁，不能守 0 壓分。
+Spec 的六個獨立 I1–I6 完整映射 Todo 與 matrix，artifact classes=source/tests/documentation。
+
+root 指定現行 79 runtime 的 pure planning helper 與 packaged feature-oneshot：11 cards、
+11 bindings、4 core gates；sizing rules=R-09/R-16/R-19，plan compatibility另含 R-22，
+Tasks surfaces=source/tests/documentation/CLI。現行完整 accepted case 計 `[0,0,2,2,2]=6/Yellow`；
+#831 `[0,0,2,0,2]=4/Yellow` 僅算術投影，未改 sizing 或 runtime。
+
+原 authoring 實跑 root 提供的 `check-child-planning.py <author-worktree> launcher-session-and-timeout
+feature-oneshot`，以明示 PYTHONPATH 指到 79 runtime，從 checkout 外 `python3 -B` 執行。
+核對 module.__file__ 與 runtime HEAD=79ba6447，並以 git diff 證明 author 基底的 planning.py、
+deck schema/cards/feature-oneshot 與該 runtime source 相同。僅載入純函式，無模型／dispatch。
+
+- 三件組 complete=true，spec/design/plan accepted=true，reasons 空；三個 headings 精確匹配。
+- 真 score=`[0,0,2,2,2]=6`、真 `sizing_band(6)=yellow`；cards=11/bindings=11/core gates=4。
+  #831 另以 dataclass 的 spec_stability=0 算 4/Yellow，只投影不改 runtime。
+- plan gate ready=true，completeness/contract_compatibility/envelope 全執行；最後一項為
+  `bypass: envelope_unavailable`。不是 measured envelope、模型資格或進件／source-owner 證據。
+- 12 組純 in-memory 負控制均拒絕：缺 spec、spec draft、design blocking、缺 Tasks、缺
+  domain、缺 state、刪 source/tests/documentation/CLI/changelog Tasks 關鍵字、synthetic
+  invariant limit=5。synthetic 只驗 6>5 會拒收，不能拿來做模型評測。所有變體未寫入文件。
+- blocking design 控制使舊算法降到 4/Yellow，但 completeness=false；該錯向分數不能當可派。
+- 四檔 newline/尾端 whitespace/無個人絕對路徑、7 個相對 Markdown links 與既有 focused
+  test 路徑檢查通過；唯一不存在的 test path 正是明示待新增的 session fixture。
+  Todo 12 項產品 Tasks 全未勾；git diff --check 通過，精確 scope 恰四檔。
+- 原 authoring 的 production/tests/CI/.cortex/changelog/VERSION 與其 HEAD 無 diff；該階段
+  未執行產品測試、CLI smoke、CI、policy_check、installed 或 merge。Root 本 PR 的 links 與
+  後續 full preflight/CI 另記；不以裸 policy_check 或 source/helper 綠燈冒充。
+
+author 自查後發現 cg/template 的既有拒絕，root 已獨立核對並採納 15 格 coverage inventory
+的精確解讀；spec/design/todo 都已同步14個合法配置＋1拒絕。該 author 階段的 source 邊界
+裁決不曾冒充獨立 review；後續獨立結果見下節。
+
+## Reviewer handoff and residuals
+
+固定判準：未處置 BLOCKER/MAJOR→FAIL；明示有界且文件列管 residual 不單獨 FAIL；
+反對接受者須具體反駁其影響分析。Root 已轉交本 #823 四件的獨立結果：
+
+- `agy_containment_review` R1＝PASS；另有獨立 offline constructor＋argv＋role/profile
+  檢查，14 個配置 admit，cg/template 精確拒絕。這不是完整 launch／OS signal 證據，
+  不能據此勾選產品 session fixture 或真 Popen 驗收。
+- `agy_dependency_reader` fresh reader 五題全正確，未發現重大歧義；root 已全文讀回。
+  審查歸因於上述獨立 reviewer／reader，結果由 root 轉交，不是 author 自評或其他 child 的 PASS。
+
+以下保留 reader 的五個驗證問題：
+
+1. canonical work_id／唯一 issue／builder branch／fragment 是什麼，#824/#851 是否本件？
+2. 真 fixture 如何確實測 production helper，且哪個 oracle 能抓「helper 綠、launch 沒接」？
+3. stdin retry 可以移除什麼，哪些 TypeError 必須立刻傳出？
+4. 負控制缺 session flag 時，如何保證沒有對 parent group 送 SIGTERM，child 又如何 reap？
+5. session 綠燈是否代表 systemd job/cgroup 或 Manager restart survival；純 Yellow 是否已可 dispatch？
+
+有界 residual：不移 cgroup、不處理 Manager cancel／kill taxonomy、不保證任意 provider 孫程序
+留在 group；完整 refine plan R13 其餘生命週期要求保留。真 fixture 採 `exec sleep`，使失敗路徑
+只有本測試持有的一個 process handle，仍驗真 group signal，並明示不代表 descendants qualification。
+本 PR repository source-owner/links 已由 root 整合；正式 authority/source-condition 仍在真正
+freeze 時重驗，本 author 未自行補登、claim 或派工。產品 implemented/tests/CI/merged/installed/live
+仍未完成；root planning PR 後續 full preflight 分帳，metadata 同步後四檔 hash 隨交接另報。

--- a/reports/review/refine-monitor-watcher-child-20260907.md
+++ b/reports/review/refine-monitor-watcher-child-20260907.md
@@ -1,0 +1,182 @@
+# Watcher-only A child intake：邊界、驗收與 gate
+
+日期2026-09-07。隔離authoring branch `feature/refine-monitor-watch-child-20260907`；當時local `origin/main`基底 `fb31083e7325be86c6c9d217da56b9c4d799f5a5`。先唯讀inventory確認operator已有其他變更、target branch/worktree不存在，再建立新worktree。當時未pull/fetch或改operator/runtime/live；作者只新增兩份spec/design、todo及此report，未commit/push、開issue、註冊`.cortex`、建立run或派模型/產品code。這是authoring當時紀錄；root後續已建立owner issue如下，不把歷史敘述當成目前Git/GitHub狀態。
+
+**最新狀態：owner [#853](https://github.com/hamanpaul/paulsha-cortex/issues/853) OPEN；本PR repository intake／unfrozen，R4內容PASS／0 MAJOR，仍8/Red禁派。** Root已查重後建立/readback本child，parent #827、umbrella #829，work item `monitor-watcher-bounded`；本PR已加入唯一`.cortex` spec/design/todo links，未merge、未正式freeze、未dispatch，不等於已凍結的run authority。R4結果由root轉交fresh reviewer `watcher_polling_r4`，僅規劃內容審查，不是產品GREEN或live驗收。Root採納只重讀final state的consumer證據及native復原擴面成本，選watcher.py內BaseObserver＋小PollingEmitter adapter＋直接root-coalescing ingress；R3再准許窄化per-scan dirfd nonfollow VFS與failure latch，沒有複製watchdog engine。原K-ring與native待選方案均撤回，raw backlog=0契約保留。W1–W12產品任務仍全未勾，不用helper ready、開票或repository links宣稱交付。未來canonical build branch=`feature/853-monitor-watcher-bounded`，fragment=`changelog.d/monitor-watcher-bounded.md`，不是authoring／本次planning整合branch或已建立的產品產物。
+
+## Authoring 方法與適用邊界
+
+原author時點依doc-coauthoring使用既定受眾/accepted模板/邊界直接起草；test-playbook將actor、state/side-effect owner、非同步race轉成Event/barrier/fake-clock與真consumer oracle。當時root禁止作者派模型，故未由本作者啟fresh-reader；文件閱讀與adversarial檢查交回主流程獨立review，未冒稱自批PASS。以下source/fixture、四檔scope與未commit／未CI敘述均屬當時紀錄；本次整合狀態與root轉交reader結果另見末節。
+
+本項只交付單一backend設計的intake候選，產品W1–W12未實作。A與work-model B可各自驗收，最後仍由C整合service與母#827全AC。基線是fb31083e父accepted三件組，不把原M1–M5候選表當已完成自動分拆；#833尚未提供本項自動child authority。
+
+已取回 `patchmud_issue` agent的既有最終A∥B→C分析（透過agent結果，沒有另跑現場）：A唯一watcher.py；B唯一work_api.py，負責provider I/O/commit隔離、source粒度generation/revision與latest-state合併、last-good/owner/error、正常production路徑的commit fence；C唯一service.py，依A/B已交付契約統一全來源排程及durable/server publication停止線性化。其殘餘一併保留：scan有限L仍需證明、snapshot store也持鎖掃描、correlation若需改輸入快照就是額外production模組、診斷若改頂層durable schema要重裁scope。C須合計watcher與refresh pools，不能各池各稱W而漏算實際refresh並行數。
+
+## Source 錨點與原因
+
+基底fb31083e的 `paulsha_cortex/monitor/watcher.py:117–137` 每事件Timer/latest_path；`:150–163` src/dest首match即return；`:165–169` cancel只取消Timer；`:209–235` unwatch/stop沒有join callback worker契約。`WatcherCallback`於`:17`仍是Path通知。
+
+`monitor/service.py:155–201`安裝workspace/project watches，`:280–284`未映射Path走全量refresh，`:301–315`project Path走project；故directory root invalidation有現成consumer seam可驗多project覆蓋。這只是目前source佐證，跨path完整性由spec T3/T4運行不變量驗收，不以靜態掃描作「不存在其他consumer」全稱背書。
+
+`service.py:317–330`仍有第二層Timer；A不修它，亦不解決work_api provider global lock/late durable publication。既有watchdog真測試位於 `tests/test_stage9_project_monitor_service.py:1147–1210`，但尚不足以證明高churn/stop races。
+
+## Parent R1–R8 mapping
+
+| Parent | A可獨立驗收 | 仍由B/C與母票持有 |
+|---|---|---|
+| R1有界owner | W1/W10/W12，callback W＋固定backend B=1、bounded intents/註冊槽與全部採用事件暫存 | service第二Timer/未映射scan、poll/rescan/GitHub統一排程與各池加總；W12不可向母票卸責 |
+| R2 coalesce | W2/W3/W12，raw0直接watch-root coverage、每generation唯一pending/ready與D | project/source最終snapshot coalesce與服務層batch/fullscan合併 |
+| R3公平 | W4，watcher ready FIFO在有限callback L前提下的界 | 全來源公平、慢provider鎖外I/O與無飢餓整合 |
+| R4 timeout/last-good | W6/W7僅callback/backend收尾與poll snapshot暫時OSError保活 | work provider timeout、last-good/authority/source revision與晚到結果 |
+| R5診斷隔離 | W7/W10/W12，revoked/drained、poll scan health/P/Tscan、callback/backend/pending/ready/stop-latch counts | 完整snapshot/read-model相容、per-source freshness及錯誤合併 |
+| R6 stop fence | W5/W6/W9/W11/W12 admission/pending/generation/completion、共享backend保護、獨立stop latch與unfinished0 | consumer已開始event/durable commit線性化publication fence |
+| R7有界收尾 | W6/W9/W10，非阻塞revoke、總S drain、不循環等鎖、backend tracked residual | service/provider/adapter cooperation、安全上下文drain接線與整體shutdown |
+| R8可重現 | W8/T1–T15，fake-clock/barrier/真consumer鎖/真BaseObserver純fixture、descendant failure/nonfollow VFS與所選OS backend另驗 | 真CLI/全鏈路服務公平/publication/部署負载最終gate（A仍做自身CLI相容） |
+
+## Truthful sizing 與純 gate
+
+domain_breadth=0：唯一production watcher.py；state_consistency=2：並行atomicity/lifecycle，不降成純函式。invariant_count=12對應W1–W12；artifact_classes=source/tests/documentation。R3補強原W2範圍/W7健康契約並增T15反例面，未降低數值或另藏模組；新的dirfd stat/listdir adapter與failure latch仍在watcher.py，重用DirectorySnapshot的公開VFS及原walk/diff/poll loop，不改套件。固定完整fix-standard為0/2+2/2/2=8/Red；#831真部署且完整accepted後才條件式6/Yellow。若實作需要第二production仍須回root重評，不能以文件accepted遮過scope差異。
+
+R4審查版於`2026-09-07T13:42:53.006278+00:00`在checkout外`/tmp`設`PYTHONDONTWRITEBYTECODE=1`，import當時runtime checkout（HEAD=`79ba644780bf1c697c722ac24a297e7d02416100`）的planning/manager純函式。三件組逐件accepted=True、complete=True、missing_kinds=[]、reasons=[]、blocking_markers=[]。真score=`domain0/state2/acceptance2/stability2/orchestration2`，total=8、band=red；不是派工許可。其後author #853 owner metadata版pure/hash與本次repository-intake metadata版hash分節記錄，不混為同一版或root planning preflight結果。
+
+真packaged fix-standard：gate_spine_count=2、cards_count=9、persona_binding_count=9；規則完整R-09/R-16/R-19。`_evaluate_yellow_plan_review`回ready=True、checks_run=(completeness,contract_compatibility,envelope)，真identity lookup得到`bypass=envelope_unavailable`，不是能力量測PASS、不覆盖Red。記憶體run僅steps=()/primary_domain=None/model_chain_override=None/sizing_band=red，未寫registry/執行model。此helper的completeness只找task surfaces（planning.py:526–543），不能單獨證明三件組accepted或設計正確；本次另實跑三件組完整性。
+
+重跑鏈：三個真檔→PlanningArtifact(spec/design/plan)→assess_planning_completeness→compute_sizing_score（真combo/完整規則）→claim.sizing_band→Yellow helper。identity讀取不輸出credentials。歷史10:19/10:42曾accepted/8Red，第二輪發現queue缺口後11:05改draft/complete=False；當時反向stability卻算6Yellow、helper仍ready，已明記NO-GO，沒有依它派工。以下保留R4所review、加入#853 owner/status之前的歷史三件組hash，不是目前intake metadata版hash或正式authority/evidence receipt；後續兩版hash於本report後方分列。
+
+| Artifact | SHA-256 |
+|---|---|
+| `docs/superpowers/specs/monitor-watcher-bounded-spec.md` | `8e92009a650f5ade491d2b3d3c9416538958420e656f4913c07d1de0c61c6482` |
+| `docs/superpowers/specs/monitor-watcher-bounded-design.md` | `c6ca2c9836ac53446f34cea8ec879e5ac6b940a787989e384681644b399e8a5f` |
+| `docs/superpowers/workstreams/monitor-watcher-bounded/todo.md` | `c716f829cd1b3cf47a2f5b186010de9bdebb0ddf621214fca123d722e041add3` |
+
+原author時點沒有執行產品test、CLI smoke、CI/policy或live驗收，也未執行commit/push；當時四份新文件的whitespace以逐檔no-index檢查驗證，不能以普通`git diff --check`忽略untracked檔當唯一證據。當時作者scope inventory僅四檔、authoring base未變；不宣稱本次root整合PR仍只有四檔或沒有planning preflight／CI。todo的未來產品gate仍待Cortex交付，root planning檢查不代替它們。
+
+## 離線可執行驗收設計
+
+候選產品測試命令：`python3 -m pytest -q tests/test_monitor_watcher_bounded.py tests/test_stage9_project_monitor_service.py`，再 `python3 -m pytest -q`。新tests檔由Cortex依todo建立，不是authoring已存在的測試證據。fixture保證network/model launcher禁用、watchdog dependency存在、fake Observer event→production admission→real worker callback，必要時真service+fake store。
+
+T1/T13在W callback barrier已取得lease時注入100事件，全部put返回才放gate，驗raw0與首輪+最多一次補跑；T2假clock驗D/FIFO；T3/T4驗多root/rename/真consumer最終store；T5/T6驗revoke、self-call、exception；T7驗非合作callback總S drain；T8固定seed虛擬60秒另真OS smoke；T9真service lock負例；T10持Observer鎖等A cleanup時健康B仍可ingress/通知；T11真BaseObserver+fake emitter shared/generation不是OS驗證；T12 late schedule補償。T13另驗stop facade無data get/unfinished累積/closed busy-spin，10k/100k retained-memory plateau。T14新增child stat、recursive listdir及iterator中途失敗，驗完整性latch/last-good與無假刪除；T15區分memory nonfollow、syscall spy與真OS external/cycle/symlink swap/root更換/fd回收/平台缺能力。所有產品cases未執行，wait均有限/finally清理。
+
+## 獨立 review：三 MAJOR 採納與證據來源
+
+首版review結果FAIL，三項均採納，不當false positive或provider residual。Reviewer `refine_plan_review` 提供的fixture全部是stdin純記憶體，**沒有fixture檔案路徑**；root另以相同真Python/watchdog完整重跑確認。作者當時只讀service與installed watchdog上述source/這些既有結果來修文件，未把它說成新產品GREEN。當時修後待主流程重審，不沿用首版pure PASS代替；後續R4內容PASS見末節，產品仍未驗。
+
+環境：`/usr/bin/python3`、Python3.12.3、watchdog6.0.0，module位於`$HOME/.local/lib/python3.12/site-packages/watchdog`；不用`-s/-I`（fixture需user site），設`PYTHONDONTWRITEBYTECODE=1`。Case1用真service+模擬首版「unwatch等待lease」的fake；Case2/3用真`watchdog.observers.api.BaseObserver`+fake emitter，不啟OS observer/backend，不連live。
+
+| MAJOR | 精確source/既有fixture輸出 | 本輪處置與新增oracle |
+|---|---|---|
+| 持consumer鎖等callback | service.py:156–185持`_watch_state_lock`呼叫unwatch；:303–306 callback取同鎖。`callback_finished_inside_unwatch: False`，caller返回釋鎖後才能完成 | W9/T9：unwatch/stop只revoke，drain分離；必須在未放callback barrier前返回，不能熬S或生stuck |
+| 外層timed join不包backend清理 | watchdog observers/api.py:353 unschedule→:234 `_remove_emitter`之`emitter.join()`，utils/__init__.py:61 stop同步呼叫hook；inotify.py:121→inotify_buffer.py:44還有內部join。`join_timeouts: [None]`、`still_running_after_S: True` | W10/T10/T12：固定owner B=1、caller等待有界、註冊槽與cleanup intent有界、卡住新watch拒收、latehandle補償 |
+| 撤A誤拆共享B | observers/api.py:60 ObservedWatch.key、:270 schedule、:335 remove_handler_for_watch、:353 unschedule。`same_backend_watch: True handlers: 2`；撤A後`B_backend_retained: False B_handler_retained: False` | W11/T11：logical refs/backend generation、只detach A、最後ref才teardown；re-watch碰retiring backend拒收待重試，舊completion不拆新generation |
+
+重跑入口為 `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=<本child checkout> /usr/bin/python3 -B -`：Case1讓真service `_install_watches()`持鎖進fake unwatch，該fake啟callback跑真`_project_id_for_path`，以`attempting` Event確認進入後`done.wait(.1)`必False；Case2 FakeEmitter.join(timeout=None)記參數並在Event gate等候，thread執行真`BaseObserver.unschedule`，`joined.wait(1)`後`thread.join(.1)`仍alive；Case3同`/virtual/parent`對A/B handlers各schedule，檢共享及unschedule後B消失。所有gate於finally放行/threads join；這些舊行為負例已由reviewer/root執行，不替代T9–T12的新產品驗收。
+
+上述首輪修正目標仍留watcher.py：drain為watcher-local API，service既有stop僅要求撤銷，C才接整體drain。第二輪已反駁「固定owner即可宣稱backend全部資源有界」：全域lock卡住時其它watch event delivery停滯，EventQueue仍無界入列。因此先前資源有界的residual判定撤回；只有W12全部採用source queues通過後，availability才可單列殘餘。既有handler不被誤拆、caller不被backend拖住、owner/queue/資源不增長均屬本票硬不變量；不暗改service或watchdog套件、不降state。
+
+## 第二輪歷史：無界來源成立、未以residual放行
+
+Reviewer在雙backend A teardown卡observer lock、B連續事件時觀察10k事件全積壓且零delivery；root另用真BaseObserver/EventEmitter但不啟OS backend、固定一backend交替兩FileModifiedEvent重跑，`qsize=10000/maxsize=0`。這是memory無界，不是單純availability residual。native額外source：watchdog6.0.0 `observers/api.py:140` queue_event→put，`:183`建立EventQueue()；`utils/bricks.py:71–79`只跳過相鄰相同事件；`inotify_buffer.py:27–33`建立DelayedQueue且立即start、`:98`逐筆put；`utils/delayed_queue.py:23–31`無界deque/append；`inotify_c.py:188/210–229`move-cookie cache有clear方法但此installed observers目錄的當下rg僅找到定義，source_for_move不移除entry。此靜態範圍證據不是所有版本/所有caller的全稱結論。
+
+作者另於11:02:09Z前在`/tmp`執行純記憶體installed-library負例（未啟OS或新thread、不跑產品code）：真BaseObserver(EventEmitter) schedule但不start，兩path交替queue_event一萬次；DelayedQueue.put一萬次；Inotify以`__new__`只建move map並呼叫remember_move_from_event一萬cookie。輸出依序`central_qsize 10000 maxsize 0`、`delayed_queue_records 10000`、`move_cookie_records 10000`、`started_threads False False`。只證明當前buffer方法沒有容量界，不宣稱真OS固定拓樸記憶體壓力E2E已測。
+
+| 裁決 | 真代價與source理由 |
+|---|---|
+| native未採用 | `inotify.py:116–119`直接建buffer，buffer直接建queue/start；即使只覆寫少量constructor，raw/cache溢出也要維護inotify_c.py:343–357的recursive wd/path改名，再加generation-safe backend rearm/reconcile。root invalidation alone不能修backend拓樸，復原面比polling大，不作本child第二條路徑 |
+| 受控polling已採用 | `polling.py:71–115`每輪snapshot/diff→事件，無DelayedQueue/move-cache；直接ingress替換中央data queue。root接受P+Tscan延遲/有限拓樸峰值、短命與same-metadata盲點可能等既有rescan；仍保留HEAD/rename/final-store及真OS驗收，不因接受取捨跳過產品gate |
+
+原K-ring候選已撤回，不能與新設計並存：它會把event先留backend queue、再陸續轉callback pending，讓全部100次ingress完成後仍可能分批晚送、破壞active首輪＋一次補跑的oracle。Root採直接root-coalescing ingress：raw0、每generation pending/ready membership/active各≤1，只有一套data狀態；Observer facade只保留獨立stop latch≤1、unfinished_tasks=0。backend-generation proxy封存token，不靠ObservedWatch的path相等去找現在的新代。
+
+此前確實停在draft/design-not-ready且未派工；現已按root裁決收斂成單一accepted候選。以下source/記憶體證據支持規劃可行性，不代表產品通過。
+
+## Root裁決的consumer/source證據與最小seams
+
+當下repo production引用掃描只定位service作watcher consumer：service.py:280–301由Path選全量/單project重讀，snapshot.py:187–211/288–309只在最終state signature改變時發ChangeEvent，sequence是觀察diff而非filesystem event log。service.py:221–243只監workspace/project非recursive、.git HEAD file與refs recursive；tests/test_stage9_project_monitor_service.py:981明文burst合成單事件，:1081的HEAD trigger驗最終todo、:1187只要求HEAD.lock replacement後通知HEAD。GitHub durable event_spool是另一consumer來源，不能混作watcher逐事件需求。此為當下佐證，T3/T4和未來consumer相容gate維持機械守護。
+
+兩個polling差異均已source＋純記憶體實證：DirectorySnapshotDiff只比較inode/mtime/size（watchdog utils/dirsnapshot.py:113–129），兩次snapshot相同metadata輸出全部空；HEAD同path換inode輸出deleted+created，跨path保留inode輸出moved(src,dest)，足以投影各root。stock PollingEmitter的OSError分支（polling.py:84–88）會emit DirDeletedEvent再stop；service.py:193不重裝已watched key，故裸PollingObserver替換不合格。
+
+最小選定seams：BaseObserver公開emitter_class注入小受控PollingEmitter；constructor後、首次schedule前替換該instance `_event_queue`（api.py:316把它交emitter）；小wrapper包instance `_take_snapshot/_snapshot`及on_thread_start，R3補DirectorySnapshot公開stat/listdir窄化VFS與per-scan failure latch。initial完整scan成功才啟用steady-state OSError保活，不吞其他例外。BaseThread.stop先設flag再on_thread_stop（utils/__init__.py:61–64）；local Observer hook先wake latch再super cleanup；BaseObserver.dispatch_events在sentinel分支先返回、尚未取Observer lock或task_done（api.py:378–391）。因此不需拷貝整套walk/poll/diff或全域patch。這些private/public相容面必須在candidate/CI測真watchdog6.0.0；介面/dirfd能力不合在watch成功前拒絕，不能fallback回native/無界queue。
+
+原author時點CI來源已核對：pyproject.toml:22的test extra只含pytest；.github/workflows/tests.yml:55–60安裝.[test]後直接pytest，沒有watchdog安裝。故todo明列在該既有test job加入watchdog6.0.0與import/version確認、核心fixture缺依賴FAIL，不能沿用舊optional skip假GREEN。此是未來產品test-only基礎設施，仍屬tests artifact，production唯一watcher.py；當時作者只改四份文件，未改CI/test-extra/正式runtime套件。這不是本次root planning preflight的結果；若未來產品交付不允許這個test job變更，須先回root解決真CI依賴，不可宣稱CI已驗watcher。
+
+離線fixture全部stdin、無檔案產物：11:29:13Z前的memory VFS以真DirectorySnapshot/DirectorySnapshotDiff與未start的PollingEmitter執行queue_events(0)；輸出HEAD replace=[deleted HEAD,created HEAD]，rename=moved HEAD→new，stock error stopped=True。`BaseObserver(PollingEmitter)`第一次schedule前替换instance queue，實際emitter收到同一queue：pre_schedule_queue_injected=True。真service以__new__配fake store/不啟服務，三個Path依序得到full-current-scan/current-project-scan:A/current-project-scan:B。
+
+同輪追加memory fixture：兩個真PollingEmitter各10k個虛擬snapshot、簡化root-coalescing sink，40,000次offer只保留2backend roots、每snapshot2records；包單一emitter snapshot seam後暫時PermissionError回last-good、stopped=False/degraded，下一次成功仍stopped=False/healthy並保留root dirty。Observer/emitter均is_alive=False，未啟OS/backend/thread。此sink未含完整generation/stop/refcount/W排程，不把它冒稱T13 PASS；錯誤僅注入_take_snapshot外層，R3已反證它不能覆蓋descendant內部吞錯，故不再以此作完整snapshot保活證據。initial/descendant failure、完整facade、真OS壓力仍未勾產品AC。
+
+## R3：兩個真缺陷、窄化修正與證據界線
+
+Reviewer `watcher_polling_r3` 回傳既有stdin程式與stdout，沒有fixture檔案；當時未請它重跑。Root亦獨立讀installed watchdog6的DirectorySnapshot.walk與native symlink排除，兩項皆採納為MAJOR，不能當bounded residual。作者當時只改這四份規劃文件，並留待新fresh review；後續R4內容PASS見末節，不以pure helper或下列memory機制驗證覆蓋產品gate。
+
+| R3缺陷 | 已有精確證據 | 修正／未完成驗收 |
+|---|---|---|
+| partial snapshot假健康 | watchdog utils/dirsnapshot.py:318–329吞listdir ENOENT/ENOTDIR/EINVAL、:331–336吞child stat OSError、:338–342吞recursive PermissionError。Reviewer真DirectorySnapshot＋memory VFS令`/v/refs` listdir拒絕：`initial_snapshot_returned_success=True`、paths僅`/v,/v/refs`；真PollingEmitter外層guard `guard_catches=0/degraded=False/last_good_replaced=True`，發`FileDeletedEvent:/v/refs/main`。child stat suppression為source確認，reviewer當時未實跑 | D4.3每操作/iterator failure latch＋candidate返回後驗；initial拒絕、steady保last-good、不進partial diff，T14真產品待驗 |
+| recursive symlink擴張 | polling.py:58–69預設os.stat；dirsnapshot.py:333–342按跟隨後S_ISDIR遞迴；native inotify_c.py:402–411明文islink skip。Reviewer真library memory VFS：polling列舉`/virtual/refs`與`/virtual/refs/linked`並收入`linked/outside`；native模擬只註冊`/virtual/refs`。這是external-link模型，不是OS/cycle實測 | D2/D4.3 nofollow descriptor VFS，明確root可跟隨且每scan重錨，descendant只link entry；T15 external/cycle/交換/root替換/fd與平台gate待產品驗 |
+
+R3另有一項**窄seam成功**：真BaseObserver.dispatch_events配一bit facade及ForbiddenLock，輸出`sentinel_bypassed_observer_lock=True/gets=1/task_dones=0/unfinished=0/threads_started=False`。它僅證stop sentinel在Observer鎖/task_done前返回；沒有證完整raw0/scheduler、closed busy-spin、stop hook阻塞或generation/memory產品PASS。D4.2原契約保留，這些T13仍全部未勾。
+
+作者於`2026-09-07 13:39:56 UTC`前以`/usr/bin/python3 -B -`、PYTHONDONTWRITEBYTECODE=1在`/tmp`跑窄機制fixture，真DirectorySnapshot/未start PollingEmitter＋memory stat/listdir：stat/listdir generator先記第一個非准許OSError，再raise；snapshot返回後若有latch就raise合成OSError。沒有新thread/OS backend/檔案產物，沒有產品code執行。
+
+```text
+initial stat_denied rejected:13
+initial list_denied rejected:13
+initial iter_denied rejected:13
+initial list_invalid rejected:22
+initial root_missing rejected:2
+initial entry_missing accepted:/v,/v/cycle,/v/link,/v/refs
+steady stat_denied/list_denied/iter_denied/list_invalid:
+  last_good=True degraded=True stopped=False（四項各別相同）
+recovery degraded=False transitions=[degraded-root,healthy-root]
+paths=/v,/v/cycle,/v/link,/v/refs,/v/refs/main
+listed=/v,/v/refs threads=False
+```
+
+重現fixture的最小seam：rows提供root/refs目錄、refs/main regular、link/cycle均S_IFLNK的stat模式；stat可對main拋EACCES或ENOENT，listdir可在refs建立或yield一筆後拋EACCES/EINVAL；stat/listdir wrapper共同`mark(op,path,errno)`，唯`path!=root and errno==ENOENT`不置failure。`candidate=DirectorySnapshot(...,stat=wrapper,listdir=generator_wrapper)`後檢failure；initial直接拒絕，steady guard回emitter._snapshot且只在health轉換記root hint。真DirectorySnapshot只listdir `/v,/v/refs`，證明link-mode可阻斷walk；**不是dirfd/syscall競態/真OS symlink證明**。後者仍由T15實際產品與OS smoke驗。
+
+Root採納的最小source選擇為watcher.py內scan-context/兩個supplied VFS wrappers，不複製watchdog traversal：每scan os.open明確root並fstat；descendant父鏈逐component dir_fd＋O_DIRECTORY/O_NOFOLLOW，最後stat follow_symlinks=False，listdir用scandir(fd)。支持面經本輪唯讀capability確認：os.open/stat∈supports_dir_fd、os.stat∈supports_follow_symlinks、os.scandir∈supports_fd、O_NOFOLLOW/O_DIRECTORY均True。watcher/tests/pyproject/README/既有tests.yml的定點檢索未找到watcher明確Windows/macOS相容驗收；這只是所列範圍當下佐證，不宣稱repo不存在其他平台承諾。新的能力缺席fail-closed是明示平台限制，不把watchdog stock的platform-independent敘述套到此adapter。
+
+FD保守同時上界≤4/scan且finally關閉；snapshot context不留活fd/traceback，不跨scan沿舊root inode。component走訪的深度H/實際entries成本計Tscan，有限拓樸M下的memory界不等於所有目錄大小或churn都有固定M。不可取消scan占原emitter及其有界fd，屬有界資源下availability殘餘；descendant拒讀誤判healthy、初次假註冊、跟隨external/cycle及fixed-topology backlog仍是硬FAIL，不挪給母票。
+
+接受的有界殘餘：P預設1秒，實際延遲P+Tscan+D+callback排隊/執行＋consumer debounce/scan，不是2秒；成本依Nbackend及各自有限拓樸M加總，snapshot/diff峰值需測。短命事件與相同inode/mtime/size改寫可能等既有rescan；當下config.py:53–55為full60秒/targeted300秒，實際配置/慢scan會改時間，不是硬保證。正常poll不強制refresh、不改service；暫時OSError同emitter保活/恢復，未知fatal明示不健康、保留診斷與unwatch→watch路徑，不永久空snapshot或無限restart。卡住stat/listdir不可強取消，原emitter仍占資源，drain在S返回tracked residual；健康B不能因A佔Observer lock而被擋ingress。這些影響可由母票繼續列管，但固定拓樸memory無界、late-generation誤投、漏已接納root、busy-spin均仍FAIL。
+
+## Adversarial 標準與殘餘
+
+未處置的A範圍缺陷/缺口→FAIL；明文承認、影響有界、母票列管的residual不單獨FAIL。不得以residual名義接受A漏掉跨project/root覆蓋、per-eventTimer、pending無界、D被延後、watcher自己late requeue或state未釋放。不得以A部分修正/測試綠燈宣稱母#827完成。
+
+R3修版當時要求root先做新fresh compact獨立review，不以未重審版本開child派工；後續R4內容PASS及root建立#853已完成。本PR又加入repository intake links，仍unfrozen／未merge／未正式freeze／未dispatch，須在#831真runtime重評再按正式Cortex流程派工。若實作需改consumer或第二production模組，先回報擴scope/真sizing，不能維持domain0。產品真OS/壓力/CLI、跨來源fairness、durable fence與live thread/freshness成果仍未證實。
+
+## R4 review addendum（不變更核心規劃）
+
+Root於R4回報fresh reviewer `watcher_polling_r4` 結果 **PASS，0 MAJOR**，對象為上表spec/design/todo三份歷史hash的R3修正版。reviewer的memory failure-latch、nonfollow link-mode、sentinel seam支持設計內容可行性；這是root轉交的獨立review結果，本作者未重新跑該review，未把source或記憶體fixture說成dirfd OS／fd上限／完整scheduler產品proof。
+
+R4 addendum在當時取代「R3兩MAJOR尚待新review」的規劃審查狀態，**不**取代產品checkbox、真8/Red gate或#831後6/Yellow條件投影。當時三件組bytes不變、只追加report歸因；其後author版補#853 owner/link、歷史時態、R4歸因與當時未register/dispatch狀態，技術核心及數值未變。Root已據草稿建立/readback唯一child #853 OPEN，未由本作者執行GitHub mutation；本PR再進repository intake，不代表產品真T13–T15、OS/symlink競態/fd界、CI/CLI/merge與母#827完整整合已完成。
+
+## 歷史author #853 owner metadata版檢核與hash
+
+該author輪次只更新四檔owner/link與狀態敘述；當時作者未執行GitHub action、`.cortex`註冊、CH/fragment新增、commit/push、product/live或dispatch。#853 OPEN建立/readback證據由root提供，本作者未另查GitHub。當時authoring branch為`feature/refine-monitor-watch-child-20260907`，不可混作本次planning整合branch或未來canonical build branch `feature/853-monitor-watcher-bounded`。
+
+以修改前記憶體字串逐段比較：spec從W1開始的全部Requirements/Boundary、design D1–D5、todo從Tests/TDD RED起的全部產品Tasks，結果均`technical_core_identical=True`。只改owner/status/R4歸因與歷史時態，未降低state/invariants、未改raw0/nonfollow/failure-latch或其他產品AC。
+
+`2026-09-07T14:00:29.422022+00:00`於`/tmp`用同一runtime HEAD `79ba644780bf1c697c722ac24a297e7d02416100`重跑完整pure鏈：三件組accepted/complete=True、missing/reasons/blocking皆空；score=`0/2/2/2/2`、total=8/red。Yellow helper仍ready=True、envelope_unavailable，不覆蓋Red或產品gate。該歷史owner/status版三件組hash如下；上表R4歷史hash保留其原審查對象，不冒稱owner metadata或本PR intake版曾重新跑R4。
+
+| Artifact | #853 metadata版 SHA-256 |
+|---|---|
+| `docs/superpowers/specs/monitor-watcher-bounded-spec.md` | `31f7d300565b3c3eb2128fa668ca71c07cc0c44f77c7b1fe2afeeff45367774b` |
+| `docs/superpowers/specs/monitor-watcher-bounded-design.md` | `0db7a7b2c9f5baac611860946b08088bee8d474bd7ed6b4503b55cfb647a595d` |
+| `docs/superpowers/workstreams/monitor-watcher-bounded/todo.md` | `ce094f7ef9ceb1ca227cfc80f2b36509d7b1458ed3ff4e13680f9a38da5a6982` |
+
+## 本PR repository intake／unfrozen metadata版
+
+本次只在root的整合worktree／branch `feature/refine-runtime-intake-20260907`修這四份watcher文件，進場唯讀確認base為`2c1bba019a63fdfee68479ef6b4b18f2c9c11c06`。這是進場base紀錄，不是待定或未發生的merge SHA；後續整合／fast-forward由root另留真實證據。原author worktree未改。
+
+Root已在本PR加入`.cortex/work-items.yaml`的#853唯一spec/design/todo links及母plan/tasks，本作者只讀核對links，未改這些root-owned檔案。當前狀態為repository intake／unfrozen：未merge、未正式freeze、未dispatch，仍8/Red禁派；repository links不是immutable run authority。
+
+Root另轉交fresh reader `schema_fresh_reader` 的五題結果：全部回答正確、未發現歧義。本作者未啟動或自批該reader，亦不把此readability結果抬升為產品／dirfd OS／fd上限proof。R4技術內容PASS歸因保留；W1–W12、D0–D6、T1–T15與sizing核心不變。
+
+這次metadata作者只做核心文字比對、hash與whitespace檢核，不執行產品／CI／`.cortex`／CH／root整合report／commit／live／issue操作。Root的planning preflight／CI結果與此作者歷史未CI分開；未來Cortex產品TDD、focused/full tests、OS／CLI／policy／review／merge gates也另留證，兩者均不由reader PASS或本次metadata檢查代替。
+
+以修改前逐hash複製的內容為基準，spec從W1起至EOF、design從Decisions（完整D0–D6/T1–T15）起至EOF、todo從Tasks起至EOF的字串比較皆`technical_core_identical=True`。本PR repository-intake metadata版hash如下；只表示當次文件bytes，不是正式freeze或新產品驗收receipt。
+
+| Artifact | 本PR intake metadata版 SHA-256 |
+|---|---|
+| `docs/superpowers/specs/monitor-watcher-bounded-spec.md` | `2096a58b493915908c266dfa78301d3fea67008bbd80cb82af761aae809d9c42` |
+| `docs/superpowers/specs/monitor-watcher-bounded-design.md` | `1f7def514771a84871a75e295f817a19bc757ae15a6693bfdc2132434588e217` |
+| `docs/superpowers/workstreams/monitor-watcher-bounded/todo.md` | `a837f7bcdd5a13b080810a7ddf0b0eec3e7feaba08d4852ceb8b60dd3e353aab` |

--- a/reports/review/refine-runtime-intake-integration-20260907.md
+++ b/reports/review/refine-runtime-intake-integration-20260907.md
@@ -1,0 +1,44 @@
+# Launcher／watcher 進件整合核對
+
+本批是 repository planning intake，不是產品修正。Root 在獨立
+`feature/refine-runtime-intake-20260907` 整合 #823 四件與 #853 四件，
+原 author 工作樹、operator、runtime、既有 run／candidate／evidence 均保留。
+產品 Tasks 全未勾，不以本 PR 合併關閉產品 issue。
+
+## Scope 與獨立內容驗收
+
+- #823 仍使用 `launcher-session-and-timeout`，唯一 issue 823；新增 spec/design links，
+  timeout 已移至 #824 候選，probe containment 由 #851 先行。只定義 launcher-local
+  helper/共用 kwargs、兩處 Popen 與 stdin 窄 retry；不改 Manager/cgroup/cancel。
+  獨立 `agy_containment_review` R1 PASS，fresh-reader 五題均正確。
+- #823 reviewer 另以真 constructor／argv／角色及 profile admission 的離線矩陣核對：
+  14 admitted、cg/template 原 `job-runner-hardening-profile-unknown` 拒絕。
+  這不是完整 launch/Popen 或 OS 證據；正式 recording matrix 與真 PGID/SID fixture
+  仍須產品驗收。負控制須在 group signal 前失敗，finally 只清自建 exec child。
+- #853 是 #827 的 watcher-only A child；R4 獨立內容 PASS，fresh-reader 五題均正確。
+  受控 polling/raw0、generation/shared backend、固定 callback/owner、partial-scan latch
+  與逐層 nonfollow dirfd VFS 有完整 W1–W12/T1–T15 契約；不能只驗外層 snapshot catch。
+  POSIX 能力要求、非原子 snapshot、短命／同 metadata 變化、真延遲組成與 FD 界線均保留。
+- #853 的 B work-model、C service 公平／durable publication／整體 drain 與各池合計，
+  仍由母票後續 child 承接；A 規劃或日後產品通過均不足以關閉 #827。
+
+## 真 gate 與 authority
+
+| 工作 | 現行真計算 | 後續條件 |
+|---|---|---|
+| #823 session-only | complete、0+0+2+2+2=6 Yellow，feature-oneshot 11 cards／4 core gates | 正式 owner/fresh base、builder 選擇、Cortex plan gate／freeze 後才產品派工 |
+| #853 watcher A | complete、0+2+2+2+2=8 Red，fix-standard 9 cards／2 core gates | 不派 builder；#831 真 loaded 後重算，6 Yellow 僅投影，不能提前採用 |
+
+Root 以現行 79 runtime 純函式重算並驗 Tasks 缺失負控制；surface-only helper 的
+`envelope_unavailable` bypass 不等 measured capability 或獨立 review。
+當下實讀 Codex Luna builder 的四項 envelope source 皆 default，plan-review projection
+為 None；不是遺漏傳 lookup 才創造的未知狀態，也不替 PatchMUD 量測／qualification 背書。
+兩個 work 的 repository links 不代表 Monitor 已 confirmed 或既有 run 已 freeze。
+#824 真 dependency marker、不登錄／不 auto-label／不 start 的邊界保持。
+
+## 交付門檻
+
+Root metadata 整合不得變更已審核心；本批另做 fresh 整合 review、精確 staging、
+changelog fragment commit 後完整 preflight，再核對 current-head 遠端 CI／threads／
+mergeability。CI pin 與本機 engine 執行身份分開保留，未取得的 gate 不預填 PASS。
+安裝、loaded runtime、真模型與產品 run 的 RED/GREEN/verify/review/ship 都不由本報告代寫。


### PR DESCRIPTION
## 摘要

補齊 #823 session-only 三件組及唯一 owner links，登錄 #853 watcher-only A child。
本 PR 屬 #829 規劃進件，不關閉尚未交付產品的 issue。

## 驗證與安全邊界

- [x] #823 獨立 R1 內容審查、fresh reader 五題通過；14 admitted／cg-template 原拒絕的離線矩陣不冒完整 launch 或 OS proof。
- [x] #853 fresh R4 內容審查與 fresh reader 五題通過；W1–W12/T1–T15、partial-scan/nonfollow/資源及延遲殘餘全部保留。
- [x] 真 completeness／sizing 分別6 Yellow與8 Red；#853不派工，#831後6僅投影，envelope bypass不當 measured capability。
- [x] #823只有session、#824 timeout與#851 probe另案；#827 B/C與母件、cgroup/restart等責任不被提早關閉。
- [x] 同步本分支fragment、Unreleased、umbrella ledger/tasks；產品Tasks保持未完成。
- [x] 未改產品、tests/CI、VERSION/policy pin/symlinks、operator/runtime、frozen artifact或durable evidence。

使用 `policy-exempt:issue-link`：規劃與owner邊界進件，不是產品完成，刻意不使用closing keyword；不豁免其他gate。
須 fresh 整合review、post-commit fullpreflight、遠端 exact-head CI/threads/mergeability全通過才merge。
