### PR TITLE
fix(launcher): 補齊 Claude builder 最小命令授權（#480 部分修復）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 
 ## [Unreleased]
 
+- **Claude builder 命令授權（#480 部分修復）**：commit-required job 使用 per-job 最小 Git 與精確 Python 測試 allowlist，保留 `acceptEdits` 與既有事件／路徑設定，解除無人可核可的測試／提交阻塞。
+
 - **Task memory delivery adapter 進件（#857）**：登錄 Hippo #146 dependency、capability-aware delivery、工具中立 receipt、strict KPI 分離與 ≥95% authorized retrieval canary gate；本項只交付 accepted 規劃，不宣稱產品或 runtime 完成。
 
 - **Launcher／watcher 子計畫進件**：補齊 #823 session-only 三件組與唯一 owner links，

--- a/changelog.d/480-claude-builder-grants.md
+++ b/changelog.d/480-claude-builder-grants.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- 修正 Claude commit-required headless builder 未授權測試與提交的阻塞：以 per-job allowlist 放行 `git add`、`git commit` 及 operator 宣告的精確 Python 測試命令，保留 `acceptEdits`、事件 hook 與既有路徑授權；不修改全域設定。

--- a/docs/claude-builder-command-grants.md
+++ b/docs/claude-builder-command-grants.md
@@ -1,0 +1,39 @@
+# Claude builder 的最小命令授權
+
+## 適用範圍
+
+一般 Claude headless builder 的 `acceptEdits` 不會自動批准 Bash 測試與 Git 提交。
+對 `commit_policy=required` 的工作，launcher 在既有 per-job `--settings`
+overlay 中加入下列授權，不修改 operator 的全域 Claude 設定：
+
+- `git add` 與 `git commit` 子命令前綴。
+- `PSC_GATE_CMD_*` 經 `gate_ledger.load_gate_specs()` 解析後，符合 Python
+  `-m pytest`／`-m unittest` 或 `pytest` 的**精確完整命令**。
+- 支援既有 `env -u PSC_REPO_ROOT` 前綴，不接受任意環境變數或 PATH 替換。
+
+worker 必須使用宣告的完整測試命令；改參數的 focused test 不會因此自動取得授權。
+其他 gate executable 不自動放行。規則不包含 push、reset、clean、任意 Git
+子命令、任意 Python、shell wrapper 或全工具授權。測試參數含 shell／permission
+pattern 特殊字元時 fail closed，不把引用過的字元誤當成安全的 permission pattern。
+
+`acceptEdits`、PostToolUse hook、linked-worktree Git metadata 的 `--add-dir`
+均保留。非 commit-required builder、planner 與 reviewer 不增加授權。
+
+## 邊界與驗收
+
+這是執行契約的可用性修復，**不是 OS sandbox**；Git hooks 與測試本身仍會執行
+candidate 程式碼。既有 runtime isolation／獨立驗收仍不可省略，不能將 allowlist
+當作對惡意 candidate 的完整防線。
+
+本修補處理 issue #480 的 commit-required builder 阻塞，不宣稱完成整套 persona
+`effective_tools` 翻譯、overlay 上限或 permission-denial 分類機制。
+
+驗證包含 launcher 單元測試，以及暫存 repo 的 live headless canary：精確測試、
+stage、commit 應成功，未宣告 `python3 -c` 應遭拒。原始失敗工作產物須保留，
+正式恢復走帶 `expected-run-id` 的 `cortex work retry-card`，不得直接改 registry。
+
+2026-09-08 live canary：使用修補後 `build_claude_argv` 產生的完整 argv，
+Claude `claude-opus-5` 在獨立暫存 Git repo 逐條執行，pytest 回報 `1 passed`，
+stage 成功，commit `021d173` 成功；未宣告的 `python3 -c` 實際回報
+`This command requires approval`，僅嘗試一次。這是 launcher 真實執行證據，
+不是 Hippo feature 的 Manager acceptance 或部署完成證據。

--- a/paulsha_cortex/coordinator/launcher.py
+++ b/paulsha_cortex/coordinator/launcher.py
@@ -520,6 +520,46 @@ def _claude_spool_hook_settings() -> str:
     return json.dumps(settings, ensure_ascii=True, sort_keys=True, separators=(",", ":"))
 
 
