### PR TITLE
feat(workflow): 完成 launcher-session-and-timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 
 ## [Unreleased]
 
+- **#823 headless launcher session**：共用 headless `Popen` kwargs 現在建立獨立
+  session/process group，保留 Claude stdin 與既有 runner override/retry 契約。
+
 - **Launcher／watcher 子計畫進件**：補齊 #823 session-only 三件組與唯一 owner links，
   登錄 #853 有界 watcher A child。真 process-group 與 cgroup 邊界、raw0／generation／
   partial-scan／nonfollow 驗收完整列管；現行 sizing 6／8 與正式產品交付分開。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@
 ## [Unreleased]
 
 - **#823 headless launcher session**：共用 headless `Popen` kwargs 現在建立獨立
-  session/process group，保留 Claude stdin 與既有 runner override/retry 契約。
+  session/process group，保留 Claude stdin 與既有 runner override/retry 契約；補齊
+  direct／systemd-run／systemd-template 的 14 格合法接線回歸與 ownership-first 負控制，
+  並明示 cgroup、restart、#824 與 #851 的未承接邊界。
 
 - **Launcher／watcher 子計畫進件**：補齊 #823 session-only 三件組與唯一 owner links，
   登錄 #853 有界 watcher A child。真 process-group 與 cgroup 邊界、raw0／generation／

--- a/README.md
+++ b/README.md
@@ -125,6 +125,14 @@ cortex bootstrap --instance cortex --repo-root "$(git rev-parse --show-toplevel)
    同為**必填**，未宣告時 Manager 在派工前即 fail-closed。值由產生器導出，不要手打：
    `python3 -m paulsha_cortex.trust_root unit four-way --job | grep '^Environment=PATH='`。
 
+   **#823 headless session 的生命週期邊界**：每個合法 headless `Popen` 嘗試（含
+   `systemd-run`／`systemd-template` 的 Manager-side client wrapper 與窄 `stdin` retry）都帶
+   `start_new_session=True`。direct child 因此有自己的 POSIX session/process group；這是
+   `setsid` 隔離，不是 systemd cgroup 移動，也不改變 unit 的 `KillMode` 或提供 cgroup
+   restart survival 保證。Manager daemon restart、timeout/parser/CLI 值域（#824）與 AGY
+   probe containment（#851）仍是獨立工作項；本 session 修正不新增 cancel/timeout/probe
+   語意，也不宣稱這些 issue 已完成或關閉。
+
 3. 使用 Deck 先 dry-run，再 emit `dispatch: hold` specs：
 
    ```bash

--- a/changelog.d/launcher-session-and-timeout.md
+++ b/changelog.d/launcher-session-and-timeout.md
@@ -1,3 +1,4 @@
 # Headless launcher session
 
 - `SubprocessLauncher` now gives every headless spawn its own session/process group while preserving Claude stdin and the existing runner-specific overrides.
+- Recording coverage now exercises all 14 legal executor/runner cells and keeps the unknown `cg` template hardening profile fail-closed; lifecycle docs distinguish POSIX session isolation from cgroup/restart, #824 timeout, and #851 probe work.

--- a/changelog.d/launcher-session-and-timeout.md
+++ b/changelog.d/launcher-session-and-timeout.md
@@ -1,0 +1,3 @@
+# Headless launcher session
+
+- `SubprocessLauncher` now gives every headless spawn its own session/process group while preserving Claude stdin and the existing runner-specific overrides.

--- a/docs/unified-work-lifecycle.md
+++ b/docs/unified-work-lifecycle.md
@@ -102,6 +102,17 @@ cortex work intake unified-work-lifecycle --repo owner/repo --issue 14 --combo f
 ```
 
 Telegram 等 bot 宿主若要提供「貼一段文字/issue 就進件」的入口，應呼叫 `submit_work_action(action="intake", ...)`（`paulsha_cortex/control/client.py`）；既有的 `/dispatch <slice_id>` 走既存 slice_id 派工，維持原樣不變，不在本次範圍內改動。
+
+### Headless launcher session boundary（#823）
+
+Headless job 的每次合法 `Popen`（direct、`systemd-run`、`systemd-template` 的外層
+Manager client，以及只移除 `stdin` 的相容 retry）都必須使用
+`start_new_session=True`。direct mode 的 child 因此離開 Manager 的 POSIX session/process
+group；這不等於把程序移入 systemd cgroup，也不承諾 Manager daemon restart 後 job 存活，
+更不改變 systemd unit 的 cgroup／`KillMode` 語意。#824 的 timeout/parser/CLI 合約與
+#851 的 AGY probe containment 仍由各自 work item 負責；#823 不藉 session flag 宣稱
+timeout、cancel、probe 或 issue closure 已完成。
+
 ### Work identity migration（設計中，見 ADR-0002）
 
 `link`／`unlink` 目前一次只能對單一 `(work_id, source)` pair 生效，重識別

--- a/openspec/changes/cortex-refine-complete/tasks.md
+++ b/openspec/changes/cortex-refine-complete/tasks.md
@@ -19,6 +19,7 @@
 - [ ] 2.7.1 先依 #851 補 AGY probe 的 argv construction containment，真 ready 非 AGY primary 不被阻擋；#824 仍需真非法 env 的 direct/probe/runtime 整合驗收，不拿 baseline fault injection 代替。
 - [ ] 2.7.2 #824 dependency 證據未滿前不登錄可 claim child／不開 auto label；解除後重新核對完整性、真 sizing、唯一 owner 與正式 freeze，不能依 custom frontmatter 自稱已鎖派工。
 - [ ] 2.7.3 依 #823 session-only 三件組完成共用 kwargs 真接線、兩個 Popen／stdin 窄重試、合法配置及既有拒絕、所有權驗證先於 group signal 的真 fixture 與候選 wheel 驗收；不擴成 cgroup/restart/cancel 實作。
+  - [x] RED：新增 `tests/test_coordinator_launcher_session.py`，鎖定 shared Popen kwargs 的 `start_new_session=True`、Claude stdin 保留，以及五個 executor 的 direct launch recording；production helper/接線仍待 GREEN card。
 - [ ] 2.8 完成 #825 最小 durable backoff，所有 lane 與 corrupt-state/expiry 可測；不標 R05 完成。
 - [ ] 2.8.1 先依 #850 有界 store／immutable event-fold child 交付 component；C/D provenance、reconciliation 與所有 lane 接線仍由 #825 後續 child 承接。
 - [ ] 2.9 以實際已載入 revision 驗 B1 成效，退出暫時 bypass 前保存 active jobs 與 rollback 方案。

