### PR TITLE
docs: 登錄通用任務記憶交付 adapter 計劃

### DIFF
--- a/.cortex/work-items.yaml
+++ b/.cortex/work-items.yaml
@@ -956,3 +956,17 @@ work_items:
       - kind: path
         ref: 'docs/superpowers/workstreams/monitor-watcher-bounded/todo.md'
     excludes: []
+  task-memory-delivery-adapter:
+    title: 'task memory delivery Cortex adapter'
+    links:
+      - kind: github_issue
+        ref: 'hamanpaul/paulsha-cortex#857'
+      - kind: path
+        ref: 'docs/superpowers/specs/task-memory-delivery-adapter-spec.md'
+      - kind: path
+        ref: 'docs/superpowers/specs/task-memory-delivery-adapter-design.md'
+      - kind: path
+        ref: 'docs/superpowers/plans/task-memory-delivery-adapter.md'
+      - kind: path
+        ref: 'docs/superpowers/workstreams/task-memory-delivery-adapter/todo.md'
+    excludes: []

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 
 ## [Unreleased]
 
+- **Task memory delivery adapter 進件（#857）**：登錄 Hippo #146 dependency、capability-aware delivery、工具中立 receipt、strict KPI 分離與 ≥95% authorized retrieval canary gate；本項只交付 accepted 規劃，不宣稱產品或 runtime 完成。
+
 - **Launcher／watcher 子計畫進件**：補齊 #823 session-only 三件組與唯一 owner links，
   登錄 #853 有界 watcher A child。真 process-group 與 cgroup 邊界、raw0／generation／
   partial-scan／nonfollow 驗收完整列管；現行 sizing 6／8 與正式產品交付分開。

--- a/changelog.d/task-memory-delivery-adapter-planning.md
+++ b/changelog.d/task-memory-delivery-adapter-planning.md
@@ -1,0 +1,3 @@
+## 計畫
+
+- 建立 #857 的通用 task memory delivery Cortex host adapter accepted spec/design/plan/Todo；此變更只登錄規劃與進件邊界，不宣稱產品實作、測試、部署或內容取得率已完成。

--- a/docs/superpowers/plans/task-memory-delivery-adapter.md
+++ b/docs/superpowers/plans/task-memory-delivery-adapter.md
@@ -1,0 +1,40 @@
+---
+status: accepted
+work_item: task-memory-delivery-adapter
+---
+
+# Task memory delivery Cortex adapter Plan
+
+## 1. Authority and dependency
+
+- [ ] 將 Cortex #857 與 Hippo #146 綁為跨 repo dependency；Hippo 是 generic contract owner，Cortex 是首個 host adapter。
+- [ ] 將本 plan、spec、design、workstream Todo 與 `.cortex/work-items.yaml` registration 保持同一 work item，讓 isolated worker 不依賴暫存檔。
+- [ ] 確認本次只走現行 `cortex work intake`/Manager single-writer；不使用 deprecated low-level dispatch、不直接寫 durable registry/ledger。
+
+## 2. Contract and RED coverage
+
+- [ ] 凍結 `hippo/task-memory/v1` envelope、0–3 candidate、manifest、delivery modes、receipt/event names 與 strict KPI separation；由 Hippo #146 的 public contract 驗證，不在 Cortex 複製第二份權威 schema。
+- [ ] 新增 Cortex adapter contract tests：Work Item/WorkflowRun/card → task envelope，缺 task id、跨 project、manifest/hash mismatch、unsupported major、ineligible source 均 fail closed。
+- [ ] 新增 receipt tests：inline/context-delivered、readonly snapshot/content-returned、manifest-bound note-fetch、permission denied/read-failed、applied-with-evidence 分流與 retry idempotency。
+- [ ] 先取得真正 RED（測試確實能抓到 adapter 未接線或錯誤分類），保存 bounded test evidence；不得以文件 checkbox 代替 RED。
+
+## 3. Adapter implementation
+
+- [ ] 在 Cortex thin adapter 接上既有 Work Item/WorkflowRun/card task identity 與 executor capability；不改 central routing、trust-root、shared quota 或 Hippo lifecycle owner。
+- [ ] 依 capability matrix 實作 primary delivery mode 選擇與 explicit fallback/ineligible reason；拒絕 arbitrary host path、global memory-root access、allow-all。
+- [ ] 以 Manager-owned sidecar/receipt boundary 接回 attempt/run，不由 worker 直接寫 Hippo ledger；receipt/hash 不符時保留 fail-closed attention。
+- [ ] 沿現有合法 routing；不以 model override 修改全域 default，不將任何 executor/model 名稱寫成 special case。
+
+## 4. Canary and utility readiness
+
+- [ ] 每個支援 delivery path 以獨立 memory root、受限 headless executor 及固定 fixture 執行至少 5 次成功與負例。
+- [ ] Cortex 固定 denied path 重現後，驗同一 generic payload 可取得允許內容；另以不同 repository/task kind 通過，證明沒有 Cortex project branch。
+- [ ] 機械計算 eligible authorized content retrieval success rate，目標 ≥95%；列出 unknown/ineligible/denied，不以 126 intent 或 299 denied view 推算 adoption。
+- [ ] 只在 canary gate 通過後設計 task-level control/treatment utility trial；retries 合併、至少明列實際 evidence、成本與誤引用，未完成不宣稱 utility improvement。
+
+## 5. Verification and delivery gates
+
+- [ ] Cortex focused tests、Hippo contract fixture/subprocess boundary、完整 tests、policy check（PR context）、`git diff --check` 全部記錄實際輸出。
+- [ ] 檢查既有 strict `offer → read → applied` 分母與輸出 schema 未改；inline/context delivery 不混入 legacy Read。
+- [ ] 以正式 Cortex read model 回查 work item/run/job state、plan/spec revision、model identity、receipt/sidecar、test/review evidence；issue open、accepted plan、queued、blocked、started、complete 必須分開報告。
+- [ ] 遇 provider stale、project registration、authority、permission、quota 或 sandbox blocker，停在精確 `needs_human`/blocked，不修改全域設定、不手造 evidence、不回收 unrelated work。

