### PR TITLE
docs(refine): 納入 terminal JSONL framing 子計畫

### DIFF
--- a/.cortex/work-items.yaml
+++ b/.cortex/work-items.yaml
@@ -956,6 +956,20 @@ work_items:
       - kind: path
         ref: 'docs/superpowers/workstreams/monitor-watcher-bounded/todo.md'
     excludes: []
+  workflow-terminal-jsonl-framing:
+    title: 'workflow-terminal-jsonl-framing'
+    links:
+      - kind: github_issue
+        ref: 'hamanpaul/paulsha-cortex#860'
+      - kind: openspec
+        ref: 'workflow-terminal-jsonl-framing'
+      - kind: path
+        ref: 'docs/superpowers/specs/workflow-terminal-jsonl-framing-spec.md'
+      - kind: path
+        ref: 'docs/superpowers/specs/workflow-terminal-jsonl-framing-design.md'
+      - kind: path
+        ref: 'docs/superpowers/workstreams/workflow-terminal-jsonl-framing/todo.md'
+    excludes: []
   task-memory-delivery-adapter:
     title: 'task memory delivery Cortex adapter'
     links:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 
 ## [Unreleased]
 
+- **Terminal JSONL framing 進件（#860）**：登錄實體 LF／CRLF 與 Unicode 資料保真
+  子計畫，沿用 terminal trust boundary，補雙層序列化／不可變重播／負控制契約。
+  本項只有規劃進件；既存 generic carrier 殘餘與產品、部署驗收保持分帳。
+
 - **Task memory delivery adapter 進件（#857）**：登錄 Hippo #146 dependency、capability-aware delivery、工具中立 receipt、strict KPI 分離與 ≥95% authorized retrieval canary gate；本項只交付 accepted 規劃，不宣稱產品或 runtime 完成。
 
 - **Launcher／watcher 子計畫進件**：補齊 #823 session-only 三件組與唯一 owner links，

--- a/changelog.d/refine-terminal-framing-20260908.md
+++ b/changelog.d/refine-terminal-framing-20260908.md
@@ -1,0 +1,7 @@
+# Terminal JSONL framing 規劃進件
+
+- 為 refine R13／R06 登錄 #860 單一 owner 與 accepted spec/design/todo。
+- 明定 newline-preserving reader、實體 LF／CRLF、Unicode 深度相等和原有
+  terminal carrier/schema/authority 邊界；保留 generic carrier 的既存殘餘。
+- 規劃審查／機械計分與產品 RED/GREEN、CI、archive、merge、loaded runtime
+  分帳，不把臨時 ASCII 描述、原事故重播或 envelope bypass 當產品完成。

--- a/docs/superpowers/plans/2026-09-07-cortex-refine-complete.md
+++ b/docs/superpowers/plans/2026-09-07-cortex-refine-complete.md
@@ -68,14 +68,14 @@ R01–R14 是本文件的需求識別碼，**不是新建的 GitHub issue**。�
 | R03 evidence／terminal 冪等 | 同內容與狀態不重複產 evidence；變更恰好一次；舊 attempt 不能改現行候選或 completion | #496／#497；#501 只驗已修版本與既存污染 | 同 path 不同內容、重複 tick、重啟、delayed terminal、retry generation 的回歸；evidence hash 與 contract hash 各自保持語意。 |
 | R04 registry 寫入放大 | 無變更 no-op、history 上限與可追溯封存、安全 tmp sweep、rollback 成本與相容性；高頻寫入量測 | #821；更大 storage 遷移須有 profiling 依據，不預設重寫資料庫 | 無變更零寫入；history 有界而必要 audit 證據可追；crash recovery／migration／讀者 schema 全過；真變更仍正確持久化。 |
 | R05 額度／預估／fallback | 多額度池與時間窗觀測、任務需求預估、並行額度預留、動態候選選擇、持久退避與 reset reconciliation | #825 保留最小退避修復；新增 quota observation、forecast、reservation 與 admission 範圍 | 派前拒絕不足候選；同池換模型仍排除；不同池合格候選可選；並行不超額預留；重啟不丟；預估不足／外部消耗可修正；未知餘量不假裝足夠。 |
-| R06 失敗分類失真 | 原始結構化原因、phase、retryability、reset 與診斷鏈一致保留；planning／build／review 共用語意 | #826 補訊號；另補 planning launcher error 被包成 content 等消費端 | auth、quota、rate-limit、effort unsupported、127、缺 handle、schema/content 各有真實 fixture；同一底層原因不因 phase 換名而丟失恢復資訊。 |
+| R06 失敗分類失真 | 原始結構化原因、phase、retryability、reset 與診斷鏈一致保留；planning／build／review 共用語意 | #826 補訊號；另補 planning launcher error 被包成 content 等消費端；#860 framing 為 R13 主責的子件 | auth、quota、rate-limit、effort unsupported、127、缺 handle、schema/content 各有真實 fixture；同一底層原因不因 phase 換名而丟失恢復資訊；合法 Unicode terminal 不得被錯報 no JSON evidence。 |
 | R07 Recovery 語意與可恢復性 | 定義 resume/retry/recover/abandon 各自 precondition、effect、generation、資源處置與合法 next_actions；解除綁定必須真的生效 | #497 + 現有 recovery 家族（含 #545/#546/#547/#577 等需先查現況再拆票） | 狀態轉換矩陣、重送冪等、CAS mismatch、重啟續跑、late evidence、已合併工作禁止重派；只清受控 attempt 資源，不丟 operator 修改。 |
 | R08 model/agent/effort 彈性 | 可擴充 capability/adapter 契約；任務需求與執行配置分離；effort 實際解析與 operator preference/pin 語意 | #483/#581 與新 execution-profile 範圍；替換分散硬編，不把本次型號寫成 invariant | 新虛構模型與新 effort 只改 descriptor 即能在既有 adapter 執行；新 runtime 只加 adapter 與測試、不改 central resolver；unsupported 在 spawn 前拒絕；requested/resolved 可對照。 |
 | R09 評測／探活／實務紀錄 | PatchMUD qualification 供給、角色 deck、完整 profile fingerprint、版本化核可清單、TTL probe 與分層 track-record | 沿用 #452/#454/#466/#534 成果；補後續管線；PatchMUD 端獨立 PR | 一份真實 report 可追到核可條目，再追到實際派工；未測量維度為 unknown；更換 effort/adapter/toolchain 後不沿用不相容評分；評測不中斷 tick 熱路徑。 |
 | R10 狀態真實性與可解釋性 | actual/planned/last execution、完整 facets、等待額度/恢復原因、有效配置與選模依據；read model 不寫 workflow | #828 負責 identity producer；另補 needs_human/freshness/decision provenance | 同卡 retry 換模型、多卡同 phase、跨 repo、未派工／已退出均不猜測；registry needs_human 保留；所有 status sections 一致；下游 fixture 獨立驗收。 |
 | R11 runtime／release 一致性 | CLI 安裝、服務載入 revision、設定 revision、artifact digest 可辨識；受治理 upgrade/restart/rollback 與 source override receipt | P4 擴充成部署一致性工作；先核對既有 installer/release 實作，避免重建 | 從 checkout 外驗 installed CLI；真正服務報告載入 artifact；未重啟舊程序不算已更新；upgrade/rollback 不丟 active jobs；#820 僅計已完成的部分。 |
 | R12 instance／工作所有權 | instance roots、workspaces、writer、資源與共享 quota authority 的邊界；installer/doctor 同源檢查，owner-aware 清理 | #818/#800/#476 等既有票；P0 手動配置轉成產品契約 | 多 instance 並行與重啟不互寫 registry；共享 quota 仍能協調；stop/cleanup 只作用於指定 owner；dirty artifacts 與下游工作不被混入 commit。 |
-| R13 launcher／parser 基礎可靠性 | argv 引號／逗號解析、process/session 與 cgroup 生命週期、timeout/取消、terminal envelope/enum 契約、adapter conformance | #822/#823/#824 + #807/#820 residual；systemd 取消語意若超出 #823 另票 | 實際 argv round-trip；kill 單 job 不連坐 manager；manager restart 對 child 的處置有證據；timeout 可設定且 parse 正確；terminal 不靠寬鬆 status 別名繞過驗證。 |
+| R13 launcher／parser 基礎可靠性 | argv 引號／逗號解析、process/session 與 cgroup 生命週期、timeout/取消、terminal envelope/enum 契約、adapter conformance | #822/#823/#824 + #807/#820 residual；#860 單函式 JSONL framing；systemd 取消語意與 carrier-authentication 超出各票者由母 #829 另拆 | 實際 argv round-trip；kill 單 job 不連坐 manager；manager restart 對 child 的處置有證據；timeout 可設定且 parse 正確；LF/CRLF 與 Unicode 字串保真，不靠刪字元、status 別名或擴大 carrier/schema 繞過驗證。 |
 | R14 進件／驗證／交付脫節 | 規範文件唯一來源、coverage matrix、逐項 evidence-backed checklist、可恢復分批審查與人力/用量預算、issue/PR/installed 狀態分開 | #830 非 Job 派工決策契約、#831 sizing 方向；補 Red 分解接續與 delivery-accounting；P5 backlog hygiene 沿用 | 缺任一驗收、未 commit、policy 佔位字時不可宣告完成；合法等待／轉換不冒充 Job；完整 spec 不因算法反向變高風險；Red 真正產出可追溯子工作；中斷只重跑缺失工作；同 issue 不重複註冊；已修未關逐票證據關閉。 |
 
 「全部交代」的意思是每列均有責任模組、交付邊界、驗收與殘餘限制；不代表用有限的靜態掃描證明今後不存在同類缺陷。關鍵全稱需求由 runtime 不變量與負面測試守護。
@@ -331,6 +331,26 @@ PatchMUD #37仍是外部producer gate，真人qualification核可若生效也需
   abc/missing-unit/overflow與合法duration到unknown sentinel可區分。這不是模型或live gate。
 - #827 watcher修订fresh R4已PASS：failure latch與逐層nofollow契約處置兩MAJOR，
   純memory/source證據不等dirfd/FD上界/OS/產品/CI；仍8Red且未派工。