--- a/openspec/changes/cortex-refine-complete/tasks.md
+++ b/openspec/changes/cortex-refine-complete/tasks.md
@@ -19,7 +19,8 @@
 - [ ] 2.7.1 先依 #851 補 AGY probe 的 argv construction containment，真 ready 非 AGY primary 不被阻擋；#824 仍需真非法 env 的 direct/probe/runtime 整合驗收，不拿 baseline fault injection 代替。
 - [ ] 2.7.2 #824 dependency 證據未滿前不登錄可 claim child／不開 auto label；解除後重新核對完整性、真 sizing、唯一 owner 與正式 freeze，不能依 custom frontmatter 自稱已鎖派工。
 - [ ] 2.7.3 依 #823 session-only 三件組完成共用 kwargs 真接線、兩個 Popen／stdin 窄重試、合法配置及既有拒絕、所有權驗證先於 group signal 的真 fixture 與候選 wheel 驗收；不擴成 cgroup/restart/cancel 實作。
-  - [x] RED：新增 `tests/test_coordinator_launcher_session.py`，鎖定 shared Popen kwargs 的 `start_new_session=True`、Claude stdin 保留，以及五個 executor 的 direct launch recording；production helper/接線仍待 GREEN card。
+  - [x] RED：新增 `tests/test_coordinator_launcher_session.py`，鎖定 shared Popen kwargs 的 `start_new_session=True`、Claude stdin 保留，以及五個 executor 的 direct launch recording。
+  - [x] GREEN：在 launcher 共用 helper 實作並接入所有 headless Popen；保留 runner override、Claude stdin-only retry 與固定 fake 相容性。
 - [ ] 2.8 完成 #825 最小 durable backoff，所有 lane 與 corrupt-state/expiry 可測；不標 R05 完成。
 - [ ] 2.8.1 先依 #850 有界 store／immutable event-fold child 交付 component；C/D provenance、reconciliation 與所有 lane 接線仍由 #825 後續 child 承接。
 - [ ] 2.9 以實際已載入 revision 驗 B1 成效，退出暫時 bypass 前保存 active jobs 與 rollback 方案。

--- a/openspec/changes/launcher-session-and-timeout/tasks.md
+++ b/openspec/changes/launcher-session-and-timeout/tasks.md
@@ -6,7 +6,8 @@ work_item: launcher-session-and-timeout
 # Pre-archive tasks
 
 - [x] T02: Record the five `_ARGV_BUILDERS` across direct, `systemd-run`, and
-  `systemd-template`; all 14 legal cells assert `start_new_session=True`, while
+  `systemd-template`; an explicit equality guard keeps the matrix complete, all
+  14 legal cells assert `start_new_session=True` on every `Popen`, and
   `cg`/template retains the unknown hardening-profile rejection before `Popen`.
 - [x] T03: Keep the shared launcher helper as the production source of the
   session flag and verify that every admitted `SubprocessLauncher` launch
@@ -22,17 +23,21 @@ work_item: launcher-session-and-timeout
   reap only the owned process handle in bounded cleanup.
 - [x] T07: Add isolated negative controls for helper bypass, a single
   runner/executor flag drop, retry flag loss, swallowed non-stdin errors, and a
-  missing-session fixture; the missing-session path records zero `killpg` calls.
-- [x] T08a: Run the focused launcher/session regression file and retain the
-  green result for this candidate.
-- [x] T08b: Run the authoritative full pytest preflight for this candidate;
-  it completed with 5682 passed, 44 skipped, and 173 subtests passed.
+  missing-session fixture; the missing-session path uses the same
+  ownership-gated signal path, records zero `killpg` calls, preserves the
+  Manager PGID/SID, and reaps only its own child handle.
+- [x] T08a: Run the focused launcher/session regression file under both
+  `umask 0002` and `umask 0022`; each run completed with 36 passed.
+- [x] T08b: Run the full pytest preflight under the Manager umask-0002
+  reproduction; it completed with 5684 passed, 44 skipped, and 173 subtests
+  passed.
 - [x] T09: Document the session-versus-cgroup, daemon-restart, #824 timeout,
   and #851 probe boundaries in the README and lifecycle guide; use existing
   CLI help surfaces only.
 - [x] T10: Preserve and extend the #823 Unreleased entry and changelog
   fragment without changing VERSION or claiming downstream delivery.
-- [ ] Manager-owned policy, independent review, and freeze checks remain
-  pending; their results are not represented as complete here.
-- [ ] Checkout-outside installation and any merge, issue, service, or live
-  runtime validation remain pending downstream actions.
+Manager-owned policy, independent review, and freeze checks remain PENDING
+downstream; their results are not represented as complete here.
+
+Checkout-outside installation and any merge, issue, service, or live runtime
+validation remain PENDING downstream actions.

--- a/openspec/changes/launcher-session-and-timeout/tasks.md
+++ b/openspec/changes/launcher-session-and-timeout/tasks.md
@@ -1,0 +1,38 @@
+---
+status: accepted
+work_item: launcher-session-and-timeout
+---
+
+# Pre-archive tasks
+
+- [x] T02: Record the five `_ARGV_BUILDERS` across direct, `systemd-run`, and
+  `systemd-template`; all 14 legal cells assert `start_new_session=True`, while
+  `cg`/template retains the unknown hardening-profile rejection before `Popen`.
+- [x] T03: Keep the shared launcher helper as the production source of the
+  session flag and verify that every admitted `SubprocessLauncher` launch
+  consumes it after runner-specific argv/I/O overrides.
+- [x] T04: Preserve the narrow Claude `stdin` compatibility retry; both
+  attempts retain the session flag, non-stdin `TypeError` is not retried, and a
+  second stdin failure is propagated.
+- [x] T05: Preserve the fixed fake-Popen signatures and existing argv/env/cwd/
+  stdin/accounting oracles while extending session recording to both systemd
+  wrapper branches.
+- [x] T06: Use the production helper for a real POSIX `bash -c 'exec sleep 30'`
+  fixture; verify PGID/SID ownership before the intentional group signal and
+  reap only the owned process handle in bounded cleanup.
+- [x] T07: Add isolated negative controls for helper bypass, a single
+  runner/executor flag drop, retry flag loss, swallowed non-stdin errors, and a
+  missing-session fixture; the missing-session path records zero `killpg` calls.
+- [x] T08a: Run the focused launcher/session regression file and retain the
+  green result for this candidate.
+- [x] T08b: Run the authoritative full pytest preflight for this candidate;
+  it completed with 5682 passed, 44 skipped, and 173 subtests passed.
+- [x] T09: Document the session-versus-cgroup, daemon-restart, #824 timeout,
+  and #851 probe boundaries in the README and lifecycle guide; use existing
+  CLI help surfaces only.
+- [x] T10: Preserve and extend the #823 Unreleased entry and changelog
+  fragment without changing VERSION or claiming downstream delivery.
+- [ ] Manager-owned policy, independent review, and freeze checks remain
+  pending; their results are not represented as complete here.
+- [ ] Checkout-outside installation and any merge, issue, service, or live
+  runtime validation remain pending downstream actions.