--- a/docs/superpowers/plans/task-memory-delivery-adapter.md
+++ b/docs/superpowers/plans/task-memory-delivery-adapter.md
@@ -15,7 +15,7 @@ work_item: task-memory-delivery-adapter
 
 - [ ] 凍結 `hippo/task-memory/v1` envelope、0–3 candidate、manifest、delivery modes、receipt/event names 與 strict KPI separation；由 Hippo #146 的 public contract 驗證，不在 Cortex 複製第二份權威 schema。
 - [ ] 新增 Cortex adapter contract tests：Work Item/WorkflowRun/card → task envelope，缺 task id、跨 project、manifest/hash mismatch、unsupported major、ineligible source 均 fail closed。
-- [ ] 新增 receipt tests：inline/context-delivered、readonly snapshot/content-returned、manifest-bound note-fetch、permission denied/read-failed、applied-with-evidence 分流與 retry idempotency。
+- [ ] 新增 receipt tests：inline/context-delivered、readonly snapshot/materialized ready/offer、僅由 tool/provider 成功返回內容產生的 content-returned、manifest-bound note-fetch、permission denied/read-failed、applied-with-evidence 分流與 retry idempotency。
 - [ ] 先取得真正 RED（測試確實能抓到 adapter 未接線或錯誤分類），保存 bounded test evidence；不得以文件 checkbox 代替 RED。
 
 ## 3. Adapter implementation

--- a/docs/superpowers/specs/task-memory-delivery-adapter-design.md
+++ b/docs/superpowers/specs/task-memory-delivery-adapter-design.md
@@ -13,7 +13,7 @@ Hippo #146 定義 `hippo/task-memory/v1` 的 task envelope、candidate 與工具
 
 ### D2 Delivery is an explicit capability matrix
 