+def _claude_builder_settings() -> str:
+    """Grant commit-required jobs Git writes and exact declared Python tests.
+
+    This is a per-process usability grant, not an OS sandbox. Never derive
+    permissions from candidate files or prompt text. Other gate executables
+    remain subject to the existing approval policy.
+    """
+    settings = json.loads(_claude_spool_hook_settings())
+    allowed = ["Bash(git add:*)", "Bash(git commit:*)"]
+    safe_chars = frozenset(
+        "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-/.:=,@+"
+    )
+    for spec in gate_ledger.load_gate_specs():
+        argv = spec.argv
+        offset = 0
+        # Support the existing scoped repository-selector cleanup, not an
+        # arbitrary env wrapper or executable/PATH substitution.
+        if Path(argv[0]).name == "env":
+            if argv[1:3] != ("-u", "PSC_REPO_ROOT"):
+                continue
+            offset = 3
+        command = argv[offset:]
+        if not command:
+            continue
+        executable = Path(command[0]).name
+        is_test = executable == "pytest" or (
+            executable in {"python", "python3"}
+            and command[1:3] in {("-m", "pytest"), ("-m", "unittest")}
+        )
+        if not is_test:
+            continue
+        # Claude rules have their own pattern grammar. Even shell-quoted
+        # wildcard/metacharacter arguments must not become permission rules.
+        if any(not set(arg) <= safe_chars for arg in argv):
+            raise ValueError("Claude builder gate cannot be represented as an exact permission rule")
+        allowed.append(f"Bash({spec.command})")
+    settings["permissions"] = {"allow": sorted(set(allowed))}
+    return json.dumps(settings, ensure_ascii=True, sort_keys=True, separators=(",", ":"))
+
+
 def _git_scope_env() -> dict[str, str]:
     """Drop inherited Git repository/config selectors before scope binding."""
 