+
+### Terminal framing child 進件（2026-09-08）
+
+- [#860](https://github.com/hamanpaul/paulsha-cortex/issues/860) 為 `workflow-terminal-jsonl-framing`
+  唯一 owner；[spec](../specs/workflow-terminal-jsonl-framing-spec.md)、
+  [design](../specs/workflow-terminal-jsonl-framing-design.md)、
+  [todo](../workstreams/workflow-terminal-jsonl-framing/todo.md) 與
+  [審查證據](../../../reports/review/refine-terminal-framing-20260908.md) 對齊。
+  Product 僅 manager.py::_extract_terminal_json，domain0/state0/invariants10，
+  accepted 真 sizing6Yellow；#831 真載入後4Yellow只是條件投影，不變更歷史分數。
+- #822 job94 的合法 Unicode 被 splitlines 切壞是獨立 framing 缺陷，不擴大 YAML 票。
+  Root／fresh reviewer 以原件只讀重播及36組 synthetic serializer/EOF/LF/CRLF反例證明
+  framing 根因與保真候選；原hash未變，這不是原 verification 採信或已修產品。
+  完整純函式八組負控制與 reader review PASS；沒有用 envelope unavailable/bypass 當资格。
+- 現行 generic top-level text/result/content/message/response 並非完整 event-type allowlist，
+  synthetic tool 的頂層 text 仍可能被原 parser 接受。本 framing diff 不新增 carrier；
+  完整 authentication 是母 #829 的後續獨立子件與2.12驗收，不假稱 #860 封鎖全部 spoof。
+- 本次只進件 planning。產品仍須真 Cortex RED/GREEN、full/policy、獨立 review、自己
+  OpenSpec archive/exact-head delivery；實際 Manager 載入需共享 owner 的安全維護窗口。
+  不因這份規劃合併而關閉 #860、#822、#829，或宣稱 R06/R13/B1 已完成。
 
 ### Canary sizing 校正紀錄
 

--- a/docs/superpowers/specs/workflow-terminal-jsonl-framing-design.md
+++ b/docs/superpowers/specs/workflow-terminal-jsonl-framing-design.md
@@ -1,0 +1,59 @@
+---
+status: accepted
+work_item: workflow-terminal-jsonl-framing
+---
+
+# Workflow terminal JSONL framing 設計
+
+與 [spec](workflow-terminal-jsonl-framing-spec.md) 同屬 owner [#860](https://github.com/hamanpaul/paulsha-cortex/issues/860)。Root 於 2026-09-08 依 fresh `bounded_contracts_review` 的 PASS／0 BLOCKER-MAJOR 接受內容供 repository intake；以下仍是未來實作，不是已部署行為，也未因此完成產品 freeze／dispatch／qualification。
+
+Repository intake 同時備妥 [自有 OpenSpec design](../../../openspec/changes/workflow-terminal-jsonl-framing/design.md) 與完整 [tasks](../../../openspec/changes/workflow-terminal-jsonl-framing/tasks.md)，不以空 shell 代替 plan。正式 artifact 順序下，Yellow gate 的第一份 plan 是 OpenSpec tasks，sizing 的最後一份 plan 是 workstream todo；兩者均完整宣告原 sizing／scope／task coverage。Operator authority baseline 自 freeze 後不改，candidate builder 僅更新有證據的 checkbox；其他 byte 差異仍 fail-closed。這是 baseline intake 接線，不改 D1–D6 的產品方案。
+
+## Decisions
+
+### D1 只修 record framing 與必要的讀取語意
+
+在 `_extract_terminal_json` 內以 `Path(log_path).open(encoding="utf-8", newline="")` 的 context manager 讀取文字，再用 literal `content.split("\n")` 切 records。Python 3.10–3.13 的 file-open newline 參數可用；不使用只有較新 Python 才支援的 `Path.read_text(newline=...)` 呼叫。保留原 OSError／UnicodeDecodeError → `workflow terminal log unreadable` 映射，handle 正常關閉。
+
+這個小讀取變更是必要的：原 `Path.read_text` 使用 universal newline，會先把裸 CR 變成 LF；只換 split 方法無法實現 spec R1 的 literal LF／CRLF 邊界。選擇 `newline=""` 不轉換資料，CRLF 的 CR 留在 JSON 行尾作合法 whitespace，既有 fence regex 自行支援 CRLF。裸 CR 相接的兩筆物件仍是一個無效 JSON record，不額外提供 fallback。
+
+不以 `str.splitlines()`、regex `\s`、Unicode normalize、`strip`／`rstrip` 改寫 record 或 payload。原有「空白行是否略過」的判斷可留，但傳入 `json.loads` 的非空 record 不經內容 strip。全檔 read／反向 list 掃描的記憶體複雜度不變；沒有新增 queue、thread 或持久狀態。
+
+### D2 保留現有採信層次
+
+資料流是「Manager 選 same-era／same-Candidate 最新 job → 讀 job.log_path → 實體 LF record → 既有 carrier extraction → terminal shape → gate／phase schema／report／identity 採信 → Manager evidence」。本票只動第二、三段的 framing；state writer 與模型 wrapper 不改。
+
+當前 source 錨點：`manager.py:10488–10508` 選 job，`:6321` 讀 job.log_path，`:4355–4405` 抽取，`:4441–4454` shape，`:6330–6334` gate，`:6358–6392` verify schema/report。Production 修改不得超出 `_extract_terminal_json`，caller 的真接線以 tests 驗，不藉 caller tests 把 production scope 算成跨模組。
+
+### D3 JSONL 與 JSON text 兩層序列化
+
+矩陣必涵蓋 inner `result` 字串／outer provider record 各自 `ensure_ascii=True/False`；`structured_output` 副本的值也可含 NEL/LS/PS。對 fixture 最終 decoded payload 做深度相等比較，而非只檢查 status；原始 payload 值必須保留。
+
+反例：只 escape inner result，outer serializer 對 `structured_output` 輸出 raw NEL，舊 `splitlines()` 仍會破壞整筆 record。合法產品修復不能依賴 provider 永遠 ASCII serialization。事故暫時恢復若採 ASCII 名稱 `U+0085` 是刻意改用說明文字的新 terminal，不是本票 fidelity oracle，也不允許回寫原檔。
+
+### D4 信任邊界與精確列管殘餘
+
+| Surface | 本票保留／驗收 | 明確未解決的範圍 |
+|---|---|---|
+| `_parse_terminal_json_text` (`manager.py:4408–4438`) | 完整 JSON、既有末尾 JSON/fence 路徑；嵌入且後接非 terminal 敘事的假 evidence 不新增採信 | 不重新設計所有「最後 payload」語意 |
+| `_unwrap_structured_output` (`:3920–3938`) | 只一層、只有 terminal_contract 白名單；未知或多層 wrapper 仍拒收 | 不新增任意 `structured_output` fallback |
+| tool `data.content` (`:4384–4388`) | 僅 `assistant.message` 可讀此 carrier；`tool.execution_complete.data.content` 保持拒收，尾端 spoof 不覆蓋真正 terminal | 當前 generic `result/content/message/text/response` (`:4389–4392`) 沒有 event-type allowlist；synthetic tool 的頂層 `text` 本來可被抽取。這是既存另一個 carrier-authentication 契約問題，交 root 的 R13/R06 列管；本票不聲稱所有 tool spoof 都拒收 |
+| terminal shape／schema | 型別、enum、exact key set、report path/size、Candidate／era／ledger 全不放寬 | parser 能讀不保證 schema／gate／獨立 reviewer 採信 |
+| reverse scan | 尾端非 terminal／非 JSON 行維持略過，回到較早合法 terminal | 較新 malformed terminal 是否應阻擋較舊 terminal 是現有選擇政策，不在 framing 修正中暗改 |
+| resource／live | 靜態有限 fixture 的全檔讀取與 hash 可重播，無額外副作用 | 全檔 O(bytes) 記憶體、live concurrent append／rotation、部署與其他 parser 的同類缺口另列管；不能宣稱本票提供 streaming memory bound 或全系統修復 |
+
+這些殘餘有明確既存 source 邊界；此次 diff 不新增 carrier 類別或 side-effect authority。若 reviewer 認為某一殘餘會令本修補本身不安全，須指出具體新增影響，root 再裁決擴 scope／另件，不以 accepted 標記遮蔽。
+
+### D5 測試與交付邊界
+
+重用 pytest／`tmp_path`／`unittest.mock`，集中新增 `tests/test_workflow_terminal_jsonl_framing.py`。先做 Unicode record-fidelity RED，再做讀取與分行兩個 seam 的最小修正；實際行數由最小且可讀的 context manager 決定，不為行數省略資源關閉。既有 carrier tests 在 `tests/test_workflow_production_wiring.py:4318–4484`，wrapper tests 在 `tests/test_terminal_result_contract.py:472–487`；維持原拒收 oracle。
+
+合成 fixture 是 CI authoritative regression。私有 #94 原檔只允許額外唯讀 replay，讀前後 SHA256 一致；不能把原 log 複製進 repo、不能要求 CI 存取 live root。Memory-only monkeypatch 只證明 seam，未來產品必另跑真 `tmp_path` file-open/newline/error tests。真 CLI help 以候選 interpreter、checkout 外 cwd 實跑；不接 live control。
+
+### D6 Sizing、審查與 authority
+
+唯一 production function 位於單一模組，因此 domain_breadth=0；無新增 shared state／writer／concurrency 轉移，因此 state_consistency=0。invariant_count=10 對應 spec R1–R10；artifact_classes 完整含 source/tests/documentation。
+
+完整 `fix-standard` 保留 gate_spine=2、cards=9、persona bindings=9、全部 R-09/R-16/R-19。Author 首稿當時三件組為 draft，真 completeness=false；舊算法因未 accepted 而較低的 raw stability 數字從未授權進件，當時 accepted 分數只是記憶體 counterfactual。現在依 root 接受更新三件組後，現行真 helper 為 completeness=true、0/0/2/2/2=6 Yellow；#831 真載入且完整 accepted 後仍僅條件投影 0/0/2/0/2=4 Yellow。詳細歷史與當前 actual／negative controls 見 report；不改低數值、刪欄位或縮 combo 規避，pure helper 也不代替正式 freeze／readiness／qualification。
+
+第一輪獨立審查標準：未處置的缺陷／缺口 → FAIL；已明文承認、影響分析有界且列管的殘餘風險不單獨構成 FAIL；反對某殘餘時須具體反駁其影響分析。本次 accepted 來自 root 完整閱讀與獨立 reviewer 的內容審查，不是作者自批；root 已建立並讀回 #860，後續 repository intake 與正式 authority 仍由 root 負責。

--- a/docs/superpowers/specs/workflow-terminal-jsonl-framing-spec.md
+++ b/docs/superpowers/specs/workflow-terminal-jsonl-framing-spec.md
@@ -1,0 +1,33 @@
+---
+status: accepted
+work_item: workflow-terminal-jsonl-framing
+---
+
+# Workflow terminal JSONL 實體記錄分界
+
+Owner 為 [#860](https://github.com/hamanpaul/paulsha-cortex/issues/860)。Root 於 2026-09-08 完整閱讀本三件組，依 fresh `bounded_contracts_review` 的 PASS／0 BLOCKER-MAJOR 接受內容，可進 repository intake；不是作者自批，也不代表正式 frozen authority、產品 dispatch 或 qualification。Intake links 與後續 authority 由 root 另行管理。事故來源為 [#822](https://github.com/hamanpaul/paulsha-cortex/issues/822)，不把本件當成 #822 已完成的修正。上位 [refine plan](../plans/2026-09-07-cortex-refine-complete.md) 映射為 **R13 primary／R06 secondary**；不是 policy 規則編號。
+
+本次 repository intake 已預先備妥自有 [OpenSpec proposal](../../../openspec/changes/workflow-terminal-jsonl-framing/proposal.md)、[design](../../../openspec/changes/workflow-terminal-jsonl-framing/design.md)、[tasks](../../../openspec/changes/workflow-terminal-jsonl-framing/tasks.md) 與 [delta](../../../openspec/changes/workflow-terminal-jsonl-framing/specs/workflow-terminal-jsonl-framing/spec.md)，承接本 R1–R10，全部產品工作仍未完成。正式映射由 root 管理；未來 builder 沿用這份 baseline，不在 freeze 後另造 planning authority。
+
+## Requirements
+
+1. **R1 實體分界**：`_extract_terminal_json` 的 JSONL records 只以 literal LF 分界；CRLF 相容，CR 交由既有 JSON whitespace／fence 規則處理。末筆沒有換行、空行及尾端換行仍相容。不把裸 CR 當另一種 record delimiter；兩筆 JSON 只以裸 CR 相接不能被 reader 正規化成兩筆。單筆 JSON 外的合法 CR whitespace 不在此禁止。
+2. **R2 Unicode 資料保真**：JSON string 內合法的 raw 或 escaped U+0085 NEL、U+2028 LS、U+2029 PS 都是資料，解析後逐值保留；不得刪除、Unicode strip、替換成空白或以模型輸出 ASCII 作為產品修復。一般非 ASCII 字元與組合字也不能改寫。
+3. **R3 雙層載體**：Claude `type=result` 的 `result` JSON string 與同 record 的 `structured_output` object 同時存在時，任一欄位值含上述字元不得破壞 record。仍沿現有 `result` carrier 解析；不得因此新增對任意 `structured_output` 的採信，也不要求兩欄永遠相等來取代既有契約。
+4. **R4 選擇／信任邊界不擴張**：保留反向掃描、既有 recognized carrier、單層 wrapper 白名單與末尾 fence 規則。尾端非 terminal／既有不受信任的 tool `data.content` 不得覆蓋較早合法 terminal；只有此類 spoof 或未知 wrapper 時仍拒收。不新增遞迴 JSON 搜尋、任意 event/structured-output fallback。現有 generic `text` 等 carrier 並非完整 event-type allowlist，不能宣稱所有 tool spoof 已封鎖，見 design D4 的列管殘餘。
+5. **R5 授權不變**：`_is_workflow_terminal_payload`、per-phase schema、status enum、report path/size、Candidate／claim-era／identity／gate-ledger 綁定全部不改。能抽出 JSON 只代表 parser 成功，不能把 exit 0、`subtype=success` 或模型 `verified` 自報提升為 Manager 採信。
+6. **R6 失敗相容**：缺 log path、I/O／UTF-8 解碼錯誤、找不到可用 terminal 的既有 fail-closed 行為與錯誤訊息保留；不得用重試模型或改 failure classification 掩蓋 framing failure。不改尚未完成 append／truncated record 的既有選擇政策。
+7. **R7 純讀與不可變重播**：同一組原始 bytes 以舊 parser 重現失敗、候選 framing 回傳與原 terminal payload 完全相等；讀前／讀後 SHA256 相同。測試使用合成 fixture、記憶體或 `tmp_path`；禁止修改真實 log、evidence、registry、frozen planning 或 live run。私有事故檔只能作 owner 授權的額外唯讀重播，不是 CI 必備依賴。
+8. **R8 反例完整**：raw/escaped 三 code points、雙層序列化、LF/CRLF、missing final newline、尾端非 terminal、tool spoof 既有拒收路徑、未知／多層 wrapper、fence 相容、錯誤讀取均有 deterministic regression；RED 必須是被收集且實際失敗，不以 import／collection failure 代替。
+9. **R9 使用說明**：文件說明實體 JSONL record 與 JSON string 內容的差別，以及 parser 成功／schema 通過／gate 通過／runtime 已載入四種不同證據。臨時以 ASCII 名稱描述 separator 的新卡恢復不等於本產品修復，不能改舊 evidence 或只 escape 內層 result 後保證成功。
+10. **R10 完整交付**：未來 Cortex 只在 `paulsha_cortex/coordinator/manager.py` 的 `_extract_terminal_json` 內修 framing／其必要的無 newline 轉換讀取。搭配 tests、documentation、自有 OpenSpec 與 changelog，通過 focused/full tests、PR-context policy、CI、獨立 review 和 exact-head delivery；實際 Manager 載入／live 驗證另由 root 在共享 owner 同意的安全窗口處理，不於本草稿操作。
+
+## Scope
+
+唯一 production module／function 是 `coordinator/manager.py::_extract_terminal_json`。不改 launcher、provider serializer、terminal_contract、registry、service、sizing、其他 parser 的 `splitlines()` 或整體 log streaming 架構。若實作需擴張任何 production 邊界，先回 root 重裁／重算，不以單模組數值掩蓋。
+
+## Evidence
+
+基底 `b1b44bc476dc49481d8467c9595e7c4db3f1a87d` 與事故 runtime `79ba644780bf1c697c722ac24a297e7d02416100` 的 `manager.py:4355–4405` 同型：`:4362` 呼叫 `content.splitlines()`，`:4367` 對被切開的片段做 `json.loads`，最後報 `workflow terminal log has no JSON evidence`。
+
+#822 job `wf-855aa5366b-verification-94` 原 log SHA256 `ba8efd04a7f61c265a684699fae353bff950334edf5c6c339548eb433c26f378`，246816 bytes；203 個實體 LF records／206 個 Python `splitlines()` 片段。整檔 3 個 NEL，最後一筆有 2 個。記憶體 LF framing 回傳逐值等於原 `structured_output`，只證明 parser，不是完整 verification acceptance。精確位置與來源見 [作者報告](../../../reports/review/refine-terminal-framing-20260908.md)。

--- a/docs/superpowers/workstreams/workflow-terminal-jsonl-framing/todo.md
+++ b/docs/superpowers/workstreams/workflow-terminal-jsonl-framing/todo.md
@@ -1,0 +1,36 @@
+---
+status: accepted
+work_item: workflow-terminal-jsonl-framing
+domain_breadth: 0
+state_consistency: 0
+invariant_count: 10
+artifact_classes:
+  - source
+  - tests
+  - documentation
+---
+
+# Workflow terminal JSONL framing 工作清單
+
+Owner 為 [#860](https://github.com/hamanpaul/paulsha-cortex/issues/860)。Root 已依獨立內容審查接受本三件組，可進 repository intake；不代表產品 freeze／dispatch／qualification。[Spec](../../specs/workflow-terminal-jsonl-framing-spec.md) 與 [design](../../specs/workflow-terminal-jsonl-framing-design.md) 為同 work item。事故 #822／refine R13 primary、R06 secondary；以下都是未來 Cortex 產品工作，沒有任何產品 checkbox 已完成。
+
+## Tasks
+
+- [ ] **T1 tests／RED（R1–R3、R7–R8）**：新增 `tests/test_workflow_terminal_jsonl_framing.py`，以合成 payload、真 `tmp_path` JSONL 與 actual `_extract_terminal_json`，parameterize raw/escaped U+0085/U+2028/U+2029、inner/outer ensure_ascii 四組、只有 outer 副本含 separator 等；先證 baseline 是收集成功後的 assertion/ValueError RED。深度相等驗全部 details/reports 字串，不只 status。
+- [ ] **T2 source／GREEN（R1–R6）**：只在 `paulsha_cortex/coordinator/manager.py::_extract_terminal_json` 採 design D1 的 newline-preserving file open 與 literal LF record split；維持 UTF-8、原錯誤映射、反向掃描、carrier／wrapper／schema 與 fence。不改 provider、status alias、其他 parser 或任何 state writer。
+- [ ] **T3 tests／framing 相容（R1、R2、R6）**：真檔測 LF/CRLF、空行、末筆無換行、尾端空行、裸 CR 相接兩筆 JSON 拒收，以及單筆 JSON 合法 CR whitespace 相容；在讀取前後 hash 相同。測 Unicode 一般文字／組合字無變動；不得因 test serializer 預設 ensure_ascii 讓 raw 案例其實沒 raw 字元。
+- [ ] **T4 tests／雙層反例（R2–R3、R8）**：分開驗 inner escaped+outer raw structured_output 的舊失敗、候選成功；`type=result` 只有任意 structured_output 而沒有已認可 carrier 時仍拒收；wrapper 的 unknown／多層偽 evidence 不被新 fallback 接住。
+- [ ] **T5 tests／terminal 信任邊界（R4–R6）**：執行並擴充 `tests/test_workflow_production_wiring.py` 的 terminal extraction cases、`tests/test_terminal_result_contract.py` 的 wrapper cases。真 terminal 後接 turn.completed／文字雜訊／tool.execution_complete.data.content spoof，結果仍是前者；只有 spoof 則 no JSON evidence。保留既有完整 fenced JSON、AGY progress+trailing fence、progress+trailing JSON，以及內嵌 fake payload 後仍有 prose 的拒收。Design D4 已披露 generic top-level text 的既存接受，不假寫「所有 tool event 都拒收」。
+- [ ] **T6 tests／schema 和純讀負例（R5–R8）**：parser fixture 以 missing path、missing file、invalid UTF-8、純非 JSON、錯 terminal shape、report 路徑／size 等既有 harness 驗失敗邊界。JSON extraction 與 per-phase schema/report validation 分開斷言；不跑 live terminalize／model／registry writer。需要 consumer integration 時僅用 tmp_path registry 和現有 fake gate，不能採信 fake 為產品 gate。
+- [ ] **T7 tests／immutable 事故重播（R7–R8）**：用可公開合成 fixture 釘住原 shape、NEL 數量與 deep equality。Owner 若額外允許對私有 #94 replay，只讀指定 log，記原 hash／bytes／實體行／byte positions與讀後 hash；舊 parser FAIL／候選 parser PASS 是 parser-only 證據，不能填 verification、review、ship 或 CompletionRecord 已完成。
+- [ ] **T8 documentation／操作與 CLI（R9）**：同步 `docs/unified-work-lifecycle.md` 的 terminal extraction／recovery 邊界，說明 LF/CRLF、Unicode data、只 escape inner result 不足及 ASCII 名稱暫避的限制。README 依真實接口影響核對，沒有新 CLI flag 不虛造新旗標；在 checkout 外用候選環境真跑 `python3 -m paulsha_cortex.cli work start --help`、`recover work --help`，保留退出碼，禁止送 live request。
+- [ ] **T9 documentation／自有 OpenSpec 與 changelog（R10）**：以 owner #860 採產品 branch `feature/860-workflow-terminal-jsonl-framing`，沿用本次已備妥的 [自有 OpenSpec upfront baseline](../../../../openspec/changes/workflow-terminal-jsonl-framing/proposal.md)（proposal/design/tasks/spec delta），不在 freeze 後重新建立 planning 文件；核對全部 R1–R10 與 T1–T10，實跑 `openspec validate workflow-terminal-jsonl-framing --strict --no-interactive` 與 repo canonical-spec gate。Operator baseline 不改；candidate 只更新有證據的 checkbox，其餘內容變更須回 root 走正式 authority 流程。Active OpenSpec tasks 的 checkbox 只列 pre-archive 的實作／測試／文件／驗證；archive 本身與下游 reverify／review／CI／PR／merge／closure／runtime qualification 仍是未完成的交付要求，以 prose 記錄，不把自身 archive 或下游成功列成 archive 前置 checkbox，也不虛勾。此清單 T10 的全程交付要求保留，不整段複製成 active OpenSpec 的 pre-archive checkbox，避免自相依。不要修改／archive #822 的 active change。新增並 commit `changelog.d/workflow-terminal-jsonl-framing.md`、補 `CHANGELOG.md [Unreleased]`；不沿用 planning author branch 的 slug 當產品 fragment。
+- [ ] **T10 tests／full、policy、獨立交付（R1–R10）**：focused 三檔 → `python3 -m pytest tests/ -q` → pinned preflight（`.project-policy.yml` canonical OpenSpec specs + full suite）與帶真 PR title/body/labels/base/head 的 policy_check → git diff --check → Python 3.10–3.13 既有 CI／build/smoke-install。Independent review 必須綁 exact Candidate 並逐項處置 finding，正式 Cortex 完成自有 OpenSpec archive／reverify／PR／merge／closure。Parser-only replay、author pure gate、CI、merged 與實際 Manager loaded revision 分別記錄；部署需共享 owner 維護窗口，不在本任務重啟或改寫 live。
+
+## Testability
+
+所有測試可不耗模型執行；合成 logs、tmp_path、pure schema helpers 是主要 oracle。未知 provider semantics、generic carrier authentication、O(bytes) 全檔資源、append/rotation、其餘 14 類與 live maintenance 是 design D4／母 refine 的列管殘餘，不把本 child 完成寫成整體 R06/R13 關閉。
+
+## Gate status
+
+本三件組已依 root 接受標示 accepted，現行真 helper completeness=true、6/Yellow；這是 repository intake 的內容證據，不是正式 freeze／dispatch／qualification。Domain/state 仍由 production scope 判定，不以「consumer 測試觸及別模組」抬高，也不因歷史 draft 的舊算法 raw score 較低宣稱 ready。首稿 accepted counterfactual 保留於歷史 report；#831 真載入後的 4/Yellow 仍是條件投影，兩者都仍須正式 completeness／Yellow plan review／readiness。

--- a/openspec/changes/cortex-refine-complete/tasks.md
+++ b/openspec/changes/cortex-refine-complete/tasks.md
@@ -23,6 +23,8 @@
 - [ ] 2.8.1 先依 #850 有界 store／immutable event-fold child 交付 component；C/D provenance、reconciliation 與所有 lane 接線仍由 #825 後續 child 承接。
 - [ ] 2.9 以實際已載入 revision 驗 B1 成效，退出暫時 bypass 前保存 active jobs 與 rollback 方案。
 - [ ] 2.10 由 #847 區分可信 frozen 自發布 metadata 等價與真 authority 變更；前者保持 needs_human/gates/attempt/model binding 且零 spawn，後者仍走合法 restart，缺 provenance 不豁免。
+- [ ] 2.11 依 #860 交付 terminal JSONL 實體 LF／CRLF 分界、合法 Unicode／雙層序列化保真與不可變重播；維持既有 carrier/schema/claim-era 採信，不以 parser-only proof 關閉 R13／R06。
+- [ ] 2.12 母 #829 另拆 carrier-authentication 子件，處置 generic top-level text/result 等鍵缺少完整 event-type allowlist 的既存殘餘；驗 terminal 後的 synthetic tool carrier 不得冒充新權威。此工作不塞入 #860 framing diff。
 
 ## 3. B2 可擴充配置與資格
 

--- a/openspec/changes/workflow-terminal-jsonl-framing/design.md
+++ b/openspec/changes/workflow-terminal-jsonl-framing/design.md
@@ -1,0 +1,65 @@
+---
+status: accepted
+work_item: workflow-terminal-jsonl-framing
+---
+
+# Workflow terminal JSONL framing 自有 OpenSpec 設計
+
+與 [spec](proposal.md) 同屬 owner [#860](https://github.com/hamanpaul/paulsha-cortex/issues/860)。Root 於 2026-09-08 依 fresh `bounded_contracts_review` 的 PASS／0 BLOCKER-MAJOR 接受內容供 repository intake；以下仍是未來實作，不是已部署行為，也未因此完成產品 freeze／dispatch／qualification。
+
+本文件完整承接 [原 accepted design](../../../docs/superpowers/specs/workflow-terminal-jsonl-framing-design.md) 的 D1–D6，並非要求 builder 在 freeze 後新增 planning 文件。這份 upfront baseline 與 [proposal](proposal.md)／[tasks](tasks.md) 一起交 root 做 integration review；不是新的 production 範圍或已完成的產品 gate。
+
+## Decisions
+
+### D1 只修 record framing 與必要的讀取語意
+
+在 `_extract_terminal_json` 內以 `Path(log_path).open(encoding="utf-8", newline="")` 的 context manager 讀取文字，再用 literal `content.split("\n")` 切 records。Python 3.10–3.13 的 file-open newline 參數可用；不使用只有較新 Python 才支援的 `Path.read_text(newline=...)` 呼叫。保留原 OSError／UnicodeDecodeError → `workflow terminal log unreadable` 映射，handle 正常關閉。
+
+這個小讀取變更是必要的：原 `Path.read_text` 使用 universal newline，會先把裸 CR 變成 LF；只換 split 方法無法實現 spec R1 的 literal LF／CRLF 邊界。選擇 `newline=""` 不轉換資料，CRLF 的 CR 留在 JSON 行尾作合法 whitespace，既有 fence regex 自行支援 CRLF。裸 CR 相接的兩筆物件仍是一個無效 JSON record，不額外提供 fallback。
+
+不以 `str.splitlines()`、regex `\s`、Unicode normalize、`strip`／`rstrip` 改寫 record 或 payload。原有「空白行是否略過」的判斷可留，但傳入 `json.loads` 的非空 record 不經內容 strip。全檔 read／反向 list 掃描的記憶體複雜度不變；沒有新增 queue、thread 或持久狀態。
+
+### D2 保留現有採信層次
+
+資料流是「Manager 選 same-era／same-Candidate 最新 job → 讀 job.log_path → 實體 LF record → 既有 carrier extraction → terminal shape → gate／phase schema／report／identity 採信 → Manager evidence」。本票只動第二、三段的 framing；state writer 與模型 wrapper 不改。
+
+當前 source 錨點：`manager.py:10488–10508` 選 job，`:6321` 讀 job.log_path，`:4355–4405` 抽取，`:4441–4454` shape，`:6330–6334` gate，`:6358–6392` verify schema/report。Production 修改不得超出 `_extract_terminal_json`，caller 的真接線以 tests 驗，不藉 caller tests 把 production scope 算成跨模組。
+
+### D3 JSONL 與 JSON text 兩層序列化
+
+矩陣必涵蓋 inner `result` 字串／outer provider record 各自 `ensure_ascii=True/False`；`structured_output` 副本的值也可含 NEL/LS/PS。對 fixture 最終 decoded payload 做深度相等比較，而非只檢查 status；原始 payload 值必須保留。
+
+反例：只 escape inner result，outer serializer 對 `structured_output` 輸出 raw NEL，舊 `splitlines()` 仍會破壞整筆 record。合法產品修復不能依賴 provider 永遠 ASCII serialization。事故暫時恢復若採 ASCII 名稱 `U+0085` 是刻意改用說明文字的新 terminal，不是本票 fidelity oracle，也不允許回寫原檔。
+
+### D4 信任邊界與精確列管殘餘
+
+| Surface | 本票保留／驗收 | 明確未解決的範圍 |
+|---|---|---|
+| `_parse_terminal_json_text` (`manager.py:4408–4438`) | 完整 JSON、既有末尾 JSON/fence 路徑；嵌入且後接非 terminal 敘事的假 evidence 不新增採信 | 不重新設計所有「最後 payload」語意 |
+| `_unwrap_structured_output` (`:3920–3938`) | 只一層、只有 terminal_contract 白名單；未知或多層 wrapper 仍拒收 | 不新增任意 `structured_output` fallback |
+| tool `data.content` (`:4384–4388`) | 僅 `assistant.message` 可讀此 carrier；`tool.execution_complete.data.content` 保持拒收，尾端 spoof 不覆蓋真正 terminal | 當前 generic `result/content/message/text/response` (`:4389–4392`) 沒有 event-type allowlist；synthetic tool 的頂層 `text` 本來可被抽取。這是既存另一個 carrier-authentication 契約問題，交 root 的 R13/R06 列管；本票不聲稱所有 tool spoof 都拒收 |
+| terminal shape／schema | 型別、enum、exact key set、report path/size、Candidate／era／ledger 全不放寬 | parser 能讀不保證 schema／gate／獨立 reviewer 採信 |
+| reverse scan | 尾端非 terminal／非 JSON 行維持略過，回到較早合法 terminal | 較新 malformed terminal 是否應阻擋較舊 terminal 是現有選擇政策，不在 framing 修正中暗改 |
+| resource／live | 靜態有限 fixture 的全檔讀取與 hash 可重播，無額外副作用 | 全檔 O(bytes) 記憶體、live concurrent append／rotation、部署與其他 parser 的同類缺口另列管；不能宣稱本票提供 streaming memory bound 或全系統修復 |
+
+這些殘餘有明確既存 source 邊界；此次 diff 不新增 carrier 類別或 side-effect authority。若 reviewer 認為某一殘餘會令本修補本身不安全，須指出具體新增影響，root 再裁決擴 scope／另件，不以 accepted 標記遮蔽。
+
+### D5 測試與交付邊界
+
+重用 pytest／`tmp_path`／`unittest.mock`，集中新增 `tests/test_workflow_terminal_jsonl_framing.py`。先做 Unicode record-fidelity RED，再做讀取與分行兩個 seam 的最小修正；實際行數由最小且可讀的 context manager 決定，不為行數省略資源關閉。既有 carrier tests 在 `tests/test_workflow_production_wiring.py:4318–4484`，wrapper tests 在 `tests/test_terminal_result_contract.py:472–487`；維持原拒收 oracle。
+
+合成 fixture 是 CI authoritative regression。私有 #94 原檔只允許額外唯讀 replay，讀前後 SHA256 一致；不能把原 log 複製進 repo、不能要求 CI 存取 live root。Memory-only monkeypatch 只證明 seam，未來產品必另跑真 `tmp_path` file-open/newline/error tests。真 CLI help 以候選 interpreter、checkout 外 cwd 實跑；不接 live control。
+
+### D6 Sizing、審查與 authority
+
+唯一 production function 位於單一模組，因此 domain_breadth=0；無新增 shared state／writer／concurrency 轉移，因此 state_consistency=0。invariant_count=10 對應 spec R1–R10；artifact_classes 完整含 source/tests/documentation。
+
+完整 `fix-standard` 保留 gate_spine=2、cards=9、persona bindings=9、全部 R-09/R-16/R-19。Author 首稿當時三件組為 draft，真 completeness=false；舊算法因未 accepted 而較低的 raw stability 數字從未授權進件，當時 accepted 分數只是記憶體 counterfactual。現在依 root 接受更新三件組後，現行真 helper 為 completeness=true、0/0/2/2/2=6 Yellow；#831 真載入且完整 accepted 後仍僅條件投影 0/0/2/0/2=4 Yellow。詳細歷史與當前 actual／negative controls 見 report；不改低數值、刪欄位或縮 combo 規避，pure helper 也不代替正式 freeze／readiness／qualification。
+
+第一輪獨立審查標準：未處置的缺陷／缺口 → FAIL；已明文承認、影響分析有界且列管的殘餘風險不單獨構成 FAIL；反對某殘餘時須具體反駁其影響分析。本次 accepted 來自 root 完整閱讀與獨立 reviewer 的內容審查，不是作者自批；root 已建立並讀回 #860，後續 repository intake 與正式 authority 仍由 root 負責。
+
+## Upfront planning 與 checkbox 契約
+
+正式映射本 child OpenSpec 後，artifact rows 先加入 proposal(spec)／design(design)／tasks(plan)，最後加入 workstream todo(plan)。Yellow helper 使用第一份 plan，sizing snapshot 使用最後一份 plan，因此 [tasks](tasks.md) 與 [原 todo](../../../docs/superpowers/workstreams/workflow-terminal-jsonl-framing/todo.md) 都完整宣告 domain=0、state=0、invariant_count=10、artifact_classes=source/tests/documentation；兩份均保留 R-09/R-16/R-19 與 R1–R10 coverage，不能以空 shell 取得 gate ready。
+
+正式 freeze 之後，operator 上的 authority baseline bytes MUST 保持原樣。Builder 只在 candidate 更新已獲證據的 tasks/todo checkbox；`kind=plan` 且 basename 為 tasks.md／todo.md 的 checkbox-only 差異才可由既有 tolerance 採信。Scope、文字、frontmatter、proposal/design/spec delta 不能暗改；有內容變更需求先回 root 走正式 authority 流程，不 patch frozen bytes。本 child active tasks 只列 pre-archive 工作；archive 本身、產品獨立 review／CI、merge／closure／runtime qualification 等下游 pending 以 prose 留存，不要求自己的 archive 先已完成才能 archive。完整交付仍受原 todo T10 與正式 Cortex gates 約束。

--- a/openspec/changes/workflow-terminal-jsonl-framing/design.md
+++ b/openspec/changes/workflow-terminal-jsonl-framing/design.md
@@ -5,7 +5,7 @@ work_item: workflow-terminal-jsonl-framing
 
 # Workflow terminal JSONL framing 自有 OpenSpec 設計
 
-與 [spec](proposal.md) 同屬 owner [#860](https://github.com/hamanpaul/paulsha-cortex/issues/860)。Root 於 2026-09-08 依 fresh `bounded_contracts_review` 的 PASS／0 BLOCKER-MAJOR 接受內容供 repository intake；以下仍是未來實作，不是已部署行為，也未因此完成產品 freeze／dispatch／qualification。
+與 [proposal](proposal.md) 同屬 owner [#860](https://github.com/hamanpaul/paulsha-cortex/issues/860)。Root 於 2026-09-08 依 fresh `bounded_contracts_review` 的 PASS／0 BLOCKER-MAJOR 接受內容供 repository intake；以下仍是未來實作，不是已部署行為，也未因此完成產品 freeze／dispatch／qualification。
 
 本文件完整承接 [原 accepted design](../../../docs/superpowers/specs/workflow-terminal-jsonl-framing-design.md) 的 D1–D6，並非要求 builder 在 freeze 後新增 planning 文件。這份 upfront baseline 與 [proposal](proposal.md)／[tasks](tasks.md) 一起交 root 做 integration review；不是新的 production 範圍或已完成的產品 gate。
 

--- a/openspec/changes/workflow-terminal-jsonl-framing/proposal.md
+++ b/openspec/changes/workflow-terminal-jsonl-framing/proposal.md
@@ -1,0 +1,53 @@
+---
+status: accepted
+work_item: workflow-terminal-jsonl-framing
+---
+
+# Workflow terminal JSONL framing 自有 OpenSpec proposal
+
+Owner 為 [#860](https://github.com/hamanpaul/paulsha-cortex/issues/860)，work_id 為 `workflow-terminal-jsonl-framing`。本 upfront baseline 承接 root 已接受的 [spec](../../../docs/superpowers/specs/workflow-terminal-jsonl-framing-spec.md)／[design](../../../docs/superpowers/specs/workflow-terminal-jsonl-framing-design.md) 等價內容；accepted 只指 planning 內容，不表示產品工作、正式 freeze／dispatch 或 qualification 完成。所有 [pre-archive tasks](tasks.md) 都未完成，產品由正式 Cortex 工作流程執行。此 baseline 新增本身仍交 root 做最終 integration review。
+
+## Why
+
+事故 [#822](https://github.com/hamanpaul/paulsha-cortex/issues/822) 的合法 JSONL record 在 JSON string 中含 raw NEL，Manager 的 `str.splitlines()` 把資料錯切為 records，報 no JSON evidence。本件修 representation fidelity，不改 schema、provider quota 或授權。Refine 映射為 R13 primary／R06 secondary；這不是 policy 規則編號，也不是宣告 #822 或母 refine 已完成。
+
+## What Changes
+
+只在 `paulsha_cortex/coordinator/manager.py::_extract_terminal_json` 使用保留 newline 的 UTF-8 reader 與 literal LF record 分界；保留 Unicode string data、既有 carrier／wrapper／fence、terminal schema 和原 fail-closed 行為。搭配合成 regression、文件／CLI help、own OpenSpec、changelog 與完整候選交付。不重寫其他 parser，不建立 state writer，不變更 live evidence。
+
+## Capabilities
+
+### New Capabilities
+
+- `workflow-terminal-jsonl-framing`：terminal JSONL 實體 record 分界與 Unicode data 保真。
+
+### Modified Capabilities
+
+不隱性修改既有 terminal 採信或 workflow authority 要求；carrier-authentication 與 streaming 資源等既存殘餘在下列 Requirements 與自有 design 列管。
+
+## Impact
+
+唯一 production module／function 是 `coordinator/manager.py::_extract_terminal_json`。Tests 集中新增 `tests/test_workflow_terminal_jsonl_framing.py` 並重用既有 production-wiring／terminal-contract harness；documentation 依真接口影響更新 lifecycle 說明並實跑 CLI help。完整 fix-standard 的 R-09／R-16／R-19、full suite、policy、CI、獨立 exact-Candidate review 與下游交付全部保留。其他 owner 的 jobs、registry、operator baseline、live service 與原事故 log 均不在此次文件操作範圍。詳見 [design](design.md)、[tasks](tasks.md) 及 [delta](specs/workflow-terminal-jsonl-framing/spec.md)。
+
+## Requirements
+
+1. **R1 實體分界**：`_extract_terminal_json` 的 JSONL records 只以 literal LF 分界；CRLF 相容，CR 交由既有 JSON whitespace／fence 規則處理。末筆沒有換行、空行及尾端換行仍相容。不把裸 CR 當另一種 record delimiter；兩筆 JSON 只以裸 CR 相接不能被 reader 正規化成兩筆。單筆 JSON 外的合法 CR whitespace 不在此禁止。
+2. **R2 Unicode 資料保真**：JSON string 內合法的 raw 或 escaped U+0085 NEL、U+2028 LS、U+2029 PS 都是資料，解析後逐值保留；不得刪除、Unicode strip、替換成空白或以模型輸出 ASCII 作為產品修復。一般非 ASCII 字元與組合字也不能改寫。
+3. **R3 雙層載體**：Claude `type=result` 的 `result` JSON string 與同 record 的 `structured_output` object 同時存在時，任一欄位值含上述字元不得破壞 record。仍沿現有 `result` carrier 解析；不得因此新增對任意 `structured_output` 的採信，也不要求兩欄永遠相等來取代既有契約。
+4. **R4 選擇／信任邊界不擴張**：保留反向掃描、既有 recognized carrier、單層 wrapper 白名單與末尾 fence 規則。尾端非 terminal／既有不受信任的 tool `data.content` 不得覆蓋較早合法 terminal；只有此類 spoof 或未知 wrapper 時仍拒收。不新增遞迴 JSON 搜尋、任意 event/structured-output fallback。現有 generic `text` 等 carrier 並非完整 event-type allowlist，不能宣稱所有 tool spoof 已封鎖，見 design D4 的列管殘餘。
+5. **R5 授權不變**：`_is_workflow_terminal_payload`、per-phase schema、status enum、report path/size、Candidate／claim-era／identity／gate-ledger 綁定全部不改。能抽出 JSON 只代表 parser 成功，不能把 exit 0、`subtype=success` 或模型 `verified` 自報提升為 Manager 採信。
+6. **R6 失敗相容**：缺 log path、I/O／UTF-8 解碼錯誤、找不到可用 terminal 的既有 fail-closed 行為與錯誤訊息保留；不得用重試模型或改 failure classification 掩蓋 framing failure。不改尚未完成 append／truncated record 的既有選擇政策。
+7. **R7 純讀與不可變重播**：同一組原始 bytes 以舊 parser 重現失敗、候選 framing 回傳與原 terminal payload 完全相等；讀前／讀後 SHA256 相同。測試使用合成 fixture、記憶體或 `tmp_path`；禁止修改真實 log、evidence、registry、frozen planning 或 live run。私有事故檔只能作 owner 授權的額外唯讀重播，不是 CI 必備依賴。
+8. **R8 反例完整**：raw/escaped 三 code points、雙層序列化、LF/CRLF、missing final newline、尾端非 terminal、tool spoof 既有拒收路徑、未知／多層 wrapper、fence 相容、錯誤讀取均有 deterministic regression；RED 必須是被收集且實際失敗，不以 import／collection failure 代替。
+9. **R9 使用說明**：文件說明實體 JSONL record 與 JSON string 內容的差別，以及 parser 成功／schema 通過／gate 通過／runtime 已載入四種不同證據。臨時以 ASCII 名稱描述 separator 的新卡恢復不等於本產品修復，不能改舊 evidence 或只 escape 內層 result 後保證成功。
+10. **R10 完整交付**：未來 Cortex 只在 `paulsha_cortex/coordinator/manager.py` 的 `_extract_terminal_json` 內修 framing／其必要的無 newline 轉換讀取。搭配 tests、documentation、自有 OpenSpec 與 changelog，通過 focused/full tests、PR-context policy、CI、獨立 review 和 exact-head delivery；實際 Manager 載入／live 驗證另由 root 在共享 owner 同意的安全窗口處理，不於本草稿操作。
+
+## Scope
+
+唯一 production module／function 是 `coordinator/manager.py::_extract_terminal_json`。不改 launcher、provider serializer、terminal_contract、registry、service、sizing、其他 parser 的 `splitlines()` 或整體 log streaming 架構。若實作需擴張任何 production 邊界，先回 root 重裁／重算，不以單模組數值掩蓋。
+
+## Evidence
+
+基底 `b1b44bc476dc49481d8467c9595e7c4db3f1a87d` 與事故 runtime `79ba644780bf1c697c722ac24a297e7d02416100` 的 `manager.py:4355–4405` 同型：`:4362` 呼叫 `content.splitlines()`，`:4367` 對被切開的片段做 `json.loads`，最後報 `workflow terminal log has no JSON evidence`。
+
+#822 job `wf-855aa5366b-verification-94` 原 log SHA256 `ba8efd04a7f61c265a684699fae353bff950334edf5c6c339548eb433c26f378`，246816 bytes；203 個實體 LF records／206 個 Python `splitlines()` 片段。整檔 3 個 NEL，最後一筆有 2 個。記憶體 LF framing 回傳逐值等於原 `structured_output`，只證明 parser，不是完整 verification acceptance。精確位置與來源見 [作者報告](../../../reports/review/refine-terminal-framing-20260908.md)。

--- a/openspec/changes/workflow-terminal-jsonl-framing/specs/workflow-terminal-jsonl-framing/spec.md
+++ b/openspec/changes/workflow-terminal-jsonl-framing/specs/workflow-terminal-jsonl-framing/spec.md
@@ -1,0 +1,100 @@
+---
+status: accepted
+work_item: workflow-terminal-jsonl-framing
+---
+
+# Workflow terminal JSONL framing delta
+
+Owner [#860](https://github.com/hamanpaul/paulsha-cortex/issues/860)。本 delta 承接 [proposal](../../proposal.md) R1–R10 與 [design](../../design.md)；accepted 只指規劃內容，所有 [產品 tasks](../../tasks.md) 仍未完成。
+
+## ADDED Requirements
+
+### Requirement: R1 實體分界
+
+系統 MUST 遵守下列契約：`_extract_terminal_json` 的 JSONL records 只以 literal LF 分界；CRLF 相容，CR 交由既有 JSON whitespace／fence 規則處理。末筆沒有換行、空行及尾端換行仍相容。不把裸 CR 當另一種 record delimiter；兩筆 JSON 只以裸 CR 相接不能被 reader 正規化成兩筆。單筆 JSON 外的合法 CR whitespace 不在此禁止。
+
+#### Scenario: LF 與 CRLF 記錄及裸 CR 負例
+
+- **WHEN** 輸入為 LF／CRLF、空行、無末尾換行，或僅以裸 CR 相接的兩筆 JSON
+- **THEN** 前述合法實體 LF records 可依原順序解析；裸 CR 相接不被 reader 正規化為兩筆，單筆 JSON 外合法 CR whitespace 仍相容
+
+### Requirement: R2 Unicode 資料保真
+
+系統 MUST 遵守下列契約：JSON string 內合法的 raw 或 escaped U+0085 NEL、U+2028 LS、U+2029 PS 都是資料，解析後逐值保留；不得刪除、Unicode strip、替換成空白或以模型輸出 ASCII 作為產品修復。一般非 ASCII 字元與組合字也不能改寫。
+
+#### Scenario: 三種合法 Unicode 資料
+
+- **WHEN** JSON string 含 raw 或 escaped U+0085／U+2028／U+2029，另含一般非 ASCII／組合字
+- **THEN** decoded payload 的每個值逐一深度相等，不 strip／刪字／替換
+
+### Requirement: R3 雙層載體
+
+系統 MUST 遵守下列契約：Claude `type=result` 的 `result` JSON string 與同 record 的 `structured_output` object 同時存在時，任一欄位值含上述字元不得破壞 record。仍沿現有 `result` carrier 解析；不得因此新增對任意 `structured_output` 的採信，也不要求兩欄永遠相等來取代既有契約。
+
+#### Scenario: 雙層 serializer 反例
+
+- **WHEN** inner result 已 escape，但同一 type=result record 的 outer structured_output 含 raw separator
+- **THEN** record 完整保留，仍經 result carrier 解析；只有任意 structured_output 的 record 不新增採信
+
+### Requirement: R4 選擇／信任邊界不擴張
+
+系統 MUST 遵守下列契約：保留反向掃描、既有 recognized carrier、單層 wrapper 白名單與末尾 fence 規則。尾端非 terminal／既有不受信任的 tool `data.content` 不得覆蓋較早合法 terminal；只有此類 spoof 或未知 wrapper 時仍拒收。不新增遞迴 JSON 搜尋、任意 event/structured-output fallback。現有 generic `text` 等 carrier 並非完整 event-type allowlist，不能宣稱所有 tool spoof 已封鎖，見 design D4 的列管殘餘。
+
+#### Scenario: 尾端 nonterminal 與已拒收 tool carrier
+
+- **WHEN** 真正 terminal 後接 nonterminal／tool.execution_complete.data.content spoof，或只有 spoof／未知多層 wrapper
+- **THEN** 前者仍選真正 terminal，後者拒收，不新增 recursive fallback；不宣稱 generic text 的既存接受已修
+
+### Requirement: R5 授權不變
+
+系統 MUST 遵守下列契約：`_is_workflow_terminal_payload`、per-phase schema、status enum、report path/size、Candidate／claim-era／identity／gate-ledger 綁定全部不改。能抽出 JSON 只代表 parser 成功，不能把 exit 0、`subtype=success` 或模型 `verified` 自報提升為 Manager 採信。
+
+#### Scenario: 解析成功不是授權
+
+- **WHEN** payload 被抽取但 phase schema、report path/size 或 Candidate／era／identity 綁定不符
+- **THEN** 既有 gate 保持 fail-closed，不能把 parser 成功或模型 verified 自報轉為採信
+
+### Requirement: R6 失敗相容
+
+系統 MUST 遵守下列契約：缺 log path、I/O／UTF-8 解碼錯誤、找不到可用 terminal 的既有 fail-closed 行為與錯誤訊息保留；不得用重試模型或改 failure classification 掩蓋 framing failure。不改尚未完成 append／truncated record 的既有選擇政策。
+
+#### Scenario: 讀取與缺證據錯誤
+
+- **WHEN** 缺 log path／檔案、I/O、invalid UTF-8、無合法 terminal 或末筆 truncated
+- **THEN** 既有錯誤映射與 terminal 選擇政策不被本 framing 修正放寬
+
+### Requirement: R7 純讀與不可變重播
+
+系統 MUST 遵守下列契約：同一組原始 bytes 以舊 parser 重現失敗、候選 framing 回傳與原 terminal payload 完全相等；讀前／讀後 SHA256 相同。測試使用合成 fixture、記憶體或 `tmp_path`；禁止修改真實 log、evidence、registry、frozen planning 或 live run。私有事故檔只能作 owner 授權的額外唯讀重播，不是 CI 必備依賴。
+
+#### Scenario: 原始 bytes 不可變重播
+
+- **WHEN** 合成或 owner 額外授權私有 log 以舊 parser 及候選 framing 純讀重播
+- **THEN** 舊失敗可重現且候選逐值等於原 payload，before/after SHA256 相同，不改 logs/evidence/registry
+
+### Requirement: R8 反例完整
+
+系統 MUST 遵守下列契約：raw/escaped 三 code points、雙層序列化、LF/CRLF、missing final newline、尾端非 terminal、tool spoof 既有拒收路徑、未知／多層 wrapper、fence 相容、錯誤讀取均有 deterministic regression；RED 必須是被收集且實際失敗，不以 import／collection failure 代替。
+
+#### Scenario: 收集成功的 deterministic regression
+
+- **WHEN** 執行 raw/escaped、雙層 serializer、framing、carrier/fence、invalid reader 的正負矩陣
+- **THEN** 先以被收集且實際 assertion/ValueError RED 證缺陷，再以候選 GREEN 保護全部對照，不拿 collection failure 當 RED
+
+### Requirement: R9 使用說明
+
+系統 MUST 遵守下列契約：文件說明實體 JSONL record 與 JSON string 內容的差別，以及 parser 成功／schema 通過／gate 通過／runtime 已載入四種不同證據。臨時以 ASCII 名稱描述 separator 的新卡恢復不等於本產品修復，不能改舊 evidence 或只 escape 內層 result 後保證成功。
+
+#### Scenario: 文件與實際 CLI
+
+- **WHEN** 候選文件說明 JSONL record 與 Unicode string data 並執行既有 CLI help
+- **THEN** 讀者能區分 parser/schema/gate/runtime loaded，知道只 escape inner 不足；不虛造新旗標或 live request
+
+### Requirement: R10 完整交付
+
+系統 MUST 遵守下列契約：未來 Cortex 只在 `paulsha_cortex/coordinator/manager.py` 的 `_extract_terminal_json` 內修 framing／其必要的無 newline 轉換讀取。搭配 tests、documentation、自有 OpenSpec 與 changelog，通過 focused/full tests、PR-context policy、CI、獨立 review 和 exact-head delivery；實際 Manager 載入／live 驗證另由 root 在共享 owner 同意的安全窗口處理，不於本草稿操作。
+
+#### Scenario: 單模組範圍與完整交付
+
+- **WHEN** Cortex 實作本 child 並推進候選驗證及正式下游交付
+- **THEN** production 只改 manager.py 的指定函式；tests/docs/changelog/own OpenSpec/full/policy/CI/review/exact-head 與安全 loaded gate 全保留，未完成不能假勾或當已部署

--- a/openspec/changes/workflow-terminal-jsonl-framing/tasks.md
+++ b/openspec/changes/workflow-terminal-jsonl-framing/tasks.md
@@ -1,0 +1,42 @@
+---
+status: accepted
+work_item: workflow-terminal-jsonl-framing
+domain_breadth: 0
+state_consistency: 0
+invariant_count: 10
+artifact_classes:
+  - source
+  - tests
+  - documentation
+---
+
+# Workflow terminal JSONL framing 自有 OpenSpec tasks
+
+Owner [#860](https://github.com/hamanpaul/paulsha-cortex/issues/860)，work_id `workflow-terminal-jsonl-framing`。本 upfront baseline 與 [proposal](proposal.md)／[design](design.md) 是完整 planning 輸入，並與 [workstream todo](../../../docs/superpowers/workstreams/workflow-terminal-jsonl-framing/todo.md) 的 R1–R10／T1–T10 同義對齊。Status accepted 是 root 接受的 planning scope，不是工作完成；本次所有 checkbox 都保持未勾。
+
+## Tasks
+
+- [ ] **T1 tests／RED（R1–R3、R7–R8）**：新增 `tests/test_workflow_terminal_jsonl_framing.py`，以合成 payload、真 `tmp_path` JSONL 與 actual `_extract_terminal_json`，parameterize raw/escaped U+0085/U+2028/U+2029、inner/outer ensure_ascii 四組、只有 outer 副本含 separator 等；先證 baseline 是收集成功後的 assertion/ValueError RED。深度相等驗全部 details/reports 字串，不只 status。
+- [ ] **T2 source／GREEN（R1–R6）**：只在 `paulsha_cortex/coordinator/manager.py::_extract_terminal_json` 採 design D1 的 newline-preserving file open 與 literal LF record split；維持 UTF-8、原錯誤映射、反向掃描、carrier／wrapper／schema 與 fence。不改 provider、status alias、其他 parser 或任何 state writer。
+- [ ] **T3 tests／framing 相容（R1、R2、R6）**：真檔測 LF/CRLF、空行、末筆無換行、尾端空行、裸 CR 相接兩筆 JSON 拒收，以及單筆 JSON 合法 CR whitespace 相容；在讀取前後 hash 相同。測 Unicode 一般文字／組合字無變動；不得因 test serializer 預設 ensure_ascii 讓 raw 案例其實沒 raw 字元。
+- [ ] **T4 tests／雙層反例（R2–R3、R8）**：分開驗 inner escaped+outer raw structured_output 的舊失敗、候選成功；`type=result` 只有任意 structured_output 而沒有已認可 carrier 時仍拒收；wrapper 的 unknown／多層偽 evidence 不被新 fallback 接住。
+- [ ] **T5 tests／terminal 信任邊界（R4–R6）**：執行並擴充 `tests/test_workflow_production_wiring.py` 的 terminal extraction cases、`tests/test_terminal_result_contract.py` 的 wrapper cases。真 terminal 後接 turn.completed／文字雜訊／tool.execution_complete.data.content spoof，結果仍是前者；只有 spoof 則 no JSON evidence。保留既有完整 fenced JSON、AGY progress+trailing fence、progress+trailing JSON，以及內嵌 fake payload 後仍有 prose 的拒收。Design D4 已披露 generic top-level text 的既存接受，不假寫「所有 tool event 都拒收」。
+- [ ] **T6 tests／schema 和純讀負例（R5–R8）**：parser fixture 以 missing path、missing file、invalid UTF-8、純非 JSON、錯 terminal shape、report 路徑／size 等既有 harness 驗失敗邊界。JSON extraction 與 per-phase schema/report validation 分開斷言；不跑 live terminalize／model／registry writer。需要 consumer integration 時僅用 tmp_path registry 和現有 fake gate，不能採信 fake 為產品 gate。
+- [ ] **T7 tests／immutable 事故重播（R7–R8）**：用可公開合成 fixture 釘住原 shape、NEL 數量與 deep equality。Owner 若額外允許對私有 #94 replay，只讀指定 log，記原 hash／bytes／實體行／byte positions與讀後 hash；舊 parser FAIL／候選 parser PASS 是 parser-only 證據，不能填 verification、review、ship 或 CompletionRecord 已完成。
+- [ ] **T8 documentation／操作與 CLI（R9）**：同步 `docs/unified-work-lifecycle.md` 的 terminal extraction／recovery 邊界，說明 LF/CRLF、Unicode data、只 escape inner result 不足及 ASCII 名稱暫避的限制。README 依真實接口影響核對，沒有新 CLI flag 不虛造新旗標；在 checkout 外用候選環境真跑 `python3 -m paulsha_cortex.cli work start --help`、`recover work --help`，保留退出碼，禁止送 live request。
+- [ ] **T9 documentation／既有 baseline 驗證與 changelog（R10／R-09）**：沿用本次 upfront proposal/design/tasks/spec delta，不重新建立另一份 change，不修改 #822 的 active change。核對 R1–R10／T1–T10 coverage，真跑 `openspec validate workflow-terminal-jsonl-framing --strict --no-interactive` 及 `openspec validate --specs`；只在 candidate 記錄已證實的 checkbox 完成。新增並 commit `changelog.d/workflow-terminal-jsonl-framing.md`、補 `CHANGELOG.md [Unreleased]`；產品 branch 是 `feature/860-workflow-terminal-jsonl-framing`，不以 planning author slug 取代。
+- [ ] **T10 tests／pre-archive 候選驗證（R1–R10／R-09/R-16/R-19）**：focused 三檔 → `python3 -m pytest tests/ -q` → pinned preflight（canonical OpenSpec specs＋full suite）與帶候選 PR title/body/labels/base/head 上下文的 policy_check → `git diff --check`；實跑 local build/smoke-install，核對 Python 3.10–3.13 既有 CI 會收集新增 tests。PR context 必須與真候選相符，若當時尚未開 PR 須明標 intended context，不宣稱遠端 CI 或 PR 已完成。任一 pre-archive gate 未通過不得勾此項；archive 後的再次驗證另屬下游要求。
+
+## Testability
+
+Source/tests/documentation 均有實際任務；R-09 由 T9/T10 保留 changelog，R-16 由 T8 真 CLI help 與 T10 policy 檢查，R-19 由 T1/T5/T6/T10 的測試收集、full suite 與後續既有 CI 覆蓋。所有 focused fixture 都可離線且不耗模型；無 live registry／model／service mutation，原事故 log 不改。Private replay 不是 CI 必備依賴或完整驗收。
+
+## Coverage
+
+R1→T1/T2/T3/T10；R2→T1/T2/T3/T4/T10；R3→T1/T2/T4/T10；R4→T2/T5/T10；R5→T2/T5/T6/T10；R6→T2/T3/T5/T6/T10；R7→T1/T6/T7/T10；R8→T1/T4/T6/T7/T10；R9→T8/T10；R10→T9/T10 與下游交付要求。上位 todo 的 T1–T8 原文保留，本文件 T9/T10 只分離 pre-archive 與下游階段，不刪除任何交付 AC。
+
+## Baseline 與下游交付（pending；不是 archive 前置 checkbox）
+
+Operator baseline 自正式 freeze 後始終不改。Candidate builder 只有經證據支持的 checkbox toggles 可採既有 tolerance；其他內容變化必須走 root 正式 authority 流程，不能用重新生成 tasks 或更動數值繞過 drift。所有 sizing 欄位與完整 fix-standard（gate spine=2、cards=9、persona bindings=9、R-09/R-16/R-19）維持原值：現行完整 accepted=6 Yellow；#831 真 loaded 後才有條件投影 4 Yellow，envelope bypass 不是資格證據。
+
+以下完整交付仍 pending：exact-Candidate 的產品獨立 verification/review、逐項 finding 處置、own OpenSpec archive、archive 後 reverify／preflight、Python 3.10–3.13 既有 CI、PR／merge／closure，以及 root 與共享 owner 同意安全窗口後的實際 Manager loaded revision／live qualification。這些依正式 Cortex 時序執行，不宣稱一律在 archive 之後才准 review，但不放進 active OpenSpec 的 pre-archive checkbox，避免把下游成功或 archive 自己變成 archive 前置條件。本段不取消原 todo T10；parser replay、author helper、CI、merged、deployed／loaded 各自分開記證據。

--- a/reports/review/refine-terminal-framing-20260908.md
+++ b/reports/review/refine-terminal-framing-20260908.md
@@ -1,0 +1,206 @@
+# Terminal JSONL framing：作者歷史草稿、root 接受與唯讀證據
+
+Author scope 僅四份 planning/report。以下首稿歷史記錄：於 2026-09-08 建立隔離 branch `feature/refine-terminal-framing-20260908`，在新 worktree 執行 `git pull --ff-only origin main`，回 Already up to date，base=`b1b44bc476dc49481d8467c9595e7c4db3f1a87d`。本作者當時沒有 commit/push、issue mutation、repository links、freeze、dispatch、產品碼或 live 狀態變更；當時三件組為 draft，交 root 獨立審查，未宣稱 accepted 或 issue-owned。現在 root 接受內容與建立 #860 的新狀態另記於末節，不回寫為作者首稿當時已做。
+
+## 來源與 route
+
+事故 run=`workflow-97a9aa661e4816e38964`，job=`wf-855aa5366b-verification-94`，Candidate=`b448ce84022ac124e1e225cfdf86a5616d6f9c68`；Claude/sonnet，2026-09-07T15:54:56.451537Z exited/0，16:04:41.315953Z NH `resume-workflow-failed: ValueError workflow terminal log has no JSON evidence`。事件 source revision=`5560e6180c0a110e4a9ca757f006a9bcec767499815e51c5d943f890b6107834`；claim=`claim:v1:685715d38ce2299bd7e0d8b5bcd232d09adc3c6fb4cf6347c2d7e82e92c8672b`。
+
+原 log 路徑以環境表示為 `$PSC_COORDINATOR_ROOT/logs/workflow/wf-855aa5366b-verification-94.jsonl`；SHA256=`ba8efd04a7f61c265a684699fae353bff950334edf5c6c339548eb433c26f378`。不附私有 prompt／原 log 內容。本案是 refine R13 primary／R06 secondary；ProblemMap strict：PM1 8（debugging black box，medium），Atlas F7 primary／F4 secondary，F5 為 misleading no-JSON 診斷症狀；broken invariant=`representation_container_fidelity_broken`，family-level fit、confidence high、evidence sufficient。先壞的是 framing，不是推理、quota 或 candidate schema。
+
+Skills 的影響：doc-coauthoring 區分 author draft／root reader；code-tracker 先按 exact parser seed 追 consumer；test-playbook 以 root cause 建立最便宜 deterministic oracle 並保留 negative controls。語意工具當時 Python server unconfigured、ctags 無 tags、cscope 無 index，採 `trace_mode=rg`（文字 call-edge conf=0.4）；純 parser 重播是獨立執行證據，不冒稱 LSP 或完整產品採信。依本次限定四檔，不另寫 experience、memory 或 vault trace。
+
+## Source／trust boundary 錨點
+
+| 錨點（相對 repo；base b1b44bc4） | 確認內容 |
+|---|---|
+| `coordinator/manager.py:10488–10508` | 同 run/card/phase/claim era/Candidate 篩選後取最新 job，非任意較早 verification |
+| `coordinator/manager.py:6321` | 消費 registry job.log_path，不讀人手指定報告取代 terminal |
+| `coordinator/manager.py:4355–4405` | UTF-8 reader、splitlines、reverse records、carrier、fence；唯一未來 production 修改函式 |
+| `coordinator/manager.py:3920–3938`／`terminal_contract.py:49` | 單層且白名單 wrapper；任意 structured_output 非新增採信來源 |
+| `coordinator/manager.py:4384–4392` | tool data.content 被 type gate 拒收，但 generic text 等鍵沒有完整 event-type allowlist，不能作全稱安全保證 |
+| `coordinator/manager.py:4441–4454、6358–6392` | extraction shape／verification schema/report 與 gate authorization 分離 |
+| `tests/test_workflow_production_wiring.py:4318–4484` | 現有 Codex/Copilot/AGY/fence/tool-data negative harness；預設 json.dumps escape Unicode，未釘本案 raw NEL |
+| `tests/test_terminal_result_contract.py:472–487` | known one-layer wrapper 與 unknown wrapper 負例 |
+| `coordinator/work_actions.py:2466–2491、2580–2628` | retry-card era/Candidate/accepted-evidence 篩選；不是本產品修補可直接 mutation 的權限 |
+
+上表 `coordinator/...` 的完整 repo prefix 為 `paulsha_cortex/`。Caller 的 breadth 是唯讀 trace，不代表新增 production 模組。
+
+作者以 AST 取 `_extract_terminal_json` 原始函式片段後做 SHA256，author base 與事故 runtime 兩份皆為 `84d267e6b15e274e73c8db6a6e2b53b0caa67647f85c81cf3e9a0d92781706b8`，並非只以 HEAD 名稱推定相同。本四件組的 local Markdown links 實際 resolve 全部存在；untracked 四檔各自 `git diff --no-index --check /dev/null FILE` 與 `git diff --check` 均無 whitespace error，沒有以尚未 tracked 而空 diff 的成功冒充四檔檢查。
+
+## 已執行的機制證據（不是產品 AC 完成）
+
+- 原檔 246816 bytes、203 個 physical LF records、206 個 `str.splitlines()` 片段；**整檔 3 個 NEL，最後 record 2 個**。
+- 末筆 physical line 203，byte `[222391,246816)`；raw U+0085 於 absolute byte 229251、239086。兩份載體的 decoded 值相同，欄位為 `details.job49_evidence`。
+- 原完整 bytes／單獨末筆 record → 正式 `_extract_terminal_json` 都報 no JSON；直接 `_parse_terminal_json_text(result)` 與 `_is_workflow_terminal_payload` 成功。
+- Memory-only LFFramed `splitlines` override → 回傳逐值等於原 `structured_output`；只 escape raw non-LF separator 的記憶體對照同樣成功；原檔讀後 SHA256 未變。
+- 正式 producer JSON schema、`_inline_terminal_reports`、`validate_verification_evidence` 純 shape 檢查 PASS；未跑完整 terminalization／gate／review／ship。
+- 合成雙層 fixture：raw NEL → FAIL；inner/outer 都 escape → PASS；只有 inner result escape 而 outer structured_output 有 raw NEL → FAIL；用 ASCII 名稱描述該字元 → PASS。後者只支持臨時新卡說明策略，不是保留原 Unicode 值的產品 oracle。
+- 真 library 的 memory `TextIOWrapper(BytesIO(...), newline=None)` 會把 bare CR 轉 LF；`newline=""` 保留 CR。證明為何 D1 同時限制 reader 與 splitter；尚未執行候選 production 的真 file-open 改動。
+- 合成 trust controls：tool.execution_complete.data.content → reject；structured_output-only → reject；tool.execution_complete 頂層 text → baseline accepted。最後一項如實列為既存 carrier-authentication 殘餘，沒有用靜態掃描支持「所有 tool spoof 都拒收」。
+
+## 風險／test matrix
+
+| Surface／觸發 | Oracle／harness | 規格／task |
+|---|---|---|
+| raw/escaped NEL/LS/PS、雙層 serializers | tmp_path actual parser，payload deep equality，舊 RED → 候選 GREEN | R2–R3／T1,T4 |
+| LF/CRLF／EOF／裸 CR 相接 | 真 newline-preserving reader；CR 不是 record delimiter，合法 JSON whitespace 仍可用 | R1,R6／T3 |
+| 末尾雜訊／tool-data spoof／unknown wrappers | 較早合法 terminal 保留；無合法 terminal 則原 error；不新增 carrier | R4–R5／T4,T5 |
+| invalid UTF-8／缺檔／wrong shape | 原例外分類；schema 不放寬 | R5–R6／T6 |
+| immutable bytes／私有來源 | synthetic CI fixture＋可選 owner-only replay；before/after SHA256 相等，無 live writer | R7–R8／T7 |
+| docs／CLI／own OpenSpec／policy／delivery | 真 help exits、self-owned change validate、full/policy/exact-head review，來源層次分開 | R9–R10／T8–T10 |
+
+State／concurrency 不新增：此為純讀 parser，不製造 shared-state transition；完整 job lifecycle、安全維護窗口及其他 owner 的 runs 不在本 child 變更內。O(bytes) 全檔讀取、concurrent append/rotation、generic carriers／latest-malformed 選擇與其他 parser 均見 design D4，母 refine R06/R13 仍保有整體驗收。
+
+## Author draft 歷史 pure planning gate
+
+2026-09-08 作者在 checkout 外 `/tmp`、`PYTHONDONTWRITEBYTECODE=1`／Python `-B` 下，以 `79ba644780bf1c697c722ac24a297e7d02416100` runtime 的真 `assess_planning_completeness`、`compute_sizing_score`、`_evaluate_yellow_plan_review` 重播，沒有建立 registry 或模型 session。固定完整 `fix-standard`：gate_spine_count=2、cards_count=9、persona_binding_count=9；適用規則為真完整 `ACCEPTANCE_SURFACE_RULES={R-09,R-16,R-19}`。三件組的真宣告為 domain=0、state=0、invariants=10、artifact_classes=source/tests/documentation。
+
+| Case（負控制只改記憶體） | 真 artifact completeness | 現行五維／total | #831 條件投影 total | 真 Yellow helper |
+|---|---|---|---|---|
+| 磁碟原 draft | false；三件 status-not-accepted，missing=spec/design/plan | 0/0/2/0/2=4 Yellow | 6 Yellow；未 accepted 仍 risk=2 | ready=true；不能代替左欄 completeness |
+| 只將三份 status 換 accepted 的 counterfactual | true；missing/reasons/markers 空 | 0/0/2/2/2=6 Yellow | 4 Yellow | ready=true |
+| accepted counterfactual 移除 design | false；missing=design | 0/0/2/1/2=5 Yellow | 5 Yellow | ready=true；仍無 artifact completeness |
+| accepted spec 移除 Requirements heading | false；required-section-missing | 0/0/2/1/2=5 Yellow | 6 Yellow | ready=true；仍不得進件 |
+| accepted spec 加 standalone blocking marker | false；blocking-decision | 0/0/2/0/2=4 Yellow | 6 Yellow | ready=true；低 raw score 不是許可 |
+| Tasks 的 documentation coverage 移除 | true | 0/0/2/2/2=6 Yellow | 4 Yellow | ready=false；missing-task-for-surface: documentation |
+| plan 增 scope_excludes=[cli] | true | 0/0/2/2/2=6 Yellow | 4 Yellow | ready=false、terminal=true；policy-scope-conflict: R-16 |
+| plan 移除 state_consistency | true | 真 compute 拋 ValueError，明示欄位 absent | 不造分數 | 不用無效分數呼叫後續 gate |
+
+`_evaluate_yellow_plan_review` 只對 plan tasks/contract/envelope 判斷（`manager.py:9336–9370`），不是三件組 accepted gate；negative controls 正好證明不能只報 ready=true。所有本表 ready=true 的 envelope observation 都是 `bypass=envelope_unavailable`，來自真 `load_model_identities()`＋`_plan_review_envelope_lookup`；不是能力量測 PASS。
+
+#831 欄是依 accepted spec 的 risk mapping，在記憶體以 `dataclasses.replace(score, spec_stability=projected_risk)` 計算：任一 marker／rejected assessment／至少兩缺 kind→2；單純一缺 kind→1；完整 accepted→0。不是已合併或已載入的 #831 runtime helper，沒有回填舊 run。其餘四維原值不動，沒有縮 combo 或 gate。首稿檢查當時磁碟始終 draft，當時禁止 register/freeze/dispatch；所有產品 T1–T10 迄本次 metadata 更新仍未勾。
+
+首稿最小重播節錄（輸入是下列歷史 SHA256 所示 draft bytes；不是將目前 accepted 檔案誤標為 draft 的命令。在隔離 checkout 外執行，`FRAMING_DOC_ROOT` 指歷史四檔所在 worktree，`PYTHONPATH` 指要查驗的 runtime；本命令不傳真 registry）：
+
+```python
+from pathlib import Path
+from dataclasses import replace
+from types import SimpleNamespace
+import os
+from paulsha_cortex.coordinator import planning, manager
+from paulsha_cortex.coordinator.claim import sizing_band
+from paulsha_cortex.coordinator.model_identities import load_model_identities
+from paulsha_cortex.deck.schema import load_cards, load_combo, resolve_combo_path, DEFAULT_CARDS_PATH
+
+root = Path(os.environ['FRAMING_DOC_ROOT'])
+slug = 'workflow-terminal-jsonl-framing'
+refs = [('spec', f'docs/superpowers/specs/{slug}-spec.md'),
+        ('design', f'docs/superpowers/specs/{slug}-design.md'),
+        ('plan', f'docs/superpowers/workstreams/{slug}/todo.md')]
+original = tuple(planning.PlanningArtifact(k, r, (root / r).read_text()) for k, r in refs)
+cards = load_cards(DEFAULT_CARDS_PATH)
+combo = load_combo(resolve_combo_path('fix-standard'), cards)
+identities = load_model_identities()
+for label, artifacts in [('draft', original), ('accepted-counterfactual', tuple(
+        replace(a, text=a.text.replace('status: draft', 'status: accepted', 1)) for a in original))]:
+    report = planning.assess_planning_completeness(artifacts)
+    score = planning.compute_sizing_score(
+        plan_artifact=artifacts[-1], completeness_report=report,
+        gate_spine_count=len(combo.gate_spine), applicable_contract_rules=planning.ACCEPTANCE_SURFACE_RULES,
+        cards_count=len(combo.cards),
+        persona_binding_count=sum(cards[e.ref].persona_binding is not None for e in combo.cards))
+    run = SimpleNamespace(steps=(), primary_domain=None, model_chain_override=None,
+                          sizing_band=sizing_band(score.total), run_id='read-only-framing-check')
+    gate = manager._evaluate_yellow_plan_review(
+        artifacts, envelope_lookup=manager._plan_review_envelope_lookup(run, identities))
+    print(label, report.complete, report.missing_kinds, score.to_dict(), gate)
+```
+
+首稿 author 當時沒有跑產品 focused/full tests、PR-context policy、CI 或 live CLI。僅為核對未來自有 OpenSpec 命令，唯讀執行了已安裝 `openspec validate --help`，確認支援 item-name／--strict／--no-interactive；不是 validation 通過。
+
+三件組 SHA256（首稿歷史 draft，不是目前 accepted bytes 或 evidence authority）：
+
+| 檔案 | SHA256 |
+|---|---|
+| spec | b3930206ea28e6b51d858f8e101bb29151ec69b785bbd15b0daed773f35e3ffa |
+| design | 39cd76289a6782eea2390211a9304f86a4e09e513efedf65adeb2a90ed2fb714 |
+| todo | 8950c097caaaee70b331688072795c2bd8b0cff2bdc6dc9b3db8a20b160c3102 |
+
+## 首稿歷史獨立 review 交接
+
+判定標準：未處置缺陷／缺口 FAIL；已承認、影響分析有界且文件列管 residual 不單獨 FAIL；反對接受須具體反駁影響分析。本作者當時只交草稿，當時尚無獨立 review PASS。
+
+當時交 fresh reader 的問題：唯一 production 邊界？為何不能只換 split？draft raw 分數能否進件？tool spoof 的已保護／既存未保護形狀？Parser replay 能否當 verified 或 live loaded 證據？Root 負責 reader 與 reviewer，不由作者自批。
+
+## 2026-09-08 root 接受／#860 owner metadata
+
+Root 轉交的獨立審查證據：root 已完整閱讀四件，fresh `bounded_contracts_review` 對抗審查 PASS／0 BLOCKER-MAJOR，覆核 36 組 framing／carrier cases、8 組 planning gates 與原 log 唯讀 proof。這是 root／reviewer 的內容與機制審查，不是本作者自行核准，也不是產品實作、正式 verification 或 runtime qualification 通過。原始 log 與其 evidence 均未因本次 metadata 更新而改寫。
+
+Root 已正式建立並 readback owner [#860](https://github.com/hamanpaul/paulsha-cortex/issues/860)，接受內容可供 repository intake。因此本次只把 spec/design/todo status 更新為 accepted、補 owner 與正確時態。Repository links、整合 PR 與正式 authority 由 root 另行管理；accepted 不等於已 merge、freeze、產品 dispatch 或 qualification。歷史 draft／accepted-counterfactual 的分數、hash 與當時未操作狀態保留於前節，不冒充當時已通過。
+
+R1–R10、D1–D5 與 T1–T8/T10 的技術內容維持原 bytes；D6 僅更新接受時點與 gate 敘述。T9 明定未來產品 branch `feature/860-workflow-terminal-jsonl-framing`，並釐清本 child 的 active OpenSpec checkbox 只列 pre-archive 工作；archive 與下游交付仍列未完成 prose，不形成自身 archive 的循環前置條件，也不刪除 T10 完整交付要求。
+
+本次 metadata 後作者實跑的純 helper，改固定 root 提供的 exact-79ba 隔離 clone，`git rev-parse HEAD` 確認 `79ba644780bf1c697c722ac24a297e7d02416100`，並確認 `planning.__file__`／`manager.__file__` 都來自該 clone；沒有宣稱 live runtime-main HEAD 仍為 79ba。原因是 root 通知其他 owner 已將 runtime-main source 移至另一 revision，而非本作者操作或部署。檢查維持 `PYTHONDONTWRITEBYTECODE=1`／Python `-B`、不建立 registry、不送模型或 control request。
+
+第一次 harness 在取得 actual accepted complete=true／6 Yellow 後，把 `PlanReviewOutcome` 誤以 dict 取值而報 TypeError；改用真 `.ready` 屬性並固定上述隔離 source 後，以下完整八組才是本次成功的 proof（exit 0）。沒有把 harness 錯誤解讀為產品 RED，也沒有以第一次部分輸出聲稱全組通過。
+
+| 本次實跑 case（變異僅記憶體） | 真 completeness | 真 total／Yellow helper |
+|---|---|---|
+| 磁碟 accepted 三件組 | true；missing kinds 空 | 6 Yellow；ready=true |
+| 三件 status 改回 draft | false；missing=spec/design/plan | 4 Yellow；ready=true 不授權進件 |
+| 缺 design | false | 5 Yellow；ready=true 不代替 artifact completeness |
+| spec 缺 Requirements heading | false | 5 Yellow；ready=true 不授權進件 |
+| spec standalone blocking marker | false | 4 Yellow；raw 降分不授權進件 |
+| Tasks 缺 documentation coverage | true | 6 Yellow；ready=false，missing-task-for-surface |
+| scope_excludes=[cli] | true | 6 Yellow；ready=false／terminal=true，R-16 conflict |
+| 缺 state_consistency | true | 真 compute 拋 ValueError，不造分數或呼叫後續 gate |
+
+固定完整 combo 仍為 gate_spine=2／cards=9／persona bindings=9，真適用規則 R-09/R-16/R-19；accepted 五維確為 0/0/2/2/2。Ready=true 的 envelope observation 仍為 `bypass=envelope_unavailable`，不當成能力量測或正式 readiness。僅以 `dataclasses.replace(score, spec_stability=0)` 另驗 #831 完整 accepted 條件投影 0/0/2/0/2=4 Yellow；沒有聲稱 #831 已 loaded，也沒有改既有 frozen revisions。
+
+該輪 metadata 前後 core SHA256 比對相等：spec 自 Requirements 至文末、design D1–D5、todo T1–T8/T10 三個獨立片段均不變。下列為新增 upfront OpenSpec 之前的 accepted 三件組歷史 SHA256；不是後續新增 baseline links 的最新 bytes。Report 本身的 hash 由各次交接訊息另列，避免自我參照。
+
+| 檔案 | Upfront OpenSpec 之前的 accepted SHA256 |
+|---|---|
+| spec | bd72bd17875381bb2e8dba55790bd6e45de5da9e4c3f28c07ed8ab676dab36f7 |
+| design | 05b8e059a0be20ef811500e1fcf2d5c469824a6641dc0f349fb8d564c5e5d5f0 |
+| todo | 68820b0e1cc4f2229afbdcb35493dea94f47cb6eade5d75eec400bb12dd98115 |
+
+前一輪 metadata 當時仍只更新四份 planning/report；沒有跑產品 focused/full tests、PR-context policy、CI 或 live qualification，沒有 product／issue／registry／service mutation，也沒有 commit/push。Root 的 repository intake／planning preflight 與未來產品 T1–T10 gates 是不同證據，不在此代填。
+
+## 2026-09-08 自有 OpenSpec upfront baseline integration
+
+Root 指派本輪 scope 為原四件加本 child 自有 OpenSpec proposal/design/tasks/spec delta，共八件；root 另管唯一 OpenSpec mapping 與其五份 integration 文件。此處不改 `.cortex`、changelog、母 plan/tasks、operator/runtime、registry、產品碼或原事故 log；不 commit/push/dispatch。本輪是避免後續 builder 在 frozen authority 後新增 planning inputs 的 intake 修正，不把所有產品工作當已完成。
+
+當下 source（author base b1b44bc4，對應 exact 79ba helper）確認：`work_bridge.py:241–245` 先追加 mapped OpenSpec proposal/spec、design/design、tasks/plan；`:246–247` 再追加 todo/plan。`current_sizing_snapshot` 的 `:274–282` 在迭代每個 plan 時覆寫變數，最後 plan 用作 sizing；`manager.py:9353` 的 Yellow review 用 `next(...)` 取第一份 plan。因此僅有 todo 完整、OpenSpec tasks 空殼並不足夠；本次 proposal/design 都自足承接原 R1–R10／D1–D6，tasks 與 todo 同樣完整宣告 0/0/10/source-tests-documentation，且保留完整 R-09/R-16/R-19 與 R1–R10 coverage。
+
+`manager.py:5055–5069` 的 checkbox 正規化只容忍 checkbox 狀態；`:5072–5099` reviewer authority map 要求 operator baseline 的 hash 先相等，才採 candidate checkbox-only hash。`:5117–5140` 的缺檔 seeding 必須有既有 authority refs 且 operator bytes 符合 baseline；`:5177–5203` 同樣先驗 operator baseline，scope／文字／metadata 變更仍 fail-closed。既有 `tests/test_checkbox_drift_tolerance.py:59–123` 與 `tests/test_builder_tasks_tick_verify_dispatch.py:1–30` 是此契約的 source/test 錨點，本輪只讀、不冒稱新跑產品測試。
+
+新 OpenSpec tasks 的十個 checkbox 只含未完成 pre-archive 工作；own archive、產品獨立 review／CI、archive 後再驗、PR／merge／closure／runtime loaded 等完整交付在 prose 明列 pending。原 todo T10 不減，T9 改沿用 upfront baseline；不把 archive 本身或下游成功放入 active change 的前置 checkbox，不令 closure 形成自相依。正式 freeze 後 operator baseline 永不由 builder 修改；candidate 只更新真證據支持的 checkbox，其他變更回 root 走正式 authority。
+
+### 本輪實跑與負控制
+
+從 `/tmp` 以 Python `-B`／`PYTHONDONTWRITEBYTECODE=1` 載入 root 指定的 exact `79ba644780bf1c697c722ac24a297e7d02416100` 隔離 clone。只以記憶體 `SimpleNamespace` 表示預期 authority links，呼叫真 `_artifact_rows` 讀本八件範圍中的六個 planning artifacts；沒有呼叫會建立 registry、frozen inputs 或派工的入口。Artifact 順序為原 spec、原 design、自有 proposal、自有 design、自有 tasks、原 todo；delta 另交 OpenSpec strict，不被誤算為第七份 planning artifact。
+
+實體六份 `assess_planning_artifact` 全部 accepted、reasons/markers 空；整體 `assess_planning_completeness.complete=true`，自有 OpenSpec 三件組單獨也 complete=true。兩份 plan 各自真 `compute_sizing_score` 都為 0/0/2/2/2=6 Yellow；真 `current_sizing_snapshot` 回 `(6, "yellow")`；真 Yellow helper 讀第一份 tasks，ready=true。固定完整 fix-standard=2 gate spine／9 cards／9 persona bindings，規則全集 R-09/R-16/R-19 不縮。Envelope observation 仍是 `bypass=envelope_unavailable`，不是能力量測；#831 的 4 Yellow 只以記憶體 stability=0 條件投影，不聲稱已載入。
+
+| 本輪 case（變異僅記憶體） | 真 completeness／逐件 rejected 數 | 真 helper 結果 |
+|---|---|---|
+| 實體六件 | true／0 | first-plan Yellow ready=true；last-plan sizing=6 |
+| 只移除第一份 tasks 的 documentation 任務標記 | true／0 | ready=false，missing-task-for-surface: documentation；完整 todo 不掩蓋 |
+| 只在第一份 tasks 排除 CLI | true／0 | ready=false，policy-scope-conflict: R-16 |
+| 只有自有 proposal 改 draft | true／1 | Yellow ready=true；kind OR 不證明所有 artifact accepted |
+| 只有自有 design 缺 Decisions | true／1 | Yellow ready=true；同 kind 的原 design 仍 accepted |
+| 第一份 tasks 加 standalone blocking marker | false／1 | Yellow ready=true 仍不得取代 completeness |
+| 兩份 spec 都改 draft | false／2 | Yellow ready=true 仍不得取代 completeness |
+| 兩份 design 都缺 Decisions | false／2 | Yellow ready=true 仍不得取代 completeness |
+| 最後 todo 缺 state_consistency | 內容只在讀取 mock 變異 | 真 sizing snapshot 回 `(None, None)`，不造分數 |
+| 第一份 tasks 缺 artifact_classes | 宣告僅記憶體移除 | 真 Yellow helper 回 None（既有 fail-soft），不冒稱拒收或允許進件 |
+
+以上十組皆按真結果完成斷言（exit 0）。第一版 harness 曾錯估「單一 proposal draft 會使 aggregate incomplete」而中止；核對 `planning.py:405–411` 確認是 accepted-kind OR，修正的是 harness 預期，不是產品或 planning 數值。本次額外要求逐件 assessment 全 accepted，以及 OpenSpec 三件組獨立 complete，避免用 aggregate true 掩蓋壞複本。此 OR／missing-declaration fail-soft 是已存在 helper 邊界，不在 #860 parser-only production scope 暗改；若今後 source 組成或內容改變，必須重新驗證，不以本次結果作全稱保證。
+
+真 `_checkbox_insensitive_equal` 對 tasks 與 todo 的記憶體單一 checkbox toggle 回 true；toggle 加 substantive 文字或修改 state metadata 都回 false。這只證純比對 seam，不是實際 candidate／operator／reviewer 全鏈已運行；實體兩份 plan 都仍 10/10 checkbox 未勾。
+
+在 author worktree 實跑 `openspec validate workflow-terminal-jsonl-framing --strict --no-interactive`：exit 0，`Change 'workflow-terminal-jsonl-framing' is valid`。這證明新增 change 有有效 delta／scenario，不代表產品實作、archive 或 CI 已完成。Root 另負責整合後的 canonical-spec／policy／full preflight 與 fresh review；本作者沒有以 strict 代替產品 T1–T10 gates。
+
+機械一致性檢查：八件的本地 Markdown links 全部存在；proposal R1–R10 原文與 spec 相等，自有 design D1–D6 與原 design 相等；tasks T1–T8 與原 todo 原文相等，原 todo T10 沒有改動；delta 有十個 requirements 與十個 scenarios。原 R1–R10／D1–D6 的產品內容與前輪完全相同，只加 upfront links／接線說明及 T9 baseline 使用方式。以下為本輪七份 planning docs SHA256，report 本身另由 hash-stop 交接提供。
+
+| 檔案 | Upfront baseline SHA256 |
+|---|---|
+| `docs/superpowers/specs/workflow-terminal-jsonl-framing-spec.md` | 3366ce02e7f7b86ce8a1741dcf3b3b24fad8c3e2e02d95152d1627ab640f09cc |
+| `docs/superpowers/specs/workflow-terminal-jsonl-framing-design.md` | 64cccfa5174a9dcc04a4f16757ac81687699f45284c1dc8d8e2eb5a70649d7ce |
+| `docs/superpowers/workstreams/workflow-terminal-jsonl-framing/todo.md` | 426321f40eb253fb6bb4532b7bc32c096891f64bab5b5812249ec54c05eb5c1a |
+| `openspec/changes/workflow-terminal-jsonl-framing/proposal.md` | f6872339728d71ebf0e071ed6f18cd9889407f28f9918db08ca319c19cff8585 |
+| `openspec/changes/workflow-terminal-jsonl-framing/design.md` | 4d581f60283fff12c9c2d42b696fa20a7c219f1a2993e782dc07668311df878b |
+| `openspec/changes/workflow-terminal-jsonl-framing/tasks.md` | 82ee46b07efa87f5a426c0dc33d3ba1262c816a4ee6c921b1495430040522098 |
+| `openspec/changes/workflow-terminal-jsonl-framing/specs/workflow-terminal-jsonl-framing/spec.md` | f5ffa1091042e6bb0531e29a2b186b4358ca987e37bce47995552e53d9c75132 |


### PR DESCRIPTION
## 範圍

為 Cortex #860 建立 accepted terminal JSONL framing spec/design/todo、自有 OpenSpec 四件組、唯一 work-item owner links、refine R13/R06 ledger 與 changelog。這是規劃進件，不包含產品碼、測試實作、模型評測、runtime 變更或 issue closure。

產品 start 前納管自己的 OpenSpec authority；其 tasks 與 todo 維持同一 scope/sizing/coverage，checkbox 僅列未完成的 pre-archive 工作，下游交付以 pending prose 分帳。後续 builder 只按真證據勾選，operator frozen baseline 保持原 bytes，避免空 delivery target 與中途新增 planning authority。

保留 LF/CRLF、合法 Unicode 資料與既有 carrier/schema/authority 邊界；generic top-level carrier authentication 是母 #829 另列工作，不藉本件宣稱全部 spoof 已解。

## 驗證與限制

Root 與獨立 reviewer 完成 36 組 framing／serializer 反例與原事故唯讀重播；八組 completeness/scope/sizing 負控制通過。實際 accepted 三件組計分6Yellow；#831部署後4Yellow只是條件投影；envelope unavailable/bypass 不是能力量測。

本地 pinned preflight 與遠端 CI 綁本 PR exact head；規劃 PASS 不替代後續 Cortex RED/GREEN、OpenSpec archive、產品 merge、installed 或 Manager loaded 證據。

## Checklist

- [x] 只改規劃、唯一 links、ledger 與對應 changelog，保留其他 owner 工作。
- [x] Fragment 與 Unreleased entry 同步；VERSION 沒有變更。
- [x] 獨立 planning review 的 actionable findings 已處置，列管殘餘具明確邊界。
- [x] issue 引用不關閉：使用 policy-exempt:issue-link，理由是 planning-only，#860/#829 產品驗收尚未交付。

`policy-exempt:issue-link` 只豁免 closing-keyword 要求，不豁免測試、review、policy 或 CI。