-Adapter 先計算 `eligible`、允許 evidence sources 與 capability，再選擇 inline、task-scoped readonly snapshot 或 manifest-bound note-fetch。每次只允許一種 primary delivery mode，receipt 另記 fallback/拒絕原因。工具不可用不改成 arbitrary path；host permission denied 不改成 allow-all。
+Adapter 先計算 `eligible`、允許 evidence sources 與 capability，再選擇 inline、task-scoped readonly snapshot 或 manifest-bound note-fetch。每次只允許一種 primary delivery mode，receipt 另記 fallback/拒絕原因。`snapshot/materialized` 只代表 readonly manifest 已 ready/offer；只有實際 tool/provider 成功返回內容才可記 `content-returned`，不能把檔案已寫好當成取得成功。工具不可用不改成 arbitrary path；host permission denied 不改成 allow-all。
 
 ### D3 Evidence is append-only sidecar, not central ledger mutation
 
@@ -39,7 +39,8 @@ Work Item/WorkflowRun/card
   -> Hippo candidate request (public v1)
   -> capability matrix
        | inline -> context-delivered receipt
-       | snapshot -> readonly manifest + content-returned receipt
+       | snapshot -> readonly manifest/materialized ready + offer
+                    -> tool/provider content-returned receipt（成功返回內容才成立）
        | note-fetch -> manifest-bound tool call + return/failure receipt
        | ineligible/failure -> bounded reason receipt
   -> Cortex sidecar/single-writer projection

--- a/docs/superpowers/specs/task-memory-delivery-adapter-design.md
+++ b/docs/superpowers/specs/task-memory-delivery-adapter-design.md
@@ -1,0 +1,60 @@
+---
+status: accepted
+work_item: task-memory-delivery-adapter
+---
+
+# Task memory delivery Cortex adapter 設計
+
+## Decisions
+
+### D1 Hippo owns generic contract; Cortex owns translation
+
+Hippo #146 定義 `hippo/task-memory/v1` 的 task envelope、candidate 與工具中立 receipt。Cortex adapter 只把 Work Item/WorkflowRun/card 的穩定欄位、當次 execution profile 的 capability 宣告與既有 read scope 映射進 envelope，再將返回 receipt 綁回同一 attempt。不得把 Cortex internal schema 暴露給 Hippo。
+
+### D2 Delivery is an explicit capability matrix
+
+Adapter 先計算 `eligible`、允許 evidence sources 與 capability，再選擇 inline、task-scoped readonly snapshot 或 manifest-bound note-fetch。每次只允許一種 primary delivery mode，receipt 另記 fallback/拒絕原因。工具不可用不改成 arbitrary path；host permission denied 不改成 allow-all。
+
+### D3 Evidence is append-only sidecar, not central ledger mutation
+
+Worker/isolated executor 只產 receipt/sidecar；Cortex Manager 收集並以既有 single-writer lifecycle 綁定 work/run/attempt。Hippo 後續 consumer 可用 public receipt replay；Cortex 不等待 Hippo acknowledgement，不代 Hippo 寫 `read`/`applied`。
+
+### D4 Strict KPI and new acquisition metrics stay separate
+
+Legacy strict funnel 只接受原本合法的 Read/Applied adapter evidence。新 receipt 以獨立版本化 projection 報告 `authorized_delivery_success_rate`、attempt/return/failure/ineligible 與 evidence-backed applied；inline 不進 legacy Read。
+
+### D5 Generic canary before utility trial
+
+第一階段只驗授權內容取得、歸因與 isolation。canary 的 task fixture 必須有 Cortex 以外 repository/task kind；permission-denied 是 bounded negative control，不從單筆或 126 個歷史意圖推算 utility。第二階段才做 task-level control/treatment，retries 合併計算。
+
+### D6 No shared routing mutation
+
+沿現行 Cortex routing；不新增 global model override、不變更 trust-root、service env 或 shared quota。若現行 routing/資格無法滿足，保留 fail-closed blocker。
+
+## Data flow
+
+```text
+Work Item/WorkflowRun/card
+  -> task envelope + capability/read scope
+  -> Hippo candidate request (public v1)
+  -> capability matrix
+       | inline -> context-delivered receipt
+       | snapshot -> readonly manifest + content-returned receipt
+       | note-fetch -> manifest-bound tool call + return/failure receipt
+       | ineligible/failure -> bounded reason receipt
+  -> Cortex sidecar/single-writer projection
+  -> Hippo public consumer / legacy KPI separation
+```
+
+## Failure rules
+
+- task identity 不完整：保留 `session_proxy` 或拒絕，不假造 task。
+- candidate hash/version 或 manifest 不符：拒收，不嘗試 arbitrary path。
+- host/tool permission denied：記 `read-failed` 與 bounded layer-unknown reason；不可聲稱已定位 root cause。
+- task 不允許額外歷史 evidence：記 `ineligible`，不可 inline 偷塞。
+- Hippo/provider unavailable：Cortex execution lifecycle 照既有 fail-safe；receipt 可 park/replay，不阻塞 unrelated completion。
+- schema major 不支援：park，保持舊 strict KPI 與既有 output schema。
+
+## Acceptance oracle
+
+所有產出都須可由 task id、attempt id、note hash、manifest hash 與 receipt chain 重建。`authorized_delivery_success_rate` 的分母只含公開 eligibility 規則下的 authorized tasks；unknown、probe、供應資料不足與 no-extra-evidence 類別分開列出，不靜默丟棄。