@@ -949,7 +989,10 @@ def build_claude_argv(
         # - review_only reviewer 是 read-only 契約，且它的 `--settings` 是那份
         #   sandbox 政策（deny 掉 $HOME 讀寫），事件根本寫不出去。
         # 這一行是 hook 的**唯一**注入點：per-job、走 argv、不落地任何檔案。
-        argv += ["--settings", _claude_spool_hook_settings()]
+        argv += [
+            "--settings",
+            _claude_builder_settings() if commit_required else _claude_spool_hook_settings(),
+        ]
     if model is not None:
         argv += ["--model", model]
     if worktree is not None and not review_only:

--- a/tests/test_coordinator_launcher.py
+++ b/tests/test_coordinator_launcher.py
@@ -20,6 +20,48 @@ from paulsha_cortex.coordinator.launcher import (
 
 
 class ArgvTests(unittest.TestCase):
+    def test_claude_commit_permissions_are_per_job_and_exact(self) -> None:
+        gate = "env -u PSC_REPO_ROOT /opt/test/bin/python -m pytest -q"
+        with mock.patch.dict(os.environ, {"PSC_GATE_CMD_PYTEST": gate}, clear=True):
+            argv = build_claude_argv(
+                prompt="P", slice_id="s", log_dir="/lg", commit_required=True,
+            )
+        settings = json.loads(argv[argv.index("--settings") + 1])
+        self.assertEqual(settings["permissions"]["allow"], sorted([
+            "Bash(git add:*)", "Bash(git commit:*)", f"Bash({gate})",
+        ]))
+        self.assertIn("hooks", settings)
+        self.assertEqual(argv[argv.index("--permission-mode") + 1], "acceptEdits")
+        for forbidden in ("Bash(*)", "Bash(git:*)", "Bash(python:*)", "bypassPermissions"):
+            self.assertNotIn(forbidden, json.dumps(argv))
+
+    def test_claude_commit_permissions_reject_rule_injection(self) -> None:
+        for gate in (
+            "python3 -m pytest tests/*", "python3 -m pytest 'x);*'",
+            "python3 -m pytest 'x;echo'", "python3 -m pytest '$(id)'",
+            "python3 -m pytest 'a\\nb'", "bash -c 'python3 -m pytest'",
+        ):
+            with self.subTest(gate=gate), mock.patch.dict(
+                os.environ, {"PSC_GATE_CMD_PYTEST": gate}, clear=True,
+            ):
+                with self.assertRaises(ValueError):
+                    build_claude_argv(prompt="P", slice_id="s", log_dir="/lg", commit_required=True)
+
+    def test_claude_commit_permissions_do_not_grant_arbitrary_commands(self) -> None:
+        for gate in ("git push origin main", "python3 -c print", "env PATH=/other pytest", "rm -rf /tmp/example"):
+            with self.subTest(gate=gate), mock.patch.dict(
+                os.environ, {"PSC_GATE_CMD_OTHER": gate}, clear=True,
+            ):
+                argv = build_claude_argv(prompt="P", slice_id="s", log_dir="/lg", commit_required=True)
+            settings = json.loads(argv[argv.index("--settings") + 1])
+            self.assertEqual(settings["permissions"]["allow"], ["Bash(git add:*)", "Bash(git commit:*)"])
+
+    def test_claude_non_commit_permissions_unchanged(self) -> None:
+        with mock.patch.dict(os.environ, {"PSC_GATE_CMD_PYTEST": "python3 -m pytest *"}, clear=True):
+            argv = build_claude_argv(prompt="P", slice_id="s", log_dir="/lg")
+        settings = json.loads(argv[argv.index("--settings") + 1])
+        self.assertNotIn("permissions", settings)
+
     def test_srt_runtime_root_resolves_regular_jitless_toolchain_wrapper(self) -> None:
         with tempfile.TemporaryDirectory() as d:
             root = Path(d) / "toolchain"


### PR DESCRIPTION
## 摘要

修復 commit-required Claude builder 的命令授權缺口：per-job allowlist 放行正常 stage／commit 與 operator 宣告的精確 Python 測試，保留 acceptEdits、hook 及路徑設定。

相關 #480：這是有界部分修復；完整 persona effective_tools 翻譯與 permission-denial 分類仍未完成，因此使用 policy-exempt:issue-link，不關閉母 issue。

## #480 已涵蓋部分

- 對 commit-required Claude builder 增加 per-job `git add`／`git commit` 授權。
- 從 operator 宣告的 gate 取得精確 pytest／unittest 命令授權，支援既有 `env -u PSC_REPO_ROOT` 前綴；拒絕規則特殊字元，不放行任意 Python／Git／shell 命令。
- 保留 acceptEdits、事件 hook、linked-worktree 的 add-dir；planner、reviewer、非 commit-required builder 不擴權。
- 單元與真實 headless canary 證實測試／stage／commit 可執行，未宣告命令仍遭拒。

## #480 尚未涵蓋部分

- 尚未將完整 persona `effective_tools` 結構化傳遞並翻譯為 executor 授權；本 PR 僅處理提交契約與特定已宣告測試。
- 未涵蓋任意 build／lint／其他測試工具、改參數的 focused test，以及非 commit-required builder。
- 尚未新增重複 permission-denial 的 typed outcome／有界終止分類。
- 不新增 OS sandbox 或宣稱完整隔離資格；Git hooks／測試仍可執行 candidate 程式碼。
- canary 為 launcher 級測試，不代表完整 Manager workflow 已驗收或 Hippo 採用率已改善。

因此本 PR 不使用自動關閉關鍵字；母 issue #480 保留 OPEN。

## 驗證

- [x] Launcher 單元測試 78 passed；Luna 獨立審查 PASS。
- [x] 真實 Claude headless canary：pytest、stage、commit 成功；未宣告 python3 -c 仍遭拒。
- [x] changelog fragment 與文件同步；未修改版號或全域權限。
- [x] 不將 launcher canary 宣稱為 Hippo feature 驗收。

- [x] 完整回歸：5652 passed、44 skipped、183 subtests passed（233.81 秒）。
- [x] preflight policy／OpenSpec PASS；preflight 使用 skip-tests 避免重複執行，完整測試已獨立跑完。
- [x] Runtime 分支套用後 launcher／gate ledger 回歸：84 passed、10 subtests passed。

本次修補最初已套入 runtime checkout，但當時未重載 manager；此為套用當下紀錄，不代表目前 daemon 版本。單一卡片恢復與 manager 程式部署是兩件事：既有 retry-card 是正式單卡恢復入口，不需要為了清理一個 job 而重啟整個 Cortex。原始 RED job 已 exited，並非仍掛住的 process；其證據與產物應保留，不直接刪 registry。是否部署本修補須獨立決定，不將 service restart 當作單 job recovery 的前置條件。