--- a/paulsha_cortex/coordinator/launcher.py
+++ b/paulsha_cortex/coordinator/launcher.py
@@ -1347,6 +1347,30 @@ _ARGV_BUILDERS = {
 }
 
 
+def build_headless_popen_kwargs(
+    *,
+    cwd: str | None,
+    env: Mapping[str, str],
+    executor: str,
+) -> dict[str, object]:
+    """Build the common spawn kwargs for every headless executor.
+
+    The launcher owns the process-group boundary.  Runner-specific callers may
+    override stdin, cwd, or env after this helper returns, but every Popen
+    attempt starts from the same isolated-session contract.
+    """
+
+    kwargs: dict[str, object] = {
+        "cwd": cwd,
+        "env": env,
+        "stderr": subprocess.STDOUT,
+        "start_new_session": True,
+    }
+    if executor == "claude":
+        kwargs["stdin"] = subprocess.PIPE
+    return kwargs
+
+
 class SubprocessLauncher:
     """真實作：headless subprocess 啟動。測試 MUST 注入 fake，不實體化。"""
 
@@ -2083,13 +2107,11 @@ class SubprocessLauncher:
         # 白名單 env 建立完成之後重新 source ~/.profile，把 env 約束整個覆寫掉。
         # direct 模式的 builder 維持 `-lc` 不動——那是既有行為，本票不改。
         argv = ["bash", "-c" if (self._review_only or degraded) else "-lc", script]