--- a/docs/superpowers/specs/task-memory-delivery-adapter-spec.md
+++ b/docs/superpowers/specs/task-memory-delivery-adapter-spec.md
@@ -29,7 +29,7 @@ Adapter MUST 只消費 Hippo public candidate contract。每次最多 0–3 則 
 Adapter MUST 依 executor capability 選擇下列互斥結果：
 
 1. `context-delivered`：inline/context input 已提供；不得映射為 Read。
-2. `snapshot-delivered`：task-scoped、唯讀、受 manifest 綁定的內容快照。
+2. `snapshot-ready`：task-scoped、唯讀、受 manifest 綁定的 snapshot/materialized artifact 已 ready/offer；artifact 存在本身不代表內容已被取閱。
 3. `note-fetch`：工具只接受本 task manifest 內的 note id，不接受任意路徑。
 4. `ineligible` 或 `read-failed(reason)`：來源不在原任務允許範圍、能力缺失、送達失敗或權限拒絕。
 
@@ -37,7 +37,7 @@ Adapter MUST NOT 將整個 memory root 加入全域權限、使用 allow-all，�
 
 ### R4 Tool-neutral evidence
 
-Receipt MUST 能區分 `candidate-selected`、`offer-emitted`、`read-attempted`、`content-returned`、`context-delivered`、`read-failed(reason)` 與 `applied-with-evidence`，並帶 task/attempt/session/tool/project/note/hash/time 關聯。相同 attempt 的重試 MUST 冪等；worker 不直接寫中央 Hippo ledger。
+Receipt MUST 能區分 `candidate-selected`、`offer-emitted`、`read-attempted`、`content-returned`、`context-delivered`、`read-failed(reason)` 與 `applied-with-evidence`，並帶 task/attempt/session/tool/project/note/hash/time 關聯。`content-returned` 只有在實際 tool/provider 成功返回內容後才能產生；snapshot/materialized ready/offer 與檔案存在不可替代它。相同 attempt 的重試 MUST 冪等；worker 不直接寫中央 Hippo ledger。
 
 ### R5 KPI compatibility
 