-        popen_kwargs: dict[str, object] = {
-            "cwd": worktree,
-            "env": env,
-            "stderr": subprocess.STDOUT,
-        }
-        if self._executor == "claude":
-            popen_kwargs["stdin"] = subprocess.PIPE
+        popen_kwargs = build_headless_popen_kwargs(
+            cwd=worktree,
+            env=env,
+            executor=self._executor,
+        )
         if runner_plan is not None:
             argv = job_runner.build_systemd_run_argv(
                 systemd_run=runner_plan.binary,

--- a/tests/test_coordinator_launcher.py
+++ b/tests/test_coordinator_launcher.py
@@ -755,7 +755,7 @@ class ArgvTests(unittest.TestCase):
         class _FakeProc:
             pid = 999
 
-        def _fake_popen(argv, *, cwd, env, stdout, stderr):
+        def _fake_popen(argv, *, cwd, env, stdout, stderr, start_new_session):
             calls.append({"argv": argv})
             return _FakeProc()
 
@@ -816,7 +816,7 @@ class ArgvTests(unittest.TestCase):
         class _FakeProc:
             pid = 741
 
-        def _fake_popen(argv, *, cwd, env, stdout, stderr):
+        def _fake_popen(argv, *, cwd, env, stdout, stderr, start_new_session):
             calls.append({"argv": argv})
             return _FakeProc()
 
@@ -855,7 +855,7 @@ class ArgvTests(unittest.TestCase):
         class _FakeProc:
             pid = 222
 
-        def _fake_popen(argv, *, cwd, env, stdout, stderr):
+        def _fake_popen(argv, *, cwd, env, stdout, stderr, start_new_session):
             calls.append({"env": env})
             return _FakeProc()
 
@@ -878,7 +878,7 @@ class ArgvTests(unittest.TestCase):
         class _FakeProc:
             pid = 223
 
-        def _fake_popen(argv, *, cwd, env, stdout, stderr):
+        def _fake_popen(argv, *, cwd, env, stdout, stderr, start_new_session):
             calls.append({"env": env})
             return _FakeProc()
 
@@ -925,7 +925,7 @@ class ArgvTests(unittest.TestCase):
         class _FakeProc:
             pid = 231
 
-        def _fake_popen(argv, *, cwd, env, stdout, stderr):
+        def _fake_popen(argv, *, cwd, env, stdout, stderr, start_new_session):
             calls.append({"env": env})
             return _FakeProc()
 
@@ -949,7 +949,7 @@ class ArgvTests(unittest.TestCase):
         class _FakeProc:
             pid = 232
 
-        def _fake_popen(argv, *, cwd, env, stdout, stderr):
+        def _fake_popen(argv, *, cwd, env, stdout, stderr, start_new_session):
             calls.append({"env": env})
             return _FakeProc()
 
@@ -975,7 +975,7 @@ class ArgvTests(unittest.TestCase):
         class _FakeProc:
             pid = 233
 
-        def _fake_popen(argv, *, cwd, env, stdout, stderr):
+        def _fake_popen(argv, *, cwd, env, stdout, stderr, start_new_session):
             calls.append({"env": env})
             return _FakeProc()
 
@@ -999,7 +999,7 @@ class ArgvTests(unittest.TestCase):
         class _FakeProc:
             pid = 234
 
-        def _fake_popen(argv, *, cwd, env, stdout, stderr):
+        def _fake_popen(argv, *, cwd, env, stdout, stderr, start_new_session):
             calls.append({"env": env})
             return _FakeProc()
 
@@ -1025,7 +1025,7 @@ class ArgvTests(unittest.TestCase):
         class _FakeProc:
             pid = 235
 
-        def _fake_popen(argv, *, cwd, env, stdout, stderr):
+        def _fake_popen(argv, *, cwd, env, stdout, stderr, start_new_session):
             calls.append({"env": env})
             return _FakeProc()
 
@@ -1053,7 +1053,7 @@ class ArgvTests(unittest.TestCase):
         class _FakeProc:
             pid = 225
 
-        def _fake_popen(argv, *, cwd, env, stdout, stderr):
+        def _fake_popen(argv, *, cwd, env, stdout, stderr, start_new_session):
             calls.append({"argv": argv, "env": env})
             return _FakeProc()
 
@@ -1105,7 +1105,7 @@ class ArgvTests(unittest.TestCase):
         class _FakeProc:
             pid = 224
 
-        def _fake_popen(argv, *, cwd, env, stdout, stderr):
+        def _fake_popen(argv, *, cwd, env, stdout, stderr, start_new_session):
             calls.append({"argv": argv, "cwd": cwd})
             return _FakeProc()
 
@@ -1139,7 +1139,7 @@ class ArgvTests(unittest.TestCase):
         class _FakeProc:
             pid = 111
 
-        def _fake_popen(argv, *, cwd, env, stdout, stderr):
+        def _fake_popen(argv, *, cwd, env, stdout, stderr, start_new_session):
             calls.append({"argv": argv})
             return _FakeProc()
 
@@ -1161,7 +1161,7 @@ class ArgvTests(unittest.TestCase):
         class _FakeProc:
             pid = 222
 
-        def _fake_popen(argv, *, cwd, env, stdout, stderr):
+        def _fake_popen(argv, *, cwd, env, stdout, stderr, start_new_session):
             calls.append({"argv": argv})
             return _FakeProc()
 
@@ -1183,7 +1183,7 @@ class ArgvTests(unittest.TestCase):
         class _FakeProc:
             pid = 226
 
-        def _fake_popen(argv, *, cwd, env, stdout, stderr):
+        def _fake_popen(argv, *, cwd, env, stdout, stderr, start_new_session):
             calls.append({"argv": argv})
             return _FakeProc()
 
@@ -1252,7 +1252,7 @@ class ArgvTests(unittest.TestCase):
         class _FakeProc:
             pid = 227
 
-        def _fake_popen(argv, *, cwd, env, stdout, stderr):
+        def _fake_popen(argv, *, cwd, env, stdout, stderr, start_new_session):
             calls.append({"argv": argv})
             return _FakeProc()
 
@@ -1319,7 +1319,7 @@ class ArgvTests(unittest.TestCase):
         class _FakeProc:
             pid = 456
 
-        def _fake_popen(argv, *, cwd, env, stdout, stderr):
+        def _fake_popen(argv, *, cwd, env, stdout, stderr, start_new_session):
             calls.append({"argv": argv, "cwd": cwd, "env": env})
             return _FakeProc()
 
@@ -1354,7 +1354,7 @@ class ArgvTests(unittest.TestCase):
         class _FakeProc:
             pid = 789
 
-        def _fake_popen(argv, *, cwd, env, stdout, stderr):
+        def _fake_popen(argv, *, cwd, env, stdout, stderr, start_new_session):
             calls.append({"argv": argv})
             return _FakeProc()
 
@@ -1395,7 +1395,7 @@ class ArgvTests(unittest.TestCase):
         class _FakeProc:
             pid = 333
 
-        def _fake_popen(argv, *, cwd, env, stdout, stderr):
+        def _fake_popen(argv, *, cwd, env, stdout, stderr, start_new_session):
             return _FakeProc()
 
         original = launcher_module.subprocess.Popen
@@ -1495,7 +1495,7 @@ class ArgvTests(unittest.TestCase):
         class _FakeProc:
             pid = 654
 
-        def _fake_popen(argv, *, cwd, env, stdout, stderr):
+        def _fake_popen(argv, *, cwd, env, stdout, stderr, start_new_session):
             calls.append({"argv": argv, "env": env})
             return _FakeProc()
 

--- a/tests/test_coordinator_launcher_session.py
+++ b/tests/test_coordinator_launcher_session.py
@@ -3,11 +3,209 @@ from __future__ import annotations
 import os
 import signal
 import subprocess
+from pathlib import Path
 
 import pytest
 
 import paulsha_cortex.coordinator.launcher as launcher_module
 from paulsha_cortex.coordinator.launcher import SubprocessLauncher
+
+
+_MATRIX_CASES = tuple(
+    (runner, executor)
+    for runner in (
+        "direct",
+        "systemd-run",
+        "systemd-template",
+    )
+    for executor in ("copilot", "claude", "codex", "agy", "cg")
+    if not (runner == "systemd-template" and executor == "cg")
+)
+
+
+def _patch_degraded_launch_seams(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+    *,
+    runner: str,
+    executor: str,
+) -> None:
+    """Keep the matrix on the production launcher path without live systemd."""
+
+    monkeypatch.setenv("PSC_JOB_RUNNER", runner)
+    monkeypatch.setenv("PSC_AGENTS_ROOT", str(tmp_path / "agents"))
+    monkeypatch.setenv("PSC_BUILDER_PATH", "/usr/bin")
+    monkeypatch.setenv("PSC_REVIEWER_PATH", "/usr/bin")
+    monkeypatch.setenv("PSC_GATE_PATH", "/usr/bin")
+    monkeypatch.setenv("PSC_BUILDER_HOME", str(tmp_path / "builder-home"))
+    monkeypatch.setenv("PSC_REVIEWER_HOME", str(tmp_path / "reviewer-home"))
+    monkeypatch.setenv("PSC_GATE_HOME", str(tmp_path / "gate-home"))
+    monkeypatch.setenv("PSC_JOB_SPEC_SPOOL", str(tmp_path / "builder-specs"))
+    monkeypatch.setenv("PSC_REVIEW_JOB_SPEC_SPOOL", str(tmp_path / "review-specs"))
+    monkeypatch.setenv("PSC_GATE_JOB_SPEC_SPOOL", str(tmp_path / "gate-specs"))
+
+    def fake_account(_env, *, role):
+        return f"{role}-account"
+
+    def fake_group(_env, *, role):
+        return f"{role}-group"
+
+    monkeypatch.setattr(launcher_module.job_runner, "resolve_job_account", fake_account)
+    monkeypatch.setattr(launcher_module.job_runner, "resolve_job_group", fake_group)
+    monkeypatch.setattr(
+        launcher_module.job_runner,
+        "preflight_systemd_run",
+        lambda **_kwargs: "/usr/bin/systemd-run",
+    )
+    monkeypatch.setattr(
+        launcher_module.job_runner,
+        "resolve_template_unit",
+        lambda _env, *, role: "cortex-job@.service",
+    )
+    monkeypatch.setattr(
+        launcher_module.job_runner,
+        "resolve_job_shim",
+        lambda _env: "/usr/bin/cortex-job-shim",
+    )
+    def principal_spool(_env, *, role):
+        principal = "reviewer" if role == launcher_module.job_runner.JOB_ROLE_REVIEW else "builder"
+        path = tmp_path / principal
+        path.mkdir(parents=True, exist_ok=True)
+        return str(path)
+
+    monkeypatch.setattr(launcher_module.job_runner, "resolve_job_spec_spool", principal_spool)
+    monkeypatch.setattr(
+        launcher_module.job_runner,
+        "preflight_systemd_template",
+        lambda **_kwargs: "/usr/bin/systemctl",
+    )
+    monkeypatch.setattr(launcher_module.job_runner, "_unit_is_active", lambda *_args: False)
+    monkeypatch.setattr(
+        launcher_module.job_runner,
+        "build_job_env",
+        lambda **kwargs: {
+            "PATH": "/usr/bin",
+            "HOME": str(tmp_path),
+            "PSC_JOB_ID": kwargs["job_id"],
+            "PSC_SLICE_ID": kwargs["slice_id"],
+            "PSC_REPO_ROOT": str(tmp_path),
+        },
+    )
+    monkeypatch.setattr(
+        launcher_module.job_runner,
+        "resolve_prompt_spec_spool",
+        principal_spool,
+    )
+    monkeypatch.setattr(launcher_module.job_runner, "write_job_prompt", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(launcher_module.job_runner, "confirm_transient_unit_started", lambda **_kwargs: None)
+    monkeypatch.setattr(launcher_module.job_runner, "confirm_template_instance_started", lambda **_kwargs: None)
+    monkeypatch.setattr(
+        launcher_module.job_runner,
+        "ensure_workspace_reachable",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(launcher_module.job_runner, "write_job_spec", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        launcher_module.job_runner,
+        "build_job_spec",
+        lambda **kwargs: {
+            "instance": kwargs["instance"],
+            "unit": kwargs["unit"],
+            "log_path": kwargs["log_path"],
+        },
+    )
+    monkeypatch.setattr(
+        launcher_module.spool_slot,
+        "system_account_exists",
+        lambda _account: False,
+    )
+    monkeypatch.setattr(
+        launcher_module.spool_slot,
+        "canonical_codex_controls",
+        lambda *_args, **_kwargs: str(tmp_path / "codex-controls"),
+    )
+    monkeypatch.setattr(
+        launcher_module.spool_slot,
+        "provision_runtime_surfaces",
+        lambda **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        launcher_module.spool_slot,
+        "copilot_oauth_authority",
+        lambda **_kwargs: tmp_path / "copilot-authority" / "config.json",
+    )
+    monkeypatch.setattr(
+        launcher_module.spool_slot,
+        "provision_copilot_home",
+        lambda **_kwargs: tmp_path / "copilot-home",
+    )
+    monkeypatch.setattr(
+        launcher_module.spool_slot,
+        "preseed_job_writable_file",
+        lambda path: Path(path).touch() or Path(path),
+    )
+    monkeypatch.setattr(
+        launcher_module.job_workspace,
+        "prepare_commit_spool",
+        lambda **_kwargs: tmp_path / "commit-spool" / "commits.bundle",
+    )
+
+    for principal in ("builder", "reviewer"):
+        (tmp_path / principal).mkdir(parents=True, exist_ok=True)
+
+    if runner == "systemd-template":
+        def fake_log_spool_dir(*, principal_id: str, spool_key: str):
+            return tmp_path / "job-logs" / principal_id / spool_key
+
+        def fake_prepare_job_log_spool(*, principal_id: str, spool_key: str, manager_log_path: str):
+            path = fake_log_spool_dir(principal_id=principal_id, spool_key=spool_key)
+            path.mkdir(parents=True, exist_ok=True)
+            log_path = path / launcher_module.job_workspace.JOB_LOG_FILENAME
+            log_path.touch()
+            return log_path
+
+        monkeypatch.setattr(launcher_module.job_workspace, "job_log_spool_dir", fake_log_spool_dir)
+        monkeypatch.setattr(
+            launcher_module.job_workspace,
+            "prepare_job_log_spool",
+            fake_prepare_job_log_spool,
+        )
+
+
+def _record_subprocess_launch(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+    *,
+    runner: str,
+    executor: str,
+    require_session: bool = False,
+) -> list[dict[str, object]]:
+    _patch_degraded_launch_seams(
+        monkeypatch,
+        tmp_path,
+        runner=runner,
+        executor=executor,
+    )
+    calls: list[dict[str, object]] = []
+
+    class FakeProcess:
+        pid = 12347
+
+    def fake_popen(argv, **kwargs):
+        if require_session:
+            assert kwargs.get("start_new_session") is True, "start_new_session flag was dropped"
+        calls.append({"argv": argv, **kwargs})
+        return FakeProcess()
+
+    monkeypatch.setattr(launcher_module.subprocess, "Popen", fake_popen)
+    launcher_kwargs = {"read_only": True} if executor == "cg" else {}
+    SubprocessLauncher(executor, **launcher_kwargs).launch(
+        slice_id=f"session-matrix-{runner}-{executor}",
+        prompt="PROMPT",
+        worktree=str(tmp_path),
+        log_dir=str(tmp_path / "logs"),
+    )
+    return calls
 
 
 @pytest.mark.parametrize(
@@ -79,6 +277,117 @@ def test_every_direct_headless_executor_records_start_new_session(
     assert calls[0]["start_new_session"] is True
     if executor == "claude":
         assert calls[0]["stdin"] is subprocess.PIPE
+
+
+@pytest.mark.parametrize(("runner", "executor"), _MATRIX_CASES)
+def test_every_admitted_runner_executor_records_start_new_session(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+    runner: str,
+    executor: str,
+) -> None:
+    calls = _record_subprocess_launch(
+        monkeypatch,
+        tmp_path,
+        runner=runner,
+        executor=executor,
+    )
+
+    assert len(calls) == 1
+    assert calls[0]["start_new_session"] is True
+    if runner == "direct":
+        assert calls[0]["cwd"] == str(tmp_path)
+        if executor == "claude":
+            assert calls[0]["stdin"] is subprocess.PIPE
+    else:
+        assert calls[0]["argv"][:2] == ["bash", "-c"]
+        assert calls[0]["stdin"] is subprocess.DEVNULL
+        if runner == "systemd-run":
+            assert "systemd-run" in calls[0]["argv"][2]
+            assert calls[0]["cwd"] == str(tmp_path)
+        else:
+            assert "systemctl" in calls[0]["argv"][2]
+            assert calls[0]["cwd"] is None
+
+
+def test_recording_negative_control_catches_helper_wiring_bypass(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    real_helper = launcher_module.build_headless_popen_kwargs
+
+    def helper_mutant(**kwargs):
+        result = real_helper(**kwargs)
+        result.pop("start_new_session")
+        return result
+
+    monkeypatch.setattr(launcher_module, "build_headless_popen_kwargs", helper_mutant)
+    with pytest.raises(AssertionError, match="start_new_session"):
+        _record_subprocess_launch(
+            monkeypatch,
+            tmp_path,
+            runner="direct",
+            executor="codex",
+            require_session=True,
+        )
+
+
+@pytest.mark.parametrize(
+    ("runner", "executor"),
+    (("systemd-run", "codex"), ("systemd-template", "claude")),
+)
+def test_recording_negative_control_catches_single_runner_executor_flag_drop(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+    runner: str,
+    executor: str,
+) -> None:
+    real_helper = launcher_module.build_headless_popen_kwargs
+
+    def helper_mutant(**kwargs):
+        result = real_helper(**kwargs)
+        if kwargs["executor"] == executor:
+            result.pop("start_new_session")
+        return result
+
+    monkeypatch.setattr(launcher_module, "build_headless_popen_kwargs", helper_mutant)
+    with pytest.raises(AssertionError, match="start_new_session"):
+        _record_subprocess_launch(
+            monkeypatch,
+            tmp_path,
+            runner=runner,
+            executor=executor,
+            require_session=True,
+        )
+
+
+def test_cg_template_keeps_unknown_hardening_rejection_before_popen(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    _patch_degraded_launch_seams(
+        monkeypatch,
+        tmp_path,
+        runner="systemd-template",
+        executor="cg",
+    )
+    calls: list[dict[str, object]] = []
+    monkeypatch.setattr(
+        launcher_module.subprocess,
+        "Popen",
+        lambda argv, **kwargs: calls.append({"argv": argv, **kwargs}),
+    )
+
+    with pytest.raises(launcher_module.job_runner.JobRunnerError) as caught:
+        SubprocessLauncher("cg", read_only=True).launch(
+            slice_id="session-matrix-cg-template",
+            prompt="PROMPT",
+            worktree=str(tmp_path),
+            log_dir=str(tmp_path / "logs"),
+        )
+
+    assert caught.value.diagnostic.reason == "job-runner-hardening-profile-unknown"
+    assert calls == []
 
 
 def test_stdin_compatibility_retry_keeps_session_flag(
@@ -183,7 +492,6 @@ def test_headless_session_owns_its_process_group_before_group_signal(tmp_path) -
     parent_pgid = os.getpgid(0)
     parent_sid = os.getsid(0)
     proc = subprocess.Popen(["bash", "-c", "exec sleep 30"], **kwargs)
-    group_owned = False
     try:
         child_pgid = os.getpgid(proc.pid)
         child_sid = os.getsid(proc.pid)
@@ -191,18 +499,61 @@ def test_headless_session_owns_its_process_group_before_group_signal(tmp_path) -
         assert child_sid == proc.pid
         assert child_pgid != parent_pgid
         assert child_sid != parent_sid
-        group_owned = True
 
+        # Ownership is established before the only intentional group signal.
         os.killpg(proc.pid, signal.SIGTERM)
         assert proc.wait(timeout=5) == -signal.SIGTERM
         assert os.getpgid(0) == parent_pgid
         assert os.getsid(0) == parent_sid
     finally:
-        if proc.poll() is None:
-            if group_owned:
-                os.killpg(proc.pid, signal.SIGKILL)
-            else:
+        try:
+            if proc.poll() is None:
                 proc.kill()
-            proc.wait(timeout=5)
-        if getattr(proc, "stdin", None) is not None:
-            proc.stdin.close()
+                proc.wait(timeout=5)
+        finally:
+            if getattr(proc, "stdin", None) is not None:
+                proc.stdin.close()
+
+
+@pytest.mark.skipif(os.name != "posix", reason="headless session isolation is POSIX-specific")
+def test_missing_session_negative_control_rejects_before_group_signal(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    kwargs = launcher_module.build_headless_popen_kwargs(
+        cwd=str(tmp_path),
+        env={"PATH": "/usr/bin"},
+        executor="codex",
+    )
+    kwargs.pop("start_new_session")
+    kwargs["stdout"] = subprocess.DEVNULL
+    parent_pgid = os.getpgid(0)
+    parent_sid = os.getsid(0)
+    killpg_calls: list[tuple[int, int]] = []
+    monkeypatch.setattr(
+        os,
+        "killpg",
+        lambda pgid, sig: killpg_calls.append((pgid, sig)),
+    )
+
+    proc = subprocess.Popen(["bash", "-c", "exec sleep 30"], **kwargs)
+    try:
+        child_pgid = os.getpgid(proc.pid)
+        child_sid = os.getsid(proc.pid)
+        ownership = (
+            child_pgid == proc.pid
+            and child_sid == proc.pid
+            and child_pgid != parent_pgid
+            and child_sid != parent_sid
+        )
+        assert not ownership
+        assert killpg_calls == []
+    finally:
+        try:
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait(timeout=5)
+        finally:
+            if getattr(proc, "stdin", None) is not None:
+                proc.stdin.close()
+    assert proc.poll() is not None

--- a/tests/test_coordinator_launcher_session.py
+++ b/tests/test_coordinator_launcher_session.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+import paulsha_cortex.coordinator.launcher as launcher_module
+from paulsha_cortex.coordinator.launcher import SubprocessLauncher
+
+
+@pytest.mark.parametrize(
+    ("executor", "expected_stdin"),
+    (
+        ("copilot", False),
+        ("claude", True),
+        ("codex", False),
+        ("agy", False),
+        ("cg", False),
+    ),
+)
+def test_headless_popen_kwargs_include_new_session_without_dropping_existing_io(
+    executor: str,
+    expected_stdin: bool,
+) -> None:
+    build_kwargs = getattr(launcher_module, "build_headless_popen_kwargs", None)
+    assert callable(build_kwargs), "launcher must expose the shared Popen kwargs helper"
+
+    env = {"PATH": "/usr/bin", "PSC_JOB_ID": "session-red"}
+    kwargs = build_kwargs(cwd="/tmp/worktree", env=env, executor=executor)
+
+    assert kwargs["cwd"] == "/tmp/worktree"
+    assert kwargs["env"] is env
+    assert kwargs["stderr"] is subprocess.STDOUT
+    assert kwargs["start_new_session"] is True
+    if expected_stdin:
+        assert kwargs["stdin"] is subprocess.PIPE
+    else:
+        assert "stdin" not in kwargs
+
+
+@pytest.mark.parametrize(
+    ("executor", "launcher_kwargs"),
+    (
+        ("copilot", {}),
+        ("claude", {}),
+        ("codex", {}),
+        ("agy", {}),
+        ("cg", {"read_only": True}),
+    ),
+)
+def test_every_direct_headless_executor_records_start_new_session(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+    executor: str,
+    launcher_kwargs: dict[str, object],
+) -> None:
+    calls: list[dict[str, object]] = []
+
+    class FakeProcess:
+        pid = 12345
+
+    def fake_popen(argv, **kwargs):
+        calls.append({"argv": argv, **kwargs})
+        return FakeProcess()
+
+    monkeypatch.setenv("PSC_JOB_RUNNER", "direct")
+    monkeypatch.setattr(launcher_module.subprocess, "Popen", fake_popen)
+
+    SubprocessLauncher(executor, **launcher_kwargs).launch(
+        slice_id=f"session-red-{executor}",
+        prompt="PROMPT",
+        worktree=str(tmp_path),
+        log_dir=str(tmp_path / "logs"),
+    )
+
+    assert len(calls) == 1
+    assert calls[0]["start_new_session"] is True
+    if executor == "claude":
+        assert calls[0]["stdin"] is subprocess.PIPE

--- a/tests/test_coordinator_launcher_session.py
+++ b/tests/test_coordinator_launcher_session.py
@@ -23,6 +23,21 @@ _MATRIX_CASES = tuple(
 )
 
 
+def _private_dir(path: Path) -> Path:
+    path.mkdir(parents=True, exist_ok=True, mode=0o700)
+    path.chmod(0o700)
+    return path
+
+
+def _assert_matrix_covers_argv_builders() -> None:
+    matrix_executors = {executor for _runner, executor in _MATRIX_CASES}
+    registered_executors = set(launcher_module._ARGV_BUILDERS)
+    assert matrix_executors == registered_executors, (
+        "session matrix executor coverage drifted from _ARGV_BUILDERS: "
+        f"matrix={sorted(matrix_executors)!r}, registered={sorted(registered_executors)!r}"
+    )
+
+
 def _patch_degraded_launch_seams(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path,
@@ -70,8 +85,7 @@ def _patch_degraded_launch_seams(
     def principal_spool(_env, *, role):
         principal = "reviewer" if role == launcher_module.job_runner.JOB_ROLE_REVIEW else "builder"
         path = tmp_path / principal
-        path.mkdir(parents=True, exist_ok=True)
-        return str(path)
+        return str(_private_dir(path))
 
     monkeypatch.setattr(launcher_module.job_runner, "resolve_job_spec_spool", principal_spool)
     monkeypatch.setattr(
@@ -151,7 +165,7 @@ def _patch_degraded_launch_seams(
     )
 
     for principal in ("builder", "reviewer"):
-        (tmp_path / principal).mkdir(parents=True, exist_ok=True)
+        _private_dir(tmp_path / principal)
 
     if runner == "systemd-template":
         def fake_log_spool_dir(*, principal_id: str, spool_key: str):
@@ -159,7 +173,7 @@ def _patch_degraded_launch_seams(
 
         def fake_prepare_job_log_spool(*, principal_id: str, spool_key: str, manager_log_path: str):
             path = fake_log_spool_dir(principal_id=principal_id, spool_key=spool_key)
-            path.mkdir(parents=True, exist_ok=True)
+            _private_dir(path)
             log_path = path / launcher_module.job_workspace.JOB_LOG_FILENAME
             log_path.touch()
             return log_path
@@ -192,8 +206,7 @@ def _record_subprocess_launch(
         pid = 12347
 
     def fake_popen(argv, **kwargs):
-        if require_session:
-            assert kwargs.get("start_new_session") is True, "start_new_session flag was dropped"
+        assert kwargs.get("start_new_session") is True, "start_new_session flag was dropped"
         calls.append({"argv": argv, **kwargs})
         return FakeProcess()
 
@@ -308,6 +321,18 @@ def test_every_admitted_runner_executor_records_start_new_session(
         else:
             assert "systemctl" in calls[0]["argv"][2]
             assert calls[0]["cwd"] is None
+
+
+def test_session_matrix_covers_every_registered_argv_builder() -> None:
+    _assert_matrix_covers_argv_builders()
+
+
+def test_new_argv_builder_requires_a_session_matrix_cell(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setitem(launcher_module._ARGV_BUILDERS, "synthetic", lambda **_kwargs: ["synthetic"])
+    with pytest.raises(AssertionError, match="coverage drifted from _ARGV_BUILDERS"):
+        _assert_matrix_covers_argv_builders()
 
 
 def test_recording_negative_control_catches_helper_wiring_bypass(
@@ -479,6 +504,23 @@ def test_second_stdin_retry_error_is_propagated(
     assert "stdin" not in calls[1]
 
 
+def _signal_owned_process_group(proc, sig: int) -> bool:
+    parent_pgid = os.getpgid(0)
+    parent_sid = os.getsid(0)
+    child_pgid = os.getpgid(proc.pid)
+    child_sid = os.getsid(proc.pid)
+    owned = (
+        child_pgid == proc.pid
+        and child_sid == proc.pid
+        and child_pgid != parent_pgid
+        and child_sid != parent_sid
+    )
+    if not owned:
+        return False
+    os.killpg(child_pgid, sig)
+    return True
+
+
 @pytest.mark.skipif(os.name != "posix", reason="headless session isolation is POSIX-specific")
 def test_headless_session_owns_its_process_group_before_group_signal(tmp_path) -> None:
     build_kwargs = launcher_module.build_headless_popen_kwargs
@@ -493,15 +535,8 @@ def test_headless_session_owns_its_process_group_before_group_signal(tmp_path) -
     parent_sid = os.getsid(0)
     proc = subprocess.Popen(["bash", "-c", "exec sleep 30"], **kwargs)
     try:
-        child_pgid = os.getpgid(proc.pid)
-        child_sid = os.getsid(proc.pid)
-        assert child_pgid == proc.pid
-        assert child_sid == proc.pid
-        assert child_pgid != parent_pgid
-        assert child_sid != parent_sid
-
         # Ownership is established before the only intentional group signal.
-        os.killpg(proc.pid, signal.SIGTERM)
+        assert _signal_owned_process_group(proc, signal.SIGTERM)
         assert proc.wait(timeout=5) == -signal.SIGTERM
         assert os.getpgid(0) == parent_pgid
         assert os.getsid(0) == parent_sid
@@ -538,15 +573,7 @@ def test_missing_session_negative_control_rejects_before_group_signal(
 
     proc = subprocess.Popen(["bash", "-c", "exec sleep 30"], **kwargs)
     try:
-        child_pgid = os.getpgid(proc.pid)
-        child_sid = os.getsid(proc.pid)
-        ownership = (
-            child_pgid == proc.pid
-            and child_sid == proc.pid
-            and child_pgid != parent_pgid
-            and child_sid != parent_sid
-        )
-        assert not ownership
+        assert not _signal_owned_process_group(proc, signal.SIGTERM)
         assert killpg_calls == []
     finally:
         try:
@@ -556,4 +583,6 @@ def test_missing_session_negative_control_rejects_before_group_signal(
         finally:
             if getattr(proc, "stdin", None) is not None:
                 proc.stdin.close()
+    assert os.getpgid(0) == parent_pgid
+    assert os.getsid(0) == parent_sid
     assert proc.poll() is not None

--- a/tests/test_coordinator_launcher_session.py
+++ b/tests/test_coordinator_launcher_session.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import os
+import signal
 import subprocess
 
 import pytest
@@ -77,3 +79,130 @@ def test_every_direct_headless_executor_records_start_new_session(
     assert calls[0]["start_new_session"] is True
     if executor == "claude":
         assert calls[0]["stdin"] is subprocess.PIPE
+
+
+def test_stdin_compatibility_retry_keeps_session_flag(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    calls: list[dict[str, object]] = []
+
+    class FakeProcess:
+        pid = 12346
+
+    def fake_popen(argv, **kwargs):
+        calls.append(dict(kwargs))
+        if len(calls) == 1:
+            raise TypeError("stdin is not supported by this fake")
+        return FakeProcess()
+
+    monkeypatch.setenv("PSC_JOB_RUNNER", "direct")
+    monkeypatch.setattr(launcher_module.subprocess, "Popen", fake_popen)
+
+    SubprocessLauncher("claude").launch(
+        slice_id="session-retry",
+        prompt="PROMPT",
+        worktree=str(tmp_path),
+        log_dir=str(tmp_path / "logs"),
+    )
+
+    assert len(calls) == 2
+    assert calls[0]["start_new_session"] is True
+    assert calls[1]["start_new_session"] is True
+    assert calls[0]["cwd"] == calls[1]["cwd"]
+    assert calls[0]["env"] is calls[1]["env"]
+    assert calls[0]["stderr"] is calls[1]["stderr"]
+    assert calls[0]["stdin"] is subprocess.PIPE
+    assert "stdin" not in calls[1]
+
+
+@pytest.mark.parametrize("message", ("start_new_session is unsupported", "other failure"))
+def test_non_stdin_popen_typeerror_is_not_retried(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+    message: str,
+) -> None:
+    calls: list[dict[str, object]] = []
+
+    def fake_popen(argv, **kwargs):
+        calls.append(dict(kwargs))
+        raise TypeError(message)
+
+    monkeypatch.setenv("PSC_JOB_RUNNER", "direct")
+    monkeypatch.setattr(launcher_module.subprocess, "Popen", fake_popen)
+
+    with pytest.raises(TypeError, match=message):
+        SubprocessLauncher("codex").launch(
+            slice_id="session-no-retry",
+            prompt="PROMPT",
+            worktree=str(tmp_path),
+            log_dir=str(tmp_path / "logs"),
+        )
+
+    assert len(calls) == 1
+    assert calls[0]["start_new_session"] is True
+
+
+def test_second_stdin_retry_error_is_propagated(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    calls: list[dict[str, object]] = []
+
+    def fake_popen(argv, **kwargs):
+        calls.append(dict(kwargs))
+        raise TypeError("stdin remains unsupported")
+
+    monkeypatch.setenv("PSC_JOB_RUNNER", "direct")
+    monkeypatch.setattr(launcher_module.subprocess, "Popen", fake_popen)
+
+    with pytest.raises(TypeError, match="stdin remains unsupported"):
+        SubprocessLauncher("claude").launch(
+            slice_id="session-double-error",
+            prompt="PROMPT",
+            worktree=str(tmp_path),
+            log_dir=str(tmp_path / "logs"),
+        )
+
+    assert len(calls) == 2
+    assert all(call["start_new_session"] is True for call in calls)
+    assert calls[0]["stdin"] is subprocess.PIPE
+    assert "stdin" not in calls[1]
+
+
+@pytest.mark.skipif(os.name != "posix", reason="headless session isolation is POSIX-specific")
+def test_headless_session_owns_its_process_group_before_group_signal(tmp_path) -> None:
+    build_kwargs = launcher_module.build_headless_popen_kwargs
+    kwargs = build_kwargs(
+        cwd=str(tmp_path),
+        env={"PATH": "/usr/bin"},
+        executor="codex",
+    )
+    kwargs["stdout"] = subprocess.DEVNULL
+
+    parent_pgid = os.getpgid(0)
+    parent_sid = os.getsid(0)
+    proc = subprocess.Popen(["bash", "-c", "exec sleep 30"], **kwargs)
+    group_owned = False
+    try:
+        child_pgid = os.getpgid(proc.pid)
+        child_sid = os.getsid(proc.pid)
+        assert child_pgid == proc.pid
+        assert child_sid == proc.pid
+        assert child_pgid != parent_pgid
+        assert child_sid != parent_sid
+        group_owned = True
+
+        os.killpg(proc.pid, signal.SIGTERM)
+        assert proc.wait(timeout=5) == -signal.SIGTERM
+        assert os.getpgid(0) == parent_pgid
+        assert os.getsid(0) == parent_sid
+    finally:
+        if proc.poll() is None:
+            if group_owned:
+                os.killpg(proc.pid, signal.SIGKILL)
+            else:
+                proc.kill()
+            proc.wait(timeout=5)
+        if getattr(proc, "stdin", None) is not None:
+            proc.stdin.close()

--- a/tests/test_headless_claude_hook_506.py
+++ b/tests/test_headless_claude_hook_506.py
@@ -532,7 +532,7 @@ def test_the_launcher_marks_the_job_environment() -> None:
     class _FakeProc:
         pid = 4242
 
-    def _fake_popen(argv, *, cwd, env, stdout, stderr):
+    def _fake_popen(argv, *, cwd, env, stdout, stderr, start_new_session):
         calls.append({"argv": argv, "env": env})
         return _FakeProc()
 
@@ -563,7 +563,7 @@ def test_the_preflight_environment_matches_the_job_environment() -> None:
     class _FakeProc:
         pid = 1
 
-    def _fake_popen(argv, *, cwd, env, stdout, stderr):
+    def _fake_popen(argv, *, cwd, env, stdout, stderr, start_new_session):
         calls.append({"env": env})
         return _FakeProc()
 
@@ -691,7 +691,7 @@ def test_end_to_end_from_launcher_injection_to_a_consumable_event(
     class _FakeProc:
         pid = 99
 
-    def _fake_popen(argv, *, cwd, env, stdout, stderr):
+    def _fake_popen(argv, *, cwd, env, stdout, stderr, start_new_session):
         calls.append({"argv": argv, "env": env})
         return _FakeProc()
 


### PR DESCRIPTION
## 摘要

完成 `launcher-session-and-timeout` 統一工作生命週期。
## 驗證

- [x] Manager exact-HEAD delivery gates
Closes #823