--- a/docs/superpowers/specs/task-memory-delivery-adapter-spec.md
+++ b/docs/superpowers/specs/task-memory-delivery-adapter-spec.md
@@ -1,0 +1,62 @@
+---
+status: accepted
+work_item: task-memory-delivery-adapter
+---
+
+# 通用 task memory delivery 的 Cortex adapter 規格
+
+本規格對應 [Cortex #857](https://github.com/hamanpaul/paulsha-cortex/issues/857)，依賴 [Hippo #146](https://github.com/hamanpaul/paulsha-hippo/issues/146)。Hippo 擁有通用 payload、候選與事件契約；Cortex 只擁有 host task identity、能力宣告、隔離輸入與 receipt 收集。Cortex 不因自身專案名稱或 workflow card 取得特殊規則。
+
+## Boundary
+
+- 跨 repo 邊界是 versioned public payload/manifest/receipt；不得 import 對方 private Python package 或讀另一方 registry、status、worktree、raw prompt、private note 正文。
+- Work Item/WorkflowRun/card 是 Cortex 任務身份來源；Hippo 是 memory candidate 與 legacy strict KPI 的權威。兩邊 failure 不互相改寫對方 lifecycle。
+- 內容取得「成功」只表示受 task scope 與 capability 授權的內容已返回；不表示 agent 理解或採用。採用需另附 note id 與實際 action/artifact evidence。
+- 歷史 278/222/126/299 聚合數字是動機證據，不是每個 job 的 permission root cause，也不是修復後採用率預測。
+
+## Requirements
+
+### R1 Task envelope
+
+Adapter MUST 產生 `hippo/task-memory/v1` envelope，至少包含穩定 `task_id`（或明示 `session_proxy`）、`attempt_id`、`session_id`、executor/tool、canonical project、goal、task kind、相關檔案／錯誤、capabilities、read scope 與允許 evidence sources。不得由 title、project name 或 workflow-card 名稱猜 task。
+
+### R2 Candidate boundary
+
+Adapter MUST 只消費 Hippo public candidate contract。每次最多 0–3 則 candidate，包含 `note_id`、content hash/version、適用條件、建議行動、來源時間與關聯理由；同一 task 依 note id/hash 去重。Boilerplate、schema、完整 source material 與 candidate 必須可分開識別。
+
+### R3 Capability-aware delivery
+
+Adapter MUST 依 executor capability 選擇下列互斥結果：
+
+1. `context-delivered`：inline/context input 已提供；不得映射為 Read。
+2. `snapshot-delivered`：task-scoped、唯讀、受 manifest 綁定的內容快照。
+3. `note-fetch`：工具只接受本 task manifest 內的 note id，不接受任意路徑。
+4. `ineligible` 或 `read-failed(reason)`：來源不在原任務允許範圍、能力缺失、送達失敗或權限拒絕。
+
+Adapter MUST NOT 將整個 memory root 加入全域權限、使用 allow-all，或反覆推薦已被拒絕的不可讀路徑。
+
+### R4 Tool-neutral evidence
+
+Receipt MUST 能區分 `candidate-selected`、`offer-emitted`、`read-attempted`、`content-returned`、`context-delivered`、`read-failed(reason)` 與 `applied-with-evidence`，並帶 task/attempt/session/tool/project/note/hash/time 關聯。相同 attempt 的重試 MUST 冪等；worker 不直接寫中央 Hippo ledger。
+
+### R5 KPI compatibility
+
+Hippo legacy strict `offer → read → applied` MUST 保留原語意與分母。`context-delivered`、inline、`content-returned` 或 denied attempt MUST NOT 自動成為 legacy Read/Applied；新工具中立取得率另以版本化指標輸出。
+
+### R6 Safety and failure truth
+
+Unsupported major schema、跨 scope candidate、manifest mismatch、無法證實的 permission 層、scope leak、receipt/hash mismatch MUST fail closed 並留下有界 reason。診斷不能授予 authority；不能以單一旗標或 project special case 假定所有 job 同一根因。
+
+### R7 Canary acceptance
+
+每個已支援 delivery path MUST 以隔離 fixture/canary 至少執行 5 次成功與負例，涵蓋 Cortex 固定 permission-denied 案例、不同 repository、不同 task kind、cross-scope rejection、relay 不覆蓋與既有 output schema 相容。eligible authorized content retrieval success rate MUST 達到至少 95%；此 gate 不等同 utility/adoption 成功。
+
+### R8 Lifecycle compatibility
+
+Cortex adapter MUST 從正式 `cortex work intake` 所建立的 Work Item/WorkflowRun 讀取輸入，不使用停用低階 dispatch，不直接修改 registry/ledger，不 recall，不關閉 sandbox/trust-root。Hippo 未安裝或 provider 不可用時，既有 Cortex lifecycle fail-safe 且可觀測。
+
+## Out of scope
+
+- 不實作 Hippo retrieval ranking、knowledge lifecycle、legacy KPI 定義或 Cortex execution engine 本身。
+- 不把任何模型名稱寫成全域 invariant；下游 executor/model 沿既有受治理 routing，不能透過 shared config 改寫或繞過 capability gate。
+- 不保證所有 executor 具有同一 tool/read 能力；無能力必須回 `ineligible`/`read-failed`，不得用權限放寬補率。

--- a/docs/superpowers/workstreams/task-memory-delivery-adapter/todo.md
+++ b/docs/superpowers/workstreams/task-memory-delivery-adapter/todo.md
@@ -1,0 +1,19 @@
+---
+status: accepted
+work_item: task-memory-delivery-adapter
+---
+
+# Task memory delivery adapter Todo
+
+## Scope
+
+Owner：Cortex #857；dependency：Hippo #146。Cortex 只做 generic host adapter/validation，不改 Hippo core、Cortex global routing 或任何 project special case。
+
+## Tasks
+
+- [ ] accepted spec/design/plan、此 Todo 與 `.cortex/work-items.yaml` registration 一致且可由 isolated worker 讀取。
+- [ ] task envelope 與 capability matrix contract fixture；缺 identity、跨 scope、unsupported schema、manifest mismatch 均 fail closed。
+- [ ] inline/context-delivered、readonly snapshot、manifest-bound note-fetch、ineligible/read-failed receipt 與 retry idempotency focused tests。
+- [ ] Manager single-writer sidecar/receipt projection；worker 不直寫 Hippo ledger，legacy strict KPI 不變。
+- [ ] 每條支援 path 5 次 canary、Cortex denied negative control、不同 repository/task kind；eligible authorized retrieval success rate ≥95%。
+- [ ] 完整 tests/policy/CI/review/merge/read-model evidence；任何 blocker 保留 needs_human，不以 issue/plan/open PR 冒稱產品完成。

--- a/docs/superpowers/workstreams/task-memory-delivery-adapter/todo.md
+++ b/docs/superpowers/workstreams/task-memory-delivery-adapter/todo.md
@@ -13,7 +13,7 @@ Owner：Cortex #857；dependency：Hippo #146。Cortex 只做 generic host adapt
 
 - [ ] accepted spec/design/plan、此 Todo 與 `.cortex/work-items.yaml` registration 一致且可由 isolated worker 讀取。
 - [ ] task envelope 與 capability matrix contract fixture；缺 identity、跨 scope、unsupported schema、manifest mismatch 均 fail closed。
-- [ ] inline/context-delivered、readonly snapshot、manifest-bound note-fetch、ineligible/read-failed receipt 與 retry idempotency focused tests。
+- [ ] inline/context-delivered、readonly snapshot/materialized ready/offer、僅由 tool/provider 成功返回內容產生的 content-returned、manifest-bound note-fetch、ineligible/read-failed receipt 與 retry idempotency focused tests。
 - [ ] Manager single-writer sidecar/receipt projection；worker 不直寫 Hippo ledger，legacy strict KPI 不變。
 - [ ] 每條支援 path 5 次 canary、Cortex denied negative control、不同 repository/task kind；eligible authorized retrieval success rate ≥95%。
 - [ ] 完整 tests/policy/CI/review/merge/read-model evidence；任何 blocker 保留 needs_human，不以 issue/plan/open PR 冒稱產品完成。


### PR DESCRIPTION
## 摘要

- 持久化通用 task memory delivery 的 Cortex host adapter accepted spec/design/plan/Todo。
- 登錄 capability-aware inline/snapshot/manifest delivery、工具中立 receipt、legacy strict KPI 分離與 authorized retrieval >=95% canary gate。
- 明確跨 repo contract boundary、不同 repository/task kind fixture、permission-denied 負例與 fail-closed blocker。

## 狀態

本 PR 僅交付可由 isolated worker 讀取的規劃與 repository intake registration，不宣稱產品實作、測試、部署、merge 或 live content retrieval 已完成；不應因合併本 PR 自動關閉產品工作。

## 驗證

- `openspec validate --specs`：22 passed / 0 failed
- `python3 -m policy_check --repo .`：0 failure；既有 R-22 advisory warnings 保留
- `git diff --cached --check`：pass

## Checklist

- [x] scope 與 Hippo public contract boundary 已明確
- [x] 不修改 global routing、sandbox、trust-root、ledger 或 runtime code
- [x] accepted spec/design/plan/Todo 與 `.cortex/work-items.yaml` 同一 work item
- [x] planning-only 狀態與後續 Cortex intake gate 已明示
